### PR TITLE
feat(dashboard): project sandbox routing trust

### DIFF
--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -104,6 +104,8 @@ let compact_keeper_trust_json ~(config : Workspace.config) ~(meta : Keeper_meta_
     ; "next_human_action", member "next_human_action"
     ; "approval_state", member "approval"
     ; "execution_summary", member "execution"
+    ; "sandbox_routing", member "sandbox_routing"
+    ; "sandbox_routing_attention", member "sandbox_routing_attention"
     ; "latest_terminal_reason", member "latest_terminal_reason"
     ; "latest_next_action", member "latest_next_action"
     ; "latest_causal_event", member "latest_causal_event"

--- a/lib/dashboard/dashboard_http_keeper_trust.ml
+++ b/lib/dashboard/dashboard_http_keeper_trust.ml
@@ -74,6 +74,8 @@ let keeper_trust_json ?(include_receipt = false)
       ("next_human_action", Option.value ~default:`Null (Json_util.assoc_member_opt "next_human_action" runtime_trust));
       ("approval_state", Option.value ~default:`Null (Json_util.assoc_member_opt "approval" runtime_trust));
       ("execution_summary", Option.value ~default:`Null (Json_util.assoc_member_opt "execution" runtime_trust));
+      ("sandbox_routing", Option.value ~default:`Null (Json_util.assoc_member_opt "sandbox_routing" runtime_trust));
+      ("sandbox_routing_attention", Option.value ~default:`Null (Json_util.assoc_member_opt "sandbox_routing_attention" runtime_trust));
       ( "latest_terminal_reason",
         Option.value ~default:`Null (Json_util.assoc_member_opt "latest_terminal_reason" runtime_trust) );
       ("latest_next_action", Option.value ~default:`Null (Json_util.assoc_member_opt "latest_next_action" runtime_trust));

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -54,6 +54,7 @@ module Snapshot_cache = struct
 end
 
 module Completion_contract_result = Keeper_completion_contract_result_label
+module Sandbox_routing = Keeper_sandbox_routing_dashboard_projection
 
 let terminal_reason_from_decision json =
   match json_member "terminal_reason" json with
@@ -297,7 +298,12 @@ let approval_queue_state_of_projection
 
 let trust_model_of_observations ~pending_approval_projection
     ~runtime_blocker_fields ~latest_receipt ~latest_next_action
-    ~attention_fields =
+    ~attention_fields ~sandbox_routing =
+  let sandbox_routing_attention =
+    Sandbox_routing.attention sandbox_routing
+    |> Option.map (fun attention ->
+      attention.Sandbox_routing.reason, attention.next_human_action)
+  in
   Trust_core.decide
     { approval_queue =
         approval_queue_state_of_projection pending_approval_projection
@@ -312,6 +318,7 @@ let trust_model_of_observations ~pending_approval_projection
     ; attention_reason = assoc_string_opt "attention_reason" attention_fields
     ; attention_next_human_action =
         assoc_string_opt "next_human_action" attention_fields
+    ; sandbox_routing_attention
     ; terminal_next_human_action = latest_next_action
     }
 ;;
@@ -522,7 +529,11 @@ let approval_queue_unavailable_timeline_event ~observed_at_unix
             ("observation_only", `Bool false);
           ])
 
-let execution_summary_json ~(meta : Keeper_meta_contract.keeper_meta) ~latest_receipt =
+let execution_summary_json
+      ~(meta : Keeper_meta_contract.keeper_meta)
+      ~latest_receipt
+      ~sandbox_routing
+  =
   let sandbox_kind =
     match latest_receipt with
     | Some receipt ->
