### PR TITLE
docs(rfc): drop the home-rooted .masc path from the workspace-root RFC

### DIFF
--- a/docs/rfc/RFC-keeper-workspace-root-only.md
+++ b/docs/rfc/RFC-keeper-workspace-root-only.md
@@ -27,7 +27,7 @@ masc 는 keeper 의 체크아웃이 `<playground_root>/repos/<repo_name>/` 에 �
 
 ### 1.1 규정은 이미 깨져 있고, 관측만 잃고 있다
 
-`~/me/.masc/playground/` 아래 `.git` 전수 조사 (2026-08-13 실측). keeper 들이 이미 `repos/` 밖에 체크아웃을 만들었고 시스템은 그것들을 보지 못한다.
+`<base-path>/.masc/playground/` 아래 `.git` 전수 조사 (2026-08-13, 운영 인스턴스 실측). keeper 들이 이미 `repos/` 밖에 체크아웃을 만들었고 시스템은 그것들을 보지 못한다.
 
 | 실제 위치 | 종류 | 현재 관측 |
 |---|---|---|


### PR DESCRIPTION
## main 이 Lint 에서 실패하고 있다

#28459 (RFC 머지) 이후 `Lint` 잡의 **Check SSOT bypass ratchet (#8462)** 스텝이 실패한다.

```
ERROR[R6-home-masc-root]: 2 occurrences (baseline 1) — SSOT bypass grew.
  docs/rfc/RFC-keeper-workspace-root-only.md:30
  docs/rfc/RFC-0373-keeper-turn-lane-admission.md:100
```

두 번째는 기존 baseline 이고, 첫 번째가 #28459 이 추가한 것이다.

## 수정

RFC 본문의 `~/me/.masc/playground/` 를 `<base-path>/.masc/playground/` 로 바꾼다. 그 문장의 목적은 측정 출처를 밝히는 것이고, 한 대의 홈 디렉터리를 박아넣지 않아도 같은 말이 된다.

## 왜 놓쳤나

#28459 를 머지하기 전에 RFC 전용 게이트만 돌렸다 — `check-doc-truth.sh`, `rfc-generate-index.py --check`, `rfc_enforcer.py`. 셋 다 경로 리터럴을 보지 않는다.

**문서 변경도 저장소 전역 ratchet 의 대상이다.** 파일의 종류로 게이트를 고른 것이 틀렸다 — ratchet 이 실제로 무엇을 스캔하는지로 골라야 했다.

## 검증

```
bash scripts/check-ssot.sh                 # SSOT_EXIT=0, R6 1 occurrences (baseline 1)
python3 scripts/rfc-generate-index.py --check   # OK
python3 scripts/rfc_enforcer.py ...        # Checked 1 RFC file(s), 1 passed
bash scripts/check-doc-truth.sh            # OK
```

RFC-WAIVED: 머지된 RFC 본문의 경로 리터럴 한 줄을 고치는 변경이다. 설계 결정은 #28459 에서 이미 이루어졌고 이 PR 은 그 문서가 저장소 ratchet 을 통과하게만 한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3Ek71sn9DrrT4japMSNQs
