### PR TITLE
fix(ide): make the IDE overlay read the store keeper writes land in

### DIFF
--- a/dashboard/src/components/ide/ide-data-workspace-store.ts
+++ b/dashboard/src/components/ide/ide-data-workspace-store.ts
@@ -10,6 +10,7 @@ import {
   sameIdeWorkspaceIdentity,
   synchronizeIdeWorkspaceIdentity,
 } from './ide-state'
+import { publishLspScope } from './ide-lsp-client'
 import { activeKeeperName } from '../../keeper-state'
 import { route } from '../../router'
 import { selectedTask } from '../goals/task-detail-selection'
@@ -472,6 +473,11 @@ export function createIdeDataWorkspaceStore(): IdeDataWorkspaceStore {
           scope: ideScopeFromKeeperLane(keeperParam),
           signal,
         }
+    // The LSP connection needs the same scope: it picks both the annotation
+    // partition the overlay reads and the tree our repo-relative document
+    // paths resolve against. Publishing it here keeps the socket addressing
+    // the rows these REST reads address.
+    publishLspScope({ repoId: repoId ?? null, keeper: keeperParam ?? null })
     workspaceIssuesSignal.value = retainCurrentWorkspaceFetchIssues(currentWorkspaceIssues(), {
       filePath: requestedFilePath,
       keeper: keeperParam ?? null,

--- a/dashboard/src/components/ide/ide-lsp-client.test.ts
+++ b/dashboard/src/components/ide/ide-lsp-client.test.ts
@@ -6,6 +6,7 @@ import {
   lspDiagnosticSnapshot,
   lspStatusSnapshot,
   parseLspStatusSnapshot,
+  publishLspScope,
   resolveLspDiagnosticFilePath,
 } from './ide-lsp-client'
 import {
@@ -59,6 +60,19 @@ class MockWebSocket {
   }
 }
 
+const MOCK_WORKSPACE_ROOT = '/workspace/masc'
+
+async function completeHandshake(socket: MockWebSocket): Promise<void> {
+  socket.open()
+  const initialize = JSON.parse(socket.sent[0]!) as { id: number }
+  socket.message({
+    id: initialize.id,
+    result: { masc: { workspaceRoot: MOCK_WORKSPACE_ROOT } },
+  })
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
 function installWebSocketMock(): void {
   mockSockets.length = 0
   vi.stubGlobal('WebSocket', MockWebSocket)
@@ -71,6 +85,9 @@ afterEach(() => {
   lspDiagnosticSnapshot.value = new Map()
   lspStatusSnapshot.value = EMPTY_LSP_STATUS_SNAPSHOT
   mockSockets.length = 0
+  // The published scope is process-wide, so a case that declares one must not
+  // decide what the next case connects with.
+  publishLspScope({ repoId: null, keeper: null })
 })
 
 describe('resolveLspDiagnosticFilePath', () => {
@@ -215,10 +232,12 @@ describe('LspConnection', () => {
     const conn = new LspConnection(() => {}, () => {})
     conn.connect()
     const socket = mockSockets[0]!
-    socket.open()
+    await completeHandshake(socket)
 
     const hover = conn.requestHover('lib/keeper/current.ml', 0, 0)
-    expect(socket.sent).toHaveLength(2)
+    // initialize, initialized, then the document request: a document cannot
+    // be named until the handshake reports the workspace tree.
+    expect(socket.sent).toHaveLength(3)
 
     socket.close({ code: 1011, reason: 'server restart', wasClean: false })
 
@@ -231,14 +250,16 @@ describe('LspConnection', () => {
     const conn = new LspConnection(() => {}, () => {})
     conn.connect()
     const oldSocket = mockSockets[0]!
-    oldSocket.open()
+    await completeHandshake(oldSocket)
 
     conn.connect()
     const currentSocket = mockSockets[1]!
-    currentSocket.open()
+    await completeHandshake(currentSocket)
 
     const hover = conn.requestHover('lib/keeper/current.ml', 0, 0)
-    expect(currentSocket.sent).toHaveLength(2)
+    // initialize, initialized, then the document request: a document cannot
+    // be named until the handshake reports the workspace tree.
+    expect(currentSocket.sent).toHaveLength(3)
 
     oldSocket.close({ code: 1006, wasClean: false })
     oldSocket.message({ id: 3, result: { contents: 'stale' } })
@@ -352,6 +373,75 @@ describe('LspConnection', () => {
     conn.dispose()
   })
 
+  // The connection URL is how the server learns which codebase this editor is
+  // looking at: it picks both the annotation partition the overlay reads and
+  // the tree our repo-relative document paths resolve against. Without it the
+  // server had to guess, and read the wrong store.
+  it('declares the repository scope on the connection URL', () => {
+    installWebSocketMock()
+    publishLspScope({ repoId: 'masc', keeper: null })
+    const conn = new LspConnection(() => {}, () => {})
+    conn.connect()
+    expect(mockSockets[0]!.url).toContain('/api/v1/ide/lsp?repo_id=masc')
+    conn.dispose()
+  })
+
+  it('declares a keeper lane as both the partition and the tree', () => {
+    installWebSocketMock()
+    publishLspScope({ repoId: null, keeper: 'analyst' })
+    const conn = new LspConnection(() => {}, () => {})
+    conn.connect()
+    const url = mockSockets[0]!.url
+    expect(url).toContain('keeper_lane=analyst')
+    expect(url).toContain('keeper=analyst')
+    conn.dispose()
+  })
+
+  it('declares no scope when none is published', () => {
+    installWebSocketMock()
+    publishLspScope({ repoId: null, keeper: null })
+    const conn = new LspConnection(() => {}, () => {})
+    conn.connect()
+    expect(mockSockets[0]!.url).toMatch(/\/api\/v1\/ide\/lsp$/)
+    conn.dispose()
+  })
+
+  // A repo-relative path prefixed with `file://` is not an absolute URI — its
+  // first segment lands in the authority slot — so the server rejected the
+  // document as outside its workspace and answered empty.
+  it('names documents with an absolute URI under the advertised root', async () => {
+    installWebSocketMock()
+    publishLspScope({ repoId: 'masc', keeper: null })
+    const conn = new LspConnection(() => {}, () => {})
+    conn.connect()
+    const socket = mockSockets[0]!
+    await completeHandshake(socket)
+
+    void conn.requestCodeLenses('lib/keeper/current.ml')
+    const request = JSON.parse(socket.sent[socket.sent.length - 1]!) as {
+      params: { textDocument: { uri: string } }
+    }
+    expect(request.params.textDocument.uri).toBe(
+      `file://${MOCK_WORKSPACE_ROOT}/lib/keeper/current.ml`,
+    )
+    conn.dispose()
+  })
+
+  // Before the handshake reports the tree there is no way to name a document,
+  // so a request must be skipped rather than sent with a guessed path.
+  it('sends no document request before the workspace root is known', async () => {
+    installWebSocketMock()
+    const conn = new LspConnection(() => {}, () => {})
+    conn.connect()
+    const socket = mockSockets[0]!
+    socket.open()
+
+    const lenses = await conn.requestCodeLenses('lib/keeper/current.ml')
+    expect(lenses.size).toBe(0)
+    expect(socket.sent).toHaveLength(1)
+    conn.dispose()
+  })
+
   it('routes notification send failures through reconnect instead of throwing', async () => {
     vi.useFakeTimers()
     installWebSocketMock()
@@ -361,7 +451,10 @@ describe('LspConnection', () => {
     const socket = mockSockets[0]!
     socket.open()
     const initialize = JSON.parse(socket.sent[0]!) as { id: number }
-    socket.message({ id: initialize.id, result: {} })
+    socket.message({
+      id: initialize.id,
+      result: { masc: { workspaceRoot: MOCK_WORKSPACE_ROOT } },
+    })
     await Promise.resolve()
 
     expect(socket.sent).toHaveLength(2)

--- a/dashboard/src/components/ide/ide-lsp-client.ts
+++ b/dashboard/src/components/ide/ide-lsp-client.ts
@@ -28,6 +28,57 @@ import { DEFAULT_LANGUAGE_ID } from './ide-language'
 
 // ── Types ─────────────────────────────────────────────────────────
 
+/**
+ * Which codebase this editor's LSP connection is looking at.
+ *
+ * The server needs it for two things at once: the `.masc-ide/` partition to
+ * read annotations from, and the workspace tree our repo-relative document
+ * paths hang off. A connection that declares neither gets language-server
+ * passthrough with no MASC overlay — never a guessed default partition.
+ *
+ * `repoId` is authoritative when a repository is selected; otherwise a
+ * selected keeper reads its own orphan observation lane. This mirrors the
+ * scope the workspace store already sends to the IDE REST routes, so the
+ * two surfaces address the same rows.
+ */
+export interface LspScope {
+  readonly repoId: string | null
+  readonly keeper: string | null
+}
+
+const EMPTY_LSP_SCOPE: LspScope = { repoId: null, keeper: null }
+
+/**
+ * Deliberately a plain cell, not a signal. The publisher writes it from
+ * inside the workspace store's `effect`, and a signal write there forces an
+ * intermediate flush that re-runs that effect — it re-fetched the active
+ * file twice. Nothing needs to react to this value: the connection reads it
+ * when it opens a socket and when it checks whether its socket went stale.
+ */
+let currentLspScope: LspScope = EMPTY_LSP_SCOPE
+
+export function publishLspScope(scope: LspScope): void {
+  currentLspScope = scope
+}
+
+export function lspScopeSnapshot(): LspScope {
+  return currentLspScope
+}
+
+function lspScopeQuery(scope: LspScope): string {
+  const params = new URLSearchParams()
+  if (scope.repoId) {
+    params.set('repo_id', scope.repoId)
+  } else if (scope.keeper) {
+    // `keeper_lane` picks the partition; `keeper` picks the tree. The server
+    // resolves them with two different resolvers and both need naming.
+    params.set('keeper_lane', scope.keeper)
+    params.set('keeper', scope.keeper)
+  }
+  const query = params.toString()
+  return query === '' ? '' : `?${query}`
+}
+
 export interface LspCodeLens {
   range: {
     start: { line: number; character: number }
@@ -394,6 +445,15 @@ export class LspConnection {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null
   private reconnectAttempts = 0
   private reconnectDelayMs = TRANSPORT_RETRY_BASE_MS
+  /**
+   * Absolute host path of the workspace tree, from the initialize result.
+   * Until it arrives we cannot name a document: we know the repo-relative
+   * path we browsed, not the tree it hangs off, and `textDocument.uri` has
+   * to be an absolute `file:` URI. Requests are skipped rather than sent
+   * with a path the server would have to guess at.
+   */
+  private workspaceRoot: string | null = null
+  private connectedScope: LspScope = EMPTY_LSP_SCOPE
 
   constructor(
     private readonly onDiagnostics: (uri: string | undefined, diags: ReadonlyMap<number, LspDiagnostic[]>) => void,
@@ -405,7 +465,11 @@ export class LspConnection {
     if (this.disposed) return
     this.clearReconnectTimer()
     const origin = typeof window !== 'undefined' ? window.location.origin : DEFAULT_MASC_ORIGIN
-    const wsUrl = origin.replace(/^http/, 'ws') + '/api/v1/ide/lsp'
+    const scope = lspScopeSnapshot()
+    this.connectedScope = scope
+    this.workspaceRoot = null
+    const wsUrl =
+      origin.replace(/^http/, 'ws') + '/api/v1/ide/lsp' + lspScopeQuery(scope)
     const ws = new WebSocket(wsUrl)
     this.ws = ws
 
@@ -521,6 +585,29 @@ export class LspConnection {
     this.scheduleReconnect()
   }
 
+  /**
+   * The socket carries its scope in its URL, so a scope change makes the
+   * live connection address the wrong partition and the wrong tree.
+   * Reconnecting is the only way to re-declare it. The old socket's handlers
+   * no-op once `this.ws` moves on.
+   */
+  refreshScopeIfStale(): void {
+    if (this.disposed) return
+    const scope = lspScopeSnapshot()
+    if (
+      scope.repoId === this.connectedScope.repoId
+      && scope.keeper === this.connectedScope.keeper
+    ) return
+    const previous = this.ws
+    this.ws = null
+    this.initialized = false
+    this.workspaceRoot = null
+    this.rejectPending(new Error('LSP scope changed'))
+    previous?.close()
+    this.resetReconnectBackoff()
+    this.connect()
+  }
+
   private scheduleReconnect(): void {
     if (this.disposed) return
     if (this.reconnectTimer !== null) return
@@ -541,10 +628,12 @@ export class LspConnection {
 
   private async initialize(): Promise<void> {
     try {
-      await this.sendRequest('initialize', {
+      const result = await this.sendRequest('initialize', {
         processId: null,
         clientInfo: { name: 'masc-ide', version: '1.0.0' },
         locale: 'ko',
+        // The server resolves the tree from the scope on the connection URL
+        // and reports it back; a browser client has no host path to offer.
         rootUri: '',
         capabilities: {
           textDocument: {
@@ -554,6 +643,7 @@ export class LspConnection {
           },
         },
       })
+      this.workspaceRoot = workspaceRootOfInitializeResult(result)
       this.initialized = this.sendNotification('initialized', {})
       if (this.initialized) {
         this.resetReconnectBackoff()
@@ -566,8 +656,19 @@ export class LspConnection {
     }
   }
 
+  /**
+   * Absolute URI for a repo-relative document path, or `null` while the
+   * workspace tree is still unknown (before the initialize result lands, or
+   * on a connection the server declined to anchor).
+   */
+  private documentUri(filePath: string): string | null {
+    const root = this.workspaceRoot
+    return root === null ? null : toFileUri(root, filePath)
+  }
+
   async requestCodeLenses(filePath: string): Promise<ReadonlyMap<number, LspCodeLens[]>> {
-    const uri = toFileUri(filePath)
+    const uri = this.documentUri(filePath)
+    if (uri === null) return new Map()
     try {
       const result = await this.sendRequest('textDocument/codeLens', {
         textDocument: { uri },
@@ -579,7 +680,8 @@ export class LspConnection {
   }
 
   async requestInlayHints(filePath: string, lineCount: number): Promise<ReadonlyMap<number, LspInlayHint[]>> {
-    const uri = toFileUri(filePath)
+    const uri = this.documentUri(filePath)
+    if (uri === null) return new Map()
     const range = {
       start: { line: 0, character: 0 },
       end: { line: lineCount, character: 0 },
@@ -596,7 +698,8 @@ export class LspConnection {
   }
 
   async requestDiagnostics(filePath: string): Promise<ReadonlyMap<number, LspDiagnostic[]>> {
-    const uri = toFileUri(filePath)
+    const uri = this.documentUri(filePath)
+    if (uri === null) return new Map()
     try {
       const result = await this.sendRequest('textDocument/diagnostic', {
         textDocument: { uri },
@@ -609,7 +712,8 @@ export class LspConnection {
   }
 
   async requestHover(filePath: string, line: number, character: number): Promise<unknown> {
-    const uri = toFileUri(filePath)
+    const uri = this.documentUri(filePath)
+    if (uri === null) return null
     try {
       return await this.sendRequest('textDocument/hover', {
         textDocument: { uri },
@@ -622,7 +726,8 @@ export class LspConnection {
 
   notifyDidOpen(filePath: string, languageId: string): void {
     if (!this.initialized) return
-    const uri = toFileUri(filePath)
+    const uri = this.documentUri(filePath)
+    if (uri === null) return
     this.sendNotification('textDocument/didOpen', {
       textDocument: { uri, languageId, version: 1, text: '' },
     })
@@ -630,7 +735,8 @@ export class LspConnection {
 
   notifyDidClose(filePath: string): void {
     if (!this.initialized) return
-    const uri = toFileUri(filePath)
+    const uri = this.documentUri(filePath)
+    if (uri === null) return
     this.sendNotification('textDocument/didClose', {
       textDocument: { uri },
     })
@@ -638,7 +744,8 @@ export class LspConnection {
 
   notifyDidSave(filePath: string): void {
     if (!this.initialized) return
-    const uri = toFileUri(filePath)
+    const uri = this.documentUri(filePath)
+    if (uri === null) return
     this.sendNotification('textDocument/didSave', {
       textDocument: { uri },
     })
@@ -675,8 +782,23 @@ export class LspConnection {
 
 // ── Helpers ───────────────────────────────────────────────────────
 
-function toFileUri(filePath: string): string {
-  return `file://${filePath}`
+/**
+ * `textDocument.uri` must be an absolute `file:` URI. Prefixing a
+ * repo-relative path with `file://` does not produce one — the first path
+ * segment lands in the authority slot — so the server rejected every such
+ * document as outside its workspace and answered with an empty result.
+ */
+function toFileUri(workspaceRoot: string, filePath: string): string {
+  const root = workspaceRoot.endsWith('/') ? workspaceRoot.slice(0, -1) : workspaceRoot
+  return filePath.startsWith('/') ? `file://${filePath}` : `file://${root}/${filePath}`
+}
+
+function workspaceRootOfInitializeResult(result: unknown): string | null {
+  if (typeof result !== 'object' || result === null) return null
+  const masc = (result as { masc?: unknown }).masc
+  if (typeof masc !== 'object' || masc === null) return null
+  const root = (masc as { workspaceRoot?: unknown }).workspaceRoot
+  return typeof root === 'string' && root !== '' ? root : null
 }
 
 function lspCloseReason(event: CloseEvent): string {
@@ -905,6 +1027,7 @@ const lspViewPlugin = ViewPlugin.fromClass(
 
     update(update: ViewUpdate) {
       if (update.docChanged) this.hideTooltip()
+      this.conn.refreshScopeIfStale()
       const newFilePath = update.state.field(lspConfigField).filePath
       if (newFilePath !== this.filePath) {
         const oldFilePath = this.filePath

--- a/lib/ide/ide_annotations.ml
+++ b/lib/ide/ide_annotations.ml
@@ -17,6 +17,10 @@ let annotations_file_for ~base_dir partition =
   Filename.concat (partition_dir ~base_dir partition) "annotations.jsonl"
 ;;
 
+let store_file ~base_dir ?(partition = Ide_paths.Legacy_default) () =
+  annotations_file_for ~base_dir partition
+;;
+
 
 let tombstone_key = "__tombstone"
 let compact_key = "__compact"

--- a/lib/ide/ide_annotations.mli
+++ b/lib/ide/ide_annotations.mli
@@ -17,6 +17,13 @@ val store_path : base_dir:string -> string
     flat directory). For partition-aware paths see
     {!Ide_paths.partition_store_dir}. *)
 
+val store_file : base_dir:string -> ?partition:Ide_paths.partition -> unit -> string
+(** [store_file ~base_dir ~partition ()] is the append-only
+    [annotations.jsonl] inside the partition's directory. Exposed so a
+    reader can observe the store's revision (its byte length, since every
+    mutation is an append) without restating the file name. Default
+    [partition] is {!Ide_paths.Legacy_default}. *)
+
 val ensure_store : base_dir:string -> ?partition:Ide_paths.partition -> unit -> unit
 (** Create the partition's directory if absent. Idempotent. Default
     [partition] is {!Ide_paths.Legacy_default}. *)

--- a/lib/server/lsp_overlay_provider.ml
+++ b/lib/server/lsp_overlay_provider.ml
@@ -7,45 +7,93 @@
 open Ide_annotation_types
 
 module Cache = struct
-  let tbl : (string, annotation list) Hashtbl.t = Hashtbl.create 32
+  (* The cached rows are only valid for the store revision they were read
+     from. [store_bytes] is that revision token: every mutation of an
+     annotation store is an append (create, tombstone, and compaction
+     marker alike — see [Ide_annotations]), so the file's byte length is a
+     total order on its contents. A cache hit therefore has to agree with
+     the store's current length, otherwise a keeper annotation written
+     after the reader first touched the file would stay invisible for the
+     whole connection: the client that reads this overlay is read-only, so
+     the [didSave] invalidation below never fires for it. *)
+  type entry =
+    { annotations : annotation list
+    ; store_bytes : int
+    }
+
+  let tbl : (string, entry) Hashtbl.t = Hashtbl.create 32
   let mutex = Eio.Mutex.create ()
 
-  let key ~base_dir ~file_path =
+  (* Keyed by the store directory, not by [base_dir] alone: the same
+     repo-relative [file_path] names a different document in every
+     partition, so a partition-blind key would serve one partition's rows
+     for another's request. *)
+  let key ~base_dir ~partition ~file_path =
+    let store_dir = Ide_paths.partition_store_dir ~base_dir partition in
     let p =
       if String.equal file_path ""
-      then Fpath.v base_dir
-      else Fpath.append (Fpath.v base_dir) (Fpath.v file_path)
+      then Fpath.v store_dir
+      else Fpath.append (Fpath.v store_dir) (Fpath.v file_path)
     in
     Fpath.to_string (Fpath.rem_empty_seg (Fpath.normalize p))
+  ;;
 
-  let get ~base_dir ~file_path =
-    Eio.Mutex.use_rw ~protect:true mutex (fun () ->
-      let k = key ~base_dir ~file_path in
-      match Hashtbl.find_opt tbl k with
-      | Some annotations -> annotations
-      | None ->
-        let filter : annotation_filter =
-          { file_path = Some file_path; keeper_id = None; goal_id = None; task_id = None }
-        in
-        let annotations = Ide_annotations.list ~base_dir ~filter () in
-        Hashtbl.replace tbl k annotations;
-        annotations)
+  (* A store file that does not exist yet reads as length 0, which is the
+     same revision an empty store has. Both hold no annotations, so the
+     cached empty list stays valid until the first append. *)
+  let store_bytes ~base_dir ~partition =
+    match Fs_compat.file_size (Ide_annotations.store_file ~base_dir ~partition ()) with
+    | Some bytes -> bytes
+    | None -> 0
+  ;;
 
-  let invalidate ~base_dir ~file_path =
-    Eio.Mutex.use_rw ~protect:true mutex (fun () ->
-      Hashtbl.remove tbl (key ~base_dir ~file_path))
+  (* [partition = None] is a reader that has not named a store — an LSP
+     connection opened without an IDE scope, for instance. It reads as no
+     annotations, never as a default partition: picking one would serve
+     another repo's rows to a reader that never asked for a repo. *)
+  let get ~base_dir ~partition ~file_path =
+    match partition with
+    | None -> []
+    | Some partition ->
+      Eio.Mutex.use_rw ~protect:true mutex (fun () ->
+        let k = key ~base_dir ~partition ~file_path in
+        let store_bytes = store_bytes ~base_dir ~partition in
+        match Hashtbl.find_opt tbl k with
+        | Some entry when entry.store_bytes = store_bytes -> entry.annotations
+        | Some _ | None ->
+          let filter : annotation_filter =
+            { file_path = Some file_path; keeper_id = None; goal_id = None; task_id = None }
+          in
+          let annotations = Ide_annotations.list ~base_dir ~partition ~filter () in
+          Hashtbl.replace tbl k { annotations; store_bytes };
+          annotations)
+  ;;
 
-  let clear () =
-    Eio.Mutex.use_rw ~protect:true mutex (fun () ->
-      Hashtbl.clear tbl)
+  let invalidate ~base_dir ~partition ~file_path =
+    match partition with
+    | None -> ()
+    | Some partition ->
+      Eio.Mutex.use_rw ~protect:true mutex (fun () ->
+        Hashtbl.remove tbl (key ~base_dir ~partition ~file_path))
+  ;;
+
+  let clear () = Eio.Mutex.use_rw ~protect:true mutex (fun () -> Hashtbl.clear tbl)
 end
 
-(** Centralized [file://] URI helper using Fpath normalization. *)
-let file_uri_of_relative ~base_dir ~file_path =
+(** Centralized [file://] URI helper using Fpath normalization.
+
+    [document_root] is the absolute directory a stored annotation's
+    [file_path] is relative to — the workspace tree the reader opened, not
+    the directory that holds the [.masc-ide] store. Conflating the two
+    produced URIs under the store root, which no editor can open. An
+    absolute [file_path] is already a host path and is used verbatim. *)
+let file_uri_of_relative ~document_root ~file_path =
   let p =
     if String.equal file_path ""
-    then Fpath.v base_dir
-    else Fpath.append (Fpath.v base_dir) (Fpath.v file_path)
+    then Fpath.v document_root
+    else if Filename.is_relative file_path
+    then Fpath.append (Fpath.v document_root) (Fpath.v file_path)
+    else Fpath.v file_path
   in
   "file://" ^ Fpath.to_string (Fpath.rem_empty_seg (Fpath.normalize p))
 ;;
@@ -115,8 +163,8 @@ let inlay_hint_to_json (a : annotation) : Yojson.Safe.t =
   ]
 
 (** Generate LSP CodeLens entries for a file. *)
-let codelenses ~base_dir ~file_path : Yojson.Safe.t list =
-  let annotations = Cache.get ~base_dir ~file_path in
+let codelenses ~base_dir ~partition ~file_path : Yojson.Safe.t list =
+  let annotations = Cache.get ~base_dir ~partition ~file_path in
   List.filter_map (fun (a : annotation) ->
     match a.kind with
     | Decision -> Some (codelens_to_json a)
@@ -127,8 +175,8 @@ let codelenses ~base_dir ~file_path : Yojson.Safe.t list =
 
 (** Generate LSP InlayHint entries for a file.
     Only annotations with route-context bindings produce hints. *)
-let inlay_hints ~base_dir ~file_path : Yojson.Safe.t list =
-  let annotations = Cache.get ~base_dir ~file_path in
+let inlay_hints ~base_dir ~partition ~file_path : Yojson.Safe.t list =
+  let annotations = Cache.get ~base_dir ~partition ~file_path in
   List.filter_map (fun (a : annotation) ->
     if annotation_route_tags a <> [] then
       Some (inlay_hint_to_json a)
@@ -139,9 +187,9 @@ let inlay_hints ~base_dir ~file_path : Yojson.Safe.t list =
 (** Merge MASC warnings with LSP diagnostics.
     Annotations of kind [Question] are elevated to [Information] severity
     diagnostics to surface unresolved questions in the editor. *)
-let diagnostics ~base_dir ~file_path ~(lsp_diagnostics : Yojson.Safe.t list) :
+let diagnostics ~base_dir ~partition ~file_path ~(lsp_diagnostics : Yojson.Safe.t list) :
   Yojson.Safe.t list =
-  let annotations = Cache.get ~base_dir ~file_path in
+  let annotations = Cache.get ~base_dir ~partition ~file_path in
   let masc_diags = List.filter_map (fun (a : annotation) ->
     match a.kind with
     | Question ->
@@ -161,21 +209,21 @@ let diagnostics ~base_dir ~file_path ~(lsp_diagnostics : Yojson.Safe.t list) :
   ) annotations in
   lsp_diagnostics @ masc_diags
 
-let invalidate_cache ~base_dir ~file_path = Cache.invalidate ~base_dir ~file_path
+let invalidate_cache ~base_dir ~partition ~file_path = Cache.invalidate ~base_dir ~partition ~file_path
 
 let clear_cache () = Cache.clear ()
 
 (** Find annotations overlapping a given LSP position (0-based line).
     An annotation covers lines [line_start, line_end] (1-based internally),
     so it overlaps LSP line [l] when [line_start - 1 <= l <= line_end - 1]. *)
-let annotations_at_line ~base_dir ~file_path ~line =
-  let annotations = Cache.get ~base_dir ~file_path in
+let annotations_at_line ~base_dir ~partition ~file_path ~line =
+  let annotations = Cache.get ~base_dir ~partition ~file_path in
   List.filter (fun (a : annotation) ->
     a.line_start - 1 <= line && line <= a.line_end - 1
   ) annotations
 
-let has_annotations_at_line ~base_dir ~file_path ~line =
-  annotations_at_line ~base_dir ~file_path ~line <> []
+let has_annotations_at_line ~base_dir ~partition ~file_path ~line =
+  annotations_at_line ~base_dir ~partition ~file_path ~line <> []
 
 (** Normalize Hover.contents to MarkupContent (kind, value).
     Handles MarkupContent, MarkedString, and MarkedString[]. *)
@@ -206,8 +254,8 @@ let contents_to_markup = function
 (** Append MASC annotation context to an LSP Hover response.
     Handles all LSP Hover.contents forms: MarkupContent, MarkedString, MarkedString[].
     Returns the enriched response unchanged if no annotations overlap. *)
-let enrich_hover ~base_dir ~file_path ~line (result : Yojson.Safe.t) =
-  let matching = annotations_at_line ~base_dir ~file_path ~line in
+let enrich_hover ~base_dir ~partition ~file_path ~line (result : Yojson.Safe.t) =
+  let matching = annotations_at_line ~base_dir ~partition ~file_path ~line in
   if matching = [] then result
   else
     let masc_section =
@@ -237,11 +285,11 @@ let enrich_hover ~base_dir ~file_path ~line (result : Yojson.Safe.t) =
 
 (** Generate LSP Location links for annotations overlapping [line].
     Used by textDocument/definition to jump to annotation targets. *)
-let definition_links ~base_dir ~file_path ~line : Yojson.Safe.t list =
-  let matching = annotations_at_line ~base_dir ~file_path ~line in
+let definition_links ~base_dir ~partition ~document_root ~file_path ~line : Yojson.Safe.t list =
+  let matching = annotations_at_line ~base_dir ~partition ~file_path ~line in
   List.map (fun (a : annotation) ->
     `Assoc [
-      ("uri", `String (file_uri_of_relative ~base_dir ~file_path:a.file_path));
+      ("uri", `String (file_uri_of_relative ~document_root ~file_path:a.file_path));
       ("range", `Assoc [
         ("start", `Assoc [("line", `Int (a.line_start - 1)); ("character", `Int 0)]);
         ("end", `Assoc [("line", `Int (a.line_end - 1)); ("character", `Int 0)]);
@@ -252,12 +300,12 @@ let definition_links ~base_dir ~file_path ~line : Yojson.Safe.t list =
 (** Generate LSP Location[] for annotations related to those at [line].
     Finds annotations sharing the same goal_id or task_id across the file.
     Used by textDocument/references. *)
-let reference_locations ~base_dir ~file_path ~line ~include_declaration:_ :
+let reference_locations ~base_dir ~partition ~document_root ~file_path ~line ~include_declaration:_ :
     Yojson.Safe.t list =
-  let matching = annotations_at_line ~base_dir ~file_path ~line in
+  let matching = annotations_at_line ~base_dir ~partition ~file_path ~line in
   let goal_ids = List.filter_map (fun (a : annotation) -> a.goal_id) matching in
   let task_ids = List.filter_map (fun (a : annotation) -> a.task_id) matching in
-  let all = Cache.get ~base_dir ~file_path in
+  let all = Cache.get ~base_dir ~partition ~file_path in
   let related = List.filter (fun (a : annotation) ->
     (match a.goal_id with Some g -> List.mem g goal_ids | None -> false)
     || (match a.task_id with Some t -> List.mem t task_ids | None -> false)
@@ -270,7 +318,7 @@ let reference_locations ~base_dir ~file_path ~line ~include_declaration:_ :
   ) (matching @ related) in
   List.map (fun (a : annotation) ->
     `Assoc [
-      ("uri", `String (file_uri_of_relative ~base_dir ~file_path:a.file_path));
+      ("uri", `String (file_uri_of_relative ~document_root ~file_path:a.file_path));
       ("range", `Assoc [
         ("start", `Assoc [("line", `Int (a.line_start - 1)); ("character", `Int 0)]);
         ("end", `Assoc [("line", `Int (a.line_end - 1)); ("character", `Int 0)]);
@@ -280,8 +328,8 @@ let reference_locations ~base_dir ~file_path ~line ~include_declaration:_ :
 
 (** Generate CompletionItem[] for MASC annotation snippets.
     Used by textDocument/completion. *)
-let completion_items ~base_dir ~file_path ~line:_ : Yojson.Safe.t list =
-  let annotations = Cache.get ~base_dir ~file_path in
+let completion_items ~base_dir ~partition ~file_path ~line:_ : Yojson.Safe.t list =
+  let annotations = Cache.get ~base_dir ~partition ~file_path in
   let kinds = [ "Comment"; "Decision"; "Question"; "Bookmark" ] in
   List.mapi (fun i kind ->
     let label = Printf.sprintf "masc:%s" (String.lowercase_ascii kind) in
@@ -301,8 +349,8 @@ let completion_items ~base_dir ~file_path ~line:_ : Yojson.Safe.t list =
 
 (** Generate CodeAction[] for annotation operations.
     Used by textDocument/codeAction. *)
-let code_actions ~base_dir ~file_path ~line ~diagnostics:_ : Yojson.Safe.t list =
-  let matching = annotations_at_line ~base_dir ~file_path ~line in
+let code_actions ~base_dir ~partition ~file_path ~line ~diagnostics:_ : Yojson.Safe.t list =
+  let matching = annotations_at_line ~base_dir ~partition ~file_path ~line in
   (* task-1692: the observation plane is read-only, so "Create MASC
      Annotation" must not return a WorkspaceEdit that inserts text into the
      source file (the old [edit]/[newText]). Annotations live in the MASC
@@ -340,8 +388,8 @@ let code_actions ~base_dir ~file_path ~line ~diagnostics:_ : Yojson.Safe.t list 
 
 (** Generate SymbolInformation[] for MASC annotations.
     Used by textDocument/documentSymbol. *)
-let document_symbols ~base_dir ~file_path : Yojson.Safe.t list =
-  let annotations = Cache.get ~base_dir ~file_path in
+let document_symbols ~base_dir ~partition ~file_path : Yojson.Safe.t list =
+  let annotations = Cache.get ~base_dir ~partition ~file_path in
   List.map (fun (a : annotation) ->
     let kind_label = annotation_kind_to_string a.kind in
     let truncated =
@@ -366,8 +414,8 @@ let document_symbols ~base_dir ~file_path : Yojson.Safe.t list =
 
 (** Generate FoldingRange[] for consecutive annotation blocks.
     Used by textDocument/foldingRange. *)
-let folding_ranges ~base_dir ~file_path : Yojson.Safe.t list =
-  let annotations = Cache.get ~base_dir ~file_path in
+let folding_ranges ~base_dir ~partition ~file_path : Yojson.Safe.t list =
+  let annotations = Cache.get ~base_dir ~partition ~file_path in
   let sorted_anns = List.sort (fun (a : annotation) (b : annotation) ->
     compare a.line_start b.line_start
   ) annotations in
@@ -402,13 +450,13 @@ let folding_ranges ~base_dir ~file_path : Yojson.Safe.t list =
 
 (** Generate DocumentHighlight[] for annotations sharing goal/task context.
     Used by textDocument/documentHighlight. *)
-let document_highlights ~base_dir ~file_path ~line : Yojson.Safe.t list =
-  let matching = annotations_at_line ~base_dir ~file_path ~line in
+let document_highlights ~base_dir ~partition ~file_path ~line : Yojson.Safe.t list =
+  let matching = annotations_at_line ~base_dir ~partition ~file_path ~line in
   if matching = [] then []
   else
     let goal_ids = List.filter_map (fun (a : annotation) -> a.goal_id) matching in
     let task_ids = List.filter_map (fun (a : annotation) -> a.task_id) matching in
-    let all = Cache.get ~base_dir ~file_path in
+    let all = Cache.get ~base_dir ~partition ~file_path in
     let related = List.filter (fun (a : annotation) ->
       (match a.goal_id with Some g -> List.mem g goal_ids | None -> false)
       || (match a.task_id with Some t -> List.mem t task_ids | None -> false)

--- a/lib/server/lsp_overlay_provider.mli
+++ b/lib/server/lsp_overlay_provider.mli
@@ -2,65 +2,89 @@
 
     Public interface for [Lsp_overlay_provider]. Internal JSON construction
     helpers ([codelens_to_json], [inlay_hint_to_json]) are intentionally
-    not exposed. *)
+    not exposed.
 
-val codelenses : base_dir:string -> file_path:string -> Yojson.Safe.t list
+    [partition] names the [.masc-ide/] store being read and is explicit on
+    every entry point: annotations live in per-codebase partitions, so a
+    reader that does not name one addresses the wrong rows. [None] means the
+    caller addresses no store — an LSP connection opened without an IDE
+    scope — and yields the empty overlay. It is never coerced to a default
+    partition.
+
+    [base_dir] is the directory that holds [.masc-ide/]. [document_root] is
+    the absolute root a stored annotation's relative [file_path] hangs off,
+    which is the workspace tree the reader opened — a different directory.
+    Only the entry points that return LSP [Location]s need it. *)
+
+val codelenses : base_dir:string -> partition:Ide_paths.partition option -> file_path:string -> Yojson.Safe.t list
 (** Generate LSP CodeLens entries for a file from MASC annotations. *)
 
-val inlay_hints : base_dir:string -> file_path:string -> Yojson.Safe.t list
+val inlay_hints : base_dir:string -> partition:Ide_paths.partition option -> file_path:string -> Yojson.Safe.t list
 (** Generate LSP InlayHint entries for annotations with route-context bindings. *)
 
 val diagnostics :
   base_dir:string ->
+  partition:Ide_paths.partition option ->
   file_path:string ->
   lsp_diagnostics:Yojson.Safe.t list ->
   Yojson.Safe.t list
 (** Merge MASC annotation diagnostics with LSP server diagnostics. *)
 
-val invalidate_cache : base_dir:string -> file_path:string -> unit
+val invalidate_cache : base_dir:string -> partition:Ide_paths.partition option -> file_path:string -> unit
 (** Remove cached annotations for a specific file. Call on didSave. *)
 
 val clear_cache : unit -> unit
 (** Remove all cached annotations. *)
 
 val enrich_hover :
-  base_dir:string -> file_path:string -> line:int -> Yojson.Safe.t -> Yojson.Safe.t
+  base_dir:string -> partition:Ide_paths.partition option -> file_path:string -> line:int -> Yojson.Safe.t -> Yojson.Safe.t
 (** Append MASC annotation context to an LSP Hover response.
     Handles all Hover.contents forms: MarkupContent, MarkedString, MarkedString[].
     Returns the original response unchanged if no annotations overlap. *)
 
-val has_annotations_at_line : base_dir:string -> file_path:string -> line:int -> bool
+val has_annotations_at_line : base_dir:string -> partition:Ide_paths.partition option -> file_path:string -> line:int -> bool
 (** Check if any MASC annotations overlap the given LSP position (0-based line). *)
 
-val definition_links : base_dir:string -> file_path:string -> line:int -> Yojson.Safe.t list
+val definition_links :
+  base_dir:string ->
+  partition:Ide_paths.partition option ->
+  document_root:string ->
+  file_path:string ->
+  line:int ->
+  Yojson.Safe.t list
 (** Generate LSP Location links for annotations overlapping [line].
     Used by textDocument/definition. *)
 
 val reference_locations :
-  base_dir:string -> file_path:string -> line:int -> include_declaration:bool ->
+  base_dir:string ->
+  partition:Ide_paths.partition option ->
+  document_root:string ->
+  file_path:string ->
+  line:int ->
+  include_declaration:bool ->
   Yojson.Safe.t list
 (** Generate LSP Location[] for annotations related to those at [line].
     Finds annotations sharing the same goal_id or task_id.
     Used by textDocument/references. *)
 
-val completion_items : base_dir:string -> file_path:string -> line:int -> Yojson.Safe.t list
+val completion_items : base_dir:string -> partition:Ide_paths.partition option -> file_path:string -> line:int -> Yojson.Safe.t list
 (** Generate CompletionItem[] for MASC annotation snippets.
     Used by textDocument/completion. *)
 
 val code_actions :
-  base_dir:string -> file_path:string -> line:int -> diagnostics:Yojson.Safe.t list ->
+  base_dir:string -> partition:Ide_paths.partition option -> file_path:string -> line:int -> diagnostics:Yojson.Safe.t list ->
   Yojson.Safe.t list
 (** Generate CodeAction[] for annotation operations.
     Used by textDocument/codeAction. *)
 
-val document_symbols : base_dir:string -> file_path:string -> Yojson.Safe.t list
+val document_symbols : base_dir:string -> partition:Ide_paths.partition option -> file_path:string -> Yojson.Safe.t list
 (** Generate SymbolInformation[] for MASC annotations.
     Used by textDocument/documentSymbol. *)
 
-val folding_ranges : base_dir:string -> file_path:string -> Yojson.Safe.t list
+val folding_ranges : base_dir:string -> partition:Ide_paths.partition option -> file_path:string -> Yojson.Safe.t list
 (** Generate FoldingRange[] for consecutive annotation blocks.
     Used by textDocument/foldingRange. *)
 
-val document_highlights : base_dir:string -> file_path:string -> line:int -> Yojson.Safe.t list
+val document_highlights : base_dir:string -> partition:Ide_paths.partition option -> file_path:string -> line:int -> Yojson.Safe.t list
 (** Generate DocumentHighlight[] for annotations sharing goal/task context.
     Used by textDocument/documentHighlight. *)

--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -11,12 +11,16 @@ module Http = Http_server_eio
 let base_path_of_state state = (Mcp_server.workspace_config state).base_path
 let extract_path_param = Server_utils.extract_path_param
 
-type ide_error =
+(* The scope vocabulary is shared with the LSP proxy; both surfaces resolve
+   through [Server_ide_scope] so a reader cannot address one partition here
+   and a different one there. Equality re-declaration keeps this module's
+   existing field access on [ide_error] unchanged. *)
+type ide_error = Server_ide_scope.ide_error =
   { code : string
   ; message : string
   }
 
-let ide_error code message = { code; message }
+let ide_error = Server_ide_scope.ide_error
 
 let json_error ?code message =
   let fields = [ "ok", `Bool false; "error", `String message ] in
@@ -36,15 +40,9 @@ let respond_ide_error ~status ~request err reqd =
     reqd
 ;;
 
-let nonempty_query_param uri key =
-  match Uri.get_query_param uri key with
-  | Some raw ->
-    let value = String.trim raw in
-    if String.equal value "" then None else Some value
-  | None -> None
-;;
+let nonempty_query_param = Server_ide_scope.nonempty_query_param
 
-type ide_scope =
+type ide_scope = Server_ide_scope.ide_scope =
   | Scope_canonical_url of
       { raw : string
       ; slug : string
@@ -55,61 +53,8 @@ type ide_scope =
       }
   | Scope_keeper_lane of { keeper_id : string }
 
-(* Keeper-lane reads address the repo-unattributed observation bucket
-   ([_orphan/] on disk). A keeper turn is a keeper-timeline fact, not a
-   repo fact: turn events and coordination tool events carry no file, so
-   they are written without a [By_url] partition. Before this scope
-   existed, read routes could only address [By_url] partitions, which made
-   that data unreachable from any API while it kept accumulating — the
-   read/write split-brain from the 2026-07-07 IDE observation audit. *)
-let partition_of_ide_scope = function
-  | Scope_canonical_url { slug; _ } | Scope_repo_id { slug; _ } ->
-    Ide_paths.By_url slug
-  | Scope_keeper_lane _ -> Ide_paths.Legacy_default
-;;
-
-let resolve_ide_scope_for_query ~state ~uri =
-  let project_base = base_path_of_state state in
-  match
-    ( nonempty_query_param uri "canonical_url"
-    , nonempty_query_param uri "repo_id"
-    , nonempty_query_param uri "keeper_lane" )
-  with
-  | None, None, None ->
-    Error
-      (ide_error
-         "missing_ide_scope"
-         "IDE scope is required; pass repo_id, canonical_url, or keeper_lane")
-  | Some _, Some _, _ | Some _, _, Some _ | _, Some _, Some _ ->
-    Error
-      (ide_error
-         "conflicting_ide_scope"
-         "IDE scope must specify exactly one of repo_id, canonical_url, or keeper_lane")
-  | Some raw, None, None ->
-    (match Ide_paths.canonical_url_of_remote raw with
-     | Some slug -> Ok (Scope_canonical_url { raw; slug })
-     | None -> Error (ide_error "invalid_canonical_url" "canonical_url is invalid"))
-  | None, Some repo_id, None ->
-    (match Repo_store.find_url_by_id ~base_path:project_base repo_id with
-     | Error message ->
-       Error (ide_error "repository_catalog_unavailable" message)
-     | Ok None -> Error (ide_error "unmatched_repo_id" "repo_id does not match a configured repository")
-     | Ok (Some url) ->
-       (match Ide_paths.canonical_url_of_remote url with
-        | Some slug -> Ok (Scope_repo_id { repo_id; slug })
-        | None ->
-          Error
-            (ide_error
-               "no_canonical_url"
-               "repo_id has no valid canonical URL")))
-  | None, None, Some keeper_id ->
-    (* [keeper_id] is a filter value compared against stored event fields,
-       never a filesystem path, so no registry lookup gates it: validating
-       against currently-active keepers would hide the history of any
-       keeper that is offline or renamed. An unknown id returns an
-       explicitly keeper_lane-scoped empty result. *)
-    Ok (Scope_keeper_lane { keeper_id })
-;;
+let partition_of_ide_scope = Server_ide_scope.partition_of_ide_scope
+let resolve_ide_scope_for_query = Server_ide_scope.resolve_ide_scope_for_query
 
 (* Mutations stay repo-scoped: an observation write without repo identity
    is exactly the orphan-bucket growth the keeper-lane read scope exists

--- a/lib/server/server_ide_lsp_proxy.ml
+++ b/lib/server/server_ide_lsp_proxy.ml
@@ -214,6 +214,11 @@ type conn_state =
   ; wsd : Ws_wsd.t
   ; base_path : string
   ; proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t
+  ; store_scope : Server_ide_scope.ide_scope option
+        (* The IDE observation scope declared on this connection's URL, in
+           the same vocabulary the REST routes use. [None] = the client
+           declared none, so this connection addresses no annotation store
+           and gets language-server passthrough only. *)
   ; workspace_root : string ref
   ; send_queue : ws_send_msg Eio.Stream.t
   ; dispatch_queue : inbound_dispatch_msg Eio.Stream.t
@@ -225,6 +230,45 @@ type conn_state =
   }
 
 let base_path_of_state state = (Mcp_server.workspace_config state).base_path
+
+(* The [.masc-ide/] partition this connection addresses. Threaded into every
+   overlay read so the reader cannot land in a partition the client never
+   named — the defect that had overlay reads served from [_orphan/] while
+   keeper writes accumulated under [by-url/<slug>/]. *)
+let overlay_partition cs =
+  Option.map Server_ide_scope.partition_of_ide_scope cs.store_scope
+;;
+
+(* What this connection addresses, read from its URL before the socket is
+   upgraded. Two things are needed and they must agree: the store partition,
+   and the workspace tree document paths are relative to. [repo_id] and
+   [keeper_lane] (+[keeper]) resolve both through the same resolvers the REST
+   IDE routes use, so the two surfaces share one vocabulary. A bare
+   [canonical_url] names a partition but no tree: its documents would be
+   keyed against the project base while their rows are stored against a repo
+   root, which is the mismatch this addressing exists to prevent, so it is
+   refused rather than served as silently empty overlays. *)
+let lsp_connection_addressing ~state ~uri =
+  match Server_ide_scope.resolve_optional_ide_scope_for_query ~state ~uri with
+  | Error err -> Error err
+  | Ok (Some (Server_ide_scope.Scope_canonical_url _)) ->
+    Error
+      (Server_ide_scope.ide_error
+         "unanchored_ide_scope"
+         "LSP connections must scope by repo_id or keeper_lane: canonical_url           names a partition but not a workspace tree")
+  | Ok ((Some (Server_ide_scope.Scope_repo_id _ | Server_ide_scope.Scope_keeper_lane _) | None) as scope)
+    ->
+    let anchor, _source =
+      Server_routes_http_routes_workspace.resolve_workspace_base ~state ~uri
+    in
+    Ok (scope, anchor)
+;;
+
+(* A stored annotation's [file_path] is relative to the workspace tree the
+   client opened, which is also the anchor its document URIs resolve
+   against — not the directory that holds the store. *)
+let document_root cs = !(cs.workspace_root)
+;;
 
 let find_process cs lang_id =
   Eio.Mutex.use_ro cs.process_mutex (fun () -> Hashtbl.find_opt cs.processes lang_id)
@@ -586,8 +630,16 @@ let initialize_capabilities_json () =
     ]
 ;;
 
-let initialize_result_json () =
-  `Assoc [ "capabilities", initialize_capabilities_json () ]
+(* [workspaceRoot] is a MASC extension on the initialize result. Without it
+   a browser client has no way to name a document: it knows the path it
+   browsed (repo-relative) but not the host tree that path hangs off, so it
+   cannot form the absolute [file:] URI the protocol requires. Advertising
+   the resolved root closes that gap without inventing a URI convention. *)
+let initialize_result_json ~workspace_root () =
+  `Assoc
+    [ "capabilities", initialize_capabilities_json ()
+    ; "masc", `Assoc [ "workspaceRoot", `String workspace_root ]
+    ]
 ;;
 
 (** Extract client request ID from JSON-RPC message fields. *)
@@ -611,11 +663,11 @@ let extract_line params =
   | _ -> None
 ;;
 
-let resolve_document_request ~base params =
+let resolve_document_request ~anchor params =
   match extract_uri params with
   | None -> Error Missing_document_uri
   | Some uri ->
-    (match resolve_relative ~base uri with
+    (match resolve_relative ~base:anchor uri with
      | None -> Error Document_uri_outside_workspace
      | Some relative_path ->
        let line =
@@ -739,13 +791,14 @@ let forward_notification cs lang_id method_ params =
 
 let forward_document_sync_notification cs method_ params =
   let wire_method = lsp_method_to_string method_ in
-  match resolve_document_request ~base:cs.base_path params with
+  match resolve_document_request ~anchor:(document_root cs) params with
   | Error _ -> ()
   | Ok request ->
     if method_ = Did_save
     then
       Lsp_overlay_provider.invalidate_cache
         ~base_dir:cs.base_path
+        ~partition:(overlay_partition cs)
         ~file_path:request.relative_path;
     (match request.language with
      | Unknown_lang -> ()
@@ -806,12 +859,12 @@ let classify_forwarded_method method_ =
 
 (** Handle textDocument/codeLens — merge LSP response with MASC overlays. *)
 let handle_codelens cs params id =
-  match resolve_document_request ~base:cs.base_path params with
+  match resolve_document_request ~anchor:(document_root cs) params with
   | Error _ -> send_response cs id (`List [])
   | Ok request ->
     let base = cs.base_path in
     let relative = request.relative_path in
-    let masc = Lsp_overlay_provider.codelenses ~base_dir:base ~file_path:relative in
+    let masc = Lsp_overlay_provider.codelenses ~base_dir:base ~partition:(overlay_partition cs) ~file_path:relative in
     (match request.language with
      | Unknown_lang -> send_response cs id (`List masc)
      | Known_lang lang_id ->
@@ -836,12 +889,12 @@ let handle_codelens cs params id =
 
 (** Handle textDocument/inlayHint — merge LSP response with MASC overlays. *)
 let handle_inlay_hint cs params id =
-  match resolve_document_request ~base:cs.base_path params with
+  match resolve_document_request ~anchor:(document_root cs) params with
   | Error _ -> send_response cs id (`List [])
   | Ok request ->
     let base = cs.base_path in
     let relative = request.relative_path in
-    let masc = Lsp_overlay_provider.inlay_hints ~base_dir:base ~file_path:relative in
+    let masc = Lsp_overlay_provider.inlay_hints ~base_dir:base ~partition:(overlay_partition cs) ~file_path:relative in
     (match request.language with
      | Unknown_lang -> send_response cs id (`List masc)
      | Known_lang lang_id ->
@@ -866,7 +919,7 @@ let handle_inlay_hint cs params id =
 
 (** Handle textDocument/diagnostic — merge LSP response with MASC diagnostics. *)
 let handle_diagnostic cs params id =
-  match resolve_document_request ~base:cs.base_path params with
+  match resolve_document_request ~anchor:(document_root cs) params with
   | Error _ -> send_response cs id (`Assoc [ "items", `List [] ])
   | Ok request ->
     let base = cs.base_path in
@@ -876,6 +929,7 @@ let handle_diagnostic cs params id =
       let diags =
         Lsp_overlay_provider.diagnostics
           ~base_dir:base
+          ~partition:(overlay_partition cs)
           ~file_path:relative
           ~lsp_diagnostics:[]
       in
@@ -887,6 +941,7 @@ let handle_diagnostic cs params id =
         let diags =
           Lsp_overlay_provider.diagnostics
             ~base_dir:base
+            ~partition:(overlay_partition cs)
             ~file_path:relative
             ~lsp_diagnostics:[]
         in
@@ -910,6 +965,7 @@ let handle_diagnostic cs params id =
            let merged =
              Lsp_overlay_provider.diagnostics
                ~base_dir:base
+               ~partition:(overlay_partition cs)
                ~file_path:relative
                ~lsp_diagnostics:existing
            in
@@ -920,7 +976,7 @@ let handle_diagnostic cs params id =
 
 (** Handle textDocument/hover — enrich LSP response with MASC annotations. *)
 let handle_hover cs params id =
-  match resolve_document_request ~base:cs.base_path params with
+  match resolve_document_request ~anchor:(document_root cs) params with
   | Error _ -> send_response cs id `Null
   | Ok request ->
     let base = cs.base_path in
@@ -931,11 +987,13 @@ let handle_hover cs params id =
        | Some line
          when Lsp_overlay_provider.has_annotations_at_line
                 ~base_dir:base
+                ~partition:(overlay_partition cs)
                 ~file_path:relative
                 ~line ->
          let enriched =
            Lsp_overlay_provider.enrich_hover
              ~base_dir:base
+             ~partition:(overlay_partition cs)
              ~file_path:relative
              ~line
              (`Assoc
@@ -957,11 +1015,13 @@ let handle_hover cs params id =
          | Some line
            when Lsp_overlay_provider.has_annotations_at_line
                   ~base_dir:base
+                  ~partition:(overlay_partition cs)
                   ~file_path:relative
                   ~line ->
            send_response cs id
              (Lsp_overlay_provider.enrich_hover
                 ~base_dir:base
+                ~partition:(overlay_partition cs)
                 ~file_path:relative
                 ~line
                 (`Assoc
@@ -986,6 +1046,7 @@ let handle_hover cs params id =
               send_response cs id
                 (Lsp_overlay_provider.enrich_hover
                    ~base_dir:base
+                   ~partition:(overlay_partition cs)
                    ~file_path:relative
                    ~line
                    result)
@@ -995,7 +1056,7 @@ let handle_hover cs params id =
 
 (** Handle textDocument/definition — merge LSP response with MASC annotation links. *)
 let handle_definition cs params id =
-  match resolve_document_request ~base:cs.base_path params with
+  match resolve_document_request ~anchor:(document_root cs) params with
   | Error _ -> send_response cs id (`List [])
   | Ok request ->
     let base = cs.base_path in
@@ -1003,7 +1064,7 @@ let handle_definition cs params id =
     let masc =
       match request.line with
       | Some line ->
-        Lsp_overlay_provider.definition_links ~base_dir:base ~file_path:relative ~line
+        Lsp_overlay_provider.definition_links ~base_dir:base ~partition:(overlay_partition cs) ~document_root:(document_root cs) ~file_path:relative ~line
       | None -> []
     in
     (match request.language with
@@ -1028,7 +1089,7 @@ let handle_definition cs params id =
 
 (** Handle textDocument/references — merge LSP response with MASC annotation locations. *)
 let handle_references cs params id =
-  match resolve_document_request ~base:cs.base_path params with
+  match resolve_document_request ~anchor:(document_root cs) params with
   | Error _ -> send_response cs id (`List [])
   | Ok request ->
     let base = cs.base_path in
@@ -1037,7 +1098,7 @@ let handle_references cs params id =
       match request.line with
       | Some line ->
         Lsp_overlay_provider.reference_locations
-          ~base_dir:base ~file_path:relative ~line ~include_declaration:true
+          ~base_dir:base ~partition:(overlay_partition cs) ~document_root:(document_root cs) ~file_path:relative ~line ~include_declaration:true
       | None -> []
     in
     (match request.language with
@@ -1062,7 +1123,7 @@ let handle_references cs params id =
 
 (** Handle textDocument/completion — merge LSP response with MASC annotation snippets. *)
 let handle_completion cs params id =
-  match resolve_document_request ~base:cs.base_path params with
+  match resolve_document_request ~anchor:(document_root cs) params with
   | Error _ -> send_response cs id (`List [])
   | Ok request ->
     let base = cs.base_path in
@@ -1070,7 +1131,7 @@ let handle_completion cs params id =
     let masc =
       match request.line with
       | Some line ->
-        Lsp_overlay_provider.completion_items ~base_dir:base ~file_path:relative ~line
+        Lsp_overlay_provider.completion_items ~base_dir:base ~partition:(overlay_partition cs) ~file_path:relative ~line
       | None -> []
     in
     (match request.language with
@@ -1095,7 +1156,7 @@ let handle_completion cs params id =
 
 (** Handle textDocument/codeAction — inject MASC annotation actions. *)
 let handle_code_action cs params id =
-  match resolve_document_request ~base:cs.base_path params with
+  match resolve_document_request ~anchor:(document_root cs) params with
   | Error _ -> send_response cs id (`List [])
   | Ok request ->
     let base = cs.base_path in
@@ -1104,7 +1165,7 @@ let handle_code_action cs params id =
       match request.line with
       | Some line ->
         Lsp_overlay_provider.code_actions
-          ~base_dir:base ~file_path:relative ~line ~diagnostics:[]
+          ~base_dir:base ~partition:(overlay_partition cs) ~file_path:relative ~line ~diagnostics:[]
       | None -> []
     in
     (match request.language with
@@ -1129,12 +1190,12 @@ let handle_code_action cs params id =
 
 (** Handle textDocument/documentSymbol — inject MASC annotation symbols. *)
 let handle_document_symbol cs params id =
-  match resolve_document_request ~base:cs.base_path params with
+  match resolve_document_request ~anchor:(document_root cs) params with
   | Error _ -> send_response cs id (`List [])
   | Ok request ->
     let base = cs.base_path in
     let relative = request.relative_path in
-    let masc = Lsp_overlay_provider.document_symbols ~base_dir:base ~file_path:relative in
+    let masc = Lsp_overlay_provider.document_symbols ~base_dir:base ~partition:(overlay_partition cs) ~file_path:relative in
     (match request.language with
      | Unknown_lang -> send_response cs id (`List masc)
      | Known_lang lang_id ->
@@ -1157,12 +1218,12 @@ let handle_document_symbol cs params id =
 
 (** Handle textDocument/foldingRange — inject MASC annotation folding ranges. *)
 let handle_folding_range cs params id =
-  match resolve_document_request ~base:cs.base_path params with
+  match resolve_document_request ~anchor:(document_root cs) params with
   | Error _ -> send_response cs id (`List [])
   | Ok request ->
     let base = cs.base_path in
     let relative = request.relative_path in
-    let masc = Lsp_overlay_provider.folding_ranges ~base_dir:base ~file_path:relative in
+    let masc = Lsp_overlay_provider.folding_ranges ~base_dir:base ~partition:(overlay_partition cs) ~file_path:relative in
     (match request.language with
      | Unknown_lang -> send_response cs id (`List masc)
      | Known_lang lang_id ->
@@ -1185,7 +1246,7 @@ let handle_folding_range cs params id =
 
 (** Handle textDocument/documentHighlight — highlight related MASC annotations. *)
 let handle_document_highlight cs params id =
-  match resolve_document_request ~base:cs.base_path params with
+  match resolve_document_request ~anchor:(document_root cs) params with
   | Error _ -> send_response cs id (`List [])
   | Ok request ->
     let base = cs.base_path in
@@ -1193,7 +1254,7 @@ let handle_document_highlight cs params id =
     let masc =
       match request.line with
       | Some line ->
-        Lsp_overlay_provider.document_highlights ~base_dir:base ~file_path:relative ~line
+        Lsp_overlay_provider.document_highlights ~base_dir:base ~partition:(overlay_partition cs) ~file_path:relative ~line
       | None -> []
     in
     (match request.language with
@@ -1245,9 +1306,19 @@ let dispatch_message cs msg =
                  | _ -> cs.base_path)
               | _ -> cs.base_path
             in
-            let root = workspace_root_for_initialize ~base_path:cs.base_path root_uri in
-            cs.workspace_root := root;
-            send_response cs n (initialize_result_json ())
+            (* A scope declared on the connection URL is authoritative: it
+               already fixed both the partition and the tree document paths
+               are relative to. Letting [rootUri] move the anchor afterwards
+               would decouple the two again, which is how document keys came
+               to be expressed against one root and stored against another.
+               Without a declared scope the client's [rootUri] still decides,
+               as before. *)
+            (match cs.store_scope with
+             | Some _ -> ()
+             | None ->
+               cs.workspace_root
+               := workspace_root_for_initialize ~base_path:cs.base_path root_uri);
+            send_response cs n (initialize_result_json ~workspace_root:!(cs.workspace_root) ())
           | Some Initialized, _ -> ()
           | Some Shutdown, Some n -> send_response cs n `Null
           | Some Exit, _ -> disconnect cs
@@ -1292,7 +1363,7 @@ let dispatch_message cs msg =
                     Mcp_error_code.(to_wire_code Method_not_found)
                     ("Read-only LSP proxy: unknown method not permitted: " ^ unknown)
                 | Forward_read_only ->
-                  (match resolve_document_request ~base:cs.base_path params with
+                  (match resolve_document_request ~anchor:(document_root cs) params with
                    | Error Missing_document_uri ->
                      send_error cs n
                        Mcp_error_code.(to_wire_code Method_not_found)
@@ -1365,6 +1436,19 @@ let add_routes ~sw ~clock router =
                | None ->
                  Log.Server.warn "LSP WebSocket: no proc_mgr available"
                | Some proc_mgr ->
+                 let uri = Uri.of_string request.Httpun.Request.target in
+                 (match lsp_connection_addressing ~state ~uri with
+                  | Error err ->
+                    Http.Response.json_value
+                      ~status:`Bad_request
+                      ~request
+                      (`Assoc
+                         [ "ok", `Bool false
+                         ; "error", `String err.Server_ide_scope.message
+                         ; "code", `String err.Server_ide_scope.code
+                         ])
+                      reqd
+                  | Ok (store_scope, workspace_base) ->
                  (* RFC-0281: drive the upgraded connection via the shared
                     attachment SSOT.  The previous code built [ws_conn] and
                     [ignore]d it (never calling Gluten [upgrade]), so frames
@@ -1396,7 +1480,8 @@ let add_routes ~sw ~clock router =
                           ; wsd
                           ; base_path = base_path_of_state state
                           ; proc_mgr
-                          ; workspace_root = ref (base_path_of_state state)
+                          ; store_scope
+                          ; workspace_root = ref workspace_base
                           ; send_queue =
                               Eio.Stream.create
                                 Lsp_proxy_limits.outbound_send_queue_capacity
@@ -1425,7 +1510,7 @@ let add_routes ~sw ~clock router =
                           ())
                   with
                   | Ok () -> ()
-                  | Error e -> Log.Server.warn "WebSocket upgrade failed: %s" e)))
+                  | Error e -> Log.Server.warn "WebSocket upgrade failed: %s" e))))
            request
            reqd)
       router

--- a/lib/server/server_ide_lsp_proxy.mli
+++ b/lib/server/server_ide_lsp_proxy.mli
@@ -11,7 +11,7 @@ val add_routes :
 module For_testing : sig
   val resolve_relative : base:string -> string -> string option
   val workspace_root_for_initialize : base_path:string -> string -> string
-  val initialize_result_json : unit -> Yojson.Safe.t
+  val initialize_result_json : workspace_root:string -> unit -> Yojson.Safe.t
   (** Fixed size of the inbound LSP dispatch worker pool
       ([Lsp_proxy_limits.inbound_dispatch_worker_count]); >1 keeps slow LSP
       init off the socket read path. *)
@@ -42,7 +42,7 @@ module For_testing : sig
       typed errors rather than becoming [""] paths, and malformed/negative
       positions stay [None] rather than [-1]. *)
   val resolve_document_request :
-    base:string ->
+    anchor:string ->
     Yojson.Safe.t ->
     (resolved_document_request, document_request_error) result
 

--- a/lib/server/server_ide_scope.ml
+++ b/lib/server/server_ide_scope.ml
@@ -1,0 +1,95 @@
+(** IDE observation scope — see [server_ide_scope.mli]. *)
+
+type ide_error =
+  { code : string
+  ; message : string
+  }
+
+let ide_error code message = { code; message }
+
+let nonempty_query_param uri key =
+  match Uri.get_query_param uri key with
+  | Some raw ->
+    let value = String.trim raw in
+    if String.equal value "" then None else Some value
+  | None -> None
+;;
+
+type ide_scope =
+  | Scope_canonical_url of
+      { raw : string
+      ; slug : string
+      }
+  | Scope_repo_id of
+      { repo_id : string
+      ; slug : string
+      }
+  | Scope_keeper_lane of { keeper_id : string }
+
+(* Keeper-lane reads address the repo-unattributed observation bucket
+   ([_orphan/] on disk). A keeper turn is a keeper-timeline fact, not a
+   repo fact: turn events and coordination tool events carry no file, so
+   they are written without a [By_url] partition. Before this scope
+   existed, read routes could only address [By_url] partitions, which made
+   that data unreachable from any API while it kept accumulating — the
+   read/write split-brain from the 2026-07-07 IDE observation audit. *)
+let partition_of_ide_scope = function
+  | Scope_canonical_url { slug; _ } | Scope_repo_id { slug; _ } ->
+    Ide_paths.By_url slug
+  | Scope_keeper_lane _ -> Ide_paths.Legacy_default
+;;
+
+let base_path_of_state state = (Mcp_server.workspace_config state).base_path
+
+(* One shape for the three declared scopes, so both the absent-scope and
+   present-scope resolvers below classify identically. *)
+let scope_params uri =
+  ( nonempty_query_param uri "canonical_url"
+  , nonempty_query_param uri "repo_id"
+  , nonempty_query_param uri "keeper_lane" )
+;;
+
+let resolve_declared_scope ~state ~params =
+  match params with
+  | Some raw, None, None ->
+    (match Ide_paths.canonical_url_of_remote raw with
+     | Some slug -> Ok (Scope_canonical_url { raw; slug })
+     | None -> Error (ide_error "invalid_canonical_url" "canonical_url is invalid"))
+  | None, Some repo_id, None ->
+    (match Repo_store.find_url_by_id ~base_path:(base_path_of_state state) repo_id with
+     | Error message -> Error (ide_error "repository_catalog_unavailable" message)
+     | Ok None ->
+       Error
+         (ide_error "unmatched_repo_id" "repo_id does not match a configured repository")
+     | Ok (Some url) ->
+       (match Ide_paths.canonical_url_of_remote url with
+        | Some slug -> Ok (Scope_repo_id { repo_id; slug })
+        | None -> Error (ide_error "no_canonical_url" "repo_id has no valid canonical URL")))
+  | None, None, Some keeper_id ->
+    (* [keeper_id] is a filter value compared against stored event fields,
+       never a filesystem path, so no registry lookup gates it: validating
+       against currently-active keepers would hide the history of any
+       keeper that is offline or renamed. An unknown id returns an
+       explicitly keeper_lane-scoped empty result. *)
+    Ok (Scope_keeper_lane { keeper_id })
+  | Some _, Some _, _ | Some _, _, Some _ | _, Some _, Some _ ->
+    Error
+      (ide_error
+         "conflicting_ide_scope"
+         "IDE scope must specify exactly one of repo_id, canonical_url, or keeper_lane")
+  | None, None, None ->
+    Error
+      (ide_error
+         "missing_ide_scope"
+         "IDE scope is required; pass repo_id, canonical_url, or keeper_lane")
+;;
+
+let resolve_ide_scope_for_query ~state ~uri =
+  resolve_declared_scope ~state ~params:(scope_params uri)
+;;
+
+let resolve_optional_ide_scope_for_query ~state ~uri =
+  match scope_params uri with
+  | None, None, None -> Ok None
+  | params -> Result.map Option.some (resolve_declared_scope ~state ~params)
+;;

--- a/lib/server/server_ide_scope.mli
+++ b/lib/server/server_ide_scope.mli
@@ -1,0 +1,56 @@
+(** IDE observation scope — the addressing vocabulary shared by every IDE
+    read surface.
+
+    A [.masc-ide/] store is partitioned, so any reader has to say which
+    partition it is addressing before it can name a document. The REST
+    routes take that decision from query parameters; the LSP proxy takes it
+    from the same parameters on its WebSocket URL. Both resolve through this
+    module so the two surfaces cannot drift into separate vocabularies —
+    the drift that left the LSP overlay reading [_orphan/] while keeper
+    writes landed in [by-url/<slug>/]. *)
+
+type ide_error =
+  { code : string
+  ; message : string
+  }
+
+val ide_error : string -> string -> ide_error
+
+val nonempty_query_param : Uri.t -> string -> string option
+(** Query parameter with surrounding whitespace trimmed, [None] when absent
+    or blank. A blank scope parameter is an absent one, never a match. *)
+
+type ide_scope =
+  | Scope_canonical_url of
+      { raw : string
+      ; slug : string
+      }
+  | Scope_repo_id of
+      { repo_id : string
+      ; slug : string
+      }
+  | Scope_keeper_lane of { keeper_id : string }
+
+val partition_of_ide_scope : ide_scope -> Ide_paths.partition
+(** The store partition the scope addresses. *)
+
+val resolve_ide_scope_for_query
+  :  state:Mcp_server.server_state
+  -> uri:Uri.t
+  -> (ide_scope, ide_error) result
+(** Resolve exactly one of [canonical_url] / [repo_id] / [keeper_lane] from
+    [uri]. Absent, conflicting, and unresolvable scopes are all typed
+    errors: there is no default scope, because guessing one is how a reader
+    silently addresses the wrong partition. *)
+
+val resolve_optional_ide_scope_for_query
+  :  state:Mcp_server.server_state
+  -> uri:Uri.t
+  -> (ide_scope option, ide_error) result
+(** Like {!resolve_ide_scope_for_query}, but a request that carries no scope
+    parameter at all resolves to [Ok None] instead of an error.
+
+    This exists for the LSP proxy, whose connection may legitimately want
+    only language-server passthrough and no MASC overlay. [Ok None] means
+    "this connection addresses no store"; it must not be collapsed into a
+    default partition. A malformed scope is still [Error]. *)

--- a/lib/server/server_routes_http_routes_workspace.mli
+++ b/lib/server/server_routes_http_routes_workspace.mli
@@ -2,6 +2,26 @@ module Http = Http_server_eio
 
 val add_routes : Http.Router.t -> Http.Router.t
 
+val resolve_workspace_base :
+  state:Mcp_server.server_state ->
+  uri:Uri.t ->
+  string
+  * [ `Project
+    | `Repository of string
+    | `RepositoryMissing of string
+    | `RepositoryUnknown of string
+    | `Playground of string
+    | `PlaygroundMissing of string
+    | `KeeperUnknown of string ]
+(** The absolute workspace tree a request's relative paths hang off, from
+    the [?repo_id=] / [?keeper=] query params, plus the source tag naming how
+    it was resolved.
+
+    This is the anchor for every repo-relative path the dashboard sends. The
+    IDE LSP proxy resolves its connection anchor through the same function so
+    a document named over the LSP socket and the same document named over
+    [/api/v1/workspace/file] cannot resolve against different roots. *)
+
 (** Pure dispatch logic for the [?keeper=<name>] query param. Exposed
     for unit testing — production code goes through {!add_routes}. *)
 val classify_keeper_query :

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -252,6 +252,7 @@ normal_targets=(
   @test/runtest-test_server_runtime_startup_maintenance
   @test/runtest-test_runtime_per_keeper_routing
   @test/runtest-test_ide_bridge
+  @test/runtest-test_ide_lsp_join_key
   @test/runtest-test_dashboard_workspace
   @test/runtest-test_host_fd_pressure_poller
   @test/runtest-test_keeper_turn_driver_failover

--- a/test/dune
+++ b/test/dune
@@ -188,6 +188,7 @@
   test_server_activity_http
   test_ide_paths
   test_ide_canonical_url_join
+  test_ide_lsp_join_key
   test_ide_partition_resolution
   test_ide_diagnostics
   test_keeper_runtime_contract
@@ -485,6 +486,7 @@
   test_server_activity_http
   test_ide_paths
   test_ide_canonical_url_join
+  test_ide_lsp_join_key
   test_ide_partition_resolution
   test_ide_diagnostics
   test_keeper_runtime_contract

--- a/test/test_ide_annotations.ml
+++ b/test/test_ide_annotations.ml
@@ -4,6 +4,12 @@ module Types = Ide_annotation_types
 module Store = Ide_annotations
 module Region = Ide_region_tracker
 module Lsp = Lsp_overlay_provider
+
+(* The overlay reader has to name the store it addresses. These cases write
+   through [Store.create]'s default partition, so they read that same one;
+   the by-URL producer/reader join is covered in
+   [test_ide_lsp_join_key.ml]. *)
+let legacy_partition = Some Ide_paths.Legacy_default
 let yojson = testable Yojson.Safe.pp Yojson.Safe.equal
 
 (* Ide_annotations.create generates ids via [Uuidm.v4_gen (Random.get_state ())].
@@ -175,7 +181,7 @@ let test_lsp_overlay_exposes_route_context () =
     | Ok _ ->
       Lsp.clear_cache ();
       let codelenses =
-        Lsp.codelenses ~base_dir ~file_path:"lib/keeper/keeper_tool_ide_runtime.ml"
+        Lsp.codelenses ~base_dir ~partition:legacy_partition ~file_path:"lib/keeper/keeper_tool_ide_runtime.ml"
       in
       (match codelenses with
        | [ codelens ] ->
@@ -184,7 +190,7 @@ let test_lsp_overlay_exposes_route_context () =
          check_contains "codelens carries evidence reference" "evidence:turn-9" title
        | rows -> failf "expected one codelens, got %d" (List.length rows));
       let inlay_hints =
-        Lsp.inlay_hints ~base_dir ~file_path:"lib/keeper/keeper_tool_ide_runtime.ml"
+        Lsp.inlay_hints ~base_dir ~partition:legacy_partition ~file_path:"lib/keeper/keeper_tool_ide_runtime.ml"
       in
       (match inlay_hints with
        | [ hint ] ->
@@ -197,6 +203,7 @@ let test_lsp_overlay_exposes_route_context () =
       let diagnostics =
         Lsp.diagnostics
           ~base_dir
+          ~partition:legacy_partition
           ~file_path:"lib/keeper/keeper_tool_ide_runtime.ml"
           ~lsp_diagnostics:[]
       in
@@ -208,6 +215,7 @@ let test_lsp_overlay_exposes_route_context () =
       let hover =
         Lsp.enrich_hover
           ~base_dir
+          ~partition:legacy_partition
           ~file_path:"lib/keeper/keeper_tool_ide_runtime.ml"
           ~line:11
           (`Assoc
@@ -526,7 +534,7 @@ let test_definition_links_at_line () =
     | Error msg -> fail msg
     | Ok _ ->
       Lsp.clear_cache ();
-      let links = Lsp.definition_links ~base_dir ~file_path:"lib/test.ml" ~line:10 in
+      let links = Lsp.definition_links ~base_dir ~partition:legacy_partition ~document_root:base_dir ~file_path:"lib/test.ml" ~line:10 in
       (match links with
        | [ link ] ->
          let uri = Option.value ~default:"" (string_field "uri" link) in
@@ -538,7 +546,7 @@ let test_definition_links_empty () =
   Eio_main.run (fun _env ->
     with_temp_dir (fun base_dir ->
     Lsp.clear_cache ();
-    let links = Lsp.definition_links ~base_dir ~file_path:"lib/empty.ml" ~line:5 in
+    let links = Lsp.definition_links ~base_dir ~partition:legacy_partition ~document_root:base_dir ~file_path:"lib/empty.ml" ~line:5 in
     check int "empty links" 0 (List.length links)))
 ;;
 
@@ -576,7 +584,7 @@ let test_reference_locations_related () =
          Lsp.clear_cache ();
          let refs =
            Lsp.reference_locations
-             ~base_dir ~file_path:"lib/a.ml" ~line:4 ~include_declaration:true
+             ~base_dir ~partition:legacy_partition ~document_root:base_dir ~file_path:"lib/a.ml" ~line:4 ~include_declaration:true
          in
          check int "two related refs" 2 (List.length refs))))
 ;;
@@ -585,7 +593,7 @@ let test_completion_items_kinds () =
   Eio_main.run (fun _env ->
     with_temp_dir (fun base_dir ->
     Lsp.clear_cache ();
-    let items = Lsp.completion_items ~base_dir ~file_path:"lib/test.ml" ~line:0 in
+    let items = Lsp.completion_items ~base_dir ~partition:legacy_partition ~file_path:"lib/test.ml" ~line:0 in
     check int "four completion items" 4 (List.length items);
     let labels = List.filter_map (string_field "label") items in
     check_contains "has masc:comment" "masc:comment" (String.concat "," labels);
@@ -596,7 +604,7 @@ let test_code_actions_create () =
   Eio_main.run (fun _env ->
     with_temp_dir (fun base_dir ->
     Lsp.clear_cache ();
-    let actions = Lsp.code_actions ~base_dir ~file_path:"lib/test.ml" ~line:5 ~diagnostics:[] in
+    let actions = Lsp.code_actions ~base_dir ~partition:legacy_partition ~file_path:"lib/test.ml" ~line:5 ~diagnostics:[] in
     check bool "has create action" true (List.length actions >= 1);
     let title = Option.value ~default:"" (string_field "title" (List.hd actions)) in
     check string "first action is create" "Create MASC Annotation" title))
@@ -619,7 +627,7 @@ let test_document_symbols_lists () =
     | Error msg -> fail msg
     | Ok _ ->
       Lsp.clear_cache ();
-      let syms = Lsp.document_symbols ~base_dir ~file_path:"lib/test.ml" in
+      let syms = Lsp.document_symbols ~base_dir ~partition:legacy_partition ~file_path:"lib/test.ml" in
       (match syms with
        | [ sym ] ->
          let name = Option.value ~default:"" (string_field "name" sym) in
@@ -658,7 +666,7 @@ let test_folding_ranges_groups () =
        | Error msg -> fail msg
        | Ok _ ->
          Lsp.clear_cache ();
-         let ranges = Lsp.folding_ranges ~base_dir ~file_path:"lib/test.ml" in
+         let ranges = Lsp.folding_ranges ~base_dir ~partition:legacy_partition ~file_path:"lib/test.ml" in
          (* folding_ranges groups consecutive annotations within 2 lines *)
          check bool "folding ranges is a list" true (List.length ranges >= 0))))
 ;;
@@ -696,7 +704,7 @@ let test_document_highlights_related () =
        | Ok _ ->
          Lsp.clear_cache ();
          let highlights =
-           Lsp.document_highlights ~base_dir ~file_path:"lib/test.ml" ~line:4
+           Lsp.document_highlights ~base_dir ~partition:legacy_partition ~file_path:"lib/test.ml" ~line:4
          in
          check int "two highlights" 2 (List.length highlights))))
 ;;

--- a/test/test_ide_lsp_join_key.ml
+++ b/test/test_ide_lsp_join_key.ml
@@ -1,0 +1,237 @@
+(** The join between a keeper's annotation write and the IDE's LSP read.
+
+    [test_ide_canonical_url_join.ml] pins the resolver that decides a write's
+    partition and repo-relative path. Nothing pinned that the LSP reader
+    addresses the partition the write landed in — so the reader read
+    [_orphan/] while keeper writes accumulated under [by-url/<slug>/], and
+    every overlay came back empty. These cases pin the reader's half of that
+    join. *)
+
+open Alcotest
+
+module Store = Ide_annotations
+module Types = Ide_annotation_types
+module Lsp = Lsp_overlay_provider
+
+let slug = "github.com_jeong-sik_masc"
+let repo_partition = Ide_paths.By_url slug
+let file_path = "lib/keeper/keeper_tool_ide_runtime.ml"
+
+(* The overlay cache is guarded by an [Eio.Mutex], so every case runs inside
+   an Eio context. *)
+let with_temp_dir f =
+  Eio_main.run (fun _env ->
+    let dir = Filename.temp_dir "masc-ide-join-" "" in
+    Fun.protect
+      ~finally:(fun () ->
+        (* Best effort: the store files live two levels down, and a leftover
+           temp dir must not fail the case. *)
+        ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir))))
+      (fun () -> f dir))
+;;
+
+let create_annotation ~base_dir ~partition ~keeper_id ~content ~line =
+  match
+    Store.create
+      ~base_dir
+      ~partition
+      ~keeper_id
+      ~file_path
+      ~line_start:line
+      ~line_end:line
+      ~kind:Types.Decision
+      ~content
+      ()
+  with
+  | Ok annotation -> annotation
+  | Error msg -> failf "annotation write failed: %s" msg
+;;
+
+let codelens_titles ~base_dir ~partition =
+  Lsp.codelenses ~base_dir ~partition ~file_path
+  |> List.filter_map (fun lens ->
+    match lens with
+    | `Assoc fields ->
+      (match List.assoc_opt "command" fields with
+       | Some (`Assoc command) ->
+         (match List.assoc_opt "title" command with
+          | Some (`String title) -> Some title
+          | _ -> None)
+       | _ -> None)
+    | _ -> None)
+;;
+
+(* The defect this file exists for: the write names a by-URL partition and the
+   read has to name the same one. A reader that omits the partition (the old
+   behaviour, which defaulted to [Legacy_default]) sees nothing. *)
+let test_by_url_write_is_read_under_its_partition () =
+  with_temp_dir (fun base_dir ->
+    Lsp.clear_cache ();
+    ignore
+      (create_annotation
+         ~base_dir
+         ~partition:repo_partition
+         ~keeper_id:"analyst"
+         ~content:"picked Eio.Mutex over Lazy here"
+         ~line:12);
+    check
+      (list string)
+      "the addressed partition yields the keeper's annotation"
+      [ "[Decision] picked Eio.Mutex over Lazy here" ]
+      (codelens_titles ~base_dir ~partition:(Some repo_partition));
+    check
+      (list string)
+      "the orphan partition does not"
+      []
+      (codelens_titles ~base_dir ~partition:(Some Ide_paths.Legacy_default))
+  )
+;;
+
+(* A reader that names no store must read as empty, not as some default
+   partition's rows: an LSP connection opened without an IDE scope has not
+   said which codebase it is looking at. *)
+let test_unaddressed_store_reads_empty () =
+  with_temp_dir (fun base_dir ->
+    Lsp.clear_cache ();
+    ignore
+      (create_annotation
+         ~base_dir
+         ~partition:Ide_paths.Legacy_default
+         ~keeper_id:"analyst"
+         ~content:"orphan lane row"
+         ~line:3);
+    check
+      (list string)
+      "no partition named, no rows served"
+      []
+      (codelens_titles ~base_dir ~partition:None)
+  )
+;;
+
+(* Two partitions hold the same repo-relative path. A cache keyed on
+   [base_dir + file_path] alone served one partition's rows for the other's
+   request. *)
+let test_partitions_do_not_share_cache_entries () =
+  with_temp_dir (fun base_dir ->
+    Lsp.clear_cache ();
+    ignore
+      (create_annotation
+         ~base_dir
+         ~partition:repo_partition
+         ~keeper_id:"analyst"
+         ~content:"by-url row"
+         ~line:5);
+    ignore
+      (create_annotation
+         ~base_dir
+         ~partition:Ide_paths.Legacy_default
+         ~keeper_id:"sangsu"
+         ~content:"orphan row"
+         ~line:5);
+    (* Read the by-URL partition first so its rows are the cached ones. *)
+    check
+      (list string)
+      "by-url partition serves its own row"
+      [ "[Decision] by-url row" ]
+      (codelens_titles ~base_dir ~partition:(Some repo_partition));
+    check
+      (list string)
+      "orphan partition is not served the by-url row"
+      [ "[Decision] orphan row" ]
+      (codelens_titles ~base_dir ~partition:(Some Ide_paths.Legacy_default))
+  )
+;;
+
+(* The client that reads this overlay is read-only, so [didSave] never fires
+   and the cache never got invalidated. An annotation a keeper writes after
+   the reader first touched the file has to become visible anyway. *)
+let test_write_after_first_read_becomes_visible () =
+  with_temp_dir (fun base_dir ->
+    Lsp.clear_cache ();
+    check
+      (list string)
+      "empty store reads empty"
+      []
+      (codelens_titles ~base_dir ~partition:(Some repo_partition));
+    ignore
+      (create_annotation
+         ~base_dir
+         ~partition:repo_partition
+         ~keeper_id:"analyst"
+         ~content:"written after the reader cached the empty store"
+         ~line:9);
+    check
+      (list string)
+      "the later write is visible without an explicit invalidation"
+      [ "[Decision] written after the reader cached the empty store" ]
+      (codelens_titles ~base_dir ~partition:(Some repo_partition))
+  )
+;;
+
+(* A [Location] URI has to point at the document in the tree the reader
+   opened. Building it from the directory that holds [.masc-ide] produced a
+   path under the store root, which no editor can open. *)
+let test_location_uri_uses_the_document_root () =
+  with_temp_dir (fun base_dir ->
+    Lsp.clear_cache ();
+    let document_root = Filename.concat base_dir "worktree" in
+    ignore
+      (create_annotation
+         ~base_dir
+         ~partition:repo_partition
+         ~keeper_id:"analyst"
+         ~content:"anchored"
+         ~line:4);
+    let uris =
+      Lsp.definition_links
+        ~base_dir
+        ~partition:(Some repo_partition)
+        ~document_root
+        ~file_path
+        ~line:3
+      |> List.filter_map (function
+        | `Assoc fields ->
+          (match List.assoc_opt "uri" fields with
+           | Some (`String uri) -> Some uri
+           | _ -> None)
+        | _ -> None)
+    in
+    check
+      (list string)
+      "location resolves under the opened tree, not under the store root"
+      [ "file://" ^ Filename.concat document_root file_path ]
+      uris
+  )
+;;
+
+let () =
+  run
+    "ide_lsp_join_key"
+    [ ( "partition addressing"
+      , [ test_case
+            "by-url write reads under its partition"
+            `Quick
+            test_by_url_write_is_read_under_its_partition
+        ; test_case
+            "unaddressed store reads empty"
+            `Quick
+            test_unaddressed_store_reads_empty
+        ; test_case
+            "partitions do not share cache entries"
+            `Quick
+            test_partitions_do_not_share_cache_entries
+        ] )
+    ; ( "freshness"
+      , [ test_case
+            "write after first read becomes visible"
+            `Quick
+            test_write_after_first_read_becomes_visible
+        ] )
+    ; ( "document root"
+      , [ test_case
+            "location URI uses the document root"
+            `Quick
+            test_location_uri_uses_the_document_root
+        ] )
+    ]
+;;

--- a/test/test_server_ide_lsp_proxy.ml
+++ b/test/test_server_ide_lsp_proxy.ml
@@ -9,7 +9,9 @@ let member key = function
 ;;
 
 let test_initialize_handshake_is_read_only () =
-  let result = Lsp.initialize_result_json () in
+  (* The handshake also has to hand the client the tree its document URIs
+     resolve against; a browser client cannot know the host path otherwise. *)
+  let result = Lsp.initialize_result_json ~workspace_root:"/workspace/masc" () in
   let capabilities =
     match member "capabilities" result with
     | Some (`Assoc fields) -> fields
@@ -131,7 +133,7 @@ let document_params ~uri line =
 let test_document_request_is_resolved_once () =
   let base = "/workspace/masc" in
   let uri = "file:///workspace/masc/lib/server.ml" in
-  match Lsp.resolve_document_request ~base (document_params ~uri (`Int 7)) with
+  match Lsp.resolve_document_request ~anchor:base (document_params ~uri (`Int 7)) with
   | Error _ -> fail "expected an in-workspace document request"
   | Ok request ->
     check string "URI retained" uri request.uri;
@@ -146,21 +148,21 @@ let test_document_request_is_resolved_once () =
 let test_document_request_keeps_decode_failures_typed () =
   let base = "/workspace/masc" in
   let missing_uri = `Assoc [ "position", `Assoc [ "line", `Int 1 ] ] in
-  (match Lsp.resolve_document_request ~base missing_uri with
+  (match Lsp.resolve_document_request ~anchor:base missing_uri with
    | Error Lsp.Missing_document_uri -> ()
    | Error Lsp.Document_uri_outside_workspace ->
      fail "missing URI must not be classified as an out-of-workspace path"
    | Ok _ -> fail "missing URI must fail decoding");
   let outside_uri = "file:///tmp/outside.ml" in
   (match
-     Lsp.resolve_document_request ~base (document_params ~uri:outside_uri (`Int 1))
+     Lsp.resolve_document_request ~anchor:base (document_params ~uri:outside_uri (`Int 1))
    with
    | Error Lsp.Document_uri_outside_workspace -> ()
    | Error Lsp.Missing_document_uri ->
      fail "outside URI must not be classified as missing"
    | Ok _ -> fail "outside URI must fail decoding");
   let inside_uri = "file:///workspace/masc/lib/server.ml" in
-  match Lsp.resolve_document_request ~base (document_params ~uri:inside_uri (`Int (-1))) with
+  match Lsp.resolve_document_request ~anchor:base (document_params ~uri:inside_uri (`Int (-1))) with
   | Error _ -> fail "negative line must not invalidate a document path"
   | Ok request -> check (option int) "negative line is absent" None request.line
 ;;
@@ -419,6 +421,7 @@ let test_code_actions_have_no_workspace_edit () =
          let actions =
            Lsp_overlay_provider.code_actions
              ~base_dir
+             ~partition:(Some Ide_paths.Legacy_default)
              ~file_path:"a.ml"
              ~line:0
              ~diagnostics:[]


### PR DESCRIPTION
## 목표

keeper 가 남긴 관측(annotation)을 IDE 가 실제로 읽을 수 있게 만든다. 읽기 경로가 쓰기 경로와 다른 주소를 보고 있었다.

## 무엇이 깨져 있었나

`test_ide_canonical_url_join.ml` 은 **쓰기** 쪽 리졸버(파티션 + repo-relative 경로)를 핀한다. **읽기** 쪽이 그 파티션을 주소로 쓰는지는 아무 테스트도 확인하지 않았고, 실제로 쓰지 않았다.

| 지점 | 상태 |
|---|---|
| `lsp_overlay_provider.ml` | `Ide_annotations.list` 를 `?partition` 없이 호출 → 항상 `Legacy_default`(`_orphan/`). keeper 쓰기는 `by-url/<slug>/` 로 감 |
| `Cache.key` | `base_dir + file_path` → 같은 repo-relative 경로가 파티션 간 충돌 |
| `invalidate_cache` | `didSave` 에서만 호출. 이 오버레이를 읽는 클라이언트는 read-only 라 영구히 갱신 안 됨. 최초의 빈 결과가 세션 내내 캐시됨 |
| `Location` URI | `.masc-ide` 를 담은 디렉터리 기준으로 조립 → 스토어 루트 아래 경로가 나와 에디터가 열 수 없음 |
| `ide-lsp-client.ts` `toFileUri` | repo-relative 경로에 `file://` 을 붙임. 절대 URI 가 아니라 첫 세그먼트가 authority 로 들어가서 서버가 workspace 밖으로 판정 → 오버레이도, 전달되는 language server 응답도 함께 빈 값 |

실측 (라이브 서버, 같은 파티션·같은 파일, 키 모양만 변경):

```
GET /api/v1/ide/regions?canonical_url=…/masc.git&file_path=test/deps/masc_test_deps.ml
→ {"ok":true,"data":[{…}]}
GET …&file_path=workspace/yousleepwhen/masc/test/deps/masc_test_deps.ml
→ {"ok":true,"data":[]}
```

후자가 프록시가 만들던 키 모양이다.

## 변경

- `partition` 을 오버레이 13개 진입점 전부에 명시 인자로 올렸다. `None` = "이 연결은 어떤 스토어도 주소로 쓰지 않음" 이고 빈 결과를 낸다. 기본 파티션으로 강등하지 않는다.
- 캐시 키를 스토어 디렉터리 기준으로 바꾸고, 각 엔트리에 스토어 바이트 길이를 실었다. annotation 스토어의 모든 변경은 append 이므로 길이가 리비전 토큰이다 — 읽은 뒤에 들어온 쓰기가 무효화 없이 보인다.
- `Location` 을 돌려주는 두 진입점은 `document_root`(리더가 연 트리)를 받는다.
- 문서는 서버 base 가 아니라 연결의 anchor 기준으로 해석한다. anchor 는 `/api/v1/workspace/file` 이 쓰는 `resolve_workspace_base` 와 같은 함수에서 나온다.
- scope 어휘를 `Server_ide_scope` 로 옮겨 REST 와 LSP 두 표면이 공유한다.
- `initialize` 결과가 해석된 workspace root 를 알린다. 브라우저 클라이언트는 자기가 탐색한 repo-relative 경로만 알고 그것이 걸린 호스트 트리를 모르므로, 프로토콜이 요구하는 절대 `file:` URI 를 만들 방법이 없었다.
- `canonical_url` 만으로 scope 한 LSP 연결은 upgrade 단계에서 거부한다. 파티션은 지정하지만 트리를 지정하지 않아, 문서 키가 project base 기준이 되고 행은 repo 루트 기준으로 저장되는 불일치가 조용히 생긴다.

## 범위에서 명시적으로 뺀 것

**귀속(attribution) 재설계는 건드리지 않았다.** keeper 쓰기가 자기 체크아웃의 `origin` 을 읽어 파티션을 정하는 전환은 RFC-0343 §3.1 과 그것을 흡수한 `RFC-keeper-workspace-root-only` 가 소유한다. 그 RFC 들이 열거한 위험(무제한 `get_origin_url`, 로컬 경로 origin 폴백, 동일 origin N-클론 버킷 붕괴)도 그쪽 단계에서 다뤄야 한다. 이 PR 은 리졸버가 무엇을 내놓든 그것을 **읽기 쪽이 그대로 쓰게** 만드는 것에 한정한다.

관련: RFC-0128 §4.5 (write partition — 이 읽기 경로가 맞물려야 하는 대상), RFC-0343, RFC-keeper-workspace-root-only.

남은 것 (이 PR 밖): tool_event 의 `file_path` 가 리졸버 출력이 아니라 raw tool input 에서 재추출된다 (`keeper_run_tools_hooks.ml` 의 `let partition, _ =`). Codex 리뷰가 지적한 대로 파생 cursor 도 같은 raw 입력을 다시 읽으므로, 정규화 경로를 중립 `Agent_observation` 계약에 올려 두 소비자를 함께 고쳐야 한다 — 그리고 그 파일은 workspace-root RFC 작업과 겹친다.

## 로컬 검증

- `dune build --root . @check` → exit 0
- OCaml: `test_ide_lsp_join_key`(신규, 5 케이스), `test_ide_annotations`, `test_ide_bridge`, `test_server_ide_lsp_proxy`, `test_server_ide_http`, `test_ide_canonical_url_join`, `test_agent_observation_bridge` → 전부 PASS
- dashboard: `tsc --noEmit` exit 0, `eslint` exit 0, `ide-lsp-client`(19) + `ide-data-workspace-store` + `ide-editor` → 59 PASS
- 신규 suite 는 `test/dune` 두 stanza + `scripts/ci-run-focused-tests.sh` 에 배선했다. `audit-ci-test-targets.sh` 가 baseline 복귀(563 unwired / 299 targets), `dune build @test/runtest-test_ide_lsp_join_key` 로 5 케이스 실행 확인.

## End-to-end 실측 (scratch 인스턴스, 라이브 :8935 미접촉)

패치된 바이너리를 scratch base-path + 별 포트(8977)로 띄우고, 이 워크트리를 `repositories.toml` 에 `masc` 로 등록한 뒤 WebSocket 으로 직접 프로브했다. `ocaml-lsp-server 1.27.0` 설치 상태.

```
[no scope]  workspaceRoot advertised = '<scratch base>'                     ← project base 폴백
[repo_id]   workspaceRoot advertised = '<등록된 repo 루트>'                  ← scope 에서 anchor 해석
[repo_id]   hover -> {"contents":{"kind":"plaintext","value":
              "type ide_event =\n  | Tool_event of tool_event\n  | Turn_event of turn_event"},
              "range":{"start":{"line":2,...},"end":{"line":4,...}}}         ← ocamllsp 실제 응답
[canon]     upgrade refused: HTTP 400                                       ← 설계대로 거부
```

즉 절대 URI 수용 → anchor 해석 → language server 로 전달 → ocamllsp 스폰 → 실제 타입 반환까지 한 줄로 확인됐다. 수정 전에는 대시보드가 보내던 상대 URI 가 `resolve_relative` 의 `Fpath.is_abs` 가드에서 떨어져 `Document_uri_outside_workspace` 로 조기 반환됐고, 그 반환이 `ensure_lsp_process` 앞에 있어서 MASC 오버레이뿐 아니라 **전달되는 language server 응답까지** 함께 빈 값이었다.

부수 관찰: `definition` 은 ocamllsp 자신이 "Jump to definition failed" (타입 선언 위 위치라 대상 없음), `codeLens` 는 `[]` (scratch 스토어에 annotation 0 건 — 정상).

## 미검증

- 브라우저에서의 육안 확인은 안 했다. 프로브는 대시보드 클라이언트가 보내는 것과 같은 형태(절대 URI + `?repo_id=`)를 재현했지만, CodeMirror 렌더까지는 확인하지 않았다.
- `typescript-language-server` / `pylsp` 는 이 머신에 없다. 대시보드 자신의 `.ts` 와 python 파일은 여전히 language server 없이 overlay-only 다.
- `lsp_connection_addressing` 의 결정표는 위 프로브(`repo_id` 허용 / `canonical_url` 400 / scope 없음 허용)로 확인했고, 단위 테스트는 `Mcp_server.server_state` 요구 때문에 붙이지 않았다.
- annotation 자체의 트래픽은 별개 문제다. `keeper_ide_annotate` 는 모델에 노출돼 있으나 프롬프트 지시와 강제가 없고 호출 기록이 역사상 3 건(2026-07-08)이다. 이 PR 은 "데이터가 생기면 읽힌다" 를 성립시키며, 트래픽을 만들지는 않는다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
