### PR TITLE
fix(runtime): reject bindings that name an undeclared provider or model

### DIFF
--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -61,13 +61,40 @@ let quota_scope_of_materialized
   Runtime_quota_window.scope_of_credential ~provider_id:provider.id credential
 ;;
 
-let of_binding (cfg : config) (b : binding) : (t, string) result =
+(* Why a binding did not become a runtime, as a closed vocabulary rather than a
+   string. The distinction the variant makes is the one the config loader has to
+   act on: [Binding_disabled] and [Provider_disabled] are choices the operator
+   wrote down, [Execution_unbuildable] is a capability limit of the adapter, and
+   the two [*_not_declared] cases are dangling references — the binding names a
+   [\[providers.x\]] or [\[models.y\]] row that does not exist. Collapsing all
+   five into one string is what let a dangling reference be dropped as quietly as
+   a deliberate disable (masc#28403): a [local_llama_server.qwen3-6-35b-uncensored]
+   binding pointed at a model row an unquoted dot had split into
+   [models.qwen3."6-35b-uncensored"], and nothing reported the runtime's absence.
+   Deciding fatality by matching the reason string would be the same defect one
+   layer up, so the vocabulary is closed and {!load_list} matches it. *)
+type drop_reason =
+  | Binding_disabled
+  | Provider_disabled of string (* provider id *)
+  | Provider_not_declared of string (* provider id the binding names *)
+  | Model_not_declared of string (* model id the binding names *)
+  | Execution_unbuildable of string (* adapter's own reason *)
+
+let string_of_drop_reason = function
+  | Binding_disabled -> "binding is disabled by runtime.toml"
+  | Provider_disabled id -> Printf.sprintf "provider %S is disabled by runtime.toml" id
+  | Provider_not_declared id -> Printf.sprintf "provider not found: %s" id
+  | Model_not_declared id -> Printf.sprintf "model not found: %s" id
+  | Execution_unbuildable reason -> reason
+;;
+
+let of_binding (cfg : config) (b : binding) : (t, drop_reason) result =
   if not b.enabled
-  then Error "binding is disabled by runtime.toml"
+  then Error Binding_disabled
   else match provider_of_id cfg b.provider_id, model_of_id cfg b.model_id with
   | Some provider, Some model ->
     if not provider.enabled
-    then Error (Printf.sprintf "provider %S is disabled by runtime.toml" provider.id)
+    then Error (Provider_disabled provider.id)
     else
       (match Runtime_adapter.binding_to_execution cfg b with
        | Ok execution ->
@@ -79,9 +106,9 @@ let of_binding (cfg : config) (b : binding) : (t, string) result =
            ; execution
            ; quota_scope = quota_scope_of_materialized ~provider ~execution
            }
-       | Error reason -> Error reason)
-  | None, _ -> Error (Printf.sprintf "provider not found: %s" b.provider_id)
-  | Some _, None -> Error (Printf.sprintf "model not found: %s" b.model_id)
+       | Error reason -> Error (Execution_unbuildable reason))
+  | None, _ -> Error (Provider_not_declared b.provider_id)
+  | Some _, None -> Error (Model_not_declared b.model_id)
 ;;
 
 let is_local_provider (provider : provider) =
@@ -104,7 +131,7 @@ let is_local_runtime (runtime : t) = is_local_provider runtime.provider
    typo that does not exist. Materialize failure stays fail-closed: the binding
    is still excluded from [runtimes] (RFC-0206 §2.1). *)
 let partition_bindings (cfg : config) (bindings : binding list)
-  : t list * (string * string) list
+  : t list * (string * drop_reason) list
   =
   let runtimes, dropped =
     List.fold_left
@@ -125,14 +152,51 @@ let partition_bindings (cfg : config) (bindings : binding list)
    runtimes" wording. The result is the suffix that follows the quoted id in
    each caller's message, so the existing prefix ("[runtime.assignments].<k> =
    <id>") is preserved and the typo case stays byte-for-byte unchanged. *)
