### PR TITLE
fix(runtime): keep AgentWorld librarian-only

### DIFF
--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -211,6 +211,159 @@ let find_declared_lane (lanes : Runtime_lane.t list) (id : string) =
   List.find_opt (fun lane -> String.equal (Runtime_lane.id lane) id) lanes
 ;;
 
+type runtime_role =
+  | Keeper_turn
+  | Cross_verification
+  | Media_failover
+  | Librarian
+  | Compaction
+  | Hitl_auto_judge
+  | Board_attention
+  | Other_exact_output_lane of string
+[@@deriving show, eq]
+
+type runtime_role_eligibility =
+  | Eligible
+  | Unsupported of
+      { target_ref : string
+      ; policy : Runtime_schema.runtime_role_policy
+      ; requested_role : runtime_role
+      }
+[@@deriving show, eq]
+
+let runtime_role_to_string = function
+  | Keeper_turn -> "keeper-turn"
+  | Cross_verification -> "cross-verification"
+  | Media_failover -> "media-failover"
+  | Librarian -> "librarian"
+  | Compaction -> "compaction"
+  | Hitl_auto_judge -> "hitl-auto-judge"
+  | Board_attention -> "board-attention"
+  | Other_exact_output_lane lane_id -> "exact-output:" ^ lane_id
+;;
+
+let runtime_role_eligibility (cfg : config) ~target_ref ~role =
+  match
+    List.find_opt
+      (fun (decl : Runtime_schema.runtime_role_policy_decl) ->
+         String.equal decl.target_ref target_ref)
+      cfg.runtime_role_policy_decls
+  with
+  | None -> Eligible
+  | Some { policy = Runtime_schema.Unrestricted; _ } -> Eligible
+  | Some { policy = Runtime_schema.Librarian_only; _ } when equal_runtime_role role Librarian ->
+    Eligible
+  | Some { policy; _ } -> Unsupported { target_ref; policy; requested_role = role }
+;;
+
+let runtime_role_policy_to_string = function
+  | Runtime_schema.Unrestricted -> "unrestricted"
+  | Runtime_schema.Librarian_only -> "librarian-only"
+;;
+
+type runtime_role_reference =
+  { target_ref : string
+  ; role : runtime_role
+  ; site : string
+  }
+
+let exact_output_lane_role = function
+  | "librarian_exact" -> Librarian
+  | "compaction_exact" -> Compaction
+  | "hitl_auto_judge" -> Hitl_auto_judge
+  | "board_attention_exact" -> Board_attention
+  | lane_id -> Other_exact_output_lane lane_id
+;;
+
+let role_references_of_config
+    (cfg : config)
+    ~(default_runtime_id : string)
+    ~(lanes : Runtime_lane.t list)
+  =
+  let expand ~site ~role id =
+    match find_declared_lane lanes id with
+    | None -> [ { target_ref = id; role; site } ]
+    | Some lane ->
+      Runtime_lane.ordered_candidates lane
+      |> List.map (fun target_ref ->
+        { target_ref
+        ; role
+        ; site = Printf.sprintf "%s via [runtime.lanes.%s]" site id
+        })
+  in
+  let default_refs =
+    expand ~site:"[runtime].default" ~role:Keeper_turn default_runtime_id
+  in
+  let assignment_refs =
+    cfg.keeper_assignments
+    |> List.concat_map (fun (keeper_name, id) ->
+      expand
+        ~site:(Printf.sprintf "[runtime.assignments].%s" keeper_name)
+        ~role:Keeper_turn
+        id)
+  in
+  let cross_verifier_refs =
+    cfg.cross_verifier_runtime_id
+    |> Option.to_list
+    |> List.concat_map (expand ~site:"[runtime].cross_verifier" ~role:Cross_verification)
+  in
+  let media_failover_refs =
+    List.map
+      (fun target_ref ->
+         { target_ref; role = Media_failover; site = "[runtime].media_failover" })
+      cfg.media_failover
+  in
+  let exact_output_refs =
+    cfg.exact_output_lane_decls
+    |> List.concat_map
+         (fun ({ Runtime_schema.id; slot_ids } : Runtime_schema.exact_output_lane_decl) ->
+            let role = exact_output_lane_role id in
+            List.map
+              (fun target_ref ->
+                 { target_ref
+                 ; role
+                 ; site = Printf.sprintf "[runtime.exact_output_lanes.%s]" id
+                 })
+              slot_ids)
+  in
+  default_refs
+  @ assignment_refs
+  @ cross_verifier_refs
+  @ media_failover_refs
+  @ exact_output_refs
+;;
+
+(* Fail before any state publication. This judges only role eligibility. Exact
+   output targets intentionally remain opaque here and are admitted/resolved by
+   Runtime_exact_output_registry at its own boundary. *)
+let validate_runtime_role_policies
+    ~(config_path : string)
+    (cfg : config)
+    ~(default_runtime_id : string)
+    ~(lanes : Runtime_lane.t list)
+  =
+  let references = role_references_of_config cfg ~default_runtime_id ~lanes in
+  match
+    List.find_map
+      (fun ({ target_ref; role; site } : runtime_role_reference) ->
+         match runtime_role_eligibility cfg ~target_ref ~role with
+         | Eligible -> None
+         | Unsupported { target_ref; policy; requested_role } ->
+           Some (site, target_ref, policy, requested_role))
+      references
+  with
+  | None -> Ok ()
+  | Some (site, target_ref, policy, requested_role) ->
+    Error
+      (Printf.sprintf
+         "%s: %s target %S is unsupported for role %S by policy %S"
+         config_path
+         site
+         target_ref
+         (runtime_role_to_string requested_role)
+         (runtime_role_policy_to_string policy))
+;;
+
 (* Each [runtime] reference is validated under its field's admission contract:
    - [Runtime_only] requires a declared runtime id for keeper assignments and
      media_failover entries. Assignment execution may still resolve a
@@ -1121,6 +1274,13 @@ let materialize_config
       (route_references
          [ "cross_verifier", cfg.cross_verifier_runtime_id ]
       @ media_failover_references cfg.media_failover)
+  in
+  let* () =
+    validate_runtime_role_policies
+      ~config_path
+      cfg
+      ~default_runtime_id:rt.id
+      ~lanes
   in
   let* () =
     if validate_max_context

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -142,9 +142,44 @@ val load_list :
     [\[runtime.lanes.<id>\]] candidate does not resolve (mirrors default
     validation — no silent fallback for a typo'd id). [keeper_assignments] is the
     keeper→runtime-id list; [media_failover] is the RFC-0265 ordered reroute
-    list; [lanes] is the ordered failover candidate lists. *)
+    list; [lanes] is the ordered failover candidate lists. It also fails when a
+    reachable route or exact-output slot violates [\[runtime.role_policies\]].
+    That check proves policy eligibility only, never target availability. *)
 
 val runtime_ids : t list -> string list
