### PR TITLE
fix(keeper): preserve effective sandbox meta for direct turns

### DIFF
--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -318,6 +318,17 @@ val terminal_latch_pause_violation : keeper_meta -> string option
 val effective_meta_result :
   base_path:string -> keeper_meta -> (keeper_meta, string) result
 
+(** The overlay alone, over defaults the caller already holds.
+
+    {!effective_meta_result} loads the profile and applies it in one step,
+    which is right for a one-shot status read. A turn that overlays more than
+    once must not re-read the profile between them, or two reads of the same
+    turn can disagree; it loads once and applies with this. *)
+val effective_meta_of_profile_defaults :
+     Keeper_types_profile.keeper_profile_defaults
+  -> keeper_meta
+  -> (keeper_meta, string) result
+
 val missing_required_sandbox_profile_error :
   keeper_name:string ->
   Keeper_types_profile.keeper_profile_defaults ->

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -395,19 +395,19 @@ let run_keeper_invocation_turn_admitted_inner
        | Error failure -> turn_resources_error ~surface failure
        | Ok { entry; publication_recovery } ->
       (match
-         Keeper_meta_contract.effective_meta_result
+         Keeper_unified_turn_pre_dispatch.load_profile_defaults
            ~base_path:ctx.config.base_path
+           ~keeper_name:entry.meta.name
+       with
+       | Error err -> tool_result_error (Agent_core.Error.to_string err)
+       | Ok profile_defaults ->
+      (match
+         Keeper_meta_contract.effective_meta_of_profile_defaults
+           profile_defaults
            entry.meta
        with
        | Error error -> tool_result_error error
        | Ok meta ->
-      (match
-         Keeper_unified_turn_pre_dispatch.load_profile_defaults
-           ~base_path:ctx.config.base_path
-           ~keeper_name:meta.name
-       with
-       | Error err -> tool_result_error (Agent_core.Error.to_string err)
-       | Ok profile_defaults ->
       (* RFC vision-delegation §2.3 site 1 (fresh input). For a Delegate keeper,
          evict each image to the artifact store + an eager analyze_image reading
          BEFORE it enters the turn, so the main history stays text-only and

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -394,7 +394,13 @@ let run_keeper_invocation_turn_admitted_inner
        with
        | Error failure -> turn_resources_error ~surface failure
        | Ok { entry; publication_recovery } ->
-      let meta = entry.meta in
+      (match
+         Keeper_meta_contract.effective_meta_result
+           ~base_path:ctx.config.base_path
+           entry.meta
+       with
+       | Error error -> tool_result_error error
+       | Ok meta ->
       (match
          Keeper_unified_turn_pre_dispatch.load_profile_defaults
            ~base_path:ctx.config.base_path
@@ -814,7 +820,7 @@ let run_keeper_invocation_turn_admitted_inner
               in
               tool_result_ok_data reply_json
 
-))))
+)))))
 
 (* Turn-observation boundary for the chat lane.
 

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -317,6 +317,52 @@ sandbox_profile = "docker"
         "none"
         (Profile.network_mode_to_string meta.network_mode)
 
+(* The direct-turn path holds profile defaults it loaded once and overlays with
+   them, rather than re-reading the profile per use: two reads inside one turn
+   could otherwise disagree. That is why the overlay is reachable on its own and
+   not only through [effective_meta_result], which loads and applies together.
+
+   Persisted runtime meta omits TOML-owned fields, so a turn reading it raw sees
+   the wrong sandbox — the overlay is what makes the turn's meta effective. *)
+let test_profile_defaults_overlay_applies_without_reloading () =
+  with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
+  let name = "overlay-once" in
+  write_keeper_agent ~keepers_dir ~name "Analyze carefully.";
+  write_file
+    (Filename.concat keepers_dir (name ^ ".toml"))
+    {|[keeper]
+sandbox_profile = "docker"
+|};
+  let config = Workspace.default_config base in
+  let persisted = seed_runtime_meta config name in
+  match Profile.load_keeper_profile_defaults ~config ~keeper_name:name with
+  | Error error ->
+    Alcotest.failf
+      "profile defaults load failed: %s"
+      (Profile.keeper_toml_load_error_to_string error)
+  | Ok defaults ->
+    (match
+       Masc.Keeper_meta_contract.effective_meta_of_profile_defaults defaults persisted
+     with
+     | Error error -> Alcotest.failf "overlay failed: %s" error
+     | Ok effective ->
+       Alcotest.(check string)
+         "overlay carries the TOML sandbox onto persisted meta"
+         "docker"
+         (Profile.sandbox_profile_to_string effective.sandbox_profile);
+       (* The same defaults applied twice must land on the same meta: the turn
+          reuses one load, so the overlay cannot depend on when it runs. *)
+       (match
+          Masc.Keeper_meta_contract.effective_meta_of_profile_defaults defaults persisted
+        with
+        | Error error -> Alcotest.failf "second overlay failed: %s" error
+        | Ok again ->
+          Alcotest.(check string)
+            "reapplying the same defaults is stable"
+            (Profile.sandbox_profile_to_string effective.sandbox_profile)
+            (Profile.sandbox_profile_to_string again.sandbox_profile)))
+;;
+
 let test_keeper_instructions_reach_meta_json () =
   with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
   let name = "probe" in
@@ -1225,6 +1271,9 @@ let () =
         [
           Alcotest.test_case "TOML sandbox overlay reaches effective meta"
             `Quick test_toml_overlay_reaches_effective_meta;
+          Alcotest.test_case
+            "profile-defaults overlay applies without reloading the profile"
+            `Quick test_profile_defaults_overlay_applies_without_reloading;
           Alcotest.test_case "keeper_exists_config answers existence typed"
             `Quick test_keeper_exists_config_answers_typed;
           Alcotest.test_case

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -335,7 +335,7 @@ sandbox_profile = "docker"
 |};
   let config = Workspace.default_config base in
   let persisted = seed_runtime_meta config name in
-  match Profile.load_keeper_profile_defaults ~config ~keeper_name:name with
+  match Profile.load_keeper_profile_defaults_result_for_base_path ~base_path:base name with
   | Error error ->
     Alcotest.failf
       "profile defaults load failed: %s"


### PR DESCRIPTION
As-Is: `ensure_keeper_exists` resolves TOML-owned fields, including `sandbox_profile = "docker"`, but the direct-message turn replaces that effective meta with the raw registry entry (whose persisted default is Local). Tool dispatch and receipts therefore run as host local/inherit.

To-Be: reapply the existing profile overlay to the latest registry entry once, then pass that single effective meta through prompt, tool factory, command routing, and receipt generation. No new policy, evidence framework, role restriction, or product gate.

Live reproduction: analyst TOML requests Docker while its latest successful receipt reports local/inherit.

Validation performed: OCaml parse-only, ocamlformat check, git diff --check. No local Dune/build/tests per current campaign instruction. CI is intentionally not awaited.