### PR TITLE
fix(keeper): persist trajectory reasoning as metadata only

### DIFF
--- a/lib/keeper/keeper_agent_run_thinking_trajectory.ml
+++ b/lib/keeper/keeper_agent_run_thinking_trajectory.ml
@@ -27,16 +27,16 @@ let persist_response_content ~keeper_name ~trajectory_acc ~turn content =
   | Some acc ->
     let now = Time_compat.now () in
     let now_iso = Masc_domain.now_iso () in
-    List.iter
-      (function
+    List.iteri
+      (fun block_index -> function
         | Agent_core.Types.Thinking { content; _ } ->
           let entry : Trajectory.thinking_entry =
             { ts = now
             ; ts_iso = now_iso
             ; turn
-            ; content
-            ; content_length = String.length content
-            ; redacted = false
+            ; identity = Trajectory.Trajectory_block { block_index }
+            ; observation =
+                Trajectory.Withheld_thinking { char_count = String.length content }
             }
           in
           append_entry ~keeper_name ~failure_label:"thinking" acc entry
@@ -49,9 +49,10 @@ let persist_response_content ~keeper_name ~trajectory_acc ~turn content =
               { ts = now
               ; ts_iso = now_iso
               ; turn
-              ; content
-              ; content_length = String.length content
-              ; redacted = false
+              ; identity = Trajectory.Trajectory_block { block_index }
+              ; observation =
+                  Trajectory.Withheld_reasoning_details
+                    { char_count = String.length content }
               }
             in
             append_entry ~keeper_name ~failure_label:"reasoning details" acc entry
@@ -60,9 +61,8 @@ let persist_response_content ~keeper_name ~trajectory_acc ~turn content =
             { ts = now
             ; ts_iso = now_iso
             ; turn
-            ; content = "[redacted]"
-            ; content_length = 0
-            ; redacted = true
+            ; identity = Trajectory.Trajectory_block { block_index }
+            ; observation = Trajectory.Withheld_redacted_thinking
             }
           in
           append_entry ~keeper_name ~failure_label:"redacted thinking" acc entry

--- a/lib/keeper/keeper_agent_run_thinking_trajectory.mli
+++ b/lib/keeper/keeper_agent_run_thinking_trajectory.mli
@@ -4,7 +4,6 @@ val persist_response_content
   -> turn:int
   -> Agent_core.Types.content_block list
   -> unit
-(** Append every [Thinking]/[RedactedThinking] block in [content] to the
-    keeper's trajectory JSONL, stamped with [turn]. Call once per turn from the
-    [after_turn] hook so no turn's reasoning is dropped. Text is persisted
-    untruncated (see {!Trajectory.append_thinking}). *)
+(** Append metadata for every reasoning block in [content] to the keeper's
+    trajectory JSONL, stamped with [turn]. Hidden content and replay signatures
+    never cross this writer boundary. *)

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -2407,11 +2407,6 @@ let handle_keeper_get_subroutes state req request reqd =
              ~default:2000
            |> max 0 |> min 10000
          in
-         let content_max_len =
-           Server_utils.int_query_param req "content_max_len"
-             ~default:Trajectory.default_thinking_truncation
-           |> max 0 |> min 50000
-         in
          let include_thinking =
            Server_utils.bool_query_param req "include_thinking"
              ~default:false
@@ -2422,13 +2417,12 @@ let handle_keeper_get_subroutes state req request reqd =
          in
          let cache_key =
            Printf.sprintf
-             "keeper:trajectory:%s:%s:%s:%d:%d:%d:%b:%d"
+             "keeper:trajectory:%s:%s:%s:%d:%d:%b:%d"
              (Workspace.masc_root_dir config)
              name
              trace_id
              limit
              result_max_len
-             content_max_len
              include_thinking
              tail_scan_lines
          in
@@ -2467,7 +2461,7 @@ let handle_keeper_get_subroutes state req request reqd =
                  ("total_entries", `Int total);
                  ("showing", `Int (List.length recent));
                  ("entries", `List (List.map
-                   (Trajectory.trajectory_line_to_json ~result_max_len ~content_max_len) recent));
+                   (Trajectory.trajectory_line_to_json ~result_max_len) recent));
                ]))
          in
          Http.Response.json_value ~compress:true ~request:req json reqd)

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -1310,7 +1310,6 @@ let keeper_chat_trace_blocks config name =
     Some
       (Server_dashboard_http_keeper_api_trace.chat_trace_block_by_turn_ref
          ~max_lines:trajectory_max_limit
-         ~max_internal_lines:trajectory_max_limit
          ~config
          ~keeper_name:name
          ~allowed_trace_ids:(keeper_chat_allowed_trace_ids m))
@@ -2436,7 +2435,7 @@ let handle_keeper_get_subroutes state req request reqd =
                in
                let all_lines =
                  if include_thinking then
-                   merge_keeper_trace_lines ~config ~trace_id trajectory_lines
+                   order_keeper_trace_lines trajectory_lines
                  else
                    trajectory_lines
                in

--- a/lib/server/server_dashboard_http_keeper_api.mli
+++ b/lib/server/server_dashboard_http_keeper_api.mli
@@ -9,11 +9,7 @@
 module Http = Http_server_eio
 (** Alias used internally for the Eio HTTP server module. *)
 
-(** {1 Trajectory merge}
-
-    The dashboard merges the on-disk turn trajectory with internal-history
-    lines (per-turn snapshots from the keeper subprocess) so the operator
-    sees both LLM messages and structural events in one feed. *)
+(** {1 Trajectory ordering} *)
 
 val trajectory_line_ts : Trajectory.trajectory_line -> float
 (** Extract the timestamp used as the merge key. *)
@@ -23,18 +19,11 @@ val dedupe_thinking_lines :
   Trajectory.trajectory_line list
 (** Collapse consecutive identical "thinking" lines to one entry. *)
 
-val read_internal_history_lines :
-  config:Workspace.config ->
-  trace_id:string -> Trajectory.trajectory_line list
-(** Read the internal-history file for [trace_id] under [config]. *)
-
-val merge_keeper_trace_lines :
-  config:Workspace.config ->
-  trace_id:string ->
-  Trajectory.trajectory_line list ->
-  Trajectory.trajectory_line list
-(** Merge [trajectory_lines] with the internal-history file in
-    timestamp order, applying [dedupe_thinking_lines]. *)
+val order_keeper_trace_lines :
+  Trajectory.trajectory_line list -> Trajectory.trajectory_line list
+(** Order trajectory events and remove replayed thinking identities. Internal
+    assistant messages are conversation output and are never reclassified as
+    hidden thinking. *)
 
 val handle_keeper_catchup_judge_post :
   Mcp_server.server_state ->

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -14,8 +14,7 @@ let json_list_length = function
 let trajectory_line_ts = Trace.line_ts
 let dedupe_thinking_lines = Trace.dedupe_thinking_lines
 
-let read_internal_history_lines = Trace.read_internal_history_lines
-let merge_keeper_trace_lines = Trace.merge_keeper_trace_lines
+let order_keeper_trace_lines = Trace.order_keeper_trace_lines
 
 let respond_error ?(status = `Bad_request) ?request ?ok reqd message =
   Http.Response.json_value ?request ~status (error_json ?ok message) reqd

--- a/lib/server/server_dashboard_http_keeper_api_post.mli
+++ b/lib/server/server_dashboard_http_keeper_api_post.mli
@@ -8,13 +8,8 @@ val json_list_length : Yojson.Safe.t -> int
 val trajectory_line_ts : Trajectory.trajectory_line -> float
 val dedupe_thinking_lines :
   Trajectory.trajectory_line list -> Trajectory.trajectory_line list
-val read_internal_history_lines :
-  config:Workspace.config -> trace_id:string -> Trajectory.trajectory_line list
-val merge_keeper_trace_lines :
-  config:Workspace.config ->
-  trace_id:string ->
-  Trajectory.trajectory_line list ->
-  Trajectory.trajectory_line list
+val order_keeper_trace_lines :
+  Trajectory.trajectory_line list -> Trajectory.trajectory_line list
 
 val respond_error :
   ?status:Httpun.Status.t ->

--- a/lib/server/server_dashboard_http_keeper_api_trace.ml
+++ b/lib/server/server_dashboard_http_keeper_api_trace.ml
@@ -6,16 +6,9 @@ let line_ts = function
 ;;
 
 module Thinking_key = struct
-  type t = float * bool * string
+  type t = int * Trajectory.thinking_identity
 
-  let compare (ts1, r1, c1) (ts2, r2, c2) =
-    let c_ts = Float.compare ts1 ts2 in
-    if c_ts <> 0
-    then c_ts
-    else
-      let c_r = Bool.compare r1 r2 in
-      if c_r <> 0 then c_r else String.compare c1 c2
-  ;;
+  let compare = Stdlib.compare
 end
 
 module Thinking_set = Set.Make (Thinking_key)
@@ -29,7 +22,7 @@ let dedupe_thinking_lines (lines : Trajectory.trajectory_line list)
          match line with
          | Trajectory.Tool_call _ -> seen, line :: acc
          | Trajectory.Thinking entry ->
-           let key = entry.ts, entry.redacted, entry.content in
+           let key = entry.turn, entry.identity in
            if Thinking_set.mem key seen
            then seen, acc
            else Thinking_set.add key seen, line :: acc)
@@ -155,8 +148,8 @@ let trajectory_line_to_chat_trace_step = function
   | Trajectory.Thinking entry ->
     Some
       (Keeper_chat_blocks.Trace_think
-         { text = entry.content
-         ; content_withheld = false
+         { text = ""
+         ; content_withheld = true
          ; ts = Some entry.ts_iso
          ; agent_core_block_index = None
          })

--- a/lib/server/server_dashboard_http_keeper_api_trace.ml
+++ b/lib/server/server_dashboard_http_keeper_api_trace.ml
@@ -32,86 +32,15 @@ let dedupe_thinking_lines (lines : Trajectory.trajectory_line list)
   List.rev rev_deduped
 ;;
 
-let log_internal_history_skips ~trace_id ~skipped ~total =
-  if skipped > 0 then
-    Log.Dashboard.warn
-      "internal history trace %s: %d of %d rows did not decode to a thinking \
-       line (older content-block format or non-assistant rows)"
-      trace_id skipped total
-;;
-
-let internal_history_lines_of_jsons ~trace_id jsons =
-  let lines_rev, skipped, total =
-    List.fold_left
-      (fun (acc, skipped, total) json ->
-        match
-          Server_dashboard_http_keeper_api_types
-          .internal_history_json_to_trajectory_line
-            json
-        with
-        | Some line -> line :: acc, skipped, total + 1
-        | None -> acc, skipped + 1, total + 1)
-      ([], 0, 0)
-      jsons
-  in
-  log_internal_history_skips ~trace_id ~skipped ~total;
-  List.rev lines_rev
-;;
-
-let read_internal_history_tail_lines ~max_lines ~(config : Workspace.config)
-    ~(trace_id : string)
+let order_keeper_trace_lines (trajectory_lines : Trajectory.trajectory_line list)
   : Trajectory.trajectory_line list
   =
-  let path = Keeper_types_support.keeper_internal_history_path config trace_id in
-  let jsons, _malformed =
-    Dated_jsonl.load_tail_lines path ~max_lines
-    |> Fs_compat.parse_jsonl_lines ~source:path
-  in
-  internal_history_lines_of_jsons ~trace_id jsons
-;;
-
-let read_internal_history_lines ~(config : Workspace.config) ~(trace_id : string)
-  : Trajectory.trajectory_line list
-  =
-  let path = Keeper_types_support.keeper_internal_history_path config trace_id in
-  (* Streaming filter: avoid materialising the full JSONL list when only a
-     subset of lines decode to [trajectory_line].
-
-     Rows that do not decode to a thinking line (older content-block format,
-     non-assistant sources, or empty-text rows) are expected here. They are
-     summarised once per read rather than warned per row: the dashboard re-reads
-     each trace file on every poll, so a single undecodable file emitted one
-     WARN per skipped row per read — a busy trace produced ~16k warnings/day,
-     dominating the WARN log and drowning genuine warnings. The per-file summary
-     keeps the signal (skipped/total counts) without the per-row volume. *)
-  let lines_rev, skipped, total =
-    Fs_compat.fold_jsonl_lines
-      ~init:([], 0, 0)
-      ~f:(fun (acc, skipped, total) ~line_no:_ json ->
-         match
-           Server_dashboard_http_keeper_api_types
-           .internal_history_json_to_trajectory_line
-             json
-         with
-       | Some line -> (line :: acc, skipped, total + 1)
-       | None -> (acc, skipped + 1, total + 1))
-      path
-  in
-  log_internal_history_skips ~trace_id ~skipped ~total;
-  List.rev lines_rev
-;;
-
-let merge_lines ~internal_lines (trajectory_lines : Trajectory.trajectory_line list)
-  : Trajectory.trajectory_line list
-  =
-  (* [stable_sort], not [sort]: the comparator returns 0 for two lines of the
+  (* Internal assistant messages are conversation output, not hidden thinking.
+     Only the trajectory writer may create thinking observations. [stable_sort],
+     not [sort]: the comparator returns 0 for two lines of the
      same kind at the same timestamp, and [List.sort] does not guarantee those
-     keep their original order (only [stable_sort] does, per the OCaml 5.4
-     manual). Stability preserves the deterministic merge order
-     ([trajectory_lines] then [internal_lines]) so repeated same-timestamp
-     thinking/tool lines render in a fixed sequence rather than an arbitrary
-     one. *)
-  dedupe_thinking_lines (trajectory_lines @ internal_lines)
+     keep their original order. *)
+  dedupe_thinking_lines trajectory_lines
   |> List.stable_sort (fun left right ->
     let cmp = Float.compare (line_ts left) (line_ts right) in
     if cmp <> 0
@@ -121,27 +50,6 @@ let merge_lines ~internal_lines (trajectory_lines : Trajectory.trajectory_line l
       | Trajectory.Thinking _, Trajectory.Tool_call _ -> -1
       | Trajectory.Tool_call _, Trajectory.Thinking _ -> 1
       | _ -> 0)
-;;
-
-let merge_keeper_trace_lines ~(config : Workspace.config) ~(trace_id : string)
-      (trajectory_lines : Trajectory.trajectory_line list)
-  : Trajectory.trajectory_line list
-  =
-  let internal_lines = read_internal_history_lines ~config ~trace_id in
-  merge_lines ~internal_lines trajectory_lines
-;;
-
-let merge_keeper_trace_lines_bounded ~max_internal_lines
-    ~(config : Workspace.config)
-    ~(trace_id : string)
-    (trajectory_lines : Trajectory.trajectory_line list)
-  : Trajectory.trajectory_line list
-  =
-  let internal_lines =
-    read_internal_history_tail_lines ~max_lines:max_internal_lines ~config
-      ~trace_id
-  in
-  merge_lines ~internal_lines trajectory_lines
 ;;
 
 let trajectory_line_to_chat_trace_step = function
@@ -201,7 +109,7 @@ let allowed_trace_id_set trace_ids =
    and the turn's steps stay available in full from the raw-trace surface. *)
 let chat_trace_steps_per_turn = 200
 
-let chat_trace_block_by_turn_ref ~max_lines ~max_internal_lines
+let chat_trace_block_by_turn_ref ~max_lines
     ~(config : Workspace.config)
     ~(keeper_name : string)
     ~(allowed_trace_ids : string list)
@@ -221,10 +129,7 @@ let chat_trace_block_by_turn_ref ~max_lines ~max_internal_lines
           Trajectory.read_recent_lines ~masc_root ~keeper_name ~trace_id
             ~max_lines
         in
-        let all_lines =
-          merge_keeper_trace_lines_bounded ~config ~trace_id ~max_internal_lines
-            trajectory_lines
-        in
+        let all_lines = order_keeper_trace_lines trajectory_lines in
         Hashtbl.replace cache trace_id all_lines;
         Some all_lines)
   in

--- a/lib/server/server_dashboard_http_keeper_api_trace.mli
+++ b/lib/server/server_dashboard_http_keeper_api_trace.mli
@@ -6,33 +6,12 @@ val dedupe_thinking_lines
   :  Trajectory.trajectory_line list
   -> Trajectory.trajectory_line list
 
-val read_internal_history_lines
-  :  config:Workspace.config
-  -> trace_id:string
-  -> Trajectory.trajectory_line list
-
-val read_internal_history_tail_lines
-  :  max_lines:int
-  -> config:Workspace.config
-  -> trace_id:string
-  -> Trajectory.trajectory_line list
-
-val merge_keeper_trace_lines
-  :  config:Workspace.config
-  -> trace_id:string
-  -> Trajectory.trajectory_line list
-  -> Trajectory.trajectory_line list
-
-val merge_keeper_trace_lines_bounded
-  :  max_internal_lines:int
-  -> config:Workspace.config
-  -> trace_id:string
-  -> Trajectory.trajectory_line list
+val order_keeper_trace_lines
+  :  Trajectory.trajectory_line list
   -> Trajectory.trajectory_line list
 
 val chat_trace_block_by_turn_ref
   :  max_lines:int
-  -> max_internal_lines:int
   -> config:Workspace.config
   -> keeper_name:string
   -> allowed_trace_ids:string list

--- a/lib/server/server_dashboard_http_keeper_api_types.ml
+++ b/lib/server/server_dashboard_http_keeper_api_types.ml
@@ -362,53 +362,6 @@ let claim_scope_summary_absent =
     ; ("keeper_turn_id", `Null)
     ]
 
-let internal_history_json_to_trajectory_line (json : Yojson.Safe.t)
-    : Trajectory.trajectory_line option =
-  let source = Safe_ops.json_string ~default:"" "source" json in
-  let message_id = Safe_ops.json_string ~default:"" "id" json in
-  (* History rows persist message text as typed [content_blocks], not a flat
-     [content] string (Keeper_context_core_message_json: "Structured
-     content_blocks is the only supported message-content shape"). Reading a
-     flat [content] field decoded to "" for every persisted internal_assistant
-     row, so the whole keeper reasoning history was skipped and invisible in the
-     dashboard trace. Use the SSOT extractor (shared with history routing /
-     memory recall) so content_blocks rows decode to their text. *)
-  let content = Keeper_context_core.text_of_history_jsonl_json json in
-  if
-    source <> "internal_assistant"
-    || String.trim content = ""
-    || String.trim message_id = ""
-  then None
-  else
-    let ts =
-      match Safe_ops.json_float_opt "ts_unix" json with
-      | Some value when value > 0.0 -> value
-      | _ ->
-          match Safe_ops.json_float_opt "timestamp" json with
-          | Some value when value > 0.0 -> value
-          | _ -> 0.0
-    in
-    if ts <= 0.0 then None
-    else
-      let ts_iso =
-        match Safe_ops.json_string_opt "ts_iso" json with
-        | Some value when Option.is_some (String_util.trim_to_option value) -> value
-        | _ ->
-            match Safe_ops.json_string_opt "ts" json with
-            | Some value when Option.is_some (String_util.trim_to_option value) -> value
-            | _ -> Masc_domain.iso8601_of_unix_seconds ts
-      in
-      Some
-        (Trajectory.Thinking
-           {
-             ts;
-             ts_iso;
-             turn = Safe_ops.json_int ~default:0 "turn" json;
-             identity = Trajectory.Internal_history_message { message_id };
-             observation =
-               Trajectory.Withheld_thinking { char_count = String.length content };
-           })
-
 let runtime_manifest_public_json row =
   Keeper_runtime_manifest.public_to_json row
 

--- a/lib/server/server_dashboard_http_keeper_api_types.ml
+++ b/lib/server/server_dashboard_http_keeper_api_types.ml
@@ -365,6 +365,7 @@ let claim_scope_summary_absent =
 let internal_history_json_to_trajectory_line (json : Yojson.Safe.t)
     : Trajectory.trajectory_line option =
   let source = Safe_ops.json_string ~default:"" "source" json in
+  let message_id = Safe_ops.json_string ~default:"" "id" json in
   (* History rows persist message text as typed [content_blocks], not a flat
      [content] string (Keeper_context_core_message_json: "Structured
      content_blocks is the only supported message-content shape"). Reading a
@@ -373,7 +374,11 @@ let internal_history_json_to_trajectory_line (json : Yojson.Safe.t)
      dashboard trace. Use the SSOT extractor (shared with history routing /
      memory recall) so content_blocks rows decode to their text. *)
   let content = Keeper_context_core.text_of_history_jsonl_json json in
-  if source <> "internal_assistant" || String.trim content = "" then None
+  if
+    source <> "internal_assistant"
+    || String.trim content = ""
+    || String.trim message_id = ""
+  then None
   else
     let ts =
       match Safe_ops.json_float_opt "ts_unix" json with
@@ -399,9 +404,9 @@ let internal_history_json_to_trajectory_line (json : Yojson.Safe.t)
              ts;
              ts_iso;
              turn = Safe_ops.json_int ~default:0 "turn" json;
-             content;
-             content_length = String.length content;
-             redacted = Safe_ops.json_bool ~default:false "redacted" json;
+             identity = Trajectory.Internal_history_message { message_id };
+             observation =
+               Trajectory.Withheld_thinking { char_count = String.length content };
            })
 
 let runtime_manifest_public_json row =

--- a/lib/server/server_dashboard_http_keeper_api_types.mli
+++ b/lib/server/server_dashboard_http_keeper_api_types.mli
@@ -187,12 +187,6 @@ val claim_scope_summary_absent : Yojson.Safe.t
 (** Pure constant: JSON record returned when no matching claim was
     observed. *)
 
-val internal_history_json_to_trajectory_line :
-  Yojson.Safe.t -> Trajectory.trajectory_line option
-(** Pure: decode one [internal_assistant] history JSON line into a
-    metadata-only [Trajectory.Thinking] record. Returns [None] when the line
-    is missing required fields or originates from a non-internal source. *)
-
 val runtime_manifest_public_json :
   Keeper_runtime_manifest.t -> Yojson.Safe.t
 (** Pure: convert a manifest row to its public JSON, with provider/model

--- a/lib/server/server_dashboard_http_keeper_api_types.mli
+++ b/lib/server/server_dashboard_http_keeper_api_types.mli
@@ -190,8 +190,8 @@ val claim_scope_summary_absent : Yojson.Safe.t
 val internal_history_json_to_trajectory_line :
   Yojson.Safe.t -> Trajectory.trajectory_line option
 (** Pure: decode one [internal_assistant] history JSON line into a
-    [Trajectory.Thinking] record. Returns [None] when the line is missing
-    required fields or originates from a non-internal source. *)
+    metadata-only [Trajectory.Thinking] record. Returns [None] when the line
+    is missing required fields or originates from a non-internal source. *)
 
 val runtime_manifest_public_json :
   Keeper_runtime_manifest.t -> Yojson.Safe.t

--- a/lib/trajectory/trajectory.ml
+++ b/lib/trajectory/trajectory.ml
@@ -77,13 +77,21 @@ type trajectory = {
 (* Thinking entries                                                  *)
 (* ================================================================ *)
 
+type thinking_observation =
+  | Withheld_thinking of { char_count : int }
+  | Withheld_reasoning_details of { char_count : int }
+  | Withheld_redacted_thinking
+
+type thinking_identity =
+  | Trajectory_block of { block_index : int }
+  | Internal_history_message of { message_id : string }
+
 type thinking_entry = {
   ts : float;
   ts_iso : string;
   turn : int;
-  content : string;
-  content_length : int;
-  redacted : bool;
+  identity : thinking_identity;
+  observation : thinking_observation;
 }
 
 type trajectory_line =
@@ -158,30 +166,44 @@ let entry_to_json ?(result_max_len = default_result_truncation)
        | None -> [])
     @ runtime_contract_field @ action_radius_field)
 
-let default_thinking_truncation = 2000
+let thinking_observation_fields = function
+  | Withheld_thinking { char_count } -> "thinking", char_count, false
+  | Withheld_reasoning_details { char_count } -> "reasoning_details", char_count, false
+  | Withheld_redacted_thinking -> "redacted_thinking", 0, true
+;;
 
-let thinking_entry_to_json ?(content_max_len = default_thinking_truncation) (e : thinking_entry) : Yojson.Safe.t =
-  let content =
-    if content_max_len > 0 then
-      String_util.utf8_safe ~max_bytes:(content_max_len + 3) ~suffix:"..."
-        e.content
-      |> String_util.to_string
-    else e.content
+let thinking_identity_to_json = function
+  | Trajectory_block { block_index } ->
+    `Assoc
+      [ "source", `String "trajectory_block"; "block_index", `Int block_index ]
+  | Internal_history_message { message_id } ->
+    `Assoc
+      [ "source", `String "internal_history_message"
+      ; "message_id", `String message_id
+      ]
+;;
+
+let thinking_entry_to_json (e : thinking_entry) : Yojson.Safe.t =
+  let reasoning_kind, char_count, redacted =
+    thinking_observation_fields e.observation
   in
   `Assoc [
     ("type", `String "thinking");
     ("ts", `Float e.ts);
     ("ts_iso", `String e.ts_iso);
     ("turn", `Int e.turn);
-    ("content", `String content);
-    ("content_length", `Int e.content_length);
-    ("redacted", `Bool e.redacted);
+    ("identity", thinking_identity_to_json e.identity);
+    ("observation", `String "withheld");
+    ("reasoning_kind", `String reasoning_kind);
+    ("present", `Bool true);
+    ("char_count", `Int char_count);
+    ("redacted", `Bool redacted);
+    ("content", `Null);
   ]
 
-let trajectory_line_to_json ?(result_max_len = default_result_truncation)
-    ?(content_max_len = default_thinking_truncation) = function
+let trajectory_line_to_json ?(result_max_len = default_result_truncation) = function
   | Tool_call e -> entry_to_json ~result_max_len e
-  | Thinking e -> thinking_entry_to_json ~content_max_len e
+  | Thinking e -> thinking_entry_to_json e
 
 let trajectory_to_json (t : trajectory) : Yojson.Safe.t =
   `Assoc [
@@ -475,12 +497,7 @@ let append_thinking ~(masc_root : string) ~(keeper_name : string) ~(trace_id : s
   let dir = trajectories_dir masc_root keeper_name in
   Fs_compat.mkdir_p dir;
   let path = trajectory_path masc_root keeper_name trace_id in
-  (* 남김없이: the thinking trajectory is the eval/audit SSOT, so persist the
-     FULL untruncated reasoning text. Truncation is a read/display concern
-     ([content_max_len] query param on the trajectory endpoint), never a
-     write-time one — truncating here destroyed reasoning before it was ever
-     stored. [content_length] still records the true length either way. *)
-  let json = thinking_entry_to_json ~content_max_len:0 entry in
+  let json = thinking_entry_to_json entry in
   Fs_compat.append_jsonl path json
 
 (** Write a trajectory summary line (appended after session ends). *)
@@ -848,38 +865,82 @@ type trajectory_line_decode_result =
   | Skipped_line
   | Malformed_line
 
+let thinking_observation_of_json json =
+  match
+    ( Json_util.assoc_member_opt "observation" json
+    , Json_util.assoc_member_opt "reasoning_kind" json
+    , Json_util.assoc_member_opt "present" json
+    , Json_util.assoc_member_opt "char_count" json
+    , Json_util.assoc_member_opt "redacted" json
+    , Json_util.assoc_member_opt "content" json )
+  with
+  | ( Some (`String "withheld")
+    , Some (`String "thinking")
+    , Some (`Bool true)
+    , Some (`Int char_count)
+    , Some (`Bool false)
+    , Some `Null ) when char_count >= 0 ->
+    Some (Withheld_thinking { char_count })
+  | ( Some (`String "withheld")
+    , Some (`String "reasoning_details")
+    , Some (`Bool true)
+    , Some (`Int char_count)
+    , Some (`Bool false)
+    , Some `Null ) when char_count >= 0 ->
+    Some (Withheld_reasoning_details { char_count })
+  | ( Some (`String "withheld")
+    , Some (`String "redacted_thinking")
+    , Some (`Bool true)
+    , Some (`Int 0)
+    , Some (`Bool true)
+    , Some `Null ) ->
+    Some Withheld_redacted_thinking
+  | _ -> None
+;;
+
+let thinking_identity_of_json json =
+  match Json_util.assoc_member_opt "identity" json with
+  | Some (`Assoc fields) ->
+    (match List.assoc_opt "source" fields with
+     | Some (`String "trajectory_block") ->
+       (match List.assoc_opt "block_index" fields with
+        | Some (`Int block_index) when block_index >= 0 ->
+          Some (Trajectory_block { block_index })
+        | _ -> None)
+     | Some (`String "internal_history_message") ->
+       (match List.assoc_opt "message_id" fields with
+        | Some (`String message_id) when String.trim message_id <> "" ->
+          Some (Internal_history_message { message_id })
+        | _ -> None)
+     | _ -> None)
+  | _ -> None
+;;
+
 let trajectory_line_of_json json =
   match Json_util.assoc_member_opt "type" json with
   | Some (`String "trajectory_summary") -> Skipped_line
   | Some (`String "thinking") ->
-      Parsed_line
-        (Thinking
-           { ts =
-               (match Json_util.assoc_member_opt "ts" json with
-                | Some (`Float f) -> f
-                | Some (`Int n) -> Float.of_int n
-                | _ -> 0.0)
-           ; ts_iso =
-               (match Json_util.assoc_member_opt "ts_iso" json with
-                | Some (`String s) -> s
-                | _ -> "")
-           ; turn =
-               (match Json_util.assoc_member_opt "turn" json with
-                | Some (`Int n) -> n
-                | _ -> 0)
-           ; content =
-               (match Json_util.assoc_member_opt "content" json with
-                | Some (`String s) -> s
-                | _ -> "")
-           ; content_length =
-               (match Json_util.assoc_member_opt "content_length" json with
-                | Some (`Int n) -> n
-                | _ -> 0)
-           ; redacted =
-               (match Json_util.assoc_member_opt "redacted" json with
-                | Some (`Bool b) -> b
-                | _ -> false)
-           })
+      (match thinking_observation_of_json json, thinking_identity_of_json json with
+       | Some observation, Some identity ->
+         Parsed_line
+           (Thinking
+              { ts =
+                  (match Json_util.assoc_member_opt "ts" json with
+                   | Some (`Float f) -> f
+                   | Some (`Int n) -> Float.of_int n
+                   | _ -> 0.0)
+              ; ts_iso =
+                  (match Json_util.assoc_member_opt "ts_iso" json with
+                   | Some (`String s) -> s
+                   | _ -> "")
+              ; turn =
+                  (match Json_util.assoc_member_opt "turn" json with
+                   | Some (`Int n) -> n
+                   | _ -> 0)
+              ; identity
+              ; observation
+              })
+       | _ -> Malformed_line)
   | _ ->
       (match tool_call_entry_of_json json with
        | Some (entry, _parsed_gate) -> Parsed_line (Tool_call entry)

--- a/lib/trajectory/trajectory.ml
+++ b/lib/trajectory/trajectory.ml
@@ -82,9 +82,7 @@ type thinking_observation =
   | Withheld_reasoning_details of { char_count : int }
   | Withheld_redacted_thinking
 
-type thinking_identity =
-  | Trajectory_block of { block_index : int }
-  | Internal_history_message of { message_id : string }
+type thinking_identity = Trajectory_block of { block_index : int }
 
 type thinking_entry = {
   ts : float;
@@ -176,11 +174,6 @@ let thinking_identity_to_json = function
   | Trajectory_block { block_index } ->
     `Assoc
       [ "source", `String "trajectory_block"; "block_index", `Int block_index ]
-  | Internal_history_message { message_id } ->
-    `Assoc
-      [ "source", `String "internal_history_message"
-      ; "message_id", `String message_id
-      ]
 ;;
 
 let thinking_entry_to_json (e : thinking_entry) : Yojson.Safe.t =
@@ -906,11 +899,6 @@ let thinking_identity_of_json json =
        (match List.assoc_opt "block_index" fields with
         | Some (`Int block_index) when block_index >= 0 ->
           Some (Trajectory_block { block_index })
-        | _ -> None)
-     | Some (`String "internal_history_message") ->
-       (match List.assoc_opt "message_id" fields with
-        | Some (`String message_id) when String.trim message_id <> "" ->
-          Some (Internal_history_message { message_id })
         | _ -> None)
      | _ -> None)
   | _ -> None

--- a/lib/trajectory/trajectory.mli
+++ b/lib/trajectory/trajectory.mli
@@ -57,18 +57,27 @@ type trajectory = {
   task_id : string option;
 }
 
-(** {1 Thinking entries}
+(** {1 Thinking observations}
 
-    Thinking blocks from LLM responses, persisted alongside tool call entries
-    in the same JSONL file with [type = "thinking"]. *)
+    Hidden reasoning is never trajectory data. These variants preserve only
+    the kind and size needed for observability; no variant can carry content
+    or a replay signature. *)
+
+type thinking_observation =
+  | Withheld_thinking of { char_count : int }
+  | Withheld_reasoning_details of { char_count : int }
+  | Withheld_redacted_thinking
+
+type thinking_identity =
+  | Trajectory_block of { block_index : int }
+  | Internal_history_message of { message_id : string }
 
 type thinking_entry = {
   ts : float;
   ts_iso : string;
   turn : int;
-  content : string;
-  content_length : int;
-  redacted : bool;
+  identity : thinking_identity;
+  observation : thinking_observation;
 }
 
 (** Tagged union for reading mixed JSONL (tool calls + thinking). *)
@@ -86,7 +95,6 @@ val gate_decision_to_json : gate_decision -> Yojson.Safe.t
 val outcome_to_json : trajectory_outcome -> Yojson.Safe.t
 val outcome_to_string : trajectory_outcome -> string
 val default_result_truncation : int
-val default_thinking_truncation : int
 val entry_to_json :
   ?result_max_len:int ->
   ?runtime_contract:Yojson.Safe.t ->
@@ -101,8 +109,8 @@ val tool_call_entry_of_json :
     JSON. The [bool] is true when the gate field parsed from a
     persisted value rather than the legacy default. Exposed for
     RFC-0233 consumers that join rows on [execution_id]. *)
-val thinking_entry_to_json : ?content_max_len:int -> thinking_entry -> Yojson.Safe.t
-val trajectory_line_to_json : ?result_max_len:int -> ?content_max_len:int -> trajectory_line -> Yojson.Safe.t
+val thinking_entry_to_json : thinking_entry -> Yojson.Safe.t
+val trajectory_line_to_json : ?result_max_len:int -> trajectory_line -> Yojson.Safe.t
 val trajectory_to_json : trajectory -> Yojson.Safe.t
 
 (** {1 Persistence} *)

--- a/lib/trajectory/trajectory.mli
+++ b/lib/trajectory/trajectory.mli
@@ -68,9 +68,7 @@ type thinking_observation =
   | Withheld_reasoning_details of { char_count : int }
   | Withheld_redacted_thinking
 
-type thinking_identity =
-  | Trajectory_block of { block_index : int }
-  | Internal_history_message of { message_id : string }
+type thinking_identity = Trajectory_block of { block_index : int }
 
 type thinking_entry = {
   ts : float;

--- a/packages/agent_core/lib/raw_trace.ml
+++ b/packages/agent_core/lib/raw_trace.ml
@@ -593,19 +593,70 @@ let start_run
   active
 ;;
 
+type assistant_block_observation =
+  | Observable_block of
+      { block_kind : string
+      ; json : Yojson.Safe.t
+      }
+  | Withheld_reasoning of
+      { block_kind : string
+      ; char_count : int
+      ; redacted : bool
+      }
+
+let observe_assistant_block block =
+  match block with
+  | Thinking { content; _ } ->
+    Withheld_reasoning
+      { block_kind = "thinking"; char_count = String.length content; redacted = false }
+  | ReasoningDetails { reasoning_content; details } ->
+    let projected = Types.reasoning_details_text ~reasoning_content ~details in
+    Withheld_reasoning
+      { block_kind = "reasoning_details"
+      ; char_count = String.length projected
+      ; redacted = false
+      }
+  | RedactedThinking _ ->
+    Withheld_reasoning
+      { block_kind = "redacted_thinking"; char_count = 0; redacted = true }
+  | Text _ ->
+    Observable_block
+      { block_kind = "text"; json = Llm_provider.Api_common.content_block_to_json block }
+  | ToolUse _ ->
+    Observable_block
+      { block_kind = "tool_use"; json = Llm_provider.Api_common.content_block_to_json block }
+  | ToolResult _ ->
+    Observable_block
+      { block_kind = "tool_result"; json = Llm_provider.Api_common.content_block_to_json block }
+  | Image _ ->
+    Observable_block
+      { block_kind = "image"; json = Llm_provider.Api_common.content_block_to_json block }
+  | Document _ ->
+    Observable_block
+      { block_kind = "document"; json = Llm_provider.Api_common.content_block_to_json block }
+  | Audio _ ->
+    Observable_block
+      { block_kind = "audio"; json = Llm_provider.Api_common.content_block_to_json block }
+;;
+
+let assistant_block_observation_to_pair = function
+  | Observable_block { block_kind; json } -> block_kind, json
+  | Withheld_reasoning { block_kind; char_count; redacted } ->
+    ( block_kind
+    , `Assoc
+        [ "type", `String "reasoning_observation"
+        ; "observation", `String "withheld"
+        ; "reasoning_kind", `String block_kind
+        ; "present", `Bool true
+        ; "char_count", `Int char_count
+        ; "redacted", `Bool redacted
+        ; "content", `Null
+        ] )
+;;
+
 let record_assistant_block active ~block_index block =
-  let json = Llm_provider.Api_common.content_block_to_json block in
-  let block_kind =
-    match block with
-    | Text _ -> "text"
-    | Thinking _ -> "thinking"
-    | ReasoningDetails _ -> "reasoning_details"
-    | RedactedThinking _ -> "redacted_thinking"
-    | ToolUse _ -> "tool_use"
-    | ToolResult _ -> "tool_result"
-    | Image _ -> "image"
-    | Document _ -> "document"
-    | Audio _ -> "audio"
+  let block_kind, json =
+    observe_assistant_block block |> assistant_block_observation_to_pair
   in
   append_record
     active

--- a/packages/agent_core/lib/raw_trace.mli
+++ b/packages/agent_core/lib/raw_trace.mli
@@ -162,6 +162,10 @@ val record_assistant_block
   -> block_index:int
   -> Types.content_block
   -> (unit, Error.t) result
+(** Persist observable assistant blocks verbatim. Thinking,
+    ReasoningDetails, and RedactedThinking persist typed metadata with
+    [content = null]; hidden reasoning bytes and signatures never cross the
+    raw-trace writer boundary. *)
 
 val record_tool_execution_started
   :  active_run

--- a/packages/agent_core/lib/trajectory.ml
+++ b/packages/agent_core/lib/trajectory.ml
@@ -174,6 +174,9 @@ let of_raw_trace_records (records : Raw_trace.record list) : trajectory =
             | Some "thinking" ->
               let content =
                 match r.assistant_block with
+                | Some (`Assoc fields)
+                  when List.assoc_opt "observation" fields = Some (`String "withheld") ->
+                  ""
                 | Some json ->
                   (try Yojson.Safe.Util.(json |> member "content" |> to_string) with
                    | Yojson.Safe.Util.Type_error _ | Not_found ->

--- a/packages/agent_core/test/test_raw_trace.ml
+++ b/packages/agent_core/test/test_raw_trace.ml
@@ -929,6 +929,76 @@ let test_tool_result_assistant_block_summary () =
   Alcotest.(check int) "tool_result blocks" 1 summary.tool_result_block_count
 ;;
 
+let test_hidden_reasoning_is_metadata_only () =
+  Eio_main.run
+  @@ fun _env ->
+  with_temp_dir
+  @@ fun root ->
+  let sink =
+    unwrap
+      (Raw_trace.create_for_session
+         ~session_root:root
+         ~session_id:"sess-hidden-reasoning"
+         ~agent_name:"raw-worker"
+         ())
+  in
+  let active =
+    unwrap
+      (Raw_trace.start_run sink ~agent_name:"raw-worker" ~prompt:"metadata only" ())
+  in
+  let secret_thinking = "PRIVATE_THINKING_BYTES" in
+  let secret_details = "PRIVATE_REASONING_DETAILS" in
+  unwrap
+    (Raw_trace.record_assistant_block active ~block_index:0
+       (Types.Thinking
+          { content = secret_thinking; signature = Some "PRIVATE_SIGNATURE" }));
+  unwrap
+    (Raw_trace.record_assistant_block active ~block_index:1
+       (Types.ReasoningDetails
+          { reasoning_content = Some secret_details
+          ; details = [ { raw = `String "PRIVATE_RAW_DETAIL"; text = None } ]
+          }));
+  unwrap
+    (Raw_trace.record_assistant_block active ~block_index:2
+       (Types.RedactedThinking "PRIVATE_REDACTED_PAYLOAD"));
+  ignore
+    (unwrap
+       (Raw_trace.finish_run active ~final_text:None ~stop_reason:(Some "EndTurn")
+          ~error:None));
+  let raw = read_file (Raw_trace.file_path sink) in
+  List.iter
+    (fun secret ->
+       Alcotest.(check bool)
+         ("raw trace withholds " ^ secret)
+         false
+         (Util.string_contains ~needle:secret raw))
+    [ secret_thinking
+    ; secret_details
+    ; "PRIVATE_SIGNATURE"
+    ; "PRIVATE_RAW_DETAIL"
+    ; "PRIVATE_REDACTED_PAYLOAD"
+    ];
+  let records = unwrap (Raw_trace.read_all ~path:(Raw_trace.file_path sink) ()) in
+  let observations =
+    records
+    |> List.filter_map (fun (record : Raw_trace.record) ->
+      if record.record_type = Raw_trace.Assistant_block
+      then record.assistant_block
+      else None)
+  in
+  Alcotest.(check int) "three reasoning observations" 3 (List.length observations);
+  List.iter
+    (fun json ->
+       let open Yojson.Safe.Util in
+       Alcotest.(check string)
+         "observation withheld"
+         "withheld"
+         (json |> member "observation" |> to_string);
+       Alcotest.(check bool) "reasoning present" true (json |> member "present" |> to_bool);
+       Alcotest.(check bool) "content is null" true (json |> member "content" = `Null))
+    observations
+;;
+
 let () =
   Random.self_init ();
   Alcotest.run
@@ -973,6 +1043,10 @@ let () =
             "tool_result assistant block summary"
             `Quick
             test_tool_result_assistant_block_summary
+        ; Alcotest.test_case
+            "hidden reasoning is metadata only"
+            `Quick
+            test_hidden_reasoning_is_metadata_only
         ] )
     ]
 ;;

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -905,7 +905,7 @@ let agent_core_interleaving_event_label = function
   | _ -> None
 
 let trajectory_interleaving_label = function
-  | Trajectory.Thinking entry -> "thinking:" ^ entry.Trajectory.content
+  | Trajectory.Thinking _ -> "thinking:[withheld]"
   | Trajectory.Tool_call entry -> "tool:" ^ entry.Trajectory.tool_name
 
 let receipt_detail_of_provider_call
@@ -1154,9 +1154,9 @@ let test_agent_core_interleaving_matches_masc_receipt_and_progress_facts () =
              (trajectory_entry_of_provider_call ~ts:1.3 ~turn ~round:2 second);
            Trajectory.flush_pending acc;
            check (list string) "MASC trajectory JSONL keeps interleaved facts"
-             [ "thinking:inspect board first"
+             [ "thinking:[withheld]"
              ; "tool:masc_board_list"
-             ; "thinking:complete after evidence"
+             ; "thinking:[withheld]"
              ; "tool:keeper_task_done"
              ]
              (Trajectory.read_all_lines ~masc_root:base_dir ~keeper_name

--- a/test/test_server_dashboard_http_keeper_api_trace.ml
+++ b/test/test_server_dashboard_http_keeper_api_trace.ml
@@ -8,41 +8,44 @@ module Runtime_lens_scan = Server_dashboard_http_keeper_runtime_manifest_scan
 module Runtime_lens_swimlane = Server_dashboard_http_keeper_runtime_lens_swimlane
 module T = Trajectory
 
-let mk_thinking_with_turn ~turn ~ts ~redacted ~content =
+let mk_thinking_with_turn ?(block_index = 0) ~turn ~ts ~redacted ~content =
   T.Thinking
     { ts
     ; ts_iso = "2026-06-29T00:00:00Z"
     ; turn
-    ; content
-    ; content_length = String.length content
-    ; redacted
+    ; identity = T.Trajectory_block { block_index }
+    ; observation =
+        if redacted then T.Withheld_redacted_thinking
+        else T.Withheld_thinking { char_count = String.length content }
     }
 ;;
 
-let mk_thinking ~ts ~redacted ~content =
-  mk_thinking_with_turn ~turn:1 ~ts ~redacted ~content
+let mk_thinking ?block_index ~ts ~redacted ~content =
+  mk_thinking_with_turn ?block_index ~turn:1 ~ts ~redacted ~content
 ;;
 
 let test_dedupe_preserves_first_order () =
   let t1 = mk_thinking ~ts:1.0 ~redacted:false ~content:"A" in
-  let t2 = mk_thinking ~ts:2.0 ~redacted:false ~content:"B" in
+  let t2 = mk_thinking ~block_index:1 ~ts:2.0 ~redacted:false ~content:"B" in
   let t1_dup = mk_thinking ~ts:1.0 ~redacted:false ~content:"A" in
   let input = [ t1; t2; t1_dup ] in
   let result = Trace.dedupe_thinking_lines input in
   check int "length" 2 (List.length result);
   match result with
   | [ T.Thinking a; T.Thinking b ] ->
-    check string "first" "A" a.content;
-    check string "second" "B" b.content
+    (match a.observation, b.observation with
+     | T.Withheld_thinking { char_count = 1 },
+       T.Withheld_thinking { char_count = 1 } -> ()
+     | _ -> fail "expected metadata-only thinking observations")
   | _ -> fail "expected two thinking lines"
 ;;
 
-let test_dedupe_precision () =
+let test_dedupe_uses_producer_identity () =
   let t1 = mk_thinking ~ts:1.1234561 ~redacted:false ~content:"A" in
-  let t2 = mk_thinking ~ts:1.1234562 ~redacted:false ~content:"A" in
+  let t2 = mk_thinking ~block_index:1 ~ts:1.1234561 ~redacted:false ~content:"A" in
   let input = [ t1; t2 ] in
   let result = Trace.dedupe_thinking_lines input in
-  (* Without the fix, Printf.sprintf "%.6f" would truncate both to 1.123456 and drop t2 *)
+  (* Same timestamp and metadata are distinct when the producer block identity differs. *)
   check int "length" 2 (List.length result)
 ;;
 
@@ -75,19 +78,21 @@ let test_read_invalid_json_skips () =
        invalid line (missing ts/timestamp), 1 valid line. *)
     Printf.fprintf
       oc
-      "{\"source\":\"internal_assistant\",\"content_blocks\":[{\"type\":\"text\",\"text\":\"A\"}],\"ts_unix\":1.0}\n\
-       {\"source\":\"internal_assistant\",\"content_blocks\":[{\"type\":\"text\",\"text\":\"B\"}]}\n\
-       {\"source\":\"internal_assistant\",\"content_blocks\":[{\"type\":\"text\",\"text\":\"C\"}],\"ts_unix\":3.0}\n";
+      "{\"id\":\"msg-a\",\"source\":\"internal_assistant\",\"content_blocks\":[{\"type\":\"text\",\"text\":\"A\"}],\"ts_unix\":1.0}\n\
+       {\"id\":\"msg-b\",\"source\":\"internal_assistant\",\"content_blocks\":[{\"type\":\"text\",\"text\":\"B\"}]}\n\
+       {\"id\":\"msg-c\",\"source\":\"internal_assistant\",\"content_blocks\":[{\"type\":\"text\",\"text\":\"C\"}],\"ts_unix\":3.0}\n";
     close_out oc;
     let result = Trace.read_internal_history_lines ~config ~trace_id:"test_trace" in
     (* Should skip the invalid line ("B") without failing *)
     check int "length" 2 (List.length result);
     match result with
     | [ T.Thinking a; T.Thinking c ] ->
-      check string "first" "A" a.content;
       check (float 0.0) "first_ts" 1.0 a.ts;
-      check string "second" "C" c.content;
-      check (float 0.0) "second_ts" 3.0 c.ts
+      check (float 0.0) "second_ts" 3.0 c.ts;
+      (match a.observation, c.observation with
+       | T.Withheld_thinking { char_count = 1 },
+         T.Withheld_thinking { char_count = 1 } -> ()
+       | _ -> fail "expected withheld internal history metadata")
     | _ -> fail "expected two valid thinking lines")
 ;;
 
@@ -99,12 +104,14 @@ let test_converter_decodes_content_blocks () =
      trace row" WARNs/day) and invisible in the dashboard trace. *)
   let json =
     Yojson.Safe.from_string
-      "{\"source\":\"internal_assistant\",\"content_blocks\":[{\"type\":\"text\",\"text\":\"hello world\"}],\"ts_unix\":2.0}"
+      "{\"id\":\"msg-hello\",\"source\":\"internal_assistant\",\"content_blocks\":[{\"type\":\"text\",\"text\":\"hello world\"}],\"ts_unix\":2.0}"
   in
   match Types.internal_history_json_to_trajectory_line json with
   | Some (T.Thinking entry) ->
-    check string "content" "hello world" entry.content;
-    check int "content_length" (String.length "hello world") entry.content_length;
+    (match entry.observation with
+     | T.Withheld_thinking { char_count } ->
+       check int "char_count" (String.length "hello world") char_count
+     | _ -> fail "expected withheld thinking metadata");
     check (float 0.0) "ts" 2.0 entry.ts
   | Some (T.Tool_call _) -> fail "expected Thinking, got Tool_call"
   | None -> fail "content_blocks row must decode to a Thinking line"
@@ -173,9 +180,8 @@ let test_chat_trace_block_by_turn_ref_reads_allowed_trace_history () =
       { ts = 1.0
       ; ts_iso = "2026-07-01T00:00:01Z"
       ; turn = 1
-      ; content = "current turn"
-      ; content_length = String.length "current turn"
-      ; redacted = false
+      ; identity = T.Trajectory_block { block_index = 0 }
+      ; observation = T.Withheld_thinking { char_count = String.length "current turn" }
       };
     T.append_thinking
       ~masc_root
@@ -184,9 +190,8 @@ let test_chat_trace_block_by_turn_ref_reads_allowed_trace_history () =
       { ts = 2.0
       ; ts_iso = "2026-07-01T00:00:02Z"
       ; turn = 42
-      ; content = "old turn"
-      ; content_length = String.length "old turn"
-      ; redacted = false
+      ; identity = T.Trajectory_block { block_index = 0 }
+      ; observation = T.Withheld_thinking { char_count = String.length "old turn" }
       };
     let trace_block_by_turn_ref =
       Trace.chat_trace_block_by_turn_ref
@@ -200,7 +205,11 @@ let test_chat_trace_block_by_turn_ref_reads_allowed_trace_history () =
     (match trace_block_by_turn_ref old_ref with
      | Some
          (Keeper_chat_blocks.Trace
-           { trace = [ Keeper_chat_blocks.Trace_think { text = "old turn"; _ } ] })
+           { trace =
+               [ Keeper_chat_blocks.Trace_think
+                   { text = ""; content_withheld = true; _ }
+               ]
+           })
        -> ()
      | Some _ -> fail "old trace_id returned unexpected trace block"
      | None -> fail "old trace_id from trace_history should enrich");
@@ -771,7 +780,7 @@ let () =
     "Server_dashboard_http_keeper_api_trace"
     [ ( "dedupe_thinking_lines"
       , [ test_case "preserves first order" `Quick test_dedupe_preserves_first_order
-        ; test_case "preserves sub-microsecond precision" `Quick test_dedupe_precision
+        ; test_case "uses producer identity" `Quick test_dedupe_uses_producer_identity
         ] )
     ; ( "read_internal_history_lines"
       , [ test_case "skips invalid jsonl rows" `Quick test_read_invalid_json_skips

--- a/test/test_server_dashboard_http_keeper_api_trace.ml
+++ b/test/test_server_dashboard_http_keeper_api_trace.ml
@@ -1,7 +1,6 @@
 open Alcotest
 open Masc
 module Trace = Server_dashboard_http_keeper_api_trace
-module Types = Server_dashboard_http_keeper_api_types
 module Checkpoints = Server_dashboard_http_keeper_api_checkpoints
 module Keeper_api = Server_dashboard_http_keeper_api
 module Runtime_lens_scan = Server_dashboard_http_keeper_runtime_manifest_scan
@@ -66,108 +65,6 @@ let with_temp_dir f =
   Fun.protect ~finally:(fun () -> rm_rf path) (fun () -> f path)
 ;;
 
-let test_read_invalid_json_skips () =
-  with_temp_dir (fun dir ->
-    let config = Workspace.default_config dir in
-    let trace_file = Keeper_types_support.keeper_internal_history_path config "test_trace" in
-    let trace_dir = Filename.dirname trace_file in
-    Unix.system (Printf.sprintf "mkdir -p '%s'" trace_dir) |> ignore;
-    let oc = open_out trace_file in
-    (* Rows persist message text as typed [content_blocks] (the only supported
-       message-content shape), not a flat [content] string. 1 valid line, 1
-       invalid line (missing ts/timestamp), 1 valid line. *)
-    Printf.fprintf
-      oc
-      "{\"id\":\"msg-a\",\"source\":\"internal_assistant\",\"content_blocks\":[{\"type\":\"text\",\"text\":\"A\"}],\"ts_unix\":1.0}\n\
-       {\"id\":\"msg-b\",\"source\":\"internal_assistant\",\"content_blocks\":[{\"type\":\"text\",\"text\":\"B\"}]}\n\
-       {\"id\":\"msg-c\",\"source\":\"internal_assistant\",\"content_blocks\":[{\"type\":\"text\",\"text\":\"C\"}],\"ts_unix\":3.0}\n";
-    close_out oc;
-    let result = Trace.read_internal_history_lines ~config ~trace_id:"test_trace" in
-    (* Should skip the invalid line ("B") without failing *)
-    check int "length" 2 (List.length result);
-    match result with
-    | [ T.Thinking a; T.Thinking c ] ->
-      check (float 0.0) "first_ts" 1.0 a.ts;
-      check (float 0.0) "second_ts" 3.0 c.ts;
-      (match a.observation, c.observation with
-       | T.Withheld_thinking { char_count = 1 },
-         T.Withheld_thinking { char_count = 1 } -> ()
-       | _ -> fail "expected withheld internal history metadata")
-    | _ -> fail "expected two valid thinking lines")
-;;
-
-let test_converter_decodes_content_blocks () =
-  (* Regression: persisted internal_assistant rows store text under typed
-     [content_blocks]. Before the fix, the converter read a flat [content]
-     field, decoded "" for every row, and returned None — the whole keeper
-     reasoning history was skipped (3339+ "Skipped invalid internal history
-     trace row" WARNs/day) and invisible in the dashboard trace. *)
-  let json =
-    Yojson.Safe.from_string
-      "{\"id\":\"msg-hello\",\"source\":\"internal_assistant\",\"content_blocks\":[{\"type\":\"text\",\"text\":\"hello world\"}],\"ts_unix\":2.0}"
-  in
-  match Types.internal_history_json_to_trajectory_line json with
-  | Some (T.Thinking entry) ->
-    (match entry.observation with
-     | T.Withheld_thinking { char_count } ->
-       check int "char_count" (String.length "hello world") char_count
-     | _ -> fail "expected withheld thinking metadata");
-    check (float 0.0) "ts" 2.0 entry.ts
-  | Some (T.Tool_call _) -> fail "expected Thinking, got Tool_call"
-  | None -> fail "content_blocks row must decode to a Thinking line"
-;;
-
-let test_converter_rejects_flat_content () =
-  (* Contract: [content_blocks] is the only supported message-content shape
-     (Keeper_context_core_message_json). A legacy flat [content] string is not
-     the supported shape and must not silently masquerade as message text. *)
-  let json =
-    Yojson.Safe.from_string
-      "{\"source\":\"internal_assistant\",\"content\":\"legacy flat\",\"ts_unix\":2.0}"
-  in
-  check
-    bool
-    "flat content (no content_blocks) does not decode"
-    true
-    (Option.is_none (Types.internal_history_json_to_trajectory_line json))
-;;
-
-let test_skip_warns_once_per_file () =
-  (* Per-file summary: a trace file whose rows do not decode to thinking lines
-     must emit ONE summary WARN, not one per row. The dashboard re-reads each
-     trace on every poll, so the previous per-row WARN flooded the log (~16k/day
-     from a single busy trace, 84% of all warnings in one observed day). *)
-  with_temp_dir (fun dir ->
-    let config = Workspace.default_config dir in
-    let trace_file =
-      Keeper_types_support.keeper_internal_history_path config "summary_trace"
-    in
-    let trace_dir = Filename.dirname trace_file in
-    Unix.system (Printf.sprintf "mkdir -p '%s'" trace_dir) |> ignore;
-    let oc = open_out trace_file in
-    (* Four rows that do not decode to a thinking line (no ts field -> ts<=0). *)
-    Printf.fprintf
-      oc
-      "{\"source\":\"internal_assistant\",\"content_blocks\":[{\"type\":\"text\",\"text\":\"A\"}]}\n\
-       {\"source\":\"internal_assistant\",\"content_blocks\":[{\"type\":\"text\",\"text\":\"B\"}]}\n\
-       {\"source\":\"internal_assistant\",\"content_blocks\":[{\"type\":\"text\",\"text\":\"C\"}]}\n\
-       {\"source\":\"internal_assistant\",\"content_blocks\":[{\"type\":\"text\",\"text\":\"D\"}]}\n";
-    close_out oc;
-    let warnings = ref [] in
-    Console_sink.For_testing.reset ();
-    Console_sink.For_testing.set_writer (Some (fun l -> warnings := l :: !warnings));
-    Fun.protect ~finally:Console_sink.For_testing.reset (fun () ->
-      let result = Trace.read_internal_history_lines ~config ~trace_id:"summary_trace" in
-      check int "all four undecodable rows skipped" 0 (List.length result));
-    let trace_warns =
-      List.filter
-        (fun l -> Astring.String.is_infix ~affix:"internal history trace" l)
-        !warnings
-    in
-    check int "one summary warn for the file, not one per skipped row" 1
-      (List.length trace_warns))
-;;
-
 let test_chat_trace_block_by_turn_ref_reads_allowed_trace_history () =
   with_temp_dir (fun dir ->
     let config = Workspace.default_config dir in
@@ -196,7 +93,6 @@ let test_chat_trace_block_by_turn_ref_reads_allowed_trace_history () =
     let trace_block_by_turn_ref =
       Trace.chat_trace_block_by_turn_ref
         ~max_lines:10
-        ~max_internal_lines:10
         ~config
         ~keeper_name
         ~allowed_trace_ids:[ "trace-current"; "trace-old" ]
@@ -782,21 +678,7 @@ let () =
       , [ test_case "preserves first order" `Quick test_dedupe_preserves_first_order
         ; test_case "uses producer identity" `Quick test_dedupe_uses_producer_identity
         ] )
-    ; ( "read_internal_history_lines"
-      , [ test_case "skips invalid jsonl rows" `Quick test_read_invalid_json_skips
-        ; test_case "summarises skips once per file" `Quick test_skip_warns_once_per_file
-        ] )
-     ; ( "internal_history_json_to_trajectory_line"
-       , [ test_case
-             "decodes content_blocks rows"
-             `Quick
-             test_converter_decodes_content_blocks
-         ; test_case
-             "rejects flat content rows"
-             `Quick
-             test_converter_rejects_flat_content
-         ] )
-     ; ( "chat_trace_block_by_turn_ref"
+    ; ( "chat_trace_block_by_turn_ref"
        , [ test_case
              "reads allowed trace_history trace ids"
              `Quick

--- a/test/test_trajectory.ml
+++ b/test/test_trajectory.ml
@@ -591,6 +591,18 @@ let test_summary_row_not_counted_as_malformed () =
   Alcotest.(check int) "skipped count counts only malformed" 1 skipped;
   Alcotest.(check int) "total rows processed" 3 total
 
+let test_raw_thinking_content_is_rejected () =
+  let legacy_raw_content =
+    {|{"type":"thinking","ts":1.0,"ts_iso":"2026-07-01T00:00:00Z","turn":1,"content":"PRIVATE_REASONING","content_length":17,"redacted":false}|}
+  in
+  let parsed, skipped, total =
+    Trajectory.trajectory_lines_of_jsonl_lines ~trace_id:"strict-current"
+      [ legacy_raw_content ]
+  in
+  Alcotest.(check int) "raw content never decodes" 0 (List.length parsed);
+  Alcotest.(check int) "raw content counted as incompatible" 1 skipped;
+  Alcotest.(check int) "one row inspected" 1 total
+
 (* ================================================================ *)
 (* Test: next_round tail-read hydration                              *)
 (* ================================================================ *)
@@ -783,20 +795,25 @@ let test_next_round_evicts_past_turn_keys () =
     in
     Alcotest.(check int) "turn 5 after eviction stays monotonic" 5 r5c)
 
-let thinking_line ?(ts = 1000.0) ?(redacted = false) content =
+let thinking_line ?(ts = 1000.0) ?(block_index = 0) ?(redacted = false) content =
   Trajectory.Thinking
     {
       ts;
       ts_iso = "2026-06-29T00:00:00Z";
       turn = 1;
-      content;
-      content_length = String.length content;
-      redacted;
+      identity = Trajectory.Trajectory_block { block_index };
+      observation =
+        if redacted then Trajectory.Withheld_redacted_thinking
+        else Trajectory.Withheld_thinking { char_count = String.length content };
     }
 
-let check_thinking_content label expected = function
+let check_thinking_count label expected = function
   | Trajectory.Thinking entry ->
-      Alcotest.(check string) label expected entry.Trajectory.content
+      (match entry.Trajectory.observation with
+       | Trajectory.Withheld_thinking { char_count }
+       | Trajectory.Withheld_reasoning_details { char_count } ->
+         Alcotest.(check int) label expected char_count
+       | Trajectory.Withheld_redacted_thinking -> Alcotest.fail (label ^ ": redacted"))
   | Trajectory.Tool_call _ -> Alcotest.fail (label ^ ": expected thinking line")
 
 let check_tool_call label expected = function
@@ -814,21 +831,23 @@ let test_dedupe_thinking_lines_uses_structural_key () =
       thinking_line ~ts:1000.0 "same";
       tool_call;
       thinking_line ~ts:1000.0 "same";
-      thinking_line ~ts:1001.0 "same";
-      thinking_line ~ts:1000.0 ~redacted:true "same";
+      thinking_line ~ts:1001.0 ~block_index:1 "same";
+      thinking_line ~ts:1000.0 ~block_index:2 ~redacted:true "same";
     ]
   in
   let deduped =
     Server_dashboard_http_keeper_api_trace.dedupe_thinking_lines lines
   in
   Alcotest.(check int) "one exact duplicate removed" 4 (List.length deduped);
-  check_thinking_content "first thinking preserved" "same" (List.nth deduped 0);
+  check_thinking_count "first thinking preserved" 4 (List.nth deduped 0);
   check_tool_call "tool call preserved" "tool_execute" (List.nth deduped 1);
-  check_thinking_content "same content at a new timestamp preserved" "same"
+  check_thinking_count "same size at a new timestamp preserved" 4
     (List.nth deduped 2);
   (match List.nth deduped 3 with
    | Trajectory.Thinking entry ->
-       Alcotest.(check bool) "redacted variant preserved" true entry.Trajectory.redacted
+       (match entry.Trajectory.observation with
+        | Trajectory.Withheld_redacted_thinking -> ()
+        | _ -> Alcotest.fail "redacted variant was not preserved")
    | Trajectory.Tool_call _ -> Alcotest.fail "expected redacted thinking line")
 
 (* ================================================================ *)
@@ -836,7 +855,7 @@ let test_dedupe_thinking_lines_uses_structural_key () =
 (* ================================================================ *)
 
 (* ================================================================ *)
-(* Test: thinking trajectory — full untruncated text, per-turn        *)
+(* Test: thinking trajectory — metadata only, per-turn               *)
 (* ================================================================ *)
 
 let read_thinking_jsonl ~masc_root ~keeper_name ~trace_id =
@@ -854,13 +873,13 @@ let read_thinking_jsonl ~masc_root ~keeper_name ~trace_id =
       loop [])
   end
 
-(* append_thinking must persist the FULL text, not the legacy 2000-byte cap. *)
-let test_append_thinking_persists_untruncated () =
+let test_append_thinking_withholds_content () =
   with_tmpdir (fun dir ->
-    let big = String.make 9000 'x' in
+    let secret = String.make 9000 'x' in
     let entry : Trajectory.thinking_entry = {
       ts = 1000.0; ts_iso = "2026-06-09T00:00:00Z"; turn = 4;
-      content = big; content_length = String.length big; redacted = false;
+      identity = Trajectory.Trajectory_block { block_index = 0 };
+      observation = Trajectory.Withheld_thinking { char_count = String.length secret };
     } in
     Trajectory.append_thinking ~masc_root:dir ~keeper_name:"k" ~trace_id:"th1" entry;
     let lines = read_thinking_jsonl ~masc_root:dir ~keeper_name:"k" ~trace_id:"th1" in
@@ -868,14 +887,16 @@ let test_append_thinking_persists_untruncated () =
     let open Yojson.Safe.Util in
     let row = List.hd lines in
     Alcotest.(check string) "type=thinking" "thinking" (row |> member "type" |> to_string);
-    Alcotest.(check int) "content untruncated (9000B, not 2000 cap)" 9000
-      (row |> member "content" |> to_string |> String.length);
-    Alcotest.(check int) "content_length records true length" 9000
-      (row |> member "content_length" |> to_int))
+    Alcotest.(check bool) "content is withheld" true (row |> member "content" = `Null);
+    Alcotest.(check int) "char_count records true length" 9000
+      (row |> member "char_count" |> to_int);
+    Alcotest.(check bool) "secret absent from JSONL" false
+      (String_util.string_contains_substring ~needle:secret
+         ~haystack:(Yojson.Safe.to_string row)))
 
 (* persist_response_content stamps every block with the hook's ~turn (not
    acc.turn) and writes one line per thinking block, untruncated. *)
-let test_persist_response_content_per_turn_full () =
+let test_persist_response_content_per_turn_metadata () =
   with_tmpdir (fun dir ->
     let acc = Trajectory.create_accumulator
       ~masc_root:dir ~keeper_name:"k" ~trace_id:"th2" ~generation:0 () in
@@ -893,8 +914,10 @@ let test_persist_response_content_per_turn_full () =
     List.iter (fun row ->
       Alcotest.(check int) "turn stamped from hook (11), not acc.turn (0)" 11
         (row |> member "turn" |> to_int)) lines;
-    Alcotest.(check int) "first block untruncated (5000B)" 5000
-      (List.hd lines |> member "content" |> to_string |> String.length))
+    Alcotest.(check int) "first block character count" 5000
+      (List.hd lines |> member "char_count" |> to_int);
+    List.iter (fun row ->
+      Alcotest.(check bool) "content null" true (row |> member "content" = `Null)) lines)
 
 let () =
   Alcotest.run "Trajectory" [
@@ -971,15 +994,17 @@ let () =
         test_read_recent_lines_skips_malformed_rows;
       Alcotest.test_case "summary row not counted as malformed" `Quick
         test_summary_row_not_counted_as_malformed;
+      Alcotest.test_case "raw thinking content is rejected" `Quick
+        test_raw_thinking_content_is_rejected;
     ]);
     ("keeper_trace", [
       Alcotest.test_case "dedupe_thinking_lines uses structural key" `Quick
         test_dedupe_thinking_lines_uses_structural_key;
     ]);
     ("thinking_trajectory", [
-      Alcotest.test_case "append_thinking persists full untruncated text" `Quick
-        test_append_thinking_persists_untruncated;
-      Alcotest.test_case "persist_response_content stamps hook turn, all blocks" `Quick
-        test_persist_response_content_per_turn_full;
+      Alcotest.test_case "append_thinking withholds content" `Quick
+        test_append_thinking_withholds_content;
+      Alcotest.test_case "persist_response_content stamps hook turn metadata" `Quick
+        test_persist_response_content_per_turn_metadata;
     ]);
   ]


### PR DESCRIPTION
## Outcome

Keeper trajectory JSONL and the trajectory API can no longer carry hidden reasoning text. The public OCaml type is a sum of metadata-only observations, and producer identity—not string equality—controls deduplication.

## Stack

Depends on #28561, which hard-cuts raw Agent Core trace payloads. This child covers the separate MASC trajectory writer/read/API path.

## Scope

- replace `content/content_length/redacted` product with `Withheld_thinking | Withheld_reasoning_details | Withheld_redacted_thinking`
- add `Trajectory_block(block_index) | Internal_history_message(message_id)` identity
- serialize strict current-only metadata with `content: null`; reject historical raw-content rows
- remove `content_max_len` from the HTTP route
- return chat trace steps with `content_withheld=true`
- dedupe by producer identity so equal text/equal length distinct blocks survive

Historical artifact purge/retention and dashboard metadata rendering remain separate follow-ups.

## Fast verification

- ocamlformat 0.29.0 check passed
- OCaml parse checks passed for all touched implementations/interfaces/tests
- dead-export ratchet passed at 548
- CI target audit passed at existing 563 unwired baseline
- SSOT, provider-name, silent-failure, OCaml-structure, Agent Core boundary ratchets passed
- `git diff --check` passed
- local Dune was not run per campaign instruction

## Three-way evidence plan

1. Contract: closed metadata and identity sums; strict decoder rejects raw content.
2. Hermetic: writer/merge/API focused fixtures prove null content and identity-based replay.
3. Live follow-up: unique post-deploy block IDs correlated across JSONL/API/WS without collecting CoT.