### PR TITLE
feat(keeper): discover workspace checkouts by measurement, not by layout

### DIFF
--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -785,9 +785,14 @@ let sandbox_path_of_meta ~(meta : Keeper_meta_contract.keeper_meta) =
   Keeper_sandbox.allowed_root_rel_of_meta ~meta
 ;;
 
+(* The workspace root, and nothing under it. A [repos/] directory used to be
+   created here, which outlived every other trace of that convention: a keeper
+   listing its root would find an empty [repos/] and infer the rule the prompts
+   no longer teach. The system creates the root; the keeper decides what goes
+   in it. *)
 let sandbox_bundle_paths_of_meta ~(meta : Keeper_meta_contract.keeper_meta) =
   let root = sandbox_path_of_meta ~meta |> strip_trailing_slashes in
-  [ root ^ "/"; root ^ "/repos/" ]
+  [ root ^ "/" ]
 ;;
 
 let ensure_sandbox_bundle ~(config : Workspace.config) ~(meta : Keeper_meta_contract.keeper_meta)
@@ -809,7 +814,7 @@ let ensure_sandbox_bundle_for_profile
   let sandbox_root =
     Keeper_sandbox.host_root_rel_of_profile sandbox_profile name |> strip_trailing_slashes
   in
-  [ sandbox_root ^ "/"; sandbox_root ^ "/repos/" ]
+  [ sandbox_root ^ "/" ]
   |> List.map (Filename.concat root)
   |> List.map Keeper_fs.ensure_dir
 ;;

