### PR TITLE
feat(proof): add strict campaign completion metric

### DIFF
--- a/lib/capability_proof/capability_proof.ml
+++ b/lib/capability_proof/capability_proof.ml
@@ -525,3 +525,84 @@ let result_error_to_string = function
   | Failure_without_evidence -> "failure_without_evidence"
   | Blank_blocker_ref -> "blank_blocker_ref"
 ;;
+
+type campaign_summary =
+  { expected : int
+  ; passed : int
+  ; failed : int
+  ; unsupported : int
+  ; not_run : int
+  ; blocked : int
+  ; missing_evidence : int
+  ; unresolved_required_cells : int
+  }
+
+type campaign_error =
+  | Duplicate_expected_case of case_id
+  | Duplicate_result_case of case_id
+  | Unexpected_result_case of case_id
+
+let case_id_equal left right = String.equal left right
+
+let rec first_duplicate_case_id seen = function
+  | [] -> None
+  | case_id :: rest ->
+    if List.exists (case_id_equal case_id) seen
+    then Some case_id
+    else first_duplicate_case_id (case_id :: seen) rest
+;;
+
+let summarize_campaign ~expected ~results =
+  let expected_ids = List.map case_id expected in
+  match first_duplicate_case_id [] expected_ids with
+  | Some duplicate -> Error (Duplicate_expected_case duplicate)
+  | None ->
+    let result_ids = List.map fst results in
+    (match first_duplicate_case_id [] result_ids with
+     | Some duplicate -> Error (Duplicate_result_case duplicate)
+     | None ->
+       (match
+          List.find_opt
+            (fun result_id ->
+              not (List.exists (case_id_equal result_id) expected_ids))
+            result_ids
+        with
+        | Some unexpected -> Error (Unexpected_result_case unexpected)
+        | None ->
+          let passed, failed, unsupported, not_run, blocked =
+            List.fold_left
+              (fun (passed, failed, unsupported, not_run, blocked) (_, result) ->
+                match result with
+                | Passed _ -> passed + 1, failed, unsupported, not_run, blocked
+                | Failed _ -> passed, failed + 1, unsupported, not_run, blocked
+                | Unsupported _ -> passed, failed, unsupported + 1, not_run, blocked
+                | Not_run -> passed, failed, unsupported, not_run + 1, blocked
+                | Blocked _ -> passed, failed, unsupported, not_run, blocked + 1)
+              (0, 0, 0, 0, 0)
+              results
+          in
+          let expected_count = List.length expected_ids in
+          let missing_evidence = expected_count - List.length results in
+          let unresolved_required_cells = failed + not_run + blocked + missing_evidence in
+          Ok
+            { expected = expected_count
+            ; passed
+            ; failed
+            ; unsupported
+            ; not_run
+            ; blocked
+            ; missing_evidence
+            ; unresolved_required_cells
+            }))
+;;
+
+let campaign_complete summary = summary.unresolved_required_cells = 0
+
+let campaign_error_to_string = function
+  | Duplicate_expected_case case_id ->
+    "duplicate_expected_case:" ^ case_id_to_string case_id
+  | Duplicate_result_case case_id ->
+    "duplicate_result_case:" ^ case_id_to_string case_id
+  | Unexpected_result_case case_id ->
+    "unexpected_result_case:" ^ case_id_to_string case_id
+;;

--- a/lib/capability_proof/capability_proof.mli
+++ b/lib/capability_proof/capability_proof.mli
@@ -195,3 +195,37 @@ val blocked : string -> (proof_result, result_error) result
 val failure_kind_to_string : failure_kind -> string
 val proof_result_to_string : proof_result -> string
 val result_error_to_string : result_error -> string
