### PR TITLE
fix(keeper): settle completed direct message scope

### DIFF
--- a/lib/keeper/keeper_world_observation_message_scope.ml
+++ b/lib/keeper/keeper_world_observation_message_scope.ml
@@ -227,6 +227,34 @@ let acknowledged_turn_refs messages =
     messages
 ;;
 
+let answered_delivery_keys messages =
+  List.filter_map
+    (fun (message : Keeper_chat_store.chat_message) ->
+      match message.role, message.kind, message.delivery_key with
+      | Keeper_chat_store.Role.Assistant,
+        Keeper_chat_store.Row_kind.Utterance,
+        Some delivery_key ->
+        Some delivery_key
+      | Keeper_chat_store.Role.Assistant,
+        Keeper_chat_store.Row_kind.Transport_failure,
+        _
+      | Keeper_chat_store.Role.Assistant,
+        Keeper_chat_store.Row_kind.Utterance,
+        None
+      | Keeper_chat_store.Role.User, _, _
+      | Keeper_chat_store.Role.Tool, _, _ ->
+        None)
+    messages
+;;
+
+let exact_delivery_was_answered answered = function
+  | None -> false
+  | Some delivery_key ->
+    List.exists
+      (Keeper_chat_delivery_identity.delivery_key_equal delivery_key)
+      answered
+;;
+
 let messages_after_ack ~ack_id messages =
   match ack_id with
   | None -> messages
@@ -241,12 +269,15 @@ let messages_after_ack ~ack_id messages =
 
 let pending_user_lines ?ack_id (messages : Keeper_chat_store.chat_message list) =
   let acknowledged = acknowledged_turn_refs messages in
+  let answered_deliveries = answered_delivery_keys messages in
   messages_after_ack ~ack_id messages
   |> List.filter (fun (message : Keeper_chat_store.chat_message) ->
     match message.role, message.turn_ref with
     | Keeper_chat_store.Role.User, Some turn_ref ->
       not (StringSet.mem (Ids.Turn_ref.to_string turn_ref) acknowledged)
-    | Keeper_chat_store.Role.User, None -> true
+      && not (exact_delivery_was_answered answered_deliveries message.delivery_key)
+    | Keeper_chat_store.Role.User, None ->
+      not (exact_delivery_was_answered answered_deliveries message.delivery_key)
     | Keeper_chat_store.Role.Assistant, _ | Keeper_chat_store.Role.Tool, _ -> false)
 ;;
 

--- a/lib/keeper/keeper_world_observation_message_scope.mli
+++ b/lib/keeper/keeper_world_observation_message_scope.mli
@@ -77,8 +77,10 @@ val render_recent_direct_conversation_context
   -> string
 
 (** Pure source-ordered classification after the optional durable ack row.
-    Paired direct turns are acknowledged only by an assistant utterance with
-    the same typed [turn_ref]; an unrelated assistant row never clears input. *)
+    Paired turns are acknowledged by an assistant utterance with the same
+    typed [turn_ref], or by a terminal assistant transcript row with the same
+    typed delivery key. An unrelated assistant row and a transport-failure row
+    never clear input. *)
 val pending_messages_of_messages
   :  ?ack_id:string
   -> targets:string list


### PR DESCRIPTION
## What changed

- treat a direct user row as answered when the durable transcript contains an assistant utterance with the exact same typed delivery key
- keep unrelated rows, transport failures, tool rows, and rows without typed provenance pending

## Why

A live 10-turn Keeper continuity canary completed all ten direct operations, then immediately ran an unwanted autonomous turn with `scope_message_pending`. The accepted user row and terminal assistant row already shared the operation delivery key, but message-scope observation only understood turn-ref pairs and the autonomous high-water mark. It therefore consumed the completed direct input again.

This is a read-side settlement fix. It adds no admission gate, no new store write, and no runtime/model policy. Tool-only terminal turns remain a separately measured gap.

## Impact

Completed direct chat operations with a terminal assistant transcript row are no longer reintroduced as heartbeat work. Other pending messages retain their individual status; no high-water mark is advanced.

## Validation

- `ocamlformat --check` on both touched files
- `ocamlc -stop-after parsing` on both touched files
- `git diff --check` and conflict-marker scan
- SSOT, silent-failure, OCaml structure, and Agent Core boundary guards
- two independent source-only adversarial reviews: no P1 blocker

Local Dune build and focused tests were intentionally not run; CI owns those checks. Live validation requires a deployed build and is not claimed by this PR.
