### PR TITLE
test(goal-index): assert the rollback failure the fault can actually reach

### DIFF
--- a/test/test_workspace_goal_index.ml
+++ b/test/test_workspace_goal_index.ml
@@ -124,6 +124,18 @@ let make_goal_task_links_recovery_path_unwritable config =
   make_path_unwritable (Workspace_goal_index.goal_task_links_path config ^ ".last-good")
 ;;
 
+(* [make_path_unwritable] swaps the file for a directory, which fails the read
+   before the write is ever reached. The two rollback cases below are about the
+   write, so they leave the backlog file readable and take the write bit off its
+   directory instead: the atomic publish cannot create the temporary it renames
+   from. Restored before the body returns so [with_test_env] can still clean up. *)
+let with_backlog_write_blocked config f =
+  let dir = Filename.dirname (Workspace_backlog.backlog_path config) in
+  let previous = (Unix.stat dir).Unix.st_perm in
+  Unix.chmod dir 0o555;
+  Fun.protect ~finally:(fun () -> Unix.chmod dir previous) f
+;;
+
 let make_backlog_path_unwritable config =
   make_path_unwritable (Workspace_backlog.backlog_path config)
 ;;
@@ -475,12 +487,15 @@ let test_batch_add_task_backlog_write_failure_rolls_back_goal_links () =
           mutation_count)))
 ;;
 
-let test_add_task_backlog_write_failure_surfaces_rollback_failure () =
+let test_add_task_goal_link_write_failure_surfaces_rollback_failure () =
   with_test_env (fun config ->
     with_activity_counter (fun activity_count ->
       with_mutation_counter (fun mutation_count ->
-        make_backlog_path_unwritable config;
         let message_count_before = message_count config in
+        (* Placed before the directory is sealed: the hook below re-runs this
+           and [make_path_unwritable] is a no-op once the directory exists. *)
+        make_goal_task_links_recovery_path_unwritable config;
+        with_backlog_write_blocked config @@ fun () ->
         Workspace_goal_index.For_testing.with_before_unlink_task_from_goal
           (fun hook_config ~goal_id:_ ~task_id:_ ->
              make_goal_task_links_recovery_path_unwritable hook_config)
@@ -493,14 +508,14 @@ let test_add_task_backlog_write_failure_surfaces_rollback_failure () =
                  ~priority:1
                  ~description:""
              with
-             | Error (Workspace.Backlog_read_failed msg) ->
+             | Error (Workspace.Goal_link_write_failed msg) ->
                check_bool
                  "rollback failure is surfaced"
                  true
                  (string_contains ~needle:"goal link rollback failed" msg)
              | Error err ->
                Alcotest.failf
-                 "expected Backlog_read_failed, got %s"
+                 "expected Goal_link_write_failed, got %s"
                  (Workspace.add_task_error_to_string err)
              | Ok created -> Alcotest.failf "expected failure, created %s" created.task_id);
         (* Rollback failure is surfaced above; unlike the successful rollback
@@ -512,12 +527,13 @@ let test_add_task_backlog_write_failure_surfaces_rollback_failure () =
           mutation_count)))
 ;;
 
-let test_batch_add_task_backlog_write_failure_surfaces_rollback_failure () =
+let test_batch_add_task_goal_link_write_failure_surfaces_rollback_failure () =
   with_test_env (fun config ->
     with_activity_counter (fun activity_count ->
       with_mutation_counter (fun mutation_count ->
-        make_backlog_path_unwritable config;
         let message_count_before = message_count config in
+        make_goal_task_links_recovery_path_unwritable config;
+        with_backlog_write_blocked config @@ fun () ->
         Workspace_goal_index.For_testing.with_before_unlink_task_from_goal
           (fun hook_config ~goal_id:_ ~task_id:_ ->
              make_goal_task_links_recovery_path_unwritable hook_config)
@@ -529,7 +545,7 @@ let test_batch_add_task_backlog_write_failure_surfaces_rollback_failure () =
                  ; "rollback failure batch b", 2, "", None, Some "goal-b"
                  ]
              with
-             | Error (Workspace.Batch_backlog_read_failed msg) ->
+             | Error (Workspace.Batch_goal_link_write_failed msg) ->
                check_bool
                  "rollback failure is surfaced"
                  true
@@ -598,11 +614,11 @@ let () =
           ; test_case
               "single create surfaces rollback failure when backlog write fails"
               `Quick
-              test_add_task_backlog_write_failure_surfaces_rollback_failure
+              test_add_task_goal_link_write_failure_surfaces_rollback_failure
           ; test_case
               "batch create surfaces rollback failure when backlog write fails"
               `Quick
-              test_batch_add_task_backlog_write_failure_surfaces_rollback_failure
+              test_batch_add_task_goal_link_write_failure_surfaces_rollback_failure
           ] )
     ]
 ;;


