### PR TITLE
feat(keeper): type completion probe evidence

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -16,6 +16,13 @@ default = "ollama_cloud.deepseek-v4-flash"
 # this explicit smart lane.
 cross_verifier = "deepseek.deepseek-v4-pro"
 
+# Local AgentWorld is permitted only as a librarian target. This row is an
+# eligibility restriction, not a runtime registration or availability claim:
+# provider/model declarations, credentials, health, and completion probes stay
+# at their existing independent boundaries.
+[runtime.role_policies]
+"ollama.agentworld-35b-a3b" = "librarian-only"
+
 # Existing workspaces are not overwritten by this seed. Copy the required lane
 # declarations into the live runtime.toml before enabling their consumers.
 # Providers and individual provider.model bindings default to `enabled = true`.

--- a/lib/keeper/keeper_capability_probe.ml
+++ b/lib/keeper/keeper_capability_probe.ml
@@ -112,6 +112,496 @@ let invocation_to_string = function
   | Provider_rejected { detail } -> Printf.sprintf "provider rejected: %s" detail
 ;;
 
+(* ------------------------------------------------------------------ *)
+(* Completion availability contract                                   *)
+(* ------------------------------------------------------------------ *)
+
+type official_client_lane =
+  | Codex_app_server
+  | Claude_code
+[@@deriving show, eq]
+
+type probe_lane =
+  | Agent_core
+  | Official_client of official_client_lane
+  | Antigravity
+[@@deriving show, eq]
+
+type probe_target =
+  { runtime_id : string
+  ; provider_id : string
+  ; binding_model_id : string
+  ; configured_model_id : string option
+  ; lane : probe_lane
+  }
+[@@deriving show, eq]
+
+let probe_lane_of_execution = function
+  | Runtime_execution.Agent_core _ -> Agent_core
+  | Runtime_execution.Codex_app_server _ -> Official_client Codex_app_server
+  | Runtime_execution.Claude_code _ -> Official_client Claude_code
+  | Runtime_execution.Antigravity_cli _ -> Antigravity
+;;
+
+let probe_target_of_runtime (runtime : Runtime.t) =
+  { runtime_id = runtime.id
+  ; provider_id = runtime.provider.id
+  ; binding_model_id = runtime.binding.model_id
+  ; configured_model_id = Runtime_execution.model_id runtime.execution
+  ; lane = probe_lane_of_execution runtime.execution
+  }
+;;
+
+let dispatch_probe_target ~agent_core ~official_client ~antigravity target =
+  match target.lane with
+  | Agent_core -> agent_core target
+  | Official_client _ -> official_client target
+  | Antigravity -> antigravity target
+;;
+
+let probe_lane_to_string = function
+  | Agent_core -> "agent_core"
+  | Official_client Codex_app_server -> "codex_app_server"
+  | Official_client Claude_code -> "claude_code"
+  | Antigravity -> "antigravity"
+;;
+
+let probe_lane_of_string = function
+  | "agent_core" -> Ok Agent_core
+  | "codex_app_server" -> Ok (Official_client Codex_app_server)
+  | "claude_code" -> Ok (Official_client Claude_code)
+  | "antigravity" -> Ok Antigravity
+  | value -> Error (Printf.sprintf "unknown completion probe lane %S" value)
+;;
+
+let non_blank ~field value =
+  if String.equal (String.trim value) ""
+  then Error (field ^ " must not be blank")
+  else Ok value
+;;
+
+let ( >>= ) = Result.bind
+
+let sorted_strings = List.sort String.compare
+
+let exact_object ~context ~fields = function
+  | `Assoc entries ->
+    let actual = entries |> List.map fst |> sorted_strings in
+    let expected = sorted_strings fields in
+    if actual = expected
+    then Ok entries
+    else
+      Error
+        (Printf.sprintf
+           "%s fields must be exactly [%s]; got [%s]"
+           context
+           (String.concat ", " expected)
+           (String.concat ", " actual))
+  | _ -> Error (context ^ " must be a JSON object")
+;;
+
+let required_field ~context name fields =
+  match List.assoc_opt name fields with
+  | Some value -> Ok value
+  | None -> Error (Printf.sprintf "%s.%s is required" context name)
+;;
+
+let json_string ~context name fields =
+  let ( let* ) = Result.bind in
+  let* value = required_field ~context name fields in
+  match value with
+  | `String value -> Ok value
+  | _ -> Error (Printf.sprintf "%s.%s must be a string" context name)
+;;
+
+let json_int ~context name fields =
+  let ( let* ) = Result.bind in
+  let* value = required_field ~context name fields in
+  match value with
+  | `Int value -> Ok value
+  | _ -> Error (Printf.sprintf "%s.%s must be an integer" context name)
+;;
+
+let json_float ~context name fields =
+  let ( let* ) = Result.bind in
+  let* value = required_field ~context name fields in
+  match value with
+  | `Float value -> Ok value
+  | `Int value -> Ok (Float.of_int value)
+  | _ -> Error (Printf.sprintf "%s.%s must be a number" context name)
+;;
+
+let json_string_option ~context name fields =
+  let ( let* ) = Result.bind in
+  let* value = required_field ~context name fields in
+  match value with
+  | `Null -> Ok None
+  | `String value -> Ok (Some value)
+  | _ -> Error (Printf.sprintf "%s.%s must be a string or null" context name)
+;;
+
+module Probe_result = struct
+  type completed_evidence =
+    { response_bytes : int
+    ; tool_invocations : int
+    ; elapsed_s : float
+    }
+  [@@deriving show, eq]
+
+  type not_run_reason =
+    | Registered_only
+    | Skipped_by_request
+    | Live_probe_deferred
+    | Runtime_not_registered
+  [@@deriving show, eq]
+
+  type t =
+    | Completed of completed_evidence
+    | Auth_failed of { detail : string }
+    | Transport_failed of { detail : string }
+    | Unsupported_lane of
+        { lane : probe_lane
+        ; detail : string
+        }
+    | Not_run of
+        { reason : not_run_reason
+        ; detail : string option
+        }
+  [@@deriving show, eq]
+
+  let completed ~response_bytes ~tool_invocations ~elapsed_s =
+    if response_bytes < 0
+    then Error "completed.response_bytes must be non-negative"
+    else if tool_invocations < 0
+    then Error "completed.tool_invocations must be non-negative"
+    else if (not (Float.is_finite elapsed_s)) || elapsed_s < 0.0
+    then Error "completed.elapsed_s must be finite and non-negative"
+    else if response_bytes = 0 && tool_invocations = 0
+    then
+      Error
+        "completed requires observed response bytes or a tool invocation; registration is not evidence"
+    else Ok (Completed { response_bytes; tool_invocations; elapsed_s })
+  ;;
+
+  let completed_of_invocation = function
+    | Tool_invoked { elapsed_s; _ } ->
+      completed ~response_bytes:0 ~tool_invocations:1 ~elapsed_s
+    | Other_tool_invoked { invoked; elapsed_s; _ } ->
+      completed
+        ~response_bytes:0
+        ~tool_invocations:(List.length invoked)
+        ~elapsed_s
+    | Replied_no_tool { reply_bytes; elapsed_s } ->
+      completed ~response_bytes:reply_bytes ~tool_invocations:0 ~elapsed_s
+    | Provider_rejected _ ->
+      Error
+        "Provider_rejected flattened auth and transport; preserve the typed failure before constructing Probe_result"
+  ;;
+
+  let failure constructor ~field ~detail =
+    Result.map constructor (non_blank ~field detail)
+  ;;
+
+  let auth_failed ~detail =
+    failure (fun detail -> Auth_failed { detail }) ~field:"auth_failed.detail" ~detail
+  ;;
+
+  let transport_failed ~detail =
+    failure
+      (fun detail -> Transport_failed { detail })
+      ~field:"transport_failed.detail"
+      ~detail
+  ;;
+
+  let unsupported_lane ~lane ~detail =
+    failure
+      (fun detail -> Unsupported_lane { lane; detail })
+      ~field:"unsupported_lane.detail"
+      ~detail
+  ;;
+
+  let not_run ~reason ?detail () = Not_run { reason; detail }
+
+  let not_run_reason_to_string = function
+    | Registered_only -> "registered_only"
+    | Skipped_by_request -> "skipped_by_request"
+    | Live_probe_deferred -> "live_probe_deferred"
+    | Runtime_not_registered -> "runtime_not_registered"
+  ;;
+
+  let not_run_reason_of_string = function
+    | "registered_only" -> Ok Registered_only
+    | "skipped_by_request" -> Ok Skipped_by_request
+    | "live_probe_deferred" -> Ok Live_probe_deferred
+    | "runtime_not_registered" -> Ok Runtime_not_registered
+    | value -> Error (Printf.sprintf "unknown not-run reason %S" value)
+  ;;
+
+  let to_yojson = function
+    | Completed { response_bytes; tool_invocations; elapsed_s } ->
+      `Assoc
+        [ "status", `String "completed"
+        ; "response_bytes", `Int response_bytes
+        ; "tool_invocations", `Int tool_invocations
+        ; "elapsed_s", `Float elapsed_s
+        ]
+    | Auth_failed { detail } ->
+      `Assoc [ "status", `String "auth_failed"; "detail", `String detail ]
+    | Transport_failed { detail } ->
+      `Assoc [ "status", `String "transport_failed"; "detail", `String detail ]
+    | Unsupported_lane { lane; detail } ->
+      `Assoc
+        [ "status", `String "unsupported_lane"
+        ; "lane", `String (probe_lane_to_string lane)
+        ; "detail", `String detail
+        ]
+    | Not_run { reason; detail } ->
+      `Assoc
+        [ "status", `String "not_run"
+        ; "reason", `String (not_run_reason_to_string reason)
+        ; ( "detail"
+          , match detail with
+            | None -> `Null
+            | Some value -> `String value )
+        ]
+  ;;
+
+  let of_yojson json =
+    let ( let* ) = Result.bind in
+    let* initial =
+      match json with
+      | `Assoc fields -> Ok fields
+      | _ -> Error "probe result must be a JSON object"
+    in
+    let* status = json_string ~context:"probe_result" "status" initial in
+    match status with
+    | "completed" ->
+      let* fields =
+        exact_object
+          ~context:"probe_result.completed"
+          ~fields:[ "status"; "response_bytes"; "tool_invocations"; "elapsed_s" ]
+          json
+      in
+      let* response_bytes =
+        json_int ~context:"probe_result.completed" "response_bytes" fields
+      in
+      let* tool_invocations =
+        json_int ~context:"probe_result.completed" "tool_invocations" fields
+      in
+      let* elapsed_s = json_float ~context:"probe_result.completed" "elapsed_s" fields in
+      completed ~response_bytes ~tool_invocations ~elapsed_s
+    | "auth_failed" | "transport_failed" ->
+      let context = "probe_result." ^ status in
+      let* fields =
+        exact_object ~context ~fields:[ "status"; "detail" ] json
+      in
+      let* detail = json_string ~context "detail" fields in
+      if String.equal status "auth_failed"
+      then auth_failed ~detail
+      else transport_failed ~detail
+    | "unsupported_lane" ->
+      let context = "probe_result.unsupported_lane" in
+      let* fields =
+        exact_object ~context ~fields:[ "status"; "lane"; "detail" ] json
+      in
+      let* lane = json_string ~context "lane" fields >>= probe_lane_of_string in
+      let* detail = json_string ~context "detail" fields in
+      unsupported_lane ~lane ~detail
+    | "not_run" ->
+      let context = "probe_result.not_run" in
+      let* fields =
+        exact_object ~context ~fields:[ "status"; "reason"; "detail" ] json
+      in
+      let* reason =
+        json_string ~context "reason" fields >>= not_run_reason_of_string
+      in
+      let* detail = json_string_option ~context "detail" fields in
+      Ok (not_run ~reason ?detail ())
+    | value ->
+      Error
+        (Printf.sprintf
+           "unknown completion probe status %S; expected completed, auth_failed, transport_failed, unsupported_lane, or not_run"
+           value)
+end
+
+type completion_probe_observation =
+  { target : probe_target
+  ; requested_role : Runtime.runtime_role
+  ; policy_eligibility : Runtime.runtime_role_eligibility
+  ; result : Probe_result.t
+  }
+[@@deriving show, eq]
+
+let completion_probe_observation ~config ~runtime ~requested_role ~result =
+  let target = probe_target_of_runtime runtime in
+  let policy_eligibility =
+    Runtime.runtime_role_eligibility
+      config
+      ~target_ref:target.runtime_id
+      ~role:requested_role
+  in
+  { target; requested_role; policy_eligibility; result }
+;;
+
+let runtime_role_of_string = function
+  | "keeper-turn" -> Ok Runtime.Keeper_turn
+  | "cross-verification" -> Ok Runtime.Cross_verification
+  | "media-failover" -> Ok Runtime.Media_failover
+  | "librarian" -> Ok Runtime.Librarian
+  | "compaction" -> Ok Runtime.Compaction
+  | "hitl-auto-judge" -> Ok Runtime.Hitl_auto_judge
+  | "board-attention" -> Ok Runtime.Board_attention
+  | value when String.starts_with ~prefix:"exact-output:" value ->
+    let prefix_length = String.length "exact-output:" in
+    let lane_id = String.sub value prefix_length (String.length value - prefix_length) in
+    Result.map
+      (fun lane_id -> Runtime.Other_exact_output_lane lane_id)
+      (non_blank ~field:"requested_role exact-output lane" lane_id)
+  | value -> Error (Printf.sprintf "unknown runtime role %S" value)
+;;
+
+let runtime_policy_to_string = function
+  | Runtime_schema.Unrestricted -> "unrestricted"
+  | Runtime_schema.Librarian_only -> "librarian-only"
+;;
+
+let runtime_policy_of_string = function
+  | "unrestricted" -> Ok Runtime_schema.Unrestricted
+  | "librarian-only" -> Ok Runtime_schema.Librarian_only
+  | value -> Error (Printf.sprintf "unknown runtime role policy %S" value)
+;;
+
+let probe_target_to_yojson target =
+  `Assoc
+    [ "runtime_id", `String target.runtime_id
+    ; "provider_id", `String target.provider_id
+    ; "binding_model_id", `String target.binding_model_id
+    ; ( "configured_model_id"
+      , match target.configured_model_id with
+        | None -> `Null
+        | Some value -> `String value )
+    ; "lane", `String (probe_lane_to_string target.lane)
+    ]
+;;
+
+let probe_target_of_yojson json =
+  let ( let* ) = Result.bind in
+  let context = "completion_probe.target" in
+  let* fields =
+    exact_object
+      ~context
+      ~fields:
+        [ "runtime_id"; "provider_id"; "binding_model_id"; "configured_model_id"; "lane" ]
+      json
+  in
+  let* runtime_id = json_string ~context "runtime_id" fields >>= non_blank ~field:"runtime_id" in
+  let* provider_id =
+    json_string ~context "provider_id" fields >>= non_blank ~field:"provider_id"
+  in
+  let* binding_model_id =
+    json_string ~context "binding_model_id" fields
+    >>= non_blank ~field:"binding_model_id"
+  in
+  let* configured_model_id = json_string_option ~context "configured_model_id" fields in
+  let* lane = json_string ~context "lane" fields >>= probe_lane_of_string in
+  Ok { runtime_id; provider_id; binding_model_id; configured_model_id; lane }
+;;
+
+let eligibility_to_yojson = function
+  | Runtime.Eligible -> `Assoc [ "status", `String "eligible" ]
+  | Runtime.Unsupported { target_ref; policy; requested_role } ->
+    `Assoc
+      [ "status", `String "unsupported"
+      ; "target_ref", `String target_ref
+      ; "policy", `String (runtime_policy_to_string policy)
+      ; "requested_role", `String (Runtime.runtime_role_to_string requested_role)
+      ]
+;;
+
+let eligibility_of_yojson json =
+  let ( let* ) = Result.bind in
+  let* initial =
+    match json with
+    | `Assoc fields -> Ok fields
+    | _ -> Error "completion_probe.policy_eligibility must be a JSON object"
+  in
+  let context = "completion_probe.policy_eligibility" in
+  let* status = json_string ~context "status" initial in
+  match status with
+  | "eligible" ->
+    let* _ = exact_object ~context ~fields:[ "status" ] json in
+    Ok Runtime.Eligible
+  | "unsupported" ->
+    let* fields =
+      exact_object
+        ~context
+        ~fields:[ "status"; "target_ref"; "policy"; "requested_role" ]
+        json
+    in
+    let* target_ref = json_string ~context "target_ref" fields in
+    let* policy = json_string ~context "policy" fields >>= runtime_policy_of_string in
+    let* requested_role =
+      json_string ~context "requested_role" fields >>= runtime_role_of_string
+    in
+    (match policy, requested_role with
+     | Runtime_schema.Unrestricted, _ ->
+       Error "unrestricted policy cannot produce unsupported eligibility"
+     | Runtime_schema.Librarian_only, Runtime.Librarian ->
+       Error "librarian-only policy cannot reject the librarian role"
+     | Runtime_schema.Librarian_only, _ ->
+       Ok (Runtime.Unsupported { target_ref; policy; requested_role }))
+  | value -> Error (Printf.sprintf "unknown policy eligibility status %S" value)
+;;
+
+let completion_probe_schema = "masc.keeper.completion-probe.v1"
+
+let completion_probe_observation_to_yojson observation =
+  `Assoc
+    [ "schema", `String completion_probe_schema
+    ; "target", probe_target_to_yojson observation.target
+    ; "requested_role", `String (Runtime.runtime_role_to_string observation.requested_role)
+    ; "policy_eligibility", eligibility_to_yojson observation.policy_eligibility
+    ; "result", Probe_result.to_yojson observation.result
+    ]
+;;
+
+let completion_probe_observation_of_yojson json =
+  let ( let* ) = Result.bind in
+  let context = "completion_probe" in
+  let* fields =
+    exact_object
+      ~context
+      ~fields:[ "schema"; "target"; "requested_role"; "policy_eligibility"; "result" ]
+      json
+  in
+  let* schema = json_string ~context "schema" fields in
+  let* () =
+    if String.equal schema completion_probe_schema
+    then Ok ()
+    else Error (Printf.sprintf "unsupported completion probe schema %S" schema)
+  in
+  let* target_json = required_field ~context "target" fields in
+  let* target = probe_target_of_yojson target_json in
+  let* requested_role =
+    json_string ~context "requested_role" fields >>= runtime_role_of_string
+  in
+  let* eligibility_json = required_field ~context "policy_eligibility" fields in
+  let* policy_eligibility = eligibility_of_yojson eligibility_json in
+  let* () =
+    match policy_eligibility with
+    | Runtime.Eligible -> Ok ()
+    | Runtime.Unsupported { target_ref; requested_role = policy_role; _ } ->
+      if not (String.equal target_ref target.runtime_id)
+      then Error "policy eligibility target_ref must equal target.runtime_id"
+      else if not (Runtime.equal_runtime_role policy_role requested_role)
+      then Error "policy eligibility requested_role must equal observation requested_role"
+      else Ok ()
+  in
+  let* result_json = required_field ~context "result" fields in
+  let* result = Probe_result.of_yojson result_json in
+  Ok { target; requested_role; policy_eligibility; result }
+;;
+
 type invocation_error =
   | Not_on_surface of verdict
   | Unresolvable_runtime of string

--- a/lib/keeper/keeper_capability_probe.mli
+++ b/lib/keeper/keeper_capability_probe.mli
@@ -114,6 +114,129 @@ type invocation =
 
 val invocation_to_string : invocation -> string
 
+(** {1 Completion availability contract}
+
+    Registration, role-policy eligibility, and observed availability are three
+    independent axes. This contract deliberately has no [Passed] constructor:
+    only [Probe_result.Completed] carries positive availability evidence, and
+    it can be created only from a non-empty response/tool observation. *)
+
+type official_client_lane =
+  | Codex_app_server
+  | Claude_code
+[@@deriving show, eq]
+
+type probe_lane =
+  | Agent_core
+  | Official_client of official_client_lane
+  | Antigravity
+[@@deriving show, eq]
+
+type probe_target =
+  { runtime_id : string
+  ; provider_id : string
+  ; binding_model_id : string
+  ; configured_model_id : string option
+      (** The model selected by the materialized execution, if explicitly
+          configured. [None] remains [null]; the binding model is not copied in
+          as a fabricated effective selection. *)
+  ; lane : probe_lane
+  }
+[@@deriving show, eq]
+
+val probe_target_of_runtime : Runtime.t -> probe_target
+
+val dispatch_probe_target :
+  agent_core:(probe_target -> 'a) ->
+  official_client:(probe_target -> 'a) ->
+  antigravity:(probe_target -> 'a) ->
+  probe_target ->
+  'a
+(** Pure lane dispatch used by the future live completion runner. Agent Core
+    covers HTTP runtimes such as GLM, Kimi, Ollama Cloud, and local AgentWorld;
+    Codex/Claude share the official-client callback; Antigravity uses its MCP
+    bridge callback. No callback is invoked for another lane. *)
+
+module Probe_result : sig
+  type completed_evidence = private
+    { response_bytes : int
+    ; tool_invocations : int
+    ; elapsed_s : float
+    }
+
+  type not_run_reason =
+    | Registered_only
+    | Skipped_by_request
+    | Live_probe_deferred
+    | Runtime_not_registered
+  [@@deriving show, eq]
+
+  type t = private
+    | Completed of completed_evidence
+    | Auth_failed of { detail : string }
+    | Transport_failed of { detail : string }
+    | Unsupported_lane of
+        { lane : probe_lane
+        ; detail : string
+        }
+    | Not_run of
+        { reason : not_run_reason
+        ; detail : string option
+        }
+  [@@deriving show, eq]
+
+  val completed :
+    response_bytes:int ->
+    tool_invocations:int ->
+    elapsed_s:float ->
+    (t, string) result
+  (** [Completed] requires non-negative counts, finite non-negative elapsed
+      time, and at least one response byte or tool invocation. A registered or
+      skipped target therefore cannot be promoted to positive evidence. *)
+
+  val completed_of_invocation : invocation -> (t, string) result
+  (** Adapts positive evidence from the existing Agent Core, official-client,
+      and Antigravity invocation paths. [Provider_rejected] is refused because
+      that legacy constructor has already flattened auth and transport into a
+      string; the live adapter must preserve the typed failure before that
+      boundary instead of string-matching it back. *)
+
+  val auth_failed : detail:string -> (t, string) result
+  val transport_failed : detail:string -> (t, string) result
+  val unsupported_lane : lane:probe_lane -> detail:string -> (t, string) result
+
+  val not_run : reason:not_run_reason -> ?detail:string -> unit -> t
+
+  val to_yojson : t -> Yojson.Safe.t
+  val of_yojson : Yojson.Safe.t -> (t, string) result
+  (** Strict tagged codec. Unknown statuses, including legacy [passed] or
+      [skipped], are rejected rather than canonicalized. *)
+end
+
+type completion_probe_observation =
+  { target : probe_target
+  ; requested_role : Runtime.runtime_role
+  ; policy_eligibility : Runtime.runtime_role_eligibility
+  ; result : Probe_result.t
+  }
+[@@deriving show, eq]
+
+val completion_probe_observation :
+  config:Runtime_schema.config ->
+  runtime:Runtime.t ->
+  requested_role:Runtime.runtime_role ->
+  result:Probe_result.t ->
+  completion_probe_observation
+(** Joins attribution with the two independent typed decisions. A runtime may
+    be [Completed] yet policy-[Unsupported] for the requested role, or policy
+    [Eligible] while [Not_run]; neither axis overwrites the other. *)
+
+val completion_probe_observation_to_yojson :
+  completion_probe_observation -> Yojson.Safe.t
+
+val completion_probe_observation_of_yojson :
+  Yojson.Safe.t -> (completion_probe_observation, string) result
+
 (** Why a probe could not be attempted at all. *)
 type invocation_error =
   | Not_on_surface of verdict

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -211,6 +211,159 @@ let find_declared_lane (lanes : Runtime_lane.t list) (id : string) =
   List.find_opt (fun lane -> String.equal (Runtime_lane.id lane) id) lanes
 ;;
 
+type runtime_role =
+  | Keeper_turn
+  | Cross_verification
+  | Media_failover
+  | Librarian
+  | Compaction
+  | Hitl_auto_judge
+  | Board_attention
+  | Other_exact_output_lane of string
+[@@deriving show, eq]
+
+type runtime_role_eligibility =
+  | Eligible
+  | Unsupported of
+      { target_ref : string
+      ; policy : Runtime_schema.runtime_role_policy
+      ; requested_role : runtime_role
+      }
+[@@deriving show, eq]
+
+let runtime_role_to_string = function
+  | Keeper_turn -> "keeper-turn"
+  | Cross_verification -> "cross-verification"
+  | Media_failover -> "media-failover"
+  | Librarian -> "librarian"
+  | Compaction -> "compaction"
+  | Hitl_auto_judge -> "hitl-auto-judge"
+  | Board_attention -> "board-attention"
+  | Other_exact_output_lane lane_id -> "exact-output:" ^ lane_id
+;;
+
+let runtime_role_eligibility (cfg : config) ~target_ref ~role =
+  match
+    List.find_opt
+      (fun (decl : Runtime_schema.runtime_role_policy_decl) ->
+         String.equal decl.target_ref target_ref)
+      cfg.runtime_role_policy_decls
+  with
+  | None -> Eligible
+  | Some { policy = Runtime_schema.Unrestricted; _ } -> Eligible
+  | Some { policy = Runtime_schema.Librarian_only; _ } when equal_runtime_role role Librarian ->
+    Eligible
+  | Some { policy; _ } -> Unsupported { target_ref; policy; requested_role = role }
+;;
+
+let runtime_role_policy_to_string = function
+  | Runtime_schema.Unrestricted -> "unrestricted"
+  | Runtime_schema.Librarian_only -> "librarian-only"
+;;
+
+type runtime_role_reference =
+  { target_ref : string
+  ; role : runtime_role
+  ; site : string
+  }
+
+let exact_output_lane_role = function
+  | "librarian_exact" -> Librarian
+  | "compaction_exact" -> Compaction
+  | "hitl_auto_judge" -> Hitl_auto_judge
+  | "board_attention_exact" -> Board_attention
+  | lane_id -> Other_exact_output_lane lane_id
+;;
+
+let role_references_of_config
+    (cfg : config)
+    ~(default_runtime_id : string)
+    ~(lanes : Runtime_lane.t list)
+  =
+  let expand ~site ~role id =
+    match find_declared_lane lanes id with
+    | None -> [ { target_ref = id; role; site } ]
+    | Some lane ->
+      Runtime_lane.ordered_candidates lane
+      |> List.map (fun target_ref ->
+        { target_ref
+        ; role
+        ; site = Printf.sprintf "%s via [runtime.lanes.%s]" site id
+        })
+  in
+  let default_refs =
+    expand ~site:"[runtime].default" ~role:Keeper_turn default_runtime_id
+  in
+  let assignment_refs =
+    cfg.keeper_assignments
+    |> List.concat_map (fun (keeper_name, id) ->
+      expand
+        ~site:(Printf.sprintf "[runtime.assignments].%s" keeper_name)
+        ~role:Keeper_turn
+        id)
+  in
+  let cross_verifier_refs =
+    cfg.cross_verifier_runtime_id
+    |> Option.to_list
+    |> List.concat_map (expand ~site:"[runtime].cross_verifier" ~role:Cross_verification)
+  in
+  let media_failover_refs =
+    List.map
+      (fun target_ref ->
+         { target_ref; role = Media_failover; site = "[runtime].media_failover" })
+      cfg.media_failover
+  in
+  let exact_output_refs =
+    cfg.exact_output_lane_decls
+    |> List.concat_map
+         (fun ({ Runtime_schema.id; slot_ids } : Runtime_schema.exact_output_lane_decl) ->
+            let role = exact_output_lane_role id in
+            List.map
+              (fun target_ref ->
+                 { target_ref
+                 ; role
+                 ; site = Printf.sprintf "[runtime.exact_output_lanes.%s]" id
+                 })
+              slot_ids)
+  in
+  default_refs
+  @ assignment_refs
+  @ cross_verifier_refs
+  @ media_failover_refs
+  @ exact_output_refs
+;;
+
+(* Fail before any state publication. This judges only role eligibility. Exact
+   output targets intentionally remain opaque here and are admitted/resolved by
+   Runtime_exact_output_registry at its own boundary. *)
+let validate_runtime_role_policies
+    ~(config_path : string)
+    (cfg : config)
+    ~(default_runtime_id : string)
+    ~(lanes : Runtime_lane.t list)
+  =
+  let references = role_references_of_config cfg ~default_runtime_id ~lanes in
+  match
+    List.find_map
+      (fun ({ target_ref; role; site } : runtime_role_reference) ->
+         match runtime_role_eligibility cfg ~target_ref ~role with
+         | Eligible -> None
+         | Unsupported { target_ref; policy; requested_role } ->
+           Some (site, target_ref, policy, requested_role))
+      references
+  with
+  | None -> Ok ()
+  | Some (site, target_ref, policy, requested_role) ->
+    Error
+      (Printf.sprintf
+         "%s: %s target %S is unsupported for role %S by policy %S"
+         config_path
+         site
+         target_ref
+         (runtime_role_to_string requested_role)
+         (runtime_role_policy_to_string policy))
+;;
+
 (* Each [runtime] reference is validated under its field's admission contract:
    - [Runtime_only] requires a declared runtime id for keeper assignments and
      media_failover entries. Assignment execution may still resolve a
@@ -1121,6 +1274,13 @@ let materialize_config
       (route_references
          [ "cross_verifier", cfg.cross_verifier_runtime_id ]
       @ media_failover_references cfg.media_failover)
+  in
+  let* () =
+    validate_runtime_role_policies
+      ~config_path
+      cfg
+      ~default_runtime_id:rt.id
+      ~lanes
   in
   let* () =
     if validate_max_context

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -142,9 +142,44 @@ val load_list :
     [\[runtime.lanes.<id>\]] candidate does not resolve (mirrors default
     validation — no silent fallback for a typo'd id). [keeper_assignments] is the
     keeper→runtime-id list; [media_failover] is the RFC-0265 ordered reroute
-    list; [lanes] is the ordered failover candidate lists. *)
+    list; [lanes] is the ordered failover candidate lists. It also fails when a
+    reachable route or exact-output slot violates [\[runtime.role_policies\]].
+    That check proves policy eligibility only, never target availability. *)
 
 val runtime_ids : t list -> string list
+
+(** {1 Role eligibility}
+
+    This admission axis is intentionally distinct from registration and live
+    availability. [Eligible] means only that the declarative role policy permits
+    the reference. *)
+
+type runtime_role =
+  | Keeper_turn
+  | Cross_verification
+  | Media_failover
+  | Librarian
+  | Compaction
+  | Hitl_auto_judge
+  | Board_attention
+  | Other_exact_output_lane of string
+[@@deriving show, eq]
+
+type runtime_role_eligibility =
+  | Eligible
+  | Unsupported of
+      { target_ref : string
+      ; policy : Runtime_schema.runtime_role_policy
+      ; requested_role : runtime_role
+      }
+[@@deriving show, eq]
+
+val runtime_role_to_string : runtime_role -> string
+
+val runtime_role_eligibility :
+  config -> target_ref:string -> role:runtime_role -> runtime_role_eligibility
+(** Pure policy lookup. It does not materialize the target, consult credentials,
+    probe health, or assert completion capability. *)
 
 type request_body_cap_error = Missing_or_non_positive_request_body_cap of
   { runtime_id : string

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -295,6 +295,21 @@ type exact_output_lane_decl =
   }
 [@@deriving show, eq]
 
+(** Role eligibility policy is separate from runtime/provider admission. A
+    declaration can name an opaque exact-output target that is not a
+    materialized Runtime, and therefore cannot imply registration or
+    availability. *)
+type runtime_role_policy =
+  | Unrestricted
+  | Librarian_only
+[@@deriving show, eq]
+
+type runtime_role_policy_decl =
+  { target_ref : string
+  ; policy : runtime_role_policy
+  }
+[@@deriving show, eq]
+
 (** {1 Top-level config}
 
     Routes/aliases/profiles/system_targets/strategy from the deleted
@@ -332,6 +347,9 @@ type config =
     (** Raw ordered AGENT_CORE target references from
         [\[runtime.exact_output_lanes.<id>\]]. MASC does not interpret them as
         provider/model runtime bindings. *)
+  ; runtime_role_policy_decls : runtime_role_policy_decl list
+    (** Role restrictions from [\[runtime.role_policies\]]. Policy admission is
+        orthogonal to target registration, resolution, and liveness. *)
   }
 [@@deriving show, eq]
 

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -204,6 +204,23 @@ type exact_output_lane_decl =
   }
 [@@deriving show, eq]
 
+(** {1 Runtime role policy}
+
+    A policy constrains which role may reference a target. It is deliberately
+    independent of provider registration, credential resolution, health, and
+    completion probes: policy eligibility is not runtime availability. *)
+
+type runtime_role_policy =
+  | Unrestricted
+  | Librarian_only
+[@@deriving show, eq]
+
+type runtime_role_policy_decl =
+  { target_ref : string
+  ; policy : runtime_role_policy
+  }
+[@@deriving show, eq]
+
 (** {1 Top-level config} *)
 
 type config =
@@ -235,6 +252,10 @@ type config =
   ; exact_output_lane_decls : exact_output_lane_decl list
     (** Raw ordered AGENT_CORE target references from
         [\[runtime.exact_output_lanes.<id>\]]. *)
+  ; runtime_role_policy_decls : runtime_role_policy_decl list
+    (** [\[runtime.role_policies\]] — target reference to role policy. These
+        declarations only constrain eligibility; they do not register or
+        resolve a runtime target and do not establish availability. *)
   }
 [@@deriving show, eq]
 

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -1354,6 +1354,10 @@ let parse_runtime_section (toml : Otoml.t) : (runtime_section, parse_error list)
            | "exact_output_lanes" ->
              (* Parsed separately as raw AGENT_CORE target references. *)
              section, errs
+           | "role_policies" ->
+             (* Parsed separately. Policy eligibility does not participate in
+                provider/runtime registration. *)
+             section, errs
            | _ when is_toml_table value ->
              (* [runtime.<profile>] tables are reserved for runtime profiles and
                 intentionally ignored by this parser layer. *)
@@ -1367,7 +1371,8 @@ let parse_runtime_section (toml : Otoml.t) : (runtime_section, parse_error list)
                       "unknown [runtime] key %S; expected default, \
                        cross_verifier, \
                        media_failover, [runtime.lanes], \
-                       [runtime.exact_output_lanes], [runtime.assignments], or a \
+                       [runtime.exact_output_lanes], [runtime.role_policies], \
+                       [runtime.assignments], or a \
                        table-valued [runtime.<profile>]"
                       key) )
         )
