### PR TITLE
perf(dated-jsonl): give the range reader a projecting variant

### DIFF
--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -181,18 +181,19 @@ let date_bounds ?since ?until () =
 
    [read_range_recent] is the bounded reader for a date range and takes the
    same cap the unfiltered branch already uses. *)
-let read_store_records store ?since ?until () =
+let read_store_records store ?since ?until ~f () =
   let since, until = date_bounds ?since ?until () in
   if since = "" && until = ""
-  then Dated_jsonl.read_recent store max_signal_scan
+  then Dated_jsonl.filter_map_recent store max_signal_scan ~f
   else (
     let start_date = if since = "" then "2020-01-01" else since in
     let end_date = if until = "" then "2099-12-31" else until in
-    Dated_jsonl.read_range_recent
+    Dated_jsonl.filter_map_range_recent
       store
       ~since:start_date
       ~until:end_date
-      max_signal_scan)
+      max_signal_scan
+      ~f)
 ;;
 
 let has_any_records store = Dated_jsonl.read_recent store 1 <> []
@@ -465,9 +466,13 @@ let wake_payload_record_identity json =
 let read_recent_verdicts ?since ?until ?(limit = max_recent_verdicts) ()
   : harness_verdict_item list
   =
-  let records = read_store_records (Eval_calibration.get_store ()) ?since ?until () in
   let verdicts : harness_verdict_item list =
-    records |> List.filter_map verdict_item_of_json
+    read_store_records
+      (Eval_calibration.get_store ())
+      ?since
+      ?until
+      ~f:verdict_item_of_json
+      ()
   in
   let verdicts =
     List.sort
@@ -493,10 +498,13 @@ let read_recent_verdicts_for_agents
   then []
   else (
     let is_wanted name = List.exists (String.equal name) wanted in
-    let records = read_store_records (Eval_calibration.get_store ()) ?since ?until () in
     let verdicts : harness_verdict_item list =
-      records
-      |> List.filter_map verdict_item_of_json
+      read_store_records
+        (Eval_calibration.get_store ())
+        ?since
+        ?until
+        ~f:verdict_item_of_json
+        ()
       |> List.filter (fun verdict -> is_wanted verdict.agent_name)
     in
     let verdicts =
@@ -509,9 +517,13 @@ let read_recent_verdicts_for_agents
 ;;
 
 let read_pre_compact_events ?since ?until () =
-  let records = read_store_records (get_pre_compact_store ()) ?since ?until () in
   let events : pre_compact_event list =
-    records |> List.filter_map pre_compact_event_of_json
+    read_store_records
+      (get_pre_compact_store ())
+      ?since
+      ?until
+      ~f:pre_compact_event_of_json
+      ()
   in
   List.sort
     (fun (left : pre_compact_event) (right : pre_compact_event) ->
@@ -520,20 +532,25 @@ let read_pre_compact_events ?since ?until () =
 ;;
 
 let read_wake_payload_events ?since ?until () =
-  let records = read_store_records (get_wake_payload_store ()) ?since ?until () in
   let events : wake_payload_event list =
-    records
-    |> List.filter_map (fun json ->
-      match wake_payload_event_of_json json with
-      | Ok event -> Some event
-      | Error detail ->
-        let keeper_name, trace_id = wake_payload_record_identity json in
-        Log.Harness.warn
-          "[wake_payload] rejected persisted record keeper=%s trace=%s: %s"
-          keeper_name
-          trace_id
-          detail;
-        None)
+    read_store_records
+      (get_wake_payload_store ())
+      ?since
+      ?until
+      ~f:(fun json ->
+        match wake_payload_event_of_json json with
+        | Ok event -> Some event
+        | Error detail ->
+          let keeper_name, trace_id = wake_payload_record_identity json in
+          (* Unconditional per-row warn: no quota and no early stop, so it does
+             not care that the reader calls this newest-first. *)
+          Log.Harness.warn
+            "[wake_payload] rejected persisted record keeper=%s trace=%s: %s"
+            keeper_name
+            trace_id
+            detail;
+          None)
+      ()
   in
   List.sort
     (fun (left : wake_payload_event) (right : wake_payload_event) ->

--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -1263,7 +1263,14 @@ let read_range t ~since ~until =
    should use this so a wide window cannot scan months of multi-MB files.
    Returns entries oldest-first within the collected set (same convention
    as [read_recent]). *)
-let read_range_recent ?(offset = 0) t ~since ~until n =
+(* Range counterpart to [filter_map_recent]: the caller's projection runs per
+   row so the parsed tree is unreachable before the next row is read, and
+   [read_range_recent] is this with an identity projection.
+
+   [f] runs outside the parse [try] for the same reason as in
+   [filter_map_recent]: the reader swallows [Yojson.Json_error] to skip
+   malformed rows and a caller's decoder must not inherit that swallow. *)
+let filter_map_range_recent ?(offset = 0) t ~since ~until n ~f =
   if n <= 0
   then []
   else (
@@ -1300,16 +1307,21 @@ let read_range_recent ?(offset = 0) t ~since ~until n =
                        List.iter
                          (fun line ->
                             if !count >= n then raise_notrace Done;
-                            try
-                              let json = Yojson.Safe.from_string line in
+                            let parsed =
+                              try Some (Yojson.Safe.from_string line)
+                              with Yojson.Json_error _ -> None
+                            in
+                            match parsed with
+                            | None -> ()
+                            | Some json ->
                               if !skip > 0
                               then decr skip
                               else begin
-                                collected := json :: !collected;
+                                (match f json with
+                                 | Some value -> collected := value :: !collected
+                                 | None -> ());
                                 incr count
-                              end
-                            with
-                            | Yojson.Json_error _ -> ())
+                              end)
                          rev_lines
                      end)
                   days
@@ -1318,6 +1330,10 @@ let read_range_recent ?(offset = 0) t ~since ~until n =
        with
        | Done -> ());
       !collected)
