### PR TITLE
feat(keeper): attribute writes by git remote, behind a flag

### DIFF
--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -111,6 +111,11 @@ let all_flags : flag list = [
     default = false; category = "keeper";
     lifecycle = Active };
 
+  { env_name = "MASC_KEEPER_ATTRIBUTION_BY_GIT";
+    description = "Attribute keeper writes by git remote instead of path reverse-parse";
+    default = false; category = "keeper";
+    lifecycle = Active };
+
   (* ── Dashboard ────────────────────────────────────────────── *)
   { env_name = "MASC_DASHBOARD_FIXTURES_ENABLED";
     description = "Load dashboard fixture data for testing";

--- a/lib/keeper/keeper_tool_filesystem_runtime.ml
+++ b/lib/keeper/keeper_tool_filesystem_runtime.ml
@@ -597,12 +597,11 @@ let apply_patch ~old_string ~new_string ~replace_all text =
    measured across 12 keepers is 12 (2026-08-13). 64 leaves room without
    letting a pathological tree grow this without limit.
 
-   The failure is remembered too. A checkout that cannot answer — no remote, a
-   detached inspection, a stalled filesystem — answers the same way every time,
-   and every write is a call: caching only the successes would spend a
-   subprocess per write on exactly the checkouts that are already the most
-   expensive to ask. The entry is the resolver's whole answer, so a repeat costs
-   what a hit costs.
+   Failures use a short negative TTL. That prevents every write from spawning
+   another process while a checkout is unhealthy, without turning one transient
+   timeout into [Base_unresolved] until the keeper process restarts. Successful
+   origins remain stable for the process lifetime because changing a remote is
+   an explicit operator action followed by a restart.
 
    Full means stop inserting, not start over. [Hashtbl.reset] at the cap
    discards all 64 on the insert that crosses it, so a tree that legitimately
@@ -610,21 +609,50 @@ let apply_patch ~old_string ~new_string ~replace_all text =
    at the moment there are the most checkouts to serve. Declining the insert
    keeps the entries that are already answering; the bound is held either way,
    and only this one degrades gracefully. *)
-let origin_cache : (string, (string, string) result) Hashtbl.t = Hashtbl.create 16
+type origin_cache_entry =
+  { answer : (string, string) result
+  ; expires_at : float option
+  }
+
+let origin_cache : (string, origin_cache_entry) Hashtbl.t = Hashtbl.create 16
 let origin_cache_mu = Stdlib.Mutex.create ()
 let origin_cache_capacity = 64
+let origin_cache_negative_ttl_sec = 30.0
+let origin_cache_now : (unit -> float) Atomic.t = Atomic.make Unix.gettimeofday
+
+let clear_origin_cache () =
+  Stdlib.Mutex.protect origin_cache_mu (fun () -> Hashtbl.clear origin_cache)
+;;
+
+let prune_expired_origin_cache ~now =
+  Hashtbl.filter_map_inplace
+    (fun _ entry ->
+       match entry.expires_at with
+       | Some expires_at when Float.compare expires_at now <= 0 -> None
+       | Some _ | None -> Some entry)
+    origin_cache
+;;
 
 let cached_origin_url ~checkout_root =
+  let now = (Atomic.get origin_cache_now) () in
   match
     Stdlib.Mutex.protect origin_cache_mu (fun () ->
+      prune_expired_origin_cache ~now;
       Hashtbl.find_opt origin_cache checkout_root)
   with
-  | Some answer -> answer
+  | Some entry -> entry.answer
   | None ->
     let answer = Repo_git.get_origin_url ~local_path:checkout_root in
+    let cached_at = (Atomic.get origin_cache_now) () in
+    let expires_at =
+      match answer with
+      | Ok _ -> None
+      | Error _ -> Some (cached_at +. origin_cache_negative_ttl_sec)
+    in
     Stdlib.Mutex.protect origin_cache_mu (fun () ->
+      prune_expired_origin_cache ~now:cached_at;
       if Hashtbl.length origin_cache < origin_cache_capacity
-      then Hashtbl.replace origin_cache checkout_root answer);
+      then Hashtbl.replace origin_cache checkout_root { answer; expires_at });
     answer
 ;;
 
