### PR TITLE
fix(dashboard): edit proactive policy from config truth

### DIFF
--- a/dashboard/src/api/dashboard-keeper-config.test.ts
+++ b/dashboard/src/api/dashboard-keeper-config.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { fetchKeeperConfig } from './dashboard-keeper-config'
+
+describe('keeper config source projection', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('preserves typed TOML versus live-meta override evidence', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        name: 'rtprobe',
+        max_context_override: null,
+        proactive: { enabled: true },
+        sources: {
+          live_meta_path: '/workspace/.masc/keepers/rtprobe.json',
+          default_manifest_path: '/workspace/.masc/config/keepers/rtprobe.toml',
+          default_source_kind: 'toml',
+          precedence: ['live_meta', 'keeper_config'],
+          has_live_override: true,
+          override_fields: ['proactive.enabled'],
+          override_field_sources: [{
+            field: 'proactive.enabled',
+            source: 'live_meta',
+            live_source: 'runtime_overlay',
+            default_source: 'toml',
+            default_source_kind: 'toml',
+            default_manifest_path: '/workspace/.masc/config/keepers/rtprobe.toml',
+            default_manifest_exists: true,
+            default_missing: false,
+            default_value: false,
+            live_value: true,
+          }],
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ))
+
+    const config = await fetchKeeperConfig('rtprobe')
+
+    expect(config.proactive.enabled).toBe(true)
+    expect(config.sources.override_field_sources).toEqual([{
+      field: 'proactive.enabled',
+      source: 'live_meta',
+      live_source: 'runtime_overlay',
+      default_source: 'toml',
+      default_source_kind: 'toml',
+      default_manifest_path: '/workspace/.masc/config/keepers/rtprobe.toml',
+      default_manifest_exists: true,
+      default_missing: false,
+      default_value: false,
+      live_value: true,
+    }])
+  })
+})

--- a/dashboard/src/api/dashboard-keeper-config.ts
+++ b/dashboard/src/api/dashboard-keeper-config.ts
@@ -6,7 +6,7 @@ import { get, post } from './core'
 import { isRecord, asBoolean, asInt, asNullableString, asNumber, asStringArray, asRecordArray, isPositiveSafeInteger } from '../components/common/normalize'
 import { ensureDevToken } from './dev-token'
 import { asKeeperRuntimeBlockerClass } from '../lib/runtime-blocker-class'
-import type { KeeperConfig, KeeperHookSlot } from '../types'
+import type { KeeperConfig, KeeperConfigOverrideFieldSource, KeeperHookSlot } from '../types'
 
 function asLooseBoolean(value: unknown, fallback = false): boolean {
   const booleanValue = asBoolean(value)
@@ -135,6 +135,27 @@ function normalizeDefaultSourceKind(value: unknown): KeeperConfig['sources']['de
   }
 }
 
