### PR TITLE
perf(transition-audit): decode store rows during the read

### DIFF
--- a/lib/keeper/keeper_transition_audit.ml
+++ b/lib/keeper/keeper_transition_audit.ml
@@ -336,8 +336,11 @@ let recent_transitions_json ~keeper_name ~limit : Yojson.Safe.t =
          consistent with just-recorded transitions. *)
       let (_ : int) = flush_pending () in
       let items =
-        Dated_jsonl.read_recent store (max limit 1 * 8)
-        |> List.filter_map (function
+        (* Project during the read: the scan window is [8 * limit] rows and only
+           the matching keeper's [record] sub-tree survives, so materialising
+           every row's parsed tree first is wasted. The selector is pure, so the
+           reader's newest-first call order is not observable. *)
+        Dated_jsonl.filter_map_recent store (max limit 1 * 8) ~f:(function
           | `Assoc fields ->
             (match List.assoc_opt "keeper" fields, List.assoc_opt "record" fields with
              | Some (`String name), Some record when String.equal name keeper_name ->
@@ -402,8 +405,9 @@ let recent_completed_turns_from_store ~keeper_name ~limit =
   | Some _, _ | _, None -> []
   | None, Some store ->
     let (_ : int) = flush_pending () in
-    Dated_jsonl.read_recent store (max limit 1 * 8)
-    |> List.filter_map (function
+    (* Same shape as above, and here the projection also decodes to a typed
+       record, so the parsed tree is garbage as soon as the row is read. *)
+    Dated_jsonl.filter_map_recent store (max limit 1 * 8) ~f:(function
       | `Assoc fields ->
         (match List.assoc_opt "keeper" fields, List.assoc_opt "completed_turn" fields with
          | Some (`String name), Some record when String.equal name keeper_name ->

--- a/test/test_keeper_transition_audit.ml
+++ b/test/test_keeper_transition_audit.ml
@@ -159,6 +159,86 @@ let test_record_and_read_multiple_turns () =
       check int (Printf.sprintf "turn %d id" idx) expected_id turn.Audit.turn_id)
     turns
 
+(* [recent_completed_turns] answers from the per-keeper in-memory ring when one
+   exists and falls through to [recent_completed_turns_from_store] otherwise —
+   the state a keeper is in after a restart. The store branch scans one shared
+   JSONL store and keeps only rows whose [keeper] field matches.
+
+   That branch was unguarded: dropping its keeper-name comparison left the
+   whole suite green, because every case here records under a single keeper and
+   reads back through the ring. Clearing the rings after recording (the store
+   keeps its rows) routes the read down the store branch. *)
+let test_store_branch_filters_by_keeper () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Audit.For_testing.reset_state ();
+      cleanup_dir base_dir)
+    (fun () ->
+      (* No sink path: [recent_completed_turns_from_store] returns [] when one
+         is configured, which would make this test vacuous. *)
+      with_env "MASC_KEEPER_TRANSITION_LOG" "" (fun () ->
+        with_env "MASC_BASE_PATH" base_dir (fun () ->
+          with_env "MASC_BASE_PATH_INPUT" base_dir (fun () ->
+            Audit.For_testing.reset_state ();
+            let record keeper_name turn_id =
+              Audit.record_completed_turn
+                ~keeper_name
+                {
+                  Audit.turn_id;
+                  started_at = float_of_int (turn_id * 10);
+                  ended_at = float_of_int ((turn_id * 10) + 5);
+                  outcome = Audit.Turn_failed;
+                }
+            in
+            (* Interleaved, so a reader that ignores the filter cannot pass by
+               ordering luck: the other keeper's rows sit between the wanted
+               ones at every position. *)
+            record "keeper-a" 1;
+            record "keeper-b" 2;
+            record "keeper-a" 3;
+            record "keeper-b" 4;
+            record "keeper-a" 5;
+            (* Drop the rings only; the JSONL rows written above survive. *)
+            Audit.For_testing.reset_state ();
+            let ids keeper_name =
+              Audit.recent_completed_turns ~keeper_name ~limit:10
+              |> List.map (fun turn -> turn.Audit.turn_id)
+              |> List.sort compare
+            in
+            check (list int) "store branch returns only keeper-a's turns"
+              [ 1; 3; 5 ] (ids "keeper-a");
+            check (list int) "store branch returns only keeper-b's turns"
+              [ 2; 4 ] (ids "keeper-b")))))
+
+(* The ring branch keys by keeper name, so its filtering is structural. Pinned
+   separately because the two branches answer the same question differently. *)
+let test_completed_turns_are_filtered_by_keeper () =
+  Audit.For_testing.reset_state ();
+  let record keeper_name turn_id =
+    Audit.record_completed_turn
+      ~keeper_name
+      {
+        Audit.turn_id;
+        started_at = float_of_int (turn_id * 10);
+        ended_at = float_of_int ((turn_id * 10) + 5);
+        outcome = Audit.Turn_failed;
+      }
+  in
+  (* Interleaved so a reader that ignores the filter cannot pass by ordering
+     luck: the other keeper's rows sit between the wanted ones. *)
+  record "keeper-a" 1;
+  record "keeper-b" 2;
+  record "keeper-a" 3;
+  record "keeper-b" 4;
+  record "keeper-a" 5;
+  let ids keeper_name =
+    Audit.recent_completed_turns ~keeper_name ~limit:10
+    |> List.map (fun turn -> turn.Audit.turn_id)
+  in
+  check (list int) "only keeper-a's turns, newest first" [ 5; 3; 1 ] (ids "keeper-a");
+  check (list int) "only keeper-b's turns, newest first" [ 4; 2 ] (ids "keeper-b")
+
 let test_ring_capacity_limit () =
   Audit.For_testing.reset_state ();
   let keeper_name = "capacity-keeper" in
@@ -598,6 +678,10 @@ let () =
         [
           test_case "empty store" `Quick test_recent_completed_turns_empty_store;
           test_case "record and read multiple" `Quick test_record_and_read_multiple_turns;
+          test_case "completed turns are filtered by keeper" `Quick
+            test_completed_turns_are_filtered_by_keeper;
+          test_case "store branch filters by keeper" `Quick
+            test_store_branch_filters_by_keeper;
           test_case "ring capacity limit" `Quick test_ring_capacity_limit;
           test_case "ring ordering newest first" `Quick test_ring_ordering_is_newest_first;
           test_case "limit respected" `Quick test_limit_respected;


### PR DESCRIPTION
Last two `read_recent |> List.filter_map <decoder>` sites. After this, no `Dated_jsonl.read_recent` call in `lib/` is followed by a decode.

## Change

Both readers in `Keeper_transition_audit` scan a `8 * limit` window and keep only rows whose `keeper` field matches:

- `recent_transitions_from_store` projects to the matching row's `record` sub-tree
- `recent_completed_turns_from_store` projects to a typed `completed_turn_record`

Both selectors are pure, so the reader's newest-first call order is not observable and `filter_map_recent` is a drop-in.

The saving differs between them, and the second is the real one. Site 1's result is still `Yojson` — only the wrapper object is dropped — so what it mostly saves is discarding non-matching keepers' rows immediately in a store that holds every keeper. Site 2 decodes to a record, so the tree is garbage as the row is read.

## What the mutation runs found

Reverting each site's keeper-name filter should turn a test red. It did not, twice, and the second failure is the interesting one:

| attempt | result | what it showed |
|---|---|---|
| 1. mutate site 2, run suite as-is | **19/19 green** | the store branch was entirely unguarded |
| 2. add a two-keeper test, mutate again | **20/20 green** | my test hit the *ring*, not the store |
| 3. add a store-branch test, mutate again | **1 failure** | now guarded |

`recent_completed_turns` answers from a per-keeper in-memory ring when one exists and falls through to the store otherwise. Every existing case records and immediately reads back, so it never left the ring. The ring keys by keeper name, which makes its filtering structural and unbreakable; the store branch compares a field and can be broken. The branch that could be wrong was the one with no coverage.

The store branch is what a keeper hits **after a restart** — rings empty, history on disk. `For_testing.reset_state ()` clears the rings and the store handle but not the day-files, which reproduces exactly that state.

Both new tests are kept: one pins the ring branch, one the store branch. They answer the same question by different means and only one of them can regress.

Keepers are interleaved (`a b a b a`) rather than grouped, so a reader that ignores the filter cannot pass by ordering luck at any `limit`; `limit:10` exceeds the row count so truncation is not mixed into the assertion; results are sorted before comparison because the assertion is about *filtering*, not order, and the two branches need not agree on order.

## Verification (local)

| check | result |
|---|---|
| `dune build --root . test/test_keeper_transition_audit.exe test/test_keeper_transition_audit_types.exe` | `BUILD_EXIT=0` |
| `test_keeper_transition_audit.exe` | **21 tests run, Test Successful** |
| `test_keeper_transition_audit_types.exe` | **2 tests run, Test Successful** |
| same suite with the store-branch filter reverted | **1 failure** — `store branch returns only keeper-a's turns` |
| fix restored | 21 tests run, Test Successful |
| `scripts/audit-ci-test-targets.sh` | OK — 203 CI targets all declared, 658 unwired at baseline |
| `dune build --root . @fmt` | no diff on any file this PR touches |

No CI wiring needed: `@test/runtest-test_keeper_transition_audit` is already invoked from `ci.yml:1069`. I nearly added a second invocation to `ci-run-focused-tests.sh` — the audit script rejected it ("repeated runtest aliases spend CI time without adding coverage"), which is also the reminder that grepping one of the two target sources is not how to check whether a suite runs.

## Not claimed

No RSS or latency number. The RFC-0372 §5 gate needs idle p95 ≤ 50 ms and this host has measured 65–2255 ms across the session.

RFC-WAIVED: `lib/keeper/keeper_transition_audit.ml` and its test. None of the RFC-required subsystems. Direction is set by existing RFC-0372.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