@@ -1522,6 +1527,53 @@ let parse_exact_output_lanes (toml : Otoml.t)
          "[runtime.exact_output_lanes] must be a table of lane tables")
 ;;
 
+let runtime_role_policy_of_string ~path = function
+  | "unrestricted" -> Ok Runtime_schema.Unrestricted
+  | "librarian-only" -> Ok Runtime_schema.Librarian_only
+  | value ->
+    Error
+      (error
+         path
+         (Printf.sprintf
+            "unknown runtime role policy %S; expected unrestricted or librarian-only"
+            value))
+;;
+
+(* [[runtime.role_policies]] constrains an opaque target reference without
+   materializing it. In particular, a successfully parsed policy row is not a
+   statement that the target is registered, credentialed, healthy, or able to
+   complete a request. Those are separate admission/probe boundaries. *)
+let parse_runtime_role_policies (toml : Otoml.t)
+  : (Runtime_schema.runtime_role_policy_decl list, parse_error list) result
+  =
+  match Otoml.find_opt toml Fun.id [ "runtime"; "role_policies" ] with
+  | None -> Ok []
+  | Some (Otoml.TomlTable entries | Otoml.TomlInlineTable entries) ->
+    partition_results
+      (List.map
+         (fun (target_ref, value) ->
+            let path = Printf.sprintf "runtime.role_policies.%s" target_ref in
+            if String.equal (String.trim target_ref) ""
+            then Error (error path "runtime role policy target must not be blank")
+            else
+              match value with
+              | Otoml.TomlString policy ->
+                Result.map
+                  (fun policy -> { Runtime_schema.target_ref; policy })
+                  (runtime_role_policy_of_string ~path policy)
+              | _ ->
+                Error
+                  (error
+                     path
+                     "runtime role policy must be a string policy name"))
+         entries)
+  | Some _ ->
+    Error
+      (error
+         "runtime.role_policies"
+         "[runtime.role_policies] must be a table of target = policy")
+;;
+
 let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) result =
   let obsolete_namespaces_result = reject_obsolete_top_level_namespaces toml in
   let providers_result = parse_providers toml in