-let unresolved_runtime_suffix ~(dropped_bindings : (string * string) list)
+let unresolved_runtime_suffix ~(dropped_bindings : (string * drop_reason) list)
     ~(runtime_count : int) (id : string) : string =
   match List.assoc_opt id dropped_bindings with
   | Some reason ->
     Printf.sprintf
       ": binding is defined but could not be materialized as a runtime — %s"
-      reason
+      (string_of_drop_reason reason)
   | None -> Printf.sprintf " not found among %d runtimes" runtime_count
+;;
+
+(* A dangling reference is an operator typo, and unlike every other drop reason
+   it is not survivable by ignoring the binding: the runtime the operator
+   declared simply does not exist, and nothing downstream will say so unless the
+   id happens to be referenced by an assignment, route, or lane. Reporting it
+   here — at load, over the whole binding list — is what makes the absence
+   visible without a reference to hang the message on (masc#28403). The other
+   three reasons stay non-fatal: they keep the RFC-0206 §2.1 contract that a
+   binding MASC cannot run is excluded rather than fatal. *)
+let dangling_reference_reason = function
+  | Provider_not_declared id ->
+    Some (Printf.sprintf "names provider %S, which has no [providers.%s] row" id id)
+  | Model_not_declared id ->
+    Some (Printf.sprintf "names model %S, which has no [models.%s] row" id id)
+  | Binding_disabled | Provider_disabled _ | Execution_unbuildable _ -> None
+;;
+
+let validate_no_dangling_bindings ~(config_path : string)
+    ~(dropped_bindings : (string * drop_reason) list) : (unit, string) result =
+  match
+    List.filter_map
+      (fun (id, reason) ->
+        Option.map
+          (fun why -> Printf.sprintf "  %s %s" id why)
+          (dangling_reference_reason reason))
+      dropped_bindings
+  with
+  | [] -> Ok ()
+  | dangling ->
+    Error
+      (Printf.sprintf
+         "%s: %d binding(s) reference a provider or model that is not declared, \
+          so the runtime they define does not exist:\n%s"
+         config_path
+         (List.length dangling)
+         (String.concat "\n" dangling))
 ;;
 
 (** TOML 에서 Runtime 목록과 default Runtime 을 로드한다.
@@ -173,7 +237,7 @@ type runtime_reference =
   }
 
 let validate_runtime_references ~(config_path : string)
-    ~(dropped_bindings : (string * string) list) (runtimes : t list)
+    ~(dropped_bindings : (string * drop_reason) list) (runtimes : t list)
     (lanes : Runtime_lane.t list) (references : runtime_reference list)
   : (unit, string) result
   =
@@ -248,7 +312,7 @@ let media_failover_references (media_failover : string list) =
    Empty candidate lists are rejected at parse time; here we reject unknown ids
    as operator typos (mirrors [runtime].default validation). *)
 let validate_lanes ~(config_path : string)
-    ~(dropped_bindings : (string * string) list) (runtimes : t list)
+    ~(dropped_bindings : (string * drop_reason) list) (runtimes : t list)
     (lane_decls : Runtime_schema.lane_decl list)
   : (unit, string) result
   =
@@ -276,7 +340,7 @@ let validate_lanes ~(config_path : string)
 ;;
 
 let lanes_of_decls ~(config_path : string)
-    ~(dropped_bindings : (string * string) list) (runtimes : t list)
+    ~(dropped_bindings : (string * drop_reason) list) (runtimes : t list)
     (lane_decls : Runtime_schema.lane_decl list)
   : (Runtime_lane.t list, string) result
   =
@@ -959,6 +1023,10 @@ let materialize_config
     result
   =
   let runtimes, dropped_bindings = partition_bindings cfg cfg.bindings in
