### PR TITLE
fix(memory): keep evidence window private

### DIFF
--- a/lib/keeper/keeper_external_attention.mli
+++ b/lib/keeper/keeper_external_attention.mli
@@ -155,13 +155,11 @@ val load_events_result :
 
 val load_events : base_path:string -> keeper_name:string -> event list
 
-val evidence_window_bytes : int
-
 val load_recent_evidence_events :
   base_path:string -> keeper_name:string -> event list
 (** Read a bounded recent tail sized for prompt evidence rather than connector
     redelivery. The first and last partial lines are excluded when the file is
-    larger than {!evidence_window_bytes}. This is not a whole-history API. *)
+    larger than the internal evidence window. This is not a whole-history API. *)
 
 val pending_for_keeper :
   base_path:string ->


### PR DESCRIPTION
## What changed

Remove the unused public `evidence_window_bytes` export while keeping the bounded evidence loader public.

## Why

#28598 introduced the constant in the interface even though no external caller needs it. The dead-surface ratchet therefore rose from its 548 baseline to 549 and failed `Meta Guards`. Keeping the policy constant private avoids an unnecessary API contract and restores the ratchet without raising its baseline.

## Validation

- `python3 scripts/audit-dead-surface.py --exports --ratchet` — 548, baseline, OK
- `git diff --check`

No build was run; this is an interface-surface cleanup only.
