### PR TITLE
fix(keeper): 주인 없이 삭제된 keeper의 shutdown 복구를 종결

### DIFF
--- a/lib/keeper/keeper_owner_registry.ml
+++ b/lib/keeper/keeper_owner_registry.ml
@@ -616,27 +616,45 @@ let cancel_queued_operation ~base_path ~keeper_name operation_id =
 ;;
 
 let create_meta ~base_path meta =
-  match find_pool base_path with
-  | Error error -> Error (Command_lookup_failed error)
-  | Ok pool ->
-    Keeper_lifecycle_reservation.with_key_lock
+  match
+    Keeper_shutdown_intake_fence.run_durable_intake_if_open
       ~base_path
       ~keeper_name:meta.Keeper_meta_contract.name
-      (fun () ->
-         match
-           Keeper_lifecycle_reservation.authorize
+      (fun _intake_token ->
+         match find_pool base_path with
+         | Error error -> Error (Command_lookup_failed error)
+         | Ok pool ->
+           Keeper_lifecycle_reservation.with_key_lock
              ~base_path
              ~keeper_name:meta.name
-             ()
-         with
-         | Error reservation -> Error (Command_lifecycle_reserved reservation)
-         | Ok () ->
-           (match ensure_empty_in_pool pool meta.name with
-            | Error error -> Error (Command_lookup_failed error)
-            | Ok owner ->
-              (match Keeper_owner.apply_meta owner (Keeper_owner_reducer.Create meta) with
-               | Error error -> Error (Command_rejected error)
-               | Ok committed -> Ok committed)))
+             (fun () ->
+                match
+                  Keeper_lifecycle_reservation.authorize
+                    ~base_path
+                    ~keeper_name:meta.name
+                    ()
+                with
+                | Error reservation -> Error (Command_lifecycle_reserved reservation)
+                | Ok () ->
+                  (match ensure_empty_in_pool pool meta.name with
+                   | Error error -> Error (Command_lookup_failed error)
+                   | Ok owner ->
+                     (match
+                        Keeper_owner.apply_meta
+                          owner
+                          (Keeper_owner_reducer.Create meta)
+                      with
+                      | Error error -> Error (Command_rejected error)
+                      | Ok committed -> Ok committed))))
+  with
+  | Keeper_shutdown_intake_fence.Intake_committed result -> result
+  | Keeper_shutdown_intake_fence.Intake_shutdown_reserved operation_id ->
+    Error
+      (shutdown_fence_error
+         (Printf.sprintf
+            "keeper=%s create_meta_operation=%s"
+            meta.name
+            (Keeper_shutdown_types.Operation_id.to_string operation_id)))
 ;;
 
 let all_projections ~base_path =

--- a/lib/keeper/keeper_owner_registry.mli
+++ b/lib/keeper/keeper_owner_registry.mli
@@ -129,9 +129,11 @@ val create_meta
   :  base_path:string
   -> Keeper_meta_contract.keeper_meta
   -> (Keeper_meta_contract.keeper_meta option, command_error) result
-(** Install an empty actor for a new Keeper, then commit its first snapshot via
-    the closed [Create] command.  A failed commit leaves the empty actor in
-    place so same-name retries remain mailbox-linearized. *)
+(** Under the durable-intake fence, install an empty actor for a new Keeper,
+    then commit its first snapshot via the closed [Create] command. A failed
+    commit leaves the empty actor in place so same-name retries remain
+    mailbox-linearized. An active shutdown reservation rejects creation before
+    an empty actor is installed. *)
 
 val exact_operation
   :  base_path:string

--- a/lib/keeper/keeper_shutdown_finalize.ml
+++ b/lib/keeper/keeper_shutdown_finalize.ml
@@ -601,16 +601,21 @@ let unregister_retired_exact ~base_path operation entry =
             (Keeper_lifecycle_reservation.snapshot_to_string owner)))
 ;;
 
-let release_finalized_admission ~(config : Workspace.config) operation =
+let release_finalized_admission
+    ~(config : Workspace.config)
+    ?successor_operation_id
+    operation
+  =
   match
-    Keeper_owner_registry.rollback_shutdown
+    Keeper_owner_registry.transition_shutdown
       ~base_path:config.base_path
       ~keeper_name:operation.keeper_name
-      ~operation_id:operation.operation_id
+      ~from_operation_id:operation.operation_id
+      ~to_operation_id:successor_operation_id
   with
-  | Ok Keeper_owner.Shutdown_rolled_back
-  | Ok Keeper_owner.Shutdown_not_reserved -> Ok operation
-  | Ok (Keeper_owner.Shutdown_reserved_by_other operation_id) ->
+  | Ok Keeper_owner.Shutdown_transition_applied
+  | Ok Keeper_owner.Shutdown_transition_already_applied -> Ok operation
+  | Ok (Keeper_owner.Shutdown_transition_reserved_by_other operation_id) ->
     Log.Keeper.warn
       "finalized Keeper shutdown found a newer admission owner: keeper=%s finalized_operation=%s current_operation=%s"
       operation.keeper_name
@@ -621,14 +626,15 @@ let release_finalized_admission ~(config : Workspace.config) operation =
     if admission_already_released_by_removal ~config operation error
     then
       (match
-         Keeper_shutdown_intake_fence.rollback_shutdown
+         Keeper_shutdown_intake_fence.transition_shutdown
            ~base_path:config.base_path
            ~keeper_name:operation.keeper_name
-           ~operation_id:operation.operation_id
+           ~from_operation_id:operation.operation_id
+           ~to_operation_id:successor_operation_id
        with
-       | Keeper_shutdown_intake_fence.Rolled_back
-       | Keeper_shutdown_intake_fence.Not_reserved -> Ok operation
-       | Keeper_shutdown_intake_fence.Reserved_by_other existing ->
+       | Keeper_shutdown_intake_fence.Transition_applied
+       | Keeper_shutdown_intake_fence.Transition_already_applied -> Ok operation
+       | Keeper_shutdown_intake_fence.Transition_reserved_by_other existing ->
          Error
            (Admission_release_failed
               ( operation
@@ -647,11 +653,11 @@ let invoke_completion_handler ~config operation action =
   | exn -> Error (Printexc.to_string exn)
 ;;
 
-let deliver_finalized_completion ~config operation =
+let deliver_finalized_completion ~config ?successor_operation_id operation =
   match operation.phase with
   | Finalized { completion = Completion_not_requested; _ }
   | Finalized { completion = Completion_delivered _; _ } ->
-    release_finalized_admission ~config operation
+    release_finalized_admission ~config ?successor_operation_id operation
   | Finalized ({ completion = Completion_pending action; _ } as evidence) ->
     (match invoke_completion_handler ~config operation action with
      | Error detail -> Error (Completion_failed (operation, detail))
@@ -666,7 +672,11 @@ let deliver_finalized_completion ~config operation =
        in
        (match replace ~config delivered with
         | Error _ as error -> error
-        | Ok persisted -> release_finalized_admission ~config persisted))
+        | Ok persisted ->
+          release_finalized_admission
+            ~config
+            ?successor_operation_id
+            persisted))
   | Prepared
   | Joined_idle
   | Finalizing_tasks _
@@ -676,7 +686,13 @@ let deliver_finalized_completion ~config operation =
   | Superseded _ -> Error Unsupported_phase
 ;;
 
-let complete_cleanup ~(config : Workspace.config) ~entry operation cleanup =
+let complete_cleanup
+    ~(config : Workspace.config)
+    ~entry
+    ?successor_operation_id
+    operation
+    cleanup
+  =
   let require_released_summary_owner () =
     match operation.cleanup_intent.reason with
     | Operator_stop_retain_meta -> Ok ()
@@ -754,7 +770,10 @@ let complete_cleanup ~(config : Workspace.config) ~entry operation cleanup =
          match replace ~config finalized with
          | Error _ as error -> error
          | Ok persisted_finalized ->
-           deliver_finalized_completion ~config persisted_finalized)
+           deliver_finalized_completion
+             ~config
+             ?successor_operation_id
+             persisted_finalized)
   in
   match validate_exact_registry_generation ~base_path:config.base_path operation entry with
   | Error detail -> block ~config operation Registry_unregister detail
@@ -772,7 +791,7 @@ let complete_cleanup ~(config : Workspace.config) ~entry operation cleanup =
         | Ok registry_unregistered -> finish registry_unregistered))
 ;;
 
-let run ~config ~entry operation =
+let run ~config ~entry ?successor_operation_id operation =
   match operation.phase with
   | Joined_idle ->
     (match read_operation_meta ~config operation with
@@ -785,7 +804,13 @@ let run ~config ~entry operation =
            | Error _ as error -> error
            | Ok ready ->
              (match ready.phase with
-              | Cleanup_ready cleanup -> complete_cleanup ~config ~entry ready cleanup
+              | Cleanup_ready cleanup ->
+                complete_cleanup
+                  ~config
+                  ~entry
+                  ?successor_operation_id
+                  ready
+                  cleanup
               | _ -> Error Unsupported_phase))))
   | Finalizing_tasks settled_task_ids ->
     (match read_operation_meta ~config operation with
@@ -798,10 +823,23 @@ let run ~config ~entry operation =
            | Error _ as error -> error
            | Ok ready ->
              (match ready.phase with
-              | Cleanup_ready cleanup -> complete_cleanup ~config ~entry ready cleanup
+              | Cleanup_ready cleanup ->
+                complete_cleanup
+                  ~config
+                  ~entry
+                  ?successor_operation_id
+                  ready
+                  cleanup
               | _ -> Error Unsupported_phase))))
-  | Cleanup_ready cleanup -> complete_cleanup ~config ~entry operation cleanup
-  | Finalized _ -> deliver_finalized_completion ~config operation
+  | Cleanup_ready cleanup ->
+    complete_cleanup
+      ~config
+      ~entry
+      ?successor_operation_id
+      operation
+      cleanup
+  | Finalized _ ->
+    deliver_finalized_completion ~config ?successor_operation_id operation
   | Prepared
   | Reconciliation_required _
   | Blocked _

