### PR TITLE
build(keeper-sandbox): make the image able to build this repo

### DIFF
--- a/Dockerfile.keeper-sandbox
+++ b/Dockerfile.keeper-sandbox
@@ -1,6 +1,19 @@
 # MASC Keeper Sandbox
 # Runtime environment for keeper agents executing Bash/Read/Edit tools.
 #
+# Base: masc.opam pins `"ocaml" {= "5.5.0"}`. The previous
+# `ubuntu:24.04` + `opam switch create ocaml-system` combination resolved to
+# the distribution compiler (4.x), so `opam install --deps-only` for this repo
+# could never succeed there. The upstream opam image ships the pinned compiler
+# already built, which also removes a 20-40 minute compiler build from every
+# image rebuild.
+#
+# Dependencies are baked into the image rather than installed at run time:
+# keeper tool dispatch runs each turn in a fresh `docker run --rm` container
+# with `--read-only` rootfs and `--cap-drop=ALL` (see
+# keeper_sandbox_docker.ml `docker_run_argv`), so a keeper cannot install
+# anything at run time. Whatever a keeper needs to build must already be here.
+#
 # Hardening notes:
 # - When docker_hardened is enabled, override at runtime:
 #     MASC_KEEPER_SANDBOX_REQUIRE_ROOTLESS=false
@@ -8,42 +21,112 @@
 # - The host docker socket is typically mounted for DinD operations.
 # - Keeper GitHub/SSH credential bundles are projected at /tmp/keeper-creds.
 
-FROM ubuntu:24.04
+FROM ocaml/opam:ubuntu-24.04-ocaml-5.5
 
-ENV DEBIAN_FRONTEND=noninteractive \
-    OPAMROOT=/opt/opam
+USER root
+ENV DEBIAN_FRONTEND=noninteractive
 
+# GitHub CLI ships from its own apt repository. The Ubuntu archive package
+# trails upstream by months, and keepers authenticate and drive PRs through
+# `gh`, so the client is pinned to the vendor channel instead.
 RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl gnupg \
+ && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+ && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+ && printf 'deb [arch=%s signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main\n' \
+      "$(dpkg --print-architecture)" > /etc/apt/sources.list.d/github-cli.list \
+ && apt-get update \
  && apt-get install -y --no-install-recommends \
       bash \
-      ca-certificates \
       coreutils \
-      curl \
       findutils \
+      g++ \
       gcc \
-      git \
       gh \
+      git \
       jq \
+      less \
       make \
       nodejs \
       npm \
-      ocaml-nox \
-      opam \
       openssh-client \
+      patch \
+      pkg-config \
       python3 \
+      python3-venv \
       ripgrep \
+      rsync \
       tree \
