### PR TITLE
feat(keeper): inventory Agent Core execution journals

### DIFF
--- a/lib/keeper/keeper_agent_core_execution_inventory.ml
+++ b/lib/keeper/keeper_agent_core_execution_inventory.ml
@@ -1,0 +1,135 @@
+module Core = Keeper_agent_core_execution_inventory_core
+module Identity = Keeper_agent_core_execution_identity
+module Store = Keeper_agent_core_execution_store
+
+type inventory = Core.t
+
+type read_error =
+  | Filesystem_unavailable
+  | Journal_root_not_directory
+  | Journal_root_unreadable
+
+type payload_observation =
+  | Payload_missing
+  | Payload_valid of string
+  | Payload_invalid
+
+let locator_leaf = "recovery-locator.json"
+let terminal_leaf = "terminal-disposition.json"
+let max_record_length = Int64.of_int (1024 * 1024)
+
+let read_record ~parent ~leaf =
+  try
+    match Eio.Path.kind ~follow:false Eio.Path.(parent / leaf) with
+    | `Not_found -> Payload_missing
+    | `Regular_file ->
+      let stat = Eio.Path.stat ~follow:false Eio.Path.(parent / leaf) in
+      let expected_length = Optint.Int63.to_int64 stat.size in
+      (match
+         Fs_compat.Capability_exact_read.read
+           ~parent
+           ~leaf
+           ~expected_length
+           ~max_length:max_record_length
+       with
+       | Error _ -> Payload_invalid
+       | Ok observation ->
+         if
+           Fs_compat.Capability_exact_read.observation_settlement_warnings observation
+           <> []
+         then Payload_invalid
+         else
+           Payload_valid
+             (Fs_compat.Capability_exact_read.observation_bytes observation))
+    | `Unknown
+    | `Fifo
+    | `Character_special
+    | `Directory
+    | `Block_device
+    | `Symbolic_link
+    | `Socket -> Payload_invalid
+  with
+  | Eio.Io _ -> Payload_invalid
+;;
+
+let observe_locator ~parent ~operation_id =
+  match read_record ~parent ~leaf:locator_leaf with
+  | Payload_missing -> Core.Locator_missing
+  | Payload_invalid -> Core.Locator_invalid
+  | Payload_valid bytes ->
+    (match Store.validate_locator_record ~operation_id bytes with
+     | Ok () -> Core.Locator_valid
+     | Error _ -> Core.Locator_invalid)
+;;
+
+let observe_terminal ~parent ~operation_id =
+  match read_record ~parent ~leaf:terminal_leaf with
+  | Payload_missing -> Core.Terminal_missing
+  | Payload_invalid -> Core.Terminal_invalid
+  | Payload_valid bytes ->
+    (match Store.decode_terminal_record ~operation_id bytes with
+     | Ok terminal -> Core.Terminal_valid terminal
+     | Error _ -> Core.Terminal_invalid)
+;;
+
+let operation_entry ~root operation_id =
+  let parent =
+    Eio.Path.(root / Identity.operation_id_to_string operation_id)
+  in
+  try
+    match Eio.Path.kind ~follow:false parent with
+    | `Directory ->
+      let locator = observe_locator ~parent ~operation_id in
+      let terminal = observe_terminal ~parent ~operation_id in
+      Core.operation_entry operation_id (Core.classify ~locator ~terminal)
+    | `Not_found -> Core.operation_entry operation_id (Core.Corrupt Core.Scope_unreadable)
+    | `Unknown
+    | `Fifo
+    | `Character_special
+    | `Regular_file
+    | `Block_device
+    | `Symbolic_link
+    | `Socket -> Core.operation_entry operation_id (Core.Corrupt Core.Scope_not_directory)
+  with
+  | Eio.Io _ -> Core.operation_entry operation_id (Core.Corrupt Core.Scope_unreadable)
+;;
+
+let inventory_entry ~root entry_name =
+  match Identity.operation_id_of_string entry_name with
+  | Ok operation_id -> operation_entry ~root operation_id
+  | Error _ -> Core.unrecognized_entry ~entry_name
+;;
+
+let read ~base_path =
+  match Fs_compat.get_fs_opt () with
+  | None -> Error Filesystem_unavailable
+  | Some fs ->
+    let root_path = Config_dir_resolver.agent_execution_journals_dir ~base_path in
+    let root = Eio.Path.(fs / root_path) in
+    (try
+       match Eio.Path.kind ~follow:false root with
+       | `Not_found -> Ok (Core.create [])
+       | `Directory ->
+         Eio.Path.read_dir root
+         |> List.map (inventory_entry ~root)
+         |> Core.create
+         |> Result.ok
+       | `Unknown
+       | `Fifo
+       | `Character_special
+       | `Regular_file
+       | `Block_device
+       | `Symbolic_link
+       | `Socket -> Error Journal_root_not_directory
+     with
+     | Eio.Io _ -> Error Journal_root_unreadable)
+;;
+
+let to_yojson = Core.to_yojson
+
+let read_error_to_string = function
+  | Filesystem_unavailable -> "Eio filesystem capability is unavailable"
+  | Journal_root_not_directory ->
+    "Agent Core execution-journal root is not a directory"
+  | Journal_root_unreadable -> "Agent Core execution-journal root is unreadable"
+;;

--- a/lib/keeper/keeper_agent_core_execution_inventory.mli
+++ b/lib/keeper/keeper_agent_core_execution_inventory.mli
@@ -1,0 +1,19 @@
+(** Capability-backed reader for the Agent Core execution-journal SSOT.
+
+    Filesystem effects stop at this module.  Callers receive the pure typed
+    projection from {!Keeper_agent_core_execution_inventory_core}; raw record
+    payloads and filesystem paths are never returned. *)
+
+type inventory = Keeper_agent_core_execution_inventory_core.t
+
+type read_error =
+  | Filesystem_unavailable
+  | Journal_root_not_directory
+  | Journal_root_unreadable
+
+val read : base_path:string -> (inventory, read_error) result
+(** Read a point-in-time startup/operator inventory.  A missing SSOT root is an
+    empty inventory.  An unreadable or unsafe root is a typed failure. *)
+
+val to_yojson : inventory -> Yojson.Safe.t
+val read_error_to_string : read_error -> string

--- a/lib/keeper/keeper_agent_core_execution_store.ml
+++ b/lib/keeper/keeper_agent_core_execution_store.ml
@@ -33,6 +33,12 @@ type prepared =
 type factory =
   Keeper_agent_core_execution_identity.t -> (prepared, prepare_error) result
 
+type journal_record_error =
+  | Record_json_invalid
+  | Record_envelope_invalid
+  | Record_operation_mismatch
+  | Record_payload_invalid
+
 let locator_leaf = "recovery-locator.json"
 let terminal_leaf = "terminal-disposition.json"
 let schema_version = 1
@@ -149,13 +155,16 @@ let locator_record_to_yojson operation locator =
     ]
 ;;
 
-let locator_record_of_yojson operation = function
+type locator_envelope =
+  { observed_operation_id : string
+  ; observed_operation : Yojson.Safe.t
+  ; locator_json : Yojson.Safe.t
+  }
+
+let locator_envelope_of_yojson = function
   | `Assoc fields
     when exact_fields [ "schema_version"; "operation_id"; "operation"; "locator" ] fields
     ->
-    let operation_id =
-      Keeper_agent_core_execution_identity.operation_id operation
-    in
     (match
        List.assoc "schema_version" fields,
        List.assoc "operation_id" fields,
@@ -163,37 +172,78 @@ let locator_record_of_yojson operation = function
        List.assoc "locator" fields
      with
      | `Int version, `String observed_operation_id, observed_operation, locator_json
-       when version = schema_version
-            && String.equal
-                 observed_operation_id
-                 (Keeper_agent_core_execution_identity.operation_id_to_string
-                    operation_id)
-            && observed_operation = Keeper_agent_core_execution_identity.to_yojson operation
-       ->
-       Agent_core.Agent.execution_locator_of_yojson locator_json
+       when version = schema_version ->
+       Ok { observed_operation_id; observed_operation; locator_json }
      | `Int version, _, _, _ when version <> schema_version ->
        Error (Printf.sprintf "unsupported locator schema version %d" version)
-     | _, `String observed_operation_id, _, _
-       when not
-              (String.equal
-                 observed_operation_id
-                 (Keeper_agent_core_execution_identity.operation_id_to_string
-                    operation_id)) ->
-       Error
-         (Printf.sprintf
-            "locator operation id mismatch: observed %S"
-            observed_operation_id)
-     | _, _, observed_operation, _
-       when observed_operation <> Keeper_agent_core_execution_identity.to_yojson operation
-       -> Error "locator operation identity does not match its directory"
      | _ -> Error "locator record fields have invalid types")
   | `Assoc _ -> Error "locator record fields are missing, duplicated, or unknown"
   | _ -> Error "locator record is not a JSON object"
 ;;
 
+let locator_record_of_yojson operation json =
+  let* envelope = locator_envelope_of_yojson json in
+  let operation_id = Keeper_agent_core_execution_identity.operation_id operation in
+  if
+    not
+      (String.equal
+         envelope.observed_operation_id
+         (Keeper_agent_core_execution_identity.operation_id_to_string operation_id))
+  then
+    Error
+      (Printf.sprintf
+         "locator operation id mismatch: observed %S"
+         envelope.observed_operation_id)
+  else if
+    envelope.observed_operation
+    <> Keeper_agent_core_execution_identity.to_yojson operation
+  then Error "locator operation identity does not match its directory"
+  else Agent_core.Agent.execution_locator_of_yojson envelope.locator_json
+;;
+
 let parse_json bytes =
   try Ok (Yojson.Safe.from_string bytes) with
   | Yojson.Json_error detail -> Error detail
+;;
+
+let validate_locator_record ~operation_id bytes =
+  match parse_json bytes with
+  | Error _ -> Error Record_json_invalid
+  | Ok json ->
+    (match locator_envelope_of_yojson json with
+     | Error _ -> Error Record_envelope_invalid
+     | Ok envelope ->
+       let expected_operation_id =
+         Keeper_agent_core_execution_identity.operation_id_to_string operation_id
+       in
+       if not (String.equal envelope.observed_operation_id expected_operation_id)
+       then Error Record_operation_mismatch
+       else
+         (match
+            Keeper_agent_core_execution_identity.of_yojson
+              envelope.observed_operation
+          with
+          | Error _ -> Error Record_payload_invalid
+          | Ok observed_operation ->
+            let derived_operation_id =
+              observed_operation
+              |> Keeper_agent_core_execution_identity.operation_id
+              |> Keeper_agent_core_execution_identity.operation_id_to_string
+            in
+            if not (String.equal derived_operation_id expected_operation_id)
+            then Error Record_operation_mismatch
+            else
+              Agent_core.Agent.execution_locator_of_yojson envelope.locator_json
+              |> Result.map (fun _ -> ())
+              |> Result.map_error (fun _ -> Record_payload_invalid)))
+;;
+
+let decode_terminal_record ~operation_id bytes =
+  match parse_json bytes with
+  | Error _ -> Error Record_json_invalid
+  | Ok json ->
+    terminal_record_of_yojson ~operation_id json
+    |> Result.map_error (fun _ -> Record_envelope_invalid)
 ;;
 
 let load_optional path =

--- a/lib/keeper/keeper_agent_core_execution_store.mli
+++ b/lib/keeper/keeper_agent_core_execution_store.mli
@@ -39,6 +39,25 @@ type prepared = private
 type factory =
   Keeper_agent_core_execution_identity.t -> (prepared, prepare_error) result
 
+type journal_record_error =
+  | Record_json_invalid
+  | Record_envelope_invalid
+  | Record_operation_mismatch
+  | Record_payload_invalid
+
+val validate_locator_record
+  :  operation_id:Keeper_agent_core_execution_identity.operation_id
+  -> string
+  -> (unit, journal_record_error) result
+(** Validate a persisted locator envelope without returning its opaque locator
+    or operation payload. *)
+
+val decode_terminal_record
+  :  operation_id:Keeper_agent_core_execution_identity.operation_id
+  -> string
+  -> (terminal_record, journal_record_error) result
+(** Decode only the closed terminal disposition used by operator inventory. *)
+
 val prepare
   :  base_path:string
   -> owner:Runtime_agent_execution_owner.t

--- a/lib/keeper_runtime/dune
+++ b/lib/keeper_runtime/dune
@@ -18,6 +18,7 @@
   keeper_internal_error
   keeper_runtime_failure_route
   keeper_agent_core_execution_identity
+  keeper_agent_core_execution_inventory_core
   keeper_latched_reason
   keeper_event_queue
   keeper_event_queue_state

--- a/lib/keeper_runtime/keeper_agent_core_execution_identity.ml
+++ b/lib/keeper_runtime/keeper_agent_core_execution_identity.ml
@@ -23,6 +23,20 @@ type error =
   | Negative_context_shrink_attempt of int
   | Non_positive_context_capacity of int
 
+type operation_id_error =
+  | Invalid_operation_id_prefix
+  | Invalid_operation_id_digest_length
+  | Invalid_operation_id_digest_character
+
+type decoding_error =
+  | Identity_not_object
+  | Identity_fields_invalid
+  | Unsupported_schema_version of int
+  | Candidate_attempt_invalid
+  | Context_attempt_invalid
+  | Thinking_attempt_invalid
+  | Identity_value_invalid of error
+
 type operation_id = string
 
 type t =
@@ -35,6 +49,20 @@ type t =
   ; thinking_attempt : thinking_attempt
   ; operation_id : operation_id
   }
+
+let operation_id_prefix = "keeper-agent-core-v1-"
+
+let exact_fields expected fields =
+  List.length fields = List.length expected
+  && List.for_all
+       (fun expected_name ->
+          List.length
+            (List.filter
+               (fun (actual_name, _) -> String.equal expected_name actual_name)
+               fields)
+          = 1)
+       expected
+;;
 
 let bounded_preview value =
   if String.length value <= 32
@@ -167,8 +195,7 @@ let create
       |> Yojson.Safe.to_string
     in
     let operation_id =
-      "keeper-agent-core-v1-"
-      ^ Digestif.SHA256.(digest_string canonical |> to_hex)
+      operation_id_prefix ^ Digestif.SHA256.(digest_string canonical |> to_hex)
     in
     Ok
       { keeper_name
@@ -185,6 +212,29 @@ let create
 let operation_id operation = operation.operation_id
 let operation_id_to_string operation_id = operation_id
 
+let operation_id_of_string value =
+  let prefix_length = String.length operation_id_prefix in
+  if
+    String.length value < prefix_length
+    || not (String.equal (String.sub value 0 prefix_length) operation_id_prefix)
+  then Error Invalid_operation_id_prefix
+  else
+    let digest =
+      String.sub value prefix_length (String.length value - prefix_length)
+    in
+    if String.length digest <> 64
+    then Error Invalid_operation_id_digest_length
+    else if
+      not
+        (String.for_all
+           (function
+             | '0' .. '9' | 'a' .. 'f' -> true
+             | _ -> false)
+           digest)
+    then Error Invalid_operation_id_digest_character
+    else Ok value
+;;
+
 let to_yojson operation =
   identity_json
     ~keeper_name:operation.keeper_name
@@ -194,6 +244,94 @@ let to_yojson operation =
     ~candidate_attempt:operation.candidate_attempt
     ~context_attempt:operation.context_attempt
     ~thinking_attempt:operation.thinking_attempt
+;;
+
+let candidate_index_of_yojson = function
+  | `Assoc fields when exact_fields [ "kind" ] fields ->
+    (match List.assoc "kind" fields with
+     | `String "lane_head" -> Ok 0
+     | _ -> Error Candidate_attempt_invalid)
+  | `Assoc fields when exact_fields [ "kind"; "ordinal" ] fields ->
+    (match List.assoc "kind" fields, List.assoc "ordinal" fields with
+     | `String "lane_fallback", `Int ordinal when ordinal > 0 -> Ok ordinal
+     | _ -> Error Candidate_attempt_invalid)
+  | _ -> Error Candidate_attempt_invalid
+;;
+
+let context_attempt_of_yojson = function
+  | `Assoc fields when exact_fields [ "kind"; "capacity_bytes" ] fields ->
+    (match List.assoc "kind" fields, List.assoc "capacity_bytes" fields with
+     | `String "initial_context", `Int capacity_bytes when capacity_bytes > 0 ->
+       Ok (0, capacity_bytes)
+     | _ -> Error Context_attempt_invalid)
+  | `Assoc fields
+    when exact_fields [ "kind"; "ordinal"; "capacity_bytes" ] fields ->
+    (match
+       List.assoc "kind" fields,
+       List.assoc "ordinal" fields,
+       List.assoc "capacity_bytes" fields
+     with
+     | `String "context_shrink", `Int ordinal, `Int capacity_bytes
+       when ordinal > 0 && capacity_bytes > 0 -> Ok (ordinal, capacity_bytes)
+     | _ -> Error Context_attempt_invalid)
+  | _ -> Error Context_attempt_invalid
+;;
+
+let thinking_override_of_yojson = function
+  | `String "runtime_policy" -> Ok None
+  | `String "force_thinking" -> Ok (Some true)
+  | `String "force_no_thinking" -> Ok (Some false)
+  | _ -> Error Thinking_attempt_invalid
+;;
+
+let of_yojson = function
+  | `Assoc fields
+    when exact_fields
+           [ "schema_version"
+           ; "keeper_name"
+           ; "trace_id"
+           ; "keeper_turn_id"
+           ; "runtime_id"
+           ; "candidate_attempt"
+           ; "context_attempt"
+           ; "thinking_attempt"
+           ]
+           fields ->
+    (match List.assoc "schema_version" fields with
+     | `Int version when version <> 1 -> Error (Unsupported_schema_version version)
+     | `Int 1 ->
+       (match
+          List.assoc "keeper_name" fields,
+          List.assoc "trace_id" fields,
+          List.assoc "keeper_turn_id" fields,
+          List.assoc "runtime_id" fields
+        with
+        | `String keeper_name, `String trace_id, `Int keeper_turn_id, `String runtime_id
+          ->
+          let ( let* ) = Result.bind in
+          let* candidate_index =
+            candidate_index_of_yojson (List.assoc "candidate_attempt" fields)
+          in
+          let* context_shrink_attempt, context_capacity_bytes =
+            context_attempt_of_yojson (List.assoc "context_attempt" fields)
+          in
+          let* thinking_override =
+            thinking_override_of_yojson (List.assoc "thinking_attempt" fields)
+          in
+          create
+            ~keeper_name
+            ~trace_id
+            ~keeper_turn_id
+            ~runtime_id
+            ~candidate_index
+            ~context_shrink_attempt
+            ~context_capacity_bytes
+            ~thinking_override
+          |> Result.map_error (fun error -> Identity_value_invalid error)
+        | _ -> Error Identity_fields_invalid)
+     | _ -> Error Identity_fields_invalid)
+  | `Assoc _ -> Error Identity_fields_invalid
+  | _ -> Error Identity_not_object
 ;;
 
 let error_to_string = function

--- a/lib/keeper_runtime/keeper_agent_core_execution_identity.mli
+++ b/lib/keeper_runtime/keeper_agent_core_execution_identity.mli
@@ -31,6 +31,20 @@ type error =
   | Negative_context_shrink_attempt of int
   | Non_positive_context_capacity of int
 
+type operation_id_error =
+  | Invalid_operation_id_prefix
+  | Invalid_operation_id_digest_length
+  | Invalid_operation_id_digest_character
+
+type decoding_error =
+  | Identity_not_object
+  | Identity_fields_invalid
+  | Unsupported_schema_version of int
+  | Candidate_attempt_invalid
+  | Context_attempt_invalid
+  | Thinking_attempt_invalid
+  | Identity_value_invalid of error
+
 type t
 type operation_id = private string
 
@@ -47,5 +61,7 @@ val create
 
 val operation_id : t -> operation_id
 val operation_id_to_string : operation_id -> string
+val operation_id_of_string : string -> (operation_id, operation_id_error) result
 val to_yojson : t -> Yojson.Safe.t
+val of_yojson : Yojson.Safe.t -> (t, decoding_error) result
 val error_to_string : error -> string

--- a/lib/keeper_runtime/keeper_agent_core_execution_inventory_core.ml
+++ b/lib/keeper_runtime/keeper_agent_core_execution_inventory_core.ml
@@ -1,0 +1,160 @@
+type terminal_record = Agent_core.Agent.execution_terminal_disposition
+
+type locator_observation =
+  | Locator_missing
+  | Locator_valid
+  | Locator_invalid
+
+type terminal_observation =
+  | Terminal_missing
+  | Terminal_valid of terminal_record
+  | Terminal_invalid
+
+type ambiguity =
+  | Scope_without_records
+  | Retired_terminal_with_locator
+  | Repair_terminal_without_locator
+
+type corruption =
+  | Unrecognized_operation_directory
+  | Scope_not_directory
+  | Scope_unreadable
+  | Locator_record_invalid
+  | Terminal_record_invalid
+  | Both_records_invalid
+
+type state =
+  | Active
+  | Terminal of terminal_record
+  | Operator_repair_required of terminal_record
+  | Ambiguous of ambiguity
+  | Corrupt of corruption
+
+type entry_fingerprint = string
+
+type entry_key =
+  | Operation_id of Keeper_agent_core_execution_identity.operation_id
+  | Redacted_entry of entry_fingerprint
+
+type entry =
+  { key : entry_key
+  ; state : state
+  }
+
+type t = { entries : entry list }
+
+let classify ~locator ~terminal =
+  match locator, terminal with
+  | Locator_invalid, Terminal_invalid -> Corrupt Both_records_invalid
+  | Locator_invalid, _ -> Corrupt Locator_record_invalid
+  | _, Terminal_invalid -> Corrupt Terminal_record_invalid
+  | Locator_missing, Terminal_missing -> Ambiguous Scope_without_records
+  | Locator_valid, Terminal_missing -> Active
+  | Locator_missing, Terminal_valid terminal ->
+    (match terminal.Agent_core.Agent.recovery with
+     | Agent_core.Agent.Retire -> Terminal terminal
+     | Agent_core.Agent.Operator_repair_required
+         Agent_core.Agent.Effect_outcome_unknown ->
+       Ambiguous Repair_terminal_without_locator)
+  | Locator_valid, Terminal_valid terminal ->
+    (match terminal.Agent_core.Agent.recovery with
+     | Agent_core.Agent.Retire -> Ambiguous Retired_terminal_with_locator
+     | Agent_core.Agent.Operator_repair_required
+         Agent_core.Agent.Effect_outcome_unknown ->
+       Operator_repair_required terminal)
+;;
+
+let operation_entry operation_id state = { key = Operation_id operation_id; state }
+
+let unrecognized_entry ~entry_name =
+  let fingerprint =
+    "execution-entry-v1-"
+    ^ Digestif.SHA256.(digest_string entry_name |> to_hex)
+  in
+  { key = Redacted_entry fingerprint; state = Corrupt Unrecognized_operation_directory }
+;;
+
+let create entries = { entries }
+let entry_fingerprint_to_string fingerprint = fingerprint
+
+let terminal_outcome_to_string = function
+  | Agent_core.Agent.Terminal_succeeded -> "succeeded"
+  | Agent_core.Agent.Terminal_failed -> "failed"
+  | Agent_core.Agent.Terminal_cancelled -> "cancelled"
+;;
+
+let recovery_action_to_string = function
+  | Agent_core.Agent.Retire -> "retire"
+  | Agent_core.Agent.Operator_repair_required Agent_core.Agent.Effect_outcome_unknown ->
+    "operator_repair_required_effect_outcome_unknown"
+;;
+
+let terminal_to_yojson (terminal : terminal_record) =
+  `Assoc
+    [ "outcome", `String (terminal_outcome_to_string terminal.outcome)
+    ; "recovery", `String (recovery_action_to_string terminal.recovery)
+    ]
+;;
+
+let ambiguity_to_string = function
+  | Scope_without_records -> "scope_without_records"
+  | Retired_terminal_with_locator -> "retired_terminal_with_locator"
+  | Repair_terminal_without_locator -> "repair_terminal_without_locator"
+;;
+
+let corruption_to_string = function
+  | Unrecognized_operation_directory -> "unrecognized_operation_directory"
+  | Scope_not_directory -> "scope_not_directory"
+  | Scope_unreadable -> "scope_unreadable"
+  | Locator_record_invalid -> "locator_record_invalid"
+  | Terminal_record_invalid -> "terminal_record_invalid"
+  | Both_records_invalid -> "both_records_invalid"
+;;
+
+let state_to_yojson = function
+  | Active -> `Assoc [ "kind", `String "active" ]
+  | Terminal terminal ->
+    `Assoc [ "kind", `String "terminal"; "terminal", terminal_to_yojson terminal ]
+  | Operator_repair_required terminal ->
+    `Assoc
+      [ "kind", `String "operator_repair_required"
+      ; "terminal", terminal_to_yojson terminal
+      ]
+  | Ambiguous ambiguity ->
+    `Assoc
+      [ "kind", `String "ambiguous"
+      ; "reason", `String (ambiguity_to_string ambiguity)
+      ]
+  | Corrupt corruption ->
+    `Assoc
+      [ "kind", `String "corrupt"
+      ; "reason", `String (corruption_to_string corruption)
+      ]
+;;
+
+let entry_to_yojson entry =
+  let key =
+    match entry.key with
+    | Operation_id operation_id ->
+      `Assoc
+        [ "kind", `String "operation_id"
+        ; ( "operation_id"
+          , `String
+              (Keeper_agent_core_execution_identity.operation_id_to_string
+                 operation_id) )
+        ]
+    | Redacted_entry fingerprint ->
+      `Assoc
+        [ "kind", `String "redacted_entry"
+        ; "fingerprint", `String fingerprint
+        ]
+  in
+  `Assoc [ "key", key; "state", state_to_yojson entry.state ]
+;;
+
+let to_yojson inventory =
+  `Assoc
+    [ "schema", `String "masc.keeper.agent_core.execution_inventory.v1"
+    ; "entries", `List (List.map entry_to_yojson inventory.entries)
+    ]
+;;

--- a/lib/keeper_runtime/keeper_agent_core_execution_inventory_core.mli
+++ b/lib/keeper_runtime/keeper_agent_core_execution_inventory_core.mli
@@ -1,0 +1,67 @@
+(** Pure operator projection for durable Keeper Agent Core execution journals.
+
+    This module receives only typed record observations.  It never reads the
+    filesystem and never exposes journal payloads, prompts, responses, or
+    reasoning content. *)
+
+type terminal_record = Agent_core.Agent.execution_terminal_disposition
+
+type locator_observation =
+  | Locator_missing
+  | Locator_valid
+  | Locator_invalid
+
+type terminal_observation =
+  | Terminal_missing
+  | Terminal_valid of terminal_record
+  | Terminal_invalid
+
+type ambiguity =
+  | Scope_without_records
+  | Retired_terminal_with_locator
+  | Repair_terminal_without_locator
+
+type corruption =
+  | Unrecognized_operation_directory
+  | Scope_not_directory
+  | Scope_unreadable
+  | Locator_record_invalid
+  | Terminal_record_invalid
+  | Both_records_invalid
+
+type state =
+  | Active
+  | Terminal of terminal_record
+  | Operator_repair_required of terminal_record
+  | Ambiguous of ambiguity
+  | Corrupt of corruption
+
+type entry_fingerprint = private string
+
+type entry_key =
+  | Operation_id of Keeper_agent_core_execution_identity.operation_id
+  | Redacted_entry of entry_fingerprint
+
+type entry =
+  { key : entry_key
+  ; state : state
+  }
+
+type t = private { entries : entry list }
+
+val classify
+  :  locator:locator_observation
+  -> terminal:terminal_observation
+  -> state
+
+val operation_entry
+  :  Keeper_agent_core_execution_identity.operation_id
+  -> state
+  -> entry
+
+val unrecognized_entry : entry_name:string -> entry
+(** Return a corrupt entry keyed only by a one-way fingerprint. *)
+
+val create : entry list -> t
+val entry_fingerprint_to_string : entry_fingerprint -> string
+val to_yojson : t -> Yojson.Safe.t

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -254,6 +254,7 @@ normal_targets=(
   @test/runtest-test_runtime_agent_execution_store_source
   @test/runtest-test_runtime_agent_execution_owner_source
   @test/runtest-test_keeper_agent_core_execution_identity
+  @test/runtest-test_keeper_agent_core_execution_inventory_core
   @test/runtest-test_ide_bridge
   @test/runtest-test_dashboard_workspace
   @test/runtest-test_host_fd_pressure_poller

--- a/test/dune
+++ b/test/dune
@@ -1954,6 +1954,7 @@
 (include stanzas/test_runtime_agent_execution_store_source.inc)
 (include stanzas/test_runtime_agent_execution_owner_source.inc)
 (include stanzas/test_keeper_agent_core_execution_identity.inc)
+(include stanzas/test_keeper_agent_core_execution_inventory_core.inc)
 
 
 (include stanzas/test_runtime_model_temperature_toml.inc)

--- a/test/stanzas/test_keeper_agent_core_execution_inventory_core.inc
+++ b/test/stanzas/test_keeper_agent_core_execution_inventory_core.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_agent_core_execution_inventory_core)
+ (modules test_keeper_agent_core_execution_inventory_core)
+ (libraries masc.keeper_runtime masc.agent_core yojson))

--- a/test/stanzas/test_runtime_agent_execution_owner_source.inc
+++ b/test/stanzas/test_runtime_agent_execution_owner_source.inc
@@ -8,7 +8,9 @@
   ../lib/runtime/runtime_agent_execution_owner.ml
   ../lib/runtime/runtime_agent_execution_owner.mli
   ../lib/keeper_runtime/keeper_agent_core_execution_identity.mli
+  ../lib/keeper_runtime/keeper_agent_core_execution_inventory_core.mli
   ../lib/keeper/keeper_agent_core_execution_store.ml
+  ../lib/keeper/keeper_agent_core_execution_inventory.ml
   ../lib/server/server_runtime_bootstrap.ml
   ../lib/keeper/keeper_agent_run.ml
   ../lib/keeper/keeper_turn_driver.ml

--- a/test/test_keeper_agent_core_execution_identity.ml
+++ b/test/test_keeper_agent_core_execution_identity.ml
@@ -80,5 +80,17 @@ let () =
   let json = Identity.to_yojson base |> Yojson.Safe.to_string in
   if contains json "generation"
   then failwith "generation must not enter crash-stable execution identity";
+  (match Identity.operation_id_of_string (id base) with
+   | Ok parsed when String.equal (Identity.operation_id_to_string parsed) (id base) -> ()
+   | Ok _ -> failwith "operation ID parser changed a valid ID"
+   | Error _ -> failwith "operation ID parser rejected a valid ID");
+  (match Identity.operation_id_of_string "keeper-agent-core-v1-not-a-digest" with
+   | Error Identity.Invalid_operation_id_digest_length -> ()
+   | Error _ -> failwith "operation ID parser returned the wrong closed error"
+   | Ok _ -> failwith "operation ID parser accepted an invalid digest");
+  (match Identity.of_yojson (Identity.to_yojson base) with
+   | Ok decoded when String.equal (id decoded) (id base) -> ()
+   | Ok _ -> failwith "typed JSON decoder changed the operation ID"
+   | Error _ -> failwith "typed JSON decoder rejected writer output");
   print_endline "test_keeper_agent_core_execution_identity: OK"
 ;;

--- a/test/test_keeper_agent_core_execution_inventory_core.ml
+++ b/test/test_keeper_agent_core_execution_inventory_core.ml
@@ -1,0 +1,101 @@
+module Core = Keeper_agent_core_execution_inventory_core
+module Identity = Keeper_agent_core_execution_identity
+
+let expect_identity = function
+  | Ok identity -> identity
+  | Error error -> failwith (Identity.error_to_string error)
+;;
+
+let operation_id =
+  Identity.create
+    ~keeper_name:"inventory-test"
+    ~trace_id:"trace-inventory"
+    ~keeper_turn_id:7
+    ~runtime_id:"glm.coding-plan"
+    ~candidate_index:0
+    ~context_shrink_attempt:0
+    ~context_capacity_bytes:4096
+    ~thinking_override:None
+  |> expect_identity
+  |> Identity.operation_id
+;;
+
+let retired =
+  { Agent_core.Agent.outcome = Agent_core.Agent.Terminal_succeeded
+  ; recovery = Agent_core.Agent.Retire
+  }
+;;
+
+let repair_required =
+  { Agent_core.Agent.outcome = Agent_core.Agent.Terminal_failed
+  ; recovery =
+      Agent_core.Agent.Operator_repair_required
+        Agent_core.Agent.Effect_outcome_unknown
+  }
+;;
+
+let assert_state label expected actual =
+  if expected <> actual then failwith (label ^ " produced the wrong typed state")
+;;
+
+let contains haystack needle =
+  let haystack_length = String.length haystack in
+  let needle_length = String.length needle in
+  let rec loop offset =
+    if offset + needle_length > haystack_length
+    then false
+    else if String.sub haystack offset needle_length = needle
+    then true
+    else loop (offset + 1)
+  in
+  needle_length = 0 || loop 0
+;;
+
+let () =
+  assert_state
+    "active"
+    Core.Active
+    (Core.classify ~locator:Core.Locator_valid ~terminal:Core.Terminal_missing);
+  assert_state
+    "terminal"
+    (Core.Terminal retired)
+    (Core.classify
+       ~locator:Core.Locator_missing
+       ~terminal:(Core.Terminal_valid retired));
+  assert_state
+    "repair required"
+    (Core.Operator_repair_required repair_required)
+    (Core.classify
+       ~locator:Core.Locator_valid
+       ~terminal:(Core.Terminal_valid repair_required));
+  assert_state
+    "retire interrupted"
+    (Core.Ambiguous Core.Retired_terminal_with_locator)
+    (Core.classify
+       ~locator:Core.Locator_valid
+       ~terminal:(Core.Terminal_valid retired));
+  assert_state
+    "repair locator missing"
+    (Core.Ambiguous Core.Repair_terminal_without_locator)
+    (Core.classify
+       ~locator:Core.Locator_missing
+       ~terminal:(Core.Terminal_valid repair_required));
+  assert_state
+    "both records corrupt"
+    (Core.Corrupt Core.Both_records_invalid)
+    (Core.classify ~locator:Core.Locator_invalid ~terminal:Core.Terminal_invalid);
+  let secret_entry_name = "raw-prompt-hidden-CoT-secret" in
+  let projection =
+    Core.create
+      [ Core.operation_entry operation_id Core.Active
+      ; Core.unrecognized_entry ~entry_name:secret_entry_name
+      ]
+    |> Core.to_yojson
+    |> Yojson.Safe.to_string
+  in
+  if contains projection secret_entry_name
+  then failwith "operator projection exposed an unrecognized raw entry name";
+  if contains projection "prompt" || contains projection "CoT"
+  then failwith "operator projection exposed forbidden reasoning or payload data";
+  print_endline "test_keeper_agent_core_execution_inventory_core: OK"
+;;

--- a/test/test_runtime_agent_execution_owner_source.ml
+++ b/test/test_runtime_agent_execution_owner_source.ml
@@ -73,6 +73,13 @@ let () =
       "lib/keeper_runtime/keeper_agent_core_execution_identity.mli"
   in
   let store = resolve_source "lib/keeper/keeper_agent_core_execution_store.ml" in
+  let inventory_core =
+    resolve_source
+      "lib/keeper_runtime/keeper_agent_core_execution_inventory_core.mli"
+  in
+  let inventory =
+    resolve_source "lib/keeper/keeper_agent_core_execution_inventory.ml"
+  in
   let bootstrap = resolve_source "lib/server/server_runtime_bootstrap.ml" in
   let keeper = resolve_source "lib/keeper/keeper_agent_run.ml" in
   let driver = resolve_source "lib/keeper/keeper_turn_driver.ml" in
@@ -119,6 +126,22 @@ let () =
     ~label:"unknown effect keeps locator"
     store
     "Agent_core.Agent.Operator_repair_required Agent_core.Agent.Effect_outcome_unknown -> Ok ()";
+  assert_contains
+    ~label:"closed inventory states"
+    inventory_core
+    "type state = | Active | Terminal of terminal_record | Operator_repair_required of terminal_record | Ambiguous of ambiguity | Corrupt of corruption";
+  assert_contains
+    ~label:"inventory SSOT"
+    inventory
+    "Config_dir_resolver.agent_execution_journals_dir ~base_path";
+  assert_contains
+    ~label:"capability-bound record observation"
+    inventory
+    "Fs_compat.Capability_exact_read.read ~parent ~leaf ~expected_length ~max_length:max_record_length";
+  assert_contains
+    ~label:"no-follow scope inspection"
+    inventory
+    "Eio.Path.kind ~follow:false parent";
   assert_contains
     ~label:"candidate ordinal ingress"
     driver


### PR DESCRIPTION
## Summary

- read the Agent Core execution-journal SSOT from `.masc/runtime/agent/executions`
- classify every scope with closed states: active, terminal, operator-repair-required, ambiguous, or corrupt
- keep classification pure and isolate directory/record observation in a capability-backed reader shell
- reject unknown schemas, duplicated fields, mismatched operation identities, unsafe resource kinds, oversized records, and changed reads
- expose only typed operation IDs, terminal disposition, status, and one-way fingerprints for unrecognized entry names; raw locator, operation payload, paths, prompts, and reasoning are withheld

## Stack

- Base: #28569 (`agent/keeper-execution-store-dispatch`)
- Depends transitively on #28568, #28567, #28554, and #28546.
- Merge bottom-up through #28569 before this PR.

## Verification

- `ocamlformat --check` on all changed OCaml files
- `ocamlc -stop-after parsing` on all changed OCaml files
- isolated type-check of identity decoder, inventory core, record codec, and reader shell: PASS
- directly compiled identity round-trip test: PASS
- directly compiled closed-state/redaction matrix test against Agent Core types: PASS
- focused execution-owner/inventory source ratchet: PASS
- CI target audit: 302 targets declared; 563 unwired suites at the existing baseline
- `git diff --check` and conflict-marker scan: PASS

Local Dune was intentionally not run. GitHub CI remains unverified at publication time.

## Scope boundary

This PR provides the backend typed inventory and operator JSON projection only. It does not add dashboard HTTP/FE routes, mutation or repair commands, journal pruning, or Raw_trace/Event_bus/Durable_event changes. Runtime identity remains `runtime_id`; this work does not infer a model name from a runtime or fabricate `model_id`.