--- a/lib/keeper/keeper_shutdown_finalize.ml
+++ b/lib/keeper/keeper_shutdown_finalize.ml
@@ -505,6 +505,34 @@ let remove_meta_file ~config operation cleanup =
      | Error error -> Error (Keeper_owner_registry.command_error_to_string error))
 ;;
 
+(* An admission fence lives inside its Keeper owner, so a registry without
+   that owner has no fence left to release. [Owner_not_found] plus the
+   keeper's metadata also gone means the keeper was removed outright (an
+   operator stop with meta removal that already unregistered the owner): the
+   removal itself achieved the admission release, and re-running release
+   against it would fail every boot forever. A leftover meta without its
+   owner is an inconsistent state and stays an error, mirroring
+   [remove_meta_file]. Logs one info line when true so the terminal
+   disposition stays observable in boot logs. *)
+let admission_already_released_by_removal
+  ~(config : Workspace.config)
+  operation
+  error
+  =
+  match error with
+  | Keeper_owner_registry.Command_lookup_failed
+      (Keeper_owner_registry.Owner_not_found _) ->
+    (match Keeper_meta_store.read_meta config operation.keeper_name with
+     | Ok None ->
+       Log.Keeper.info
+         "shutdown admission already released by Keeper removal: keeper=%s operation=%s"
+         operation.keeper_name
+         (Operation_id.to_string operation.operation_id);
+       true
+     | Ok (Some _) | Error _ -> false)
+  | _ -> false
+;;
+
 let remove_session_dir ~config operation =
   if operation.cleanup_intent.remove_session
   then (
@@ -598,9 +626,12 @@ let release_finalized_admission ~(config : Workspace.config) operation =
     (Operation_id.to_string operation_id);
     Ok operation
   | Error error ->
-    Error
-      (Admission_release_failed
-         (operation, Keeper_owner_registry.command_error_to_string error))
+    if admission_already_released_by_removal ~config operation error
+    then Ok operation
+    else
+      Error
+        (Admission_release_failed
+           (operation, Keeper_owner_registry.command_error_to_string error))
 ;;
 
 let invoke_completion_handler ~config operation action =

--- a/lib/keeper/keeper_shutdown_finalize.ml
+++ b/lib/keeper/keeper_shutdown_finalize.ml
@@ -505,47 +505,24 @@ let remove_meta_file ~config operation cleanup =
      | Error error -> Error (Keeper_owner_registry.command_error_to_string error))
 ;;
 
-(* An admission fence lives inside its Keeper owner, so a registry without
-   that owner has no fence left to release. [Owner_not_found] plus the
-   keeper's metadata also gone means the keeper was removed outright (an
-   operator stop with meta removal that already unregistered the owner): the
-   removal itself achieved the admission release, and re-running release
-   against it would fail every boot forever. A leftover meta without its
-   owner is an inconsistent state and stays an error, mirroring
-   [remove_meta_file]. Logs one info line when true so the terminal
-   disposition stays observable in boot logs.
-
-   Stated over [keeper_name] / [operation_id] rather than a whole operation
-   because the boot restore pass reaches the same condition holding only those
-   two: a corrupt owner fence carries no operation record. Both gates must ask
-   this question -- settling it after [recover_operation] alone leaves the
-   restore pass aborting on the very crash window this exists to close. *)
-let admission_already_released_by_removal_for
-  ~(config : Workspace.config)
-  ~keeper_name
-  ~operation_id
-  error
-  =
-  match error with
-  | Keeper_owner_registry.Command_lookup_failed
-      (Keeper_owner_registry.Owner_not_found _) ->
-    (match Keeper_meta_store.read_meta config keeper_name with
+let admission_already_released_by_removal ~(config : Workspace.config) operation error =
+  match
+    meta_disposition_of_cleanup_reason operation.cleanup_intent.reason,
+    error
+  with
+  | ( Remove_meta
+    , Keeper_owner_registry.Command_lookup_failed
+        (Keeper_owner_registry.Owner_not_found _) ) ->
+    (match Keeper_meta_store.read_meta config operation.keeper_name with
      | Ok None ->
        Log.Keeper.info
-         "shutdown admission already released by Keeper removal: keeper=%s operation=%s"
-         keeper_name
-         (Operation_id.to_string operation_id);
+         "shutdown owner admission already released by Keeper removal: keeper=%s operation=%s"
+         operation.keeper_name
+         (Operation_id.to_string operation.operation_id);
        true
      | Ok (Some _) | Error _ -> false)
-  | _ -> false
-;;
-
-let admission_already_released_by_removal ~(config : Workspace.config) operation error =
-  admission_already_released_by_removal_for
-    ~config
-    ~keeper_name:operation.keeper_name
-    ~operation_id:operation.operation_id
-    error
+  | (Retain_operator_pause | Retain_dead_tombstone), _
+  | Remove_meta, _ -> false
 ;;
 
 let remove_session_dir ~config operation =
@@ -642,7 +619,22 @@ let release_finalized_admission ~(config : Workspace.config) operation =
     Ok operation
   | Error error ->
     if admission_already_released_by_removal ~config operation error
-    then Ok operation
+    then
+      (match
+         Keeper_shutdown_intake_fence.rollback_shutdown
+           ~base_path:config.base_path
+           ~keeper_name:operation.keeper_name
+           ~operation_id:operation.operation_id
+       with
+       | Keeper_shutdown_intake_fence.Rolled_back
+       | Keeper_shutdown_intake_fence.Not_reserved -> Ok operation
+       | Keeper_shutdown_intake_fence.Reserved_by_other existing ->
+         Error
+           (Admission_release_failed
+              ( operation
+              , Printf.sprintf
+                  "shutdown intake fence is reserved by another operation: existing=%s"
+                  (Operation_id.to_string existing) )))
     else
       Error
         (Admission_release_failed

--- a/lib/keeper/keeper_shutdown_finalize.ml
+++ b/lib/keeper/keeper_shutdown_finalize.ml
@@ -606,13 +606,28 @@ let release_finalized_admission
     ?successor_operation_id
     operation
   =
-  match
-    Keeper_owner_registry.transition_shutdown
-      ~base_path:config.base_path
-      ~keeper_name:operation.keeper_name
-      ~from_operation_id:operation.operation_id
-      ~to_operation_id:successor_operation_id
-  with
+  let release_result =
+    match successor_operation_id with
+    | None ->
+      Keeper_owner_registry.rollback_shutdown
+        ~base_path:config.base_path
+        ~keeper_name:operation.keeper_name
+        ~operation_id:operation.operation_id
+      |> Result.map (function
+        | Keeper_owner.Shutdown_rolled_back ->
+          Keeper_owner.Shutdown_transition_applied
+        | Keeper_owner.Shutdown_not_reserved ->
+          Keeper_owner.Shutdown_transition_already_applied
+        | Keeper_owner.Shutdown_reserved_by_other operation_id ->
+          Keeper_owner.Shutdown_transition_reserved_by_other operation_id)
+    | Some _ ->
+      Keeper_owner_registry.transition_shutdown
+        ~base_path:config.base_path
+        ~keeper_name:operation.keeper_name
+        ~from_operation_id:operation.operation_id
+        ~to_operation_id:successor_operation_id
+  in
+  match release_result with
   | Ok Keeper_owner.Shutdown_transition_applied
   | Ok Keeper_owner.Shutdown_transition_already_applied -> Ok operation
   | Ok (Keeper_owner.Shutdown_transition_reserved_by_other operation_id) ->

--- a/lib/keeper/keeper_shutdown_finalize.ml
+++ b/lib/keeper/keeper_shutdown_finalize.ml
@@ -513,24 +513,39 @@ let remove_meta_file ~config operation cleanup =
    against it would fail every boot forever. A leftover meta without its
    owner is an inconsistent state and stays an error, mirroring
    [remove_meta_file]. Logs one info line when true so the terminal
-   disposition stays observable in boot logs. *)
-let admission_already_released_by_removal
+   disposition stays observable in boot logs.
+
+   Stated over [keeper_name] / [operation_id] rather than a whole operation
+   because the boot restore pass reaches the same condition holding only those
+   two: a corrupt owner fence carries no operation record. Both gates must ask
+   this question -- settling it after [recover_operation] alone leaves the
+   restore pass aborting on the very crash window this exists to close. *)
+let admission_already_released_by_removal_for
   ~(config : Workspace.config)
-  operation
+  ~keeper_name
+  ~operation_id
   error
   =
   match error with
   | Keeper_owner_registry.Command_lookup_failed
       (Keeper_owner_registry.Owner_not_found _) ->
