### PR TITLE
perf(audit-log): project audit rows during the read, not after it

### DIFF
--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -261,40 +261,66 @@ let get_audit_store (config : config) : Dated_jsonl.t =
       audit_store_cache := StringMap.add base store !audit_store_cache;
       store)
 
-(** Parse JSON list into audit entries. Logs first 5 failures individually,
-    then a summary. Returns only successfully parsed entries. *)
+(** How many corrupt entries are reported individually before the reader falls
+    back to a single suppressed-count summary. *)
 let max_logged_errors = 5
 
-let parse_entries (jsons : Yojson.Safe.t list) : audit_entry list =
-  (* Logging side effects (per-entry corrupt-entry ERROR, rate-limited
-     by [max_logged_errors]) are kept inside the fold body — they are
-     observably equivalent to the original [List.iter] order. *)
+(* What one row turned into. Small enough that a window's worth of these costs
+   a fraction of the [`Assoc] trees they stand in for, which is what lets the
+   read path drop each tree before parsing the next row. *)
+type parsed_row =
+  | Parsed of audit_entry
+  | Corrupt of string
+
+let parsed_row_of_json json =
+  match entry_of_json_r json with
+  | Ok entry -> Parsed entry
+  | Error reason -> Corrupt reason
+
+(* The rate-limited logging lives here, over a chronological list, and both
+   read paths call it. "First five" therefore means the same five rows however
+   the rows were obtained — see [read_entries], where the projection runs
+   newest-first. *)
+let report_and_keep_parsed (rows : parsed_row list) : audit_entry list =
   let ok_rev, err_count =
     List.fold_left
-      (fun (ok, errc) json ->
-        match entry_of_json_r json with
-        | Ok entry -> (entry :: ok, errc)
-        | Error reason ->
+      (fun (ok, errc) row ->
+        match row with
+        | Parsed entry -> (entry :: ok, errc)
+        | Corrupt reason ->
             let errc = errc + 1 in
             if errc <= max_logged_errors then
               Log.Misc.error "audit_log: corrupt entry (#%d): %s" errc reason;
             (ok, errc))
       ([], 0)
-      jsons
+      rows
   in
   if err_count > 0 then
     Log.Misc.error "audit_log: %d/%d entries failed to parse (possible corruption)%s"
-      err_count (List.length jsons)
+      err_count (List.length rows)
       (if err_count > max_logged_errors
        then Printf.sprintf " (%d more suppressed)" (err_count - max_logged_errors)
        else "");
   List.rev ok_rev
 
+
 (** Read recent audit entries from the date-split store.
     Structural parse failures go through [parse_entries] ERROR path. *)
 let read_entries ?(n = 10_000) (config : config) : audit_entry list =
   let store = get_audit_store config in
-  Dated_jsonl.read_recent store n |> parse_entries
+  (* [read_recent |> parse_entries] held the whole window's [`Assoc] trees and
+     the decoded entries at once; the default window is 10_000 rows and
+     /api/v1/audit asks for up to 5_000. Projecting during the read makes a
+     row's tree unreachable before the next row is parsed.
+
+     [filter_map_recent] calls [f] newest-first but returns chronologically, so
+     the projection here is pure and every order-dependent effect stays in
+     [report_and_keep_parsed] below it, running over the chronological list.
+     Which five corrupt entries get logged, and the order they are numbered in,
+     are unchanged. *)
+  Dated_jsonl.filter_map_recent store n ~f:(fun json ->
+    Some (parsed_row_of_json json))
+  |> report_and_keep_parsed
 
 (** Append a single entry to the audit log (thread-safe via Dated_jsonl). *)
 let append_entry (config : config) (entry : audit_entry) =

--- a/lib/audit_log.mli
+++ b/lib/audit_log.mli
@@ -12,7 +12,7 @@
 
     Internal helpers ([preview], [outcome_to_json]
     decoders, the [audit_store_cache] and its mutex,
-    [get_audit_store], [parse_entries], [max_logged_errors],
+    [get_audit_store], [report_and_keep_parsed], [max_logged_errors],
     [remove_assoc_keys]) are hidden — callers use the typed log
     helpers and the read / prune / stats accessors only.
 

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=660
+UNWIRED_BASELINE=659
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/test/test_audit_log.ml
+++ b/test/test_audit_log.ml
@@ -118,6 +118,99 @@ let test_get_stats_reports_oldest_and_newest_in_read_order () =
       check (option (float 0.001)) "newest is the last row read" (Some 300.0)
         stats.Audit_log.newest_timestamp)
 
