### PR TITLE
fix(keeper): remove Docker to host execution fallback

### DIFF
--- a/dashboard/src/api/dashboard-keeper-config.test.ts
+++ b/dashboard/src/api/dashboard-keeper-config.test.ts
@@ -55,4 +55,35 @@ describe('keeper config source projection', () => {
       live_value: true,
     }])
   })
+
+  it('rejects unavailable effective config instead of normalizing raw defaults', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        name: 'rtprobe',
+        effective_config: null,
+        config_error: {
+          keeper: 'rtprobe',
+          keeper_path: '/workspace/.masc/config/keepers/rtprobe.toml',
+          failing_path: '/workspace/.masc/config/keepers/rtprobe.toml',
+          kind: 'profile_error',
+          detail: 'missing required sandbox_profile',
+          terminal_reason: 'config_invalid',
+          severity: 'error',
+          blocking: true,
+          operator_action_required: true,
+          next_action: 'fix_keeper_toml_config',
+        },
+        sources: {
+          live_meta_path: '/workspace/.masc/keepers/rtprobe.json',
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ))
+
+    await expect(fetchKeeperConfig('rtprobe')).rejects.toThrow(
+      'Keeper config unavailable for rtprobe: profile_error at /workspace/.masc/config/keepers/rtprobe.toml: missing required sandbox_profile',
+    )
+  })
 })

--- a/dashboard/src/api/dashboard-keeper-config.ts
+++ b/dashboard/src/api/dashboard-keeper-config.ts
@@ -156,8 +156,41 @@ function normalizeOverrideFieldSources(raw: unknown): KeeperConfigOverrideFieldS
     .filter((row): row is KeeperConfigOverrideFieldSource => row !== null)
 }
 
