### PR TITLE
perf(dashboard): let measured polling routes revalidate instead of refetching

### DIFF
--- a/dashboard/src/api/core.test.ts
+++ b/dashboard/src/api/core.test.ts
@@ -14,6 +14,7 @@ import {
   getStoredToken,
   getStoredTokenMeta,
   post,
+  readCacheMode,
   runOperatorAction,
   setStoredToken,
   subscribeStoredTokenChanges,
@@ -168,6 +169,45 @@ describe('post', () => {
 
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(init.cache).toBe('no-store')
+  })
+
+  it('lets a measured polling route revalidate against the server', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{"entries":[]}', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await get('/api/v1/dashboard/board')
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(init.cache).toBe('no-cache')
+  })
+
+  // Several callers build their path as `${route}?${qs}`. Matching the path as
+  // given would leave every one of them on `no-store` while the unparameterised
+  // caller revalidated -- a difference no route-level reasoning would predict.
+  it('keeps a route revalidating when the caller appends a query string', () => {
+    expect(readCacheMode('/api/v1/dashboard/telemetry?window=1h')).toBe('no-cache')
+  })
+
+  // The mirror failure: a prefix match would sweep in this sibling, which was
+  // never measured for byte-identical repeats.
+  it('does not extend a listed route to its sub-routes', () => {
+    expect(readCacheMode('/api/v1/dashboard/telemetry/summary')).toBe('no-store')
+  })
+
+  // This route repeats byte-identically, so it looks eligible on traffic
+  // grounds alone. It is excluded because its body names environment variables
+  // and host paths, and listing it is what would persist them to disk.
+  it('keeps the secret-bearing composite route out of the browser cache', () => {
+    expect(readCacheMode('/api/v1/keepers/composite')).toBe('no-store')
+  })
+
+  it('leaves an unrecognised route on the conservative default', () => {
+    expect(readCacheMode('/api/v1/some/route/added/later')).toBe('no-store')
   })
 
   it('keeps board voter resolution scoped to query params', () => {

--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -409,6 +409,62 @@ const DASHBOARD_BOOTSTRAP_WARM_PATHS = new Set([
   '/api/v1/dashboard/briefing',
 ])
 
+/**
+ * Routes whose polled body the browser may hold and revalidate.
+ *
+ * Reads default to `no-store`, so a body reaches the browser's HTTP cache only
+ * when its route is listed here. Two conditions gate membership, both measured
+ * against a running server rather than assumed:
+ *
+ *   1. The body repeats byte-identically across polls. A route whose body
+ *      changes every poll can never answer 304, so listing it would buy a
+ *      digest computation and nothing else. `/dashboard/bootstrap` and
+ *      `/activity/events` fail this and are absent.
+ *   2. The body carries no secret projection. `/keepers/composite` embeds
+ *      `secret_projection` -- environment variable names and host paths, no
+ *      values -- and listing a route is precisely what would put those on
+ *      disk, so it stays `no-store` despite repeating byte-identically.
+ *
+ * Measured 2026-08-13 against a live server: these routes carry 1,741,479 of
+ * the 2,132,911 bytes one refresh cycle transfers (81.6%). Condition 2 costs
+ * 49,743 of those bytes (2.3%); condition 1 excludes a further 341,689 (16.0%)
+ * that no caching strategy could recover.
+ *
+ * Listing a route cannot serve a stale body: `no-cache` stores the response but
+ * revalidates before every use, so the server's ETag decides what the client
+ * sees, not a client-side freshness window.
+ */
+const BROWSER_REVALIDATED_PATHS = new Set([
+  '/api/v1/dashboard/scheduled-automation',
+  '/api/v1/dashboard/telemetry',
+  '/api/v1/dashboard/tool-quality',
+  '/api/v1/dashboard/board',
+  '/api/v1/board',
+  '/api/v1/dashboard/harness-health',
+  '/api/v1/agent-activity',
+  '/api/v1/dashboard/goals',
+  '/api/v1/dashboard/gate',
+])
+
+/**
+ * Eligibility belongs to the route, not to one request's parameters:
+ * `/dashboard/telemetry?window=1h` is the same route as `/dashboard/telemetry`,
+ * and several callers build paths that way. Matching the path as given would
+ * silently miss every parameterised caller.
+ *
+ * Matching by prefix would fail in the other direction -- it would capture
+ * `/dashboard/telemetry/summary`, a distinct route that was never measured. So
+ * the query is split off and what remains is matched exactly.
+ *
+ * A route absent from the set gets `no-store`, which is what an unrecognised
+ * path should get: the conservative answer, not the convenient one.
+ */
+export function readCacheMode(path: string): RequestCache {
+  const queryStart = path.indexOf('?')
+  const route = queryStart === -1 ? path : path.slice(0, queryStart)
+  return BROWSER_REVALIDATED_PATHS.has(route) ? 'no-cache' : 'no-store'
+}
+
 import { isRecord } from '../lib/type-guards'
 
 interface ErrorResponseInfo {
@@ -653,6 +709,7 @@ export async function get<T>(path: string, opts: GetOptions = {}): Promise<T> {
     path,
     {
       headers: authHeaders({ includeActor: opts.includeActorHeader }),
+      cache: readCacheMode(path),
       signal: opts.signal,
     },
     opts.timeoutMs ?? DEFAULT_GET_TIMEOUT_MS,
@@ -688,6 +745,7 @@ export async function getWithResponse<T>(
     path,
     {
       headers: authHeaders({ includeActor: opts.includeActorHeader }),
+      cache: readCacheMode(path),
       signal: opts.signal,
     },
     opts.timeoutMs ?? DEFAULT_GET_TIMEOUT_MS,

--- a/test/test_http_server_eio.ml
+++ b/test/test_http_server_eio.ml
@@ -609,6 +609,135 @@ let test_json_conditional_tag_is_weak_and_body_derived () =
     etag
     (tag_of conditional_body)
 
+(* [json_conditional] is a pure function, which is what lets the cases above
+   cover every combination of method, status, and If-None-Match. It also means
+   none of them touches a response, so the step that turns a [Tagged] decision
+   into bytes stayed unverified: whether the validator headers reach the client
+   at all, and whether a matching tag produces a bodiless 304.
+
+   A client cannot revalidate on a decision it never sees, so that step is
+   exercised here against a real [Server_connection] rather than inferred from
+   the branch that builds it. *)
+
+let serve_json_over_wire ?if_none_match body =
+  Eio_main.run (fun _env ->
+    let response_buf = Buffer.create 1024 in
+    let conn =
+      Httpun.Server_connection.create (fun reqd ->
+        Response.json ~request:(Httpun.Reqd.request reqd) body reqd)
+    in
+    let headers =
+      let base = [ ("host", "127.0.0.1") ] in
+      match if_none_match with
+      | None -> base
+      | Some tag -> ("if-none-match", tag) :: base
+    in
+    let request =
+      Httpun.Request.create ~headers:(Httpun.Headers.of_list headers) `GET "/probe"
+    in
+    let request_head =
+      Printf.sprintf
+        "%s %s HTTP/1.1\r\n%s"
+        (Httpun.Method.to_string request.Httpun.Request.meth)
+        request.Httpun.Request.target
+        (Httpun.Headers.to_string request.Httpun.Request.headers)
+    in
+    let bytes =
+      Bigstringaf.of_string ~off:0 ~len:(String.length request_head) request_head
+    in
+    let rec feed off =
+      let remaining = Bigstringaf.length bytes - off in
+      if remaining > 0
+      then (
+        let consumed = Httpun.Server_connection.read conn bytes ~off ~len:remaining in
+        if consumed <= 0 then Alcotest.fail "httpun test feed made no progress";
+        feed (off + consumed))
+    in
+    feed 0;
+    let rec flush () =
+      match Httpun.Server_connection.next_write_operation conn with
+      | `Write iovecs ->
+        List.iter
+          (fun (iov : Bigstringaf.t Httpun.IOVec.t) ->
+             Buffer.add_string
+               response_buf
+               (Bigstringaf.substring iov.buffer ~off:iov.off ~len:iov.len))
+          iovecs;
+        let written =
+          List.fold_left
+            (fun total (iov : Bigstringaf.t Httpun.IOVec.t) -> total + iov.len)
+            0
+            iovecs
+        in
+        Httpun.Server_connection.report_write_result conn (`Ok written);
+        flush ()
+      | `Yield | `Close _ -> ()
+    in
+    flush ();
+    Buffer.contents response_buf)
+;;
+
+let response_header response name =
+  let field = String.lowercase_ascii name ^ ":" in
+  String.split_on_char '\n' response
+  |> List.filter_map (fun line ->
+       let line = String.trim line in
+       if String.starts_with ~prefix:field (String.lowercase_ascii line)
+       then
+         Some
+           (String.trim
+              (String.sub
+                 line
+                 (String.length field)
+                 (String.length line - String.length field)))
+       else None)
+  |> function
+  | value :: _ -> Some value
+  | [] -> None
+;;
+
+let response_status_line response =
+  match String.index_opt response '\r' with
+  | Some idx -> String.sub response 0 idx
+  | None -> response
+;;
+
+let test_json_response_puts_the_validator_on_the_wire () =
+  let response = serve_json_over_wire conditional_body in
+  Alcotest.(check string)
+    "a plain read is answered in full"
+    "HTTP/1.1 200 OK"
+    (response_status_line response);
+  Alcotest.(check (option string))
+    "the client receives the tag it must present to revalidate"
+    (Some (tag_of conditional_body))
+    (response_header response "etag");
+  Alcotest.(check (option string))
+    "and is told to revalidate rather than invent a freshness window"
+    (Some "no-cache")
+    (response_header response "cache-control")
+;;
+
+let test_json_response_matching_tag_sends_no_body () =
+  let response =
+    serve_json_over_wire ~if_none_match:(tag_of conditional_body) conditional_body
+  in
+  Alcotest.(check string)
+    "a client holding the current body is told so"
+    "HTTP/1.1 304 Not Modified"
+    (response_status_line response);
+  Alcotest.(check (option string))
+    "with nothing to read"
+    (Some "0")
+    (response_header response "content-length");
+  Alcotest.(check bool)
+    "and the body itself never reaches the socket"
+    false
+    (List.exists
+       (fun line -> String.equal (String.trim line) conditional_body)
+       (String.split_on_char '\n' response))
+;;
+
 let response_tests =
   [ ( "content_headers preserve all header segments"
     , `Quick
@@ -634,6 +763,12 @@ let response_tests =
   ; ( "the tag is weak and body-derived"
     , `Quick
     , test_json_conditional_tag_is_weak_and_body_derived )
+  ; ( "a JSON response puts the validator on the wire"
+    , `Quick
+    , test_json_response_puts_the_validator_on_the_wire )
+  ; ( "a matching tag sends no body"
+    , `Quick
+    , test_json_response_matching_tag_sends_no_body )
   ]
 ;;
 


### PR DESCRIPTION
## Problem

#28479 taught the server to answer `304` when a polled JSON body has not changed. The dashboard never asks. Every read goes out as `cache: 'no-store'` (`dashboard/src/api/core.ts`), which tells the browser not to store the response — so it holds no copy, sends no `If-None-Match`, and the server has nothing to compare against. The merged ETag path is unreachable from the only client that polls it.

## What this changes

Reads still default to `no-store`. Nine measured routes opt into `no-cache`, which stores the response and revalidates before every use.

## Why opt-in rather than flipping the default

Flipping `core.ts`'s default would also cache `/api/v1/keepers/composite`, whose body carries `secret_projection` — environment variable *names* and host paths, no values (`lib/keeper/keeper_secret_projection.ml:403`). Measured against a live server, that trade is lopsided:

| | bytes/cycle | share |
|---|---:|---:|
| stable **and** carries no secret projection | 1,741,479 | **81.6%** |
| stable but carries `secret_projection` | 49,743 | 2.3% |
| changes every poll — no `304` is possible | 341,689 | 16.0% |
| total | 2,132,911 | |

The global flip buys 2.3% more, and that 2.3% is the entire security cost. The 16% is unreachable either way: `/dashboard/bootstrap` and `/activity/events` return a different body on every poll, so listing them would buy a digest computation and nothing else.

Method: poll each route 4× 0.4s apart, compare SHA-256 of the bodies, and check for the `secret_projection` marker.

## Two ways this could have gone wrong silently

Both are pinned by tests:

- **Query strings.** Several callers build `${route}?${qs}` (`dashboard-telemetry.ts:232`, `dashboard-execution.ts:87`, `dashboard-gate.ts:376`). Matching the path as given — the shape `DASHBOARD_BOOTSTRAP_WARM_PATHS` uses — would leave every parameterised caller on `no-store` while the bare caller revalidated.
- **Prefix matching.** The mirror failure: `/dashboard/telemetry/summary` is a distinct route that was never measured, and a prefix match would sweep it in.

So the query is split off and what remains is matched exactly. An unlisted route gets `no-store` — the conservative answer, not the convenient one.

## Bearer tokens

Cache entries are keyed by URL, not by `Authorization`. `no-cache` closes the gap that would otherwise open: the browser revalidates on every read, so a stored body is only reused when the server — authenticated as the current caller — computes the same ETag for it. A response can never be served across a token change without the server agreeing to it.

## Server-side gap this also closes

`json_conditional` is a pure function, which is what let #28479 cover every combination of method, status, and `If-None-Match`. It also meant no test touched a response, so the step that turns a `Tagged` decision into bytes was unverified. Two cases now drive a real `Httpun.Server_connection`:

- a plain `GET` comes back `200` carrying `etag` and `cache-control: no-cache`
- the same request presenting that tag comes back `304 Not Modified`, `content-length: 0`, with the body absent from the socket

Without them, this PR's client change would have rested on reading the branch that emits the headers rather than on observing it.

## Verification

- `npx vitest run src/api` — 47 files, 771 tests, exit 0
- `npx tsc --noEmit` — exit 0
- `dune build test/test_http_server_eio.exe` + the two new cases — see below

## Not covered

The measurement ran against one workspace's data volume. The eligibility *conditions* are properties of each route's shape, but the byte shares are that workspace's.

A path here is a literal in two places: this set and the module that builds the request. If a route is renamed and only one is updated, the set stops matching and that route silently returns to `no-store` — the status quo, so the drift direction is safe, but it is silent. Closing it properly means the api modules importing their path from a shared constant rather than inlining it, which is a change across ~9 modules and belongs in its own PR.

WORKAROUND-WAIVED: the added matcher is exact membership in a closed, enumerated set, not a substring or prefix classifier — a test pins that `/dashboard/telemetry/summary` does *not* match `/dashboard/telemetry`. Route paths are the wire identifier and are already strings at this boundary (`get(path: string)`); the file's existing `DASHBOARD_BOOTSTRAP_WARM_PATHS` is the same shape. The signature's harm model is a classifier that grows new prefixes while the compiler cannot see reader omissions; here an omission fails closed to `no-store`.

RFC-WAIVED: touches neither credential/identity, repo_manager, operator control, keeper sandbox, dashboard credential components, hooks, nor workflow docs. The one secret-adjacent route is excluded by this change rather than modified by it.