+
+(** {1 Role eligibility}
+
+    This admission axis is intentionally distinct from registration and live
+    availability. [Eligible] means only that the declarative role policy permits
+    the reference. *)
+
+type runtime_role =
+  | Keeper_turn
+  | Cross_verification
+  | Media_failover
+  | Librarian
+  | Compaction
+  | Hitl_auto_judge
+  | Board_attention
+  | Other_exact_output_lane of string
+[@@deriving show, eq]
+
+type runtime_role_eligibility =
+  | Eligible
+  | Unsupported of
+      { target_ref : string
+      ; policy : Runtime_schema.runtime_role_policy
+      ; requested_role : runtime_role
+      }
+[@@deriving show, eq]
+
+val runtime_role_to_string : runtime_role -> string
+
+val runtime_role_eligibility :
+  config -> target_ref:string -> role:runtime_role -> runtime_role_eligibility
+(** Pure policy lookup. It does not materialize the target, consult credentials,
+    probe health, or assert completion capability. *)
 
 type request_body_cap_error = Missing_or_non_positive_request_body_cap of
   { runtime_id : string

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -295,6 +295,21 @@ type exact_output_lane_decl =
   }
 [@@deriving show, eq]
 
+(** Role eligibility policy is separate from runtime/provider admission. A
+    declaration can name an opaque exact-output target that is not a
+    materialized Runtime, and therefore cannot imply registration or
+    availability. *)
+type runtime_role_policy =
+  | Unrestricted
+  | Librarian_only
+[@@deriving show, eq]
+
+type runtime_role_policy_decl =
+  { target_ref : string
+  ; policy : runtime_role_policy
+  }
+[@@deriving show, eq]
+
 (** {1 Top-level config}
 
     Routes/aliases/profiles/system_targets/strategy from the deleted
@@ -332,6 +347,9 @@ type config =
     (** Raw ordered AGENT_CORE target references from
         [\[runtime.exact_output_lanes.<id>\]]. MASC does not interpret them as
         provider/model runtime bindings. *)
+  ; runtime_role_policy_decls : runtime_role_policy_decl list
+    (** Role restrictions from [\[runtime.role_policies\]]. Policy admission is
+        orthogonal to target registration, resolution, and liveness. *)
   }
 [@@deriving show, eq]
 

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -204,6 +204,23 @@ type exact_output_lane_decl =
   }
 [@@deriving show, eq]
 