-    (match Keeper_meta_store.read_meta config operation.keeper_name with
+    (match Keeper_meta_store.read_meta config keeper_name with
      | Ok None ->
        Log.Keeper.info
          "shutdown admission already released by Keeper removal: keeper=%s operation=%s"
-         operation.keeper_name
-         (Operation_id.to_string operation.operation_id);
+         keeper_name
+         (Operation_id.to_string operation_id);
        true
      | Ok (Some _) | Error _ -> false)
   | _ -> false
+;;
+
+let admission_already_released_by_removal ~(config : Workspace.config) operation error =
+  admission_already_released_by_removal_for
+    ~config
+    ~keeper_name:operation.keeper_name
+    ~operation_id:operation.operation_id
+    error
 ;;
 
 let remove_session_dir ~config operation =

--- a/lib/keeper/keeper_shutdown_finalize.mli
+++ b/lib/keeper/keeper_shutdown_finalize.mli
@@ -36,6 +36,7 @@ val register_completion_handler :
 val run :
   config:Workspace.config ->
   entry:Keeper_registry.registry_entry option ->
+  ?successor_operation_id:Keeper_shutdown_types.Operation_id.t ->
   Keeper_shutdown_types.t ->
   (Keeper_shutdown_types.t, error) result
 

--- a/lib/keeper/keeper_shutdown_finalize.mli
+++ b/lib/keeper/keeper_shutdown_finalize.mli
@@ -52,6 +52,19 @@ val admission_already_released_by_removal :
   -> Keeper_owner_registry.command_error
   -> bool
 
+(** Same judgement stated over the identity alone, for the boot restore pass:
+    it reaches this condition holding only a keeper name and an operation id
+    (a corrupt owner fence carries no operation record). Both the restore pass
+    and the recovery pass must ask it — settling only the latter leaves boot
+    recovery aborting on a keeper removed between [complete_cleanup] and its
+    completion receipt. *)
+val admission_already_released_by_removal_for :
+     config:Workspace.config
+  -> keeper_name:string
+  -> operation_id:Keeper_shutdown_types.Operation_id.t
+  -> Keeper_owner_registry.command_error
+  -> bool
+
 module For_testing : sig
   val paused_meta :
     Keeper_meta_contract.keeper_meta -> Keeper_meta_contract.keeper_meta

--- a/lib/keeper/keeper_shutdown_finalize.mli
+++ b/lib/keeper/keeper_shutdown_finalize.mli
@@ -39,6 +39,19 @@ val run :
   Keeper_shutdown_types.t ->
   (Keeper_shutdown_types.t, error) result
 
+(** [admission_already_released_by_removal ~config operation error] holds when
+    [error] says the Keeper owner is absent from the registry and the keeper's
+    metadata is gone from the store: the keeper was removed outright, so the
+    admission fence this operation wants to release no longer exists — the
+    removal itself achieved the release. Logs one info line when true. A
+    leftover meta without its owner keeps the error, mirroring the
+    [remove_meta_file] cross-check. *)
+val admission_already_released_by_removal :
+     config:Workspace.config
+  -> Keeper_shutdown_types.t
+  -> Keeper_owner_registry.command_error
+  -> bool
+
 module For_testing : sig
   val paused_meta :
     Keeper_meta_contract.keeper_meta -> Keeper_meta_contract.keeper_meta

--- a/lib/keeper/keeper_shutdown_finalize.mli
+++ b/lib/keeper/keeper_shutdown_finalize.mli
@@ -39,29 +39,17 @@ val run :
   Keeper_shutdown_types.t ->
   (Keeper_shutdown_types.t, error) result
 
-(** [admission_already_released_by_removal ~config operation error] holds when
-    [error] says the Keeper owner is absent from the registry and the keeper's
-    metadata is gone from the store: the keeper was removed outright, so the
-    admission fence this operation wants to release no longer exists — the
-    removal itself achieved the release. Logs one info line when true. A
-    leftover meta without its owner keeps the error, mirroring the
-    [remove_meta_file] cross-check. *)
+(** [admission_already_released_by_removal ~config operation error] holds only
+    for a [Remove_meta] operation when [error] says the Keeper owner is absent
+    from the registry and the keeper's metadata is gone from the store. In
+    that state the owner-local fence disappeared with the removed Keeper. The
+    caller remains responsible for releasing the exact process-local intake
+    fence after any pending completion receipt is durably settled. Logs one
+    info line when true. Retain-meta intents and leftover metadata keep the
+    error. *)
 val admission_already_released_by_removal :
      config:Workspace.config
   -> Keeper_shutdown_types.t
-  -> Keeper_owner_registry.command_error
-  -> bool
-
-(** Same judgement stated over the identity alone, for the boot restore pass:
-    it reaches this condition holding only a keeper name and an operation id
-    (a corrupt owner fence carries no operation record). Both the restore pass
-    and the recovery pass must ask it — settling only the latter leaves boot
-    recovery aborting on a keeper removed between [complete_cleanup] and its
-    completion receipt. *)
-val admission_already_released_by_removal_for :
-     config:Workspace.config
-  -> keeper_name:string
-  -> operation_id:Keeper_shutdown_types.Operation_id.t
   -> Keeper_owner_registry.command_error
   -> bool
 

--- a/lib/keeper/keeper_shutdown_runtime.ml
+++ b/lib/keeper/keeper_shutdown_runtime.ml
@@ -67,7 +67,19 @@ let restore_admission ~config ~keeper_name ~operation_id =
          keeper_name
          (Operation_id.to_string operation_id)
          (Operation_id.to_string existing))
-  | Error error -> Error (Keeper_owner_registry.command_error_to_string error)
+  | Error error ->
+    (* A keeper removed between [complete_cleanup] and its completion receipt
+       leaves a fenced operation whose owner is gone. The restore pass runs
+       before recovery, so without this the boot aborts here and the recovery
+       pass never gets to settle it -- the same crash window, one gate earlier. *)
+    if
+      Keeper_shutdown_finalize.admission_already_released_by_removal_for
+        ~config
+        ~keeper_name
+        ~operation_id
+        error
+    then Ok ()
+    else Error (Keeper_owner_registry.command_error_to_string error)
 ;;
 
 let restore_inventory_admission ~config inventory =

--- a/lib/keeper/keeper_shutdown_runtime.ml
+++ b/lib/keeper/keeper_shutdown_runtime.ml
@@ -481,7 +481,11 @@ let settled_reconciliation_state
   }
 ;;
 
-let recover_operation ~config (operation : Keeper_shutdown_types.t) =
+let recover_operation
+    ~config
+    ?successor_operation_id
+    (operation : Keeper_shutdown_types.t)
+  =
   let persist_recovered recovered =
     match
       Keeper_shutdown_store.replace
@@ -512,7 +516,11 @@ let recover_operation ~config (operation : Keeper_shutdown_types.t) =
      | Finalizing_tasks _
      | Cleanup_ready _
      | Finalized _ ->
-       Keeper_shutdown_finalize.run ~config ~entry:None recovered
+       Keeper_shutdown_finalize.run
+         ~config
+         ~entry:None
+         ?successor_operation_id
+         recovered
        |> Result.map_error Keeper_shutdown_finalize.error_to_string
      | Prepared
      | Reconciliation_required _
@@ -525,7 +533,10 @@ let recover_operation_with_corrupt_owner_fence
     ~corrupt_owner_fence
     operation
   =
-  match recover_operation ~config operation with
+  let successor_operation_id =
+    Option.map (fun fence -> fence.operation_id) corrupt_owner_fence
+  in
+  match recover_operation ~config ?successor_operation_id operation with
   | Error _ as error -> error
   | Ok recovered ->
     if Keeper_shutdown_types.requires_admission_fence recovered

--- a/lib/keeper/keeper_shutdown_runtime.ml
+++ b/lib/keeper/keeper_shutdown_runtime.ml
@@ -143,16 +143,19 @@ let restore_inventory_admission ~config inventory =
                  Ok
                    (String_map.add
                       operation.keeper_name
-                      operation.operation_id
+                      operation
                       fences)
-               | Some existing when Operation_id.equal existing operation.operation_id ->
+               | Some existing
+                 when Operation_id.equal
+                        existing.operation_id
+                        operation.operation_id ->
                  Ok fences
                | Some existing ->
                  Error
                    (Printf.sprintf
                       "multiple current shutdown admission owners: keeper=%s first=%s second=%s"
                       operation.keeper_name
-                      (Operation_id.to_string existing)
+                      (Operation_id.to_string existing.operation_id)
                       (Operation_id.to_string operation.operation_id))))
          | Keeper_shutdown_store.Operation _ -> fences)
       (Ok String_map.empty)
@@ -168,15 +171,16 @@ let restore_inventory_admission ~config inventory =
     let rec restore_corrupt_fences blocked = function
       | [] -> Ok blocked
       | { keeper_name; operation_id } :: rest ->
-        let operation_id =
+        let operation_id, ownerless_policy =
           match String_map.find_opt keeper_name current_fences with
-          | Some current -> current
-          | None -> operation_id
+          | Some current ->
+            current.operation_id, Require_removal_evidence current
+          | None -> operation_id, Restore_corrupt_fence
         in
         (match
            restore_admission
              ~config
-             ~ownerless_policy:Restore_corrupt_fence
+             ~ownerless_policy
              ~keeper_name
              ~operation_id
          with

--- a/lib/keeper/keeper_shutdown_runtime.ml
+++ b/lib/keeper/keeper_shutdown_runtime.ml
@@ -51,7 +51,11 @@ let operation_requires_fence (operation : Keeper_shutdown_types.t) =
   Keeper_shutdown_types.requires_admission_fence operation
 ;;
 
-let restore_admission ~config ~keeper_name ~operation_id =
+type ownerless_restore_policy =
+  | Require_removal_evidence of Keeper_shutdown_types.t
+  | Restore_corrupt_fence
+
+let restore_admission ~config ~ownerless_policy ~keeper_name ~operation_id =
   match
     Keeper_owner_registry.restore_shutdown
       ~base_path:config.Workspace.base_path
@@ -69,31 +73,44 @@ let restore_admission ~config ~keeper_name ~operation_id =
          (Operation_id.to_string existing))
   | Error
       (Keeper_owner_registry.Command_lookup_failed
-         (Keeper_owner_registry.Owner_not_found _)) ->
-    (* [complete_cleanup] can remove both metadata and its Owner before a
-       blocked cleanup or pending completion is settled. The Owner-local
-       fence is gone in that state, but the independent intake fence must
-       remain until recovery reaches a durable non-fenced phase. *)
-    (match
-       Keeper_shutdown_intake_fence.restore_shutdown
-         ~base_path:config.Workspace.base_path
-         ~keeper_name
-         ~operation_id
-     with
-     | Keeper_shutdown_intake_fence.Restored
-     | Keeper_shutdown_intake_fence.Already_restored ->
-       Log.Keeper.info
-         "restored ownerless shutdown intake fence: keeper=%s operation=%s"
-         keeper_name
-         (Operation_id.to_string operation_id);
-       Ok ()
-     | Keeper_shutdown_intake_fence.Restore_conflict existing ->
-       Error
-         (Printf.sprintf
-            "shutdown admission restore conflict: keeper=%s durable=%s existing=%s"
-            keeper_name
-            (Operation_id.to_string operation_id)
-            (Operation_id.to_string existing)))
+         (Keeper_owner_registry.Owner_not_found _) as error) ->
+    let may_restore_ownerless =
+      match ownerless_policy with
+      | Restore_corrupt_fence -> true
+      | Require_removal_evidence operation ->
+        Keeper_shutdown_finalize.admission_already_released_by_removal
+          ~config
+          operation
+          error
+    in
+    if not may_restore_ownerless
+    then Error (Keeper_owner_registry.command_error_to_string error)
+    else
+      (* [complete_cleanup] can remove both metadata and its Owner before a
+         remove-meta cleanup or pending completion is settled. The Owner-local
+         fence is gone in that state, but the independent intake fence must
+         remain until recovery reaches a durable non-fenced phase. Corrupt
+         records also remain fail-closed without readable intent evidence. *)
+      (match
+         Keeper_shutdown_intake_fence.restore_shutdown
+           ~base_path:config.Workspace.base_path
+           ~keeper_name
+           ~operation_id
+       with
+       | Keeper_shutdown_intake_fence.Restored
+       | Keeper_shutdown_intake_fence.Already_restored ->
+         Log.Keeper.info
+           "restored ownerless shutdown intake fence: keeper=%s operation=%s"
+           keeper_name
+           (Operation_id.to_string operation_id);
+         Ok ()
+       | Keeper_shutdown_intake_fence.Restore_conflict existing ->
+         Error
+           (Printf.sprintf
+              "shutdown admission restore conflict: keeper=%s durable=%s existing=%s"
+              keeper_name
+              (Operation_id.to_string operation_id)
+              (Operation_id.to_string existing)))
   | Error error -> Error (Keeper_owner_registry.command_error_to_string error)
 ;;
 
