### PR TITLE
refactor(keeper-toml): let a field name carry the kind it accepts

### DIFF
--- a/lib/keeper/keeper_types_profile_toml_parser.ml
+++ b/lib/keeper/keeper_types_profile_toml_parser.ml
@@ -4,24 +4,42 @@ include Keeper_types_profile_defaults
 include Keeper_types_profile_toml_normalizers
 include Keeper_types_profile_agent_core_env
 
-let keeper_toml_field_names =
-  [ "name"
-  ; "instructions"
-  ; "autonomous_wake_prompt"
-  ; "autoboot_enabled"
-  ; "mention_targets"
-  ; "proactive_enabled"
-  ; "allowed_paths"
-  ; "sandbox_profile"
-  ; "sandbox_image"
-  ; "network_mode"
-  ; "multimodal_policy"
-  ; "active_goal_ids"
-  ; "max_context_override"
-  ; "telemetry_feedback_enabled"
-  ; "telemetry_feedback_window_hours"
-  ; "always_allow"
+type keeper_toml_field_kind =
+  | Field_string
+  | Field_bool
+  | Field_int
+  | Field_string_array
+
+(* One list carries both what a keeper TOML key may be called and what it may
+   hold. [detect_unknown_keeper_toml_keys] reads the names and
+   [validate_known_keeper_field_types] reads the kinds, so a key cannot be
+   accepted as known while having no declared type.
+
+   That combination is what makes the loader's conflation reachable: for a key
+   nothing type-checks, [Keeper_toml_loader.toml_string_list] returns [[]] and
+   [toml_bool_opt] returns [None] for a wrong-typed value exactly as they do
+   for an absent one, and the profile keeps a default the file did not ask for
+   (#26622). Declaring the kind here is what keeps that unreachable. *)
+let keeper_toml_fields =
+  [ "name", Field_string
+  ; "instructions", Field_string
+  ; "autonomous_wake_prompt", Field_string
+  ; "autoboot_enabled", Field_bool
+  ; "mention_targets", Field_string_array
+  ; "proactive_enabled", Field_bool
+  ; "allowed_paths", Field_string_array
+  ; "sandbox_profile", Field_string
+  ; "sandbox_image", Field_string
+  ; "network_mode", Field_string
+  ; "multimodal_policy", Field_string
+  ; "active_goal_ids", Field_string_array
+  ; "max_context_override", Field_int
+  ; "telemetry_feedback_enabled", Field_bool
+  ; "telemetry_feedback_window_hours", Field_int
+  ; "always_allow", Field_bool
   ]
+
+let keeper_toml_field_names = List.map fst keeper_toml_fields
 
 let canonical_keeper_toml_key_names = keeper_toml_field_names
 
@@ -57,35 +75,24 @@ let toml_value_kind = function
   | Keeper_toml_loader.Toml_local_time _ -> "local time"
 ;;
 
+let keeper_toml_field_kind_expectation = function
+  | Field_string ->
+    "string", (function Keeper_toml_loader.Toml_string _ -> true | _ -> false)
+  | Field_bool ->
+    "boolean", (function Keeper_toml_loader.Toml_bool _ -> true | _ -> false)
+  | Field_int ->
+    "integer", (function Keeper_toml_loader.Toml_int _ -> true | _ -> false)
+  | Field_string_array ->
+    ( "string array"
+    , function Keeper_toml_loader.Toml_string_array _ -> true | _ -> false )
+;;
+
 let validate_known_keeper_field_types doc =
-  let string_fields =
-    [ "name"; "instructions"; "autonomous_wake_prompt"; "sandbox_profile"
-    ; "sandbox_image"; "network_mode"; "multimodal_policy" ]
-  in
-  let bool_fields =
-    [ "autoboot_enabled"; "proactive_enabled"; "telemetry_feedback_enabled"
-    ; "always_allow" ]
-  in
-  let int_fields =
-    [ "max_context_override"; "telemetry_feedback_window_hours" ]
-  in
-  let string_array_fields =
-    [ "mention_targets"; "allowed_paths"; "active_goal_ids" ]
-  in
   let expected key =
     let bare_key = String.sub key 7 (String.length key - 7) in
-    if List.mem bare_key string_fields
-    then Some ("string", function Keeper_toml_loader.Toml_string _ -> true | _ -> false)
-    else if List.mem bare_key bool_fields
-    then Some ("boolean", function Keeper_toml_loader.Toml_bool _ -> true | _ -> false)
-    else if List.mem bare_key int_fields
-    then Some ("integer", function Keeper_toml_loader.Toml_int _ -> true | _ -> false)
-    else if List.mem bare_key string_array_fields
-    then
-      Some
-        ( "string array"
-        , function Keeper_toml_loader.Toml_string_array _ -> true | _ -> false )
-    else None
+    Option.map
+      keeper_toml_field_kind_expectation
+      (List.assoc_opt bare_key keeper_toml_fields)
   in
   doc
   |> List.find_map (fun (key, value) ->

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -552,6 +552,35 @@ let test_profile_rejects_unknown_key () =
        check bool "names unknown key" true
          (String_util.contains_substring detail "keeper.typo_field"))
 
+(* Each declared kind must reject a value of another kind. Paired with
+   [keeper_toml_fields], where a key cannot exist without a kind, this covers a
+   newly added key too: it has to pick one of these four, and each is shown to
+   fail the load rather than fall through to [Keeper_toml_loader], where a
+   wrong-typed value and an absent one produce the same default (#26622). *)
+let test_each_keeper_field_kind_rejects_a_wrong_typed_value () =
+  List.iter
+    (fun (field, wrong, expected_kind) ->
+       let input = Printf.sprintf "[keeper]\n%s = %s\n" field wrong in
+       match TL.parse_toml input with
+       | Error error -> failf "fixture for %s did not parse: %s" field error
+       | Ok doc ->
+         (match KTP.profile_defaults_of_toml doc with
+          | Ok _ -> failf "%s accepted a wrong-typed value" field
+          | Error detail ->
+            check bool
+              (field ^ " names the field")
+              true
+              (String_util.contains_substring detail ("keeper." ^ field));
+            check bool
+              (field ^ " names the expected kind")
+              true
+              (String_util.contains_substring detail expected_kind)))
+    [ "name", "true", "string"
+    ; "autoboot_enabled", "\"yes\"", "boolean"
+    ; "max_context_override", "\"128001\"", "integer"
+    ; "mention_targets", "true", "string array"
+    ]
+
 let test_profile_full () =
   let input = {|
 [keeper]
@@ -1669,6 +1698,8 @@ let () =
           test_case "nonexistent dir" `Quick test_discover_nonexistent_dir;
           test_case "retains invalid files" `Quick
             test_discover_retains_invalid_files;
+          test_case "each field kind rejects a wrong-typed value" `Quick
+            test_each_keeper_field_kind_rejects_a_wrong_typed_value;
           test_case "materializable helper uses base path" `Quick
             test_profile_defaults_materializable_for_name_uses_base_path;
           test_case "bundled keeper profiles resolve prompt defaults" `Quick


### PR DESCRIPTION
## 무엇이 문제였나

keeper TOML 키가 무엇인지를 **두 목록이 따로** 정했습니다.

| | 무엇을 정하는가 | 출처 |
|---|---|---|
| `keeper_toml_field_names` | 어떤 이름이 알려진 키인가 | 16개 목록 |
| `validate_known_keeper_field_types` | 각 키가 어떤 타입을 받는가 | 손으로 쓴 4개 목록 (7 + 4 + 2 + 3) |

오늘은 일치합니다 — 16 대 16, 차집합 0. 다만 **일치를 강제하는 것이 없습니다.**

앞의 목록에만 추가된 키는:

1. `detect_unknown_keeper_toml_keys` 를 통과합니다 (알려진 키)
2. `validate_known_keeper_field_types` 의 `expected` 가 `None` 을 돌려줘 **타입 검사를 건너뜁니다**
3. `Keeper_toml_loader` 에 도달합니다 — 거기서 잘못된 타입은 부재와 같은 값입니다:

```ocaml
let toml_string_list doc key =
  match List.assoc_opt key doc with
  | Some (Toml_string_array xs) -> xs
  | Some ( Toml_string _ | Toml_int _ | ... )     (* 잘못된 타입 *)
  | None -> []                                     (* 부재 *)
```

결과는 파일이 요청하지 않은 기본값을 프로파일이 그대로 갖는 것입니다. #26622 가 보고한 것이 이 삼킴이고, 그 뒤 catch-all `| _ -> []` 이 전수 열거로 바뀌었지만 — 컴파일러가 **새 `toml_value` variant** 는 잡게 됐어도 잘못된 타입과 부재는 여전히 같은 arm 에 묶여 있습니다. arm 이 존재하는 것과 케이스가 구별되는 것은 다릅니다.

## 무엇을 바꿨나

이름과 kind 를 한 목록이 싣습니다.

```ocaml
type keeper_toml_field_kind = Field_string | Field_bool | Field_int | Field_string_array

let keeper_toml_fields =
  [ "name", Field_string
  ; "autoboot_enabled", Field_bool
  ; "mention_targets", Field_string_array
  ; ... ]

let keeper_toml_field_names = List.map fst keeper_toml_fields
```

kind 없는 키는 **컴파일되지 않습니다.** 손으로 쓴 4개 목록은 사라지고 `validate_known_keeper_field_types` 는 `List.assoc_opt bare_key keeper_toml_fields` 하나를 봅니다.

동작 변화는 없습니다 — 오늘의 16개 매핑을 그대로 옮겼습니다. 바뀐 것은 다음 키가 추가될 때 무슨 일이 일어나는가입니다.

## 검증

```
$ dune build @check --root .                      # exit 0
$ ./_build/default/test/test_keeper_toml.exe
Test Successful in 0.062s. 85 tests run.          # 기존 84 + 신규 1
```

구조는 컴파일러가 지키고(이름에는 반드시 kind 가 있다), **각 kind 가 실제로 거부하는지**는 테스트가 지킵니다 — kind 당 한 케이스, 에러 메시지가 필드명과 기대 kind 를 모두 담는지 확인합니다. 새 키는 넷 중 하나를 골라야 하므로 자동으로 덮입니다.

mutation:

| mutation | 결과 |
|---|---|
| `Field_bool` 의 술어를 `fun _ -> true` 로 (해당 kind 검증 무력화) | 2 failures |
| `"name"` 을 `Field_int` 로 선언 (잘못된 kind) | 2 failures |
| 원복 | 85 tests, exit 0 |

API 를 넓히지 않았습니다 — `keeper_toml_fields` 는 `.mli` 밖에 두고, 테스트는 kind 당 대표 필드로 동작만 확인합니다.

Refs #26622

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjVgGJk1fDCWsatrWt53BS
