### PR TITLE
fix(repo_manager): bound get_origin_url like every other inspection read

### DIFF
--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -453,9 +453,6 @@ let repository_checkouts_json_with_budget
     ~(config : Workspace.config)
     ~(meta : keeper_meta)
   =
-  let inspection_budget =
-    Repo_git.Inspection_budget.create ~timeout_sec:inspection_budget_sec ()
-  in
   let sandbox_abs =
     Keeper_sandbox.host_root_abs_of_meta ~config meta
     |> normalize_path
@@ -463,6 +460,13 @@ let repository_checkouts_json_with_budget
   let observed_at_unix = Time_compat.now () in
   let catalog = Repo_store.load_all ~base_path:config.base_path in
   let scan = Keeper_playground_checkouts.discover ~root:sandbox_abs in
+  (* The budget bounds the per-checkout Git inspections below, so it starts
+     after [load_all] and [discover]. Opening it first let a large catalog or a
+     slow filesystem walk exhaust it before any Git subprocess ran, and every
+     checkout then reported branch/head/status as unavailable. *)
+  let inspection_budget =
+    Repo_git.Inspection_budget.create ~timeout_sec:inspection_budget_sec ()
+  in
   let entries =
     match scan with
     | Ok discovery ->

--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -395,13 +395,13 @@ let checkout_json ~budget ~catalog (checkout : Keeper_playground_checkouts.check
   let name = checkout.name in
   let origin =
     with_inspection_budget budget (fun timeout_sec ->
-      Repo_git.get_origin_url ~timeout_sec ~local_path:checkout_abs ())
+      Repo_git.get_origin_url ~timeout_sec ~local_path:checkout_abs ()
+      |> Result.map_error Repo_git.origin_lookup_error_to_string)
   in
   let catalog_resolution =
     match origin with
     | Ok origin -> resolve_catalog ~catalog ~origin
-    | Error error ->
-      Origin_unavailable (Repo_git.origin_lookup_error_to_string error)
+    | Error error -> Origin_unavailable error
   in
   let repository : Repo_manager_types.repository =
     match catalog_resolution with

--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -319,7 +319,7 @@ let first_git_line ~budget ~cwd args =
 let dirty_state ~budget ~repository =
   match
     with_inspection_budget budget (fun timeout_sec ->
-      Repo_git.status_summary ~timeout_sec ~repository)
+      Repo_git.status_summary ~timeout_sec ~repository ())
   with
   | Ok summary -> Ok (summary.Repo_git.changed_files > 0, summary.changed_files)
   | Error _ as error -> error
@@ -337,7 +337,7 @@ let freshness_of_catalog ~budget ~repository = function
      | Ok upstream_head ->
        (match
           with_inspection_budget budget (fun timeout_sec ->
-            Repo_git.ahead_behind ~timeout_sec ~repository ~target_ref)
+            Repo_git.ahead_behind ~timeout_sec ~repository ~target_ref ())
         with
         | Error error -> Freshness_unavailable error
         | Ok (0, 0) -> Current { target_ref; upstream_head }
@@ -395,7 +395,7 @@ let checkout_json ~budget ~catalog (checkout : Keeper_playground_checkouts.check
   let name = checkout.name in
   let origin =
     with_inspection_budget budget (fun timeout_sec ->
-      Repo_git.get_origin_url ~timeout_sec ~local_path:checkout_abs)
+      Repo_git.get_origin_url ~timeout_sec ~local_path:checkout_abs ())
   in
   let catalog_resolution =
     match origin with
@@ -412,7 +412,7 @@ let checkout_json ~budget ~catalog (checkout : Keeper_playground_checkouts.check
   in
   let branch =
     with_inspection_budget budget (fun timeout_sec ->
-      Repo_git.current_branch ~timeout_sec ~repository)
+      Repo_git.current_branch ~timeout_sec ~repository ())
   in
   let head = first_git_line ~budget ~cwd:checkout_abs [ "rev-parse"; "HEAD" ] in
   let dirty = dirty_state ~budget ~repository in

--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -301,24 +301,44 @@ let resolve_catalog ~catalog ~origin =
        | [] -> Unregistered
        | repos -> Ambiguous (List.map (fun repo -> repo.Repo_manager_types.id) repos))
 
-let first_git_line ~cwd args =
-  match Repo_git.run_git ~cwd args with
+let with_inspection_budget budget inspect =
+  match Repo_git.Inspection_budget.remaining_timeout budget with
+  | Error _ as error -> error
+  | Ok timeout_sec -> inspect timeout_sec
+;;
+
+let first_git_line ~budget ~cwd args =
+  match
+    with_inspection_budget budget (fun timeout_sec ->
+      Repo_git.run_git ~cwd ~timeout_sec args)
+  with
   | Ok (line :: _) -> Ok line
   | Ok [] -> Error (Printf.sprintf "git %s returned no output" (String.concat " " args))
   | Error _ as error -> error
 
-let dirty_state ~repository =
-  match Repo_git.status_summary ~repository with
+let dirty_state ~budget ~repository =
+  match
+    with_inspection_budget budget (fun timeout_sec ->
+      Repo_git.status_summary ~timeout_sec ~repository)
+  with
   | Ok summary -> Ok (summary.Repo_git.changed_files > 0, summary.changed_files)
   | Error _ as error -> error
 
-let freshness_of_catalog ~repository = function
+let freshness_of_catalog ~budget ~repository = function
   | Registered catalog_repo ->
     let target_ref = "origin/" ^ catalog_repo.default_branch in