@@ -156,7 +173,13 @@ let restore_inventory_admission ~config inventory =
           | Some current -> current
           | None -> operation_id
         in
-        (match restore_admission ~config ~keeper_name ~operation_id with
+        (match
+           restore_admission
+             ~config
+             ~ownerless_policy:Restore_corrupt_fence
+             ~keeper_name
+             ~operation_id
+         with
          | Error _ as error -> error
          | Ok () -> restore_corrupt_fences (keeper_name :: blocked) rest)
     in
@@ -179,6 +202,7 @@ let restore_inventory_admission ~config inventory =
           (match
              restore_admission
                ~config
+               ~ownerless_policy:(Require_removal_evidence operation)
                ~keeper_name:operation.keeper_name
                ~operation_id:operation.operation_id
            with

--- a/lib/keeper/keeper_shutdown_runtime.ml
+++ b/lib/keeper/keeper_shutdown_runtime.ml
@@ -67,19 +67,34 @@ let restore_admission ~config ~keeper_name ~operation_id =
          keeper_name
          (Operation_id.to_string operation_id)
          (Operation_id.to_string existing))
-  | Error error ->
-    (* A keeper removed between [complete_cleanup] and its completion receipt
-       leaves a fenced operation whose owner is gone. The restore pass runs
-       before recovery, so without this the boot aborts here and the recovery
-       pass never gets to settle it -- the same crash window, one gate earlier. *)
-    if
-      Keeper_shutdown_finalize.admission_already_released_by_removal_for
-        ~config
-        ~keeper_name
-        ~operation_id
-        error
-    then Ok ()
-    else Error (Keeper_owner_registry.command_error_to_string error)
+  | Error
+      (Keeper_owner_registry.Command_lookup_failed
+         (Keeper_owner_registry.Owner_not_found _)) ->
+    (* [complete_cleanup] can remove both metadata and its Owner before a
+       blocked cleanup or pending completion is settled. The Owner-local
+       fence is gone in that state, but the independent intake fence must
+       remain until recovery reaches a durable non-fenced phase. *)
+    (match
+       Keeper_shutdown_intake_fence.restore_shutdown
+         ~base_path:config.Workspace.base_path
+         ~keeper_name
+         ~operation_id
+     with
+     | Keeper_shutdown_intake_fence.Restored
+     | Keeper_shutdown_intake_fence.Already_restored ->
+       Log.Keeper.info
+         "restored ownerless shutdown intake fence: keeper=%s operation=%s"
+         keeper_name
+         (Operation_id.to_string operation_id);
+       Ok ()
+     | Keeper_shutdown_intake_fence.Restore_conflict existing ->
+       Error
+         (Printf.sprintf
+            "shutdown admission restore conflict: keeper=%s durable=%s existing=%s"
+            keeper_name
+            (Operation_id.to_string operation_id)
+            (Operation_id.to_string existing)))
+  | Error error -> Error (Keeper_owner_registry.command_error_to_string error)
 ;;
 
 let restore_inventory_admission ~config inventory =

--- a/lib/keeper/keeper_shutdown_runtime.ml
+++ b/lib/keeper/keeper_shutdown_runtime.ml
@@ -527,7 +527,13 @@ let recover_operation_with_corrupt_owner_fence
               (Operation_id.to_string operation.operation_id)
               (Operation_id.to_string existing))
        | Error error ->
-         Error (Keeper_owner_registry.command_error_to_string error))
+         if
+           Keeper_shutdown_finalize.admission_already_released_by_removal
+             ~config
+             operation
+             error
+         then Ok recovered
+         else Error (Keeper_owner_registry.command_error_to_string error))
 ;;
 
 let recover_at_boot ~config =

--- a/lib/keeper/keeper_shutdown_runtime.ml
+++ b/lib/keeper/keeper_shutdown_runtime.ml
@@ -559,7 +559,24 @@ let recover_operation_with_corrupt_owner_fence
              ~config
              operation
              error
-         then Ok recovered
+         then
+           (match
+              Keeper_shutdown_intake_fence.transition_shutdown
+                ~base_path:config.Workspace.base_path
+                ~keeper_name
+                ~from_operation_id:operation.operation_id
+                ~to_operation_id:successor_operation_id
+            with
+            | Keeper_shutdown_intake_fence.Transition_applied
+            | Keeper_shutdown_intake_fence.Transition_already_applied ->
+              Ok recovered
+            | Keeper_shutdown_intake_fence.Transition_reserved_by_other existing ->
+              Error
+                (Printf.sprintf
+                   "shutdown admission restore conflict: keeper=%s recovered=%s existing=%s"
+                   keeper_name
+                   (Operation_id.to_string operation.operation_id)
+                   (Operation_id.to_string existing)))
          else Error (Keeper_owner_registry.command_error_to_string error))
 ;;
 

--- a/lib/keeper/keeper_shutdown_runtime.mli
+++ b/lib/keeper/keeper_shutdown_runtime.mli
@@ -64,8 +64,13 @@ val recover_at_boot :
     lets bootstrap isolate every Keeper in its own process-lifetime fiber. *)
 val recover_operation :
   config:Workspace.config ->
+  ?successor_operation_id:Keeper_shutdown_types.Operation_id.t ->
   Keeper_shutdown_types.t ->
   (Keeper_shutdown_types.t, string) result
