### PR TITLE
fix(test): make the Docker fixture Docker, and wire the suite into CI

### DIFF
--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=563
+UNWIRED_BASELINE=562
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -253,6 +253,7 @@ normal_targets=(
   @test/runtest-test_server_runtime_startup_maintenance
   @test/runtest-test_runtime_per_keeper_routing
   @test/runtest-test_ide_bridge
+  @test/runtest-test_keeper_run_tools_hooks
   @test/runtest-test_ide_lsp_join_key
   @test/runtest-test_dashboard_workspace
   @test/runtest-test_host_fd_pressure_poller

--- a/test/test_keeper_run_tools_hooks.ml
+++ b/test/test_keeper_run_tools_hooks.ml
@@ -46,7 +46,15 @@ let make_meta ?(sandbox_profile = Keeper_types_profile_sandbox.Local) name =
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with
-  | Ok m -> m
+  (* [sandbox_profile] is not a persisted meta field — it comes from the
+     keeper's TOML profile — so the fixture JSON cannot carry it, and passing
+     it there is rejected as outside the current schema. Set it on the record
+     the fixture returns instead. Before this, the parameter was accepted and
+     dropped: a case asking for [Docker] got a Local keeper, and
+     [keeper_observation_host_path_of_visible_path] returns early for
+     non-Docker profiles, so the container->host mapping the Docker case is
+     named for never ran. *)
+  | Ok m -> { m with Masc.Keeper_meta_contract.sandbox_profile }
   | Error e -> Alcotest.fail e
 ;;
 
@@ -71,11 +79,17 @@ let test_explicit_cwd_scopes_relative_file_path () =
        [ "file_path", `String "lib/foo.ml"; "cwd", `String "repos/masc" ])
 ;;
 
-let test_scratch_path_stays_sandbox_rooted_with_repo_cwd () =
+(* #28533 dropped "scratch" from the sandbox-rooted prefix list, in the same
+   change that removed the tool-schema sentence teaching it: no code ever
+   created that directory, so the only paths shaped like it were ones a model
+   invented from the sentence. A [scratch/…] path is therefore an ordinary
+   relative path now and anchors at the typed [cwd] like any other. "repos"
+   deliberately stays in that list. *)
+let test_scratch_path_anchors_at_cwd_like_any_relative_path () =
   check
     string
     "scratch/file_path"
-    "/sandbox/tester/scratch/notes.md"
+    "/sandbox/tester/repos/masc/scratch/notes.md"
     (observed_path
        [ "file_path", `String "scratch/notes.md"; "cwd", `String "repos/masc" ])
 ;;
@@ -568,9 +582,9 @@ let () =
             `Quick
             test_explicit_cwd_scopes_relative_file_path
         ; test_case
-            "scratch path stays sandbox-rooted with repo cwd"
+            "scratch path anchors at cwd like any relative path"
             `Quick
-            test_scratch_path_stays_sandbox_rooted_with_repo_cwd
+            test_scratch_path_anchors_at_cwd_like_any_relative_path
         ; test_case
             "sandbox-rooted file_path ignores cwd"
             `Quick


### PR DESCRIPTION
Closes #28594.

## 문제

`test_keeper_run_tools_hooks` 가 main 에서 **2건 실패하는데 CI 는 초록**이었다. suite 가 `test/dune` 에는 선언돼 있지만 CI 매니페스트 어디에도 없어 컴파일만 됐다.

원인은 서로 독립적인 두 개다.

## 1. Docker fixture 가 Docker 가 아니었다

`make_meta` 는 `?sandbox_profile` 을 받고 **버렸다**.

#26116 이 fixture JSON 에서 `sandbox_profile` 을 제거한 것 자체는 옳다 — meta 스키마가 그 필드를 거부한다 (`fields outside the current schema: sandbox_profile`). 값은 keeper 의 TOML 프로파일에서 온다. 다만 시그니처의 파라미터가 남아 아무 데도 닿지 않게 됐다.

결과: `with_partition_fixture ~sandbox_profile:Docker` 로 호출해도 meta 는 Local 이고, `keeper_observation_host_path_of_visible_path` 는 첫 줄에서

```ocaml
if Filename.is_relative raw_path
   || meta.sandbox_profile <> Keeper_types_profile_sandbox.Docker
then raw_path
```

로 경로를 그대로 돌려준다. **컨테이너→호스트 매핑이 아예 실행되지 않았다** — 그 테스트 이름이 주장하는 바로 그것이. 받은 값이 컨테이너 경로 원본이었던 이유다.

프로파일을 fixture 가 돌려준 레코드에 얹는다. JSON 이 아니라 거기가 그 값이 사는 곳이다.

## 2. scratch 케이스가 낡았다

`scratch path stays sandbox rooted with repo cwd` 는 #28533 이 **의도적으로 제거한** 동작을 핀하고 있었다. 그 PR 은 `scratch` 를 sandbox-rooted 접두 목록에서 빼면서, 같은 변경으로 그것을 가르치던 tool schema 문장도 지웠다 — 그 디렉터리를 만드는 코드가 없었기 때문이다. 커밋 메시지가 영향까지 명시한다.

따라서 `scratch/…` 는 이제 평범한 상대 경로이고 typed `cwd` 에 anchor 된다. 기대값을 그렇게 바꾸고 케이스명도 그렇게 고쳤다 (`test_scratch_path_anchors_at_cwd_like_any_relative_path`). `repos` 는 그 목록에 의도적으로 남아 있다.

## 3. CI 배선

둘 다 초록이 된 뒤 `scripts/ci-run-focused-tests.sh` 에 `@test/runtest-test_keeper_run_tools_hooks` 를 추가하고, unwired 래칫을 **563 → 562** 로 조였다. 가드가 직접 요구한 것이다:

> Set UNWIRED_BASELINE=562. The gap is not slack to spend: leaving it lets a later change add an unwired suite and still pass.

이걸 안 조이면 다음에 배선 안 된 suite 가 하나 들어와도 통과한다.

## 로컬 검증

- `dune build --root . @check` → exit 0
- `./_build/default/test/test_keeper_run_tools_hooks.exe` → **26/26 PASS** (수정 전 main: 2 FAIL)
- `dune build @test/runtest-test_keeper_run_tools_hooks` → 26 tests, Successful (별칭이 실제로 실행됨을 확인)
- `scripts/audit-ci-test-targets.sh` → exit 0 (301 targets / 562 unwired, baseline)

## 부수 효과

#28595 (`fix(ide): carry the resolver's path on the observation`) 가 이 suite 에 producer 테스트를 하나 추가했는데, 배선이 없어 CI 에서 실행되지 않는 상태였다. 이 PR 이 머지되면 그 테스트도 돌기 시작한다. 순서는 어느 쪽이 먼저든 무방하다.

## 미검증

- 다른 unwired suite 561개는 건드리지 않았다. 이 PR 은 실패가 실제로 관측된 하나만 다룬다.
- Docker 케이스는 이제 매핑 경로를 실행하지만, 실제 컨테이너 런타임에서의 동작이 아니라 경로 계산만 검증한다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
