### PR TITLE
feat(proof): add strict case JSON codec

### DIFF
--- a/lib/capability_proof/capability_proof.ml
+++ b/lib/capability_proof/capability_proof.ml
@@ -525,3 +525,217 @@ let result_error_to_string = function
   | Failure_without_evidence -> "failure_without_evidence"
   | Blank_blocker_ref -> "blank_blocker_ref"
 ;;
+
+type case_json_error =
+  | Expected_object
+  | Unknown_field of string
+  | Missing_field of string
+  | Duplicate_field of string
+  | Expected_string of string
+  | Expected_nullable_string of string
+  | Unknown_variant of string * string
+  | Invalid_case_field of create_error
+  | Case_id_mismatch of
+      { encoded : string
+      ; derived : string
+      }
+
+let case_wire_fields =
+  [ "case_id"
+  ; "runtime_id"
+  ; "model_id"
+  ; "role"
+  ; "capability"
+  ; "scenario"
+  ; "protocol"
+  ; "build_commit"
+  ; "config_revision"
+  ]
+;;
+
+let option_to_json = function
+  | None -> `Null
+  | Some value -> `String value
+;;
+
+let case_to_json case =
+  `Assoc
+    [ "case_id", `String (case_id case |> case_id_to_string)
+    ; "runtime_id", `String (runtime_id case)
+    ; "model_id", option_to_json (model_id case)
+    ; "role", `String (proof_role_to_string (role case))
+    ; "capability", `String (capability_case_to_string (capability case))
+    ; "scenario", `String (scenario_to_string (scenario case))
+    ; "protocol", `String (protocol_to_string (protocol case))
+    ; "build_commit", option_to_json (build_commit case)
+    ; "config_revision", option_to_json (config_revision case)
+    ]
+;;
+
+let exact_lane_of_string = function
+  | "librarian" -> Some Librarian
+  | "hitl_auto_judge" -> Some Hitl_auto_judge
+  | "board_attention" -> Some Board_attention
+  | "compaction" -> Some Compaction
+  | _ -> None
+;;
+
+let proof_role_of_string = function
+  | "autonomous_keeper" -> Some Autonomous_keeper
+  | "completion_authority" -> Some Completion_authority
+  | "verification" -> Some Verification
+  | "cross_verifier" -> Some Cross_verifier
+  | "fusion_panel" -> Some Fusion_panel
+  | "fusion_judge" -> Some Fusion_judge
+  | "fusion_meta_judge" -> Some Fusion_meta_judge
+  | value ->
+    let prefix = "exact_lane:" in
+    let prefix_length = String.length prefix in
+    if String.length value > prefix_length
+       && String.sub value 0 prefix_length = prefix
+    then
+      String.sub value prefix_length (String.length value - prefix_length)
+      |> exact_lane_of_string
+      |> Option.map (fun lane -> Exact_lane lane)
+    else None
+;;
+
+let capability_case_of_string = function
+  | "provider_probe" -> Some Provider_probe
+  | "autonomous_turn" -> Some Autonomous_turn
+  | "verification_run" -> Some Verification_run
+  | "cross_verification" -> Some Cross_verification
+  | "librarian_run" -> Some Librarian_run
+  | "hitl_auto_judge_run" -> Some Hitl_auto_judge_run
+  | "board_attention_run" -> Some Board_attention_run
+  | "compaction_run" -> Some Compaction_run
+  | "fusion_panel_run" -> Some Fusion_panel_run
+  | "fusion_judge_run" -> Some Fusion_judge_run
+  | "fusion_meta_judge_run" -> Some Fusion_meta_judge_run
+  | "queue_fifo" -> Some Queue_fifo
+  | "scheduler_occurrence" -> Some Scheduler_occurrence
+  | "board_comment" -> Some Board_comment
+  | "task_lifecycle" -> Some Task_lifecycle
+  | "goal_lifecycle" -> Some Goal_lifecycle
+  | "tool_serial" -> Some Tool_serial
+  | "tool_parallel" -> Some Tool_parallel
+  | "tool_batch" -> Some Tool_batch
+  | "async_lifecycle" -> Some Async_lifecycle
+  | "sandbox_containment" -> Some Sandbox_containment
+  | "broadcast_turn" -> Some Broadcast_turn
+  | "stream_replay" -> Some Stream_replay
+  | "restart_succession" -> Some Restart_succession
+  | _ -> None
+;;
+
+let scenario_of_string = function
+  | "nominal" -> Some Nominal
+  | "invalid_input" -> Some Invalid_input
+  | "provider_rejected" -> Some Provider_rejected
+  | "effect_denied" -> Some Effect_denied
+  | "effect_deferred" -> Some Effect_deferred
+  | "cancelled" -> Some Cancelled
+  | "restart_recovery" -> Some Restart_recovery
+  | "outcome_unknown" -> Some Outcome_unknown
+  | "duplicate_delivery" -> Some Duplicate_delivery
+  | "blocked_head" -> Some Blocked_head
+  | _ -> None
+;;
+
+let protocol_of_string = function
+  | "agent_core_http" -> Some Agent_core_http
+  | "official_client" -> Some Official_client
+  | "mcp" -> Some Mcp
+  | "dashboard_http" -> Some Dashboard_http
+  | "sse" -> Some Sse
+  | "websocket" -> Some Websocket
+  | "browser" -> Some Browser
+  | "durable_store" -> Some Durable_store
+  | "domain_api" -> Some Domain_api
+  | _ -> None
+;;
+
+let decode_unique fields name =
+  match List.filter (fun (field, _) -> String.equal field name) fields with
+  | [] -> Error (Missing_field name)
+  | [ (_, value) ] -> Ok value
+  | _ -> Error (Duplicate_field name)
+;;
+
+let decode_string fields name =
+  let* value = decode_unique fields name in
+  match value with
+  | `String value -> Ok value
+  | _ -> Error (Expected_string name)
+;;
+
+let decode_nullable_string fields name =
+  let* value = decode_unique fields name in
+  match value with
+  | `Null -> Ok None
+  | `String value -> Ok (Some value)
+  | _ -> Error (Expected_nullable_string name)
+;;
+
+let decode_variant fields name decode =
+  let* encoded = decode_string fields name in
+  match decode encoded with
+  | Some value -> Ok value
+  | None -> Error (Unknown_variant (name, encoded))
+;;
+
+let case_of_json = function
+  | `Assoc fields ->
+    (match
+       List.find_opt
+         (fun (name, _) -> not (List.mem name case_wire_fields))
+         fields
+     with
+     | Some (name, _) -> Error (Unknown_field name)
+     | None ->
+       let* encoded_case_id = decode_string fields "case_id" in
+       let* runtime_id = decode_string fields "runtime_id" in
+       let* model_id = decode_nullable_string fields "model_id" in
+       let* role = decode_variant fields "role" proof_role_of_string in
+       let* capability =
+         decode_variant fields "capability" capability_case_of_string
+       in
+       let* scenario = decode_variant fields "scenario" scenario_of_string in
+       let* protocol = decode_variant fields "protocol" protocol_of_string in
+       let* build_commit = decode_nullable_string fields "build_commit" in
+       let* config_revision = decode_nullable_string fields "config_revision" in
+       (match
+          create
+            ~runtime_id
+            ~model_id
+            ~role
+            ~capability
+            ~scenario
+            ~protocol
+            ~build_commit
+            ~config_revision
+        with
+        | Error error -> Error (Invalid_case_field error)
+        | Ok case ->
+          let derived_case_id = case_id case |> case_id_to_string in
+          if String.equal encoded_case_id derived_case_id
+          then Ok case
+          else
+            Error
+              (Case_id_mismatch
+                 { encoded = encoded_case_id; derived = derived_case_id })))
+  | _ -> Error Expected_object
+;;
+
+let case_json_error_to_string = function
+  | Expected_object -> "expected_object"
+  | Unknown_field name -> "unknown_field:" ^ name
+  | Missing_field name -> "missing_field:" ^ name
+  | Duplicate_field name -> "duplicate_field:" ^ name
+  | Expected_string name -> "expected_string:" ^ name
+  | Expected_nullable_string name -> "expected_nullable_string:" ^ name
+  | Unknown_variant (name, value) -> "unknown_variant:" ^ name ^ ":" ^ value
+  | Invalid_case_field error -> "invalid_case_field:" ^ create_error_to_string error
+  | Case_id_mismatch { encoded; derived } ->
+    Printf.sprintf "case_id_mismatch:encoded=%s:derived=%s" encoded derived
+;;

--- a/lib/capability_proof/capability_proof.mli
+++ b/lib/capability_proof/capability_proof.mli
@@ -195,3 +195,26 @@ val blocked : string -> (proof_result, result_error) result
 val failure_kind_to_string : failure_kind -> string
 val proof_result_to_string : proof_result -> string
 val result_error_to_string : result_error -> string
+
+type case_json_error =
+  | Expected_object
+  | Unknown_field of string
+  | Missing_field of string
+  | Duplicate_field of string
+  | Expected_string of string
+  | Expected_nullable_string of string
+  | Unknown_variant of string * string
+  | Invalid_case_field of create_error
+  | Case_id_mismatch of
+      { encoded : string
+      ; derived : string
+      }
+
+val case_to_json : t -> Yojson.Safe.t
+val case_of_json : Yojson.Safe.t -> (t, case_json_error) result
+(** Strict current-only codec for one matrix case. Unknown, duplicate,
+    missing, malformed, or identity-inconsistent fields are rejected. Optional
+    provenance is represented only as JSON [null]; no historical shape or
+    placeholder value is inferred. *)
+
+val case_json_error_to_string : case_json_error -> string

--- a/lib/capability_proof/dune
+++ b/lib/capability_proof/dune
@@ -7,4 +7,4 @@
  (modules capability_proof)
  (flags
   (:standard -w +4 -w +33))
- (libraries digestif))
+ (libraries digestif yojson))

--- a/test/capability_proof/dune
+++ b/test/capability_proof/dune
@@ -1,4 +1,4 @@
 (test
  (name test_capability_proof)
  (modules test_capability_proof)
- (libraries alcotest masc.capability_proof))
+ (libraries alcotest masc.capability_proof yojson))

--- a/test/capability_proof/test_capability_proof.ml
+++ b/test/capability_proof/test_capability_proof.ml
@@ -162,6 +162,102 @@ let test_blank_blocker_is_rejected () =
   | Ok result -> failf "blank blocker accepted as %s" (proof_result_to_string result)
 ;;
 
+let fixture_case () =
+  match
+    create
+      ~model_id:None
+      ~role:(Exact_lane Librarian)
+      ~capability:Librarian_run
+      ~scenario:Restart_recovery
+      ~protocol:Durable_store
+      ~build_commit:None
+      ()
+  with
+  | Ok case -> case
+  | Error error -> failf "unexpected case error: %s" (create_error_to_string error)
+;;
+
+let test_case_json_round_trip_preserves_absence () =
+  let original = fixture_case () in
+  match case_of_json (case_to_json original) with
+  | Error error -> failf "unexpected codec error: %s" (case_json_error_to_string error)
+  | Ok decoded ->
+    check
+      string
+      "identity round trips"
+      (original |> case_id |> case_id_to_string)
+      (decoded |> case_id |> case_id_to_string);
+    check (option string) "model remains null" None (model_id decoded);
+    check (option string) "build remains null" None (build_commit decoded)
+;;
+
+let add_field name value = function
+  | `Assoc fields -> `Assoc ((name, value) :: fields)
+  | _ -> fail "case_to_json must emit an object"
+;;
+
+let replace_field name replacement = function
+  | `Assoc fields ->
+    `Assoc
+      (List.map
+         (fun (field, value) ->
+           if String.equal field name then field, replacement else field, value)
+         fields)
+  | _ -> fail "case_to_json must emit an object"
+;;
+
+let remove_field name = function
+  | `Assoc fields -> `Assoc (List.filter (fun (field, _) -> not (String.equal field name)) fields)
+  | _ -> fail "case_to_json must emit an object"
+;;
+
+let test_case_json_rejects_unknown_duplicate_and_missing_fields () =
+  let json = case_to_json (fixture_case ()) in
+  let cases =
+    [ Unknown_field "future", add_field "future" `Null json
+    ; Duplicate_field "runtime_id", add_field "runtime_id" (`String "duplicate") json
+    ; Missing_field "protocol", remove_field "protocol" json
+    ]
+  in
+  List.iter
+    (fun (expected, json) ->
+      match case_of_json json with
+      | Error error ->
+        check
+          string
+          "strict structural error"
+          (case_json_error_to_string expected)
+          (case_json_error_to_string error)
+      | Ok decoded ->
+        failf "malformed JSON produced %s" (decoded |> case_id |> case_id_to_string))
+    cases
+;;
+
+let test_case_json_rejects_unknown_variant () =
+  match case_to_json (fixture_case ()) |> replace_field "role" (`String "keeper-ish") |> case_of_json with
+  | Error (Unknown_variant ("role", "keeper-ish")) -> ()
+  | Error error -> failf "unexpected codec error: %s" (case_json_error_to_string error)
+  | Ok _ -> fail "unknown role was accepted"
+;;
+
+let test_case_json_rejects_wrong_nullability () =
+  match case_to_json (fixture_case ()) |> replace_field "runtime_id" `Null |> case_of_json with
+  | Error (Expected_string "runtime_id") -> ()
+  | Error error -> failf "unexpected codec error: %s" (case_json_error_to_string error)
+  | Ok _ -> fail "null runtime_id was accepted"
+;;
+
+let test_case_json_rejects_identity_mismatch () =
+  match
+    case_to_json (fixture_case ())
+    |> replace_field "case_id" (`String "cpc_wrong")
+    |> case_of_json
+  with
+  | Error (Case_id_mismatch { encoded = "cpc_wrong"; _ }) -> ()
+  | Error error -> failf "unexpected codec error: %s" (case_json_error_to_string error)
+  | Ok _ -> fail "mismatched case id was accepted"
+;;
+
 let () =
   run
     "capability proof identity"
