### PR TITLE
Type approval SSE producer events

### DIFF
--- a/dashboard/src/sse-event-type-parity.test.ts
+++ b/dashboard/src/sse-event-type-parity.test.ts
@@ -276,11 +276,38 @@ function parseBackendEmittedEventTypes(libRoot: string): BackendEventEvidence[] 
   return [...evidence].map(([eventType, sourceFile]) => ({ eventType, sourceFile }))
 }
 
+function parseTypedDashboardEventTypes(source: string): Map<string, string> {
+  const mappingStart = source.indexOf('let to_string = function')
+  const mappingEnd = source.indexOf('\n;;', mappingStart)
+  if (mappingStart < 0 || mappingEnd <= mappingStart) {
+    throw new Error('Dashboard_sse_event.to_string exhaustive mapping not found')
+  }
+  const mapping = new Map<string, string>()
+  const mappingSource = source.slice(mappingStart, mappingEnd)
+  for (const match of mappingSource.matchAll(/\|\s+([A-Z][A-Za-z0-9_]*)\s+->\s+"([^"]+)"/g)) {
+    const constructor = match[1]
+    const eventType = match[2]
+    if (constructor && eventType) mapping.set(eventType, constructor)
+  }
+  return mapping
+}
+
 const sseRegistrySource = readFileSync(resolve(process.cwd(), 'src/types/sse-event-registry.ts'), 'utf8')
 const sseRegistryConstants = parseExportedStringConstants(sseRegistrySource)
 const sseStoreSource = readFileSync(resolve(process.cwd(), 'src/sse-store.ts'), 'utf8')
 const feRouted = parseFeRoutedEventTypes(sseStoreSource, sseRegistryConstants)
