### PR TITLE
feat(runtime): forward Agent Core execution store

### DIFF
--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -1001,6 +1001,7 @@ let run_blocks
     ?(on_event : (Agent_core.Types.sse_event -> unit) option)
     ?(on_yield : (unit -> unit) option)
     ?(on_resume : (unit -> unit) option)
+    ?execution_store
     ?(agent_ref : Agent_core.Agent.t option ref option)
     ?cooperative_yield_probe
     (goal_blocks : Agent_core.Types.content_block list)
@@ -1069,6 +1070,7 @@ let run_blocks
                    ?clock
                    ?on_yield
                    ?on_resume
+                   ?execution_store
                    ~on_event:cb
                    agent
                    goal_blocks
@@ -1078,6 +1080,7 @@ let run_blocks
                    ?clock
                    ?on_yield
                    ?on_resume
+                   ?execution_store
                    agent
                    goal_blocks)
               |> Result.map (fun response -> `Completed response)
@@ -1106,6 +1109,7 @@ let run_blocks
                   ?clock
                   ?on_yield
                   ?on_resume
+                  ?execution_store
                   ~api_strategy
                   ~on_tool_boundary
                   agent
@@ -1302,12 +1306,13 @@ let run
     ?on_event
     ?on_yield
     ?on_resume
+    ?execution_store
     ?agent_ref
     ?cooperative_yield_probe
     (goal : string)
   : (run_result, Agent_core.Error.t) result =
   run_blocks ~sw ~net ~config ?agent_core_checkpoint ?on_event ?on_yield ?on_resume
-    ?agent_ref ?cooperative_yield_probe [Agent_core.Types.Text goal]
+    ?execution_store ?agent_ref ?cooperative_yield_probe [Agent_core.Types.Text goal]
 
 (* ================================================================ *)
 (* Convenience: run_with_masc_tools                                  *)

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -351,6 +351,7 @@ val run :
   ?on_event:(Agent_core.Types.sse_event -> unit) ->
   ?on_yield:(unit -> unit) ->
   ?on_resume:(unit -> unit) ->
+  ?execution_store:Agent_core.Agent.execution_store ->
   ?agent_ref:Agent_core.Agent.t option ref ->
   ?cooperative_yield_probe:cooperative_yield_probe ->
   string ->
@@ -369,11 +370,15 @@ val run_blocks :
   ?on_event:(Agent_core.Types.sse_event -> unit) ->
   ?on_yield:(unit -> unit) ->
   ?on_resume:(unit -> unit) ->
+  ?execution_store:Agent_core.Agent.execution_store ->
   ?agent_ref:Agent_core.Agent.t option ref ->
   ?cooperative_yield_probe:cooperative_yield_probe ->
   Agent_core.Types.content_block list ->
   (run_result, Agent_core.Error.t) result
-(** Runs an Agent Core agent against structured user-authored content blocks. *)
+(** Runs an Agent Core agent against structured user-authored content blocks.
+    When [execution_store] is supplied, the caller-owned store is forwarded
+    unchanged to the one Agent Core execution path selected for this API call.
+    The store remains scoped to one API call and must not be reused. *)
 
 val run_with_masc_tools :
   sw:Eio.Switch.t ->

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -251,6 +251,7 @@ normal_targets=(
   @test/runtest-test_exec_policy_cwd_hint
   @test/runtest-test_server_runtime_startup_maintenance
   @test/runtest-test_runtime_per_keeper_routing
+  @test/runtest-test_runtime_agent_execution_store_source
   @test/runtest-test_ide_bridge
   @test/runtest-test_dashboard_workspace
   @test/runtest-test_host_fd_pressure_poller

--- a/test/dune
+++ b/test/dune
@@ -1951,6 +1951,8 @@
 
 (include stanzas/test_runtime_agent_core_eio_context_classify.inc)
 
+(include stanzas/test_runtime_agent_execution_store_source.inc)
+
 
 (include stanzas/test_runtime_model_temperature_toml.inc)
 

--- a/test/stanzas/test_runtime_agent_execution_store_source.inc
+++ b/test/stanzas/test_runtime_agent_execution_store_source.inc
@@ -1,0 +1,9 @@
+; Runtime_agent must forward one caller-owned Agent Core execution store to
+; every execution strategy selected by run_blocks.
+
+(test
+ (name test_runtime_agent_execution_store_source)
+ (modules test_runtime_agent_execution_store_source)
+ (deps
+  ../lib/runtime/runtime_agent.ml
+  ../lib/runtime/runtime_agent.mli))

--- a/test/test_runtime_agent_execution_store_source.ml
+++ b/test/test_runtime_agent_execution_store_source.ml
@@ -1,0 +1,85 @@
+(* Keep Runtime_agent's caller-owned execution-store contract present on every
+   Agent Core execution strategy without constructing a second store or
+   silently dropping the store when streaming or cooperative yield is used. *)
+
+let read_file path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> In_channel.input_all ic)
+;;
+
+let normalize_whitespace input =
+  let output = Buffer.create (String.length input) in
+  let pending_space = ref false in
+  String.iter
+    (function
+      | ' ' | '\n' | '\r' | '\t' -> pending_space := Buffer.length output > 0
+      | char ->
+        if !pending_space then Buffer.add_char output ' ';
+        pending_space := false;
+        Buffer.add_char output char)
+    input;
+  Buffer.contents output
+;;
+
+let contains haystack needle =
+  let haystack_length = String.length haystack in
+  let needle_length = String.length needle in
+  let rec loop offset =
+    if offset + needle_length > haystack_length
+    then false
+    else if String.sub haystack offset needle_length = needle
+    then true
+    else loop (offset + 1)
+  in
+  needle_length = 0 || loop 0
+;;
+
+let assert_contains ~label source expected =
+  if not (contains source expected)
+  then failwith (Printf.sprintf "[%s] expected source to contain %S" label expected)
+;;
+
+let resolve_source relative =
+  let parent path = Filename.dirname path in
+  let project_root = parent (parent (parent (parent Sys.executable_name))) in
+  let candidates =
+    [ relative; Filename.concat project_root relative; Filename.concat ".." relative ]
+  in
+  match List.find_opt Sys.file_exists candidates with
+  | Some path -> normalize_whitespace (read_file path)
+  | None ->
+    failwith
+      (Printf.sprintf
+         "could not resolve %s (cwd=%s, exe=%s)"
+         relative
+         (Sys.getcwd ())
+         Sys.executable_name)
+;;
+
+let () =
+  let implementation = resolve_source "lib/runtime/runtime_agent.ml" in
+  let interface = resolve_source "lib/runtime/runtime_agent.mli" in
+  assert_contains
+    ~label:"stream execution"
+    implementation
+    "Agent_core.Agent.run_stream_blocks ~sw ?clock ?on_yield ?on_resume ?execution_store ~on_event:cb";
+  assert_contains
+    ~label:"sync execution"
+    implementation
+    "Agent_core.Agent.run_blocks ~sw ?clock ?on_yield ?on_resume ?execution_store agent";
+  assert_contains
+    ~label:"cooperative execution"
+    implementation
+    "Agent_core.Agent.Advanced.run_blocks ~sw ?clock ?on_yield ?on_resume ?execution_store ~api_strategy";
+  assert_contains
+    ~label:"string wrapper"
+    implementation
+    "run_blocks ~sw ~net ~config ?agent_core_checkpoint ?on_event ?on_yield ?on_resume ?execution_store ?agent_ref";
+  assert_contains
+    ~label:"public interface"
+    interface
+    "?on_resume:(unit -> unit) -> ?execution_store:Agent_core.Agent.execution_store -> ?agent_ref:Agent_core.Agent.t option ref ->";
+  print_endline "test_runtime_agent_execution_store_source: OK"
+;;


### PR DESCRIPTION
## Summary

- add an optional caller-owned `Agent_core.Agent.execution_store` to `Runtime_agent.run` and `run_blocks`
- forward that same store unchanged to the selected sync, streaming, or cooperative Agent Core execution path
- add a focused source ratchet covering the public interface, string wrapper, and all three execution strategies

## Why

`Runtime_agent` was the MASC boundary that selected `Agent.run_blocks`, `Agent.run_stream_blocks`, or `Agent.Advanced.run_blocks`, but it did not expose or forward Agent Core's durable execution store. Callers therefore could not bind an Execution Journal to this boundary.

This PR only establishes the injection contract. It deliberately does not construct a store inside `Runtime_agent`: Agent Core requires an application-lifetime execution runtime plus a caller-owned fresh directory, locator persistence callback, and terminal-disposition callback.

## Validation

Passed locally:

- `ocaml test/test_runtime_agent_execution_store_source.ml`
- `ocamlc -stop-after parsing` for the changed `.ml` and `.mli` files
- `ocamlformat 0.29.0 --check` for the changed OCaml files
- `git diff --check`
- conflict-marker scan over all changed files

Not yet verified:

- no local Dune build or Dune test was run, per the implementation constraint
- GitHub CI is not yet verified
- no live `/Users/dancer/me/.masc` execution was changed or exercised

## Stack dependency

- base: `main@6959248d23abe7e2574038c86cca3931618840c1`
- head: `e34a558e462ba3ac465b45cb9980191145162827`
- this is the root execution-store injection slice
- follow-up stacked PRs must own application-lifetime execution-runtime creation, per-call store directory and locator persistence, restart reconciliation, and only then the separate direct-writer hard cut

## Remaining gaps

- no production caller creates or supplies the store yet
- recovery locator and terminal disposition are not persisted by MASC
- `run_with_masc_tools` does not expose this option in this minimal slice
- existing Raw trace, Event bus, and legacy durable writers remain unchanged
- Dashboard execution correlation and stateful fleet proof remain follow-ups
