### PR TITLE
feat(proof): require three-path evidence verdicts

### DIFF
--- a/lib/capability_proof/capability_proof.ml
+++ b/lib/capability_proof/capability_proof.ml
@@ -457,10 +457,8 @@ type failure_kind =
   | Gate_settlement_failure
   | Domain_receipt_failure
 
-type runtime_role_policy = Agentworld_runtime_librarian_only
-
 type unsupported_reason =
-  | Runtime_role_policy of runtime_role_policy
+  | Runtime_role_not_declared of proof_role
   | Protocol_not_supported of protocol
   | Capability_not_declared of capability_case
 
@@ -491,12 +489,9 @@ let failure_kind_to_string = function
   | Domain_receipt_failure -> "domain_receipt_failure"
 ;;
 
-let runtime_role_policy_to_string = function
-  | Agentworld_runtime_librarian_only -> "agentworld_runtime_librarian_only"
-;;
-
 let unsupported_reason_to_string = function
-  | Runtime_role_policy policy -> "runtime_role_policy:" ^ runtime_role_policy_to_string policy
+  | Runtime_role_not_declared role ->
+    "runtime_role_not_declared:" ^ proof_role_to_string role
   | Protocol_not_supported protocol -> "protocol_not_supported:" ^ protocol_to_string protocol
   | Capability_not_declared capability ->
     "capability_not_declared:" ^ capability_case_to_string capability

--- a/lib/capability_proof/capability_proof.ml
+++ b/lib/capability_proof/capability_proof.ml
@@ -326,3 +326,218 @@ let scenario t = t.scenario
 let protocol t = t.protocol
 let build_commit t = t.build_commit
 let config_revision t = t.config_revision
