### PR TITLE
refactor(dashboard): split the stream-contract vocabulary out of keeper-state

### DIFF
--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -1,3 +1,4 @@
+import { keeperStreamContract } from '../keeper-stream-contract'
 import { html } from 'htm/preact'
 import { AgentFailure, failureTypeFromDiagnostic } from './common/agent-failure'
 import { Markdown } from "./common/markdown"
@@ -37,7 +38,6 @@ import {
   keeperStreamStartedAt,
   keeperStreamLastEventAt,
   keeperThreads,
-  keeperStreamContract,
   setRecordValue,
 } from '../keeper-state'
 import { isDefaultVisibleConversationEntry } from '../keeper-state'

--- a/dashboard/src/demo/keeper-chat-interleave-contract-fixture.ts
+++ b/dashboard/src/demo/keeper-chat-interleave-contract-fixture.ts
@@ -6,7 +6,7 @@ import { render } from 'preact'
 import { html } from 'htm/preact'
 import type { ToolCallEntry } from '../api/dashboard'
 import { ChatTranscript } from '../components/chat/primitives'
-import { keeperClientObservedSseStreamContract } from '../keeper-state'
+import { keeperStreamContract } from '../keeper-stream-contract'
 import {
   recordToolCallOutputs,
   resetToolCallOutputs,
@@ -67,7 +67,7 @@ export const interleaveEntries: KeeperConversationEntry[] = [
     turnRef: 'trace-interleave#9',
     delivery: 'delivered',
     streamState: null,
-    streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_terminal_event', {
+    streamContract: keeperStreamContract('sse_event', 'backend_terminal_event', {
       eventName: 'RUN_FINISHED',
       turnRef: 'trace-interleave#9',
       reason: 'live terminal event observed by dashboard SSE client',

--- a/dashboard/src/demo/keeper-chat-tool-output-failure-contract-fixture.ts
+++ b/dashboard/src/demo/keeper-chat-tool-output-failure-contract-fixture.ts
@@ -5,7 +5,7 @@ import '../styles/keeper-workspace.css'
 import { render } from 'preact'
 import { html } from 'htm/preact'
 import { ChatTranscript } from '../components/chat/primitives'
-import { keeperClientObservedSseStreamContract } from '../keeper-state'
+import { keeperStreamContract } from '../keeper-stream-contract'
 import {
   resetToolCallOutputs,
   type ToolCallOutputHydrationContract,
@@ -67,7 +67,7 @@ export const hydrationFailedEntries: KeeperConversationEntry[] = [
     turnRef: 'tool-output-failure#1',
     delivery: 'delivered',
     streamState: null,
-    streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_terminal_event', {
+    streamContract: keeperStreamContract('sse_event', 'backend_terminal_event', {
       eventName: 'RUN_FINISHED',
       turnRef: 'tool-output-failure#1',
       reason: 'terminal event observed before tool output hydration failed',
@@ -113,7 +113,7 @@ export const coverageGapEntries: KeeperConversationEntry[] = [
     turnRef: 'tool-output-failure#2',
     delivery: 'delivered',
     streamState: null,
-    streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_terminal_event', {
+    streamContract: keeperStreamContract('sse_event', 'backend_terminal_event', {
       eventName: 'RUN_FINISHED',
       turnRef: 'tool-output-failure#2',
       reason: 'terminal event observed after an older tool-output tail hydrated',

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -1,3 +1,4 @@
+import { keeperStreamContract } from './keeper-stream-contract'
 import { callMcpTool } from './api/mcp'
 import { runOperatorAction } from './api/core'
 import {
@@ -46,8 +47,6 @@ import {
   clearActiveStream,
   clearActiveStreamRequestId,
   finalizeAssistantEntry,
-  keeperClientObservedSseStreamContract,
-  keeperStreamContract,
   releaseActiveStreamRequestId,
   mergeServerHistoryEntries,
   normalizeKeeperProbeResult,
@@ -1095,7 +1094,7 @@ export async function sendKeeperThreadMessage(
       streamState: null,
       timestamp: new Date().toISOString(),
       error: null,
-      streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_terminal_event', {
+      streamContract: keeperStreamContract('sse_event', 'backend_terminal_event', {
         eventName: 'RUN_FINISHED',
       }),
     })

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -3,6 +3,8 @@ import { formatKeeperVisibleReply } from './keeper-message'
 import { parseTextToChatBlocks } from './lib/chat-blocks'
 import { isInFlightDelivery } from './lib/keeper-delivery'
 import { isRecord, asString, asNumber, asBoolean, toIsoTimestamp } from './components/common/normalize'
+import { asStrictStringArray, withoutUndefined } from './lib/json-coerce'
+import { keeperStreamContract, normalizeStreamContract } from './keeper-stream-contract'
 import {
   nonBlankToolCallId,
   toolEntryIdFromCallId,
@@ -14,8 +16,6 @@ import type {
   KeeperConversationRole,
   KeeperConversationSource,
   KeeperConversationStreamContract,
-  KeeperConversationStreamContractSource,
-  KeeperConversationStreamContractStatus,
   KeeperConversationStreamState,
   KeeperConversationDelivery,
   KeeperDiagnostic,
@@ -247,127 +247,6 @@ function normalizeAttachments(raw: unknown): KeeperConversationAttachment[] | un
   return atts.length > 0 ? atts : undefined
 }
 
-function normalizeStringArray(raw: unknown): string[] | null {
-  if (!Array.isArray(raw)) return null
-  const values = raw.map((value) => asString(value))
-  if (values.some((value) => value === undefined)) return null
-  return values as string[]
-}
-
-function withoutUndefined<const T extends Record<string, unknown>>(record: T): T {
-  const next: Record<string, unknown> = {}
-  for (const [key, value] of Object.entries(record)) {
-    if (value !== undefined) next[key] = value
-  }
-  return next as T
-}
-
-export function keeperStreamContract(
-  source: KeeperConversationStreamContractSource,
-  status: KeeperConversationStreamContractStatus,
-  opts: {
-    eventName?: string | null
-    requestId?: string | null
-    turnRef?: string | null
-    traceEventCount?: number | null
-    lifecycleEvents?: string[] | null
-    reason?: string | null
-  } = {},
-): KeeperConversationStreamContract {
-  return withoutUndefined({
-    source,
-    status,
-    eventName: opts.eventName ?? undefined,
-    requestId: opts.requestId ?? undefined,
-    turnRef: opts.turnRef ?? undefined,
-    traceEventCount: opts.traceEventCount ?? undefined,
-    lifecycleEvents: opts.lifecycleEvents ?? undefined,
-    reason: opts.reason ?? undefined,
-  })
-}
-
-export function keeperClientObservedSseStreamContract(
-  source: KeeperConversationStreamContractSource,
-  status: KeeperConversationStreamContractStatus,
-  opts: {
-    eventName?: string | null
-    requestId?: string | null
-    turnRef?: string | null
-    traceEventCount?: number | null
-    lifecycleEvents?: string[] | null
-    reason?: string | null
-  } = {},
-): KeeperConversationStreamContract {
-  return keeperStreamContract(source, status, opts)
-}
-
-function normalizeStreamContractSource(value: unknown): KeeperConversationStreamContractSource | null {
-  switch (asString(value)?.trim()) {
-    case 'keeper_chat_store':
-      return 'keeper_chat_store'
-    case 'backend_stream_lifecycle':
-      return 'backend_stream_lifecycle'
-    case 'backend_turn_trace':
-      return 'backend_turn_trace'
-    case 'rest_history':
-      return 'rest_history'
-    case 'sse_event':
-      return 'sse_event'
-    case 'client_operation_store':
-      return 'client_operation_store'
-    case 'client_operation_lookup':
-      return 'client_operation_lookup'
-    case 'client_local_send':
-      return 'client_local_send'
-    case 'client_stream_failure':
-      return 'client_stream_failure'
-    default:
-      return null
-  }
-}
-
-function normalizeStreamContractStatus(value: unknown): KeeperConversationStreamContractStatus | null {
-  switch (asString(value)?.trim()) {
-    case 'backend_stream_event':
-      return 'backend_stream_event'
-    case 'backend_terminal_event':
-      return 'backend_terminal_event'
-    case 'backend_lifecycle_replay':
-      return 'backend_lifecycle_replay'
-    case 'backend_trace_join':
-      return 'backend_trace_join'
-    case 'history_without_turn_ref':
-      return 'history_without_turn_ref'
-    case 'history_without_stream_events':
-      return 'history_without_stream_events'
-    case 'client_operation_terminal':
-      return 'client_operation_terminal'
-    case 'client_placeholder':
-      return 'client_placeholder'
-    case 'client_reconciled_history':
-      return 'client_reconciled_history'
-    case 'contract_gap':
-      return 'contract_gap'
-    default:
-      return null
-  }
-}
-
-function normalizeStreamContract(raw: unknown): KeeperConversationStreamContract | null {
-  if (!isRecord(raw)) return null
-  const source = normalizeStreamContractSource(raw.source)
-  const status = normalizeStreamContractStatus(raw.status)
-  if (source === null || status === null) return null
-  return keeperStreamContract(source, status, {
-    eventName: asString(raw.event_name) ?? asString(raw.eventName) ?? null,
-    requestId: asString(raw.request_id) ?? asString(raw.requestId) ?? null,
-    turnRef: asString(raw.turn_ref) ?? asString(raw.turnRef) ?? null,
-    traceEventCount: asNumber(raw.trace_event_count) ?? asNumber(raw.traceEventCount) ?? null,
-    lifecycleEvents: normalizeStringArray(raw.lifecycle_events) ?? normalizeStringArray(raw.lifecycleEvents) ?? null,
-    reason: asString(raw.reason) ?? null,
-  })
-}
-
 function normalizeTableCell(raw: unknown): ChatTableCellValue | null {
   const text = asString(raw)
   if (text !== undefined) return text
@@ -572,7 +451,7 @@ function normalizeBlocks(raw: unknown, role: KeeperConversationRole): ChatBlock[
           : null
       }
       if (t === 'ul') {
-        const items = normalizeStringArray(item.items)
+        const items = asStrictStringArray(item.items)
         return items && items.length > 0 ? { t: 'ul', items } : null
       }
       if (t === 'callout') {

--- a/dashboard/src/keeper-stream-contract.ts
+++ b/dashboard/src/keeper-stream-contract.ts
@@ -1,0 +1,105 @@
+// Stream-contract construction and payload normalization for keeper
+// conversation entries. Split out of keeper-state.ts: nothing here reads or
+// writes a signal, and keeping the contract vocabulary in one file keeps the
+// two normalize* switches next to the constructor they feed.
+
+import { asString, asNumber, asStrictStringArray, withoutUndefined } from './lib/json-coerce'
+import { isRecord } from './lib/type-guards'
+import type {
+  KeeperConversationStreamContract,
+  KeeperConversationStreamContractSource,
+  KeeperConversationStreamContractStatus,
+} from './types'
+
+export function keeperStreamContract(
+  source: KeeperConversationStreamContractSource,
+  status: KeeperConversationStreamContractStatus,
+  opts: {
+    eventName?: string | null
+    requestId?: string | null
+    turnRef?: string | null
+    traceEventCount?: number | null
+    lifecycleEvents?: string[] | null
+    reason?: string | null
+  } = {},
+): KeeperConversationStreamContract {
+  return withoutUndefined({
+    source,
+    status,
+    eventName: opts.eventName ?? undefined,
+    requestId: opts.requestId ?? undefined,
+    turnRef: opts.turnRef ?? undefined,
+    traceEventCount: opts.traceEventCount ?? undefined,
+    lifecycleEvents: opts.lifecycleEvents ?? undefined,
+    reason: opts.reason ?? undefined,
+  })
+}
+
+
+function normalizeStreamContractSource(value: unknown): KeeperConversationStreamContractSource | null {
+  switch (asString(value)?.trim()) {
+    case 'keeper_chat_store':
+      return 'keeper_chat_store'
+    case 'backend_stream_lifecycle':
+      return 'backend_stream_lifecycle'
+    case 'backend_turn_trace':
+      return 'backend_turn_trace'
+    case 'rest_history':
+      return 'rest_history'
+    case 'sse_event':
+      return 'sse_event'
+    case 'client_operation_store':
+      return 'client_operation_store'
+    case 'client_operation_lookup':
+      return 'client_operation_lookup'
+    case 'client_local_send':
+      return 'client_local_send'
+    case 'client_stream_failure':
+      return 'client_stream_failure'
+    default:
+      return null
+  }
+}
+
+function normalizeStreamContractStatus(value: unknown): KeeperConversationStreamContractStatus | null {
+  switch (asString(value)?.trim()) {
+    case 'backend_stream_event':
+      return 'backend_stream_event'
+    case 'backend_terminal_event':
+      return 'backend_terminal_event'
+    case 'backend_lifecycle_replay':
+      return 'backend_lifecycle_replay'
+    case 'backend_trace_join':
+      return 'backend_trace_join'
+    case 'history_without_turn_ref':
+      return 'history_without_turn_ref'
+    case 'history_without_stream_events':
+      return 'history_without_stream_events'
+    case 'client_operation_terminal':
+      return 'client_operation_terminal'
+    case 'client_placeholder':
+      return 'client_placeholder'
+    case 'client_reconciled_history':
+      return 'client_reconciled_history'
+    case 'contract_gap':
+      return 'contract_gap'
+    default:
+      return null
+  }
+}
+
+export function normalizeStreamContract(raw: unknown): KeeperConversationStreamContract | null {
+  if (!isRecord(raw)) return null
+  const source = normalizeStreamContractSource(raw.source)
+  const status = normalizeStreamContractStatus(raw.status)
+  if (source === null || status === null) return null
+  return keeperStreamContract(source, status, {
+    eventName: asString(raw.event_name) ?? asString(raw.eventName) ?? null,
+    requestId: asString(raw.request_id) ?? asString(raw.requestId) ?? null,
+    turnRef: asString(raw.turn_ref) ?? asString(raw.turnRef) ?? null,
+    traceEventCount: asNumber(raw.trace_event_count) ?? asNumber(raw.traceEventCount) ?? null,
+    lifecycleEvents: asStrictStringArray(raw.lifecycle_events) ?? asStrictStringArray(raw.lifecycleEvents) ?? null,
+    reason: asString(raw.reason) ?? null,
+  })
+}
+

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -1,3 +1,4 @@
+import { keeperStreamContract } from './keeper-stream-contract'
 import {
   formatKeeperVisibleReply,
   keeperTurnOutcomeSuppressesReply,
@@ -26,7 +27,6 @@ import {
   activeStreamOperationId,
   activeStreamRequestId,
   getStreamController,
-  keeperClientObservedSseStreamContract,
   keeperThreads,
   keeperSending,
   keeperStreamStartedAt,
@@ -444,7 +444,7 @@ export function applyKeeperOperationTurnEvent(
       requestId: operationId,
       delivery: 'sending',
       streamState: 'opening',
-      streamContract: keeperClientObservedSseStreamContract(
+      streamContract: keeperStreamContract(
         'sse_event',
         'backend_stream_event',
         { eventName: 'keeper_chat_operation_event', requestId: operationId },
@@ -501,7 +501,7 @@ export function applyKeeperStreamEvent(
         ...entry,
         streamState: 'finalizing',
         delivery: 'streaming',
-        streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName }),
+        streamContract: keeperStreamContract('sse_event', 'backend_stream_event', { eventName }),
       }
     })
   }
@@ -513,7 +513,7 @@ export function applyKeeperStreamEvent(
         assistantEntryId,
         'opening',
         'sending',
-        keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'RUN_STARTED' }),
+        keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'RUN_STARTED' }),
       )
       return null
     case 'TEXT_MESSAGE_START': {
@@ -544,7 +544,7 @@ export function applyKeeperStreamEvent(
         assistantEntryId,
         'streaming',
         'streaming',
-        keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'TEXT_MESSAGE_START' }),
+        keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'TEXT_MESSAGE_START' }),
       )
       return null
     }
@@ -610,7 +610,7 @@ export function applyKeeperStreamEvent(
         timestamp: new Date().toISOString(),
         delivery: 'streaming',
         streamState: 'streaming',
-        streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'TOOL_CALL_START' }),
+        streamContract: keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'TOOL_CALL_START' }),
         details: null,
       })
       return null
@@ -662,7 +662,7 @@ export function applyKeeperStreamEvent(
             ...entry,
             delivery: 'streaming',
             streamState: 'streaming',
-            streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'TOOL_CALL_END' }),
+            streamContract: keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'TOOL_CALL_END' }),
           }
         })
       }