+
+type campaign_summary = private
+  { expected : int
+  ; passed : int
+  ; failed : int
+  ; unsupported : int
+  ; not_run : int
+  ; blocked : int
+  ; missing_evidence : int
+  ; unresolved_required_cells : int
+  }
+
+type campaign_error =
+  | Duplicate_expected_case of case_id
+  | Duplicate_result_case of case_id
+  | Unexpected_result_case of case_id
+
+val summarize_campaign
+  :  expected:t list
+  -> results:(case_id * proof_result) list
+  -> (campaign_summary, campaign_error) result
+(** Computes the strict campaign metric:
+
+    {v
+      unresolved_required_cells =
+        failed + not_run + blocked + missing_evidence
+    v}
+
+    [Unsupported] is reported separately and is accepted only because its
+    constructor requires a typed policy or capability reason. Unknown,
+    duplicate, or contradictory case identities reject the summary. *)
+
+val campaign_complete : campaign_summary -> bool
+val campaign_error_to_string : campaign_error -> string

--- a/test/capability_proof/test_capability_proof.ml
+++ b/test/capability_proof/test_capability_proof.ml
@@ -211,7 +211,7 @@ let test_campaign_complete_accepts_passed_and_typed_unsupported () =
   let results =
     [ case_id passed_case, pass ()
     ; ( case_id unsupported_case
-      , unsupported (Runtime_role_policy Agentworld_runtime_librarian_only) )
+      , unsupported (Capability_not_declared Autonomous_turn) )
     ]
   in
   match summarize_campaign ~expected:[ passed_case; unsupported_case ] ~results with

--- a/test/capability_proof/test_capability_proof.ml
+++ b/test/capability_proof/test_capability_proof.ml
@@ -211,7 +211,7 @@ let test_campaign_complete_accepts_passed_and_typed_unsupported () =
   let results =
     [ case_id passed_case, pass ()
     ; ( case_id unsupported_case
-      , unsupported (Runtime_role_policy Local_agentworld_librarian_only) )
+      , unsupported (Runtime_role_policy Agentworld_runtime_librarian_only) )
     ]
   in
   match summarize_campaign ~expected:[ passed_case; unsupported_case ] ~results with

--- a/test/capability_proof/test_capability_proof.ml
+++ b/test/capability_proof/test_capability_proof.ml
@@ -162,6 +162,91 @@ let test_blank_blocker_is_rejected () =
   | Ok result -> failf "blank blocker accepted as %s" (proof_result_to_string result)
 ;;
 
