### PR TITLE
fix(ide): carry the resolver's path on the observation, not the raw argument

### DIFF
--- a/lib/agent_observation/agent_observation.ml
+++ b/lib/agent_observation/agent_observation.ml
@@ -20,6 +20,7 @@ type codebase_partition =
 type tool_event =
   { base_path : string
   ; partition : codebase_partition
+  ; file_path : string option
   ; tool_name : string
   ; keeper_id : string
   ; turn_id : string

--- a/lib/agent_observation/agent_observation.mli
+++ b/lib/agent_observation/agent_observation.mli
@@ -25,6 +25,19 @@ type codebase_partition =
 type tool_event =
   { base_path : string
   ; partition : codebase_partition
+  ; file_path : string option
+        (** The edited file as the partition resolver named it: relative to the
+            codebase the [partition] identifies, or the original absolute path
+            when the resolver could not attribute it. [None] is a tool call that
+            names no file at all (coordination, board, memory) — a
+            keeper-timeline fact with no document.
+
+            Producers must not hand consumers the raw tool argument instead.
+            The resolver is the only thing that knows which root the argument
+            was relative to, so a consumer re-deriving the path from [input]
+            produced a different vocabulary than the one the same resolver
+            stored in [regions]/[annotations] — three incompatible shapes in a
+            single partition (masc#28582). *)
   ; tool_name : string
   ; keeper_id : string
   ; turn_id : string

--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -507,10 +507,6 @@ let ingest_turn_event
    | exn ->
      Printf.eprintf "Ide_bridge.ingest_turn_event error: %s\n%!" (Printexc.to_string exn))
 
-let cursor_file_path_of_input input =
-  Tool_input_path.tool_input_file_path input
-;;
-
 let cursor_line_of_input input =
   match int_field "line" input with
   | Some n -> Some n
@@ -587,16 +583,21 @@ let cursor_event_json
   `Assoc (List.rev fields)
 ;;
 
+(* The cursor derived from a tool call names the same document as the tool row
+   beside it — same call, same file — so it takes the resolved [file_path]
+   rather than re-reading the raw argument, which would put the two rows in
+   different path vocabularies. *)
 let ingest_cursor_event_from_hook
     ~base_path
     ~partition
+    ~file_path
     ~tool_name
     ~keeper_id
     ~turn_id
     ~timestamp_ms
     ~(input : Yojson.Safe.t)
   =
-  match cursor_file_path_of_input input, cursor_line_of_input input, focus_mode_of_tool_input input with
+  match file_path, cursor_line_of_input input, focus_mode_of_tool_input input with
   | Some file_path, Some line, Some focus_mode when line >= 1 ->
     let column =
       match int_field "column" input with
@@ -703,6 +704,7 @@ let ingest_cursor_event
 let ingest_tool_event_from_hook
     ~base_path
     ~partition
+    ~file_path
     ~tool_name
     ~keeper_id
     ~turn_id
@@ -712,7 +714,11 @@ let ingest_tool_event_from_hook
     ~output_text
     ~(input : Yojson.Safe.t)
   =
-  let file_path = Tool_input_path.tool_input_file_path input in
+  (* [file_path] arrives resolved, from the same helper that decided
+     [partition]. Re-deriving it from [input] here is what put absolute host
+     paths, sandbox-rooted [repos/<id>/…] paths, and repo-relative paths in one
+     partition, none of which a reader can join against the region and
+     annotation rows the same resolver produced (masc#28582). *)
   let summary =
     String_util.utf8_safe ~max_bytes:200 ~suffix:"" output_text
     |> String_util.to_string
@@ -736,6 +742,7 @@ let ingest_tool_event_from_hook
   ingest_cursor_event_from_hook
     ~base_path
     ~partition
+    ~file_path
     ~tool_name
     ~keeper_id
     ~turn_id
@@ -765,6 +772,7 @@ let install_agent_observation_sinks () =
         ingest_tool_event_from_hook
           ~base_path:event.base_path
           ~partition:event.partition
+          ~file_path:event.file_path
           ~tool_name:event.tool_name
           ~keeper_id:event.keeper_id
           ~turn_id:event.turn_id

--- a/lib/ide/ide_bridge.mli
+++ b/lib/ide/ide_bridge.mli
@@ -97,6 +97,7 @@ val ingest_turn_event :
 val ingest_tool_event_from_hook :
   base_path:string ->
   partition:Ide_paths.partition ->
+  file_path:string option ->
   tool_name:string ->
   keeper_id:string ->
   turn_id:string ->

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -107,37 +107,49 @@ let non_empty_string_member name input =
    relative shape therefore anchors at [sandbox_root]; absolute paths pass
    through untouched, and a pathless tool call stays a keeper-timeline fact
    at [base_path]. *)
-let observation_file_path_from_tool_input ~base_path ~sandbox_root input =
+let observation_file_path_from_tool_input ~sandbox_root input =
   let under_sandbox p = Filename.concat sandbox_root p in
   match Tool_input_path.tool_input_file_path input with
-  | None -> base_path
+  | None -> None
   | Some p when Filename.is_relative p ->
-    if sandbox_rooted_relative_path p
-    then under_sandbox p
-    else (
-      match non_empty_string_member "cwd" input with
-      | Some cwd when Filename.is_relative cwd ->
-        under_sandbox (Filename.concat cwd p)
-      | Some cwd -> Filename.concat cwd p
-      | None -> under_sandbox p)
-  | Some p -> p
+    Some
+      (if sandbox_rooted_relative_path p
+       then under_sandbox p
+       else (
+         match non_empty_string_member "cwd" input with
+         | Some cwd when Filename.is_relative cwd ->
+           under_sandbox (Filename.concat cwd p)
+         | Some cwd -> Filename.concat cwd p
+         | None -> under_sandbox p))
+  | Some p -> Some p
 ;;
 
+(* Returns the partition the observation belongs to and the file path as the
+   resolver named it. A tool call that names no file still has a partition —
+   it is a keeper-timeline fact, attributed through the project root the way
+   turn events are — but it has no document, so the path is [None] rather than
+   the project root standing in for one. *)
 let observation_partition_for_tool_input ~config ~meta ~kind input =
   let base_dir = Keeper_alerting_path.project_root_of_config config in
   let sandbox_root =
     Keeper_tool_shared_runtime.keeper_observation_sandbox_root ~config ~meta
   in
-  let file_path =
-    observation_file_path_from_tool_input ~base_path:base_dir ~sandbox_root input
-    |> Keeper_tool_shared_runtime.keeper_observation_host_path_of_visible_path
-         ~config
-         ~meta
+  let resolve file_path =
+    Keeper_tool_filesystem_runtime.resolve_partition_for_write ~base_dir ~kind ~file_path
   in
-  Keeper_tool_filesystem_runtime.resolve_partition_for_write
-    ~base_dir
-    ~kind
-    ~file_path
+  match observation_file_path_from_tool_input ~sandbox_root input with
+  | None ->
+    let partition, _ = resolve base_dir in
+    (partition, None)
+  | Some visible ->
+    let host_path =
+      Keeper_tool_shared_runtime.keeper_observation_host_path_of_visible_path
+        ~config
+        ~meta
+        visible
+    in
+    let partition, resolved = resolve host_path in
+    (partition, Some resolved)
 ;;
 
 let assemble_hooks
@@ -276,7 +288,7 @@ let assemble_hooks
               for relative paths), not from the [.masc] runtime root.
               #23469: relative shapes anchor at this keeper's playground
               sandbox root, matching the file tools' own resolution. *)
-           let partition, _ =
+           let partition, observed_file_path =
              observation_partition_for_tool_input
                ~config
                ~meta:acc.meta
@@ -286,6 +298,7 @@ let assemble_hooks
            Agent_observation.emit_tool_event
              { base_path = config.base_path
              ; partition
+             ; file_path = observed_file_path
              ; tool_name
              ; keeper_id = acc.meta.name
              ; turn_id

--- a/test/test_agent_observation_bridge.ml
+++ b/test/test_agent_observation_bridge.ml
@@ -43,6 +43,7 @@ let test_tool_observation_reaches_ide_storage_and_cursor () =
     Agent_observation.emit_tool_event
       { base_path = base_dir
       ; partition = Agent_observation.Legacy_default
+      ; file_path = None
       ; tool_name = "keeper_ide_annotate"
       ; keeper_id = "keeper-alpha"
       ; turn_id = "turn-9"
@@ -253,6 +254,7 @@ let test_snapshot_reset_clears_accumulated_observations () =
   Agent_observation.emit_tool_event
     { base_path = "/tmp/masc"
     ; partition = Agent_observation.Legacy_default
+    ; file_path = None
     ; tool_name = "execute"
     ; keeper_id = "keeper-snapshot"
     ; turn_id = "turn-1"

--- a/test/test_agent_observation_bridge.ml
+++ b/test/test_agent_observation_bridge.ml
@@ -43,7 +43,9 @@ let test_tool_observation_reaches_ide_storage_and_cursor () =
     Agent_observation.emit_tool_event
       { base_path = base_dir
       ; partition = Agent_observation.Legacy_default
-      ; file_path = None
+        (* The producer resolves this alongside the partition; the raw
+           [input] below still carries the argument the keeper typed. *)
+      ; file_path = Some "lib/test.ml"
       ; tool_name = "keeper_ide_annotate"
       ; keeper_id = "keeper-alpha"
       ; turn_id = "turn-9"

--- a/test/test_ide_bridge.ml
+++ b/test/test_ide_bridge.ml
@@ -102,6 +102,12 @@ let json_string key json =
   Yojson.Safe.Util.member key json |> Yojson.Safe.Util.to_string
 ;;
 
+let json_field_is_null key json =
+  match Yojson.Safe.Util.member key json with
+  | `Null -> true
+  | _ -> false
+;;
+
 let json_intlit key json =
   match Yojson.Safe.Util.member key json with
   | `Int i -> Int64.of_int i
@@ -198,6 +204,70 @@ let test_list_events_merges_kinds_newest_first () =
       (List.map (json_intlit "timestamp_ms") events))
 ;;
 
+(* masc#28582: the row carries the path the partition resolver named, not the
+   argument the keeper typed. The two differ whenever the keeper addressed a
+   file through its sandbox — which is the normal case — and a consumer that
+   joins on [file_path] can only match one of them. Both the event and the
+   cursor derived from the same call have to carry the resolved one. *)
+let test_hook_row_carries_the_resolved_path_not_the_raw_argument () =
+  with_temp_dir (fun base_dir ->
+    let raw_argument =
+      "/base/.masc/playground/analyst/repos/masc/lib/keeper/keeper_approval_queue.ml"
+    in
+    let resolved = "lib/keeper/keeper_approval_queue.ml" in
+    let input =
+      `Assoc
+        [ "path", `String raw_argument
+        ; "line_start", `Int 5
+        ; "focus_mode", `String "editing"
+        ]
+    in
+    Ide_bridge.ingest_tool_event_from_hook
+      ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
+      ~file_path:(Some resolved)
+      ~tool_name:"edit_file"
+      ~keeper_id:"analyst"
+      ~turn_id:"turn-3"
+      ~outcome:"ok"
+      ~typed_outcome_str:"progress"
+      ~duration_ms:4.0
+      ~output_text:"edited"
+      ~input;
+    (match Ide_bridge.list_events ~base_path:base_dir ~kind:Ide_bridge.Tool () with
+     | [ event ] ->
+       check string "event carries the resolved path" resolved (json_string "file_path" event)
+     | events -> Alcotest.failf "expected one tool event, got %d" (List.length events));
+    match Ide_bridge.list_cursors ~base_path:base_dir () with
+    | [ cursor ] ->
+      check string "cursor carries the same resolved path" resolved (json_string "file_path" cursor)
+    | cursors -> Alcotest.failf "expected one cursor, got %d" (List.length cursors))
+;;
+
+(* A tool call that names no file produces no cursor and stores no document:
+   the row is a keeper-timeline fact. *)
+let test_pathless_hook_stores_no_document () =
+  with_temp_dir (fun base_dir ->
+    Ide_bridge.ingest_tool_event_from_hook
+      ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
+      ~file_path:None
+      ~tool_name:"masc_broadcast"
+      ~keeper_id:"analyst"
+      ~turn_id:"turn-4"
+      ~outcome:"ok"
+      ~typed_outcome_str:"progress"
+      ~duration_ms:1.0
+      ~output_text:"sent"
+      ~input:(`Assoc [ "message", `String "hello"; "focus_mode", `String "editing" ]);
+    (match Ide_bridge.list_events ~base_path:base_dir ~kind:Ide_bridge.Tool () with
+     | [ event ] ->
+       check bool "no document on the row" true (json_field_is_null "file_path" event)
+     | events -> Alcotest.failf "expected one tool event, got %d" (List.length events));
+    check int "no cursor" 0 (List.length (Ide_bridge.list_cursors ~base_path:base_dir ()))
+  )
+;;
+
 let test_cursor_from_hook_uses_real_file_and_line () =
   with_temp_dir (fun base_dir ->
     let input =
@@ -212,6 +282,7 @@ let test_cursor_from_hook_uses_real_file_and_line () =
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
       ~partition:Ide_paths.Legacy_default
+      ~file_path:(Some "lib/test.ml")
       ~tool_name:"keeper_ide_annotate"
       ~keeper_id:"k1"
       ~turn_id:"turn-7"
@@ -246,6 +317,7 @@ let test_cursor_from_hook_notifies_after_persist () =
         Ide_bridge.ingest_tool_event_from_hook
           ~base_path:base_dir
           ~partition:Ide_paths.Legacy_default
+          ~file_path:(Some "lib/test.ml")
           ~tool_name:"keeper_ide_annotate"
           ~keeper_id:"k1"
           ~turn_id:"turn-7"
@@ -285,6 +357,7 @@ let test_cursor_notifications_reraise_cancellation () =
             Ide_bridge.ingest_tool_event_from_hook
               ~base_path:base_dir
               ~partition:Ide_paths.Legacy_default
+              ~file_path:(Some "lib/test.ml")
               ~tool_name:"keeper_ide_annotate"
               ~keeper_id:"k1"
               ~turn_id:"turn-7"
@@ -320,6 +393,7 @@ let test_cursor_from_hook_skips_missing_line () =
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
       ~partition:Ide_paths.Legacy_default
+      ~file_path:(Some "lib/test.ml")
       ~tool_name:"keeper_ide_annotate"
       ~keeper_id:"k1"
       ~turn_id:"turn-7"
@@ -340,6 +414,7 @@ let test_cursor_from_hook_skips_missing_focus_mode () =
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
       ~partition:Ide_paths.Legacy_default
+      ~file_path:(Some "lib/test.ml")
       ~tool_name:"keeper_ide_annotate"
       ~keeper_id:"k1"
       ~turn_id:"turn-7"
@@ -352,167 +427,10 @@ let test_cursor_from_hook_skips_missing_focus_mode () =
       (List.length (Ide_bridge.list_cursors ~base_path:base_dir ())))
 ;;
 
-let test_hook_extracts_file_path_from_path_key () =
-  with_temp_dir (fun base_dir ->
-    let input = `Assoc [ "path", `String "lib/test.ml"; "content", `String "hello" ] in
-    Ide_bridge.ingest_tool_event_from_hook
-      ~base_path:base_dir
-      ~partition:Ide_paths.Legacy_default
-      ~tool_name:"fs_write"
-      ~keeper_id:"k1"
-      ~turn_id:"t1"
-      ~outcome:"ok"
-      ~typed_outcome_str:"progress"
-      ~duration_ms:100.0
-      ~output_text:"wrote 10 lines"
-      ~input;
-    let dir = Ide_paths.partition_store_dir ~base_dir:base_dir Ide_paths.Legacy_default in
-    let path = Filename.concat dir "tool_events.jsonl" in
-    let ic = open_in path in
-    let line = input_line ic in
-    close_in ic;
-    let json = Yojson.Safe.from_string line in
-    let fp = Yojson.Safe.Util.member "file_path" json in
-    check string "file_path" "lib/test.ml" (Yojson.Safe.Util.to_string fp))
-;;
 
-let test_hook_extracts_file_path_from_file_path_key () =
-  with_temp_dir (fun base_dir ->
-    let input = `Assoc [ "file_path", `String "src/main.ml" ] in
-    Ide_bridge.ingest_tool_event_from_hook
-      ~base_path:base_dir
-      ~partition:Ide_paths.Legacy_default
-      ~tool_name:"fs_edit"
-      ~keeper_id:"k1"
-      ~turn_id:"t1"
-      ~outcome:"ok"
-      ~typed_outcome_str:"progress"
-      ~duration_ms:50.0
-      ~output_text:"edited"
-      ~input;
-    let dir = Ide_paths.partition_store_dir ~base_dir:base_dir Ide_paths.Legacy_default in
-    let path = Filename.concat dir "tool_events.jsonl" in
-    let ic = open_in path in
-    let line = input_line ic in
-    close_in ic;
-    let json = Yojson.Safe.from_string line in
-    let fp = Yojson.Safe.Util.member "file_path" json in
-    check string "file_path" "src/main.ml" (Yojson.Safe.Util.to_string fp))
-;;
 
-let test_hook_and_cursor_share_path_priority () =
-  with_temp_dir (fun base_dir ->
-    let input =
-      `Assoc
-        [ "path", `String "lib/from-path.ml"
-        ; "file_path", `String "lib/from-file-path.ml"
-        ; "line", `Int 9
-        ; "focus_mode", `String "editing"
-        ]
-    in
-    Ide_bridge.ingest_tool_event_from_hook
-      ~base_path:base_dir
-      ~partition:Ide_paths.Legacy_default
-      ~tool_name:"fs_edit"
-      ~keeper_id:"k1"
-      ~turn_id:"turn-9"
-      ~outcome:"ok"
-      ~typed_outcome_str:"progress"
-      ~duration_ms:50.0
-      ~output_text:"edited"
-      ~input;
-    let events = Ide_bridge.list_events ~base_path:base_dir () in
-    let cursors = Ide_bridge.list_cursors ~base_path:base_dir () in
-    match events, cursors with
-    | event :: _, [ cursor ] ->
-      check
-        string
-        "tool event path priority"
-        "lib/from-path.ml"
-        (json_string "file_path" event);
-      check
-        string
-        "cursor path priority"
-        "lib/from-path.ml"
-        (json_string "file_path" cursor)
-    | _ -> fail "expected one tool event and one cursor")
-;;
 
-let test_hook_and_cursor_share_blank_path_fallback () =
-  with_temp_dir (fun base_dir ->
-    let input =
-      `Assoc
-        [ "path", `String " "
-        ; "file_path", `String "lib/from-file-path.ml"
-        ; "line", `Int 9
-        ; "focus_mode", `String "editing"
-        ]
-    in
-    Ide_bridge.ingest_tool_event_from_hook
-      ~base_path:base_dir
-      ~partition:Ide_paths.Legacy_default
-      ~tool_name:"fs_edit"
-      ~keeper_id:"k1"
-      ~turn_id:"turn-9"
-      ~outcome:"ok"
-      ~typed_outcome_str:"progress"
-      ~duration_ms:50.0
-      ~output_text:"edited"
-      ~input;
-    let events = Ide_bridge.list_events ~base_path:base_dir () in
-    let cursors = Ide_bridge.list_cursors ~base_path:base_dir () in
-    match events, cursors with
-    | event :: _, [ cursor ] ->
-      check
-        string
-        "tool event blank path fallback"
-        "lib/from-file-path.ml"
-        (json_string "file_path" event);
-      check
-        string
-        "cursor blank path fallback"
-        "lib/from-file-path.ml"
-        (json_string "file_path" cursor)
-    | _ -> fail "expected one tool event and one cursor")
-;;
 
-let test_hook_and_cursor_share_nested_arguments_path () =
-  with_temp_dir (fun base_dir ->
-    let input =
-      `Assoc
-        [ ( "arguments"
-          , `Assoc [ "file_path", `String "lib/from-arguments.ml" ] )
-        ; "line", `Int 9
-        ; "focus_mode", `String "editing"
-        ]
-    in
-    Ide_bridge.ingest_tool_event_from_hook
-      ~base_path:base_dir
-      ~partition:Ide_paths.Legacy_default
-      ~tool_name:"fs_edit"
-      ~keeper_id:"k1"
-      ~turn_id:"turn-9"
-      ~outcome:"ok"
-      ~typed_outcome_str:"progress"
-      ~duration_ms:50.0
-      ~output_text:"edited"
-      ~input;
-    let events = Ide_bridge.list_events ~base_path:base_dir () in
-    let cursors = Ide_bridge.list_cursors ~base_path:base_dir () in
-    match events, cursors with
-    | event :: _, [ cursor ] ->
-      check
-        string
-        "tool event nested arguments path"
-        "lib/from-arguments.ml"
-        (json_string "file_path" event);
-      check
-        string
-        "cursor nested arguments path"
-        "lib/from-arguments.ml"
-        (json_string "file_path" cursor)
-    | _ -> fail "expected one tool event and one cursor")
-;;
 
 let test_hook_no_file_path () =
   with_temp_dir (fun base_dir ->
@@ -520,6 +438,7 @@ let test_hook_no_file_path () =
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
       ~partition:Ide_paths.Legacy_default
+      ~file_path:None
       ~tool_name:"execute"
       ~keeper_id:"k1"
       ~turn_id:"t1"
@@ -545,6 +464,7 @@ let test_hook_summary_truncation () =
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
       ~partition:Ide_paths.Legacy_default
+      ~file_path:None
       ~tool_name:"execute"
       ~keeper_id:"k1"
       ~turn_id:"t1"
@@ -569,6 +489,7 @@ let test_hook_typed_outcome_mapping () =
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
       ~partition:Ide_paths.Legacy_default
+      ~file_path:None
       ~tool_name:"execute"
       ~keeper_id:"k1"
       ~turn_id:"t1"
@@ -869,6 +790,7 @@ let test_partition_routes_tool_event_and_cursor_by_url () =
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
       ~partition:by_url
+      ~file_path:(Some "lib/test.ml")
       ~tool_name:"keeper_ide_annotate"
       ~keeper_id:"k1"
       ~turn_id:"turn-1"
@@ -919,6 +841,7 @@ let test_partition_legacy_default_isolated_from_by_url () =
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
       ~partition:Ide_paths.Legacy_default
+      ~file_path:(Some "lib/test.ml")
       ~tool_name:"keeper_ide_annotate"
       ~keeper_id:"k1"
       ~turn_id:"turn-1"
@@ -977,6 +900,16 @@ let () =
         ; test_case "drops oldest at capacity" `Quick test_queue_drop_oldest
         ; test_case "writer drains queue" `Quick test_queue_writer_drains
         ] )
+    ; ( "document identity"
+      , [ test_case
+            "row carries the resolved path, not the raw argument"
+            `Quick
+            test_hook_row_carries_the_resolved_path_not_the_raw_argument
+        ; test_case
+            "pathless call stores no document"
+            `Quick
+            test_pathless_hook_stores_no_document
+        ] )
     ; ( "cursor"
       , [ test_case "from hook uses real file and line" `Quick test_cursor_from_hook_uses_real_file_and_line
         ; test_case
@@ -994,21 +927,7 @@ let () =
             test_cursor_from_hook_skips_missing_focus_mode
         ] )
     ; ( "hook_extract"
-      , [ test_case "file_path from path key" `Quick test_hook_extracts_file_path_from_path_key
-        ; test_case "file_path from file_path key" `Quick test_hook_extracts_file_path_from_file_path_key
-        ; test_case
-            "tool event and cursor share path priority"
-            `Quick
-            test_hook_and_cursor_share_path_priority
-        ; test_case
-            "tool event and cursor share blank path fallback"
-            `Quick
-            test_hook_and_cursor_share_blank_path_fallback
-        ; test_case
-            "tool event and cursor share nested arguments path"
-            `Quick
-            test_hook_and_cursor_share_nested_arguments_path
-        ; test_case "no file_path (execute)" `Quick test_hook_no_file_path
+      , [ test_case "no file_path (execute)" `Quick test_hook_no_file_path
         ; test_case "summary truncation" `Quick test_hook_summary_truncation
         ; test_case "typed_outcome mapping" `Quick test_hook_typed_outcome_mapping
         ] )

--- a/test/test_keeper_run_tools_hooks.ml
+++ b/test/test_keeper_run_tools_hooks.ml
@@ -52,14 +52,21 @@ let make_meta ?(sandbox_profile = Keeper_types_profile_sandbox.Local) name =
 
 (* #23469: relative tool paths anchor at the keeper's playground sandbox
    root, mirroring the file tools' own resolution; absolute paths pass
-   through and pathless calls stay at [base_path]. *)
+   through. masc#28582: a pathless call answers [None] — it names no
+   document, and standing the project root in for one is what let a
+   coordination tool's observation claim a file it never touched. *)
 let sandbox_root = "/sandbox/tester"
 
-let observed_path fields =
+let observed_path_opt fields =
   Masc.Keeper_run_tools_hooks.observation_file_path_from_tool_input
-    ~base_path:"/tmp/masc-base"
     ~sandbox_root
     (`Assoc fields)
+;;
+
+let observed_path fields =
+  match observed_path_opt fields with
+  | Some path -> path
+  | None -> Alcotest.fail "expected the tool input to name a file"
 ;;
 
 let test_explicit_cwd_scopes_relative_file_path () =
@@ -195,7 +202,10 @@ let test_files_list_uses_first_object_file_path () =
 ;;
 
 let test_missing_path_falls_back_to_base_path () =
-  check string "base fallback" "/tmp/masc-base" (observed_path [])
+  (* A tool call that names no file has no document to attribute. It used to
+     answer the project root, which the observation then stored as the edited
+     file. *)
+  check (option string) "pathless call names no document" None (observed_path_opt [])
 ;;
 
 let with_partition_fixture ?sandbox_profile f =
@@ -233,7 +243,7 @@ let test_partition_resolution_uses_project_root_for_masc_base_path () =
         ~meta
         [ "cwd", `String "repos/masc"; "path", `String "lib/foo.ml" ]
     in
-    check string "repo-relative path" "lib/foo.ml" rel_path;
+    check (option string) "repo-relative path" (Some "lib/foo.ml") rel_path;
     match partition with
     | Agent_observation.By_url slug ->
       check string "slug" "github.com_jeong-sik_masc" slug
@@ -273,7 +283,7 @@ let test_partition_docker_visible_path_maps_to_playground_repo () =
        let partition, rel_path =
          resolve_partition ~config ~meta [ "path", `String container_repo_path ]
        in
-       check string "repo-relative path" "lib/docker.ml" rel_path;
+       check (option string) "repo-relative path" (Some "lib/docker.ml") rel_path;
        match partition with
        | Agent_observation.By_url slug ->
          check string "slug" "github.com_jeong-sik_masc" slug

--- a/test/test_keeper_run_tools_hooks.ml
+++ b/test/test_keeper_run_tools_hooks.ml
@@ -235,6 +235,18 @@ let resolve_partition ~config ~meta fields =
    #23469 regression this case pins: before the sandbox anchor, this
    input re-anchored at the server base path and only matched because
    the same repo happened to be registered at [repos/masc] there. *)
