### PR TITLE
fix(test): follow the runtime contract wording the prose change landed

### DIFF
--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -379,7 +379,7 @@ let test_turn_context_fields_stored () =
       true
       (String_util.contains_substring
          Yojson.Safe.Util.(member "execute_path_basis" path_resolution |> to_string)
-         "do not repeat the repo prefix");
+         "do not repeat the cwd prefix");
     Alcotest.(check bool)
       "runtime contract points .masc state at task/context tools"
       true


### PR DESCRIPTION
## main 이 red 다

[#28533](https://github.com/jeong-sik/masc/pull/28533) 이 `execute_path_basis` 산문을 바꾸면서, 그 문자열을 단언하는 `test_keeper_tool_call_log` 를 고치지 않았다.

```
lib/keeper/keeper_runtime_contract.ml:285   "do not repeat the cwd prefix in the path."
test/test_keeper_tool_call_log.ml:382       "do not repeat the repo prefix"        ← 옛 문자열
```

## 수정

단언 문자열만 새 산문에 맞춘다. 단언 자체는 유지할 가치가 있다 — 계약이 cwd/path 관계를 설명한다는 것을 고정하며, 그건 재작성이 보존해야 했던 바로 그 성질이다.

## 왜 놓쳤나

#28533 을 머지하기 전 네 개 스위트를 돌렸는데 이것은 그 안에 없었다. 계획서에는 영향받는 테스트로 적혀 있었고 내가 내 목록을 따르지 않았다.

**산문 변경은 그것을 인용하는 지점을 컴파일러가 잡아주지 않는다.** 그 목록이 존재한 이유가 정확히 그것이다.

## 검증

```
@test/runtest-test_keeper_tool_call_log   Test Successful.  36 tests run.
```

RFC-WAIVED: 머지된 산문 변경에 테스트 단언을 맞추는 한 줄 수정이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3Ek71sn9DrrT4japMSNQs