@@ -613,6 +624,11 @@ let execution_summary_json ~(meta : Keeper_meta_contract.keeper_meta) ~latest_re
       ("completion_observation_summary", `String completion_observation_summary);
       ( "latest_receipt_at",
         Json_util.string_opt_to_json (Option.bind latest_receipt (json_string_opt_member "ended_at")) );
+      ( "sandbox_routing",
+        Sandbox_routing.descriptor_to_yojson sandbox_routing );
+      ( "sandbox_routing_attention",
+        Sandbox_routing.attention sandbox_routing
+        |> Sandbox_routing.attention_to_yojson );
     ]
 
 let latest_causal_event_summary ~observed_at_unix ~meta ~latest_decision
@@ -729,6 +745,11 @@ let collect_summary_raw ~(config : Workspace.config) ~(meta : keeper_meta) =
 ;;
 
 let summary_json_of_raw ~(meta : keeper_meta) (raw : raw_observations) =
+  let sandbox_routing =
+    match raw.latest_receipt with
+    | Some receipt -> Sandbox_routing.of_receipt receipt
+    | None -> Sandbox_routing.Absent
+  in
   let latest_receipt_for_runtime_state =
     current_receipt_for_runtime_state ~meta
       ~runtime_blocker_fields:raw.runtime_blocker_fields raw.latest_receipt
@@ -752,9 +773,11 @@ let summary_json_of_raw ~(meta : keeper_meta) (raw : raw_observations) =
       ~runtime_blocker_fields:raw.runtime_blocker_fields
       ~latest_receipt:latest_receipt_for_runtime_state
       ~latest_next_action ~attention_fields:raw.attention_fields
+      ~sandbox_routing
   in
   let execution_summary =
     execution_summary_json ~meta ~latest_receipt:raw.latest_receipt
+      ~sandbox_routing
   in
   let approval_state =
     approval_state_json
@@ -782,6 +805,11 @@ let summary_json_of_raw ~(meta : keeper_meta) (raw : raw_observations) =
      @ [ ("approval_queue_state", raw.pending_approval_projection.state)
        ; ("approval", approval_state)
        ; ("execution", execution_summary)
+       ; ( "sandbox_routing",
+           Sandbox_routing.descriptor_to_yojson sandbox_routing )
+       ; ( "sandbox_routing_attention",
+           Sandbox_routing.attention sandbox_routing
+           |> Sandbox_routing.attention_to_yojson )
        ; ("latest_terminal_reason", latest_terminal_reason_json)
        ; ("latest_next_action", Json_util.string_opt_to_json latest_next_action)
        ; ("latest_causal_event", latest_causal_event)
@@ -924,6 +952,11 @@ let collect_raw_snapshot_with_pending_reader
 
 let snapshot_json_of_raw ~(meta : keeper_meta) (raw : raw_snapshot) =
   let observations = raw.observations in
+  let sandbox_routing =
+    match observations.latest_receipt with
+    | Some receipt -> Sandbox_routing.of_receipt receipt
+    | None -> Sandbox_routing.Absent
+  in
   let latest_receipt_for_runtime_state =
     current_receipt_for_runtime_state ~meta
       ~runtime_blocker_fields:observations.runtime_blocker_fields
@@ -958,6 +991,7 @@ let snapshot_json_of_raw ~(meta : keeper_meta) (raw : raw_snapshot) =
       ~runtime_blocker_fields:observations.runtime_blocker_fields
       ~latest_receipt:latest_receipt_for_runtime_state ~latest_next_action
       ~attention_fields:observations.attention_fields
+      ~sandbox_routing
   in
   let approval_state =
     approval_state_json
@@ -966,6 +1000,7 @@ let snapshot_json_of_raw ~(meta : keeper_meta) (raw : raw_snapshot) =
   in
   let execution_summary =
     execution_summary_json ~meta ~latest_receipt:observations.latest_receipt
+      ~sandbox_routing
   in
   let causal_timeline =
     causal_timeline_json
@@ -1015,6 +1050,11 @@ let snapshot_json_of_raw ~(meta : keeper_meta) (raw : raw_snapshot) =
      @ [ ("approval_queue_state", observations.pending_approval_projection.state)
        ; ("approval", approval_state)
        ; ("execution", execution_summary)
+       ; ( "sandbox_routing",
+           Sandbox_routing.descriptor_to_yojson sandbox_routing )
+       ; ( "sandbox_routing_attention",
+           Sandbox_routing.attention sandbox_routing
+           |> Sandbox_routing.attention_to_yojson )
        ; ("latest_terminal_reason", latest_terminal_reason_json)
        ; ("latest_next_action", Json_util.string_opt_to_json latest_next_action)
        ; ( "pending_approval_count"

--- a/lib/keeper/keeper_runtime_trust_snapshot_core.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot_core.ml
@@ -10,6 +10,7 @@ type raw =
   ; attention_needs_attention : bool
   ; attention_reason : string option
   ; attention_next_human_action : string option
+  ; sandbox_routing_attention : (string * string) option
   ; terminal_next_human_action : string option
   }
 
@@ -94,10 +95,16 @@ let decide raw =
   in
   let needs_attention =
     raw.attention_needs_attention
+    || Option.is_some raw.sandbox_routing_attention
     || display_disposition_requires_attention disposition
   in
   let attention_reason =
     match raw.attention_reason with
+    | Some _ as reason -> reason
+    | None -> Option.map fst raw.sandbox_routing_attention
+  in
+  let attention_reason =
+    match attention_reason with
     | Some _ as reason -> reason
     | None when needs_attention -> Some disposition_reason
     | None -> None
@@ -105,8 +112,11 @@ let decide raw =
   let next_human_action =
     match raw.attention_next_human_action with
     | Some _ as action -> action
-    | None when needs_attention -> raw.terminal_next_human_action
-    | None -> None
+    | None ->
+      (match raw.sandbox_routing_attention with
+       | Some (_, action) -> Some action
+       | None when needs_attention -> raw.terminal_next_human_action
+       | None -> None)
   in
   { disposition
   ; disposition_reason

--- a/lib/keeper/keeper_runtime_trust_snapshot_core.mli
+++ b/lib/keeper/keeper_runtime_trust_snapshot_core.mli
@@ -16,6 +16,7 @@ type raw =
   ; attention_needs_attention : bool
   ; attention_reason : string option
   ; attention_next_human_action : string option
+  ; sandbox_routing_attention : (string * string) option
   ; terminal_next_human_action : string option
   }
 

--- a/lib/keeper/keeper_sandbox_routing_dashboard_projection.ml
+++ b/lib/keeper/keeper_sandbox_routing_dashboard_projection.ml
@@ -1,0 +1,160 @@
+type failure_status =
+  | Mismatch
+  | Unobserved
+
+type violation =
+  | Effective_resolution_unavailable
+  | Config_effective_mismatch
+  | Receipt_evidence_unavailable
+  | Effective_receipt_mismatch
+
+type verification =
+  | Verified of { containment : string }
+  | Not_verified of
+      { status : failure_status
+      ; violation : violation
+      ; detail : string
+      }
+
+type observation =
+  | Absent
+  | Observed of
+      { descriptor : Yojson.Safe.t
+      ; verification : verification
+      }
+  | Invalid_descriptor of
+      { descriptor : Yojson.Safe.t
+      ; detail : string
+      }
+
+type attention =
+  { reason : string
+  ; next_human_action : string
+  }
+
+let nonempty_string field json =
+  match Json_util.assoc_string_opt field json with
+  | Some value when String.trim value <> "" -> Ok value
+  | Some _ | None -> Error (field ^ " must be a non-empty string")
+;;
+
+let violation_of_string = function
+  | "effective_resolution_unavailable" -> Some Effective_resolution_unavailable
+  | "config_effective_mismatch" -> Some Config_effective_mismatch
+  | "receipt_evidence_unavailable" -> Some Receipt_evidence_unavailable
+  | "effective_receipt_mismatch" -> Some Effective_receipt_mismatch
+  | _ -> None
+;;
+
+let violation_to_string = function
+  | Effective_resolution_unavailable -> "effective_resolution_unavailable"
+  | Config_effective_mismatch -> "config_effective_mismatch"
+  | Receipt_evidence_unavailable -> "receipt_evidence_unavailable"
+  | Effective_receipt_mismatch -> "effective_receipt_mismatch"
+;;
+
+let violation_matches_status status violation =
+  match status, violation with
+  | ( Mismatch
+    , (Config_effective_mismatch | Effective_receipt_mismatch) )
+  | ( Unobserved
+    , (Effective_resolution_unavailable | Receipt_evidence_unavailable) ) ->
+    true
+  | (Mismatch, (Effective_resolution_unavailable | Receipt_evidence_unavailable))
+  | (Unobserved, (Config_effective_mismatch | Effective_receipt_mismatch)) ->
+    false
+;;
+
+let decode_verification descriptor =
+  match Json_util.assoc_string_opt "schema" descriptor with
+  | Some "masc.keeper.sandbox-routing.v1" ->
+    (match Json_util.assoc_member_opt "verification" descriptor with
+     | None -> Error "verification object is missing"
+     | Some verification ->
+       (match nonempty_string "status" verification with
+        | Error _ as error -> error
+        | Ok "verified" ->
+          (match nonempty_string "containment" verification with
+           | Ok "not_verified" ->
+             Error "verified routing cannot use containment=not_verified"
+           | Ok containment -> Ok (Verified { containment })
+           | Error _ as error -> error)
+        | Ok ("mismatch" as status) | Ok ("unobserved" as status) ->
+          (match nonempty_string "containment" verification with
+           | Ok "not_verified" ->
+             (match
+                nonempty_string "violation" verification,
+                nonempty_string "detail" verification
+              with
+              | Ok violation_wire, Ok detail ->
+                let status =
+                  if String.equal status "mismatch" then Mismatch else Unobserved
+                in
+                (match violation_of_string violation_wire with
+                 | Some violation when violation_matches_status status violation ->
+                   Ok (Not_verified { status; violation; detail })
+                 | Some _ ->
+                   Error
+                     "sandbox routing violation is inconsistent with verification status"
+                 | None ->
+                   Error
+                     ("unknown sandbox routing violation: " ^ violation_wire))
+              | Error error, _ | _, Error error -> Error error)
+           | Ok containment ->
+             Error
+               (Printf.sprintf
+                  "%s routing must use containment=not_verified, got %s"
+                  status
+                  containment)
+           | Error _ as error -> error)
+        | Ok status ->
+          Error ("unknown sandbox routing verification status: " ^ status)))
+  | Some schema -> Error ("unknown sandbox routing descriptor schema: " ^ schema)
+  | None -> Error "sandbox routing descriptor schema is missing"
+;;
+
+let of_receipt receipt =
+  match Json_util.assoc_member_opt "sandbox" receipt with
+  | None -> Absent
+  | Some sandbox ->
+    (match Json_util.assoc_member_opt "routing" sandbox with
+     | None | Some `Null -> Absent
+     | Some descriptor ->
+       (match decode_verification descriptor with
+        | Ok verification -> Observed { descriptor; verification }
+        | Error detail -> Invalid_descriptor { descriptor; detail }))
+;;
+
+let descriptor_to_yojson = function
+  | Absent -> `Null
+  | Observed { descriptor; _ }
+  | Invalid_descriptor { descriptor; _ } ->
+    descriptor
+;;
+
+let next_human_action = "inspect_sandbox_routing_evidence"
+
+let attention = function
+  | Absent | Observed { verification = Verified _; _ } -> None
+  | Observed
+      { verification = Not_verified { violation; _ }; _ } ->
+    Some
+      { reason = "sandbox_routing_" ^ violation_to_string violation
+      ; next_human_action
+      }
+  | Invalid_descriptor _ ->
+    Some
+      { reason = "sandbox_routing_descriptor_invalid"
+      ; next_human_action
+      }
+;;
+
+let attention_to_yojson = function
+  | None -> `Null
+  | Some attention ->
+    `Assoc
+      [ "needs_attention", `Bool true
+      ; "reason", `String attention.reason
+      ; "next_human_action", `String attention.next_human_action
+      ]
+;;

