### PR TITLE
fix(dashboard): surface composite health truth

### DIFF
--- a/dashboard/src/api/dashboard-tools-prompts.ts
+++ b/dashboard/src/api/dashboard-tools-prompts.ts
@@ -571,6 +571,9 @@ export interface DashboardKeeperEventQueueHealth {
 
 export interface DashboardFullHealthResponse {
   health_detail?: string
+  overall_status?: string | null
+  operator_action_required?: boolean | null
+  operator_action_reasons?: string[]
   schedule_runner?: DashboardScheduleRunnerStatus | null
   keeper_event_queue?: DashboardKeeperEventQueueHealth | null
 }
@@ -804,6 +807,12 @@ export function normalizeFullHealthResponse(
   const keeperEventQueue = normalizeKeeperEventQueueHealth(raw.keeper_event_queue)
   return {
     ...raw,
+    overall_status: typeof raw.overall_status === 'string' ? raw.overall_status : null,
+    operator_action_required:
+      typeof raw.operator_action_required === 'boolean' ? raw.operator_action_required : null,
+    operator_action_reasons: Array.isArray(raw.operator_action_reasons)
+      ? raw.operator_action_reasons.filter((value): value is string => typeof value === 'string')
+      : [],
     ...(scheduleRunner ? { schedule_runner: scheduleRunner } : {}),
     ...(keeperEventQueue ? { keeper_event_queue: keeperEventQueue } : {}),
   }

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1220,6 +1220,9 @@ describe('fetchDashboardFullHealth', () => {
   it('uses the full health path', async () => {
     const rawResponse = {
       health_detail: 'full',
+      overall_status: 'degraded',
+      operator_action_required: true,
+      operator_action_reasons: ['keeper_fleet_safety', 'keeper_event_queue'],
       schedule_runner: {
         schema: 'masc.schedule.runner_status.v1',
         status: 'ok',
@@ -1275,6 +1278,11 @@ describe('fetchDashboardFullHealth', () => {
 
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/health?full=1')
     expect(result.health_detail).toBe('full')
+    expect(result).toMatchObject({
+      overall_status: 'degraded',
+      operator_action_required: true,
+      operator_action_reasons: ['keeper_fleet_safety', 'keeper_event_queue'],
+    })
     expect(result.schedule_runner).toMatchObject({
       schema: 'masc.schedule.runner_status.v1',
       status: 'ok',

--- a/dashboard/src/app.test.ts
+++ b/dashboard/src/app.test.ts
@@ -142,10 +142,13 @@ describe('App v2 header chrome', () => {
     // button instead. The live-count + pulse coverage is preserved here.
     const liveChip = container.querySelector('.v2-statchip.live') as HTMLElement | null
     expect(liveChip).not.toBeNull()
-    expect(liveChip?.textContent).toContain('7 실행 중')
-    // Pulse is now carried by the StatusDot pip (`.dot2.pulse`), replacing the old
-    // `motion-safe:animate-pulse` utility class on an inner span.
-    expect(liveChip?.querySelector('.dot2.pulse')).not.toBeNull()
+    // The chip now names its source: without a runtime-health projection it
+    // reports unknown rather than asserting a running count it cannot derive.
+    expect(liveChip?.textContent).toContain('미수집')
+    // Pulse is carried by the StatusDot pip (`.dot2.pulse`), and it now tracks
+    // the count's meaning rather than the chip's presence: an unknown count has
+    // nothing live to pulse for, so the pip is idle.
+    expect(liveChip?.querySelector('.dot2.pulse')).toBeNull()
   })
 
   it('uses runtime health for the live running-count chip when rows are stale', () => {
@@ -174,7 +177,9 @@ describe('App v2 header chrome', () => {
 
     const liveChip = container.querySelector('.v2-statchip.live') as HTMLElement | null
     expect(liveChip).not.toBeNull()
-    expect(liveChip?.textContent).toContain('1 실행 중')
+    // runtime-health counts what can execute; 실행 중 is the row-derived
+    // fallback vocabulary and no longer applies to this source.
+    expect(liveChip?.textContent).toContain('1 실행 가능')
     expect(liveChip?.title).toContain('runtime health')
     expect(liveChip?.title).toContain('paused=3')
     expect(liveChip?.title).toContain('offline=0 (not derived from execution rows)')

--- a/dashboard/src/components/dashboard-full-health-state.ts
+++ b/dashboard/src/components/dashboard-full-health-state.ts
@@ -1,0 +1,39 @@
+import { computed } from '@preact/signals'
+import { fetchDashboardFullHealth, type DashboardFullHealthResponse } from '../api/dashboard'
+import { createManagedAsyncResource } from '../lib/async-state'
+import { setupVisibleAutoRefresh } from '../lib/auto-refresh'
+
+export const dashboardFullHealthResource = createManagedAsyncResource<DashboardFullHealthResponse>()
+
+export const dashboardFullHealth = computed(() => {
+  return dashboardFullHealthResource.state.value.data
+})
+
+export function loadDashboardFullHealth(): Promise<void> {
+  return dashboardFullHealthResource
+    .load(signal => fetchDashboardFullHealth({ signal }))
+    .then(() => undefined)
+}
+
+export const DASHBOARD_FULL_HEALTH_REFRESH_MS = 60_000
+
+let subscriberCount = 0
+let stopRefresh: (() => void) | null = null
+
+/** Share one visibility-aware /health poller between global chrome and Overview. */
+export function subscribeDashboardFullHealthRefresh(): () => void {
+  subscriberCount += 1
+  if (subscriberCount === 1) {
+    void loadDashboardFullHealth()
+    stopRefresh = setupVisibleAutoRefresh(() => {
+      void loadDashboardFullHealth()
+    }, DASHBOARD_FULL_HEALTH_REFRESH_MS)
+  }
+  return () => {
+    subscriberCount -= 1
+    if (subscriberCount === 0) {
+      stopRefresh?.()
+      stopRefresh = null
+    }
+  }
+}

--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -32,6 +32,10 @@ import type {
 } from '../../api/dashboard'
 import { keepers, boardPosts, boardTotal, lastBoardRefreshAt, shellRuntimeResolution } from '../../store'
 import type { Goal } from '../../types/core'
+import {
+  LIVE_OVERVIEW_COMPOSITE_HEALTH,
+  LIVE_OVERVIEW_HEALTH_CONTRADICTION,
+} from '../../testing/dashboard-composite-health-fixture'
 
 const overviewMocks = vi.hoisted(() => ({
   scheduledAutomationProjection: { value: null as null | DashboardScheduledAutomationProjection },
@@ -1069,6 +1073,41 @@ describe('Overview prototype surface', () => {
 
     keepers.value = []
     shellRuntimeResolution.value = null
+  })
+
+  it('shows the live 8-roster/7-executable composite health contradiction consistently', async () => {
+    const previousKeepers = keepers.value
+    const previousResolution = shellRuntimeResolution.value
+    const previousFetch = global.fetch
+    keepers.value = Array.from({ length: 8 }, (_, index) => makeKeeper({ name: `keeper-${index + 1}` }))
+    shellRuntimeResolution.value = {
+      fleet_safety: LIVE_OVERVIEW_HEALTH_CONTRADICTION,
+    } as never
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input)
+      const body = url.includes('/health?full=1') ? LIVE_OVERVIEW_COMPOSITE_HEALTH : {}
+      return Promise.resolve(new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+    }))
+
+    try {
+      const { container } = render(h(Overview, null))
+
+      await waitFor(() => {
+        expect(container.querySelector('[data-testid="kpi-run"] .ov-kpi-v')?.textContent).toBe('7 / 8')
+        expect(container.querySelector('[data-testid="kpi-att"] .ov-kpi-v')?.textContent).toBe('1')
+        expect(container.querySelector('[data-testid="overview-attention"] .ov-count')?.textContent).toBe('1')
+        expect(container.querySelector('[data-testid="overview-attention"]')?.textContent).not.toContain('모든 keeper 정상')
+        expect(container.querySelector('[data-testid="attention-row-runtime-health"]')?.textContent).toContain('Runtime health degraded')
+        expect(container.querySelector('[data-testid="attention-row-runtime-health"]')?.textContent).toContain('keeper_reaction_ledger')
+      })
+    } finally {
+      keepers.value = previousKeepers
+      shellRuntimeResolution.value = previousResolution
+      if (previousFetch) vi.stubGlobal('fetch', previousFetch)
+    }
   })
 
   it('shows no keeper execution count when the fleet projection is missing', () => {

--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -1,6 +1,6 @@
 import { h } from 'preact'
 import { cleanup, render, waitFor } from '@testing-library/preact'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   computeFunnelCounts,
   formatTargetRatio,
@@ -45,6 +45,20 @@ vi.mock('../schedule/schedule-state', () => ({
   scheduledAutomationProjection: overviewMocks.scheduledAutomationProjection,
   subscribeScheduledAutomationRefresh: () => () => {},
 }))
+
+// Overview joins the shared full-health subscription on mount, and the first
+// subscriber polls /dashboard/shell and /dashboard/execution. The harness
+// blocks real requests, so without an answer the render never reaches the
+// assertions.
+//
+// The subscription itself is not mocked: two cases below drive Overview
+// *through* it by stubbing /health?full=1, and a module mock would cut the
+// path they exercise. Only the network is replaced, and only for cases that
+// do not stub fetch themselves.
+const emptyJsonResponse = () =>
+  Promise.resolve(
+    new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }),
+  )
 
 // bar-seg ratio helper (mirrors FunnelCard inline logic)
 function segPct(counts: FunnelCounts, key: 'created' | 'inProgress' | 'awaiting' | 'completed'): number {
@@ -1019,7 +1033,14 @@ describe('computeOverviewDigest', () => {
 // ─── Prototype overview surface (header / KPIs / domains) ─────────────────────
 
 describe('Overview prototype surface', () => {
+  beforeEach(() => {
+    // Answer the full-health poll Overview starts on mount. Cases that need a
+    // specific body stub fetch themselves and override this.
+    vi.stubGlobal('fetch', vi.fn().mockImplementation(emptyJsonResponse))
+  })
+
   afterEach(() => {
+    vi.unstubAllGlobals()
     cleanup()
   })
 
@@ -1037,7 +1058,7 @@ describe('Overview prototype surface', () => {
     expect(cells).toHaveLength(7)
     const labels = [...cells].map(c => c.querySelector('.ov-kpi-k')?.textContent)
     expect(labels).toEqual([
-      '실행 중 keeper',
+      '실행 Fiber',
       '주의 필요',
       '열린 Gate',
       '최우선 목표',
@@ -1066,7 +1087,7 @@ describe('Overview prototype surface', () => {
     const { container } = render(h(Overview, null))
     // The roster holds 2 active-looking rows; the projection reports 4 running.
     // The projection wins.
-    expect(container.querySelector('[data-testid="kpi-run"] .ov-kpi-v')?.textContent).toBe('4 / 2')
+    expect(container.querySelector('[data-testid="kpi-run"] .ov-kpi-v')?.textContent).toBe('4 / 등록 2')
     expect(container.querySelector('[data-testid="fleet-stat-running"] .v')?.textContent).toBe('4')
     expect(container.querySelector('[data-testid="fleet-stat-recovering"] .v')?.textContent).toBe('3')
     expect(container.querySelector('[data-testid="fleet-stat-paused"] .v')?.textContent).toBe('1')
@@ -1096,7 +1117,7 @@ describe('Overview prototype surface', () => {
       const { container } = render(h(Overview, null))
 
       await waitFor(() => {
-        expect(container.querySelector('[data-testid="kpi-run"] .ov-kpi-v')?.textContent).toBe('7 / 8')
+        expect(container.querySelector('[data-testid="kpi-run"] .ov-kpi-v')?.textContent).toBe('7 / 등록 8')
         expect(container.querySelector('[data-testid="kpi-att"] .ov-kpi-v')?.textContent).toBe('1')
         expect(container.querySelector('[data-testid="overview-attention"] .ov-count')?.textContent).toBe('1')
         expect(container.querySelector('[data-testid="overview-attention"]')?.textContent).not.toContain('모든 keeper 정상')
@@ -1122,7 +1143,7 @@ describe('Overview prototype surface', () => {
     shellRuntimeResolution.value = null
 
     const { container } = render(h(Overview, null))
-    expect(container.querySelector('[data-testid="kpi-run"] .ov-kpi-v')?.textContent).toBe('— / 3')
+    expect(container.querySelector('[data-testid="kpi-run"] .ov-kpi-v')?.textContent).toBe('— / 등록 3')
     expect(container.querySelector('[data-testid="fleet-stat-running"] .v')?.textContent).toBe('—')
     expect(container.querySelector('[data-testid="fleet-stat-recovering"] .v')?.textContent).toBe('—')
     expect(container.querySelector('[data-testid="fleet-stat-paused"] .v')?.textContent).toBe('—')
@@ -1143,7 +1164,7 @@ describe('Overview prototype surface', () => {
     } as never
 
     const { container } = render(h(Overview, null))
-    expect(container.querySelector('[data-testid="kpi-run"] .ov-kpi-v')?.textContent).toBe('0 / 1')
+    expect(container.querySelector('[data-testid="kpi-run"] .ov-kpi-v')?.textContent).toBe('0 / 등록 1')
     expect(container.querySelector('[data-testid="fleet-stat-running"] .v')?.textContent).toBe('0')
 
     keepers.value = []

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -1092,7 +1092,7 @@ function OverviewKpiStrip({
       : undefined
   return html`
     <section class="ov-kpis v2-overview-kpis" aria-label="Cross-surface KPIs" data-testid="overview-kpis">
-      <${OverviewKpi} label="실행 중 keeper" value=${fleetCountText(fleet?.running)} sub=${` / ${stats.total}`} tone=${fleet?.running != null ? 'ok' : undefined} testId="kpi-run" onClick=${() => navigate('monitoring')} />
+      <${OverviewKpi} label="실행 Fiber" value=${fleetCountText(fleet?.running)} sub=${` / 등록 ${stats.total}`} tone=${fleet?.running != null ? 'ok' : undefined} testId="kpi-run" onClick=${() => navigate('monitoring')} />
       <${OverviewKpi} label="주의 필요" value=${attentionValue} tone=${attentionTone} testId="kpi-att" onClick=${() => navigate('monitoring', { section: 'fleet-health' })} />
       ${approvalQueueState && approvalQueueState.state !== 'ready'
         ? html`<${OverviewKpi}
@@ -1571,12 +1571,12 @@ function OverviewDomainSection({
       <!-- FLEET summary · overview.jsx:252-260 -->
       <${DomainCard} title="Fleet 요약" linkLabel="Monitor" nav=${{ tab: 'monitoring' }} testId="domain-fleet">
         <div class="ov-fleet-sum">
-          <div class="ov-fleet-stat" data-testid="fleet-stat-running"><span class="v ok">${fleetCountText(fleet?.running)}</span><span class="k">실행</span></div>
+          <div class="ov-fleet-stat" data-testid="fleet-stat-running"><span class="v ok">${fleetCountText(fleet?.running)}</span><span class="k">실행 Fiber</span></div>
           <div class="ov-fleet-stat" data-testid="fleet-stat-recovering"><span class=${`v ${(fleet?.recovering ?? 0) > 0 ? 'warn' : ''}`}>${fleetCountText(fleet?.recovering)}</span><span class="k">복구</span></div>
           <div class="ov-fleet-stat" data-testid="fleet-stat-paused"><span class="v">${fleetCountText(fleet?.paused)}</span><span class="k">일시정지</span></div>
           <div class="ov-fleet-stat"><span class="v warn">${stats.att}</span><span class="k">주의</span></div>
           <div class="ov-fleet-stat"><span class=${`v ${stats.hot > 0 ? 'bad' : ''}`}>${stats.hot}</span><span class="k">압박</span></div>
-          <div class="ov-fleet-stat"><span class="v">${stats.total}</span><span class="k">전체</span></div>
+          <div class="ov-fleet-stat"><span class="v">${stats.total}</span><span class="k">등록</span></div>
         </div>
         ${keeperQueueSummary.hasProjection
           ? html`

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -1090,10 +1090,13 @@ function OverviewKpiStrip({
     : attentionCount > 0 || health.state === 'unavailable'
       ? 'bad'
       : undefined
+  const attentionTarget = health.issueCount > 0 || health.state === 'unavailable'
+    ? { section: 'fleet-health' }
+    : { section: 'agents' }
   return html`
     <section class="ov-kpis v2-overview-kpis" aria-label="Cross-surface KPIs" data-testid="overview-kpis">
       <${OverviewKpi} label="실행 Fiber" value=${fleetCountText(fleet?.running)} sub=${` / 등록 ${stats.total}`} tone=${fleet?.running != null ? 'ok' : undefined} testId="kpi-run" onClick=${() => navigate('monitoring')} />
-      <${OverviewKpi} label="주의 필요" value=${attentionValue} tone=${attentionTone} testId="kpi-att" onClick=${() => navigate('monitoring', { section: 'fleet-health' })} />
+      <${OverviewKpi} label="주의 필요" value=${attentionValue} tone=${attentionTone} testId="kpi-att" onClick=${() => navigate('monitoring', attentionTarget)} />
       ${approvalQueueState && approvalQueueState.state !== 'ready'
         ? html`<${OverviewKpi}
             label="열린 Gate"
@@ -1160,7 +1163,7 @@ function OverviewAttentionPanel({
   return html`
     <section class="ov-card ov-attn v2-overview-attention" data-testid="overview-attention">
       <div class="ov-card-h">
-        <h3>주의 필요 · 지금 손이 필요한 것</h3>
+        <h3>${attentionCount === 0 && health.state === 'status' ? '상태 참고' : '주의 필요 · 지금 손이 필요한 것'}</h3>
         <span class="ov-count">${attentionCountLabel}</span>
       </div>
       <div class="ov-attn-list v2-overview-attention-list">
@@ -1179,7 +1182,7 @@ function OverviewAttentionPanel({
                 <button type="button" class="ov-attn-act">상태 상세 →</button>
               </div>
             `
-          : health.state === 'attention'
+          : health.state === 'attention' || health.state === 'status'
             ? health.issues.map(issue => html`
                 <div
                   key=${issue.kind}

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -46,6 +46,10 @@ import {
   resolveKeeperFleetExecutionCounts,
   type KeeperFleetExecutionCounts,
 } from '../../runtime-counts'
+import {
+  projectDashboardCompositeHealth,
+  type DashboardCompositeHealthVerdict,
+} from '../../lib/dashboard-composite-health'
 import { createAsyncResource, type AsyncResource, type AsyncState } from '../../lib/async-state'
 import { navigate } from '../../router'
 import { gateData } from '../gate-signals'
@@ -57,16 +61,18 @@ import {
 import {
   fetchTelemetry,
   fetchTelemetrySummary,
-  fetchDashboardFullHealth,
   type TelemetryEntry,
   type TelemetrySourceSummary,
-  type DashboardFullHealthResponse,
   type DashboardKeeperEventQueueHealth,
   type DashboardScheduleRunnerStatus,
 } from '../../api/dashboard'
 import {
   OVERVIEW_TELEMETRY_EVENTS_PER_BUCKET,
 } from '../../config/constants'
+import {
+  dashboardFullHealth,
+  subscribeDashboardFullHealthRefresh,
+} from '../dashboard-full-health-state'
 
 // ─── Attention / Keeper v2 helpers ───────────────────────────────────────────
 
@@ -995,14 +1001,6 @@ function loadOverviewTelemetry(nowMs = Date.now()): Promise<void> {
   })
 }
 
-const overviewFullHealthResource: AsyncResource<DashboardFullHealthResponse> = createAsyncResource()
-
-function loadOverviewFullHealth(): Promise<void> {
-  return overviewFullHealthResource.load(async () => {
-    return fetchDashboardFullHealth()
-  })
-}
-
 // ─── Keeper-v2 overview surfaces ─────────────────────────────────────────────
 
 function nowHMKst(): string {
@@ -1073,18 +1071,29 @@ function OverviewKpi({
 function OverviewKpiStrip({
   stats,
   fleet,
+  health,
   digest,
   approvalQueueState,
 }: {
   stats: OverviewStats
   fleet: KeeperFleetExecutionCounts | null
+  health: DashboardCompositeHealthVerdict
   digest: OverviewDigest
   approvalQueueState: NonNullable<typeof gateData.value>['approval_queue_state'] | undefined
 }) {
+  const attentionCount = stats.att + health.issueCount
+  const attentionValue = health.state === 'unavailable'
+    ? stats.att > 0 ? `${stats.att}+?` : '—'
+    : String(attentionCount)
+  const attentionTone = health.state === 'attention' && health.severity === 'warn' && stats.att === 0
+    ? 'warn'
+    : attentionCount > 0 || health.state === 'unavailable'
+      ? 'bad'
+      : undefined
   return html`
     <section class="ov-kpis v2-overview-kpis" aria-label="Cross-surface KPIs" data-testid="overview-kpis">
       <${OverviewKpi} label="실행 중 keeper" value=${fleetCountText(fleet?.running)} sub=${` / ${stats.total}`} tone=${fleet?.running != null ? 'ok' : undefined} testId="kpi-run" onClick=${() => navigate('monitoring')} />
-      <${OverviewKpi} label="주의 필요" value=${String(stats.att)} tone=${stats.att > 0 ? 'bad' : undefined} testId="kpi-att" onClick=${() => navigate('monitoring')} />
+      <${OverviewKpi} label="주의 필요" value=${attentionValue} tone=${attentionTone} testId="kpi-att" onClick=${() => navigate('monitoring', { section: 'fleet-health' })} />
       ${approvalQueueState && approvalQueueState.state !== 'ready'
         ? html`<${OverviewKpi}
             label="열린 Gate"
@@ -1113,7 +1122,13 @@ function attentionToneClass(sev: KeeperAttentionReason['sev']): string {
   return sev === 'bad' ? 'bg-destructive' : 'bg-warning'
 }
 
-function OverviewAttentionPanel({ keeperList }: { keeperList: readonly Keeper[] }) {
+function OverviewAttentionPanel({
+  keeperList,
+  health,
+}: {
+  keeperList: readonly Keeper[]
+  health: DashboardCompositeHealthVerdict
+}) {
   const attn = useMemo(
     () => pickAttentionKeepers(keeperList).slice().sort((a, b) => {
       const aBad = deriveKeeperAttentionReason(a).sev === 'bad'
@@ -1125,7 +1140,7 @@ function OverviewAttentionPanel({ keeperList }: { keeperList: readonly Keeper[] 
     [keeperList],
   )
 
-  if (attn.length === 0) {
+  if (attn.length === 0 && health.state === 'healthy') {
     return html`
       <section class="ov-card ov-attn v2-overview-attention" data-testid="overview-attention">
         <div class="ov-card-h">
@@ -1137,13 +1152,51 @@ function OverviewAttentionPanel({ keeperList }: { keeperList: readonly Keeper[] 
     `
   }
 
+  const attentionCount = attn.length + health.issueCount
+  const attentionCountLabel = health.state === 'unavailable'
+    ? attn.length > 0 ? `${attn.length}+?` : '—'
+    : String(attentionCount)
+
   return html`
     <section class="ov-card ov-attn v2-overview-attention" data-testid="overview-attention">
       <div class="ov-card-h">
         <h3>주의 필요 · 지금 손이 필요한 것</h3>
-        <span class="ov-count">${attn.length}</span>
+        <span class="ov-count">${attentionCountLabel}</span>
       </div>
       <div class="ov-attn-list v2-overview-attention-list">
+        ${health.state === 'unavailable'
+          ? html`
+              <div
+                class="ov-attn-row v2-overview-attention-row"
+                data-testid="attention-row-composite-health-unavailable"
+                onClick=${() => navigate('monitoring', { section: 'fleet-health' })}
+              >
+                <span class="inline-block size-2 rounded-full bg-warning"></span>
+                <div class="ov-attn-meta">
+                  <div class="ov-attn-name">Fleet health 미연결</div>
+                  <div class="ov-attn-reason sev-warn">Backend composite health verdict has not loaded.</div>
+                </div>
+                <button type="button" class="ov-attn-act">상태 상세 →</button>
+              </div>
+            `
+          : health.state === 'attention'
+            ? health.issues.map(issue => html`
+                <div
+                  key=${issue.kind}
+                  class="ov-attn-row v2-overview-attention-row"
+                  data-testid=${`attention-row-${issue.kind}`}
+                  title=${issue.detail}
+                  onClick=${() => navigate('monitoring', { section: 'fleet-health' })}
+                >
+                  <span class=${`inline-block size-2 rounded-full ${issue.severity === 'bad' ? 'bg-destructive' : 'bg-warning'}`}></span>
+                  <div class="ov-attn-meta">
+                    <div class="ov-attn-name">${issue.label}</div>
+                    <div class=${`ov-attn-reason sev-${issue.severity}`}>${issue.detail}</div>
+                  </div>
+                  <button type="button" class="ov-attn-act">상태 상세 →</button>
+                </div>
+              `)
+            : null}
         ${attn.map(k => {
           const reason = deriveKeeperAttentionReason(k)
           const displayName = k.koreanName && k.koreanName !== '' ? k.koreanName : k.name
@@ -1554,17 +1607,17 @@ export function Overview() {
   useNowSecondsTicker()
   useEffect(() => {
     void loadOverviewTelemetry()
-    void loadOverviewFullHealth()
     const interval = window.setInterval(() => {
       void loadOverviewTelemetry()
-      void loadOverviewFullHealth()
     }, 60_000)
+    const stopFullHealthRefresh = subscribeDashboardFullHealthRefresh()
     // Schedule state is its own projection with its own poller. Root used to
     // reach it through the tool inventory, which meant entering the home
     // surface fetched the whole tool registry.
     const stopScheduleRefresh = subscribeScheduledAutomationRefresh()
     return () => {
       window.clearInterval(interval)
+      stopFullHealthRefresh()
       stopScheduleRefresh()
     }
   }, [])
@@ -1578,19 +1631,15 @@ export function Overview() {
       ? gateData.value?.approval_queue?.length ?? null
       : null
   const scheduledAutomationData = scheduledAutomationProjection.value ?? null
-  const scheduleRunnerStatus =
-    overviewFullHealthResource.state.value.status === 'loaded'
-      ? overviewFullHealthResource.state.value.data.schedule_runner ?? null
-      : null
-  const keeperQueueHealth =
-    overviewFullHealthResource.state.value.status === 'loaded'
-      ? overviewFullHealthResource.state.value.data.keeper_event_queue ?? null
-      : null
+  const fullHealth = dashboardFullHealth.value
+  const scheduleRunnerStatus = fullHealth?.schedule_runner ?? null
+  const keeperQueueHealth = fullHealth?.keeper_event_queue ?? null
   // Keeper execution counts come from the runtime-health fleet projection the
   // shell already holds — the same `keeper_fleet_safety_health_json` payload
   // `/health?full=1` embeds, so reading it here adds no request.
   const fleetSafety = shellRuntimeResolution.value?.fleet_safety ?? null
   const fleet = useMemo(() => resolveKeeperFleetExecutionCounts(fleetSafety), [fleetSafety])
+  const compositeHealth = useMemo(() => projectDashboardCompositeHealth(fullHealth), [fullHealth])
   const stats = useMemo(() => computeOverviewStats(keeperList, taskList), [keeperList, taskList])
   const digest = useMemo(
     () => computeOverviewDigest(
@@ -1612,11 +1661,12 @@ export function Overview() {
         <${OverviewKpiStrip}
           stats=${stats}
           fleet=${fleet}
+          health=${compositeHealth}
           digest=${digest}
           approvalQueueState=${approvalQueueState}
         />
         <div class="ov-grid v2-overview-primary-grid" data-testid="overview-primary-grid">
-          <${OverviewAttentionPanel} keeperList=${keeperList} />
+          <${OverviewAttentionPanel} keeperList=${keeperList} health=${compositeHealth} />
           <${OverviewTelemetry} telemetry=${telemetry} />
         </div>
         <${OverviewDomainSection}

--- a/dashboard/src/components/v2/top-bar-v2.test.ts
+++ b/dashboard/src/components/v2/top-bar-v2.test.ts
@@ -1,0 +1,81 @@
+import { h } from 'preact'
+import { cleanup, fireEvent, render } from '@testing-library/preact'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { LIVE_OVERVIEW_COMPOSITE_HEALTH } from '../../testing/dashboard-composite-health-fixture'
+
+const mocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  keepers: { value: [] as unknown[] },
+  dashboardFullHealth: { value: null as unknown },
+  shellRuntimeResolution: {
+    value: null as unknown,
+  },
+}))
+
+vi.mock('../../store', () => ({
+  executionLoaded: { value: true },
+  keepers: mocks.keepers,
+  shellCounts: { value: null },
+  shellRuntimeResolution: mocks.shellRuntimeResolution,
+  staleKeepers: { value: new Set<string>() },
+}))
+
+vi.mock('../gate-signals', () => ({
+  gateData: {
+    value: {
+      approval_queue_state: { state: 'ready' },
+      approval_queue: [],
+    },
+  },
+}))
+
+vi.mock('../dashboard-full-health-state', () => ({
+  dashboardFullHealth: mocks.dashboardFullHealth,
+  subscribeDashboardFullHealthRefresh: () => () => {},
+}))
+
+vi.mock('../../router', () => ({
+  navigate: mocks.navigate,
+  route: { value: { tab: 'overview', params: {} } },
+}))
+
+vi.mock('../../keeper-state', () => ({ activeKeeperName: { value: '' } }))
+vi.mock('../dashboard-shell', () => ({
+  ConnectionStatus: () => null,
+  ErrorCounterBadge: () => null,
+  BuildIdentityBadge: () => null,
+}))
+vi.mock('../auth-status', () => ({ AuthStatus: () => null }))
+vi.mock('../emergency-stop-control', () => ({ EmergencyStopControl: () => null }))
+vi.mock('../transport-beacon', () => ({ TransportBeacon: () => null }))
+vi.mock('../copilot-dock', () => ({ CopilotDockTopBarButton: () => null }))
+vi.mock('../tweaks-panel', () => ({ TweaksPanelToggle: () => null }))
+vi.mock('./primitives-v2', () => ({ StatusDot: () => null }))
+vi.mock('./nav-rail-v2', () => ({ surfaceLabel: () => 'Overview' }))
+
+import { AttentionIndicatorV2 } from './top-bar-v2'
+
+describe('AttentionIndicatorV2 composite health interaction', () => {
+  afterEach(() => {
+    cleanup()
+    mocks.navigate.mockReset()
+    mocks.shellRuntimeResolution.value = null
+    mocks.dashboardFullHealth.value = null
+  })
+
+  it('opens the degraded backend health rows and drills into fleet health', () => {
+    mocks.dashboardFullHealth.value = LIVE_OVERVIEW_COMPOSITE_HEALTH
+    const { getByRole, getByText } = render(h(AttentionIndicatorV2, null))
+
+    const attentionButton = getByRole('button', { name: /주의 1/ })
+    expect(attentionButton.textContent).not.toContain('정상')
+
+    fireEvent.click(attentionButton)
+    const fleetRow = getByText('Runtime health degraded').closest('button')
+    expect(fleetRow?.title).toContain('keeper_fleet_safety')
+    expect(fleetRow?.title).toContain('keeper_reaction_ledger')
+
+    fireEvent.click(fleetRow!)
+    expect(mocks.navigate).toHaveBeenCalledWith('monitoring', { section: 'fleet-health' })
+  })
+})

--- a/dashboard/src/components/v2/top-bar-v2.ts
+++ b/dashboard/src/components/v2/top-bar-v2.ts
@@ -197,6 +197,9 @@ export function AttentionIndicatorV2() {
 
 export function TopBarV2({ dock }: { dock: CopilotDockApi }) {
   const tab = route.value.tab
+  const shellKeeperFiberCount = typeof shellCounts.value?.keepers === 'number'
+    ? shellCounts.value.keepers
+    : null
   const fallbackRunningKeepers = keepers.value.filter((keeper) => keeperRowLooksRunning({
     status: keeper.status,
     phase: keeper.lifecycle_phase ?? keeper.phase,
@@ -207,7 +210,7 @@ export function TopBarV2({ dock }: { dock: CopilotDockApi }) {
   const runtimeCounts = resolveRuntimeCounts({
     executionLoaded: executionLoaded.value,
     agentsCount: shellCounts.value?.agents ?? 0,
-    keepersCount: shellCounts.value?.keepers ?? fallbackRunningKeepers,
+    keepersCount: shellKeeperFiberCount ?? fallbackRunningKeepers,
     keeperRowsCount: keepers.value.length,
     shellCounts: shellCounts.value,
     shellConfiguredKeepers: shellCounts.value?.configured_keepers,
@@ -215,11 +218,18 @@ export function TopBarV2({ dock }: { dock: CopilotDockApi }) {
     runtimeHealthGeneratedAt: shellRuntimeResolution.value?.generated_at ?? null,
   })
   const keeperCount = runtimeCounts.live.keepers
-  const countMeaning = keeperLiveCountMeaning(runtimeCounts.source)
-  const countLabel = countMeaning === 'executable' ? '실행 가능' : '실행 중'
+  const countMeaning = keeperLiveCountMeaning(
+    runtimeCounts.source,
+    shellKeeperFiberCount === null ? 'running' : 'keeper-fiber',
+  )
+  const countPresentation = countMeaning === 'executable'
+    ? { label: '실행 가능', metric: 'executable' }
+    : countMeaning === 'running'
+      ? { label: '실행 중', metric: 'running' }
+      : { label: 'Keeper Fiber', metric: 'keeper_fibers' }
   const countTitle = [
     `runtime count: ${runtimeCountSourceLabel(runtimeCounts.source)}`,
-    `${countMeaning}=${runtimeCounts.live.keepers}`,
+    `${countPresentation.metric}=${runtimeCounts.live.keepers}`,
     `paused=${runtimeCounts.live.pausedKeepers}`,
     runtimeCounts.source === 'runtime-health'
       ? 'offline=0 (not derived from execution rows)'
@@ -237,7 +247,7 @@ export function TopBarV2({ dock }: { dock: CopilotDockApi }) {
       </div>
       <div class="v2-top-spacer"></div>
       <span class="v2-statchip live" title=${countTitle}>
-        <${StatusDot} status="run" pulse=${true} />${keeperCount} ${countLabel}
+        <${StatusDot} status="run" pulse=${countMeaning !== 'keeper-fiber'} />${keeperCount} ${countPresentation.label}
       </span>
       <${AttentionIndicatorV2} />
       <button class="v2-statchip" onClick=${() => navigate('schedule')} title="예약 자동화 큐">

--- a/dashboard/src/components/v2/top-bar-v2.ts
+++ b/dashboard/src/components/v2/top-bar-v2.ts
@@ -96,7 +96,7 @@ export function AttentionIndicatorV2() {
     const issue = a.health.issues[0]
     return html`
       <button
-        class=${`v2-statchip ${issue.severity}`}
+        class=${`v2-statchip attn ${issue.severity}`}
         onClick=${() => navigate('monitoring', { section: 'fleet-health' })}
         title=${issue.detail}
       >${'◌'} ${issue.label}</button>
@@ -218,18 +218,22 @@ export function TopBarV2({ dock }: { dock: CopilotDockApi }) {
     runtimeHealthGeneratedAt: shellRuntimeResolution.value?.generated_at ?? null,
   })
   const keeperCount = runtimeCounts.live.keepers
-  const countMeaning = keeperLiveCountMeaning(
-    runtimeCounts.source,
-    shellKeeperFiberCount === null ? 'running' : 'keeper-fiber',
-  )
+  const countMeaning = runtimeCounts.live.available
+    ? keeperLiveCountMeaning(
+        runtimeCounts.source,
+        shellKeeperFiberCount === null ? 'running' : 'keeper-fiber',
+      )
+    : 'unknown'
   const countPresentation = countMeaning === 'executable'
-    ? { label: '실행 가능', metric: 'executable' }
+    ? { value: String(keeperCount), label: '실행 가능', metric: 'executable' }
     : countMeaning === 'running'
-      ? { label: '실행 중', metric: 'running' }
-      : { label: 'Keeper Fiber', metric: 'keeper_fibers' }
+      ? { value: String(keeperCount), label: '실행 중', metric: 'running' }
+      : countMeaning === 'keeper-fiber'
+        ? { value: String(keeperCount), label: 'Keeper Fiber', metric: 'keeper_fibers' }
+        : { value: '—', label: '미수집', metric: 'unknown' }
   const countTitle = [
     `runtime count: ${runtimeCountSourceLabel(runtimeCounts.source)}`,
-    `${countPresentation.metric}=${runtimeCounts.live.keepers}`,
+    `${countPresentation.metric}=${countPresentation.value}`,
     `paused=${runtimeCounts.live.pausedKeepers}`,
     runtimeCounts.source === 'runtime-health'
       ? 'offline=0 (not derived from execution rows)'
@@ -247,7 +251,7 @@ export function TopBarV2({ dock }: { dock: CopilotDockApi }) {
       </div>
       <div class="v2-top-spacer"></div>
       <span class="v2-statchip live" title=${countTitle}>
-        <${StatusDot} status="run" pulse=${countMeaning !== 'keeper-fiber'} />${keeperCount} ${countPresentation.label}
+        <${StatusDot} status=${countMeaning === 'unknown' ? 'idle' : 'run'} pulse=${countMeaning === 'executable' || countMeaning === 'running'} />${countPresentation.value} ${countPresentation.label}
       </span>
       <${AttentionIndicatorV2} />
       <button class="v2-statchip" onClick=${() => navigate('schedule')} title="예약 자동화 큐">

--- a/dashboard/src/components/v2/top-bar-v2.ts
+++ b/dashboard/src/components/v2/top-bar-v2.ts
@@ -15,6 +15,10 @@ import { TweaksPanelToggle } from '../tweaks-panel'
 import { StatusDot } from './primitives-v2'
 import { surfaceLabel } from './nav-rail-v2'
 import { configuredCountSourceLabel, keeperRowLooksRunning, resolveRuntimeCounts, runtimeCountSourceLabel } from '../../runtime-counts'
+import {
+  projectDashboardCompositeHealth,
+  type DashboardCompositeHealthVerdict,
+} from '../../lib/dashboard-composite-health'
 // Operational/safety chrome the v2 prototype omits but operators rely on
 // (connection state, transport telemetry, emergency stop, error inbox, auth,
 // build identity). Re-mounted into the v2 top bar so the reskin does not drop
@@ -24,6 +28,10 @@ import { ConnectionStatus, ErrorCounterBadge, BuildIdentityBadge } from '../dash
 import { AuthStatus } from '../auth-status'
 import { EmergencyStopControl } from '../emergency-stop-control'
 import { TransportBeacon } from '../transport-beacon'
+import {
+  dashboardFullHealth,
+  subscribeDashboardFullHealthRefresh,
+} from '../dashboard-full-health-state'
 
 const DEAD_PHASES = new Set(['Overflowed', 'Crashed', 'Dead'])
 
@@ -33,6 +41,7 @@ interface AttentionAgg {
   keepers: number
   dead: number
   stale: number
+  health: DashboardCompositeHealthVerdict
   total: number
 }
 
@@ -46,18 +55,31 @@ function computeAttention(): AttentionAgg {
   const attKeepers = ks.filter((k) => k.needs_attention === true).length
   const dead = ks.filter((k) => !!k.lifecycle_phase && DEAD_PHASES.has(k.lifecycle_phase)).length
   const stale = staleKeepers.value.size
+  const health = projectDashboardCompositeHealth(dashboardFullHealth.value)
   return {
     approvals,
     approvalQueueState,
     keepers: attKeepers,
     dead,
     stale,
-    total: (approvals ?? 0) + attKeepers + dead + stale,
+    health,
+    total: (approvals ?? 0) + attKeepers + dead + stale + health.issueCount,
   }
 }
 
-function AttentionIndicatorV2() {
+interface AttentionRow {
+  k: string
+  n: number | string
+  lbl: string
+  detail?: string
+  sev: 'bad' | 'warn'
+  nav: 'approvals' | 'monitoring' | 'connectors'
+  params?: Record<string, string>
+}
+
+export function AttentionIndicatorV2() {
   const [open, setOpen] = useState(false)
+  useEffect(() => subscribeDashboardFullHealthRefresh(), [])
   useEffect(() => {
     if (!open) return
     const close = () => setOpen(false)
@@ -85,20 +107,45 @@ function AttentionIndicatorV2() {
       >? 승인 큐 확인 필요</button>
     `
   }
-  if (!a.total) {
+  if (!a.total && a.health.state === 'healthy') {
     return html`<span class="v2-statchip live" title="처리할 항목 없음">${'✓'} 정상</span>`
   }
-  const rows = [
-    { k: 'approvals', n: a.approvals, lbl: '승인 대기', sev: 'bad', nav: 'approvals' as const },
-    { k: 'keepers', n: a.keepers, lbl: '주의 keeper', sev: 'warn', nav: 'monitoring' as const },
-    { k: 'dead', n: a.dead, lbl: '죽음·넘침', sev: 'bad', nav: 'monitoring' as const },
-    { k: 'stale', n: a.stale, lbl: 'stale 게이트', sev: 'warn', nav: 'connectors' as const },
-  ].filter((r) => r.n !== null && r.n > 0)
-  const tone = a.approvals > 0 || a.dead > 0 ? 'bad' : 'warn'
+  const rows: AttentionRow[] = []
+  if (a.approvals !== null && a.approvals > 0) rows.push({ k: 'approvals', n: a.approvals, lbl: '승인 대기', sev: 'bad', nav: 'approvals' })
+  if (a.keepers > 0) rows.push({ k: 'keepers', n: a.keepers, lbl: '주의 keeper', sev: 'warn', nav: 'monitoring' })
+  if (a.dead > 0) rows.push({ k: 'dead', n: a.dead, lbl: '죽음·넘침', sev: 'bad', nav: 'monitoring' })
+  if (a.stale > 0) rows.push({ k: 'stale', n: a.stale, lbl: 'stale 게이트', sev: 'warn', nav: 'connectors' })
+  if (a.health.state === 'attention') {
+    rows.push(...a.health.issues.map(issue => ({
+      k: issue.kind,
+      n: 1,
+      lbl: issue.label,
+      detail: issue.detail,
+      sev: issue.severity,
+      nav: 'monitoring' as const,
+      params: { section: 'fleet-health' },
+    })))
+  } else if (a.health.state === 'unavailable') {
+    rows.push({
+      k: 'composite-health-unavailable',
+      n: '—',
+      lbl: 'Fleet health 미연결',
+      detail: 'Backend composite fleet health verdict has not loaded.',
+      sev: 'warn',
+      nav: 'monitoring',
+      params: { section: 'fleet-health' },
+    })
+  }
+  const tone = a.approvals > 0 || a.dead > 0 || (a.health.state === 'attention' && a.health.severity === 'bad')
+    ? 'bad'
+    : 'warn'
+  const totalLabel = a.health.state === 'unavailable'
+    ? a.total > 0 ? `${a.total}+?` : '?'
+    : String(a.total)
   return html`
     <div class="attn-wrap" onClick=${(e: Event) => e.stopPropagation()}>
       <button class=${`v2-statchip attn ${tone}`} onClick=${() => setOpen((o) => !o)} title="지금 나를 필요로 하는 것">
-        ${'⚑'} 주의 <b>${a.total}</b>
+        ${'⚑'} 주의 <b>${totalLabel}</b>
       </button>
       ${open
         ? html`
@@ -106,7 +153,12 @@ function AttentionIndicatorV2() {
               <div class="attn-menu-h">지금 나를 필요로 하는 것</div>
               ${rows.map(
                 (r) => html`
-                  <button key=${r.k} class="attn-row" onClick=${() => { setOpen(false); navigate(r.nav) }}>
+                  <button
+                    key=${r.k}
+                    class="attn-row"
+                    title=${r.detail}
+                    onClick=${() => { setOpen(false); navigate(r.nav, r.params) }}
+                  >
                     <span class=${`dot2 ${r.sev}`}></span>
                     <span class="attn-row-lbl">${r.lbl}</span>
                     <span class="attn-row-n mono">${r.n}</span>

--- a/dashboard/src/components/v2/top-bar-v2.ts
+++ b/dashboard/src/components/v2/top-bar-v2.ts
@@ -212,7 +212,7 @@ export function TopBarV2({ dock }: { dock: CopilotDockApi }) {
       </div>
       <div class="v2-top-spacer"></div>
       <span class="v2-statchip live" title=${countTitle}>
-        <${StatusDot} status="run" pulse=${true} />${running} 실행 중
+        <${StatusDot} status="run" pulse=${true} />${running} 실행 가능
       </span>
       <${AttentionIndicatorV2} />
       <button class="v2-statchip" onClick=${() => navigate('schedule')} title="예약 자동화 큐">

--- a/dashboard/src/components/v2/top-bar-v2.ts
+++ b/dashboard/src/components/v2/top-bar-v2.ts
@@ -14,7 +14,7 @@ import { CopilotDockTopBarButton, type CopilotDockApi } from '../copilot-dock'
 import { TweaksPanelToggle } from '../tweaks-panel'
 import { StatusDot } from './primitives-v2'
 import { surfaceLabel } from './nav-rail-v2'
-import { configuredCountSourceLabel, keeperRowLooksRunning, resolveRuntimeCounts, runtimeCountSourceLabel } from '../../runtime-counts'
+import { configuredCountSourceLabel, keeperLiveCountMeaning, keeperRowLooksRunning, resolveRuntimeCounts, runtimeCountSourceLabel } from '../../runtime-counts'
 import {
   projectDashboardCompositeHealth,
   type DashboardCompositeHealthVerdict,
@@ -88,29 +88,41 @@ export function AttentionIndicatorV2() {
   }, [open])
 
   const a = computeAttention()
-  if (a.approvalQueueState && a.approvalQueueState.state !== 'ready') {
-    const state = a.approvalQueueState
-    return html`
-      <button
-        class=${`v2-statchip attn ${state.severity}`}
-        onClick=${() => navigate('approvals')}
-        title=${state.operator_detail}
-      >${state.icon} ${state.title}</button>
-    `
-  }
-  if (a.approvalQueueState?.state !== 'ready' || a.approvals === null) {
-    return html`
-      <button
-        class="v2-statchip attn warn"
-        onClick=${() => navigate('approvals')}
-        title="Gate queue state has not loaded"
-      >? 승인 큐 확인 필요</button>
-    `
-  }
-  if (!a.total && a.health.state === 'healthy') {
+  const approvalQueueUnknown = a.approvalQueueState?.state !== 'ready' || a.approvals === null
+  if (!a.total && a.health.state === 'healthy' && !approvalQueueUnknown) {
     return html`<span class="v2-statchip live" title="처리할 항목 없음">${'✓'} 정상</span>`
   }
+  if (!a.total && a.health.state === 'status' && !approvalQueueUnknown) {
+    const issue = a.health.issues[0]
+    return html`
+      <button
+        class=${`v2-statchip ${issue.severity}`}
+        onClick=${() => navigate('monitoring', { section: 'fleet-health' })}
+        title=${issue.detail}
+      >${'◌'} ${issue.label}</button>
+    `
+  }
   const rows: AttentionRow[] = []
+  if (a.approvalQueueState && a.approvalQueueState.state !== 'ready') {
+    const state = a.approvalQueueState
+    rows.push({
+      k: 'approval-queue-state',
+      n: '—',
+      lbl: `${state.icon} ${state.title}`,
+      detail: state.operator_detail,
+      sev: state.severity,
+      nav: 'approvals',
+    })
+  } else if (a.approvals === null) {
+    rows.push({
+      k: 'approval-queue-unavailable',
+      n: '—',
+      lbl: '승인 큐 미연결',
+      detail: 'Gate queue state has not loaded.',
+      sev: 'warn',
+      nav: 'approvals',
+    })
+  }
   if (a.approvals !== null && a.approvals > 0) rows.push({ k: 'approvals', n: a.approvals, lbl: '승인 대기', sev: 'bad', nav: 'approvals' })
   if (a.keepers > 0) rows.push({ k: 'keepers', n: a.keepers, lbl: '주의 keeper', sev: 'warn', nav: 'monitoring' })
   if (a.dead > 0) rows.push({ k: 'dead', n: a.dead, lbl: '죽음·넘침', sev: 'bad', nav: 'monitoring' })
@@ -119,6 +131,16 @@ export function AttentionIndicatorV2() {
     rows.push(...a.health.issues.map(issue => ({
       k: issue.kind,
       n: 1,
+      lbl: issue.label,
+      detail: issue.detail,
+      sev: issue.severity,
+      nav: 'monitoring' as const,
+      params: { section: 'fleet-health' },
+    })))
+  } else if (a.health.state === 'status') {
+    rows.push(...a.health.issues.map(issue => ({
+      k: `${issue.kind}-status`,
+      n: '정보',
       lbl: issue.label,
       detail: issue.detail,
       sev: issue.severity,
@@ -136,10 +158,11 @@ export function AttentionIndicatorV2() {
       params: { section: 'fleet-health' },
     })
   }
-  const tone = a.approvals > 0 || a.dead > 0 || (a.health.state === 'attention' && a.health.severity === 'bad')
+  const tone = (a.approvals ?? 0) > 0 || a.dead > 0 || (a.health.state === 'attention' && a.health.severity === 'bad')
+    || (a.approvalQueueState?.state !== 'ready' && a.approvalQueueState?.severity === 'bad')
     ? 'bad'
     : 'warn'
-  const totalLabel = a.health.state === 'unavailable'
+  const totalLabel = a.health.state === 'unavailable' || approvalQueueUnknown
     ? a.total > 0 ? `${a.total}+?` : '?'
     : String(a.total)
   return html`
@@ -191,10 +214,12 @@ export function TopBarV2({ dock }: { dock: CopilotDockApi }) {
     runtimeFleetSafety: shellRuntimeResolution.value?.fleet_safety ?? null,
     runtimeHealthGeneratedAt: shellRuntimeResolution.value?.generated_at ?? null,
   })
-  const running = runtimeCounts.live.keepers
+  const keeperCount = runtimeCounts.live.keepers
+  const countMeaning = keeperLiveCountMeaning(runtimeCounts.source)
+  const countLabel = countMeaning === 'executable' ? '실행 가능' : '실행 중'
   const countTitle = [
     `runtime count: ${runtimeCountSourceLabel(runtimeCounts.source)}`,
-    `running=${runtimeCounts.live.keepers}`,
+    `${countMeaning}=${runtimeCounts.live.keepers}`,
     `paused=${runtimeCounts.live.pausedKeepers}`,
     runtimeCounts.source === 'runtime-health'
       ? 'offline=0 (not derived from execution rows)'
@@ -212,7 +237,7 @@ export function TopBarV2({ dock }: { dock: CopilotDockApi }) {
       </div>
       <div class="v2-top-spacer"></div>
       <span class="v2-statchip live" title=${countTitle}>
-        <${StatusDot} status="run" pulse=${true} />${running} 실행 가능
+        <${StatusDot} status="run" pulse=${true} />${keeperCount} ${countLabel}
       </span>
       <${AttentionIndicatorV2} />
       <button class="v2-statchip" onClick=${() => navigate('schedule')} title="예약 자동화 큐">

--- a/dashboard/src/lib/dashboard-composite-health.test.ts
+++ b/dashboard/src/lib/dashboard-composite-health.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { LIVE_OVERVIEW_COMPOSITE_HEALTH } from '../testing/dashboard-composite-health-fixture'
+import { projectDashboardCompositeHealth } from './dashboard-composite-health'
+
+describe('projectDashboardCompositeHealth', () => {
+  it('preserves the live degraded backend composite as one operator item', () => {
+    expect(projectDashboardCompositeHealth(LIVE_OVERVIEW_COMPOSITE_HEALTH)).toEqual({
+      state: 'attention',
+      severity: 'warn',
+      issueCount: 1,
+      issues: [
+        {
+          kind: 'runtime-health',
+          severity: 'warn',
+          label: 'Runtime health degraded',
+          detail: 'status=degraded · keeper_fleet_safety · keeper_reaction_ledger · keeper_event_queue',
+        },
+      ],
+    })
+  })
+
+  it('does not fabricate healthy when the composite projection is absent', () => {
+    expect(projectDashboardCompositeHealth(null)).toEqual({
+      state: 'unavailable',
+      issueCount: 0,
+      issues: [],
+    })
+  })
+
+  it('returns healthy only when every reported backend verdict is healthy', () => {
+    const fixture = {
+      overall_status: 'ok',
+      operator_action_required: false,
+      operator_action_reasons: [],
+    }
+
+    expect(projectDashboardCompositeHealth(fixture)).toEqual({
+      state: 'healthy',
+      issueCount: 0,
+      issues: [],
+    })
+  })
+})

--- a/dashboard/src/lib/dashboard-composite-health.ts
+++ b/dashboard/src/lib/dashboard-composite-health.ts
@@ -15,6 +15,12 @@ export type DashboardCompositeHealthVerdict =
   | { state: 'unavailable'; issueCount: 0; issues: readonly [] }
   | { state: 'healthy'; issueCount: 0; issues: readonly [] }
   | {
+    state: 'status'
+    severity: 'warn' | 'bad'
+    issueCount: 0
+    issues: readonly [DashboardCompositeHealthIssue]
+  }
+  | {
     state: 'attention'
     severity: 'warn' | 'bad'
     issueCount: 1
@@ -23,8 +29,9 @@ export type DashboardCompositeHealthVerdict =
 
 /**
  * Projects the backend-owned /health composite verdict without reimplementing
- * its subsystem policy. One composite verdict is one operator-attention item;
- * operator_action_reasons remain evidence rather than a client-side recount.
+ * its subsystem policy. A composite verdict contributes one operator-attention
+ * item only when the backend explicitly requests action; non-ok status remains
+ * visible without being recounted as operator work.
  */
 export function projectDashboardCompositeHealth(
   health: DashboardCompositeHealthSource | null | undefined,
@@ -38,19 +45,30 @@ export function projectDashboardCompositeHealth(
     return { state: 'healthy', issueCount: 0, issues: [] }
   }
 
-  const severity = status === 'blocked' || status === 'error' ? 'bad' : 'warn'
+  const severity = status === 'blocked' || status === 'error' || status === 'timeout' ? 'bad' : 'warn'
   const reasons = health?.operator_action_reasons?.filter(reason => reason.trim() !== '') ?? []
+  const issue: DashboardCompositeHealthIssue = {
+    kind: 'runtime-health',
+    severity,
+    label: `Runtime health ${status}`,
+    detail: reasons.length > 0
+      ? `status=${status} · ${reasons.join(' · ')}`
+      : `status=${status} · operator_action_required=${requiresAction}`,
+  }
+
+  if (!requiresAction) {
+    return {
+      state: 'status',
+      severity,
+      issueCount: 0,
+      issues: [issue],
+    }
+  }
+
   return {
     state: 'attention',
     severity,
     issueCount: 1,
-    issues: [{
-      kind: 'runtime-health',
-      severity,
-      label: `Runtime health ${status}`,
-      detail: reasons.length > 0
-        ? `status=${status} · ${reasons.join(' · ')}`
-        : `status=${status} · operator_action_required=${requiresAction}`,
-    }],
+    issues: [issue],
   }
 }

--- a/dashboard/src/lib/dashboard-composite-health.ts
+++ b/dashboard/src/lib/dashboard-composite-health.ts
@@ -1,0 +1,56 @@
+export interface DashboardCompositeHealthSource {
+  overall_status?: string | null
+  operator_action_required?: boolean | null
+  operator_action_reasons?: readonly string[]
+}
+
+export interface DashboardCompositeHealthIssue {
+  kind: 'runtime-health'
+  severity: 'warn' | 'bad'
+  label: string
+  detail: string
+}
+
+export type DashboardCompositeHealthVerdict =
+  | { state: 'unavailable'; issueCount: 0; issues: readonly [] }
+  | { state: 'healthy'; issueCount: 0; issues: readonly [] }
+  | {
+    state: 'attention'
+    severity: 'warn' | 'bad'
+    issueCount: 1
+    issues: readonly [DashboardCompositeHealthIssue]
+  }
+
+/**
+ * Projects the backend-owned /health composite verdict without reimplementing
+ * its subsystem policy. One composite verdict is one operator-attention item;
+ * operator_action_reasons remain evidence rather than a client-side recount.
+ */
+export function projectDashboardCompositeHealth(
+  health: DashboardCompositeHealthSource | null | undefined,
+): DashboardCompositeHealthVerdict {
+  const status = health?.overall_status?.trim() || null
+  const requiresAction = health?.operator_action_required
+  if (!status || typeof requiresAction !== 'boolean') {
+    return { state: 'unavailable', issueCount: 0, issues: [] }
+  }
+  if (status === 'ok' && !requiresAction) {
+    return { state: 'healthy', issueCount: 0, issues: [] }
+  }
+
+  const severity = status === 'blocked' || status === 'error' ? 'bad' : 'warn'
+  const reasons = health?.operator_action_reasons?.filter(reason => reason.trim() !== '') ?? []
+  return {
+    state: 'attention',
+    severity,
+    issueCount: 1,
+    issues: [{
+      kind: 'runtime-health',
+      severity,
+      label: `Runtime health ${status}`,
+      detail: reasons.length > 0
+        ? `status=${status} · ${reasons.join(' · ')}`
+        : `status=${status} · operator_action_required=${requiresAction}`,
+    }],
+  }
+}

--- a/dashboard/src/runtime-counts.ts
+++ b/dashboard/src/runtime-counts.ts
@@ -8,6 +8,8 @@ export type RuntimeCountSource =
   | 'partial'
   | 'unknown'
 
+export type KeeperLiveCountMeaning = 'executable' | 'running'
+
 export type ConfiguredCountSource = 'namespace-truth' | 'shell' | 'none'
 
 export interface LiveRuntimeView {
@@ -379,6 +381,10 @@ export function runtimeCountSourceLabel(source: RuntimeCountSource): string {
     default:
       return '미수집'
   }
+}
+
+export function keeperLiveCountMeaning(source: RuntimeCountSource): KeeperLiveCountMeaning {
+  return source === 'runtime-health' ? 'executable' : 'running'
 }
 
 export function configuredCountSourceLabel(source: ConfiguredCountSource): string {

--- a/dashboard/src/runtime-counts.ts
+++ b/dashboard/src/runtime-counts.ts
@@ -8,7 +8,7 @@ export type RuntimeCountSource =
   | 'partial'
   | 'unknown'
 
-export type KeeperLiveCountMeaning = 'executable' | 'running'
+export type KeeperLiveCountMeaning = 'executable' | 'running' | 'keeper-fiber'
 
 export type ConfiguredCountSource = 'namespace-truth' | 'shell' | 'none'
 
@@ -383,8 +383,11 @@ export function runtimeCountSourceLabel(source: RuntimeCountSource): string {
   }
 }
 
-export function keeperLiveCountMeaning(source: RuntimeCountSource): KeeperLiveCountMeaning {
-  return source === 'runtime-health' ? 'executable' : 'running'
+export function keeperLiveCountMeaning(
+  source: RuntimeCountSource,
+  fallbackMeaning: Exclude<KeeperLiveCountMeaning, 'executable'>,
+): KeeperLiveCountMeaning {
+  return source === 'runtime-health' ? 'executable' : fallbackMeaning
 }
 
 export function configuredCountSourceLabel(source: ConfiguredCountSource): string {

--- a/dashboard/src/runtime-counts.ts
+++ b/dashboard/src/runtime-counts.ts
@@ -8,7 +8,7 @@ export type RuntimeCountSource =
   | 'partial'
   | 'unknown'
 
-export type KeeperLiveCountMeaning = 'executable' | 'running' | 'keeper-fiber'
+export type KeeperLiveCountMeaning = 'executable' | 'running' | 'keeper-fiber' | 'unknown'
 
 export type ConfiguredCountSource = 'namespace-truth' | 'shell' | 'none'
 
@@ -385,7 +385,7 @@ export function runtimeCountSourceLabel(source: RuntimeCountSource): string {
 
 export function keeperLiveCountMeaning(
   source: RuntimeCountSource,
-  fallbackMeaning: Exclude<KeeperLiveCountMeaning, 'executable'>,
+  fallbackMeaning: Exclude<KeeperLiveCountMeaning, 'executable' | 'unknown'>,
 ): KeeperLiveCountMeaning {
   return source === 'runtime-health' ? 'executable' : fallbackMeaning
 }

--- a/dashboard/src/testing/dashboard-composite-health-fixture.ts
+++ b/dashboard/src/testing/dashboard-composite-health-fixture.ts
@@ -1,0 +1,73 @@
+import type { DashboardFleetSafetyHealth } from '../types'
+import type { DashboardFullHealthResponse } from '../api/dashboard'
+
+export const LIVE_OVERVIEW_COMPOSITE_HEALTH: DashboardFullHealthResponse = {
+  health_detail: 'full',
+  overall_status: 'degraded',
+  operator_action_required: true,
+  operator_action_reasons: [
+    'keeper_fleet_safety',
+    'keeper_reaction_ledger',
+    'keeper_event_queue',
+  ],
+  schedule_runner: null,
+  keeper_event_queue: null,
+}
+
+/**
+ * Regression fixture from the 2026-08-13 live Overview contradiction:
+ * the roster showed 8/8 while runtime health reported 7 executable keepers,
+ * a reaction-capacity shortfall, and a degraded reaction ledger.
+ */
+export const LIVE_OVERVIEW_HEALTH_CONTRADICTION: DashboardFleetSafetyHealth = {
+  keeper_fibers: 8,
+  paused_keepers: 0,
+  paused_keepers_health: null,
+  keeper_fleet_safety: {
+    schema: 'masc.keeper_fleet_operator.v1',
+    status: 'degraded',
+    reason: 'reaction_capacity_below_target',
+    blocker: 'reaction_capacity_below_target',
+    blocked_keeper_count: 1,
+    blocked_keepers: [{
+      keeper_name: 'rtprobe',
+      agent_name: 'rtprobe',
+      task_id: null,
+      task_status: null,
+      reason: 'phase_running',
+      action: 'inspect_capacity_accounting',
+      execution_truth: 'retained_disabled',
+      non_executable_cause: 'proactive_disabled',
+      operator_action_type: null,
+      operator_tool_name: null,
+      operator_action_confirm_required: null,
+    }],
+    bootable_keeper_count: 8,
+    running_keeper_fiber_count: 7,
+    failing_keeper_fiber_count: 1,
+    recovering_keeper_fiber_count: 1,
+    executable_keeper_fiber_count: 7,
+    no_executable_keeper_fibers: false,
+    reaction_capacity_below_target: true,
+    reaction_capacity_shortfall_count: 1,
+    paused_keeper_count: 0,
+    autoboot_enabled_keeper_count: 8,
+    paused_autoboot_enabled_keeper_count: 0,
+    target_reaction_capacity_count: 8,
+    operator_action_required: true,
+  },
+  keeper_reaction_ledger: {
+    status: 'degraded',
+    operator_action_required: true,
+    keeper_count: 8,
+    row_count: 42,
+    stimulus_count: 21,
+    reaction_count: 14,
+    turn_started_count: 14,
+    quarantined_row_count: 0,
+    cursor_swept_stimulus_count: 7,
+    pending_stimulus_count: 0,
+    read_error_count: 0,
+    pending_by_keeper: [],
+  },
+}


### PR DESCRIPTION
## Summary
- preserve backend full-health overall_status, operator_action_required, and operator_action_reasons as typed dashboard metadata
- share one visibility-aware full-health projection between the v2 top-bar Attention indicator and Overview
- render missing health as unavailable and backend degraded health as an operator item instead of claiming every keeper is healthy
- lock the observed 8-roster / 7-executable / degraded-health contradiction into a regression fixture

## Verification
- pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/lib/dashboard-composite-health.test.ts src/components/v2/top-bar-v2.test.ts src/components/overview/overview.test.ts src/api/dashboard.test.ts (251 passed)
- pnpm exec tsc --noEmit
- pnpm exec eslint on all changed dashboard TypeScript files
- git diff --check

## Scope
- independent from #28548; base is main at 6959248d23
- excludes SSE, OTel, model/reasoning metadata, and backend scheduler changes
- local Dune build intentionally not run per task constraint