### PR TITLE
feat(keeper): bind execution stores per API call

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -926,6 +926,9 @@ let run_turn
                              ~site:"runtime_runtime"
                              config
                              manifest)
+                      ~execution_store_factory:
+                        (Keeper_agent_core_execution_store.current_owner_factory
+                           ~base_path:config.base_path)
                       ?deferred_runtime_lane
                       ~on_runtime_retry_deferred:record_runtime_retry_deferred
                       ?on_deferred_runtime_consumed

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -249,8 +249,8 @@ let context_compaction_id ctx ~source =
     ctx.manifest_trace_id (turn_label ctx) source
 
 let clock_refs_for_context ctx ~event ?agent_core_turn_count ?elapsed_ms
-    ?event_bus_correlation_id ?event_bus_run_id ?parent_event_id ?caused_by
-    ?logical_seq ?compaction_source () =
+    ?provider_attempt_id ?event_bus_correlation_id ?event_bus_run_id
+    ?parent_event_id ?caused_by ?logical_seq ?compaction_source () =
   let tool_batch_id =
     match event with
     | Provider_lane_resolved ->
@@ -274,7 +274,7 @@ let clock_refs_for_context ctx ~event ?agent_core_turn_count ?elapsed_ms
   in
   clock_refs ~edge_id:(context_edge_id ctx event)
     ~lane:(clock_lane_of_event event) ~source_clock:(source_clock_of_event event)
-    ?elapsed_ms ?tool_batch_id
+    ?elapsed_ms ?provider_attempt_id ?tool_batch_id
     ?checkpoint_id ?compaction_id ?compaction_source
     ?event_bus_correlation_id ?event_bus_run_id ?parent_event_id ?caused_by
     ?logical_seq ()

--- a/lib/keeper/keeper_runtime_manifest.mli
+++ b/lib/keeper/keeper_runtime_manifest.mli
@@ -116,6 +116,7 @@ val clock_refs_for_context :
   event:event_kind ->
   ?agent_core_turn_count:int ->
   ?elapsed_ms:int ->
+  ?provider_attempt_id:string ->
   ?event_bus_correlation_id:string ->
   ?event_bus_run_id:string ->
   ?parent_event_id:string ->

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -538,6 +538,7 @@ let run_named
     ?on_request_wire_observation
     ?runtime_manifest_context
     ?runtime_manifest_append
+    ?execution_store_factory
     ?deferred_runtime_lane
     ?on_runtime_retry_deferred
     ?on_deferred_runtime_consumed
@@ -834,7 +835,7 @@ let run_named
       | Resolved_runtime _ -> true
       | Missing_runtime _ -> false)
     ~emit_runtime_manifest