-    (match first_git_line ~cwd:repository.Repo_manager_types.local_path [ "rev-parse"; target_ref ] with
+    (match
+       first_git_line
+         ~budget
+         ~cwd:repository.Repo_manager_types.local_path
+         [ "rev-parse"; target_ref ]
+     with
      | Error error -> Freshness_unavailable error
      | Ok upstream_head ->
-       (match Repo_git.ahead_behind ~repository ~target_ref with
+       (match
+          with_inspection_budget budget (fun timeout_sec ->
+            Repo_git.ahead_behind ~timeout_sec ~repository ~target_ref)
+        with
         | Error error -> Freshness_unavailable error
         | Ok (0, 0) -> Current { target_ref; upstream_head }
         | Ok (0, ahead) -> Ahead { target_ref; upstream_head; ahead }
@@ -366,14 +386,17 @@ let freshness_json = function
   | Freshness_unavailable error ->
     `Assoc [ "state", `String "unavailable"; "error", `String error ]
 
-let checkout_json ~catalog (checkout : Keeper_playground_checkouts.checkout) =
+let checkout_json ~budget ~catalog (checkout : Keeper_playground_checkouts.checkout) =
   (* The checkout's own path, as discovered. Previously this reassembled
      [sandbox_abs/repos/<name>], which meant any checkout found outside that
      one shape was inspected at a path that does not exist — every git call
      below would fail and the entry would render as "unavailable". *)
   let checkout_abs = checkout.absolute_path in
   let name = checkout.name in
-  let origin = Repo_git.get_origin_url ~local_path:checkout_abs in
+  let origin =
+    with_inspection_budget budget (fun timeout_sec ->
+      Repo_git.get_origin_url ~timeout_sec ~local_path:checkout_abs)
+  in
   let catalog_resolution =
     match origin with
     | Ok origin -> resolve_catalog ~catalog ~origin
@@ -387,9 +410,12 @@ let checkout_json ~catalog (checkout : Keeper_playground_checkouts.checkout) =
       ; default_branch = ""; keepers = []; status = Active; auto_sync = false
       ; sync_interval = 0; created_at = 0L; updated_at = 0L }
   in
-  let branch = Repo_git.current_branch ~repository in
-  let head = first_git_line ~cwd:checkout_abs [ "rev-parse"; "HEAD" ] in
-  let dirty = dirty_state ~repository in
+  let branch =
+    with_inspection_budget budget (fun timeout_sec ->
+      Repo_git.current_branch ~timeout_sec ~repository)
+  in
+  let head = first_git_line ~budget ~cwd:checkout_abs [ "rev-parse"; "HEAD" ] in
+  let dirty = dirty_state ~budget ~repository in
   let inspection_errors =
     [ (match branch with Error error -> Some ("branch: " ^ error) | Ok _ -> None)
     ; (match head with Error error -> Some ("head: " ^ error) | Ok _ -> None)
@@ -417,10 +443,19 @@ let checkout_json ~catalog (checkout : Keeper_playground_checkouts.checkout) =
     ; "changed_files", (match dirty with Ok (_, value) -> `Int value | Error _ -> `Null)
     ; "inspection_state", `String (if inspection_errors = [] then "available" else "unavailable")
     ; "inspection_errors", `List (List.map (fun error -> `String error) inspection_errors)
-    ; "freshness", freshness_json (freshness_of_catalog ~repository catalog_resolution)
+    ; ( "freshness"
+      , freshness_json
+          (freshness_of_catalog ~budget ~repository catalog_resolution) )
     ]
 
-let repository_checkouts_json ~(config : Workspace.config) ~(meta : keeper_meta) =
+let repository_checkouts_json_with_budget
+    ~inspection_budget_sec
+    ~(config : Workspace.config)
+    ~(meta : keeper_meta)
+  =
+  let inspection_budget =
+    Repo_git.Inspection_budget.create ~timeout_sec:inspection_budget_sec ()
+  in
   let sandbox_abs =
     Keeper_sandbox.host_root_abs_of_meta ~config meta
     |> normalize_path
@@ -432,13 +467,15 @@ let repository_checkouts_json ~(config : Workspace.config) ~(meta : keeper_meta)
     match scan with
     | Ok discovery ->
       Keeper_playground_checkouts.found discovery
-      |> List.map (checkout_json ~catalog)
+      |> List.map (checkout_json ~budget:inspection_budget ~catalog)
     | Error _ -> []
   in
   `Assoc
     [ ( "state"
       , `String
           (match catalog, scan with
+           | Ok _, Ok _ when Repo_git.Inspection_budget.is_exhausted inspection_budget ->
+             "inspection_budget_exhausted"
            | Ok _, Ok _ -> "available"
            | Error _, _ -> "catalog_unavailable"
            (* A failed scan and an empty playground used to be the same empty
@@ -451,6 +488,17 @@ let repository_checkouts_json ~(config : Workspace.config) ~(meta : keeper_meta)
     ; "entries", `List entries
     ; "error", (match catalog with Ok _ -> `Null | Error error -> `String error)
     ]
+
+let repository_checkouts_json ~config ~meta =
+  repository_checkouts_json_with_budget
+    ~inspection_budget_sec:Repo_git.inspection_timeout_sec
+    ~config
+    ~meta
+;;
+
+module For_testing = struct
+  let repository_checkouts_json_with_budget = repository_checkouts_json_with_budget
+end
 
 let preflight_status_json ~timeout_sec =
   Keeper_sandbox_runtime.docker_preflight ~timeout_sec ()

--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -400,7 +400,8 @@ let checkout_json ~budget ~catalog (checkout : Keeper_playground_checkouts.check
   let catalog_resolution =
     match origin with
     | Ok origin -> resolve_catalog ~catalog ~origin
-    | Error error -> Origin_unavailable error
+    | Error error ->
+      Origin_unavailable (Repo_git.origin_lookup_error_to_string error)
   in
   let repository : Repo_manager_types.repository =
     match catalog_resolution with
@@ -448,7 +449,8 @@ let checkout_json ~budget ~catalog (checkout : Keeper_playground_checkouts.check
           (freshness_of_catalog ~budget ~repository catalog_resolution) )
     ]
 
-let repository_checkouts_json_with_budget
+let repository_checkouts_json_with_budget_impl
+    ~before_git_inspection
     ~inspection_budget_sec
     ~(config : Workspace.config)
     ~(meta : keeper_meta)
@@ -460,6 +462,7 @@ let repository_checkouts_json_with_budget
   let observed_at_unix = Time_compat.now () in
   let catalog = Repo_store.load_all ~base_path:config.base_path in
   let scan = Keeper_playground_checkouts.discover ~root:sandbox_abs in
+  before_git_inspection ();
   (* The budget bounds the per-checkout Git inspections below, so it starts
      after [load_all] and [discover]. Opening it first let a large catalog or a
      slow filesystem walk exhaust it before any Git subprocess ran, and every
@@ -493,6 +496,14 @@ let repository_checkouts_json_with_budget
     ; "error", (match catalog with Ok _ -> `Null | Error error -> `String error)
     ]
 
+let repository_checkouts_json_with_budget ~inspection_budget_sec ~config ~meta =
+  repository_checkouts_json_with_budget_impl
+    ~before_git_inspection:(fun () -> ())
+    ~inspection_budget_sec
+    ~config
+    ~meta
+;;
+
 let repository_checkouts_json ~config ~meta =
   repository_checkouts_json_with_budget
     ~inspection_budget_sec:Repo_git.inspection_timeout_sec
@@ -502,6 +513,19 @@ let repository_checkouts_json ~config ~meta =
 
 module For_testing = struct
   let repository_checkouts_json_with_budget = repository_checkouts_json_with_budget
+
+  let repository_checkouts_json_with_budget_after_discovery
+      ~before_git_inspection
+      ~inspection_budget_sec
+      ~config
+      ~meta
+    =
+    repository_checkouts_json_with_budget_impl
+      ~before_git_inspection
+      ~inspection_budget_sec
+      ~config
+      ~meta
+  ;;
 end
 
 let preflight_status_json ~timeout_sec =

--- a/lib/keeper/keeper_sandbox_control.mli
+++ b/lib/keeper/keeper_sandbox_control.mli
@@ -56,6 +56,14 @@ val repository_checkouts_json :
     checkout directory; freshness is measured against the local tracking ref.
     Missing or ambiguous evidence is returned as an explicit typed state. *)
 
+module For_testing : sig
+  val repository_checkouts_json_with_budget :
+    inspection_budget_sec:float ->
+    config:Workspace.config ->
+    meta:keeper_meta ->
+    Yojson.Safe.t
+end
+
 val live_status_json :
   ?include_preflight:bool ->
   ?preflight_override:Yojson.Safe.t option ->

--- a/lib/keeper/keeper_sandbox_control.mli
+++ b/lib/keeper/keeper_sandbox_control.mli
@@ -62,6 +62,13 @@ module For_testing : sig
     config:Workspace.config ->
     meta:keeper_meta ->
     Yojson.Safe.t
+
+  val repository_checkouts_json_with_budget_after_discovery :
+    before_git_inspection:(unit -> unit) ->
+    inspection_budget_sec:float ->
+    config:Workspace.config ->
+    meta:keeper_meta ->
+    Yojson.Safe.t
 end
 
 val live_status_json :

--- a/lib/repo_manager/dune
+++ b/lib/repo_manager/dune
@@ -22,6 +22,8 @@
   masc.masc_exec
   masc.masc_log
   masc.masc_process
+  mtime
+  mtime.clock.os
   yojson
   otoml
   unix)

--- a/lib/repo_manager/repo_git.ml
+++ b/lib/repo_manager/repo_git.ml
@@ -190,8 +190,23 @@ let get_branches ~repository =
   | Ok lines -> Ok lines
   | Error msg -> Error msg
 
+(* Bounded and read-only, matching [worktree_root] below. Reading a remote URL
+   is a config lookup, but [run_git] defaults to no timeout, so a git index
+   lock held by another process — or a stalled filesystem — would block the
+   caller indefinitely. Both callers sit on request paths: repository checkout
+   inspection renders a dashboard response, and write attribution is about to
+   move onto the tool post-hook (RFC-keeper-workspace-root-only §5.1).
+
+   [read_only_git_env] adds GIT_OPTIONAL_LOCKS=0 so an inspection never takes
+   a lock that a keeper's own git command then waits on. *)
 let get_origin_url ~local_path =
-  match run_git ~cwd:local_path [ "remote"; "get-url"; "origin" ] with
+  match
+    run_git
+      ~cwd:local_path
+      ~env:read_only_git_env
+      ~timeout_sec:status_summary_timeout_sec
+      [ "remote"; "get-url"; "origin" ]
+  with
   | Ok (url :: _) -> Ok url
   | Ok [] -> Error "git remote get-url origin returned no output"
   | Error msg -> Error msg

--- a/lib/repo_manager/repo_git.ml
+++ b/lib/repo_manager/repo_git.ml
@@ -33,6 +33,17 @@ let read_only_git_env = ("GIT_OPTIONAL_LOCKS", "0") :: non_interactive_git_env
 
 let inspection_timeout_sec = 5.0
 
+type origin_lookup_error =
+  | Origin_missing
+  | Origin_lookup_timed_out of string
+  | Origin_lookup_failed of string
+
+let origin_lookup_error_to_string = function
+  | Origin_missing -> "origin remote is not configured"
+  | Origin_lookup_timed_out detail -> detail
+  | Origin_lookup_failed detail -> detail
+;;
+
 module Inspection_budget = struct
   type t =
     { started_at : Mtime.t
@@ -65,6 +76,23 @@ end
 let split_lines text =
   if text = "" then []
   else String.split_on_char '\n' text |> List.filter (fun line -> line <> "")
+
+let git_failure_detail args status stdout stderr =
+  let status_text =
+    match status with
+    | Unix.WEXITED code -> Printf.sprintf "exit %d" code
+    | Unix.WSIGNALED signal -> Printf.sprintf "signal %d" signal
+    | Unix.WSTOPPED signal -> Printf.sprintf "stopped %d" signal
+  in
+  let detail =
+    let stderr = String.trim stderr in
+    let stdout = String.trim stdout in
+    if stderr <> "" then status_text ^ ": " ^ stderr
+    else if stdout <> "" then status_text ^ ": " ^ stdout
+    else status_text
+  in
+  Printf.sprintf "git %s failed: %s" (String.concat " " args) detail
+;;
 
 type status_summary = {
   changed_files : int;
@@ -158,20 +186,7 @@ let run_git ~cwd ?(env = []) ?timeout_sec args : (string list, string) result =
   match status with
   | Unix.WEXITED 0 -> Ok (split_lines stdout)
   | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ ->
-      let status_text =
-        match status with
-        | Unix.WEXITED code -> Printf.sprintf "exit %d" code
-        | Unix.WSIGNALED signal -> Printf.sprintf "signal %d" signal
-        | Unix.WSTOPPED signal -> Printf.sprintf "stopped %d" signal
-      in
-      let detail =
-        let stderr = String.trim stderr in
-        let stdout = String.trim stdout in
-        if stderr <> "" then status_text ^ ": " ^ stderr
-        else if stdout <> "" then status_text ^ ": " ^ stdout
-        else status_text
-      in
-      Error (Printf.sprintf "git %s failed: %s" (String.concat " " args) detail)
+    Error (git_failure_detail args status stdout stderr)
 
 let clone ~repository =
   let env = non_interactive_git_env in
@@ -229,16 +244,25 @@ let get_branches ~repository =
    [read_only_git_env] adds GIT_OPTIONAL_LOCKS=0 so an inspection never takes
    a lock that a keeper's own git command then waits on. *)
 let get_origin_url ?(timeout_sec = inspection_timeout_sec) ~local_path () =
-  match
-    run_git
-      ~cwd:local_path
-      ~env:read_only_git_env
+  let args = [ "remote"; "get-url"; "origin" ] in
+  let argv = "git" :: "-C" :: local_path :: args in
+  let status, stdout, stderr =
+    Process_eio.run_argv_with_status_split
+      ~env:(merge_env read_only_git_env)
       ~timeout_sec
-      [ "remote"; "get-url"; "origin" ]
-  with
-  | Ok (url :: _) -> Ok url
-  | Ok [] -> Error "git remote get-url origin returned no output"
-  | Error msg -> Error msg
+      argv
+  in
+  match status, split_lines stdout with
+  | Unix.WEXITED 0, url :: _ -> Ok url
+  | Unix.WEXITED 0, [] ->
+    Error (Origin_lookup_failed "git remote get-url origin returned no output")
+  (* Git gives a missing remote a distinct exit status, so absence stays typed
+     without inspecting mutable stderr text. *)
+  | Unix.WEXITED 2, _ -> Error Origin_missing
+  | Unix.WEXITED 124, _ ->
+    Error (Origin_lookup_timed_out (git_failure_detail args status stdout stderr))
+  | (Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _), _ ->
+    Error (Origin_lookup_failed (git_failure_detail args status stdout stderr))
 
 let worktree_root ~local_path =
   match

--- a/lib/repo_manager/repo_git.ml
+++ b/lib/repo_manager/repo_git.ml
@@ -49,11 +49,14 @@ module Inspection_budget = struct
     Mtime.Span.to_float_ns (Mtime.span budget.started_at (Mtime_clock.now ())) /. 1e9
   ;;
 
-  let remaining_timeout budget =
+  (* [open Repo_manager_types] above brings [repository_status]'s [Error of
+     string] into scope, shadowing the result constructor. This budget answers
+     with a result, so name the type and qualify the constructors. *)
+  let remaining_timeout budget : (float, string) Stdlib.result =
     let remaining = budget.timeout_sec -. elapsed_sec budget in
     if Float.compare remaining 0.0 <= 0
-    then Error "git inspection request budget exhausted"
-    else Ok (min inspection_timeout_sec remaining)
+    then Stdlib.Error "git inspection request budget exhausted"
+    else Stdlib.Ok (min inspection_timeout_sec remaining)
   ;;
 
   let is_exhausted budget = Result.is_error (remaining_timeout budget)
@@ -225,7 +228,7 @@ let get_branches ~repository =
 
    [read_only_git_env] adds GIT_OPTIONAL_LOCKS=0 so an inspection never takes
    a lock that a keeper's own git command then waits on. *)
-let get_origin_url ?(timeout_sec = inspection_timeout_sec) ~local_path =
+let get_origin_url ?(timeout_sec = inspection_timeout_sec) ~local_path () =
   match
     run_git
       ~cwd:local_path
@@ -288,7 +291,7 @@ let origin_head_branch ~local_path =
   | Ok [] -> Stdlib.Error "git symbolic-ref refs/remotes/origin/HEAD returned no output"
   | Error msg -> Stdlib.Error msg
 
-let current_branch ?(timeout_sec = inspection_timeout_sec) ~repository =
+let current_branch ?(timeout_sec = inspection_timeout_sec) ~repository () =
   match
     run_git ~cwd:repository.local_path ~env:read_only_git_env
       ~timeout_sec
@@ -302,6 +305,7 @@ let ahead_behind
     ?(timeout_sec = inspection_timeout_sec)
     ~repository
     ~target_ref
+    ()
     : (int * int, string) result
   =
   match
@@ -338,7 +342,7 @@ let get_recent_commits ~repository ~branch ~limit =
   | Ok lines -> Ok lines
   | Error msg -> Error msg
 
-let status_summary ?(timeout_sec = inspection_timeout_sec) ~repository =
+let status_summary ?(timeout_sec = inspection_timeout_sec) ~repository () =
   match
     run_git ~cwd:repository.local_path ~env:read_only_git_env
       ~timeout_sec

--- a/lib/repo_manager/repo_git.ml
+++ b/lib/repo_manager/repo_git.ml
@@ -31,7 +31,33 @@ let non_interactive_git_env =
 
 let read_only_git_env = ("GIT_OPTIONAL_LOCKS", "0") :: non_interactive_git_env
 
-let status_summary_timeout_sec = 5.0
+let inspection_timeout_sec = 5.0
+
+module Inspection_budget = struct
+  type t =
+    { started_at : Mtime.t
+    ; timeout_sec : float
+    }
+
+  let create ?(timeout_sec = inspection_timeout_sec) () =
+    if not (Float.is_finite timeout_sec && Float.compare timeout_sec 0.0 > 0)
+    then invalid_arg "Repo_git.Inspection_budget.create: timeout_sec must be finite and positive";
+    { started_at = Mtime_clock.now (); timeout_sec }
+  ;;
+
+  let elapsed_sec budget =
+    Mtime.Span.to_float_ns (Mtime.span budget.started_at (Mtime_clock.now ())) /. 1e9
+  ;;
+
+  let remaining_timeout budget =
+    let remaining = budget.timeout_sec -. elapsed_sec budget in
+    if Float.compare remaining 0.0 <= 0
+    then Error "git inspection request budget exhausted"
+    else Ok (min inspection_timeout_sec remaining)
+  ;;
+
+  let is_exhausted budget = Result.is_error (remaining_timeout budget)
+end
 
 let split_lines text =
   if text = "" then []
@@ -199,12 +225,12 @@ let get_branches ~repository =
 
    [read_only_git_env] adds GIT_OPTIONAL_LOCKS=0 so an inspection never takes
    a lock that a keeper's own git command then waits on. *)
-let get_origin_url ~local_path =
+let get_origin_url ?(timeout_sec = inspection_timeout_sec) ~local_path =
   match
     run_git
       ~cwd:local_path
       ~env:read_only_git_env
-      ~timeout_sec:status_summary_timeout_sec
+      ~timeout_sec
       [ "remote"; "get-url"; "origin" ]
   with
   | Ok (url :: _) -> Ok url
@@ -216,7 +242,7 @@ let worktree_root ~local_path =
     run_git
       ~cwd:local_path
       ~env:read_only_git_env
-      ~timeout_sec:status_summary_timeout_sec
+      ~timeout_sec:inspection_timeout_sec
       [ "rev-parse"; "--show-toplevel" ]
   with
   | Ok (root :: _) ->
@@ -255,29 +281,32 @@ let origin_head_branch ~local_path =
     run_git
       ~cwd:local_path
       ~env:read_only_git_env
-      ~timeout_sec:status_summary_timeout_sec
+      ~timeout_sec:inspection_timeout_sec
       [ "symbolic-ref"; "-q"; "refs/remotes/origin/HEAD" ]
   with
   | Ok (refname :: _) -> branch_of_origin_head_ref refname
   | Ok [] -> Stdlib.Error "git symbolic-ref refs/remotes/origin/HEAD returned no output"
   | Error msg -> Stdlib.Error msg
 
-let inspect_timeout_sec = status_summary_timeout_sec
-
-let current_branch ~repository =
+let current_branch ?(timeout_sec = inspection_timeout_sec) ~repository =
   match
     run_git ~cwd:repository.local_path ~env:read_only_git_env
-      ~timeout_sec:inspect_timeout_sec
+      ~timeout_sec
       [ "rev-parse"; "--abbrev-ref"; "HEAD" ]
   with
   | Ok (name :: _) -> Ok name
   | Ok [] -> Error "git rev-parse --abbrev-ref HEAD returned no output"
   | Error msg -> Error msg
 
-let ahead_behind ~repository ~target_ref : (int * int, string) result =
+let ahead_behind
+    ?(timeout_sec = inspection_timeout_sec)
+    ~repository
+    ~target_ref
+    : (int * int, string) result
+  =
   match
     run_git ~cwd:repository.local_path ~env:read_only_git_env
-      ~timeout_sec:inspect_timeout_sec
+      ~timeout_sec
       [ "rev-list"; "--left-right"; "--count"; target_ref ^ "...HEAD" ]
   with
   | Stdlib.Error msg -> Stdlib.Error msg
@@ -309,10 +338,10 @@ let get_recent_commits ~repository ~branch ~limit =
   | Ok lines -> Ok lines
   | Error msg -> Error msg
 
-let status_summary ~repository =
+let status_summary ?(timeout_sec = inspection_timeout_sec) ~repository =
   match
     run_git ~cwd:repository.local_path ~env:read_only_git_env
-      ~timeout_sec:status_summary_timeout_sec
+      ~timeout_sec
       ["--no-optional-locks"; "status"; "--porcelain=v1"; "--untracked-files=normal"]
   with
   | Stdlib.Error msg -> Stdlib.Error msg

--- a/lib/repo_manager/repo_git.mli
+++ b/lib/repo_manager/repo_git.mli
@@ -3,6 +3,13 @@ open Repo_manager_types
 val inspection_timeout_sec : float
 (** Total default budget for one request's repository Git inspection. *)
 
+type origin_lookup_error =
+  | Origin_missing
+  | Origin_lookup_timed_out of string
+  | Origin_lookup_failed of string
+
+val origin_lookup_error_to_string : origin_lookup_error -> string
+
 module Inspection_budget : sig
   type t
 
@@ -55,9 +62,10 @@ val get_branches :
 (** [get_branches ~repository] returns all local and remote branch names. *)
 
 val get_origin_url :
-  ?timeout_sec:float -> local_path:string -> unit -> (string, string) result
+  ?timeout_sec:float -> local_path:string -> unit -> (string, origin_lookup_error) result
 (** [get_origin_url ~local_path] returns the configured [origin] remote URL
-    for the repository at [local_path]. *)
+    for the repository at [local_path]. Missing configuration, a bounded
+    timeout, and other Git failures remain distinct typed outcomes. *)
 
 val worktree_root : local_path:string -> (string, string) result
 (** [worktree_root ~local_path] returns Git's [--show-toplevel] path for

--- a/lib/repo_manager/repo_git.mli
+++ b/lib/repo_manager/repo_git.mli
@@ -54,7 +54,8 @@ val get_branches :
   repository:repository -> (string list, string) result
 (** [get_branches ~repository] returns all local and remote branch names. *)
 
-val get_origin_url : ?timeout_sec:float -> local_path:string -> (string, string) result
+val get_origin_url :
+  ?timeout_sec:float -> local_path:string -> unit -> (string, string) result
 (** [get_origin_url ~local_path] returns the configured [origin] remote URL
     for the repository at [local_path]. *)
 
@@ -70,7 +71,7 @@ val origin_head_branch : local_path:string -> (string, string) result
     surface [Error _] to the operator instead of inventing a default branch. *)
 
 val current_branch :
-  ?timeout_sec:float -> repository:repository -> (string, string) result
+  ?timeout_sec:float -> repository:repository -> unit -> (string, string) result
 (** [current_branch ~repository] returns the short name of the checked-out
     branch via [git rev-parse --abbrev-ref HEAD]. A detached HEAD returns
     ["HEAD"]. Read-only ([GIT_OPTIONAL_LOCKS=0]) with a bounded timeout. *)
@@ -79,6 +80,7 @@ val ahead_behind :
   ?timeout_sec:float ->
   repository:repository ->
   target_ref:string ->
+  unit ->
   (int * int, string) result
 (** [ahead_behind ~repository ~target_ref] returns [(behind, ahead)]:
     [behind] counts commits reachable from [target_ref] but not from HEAD,
@@ -92,7 +94,7 @@ val get_recent_commits :
     [limit] commits on [branch] as ["HASH subject"] lines. *)
 
 val status_summary :
-  ?timeout_sec:float -> repository:repository -> (status_summary, string) result
+  ?timeout_sec:float -> repository:repository -> unit -> (status_summary, string) result
 (** [status_summary ~repository] returns a read-only dirty-tree summary using
     [git --no-optional-locks status --porcelain=v1] with
     [GIT_OPTIONAL_LOCKS=0]. It returns [Error _] instead of inventing a clean

--- a/lib/repo_manager/repo_git.mli
+++ b/lib/repo_manager/repo_git.mli
@@ -1,5 +1,21 @@
 open Repo_manager_types
 
+val inspection_timeout_sec : float
+(** Total default budget for one request's repository Git inspection. *)
+
+module Inspection_budget : sig
+  type t
+
+  val create : ?timeout_sec:float -> unit -> t
+  (** Start one monotonic request budget. *)
+
+  val remaining_timeout : t -> (float, string) result
+  (** Return the positive timeout still available to the next Git subprocess,
+      capped by {!inspection_timeout_sec}. *)
+
+  val is_exhausted : t -> bool
+end
+
 type status_summary = {
   changed_files : int;
   staged_files : int;
@@ -38,7 +54,7 @@ val get_branches :
   repository:repository -> (string list, string) result
 (** [get_branches ~repository] returns all local and remote branch names. *)
 
-val get_origin_url : local_path:string -> (string, string) result
+val get_origin_url : ?timeout_sec:float -> local_path:string -> (string, string) result
 (** [get_origin_url ~local_path] returns the configured [origin] remote URL
     for the repository at [local_path]. *)
 
@@ -53,13 +69,17 @@ val origin_head_branch : local_path:string -> (string, string) result
     callers that need an auditable repository-registration candidate should
     surface [Error _] to the operator instead of inventing a default branch. *)
 
-val current_branch : repository:repository -> (string, string) result
+val current_branch :
+  ?timeout_sec:float -> repository:repository -> (string, string) result
 (** [current_branch ~repository] returns the short name of the checked-out
     branch via [git rev-parse --abbrev-ref HEAD]. A detached HEAD returns
     ["HEAD"]. Read-only ([GIT_OPTIONAL_LOCKS=0]) with a bounded timeout. *)
 
 val ahead_behind :
-  repository:repository -> target_ref:string -> (int * int, string) result
+  ?timeout_sec:float ->
+  repository:repository ->
+  target_ref:string ->
+  (int * int, string) result
 (** [ahead_behind ~repository ~target_ref] returns [(behind, ahead)]:
     [behind] counts commits reachable from [target_ref] but not from HEAD,
     [ahead] the reverse, via
@@ -71,7 +91,8 @@ val get_recent_commits :
 (** [get_recent_commits ~repository ~branch ~limit] returns the most recent
     [limit] commits on [branch] as ["HASH subject"] lines. *)
 
-val status_summary : repository:repository -> (status_summary, string) result
+val status_summary :
+  ?timeout_sec:float -> repository:repository -> (status_summary, string) result
 (** [status_summary ~repository] returns a read-only dirty-tree summary using
     [git --no-optional-locks status --porcelain=v1] with
     [GIT_OPTIONAL_LOCKS=0]. It returns [Error _] instead of inventing a clean

--- a/lib/repo_manager/repo_store.ml
+++ b/lib/repo_manager/repo_store.ml
@@ -411,7 +411,14 @@ let canonical_path raw =
   try Unix.realpath raw
   with Unix.Unix_error _ | Sys_error _ -> normalize_path raw
 
-let discover_repositories ~base_path =
+let discovery_skip_log_line ~abs_repo_dir ~detail =
+  Printf.sprintf
+    "repo discovery skipped %S: origin unavailable (%S)"
+    abs_repo_dir
+    detail
+;;
+
+let discover_repositories_with_budget ~origin_budget_sec ~base_path =
   (* Issue #13188 + #13217 review: [find <base_path>] echoes the
      search-path prefix in every result, and a relative base_path
      (e.g. ["workspace"]) used to duplicate via [Filename.concat
@@ -423,6 +430,7 @@ let discover_repositories ~base_path =
      [base_path] to its canonical absolute form (symlinks + ".."
      + redundant "." collapsed) before invoking [find] so every
      downstream comparison sees a single normalized representation. *)
+  let budget = Repo_git.Inspection_budget.create ~timeout_sec:origin_budget_sec () in
   let abs_base_path = canonical_path base_path in
   let* repositories = load_all ~base_path in
   let existing_paths =
@@ -457,51 +465,76 @@ let discover_repositories ~base_path =
                && (not (String.equal segment "." || String.equal segment ".."))
                && Char.equal segment.[0] '.')
   in
-  let candidates =
-    List.filter_map
-      (fun git_dir ->
+  let rec collect_candidates inspected acc = function
+    | [] -> Ok (List.rev acc)
+    | git_dir :: rest ->
         (* Canonicalize again here in case find traversed a symlink the
            caller did not anticipate; the existing-repo membership check
            below relies on identical normalized representations. *)
         let abs_repo_dir = canonical_path (Filename.dirname git_dir) in
-        if has_hidden_segment_under_base abs_repo_dir then None
-        else if List.exists (String.equal abs_repo_dir) existing_paths then None
+        if has_hidden_segment_under_base abs_repo_dir
+        then collect_candidates inspected acc rest
+        else if List.exists (String.equal abs_repo_dir) existing_paths
+        then collect_candidates inspected acc rest
         else
-          match Repo_git.get_origin_url ~local_path:abs_repo_dir with
-          | Ok url ->
+          (match Repo_git.Inspection_budget.remaining_timeout budget with
+           | Error _ ->
+             Error
+               (Printf.sprintf
+                  "repository origin inspection budget exhausted after %d candidates"
+                  inspected)
+           | Ok timeout_sec ->
+             (match
+                Repo_git.get_origin_url ~timeout_sec ~local_path:abs_repo_dir
+              with
+              | Ok url ->
               let name = Filename.basename abs_repo_dir in
               let id = slugify_id name in
-              Some
-                {
-                  id;
-                  name;
-                  url;
-                  local_path = abs_repo_dir;
-                  aliases = [];
-                  default_branch = "main";
-                  keepers = [];
-                  status = Active;
-                  auto_sync = false;
-                  sync_interval = 0;
-                  created_at = Int64.zero;
-                  updated_at = Int64.zero;
+              let candidate =
+                { id
+                ; name
+                ; url
+                ; local_path = abs_repo_dir
+                ; aliases = []
+                ; default_branch = "main"
+                ; keepers = []
+                ; status = Active
+                ; auto_sync = false
+                ; sync_interval = 0
+                ; created_at = Int64.zero
+                ; updated_at = Int64.zero
                 }
-          (* Now that [get_origin_url] is bounded, this branch fires on a
-             timeout as well as on a checkout that genuinely has no origin —
-             and the two are not the same thing. Dropping either one silently
-             makes a repository vanish from discovery with nothing to read:
-             before the bound, the same condition at least presented as a hang.
-             Say which one happened; the drop itself stays, because a candidate
-             without an origin has no url to register. *)
-          | Error detail ->
-            Log.Misc.warn
-              "repo discovery skipped %s: origin unavailable (%s)"
-              abs_repo_dir
-              detail;
-            None)
-      git_dirs
+              in
+              collect_candidates (inspected + 1) (candidate :: acc) rest
+              (* Now that [get_origin_url] is bounded, this branch fires on a
+                 timeout as well as on a checkout that genuinely has no origin.
+                 The rendered fields use OCaml string escaping so repository
+                 names and Git stderr cannot inject terminal controls or forge
+                 a second log line. *)
+              | Error detail ->
+                Log.Misc.warn "%s"
+                  (discovery_skip_log_line ~abs_repo_dir ~detail);
+                if Repo_git.Inspection_budget.is_exhausted budget
+                then
+                  Error
+                    (Printf.sprintf
+                       "repository origin inspection budget exhausted after %d candidates"
+                       (inspected + 1))
+                else collect_candidates (inspected + 1) acc rest))
   in
-  Ok candidates
+  collect_candidates 0 [] git_dirs
+;;
+
+let discover_repositories ~base_path =
+  discover_repositories_with_budget
+    ~origin_budget_sec:Repo_git.inspection_timeout_sec
+    ~base_path
+;;
+
+module For_testing = struct
+  let discover_repositories_with_budget = discover_repositories_with_budget
+  let discovery_skip_log_line = discovery_skip_log_line
+end
 
 let register_discovered ~base_path =
   let* candidates = discover_repositories ~base_path in

--- a/lib/repo_manager/repo_store.ml
+++ b/lib/repo_manager/repo_store.ml
@@ -486,7 +486,19 @@ let discover_repositories ~base_path =
                   created_at = Int64.zero;
                   updated_at = Int64.zero;
                 }
-          | Error _ -> None)
+          (* Now that [get_origin_url] is bounded, this branch fires on a
+             timeout as well as on a checkout that genuinely has no origin —
+             and the two are not the same thing. Dropping either one silently
+             makes a repository vanish from discovery with nothing to read:
+             before the bound, the same condition at least presented as a hang.
+             Say which one happened; the drop itself stays, because a candidate
+             without an origin has no url to register. *)
+          | Error detail ->
+            Log.Misc.warn
+              "repo discovery skipped %s: origin unavailable (%s)"
+              abs_repo_dir
+              detail;
+            None)
       git_dirs
   in
   Ok candidates

--- a/lib/repo_manager/repo_store.ml
+++ b/lib/repo_manager/repo_store.ml
@@ -512,20 +512,26 @@ let discover_repositories_with_budget_impl
               in
               collect_candidates (inspected + 1) (candidate :: acc) rest
               (* Now that [get_origin_url] is bounded, this branch fires on a
-                 timeout as well as on a checkout that genuinely has no origin.
+                 timeout as well as on a checkout that genuinely has no origin,
+                 and [(string, string) result] cannot tell them apart. So do not
+                 ask the budget which case it was — that answer is a proxy, and
+                 it turned "this checkout has no origin remote" into a discovery
+                 failure whenever the budget happened to be spent.
+
+                 Skipping is right either way. A spent budget only matters while
+                 candidates remain unfunded, and [remaining_timeout] aborts on
+                 the next iteration for exactly that reason. When [rest] is
+                 empty every entry in [git_dirs] has already been collected,
+                 skipped, or attempted, so nothing was left uninspected and
+                 discarding [acc] bought nothing.
+
                  The rendered fields use OCaml string escaping so repository
                  names and Git stderr cannot inject terminal controls or forge
                  a second log line. *)
               | Error detail ->
                 Log.Misc.warn "%s"
                   (discovery_skip_log_line ~abs_repo_dir ~detail);
-                if Repo_git.Inspection_budget.is_exhausted budget
-                then
-                  Error
-                    (Printf.sprintf
-                       "repository origin inspection budget exhausted after %d candidates"
-                       (inspected + 1))
-                else collect_candidates (inspected + 1) acc rest))
+                collect_candidates (inspected + 1) acc rest))
   in
   collect_candidates 0 [] git_dirs
 ;;

--- a/lib/repo_manager/repo_store.ml
+++ b/lib/repo_manager/repo_store.ml
@@ -511,27 +511,24 @@ let discover_repositories_with_budget_impl
                 }
               in
               collect_candidates (inspected + 1) (candidate :: acc) rest
-              (* Now that [get_origin_url] is bounded, this branch fires on a
-                 timeout as well as on a checkout that genuinely has no origin,
-                 and [(string, string) result] cannot tell them apart. So do not
-                 ask the budget which case it was — that answer is a proxy, and
-                 it turned "this checkout has no origin remote" into a discovery
-                 failure whenever the budget happened to be spent.
-
-                 Skipping is right either way. A spent budget only matters while
-                 candidates remain unfunded, and [remaining_timeout] aborts on
-                 the next iteration for exactly that reason. When [rest] is
-                 empty every entry in [git_dirs] has already been collected,
-                 skipped, or attempted, so nothing was left uninspected and
-                 discarding [acc] bought nothing.
-
-                 The rendered fields use OCaml string escaping so repository
+              (* Typed origin failures let a real timeout fail the incomplete
+                 scan while a missing remote remains a normal skip. The
+                 rendered fields use OCaml string escaping so repository
                  names and Git stderr cannot inject terminal controls or forge
                  a second log line. *)
               | Error detail ->
+                let detail_text = Repo_git.origin_lookup_error_to_string detail in
                 Log.Misc.warn "%s"
-                  (discovery_skip_log_line ~abs_repo_dir ~detail);
-                collect_candidates (inspected + 1) acc rest))
+                  (discovery_skip_log_line ~abs_repo_dir ~detail:detail_text);
+                (match detail with
+                 | Repo_git.Origin_lookup_timed_out _ ->
+                   Error
+                     (Printf.sprintf
+                        "repository origin inspection budget exhausted after %d candidates"
+                        (inspected + 1))
+                 | Repo_git.Origin_missing
+                 | Repo_git.Origin_lookup_failed _ ->
+                   collect_candidates (inspected + 1) acc rest)))
   in
   collect_candidates 0 [] git_dirs
 ;;

--- a/lib/repo_manager/repo_store.ml
+++ b/lib/repo_manager/repo_store.ml
@@ -485,7 +485,7 @@ let discover_repositories_with_budget ~origin_budget_sec ~base_path =
                   inspected)
            | Ok timeout_sec ->
              (match
-                Repo_git.get_origin_url ~timeout_sec ~local_path:abs_repo_dir
+                Repo_git.get_origin_url ~timeout_sec ~local_path:abs_repo_dir ()
               with
               | Ok url ->
               let name = Filename.basename abs_repo_dir in

--- a/lib/repo_manager/repo_store.ml
+++ b/lib/repo_manager/repo_store.ml
@@ -418,7 +418,11 @@ let discovery_skip_log_line ~abs_repo_dir ~detail =
     detail
 ;;
 
-let discover_repositories_with_budget ~origin_budget_sec ~base_path =
+let discover_repositories_with_budget_impl
+    ~before_origin_inspection
+    ~origin_budget_sec
+    ~base_path
+  =
   (* Issue #13188 + #13217 review: [find <base_path>] echoes the
      search-path prefix in every result, and a relative base_path
      (e.g. ["workspace"]) used to duplicate via [Filename.concat
@@ -430,7 +434,6 @@ let discover_repositories_with_budget ~origin_budget_sec ~base_path =
      [base_path] to its canonical absolute form (symlinks + ".."
      + redundant "." collapsed) before invoking [find] so every
      downstream comparison sees a single normalized representation. *)
-  let budget = Repo_git.Inspection_budget.create ~timeout_sec:origin_budget_sec () in
   let abs_base_path = canonical_path base_path in
   let* repositories = load_all ~base_path in
   let existing_paths =
@@ -440,6 +443,8 @@ let discover_repositories_with_budget ~origin_budget_sec ~base_path =
       repositories
   in
   let git_dirs = discover_git_dirs ~base_path:abs_base_path in
+  before_origin_inspection ();
+  let budget = Repo_git.Inspection_budget.create ~timeout_sec:origin_budget_sec () in
   let has_hidden_segment_under_base path =
     if String.equal path abs_base_path then false
     else
@@ -525,6 +530,13 @@ let discover_repositories_with_budget ~origin_budget_sec ~base_path =
   collect_candidates 0 [] git_dirs
 ;;
 
+let discover_repositories_with_budget ~origin_budget_sec ~base_path =
+  discover_repositories_with_budget_impl
+    ~before_origin_inspection:(fun () -> ())
+    ~origin_budget_sec
+    ~base_path
+;;
+
 let discover_repositories ~base_path =
   discover_repositories_with_budget
     ~origin_budget_sec:Repo_git.inspection_timeout_sec
@@ -533,6 +545,17 @@ let discover_repositories ~base_path =
 
 module For_testing = struct
   let discover_repositories_with_budget = discover_repositories_with_budget
+  let discover_repositories_with_budget_after_scan
+      ~before_origin_inspection
+      ~origin_budget_sec
+      ~base_path
+    =
+    discover_repositories_with_budget_impl
+      ~before_origin_inspection
+      ~origin_budget_sec
+      ~base_path
+  ;;
+
   let discovery_skip_log_line = discovery_skip_log_line
 end
 

--- a/lib/repo_manager/repo_store.mli
+++ b/lib/repo_manager/repo_store.mli
@@ -59,6 +59,12 @@ module For_testing : sig
     base_path:string ->
     (repository list, string) result
 
+  val discover_repositories_with_budget_after_scan :
+    before_origin_inspection:(unit -> unit) ->
+    origin_budget_sec:float ->
+    base_path:string ->
+    (repository list, string) result
+
   val discovery_skip_log_line :
     abs_repo_dir:string -> detail:string -> string
 end

--- a/lib/repo_manager/repo_store.mli
+++ b/lib/repo_manager/repo_store.mli
@@ -53,6 +53,16 @@ val discover_repositories : base_path:string -> (repository list, string) result
     intended for Phase 1 onboarding where the operator confirms discovered
     repositories before adding them to the store. *)
 
+module For_testing : sig
+  val discover_repositories_with_budget :
+    origin_budget_sec:float ->
+    base_path:string ->
+    (repository list, string) result
+
+  val discovery_skip_log_line :
+    abs_repo_dir:string -> detail:string -> string
+end
+
 val register_discovered : base_path:string -> (repository list, string) result
 (** [register_discovered ~base_path] scans [base_path] for git repositories
     using {!discover_repositories} and automatically persists each candidate.

--- a/lib/repo_manager/repo_sync.ml
+++ b/lib/repo_manager/repo_sync.ml
@@ -32,16 +32,16 @@ let advance_outcome_label = function
    [Error] because the fetch itself succeeded and refs are current. *)
 let advance_working_tree ~repository : advance_outcome =
   let target_ref = "origin/" ^ repository.default_branch in
-  match Repo_git.ahead_behind ~repository ~target_ref with
+  match Repo_git.ahead_behind ~repository ~target_ref () with
   | Error reason -> Advance_inspect_failed { reason }
   | Ok (0, _ahead) -> Already_current
   | Ok (behind, _ahead) -> (
-      match Repo_git.current_branch ~repository with
+      match Repo_git.current_branch ~repository () with
       | Error reason -> Advance_inspect_failed { reason }
       | Ok current when not (String.equal current repository.default_branch) ->
           Skipped_not_on_default_branch { current }
       | Ok _default -> (
-          match Repo_git.status_summary ~repository with
+          match Repo_git.status_summary ~repository () with
           | Error reason -> Advance_inspect_failed { reason }
           | Ok summary
             when summary.Repo_git.staged_files > 0

--- a/lib/server/server_routes_http_routes_repositories.ml
+++ b/lib/server/server_routes_http_routes_repositories.ml
@@ -39,7 +39,7 @@ let status_json = function
 let git_status_json ~base_path (repo : Repo_manager_types.repository) =
   let abs_local_path = Repo_store.local_path ~base_path repo in
   let repo_for_git = { repo with local_path = abs_local_path } in
-  match Repo_git.status_summary ~repository:repo_for_git with
+  match Repo_git.status_summary ~repository:repo_for_git () with
   | Ok summary ->
       `Assoc
         [
@@ -68,7 +68,7 @@ let sync_currency_json ~base_path (repo : Repo_manager_types.repository) =
   let abs_local_path = Repo_store.local_path ~base_path repo in
   let repo_for_git = { repo with local_path = abs_local_path } in
   let target_ref = "origin/" ^ repo.default_branch in
-  match Repo_git.ahead_behind ~repository:repo_for_git ~target_ref with
+  match Repo_git.ahead_behind ~repository:repo_for_git ~target_ref () with
   | Ok (behind, ahead) ->
       `Assoc
         [

--- a/test/test_keeper_visible_path_projection.ml
+++ b/test/test_keeper_visible_path_projection.ml
@@ -289,6 +289,39 @@ let test_repository_checkout_projection_shares_inspection_budget () =
          (elapsed < 1.0))
 ;;
 
+let test_repository_checkout_budget_starts_after_discovery () =
+  setup
+  @@ fun ~config ~meta ~playground ~publication_recovery:_ ->
+  let checkout = Filename.concat playground "repos/fast-checkout" in
+  ensure_dir checkout;
+  ignore (run_git_or_fail ~cwd:checkout [ "init"; "-b"; "main" ]);
+  ignore (run_git_or_fail ~cwd:checkout [ "config"; "user.email"; "test@example.com" ]);
+  ignore (run_git_or_fail ~cwd:checkout [ "config"; "user.name"; "Test" ]);
+  ignore
+    (run_git_or_fail ~cwd:checkout [ "commit"; "--allow-empty"; "-m"; "initial" ]);
+  ignore
+    (run_git_or_fail
+       ~cwd:checkout
+       [ "remote"; "add"; "origin"; "https://example.invalid/fast-checkout.git" ]);
+  let projection =
+    Keeper_sandbox_control.For_testing
+    .repository_checkouts_json_with_budget_after_discovery
+      ~before_git_inspection:(fun () -> Unix.sleepf 0.6)
+      ~inspection_budget_sec:0.5
+      ~config
+      ~meta
+  in
+  Alcotest.(check string)
+    "catalog and filesystem discovery do not spend Git inspection budget"
+    "available"
+    (projection |> Json.member "state" |> Json.to_string);
+  let entry = projection |> Json.member "entries" |> Json.to_list |> List.hd in
+  Alcotest.(check string)
+    "fast checkout remains inspectable after slow discovery"
+    "available"
+    (entry |> Json.member "inspection_state" |> Json.to_string)
+;;
+
 let test_visible_scratch_read_resolves_to_private_storage () =
   setup
   @@ fun ~config ~meta ~playground ~publication_recovery:_ ->
@@ -620,6 +653,10 @@ let () =
             "shares one inspection budget across checkouts"
             `Quick
             test_repository_checkout_projection_shares_inspection_budget
+        ; Alcotest.test_case
+            "starts inspection budget after discovery"
+            `Quick
+            test_repository_checkout_budget_starts_after_discovery
         ] )
     ]
 ;;

--- a/test/test_keeper_visible_path_projection.ml
+++ b/test/test_keeper_visible_path_projection.ml
@@ -250,6 +250,45 @@ let test_repository_checkout_projection_ignores_symlinked_directory () =
   Alcotest.(check int) "symlink checkout excluded" 0 (List.length entries)
 ;;
 
+let test_repository_checkout_projection_shares_inspection_budget () =
+  setup
+  @@ fun ~config ~meta ~playground ~publication_recovery:_ ->
+  let fake_bin = Filename.concat playground "fake-bin" in
+  ensure_dir fake_bin;
+  let fake_git = Filename.concat fake_bin "git" in
+  write_file fake_git "#!/bin/sh\nsleep 30\n";
+  Unix.chmod fake_git 0o755;
+  List.iter
+    (fun name ->
+       ensure_dir (Filename.concat playground ("repos/" ^ name ^ "/.git")))
+    [ "stalled-a"; "stalled-b" ];
+  let old_path = Sys.getenv "PATH" in
+  Fun.protect
+    ~finally:(fun () -> Unix.putenv "PATH" old_path)
+    (fun () ->
+       Unix.putenv "PATH" (fake_bin ^ ":" ^ old_path);
+       let started_at = Unix.gettimeofday () in
+       let projection =
+         Keeper_sandbox_control.For_testing.repository_checkouts_json_with_budget
+           ~inspection_budget_sec:0.2
+           ~config
+           ~meta
+       in
+       let elapsed = Unix.gettimeofday () -. started_at in
+       Alcotest.(check string)
+         "projection reports the exhausted request budget"
+         "inspection_budget_exhausted"
+         (projection |> Json.member "state" |> Json.to_string);
+       Alcotest.(check int)
+         "both checkout identities remain visible"
+         2
+         (projection |> Json.member "entries" |> Json.to_list |> List.length);
+       Alcotest.(check bool)
+         "two stalled checkouts share one wall-clock budget"
+         true
+         (elapsed < 1.0))
+;;
+
 let test_visible_scratch_read_resolves_to_private_storage () =
   setup
   @@ fun ~config ~meta ~playground ~publication_recovery:_ ->
@@ -577,6 +616,10 @@ let () =
             "ignores symlinked checkout directories"
             `Quick
             test_repository_checkout_projection_ignores_symlinked_directory
+        ; Alcotest.test_case
+            "shares one inspection budget across checkouts"
+            `Quick
+            test_repository_checkout_projection_shares_inspection_budget
         ] )
     ]
 ;;

--- a/test/test_keeper_visible_path_projection.ml
+++ b/test/test_keeper_visible_path_projection.ml
@@ -256,7 +256,7 @@ let test_repository_checkout_projection_shares_inspection_budget () =
   let fake_bin = Filename.concat playground "fake-bin" in
   ensure_dir fake_bin;
   let fake_git = Filename.concat fake_bin "git" in
-  write_file fake_git "#!/bin/sh\nsleep 30\n";
+  write_file fake_git "#!/bin/sh\nexec sleep 30\n";
   Unix.chmod fake_git 0o755;
   List.iter
     (fun name ->

--- a/test/test_repo_git.ml
+++ b/test/test_repo_git.ml
@@ -141,7 +141,7 @@ let test_get_origin_url () =
        with
        | Ok () -> ()
        | Error e -> Alcotest.fail ("git remote add failed: " ^ e));
-      match Repo_git.get_origin_url ~local_path:source with
+      match Repo_git.get_origin_url ~local_path:source () with
       | Ok url ->
           Alcotest.(check string)
             "origin URL"
@@ -162,7 +162,7 @@ let test_get_origin_url_times_out_on_stalled_config () =
         (fun () ->
           Unix.putenv "PATH" (fake_bin ^ ":" ^ old_path);
           let started_at = Unix.gettimeofday () in
-          match Repo_git.get_origin_url ~local_path:tmp with
+          match Repo_git.get_origin_url ~local_path:tmp () with
           | Ok url -> Alcotest.failf "expected timeout, got origin %s" url
           | Error error ->
               let elapsed = Unix.gettimeofday () -. started_at in
@@ -191,7 +191,7 @@ let test_get_origin_url_uses_read_only_git_env () =
       ~finally:(fun () -> Exec_tap.disable ())
       (fun () ->
          Exec_tap.enable ~writer:(fun line -> captured := line :: !captured);
-         match Repo_git.get_origin_url ~local_path:source with
+         match Repo_git.get_origin_url ~local_path:source () with
          | Error e -> Alcotest.fail ("origin failed: " ^ e)
          | Ok _ ->
            let joined = String.concat "\n" (List.rev !captured) in
@@ -248,13 +248,13 @@ let test_status_summary_counts_porcelain_rows () =
       | Ok () -> ()
       | Error e -> Alcotest.fail ("git commit tracked failed: " ^ e));
       let repo = sample_repo ~url:source source in
-      (match Repo_git.status_summary ~repository:repo with
+      (match Repo_git.status_summary ~repository:repo () with
       | Error e -> Alcotest.fail ("clean status failed: " ^ e)
       | Ok summary ->
           Alcotest.(check int) "clean changed" 0 summary.changed_files);
       write_file tracked "modified\n";
       write_file (Filename.concat source "untracked.txt") "new\n";
-      (match Repo_git.status_summary ~repository:repo with
+      (match Repo_git.status_summary ~repository:repo () with
       | Error e -> Alcotest.fail ("dirty status failed: " ^ e)
       | Ok summary ->
           Alcotest.(check int) "dirty changed" 2 summary.changed_files;
@@ -264,7 +264,7 @@ let test_status_summary_counts_porcelain_rows () =
       (match run_cmd ~cwd:source ["git"; "add"; "tracked.txt"] with
       | Ok () -> ()
       | Error e -> Alcotest.fail ("git add modified failed: " ^ e));
-      match Repo_git.status_summary ~repository:repo with
+      match Repo_git.status_summary ~repository:repo () with
       | Error e -> Alcotest.fail ("staged status failed: " ^ e)
       | Ok summary ->
           Alcotest.(check int) "staged changed" 2 summary.changed_files;
@@ -282,7 +282,7 @@ let test_status_summary_uses_read_only_git_conventions () =
         ~finally:(fun () -> Exec_tap.disable ())
         (fun () ->
           Exec_tap.enable ~writer:(fun line -> captured := line :: !captured);
-          match Repo_git.status_summary ~repository:repo with
+          match Repo_git.status_summary ~repository:repo () with
           | Error e -> Alcotest.fail ("status failed: " ^ e)
           | Ok _ ->
               let joined = String.concat "\n" (List.rev !captured) in

--- a/test/test_repo_git.ml
+++ b/test/test_repo_git.ml
@@ -130,6 +130,51 @@ let test_get_branches () =
           | Ok branches ->
               Alcotest.(check bool) "has main" true (List.mem "main" branches)))
 
+let test_get_origin_url () =
+  with_temp_dir (fun tmp ->
+      let source = Filename.concat tmp "source" in
+      init_local_repo source;
+      (match
+         run_cmd
+           ~cwd:source
+           [ "git"; "remote"; "add"; "origin"; "https://example.test/owner/repo.git" ]
+       with
+       | Ok () -> ()
+       | Error e -> Alcotest.fail ("git remote add failed: " ^ e));
+      match Repo_git.get_origin_url ~local_path:source with
+      | Ok url ->
+          Alcotest.(check string)
+            "origin URL"
+            "https://example.test/owner/repo.git"
+            url
+      | Error e -> Alcotest.fail ("get_origin_url failed: " ^ e))
+
+let test_get_origin_url_times_out_on_stalled_config () =
+  with_temp_dir (fun tmp ->
+      let fake_bin = Filename.concat tmp "bin" in
+      Unix.mkdir fake_bin 0o755;
+      let fake_git = Filename.concat fake_bin "git" in
+      write_file fake_git "#!/bin/sh\nsleep 30\n";
+      Unix.chmod fake_git 0o755;
+      let old_path = Sys.getenv "PATH" in
+      Fun.protect
+        ~finally:(fun () -> Unix.putenv "PATH" old_path)
+        (fun () ->
+          Unix.putenv "PATH" (fake_bin ^ ":" ^ old_path);
+          let started_at = Unix.gettimeofday () in
+          match Repo_git.get_origin_url ~local_path:tmp with
+          | Ok url -> Alcotest.failf "expected timeout, got origin %s" url
+          | Error error ->
+              let elapsed = Unix.gettimeofday () -. started_at in
+              Alcotest.(check bool)
+                "reports timeout"
+                true
+                (String_util.contains_substring error "timeout after 5s");
+              Alcotest.(check bool)
+                "returns within a bounded interval"
+                true
+                (elapsed >= 4.0 && elapsed < 10.0)))
+
 let test_fetch () =
   with_temp_dir (fun tmp ->
       let source = Filename.concat tmp "source" in
@@ -262,6 +307,13 @@ let () =
         ] );
       ( "get_branches",
         [ Alcotest.test_case "returns branches" `Quick test_get_branches ] );
+      ( "get_origin_url",
+        [ Alcotest.test_case "returns configured origin" `Quick test_get_origin_url
+        ; Alcotest.test_case
+            "times out on stalled config"
+            `Slow
+            test_get_origin_url_times_out_on_stalled_config
+        ] );
       ( "fetch", [ Alcotest.test_case "returns remotes" `Quick test_fetch ] );
       ( "get_recent_commits",
         [ Alcotest.test_case "returns commits" `Quick test_get_recent_commits ] );

--- a/test/test_repo_git.ml
+++ b/test/test_repo_git.ml
@@ -147,7 +147,21 @@ let test_get_origin_url () =
             "origin URL"
             "https://example.test/owner/repo.git"
             url
-      | Error e -> Alcotest.fail ("get_origin_url failed: " ^ e))
+      | Error e ->
+        Alcotest.fail
+          ("get_origin_url failed: " ^ Repo_git.origin_lookup_error_to_string e))
+
+let test_get_origin_url_reports_missing_without_text_matching () =
+  with_temp_dir (fun tmp ->
+    let source = Filename.concat tmp "source" in
+    init_local_repo source;
+    match Repo_git.get_origin_url ~local_path:source () with
+    | Error Repo_git.Origin_missing -> ()
+    | Error error ->
+      Alcotest.failf
+        "unexpected missing-origin outcome: %s"
+        (Repo_git.origin_lookup_error_to_string error)
+    | Ok url -> Alcotest.failf "missing origin returned URL %s" url)
 
 let test_get_origin_url_times_out_on_stalled_config () =
   with_temp_dir (fun tmp ->
@@ -164,7 +178,7 @@ let test_get_origin_url_times_out_on_stalled_config () =
           let started_at = Unix.gettimeofday () in
           match Repo_git.get_origin_url ~local_path:tmp () with
           | Ok url -> Alcotest.failf "expected timeout, got origin %s" url
-          | Error error ->
+          | Error (Repo_git.Origin_lookup_timed_out error) ->
               let elapsed = Unix.gettimeofday () -. started_at in
               Alcotest.(check bool)
                 "reports timeout"
@@ -173,7 +187,11 @@ let test_get_origin_url_times_out_on_stalled_config () =
               Alcotest.(check bool)
                 "returns within a bounded interval"
                 true
-                (elapsed >= 4.0 && elapsed < 10.0)))
+                (elapsed >= 4.0 && elapsed < 10.0)
+          | Error error ->
+            Alcotest.failf
+              "expected typed timeout, got %s"
+              (Repo_git.origin_lookup_error_to_string error)))
 
 let test_get_origin_url_uses_read_only_git_env () =
   with_temp_dir (fun tmp ->
@@ -192,7 +210,9 @@ let test_get_origin_url_uses_read_only_git_env () =
       (fun () ->
          Exec_tap.enable ~writer:(fun line -> captured := line :: !captured);
          match Repo_git.get_origin_url ~local_path:source () with
-         | Error e -> Alcotest.fail ("origin failed: " ^ e)
+         | Error e ->
+           Alcotest.fail
+             ("origin failed: " ^ Repo_git.origin_lookup_error_to_string e)
          | Ok _ ->
            let joined = String.concat "\n" (List.rev !captured) in
            Alcotest.(check bool)
@@ -334,6 +354,10 @@ let () =
         [ Alcotest.test_case "returns branches" `Quick test_get_branches ] );
       ( "get_origin_url",
         [ Alcotest.test_case "returns configured origin" `Quick test_get_origin_url
+        ; Alcotest.test_case
+            "reports missing origin as typed absence"
+            `Quick
+            test_get_origin_url_reports_missing_without_text_matching
         ; Alcotest.test_case
             "times out on stalled config"
             `Slow

--- a/test/test_repo_git.ml
+++ b/test/test_repo_git.ml
@@ -175,6 +175,31 @@ let test_get_origin_url_times_out_on_stalled_config () =
                 true
                 (elapsed >= 4.0 && elapsed < 10.0)))
 
+let test_get_origin_url_uses_read_only_git_env () =
+  with_temp_dir (fun tmp ->
+    let source = Filename.concat tmp "source" in
+    init_local_repo source;
+    (match
+       run_cmd
+         ~cwd:source
+         [ "git"; "remote"; "add"; "origin"; "https://example.test/owner/repo.git" ]
+     with
+     | Ok () -> ()
+     | Error e -> Alcotest.fail ("git remote add failed: " ^ e));
+    let captured = ref [] in
+    Fun.protect
+      ~finally:(fun () -> Exec_tap.disable ())
+      (fun () ->
+         Exec_tap.enable ~writer:(fun line -> captured := line :: !captured);
+         match Repo_git.get_origin_url ~local_path:source with
+         | Error e -> Alcotest.fail ("origin failed: " ^ e)
+         | Ok _ ->
+           let joined = String.concat "\n" (List.rev !captured) in
+           Alcotest.(check bool)
+             "sets GIT_OPTIONAL_LOCKS env key"
+             true
+             (String_util.contains_substring joined "\"GIT_OPTIONAL_LOCKS\"")))
+
 let test_fetch () =
   with_temp_dir (fun tmp ->
       let source = Filename.concat tmp "source" in
@@ -313,6 +338,10 @@ let () =
             "times out on stalled config"
             `Slow
             test_get_origin_url_times_out_on_stalled_config
+        ; Alcotest.test_case
+            "uses read-only git environment"
+            `Quick
+            test_get_origin_url_uses_read_only_git_env
         ] );
       ( "fetch", [ Alcotest.test_case "returns remotes" `Quick test_fetch ] );
       ( "get_recent_commits",

--- a/test/test_repo_store.ml
+++ b/test/test_repo_store.ml
@@ -529,6 +529,52 @@ let test_discover_skips_registered () =
                 Alcotest.(check int) "skips already registered" 0
                   (List.length repos)))
 
+let test_discover_origin_budget_is_cumulative () =
+  with_temp_base_path (fun base_path ->
+    let fake_bin = Filename.concat base_path "fake-bin" in
+    Unix.mkdir fake_bin 0o755;
+    let fake_git = Filename.concat fake_bin "git" in
+    write_file fake_git "#!/bin/sh\nsleep 30\n";
+    Unix.chmod fake_git 0o755;
+    List.iter
+      (fun name ->
+         let repo = Filename.concat base_path name in
+         Unix.mkdir repo 0o755;
+         Unix.mkdir (Filename.concat repo ".git") 0o755)
+      [ "stalled-a"; "stalled-b" ];
+    let old_path = Sys.getenv "PATH" in
+    Fun.protect
+      ~finally:(fun () -> Unix.putenv "PATH" old_path)
+      (fun () ->
+         Unix.putenv "PATH" (fake_bin ^ ":" ^ old_path);
+         let started_at = Unix.gettimeofday () in
+         let result =
+           Repo_store.For_testing.discover_repositories_with_budget
+             ~origin_budget_sec:0.2
+             ~base_path
+         in
+         let elapsed = Unix.gettimeofday () -. started_at in
+         (match result with
+          | Error _ -> ()
+          | Ok _ -> Alcotest.fail "exhausted discovery budget returned a partial success");
+         Alcotest.(check bool)
+           "two stalled repositories share one request budget"
+           true
+           (elapsed < 1.0)))
+;;
+
+let test_discovery_warning_escapes_untrusted_fields () =
+  let line =
+    Repo_store.For_testing.discovery_skip_log_line
+      ~abs_repo_dir:"/tmp/repo\nforged"
+      ~detail:"fatal:\027[31mred"
+  in
+  Alcotest.(check string)
+    "newline and terminal escape are rendered as quoted escapes"
+    "repo discovery skipped \"/tmp/repo\\nforged\": origin unavailable (\"fatal:\\027[31mred\")"
+    line
+;;
+
 let test_register_discovered_auto_adds () =
   if not (git_available ()) then Alcotest.skip ()
   else
@@ -801,6 +847,10 @@ let () =
           Alcotest.test_case "relative base path keeps visible repos" `Quick
             test_discover_relative_base_path_keeps_visible_repos;
           Alcotest.test_case "skips registered repos" `Quick test_discover_skips_registered;
+          Alcotest.test_case "shares one origin inspection budget" `Quick
+            test_discover_origin_budget_is_cumulative;
+          Alcotest.test_case "escapes discovery warning fields" `Quick
+            test_discovery_warning_escapes_untrusted_fields;
         ] );
       ( "registration",
         [

--- a/test/test_repo_store.ml
+++ b/test/test_repo_store.ml
@@ -563,6 +563,46 @@ let test_discover_origin_budget_is_cumulative () =
            (elapsed < 1.0)))
 ;;
 
+(* A spent budget is only a discovery failure while candidates remain unfunded.
+   When the last candidate is the one that failed, every entry has already been
+   collected, skipped, or attempted, so the walk is complete. Aborting there used
+   to discard the whole collected list, and — because the bounded
+   [get_origin_url] returns an untyped string error — it did so for a checkout
+   that simply had no origin remote as readily as for a timeout. *)
+let test_discover_spent_budget_on_last_candidate_is_not_a_failure () =
+  with_temp_base_path (fun base_path ->
+    let fake_bin = Filename.concat base_path "fake-bin" in
+    Unix.mkdir fake_bin 0o755;
+    let fake_git = Filename.concat fake_bin "git" in
+    write_file fake_git "#!/bin/sh\nexec sleep 30\n";
+    Unix.chmod fake_git 0o755;
+    let repo = Filename.concat base_path "stalled-only" in
+    Unix.mkdir repo 0o755;
+    Unix.mkdir (Filename.concat repo ".git") 0o755;
+    let old_path = Sys.getenv "PATH" in
+    Fun.protect
+      ~finally:(fun () -> Unix.putenv "PATH" old_path)
+      (fun () ->
+         Unix.putenv "PATH" (fake_bin ^ ":" ^ old_path);
+         let started_at = Unix.gettimeofday () in
+         let result =
+           Repo_store.For_testing.discover_repositories_with_budget
+             ~origin_budget_sec:0.2
+             ~base_path
+         in
+         let elapsed = Unix.gettimeofday () -. started_at in
+         (match result with
+          | Ok repos ->
+            Alcotest.(check int)
+              "the uninspectable checkout is skipped, not registered"
+              0
+              (List.length repos)
+          | Error detail ->
+            Alcotest.fail
+              ("a completed walk was reported as a discovery failure: " ^ detail));
+         Alcotest.(check bool) "still bounded by the budget" true (elapsed < 1.0)))
+;;
+
 let test_discover_origin_budget_starts_after_filesystem_scan () =
   if not (git_available ()) then Alcotest.skip ()
   else
@@ -870,6 +910,8 @@ let () =
             test_discover_origin_budget_is_cumulative;
           Alcotest.test_case "starts origin budget after filesystem scan" `Quick
             test_discover_origin_budget_starts_after_filesystem_scan;
+          Alcotest.test_case "spent budget on the last candidate is not a failure"
+            `Quick test_discover_spent_budget_on_last_candidate_is_not_a_failure;
           Alcotest.test_case "escapes discovery warning fields" `Quick
             test_discovery_warning_escapes_untrusted_fields;
         ] );