+(** [successor_operation_id] hands the admission fence to that operation in the
+    same transition instead of releasing it: a keeper whose shutdown is
+    immediately superseded never has an unfenced moment between the two. Absent,
+    the fence is released as before. *)
 
 (** Recover one current operation. If recovery releases admission and the
     owner also has corrupt durable state, restore that deterministic fail-closed

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -97,6 +97,7 @@ normal_targets=(
   @test/runtest-test_keeper_codex_error_carriage
   @test/runtest-test_keeper_persistence_span_history
   @test/runtest-test_keeper_rotation_eligibility_census
+  @test/runtest-test_keeper_shutdown_ownerless_admission_release
   @test/runtest-test_keeper_toml_accessor_matrix
   @test/runtest-test_keeper_turn_dispatch_authority
   @test/runtest-test_runtime_quota_window

--- a/test/dune
+++ b/test/dune
@@ -2010,6 +2010,8 @@
 
 (include stanzas/test_keeper_shutdown_reconciliation_settlement.inc)
 
+(include stanzas/test_keeper_shutdown_ownerless_admission_release.inc)
+
 (include stanzas/test_log_file_sink_self_heal.inc)
 
 (include stanzas/test_limit_schema_widen.inc)

--- a/test/stanzas/test_keeper_shutdown_ownerless_admission_release.inc
+++ b/test/stanzas/test_keeper_shutdown_ownerless_admission_release.inc
@@ -1,0 +1,8 @@
+; Boot recovery settles durable shutdown operations whose keeper was removed
+; outright: with the owner gone and the metadata gone with it there is no
+; admission fence left to release (2026-08-12 [full-cycle-probe] zombies).
+
+(test
+ (name test_keeper_shutdown_ownerless_admission_release)
+ (modules test_keeper_shutdown_ownerless_admission_release)
+ (libraries masc_test_deps))

--- a/test/test_keeper_shutdown_ownerless_admission_release.ml
+++ b/test/test_keeper_shutdown_ownerless_admission_release.ml
@@ -1,0 +1,262 @@
+(* Boot recovery re-enters every durable shutdown operation, including ones
+   whose keeper was later removed outright: an operator stop with meta
+   removal unregisters the owner and deletes the metadata. An admission
+   fence lives inside its Keeper owner, so once the owner is gone and the
+   keeper's metadata went with it there is no fence left to release — the
+   removal itself achieved the release. Before this settlement existed,
+   three durable operations for the deleted keeper [full-cycle-probe]
+   failed recovery on every boot (2026-08-12): finalized operations died at
+   admission release, the superseded one at the shutdown transition, and no
+   code path could retire any of them. A leftover meta without its owner
+   stays an error, mirroring the [remove_meta_file] cross-check. *)
+
+open Alcotest
+open Masc
+open Keeper_shutdown_types
+
+let temp_dir prefix =
+  let dir = Filename.temp_file prefix "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+;;
+
+let cleanup_dir path =
+  let rec rm p =
+    match Unix.lstat p with
+    | { Unix.st_kind = Unix.S_DIR; _ } ->
+      Array.iter (fun name -> rm (Filename.concat p name)) (Sys.readdir p);
+      Unix.rmdir p
+    | _ -> Unix.unlink p
+    | exception Unix.Unix_error _ -> ()
+  in
+  rm path
+;;
+
+let with_workspace f =
+  let base = temp_dir "keeper_shutdown_ownerless_" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base)
+    (fun () ->
+       Eio_main.run @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       Keeper_shutdown_finalize.register_remove_pending_confirms_by_target
+         (fun _config ~target_type:_ ~target_id:_ -> Ok 0);
+       Fun.protect
+         ~finally:(fun () ->
+           Keeper_shutdown_finalize.For_testing
+           .reset_remove_pending_confirms_by_target ();
+           Fs_compat.clear_fs ())
+         (fun () ->
+            let config = Workspace.default_config base in
+            let (_init_msg : string) = Workspace.init config ~agent_name:None in
+            Eio.Switch.run @@ fun sw ->
+            (match Keeper_owner_registry.install_from_store ~sw ~operation_runner:None ~on_turn_slot_released:None config with
+             | Ok 0 -> ()
+             | Ok count -> failf "unexpected initial owner count: %d" count
+             | Error error ->
+               fail (Keeper_owner_registry.install_error_to_string error));
+            f ~config))
+;;
+
+let fixture_meta_exn name =
+  let json =
+    `Assoc
+      [ "name", `String name
+      ; "agent_name", `String (Keeper_identity.keeper_agent_name name)
+      ; "trace_id", `String "trace-ownerless-admission-release-test"
+      ]
+  in
+  match Masc_test_deps.meta_of_json_fixture json with
+  | Ok meta -> meta
+  | Error detail -> failf "meta fixture rejected: %s" detail
+;;
+
+let trace_id_exn value =
+  match Keeper_id.Trace_id.of_string value with
+  | Ok trace_id -> trace_id
+  | Error detail -> failf "trace id rejected: %s" detail
+;;
+
+(* Digest of the meta the original finalization snapshotted. The keeper is
+   gone by recovery time, so the digest only has to be well-formed audit
+   evidence, not anything present on disk. *)
+let removed_keeper_digest name =
+  Keeper_meta_json.Snapshot_digest.of_meta (fixture_meta_exn name)
+;;
+
+let finalized_after_removal_evidence name =
+  { cleanup =
+      { settled_task_ids = []
+      ; pending_confirms_removed = 0
+      ; meta_snapshot_digest = removed_keeper_digest name
+      }
+  ; meta_removed = true
+  ; session_removed = true
+  ; registry_unregistered = true
+  ; accumulator_dropped = true
+  ; completion = Completion_not_requested
+  }
+;;
+
+let make_operation ~keeper_name ~phase ~cleanup_intent =
+  { schema_version
+  ; revision = 1
+  ; operation_id = Operation_id.generate ()
+  ; keeper_name
+  ; lane_ownership = Dormant_meta
+  ; trace_id = trace_id_exn "trace-ownerless-admission-release-test"
+  ; generation = 1
+  ; actor = "test"
+  ; cleanup_intent
+  ; turn_disposition = No_inflight_turn
+  ; expected_backlog_version = 0
+  ; owned_task_ids = []
+  ; join_evidence = None
+  ; phase
+  ; created_at = Masc_domain.now_iso ()
+  ; updated_at = Masc_domain.now_iso ()
+  }
+;;
+
+let persist_exn ~config operation =
+  match Keeper_shutdown_store.persist_new ~config operation with
+  | Ok () -> ()
+  | Error error ->
+    failf "persist_new failed: %s" (Keeper_shutdown_store.error_to_string error)
+;;
+
+let recover_fence ~config operation =
+  Keeper_shutdown_runtime.recover_operation_with_corrupt_owner_fence
+    ~config
+    ~corrupt_owner_fence:None
+    operation
+;;
+
+let check_settled label ~config operation =
+  match recover_fence ~config operation with
+  | Ok recovered ->
+    check
+      bool
+      (label ^ ": settled operation must not fence admission")
+      false
+      (requires_admission_fence recovered);
+    check
+      bool
+      (label ^ ": settlement keeps the terminal phase")
+      true
+      (match recovered.phase with
+       | Finalized _ | Superseded _ -> true
+       | _ -> false)
+  | Error detail -> failf "%s: recovery still fails: %s" label detail
+;;
+
+(* A finalized operation for a keeper whose owner and metadata are both gone
+   — the [full-cycle-probe] shape: finalization already removed the meta and
+   session, the keeper deletion took the owner, and only the admission
+   release was still failing. Recovery must settle it instead of failing
+   every boot. *)
+let test_finalized_operation_settles_when_keeper_removed () =
+  with_workspace (fun ~config ->
+    let name = "ownerless-finalized" in
+    let operation =
+      make_operation
+        ~keeper_name:name
+        ~phase:(Finalized (finalized_after_removal_evidence name))
+        ~cleanup_intent:
+          { reason = Operator_stop_remove_meta; remove_session = true }
+    in
+    persist_exn ~config operation;
+    check_settled "finalized" ~config operation)
+;;
+
+(* A superseded operation for the same removed keeper settles at the
+   shutdown transition instead: no fence exists to transition away from. *)
+let test_superseded_operation_settles_when_keeper_removed () =
+  with_workspace (fun ~config ->
+    let operation =
+      make_operation
+        ~keeper_name:"ownerless-superseded"
+        ~phase:(Superseded (Operator_metadata_update { actor = "dashboard" }))
+        ~cleanup_intent:
+          { reason = Operator_stop_retain_meta; remove_session = false }
+    in
+    persist_exn ~config operation;
+    check_settled "superseded" ~config operation)
+;;
+
+(* Metadata that outlived its owner is an inconsistent state, not a removal:
+   the release must keep failing so the inconsistency surfaces instead of
+   being silently absorbed. *)
+let test_meta_without_owner_still_fails () =
+  with_workspace (fun ~config ->
+    let name = "ownerless-with-meta" in
+    let meta = fixture_meta_exn name in
+    (match Keeper_meta_store.replace_snapshot config meta with
+     | Ok () -> ()
+     | Error detail -> failf "replace_snapshot failed: %s" detail);
+    let operation =
+      make_operation
+        ~keeper_name:name
+        ~phase:(Finalized (finalized_after_removal_evidence name))
+        ~cleanup_intent:
+          { reason = Operator_stop_remove_meta; remove_session = true }
+    in
+    persist_exn ~config operation;
+    match recover_fence ~config operation with
+    | Ok _ -> fail "recovery settled an operation whose meta outlived its owner"
+    | Error detail ->
+      check
+        string
+        "failure names the admission release"
+        "Keeper shutdown admission release failed"
+        (String.sub detail 0
+           (String.length "Keeper shutdown admission release failed")))
+;;
+
+(* Only [Owner_not_found] is a removal signal: a registry that is stopping,
+   for example, must not be mistaken for a deleted keeper. *)
+let test_predicate_rejects_other_lookup_errors () =
+  with_workspace (fun ~config ->
+    let operation =
+      make_operation
+        ~keeper_name:"ownerless-inventory-stopping"
+        ~phase:(Finalized (finalized_after_removal_evidence
+                             "ownerless-inventory-stopping"))
+        ~cleanup_intent:
+          { reason = Operator_stop_remove_meta; remove_session = true }
+    in
+    check
+      bool
+      "inventory stopping is not a removal"
+      false
+      (Keeper_shutdown_finalize.admission_already_released_by_removal
+         ~config
+         operation
+         (Keeper_owner_registry.Command_lookup_failed
+            Keeper_owner_registry.Inventory_stopping)))
+;;
+
+let () =
+  Alcotest.run
+    "keeper_shutdown_ownerless_admission_release"
+    [ ( "recovery"
+      , [ Alcotest.test_case
+            "finalized operation settles when keeper removed"
+            `Quick
+            test_finalized_operation_settles_when_keeper_removed
+        ; Alcotest.test_case
+            "superseded operation settles when keeper removed"
+            `Quick
+            test_superseded_operation_settles_when_keeper_removed
+        ; Alcotest.test_case
+            "meta without owner still fails"
+            `Quick
+            test_meta_without_owner_still_fails
+        ; Alcotest.test_case
+            "predicate rejects other lookup errors"
+            `Quick
+            test_predicate_rejects_other_lookup_errors
+        ] )
+    ]
+;;

--- a/test/test_keeper_shutdown_ownerless_admission_release.ml
+++ b/test/test_keeper_shutdown_ownerless_admission_release.ml
@@ -183,6 +183,28 @@ let check_create_meta_rejected label ~config operation =
          ~base_path:config.base_path)
 ;;
 
+let create_owner_meta_exn ~config name =
+  match
+    Keeper_owner_registry.create_meta
+      ~base_path:config.Workspace.base_path
+      (fixture_meta_exn name)
+  with
+  | Ok (Some _) -> ()
+  | Ok None -> fail "owner metadata creation removed its snapshot"
+  | Error error ->
+    fail (Keeper_owner_registry.command_error_to_string error)
+;;
+
+let owner_shutdown_operation_id_exn ~config name =
+  match
+    Keeper_owner_registry.shutdown_operation_id
+      ~base_path:config.Workspace.base_path
+      ~keeper_name:name
+  with
+  | Ok operation_id -> operation_id
+  | Error error -> fail (Keeper_owner_registry.lookup_error_to_string error)
+;;
+
 (* A finalized operation for a keeper whose owner and metadata are both gone
    — the [full-cycle-probe] shape: finalization already removed the meta and
    session, the keeper deletion took the owner, and only the admission
@@ -267,6 +289,60 @@ let test_ownerless_finalizer_hands_intake_to_corrupt_successor () =
          | Some actual -> Operation_id.equal actual successor_operation_id
          | None -> false);
       check_create_meta_rejected "corrupt successor" ~config operation)
