### PR TITLE
fix(keeper): type sandbox routing evidence

### DIFF
--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -76,6 +76,212 @@ let backend_of_meta (meta : keeper_meta) =
   | Docker -> "docker"
   | Local -> "local"
 
+module Sandbox_routing = struct
+  type boundary =
+    | Host_local
+    | Docker_contained
+    | Docker_inherited_network
+  [@@deriving show, eq]
+
+  type invalid_boundary =
+    | Host_network_none_unenforceable
+  [@@deriving show, eq]
+
+  type requested = Requested of boundary
+
+  type effective =
+    | Resolved of boundary
+    | Resolution_failed of { detail : string }
+
+  type receipt =
+    | Observed of boundary
+    | Unobserved of { detail : string }
+
+  type evidence =
+    { requested : requested
+    ; effective : effective
+    ; receipt : receipt
+    }
+
+  type violation =
+    | Effective_resolution_unavailable of { detail : string }
+    | Config_effective_mismatch of
+        { requested : boundary
+        ; effective : boundary
+        }
+    | Receipt_evidence_unavailable of { detail : string }
+    | Effective_receipt_mismatch of
+        { effective : boundary
+        ; receipt : boundary
+        }
+  [@@deriving show, eq]
+
+  type verified = Verified of boundary
+
+  let boundary_to_string = function
+    | Host_local -> "host_local"
+    | Docker_contained -> "docker_contained"
+    | Docker_inherited_network -> "docker_inherited_network"
+  ;;
+
+  let invalid_boundary_to_string = function
+    | Host_network_none_unenforceable ->
+      "local host execution cannot enforce network_mode=none"
+  ;;
+
+  let violation_to_string = function
+    | Effective_resolution_unavailable { detail } ->
+      "effective sandbox resolution unavailable: " ^ detail
+    | Config_effective_mismatch { requested; effective } ->
+      Printf.sprintf
+        "config requested %s but runtime resolved %s"
+        (boundary_to_string requested)
+        (boundary_to_string effective)
+    | Receipt_evidence_unavailable { detail } ->
+      "sandbox receipt evidence unavailable: " ^ detail
+    | Effective_receipt_mismatch { effective; receipt } ->
+      Printf.sprintf
+        "runtime resolved %s but receipt observed %s"
+        (boundary_to_string effective)
+        (boundary_to_string receipt)
+  ;;
+
+  (* [Local, Network_none] is not another supported boundary. Host execution
+     inherits the server network namespace, so accepting that product would
+     turn an unenforced request into a containment claim. *)
+  let boundary_of_profile_network ~sandbox_profile ~network_mode =
+    match sandbox_profile, network_mode with
+    | Local, Network_inherit -> Ok Host_local
+    | Local, Network_none -> Error Host_network_none_unenforceable
+    | Docker, Network_none -> Ok Docker_contained
+    | Docker, Network_inherit -> Ok Docker_inherited_network
+  ;;
+
+  let requested_of_config ~sandbox_profile ~network_mode =
+    Result.map
+      (fun boundary -> Requested boundary)
+      (boundary_of_profile_network ~sandbox_profile ~network_mode)
+  ;;
+
+  let effective_resolved ~sandbox_profile ~network_mode =
+    Result.map
+      (fun boundary -> Resolved boundary)
+      (boundary_of_profile_network ~sandbox_profile ~network_mode)
+  ;;
+
+  let non_blank ~field detail =
+    if String.equal (String.trim detail) ""
+    then Error (field ^ " must not be blank")
+    else Ok detail
+  ;;
+
+  let effective_resolution_failed ~detail =
+    Result.map
+      (fun detail -> Resolution_failed { detail })
+      (non_blank ~field:"sandbox effective-resolution failure detail" detail)
+  ;;
+
+  let receipt_observed ~sandbox_profile ~network_mode =
+    Result.map
+      (fun boundary -> Observed boundary)
+      (boundary_of_profile_network ~sandbox_profile ~network_mode)
+  ;;
+
+  let receipt_unobserved ~detail =
+    Result.map
+      (fun detail -> Unobserved { detail })
+      (non_blank ~field:"sandbox receipt unobserved detail" detail)
+  ;;
+
+  let evidence ~requested ~effective ~receipt = { requested; effective; receipt }
+
+  let verify { requested = Requested requested; effective; receipt } =
+    match effective with
+    | Resolution_failed { detail } ->
+      Error (Effective_resolution_unavailable { detail })
+    | Resolved effective when not (equal_boundary requested effective) ->
+      Error (Config_effective_mismatch { requested; effective })
+    | Resolved effective ->
+      (match receipt with
+       | Unobserved { detail } -> Error (Receipt_evidence_unavailable { detail })
+       | Observed receipt when not (equal_boundary effective receipt) ->
+         Error (Effective_receipt_mismatch { effective; receipt })
+       | Observed _ -> Ok (Verified effective))
+  ;;
+
+  let boundary_json boundary = `String (boundary_to_string boundary)
+
+  let effective_to_yojson = function
+    | Resolved boundary ->
+      `Assoc
+        [ "status", `String "resolved"
+        ; "boundary", boundary_json boundary
+        ]
+    | Resolution_failed { detail } ->
+      `Assoc
+        [ "status", `String "resolution_failed"
+        ; "boundary", `Null
+        ; "detail", `String detail
+        ]
+  ;;
+
+  let receipt_to_yojson = function
+    | Observed boundary ->
+      `Assoc
+        [ "status", `String "observed"
+        ; "boundary", boundary_json boundary
+        ]
+    | Unobserved { detail } ->
+      `Assoc
+        [ "status", `String "unobserved"
+        ; "boundary", `Null
+        ; "detail", `String detail
+        ]
+  ;;
+
+  let violation_kind = function
+    | Effective_resolution_unavailable _ -> "effective_resolution_unavailable"
+    | Config_effective_mismatch _ -> "config_effective_mismatch"
+    | Receipt_evidence_unavailable _ -> "receipt_evidence_unavailable"
+    | Effective_receipt_mismatch _ -> "effective_receipt_mismatch"
+  ;;
+
+  let descriptor_to_yojson
+      ({ requested = Requested requested; effective; receipt } as evidence)
+    =
+    let verification =
+      match verify evidence with
+      | Ok (Verified boundary) ->
+        `Assoc
+          [ "status", `String "verified"
+          ; "containment", boundary_json boundary
+          ; "violation", `Null
+          ; "detail", `Null
+          ]
+      | Error violation ->
+        let status =
+          match violation with
+          | Config_effective_mismatch _ | Effective_receipt_mismatch _ -> "mismatch"
+          | Effective_resolution_unavailable _ | Receipt_evidence_unavailable _ ->
+            "unobserved"
+        in
+        `Assoc
+          [ "status", `String status
+          ; "containment", `String "not_verified"
+          ; "violation", `String (violation_kind violation)
+          ; "detail", `String (violation_to_string violation)
+          ]
+    in
+    `Assoc
+      [ "schema", `String "masc.keeper.sandbox-routing.v1"
+      ; "config_requested", boundary_json requested
+      ; "resolved_effective", effective_to_yojson effective
+      ; "receipt_evidence", receipt_to_yojson receipt
+      ; "verification", verification
+      ]
+  ;;
+end
+
 let task_is_linked_to_keeper_goals ?(task_goal_index = Hashtbl.create 0) goal_ids (task : Masc_domain.task) =
   let task_goal_ids =
     (* DET-OK: an absent bucket means no recorded links; this is the same []
@@ -252,7 +458,12 @@ let nonempty_list = function
   | None -> []
 
 let backend_detail_keys =
-  [ "sandbox_profile"; "network_mode"; "backend"; "sandbox_target" ]
+  [ "sandbox_profile"
+  ; "network_mode"
+  ; "backend"
+  ; "sandbox_target"
+  ; "sandbox_routing"
+  ]
 
 let is_backend_detail_key key = List.mem key backend_detail_keys
 
@@ -292,7 +503,7 @@ let path_resolution_contract_json =
 
 let runtime_observability_contract_json_from_fields ~keeper_name ?agent_name ?trace_id
     ?session_id ?generation ?keeper_turn_id ?task_id ?goal_ids
-    ?sandbox_profile ?sandbox_root ?allowed_paths ?network_mode
+    ?sandbox_profile ?sandbox_root ?allowed_paths ?network_mode ?sandbox_routing
     ?runtime_profile () : Yojson.Safe.t =
   `Assoc
     [
@@ -309,12 +520,16 @@ let runtime_observability_contract_json_from_fields ~keeper_name ?agent_name ?tr
       ("allowed_paths", Json_util.json_string_list (nonempty_list allowed_paths));
       ("path_resolution", path_resolution_contract_json);
       ("network_mode", string_opt_json network_mode);
+      ( "sandbox_routing"
+      , match sandbox_routing with
+        | None -> `Null
+        | Some evidence -> Sandbox_routing.descriptor_to_yojson evidence );
       ("runtime_profile", string_opt_json runtime_profile);
     ]
 
 let runtime_contract_json_from_fields ~keeper_name ?agent_name ?trace_id
     ?session_id ?generation ?keeper_turn_id ?task_id ?goal_ids
-    ?sandbox_profile ?sandbox_root ?allowed_paths ?network_mode
+    ?sandbox_profile ?sandbox_root ?allowed_paths ?network_mode ?sandbox_routing
     ?runtime_profile () : Yojson.Safe.t =
   runtime_observability_contract_json_from_fields
     ~keeper_name
@@ -329,6 +544,7 @@ let runtime_contract_json_from_fields ~keeper_name ?agent_name ?trace_id
     ?sandbox_root
     ?allowed_paths
     ?network_mode
+    ?sandbox_routing
     ?runtime_profile
     ()
   |> redact_backend_details

--- a/lib/keeper/keeper_runtime_contract.mli
+++ b/lib/keeper/keeper_runtime_contract.mli
@@ -10,6 +10,94 @@ val validate_active_goal_ids :
     Returns only goal IDs that actually exist. Logs pruned IDs at warn level. *)
 
 val backend_of_meta : Keeper_meta_contract.keeper_meta -> string
+
+(** {1 Sandbox routing evidence}
+
+    Persisted config intent, runtime resolution, and receipt observation are
+    separate evidence stages. They used to be projected as the same
+    [(sandbox_profile, network_mode)] pair, which allowed a Docker request and
+    a local/inherit receipt to look self-consistent. This module makes the
+    boundary a closed sum and validates the three stages without starting or
+    inspecting Docker. *)
+module Sandbox_routing : sig
+  type boundary =
+    | Host_local
+    | Docker_contained
+    | Docker_inherited_network
+  [@@deriving show, eq]
+
+  type invalid_boundary =
+    | Host_network_none_unenforceable
+  [@@deriving show, eq]
+
+  type requested = private Requested of boundary
+
+  type effective = private
+    | Resolved of boundary
+    | Resolution_failed of { detail : string }
+
+  type receipt = private
+    | Observed of boundary
+    | Unobserved of { detail : string }
+
+  type evidence = private
+    { requested : requested
+    ; effective : effective
+    ; receipt : receipt
+    }
+
+  type violation =
+    | Effective_resolution_unavailable of { detail : string }
+    | Config_effective_mismatch of
+        { requested : boundary
+        ; effective : boundary
+        }
+    | Receipt_evidence_unavailable of { detail : string }
+    | Effective_receipt_mismatch of
+        { effective : boundary
+        ; receipt : boundary
+        }
+  [@@deriving show, eq]
+
+  type verified = private Verified of boundary
+
+  val boundary_to_string : boundary -> string
+  val invalid_boundary_to_string : invalid_boundary -> string
+  val violation_to_string : violation -> string
+
+  val requested_of_config :
+    sandbox_profile:Keeper_types_profile_sandbox.sandbox_profile ->
+    network_mode:Keeper_types_profile_sandbox.network_mode ->
+    (requested, invalid_boundary) result
+
+  val effective_resolved :
+    sandbox_profile:Keeper_types_profile_sandbox.sandbox_profile ->
+    network_mode:Keeper_types_profile_sandbox.network_mode ->
+    (effective, invalid_boundary) result
+
+  val effective_resolution_failed : detail:string -> (effective, string) result
+
+  val receipt_observed :
+    sandbox_profile:Keeper_types_profile_sandbox.sandbox_profile ->
+    network_mode:Keeper_types_profile_sandbox.network_mode ->
+    (receipt, invalid_boundary) result
+
+  val receipt_unobserved : detail:string -> (receipt, string) result
+
+  val evidence :
+    requested:requested -> effective:effective -> receipt:receipt -> evidence
+
+  val verify : evidence -> (verified, violation) result
+  (** Fail closed unless effective resolution exists and all three boundaries
+      are identical. No [bool] success flag exists for a caller to combine with
+      registration or receipt presence permissively. *)
+
+  val descriptor_to_yojson : evidence -> Yojson.Safe.t
+  (** Operator-facing containment descriptor. Failed verification emits
+      [containment = "not_verified"] plus a typed violation; it never reports
+      the requested Docker boundary as effective containment. *)
+end
+
 val task_is_linked_to_keeper_goals :
   ?task_goal_index:(string, string list) Hashtbl.t -> string list -> Masc_domain.task -> bool
 
@@ -74,6 +162,7 @@ val runtime_contract_json_from_fields :
   ?sandbox_root:string ->
   ?allowed_paths:string list ->
   ?network_mode:string ->
+  ?sandbox_routing:Sandbox_routing.evidence ->
   ?runtime_profile:string ->
   unit ->
   Yojson.Safe.t
@@ -93,6 +182,7 @@ val runtime_observability_contract_json_from_fields :
   ?sandbox_root:string ->
   ?allowed_paths:string list ->
   ?network_mode:string ->
+  ?sandbox_routing:Sandbox_routing.evidence ->
   ?runtime_profile:string ->
   unit ->
   Yojson.Safe.t

--- a/test/test_keeper_runtime_contract.ml
+++ b/test/test_keeper_runtime_contract.ml
@@ -217,6 +217,157 @@ let test_scoped_verification_keeps_isolation () =
         included)
 ;;
 
+module Sandbox = Keeper_types_profile_sandbox
+module Routing = Keeper_runtime_contract.Sandbox_routing
+
+let routing_stage label = function
+  | Ok value -> value
+  | Error invalid ->
+    failf "%s: %s" label (Routing.invalid_boundary_to_string invalid)
+;;
+
+let requested ~sandbox_profile ~network_mode =
+  Routing.requested_of_config ~sandbox_profile ~network_mode
+  |> routing_stage "config request"
+;;
+
+let effective ~sandbox_profile ~network_mode =
+  Routing.effective_resolved ~sandbox_profile ~network_mode
+  |> routing_stage "effective resolution"
+;;
+
+let receipt ~sandbox_profile ~network_mode =
+  Routing.receipt_observed ~sandbox_profile ~network_mode
+  |> routing_stage "receipt observation"
+;;
+
+let json_string path json =
+  let open Yojson.Safe.Util in
+  List.fold_left (fun cursor field -> member field cursor) json path |> to_string
+;;
+
+let test_sandbox_routing_verifies_matching_docker_evidence () =
+  let requested =
+    requested ~sandbox_profile:Sandbox.Docker ~network_mode:Sandbox.Network_none
+  in
+  let effective =
+    effective ~sandbox_profile:Sandbox.Docker ~network_mode:Sandbox.Network_none
+  in
+  let receipt =
+    receipt ~sandbox_profile:Sandbox.Docker ~network_mode:Sandbox.Network_none
+  in
+  let evidence = Routing.evidence ~requested ~effective ~receipt in
+  (match Routing.verify evidence with
+   | Ok _ -> ()
+   | Error violation ->
+     failf "expected verified Docker containment: %s"
+       (Routing.violation_to_string violation));
+  let descriptor = Routing.descriptor_to_yojson evidence in
+  check string "verified status" "verified"
+    (json_string [ "verification"; "status" ] descriptor);
+  check string "verified containment" "docker_contained"
+    (json_string [ "verification"; "containment" ] descriptor)
+;;
+
+let test_sandbox_routing_exposes_requested_effective_receipt_mismatch () =
+  (* Live-shaped negative fixture: config requests Docker/none while both the
+     resolved runtime and its receipt report local/inherit. The legacy flat
+     fields look internally consistent; the staged descriptor must not turn
+     them into a containment claim. *)
+  let requested =
+    requested ~sandbox_profile:Sandbox.Docker ~network_mode:Sandbox.Network_none
+  in
+  let effective =
+    effective ~sandbox_profile:Sandbox.Local ~network_mode:Sandbox.Network_inherit
+  in
+  let receipt =
+    receipt ~sandbox_profile:Sandbox.Local ~network_mode:Sandbox.Network_inherit
+  in
+  let evidence = Routing.evidence ~requested ~effective ~receipt in
+  (match Routing.verify evidence with
+   | Error (Routing.Config_effective_mismatch { requested; effective }) ->
+     check string "requested boundary" "docker_contained"
+       (Routing.boundary_to_string requested);
+     check string "effective boundary" "host_local"
+       (Routing.boundary_to_string effective)
+   | Error violation ->
+     failf "expected config/effective mismatch, got %s"
+       (Routing.violation_to_string violation)
+   | Ok _ -> fail "mismatched routing evidence must fail closed");
+  let descriptor = Routing.descriptor_to_yojson evidence in
+  check string "descriptor config request" "docker_contained"
+    (json_string [ "config_requested" ] descriptor);
+  check string "descriptor effective" "host_local"
+    (json_string [ "resolved_effective"; "boundary" ] descriptor);
+  check string "descriptor receipt" "host_local"
+    (json_string [ "receipt_evidence"; "boundary" ] descriptor);
+  check string "descriptor mismatch status" "mismatch"
+    (json_string [ "verification"; "status" ] descriptor);
+  check string "descriptor never claims containment" "not_verified"
+    (json_string [ "verification"; "containment" ] descriptor);
+  check string "typed violation" "config_effective_mismatch"
+    (json_string [ "verification"; "violation" ] descriptor);
+  let operator_contract =
+    Keeper_runtime_contract.runtime_observability_contract_json_from_fields
+      ~keeper_name:"code-reviewer"
+      ~sandbox_profile:"local"
+      ~network_mode:"inherit"
+      ~sandbox_routing:evidence
+      ()
+  in
+  check string "operator contract retains request" "docker_contained"
+    (json_string [ "sandbox_routing"; "config_requested" ] operator_contract);
+  let keeper_contract =
+    Keeper_runtime_contract.runtime_contract_json_from_fields
+      ~keeper_name:"code-reviewer"
+      ~sandbox_profile:"local"
+      ~network_mode:"inherit"
+      ~sandbox_routing:evidence
+      ()
+  in
+  check bool "keeper projection redacts backend routing evidence" true
+    (Yojson.Safe.Util.member "sandbox_routing" keeper_contract = `Null)
+;;
+
+let test_sandbox_routing_requires_receipt_evidence () =
+  let requested =
+    requested ~sandbox_profile:Sandbox.Docker ~network_mode:Sandbox.Network_none
+  in
+  let effective =
+    effective ~sandbox_profile:Sandbox.Docker ~network_mode:Sandbox.Network_none
+  in
+  let receipt =
+    match
+      Routing.receipt_unobserved
+        ~detail:"execution receipt did not record the runtime route"
+    with
+    | Ok receipt -> receipt
+    | Error error -> fail error
+  in
+  let evidence = Routing.evidence ~requested ~effective ~receipt in
+  (match Routing.verify evidence with
+   | Error (Routing.Receipt_evidence_unavailable _) -> ()
+   | Error violation ->
+     failf "expected unavailable receipt, got %s"
+       (Routing.violation_to_string violation)
+   | Ok _ -> fail "missing receipt evidence must fail closed");
+  let descriptor = Routing.descriptor_to_yojson evidence in
+  check string "unobserved status" "unobserved"
+    (json_string [ "verification"; "status" ] descriptor);
+  check string "unobserved never claims containment" "not_verified"
+    (json_string [ "verification"; "containment" ] descriptor)
+;;
+
+let test_sandbox_routing_rejects_unenforceable_host_network_none () =
+  match
+    Routing.requested_of_config
+      ~sandbox_profile:Sandbox.Local
+      ~network_mode:Sandbox.Network_none
+  with
+  | Error Routing.Host_network_none_unenforceable -> ()
+  | Ok _ -> fail "local/network-none cannot be represented as enforced"
+;;
+
 let () =
   run
     "keeper_runtime_contract"
@@ -231,6 +382,16 @@ let () =
             test_preloaded_tasks_fall_back_to_all_tasks
         ; test_case "keeps isolation for scoped verification" `Quick
             test_scoped_verification_keeps_isolation
+        ] )
+    ; ( "sandbox_routing"
+      , [ test_case "verifies matching Docker evidence" `Quick
+            test_sandbox_routing_verifies_matching_docker_evidence
+        ; test_case "exposes requested/effective/receipt mismatch" `Quick
+            test_sandbox_routing_exposes_requested_effective_receipt_mismatch
+        ; test_case "requires receipt evidence" `Quick
+            test_sandbox_routing_requires_receipt_evidence
+        ; test_case "rejects unenforceable host network-none" `Quick
+            test_sandbox_routing_rejects_unenforceable_host_network_none
         ] )
     ]
 ;;


