### PR TITLE
ci(tests): name the focused-test group that set the exit code

### DIFF
--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -15,6 +15,24 @@ export DUNE_JOBS="${DUNE_JOBS:-1}"
 export ME_ROOT="${ME_ROOT:-/tmp/me}"
 mkdir -p "${ME_ROOT}"
 
+# Which groups failed, recorded through a file rather than a shell array: two
+# groups run inside subshells so their test knobs cannot leak, and a subshell
+# cannot append to its parent's array. Without this the step exited 1 while
+# every group in the log reported success, and the only way to find the failing
+# one was to re-run the suites by hand (masc#28502).
+failed_groups_file="$(mktemp)"
+trap 'rm -f "${failed_groups_file}"' EXIT
+
+record_group_failure() {
+  local label="$1"
+  local status="$2"
+  printf '%s (exit %s)\n' "${label}" "${status}" >>"${failed_groups_file}"
+  # Emitted after ::endgroup:: on purpose: an annotation written inside a
+  # collapsed group is only visible to someone who already knows to expand it,
+  # which is the thing that was missing.
+  echo "::error::focused tests: ${label} failed (exit ${status})"
+}
+
 run_group() {
   local label="$1"
   local timeout_sec="$2"
@@ -26,8 +44,38 @@ run_group() {
   CI_TEST_TIMEOUT_SEC="${timeout_sec}" \
     scripts/ci-run-tests.sh "opam exec -- dune build --root .${target_args}" || status=$?
   echo "::endgroup::"
+  if [ "${status}" -ne 0 ]; then
+    record_group_failure "${label}" "${status}"
+  fi
   return "${status}"
 }
+
+# A group that runs a shell test rather than dune targets. Shares the
+# announcement so a shell test cannot fail more quietly than a dune suite —
+# which it did: [host-fd-health-paths] prints nothing when it passes, so a
+# silent group and a silent failure looked identical in the log.
+run_shell_group() {
+  local label="$1"
+  local script_path="$2"
+  local status=0
+  echo "::group::focused tests: ${label}"
+  bash "${script_path}" || status=$?
+  echo "::endgroup::"
+  if [ "${status}" -ne 0 ]; then
+    record_group_failure "${label}" "${status}"
+  fi
+  return "${status}"
+}
+
+# Sourced rather than executed: stop here and expose only the definitions
+# above. Standard bash idiom, and it changes nothing when the script runs
+# normally ([BASH_SOURCE[0]] equals [$0] then). It exists so the failure
+# announcement can be tested without a dune build, which is the only way to
+# show that a change whose entire purpose is "name the failing group" actually
+# names it.
+if [ "${BASH_SOURCE[0]}" != "$0" ]; then
+  return 0
+fi
 
 paused_targets=(
   @test/runtest-test_keeper_turn_outcome
@@ -270,11 +318,15 @@ overall_status=0
   run_group paused-work 600 "${paused_targets[@]}"
 ) || overall_status=1
 
-echo "::group::focused tests: host-fd-health-paths"
-if ! bash test/test_monitor_system_health_paths.sh; then
-  overall_status=1
-fi
-echo "::endgroup::"
+run_shell_group host-fd-health-paths test/test_monitor_system_health_paths.sh \
+  || overall_status=1
+
+# Runs first among the cheap checks on purpose: it asserts that this script
+# still names a failing group, and it costs no build. If it is the thing that
+# breaks, the run says so by name instead of exiting 1 in silence — the state
+# masc#28502 describes.
+run_shell_group focused-failure-reporting \
+  test/test_ci_focused_tests_names_failing_group.sh || overall_status=1
 
 run_group board-attention-worker 180 "${board_attention_targets[@]}" || overall_status=1
 run_group normal 1200 "${normal_targets[@]}" || overall_status=1
@@ -296,5 +348,22 @@ fi
   export MASC_E2E_TESTS=true
   run_group sse 900 "${sse_targets[@]}"
 ) || overall_status=1
+
+# One place that states the outcome in full. A reader who opens the step and
+# scrolls to the bottom should not have to reconstruct which of seven groups
+# set the exit code.
+if [ -s "${failed_groups_file}" ]; then
+  echo "focused tests: failing groups"
+  sed 's/^/  /' "${failed_groups_file}"
+  overall_status=1
+elif [ "${overall_status}" -ne 0 ]; then
+  # The exit code says something failed and no group claimed it. That is a
+  # defect in this script, not in the suites, and saying so is better than
+  # exiting 1 with nothing to read.
+  echo "::error::focused tests: exit ${overall_status} with no group recorded; \
+ci-run-focused-tests.sh has a failure path that does not call record_group_failure"
+else
+  echo "focused tests: all groups passed"
+fi
 
 exit "${overall_status}"