+(** {1 Runtime role policy}
+
+    A policy constrains which role may reference a target. It is deliberately
+    independent of provider registration, credential resolution, health, and
+    completion probes: policy eligibility is not runtime availability. *)
+
+type runtime_role_policy =
+  | Unrestricted
+  | Librarian_only
+[@@deriving show, eq]
+
+type runtime_role_policy_decl =
+  { target_ref : string
+  ; policy : runtime_role_policy
+  }
+[@@deriving show, eq]
+
 (** {1 Top-level config} *)
 
 type config =
@@ -235,6 +252,10 @@ type config =
   ; exact_output_lane_decls : exact_output_lane_decl list
     (** Raw ordered AGENT_CORE target references from
         [\[runtime.exact_output_lanes.<id>\]]. *)
+  ; runtime_role_policy_decls : runtime_role_policy_decl list
+    (** [\[runtime.role_policies\]] — target reference to role policy. These
+        declarations only constrain eligibility; they do not register or
+        resolve a runtime target and do not establish availability. *)
   }
 [@@deriving show, eq]
 

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -1354,6 +1354,10 @@ let parse_runtime_section (toml : Otoml.t) : (runtime_section, parse_error list)
            | "exact_output_lanes" ->
              (* Parsed separately as raw AGENT_CORE target references. *)
              section, errs
+           | "role_policies" ->
+             (* Parsed separately. Policy eligibility does not participate in
+                provider/runtime registration. *)
+             section, errs
            | _ when is_toml_table value ->
              (* [runtime.<profile>] tables are reserved for runtime profiles and
                 intentionally ignored by this parser layer. *)
@@ -1367,7 +1371,8 @@ let parse_runtime_section (toml : Otoml.t) : (runtime_section, parse_error list)
                       "unknown [runtime] key %S; expected default, \
                        cross_verifier, \
                        media_failover, [runtime.lanes], \
-                       [runtime.exact_output_lanes], [runtime.assignments], or a \
+                       [runtime.exact_output_lanes], [runtime.role_policies], \
+                       [runtime.assignments], or a \
                        table-valued [runtime.<profile>]"
                       key) )
         )
@@ -1522,6 +1527,53 @@ let parse_exact_output_lanes (toml : Otoml.t)
          "[runtime.exact_output_lanes] must be a table of lane tables")
 ;;
 
