### PR TITLE
fix(runtime): normalize turn provider identity once

### DIFF
--- a/lib/runtime/runtime_agent_core_runner.ml
+++ b/lib/runtime/runtime_agent_core_runner.ml
@@ -142,6 +142,10 @@ let apply_inference_seed
 ;;
 
 let resolve_runtime_providers_for_turn ~runtime_id () =
+  (* Normalize once for both the catalog lookup and the inference lookup. If
+     only the provider resolver trims, a padded id can resolve the binding but
+     miss the seed and silently change what reaches the model. *)
+  let runtime_id = String.trim runtime_id in
   (* The empty id documents "the default runtime", and the resolver honours that
      by going through [Runtime.get_default_runtime]. The seed lookup is keyed by
      id, so passing "" through would look up a runtime that does not exist and

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -1334,6 +1334,27 @@ let test_thinking_support_false_forces_off () =
       seed.Runtime_inference.thinking_enabled)
 ;;
 
+let test_turn_provider_resolution_normalizes_runtime_id_once () =
+  with_runtime_thinking (fun () ->
+    match
+      Runtime_agent_core_runner.resolve_runtime_providers_for_turn
+        ~runtime_id:"  ollama_cloud.think  "
+        ()
+    with
+    | Error msg -> Alcotest.failf "padded runtime id should resolve: %s" msg
+    | Ok [ provider ] ->
+      Alcotest.(check (option bool))
+        "trimmed id selects the thinking seed"
+        (Some true)
+        provider.Llm_provider.Provider_config.enable_thinking;
+      Alcotest.(check (option bool))
+        "trimmed id selects the preserve-thinking seed"
+        (Some true)
+        provider.Llm_provider.Provider_config.preserve_thinking
+    | Ok providers ->
+      Alcotest.failf "expected exactly one provider, got %d" (List.length providers))
+;;
+
 let test_runtime_inventory_surfaces_parameter_policy () =
   with_runtime_thinking (fun () ->
     let json = Server_dashboard_http_runtime_info.runtime_inventory_json () in
@@ -2015,6 +2036,10 @@ let () =
             "thinking-support=false forces thinking off (Some false)"
             `Quick
             test_thinking_support_false_forces_off
+        ; Alcotest.test_case
+            "turn provider resolution normalizes runtime id once"
+            `Quick
+            test_turn_provider_resolution_normalizes_runtime_id_once
         ; Alcotest.test_case
             "runtime inventory surfaces AGENT_CORE parameter policy"
             `Quick


### PR DESCRIPTION
## Summary

Follow-up to #28530. Normalize the turn-level runtime provider id once before both provider lookup and thinking-capability lookup.

Without this, a runtime id containing harmless surrounding whitespace can resolve through one path while missing the per-model thinking policy lookup, so the final request can silently lose the configured thinking flag.

## Changes

- trim `runtime_id` at the entry to `resolve_runtime_providers_for_turn`
- reuse the normalized id for provider resolution and inference config lookup
- add a regression test covering a padded `ollama_cloud.think` id

## Verification

- `scripts/dune-local.sh build @test/runtest-test_runtime_per_keeper_routing`
- 42 tests passed

Full repository build intentionally left to the operator.