+
+type proof_path =
+  | Hermetic
+  | Isolated
+  | Fleet
+
+type evidence_kind =
+  | Journal
+  | Receipt
+  | Durable_queue
+  | Gate
+  | Domain_store
+  | Api
+  | Sse_trace
+  | Browser_screenshot
+  | Config_snapshot
+  | Deployment_identity
+
+type evidence_ref =
+  { path : proof_path
+  ; kind : evidence_kind
+  ; locator : string
+  ; sha256 : string
+  ; captured_at : string
+  }
+
+type evidence_error =
+  | Blank_locator
+  | Blank_captured_at
+  | Invalid_sha256
+
+let proof_path_to_string = function
+  | Hermetic -> "hermetic"
+  | Isolated -> "isolated"
+  | Fleet -> "fleet"
+;;
+
+let evidence_kind_to_string = function
+  | Journal -> "journal"
+  | Receipt -> "receipt"
+  | Durable_queue -> "durable_queue"
+  | Gate -> "gate"
+  | Domain_store -> "domain_store"
+  | Api -> "api"
+  | Sse_trace -> "sse_trace"
+  | Browser_screenshot -> "browser_screenshot"
+  | Config_snapshot -> "config_snapshot"
+  | Deployment_identity -> "deployment_identity"
+;;
+
+let evidence_error_to_string = function
+  | Blank_locator -> "blank_locator"
+  | Blank_captured_at -> "blank_captured_at"
+  | Invalid_sha256 -> "invalid_sha256"
+;;
+
+let all_proof_paths = [ Hermetic; Isolated; Fleet ]
+
+let is_lower_hex = function
+  | '0' .. '9' | 'a' .. 'f' -> true
+  | _ -> false
+;;
+
+let valid_sha256 value = String.length value = 64 && String.for_all is_lower_hex value
+
+let create_evidence_ref ~path ~kind ~locator ~sha256 ~captured_at =
+  if String.trim locator = ""
+  then Error Blank_locator
+  else if not (valid_sha256 sha256)
+  then Error Invalid_sha256
+  else if String.trim captured_at = ""
+  then Error Blank_captured_at
+  else Ok { path; kind; locator; sha256; captured_at }
+;;
+
+let evidence_path evidence = evidence.path
+let evidence_kind evidence = evidence.kind
+let evidence_locator evidence = evidence.locator
+let evidence_sha256 evidence = evidence.sha256
+let evidence_captured_at evidence = evidence.captured_at
+
+type evidence_bundle = evidence_ref list
+
+type bundle_error =
+  | Missing_proof_paths of proof_path list
+  | Duplicate_evidence_ref of string
+
+let evidence_identity evidence =
+  String.concat
+    "\000"
+    [ proof_path_to_string evidence.path
+    ; evidence_kind_to_string evidence.kind
+    ; evidence.locator
+    ; evidence.sha256
+    ; evidence.captured_at
+    ]
+;;
+
+let rec first_duplicate seen = function
+  | [] -> None
+  | evidence :: rest ->
+    let identity = evidence_identity evidence in
+    if List.mem identity seen then Some evidence.locator else first_duplicate (identity :: seen) rest
+;;
+
+let create_evidence_bundle refs =
+  match first_duplicate [] refs with
+  | Some locator -> Error (Duplicate_evidence_ref locator)
+  | None ->
+    let missing =
+      List.filter
+        (fun path -> not (List.exists (fun evidence -> evidence.path = path) refs))
+        all_proof_paths
+    in
+    if missing = [] then Ok refs else Error (Missing_proof_paths missing)
+;;
+
+let evidence_bundle_refs bundle = bundle
+
+let bundle_error_to_string = function
+  | Missing_proof_paths paths ->
+    "missing_proof_paths:" ^ String.concat "," (List.map proof_path_to_string paths)
+  | Duplicate_evidence_ref locator -> "duplicate_evidence_ref:" ^ locator
+;;
+
+type failure_kind =
+  | Contract_violation
+  | Provider_failure
+  | Infrastructure_failure
+  | Evidence_mismatch
+  | Stream_replay_duplicate
+  | Queue_order_violation
+  | Sandbox_escape
+  | Scheduler_settlement_failure
+  | Gate_settlement_failure
+  | Domain_receipt_failure
+
+type runtime_role_policy = Local_agentworld_librarian_only
+
+type unsupported_reason =
+  | Runtime_role_policy of runtime_role_policy
+  | Protocol_not_supported of protocol
+  | Capability_not_declared of capability_case
+
+type blocker_ref = string
+
+type proof_result =
+  | Passed of evidence_bundle
+  | Failed of failure_kind * evidence_ref list
+  | Unsupported of unsupported_reason
+  | Not_run
+  | Blocked of blocker_ref
+
+type result_error =
+  | Invalid_evidence_bundle of bundle_error
+  | Failure_without_evidence
+  | Blank_blocker_ref
+
+let failure_kind_to_string = function
+  | Contract_violation -> "contract_violation"
+  | Provider_failure -> "provider_failure"
+  | Infrastructure_failure -> "infrastructure_failure"
+  | Evidence_mismatch -> "evidence_mismatch"
+  | Stream_replay_duplicate -> "stream_replay_duplicate"
+  | Queue_order_violation -> "queue_order_violation"
+  | Sandbox_escape -> "sandbox_escape"
+  | Scheduler_settlement_failure -> "scheduler_settlement_failure"
+  | Gate_settlement_failure -> "gate_settlement_failure"
+  | Domain_receipt_failure -> "domain_receipt_failure"
+;;
+
+let runtime_role_policy_to_string = function
+  | Local_agentworld_librarian_only -> "local_agentworld_librarian_only"
+;;
+
+let unsupported_reason_to_string = function
+  | Runtime_role_policy policy -> "runtime_role_policy:" ^ runtime_role_policy_to_string policy
+  | Protocol_not_supported protocol -> "protocol_not_supported:" ^ protocol_to_string protocol
+  | Capability_not_declared capability ->
+    "capability_not_declared:" ^ capability_case_to_string capability
+;;
+
+let passed refs =
+  match create_evidence_bundle refs with
+  | Ok bundle -> Ok (Passed bundle)
+  | Error error -> Error (Invalid_evidence_bundle error)
+;;
+
+let failed kind = function
+  | [] -> Error Failure_without_evidence
+  | refs -> Ok (Failed (kind, refs))
+;;
+
+let unsupported reason = Unsupported reason
+let not_run = Not_run
+
+let blocked blocker =
+  if String.trim blocker = "" then Error Blank_blocker_ref else Ok (Blocked blocker)
+;;
+
+let blocker_ref_to_string blocker = blocker
+
+let proof_result_to_string = function
+  | Passed _ -> "passed"
+  | Failed (kind, _) -> "failed:" ^ failure_kind_to_string kind
+  | Unsupported reason -> "unsupported:" ^ unsupported_reason_to_string reason
+  | Not_run -> "not_run"
+  | Blocked blocker -> "blocked:" ^ blocker
+;;
+
+let result_error_to_string = function
+  | Invalid_evidence_bundle error -> "invalid_evidence_bundle:" ^ bundle_error_to_string error
+  | Failure_without_evidence -> "failure_without_evidence"
+  | Blank_blocker_ref -> "blank_blocker_ref"
+;;