+let runtime_role_policy_of_string ~path = function
+  | "unrestricted" -> Ok Runtime_schema.Unrestricted
+  | "librarian-only" -> Ok Runtime_schema.Librarian_only
+  | value ->
+    Error
+      (error
+         path
+         (Printf.sprintf
+            "unknown runtime role policy %S; expected unrestricted or librarian-only"
+            value))
+;;
+
+(* [[runtime.role_policies]] constrains an opaque target reference without
+   materializing it. In particular, a successfully parsed policy row is not a
+   statement that the target is registered, credentialed, healthy, or able to
+   complete a request. Those are separate admission/probe boundaries. *)
+let parse_runtime_role_policies (toml : Otoml.t)
+  : (Runtime_schema.runtime_role_policy_decl list, parse_error list) result
+  =
+  match Otoml.find_opt toml Fun.id [ "runtime"; "role_policies" ] with
+  | None -> Ok []
+  | Some (Otoml.TomlTable entries | Otoml.TomlInlineTable entries) ->
+    partition_results
+      (List.map
+         (fun (target_ref, value) ->
+            let path = Printf.sprintf "runtime.role_policies.%s" target_ref in
+            if String.equal (String.trim target_ref) ""
+            then Error (error path "runtime role policy target must not be blank")
+            else
+              match value with
+              | Otoml.TomlString policy ->
+                Result.map
+                  (fun policy -> { Runtime_schema.target_ref; policy })
+                  (runtime_role_policy_of_string ~path policy)
+              | _ ->
+                Error
+                  (error
+                     path
+                     "runtime role policy must be a string policy name"))
+         entries)
+  | Some _ ->
+    Error
+      (error
+         "runtime.role_policies"
+         "[runtime.role_policies] must be a table of target = policy")
+;;
+
 let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) result =
   let obsolete_namespaces_result = reject_obsolete_top_level_namespaces toml in
   let providers_result = parse_providers toml in
@@ -1531,6 +1583,7 @@ let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) resu
   let bindings_result = parse_bindings toml in
   let lanes_result = parse_lanes toml in
   let exact_output_lanes_result = parse_exact_output_lanes toml in
+  let runtime_role_policies_result = parse_runtime_role_policies toml in
   let errs = function Ok _ -> [] | Error errs -> errs in
   let all_errors =
     errs obsolete_namespaces_result
@@ -1541,6 +1594,7 @@ let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) resu
     @ errs bindings_result
     @ errs lanes_result
     @ errs exact_output_lanes_result
+    @ errs runtime_role_policies_result
   in
   if all_errors <> []
   then Error all_errors
@@ -1566,6 +1620,11 @@ let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) resu
         ~label:"exact_output_lanes"
         exact_output_lanes_result
     in
+    let runtime_role_policy_decls =
+      extract_after_all_errors_guard
+        ~label:"runtime_role_policies"
+        runtime_role_policies_result
+    in
     Ok
       { Runtime_schema.providers
       ; models
@@ -1576,6 +1635,7 @@ let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) resu
       ; media_failover = runtime_section.media_failover
       ; lane_decls
       ; exact_output_lane_decls
+      ; runtime_role_policy_decls
       })
 ;;
 

--- a/lib/runtime/runtime_toml.mli
+++ b/lib/runtime/runtime_toml.mli
@@ -1,13 +1,16 @@
 (** Declarative Runtime TOML parser (RFC-0206, runtime→Runtime rebirth).
 
     Re-homed from the deleted [Runtime_declarative_parser]. Parses only
-    RFC-0058 layers 1-3 plus [\[runtime\].default] into a self-standing
+    RFC-0058 layers 1-3 plus [\[runtime\].default] and declarative role
+    eligibility policies into a self-standing
     {!Runtime_schema.config}:
 
     - [\[providers.*\]] — Layer 1
     - [\[models.*\]] — Layer 2
     - [<provider>.<model>] binding tables — Layer 3
     - [\[runtime\].default] — the default Runtime id ([provider.model])
+    - [\[runtime.role_policies\]] — target eligibility policy (never an
+      availability or registration declaration)
 
     The routing layers are intentionally NOT parsed: Layer 4 aliases
     ([<p>.<m>.<a>]), Layer 5 [\[routes\]]/[\[system\]]/[\[profiles\]], and the

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -942,6 +942,73 @@ let test_exact_output_lane_rejects_unknown_key () =
          errors)
   | Ok _ -> fail "unknown exact-output lane key must fail config parsing"
 
