### PR TITLE
ci(tests): run 44 more suites that only compiled

### DIFF
--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=626
+UNWIRED_BASELINE=582
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -38,6 +38,50 @@ paused_targets=(
 
 normal_targets=(
   @test/runtest-test_board_dispatch
+  @test/runtest-test_cancel_safe
+  @test/runtest-test_cancel_wall_bucket
+  @test/runtest-test_cap_blocker_structured_error
+  @test/runtest-test_capability_registry
+  @test/runtest-test_channel_gate
+  @test/runtest-test_channel_gate_binding_store
+  @test/runtest-test_channel_gate_connector_routes
+  @test/runtest-test_channel_gate_discord_state
+  @test/runtest-test_channel_gate_imessage_state
+  @test/runtest-test_channel_gate_metrics
+  @test/runtest-test_client_registry_eio
+  @test/runtest-test_code_navigation_eio
+  @test/runtest-test_common
+  @test/runtest-test_compaction_exact_output_entrypoint_clockless
+  @test/runtest-test_compaction_llm_summarizer
+  @test/runtest-test_compression
+  @test/runtest-test_concurrency_stress
+  @test/runtest-test_config_coverage
+  @test/runtest-test_config_dir_resolver
+  @test/runtest-test_console_sink
+  @test/runtest-test_context_max_observed_9953
+  @test/runtest-test_cost_token_decouple
+  @test/runtest-test_cost_usd_source_attribution_10318
+  @test/runtest-test_credential_alias_10440
+  @test/runtest-test_cross_context_mutex
+  @test/runtest-test_dashboard_agent_core_bridge
+  @test/runtest-test_dashboard_attribution
+  @test/runtest-test_dashboard_briefing_sections
+  @test/runtest-test_dashboard_cache
+  @test/runtest-test_dashboard_continuity_briefs
+  @test/runtest-test_dashboard_coverage
+  @test/runtest-test_dashboard_execute_output
+  @test/runtest-test_dashboard_feature_health
+  @test/runtest-test_dashboard_gate_metrics
+  @test/runtest-test_dashboard_goal_id_projection
+  @test/runtest-test_dashboard_k2_feeds
+  @test/runtest-test_dashboard_keeper_cost_aggregates
+  @test/runtest-test_dashboard_keeper_metrics_10286
+  @test/runtest-test_dashboard_labels
+  @test/runtest-test_dashboard_librarian_metric
+  @test/runtest-test_dashboard_link_preview
+  @test/runtest-test_dashboard_nav_event
+  @test/runtest-test_dashboard_perf
+  @test/runtest-test_dashboard_recent_terminal_tasks
   @test/runtest-test_auth_ambiguous_lookup_9786
   @test/runtest-test_auth_credential_hash_collision
   @test/runtest-test_auth_load_credential_of


### PR DESCRIPTION
## 무엇을 배선했나

미배선 631개 중 두 번째 표본 50개를 실행해 분류했습니다:

| 결과 | 수 |
|---|---|
| 통과 | 44 |
| 실패 | 6 |

통과한 44개를 배선하고 래칫 baseline 을 `631 → 587` 로 내립니다.

## flaky 선별

44개 각각 `dune build --force` 로 **2회씩** 실행했습니다 — 44/44 안정, flaky 0.

이 선별은 `#28507` 때문에 넣었습니다. 같은 세션에서 `test_keeper_claude_code_runtime` 의 `lifecycle 7` 이 8회 중 2회만 통과하는 것을 발견했고, 한 번 초록인 스위트를 배선하면 그 확률이 그대로 main 의 red 확률이 됩니다.

## 배선하지 않은 6개

```
test_channel_gate_discord_state_in_process
test_completion_trust_harness
test_copilot_dock_channel_wiring
test_dashboard
test_dashboard_http_core          ← 이미 #28477 로 추적 중 (3건 실패)
test_dashboard_namespace_truth
```

배선하면 main 이 red 가 됩니다. `#28509` 와 같은 구조입니다 — 고쳐야 배선됩니다.

## 누적 상황

| 표본 | 측정 | green | red |
|---|---|---|---|
| 배치 1 (#28508) | 30 | 25 | 5 |
| 배치 2 (이 PR) | 50 | 44 | 6 |
| 합계 | 80 | 69 | 11 |

red 비율 11/80 ≈ 14%. 남은 587개에 같은 비율이 유지된다면 약 80개가 red 입니다 — **다만 표본은 알파벳 순 앞부분이라 무작위가 아니고, 그 추정에 근거가 강하지 않습니다.**

## 측정 조건과 한계

- 로컬 macOS 측정입니다. Linux CI 초록은 이 PR 의 CI 가 증명해야 하고, red 로 나오면 그 항목을 빼고 baseline 을 다시 맞춥니다. 그 전에는 머지하지 않습니다.
- 배치 1 에서는 로컬 25/25 와 CI 25/25 가 일치했습니다. 이번에도 그러리라는 보장은 없습니다.
- 표본은 미배선 목록의 알파벳 순 앞부분 80개입니다. 나머지 587개는 미측정입니다.

RFC-WAIVED: CI 테스트 타깃 배선 + 래칫 baseline. 코드 표면 무변경.

Refs #26733, #28477, #28509

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
