### PR TITLE
ci(tests): run the 15 suites written since the ratchet but never wired

### DIFF
--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=581
+UNWIRED_BASELINE=566
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -38,6 +38,21 @@ paused_targets=(
 
 normal_targets=(
   @test/runtest-test_board_dispatch
+  @test/runtest-test_dedup_rules
+  @test/runtest-test_exec_command_gate_log_sink
+  @test/runtest-test_file_kind_vocabulary
+  @test/runtest-test_http_auth_strict_flag
+  @test/runtest-test_keeper_chat_broadcast
+  @test/runtest-test_keeper_codex_effort_clamp
+  @test/runtest-test_keeper_codex_error_carriage
+  @test/runtest-test_keeper_persistence_span_history
+  @test/runtest-test_keeper_rotation_eligibility_census
+  @test/runtest-test_keeper_toml_accessor_matrix
+  @test/runtest-test_keeper_turn_dispatch_authority
+  @test/runtest-test_runtime_quota_window
+  @test/runtest-test_subsystem_health_state
+  @test/runtest-test_trailing_slash_rules
+  @test/runtest-test_verification_run_registry
   @test/runtest-test_slack_user_directory
   @test/runtest-test_cancel_safe
   @test/runtest-test_cancel_wall_bucket


### PR DESCRIPTION
## 무엇을 배선했나

래칫(`#26959`, 2026-08-06) 도입 **이후에 추가된** 미배선 테스트 15개입니다. 두 CI 타깃 소스(`.github/workflows/ci.yml` · `scripts/ci-run-focused-tests.sh`) 어디에도 이름이 없어 **한 번도 실행된 적이 없습니다.**

```
test_dedup_rules                        test_keeper_codex_error_carriage
test_exec_command_gate_log_sink         test_keeper_persistence_span_history
test_file_kind_vocabulary               test_keeper_rotation_eligibility_census
test_http_auth_strict_flag              test_keeper_toml_accessor_matrix
test_keeper_chat_broadcast              test_keeper_turn_dispatch_authority
test_keeper_codex_effort_clamp          test_runtime_quota_window
test_subsystem_health_state             test_trailing_slash_rules
test_verification_run_registry
```

## 앞의 두 배치와 성격이 다릅니다

| 표본 | 기준 | 측정 | green | red |
|---|---|---|---|---|
| 배치 1 (#28508) | 알파벳 순 | 30 | 25 | 5 |
| 배치 2 (#28515) | 알파벳 순 | 50 | 44 | 6 |
| 배치 3 (이 PR) | 추가 시점 (08-06 이후) | 15 | **15** | **0** |

red 가 0 입니다. 최근 코드에 맞춰 작성됐으니 **고칠 것이 없고 배선만 빠졌습니다.** 미배선 581개는 균질하지 않습니다 — 낡아서 red 인 부분과 그냥 누락된 부분이 섞여 있고, 후자가 최근으로 갈수록 많습니다.

## flaky 선별

15개 각각 `dune build --force` 로 2회씩 실행, 15/15 안정.

## 검증

```
$ bash scripts/audit-ci-test-targets.sh
[ci-test-targets] OK - 295 CI targets, all declared in Dune
[ci-test-targets] OK - 566 suites unwired, at baseline
```

## 이 목록을 두 번 만들었습니다

처음에는 배선 목록을 `scripts/ci-run-focused-tests.sh` 한 파일에서만 뽑아 43개를 대상으로 잡았습니다. audit 이 거부했습니다:

```
[ci-test-targets] FAIL - CI executes the same Dune test target more than once
  - test_caller_identity_credential_binding
  - test_claimable_task_summaries
  …
```

`CI_TARGET_SOURCES` 는 두 파일이고, 두 소스 기준 배선은 196 이 아니라 280 입니다 — 84개를 미배선으로 잘못 셌습니다. 이 PR 의 15개는 audit 이 통과시킨 목록입니다.

`#28508` · `#28515` 는 audit 스크립트 자신의 계산을 덤프해 뽑았으므로 이 오류의 영향을 받지 않습니다.

## 한계

로컬 macOS 측정입니다. Linux CI 가 red 로 보고하면 그 항목을 빼고 baseline 을 다시 맞춥니다. 그 전에는 머지하지 않습니다.

RFC-WAIVED: CI 테스트 타깃 배선 + 래칫 baseline. 코드 표면 무변경.

Refs #28509, #28518

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