+function normalizeOverrideFieldSources(raw: unknown): KeeperConfigOverrideFieldSource[] {
+  return asRecordArray(raw)
+    .map((row): KeeperConfigOverrideFieldSource | null => {
+      const field = asNullableString(row.field)
+      if (!field) return null
+      return {
+        field,
+        source: asNullableString(row.source),
+        live_source: asNullableString(row.live_source),
+        default_source: asNullableString(row.default_source),
+        default_source_kind: normalizeDefaultSourceKind(row.default_source_kind),
+        default_manifest_path: asNullableString(row.default_manifest_path),
+        default_manifest_exists: asBoolean(row.default_manifest_exists) ?? null,
+        default_missing: asBoolean(row.default_missing) ?? null,
+        default_value: row.default_value,
+        live_value: row.live_value,
+      }
+    })
+    .filter((row): row is KeeperConfigOverrideFieldSource => row !== null)
+}
+
 function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfig {
   const data = isRecord(raw) ? raw : {}
   const prompt = isRecord(data.prompt) ? data.prompt : {}
@@ -219,6 +240,7 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
       precedence: normalizeStringList(sources.precedence),
       has_live_override: asLooseBoolean(sources.has_live_override),
       override_fields: normalizeStringList(sources.override_fields),
+      override_field_sources: normalizeOverrideFieldSources(sources.override_field_sources),
     },
     metrics: {
       generation: asInt(metrics.generation) ?? 0,

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -91,6 +91,7 @@ function makeKeeperConfig(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
       precedence: ['live_meta', 'keeper_config'],
       has_live_override: true,
       override_fields: ['prompt.instructions'],
+      override_field_sources: [],
     },
     metrics: {
       generation: 3,
@@ -459,6 +460,34 @@ describe('initRuntimeDraftFromConfig — sandbox fields', () => {
     })
     const draft = initRuntimeDraftFromConfig(c)
     expect(draft.runtime_id).toBe('runpod_mtp.qwen36-35b-a3b-mtp')
+  })
+
+  it('uses the declarative proactive value when live meta has drifted', () => {
+    const base = makeKeeperConfigForSandbox()
+    const c = makeKeeperConfigForSandbox({
+      proactive: { enabled: true },
+      sources: {
+        ...base.sources,
+        override_field_sources: [{
+          field: 'proactive.enabled',
+          source: 'live_meta',
+          live_source: 'runtime_overlay',
+          default_source: 'toml',
+          default_source_kind: 'toml',
+          default_manifest_path: '/tmp/config/keepers/rtprobe.toml',
+          default_manifest_exists: true,
+          default_missing: false,
+          default_value: false,
+          live_value: true,
+        }],
+      },
+    })
+
+    expect(initRuntimeDraftFromConfig(c).proactive_enabled).toBe(false)
+    expect(buildRuntimePayload({
+      ...initRuntimeDraftFromConfig(c),
+      proactive_enabled: true,
+    }, c)).toEqual({ proactive_enabled: true })
   })
 
   it('defaults sandbox fields when config is missing them', () => {
@@ -1433,6 +1462,62 @@ describe('KeeperConfigPanel', () => {
         autoboot_enabled: false,
         max_context_override: 64000,
       }),
+    )
+  })
+
+  it('edits proactive policy from TOML truth when live meta has drifted', async () => {
+    const base = makeKeeperConfig()
+    const drifted = makeKeeperConfig({
+      proactive: { enabled: true },
+      sources: {
+        ...base.sources,
+        override_fields: ['proactive.enabled'],
+        override_field_sources: [{
+          field: 'proactive.enabled',
+          source: 'live_meta',
+          live_source: 'runtime_overlay',
+          default_source: 'toml',
+          default_source_kind: 'toml',
+          default_manifest_path: '/tmp/config/keepers/rtprobe.toml',
+          default_manifest_exists: true,
+          default_missing: false,
+          default_value: false,
+          live_value: true,
+        }],
+      },
+    })
+    mocks.fetchKeeperConfig.mockResolvedValueOnce(drifted)
+    mocks.patchKeeperConfig.mockResolvedValueOnce(makeKeeperConfig({
+      proactive: { enabled: true },
+    }))
+
+    render(html`<${KeeperConfigPanel} keeperName="keeper-sangsu" />`, container)
+    await flush()
+    await flush()
+
+    expect(container.textContent).toContain('프로액티브 설정 드리프트')
+    expect(container.textContent).toContain('TOML OFF / live meta ON')
+
+    selectKcfTab(container, '실행 정책')
+    await flush()
+    const proactive = container.querySelector('button[aria-label="프로액티브 활성"]') as HTMLButtonElement | null
+    expect(proactive?.getAttribute('aria-checked')).toBe('false')
+    expect(container.textContent).toContain('TOML OFF / live meta ON')
+
+    proactive?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flush()
+    expect(proactive?.getAttribute('aria-checked')).toBe('true')
+
+    const saveButton = Array.from(container.querySelectorAll('button')).find(button =>
+      button.textContent?.includes('런타임 설정 저장'),
+    )
+    saveButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flush()
+    await flush()
+
+    expect(mocks.patchKeeperConfig).toHaveBeenCalledWith(
+      'keeper-sangsu',
+      { proactive_enabled: true },
     )
   })
 

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -331,6 +331,77 @@ export type RuntimeDraft = {
   autonomous_wake_prompt: string
 }
 
