### PR TITLE
test(auth,grpc): let five never-run suites pin the current contracts

### DIFF
--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=631
+UNWIRED_BASELINE=626
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -38,6 +38,11 @@ paused_targets=(
 
 normal_targets=(
   @test/runtest-test_board_dispatch
+  @test/runtest-test_auth_ambiguous_lookup_9786
+  @test/runtest-test_auth_credential_hash_collision
+  @test/runtest-test_auth_load_credential_of
+  @test/runtest-test_auth_token_uniqueness_audit
+  @test/runtest-test_grpc_workspace
   @test/runtest-test_activity_graph
   @test/runtest-test_adaptive_cache_ttl
   @test/runtest-test_agent_card_action_mirror

--- a/test/test_auth_ambiguous_lookup_9786.ml
+++ b/test/test_auth_ambiguous_lookup_9786.ml
@@ -37,24 +37,21 @@ let with_temp_base f =
     (fun () -> f base)
 
 let write_cred ~base ~agent_name ~token_hash =
-  let agents_dir = Filename.concat base ".masc/auth/agents" in
-  let rec mkdirs p =
-    if Sys.file_exists p then ()
-    else begin
-      mkdirs (Filename.dirname p);
-      try Unix.mkdir p 0o755 with Unix.Unix_error _ -> ()
-    end
+  (* Write through the production writer so a credential schema change breaks
+     this fixture at compile time instead of at [of_yojson] runtime. The
+     hand-written JSON this replaces omitted [id]/[agent_id]/[expires_at], which
+     the decoder requires as keys even where the record type defaults them. *)
+  let cred : Masc_domain.agent_credential =
+    { id = None
+    ; agent_id = None
+    ; agent_name
+    ; token = token_hash
+    ; role = Masc_domain.Worker
+    ; created_at = "2026-04-25T00:00:00Z"
+    ; expires_at = None
+    }
   in
-  mkdirs agents_dir;
-  let path = Filename.concat agents_dir (agent_name ^ ".json") in
-  let json =
-    Printf.sprintf
-      "{\"agent_name\":%S,\"token\":%S,\"role\":\"worker\",\"created_at\":\"2026-04-25T00:00:00Z\"}"
-      agent_name token_hash
-  in
-  let oc = open_out path in
-  output_string oc json;
-  close_out oc
+  Auth.save_credential base cred
 
 let ambiguous_counter_for ~first_match =
   Masc.Otel_metric_store.metric_value_or_zero

--- a/test/test_auth_credential_hash_collision.ml
+++ b/test/test_auth_credential_hash_collision.ml
@@ -77,25 +77,21 @@ let with_temp_base f =
     (fun () -> f base)
 
 let write_cred ~base ~agent_name ~role ~token_hash =
-  let agents_dir = Filename.concat base ".masc/auth/agents" in
-  let rec mkdirs p =
-    if Sys.file_exists p then ()
-    else begin
-      mkdirs (Filename.dirname p);
-      try Unix.mkdir p 0o755 with Unix.Unix_error _ -> ()
-    end
+  (* Write through the production writer so a credential schema change breaks
+     this fixture at compile time instead of at [of_yojson] runtime. The
+     hand-written JSON this replaces omitted [id]/[agent_id]/[expires_at], which
+     the decoder requires as keys even where the record type defaults them. *)
+  let cred : Masc_domain.agent_credential =
+    { id = None
+    ; agent_id = None
+    ; agent_name
+    ; token = token_hash
+    ; role = role
+    ; created_at = "2026-06-24T00:00:00Z"
+    ; expires_at = None
+    }
   in
-  mkdirs agents_dir;
-  let path = Filename.concat agents_dir (agent_name ^ ".json") in
-  let role_str = Masc_domain.agent_role_to_string role in
-  let json =
-    Printf.sprintf
-      "{\"agent_name\":%S,\"token\":%S,\"role\":%S,\"created_at\":\"2026-06-24T00:00:00Z\"}"
-      agent_name token_hash role_str
-  in
-  let oc = open_out path in
-  output_string oc json;
-  close_out oc
+  Auth.save_credential base cred
 
 let test_unknown_token_is_mismatch () =
   with_temp_base (fun base ->

--- a/test/test_auth_load_credential_of.ml
+++ b/test/test_auth_load_credential_of.ml
@@ -34,24 +34,21 @@ let with_temp_base f =
     (fun () -> f base)
 
 let write_cred ~base ~agent_name ~token_hash =
-  let agents_dir = Filename.concat base ".masc/auth/agents" in
-  let rec mkdirs p =
-    if Sys.file_exists p then ()
-    else begin
-      mkdirs (Filename.dirname p);
-      try Unix.mkdir p 0o755 with Unix.Unix_error _ -> ()
-    end
+  (* Write through the production encoder so a credential schema change breaks
+     this fixture at compile time instead of at [of_yojson] runtime. The
+     hand-written JSON this replaces omitted [id]/[agent_id]/[expires_at], which
+     the decoder requires as keys even where the record type defaults them. *)
+  let cred : Masc_domain.agent_credential =
+    { id = None
+    ; agent_id = None
+    ; agent_name
+    ; token = token_hash
+    ; role = Masc_domain.Worker
+    ; created_at = "2026-04-26T00:00:00Z"
+    ; expires_at = None
+    }
   in
-  mkdirs agents_dir;
-  let path = Filename.concat agents_dir (agent_name ^ ".json") in
-  let json =
-    Printf.sprintf
-      "{\"agent_name\":%S,\"token\":%S,\"role\":\"worker\",\"created_at\":\"2026-04-26T00:00:00Z\"}"
-      agent_name token_hash
-  in
-  let oc = open_out path in
-  output_string oc json;
-  close_out oc
+  Auth.save_credential base cred
 
 let test_exact_match_load_ok () =
   with_temp_base (fun base ->

--- a/test/test_auth_token_uniqueness_audit.ml
+++ b/test/test_auth_token_uniqueness_audit.ml
@@ -28,26 +28,21 @@ let with_temp_base f =
    Bypasses the Auth API on purpose so we can craft duplicates
    without [save_raw_token_credential] re-hashing. *)
 let write_cred ~base ~agent_name ~token_hash =
-  let agents_dir =
-    Filename.concat base ".masc/auth/agents"
+  (* Write through the production writer so a credential schema change breaks
+     this fixture at compile time instead of at [of_yojson] runtime. The
+     hand-written JSON this replaces omitted [id]/[agent_id]/[expires_at], which
+     the decoder requires as keys even where the record type defaults them. *)
+  let cred : Masc_domain.agent_credential =
+    { id = None
+    ; agent_id = None
+    ; agent_name
+    ; token = token_hash
+    ; role = Masc_domain.Worker
+    ; created_at = "2026-04-25T00:00:00Z"
+    ; expires_at = None
+    }
   in
-  let rec mkdirs p =
-    if Sys.file_exists p then ()
-    else begin
-      mkdirs (Filename.dirname p);
-      try Unix.mkdir p 0o755 with Unix.Unix_error _ -> ()
-    end
-  in
-  mkdirs agents_dir;
-  let path = Filename.concat agents_dir (agent_name ^ ".json") in
-  let json =
-    Printf.sprintf
-      "{\"agent_name\":%S,\"token\":%S,\"role\":\"worker\",\"created_at\":\"2026-04-25T00:00:00Z\"}"
-      agent_name token_hash
-  in
-  let oc = open_out path in
-  output_string oc json;
-  close_out oc
+  Auth.save_credential base cred
 
 let test_empty_store_returns_empty () =
   with_temp_base (fun base ->

--- a/test/test_grpc_workspace.ml
+++ b/test/test_grpc_workspace.ml
@@ -420,13 +420,25 @@ let test_get_status_projects_backlog_tasks () =
   with_temp_dir "masc-grpc-status" (fun dir ->
     let workspace_config = Workspace_utils.default_config dir in
     ignore (Masc.Workspace.init workspace_config ~agent_name:(Some "alpha"));
+    (* Registration turns the requested "alpha" into a generated nickname
+       ("alpha-witty-gecko"), and claiming a task moves the agent off "active".
+       Re-stating either literal here would pin the naming scheme and the
+       status vocabulary instead of the projection, so both come from the
+       workspace itself. *)
+    let sole_agent () =
+      match Masc.Workspace.get_agents_raw workspace_config with
+      | [ (agent : Masc_domain.agent) ] -> agent
+      | agents ->
+        Alcotest.failf "expected exactly 1 registered agent, got %d" (List.length agents)
+    in
+    let agent_name = (sole_agent ()).name in
     ignore
       (Masc.Workspace.add_task
          workspace_config
          ~title:"Fix stale projection"
          ~priority:1
          ~description:"Use backlog SSOT for gRPC status");
-    ignore (Masc.Workspace.claim_next_r workspace_config ~agent_name:"alpha" ());
+    ignore (Masc.Workspace.claim_next_r workspace_config ~agent_name ());
     let service =
       Masc_grpc_service.create_service
         ~workspace_config
@@ -439,14 +451,18 @@ let test_get_status_projects_backlog_tasks () =
       let resp = T.StatusResponse.of_bytes (handler "") in
       Alcotest.(check int) "agents count" 1 (List.length resp.agents);
       let agent = List.hd resp.agents in
-      Alcotest.(check string) "agent name" "alpha" agent.T.name;
-      Alcotest.(check string) "agent status" "active" agent.T.status;
+      let stored = sole_agent () in
+      Alcotest.(check string) "agent name" stored.name agent.T.name;
+      Alcotest.(check string)
+        "agent status"
+        (Masc_domain.agent_status_to_string stored.status)
+        agent.T.status;
       Alcotest.(check int) "tasks count" 1 (List.length resp.tasks);
       let task = List.hd resp.tasks in
       Alcotest.(check string) "task id" "task-001" task.T.id;
       Alcotest.(check string) "task title" "Fix stale projection" task.T.title;
       Alcotest.(check string) "task status" "claimed" task.T.status;
-      Alcotest.(check string) "task assignee" "alpha" task.T.assigned_to;
+      Alcotest.(check string) "task assignee" stored.name task.T.assigned_to;
       Alcotest.(check int) "task priority" 1 task.T.priority
     | _ -> Alcotest.fail "GetStatus unary handler missing")
 ;;


### PR DESCRIPTION
## 무엇이 문제였나

이 다섯 스위트는 `test/dune` 이 선언하지만 CI 타깃이 이름을 부르지 않습니다 — **한 번도 실행된 적이 없습니다.** 다섯 다 red 였고, 각 픽스처가 자기가 고정한다는 계약에서 떨어져 나가 있었습니다.

## auth 4개 — 값의 선택성과 키의 선택성이 다릅니다

픽스처가 자격증명 JSON 을 손으로 4개 키만 씁니다:

```json
{"agent_name":"…","token":"…","role":"worker","created_at":"…"}
```

디코더는 7개 키가 **모두 있어야** 통과시킵니다. `id`·`agent_id`·`expires_at` 은 값이 `null` 이어도 되지만 키 부재는 거부합니다:

```ocaml
(* types_auth.ml — require_credential_optional_string *)
| Some `Null -> Ok None
| None -> Error (… "missing required field %S" …)
```

레코드 타입은 `[@default None]` 이라 "생략 가능" 처럼 보이는데 디코더가 그렇게 읽지 않습니다.

그 결과 실행 시 이렇게 됩니다:

```
[WARN] [Auth] [load_credential] parse error for keeper-sangsu-agent:
       agent_credential_of_yojson: missing required field "id"
FAIL: expected Ok, got Error Credential_missing { ctx_agent_name = "keeper-sangsu-agent" }
```

**파일은 있는데 호출자는 "없음" 을 봅니다** — `load_credential` 이 파싱 실패를 `None` 으로 접기 때문입니다. 이 PR 은 그 접힘을 건드리지 않고(별개 문제) 픽스처만 고칩니다.

수리는 `"id":null` 을 채워 넣는 것이 아니라 **프로덕션 writer 를 쓰는 것**입니다:

```ocaml
let cred : Masc_domain.agent_credential =
  { id = None; agent_id = None; agent_name; token = token_hash
  ; role = Masc_domain.Worker; created_at = "…"; expires_at = None }
in
Auth.save_credential base cred
```

다음 스키마 변경은 런타임이 아니라 **컴파일 에러**가 됩니다. 값을 채우는 수리는 다음 필드에서 같은 일을 반복하게 합니다.

## grpc 1개 — 세 단언이 순차적으로 드러났습니다

```
FAIL agent name      Expected "alpha"     Received "alpha-witty-gecko"
FAIL agent status    Expected "active"    Received "busy"
FAIL task assignee   Expected "alpha"     Received "alpha-witty-gecko"
```

첫 것만 고치면 다음이 나오는 구조였습니다. 등록이 요청 이름을 생성 닉네임으로 바꾸고, claim 이 상태를 옮깁니다. 세 값 모두 워크스페이스에서 읽어 gRPC 뷰와 대조하도록 바꿨습니다 — 테스트가 고정하는 것은 **projection** 이지 네이밍 규칙이나 상태 어휘가 아닙니다.

중간에 버린 접근 하나를 적어 둡니다: `Workspace.init` 의 반환값을 쓰려 했는데, 그것은 이름이 아니라 사람이 읽는 메시지(`"MASC workspace created!\nalpha-witty-gecko session bound\n…"`)였습니다. `Workspace.get_agents_raw` 가 맞는 출처입니다.

## 검증

```
$ ./_build/default/test/test_auth_load_credential_of.exe        All P2-a tests passed
$ ./_build/default/test/test_auth_ambiguous_lookup_9786.exe     PASS
$ ./_build/default/test/test_auth_token_uniqueness_audit.exe    PASS
$ ./_build/default/test/test_auth_credential_hash_collision.exe PASS
$ ./_build/default/test/test_grpc_workspace.exe                 Test Successful in 0.194s. 33 tests run.

$ bash scripts/audit-ci-test-targets.sh
[ci-test-targets] OK - 235 CI targets, all declared in Dune
[ci-test-targets] OK - 626 suites unwired, at baseline
```

## 측정 조건과 한계

- 로컬 macOS 측정입니다. Linux CI 초록은 이 PR 의 CI 가 증명해야 하고, red 로 나오면 그 항목을 빼고 baseline 을 다시 맞춥니다.
- `load_credential` 이 파싱 실패를 `Credential_missing` 으로 접는 문제는 **고치지 않았습니다.** 픽스처가 고쳐져 이 경로로는 더 이상 발화하지 않지만, 저장된 파일이 손상되면 같은 오분류가 납니다. 라이브 자격증명 43개는 전부 키가 완전해 지금 프로덕션 영향은 없습니다 (측정).
- `#28509` 의 다섯 번째인 `test_board_api_e2e` 는 여기 없습니다 — runtest 별칭 자체가 없어 배선이 불가능하고, 그 이슈에 남깁니다.

RFC-WAIVED: 테스트 픽스처와 CI 타깃 배선. `lib/auth/` 의 프로덕션 코드는 무변경 — 픽스처가 기존 `Auth.save_credential` 을 호출하도록 바꿨을 뿐입니다.

Refs #28509, #28396

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