+let test_runtime_role_policy_is_typed_and_does_not_register_target () =
+  let target_ref = "local.canary" in
+  let content =
+    "[runtime.role_policies]\n\
+     \"local.canary\" = \"librarian-only\"\n"
+  in
+  match Runtime_toml.parse_string content with
+  | Error errors ->
+    failf
+      "librarian-only role policy must parse: %s"
+      (String.concat "; " (List.map Runtime_toml.show_parse_error errors))
+  | Ok config ->
+    check int "policy parsing does not materialize a runtime binding" 0
+      (List.length config.bindings);
+    (match config.runtime_role_policy_decls with
+     | [ { target_ref = parsed_target; policy = Runtime_schema.Librarian_only } ] ->
+       check string "opaque target reference is preserved" target_ref parsed_target
+     | policies ->
+       failf
+         "expected one librarian-only policy, got %d"
+         (List.length policies));
+    (match
+     Runtime.runtime_role_eligibility config ~target_ref ~role:Runtime.Librarian
+     with
+     | Runtime.Eligible -> ()
+     | Runtime.Unsupported _ -> fail "policy target must be eligible for librarian");
+    List.iter
+      (fun role ->
+         match Runtime.runtime_role_eligibility config ~target_ref ~role with
+         | Runtime.Unsupported { target_ref = rejected; policy; requested_role } ->
+           check string "unsupported result carries target" target_ref rejected;
+           check bool "unsupported result carries closed policy" true
+             (Runtime_schema.equal_runtime_role_policy
+                policy
+                Runtime_schema.Librarian_only);
+           check bool "unsupported result carries requested role" true
+             (Runtime.equal_runtime_role requested_role role)
+         | Runtime.Eligible ->
+           failf
+             "policy target must be unsupported for %s"
+             (Runtime.runtime_role_to_string role))
+      [ Runtime.Keeper_turn
+      ; Runtime.Cross_verification
+      ; Runtime.Media_failover
+      ; Runtime.Compaction
+      ; Runtime.Hitl_auto_judge
+      ; Runtime.Board_attention
+      ; Runtime.Other_exact_output_lane "future-role"
+      ]
+
+let test_runtime_role_policy_rejects_unknown_policy () =
+  match
+    Runtime_toml.parse_string
+      "[runtime.role_policies]\n\
+       \"local.canary\" = \"probably-librarian\"\n"
+  with
+  | Ok _ -> fail "an unknown role policy must be rejected"
+  | Error errors ->
+    check bool "policy error names the exact target path" true
+      (List.exists
+         (fun (error : Runtime_toml.parse_error) ->
+            String.equal
+              error.path
+              "runtime.role_policies.local.canary"
+            && String_util.contains_substring error.message "unknown runtime role policy")
+         errors)
+
 let test_retired_native_streaming_capability_is_rejected () =
   let config =
     "[models.sample]\n\
@@ -982,6 +1049,10 @@ let test_repo_runtime_toml_loads () =
     (match Runtime_toml.parse_file path with
      | Error _ -> fail "repo runtime.toml exact-output lanes must parse"
      | Ok config ->
+       check int
+         "public seed does not require an environment-specific role policy"
+         0
+         (List.length config.runtime_role_policy_decls);
 let lane_signatures =
   config.exact_output_lane_decls
   |> List.map (fun (lane : Runtime_schema.exact_output_lane_decl) ->
@@ -2183,6 +2254,81 @@ let with_temp_runtime_toml content f =
        )
     (fun () -> f path)
 
+let runtime_role_policy_fixture ?cross_verifier ?(exact_lane = "librarian_exact") () =
+  let cross_verifier =
+    Option.fold ~none:"" ~some:(Printf.sprintf "cross_verifier = %S\n") cross_verifier
+  in
+  Printf.sprintf
+    "[providers.local]\n\
+     protocol = \"ollama-http\"\n\
+     endpoint = \"http://127.0.0.1:11434\"\n\
+     \n\
+     [models.chat]\n\
+     api-name = \"chat\"\n\
+     max-context = 1024\n\
+     \n\
+     [models.canary]\n\
+     api-name = \"fixture-model-v1\"\n\
+     max-context = 2048\n\
+     \n\
+     [local.chat]\n\
+     \n\
+     [local.canary]\n\
+     \n\
+     [runtime]\n\
+     default = \"local.chat\"\n\
+     %s\n\
+     [runtime.role_policies]\n\
+     \"local.canary\" = \"librarian-only\"\n\
+     \n\
+     [runtime.lanes.cross_verifier_lane]\n\
+     strategy = \"ordered\"\n\
+     candidates = [\"local.canary\"]\n\
+     \n\
+     [runtime.exact_output_lanes.%s]\n\
+     slots = [\"local.canary\"]\n"
+    cross_verifier
+    exact_lane
+
+let test_materialized_runtime_stays_librarian_only_at_config_resolution () =
+  let target_ref = "local.canary" in
+  with_temp_runtime_toml (runtime_role_policy_fixture ()) (fun path ->
+    match Runtime.load_list ~config_path:path with
+    | Error message ->
+      failf "a materialized librarian-only target must load: %s" message
+    | Ok (runtimes, _, _, _, _, _) ->
+      check bool "runtime binding materializes independently" true
+        (List.exists
+           (fun (runtime : Runtime.t) -> String.equal runtime.id target_ref)
+           runtimes));
+  with_temp_runtime_toml
+    (runtime_role_policy_fixture ~cross_verifier:"cross_verifier_lane" ())
+    (fun path ->
+       match Runtime.load_list ~config_path:path with
+       | Ok _ ->
+         fail "materialization must not make the target eligible for cross-verification"
+       | Error message ->
+         check bool "config-resolution rejection names role" true
+           (String_util.contains_substring message "cross-verification");
+         check bool "config-resolution rejection proves lane expansion" true
+           (String_util.contains_substring
+              message
+              "via [runtime.lanes.cross_verifier_lane]");
+         check bool "config-resolution rejection names target" true
+           (String_util.contains_substring message target_ref);
+         check bool "config-resolution rejection names policy" true
+           (String_util.contains_substring message "librarian-only"));
+  with_temp_runtime_toml
+    (runtime_role_policy_fixture ~exact_lane:"compaction_exact" ())
+    (fun path ->
+       match Runtime.load_list ~config_path:path with
+       | Ok _ -> fail "the policy target must not enter the compaction exact-output role"
+       | Error message ->
+         check bool "exact-output rejection names lane" true
+           (String_util.contains_substring message "compaction_exact");
+         check bool "exact-output rejection names role" true
+           (String_util.contains_substring message "compaction"))
+
 let with_fake_runtime_model_catalog f =
   let content =
     "[[models]]\n\
@@ -2671,6 +2817,7 @@ let test_of_binding_reports_an_undeclared_provider () =
     ; media_failover = []
     ; lane_decls = []
     ; exact_output_lane_decls = []
+    ; runtime_role_policy_decls = []
     }
   in
   let binding =
