### PR TITLE
refactor(keeper): drop the sandbox record's repos vocabulary

### DIFF
--- a/lib/keeper/keeper_sandbox.ml
+++ b/lib/keeper/keeper_sandbox.ml
@@ -18,8 +18,6 @@ type t =
   ; host_root_abs : string
   ; container_root : string option
   ; root_arg : string
-  ; repos_arg : string
-  ; task_overlay_pattern : string
   }
 
 let strip_trailing_slashes = Env_config_core.strip_trailing_slashes
@@ -168,8 +166,6 @@ let of_meta ~(config : Workspace.config) ~(meta : Keeper_meta_contract.keeper_me
        | Local -> None
        | Docker -> Some (container_root meta.name))
   ; root_arg = "."
-  ; repos_arg = "repos"
-  ; task_overlay_pattern = "repos/<repo>"
   }
 
 let allowed_root_rel_of_meta ~(meta : Keeper_meta_contract.keeper_meta) : string =
@@ -267,11 +263,5 @@ let context_status_fields (t : t) : (string * Yojson.Safe.t) list =
   ; "sandbox_network_mode", `String t.network_mode
   ; "sandbox_lifetime", `String storage_lifetime
   ; "sandbox_root", `String t.root_arg
-  ; "sandbox_repos", `String t.repos_arg
-  ; "sandbox_task_overlay_pattern", `String t.task_overlay_pattern
-  ; ( "sandbox_paths"
-    , `Assoc
-        [ "root", `String t.root_arg
-        ; "repos", `String t.repos_arg
-        ] )
+  ; "sandbox_paths", `Assoc [ "root", `String t.root_arg ]
   ]

--- a/lib/keeper/keeper_sandbox.mli
+++ b/lib/keeper/keeper_sandbox.mli
@@ -21,8 +21,6 @@ type t = {
   host_root_abs : string;
   container_root : string option;
   root_arg : string;
-  repos_arg : string;
-  task_overlay_pattern : string;
 }
 
 (** {1 Keeper-visible paths} *)

--- a/lib/keeper/keeper_sandbox_repo_path.ml
+++ b/lib/keeper/keeper_sandbox_repo_path.ml
@@ -8,13 +8,6 @@ let normalize_path path =
 let playground_root_no_create ~(config : Workspace.config) ~(meta : keeper_meta) =
   Keeper_sandbox.host_root_abs_of_meta ~config meta
 
-let repos_root_of_playground_root playground_root =
-  Filename.concat playground_root "repos" |> normalize_path
-
-let repo_root_of_playground_root ~playground_root ~repo_name =
-  Filename.concat (repos_root_of_playground_root playground_root) repo_name
-  |> normalize_path
-
 let safe_repo_component s =
   s <> ""
   && s <> "."
@@ -31,20 +24,6 @@ let safe_repo_component s =
           || c = '_'
           || c = '.')
        s
-
-let candidate_repo_roots_no_create ~base_path ~keeper_id ~repository_id =
-  if not (safe_repo_component repository_id)
-  then []
-  else
-    [ Keeper_types_profile_sandbox.Local; Keeper_types_profile_sandbox.Docker ]
-    |> List.map (fun sandbox_profile ->
-      let playground_root =
-        Filename.concat
-          base_path
-          (Keeper_sandbox.host_root_rel_of_profile sandbox_profile keeper_id)
-      in
-      repo_root_of_playground_root ~playground_root ~repo_name:repository_id)
-    |> List.sort_uniq String.compare
 
 type execution_location_scope =
   | Playground_root

--- a/lib/keeper/keeper_sandbox_repo_path.mli
+++ b/lib/keeper/keeper_sandbox_repo_path.mli
@@ -9,16 +9,6 @@ val normalize_path : string -> string
 val playground_root_no_create :
   config:Workspace.config -> meta:Keeper_meta_contract.keeper_meta -> string
 
-val candidate_repo_roots_no_create :
-  base_path:string ->
-  keeper_id:string ->
-  repository_id:string ->
-  string list
-(** Candidate host-side sandbox repo roots for [repository_id] under
-    [keeper_id]'s known sandbox backends. Returns [[]] when [repository_id] is
-    not a safe single path component. This performs no filesystem mutation and
-    does not require the keeper registry. *)
-
 val execution_location_json :
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -783,7 +783,6 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
              ("sandbox_id", `String sandbox.sandbox_id);
              ("sandbox_backend", `String (Keeper_sandbox.backend_to_string sandbox.backend));
              ("sandbox_root", `String sandbox.root_arg);
-             ("sandbox_repos", `String sandbox.repos_arg);
              ("sandbox_container_root", Json_util.string_opt_to_json sandbox.container_root);
              ("default_cwd", `String keeper_visible_abs);
              ("sandbox_profile", `String (sandbox_profile_to_string m.sandbox_profile));