+  (* Ahead of default / assignment / route validation on purpose: a dangling
+     binding makes a runtime the operator declared not exist, and the messages
+     below can only describe an id something else referenced. *)
+  let* () = validate_no_dangling_bindings ~config_path ~dropped_bindings in
   let assignments = cfg.keeper_assignments in
   let* rt =
     match cfg.default_runtime_id with

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -22,7 +22,25 @@ type t =
   }
 
 val id_of_binding : binding -> string
-val of_binding : config -> binding -> (t, string) result
+
+type drop_reason =
+  | Binding_disabled
+  | Provider_disabled of string
+  | Provider_not_declared of string
+  | Model_not_declared of string
+  | Execution_unbuildable of string
+      (** Why a binding did not become a runtime. Closed so consumers decide per
+          case instead of matching the rendered text: the [*_not_declared] pair
+          is a dangling reference (an operator typo, fatal at
+          {!load_list}), while a disabled binding or provider is a choice the
+          operator wrote down and [Execution_unbuildable] is an adapter
+          capability limit — both non-fatal, per RFC-0206 §2.1. *)
+
+val string_of_drop_reason : drop_reason -> string
+(** Operator-facing rendering. Single source for the wording, so a reason read
+    from a runtime message and one read from a load error cannot drift. *)
+
+val of_binding : config -> binding -> (t, drop_reason) result
 (** Materialize one binding while preserving failure information. [Error reason]
     when the binding is disabled, its provider/model id is unresolved, or the
     provider transport/protocol cannot be materialized into a

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -4,8 +4,10 @@
     layers 1-3 plus [[runtime].default] into a self-standing
     {!Runtime_schema.config}. Reserved top-level namespaces: providers,
     models, runtime, web_search. Dropped routing namespaces system, routes, and
-    profiles are rejected rather than ignored. Any other top-level table is a provider table, with
-    sub-tables as model bindings.
+    profiles are rejected rather than ignored. A top-level table whose name
+    [\[providers\]] declares carries that provider's model bindings as
+    sub-tables; every other top-level table belongs to a different parser and is
+    left alone.
 
     Routing layers are intentionally NOT parsed (see {!Runtime_toml} mli):
     Layer 4 aliases, Layer 5 routes/system/profiles, and the
@@ -1189,16 +1191,35 @@ let parse_provider_table (provider_id : string) (tbl : Otoml.t)
        entries)
 ;;
 
+(* Top-level table names that own a binding group, taken from the [\[providers\]]
+   keys as written rather than from successfully parsed providers: a malformed
+   provider row must be reported as a provider error, not silently reclassify its
+   bindings as some other namespace. *)
+let declared_provider_ids (toml : Otoml.t) : string list =
+  match Otoml.find_opt toml Fun.id [ "providers" ] with
+  | Some (Otoml.TomlTable entries | Otoml.TomlInlineTable entries) -> List.map fst entries
+  | Some _ | None -> []
+;;
+
 let parse_bindings (toml : Otoml.t)
   : (Runtime_schema.binding list, parse_error list) result
   =
   let top_entries = Otoml.get_table toml in
-  (* Only top-level tables can describe a provider; scalar / array entries
-     (e.g. an operator-authored ["comment = ..."]) would crash
-     [Otoml.get_table] in [parse_provider_table]. *)
+  let declared = declared_provider_ids toml in
+  (* A top-level table describes a provider's bindings only when [\[providers\]]
+     declares that provider. The namespace used to be defined by exclusion —
+     anything not on the reserved list — which made every unrelated config
+     section a phantom binding group: [\[voice.tts\]] and [\[fusion.presets\]]
+     each parsed as a binding whose provider did not exist, and the loader had to
+     drop unresolved bindings quietly for boot to survive them. That silence is
+     what hid a real dangling reference (masc#28403). Naming the namespace
+     positively lets {!Runtime.load_list} treat an unresolved binding as the typo
+     it is. Scalar / array entries are still excluded because
+     [parse_provider_table] would crash on them. *)
   let provider_tables =
     List.filter
-      (fun (name, value) -> (not (is_reserved name)) && is_toml_table value)
+      (fun (name, value) ->
+        (not (is_reserved name)) && is_toml_table value && List.mem name declared)
       top_entries
   in
   Result.map

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -2438,6 +2438,161 @@ let test_runtime_binding_disable_excludes_only_that_binding () =
         (String_util.contains_substring msg "disabled by runtime.toml"))
 ;;
 
