### PR TITLE
perf(dashboard): cache the repository observation snapshot

### DIFF
--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -11,11 +11,67 @@ let dashboard_projection_cache_ttl_s =
   Server_dashboard_http_core_cache.dashboard_projection_cache_ttl_s
 ;;
 
-(* Repository observation snapshot handler *)
+(* Repository observation snapshot handler.
+
+   This route was the most expensive on the server per request: 722.9 ms cold
+   and 681.4 ms warm for a 2.9 KB response, measured twice back to back. The
+   second pass costing the same as the first is what an absent cache looks like
+   from outside — every request re-ran two git subprocesses per configured
+   repository (5 repositories, 10 spawns).
+
+   The comment below claimed the fan-out makes the snapshot cost the slowest
+   repository rather than the sum. Timed individually the repositories sum to
+   745 ms and the slowest is 252 ms, and the endpoint measures 681-723 ms.
+   Sampling the process table during a request does show concurrent git
+   children, so the fan-out is real; ten git processes contending on one disk
+   just do not scale down to the slowest one. Corrected rather than removed,
+   because the fan-out is still why this is 745 ms and not several seconds.
+
+   Only [Repo_store.load_all] succeeding is cached. A failure to enumerate the
+   repositories is a transient condition and caching it would hold the error
+   for a TTL after the cause cleared. *)
+let repository_observation_snapshot_json ~clock ~(config : Workspace.config) =
+  let base_path = config.base_path in
+  match Repo_store.load_all ~base_path with
+  | Error error -> Error error
+  | Ok repos ->
+    let cache_key =
+      Server_dashboard_http_core_cache.dashboard_query_cache_key
+        config
+        "repository_observation_snapshot"
+        []
+    in
+    (* [shell_surface_cache_ttl_s] is the 60 s tier documented for state that
+       "changes more frequently than deep surfaces". A working tree does, and
+       the trade-off is explicit: a cached snapshot reports a tree as it stood
+       up to one TTL ago. Uncached, every poll paid 681 ms of subprocess work
+       to say the same thing. *)
+    Ok
+      (Dashboard_cache.get_or_compute
+         cache_key
+         ~ttl:Server_dashboard_http_core_cache.shell_surface_cache_ttl_s
+         (fun () ->
+           let repo_list =
+             Eio.Fiber.List.map
+               (Server_routes_http_routes_repositories.repository_observation_json
+                  ~base_path)
+               repos
+           in
+           `Assoc
+             [ "ok", `Bool true
+             ; "timestamp", `Float (Eio.Time.now clock)
+             ; "repository_count", `Int (List.length repos)
+             ; "repositories", `List repo_list
+             ]))
+;;
+
 let handle_repository_observation_snapshot ~sw:_ ~clock request reqd =
   Server_auth.with_public_read (fun state req inner_reqd ->
-    let base_path = (Mcp_server.workspace_config state).base_path in
-    match Repo_store.load_all ~base_path with
+    match
+      repository_observation_snapshot_json
+        ~clock
+        ~config:(Mcp_server.workspace_config state)
+    with
     | Error error ->
       Http_server_eio.Response.json_value
         ~status:`Internal_server_error
@@ -23,25 +79,7 @@ let handle_repository_observation_snapshot ~sw:_ ~clock request reqd =
         ~request:req
         (`Assoc [ "ok", `Bool false; "error", `String error ])
         inner_reqd
-    | Ok repos ->
-      (* Each repository's observation is two git subprocesses, and they do not
-         depend on one another, so the snapshot costs the slowest repository
-         rather than the sum of all of them. Sequentially this was 1.4-2.2 s for
-         2.9 KB. *)
-      let repo_list =
-        Eio.Fiber.List.map
-          (Server_routes_http_routes_repositories.repository_observation_json
-             ~base_path)
-          repos
-      in
-      let snapshot =
-        `Assoc
-          [ "ok", `Bool true
-          ; "timestamp", `Float (Eio.Time.now clock)
-          ; "repository_count", `Int (List.length repos)
-          ; "repositories", `List repo_list
-          ]
-      in
+    | Ok snapshot ->
       Http_server_eio.Response.json_value
         ~compress:true
         ~request:req

--- a/lib/server/server_dashboard_http.mli
+++ b/lib/server/server_dashboard_http.mli
@@ -49,6 +49,17 @@ val approval_resolve_decision_required_message : string
 
 (** {1 Board / memory / Gate HTTP entries} *)
 
+val repository_observation_snapshot_json :
+  clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  config:Workspace.config ->
+  (Yojson.Safe.t, string) result
+(** Git observation across the configured repositories, for
+    [GET /api/v1/dashboard/repository-observation-snapshot].
+
+    The snapshot itself is cached; failing to enumerate the repositories is
+    not, so a transient store error is not held for a TTL after it clears.
+    Exposed so the cache policy can be exercised without an HTTP round trip. *)
+
 val handle_repository_observation_snapshot :
   sw:Eio.Switch.t ->
   clock:float Eio.Time.clock_ty Eio.Resource.t ->

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -1478,6 +1478,67 @@ let test_agent_activity_keys_on_its_window () =
       check (float 0.001) "the computed window is the one asked for" 1.0
         (other |> member "hours" |> to_float))
 
+(* The most expensive route on the server per request before this: 722.9 ms
+   cold, 681.4 ms warm, for 2.9 KB — two git subprocesses per configured
+   repository, on every request. *)
+let test_repository_observation_reads_its_cache_key () =
+  with_test_env @@ fun ~env ~sw:_ ~config ->
+  Fun.protect
+    ~finally:Dashboard_cache.invalidate_all
+    (fun () ->
+      Dashboard_cache.invalidate_all ();
+      let cache_key =
+        Server_dashboard_http_core_cache.dashboard_query_cache_key
+          config
+          "repository_observation_snapshot"
+          []
+      in
+      seed_cache cache_key;
+      match
+        Server_dashboard_http.repository_observation_snapshot_json
+          ~clock:(Eio.Stdenv.clock env)
+          ~config
+      with
+      | Error detail -> fail detail
+      | Ok snapshot ->
+        check
+          (of_pp Yojson.Safe.pp)
+          "the snapshot is served from its cache key"
+          (cache_sentinel cache_key)
+          snapshot)
+
+(* Enumerating the repositories is the step that can fail transiently. Caching
+   that failure would hold it for a TTL after the cause cleared, so the cache
+   sits inside the Ok branch and an Error must leave the key untouched. *)
+let test_repository_observation_does_not_cache_a_store_failure () =
+  with_test_env @@ fun ~env ~sw:_ ~config ->
+  Fun.protect
+    ~finally:Dashboard_cache.invalidate_all
+    (fun () ->
+      Dashboard_cache.invalidate_all ();
+      let cache_key =
+        Server_dashboard_http_core_cache.dashboard_query_cache_key
+          config
+          "repository_observation_snapshot"
+          []
+      in
+      (* [Repo_store.load_all] parses repositories.toml, so malformed TOML is
+         the failure it actually reports — an absent file is Ok []. *)
+      let repos_toml =
+        Config_dir_resolver.repositories_toml_path ~base_path:config.base_path
+      in
+      Fs_compat.mkdir_p (Filename.dirname repos_toml);
+      Fs_compat.save_file repos_toml "[repository\nname = \"unterminated";
+      (match
+         Server_dashboard_http.repository_observation_snapshot_json
+           ~clock:(Eio.Stdenv.clock env)
+           ~config
+       with
+       | Ok _ -> fail "malformed repositories.toml should not produce a snapshot"
+       | Error _ -> ());
+      check bool "a failed enumeration leaves the cache key empty" true
+        (Option.is_none (Dashboard_cache.peek cache_key)))
+
 let test_dashboard_proof_http_json_surfaces_submission_index () =
   with_test_env @@ fun ~env:_ ~sw:_ ~config ->
   let module V = Lib.Verification in
@@ -3645,6 +3706,10 @@ let () =
             test_dashboard_proof_http_json_surfaces_submission_index;
           test_case "scheduled-automation reads its cache key" `Quick
             test_scheduled_automation_reads_its_cache_key;
+          test_case "repository observation reads its cache key" `Quick
+            test_repository_observation_reads_its_cache_key;
+          test_case "repository observation does not cache a store failure"
+            `Quick test_repository_observation_does_not_cache_a_store_failure;
           test_case "agent-activity keys on its window" `Quick
             test_agent_activity_keys_on_its_window;
           test_case "execution trust uses narrow Keeper projection" `Quick


### PR DESCRIPTION
Closes the measurement in #28461.

## The cost

The most expensive route on the server per request. Polled twice back to back:

| pass 1 | pass 2 | bytes |
|---|---|---|
| 722.9 ms | 681.4 ms | 2 917 |

The second pass costing the same as the first is what an absent cache looks
like from outside. Every request ran two git subprocesses per configured
repository — 5 repositories, 10 spawns — for 2.9 KB of output.

## Reversing the call made in #28460

That PR left this route alone, arguing that `rg` finds no consumer beyond its
own registration, so caching it would optimise something nobody calls and
"cache it into permanence".

Half of that holds and half does not. Zero in-repo references is evidence, not
proof: it is a public route a keeper or an operator script can reach, and the
dashboard is not the only client the server has. And an unprotected 681 ms
subprocess fan-out is a hazard for whatever *does* poll it — one monitoring
loop is ten git processes per interval. "Permanence" was also overstated:
caching is a few lines and removing the route stays a one-line delete. #28461
remains open for that decision.

## Change

`shell_surface_cache_ttl_s` — the documented 60 s tier for state that "changes
more frequently than deep surfaces". The trade-off is explicit and worth
stating rather than burying: **a cached snapshot reports a working tree as it
stood up to one TTL ago.** Uncached, every poll paid 681 ms of subprocess work
to say the same thing.

Only the success is cached. `Repo_store.load_all` failing is transient —
malformed `repositories.toml`, a partial write — and caching that would hold
the error for a TTL after the cause cleared. The cache therefore sits inside
the `Ok` branch, and a test pins that.

The projection is named (`repository_observation_snapshot_json`) so the policy
has one home and a test can reach it without an HTTP round trip, matching
`dashboard_scheduled_automation_http_json` from #28460.

## A comment corrected

The handler claimed the `Eio.Fiber.List.map` fan-out makes the snapshot cost
the slowest repository rather than the sum:

```
repo             status     sync    total
masc              189ms     64ms    252ms
wkbl               63ms     69ms    132ms
kirin              55ms     51ms    106ms
grpc-direct        81ms     51ms    133ms
ocaml-webrtc       52ms     69ms    121ms
                                    -----
sequential sum                      745ms
slowest repository                  252ms
```

The endpoint measures 681–723 ms, which is the sum, not the max. Sampling the
process table during a request *does* show concurrent git children, so the
fan-out is real — ten git processes contending on one disk simply do not scale
down to the slowest one. The comment is corrected rather than deleted: the
fan-out is still why this is 745 ms and not several seconds.

## Tests

Two cases in the `dashboard behavior contracts` suite CI runs
(`@test/runtest-dashboard-http-behavior-contracts`), 16/16 green.

- `repository observation reads its cache key` — seeds a sentinel under the key
  the projection should consult and asserts the projection returns it.
- `repository observation does not cache a store failure` — writes malformed
  `repositories.toml`, asserts the call errors and the cache key stays empty.

Mutations:

```
cache removed                       [FAIL]  8  reads its cache key
cache moved outside the Ok branch   [FAIL]  9  does not cache a store failure
```

Restored: 16/16 under `--force`.

## Inherited CI

`main` is currently red for three suites unrelated to this change —
`subscription boundary 27` (Codex app-server host action), `turn-scoped
transport 0` (response acknowledgement), and `lifecycle 14` (Claude Code
current-owner state, which #28496 appears to address). Verified identical on
`main`'s own run 31653645563 at `9895a6205b`, so any red here is inherited.

RFC-WAIVED: a dashboard read projection and its cache policy; no credential,
identity, operator control-plane, sandbox, hook, or workflow surface is
touched.