--- a/lib/keeper/keeper_sandbox_routing_dashboard_projection.mli
+++ b/lib/keeper/keeper_sandbox_routing_dashboard_projection.mli
@@ -1,0 +1,51 @@
+(** Pure backend projection of the canonical execution-receipt
+    [sandbox.routing] descriptor. *)
+
+type failure_status =
+  | Mismatch
+  | Unobserved
+
+type violation =
+  | Effective_resolution_unavailable
+  | Config_effective_mismatch
+  | Receipt_evidence_unavailable
+  | Effective_receipt_mismatch
+
+type verification =
+  | Verified of { containment : string }
+  | Not_verified of
+      { status : failure_status
+      ; violation : violation
+      ; detail : string
+      }
+
+type observation =
+  | Absent
+  | Observed of
+      { descriptor : Yojson.Safe.t
+      ; verification : verification
+      }
+  | Invalid_descriptor of
+      { descriptor : Yojson.Safe.t
+      ; detail : string
+      }
+
+type attention =
+  { reason : string
+  ; next_human_action : string
+  }
+
+val of_receipt : Yojson.Safe.t -> observation
+(** Decode only [receipt.sandbox.routing]. Missing evidence remains [Absent];
+    flat sandbox fields and the duplicate runtime-contract projection are not
+    fallback evidence. *)
+
+val descriptor_to_yojson : observation -> Yojson.Safe.t
+(** [Absent] becomes JSON [null]. Present descriptors retain their exact
+    receipt value, including malformed descriptors that require attention. *)
+
+val attention : observation -> attention option
+(** Verified evidence has no sandbox-routing attention. Mismatch, unobserved,
+    and malformed evidence require operator inspection. *)
+
+val attention_to_yojson : attention option -> Yojson.Safe.t