+(* masc#28403. The runtime this declares — [local.typo] — cannot exist, because
+   no [models.typo] row does. Nothing references it, which is the whole point:
+   before this was a load error the only way a dangling binding surfaced was an
+   assignment / route / lane naming it, so an unreferenced one vanished in
+   silence. A live [local_llama_server.qwen3-6-35b-uncensored] binding did
+   exactly that for an unknown length of time, and was found only by parsing the
+   TOML with a separate script. *)
+let test_binding_naming_an_undeclared_model_fails_the_load () =
+  let runtime_toml =
+    "[providers.local]\n\
+     protocol = \"openai-compatible-http\"\n\
+     endpoint = \"http://127.0.0.1:1/v1\"\n\
+     \n\
+     [models.good]\n\
+     api-name = \"good\"\n\
+     max-context = 1024\n\
+     \n\
+     [local.good]\n\
+     [local.typo]\n\
+     \n\
+     [runtime]\n\
+     default = \"local.good\"\n"
+  in
+  with_temp_runtime_toml runtime_toml (fun path ->
+    match Runtime.load_list ~config_path:path with
+    | Ok (runtimes, _, _, _, _, _) ->
+      failf
+        "binding naming an undeclared model must fail the load; got runtimes [%s]"
+        (String.concat "; " (List.map (fun (r : Runtime.t) -> r.id) runtimes))
+    | Error msg ->
+      check bool "error names the dangling binding" true
+        (String_util.contains_substring msg "local.typo");
+      check bool "error names the missing model row" true
+        (String_util.contains_substring msg "[models.typo]"))
+;;
+
+(* The other half of masc#28403: the binding namespace is now the set of
+   declared providers, not "every top-level table that is not reserved". Both
+   tables below exist in the live runtime.toml and are read by other parsers;
+   under the old exclusion rule each parsed as a binding whose provider did not
+   exist, which is why an unresolved binding had to be dropped quietly for boot
+   to survive at all. If this test fails with a dangling-binding error, the
+   namespace has been re-opened and the check above is load-bearing for config
+   sections it was never meant to judge. *)
+let test_non_provider_namespaces_are_not_bindings () =
+  let runtime_toml =
+    "[providers.local]\n\
+     protocol = \"openai-compatible-http\"\n\
+     endpoint = \"http://127.0.0.1:1/v1\"\n\
+     \n\
+     [models.good]\n\
+     api-name = \"good\"\n\
+     max-context = 1024\n\
+     \n\
+     [local.good]\n\
+     \n\
+     [voice.local_playback]\n\
+     enabled = true\n\
+     \n\
+     [fusion.presets]\n\
+     quorum = \"three\"\n\
+     \n\
+     [runtime]\n\
+     default = \"local.good\"\n"
+  in
+  with_temp_runtime_toml runtime_toml (fun path ->
+    match Runtime.load_list ~config_path:path with
+    | Error msg -> failf "non-provider namespaces must not be bindings: %s" msg
+    | Ok (runtimes, _, _, _, _, _) ->
+      check (list string) "only the declared provider binds a runtime"
+        [ "local.good" ]
+        (List.map (fun (runtime : Runtime.t) -> runtime.id) runtimes))
+;;
+
+(* RFC-0206 §2.1 is unchanged by the above: a binding MASC is told not to run is
+   still excluded rather than fatal. Only a dangling reference — a runtime that
+   cannot exist — is fatal, so this asserts the two classes stayed apart rather
+   than the load simply becoming stricter. *)
+let test_deliberate_disable_is_still_a_tolerated_drop () =
+  let runtime_toml =
+    "[providers.local]\n\
+     protocol = \"openai-compatible-http\"\n\
+     endpoint = \"http://127.0.0.1:1/v1\"\n\
+     \n\
+     [providers.dormant]\n\
+     enabled = false\n\
+     protocol = \"openai-compatible-http\"\n\
+     endpoint = \"http://127.0.0.1:2/v1\"\n\
+     \n\
+     [models.good]\n\
+     api-name = \"good\"\n\
+     max-context = 1024\n\
+     \n\
+     [local.good]\n\
+     [local.off]\n\
+     enabled = false\n\
+     [dormant.good]\n\
+     \n\
+     [models.off]\n\
+     api-name = \"off\"\n\
+     max-context = 1024\n\
+     \n\
+     [runtime]\n\
+     default = \"local.good\"\n"
+  in
+  with_temp_runtime_toml runtime_toml (fun path ->
+    match Runtime.load_list ~config_path:path with
+    | Error msg -> failf "deliberate disables must not fail the load: %s" msg
+    | Ok (runtimes, _, _, _, _, _) ->
+      check (list string) "disabled binding and disabled provider are excluded"
+        [ "local.good" ]
+        (List.map (fun (runtime : Runtime.t) -> runtime.id) runtimes))
+;;
+
+(* [Provider_not_declared] is unreachable from TOML once the namespace is closed
+   — a table under an undeclared provider is no longer read as a binding at all
+   — so it is exercised at its own boundary rather than left as a variant no
+   test constructs. *)
+let test_of_binding_reports_an_undeclared_provider () =
+  let cfg =
+    { Runtime_schema.providers = []
+    ; models = []
+    ; bindings = []
+    ; default_runtime_id = None
+    ; cross_verifier_runtime_id = None
+    ; keeper_assignments = []
+    ; media_failover = []
+    ; lane_decls = []
+    ; exact_output_lane_decls = []
+    }
+  in
+  let binding =
+    { Runtime_schema.provider_id = "absent"
+    ; model_id = "whatever"
+    ; enabled = true
+    ; is_default = false
+    ; wizard_default = false
+    ; max_concurrent = None
+    ; max_request_body_bytes = None
+    ; price_input = None
+    ; price_output = None
+    ; keep_alive = None
+    ; num_ctx = None
+    }
+  in
+  match Runtime.of_binding cfg binding with
+  | Ok _ -> fail "binding with an undeclared provider must not materialize"
+  | Error (Runtime.Provider_not_declared id) ->
+    check string "reports the provider it could not find" "absent" id
+  | Error other ->
+    failf
+      "expected Provider_not_declared, got %s"
+      (Runtime.string_of_drop_reason other)
+;;
+
 let test_runtime_toml_rejects_non_boolean_enabled () =
   let runtime_toml =
     "[providers.local]\n\
@@ -3891,6 +4046,14 @@ let () =
             test_runtime_provider_disable_excludes_its_bindings;
           test_case "disabled binding is excluded and rejected when referenced" `Quick
             test_runtime_binding_disable_excludes_only_that_binding;
+          test_case "unreferenced binding naming an undeclared model fails the load"
+            `Quick test_binding_naming_an_undeclared_model_fails_the_load;
+          test_case "non-provider top-level namespaces are not bindings" `Quick
+            test_non_provider_namespaces_are_not_bindings;
+          test_case "deliberate disables stay tolerated drops" `Quick
+            test_deliberate_disable_is_still_a_tolerated_drop;
+          test_case "of_binding reports an undeclared provider" `Quick
+            test_of_binding_reports_an_undeclared_provider;
           test_case "runtime enabled fields require booleans" `Quick
             test_runtime_toml_rejects_non_boolean_enabled;
           test_case

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -1171,7 +1171,10 @@ let runtime_or_fail ?(provider = runpod_provider) () =
   in
   match Runtime.of_binding cfg runpod_binding with
   | Ok runtime -> runtime