--- a/lib/keeper/keeper_playground_checkouts.ml
+++ b/lib/keeper/keeper_playground_checkouts.ml
@@ -1,0 +1,342 @@
+type git_link =
+  | Git_directory
+  | Git_pointer_file
+
+type checkout =
+  { relative_path : string
+  ; absolute_path : string
+  ; name : string
+  ; git_link : git_link
+  }
+
+type limit =
+  | Entry_budget_exhausted of
+      { scanned : int
+      ; budget : int
+      }
+  | Checkout_budget_exhausted of { budget : int }
+  | Directory_unreadable of
+      { relative_path : string
+      ; detail : string
+      }
+
+type scan_error =
+  | Root_missing of { root : string }
+  | Root_not_directory of
+      { root : string
+      ; kind : string
+      }
+  | Root_unreadable of
+      { root : string
+      ; detail : string
+      }
+
+type discovery =
+  | Complete of checkout list
+  | Partial of
+      { found : checkout list
+      ; limit : limit
+      }
+
+(* Measured across the live playground (12 keepers, 2026-08-13): worst case 495
+   readdir entries over 107 directories (a keeper holding source-shaped
+   artifacts outside any checkout), median 34. 8192 is roughly 16x the worst
+   observation.
+
+   This is a safety stop, not a tuning knob. A normal playground cannot reach
+   it, so [Entry_budget_exhausted] is itself the anomaly signal — raise the
+   ceiling only after understanding what produced that many entries. *)
+let max_scanned_entries = 8_192
+
+(* Bounded by what happens downstream, not by the walk: [checkout_json] spends
+   six bounded git subprocesses per reported checkout, so 32 caps one status
+   render at 192 spawns. The live maximum is 12 checkouts for one keeper.
+
+   If this needs to grow, the thing to fix is running six git calls per
+   checkout inline on an HTTP path, not this constant. *)
+let max_reported_checkouts = 32
+
+let file_kind_to_string : Unix.file_kind -> string = function
+  | S_REG -> "regular file"
+  | S_DIR -> "directory"
+  | S_CHR -> "character device"
+  | S_BLK -> "block device"
+  | S_LNK -> "symlink"
+  | S_FIFO -> "fifo"
+  | S_SOCK -> "socket"
+;;
+
+let strip_trailing_slash path =
+  let n = String.length path in
+  if n > 1 && path.[n - 1] = '/' then String.sub path 0 (n - 1) else path
+;;
+
+(* [Fs_compat.exact_path_kind] reports a missing path as a value but raises on
+   a permission error: lstat of a child under a mode-000 directory fails with
+   EACCES. Both [Sys_error] and [Unix.Unix_error] are possible.
+
+   "Cannot tell" is not "is not there", but at this point in the walk the two
+   lead to the same local decision — do not classify this entry as a checkout.
+   The condition still surfaces: the enclosing [read_dir] of that directory
+   fails and becomes [Directory_unreadable], which the caller sees. *)
+let path_kind_no_follow path =
+  try Fs_compat.exact_path_kind ~follow:false path with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | Sys_error _ | Unix.Unix_error _ -> Fs_compat.Exact_unknown
+;;
+
+let is_directory_no_follow abs =
+  match path_kind_no_follow abs with
+  | Fs_compat.Exact_kind Unix.S_DIR -> true
+  | Fs_compat.Exact_kind _ | Fs_compat.Exact_missing | Fs_compat.Exact_unknown ->
+    false
+;;
+
+(* A [.git] symlink is rejected rather than followed: it can point outside the
+   workspace root, and treating it as a checkout would attribute writes to a
+   tree the keeper does not own. *)
+let git_link_of_dir abs =
+  match path_kind_no_follow (Filename.concat abs ".git") with
+  | Fs_compat.Exact_kind Unix.S_DIR -> Some Git_directory
+  | Fs_compat.Exact_kind Unix.S_REG -> Some Git_pointer_file
+  | Fs_compat.Exact_kind _ | Fs_compat.Exact_missing | Fs_compat.Exact_unknown ->
+    None
+;;
+
+let relative_of_segments = function
+  | [] -> "."
+  | segments -> String.concat "/" segments
+;;
+
+let take n items =
+  let rec go acc n = function
+    | item :: rest when n > 0 -> go (item :: acc) (n - 1) rest
+    | _ -> List.rev acc
+  in
+  go [] n items
+;;
+
+let sort_by_relative_path checkouts =
+  List.sort
+    (fun a b -> String.compare a.relative_path b.relative_path)
+    checkouts
+;;
+
+(* Internal control flow for the walk below. [Truncated] carries a partial but
+   real result; [Root_read_failed] means there is no result at all, which is a
+   different answer and must not collapse into an empty list. *)
+exception Truncated of limit
+exception Root_read_failed of string
+
+let discover ~root =
+  let root = strip_trailing_slash root in
+  (* Unlike the entries below, a root that cannot be stat'ed is reported as
+     unreadable rather than as "not a directory" — the caller needs to tell a
+     permission problem from a wrong path. *)
+  match
+    try Ok (Fs_compat.exact_path_kind ~follow:false root) with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | Sys_error detail -> Error detail
+    | Unix.Unix_error (code, operation, _) ->
+      Error (Printf.sprintf "%s: %s" operation (Unix.error_message code))
+  with
+  | Error detail -> Error (Root_unreadable { root; detail })
+  | Ok root_kind ->
+  match root_kind with
+  | Fs_compat.Exact_missing -> Error (Root_missing { root })
+  | Fs_compat.Exact_unknown ->
+    Error (Root_not_directory { root; kind = "unknown" })
+  | Fs_compat.Exact_kind Unix.S_DIR ->
+    (* The root itself may be the checkout. Answer that before walking, so a
+       keeper that clones straight into its workspace root is not a blind
+       spot. *)
+    (match git_link_of_dir root with
+     | Some git_link ->
+       Ok
+         (Complete
+            [ { relative_path = "."
+              ; absolute_path = root
+              ; name = Filename.basename root
+              ; git_link
+              }
+            ])
+     | None ->
+       let queue = Queue.create () in
+       Queue.add [] queue;
+       let scanned = ref 0 in
+       let found = ref [] in
+       let found_count = ref 0 in
+       let truncation = ref None in
+       let unreadable = ref None in
+       let root_error = ref None in
+       (try
+          while not (Queue.is_empty queue) do
+            let segments = Queue.pop queue in
+            let relative = relative_of_segments segments in
+            let absolute =
+              match segments with
+              | [] -> root
+              | _ -> Filename.concat root relative
+            in
+            (* One yield per directory. The walk runs on the same domain fiber
+               that serves HTTP, and a long uninterrupted walk would starve
+               other requests between them. *)
+            Eio_guard.fair_yield ();
+            let entries =
+              let fail detail =
+                match segments with
+                | [] -> raise (Root_read_failed detail)
+                | _ ->
+                  (* Skip this subtree and keep walking. Ending the scan here
+                     would drop every checkout the traversal had not reached
+                     yet — with breadth-first order that is whatever sorts
+                     after the unreadable directory, which is arbitrary. The
+                     listing narrows; it does not stop. *)
+                  if Option.is_none !unreadable
+                  then
+                    unreadable
+                    := Some (Directory_unreadable { relative_path = relative; detail });
+                  []
+              in
+              try Fs_compat.read_dir absolute with
+              | Eio.Cancel.Cancelled _ as exn -> raise exn
+              | Sys_error detail -> fail detail
+              | Unix.Unix_error (code, operation, _) ->
+                fail (Printf.sprintf "%s: %s" operation (Unix.error_message code))
+            in
+            scanned := !scanned + List.length entries;
+            if !scanned > max_scanned_entries
+            then
+              raise
+                (Truncated
+                   (Entry_budget_exhausted
+                      { scanned = !scanned; budget = max_scanned_entries }));
+            List.iter
+              (fun entry ->
+                 if not (String.equal entry "." || String.equal entry "..")
+                 then (
+                   let child_segments = segments @ [ entry ] in
+                   let child_abs = Filename.concat absolute entry in
+                   if is_directory_no_follow child_abs
+                   then (
+                     match git_link_of_dir child_abs with
+                     | Some git_link ->
+                       (* Found a checkout: do not descend. Its subtree belongs
+                          to it, which is what keeps _build/.sandbox/.git and
+                          node_modules out without naming them. *)
+                       found
+                       := { relative_path = relative_of_segments child_segments
+                          ; absolute_path = child_abs
+                          ; name = entry
+                          ; git_link
+                          }
+                          :: !found;
+                       incr found_count;
+                       if !found_count > max_reported_checkouts
+                       then
+                         raise
+                           (Truncated
+                              (Checkout_budget_exhausted
+                                 { budget = max_reported_checkouts }))
+                     | None -> Queue.add child_segments queue)))
+              entries
+          done
+        with
+        | Truncated limit -> truncation := Some limit
+        | Root_read_failed detail -> root_error := Some detail);
+       (match !root_error with
+        | Some detail -> Error (Root_unreadable { root; detail })
+        | None ->
+          (* A budget stop is reported ahead of an unreadable directory: it
+             bounds the whole listing, while the latter bounds one subtree. *)
+          (match !truncation, !unreadable with
+           | None, None -> Ok (Complete (sort_by_relative_path !found))
+           | Some limit, _ | None, Some limit ->
+             Ok
+               (Partial
+                  { found =
+                      take max_reported_checkouts (sort_by_relative_path !found)
+                  ; limit
+                  }))))
+  | Fs_compat.Exact_kind kind ->
+    Error (Root_not_directory { root; kind = file_kind_to_string kind })
+;;
+
+let found = function
+  | Complete checkouts -> checkouts
+  | Partial { found; _ } -> found
+;;
+
+let join checkout ~suffix =
+  match String.equal checkout.relative_path ".", String.equal suffix "" with
+  | true, true -> "."
+  | true, false -> suffix
+  | false, true -> checkout.relative_path
+  | false, false -> Filename.concat checkout.relative_path suffix
+;;
+
+type name_resolution =
+  | Resolved of checkout
+  | Not_found
+  | Ambiguous of checkout list
+
+let resolve_by_name discovery ~name =
+  match List.filter (fun c -> String.equal c.name name) (found discovery) with
+  | [ checkout ] -> Resolved checkout
+  | [] -> Not_found
+  | many -> Ambiguous many
+;;
+
+let limit_to_string = function
+  | Entry_budget_exhausted { scanned; budget } ->
+    Printf.sprintf "entry budget exhausted (scanned %d, budget %d)" scanned budget
+  | Checkout_budget_exhausted { budget } ->
+    Printf.sprintf "checkout budget exhausted (budget %d)" budget
+  | Directory_unreadable { relative_path; detail } ->
+    Printf.sprintf "directory unreadable at %s: %s" relative_path detail
+;;
+
+let scan_error_to_string = function
+  | Root_missing { root } -> Printf.sprintf "workspace root missing: %s" root
+  | Root_not_directory { root; kind } ->
+    Printf.sprintf "workspace root is a %s, not a directory: %s" kind root
+  | Root_unreadable { root; detail } ->
+    Printf.sprintf "workspace root unreadable: %s: %s" root detail
+;;
+
+let limit_code = function
+  | Entry_budget_exhausted _ -> "entry_budget"
+  | Checkout_budget_exhausted _ -> "checkout_budget"
+  | Directory_unreadable _ -> "directory_unreadable"
+;;
+
+let scan_json (result : (discovery, scan_error) result) : Yojson.Safe.t =
+  match result with
+  | Ok (Complete _) ->
+    `Assoc
+      [ "state", `String "complete"
+      ; "root_relative", `Bool true
+      ; "limit", `Null
+      ; "detail", `Null
+      ; "scanned_entries", `Null
+      ]
+  | Ok (Partial { limit; _ }) ->
+    `Assoc
+      [ "state", `String "partial"
+      ; "root_relative", `Bool true
+      ; "limit", `String (limit_code limit)
+      ; "detail", `String (limit_to_string limit)
+      ; ( "scanned_entries"
+        , match limit with
+          | Entry_budget_exhausted { scanned; _ } -> `Int scanned
+          | Checkout_budget_exhausted _ | Directory_unreadable _ -> `Null )
+      ]
+  | Error error ->
+    `Assoc
+      [ "state", `String "unavailable"
+      ; "root_relative", `Bool true
+      ; "limit", `Null
+      ; "detail", `String (scan_error_to_string error)
+      ; "scanned_entries", `Null
+      ]
+;;

--- a/lib/keeper/keeper_playground_checkouts.mli
+++ b/lib/keeper/keeper_playground_checkouts.mli
@@ -73,16 +73,13 @@ type discovery =
       ; limit : limit
       }
 
-val max_scanned_entries : int
-(** Safety stop, not a design parameter. Measured across the live playground
-    (12 keepers, 2026-08-13): worst case 495 entries, median 34. A normal
-    playground cannot reach this ceiling, so reaching it is itself the signal
-    that something unexpected sits under the root. *)
-
 val max_reported_checkouts : int
 (** Bounded by downstream cost rather than by the scan: each reported checkout
     costs six bounded git subprocesses in
-    {!Keeper_sandbox_control.checkout_json}. Live maximum is 12. *)
+    {!Keeper_sandbox_control.checkout_json}. Live maximum is 12.
+
+    Exposed because a test builds one checkout past it; the entry budget is a
+    pure safety stop with no such handle and stays internal. *)
 
 val discover : root:string -> (discovery, scan_error) result
 (** [discover ~root] walks [root] and reports the git checkouts under it,

--- a/lib/keeper/keeper_playground_checkouts.mli
+++ b/lib/keeper/keeper_playground_checkouts.mli
@@ -1,0 +1,122 @@
+(** Discover git checkouts under a keeper's workspace root by measurement.
+
+    The system does not regulate what a keeper puts under its workspace root.
+    It observes. A directory is a checkout when it holds a [.git] entry; where
+    that directory sits is the keeper's business.
+
+    This replaces three independent scans that each hardcoded a [repos/]
+    segment and each disagreed about what counted as a checkout: one accepted
+    any directory, one required [.git], one excluded dot-prefixed names. See
+    RFC-keeper-workspace-root-only §1.2.
+
+    {1 Traversal}
+
+    Breadth-first from the root, stopping at every checkout found — the
+    subtree of a checkout belongs to that checkout, so [_build/.sandbox/.git]
+    and [node_modules/*/.git] are never reached. That stop is what bounds the
+    walk; there is no depth limit, because a depth limit is the same kind of
+    layout rule this module exists to remove (a checkout placed one level too
+    deep would silently vanish).
+
+    Symlinks are not followed, so the traversal cannot cycle. *)
+
+type git_link =
+  | Git_directory (** [<dir>/.git] is a directory: a primary checkout. *)
+  | Git_pointer_file
+      (** [<dir>/.git] is a regular file holding a [gitdir:] pointer: a linked
+          worktree or a submodule. *)
+
+type checkout =
+  { relative_path : string
+      (** Path from the workspace root. ["repos/masc"], ["masc"], or ["."]
+          when the root is itself a checkout. *)
+  ; absolute_path : string  (** Normalized absolute path to the checkout. *)
+  ; name : string
+      (** Basename of [relative_path]; the root's basename when it is ["."]. *)
+  ; git_link : git_link
+  }
+
+(** Why a scan returned fewer checkouts than the tree may hold. Truncation is
+    not failure: the list is real, just partial. Callers must not present a
+    truncated list as complete. *)
+type limit =
+  | Entry_budget_exhausted of
+      { scanned : int
+      ; budget : int
+      }
+  | Checkout_budget_exhausted of { budget : int }
+  | Directory_unreadable of
+      { relative_path : string
+      ; detail : string
+      }
+      (** One subdirectory could not be read. The checkouts found before it are
+          still returned — a single unreadable directory does not blank the
+          whole listing. *)
+
+(** A scan that produced no list at all. Distinct from [Complete []], which
+    says the root exists and holds no checkout. *)
+type scan_error =
+  | Root_missing of { root : string }
+  | Root_not_directory of
+      { root : string
+      ; kind : string
+      }
+  | Root_unreadable of
+      { root : string
+      ; detail : string
+      }
+
+type discovery =
+  | Complete of checkout list
+  | Partial of
+      { found : checkout list
+      ; limit : limit
+      }
+
+val max_scanned_entries : int
+(** Safety stop, not a design parameter. Measured across the live playground
+    (12 keepers, 2026-08-13): worst case 495 entries, median 34. A normal
+    playground cannot reach this ceiling, so reaching it is itself the signal
+    that something unexpected sits under the root. *)
+
+val max_reported_checkouts : int
+(** Bounded by downstream cost rather than by the scan: each reported checkout
+    costs six bounded git subprocesses in
+    {!Keeper_sandbox_control.checkout_json}. Live maximum is 12. *)
+
+val discover : root:string -> (discovery, scan_error) result
+(** [discover ~root] walks [root] and reports the git checkouts under it,
+    sorted by [relative_path].
+
+    Checks [root] itself first: if [<root>/.git] exists, the result is that one
+    checkout with [relative_path = "."] and nothing below is scanned. *)
+
+val found : discovery -> checkout list
+(** The checkouts in a discovery, whether complete or partial. Use only where
+    partiality genuinely does not change the answer. *)
+
+val join : checkout -> suffix:string -> string
+(** [join c ~suffix] is the root-relative logical path of [suffix] inside [c].
+
+    Handles the two edges that callers previously got wrong in different ways:
+    an empty [suffix] (["repos/masc"], not ["repos/masc/"]) and a root checkout
+    (["lib"], not ["./lib"]). *)
+
+type name_resolution =
+  | Resolved of checkout
+  | Not_found
+  | Ambiguous of checkout list
+
+val resolve_by_name : discovery -> name:string -> name_resolution
+(** Find a checkout by basename. Two checkouts can share a basename once the
+    layout is free (a keeper holding both [repos/masc] and [.masc/repos/masc]),
+    so this reports [Ambiguous] rather than picking by sort order. *)
+
+val limit_to_string : limit -> string
+val scan_error_to_string : scan_error -> string
+
+val scan_json : (discovery, scan_error) result -> Yojson.Safe.t
+(** The wire ["scan"] object. Renders complete, truncated, and failed scans
+    through one encoder so that "the root is missing" and "the root holds no
+    checkout" stay distinguishable on the wire — today both surface as an
+    empty list. *)

--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -255,55 +255,10 @@ let cleanup_stale ~(config : Workspace.config) ~(timeout_sec : float) () =
     ~timeout_sec
     ()
 
-let observed_is_dir path =
-  try
-    match Fs_compat.exact_path_kind ~follow:false path with
-    | Fs_compat.Exact_kind Unix.S_DIR -> true
-    | Fs_compat.Exact_missing
-    | Fs_compat.Exact_kind _
-    | Fs_compat.Exact_unknown -> false
-  with
-  | Sys_error error ->
-    Log.Keeper.warn
-      "playground filesystem observation failed path=%s error=%s"
-      path
-      error;
-    false
-  | Unix.Unix_error (error, operation, argument) ->
-    Log.Keeper.warn
-      "playground filesystem observation failed path=%s error=%s(%s): %s"
-      path
-      operation
-      argument
-      (Unix.error_message error);
-    false
-
-let valid_checkout_name name =
-  name <> ""
-  && name <> "."
-  && name <> ".."
-  && not (String.contains name '/')
-  && not (String.contains name '\\')
-  && String.equal (Filename.basename name) name
-
-let filesystem_checkout_names sandbox_abs =
-  let repos_dir = Filename.concat sandbox_abs "repos" in
-  if not (observed_is_dir repos_dir) then []
-  else
-    try
-      Sys.readdir repos_dir
-      |> Array.to_list
-      |> List.filter (fun name ->
-        let repo_path = Filename.concat repos_dir name in
-        valid_checkout_name name && observed_is_dir repo_path)
-      |> List.sort String.compare
-    with
-    | Sys_error error ->
-      Log.Keeper.warn
-        "repository checkout observation failed path=%s error=%s"
-        repos_dir
-        error;
-      []
+(* [observed_is_dir], [valid_checkout_name] and [filesystem_checkout_names]
+   lived here to list [<sandbox>/repos/*]. Discovery now measures the tree
+   ([Keeper_playground_checkouts]), which also validates entry kinds and
+   reports read failures as a typed result instead of a warn-and-empty-list. *)
 
 type catalog_resolution =
   | Registered of Repo_manager_types.repository
@@ -411,8 +366,13 @@ let freshness_json = function
   | Freshness_unavailable error ->
     `Assoc [ "state", `String "unavailable"; "error", `String error ]
 
-let checkout_json ~catalog ~sandbox_abs name =
-  let checkout_abs = Filename.concat (Filename.concat sandbox_abs "repos") name in
+let checkout_json ~catalog (checkout : Keeper_playground_checkouts.checkout) =
+  (* The checkout's own path, as discovered. Previously this reassembled
+     [sandbox_abs/repos/<name>], which meant any checkout found outside that
+     one shape was inspected at a path that does not exist — every git call
+     below would fail and the entry would render as "unavailable". *)
+  let checkout_abs = checkout.absolute_path in
+  let name = checkout.name in
   let origin = Repo_git.get_origin_url ~local_path:checkout_abs in
   let catalog_resolution =
     match origin with
@@ -439,7 +399,17 @@ let checkout_json ~catalog ~sandbox_abs name =
   in
   `Assoc
     [ "checkout_name", `String name
-    ; "path", `String (Filename.concat "repos" name)
+    ; "path", `String checkout.relative_path
+      (* [path] is relative to the keeper's workspace root and is whatever the
+         keeper actually used; it is no longer prefixed with a segment the
+         system prescribes. [path_base] states that basis on the wire so a
+         reader does not have to know the old convention. *)
+    ; "path_base", `String "playground_root"
+    ; ( "git_link"
+      , `String
+          (match checkout.git_link with
+           | Keeper_playground_checkouts.Git_directory -> "directory"
+           | Keeper_playground_checkouts.Git_pointer_file -> "pointer_file") )
     ; "catalog", catalog_json catalog_resolution
     ; "branch", (match branch with Ok value -> `String value | Error _ -> `Null)
     ; "head", (match head with Ok value -> `String value | Error _ -> `Null)
