### PR TITLE
fix(keeper): reconcile reflected pauses into registry FSM

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -223,17 +223,27 @@ let set_keeper_paused_state ~agent_name paused =
           only reason available here is a synthesized [Operator_paused]. Applying
           it to a lane that already carries a classified latch relabels a
           terminal failure as an operator pause -- every heartbeat cycle, so the
-          real reason never survives. Nothing to reconcile: skip (#28397).
+          real reason never survives. Skip the durable owner command, but still
+          reconcile a stale registry phase with the existing pause bit (#28397).
 
           A paused lane with no latched reason is left alone by this guard: the
           contract calls that a fail-closed unclassified state, and deciding what
           it should become is a separate question from not clobbering a reason
           that exists. *)
        if paused && entry.meta.paused && Option.is_some entry.meta.latched_reason
-       then
+       then (
          Log.Keeper.debug
            "directive pause: %s already latched, leaving its reason intact"
-           entry.name
+           entry.name;
+         if
+           Keeper_state_machine.can_transition
+             ~from_phase:entry.phase
+             ~to_phase:Keeper_state_machine.Paused
+         then
+           Keeper_registry.dispatch_event_unit
+             ~base_path:entry.base_path
+             entry.name
+             Keeper_state_machine.Operator_pause)
        else if (not paused) && transcript_corruption_reset_required entry.meta
        then (
           Otel_metric_store.inc_counter

--- a/test/test_keeper_latched_reason_wiring.ml
+++ b/test/test_keeper_latched_reason_wiring.ml
@@ -245,6 +245,54 @@ let test_pause_directive_leaves_an_existing_latch_intact () =
            (latched_reason_wire entry.meta)
        | None -> fail "expected registered keeper after pause directive")
 
+let test_reflected_operator_pause_reconciles_registry_phase () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio.Switch.run @@ fun sw ->
+  let base_path = Masc_test_deps.setup_test_workspace () in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_registry.For_testing.clear ();
+      Masc_test_deps.cleanup_test_workspace base_path)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_path in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       let keeper_name = "reflected-operator-pause" in
+       let meta =
+         { (make_meta keeper_name) with
+           paused = true
+         ; latched_reason =
+             Some
+               (Keeper_latched_reason.Operator_paused
+                  { operator_actor = Keeper_latched_reason.operator_actor_grpc_directive })
+         }
+       in
+       Keeper_meta_store.replace_snapshot config meta |> Result.get_ok;
+       Keeper_owner_registry.install_from_store
+         ~sw
+         ~operation_runner:None
+         ~on_turn_slot_released:None
+         config
+       |> Result.get_ok
+       |> ignore;
+       Keeper_registry.For_testing.clear ();
+       ignore (Keeper_registry.For_testing.register ~base_path:config.base_path keeper_name meta);
+       Keeper_keepalive.process_directive ~agent_name:keeper_name Keeper_directive.Pause;
+       match Keeper_registry.get ~base_path:config.base_path keeper_name with
+       | Some entry ->
+         check
+           string
+           "reflected pause reconciles the registry phase"
+           "paused"
+           (Keeper_state_machine.phase_to_string entry.phase);
+         check
+           (option string)
+           "reflected pause preserves the durable latch"
+           (Some wire_grpc_directive)
+           (latched_reason_wire entry.meta)
+       | None -> fail "expected registered keeper after reflected pause")
+
 let test_keeper_down_retain_records_reason () =
   let retained =
     apply_reducer_command
@@ -317,5 +365,7 @@ let () =
             test_dead_tombstone_final_meta_records_reason
         ; test_case "reflected pause leaves an existing latch intact" `Quick
             test_pause_directive_leaves_an_existing_latch_intact
+        ; test_case "reflected operator pause reconciles registry phase" `Quick
+            test_reflected_operator_pause_reconciles_registry_phase
         ] )
     ]


### PR DESCRIPTION
## What changed

- Preserve an existing durable pause latch when a reflected `Pause` directive arrives.
- If the registry FSM can transition to `Paused`, dispatch only `Operator_pause` so the registry phase catches up without rewriting the latch reason.
- Add a regression for `meta.paused=true` plus an operator latch while the registry phase is still `Running`.

## Root cause

The #28397 latch-preservation guard skipped the entire pause path when durable metadata was already paused and classified. That correctly avoided replacing terminal reasons with a synthesized operator reason, but it also skipped the registry FSM transition. A lane could therefore remain `Running` in the registry while durable metadata said `paused=true`; `Resume_owner` then rejected it because it requires a paused registry lane.

## Impact

A reflected pause now repairs that split state while retaining the original durable reason. No new gate, persistence write, API, or resume bypass is introduced. Phases that cannot legally transition to `Paused` are left unchanged.

## Validation

- `dune exec ./test/test_keeper_latched_reason_wiring.exe` — 8 tests passed
- `dune exec ./test/test_keeper_paused_work_cancellation_transaction.exe` — 10 tests passed
- `dune exec ./test/test_keeper_state_machine.exe` — 105 tests passed
- `dune build lib/masc.cmxa` — passed
- `git diff --check` — passed

Additional sweep: `test_keeper_keepalive_helpers.exe` passed 20/21 tests. Its first `current_task_reconciliation` case failed before reaching the pause path because the fixture had no owner inventory installed (`Keeper owner inventory is not installed`). This PR does not alter that unrelated path.