### PR TITLE
test(dated-jsonl): pin the dotfile rule on the read_recent_result path too

### DIFF
--- a/test/test_dated_jsonl.ml
+++ b/test/test_dated_jsonl.ml
@@ -320,6 +320,26 @@ let test_read_recent_result_rejects_base_symlink () =
   | Ok _ -> fail "base symlink was treated as an empty store"
 ;;
 
+(* The environment writes dotfiles into any directory it touches — macOS puts
+   .DS_Store beside the month directories. Failing the read on one of those
+   would hide every row in the store, so they are skipped. A real layout
+   violation still fails: that means a writer is wrong (see the test below). *)
+let test_read_recent_result_skips_dot_entries () =
+  let base_dir = tmpdir "dated_jsonl_dot_entries" in
+  write_dated_file base_dir "2026-02" "01" [ {|{"i":1}|} ];
+  Fs_compat.append_file (Filename.concat base_dir ".DS_Store") "not dated";
+  Fs_compat.append_file
+    (Filename.concat (Filename.concat base_dir "2026-02") ".DS_Store")
+    "not dated";
+  let store = Dated_jsonl.create ~base_dir () in
+  match Dated_jsonl.read_recent_result store 10 with
+  | Ok rows -> check int "the row is still readable" 1 (List.length rows)
+  | Error error ->
+    failf
+      "a stray dotfile hid the whole store: %s"
+      (Dated_jsonl.read_error_to_string error)
+;;
+
 let test_read_recent_result_rejects_invalid_layout () =
   let base_dir = tmpdir "dated_jsonl_invalid_layout" in
   let invalid_month = "2026-aa" in
@@ -935,6 +955,8 @@ let () =
             test_read_recent_result_rejects_base_symlink;
           test_case "strict read rejects invalid layout" `Quick
             test_read_recent_result_rejects_invalid_layout;
+          test_case "strict read skips dot entries" `Quick
+            test_read_recent_result_skips_dot_entries;
           test_case "strict read accepts leap day" `Quick
             test_read_recent_result_accepts_leap_day;
           test_case "strict read rejects FIFO without blocking" `Quick


### PR DESCRIPTION
## 요약

[#28486](https://github.com/jeong-sik/masc/pull/28486) 이 이미 고친 동작을 **다른 읽기 경로에서 고정**한다. 테스트 1건 추가.

## 이 PR 이 축소된 이유

원래 이 PR 은 `.DS_Store` 하나가 스토어 전체를 가리는 결함을 고치려 했다. 그 사이 #28486 (`fix(dated-jsonl): read past a dotfile the store did not write`) 이 같은 문제를 먼저 고쳤다 — main 의 `entry_is_foreign_to_layout` 이 그것이다.

구현은 중복이므로 버렸다. 남긴 것은 **main 이 덮지 않은 축**이다.

## 남은 것: `read_recent_result` 경로

#28486 의 픽스처는 `iter_all_entries_result` 를 덮는다.

`read_recent_result` 와 `read_range` 는 `validate_layout_entries` 를 공유하므로 같은 수정을 받았지만, **거기서는 아무것도 단언하지 않는다.** 그런데 stray `.DS_Store` 가 가장 먼저 드러날 경로가 그쪽이다 — 대시보드와 recent-row 리더가 호출하는 것이 그것이기 때문이다.

## 반대 방향도 함께 고정한다

추가한 케이스는 dotfile skip 만 보이지 않는다. `2026-aa/` 나 `29.jsonl` 같은 **진짜 레이아웃 위반은 여전히 `Invalid_layout_entry`** 라는 것도 기존 테스트와 함께 성립해야 한다. skip 만 증명하는 테스트는 나중에 그 범위를 넓히는 변경을 잡지 못한다.

## 검증

```
@test/runtest-test_dated_jsonl   Test Successful.  51 tests run.
```

main 의 구현(#28486)에 대해 통과한다 — 이 PR 은 구현을 바꾸지 않는다.

RFC-WAIVED: 이미 머지된 동작을 다른 호출 경로에서 고정하는 테스트 1건이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3Ek71sn9DrrT4japMSNQs