--- a/test/test_ci_focused_tests_names_failing_group.sh
+++ b/test/test_ci_focused_tests_names_failing_group.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# masc#28502. The focused-tests step exited 1 while every group in its log
+# reported success, so the only way to find the failing group was to re-run the
+# suites by hand. These assert the announcement exists, because a diagnostic
+# that is only checked by reading the source is a diagnostic that silently
+# stops working.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+script="${repo_root}/scripts/ci-run-focused-tests.sh"
+
+fail() {
+  printf '%s\n' "$1" >&2
+  exit 1
+}
+
+# Sourcing gives the definitions without the driver. Run in a subshell because
+# the script cds to the repo root.
+run_case() (
+  # shellcheck source=scripts/ci-run-focused-tests.sh
+  . "${script}"
+  "$@"
+)
+
+# --- a failing group is named where a reader will see it ---
+
+output="$(run_case record_group_failure normal 2 2>&1)" || true
+case "${output}" in
+  *"::error::focused tests: normal failed (exit 2)"*) ;;
+  *) fail "a failing group must be announced by name; got: ${output}" ;;
+esac
+
+# --- the announcement is outside the collapsed group ---
+#
+# An annotation written between ::group:: and ::endgroup:: is only visible to
+# someone who already knows to expand it, which is the state this fixes. The
+# helper itself must therefore emit no group markers.
+case "${output}" in
+  *"::group::"*) fail "the failure announcement must not open a collapsed group" ;;
+  *) ;;
+esac
+
+# --- the failure is recorded, not just printed ---
+#
+# Two groups run inside subshells, and a subshell cannot append to its parent's
+# array. The file is what makes the end-of-run summary possible at all, so an
+# implementation that only echoed would pass the first assertion and still lose
+# the summary.
+recorded="$(
+  # shellcheck source=scripts/ci-run-focused-tests.sh
+  . "${script}"
+  record_group_failure sse 3 >/dev/null 2>&1
+  ( record_group_failure operator-control 4 >/dev/null 2>&1 )
+  cat "${failed_groups_file}"
+)"
+case "${recorded}" in
+  *"sse (exit 3)"*) ;;
+  *) fail "a direct failure must be recorded; got: ${recorded}" ;;
+esac
+case "${recorded}" in
+  *"operator-control (exit 4)"*) ;;
+  *) fail "a failure inside a subshell must survive to the parent; got: ${recorded}" ;;
+esac
+
+# --- the temp file outlives a subshell ---
+#
+# bash resets the EXIT trap in ( ) subshells, so the parent's cleanup does not
+# fire early. Asserted rather than assumed: if that ever changed, every
+# subshell group's failure would vanish and the step would go back to exiting 1
+# with an empty summary.
+survived="$(
+  # shellcheck source=scripts/ci-run-focused-tests.sh
+  . "${script}"
+  ( : )
+  if [ -f "${failed_groups_file}" ]; then echo present; fi
+)"
+[ "${survived}" = "present" ] \
+  || fail "the record file must survive a subshell exiting"
+
+echo "ok: focused-tests failures are named, recorded, and survive subshells"


### PR DESCRIPTION
#28502 의 1단계. **원인을 고치는 게 아니라 원인을 볼 수 있게 만든다** — 지금은 그 수단 자체가 없다.

## 증상

`Build and Test` 의 `Run focused OCaml behavior suites` 가 여러 PR 에서 동시에 실패하는데, 로그의 모든 그룹이 성공을 보고한다.

```
##[group]focused tests: paused-work            → 전부 [OK]
##[group]focused tests: host-fd-health-paths   → 출력 0 줄
##[group]focused tests: normal                 → 전부 [OK]
##[group]focused tests: operator-control       → 전부 [OK]
##[group]focused tests: sse                    → Test Successful. 7 tests run.
[ci-run] tests completed successfully (elapsed_sec=18)
##[endgroup]
##[error]Process completed with exit code 1.      ← 5초 뒤, 사유 없음
```

## 원인

```bash
run_group normal 1200 "${normal_targets[@]}" || overall_status=1
```

