### PR TITLE
feat(proof): add closed capability case identity

### DIFF
--- a/lib/capability_proof/capability_proof.ml
+++ b/lib/capability_proof/capability_proof.ml
@@ -1,0 +1,328 @@
+type exact_lane =
+  | Librarian
+  | Hitl_auto_judge
+  | Board_attention
+  | Compaction
+
+type proof_role =
+  | Autonomous_keeper
+  | Completion_authority
+  | Verification
+  | Cross_verifier
+  | Exact_lane of exact_lane
+  | Fusion_panel
+  | Fusion_judge
+  | Fusion_meta_judge
+
+type capability_case =
+  | Provider_probe
+  | Autonomous_turn
+  | Verification_run
+  | Cross_verification
+  | Librarian_run
+  | Hitl_auto_judge_run
+  | Board_attention_run
+  | Compaction_run
+  | Fusion_panel_run
+  | Fusion_judge_run
+  | Fusion_meta_judge_run
+  | Queue_fifo
+  | Scheduler_occurrence
+  | Board_comment
+  | Task_lifecycle
+  | Goal_lifecycle
+  | Tool_serial
+  | Tool_parallel
+  | Tool_batch
+  | Async_lifecycle
+  | Sandbox_containment
+  | Broadcast_turn
+  | Stream_replay
+  | Restart_succession
+
+type scenario =
+  | Nominal
+  | Invalid_input
+  | Provider_rejected
+  | Effect_denied
+  | Effect_deferred
+  | Cancelled
+  | Restart_recovery
+  | Outcome_unknown
+  | Duplicate_delivery
+  | Blocked_head
+
+type protocol =
+  | Agent_core_http
+  | Official_client
+  | Mcp
+  | Dashboard_http
+  | Sse
+  | Websocket
+  | Browser
+  | Durable_store
+  | Domain_api
+
+type field =
+  | Runtime_id
+  | Model_id
+  | Build_commit
+  | Config_revision
+
+type create_error = Blank_field of field
+
+type case_id = string
+
+type t =
+  { runtime_id : string
+  ; model_id : string option
+  ; role : proof_role
+  ; capability : capability_case
+  ; scenario : scenario
+  ; protocol : protocol
+  ; build_commit : string option
+  ; config_revision : string option
+  ; case_id : case_id
+  }
+
+let exact_lane_to_string = function
+  | Librarian -> "librarian"
+  | Hitl_auto_judge -> "hitl_auto_judge"
+  | Board_attention -> "board_attention"
+  | Compaction -> "compaction"
+;;
+
+let proof_role_to_string = function
+  | Autonomous_keeper -> "autonomous_keeper"
+  | Completion_authority -> "completion_authority"
+  | Verification -> "verification"
+  | Cross_verifier -> "cross_verifier"
+  | Exact_lane lane -> "exact_lane:" ^ exact_lane_to_string lane
+  | Fusion_panel -> "fusion_panel"
+  | Fusion_judge -> "fusion_judge"
+  | Fusion_meta_judge -> "fusion_meta_judge"
+;;
+
+let capability_case_to_string = function
+  | Provider_probe -> "provider_probe"
+  | Autonomous_turn -> "autonomous_turn"
+  | Verification_run -> "verification_run"
+  | Cross_verification -> "cross_verification"
+  | Librarian_run -> "librarian_run"
+  | Hitl_auto_judge_run -> "hitl_auto_judge_run"
+  | Board_attention_run -> "board_attention_run"
+  | Compaction_run -> "compaction_run"
+  | Fusion_panel_run -> "fusion_panel_run"
+  | Fusion_judge_run -> "fusion_judge_run"
+  | Fusion_meta_judge_run -> "fusion_meta_judge_run"
+  | Queue_fifo -> "queue_fifo"
+  | Scheduler_occurrence -> "scheduler_occurrence"
+  | Board_comment -> "board_comment"
+  | Task_lifecycle -> "task_lifecycle"
+  | Goal_lifecycle -> "goal_lifecycle"
+  | Tool_serial -> "tool_serial"
+  | Tool_parallel -> "tool_parallel"
+  | Tool_batch -> "tool_batch"
+  | Async_lifecycle -> "async_lifecycle"
+  | Sandbox_containment -> "sandbox_containment"
+  | Broadcast_turn -> "broadcast_turn"
+  | Stream_replay -> "stream_replay"
+  | Restart_succession -> "restart_succession"
+;;
+
+let scenario_to_string = function
+  | Nominal -> "nominal"
+  | Invalid_input -> "invalid_input"
+  | Provider_rejected -> "provider_rejected"
+  | Effect_denied -> "effect_denied"
+  | Effect_deferred -> "effect_deferred"
+  | Cancelled -> "cancelled"
+  | Restart_recovery -> "restart_recovery"
+  | Outcome_unknown -> "outcome_unknown"
+  | Duplicate_delivery -> "duplicate_delivery"
+  | Blocked_head -> "blocked_head"
+;;
+
+let protocol_to_string = function
+  | Agent_core_http -> "agent_core_http"
+  | Official_client -> "official_client"
+  | Mcp -> "mcp"
+  | Dashboard_http -> "dashboard_http"
+  | Sse -> "sse"
+  | Websocket -> "websocket"
+  | Browser -> "browser"
+  | Durable_store -> "durable_store"
+  | Domain_api -> "domain_api"
+;;
+
+let field_to_string = function
+  | Runtime_id -> "runtime_id"
+  | Model_id -> "model_id"
+  | Build_commit -> "build_commit"
+  | Config_revision -> "config_revision"
+;;
+
+let create_error_to_string = function
+  | Blank_field field -> "blank_field:" ^ field_to_string field
+;;
+
+let all_proof_roles =
+  [ Autonomous_keeper
+  ; Completion_authority
+  ; Verification
+  ; Cross_verifier
+  ; Exact_lane Librarian
+  ; Exact_lane Hitl_auto_judge
+  ; Exact_lane Board_attention
+  ; Exact_lane Compaction
+  ; Fusion_panel
+  ; Fusion_judge
+  ; Fusion_meta_judge
+  ]
+;;
+
+let all_capability_cases =
+  [ Provider_probe
+  ; Autonomous_turn
+  ; Verification_run
+  ; Cross_verification
+  ; Librarian_run
+  ; Hitl_auto_judge_run
+  ; Board_attention_run
+  ; Compaction_run
+  ; Fusion_panel_run
+  ; Fusion_judge_run
+  ; Fusion_meta_judge_run
+  ; Queue_fifo
+  ; Scheduler_occurrence
+  ; Board_comment
+  ; Task_lifecycle
+  ; Goal_lifecycle
+  ; Tool_serial
+  ; Tool_parallel
+  ; Tool_batch
+  ; Async_lifecycle
+  ; Sandbox_containment
+  ; Broadcast_turn
+  ; Stream_replay
+  ; Restart_succession
+  ]
+;;
+
+let all_scenarios =
+  [ Nominal
+  ; Invalid_input
+  ; Provider_rejected
+  ; Effect_denied
+  ; Effect_deferred
+  ; Cancelled
+  ; Restart_recovery
+  ; Outcome_unknown
+  ; Duplicate_delivery
+  ; Blocked_head
+  ]
+;;
+
+let all_protocols =
+  [ Agent_core_http
+  ; Official_client
+  ; Mcp
+  ; Dashboard_http
+  ; Sse
+  ; Websocket
+  ; Browser
+  ; Durable_store
+  ; Domain_api
+  ]
+;;
+
+let nonblank field value =
+  if String.trim value = "" then Error (Blank_field field) else Ok value
+;;
+
+let optional_nonblank field = function
+  | None -> Ok None
+  | Some value -> Result.map (fun value -> Some value) (nonblank field value)
+;;
+
+let length_prefixed value = Printf.sprintf "%d:%s" (String.length value) value
+
+let optional_material = function
+  | None -> "n"
+  | Some value -> "s" ^ length_prefixed value
+;;
+
+let canonical_material
+      ~runtime_id
+      ~model_id
+      ~role
+      ~capability
+      ~scenario
+      ~protocol
+      ~build_commit
+      ~config_revision
+  =
+  [ "masc-capability-proof-case-v1"
+  ; length_prefixed runtime_id
+  ; optional_material model_id
+  ; length_prefixed (proof_role_to_string role)
+  ; length_prefixed (capability_case_to_string capability)
+  ; length_prefixed (scenario_to_string scenario)
+  ; length_prefixed (protocol_to_string protocol)
+  ; optional_material build_commit
+  ; optional_material config_revision
+  ]
+  |> String.concat ""
+;;
+
+let ( let* ) = Result.bind
+
+let create
+      ~runtime_id
+      ~model_id
+      ~role
+      ~capability
+      ~scenario
+      ~protocol
+      ~build_commit
+      ~config_revision
+  =
+  let* runtime_id = nonblank Runtime_id runtime_id in
+  let* model_id = optional_nonblank Model_id model_id in
+  let* build_commit = optional_nonblank Build_commit build_commit in
+  let* config_revision = optional_nonblank Config_revision config_revision in
+  let material =
+    canonical_material
+      ~runtime_id
+      ~model_id
+      ~role
+      ~capability
+      ~scenario
+      ~protocol
+      ~build_commit
+      ~config_revision
+  in
+  let case_id = "cpc_" ^ Digestif.SHA256.(digest_string material |> to_hex) in
+  Ok
+    { runtime_id
+    ; model_id
+    ; role
+    ; capability
+    ; scenario
+    ; protocol
+    ; build_commit
+    ; config_revision
+    ; case_id
+    }
+;;
+
+let case_id t = t.case_id
+let case_id_to_string value = value
+let runtime_id t = t.runtime_id
+let model_id t = t.model_id
+let role t = t.role
+let capability t = t.capability
+let scenario t = t.scenario
+let protocol t = t.protocol
+let build_commit t = t.build_commit
+let config_revision t = t.config_revision