--- a/test/test_repo_store.ml
+++ b/test/test_repo_store.ml
@@ -563,13 +563,7 @@ let test_discover_origin_budget_is_cumulative () =
            (elapsed < 1.0)))
 ;;
 
-(* A spent budget is only a discovery failure while candidates remain unfunded.
-   When the last candidate is the one that failed, every entry has already been
-   collected, skipped, or attempted, so the walk is complete. Aborting there used
-   to discard the whole collected list, and — because the bounded
-   [get_origin_url] returns an untyped string error — it did so for a checkout
-   that simply had no origin remote as readily as for a timeout. *)
-let test_discover_spent_budget_on_last_candidate_is_not_a_failure () =
+let test_discover_timeout_on_last_candidate_is_typed_failure () =
   with_temp_base_path (fun base_path ->
     let fake_bin = Filename.concat base_path "fake-bin" in
     Unix.mkdir fake_bin 0o755;
@@ -592,15 +586,32 @@ let test_discover_spent_budget_on_last_candidate_is_not_a_failure () =
          in
          let elapsed = Unix.gettimeofday () -. started_at in
          (match result with
-          | Ok repos ->
-            Alcotest.(check int)
-              "the uninspectable checkout is skipped, not registered"
-              0
-              (List.length repos)
-          | Error detail ->
-            Alcotest.fail
-              ("a completed walk was reported as a discovery failure: " ^ detail));
+          | Error _ -> ()
+          | Ok _ -> Alcotest.fail "timed-out final origin was silently skipped");
          Alcotest.(check bool) "still bounded by the budget" true (elapsed < 1.0)))