--- a/lib/capability_proof/capability_proof.ml
+++ b/lib/capability_proof/capability_proof.ml
@@ -458,7 +458,6 @@ type failure_kind =
   | Domain_receipt_failure
 
 type unsupported_reason =
-  | Runtime_role_not_declared of proof_role
   | Protocol_not_supported of protocol
   | Capability_not_declared of capability_case
 
@@ -490,8 +489,6 @@ let failure_kind_to_string = function
 ;;
 
 let unsupported_reason_to_string = function
-  | Runtime_role_not_declared role ->
-    "runtime_role_not_declared:" ^ proof_role_to_string role
   | Protocol_not_supported protocol -> "protocol_not_supported:" ^ protocol_to_string protocol
   | Capability_not_declared capability ->
     "capability_not_declared:" ^ capability_case_to_string capability

--- a/lib/capability_proof/capability_proof.ml
+++ b/lib/capability_proof/capability_proof.ml
@@ -457,7 +457,7 @@ type failure_kind =
   | Gate_settlement_failure
   | Domain_receipt_failure
 
-type runtime_role_policy = Local_agentworld_librarian_only
+type runtime_role_policy = Agentworld_runtime_librarian_only
 
 type unsupported_reason =
   | Runtime_role_policy of runtime_role_policy
@@ -492,7 +492,7 @@ let failure_kind_to_string = function
 ;;
 
 let runtime_role_policy_to_string = function
-  | Local_agentworld_librarian_only -> "local_agentworld_librarian_only"
+  | Agentworld_runtime_librarian_only -> "agentworld_runtime_librarian_only"
 ;;
 
 let unsupported_reason_to_string = function

--- a/lib/capability_proof/capability_proof.ml
+++ b/lib/capability_proof/capability_proof.ml
@@ -401,12 +401,6 @@ let create_evidence_ref ~path ~kind ~locator ~sha256 ~captured_at =
   else Ok { path; kind; locator; sha256; captured_at }
 ;;
 
-let evidence_path evidence = evidence.path
-let evidence_kind evidence = evidence.kind
-let evidence_locator evidence = evidence.locator
-let evidence_sha256 evidence = evidence.sha256
-let evidence_captured_at evidence = evidence.captured_at
-
 type evidence_bundle = evidence_ref list
 
 type bundle_error =
@@ -525,8 +519,6 @@ let not_run = Not_run
 let blocked blocker =
   if String.trim blocker = "" then Error Blank_blocker_ref else Ok (Blocked blocker)
 ;;
-
-let blocker_ref_to_string blocker = blocker
 
 let proof_result_to_string = function
   | Passed _ -> "passed"

--- a/lib/capability_proof/capability_proof.mli
+++ b/lib/capability_proof/capability_proof.mli
@@ -168,7 +168,7 @@ type failure_kind =
   | Gate_settlement_failure
   | Domain_receipt_failure
 
-type runtime_role_policy = Local_agentworld_librarian_only
+type runtime_role_policy = Agentworld_runtime_librarian_only
 
 type unsupported_reason =
   | Runtime_role_policy of runtime_role_policy

--- a/lib/capability_proof/capability_proof.mli
+++ b/lib/capability_proof/capability_proof.mli
@@ -169,7 +169,6 @@ type failure_kind =
   | Domain_receipt_failure
 
 type unsupported_reason =
-  | Runtime_role_not_declared of proof_role
   | Protocol_not_supported of protocol
   | Capability_not_declared of capability_case
 

--- a/lib/capability_proof/capability_proof.mli
+++ b/lib/capability_proof/capability_proof.mli
@@ -146,15 +146,7 @@ val create_evidence_ref
   -> captured_at:string
   -> (evidence_ref, evidence_error) result
 
-val evidence_path : evidence_ref -> proof_path
-val evidence_kind : evidence_ref -> evidence_kind
-val evidence_locator : evidence_ref -> string
-val evidence_sha256 : evidence_ref -> string
-val evidence_captured_at : evidence_ref -> string
-val proof_path_to_string : proof_path -> string
-val evidence_kind_to_string : evidence_kind -> string
 val evidence_error_to_string : evidence_error -> string
