### PR TITLE
docs: make Keeper campaign feature-first

### DIFF
--- a/docs/KEEPER-FULL-FEATURE-GOAL.md
+++ b/docs/KEEPER-FULL-FEATURE-GOAL.md
@@ -150,9 +150,10 @@ framework, runtime-role policy, unused execution-store plumbing처럼 현재 기
 - 기능을 막는 새 admission 조건을 추가하지 않는다.
 - Runtime 이름이나 사용자 로컬 설정을 production OCaml variant로 만들지 않는다.
 - 빠르게 Draft로 발행하고 긴 CI를 기다리지 않고 다음 독립 기능으로 이동한다.
-- push 전 `git diff --check`, parser/format, 필요한 frontend typecheck와 focused test처럼
-  빠른 검사를 수행한다. 로컬 Dune build는 실행하지 않고 OCaml build와 넓은 동작 검증은
-  exact-head CI에서 판정한다.
+- push 전 `git diff --check`, parser/format, 필요한 frontend typecheck와 focused test를
+  수행한다. OCaml 코드나 공개 타입을 바꾸면 관련 Dune build와 focused test를
+  `scripts/dune-local.sh`로 실행하고, 넓은 경계를 바꾸면 영향 범위에 비례한 저장소 전체
+  검증도 수행한다. exact-head CI는 이 로컬 검증을 대체하지 않는 최종 판정이다.
 - Dashboard도 reducer, interaction, reconnect를 포함한 실제 UI 기능 고장만 수정한다.
 
 ## 7. Live 실행 경계

--- a/docs/KEEPER-FULL-FEATURE-GOAL.md
+++ b/docs/KEEPER-FULL-FEATURE-GOAL.md
@@ -1,551 +1,156 @@
-# Keeper Full-Feature Goal — Unblocked, Durable, Observable
+# MASC Keeper 기능 우선 검증·개선 계획
 
-> Status: Proposed implementation contract
-> Scope: MASC Keeper execution, Gate, compaction, asynchronous operations, and
-> the agent core composition boundary
+> Status: Active implementation plan
+> Scope: Keeper의 실제 제품 기능, 연속 실행, 실행 결과 관측
 
-This document states the target behavior and ownership rules. It does not claim
-that an open PR, green unit test, or private foundation is already live. Current
-commits, PR dependencies, CI, and purge targets belong in companion execution
-documents and must be refreshed from their authoritative sources.
+## 1. 목표
 
-## 1. Copyable Goal
+목표는 새로운 범용 프레임워크나 정책을 만드는 것이 아니다. Keeper에서 이미
+제공하는 기능이 요청부터 terminal 결과까지 실제로 동작하고, 기다림이나 재시작이
+필요한 기능은 같은 작업을 이어가며, 실패하면 실패 지점이 사용자에게 드러나게 한다.
 
-> Rebuild MASC so every Keeper remains an independently progressing durable
-> lane; remove generic governance, risk taxonomy, numeric admission, implicit
-> execution limits, command/tool/product heuristics, and their derived hard
-> prohibitions; retain only objectively provable typed execution invariants;
-> route external effects through exact Always Allowed, configured LLM Auto
-> Judge, or nonblocking HITL; compose each MASC operation with one or more
-> finite agent core Agent runs; make Tool, Model, LLM Agent, Keeper, Fusion, and the
-> product shorthand `Any`, `Any[]`, and `AsyncAny[]` compose through typed
-> invocation adapters whose asynchronous progress survives restart; preserve
-> active identities through MASC-owned LLM compaction and reinjection; and
-> prove owner-only wake-up, lane isolation, one-shot grants, Task LLM
-> verification, and complete causal observability in CI.
+현재 사용 가능한 GLM Coding, Kimi Coding, Ollama Cloud, local llama-server,
+Codex subscription, Claude Code subscription은 이 사용자의 live 검증 자원이다.
+제품 코드에 이 목록, 개수, 이름, 전용 역할 정책을 넣지 않는다. local
+llama-server의 모델 이름도 제품 개념이 아니다.
 
-## 2. Success Is Evidence, Not a Percentage
+Lane은 특정 종류의 일을 수행하는 실행 경로다. Runtime은 어떤 Lane에도 할당할 수
+있다. `librarian`, `verification`, `judge`, `fusion panel`, `meta judge`는
+Runtime의 고정 role이 아니다. 실제 Lane 실행이 실패하면 그 실행 경계의 기능 고장으로
+관측하며, 사전 runtime-role 정책으로 할당을 막지 않는다.
 
-The Goal is complete only when current evidence proves all of these gates:
+## 2. 완료 판정
 
-1. forbidden active-source concepts are absent;
-2. agent core owns only generic finite Agent execution and provider/runtime behavior;
-3. MASC owns long-lived Keeper product orchestration;
-4. Gate modes are exact, non-hierarchical, nonblocking, and observable;
-5. each Keeper drains an independent durable queue;
-6. waiting operations release runnable capacity and later resume by exact wake;
-7. side-effect uncertainty is fenced and never converted into blind retry;
-8. MASC-owned LLM compaction preserves active typed anchors;
-9. compaction output is reinjected and observable Before/After;
-10. Scheduler, Connector, Fusion, and typed Any-as-a-Tool adapters share one
-    operation law;
-11. Task completion is decided at an LLM boundary;
-12. replacement code, focused tests, authoritative CI, and live behavior agree;
-13. obsolete implementations, tests, environment knobs, and current docs are
-    deleted.
+기능별 완료 기준은 그 기능의 사용자 관점 동작이다.
 
-## 3. Two Nested Authorities
+1. 요청이 실제 실행 경계까지 도달한다.
+2. 의도한 결과를 내거나 사용자가 확인할 수 있는 구체적인 실패로 끝난다.
+3. 해당 기능이 원래 제공하는 상태/receipt/UI가 있다면 실제 결과와 모순되지 않는다.
 
-```text
-MASC durable operation                    agent core finite Agent.run
-────────────────────────────────────      ───────────────────────────────
-Keeper / Task / Goal / Board owner        Agent turn and provider attempt
-Gate / HITL / schedule decision           Tool invocation and tool attempt
-Long-lived wait / wake / resume           Structured output and ToolResult
-Product checkpoint and Memory             Run-local receipt and crash fence
-Compaction and reinjection                Provider-native streaming/capacity
-Dashboard product projection              Exact finite-run event projection
-```
+기능이 wait, async handle, queue, scheduler 또는 process restart를 포함하면 같은
+identity로 후속 진행되는 것도 확인한다. 해당 기능과 무관한 fleet 상태, runtime 수,
+optional telemetry, 증거 문서의 존재를 제품 실행 조건으로 만들지 않는다.
 