+function keeperConfigUnavailableMessage(raw: unknown): string {
+  if (!isRecord(raw)) {
+    throw new Error('Invalid keeper config response: config_error must be a typed object')
+  }
+  const keeper = asNullableString(raw.keeper)
+  const keeperPath = asNullableString(raw.keeper_path)
+  const kind = asNullableString(raw.kind)
+  const failingPath = asNullableString(raw.failing_path)
+  const detail = asNullableString(raw.detail)
+  const validKind = kind === 'read_error'
+    || kind === 'parse_error'
+    || kind === 'profile_error'
+    || kind === 'invalid_name'
+  if (
+    !keeper
+    || !keeperPath
+    || !validKind
+    || !failingPath
+    || !detail
+    || raw.terminal_reason !== 'config_invalid'
+    || raw.severity !== 'error'
+    || raw.blocking !== true
+    || raw.operator_action_required !== true
+    || raw.next_action !== 'fix_keeper_toml_config'
+  ) {
+    throw new Error('Invalid keeper config response: config_error must be a typed object')
+  }
+  return `Keeper config unavailable for ${keeper}: ${kind} at ${failingPath}: ${detail}`
+}
+
 function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfig {
   const data = isRecord(raw) ? raw : {}
+  if (data.config_error !== undefined && data.config_error !== null) {
+    throw new Error(keeperConfigUnavailableMessage(data.config_error))
+  }
   const prompt = isRecord(data.prompt) ? data.prompt : {}
   const promptBlocks = isRecord(prompt.system_prompt_blocks) ? prompt.system_prompt_blocks : {}
   const execution = isRecord(data.execution) ? data.execution : {}

--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -45,22 +45,51 @@ let keeper_config_json (config : Workspace.config) (name : string)
       (`Not_found,
        `Assoc [ ("error", `String (Printf.sprintf "keeper %S not found" name)) ])
   | Ok (Some (m : Keeper_meta_contract.keeper_meta)) ->
+      let raw_meta = m in
       (* bootstrap_runtime is called at server startup — skip here to
          avoid blocking the HTTP handler with Eio.Mutex + file I/O (#3335). *)
-      let defaults, profile_config_error =
+      let effective_meta =
         match
           Keeper_types_profile.load_keeper_profile_defaults_result_for_base_path
             ~base_path:config.base_path
             m.name
         with
-        | Ok defaults -> defaults, None
+        | Ok defaults ->
+          (match Keeper_meta_contract.effective_meta_of_profile_defaults defaults m with
+           | Ok meta -> Ok (defaults, meta)
+           | Error detail ->
+             let keeper_path =
+               Option.value
+                 ~default:(Keeper_types_profile.keeper_meta_path config m.name)
+                 defaults.manifest_path
+             in
+             Error
+               { Keeper_types_profile.keeper_name = m.name
+               ; keeper_path
+               ; failing_path = keeper_path
+               ; kind = Keeper_types_profile.Profile_error
+               ; detail
+               })
         | Error error ->
-          ( Keeper_types_profile.empty_keeper_profile_defaults
-          , Some
-              (Keeper_types_profile.keeper_toml_config_error_of_load_error
-                 ~keeper_name:m.name
-                 error) )
+          Error
+            (Keeper_types_profile.keeper_toml_config_error_of_load_error
+               ~keeper_name:m.name
+               error)
       in
+      (match effective_meta with
+       | Error config_error ->
+         let body =
+           `Assoc
+             [ "name", `String raw_meta.name
+             ; "effective_config", `Null
+             ; ( "config_error"
+               , Keeper_types_profile.keeper_toml_config_error_to_json
+                   config_error )
+             ; "sources", source_provenance_json config raw_meta
+             ]
+         in
+         `OK, with_keeper_config_field_presence body
+       | Ok (defaults, m) ->
       let active_goals =
         List.filter_map
           (fun goal_id ->
@@ -278,21 +307,28 @@ let keeper_config_json (config : Workspace.config) (name : string)
          ( "autonomous_wake_prompt",
            Json_util.string_opt_to_json
              defaults.Keeper_types_profile.autonomous_wake_prompt );
-         ("sandbox_profile", `String (Keeper_types_profile_sandbox.sandbox_profile_to_string m.sandbox_profile));
-         ("network_mode", `String (Keeper_types_profile_sandbox.network_mode_to_string m.network_mode));         ("sandbox_last_error", Json_util.string_opt_to_json sandbox_last_error);
-         ("allowed_paths",
-           `List (List.map (fun s -> `String s) m.allowed_paths));
-	         ("effective_allowed_paths",
-	           `List (List.map (fun s -> `String s)
-	             (Keeper_alerting_path.effective_allowed_paths ~meta:m)));
-	         ("pipeline_stage", `String pipeline_stage);
-	         ("lifecycle_phase", Json_util.string_opt_to_json lifecycle_phase);
-	         ("pipeline_stage_detail", `String pipeline_stage_detail);
+         ( "sandbox_profile"
+         , `String
+             (Keeper_types_profile_sandbox.sandbox_profile_to_string
+                m.sandbox_profile) );
+         ( "network_mode"
+         , `String
+             (Keeper_types_profile_sandbox.network_mode_to_string
+                m.network_mode) );
+         ("sandbox_last_error", Json_util.string_opt_to_json sandbox_last_error);
+         ( "allowed_paths"
+         , `List (List.map (fun s -> `String s) m.allowed_paths) );
+         ( "effective_allowed_paths"
+         , `List
+             (List.map
+                (fun s -> `String s)
+                (Keeper_alerting_path.effective_allowed_paths ~meta:m)) );
+         ("pipeline_stage", `String pipeline_stage);
+         ("lifecycle_phase", Json_util.string_opt_to_json lifecycle_phase);
+         ("pipeline_stage_detail", `String pipeline_stage_detail);
 	         ("state_diagram", `String state_diagram);
          ( "config_error",
-           Json_util.option_to_yojson
-             Keeper_types_profile.keeper_toml_config_error_to_json
-             profile_config_error );
+           `Null );
          ("prompt", prompt);
          ("execution", execution);
          ("proactive", proactive);
@@ -301,11 +337,11 @@ let keeper_config_json (config : Workspace.config) (name : string)
          ("runtime", runtime_surface_json config m);
          ("runtime_trust", runtime_trust);
          ("workspace", workspace);
-         ("sources", source_provenance_json config m);
+         ("sources", source_provenance_json config raw_meta);
          ("metrics", metrics);
        ]
       in
-      (`OK, with_keeper_config_field_presence body)
+      (`OK, with_keeper_config_field_presence body))
 
 (** Per-keeper cost/latency aggregates for the O4 cost dashboard.
 

--- a/lib/keeper/keeper_sandbox_shell_ir_target.ml
+++ b/lib/keeper/keeper_sandbox_shell_ir_target.ml
@@ -7,6 +7,7 @@ open Keeper_types_profile
 type target_error =
   { message : string
   ; fields : (string * Yojson.Safe.t) list
+  ; class_ : Tool_result.tool_failure_class
   }
 
 type docker_dispatch =
@@ -14,7 +15,9 @@ type docker_dispatch =
   ; runtime : Keeper_turn_sandbox_runtime.t
   }
 
-let target_error ?(fields = []) message = { message; fields }
+let target_error ?(fields = []) ?(class_ = Tool_result.Runtime_failure) message =
+  { message; fields; class_ }
+;;
 
 let docker_image (meta : keeper_meta) =
   match meta.sandbox_image with
@@ -25,26 +28,29 @@ let docker_image (meta : keeper_meta) =
 let tool_failure_class_of_image_preflight_failure failure_class =
   match failure_class with
   | Keeper_sandbox_runtime_classify.Image_config_missing ->
-    "policy_rejection"
+    Tool_result.Policy_rejection
   | Image_inspect_timeout ->
-    "transient_error"
-  | _ -> "runtime_failure"
+    Tool_result.Transient_error
+  | _ -> Tool_result.Runtime_failure
 ;;
 
-let image_preflight_failure_fields (failure : Keeper_sandbox_runtime.classified_error) =
+let image_preflight_failure_fields ~class_
+    (failure : Keeper_sandbox_runtime.classified_error) =
   let sandbox_failure_class =
     Keeper_sandbox_runtime_classify.docker_failure_class_to_string failure.failure_class
   in
   [ "requested_sandbox", `String "docker"
   ; "sandbox_failure_class", `String sandbox_failure_class
   ; ( "failure_class"
-    , `String (tool_failure_class_of_image_preflight_failure failure.failure_class) )
+    , `String (Tool_result.tool_failure_class_to_string class_) )
   ]
 ;;
 
 let image_preflight_target_error (failure : Keeper_sandbox_runtime.classified_error) =
+  let class_ = tool_failure_class_of_image_preflight_failure failure.failure_class in
   target_error
-    ~fields:(image_preflight_failure_fields failure)
+    ~class_
+    ~fields:(image_preflight_failure_fields ~class_ failure)
     (Keeper_sandbox_runtime.docker_image_preflight_failure_message
        ~prefix:"docker_container_start_failed"
        failure)

--- a/lib/keeper/keeper_sandbox_shell_ir_target.ml
+++ b/lib/keeper/keeper_sandbox_shell_ir_target.ml
@@ -128,23 +128,3 @@ let docker_target ~turn_sandbox_factory ~meta ~cwd ?timeout_sec () =
          ; runtime
          })
 ;;
-
-let docker_local_fallback_target ~meta ?timeout_sec () =
-  let image = docker_image meta in
-  match
-    Keeper_sandbox_runtime.docker_image_present_optional
-      ~image
-      ?timeout_sec
-      ()
-  with
-  | Ok () -> None
-  | Error message ->
-    Some
-      ( Masc_exec.Sandbox_target.host ()
-      , [ "requested_sandbox", `String "docker"
-        ; "via", `String "local_fallback"
-        ; "fallback_reason", `String "docker_preflight_unavailable"
-        ; "sandbox_fallback", `String "local_playground"
-        ; "sandbox_fallback_reason", `String (Exec_policy.truncate_for_log message)
-        ] )
-;;

--- a/lib/keeper/keeper_sandbox_shell_ir_target.mli
+++ b/lib/keeper/keeper_sandbox_shell_ir_target.mli
@@ -3,6 +3,7 @@
 type target_error =
   { message : string
   ; fields : (string * Yojson.Safe.t) list
+  ; class_ : Tool_result.tool_failure_class
   }
 
 type docker_dispatch =
@@ -10,7 +11,11 @@ type docker_dispatch =
   ; runtime : Keeper_turn_sandbox_runtime.t
   }
 
-val target_error : ?fields:(string * Yojson.Safe.t) list -> string -> target_error
+val target_error
+  :  ?fields:(string * Yojson.Safe.t) list
+  -> ?class_:Tool_result.tool_failure_class
+  -> string
+  -> target_error
 
 val docker_image : Keeper_meta_contract.keeper_meta -> string
 

--- a/lib/keeper/keeper_sandbox_shell_ir_target.mli
+++ b/lib/keeper/keeper_sandbox_shell_ir_target.mli
@@ -21,9 +21,3 @@ val docker_target
   -> ?timeout_sec:float
   -> unit
   -> (docker_dispatch, target_error) result
-
-val docker_local_fallback_target
-  :  meta:Keeper_meta_contract.keeper_meta
-  -> ?timeout_sec:float
-  -> unit
-  -> (Masc_exec.Sandbox_target.t * (string * Yojson.Safe.t) list) option

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -345,6 +345,7 @@ let handle_tool_execute_typed
          | Error ({ message; fields; class_ } : Keeper_sandbox_shell_ir_target.target_error) ->
            Keeper_tool_execution.failure
              ~class_
+             ~effect_disposition:Tool_result.Proven_pre_effect
              (error_json
                 ~fields:
                   ([ "typed", `Bool true; "cmd", `String cmd ]

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -342,8 +342,9 @@ let handle_tool_execute_typed
                   })
         in
         (match dispatch_sandbox with
-         | Error ({ message; fields } : Keeper_sandbox_shell_ir_target.target_error) ->
+         | Error ({ message; fields; class_ } : Keeper_sandbox_shell_ir_target.target_error) ->
            Keeper_tool_execution.failure
+             ~class_
              (error_json
                 ~fields:
                   ([ "typed", `Bool true; "cmd", `String cmd ]

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -158,8 +158,6 @@ let normalize_path_for_keeper_tool_execute_shell_ir_containment path =
 
 (* Backend target helpers for typed Shell IR dispatch. *)
 let docker_sandbox_target = Keeper_sandbox_shell_ir_target.docker_target
-let docker_local_fallback_target =
-  Keeper_sandbox_shell_ir_target.docker_local_fallback_target
 
 type dispatch_bundle =
   { sandbox : Masc_exec.Sandbox_target.t
@@ -196,7 +194,6 @@ let handle_tool_execute_typed
       ~(args : Yojson.Safe.t)
       ()
   =
-  let root = Keeper_alerting_path.project_root_of_config config in
   match
     Keeper_tool_execute_path.resolve_tool_execute_cwd_typed
       ~config
@@ -242,10 +239,6 @@ let handle_tool_execute_typed
         let cmd = typed_input_command_text input in
         let timeout_sec = typed_input_timeout_sec input in
         let input = input_with_cwd cwd input in
-        (* This location check only selects the explicit local-fallback route.
-           It is not authorization evidence. The outer Keeper Gate remains the
-           sole authorization boundary for every Execute request. *)
-        let in_playground = Keeper_tool_execute_path.in_playground ~root ~cwd ~meta in
         let sandbox_profile, _ =
           Keeper_sandbox_runner.effective_sandbox_profile ~meta
         in
@@ -322,27 +315,17 @@ let handle_tool_execute_typed
               Error
                 (Keeper_sandbox_shell_ir_target.target_error
                    "typed Shell IR Docker dispatch does not support env yet")
-            else (
-              match docker_local_fallback_target ~meta ?timeout_sec () with
-              | Some (target, fields) when in_playground ->
-                (match target with
-                 | Masc_exec.Sandbox_target.Host ->
-                   local_dispatch_sandbox ~extra_fields:fields ()
-                 | Docker _ ->
-                   Error
-                     (Keeper_sandbox_shell_ir_target.target_error
-                        "Docker preflight fallback returned a Docker target"))
-              | Some _ | None ->
-                docker_sandbox_target
-                  ~turn_sandbox_factory
-                  ~meta
-                  ~cwd
-                  ?timeout_sec
-                  ()
-                |> Result.map
-                     (fun
-                       (dispatch : Keeper_sandbox_shell_ir_target.docker_dispatch)
-                     ->
+            else
+              docker_sandbox_target
+                ~turn_sandbox_factory
+                ~meta
+                ~cwd
+                ?timeout_sec
+                ()
+              |> Result.map
+                   (fun
+                     (dispatch : Keeper_sandbox_shell_ir_target.docker_dispatch)
+                   ->
                   { sandbox = dispatch.target
                   ; fields =
                       [ "requested_sandbox", `String "docker"
@@ -356,7 +339,7 @@ let handle_tool_execute_typed
                            ?timeout_sec
                            dispatch.runtime)
                   ; cleanup = Fun.id
-                  }))
+                  })
         in
         (match dispatch_sandbox with
          | Error ({ message; fields } : Keeper_sandbox_shell_ir_target.target_error) ->

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -1240,6 +1240,44 @@ let test_keeper_list_row_surfaces_effective_meta_errors () =
              (List.mem_assoc "effective_meta_error" fields)
        | _ -> Alcotest.fail "expected object row")
 
+let test_config_snapshot_does_not_fallback_to_raw_meta () =
+  with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
+  let name = "bad-config-snapshot" in
+  write_keeper_agent ~keepers_dir ~name "Missing sandbox profile";
+  write_file
+    (Filename.concat keepers_dir (name ^ ".toml"))
+    {|[keeper]
+|};
+  let config = Workspace.default_config base in
+  ignore (seed_runtime_meta config name : Masc.Keeper_meta_contract.keeper_meta);
+  match Dashboard_http_keeper_snapshot.keeper_config_json config name with
+  | `Not_found, _ -> Alcotest.fail "expected a typed unavailable config snapshot"
+  | `OK, json ->
+    Alcotest.(check (option string))
+      "snapshot preserves the raw keeper identity"
+      (Some name)
+      (json_string_field "name" json);
+    Alcotest.(check bool)
+      "effective config is explicitly unavailable"
+      true
+      (json_field "effective_config" json = Some `Null);
+    Alcotest.(check bool)
+      "raw sandbox defaults are not projected as effective"
+      true
+      (json_field "sandbox_profile" json = None);
+    Alcotest.(check bool)
+      "typed config error remains visible"
+      true
+      (match json_field "config_error" json with
+       | Some (`Assoc _) -> true
+       | Some _ | None -> false);
+    Alcotest.(check bool)
+      "raw source provenance remains visible"
+      true
+      (match json_field "sources" json with
+       | Some (`Assoc _) -> true
+       | Some _ | None -> false)
+
 let test_keeper_list_error_row_preserves_keepalive_state () =
   with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
   let name = "badprofile-running" in
@@ -1324,6 +1362,9 @@ let () =
             test_status_surfaces_chat_operation_runtime;
           Alcotest.test_case "keeper list surfaces effective meta errors"
             `Quick test_keeper_list_row_surfaces_effective_meta_errors;
+          Alcotest.test_case
+            "config snapshot never falls back to raw effective fields"
+            `Quick test_config_snapshot_does_not_fallback_to_raw_meta;
           Alcotest.test_case
             "keeper list error row preserves keepalive state"
             `Quick test_keeper_list_error_row_preserves_keepalive_state;

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -744,7 +744,7 @@ let test_execute_typed_repeated_executable_arg_is_preserved () =
     true
     (response_mentions raw "output" "echo hello")
 
-let test_execute_typed_pipeline_falls_back_to_local_playground () =
+let test_execute_typed_pipeline_requires_docker_factory () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "missing:test" @@ fun () ->
   setup ~sandbox:Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
@@ -756,37 +756,12 @@ let test_execute_typed_pipeline_falls_back_to_local_playground () =
       ~args:(tool_execute_typed_pipeline_args ~cwd:playground)
       ()
   in
-  check_typed_pipeline_response raw;
-  let local_cwd =
-    Keeper_alerting_path.normalize_path_for_check playground
-    |> Keeper_alerting_path.strip_trailing_slashes
-  in
-  Alcotest.(check (option string)) "requested docker" (Some "docker")
-    (parse_string_field raw "requested_sandbox");
-  Alcotest.(check (option string)) "fallback local playground"
-    (Some "local_playground")
-    (parse_string_field raw "sandbox_fallback");
-  Alcotest.(check (option string)) "fallback dispatch identity"
-    (Some "local_fallback")
-    (parse_string_field raw "via");
-  Alcotest.(check bool) "fallback response exposes actual Local host namespace" true
-    (String_util.contains_substring raw config.Workspace.base_path);
-  Alcotest.(check (option string)) "fallback top-level cwd is Local host cwd"
-    (Some local_cwd)
-    (parse_string_field raw "cwd");
-  let execution_location_cwd =
-    try
-      raw
-      |> Yojson.Safe.from_string
-      |> Yojson.Safe.Util.member "execution_location"
-      |> Yojson.Safe.Util.member "cwd"
-      |> Yojson.Safe.Util.to_string_option
-    with
-    | Yojson.Json_error _ -> None
-  in
-  Alcotest.(check (option string)) "fallback nested cwd matches top-level cwd"
-    (Some local_cwd)
-    execution_location_cwd
+  Alcotest.(check (option bool)) "Docker request did not run on Host" None
+    (parse_bool_field raw "ok");
+  Alcotest.(check bool) "missing factory is explicit" true
+    (response_mentions raw "error" "requires a turn sandbox factory");
+  Alcotest.(check (option string)) "no local fallback" None
+    (parse_string_field raw "sandbox_fallback")
 
 let test_execute_typed_pipeline_uses_local_shell_ir_dispatch () =
   setup ~sandbox:Keeper_types_profile_sandbox.Local
@@ -834,45 +809,12 @@ let test_execute_routes_through_docker () =
       ~args:(tool_execute_typed_exec_args ~cwd:playground "pwd" ~argv:[])
       ()
   in
-  Alcotest.(check (option bool)) "typed Execute succeeds via local fallback" (Some true)
+  Alcotest.(check (option bool)) "Docker request did not run on Host" None
     (parse_bool_field raw "ok");
-  Alcotest.(check (option string)) "requested docker" (Some "docker")
-    (parse_string_field raw "requested_sandbox");
-  Alcotest.(check (option string)) "fallback local playground"
-    (Some "local_playground")
-    (parse_string_field raw "sandbox_fallback");
-  Alcotest.(check (option string)) "fallback dispatch identity"
-    (Some "local_fallback")
-    (parse_string_field raw "via");
-  Alcotest.(check (option string)) "fallback reason is typed"
-    (Some "docker_preflight_unavailable")
-    (parse_string_field raw "fallback_reason");
-  Alcotest.(check bool) "fallback retains private preflight detail" true
-    (Option.is_some (parse_string_field raw "sandbox_fallback_reason"));
-  let stdout =
-    parse_string_field raw "output"
-    |> Option.map String.trim
-  in
-  let local_cwd =
-    Keeper_alerting_path.normalize_path_for_check playground
-    |> Keeper_alerting_path.strip_trailing_slashes
-  in
-  Alcotest.(check (option string)) "fallback stdout reports Local cwd"
-    (Some local_cwd)
-    stdout;
-  Alcotest.(check (option string)) "fallback top-level cwd reports Local namespace"
-    stdout
-    (parse_string_field raw "cwd");
-  let execution_location_cwd =
-    raw
-    |> Yojson.Safe.from_string
-    |> Yojson.Safe.Util.member "execution_location"
-    |> Yojson.Safe.Util.member "cwd"
-    |> Yojson.Safe.Util.to_string_option
-  in
-  Alcotest.(check (option string)) "fallback nested cwd reports Local namespace"
-    stdout
-    execution_location_cwd
+  Alcotest.(check bool) "missing Docker image is explicit" true
+    (response_mentions raw "error" "docker image");
+  Alcotest.(check (option string)) "no local fallback" None
+    (parse_string_field raw "sandbox_fallback")
 
 let test_execute_legacy_skips_docker () =
   with_env "MASC_KEEPER_SANDBOX_DOCKER_IMAGE" "" @@ fun () ->
@@ -1090,12 +1032,11 @@ let test_execute_git_routes_through_docker () =
       ~args:(tool_execute_typed_exec_args ~cwd:repo "git" ~argv:[ "status" ])
       ()
   in
-  Alcotest.(check (option bool)) "typed git bash uses local fallback" (Some true)
+  Alcotest.(check (option bool)) "Docker git did not run on Host" None
     (parse_bool_field raw "ok");
-  Alcotest.(check (option string)) "requested docker" (Some "docker")
-    (parse_string_field raw "requested_sandbox");
-  Alcotest.(check (option string)) "fallback local playground"
-    (Some "local_playground")
+  Alcotest.(check bool) "missing factory is explicit" true
+    (response_mentions raw "error" "requires a turn sandbox factory");
+  Alcotest.(check (option string)) "no local fallback" None
     (parse_string_field raw "sandbox_fallback")
 
 let test_execute_git_uses_turn_runtime () =
@@ -1432,7 +1373,7 @@ let test_docker_shell_ir_parse_failure_blocks_before_run () =
       false
       (Sys.file_exists log_path)
 
-let test_execute_missing_image_falls_back_to_local_playground () =
+let test_execute_missing_image_without_factory_fails_closed () =
   with_fake_docker fake_docker_missing_image_script @@ fun () ->
   setup ~sandbox:Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
@@ -1451,14 +1392,14 @@ let test_execute_missing_image_falls_back_to_local_playground () =
       ~args:(tool_execute_typed_pipeline_args ~cwd:playground)
       ()
   in
-  check_typed_pipeline_response raw;
-  Alcotest.(check (option string)) "requested docker" (Some "docker")
-    (parse_string_field raw "requested_sandbox");
-  Alcotest.(check (option string)) "fallback local playground"
-    (Some "local_playground")
+  Alcotest.(check (option bool)) "Docker request did not run on Host" None
+    (parse_bool_field raw "ok");
+  Alcotest.(check bool) "missing factory is explicit" true
+    (response_mentions raw "error" "requires a turn sandbox factory");
+  Alcotest.(check (option string)) "no local fallback" None
     (parse_string_field raw "sandbox_fallback");
-  let log = read_file log_path in
-  Alcotest.(check bool) "image inspect attempted" true
+  let log = if Sys.file_exists log_path then read_file log_path else "" in
+  Alcotest.(check bool) "image inspect skipped without factory" false
     (String_util.contains_substring log "image inspect missing:test");
   Alcotest.(check bool) "docker run skipped" false
     (String_util.contains_substring log "\nrun ")
@@ -2292,8 +2233,8 @@ let () =
             "tool_execute typed repeated executable arg is preserved"
             `Quick test_execute_typed_repeated_executable_arg_is_preserved;
           Alcotest.test_case
-            "tool_execute typed pipeline falls back to local playground"
-            `Quick test_execute_typed_pipeline_falls_back_to_local_playground;
+            "tool_execute typed pipeline requires docker factory"
+            `Quick test_execute_typed_pipeline_requires_docker_factory;
           Alcotest.test_case
             "tool_execute typed pipeline uses turn sandbox docker runner"
             `Quick test_execute_typed_pipeline_uses_turn_sandbox_docker_runner;
@@ -2312,8 +2253,8 @@ let () =
             "docker shell parse failure blocks before run"
             `Quick
             test_docker_shell_ir_parse_failure_blocks_before_run;
-          Alcotest.test_case "tool_execute missing image falls back locally" `Quick
-            test_execute_missing_image_falls_back_to_local_playground;
+          Alcotest.test_case "tool_execute missing image without factory fails closed" `Quick
+            test_execute_missing_image_without_factory_fails_closed;
           Alcotest.test_case
             "tool_execute outside playground rejects before image preflight"
             `Quick


### PR DESCRIPTION
## Summary

- Docker-profile typed Execute no longer has a Docker to Host/local fallback branch.
- Docker image, daemon, factory, and preflight failures remain explicit typed tool failures.
- Target/preflight failures are recorded as `Proven_pre_effect` because command dispatch has not occurred.
- Local-profile Execute still uses the Host target by declaration.
- The obsolete fallback helper and its public API are removed.

## Boundary

- This changes only concrete Execute target resolution, failure disposition, and the existing route tests.
- It does not gate no-tool turns, provider selection, HITL replay, or unrelated Keeper features.
- It introduces no new runtime policy, feature flag, admission gate, or framework.

## Exact stack

- parent PR: #28635
- base: `bc94c1c0a274eeda785bcd694bb4e40d53a87270`
- head: `be40d9101c72c7b978231b88d8c2e122bebb12bc`
- diff: 3 production files and 1 existing route test file

## Current-head validation

- OCaml changed-file format and parse-only checks: pass
- `git diff --check`: pass
- Independent adversarial source re-review: in progress
- Exact-head CI: in progress
- No local Dune build

Draft and do-not-merge stay in place until the parent lands and this exact child head is independently green.