### PR TITLE
refactor(keeper): stop teaching a layout the system does not create

### DIFF
--- a/lib/exec_policy/exec_policy.ml
+++ b/lib/exec_policy/exec_policy.ml
@@ -25,13 +25,13 @@ let block_reason_to_string = function
   | Chain_or_redirect ->
     "Blocked: chaining (&&/||/;) and redirects (|/>) are not allowed. Run ONE command \
      per call. To change directory, use the `cwd` argument instead of `cd` - Good: \
-     cwd='repos/project', cmd='ls'. Bad: cmd='cd repos/project && ls'. For pipelines \
+     cwd='<dir>', cmd='ls'. Bad: cmd='cd <dir> && ls'. For pipelines \
      like `rg foo | wc -l`, run the primary command and process \
      output at the LLM layer. To write files, use Write."
   | Injection ->
     "Shell injection syntax (;, &&, standalone &, `, $) not allowed. Run ONE command per \
-     call. To change directory, use the `cwd` argument - Good: cwd='repos/masc', \
-     cmd='ls'. Bad: cmd='cd repos/masc && ls' or cmd='cmd1 ; cmd2'. \
+     call. To change directory, use the `cwd` argument - Good: cwd='<dir>', \
+     cmd='ls'. Bad: cmd='cd <dir> && ls' or cmd='cmd1 ; cmd2'. \
      Relative paths resolve from `cwd` (defaults to playground root). For file writes, \
      use Edit or Write."
   | Process_substitution -> "Process substitution (<(...) or >(...)) is not allowed."

--- a/lib/exec_policy/exec_policy.mli
+++ b/lib/exec_policy/exec_policy.mli
@@ -34,9 +34,9 @@ val existing_sibling_dirs_hint : ?workdir:string -> string -> string option
 (** For a required directory [path] that is missing on disk, enumerate the
     real child-directory names under its nearest existing ancestor (read via
     [Sys.readdir]) and render them as a [Cwd_not_directory] hint. Grounds
-    caller self-correction in filesystem truth (e.g. a stale
-    ["repos/masc-mcp"] yields the real ["repos/"] entries) without a rename
-    table or any substring/similarity matching. [None] when no existing
+    caller self-correction in filesystem truth (a stale directory name yields
+    the real sibling entries) without a rename table or any
+    substring/similarity matching. [None] when no existing
     ancestor directory has child directories to surface. *)
 
 val validate_shell_ir_paths :

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -71,11 +71,21 @@ let relative_path_has_segment_prefix prefix raw =
   String.equal raw prefix || String.starts_with ~prefix:(prefix ^ "/") raw
 ;;
 
+(* "scratch" is gone: no code ever created that directory, and the tool schema
+   that taught it ('repos/X' or 'scratch/X') is removed in this change. It only
+   ever mattered for a path a model invented from that sentence.
+
+   "repos" stays for now. Removing it changes how {file_path; cwd} pairs anchor
+   — the enclosing function decides whether a relative path is already
+   workspace-rooted or is relative to cwd, and it can only decide that from a
+   fixed vocabulary. That is the same layout assumption this work removes
+   elsewhere, so it needs the resolver the tools themselves use rather than a
+   shorter list. Separate change. *)
 let sandbox_rooted_relative_path raw =
   Filename.is_relative raw
   && List.exists
        (fun prefix -> relative_path_has_segment_prefix prefix raw)