+
+let read_range_recent ?offset t ~since ~until n =
+  filter_map_range_recent ?offset t ~since ~until n ~f:(fun json -> Some json)
+;;
 
 let prune t ~days =
   let mutex = Atomic.get t.mutex in

--- a/lib/dated_jsonl/dated_jsonl.mli
+++ b/lib/dated_jsonl/dated_jsonl.mli
@@ -159,6 +159,24 @@ val read_range : t -> since:string -> until:string -> Yojson.Safe.t list
     within [[since, until]] (inclusive, format ["YYYY-MM-DD"]).
     Result is in chronological order. *)
 
+val filter_map_range_recent
+  :  ?offset:int
+  -> t
+  -> since:string
+  -> until:string
+  -> int
+  -> f:(Yojson.Safe.t -> 'a option)
+  -> 'a list
+(** Range counterpart to {!filter_map_recent}: [List.filter_map f
+    (read_range_recent ?offset t ~since ~until n)] without ever holding the
+    intermediate [Yojson.Safe.t list].
+
+    Same contract as {!filter_map_recent} in every respect that matters —
+    [n] and [offset] count parsed rows rather than selected ones, the returned
+    list is chronological, and {b [f] is called newest-first}, so a projection
+    whose side effects depend on call order is not interchangeable with the
+    [read_range_recent |> List.filter_map] form. *)
+
 val read_range_recent
   :  ?offset:int
   -> t


### PR DESCRIPTION
Closes the asymmetry that produced the unbounded-read defects fixed in #28478 and #28483.

## The asymmetry

`Dated_jsonl` offers two traversals. Only one of them could avoid materialising rows:

| | materialising | projecting |
|---|---|---|
| newest N | `read_recent` | `filter_map_recent` (#28455) |
| date range | `read_range` / `read_range_recent` | **absent** |

A caller reading a date range had no way to decode without first building the whole `Yojson.Safe.t list`. That is why every range call site in this repo materialises — and, with `read_range` also being the only reader carrying no row bound, why range reads converged on *unbounded and materialising*.

`filter_map_range_recent` fills the empty cell. `read_range_recent` becomes it with an identity projection, so both readers now have exactly one traversal implementation each and the two cannot drift.

## Migration

`Dashboard_harness_health.read_store_records` takes `~f` and projects in both of its branches. Its four call sites were all `read_store_records ... |> List.filter_map <decoder>`:

- `read_recent_verdicts` and `read_recent_verdicts_for_agents` → `~f:verdict_item_of_json`
- `read_pre_compact_events` → `~f:pre_compact_event_of_json`
- `read_wake_payload_events` → the inline `Ok`/`Error` decoder moves into `~f`

That last decoder logs a warning per rejected record. It is safe under the reader's newest-first call order because the log is unconditional — no quota, no numbering, no early stop — unlike the rate-limited logging that kept `audit_log.read_entries` out of #28455 and needed the separate treatment in #28463. A comment records why.

`max_signal_scan` is 500, so this is 500 parsed trees per call rather than the 100 000 of the earlier migrations. The reason to do it is the asymmetry, not the bytes: an API with a missing cell steers callers toward the cell that exists.

## Verification (local)

| check | result |
|---|---|
| `dune build --root . test/test_dashboard_harness_health.exe test/test_dated_jsonl.exe` | `BUILD_EXIT=0` |
| `test_dated_jsonl.exe` | **50 tests run, Test Successful** |
| `test_dashboard_harness_health.exe` | **5 tests run, Test Successful** |
| `dune build --root . @fmt` | no diff on any file this PR touches |

No new test. This changes what is held in memory, not what is returned, so the evidence that matters is the existing suites passing unchanged — including `a date filter does not remove the row cap` from #28478, which exercises the range branch that was rewritten here.

`read_range_recent`'s own contract is preserved by construction rather than by assertion: it is now defined as `filter_map_range_recent ~f:(fun json -> Some json)`, so there is no second traversal that could behave differently.

## Not claimed

No RSS or latency number. The RFC-0372 §5 gate needs idle p95 ≤ 50 ms; this host has ranged 65–2255 ms across the session and is currently at load average 400.

RFC-WAIVED: `lib/dated_jsonl/` and one dashboard reader. None of the RFC-required subsystems. Direction is set by existing RFC-0372.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
