### PR TITLE
test(dashboard): wait on the behaviour this test names, not on a caption

### DIFF
--- a/dashboard/src/components/keeper-workspace/keeper-lane-section.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-lane-section.test.ts
@@ -1,5 +1,5 @@
 import { html } from 'htm/preact'
-import { cleanup, render, screen, waitFor } from '@testing-library/preact'
+import { cleanup, render, waitFor } from '@testing-library/preact'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { DashboardKeeperWaitingInventory } from '../../api'
@@ -60,8 +60,14 @@ describe('KeeperLaneSection', () => {
     mocks.fetchKeeperWaitingInventory.mockResolvedValue(inventory())
     render(html`<${KeeperLaneSection} keeper=${{ name: 'kidsnote', agent_name: 'agent-kidsnote' }} />`)
 
-    await waitFor(() => expect(screen.getByText('처리 대기 중')).toBeTruthy())
-    expect(mocks.fetchKeeperWaitingInventory).toHaveBeenCalledTimes(1)
+    // Wait on the two things this test is named for -- the push registration and
+    // the first read -- rather than on a caption. The previous wait was for the
+    // literal '처리 대기 중', which a copy sweep renamed to '대기 중'; the test
+    // then timed out on a component that was working.
+    await waitFor(() => {
+      expect(mocks.refresh).not.toBeNull()
+      expect(mocks.fetchKeeperWaitingInventory).toHaveBeenCalledTimes(1)
+    })
 
     mocks.refresh?.('rondo')
     expect(mocks.fetchKeeperWaitingInventory).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
## 무엇이 문제였나

`keeper-lane-section.test.ts` 의 "re-reads only the visible keeper when its WS invalidation arrives" 가 clean main 에서 5000ms 타임아웃으로 실패합니다 (`#28443` 재현 확인).

원인은 컴포넌트가 아니라 테스트가 기다리는 문구입니다:

```
$ rg -ln '처리 대기 중' src/
src/components/keeper-workspace/keeper-lane-section.test.ts     ← 테스트 파일에만 있음
```

copy 감사가 라벨을 `처리 대기 중` → `대기 중` 으로 바꿨고 (`keeper-lane-strip.ts:44` 의 `waiting: '대기 중'`), 테스트의 `getByText('처리 대기 중')` 이 영원히 해소되지 않습니다. **컴포넌트는 정상 동작 중인데 테스트가 타임아웃합니다.**

## 무엇을 바꿨나

문구를 새 문구로 갈아끼우면 다음 copy 감사에서 같은 일이 반복됩니다. 테스트 이름이 말하는 **동작**을 기다리도록 바꿨습니다:

```ts
await waitFor(() => {
  expect(mocks.refresh).not.toBeNull()
  expect(mocks.fetchKeeperWaitingInventory).toHaveBeenCalledTimes(1)
})
```

push 등록과 첫 읽기 — 이 케이스가 검증하려는 두 가지입니다. 이후 단언(`refresh('rondo')` 는 재읽기를 만들지 않고, `refresh('kidsnote')` 는 만든다)은 그대로입니다.

`screen` import 가 쓰이지 않게 되어 함께 제거했습니다.

## 검증

```
before:  Test timed out in 5000ms.        1 failed
after:   Test Files 1 passed (1)          Duration 2.54s

$ npx vitest run src/components/keeper-workspace/
Test Files  8 passed (8)
Tests     143 passed (143)
```

## 곁가지 — 확인하지 못한 것

같은 종류(소스에 없는 문구를 기다리는 테스트)를 찾으려고 대시보드 테스트의 `getByText` 한국어 리터럴을 소스와 대조했더니 7개 파일이 걸렸습니다. 다만 대부분 `답글 ${n}개 접힘` 같은 **템플릿 리터럴**이라 단순 substring 대조로는 판정할 수 없습니다 — **오탐일 가능성이 높고, 이 PR 은 그 7개를 주장하지 않습니다.** 판정하려면 각 스위트를 실제로 돌려야 합니다.

RFC-WAIVED: 대시보드 테스트 1개 수정. 컴포넌트 코드 무변경.

Closes #28443

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