-    ~run_attempt:(fun ~idx:_ ~runtime_id:attempt_runtime_id candidate ->
+    ~run_attempt:(fun ~idx:runtime_candidate_index ~runtime_id:attempt_runtime_id candidate ->
       match candidate with
       | Missing_runtime runtime_id ->
         Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
@@ -1108,6 +1109,8 @@ let run_named
           let try_provider_ctx : Keeper_turn_driver_try_provider.try_provider_ctx =
             { runtime_id = attempt_runtime_id
             ; error_runtime_id
+            ; runtime_candidate_index
+            ; context_shrink_attempt = 0
             ; max_request_body_bytes
             ; (* #27320: the first attempt's windowing budget starts at the
                  full declared cap; [run_try_provider_with_context_overflow_shrink]
@@ -1188,6 +1191,7 @@ let run_named
             ; event_bus
             ; runtime_manifest_context
             ; runtime_manifest_append
+            ; execution_store_factory
             ; turn_start
             ; seq_ref
             }

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -134,6 +134,7 @@ val run_named :
      unit) ->
   ?runtime_manifest_context:Keeper_runtime_manifest.turn_context ->
   ?runtime_manifest_append:(Keeper_runtime_manifest.t -> unit) ->
+  ?execution_store_factory:Keeper_agent_core_execution_store.factory ->
   ?deferred_runtime_lane:deferred_runtime_lane ->
   ?on_runtime_retry_deferred:(deferred_runtime_lane -> unit) ->
   ?on_deferred_runtime_consumed:(unit -> unit) ->

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -38,6 +38,8 @@ type try_provider_ctx =
   { (* Runtime identity *)
     runtime_id : string
   ; error_runtime_id : string
+  ; runtime_candidate_index : int
+  ; context_shrink_attempt : int
   ; max_request_body_bytes : int
   ; (* #27320: the model-input windowing budget consulted by
        [budgeted_model_input_projection]. Starts at [max_request_body_bytes]
@@ -134,6 +136,7 @@ type try_provider_ctx =
     event_bus : Agent_core.Event_bus.t option
   ; runtime_manifest_context : Keeper_runtime_manifest.turn_context option
   ; runtime_manifest_append : (Keeper_runtime_manifest.t -> unit) option
+  ; execution_store_factory : Keeper_agent_core_execution_store.factory option
   ; turn_start : Mtime.t
   ; seq_ref : int ref
   }
@@ -142,6 +145,7 @@ let emit_runtime_manifest
       (ctx : try_provider_ctx)
       ?status
       ?decision
+      ?provider_attempt_id
       event
   =
   match ctx.runtime_manifest_context, ctx.runtime_manifest_append with
@@ -172,7 +176,7 @@ let emit_runtime_manifest
         (Keeper_runtime_manifest.with_clock_refs
            ~clock_refs:
              (Keeper_runtime_manifest.clock_refs_for_context manifest_ctx ~event
-                ?elapsed_ms ~logical_seq:!(ctx.seq_ref) ())
+                ?elapsed_ms ?provider_attempt_id ~logical_seq:!(ctx.seq_ref) ())
            decision)
     in
     Keeper_runtime_manifest.make_for_context manifest_ctx ~event
@@ -598,6 +602,62 @@ let budgeted_model_input_projection (ctx : try_provider_ctx)
        | Some inner -> inner windowed)
 ;;
 
+let execution_operation
+      (ctx : try_provider_ctx)
+      ~enable_thinking_override
+  =
+  match ctx.runtime_manifest_context with
+  | None ->
+    Error
+      (Agent_core.Error.Internal
+         "Keeper Agent Core execution store requires a durable turn context")
+  | Some
+      { Keeper_runtime_manifest.manifest_keeper_name
+      ; manifest_trace_id
+      ; manifest_keeper_turn_id = None
+      ; _
+      } ->
+    Error
+      (Agent_core.Error.Internal
+         (Printf.sprintf
+            "Keeper Agent Core execution store requires a durable turn id (keeper=%s trace=%s)"
+            manifest_keeper_name
+            manifest_trace_id))
+  | Some
+      { Keeper_runtime_manifest.manifest_keeper_name
+      ; manifest_trace_id
+      ; manifest_keeper_turn_id = Some keeper_turn_id
+      ; _
+      } ->
+    Keeper_agent_core_execution_identity.create
+      ~keeper_name:manifest_keeper_name
+      ~trace_id:manifest_trace_id
+      ~keeper_turn_id
+      ~runtime_id:ctx.runtime_id
+      ~candidate_index:ctx.runtime_candidate_index
+      ~context_shrink_attempt:ctx.context_shrink_attempt
+      ~context_capacity_bytes:ctx.model_input_capacity_bytes
+      ~thinking_override:enable_thinking_override
+    |> Result.map_error (fun error ->
+      Agent_core.Error.Internal
+        ("invalid Keeper Agent Core execution identity: "
+         ^ Keeper_agent_core_execution_identity.error_to_string error))
+;;
+
+let execution_scope_decision operation prepared =
+  `Assoc
+    [ ( "operation_id"
+      , `String
+          (Keeper_agent_core_execution_identity.operation_id_to_string
+             prepared.Keeper_agent_core_execution_store.operation_id) )
+    ; ( "execution_mode"
+      , `String
+          (Keeper_agent_core_execution_store.execution_mode_to_string prepared.mode)
+      )
+    ; "operation", Keeper_agent_core_execution_identity.to_yojson operation
+    ]
+;;
+
 let run_try_provider
       (ctx : try_provider_ctx)
       ?enable_thinking_override
@@ -713,31 +773,84 @@ let run_try_provider
       Eio.Switch.run (fun attempt_sw ->
         let run_fn () =
           Eio_guard.check_if_ready ();
-          match ctx.goal_blocks with
-          | Some blocks ->
-              Runtime_agent.run_blocks
-                ~sw:attempt_sw
-                ~net:ctx.net
-                ~config
-                ?agent_core_checkpoint:ctx.agent_core_checkpoint
-                ?on_event:ctx.on_event
-                ?on_yield:ctx.on_yield
-                ?on_resume:ctx.on_resume
-                ~agent_ref:local_agent_ref
-                ?cooperative_yield_probe:ctx.cooperative_yield_probe
-                blocks
-          | None ->
-              Runtime_agent.run
-                ~sw:attempt_sw
-                ~net:ctx.net
-                ~config
-                ?agent_core_checkpoint:ctx.agent_core_checkpoint
-                ?on_event:ctx.on_event
-                ?on_yield:ctx.on_yield
-                ?on_resume:ctx.on_resume
-                ~agent_ref:local_agent_ref
-                ?cooperative_yield_probe:ctx.cooperative_yield_probe
-                ctx.goal
+          let prepared_execution =
+            match ctx.execution_store_factory with
+            | None -> Ok None
+            | Some factory ->
+              let* operation =
+                execution_operation ctx ~enable_thinking_override
+              in
+              (match factory operation with
+               | Ok prepared -> Ok (Some (operation, prepared))
+               | Error error ->
+                 Error
+                   (Keeper_agent_core_execution_store.prepare_error_to_core_error
+                      error))
+          in
+          match prepared_execution with
+          | Error _ as error -> error
+          | Ok prepared_execution ->
+            let execution_store =
+              Option.map
+                (fun (_, prepared) -> prepared.Keeper_agent_core_execution_store.execution_store)
+                prepared_execution
+            in
+            Option.iter
+              (fun (operation, prepared) ->
+                 let provider_attempt_id =
+                   Keeper_agent_core_execution_identity.operation_id_to_string
+                     prepared.Keeper_agent_core_execution_store.operation_id
+                 in
+                 emit_runtime_manifest
+                   ctx
+                   ~status:"started"
+                   ~decision:(execution_scope_decision operation prepared)
+                   ~provider_attempt_id
+                   Keeper_runtime_manifest.Provider_attempt_started)
+              prepared_execution;
+            let result =
+              match ctx.goal_blocks with
+              | Some blocks ->
+                Runtime_agent.run_blocks
+                  ~sw:attempt_sw
+                  ~net:ctx.net
+                  ~config
+                  ?agent_core_checkpoint:ctx.agent_core_checkpoint
+                  ?on_event:ctx.on_event
+                  ?on_yield:ctx.on_yield
+                  ?on_resume:ctx.on_resume
+                  ?execution_store
+                  ~agent_ref:local_agent_ref
+                  ?cooperative_yield_probe:ctx.cooperative_yield_probe
+                  blocks
+              | None ->
+                Runtime_agent.run
+                  ~sw:attempt_sw
+                  ~net:ctx.net
+                  ~config
+                  ?agent_core_checkpoint:ctx.agent_core_checkpoint
+                  ?on_event:ctx.on_event
+                  ?on_yield:ctx.on_yield
+                  ?on_resume:ctx.on_resume
+                  ?execution_store
+                  ~agent_ref:local_agent_ref
+                  ?cooperative_yield_probe:ctx.cooperative_yield_probe
+                  ctx.goal
+            in
+            Option.iter
+              (fun (operation, prepared) ->
+                 let provider_attempt_id =
+                   Keeper_agent_core_execution_identity.operation_id_to_string
+                     prepared.Keeper_agent_core_execution_store.operation_id
+                 in
+                 emit_runtime_manifest
+                   ctx
+                   ~status:(match result with Ok _ -> "completed" | Error _ -> "failed")
+                   ~decision:(execution_scope_decision operation prepared)
+                   ~provider_attempt_id
+                   Keeper_runtime_manifest.Provider_attempt_finished)
+              prepared_execution;
+            result
         in
         run_fn ())
     in
@@ -952,6 +1065,7 @@ let run_try_provider_with_context_overflow_shrink
   in
   let checkpoint_after = ref None in
   let success_sample = ref None in
+  let context_shrink_attempt = ref 0 in
   let result =
     context_overflow_shrink_sequence
       ~starting_capacity_bytes
@@ -963,6 +1077,7 @@ let run_try_provider_with_context_overflow_shrink
           ~runtime_id:ctx.runtime_id
           ~capacity_bytes)
       ~on_shrink_retry:(fun ~shrink_attempt ~previous_capacity_bytes ~capacity_bytes ->
+        context_shrink_attempt := shrink_attempt;
         emit_context_overflow_shrink_manifest
           ctx
           ~shrink_attempt
@@ -971,7 +1086,10 @@ let run_try_provider_with_context_overflow_shrink
       ~attempt:(fun ~capacity_bytes ->
         let attempt_result, attempt_checkpoint_after, attempt_success_sample =
           run_try_provider
-            { ctx with model_input_capacity_bytes = capacity_bytes }
+            { ctx with
+              model_input_capacity_bytes = capacity_bytes
+            ; context_shrink_attempt = !context_shrink_attempt
+            }
             ?enable_thinking_override
             candidate
         in

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -16,6 +16,8 @@ type provider_progress_sample =
 type try_provider_ctx =
   { runtime_id : string
   ; error_runtime_id : string
+  ; runtime_candidate_index : int
+  ; context_shrink_attempt : int
   ; max_request_body_bytes : int
   ; model_input_capacity_bytes : int
   ; base_path : string
@@ -72,6 +74,7 @@ type try_provider_ctx =
   ; event_bus : Agent_core.Event_bus.t option
   ; runtime_manifest_context : Keeper_runtime_manifest.turn_context option
   ; runtime_manifest_append : (Keeper_runtime_manifest.t -> unit) option
+  ; execution_store_factory : Keeper_agent_core_execution_store.factory option
   ; turn_start : Mtime.t
   ; seq_ref : int ref
   }

--- a/test/test_runtime_agent_execution_owner_source.ml
+++ b/test/test_runtime_agent_execution_owner_source.ml
@@ -74,6 +74,11 @@ let () =
   in
   let store = resolve_source "lib/keeper/keeper_agent_core_execution_store.ml" in
   let bootstrap = resolve_source "lib/server/server_runtime_bootstrap.ml" in
+  let keeper = resolve_source "lib/keeper/keeper_agent_run.ml" in
+  let driver = resolve_source "lib/keeper/keeper_turn_driver.ml" in
+  let provider =
+    resolve_source "lib/keeper/keeper_turn_driver_try_provider.ml"
+  in
   assert_contains
     ~label:"typed creation"
     owner
@@ -114,6 +119,19 @@ let () =
     ~label:"unknown effect keeps locator"
     store
     "Agent_core.Agent.Operator_repair_required Agent_core.Agent.Effect_outcome_unknown -> Ok ()";
+  assert_contains
+    ~label:"candidate ordinal ingress"
+    driver
+    "~run_attempt:(fun ~idx:runtime_candidate_index ~runtime_id:attempt_runtime_id candidate";
+  assert_contains
+    ~label:"production factory"
+    keeper
+    "~execution_store_factory: (Keeper_agent_core_execution_store.current_owner_factory ~base_path:config.base_path)";
+  assert_contains
+    ~label:"API boundary factory"
+    provider
+    "let run_fn () = Eio_guard.check_if_ready (); let prepared_execution =";
+  assert_contains ~label:"execution-store forwarding" provider "?execution_store";
   List.iter
     (fun relative ->
        assert_not_contains


### PR DESCRIPTION
## Summary

- construct the durable operation identity at the Runtime_agent API-call boundary
- carry exact runtime-candidate and context-shrink ordinals instead of inferring them from strings or capacities
- prepare a fresh or crash-resumed Execution_store for every Agent Core API call and forward it to both block and stream paths
- project the stable operation ID, execution mode, and typed operation metadata into provider-attempt manifest events

## Stack

- Base: #28568 (`agent/keeper-execution-store-lifecycle`)
- Depends transitively on #28567, #28554, and #28546.
- Merge order: #28554, #28567, #28568, then this PR.

## Verification

- `ocamlformat --check` on changed OCaml files
- `ocamlc -stop-after parsing` on changed OCaml files
- direct compiled identity unit test: PASS
- isolated lifecycle interface/type check: PASS
- focused production-dispatch source ratchet: PASS
- CI target audit: 301 targets declared; 563 unwired suites at existing baseline
- `git diff --check` and conflict-marker scan: PASS

Local Dune was intentionally not run. GitHub CI remains unverified at publication time.

## Scope boundary

Only the production Keeper Agent Core path supplies the lifecycle factory. This PR does not add startup inventory/operator repair, terminal retention policy, or remove Raw_trace/Event_bus/Durable_event writers.