### PR TITLE
test(claude-runtime): load session state under the keeper the runner used

### DIFF
--- a/test/test_keeper_claude_code_runtime.ml
+++ b/test/test_keeper_claude_code_runtime.ml
@@ -721,12 +721,13 @@ let test_tools_support_false_omits_mcp_bridge () =
                (keeper_response_text turn)))
 ;;
 
-let load_state base_path =
-  match
-    Keeper_official_client_session_store.load
-      ~base_path
-      ~keeper_name:"claude-fixture"
-  with
+(* The suite drives two runners under different keeper names, and the session
+   store is keyed by that name: the main runner uses [claude-fixture] and
+   [run_direct_attempt] uses [claude-pre-dispatch]. Loading under a fixed name
+   reads an empty store for the other runner's tests and reports it as state
+   that disappeared. *)
+let load_state ?(keeper_name = "claude-fixture") base_path =
+  match Keeper_official_client_session_store.load ~base_path ~keeper_name with
   | Error detail -> fail detail
   | Ok None -> fail "Claude Code current-owner state disappeared"
   | Ok (Some state) -> state
@@ -1235,7 +1236,9 @@ let test_repeated_tool_stop_records_pre_result_turn_identity () =
                check string "repeated tool" "masc_probe" tool_name;
                check int "repeat threshold" 3 repeated_count
              | _ -> fail "repeated Claude tool call was not a checkpoint yield"));
-         match (load_state base_path).phase with
+         match
+           (load_state ~keeper_name:"claude-pre-dispatch" base_path).phase
+         with
          | Settled { session_id; turn_id; _ } ->
            check
              string


### PR DESCRIPTION
## 무엇이 문제였나

main 의 `Build and Test` red 4건 중 하나인 `lifecycle 14` (`repeated tool stop records pre-result turn identity`) 가 이렇게 실패합니다:

```
ASSERT repeated tool                                   ← 통과
ASSERT repeat threshold                                ← 통과
ASSERT Claude Code current-owner state disappeared     ← 실패
```

메시지가 "런타임이 상태를 저장하지 않는다" 로 읽힙니다. **아닙니다. 스위트 안의 이름 불일치입니다.**

## 세션 스토어는 keeper 이름으로 키를 잡습니다

이 파일은 러너를 둘 굴립니다:

```
메인 러너              ~keeper_name:"claude-fixture"        (2곳)
run_direct_attempt     ~keeper_name:"claude-pre-dispatch"   (1곳, :1104)
```

그런데 `load_state` 가 이름을 하드코딩했습니다:

```ocaml
let load_state base_path =
  Keeper_official_client_session_store.load ~base_path ~keeper_name:"claude-fixture"
```

`run_direct_attempt` 로 돌린 뒤 durable 상태를 단언하는 테스트는 이 하나뿐이라, 그 케이스만 빈 스토어를 읽고 `Ok None` 을 "상태가 사라졌다" 로 보고했습니다. 나머지 네 `load_state` 호출자는 메인 러너를 쓰므로 영향이 없었고, 그래서 이 하나만 red 였습니다.

## 무엇을 바꿨나

`load_state` 가 이름을 받습니다. 기본값은 `claude-fixture` 라 **기존 호출자 4곳은 그대로**이고, 반복-도구 케이스만 `claude-pre-dispatch` 를 넘깁니다.

**런타임은 건드리지 않았습니다.** `Keeper_claude_code_runtime` 은 `settle_host_stop` (`keeper_claude_code_runtime.ml:553-597`) 에서 Codex 런타임과 같은 방식으로 host stop 을 정착시킵니다. 상태는 처음부터 저장되고 있었고, 다른 키 아래 있었을 뿐입니다.

## 검증

```
$ ./_build/default/test/test_keeper_claude_code_runtime.exe
Test Successful in 19.859s. 16 tests run.      # exit 0 (수리 전: 1 failure)
```

mutation — 하드코딩된 이름으로 되돌림:

```
ASSERT repeated tool                                   ← 여전히 통과
ASSERT repeat threshold                                ← 여전히 통과
ASSERT Claude Code current-owner state disappeared     ← 원래 실패 재현
```

나머지 15건은 초록으로 남습니다. 즉 움직인 것은 **그 단언 하나**이고 러너나 런타임이 아닙니다. 원복 후 16 green.

## main red 에 대한 영향

이 PR 이 머지되면 `Build and Test` 의 실패 집합에서 `lifecycle` 이 빠집니다. #28486 이 `read_range` 를 빼므로, 둘이 함께 들어가면 4건 → 2건(`subscription boundary` · `turn-scoped transport`) 이 됩니다.

Refs #28387

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjVgGJk1fDCWsatrWt53BS
