### PR TITLE
fix(dashboard): date the two feature-proof counters that still latch

### DIFF
--- a/lib/dashboard/dashboard_keeper_feature_proof.ml
+++ b/lib/dashboard/dashboard_keeper_feature_proof.ml
@@ -112,16 +112,52 @@ let meta_feature_json
     ("next_action", `String next_action);
   ]
 
+let timestamp_within_window ?window_hours ~now ts =
+  (* Reject zero/negative timestamps (marker/unset) and future timestamps
+     (clock skew or corrupted logs). Without the [ts <= now] guard, any
+     future timestamp would satisfy the recency check because [now -. ts]
+     would be negative and trivially [<= hours *. 3600.0]. *)
+  ts > 0.0
+  && ts <= now
+  &&
+  match window_hours with
+  | None -> true
+  | Some hours when hours <= 0.0 ->
+    (* Non-positive window is treated as "no recency check": flipping it
+       to a hard reject would silently disqualify all past evidence. The
+       top-level [json] helper clamps callers' inputs to a sane domain;
+       this keeps internal logic robust if a caller bypasses the boundary. *)
+    true
+  | Some hours -> now -. ts <= hours *. Masc_time_constants.hour
+
+(* Every counter in keeper meta is a lifetime total: once it passes zero it
+   stays positive for the rest of the keeper's life. A feature that asks only
+   "is this counter above zero" therefore reports a stopped keeper as present
+   forever — a 26-hour-paused keeper passed [runtime_liveness] on the live
+   fleet (#27947).
+
+   [last_activity] dates the counter, and the window is applied here rather
+   than inside each [predicate] so that adding a counter feature requires
+   naming the timestamp that dates it. A predicate cannot opt out. *)
 let meta_counter_feature
       snapshots
       ~id
       ~label
       ~eligible
+      ~now
+      ~last_activity
       ~predicate
       ~summary_label
       ~evidence_refs
       ~next_action
   =
+  let predicate meta =
+    predicate meta
+    && timestamp_within_window
+         ~window_hours:Decision.recent_turn_max_age_hours
+         ~now
+         (last_activity meta)
+  in
   let eligible_snapshots = List.filter eligible snapshots in
   let total = keeper_count eligible_snapshots in
   let observed =
@@ -157,40 +193,14 @@ let meta_counter_feature
     ~next_action
     eligible_snapshots
 
-let timestamp_within_window ?window_hours ~now ts =
-  (* Reject zero/negative timestamps (marker/unset) and future timestamps
-     (clock skew or corrupted logs). Without the [ts <= now] guard, any
-     future timestamp would satisfy the recency check because [now -. ts]
-     would be negative and trivially [<= hours *. 3600.0]. *)
-  ts > 0.0
-  && ts <= now
-  &&
-  match window_hours with
-  | None -> true
-  | Some hours when hours <= 0.0 ->
-    (* Non-positive window is treated as "no recency check": flipping it
-       to a hard reject would silently disqualify all past evidence. The
-       top-level [json] helper clamps callers' inputs to a sane domain;
-       this keeps internal logic robust if a caller bypasses the boundary. *)
-    true
-  | Some hours -> now -. ts <= hours *. Masc_time_constants.hour
-
 let runtime_liveness_feature ~now snapshots =
   meta_counter_feature snapshots
     ~id:"runtime_liveness"
     ~label:"Persisted keeper runtime turns"
     ~eligible:(fun _snapshot -> true)
-    ~predicate:(fun meta ->
-       (* A lifetime counter latches: once [total_turns] passes zero it stays
-          positive for the rest of the keeper's life, so a counter-only
-          predicate reports a stopped keeper as live forever. This feature is
-          named liveness, so it also requires the last persisted turn to be
-          recent, using the same window as [persistent_24h_turn_exchange]. *)
-       meta.runtime.usage.total_turns > 0
-       && timestamp_within_window
-            ~window_hours:Decision.recent_turn_max_age_hours
-            ~now
-            meta.runtime.usage.last_turn_ts)
+    ~now
+    ~last_activity:(fun meta -> meta.runtime.usage.last_turn_ts)
+    ~predicate:(fun meta -> meta.runtime.usage.total_turns > 0)
     ~summary_label:
       (Printf.sprintf
          "keepers have persisted runtime turns with a latest turn <= %.1fh old"
@@ -274,11 +284,19 @@ let persistent_turn_exchange_feature ~config ~now snapshots =
         "Keep the runtime running until every keeper has decision-log turn evidence spanning at least 24h with a recent latest turn." );
   ]
 
-let autonomous_tool_feature snapshots =
+let autonomous_tool_feature ~now snapshots =
   meta_counter_feature snapshots
     ~id:"autonomous_tool_use"
     ~label:"Autonomous tool turns"
     ~eligible:(fun _snapshot -> true)
+    ~now
+      (* [last_autonomous_action_at] dates this counter specifically, so a
+         keeper that is turning on chat but has not acted autonomously in the
+         window does not carry the claim. *)
+    ~last_activity:(fun meta ->
+       Option.value
+         (Masc_domain.parse_iso8601_opt meta.runtime.last_autonomous_action_at)
+         ~default:0.0)
     ~predicate:(fun meta ->
        meta.runtime.autonomous_action_count > 0
        && meta.runtime.autonomous_tool_turn_count > 0)
@@ -287,11 +305,17 @@ let autonomous_tool_feature snapshots =
     ~next_action:
       "Run or repair keepers until each active keeper records autonomous tool-turn counters."
 
-let board_reactive_feature snapshots =
+let board_reactive_feature ~now snapshots =
   meta_counter_feature snapshots
     ~id:"board_reactive_autonomy"
     ~label:"Board-reactive turns"
     ~eligible:(fun _snapshot -> true)
+    ~now
+      (* Keeper meta carries no timestamp for the board-reactive counter, so
+         this dates it by the keeper's last persisted turn. That is enough to
+         drop a stopped keeper; a keeper still turning but not board-reacting
+         keeps the claim until meta gains a per-kind timestamp. *)
+    ~last_activity:(fun meta -> meta.runtime.usage.last_turn_ts)
     ~predicate:(fun meta -> meta.runtime.board_reactive_turn_count > 0)
     ~summary_label:"keepers have board-reactive turn counters"
     ~evidence_refs:[keeper_meta_evidence; route_evidence "/api/v1/dashboard/board"]
@@ -455,8 +479,8 @@ let json ~config ?window_hours ?now () =
     [
       runtime_liveness_feature ~now snapshots;
       persistent_turn_exchange_feature ~config ~now snapshots;
-      autonomous_tool_feature snapshots;
-      board_reactive_feature snapshots;
+      autonomous_tool_feature ~now snapshots;
+      board_reactive_feature ~now snapshots;
       scheduled_proactive_feature ~config ?window_hours ~now snapshots;
     ]
   in

--- a/test/test_dashboard_keeper_feature_proof.ml
+++ b/test/test_dashboard_keeper_feature_proof.ml
@@ -53,7 +53,7 @@ let with_workspace f =
 
 (* Both keepers have taken turns, so [total_turns > 0] holds for both. They
    differ only in when the last turn landed. *)
-let seed_keeper config ~name ~last_turn_ts =
+let seed_keeper config ?(autonomous_at = "") ~name ~last_turn_ts () =
   let json =
     `Assoc
       [ "name", `String name
@@ -67,6 +67,17 @@ let seed_keeper config ~name ~last_turn_ts =
     let meta =
       Keeper_meta_contract.map_usage
         (fun usage -> { usage with total_turns = 5; last_turn_ts })
+        meta
+    in
+    let meta =
+      Keeper_meta_contract.map_runtime
+        (fun runtime ->
+           { runtime with
+             autonomous_action_count = 3
+           ; autonomous_tool_turn_count = 2
+           ; board_reactive_turn_count = 4
+           ; last_autonomous_action_at = autonomous_at
+           })
         meta
     in
     (match Keeper_meta_store.replace_snapshot config meta with
@@ -96,11 +107,12 @@ let keeper_names feature key =
 let test_stale_keeper_fails_runtime_liveness () =
   with_workspace
   @@ fun config ->
-  seed_keeper config ~name:"fresh" ~last_turn_ts:(now -. hour_seconds);
+  seed_keeper config ~name:"fresh" ~last_turn_ts:(now -. hour_seconds) ();
   seed_keeper
     config
     ~name:"stale"
-    ~last_turn_ts:(now -. ((recent_window_hours +. 2.0) *. hour_seconds));
+    ~last_turn_ts:(now -. ((recent_window_hours +. 2.0) *. hour_seconds))
+    ();
   let payload = Feature_proof.json ~config ~now () in
   let feature = feature_by_id payload "runtime_liveness" in
   check
@@ -125,7 +137,7 @@ let test_stale_keeper_fails_runtime_liveness () =
 let test_recent_keeper_passes_runtime_liveness () =
   with_workspace
   @@ fun config ->
-  seed_keeper config ~name:"fresh" ~last_turn_ts:(now -. hour_seconds);
+  seed_keeper config ~name:"fresh" ~last_turn_ts:(now -. hour_seconds) ();
   let payload = Feature_proof.json ~config ~now () in
   let feature = feature_by_id payload "runtime_liveness" in
   check
@@ -145,7 +157,7 @@ let test_recent_keeper_passes_runtime_liveness () =
 let test_keeper_without_turns_fails_runtime_liveness () =
   with_workspace
   @@ fun config ->
-  seed_keeper config ~name:"idle" ~last_turn_ts:0.0;
+  seed_keeper config ~name:"idle" ~last_turn_ts:0.0 ();
   let payload = Feature_proof.json ~config ~now () in
   let feature = feature_by_id payload "runtime_liveness" in
   check
@@ -160,6 +172,70 @@ let test_keeper_without_turns_fails_runtime_liveness () =
     (U.member "status" feature |> U.to_string)
 ;;
 
+(* [autonomous_tool_use] and [board_reactive_autonomy] read lifetime counters,
+   which never decrease. Both keepers below carry the same counters; only the
+   timestamps differ, so a predicate that ignores time reports them
+   identically. *)
+let iso_ago seconds = Masc_domain.iso8601_of_unix_seconds (now -. seconds)
+
+let test_stale_keeper_fails_autonomous_tool_use () =
+  with_workspace
+  @@ fun config ->
+  seed_keeper
+    config
+    ~name:"fresh"
+    ~last_turn_ts:(now -. hour_seconds)
+    ~autonomous_at:(iso_ago hour_seconds)
+    ();
+  seed_keeper
+    config
+    ~name:"stale"
+    ~last_turn_ts:(now -. hour_seconds)
+    ~autonomous_at:(iso_ago ((recent_window_hours +. 2.0) *. hour_seconds))
+    ();
+  let payload = Feature_proof.json ~config ~now () in
+  let feature = feature_by_id payload "autonomous_tool_use" in
+  check
+    (list string)
+    "a keeper still turning but not acting autonomously is not observed"
+    [ "fresh" ]
+    (keeper_names feature "observed_keepers");
+  check
+    (list string)
+    "it is reported missing rather than dropped"
+    [ "stale" ]
+    (keeper_names feature "missing_keepers")
+;;
+
+let test_stopped_keeper_fails_board_reactive_autonomy () =
+  with_workspace
+  @@ fun config ->
+  seed_keeper
+    config
+    ~name:"fresh"
+    ~last_turn_ts:(now -. hour_seconds)
+    ~autonomous_at:(iso_ago hour_seconds)
+    ();
+  seed_keeper
+    config
+    ~name:"stopped"
+    ~last_turn_ts:(now -. ((recent_window_hours +. 2.0) *. hour_seconds))
+    ~autonomous_at:(iso_ago hour_seconds)
+    ();
+  let payload = Feature_proof.json ~config ~now () in
+  let feature = feature_by_id payload "board_reactive_autonomy" in
+  check
+    (list string)
+    "a stopped keeper does not carry the board-reactive claim"
+    [ "fresh" ]
+    (keeper_names feature "observed_keepers");
+  check
+    string
+    "a partially stopped fleet does not pass"
+    "warn"
+    (U.member "status" feature |> U.to_string)
+;;
+
 let () =
   run
     "dashboard_keeper_feature_proof"
@@ -170,6 +246,16 @@ let () =
             "keeper without turns fails"
             `Quick
             test_keeper_without_turns_fails_runtime_liveness
+        ] )
+    ; ( "counter_features_are_dated"
+      , [ test_case
+            "stale autonomous action fails autonomous_tool_use"
+            `Quick
+            test_stale_keeper_fails_autonomous_tool_use
+        ; test_case
+            "stopped keeper fails board_reactive_autonomy"
+            `Quick
+            test_stopped_keeper_fails_board_reactive_autonomy
         ] )
     ]
 ;;


