### PR TITLE
test(keeper): align cwd path contract assertion

### DIFF
--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -379,7 +379,7 @@ let test_turn_context_fields_stored () =
       true
       (String_util.contains_substring
          Yojson.Safe.Util.(member "execute_path_basis" path_resolution |> to_string)
-         "do not repeat the repo prefix");
+         "do not repeat the cwd prefix");
     Alcotest.(check bool)
       "runtime contract points .masc state at task/context tools"
       true


### PR DESCRIPTION
## Outcome

Repairs the current `main` focused-suite failure introduced by #28533. That refactor intentionally changed the path contract from a deleted repo layout to the typed `cwd` basis, but the tool-call-log assertion still expected the removed phrase.

## Evidence

The same failure appeared at the exact test line on Draft PRs #28545, #28546, #28548, and #28552:

- suite: `test_keeper_tool_call_log`
- case: `redaction / turn context fields stored`
- assertion: runtime contract Execute path basis
- old expected text: `do not repeat the repo prefix`
- current SSOT text: `do not repeat the cwd prefix`

## Fast verification

- ocamlformat check passed
- OCaml parse check passed
- `git diff --check` passed
- local Dune was not run per campaign instruction

This is a test-only repair; no production behavior changes.