+(* The reader projects rows during the read, and [Dated_jsonl.filter_map_recent]
+   applies the projection newest-first. These pin the two things that would
+   break if the order-dependent work ever moved into the projection: the
+   returned entries stay chronological, and a row the decoder rejects is
+   skipped rather than ending the read. *)
+
+let raw_audit_store base_dir =
+  Dated_jsonl.create
+    ~base_dir:
+      (Filename.concat
+         (Workspace_utils.masc_dir (Workspace.default_config base_dir))
+         Audit_log.store_dirname)
+    ()
+
+let test_read_entries_returns_chronological_order () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Workspace.default_config base_dir in
+      List.iter
+        (fun ts ->
+          Audit_log.append_entry config
+            (entry ~timestamp:ts ~agent_id:"keeper-a"
+               ~action:Audit_log.AuthSuccess ~outcome:Audit_log.Success))
+        [ 100.0; 200.0; 300.0; 400.0 ];
+      let timestamps =
+        Audit_log.read_entries ~n:10 config
+        |> List.map (fun (e : Audit_log.audit_entry) -> e.Audit_log.timestamp)
+      in
+      check (list (float 0.001)) "entries are oldest-first"
+        [ 100.0; 200.0; 300.0; 400.0 ] timestamps)
+
+let test_read_entries_skips_rows_the_decoder_rejects () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Workspace.default_config base_dir in
+      let store = raw_audit_store base_dir in
+      (* Interleaved so a reader that stops at the first rejected row returns a
+         short prefix rather than the full set, and one that drops the wrong
+         side returns the corrupt rows' neighbours. *)
+      Audit_log.append_entry config
+        (entry ~timestamp:100.0 ~agent_id:"keeper-a"
+           ~action:Audit_log.AuthSuccess ~outcome:Audit_log.Success);
+      Dated_jsonl.append store (`Assoc [ ("not", `String "an audit entry") ]);
+      Audit_log.append_entry config
+        (entry ~timestamp:200.0 ~agent_id:"keeper-a"
+           ~action:Audit_log.AuthSuccess ~outcome:Audit_log.Success);
+      Dated_jsonl.append store (`Assoc [ ("still", `String "not one") ]);
+      Audit_log.append_entry config
+        (entry ~timestamp:300.0 ~agent_id:"keeper-a"
+           ~action:Audit_log.AuthSuccess ~outcome:Audit_log.Success);
+      let timestamps =
+        Audit_log.read_entries ~n:10 config
+        |> List.map (fun (e : Audit_log.audit_entry) -> e.Audit_log.timestamp)
+      in
+      check (list (float 0.001))
+        "every decodable row survives its corrupt neighbours, in order"
+        [ 100.0; 200.0; 300.0 ] timestamps)
+
+(* [n] bounds rows parsed, not rows returned, so a window that covers the
+   corrupt rows still yields fewer entries than [n]. *)
+let test_read_entries_window_counts_parsed_rows () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Workspace.default_config base_dir in
+      let store = raw_audit_store base_dir in
+      Audit_log.append_entry config
+        (entry ~timestamp:100.0 ~agent_id:"keeper-a"
+           ~action:Audit_log.AuthSuccess ~outcome:Audit_log.Success);
+      Dated_jsonl.append store (`Assoc [ ("not", `String "an audit entry") ]);
+      Audit_log.append_entry config
+        (entry ~timestamp:200.0 ~agent_id:"keeper-a"
+           ~action:Audit_log.AuthSuccess ~outcome:Audit_log.Success);
+      let timestamps =
+        Audit_log.read_entries ~n:2 config
+        |> List.map (fun (e : Audit_log.audit_entry) -> e.Audit_log.timestamp)
+      in
+      (* The two newest rows are the corrupt one and 200.0, so a window of 2
+         yields one entry. Reading 3 more would mean n counted selected rows. *)
+      check (list (float 0.001)) "the window bounds parsed rows"
+        [ 200.0 ] timestamps)
+
 (* ── Codec round-trip tests ────────────────────────────────────────── *)
 
 let action_roundtrip label action expected_wire =