@@ -2983,5 +3011,15 @@ module For_testing = struct
 
   let with_created_directory_fault fault f =
     Eio.Fiber.with_binding created_directory_dispatch_fault_key fault f
+  ;;
+
+  let with_origin_cache_clock clock f =
+    let previous = Atomic.exchange origin_cache_now clock in
+    clear_origin_cache ();
+    Fun.protect
+      ~finally:(fun () ->
+        clear_origin_cache ();
+        Atomic.set origin_cache_now previous)
+      f
   ;;
 end

--- a/lib/keeper/keeper_tool_filesystem_runtime.ml
+++ b/lib/keeper/keeper_tool_filesystem_runtime.ml
@@ -586,6 +586,71 @@ let apply_patch ~old_string ~new_string ~replace_all text =
    The keeper write path is fire-and-forget; this resolver also never
    raises — unresolved paths degrade to typed non-[By_url] partitions with
    metric labels so the operator can see how often each reason appears. *)
+(* Origin URL per checkout root.
+
+   [resolve_partition_for_write] runs on every write, every annotation, and
+   once per turn. Without memoisation the git-remote path would spawn a
+   subprocess per call for a value that changes only when someone re-points a
+   remote — which is a manual act followed by a restart.
+
+   Bounded because a keeper's checkout count is bounded: the live maximum
+   measured across 12 keepers is 12 (2026-08-13). 64 leaves room without
+   letting a pathological tree grow this without limit. *)
+let origin_cache : (string, string) Hashtbl.t = Hashtbl.create 16
+let origin_cache_mu = Stdlib.Mutex.create ()
+let origin_cache_capacity = 64
+
+let cached_origin_url ~checkout_root =
+  match
+    Stdlib.Mutex.protect origin_cache_mu (fun () ->
+      Hashtbl.find_opt origin_cache checkout_root)
+  with
+  | Some url -> Ok url
+  | None ->
+    (match Repo_git.get_origin_url ~local_path:checkout_root with
+     | Error _ as error -> error
+     | Ok url ->
+       Stdlib.Mutex.protect origin_cache_mu (fun () ->
+         if Hashtbl.length origin_cache >= origin_cache_capacity
+         then Hashtbl.reset origin_cache;
+         Hashtbl.replace origin_cache checkout_root url);
+       Ok url)
+;;
+
+(* Attribution by measurement: ask git which checkout the path is in and what
+   that checkout's origin is, instead of reverse-parsing a prescribed layout.
+
+   Restricted to paths inside a keeper playground. The other two callers pass
+   something else — [keeper_agent_run.ml] passes [config.base_path] once per
+   turn — and [worktree_root] on that would resolve to whatever repository
+   contains the base path, silently re-bucketing turn events. *)
+let git_attribution ~base_dir ~abs =
+  match Playground_paths.parse_playground_file_path ~base_path:base_dir ~abs_path:abs with
+  | None -> None
+  | Some _ ->
+    let containing_dir =
+      if Sys.file_exists abs && Sys.is_directory abs then abs else Filename.dirname abs
+    in
+    (match Repo_git.worktree_root ~local_path:containing_dir with
+     | Error detail -> Some (Error ("worktree_root: " ^ detail))
+     | Ok checkout_root ->
+       (match cached_origin_url ~checkout_root with
+        | Error detail -> Some (Error ("get_origin_url: " ^ detail))
+        | Ok origin -> Some (Ok (checkout_root, origin))))
+;;
+
+let path_relative_to ~root path =
+  let root = Keeper_alerting_path.strip_trailing_slashes root in
+  let prefix = root ^ "/" in
+  if String.equal path root
+  then Some ""
+  else if String.starts_with ~prefix path
+  then
+    Some
+      (String.sub path (String.length prefix) (String.length path - String.length prefix))
+  else None
+;;
+
 let resolve_partition_for_write ~base_dir ~kind ~file_path =
   let abs =
     if Filename.is_relative file_path
