### PR TITLE
fix(keeper): wire sandbox routing receipts

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -621,6 +621,7 @@ let run_turn
     Keeper_run_tools.prepare_agent_setup
       ~config
       ~meta
+      ~profile_defaults
       ~publication_recovery
       ?continuation_channel
       ?on_tool_result_ready
@@ -731,6 +732,9 @@ let run_turn
     in
     let receipt_response_text_present_ref =
       s.Keeper_run_tools.receipt_response_text_present_ref
+    in
+    let sandbox_routing_for_receipt =
+      s.Keeper_run_tools.sandbox_routing_for_receipt
     in
     let request_evidence_ref = ref None in
     let current_request_input_messages_ref = ref None in
@@ -1170,6 +1174,17 @@ let run_turn
          | Some (_, reason) -> Some reason
          | None -> fallback_reason
        in
+       let sandbox_routing, receipt_turn_result =
+         match sandbox_routing_for_receipt () with
+         | Ok evidence -> Some evidence, turn_result
+         | Error refusal ->
+           let detail = Keeper_sandbox_factory.routing_refusal_to_string refusal in
+           ( Keeper_sandbox_factory.routing_refusal_evidence refusal
+           , Error
+               (Agent_core.Error.Config
+                  (Agent_core.Error.InvalidConfig
+                     { field = "keeper.sandbox_routing.receipt"; detail })) )
+       in
        let settled_runtime_id, settled_max_context =
          match turn_result with
          | Ok result -> result.runtime_id, result.max_context
@@ -1185,12 +1200,13 @@ let run_turn
            ~keeper_visible_sandbox_root
            ~receipt_started_at
            ~runtime_manifest_context
+           ~sandbox_routing
            ~acc
            ~degraded_retry_applied
            ~degraded_retry_runtime:receipt_degraded_retry_runtime
            ~fallback_reason:receipt_fallback_reason
            ~runtime_rotation_attempts
-           ~turn_result
+           ~turn_result:receipt_turn_result
            ~receipt_turn_count_ref
            ~receipt_stop_reason_ref
            ~receipt_runtime_observation_ref

--- a/lib/keeper/keeper_agent_run_receipt.ml
+++ b/lib/keeper/keeper_agent_run_receipt.ml
@@ -50,6 +50,7 @@ let finalize
     ~keeper_visible_sandbox_root
     ~receipt_started_at
     ~runtime_manifest_context
+    ~sandbox_routing
     ~(acc : Keeper_run_tools.hook_accumulator)
     ~degraded_retry_applied
     ~degraded_retry_runtime
@@ -148,6 +149,7 @@ let finalize
     ; sandbox_kind = Keeper_execution_receipt.sandbox_kind_of_meta meta
     ; sandbox_root = Some keeper_visible_sandbox_root
     ; network_mode = meta.network_mode
+    ; sandbox_routing
     ; runtime_id
     ; runtime_selected_model =
         Option.bind runtime_observation (fun obs -> obs.selected_model)

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -305,6 +305,7 @@ let to_json_with_operator_disposition
       ~sandbox_profile:(Keeper_types_profile_sandbox.sandbox_profile_to_string receipt.sandbox_kind)
       ?sandbox_root:receipt.sandbox_root
       ~network_mode:(Keeper_types_profile_sandbox.network_mode_to_string receipt.network_mode)
+      ?sandbox_routing:receipt.sandbox_routing
       ~runtime_profile:(receipt.runtime_id)
       ()
   in
