### PR TITLE
fix(keeper): signal a freed turn slot only to a lane that lost it

### DIFF
--- a/lib/keeper/keeper_owner.ml
+++ b/lib/keeper/keeper_owner.ml
@@ -199,6 +199,15 @@ type t =
   ; stopping_waiters : ((unit, error) result Eio.Promise.u) list ref
   ; shutdown_idle_waiters : ((unit, error) result Eio.Promise.u) list ref
   ; on_turn_slot_released : (unit -> unit) option
+  ; autonomous_lost_slot : bool ref
+        (* Set when the autonomous lane asked for the slot and was refused,
+           cleared when the release notification is delivered. Without it the
+           notification fires after every turn, and since a woken keeper starts
+           its next turn immediately, each turn's end schedules the next one:
+           the keepalive cadence stops governing and turn rate rises to one per
+           turn duration. Only a lane that actually lost the slot needs telling
+           that it is free. Owner-fiber-local; every reader and writer below
+           runs in the command loop. *)
   }
 
 let error_to_string = function
@@ -236,8 +245,9 @@ let notify_turn_slot_released t =
   match t.on_turn_slot_released with
   | None -> ()
   | Some notify ->
-    if Option.is_none (Atomic.get t.turn_in_flight)
+    if Option.is_none (Atomic.get t.turn_in_flight) && !(t.autonomous_lost_slot)
     then (
+      t.autonomous_lost_slot := false;
       try notify () with
       | exn ->
         Log.Keeper.routine
@@ -495,6 +505,7 @@ let start
     ; store_error = ref None
     ; child_active = ref false
     ; child_cancel = Atomic.make None
+    ; autonomous_lost_slot = ref false
     ; stopping_waiters = ref []
     ; shutdown_idle_waiters = ref []
     ; on_turn_slot_released
@@ -845,6 +856,9 @@ let start
               | Ok () ->
                 (match Atomic.get t.turn_in_flight with
                  | Some in_flight ->
+                   (match lane with
+                    | Autonomous -> t.autonomous_lost_slot := true
+                    | Chat_operation | Maintenance -> ());
                    Eio.Promise.resolve
                      resolve
                      (Ok (Autonomous_busy (Turn_busy (Some in_flight))))

--- a/lib/keeper/keeper_owner.mli
+++ b/lib/keeper/keeper_owner.mli
@@ -140,9 +140,19 @@ val start
   -> keeper_name:string
   -> initial_meta:Keeper_meta_contract.keeper_meta option
   -> (t, error) result
-(** [on_turn_slot_released] fires when a turn ends and the slot is still
-    unclaimed after the queued chat operation, if any, has been offered it. The
-    signal therefore means "a turn can start now", not "a turn ended".
+(** [on_turn_slot_released] fires when a turn ends, the slot is still unclaimed
+    after the queued chat operation (if any) has been offered it, and the
+    autonomous lane has been refused the slot since the last notification. The
+    signal therefore means "the lane that lost the slot can start now", not "a
+    turn ended".
+
+    All three conditions are load-bearing. Dropping the third one is what
+    {!Keeper_registry.Turn_slot_released} did on 2026-08-12: a keeper woken by
+    the release starts its next turn at once, so every turn end scheduled the
+    next turn and the keepalive cadence stopped governing. Measured on the live
+    fleet across the restart that carried it: turn starts went from 114.9/hour
+    to 1523.5/hour, and the median interval between keepalive cycles fell from
+    313s to 10s — the turn duration, not the configured cadence.
 
     It exists because the two lanes learn about a free slot by opposite means.
     A chat producer notifies the Owner through {!wake_operation_drain} — "the

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -916,11 +916,27 @@ let initialize_owner_state_blocking
         ~on_turn_slot_released:
           (Some
              (fun ~keeper_name ->
-               ignore
-                 (Keeper_registry.wakeup_running
-                    ~intent:Keeper_registry.Turn_slot_released
-                    ~base_path:(Mcp_server.workspace_config state).base_path
-                    keeper_name)))
+               match
+                 Keeper_registry.wakeup_running
+                   ~intent:Keeper_registry.Turn_slot_released
+                   ~base_path:(Mcp_server.workspace_config state).base_path
+                   keeper_name
+               with
+               | Keeper_registry.Signaled -> ()
+               | Keeper_registry.Deferred_unregistered ->
+                 Log.Keeper.info
+                   ~keeper_name
+                   "turn slot release wake deferred: keeper is no longer registered"
+               | Keeper_registry.Deferred_not_running phase ->
+                 Log.Keeper.info
+                   ~keeper_name
+                   "turn slot release wake deferred: phase=%s"
+                   (Keeper_state_machine.phase_to_string phase)
+               | Keeper_registry.Deferred_lifecycle _ ->
+                 (* The registry already logged this arm and incremented
+                    LifecycleDispatchRejections with intent=turn_slot_released;
+                    repeating it here would double-count one denial. *)
+                 ()))
         (Mcp_server.workspace_config state)
     with
     | Ok count -> count

--- a/test/test_keeper_owner.ml
+++ b/test/test_keeper_owner.ml
@@ -881,9 +881,58 @@ let test_turn_slot_release_signals_availability () =
     "a handoff claimed by chat owes no availability signal"
     0
     !released;
+  (* Only a lane that asked and was refused is owed the signal. Nothing has
+     been refused yet, so make the autonomous lane lose the slot to the chat
+     turn now holding it. *)
+  (match Owner.run_autonomous_if_idle owner (fun () -> ()) with
+   | Ok (`Busy (Owner.Turn_busy _)) -> ()
+   | Ok (`Busy other) ->
+     fail ("autonomous lost the slot for the wrong reason: "
+           ^ Owner.autonomous_block_to_string other)
+   | Ok (`Ran ()) -> fail "autonomous ran while the chat lane held the slot"
+   | Error error -> fail (Owner.error_to_string error));
   Eio.Promise.resolve resolve_release_chat ();
   ignore (await_terminal owner (operation_id "kmsg-slot-release") 1_000);
-  check int "the slot left unclaimed signals once" 1 !released
+  check int "the slot left unclaimed signals the refused lane once" 1 !released
+;;
+
+(* Regression guard for the wake storm of 2026-08-12: the notification used to
+   fire on every turn end, and a woken keeper starts its next turn at once, so
+   each turn scheduled the next one and the fleet ran 13x its measured turn
+   rate. A turn that nobody was waiting behind owes no signal. *)
+let test_uncontested_turn_end_signals_nothing () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let released = ref 0 in
+  let path = Filename.temp_file "keeper-owner-uncontested-" ".sqlite3" in
+  Unix.unlink path;
+  Eio.Switch.on_release sw (fun () ->
+    if Sys.file_exists path then Unix.unlink path);
+  let owner =
+    owner_ok
+      (Owner.start
+         ~sw
+         ~store:{ replace = (fun _ -> Ok ()); remove = (fun _ -> Ok ()) }
+         ~operation_store_path:path
+         ~now:(fun () -> 42.0)
+         ~operation_runner:None
+         ~on_turn_slot_released:(Some (fun () -> incr released))
+         ~keeper_name:"uncontested"
+         ~initial_meta:(Some (make_meta "uncontested")))
+  in
+  List.iter
+    (fun turn ->
+      match Owner.run_autonomous_if_idle owner (fun () -> ()) with
+      | Ok (`Ran ()) -> ()
+      | Ok (`Busy block) ->
+        fail
+          (Printf.sprintf
+             "turn %d found the slot busy on an idle owner: %s"
+             turn
+             (Owner.autonomous_block_to_string block))
+      | Error error -> fail (Owner.error_to_string error))
+    [ 1; 2; 3 ];
+  check int "an uncontested turn end signals nothing" 0 !released
 ;;
 
 let test_chat_lane_holder_blocks_autonomous_admission () =
@@ -2436,6 +2485,10 @@ let () =
             "turn slot release signals availability"
             `Quick
             test_turn_slot_release_signals_availability
+        ; test_case
+            "uncontested turn end signals nothing"
+            `Quick
+            test_uncontested_turn_end_signals_nothing
         ; test_case
             "operation lifecycle is durable and projected"
             `Quick


### PR DESCRIPTION
#28451 이 프로덕션에서 **wake storm** 을 일으켰습니다. 이 PR 이 원인을 닫습니다.

## 증상 (실측)

재시작 시각 `2026-08-12T17:19:31Z` 을 경계로 같은 fleet 을 비교했습니다. 출처는 `.masc/logs/system_log_2026-08-12.jsonl`, 턴 시작은 FSM 전이 `idle -> phase_gating`, 사이클은 `keepalive turn scheduled for <keeper>` 입니다.

| | PRE (17.33h) | POST (0.59h) |
|---|---|---|
| 턴 시작 | 1990건 = **114.9/시간** | 901건 = **1523.5/시간** |
| keepalive 사이클 간격 중앙값 | 313초 | **10초** |
| 간격 60초 미만 | 7.9% (n=1146) | **98.7%** (n=900) |

POST 간격 중앙값 10초는 설정된 케이던스가 아니라 관측된 **턴 지속시간**(`turn_duration_sec` 4~9초)과 일치합니다. 케이던스가 더 이상 주기를 결정하지 못합니다.

같은 빌드 창(01:06~02:12 KST)에 들어간 다른 keeper 커밋 2건(#28456, #28462)은 wake **프롬프트 내용** 변경이라 주기에 영향이 없습니다.

## 원인

`notify_turn_slot_released` 는 자식 턴이 끝날 때마다 호출되고(`keeper_owner.ml`), 조건은 "슬롯이 비었는가" 하나뿐이었습니다. **기다리는 레인이 있는지는 보지 않습니다.**

```
턴 종료 → 슬롯 free → 발화 → 자기 keeper 를 wake
        → interruptible_sleep 이 Woken 반환 → 즉시 다음 사이클
        → 턴 시작 → 종료 → 반복
```

RFC-0373 이 고치려던 것은 "**거부당한** 자율 레인에게 슬롯이 났다고 알리기"인데, 구현은 "**모든** 턴 종료를 알리기"가 됐습니다. 턴 종료 직후에는 언제나 슬롯이 비어 있으므로 조건이 사실상 상수 참이었습니다.

## 수정

거부를 래치합니다. 자율 레인이 슬롯을 요청했다가 `Turn_busy` 로 거부되면 Owner 가 기록하고, 알림을 전달할 때 지웁니다. 아무도 뒤에 줄서지 않은 턴은 아무 신호도 내지 않습니다.

래치는 Owner 파이버 전용입니다 — 쓰기는 `Run_if_idle` 커맨드 처리부, 읽기는 커맨드 루프이고 둘 다 같은 파이버라 `bool ref` 로 충분합니다.

## 같은 경계의 결함 1건

**버려지던 typed outcome** — bootstrap 리스너가 `ignore (Keeper_registry.wakeup_running ...)` 로 `wakeup_outcome` 을 버렸습니다. `Deferred_unregistered` / `Deferred_not_running` 으로 wake 가 유실돼도 흔적이 없습니다. 형제 호출부 3곳(`fusion_sink.ml:380`, `completion_authority_wakeup.ml:78`, `server_schedule_consumers.ml:525`)은 전부 exhaustive match 하므로 그 패턴에 맞췄습니다. `Deferred_lifecycle` 은 registry 가 이미 `intent=turn_slot_released` 로 로깅+카운트하므로 중복 기록하지 않습니다.

이 두 변형은 실제로 도달합니다 — 일시정지/종료 중인 keeper 는 `Running` 이 아니므로 `Deferred_not_running` 이 나옵니다.

`notify` 의 catch-all 에 `Eio.Cancel.Cancelled` 재-raise 를 넣었다가 **철회**했습니다. 호출 사슬(`wakeup_running` → `admit_autonomous` → `Otel_metric_store.inc_counter` → `Log.Keeper.info`) 어디에도 Eio 서스펜션 지점이 없어 `Cancelled` 가 발생할 수 없고, 리스너 계약도 "must not block" 입니다. 도달 불가능한 가드를 넣는 것이라 뺐습니다.

## 검증

- `test/test_keeper_owner.exe` 39/39 통과.
- 신규 `uncontested turn end signals nothing` — 아무도 거부당하지 않은 상태에서 자율 턴 3회를 연속 실행하고 신호 0건을 확인.
- **뮤테이션 검증**: 래치 조건 `&& !(t.autonomous_lost_slot)` 를 제거하면 이 테스트가 실패합니다 (`1 failure! in 0.803s`). 가드가 공허하지 않음을 확인했습니다.
- 기존 `turn slot release signals availability` 는 자율 레인이 한 번도 거부당하지 않는 시나리오라 옛 계약을 인코딩하고 있었습니다. 채팅이 슬롯을 잡은 뒤 자율 시도를 넣어 실제 대기자를 만들도록 갱신했습니다.
- `scripts/lint-cancel-guard.sh` EXIT=0, `scripts/lint-ignore-without-comment.sh` EXIT=0.

## 남는 것

프로덕션은 이 PR 이 병합되고 **재빌드+재시작이 끝나야** 정상 주기로 돌아옵니다. 그 전까지는 계속 13.3배로 돕니다.

RFC-0373 의 **순서** 문제(경합 시 채팅이 먼저 슬롯을 받는 것)는 이 PR 범위 밖이고 그대로 열려 있습니다.