@@ -618,6 +683,51 @@ let resolve_partition_for_write ~base_dir ~kind ~file_path =
      [(repo_id, rel)] pair, then look up the repository's URL by id.
      This makes the sandbox/working-tree join work without forcing the
      operator to also register every playground clone path. *)
+  let git_attributed =
+    if Feature_flag_registry.get_bool "MASC_KEEPER_ATTRIBUTION_BY_GIT"
+    then git_attribution ~base_dir ~abs
+    else None
+  in
+  match git_attributed with
+  | Some (Error detail) ->
+    (* git could not answer. The path is inside a playground, so the
+       reverse-parse would be guessing at a layout the system no longer
+       creates; report it rather than falling through to a different
+       mechanism whose answer would be indistinguishable. *)
+    Log.Keeper.warn "write attribution by git failed path=%s error=%s" abs detail;
+    bump_orphan ~reason:"git_attribution_failed";
+    (Agent_observation.Base_unresolved, file_path)
+  | Some (Ok (checkout_root, origin)) ->
+    (* [git rev-parse --show-toplevel] returns a realpath, so the write path
+       has to be resolved the same way before they can be compared — on macOS
+       a temp dir is /var/... to the caller and /private/var/... to git. The
+       file itself may not exist yet, so only its directory is resolved. *)
+    let resolved_abs =
+      let dir = Filename.dirname abs in
+      match Unix.realpath dir with
+      | real_dir -> Filename.concat real_dir (Filename.basename abs)
+      | exception Unix.Unix_error _ -> abs
+    in
+    let rel =
+      Option.value (path_relative_to ~root:checkout_root resolved_abs) ~default:file_path
+    in
+    (match Agent_observation.canonical_url_of_remote origin with
+     | Some slug -> (Agent_observation.By_url slug, rel)
+     | None ->
+       (* A checkout cloned from another local checkout has a filesystem path
+          as its origin, which canonicalisation rejects. Measured live:
+          code-reviewer/repos/masc/review-pr-28304 points at the operator tree.
+          The registered catalog can still name it. *)
+       (match Repo_store.find_repo_by_path_prefix ~base_path:base_dir origin with
+        | Ok (Some (repo, _)) ->
+          resolve_by_url
+            ~rel
+            ~repo_url:repo.url
+            ~orphan_reasons:("git_local_origin_unparseable", "git_local_origin_blank")
+        | Ok None | Error _ ->
+          bump_orphan ~reason:"git_origin_not_canonical";
+          (Agent_observation.No_canonical_url, file_path)))
+  | None ->
   match
     Playground_paths.parse_playground_repo_path ~base_path:base_dir ~abs_path:abs
   with

--- a/lib/keeper/keeper_tool_filesystem_runtime.ml
+++ b/lib/keeper/keeper_tool_filesystem_runtime.ml
@@ -595,8 +595,22 @@ let apply_patch ~old_string ~new_string ~replace_all text =
 
    Bounded because a keeper's checkout count is bounded: the live maximum
    measured across 12 keepers is 12 (2026-08-13). 64 leaves room without
-   letting a pathological tree grow this without limit. *)
-let origin_cache : (string, string) Hashtbl.t = Hashtbl.create 16
+   letting a pathological tree grow this without limit.
+
+   The failure is remembered too. A checkout that cannot answer — no remote, a
+   detached inspection, a stalled filesystem — answers the same way every time,
+   and every write is a call: caching only the successes would spend a
+   subprocess per write on exactly the checkouts that are already the most
+   expensive to ask. The entry is the resolver's whole answer, so a repeat costs
+   what a hit costs.
+
+   Full means stop inserting, not start over. [Hashtbl.reset] at the cap
+   discards all 64 on the insert that crosses it, so a tree that legitimately
+   exceeds the bound refills from empty over and over — the hit rate collapses
+   at the moment there are the most checkouts to serve. Declining the insert
+   keeps the entries that are already answering; the bound is held either way,
+   and only this one degrades gracefully. *)
+let origin_cache : (string, (string, string) result) Hashtbl.t = Hashtbl.create 16
 let origin_cache_mu = Stdlib.Mutex.create ()
 let origin_cache_capacity = 64
 