-The dependency remains one-way:
+관측 인프라가 없거나 오래됐다는 이유만으로 정상 기능을 막지 않는다. 단, 요청한
+실행 의미가 바뀌는 경우에는 명시적으로 실패해야 한다. 예를 들어 Docker 실행 요청을
+Host 실행으로 몰래 바꾸는 것은 허용하지 않는다.
 
-```text
-MASC  ──depends on──>  agent core
-agent core   ──must not know──> Keeper / Board / Task / Goal / Gate / HITL
-                         Fusion / Connector / Scheduler / MASC
-```
+성능·효율 최적화는 baseline 기능이 동작한 뒤 별도 PR로 다룬다. 최적화가 없어도
+기능이 정확히 동작한다면 admission gate로 만들지 않는다.
 
-### 3.1 agent core ownership
+## 3. 기능 범위와 조사 방법
 
-agent core owns reusable provider/model catalogs, multimodal protocol values,
-streaming, reasoning/tool feedback, finite Agent-run topology, exact ToolUse and
-ToolResult structure, invocation-local identity, run-local effect receipts,
-provider-native context capacity, typed provider failure, and generic typed
-hooks around one finite tool invocation. agent core also owns the generic typed
-asynchronous accept/reconcile/cancel/observe protocol and its optional
-journal-backed reference runtime. It does not own a MASC long-lived operation
-namespace, worker/wake policy, or Keeper lifecycle.
+먼저 live canary로 기능을 실행한다. 실패가 재현되면 필요한 방법만 선택해 경계를
+좁힌다. 다음 세 방법은 선택지이며 모든 기능의 통과 조건이 아니다.
 
-For one finite run, agent core may privately own:
+- A — source path: 입력이 어느 reducer와 effect boundary를 지나 어느 store/receipt에
+  도달하는지 추적한다.
+- B — focused scenario: 성공, 명시적 실패, 재개/중복 중 해당 기능에 필요한 경우만
+  작은 fixture로 확인한다.
+- C — live scenario: 고유 canary ID로 실제 `~/me/.masc`에서 실행하고 API, receipt,
+  Dashboard를 같은 ID로 대조한다.
 
-- `Agent_run -> Agent_turn -> Provider_attempt`;
-- structured output blocks and tool invocations;
-- nested child Agent runs;
-- typed `PreTool -> Tool_attempt -> PostTool` lifecycle under each invocation;
-- a single-writer run journal and caller-selected durable store;
-- persist-before-effect attempt evidence;
-- receipt-after-effect evidence;
-- typed `Effect_outcome_unknown` and reconciliation fencing.
+| 기능 | source 조사 예시 | focused 확인 예시 | live 실행 예시 |
+|---|---|---|---|
+| 자율 turn·승계 | turn 시작→provider→후속 turn | wait/restart가 필요한 경로 | Keeper가 이전 작업을 이어 완료 |
+| Queue·Scheduler | enqueue→claim→terminal receipt | blocked/failed head가 있는 경로 | 고유 event/occurrence의 처리 순서 |
+| HITL Auto Judge | request→judge→resolution→wake | approve/reject/defer 중 구현된 결과 | configured judge로 owner가 다시 진행 |
+| Tool·Multi·Batch | tool plan→dispatch→result | 순차/독립 병렬/partial failure | 실제 tool 결과와 호출 순서 |
+| Async | accept→handle→observe/cancel→terminal | terminal 및 cancel | handle을 다시 조회해 최종 결과 확인 |
+| Board·Task·Goal·Broadcast | command→store revision→event | duplicate/revision conflict | canary 객체의 생성부터 terminal |
+| Verification·Fusion·Judge | producer/panel→verdict→consumer | partial/all-fail 및 judge 단계 | 실제 configured topology 한 건 완료 |
+| Sandbox | TOML→effective meta→execute target | Docker 준비 실패 | Docker 또는 명시적 실패, Host 강등 없음 |
+| Stream·Reasoning | provider event→reducer→projection | replay/out-of-order/same text | 같은 event 1회, 다른 동일 text 보존 |
+| Dashboard | receipt/store→API→UI | loading/stale/failed projection | DOM 숫자·상태와 같은 시각 API 대조 |
 
-This is not a Keeper lane. A finite agent core execution scope must close at run
-completion and must never become one infinite Keeper-lifetime WAL.
+fixture와 source 추적은 live 실패를 설명하고 수정을 좁히기 위해 사용한다. 기존
+artifact만으로 원인이 분명한 경우에는 불필요한 새 harness를 만들지 않는다.
 
-### 3.2 MASC ownership
+## 4. 상태와 SSOT
 
-MASC owns Keeper lifecycle, owner-lane scheduling, durable product operations,
-Gate/HITL, Task/Goal/Board/Connector/Fusion state, Scheduler occurrence
-semantics, Memory, compaction policy and execution, reinjection, and dashboard
-projections. MASC also owns the adapters that expose Keeper, Fusion, Connector,
-Scheduler, or another MASC operation through the generic agent core tool boundary.
-agent core may provide a generic Agent adapter; it must not gain MASC-specific node
-kinds or dispatch rules.
+새로운 campaign-wide evidence registry를 먼저 만들지 않는다. 기능을 조사할 때
+source에서 현재 producer-owned store와 consumer를 확인하고 그 경계를 유지한다.
+Dashboard/SSE/OTel은 product 상태를 보여주는 consumer이며 복구 권위로 사용하지 않는다.
 
-A MASC operation may reference an agent core run and its nodes:
+한 기능에서 dual writer나 fallback reader가 실제 불일치를 만들면 그 기능 PR에서
+producer와 consumer를 추적한 뒤 제거한다. 모든 subsystem을 새 Journal로 이전하는
+작업을 선행 조건으로 삼지 않는다.
 
-```text
-MASC operation_id -> agent core run_ref -> agent core node_id / receipt cursor
-```
+핵심 로직은 가능하면 `Raw -> Resolved -> Decision -> Command`의 pure core로 두고,
+filesystem/network/process effect는 바깥 shell에서 실행한다. 유효한 상태 조합은
+곱타입의 boolean 묶음보다 닫힌 합타입으로 표현한다. 이 원칙 역시 기존 기능을
+막는 새 framework를 만들기 위한 이유로 사용하지 않는다.
 
