### PR TITLE
fix(slack): answer an empty user id without asking Slack

### DIFF
--- a/lib/gate/slack_user_directory.ml
+++ b/lib/gate/slack_user_directory.ml
@@ -73,7 +73,14 @@ let store_entry t ~user_id entry =
   Mutex.unlock t.mu
 
 let display_label t ~user_id =
-  match live_entry t ~user_id with
+  (* Slack omits [user] on bot and system events, so an empty id reaches here.
+     It can never resolve -- users.info answers user_not_found -- and letting it
+     through spends an API call, a WARN naming no one, and a failure-cache entry
+     keyed on "" to learn that. Answer it here instead (#28402). *)
+  if String.equal user_id ""
+  then None
+  else
+    match live_entry t ~user_id with
   | Some (Label label) -> Some label
   | Some Fetch_failed -> None
   | None ->

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=582
+UNWIRED_BASELINE=581
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -38,6 +38,7 @@ paused_targets=(
 
 normal_targets=(
   @test/runtest-test_board_dispatch
+  @test/runtest-test_slack_user_directory
   @test/runtest-test_cancel_safe
   @test/runtest-test_cancel_wall_bucket
   @test/runtest-test_cap_blocker_structured_error

--- a/test/test_slack_user_directory.ml
+++ b/test/test_slack_user_directory.ml
@@ -89,6 +89,17 @@ let test_mention_rewrite () =
     "plain @text < unrelated >"
     (D.rewrite_mentions t "plain @text < unrelated >")
 
+let test_empty_user_id_never_fetches () =
+  let now_ref = ref 0.0 in
+  let t, calls = directory ~now_ref [ ("U1", Ok (info ~display_name:"Vincent" "U1")) ] in
+  check (option string) "empty id resolves to nothing" None (D.display_label t ~user_id:"");
+  check int "empty id never fetches" 0 !calls;
+  (* The guard must not poison the cache under the empty key: the next real id
+     still reaches the fetch. *)
+  check (option string) "a real id still resolves" (Some "Vincent")
+    (D.display_label t ~user_id:"U1");
+  check int "the real id is the first fetch" 1 !calls
+
 let test_mention_rewrite_malformed_tokens_pass_through () =
   let now_ref = ref 0.0 in
   let t, calls = directory ~now_ref [] in
@@ -115,5 +126,7 @@ let () =
           test_case "rewrite" `Quick test_mention_rewrite;
           test_case "malformed tokens pass through" `Quick
             test_mention_rewrite_malformed_tokens_pass_through;
+          test_case "empty user id never fetches" `Quick
+            test_empty_user_id_never_fetches;
         ] );
     ]


### PR DESCRIPTION
## 무엇이 문제였나

Slack 은 bot/system 이벤트에서 `user` 필드를 비웁니다. 그 빈 id 가 `display_label` 까지 도달하고, `users.info` 는 그것에 `user_not_found` 밖에 답할 수 없습니다:

```
2026-08-12T13:28:12Z WARN slack users.info failed for  (raw id will render until retry in 300s): slack api: user_not_found
2026-08-12T13:49:14Z WARN slack users.info failed for  (raw id will render until retry in 300s): slack api: user_not_found
```

(`failed for ` 뒤가 빈 문자열)

즉 그런 이벤트마다 **API 호출 1회 + 아무도 지목하지 않는 WARN + `""` 키의 300초 failure-cache 엔트리**를 쓰고 아무것도 배우지 못합니다.

## 무엇을 바꿨나

빈 id 를 캐시와 fetch **앞에서** 답합니다:

```ocaml
let display_label t ~user_id =
  if String.equal user_id ""
  then None
  else
    match live_entry t ~user_id with
    …
```

## 검증

```
$ ./_build/default/test/test_slack_user_directory.exe
Test Successful in 0.002s. 6 tests run.     (기존 5 + 신규 1)
```

회귀 테스트는 fetch 횟수만 세지 않습니다. 가드가 **자기 몫만 했는지** — 빈 조회가 캐시를 오염시키지 않았는지 — 도 확인합니다:

```ocaml
check (option string) "empty id resolves to nothing" None (D.display_label t ~user_id:"");
check int "empty id never fetches" 0 !calls;
check (option string) "a real id still resolves" (Some "Vincent") (D.display_label t ~user_id:"U1");
check int "the real id is the first fetch" 1 !calls
```

mutation:

| mutation | 결과 |
|---|---|
| 가드를 `if false` 로 (무력화) | `1 failure! FAIL empty id never fetches` |
| 원복 | `6 tests run`, exit 0 |

포맷: 두 파일 모두 `ocamlformat --check` clean 입니다. `origin/main` 의 원본도 clean 임을 먼저 확인해, 검사 실패가 이 변경에서 올 수 있는지 분리했습니다.

## 범위 밖으로 둔 것

빈 `user` 를 **왜** 여기까지 흘려보내는지는 손대지 않았습니다. 호출자가 그것을 걸러야 한다는 주장도 가능하지만, 그 판단은 이벤트 종류별로 갈리고 이 디렉터리는 어느 호출자든 같은 답을 줘야 합니다. 이슈가 제안한 위치(`lookup 진입 전`)를 그대로 따랐습니다.

RFC-WAIVED: Slack 사용자 라벨 조회의 입력 가드 1개 + 회귀 테스트. credential/identity/operator/sandbox 표면 무관.

Closes #28402

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
