### PR TITLE
feat(dashboard): tail 창보다 오래된 직접 대화를 페이징으로 노출 (GET /chat/history/page)

### DIFF
--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -1304,27 +1304,29 @@ let autonomous_turn_json (turn : Keeper_autonomous_turn_source.turn) =
      @ trace_fields)
 ;;
 
+let keeper_chat_trace_blocks config name =
+  match Keeper_meta_store.read_meta config name with
+  | Ok (Some m) ->
+    Some
+      (Server_dashboard_http_keeper_api_trace.chat_trace_block_by_turn_ref
+         ~max_lines:trajectory_max_limit
+         ~max_internal_lines:trajectory_max_limit
+         ~config
+         ~keeper_name:name
+         ~allowed_trace_ids:(keeper_chat_allowed_trace_ids m))
+  | Ok None -> None
+  | Error err ->
+    Log.Keeper.warn
+      "dashboard keeper chat history: read_meta failed for %s; trace enrichment skipped: %s"
+      name
+      err;
+    None
+;;
+
 let keeper_chat_history_json config name =
   let base_dir = (config : Workspace.config).base_path in
   let messages = Keeper_chat_store.load ~base_dir ~keeper_name:name in
-  let trace_block_by_turn_ref =
-    match Keeper_meta_store.read_meta config name with
-    | Ok (Some m) ->
-      Some
-        (Server_dashboard_http_keeper_api_trace.chat_trace_block_by_turn_ref
-           ~max_lines:trajectory_max_limit
-           ~max_internal_lines:trajectory_max_limit
-           ~config
-           ~keeper_name:name
-           ~allowed_trace_ids:(keeper_chat_allowed_trace_ids m))
-    | Ok None -> None
-    | Error err ->
-      Log.Keeper.warn
-        "dashboard keeper chat history: read_meta failed for %s; trace enrichment skipped: %s"
-        name
-        err;
-      None
-  in
+  let trace_block_by_turn_ref = keeper_chat_trace_blocks config name in
   let chat_rows = Keeper_chat_store.to_json_array ~base_dir ?trace_block_by_turn_ref messages in
   (* Appended, not merged by timestamp: the client already sorts the whole
      transcript by [ts] and breaks ties by original index, and rows the chat
@@ -1344,6 +1346,54 @@ let keeper_chat_history_json config name =
       name
       (List.length autonomous_rows);
     other
+;;
+
+(* Direct-conversation rows older than [before], one [Keeper_chat_store] window
+   at a time. Separate from [keeper_chat_history_json] rather than a mode of it,
+   because the two answer different questions:
+
+   - /chat/history is the transcript: the tail window plus every autonomous turn
+     the retention root still holds ([Keeper_raw_trace_retention.history_limit]).
+   - this is the walk backwards through direct rows the tail window evicted.
+     Autonomous turns are excluded on purpose -- they are bounded by retention,
+     not by this window, so the first transcript fetch already carried every one
+     that exists. Repeating them per page would duplicate rows the client holds.
+
+   [next_before] is the cursor for the following page, computed here so the
+   caller does not reimplement the rule: the oldest [ts] among the returned
+   rows, or [null] for an empty page. The fold tolerates a row carrying no [ts]
+   by skipping it, which today cannot happen -- [Keeper_chat_store.parse_line]
+   maps an absent [ts] to [Some 0.0] rather than [None] (see the store's own
+   [quiet_line_ts], which maps the same absence to [None]). That disagreement
+   is tracked separately; this fold is written against the documented type so
+   it stays correct when the store's decoder is repaired.
+
+   Uncached: pages are user-initiated and [load_page] is already bounded I/O
+   (binary-search probes plus one window slice). A cache keyed by cursor would
+   add entries per click without a measured hot path asking for it. *)
+let keeper_chat_history_page_json config name ~before =
+  let base_dir = (config : Workspace.config).base_path in
+  let { Keeper_chat_store.messages; has_more } =
+    Keeper_chat_store.load_page ~base_dir ~keeper_name:name ?before ()
+  in
+  let trace_block_by_turn_ref = keeper_chat_trace_blocks config name in
+  let next_before =
+    List.fold_left
+      (fun acc ({ ts; _ } : Keeper_chat_store.chat_message) ->
+        match ts, acc with
+        | None, _ -> acc
+        | Some t, None -> Some t
+        | Some t, Some a -> Some (Float.min a t))
+      None
+      messages
+  in
+  `Assoc
+    [ "schema", `String "masc.keeper_chat_history.page.v1"
+    ; ( "messages"
+      , Keeper_chat_store.to_json_array ~base_dir ?trace_block_by_turn_ref messages )
+    ; "has_more", `Bool has_more
+    ; "next_before", (match next_before with Some t -> `Float t | None -> `Null)
+    ]
 ;;
 
 let cached_keeper_chat_history_json config name =
@@ -1567,6 +1617,33 @@ let handle_keeper_get_subroutes state req request reqd =
            in
            Server_auth.respond_json_value_with_cors ~status:`OK request reqd
              (Keeper_catchup_digest.to_json digest)))
