### PR TITLE
ci(tests): run 25 suites that only compiled

### DIFF
--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=656
+UNWIRED_BASELINE=631
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -38,6 +38,31 @@ paused_targets=(
 
 normal_targets=(
   @test/runtest-test_board_dispatch
+  @test/runtest-test_activity_graph
+  @test/runtest-test_adaptive_cache_ttl
+  @test/runtest-test_agent_card_action_mirror
+  @test/runtest-test_agent_core_adapters
+  @test/runtest-test_agent_core_empty_response_diagnostic
+  @test/runtest-test_agent_observation_bridge
+  @test/runtest-test_anti_rationalization_empty_reject
+  @test/runtest-test_artifacts_endpoint
+  @test/runtest-test_attempt_state
+  @test/runtest-test_attribution
+  @test/runtest-test_audit_projection
+  @test/runtest-test_auth_bearer_mismatch_9786
+  @test/runtest-test_auth_credential_index_cache
+  @test/runtest-test_auth_error_kind
+  @test/runtest-test_auth_error_kind_dashboard_fallback
+  @test/runtest-test_auth_login
+  @test/runtest-test_auth_rotate_shared_tokens_10304
+  @test/runtest-test_auth_strict_mode
+  @test/runtest-test_backend
+  @test/runtest-test_backend_coverage
+  @test/runtest-test_blocker_class_exhaustiveness
+  @test/runtest-test_board_author_identity_10297
+  @test/runtest-test_board_collect_pause_gate
+  @test/runtest-test_board_context_inference_resolution
+  @test/runtest-test_board_core_payload
   @test/runtest-test_transport_integration
   @test/runtest-test_keeper_playground_checkout_discovery
   @test/runtest-test_keeper_autonomous_turn_source


### PR DESCRIPTION
## 무엇이 문제였나

`test/dune` 이 선언했지만 CI 타깃이 이름을 부르지 않는 스위트가 **656개** 있습니다. 이들은 컴파일만 되고 **한 번도 실행되지 않습니다** — 단언이 그것이 고정하려는 코드보다 오래 살아남을 수 있습니다.

`#28031` 이 그 안에서 빨간 것(`test_board_dispatch` 4건 실패)이 나온 실례입니다.

## 무엇을 바꿨나

미배선 656개 중 앞에서부터 30개를 실행해 분류했습니다:

| 결과 | 수 |
|---|---|
| 통과 | 25 |
| 실패 | 5 |
| 별칭 없음 | 0 |

통과한 25개를 `scripts/ci-run-focused-tests.sh` 에 배선하고 래칫 baseline 을 `656 → 631` 로 내립니다.

실패한 5개(`test_auth_ambiguous_lookup_9786` · `test_auth_credential_hash_collision` · `test_auth_load_credential_of` · `test_auth_token_uniqueness_audit` · `test_board_api_e2e`)는 **배선하지 않았습니다** — main 을 red 로 만듭니다. 별도 이슈로 올립니다.

## 검증

```
$ bash scripts/audit-ci-test-targets.sh
[ci-test-targets] OK - 230 CI targets, all declared in Dune
[ci-test-targets] OK - 631 suites unwired, at baseline
```

flaky 선별 — 25개 각각 `dune build --force` 로 **2회씩** 실행, 25/25 안정 (flaky 0). 같은 세션에서 `test_keeper_claude_code_runtime` 의 `lifecycle 7` 이 8회 중 2회만 통과하는 것을 발견해(#28507) 이 선별을 넣었습니다.

## 측정 조건과 한계

- 로컬 macOS 측정입니다. **Linux CI 초록은 이 PR 의 CI 가 증명해야 합니다** — CI 가 일부를 red 로 보고하면 그 항목만 빼고 baseline 을 다시 맞춥니다. 그 전에는 머지하지 않습니다.
- 25개 순차 `--force` 실행 wall clock 305s. CI 는 단일 `dune build` 호출이라 dune 호출 오버헤드가 25배 붙지 않으므로 이 수치는 CI 비용의 상한입니다.
- 배선은 앞에서부터 30개 표본이지 전수가 아닙니다. 남은 631개는 미측정입니다.

RFC-WAIVED: CI 테스트 타깃 배선 + 래칫 baseline. credential/identity/operator/sandbox 코드 표면 무변경.

Refs #26733

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