-  | Error reason -> failf "expected runtime binding to materialize: %s" reason
+  | Error reason ->
+    failf
+      "expected runtime binding to materialize: %s"
+      (Runtime.string_of_drop_reason reason)
 
 let test_runtime_of_binding_preserves_failure_reason () =
   let cfg =
@@ -1188,9 +1191,14 @@ let test_runtime_of_binding_preserves_failure_reason () =
   in
   match Runtime.of_binding cfg { runpod_binding with enabled = false } with
   | Ok _ -> fail "expected disabled binding materialization to fail"
-  | Error reason ->
+  | Error Runtime.Binding_disabled ->
     check string "disabled binding reason"
-      "binding is disabled by runtime.toml" reason
+      "binding is disabled by runtime.toml"
+      (Runtime.string_of_drop_reason Runtime.Binding_disabled)
+  | Error other ->
+    failf
+      "expected Binding_disabled, got %s"
+      (Runtime.string_of_drop_reason other)
 
 let with_dashboard_probe_http_get hook f =
   Server_dashboard_http_runtime_info.set_dashboard_runtime_provider_http_get_for_tests


### PR DESCRIPTION
Closes #28403.

## 증상

`runtime.toml` 이 선언한 런타임 하나가 materialize 되지 않는데 **에러도 경고도 없다**. 47 선언 → 46 materialize. 빠진 것은 `local_llama_server.qwen3-6-35b-uncensored` 이고, 모델 키의 따옴표 없는 점이 `[models.qwen3."6-35b-uncensored"]` 로 쪼개져 바인딩이 참조할 대상이 사라진 것이다.