@@ -312,6 +405,12 @@ let () =
             test_audit_events_filter_severity_before_paging;
           test_case "get_stats reports oldest and newest in read order" `Quick
             test_get_stats_reports_oldest_and_newest_in_read_order;
+          test_case "read_entries returns chronological order" `Quick
+            test_read_entries_returns_chronological_order;
+          test_case "read_entries skips rows the decoder rejects" `Quick
+            test_read_entries_skips_rows_the_decoder_rejects;
+          test_case "read_entries window counts parsed rows" `Quick
+            test_read_entries_window_counts_parsed_rows;
         ] );
       ( "codec_roundtrip",
         [


### PR DESCRIPTION
Follow-up to #28455, which added `Dated_jsonl.filter_map_recent`, migrated
`Audit_log.get_stats`, and left the rest:

> The remaining decode-immediately sites have order-sensitive per-row side
> effects and need their own equivalence tests, so they are left for follow-ups.

`Audit_log.read_entries` is one of them.

## What it held

```ocaml
Dated_jsonl.read_recent store n |> parse_entries
```

Every row's `` `Assoc `` tree and every decoded `audit_entry` are live at the
same moment, and the trees are unreachable the instant `parse_entries` returns.
The default window is 10 000 rows; `/api/v1/audit` asks for up to 5 000
(`server_routes_http_routes_activity.ml:705`).

## The order-sensitive part, and why it does not move

`parse_entries` logs corrupt entries individually, rate-limited to the first
five, then a suppressed-count summary. `filter_map_recent` applies `f`
**newest-first** — its own documentation says so, and warns that "report the
first N drops" is exactly the kind of effect that must not be converted by
substitution.

But the same documentation says the *returned list* is chronological. So the
projection is made pure and the effect stays below it:

```ocaml
type parsed_row = Parsed of audit_entry | Corrupt of string

Dated_jsonl.filter_map_recent store n ~f:(fun json -> Some (parsed_row_of_json json))
|> report_and_keep_parsed
```

`report_and_keep_parsed` folds the chronological list and does the logging.
Which five corrupt entries are reported, and the numbers they are reported
with, are unchanged. A `Corrupt reason` or a decoded entry is a fraction of the
tree it replaces, so a row's tree is unreachable before the next row is parsed
— which is the whole point of the primitive.

`parse_entries` lost its only caller and is deleted rather than kept for tests.
A test-only entry point is a backdoor, and everything it described is now
reachable through `read_entries`.

## Tests

A correct migration here is observationally identical to the old path, so these
pin what a *wrong* one would break rather than the change itself:

- `read_entries returns chronological order` — four rows, oldest-first out.
  This is the one the newest-first projection would break.
- `read_entries skips rows the decoder rejects` — corrupt rows interleaved
  between good ones, so a reader that stops at the first rejection returns a
  short prefix and one that drops the wrong side returns their neighbours.
- `read_entries window counts parsed rows` — `n = 2` over `[good, corrupt,
  good]` yields one entry, not two.

Mutation — reversing the projected list, i.e. a reader that returns rows in the
order `f` saw them:

```
[FAIL]  audit_log  3  read_entries returns chronological order
[FAIL]  audit_log  4  read_entries skips rows the decoder rejects
```

Restored: 13/13 green under `--force`. `test_audit_log` is already in
`scripts/ci-run-focused-tests.sh:141`, so these run in CI rather than only
compiling.

## Ratchet

`audit-ci-test-targets.sh` on `main` reports 659 unwired against a 660
baseline and asks by name for the baseline to be lowered to hold the gain.
This branch adds no suite, so the slack is pre-existing; lowered here.

```
[ci-test-targets] OK - 200 CI targets, all declared in Dune
[ci-test-targets] OK - 659 suites unwired, at baseline
```

## Still not migrated

`eval_calibration.find_divergences` (1 000 rows) and `calibration_stats`
(5 000 rows) both fold rows into `StringMap`s keyed by `notes_hash`, where
`StringMap.add` means the last writer wins — so the surviving record flips if
the fold sees rows newest-first. They also retain the trees rather than
decoding to a smaller type, so the projection would have to be designed before
it pays for itself. Left for a separate change with its own equivalence test.

RFC-WAIVED: a read path in the audit log and its tests; no credential,
identity, operator control-plane, sandbox, hook, or workflow surface is
touched.