-MASC decides when a Keeper may start, wait, do other work, or wake. agent core reports
-the exact finite run outcome; it does not decide product continuation.
+## 5. 현재 확인된 실제 고장과 수정 순서
 
-“MASC is a read-only agent core execution projection” means only that MASC must not
-invent or rewrite agent core run history. It does not make MASC read-only for its own
-operation journal, Gate decisions, checkpoints, or Keeper lane.
+### 5.1 Dashboard 상태 의미
 
-### 3.3 No duplicate SSOT
+- As-Is: 같은 화면에서 executable, running fiber, configured roster가 같은
+  `실행 중` 또는 `정상` 의미로 섞였다. Gate loading이 fleet health를 가리기도 했다.
+- To-Be: fresh health의 executable, shell의 Keeper fiber, roster-derived running을
+  서로 다른 이름으로 표시한다. backend status와 operator-action 신호를 둘 다 보존하고,
+  action 신호가 없는 non-ok 상태를 숨기거나 주의 항목으로 재해석하지 않는다. 미수집은
+  0이 아니라 unknown으로 표시한다.
 
-The finite agent core run has one simple law:
+### 5.2 Sandbox 설정 전달
 
-```text
-Execution Journal = sole execution writer and recovery SSOT
-Event_bus          = volatile post-commit notification projection
-Raw_trace          = read/export diagnostic projection
-Durable_event      = deleted
-```
+- As-Is: direct/message turn이 TOML로 resolve한 meta를 registry의 raw Local meta로
+  다시 덮어썼다.
+- To-Be: 최신 registry meta에 한 번 읽은 TOML defaults를 overlay한 단일 effective
+  meta를 runtime/tool/receipt까지 전달한다.
 
-The runtime writes each execution fact once to the Journal. Event_bus,
-Raw_trace, logs, metrics, and downstream dashboards derive from committed
-events and cursors. They cannot append competing execution history or
-participate in recovery.
+### 5.3 Docker의 Host 강등
 
-The production cut wires the Journal and deletes the old
-`Durable_event.append` and independent `Raw_trace.record_*` execution-write
-paths in the same change. There is no dual-write comparison interval and no
-compatibility adapter that keeps the old writer alive.
+- As-Is: Docker image preflight 실패 시 Host target으로 바꿔 실행할 수 있었다.
+- To-Be: Local 요청만 Host에서 실행한다. Docker 요청은 Docker target에서 실행하거나
+  구체적인 typed tool failure로 끝난다.
 
-Projection failure cannot relabel, roll back, or hide a Journal commit.
+### 5.4 Hidden reasoning 공개 저장
 
-Across the product boundary:
+- As-Is: provider thinking 원문이 raw trace와 public trajectory/API 경로에 남았다.
+- To-Be: 공개 관측에는 kind, size, redacted 여부만 남긴다. Agent Core가 provider
+  continuation에 필요한 private checkpoint는 이 변경에서 삭제하지 않는다.
 
-- agent core writes finite Agent-run execution history;
-- MASC writes long-lived product operation and Keeper-lane history.
+### 5.5 Queue 정체
 
-An agent core addition is valid only when a generic agent core consumer can use it without
-learning MASC product concepts.
+- As-Is: 현재 live의 일부 pending event는 owner가 operator-paused여서 처리되지 않는다.
+- To-Be: 이는 곧바로 FIFO 구현 결함으로 단정하지 않는다. owner를 실행 가능한
+  상태로 둔 canary에서도 claim/terminal이 유실될 때에만 queue 코드 수정 PR을 만든다.
 
-### 3.4 Lossless recursive execution and canonical feedback
+다음 작업은 고정 architecture stack이나 고정 순서로 진행하지 않는다. queue delivery,
+scheduler occurrence, HITL wake, async/batch/broadcast, verification/fusion,
+Dashboard drill-down 중 live canary로 실제 실패한 경계를 먼저 수정한다. 서로 독립적인
+고장은 병렬 PR로 진행한다.
 
-The finite-run Journal is a typed recursive tree, not a flat list of display
-strings:
+## 6. 작은 PR 원칙
+
+실제 dependency가 있을 때만 stack한다.
 
 ```text
-Agent_run
-└─ Agent_turn
-   ├─ Provider_attempt
-   │  ├─ reasoning / progress / output blocks
-   │  └─ Tool_invocation
-   │     ├─ PreTool
-   │     ├─ Tool_attempt*
-   │     │  └─ child Tool_invocation, Agent_run, or external execution reference
-   │     └─ PostTool
-   └─ next Agent_turn
+sandbox effective meta -> Docker no-host-fallback
+raw trace metadata-only -> public trajectory metadata-only
 ```
 