@@ -457,12 +427,24 @@ let repository_checkouts_json ~(config : Workspace.config) ~(meta : keeper_meta)
   in
   let observed_at_unix = Time_compat.now () in
   let catalog = Repo_store.load_all ~base_path:config.base_path in
+  let scan = Keeper_playground_checkouts.discover ~root:sandbox_abs in
   let entries =
-    filesystem_checkout_names sandbox_abs
-    |> List.map (checkout_json ~catalog ~sandbox_abs)
+    match scan with
+    | Ok discovery ->
+      Keeper_playground_checkouts.found discovery
+      |> List.map (checkout_json ~catalog)
+    | Error _ -> []
   in
   `Assoc
-    [ "state", `String (match catalog with Ok _ -> "available" | Error _ -> "catalog_unavailable")
+    [ ( "state"
+      , `String
+          (match catalog, scan with
+           | Ok _, Ok _ -> "available"
+           | Error _, _ -> "catalog_unavailable"
+           (* A failed scan and an empty playground used to be the same empty
+              list. They are different answers and now say so. *)
+           | Ok _, Error _ -> "filesystem_unavailable") )
+    ; "scan", Keeper_playground_checkouts.scan_json scan
     ; "freshness_basis", `String "local_tracking_ref"
     ; "observed_at", `String (Masc_domain.iso8601_of_unix_seconds observed_at_unix)
     ; "observed_at_unix", `Float observed_at_unix

--- a/lib/keeper/keeper_tool_filesystem_runtime.ml
+++ b/lib/keeper/keeper_tool_filesystem_runtime.ml
@@ -197,36 +197,43 @@ let string_opt_nonempty name json =
    A keeper that guesses the host layout ("workspace/<org>/<repo>") gets the
    same "directory does not exist" as one that asked for a repo nobody
    materialized, and the two need opposite responses: retry with the right
-   prefix, or stop asking. Live taskmaster hit the first and kept retrying
-   (#23442). The vocabulary is "repos/<repo>" -- see the projection note in
-   [resolve_read_file_cwd] -- so the accepted set is exactly what sits under
-   the keeper's playground [repos/]. An empty set is reported as empty rather
-   than omitted, because "no repository is materialized" is the answer to a
-   different question than "you named the wrong one". *)
-let materialized_repo_cwds ~config ~meta =
-  let repos_root = Filename.concat (keeper_playground_root ~config ~meta) "repos" in
-  if not (safe_is_dir repos_root)
-  then []
-  else (
-    match Sys.readdir repos_root with
-    | exception Sys_error _ -> []
-    | entries ->
-      Array.to_list entries
-      |> List.filter (fun name ->
-           (not (String.length name > 0 && name.[0] = '.'))
-           && safe_is_dir (Filename.concat repos_root name))
-      |> List.sort String.compare)
-;;
-
+   path, or stop asking. Live taskmaster hit the first and kept retrying
+   (#23442). The set is measured, not prescribed: whatever git checkouts sit
+   under the keeper's workspace root, wherever the keeper put them. An empty
+   set is reported as empty rather than omitted, because "no repository is
+   materialized" is the answer to a different question than "you named the
+   wrong one" — and by the same argument a scan that failed is a third answer
+   and says so. *)
 let available_cwd_hint ~config ~meta =
-  match materialized_repo_cwds ~config ~meta with
-  | [] ->
-    " no repository is materialized under repos/ for this keeper, so no \
-     repos/<repo> cwd exists yet"
-  | repos ->
+  let root = keeper_playground_root ~config ~meta in
+  match Keeper_playground_checkouts.discover ~root with
+  | Ok (Keeper_playground_checkouts.Complete []) ->
+    " no repository is materialized for this keeper yet, so the workspace root \
+     is the only cwd that exists"
+  | Ok (Keeper_playground_checkouts.Complete checkouts) ->
     Printf.sprintf
-      " available repo cwds: %s"
-      (String.concat ", " (List.map (fun name -> "repos/" ^ name) repos))
+      " available cwds: %s"
+      (String.concat
+         ", "
+         (List.map
+            (fun (c : Keeper_playground_checkouts.checkout) -> c.relative_path)
+            checkouts))
+  | Ok (Keeper_playground_checkouts.Partial { found; limit }) ->
+    (* Presenting a truncated list as complete is worse than saying it is
+       truncated: a keeper that cannot find its repo in a list that looks
+       exhaustive concludes it should stop asking. *)
+    Printf.sprintf
+      " available cwds (partial, %s): %s"
+      (Keeper_playground_checkouts.limit_to_string limit)
+      (String.concat
+         ", "
+         (List.map
+            (fun (c : Keeper_playground_checkouts.checkout) -> c.relative_path)
+            found))
+  | Error error ->
+    Printf.sprintf
+      " workspace checkout scan failed (%s); cwds could not be enumerated"
+      (Keeper_playground_checkouts.scan_error_to_string error)
 ;;
 
 let resolve_read_file_cwd ~(config : Workspace.config) ~(meta : keeper_meta) ~cwd =

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -155,39 +155,58 @@ let container_path_of_host (t : t) ~host_path =
          t.host_root)
 ;;
 
-let repos_in_playground host_root =
-  let repos_dir = Filename.concat host_root "repos" in
-  if not (Sys.file_exists repos_dir && Sys.is_directory repos_dir)
-  then []
-  else (
-    try
-      Sys.readdir repos_dir
-      |> Array.to_list
-      |> List.filter (fun name ->
-        let p = Filename.concat repos_dir name in
-        try Sys.is_directory p && Sys.file_exists (Filename.concat p ".git") with
-        | Sys_error _ -> false)
-      |> List.sort compare
-    with
-    | Sys_error _ -> [])
+(* Previously listed [<host_root>/repos/*] and swallowed every failure into an
+   empty list, which made "no checkout", "no repos directory" and "could not
+   read" indistinguishable. A cwd that cannot be mapped is silently redirected
+   to the container root, so the reason has to reach the log. *)
+let discovered_checkouts (t : t) =
+  match Keeper_playground_checkouts.discover ~root:t.host_root with
+  | Ok (Keeper_playground_checkouts.Complete checkouts) -> checkouts
+  | Ok (Keeper_playground_checkouts.Partial { found; limit }) ->
+    Log.Keeper.warn
+      "playground checkout scan incomplete keeper=%s root=%s limit=%s"
+      t.meta.name
+      t.host_root
+      (Keeper_playground_checkouts.limit_to_string limit);
+    found
+  | Error error ->
+    Log.Keeper.warn
+      "playground checkout scan failed keeper=%s root=%s error=%s"
+      t.meta.name
+      t.host_root
+      (Keeper_playground_checkouts.scan_error_to_string error);
+    []
+;;
 
 let skip_worktree_prefix = function
   | ".worktrees" :: _branch :: rest -> rest
   | "./.worktrees" :: _branch :: rest -> rest
   | other -> other
 
-let find_repo_segment_and_suffix ~repos ~host_cwd =
-  let segments = String.split_on_char '/' host_cwd in
-  let rec find_suffix = function
-    | [] -> None
+type cwd_match =
+  | Matched of Keeper_playground_checkouts.checkout * string
+  | Ambiguous_segment of string * Keeper_playground_checkouts.checkout list
+  | No_match
+
+(* Once the layout is free, two checkouts can share a basename (a keeper
+   holding both [repos/masc] and [.masc/repos/masc]). The previous [List.mem]
+   answered such a case by sort order, i.e. arbitrarily. *)
+let find_checkout_and_suffix ~checkouts ~host_cwd =
+  let rec find = function
+    | [] -> No_match
     | head :: tail ->
-      if List.mem head repos then
-        let effective_tail = skip_worktree_prefix tail in
-        Some (head, String.concat "/" effective_tail)
-      else
-        find_suffix tail
+      (match
+         List.filter
+           (fun (c : Keeper_playground_checkouts.checkout) ->
+              String.equal c.name head)
+           checkouts
+       with
+       | [ checkout ] ->
+         Matched (checkout, String.concat "/" (skip_worktree_prefix tail))
+       | [] -> find tail
+       | many -> Ambiguous_segment (head, many))
   in
-  find_suffix segments
+  find (String.split_on_char '/' host_cwd)
 
 let container_cwd_of_host (t : t) ~host_cwd =
   match container_path_of_host t ~host_path:host_cwd with
@@ -197,14 +216,28 @@ let container_cwd_of_host (t : t) ~host_cwd =
             ~container_root:t.container_root ~host_cwd with
     | Some cwd -> cwd
     | None ->
-      let repos = repos_in_playground t.host_root in
-      (match find_repo_segment_and_suffix ~repos ~host_cwd with
-       | Some (repo_name, suffix) ->
-         let logical_path =
-           Filename.concat (Filename.concat "repos" repo_name) suffix
-         in
-         Filename.concat t.container_root logical_path
-       | None -> t.container_root)
+      let checkouts = discovered_checkouts t in
+      (match find_checkout_and_suffix ~checkouts ~host_cwd with
+       | Matched (checkout, suffix) ->
+         Filename.concat
+           t.container_root
+           (Keeper_playground_checkouts.join checkout ~suffix)
+       | Ambiguous_segment (segment, many) ->
+         (* Falling back to the container root is still the answer — there is
+            no better one — but which of the candidates was meant is now
+            recorded instead of decided by sort order. *)
+         Log.Keeper.warn
+           "playground cwd segment matches multiple checkouts keeper=%s segment=%s \
+            paths=%s"
+           t.meta.name
+           segment
+           (String.concat
+              ","
+              (List.map
+                 (fun (c : Keeper_playground_checkouts.checkout) -> c.relative_path)
+                 many));
+         t.container_root
+       | No_match -> t.container_root)
 ;;
 
 let format_docker_exec_error ~head_program ~st ~out =

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -37,6 +37,7 @@ paused_targets=(
 )
 
 normal_targets=(
+  @test/runtest-test_keeper_playground_checkout_discovery
   @test/runtest-test_keeper_autonomous_turn_source
   @test/runtest-test_keeper_autoboot_single_owner
   @test/runtest-test_keeper_meta_current_schema

--- a/test/dune
+++ b/test/dune
@@ -207,6 +207,7 @@
   test_keeper_runtime_attempt
   test_keeper_allowed_paths
   test_playground_paths
+  test_keeper_playground_checkout_discovery
   test_keeper_meta_cwd_resilience
   test_keeper_effective_meta_overlay
   test_metrics_rotation
@@ -503,6 +504,7 @@
   test_keeper_runtime_attempt
   test_keeper_allowed_paths
   test_playground_paths
+  test_keeper_playground_checkout_discovery
   test_keeper_meta_cwd_resilience
   test_keeper_effective_meta_overlay
   test_metrics_rotation

--- a/test/test_keeper_playground_checkout_discovery.ml
+++ b/test/test_keeper_playground_checkout_discovery.ml
@@ -1,0 +1,383 @@
+(** Tests for [Keeper_playground_checkouts.discover].
+
+    Each case pins one decision from RFC-keeper-workspace-root-only. The
+    fixtures are shaped after the live playground measured on 2026-08-13, not
+    after the layout the system used to prescribe. *)
+
+open Alcotest
+module C = Masc.Keeper_playground_checkouts
+
+let rec rm_rf path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path |> Array.iter (fun n -> rm_rf (Filename.concat path n));
+      Unix.rmdir path)
+    else Sys.remove path
+;;
+
+let mkdir_p path =
+  let rec go path =
+    if not (Sys.file_exists path)
+    then (
+      go (Filename.dirname path);
+      Unix.mkdir path 0o755)
+  in
+  go path
+;;
+
+let write_file path contents =
+  mkdir_p (Filename.dirname path);
+  let oc = open_out path in
+  output_string oc contents;
+  close_out oc
+;;
+
+(** A primary checkout: [<dir>/.git] is a directory. *)
+let make_checkout root rel = mkdir_p (Filename.concat (Filename.concat root rel) ".git")
+
+(** A linked worktree: [<dir>/.git] is a regular file holding a gitdir pointer. *)
+let make_worktree root rel =
+  let dir = Filename.concat root rel in
+  mkdir_p dir;
+  write_file (Filename.concat dir ".git") "gitdir: /somewhere/.git/worktrees/x\n"
+;;
+
+let with_temp_root f =
+  let dir = Filename.temp_file "keeper-checkout-discovery-" "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect ~finally:(fun () -> try rm_rf dir with _ -> ()) (fun () -> f dir)
+;;
+
+let paths_of result =
+  match result with
+  | Ok (C.Complete cs) -> List.map (fun (c : C.checkout) -> c.relative_path) cs
+  | Ok (C.Partial { found; _ }) ->
+    List.map (fun (c : C.checkout) -> c.relative_path) found
+  | Error e -> [ "<error: " ^ C.scan_error_to_string e ^ ">" ]
+;;
+
+let check_paths msg expected result = check (list string) msg expected (paths_of result)
+
+(* ------------------------------------------------------------------ *)
+(* Discovery shape                                                     *)
+(* ------------------------------------------------------------------ *)
+
+(* The old layout must keep working: this is what makes the change need no
+   migration. *)
+let test_finds_legacy_repos_layout () =
+  with_temp_root (fun root ->
+    make_checkout root "repos/masc";
+    check_paths "repos/masc is still found" [ "repos/masc" ] (C.discover ~root))
+;;
+
+let test_finds_checkout_directly_under_root () =
+  with_temp_root (fun root ->
+    make_checkout root "masc";
+    check_paths "a checkout one level down is found" [ "masc" ] (C.discover ~root))
+;;
+
+(* A keeper that clones straight into its workspace root would otherwise be a
+   blind spot. *)
+let test_root_itself_is_a_checkout () =
+  with_temp_root (fun root ->
+    mkdir_p (Filename.concat root ".git");
+    make_checkout root "nested/other";
+    check_paths "root reports as \".\" and nothing below is scanned" [ "." ]
+      (C.discover ~root))
+;;
+
+(* Measured live: code-reviewer and sangsu both put checkouts under a
+   dot-directory. A scan that skips hidden names loses them. *)
+let test_finds_checkout_under_hidden_directory () =
+  with_temp_root (fun root ->
+    make_checkout root ".masc/repos/vp-tempo-cli";
+    check_paths "hidden directories are traversed"
+      [ ".masc/repos/vp-tempo-cli" ]
+      (C.discover ~root))
+;;
+
+let test_finds_worktree_with_gitdir_file () =
+  with_temp_root (fun root ->
+    make_worktree root ".tmp/task136-fix";
+    check_paths "a .git file counts as a checkout"
+      [ ".tmp/task136-fix" ]
+      (C.discover ~root);
+    match C.discover ~root with
+    | Ok (C.Complete [ c ]) ->
+      check bool "classified as a pointer file" true (c.git_link = C.Git_pointer_file)
+    | _ -> fail "expected exactly one checkout")
+;;
+
+(* No depth limit: a depth limit is the same kind of layout rule this module
+   removes, and it fails silently. *)
+let test_no_depth_limit () =
+  with_temp_root (fun root ->
+    make_checkout root "a/b/c/d/e/masc";
+    check_paths "a deeply nested checkout is found"
+      [ "a/b/c/d/e/masc" ]
+      (C.discover ~root))
+;;
+
+(* ------------------------------------------------------------------ *)
+(* Stopping at a checkout                                              *)
+(* ------------------------------------------------------------------ *)
+
+(* dune writes _build/.sandbox/.git and yarn writes node_modules/*/.git. Both
+   live inside a checkout, so stopping there removes them without naming them.
+   No blacklist. *)
+let test_does_not_descend_into_a_checkout () =
+  with_temp_root (fun root ->
+    make_checkout root "repos/masc";
+    make_worktree root "repos/masc/_build/.sandbox";
+    make_checkout root "repos/masc/node_modules/pkg";
+    check_paths "build artifacts inside a checkout are not reported"
+      [ "repos/masc" ]
+      (C.discover ~root))
+;;
+
+let test_hierarchical_worktree_is_not_a_separate_checkout () =
+  with_temp_root (fun root ->
+    make_checkout root "repos/masc";
+    make_worktree root "repos/masc/.worktrees/task-017";
+    check_paths "a worktree under its parent checkout is not counted twice"
+      [ "repos/masc" ]
+      (C.discover ~root))
+;;
+
+(* Measured live: kidsnote/repos/masc-task-188 sits beside the checkout it
+   belongs to, not under it. The old scan already counted these, so the
+   behaviour must not change. *)
+let test_flat_worktree_is_its_own_checkout () =
+  with_temp_root (fun root ->
+    make_checkout root "repos/masc";
+    make_worktree root "repos/masc-task-188";
+    check_paths "a worktree beside the checkout is counted"
+      [ "repos/masc"; "repos/masc-task-188" ]
+      (C.discover ~root))
+;;
+
+(* Measured live: code-reviewer/repos/masc/review-pr-28304 is a worktree
+   outside the .worktrees/ convention. Naming that directory would miss it. *)
+let test_worktree_outside_the_worktrees_convention () =
+  with_temp_root (fun root ->
+    make_checkout root "repos/masc";
+    make_worktree root "repos/review-pr-28304";
+    check_paths "no special handling of the .worktrees name"
+      [ "repos/masc"; "repos/review-pr-28304" ]
+      (C.discover ~root))
+;;
+
+(* ------------------------------------------------------------------ *)
+(* Symlinks                                                            *)
+(* ------------------------------------------------------------------ *)
+
+let test_symlinked_directory_is_not_traversed () =
+  with_temp_root (fun root ->
+    make_checkout root "repos/masc";
+    Unix.symlink (Filename.concat root "repos") (Filename.concat root "link");
+    check_paths "a symlink to a directory does not duplicate its contents"
+      [ "repos/masc" ]
+      (C.discover ~root))
+;;
+
+(* A .git symlink can point outside the workspace root; treating it as a
+   checkout would attribute writes to a tree the keeper does not own. *)
+let test_symlinked_git_entry_is_rejected () =
+  with_temp_root (fun root ->
+    let target = Filename.concat root "elsewhere" in
+    mkdir_p target;
+    let dir = Filename.concat root "repos/x" in
+    mkdir_p dir;
+    Unix.symlink target (Filename.concat dir ".git");
+    check_paths "a symlinked .git is not a checkout" [] (C.discover ~root))
+;;
+
+(* ------------------------------------------------------------------ *)
+(* Failure is not emptiness                                            *)
+(* ------------------------------------------------------------------ *)
+
+(* The whole point of the typed result: today "the root does not exist" and
+   "the root holds no checkout" both surface as []. *)
+let test_missing_root_is_not_an_empty_listing () =
+  with_temp_root (fun root ->
+    let missing = Filename.concat root "does-not-exist" in
+    match C.discover ~root:missing with
+    | Error (C.Root_missing _) -> ()
+    | Ok (C.Complete []) -> fail "a missing root must not read as an empty listing"
+    | Ok _ -> fail "expected Root_missing"
+    | Error e -> fail ("expected Root_missing, got " ^ C.scan_error_to_string e))
+;;
+
+let test_empty_root_is_a_complete_empty_listing () =
+  with_temp_root (fun root ->
+    match C.discover ~root with
+    | Ok (C.Complete []) -> ()
+    | other -> fail ("expected Complete [], got " ^ String.concat "," (paths_of other)))
+;;
+
+let test_root_that_is_a_file () =
+  with_temp_root (fun root ->
+    let path = Filename.concat root "a-file" in
+    write_file path "x";
+    match C.discover ~root:path with
+    | Error (C.Root_not_directory _) -> ()
+    | _ -> fail "expected Root_not_directory")
+;;
+
+(* One unreadable subdirectory must not blank the whole listing. *)
+let test_unreadable_subdirectory_is_partial_not_fatal () =
+  if Unix.geteuid () = 0
+  then ()
+  else
+    with_temp_root (fun root ->
+      make_checkout root "repos/masc";
+      let blocked = Filename.concat root "blocked" in
+      mkdir_p blocked;
+      Unix.chmod blocked 0o000;
+      (* Restore under protect: if discover raises, an un-restored 0o000
+         directory also blocks the harness's own cleanup. *)
+      let result =
+        Fun.protect
+          ~finally:(fun () -> try Unix.chmod blocked 0o755 with _ -> ())
+          (fun () -> C.discover ~root)
+      in
+      match result with
+      | Ok (C.Partial { found; limit = C.Directory_unreadable _ }) ->
+        check (list string) "checkouts found before the failure are kept"
+          [ "repos/masc" ]
+          (List.map (fun (c : C.checkout) -> c.relative_path) found)
+      | other ->
+        fail
+          ("expected Partial Directory_unreadable, got "
+           ^ String.concat "," (paths_of other)))
+;;
+
+(* ------------------------------------------------------------------ *)
+(* Name resolution and path joining                                    *)
+(* ------------------------------------------------------------------ *)
+
+(* Two checkouts can share a basename once the layout is free. Picking by sort
+   order would be an arbitrary answer to an ambiguous question. *)
+let test_duplicate_basename_is_ambiguous () =
+  with_temp_root (fun root ->
+    make_checkout root "repos/masc";
+    make_checkout root "work/masc";
+    match C.discover ~root with
+    | Ok discovery ->
+      (match C.resolve_by_name discovery ~name:"masc" with
+       | C.Ambiguous many -> check int "both candidates reported" 2 (List.length many)
+       | C.Resolved _ -> fail "must not pick one of two same-named checkouts"
+       | C.Not_found -> fail "expected Ambiguous")
+    | Error e -> fail (C.scan_error_to_string e))
+;;
+
+let test_join_edges () =
+  with_temp_root (fun root ->
+    make_checkout root "repos/masc";
+    match C.discover ~root with
+    | Ok (C.Complete [ c ]) ->
+      check string "empty suffix does not leave a trailing slash"
+        "repos/masc"
+        (C.join c ~suffix:"");
+      check string "suffix is appended"
+        "repos/masc/lib/foo.ml"
+        (C.join c ~suffix:"lib/foo.ml")
+    | _ -> fail "expected exactly one checkout");
+  with_temp_root (fun root ->
+    mkdir_p (Filename.concat root ".git");
+    match C.discover ~root with
+    | Ok (C.Complete [ c ]) ->
+      check string "root checkout does not produce a ./ prefix" "lib"
+        (C.join c ~suffix:"lib");
+      check string "root checkout with empty suffix stays \".\"" "."
+        (C.join c ~suffix:"")
+    | _ -> fail "expected the root to be the only checkout")
+;;
+
+let test_results_are_sorted_and_stable () =
+  with_temp_root (fun root ->
+    make_checkout root "work/b";
+    make_checkout root "repos/a";
+    make_checkout root "zz";
+    let first = paths_of (C.discover ~root) in
+    let second = paths_of (C.discover ~root) in
+    check (list string) "sorted by relative path" [ "repos/a"; "work/b"; "zz" ] first;
+    check (list string) "repeated scans agree" first second)
+;;
+
+(* ------------------------------------------------------------------ *)
+(* Wire encoding                                                       *)
+(* ------------------------------------------------------------------ *)
+
+let scan_state json =
+  match json with
+  | `Assoc fields ->
+    (match List.assoc_opt "state" fields with
+     | Some (`String s) -> s
+     | _ -> "<missing>")
+  | _ -> "<not an object>"
+;;
+
+(* A missing root and an empty root must not encode the same way. *)
+let test_scan_json_separates_failure_from_emptiness () =
+  with_temp_root (fun root ->
+    check string "empty root encodes as complete" "complete"
+      (scan_state (C.scan_json (C.discover ~root)));
+    let missing = Filename.concat root "does-not-exist" in
+    check string "missing root encodes as unavailable" "unavailable"
+      (scan_state (C.scan_json (C.discover ~root:missing))))
+;;
+
+let () =
+  run
+    "keeper_playground_checkout_discovery"
+    [ ( "discovery"
+      , [ test_case "legacy repos/ layout still found" `Quick test_finds_legacy_repos_layout
+        ; test_case "checkout directly under root" `Quick
+            test_finds_checkout_directly_under_root
+        ; test_case "root itself is a checkout" `Quick test_root_itself_is_a_checkout
+        ; test_case "hidden directories are traversed" `Quick
+            test_finds_checkout_under_hidden_directory
+        ; test_case "gitdir file counts as checkout" `Quick
+            test_finds_worktree_with_gitdir_file
+        ; test_case "no depth limit" `Quick test_no_depth_limit
+        ] )
+    ; ( "stopping at a checkout"
+      , [ test_case "does not descend into a checkout" `Quick
+            test_does_not_descend_into_a_checkout
+        ; test_case "hierarchical worktree not counted" `Quick
+            test_hierarchical_worktree_is_not_a_separate_checkout
+        ; test_case "flat worktree is its own checkout" `Quick
+            test_flat_worktree_is_its_own_checkout
+        ; test_case "worktree outside .worktrees/" `Quick
+            test_worktree_outside_the_worktrees_convention
+        ] )
+    ; ( "symlinks"
+      , [ test_case "symlinked directory not traversed" `Quick
+            test_symlinked_directory_is_not_traversed
+        ; test_case "symlinked .git rejected" `Quick test_symlinked_git_entry_is_rejected
+        ] )
+    ; ( "failure is not emptiness"
+      , [ test_case "missing root is not an empty listing" `Quick
+            test_missing_root_is_not_an_empty_listing
+        ; test_case "empty root is Complete []" `Quick
+            test_empty_root_is_a_complete_empty_listing
+        ; test_case "root that is a file" `Quick test_root_that_is_a_file
+        ; test_case "unreadable subdirectory is partial" `Quick
+            test_unreadable_subdirectory_is_partial_not_fatal
+        ] )
+    ; ( "resolution and joining"
+      , [ test_case "duplicate basename is ambiguous" `Quick
+            test_duplicate_basename_is_ambiguous
+        ; test_case "join edges" `Quick test_join_edges
+        ; test_case "sorted and stable" `Quick test_results_are_sorted_and_stable
+        ] )
+    ; ( "wire"
+      , [ test_case "scan_json separates failure from emptiness" `Quick
+            test_scan_json_separates_failure_from_emptiness
+        ] )
+    ]
+;;

--- a/test/test_keeper_playground_checkout_discovery.ml
+++ b/test/test_keeper_playground_checkout_discovery.ml
@@ -255,6 +255,24 @@ let test_unreadable_subdirectory_is_partial_not_fatal () =
            ^ String.concat "," (paths_of other)))
 ;;
 