-       [ "repos"; "scratch"; Common.masc_dirname; "playground" ]
+       [ "repos"; Common.masc_dirname; "playground" ]
 ;;
 
 let non_empty_string_member name input =

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -276,14 +276,13 @@ let path_resolution_contract_json =
     ; ( "discover_before_read"
       , `String
           "When unsure, inspect visible paths with the currently exposed read/listing \
-           tools before Read. For repo files, use cwd=\"repos/<repo>\" plus \
-           file_path=\"lib/...\", or use file_path=\"repos/<repo>/lib/...\"."
+           tools before Read. For files inside a checkout, set cwd to that checkout \
+           and pass file_path relative to it."
       )
     ; ( "execute_path_basis"
       , `String
-          "Execute path arguments resolve against cwd. If cwd=\"repos/<repo>\" is set, \
-           pass repo-relative paths such as lib/...; do not repeat the repo prefix \
-           as repos/<repo>/lib/..." )
+          "Execute path arguments resolve against cwd. When cwd is set, pass paths \
+           relative to it; do not repeat the cwd prefix in the path." )
     ; ( "masc_state_basis"
       , `String
           ".masc runtime state is not a sandbox filesystem target. Use keeper \

--- a/lib/keeper/keeper_sandbox_exec_failure.ml
+++ b/lib/keeper/keeper_sandbox_exec_failure.ml
@@ -50,7 +50,7 @@ let docker_failure_message_internal
       && String_util.contains_substring output "No such file or directory"
     then
       " hint=cwd_not_directory: create or repair the sandbox repo checkout first, \
-       then retry with cwd=repos/<repo>."
+       then retry with that directory as cwd."
     else ""
   in
   let mount_failure_context =

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -313,15 +313,14 @@ let read_file_schema =
         "file_path"
         "string"
         "Existing file path to read. Relative paths resolve against cwd when cwd is \
-         provided, otherwise against the keeper sandbox. Read does not inherit Execute \
-         cwd implicitly; pass cwd explicitly or use a sandbox-relative repos/<repo>/... \
-         path."
+         provided, otherwise against your workspace root. Read does not inherit Execute \
+         cwd implicitly; pass cwd explicitly or give a path relative to the workspace \
+         root."
     ; property
         "cwd"
         "string"
-        "Optional sandbox-relative directory to resolve file_path from, e.g. \
-         repos/masc. This is explicit only; Read never inherits the previous \
-         Execute cwd."
+        "Optional directory, relative to your workspace root, to resolve file_path \
+         from. This is explicit only; Read never inherits the previous Execute cwd."
     ; property
         "offset"
         "integer"

--- a/lib/keeper/keeper_workspace_read_ops.ml
+++ b/lib/keeper/keeper_workspace_read_ops.ml
@@ -105,15 +105,15 @@ let try_handle_with_outcome
   let run_readonly_in_sandbox ?(ok_exit_codes = [ 0 ]) ~target ~command_argv
       ~max_bytes ~timeout_sec () =
     (* Pre-flight parity with [Keeper_sandbox_read_backend.read_file]: verify
-       the host target exists before spawning a container, so a wrong
-       repos/<segment> guess fails with a precise host-path error instead of
-       burning a docker run that ends in "No such file or directory". *)
+       the host target exists before spawning a container, so a wrong path
+       guess fails with a precise host-path error instead of burning a docker
+       run that ends in "No such file or directory". *)
     if not (Sys.file_exists target) then
       Error
         (sandbox_read_error ~target
            (Printf.sprintf
-              "path_not_found: %s (host path does not exist; list repos/ to \
-               see your actual checkouts before searching)"
+              "path_not_found: %s (host path does not exist; list your \
+               workspace root to see what is actually there before searching)"
               target))
     else
       match

--- a/lib/tool_surface/tool_shard_types_schemas_base.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_base.ml
@@ -22,8 +22,7 @@ let base_tools : Masc_domain.tool_schema list =
     ; description =
         "Check your own persisted checkpoint and session state. Returns: name (your \
          keeper name), checkpoint_bytes, message_count, generation, memory fact counts, \
-         sandbox health, and canonical sandbox paths (sandbox_root, sandbox_repos) plus \
-         backend/profile metadata. Context-window occupancy is not \
+         sandbox health, and your workspace root plus backend/profile metadata. Context-window occupancy is not \
          currently observed and is not returned. sandbox paths are tool-ready and can be \
          passed directly as path or cwd to keeper tools without prefix. Use when checking \
          checkpoint/session continuity or resolving a path without string-interpolating \

--- a/lib/tool_surface/tool_shard_types_schemas_filesystem.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_filesystem.ml
@@ -6,10 +6,9 @@ let filesystem_tools : Masc_domain.tool_schema list =
   [ { name = "tool_read_file"
     ; description =
         "Read a file as text (truncated at max_bytes). path is REQUIRED. Paths resolve \
-         relative to your playground — use 'repos/X/lib/foo.ml' not \
-         '.masc/playground/your-name/repos/X/lib/foo.ml'. Good: path='lib/foo.ml', \
-         path='repos/masc/lib/workspace.ml'. Bad: path=''. For multi-file search, use \
-         Grep."
+         relative to your workspace root, or to the typed `cwd` when you pass one — \
+         never a host path like '.masc/playground/your-name/...'. Good: \
+         path='lib/foo.ml'. Bad: path=''. For multi-file search, use Grep."
     ; input_schema =
         `Assoc
           [ "type", `String "object"

--- a/lib/tool_surface/tool_shard_types_schemas_search_files.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_search_files.ml
@@ -8,9 +8,9 @@ let tool_search_files_schema : Masc_domain.tool_schema =
   { name = "tool_search_files"
   ; description =
         "Search file contents with ripgrep. Provide a regex `pattern` (and \
-         optionally path/glob/type). Paths resolve automatically — use \
-         'repos/X' or 'scratch/X'; never include host paths like \
-         '.masc/playground/your-name/repos/X'. To list a directory, read a \
+         optionally path/glob/type). Paths resolve against your workspace \
+         root — pass a path relative to it, never a host path like \
+         '.masc/playground/your-name/...'. To list a directory, read a \
          file, run find, or view git status/log/diff, use the Execute tool."
   ; input_schema =
         `Assoc


### PR DESCRIPTION
## 요약

모델에게 `repos/<repo>` 레이아웃을 가르치는 산문을 걷어낸다. 시스템이 **만들지 않는** 구조다.

의존: #28467 (체크아웃 발견 실측화) 위에 쌓았다.

## 왜

per-keeper clone 은 #24558 에서 삭제됐고, 그 브랜치가 `ensure_sandbox_bundle` 의 빈 `repos/` 생성까지 멈췄다. 그런데 툴 스키마·런타임 계약·실패 힌트는 계속 그 경로를 지시한다.

**유지되지 않는 레이아웃을 설명하는 산문은 아무도 모르게 낡는다.** 이미 두 번 그랬다:

- 불변식 *"every catalog id resolves under `repos/<name>/`"* 가 거짓이어서 제거됨 (RFC-0324 B-1). 그 전까지 `path_not_found` **379건/24h**.
- 남은 `'repos/X' or 'scratch/X'` 문장이 가르치는 `scratch/` 는 **어떤 코드도 만든 적이 없다.**

## 무엇을

각 지점이 이제 **어디를 기준으로 경로가 풀리는지**(workspace root, 또는 typed `cwd`)만 말하고, 그 아래에 무엇이 있는지는 말하지 않는다.

| 파일 | 변경 |
|---|---|
| `tool_shard_types_schemas_search_files.ml` | `'repos/X' or 'scratch/X'` → workspace root 기준 |
| `tool_shard_types_schemas_filesystem.ml` | `path='repos/masc/...'` 예시 제거 |
| `tool_shard_types_schemas_base.ml` | `sandbox_root, sandbox_repos` → "your workspace root" |
| `keeper_tool_descriptor.ml` ×2 | `repos/<repo>/...`, `e.g. repos/masc` |
| `exec_policy.ml` ×3 | 예시 경로만 `<dir>` 로 |
| `exec_policy.mli` | 문서 예시 중립화 |
| `keeper_runtime_contract.ml` ×2 | `cwd="repos/<repo>"` → "checkout 을 cwd 로" |
| `keeper_sandbox_exec_failure.ml` | `retry with cwd=repos/<repo>` |
| `keeper_workspace_read_ops.ml` | `list repos/` → workspace root 나열 |

keeper 는 이미 관측 채널을 갖고 있다 — `execution_location` 이 Execute 응답마다 실측 `cwd` 를 돌려주고, list/read 툴이 직접 답한다. **관측은 낡지 않고 산문은 낡는다.**

## 규약은 유지한다

`exec_policy` 의 "한 호출에 명령 하나, `cd` 대신 `cwd`" 는 **셸 표면의 규칙**이지 레이아웃이 아니다. 문장은 그대로 두고 예시 경로만 바꿨다. "host path 를 넣지 마라" 도 같다.

## `scratch` 와 `repos` 를 다르게 다룬 이유

**`scratch` 제거** — 그것을 가르치던 문장과 허용목록(`keeper_run_tools_hooks.ml`) 항목을 **같은 변경에서** 뺐다. 둘은 짝으로만 동작했다: 산문만 지우면 이미 `scratch/` 를 쓰는 keeper 의 귀속만 남고, 허용목록만 지우면 산문이 가르친 경로가 오귀속된다.

**`repos` 유지** — 빼면 `{file_path; cwd}` 쌍의 앵커링이 바뀐다. `sandbox_rooted_relative_path` 는 "이 상대 경로가 이미 workspace-rooted 인가, cwd 상대인가" 를 고정 어휘로 판정하는데, 목록을 줄이는 것은 **같은 레이아웃 가정을 더 약하게 유지**하는 것일 뿐이다. 툴이 실제로 쓰는 리졸버를 hook 이 재사용하도록 바꿔야 하며, 그 이유를 호출 지점에 주석으로 남겼다.

## 검증

```
@test/runtest-test_keeper_tool_schema_bytes               2 tests   Successful
@test/runtest-test_keeper_system_prompt_bytes             6 tests   Successful
@test/runtest-test_keeper_tool_descriptor_registry_integrity  2 tests   Successful
@test/runtest-test_exec_policy_cwd_hint                  44 tests   Successful
dune build @check                                        CHECK=0
```

ratchet: `check-ssot.sh`=0, `audit-dead-surface.py --ratchet`=0, `audit-ci-test-targets.sh`=0, `audit-odoc-refs.py`=0, `validate-prompt-paths.sh`=0.

> `validate-prompt-paths.sh` 가 통과하는 것은 신호가 아니다 — 그 게이트는 `config/prompts` 와 `config/keepers` 만 보는데 거기에는 애초에 `repos` 가 0건이다. 모델이 실제로 읽는 산문은 OCaml 소스에 있고 그 게이트는 그것을 본 적이 없다. 교체는 별도 PR 로 다룬다.

## 남는 것

`sandbox_repos` / `sandbox_paths.repos` wire 필드는 아직 나간다. 산문에서 그 이름을 지웠으므로 모델은 더 이상 그것을 찾지 않는다 — 필드 제거는 `repos_arg` 레코드 필드와 함께 후속에서 한다. 순서는 이쪽이 안전하다: 필드를 먼저 지우면 스키마가 존재하지 않는 키를 약속하게 된다.

RFC: `docs/rfc/RFC-keeper-workspace-root-only.md` §3.3

RFC-WAIVED: 대체 RFC 가 머지되어 있고(#28459), 이 변경은 그 §3.3 이 명시한 단계다. 산문만 바꾸며 동작 변경은 `scratch` 허용목록 항목 하나다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3Ek71sn9DrrT4japMSNQs