-Every node has an exact typed identity, parent edge, order, lifecycle state, and
-canonical payload or payload reference. Recursion may nest Agent and Tool
-invocations without flattening. Cross-run shared work is represented by an
-exact reference rather than copying history. Cycles are rejected by exact
-ancestry identity, not by a guessed depth cap. A child invocation or Agent run
-is parented by the exact Tool attempt that created it, never directly by the
-logical Tool invocation; otherwise retries would merge distinct child history.
-
-`PreTool` is committed before the handler effect and contains the canonical
-input plus the typed agent core hook outcome. A MASC adapter records its product Gate
-and admission decision in the referenced MASC operation, not by adding
-MASC-specific fields to the agent core node. A rejected invocation has no Tool attempt
-and commits a typed rejection. An executed invocation commits its exact
-canonical ToolResult or typed failure before any post hook. `PostToolUse` then
-observes every committed terminal result; declared failure additionally runs
-`PostToolUseFailure`. Observer failure is recorded but cannot rewrite the
-ToolResult. The runtime closes the invocation lifecycle after all observers
-settle.
-
-For an asynchronous MASC adapter, the ToolResult closes the finite submission
-invocation with an acceptance receipt; it does not claim that the long-lived
-child operation has completed. Child progress and terminal wake are MASC
-operation events and do not fire a second agent core post-hook lifecycle.
-
-The next provider request is constructed only from committed canonical protocol
-values:
-
-- each committed assistant output block is admitted once;
-- each ToolUse is paired with its exact ToolResult by invocation identity;
-- provider reasoning is replayed only through the selected provider's typed
-  replay contract;
-- stream deltas, progress rows, logs, dashboard text, failed fallback attempts,
-  and abandoned retry output are never converted into conversation history;
-- a failed attempt remains visible in the Journal without becoming model input.
-
-No substring comparison, repeated-text suppression, prose parsing, or
-model-name branch decides what is fed back. If a provider genuinely emits
-identical content twice, the two identified nodes remain distinct. If a
-projection repeats one node, the projection is wrong; it cannot rewrite the
-Journal to conceal the defect.
-
-Cancellation or process interruption cannot delete already committed
-reasoning, progress, ToolUse, ToolResult, or output nodes. Recovery closes or
-resumes open nodes from their exact persisted state and renders an explicit
-cancelled, aborted, unknown, or incomplete outcome. An implicit queue-age,
-turn-count, or elapsed-time watchdog cannot erase the run or replace it with a
-single synthetic error message.
-
-## 4. Deterministic and LLM Boundaries
-
-Deterministic code may enforce facts that are directly provable:
-
-- typed input and schema validity;
-- exact identity, revision, ownership, and one-use consumption;
-- path jail and sandbox confinement;
-- provider/model capability declared by the selected catalog entry;
-- queue claim, append ordering, checksum, cursor, and journal integrity;
-- explicit cancellation and hard provider context capacity.
-
-Meaning judgments belong to a configured LLM:
-
-- whether an external effect should proceed;
-- whether Task evidence satisfies completion;
-- which history is relevant, summarized, remembered, or forgotten;
-- whether Board, Connector, Goal, or Task information should wake a Keeper;
-- whether a sequence of typed attempts is semantically stalled and should be
-  replanned, delegated, switched to another declared runtime, or surfaced for
-  human input;
-- how Fusion, quorum, or Judge-of-Judges results should be synthesized.
-
-Semantic-stall judgment receives the structured recent invocation tree and
-declared outcomes. It is never triggered by repeated substrings, a consecutive
-count, elapsed time, cost, tokens, or turn budget. Its result schedules another
-explicit activity; it does not silently delete the turn or globally Pause/Stop
-the Keeper.
-
-Risk levels, keyword lists, tool names, shell-command inspection, scores,
-consecutive counts, fixed ratios, elapsed age, and arbitrary numeric thresholds
-do not become objective by being encoded in a type.
-
-Cost, tokens, turns, tool rounds, idle turns, and elapsed time are observations.
-They do not authorize Stop, Pause, failure, or fleet-wide admission.
-
-## 5. Gate Contract
-
-Gate applies to external-effect dispatch, not every internal state transition:
-
-```text
-Always_allow | Auto_judge | Manual
-```
-
-- Input contains exact Keeper, operation, invocation, normalized typed payload,
-  origin, and causal context known by the producer.
-- An absent optional fact is persisted as exact absence; it is never
-  reconstructed from names, command strings, paths, or later logs.
-- Always Allowed matches an exact persisted scope or exact request. It never
-  expands by similarity, prefix, tool family, vendor, or inferred risk.
-- Auto Judge sends the complete persisted envelope to the explicitly configured
-  LLM runtime. Local classification cannot pre-empt or reinterpret the verdict.
-- Manual persists pending work and returns control to the owner lane.
-- Resolution creates an exact one-shot grant and wakes only the owner Keeper.
-- Duplicate exact IDs are a consistency concern. A fleet-wide count cap is not.
-- Storage, runtime, persistence, and recovery failures are typed and observable.
-- Saving a mode and recovering old work are separate results. A successful save
-  remains successful even if recovery reports a typed partial failure.
-- “Recovery orchestration completed” must not be presented as “every
-  asynchronous Judge finished.” Per-item start and terminal states remain
-  explicit.
-
-Always Allowed, Auto Judge, and Manual are alternatives, not a risk hierarchy.
-Objective executor invariants remain separate from all three.
-
-## 6. Lane-per-Keeper Contract
-
-Each Keeper owns one ordered event/revision timeline and one durable runnable
-queue. Linear means a total order of state transitions, not completion order.
-
-- Any authenticated producer may append exact work for an owner Keeper.
-- Only that Keeper's drain may claim and consume it.
-- A claim carries owner, operation, revision, and fencing epoch.
-- A stale worker cannot commit after a newer owner epoch.
-- Checkpoint updates use compare-and-swap or a typed revision conflict.
-- A busy Keeper keeps its current runnable work and queues new input.
-- A quick connector acknowledgement is itself a durable outbox effect with
-  identity and receipt.
-- Waiting may retain a suspended fiber as an optimization, but that fiber is
-  never recovery truth and retains no global worker, runnable slot, or lane
-  claim.
-- New runnable work may proceed while another operation waits.
-- An exact wake requeues the continuation; duplicate wakes converge on one
-  revision.
-- Corruption or failure is isolated to the owner lane and never stops unrelated
-  Keepers.
-
-Suggested durable operation states include:
-
-```text
-Requested -> Claimed -> Running
-Requested -> Gate_waiting -> Claimed
-Running -> Waiting_child | Waiting_external | Compacting
-Running -> Intent_committed -> Side_effect_started
-Side_effect_started -> Receipt_committed | Outcome_unknown
-* -> Completed | Failed | Cancelled | Recovery_conflict
-```
-
-The exact algebra may be refined, but `Outcome_unknown` cannot be collapsed into
-success, failure, or automatic retry.
-
-## 7. Side-Effect and Restart Law
-
-General external effects cannot be promised exactly once.
-
-Before dispatch, persist a stable intent containing owner epoch, operation ID,
-invocation ID, exact payload digest, and any downstream idempotency key. After
-dispatch, persist the exact receipt before projecting success.
-
-- If the provider supports idempotency, replay uses the same stable key.
-- If a committed receipt exists, do not execute again.
-- If an attempt exists without a provable receipt, record `Outcome_unknown`.
-- A non-idempotent unknown enters lane-local reconciliation or HITL.
-- Blind resume is forbidden.
-- Parent and child operations retain exact join and cancellation edges.
-
-agent core owns the run-local attempt/receipt; MASC owns the product intent,
-continuation, and decision about what to do with the reported outcome.
-
-## 8. Asynchronous Any-as-a-Tool
-
-Tool, Model, LLM Agent, Keeper, Fusion, and heterogeneous collections use the
-same parent/child operation law.
-
-`Any`, `Any[]`, and `AsyncAny[]` are product shorthand, not untyped JSON types
-or public agent core coordinator concepts:
-
-- `Any` is one existentially packed typed invocation with its adapter witness;
-- programmatic `Any[]` is an immutable collection with explicit serial or
-  concurrent composition; `[]` has the exact empty-result identity;
-- `AsyncAny[]` is concurrent submission of that same collection with durable
-  handles, not a second payload schema or execution writer.
-
-A provider-visible collection Tool requires at least one call because an empty
-wire request has no invocation intent. That schema fact does not become a
-programmatic collection-size gate.
-
-The implementation may name these concepts `Invocable`, `Invocation`, or
-`Many`. Correctness comes from the typed request/result witness, not the word
-“Any”. A wire discriminator is resolved exactly once at the decode boundary;
-runtime dispatch cannot use substring matching or free-form type names.
-
-One invocation or one serial/concurrent collection may itself be exposed as a
-Tool. Recursive composition uses the same tree: the composite has one outer
-`PreTool`/`PostTool` boundary and every child retains its own nested boundary.
-Neither the execution writer nor the dashboard duplicates the child events as
-flat outer events.
-
-- agent core owns generic Tool, Model-call, finite-Agent adapter mechanics, and the
-  typed asynchronous acceptance/reconciliation/cancellation/observation
-  façade.
-- MASC owns Keeper, Fusion, and other product adapters, the injected
-  long-lived operation backend namespace, worker and wake policy, continuation,
-  authorization, and application switch.
-- An adapter cannot make agent core import or encode Keeper, Fusion, Board, Goal,
-  Scheduler, Connector, or MASC variants.
-- A parent submits immutable child requests and stores exact child references.
-- Children may run concurrently or on their own Keeper lanes.
-- Parent waiting releases its claim and later joins by exact continuation.
-- Results use a versioned typed envelope with value, error, artifact, runtime
-  attempts, provenance, and terminal state.
-- Collection results preserve declared input order and an all-settled domain
-  outcome for every child. A declared child failure does not cancel siblings.
-  Infrastructure failure cancels unfinished structural siblings, preserves
-  every committed partial outcome, and never affects unrelated lanes.
-- Asynchronous submission atomically commits the submission and every child
-  intent, or commits none. It returns one ordered receipt of exact operation
-  handles. Acceptance is not completion; ambiguous publication reconciles by
-  the same submission identity and request digest.
-- A terminal child commit appends one exact continuation event for the owner
-  lane. Wake notification may coalesce by the persisted cursor/revision, but no
-  terminal event is dropped. Both declared success and declared failure make
-  the owner runnable.
-- One declared child failure does not stop siblings, quorum, parent, or
-  unrelated lanes. Infrastructure failure remains an explicit outer result.
-- Cancellation, orphan detection, cycles, partial failure, and quorum are
-  explicit graph semantics.
-- Scale changes queue depth and observed latency, not correctness rules.
-
-There is no semantic branch or hidden admission cap based on collection
-cardinality. Typed backpressure may report unavailable capacity; it cannot
-silently drop children, convert ambiguous admission into success, or become a
-budget-derived Stop/Pause gate.
-
-## 9. MASC-Owned LLM Compaction
-
-agent core has no reducer, automatic truncation, compaction policy, or overflow retry.
-agent core returns typed capacity/overflow facts. MASC queues compaction in the owner
-lane and invokes a configured model.
-
-- Compaction is a durable operation and releases the owner claim while waiting.
-- A plan binds source checkpoint generation, transcript digest, unit span
-  digest, and protected anchors.
-- Apply uses compare-and-swap; a stale plan is rejected without changing source.
-- The LLM receives canonical message/unit values, not flattened display prose.
-- Open ToolUse cycles, active ToolProgress, unresolved effects, artifacts, and
-  continuations remain exact.
-- Closed terminal history may be reduced only after exact durable joins.
-- Output is reinjected as model context, not written as Task/Goal/Board truth.
-- Before/After evidence stores source, plan, output, runtime attempts,
-  checkpoint, anchors, and reinjection receipt.
-
-Capacity is computed from the complete provider request: system prompt, tools,
-memory, multimodal blocks, provider framing, and reserved output. Use
-provider-native token counting when available; otherwise preserve typed
-`Unknown` rather than guessing from characters.
-
-A fit claim is bound to one exact pending source and the same immutable request
-artifact that agent core later dispatches after applying its hooks and model-input
-projection. MASC must not reconstruct that provider request. A manual
-compaction with no pending source may record semantic reduction, but it cannot
-claim that an unknown future turn fits. Source-bound manual and overflow work
-must remeasure after compaction because the request artifact changed.
-
-If one compaction request is itself too large:
-
-1. try the next declared compaction runtime candidate;
-2. create capacity-safe contiguous waves from typed structural units;
-3. preserve immutable anchors and exact source-span provenance between waves;
-4. externalize one indivisible payload as a content-addressed Artifact;
-5. keep the original source and record typed rejection if all candidates fail.
-
-No fixed importance score, arbitrary ratio, marker string, pair repair, or
-silent drop is permitted.
-
-## 10. Memory and Artifact Boundary
-
-Raw large ToolResult and multimodal payloads are content-addressed Artifacts
-with digest, length, media type, provenance, and access status.
-
-Memory is deliberate LLM-authored durable knowledge that may reference
-Artifacts. Relevance, consolidation, and forgetting are LLM decisions. A
-deterministic fallback summary cannot become semantic Memory.
-
-Reinjection records exact Keeper, source trace/turn, block digest, fact IDs, and
-checkpoint generation. Volatile echo suppression and “latest N” selection are
-not correctness contracts.
-
-## 11. Scheduler, Connector, and Fusion
-
-All producers append the same durable owner-lane operation.
-
-- Connector identity includes connector, space/server, channel, participant,
-  inbound event, provenance, and authentication context.
-- Inbound dedupe, cursor, and ordering are explicit; spaces remain isolated.
-- Outbound work uses a durable outbox, idempotency where supported, and receipt.
-- Scheduler occurrences record due, claimed, started, skipped, completed,
-  cancelled, and rescheduled transitions.
-- iCalendar compatibility preserves UID, RECURRENCE-ID, RRULE, RDATE, EXDATE,
-  timezone/DST, update/cancel, catch-up, and misfire semantics.
-- Every occurrence passes its configured Gate; a recurring schedule is not an
-  infinite grant.
-- Fusion and Judge-of-Judges submit typed children and join asynchronously.
-
-## 12. Runtime and Dashboard
-
-Runtime selects Text, Voice, Image, Audio, Judge, and compaction models from
-typed provider/model catalogs. Fallback follows explicit candidate order and
-declared capability, never names, URLs, or vendor strings.
-
-MASC owns the application-lifetime switch and the single host CPU-allocation
-policy. It creates and shares one opaque agent core execution runtime with an explicit
-allocation; agent core encapsulates its internal pool and exposes no raw pool or
-allocation heuristic. Journal codec, recovery scan, and projection work cannot
-create a pool per lane/event or silently fall back onto the Keeper or server
-scheduling domain. Resource exhaustion is a typed lane-local result, not a
-fleet stop or a reason to discard committed progress.
-
-Dashboard chat preserves causal interleaving of thinking, output, ToolUse,
-progress, ToolResult, multimodal blocks, child operations, compaction, and
-reinjection. It shows product operation identity and referenced agent core run/node
-identity without merging their writers.
-
-The dashboard recursively projects the committed tree. It may fold nodes for
-navigation, but it cannot flatten parent/child boundaries, merge identical
-content, reorder by arrival time, synthesize a missing ToolResult, or replace
-the canonical payload with a summary. A gap is rendered as an explicit gap with
-the last durable cursor and recovered through the SSOT reader.
-
-Observability failure never changes durable truth. Journal and receipt commits
-precede EventBus, SSE, log, metric, and dashboard projections.
-
-## 13. Required Behavioral Proofs
-
-| Proof | Required behavior |
-|---|---|
-| lane isolation | Keeper A waits while Keeper B and later A work continue |
-| owner fencing | a stale drain cannot mutate a newer checkpoint revision |
-| HITL one-shot | pending is nonblocking; exact grant wakes one lane once |
-| Auto Judge context | restart delivers the exact persisted request to the LLM |
-| side-effect uncertainty | attempt without receipt becomes `Outcome_unknown` |
-| canonical feedback | failed attempts and projection text never re-enter model history |
-| recursive Journal | nested Agent/Tool/PreTool/PostTool nodes round-trip without flattening |
-| async collection | atomic admission returns ordered handles; every terminal child event reaches its owner |
-| interrupted run | cancellation preserves committed partial nodes and explicit terminal state |
-| server isolation | journal work cannot stall the Keeper or server scheduling domain |
-| restart recovery | durable operation and finite agent core run references reconcile |
-| active compaction | ToolUse/progress/unresolved effect anchors remain exact |
-| oversized compaction | fallback/waves avoid arbitrary truncation |
-| reinjection | exact receipt proves which compacted block entered which turn |
-| producer convergence | Scheduler/Connector/Fusion converge on owner revisions |
-| Task verification | schema-valid LLM evidence decides completion |
-| dashboard causality | UI joins operation, run, progress, compact, and finish |
-| legacy absence | forbidden source, tests, env knobs, and current docs are gone |
-
-Small immutable fakes are sufficient for semantic tests. Large-cardinality
-benchmarks are useful for capacity observation but are not correctness gates.
-
-## 14. Hard-Cut Rule
-
-Legacy behavior is not a compatibility target. Once its replacement is proved,
-delete the parser, adapter, fallback, environment variable, fixture,
-implementation-shape test, and contradictory current documentation.
-
-Do not create a compatibility shim merely to keep a stack green. Historical
-audits may remain only when clearly marked as history.
-
-## 15. Dependency Order
-
-Keep each PR single-contract and independently reviewable:
-
-1. finish the agent core finite-run single-writer hard cut without public complexity;
-2. release agent core and pin MASC exactly;
-3. compose MASC operation identity with agent core run/node/receipt identity;
-4. make per-owner progress and continuation durable;
-5. implement owner-only wake, fencing, and restart reconciliation;
-6. make compaction a durable lane operation with source CAS;
-7. hard-cut Artifact/Memory and exact reinjection receipts;
-8. adapt Scheduler, Connector, Fusion, and typed Any-as-a-Tool composition;
-9. expose lossless dashboard projections;
-10. prove mixed Lane/Gate/compaction/restart behavior;
-11. perform the final implementation, test, environment, and documentation
-    purge.
-
-## 16. Definition of Done
-
-The Goal is done only when every evidence gate in §2 and every behavioral proof
-in §13 passes on current source, authoritative CI, and applicable live runtime,
-with the §14 hard cut complete. A private foundation or Draft PR is progress,
-not completion.
+Dashboard truth, stream reducer 등 독립 수정은 main에서 별도 PR로 둔다. 공통 evidence
+framework, runtime-role policy, unused execution-store plumbing처럼 현재 기능을 직접
+고치지 않는 PR은 닫거나 보류한다.
+
+각 PR은 다음을 지킨다.
+
+- 하나의 재현 가능한 As-Is와 하나의 To-Be를 가진다.
+- 기능을 막는 새 admission 조건을 추가하지 않는다.
+- Runtime 이름이나 사용자 로컬 설정을 production OCaml variant로 만들지 않는다.
+- 빠르게 Draft로 발행하고 긴 CI를 기다리지 않고 다음 독립 기능으로 이동한다.
+- 현재 단계에서는 `git diff --check`, parser/typecheck 등 짧은 검사만 수행한다.
+- local Dune build와 대규모 테스트 추가는 뒤의 검증 단계에서 한다.
+- Dashboard도 reducer, interaction, reconnect를 포함한 실제 UI 기능 고장만 수정한다.
+
+## 7. Live 실행 경계
+
+- live 확인은 `/health?full=1`의 effective base/root를 먼저 확인한다.
+- canary Board/Task/Goal에는 고유 prefix를 사용한다.
+- Git/commit/PR 효과가 필요한 도구 검증은 새 private canary repository에서만 한다.
+- 기존 운영 객체와 credential은 별도 승인 없이 변경하지 않는다. 격리된 canary
+  Keeper와 canary config는 이 검증 범위 안에서 만들고 변경할 수 있다.
+- source, PR, CI, merged, deployed, live 결과는 서로 다른 상태로 보고한다.
+- screenshot은 보조 증거이며 API/receipt와 다른 사실을 만들지 않는다.