+;;
+
+let test_plain_release_keeps_owner_fenced_on_intake_conflict () =
+  with_workspace (fun ~config ->
+    let name = "release-intake-conflict" in
+    let operation =
+      make_operation
+        ~keeper_name:name
+        ~phase:(Finalized (finalized_after_removal_evidence name))
+        ~cleanup_intent:
+          { reason = Operator_stop_remove_meta; remove_session = true }
+    in
+    create_owner_meta_exn ~config name;
+    (match
+       Keeper_owner_registry.begin_shutdown
+         ~base_path:config.base_path
+         ~keeper_name:name
+         ~operation_id:operation.operation_id
+     with
+     | Ok (Keeper_owner.Shutdown_reserved _)
+     | Ok (Keeper_owner.Shutdown_already_reserved _) -> ()
+     | Error error ->
+       fail (Keeper_owner_registry.command_error_to_string error));
+    (match
+       Keeper_shutdown_intake_fence.rollback_shutdown
+         ~base_path:config.base_path
+         ~keeper_name:name
+         ~operation_id:operation.operation_id
+     with
+     | Keeper_shutdown_intake_fence.Rolled_back -> ()
+     | Keeper_shutdown_intake_fence.Not_reserved
+     | Keeper_shutdown_intake_fence.Reserved_by_other _ ->
+       fail "fixture failed to remove the current intake fence");
+    let conflicting_operation_id = Operation_id.generate () in
+    (match
+       Keeper_shutdown_intake_fence.restore_shutdown
+         ~base_path:config.base_path
+         ~keeper_name:name
+         ~operation_id:conflicting_operation_id
+     with
+     | Keeper_shutdown_intake_fence.Restored -> ()
+     | Keeper_shutdown_intake_fence.Already_restored
+     | Keeper_shutdown_intake_fence.Restore_conflict _ ->
+       fail "fixture failed to install the conflicting intake fence");
+    (match Keeper_shutdown_finalize.run ~config ~entry:None operation with
+     | Error _ -> ()
+     | Ok _ -> fail "conflicting intake fence was reported as released");
+    check
+      (option string)
+      "owner-local admission remains closed after release conflict"
+      (Some (Operation_id.to_string operation.operation_id))
+      (Option.map
+         Operation_id.to_string
+         (owner_shutdown_operation_id_exn ~config name)))
 ;;
 
 (* Metadata that outlived its owner is an inconsistent state, not a removal:
@@ -427,6 +503,63 @@ let test_boot_recovery_rejects_ownerless_dead_tombstone () =
     Dead_tombstone_cleanup
 ;;
 
+let check_corrupt_sibling_does_not_hide_ownerless_retain label reason =
+  with_workspace (fun ~config ->
+    let operation =
+      make_operation
+        ~keeper_name:label
+        ~phase:(Blocked { stage = Meta_remove; detail = "fixture" })
+        ~cleanup_intent:{ reason; remove_session = false }
+    in
+    let corrupt_sibling =
+      { operation with operation_id = Operation_id.generate () }
+    in
+    persist_exn ~config operation;
+    persist_exn ~config corrupt_sibling;
+    let corrupt_path =
+      match
+        Keeper_shutdown_store.path
+          ~config
+          ~keeper_name:label
+          corrupt_sibling.operation_id
+      with
+      | Ok path -> path
+      | Error error ->
+        fail (Keeper_shutdown_store.error_to_string error)
+    in
+    (match Fs_compat.save_file_atomic corrupt_path "{not-json" with
+     | Ok () -> ()
+     | Error detail -> fail detail);
+    (match Keeper_shutdown_runtime.recover_at_boot ~config with
+     | [ Error _ ] -> ()
+     | [ Ok _ ] ->
+       fail "corrupt sibling hid the ownerless retain-meta inconsistency"
+     | outcomes ->
+       failf
+         "unexpected corrupt-sibling recovery outcome count: %d"
+         (List.length outcomes));
+    check
+      bool
+      "invalid current operation did not acquire a corrupt-only fence"
+      true
+      (Option.is_none
+         (Keeper_shutdown_intake_fence.shutdown_operation_id
+            ~base_path:config.base_path
+            ~keeper_name:label)))
+;;
+
+let test_corrupt_sibling_does_not_hide_ownerless_operator_retain () =
+  check_corrupt_sibling_does_not_hide_ownerless_retain
+    "ownerless-corrupt-operator-retain"
+    Operator_stop_retain_meta
+;;
+
+let test_corrupt_sibling_does_not_hide_ownerless_dead_tombstone () =
+  check_corrupt_sibling_does_not_hide_ownerless_retain
+    "ownerless-corrupt-dead-tombstone"
+    Dead_tombstone_cleanup
+;;
+
 let pending_completion_operation name =
   let evidence = finalized_after_removal_evidence name in
   make_operation
@@ -548,6 +681,10 @@ let () =
             `Quick
             test_ownerless_finalizer_hands_intake_to_corrupt_successor
         ; Alcotest.test_case
+            "plain release keeps owner fenced on intake conflict"
+            `Quick
+            test_plain_release_keeps_owner_fenced_on_intake_conflict
+        ; Alcotest.test_case
             "meta without owner still fails"
             `Quick
             test_meta_without_owner_still_fails
@@ -559,6 +696,14 @@ let () =
             "predicate rejects retain-meta intents"
             `Quick
             test_predicate_rejects_retain_meta_intents
+        ; Alcotest.test_case
+            "corrupt sibling does not hide ownerless operator-retain"
+            `Quick
+            test_corrupt_sibling_does_not_hide_ownerless_operator_retain
+        ; Alcotest.test_case
+            "corrupt sibling does not hide ownerless dead-tombstone"
+            `Quick
+            test_corrupt_sibling_does_not_hide_ownerless_dead_tombstone
         ] )
     ]
 ;;

--- a/test/test_keeper_shutdown_ownerless_admission_release.ml
+++ b/test/test_keeper_shutdown_ownerless_admission_release.ml
@@ -237,6 +237,73 @@ let test_predicate_rejects_other_lookup_errors () =
             Keeper_owner_registry.Inventory_stopping)))
 ;;
 
+(* The cases above enter through [recover_operation_with_corrupt_owner_fence].
+   Boot does not start there: [recover_at_boot] runs [restore_inventory_admission]
+   first, and only operations that still want a fence go through it. Every
+   fixture above finalizes with [Completion_not_requested], which
+   [requires_admission_fence] answers false for — so none of them ever reached
+   the restore pass, and the gate there went unexercised.
+
+   A dashboard purge that crashed between [complete_cleanup] and its completion
+   receipt leaves exactly the state that does want a fence: meta and owner gone,
+   phase [Finalized { completion = Completion_pending _ }]. Boot must settle it
+   rather than abort, or the crash window this suite exists to close stays open
+   one gate earlier. *)
+let test_boot_recovery_settles_pending_completion_after_removal () =
+  with_workspace (fun ~config ->
+    let name = "ownerless-pending-completion" in
+    let evidence = finalized_after_removal_evidence name in
+    (* [Completion_pending Dashboard_keeper_purged] is only a valid record next
+       to a [Dashboard_keeper_purge] intent — the store rejects any other
+       pairing (Finalized_completion_mismatch). That pairing is also exactly
+       the reported scenario: a dashboard purge that crashed before its
+       receipt. *)
+    let operation =
+      make_operation
+        ~keeper_name:name
+        ~phase:
+          (Finalized
+             { evidence with completion = Completion_pending Dashboard_keeper_purged })
+        ~cleanup_intent:
+          { reason =
+              Dashboard_keeper_purge { requested_name = name; agent_name = name }
+          ; remove_session = true
+          }
+    in
+    check
+      bool
+      "fixture must be one the restore pass actually fences"
+      true
+      (requires_admission_fence operation);
+    (* Settling the fence is only half of this boot: the pending receipt is then
+       delivered, and without a registered handler that step fails for a reason
+       unrelated to the gate under test. Record the delivery so the assertion
+       below is about recovery reaching the end, not about harness wiring. *)
+    let delivered = ref [] in
+    Keeper_shutdown_finalize.register_completion_handler
+      (fun _config delivered_operation action ->
+         delivered := (delivered_operation.keeper_name, action) :: !delivered;
+         Ok ());
+    persist_exn ~config operation;
+    match Keeper_shutdown_runtime.recover_at_boot ~config with
+    | [] -> failf "boot recovery returned no outcome for %s" name
+    | outcomes ->
+      List.iter
+        (function
+          | Ok _ -> ()
+          | Error detail -> failf "boot recovery still fails: %s" detail)
+        outcomes;
+      (* The receipt the crash lost is what recovery owes: settling the fence
+         without delivering it would leave the purge half-finished. *)
+      check
+        (list (pair string string))
+        "boot delivers the pending completion it recovered"
+        [ name, "dashboard_keeper_purged" ]
+        (List.rev_map
+           (fun (keeper, action) -> keeper, completion_action_to_string action)
+           !delivered))
+;;
+
 let () =
   Alcotest.run
     "keeper_shutdown_ownerless_admission_release"