--- a/test/test_keeper_runtime_trust_snapshot.ml
+++ b/test/test_keeper_runtime_trust_snapshot.ml
@@ -978,6 +978,143 @@ let test_approval_queue_failure_remains_typed_unavailable () =
           |> to_string))
 ;;
 
+let sandbox_routing_descriptor ~status ~containment ~violation ~detail =
+  `Assoc
+    [ "schema", `String "masc.keeper.sandbox-routing.v1"
+    ; "config_requested", `String "docker_contained"
+    ; ( "resolved_effective"
+      , `Assoc
+          [ "status", `String "resolved"
+          ; "boundary", `String "host_local"
+          ] )
+    ; ( "receipt_evidence"
+      , `Assoc
+          [ "status", `String "observed"
+          ; "boundary", `String "host_local"
+          ] )
+    ; ( "verification"
+      , `Assoc
+          [ "status", `String status
+          ; "containment", `String containment
+          ; "violation", violation
+          ; "detail", detail
+          ] )
+    ]
+;;
+
+let routing_receipt descriptor =
+  `Assoc
+    [ "ended_at", `String "2026-08-13T00:00:00Z"
+    ; "operator_disposition", `String "pass"
+    ; "operator_disposition_reason", `String "healthy"
+    ; "terminal_reason_code", `String "success"
+    ; "completion_contract_result", `String "response_observed"
+    ; ( "sandbox"
+      , `Assoc
+          [ "kind", `String "local"
+          ; "network_mode", `String "inherit"
+          ; "routing", descriptor
+          ] )
+    ]
+;;
+
+let test_sandbox_routing_mismatch_projects_attention_from_descriptor () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> remove_tree base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      let meta = make_meta "runtime-trust-sandbox-routing-mismatch" in
+      let descriptor =
+        sandbox_routing_descriptor
+          ~status:"mismatch"
+          ~containment:"not_verified"
+          ~violation:(`String "config_effective_mismatch")
+          ~detail:(`String "config requested Docker but runtime resolved local")
+      in
+      Masc.Keeper_types_support.keeper_execution_receipt_store config meta.name
+      |> fun store -> Dated_jsonl.append store (routing_receipt descriptor);
+      let snapshot =
+        K.For_testing.snapshot_json_inner_with_pending_reader
+          ~read_pending:(fun ~base_path:_ -> Ok [])
+          ~config
+          ~meta
+      in
+      let open Yojson.Safe.Util in
+      Alcotest.(check bool)
+        "descriptor is projected without re-inference"
+        true
+        (snapshot |> member "sandbox_routing" = descriptor);
+      Alcotest.(check bool)
+        "execution summary shares descriptor"
+        true
+        (snapshot |> member "execution" |> member "sandbox_routing" = descriptor);
+      Alcotest.(check bool)
+        "routing mismatch requires attention"
+        true
+        (snapshot |> member "needs_attention" |> to_bool);
+      Alcotest.(check string)
+        "attention reason comes from typed violation"
+        "sandbox_routing_config_effective_mismatch"
+        (snapshot |> member "attention_reason" |> to_string);
+      Alcotest.(check string)
+        "routing attention has an operator action"
+        "inspect_sandbox_routing_evidence"
+        (snapshot |> member "next_human_action" |> to_string);
+      Alcotest.(check string)
+        "nested routing attention uses the same reason"
+        "sandbox_routing_config_effective_mismatch"
+        (snapshot
+         |> member "sandbox_routing_attention"
+         |> member "reason"
+         |> to_string);
+      let dashboard_trust =
+        Masc.Dashboard_http_keeper_trust.keeper_trust_json config meta
+      in
+      Alcotest.(check bool)
+        "dashboard trust API exposes the same descriptor"
+        true
+        (dashboard_trust |> member "sandbox_routing" = descriptor))
+;;
+
+let test_sandbox_routing_verified_or_absent_projects_optional_null () =
+  let verified =
+    sandbox_routing_descriptor
+      ~status:"verified"
+      ~containment:"docker_contained"
+      ~violation:`Null
+      ~detail:`Null
+  in
+  let verified_observation =
+    Masc.Keeper_sandbox_routing_dashboard_projection.of_receipt
+      (routing_receipt verified)
+  in
+  Alcotest.(check bool)
+    "verified descriptor remains present"
+    true
+    (Masc.Keeper_sandbox_routing_dashboard_projection.descriptor_to_yojson
+       verified_observation
+     = verified);
+  Alcotest.(check bool)
+    "verified descriptor has no attention"
+    true
+    (Masc.Keeper_sandbox_routing_dashboard_projection.attention
+       verified_observation
+     = None);
+  let absent =
+    Masc.Keeper_sandbox_routing_dashboard_projection.of_receipt
+      (`Assoc [ "sandbox", `Assoc [ "routing", `Null ] ])
+  in
+  Alcotest.(check bool)
+    "absent routing evidence stays JSON null"
+    true
+    (Masc.Keeper_sandbox_routing_dashboard_projection.descriptor_to_yojson absent
+     = `Null)
+;;
+
 let () =
   Alcotest.run
     "keeper_runtime_trust_snapshot"
@@ -1068,6 +1205,16 @@ let () =
             "queue failure remains typed unavailable"
             `Quick
             test_approval_queue_failure_remains_typed_unavailable
+        ] )
+    ; ( "sandbox_routing_projection"
+      , [ Alcotest.test_case
+            "mismatch projects descriptor attention"
+            `Quick
+            test_sandbox_routing_mismatch_projects_attention_from_descriptor
+        ; Alcotest.test_case
+            "verified and absent evidence project optional null"
+            `Quick
+            test_sandbox_routing_verified_or_absent_projects_optional_null
         ] )
     ]
 ;;