--- a/docs/KEEPER-FULL-FEATURE-GOAL.md
+++ b/docs/KEEPER-FULL-FEATURE-GOAL.md
@@ -24,7 +24,9 @@ Runtime의 고정 role이 아니다. 실제 Lane 실행이 실패하면 그 실�
 기능별 완료 기준은 그 기능의 사용자 관점 동작이다.
 
 1. 요청이 실제 실행 경계까지 도달한다.
-2. 의도한 결과를 내거나 사용자가 확인할 수 있는 구체적인 실패로 끝난다.
+2. 의도한 결과, 사용자가 확인할 수 있는 구체적인 실패, 또는 효과가 실행됐을
+   가능성은 있지만 결과를 증명할 수 없는 명시적 `Effect_outcome_unknown` /
+   `Indeterminate` 상태로 끝난다.
 3. 해당 기능이 원래 제공하는 상태/receipt/UI가 있다면 실제 결과와 모순되지 않는다.
 
 기능이 wait, async handle, queue, scheduler 또는 process restart를 포함하면 같은
@@ -34,6 +36,12 @@ optional telemetry, 증거 문서의 존재를 제품 실행 조건으로 만들
 관측 인프라가 없거나 오래됐다는 이유만으로 정상 기능을 막지 않는다. 단, 요청한
 실행 의미가 바뀌는 경우에는 명시적으로 실패해야 한다. 예를 들어 Docker 실행 요청을
 Host 실행으로 몰래 바꾸는 것은 허용하지 않는다.