@@ -245,6 +312,10 @@ let () =
             "finalized operation settles when keeper removed"
             `Quick
             test_finalized_operation_settles_when_keeper_removed
+        ; Alcotest.test_case
+            "boot recovery settles a pending completion after removal"
+            `Quick
+            test_boot_recovery_settles_pending_completion_after_removal
         ; Alcotest.test_case
             "superseded operation settles when keeper removed"
             `Quick

--- a/test/test_keeper_shutdown_ownerless_admission_release.ml
+++ b/test/test_keeper_shutdown_ownerless_admission_release.ml
@@ -46,6 +46,8 @@ let with_workspace f =
          ~finally:(fun () ->
            Keeper_shutdown_finalize.For_testing
            .reset_remove_pending_confirms_by_target ();
+           Keeper_shutdown_finalize.For_testing.reset_completion_handler ();
+           Keeper_shutdown_intake_fence.For_testing.reset ();
            Fs_compat.clear_fs ())
          (fun () ->
             let config = Workspace.default_config base in
@@ -151,6 +153,36 @@ let check_settled label ~config operation =
   | Error detail -> failf "%s: recovery still fails: %s" label detail
 ;;
 
+let check_intake_fenced label ~config operation =
+  check
+    bool
+    (label ^ ": exact intake fence remains installed")
+    true
+    (match
+       Keeper_shutdown_intake_fence.shutdown_operation_id
+         ~base_path:config.Workspace.base_path
+         ~keeper_name:operation.keeper_name
+     with
+     | Some existing -> Operation_id.equal existing operation.operation_id
+     | None -> false)
+;;
+
+let check_create_meta_rejected label ~config operation =
+  match
+    Keeper_owner_registry.create_meta
+      ~base_path:config.Workspace.base_path
+      (fixture_meta_exn operation.keeper_name)
+  with
+  | Ok _ -> failf "%s: same-name Keeper was recreated through a shutdown fence" label
+  | Error _ ->
+    check
+      int
+      (label ^ ": rejected creation did not install an empty Owner")
+      0
+      (Keeper_owner_registry.For_testing.installed_owner_count
+         ~base_path:config.base_path)
+;;
+
 (* A finalized operation for a keeper whose owner and metadata are both gone
    — the [full-cycle-probe] shape: finalization already removed the meta and
    session, the keeper deletion took the owner, and only the admission
@@ -170,9 +202,10 @@ let test_finalized_operation_settles_when_keeper_removed () =
     check_settled "finalized" ~config operation)
 ;;
 
-(* A superseded operation for the same removed keeper settles at the
-   shutdown transition instead: no fence exists to transition away from. *)
-let test_superseded_operation_settles_when_keeper_removed () =
+(* A retain-meta supersession cannot use owner absence as removal evidence.
+   Its durable contract says metadata remains, so losing both owner and meta
+   is an inconsistency that recovery must surface. *)
+let test_retain_meta_supersession_does_not_fast_path () =
   with_workspace (fun ~config ->
     let operation =
       make_operation
@@ -182,7 +215,14 @@ let test_superseded_operation_settles_when_keeper_removed () =
           { reason = Operator_stop_retain_meta; remove_session = false }
     in
     persist_exn ~config operation;
-    check_settled "superseded" ~config operation)
+    match recover_fence ~config operation with
+    | Ok _ -> fail "retain-meta supersession was mistaken for a removed Keeper"
+    | Error detail ->
+      check
+        bool
+        "retain-meta inconsistency preserves Owner_not_found"
+        true
+        (String_util.contains_substring detail "Keeper owner not found"))
 ;;
 
 (* Metadata that outlived its owner is an inconsistent state, not a removal:
@@ -237,6 +277,35 @@ let test_predicate_rejects_other_lookup_errors () =
             Keeper_owner_registry.Inventory_stopping)))
 ;;
 
+(* Owner absence plus missing metadata is only terminal removal evidence when
+   the operation itself promised [Remove_meta]. Retain-meta operations must
+   keep surfacing the inconsistency. *)
+let test_predicate_rejects_retain_meta_intents () =
+  with_workspace (fun ~config ->
+    let owner_not_found name =
+      Keeper_owner_registry.Command_lookup_failed
+        (Keeper_owner_registry.Owner_not_found name)
+    in
+    let check_reason label reason =
+      let operation =
+        make_operation
+          ~keeper_name:label
+          ~phase:(Blocked { stage = Meta_remove; detail = "fixture" })
+          ~cleanup_intent:{ reason; remove_session = false }
+      in
+      check
+        bool
+        (label ^ ": retain-meta intent is not removal evidence")
+        false
+        (Keeper_shutdown_finalize.admission_already_released_by_removal
+           ~config
+           operation
+           (owner_not_found label))
+    in
+    check_reason "ownerless-retain-operator" Operator_stop_retain_meta;
+    check_reason "ownerless-retain-tombstone" Dead_tombstone_cleanup)
+;;
+
 (* The cases above enter through [recover_operation_with_corrupt_owner_fence].
    Boot does not start there: [recover_at_boot] runs [restore_inventory_admission]
    first, and only operations that still want a fence go through it. Every
@@ -249,27 +318,77 @@ let test_predicate_rejects_other_lookup_errors () =
    phase [Finalized { completion = Completion_pending _ }]. Boot must settle it
    rather than abort, or the crash window this suite exists to close stays open
    one gate earlier. *)
+let test_boot_recovery_keeps_blocked_ownerless_cleanup_fenced () =
+  with_workspace (fun ~config ->
+    let operation =
+      make_operation
+        ~keeper_name:"ownerless-blocked-cleanup"
+        ~phase:
+          (Blocked
+             { stage = Session_remove
+             ; detail = "remove_session_dir failed after remove_meta_file"
+             })
+        ~cleanup_intent:
+          { reason = Operator_stop_remove_meta; remove_session = true }
+    in
+    persist_exn ~config operation;
+    (match Keeper_shutdown_runtime.recover_at_boot ~config with
+     | [ Ok recovered ] ->
+       check
+         bool
+         "blocked cleanup remains blocked"
+         true
+         (match recovered.phase with
+          | Blocked _ -> true
+          | _ -> false)
+     | [ Error detail ] -> failf "blocked cleanup recovery failed: %s" detail
+     | outcomes -> failf "unexpected blocked cleanup outcome count: %d" (List.length outcomes));
+    check_intake_fenced "blocked cleanup" ~config operation;
+    check_create_meta_rejected "blocked cleanup" ~config operation)
+;;
+
+let pending_completion_operation name =
+  let evidence = finalized_after_removal_evidence name in
+  make_operation
+    ~keeper_name:name
+    ~phase:
+      (Finalized
+         { evidence with completion = Completion_pending Dashboard_keeper_purged })
+    ~cleanup_intent:
+      { reason = Dashboard_keeper_purge { requested_name = name; agent_name = name }
+      ; remove_session = true
+      }
+;;
+
+let test_boot_recovery_keeps_failed_pending_completion_fenced () =
+  with_workspace (fun ~config ->
+    let operation = pending_completion_operation "ownerless-pending-failed" in
+    Keeper_shutdown_finalize.register_completion_handler
+      (fun _config _operation _action -> Error "completion unavailable");
+    persist_exn ~config operation;
+    (match Keeper_shutdown_runtime.recover_at_boot ~config with
+     | [ Error detail ] ->
+       check
+         bool
+         "pending completion failure is reported"
+         true
+         (String_util.contains_substring detail "completion unavailable")
+     | [ Ok _ ] -> fail "failed pending completion was reported as recovered"
+     | outcomes ->
+       failf "unexpected pending completion outcome count: %d" (List.length outcomes));
+    check_intake_fenced "failed pending completion" ~config operation;
+    check_create_meta_rejected "failed pending completion" ~config operation)
+;;
+
 let test_boot_recovery_settles_pending_completion_after_removal () =
   with_workspace (fun ~config ->
     let name = "ownerless-pending-completion" in
-    let evidence = finalized_after_removal_evidence name in
     (* [Completion_pending Dashboard_keeper_purged] is only a valid record next
        to a [Dashboard_keeper_purge] intent — the store rejects any other
        pairing (Finalized_completion_mismatch). That pairing is also exactly
        the reported scenario: a dashboard purge that crashed before its
        receipt. *)
-    let operation =
-      make_operation
-        ~keeper_name:name
-        ~phase:
-          (Finalized
-             { evidence with completion = Completion_pending Dashboard_keeper_purged })
-        ~cleanup_intent:
-          { reason =
-              Dashboard_keeper_purge { requested_name = name; agent_name = name }
-          ; remove_session = true
-          }
-    in
+    let operation = pending_completion_operation name in
     check
       bool
       "fixture must be one the restore pass actually fences"
@@ -301,7 +420,15 @@ let test_boot_recovery_settles_pending_completion_after_removal () =
         [ name, "dashboard_keeper_purged" ]
         (List.rev_map
            (fun (keeper, action) -> keeper, completion_action_to_string action)
-           !delivered))
+           !delivered);
+      check
+        bool
+        "delivered receipt releases the exact intake fence"
+        true
+        (Option.is_none
+           (Keeper_shutdown_intake_fence.shutdown_operation_id
+              ~base_path:config.base_path
+              ~keeper_name:name)))
 ;;
 
 let () =
@@ -313,13 +440,21 @@ let () =
             `Quick
             test_finalized_operation_settles_when_keeper_removed
         ; Alcotest.test_case
+            "blocked ownerless cleanup keeps admission fenced"
+            `Quick
+            test_boot_recovery_keeps_blocked_ownerless_cleanup_fenced
+        ; Alcotest.test_case
+            "failed pending completion keeps admission fenced"
+            `Quick
+            test_boot_recovery_keeps_failed_pending_completion_fenced
+        ; Alcotest.test_case
             "boot recovery settles a pending completion after removal"
             `Quick
             test_boot_recovery_settles_pending_completion_after_removal
         ; Alcotest.test_case
-            "superseded operation settles when keeper removed"
+            "retain-meta supersession does not fast-path removal"
             `Quick
-            test_superseded_operation_settles_when_keeper_removed
+            test_retain_meta_supersession_does_not_fast_path
         ; Alcotest.test_case
             "meta without owner still fails"
             `Quick
@@ -328,6 +463,10 @@ let () =
             "predicate rejects other lookup errors"
             `Quick
             test_predicate_rejects_other_lookup_errors
