### PR TITLE
feat(dashboard): 자율턴 run 을 펼칠 때 양 끝만 그리고 가운데는 컨트롤 뒤로

### DIFF
--- a/dashboard/src/components/chat/autonomous-turn-run.test.ts
+++ b/dashboard/src/components/chat/autonomous-turn-run.test.ts
@@ -10,7 +10,7 @@ import { render } from 'preact'
 import { act } from 'preact/test-utils'
 import { html } from 'htm/preact'
 import type { KeeperConversationEntry } from '../../types'
-import { ChatTranscript } from './primitives'
+import { autonomousRunWindow, ChatTranscript } from './primitives'
 
 const wake = (id: string, timestamp: string): KeeperConversationEntry =>
   ({
@@ -135,5 +135,85 @@ describe('ChatTranscript — folded autonomous runs', () => {
     // The second run begins at the first unseen turn, so the line sits
     // immediately before it rather than after the whole block.
     expect(divider?.nextElementSibling).toBe(runs[1])
+  })
+
+  const openFirstRun = () => {
+    act(() => {
+      runHeaders()[0]?.click()
+    })
+  }
+
+  const nestedTurns = (): Element[] => [
+    ...container.querySelectorAll('.chat-auto-run-turns > .chat-block-trace'),
+  ]
+
+  const moreControl = (): HTMLElement | null =>
+    container.querySelector('.chat-auto-run-more')
+
+  it('draws only the two ends of a long run, with the middle behind one control', () => {
+    // Opening a 30-turn run must not trade the wall of headers the fold
+    // removed for a wall of rows.
+    draw(wakesFrom('a', DAY_ONE, 30))
+    openFirstRun()
+    expect(nestedTurns().length).toBe(6)
+    expect(moreControl()?.textContent?.trim()).toBe('가운데 24개 더 보기')
+  })
+
+  it('draws the run whole when the control would stand for a single turn', () => {
+    // 7 turns is head(3) + tail(3) + 1: a press to save one row is a worse
+    // trade than the row, so no control belongs in the output.
+    draw(wakesFrom('a', DAY_ONE, 7))
+    openFirstRun()
+    expect(nestedTurns().length).toBe(7)
+    expect(moreControl()).toBeNull()
+  })
+
+  it('reveals a step of turns per press and reports what is still hidden', () => {
+    draw(wakesFrom('a', DAY_ONE, 30))
+    openFirstRun()
+    act(() => {
+      moreControl()?.click()
+    })
+    // head 3 -> 13, tail 3, so 16 rows drawn and 14 still behind the control.
+    expect(nestedTurns().length).toBe(16)
+    expect(moreControl()?.textContent?.trim()).toBe('가운데 14개 더 보기')
+  })
+
+  it('retires the control once every turn is drawn', () => {
+    draw(wakesFrom('a', DAY_ONE, 20))
+    openFirstRun()
+    act(() => {
+      moreControl()?.click()
+    })
+    act(() => {
+      moreControl()?.click()
+    })
+    // head reaches 23 >= 20, so the window degenerates to the whole run.
+    expect(nestedTurns().length).toBe(20)
+    expect(moreControl()).toBeNull()
+  })
+})
+
+describe('autonomousRunWindow', () => {
+  it('draws a run whole up to the point where hiding saves more than one turn', () => {
+    // 0..7 inclusive: the window never hides a single turn behind a press.
+    for (const total of [0, 1, 5, 6, 7]) {
+      expect(autonomousRunWindow(total, 3)).toEqual({ head: total, tail: 0, hidden: 0 })
+    }
+  })
+
+  it('splits into both ends once the middle is worth a control', () => {
+    expect(autonomousRunWindow(8, 3)).toEqual({ head: 3, tail: 3, hidden: 2 })
+    expect(autonomousRunWindow(200, 3)).toEqual({ head: 3, tail: 3, hidden: 194 })
+  })
+
+  it('closes the window as the head walks down, never overlapping the tail', () => {
+    // The head grows by presses; the sum of drawn ends can never exceed the run.
+    for (const head of [3, 13, 23, 33]) {
+      const w = autonomousRunWindow(30, head)
+      expect(w.head + w.tail + w.hidden).toBe(30)
+      expect(w.hidden).toBeGreaterThanOrEqual(0)
+    }
+    expect(autonomousRunWindow(30, 33)).toEqual({ head: 30, tail: 0, hidden: 0 })
   })
 })

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -3807,10 +3807,40 @@ function AutonomousTurnGroup({
   `
 }
 
+// How many turns an opened run draws at each end before the middle becomes a
+// control. A run has no ceiling -- a keeper wakes on the order of once every
+// few minutes, so an unattended weekend is hundreds of turns -- and drawing it
+// whole trades the wall of headers the fold removed for a wall of rows. The
+// two ends are the parts a reader asks for: where the run started and what the
+// keeper just did.
+const AUTONOMOUS_RUN_WINDOW_HEAD = 3
+const AUTONOMOUS_RUN_WINDOW_TAIL = 3
+// Turns revealed per press of the middle control. Small enough that one press
+// cannot restore the wall, large enough that walking a long run is not dozens
+// of presses.
+const AUTONOMOUS_RUN_WINDOW_STEP = 10
+
+/** Which slice of an opened run to draw, given how far the reader has already
+ *  walked the head down. [hidden] is the count the middle control stands for;
+ *  zero means every turn is drawn and no control belongs in the output.
+ *
+ *  A run only short enough to hide one turn is drawn whole: a control that
+ *  costs a press to save a single row is the same trade `foldAutonomousRuns`
+ *  declines at its own threshold. */
+export function autonomousRunWindow(
+  total: number,
+  headCount: number,
+): { head: number; tail: number; hidden: number } {
+  const tail = AUTONOMOUS_RUN_WINDOW_TAIL
+  if (total <= headCount + tail + 1) return { head: total, tail: 0, hidden: 0 }
+  return { head: headCount, tail, hidden: total - headCount - tail }
+}
+
 /** A run of consecutive autonomous turns behind one header. Starts closed for
  *  the same reason each turn does: the transcript's subject is the conversation
  *  these wakes sit between. Expanding renders the run's turns as the same rows
- *  they would be at top level, each still closed and each still its own turn. */
+ *  they would be at top level, each still closed and each still its own turn --
+ *  but only the window's worth of them, with the middle behind a control. */
 function AutonomousTurnRun({
   entries,
   showMetadata,
@@ -3831,10 +3861,25 @@ function AutonomousTurnRun({
   action?: ChatTranscriptAction
 }) {
   const [open, setOpen] = useState(false)
+  // Only ever grows, and only by a press: new turns arriving in an open run
+  // extend the tail, so the reader's walked-down head stays where they left it.
+  const [headCount, setHeadCount] = useState(AUTONOMOUS_RUN_WINDOW_HEAD)
   const first = timeLabel(entries[0]?.timestamp)
   const last = timeLabel(entries[entries.length - 1]?.timestamp)
   // Both ends or neither: a half range would read as a single point in time.
   const range = first && last ? (first === last ? first : `${first} ~ ${last}`) : null
+  const drawn = autonomousRunWindow(entries.length, headCount)
+  const turn = (entry: KeeperConversationEntry) => html`<${AutonomousTurnGroup}
+    key=${entry.id}
+    entry=${entry}
+    showMetadata=${showMetadata}
+    variant=${variant}
+    showSourceBadge=${showSourceBadge}
+    toolOutputsCoveredSinceMs=${toolOutputsCoveredSinceMs}
+    toolOutputsCoveredThroughMs=${toolOutputsCoveredThroughMs}
+    toolOutputHydrationContract=${toolOutputHydrationContract}
+    action=${action}
+  />`
   return html`
     <div class="chat-block-trace chat-auto-run ${open ? 'open' : ''}">
       <button
@@ -3850,17 +3895,17 @@ function AutonomousTurnRun({
       </button>
       ${open
         ? html`<div class="chat-auto-run-turns">
-            ${entries.map((entry) => html`<${AutonomousTurnGroup}
-              key=${entry.id}
-              entry=${entry}
-              showMetadata=${showMetadata}
-              variant=${variant}
-              showSourceBadge=${showSourceBadge}
-              toolOutputsCoveredSinceMs=${toolOutputsCoveredSinceMs}
-              toolOutputsCoveredThroughMs=${toolOutputsCoveredThroughMs}
-              toolOutputHydrationContract=${toolOutputHydrationContract}
-              action=${action}
-            />`)}
+            ${entries.slice(0, drawn.head).map(turn)}
+            ${drawn.hidden > 0
+              ? html`<button
+                  type="button"
+                  class="chat-auto-run-more"
+                  onClick=${() => setHeadCount((n) => n + AUTONOMOUS_RUN_WINDOW_STEP)}
+                >
+                  가운데 ${drawn.hidden}개 더 보기
+                </button>`
+              : null}
+            ${drawn.tail > 0 ? entries.slice(entries.length - drawn.tail).map(turn) : null}
           </div>`
         : null}
     </div>

--- a/dashboard/src/styles/chat-blocks-v2.css
+++ b/dashboard/src/styles/chat-blocks-v2.css
@@ -82,6 +82,25 @@
   background: var(--color-bg-surface);
 }
 
+/* Stands for the turns between the run's two drawn ends. Dashed rather than
+   solid so it reads as a gap in the sequence, not as another turn row. */
+.chat-auto-run-more {
+  width: 100%;
+  padding: 6px 12px;
+  border: 1px dashed var(--color-border-default);
+  border-radius: var(--r-1);
+  background: transparent;
+  color: var(--color-fg-secondary);
+  font-size: var(--fs-xs);
+  text-align: center;
+  cursor: pointer;
+  transition: background var(--t-fast);
+}
+
+.chat-auto-run-more:hover {
+  background: var(--color-bg-hover);
+}
+
 .chat-block-trace-hd {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## 무엇을

자율턴 run 을 펼쳤을 때 **가장 오래된 3개 + 가장 최근 3개**만 그리고, 그 사이는 한 번에 10개씩 여는 컨트롤 뒤에 둔다.

## 왜

접기는 이미 두 겹 있었다.

- `foldAutonomousRuns` — 연속 자율턴 3개 이상을 헤더 하나 뒤로 접음
- `AutonomousTurnGroup` — 각 턴은 닫힌 채 시작

둘 다 **얼마나 많은 헤더가 보이는지**와 **한 턴이 얼마나 높은지**를 제한하지만, **run 을 펼쳤을 때 몇 행이 생기는지**는 제한하지 않았다. `AutonomousTurnRun` 본문이 `entries.map(...)` 이라 아무도 안 보는 주말이 지나면 한 번의 클릭이 수백 행을 한 draw 에 만든다 — 접기가 없애려던 바로 그 벽이 클릭 한 번 뒤로 옮겨간 것.

## 어떻게

`GET /chat/history` 는 커서 없이 창 전체를 돌려주고 엔트리는 이미 클라이언트 메모리에 있다. 그래서 이건 **더 불러오기가 아니라 더 그리기**다 — 서버 변경 0, run 헤더의 총 개수 표시도 그대로 진실을 말한다.

- `AUTONOMOUS_RUN_WINDOW_HEAD` / `_TAIL` = 3 — 독자가 찾는 두 부분(run 이 시작한 지점, 키퍼가 방금 한 일)
- `AUTONOMOUS_RUN_WINDOW_STEP` = 10 — 한 번 눌러 벽이 복원되지 않을 만큼 작고, 긴 run 을 걷는 데 수십 번 누르지 않을 만큼 큼
- 숨길 턴이 1개뿐인 run 은 통째로 그린다. 한 행을 아끼려고 클릭을 요구하는 건 `foldAutonomousRuns` 가 자기 임계값에서 거절하는 것과 같은 거래다.

이 임계값(7 이하는 통째로) 덕분에 **기존 run 테스트는 경로가 바뀌지 않는다** — 6턴 run 을 6행으로 단언하는 테스트가 그대로 통과한다.

## 검증

로컬 실행:

- `vitest run src/components/chat/autonomous-turn-run.test.ts` — **13 passed** (기존 6 + 신규 7)
- `vitest run src/components/chat/` — **14 files / 283 tests passed** (인접 회귀 없음)
- `tsc --noEmit -p tsconfig.json` — exit 0
- `eslint` (변경 2파일) — exit 0

신규 테스트가 고정하는 계약:

| | 단언 |
|---|---|
| 렌더 | 30턴 run 을 열면 6행 + `가운데 24개 더 보기` 하나 |
| 렌더 | 7턴 run 은 통째로 7행, 컨트롤 없음 |
| 렌더 | 한 번 누르면 16행 / `가운데 14개 더 보기` |
| 렌더 | 다 열리면 컨트롤이 사라짐 |
| 순수 | `autonomousRunWindow` 경계 — 7 통째, 8 분할 |
| 순수 | head 가 tail 을 지나쳐도 `head+tail+hidden == total`, `hidden >= 0` |

`autonomousRunWindow` 를 export 해 렌더 없이 경계를 직접 고정했다 (`foldAutonomousRuns` 가 이미 쓰는 관례).

## 범위 밖 (의도적)

- **200 한계는 안 건드린다.** 자율턴의 진짜 상한은 `Keeper_raw_trace_retention.history_limit = 200` 이고 RFC-0358 §3 이 reader 와 retention 의 공유 경계로 선언했다. 그 너머 턴은 raw trace 파일이 **삭제**되므로 렌더를 늘려도 불러올 게 없다. 늘리려면 디스크 예산 결정이라 RFC 개정 사안이다.
- **direct chat 의 서버 페이지네이션은 별건.** `Keeper_chat_store.load_page` (RFC-0228 P1) 가 `?before` 커서와 `has_more` 를 이미 갖고 있는데 `/chat/history` 라우트는 커서 없는 `load` 만 부른다. 별도 PR 감.
- 가상화(virtualization) 미도입 — 창이 6~수십 행으로 유계라 필요 없다.

RFC-WAIVED: 대시보드 채팅 transcript 렌더링은 CLAUDE.md agent_delegation 이 RFC 를 요구하는 subsystem (credential / repo_manager / operator_control / dashboard credential-settings / hooks / workflow 문서) 어디에도 해당하지 않는다.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
