### PR TITLE
test(task-outcomes): meet the evidence and persistence contracts the tool now has

### DIFF
--- a/test/test_keeper_task_outcomes.ml
+++ b/test/test_keeper_task_outcomes.ml
@@ -345,7 +345,24 @@ let strict_contract : Masc_domain.task_contract =
   ; verify_gate_evidence = []
   }
 
+(* [verification_submit_request_fn] defaults to an error and is filled at boot
+   by the server (`Verification_run_registry.install_global`). These two cases
+   exercise the outcome the task tool returns, not the storage boundary behind
+   it, so they stand in a persisting hook for the duration. Restored after, so
+   a case that should see the absent-hook error still does. *)
+let with_verification_persistence f =
+  let previous = Atomic.get Workspace_hooks.verification_submit_request_fn in
+  Atomic.set
+    Workspace_hooks.verification_submit_request_fn
+    (fun _config ~task:_ ~assignee:_ ~verification_id:_ ~evidence_refs:_ -> Ok ());
+  Fun.protect
+    ~finally:(fun () ->
+      Atomic.set Workspace_hooks.verification_submit_request_fn previous)
+    f
+;;
+
 let test_strict_done_submits_for_verification () =
+  with_verification_persistence @@ fun () ->
   let base_path = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_path)
@@ -387,7 +404,7 @@ let test_strict_done_submits_for_verification () =
               (`Assoc
                 [ "task_id", `String "task-001"
                 ; "result", `String "implementation complete"
-                ; "evidence_refs", `List [ `String "commit:abc123" ]
+                ; "evidence_refs", `List [ `String "note:commit abc123" ]
                 ]));
        match Masc.Workspace.get_tasks_raw config with
        | [ { task_status = Masc_domain.AwaitingVerification _;
@@ -395,12 +412,13 @@ let test_strict_done_submits_for_verification () =
          check string "result preserved as summary"
            "implementation complete" handoff.summary;
          check (list string) "evidence preserved"
-           [ "commit:abc123" ] handoff.evidence_refs
+           [ "note:commit abc123" ] handoff.evidence_refs
        | [ _ ] -> fail "completion did not enter awaiting_verification"
        | tasks ->
          failf "expected exactly one persisted task, got %d" (List.length tasks))
 
 let test_default_done_is_terminal () =
+  with_verification_persistence @@ fun () ->
   let base_path = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_path)
@@ -441,7 +459,7 @@ let test_default_done_is_terminal () =
              (`Assoc
                [ "task_id", `String "task-001"
                ; "result", `String "implementation complete"
-               ; "evidence_refs", `List [ `String "commit:abc123" ]
+               ; "evidence_refs", `List [ `String "note:commit abc123" ]
                ])
        in
        (match execution.disposition with
@@ -455,7 +473,7 @@ let test_default_done_is_terminal () =
          check string "result preserved as summary"
            "implementation complete" handoff.summary;
          check (list string) "evidence preserved"
-           [ "commit:abc123" ] handoff.evidence_refs
+           [ "note:commit abc123" ] handoff.evidence_refs
        | [ _ ] -> fail "advisory/default completion was not terminal"
        | tasks ->
          failf "expected exactly one persisted task, got %d" (List.length tasks))


### PR DESCRIPTION
## 무엇이 문제였나

`test_keeper_task_outcomes` 가 main 에서 **4건 실패**하고 CI 에 배선돼 있지 않습니다 (#27354 · #28031 과 같은 클래스). 넷 중 둘은 스위트가 **이동한 계약** 위에 서 있던 것이었습니다.

### 1층 — evidence 형식

#27280 (`fd6d86deb8 fix(task): refuse an evidence reference the store cannot read, at submit`) 이 `keeper_task_done` 을 조였습니다:

```
evidence_refs entries must be artifact:<producer-root-relative-path> or note:<text>.
Nothing else can be read back at review. Wrap a Board post id, a commit, a URL,
or any narrative as note:<text>.
```

fixture 는 `"commit:abc123"` 을 그대로 보내고 있었고, 그래서 완료가 상태 전이에 닿기 전에 거절됐습니다. 도구가 안내하는 대로 `note:` 로 감쌌습니다.

### 2층 — verification 영속 훅

그걸 지나자 다음이 나왔습니다:

```
verification request creation failed before status transition:
  verification request persistence hook is not installed
```

`verification_submit_request_fn` 은 기본값이 에러이고 서버가 부팅 때 채웁니다 (`Verification_run_registry.install_global`). 테스트 프로세스는 채우지 않습니다. 이 두 케이스는 **도구가 돌려주는 outcome** 이 대상이지 그 뒤의 저장 경계가 아니므로, 지속되는 훅을 세워두고 끝나면 되돌립니다 — 훅 부재 에러를 봐야 하는 케이스는 계속 볼 수 있습니다.

`.mli:145` 가 그 `Atomic.t` 를 공개하고 있고, `test_workspace_coverage.ml:1839` 가 같은 방식으로 다른 훅을 세웁니다.

## 결과

`strict done submits for verification` 이 둘 다 적용하고 통과합니다. **4 failures → 3.**

```
$ ./_build/default/test/test_keeper_task_outcomes.exe
3 failures! in 0.086s. 10 tests run.
```

## 남은 3건은 별개이고 여기서 다루지 않습니다

- **`default done is terminal`** — 이제 훅 에러 대신 **진짜 질문**에 도달합니다. 태스크는 계약 없이(`add_task`) 만들어지는데도 완료가 검증 제출 경로를 탑니다. 기본이 submit-for-verification 이 된 것인지, 케이스가 낡은 것인지 — 훅 에러가 그 구분을 가리고 있었습니다.
- **`keeper_tasks_list recovery is degraded`** — `recovery_non_authoritative` 를 기대하고 `primary` 를 관측합니다.
- **`keeper_tasks_list revision covers projection`** — 출력에 단언이 남지 않고 실패합니다.

셋 다 분류가 먼저이고, **분류 전에 기대값을 관측값으로 맞추면** 결함을 테스트로 승인하게 됩니다 (#28474 에서 같은 순서로 처리했습니다).

## CI 배선은 별도

이 스위트는 미배선입니다. 배선은 unwired baseline 줄을 건드리는데 #28474 · #28491 이 이미 같은 줄에 걸려 있고, 어차피 3건이 남아 있어 지금은 초록이 아닙니다.

Refs #27354

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjVgGJk1fDCWsatrWt53BS