+        ; Alcotest.test_case
+            "predicate rejects retain-meta intents"
+            `Quick
+            test_predicate_rejects_retain_meta_intents
         ] )
     ]
 ;;

--- a/test/test_keeper_shutdown_ownerless_admission_release.ml
+++ b/test/test_keeper_shutdown_ownerless_admission_release.ml
@@ -391,6 +391,42 @@ let test_boot_recovery_keeps_blocked_ownerless_cleanup_fenced () =
     check_create_meta_rejected "blocked cleanup" ~config operation)
 ;;
 
+let check_boot_recovery_rejects_ownerless_retain_intent label reason =
+  with_workspace (fun ~config ->
+    let operation =
+      make_operation
+        ~keeper_name:label
+        ~phase:(Blocked { stage = Meta_remove; detail = "fixture" })
+        ~cleanup_intent:{ reason; remove_session = false }
+    in
+    persist_exn ~config operation;
+    (match Keeper_shutdown_runtime.recover_at_boot ~config with
+     | [ Error _ ] -> ()
+     | [ Ok _ ] -> fail "ownerless retain-meta operation was reported as recovered"
+     | outcomes ->
+       failf "unexpected retain-meta recovery outcome count: %d" (List.length outcomes));
+    check
+      bool
+      "inconsistent retain-meta state does not install an ownerless fence"
+      true
+      (Option.is_none
+         (Keeper_shutdown_intake_fence.shutdown_operation_id
+            ~base_path:config.base_path
+            ~keeper_name:operation.keeper_name)))
+;;
+
+let test_boot_recovery_rejects_ownerless_operator_retain () =
+  check_boot_recovery_rejects_ownerless_retain_intent
+    "ownerless-blocked-operator-retain"
+    Operator_stop_retain_meta
+;;
+
+let test_boot_recovery_rejects_ownerless_dead_tombstone () =
+  check_boot_recovery_rejects_ownerless_retain_intent
+    "ownerless-blocked-dead-tombstone"
+    Dead_tombstone_cleanup
+;;
+
 let pending_completion_operation name =
   let evidence = finalized_after_removal_evidence name in
   make_operation
@@ -487,6 +523,14 @@ let () =
             "blocked ownerless cleanup keeps admission fenced"
             `Quick
             test_boot_recovery_keeps_blocked_ownerless_cleanup_fenced
+        ; Alcotest.test_case
+            "ownerless operator-retain inconsistency fails boot recovery"
+            `Quick
+            test_boot_recovery_rejects_ownerless_operator_retain
+        ; Alcotest.test_case
+            "ownerless dead-tombstone inconsistency fails boot recovery"
+            `Quick
+            test_boot_recovery_rejects_ownerless_dead_tombstone
         ; Alcotest.test_case
             "failed pending completion keeps admission fenced"
             `Quick

--- a/test/test_keeper_shutdown_ownerless_admission_release.ml
+++ b/test/test_keeper_shutdown_ownerless_admission_release.ml
@@ -225,7 +225,7 @@ let test_retain_meta_supersession_does_not_fast_path () =
       (String_util.contains_substring detail "Keeper owner not found"))
 ;;
 
-let test_ownerless_recovery_hands_intake_to_corrupt_successor () =
+let test_ownerless_finalizer_hands_intake_to_corrupt_successor () =
   with_workspace (fun ~config ->
     let name = "ownerless-corrupt-successor" in
     let operation =
@@ -247,16 +247,16 @@ let test_ownerless_recovery_hands_intake_to_corrupt_successor () =
      | Keeper_shutdown_intake_fence.Restore_conflict _ ->
        fail "fixture failed to install current intake fence");
     match
-      Keeper_shutdown_runtime.recover_operation_with_corrupt_owner_fence
+      Keeper_shutdown_finalize.run
         ~config
-        ~corrupt_owner_fence:
-          (Some
-             { keeper_name = name
-             ; operation_id = successor_operation_id
-             })
+        ~entry:None
+        ~successor_operation_id
         operation
     with
-    | Error detail -> failf "ownerless corrupt handoff failed: %s" detail
+    | Error error ->
+      failf
+        "ownerless corrupt handoff failed: %s"
+        (Keeper_shutdown_finalize.error_to_string error)
     | Ok _ ->
       check bool "corrupt successor owns the intake fence" true
         (match
@@ -500,9 +500,9 @@ let () =
             `Quick
             test_retain_meta_supersession_does_not_fast_path
         ; Alcotest.test_case
-            "ownerless recovery hands intake to corrupt successor"
+            "ownerless finalizer hands intake to corrupt successor"
             `Quick
-            test_ownerless_recovery_hands_intake_to_corrupt_successor
+            test_ownerless_finalizer_hands_intake_to_corrupt_successor
         ; Alcotest.test_case
             "meta without owner still fails"
             `Quick

--- a/test/test_keeper_shutdown_ownerless_admission_release.ml
+++ b/test/test_keeper_shutdown_ownerless_admission_release.ml
@@ -222,7 +222,51 @@ let test_retain_meta_supersession_does_not_fast_path () =
         bool
         "retain-meta inconsistency preserves Owner_not_found"
         true
-        (String_util.contains_substring detail "Keeper owner not found"))
+      (String_util.contains_substring detail "Keeper owner not found"))
+;;
+
+let test_ownerless_recovery_hands_intake_to_corrupt_successor () =
+  with_workspace (fun ~config ->
+    let name = "ownerless-corrupt-successor" in
+    let operation =
+      make_operation
+        ~keeper_name:name
+        ~phase:(Finalized (finalized_after_removal_evidence name))
+        ~cleanup_intent:
+          { reason = Operator_stop_remove_meta; remove_session = true }
+    in
+    let successor_operation_id = Operation_id.generate () in
+    (match
+       Keeper_shutdown_intake_fence.restore_shutdown
+         ~base_path:config.base_path
+         ~keeper_name:name
+         ~operation_id:operation.operation_id
+     with
+     | Keeper_shutdown_intake_fence.Restored -> ()
+     | Keeper_shutdown_intake_fence.Already_restored
+     | Keeper_shutdown_intake_fence.Restore_conflict _ ->
+       fail "fixture failed to install current intake fence");
+    match
+      Keeper_shutdown_runtime.recover_operation_with_corrupt_owner_fence
+        ~config
+        ~corrupt_owner_fence:
+          (Some
+             { keeper_name = name
+             ; operation_id = successor_operation_id
+             })
+        operation
+    with
+    | Error detail -> failf "ownerless corrupt handoff failed: %s" detail
+    | Ok _ ->
+      check bool "corrupt successor owns the intake fence" true
+        (match
+           Keeper_shutdown_intake_fence.shutdown_operation_id
+             ~base_path:config.base_path
+             ~keeper_name:name
+         with
+         | Some actual -> Operation_id.equal actual successor_operation_id
+         | None -> false);
+      check_create_meta_rejected "corrupt successor" ~config operation)
 ;;
 
 (* Metadata that outlived its owner is an inconsistent state, not a removal:
@@ -455,6 +499,10 @@ let () =
             "retain-meta supersession does not fast-path removal"
             `Quick
             test_retain_meta_supersession_does_not_fast_path
+        ; Alcotest.test_case
+            "ownerless recovery hands intake to corrupt successor"
+            `Quick
+            test_ownerless_recovery_hands_intake_to_corrupt_successor
         ; Alcotest.test_case
             "meta without owner still fails"
             `Quick


### PR DESCRIPTION
## 증상 (실측)

삭제된 keeper `full-cycle-probe`의 shutdown operation 3개가 매 부트마다 복구 실패하며 ERROR를 반복 출력 (`~/me/.masc`, 2026-08-12):

- `shutdown-06e24456` / `shutdown-95dfe9b3` (finalized): `Keeper shutdown admission release failed in operation ...: Keeper owner not found: full-cycle-probe`
- `shutdown-44327abd` (superseded): `shutdown recovery failed ... error=Keeper owner not found: full-cycle-probe`

store에 removal API가 없어(audit 보존이 의도) 종결 가능한 코드 경로가 하나도 없었습니다.

## 근본 원인

admission fence는 Keeper owner registry 내부에 존재합니다. operator stop이 meta 삭제까지 완료하면 owner와 meta가 함께 사라지는데, 남은 operation의 release/transition 단계는 그 시점에 자기가 지운 owner를 다시 조회합니다 — 순서 모순으로 매 부트 `Owner_not_found`.

- finalized → `release_finalized_admission` → `rollback_shutdown` 초기 `get`에서 실패
- superseded → `recover_operation_with_corrupt_owner_fence`의 `transition_shutdown` 초기 `get`에서 실패

## 수정

`Keeper_shutdown_finalize.admission_already_released_by_removal` 공용 판별 함수:

- `Command_lookup_failed (Owner_not_found _)` + keeper meta 부재 → **이미 달성됨**으로 종결 (INFO 1줄)
- meta가 남아 있으면 불일치 상태이므로 기존 에러 유지 — `remove_meta_file`의 교차검증 선례와 동일
- `Inventory_stopping` 등 다른 lookup 에러는 종결 대상 아님 (typed variant match, 문자열 분류 아님)

두 실패 지점(finalize의 release, runtime의 transition)이 같은 판별을 공유합니다.

## 검증

- `test_keeper_shutdown_ownerless_admission_release` 4케이스 green (신규, CI names 등록 완료):
  - finalized/superseded 좀비 복구 종결
  - meta만 남은 경우 여전히 실패 (에러 보존 핀 — 같은 경로가 실제 `Admission_release_failed`에 도달함을 관측)
  - `Inventory_stopping` 거부
- 인접 suite 회귀 없음: reconciliation_settlement, benign_termination, shutdown_flag 전부 green
- `dune build @check` green

## RFC 체크

`bash ~/me/scripts/pr-rfc-check.sh --pr-body /tmp/pr-body.md` → PASS (해당 subsystem 아님: credential/identity/repo/operator_control/sandbox/hooks/workflow 외)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