### PR DESCRIPTION
## Stack

- Parent: #28572
- Exact parent head used: e99146f87c349f64f0fe77d43146f38d6bcbe84c

## What

- Decode only canonical execution receipt sandbox.routing using a closed typed projection.
- Preserve the exact routing descriptor in runtime trust, keeper trust API, execution summary, and compact dashboard trust.
- Preserve missing receipt evidence as JSON null.
- Raise operator attention from the same SSOT for mismatch, unobserved, or invalid descriptors, even when the legacy operator disposition says pass.
- Reject unknown schemas, statuses, violation labels, inconsistent status/violation pairs, and false verified containment.
- Do not infer containment from flat sandbox_profile/network_mode or runtime_contract fallback fields.

## Focused proof

- mismatch descriptor is projected unchanged and forces typed operator attention
- verified descriptor stays present without attention
- absent descriptor stays JSON null
- dashboard keeper trust API exposes the same descriptor

## Validation

- ocamlc parsing for all changed ML/MLI files
- ocamlformat --check
- git diff --check
- scripts/check-ssot.sh
- scripts/lint/no-provider-name-hardcoding.sh
- scripts/ci/check-silent-failure-patterns.sh
- scripts/ocaml-structure-ratchet.sh
- scripts/check-agent-core-boundary.sh

Local Dune was intentionally not run per stack constraint.

## Follow-up gaps

- dashboard DOM/browser rendering and screenshot proof
- live Docker/private-canary execution
- live config mutation, restart, and network checks