이 런타임은 dispatchable 에도 blocked 에도 없었다 — 2026-08-12 의 39-런타임 실측에서 측정 대상 목록에서 통째로 빠졌고, 별도 스크립트로 TOML 을 파싱하기 전까지 아무도 몰랐다.

## 왜 조용했나

드롭 사유가 `string` 이었다. `of_binding` 은 다섯 가지 서로 다른 사유를 한 타입에 압축한다:

```
"binding is disabled by runtime.toml"       ← 운영자가 적어둔 선택
"provider %S is disabled by runtime.toml"   ← 운영자가 적어둔 선택
<adapter 의 사유>                            ← 어댑터 능력 한계
"provider not found: %s"                    ← dangling reference (오타)
"model not found: %s"                       ← dangling reference (오타)
```

하류가 이 다섯을 구분할 방법이 없으니 정책도 하나뿐이었다 — 전부 조용히 드롭. dangling 만 골라 치명적으로 만들려면 사유 문자열을 매칭해야 하는데, 그건 CLAUDE.md 가 금지하는 문자열 분류기를 한 층 위에서 다시 만드는 것이다.

그리고 드롭이 관대해야만 했던 진짜 이유가 따로 있었다. **바인딩 네임스페이스가 배제로 정의돼 있다** — `parse_bindings` 는 예약어가 아닌 모든 최상위 테이블을 프로바이더로 읽는다. 그래서 `[voice.tts]`, `[voice.stt]`, `[voice.session]`, `[voice.local_playback]`, `[fusion.presets]` 다섯이 지금 프로바이더 `voice` / `fusion` 의 바인딩으로 파싱되고 있고, 각각 `provider not found` 로 드롭되고 있다. 이 다섯이 조용히 드롭되지 않으면 부팅이 안 된다.

즉 열린 어휘가 관대한 드롭을 강제했고, 관대한 드롭이 진짜 오타를 가렸다.

## 변경

**1. 네임스페이스를 닫는다** (`runtime_toml.ml`). 최상위 테이블이 바인딩 그룹인 것은 그 이름을 `[providers]` 가 선언했을 때뿐이다. `[voice.*]` 와 `[fusion.presets]` 는 이제 유령 바인딩이 아니라 그냥 다른 파서의 섹션이다.