+;;
+
+let test_discover_skips_missing_origin_without_failing_request () =
+  if not (git_available ()) then Alcotest.skip ()
+  else
+    with_temp_base_path (fun base_path ->
+      let without_origin = Filename.concat base_path "without-origin" in
+      Unix.mkdir without_origin 0o755;
+      init_git_repo without_origin "https://github.com/test/temporary";
+      (match Repo_git.run_git ~cwd:without_origin [ "remote"; "remove"; "origin" ] with
+       | Ok _ -> ()
+       | Error detail -> Alcotest.fail detail);
+      let with_origin = Filename.concat base_path "with-origin" in
+      Unix.mkdir with_origin 0o755;
+      init_git_repo with_origin "https://github.com/test/with-origin";
+      match Repo_store.discover_repositories ~base_path with
+      | Error detail ->
+        Alcotest.fail ("missing origin failed repository discovery: " ^ detail)
+      | Ok repos ->
+        Alcotest.(check (list string))
+          "missing-origin repository is skipped while valid candidates survive"
+          [ "with-origin" ]
+          (List.map (fun (repo : repository) -> repo.id) repos))
 ;;
 
 let test_discover_origin_budget_starts_after_filesystem_scan () =
@@ -906,12 +917,14 @@ let () =
           Alcotest.test_case "relative base path keeps visible repos" `Quick
             test_discover_relative_base_path_keeps_visible_repos;
           Alcotest.test_case "skips registered repos" `Quick test_discover_skips_registered;
