### PR TITLE
feat(keeper): type Agent Core operation identity

### DIFF
--- a/lib/keeper_runtime/dune
+++ b/lib/keeper_runtime/dune
@@ -17,6 +17,7 @@
   keeper_provider_attempt_effect_core
   keeper_internal_error
   keeper_runtime_failure_route
+  keeper_agent_core_execution_identity
   keeper_latched_reason
   keeper_event_queue
   keeper_event_queue_state

--- a/lib/keeper_runtime/keeper_agent_core_execution_identity.ml
+++ b/lib/keeper_runtime/keeper_agent_core_execution_identity.ml
@@ -1,0 +1,214 @@
+type candidate_attempt =
+  | Lane_head
+  | Lane_fallback of { ordinal : int }
+
+type context_attempt =
+  | Initial_context of { capacity_bytes : int }
+  | Context_shrink of
+      { ordinal : int
+      ; capacity_bytes : int
+      }
+
+type thinking_attempt =
+  | Runtime_thinking_policy
+  | Force_thinking
+  | Force_no_thinking
+
+type error =
+  | Invalid_keeper_name of string
+  | Invalid_trace_id of string
+  | Invalid_runtime_id of string
+  | Non_positive_keeper_turn_id of int
+  | Negative_candidate_attempt of int
+  | Negative_context_shrink_attempt of int
+  | Non_positive_context_capacity of int
+
+type operation_id = string
+
+type t =
+  { keeper_name : string
+  ; trace_id : string
+  ; keeper_turn_id : int
+  ; runtime_id : string
+  ; candidate_attempt : candidate_attempt
+  ; context_attempt : context_attempt
+  ; thinking_attempt : thinking_attempt
+  ; operation_id : operation_id
+  }
+
+let bounded_preview value =
+  if String.length value <= 32
+  then value
+  else Printf.sprintf "%s...(%d bytes)" (String.sub value 0 32) (String.length value)
+;;
+
+let is_portable_name value =
+  let length = String.length value in
+  length > 0
+  && not (String.equal value "." || String.equal value "..")
+  && String.for_all
+       (function
+         | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '.' | '_' | '-' -> true
+         | _ -> false)
+       value
+;;
+
+let is_trace_id value =
+  let length = String.length value in
+  length > 0
+  && length <= 64
+  && not (String.equal value "." || String.equal value "..")
+  && String.for_all
+       (function
+         | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '-' -> true
+         | _ -> false)
+       value
+;;
+
+let candidate_attempt_to_yojson = function
+  | Lane_head -> `Assoc [ "kind", `String "lane_head" ]
+  | Lane_fallback { ordinal } ->
+    `Assoc [ "kind", `String "lane_fallback"; "ordinal", `Int ordinal ]
+;;
+
+let context_attempt_to_yojson = function
+  | Initial_context { capacity_bytes } ->
+    `Assoc
+      [ "kind", `String "initial_context"; "capacity_bytes", `Int capacity_bytes ]
+  | Context_shrink { ordinal; capacity_bytes } ->
+    `Assoc
+      [ "kind", `String "context_shrink"
+      ; "ordinal", `Int ordinal
+      ; "capacity_bytes", `Int capacity_bytes
+      ]
+;;
+
+let thinking_attempt_to_yojson = function
+  | Runtime_thinking_policy -> `String "runtime_policy"
+  | Force_thinking -> `String "force_thinking"
+  | Force_no_thinking -> `String "force_no_thinking"
+;;
+
+let identity_json
+      ~keeper_name
+      ~trace_id
+      ~keeper_turn_id
+      ~runtime_id
+      ~candidate_attempt
+      ~context_attempt
+      ~thinking_attempt
+  =
+  `Assoc
+    [ "schema_version", `Int 1
+    ; "keeper_name", `String keeper_name
+    ; "trace_id", `String trace_id
+    ; "keeper_turn_id", `Int keeper_turn_id
+    ; "runtime_id", `String runtime_id
+    ; "candidate_attempt", candidate_attempt_to_yojson candidate_attempt
+    ; "context_attempt", context_attempt_to_yojson context_attempt
+    ; "thinking_attempt", thinking_attempt_to_yojson thinking_attempt
+    ]
+;;
+
+let create
+      ~keeper_name
+      ~trace_id
+      ~keeper_turn_id
+      ~runtime_id
+      ~candidate_index
+      ~context_shrink_attempt
+      ~context_capacity_bytes
+      ~thinking_override
+  =
+  if not (is_portable_name keeper_name)
+  then Error (Invalid_keeper_name (bounded_preview keeper_name))
+  else if not (is_trace_id trace_id)
+  then Error (Invalid_trace_id (bounded_preview trace_id))
+  else if not (is_portable_name runtime_id)
+  then Error (Invalid_runtime_id (bounded_preview runtime_id))
+  else if keeper_turn_id <= 0
+  then Error (Non_positive_keeper_turn_id keeper_turn_id)
+  else if candidate_index < 0
+  then Error (Negative_candidate_attempt candidate_index)
+  else if context_shrink_attempt < 0
+  then Error (Negative_context_shrink_attempt context_shrink_attempt)
+  else if context_capacity_bytes <= 0
+  then Error (Non_positive_context_capacity context_capacity_bytes)
+  else
+    let candidate_attempt =
+      if candidate_index = 0
+      then Lane_head
+      else Lane_fallback { ordinal = candidate_index }
+    in
+    let context_attempt =
+      if context_shrink_attempt = 0
+      then Initial_context { capacity_bytes = context_capacity_bytes }
+      else
+        Context_shrink
+          { ordinal = context_shrink_attempt
+          ; capacity_bytes = context_capacity_bytes
+          }
+    in
+    let thinking_attempt =
+      match thinking_override with
+      | None -> Runtime_thinking_policy
+      | Some true -> Force_thinking
+      | Some false -> Force_no_thinking
+    in
+    let canonical =
+      identity_json
+        ~keeper_name
+        ~trace_id
+        ~keeper_turn_id
+        ~runtime_id
+        ~candidate_attempt
+        ~context_attempt
+        ~thinking_attempt
+      |> Yojson.Safe.to_string
+    in
+    let operation_id =
+      "keeper-agent-core-v1-"
+      ^ Digestif.SHA256.(digest_string canonical |> to_hex)
+    in
+    Ok
+      { keeper_name
+      ; trace_id
+      ; keeper_turn_id
+      ; runtime_id
+      ; candidate_attempt
+      ; context_attempt
+      ; thinking_attempt
+      ; operation_id
+      }
+;;
+
+let operation_id operation = operation.operation_id
+let operation_id_to_string operation_id = operation_id
+
+let to_yojson operation =
+  identity_json
+    ~keeper_name:operation.keeper_name
+    ~trace_id:operation.trace_id
+    ~keeper_turn_id:operation.keeper_turn_id
+    ~runtime_id:operation.runtime_id
+    ~candidate_attempt:operation.candidate_attempt
+    ~context_attempt:operation.context_attempt
+    ~thinking_attempt:operation.thinking_attempt
+;;
+
+let error_to_string = function
+  | Invalid_keeper_name value ->
+    Printf.sprintf "invalid keeper name %S" value
+  | Invalid_trace_id value ->
+    Printf.sprintf "invalid trace id %S" value
+  | Invalid_runtime_id value ->
+    Printf.sprintf "invalid runtime id %S" value
+  | Non_positive_keeper_turn_id value ->
+    Printf.sprintf "keeper turn id must be positive, received %d" value
+  | Negative_candidate_attempt value ->
+    Printf.sprintf "runtime candidate index must be non-negative, received %d" value
+  | Negative_context_shrink_attempt value ->
+    Printf.sprintf "context shrink attempt must be non-negative, received %d" value
+  | Non_positive_context_capacity value ->
+    Printf.sprintf "context capacity must be positive, received %d" value
+;;

--- a/lib/keeper_runtime/keeper_agent_core_execution_identity.mli
+++ b/lib/keeper_runtime/keeper_agent_core_execution_identity.mli
@@ -1,0 +1,51 @@
+(** Pure, durable identity for one Keeper Agent Core API call.
+
+    Retry dimensions are closed sums rather than caller-authored labels.  The
+    resulting identifier is safe for use as a single path component and stays
+    stable across a process restart: Keeper generation is deliberately not an
+    identity field because a crash may advance it while resuming the same
+    durable turn. *)
+
+type candidate_attempt =
+  | Lane_head
+  | Lane_fallback of { ordinal : int }
+
+type context_attempt =
+  | Initial_context of { capacity_bytes : int }
+  | Context_shrink of
+      { ordinal : int
+      ; capacity_bytes : int
+      }
+
+type thinking_attempt =
+  | Runtime_thinking_policy
+  | Force_thinking
+  | Force_no_thinking
+
+type error =
+  | Invalid_keeper_name of string
+  | Invalid_trace_id of string
+  | Invalid_runtime_id of string
+  | Non_positive_keeper_turn_id of int
+  | Negative_candidate_attempt of int
+  | Negative_context_shrink_attempt of int
+  | Non_positive_context_capacity of int
+
+type t
+type operation_id = private string
+
+val create
+  :  keeper_name:string
+  -> trace_id:string
+  -> keeper_turn_id:int
+  -> runtime_id:string
+  -> candidate_index:int
+  -> context_shrink_attempt:int
+  -> context_capacity_bytes:int
+  -> thinking_override:bool option
+  -> (t, error) result
+
+val operation_id : t -> operation_id
+val operation_id_to_string : operation_id -> string
+val to_yojson : t -> Yojson.Safe.t
+val error_to_string : error -> string

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -253,6 +253,7 @@ normal_targets=(
   @test/runtest-test_runtime_per_keeper_routing
   @test/runtest-test_runtime_agent_execution_store_source
   @test/runtest-test_runtime_agent_execution_owner_source
+  @test/runtest-test_keeper_agent_core_execution_identity
   @test/runtest-test_ide_bridge
   @test/runtest-test_dashboard_workspace
   @test/runtest-test_host_fd_pressure_poller

--- a/test/dune
+++ b/test/dune
@@ -1953,6 +1953,7 @@
 
 (include stanzas/test_runtime_agent_execution_store_source.inc)
 (include stanzas/test_runtime_agent_execution_owner_source.inc)
+(include stanzas/test_keeper_agent_core_execution_identity.inc)
 
 
 (include stanzas/test_runtime_model_temperature_toml.inc)

--- a/test/stanzas/test_keeper_agent_core_execution_identity.inc
+++ b/test/stanzas/test_keeper_agent_core_execution_identity.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_agent_core_execution_identity)
+ (modules test_keeper_agent_core_execution_identity)
+ (libraries masc.keeper_runtime yojson))

--- a/test/test_keeper_agent_core_execution_identity.ml
+++ b/test/test_keeper_agent_core_execution_identity.ml
@@ -1,0 +1,84 @@
+module Identity = Keeper_agent_core_execution_identity
+
+let expect_ok = function
+  | Ok value -> value
+  | Error error -> failwith (Identity.error_to_string error)
+;;
+
+let operation
+      ?(candidate_index = 0)
+      ?(context_shrink_attempt = 0)
+      ?(context_capacity_bytes = 4096)
+      ?thinking_override
+      ()
+  =
+  Identity.create
+    ~keeper_name:"sangsu"
+    ~trace_id:"trace-keeper-1"
+    ~keeper_turn_id:42
+    ~runtime_id:"glm.coding-plan"
+    ~candidate_index
+    ~context_shrink_attempt
+    ~context_capacity_bytes
+    ~thinking_override
+  |> expect_ok
+;;
+
+let id operation =
+  operation |> Identity.operation_id |> Identity.operation_id_to_string
+;;
+
+let assert_distinct label left right =
+  if String.equal (id left) (id right)
+  then failwith (label ^ " did not change the durable operation id")
+;;
+
+let contains haystack needle =
+  let haystack_length = String.length haystack in
+  let needle_length = String.length needle in
+  let rec loop offset =
+    if offset + needle_length > haystack_length
+    then false
+    else if String.sub haystack offset needle_length = needle
+    then true
+    else loop (offset + 1)
+  in
+  needle_length = 0 || loop 0
+;;
+
+let () =
+  let base = operation () in
+  if not (String.equal (id base) (id (operation ())))
+  then failwith "identical typed inputs produced unstable operation ids";
+  assert_distinct "outer candidate attempt" base (operation ~candidate_index:1 ());
+  assert_distinct
+    "context shrink attempt"
+    base
+    (operation ~context_shrink_attempt:1 ~context_capacity_bytes:2048 ());
+  assert_distinct
+    "forced no-thinking attempt"
+    base
+    (operation ~thinking_override:false ());
+  assert_distinct
+    "forced thinking attempt"
+    base
+    (operation ~thinking_override:true ());
+  (match
+     Identity.create
+       ~keeper_name:"sangsu"
+       ~trace_id:"trace-keeper-1"
+       ~keeper_turn_id:42
+       ~runtime_id:"glm.coding-plan"
+       ~candidate_index:(-1)
+       ~context_shrink_attempt:0
+       ~context_capacity_bytes:4096
+       ~thinking_override:None
+   with
+   | Error (Identity.Negative_candidate_attempt (-1)) -> ()
+  | Error error -> failwith ("wrong validation error: " ^ Identity.error_to_string error)
+  | Ok _ -> failwith "negative candidate attempt was accepted");
+  let json = Identity.to_yojson base |> Yojson.Safe.to_string in
+  if contains json "generation"
+  then failwith "generation must not enter crash-stable execution identity";
+  print_endline "test_keeper_agent_core_execution_identity: OK"
+;;


### PR DESCRIPTION
## Summary

- model the runtime candidate, context retry, and thinking-policy axes as closed sum types
- derive a deterministic operation ID from canonical typed metadata
- keep process generation out of the durable identity so crash resume can recover the same keeper turn operation

## Stack

- Base: #28554 (`agent/keeper-execution-store-owner`)
- This is the first child in the execution locator lifecycle stack.
- Merge order: #28554, this PR, then the lifecycle and dispatch children.

## Verification

- `ocamlformat --check` on changed OCaml files
- `ocamlc -stop-after parsing` on changed OCaml files
- direct compiled identity unit test: PASS
- focused execution-owner source ratchet: PASS
- CI target audit: 301 targets declared; 563 unwired suites at existing baseline
- `git diff --check` and conflict-marker scan: PASS

Local Dune was intentionally not run. GitHub CI remains unverified at publication time.

## Scope boundary

This PR introduces identity only. It does not persist locators, dispatch stores, or remove Raw_trace/Event_bus/Durable_event writers.