`run_group` 은 status 를 **반환은 하는데 아무도 그 실패를 말하지 않는다.** `::endgroup::` 로 섹션이 접힌 뒤 호출자가 조용히 플래그만 세우고, 마지막에 `exit "${overall_status}"` 한다. 일곱 그룹 중 어느 것이 exit code 를 세웠는지 **로그 어디에도 없다.**

`host-fd-health-paths` 는 한 겹 더 나쁘다: `run_group` 을 안 거치고 인라인이며, 통과할 때 아무것도 출력하지 않는다. **조용한 그룹과 조용한 실패가 로그에서 구별되지 않는다.**

## 변경

**1. 실패한 그룹을 이름으로 알린다.**

```bash
record_group_failure() {
  ...
  echo "::error::focused tests: ${label} failed (exit ${status})"
}
```

`::endgroup::` **뒤에** 낸다. 접힌 그룹 안에 쓴 주석은 이미 펼칠 줄 아는 사람에게만 보이고, 그게 지금 없는 바로 그것이다.

**2. 파일에 기록한다 — 배열이 아니라.** 두 그룹(`paused-work`, `operator-control`, `sse`)은 테스트 knob 이 새지 않도록 서브셸에서 돈다. **서브셸은 부모의 배열에 append 할 수 없다.** 파일이라야 끝의 요약이 성립한다.

**3. 셸 테스트 그룹도 같은 알림을 쓴다** (`run_shell_group`). 셸 테스트가 dune suite 보다 조용히 실패할 수 없다.

**4. 끝에 한 곳에서 결과를 말한다.**

```
focused tests: failing groups
  normal (exit 1)
  sse (exit 124)
```

그리고 **아무 그룹도 자기 실패를 주장하지 않았는데 exit code 가 0 이 아니면** 그것도 말한다 — 그건 suite 결함이 아니라 이 스크립트의 결함이고, 침묵으로 1 을 내는 것보다 낫다.

## 검증

```
bash -n scripts/ci-run-focused-tests.sh          OK
shellcheck -x -S warning (양쪽 파일)              exit 0
test/test_ci_focused_tests_names_failing_group.sh OK
```

새 셸 테스트가 네 가지를 건다:

| 주장 | 왜 |
|---|---|
| 실패한 그룹이 이름으로 알려진다 | 이 PR 의 전부 |
| 알림이 접힌 그룹 **밖**에 있다 | 안에 있으면 지금과 같은 상태 |
| 출력만이 아니라 **기록**된다 | 요약이 성립하려면 필요 |
| 기록 파일이 서브셸 종료를 넘겨 산다 | 아래 참조 |

**변이 검증** 2건:

```
::error:: 라인 제거   → "a failing group must be announced by name; got: "
파일 append 제거      → "a direct failure must be recorded; got: "
```

**추측하지 않고 확인한 것**: bash `( )` 서브셸이 부모의 EXIT trap 을 상속하는지. 상속하면 첫 서브셸이 끝날 때 기록 파일이 지워져 서브셸 그룹의 실패가 전부 사라진다. 실측 결과 상속하지 않는다 — 그리고 그 사실이 조용히 바뀌면 이 기능이 통째로 무력해지므로 테스트로 박았다.

## 이게 하지 않는 것

**실패 자체를 고치지 않는다.** 어느 그룹이 죽는지 아직 모르고, 그걸 알 수단을 만드는 게 이 PR 이다. 특정은 이 변경이 머지돼 한 번 돌아야 가능하다.

곁가지로, 이 조건이 얼마나 일상이 됐는지: **CI 테스트 배선을 고치는 PR(#28518, #28519)조차 같은 실패를 달고 머지됐다.** 상시 실패하는 required check 는 안전망이 아니라 소음이고, 소음은 진짜 실패를 통과시킨다.

## 테스트용 seam 을 하나 추가했다

`scripts/ci-run-focused-tests.sh` 가 source 될 때 정의만 노출하고 드라이버 앞에서 `return 0` 한다. 표준 bash 관용구이고 실행 경로에서는 아무것도 바뀌지 않지만(그때 `BASH_SOURCE[0]` = `$0`), **테스트를 위해 넣은 seam 인 것은 사실이라 밝혀둔다.** 대안은 dune 빌드 없이는 검증 불가이고, "실패를 보이게 만든다"는 변경이 스스로를 증명하지 못하는 쪽이 더 나쁘다고 판단했다.

RFC-WAIVED: credential / identity / operator control plane / keeper sandbox / dashboard credential / hooks / workflow 어느 subsystem 도 건드리지 않는다. CI 테스트 러너 스크립트와 그 테스트만 바뀐다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