-val all_proof_paths : proof_path list
 
 type evidence_bundle
 
@@ -162,12 +154,7 @@ type bundle_error =
   | Missing_proof_paths of proof_path list
   | Duplicate_evidence_ref of string
 
-val create_evidence_bundle : evidence_ref list -> (evidence_bundle, bundle_error) result
-(** A passing bundle requires evidence from Hermetic, Isolated, and Fleet.
-    Exact duplicate references are rejected instead of being counted twice. *)
-
 val evidence_bundle_refs : evidence_bundle -> evidence_ref list
-val bundle_error_to_string : bundle_error -> string
 
 type failure_kind =
   | Contract_violation
@@ -208,9 +195,6 @@ val unsupported : unsupported_reason -> proof_result
 val not_run : proof_result
 val blocked : string -> (proof_result, result_error) result
 
-val blocker_ref_to_string : blocker_ref -> string
 val failure_kind_to_string : failure_kind -> string
-val runtime_role_policy_to_string : runtime_role_policy -> string
-val unsupported_reason_to_string : unsupported_reason -> string
 val proof_result_to_string : proof_result -> string
 val result_error_to_string : result_error -> string

--- a/lib/capability_proof/capability_proof.mli
+++ b/lib/capability_proof/capability_proof.mli
@@ -113,3 +113,104 @@ val all_capability_cases : capability_case list
 val all_scenarios : scenario list
 val all_protocols : protocol list
 (** Closed variant inventories used by manifest generators. *)
+
+type proof_path =
+  | Hermetic
+  | Isolated
+  | Fleet
+
+type evidence_kind =
+  | Journal
+  | Receipt
+  | Durable_queue
+  | Gate
+  | Domain_store
+  | Api
+  | Sse_trace
+  | Browser_screenshot
+  | Config_snapshot
+  | Deployment_identity
+
+type evidence_ref
+
+type evidence_error =
+  | Blank_locator
+  | Blank_captured_at
+  | Invalid_sha256
+
+val create_evidence_ref
+  :  path:proof_path
+  -> kind:evidence_kind
+  -> locator:string
+  -> sha256:string
+  -> captured_at:string
+  -> (evidence_ref, evidence_error) result
+
+val evidence_path : evidence_ref -> proof_path
+val evidence_kind : evidence_ref -> evidence_kind
+val evidence_locator : evidence_ref -> string
+val evidence_sha256 : evidence_ref -> string
+val evidence_captured_at : evidence_ref -> string
+val proof_path_to_string : proof_path -> string
+val evidence_kind_to_string : evidence_kind -> string
+val evidence_error_to_string : evidence_error -> string
+val all_proof_paths : proof_path list
+
+type evidence_bundle
+
+type bundle_error =
+  | Missing_proof_paths of proof_path list
+  | Duplicate_evidence_ref of string
+
+val create_evidence_bundle : evidence_ref list -> (evidence_bundle, bundle_error) result
+(** A passing bundle requires evidence from Hermetic, Isolated, and Fleet.
+    Exact duplicate references are rejected instead of being counted twice. *)
+
+val evidence_bundle_refs : evidence_bundle -> evidence_ref list
+val bundle_error_to_string : bundle_error -> string
+
+type failure_kind =
+  | Contract_violation
+  | Provider_failure
+  | Infrastructure_failure
+  | Evidence_mismatch
+  | Stream_replay_duplicate
+  | Queue_order_violation
+  | Sandbox_escape
+  | Scheduler_settlement_failure
+  | Gate_settlement_failure
+  | Domain_receipt_failure
+
+type runtime_role_policy = Local_agentworld_librarian_only
+
+type unsupported_reason =
+  | Runtime_role_policy of runtime_role_policy
+  | Protocol_not_supported of protocol
+  | Capability_not_declared of capability_case
+
+type blocker_ref = private string
+
+type proof_result = private
+  | Passed of evidence_bundle
+  | Failed of failure_kind * evidence_ref list
+  | Unsupported of unsupported_reason
+  | Not_run
+  | Blocked of blocker_ref
+
+type result_error =
+  | Invalid_evidence_bundle of bundle_error
+  | Failure_without_evidence
+  | Blank_blocker_ref
+
+val passed : evidence_ref list -> (proof_result, result_error) result
+val failed : failure_kind -> evidence_ref list -> (proof_result, result_error) result
+val unsupported : unsupported_reason -> proof_result
+val not_run : proof_result
+val blocked : string -> (proof_result, result_error) result
+
+val blocker_ref_to_string : blocker_ref -> string
+val failure_kind_to_string : failure_kind -> string
+val runtime_role_policy_to_string : runtime_role_policy -> string
+val unsupported_reason_to_string : unsupported_reason -> string
+val proof_result_to_string : proof_result -> string
+val result_error_to_string : result_error -> string