+          Alcotest.test_case "skips missing origin without failing discovery" `Quick
+            test_discover_skips_missing_origin_without_failing_request;
           Alcotest.test_case "shares one origin inspection budget" `Quick
             test_discover_origin_budget_is_cumulative;
           Alcotest.test_case "starts origin budget after filesystem scan" `Quick
             test_discover_origin_budget_starts_after_filesystem_scan;
-          Alcotest.test_case "spent budget on the last candidate is not a failure"
-            `Quick test_discover_spent_budget_on_last_candidate_is_not_a_failure;
+          Alcotest.test_case "timeout on the last candidate is a typed failure" `Quick
+            test_discover_timeout_on_last_candidate_is_typed_failure;
           Alcotest.test_case "escapes discovery warning fields" `Quick
             test_discovery_warning_escapes_untrusted_fields;
         ] );

--- a/test/test_repo_store.ml
+++ b/test/test_repo_store.ml
@@ -534,7 +534,7 @@ let test_discover_origin_budget_is_cumulative () =
     let fake_bin = Filename.concat base_path "fake-bin" in
     Unix.mkdir fake_bin 0o755;
     let fake_git = Filename.concat fake_bin "git" in
-    write_file fake_git "#!/bin/sh\nsleep 30\n";
+    write_file fake_git "#!/bin/sh\nexec sleep 30\n";
     Unix.chmod fake_git 0o755;
     List.iter
       (fun name ->

--- a/test/test_repo_store.ml
+++ b/test/test_repo_store.ml
@@ -563,6 +563,25 @@ let test_discover_origin_budget_is_cumulative () =
            (elapsed < 1.0)))
 ;;
 