-const backendEmitted = parseBackendEmittedEventTypes(resolve(process.cwd(), '../lib'))
+const typedBackendEventSource = readFileSync(
+  resolve(process.cwd(), '../lib/dashboard_sse_event/dashboard_sse_event.ml'),
+  'utf8',
+)
+const typedBackendEvents = parseTypedDashboardEventTypes(typedBackendEventSource)
+const backendEmitted = [
+  ...parseBackendEmittedEventTypes(resolve(process.cwd(), '../lib')),
+  ...[...typedBackendEvents.keys()].map(eventType => ({
+    eventType,
+    sourceFile: 'lib/dashboard_sse_event/dashboard_sse_event.ml',
+  })),
+]
 const classified = new Set([
   ...Object.keys(BACKEND_EMITTED),
   ...Object.keys(FE_ONLY_OR_EXTERNAL),
@@ -342,6 +369,15 @@ describe('SSE event-type cross-boundary parity (exact-match routes)', () => {
     )
   })
 
+  it('source-parses the closed typed backend event sum', () => {
+    expect(Object.fromEntries(typedBackendEvents)).toEqual({
+      'approval:pending': 'Approval_pending',
+      'approval:resolved': 'Approval_resolved',
+      'approval:audit': 'Approval_audit',
+      'approval:summary_updated': 'Approval_summary_updated',
+    })
+  })
+
   it('accepts every source-discovered backend SSE event in the closed frontend sum', () => {
     const registered = new Set<string>(SSE_EVENT_TYPES)
     const unregistered = backendEmitted.filter(({ eventType }) => !registered.has(eventType))
@@ -364,7 +400,13 @@ describe('SSE event-type cross-boundary parity (exact-match routes)', () => {
     it(`backend ${backendFile.replace('../', '')} still emits "${eventType}"`, () => {
       const source = readFileSync(resolve(process.cwd(), backendFile), 'utf8')
       const wireType = BACKEND_WIRE_TYPE_ALIASES[eventType] ?? eventType
-      expect(source).toContain(`"${wireType}"`)
+      const typedConstructor = typedBackendEvents.get(wireType)
+      if (typedConstructor) {
+        expect(typedBackendEventSource).toContain(`| ${typedConstructor} -> "${wireType}"`)
+        expect(source).toContain(`Dashboard_sse_event.${typedConstructor}`)
+      } else {
+        expect(source).toContain(`"${wireType}"`)
+      }
     })
   }
 
@@ -374,18 +416,8 @@ describe('SSE event-type cross-boundary parity (exact-match routes)', () => {
   // schema coverage, and nothing bound it to a refresh — so Auto Judge
   // verdicts settled invisibly until the 120-180s periodic sweep. Keep this
   // producer-side positive control in addition to the bilateral registry gate.
-  const backendApprovalEvents = ((): string[] => {
-    const source = readFileSync(
-      resolve(process.cwd(), '../lib/keeper/keeper_approval_queue.ml'),
-      'utf8',
-    )
-    const found = new Set<string>()
-    for (const match of source.matchAll(/"(approval:[a-z_]+)"/g)) {
-      const eventType = match[1]
-      if (eventType !== undefined) found.add(eventType)
-    }
-    return [...found]
-  })()
+  const backendApprovalEvents = [...typedBackendEvents.keys()]
+    .filter(eventType => eventType.startsWith('approval:'))
 
   it('parses a non-empty backend approval:* inventory', () => {
     // Positive control: a rename or regex drift that matches nothing must fail

--- a/lib/dashboard_sse_event/dashboard_sse_event.ml
+++ b/lib/dashboard_sse_event/dashboard_sse_event.ml
@@ -1,0 +1,16 @@
+type t =
+  | Approval_pending
+  | Approval_resolved
+  | Approval_audit
+  | Approval_summary_updated
+
+let to_string = function
+  | Approval_pending -> "approval:pending"
+  | Approval_resolved -> "approval:resolved"
+  | Approval_audit -> "approval:audit"
+  | Approval_summary_updated -> "approval:summary_updated"
+;;
+
+let encode event ~payload =
+  `Assoc [ "type", `String (to_string event); "payload", payload ]
+;;

--- a/lib/dashboard_sse_event/dashboard_sse_event.mli
+++ b/lib/dashboard_sse_event/dashboard_sse_event.mli
@@ -1,0 +1,16 @@
+(** Closed event vocabulary for dashboard SSE producers migrated to the typed
+    broadcast boundary.
+
+    This first slice covers the HITL approval lifecycle. Add a constructor and
+    its exhaustive [to_string] arm before a new wire event can compile. *)
+type t =
+  | Approval_pending
+  | Approval_resolved
+  | Approval_audit
+  | Approval_summary_updated
+
+val to_string : t -> string
+
+(** [encode event ~payload] is the pure JSON boundary. Effectful broadcasting
+    stays in the caller so retry/cancellation policy remains visible there. *)
+val encode : t -> payload:Yojson.Safe.t -> Yojson.Safe.t

--- a/lib/dashboard_sse_event/dune
+++ b/lib/dashboard_sse_event/dune
@@ -5,5 +5,5 @@
  (public_name masc.dashboard_sse_event)
  (wrapped false)
  (flags
-  (:standard -w +4 -w +33))
+  (:standard -w +4 -w +33 -warn-error +8))
  (libraries yojson))

--- a/lib/dashboard_sse_event/dune
+++ b/lib/dashboard_sse_event/dune
@@ -1,0 +1,9 @@
+(include_subdirs no)
+
+(library
+ (name dashboard_sse_event)
+ (public_name masc.dashboard_sse_event)
+ (wrapped false)
+ (flags
+  (:standard -w +4 -w +33))
+ (libraries yojson))

--- a/lib/dune
+++ b/lib/dune
@@ -145,6 +145,9 @@
   ;; lib/dashboard_eval_feed/. 178+59 LoC, deps: stdlib + Yojson +
   ;; masc.agent_core + masc_core (Json_util/Safe_ops).
   masc.dashboard_eval_feed
+  ;; Closed dashboard SSE producer sum + pure JSON encoder. Effectful
+  ;; broadcasting remains in the parent library's caller shells.
+  masc.dashboard_sse_event
   ;; RFC-0056 Phase 1 — Dashboard_tla_specs leaf module extracted to
   ;; lib/dashboard_tla_specs/. 330+87 LoC, deps: stdlib + Yojson + Unix +
   ;; fs_compat (Fs_compat) + masc_core (Json_util/String_util) +

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -1531,9 +1531,9 @@ let merge_loaded_map ~surface ~existing ~loaded =
    hashtable and creates a Dated_jsonl handle. It is also used by synchronous
    tests outside an Eio context, so an Eio mutex would either raise Get_context
    or poison the registry after a recoverable store-creation failure. *)
-let approval_sse_pending_event = "approval:pending"
-let approval_sse_resolved_event = "approval:resolved"
-let approval_sse_summary_event = "approval:summary_updated"
+let approval_sse_pending_event = Dashboard_sse_event.Approval_pending
+let approval_sse_resolved_event = Dashboard_sse_event.Approval_resolved
+let approval_sse_summary_event = Dashboard_sse_event.Approval_summary_updated
 
 let generate_id () = make_generated_id "appr"
 
@@ -1842,15 +1842,14 @@ let pending_entry_json_fields
 let broadcast_pending entry audit_receipt =
   try
     Sse.broadcast
-      (`Assoc
-          [ "type", `String approval_sse_pending_event
-          ; ( "payload"
-            , `Assoc
-                (pending_entry_json_fields
-                   ~include_input:true
-                   entry
-                 @ [ "audit", Keeper_approval.Audit.receipt_to_yojson audit_receipt ]) )
-          ])
+      (Dashboard_sse_event.encode
+         approval_sse_pending_event
+         ~payload:
+           (`Assoc
+              (pending_entry_json_fields
+                 ~include_input:true
+                 entry
+               @ [ "audit", Keeper_approval.Audit.receipt_to_yojson audit_receipt ])))
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
@@ -1914,14 +1913,13 @@ let record_summary_updated ~now (entry : pending_approval) =
        ());
   try
     Sse.broadcast
-      (`Assoc
-         [ "type", `String approval_sse_summary_event
-         ; ( "payload"
-           , `Assoc
-               (pending_entry_json_fields
-                  ~include_input:false
-                  entry) )
-         ])
+      (Dashboard_sse_event.encode
+         approval_sse_summary_event
+         ~payload:
+           (`Assoc
+              (pending_entry_json_fields
+                 ~include_input:false
+                 entry)))
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
@@ -1929,7 +1927,7 @@ let record_summary_updated ~now (entry : pending_approval) =
       ~keeper_name:entry.keeper_name
       ~site:"broadcast_summary"
       ~id:entry.id
-      ~event_type:approval_sse_summary_event
+      ~event_type:(Dashboard_sse_event.to_string approval_sse_summary_event)
       exn
 ;;
 
@@ -2878,17 +2876,16 @@ let resolve_entry
   before_terminal_publish ();
   (try
      Sse.broadcast
-       (`Assoc
-           [ "type", `String approval_sse_resolved_event
-           ; ( "payload"
-             , `Assoc
-                 [ "id", `String entry.id
-                 ; "keeper_name", `String entry.keeper_name
-                 ; "tool_name", `String entry.tool_name
-                 ; "decision", `String decision_str
-                 ; "audit", Keeper_approval.Audit.receipt_to_yojson audit_receipt
-                 ] )
-           ])
+       (Dashboard_sse_event.encode
+          approval_sse_resolved_event
+          ~payload:
+            (`Assoc
+               [ "id", `String entry.id
+               ; "keeper_name", `String entry.keeper_name
+               ; "tool_name", `String entry.tool_name
+               ; "decision", `String decision_str
+               ; "audit", Keeper_approval.Audit.receipt_to_yojson audit_receipt
+               ]))
    with
    | Eio.Cancel.Cancelled _ as e -> raise e
    | exn ->

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -259,7 +259,7 @@ let audit_receipts_to_yojson receipts =
   `List (List.map Keeper_approval.Audit.receipt_to_yojson receipts)
 ;;
 
-let approval_sse_audit_event = "approval:audit"
+let approval_sse_audit_event = Dashboard_sse_event.Approval_audit
 
 let authorization_subject_id = function
   | One_shot_resolution approval_id -> Some approval_id
@@ -281,14 +281,13 @@ let broadcast_failed_authorization_audits ~keeper_name ~source receipts =
        | Error _ ->
          (try
             Sse.broadcast
-              (`Assoc
-                  [ "type", `String approval_sse_audit_event
-                  ; ( "payload"
-                    , `Assoc
-                        [ "id", Json_util.string_opt_to_json id
-                        ; "audit", Keeper_approval.Audit.receipt_to_yojson receipt
-                        ] )
-                  ])
+              (Dashboard_sse_event.encode
+                 approval_sse_audit_event
+                 ~payload:
+                   (`Assoc
+                      [ "id", Json_util.string_opt_to_json id
+                      ; "audit", Keeper_approval.Audit.receipt_to_yojson receipt
+                      ]))
           with
           | Eio.Cancel.Cancelled _ as exn ->
             (* Authorization is already committed.  This observation lane must

--- a/test/dashboard_sse_event/dune
+++ b/test/dashboard_sse_event/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_dashboard_sse_event)
+ (libraries dashboard_sse_event alcotest yojson fmt))

--- a/test/dashboard_sse_event/test_dashboard_sse_event.ml
+++ b/test/dashboard_sse_event/test_dashboard_sse_event.ml
@@ -1,0 +1,48 @@
+let event_cases =
+  [ Dashboard_sse_event.Approval_pending, "approval:pending"
+  ; Dashboard_sse_event.Approval_resolved, "approval:resolved"
+  ; Dashboard_sse_event.Approval_audit, "approval:audit"
+  ; Dashboard_sse_event.Approval_summary_updated, "approval:summary_updated"
+  ]
+;;
+
+let test_closed_wire_vocabulary () =
+  List.iter
+    (fun (event, expected) ->
+       Alcotest.(check string)
+         expected
+         expected
+         (Dashboard_sse_event.to_string event))
+    event_cases;
+  let distinct =
+    event_cases
+    |> List.map snd
+    |> List.sort_uniq String.compare
+    |> List.length
+  in
+  Alcotest.(check int) "wire names are unique" (List.length event_cases) distinct
+;;
+
+let test_pure_encoder_preserves_payload () =
+  let payload = `Assoc [ "id", `String "appr-1" ] in
+  let expected =
+    `Assoc
+      [ "type", `String "approval:pending"
+      ; "payload", payload
+      ]
+  in
+  Alcotest.(check (testable (Fmt.of_to_string Yojson.Safe.to_string) ( = )))
+    "typed event encodes canonical type before payload"
+    expected
+    (Dashboard_sse_event.encode Dashboard_sse_event.Approval_pending ~payload)
+;;
+
+let () =
+  Alcotest.run
+    "dashboard_sse_event"
+    [ ( "closed_sum"
+      , [ Alcotest.test_case "wire vocabulary" `Quick test_closed_wire_vocabulary
+        ; Alcotest.test_case "pure encoder" `Quick test_pure_encoder_preserves_payload
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Stack

- Depends on #28570 (`fix/dashboard-sse-event-registry`)
- Base commit: `328075e9b54241796686997347bdf240521ec1df`

## What changed

- add a closed OCaml `Dashboard_sse_event.t` sum for the four HITL approval events
- add exhaustive constructor-to-wire encoding and a pure canonical JSON encoder
- make incomplete event matches a compile error for the leaf library
- replace approval queue/gate string event constants with typed constructors
- keep `Sse.broadcast` and cancellation/error handling in the existing effect shells
- teach the #28570 parity test to source-parse the typed OCaml sum and prove constructor use at each producer

## Why

#28570 closes the frontend event registry, but backend approval producers still owned raw string literals. A producer rename or dynamically assembled value could therefore bypass compiler checking. This first minimal migration makes the HITL approval lifecycle compile against a closed backend sum without adding legacy or prefix compatibility.

## Impact

`approval:pending`, `approval:resolved`, `approval:audit`, and `approval:summary_updated` preserve their exact JSON wire shape. New approval event names require an OCaml constructor, an exhaustive encoder arm, producer use, and frontend registry parity.

## Validation

- direct `ocamlfind/ocamlc` compile of `dashboard_sse_event.mli` and `.ml`
- direct Alcotest execution: 2/2 passed
- `ocamlc -stop-after parsing` for both modified keeper effect shells
- `pnpm exec vitest run src/sse-event-type-parity.test.ts` — 48/48 passed
- `pnpm run typecheck`
- changed-file ESLint
- `ocamlformat --check` (repository formatting disabled by policy)

Local Dune was intentionally not run.
