### PR TITLE
fix(dashboard): bound the harness-health read when a date filter is given

### DIFF
--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -173,6 +173,14 @@ let date_bounds ?since ?until () =
   since, until
 ;;
 
+(* Both branches read at most [max_signal_scan] rows. They did not: the
+   unfiltered branch was bounded and the filtered one was not, so supplying a
+   date — which a caller does to narrow the result — removed the row cap and
+   scanned every day-file in range. A one-sided bound widens further, since the
+   missing side is filled with 2020-01-01 / 2099-12-31 below.
+
+   [read_range_recent] is the bounded reader for a date range and takes the
+   same cap the unfiltered branch already uses. *)
 let read_store_records store ?since ?until () =
   let since, until = date_bounds ?since ?until () in
   if since = "" && until = ""
@@ -180,7 +188,11 @@ let read_store_records store ?since ?until () =
   else (
     let start_date = if since = "" then "2020-01-01" else since in
     let end_date = if until = "" then "2099-12-31" else until in
-    Dated_jsonl.read_range store ~since:start_date ~until:end_date)
+    Dated_jsonl.read_range_recent
+      store
+      ~since:start_date
+      ~until:end_date
+      max_signal_scan)
 ;;
 
 let has_any_records store = Dated_jsonl.read_recent store 1 <> []
@@ -590,7 +602,12 @@ let read_keeper_metric_records ?since ?until (config : Workspace.config) keeper_
     let since, until = date_bounds ?since ?until () in
     let start_date = if since = "" then "2020-01-01" else since in
     let end_date = if until = "" then "2099-12-31" else until in