--- a/lib/capability_proof/capability_proof.mli
+++ b/lib/capability_proof/capability_proof.mli
@@ -168,10 +168,8 @@ type failure_kind =
   | Gate_settlement_failure
   | Domain_receipt_failure
 
-type runtime_role_policy = Agentworld_runtime_librarian_only
-
 type unsupported_reason =
-  | Runtime_role_policy of runtime_role_policy
+  | Runtime_role_not_declared of proof_role
   | Protocol_not_supported of protocol
   | Capability_not_declared of capability_case
 

--- a/test/capability_proof/test_capability_proof.ml
+++ b/test/capability_proof/test_capability_proof.ml
@@ -147,11 +147,11 @@ let test_failed_requires_evidence () =
 ;;
 
 let test_unsupported_policy_is_not_a_failure () =
-  let result = unsupported (Runtime_role_policy Local_agentworld_librarian_only) in
+  let result = unsupported (Runtime_role_policy Agentworld_runtime_librarian_only) in
   check
     string
     "policy exclusion stays typed"
-    "unsupported:runtime_role_policy:local_agentworld_librarian_only"
+    "unsupported:runtime_role_policy:agentworld_runtime_librarian_only"
     (proof_result_to_string result)
 ;;
 

--- a/test/capability_proof/test_capability_proof.ml
+++ b/test/capability_proof/test_capability_proof.ml
@@ -147,11 +147,11 @@ let test_failed_requires_evidence () =
 ;;
 
 let test_unsupported_policy_is_not_a_failure () =
-  let result = unsupported (Runtime_role_policy Agentworld_runtime_librarian_only) in
+  let result = unsupported (Runtime_role_not_declared Autonomous_keeper) in
   check
     string
     "policy exclusion stays typed"
-    "unsupported:runtime_role_policy:agentworld_runtime_librarian_only"
+    "unsupported:runtime_role_not_declared:autonomous_keeper"
     (proof_result_to_string result)
 ;;
 

--- a/test/capability_proof/test_capability_proof.ml
+++ b/test/capability_proof/test_capability_proof.ml
@@ -147,11 +147,11 @@ let test_failed_requires_evidence () =
 ;;
 
 let test_unsupported_policy_is_not_a_failure () =
-  let result = unsupported (Runtime_role_not_declared Autonomous_keeper) in
+  let result = unsupported (Capability_not_declared Autonomous_turn) in
   check
     string
     "policy exclusion stays typed"
-    "unsupported:runtime_role_not_declared:autonomous_keeper"
+    "unsupported:capability_not_declared:autonomous_turn"
     (proof_result_to_string result)
 ;;
 

--- a/test/capability_proof/test_capability_proof.ml
+++ b/test/capability_proof/test_capability_proof.ml
@@ -84,6 +84,84 @@ let test_closed_inventory_has_unique_case_ids () =
   check (list string) "no matrix identity collisions" [] (List.rev !collisions)
 ;;
 
