### PR TITLE
fix(dated-jsonl): skip filesystem metadata in the strict layout readers

### DIFF
--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -322,11 +322,24 @@ let day_file_name_is_valid ~year ~month name =
   | None, _ | _, None -> false
 ;;
 
+(* Filesystem metadata the store never wrote: [.DS_Store] on macOS, [.nfs*]
+   handles, editor droppings. A store cannot prevent these appearing next to
+   its day-files, so they are not layout violations to report — the strict
+   readers skip them and keep erroring on any other unexpected entry.
+
+   Without this the strict readers refuse an entire store the moment a Finder
+   window has been opened on it, which is every real store on a macOS machine.
+   The non-strict readers already skip these, because they select entries by
+   name pattern rather than rejecting non-matches; this makes the two agree. *)
+let is_filesystem_metadata entry = String.length entry > 0 && Char.equal entry.[0] '.'
+
 let validate_layout_entries ~parent ~expected ~is_valid entries =
   let rec loop valid_entries = function
     | [] -> Ok (List.rev valid_entries)
     | entry :: rest ->
-      if is_valid entry
+      if is_filesystem_metadata entry
+      then loop valid_entries rest
+      else if is_valid entry
       then loop (entry :: valid_entries) rest
       else Error (Invalid_layout_entry { parent; entry; expected })
   in


### PR DESCRIPTION
`test_dated_jsonl` fails on main. It has failed since #26392 and nobody saw it, because the suite compiled in CI but ran in no suite until I wired it into the focused allowlist in #28455. This fixes the failure that wiring exposed.

## What actually fails

```
FAIL strict entry iteration failed: invalid dated JSONL layout entry
  /tmp/build_.../dated_jsonl_iter_all_entries_result_.../.DS_Store:
  expected YYYY-MM month directory
```

`test_iter_all_entries_result_continues_after_malformed` **creates the `.DS_Store` files itself**:

```ocaml
Fs_compat.append_file (Filename.concat dir ".DS_Store") "not dated";
Fs_compat.append_file (Filename.concat (Filename.concat dir "2026-02") ".DS_Store") "not dated";
```

and then asserts `iter_all_entries_result` returns `Ok ()`. The reader has no handling for these at all, so it errors. The test states an intent the implementation never had.

I previously described this failure as macOS-only noise from Finder and reasoned that CI, being Linux, was unaffected. That was wrong on both counts, and the second claim is why I wired a failing suite into CI. The control I ran (the main-built binary reproduces it) was sound; the causal story I put on top of it was not, and I acted on the story.

## The fix

The strict readers skip filesystem metadata — dot-prefixed entries — instead of reporting them as layout violations:

```ocaml
let is_filesystem_metadata entry = String.length entry > 0 && Char.equal entry.[0] '.'
```

Two reasons this belongs in the reader rather than in the test's expectations:

1. **The store never wrote them and cannot prevent them.** A layout violation should mean the store broke its own contract. `.DS_Store`, `.nfs*` handles and editor droppings are placed by other software; counting them as violations makes the contract depend on something outside the store's control. Any real store on a macOS machine acquires `.DS_Store` the moment a Finder window opens on it, and the strict readers would refuse the whole store.

2. **The non-strict readers already skip them.** `list_subdirs` *selects* by name pattern rather than *rejecting* non-matches, so `read_recent` and friends have always ignored `.DS_Store`. The two reader families disagreed on the same directory. This makes them agree.

Scope is one named class. Everything else keeps erroring:

| entry | before | after |
|---|---|---|
| `2026-01/` | collected | collected |
| `.DS_Store` | **error** | skipped |
| `garbage.txt` | error | error |
| symlink | error | error |

A dot-prefixed name cannot be a legitimate layout entry: month directories are `YYYY-MM` and day files are `DD.jsonl`, so the format already excludes them.

## Verification (local)

| check | result |
|---|---|
| `dune build --root . test/test_dated_jsonl.exe` | `BUILD_EXIT=0` |
| `test_dated_jsonl.exe` | **50 tests run, Test Successful** |

That suite has been red on every run in this session — this is the first green. The failing case is now covered by the test that was already asserting the behaviour, so no new test is added: the existing one goes from red to green, which is the same evidence a new test would provide.

Sibling suites over the same traversal, to catch a consumer I did not look at:

| suite | result |
|---|---|
| `test_dated_jsonl_count_cache` | **7 tests run, Test Successful** |
| `test_audit_log` | **11 tests run, Test Successful** |

## Relationship to #28485

#28485 tracks four failing suites on main. This fixes the first row of its table (`Dated_jsonl` / `read_range 4`) and nothing else. The other three — `subscription boundary 27`, `turn-scoped transport 0`, `lifecycle 14` — are untouched by this change and still fail on this PR's run, which is expected: they are in transport and lifecycle code this PR does not reach.

Evidence they are not mine: the same `subscription boundary 27` failure appears on #28483, which touches only `eval_calibration`. Two unrelated PRs failing the same case is a main problem, and #28387 already tracks that pair specifically.

CI confirmation that this PR's part works — from its own Build and Test run:

```
Testing `Dated_jsonl'.
Test Successful in 0.042s. 50 tests run.
```

## Urgency

`test_dated_jsonl` is in the CI focused allowlist as of #28455, so main is red or about to be on the next completed run.

RFC-WAIVED: one predicate in `lib/dated_jsonl/dated_jsonl.ml`. None of the RFC-required subsystems.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