+
+외부 효과의 결과가 indeterminate이면 같은 효과를 재실행, 재시도 또는 보상하지
+않는다. 대상 상태를 별도로 확인하거나 operator가 명시적으로 결론낼 때까지 unknown을
+보존한다. 실행 결과와 재시도 의미의 권위는 이 계획 문서가 아니라
+`lib/tool_types/tool_result.mli`와 `lib/keeper/keeper_gate_replay.mli`의 typed source
+계약이다.
 
 성능·효율 최적화는 baseline 기능이 동작한 뒤 별도 PR로 다룬다. 최적화가 없어도
 기능이 정확히 동작한다면 admission gate로 만들지 않는다.
@@ -47,8 +55,9 @@ Host 실행으로 몰래 바꾸는 것은 허용하지 않는다.
   도달하는지 추적한다.
 - B — focused scenario: 성공, 명시적 실패, 재개/중복 중 해당 기능에 필요한 경우만
   작은 fixture로 확인한다.
-- C — live scenario: 고유 canary ID로 실제 `~/me/.masc`에서 실행하고 API, receipt,
-  Dashboard를 같은 ID로 대조한다.
+- C — live scenario: 먼저 `/health?full=1`에서 `effective_base_path`와
+  `effective_masc_root`를 읽고, 확인된 effective root에서 고유 canary ID로 실행한 뒤
+  API, receipt, Dashboard를 같은 ID로 대조한다.
 
 | 기능 | source 조사 예시 | focused 확인 예시 | live 실행 예시 |
 |---|---|---|---|