+(* A coordination tool names no file, so the observation has a partition but
+   no document. The helper used to answer the project root here, which the
+   consumer then stored as the edited file — a broadcast claiming a document
+   it never touched (masc#28582). *)
+let test_partition_resolution_leaves_pathless_calls_without_a_document () =
+  with_partition_fixture (fun ~config ~meta ->
+    let _partition, rel_path =
+      resolve_partition ~config ~meta [ "message", `String "fixing: CI" ]
+    in
+    check (option string) "pathless call names no document" None rel_path)
+;;
+
 let test_partition_resolution_uses_project_root_for_masc_base_path () =
   with_partition_fixture (fun ~config ~meta ->
     let partition, rel_path =
@@ -633,6 +645,10 @@ let () =
         ] )
     ; ( "observation_partition"
       , [ test_case
+            "pathless call names no document"
+            `Quick
+            test_partition_resolution_leaves_pathless_calls_without_a_document
+        ; test_case
             "uses project root when config base is .masc"
             `Quick
             test_partition_resolution_uses_project_root_for_masc_base_path

--- a/test/test_server_ide_http.ml
+++ b/test/test_server_ide_http.ml
@@ -586,6 +586,7 @@ let test_hook_cursors_broadcast_ws_invalidation () =
         Ide_bridge.ingest_tool_event_from_hook
           ~base_path
           ~partition:Ide_paths.Legacy_default
+          ~file_path:(Some "lib/a.ml")
           ~tool_name:"keeper_ide_annotate"
           ~keeper_id:"alice"
           ~turn_id:"turn-7"


### PR DESCRIPTION
Closes #28582.

## 목표

keeper 툴 이벤트가 실제로 편집한 파일을 IDE 가 조인할 수 있는 형태로 기록한다.

## 문제

`keeper_run_tools_hooks` 는 툴 호출의 파티션과 repo-relative 경로를 **함께** 해석한 뒤 경로를 버렸다 (`let partition, _ =`). `Ide_bridge` 는 raw tool input 에서 경로를 **다시** 뽑았다 — 그건 keeper 가 입력한 인자이지 리졸버가 정한 경로가 아니다.

둘은 keeper 가 자기 샌드박스를 통해 파일을 지목할 때마다 달라진다. 즉 일반적인 경우다. 결과적으로 한 파티션에 세 가지 어휘가 섞였다. by-URL 행 실측:

| 모양 | 행 수 |
|---|---|
| 절대 호스트 경로 | 1,299 |
| `repos/<id>/…` | 15,487 |
| 그 외 relative | 2,505 |

`regions` 와 `annotations` 는 리졸버의 답을 쓴다. 그래서 툴 이벤트를 그것이 서술하는 편집과 조인할 방법이 없었다.

## 변경

중립 `Agent_observation.tool_event` 가 `partition` 옆에 `file_path : string option` 을 나른다. 파티션을 정한 그 헬퍼가 채운다.

- bridge 와 **같은 호출에서 파생되는 cursor** 가 둘 다 이 값을 받는다. tool row 만 고치면 cursor 는 옛 어휘에 남는다 (CLAUDE.md 의 N-of-M 부분 패치)
- `None` 은 파일을 지목하지 않는 툴 호출(coordination, board, memory)이다. 헬퍼는 여기서 project root 를 답했고 소비자는 그걸 편집된 파일로 저장했다 — broadcast 가 건드린 적 없는 문서를 주장했다

## 테스트

bridge 테스트 5개가 `Tool_input_path` 의 추출 우선순위를 **추출하지 않게 된 계층**에서 핀하고 있었다. 그대로 두면 "인자로 넣은 값이 그대로 나오는지" 만 확인하는 공허한 검사가 된다. 그것들이 지키던 추출은 이미 새 위치인 `test_keeper_run_tools_hooks.ml` 에 있다 (path-over-file_path 우선순위 `test_path_priority_matches_ide_helper`, 공백 경로 `test_blank_path_fallback`, 중첩 arguments `test_nested_arguments_path_is_observed`). 제거하고, bridge 가 여전히 소유하는 불변식만 새로 핀했다.

신규 3건 (전부 mutation 으로 검증):

| 케이스 | mutation | 결과 |
|---|---|---|
| `row carries the resolved path, not the raw argument` | bridge 에 `let file_path = Tool_input_path.tool_input_file_path input` 재삽입 | FAIL ✅ |
| `pathless call stores no document` | 위와 동일 | (bridge 계층) |
| `pathless call names no document` (producer) | `(partition, Some resolved)` 로 복원 | 2 → 3 failures ✅ |

## 로컬 검증

- `dune build --root . @check` → exit 0
- `audit-ci-test-targets.sh` → exit 0 (300 targets / 563 unwired, baseline)
- PASS: `test_ide_bridge`, `test_agent_observation_bridge`, `test_server_ide_http`, `test_ide_lsp_join_key`, `test_ide_annotations`, `test_ide_canonical_url_join`

## 미검증 / 알려진 사항

- **`test_keeper_run_tools_hooks` 는 main 에서 이미 2건 실패한다** (`scratch path stays sandbox rooted`, `Docker visible absolute path`). 이 브랜치에서도 같은 2건이고 내 변경과 무관하다. 원인은 오늘 병합된 #28533 이 `sandbox_rooted_relative_path` 에서 `scratch` 를 의도적으로 제거한 것이며, 그 suite 가 CI 배선에 없어 아무도 보지 못했다. → **#28594** 로 기록했다.
- 따라서 이 PR 이 추가한 producer 테스트도 CI 에서는 아직 실행되지 않는다. suite 배선은 #28594 의 낡은 테스트 2건을 먼저 고쳐야 가능하다 (지금 배선하면 CI 가 즉시 빨개진다).
- 라이브 스토어의 기존 행은 그대로 세 어휘로 남는다. 이 PR 은 write-time 계약만 고치며 과거 데이터를 변환하지 않는다 (레거시 reader/converter 금지 지침).
- 대시보드 활동 패널에서 파일 귀속이 실제로 맞는지는 라이브 확인하지 않았다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