@@ -4088,6 +4235,16 @@ let () =
             test_exact_output_lane_config_is_ordered_and_rejects_duplicates;
           test_case "exact-output lane rejects unknown keys" `Quick
             test_exact_output_lane_rejects_unknown_key;
+          test_case
+            "runtime role policy is typed and does not register its target"
+            `Quick
+            test_runtime_role_policy_is_typed_and_does_not_register_target;
+          test_case "runtime role policy rejects an unknown policy" `Quick
+            test_runtime_role_policy_rejects_unknown_policy;
+          test_case
+            "materialized runtime stays librarian-only at config resolution"
+            `Quick
+            test_materialized_runtime_stays_librarian_only_at_config_resolution;
           test_case "retired native-streaming capability is rejected" `Quick
             test_retired_native_streaming_capability_is_rejected;
           test_case "repo runtime.toml loads through runtime parser" `Quick

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -959,6 +959,7 @@ let test_runtime_adapter_keeps_auth_out_of_headers () =
     ; media_failover = []
     ; lane_decls = []
     ; exact_output_lane_decls = []
+    ; runtime_role_policy_decls = []
     }
   in
   match Runtime_adapter.binding_to_provider_config cfg runpod_binding with
@@ -992,6 +993,7 @@ let test_runtime_adapter_filters_toml_auth_headers () =
     ; media_failover = []
     ; lane_decls = []
     ; exact_output_lane_decls = []