+(* Truncation must be visible. A caller that cannot tell a capped listing from
+   a complete one will present the cap as the whole answer. *)
+let test_checkout_budget_truncates_visibly () =
+  with_temp_root (fun root ->
+    for i = 0 to C.max_reported_checkouts do
+      make_checkout root (Printf.sprintf "repos/r%03d" i)
+    done;
+    match C.discover ~root with
+    | Ok (C.Partial { found; limit = C.Checkout_budget_exhausted _ }) ->
+      check int "listing is capped at the budget" C.max_reported_checkouts
+        (List.length found)
+    | Ok (C.Complete cs) ->
+      failf "expected Partial, got Complete with %d checkouts" (List.length cs)
+    | Ok (C.Partial { limit; _ }) ->
+      fail ("expected Checkout_budget_exhausted, got " ^ C.limit_to_string limit)
+    | Error e -> fail (C.scan_error_to_string e))
+;;
+
 (* ------------------------------------------------------------------ *)
 (* Name resolution and path joining                                    *)
 (* ------------------------------------------------------------------ *)
@@ -368,6 +386,8 @@ let () =
         ; test_case "root that is a file" `Quick test_root_that_is_a_file
         ; test_case "unreadable subdirectory is partial" `Quick
             test_unreadable_subdirectory_is_partial_not_fatal
