### PR TITLE
test(supervisor): build keeper meta through the shared fixture helper

### DIFF
--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -200,16 +200,15 @@ let test_crash_log_empty_for_unknown () =
 let test_should_cleanup_dead_true () =
   Reg.For_testing.clear ();
   let _entry = Reg.For_testing.register ~base_path:"/tmp" "dead1"
-      (let json = `Assoc [
-        ("name", `String "dead1");
-        ("agent_name", `String "agent-dead1");
-        ("trace_id", `String "trace-dead1");
-        ("sandbox_profile", `String "local");
-        ("network_mode", `String "inherit");
-      ] in
-      match Keeper_meta_json_parse.meta_of_json json with
-      | Ok meta -> meta
-      | Error err -> fail err)
+      (match
+         Masc_test_deps.meta_of_json_fixture
+           (`Assoc
+             [ ("name", `String "dead1")
+             ; ("trace_id", `String "trace-dead1")
+             ])
+       with
+       | Ok meta -> meta
+       | Error err -> fail err)
   in
   Reg.mark_dead ~base_path:"/tmp" "dead1" ~at:10.0;
   let entry = Option.get (Reg.get ~base_path:"/tmp" "dead1") in
@@ -219,16 +218,15 @@ let test_should_cleanup_dead_true () =
 let test_should_cleanup_dead_false_when_recent () =
   Reg.For_testing.clear ();
   let _entry = Reg.For_testing.register ~base_path:"/tmp" "dead2"
-      (let json = `Assoc [
-        ("name", `String "dead2");
-        ("agent_name", `String "agent-dead2");
-        ("trace_id", `String "trace-dead2");
-        ("sandbox_profile", `String "local");
-        ("network_mode", `String "inherit");
-      ] in
-      match Keeper_meta_json_parse.meta_of_json json with
-      | Ok meta -> meta
-      | Error err -> fail err)
+      (match
+         Masc_test_deps.meta_of_json_fixture
+           (`Assoc
+             [ ("name", `String "dead2")
+             ; ("trace_id", `String "trace-dead2")
+             ])
+       with
+       | Ok meta -> meta
+       | Error err -> fail err)
   in
   Reg.mark_dead ~base_path:"/tmp" "dead2" ~at:100.0;
   let entry = Option.get (Reg.get ~base_path:"/tmp" "dead2") in
@@ -283,15 +281,21 @@ let test_done_signal_maps_registry_result () =
 (* Shared pure supervisor fixtures. *)
 
 let bp = "/tmp/test-supervisor-prop"
+(* sandbox_profile and network_mode left the meta JSON wire schema -- they
+   arrive from keeper.toml now, and meta_of_json rejects a document that still
+   carries them ("fields outside the current schema ... runtime reset
+   required"). This fixture only ever set them to the record defaults
+   ("local" / "inherit"), so dropping them changes nothing these cases assert.
+   test_keeper_keepalive_helpers made the same edit; this suite was outside CI,
+   so its copy kept the old shape (#28131). *)
 let make_meta name =
-  let json = `Assoc [
-    ("name", `String name);
-    ("agent_name", `String ("agent-" ^ name));
-    ("trace_id", `String ("trace-" ^ name));
-    ("sandbox_profile", `String "local");
-    ("network_mode", `String "inherit");
-  ] in
-  match Keeper_meta_json_parse.meta_of_json json with
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+        [ ("name", `String name)
+        ; ("trace_id", `String ("trace-" ^ name))
+        ])
+  with
   | Ok meta -> meta
   | Error err -> fail ("make_meta: " ^ err)
 


### PR DESCRIPTION
## 무엇이 문제였나

`test_keeper_supervisor` 는 45건 중 **33건이 실패**합니다 (`#28131` 당시 44중 32 — 그 뒤 테스트가 하나 늘고 실패도 하나 늘었습니다). CI 밖이라 아무도 보지 못했습니다.

원인을 전수 집계하니 이슈의 진단과 분포가 달랐습니다:

```
30  FAIL make_meta: invalid current keeper meta: …            ← 픽스처 스키마 드리프트
 2  FAIL later keeper still supervised
 2  FAIL invalid current keeper meta: …
 1  FAIL … Keeper owner inventory is not installed            ← 이슈의 진단
```

**30/33 이 손으로 쓴 meta 픽스처 하나**에서 나옵니다. 그리고 그 픽스처는 **세 가지로 동시에** 낡아 있었고, 각각이 앞의 것에 가려져 있었습니다:

```
1차:  fields outside the current schema: sandbox_profile, network_mode
2차:  missing required fields: schema, instructions, multimodal_policy, trace_history,
      generation, last_handoff_ts, created_at, updated_at, total_turns, total_input_tokens
3차:  agent_name does not match canonical keeper agent name
```

- `sandbox_profile` · `network_mode` 는 meta JSON 에서 빠지고 `keeper.toml` 로 옮겨갔습니다.
- 필수 필드가 10개 늘었습니다.
- `#28250` 이 keeper→agent 이름을 계층 공유 코덱으로 만들었습니다.

형제 스위트 `test_keeper_keepalive_helpers` 는 1차 편집을 이미 했고 주석까지 남겨 뒀습니다 — **그 스위트는 CI 에서 돌아 red 가 보였고, 이쪽은 안 돌아서 안 고쳐졌습니다.**

## 무엇을 바꿨나

세 픽스처를 전부 `Masc_test_deps.meta_of_json_fixture` 로 돌립니다. 그 헬퍼가 현재 스키마를 채우고 canonical agent name 을 파생하므로, 이름과 trace_id 만 넘기면 드리프트할 것이 남지 않습니다.

```ocaml
let make_meta name =
  match
    Masc_test_deps.meta_of_json_fixture
      (`Assoc [ ("name", `String name); ("trace_id", `String ("trace-" ^ name)) ])
  with
  | Ok meta -> meta
  | Error err -> fail ("make_meta: " ^ err)
```

값을 하나씩 채워 넣는 수리는 다음 스키마 변경에서 같은 일을 반복하게 합니다 — 세 번 낡았다는 사실 자체가 그 방식의 결과입니다.

## 검증

```
before:  33 failures! in 45 tests run
after:    5 failures! in 45 tests run
```

## 남은 5건 — 이 PR 의 범위가 아닙니다

원인이 셋으로 갈립니다:

```
3건  Keeper owner inventory is not installed        ← #28131 의 원래 진단
1건  invalid keeper profile for keeper empty-intent
1건  terminal registry phase is Dead / persisted tombstone meta becomes registry authority
```

inventory 3건 중 2건은 `with_reap_ready_dead_keeper` 하네스를 지나는데, 그 하네스에 `Eio.Switch.run` 이 없어 `install_from_store ~sw` 를 부르려면 구조를 바꿔야 합니다. 검증된 28건 수리를 그 작업에 묶지 않고 여기서 끊습니다.

**5건이 남아 있으므로 이 스위트는 아직 CI 에 배선하지 않습니다.** `#28131` 은 열어 둡니다.

RFC-WAIVED: 테스트 픽스처를 기존 공유 헬퍼로 교체. 프로덕션 코드 무변경.

Refs #28131

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