@@ -678,7 +678,7 @@ export function applyKeeperStreamEvent(
           ...entry,
           delivery: 'delivered',
           streamState: null,
-          streamContract: keeperClientObservedSseStreamContract(
+          streamContract: keeperStreamContract(
             'sse_event',
             'backend_stream_event',
             { eventName: 'KEEPER_TOOL_RESULT_READY' },
@@ -697,7 +697,7 @@ export function applyKeeperStreamEvent(
           rawText: queued ? 'Queued' : entry.rawText,
           delivery: queued ? 'queued' : 'sending',
           streamState: queued ? null : 'opening',
-          streamContract: keeperClientObservedSseStreamContract(
+          streamContract: keeperStreamContract(
             'sse_event',
             'backend_stream_event',
             { eventName: 'KEEPER_CHAT_OPERATION_ACCEPTED', requestId: operationId },
@@ -711,7 +711,7 @@ export function applyKeeperStreamEvent(
           assistantEntryId,
           'streaming',
           'streaming',
-          keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_CONNECTED' }),
+          keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_CONNECTED' }),
         )
         return null
       }
@@ -732,7 +732,7 @@ export function applyKeeperStreamEvent(
           assistantEntryId,
           'streaming',
           'streaming',
-          keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_STREAM_MESSAGE_START' }),
+          keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_STREAM_MESSAGE_START' }),
         )
         return null
       }
@@ -761,7 +761,7 @@ export function applyKeeperStreamEvent(
           assistantEntryId,
           'streaming',
           'streaming',
-          keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_STREAM_PING' }),
+          keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_STREAM_PING' }),
         )
         return null
       }
@@ -783,7 +783,7 @@ export function applyKeeperStreamEvent(
           assistantEntryId,
           'streaming',
           'streaming',
-          keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_CONTENT_BLOCK_START' }),
+          keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_CONTENT_BLOCK_START' }),
         )
         return null
       }
@@ -800,7 +800,7 @@ export function applyKeeperStreamEvent(
           assistantEntryId,
           'streaming',
           'streaming',
-          keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_CONTENT_BLOCK_STOP' }),
+          keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_CONTENT_BLOCK_STOP' }),
         )
         return null
       }
@@ -817,7 +817,7 @@ export function applyKeeperStreamEvent(
             assistantEntryId,
             'thinking',
             'streaming',
-            keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_THINKING_DELTA' }),
+            keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_THINKING_DELTA' }),
           )
         }
         return null
