### PR TITLE
fix(probe): release the tool description's precondition in the default prompt

### DIFF
--- a/bin/keeper_capability_probe_cli.ml
+++ b/bin/keeper_capability_probe_cli.ml
@@ -32,9 +32,23 @@ projected is reported and never dispatched: spending a turn on it would
 measure the projection policy, not the runtime.
 |}
 
+(* The second sentence exists because tool descriptions carry workflow
+   preconditions and the model obeys them over a vaguer prompt. [masc_board_vote]
+   reads "only after the post_id is visible from ... masc_board_list", so a
+   compliant model calls masc_board_list instead and the probe scores a miss --
+   35% of board-write attempts across the two deepseek runtimes.
+
+   Nothing here is executed: [probe_invocation] reads the ToolUse block's name
+   and discards the arguments, so an invented id measures the same thing a real
+   one does. Saying so is the whole fix; the earlier framing of this as a missing
+   precondition-resolution step assumed a dispatch that does not happen
+   (masc#28475). *)
 let default_prompt =
-  "Call the tool named {tool} exactly once, with any arguments that satisfy \
-   its schema. Reply with the tool call only — no explanation, no preamble."
+  "Call the tool named {tool} exactly once. Invent any argument values you need, \
+   including ids that look real — this is a capability check and the call is not \
+   executed, so you do not need to look anything up first, even if the tool's \
+   description says to. Reply with the tool call only — no explanation, no \
+   preamble."
 
 type config =
   { runtimes : string list


### PR DESCRIPTION
## 무엇

프로브의 기본 프롬프트가 도구 설명의 workflow 선행조건에 지고 있었다. 한 문장을 추가해 그 지시를 명시적으로 해제한다.

## 왜

`masc_board_vote` 의 투영된 설명:

> Vote on one existing board post by exact post_id. Use ... **only after the post_id is visible from board activity, masc_board_list, masc_board_search, or masc_board_post_get.**

기존 프롬프트는 *"with any arguments that satisfy its schema"* 였다. 둘 중 더 구체적인 쪽(도구 설명)을 모델이 따라 `masc_board_list` 를 대신 호출했고, 프로브는 그걸 미스로 채점했다. **도구 표면에 순종한 모델이 낮은 점수를 받는, 부호가 뒤집힌 계측이다.**

도구별 성공률이 이 축으로 정확히 갈렸다 (도구당 32시도):

| 도구 | 설명에 선행조건 | invoked |
|---|---|---|
| `keeper_tools_list` · `masc_add_task` · `masc_goal_upsert` | 없음 | 32/32 |
| `masc_board_post` | 없음 | 31/32 |
| `masc_board_comment` | **있음** | 30/32 |
| `masc_board_vote` | **있음** | 28/32 |

읽기/쓰기 축이 아니다 — `masc_add_task`·`masc_goal_upsert` 는 쓰기인데 무결점이다.

## 인자는 애초에 필요 없었다

`probe_invocation` 은 도구를 **실행하지 않는다**. 응답의 ToolUse 블록에서 이름만 꺼내고(`keeper_capability_probe.ml:171`) 인자는 버린다. 지어낸 id 가 진짜 id 와 정확히 같은 것을 측정한다.

## 측정

같은 셀(deepseek 2 런타임 × board_comment/vote):

```
old prompt                   n=40  substituted=14  (35%)
old prompt + real post_id    n=32  substituted= 0  ( 0%)
new prompt, no post_id       n=24  substituted= 0  ( 0%)

Fisher exact (old vs new): p = 0.0005
```

가운데 arm 이 대조군이다. **진짜 id 를 공급한 것과 "찾아볼 필요 없다"고 말한 것이 같은 결과**를 낸다 — id 의 유효성은 변수가 아니었다.

## 이슈 원안을 대체한다

#28475 는 원래 "도구 설명이 다른 도구를 선행조건으로 지목하면 프로브가 그걸 먼저 호출해 id 를 얻는다"를 제안했다. 그 안은 두 가지가 틀렸다:

1. **디스패치를 전제한다.** 프로브는 실행하지 않으므로 유효한 id 가 필요 없다.
2. **구현하려면 description 을 파싱해야 한다.** CLAUDE.md 워크어라운드 시그니처 2번(문자열 분류기 추가)에 걸린다.

## 테스트

**단위 테스트를 붙이지 않았다.** 이 결함은 두 자연어 지시가 경쟁하고 더 구체적인 쪽이 이기는 층에 있어서, 어떤 타입이나 단언으로도 재현할 수 없다. 검증 수단은 실측뿐이고 위 표가 그것이다. 프롬프트 문자열을 단언하는 테스트는 회귀를 잡지 못하고 문자열을 고정하기만 한다.

같은 이유로 이 수정은 다음 재측정에서 도구별 분모를 바꾼다 — `masc_board_vote` 28/32 는 능력 측정이 아니었다.

Closes #28475