@@ -359,6 +360,11 @@ let to_json_with_operator_disposition
           ; ( "sandbox_root", string_opt_json receipt.sandbox_root )
           ; ( "network_mode"
             , `String (Keeper_types_profile_sandbox.network_mode_to_string receipt.network_mode) )
+          ; ( "routing"
+            , match receipt.sandbox_routing with
+              | Some evidence ->
+                Keeper_runtime_contract.Sandbox_routing.descriptor_to_yojson evidence
+              | None -> `Null )
           ] )
     ; ( "runtime"
       , `Assoc

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -139,6 +139,7 @@ type t =
   ; sandbox_kind : Keeper_types_profile_sandbox.sandbox_profile
   ; sandbox_root : string option
   ; network_mode : Keeper_types_profile_sandbox.network_mode
+  ; sandbox_routing : Keeper_runtime_contract.Sandbox_routing.evidence option
   ; runtime_id : string
   ; runtime_selected_model : string option
   ; runtime_attempt_count : int

--- a/lib/keeper/keeper_execution_receipt_types.ml
+++ b/lib/keeper/keeper_execution_receipt_types.ml
@@ -167,6 +167,7 @@ type t =
   ; sandbox_kind : Keeper_types_profile_sandbox.sandbox_profile
   ; sandbox_root : string option
   ; network_mode : Keeper_types_profile_sandbox.network_mode
+  ; sandbox_routing : Keeper_runtime_contract.Sandbox_routing.evidence option
   ; runtime_id : string
   ; runtime_selected_model : string option
   ; runtime_attempt_count : int

--- a/lib/keeper/keeper_execution_receipt_types.mli
+++ b/lib/keeper/keeper_execution_receipt_types.mli
@@ -66,6 +66,7 @@ type t = {
   sandbox_kind : Keeper_types_profile_sandbox.sandbox_profile;
   sandbox_root : string option;
   network_mode : Keeper_types_profile_sandbox.network_mode;
+  sandbox_routing : Keeper_runtime_contract.Sandbox_routing.evidence option;
   runtime_id : string;
   runtime_selected_model : string option;
   runtime_attempt_count : int;

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -514,26 +514,18 @@ let effective_meta_of_profile_defaults
     (meta : keeper_meta) : (keeper_meta, string) result =
   let open Keeper_types_profile in
   let has_profile_source = Option.is_some defaults.manifest_path in
-  let target_sandbox_profile =
-    match defaults.sandbox_profile, defaults.manifest_path with
-    | Some profile, _ -> Ok profile
-    | None, None -> Ok meta.sandbox_profile
-    | None, Some _ ->
-      Error
-        (missing_required_sandbox_profile_error
-           ~keeper_name:meta.name
-           defaults)
-  in
-  match target_sandbox_profile with
-  | Error _ as err -> err
-  | Ok sandbox_profile ->
-      let default_network_mode =
-        if has_profile_source then default_network_mode_for_profile sandbox_profile
-        else meta.network_mode
-      in
-      let network_mode =
-        apply_profile_default defaults.network_mode default_network_mode
-      in
+  match
+    resolve_sandbox_route
+      ~fallback_sandbox_profile:meta.sandbox_profile
+      ~fallback_network_mode:meta.network_mode
+      defaults
+  with
+  | Sandbox_profile_missing _ ->
+    Error
+      (missing_required_sandbox_profile_error
+         ~keeper_name:meta.name
+         defaults)
+  | Sandbox_route { sandbox_profile; network_mode } ->
       Ok
         { meta with
           proactive =

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -52,6 +52,11 @@ let freeze = Keeper_run_tools_hook_accumulator.freeze
 type agent_setup = Keeper_run_tools_hooks.agent_setup =
   { tools : Agent_core.Tool.t list
   ; cleanup : unit -> unit
+  ; sandbox_routing_for_receipt :
+      unit ->
+      ( Keeper_runtime_contract.Sandbox_routing.evidence
+      , Keeper_sandbox_factory.routing_refusal )
+      result
   ; terminal_effect_state : unit -> Keeper_tools_agent_core.terminal_effect_state
   ; user_message : string
   ; hooks : Agent_core.Hooks.hooks

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -53,6 +53,11 @@ val freeze : hook_accumulator -> hook_outputs
 type agent_setup =
   { tools : Agent_core.Tool.t list
   ; cleanup : unit -> unit
+  ; sandbox_routing_for_receipt :
+      unit ->
+      ( Keeper_runtime_contract.Sandbox_routing.evidence
+      , Keeper_sandbox_factory.routing_refusal )
+      result
   ; terminal_effect_state : unit -> Keeper_tools_agent_core.terminal_effect_state
   ; user_message : string
   ; hooks : Agent_core.Hooks.hooks
@@ -71,6 +76,7 @@ type agent_setup =
 val prepare_agent_setup
   :  config:Workspace.config
   -> meta:Keeper_meta_contract.keeper_meta
+  -> profile_defaults:Keeper_types_profile.keeper_profile_defaults
   -> publication_recovery:
        Keeper_publication_recovery_availability.turn_context
   -> turn_ctx_cell:Keeper_tool_call_log.turn_ctx_cell

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -13,6 +13,11 @@ type hook_accumulator = Keeper_run_tools_hook_accumulator.hook_accumulator
 type agent_setup =
   { tools : Agent_core.Tool.t list
   ; cleanup : unit -> unit
+  ; sandbox_routing_for_receipt :
+      unit ->
+      ( Keeper_runtime_contract.Sandbox_routing.evidence
+      , Keeper_sandbox_factory.routing_refusal )
+      result
   ; terminal_effect_state : unit -> Keeper_tools_agent_core.terminal_effect_state
   ; user_message : string
   ; hooks : Agent_core.Hooks.hooks
@@ -39,6 +44,11 @@ type ctx =
       turn:int -> tool_list:string list -> lane:turn_lane -> unit
   ; config : Workspace.config
   ; keeper_tools_cleanup : unit -> unit
+  ; sandbox_routing_for_receipt :
+      unit ->
+      ( Keeper_runtime_contract.Sandbox_routing.evidence
+      , Keeper_sandbox_factory.routing_refusal )
+      result
   ; terminal_effect_state : unit -> Keeper_tools_agent_core.terminal_effect_state
   ; keeper_turn_id : int
   ; meta : Keeper_meta_contract.keeper_meta
@@ -171,6 +181,7 @@ let assemble_hooks
       ~base_path:config.Workspace.base_path
   in
   let keeper_tools_cleanup = ctx.keeper_tools_cleanup in
+  let sandbox_routing_for_receipt = ctx.sandbox_routing_for_receipt in
   let terminal_effect_state = ctx.terminal_effect_state in
   let keeper_turn_id = ctx.keeper_turn_id in
   let meta = ctx.meta in
@@ -617,6 +628,7 @@ let assemble_hooks
     Ok
       { tools
       ; cleanup = keeper_tools_cleanup
+      ; sandbox_routing_for_receipt
       ; terminal_effect_state
       ; user_message
       ; hooks

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -100,6 +100,7 @@ let gate_causal_initial
 let prepare_agent_setup
       ~(config : Workspace.config)
       ~(meta : Keeper_meta_contract.keeper_meta)
+      ~(profile_defaults : Keeper_types_profile.keeper_profile_defaults)
       ~(publication_recovery :
           Keeper_publication_recovery_availability.turn_context)
       ~(turn_ctx_cell : Keeper_tool_call_log.turn_ctx_cell)
@@ -161,9 +162,45 @@ let prepare_agent_setup
     ; extra_system_context_size = None
     }
   in
+  let* requested_sandbox_profile, requested_network_mode =
+    match
+      Keeper_types_profile.resolve_sandbox_route
+        ~fallback_sandbox_profile:meta.sandbox_profile
+        ~fallback_network_mode:meta.network_mode
+        profile_defaults
+    with
+    | Keeper_types_profile.Sandbox_route { sandbox_profile; network_mode } ->
+      Ok (sandbox_profile, network_mode)
+    | Keeper_types_profile.Sandbox_profile_missing { manifest_path } ->
+      let detail =
+        Printf.sprintf
+          "keeper %s sandbox request is missing sandbox_profile in %s"
+          meta.name
+          manifest_path
+      in
+      Keeper_turn_helpers.record_pre_dispatch_terminal_observation
+        ~config
+        ~meta
+        ~generation
+        ~runtime_id:runtime_id_string
+        ~outcome:`Error
+        ~terminal_reason_code:"config_error"
+        ~activity_kind:"keeper.sandbox_routing_refused"
+        ~trajectory_outcome:(Trajectory.Failed detail)
+        ~error_kind:(Keeper_execution_receipt.error_kind_of_string "config_error")
+        ~error_message:detail
+        ~keeper_turn_id
+        ();
+      Error
+        (Agent_core.Error.Config
+           (Agent_core.Error.InvalidConfig
+              { field = "keeper.sandbox_profile"; detail }))
+  in
   let
     { Keeper_tools_agent_core.tools = keeper_tools
     ; cleanup = keeper_tools_cleanup
+    ; sandbox_routing_admission
+    ; sandbox_routing_for_receipt
     ; terminal_effect_state
     ; gate_replay_delivery
     }
@@ -176,7 +213,40 @@ let prepare_agent_setup
       ?continuation_channel
       ~gate_context
       ?hitl_resolution
+      ~requested_sandbox_profile
+      ~requested_network_mode
       ()
+  in
+  let* () =
+    match sandbox_routing_admission with
+    | Ok () -> Ok ()
+    | Error refusal ->
+      let detail = Keeper_sandbox_factory.routing_refusal_to_string refusal in
+      (try keeper_tools_cleanup () with
+       | Eio.Cancel.Cancelled _ as exn -> raise exn
+       | exn ->
+         Log.Keeper.error
+           "keeper tool cleanup after sandbox routing refusal raised: %s"
+           (Printexc.to_string exn));
+      Keeper_turn_helpers.record_pre_dispatch_terminal_observation
+        ~config
+        ~meta
+        ~generation
+        ~runtime_id:runtime_id_string
+        ~outcome:`Error
+        ~terminal_reason_code:"config_error"
+        ~activity_kind:"keeper.sandbox_routing_refused"
+        ~trajectory_outcome:(Trajectory.Failed detail)
+        ~error_kind:(Keeper_execution_receipt.error_kind_of_string "config_error")
+        ~error_message:detail
+        ?sandbox_routing:
+          (Keeper_sandbox_factory.routing_refusal_evidence refusal)
+        ~keeper_turn_id
+        ();
+      Error
+        (Agent_core.Error.Config
+           (Agent_core.Error.InvalidConfig
+              { field = "keeper.sandbox_routing"; detail }))
   in
   let replay_delivery =
     Option.map
@@ -386,6 +456,7 @@ let prepare_agent_setup
     ; record_tool_assignment
     ; config
     ; keeper_tools_cleanup
+    ; sandbox_routing_for_receipt
     ; terminal_effect_state
     ; keeper_turn_id
     ; meta

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -195,6 +195,15 @@ module Sandbox_routing = struct
 
   let evidence ~requested ~effective ~receipt = { requested; effective; receipt }
 
+  let verify_effective (Requested requested) effective =
+    match effective with
+    | Resolution_failed { detail } ->
+      Error (Effective_resolution_unavailable { detail })
+    | Resolved effective when not (equal_boundary requested effective) ->
+      Error (Config_effective_mismatch { requested; effective })
+    | Resolved _ -> Ok ()
+  ;;
+
   let verify { requested = Requested requested; effective; receipt } =
     match effective with
     | Resolution_failed { detail } ->

--- a/lib/keeper/keeper_runtime_contract.mli
+++ b/lib/keeper/keeper_runtime_contract.mli
@@ -87,6 +87,11 @@ module Sandbox_routing : sig
   val evidence :
     requested:requested -> effective:effective -> receipt:receipt -> evidence
 
+  val verify_effective : requested -> effective -> (unit, violation) result
+  (** Admit an execution route only when runtime resolution exists and matches
+      the persisted request. Receipt evidence is deliberately checked later,
+      at receipt assembly. *)
+
   val verify : evidence -> (verified, violation) result
   (** Fail closed unless effective resolution exists and all three boundaries
       are identical. No [bool] success flag exists for a caller to combine with

--- a/lib/keeper/keeper_sandbox_factory.ml
+++ b/lib/keeper/keeper_sandbox_factory.ml
@@ -3,26 +3,151 @@ type resolve_result =
   | No_factory
   | Local_profile
 
+module Routing = Keeper_runtime_contract.Sandbox_routing
+
+type routing_admission =
+  { requested : Routing.requested
+  ; effective : Routing.effective
+  }
+
+type routing_refusal =
+  | Invalid_requested_boundary of Routing.invalid_boundary
+  | Invalid_effective_boundary of Routing.invalid_boundary
+  | Admission_violation of
+      { violation : Routing.violation
+      ; evidence : Routing.evidence
+      }
+  | Receipt_violation of
+      { violation : Routing.violation
+      ; evidence : Routing.evidence
+      }
+  | Invalid_receipt_boundary of Routing.invalid_boundary
+  | Invalid_receipt_detail of string
+
 type t = {
   config : Workspace.config;
   meta : Keeper_meta_contract.keeper_meta;
   turn_id : int;
-  default_network_override : Keeper_types_profile_sandbox.network_mode option;
+  effective_profile : Keeper_types_profile_sandbox.sandbox_profile;
+  effective_network : Keeper_types_profile_sandbox.network_mode;
+  routing : (routing_admission, routing_refusal) result;
   cache :
     ((bool * string * string * string), Keeper_turn_sandbox_runtime.t) Hashtbl.t;
   mutex : Eio.Mutex.t;
 }
 
-let create ?default_network_override
+let routing_refusal_to_string = function
+  | Invalid_requested_boundary invalid ->
+    "invalid requested sandbox route: "
+    ^ Routing.invalid_boundary_to_string invalid
+  | Invalid_effective_boundary invalid ->
+    "invalid effective sandbox route: "
+    ^ Routing.invalid_boundary_to_string invalid
+  | Admission_violation { violation; _ }
+  | Receipt_violation { violation; _ } ->
+    Routing.violation_to_string violation
+  | Invalid_receipt_boundary invalid ->
+    "receipt observed an invalid sandbox route: "
+    ^ Routing.invalid_boundary_to_string invalid
+  | Invalid_receipt_detail detail ->
+    "sandbox routing receipt detail is invalid: " ^ detail
+;;
+
+let routing_refusal_evidence = function
+  | Admission_violation { evidence; _ }
+  | Receipt_violation { evidence; _ } ->
+    Some evidence
+  | Invalid_requested_boundary _
+  | Invalid_effective_boundary _
+  | Invalid_receipt_boundary _
+  | Invalid_receipt_detail _ ->
+    None
+;;
+
+let routing_admission_of_routes
+      ~requested_sandbox_profile
+      ~requested_network_mode
+      ~effective_profile
+      ~effective_network
+  =
+  match
+    Routing.requested_of_config
+      ~sandbox_profile:requested_sandbox_profile
+      ~network_mode:requested_network_mode
+  with
+  | Error invalid -> Error (Invalid_requested_boundary invalid)
+  | Ok requested ->
+    (match
+       Routing.effective_resolved
+         ~sandbox_profile:effective_profile
+         ~network_mode:effective_network
+     with
+     | Error invalid -> Error (Invalid_effective_boundary invalid)
+     | Ok effective ->
+       (match Routing.verify_effective requested effective with
+        | Ok () -> Ok { requested; effective }
+        | Error violation ->
+          let receipt =
+            Routing.receipt_unobserved
+              ~detail:"receipt not written because sandbox routing admission failed"
+          in
+          (match receipt with
+           | Ok receipt ->
+             let evidence = Routing.evidence ~requested ~effective ~receipt in
+             Error (Admission_violation { violation; evidence })
+           | Error detail -> Error (Invalid_receipt_detail detail))))
+;;
+
+let create ?default_network_override ?requested_sandbox_profile
+    ?requested_network_mode
     ~(config : Workspace.config) ~(meta : Keeper_meta_contract.keeper_meta) ?(turn_id = 0) () =
+  let effective_profile, declared_network =
+    Keeper_sandbox_runner.effective_sandbox_profile ~meta
+  in
+  let effective_network =
+    Option.value default_network_override ~default:declared_network
+  in
+  let requested_sandbox_profile =
+    Option.value requested_sandbox_profile ~default:meta.sandbox_profile
+  in
+  let requested_network_mode =
+    Option.value requested_network_mode ~default:meta.network_mode
+  in
   {
     config;
     meta;
     turn_id;
-    default_network_override;
+    effective_profile;
+    effective_network;
+    routing =
+      routing_admission_of_routes
+        ~requested_sandbox_profile
+        ~requested_network_mode
+        ~effective_profile
+        ~effective_network;
     cache = Hashtbl.create 4;
     mutex = Eio.Mutex.create ();
   }
+
+let routing_admission t = Result.map (fun _ -> ()) t.routing
+
+let routing_evidence_for_receipt t =
+  match t.routing with
+  | Error _ as error -> error
+  | Ok { requested; effective } ->
+    (match
+       Routing.receipt_observed
+         ~sandbox_profile:t.effective_profile
+         ~network_mode:t.effective_network
+     with
+     | Error invalid -> Error (Invalid_receipt_boundary invalid)
+     | Ok receipt ->
+       let evidence = Routing.evidence ~requested ~effective ~receipt in
+       (match Routing.verify evidence with
+        | Ok _ -> Ok evidence
+        | Error violation ->
+          Error (Receipt_violation { violation; evidence })))
+;;
 
 let with_lock (t : t) f =
   Eio.Mutex.use_rw ~protect:true t.mutex f
@@ -51,13 +176,8 @@ let resolve (t : t) ~cwd =
   with_lock t (fun () ->
     let meta = t.meta in
     let in_playground = in_playground_of_cwd t ~meta ~cwd in
-    let (effective_profile, effective_network) =
-      Keeper_sandbox_runner.effective_sandbox_profile ~meta
-    in
-    let actual_network =
-      Option.value t.default_network_override ~default:effective_network
-    in
-    match effective_profile with
+    let actual_network = t.effective_network in
+    match t.effective_profile with
     | Keeper_types_profile_sandbox.Local -> Local_profile
     | Keeper_types_profile_sandbox.Docker ->
       let host_root =

--- a/lib/keeper/keeper_sandbox_factory.mli
+++ b/lib/keeper/keeper_sandbox_factory.mli
@@ -2,8 +2,8 @@
 
     A single keeper turn may dispatch tool calls from different cwds,
     each implying a different [in_playground] state.  The factory
-    centralizes the {!Keeper_sandbox_runner.effective_sandbox_profile}
-    invariant, evaluates [in_playground] from the call-site [cwd] only for
+    evaluates {!Keeper_sandbox_runner.effective_sandbox_profile} once at
+    construction, evaluates [in_playground] from the call-site [cwd] only for
     runtime workspace reuse, and memoizes one runtime per
     [(in_playground, network_mode)]
     so a Docker container is created at most once per compatible dispatch
@@ -30,22 +30,57 @@ type resolve_result =
 
 type t
 
+type routing_refusal =
+  | Invalid_requested_boundary of
+      Keeper_runtime_contract.Sandbox_routing.invalid_boundary
+  | Invalid_effective_boundary of
+      Keeper_runtime_contract.Sandbox_routing.invalid_boundary
+  | Admission_violation of
+      { violation : Keeper_runtime_contract.Sandbox_routing.violation
+      ; evidence : Keeper_runtime_contract.Sandbox_routing.evidence
+      }
+  | Receipt_violation of
+      { violation : Keeper_runtime_contract.Sandbox_routing.violation
+      ; evidence : Keeper_runtime_contract.Sandbox_routing.evidence
+      }
+  | Invalid_receipt_boundary of
+      Keeper_runtime_contract.Sandbox_routing.invalid_boundary
+  | Invalid_receipt_detail of string
+
+val routing_refusal_to_string : routing_refusal -> string
+val routing_refusal_evidence : routing_refusal -> Keeper_runtime_contract.Sandbox_routing.evidence option
+
 val create :
   ?default_network_override:Keeper_types_profile_sandbox.network_mode ->
+  ?requested_sandbox_profile:Keeper_types_profile_sandbox.sandbox_profile ->
+  ?requested_network_mode:Keeper_types_profile_sandbox.network_mode ->
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->
   ?turn_id:int ->
   unit ->
   t
-(** Create an empty factory.  [default_network_override], when supplied,
-    is applied to every runtime created via {!resolve}. *)
+(** Create an empty factory and freeze both the requested and actual effective
+    route. [requested_*] must come from the persisted keeper profile; callers
+    that omit them use [meta] as both stages. [default_network_override], when
+    supplied, participates in the effective stage and is applied to every
+    runtime created via {!resolve}. *)
+
+val routing_admission : t -> (unit, routing_refusal) result
+(** Typed pre-effect admission. A config/effective mismatch is rejected before
+    any Docker runtime or tool effect can start. *)
+
+val routing_evidence_for_receipt :
+  t ->
+  (Keeper_runtime_contract.Sandbox_routing.evidence, routing_refusal) result
+(** Observe the factory-frozen effective route at receipt assembly. Absence or
+    inconsistency remains a typed refusal; it is never replaced with [meta]. *)
 
 val resolve :
   t ->
   cwd:string ->
   resolve_result
-(** Returns [Runtime runtime] when {!Keeper_sandbox_runner.effective_sandbox_profile}
-    yields [Docker] for the construction meta. [in_playground] is
+(** Returns [Runtime runtime] when the factory-frozen effective route yields
+    [Docker]. [in_playground] is
     derived from [cwd] vs the keeper's playground root for runtime workspace
     reuse only. Memoizes per [(in_playground, network_mode, host_root, image)]
     so subsequent compatible calls reuse the same container without crossing

--- a/lib/keeper/keeper_tools_agent_core.mli
+++ b/lib/keeper/keeper_tools_agent_core.mli
@@ -35,6 +35,13 @@ type gate_replay_delivery =
 type tool_bundle =
   { tools : Agent_core.Tool.t list
   ; cleanup : unit -> unit
+  ; sandbox_routing_admission :
+      (unit, Keeper_sandbox_factory.routing_refusal) result
+  ; sandbox_routing_for_receipt :
+      unit ->
+      ( Keeper_runtime_contract.Sandbox_routing.evidence
+      , Keeper_sandbox_factory.routing_refusal )
+      result
   ; terminal_effect_state : unit -> terminal_effect_state
   ; gate_replay_delivery : gate_replay_delivery option
   }

--- a/lib/keeper/keeper_tools_agent_core_bundle.ml
+++ b/lib/keeper/keeper_tools_agent_core_bundle.ml
@@ -49,16 +49,30 @@ let make_tool_bundle_for_descriptors
       ?continuation_channel
       ?gate_context
       ?hitl_resolution
+      ?requested_sandbox_profile
+      ?requested_network_mode
       ~(descriptors : Keeper_tool_descriptor.t list)
       ()
   : tool_bundle
   =
-  (* PR-3b (#11611 part 1): replace eager [Keeper_turn_sandbox_runtime]
-     instances with a factory.  in_playground/cwd are unknown at
-     turn-start, so the factory defers
-     [Keeper_sandbox_runner.effective_sandbox_profile] resolution until
-     each tool call site that already knows its [cwd]. *)
-  let turn_sandbox_factory = Some (Keeper_sandbox_factory.create ~config ~meta ()) in
+  (* Runtime construction stays lazy because in_playground/cwd are unknown at
+     turn start. Route resolution is different: the factory freezes it now so
+     dispatch and the execution receipt observe the same effective boundary. *)
+  let sandbox_factory =
+    Keeper_sandbox_factory.create
+      ?requested_sandbox_profile
+      ?requested_network_mode
+      ~config
+      ~meta
+      ()
+  in
+  let turn_sandbox_factory = Some sandbox_factory in
+  let sandbox_routing_admission =
+    Keeper_sandbox_factory.routing_admission sandbox_factory
+  in
+  let sandbox_routing_for_receipt () =
+    Keeper_sandbox_factory.routing_evidence_for_receipt sandbox_factory
+  in
   let gate_grant =
     Option.bind hitl_resolution Keeper_gate.cycle_grant_of_resolution
   in
@@ -78,8 +92,9 @@ let make_tool_bundle_for_descriptors
      producer's ordinary Gate behavior instead of inventing another replay
      constraint. *)
   let gate_replay_delivery =
-    match hitl_resolution, gate_grant with
-    | ( Some
+    match sandbox_routing_admission, hitl_resolution, gate_grant with
+    | ( Ok ()
+      , Some
           { Keeper_event_queue.approval_id
           ; decision = Keeper_event_queue.Hitl_approved
           ; _
@@ -125,7 +140,7 @@ let make_tool_bundle_for_descriptors
            approval_id
            (Keeper_gate_replay.outcome_to_string outcome));
       Some Keeper_tools_agent_core.{ approval_id; outcome }
-    | _ -> None
+    | Error _, _, _ | Ok (), _, _ -> None
   in
   let record_gate_result =
     Option.map
@@ -294,6 +309,8 @@ let make_tool_bundle_for_descriptors
   ; cleanup =
       (fun () ->
         Option.iter Keeper_sandbox_factory.cleanup turn_sandbox_factory)
+  ; sandbox_routing_admission
+  ; sandbox_routing_for_receipt
   ; terminal_effect_state = (fun () -> Atomic.get terminal_effect_state)
   ; gate_replay_delivery
   }
@@ -309,6 +326,8 @@ let make_tool_bundle
       ?continuation_channel
       ?gate_context
       ?hitl_resolution
+      ?requested_sandbox_profile
+      ?requested_network_mode
       ()
   =
   make_tool_bundle_for_descriptors
@@ -320,6 +339,8 @@ let make_tool_bundle
     ?continuation_channel
     ?gate_context
     ?hitl_resolution
+    ?requested_sandbox_profile
+    ?requested_network_mode
     ~descriptors:(Keeper_tool_descriptor.model_visible_descriptors ())
     ()
 ;;

--- a/lib/keeper/keeper_tools_agent_core_bundle.mli
+++ b/lib/keeper/keeper_tools_agent_core_bundle.mli
@@ -14,6 +14,8 @@ val make_tool_bundle
   -> ?continuation_channel:Keeper_continuation_channel.t
   -> ?gate_context:Keeper_gate_causal_context.t
   -> ?hitl_resolution:Keeper_event_queue.hitl_resolution
+  -> ?requested_sandbox_profile:Keeper_types_profile_sandbox.sandbox_profile
+  -> ?requested_network_mode:Keeper_types_profile_sandbox.network_mode
   -> unit
   -> Keeper_tools_agent_core.tool_bundle
 

--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -196,6 +196,7 @@ let record_pre_dispatch_terminal_observation
       ?degraded_retry_runtime
       ?fallback_reason
       ?(runtime_rotation_attempts = [])
+      ?sandbox_routing
       ?keeper_turn_id
       ()
   : unit
@@ -234,6 +235,7 @@ let record_pre_dispatch_terminal_observation
     ; sandbox_kind = Keeper_execution_receipt.sandbox_kind_of_meta meta
     ; sandbox_root = Some (Keeper_sandbox.host_root_abs_of_meta ~config meta)
     ; network_mode = meta.network_mode
+    ; sandbox_routing
     ; runtime_id
     ; runtime_selected_model = None
     ; runtime_attempt_count = 0

--- a/lib/keeper/keeper_turn_helpers.mli
+++ b/lib/keeper/keeper_turn_helpers.mli
@@ -78,6 +78,7 @@ val record_pre_dispatch_terminal_observation :
   ?degraded_retry_runtime:string ->
   ?fallback_reason:Keeper_error_classify.degraded_retry_reason ->
   ?runtime_rotation_attempts:Keeper_execution_receipt.runtime_rotation_attempt list ->
+  ?sandbox_routing:Keeper_runtime_contract.Sandbox_routing.evidence ->
   ?keeper_turn_id:int ->
   unit -> unit
 (** Record a terminal observation (receipt + activity graph event) for a

--- a/lib/keeper/keeper_types_profile_defaults.ml
+++ b/lib/keeper/keeper_types_profile_defaults.ml
@@ -52,3 +52,34 @@ let empty_keeper_profile_defaults =
     agent_core_env = [];
   }
 ;;
+
+type sandbox_route_resolution =
+  | Sandbox_route of
+      { sandbox_profile : Keeper_types_profile_sandbox.sandbox_profile
+      ; network_mode : Keeper_types_profile_sandbox.network_mode
+      }
+  | Sandbox_profile_missing of { manifest_path : string }
+
+let resolve_sandbox_route
+      ~fallback_sandbox_profile
+      ~fallback_network_mode
+      defaults
+  =
+  match defaults.sandbox_profile, defaults.manifest_path with
+  | None, Some manifest_path -> Sandbox_profile_missing { manifest_path }
+  | sandbox_profile, manifest_path ->
+    let sandbox_profile =
+      Option.value sandbox_profile ~default:fallback_sandbox_profile
+    in
+    let network_default =
+      match manifest_path with
+      | Some _ ->
+        Keeper_types_profile_sandbox.default_network_mode_for_profile
+          sandbox_profile
+      | None -> fallback_network_mode
+    in
+    let network_mode =
+      Option.value defaults.network_mode ~default:network_default
+    in
+    Sandbox_route { sandbox_profile; network_mode }
+;;

--- a/lib/keeper/keeper_types_profile_defaults.mli
+++ b/lib/keeper/keeper_types_profile_defaults.mli
@@ -23,3 +23,19 @@ type keeper_profile_defaults = {
 }
 
 val empty_keeper_profile_defaults : keeper_profile_defaults
+
+type sandbox_route_resolution =
+  | Sandbox_route of
+      { sandbox_profile : Keeper_types_profile_sandbox.sandbox_profile
+      ; network_mode : Keeper_types_profile_sandbox.network_mode
+      }
+  | Sandbox_profile_missing of { manifest_path : string }
+
+val resolve_sandbox_route :
+  fallback_sandbox_profile:Keeper_types_profile_sandbox.sandbox_profile ->
+  fallback_network_mode:Keeper_types_profile_sandbox.network_mode ->
+  keeper_profile_defaults ->
+  sandbox_route_resolution
+(** Single resolver for the persisted TOML sandbox request. A loaded manifest
+    without [sandbox_profile] remains a typed missing request; it never falls
+    back to runtime metadata. *)

--- a/test/test_keeper_runtime_contract.ml
+++ b/test/test_keeper_runtime_contract.ml
@@ -368,6 +368,117 @@ let test_sandbox_routing_rejects_unenforceable_host_network_none () =
   | Ok _ -> fail "local/network-none cannot be represented as enforced"
 ;;
 
+let test_sandbox_factory_refuses_toml_effective_mismatch_before_effect () =
+  let config = make_config () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_config config)
+    (fun () ->
+      let meta =
+        { (make_meta ()) with
+          sandbox_profile = Sandbox.Local
+        ; network_mode = Sandbox.Network_inherit
+        }
+      in
+      let factory =
+        Keeper_sandbox_factory.create
+          ~requested_sandbox_profile:Sandbox.Docker
+          ~requested_network_mode:Sandbox.Network_none
+          ~config
+          ~meta
+          ()
+      in
+      Fun.protect
+        ~finally:(fun () -> Keeper_sandbox_factory.cleanup factory)
+        (fun () ->
+          match Keeper_sandbox_factory.routing_admission factory with
+          | Ok () -> fail "Docker request/local effective route must be refused"
+          | Error refusal ->
+            let descriptor =
+              match Keeper_sandbox_factory.routing_refusal_evidence refusal with
+              | Some evidence -> Routing.descriptor_to_yojson evidence
+              | None -> fail "mismatch refusal must retain staged evidence"
+            in
+            check string "factory mismatch status" "mismatch"
+              (json_string [ "verification"; "status" ] descriptor);
+            check string "factory refuses containment" "not_verified"
+              (json_string [ "verification"; "containment" ] descriptor);
+            check string "factory typed violation" "config_effective_mismatch"
+              (json_string [ "verification"; "violation" ] descriptor)))
+;;
+
+let test_sandbox_factory_receipt_observes_frozen_effective_route () =
+  let config = make_config () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_config config)
+    (fun () ->
+      let meta =
+        { (make_meta ()) with
+          sandbox_profile = Sandbox.Docker
+        ; network_mode = Sandbox.Network_none
+        }
+      in
+      let factory =
+        Keeper_sandbox_factory.create
+          ~requested_sandbox_profile:Sandbox.Docker
+          ~requested_network_mode:Sandbox.Network_none
+          ~config
+          ~meta
+          ()
+      in
+      Fun.protect
+        ~finally:(fun () -> Keeper_sandbox_factory.cleanup factory)
+        (fun () ->
+          (match Keeper_sandbox_factory.routing_admission factory with
+           | Ok () -> ()
+           | Error refusal ->
+             fail
+               (Keeper_sandbox_factory.routing_refusal_to_string refusal));
+          let evidence =
+            match Keeper_sandbox_factory.routing_evidence_for_receipt factory with
+            | Ok evidence -> evidence
+            | Error refusal ->
+              fail
+                (Keeper_sandbox_factory.routing_refusal_to_string refusal)
+          in
+          let descriptor = Routing.descriptor_to_yojson evidence in
+          check string "receipt route verified" "verified"
+            (json_string [ "verification"; "status" ] descriptor);
+          check string "receipt route contained" "docker_contained"
+            (json_string [ "verification"; "containment" ] descriptor)))
+;;
+
+let test_sandbox_factory_does_not_fallback_when_receipt_evidence_is_unavailable () =
+  let config = make_config () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_config config)
+    (fun () ->
+      let meta =
+        { (make_meta ()) with
+          sandbox_profile = Sandbox.Local
+        ; network_mode = Sandbox.Network_inherit
+        }
+      in
+      let factory =
+        Keeper_sandbox_factory.create
+          ~requested_sandbox_profile:Sandbox.Local
+          ~requested_network_mode:Sandbox.Network_none
+          ~config
+          ~meta
+          ()
+      in
+      Fun.protect
+        ~finally:(fun () -> Keeper_sandbox_factory.cleanup factory)
+        (fun () ->
+          match Keeper_sandbox_factory.routing_evidence_for_receipt factory with
+          | Error refusal ->
+            check bool "typed unavailable evidence detail" true
+              (String.starts_with
+                 ~prefix:"invalid requested sandbox route:"
+                 (Keeper_sandbox_factory.routing_refusal_to_string refusal))
+          | Ok _ ->
+            fail "unavailable routing evidence must not fall back to meta"))
+;;
+
 let () =
   run
     "keeper_runtime_contract"
@@ -392,6 +503,12 @@ let () =
             test_sandbox_routing_requires_receipt_evidence
         ; test_case "rejects unenforceable host network-none" `Quick
             test_sandbox_routing_rejects_unenforceable_host_network_none
+        ; test_case "factory refuses TOML/effective mismatch before effect" `Quick
+            test_sandbox_factory_refuses_toml_effective_mismatch_before_effect
+        ; test_case "receipt observes factory-frozen effective route" `Quick
+            test_sandbox_factory_receipt_observes_frozen_effective_route
+        ; test_case "receipt absence does not fall back to meta" `Quick
+            test_sandbox_factory_does_not_fallback_when_receipt_evidence_is_unavailable
         ] )
     ]
 ;;

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -245,6 +245,7 @@ let base_receipt : R.t =
   ; sandbox_kind = Keeper_types_profile_sandbox.Local
   ; sandbox_root = None
   ; network_mode = Keeper_types_profile_sandbox.Network_none
+  ; sandbox_routing = None
   ; runtime_id = "runtime-1"
   ; runtime_selected_model = None
   ; runtime_attempt_count = 1


### PR DESCRIPTION
## Stack

- Parent: #28562
- Base branch: fix/keeper-sandbox-routing-contract
- This child consumes the closed sandbox-routing contract introduced by the parent.

## What

- Resolve the persisted TOML sandbox request through one resolve_sandbox_route SSOT shared by meta overlay and runtime admission.
- Freeze the sandbox factory actual effective profile/network once per turn; tool dispatch no longer re-reads route metadata on every resolve.
- Add a closed routing_refusal sum for invalid requested/effective/receipt boundaries, admission mismatches, and receipt mismatches.
- Gate HITL replay and provider/tool setup on typed config-request/effective-route admission.
- On refusal, write a pre-dispatch execution receipt with canonical config_error, typed staged evidence when available, and no tool/Docker effect.
- At finalization, obtain receipt evidence from the same factory-frozen route. A missing or inconsistent receipt observation returns a typed config error rather than copying meta.
- Serialize the descriptor into runtime_contract.sandbox_routing and sandbox.routing.

## Focused proof added

- Docker/none TOML request with Local/inherit effective route is refused before effects and serializes config_effective_mismatch plus containment=not_verified.
- Matching Docker/none routing produces verified receipt evidence from the factory-frozen effective route.
- Invalid/unavailable receipt evidence returns a typed refusal and does not fall back to meta.

No Docker runtime is created by these fixtures because they never call resolve.

## Fast local checks

- ocamlc stop-after parsing for every changed ML/MLI
- ocamlformat check for every changed ML/MLI
- git diff check
- scripts/check-ssot.sh
- scripts/lint/no-provider-name-hardcoding.sh
- scripts/ci/check-silent-failure-patterns.sh
- scripts/ocaml-structure-ratchet.sh
- scripts/check-agent-core-boundary.sh

Per task constraint, no local Dune build/test was run. Focused Alcotest cases are included for CI.

## Excluded follow-ups

- Dashboard rendering of the new routing descriptor.
- Private-canary real Docker execution and browser/screenshot verification.
- Live config mutation, server restart, and network probing.