### PR TITLE
fix(dashboard): withhold hidden CoT from trajectory requests

### DIFF
--- a/dashboard/src/api/dashboard-keeper-trajectory.test.ts
+++ b/dashboard/src/api/dashboard-keeper-trajectory.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const getMock = vi.hoisted(() => vi.fn())
+
+vi.mock('./core', () => ({
+  get: getMock,
+}))
+
+import { fetchKeeperTrajectory } from './dashboard-keeper-trajectory'
+
+afterEach(() => {
+  getMock.mockReset()
+})
+
+describe('fetchKeeperTrajectory', () => {
+  it('explicitly withholds hidden thinking at the HTTP boundary', async () => {
+    getMock.mockResolvedValue({ entries: [] })
+
+    await fetchKeeperTrajectory('keeper/a', 100)
+
+    expect(getMock).toHaveBeenCalledWith(
+      '/api/v1/keepers/keeper%2Fa/trajectory?limit=100&include_thinking=false',
+    )
+  })
+})

--- a/dashboard/src/api/dashboard-keeper-trajectory.ts
+++ b/dashboard/src/api/dashboard-keeper-trajectory.ts
@@ -41,23 +41,13 @@ export type TrajectoryResponse = {
 export function fetchKeeperTrajectory(
   name: string,
   limit?: number,
-  includeThinking = true,
-  fullOutput = false,
 ): Promise<TrajectoryResponse> {
   const params = new URLSearchParams()
   if (limit != null) params.set('limit', String(limit))
-  // Always send include_thinking explicitly — backend defaults to false,
-  // so omitting the param means "don't include".
-  params.set('include_thinking', includeThinking ? 'true' : 'false')
-  // Request full output for session trace detail view.
-  // content_max_len=0 → no cap: surface the COMPLETE reasoning text in the
-  // detail view (남김없이). The backend persists thinking untruncated and
-  // treats 0 as "no truncation"; size is intentionally accepted here, this is
-  // the drill-in surface (the timeline list keeps the default preview cap).
-  if (fullOutput) {
-    params.set('result_max_len', '10000')
-    params.set('content_max_len', '0')
-  }
+  // Hidden chain-of-thought is not dashboard data. Keep this explicit so a
+  // backend default change cannot make raw reasoning cross the HTTP boundary.
+  // A separate typed metadata projection may expose presence/counts later.
+  params.set('include_thinking', 'false')
   const qs = params.toString()
   return get<TrajectoryResponse>(
     `/api/v1/keepers/${encodeURIComponent(name)}/trajectory${qs ? `?${qs}` : ''}`,

--- a/dashboard/src/components/journey-panel.test.ts
+++ b/dashboard/src/components/journey-panel.test.ts
@@ -200,7 +200,7 @@ describe('JourneyPanel', () => {
       expect(screen.getByText('trajectory + I/O')).toBeInTheDocument()
     })
 
-    expect(fetchKeeperTrajectory).toHaveBeenCalledWith('keeper-a', 200, true, true)
+    expect(fetchKeeperTrajectory).toHaveBeenCalledWith('keeper-a', 200)
     expect(fetchKeeperToolCalls).toHaveBeenCalledWith('keeper-a', 200, expect.objectContaining({
       signal: expect.any(AbortSignal),
     }))

--- a/dashboard/src/components/journey-panel.ts
+++ b/dashboard/src/components/journey-panel.ts
@@ -71,7 +71,7 @@ async function fetchWaterfallSources(
   const [trajectory, toolCalls, runtimeTrace] = await Promise.all([
     settleSource<TrajectoryResponse>(
       'trajectory',
-      fetchKeeperTrajectory(keeperName, 200, true, true),
+      fetchKeeperTrajectory(keeperName, 200),
     ),
     settleSource<ToolCallsResponse>(
       'tool-calls',

--- a/dashboard/src/components/session-trace/session-trace-state.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.ts
@@ -813,7 +813,7 @@ export async function loadSessionTrace(agentName: string, isKeeper: boolean): Pr
   try {
     const timelinePromise = fetchAgentTimeline(agentName, TIMELINE_HOURS, TIMELINE_LIMIT)
     const trajectoryPromise = isKeeper
-      ? fetchKeeperTrajectory(agentName, TRAJECTORY_LIMIT, true, true)
+      ? fetchKeeperTrajectory(agentName, TRAJECTORY_LIMIT)
       : Promise.resolve(null)
     const toolCallsPromise = isKeeper
       ? fetchKeeperToolCalls(agentName, TOOL_CALL_LIMIT)


### PR DESCRIPTION
## Outcome

The dashboard no longer requests raw Keeper thinking or unbounded reasoning content from the trajectory endpoint. Every trajectory request explicitly sends `include_thinking=false`, so a backend default change cannot expose hidden CoT.

## Scope

- remove caller-controlled thinking/full-output flags from the dashboard API
- remove the `content_max_len=0` raw reasoning request path
- update Journey and Session Trace callers
- add an HTTP-boundary regression test including encoded Keeper identity

Typed reasoning metadata and backend raw-trace retention are intentionally separate stacked follow-ups. This PR does not claim either is complete.

## Fast verification

- 32 focused Vitest tests passed (3 files)
- `pnpm typecheck` passed
- changed-file ESLint passed
- `git diff --check` passed
- local Dune was not run per campaign instruction

## Three-way evidence plan

1. Contract: API test proves `include_thinking=false`.
2. Component: Journey and Session Trace focused suites prove callers use the closed API.
3. Live/browser follow-up: capture request trace and DOM evidence after deployment without persisting raw reasoning.