+let test_discover_origin_budget_starts_after_filesystem_scan () =
+  if not (git_available ()) then Alcotest.skip ()
+  else
+    with_temp_base_path (fun base_path ->
+      let repo = Filename.concat base_path "fast-origin" in
+      Unix.mkdir repo 0o755;
+      init_git_repo repo "https://github.com/test/fast-origin";
+      match
+        Repo_store.For_testing.discover_repositories_with_budget_after_scan
+          ~before_origin_inspection:(fun () -> Unix.sleepf 0.25)
+          ~origin_budget_sec:0.2
+          ~base_path
+      with
+      | Error detail ->
+        Alcotest.fail ("filesystem discovery consumed origin budget: " ^ detail)
+      | Ok repos ->
+        Alcotest.(check int) "fast origin remains inspectable" 1 (List.length repos))
+;;
+
 let test_discovery_warning_escapes_untrusted_fields () =
   let line =
     Repo_store.For_testing.discovery_skip_log_line
@@ -849,6 +868,8 @@ let () =
           Alcotest.test_case "skips registered repos" `Quick test_discover_skips_registered;
           Alcotest.test_case "shares one origin inspection budget" `Quick
             test_discover_origin_budget_is_cumulative;
+          Alcotest.test_case "starts origin budget after filesystem scan" `Quick
+            test_discover_origin_budget_starts_after_filesystem_scan;
           Alcotest.test_case "escapes discovery warning fields" `Quick
             test_discovery_warning_escapes_untrusted_fields;
         ] );