@@ -180,6 +276,13 @@ let () =
         ; test_case "failure needs evidence" `Quick test_failed_requires_evidence
         ; test_case "unsupported is typed" `Quick test_unsupported_policy_is_not_a_failure
         ; test_case "blocker nonblank" `Quick test_blank_blocker_is_rejected
+        ] )
+    ; ( "case JSON"
+      , [ test_case "round trip" `Quick test_case_json_round_trip_preserves_absence
+        ; test_case "strict fields" `Quick test_case_json_rejects_unknown_duplicate_and_missing_fields
+        ; test_case "closed variants" `Quick test_case_json_rejects_unknown_variant
+        ; test_case "nullability" `Quick test_case_json_rejects_wrong_nullability
+        ; test_case "identity" `Quick test_case_json_rejects_identity_mismatch
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- encode the complete capability-case identity as current-only JSON
- reject unknown, duplicate, missing, malformed, and unknown-variant fields
- recompute and verify the deterministic case ID on decode
- preserve absent model/build/config provenance only as JSON null

## Validation
- 17 focused tests passed via direct ocamlfind compilation (no Dune)
- dead-export ratchet stays at baseline 548
- CI target audit stays at baseline 563 unwired suites
- ocamlformat, ocamlc parse, git diff, and conflict-marker checks passed
- local Dune build intentionally not run; CI is not yet evaluated

## Stack
- sibling of #28549; depends on #28547, which depends on #28545
- follow-up connects this codec to the manifest/API boundary; it is not an HTTP writer itself

No runtime discovery, filesystem mutation, provider call, or dashboard effect is included.