### PR TITLE
test: 모델용 산문의 문구를 고정하던 단언 제거 + 재발 방지 린트

### DIFF
--- a/scripts/ci/run-lint-suite.sh
+++ b/scripts/ci/run-lint-suite.sh
@@ -103,6 +103,7 @@ blocking_lints() {
   run_lint "No inline error-envelope literals" bash scripts/lint/no-inline-error-envelope.sh
   run_lint "No inline json_kind_name" bash scripts/lint/no-inline-json-kind-name.sh
   run_lint "No yojson 3.0 dead arms" bash scripts/lint/no-yojson-3-dead-arms.sh
+  run_lint "No model-prose substring tests" bash scripts/lint/no-model-prose-substring-tests.sh
   run_lint "Workflow YAML syntax" bash scripts/lint/yaml-syntax.sh
   run_lint "Board SLO extractor fixture" bash scripts/test-board-slo-extractor.sh
   run_lint "Branch protection fail-closed fixture" bash scripts/test-main-branch-protection-fail-closed.sh

--- a/scripts/lint/no-model-prose-substring-tests.sh
+++ b/scripts/lint/no-model-prose-substring-tests.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# no-model-prose-substring-tests.sh — Block tests that pin a phrase from the
+# runtime contract's guidance prose.
+#
+# Those fields hold sentences written for a model to read. Their wording is a
+# prompt-engineering choice and must stay free to change. A test that asserts
+# a substring of one converts every rewording into a red build with no change
+# in behaviour.
+#
+# Rationale: #28533 changed "do not repeat the repo prefix" to "...the cwd
+# prefix" in keeper_runtime_contract.ml and touched no test. The stale
+# substring in test_keeper_tool_call_log.ml turned main red, and because the
+# CI Regression Gate aggregates strictly, every open PR was blocked until
+# #28540 swapped one string for another -- a fix that leaves the next
+# rewording free to do it again.
+#
+# What a test may assert about these fields: that they are present and carry
+# non-empty text. That is the wiring regression worth catching; the sentence
+# itself is not a contract.
+#
+# The guarded field list is READ FROM THE SOURCE, not copied here, so adding a
+# guidance field extends the guard automatically.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+contract="${repo_root}/lib/keeper/keeper_runtime_contract.ml"
+
+if [[ ! -f "$contract" ]]; then
+  echo "ERROR: cannot find ${contract}" >&2
+  exit 1
+fi
+
+# Guidance fields are the `( "name"` entries in the path-resolution block:
+# each pairs a field name with a `String` sentence on the following lines.
+# Read with a while-loop rather than mapfile: this script runs on developer
+# macOS too, where the default bash is 3.2 and has no mapfile.
+fields=()
+while IFS= read -r field; do
+  [[ -n "$field" ]] && fields+=("$field")
+done < <(grep -oE '\( "[a-z_]+"$' "$contract" | grep -oE '[a-z_]{4,}' | sort -u)
+
+if [[ ${#fields[@]} -eq 0 ]]; then
+  echo "ERROR: no guidance fields parsed from ${contract}" >&2
+  echo "  The block shape changed; update this lint's extraction." >&2
+  exit 1
+fi
+
+# A violation is a contains_substring call whose haystack is one of those
+# fields. The haystack follows the call, as in
+#
+#   (String_util.contains_substring
+#      Yojson.Safe.Util.(member "execute_path_basis" ... |> to_string)
+#      "some phrase")
+#
+# so the window is the lines AFTER the call, not before. Using -B here is how
+# the first draft of this lint passed against a deliberately reintroduced
+# violation; the two-way check below the fix is what caught that.
+violations=""
+for field in "${fields[@]}"; do
+  hits="$(grep -rn --include='*.ml' -A4 'contains_substring' "${repo_root}/test" 2>/dev/null \
+          | grep -F "\"${field}\"" || true)"
+  [[ -n "$hits" ]] && violations+="${hits}"$'\n'
+done
+
+if [[ -n "${violations//[[:space:]]/}" ]]; then
+  echo "FAIL: a test pins wording from the runtime contract's guidance prose"
+  echo ""
+  echo "$violations"
+  echo "Those fields are sentences written for a model. Rewording them is not a"
+  echo "behaviour change, so a substring assertion on one only makes prompt edits"
+  echo "expensive -- see #28533 -> #28540."
+  echo ""
+  echo "Assert the wiring instead:"
+  echo "  match Yojson.Safe.Util.member \"<field>\" path_resolution with"
+  echo "  | \`String text -> String.trim text <> \"\""
+  echo "  | _ -> false"
+  exit 1
+fi
+
+echo "OK: no test pins runtime-contract guidance wording (${#fields[@]} fields guarded)"
+exit 0

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -374,18 +374,27 @@ let test_turn_context_fields_stored () =
     let path_resolution =
       Yojson.Safe.Util.member "path_resolution" runtime_contract
     in
+    (* Guidance fields are prose written for a model to read, so their wording
+       is a prompt-engineering choice that must stay free to change. Pinning a
+       phrase from them made rewording a test failure: #28533 changed "repo
+       prefix" to "cwd prefix" and turned main red for ninety minutes without
+       touching a single line of behaviour.
+
+       What the log actually owes its reader is that the fields are wired and
+       carry something -- absent or empty is the regression worth catching. *)
+    let carries_guidance field =
+      match Yojson.Safe.Util.member field path_resolution with
+      | `String text -> String.trim text <> ""
+      | _ -> false
+    in
     Alcotest.(check bool)
-      "runtime contract explains Execute repo cwd path basis"
+      "path_resolution carries execute_path_basis guidance"
       true
-      (String_util.contains_substring
-         Yojson.Safe.Util.(member "execute_path_basis" path_resolution |> to_string)
-         "do not repeat the cwd prefix");
+      (carries_guidance "execute_path_basis");
     Alcotest.(check bool)
-      "runtime contract points .masc state at task/context tools"
+      "path_resolution carries masc_state_basis guidance"
       true
-      (String_util.contains_substring
-         Yojson.Safe.Util.(member "masc_state_basis" path_resolution |> to_string)
-         "Use keeper task/context tools");
+      (carries_guidance "masc_state_basis");
     let omits_field name =
       match runtime_contract with
       | `Assoc fields -> not (List.mem_assoc name fields)


### PR DESCRIPTION
## 무엇을

모델이 읽으라고 내보내는 **산문의 문구를 고정하던 테스트 단언 2건을 제거**하고, 그 계열이 다시 들어오지 못하게 린트를 건다.

## 왜 — 오늘 main 이 90분 red 였던 이유

- #28533 이 `keeper_runtime_contract.ml:284` 의 문장을 `"do not repeat the repo prefix"` → `"...the cwd prefix in the path."` 로 바꿨다. **테스트 파일은 하나도 안 건드렸다** (`--stat` 확인).
- `test_keeper_tool_call_log.ml` 이 옛 문구를 substring 으로 단언하고 있었다 → main red.
- CI Regression Gate 가 차등이 아니라 **엄격 집계**라 열린 PR 전부가 막혔다.
- #28540 이 복구했지만 **문자열을 새 문자열로 바꿨을 뿐**이라 다음 리워딩에서 그대로 재발한다.

동작은 1바이트도 안 변했는데 빌드가 red 가 됐다. 그 필드들은 프롬프트 엔지니어링 대상이고, 문구를 다듬는 건 자유여야 한다.

## 무엇을 남기고 무엇을 지웠나 — 1136개를 다 지우지 않았다

`contains_substring` 은 test/ 에 **1136회 / 109파일** 있다. 전부 같은 것이 아니라서 종류를 갈랐다.

| 종류 | 예 | 판정 |
|---|---|---|
| **모델용 산문 문구 고정** | `execute_path_basis` 안의 `"do not repeat the ... prefix"` | **제거** — lib 문구 변경이 곧 red |
| 테스트가 심은 비밀값 누출 검사 | `secret123`, `sk-proj-...`, `/Users/dancer` 가 로그에 **없어야** 함 | 유지 — needle 을 테스트가 소유, 남의 편집으로 안 썩음 |
| 에러 메시지 계약 | `"unknown [runtime] key"` | 유지 — 메시지 자체가 계약 |
| 프로토콜 마커 | `"MASC_TOOL_RESULT"`, `"[Co-view context]"` | 유지 — 구분자, 산문 아님 |

실제 드리프트 계열은 **1파일 2건**뿐이었다. 같은 파일에 남은 6건은 전부 비밀값 음성 단언이다.

대체 단언은 같은 파일이 이미 쓰던 구조 검사 방식(`omits_field`)을 따른다 — 필드가 **배선되어 있고 비어 있지 않은가**. 그게 잡을 값이 있는 회귀고, 문장은 계약이 아니다.

## 린트

`scripts/lint/no-model-prose-substring-tests.sh` — 가드 대상 필드 목록을 **소스에서 읽는다**(`keeper_runtime_contract.ml` 의 `( "name"` 항목). 하드코딩 복사가 아니라서 guidance 필드를 추가하면 가드가 저절로 넓어진다. 현재 4개(`read_basis`·`discover_before_read`·`execute_path_basis`·`masc_state_basis`).

`scripts/ci/run-lint-suite.sh:106` 에 배선.

## 검증 — 양방향

린트는 **두 방향 다** 확인했다. 한쪽만 보면 "항상 OK 를 내는 가드"를 못 잡는다.

| 상태 | 기대 | 실측 |
|---|---|---|
| 수정 후 트리 | 통과 | `OK: ... (4 fields guarded)` exit 0 |
| 위반을 일부러 되돌린 트리 | 검출 | `FAIL: a test pins wording...` exit 1, 파일·행 지목 |

**초안은 이 검사에서 걸렸다.** `-B4`(호출 *앞* 4줄)로 봤는데 haystack 은 `contains_substring` **다음 줄**에 온다. 되돌린 위반에 대해 초안이 `OK` 를 냈고, 그래서 `-A4` 로 고쳤다. 커밋 메시지와 스크립트 주석에 남겼다.

그 외:

- `test_keeper_tool_call_log` — **36/36 통과**
- `bash scripts/ci/run-lint-suite.sh blocking` — `SUITE_EXIT=0`, 새 린트가 스위트 안에서 실행됨을 로그로 확인
- 이식성: 초안이 `mapfile` 을 써 macOS bash 3.2 에서 `command not found` 였다. while-read 로 교체.

## #28540 과의 관계

#28540 은 이미 머지됐고 main 은 green 이다. 이 PR 은 그 수정을 되돌리지 않고 **문구 의존 자체를 없앤다**. 충돌 없음(base = 5c8f08171b).

RFC-WAIVED: 테스트 단언 교체 + 린트 추가는 CLAUDE.md agent_delegation 이 RFC 를 요구하는 subsystem 어디에도 해당하지 않는다.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