@@ -1531,6 +1583,7 @@ let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) resu
   let bindings_result = parse_bindings toml in
   let lanes_result = parse_lanes toml in
   let exact_output_lanes_result = parse_exact_output_lanes toml in
+  let runtime_role_policies_result = parse_runtime_role_policies toml in
   let errs = function Ok _ -> [] | Error errs -> errs in
   let all_errors =
     errs obsolete_namespaces_result
@@ -1541,6 +1594,7 @@ let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) resu
     @ errs bindings_result
     @ errs lanes_result
     @ errs exact_output_lanes_result
+    @ errs runtime_role_policies_result
   in
   if all_errors <> []
   then Error all_errors
@@ -1566,6 +1620,11 @@ let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) resu
         ~label:"exact_output_lanes"
         exact_output_lanes_result
     in
+    let runtime_role_policy_decls =
+      extract_after_all_errors_guard
+        ~label:"runtime_role_policies"
+        runtime_role_policies_result
+    in
     Ok
       { Runtime_schema.providers
       ; models
@@ -1576,6 +1635,7 @@ let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) resu
       ; media_failover = runtime_section.media_failover
       ; lane_decls
       ; exact_output_lane_decls
+      ; runtime_role_policy_decls
       })
 ;;
 

--- a/lib/runtime/runtime_toml.mli
+++ b/lib/runtime/runtime_toml.mli
@@ -1,13 +1,16 @@
 (** Declarative Runtime TOML parser (RFC-0206, runtime→Runtime rebirth).
 
     Re-homed from the deleted [Runtime_declarative_parser]. Parses only
-    RFC-0058 layers 1-3 plus [\[runtime\].default] into a self-standing
+    RFC-0058 layers 1-3 plus [\[runtime\].default] and declarative role
+    eligibility policies into a self-standing
     {!Runtime_schema.config}:
 
     - [\[providers.*\]] — Layer 1
     - [\[models.*\]] — Layer 2
     - [<provider>.<model>] binding tables — Layer 3
     - [\[runtime\].default] — the default Runtime id ([provider.model])
+    - [\[runtime.role_policies\]] — target eligibility policy (never an
+      availability or registration declaration)
 
     The routing layers are intentionally NOT parsed: Layer 4 aliases
     ([<p>.<m>.<a>]), Layer 5 [\[routes\]]/[\[system\]]/[\[profiles\]], and the

--- a/test/test_keeper_capability_probe.ml
+++ b/test/test_keeper_capability_probe.ml
@@ -208,6 +208,288 @@ let write_file path contents =
   close_out oc
 ;;
 
+let completion_result_or_fail = function
+  | Ok result -> result
+  | Error detail -> failf "completion result fixture rejected: %s" detail
+;;
+
+let test_completion_requires_observed_evidence () =
+  (match
+     Probe.Probe_result.completed
+       ~response_bytes:0
+       ~tool_invocations:0
+       ~elapsed_s:0.1
+   with
+   | Ok _ -> fail "registration-only input became Completed"
+   | Error detail ->
+     check bool "rejection names missing evidence" true
+       (String_util.contains_substring detail "registration is not evidence"));
+  List.iter
+    (fun status ->
+       match
+         Probe.Probe_result.of_yojson
+           (`Assoc [ "status", `String status ])
+       with
+       | Ok _ -> failf "legacy %s status was admitted" status
+       | Error detail ->
+         check bool ("unknown status rejects " ^ status) true
+           (String_util.contains_substring detail "unknown completion probe status"))
+    [ "passed"; "skipped" ]
+;;
+
+let test_existing_lane_evidence_adapts_without_failure_string_matching () =
+  List.iter
+    (fun invocation ->
+       match Probe.Probe_result.completed_of_invocation invocation with
+       | Ok (Probe.Probe_result.Completed _) -> ()
+       | Ok _ -> fail "positive invocation became a non-completed result"
+       | Error detail -> failf "positive invocation was rejected: %s" detail)
+    [ Probe.Tool_invoked { tool = "masc_board_list"; elapsed_s = 0.2 }
+    ; Probe.Other_tool_invoked
+        { requested = "masc_board_list"
+        ; invoked = [ "keeper_tasks_list" ]
+        ; elapsed_s = 0.3
+        }
+    ; Probe.Replied_no_tool { reply_bytes = 12; elapsed_s = 0.4 }
+    ];
+  match
+    Probe.Probe_result.completed_of_invocation
+      (Probe.Provider_rejected { detail = "401 or connection reset" })
+  with
+  | Ok _ -> fail "flattened provider rejection was misclassified as completion"
+  | Error detail ->
+    check bool "legacy failure requires typed producer" true
+      (String_util.contains_substring detail "preserve the typed failure")
+;;
+
+let test_completion_result_codec_round_trips_closed_outcomes () =
+  let results =
+    [ completion_result_or_fail
+        (Probe.Probe_result.completed
+           ~response_bytes:12
+           ~tool_invocations:0
+           ~elapsed_s:0.25)
+    ; completion_result_or_fail
+        (Probe.Probe_result.auth_failed ~detail:"credential rejected")
+    ; completion_result_or_fail
+        (Probe.Probe_result.transport_failed ~detail:"connection refused")
+    ; completion_result_or_fail
+        (Probe.Probe_result.unsupported_lane
+           ~lane:Probe.Antigravity
+           ~detail:"completion adapter is not wired")
+    ; Probe.Probe_result.not_run
+        ~reason:Probe.Probe_result.Registered_only
+        ~detail:"catalog row only"
+        ()
+    ]
+  in
+  List.iter
+    (fun result ->
+       let encoded = Probe.Probe_result.to_yojson result in
+       match Probe.Probe_result.of_yojson encoded with
+       | Error detail -> failf "probe-result round trip failed: %s" detail
+       | Ok decoded ->
+         check bool "closed probe result round-trips" true (decoded = result))
+    results
+;;
+
+let completion_fleet_runtime_toml =
+  "[providers.glm]\n\
+   protocol = \"openai-compatible-http\"\n\
+   endpoint = \"http://127.0.0.1:1/v1\"\n\
+   \n\
+   [providers.kimi]\n\
+   protocol = \"openai-compatible-http\"\n\
+   endpoint = \"http://127.0.0.1:2/v1\"\n\
+   \n\
+   [providers.ollama_cloud]\n\
+   protocol = \"openai-compatible-http\"\n\
+   endpoint = \"http://127.0.0.1:3/v1\"\n\
+   \n\
+   [providers.ollama]\n\
+   protocol = \"ollama-http\"\n\
+   endpoint = \"http://127.0.0.1:11434\"\n\
+   \n\
+   [providers.codex]\n\
+   protocol = \"codex-app-server\"\n\
+   command = \"/usr/bin/true\"\n\
+   is-non-interactive = true\n\
+   \n\
+   [providers.claude]\n\
+   protocol = \"claude-code\"\n\
+   command = \"/usr/bin/true\"\n\
+   is-non-interactive = true\n\
+   \n\
+   [providers.antigravity]\n\
+   protocol = \"antigravity-cli\"\n\
+   command = \"/usr/bin/true\"\n\
+   is-non-interactive = true\n\
+   timeout-s = 30.0\n\
+   \n\
+   [providers.antigravity.credentials]\n\
+   type = \"file\"\n\
+   path = \"/tmp/masc-completion-probe-oauth-fixture\"\n\
+   \n\
+   [models.glm-5]\n\
+   api-name = \"glm-5\"\n\
+   max-context = 200000\n\
+   [models.kimi-k2-7]\n\
+   api-name = \"kimi-k2.7\"\n\
+   max-context = 262144\n\
+   [models.deepseek-v4-flash]\n\
+   api-name = \"deepseek-v4-flash\"\n\
+   max-context = 1048576\n\
+   [models.agentworld-35b-a3b]\n\
+   api-name = \"agentworld-35b-a3b\"\n\
+   max-context = 32768\n\
+   [models.codex]\n\
+   api-name = \"gpt-5.6\"\n\
+   max-context = 400000\n\
+   [models.claude]\n\
+   api-name = \"claude-sonnet-4-6\"\n\
+   max-context = 200000\n\
+   [models.gemini]\n\
+   api-name = \"gemini-3.1-pro\"\n\
+   max-context = 1000000\n\
+   \n\
+   [glm.glm-5]\n\
+   [kimi.kimi-k2-7]\n\
+   [ollama_cloud.deepseek-v4-flash]\n\
+   [ollama.agentworld-35b-a3b]\n\
+   [codex.codex]\n\
+   [claude.claude]\n\
+   [antigravity.gemini]\n\
+   \n\
+   [runtime]\n\
+   default = \"glm.glm-5\"\n\
+   \n\
+   [runtime.role_policies]\n\
+   \"ollama.agentworld-35b-a3b\" = \"librarian-only\"\n"
+;;
+
+let with_completion_fleet f =
+  let path = Filename.temp_file "completion-probe-fleet" ".toml" in
+  write_file path completion_fleet_runtime_toml;
+  let snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () ->
+      Runtime.For_testing.restore snapshot;
+      if Sys.file_exists path then Sys.remove path)
+    (fun () ->
+       let config =
+         match Runtime_toml.parse_file path with
+         | Ok config -> config
+         | Error errors ->
+           failf
+             "completion fleet parse failed: %s"
+             (String.concat
+                "; "
+                (List.map Runtime_toml.show_parse_error errors))
+       in
+       (match Runtime.init_default ~config_path:path with
+        | Ok () -> ()
+        | Error detail -> failf "completion fleet materialization failed: %s" detail);
+       f config)
+;;
+
+let completion_fleet_runtime_ids =
+  [ "glm.glm-5", "agent_core"
+  ; "kimi.kimi-k2-7", "agent_core"
+  ; "ollama_cloud.deepseek-v4-flash", "agent_core"
+  ; "ollama.agentworld-35b-a3b", "agent_core"
+  ; "codex.codex", "official_client"
+  ; "claude.claude", "official_client"
+  ; "antigravity.gemini", "antigravity"
+  ]
+;;
+
+let runtime_or_fail runtime_id =
+  match Runtime.get_runtime_by_id runtime_id with
+  | Some runtime -> runtime
+  | None -> failf "completion fleet runtime %s did not materialize" runtime_id
+;;
+
+let test_completion_probe_targets_preserve_attribution_and_lane_dispatch () =
+  with_completion_fleet (fun config ->
+    List.iter
+      (fun (runtime_id, expected_dispatch) ->
+         let runtime = runtime_or_fail runtime_id in
+         let target = Probe.probe_target_of_runtime runtime in
+         check string "runtime attribution" runtime_id target.runtime_id;
+         check string "provider attribution" runtime.provider.id target.provider_id;
+         check string "binding model attribution" runtime.binding.model_id
+           target.binding_model_id;
+         let dispatched =
+           Probe.dispatch_probe_target
+             ~agent_core:(fun _ -> "agent_core")
+             ~official_client:(fun _ -> "official_client")
+             ~antigravity:(fun _ -> "antigravity")
+             target
+         in
+         check string (runtime_id ^ " dispatch") expected_dispatch dispatched;
+         let registered_only =
+           Probe.Probe_result.not_run
+             ~reason:Probe.Probe_result.Registered_only
+             ()
+         in
+         let observation =
+           Probe.completion_probe_observation
+             ~config
+             ~runtime
+             ~requested_role:Runtime.Librarian
+             ~result:registered_only
+         in
+         (match observation.result with
+          | Probe.Probe_result.Not_run
+              { reason = Probe.Probe_result.Registered_only; _ } -> ()
+          | _ -> failf "%s registration became positive evidence" runtime_id))
+      completion_fleet_runtime_ids)
+;;
+
+let test_policy_eligibility_and_completion_evidence_remain_independent () =
+  with_completion_fleet (fun config ->
+    let runtime = runtime_or_fail "ollama.agentworld-35b-a3b" in
+    let completed =
+      completion_result_or_fail
+        (Probe.Probe_result.completed
+           ~response_bytes:24
+           ~tool_invocations:0
+           ~elapsed_s:0.5)
+    in
+    let unsupported_but_completed =
+      Probe.completion_probe_observation
+        ~config
+        ~runtime
+        ~requested_role:Runtime.Keeper_turn
+        ~result:completed
+    in
+    (match unsupported_but_completed.policy_eligibility, unsupported_but_completed.result with
+     | Runtime.Unsupported _, Probe.Probe_result.Completed _ -> ()
+     | _ -> fail "availability evidence overwrote AgentWorld role policy");
+    let eligible_but_not_run =
+      Probe.completion_probe_observation
+        ~config
+        ~runtime
+        ~requested_role:Runtime.Librarian
+        ~result:
+          (Probe.Probe_result.not_run
+             ~reason:Probe.Probe_result.Live_probe_deferred
+             ())
+    in
+    (match eligible_but_not_run.policy_eligibility, eligible_but_not_run.result with
+     | Runtime.Eligible, Probe.Probe_result.Not_run _ -> ()
+     | _ -> fail "policy eligibility fabricated completion availability");
+    List.iter
+      (fun observation ->
+         let json = Probe.completion_probe_observation_to_yojson observation in
+         match Probe.completion_probe_observation_of_yojson json with
+         | Error detail -> failf "observation codec rejected its output: %s" detail
+         | Ok decoded ->
+           check bool "completion observation round-trips" true
+             (decoded = observation))
+      [ unsupported_but_completed; eligible_but_not_run ])
+;;
+
 let probe_antigravity_offline ~runtime_id ~tool =
   Eio_main.run (fun env ->
     Eio.Switch.run (fun sw ->
@@ -562,6 +844,18 @@ let () =
     ; ( "agreement with the surface"
       , [ test_case "round-trips every published name" `Quick test_agrees_with_the_surface_it_reports_on
         ; test_case "no schema-withheld descriptor" `Quick test_no_descriptor_is_withheld_by_a_schema_error
+        ] )
+    ; ( "completion availability contract"
+      , [ test_case "Completed requires observed evidence" `Quick
+            test_completion_requires_observed_evidence
+        ; test_case "existing lanes adapt only positive evidence" `Quick
+            test_existing_lane_evidence_adapts_without_failure_string_matching
+        ; test_case "closed Probe_result codec round-trips" `Quick
+            test_completion_result_codec_round_trips_closed_outcomes
+        ; test_case "fleet attribution and lane dispatch stay typed" `Quick
+            test_completion_probe_targets_preserve_attribution_and_lane_dispatch
+        ; test_case "policy and availability remain independent" `Quick
+            test_policy_eligibility_and_completion_evidence_remain_independent
         ] )
     ; ( "probe_invocation (offline)"
       , [ test_case "operator-only costs no turn" `Quick test_operator_only_costs_no_turn

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -942,6 +942,73 @@ let test_exact_output_lane_rejects_unknown_key () =
          errors)
   | Ok _ -> fail "unknown exact-output lane key must fail config parsing"
 
+let test_runtime_role_policy_is_typed_and_does_not_register_target () =
+  let target_ref = "ollama.agentworld-35b-a3b" in
+  let content =
+    "[runtime.role_policies]\n\
+     \"ollama.agentworld-35b-a3b\" = \"librarian-only\"\n"
+  in
+  match Runtime_toml.parse_string content with
+  | Error errors ->
+    failf
+      "librarian-only role policy must parse: %s"
+      (String.concat "; " (List.map Runtime_toml.show_parse_error errors))
+  | Ok config ->
+    check int "policy parsing does not materialize a runtime binding" 0
+      (List.length config.bindings);
+    (match config.runtime_role_policy_decls with
+     | [ { target_ref = parsed_target; policy = Runtime_schema.Librarian_only } ] ->
+       check string "opaque target reference is preserved" target_ref parsed_target
+     | policies ->
+       failf
+         "expected one librarian-only policy, got %d"
+         (List.length policies));
+    (match
+       Runtime.runtime_role_eligibility config ~target_ref ~role:Runtime.Librarian
+     with
+     | Runtime.Eligible -> ()
+     | Runtime.Unsupported _ -> fail "AgentWorld must be eligible for librarian");
+    List.iter
+      (fun role ->
+         match Runtime.runtime_role_eligibility config ~target_ref ~role with
+         | Runtime.Unsupported { target_ref = rejected; policy; requested_role } ->
+           check string "unsupported result carries target" target_ref rejected;
+           check bool "unsupported result carries closed policy" true
+             (Runtime_schema.equal_runtime_role_policy
+                policy
+                Runtime_schema.Librarian_only);
+           check bool "unsupported result carries requested role" true
+             (Runtime.equal_runtime_role requested_role role)
+         | Runtime.Eligible ->
+           failf
+             "AgentWorld must be unsupported for %s"
+             (Runtime.runtime_role_to_string role))
+      [ Runtime.Keeper_turn
+      ; Runtime.Cross_verification
+      ; Runtime.Media_failover
+      ; Runtime.Compaction
+      ; Runtime.Hitl_auto_judge
+      ; Runtime.Board_attention
+      ; Runtime.Other_exact_output_lane "future-role"
+      ]
+
+let test_runtime_role_policy_rejects_unknown_policy () =
+  match
+    Runtime_toml.parse_string
+      "[runtime.role_policies]\n\
+       \"ollama.agentworld-35b-a3b\" = \"probably-librarian\"\n"
+  with
+  | Ok _ -> fail "an unknown role policy must be rejected"
+  | Error errors ->
+    check bool "policy error names the exact target path" true
+      (List.exists
+         (fun (error : Runtime_toml.parse_error) ->
+            String.equal
+              error.path
+              "runtime.role_policies.ollama.agentworld-35b-a3b"
+            && String_util.contains_substring error.message "unknown runtime role policy")
+         errors)
+
 let test_retired_native_streaming_capability_is_rejected () =
   let config =
     "[models.sample]\n\
@@ -982,6 +1049,14 @@ let test_repo_runtime_toml_loads () =
     (match Runtime_toml.parse_file path with
      | Error _ -> fail "repo runtime.toml exact-output lanes must parse"
      | Ok config ->
+let role_policies = config.runtime_role_policy_decls in
+check int "public seed declares one role policy" 1 (List.length role_policies);
+(match role_policies with
+ | [ { target_ref; policy = Runtime_schema.Librarian_only } ] ->
+   check string "public seed restricts local AgentWorld"
+     "ollama.agentworld-35b-a3b"
+     target_ref
+ | _ -> fail "public seed role policy must be AgentWorld librarian-only");
 let lane_signatures =
   config.exact_output_lane_decls
   |> List.map (fun (lane : Runtime_schema.exact_output_lane_decl) ->
@@ -2183,6 +2258,85 @@ let with_temp_runtime_toml content f =
        )
     (fun () -> f path)
 
+let agentworld_role_policy_fixture ?cross_verifier ?(exact_lane = "librarian_exact") () =
+  let cross_verifier =
+    Option.fold ~none:"" ~some:(Printf.sprintf "cross_verifier = %S\n") cross_verifier
+  in
+  Printf.sprintf
+    "[providers.local]\n\
+     protocol = \"ollama-http\"\n\
+     endpoint = \"http://127.0.0.1:11434\"\n\
+     \n\
+     [providers.ollama]\n\
+     protocol = \"ollama-http\"\n\
+     endpoint = \"http://127.0.0.1:11434\"\n\
+     \n\
+     [models.chat]\n\
+     api-name = \"chat\"\n\
+     max-context = 1024\n\
+     \n\
+     [models.agentworld-35b-a3b]\n\
+     api-name = \"agentworld-35b-a3b\"\n\
+     max-context = 32768\n\
+     \n\
+     [local.chat]\n\
+     \n\
+     [ollama.agentworld-35b-a3b]\n\
+     \n\
+     [runtime]\n\
+     default = \"local.chat\"\n\
+     %s\n\
+     [runtime.role_policies]\n\
+     \"ollama.agentworld-35b-a3b\" = \"librarian-only\"\n\
+     \n\
+     [runtime.lanes.cross_verifier_lane]\n\
+     strategy = \"ordered\"\n\
+     candidates = [\"ollama.agentworld-35b-a3b\"]\n\
+     \n\
+     [runtime.exact_output_lanes.%s]\n\
+     slots = [\"ollama.agentworld-35b-a3b\"]\n"
+    cross_verifier
+    exact_lane
+
+let test_materialized_agentworld_stays_librarian_only_at_config_resolution () =
+  let target_ref = "ollama.agentworld-35b-a3b" in
+  with_temp_runtime_toml (agentworld_role_policy_fixture ()) (fun path ->
+    match Runtime.load_list ~config_path:path with
+    | Error message ->
+      failf "a materialized AgentWorld librarian target must load: %s" message
+    | Ok (runtimes, _, _, _, _, _) ->
+      check bool "AgentWorld binding materializes independently" true
+        (List.exists
+           (fun (runtime : Runtime.t) -> String.equal runtime.id target_ref)
+           runtimes));
+  with_temp_runtime_toml
+    (agentworld_role_policy_fixture ~cross_verifier:"cross_verifier_lane" ())
+    (fun path ->
+       match Runtime.load_list ~config_path:path with
+       | Ok _ ->
+         fail "materialization must not make AgentWorld eligible for cross-verification"
+       | Error message ->
+         check bool "config-resolution rejection names role" true
+           (String_util.contains_substring message "cross-verification");
+         check bool "config-resolution rejection proves lane expansion" true
+           (String_util.contains_substring
+              message
+              "via [runtime.lanes.cross_verifier_lane]");
+         check bool "config-resolution rejection names target" true
+           (String_util.contains_substring message target_ref);
+         check bool "config-resolution rejection names policy" true
+           (String_util.contains_substring message "librarian-only"));
+  with_temp_runtime_toml
+    (agentworld_role_policy_fixture ~exact_lane:"compaction_exact" ())
+    (fun path ->
+       match Runtime.load_list ~config_path:path with
+       | Ok _ -> fail "AgentWorld must not enter the compaction exact-output role"
+       | Error message ->
+         check bool "exact-output rejection names lane" true
+           (String_util.contains_substring message "compaction_exact");
+         check bool "exact-output rejection names role" true
+           (String_util.contains_substring message "compaction"))
+
 let with_fake_runtime_model_catalog f =
   let content =
     "[[models]]\n\
@@ -2671,6 +2825,7 @@ let test_of_binding_reports_an_undeclared_provider () =
     ; media_failover = []
     ; lane_decls = []
     ; exact_output_lane_decls = []
+    ; runtime_role_policy_decls = []
     }
   in
   let binding =
@@ -4088,6 +4243,16 @@ let () =
             test_exact_output_lane_config_is_ordered_and_rejects_duplicates;
           test_case "exact-output lane rejects unknown keys" `Quick
             test_exact_output_lane_rejects_unknown_key;
+          test_case
+            "runtime role policy is typed and does not register its target"
+            `Quick
+            test_runtime_role_policy_is_typed_and_does_not_register_target;
+          test_case "runtime role policy rejects an unknown policy" `Quick
+            test_runtime_role_policy_rejects_unknown_policy;
+          test_case
+            "materialized AgentWorld stays librarian-only at config resolution"
+            `Quick
+            test_materialized_agentworld_stays_librarian_only_at_config_resolution;
           test_case "retired native-streaming capability is rejected" `Quick
             test_retired_native_streaming_capability_is_rejected;
           test_case "repo runtime.toml loads through runtime parser" `Quick

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -959,6 +959,7 @@ let test_runtime_adapter_keeps_auth_out_of_headers () =
     ; media_failover = []
     ; lane_decls = []
     ; exact_output_lane_decls = []
+    ; runtime_role_policy_decls = []
     }
   in
   match Runtime_adapter.binding_to_provider_config cfg runpod_binding with
@@ -992,6 +993,7 @@ let test_runtime_adapter_filters_toml_auth_headers () =
     ; media_failover = []
     ; lane_decls = []
     ; exact_output_lane_decls = []
+    ; runtime_role_policy_decls = []
     }
   in
   match Runtime_adapter.binding_to_provider_config cfg runpod_binding with
@@ -1026,6 +1028,7 @@ let provider_cfg () =
     ; media_failover = []
     ; lane_decls = []
     ; exact_output_lane_decls = []
+    ; runtime_role_policy_decls = []
     }
   in
   match Runtime_adapter.binding_to_provider_config cfg runpod_binding with