+let evidence ?(path = Hermetic) ?(kind = Journal) locator =
+  create_evidence_ref
+    ~path
+    ~kind
+    ~locator
+    ~sha256:(String.make 64 'a')
+    ~captured_at:"2026-08-13T09:00:00Z"
+  |> function
+  | Ok evidence -> evidence
+  | Error error -> failf "unexpected evidence error: %s" (evidence_error_to_string error)
+;;
+
+let three_path_evidence () =
+  [ evidence ~path:Hermetic "fixture:capability-proof"
+  ; evidence ~path:Isolated ~kind:Receipt "receipt:isolated-run"
+  ; evidence ~path:Fleet ~kind:Api "api:/health?full=1"
+  ]
+;;
+
+let test_pass_requires_all_three_proof_paths () =
+  match passed [ evidence ~path:Hermetic "fixture:only" ] with
+  | Error (Invalid_evidence_bundle (Missing_proof_paths [ Isolated; Fleet ])) -> ()
+  | Error error -> failf "unexpected pass error: %s" (result_error_to_string error)
+  | Ok result -> failf "incomplete evidence passed as %s" (proof_result_to_string result)
+;;
+
+let test_pass_accepts_complete_bundle () =
+  match passed (three_path_evidence ()) with
+  | Error error -> failf "unexpected pass error: %s" (result_error_to_string error)
+  | Ok (Passed bundle) -> check int "all evidence retained" 3 (List.length (evidence_bundle_refs bundle))
+  | Ok result -> failf "expected passed, got %s" (proof_result_to_string result)
+;;
+
+let test_duplicate_evidence_is_rejected () =
+  let duplicate = evidence ~path:Hermetic "fixture:duplicate" in
+  match passed (duplicate :: duplicate :: three_path_evidence ()) with
+  | Error (Invalid_evidence_bundle (Duplicate_evidence_ref "fixture:duplicate")) -> ()
+  | Error error -> failf "unexpected duplicate error: %s" (result_error_to_string error)
+  | Ok result -> failf "duplicate evidence passed as %s" (proof_result_to_string result)
+;;
+
+let test_invalid_digest_is_typed () =
+  match
+    create_evidence_ref
+      ~path:Hermetic
+      ~kind:Journal
+      ~locator:"fixture:bad-digest"
+      ~sha256:"not-a-sha256"
+      ~captured_at:"2026-08-13T09:00:00Z"
+  with
+  | Error Invalid_sha256 -> ()
+  | Error error -> failf "unexpected evidence error: %s" (evidence_error_to_string error)
+  | Ok _ -> fail "invalid digest was accepted"
+;;
+
+let test_failed_requires_evidence () =
+  match failed Provider_failure [] with
+  | Error Failure_without_evidence -> ()
+  | Error error -> failf "unexpected failure error: %s" (result_error_to_string error)
+  | Ok result -> failf "evidence-free failure accepted as %s" (proof_result_to_string result)
+;;
+
+let test_unsupported_policy_is_not_a_failure () =
+  let result = unsupported (Runtime_role_policy Local_agentworld_librarian_only) in
+  check
+    string
+    "policy exclusion stays typed"
+    "unsupported:runtime_role_policy:local_agentworld_librarian_only"
+    (proof_result_to_string result)
+;;
+
+let test_blank_blocker_is_rejected () =
+  match blocked " \t" with
+  | Error Blank_blocker_ref -> ()
+  | Error error -> failf "unexpected blocker error: %s" (result_error_to_string error)
+  | Ok result -> failf "blank blocker accepted as %s" (proof_result_to_string result)
+;;
+
 let () =
   run
     "capability proof identity"
@@ -93,6 +171,15 @@ let () =
         ; test_case "absence is distinct" `Quick test_present_and_absent_values_have_distinct_identity
         ; test_case "blank rejected" `Quick test_blank_values_are_rejected
         ; test_case "closed inventory unique" `Quick test_closed_inventory_has_unique_case_ids
+        ] )
+    ; ( "verdict"
+      , [ test_case "pass requires A/B/C" `Quick test_pass_requires_all_three_proof_paths
+        ; test_case "complete pass" `Quick test_pass_accepts_complete_bundle
+        ; test_case "duplicate evidence" `Quick test_duplicate_evidence_is_rejected
+        ; test_case "invalid digest" `Quick test_invalid_digest_is_typed
+        ; test_case "failure needs evidence" `Quick test_failed_requires_evidence
+        ; test_case "unsupported is typed" `Quick test_unsupported_policy_is_not_a_failure
+        ; test_case "blocker nonblank" `Quick test_blank_blocker_is_rejected
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- add closed Hermetic, Isolated, and Fleet proof paths plus typed evidence kinds
- require all three paths before constructing Passed, and reject duplicate evidence references
- model Failed, Unsupported, Not_run, and Blocked without boolean/status products
- require hashed evidence for failures and preserve AgentWorld librarian-only as a typed unsupported policy reason

## Validation
- 12 focused tests passed via direct ocamlfind compilation (no Dune)
- ocamlformat --check on changed OCaml files
- ocamlc -stop-after parsing on implementation, interface, and focused test
- git diff --check and conflict-marker scan
- local Dune build intentionally not run per campaign instruction; CI is not yet evaluated

## Stack
- depends on #28545
- follow-up: deterministic compatible-cell manifest generation and strict JSON/API projection

This PR adds only the pure evidence contract. It performs no discovery, runtime mutation, provider call, or dashboard effect.