### PR TITLE
fix(dashboard): give a chat placeholder its operation id at creation

### DIFF
--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -406,6 +406,42 @@ describe('sendKeeperThreadMessage operation stream', () => {
     expect(operationIds.every(id => id.startsWith('kmsg-'))).toBe(true)
   })
 
+  it('keeps one row per turn when the stream dies before the operation is accepted', async () => {
+    // No KEEPER_CHAT_OPERATION_ACCEPTED: this is the disconnected-socket case,
+    // where the accept handler never runs and the placeholders are left with
+    // whatever identity they were created with. The backend still accepted the
+    // message, so history comes back carrying the operation's request id.
+    let submittedRequestId = ''
+    streamKeeperMessage.mockImplementation(
+      async (_name: string, _message: string, opts: { requestId: string }) => {
+        submittedRequestId = opts.requestId
+        return { terminal: true }
+      },
+    )
+
+    await sendKeeperThreadMessage('echo', 'hi')
+
+    fetchKeeperChatHistory.mockResolvedValue([
+      {
+        role: 'user',
+        content: 'hi',
+        ts: 1_780_000_000,
+        delivery_key: { kind: 'operation', request_id: submittedRequestId },
+      },
+      {
+        role: 'assistant',
+        content: 'hello there',
+        ts: 1_780_000_001,
+        delivery_key: { kind: 'operation', request_id: submittedRequestId },
+      },
+    ])
+    await hydrateKeeperChatHistory('echo')
+
+    const thread = keeperThreads.value.echo ?? []
+    expect(thread.filter(entry => entry.role === 'user')).toHaveLength(1)
+    expect(thread.filter(entry => entry.role === 'assistant')).toHaveLength(1)
+  })
+
   it('does not abort the running operation when a second operation is accepted', async () => {
     const streams: Array<{
       requestId: string

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -920,6 +920,14 @@ export async function sendKeeperThreadMessage(
   appendThreadEntry(keeperName, {
     id: localId,
     role: 'user',
+    // The operation id is the same value the backend stamps as the row's
+    // delivery_key request_id, so carrying it from the start lets the history
+    // merge recognise its own placeholder. Waiting for
+    // KEEPER_CHAT_OPERATION_ACCEPTED to stamp it leaves the row identity-less
+    // whenever the stream dies first, and sameConversationEntry reads
+    // "one side has a request id" as "different rows" — which renders the sent
+    // message twice, once local and once from history.
+    requestId: operationId,
     source: 'direct_user',
     label: 'You',
     text: message,
@@ -937,6 +945,7 @@ export async function sendKeeperThreadMessage(
   appendThreadEntry(keeperName, {
     id: assistantId,
     role: 'assistant',
+    requestId: operationId,
     source: 'direct_assistant',
     label: keeperName,
     text: '',


### PR DESCRIPTION
스트림이 끊긴 채로 메시지를 보내면 **보낸 메시지와 그 응답이 각각 두 번 렌더**됩니다.

## 증상

한 번 보낸 메시지가 2초 간격으로 두 줄 찍히고, 위쪽 줄에는 출처 배지(`Dashboard` / `owner`)가 없고 아래쪽 줄에는 있습니다. 응답도 같이 두 번 나옵니다. 발생 시 헤더는 `Client WS · disconnected` / `Reconnecting` 상태였습니다. 런타임과 무관합니다 (관측은 `kimi_coding.kimi-k3`).

## 원인

송신 시 로컬 플레이스홀더 두 개가 붙습니다 — 사용자 행(`keeper-actions.ts:920`)과 어시스턴트 행(`:937`). 둘 다 `requestId` 없이 생성됩니다.

`requestId` 는 단 한 곳에서 찍힙니다 (`:979`) — 스트림이 `KEEPER_CHAT_OPERATION_ACCEPTED` 를 배달했을 때만. 소켓이 끊겨 그 이벤트가 안 오면 두 행 모두 식별자 없이 남습니다.

히스토리 병합의 동일성 판정은 이렇습니다 (`keeper-state.ts:1390-1393`):

```ts
if (leftRequestId && rightRequestId) return leftRequestId === rightRequestId
if (leftRequestId || rightRequestId) return false   // 한쪽만 있으면 다른 행
```

서버는 메시지를 정상 접수했으므로 히스토리 행에는 `delivery_key.request_id` 가 실려 옵니다 (`deliveryIdentityFromKey`, `:901-909`). 결과적으로 로컬 행은 requestId 없음 / 히스토리 행은 있음 → `false` → `coveredByHistory` 가 false → 로컬 행이 살아남아 히스토리 행과 나란히 렌더됩니다.

플레이스홀더 두 개가 같은 `stampPlaceholderRequestId([localId, assistantId], ...)` 한 호출로 함께 찍히므로, 그 호출이 없으면 **둘 다** 중복됩니다. 원인 하나에 피해자 둘입니다.

`keeper-state.ts:1492` 의 기존 방어(`entry.role === 'assistant' && coveredByHistory`, 2026-07-28 사고 수정)는 이 경로를 못 막습니다. `coveredByHistory` 자체가 false 이기 때문입니다.

## 수정

`operationId` 를 플레이스홀더 생성 시점에 넣습니다. 이 값은 `:919` 에서 이미 만들어져 `:969` 에서 요청에 실려 가고, `:975` 에서 서버 `operation_id` 와 같은지 검증됩니다. 즉 **히스토리 행의 `delivery_key.request_id` 와 동일한 값**이므로 ACCEPTED 이벤트를 기다릴 이유가 없습니다.

이러면 스트림이 죽어도 양쪽에 같은 requestId 가 있어 `:1392` 로 매칭되고, `:1393` 의 "한쪽만 있으면 다르다" 분기를 아예 타지 않습니다.

`stampPlaceholderRequestId` 는 그대로 둡니다 — 같은 값이면 no-op 이고 (`entry.requestId === requestId ? entry : ...`), 다른 값이면 `:975` 가 먼저 throw 합니다.

## 검증

- 신규 `keeps one row per turn when the stream dies before the operation is accepted` — ACCEPTED 를 배달하지 않는 스트림으로 송신한 뒤, 같은 operation id 를 실은 히스토리를 머지하고 사용자/어시스턴트 행이 각각 1개인지 확인.
- **뮤테이션 검증**: 두 `requestId: operationId` 를 제거하면 이 테스트가 실패합니다 — 사용자 행 `Expected 1 / Received 2`. 보고된 증상이 그대로 재현됩니다.
- `keeper-actions.test.ts` + `keeper-state.test.ts` + `keeper-stream.test.ts` **132/132 통과**.

## 범위 밖

`sameConversationEntry` 의 "한쪽만 requestId 를 가지면 다른 행" 규칙 자체는 그대로 둡니다. 서로 다른 턴을 잘못 합치지 않으려는 보수적 선택이고, 이 PR 은 플레이스홀더가 애초에 식별자를 갖게 해서 그 분기에 도달하지 않게 합니다.