### PR DESCRIPTION
## 무엇이 문제였나

`test_workspace_goal_index` 의 롤백 케이스 2건이 red 입니다 (`persistent registry 7` / `8`). 둘 다 같은 단언에서 실패합니다:

```
ASSERT rollback failure is surfaced
   Expected: true      (msg 에 "goal link rollback failed" 포함)
   Received: false
```

**순서가 그 문구를 불가능하게 만듭니다.** `add_task_with_result` 는 백로그를 먼저 읽고 (`workspace_task_create.ml:119`) 골 링크는 그 뒤에 씁니다. 롤백 텍스트를 붙이는 자리는 `Goal_link_write_failed` 와 `Backlog_write_failed` 둘뿐입니다 (`:183`, `:193`). `Backlog_read_failed` 시점엔 링크가 아직 없으므로 `append_goal_link_rollback_failures` 는 빈 목록을 받고 원본 msg 를 그대로 돌려줍니다.

읽기가 실패한 이유는 주입된 결함 자체였습니다 — `make_path_unwritable` 은 **파일을 디렉터리로 치환**하므로 쓰기에 도달하기 전에 읽기가 깨집니다. 테스트 이름은 `..._backlog_write_failure_...` 인데 매치하는 것은 `Backlog_read_failed` 였고, 그 불일치가 증상이었습니다.

## 무엇을 바꿨나

백로그 파일은 읽히게 두고 **그 디렉터리의 쓰기 비트만** 뺍니다. 그러면 골 링크 쓰기가 실패하고, 그 롤백이 `.last-good` 디렉터리에 부딪혀 실패하며, 메시지가 둘 다 싣습니다:

```
Error linking task to goal: write_goal_task_links: primary readback mismatch for …;
  goal link rollback failed: goal-a/task-001: write_goal_task_links: recovery write/readback failed …
```

이름도 증명하는 것에 맞춰 `goal_link_write_failure` 로 바꿨습니다.

복구 경로 결함은 디렉터리를 봉인하기 **전에** 만듭니다 — `make_path_unwritable` 은 `mkdir` 이 필요하고, 디렉터리가 이미 있으면 no-op 이라 훅에서 재실행돼도 안전합니다. 권한은 `Fun.protect` 로 되돌려 `with_test_env` 의 정리가 계속 동작합니다.

## 커버리지는 늘어납니다

기존 `Goal_link_write_failed` 케이스는 `String.length msg > 0` 만 봅니다 (`:381`). 롤백 문구를 확인하는 곳은 이 두 케이스뿐이고, 지금까지 한 번도 통과한 적이 없습니다.

## 남는 것 — backlog-write 경로는 여전히 미커버

그 경로를 격리하려면 **골 링크 쓰기는 성공하고 백로그 쓰기만 실패**해야 하는데, 둘 다 `.masc/tasks` 에 살아서 디렉터리 단위 결함으로는 나눌 수 없습니다. 두 단계 사이의 seam 을 프로덕션에 넣는 것은 test backdoor 라 `CLAUDE.md` 체크리스트 6번에 걸립니다. 이 PR 에서는 하지 않았습니다.

## 검증

```
$ ./_build/default/test/test_workspace_goal_index.exe
Test Successful in 0.130s. 17 tests run.       # exit 0 (수리 전: 2 failures)
```

mutation — `append_goal_link_rollback_failures` 가 non-empty 목록에 대해 msg 를 그대로 반환:

```
2 failures! in 0.122s. 17 tests run.
```

원복 후 17 green.

## CI 배선은 별도

이 스위트는 CI 에 배선돼 있지 않습니다 (`#27354` 의 4개 중 3개가 그렇고, 배선된 하나만 초록이었습니다). 배선은 unwired baseline 줄을 건드리는데 #28474 · #28491 이 이미 같은 줄에 걸려 있어 3-way 충돌이 됩니다. 그 둘이 정리된 뒤 별도로 올리는 편이 낫습니다.

Refs #27354

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjVgGJk1fDCWsatrWt53BS