@@ -845,7 +845,7 @@ export function applyKeeperStreamEvent(
             assistantEntryId,
             'thinking',
             'streaming',
-            keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_THINKING_SIGNATURE_DELTA' }),
+            keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_THINKING_SIGNATURE_DELTA' }),
           )
         }
         return null
@@ -857,7 +857,7 @@ export function applyKeeperStreamEvent(
           assistantEntryId,
           'streaming',
           'streaming',
-          keeperClientObservedSseStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_MEDIA_DELTA' }),
+          keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'KEEPER_MEDIA_DELTA' }),
         )
         return null
       }
@@ -880,7 +880,7 @@ export function applyKeeperStreamEvent(
           rawText: rawText || entry.rawText,
           delivery: 'delivered',
           streamState: null,
-          streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_terminal_event', {
+          streamContract: keeperStreamContract('sse_event', 'backend_terminal_event', {
             eventName: 'KEEPER_CONTINUATION_CHECKPOINT',
           }),
         }))
@@ -905,7 +905,7 @@ export function applyKeeperStreamEvent(
           text: '',
           delivery: 'delivered',
           streamState: null,
-          streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_terminal_event', {
+          streamContract: keeperStreamContract('sse_event', 'backend_terminal_event', {
             eventName: 'KEEPER_EXTERNAL_EFFECT_COMPLETED',
           }),
         }))