### PR DESCRIPTION
## 무엇이 문제였나

keeper meta 의 카운터는 전부 **생애 누적**입니다. 한 번 0을 넘으면 키퍼가 죽을 때까지 양수로 남습니다. 그래서 `counter > 0` 술어는 정지한 키퍼를 영원히 "있음" 으로 보고합니다.

#28127 이 `runtime_liveness` 를 고쳤지만 나머지 둘은 그대로였습니다:

```ocaml
~id:"autonomous_tool_use"
~eligible:(fun _snapshot -> true)
~predicate:(fun meta ->
   meta.runtime.autonomous_action_count > 0
   && meta.runtime.autonomous_tool_turn_count > 0)

~id:"board_reactive_autonomy"
~eligible:(fun _snapshot -> true)
~predicate:(fun meta -> meta.runtime.board_reactive_turn_count > 0)
```

#27947 이 라이브에서 측정한 형태 그대로입니다 — 26시간 정지한 `full-cycle-probe` 가 `runtime_liveness` 를 통과했습니다.

## 무엇을 바꿨나

두 술어를 각각 고치는 대신 **공유 헬퍼가 시각을 요구**하도록 했습니다.

```ocaml
let meta_counter_feature snapshots ~id ~label ~eligible ~now ~last_activity ~predicate ... =
  let predicate meta =
    predicate meta
    && timestamp_within_window
         ~window_hours:Decision.recent_turn_max_age_hours ~now (last_activity meta)
  in
```