--- a/lib/capability_proof/capability_proof.mli
+++ b/lib/capability_proof/capability_proof.mli
@@ -1,0 +1,119 @@
+(** Closed identity contract for one capability-proof matrix cell.
+
+    This module contains no runtime discovery or execution effects. Callers
+    resolve those facts first, then create an immutable case identity here. *)
+
+type exact_lane =
+  | Librarian
+  | Hitl_auto_judge
+  | Board_attention
+  | Compaction
+
+type proof_role =
+  | Autonomous_keeper
+  | Completion_authority
+  | Verification
+  | Cross_verifier
+  | Exact_lane of exact_lane
+  | Fusion_panel
+  | Fusion_judge
+  | Fusion_meta_judge
+
+type capability_case =
+  | Provider_probe
+  | Autonomous_turn
+  | Verification_run
+  | Cross_verification
+  | Librarian_run
+  | Hitl_auto_judge_run
+  | Board_attention_run
+  | Compaction_run
+  | Fusion_panel_run
+  | Fusion_judge_run
+  | Fusion_meta_judge_run
+  | Queue_fifo
+  | Scheduler_occurrence
+  | Board_comment
+  | Task_lifecycle
+  | Goal_lifecycle
+  | Tool_serial
+  | Tool_parallel
+  | Tool_batch
+  | Async_lifecycle
+  | Sandbox_containment
+  | Broadcast_turn
+  | Stream_replay
+  | Restart_succession
+
+type scenario =
+  | Nominal
+  | Invalid_input
+  | Provider_rejected
+  | Effect_denied
+  | Effect_deferred
+  | Cancelled
+  | Restart_recovery
+  | Outcome_unknown
+  | Duplicate_delivery
+  | Blocked_head
+
+type protocol =
+  | Agent_core_http
+  | Official_client
+  | Mcp
+  | Dashboard_http
+  | Sse
+  | Websocket
+  | Browser
+  | Durable_store
+  | Domain_api
+
+type field =
+  | Runtime_id
+  | Model_id
+  | Build_commit
+  | Config_revision
+
+type create_error = Blank_field of field
+
+type t
+type case_id = private string
+
+val create
+  :  runtime_id:string
+  -> model_id:string option
+  -> role:proof_role
+  -> capability:capability_case
+  -> scenario:scenario
+  -> protocol:protocol
+  -> build_commit:string option
+  -> config_revision:string option
+  -> (t, create_error) result
+(** Rejects blank present values. Exact absence remains [None] and is encoded
+    distinctly; the constructor never fabricates an unknown model, build, or
+    configuration revision. *)
+
+val case_id : t -> case_id
+val case_id_to_string : case_id -> string
+
+val runtime_id : t -> string
+val model_id : t -> string option
+val role : t -> proof_role
+val capability : t -> capability_case
+val scenario : t -> scenario
+val protocol : t -> protocol
+val build_commit : t -> string option
+val config_revision : t -> string option
+
+val exact_lane_to_string : exact_lane -> string
+val proof_role_to_string : proof_role -> string
+val capability_case_to_string : capability_case -> string
+val scenario_to_string : scenario -> string
+val protocol_to_string : protocol -> string
+val create_error_to_string : create_error -> string
+
+val all_proof_roles : proof_role list
+val all_capability_cases : capability_case list
+val all_scenarios : scenario list
+val all_protocols : protocol list
+(** Closed variant inventories used by manifest generators. *)