### PR DESCRIPTION
## What\n\n- Add a closed Sandbox_routing boundary sum for host-local, Docker-contained, and Docker-with-inherited-network routes.\n- Keep config request, resolved/effective route, and receipt observation as separate typed stages.\n- Fail closed with typed violations when resolution/receipt evidence is missing or any stage disagrees.\n- Add an operator descriptor whose negative result is mismatch or unobserved with containment=not_verified.\n- Allow runtime observability contracts to carry the typed descriptor while keeping backend details out of the keeper-visible projection.\n\nThis PR is independent of #28552 and #28560 and is based directly on main.\n\n## Proof\n\n- Positive fixture: Docker/none request, effective route, and receipt all verify as docker_contained.\n- Live-shaped negative fixture: Docker/none request plus Local/inherit effective and receipt reports config_effective_mismatch and never claims containment.\n- Missing receipt evidence reports receipt_evidence_unavailable and not_verified.\n- Local/network-none is rejected because the host route cannot enforce network isolation.\n\nLocal checks:\n- ocamlc -stop-after parsing on the changed interface, implementation, and test\n- ocamlformat --check on all changed files\n- scripts/check-ssot.sh\n- scripts/lint/no-provider-name-hardcoding.sh\n- scripts/ci/check-silent-failure-patterns.sh\n- scripts/ocaml-structure-ratchet.sh\n- scripts/check-agent-core-boundary.sh\n- git diff --check\n\nPer task constraint, no local Dune build/test was run. The focused Alcotest cases are included for CI.\n\n## Scope and follow-up stack\n\nThis slice is pure contract/codec/fixture only. It does not start Docker, change live config, make network calls, or alter the execution effect shell.\n\nThree verification/implementation approaches:\n\n1. This PR: pure contract plus positive and negative containment fixtures.\n2. Follow-up small PR: wire TOML config request, sandbox factory resolution, and execution receipt observation at their actual effect boundaries; refuse or surface typed mismatches.\n3. Follow-up small PR: dashboard rendering plus private-canary live E2E that correlates requested/effective/receipt evidence and records a browser screenshot.\n\nUntil approach 2 lands, sandbox_routing is null unless a caller supplies typed evidence. Existing flat sandbox_profile/network_mode fields are not upgraded into proof.