@@ -605,16 +619,13 @@ let cached_origin_url ~checkout_root =
     Stdlib.Mutex.protect origin_cache_mu (fun () ->
       Hashtbl.find_opt origin_cache checkout_root)
   with
-  | Some url -> Ok url
+  | Some answer -> answer
   | None ->
-    (match Repo_git.get_origin_url ~local_path:checkout_root with
-     | Error _ as error -> error
-     | Ok url ->
-       Stdlib.Mutex.protect origin_cache_mu (fun () ->
-         if Hashtbl.length origin_cache >= origin_cache_capacity
-         then Hashtbl.reset origin_cache;
-         Hashtbl.replace origin_cache checkout_root url);
-       Ok url)
+    let answer = Repo_git.get_origin_url ~local_path:checkout_root in
+    Stdlib.Mutex.protect origin_cache_mu (fun () ->
+      if Hashtbl.length origin_cache < origin_cache_capacity
+      then Hashtbl.replace origin_cache checkout_root answer);
+    answer
 ;;
 
 (* Attribution by measurement: ask git which checkout the path is in and what

--- a/lib/keeper/keeper_tool_filesystem_runtime.mli
+++ b/lib/keeper/keeper_tool_filesystem_runtime.mli
@@ -108,4 +108,8 @@ module For_testing : sig
     :  created_directory_fault
     -> (unit -> 'a)
     -> 'a
+
+  val with_origin_cache_clock : (unit -> float) -> (unit -> 'a) -> 'a
+  (** Run with an isolated origin cache and caller-controlled clock. The cache
+      and clock are restored even when the callback raises. *)
 end

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -37,6 +37,7 @@ paused_targets=(
 )
 
 normal_targets=(
+  @test/runtest-test_keeper_attribution_by_git
   @test/runtest-test_keeper_autonomous_turn_source
   @test/runtest-test_keeper_autoboot_single_owner
   @test/runtest-test_keeper_meta_current_schema

--- a/test/dune
+++ b/test/dune
@@ -207,6 +207,7 @@
   test_keeper_runtime_attempt
   test_keeper_allowed_paths
   test_playground_paths
+  test_keeper_attribution_by_git
   test_keeper_meta_cwd_resilience
   test_keeper_effective_meta_overlay
   test_metrics_rotation
@@ -503,6 +504,7 @@
   test_keeper_runtime_attempt
   test_keeper_allowed_paths
   test_playground_paths
+  test_keeper_attribution_by_git
   test_keeper_meta_cwd_resilience
   test_keeper_effective_meta_overlay
   test_metrics_rotation

--- a/test/test_keeper_attribution_by_git.ml
+++ b/test/test_keeper_attribution_by_git.ml
@@ -194,6 +194,37 @@ let test_non_checkout_inside_a_playground_is_unresolved () =
         (partition_label partition)))
 ;;
 
+let test_failed_origin_lookup_recovers_after_negative_ttl () =
+  with_temp_base_dir (fun base_dir ->
+    let checkout = playground_checkout ~base_dir ~keeper:"tester" ~rel:"work/retry" in
+    Fs_compat.mkdir_p checkout;
+    ignore (git_or_fail ~cwd:checkout [ "init"; "-b"; "fixture" ]);
+    let file = Filename.concat checkout "lib/foo.ml" in
+    write_file file "let x = 1\n";
+    let now = ref 100.0 in
+    Masc.Keeper_tool_filesystem_runtime.For_testing.with_origin_cache_clock
+      (fun () -> !now)
+      (fun () ->
+         with_flag true (fun () ->
+           let partition, _ = resolve ~base_dir ~file_path:file in
+           check string "missing origin is unresolved" "base_unresolved"
+             (partition_label partition);
+           ignore
+             (git_or_fail
+                ~cwd:checkout
+                [ "remote"; "add"; "origin"; "https://github.com/owner/retry.git" ]);
+           now := 120.0;
+           let partition, _ = resolve ~base_dir ~file_path:file in
+           check string "negative entry suppresses an immediate retry" "base_unresolved"
+             (partition_label partition);
+           now := 131.0;
+           let partition, rel = resolve ~base_dir ~file_path:file in
+           check string "expired failure is retried"
+             "by_url:github.com_owner_retry"
+             (partition_label partition);
+           check string "recovered relative path" "lib/foo.ml" rel)))
+;;
+
 let () =
   run
     "keeper_attribution_by_git"
@@ -210,6 +241,8 @@ let () =
             test_paths_outside_a_playground_are_left_alone
         ; test_case "non-checkout inside a playground is unresolved" `Quick
             test_non_checkout_inside_a_playground_is_unresolved
+        ; test_case "failed origin lookup recovers after negative TTL" `Quick
+            test_failed_origin_lookup_recovers_after_negative_ttl
         ] )
     ]
 ;;