@@ -1167,6 +1170,7 @@ let runtime_or_fail ?(provider = runpod_provider) () =
     ; media_failover = []
     ; lane_decls = []
     ; exact_output_lane_decls = []
+    ; runtime_role_policy_decls = []
     }
   in
   match Runtime.of_binding cfg runpod_binding with
@@ -1187,6 +1191,7 @@ let test_runtime_of_binding_preserves_failure_reason () =
     ; media_failover = []
     ; lane_decls = []
     ; exact_output_lane_decls = []
+    ; runtime_role_policy_decls = []
     }
   in
   match Runtime.of_binding cfg { runpod_binding with enabled = false } with


### PR DESCRIPTION
## Stack

- Parent: #28552
- Base branch: `fix/agentworld-librarian-only-policy` at `bab2260be1301012f808ae4992efda247875f32c`

## Summary

- add a closed completion-probe result: `Completed evidence | Auth_failed | Transport_failed | Unsupported_lane | Not_run reason`
- make `Completed` constructible only from non-empty response/tool evidence; reject registration-only and legacy `passed`/`skipped` statuses
- preserve runtime/provider/binding-model/configured-model/lane attribution, keeping an absent configured model as JSON `null`
- route GLM, Kimi, Ollama Cloud, and local AgentWorld through the existing Agent Core lane; Codex/Claude through the existing official-client lane; Antigravity through its MCP-bridge lane
- join completion evidence with #28552 policy eligibility without collapsing either axis: `Completed + Unsupported` and `Not_run + Eligible` are both representable
- strictly encode/decode the versioned observation and reject unknown/extra fields