+        ; test_case "checkout budget truncates visibly" `Quick
+            test_checkout_budget_truncates_visibly
         ] )
     ; ( "resolution and joining"
       , [ test_case "duplicate basename is ambiguous" `Quick

--- a/test/test_keeper_visible_path_projection.ml
+++ b/test/test_keeper_visible_path_projection.ml
@@ -398,6 +398,11 @@ let test_cwd_rejection_names_the_materialized_repos () =
   setup
   @@ fun ~config ~meta ~playground ~publication_recovery:_ ->
   allow_repo ~config ~meta "masc";
+  (* The hint enumerates git checkouts measured under the workspace root, not
+     every directory under a prescribed [repos/]. A fixture without [.git] is a
+     plain directory — still a legal cwd, but not something the system reports
+     as a checkout. *)
+  write_file (Filename.concat playground "repos/masc/.git/HEAD") "ref: refs/heads/main\n";
   write_file (Filename.concat playground "repos/masc/README.md") "readme\n";
   let raw =
     handle_read_file


### PR DESCRIPTION
## 요약

keeper 의 체크아웃을 `<workspace_root>/repos/*` 로 **규정**하던 것을, root 아래에서 git 체크아웃을 **실측 발견**하는 것으로 바꾼다. RFC-keeper-workspace-root-only §3.2 구현의 첫 단계.