--- a/lib/capability_proof/capability_proof.mli
+++ b/lib/capability_proof/capability_proof.mli
@@ -105,10 +105,6 @@ val protocol : t -> protocol
 val build_commit : t -> string option
 val config_revision : t -> string option
 
-val exact_lane_to_string : exact_lane -> string
-val proof_role_to_string : proof_role -> string
-val capability_case_to_string : capability_case -> string
-val scenario_to_string : scenario -> string
 val protocol_to_string : protocol -> string
 val create_error_to_string : create_error -> string
 

--- a/lib/capability_proof/dune
+++ b/lib/capability_proof/dune
@@ -1,0 +1,10 @@
+(include_subdirs no)
+
+(library
+ (name masc_capability_proof)
+ (public_name masc.capability_proof)
+ (wrapped false)
+ (modules capability_proof)
+ (flags
+  (:standard -w +4 -w +33))
+ (libraries digestif))

--- a/test/capability_proof/dune
+++ b/test/capability_proof/dune
@@ -1,0 +1,4 @@
+(test
+ (name test_capability_proof)
+ (modules test_capability_proof)
+ (libraries alcotest masc.capability_proof))

--- a/test/capability_proof/test_capability_proof.ml
+++ b/test/capability_proof/test_capability_proof.ml
@@ -1,0 +1,98 @@
+open Alcotest
+open Capability_proof
+
+let create
+      ?(runtime_id = "ollama_cloud.deepseek-v4-flash")
+      ?(model_id = Some "deepseek-v4-flash")
+      ?(role = Autonomous_keeper)
+      ?(capability = Autonomous_turn)
+      ?(scenario = Nominal)
+      ?(protocol = Agent_core_http)
+      ?(build_commit = Some "6959248d23")
+      ?(config_revision = Some "sha256:runtime-config")
+      ()
+  =
+  Capability_proof.create
+    ~runtime_id
+    ~model_id
+    ~role
+    ~capability
+    ~scenario
+    ~protocol
+    ~build_commit
+    ~config_revision
+;;
+
+let id result =
+  match result with
+  | Ok case -> case |> case_id |> case_id_to_string
+  | Error error -> failf "unexpected create error: %s" (create_error_to_string error)
+;;
+
+let test_identity_is_deterministic () =
+  check string "same inputs have one identity" (id (create ())) (id (create ()))
+;;
+
+let test_absence_is_not_fabricated () =
+  match create ~model_id:None ~build_commit:None ~config_revision:None () with
+  | Error error -> failf "unexpected create error: %s" (create_error_to_string error)
+  | Ok case ->
+    check (option string) "model remains absent" None (model_id case);
+    check (option string) "build remains absent" None (build_commit case);
+    check (option string) "config revision remains absent" None (config_revision case)
+;;
+
+let test_present_and_absent_values_have_distinct_identity () =
+  check bool "model absence changes identity" true (id (create ~model_id:None ()) <> id (create ()))
+;;
+
+let test_blank_values_are_rejected () =
+  let cases =
+    [ Blank_field Runtime_id, create ~runtime_id:" \t" ()
+    ; Blank_field Model_id, create ~model_id:(Some "") ()
+    ; Blank_field Build_commit, create ~build_commit:(Some " ") ()
+    ; Blank_field Config_revision, create ~config_revision:(Some "\n") ()
+    ]
+  in
+  List.iter
+    (fun (expected, actual) ->
+      match actual with
+      | Error error ->
+        check string "typed blank field" (create_error_to_string expected) (create_error_to_string error)
+      | Ok case -> failf "blank field produced %s" (case |> case_id |> case_id_to_string))
+    cases
+;;
+
+let test_closed_inventory_has_unique_case_ids () =
+  let seen = Hashtbl.create 32768 in
+  let collisions = ref [] in
+  List.iter
+    (fun role ->
+      List.iter
+        (fun capability ->
+          List.iter
+            (fun scenario ->
+              List.iter
+                (fun protocol ->
+                  let case_id = id (create ~role ~capability ~scenario ~protocol ()) in
+                  if Hashtbl.mem seen case_id then collisions := case_id :: !collisions;
+                  Hashtbl.add seen case_id ())
+                all_protocols)
+            all_scenarios)
+        all_capability_cases)
+    all_proof_roles;
+  check (list string) "no matrix identity collisions" [] (List.rev !collisions)
+;;
+
+let () =
+  run
+    "capability proof identity"
+    [ ( "identity"
+      , [ test_case "deterministic" `Quick test_identity_is_deterministic
+        ; test_case "absence preserved" `Quick test_absence_is_not_fabricated
+        ; test_case "absence is distinct" `Quick test_present_and_absent_values_have_distinct_identity
+        ; test_case "blank rejected" `Quick test_blank_values_are_rejected
+        ; test_case "closed inventory unique" `Quick test_closed_inventory_has_unique_case_ids
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- add a pure capability-proof leaf with closed role, capability, scenario, and protocol sums
- derive a deterministic SHA-256 case identity from the full matrix key
- preserve unavailable model, build, and config provenance as None instead of fabricated labels

## Validation
- ocamlformat --check on changed OCaml files
- ocamlc -stop-after parsing on implementation, interface, and focused test
- git diff --check and conflict-marker scan
- local Dune build intentionally not run per campaign instruction; CI is not yet evaluated

## Stack
Root PR for the capability evidence stack. Follow-ups add typed evidence/verdict requirements and manifest generation. No runtime discovery, live config mutation, or dashboard effect is included here.