### PR TITLE
fix(dated-jsonl): read past a dotfile the store did not write

### DIFF
--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -322,9 +322,24 @@ let day_file_name_is_valid ~year ~month name =
   | None, _ | _, None -> false
 ;;
 
+(* A name this layout can never produce is a foreign file, not a corrupted
+   member of it. Month directories are [YYYY-MM] and day files are
+   [DD.jsonl]; neither can begin with a dot, so a dotfile was written by
+   something other than this store.
+
+   macOS writes [.DS_Store] into any directory Finder opens, and the live
+   store sits under a browsed home, so failing the whole read for one would
+   take every reader of that store down for the rest of a Finder visit.
+   Entries that do belong to the layout stay strict: a directory named
+   [2026-13] or a file named [32.jsonl] is corruption and still fails. *)
+let entry_is_foreign_to_layout entry =
+  String.length entry > 0 && Char.equal entry.[0] '.'
+;;
+
 let validate_layout_entries ~parent ~expected ~is_valid entries =
   let rec loop valid_entries = function
     | [] -> Ok (List.rev valid_entries)
+    | entry :: rest when entry_is_foreign_to_layout entry -> loop valid_entries rest
     | entry :: rest ->
       if is_valid entry
       then loop (entry :: valid_entries) rest


### PR DESCRIPTION
## 증상 — main 이 red 이고, 라이브 스토어도 같은 조건에 있습니다

`test_dated_jsonl` 이 main 에서 실패합니다 (`b4c4d36e`, 2026-08-12T17:40Z CI, 로컬 재현 동일):

```
[FAIL] read_range 4  strict entry iteration continues after malformed
ASSERT strict entry iteration failed: invalid dated JSONL layout entry
       …/dated_jsonl_iter_all_entries_result_…/.DS_Store: expected YYYY-MM month directory
```

`validate_layout_entries` 는 `YYYY-MM` 이 아닌 **첫 엔트리에서 읽기 전체를 실패**시킵니다. 그 경로를 지나는 것은 `iter_all_entries_result` / `read_recent_result` / `read_range_result` 전부이고, `iter_all_entries_result` 의 프로덕션 소비자는 `keeper_reaction_ledger` 입니다.

macOS 는 Finder 가 연 디렉터리마다 `.DS_Store` 를 씁니다. 라이브 스토어는 `~/me/.masc` 아래 — 사람이 열어보는 홈입니다. **Finder 방문 한 번이 그 스토어의 모든 읽기를 지웁니다**, 누가 파일을 지울 때까지.

## 수리

레이아웃이 만들 수 있는 이름은 `YYYY-MM`(디렉터리)과 `DD.jsonl`(파일)뿐이고, **둘 다 점으로 시작할 수 없습니다.** 그러므로 dotfile 은 손상된 멤버가 아니라 이 스토어가 쓰지 않은 외부 파일입니다.

```ocaml
let entry_is_foreign_to_layout entry =
  String.length entry > 0 && Char.equal entry.[0] '.'
```

"유효 판정을 넓힌 것" 이 아닙니다 — 레이아웃 멤버가 될 수 있는 엔트리는 그대로 엄격합니다. 기존 대조군 `test_read_recent_result_rejects_invalid_layout` 이 `2026-aa`(월)과 2월의 `29.jsonl`(일)을 여전히 거부하도록 요구합니다.

같은 논증을 오늘 `board_audience` 에서도 썼습니다 (#28474): *"`Agent_id` 가 될 수 없는 토큰은 실패한 주소가 아니라 prose"*.

## 언제부터 깨져 있었나

`test_iter_all_entries_result_continues_after_malformed` 는 **#26392 (2026-07-30)** 에서 `.DS_Store` 시딩을 추가했고, `validate_layout_entries` 는 도입(#25176) 이후 **한 번도 수정되지 않았습니다** (`git log -S 'validate_layout_entries'` → 커밋 1개). 즉 14일간 red 였습니다.

드러나지 않은 이유는 실행 조건입니다 — CI 는 변경 감지가 이 스위트를 고를 때만 돌립니다. 같은 날 두 main run 을 **같은 패턴으로** 비교하면:

```
14:32Z 4be39742  ag_ui  auth  lifecycle  mcp  subscription boundary  turn-scoped transport
17:40Z b4c4d36e  lifecycle  read_range  subscription boundary  turn-scoped transport
```

`read_range` 는 "새로 생긴 실패" 가 아니라 **새로 관측된 실패**입니다. 이 창에서 dated_jsonl 을 건드린 세 커밋(#28420 · #28455 · #28458)은 전부 `iter_all_entries_result` / `list_month_dirs_result` / `validate_layout_entries` 를 건드리지 않았습니다 (각 커밋 diff 에서 매치 0).

## 검증

```
$ ./_build/default/test/test_dated_jsonl.exe
Test Successful in 0.128s. 50 tests run.     # 수리 전: 1 failure
```

mutation 양방향:

| mutation | 결과 |
|---|---|
| 술어를 항상 false 로 (= 오늘의 main) | `[FAIL] read_range 4 strict entry iteration continues after malformed` |
| 유효하지 않은 엔트리를 전부 skip (과도한 관용) | `[FAIL] read_recent 13 strict read rejects invalid layout` |
| 원복 | 50 tests, exit 0 |

한쪽만 잡히면 검사가 반쪽입니다 — 관용을 없애면 dotfile 케이스가, 관용을 넓히면 손상 케이스가 각각 실패합니다.

## 남는 것 (이 PR 범위 밖)

같은 main run 에서 `lifecycle` / `subscription boundary` / `turn-scoped transport` 3개 스위트도 실패 중이고, 이들은 최소 13:55Z 부터 지속됐습니다. 별개 원인이라 여기서 다루지 않습니다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjVgGJk1fDCWsatrWt53BS