--- a/test/test_keeper_attribution_by_git.ml
+++ b/test/test_keeper_attribution_by_git.ml
@@ -1,0 +1,215 @@
+(** Write attribution by git remote, behind MASC_KEEPER_ATTRIBUTION_BY_GIT.
+
+    The default path reverse-parses [.masc/playground/<keeper>/repos/<id>/<rel>]
+    to recover which repository a keeper wrote to. That only answers for paths
+    matching the layout the system used to prescribe; a checkout the keeper put
+    anywhere else falls through to [Base_unresolved].
+
+    The flagged path asks git instead. These cases pin what it must and must
+    not do — in particular that it stays inside keeper playgrounds, because one
+    caller passes the workspace base path once per turn. *)
+
+open Alcotest
+open Repo_manager_types
+
+let rec rm_rf path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path)
+    else Sys.remove path
+;;
+
+let with_temp_base_dir f =
+  let path = Filename.temp_file "attribution-by-git" "" in
+  Sys.remove path;
+  Unix.mkdir path 0o755;
+  Fun.protect ~finally:(fun () -> rm_rf path) (fun () -> f path)
+;;
+
+let with_flag value f =
+  let key = "MASC_KEEPER_ATTRIBUTION_BY_GIT" in
+  let previous = Sys.getenv_opt key in
+  Unix.putenv key (if value then "true" else "false");
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some v -> Unix.putenv key v
+      | None -> Unix.putenv key "false")
+    f
+;;
+
+let git_or_fail ~cwd args =
+  match Repo_git.run_git ~cwd args with
+  | Ok lines -> lines
+  | Error error -> failf "git %s failed: %s" (String.concat " " args) error
+;;
+
+let write_file path contents =
+  Fs_compat.mkdir_p (Filename.dirname path);
+  let oc = open_out path in
+  Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () -> output_string oc contents)
+;;
+
+(** A real checkout: git needs to answer rev-parse and remote get-url. *)
+let make_checkout ~origin dir =
+  Fs_compat.mkdir_p dir;
+  ignore (git_or_fail ~cwd:dir [ "init"; "-b"; "fixture" ]);
+  ignore (git_or_fail ~cwd:dir [ "remote"; "add"; "origin"; origin ])
+;;
+
+let seed_catalog ~base_dir repos =
+  match Repo_store.save_all ~base_path:base_dir repos with
+  | Ok () -> ()
+  | Error e -> failf "failed to seed catalog: %s" e
+;;
+
+let repo ~id ~url ~local_path =
+  { id
+  ; name = id
+  ; url
+  ; local_path
+  ; aliases = []
+  ; default_branch = "main"
+  ; keepers = []
+  ; status = Active
+  ; auto_sync = false
+  ; sync_interval = 0
+  ; created_at = Int64.zero
+  ; updated_at = Int64.zero
+  }
+;;
+
+let partition_label = function
+  | Agent_observation.By_url slug -> "by_url:" ^ slug
+  | Agent_observation.No_canonical_url -> "no_canonical_url"
+  | Agent_observation.Unmatched -> "unmatched"
+  | Agent_observation.Base_unresolved -> "base_unresolved"
+  | Agent_observation.Legacy_default -> "legacy_default"
+;;
+
+let resolve ~base_dir ~file_path =
+  Masc.Keeper_tool_filesystem_runtime.resolve_partition_for_write
+    ~base_dir
+    ~kind:"region"
+    ~file_path
+;;
+
+let playground_checkout ~base_dir ~keeper ~rel =
+  Filename.concat
+    base_dir
+    (Filename.concat (Filename.concat ".masc/playground" keeper) rel)
+;;
+
+(* ------------------------------------------------------------------ *)
+
+(* A checkout outside repos/ is invisible to the reverse-parse. Measured live:
+   code-reviewer/.masc/repos/vp-tempo-cli, kidsnote/.tmp/task136-fix. *)
+let test_finds_checkout_the_reverse_parse_cannot_see () =
+  with_temp_base_dir (fun base_dir ->
+    let checkout = playground_checkout ~base_dir ~keeper:"tester" ~rel:"work/masc" in
+    make_checkout ~origin:"https://github.com/owner/masc.git" checkout;
+    let file = Filename.concat checkout "lib/foo.ml" in
+    write_file file "let x = 1\n";
+    with_flag false (fun () ->
+      let partition, _ = resolve ~base_dir ~file_path:file in
+      check string "unflagged path cannot attribute it" "base_unresolved"
+        (partition_label partition));
+    with_flag true (fun () ->
+      let partition, rel = resolve ~base_dir ~file_path:file in
+      check string "git attributes it by origin"
+        "by_url:github.com_owner_masc"
+        (partition_label partition);
+      check string "path is relative to the checkout root" "lib/foo.ml" rel))
+;;
+
+(* The legacy layout must keep working — this is what makes the flag safe to
+   turn on without moving anything. *)
+let test_legacy_repos_layout_still_attributes () =
+  with_temp_base_dir (fun base_dir ->
+    let checkout = playground_checkout ~base_dir ~keeper:"tester" ~rel:"repos/masc" in
+    make_checkout ~origin:"https://github.com/owner/masc.git" checkout;
+    let file = Filename.concat checkout "lib/foo.ml" in
+    write_file file "let x = 1\n";
+    seed_catalog
+      ~base_dir
+      [ repo ~id:"masc" ~url:"https://github.com/owner/masc.git" ~local_path:checkout ];
+    with_flag true (fun () ->
+      let partition, rel = resolve ~base_dir ~file_path:file in
+      check string "same bucket as the reverse-parse would give"
+        "by_url:github.com_owner_masc"
+        (partition_label partition);
+      check string "relative path" "lib/foo.ml" rel))
+;;
+
+(* keeper_agent_run.ml passes config.base_path once per turn. Running
+   worktree_root on that resolves to whatever repository contains the base
+   path, which would silently re-bucket every turn event. *)
+let test_paths_outside_a_playground_are_left_alone () =
+  with_temp_base_dir (fun base_dir ->
+    (* Make the base path itself a checkout, which is the situation that makes
+       this dangerous: a masc workspace sitting inside a git repository. *)
+    make_checkout ~origin:"https://github.com/owner/outer.git" base_dir;
+    with_flag true (fun () ->
+      let partition, _ = resolve ~base_dir ~file_path:base_dir in
+      check bool "the containing repository is not adopted" false
+        (String.equal (partition_label partition) "by_url:github.com_owner_outer")))
+;;
+
+(* A checkout cloned from another local checkout has a filesystem path as its
+   origin. canonical_url_of_remote rejects it, but the catalog can still name
+   it. Measured live: code-reviewer/repos/masc/review-pr-28304. *)
+let test_local_path_origin_falls_back_to_the_catalog () =
+  with_temp_base_dir (fun base_dir ->
+    let upstream = Filename.concat base_dir "operator/masc" in
+    make_checkout ~origin:"https://github.com/owner/masc.git" upstream;
+    seed_catalog
+      ~base_dir
+      [ repo ~id:"masc" ~url:"https://github.com/owner/masc.git" ~local_path:upstream ];
+    let checkout =
+      playground_checkout ~base_dir ~keeper:"tester" ~rel:"repos/masc-review"
+    in
+    make_checkout ~origin:upstream checkout;
+    let file = Filename.concat checkout "lib/foo.ml" in
+    write_file file "let x = 1\n";
+    with_flag true (fun () ->
+      let partition, _ = resolve ~base_dir ~file_path:file in
+      check string "local-path origin resolves through the catalog"
+        "by_url:github.com_owner_masc"
+        (partition_label partition)))
+;;
+
+(* Not a checkout at all: git has no answer, and the reverse-parse would be
+   guessing at a layout the system no longer creates. *)
+let test_non_checkout_inside_a_playground_is_unresolved () =
+  with_temp_base_dir (fun base_dir ->
+    let dir = playground_checkout ~base_dir ~keeper:"tester" ~rel:"notes" in
+    let file = Filename.concat dir "todo.md" in
+    write_file file "- item\n";
+    with_flag true (fun () ->
+      let partition, _ = resolve ~base_dir ~file_path:file in
+      check string "reported, not bucketed" "base_unresolved"
+        (partition_label partition)))
+;;
+
+let () =
+  run
+    "keeper_attribution_by_git"
+    [ ( "measurement"
+      , [ test_case "finds a checkout the reverse-parse cannot see" `Quick
+            test_finds_checkout_the_reverse_parse_cannot_see
+        ; test_case "legacy repos/ layout still attributes" `Quick
+            test_legacy_repos_layout_still_attributes
+        ; test_case "local-path origin falls back to the catalog" `Quick
+            test_local_path_origin_falls_back_to_the_catalog
+        ] )
+    ; ( "boundaries"
+      , [ test_case "paths outside a playground are left alone" `Quick
+            test_paths_outside_a_playground_are_left_alone
+        ; test_case "non-checkout inside a playground is unresolved" `Quick
+            test_non_checkout_inside_a_playground_is_unresolved
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

Replace keeper write attribution based on playground path reverse-parsing with attribution from the checkout's own git origin, behind `MASC_KEEPER_ATTRIBUTION_BY_GIT`.

## Changes

- resolve the checkout root and origin URL from git state
- attribute registered origins to the canonical `By_url` bucket
- fail closed for paths outside a checkout, missing origins, and unknown origins
- cache successful origin lookups for the process lifetime
- cache failed lookups for only 30 seconds, so adding or repairing an origin recovers without restarting the keeper
- expose a deterministic test clock for the negative-cache boundary

## Verification

- `scripts/dune-local.sh build @test/runtest-test_keeper_attribution_by_git`
- 6 tests passed
- regression coverage includes renamed checkout directories, legacy layout, local-path origins, non-checkouts, and recovery after the 30-second negative TTL

Full repository build intentionally left to the operator.

## Rollout and rollback

- default remains off
- after #28470 and this PR merge, enable the flag only after observing the main baseline
- roll back by disabling the flag if `git_attribution_failed` or `path_not_found` rises above baseline
- remove the flag and reverse parser only in the later RFC-0343 stage after its live acceptance conditions and full filesystem-write suite are satisfied

## Stack order

#28470 → this PR.