--- a/test/test_keeper_cwd_response.ml
+++ b/test/test_keeper_cwd_response.ml
@@ -38,8 +38,6 @@ let mk_local_sandbox () : Keeper_sandbox.t =
   ; host_root_abs = host_root_marker ^ "/.masc/playground/test-local"
   ; container_root = None
   ; root_arg = "."
-  ; repos_arg = "repos"
-  ; task_overlay_pattern = "repos/<repo>"
   }
 
 let mk_docker_sandbox () : Keeper_sandbox.t =
@@ -53,8 +51,6 @@ let mk_docker_sandbox () : Keeper_sandbox.t =
       host_root_marker ^ "/.masc/playground/docker/test-docker"
   ; container_root = Some "/home/keeper/playground/test-docker"
   ; root_arg = "."
-  ; repos_arg = "repos"
-  ; task_overlay_pattern = "repos/<repo>"
   }
 
 let local_response ~host_cwd =


### PR DESCRIPTION
## 요약

`Keeper_sandbox.t` 에서 `repos` 어휘를 제거한다. 시스템이 만들지 않고 스키마가 더는 이름 부르지 않는 디렉터리를 설명하던 필드들이다.

## 지우는 것

| 대상 | 위치 |
|---|---|
| `repos_arg`, `task_overlay_pattern` 레코드 필드 | `keeper_sandbox.ml:21-22`, `.mli:24-25` |
| wire `sandbox_repos`, `sandbox_task_overlay_pattern`, `sandbox_paths.repos` | `keeper_sandbox.ml:270-275` |
| wire `sandbox_repos` (두 번째 노출부) | `keeper_status_detail.ml:786` |
| 죽은 `candidate_repo_roots_no_create` | `keeper_sandbox_repo_path.ml:35`, `.mli:12` |
| 죽은 `repos_root_of_playground_root`, `repo_root_of_playground_root` | `keeper_sandbox_repo_path.ml:11,14` |

## 필드를 지우는 것이 제거를 검증 가능하게 만든다

**컴파일러가 모든 사용처를 찾아냈다** — 이 브랜치에서는 테스트 픽스처 하나(`test_keeper_cwd_response.ml:41`)였다.

앞선 산문 제거([#28533](https://github.com/jeong-sik/masc/pull/28533))에는 그런 도움이 없었다. 인용 지점을 손으로 훑어야 했고 **하나를 놓쳤다** ([#28540](https://github.com/jeong-sik/masc/pull/28540) 이 그것을 고친다). 같은 작업의 두 절반이 이렇게 다르다.

## 순서

스키마가 `sandbox_repos` 를 이름 부르던 문장이 먼저 사라졌다(#28533). 필드를 먼저 지웠다면 툴 설명이 **응답에 없는 키를 약속**하게 된다.

대시보드는 이 세 필드를 읽은 적이 없다 — `dashboard/src` 를 확인하고 제거했다.

## 죽은 함수 3개

`candidate_repo_roots_no_create` 와 그것만 쓰던 경로 조립기 둘. `lib/`, `bin/`, `test/` 어디에도 호출자가 없다. `sandbox_profile` 도입 이전에 "이 keeper 에게 이 저장소가 어디 있을까" 를 추측하던 방식이다.

## 검증

```
@test/runtest-test_keeper_cwd_response                14 tests   Successful
@test/runtest-test_keeper_visible_path_projection     통과
@test/runtest-test_keeper_sandbox_docker_cwd_response 통과
dune build @check                                     CHECK=0
check-ssot.sh                                         SSOT=0
audit-dead-surface.py --ratchet                       DEAD=0
audit-odoc-refs.py                                    ODOC=0
```

> `test_keeper_tool_call_log` 의 `runtime contract explains Execute repo cwd path basis` 가 실패하는데 **이 변경과 무관하다** — #28533 이 남긴 stale 단언이며 [#28540](https://github.com/jeong-sik/masc/pull/28540) 에서 고친다.

## 이 PR 이 하지 않는 것

`MASC_KEEPER_DOCKER_PLAYGROUND` (프로덕션 reader 0) 는 계획에 이 단계로 잡혀 있었으나 뺐다. 제거하려면 6개 파일과 "플래그가 true 여도 Local 은 Local" 을 고정하는 스위트 삭제가 따라오는데, 그건 레이아웃이 아니라 **feature-flag 위생**이다. 별도 변경.

RFC: `docs/rfc/RFC-keeper-workspace-root-only.md` §3.5

RFC-WAIVED: 대체 RFC 가 머지되어 있고(#28459), 이 변경은 그 §3.5 의 타입 항목이다. 소비자가 없는 필드와 호출자가 없는 함수를 제거한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3Ek71sn9DrrT4japMSNQs
