### PR TITLE
test(capabilities): locate the example manifest from the masc root too

### DIFF
--- a/packages/agent_core/test/test_capabilities.ml
+++ b/packages/agent_core/test/test_capabilities.ml
@@ -1650,13 +1650,28 @@ let test_manifest_base_label_constructor_canonicalizes () =
 ;;
 
 let test_example_manifest_base_labels_are_canonical () =
-  let path =
+  (* The candidates are cwd-relative and the file lives at
+     [packages/agent_core/docs/]. Dune runs this suite from that directory, but
+     the executable is also driven by hand from the masc root, where none of the
+     three original candidates resolve — so that invocation reported the example
+     manifest as unparseable rather than as unlocated. The repo-root-relative
+     path covers it, and a miss now names the directory it searched from instead
+     of failing later on a path nobody chose. *)
+  let candidates =
     [ "docs/example-capability-manifest.json"
     ; "../docs/example-capability-manifest.json"
     ; "../../docs/example-capability-manifest.json"
+    ; "packages/agent_core/docs/example-capability-manifest.json"
     ]
-    |> List.find_opt Sys.file_exists
-    |> Option.value ~default:"docs/example-capability-manifest.json"
+  in
+  let path =
+    match List.find_opt Sys.file_exists candidates with
+    | Some path -> path
+    | None ->
+      failf
+        "example manifest not found from %s; tried %s"
+        (Sys.getcwd ())
+        (String.concat ", " candidates)
   in
   match Capability_manifest.load_file path with
   | Error msg -> failf "example manifest should parse: %s" msg


### PR DESCRIPTION
## 무엇이 문제였나

`test_capabilities.exe` 는 dune 으로 돌면 통과하고(dune 이 `packages/agent_core` 에서 실행), **같은 실행 파일을 masc 루트에서 손으로 태우면 실패**합니다.

```
$ ./_build/default/packages/agent_core/test/test_capabilities.exe        # 루트에서
ASSERT example manifest should parse: cannot read capability manifest
  docs/example-capability-manifest.json: No such file or directory

$ cd packages/agent_core && ../../_build/…/test_capabilities.exe
Test Successful in 0.054s. 101 tests run.
```

원인은 cwd 상대 후보 세 개입니다:

```ocaml
[ "docs/example-capability-manifest.json"
; "../docs/example-capability-manifest.json"
; "../../docs/example-capability-manifest.json" ]
|> List.find_opt Sys.file_exists
|> Option.value ~default:"docs/example-capability-manifest.json"
```

파일은 `packages/agent_core/docs/` 에 있어서 masc 루트에서는 셋 다 안 맞습니다.

## 메시지가 그 사실을 숨겼습니다

찾지 못하면 조용히 첫 후보로 폴백하고, `load_file` 이 *"cannot read capability manifest … No such file or directory"* 를 냅니다. **manifest 가 깨진 것처럼 읽힙니다** — 실제로는 탐색이 닿지 않은 경로입니다.

세션 중 이 실패를 보고 #27930(capability manifest 관련 이슈)의 증상으로 오독할 뻔했습니다. 잘못된 디렉터리에서 난 red 는 대상 코드 탓으로 넘기기 쉽습니다.

## 무엇을 바꿨나

- 저장소 루트 기준 후보 `packages/agent_core/docs/example-capability-manifest.json` 추가
- 조용한 폴백을 **탐색한 디렉터리와 시도한 후보 전부를 명시하는 실패**로 교체

## 검증

```
루트에서            101 tests, exit 0      (수리 전: 1 failure)
packages/agent_core 101 tests, exit 0      (수리 전에도 통과)
```

mutation — 새 후보만 제거:

```
ASSERT example manifest not found from /…/masc/.worktrees/…;
  tried docs/…, ../docs/…, ../../docs/…
```

루트 실행은 실패하고 `packages/agent_core` 실행은 초록으로 남습니다. 즉 **두 변경(후보 추가 / 메시지 개선)이 분리 가능**하고 각각 관측됩니다. 원복 후 101 green.

## 범위

CI 는 `@packages/agent_core/test/runtest` alias 로 돌아 dune 이 cwd 를 맞춰주므로 **CI 동작에는 변화가 없습니다.** 수동 실행과 실패 메시지만 바뀝니다. baseline 이나 배선 파일은 건드리지 않아 대기 중인 다른 PR 과 충돌하지 않습니다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjVgGJk1fDCWsatrWt53BS