## 왜

시스템은 `repos/` 를 만들지 않는다. per-keeper clone 은 #24558 에서 삭제됐고 keeper 가 스스로 clone 한다. 그런데 스캔·조립·힌트는 그 구조를 계속 가정했다.

`~/me/.masc/playground/` 실측(2026-08-13): keeper 들이 이미 `repos/` 밖에 체크아웃을 만들었고 **시스템이 보지 못한다**.

| 실제 위치 | 현재 관측 |
|---|---|
| `code-reviewer/.masc/repos/vp-tempo-cli/` | 안 보임 |
| `sangsu/.masc/repos/vp-slugify-lib/` | 안 보임 |
| `kidsnote/.tmp/task136-fix/` (외 2건) | 안 보임 |

그리고 같은 질문에 세 곳이 다르게 답하고 있었다.

| 위치 | 체크아웃 판정 | 실패 처리 |
|---|---|---|
| `keeper_sandbox_control.ml:289` | 디렉터리면 전부 (`.git` 무관) | warn 후 `[]` |
| `keeper_turn_sandbox_runtime.ml:158` | 디렉터리 + `.git` 필수 | `[]`, 로그 없음 |
| `keeper_tool_filesystem_runtime.ml:206` | 디렉터리 + dot 제외 | `[]`, 로그 없음 |

