### PR TITLE
feat(runtime): own Agent Core execution runtime

### DIFF
--- a/lib/runtime/runtime_agent_execution_owner.ml
+++ b/lib/runtime/runtime_agent_execution_owner.ml
@@ -1,0 +1,32 @@
+type t = Agent_core.Agent.execution_runtime
+
+type install_error = Already_installed
+
+type availability =
+  | Available of t
+  | Unavailable
+
+let installed_owner : t option Atomic.t = Atomic.make None
+
+let create ~sw ~domain_mgr ~domain_count =
+  Agent_core.Agent.create_execution_runtime ~sw ~domain_mgr ~domain_count
+;;
+
+let install ~sw owner =
+  let installed = Some owner in
+  if Atomic.compare_and_set installed_owner None installed
+  then begin
+    Eio.Switch.on_release sw (fun () ->
+      ignore (Atomic.compare_and_set installed_owner installed None));
+    Ok ()
+  end
+  else Error Already_installed
+;;
+
+let current () =
+  match Atomic.get installed_owner with
+  | Some owner -> Available owner
+  | None -> Unavailable
+;;
+
+let execution_runtime owner = owner

--- a/lib/runtime/runtime_agent_execution_owner.mli
+++ b/lib/runtime/runtime_agent_execution_owner.mli
@@ -1,0 +1,36 @@
+(** Process-wide owner of Agent Core's application-lifetime execution runtime.
+
+    The server composition root creates and installs exactly one owner under
+    its root switch.  Keeper call sites may later obtain the shared runtime to
+    create one fresh execution store per Agent API call; they must not create a
+    runtime inside a turn or provider retry. *)
+
+type t
+
+type install_error = Already_installed
+
+type availability =
+  | Available of t
+  | Unavailable
+
+val create
+  :  sw:Eio.Switch.t
+  -> domain_mgr:_ Eio.Domain_manager.t
+  -> domain_count:int
+  -> (t, Agent_core.Error.t) result
+(** Create the application-lifetime runtime.  [sw] must be the process owner
+    switch rather than a request, turn, or provider-attempt switch. *)
+
+val install : sw:Eio.Switch.t -> t -> (unit, install_error) result
+(** Install the sole process owner.  The exact installation is released when
+    [sw] closes, so a later application lifetime in the same test process may
+    install a new owner. *)
+
+val current : unit -> availability
+(** Return the installed owner without inventing an inline or per-turn
+    fallback. *)
+
+val execution_runtime : t -> Agent_core.Agent.execution_runtime
+(** Project the owned capability for construction of caller-owned execution
+    stores.  Store directory and locator lifecycle remain the caller's
+    responsibility. *)

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -631,6 +631,8 @@ let startup_failure_disposition ~state_ready =
 type owner_initialization_error =
   | Runtime_config_path_unavailable
   | Run_registry_already_installed of [ `Exact_lane | `Fusion | `Verification ]
+  | Agent_core_execution_runtime_initialization_failed of Agent_core.Error.t
+  | Agent_core_execution_runtime_already_installed
   | Runtime_default_initialization_failed of Runtime.strict_init_error
   | Keeper_persistence_preparation_failed of
       Server_bootstrap_loops.keeper_persistence_prepare_error
@@ -652,6 +654,7 @@ type initialized_owner_state =
   ; path_diagnostics : Server_base_path_diagnostics.t
   ; prepared_keeper_persistence : Server_bootstrap_loops.prepared_keeper_persistence
   ; domain_pool : Domain_pool.t
+  ; agent_core_execution_runtime : Runtime_agent_execution_owner.t
   }
 
 type activated_owner_state =
@@ -669,6 +672,11 @@ let owner_initialization_error_to_string = function
     "Verification run registry already has a process owner"
   | Run_registry_already_installed `Exact_lane ->
     "Exact lane run registry already has a process owner"
+  | Agent_core_execution_runtime_initialization_failed error ->
+    "Agent Core execution runtime initialization failed: "
+    ^ Agent_core.Error.to_string error
+  | Agent_core_execution_runtime_already_installed ->
+    "Agent Core execution runtime already has a process owner"
   | Runtime_default_initialization_failed error ->
     "Runtime.init_default_degraded failed: "
     ^ Runtime.strict_init_error_to_string error
@@ -1030,7 +1038,28 @@ let initialize_owner_state_blocking
   Log.Server.info
     "Domain_pool created (%d domains) for dashboard/keeper compute"
     (Domain_pool.domain_count domain_pool);
-  { state; path_diagnostics; prepared_keeper_persistence; domain_pool }
+  let agent_core_execution_runtime =
+    match
+      Runtime_agent_execution_owner.create
+        ~sw
+        ~domain_mgr
+        ~domain_count:(Domain_pool.domain_count domain_pool)
+    with
+    | Ok runtime -> runtime
+    | Error error ->
+      raise
+        (Owner_initialization_failed
+           (Agent_core_execution_runtime_initialization_failed error))
+  in
+  Log.Server.info
+    "Agent Core execution runtime created (%d domains) for execution journals"
+    (Domain_pool.domain_count domain_pool);
+  { state
+  ; path_diagnostics
+  ; prepared_keeper_persistence
+  ; domain_pool
+  ; agent_core_execution_runtime
+  }
 
 (* Cap the per-boot file list in the sync log line; full counts are always
    logged, names are illustrative. *)
@@ -1292,6 +1321,16 @@ let activate_owner_state
       (initialized : initialized_owner_state)
   =
   let state = initialized.state in
+  (match
+     Runtime_agent_execution_owner.install
+       ~sw
+       initialized.agent_core_execution_runtime
+   with
+   | Ok () -> ()
+   | Error Runtime_agent_execution_owner.Already_installed ->
+     raise
+       (Owner_initialization_failed
+          Agent_core_execution_runtime_already_installed));
   (* Establish the complete barrier before the irreversible ownership commit.
      Gate restore, claim, and start stay ordered inside one transport-neutral
      function. Each composition root publishes readiness only after its own

--- a/lib/server/server_runtime_bootstrap.mli
+++ b/lib/server/server_runtime_bootstrap.mli
@@ -132,6 +132,8 @@ val startup_failure_disposition : state_ready:bool -> startup_failure_dispositio
 type owner_initialization_error =
   | Runtime_config_path_unavailable
   | Run_registry_already_installed of [ `Exact_lane | `Fusion | `Verification ]
+  | Agent_core_execution_runtime_initialization_failed of Agent_core.Error.t
+  | Agent_core_execution_runtime_already_installed
   | Runtime_default_initialization_failed of Runtime.strict_init_error
   | Keeper_persistence_preparation_failed of
       Server_bootstrap_loops.keeper_persistence_prepare_error

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -252,6 +252,7 @@ normal_targets=(
   @test/runtest-test_server_runtime_startup_maintenance
   @test/runtest-test_runtime_per_keeper_routing
   @test/runtest-test_runtime_agent_execution_store_source
+  @test/runtest-test_runtime_agent_execution_owner_source
   @test/runtest-test_ide_bridge
   @test/runtest-test_dashboard_workspace
   @test/runtest-test_host_fd_pressure_poller

--- a/test/dune
+++ b/test/dune
@@ -1952,6 +1952,7 @@
 (include stanzas/test_runtime_agent_core_eio_context_classify.inc)
 
 (include stanzas/test_runtime_agent_execution_store_source.inc)
+(include stanzas/test_runtime_agent_execution_owner_source.inc)
 
 
 (include stanzas/test_runtime_model_temperature_toml.inc)

--- a/test/stanzas/test_runtime_agent_execution_owner_source.inc
+++ b/test/stanzas/test_runtime_agent_execution_owner_source.inc
@@ -1,0 +1,14 @@
+; Agent Core execution runtime is created once by the server composition root,
+; installed under its root switch, and never reconstructed by turn retry code.
+
+(test
+ (name test_runtime_agent_execution_owner_source)
+ (modules test_runtime_agent_execution_owner_source)
+ (deps
+  ../lib/runtime/runtime_agent_execution_owner.ml
+  ../lib/runtime/runtime_agent_execution_owner.mli
+  ../lib/server/server_runtime_bootstrap.ml
+  ../lib/keeper/keeper_agent_run.ml
+  ../lib/keeper/keeper_turn_driver.ml
+  ../lib/keeper/keeper_turn_driver_try_provider.ml
+  ../lib/runtime/runtime_agent.ml))

--- a/test/test_runtime_agent_execution_owner_source.ml
+++ b/test/test_runtime_agent_execution_owner_source.ml
@@ -1,0 +1,108 @@
+(* Keep Agent Core's execution runtime at the application owner boundary.
+   A Keeper turn, candidate failover, or context-shrink retry must never create
+   a replacement runtime as an implicit fallback. *)
+
+let read_file path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> In_channel.input_all ic)
+;;
+
+let normalize_whitespace input =
+  let output = Buffer.create (String.length input) in
+  let pending_space = ref false in
+  String.iter
+    (function
+      | ' ' | '\n' | '\r' | '\t' -> pending_space := Buffer.length output > 0
+      | char ->
+        if !pending_space then Buffer.add_char output ' ';
+        pending_space := false;
+        Buffer.add_char output char)
+    input;
+  Buffer.contents output
+;;
+
+let contains haystack needle =
+  let haystack_length = String.length haystack in
+  let needle_length = String.length needle in
+  let rec loop offset =
+    if offset + needle_length > haystack_length
+    then false
+    else if String.sub haystack offset needle_length = needle
+    then true
+    else loop (offset + 1)
+  in
+  needle_length = 0 || loop 0
+;;
+
+let assert_contains ~label source expected =
+  if not (contains source expected)
+  then failwith (Printf.sprintf "[%s] expected source to contain %S" label expected)
+;;
+
+let assert_not_contains ~label source unexpected =
+  if contains source unexpected
+  then failwith (Printf.sprintf "[%s] source must not contain %S" label unexpected)
+;;
+
+let resolve_source relative =
+  let parent path = Filename.dirname path in
+  let project_root = parent (parent (parent (parent Sys.executable_name))) in
+  let candidates =
+    [ relative; Filename.concat project_root relative; Filename.concat ".." relative ]
+  in
+  match List.find_opt Sys.file_exists candidates with
+  | Some path -> normalize_whitespace (read_file path)
+  | None ->
+    failwith
+      (Printf.sprintf
+         "could not resolve %s (cwd=%s, exe=%s)"
+         relative
+         (Sys.getcwd ())
+         Sys.executable_name)
+;;
+
+let () =
+  let owner = resolve_source "lib/runtime/runtime_agent_execution_owner.ml" in
+  let owner_interface =
+    resolve_source "lib/runtime/runtime_agent_execution_owner.mli"
+  in
+  let bootstrap = resolve_source "lib/server/server_runtime_bootstrap.ml" in
+  assert_contains
+    ~label:"typed creation"
+    owner
+    "Agent_core.Agent.create_execution_runtime ~sw ~domain_mgr ~domain_count";
+  assert_contains
+    ~label:"single owner claim"
+    owner
+    "Atomic.compare_and_set installed_owner None installed";
+  assert_contains
+    ~label:"root switch release"
+    owner
+    "Eio.Switch.on_release sw";
+  assert_contains
+    ~label:"no fallback availability"
+    owner_interface
+    "type availability = | Available of t | Unavailable";
+  assert_contains
+    ~label:"composition-root sizing"
+    bootstrap
+    "Runtime_agent_execution_owner.create ~sw ~domain_mgr ~domain_count:(Domain_pool.domain_count domain_pool)";
+  assert_contains
+    ~label:"composition-root install"
+    bootstrap
+    "Runtime_agent_execution_owner.install ~sw initialized.agent_core_execution_runtime";
+  List.iter
+    (fun relative ->
+       assert_not_contains
+         ~label:relative
+         (resolve_source relative)
+         "create_execution_runtime")
+    [ "lib/keeper/keeper_agent_run.ml"
+    ; "lib/keeper/keeper_turn_driver.ml"
+    ; "lib/keeper/keeper_turn_driver_try_provider.ml"
+    ; "lib/runtime/runtime_agent.ml"
+    ];
+  print_endline "test_runtime_agent_execution_owner_source: OK"
+;;


### PR DESCRIPTION
## Summary

- add a typed process owner for Agent Core's application-lifetime execution runtime
- create the runtime once from the shared server composition root and bind cleanup to the root Eio switch
- fail closed on duplicate installation; expose no inline or per-turn fallback
- add a source ratchet proving Keeper turn/failover/context-shrink code cannot create its own execution runtime
- wire the ratchet into the focused CI target list without changing the unwired baseline

## Stack

- Base: #28546 (`agent/runtime-agent-execution-store`)
- Head: `agent/keeper-execution-store-owner`
- Merge order: #28546 first, then this PR

## Scope decision

The production caller census found no durable operation identity that is unique across outer runtime-candidate attempts, inner context-shrink/no-thinking retries, and crash resume. This PR therefore does not synthesize a locator or create execution stores yet. A follow-up stacked PR must first introduce that durable typed operation identity and locator lifecycle, then construct one fresh store per Agent API call and pass it through the #28546 contract.

Raw_trace, Event_bus, Durable_event, and direct-writer removal are intentionally out of scope.

## Fast verification

- `ocaml test/test_runtime_agent_execution_owner_source.ml`
- `ocamlc -stop-after parsing -c` for changed OCaml sources/interfaces
- `ocamlformat 0.29.0 --check` for changed OCaml sources/interfaces
- `bash -n scripts/ci-run-focused-tests.sh`
- `bash scripts/audit-ci-test-targets.sh` (300 CI targets; unwired baseline remains 563)
- `git diff --check`
- conflict-marker scan

Local Dune build/tests were intentionally not run. GitHub CI is not yet verified for this head.