-    Dated_jsonl.read_range store ~since:start_date ~until:end_date
+    (* Same cap as the unfiltered branch below; see [read_store_records]. *)
+    Dated_jsonl.read_range_recent
+      store
+      ~since:start_date
+      ~until:end_date
+      max_signal_scan
   | None, None -> Dated_jsonl.read_recent store max_signal_scan
 ;;
 

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=659
+UNWIRED_BASELINE=658
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -137,6 +137,7 @@ normal_targets=(
   @test/runtest-test_keeper_secret_redaction
   @test/runtest-test_keeper_sandbox_docker_route
   @test/runtest-test_dashboard_dev_token_host_gate
+  @test/runtest-test_dashboard_harness_health
   @test/runtest-test_telemetry_unified_keeper_fan_in
   @test/runtest-test_dated_jsonl
   @test/runtest-test_audit_log

--- a/test/test_dashboard_harness_health.ml
+++ b/test/test_dashboard_harness_health.ml
@@ -44,6 +44,35 @@ let record_wake_payload ~trace_id =
     ~role_counts:[ "user", 1; "assistant", 2 ]
     ~tool_count:4
 
+(* The reader capped an unfiltered read and did not cap a filtered one, so
+   supplying a date — which narrows the request — removed the row bound and
+   scanned every day-file in range. Both branches must read at most the same
+   number of rows. The cap's value is deliberately not asserted here: the
+   invariant is that a filter cannot widen the read. *)
+let test_a_date_filter_does_not_remove_the_row_cap () =
+  reset_after @@ fun () ->
+  with_temp_dir "wake-payload-cap" @@ fun dir ->
+  H.set_wake_payload_store_for_testing ~base_dir:dir;
+  let store = H.get_wake_payload_store () in
+  ignore (record_wake_payload ~trace_id:"cap-seed");
+  (* Copy the recorded row instead of hand-writing the schema, so this test
+     does not need editing when the event shape changes. *)
+  let template =
+    match Dated_jsonl.read_recent store 1 with
+    | [ row ] -> row
+    | _ -> fail "expected exactly one seeded row"
+  in
+  let seeded = 600 in
+  for _ = 1 to seeded do
+    Dated_jsonl.append store template
+  done;
+  let unfiltered = List.length (H.read_wake_payload_events ()) in
+  let filtered = List.length (H.read_wake_payload_events ~since:"2020-01-01" ()) in
+  check bool "the unfiltered read is capped below what was seeded" true
+    (unfiltered <= seeded);
+  check int "a date filter reads no more than an unfiltered read" unfiltered
+    filtered
+
 let test_wake_payload_store_round_trip () =
   reset_after @@ fun () ->
   with_temp_dir "wake-payload-store" @@ fun dir ->
@@ -150,6 +179,8 @@ let () =
       ( "runtime_stores",
         [
           test_case "wake payload round trip" `Quick test_wake_payload_store_round_trip;
+          test_case "a date filter does not remove the row cap" `Quick
+            test_a_date_filter_does_not_remove_the_row_cap;
           test_case "wake payload reset rebinds store" `Quick
             test_reset_rebinds_wake_payload_store;
           test_case "malformed exact records are rejected" `Quick


### PR DESCRIPTION
Found while measuring RFC-0375's gating question (#28469). The row bound in `Dashboard_harness_health` is attached to the wrong branch.

## The defect

```ocaml
let read_store_records store ?since ?until () =
  let since, until = date_bounds ?since ?until () in
  if since = "" && until = ""
  then Dated_jsonl.read_recent store max_signal_scan    (* bounded: 500 rows *)
  else (
    let start_date = if since = "" then "2020-01-01" else since in
    let end_date = if until = "" then "2099-12-31" else until in
    Dated_jsonl.read_range store ~since:start_date ~until:end_date)   (* no bound *)
```

`Dated_jsonl.read_range` carries no row bound in its signature:

```ocaml
val read_range : t -> since:string -> until:string -> Yojson.Safe.t list
```

So supplying a date — which a caller does to *narrow* the request — removes the only cap on the read. A one-sided bound widens it further, because the missing side is filled with `2020-01-01` / `2099-12-31`: a request carrying just `since` scans every day-file in the store, unbounded in rows.

`read_keeper_metric_records` (same file) has the identical shape.

## The fix

`Dated_jsonl.read_range_recent` is the bounded range reader and already exists. Its own documentation prescribes this exact substitution:

> use it instead of `read_range` when a result bound exists and the window may span large stores

It takes the same `max_signal_scan` the unfiltered branch already uses, and returns oldest-first within the collected set — matching `read_recent`, so the two branches keep the same order contract.

**Behaviour change**: a filtered read over a store holding more than `max_signal_scan` rows in range now returns the newest 500 rather than all of them. That is the intent — the unfiltered branch has always behaved this way — but it is a truncation that did not happen before, and a caller that depended on completeness through a date filter would see fewer rows.

## Verification (local)

| check | result |
|---|---|
| `dune build --root . test/test_dashboard_harness_health.exe` | `BUILD_EXIT=0` |
| `test_dashboard_harness_health.exe` with the fix | **5 tests run, Test Successful** |
| same test with the fix reverted (mutation) | **1 failure** — `a date filter reads no more than an unfiltered read` |
| fix restored | 5 tests run, Test Successful |
| `scripts/audit-ci-test-targets.sh` | OK — 202 CI targets all declared, 658 unwired at baseline |
| `dune build --root . @fmt` | no diff on any file this PR touches |

The mutation run is the point: the test was reverted against the original unbounded reader and exactly one case went red, so it detects this defect rather than merely describing the new behaviour.

The test seeds 600 rows by **copying a row the public API recorded**, so it does not hard-code the event schema and will not need editing when that shape changes. It asserts the invariant, not the constant: `filtered = unfiltered`, plus "some cap applies". Pinning `500` would make every future tuning of `max_signal_scan` a test failure, and a test that breaks on intended changes stops being read.

`test_dashboard_harness_health` compiled in CI but ran in no suite; added to the focused allowlist and `UNWIRED_BASELINE` lowered 659 → 658.

## Not claimed

No RSS or latency number. The RFC-0372 §5 gate needs the idle p95 ≤ 50 ms control; measured on this host it is 171 ms, so any run now must be discarded. The claim here is structural: an unbounded read became bounded, and the bound is the one the sibling branch already used.

RFC-WAIVED: `lib/dashboard/dashboard_harness_health.ml`, one test file, and the CI test allowlist. None of the RFC-required subsystems. Direction is set by existing RFC-0372 (§4 Phase 1, "delete the unbounded contract").

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