대시보드가 보는 집합, 런타임이 인식하는 집합, keeper 에게 알려주는 집합이 각각 달랐다.

## 무엇을

**신규 `lib/keeper/keeper_playground_checkouts.{ml,mli}`** — 발견 SSOT.

발견 규칙 하나: `<dir>/.git` 이 있고 심링크가 아니면 체크아웃이며, **그 하위로는 내려가지 않는다.**

이 한 규칙이 세 가지를 부수 효과로 해결한다.

- `_build/.sandbox/.git`, `node_modules/*/.git` 은 체크아웃 **내부**라 자동으로 걸러진다. 이름 블랙리스트 불필요.
- `.worktrees/<task>/` 는 부모에서 정지된다. **`.worktrees` 라는 이름을 특별 취급하는 코드가 한 줄도 없다** — 실측상 worktree 는 그 관례 밖에도 놓인다(`review-pr-28304`, `masc-task-188`).
- 깊이 상한이 필요 없다. 상한은 "체크아웃은 root 로부터 N 단계 안에 있어야 한다"를 강제하는 규정의 약한 형태이고, 어기면 **조용히 안 보인다**.

**실측 비용** (12 keeper): 최악 495 readdir 엔트리 / 107 디렉터리, 중앙값 34. 예산 8192 의 6%. 폭발을 막는 것은 깊이가 아니라 체크아웃에서의 정지다.