프로바이더 id 는 `parse_providers` 의 성공 결과가 아니라 `[providers]` 의 **키에서** 읽는다. 프로바이더 행 하나가 malformed 일 때 그 바인딩들이 갑자기 "다른 네임스페이스"로 재분류되면 안 되기 때문이다 — 그건 프로바이더 에러로 보고돼야 한다.

**2. 드롭 사유를 닫힌 variant 로** (`runtime.ml`). `of_binding : config -> binding -> (t, drop_reason) result`.

```ocaml
type drop_reason =
  | Binding_disabled
  | Provider_disabled of string
  | Provider_not_declared of string
  | Model_not_declared of string
  | Execution_unbuildable of string
```

렌더링은 `string_of_drop_reason` 하나로 모았다. 런타임 메시지에서 읽은 사유와 로드 에러에서 읽은 사유가 어긋날 수 없다.

**3. dangling 은 로드 에러** (`load_list`). `*_not_declared` 두 경우만 치명적이고, 나머지 셋은 RFC-0206 §2.1 대로 비치명적 제외를 유지한다. 검사는 default / assignment / route 검증 **앞**에 둔다 — 그 아래 메시지들은 무언가가 참조한 id 만 설명할 수 있고, 이 사고의 핵심은 아무도 참조하지 않았다는 것이다.

## 검증

```
test_runtime_config_validity        78 tests   OK   (+4)
test_runtime_provider_auth_headers  41 tests   OK
test_runtime_per_keeper_routing      5 tests   OK
test_runtime_claude_code_config     50 tests   OK
dune build (전체)                    exit 0
```

새 케이스 4개:

| 케이스 | 증명 |
|---|---|
| `unreferenced binding naming an undeclared model fails the load` | 아무도 참조하지 않는 dangling 이 로드에서 잡힌다 |
| `non-provider top-level namespaces are not bindings` | `[voice.local_playback]` · `[fusion.presets]` 가 있어도 로드 성공 |
| `deliberate disables stay tolerated drops` | disabled binding / disabled provider 는 그대로 관대 |
| `of_binding reports an undeclared provider` | 네임스페이스를 닫으면 TOML 에서 도달 불가해지는 variant 를 자기 경계에서 검증 |

**변이 검증** (구현만 되돌리고 재실행):

- `load_list` 의 dangling 검사 제거 → `FAIL binding naming an undeclared model must fail the load; got runtimes [local.good]`. 신고된 결함이 그대로 재현된다 — 선언한 런타임이 조용히 사라지고 로드는 성공한다.
- 네임스페이스 재개방 → **4 failures**, 그중 하나가 `repo runtime.toml should load: ... 5 binding(s) reference a provider or model that is not declared`. 레포 자신의 `config/runtime.toml` 이 로드에 실패한다. 두 절반이 결합돼 있다는 증거이고, 네임스페이스를 닫지 않은 채 dangling 검사만 넣었으면 부팅이 깨졌을 것이다.

## 범위

이슈의 제안 2번(`api-name` 없는 `[models.X]` 거부)은 포함하지 않았다. 라이브 설정과 레포 설정 모두 `api-name` 없는 모델 행이 0건이라 지금은 관측된 사고가 없고, 1번만으로 이 사고는 로드 시점에 잡힌다 — 이슈 본문의 판단과 같다. 별도 판단이 필요하면 이슈에 남긴다.

설정 파일 자체의 오타는 이미 고쳐져 있다 (`~/me/.masc/config/runtime.toml`, git 미추적). 이 PR 은 그 오타를 다시 저지를 때 로더가 잡도록 만드는 것이다.

RFC-WAIVED: credential / identity / operator control plane / keeper sandbox / dashboard credential / hooks / workflow 어느 subsystem 도 건드리지 않는다. runtime TOML 파서와 런타임 목록 로더, 그리고 그 테스트만 바뀐다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