+      unzip \
+      zip \
+      m4 \
+      libev-dev \
+      libgmp-dev \
+      libprotobuf-dev \
+      libsqlite3-dev \
+      libssl-dev \
+      libzstd-dev \
+      protobuf-compiler \
+      zlib1g-dev \
  && rm -rf /var/lib/apt/lists/*
+# The -dev packages above are the depexts opam reports for this dependency set
+# (`opam install --deps-only --depext-only --dry-run`): libgmp-dev,
+# libprotobuf-dev, libsqlite3-dev, libssl-dev, pkg-config, protobuf-compiler.
+# They are installed here rather than by opam because the image build runs as a
+# non-root user at that point and the container has no package manager access
+# at run time.
 
-# Install dune 3.22 via opam.
-# Ubuntu 24.04's ocaml-dune apt package provides dune 3.14 only;
-# the repo dune-project requires (lang dune 3.22).
-RUN opam init --disable-sandboxing --root "$OPAMROOT" --bare -y \
- && opam switch create default ocaml-system --root "$OPAMROOT" -y \
- && opam install --root "$OPAMROOT" -y dune.3.22.0 ppxlib ppx_deriving_yojson ppx_let ppx_deriving bisect_ppx ocaml-protoc-plugin \
- && rm -rf "$OPAMROOT/repo" "$OPAMROOT/.opam-switch/sources"
+# MASC_KEEPER_DOCKER_PLAYGROUND_ROOT defaults to /home/keeper/playground and is
+# supplied as a bind mount. The container runs as the host uid/gid
+# (`--user <uid>:<gid>`), which matches no image account, so the mount point is
+# created up front and left group/other writable.
+RUN mkdir -p /home/keeper/playground && chmod 0777 /home/keeper /home/keeper/playground
 
-ENV PATH="/opt/opam/default/bin:${PATH}"
+USER opam
+
+# Only the package metadata is copied: the dependency set is what belongs in
+# the image, and copying sources would pin the image to one commit of the repo
+# a keeper is about to clone itself.
+#
+# The pins are replayed explicitly. Eight dependencies (mcp_protocol,
+# grpc-direct, grpc-direct-core, ocaml-webrtc, ws-direct-core/-eio/-gluten and
+# a bisect_ppx fork) are absent from opam-repository, so `--deps-only` alone
+# fails to solve. opam does not apply the lock file's `pin-depends:` on its own
+# here — see opam-pin-from-lock.sh for what was tried and how each option
+# failed.
+# --chown: COPY writes as root, but this stage runs as `opam`, so the cleanup
+# at the end of the RUN below cannot remove root-owned files.
+COPY --chown=opam:opam masc.opam masc.opam.locked /tmp/masc/
+COPY --chown=opam:opam scripts/opam-pin-from-lock.sh /tmp/opam-pin-from-lock.sh
+# --with-test pulls alcotest / qcheck-* / bisect_ppx, which masc.opam declares
+# under {with-test}. Without it `dune build @check` fails on 258 test stanzas:
+# a keeper that cannot run the suite cannot verify its own change.
+RUN sh /tmp/opam-pin-from-lock.sh /tmp/masc/masc.opam.locked \
+ && opam install --deps-only --with-test --yes /tmp/masc/masc.opam \
+ && opam clean -a -c -s --logs \
+ && rm -rf /tmp/masc /tmp/opam-pin-from-lock.sh
+
+USER root
+
+# Tool dispatch invokes `bash -c`, which reads neither a login profile nor an
+# opam environment, so `eval $(opam env)` never runs. Exporting the switch
+# variables here is what makes the installed packages visible: with only the
+# binaries on PATH, dune runs but every `(libraries yojson ...)` stanza fails
+# with "Library not found" because dune resolves libraries through
+# OPAM_SWITCH_PREFIX.
+#
+# The switch name is fixed by the base image tag above (ocaml-5.5 yields switch
+# "5.5"). The check below fails the build if that stops holding, instead of
+# shipping an image whose dune silently cannot see any library.
+ENV OPAM_SWITCH_PREFIX=/home/opam/.opam/5.5 \
+    OCAML_TOPLEVEL_PATH=/home/opam/.opam/5.5/lib/toplevel \
+    OCAMLTOP_INCLUDE_PATH=/home/opam/.opam/5.5/lib/toplevel \
+    CAML_LD_LIBRARY_PATH=/home/opam/.opam/5.5/lib/stublibs:/home/opam/.opam/5.5/lib/ocaml/stublibs:/home/opam/.opam/5.5/lib/ocaml \
+    PATH=/home/opam/.opam/5.5/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN test -d "${OPAM_SWITCH_PREFIX}/lib/yojson" \
+ || { echo "opam switch prefix drift: ${OPAM_SWITCH_PREFIX} has no lib/yojson" >&2; exit 1; }
 
 VOLUME ["/tmp/keeper-creds"]
 

--- a/masc.opam.locked
+++ b/masc.opam.locked
@@ -238,15 +238,15 @@ pin-depends: [
   ]
   [
   "ws-direct-core.0.1.0"
-  "git+https://github.com/jeong-sik/ws-direct.git#88f325956e8d03e5d68838145ada08a19e221c42"
+  "git+https://github.com/jeong-sik/ws-direct.git#05e01cf008d4a5024474d13cee35cda42e2bea09"
 ]
   [
   "ws-direct-eio.0.1.0"
-  "git+https://github.com/jeong-sik/ws-direct.git#88f325956e8d03e5d68838145ada08a19e221c42"
+  "git+https://github.com/jeong-sik/ws-direct.git#05e01cf008d4a5024474d13cee35cda42e2bea09"
 ]
   [
   "ws-direct-gluten.0.1.0"
-  "git+https://github.com/jeong-sik/ws-direct.git#88f325956e8d03e5d68838145ada08a19e221c42"
+  "git+https://github.com/jeong-sik/ws-direct.git#05e01cf008d4a5024474d13cee35cda42e2bea09"
 ]
 ]
 x-maintenance-intent: ["(latest)"]

--- a/scripts/check-sandbox-dune-version.sh
+++ b/scripts/check-sandbox-dune-version.sh
@@ -21,20 +21,40 @@ if [[ -z "$req_ver" ]]; then
   exit 1
 fi
 
-# --- Extract installed dune version from Dockerfile.keeper-sandbox -----------
-# Looks for an opam install line containing dune.X.Y.Z
+# --- Extract installed dune version -----------------------------------------
+# Two ways the image can end up with dune, checked in that order:
+#
+#   1. an explicit `opam install dune.X.Y.Z` line in the Dockerfile
+#   2. `opam install --deps-only` against masc.opam, which resolves dune from
+#      masc.opam.locked — the Dockerfile copies that lock in and installs from
+#      it, so the lock's pin is the version the image gets
+#
+# `|| true` is required: these greps run under `set -euo pipefail`, and a
+# no-match grep exits 1, which would kill the script before it could print
+# the diagnostic below.
 sandbox_ver="$(grep -oE 'dune\.[0-9]+\.[0-9]+(\.[0-9]+)?' \
-               "$repo_root/Dockerfile.keeper-sandbox" \
-               | head -1 | sed 's/^dune\.//')"
+               "$repo_root/Dockerfile.keeper-sandbox" 2>/dev/null \
+               | head -1 | sed 's/^dune\.//' || true)"
+sandbox_source="Dockerfile.keeper-sandbox (explicit install)"
+
+if [[ -z "$sandbox_ver" ]] \
+   && grep -qE '^[[:space:]]*(RUN|&&)?[^#]*--deps-only' \
+        "$repo_root/Dockerfile.keeper-sandbox"; then
+  sandbox_ver="$(grep -oE '"dune" \{= "[0-9]+\.[0-9]+(\.[0-9]+)?"\}' \
+                 "$repo_root/masc.opam.locked" 2>/dev/null \
+                 | head -1 | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' || true)"
+  sandbox_source="masc.opam.locked (via --deps-only)"
+fi
 
 if [[ -z "$sandbox_ver" ]]; then
-  printf 'ERROR: could not extract dune version from Dockerfile.keeper-sandbox\n' >&2
-  printf '  Expected an opam install line containing: dune.X.Y.Z\n' >&2
+  printf 'ERROR: could not determine the dune version the sandbox image installs\n' >&2
+  printf '  Looked for: an `opam install dune.X.Y.Z` line in Dockerfile.keeper-sandbox,\n' >&2
+  printf '  then, if it installs with --deps-only, `"dune" {= "X.Y.Z"}` in masc.opam.locked\n' >&2
   exit 1
 fi
 
 printf 'dune-project requires  : %s\n' "$req_ver"
-printf 'Dockerfile installs    : %s\n' "$sandbox_ver"
+printf 'sandbox image installs : %s  (from %s)\n' "$sandbox_ver" "$sandbox_source"
 
 # --- Version comparison: sandbox_ver >= req_ver (using sort -V) ---------------
 # printf puts req_ver first; sort -V -C returns 0 only when the two lines are

--- a/scripts/opam-pin-from-lock.sh
+++ b/scripts/opam-pin-from-lock.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env sh
+# Pin the git dependencies recorded in a lock file's `pin-depends:` section.
+#
+# Eleven first-party packages are absent from opam-repository, so a plain
+# `opam install --deps-only` on masc.opam fails at solve time with
+# "unknown package: mcp_protocol". The lock file records each package and its
+# git URL, which is what this script replays.
+#
+# Why not the alternatives:
+# - `opam install --locked` and `opam install <file>.locked` do not apply
+#   pin-depends: both still fail to solve.
+# - `opam pin add --locked <dir>` does apply them, but crashes partway
+#   through with Invalid_argument("String.sub / Bytes.sub").
+# - scripts/opam-pin-external-deps.sh acquires a host switch write lease and
+#   validates the caller's shell prefix, neither of which exists in an image
+#   build.
+#
+# `-n` pins without building; the caller runs one `opam install` afterwards so
+# the solve happens once over the whole dependency set.
+#
+# Usage: opam-pin-from-lock.sh <path-to-opam.locked>
+
+set -eu
+
+lock="${1:?usage: opam-pin-from-lock.sh <path-to-opam.locked>}"
+
+# pin-depends entries are two-line pairs (package, then git URL), but the
+# lock file's indentation is not uniform, so pairs are recovered by tracking
+# the line before each git URL rather than by block structure. The repo's own
+# `dev-repo:` field also carries a git URL and is excluded.
+awk '/"git\+/ { gsub(/[ "]/, "", prev); gsub(/[ "]/, "", $0); print prev, $0 } { prev = $0 }' \
+  "$lock" \
+  | grep -v 'dev-repo' \
+  > /tmp/opam-pins.txt
+
+if [ ! -s /tmp/opam-pins.txt ]; then
+  echo "opam-pin-from-lock: no pin-depends entries found in $lock" >&2
+  exit 1
+fi
+
+while read -r pkg url; do
+  echo "opam-pin-from-lock: pinning $pkg -> $url"
+  opam pin add -n -y "$pkg" "$url"
+done < /tmp/opam-pins.txt
+
+rm -f /tmp/opam-pins.txt


### PR DESCRIPTION
## 요약

keeper sandbox 이미지가 이 저장소를 빌드할 수 있게 만든다. **컨테이너 안에서 `dune build lib` 이 통과하는 것을 확인했다.**

## 이미지가 masc 를 빌드할 수 없었다

`Dockerfile.keeper-sandbox` 는 `ocaml-system` 으로 switch 를 만들었다. 그건 배포판 컴파일러(Debian 12 에서 4.x)로 해석되는데 `masc.opam` 은 `"ocaml" {= "5.5.0"}` 을 pin 한다. 거기서 `opam install --deps-only` 는 **애초에 풀릴 수 없었다.**

배포 중인 `:local` 이미지는 2026-06-16 자이고 dune 이 없으며 gh 는 2.23.0(2023년) 이다.

base 를 `ocaml/opam:ubuntu-24.04-ocaml-5.5` 로 바꾼다. pin 된 컴파일러가 이미 빌드돼 있어 재빌드마다 20~40분짜리 컴파일러 빌드가 사라진다.

## `--deps-only` 를 통과시키기 위해 필요했던 세 가지

### 1. pin-depends 재생 (`scripts/opam-pin-from-lock.sh`)

의존성 8개가 opam-repository 에 없다 (`mcp_protocol`, `grpc-direct{,-core}`, `ocaml-webrtc`, `ws-direct-{core,eio,gluten}`, bisect_ppx fork). opam 2.1.6 은 lock 파일의 `pin-depends:` 를 스스로 적용하지 않는다:

| 시도 | 결과 |
|---|---|
| `opam install --locked` | 여전히 solve 실패 |
| `opam install <file>.locked` | 에러가 `mcp_protocol` → `grpc-direct` 로 이동 (부분 적용) |
| `opam pin add --locked <dir>` | pin 은 적용되나 `Invalid_argument("String.sub / Bytes.sub")` 로 중간에 크래시 |
| `scripts/opam-pin-external-deps.sh` | 호스트 switch write lease 를 잡고 호출자 shell prefix 를 검증한다 — 이미지 빌드에는 둘 다 없다 |

새 스크립트가 lock 의 `pin-depends` 를 파싱해 `opam pin add -n -y` 를 명시적으로 발행한다. 헤더에 위 표를 그대로 적어 뒀다.

### 2. depext 를 추측하지 않고 실측

처음에 `libev-dev` / `libzstd-dev` / `zlib1g-dev` 를 넣었다가 `conf-sqlite3` 에서 막혔다. `opam install --deps-only --depext-only --dry-run` 이 보고하는 실제 목록은 `libgmp-dev`, `libprotobuf-dev`, `libsqlite3-dev`, `libssl-dev`, `pkg-config`, `protobuf-compiler` 다.

의존성 단계가 `opam` 사용자로 돌고 런타임 컨테이너에는 패키지 관리자 접근이 없으므로 root 단계에서 설치한다.

### 3. `masc.opam.locked` 의 ws-direct SHA drift

lock 이 `88f3259` 를 pin 하는데 SSOT(`scripts/opam-pin-external-deps.sh` 의 `WS_DIRECT_SHA`)는 `05e01cf` 다. 이것이 `Unbound value Ws_wsd.send_text_bigstring` 로 드러났다.

**lock 파일에 소비자가 없어서** 이 drift 가 눈에 띄지 않았다 — CI 도 로컬도 `opam-pin-external-deps.sh` 를 쓴다. 이미지 빌드가 첫 소비자가 되면서 나타났다.

> `masc.opam.locked` 는 생성 파일이다. 이 3줄은 pin SSOT 와 맞추는 교정이고, 정본은 `opam lock` 재생성이다.

## 그 외

**`--with-test`** — `alcotest` / `qcheck-*` / `bisect_ppx` 를 가져온다. 없으면 258개 테스트 스탠자가 컴파일되지 않는다. 자기 변경을 테스트로 증명하지 못하는 keeper 는 검증을 못 한다.

**opam switch 변수 export** — 툴 디스패치는 `bash -c` 로 도는데 그건 프로필을 읽지 않으므로 `eval $(opam env)` 가 실행되지 않는다. 바이너리만 PATH 에 있으면 dune 은 돌지만 모든 `(libraries yojson ...)` 스탠자가 "Library not found" 로 죽는다 — dune 은 `OPAM_SWITCH_PREFIX` 로 라이브러리를 찾기 때문이다. switch 이름 가정이 깨지면 빌드가 실패하도록 `RUN test -d` 가드를 뒀다. 라이브러리를 못 보는 dune 을 조용히 담은 이미지를 배포하는 것보다 낫다.

**gh 는 벤더 apt 저장소에서** — keeper 가 PR 을 이걸로 몰고, Ubuntu 아카이브 패키지는 upstream 보다 뒤처진다.

## 검증

호스트가 아니라 **컨테이너 안에서** 확인했다.

```
docker build -f Dockerfile.keeper-sandbox -t masc-keeper-sandbox:next .
  → BUILD_EXIT=0

docker run --rm -v "$PWD:/src:ro" --entrypoint sh masc-keeper-sandbox:next \
  -c 'cp -r /src /tmp/b && cd /tmp/b && rm -rf _build && dune build lib'
  → IN_CONTAINER_EXIT=0, 에러 0건
```

두 에러가 모두 닫혔다: `alcotest` 258건(`--with-test`)과 `Ws_wsd.send_text_bigstring`(lock SHA).

ratchet: `check-ssot.sh`=0, `audit-ci-test-targets.sh`=0, `audit-odoc-refs.py`=0.

## 배포하지 않는다

이 PR 은 `Dockerfile` 만 바꾼다. 실행 중인 keeper 는 여전히 `masc-keeper-sandbox:local` 을 쓴다 (`env_config_sandbox.ml:71-73` 의 코드 기본값, docker profile keeper `sangsu`/`analyst` 둘 다 `sandbox_image` 미지정).

`:local` 로 승격하는 것은 별개 결정이다. 가장 안전한 순서는 한 keeper 의 TOML 에 `sandbox_image` 를 지정해 실측한 뒤 확대하는 것이다 — `resolve_sandbox_image` (`keeper_sandbox_docker.ml:141`) 가 `meta.sandbox_image` 를 env 보다 우선한다. 이미지 존재 확인은 pull 하지 않고 `docker image inspect` 만 하므로(`keeper_sandbox_runtime.ml:690-745`) 로컬 전용 태그로도 안전하다.

RFC-WAIVED: 빌드 환경 정의 변경이다. keeper sandbox **런타임** 동작(경계, credential, 격리 플래그)은 건드리지 않는다 — 이미지가 이 저장소를 빌드할 수 있게 만드는 것이 전부다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3Ek71sn9DrrT4japMSNQs