**대시보드 개수 델타**: code-reviewer +1, kidsnote +3, sangsu +1, **rondo 3→3**, 나머지 8개 0. worktree fanout 없음.

### 실패는 빈 목록이 아니다

```ocaml
type discovery = Complete of checkout list | Partial of { found : checkout list; limit : limit }
val discover : root:string -> (discovery, scan_error) result
```

호출자가 `Complete`/`Partial` 두 갈래를 매치해야 컴파일된다. **`Error (Root_missing _)` 가 `Ok (Complete [])` 과 wire 에서 구별된다** — 오늘은 둘 다 `entries: []` 다.

읽을 수 없는 하위 디렉터리는 건너뛰고 **계속 걷는다**. 거기서 멈추면 BFS 순서상 그 뒤에 오는 체크아웃을 전부 잃는데, 무엇을 잃는지가 정렬 순서에 달리게 된다.

### 함께 고친 것 — 이것 없이는 반쪽이다

| 위치 | 변경 |
|---|---|
| `keeper_sandbox_control.ml:415,442` | `sandbox_abs/repos/<name>` 재조립 → `checkout.absolute_path` / `relative_path` |
| `keeper_turn_sandbox_runtime.ml:204` | `concat "repos" repo` → `join checkout ~suffix` |
| `keeper_tool_filesystem_runtime.ml:221` | `"repos/" ^ name` 산문 → 실측 경로 열거 |
| **`keeper_alerting_path.ml:790,812`** | **`[root; root/repos]` mkdir → `[root]`** |

마지막이 가장 중요하다. 이것 없이는 시스템이 keeper 부팅마다 빈 `repos/` 를 만들고, 모델이 root 를 `ls` 하면 그걸 보고 규약을 재발명한다.

### wire

`path` 의미가 바뀌고(`"repos/masc"` → 실측 `relative_path`), `path_base`·`git_link`·`scan` 이 추가된다. 대시보드는 `path` 를 불투명 문자열로만 다루므로(`keeper-detail-comms.ts:101-118`) TS 변경이 없고 기존 TS 테스트도 접두사를 단언하지 않는다.

기존 설치 기반은 여전히 `"repos/masc"` 를 낸다 — **마이그레이션 0**.

### `Ambiguous`

레이아웃이 자유로워지면 두 체크아웃이 basename 을 공유할 수 있다(`repos/masc` + `.masc/repos/masc`). 기존 `List.mem` 은 정렬 순서로 답했다. 이제 `Ambiguous` 를 반환하고 로그를 남긴 뒤 기존 폴백(container root)을 유지한다 — 답은 같지만 왜 그렇게 됐는지가 남는다.

## 검증

```
20 tests run. Test Successful.        # test_keeper_playground_checkout_discovery
dune build @check                      # FINAL_EXIT=0
bash scripts/audit-ci-test-targets.sh  # OK, 201 CI targets
```

**테스트가 구현 결함 2건을 잡았다.**

1. `Fs_compat.exact_path_kind` 는 권한 오류를 예외로 던진다(`Unix_error(EACCES, "lstat")`). 새 코드가 `Sys_error` 만 잡았는데, **삭제한 `observed_is_dir` 는 그 두 예외를 다 잡고 있었다.**
2. 읽기 실패로 탐색을 중단하면 BFS 순서상 뒤쪽 체크아웃을 전부 잃는다.

**CI 배선 2곳** (`audit-ci-test-targets.sh` 가 `ci.yml` 과 `ci-run-focused-tests.sh` 양쪽 참조를 중복으로 FAIL 시키므로 한 곳만):

- `test/dune` (names + modules)
- `scripts/ci-run-focused-tests.sh` 의 `normal_targets`

배선 결과 unwired 가 660 → 659 로 줄어 `UNWIRED_BASELINE` 도 함께 낮췄다.

**기존 테스트 1건의 픽스처를 고쳤다** (`test_keeper_visible_path_projection.ml:397`): `repos/masc/README.md` 만 만들고 `.git` 이 없어 이제 체크아웃으로 발견되지 않는다. 픽스처가 바뀌는 것 자체가 의미 좁힘의 기록이다 — "`repos/` 밑 아무 디렉터리"에서 "root 밑 git 체크아웃"으로.

## 이 PR 이 하지 않는 것

- **귀속(attribution) 전환.** `parse_playground_repo_path` 는 그대로다. RFC §5 의 PR2a/PR2b.
- **모델 대면 산문 제거.** 툴 스키마의 `repos/X` 예시는 그대로다 (PR3). 시스템이 먼저 전부 인식하게 만든 뒤 산문을 지우는 순서다 — 반대로 하면 keeper 는 딴 데 clone 하는데 시스템은 `repos/` 만 본다.
- **`execution_location_scope` 재정의.** `Repo_root`/`Repo_subpath` 는 아직 문자열 매칭이다. 이 함수는 Execute 응답마다 호출되므로 목록 스캔이 아니라 cwd 에서 위로 올라가며 `.git` 을 찾는 O(depth) 구현이 필요하고, 그건 별도 PR 로 뺀다. 소비자가 0 이라 동작에는 영향이 없다.
- **`sandbox_repos` wire 필드.** 여전히 `"repos"` 를 낸다 (PR3/PR4).

RFC: `docs/rfc/RFC-keeper-workspace-root-only.md` (#28459 에서 머지)

WORKAROUND-WAIVED: 이 PR 은 문자열 분류기를 추가하지 않고 **제거한다.** `repos/` 경로 문자열 매칭 3곳(`keeper_sandbox_control.ml:290`, `keeper_turn_sandbox_runtime.ml:158`, `keeper_tool_filesystem_runtime.ml:206`)과 mkdir 2곳을 git 실측 발견으로 교체하며, 새로 추가되는 판정은 문자열이 아니라 `.git` 항목의 파일 종류다. 게이트가 매칭한 문장은 "`execution_location_scope` 가 **아직** 문자열로 분류한다 — 후속 PR" 이라는 범위 서술이고, 그 교체 방향(문자열 매칭 → `git rev-parse` 실측)은 RFC-keeper-workspace-root-only §3.6 에 명시돼 있다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3Ek71sn9DrrT4japMSNQs
