### PR TITLE
fix(probe): resolve providers with the runtime inference seed

### DIFF
--- a/lib/keeper/keeper_capability_probe.ml
+++ b/lib/keeper/keeper_capability_probe.ml
@@ -203,7 +203,10 @@ let probe_invocation ~sw ~net ?clock ~now ~runtime_id ~tool ~prompt () =
         | Runtime_execution.Claude_code _ ->
           Error (Not_agent_core_lane (Runtime_execution.label rt.Runtime.execution))
         | Runtime_execution.Agent_core _ ->
-    (match Runtime_agent_core_runner.resolve_runtime_providers ~runtime_id () with
+    (* [_for_turn], not the bare resolver: the bare one yields the provider
+       binding without the runtime's inference seed, and a probe that measures a
+       request no keeper turn would send measures itself (masc#28473). *)
+    (match Runtime_agent_core_runner.resolve_runtime_providers_for_turn ~runtime_id () with
      | Error detail -> Error (Unresolvable_runtime detail)
      | Ok [] ->
        Error (Unresolvable_runtime (Printf.sprintf "%s resolved no provider" runtime_id))

--- a/lib/runtime/runtime_agent_core_runner.ml
+++ b/lib/runtime/runtime_agent_core_runner.ml
@@ -109,3 +109,29 @@ let resolve_runtime_providers ~runtime_id () =
            "requested runtime %S not found among configured runtimes \
             (no silent fallback to default — RFC-0206 §2.1)"
            runtime_id)
+
+let apply_inference_seed
+      ~(seed : Runtime_inference.seed)
+      (config : Llm_provider.Provider_config.t)
+  : Llm_provider.Provider_config.t
+  =
+  (* A declared seed value wins; an absent one leaves the provider binding
+     alone, so this can only add what the runtime actually declares. Mirrors
+     [Keeper_turn_driver.attempt_inference_policy], whose fallback is the
+     caller's value — here the resolved binding plays that role. *)
+  let declared_or_kept current = function
+    | Some _ as declared -> declared
+    | None -> current
+  in
+  { config with
+    enable_thinking = declared_or_kept config.enable_thinking seed.thinking_enabled
+  ; preserve_thinking = declared_or_kept config.preserve_thinking seed.preserve_thinking
+  }
+;;
+
+let resolve_runtime_providers_for_turn ~runtime_id () =
+  Result.map
+    (List.map
+       (apply_inference_seed ~seed:(Runtime_inference.for_runtime ~name:runtime_id)))
+    (resolve_runtime_providers ~runtime_id ())
+;;

--- a/lib/runtime/runtime_agent_core_runner.ml
+++ b/lib/runtime/runtime_agent_core_runner.ml
@@ -115,23 +115,50 @@ let apply_inference_seed
       (config : Llm_provider.Provider_config.t)
   : Llm_provider.Provider_config.t
   =
-  (* A declared seed value wins; an absent one leaves the provider binding
-     alone, so this can only add what the runtime actually declares. Mirrors
-     [Keeper_turn_driver.attempt_inference_policy], whose fallback is the
-     caller's value — here the resolved binding plays that role. *)
-  let declared_or_kept current = function
-    | Some _ as declared -> declared
-    | None -> current
-  in
+  (* Mirrors [Keeper_turn_driver.attempt_inference_policy] field by field, and
+     the two are not the same shape:
+
+     - [enable_thinking]: a declared seed wins, an absent one falls back. The
+       turn path's fallback is its caller's value; here the resolved binding
+       plays that role.
+     - [preserve_thinking]: the seed is the sole authority. The turn path writes
+       [runtime_seed.preserve_thinking] straight into the agent config
+       (keeper_turn_driver.ml:1176) with no fallback, so an undeclared axis
+       reaches the wire as [None].
+
+     Keeping the binding's value on the second field is what a symmetric
+     implementation does, and it made the probe send a request the turn would
+     not: binding [Some true] plus an undeclared seed gave the probe
+     [Some true] and the turn [None]. That is this PR's own defect class in the
+     field this PR added, which is why the agreement is pinned by a test over
+     every declaration combination rather than by this comment. *)
   { config with
-    enable_thinking = declared_or_kept config.enable_thinking seed.thinking_enabled
-  ; preserve_thinking = declared_or_kept config.preserve_thinking seed.preserve_thinking
+    enable_thinking =
+      (match seed.thinking_enabled with
+       | Some _ as declared -> declared
+       | None -> config.enable_thinking)
+  ; preserve_thinking = seed.preserve_thinking
   }
 ;;
 
 let resolve_runtime_providers_for_turn ~runtime_id () =
+  (* The empty id documents "the default runtime", and the resolver honours that
+     by going through [Runtime.get_default_runtime]. The seed lookup is keyed by
+     id, so passing "" through would look up a runtime that does not exist and
+     return an absent seed — the default runtime would resolve its binding and
+     lose its own [thinking-support], which is the mismatch this function is for
+     (review on #28530). Resolve the id first so both halves name the same
+     runtime. *)
+  let seed_runtime_id =
+    if String.equal runtime_id ""
+    then (
+      match Runtime.get_default_runtime () with
+      | Some rt -> rt.Runtime.id
+      | None -> runtime_id)
+    else runtime_id
+  in
   Result.map
     (List.map
-       (apply_inference_seed ~seed:(Runtime_inference.for_runtime ~name:runtime_id)))
+       (apply_inference_seed ~seed:(Runtime_inference.for_runtime ~name:seed_runtime_id)))
     (resolve_runtime_providers ~runtime_id ())
 ;;

--- a/lib/runtime/runtime_agent_core_runner.mli
+++ b/lib/runtime/runtime_agent_core_runner.mli
@@ -44,4 +44,30 @@ val resolve_runtime_providers :
 (** Resolve the requested runtime's provider config via the RFC-0207 runtime
     catalog. An empty [runtime_id] resolves the default runtime; a non-empty
     id that is not a configured runtime returns [Error] — never the default
-    runtime (no Unknown→Permissive substitution, RFC-0206 §2.1; audit F8). *)
+    runtime (no Unknown→Permissive substitution, RFC-0206 §2.1; audit F8).
+
+    This is the provider {i binding} only. A turn additionally carries the
+    runtime's inference seed — use {!resolve_runtime_providers_for_turn} when
+    the caller is about to dispatch. *)
+
+val apply_inference_seed
+  :  seed:Runtime_inference.seed
+  -> Llm_provider.Provider_config.t
+  -> Llm_provider.Provider_config.t
+(** Overlay a runtime's thinking seed onto a resolved provider config. Declared
+    seed values win; absent ones leave the binding untouched. *)
+
+val resolve_runtime_providers_for_turn :
+  runtime_id:string -> unit ->
+  (Llm_provider.Provider_config.t list, string) result
+(** {!resolve_runtime_providers} with the runtime's inference seed applied, i.e.
+    the config a keeper turn would dispatch with.
+
+    Resolving without the seed is not merely a lost hint. An absent
+    [enable_thinking] makes {!Llm_provider.Backend_ollama} omit the wire [think]
+    field entirely, handing the decision to the model's chat template — whose
+    default is thinking-on for reasoning models. [ollama.agentworld-35b-a3b]
+    declares [thinking-support = false]; probed without the seed it spent ~900
+    output tokens reasoning and emitted its tool call as bare JSON, which Ollama
+    could not parse into [tool_calls], so it scored 0/12 as though it could not
+    call tools at all. It called them every time (masc#28473). *)

--- a/test/test_keeper_capability_probe.ml
+++ b/test/test_keeper_capability_probe.ml
@@ -8,6 +8,7 @@ open Alcotest
 
 module Probe = Masc.Keeper_capability_probe
 module Descriptor = Masc.Keeper_tool_descriptor
+module Runner = Runtime_agent_core_runner
 
 let verdict = testable (Fmt.of_to_string Probe.verdict_to_string) ( = )
 
@@ -238,6 +239,64 @@ let test_lane_guard_refuses_an_official_client_runtime () =
       | Error e -> failf "expected Not_agent_core_lane, got: %s" (Probe.invocation_error_to_string e))
 ;;
 
+(* The seed overlay is what makes the probe's request match a keeper turn's.
+   Without it agentworld-35b-a3b scored 0/12 while actually calling the tool
+   every time: an absent enable_thinking makes Backend_ollama omit the wire
+   [think] field, the model's chat template defaults to thinking-on, and the
+   call arrives as prose past the budget (masc#28473).
+
+   Built from a bare provider config so removing the overlay in the probe would
+   leave these red -- asserting against Runtime_inference output would make the
+   expectation a restatement of the function under test. *)
+let bare_config () =
+  Llm_provider.Provider_config.make
+    ~kind:Llm_provider.Provider_config.Ollama
+    ~model_id:"agentworld:UD-Q4_K_XL"
+    ~base_url:"http://127.0.0.1:11434"
+    ()
+;;
+
+let bool_opt = testable (Fmt.of_to_string (function
+  | None -> "None"
+  | Some b -> Printf.sprintf "Some %b" b))
+  ( = )
+
+let test_declared_thinking_off_reaches_the_config () =
+  let seed =
+    { Runtime_inference.thinking_budget = None
+    ; thinking_enabled = Some false
+    ; preserve_thinking = None
+    }
+  in
+  let out = Runner.apply_inference_seed ~seed (bare_config ()) in
+  (* Some false, not None: None is what omits the wire field. *)
+  check bool_opt "declared thinking-off reaches the request" (Some false) out.enable_thinking
+;;
+
+let test_declared_thinking_on_reaches_the_config () =
+  let seed =
+    { Runtime_inference.thinking_budget = None
+    ; thinking_enabled = Some true
+    ; preserve_thinking = Some true
+    }
+  in
+  let out = Runner.apply_inference_seed ~seed (bare_config ()) in
+  check bool_opt "declared thinking-on reaches the request" (Some true) out.enable_thinking;
+  check bool_opt "preserve_thinking rides along" (Some true) out.preserve_thinking
+;;
+
+let test_undeclared_seed_leaves_the_binding_alone () =
+  let seed =
+    { Runtime_inference.thinking_budget = None
+    ; thinking_enabled = None
+    ; preserve_thinking = None
+    }
+  in
+  let base = { (bare_config ()) with Llm_provider.Provider_config.enable_thinking = Some true } in
+  let out = Runner.apply_inference_seed ~seed base in
+  check bool_opt "an absent seed does not clear the binding" (Some true) out.enable_thinking
+;;
+
 let () =
   run
     "keeper_capability_probe"
@@ -257,6 +316,11 @@ let () =
       , [ test_case "operator-only costs no turn" `Quick test_operator_only_costs_no_turn
         ; test_case "unknown runtime is named" `Quick test_unknown_runtime_is_named
         ; test_case "lane guard refuses an official-client runtime" `Quick test_lane_guard_refuses_an_official_client_runtime
+        ] )
+    ; ( "inference seed overlay"
+      , [ test_case "declared thinking-off reaches the request" `Quick test_declared_thinking_off_reaches_the_config
+        ; test_case "declared thinking-on reaches the request" `Quick test_declared_thinking_on_reaches_the_config
+        ; test_case "absent seed leaves the binding alone" `Quick test_undeclared_seed_leaves_the_binding_alone
         ] )
     ]
 ;;

--- a/test/test_keeper_capability_probe.ml
+++ b/test/test_keeper_capability_probe.ml
@@ -9,6 +9,7 @@ open Alcotest
 module Probe = Masc.Keeper_capability_probe
 module Descriptor = Masc.Keeper_tool_descriptor
 module Runner = Runtime_agent_core_runner
+module Turn_driver = Masc.Keeper_turn_driver
 
 let verdict = testable (Fmt.of_to_string Probe.verdict_to_string) ( = )
 
@@ -256,10 +257,17 @@ let bare_config () =
     ()
 ;;
 
-let bool_opt = testable (Fmt.of_to_string (function
+let show_bool_opt = function
   | None -> "None"
-  | Some b -> Printf.sprintf "Some %b" b))
-  ( = )
+  | Some b -> Printf.sprintf "Some %b" b
+;;
+
+let bool_opt = testable (Fmt.of_to_string show_bool_opt) ( = )
+
+(* Any id that resolves no declared seed: the agreement under test is between
+   the two functions, and a runtime whose seed came from config would make the
+   loop assert the same triple three times. *)
+let bool_opts = [ Some true; Some false; None ]
 
 let test_declared_thinking_off_reaches_the_config () =
   let seed =
@@ -297,6 +305,54 @@ let test_undeclared_seed_leaves_the_binding_alone () =
   check bool_opt "an absent seed does not clear the binding" (Some true) out.enable_thinking
 ;;
 
+(* The pin the review asked for (#28530): seed application now exists twice —
+   [Runner.apply_inference_seed] on the probe path and
+   [Keeper_turn_driver.For_testing.attempt_inference_policy] on the turn path.
+   Two implementations of "what does this runtime actually send" is the shape of
+   the defect this PR fixes, so their agreement is asserted rather than assumed.
+
+   Both are driven from the same runtime id, because the turn path resolves the
+   seed itself — handing the probe a synthetic seed the turn path never sees
+   would compare two different questions. The binding is what varies, over every
+   declaration combination, which is also where the disagreement lives: an
+   undeclared seed axis leaves the turn path writing [None] and the probe path
+   keeping the binding's value. *)
+let seed_free_runtime_id = "masc-test-no-such-runtime"
+
+let test_probe_and_turn_agree_on_the_seed () =
+  let seed = Runtime_inference.for_runtime ~name:seed_free_runtime_id in
+  List.iter
+    (fun binding_enable ->
+      List.iter
+        (fun binding_preserve ->
+          let binding =
+            { (bare_config ()) with
+              Llm_provider.Provider_config.enable_thinking = binding_enable
+            ; preserve_thinking = binding_preserve
+            }
+          in
+          let probe = Runner.apply_inference_seed ~seed binding in
+          let turn =
+            Turn_driver.For_testing.attempt_inference_policy
+              ~runtime_id:seed_free_runtime_id
+              ~fallback_enable_thinking:binding_enable
+              ()
+          in
+          let label field =
+            Printf.sprintf
+              "%s: binding(enable=%s preserve=%s)"
+              field
+              (show_bool_opt binding_enable)
+              (show_bool_opt binding_preserve)
+          in
+          check bool_opt (label "enable_thinking")
+            turn.attempt_enable_thinking probe.enable_thinking;
+          check bool_opt (label "preserve_thinking")
+            turn.attempt_preserve_thinking probe.preserve_thinking)
+        bool_opts)
+    bool_opts
+;;
+
 let () =
   run
     "keeper_capability_probe"
@@ -321,6 +377,8 @@ let () =
       , [ test_case "declared thinking-off reaches the request" `Quick test_declared_thinking_off_reaches_the_config
         ; test_case "declared thinking-on reaches the request" `Quick test_declared_thinking_on_reaches_the_config
         ; test_case "absent seed leaves the binding alone" `Quick test_undeclared_seed_leaves_the_binding_alone
+        ; test_case "probe and turn agree on every declaration combination" `Quick
+            test_probe_and_turn_agree_on_the_seed
         ] )
     ]
 ;;


### PR DESCRIPTION
## 무엇

`resolve_runtime_providers` 는 provider **바인딩**만 준다. 키퍼 턴은 거기에 런타임의 inference seed 를 추가로 얹는다(`Keeper_turn_driver.attempt_inference_policy`). 능력 프로브는 그 단계를 건너뛰어서, 자기가 측정한다고 주장하는 경로와 **다른 요청**을 보내고 있었다.

`Runtime_agent_core_runner.resolve_runtime_providers_for_turn` 을 추가하고 프로브가 그걸 쓰게 했다.

## 왜 — 측정값이 뒤집혔다

`ollama.agentworld-35b-a3b` 가 도구 프로브에서 **0/12** 였다. 실제로는 **12번 다 도구를 불렀다.**

```
think 필드 생략 (= 프로브가 보내던 요청)   eval_count=977
  tool_calls : 0
  thinking   : 3613 B
  content    : 46 B  '{"name": "keeper_tools_list", "arguments": {}}'

think:false (= 키퍼 턴이 보내는 요청)      eval_count~15
  tool_calls : 1 -> keeper_tools_list
  content    : 0 B
```

사슬:

1. 프로브가 seed 를 안 얹어 `config.enable_thinking = None`
2. `Backend_ollama` 는 `None` 에서 와이어 `think` 필드를 **생략**한다 (`| None -> body`)
3. 이 모델의 chat template 은 `enable_thinking is false` 일 때만 빈 `<think></think>` 를 선주입한다. 필드가 없으면 `<think>` 를 열고 추론을 시작한다
4. 3,613 B 추론으로 출력 예산 소진 → 템플릿이 지시한 `<tool_call><function=…>` XML 이 아니라 맨 JSON 으로 호출
5. Ollama 가 맨 JSON 을 `tool_calls` 로 못 바꿈 → content 로 강등 → `Replied_no_tool { reply_bytes = 46 }`

같은 프롬프트(315 토큰), **같은 샘플러 파라미터**(`top_k=40, top_p=0.900, min_p=0.000, temp=0.800`)인데 생성 토큰이 15 vs 949/977 로 갈린 게 "요청이 다르다" 의 증거였다.

`runtime.toml` 주석이 이 축을 이미 적어두고 있었다:

> `thinking-support=false(think:false)` **배선에서만 준수 확인됨** — raw generate는 추론이 출력 예산을 소진한다.

프로브는 정확히 그 "배선" 을 건너뛴 경로다.

## 두 번째 호출자

`resolve_runtime_providers` 호출자는 둘이고, **둘 다** seed 를 안 얹는다:

- `lib/keeper/keeper_capability_probe.ml` — 이 PR 에서 수정
- `lib/fusion/fusion_agent_core.ml:173` — **수정하지 않음**

fusion 은 프로덕션 경로라 seed 를 얹으면 실제 패널이 보내는 요청이 바뀐다. 측정 없이 바꾸지 않았고 별도 이슈로 남긴다. 추상화는 `_for_turn` 으로 만들어뒀으니 채택은 한 줄이다.

## 테스트

`test/test_keeper_capability_probe.ml` 에 3 케이스 (기존 배선 사용, 신규 CI 타깃 없음):

- 선언된 thinking-off 가 요청에 도달 (`Some false`, `None` 아님 — `None` 이 필드를 생략시킨다)
- 선언된 thinking-on + `preserve_thinking` 동반 도달
- seed 가 비면 기존 바인딩을 덮지 않음

변이 검증:

| 변이 | 결과 |
|---|---|
| `apply_inference_seed` 를 no-op 으로 | **2 FAIL** |
| 프로브를 bare resolver 로 되돌림 | **0 FAIL — 호출부 미커버** |

**호출부는 테스트로 막히지 않는다.** 단위 테스트는 헬퍼의 의미만 고정한다. 호출부를 막으려면 turn-ready config 를 별도 타입으로 두거나(컴파일 에러화) 요청을 관측하는 통합 테스트가 필요하고, 둘 다 이 PR 범위 밖이라 명시해 둔다.

## 검증

- `dune build --root . @test/runtest-test_keeper_capability_probe` → 14/14
- `dune build --root .` 전체 통과
- `dune build --root . @fmt` 는 **base(origin/main)에서도 실패** — `lib/keeper_tooling/dune` 등 무관 파일. 이 PR 의 3 파일은 fmt clean
- `packages/agent_core/lib/llm_provider` 의 `exact_output_plan.ml` 테스트 1건은 **base 에서도 실패** (대조군 실행으로 확인)

## 검토했지만 하지 않은 것

`Backend_ollama` 가 `None` 에서 `think` 를 생략하는 것 자체를 "resolved 값을 보내도록" 바꾸려다 되돌렸다. `Option.value ~default:false` 와 와이어 인코딩이 `None` 을 다르게 읽는 게 자기모순처럼 보였지만, 비-template 모델에서는 `thinking_requested` 가 시스템 프롬프트에 **영향이 없어서** 모순이 아니다. `None` 은 두 질문("토큰 주입?" / "서버에 지시?")에 각각 "선언된 게 없다" 로 일관되게 답한다. 남는 건 정책 질문이고, ollama 런타임 3개가 전부 `thinking-support` 를 선언하고 있어 프로덕션 노출이 0 이다. 테스트로 핀된 계약(`build_request omits think when caller omits it`)을 그 근거로 뒤집지 않았다.

Closes #28473

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
