### PR TITLE
ci(tests): make the unwired ratchet exact, not an upper bound

### DIFF
--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -141,10 +141,19 @@ if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then
   exit 2
 fi
 
-# A lower count is accepted so the exact baseline can be tightened in the same
-# change that wires more current suites.
+# A count below the baseline is a regression too. The gap between the two is
+# budget: a later change can add an unwired suite and still read as "OK", so a
+# gain nobody locked in becomes room for new debt. Measured on 2026-08-13: 45
+# test files added after this ratchet landed (#26959) are still unwired, and
+# #28383 is one of them -- it added test_caller_identity_credential_binding
+# with the baseline unchanged at 662 on both sides of the merge.
 if [ "$unwired" -lt "$UNWIRED_BASELINE" ]; then
-  echo "[ci-test-targets] OK - ${unwired} suites unwired, ${UNWIRED_BASELINE} baseline — lower UNWIRED_BASELINE in $0 to hold the gain"
-else
-  echo "[ci-test-targets] OK - ${unwired} suites unwired, at baseline"
+  echo
+  echo "[ci-test-targets] FAIL - ${unwired} suites unwired, under the ${UNWIRED_BASELINE} baseline by $((UNWIRED_BASELINE - unwired))"
+  echo
+  echo "Set UNWIRED_BASELINE=${unwired} in $0. The gap is not slack to spend:"
+  echo "leaving it lets a later change add an unwired suite and still pass."
+  exit 2
 fi
+
+echo "[ci-test-targets] OK - ${unwired} suites unwired, at baseline"


### PR DESCRIPTION
## 무엇이 문제였나

래칫이 `unwired <= baseline` 을 통과시킵니다. 그래서 실제값과 baseline 사이의 **간격이 예산**이 됩니다 — 누군가 스위트를 배선하고 숫자를 안 내리면, 나중 변경이 미배선 스위트를 하나 추가해도 `OK` 로 읽힙니다.

가정이 아닙니다. 측정했습니다 (2026-08-13, `origin/main` 기준):

```
지난 30일 추가된 test/test_*.ml      195
  그중 미배선                        139   (71%)
    래칫 도입(#26959, 08-06) 이전     93
    래칫 도입 이후                    45   ← 래칫이 있는 상태에서 들어왔다
```

`#28383` 이 그 45개 중 하나입니다:

```
$ git show 1f0bad0fd6 --name-only
test/dune                                          ← 경로 필터에 걸리므로 audit 은 실행됐다
test/test_caller_identity_credential_binding.ml    ← 미배선

$ git show 1f0bad0fd6^:scripts/audit-ci-test-targets.sh | rg -o 'UNWIRED_BASELINE=[0-9]+'
UNWIRED_BASELINE=662
$ git show 1f0bad0fd6:scripts/audit-ci-test-targets.sh  | rg -o 'UNWIRED_BASELINE=[0-9]+'
UNWIRED_BASELINE=662
```

baseline 이 양쪽 다 662 인데 미배선이 하나 늘었습니다. 즉 **여유가 이미 있었고 조용히 소모됐습니다.**

## 무엇을 바꿨나

baseline 아래도 실패로 만들고, 써야 할 숫자를 알려줍니다.

```
[ci-test-targets] FAIL - 582 suites unwired, under the 583 baseline by 1

Set UNWIRED_BASELINE=582 in scripts/audit-ci-test-targets.sh. The gap is not slack to spend:
leaving it lets a later change add an unwired suite and still pass.
```

스크립트가 이미 `lower UNWIRED_BASELINE ... to hold the gain` 이라고 안내하고 있었지만, 강제하는 것이 없었습니다.

## 검증

| 상태 | 결과 |
|---|---|
| baseline 582 = 실제 582 | `OK - 582 suites unwired, at baseline`, exit 0 |
| baseline 583 (실제보다 위) | `FAIL - … under the 583 baseline by 1`, exit 2 |
| baseline 581 (실제보다 아래) | 기존 FAIL 경로, exit 2 |

## 트레이드오프

스위트를 **삭제**하는 PR 도 이제 baseline 을 함께 내려야 합니다. 마찰이 한 줄 늘지만, 실패 메시지가 써야 할 숫자를 그대로 줍니다. 이 마찰이 없으면 그 삭제가 만든 여유가 다음 미배선 스위트의 예산이 됩니다 — 위 45건이 그 결과입니다.

기존 게이트를 조이는 변경이고 새 게이트를 추가하지 않습니다.

RFC-WAIVED: 기존 CI 래칫의 비교 조건 1개 변경. 코드 표면 무관.

Refs #26733, #26959

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
