### PR TITLE
fix(agent-core): persist reasoning metadata without hidden CoT

### DIFF
--- a/packages/agent_core/lib/raw_trace.ml
+++ b/packages/agent_core/lib/raw_trace.ml
@@ -593,19 +593,70 @@ let start_run
   active
 ;;
 
+type assistant_block_observation =
+  | Observable_block of
+      { block_kind : string
+      ; json : Yojson.Safe.t
+      }
+  | Withheld_reasoning of
+      { block_kind : string
+      ; char_count : int
+      ; redacted : bool
+      }
+
+let observe_assistant_block block =
+  match block with
+  | Thinking { content; _ } ->
+    Withheld_reasoning
+      { block_kind = "thinking"; char_count = String.length content; redacted = false }
+  | ReasoningDetails { reasoning_content; details } ->
+    let projected = Types.reasoning_details_text ~reasoning_content ~details in
+    Withheld_reasoning
+      { block_kind = "reasoning_details"
+      ; char_count = String.length projected
+      ; redacted = false
+      }
+  | RedactedThinking _ ->
+    Withheld_reasoning
+      { block_kind = "redacted_thinking"; char_count = 0; redacted = true }
+  | Text _ ->
+    Observable_block
+      { block_kind = "text"; json = Llm_provider.Api_common.content_block_to_json block }
+  | ToolUse _ ->
+    Observable_block
+      { block_kind = "tool_use"; json = Llm_provider.Api_common.content_block_to_json block }
+  | ToolResult _ ->
+    Observable_block
+      { block_kind = "tool_result"; json = Llm_provider.Api_common.content_block_to_json block }
+  | Image _ ->
+    Observable_block
+      { block_kind = "image"; json = Llm_provider.Api_common.content_block_to_json block }
+  | Document _ ->
+    Observable_block
+      { block_kind = "document"; json = Llm_provider.Api_common.content_block_to_json block }
+  | Audio _ ->
+    Observable_block
+      { block_kind = "audio"; json = Llm_provider.Api_common.content_block_to_json block }
+;;
+
+let assistant_block_observation_to_pair = function
+  | Observable_block { block_kind; json } -> block_kind, json
+  | Withheld_reasoning { block_kind; char_count; redacted } ->
+    ( block_kind
+    , `Assoc
+        [ "type", `String "reasoning_observation"
+        ; "observation", `String "withheld"
+        ; "reasoning_kind", `String block_kind
+        ; "present", `Bool true
+        ; "char_count", `Int char_count
+        ; "redacted", `Bool redacted
+        ; "content", `Null
+        ] )
+;;
+
 let record_assistant_block active ~block_index block =
-  let json = Llm_provider.Api_common.content_block_to_json block in
-  let block_kind =
-    match block with
-    | Text _ -> "text"
-    | Thinking _ -> "thinking"
-    | ReasoningDetails _ -> "reasoning_details"
-    | RedactedThinking _ -> "redacted_thinking"
-    | ToolUse _ -> "tool_use"
-    | ToolResult _ -> "tool_result"
-    | Image _ -> "image"
-    | Document _ -> "document"
-    | Audio _ -> "audio"
+  let block_kind, json =
+    observe_assistant_block block |> assistant_block_observation_to_pair
   in
   append_record
     active

--- a/packages/agent_core/lib/raw_trace.ml
+++ b/packages/agent_core/lib/raw_trace.ml
@@ -129,7 +129,10 @@ type active_run =
 
 exception Trace_error of Error.t
 
-let trace_version = 2
+(* v3 is a privacy hard cut: assistant reasoning is metadata-only at every
+   nesting depth, including structured ToolResult content. v2 rows are not
+   migrated or rewritten and the exact-version decoder rejects them. *)
+let trace_version = 3
 let json_parse_error = Util.json_parse_error
 
 let safe_name name =
@@ -604,6 +607,60 @@ type assistant_block_observation =
       ; redacted : bool
       }
 