+export type KeeperConfigBooleanProjection =
+  | { kind: 'configured'; configured: boolean; live: boolean }
+  | {
+      kind: 'drift'
+      configured: boolean
+      live: boolean
+      defaultSource: 'toml'
+      defaultManifestPath: string | null
+    }
+  | { kind: 'live-only'; live: boolean }
+  | { kind: 'invalid-evidence'; live: boolean }
+
+type KeeperConfigBooleanField = 'autoboot_enabled' | 'proactive.enabled'
+
+/** Resolve an editable boolean against the same declarative config evidence
+ * the PATCH endpoint writes. The top-level value is live-meta state; when a
+ * typed source row proves that TOML differs, the editor must start from TOML
+ * rather than presenting the stale runtime overlay as the persisted policy. */
+export function keeperConfigBooleanProjection(
+  c: KeeperConfig,
+  field: KeeperConfigBooleanField,
+  live: boolean,
+): KeeperConfigBooleanProjection {
+  const evidence = c.sources.override_field_sources?.find(row => row.field === field)
+  if (!evidence || evidence.default_missing === true) return { kind: 'live-only', live }
+  if (
+    evidence.default_source_kind !== 'toml'
+    || typeof evidence.default_value !== 'boolean'
+    || typeof evidence.live_value !== 'boolean'
+  ) {
+    return { kind: 'invalid-evidence', live }
+  }
+  if (evidence.default_value === evidence.live_value) {
+    return { kind: 'configured', configured: evidence.default_value, live: evidence.live_value }
+  }
+  return {
+    kind: 'drift',
+    configured: evidence.default_value,
+    live: evidence.live_value,
+    defaultSource: 'toml',
+    defaultManifestPath: evidence.default_manifest_path,
+  }
+}
+
+function configuredBooleanValue(projection: KeeperConfigBooleanProjection): boolean {
+  return projection.kind === 'configured' || projection.kind === 'drift'
+    ? projection.configured
+    : projection.live
+}
+
+function proactiveConfigProjection(c: KeeperConfig): KeeperConfigBooleanProjection {
+  return keeperConfigBooleanProjection(c, 'proactive.enabled', c.proactive.enabled)
+}
+
+function proactiveConfigValue(c: KeeperConfig): boolean {
+  return configuredBooleanValue(proactiveConfigProjection(c))
+}
+
+function proactiveConfigHint(c: KeeperConfig): string {
+  const projection = proactiveConfigProjection(c)
+  if (projection.kind === 'drift') {
+    const configured = projection.configured ? 'ON' : 'OFF'
+    const live = projection.live ? 'ON' : 'OFF'
+    return `유휴 시 keeper 자가 기동 · TOML ${configured} / live meta ${live}`
+  }
+  if (projection.kind === 'invalid-evidence') {
+    return '유휴 시 keeper 자가 기동 · config source evidence invalid'
+  }
+  return '유휴 시 keeper 자가 기동'
+}
+
 // Mirror of the server contract
 // (Env_config_keeper.KeeperAutonomous.max_wake_prompt_bytes): the value is
 // appended to the durable checkpoint on every autonomous turn.
@@ -418,7 +489,7 @@ export function initRuntimeDraftFromConfig(c: KeeperConfig): RuntimeDraft {
     mention_targets_text: c.workspace.mention_targets.join('\n'),
     network_mode: coerceNetworkMode(c.network_mode),
     allowed_paths_text: (c.allowed_paths ?? []).join('\n'),
-    proactive_enabled: c.proactive.enabled,
+    proactive_enabled: proactiveConfigValue(c),
     autonomous_wake_prompt: c.autonomous_wake_prompt ?? '',
   }
 }
@@ -573,6 +644,7 @@ export function keeperConfigControlInventory(
             'sources.precedence',
             'sources.has_live_override',
             'sources.override_fields',
+            'sources.override_field_sources',
           ]),
         },
       ]