+    ; runtime_role_policy_decls = []
     }
   in
   match Runtime_adapter.binding_to_provider_config cfg runpod_binding with
@@ -1026,6 +1028,7 @@ let provider_cfg () =
     ; media_failover = []
     ; lane_decls = []
     ; exact_output_lane_decls = []
+    ; runtime_role_policy_decls = []
     }
   in
   match Runtime_adapter.binding_to_provider_config cfg runpod_binding with
@@ -1167,6 +1170,7 @@ let runtime_or_fail ?(provider = runpod_provider) () =
     ; media_failover = []
     ; lane_decls = []
     ; exact_output_lane_decls = []
+    ; runtime_role_policy_decls = []
     }
   in
   match Runtime.of_binding cfg runpod_binding with
@@ -1187,6 +1191,7 @@ let test_runtime_of_binding_preserves_failure_reason () =
     ; media_failover = []
     ; lane_decls = []
     ; exact_output_lane_decls = []
+    ; runtime_role_policy_decls = []
     }
   in
   match Runtime.of_binding cfg { runpod_binding with enabled = false } with


### PR DESCRIPTION
## Summary

- add a closed runtime role-policy schema and parse `[runtime.role_policies]` as eligibility-only metadata
- return typed `Eligible | Unsupported` decisions and fail config resolution when a restricted target reaches Keeper, cross-verification, media failover, compaction, HITL auto judge, Board attention, or another exact-output role
- preserve lane-over-runtime routing semantics, so a restricted candidate is rejected when `cross_verifier` reaches it through a lane while a dormant lane stays inert
- seed `ollama.agentworld-35b-a3b = librarian-only` without declaring the provider/model or claiming availability

## Boundary

`Eligible` proves only that the declared policy permits a target reference. This change does not inspect credentials, register an Agent Core target, probe health/completion, or infer availability from materialization. It does not edit `/Users/dancer/me/.masc`, restart the live fleet, or overwrite existing workspaces; `config/runtime.toml` remains the new-workspace seed.

This slice gates Runtime routes and exact-output standalone roles. Fusion panel/judge/judge-of-judges consumption remains a separate small role-consumer PR before live rollout.

## Verification

- `ocamlformat --check` on all touched OCaml files
- `ocamlc -stop-after parsing` on all touched `.ml`/`.mli` files
- `bash scripts/check-toml-syntax.sh`
- `bash scripts/check-ssot.sh`
- `bash scripts/lint/no-provider-name-hardcoding.sh`
- `git diff --check`

Focused Alcotest cases were added for parser/typed eligibility, unknown-policy rejection, seed non-registration, cross-verifier lane expansion, and exact-output role rejection. Local Dune build/test was intentionally not run under the execution constraint; CI owns typechecking and executable tests.

## Follow-up completion stack

1. **Completion probe**: add authenticated typed completion evidence (`available | unavailable reason | unobserved`) without deriving it from registration or policy eligibility.
2. **Sandbox contract**: add typed requested/effective sandbox evidence and fail closed when the runtime cannot honor the role contract.
3. **Attribution + dashboard**: project role eligibility, completion-probe evidence, selected lane/slot, and sandbox provenance into execution telemetry and dashboards; preserve unobserved data as `null`.

Publish these as small PRs, stacked only where a typed producer/consumer dependency is real, then apply and verify the live policy separately.