### PR TITLE
fix(keeper): settle applied Gate replay posts

### DIFF
--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -176,6 +176,7 @@ let finalize
           ~session_id:
             (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
           ~response_text
+          ~suppress_visible_response
           ~stop_reason:result.stop_reason
           checkpoint
       in

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -90,9 +90,20 @@ let finalize
     Keeper_agent_run_response_text.stop_reason_suppresses_visible_response
       result.stop_reason
   in
+  (* Every arm named, no catch-all: a new outcome must state whether its effect
+     already reached the reader rather than defaulting to "did not". *)
+  let terminal_effect_settled =
+    match turn_outcome with
+    | Keeper_turn_outcome.External_effect_completed -> true
+    | Keeper_turn_outcome.Visible_reply
+    | Keeper_turn_outcome.Continuation_checkpoint
+    | Keeper_turn_outcome.External_effect_pending
+    | Keeper_turn_outcome.No_visible_reply -> false
+  in
   let suppression_reasons =
     Keeper_replay_checkpoint.wire_capture_response_suppression_reasons
       ~control_checkpoint
+      ~terminal_effect_settled
   in
   let suppress_visible_response = suppression_reasons <> [] in
   let raw_response_text_present =

--- a/lib/keeper/keeper_gate_replay.ml
+++ b/lib/keeper/keeper_gate_replay.ml
@@ -222,6 +222,22 @@ type effect_outcome =
   | Effect_failed of string
   | Effect_indeterminate of string
 
+type replay_execution =
+  { outcome : outcome
+  ; terminal_effect_receipt :
+      Keeper_tool_execution.terminal_effect_receipt option
+  }
+
+let replay_execution ?terminal_effect_receipt outcome =
+  { outcome; terminal_effect_receipt }
+;;
+
+let applied_terminal_effect_receipt replay_effect receipt =
+  match replay_effect with
+  | Effect_applied _ | Effect_applied_with_warning _ -> receipt
+  | Effect_failed _ | Effect_indeterminate _ -> None
+;;
+
 let replay_artifact_identity artifact_ref =
   Tool_output.with_preview artifact_ref ""
 ;;
@@ -258,6 +274,8 @@ module Repair_map = Map.Make (String)
 type pending_repair =
   { operation : string
   ; replay_effect : effect_outcome
+  ; terminal_effect_receipt :
+      Keeper_tool_execution.terminal_effect_receipt option
   }
 
 (* A Keeper turn already owns the per-Keeper admission mutex before replay
@@ -352,35 +370,52 @@ let replay_journal_status ~base_path ~approval_id replay_outcome =
     Error (Keeper_approval_queue.grant_error_to_string error)
 ;;
 
-let replayed_outcome ~base_path ~approval_id ~operation replay_effect =
+let replayed_outcome
+      ~base_path
+      ~approval_id
+      ~operation
+      ?terminal_effect_receipt
+      replay_effect
+  =
+  let terminal_effect_receipt =
+    applied_terminal_effect_receipt replay_effect terminal_effect_receipt
+  in
   remember_pending_repair
     ~base_path
     ~approval_id
-    { operation; replay_effect };
+    { operation; replay_effect; terminal_effect_receipt };
   match persist_replay_effect ~base_path replay_effect with
   | Error detail ->
-    Repair_required { operation; stage = Evidence_storage; detail }
+    replay_execution
+      ?terminal_effect_receipt
+      (Repair_required { operation; stage = Evidence_storage; detail })
   | Ok replay_outcome ->
     (match replay_journal_status ~base_path ~approval_id replay_outcome with
      | Error detail ->
-       Repair_required { operation; stage = Replay_journal; detail }
+       replay_execution
+         ?terminal_effect_receipt
+         (Repair_required { operation; stage = Replay_journal; detail })
      | Ok journal ->
        forget_pending_repair ~base_path ~approval_id;
-       (match replay_outcome with
-        | Keeper_approval_queue.Replay_applied output_ref ->
-          Applied { operation; output_ref; journal }
-        | Keeper_approval_queue.Replay_applied_with_warning detail_ref ->
-          Applied_with_warning { operation; detail_ref; journal }
-        | Keeper_approval_queue.Replay_failed detail_ref ->
-          Failed { operation; detail_ref; journal }
-        | Keeper_approval_queue.Replay_indeterminate detail_ref ->
-          Indeterminate { operation; detail_ref; journal }))
+       let outcome =
+         match replay_outcome with
+         | Keeper_approval_queue.Replay_applied output_ref ->
+           Applied { operation; output_ref; journal }
+         | Keeper_approval_queue.Replay_applied_with_warning detail_ref ->
+           Applied_with_warning { operation; detail_ref; journal }
+         | Keeper_approval_queue.Replay_failed detail_ref ->
+           Failed { operation; detail_ref; journal }
+         | Keeper_approval_queue.Replay_indeterminate detail_ref ->
+           Indeterminate { operation; detail_ref; journal }
+       in
+       replay_execution ?terminal_effect_receipt outcome)
 ;;
 
-let durable_replay_outcome
+let durable_replay_execution
       ~base_path
       ~operation
       ~journal
+      ?terminal_effect_receipt
       replay_outcome
   =
   let verified =
@@ -402,15 +437,27 @@ let durable_replay_outcome
         (fun _ -> `Indeterminate detail_ref)
         (retrieve_replay_artifact ~base_path detail_ref)
   in
-  match verified with
-  | Ok (`Applied output_ref) -> Applied { operation; output_ref; journal }
-  | Ok (`Applied_with_warning detail_ref) ->
-    Applied_with_warning { operation; detail_ref; journal }
-  | Ok (`Failed detail_ref) -> Failed { operation; detail_ref; journal }
-  | Ok (`Indeterminate detail_ref) ->
-    Indeterminate { operation; detail_ref; journal }
-  | Error detail ->
-    Repair_required { operation; stage = Evidence_retrieval; detail }
+  let outcome =
+    match verified with
+    | Ok (`Applied output_ref) -> Applied { operation; output_ref; journal }
+    | Ok (`Applied_with_warning detail_ref) ->
+      Applied_with_warning { operation; detail_ref; journal }
+    | Ok (`Failed detail_ref) -> Failed { operation; detail_ref; journal }
+    | Ok (`Indeterminate detail_ref) ->
+      Indeterminate { operation; detail_ref; journal }
+    | Error detail ->
+      Repair_required { operation; stage = Evidence_retrieval; detail }
+  in
+  replay_execution ?terminal_effect_receipt outcome
+;;
+
+let durable_replay_outcome ~base_path ~operation ~journal replay_outcome =
+  (durable_replay_execution
+     ~base_path
+     ~operation
+     ~journal
+     replay_outcome)
+    .outcome
 ;;
 
 type replay_evidence_effect =
@@ -724,7 +771,36 @@ let compose_model_message
       hitl_resolution
 ;;
 
-let replay_approved_effect
+let connector_post_terminal_effect_receipt connector_post =
+  Keeper_tool_execution.Surface_post_completed
+    (Keeper_tool_in_process_runtime.connector_post_replay_target connector_post)
+;;
+
+let terminal_effect_receipt_of_durable_replay request replay_outcome =
+  match
+    replayable_of_operation request.Keeper_approval_queue.tool_name,
+    replay_outcome
+  with
+  | ( Some Replay_connector_post
+    , ( Keeper_approval_queue.Replay_applied _
+      | Keeper_approval_queue.Replay_applied_with_warning _ ) ) ->
+    Result.map
+      (fun connector_post ->
+         Some (connector_post_terminal_effect_receipt connector_post))
+      (connector_post_of_gate_input request.input)
+  | ( ( Some Replay_write
+      | Some Replay_execute
+      | Some Replay_network_read
+      | Some Replay_memory_write
+      | None )
+    , _ )
+  | Some Replay_connector_post,
+    ( Keeper_approval_queue.Replay_failed _
+    | Keeper_approval_queue.Replay_indeterminate _ ) ->
+    Ok None
+;;
+
+let replay_approved_effect_with_receipt
       ~(config : Workspace.config)
       ~(meta : Keeper_meta_contract.keeper_meta)
       ~(publication_recovery :
@@ -747,29 +823,41 @@ let replay_approved_effect
          ~base_path:config.base_path
          ~approval_id
      with
-     | Some { operation; replay_effect } ->
+     | Some { operation; replay_effect; terminal_effect_receipt } ->
        replayed_outcome
          ~base_path:config.base_path
          ~approval_id
          ~operation
+         ?terminal_effect_receipt
          replay_effect
      | None ->
-       Repair_required
-         { operation = "unknown"
-         ; detail = Keeper_approval_queue.grant_error_to_string error
-         ; stage = Resolution_lookup
-         })
+       replay_execution
+         (Repair_required
+            { operation = "unknown"
+            ; detail = Keeper_approval_queue.grant_error_to_string error
+            ; stage = Resolution_lookup
+            }))
   | Ok
       { request
       ; state = Keeper_approval_queue.Resolution_consumed
       ; replay_outcome = Some replay_outcome
       } ->
     forget_pending_repair ~base_path:config.base_path ~approval_id;
-    durable_replay_outcome
-      ~base_path:config.base_path
-      ~operation:request.tool_name
-      ~journal:Replay_journal_already_recorded
-      replay_outcome
+    (match terminal_effect_receipt_of_durable_replay request replay_outcome with
+     | Error detail ->
+       replay_execution
+         (Repair_required
+            { operation = request.tool_name
+            ; stage = Request_decode
+            ; detail
+            })
+     | Ok terminal_effect_receipt ->
+       durable_replay_execution
+         ~base_path:config.base_path
+         ~operation:request.tool_name
+         ~journal:Replay_journal_already_recorded
+         ?terminal_effect_receipt
+         replay_outcome)
   | Ok
       { request
       ; state = Keeper_approval_queue.Resolution_consumed
@@ -780,11 +868,12 @@ let replay_approved_effect
          ~base_path:config.base_path
          ~approval_id
      with
-     | Some { operation; replay_effect } ->
+     | Some { operation; replay_effect; terminal_effect_receipt } ->
        replayed_outcome
          ~base_path:config.base_path
          ~approval_id
          ~operation
+         ?terminal_effect_receipt
          replay_effect
      | None ->
        replayed_outcome
@@ -798,17 +887,18 @@ let replay_approved_effect
       ; state = Keeper_approval_queue.Resolution_unconsumed
       ; replay_outcome = Some _
       } ->
-    Repair_required
-      { operation = request.tool_name
-      ; stage = Invalid_resolution_state
-      ; detail = "replay outcome exists before grant consumption"
-      }
+    replay_execution
+      (Repair_required
+         { operation = request.tool_name
+         ; stage = Invalid_resolution_state
+         ; detail = "replay outcome exists before grant consumption"
+         })
   | Ok
       { request
       ; state = Keeper_approval_queue.Resolution_unconsumed
       ; replay_outcome = None
       } ->
-    let run_effect operation run =
+    let run_effect ?terminal_effect_receipt operation run =
       let execution =
         try Ok (run ()) with
         | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -835,11 +925,12 @@ let replay_approved_effect
              request
          with
          | Error detail ->
-           Repair_required
-             { operation
-             ; stage = Stale_grant_retirement
-             ; detail
-             }
+           replay_execution
+             (Repair_required
+                { operation
+                ; stage = Stale_grant_retirement
+                ; detail
+                })
          | Ok () ->
            replayed_outcome
              ~base_path:config.base_path
@@ -851,16 +942,24 @@ let replay_approved_effect
           ~base_path:config.base_path
           ~approval_id
           ~operation
+          ?terminal_effect_receipt
           (summarize_execution ~operation execution)
     in
-    let replay operation decode run =
+    let replay ?terminal_effect_receipt_of_args operation decode run =
       match decode request.input with
       | Error detail ->
-        Repair_required { operation; stage = Request_decode; detail }
-      | Ok args -> run_effect operation (fun () -> run args)
+        replay_execution
+          (Repair_required { operation; stage = Request_decode; detail })
+      | Ok args ->
+        let terminal_effect_receipt =
+          Option.map
+            (fun make_receipt -> make_receipt args)
+            terminal_effect_receipt_of_args
+        in
+        run_effect ?terminal_effect_receipt operation (fun () -> run args)
     in
     (match replayable_of_operation request.tool_name with
-     | None -> Not_applicable
+     | None -> replay_execution Not_applicable
      | Some Replay_write ->
        replay write_operation write_args_of_gate_input (fun args ->
          Keeper_tool_filesystem_runtime.handle_file_write_with_outcome
@@ -887,11 +986,12 @@ let replay_approved_effect
      | Some Replay_network_read ->
        (match network_read_of_gate_input request.input with
         | Error detail ->
-          Repair_required
-            { operation = network_read_operation
-            ; stage = Request_decode
-            ; detail
-            }
+          replay_execution
+            (Repair_required
+               { operation = network_read_operation
+               ; stage = Request_decode
+               ; detail
+               })
         | Ok (Keeper_tool_in_process_runtime.Replay_web_search args) ->
           run_effect network_read_operation (fun () ->
             Keeper_tool_in_process_runtime.handle_web_search_with_outcome
@@ -914,6 +1014,7 @@ let replay_approved_effect
               ()))
      | Some Replay_connector_post ->
        replay
+         ~terminal_effect_receipt_of_args:connector_post_terminal_effect_receipt
          connector_post_operation
          connector_post_of_gate_input
          (fun connector_post ->
@@ -934,6 +1035,30 @@ let replay_approved_effect
            ~gate_grant:grant
            ~args
            ()))
+;;
+
+let replay_approved_effect
+      ~config
+      ~meta
+      ~publication_recovery
+      ~turn_sandbox_factory
+      ?continuation_channel
+      ?gate_context
+      ~grant
+      ~approval_id
+      ()
+  =
+  (replay_approved_effect_with_receipt
+     ~config
+     ~meta
+     ~publication_recovery
+     ~turn_sandbox_factory
+     ?continuation_channel
+     ?gate_context
+     ~grant
+     ~approval_id
+     ())
+    .outcome
 ;;
 
 module For_testing = struct

--- a/lib/keeper/keeper_gate_replay.mli
+++ b/lib/keeper/keeper_gate_replay.mli
@@ -144,6 +144,15 @@ val replayable_of_operation : string -> replayable option
     call. Exposed because a decode function that exists but is never dispatched
     to is indistinguishable from a working replay at the boundary. *)
 
+type replay_execution =
+  { outcome : outcome
+  ; terminal_effect_receipt :
+      Keeper_tool_execution.terminal_effect_receipt option
+  }
+(** The durable replay outcome plus the turn-settlement receipt owned by a
+    successfully applied connector post. Other replayable operations and
+    unapplied or indeterminate connector effects carry [None]. *)
+
 (** Replay the approved effect behind [approval_id] exactly once.
 
     Covers operations whose approvals a Keeper must otherwise re-earn by
@@ -173,6 +182,21 @@ val replay_approved_effect :
   approval_id:string ->
   unit ->
   outcome
+
+val replay_approved_effect_with_receipt :
+  config:Workspace.config ->
+  meta:Keeper_meta_contract.keeper_meta ->
+  publication_recovery:Keeper_publication_recovery_availability.turn_context ->
+  turn_sandbox_factory:Keeper_sandbox_factory.t option ->
+  ?continuation_channel:Keeper_continuation_channel.t ->
+  ?gate_context:(unit -> Keeper_gate.causal_context) ->
+  grant:Keeper_gate.cycle_grant ->
+  approval_id:string ->
+  unit ->
+  replay_execution
+(** Replay exactly once and retain the typed connector-post receipt needed by
+    turn finalization. [replay_approved_effect] is the outcome-only projection
+    for callers that do not own a turn boundary. *)
 
 module For_testing : sig
   val persist_replay_artifact :

--- a/lib/keeper/keeper_replay_checkpoint.ml
+++ b/lib/keeper/keeper_replay_checkpoint.ml
@@ -2,9 +2,12 @@
 
 type replay_suffix_prune_reason =
   | Canonical_success_replay
+  | Suppressed_terminal_effect_response
 
 let replay_suffix_prune_reason_to_string = function
   | Canonical_success_replay -> "canonical_success_replay"
+  | Suppressed_terminal_effect_response ->
+    "suppressed_terminal_effect_response"
 ;;
 
 let replay_response_text_for_persistence ~suppress_visible_response ~response_text =
@@ -84,10 +87,22 @@ let drop_trailing_blank_assistants messages =
   drop false (List.rev messages)
 ;;
 
+let drop_trailing_assistants messages =
+  let rec drop dropped = function
+    | ({ Agent_core.Types.role = Agent_core.Types.Assistant; _ } :
+        Agent_core.Types.message)
+      :: rest ->
+      drop true rest
+    | reversed -> List.rev reversed, dropped
+  in
+  drop false (List.rev messages)
+;;
+
 let canonical_success_replay_checkpoint
       ~(history_messages : Agent_core.Types.message list)
       ~(session_id : string)
       ~(response_text : string)
+      ~suppress_visible_response
       (checkpoint : Agent_core.Checkpoint.t)
   =
   match
@@ -98,21 +113,35 @@ let canonical_success_replay_checkpoint
   | Ok current_suffix ->
        (* A blank visible response is not authority to erase typed replay. The
           suffix may contain an actual user input, ToolUse/ToolResult pair,
-          thinking, or media whose effect has already happened. Remove only an
-          inert trailing Assistant shell; the typed skipped-wake rule above owns
-          the autonomous marker independently. *)
-       let current_suffix, blank_assistant_dropped =
-         if String.trim response_text = ""
-         then drop_trailing_blank_assistants current_suffix
-         else current_suffix, false
-       in
-       let replay_suffix_pruned =
-         if blank_assistant_dropped
-         then Some Canonical_success_replay
-         else None
+          thinking, or media whose effect has already happened. Ordinary blank
+          completion removes only an inert trailing Assistant shell. A typed
+          terminal-effect receipt is stronger: the external post is already the
+          visible result, so its trailing provider Assistant response is not
+          durable conversation. Both paths preserve every preceding typed
+          replay node. *)
+       let current_suffix, replay_suffix_pruned =
+         if suppress_visible_response
+         then
+           let current_suffix, assistant_dropped =
+             drop_trailing_assistants current_suffix
+           in
+           ( current_suffix
+           , if assistant_dropped
+             then Some Suppressed_terminal_effect_response
+             else None )
+         else if String.trim response_text = ""
+         then
+           let current_suffix, blank_assistant_dropped =
+             drop_trailing_blank_assistants current_suffix
+           in
+           ( current_suffix
+           , if blank_assistant_dropped
+             then Some Canonical_success_replay
+             else None )
+         else current_suffix, None
        in
        let checkpoint =
-         if String.trim response_text = ""
+         if suppress_visible_response || String.trim response_text = ""
          then
            { checkpoint with
              Agent_core.Checkpoint.session_id
@@ -178,6 +207,7 @@ let checkpoint_for_replay_persistence
       ~(history_messages : Agent_core.Types.message list)
       ~(session_id : string)
       ~(response_text : string)
+      ?(suppress_visible_response = false)
       ?(stop_reason = Runtime_agent.Completed)
       (checkpoint : Agent_core.Checkpoint.t)
   =
@@ -217,6 +247,7 @@ let checkpoint_for_replay_persistence
       ~history_messages
       ~session_id
       ~response_text
+      ~suppress_visible_response
       checkpoint
 ;;
 

--- a/lib/keeper/keeper_replay_checkpoint.ml
+++ b/lib/keeper/keeper_replay_checkpoint.ml
@@ -25,13 +25,27 @@ let consume_replay_response
 
 type wire_capture_response_suppression_reason =
   | Control_checkpoint
+  (* The turn's effect already reached the reader — an approved connector post
+     that a Gate replay settled before the model spoke. Anything the model then
+     says is a second message about work already delivered. [Control_checkpoint]
+     cannot cover this: it reads [stop_reason], and a turn that answers in plain
+     text without calling a tool stops at [Completed] like any other. *)
+  | Terminal_effect_settled
 
-let wire_capture_response_suppression_reasons ~control_checkpoint =
-  if control_checkpoint then [ Control_checkpoint ] else []
+let wire_capture_response_suppression_reasons
+      ~control_checkpoint
+      ~terminal_effect_settled
+  =
+  List.filter_map
+    (fun (applies, reason) -> if applies then Some reason else None)
+    [ control_checkpoint, Control_checkpoint
+    ; terminal_effect_settled, Terminal_effect_settled
+    ]
 ;;
 
 let wire_capture_response_suppression_reason_label = function
   | Control_checkpoint -> "control_checkpoint"
+  | Terminal_effect_settled -> "terminal_effect_settled"
 ;;
 
 let emit_wire_capture_response_suppressed_metric ~keeper_name reason =

--- a/lib/keeper/keeper_replay_checkpoint.mli
+++ b/lib/keeper/keeper_replay_checkpoint.mli
@@ -34,6 +34,7 @@ val checkpoint_for_replay_persistence :
   history_messages:Agent_core.Types.message list ->
   session_id:string ->
   response_text:string ->
+  ?suppress_visible_response:bool ->
   ?stop_reason:Runtime_agent.stop_reason ->
   Agent_core.Checkpoint.t ->
   (Agent_core.Checkpoint.t * replay_suffix_prune_reason option, string) result

--- a/lib/keeper/keeper_replay_checkpoint.mli
+++ b/lib/keeper/keeper_replay_checkpoint.mli
@@ -14,7 +14,15 @@ val consume_replay_response :
 type wire_capture_response_suppression_reason
 
 val wire_capture_response_suppression_reasons :
-  control_checkpoint:bool -> wire_capture_response_suppression_reason list
+     control_checkpoint:bool
+  -> terminal_effect_settled:bool
+  -> wire_capture_response_suppression_reason list
+(** [terminal_effect_settled] is the turn outcome saying the effect already
+    reached the reader. It is a separate question from [control_checkpoint],
+    which reads [stop_reason]: a turn whose effect a Gate replay settled before
+    the model spoke still stops at [Completed] when the model answers in plain
+    text, so only the outcome can tell that the visible text would be a second
+    message about work already delivered. *)
 
 val wire_capture_response_suppression_reason_label :
   wire_capture_response_suppression_reason -> string

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -1044,6 +1044,14 @@ let connector_post_replay_of_gate_input input =
   | _ -> Error "approved connector_post input must be an object"
 ;;
 
+let connector_post_replay_target = function
+  | Replay_discord_post { channel_id; _ } ->
+    Keeper_surface_post.To_discord { channel_id }
+  | Replay_slack_post { channel_id; thread_ts; blocks; _ } ->
+    Keeper_surface_post.To_slack
+      { channel_id; thread_ts; blocks = Some blocks }
+;;
+
 let with_connector_post_gate_execution
       ~config
       ~(meta : keeper_meta)

--- a/lib/keeper/keeper_tool_in_process_runtime.mli
+++ b/lib/keeper/keeper_tool_in_process_runtime.mli
@@ -47,6 +47,12 @@ val connector_post_replay_of_gate_input :
     and used for one-shot Gate consumption; content and blocks are never
     truncated or reconstructed for replay. *)
 
+val connector_post_replay_target :
+  connector_post_replay -> Keeper_surface_post.post_target
+(** Recover the exact terminal surface target carried by the durable request.
+    Host replay uses this receipt to settle the enclosing turn as an external
+    effect instead of delivering a second assistant reply. *)
+
 val replay_connector_post_with_outcome :
   config:Workspace.config ->
   meta:keeper_meta ->

--- a/lib/keeper/keeper_tools_agent_core.ml
+++ b/lib/keeper/keeper_tools_agent_core.ml
@@ -25,6 +25,8 @@ type terminal_effect_state =
 type gate_replay_delivery =
   { approval_id : string
   ; outcome : Keeper_gate_replay.outcome
+  ; terminal_effect_receipt :
+      Keeper_tool_execution.terminal_effect_receipt option
   }
 
 type tool_bundle =

--- a/lib/keeper/keeper_tools_agent_core.mli
+++ b/lib/keeper/keeper_tools_agent_core.mli
@@ -30,6 +30,8 @@ type terminal_effect_state =
 type gate_replay_delivery =
   { approval_id : string
   ; outcome : Keeper_gate_replay.outcome
+  ; terminal_effect_receipt :
+      Keeper_tool_execution.terminal_effect_receipt option
   }
 
 type tool_bundle =

--- a/lib/keeper/keeper_tools_agent_core_bundle.ml
+++ b/lib/keeper/keeper_tools_agent_core_bundle.ml
@@ -39,6 +39,18 @@ let terminal_externalization_failure
     None
 ;;
 
+let initial_terminal_effect_state = function
+  | Some
+      { Keeper_tools_agent_core.outcome =
+          ( Keeper_gate_replay.Applied _
+          | Keeper_gate_replay.Applied_with_warning _ )
+      ; terminal_effect_receipt = Some receipt
+      ; _
+      } ->
+    Keeper_tools_agent_core.Terminal_effect_completed receipt
+  | Some _ | None -> Keeper_tools_agent_core.Terminal_effect_open
+;;
+
 let make_tool_bundle_for_descriptors
       ~(config : Workspace.config)
       ~(meta : Keeper_meta_contract.keeper_meta)
@@ -85,8 +97,8 @@ let make_tool_bundle_for_descriptors
           ; _
           }
       , Some grant ) ->
-      let outcome =
-        Keeper_gate_replay.replay_approved_effect
+      let replay_execution =
+        Keeper_gate_replay.replay_approved_effect_with_receipt
            ~config
            ~meta
            ~publication_recovery
@@ -97,6 +109,7 @@ let make_tool_bundle_for_descriptors
            ~approval_id
            ()
       in
+      let outcome = replay_execution.Keeper_gate_replay.outcome in
       (match outcome with
        | Keeper_gate_replay.Not_applicable -> ()
        | Keeper_gate_replay.Applied _ as outcome ->
@@ -124,7 +137,12 @@ let make_tool_bundle_for_descriptors
            "gate replay approval=%s %s"
            approval_id
            (Keeper_gate_replay.outcome_to_string outcome));
-      Some Keeper_tools_agent_core.{ approval_id; outcome }
+      Some
+        Keeper_tools_agent_core.
+          { approval_id
+          ; outcome
+          ; terminal_effect_receipt = replay_execution.terminal_effect_receipt
+          }
     | _ -> None
   in
   let record_gate_result =
@@ -146,11 +164,15 @@ let make_tool_bundle_for_descriptors
      after the whole tool batch and checkpoint sink have completed. A generic
      deferred tool transition retains the existing durable-stimulus checkpoint;
      only a typed external-effect defer stops the provider loop until Gate's
-     durable resolution wakes a later turn. A terminal completion supersedes a
-     defer in the same batch; a proven terminal failure dominates every state
-     regardless of callback order. Failure is sticky so its first diagnostic
-     remains authoritative. *)
-  let terminal_effect_state = Atomic.make Terminal_effect_open in
+     durable resolution wakes a later turn. An already-applied connector replay
+     seeds this same state from its producer-owned receipt, so finalization does
+     not mistake the post-effect continuation for another visible reply. A
+     terminal completion supersedes a defer in the same batch; a proven terminal
+     failure dominates every state regardless of callback order. Failure is
+     sticky so its first diagnostic remains authoritative. *)
+  let terminal_effect_state =
+    Atomic.make (initial_terminal_effect_state gate_replay_delivery)
+  in
   let mark_deferred_tool_result () =
     ignore
       (Atomic.compare_and_set
@@ -350,6 +372,8 @@ module For_testing = struct
     | Terminal_effect -> true
     | Continue_after_success -> false
   ;;
+
+  let initial_terminal_effect_state = initial_terminal_effect_state
 
   let terminal_externalization_failure =
     terminal_externalization_failure

--- a/lib/keeper/keeper_tools_agent_core_bundle.mli
+++ b/lib/keeper/keeper_tools_agent_core_bundle.mli
@@ -31,6 +31,10 @@ val make_tools
 module For_testing : sig
   val is_terminal_effect_handler : Keeper_tool_descriptor.runtime_handler -> bool
 
+  val initial_terminal_effect_state :
+    Keeper_tools_agent_core.gate_replay_delivery option ->
+    Keeper_tools_agent_core.terminal_effect_state
+
   val terminal_externalization_failure :
     Keeper_tools_agent_core.terminal_effect_state ->
     Tool_bridge.externalization_error ->

--- a/test/test_keeper_gate_replay.ml
+++ b/test/test_keeper_gate_replay.ml
@@ -780,6 +780,30 @@ let test_slack_connector_post_retains_thread_ts () =
   | Error detail -> Alcotest.fail detail
 ;;
 
+let test_connector_post_replay_retains_terminal_target () =
+  let open Masc.Keeper_tool_in_process_runtime in
+  let input =
+    `Assoc
+      [ "connector", `String "discord"
+      ; "channel_id", `String "D-exact"
+      ; "content", `String "approved reply"
+      ]
+  in
+  match connector_post_replay_of_gate_input input with
+  | Ok connector_post ->
+    (match connector_post_replay_target connector_post with
+     | Masc.Keeper_surface_post.To_discord { channel_id } ->
+       Alcotest.check
+         Alcotest.string
+         "terminal target remains the approved channel"
+         "D-exact"
+         channel_id
+     | ( Masc.Keeper_surface_post.To_dashboard
+       | Masc.Keeper_surface_post.To_slack _ ) ->
+       Alcotest.fail "Discord replay produced the wrong terminal target")
+  | Error detail -> Alcotest.fail detail
+;;
+
 let test_connector_post_rejects_heuristic_or_truncated_input () =
   List.iter
     (fun input ->
@@ -912,6 +936,10 @@ let () =
             "slack connector request retains thread_ts"
             `Quick
             test_slack_connector_post_retains_thread_ts
+        ; Alcotest.test_case
+            "connector replay retains terminal target"
+            `Quick
+            test_connector_post_replay_retains_terminal_target
         ; Alcotest.test_case
             "memory write replay keeps exact input"
             `Quick

--- a/test/test_keeper_replay_checkpoint.ml
+++ b/test/test_keeper_replay_checkpoint.ml
@@ -385,6 +385,34 @@ let test_empty_success_preserves_tool_execution_suffix () =
     (prune_reason_to_string reason)
 ;;
 
+let test_terminal_effect_suppression_drops_plain_provider_response () =
+  let open Agent_core.Types in
+  let history =
+    [ message User [ Text "old user" ]; message Assistant [ Text "old answer" ] ]
+  in
+  let current_user = message User [ Text "approved connector replay evidence" ] in
+  let provider_response =
+    message Assistant [ Text "The approved message was already sent." ]
+  in
+  let patched, reason =
+    Finalize.checkpoint_for_replay_persistence
+      ~history_messages:history
+      ~session_id:"terminal-effect-session"
+      ~response_text:""
+      ~suppress_visible_response:true
+      (checkpoint (history @ [ current_user; provider_response ]))
+    |> expect_ok
+  in
+  Alcotest.(check bool)
+    "typed replay evidence remains and provider response is absent"
+    true
+    (patched.messages = history @ [ current_user ]);
+  Alcotest.(check (option string))
+    "terminal effect response pruning is observable"
+    (Some "suppressed_terminal_effect_response")
+    (prune_reason_to_string reason)
+;;
+
 let test_input_required_preserves_exact_tool_failure_suffix () =
   let open Agent_core.Types in
   let history =
@@ -673,6 +701,10 @@ let () =
             "empty success preserves tool execution suffix"
             `Quick
             test_empty_success_preserves_tool_execution_suffix
+        ; Alcotest.test_case
+            "terminal effect suppression drops provider response"
+            `Quick
+            test_terminal_effect_suppression_drops_plain_provider_response
         ; Alcotest.test_case
             "InputRequired preserves exact tool-failure suffix"
             `Quick

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -2684,6 +2684,105 @@ let test_approved_memory_write_replays_without_model_resubmission () =
        | Ok None -> fail "host replay persisted no memory snapshot"
        | Error detail -> fail detail)
 
+let test_durable_connector_replay_settles_terminal_turn () =
+  with_exec_fixture "keeper_durable_connector_replay_terminal"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       let input =
+         `Assoc
+           [ "connector", `String "discord"
+           ; "channel_id", `String "D-approved"
+           ; "content", `String "approved reply already delivered"
+           ]
+       in
+       let approval_id =
+         match
+           Masc.Keeper_approval_queue.submit_pending
+             ~keeper_name:meta.name
+             ~tool_name:"connector_post"
+             ~input
+             ~base_path:config.base_path
+             ()
+         with
+         | Ok submission -> submission.approval_id
+         | Error error ->
+           fail (Masc.Keeper_approval_queue.storage_error_to_string error)
+       in
+       (match
+          Masc.Keeper_approval_queue.resolve_with_policy
+            ~base_path:config.base_path
+            ~id:approval_id
+            ~decision:Keeper_approval_queue_rules_types.Decision.Approve
+            ~source:Keeper_approval_queue_rules_types.Auto_judge
+            ()
+        with
+        | Ok _ -> ()
+        | Error error ->
+          fail (Masc.Keeper_approval_queue.resolve_error_to_string error));
+       (match
+          Masc.Keeper_approval_queue.consume_approved_resolution
+            ~base_path:config.base_path
+            ~id:approval_id
+            ~keeper_name:meta.name
+            ~tool_name:"connector_post"
+            ~input
+        with
+        | Ok (Masc.Keeper_approval_queue.Consumption_committed _)
+        | Ok Masc.Keeper_approval_queue.Consumption_already_committed ->
+          ()
+        | Ok Masc.Keeper_approval_queue.Consumption_not_matching ->
+          fail "exact connector approval did not match"
+        | Error error ->
+          fail (Masc.Keeper_approval_queue.grant_error_to_string error));
+       let output_ref =
+         Tool_blob_store.put_durable
+           (Tool_blob_store.create ~base_path:config.base_path)
+           ~bytes:(Masc.Keeper_surface_post.ok_json ~surface:"discord" ())
+           ~mime:"application/json"
+       in
+       (match
+          Masc.Keeper_approval_queue.record_consumed_resolution_replay
+            ~base_path:config.base_path
+            ~id:approval_id
+            ~outcome:(Masc.Keeper_approval_queue.Replay_applied output_ref)
+        with
+        | Ok Masc.Keeper_approval_queue.Replay_recorded
+        | Ok Masc.Keeper_approval_queue.Replay_already_recorded ->
+          ()
+        | Error error ->
+          fail (Masc.Keeper_approval_queue.grant_error_to_string error));
+       let resolution : Keeper_event_queue.hitl_resolution =
+         { approval_id
+         ; decision = Keeper_event_queue.Hitl_approved
+         ; channel =
+             Keeper_continuation_channel.unrouted
+               "durable connector replay terminal test"
+         }
+       in
+       let bundle =
+         Masc.Keeper_tools_agent_core_bundle.make_tool_bundle
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot:ctx_work
+           ~hitl_resolution:resolution
+           ()
+       in
+       Fun.protect ~finally:bundle.cleanup @@ fun () ->
+       match bundle.terminal_effect_state () with
+       | Masc.Keeper_tools_agent_core.Terminal_effect_completed
+           (Masc.Keeper_tool_execution.Surface_post_completed
+              (Masc.Keeper_surface_post.To_discord { channel_id })) ->
+         check string
+           "durable replay settles the exact approved target"
+           "D-approved"
+           channel_id
+       | ( Masc.Keeper_tools_agent_core.Terminal_effect_open
+         | Masc.Keeper_tools_agent_core.Deferred_tool_result
+         | Masc.Keeper_tools_agent_core.External_effect_deferred
+         | Masc.Keeper_tools_agent_core.Terminal_effect_completed _
+         | Masc.Keeper_tools_agent_core.Terminal_effect_failed _ ) ->
+         fail "durable connector replay remained eligible for visible delivery")
+
 let approved_web_search_resolution
       ~config
       ~meta
@@ -4318,6 +4417,8 @@ let () =
         test_approved_web_search_replays_without_model_resubmission;
       test_case "approved memory write replays without model resubmission" `Quick
         test_approved_memory_write_replays_without_model_resubmission;
+      test_case "durable connector replay settles terminal turn" `Quick
+        test_durable_connector_replay_settles_terminal_turn;
       test_case "blob failure repairs journal without second effect" `Quick
         test_blob_failure_repairs_journal_without_second_effect;
       test_case "journal failure retries only persistence" `Quick

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -249,6 +249,77 @@ let test_terminal_effect_defer_kinds_remain_distinct () =
     Masc.Keeper_tools_agent_core.External_effect_deferred
     "external_effect_deferred"
 
+let test_applied_gate_replay_seeds_terminal_settlement () =
+  let output_ref =
+    match
+      Tool_output.make_artifact_ref
+        ~sha256:(String.make 64 'a')
+        ~bytes:2
+        ~preview:""
+        ~mime:"application/json"
+    with
+    | Ok output_ref -> output_ref
+    | Error error -> fail (Tool_output.make_error_to_string error)
+  in
+  let receipt =
+    Masc.Keeper_tool_execution.Surface_post_completed
+      (Masc.Keeper_surface_post.To_discord { channel_id = "D-approved" })
+  in
+  let replay_delivery : Masc.Keeper_tools_agent_core.gate_replay_delivery =
+    { approval_id = "approval-terminal"
+    ; outcome =
+        Masc.Keeper_gate_replay.Applied
+          { operation = "connector_post"
+          ; output_ref
+          ; journal = Masc.Keeper_gate_replay.Replay_journal_recorded
+          }
+    ; terminal_effect_receipt = Some receipt
+    }
+  in
+  let state =
+    Masc.Keeper_tools_agent_core_bundle.For_testing.initial_terminal_effect_state
+      (Some replay_delivery)
+  in
+  (match state with
+   | Masc.Keeper_tools_agent_core.Terminal_effect_completed
+       (Masc.Keeper_tool_execution.Surface_post_completed
+          (Masc.Keeper_surface_post.To_discord { channel_id })) ->
+     check string "receipt keeps the approved target" "D-approved" channel_id
+   | ( Masc.Keeper_tools_agent_core.Terminal_effect_open
+     | Masc.Keeper_tools_agent_core.Deferred_tool_result
+     | Masc.Keeper_tools_agent_core.External_effect_deferred
+     | Masc.Keeper_tools_agent_core.Terminal_effect_completed _
+     | Masc.Keeper_tools_agent_core.Terminal_effect_failed _ ) ->
+     fail "applied connector replay did not seed terminal completion");
+  let non_terminal_replay =
+    { replay_delivery with
+      outcome =
+        Masc.Keeper_gate_replay.Applied
+          { operation = "network_read"
+          ; output_ref
+          ; journal = Masc.Keeper_gate_replay.Replay_journal_recorded
+          }
+    ; terminal_effect_receipt = None
+    }
+  in
+  (match
+     Masc.Keeper_tools_agent_core_bundle.For_testing.initial_terminal_effect_state
+       (Some non_terminal_replay)
+   with
+   | Masc.Keeper_tools_agent_core.Terminal_effect_open -> ()
+   | ( Masc.Keeper_tools_agent_core.Deferred_tool_result
+     | Masc.Keeper_tools_agent_core.External_effect_deferred
+     | Masc.Keeper_tools_agent_core.Terminal_effect_completed _
+     | Masc.Keeper_tools_agent_core.Terminal_effect_failed _ ) ->
+     fail "non-terminal Gate replay acquired a terminal boundary");
+  match Masc.Keeper_agent_run.terminal_effect_boundary_decision state with
+  | Ok (Runtime_agent.Yield Runtime_agent.Terminal_tool_completed) -> ()
+  | Ok Runtime_agent.Continue ->
+    fail "applied connector replay re-entered ordinary visible delivery"
+  | Ok (Runtime_agent.Yield _) ->
+    fail "applied connector replay selected the wrong yield boundary"
+  | Error error -> fail (Agent_core.Error.to_string error)
+
 let tool_call ?(input = Some "input") ?(output = Some "output") tool_name
     : Masc.Keeper_agent_result.tool_call_detail =
   { tool_name
@@ -727,6 +798,8 @@ let () =
             test_external_effect_status_becomes_persisted_chat_block;
           test_case "terminal effect defer kinds remain distinct" `Quick
             test_terminal_effect_defer_kinds_remain_distinct;
+          test_case "applied Gate replay seeds terminal settlement" `Quick
+            test_applied_gate_replay_seeds_terminal_settlement;
           test_case "repeated exact tool call boundary" `Quick
             test_repeated_exact_tool_call_boundary;
           test_case "autonomous yield boundary contract" `Quick

--- a/test/test_keeper_wire_capture_suppression.ml
+++ b/test/test_keeper_wire_capture_suppression.ml
@@ -18,19 +18,32 @@ let input_required_request () : Agent_core.Error.input_required =
 (* ── wire_capture_response_suppression_reasons / labels / metrics ───── *)
 
 let test_wire_capture_suppression_reasons_emit_control_metric () =
-  let reasons ~control_checkpoint =
+  let reasons ~control_checkpoint ~terminal_effect_settled =
     Finalize.wire_capture_response_suppression_reasons
       ~control_checkpoint
+      ~terminal_effect_settled
     |> List.map Finalize.wire_capture_response_suppression_reason_label
   in
   Alcotest.(check (list string))
     "no suppression"
     []
-    (reasons ~control_checkpoint:false);
+    (reasons ~control_checkpoint:false ~terminal_effect_settled:false);
   Alcotest.(check (list string))
     "control checkpoint"
     [ "control_checkpoint" ]
-    (reasons ~control_checkpoint:true);
+    (reasons ~control_checkpoint:true ~terminal_effect_settled:false);
+  (* A Gate replay settles the post before the model speaks. If the model then
+     answers in plain text without calling a tool, the run stops at [Completed]
+     like any other, so [control_checkpoint] is false — only the outcome knows
+     the reader already got the message. *)
+  Alcotest.(check (list string))
+    "terminal effect already settled"
+    [ "terminal_effect_settled" ]
+    (reasons ~control_checkpoint:false ~terminal_effect_settled:true);
+  Alcotest.(check (list string))
+    "both reasons are reported, not collapsed"
+    [ "control_checkpoint"; "terminal_effect_settled" ]
+    (reasons ~control_checkpoint:true ~terminal_effect_settled:true);
   let keeper_name = "wirecap_suppression_metric" in
   let labels reason = [ ("keeper", keeper_name); ("reason", reason) ] in
   let control_labels = labels "control_checkpoint" in
@@ -43,7 +56,7 @@ let test_wire_capture_suppression_reasons_emit_control_metric () =
   let control_before = metric_value ~labels:control_labels in
   Finalize.emit_wire_capture_response_suppressed_metrics
     ~keeper_name
-    (Finalize.wire_capture_response_suppression_reasons ~control_checkpoint:true);
+    (Finalize.wire_capture_response_suppression_reasons ~control_checkpoint:true ~terminal_effect_settled:false);
   Alcotest.(check (float 0.0001))
     "control checkpoint metric increments"
     (control_before +. 1.0)

--- a/test/test_keeper_wire_capture_suppression.ml
+++ b/test/test_keeper_wire_capture_suppression.ml
@@ -45,8 +45,9 @@ let test_wire_capture_suppression_reasons_emit_control_metric () =
     [ "control_checkpoint"; "terminal_effect_settled" ]
     (reasons ~control_checkpoint:true ~terminal_effect_settled:true);
   let keeper_name = "wirecap_suppression_metric" in
-  let labels reason = [ ("keeper", keeper_name); ("reason", reason) ] in
+  let labels reason = [ "keeper", keeper_name; "reason", reason ] in
   let control_labels = labels "control_checkpoint" in
+  let terminal_labels = labels "terminal_effect_settled" in
   let metric_value ~labels =
     Metrics.metric_value_or_zero
       Keeper_metrics.(to_string WireCaptureResponseSuppressed)
@@ -54,13 +55,20 @@ let test_wire_capture_suppression_reasons_emit_control_metric () =
       ()
   in
   let control_before = metric_value ~labels:control_labels in
+  let terminal_before = metric_value ~labels:terminal_labels in
   Finalize.emit_wire_capture_response_suppressed_metrics
     ~keeper_name
-    (Finalize.wire_capture_response_suppression_reasons ~control_checkpoint:true ~terminal_effect_settled:false);
+    (Finalize.wire_capture_response_suppression_reasons
+       ~control_checkpoint:true
+       ~terminal_effect_settled:true);
   Alcotest.(check (float 0.0001))
     "control checkpoint metric increments"
     (control_before +. 1.0)
-    (metric_value ~labels:control_labels)
+    (metric_value ~labels:control_labels);
+  Alcotest.(check (float 0.0001))
+    "terminal effect metric increments"
+    (terminal_before +. 1.0)
+    (metric_value ~labels:terminal_labels)
 ;;
 
 (* ── consume_replay_response ────────────────────────────────── *)
@@ -151,6 +159,26 @@ let test_direct_response_observation_preserves_raw_response_text () =
     finalized.response_text
 ;;
 
+let test_terminal_effect_completion_suppresses_plain_provider_text () =
+  let suppress_response_text =
+    Finalize.wire_capture_response_suppression_reasons
+      ~control_checkpoint:false
+      ~terminal_effect_settled:true
+    <> []
+  in
+  let finalized =
+    Response_text.finalize
+      ~stop_reason:Runtime_agent.Completed
+      ~raw_response_text:"The approved connector post already went out."
+      ~suppress_response_text
+      ()
+  in
+  Alcotest.(check string)
+    "plain provider text after a terminal replay is not a second reply"
+    ""
+    finalized.response_text
+;;
+
 let () =
   Alcotest.run
     "keeper_wire_capture_suppression"
@@ -189,6 +217,10 @@ let () =
             "direct response observation preserves raw response text"
             `Quick
             test_direct_response_observation_preserves_raw_response_text
+        ; Alcotest.test_case
+            "terminal replay suppresses plain provider text"
+            `Quick
+            test_terminal_effect_completion_suppresses_plain_provider_text
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

Propagate the typed terminal-effect receipt from an approved Host Gate connector replay into turn finalization.

A normal `keeper_surface_post` marks the turn as `External_effect_completed`, but the Host replay path previously discarded the same Discord/Slack destination after sending. The continuation model turn could therefore be finalized as a normal visible reply and deliver a second monologue after the approved post had already gone out.

## Changes

- derive the exact terminal surface target from the durable producer-owned `connector_post` request
- return that receipt alongside the durable replay outcome
- retain the receipt across in-process evidence/journal repair
- recover it from consumed durable `Replay_applied` and `Replay_applied_with_warning` records
- seed the tool bundle terminal state from an applied replay receipt
- leave non-connector, failed, and indeterminate replays non-terminal

## Verification

- `@test/runtest-test_keeper_gate_replay`: 26 passed
- `@test/runtest-test_keeper_turn_outcome`: 29 passed
- `@test/runtest-test_keeper_tool_dispatch_runtime`: 49 passed
- the integration regression constructs a consumed, durably applied Discord approval without network I/O, rebuilds the production tool bundle, and observes `Terminal_effect_completed` for the exact approved channel

Full repository build intentionally left to the operator.

## Relationship

Independent of #28539. That PR owns directive configuration and failure-safe prompt projection; this PR repairs the actual continuation-settlement boundary that prevented an already delivered post from suppressing a second visible reply.