+  else if ends_with "/chat/history/page" then
+    (* Checked before "/chat/history": [ends_with] would not confuse the two,
+       but keeping the longer suffix first means adding a third sub-route later
+       cannot silently shadow this one. *)
+    let name = extract_name "/chat/history/page" in
+    if name = "" then
+      Server_auth.respond_json_value_with_cors ~status:`Bad_request request reqd
+        (error_json "missing keeper name")
+    else if not (Keeper_config.validate_name name) then
+      Server_auth.respond_json_value_with_cors ~status:`Bad_request request reqd
+        (error_json (Printf.sprintf "invalid keeper name: %s" name))
+    else (
+      (* Absent [before] means the newest window -- the same rows /chat/history
+         serves, minus the autonomous turns. Present but unparseable is a client
+         bug, not a request for the newest page, so it is rejected rather than
+         silently treated as absent. *)
+      match Server_utils.query_param req "before" with
+      | Some raw when float_of_string_opt (String.trim raw) = None ->
+        Server_auth.respond_json_value_with_cors ~status:`Bad_request request reqd
+          (error_json "before must be a unix-seconds float")
+      | before_raw ->
+        let before =
+          Option.bind before_raw (fun raw -> float_of_string_opt (String.trim raw))
+        in
+        let config = Mcp_server.workspace_config state in
+        Server_auth.respond_json_value_with_cors ~status:`OK request reqd
+          (keeper_chat_history_page_json config name ~before))
   else if ends_with "/chat/history" then
     let name = extract_name "/chat/history" in
     if name = "" then

--- a/lib/server/server_dashboard_http_keeper_api.mli
+++ b/lib/server/server_dashboard_http_keeper_api.mli
@@ -84,6 +84,22 @@ include module type of Server_dashboard_http_keeper_api_types
     moved to Server_dashboard_http_keeper_api_types — re-exported via
     [include module type of] above. *)
 