## Evidence boundary

This PR adds the pure harness/codec only. It does not perform network calls, inspect live credentials, mutate `/Users/dancer/me/.masc`, or restart the fleet.

Existing `Keeper_capability_probe` positive invocation evidence is reusable through `completed_of_invocation`. Its legacy `Provider_rejected string` is intentionally refused: auth and transport were already flattened there, so this code does not recover a typed cause by string matching. A follow-up live adapter must preserve the typed producer error before that boundary.

## Verification

- `ocamlformat --check` on touched OCaml files
- `ocamlc -stop-after parsing` on touched `.ml`/`.mli` files
- `bash scripts/check-ssot.sh`
- `bash scripts/lint/no-provider-name-hardcoding.sh`
- `bash scripts/ci/check-silent-failure-patterns.sh`
- `bash scripts/check-agent-core-boundary.sh`
- `bash scripts/ocaml-structure-ratchet.sh`
- `git diff --check`

Focused Alcotest cases cover positive-evidence construction, rejection of passed/skipped/registration-only, strict codec round-trips, seven representative runtime families, exact lane callback dispatch, model/runtime attribution, and policy-vs-availability independence. Local Dune was intentionally not run under the execution constraint; CI owns typechecking and executable tests.

## Follow-ups

1. Small live adapter PR: preserve typed Agent Core / Codex / Claude / Antigravity auth and transport failures and invoke one bounded completion per target.
2. Private-canary E2E: probe each configured runtime with authenticated evidence and record `Not_run` rather than pass for deferred/skipped cases.
3. Stack sandbox requested/effective evidence, then execution attribution/dashboard projection; unobserved values remain `null`.
4. Only after E2E evidence, apply any live config change separately.