--- a/test/test_repo_sync.ml
+++ b/test/test_repo_sync.ml
@@ -200,7 +200,7 @@ let test_sync_advances_clean_clone () =
                Alcotest.(check int) "advanced over one commit" 1 behind
            | other -> check_outcome "advanced" other);
           (match
-             Repo_git.ahead_behind ~repository:repo ~target_ref:"origin/main"
+             Repo_git.ahead_behind ~repository:repo ~target_ref:"origin/main" ()
            with
            | Ok (behind, ahead) ->
                Alcotest.(check (pair int int))


### PR DESCRIPTION
## Summary

Make repository-origin discovery bounded and observable instead of silently treating every failure as a missing origin.

## Changes

- bound `git remote get-url origin` with the existing 5-second git timeout
- preserve the existing `None` result at the registration boundary, where no URL can be registered
- log the concrete failure so a timeout is distinguishable from a repository with no origin
- add direct success and stalled-process regression tests

## Verification

- `scripts/dune-local.sh build @test/runtest-test_repo_git`
- 10 tests passed
- the timeout test places a fake `git` first on `PATH`, stalls it for 30 seconds, and observes the bounded timeout error in about 5 seconds

Full repository build intentionally left to the operator.

## Stack order

Merge before #28527, which calls this lookup from write attribution.