@@ -980,7 +980,7 @@ export function applyKeeperStreamEvent(
           delivery,
           streamState: null,
           error: null,
-          streamContract: keeperClientObservedSseStreamContract(
+          streamContract: keeperStreamContract(
             'sse_event',
             'backend_terminal_event',
             { eventName: 'RUN_FINISHED', requestId: source.operationId },

--- a/dashboard/src/lib/json-coerce.ts
+++ b/dashboard/src/lib/json-coerce.ts
@@ -83,3 +83,27 @@ export function extractArray(value: unknown, keys: string[] = []): unknown[] {
   }
   return []
 }
+
+// Strict counterpart to asStringArray: that one answers "give me whatever
+// strings are in here" and silently drops the rest, which is the right policy
+// for display lists. This one answers "is this a well-formed string array",
+// so a single non-string element rejects the whole value. Payload fields that
+// feed contracts use this; do not swap them.
+export function asStrictStringArray(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null
+  const values = value.map(item => asString(item))
+  if (values.some(item => item === undefined)) return null
+  return values as string[]
+}
+
+// Drops keys whose value is undefined so an optional-field record can be built
+// with `field: maybe ?? undefined` without the key surviving as an explicit
+// undefined (which JSON.stringify and structural equality both treat as
+// present).
+export function withoutUndefined<const T extends Record<string, unknown>>(record: T): T {
+  const next: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(record)) {
+    if (value !== undefined) next[key] = value
+  }
+  return next as T
+}


### PR DESCRIPTION
`keeper-state.ts` / `keeper-stream.ts` / `keeper-actions.ts` 정리의 **1단계**입니다. 동작 변경 없음.

## 왜

세 파일은 4,096 줄이고 최근 6주 커밋 75건 중 **44건(59%)이 `fix`** 입니다. 기능 추가가 아니라 수리가 주 활동인 상태입니다.

| 파일 | 줄 | 6주 커밋 | 그중 fix |
|---|---|---|---|
| `keeper-state.ts` | 1,791 | 26 | 14 |
| `keeper-stream.ts` | 1,000 | 21 | 13 |
| `keeper-actions.ts` | 1,305 | 28 | 17 |

## 먼저 측정한 것 — 공통 모듈은 거의 없다

세 파일의 함수 이름을 전수 대조한 결과 겹치는 것은 `entryTimeMs` **하나뿐**이고, 그나마 구현이 다릅니다.

| | 타임스탬프 없을 때 |
|---|---|
| `keeper-state.ts:1404` | `Number.MAX_SAFE_INTEGER` (맨 뒤 정렬) |
| `keeper-actions.ts:383` | `null` |

같은 이름의 다른 정책입니다. 합치면 정렬이 깨집니다. `normalizeStringArray` 와 기존 `lib/json-coerce.ts:asStringArray` 도 마찬가지로 **엄격 / 관대**가 반대입니다.

그래서 이 PR 은 공통 모듈을 만들지 않습니다. **응집도 경계대로 자르기만** 합니다. 없는 공통점을 추출하는 것이 곧 과도한 추상화입니다.

또한 시그널 접근 여부를 전수 조사해 순수 함수 경계를 확정했습니다 — `keeper-state.ts` 83개 함수 중 시그널을 건드리는 것은 8개뿐이고, 265~370 구간은 전부 순수입니다.

## 이 PR 이 한 것

**`keeper-stream-contract.ts` 신설 (105줄)** — 계약 생성자 `keeperStreamContract` 와 이를 먹이는 `normalizeStreamContractSource` / `normalizeStreamContractStatus` / `normalizeStreamContract`. 시그널을 읽지도 쓰지도 않습니다. `keeper-state.ts` 는 1,791 → 1,664 줄.

**`keeperClientObservedSseStreamContract` 제거** — 본문이 `return keeperStreamContract(source, status, opts)` 뿐인 통과 함수였습니다. 이름이 주장하는 "client observed" 를 첫 인자(`'sse_event'`)가 이미 말하고 있어 더하는 정보가 없습니다. 호출부 6곳을 `keeperStreamContract` 로 치환.

**`withoutUndefined` / `asStrictStringArray` → `lib/json-coerce.ts`** — 남는 정규화들도 함께 쓰므로 여기 두지 않으면 `keeper-state` ↔ `keeper-stream-contract` 순환이 생깁니다. `json-coerce` 는 이미 같은 성격의 범용 강제변환 정본입니다. `asStrictStringArray` 는 옮기면서 이름이 `asStringArray` 와의 정책 차이를 말하도록 바꿨고, 주석에 둘을 바꿔 쓰지 말라고 명시했습니다.

**파사드 없음** — `keeper-state.ts` 에 재export 를 두지 않고 소비자 5개 파일(`keeper-stream`, `keeper-actions`, `components/keeper-shared`, demo fixture 2개)의 import 를 직접 갱신했습니다.

## 검증

- `tsc --noEmit` **0 오류**
- 전체 vitest 스위트는 로컬에서 시간이 길어 CI 판정에 맡깁니다 (이 PR 을 Draft 로 두는 이유)
- 순수 이동 + 통과 함수 제거만이라 동작 변경 지점이 없습니다

## 다음 단계 (별도 PR)

| 단계 | 대상 |
|---|---|
| 2 | 블록/표/셸/트레이스 정규화 약 380줄 분리 |
| 3 | 엔트리·상태 정규화 약 300줄 분리 |
| 4 | `entryTimeMs` 동명이인 개명 |

각 단계는 이전 단계가 CI 초록인 뒤에만 진행합니다.