`~last_activity` 가 필수 인자이므로, 새 카운터 feature 를 추가하려면 **그 카운터를 날짜화하는 타임스탬프를 반드시 지목**해야 합니다. 술어가 빠져나갈 수 없습니다. (기존 `~eligible:(fun _ -> true)` 가 실질 no-op 이었던 것과 대비됩니다 — 그건 호출자가 무력화할 수 있는 자리였습니다.)

호출부 3곳:

| feature | `last_activity` |
|---|---|
| `runtime_liveness` | `usage.last_turn_ts` |
| `autonomous_tool_use` | `last_autonomous_action_at` (ISO → `Masc_domain.parse_iso8601_opt`) — 이 카운터 전용 타임스탬프 |
| `board_reactive_autonomy` | `usage.last_turn_ts` — meta 에 board-reactive 전용 타임스탬프가 없음 |

## 부분 보증이라는 점을 코드에 적었습니다

`board_reactive_autonomy` 는 정지한 키퍼를 떨어뜨리지만, **계속 턴을 돌면서 board 에 반응만 안 하는 키퍼는 여전히 주장을 유지**합니다. meta 가 per-kind 타임스탬프를 갖기 전에는 더 좁힐 수 없어서, 주석에 그 한계를 명시했습니다. 스키마 필드 추가는 이 PR 범위 밖입니다.

## 검증

```
$ dune build @check --root .                                   # exit 0
$ ./_build/default/test/test_dashboard_keeper_feature_proof.exe
Test Successful in 0.294s. 5 tests run.                        # 기존 3 + 신규 2
```

신규 케이스 2건은 **카운터가 동일하고 타임스탬프만 다른 키퍼 둘**을 심습니다. 시각을 보지 않는 술어는 둘을 구별할 수 없으므로, 이 설계 자체가 래칭을 잡습니다.

mutation — 윈도우를 `1_000_000.0` 시간으로 넓히면:

```
3 failures! in 0.219s. 5 tests run.
[FAIL] runtime_liveness            0  stale keeper fails
[FAIL] counter_features_are_dated  0  stale autonomous action fails autonomous_tool_use
[FAIL] counter_features_are_dated  1  stopped keeper fails board_reactive_autonomy
```

세 recency 주장 전부가 테스트로 강제됩니다. 원복 후 5/5 초록.

Refs #27947

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjVgGJk1fDCWsatrWt53BS
