### PR TITLE
fix(dashboard): dedupe Agent Core events by identity

### DIFF
--- a/dashboard/src/agent-core-runtime-store.test.ts
+++ b/dashboard/src/agent-core-runtime-store.test.ts
@@ -469,6 +469,48 @@ describe('agent-core-runtime-store', () => {
     expect(agentCoreHealthSummary.value.agentEventsCount).toBe(2)
   })
 
+  it('keeps live arrivals out of the replay-loaded page count', async () => {
+    const entry = (seq: number): TelemetryEntry => ({
+      source: 'agent_core_event',
+      type: 'agent_core:masc:trust_updated',
+      ts_unix: 700 + seq,
+      correlation_id: `corr-replay-${seq}`,
+      run_id: 'run-replay-pages',
+      seq,
+      payload: { agent_a: 'a', agent_b: 'b', trust_score: 0.5 },
+    }) as TelemetryEntry
+
+    fetchTelemetryMock.mockResolvedValue({
+      generated_at: '2026-04-15T12:00:00Z',
+      count: 1,
+      total_matching_entries: 3,
+      has_more: true,
+      entries: [entry(1)],
+    })
+    await replayAgentCoreRuntimeTelemetry()
+
+    expect(applyAgentCoreRuntimeEvent({
+      type: 'agent_core:masc:trust_updated',
+      ts_unix: 999,
+      correlation_id: 'corr-live-between-pages',
+      run_id: 'run-live-between-pages',
+      payload: { agent_a: 'live', agent_b: 'peer', trust_score: 0.6 },
+    })).toBe(true)
+
+    fetchTelemetryMock.mockResolvedValue({
+      generated_at: '2026-04-15T12:00:00Z',
+      count: 1,
+      total_matching_entries: 3,
+      has_more: true,
+      entries: [entry(2)],
+    })
+    await loadMoreAgentCoreEvents()
+
+    expect(agentCoreHealthSummary.value.replayLoadedEvents).toBe(2)
+    expect(agentCoreHealthSummary.value.replayTotalMatchingEvents).toBe(3)
+    expect(agentCoreHealthSummary.value.replayTruncated).toBe(true)
+  })
+
   it('keeps loading more from retiring hasMore before the window is exhausted', async () => {
     // A replayed row sits inside the server's total-matching count. Counting
     // it again made loaded exceed total, and noteAgentCoreReplayWindow reads

--- a/dashboard/src/agent-core-runtime-store.test.ts
+++ b/dashboard/src/agent-core-runtime-store.test.ts
@@ -116,6 +116,7 @@ describe('agent-core-runtime-store', () => {
   it('dedupes a live event already present in replayed telemetry', () => {
     const liveEvent = {
       type: 'agent_core:masc:trust_updated',
+      event_id: 'evt-live-replay',
       ts_unix: 123,
       correlation_id: 'corr-live',
       run_id: 'run-live',
@@ -271,6 +272,7 @@ describe('agent-core-runtime-store', () => {
       const driftEvent = {
         source: 'agent_core_event',
         type: 'agent_core:durable:llm_request',
+        event_id: 'evt-drift',
         correlation_id: 'corr-drift',
         run_id: 'run-drift',
         payload: {
@@ -290,6 +292,81 @@ describe('agent-core-runtime-store', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('preserves identical strings from distinct event identities', () => {
+    const event = (eventId: string) => ({
+      type: 'agent_core:masc:trust_updated',
+      event_id: eventId,
+      ts_unix: 600,
+      correlation_id: 'corr-shared',
+      run_id: 'run-shared',
+      payload: {
+        agent_a: 'same-agent',
+        agent_b: 'same-peer',
+        trust_score: 0.5,
+        timestamp: 600,
+      },
+    })
+
+    expect(applyAgentCoreRuntimeEvent(event('evt-distinct-a'))).toBe(true)
+    expect(applyAgentCoreRuntimeEvent(event('evt-distinct-b'))).toBe(true)
+    expect(agentCoreHealthSummary.value.totalEvents).toBe(2)
+    expect(agentCoreHealthSummary.value.agentEventsCount).toBe(2)
+  })
+
+  it('scopes a repeated producer event id to its run', () => {
+    const event = (runId: string) => ({
+      type: 'agent_core:masc:trust_updated',
+      event_id: 'evt-process-local',
+      run_id: runId,
+      payload: {
+        agent_a: 'same-agent',
+        agent_b: 'same-peer',
+        trust_score: 0.5,
+      },
+    })
+
+    expect(applyAgentCoreRuntimeEvent(event('run-a'))).toBe(true)
+    expect(applyAgentCoreRuntimeEvent(event('run-b'))).toBe(true)
+    expect(agentCoreHealthSummary.value.totalEvents).toBe(2)
+  })
+
+  it('preserves unidentified identical events instead of content-deduping them', () => {
+    const event = {
+      type: 'agent_core:masc:trust_updated',
+      ts_unix: 610,
+      correlation_id: 'corr-legacy',
+      run_id: 'run-legacy',
+      payload: {
+        agent_a: 'legacy-agent',
+        agent_b: 'legacy-peer',
+        trust_score: 0.4,
+        timestamp: 610,
+      },
+    }
+
+    expect(applyAgentCoreRuntimeEvent(event)).toBe(true)
+    expect(applyAgentCoreRuntimeEvent(event)).toBe(true)
+    expect(agentCoreHealthSummary.value.totalEvents).toBe(2)
+    expect(agentCoreHealthSummary.value.agentEventsCount).toBe(2)
+  })
+
+  it('dedupes one stable run sequence across replay and live delivery', () => {
+    const event = {
+      type: 'agent_core:masc:trust_updated',
+      run_id: 'run-sequenced',
+      seq: 7,
+      payload: {
+        agent_a: 'sequenced-agent',
+        agent_b: 'sequenced-peer',
+        trust_score: 0.7,
+      },
+    }
+
+    hydrateAgentCoreRuntimeFromTelemetryEntries([{ source: 'agent_core_event', ...event } as TelemetryEntry])
+    expect(applyAgentCoreRuntimeEvent(event)).toBe(false)
+    expect(agentCoreHealthSummary.value.totalEvents).toBe(1)
   })
 
   it('replays recent Agent Core telemetry via the dashboard API', async () => {

--- a/dashboard/src/agent-core-runtime-store.test.ts
+++ b/dashboard/src/agent-core-runtime-store.test.ts
@@ -516,6 +516,7 @@ describe('agent-core-runtime-store', () => {
     expect(agentCoreHealthSummary.value.replayLoadedEvents).toBe(2)
     expect(agentCoreHealthSummary.value.replayTotalMatchingEvents).toBe(3)
     expect(agentCoreHealthSummary.value.replayTruncated).toBe(true)
+    expect(agentCoreHealthSummary.value.totalEvents).toBe(4)
   })
 
   it('keeps loading more from retiring hasMore before the window is exhausted', async () => {

--- a/dashboard/src/agent-core-runtime-store.test.ts
+++ b/dashboard/src/agent-core-runtime-store.test.ts
@@ -7,6 +7,7 @@ vi.mock('./api/dashboard', () => ({
 import { fetchTelemetry, type TelemetryEntry } from './api/dashboard'
 import {
   applyAgentCoreRuntimeEvent,
+  appendAgentCoreRuntimeFromTelemetryEntries,
   hydrateAgentCoreRuntimeFromTelemetryEntries,
   replayAgentCoreRuntimeTelemetry,
   loadMoreAgentCoreEvents,
@@ -609,5 +610,39 @@ describe('agent-core-runtime-store', () => {
     })
     expect(agentCoreHealthSummary.value.replayLoadedEvents).toBe(2)
     expect(agentCoreHealthSummary.value.replayTruncated).toBe(false)
+  })
+
+  it('stops at the telemetry offset cap without replaying a clamped page', async () => {
+    const entry = (seq: number): TelemetryEntry => ({
+      source: 'agent_core_event',
+      type: 'agent_core:masc:trust_updated',
+      event_id: `evt-cap-${seq}`,
+      run_id: 'run-cap',
+      payload: { agent_a: 'a', agent_b: 'b', trust_score: 0.5 },
+    }) as TelemetryEntry
+
+    hydrateAgentCoreRuntimeFromTelemetryEntries([entry(1)])
+    fetchTelemetryMock.mockResolvedValue({
+      generated_at: '2026-04-15T12:00:00Z',
+      count: 1,
+      total_matching_entries: 6000,
+      offset: 5000,
+      has_more: true,
+      entries: [entry(2)],
+    })
+
+    // Simulate the first request beyond the server's 5000 offset cap.
+    appendAgentCoreRuntimeFromTelemetryEntries([], 5499)
+    await loadMoreAgentCoreEvents()
+
+    expect(fetchTelemetryMock).toHaveBeenLastCalledWith({
+      source: 'agent_core_event',
+      n: 500,
+      offset: 5499,
+      signal: undefined,
+    })
+    expect(agentCoreHealthSummary.value.replayLoadedEvents).toBe(5499)
+    expect(agentCoreHealthSummary.value.replayTruncated).toBe(false)
+    expect(agentCoreHealthSummary.value.agentEventsCount).toBe(1)
   })
 })

--- a/dashboard/src/agent-core-runtime-store.test.ts
+++ b/dashboard/src/agent-core-runtime-store.test.ts
@@ -392,6 +392,7 @@ describe('agent-core-runtime-store', () => {
     fetchTelemetryMock.mockResolvedValue({
       generated_at: '2026-04-15T12:00:00Z',
       count: 1,
+      offset: 0,
       total_matching_entries: 1200,
       truncated: true,
       entries: [
@@ -430,6 +431,7 @@ describe('agent-core-runtime-store', () => {
     fetchTelemetryMock.mockResolvedValue({
       generated_at: '2026-04-15T12:00:00Z',
       count: 1,
+      offset: 0,
       total_matching_entries: 1200,
       truncated: true,
       entries: [
@@ -484,6 +486,7 @@ describe('agent-core-runtime-store', () => {
     fetchTelemetryMock.mockResolvedValue({
       generated_at: '2026-04-15T12:00:00Z',
       count: 1,
+      offset: 0,
       total_matching_entries: 3,
       has_more: true,
       entries: [entry(1)],
@@ -501,6 +504,7 @@ describe('agent-core-runtime-store', () => {
     fetchTelemetryMock.mockResolvedValue({
       generated_at: '2026-04-15T12:00:00Z',
       count: 1,
+      offset: 1,
       total_matching_entries: 3,
       has_more: true,
       entries: [entry(2)],
@@ -544,6 +548,7 @@ describe('agent-core-runtime-store', () => {
     fetchTelemetryMock.mockResolvedValue({
       generated_at: '2026-04-15T12:00:00Z',
       count: 2,
+      offset: 0,
       total_matching_entries: 1200,
       truncated: true,
       entries: [entry(1), entry(2)],
@@ -556,6 +561,7 @@ describe('agent-core-runtime-store', () => {
     fetchTelemetryMock.mockResolvedValue({
       generated_at: '2026-04-15T12:00:00Z',
       count: 2,
+      offset: 2,
       total_matching_entries: 1200,
       truncated: true,
       entries: [entry(3), entry(4)],
@@ -573,6 +579,7 @@ describe('agent-core-runtime-store', () => {
     fetchTelemetryMock.mockResolvedValue({
       generated_at: '2026-04-15T12:00:00Z',
       count: 1,
+      offset: 0,
       total_matching_entries: 2,
       has_more: true,
       entries: [{
@@ -590,6 +597,7 @@ describe('agent-core-runtime-store', () => {
     fetchTelemetryMock.mockResolvedValue({
       generated_at: '2026-04-15T12:00:00Z',
       count: 1,
+      offset: 1,
       total_matching_entries: 2,
       has_more: false,
       entries: [{
@@ -643,6 +651,8 @@ describe('agent-core-runtime-store', () => {
     })
     expect(agentCoreHealthSummary.value.replayLoadedEvents).toBe(5499)
     expect(agentCoreHealthSummary.value.replayTruncated).toBe(false)
+    expect(agentCoreHealthSummary.value.replayCapped).toBe(true)
+    expect(agentCoreHealthSummary.value.hasMore).toBe(false)
     expect(agentCoreHealthSummary.value.agentEventsCount).toBe(1)
   })
 })

--- a/dashboard/src/agent-core-runtime-store.test.ts
+++ b/dashboard/src/agent-core-runtime-store.test.ts
@@ -333,7 +333,7 @@ describe('agent-core-runtime-store', () => {
     expect(agentCoreHealthSummary.value.totalEvents).toBe(2)
   })
 
-  it('preserves unidentified identical events instead of content-deduping them', () => {
+  it('dedupes the current native envelope across replay and live delivery', () => {
     const event = {
       type: 'agent_core:masc:trust_updated',
       ts_unix: 610,
@@ -347,10 +347,27 @@ describe('agent-core-runtime-store', () => {
       },
     }
 
+    hydrateAgentCoreRuntimeFromTelemetryEntries([
+      { source: 'agent_core_event', ...event } as TelemetryEntry,
+    ])
+    expect(applyAgentCoreRuntimeEvent(event)).toBe(false)
+    expect(agentCoreHealthSummary.value.totalEvents).toBe(1)
+    expect(agentCoreHealthSummary.value.agentEventsCount).toBe(1)
+  })
+
+  it('preserves identical events with no producer identity', () => {
+    const event = {
+      type: 'agent_core:masc:trust_updated',
+      payload: {
+        agent_a: 'unidentified-agent',
+        agent_b: 'unidentified-peer',
+        trust_score: 0.4,
+      },
+    }
+
     expect(applyAgentCoreRuntimeEvent(event)).toBe(true)
     expect(applyAgentCoreRuntimeEvent(event)).toBe(true)
     expect(agentCoreHealthSummary.value.totalEvents).toBe(2)
-    expect(agentCoreHealthSummary.value.agentEventsCount).toBe(2)
   })
 
   it('dedupes one stable run sequence across replay and live delivery', () => {

--- a/dashboard/src/agent-core-runtime-store.test.ts
+++ b/dashboard/src/agent-core-runtime-store.test.ts
@@ -9,6 +9,7 @@ import {
   applyAgentCoreRuntimeEvent,
   hydrateAgentCoreRuntimeFromTelemetryEntries,
   replayAgentCoreRuntimeTelemetry,
+  loadMoreAgentCoreEvents,
 } from './agent-core-runtime-store'
 import {
   agentCoreAgentEvents,
@@ -449,5 +450,54 @@ describe('agent-core-runtime-store', () => {
 
     expect(agentCoreHealthSummary.value.totalEvents).toBe(1201)
     expect(agentCoreHealthSummary.value.agentEventsCount).toBe(2)
+  })
+
+  it('keeps loading more from retiring hasMore before the window is exhausted', async () => {
+    // A replayed row sits inside the server's total-matching count. Counting
+    // it again made loaded exceed total, and noteAgentCoreReplayWindow reads
+    // loaded >= total as "nothing left" — so the second page silently became
+    // the last one no matter how many rows the server still held.
+    const entry = (seq: number): TelemetryEntry =>
+      ({
+        source: 'agent_core_event',
+        type: 'agent_core:masc:trust_updated',
+        ts_unix: 500 + seq,
+        correlation_id: `corr-${seq}`,
+        run_id: 'run-page',
+        seq,
+        payload: {
+          agent_a: 'gamma',
+          agent_b: 'delta',
+          trust_score: 0.5,
+          timestamp: 500 + seq,
+        },
+      }) as TelemetryEntry
+
+    fetchTelemetryMock.mockResolvedValue({
+      generated_at: '2026-04-15T12:00:00Z',
+      count: 2,
+      total_matching_entries: 1200,
+      truncated: true,
+      entries: [entry(1), entry(2)],
+    })
+    await replayAgentCoreRuntimeTelemetry()
+
+    expect(agentCoreHealthSummary.value.replayLoadedEvents).toBe(2)
+    expect(agentCoreHealthSummary.value.replayTruncated).toBe(true)
+
+    fetchTelemetryMock.mockResolvedValue({
+      generated_at: '2026-04-15T12:00:00Z',
+      count: 2,
+      total_matching_entries: 1200,
+      truncated: true,
+      entries: [entry(3), entry(4)],
+    })
+    await loadMoreAgentCoreEvents()
+
+    // Four distinct rows loaded out of 1200 — the operator must still be able
+    // to ask for the rest.
+    expect(agentCoreHealthSummary.value.replayLoadedEvents).toBe(4)
+    expect(agentCoreHealthSummary.value.replayTotalMatchingEvents).toBe(1200)
+    expect(agentCoreHealthSummary.value.replayTruncated).toBe(true)
   })
 })

--- a/dashboard/src/agent-core-runtime-store.test.ts
+++ b/dashboard/src/agent-core-runtime-store.test.ts
@@ -333,7 +333,7 @@ describe('agent-core-runtime-store', () => {
     expect(agentCoreHealthSummary.value.totalEvents).toBe(2)
   })
 
-  it('dedupes the current native envelope across replay and live delivery', () => {
+  it('preserves current native envelopes until the producer emits an identity', () => {
     const event = {
       type: 'agent_core:masc:trust_updated',
       ts_unix: 610,
@@ -350,9 +350,9 @@ describe('agent-core-runtime-store', () => {
     hydrateAgentCoreRuntimeFromTelemetryEntries([
       { source: 'agent_core_event', ...event } as TelemetryEntry,
     ])
-    expect(applyAgentCoreRuntimeEvent(event)).toBe(false)
-    expect(agentCoreHealthSummary.value.totalEvents).toBe(1)
-    expect(agentCoreHealthSummary.value.agentEventsCount).toBe(1)
+    expect(applyAgentCoreRuntimeEvent(event)).toBe(true)
+    expect(agentCoreHealthSummary.value.totalEvents).toBe(2)
+    expect(agentCoreHealthSummary.value.agentEventsCount).toBe(2)
   })
 
   it('preserves identical events with no producer identity', () => {
@@ -506,6 +506,13 @@ describe('agent-core-runtime-store', () => {
     })
     await loadMoreAgentCoreEvents()
 
+    expect(fetchTelemetryMock).toHaveBeenLastCalledWith({
+      source: 'agent_core_event',
+      n: 500,
+      offset: 1,
+      signal: undefined,
+    })
+
     expect(agentCoreHealthSummary.value.replayLoadedEvents).toBe(2)
     expect(agentCoreHealthSummary.value.replayTotalMatchingEvents).toBe(3)
     expect(agentCoreHealthSummary.value.replayTruncated).toBe(true)
@@ -558,5 +565,48 @@ describe('agent-core-runtime-store', () => {
     expect(agentCoreHealthSummary.value.replayLoadedEvents).toBe(4)
     expect(agentCoreHealthSummary.value.replayTotalMatchingEvents).toBe(1200)
     expect(agentCoreHealthSummary.value.replayTruncated).toBe(true)
+  })
+
+  it('pages by fetched replay rows rather than projected Agent Core rows', async () => {
+    fetchTelemetryMock.mockResolvedValue({
+      generated_at: '2026-04-15T12:00:00Z',
+      count: 1,
+      total_matching_entries: 2,
+      has_more: true,
+      entries: [{
+        source: 'agent_core_event',
+        type: 'agent_core:durable:llm_request',
+        event_id: 'evt-page-1',
+        run_id: 'run-page-offset',
+        payload: { agent_name: 'alpha', model: 'gpt-5', input_tokens: 10 },
+      } as TelemetryEntry],
+    })
+    await replayAgentCoreRuntimeTelemetry()
+
+    expect(agentCoreAgentEvents.value).toHaveLength(0)
+
+    fetchTelemetryMock.mockResolvedValue({
+      generated_at: '2026-04-15T12:00:00Z',
+      count: 1,
+      total_matching_entries: 2,
+      has_more: false,
+      entries: [{
+        source: 'agent_core_event',
+        type: 'agent_core:durable:error_occurred',
+        event_id: 'evt-page-2',
+        run_id: 'run-page-offset',
+        payload: { agent_name: 'alpha', error_domain: 'tool' },
+      } as TelemetryEntry],
+    })
+    await loadMoreAgentCoreEvents()
+
+    expect(fetchTelemetryMock).toHaveBeenLastCalledWith({
+      source: 'agent_core_event',
+      n: 500,
+      offset: 1,
+      signal: undefined,
+    })
+    expect(agentCoreHealthSummary.value.replayLoadedEvents).toBe(2)
+    expect(agentCoreHealthSummary.value.replayTruncated).toBe(false)
   })
 })

--- a/dashboard/src/agent-core-runtime-store.ts
+++ b/dashboard/src/agent-core-runtime-store.ts
@@ -568,7 +568,10 @@ export function hydrateAgentCoreRuntimeFromTelemetryEntries(entries: TelemetryEn
   })
 }
 
-export function appendAgentCoreRuntimeFromTelemetryEntries(entries: TelemetryEntry[]): void {
+export function appendAgentCoreRuntimeFromTelemetryEntries(
+  entries: TelemetryEntry[],
+  replayOffset = replayFetchedAgentCoreEventCount,
+): void {
   const ordered = [...entries].sort((a, b) => {
     const left = coerceAgentCoreRuntimeEnvelope(a)
     const right = coerceAgentCoreRuntimeEnvelope(b)
@@ -577,7 +580,7 @@ export function appendAgentCoreRuntimeFromTelemetryEntries(entries: TelemetryEnt
   for (const entry of ordered) {
     applyAgentCoreRuntimeEvent(entry, { origin: 'replay' })
   }
-  replayFetchedAgentCoreEventCount += entries.length
+  replayFetchedAgentCoreEventCount = replayOffset + entries.length
 }
 
 export async function replayAgentCoreRuntimeTelemetry(signal?: AbortSignal): Promise<void> {
@@ -616,7 +619,20 @@ export async function loadMoreAgentCoreEvents(signal?: AbortSignal): Promise<voi
     offset: currentOffset,
     signal,
   })
-  appendAgentCoreRuntimeFromTelemetryEntries(response.entries)
+  const responseOffset = response.offset ?? currentOffset
+  // The server caps telemetry offsets. Once it reports an earlier offset than
+  // requested, this is a replay of a page we already consumed: do not project
+  // it again or advance the cursor beyond reachable history.
+  if (responseOffset < currentOffset) {
+    noteAgentCoreReplayWindow({
+      loadedEvents: replayFetchedAgentCoreEventCount,
+      totalMatchingEvents: response.total_matching_entries ?? response.count,
+      truncated: false,
+      observedTotalEvents: agentCoreTotalEvents.value,
+    })
+    return
+  }
+  appendAgentCoreRuntimeFromTelemetryEntries(response.entries, responseOffset)
   noteAgentCoreReplayWindow({
     loadedEvents: replayFetchedAgentCoreEventCount,
     totalMatchingEvents: response.total_matching_entries ?? response.count,

--- a/dashboard/src/agent-core-runtime-store.ts
+++ b/dashboard/src/agent-core-runtime-store.ts
@@ -22,7 +22,12 @@ import type {
 type AgentCoreRuntimeEnvelope = Record<string, unknown> & {
   type: string
   payload: Record<string, unknown>
+  dashboard_event_key?: string
 }
+
+type RuntimeEventIdentity =
+  | { kind: 'stable'; key: string }
+  | { kind: 'unidentified' }
 
 type IngestOptions = {
   includeLiveTrace?: boolean
@@ -40,6 +45,7 @@ type EvidenceRefSets = {
 }
 
 const seenAgentCoreEventKeys = new Set<string>()
+let unidentifiedAgentCoreEventSequence = 0
 let replayGeneration = 0
 let initialReplayPromise: Promise<void> | null = null
 
@@ -206,41 +212,31 @@ function runtimeEventType(event: AgentCoreRuntimeEnvelope): string {
   return asString(event.event_type) ?? event.type
 }
 
-function runtimeEventKey(event: AgentCoreRuntimeEnvelope): string {
+function stableRuntimeEventIdentity(event: AgentCoreRuntimeEnvelope): RuntimeEventIdentity {
   const payload = eventPayload(event)
-  const type = runtimeEventType(event)
-  const correlationId = asString(event.correlation_id)
-  const runId = asString(event.run_id)
-  const reportedTsUnix = eventReportedUnixSeconds(event)
-  const agentName =
-    asString(event.agent_name)
-    ?? asString(payload.agent_name)
-    ?? asString(payload.agent)
-    ?? asString(payload.keeper_name)
-    ?? ''
-  const taskId = asString(event.task_id) ?? asString(payload.task_id) ?? ''
-  const toolName = asString(event.tool_name) ?? asString(payload.tool_name) ?? ''
-  const turn = asNumber(event.turn) ?? asNumber(payload.turn)
-  if (correlationId || runId || reportedTsUnix != null) {
-    return [
-      type,
-      agentName,
-      correlationId ?? '',
-      runId ?? '',
-      reportedTsUnix != null ? String(reportedTsUnix) : '',
-      taskId,
-      toolName,
-      turn != null ? String(turn) : '',
-    ].join('|')
+  const runId = asString(event.run_id) ?? asString(payload.run_id)
+  const eventId = asString(event.event_id) ?? asString(payload.event_id)
+  if (eventId) {
+    const scope = runId ?? asString(event.correlation_id) ?? asString(payload.correlation_id) ?? ''
+    return { kind: 'stable', key: `event:${scope}|${eventId}` }
   }
-  return JSON.stringify({
-    type,
-    agentName,
-    taskId,
-    toolName,
-    turn: turn ?? null,
-    payload,
-  })
+
+  const seq = asNumber(event.seq) ?? asNumber(payload.seq)
+  if (runId && seq != null && Number.isSafeInteger(seq) && seq >= 0) {
+    return { kind: 'stable', key: `run:${runId}|seq:${seq}` }
+  }
+
+  return { kind: 'unidentified' }
+}
+
+function runtimeEventKey(event: AgentCoreRuntimeEnvelope): string {
+  if (event.dashboard_event_key) return event.dashboard_event_key
+  const identity = stableRuntimeEventIdentity(event)
+  const key = identity.kind === 'stable'
+    ? identity.key
+    : `unidentified:${++unidentifiedAgentCoreEventSequence}`
+  event.dashboard_event_key = key
+  return key
 }
 
 function traceDetail(
@@ -534,23 +530,23 @@ function coerceAgentCoreRuntimeEnvelope(raw: unknown): AgentCoreRuntimeEnvelope 
 export function applyAgentCoreRuntimeEvent(raw: unknown, opts?: IngestOptions): boolean {
   const event = coerceAgentCoreRuntimeEnvelope(raw)
   if (!event) return false
-  const key = runtimeEventKey(event)
-  if (seenAgentCoreEventKeys.has(key)) {
-    return false
-  }
-  seenAgentCoreEventKeys.add(key)
-  ingestRuntimeProjection(event, opts)
-  if (opts?.origin === 'replay') {
-    agentCoreTotalEvents.value = seenAgentCoreEventKeys.size
+  const identity = stableRuntimeEventIdentity(event)
+  if (identity.kind === 'stable') {
+    if (seenAgentCoreEventKeys.has(identity.key)) return false
+    seenAgentCoreEventKeys.add(identity.key)
+    event.dashboard_event_key = identity.key
   } else {
-    agentCoreTotalEvents.value = Math.max(seenAgentCoreEventKeys.size, agentCoreTotalEvents.value + 1)
+    runtimeEventKey(event)
   }
+  ingestRuntimeProjection(event, opts)
+  agentCoreTotalEvents.value += 1
   return true
 }
 
 export function hydrateAgentCoreRuntimeFromTelemetryEntries(entries: TelemetryEntry[]): void {
   resetAgentCoreRuntimeSignals()
   seenAgentCoreEventKeys.clear()
+  unidentifiedAgentCoreEventSequence = 0
   const ordered = [...entries].sort((a, b) => {
     const left = coerceAgentCoreRuntimeEnvelope(a)
     const right = coerceAgentCoreRuntimeEnvelope(b)

--- a/dashboard/src/agent-core-runtime-store.ts
+++ b/dashboard/src/agent-core-runtime-store.ts
@@ -226,6 +226,21 @@ function stableRuntimeEventIdentity(event: AgentCoreRuntimeEnvelope): RuntimeEve
     return { kind: 'stable', key: `run:${runId}|seq:${seq}` }
   }
 
+  // Native Event_bus envelopes currently carry no event_id/seq. The server
+  // does, however, persist and replay this exact identity tuple, so use it
+  // until the producer grows a first-class event id. Requiring every member
+  // avoids reviving the old content-based heuristic for genuinely
+  // unidentified events.
+  const correlationId =
+    asString(event.correlation_id) ?? asString(payload.correlation_id)
+  const reportedTsUnix = eventReportedUnixSeconds(event)
+  if (runId && correlationId && reportedTsUnix != null) {
+    return {
+      kind: 'stable',
+      key: `envelope:${runtimeEventType(event)}|${runId}|${correlationId}|${reportedTsUnix}`,
+    }
+  }
+
   return { kind: 'unidentified' }
 }
 

--- a/dashboard/src/agent-core-runtime-store.ts
+++ b/dashboard/src/agent-core-runtime-store.ts
@@ -48,6 +48,7 @@ const seenAgentCoreEventKeys = new Set<string>()
 let unidentifiedAgentCoreEventSequence = 0
 let replayGeneration = 0
 let initialReplayPromise: Promise<void> | null = null
+let replayLoadedAgentCoreEventCount = 0
 
 function emptyEvidenceRefSets(): EvidenceRefSets {
   return {
@@ -554,6 +555,7 @@ export function applyAgentCoreRuntimeEvent(raw: unknown, opts?: IngestOptions): 
     runtimeEventKey(event)
   }
   ingestRuntimeProjection(event, opts)
+  if (opts?.origin === 'replay') replayLoadedAgentCoreEventCount += 1
   // A live arrival is news the replay window never counted, so it belongs
   // above the server's total. A replayed row is not: it is already inside
   // that total, and counting it again is what made "load more" claim 1700
@@ -562,24 +564,11 @@ export function applyAgentCoreRuntimeEvent(raw: unknown, opts?: IngestOptions): 
   return true
 }
 
-/** How many distinct events this store has actually loaded.
- *
- *  Separate from `agentCoreTotalEvents`, which `noteAgentCoreReplayWindow`
- *  assigns the server's total-matching count — feeding that number back as
- *  `loadedEvents` makes loaded and total equal by construction, which reads
- *  as "fully loaded" however little was fetched.
- *
- *  Both halves are already tracked: stable identities cannot double-count
- *  because the set rejects repeats, and unidentified events are numbered as
- *  they are keyed. */
-function loadedAgentCoreEventCount(): number {
-  return seenAgentCoreEventKeys.size + unidentifiedAgentCoreEventSequence
-}
-
 export function hydrateAgentCoreRuntimeFromTelemetryEntries(entries: TelemetryEntry[]): void {
   resetAgentCoreRuntimeSignals()
   seenAgentCoreEventKeys.clear()
   unidentifiedAgentCoreEventSequence = 0
+  replayLoadedAgentCoreEventCount = 0
   const ordered = [...entries].sort((a, b) => {
     const left = coerceAgentCoreRuntimeEnvelope(a)
     const right = coerceAgentCoreRuntimeEnvelope(b)
@@ -589,8 +578,8 @@ export function hydrateAgentCoreRuntimeFromTelemetryEntries(entries: TelemetryEn
     applyAgentCoreRuntimeEvent(entry, { origin: 'replay' })
   }
   noteAgentCoreReplayWindow({
-    loadedEvents: loadedAgentCoreEventCount(),
-    totalMatchingEvents: loadedAgentCoreEventCount(),
+    loadedEvents: replayLoadedAgentCoreEventCount,
+    totalMatchingEvents: replayLoadedAgentCoreEventCount,
     truncated: false,
   })
 }
@@ -616,7 +605,7 @@ export async function replayAgentCoreRuntimeTelemetry(signal?: AbortSignal): Pro
   if (generation !== replayGeneration) return
   hydrateAgentCoreRuntimeFromTelemetryEntries(response.entries)
   noteAgentCoreReplayWindow({
-    loadedEvents: loadedAgentCoreEventCount(),
+    loadedEvents: replayLoadedAgentCoreEventCount,
     totalMatchingEvents: response.total_matching_entries ?? response.count,
     truncated: response.has_more ?? response.truncated ?? false,
   })
@@ -644,7 +633,7 @@ export async function loadMoreAgentCoreEvents(signal?: AbortSignal): Promise<voi
   })
   appendAgentCoreRuntimeFromTelemetryEntries(response.entries)
   noteAgentCoreReplayWindow({
-    loadedEvents: loadedAgentCoreEventCount(),
+    loadedEvents: replayLoadedAgentCoreEventCount,
     totalMatchingEvents: response.total_matching_entries ?? response.count,
     truncated: response.has_more ?? response.truncated ?? false,
   })

--- a/dashboard/src/agent-core-runtime-store.ts
+++ b/dashboard/src/agent-core-runtime-store.ts
@@ -539,8 +539,26 @@ export function applyAgentCoreRuntimeEvent(raw: unknown, opts?: IngestOptions): 
     runtimeEventKey(event)
   }
   ingestRuntimeProjection(event, opts)
-  agentCoreTotalEvents.value += 1
+  // A live arrival is news the replay window never counted, so it belongs
+  // above the server's total. A replayed row is not: it is already inside
+  // that total, and counting it again is what made "load more" claim 1700
+  // of 1200 and retire `hasMore` with rows still unfetched.
+  if (opts?.origin !== 'replay') agentCoreTotalEvents.value += 1
   return true
+}
+
+/** How many distinct events this store has actually loaded.
+ *
+ *  Separate from `agentCoreTotalEvents`, which `noteAgentCoreReplayWindow`
+ *  assigns the server's total-matching count — feeding that number back as
+ *  `loadedEvents` makes loaded and total equal by construction, which reads
+ *  as "fully loaded" however little was fetched.
+ *
+ *  Both halves are already tracked: stable identities cannot double-count
+ *  because the set rejects repeats, and unidentified events are numbered as
+ *  they are keyed. */
+function loadedAgentCoreEventCount(): number {
+  return seenAgentCoreEventKeys.size + unidentifiedAgentCoreEventSequence
 }
 
 export function hydrateAgentCoreRuntimeFromTelemetryEntries(entries: TelemetryEntry[]): void {
@@ -556,8 +574,8 @@ export function hydrateAgentCoreRuntimeFromTelemetryEntries(entries: TelemetryEn
     applyAgentCoreRuntimeEvent(entry, { origin: 'replay' })
   }
   noteAgentCoreReplayWindow({
-    loadedEvents: agentCoreTotalEvents.value,
-    totalMatchingEvents: agentCoreTotalEvents.value,
+    loadedEvents: loadedAgentCoreEventCount(),
+    totalMatchingEvents: loadedAgentCoreEventCount(),
     truncated: false,
   })
 }
@@ -583,7 +601,7 @@ export async function replayAgentCoreRuntimeTelemetry(signal?: AbortSignal): Pro
   if (generation !== replayGeneration) return
   hydrateAgentCoreRuntimeFromTelemetryEntries(response.entries)
   noteAgentCoreReplayWindow({
-    loadedEvents: agentCoreTotalEvents.value,
+    loadedEvents: loadedAgentCoreEventCount(),
     totalMatchingEvents: response.total_matching_entries ?? response.count,
     truncated: response.has_more ?? response.truncated ?? false,
   })
@@ -611,7 +629,7 @@ export async function loadMoreAgentCoreEvents(signal?: AbortSignal): Promise<voi
   })
   appendAgentCoreRuntimeFromTelemetryEntries(response.entries)
   noteAgentCoreReplayWindow({
-    loadedEvents: agentCoreTotalEvents.value,
+    loadedEvents: loadedAgentCoreEventCount(),
     totalMatchingEvents: response.total_matching_entries ?? response.count,
     truncated: response.has_more ?? response.truncated ?? false,
   })

--- a/dashboard/src/agent-core-runtime-store.ts
+++ b/dashboard/src/agent-core-runtime-store.ts
@@ -5,7 +5,6 @@ import { fetchTelemetry, type TelemetryEntry } from './api/dashboard'
 import { AGENT_CORE_TELEMETRY_REPLAY_LIMIT, AGENT_CORE_EVENT_PREFIX } from './config/constants'
 import {
   agentCoreTotalEvents,
-  agentCoreAgentEvents,
   agentCoreReplayLoadedEvents,
   agentCoreReplayTotalMatchingEvents,
   noteAgentCoreReplayWindow,
@@ -48,7 +47,7 @@ const seenAgentCoreEventKeys = new Set<string>()
 let unidentifiedAgentCoreEventSequence = 0
 let replayGeneration = 0
 let initialReplayPromise: Promise<void> | null = null
-let replayLoadedAgentCoreEventCount = 0
+let replayFetchedAgentCoreEventCount = 0
 
 function emptyEvidenceRefSets(): EvidenceRefSets {
   return {
@@ -225,21 +224,6 @@ function stableRuntimeEventIdentity(event: AgentCoreRuntimeEnvelope): RuntimeEve
   const seq = asNumber(event.seq) ?? asNumber(payload.seq)
   if (runId && seq != null && Number.isSafeInteger(seq) && seq >= 0) {
     return { kind: 'stable', key: `run:${runId}|seq:${seq}` }
-  }
-
-  // Native Event_bus envelopes currently carry no event_id/seq. The server
-  // does, however, persist and replay this exact identity tuple, so use it
-  // until the producer grows a first-class event id. Requiring every member
-  // avoids reviving the old content-based heuristic for genuinely
-  // unidentified events.
-  const correlationId =
-    asString(event.correlation_id) ?? asString(payload.correlation_id)
-  const reportedTsUnix = eventReportedUnixSeconds(event)
-  if (runId && correlationId && reportedTsUnix != null) {
-    return {
-      kind: 'stable',
-      key: `envelope:${runtimeEventType(event)}|${runId}|${correlationId}|${reportedTsUnix}`,
-    }
   }
 
   return { kind: 'unidentified' }
@@ -555,7 +539,6 @@ export function applyAgentCoreRuntimeEvent(raw: unknown, opts?: IngestOptions): 
     runtimeEventKey(event)
   }
   ingestRuntimeProjection(event, opts)
-  if (opts?.origin === 'replay') replayLoadedAgentCoreEventCount += 1
   // A live arrival is news the replay window never counted, so it belongs
   // above the server's total. A replayed row is not: it is already inside
   // that total, and counting it again is what made "load more" claim 1700
@@ -568,7 +551,7 @@ export function hydrateAgentCoreRuntimeFromTelemetryEntries(entries: TelemetryEn
   resetAgentCoreRuntimeSignals()
   seenAgentCoreEventKeys.clear()
   unidentifiedAgentCoreEventSequence = 0
-  replayLoadedAgentCoreEventCount = 0
+  replayFetchedAgentCoreEventCount = 0
   const ordered = [...entries].sort((a, b) => {
     const left = coerceAgentCoreRuntimeEnvelope(a)
     const right = coerceAgentCoreRuntimeEnvelope(b)
@@ -577,9 +560,10 @@ export function hydrateAgentCoreRuntimeFromTelemetryEntries(entries: TelemetryEn
   for (const entry of ordered) {
     applyAgentCoreRuntimeEvent(entry, { origin: 'replay' })
   }
+  replayFetchedAgentCoreEventCount = entries.length
   noteAgentCoreReplayWindow({
-    loadedEvents: replayLoadedAgentCoreEventCount,
-    totalMatchingEvents: replayLoadedAgentCoreEventCount,
+    loadedEvents: replayFetchedAgentCoreEventCount,
+    totalMatchingEvents: replayFetchedAgentCoreEventCount,
     truncated: false,
   })
 }
@@ -593,6 +577,7 @@ export function appendAgentCoreRuntimeFromTelemetryEntries(entries: TelemetryEnt
   for (const entry of ordered) {
     applyAgentCoreRuntimeEvent(entry, { origin: 'replay' })
   }
+  replayFetchedAgentCoreEventCount += entries.length
 }
 
 export async function replayAgentCoreRuntimeTelemetry(signal?: AbortSignal): Promise<void> {
@@ -605,7 +590,7 @@ export async function replayAgentCoreRuntimeTelemetry(signal?: AbortSignal): Pro
   if (generation !== replayGeneration) return
   hydrateAgentCoreRuntimeFromTelemetryEntries(response.entries)
   noteAgentCoreReplayWindow({
-    loadedEvents: replayLoadedAgentCoreEventCount,
+    loadedEvents: replayFetchedAgentCoreEventCount,
     totalMatchingEvents: response.total_matching_entries ?? response.count,
     truncated: response.has_more ?? response.truncated ?? false,
   })
@@ -624,7 +609,7 @@ export function ensureAgentCoreRuntimeReplay(): Promise<void> {
 }
 
 export async function loadMoreAgentCoreEvents(signal?: AbortSignal): Promise<void> {
-  const currentOffset = agentCoreAgentEvents.value.length
+  const currentOffset = replayFetchedAgentCoreEventCount
   const response = await fetchTelemetry({
     source: 'agent_core_event',
     n: AGENT_CORE_TELEMETRY_REPLAY_LIMIT,
@@ -633,7 +618,7 @@ export async function loadMoreAgentCoreEvents(signal?: AbortSignal): Promise<voi
   })
   appendAgentCoreRuntimeFromTelemetryEntries(response.entries)
   noteAgentCoreReplayWindow({
-    loadedEvents: replayLoadedAgentCoreEventCount,
+    loadedEvents: replayFetchedAgentCoreEventCount,
     totalMatchingEvents: response.total_matching_entries ?? response.count,
     truncated: response.has_more ?? response.truncated ?? false,
   })

--- a/dashboard/src/agent-core-runtime-store.ts
+++ b/dashboard/src/agent-core-runtime-store.ts
@@ -570,7 +570,7 @@ export function hydrateAgentCoreRuntimeFromTelemetryEntries(entries: TelemetryEn
 
 export function appendAgentCoreRuntimeFromTelemetryEntries(
   entries: TelemetryEntry[],
-  replayOffset = replayFetchedAgentCoreEventCount,
+  replayOffset: number,
 ): void {
   const ordered = [...entries].sort((a, b) => {
     const left = coerceAgentCoreRuntimeEnvelope(a)
@@ -619,20 +619,20 @@ export async function loadMoreAgentCoreEvents(signal?: AbortSignal): Promise<voi
     offset: currentOffset,
     signal,
   })
-  const responseOffset = response.offset ?? currentOffset
   // The server caps telemetry offsets. Once it reports an earlier offset than
   // requested, this is a replay of a page we already consumed: do not project
   // it again or advance the cursor beyond reachable history.
-  if (responseOffset < currentOffset) {
+  if (response.offset !== currentOffset) {
     noteAgentCoreReplayWindow({
       loadedEvents: replayFetchedAgentCoreEventCount,
       totalMatchingEvents: response.total_matching_entries ?? response.count,
       truncated: false,
+      capped: true,
       observedTotalEvents: agentCoreTotalEvents.value,
     })
     return
   }
-  appendAgentCoreRuntimeFromTelemetryEntries(response.entries, responseOffset)
+  appendAgentCoreRuntimeFromTelemetryEntries(response.entries, response.offset)
   noteAgentCoreReplayWindow({
     loadedEvents: replayFetchedAgentCoreEventCount,
     totalMatchingEvents: response.total_matching_entries ?? response.count,

--- a/dashboard/src/agent-core-runtime-store.ts
+++ b/dashboard/src/agent-core-runtime-store.ts
@@ -621,5 +621,6 @@ export async function loadMoreAgentCoreEvents(signal?: AbortSignal): Promise<voi
     loadedEvents: replayFetchedAgentCoreEventCount,
     totalMatchingEvents: response.total_matching_entries ?? response.count,
     truncated: response.has_more ?? response.truncated ?? false,
+    observedTotalEvents: agentCoreTotalEvents.value,
   })
 }

--- a/dashboard/src/api/dashboard-telemetry.ts
+++ b/dashboard/src/api/dashboard-telemetry.ts
@@ -34,7 +34,7 @@ export type TelemetryResponse = {
   query?: Record<string, unknown>
   count: number
   total_matching_entries?: number
-  offset?: number
+  offset: number
   has_more?: boolean
   truncated?: boolean
   entries: TelemetryEntry[]
@@ -115,7 +115,8 @@ function decodeTelemetryEntry(raw: unknown): TelemetryEntry | null {
 function decodeTelemetryResponse(raw: unknown): TelemetryResponse | null {
   if (!isRecord(raw)) return null
   const generatedAt = asString(raw.generated_at)
-  if (!generatedAt) return null
+  const offset = asNumber(raw.offset)
+  if (!generatedAt || offset == null || !Number.isSafeInteger(offset) || offset < 0) return null
   return {
     generated_at: generatedAt,
     generated_at_iso: asString(raw.generated_at_iso),
@@ -125,7 +126,7 @@ function decodeTelemetryResponse(raw: unknown): TelemetryResponse | null {
     query: isRecord(raw.query) ? raw.query : undefined,
     count: asNumber(raw.count, 0),
     total_matching_entries: asNumber(raw.total_matching_entries, asNumber(raw.count, 0)),
-    offset: asNumber(raw.offset, 0),
+    offset,
     has_more: asBoolean(raw.has_more, false),
     truncated: asBoolean(raw.truncated, false),
     entries: asRecordArray(raw.entries)

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1492,6 +1492,7 @@ describe('fetchTelemetrySummary', () => {
       retention: { window_days: 7 },
       query: { source: 'tool_metric', n: 100 },
       count: 1,
+      offset: 0,
       total_matching_entries: 2,
       truncated: true,
       entries: [
@@ -1518,6 +1519,7 @@ describe('fetchTelemetrySummary', () => {
     expect(result.source).toBe('telemetry_unified')
     expect(result.retention).toMatchObject({ window_days: 7 })
     expect(result.query).toMatchObject({ source: 'tool_metric', n: 100 })
+    expect(result.offset).toBe(0)
     expect(result.total_matching_entries).toBe(2)
     expect(result.truncated).toBe(true)
   })

--- a/dashboard/src/components/agent-core-health-chip.test.ts
+++ b/dashboard/src/components/agent-core-health-chip.test.ts
@@ -4,6 +4,7 @@ import { cleanup, render, waitFor } from '@testing-library/preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { TelemetryEntry } from '../api/dashboard'
 import { hydrateAgentCoreRuntimeFromTelemetryEntries } from '../agent-core-runtime-store'
+import { noteAgentCoreReplayWindow } from '../store'
 import { AgentCoreHealthChip } from './agent-core-health-chip'
 
 const fetchTelemetryMock = vi.hoisted(() => vi.fn())
@@ -85,6 +86,7 @@ describe('AgentCoreHealthChip', () => {
     fetchTelemetryMock.mockResolvedValue({
       generated_at: '2026-04-15T12:00:00Z',
       count: 0,
+      offset: 0,
       total_matching_entries: 0,
       truncated: false,
       entries: [],
@@ -111,5 +113,25 @@ describe('AgentCoreHealthChip', () => {
       expect(container.textContent).toContain('Agent Core 리플레이를 불러오지 못했습니다')
       expect(container.textContent).toContain('journal unavailable')
     })
+  })
+
+  it('shows the server replay cap without offering another duplicate page', () => {
+    hydrateAgentCoreRuntimeFromTelemetryEntries([{
+      source: 'agent_core_event',
+      type: 'agent_core:masc:trust_updated',
+      event_id: 'visible-capped-window',
+      payload: { agent_a: 'a', agent_b: 'b', trust_score: 0.5 },
+    }] as TelemetryEntry[])
+    noteAgentCoreReplayWindow({
+      loadedEvents: 5499,
+      totalMatchingEvents: 6000,
+      truncated: false,
+      capped: true,
+    })
+
+    const { container } = render(html`<${AgentCoreHealthChip} />`)
+
+    expect(container.textContent).toContain('서버 조회 한도')
+    expect(container.textContent).not.toContain('더 보기')
   })
 })

--- a/dashboard/src/components/agent-core-health-chip.ts
+++ b/dashboard/src/components/agent-core-health-chip.ts
@@ -46,8 +46,11 @@ function describeAgentEvent(evt: AgentCoreAgentEvent): string {
 }
 
 function describeTotalEventsDetail(summary: Pick<AgentCoreHealthSummary,
-  'replayLoadedEvents' | 'replayTotalMatchingEvents' | 'replayTruncated'
+  'replayLoadedEvents' | 'replayTotalMatchingEvents' | 'replayTruncated' | 'replayCapped'
 >): string {
+  if (summary.replayCapped) {
+    return `최근 ${summary.replayLoadedEvents}개 표시 중 (서버 조회 한도)`
+  }
   if (summary.replayTruncated) {
     return `최근 ${summary.replayLoadedEvents}개 표시 중 (전체 ${summary.replayTotalMatchingEvents})`
   }

--- a/dashboard/src/components/telemetry-unified.test.ts
+++ b/dashboard/src/components/telemetry-unified.test.ts
@@ -14,6 +14,7 @@ const baseTelemetry: TelemetryResponse = {
   source: 'telemetry_unified',
   query: { source: 'tool_metric', n: 100 },
   count: 1,
+  offset: 0,
   entries: [
     {
       source: 'tool_metric',

--- a/dashboard/src/store.test.ts
+++ b/dashboard/src/store.test.ts
@@ -4,6 +4,7 @@ import {
   agentCoreReplayLoadedEvents,
   agentCoreReplayTotalMatchingEvents,
   agentCoreReplayTruncated,
+  agentCoreReplayCapped,
   agentCoreTotalLlmCalls,
   agentCoreTotalErrors,
   agentCoreLastLlmCallTs,
@@ -41,6 +42,7 @@ describe('agentCoreHealthSummary', () => {
     expect(agentCoreHealthSummary.value.replayLoadedEvents).toBe(0)
     expect(agentCoreHealthSummary.value.replayTotalMatchingEvents).toBe(0)
     expect(agentCoreHealthSummary.value.replayTruncated).toBe(false)
+    expect(agentCoreHealthSummary.value.replayCapped).toBe(false)
     expect(agentCoreHealthSummary.value.totalLlmCalls).toBe(4)
     expect(agentCoreHealthSummary.value.totalErrors).toBe(2)
     expect(agentCoreHealthSummary.value.evidenceRefsCount).toBe(0)
@@ -61,6 +63,20 @@ describe('agentCoreHealthSummary', () => {
     expect(agentCoreHealthSummary.value.replayLoadedEvents).toBe(500)
     expect(agentCoreHealthSummary.value.replayTotalMatchingEvents).toBe(1842)
     expect(agentCoreHealthSummary.value.replayTruncated).toBe(true)
+    expect(agentCoreHealthSummary.value.replayCapped).toBe(false)
+  })
+
+  it('marks a server-capped replay window without offering another page', () => {
+    noteAgentCoreReplayWindow({
+      loadedEvents: 5499,
+      totalMatchingEvents: 6000,
+      truncated: false,
+      capped: true,
+    })
+
+    expect(agentCoreReplayCapped.value).toBe(true)
+    expect(agentCoreHealthSummary.value.replayCapped).toBe(true)
+    expect(agentCoreHealthSummary.value.hasMore).toBe(false)
   })
 
   it('reflects agent event buffer length', () => {
@@ -119,6 +135,7 @@ describe('agentCoreHealthSummary', () => {
     expect(s.replayLoadedEvents).toBe(0)
     expect(s.replayTotalMatchingEvents).toBe(0)
     expect(s.replayTruncated).toBe(false)
+    expect(s.replayCapped).toBe(false)
     expect(s.totalLlmCalls).toBe(0)
     expect(s.totalErrors).toBe(0)
     expect(s.agentEventsCount).toBe(0)

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -356,6 +356,7 @@ export const agentCoreTotalEvents = signal(0)
 export const agentCoreReplayLoadedEvents = signal(0)
 export const agentCoreReplayTotalMatchingEvents = signal(0)
 export const agentCoreReplayTruncated = signal(false)
+export const agentCoreReplayCapped = signal(false)
 export const agentCoreTotalLlmCalls = signal(0)
 export const agentCoreTotalErrors = signal(0)
 export const agentCoreLastLlmCallTs = signal<number | null>(null)
@@ -376,6 +377,7 @@ export function resetAgentCoreRuntimeSignals(): void {
   agentCoreReplayLoadedEvents.value = 0
   agentCoreReplayTotalMatchingEvents.value = 0
   agentCoreReplayTruncated.value = false
+  agentCoreReplayCapped.value = false
   agentCoreTotalLlmCalls.value = 0
   agentCoreTotalErrors.value = 0
   agentCoreLastLlmCallTs.value = null
@@ -394,6 +396,7 @@ export function noteAgentCoreReplayWindow(input: {
   loadedEvents: number
   totalMatchingEvents: number
   truncated: boolean
+  capped?: boolean
   observedTotalEvents?: number
 }): void {
   const loadedEvents = Math.max(0, Math.floor(input.loadedEvents))
@@ -403,9 +406,11 @@ export function noteAgentCoreReplayWindow(input: {
     Math.floor(input.observedTotalEvents ?? totalMatchingEvents),
   )
   const truncated = input.truncated && totalMatchingEvents > loadedEvents
+  const capped = Boolean(input.capped) && totalMatchingEvents > loadedEvents
   agentCoreReplayLoadedEvents.value = loadedEvents
   agentCoreReplayTotalMatchingEvents.value = totalMatchingEvents
-  agentCoreReplayTruncated.value = truncated
+  agentCoreReplayTruncated.value = truncated && !capped
+  agentCoreReplayCapped.value = capped
   agentCoreTotalEvents.value = observedTotalEvents
 }
 
@@ -514,6 +519,7 @@ export const agentCoreHealthSummary: ReadonlySignal<AgentCoreHealthSummary> = co
   replayLoadedEvents: agentCoreReplayLoadedEvents.value,
   replayTotalMatchingEvents: agentCoreReplayTotalMatchingEvents.value,
   replayTruncated: agentCoreReplayTruncated.value,
+  replayCapped: agentCoreReplayCapped.value,
   hasMore: agentCoreReplayTruncated.value,
   totalLlmCalls: agentCoreTotalLlmCalls.value,
   totalErrors: agentCoreTotalErrors.value,

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -394,14 +394,19 @@ export function noteAgentCoreReplayWindow(input: {
   loadedEvents: number
   totalMatchingEvents: number
   truncated: boolean
+  observedTotalEvents?: number
 }): void {
   const loadedEvents = Math.max(0, Math.floor(input.loadedEvents))
   const totalMatchingEvents = Math.max(loadedEvents, Math.floor(input.totalMatchingEvents))
+  const observedTotalEvents = Math.max(
+    totalMatchingEvents,
+    Math.floor(input.observedTotalEvents ?? totalMatchingEvents),
+  )
   const truncated = input.truncated && totalMatchingEvents > loadedEvents
   agentCoreReplayLoadedEvents.value = loadedEvents
   agentCoreReplayTotalMatchingEvents.value = totalMatchingEvents
   agentCoreReplayTruncated.value = truncated
-  agentCoreTotalEvents.value = totalMatchingEvents
+  agentCoreTotalEvents.value = observedTotalEvents
 }
 
 function sameAgentCoreAgentEvent(left: AgentCoreAgentEvent, right: AgentCoreAgentEvent): boolean {

--- a/dashboard/src/types/agent-core.ts
+++ b/dashboard/src/types/agent-core.ts
@@ -57,6 +57,7 @@ export interface AgentCoreHealthSummary {
   replayLoadedEvents: number
   replayTotalMatchingEvents: number
   replayTruncated: boolean
+  replayCapped: boolean
   hasMore: boolean
   totalLlmCalls: number
   totalErrors: number

--- a/lib/telemetry_unified/telemetry_unified.ml
+++ b/lib/telemetry_unified/telemetry_unified.ml
@@ -797,10 +797,7 @@ let read_unified_result ~base_path ~masc_root ?(sources = all_sources)
   (* Sort by timestamp descending (newest first) *)
   let sorted = sort_newest_first filtered in
   let total_matching_entries = List.length sorted in
-  let entries =
-    if total_matching_entries <= offset + n then sorted
-    else sorted |> List.drop offset |> take_first n
-  in
+  let entries = sorted |> List.drop offset |> take_first n in
   { entries; total_matching_entries; truncated = total_matching_entries > offset + n }
 
 let read_unified ~base_path ~masc_root ?sources ?keeper_name ?session_id

--- a/test/test_telemetry_unified.ml
+++ b/test/test_telemetry_unified.ml
@@ -542,6 +542,33 @@ let test_n_limits_output () =
   in
   Alcotest.(check int) "limited to 10" 10 (List.length entries)
 
+let test_offset_windows_final_page () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "telem_offset_final_page" in
+  let telemetry_dir = Filename.concat dir ".masc/telemetry" in
+  Fs_compat.mkdir_p telemetry_dir;
+  write_jsonl telemetry_dir
+    (List.init 3 (fun i ->
+       `Assoc [ "timestamp", `Float (Float.of_int i); "i", `Int i ]));
+  let read offset =
+    Telemetry_unified.read_unified_result
+      ~base_path:dir
+      ~masc_root:(masc_root dir)
+      ~sources:[ Telemetry_unified.Agent_event ]
+      ~limit:(Telemetry_unified.read_limit_of_int 2)
+      ~offset
+      ()
+  in
+  let final_page = read 2 in
+  Alcotest.(check int) "total remains pre-page" 3
+    final_page.total_matching_entries;
+  Alcotest.(check bool) "final page is not truncated" false final_page.truncated;
+  Alcotest.(check (list int)) "offset drops the preceding rows" [ 0 ]
+    (List.map (json_int_field "i") final_page.entries);
+  Alcotest.(check int) "offset at end is empty" 0
+    (List.length (read 3).entries)
+
 let test_time_window_reports_total_before_limit () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1530,6 +1557,8 @@ let () =
             test_keeper_metrics_fast_path_sets_truncated_with_marker;
           Alcotest.test_case "sorted newest first" `Quick test_sorted_newest_first;
           Alcotest.test_case "n limits output" `Quick test_n_limits_output;
+          Alcotest.test_case "offset windows final page" `Quick
+            test_offset_windows_final_page;
           Alcotest.test_case "time window reports total before limit" `Quick
             test_time_window_reports_total_before_limit;
           Alcotest.test_case "time window reads matching day files" `Quick


### PR DESCRIPTION
## Summary
- dedupe replay/live Agent Core events only by stable event_id or run_id+seq
- scope producer event IDs by run/correlation so process-local IDs do not collide across runs
- preserve identical strings from distinct event identities
- preserve unidentified legacy occurrences instead of content/timestamp suppression

## Validation
- focused Vitest: 12/12 passed
- dashboard TypeScript typecheck passed
- changed-file ESLint passed
- git diff check passed
- local Dune build intentionally not run; CI is not yet evaluated

## Follow-ups
- producer/journal projection must emit stable run/node/event/cursor identity for every stream chunk
- hidden CoT removal and typed reasoning metadata are separate stacked changes
- session trajectory content-based legacy rows remain outside this reducer slice

No backend writer, runtime state, or live dashboard environment was mutated.