@@ -141,8 +150,9 @@ framework, runtime-role policy, unused execution-store plumbing처럼 현재 기
 - 기능을 막는 새 admission 조건을 추가하지 않는다.
 - Runtime 이름이나 사용자 로컬 설정을 production OCaml variant로 만들지 않는다.
 - 빠르게 Draft로 발행하고 긴 CI를 기다리지 않고 다음 독립 기능으로 이동한다.
-- 현재 단계에서는 `git diff --check`, parser/typecheck 등 짧은 검사만 수행한다.
-- local Dune build와 대규모 테스트 추가는 뒤의 검증 단계에서 한다.
+- push 전 `git diff --check`, parser/format, 필요한 frontend typecheck와 focused test처럼
+  빠른 검사를 수행한다. 로컬 Dune build는 실행하지 않고 OCaml build와 넓은 동작 검증은
+  exact-head CI에서 판정한다.
 - Dashboard도 reducer, interaction, reconnect를 포함한 실제 UI 기능 고장만 수정한다.
 
 ## 7. Live 실행 경계
@@ -151,6 +161,7 @@ framework, runtime-role policy, unused execution-store plumbing처럼 현재 기
 - canary Board/Task/Goal에는 고유 prefix를 사용한다.
 - Git/commit/PR 효과가 필요한 도구 검증은 새 private canary repository에서만 한다.
 - 기존 운영 객체와 credential은 별도 승인 없이 변경하지 않는다. 격리된 canary
-  Keeper와 canary config는 이 검증 범위 안에서 만들고 변경할 수 있다.
+  Keeper와 canary config를 만들거나 변경하는 것도 operator의 명시적 승인을 받은
+  범위에서만 한다. 이 계획 자체는 live mutation 권한을 부여하지 않는다.
 - source, PR, CI, merged, deployed, live 결과는 서로 다른 상태로 보고한다.
 - screenshot은 보조 증거이며 API/receipt와 다른 사실을 만들지 않는다.

--- a/docs/KEEPER-FULL-FEATURE-GOAL.md
+++ b/docs/KEEPER-FULL-FEATURE-GOAL.md
@@ -150,10 +150,9 @@ framework, runtime-role policy, unused execution-store plumbing처럼 현재 기
 - 기능을 막는 새 admission 조건을 추가하지 않는다.
 - Runtime 이름이나 사용자 로컬 설정을 production OCaml variant로 만들지 않는다.
 - 빠르게 Draft로 발행하고 긴 CI를 기다리지 않고 다음 독립 기능으로 이동한다.
-- push 전 `git diff --check`, parser/format, 필요한 frontend typecheck와 focused test를
-  수행한다. OCaml 코드나 공개 타입을 바꾸면 관련 Dune build와 focused test를
-  `scripts/dune-local.sh`로 실행하고, 넓은 경계를 바꾸면 영향 범위에 비례한 저장소 전체
-  검증도 수행한다. exact-head CI는 이 로컬 검증을 대체하지 않는 최종 판정이다.
+- push 전 `git diff --check`, parser/format, 필요한 frontend typecheck와 focused test처럼
+  빠른 검사를 수행한다. 로컬 Dune build는 실행하지 않고 OCaml build와 넓은 동작 검증은
+  exact-head CI에서 판정한다.
 - Dashboard도 reducer, interaction, reconnect를 포함한 실제 UI 기능 고장만 수정한다.
 
 ## 7. Live 실행 경계