+(** {1 Chat history paging} *)
+
+val keeper_chat_history_page_json :
+  Workspace.config -> string -> before:float option -> Yojson.Safe.t
+(** Body for [GET /chat/history/page]: direct-conversation rows older than
+    [before], newest window when [before] is [None].
+
+    Autonomous turns are not included. They are bounded by
+    {!Masc.Keeper_raw_trace_retention.history_limit} rather than by this window,
+    so [GET /chat/history] already carried every one that exists; repeating them
+    per page would duplicate rows the caller holds.
+
+    [next_before] is the cursor for the following page — the oldest [ts] among
+    the returned rows, or [`Null] for an empty page. A caller must stop on a
+    null cursor rather than resend the previous one. *)
+
 (** {1 Checkpoint inventory} *)
 
 val stat_json_of_path : string -> Yojson.Safe.t

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -92,6 +92,7 @@ normal_targets=(
   @test/runtest-test_file_kind_vocabulary
   @test/runtest-test_http_auth_strict_flag
   @test/runtest-test_keeper_chat_broadcast
+  @test/runtest-test_server_dashboard_http_keeper_chat_page
   @test/runtest-test_keeper_codex_effort_clamp
   @test/runtest-test_keeper_codex_error_carriage
   @test/runtest-test_keeper_persistence_span_history

--- a/test/dune
+++ b/test/dune
@@ -100,6 +100,7 @@
   test_keeper_turn_terminal_disposition_field
   test_keeper_memory_os_current
   test_server_dashboard_http_keeper_api_trace
+  test_server_dashboard_http_keeper_chat_page
   test_keeper_paused_work_resume_surface
   eval_memory_os_value
   test_keeper_running_reconcile_attempt
@@ -397,6 +398,7 @@
   test_keeper_turn_terminal_disposition_field
   test_keeper_memory_os_current
   test_server_dashboard_http_keeper_api_trace
+  test_server_dashboard_http_keeper_chat_page
   test_keeper_paused_work_resume_surface
   eval_memory_os_value
   test_keeper_running_reconcile_attempt

--- a/test/test_server_dashboard_http_keeper_chat_page.ml
+++ b/test/test_server_dashboard_http_keeper_chat_page.ml
@@ -1,0 +1,236 @@
+(* Body contract for GET /chat/history/page.
+
+   The store-level walk is already pinned by test_keeper_chat_store.ml
+   ("load_page walks backward"). What is asserted here is the layer this route
+   adds on top: the schema tag, the cursor the caller is told to use next, and
+   the two ways paging ends -- exhausted history, and history that exists but
+   no cursor can reach. *)
+
+open Masc
+module Keeper_api = Server_dashboard_http_keeper_api
+
+let rec remove_tree path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+      Unix.rmdir path
+    end
+    else Sys.remove path
+;;
+
+let rec mkdir_p dir =
+  if dir = "" || dir = "." || dir = "/" then ()
+  else if Sys.file_exists dir then ()
+  else begin
+    mkdir_p (Filename.dirname dir);
+    Unix.mkdir dir 0o755
+  end
+;;
+
+let temp_base_path prefix =
+  Filename.concat
+    (Filename.get_temp_dir_name ())
+    (Printf.sprintf "%s-%d-%d" prefix (Unix.getpid ()) (Random.bits ()))
+;;
+
+let chat_path ~base_dir ~keeper_name =
+  Filename.concat
+    (Filename.concat
+       (Common.masc_dir_from_base_path ~base_path:base_dir)
+       "keeper_chat")
+    (keeper_name ^ ".jsonl")
+;;
+
+(* [ts] omitted entirely for [`Untimed]: that is the legacy row shape the
+   cursor cannot order, and constructing it is the whole point of one case.
+   [id] is required -- the store drops rows without one. *)
+let row ~content stamp =
+  let base = [ "id", `String content; "role", `String "user"; "content", `String content ] in
+  match stamp with
+  | `At ts -> `Assoc (base @ [ "ts", `Float ts ])
+  | `Untimed -> `Assoc base
+;;
+
+let write_lane ~base_dir ~keeper_name rows =
+  let path = chat_path ~base_dir ~keeper_name in
+  mkdir_p (Filename.dirname path);
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out oc)
+    (fun () ->
+      List.iter
+        (fun row -> output_string oc (Yojson.Safe.to_string row ^ "\n"))
+        rows)
+;;
+
+let numbered ~total =
+  List.init total (fun i ->
+    let n = i + 1 in
+    row ~content:(Printf.sprintf "msg-%04d" n) (`At (float_of_int n)))
+;;
+
+let field name = function
+  | `Assoc fields -> List.assoc_opt name fields
+  | _ -> None
+;;
+
+let messages_of body =
+  match field "messages" body with
+  | Some (`List rows) -> rows
+  | Some _ | None -> Alcotest.fail "messages is not a list"
+;;
+
+let content_of = function
+  | `Assoc fields ->
+    (match List.assoc_opt "content" fields with
+     | Some (`String s) -> s
+     | Some _ | None -> Alcotest.fail "row has no string content")
+  | _ -> Alcotest.fail "row is not an object"
+;;
+
+let bool_field name body =
+  match field name body with
+  | Some (`Bool b) -> b
+  | Some _ | None -> Alcotest.fail (name ^ " is not a bool")
+;;
+
+let with_lane prefix rows f =
+  let base_dir = temp_base_path prefix in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "pager" in
+      write_lane ~base_dir ~keeper_name rows;
+      f (Workspace.default_config base_dir) keeper_name)
+;;
+
+let test_tag_and_cursor () =
+  with_lane "chat-page-cursor" (numbered ~total:300) (fun config name ->
+    let body = Keeper_api.keeper_chat_history_page_json config name ~before:None in
+    Alcotest.(check (option string))
+      "schema tag"
+      (Some "masc.keeper_chat_history.page.v1")
+      (match field "schema" body with Some (`String s) -> Some s | _ -> None);
+    let rows = messages_of body in
+    Alcotest.(check int) "newest window size" 100 (List.length rows);
+    Alcotest.(check string)
+      "newest row last"
+      "msg-0300"
+      (content_of (List.hd (List.rev rows)));
+    Alcotest.(check bool) "older rows remain" true (bool_field "has_more" body);
+    (* The cursor is the oldest ts in the window, so the next page starts
+       exactly where this one stopped -- no row served twice, none skipped. *)
+    Alcotest.(check (option (float 0.001)))
+      "next cursor is the oldest returned ts"
+      (Some 201.0)
+      (match field "next_before" body with Some (`Float f) -> Some f | _ -> None))
+;;
+
+let test_cursor_walks_without_gap_or_repeat () =
+  with_lane "chat-page-walk" (numbered ~total:300) (fun config name ->
+    let page before = Keeper_api.keeper_chat_history_page_json config name ~before in
+    let first = page None in
+    let cursor body =
+      match field "next_before" body with Some (`Float f) -> Some f | _ -> None
+    in
+    let second = page (cursor first) in
+    let rows = messages_of second in
+    Alcotest.(check string) "page 2 first" "msg-0101" (content_of (List.hd rows));
+    Alcotest.(check string)
+      "page 2 last is one below page 1's first"
+      "msg-0200"
+      (content_of (List.hd (List.rev rows)));
+    let third = page (cursor second) in
+    let third_rows = messages_of third in
+    Alcotest.(check string)
+      "page 3 first"
+      "msg-0001"
+      (content_of (List.hd third_rows));
+    Alcotest.(check bool)
+      "history exhausted"
+      false
+      (bool_field "has_more" third))
+;;
+
+let test_exhausted_history_reports_null_cursor () =
+  with_lane "chat-page-short" (numbered ~total:3) (fun config name ->
+    let body = Keeper_api.keeper_chat_history_page_json config name ~before:(Some 1.0) in
+    Alcotest.(check int) "no rows older than the first" 0 (List.length (messages_of body));
+    Alcotest.(check bool) "nothing older" false (bool_field "has_more" body);
+    Alcotest.(check bool)
+      "empty page carries no cursor"
+      true
+      (match field "next_before" body with Some `Null -> true | _ -> false))
+;;
+
+let test_cursor_is_monotonic_so_the_walk_terminates () =
+  (* Whatever the rows carry, each page's cursor must be strictly older than
+     the one that produced it. That is the property the caller's loop relies on
+     to end; asserting it directly means a future change to how the store
+     stamps rows cannot turn "load more" into a spin. *)
+  with_lane "chat-page-monotonic" (numbered ~total:300) (fun config name ->
+    let cursor body =
+      match field "next_before" body with Some (`Float f) -> Some f | _ -> None
+    in
+    let rec walk before seen steps =
+      if steps > 10 then Alcotest.fail "cursor did not terminate within 10 pages"
+      else
+        let body = Keeper_api.keeper_chat_history_page_json config name ~before in
+        match cursor body with
+        | None -> List.rev seen
+        | Some c ->
+          (match before with
+           | Some prev when c >= prev ->
+             Alcotest.failf "cursor %f did not move below previous %f" c prev
+           | Some _ | None -> ());
+          walk (Some c) (c :: seen) (steps + 1)
+    in
+    let cursors = walk None [] 0 in
+    Alcotest.(check bool) "the walk produced pages" true (cursors <> []))
+;;
+
+let test_autonomous_turns_are_not_repeated_per_page () =
+  (* /chat/history carries every autonomous turn retention still holds; a page
+     that re-sent them would duplicate rows the caller already has. With no
+     autonomous source written at all, the assertion is simply that the page
+     body is exactly the chat rows. *)
+  with_lane "chat-page-direct-only" (numbered ~total:5) (fun config name ->
+    let body = Keeper_api.keeper_chat_history_page_json config name ~before:None in
+    let rows = messages_of body in
+    Alcotest.(check int) "chat rows only" 5 (List.length rows);
+    List.iter
+      (fun r ->
+        Alcotest.(check bool)
+          "no autonomous_turn marker on a paged row"
+          false
+          (match r with
+           | `Assoc fields -> List.mem_assoc "autonomous_turn" fields
+           | _ -> false))
+      rows)
+;;
+
+let () =
+  Alcotest.run
+    "server_dashboard_http_keeper_chat_page"
+    [ ( "GET /chat/history/page"
+      , [ Alcotest.test_case "schema tag and next cursor" `Quick test_tag_and_cursor
+        ; Alcotest.test_case
+            "walking the cursor repeats no row and skips none"
+            `Quick
+            test_cursor_walks_without_gap_or_repeat
+        ; Alcotest.test_case
+            "exhausted history reports a null cursor"
+            `Quick
+            test_exhausted_history_reports_null_cursor
+        ; Alcotest.test_case
+            "the cursor moves strictly older so the walk terminates"
+            `Quick
+            test_cursor_is_monotonic_so_the_walk_terminates
+        ; Alcotest.test_case
+            "autonomous turns are not repeated per page"
+            `Quick
+            test_autonomous_turns_are_not_repeated_per_page
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 무엇을

`GET /api/v1/keepers/:name/chat/history/page?before=<ts>` 를 추가한다. 대시보드가 tail 창보다 오래된 직접 대화를 한 창씩 뒤로 걸어갈 수 있게 된다.

## 왜 — 측정부터

`Keeper_chat_store.load_page` 는 RFC-0228 P1 이후 `?before` 커서와 `has_more` 를 갖고 있는데, **HTTP 로 노출된 적이 없다.** `/chat/history` 는 커서 없는 `load` 를 부르고, 그 창은 최근 user/assistant 100행(절대 상한 400줄)이다. 그보다 오래된 건 디스크에 있는데 대시보드에서 열 수 없다.

이게 이론적 한계가 아님을 라이브 레인에서 확인했다 (`~/me/.masc/keeper_chat/*.jsonl`):

| keeper | 전체 행 | primary | 도달 가능 | 불가시 |
|---|---:|---:|---:|---:|
| sangsu | 2333 | 1766 | 100 | **1666 (94%)** |
| kidsnote | 614 | 460 | 100 | 360 |
| rtprobe | 443 | 272 | 100 | 172 |
| rondo | 507 | 245 | 100 | 145 |
| lane-smith | 469 | 156 | 100 | 56 |
| analyst | 327 | 134 | 100 | 34 |
| taskmaster | 293 | 107 | 100 | 7 |
| code-reviewer | 337 | 69 | 69 | 0 |

**8개 중 7개가 창을 넘는다.**

## 설계 결정

**자율턴은 페이지에 넣지 않는다.** 자율턴은 이 창이 아니라 `Keeper_raw_trace_retention.history_limit` 로 경계가 정해지므로, 첫 `/chat/history` 가 이미 존재하는 전부를 실어 보냈다. 페이지마다 다시 보내면 클라이언트가 가진 행을 중복시킨다. 그래서 이건 기존 라우트의 *모드*가 아니라 **형제 리소스**이고, `/chat/history` 에 쿼리 파라미터를 붙이는 대신 별도 경로 + 자체 schema 태그로 냈다. 기존 라우트의 배열 응답 형태는 그대로라 **깨지는 클라이언트가 없다.**

**커서를 서버가 계산한다.** `next_before` = 반환된 행 중 가장 오래된 `ts`. 클라이언트가 걷기 규칙을 다시 구현하면 행을 건너뛰거나 중복시킬 수 있으므로 SSOT 를 서버에 둔다.

**`before` 부재 = 최신 창. 파싱 실패 = 400.** 클라이언트 버그가 "1페이지 주세요"로 읽혀서는 안 된다.

**캐시 없음.** 페이지는 사용자 클릭이고 `load_page` 는 이미 유계 I/O(이진 탐색 프로브 + 창 슬라이스 하나)다. 커서별 캐시는 클릭마다 엔트리를 만드는데 그걸 요구하는 측정된 hot path 가 없다.

**trace 보강 중복 제거.** `keeper_chat_trace_blocks` 로 올려서 두 라우트가 같은 방식으로 읽는다.

## 검증

로컬 실행:

- `dune build @default @check` — `FULL_BUILD_EXIT=0`, 에러 0
- 신규 `test_server_dashboard_http_keeper_chat_page` — **5/5 통과**
- 회귀: `test_keeper_chat_store` 57/57, `test_keeper_catchup_digest` 7/7, `test_server_dashboard_http_keeper_api_trace` 17/17

테스트가 고정하는 건 이 라우트가 **더한 층**이다(스토어 walk 자체는 `test_keeper_chat_store.ml` 이 이미 덮는다):

| 케이스 | 단언 |
|---|---|
| schema tag and next cursor | `masc.keeper_chat_history.page.v1`, 창 100행, 커서 = 가장 오래된 ts |
| walking the cursor | 2·3페이지가 행을 중복도 누락도 안 함, 소진 시 `has_more=false` |
| exhausted history | 빈 페이지는 `next_before: null` |
| cursor moves strictly older | 매 페이지 커서가 직전보다 엄격히 작음 → walk 종료 보장 |
| autonomous turns not repeated | 페이지 본문에 `autonomous_turn` 마커 0건 |

## 작업 중 발견한 결함 (우회하지 않음) — #28550

`next_before` 를 "ts 없는 행이면 null" 로 고정하려다 실패해서 발견했다. `Keeper_chat_store.parse_line:1312` 은 `ts` 부재를 **`Some 0.0`** 으로 읽는데, 같은 파일의 `quiet_line_ts:1657` 은 같은 부재를 **`None`** 으로 읽는다. 그래서 `chat_message.ts` 의 `None` 은 이 경로에서 도달 불가고, `load_page` 의 `.mli` 가 문서화한 "legacy rows … unreachable through paging" 이 성립하지 않는다.

이 PR 은 그걸 **우회하지도, 테스트로 고정하지도 않았다.** 대신:
- `.mli` / 코드 주석을 실제 동작에 맞춰 쓰고 결함을 명시
- 종료 보장 테스트는 버그 동작이 아니라 **커서 단조 감소**라는 참인 성질을 단언
- 결함은 소비자 3곳(catchup digest, surface_read, load_page)의 `None` 처리 결정이 필요해 별도 이슈

라이브 데이터에 `ts` 없는 행은 **0건**이라 지금 깨지고 있지는 않다.

## 범위 밖

클라이언트 소비("이전 대화 더 보기" 컨트롤)는 후속 PR. 이 PR 은 서버 표면만이라 대시보드 동작은 변하지 않는다.

RFC-WAIVED: 대시보드 읽기 라우트 추가는 CLAUDE.md agent_delegation 이 RFC 를 요구하는 subsystem (credential / repo_manager / operator_control / dashboard credential-settings / hooks / workflow 문서) 어디에도 해당하지 않는다.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