@@ -667,6 +739,7 @@ export function keeperConfigControlInventory(
           [
             'autoboot_enabled',
             'proactive.enabled',
+            'sources.override_field_sources',
           ],
         ),
         keeperRuntimeControlItem(
@@ -889,7 +962,7 @@ export function buildRuntimePayloadResult(
   if (!sameStringArray(newPaths, origPaths)) payload.allowed_paths = newPaths
   if (draft.sandbox_profile !== coerceSandboxProfile(orig.sandbox_profile)) payload.sandbox_profile = draft.sandbox_profile
   if (draft.network_mode !== coerceNetworkMode(orig.network_mode)) payload.network_mode = draft.network_mode
-  if (draft.proactive_enabled !== orig.proactive.enabled) payload.proactive_enabled = draft.proactive_enabled
+  if (draft.proactive_enabled !== proactiveConfigValue(orig)) payload.proactive_enabled = draft.proactive_enabled
   return { ok: true, payload }
 }
 
@@ -1911,6 +1984,12 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
       <${KcfFacts} rows=${[
         ['기본 소스', c.sources.default_source_kind],
         ['라이브 오버라이드', c.sources.has_live_override ? 'ON' : 'OFF'],
+        ...(proactiveConfigProjection(c).kind === 'drift'
+          ? [[
+              '프로액티브 설정 드리프트',
+              `TOML ${proactiveConfigValue(c) ? 'ON' : 'OFF'} / live meta ${c.proactive.enabled ? 'ON' : 'OFF'}`,
+            ] as const]
+          : []),
       ]} />
     </${KcfSec}>
 
@@ -2001,7 +2080,7 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
         <${SetToggle} ariaLabel="자동 부팅" on=${rd.autoboot_enabled}
           onChange=${(v: boolean) => updateRuntimeDraft('autoboot_enabled', v)} />
       </${SetRow}>
-      <${SetRow} label="활성" hint="유휴 시 keeper 자가 기동" dirty=${dirtyFlags.proactive_enabled}>
+      <${SetRow} label="활성" hint=${proactiveConfigHint(c)} dirty=${dirtyFlags.proactive_enabled}>
         <${SetToggle} ariaLabel="프로액티브 활성" on=${rd.proactive_enabled}
           onChange=${(v: boolean) => updateRuntimeDraft('proactive_enabled', v)} />
       </${SetRow}>
@@ -2019,7 +2098,7 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
       </div>
     ` : html`
       <${BoolRow} label="자동 부팅" value=${c.autoboot_enabled} />
-      <${BoolRow} label="활성" value=${c.proactive.enabled} />
+      <${BoolRow} label="활성" value=${proactiveConfigValue(c)} />
       <${ConfigRow} label="자율 턴 깨우기 프롬프트"
         value=${c.autonomous_wake_prompt ?? `(상속) ${c.prompt.unified_user_message_preview || 'Continue.'}`} />
     `}

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -1398,6 +1398,19 @@ interface KeeperConfigWorkspace {
   missing_active_goal_ids: string[]
 }
 
+export interface KeeperConfigOverrideFieldSource {
+  field: string
+  source: string | null
+  live_source: string | null
+  default_source: string | null
+  default_source_kind: 'toml' | null
+  default_manifest_path: string | null
+  default_manifest_exists: boolean | null
+  default_missing: boolean | null
+  default_value: unknown
+  live_value: unknown
+}
+
 interface KeeperConfigSources {
   live_meta_path: string
   default_manifest_path: string | null
@@ -1405,6 +1418,7 @@ interface KeeperConfigSources {
   precedence: string[]
   has_live_override: boolean
   override_fields: string[]
+  override_field_sources: KeeperConfigOverrideFieldSource[]
 }
 
 interface KeeperConfigMetrics {


### PR DESCRIPTION
## Summary

- preserve typed `sources.override_field_sources` evidence from the Keeper config response
- initialize and diff the proactive editor against the TOML value when typed evidence proves live-meta drift
- surface `TOML OFF / live meta ON` instead of presenting the stale overlay as persisted policy

## Live reproduction

For `rtprobe`, the live config response reported `proactive.enabled=true`, while its own typed source evidence reported `default_source_kind=toml`, `default_value=false`, and `live_value=true`. Fleet health therefore correctly classified the keeper as `retained_disabled/proactive_disabled`, but the Dashboard toggle displayed ON.

This change consumes the existing source-provenance projection. It adds no file parsing, fallback heuristic, or additional request.

## Verification

- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/api/dashboard-keeper-config.test.ts src/components/keeper-config-panel.test.ts` — 75 passed
- `pnpm typecheck` — passed
- changed-file ESLint — passed

## Out of scope

- global Overview/header health aggregation
- SSE parity and live-meta reconciliation
- backend runtime mutation or restart