--- a/docs/rfc/RFC-0099-session-lifecycle-typed-events.md
+++ b/docs/rfc/RFC-0099-session-lifecycle-typed-events.md
@@ -17,8 +17,9 @@ Status: Active (PR-2 #15810 & PR-3 #15853 merged; PR-4/5/6 pending)
 Author: jeong-sik (vincent)
 Date: 2026-05-17
 Scope: SSE / WS / gRPC / WebRTC session lifecycle uniformity at the transport layer
-Out of scope: execution-boundary ownership (now covered by
-`docs/KEEPER-FULL-FEATURE-GOAL.md`), Streamable HTTP migration
+Out of scope: execution-boundary ownership (defined by the typed source
+contracts in `lib/tool_types/tool_result.mli` and
+`lib/keeper/keeper_gate_replay.mli`), Streamable HTTP migration
 (IMPROVE-02, awaits in-flight #15722/#15725), FD accounting (IMPROVE-03)
 Series: **IMPROVE-05** of the masc + oas improvement series. Sibling RFCs: [[RFC-0098]] (typed envelope, IMPROVE-01).
 
@@ -48,10 +49,12 @@ ALB / Cloudflare-style middleboxes drop idle connections at ~60s. Without a *uni
 
 ## 2. Non-goals
 
-- **Execution-boundary redesign.** The current authority is
-  `docs/KEEPER-FULL-FEATURE-GOAL.md`; this RFC is about *transport-edge*
+- **Execution-boundary redesign.** The current authority is the typed source
+  contract in `lib/tool_types/tool_result.mli` and
+  `lib/keeper/keeper_gate_replay.mli`; this RFC is about *transport-edge*
   session lifecycle (open/upgrade/resume/evict/close), not provider, caller,
-  or tool execution boundaries.
+  or tool execution boundaries. `docs/KEEPER-FULL-FEATURE-GOAL.md` is an
+  implementation and live-verification plan, not an authority boundary.
 - **Streamable HTTP migration.** [[RFC-0098]] documents IMPROVE-02 (Streamable HTTP as default) which awaits in-flight PRs #15722/#15725. This RFC operates on the current SSE/WS/gRPC/WebRTC stack regardless of that migration.
 - **FD accounting.** WS-C RFC (IMPROVE-03) handles FD ceiling / pool accounting. This RFC's `Backpressure_shed` close frames will *consume* FD-pressure signals from that RFC once it lands.
 - **Adding a fifth transport.** Coverage of the existing four is the goal.
@@ -203,4 +206,6 @@ PR-2 is **wire-inert** (Event_bus only). PR-3 introduces the first client-visibl
 - [WebSocket Close Codes — RFC 6455 §7.4.2](https://www.rfc-editor.org/rfc/rfc6455#section-7.4.2)
 - [gRPC Status Codes](https://grpc.io/docs/guides/status-codes/)
 - [Server-Sent Events — MDN](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events)
-- `docs/KEEPER-FULL-FEATURE-GOAL.md` — current execution-boundary authority
+- `docs/KEEPER-FULL-FEATURE-GOAL.md` — feature implementation and live-verification plan
+- `lib/tool_types/tool_result.mli` — typed execution result and effect-disposition contract
+- `lib/keeper/keeper_gate_replay.mli` — durable replay and indeterminate-effect contract

--- a/docs/rfc/RFC-0373-keeper-turn-lane-admission.md
+++ b/docs/rfc/RFC-0373-keeper-turn-lane-admission.md
@@ -97,7 +97,7 @@ a policy before knowing what the exclusion protects would be guessing.
 
 ## Measurements
 
-Whole-day log, 2026-08-12, 7 keepers (`~/me/.masc/logs/system_log_2026-08-12.jsonl`):
+Whole-day log, 2026-08-12, 7 keepers (`<base-path>/.masc/logs/system_log_2026-08-12.jsonl`):
 
 | | |
 |---|---|

--- a/scripts/check-ssot.sh
+++ b/scripts/check-ssot.sh
@@ -101,10 +101,9 @@ check_rule "R5-health-path" 0 \
 # SSOT-R6 — no home-anchored MASC runtime root. Runtime state must resolve
 # from an explicit base path and then append .masc.
 #
-# The baseline count of 1 is intentional: the match is in documentation that
-# explicitly warn against bare home-anchored .masc roots (e.g. tilde or
-# HOME env expansion). See KEEPER-USER-MANUAL.md. No code or script uses such a root.
-check_rule "R6-home-masc-root" 1 \
+# Bare home-anchored .masc roots are fully purged. Keep the ratchet at zero so
+# neither code nor documentation can silently restore one.
+check_rule "R6-home-masc-root" 0 \
   "<base-path>/.masc with explicit MASC_BASE_PATH or --base-path" \
   '(\$HOME|\$\{HOME[^}]*\}|~)/[^[:space:]`'\''"]*\.masc([/[:space:]`'\''".,)]|$)' \
   '' \

--- a/scripts/check-ssot.sh
+++ b/scripts/check-ssot.sh
@@ -101,9 +101,10 @@ check_rule "R5-health-path" 0 \
 # SSOT-R6 — no home-anchored MASC runtime root. Runtime state must resolve
 # from an explicit base path and then append .masc.
 #
-# Bare home-anchored .masc roots are fully purged. Keep the ratchet at zero so
-# neither code nor documentation can silently restore one.
-check_rule "R6-home-masc-root" 0 \
+# The baseline count of 1 is intentional: the match is in documentation that
+# explicitly warn against bare home-anchored .masc roots (e.g. tilde or
+# HOME env expansion). See KEEPER-USER-MANUAL.md. No code or script uses such a root.
+check_rule "R6-home-masc-root" 1 \
   "<base-path>/.masc with explicit MASC_BASE_PATH or --base-path" \
   '(\$HOME|\$\{HOME[^}]*\}|~)/[^[:space:]`'\''"]*\.masc([/[:space:]`'\''".,)]|$)' \
   '' \


### PR DESCRIPTION
## What changed

- Replaced the 551-line framework/gate-first Keeper contract with a 156-line feature-first implementation plan.
- Treats configured runtimes as user-specific live test resources, never production role policy.
- Defines lanes as assignable execution paths and removes runtime-role admission.
- Makes live feature execution the starting point; source tracing and fixtures are optional tools after a concrete failure.
- Records the four currently reproduced As-Is/To-Be fixes and the small-PR boundaries.

## Why

The previous document overfit one local runtime inventory and turned observability architecture into product admission gates. The current work is to make existing Keeper features actually execute end-to-end.

## Validation

- `git diff --check`
- adversarial source/document review
- documentation/script-only; `git diff --check`, `bash -n scripts/check-ssot.sh`, SSOT ratchets (R6 0/0), and doc-truth checks pass


## Latest review absorption

- exact head: `4abca4477d14ea0575ccf444a54310d6b7528e8d`
- restored proportional local Dune validation for OCaml/public type changes
- restored the truthful zero baseline for home-anchored `.masc` roots