+let case ?(model_id = Some "model") runtime_id =
+  match create ~runtime_id ~model_id () with
+  | Ok case -> case
+  | Error error -> failf "unexpected case error: %s" (create_error_to_string error)
+;;
+
+let pass () =
+  match passed (three_path_evidence ()) with
+  | Ok result -> result
+  | Error error -> failf "unexpected pass error: %s" (result_error_to_string error)
+;;
+
+let block locator =
+  match blocked locator with
+  | Ok result -> result
+  | Error error -> failf "unexpected blocker error: %s" (result_error_to_string error)
+;;
+
+let test_campaign_metric_counts_every_unresolved_state () =
+  let cases = List.map case [ "passed"; "failed"; "unsupported"; "not-run"; "blocked"; "missing" ] in
+  let case_id_at index = List.nth cases index |> case_id in
+  let results =
+    [ case_id_at 0, pass ()
+    ; case_id_at 1, Result.get_ok (failed Provider_failure [ evidence "receipt:failure" ])
+    ; case_id_at 2, unsupported (Protocol_not_supported Browser)
+    ; case_id_at 3, not_run
+    ; case_id_at 4, block "blocker:credential"
+    ]
+  in
+  match summarize_campaign ~expected:cases ~results with
+  | Error error -> failf "unexpected campaign error: %s" (campaign_error_to_string error)
+  | Ok summary ->
+    check int "expected" 6 summary.expected;
+    check int "passed" 1 summary.passed;
+    check int "failed" 1 summary.failed;
+    check int "unsupported" 1 summary.unsupported;
+    check int "not run" 1 summary.not_run;
+    check int "blocked" 1 summary.blocked;
+    check int "missing" 1 summary.missing_evidence;
+    check int "strict unresolved metric" 4 summary.unresolved_required_cells;
+    check bool "campaign incomplete" false (campaign_complete summary)
+;;
+
+let test_campaign_complete_accepts_passed_and_typed_unsupported () =
+  let passed_case = case "passed" in
+  let unsupported_case = case "unsupported" in
+  let results =
+    [ case_id passed_case, pass ()
+    ; ( case_id unsupported_case
+      , unsupported (Runtime_role_policy Local_agentworld_librarian_only) )
+    ]
+  in
+  match summarize_campaign ~expected:[ passed_case; unsupported_case ] ~results with
+  | Error error -> failf "unexpected campaign error: %s" (campaign_error_to_string error)
+  | Ok summary ->
+    check int "unresolved zero" 0 summary.unresolved_required_cells;
+    check bool "campaign complete" true (campaign_complete summary)
+;;
+
+let test_campaign_rejects_duplicate_expected_identity () =
+  let duplicate = case "same" in
+  match summarize_campaign ~expected:[ duplicate; duplicate ] ~results:[] with
+  | Error (Duplicate_expected_case _) -> ()
+  | Error error -> failf "unexpected campaign error: %s" (campaign_error_to_string error)
+  | Ok _ -> fail "duplicate expected identity was accepted"
+;;
+
+let test_campaign_rejects_duplicate_result_identity () =
+  let expected = case "same" in
+  let id = case_id expected in
+  match summarize_campaign ~expected:[ expected ] ~results:[ id, not_run; id, not_run ] with
+  | Error (Duplicate_result_case _) -> ()
+  | Error error -> failf "unexpected campaign error: %s" (campaign_error_to_string error)
+  | Ok _ -> fail "duplicate result identity was accepted"
+;;
+
+let test_campaign_rejects_unexpected_result_identity () =
+  let expected = case "expected" in
+  let unexpected = case "unexpected" in
+  match summarize_campaign ~expected:[ expected ] ~results:[ case_id unexpected, not_run ] with
+  | Error (Unexpected_result_case _) -> ()
+  | Error error -> failf "unexpected campaign error: %s" (campaign_error_to_string error)
+  | Ok _ -> fail "unexpected result identity was accepted"
+;;
+
 let () =
   run
     "capability proof identity"
@@ -180,6 +265,13 @@ let () =
         ; test_case "failure needs evidence" `Quick test_failed_requires_evidence
         ; test_case "unsupported is typed" `Quick test_unsupported_policy_is_not_a_failure
         ; test_case "blocker nonblank" `Quick test_blank_blocker_is_rejected
+        ] )
+    ; ( "campaign metric"
+      , [ test_case "all unresolved states" `Quick test_campaign_metric_counts_every_unresolved_state
+        ; test_case "complete" `Quick test_campaign_complete_accepts_passed_and_typed_unsupported
+        ; test_case "duplicate expected" `Quick test_campaign_rejects_duplicate_expected_identity
+        ; test_case "duplicate result" `Quick test_campaign_rejects_duplicate_result_identity
+        ; test_case "unexpected result" `Quick test_campaign_rejects_unexpected_result_identity
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- compute the campaign goal as Failed + Not_run + Blocked + MissingEvidence
- accept only explicit typed Unsupported cells outside that unresolved count
- reject duplicate expected/result identities and results outside the expected manifest
- expose campaign_complete only when unresolved_required_cells is exactly zero

## Validation
- 17 focused tests passed via direct ocamlfind compilation (no Dune)
- ocamlformat --check and ocamlc parse checks passed
- git diff --check and conflict-marker scan passed
- local Dune build intentionally not run; CI is not yet evaluated

## Stack
- depends on #28547, which depends on #28545
- follow-up: runtime/config manifest generator feeds this metric; API and dashboard project it read-only

No runtime, provider, filesystem, or dashboard effects are performed by this pure leaf.