### PR TITLE
fix(worktrees): preserve live locked cleanups

### DIFF
--- a/scripts/cleanup-merged-worktrees.sh
+++ b/scripts/cleanup-merged-worktrees.sh
@@ -31,7 +31,9 @@ git fetch origin main --quiet
 #  (1) `git branch --merged origin/main` — catches fast-forward / non-squash merges
 #  (2) `gh pr list --state merged` — catches squash-merges (common case on this repo)
 # Union both so squash-merged worktrees are actually cleaned.
-FF_MERGED="$(git branch --merged origin/main | sed 's/^[* ]*//' | grep -v '^main$' || true)"
+# A branch checked out in another worktree is prefixed with [+]. Those are the
+# branches this script exists to inspect, so normalize [+] along with [*].
+FF_MERGED="$(git branch --merged origin/main | sed 's/^[*+ ]*//' | grep -v '^main$' || true)"
 
 if command -v gh >/dev/null 2>&1; then
   SQUASH_MERGED="$(gh pr list --state merged --limit 500 --json headRefName --jq '.[].headRefName' 2>/dev/null || true)"
@@ -78,7 +80,8 @@ while read -r branch; do
   fi
 
   if worktree_cleanup_is_locked "$wt_path"; then
-    local owner
+    # This loop runs at script scope, not inside a function; [local] here
+    # aborts exactly when the safety guard needs to report a live lock.
     owner="$(cat "$wt_path/.masc-lock" 2>/dev/null || true)"
     echo "LOCKED $wt_path (branch $branch) — skipped (held by $owner)"
     locked=$((locked+1))

--- a/scripts/cleanup-stale-worktrees.sh
+++ b/scripts/cleanup-stale-worktrees.sh
@@ -52,6 +52,7 @@ stale=0
 dirty=0
 nested=0
 active=0
+locked=0
 removed=0
 skipped=0
 
@@ -98,6 +99,13 @@ while read -r wt_path; do
     continue
   fi
 
+  if worktree_cleanup_is_locked "$wt_path"; then
+    owner="$(cat "$wt_path/.masc-lock" 2>/dev/null || true)"
+    echo "LOCKED  $wt_path — skipped (held by $owner)"
+    locked=$((locked+1))
+    continue
+  fi
+
   age_days=$(( ( $(date +%s) - last_ts ) / 86400 ))
   stale=$((stale+1))
 
@@ -117,9 +125,9 @@ done < <(git worktree list --porcelain | awk '/^worktree /{print $2}')
 if [ "$APPLY" -eq 1 ]; then
   git worktree prune
   echo ""
-  echo "Summary (--days $DAYS --apply): stale=$stale removed=$removed dirty=$dirty nested=$nested active=$active skipped=$skipped"
+  echo "Summary (--days $DAYS --apply): stale=$stale removed=$removed dirty=$dirty nested=$nested active=$active locked=$locked skipped=$skipped"
 else
   echo ""
-  echo "Summary (--days $DAYS dry-run): stale=$stale dirty=$dirty nested=$nested active=$active skipped=$skipped"
+  echo "Summary (--days $DAYS dry-run): stale=$stale dirty=$dirty nested=$nested active=$active locked=$locked skipped=$skipped"
   echo "Pass --apply to remove the listed candidates."
 fi

--- a/test/test_worktree_cleanup_lock_guards.sh
+++ b/test/test_worktree_cleanup_lock_guards.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+git init --bare "$TMP/origin.git" >/dev/null
+git init -b main "$TMP/repo" >/dev/null
+git -C "$TMP/repo" config user.email test@example.com
+git -C "$TMP/repo" config user.name "Test User"
+git -C "$TMP/repo" -c core.hooksPath=/dev/null commit --allow-empty -m initial >/dev/null
+git -C "$TMP/repo" remote add origin "$TMP/origin.git"
+git -C "$TMP/repo" push -u origin main >/dev/null
+
+# Merged cleanup: a live .masc-lock must reach the guard without the historical
+# top-level [local] error and must preserve the worktree.
+git -C "$TMP/repo" branch merged-lock
+git -C "$TMP/repo" worktree add "$TMP/merged-lock" merged-lock >/dev/null
+printf 'test-holder %s\n' "$$" > "$TMP/merged-lock/.masc-lock"
+merged_output="$(cd "$TMP/repo" && bash "$ROOT/scripts/cleanup-merged-worktrees.sh" --apply)"
+grep -E 'LOCKED .*/merged-lock ' <<< "$merged_output" >/dev/null
+test -d "$TMP/merged-lock"
+
+# Stale cleanup has the same lock invariant. The old commit date makes this
+# branch eligible without sleeping or changing the system clock.
+git -C "$TMP/repo" checkout --orphan stale-lock >/dev/null
+GIT_AUTHOR_DATE='2000-01-01T00:00:00Z' \
+GIT_COMMITTER_DATE='2000-01-01T00:00:00Z' \
+  git -C "$TMP/repo" -c core.hooksPath=/dev/null commit --allow-empty -m stale >/dev/null
+git -C "$TMP/repo" checkout main >/dev/null
+git -C "$TMP/repo" worktree add "$TMP/stale-lock" stale-lock >/dev/null
+printf 'test-holder %s\n' "$$" > "$TMP/stale-lock/.masc-lock"
+stale_output="$(cd "$TMP/repo" && bash "$ROOT/scripts/cleanup-stale-worktrees.sh" --days 1 --apply)"
+grep -E 'LOCKED  .*/stale-lock ' <<< "$stale_output" >/dev/null
+test -d "$TMP/stale-lock"
+
+echo "worktree cleanup live-lock guards: OK"


### PR DESCRIPTION
## Problem

The macOS sweeper delegates destructive cleanup to these scripts, but the safety boundary had three holes:

- merged cleanup used `local owner` at script scope and aborted when a live lock was reached
- stale cleanup did not consult `.masc-lock`
- `git branch --merged` prefixes branches checked out in another worktree with `+`, which the parser did not strip, so the primary cleanup candidates were skipped

## Change

- report live locks without the script-scope `local` error
- apply the shared live-lock guard to stale cleanup
- normalize the linked-worktree `+` marker
- add an integration test that creates real merged/stale locked worktrees and proves `--apply` preserves both

## Focused verification

- `bash -n scripts/cleanup-merged-worktrees.sh scripts/cleanup-stale-worktrees.sh test/test_worktree_cleanup_lock_guards.sh`
- `test/test_worktree_cleanup_lock_guards.sh`
- `shellcheck -e SC1091 scripts/cleanup-merged-worktrees.sh scripts/cleanup-stale-worktrees.sh test/test_worktree_cleanup_lock_guards.sh`

Full build intentionally left to the operator.