+let assistant_block_observation_to_pair = function
+  | Observable_block { block_kind; json } -> block_kind, json
+  | Withheld_reasoning { block_kind; char_count; redacted } ->
+    ( block_kind
+    , `Assoc
+        [ "type", `String "reasoning_observation"
+        ; "observation", `String "withheld"
+        ; "reasoning_kind", `String block_kind
+        ; "present", `Bool true
+        ; "char_count", `Int char_count
+        ; "redacted", `Bool redacted
+        ; "content", `Null
+        ] )
+;;
+
+let withheld_reasoning_json ~block_kind ~char_count ~redacted =
+  Withheld_reasoning { block_kind; char_count; redacted }
+  |> assistant_block_observation_to_pair
+  |> snd
+;;
+
+let rec raw_trace_content_block_to_json block =
+  match block with
+  | Thinking { content; _ } ->
+    withheld_reasoning_json
+      ~block_kind:"thinking"
+      ~char_count:(String.length content)
+      ~redacted:false
+  | ReasoningDetails { reasoning_content; details } ->
+    let projected = Types.reasoning_details_text ~reasoning_content ~details in
+    withheld_reasoning_json
+      ~block_kind:"reasoning_details"
+      ~char_count:(String.length projected)
+      ~redacted:false
+  | RedactedThinking _ ->
+    withheld_reasoning_json
+      ~block_kind:"redacted_thinking"
+      ~char_count:0
+      ~redacted:true
+  | ToolResult { content_blocks = Some blocks; _ } ->
+    (match Llm_provider.Api_common.content_block_to_json block with
+     | `Assoc fields ->
+       `Assoc
+         (List.map
+            (fun (key, value) ->
+              if String.equal key "content"
+              then key, `List (List.map raw_trace_content_block_to_json blocks)
+              else key, value)
+            fields)
+     | json -> json)
+  | Text _ | ToolUse _ | ToolResult _ | Image _ | Document _ | Audio _ ->
+    Llm_provider.Api_common.content_block_to_json block
+;;
+
 let observe_assistant_block block =
   match block with
   | Thinking { content; _ } ->
@@ -619,39 +676,17 @@ let observe_assistant_block block =
   | RedactedThinking _ ->
     Withheld_reasoning
       { block_kind = "redacted_thinking"; char_count = 0; redacted = true }
-  | Text _ ->
-    Observable_block
-      { block_kind = "text"; json = Llm_provider.Api_common.content_block_to_json block }
+  | Text _ -> Observable_block { block_kind = "text"; json = raw_trace_content_block_to_json block }
   | ToolUse _ ->
-    Observable_block
-      { block_kind = "tool_use"; json = Llm_provider.Api_common.content_block_to_json block }
+    Observable_block { block_kind = "tool_use"; json = raw_trace_content_block_to_json block }
   | ToolResult _ ->
-    Observable_block
-      { block_kind = "tool_result"; json = Llm_provider.Api_common.content_block_to_json block }
+    Observable_block { block_kind = "tool_result"; json = raw_trace_content_block_to_json block }
   | Image _ ->
-    Observable_block
-      { block_kind = "image"; json = Llm_provider.Api_common.content_block_to_json block }
+    Observable_block { block_kind = "image"; json = raw_trace_content_block_to_json block }
   | Document _ ->
-    Observable_block
-      { block_kind = "document"; json = Llm_provider.Api_common.content_block_to_json block }
+    Observable_block { block_kind = "document"; json = raw_trace_content_block_to_json block }
   | Audio _ ->
-    Observable_block
-      { block_kind = "audio"; json = Llm_provider.Api_common.content_block_to_json block }
-;;
-
-let assistant_block_observation_to_pair = function
-  | Observable_block { block_kind; json } -> block_kind, json
-  | Withheld_reasoning { block_kind; char_count; redacted } ->
-    ( block_kind
-    , `Assoc
-        [ "type", `String "reasoning_observation"
-        ; "observation", `String "withheld"
-        ; "reasoning_kind", `String block_kind
-        ; "present", `Bool true
-        ; "char_count", `Int char_count
-        ; "redacted", `Bool redacted
-        ; "content", `Null
-        ] )
+    Observable_block { block_kind = "audio"; json = raw_trace_content_block_to_json block }
 ;;
 
 let record_assistant_block active ~block_index block =

--- a/packages/agent_core/lib/raw_trace.mli
+++ b/packages/agent_core/lib/raw_trace.mli
@@ -121,6 +121,11 @@ val record_of_json : Yojson.Safe.t -> (record, Error.t) result
 val record_to_yojson : record -> Yojson.Safe.t
 val record_of_yojson : Yojson.Safe.t -> (record, string) result
 val trace_version : int
+(** Current writer/reader hard-cut version. Version 3 withholds assistant
+    reasoning recursively, including structured ToolResult content. Historical
+    v2 rows may contain reasoning bytes; they are retained as historical files
+    but rejected by the exact-version decoder and are never migrated or
+    rewritten into the v3 read model. *)
 
 val create
   :  ?redact_secrets:bool

--- a/packages/agent_core/lib/raw_trace.mli
+++ b/packages/agent_core/lib/raw_trace.mli
@@ -162,6 +162,10 @@ val record_assistant_block
   -> block_index:int
   -> Types.content_block
   -> (unit, Error.t) result
+(** Persist observable assistant blocks verbatim. Thinking,
+    ReasoningDetails, and RedactedThinking persist typed metadata with
+    [content = null]; hidden reasoning bytes and signatures never cross the
+    raw-trace writer boundary. *)
 
 val record_tool_execution_started
   :  active_run

--- a/packages/agent_core/lib/raw_trace_query.ml
+++ b/packages/agent_core/lib/raw_trace_query.ml
@@ -109,7 +109,11 @@ let summarize_run run_ref =
     |> List.find_opt (fun (record : Raw_trace.record) ->
       record.record_type = Run_finished)
   in
-  let thinking_block_count = count_block_kind "thinking" in
+  let thinking_block_count =
+    count_block_kind "thinking"
+    + count_block_kind "reasoning_details"
+    + count_block_kind "redacted_thinking"
+  in
   let text_block_count = count_block_kind "text" in
   let tool_use_block_count = count_block_kind "tool_use" in
   let tool_result_block_count = count_block_kind "tool_result" in

--- a/packages/agent_core/lib/trajectory.ml
+++ b/packages/agent_core/lib/trajectory.ml
@@ -171,7 +171,7 @@ let of_raw_trace_records (records : Raw_trace.record list) : trajectory =
            { st with p_agent_name = r.agent_name; p_model; p_started_at = r.ts; p_prompt }
          | Assistant_block ->
            (match r.block_kind with
-            | Some "thinking" ->
+            | Some ("thinking" | "reasoning_details" | "redacted_thinking") ->
               let content =
                 match r.assistant_block with
                 | Some (`Assoc fields)

--- a/packages/agent_core/lib/trajectory.ml
+++ b/packages/agent_core/lib/trajectory.ml
@@ -174,6 +174,9 @@ let of_raw_trace_records (records : Raw_trace.record list) : trajectory =
             | Some "thinking" ->
               let content =
                 match r.assistant_block with
+                | Some (`Assoc fields)
+                  when List.assoc_opt "observation" fields = Some (`String "withheld") ->
+                  ""
                 | Some json ->
                   (try Yojson.Safe.Util.(json |> member "content" |> to_string) with
                    | Yojson.Safe.Util.Type_error _ | Not_found ->

--- a/packages/agent_core/test/test_raw_trace.ml
+++ b/packages/agent_core/test/test_raw_trace.ml
@@ -929,6 +929,76 @@ let test_tool_result_assistant_block_summary () =
   Alcotest.(check int) "tool_result blocks" 1 summary.tool_result_block_count
 ;;
 
+let test_hidden_reasoning_is_metadata_only () =
+  Eio_main.run
+  @@ fun _env ->
+  with_temp_dir
+  @@ fun root ->
+  let sink =
+    unwrap
+      (Raw_trace.create_for_session
+         ~session_root:root
+         ~session_id:"sess-hidden-reasoning"
+         ~agent_name:"raw-worker"
+         ())
+  in
+  let active =
+    unwrap
+      (Raw_trace.start_run sink ~agent_name:"raw-worker" ~prompt:"metadata only" ())
+  in
+  let secret_thinking = "PRIVATE_THINKING_BYTES" in
+  let secret_details = "PRIVATE_REASONING_DETAILS" in
+  unwrap
+    (Raw_trace.record_assistant_block active ~block_index:0
+       (Types.Thinking
+          { content = secret_thinking; signature = Some "PRIVATE_SIGNATURE" }));
+  unwrap
+    (Raw_trace.record_assistant_block active ~block_index:1
+       (Types.ReasoningDetails
+          { reasoning_content = Some secret_details
+          ; details = [ { raw = `String "PRIVATE_RAW_DETAIL"; text = None } ]
+          }));
+  unwrap
+    (Raw_trace.record_assistant_block active ~block_index:2
+       (Types.RedactedThinking "PRIVATE_REDACTED_PAYLOAD"));
+  ignore
+    (unwrap
+       (Raw_trace.finish_run active ~final_text:None ~stop_reason:(Some "EndTurn")
+          ~error:None));
+  let raw = read_file (Raw_trace.file_path sink) in
+  List.iter
+    (fun secret ->
+       Alcotest.(check bool)
+         ("raw trace withholds " ^ secret)
+         false
+         (Util.string_contains ~needle:secret raw))
+    [ secret_thinking
+    ; secret_details
+    ; "PRIVATE_SIGNATURE"
+    ; "PRIVATE_RAW_DETAIL"
+    ; "PRIVATE_REDACTED_PAYLOAD"
+    ];
+  let records = unwrap (Raw_trace.read_all ~path:(Raw_trace.file_path sink) ()) in
+  let observations =
+    records
+    |> List.filter_map (fun (record : Raw_trace.record) ->
+      if record.record_type = Raw_trace.Assistant_block
+      then record.assistant_block
+      else None)
+  in
+  Alcotest.(check int) "three reasoning observations" 3 (List.length observations);
+  List.iter
+    (fun json ->
+       let open Yojson.Safe.Util in
+       Alcotest.(check string)
+         "observation withheld"
+         "withheld"
+         (json |> member "observation" |> to_string);
+       Alcotest.(check bool) "reasoning present" true (json |> member "present" |> to_bool);
+       Alcotest.(check bool) "content is null" true (json |> member "content" = `Null))
+    observations
+;;
+
 let () =
   Random.self_init ();
   Alcotest.run
@@ -973,6 +1043,10 @@ let () =
             "tool_result assistant block summary"
             `Quick
             test_tool_result_assistant_block_summary
+        ; Alcotest.test_case
+            "hidden reasoning is metadata only"
+            `Quick
+            test_hidden_reasoning_is_metadata_only
         ] )
     ]
 ;;

--- a/packages/agent_core/test/test_raw_trace.ml
+++ b/packages/agent_core/test/test_raw_trace.ml
@@ -667,18 +667,23 @@ let raw_record_json
      @ fields)
 ;;
 
-let test_record_of_json_rejects_version_one () =
-  let json = raw_record_json ~trace_version:1 [] in
-  (match Raw_trace.record_of_json json with
-   | Error (Error.Serialization (VersionMismatch { expected; got })) ->
-     Alcotest.(check int) "expected current" Raw_trace.trace_version expected;
-     Alcotest.(check int) "got old" 1 got
-   | Error error -> Alcotest.fail ("unexpected error: " ^ Error.to_string error)
-   | Ok _ -> Alcotest.fail "trace version 1 must be rejected");
-  Alcotest.(check bool)
-    "public yojson decoder also rejects old version"
-    true
-    (Result.is_error (Raw_trace.record_of_yojson json))
+let test_record_of_json_rejects_historical_versions () =
+  List.iter
+    (fun historical_version ->
+      let json = raw_record_json ~trace_version:historical_version [] in
+      (match Raw_trace.record_of_json json with
+       | Error (Error.Serialization (VersionMismatch { expected; got })) ->
+         Alcotest.(check int) "expected current" Raw_trace.trace_version expected;
+         Alcotest.(check int) "got historical" historical_version got
+       | Error error -> Alcotest.fail ("unexpected error: " ^ Error.to_string error)
+       | Ok _ ->
+         Alcotest.fail
+           (Printf.sprintf "trace version %d must be rejected" historical_version));
+      Alcotest.(check bool)
+        "public yojson decoder also rejects historical version"
+        true
+        (Result.is_error (Raw_trace.record_of_yojson json)))
+    [ 1; 2 ]
 ;;
 
 let test_record_of_json_rejects_removed_descriptor_fields () =
@@ -961,6 +966,27 @@ let test_hidden_reasoning_is_metadata_only () =
   unwrap
     (Raw_trace.record_assistant_block active ~block_index:2
        (Types.RedactedThinking "PRIVATE_REDACTED_PAYLOAD"));
+  unwrap
+    (Raw_trace.record_assistant_block active ~block_index:3
+       (Types.ToolResult
+          { tool_use_id = "tool-with-reasoning"
+          ; content = "structured"
+          ; outcome = Tool_succeeded
+          ; json = None
+          ; content_blocks =
+              Some
+                [ Types.Thinking
+                    { content = "NESTED_PRIVATE_THINKING"
+                    ; signature = Some "NESTED_PRIVATE_SIGNATURE"
+                    }
+                ; Types.ReasoningDetails
+                    { reasoning_content = Some "NESTED_PRIVATE_REASONING"
+                    ; details =
+                        [ { raw = `String "NESTED_PRIVATE_RAW"; text = None } ]
+                    }
+                ; Types.RedactedThinking "NESTED_PRIVATE_REDACTED"
+                ]
+          }));
   ignore
     (unwrap
        (Raw_trace.finish_run active ~final_text:None ~stop_reason:(Some "EndTurn")
@@ -977,6 +1003,11 @@ let test_hidden_reasoning_is_metadata_only () =
     ; "PRIVATE_SIGNATURE"
     ; "PRIVATE_RAW_DETAIL"
     ; "PRIVATE_REDACTED_PAYLOAD"
+    ; "NESTED_PRIVATE_THINKING"
+    ; "NESTED_PRIVATE_SIGNATURE"
+    ; "NESTED_PRIVATE_REASONING"
+    ; "NESTED_PRIVATE_RAW"
+    ; "NESTED_PRIVATE_REDACTED"
     ];
   let records = unwrap (Raw_trace.read_all ~path:(Raw_trace.file_path sink) ()) in
   let observations =
@@ -986,7 +1017,18 @@ let test_hidden_reasoning_is_metadata_only () =
       then record.assistant_block
       else None)
   in
-  Alcotest.(check int) "three reasoning observations" 3 (List.length observations);
+  Alcotest.(check int) "four assistant observations" 4 (List.length observations);
+  let reasoning_observations, tool_results =
+    List.partition
+      (fun json ->
+        Yojson.Safe.Util.(json |> member "observation" |> to_string_option)
+        = Some "withheld")
+      observations
+  in
+  Alcotest.(check int)
+    "three top-level reasoning observations"
+    3
+    (List.length reasoning_observations);
   List.iter
     (fun json ->
        let open Yojson.Safe.Util in
@@ -996,7 +1038,30 @@ let test_hidden_reasoning_is_metadata_only () =
          (json |> member "observation" |> to_string);
        Alcotest.(check bool) "reasoning present" true (json |> member "present" |> to_bool);
        Alcotest.(check bool) "content is null" true (json |> member "content" = `Null))
-    observations
+    reasoning_observations;
+  let nested =
+    match tool_results with
+    | [ json ] -> Yojson.Safe.Util.(json |> member "content" |> to_list)
+    | _ -> Alcotest.fail "expected one structured ToolResult observation"
+  in
+  Alcotest.(check int) "three nested reasoning observations" 3 (List.length nested);
+  List.iter
+    (fun json ->
+      let open Yojson.Safe.Util in
+      Alcotest.(check string)
+        "nested observation withheld"
+        "withheld"
+        (json |> member "observation" |> to_string);
+      Alcotest.(check bool) "nested content is null" true
+        (json |> member "content" = `Null))
+    nested;
+  let runs = unwrap (Raw_trace_query.read_runs ~path:(Raw_trace.file_path sink) ()) in
+  let summary = unwrap (Raw_trace_query.summarize_run (List.hd runs)) in
+  Alcotest.(check int)
+    "all reasoning kinds count as thinking activity"
+    3
+    summary.thinking_block_count;
+  Alcotest.(check bool) "reasoning activity is visible" true summary.saw_thinking
 ;;
 
 let () =
@@ -1021,9 +1086,9 @@ let () =
             `Quick
             test_record_of_json_rejects_invalid_tool_choice
         ; Alcotest.test_case
-            "version one rejected"
+            "historical versions rejected"
             `Quick
-            test_record_of_json_rejects_version_one
+            test_record_of_json_rejects_historical_versions
         ; Alcotest.test_case
             "removed descriptor fields rejected"
             `Quick

--- a/packages/agent_core/test/test_trajectory.ml
+++ b/packages/agent_core/test/test_trajectory.ml
@@ -112,6 +112,32 @@ let test_basic_trajectory () =
   ()
 ;;
 
+let test_all_withheld_reasoning_kinds_are_activity () =
+  let withheld kind seq =
+    make_record
+      ~seq
+      ~ts:(100.0 +. Float.of_int seq)
+      ~agent_name:"test-agent"
+      ~record_type:Assistant_block
+      ~block_kind:kind
+      ~assistant_block:
+        (`Assoc
+          [ "observation", `String "withheld"
+          ; "content", `Null
+          ])
+      ()
+  in
+  let trajectory =
+    Trajectory.of_raw_trace_records
+      [ withheld "thinking" 1
+      ; withheld "reasoning_details" 2
+      ; withheld "redacted_thinking" 3
+      ]
+  in
+  let think, _act, _observe, _respond = Trajectory.count_steps trajectory in
+  Alcotest.(check int) "all reasoning variants remain visible as activity" 3 think
+;;
+
 let test_tool_call_pairing () =
   let records =
     [ make_record
@@ -493,6 +519,10 @@ let () =
     "trajectory"
     [ ( "trajectory"
       , [ Alcotest.test_case "basic trajectory from records" `Quick test_basic_trajectory
+        ; Alcotest.test_case
+            "all withheld reasoning kinds remain activity"
+            `Quick
+            test_all_withheld_reasoning_kinds_are_activity
         ; Alcotest.test_case "tool call pairing" `Quick test_tool_call_pairing
         ; Alcotest.test_case "error run" `Quick test_error_run
         ; Alcotest.test_case "orphan tool finish" `Quick test_orphan_tool_finish


### PR DESCRIPTION
## Outcome

Agent Core raw trace no longer persists Thinking, ReasoningDetails, RedactedThinking payloads or signatures. The writer emits a closed internal observation and serializes only metadata: kind, presence, character count, redaction, and `content: null`.

## Scope

- pattern-match every current content-block variant before serialization
- keep text/tool/media blocks on their existing observable path
- withhold all reasoning bytes and replay signatures at the writer boundary
- make the trajectory projection treat withheld reasoning as an empty-content Think step rather than stringify metadata
- add a direct regression test with five distinct secret sentinels

Historical-file purge/retention, Keeper trajectory JSONL, and dashboard metadata projection are separate small follow-ups. This PR does not claim those stores are cleaned.

## Fast verification

- ocamlformat 0.29.0 check passed
- `ocamlc -stop-after parsing` passed for all four touched files
- dead-export ratchet passed at 548
- CI target audit passed at the existing 563 unwired baseline
- `git diff --check` passed
- local Dune was not run per campaign instruction

## Three-way evidence plan

1. Contract: exhaustive content-block pattern match and typed observation.
2. Hermetic: raw JSONL sentinel non-presence plus decoded metadata assertions.
3. Live follow-up: post-deploy unique response receipt and raw artifact scan, without collecting CoT.