### PR TITLE
fix(test): repair the librarian retry suite against the real chat-store API

### DIFF
--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -5,6 +5,10 @@ module Runtime = Masc.Keeper_librarian_runtime
 module Memory = Masc.Keeper_memory_os_types
 module Budget = Masc.Keeper_memory_os_budget
 module Post_turn_memory = Masc.Keeper_agent_run_post_turn_memory
+module Keeper_chat_store = Masc.Keeper_chat_store
+module Keeper_counterpart_observation = Masc.Keeper_counterpart_observation
+module Keeper_external_attention = Masc.Keeper_external_attention
+module Surface_ref = Masc.Surface_ref
 
 (* Render tests resolve the real repo templates so template <-> code
    variable drift fails here instead of as a live [Prompt_render_failed]
@@ -539,7 +543,6 @@ let test_counterpart_observations_keep_direct_and_attention_fallback () =
          ~surface
          ~conversation_id
          ~external_message_id
-         ~workspace_id:"guild-fallback"
          ~speaker:
            { speaker_id = item.actor.actor_id
            ; speaker_name = item.actor.display_name


### PR DESCRIPTION
main 이 깨져 있다. `dune build .` 가 실패한다:

```
File "test/test_keeper_librarian_retry.ml", line 406, characters 7-24:
406 |        Keeper_chat_store.append_user_message
             ^^^^^^^^^^^^^^^^^
Error: Unbound module Keeper_chat_store
```

## 원인

#28598 (`fix(memory): wire typed counterpart evidence`, 12:33 병합) 이 이 파일에 counterpart evidence 커버리지를 추가했는데, 새 코드가 상륙한 트리와 맞지 않는다.

**1. 모듈 4개를 한정자 없이 참조했다.** 이 파일에는 `open Masc` 가 없다. 그래서 상단에 별칭을 선언하는 관례가 있는데(`module Librarian = Masc.Keeper_librarian` 등 5개) 새 참조가 그걸 건너뛰었다.

`Keeper_chat_store`, `Keeper_counterpart_observation`, `Keeper_external_attention`, `Surface_ref` 에 별칭을 추가했다.

`Ids` 와 `Json_util` 은 건드리지 않았다 — 각각 `masc_types`, 별도 라이브러리에서 오므로 이미 해결된다. 처음엔 이 둘도 같이 별칭을 걸었다가 `Unbound module Masc.Ids` 로 되돌렸다.

**2. `append_user_message` 에 존재하지 않는 `~workspace_id` 를 넘겼다.**

```
val append_user_message :
  base_dir:string -> keeper_name:string -> content:string ->
  ?attachments:… -> ?surface:Surface_ref.t -> ?conversation_id:string ->
  ?external_message_id:string -> ?speaker:speaker ->
  ?extra_mentions:… -> unit -> unit
```

workspace 정체성은 이미 `~surface` 를 타고 간다. 같은 호출부가 바로 위에서

```ocaml
Discord { guild_id = Some "guild-fallback"; channel_id = "channel-fallback"; … }
```

를 만들어 `~surface` 로 넘긴다. 빠진 게 없으므로 API 에 파라미터를 추가하지 않고 인자를 제거했다.

## 검증

- `dune build .` → exit 0 (사용자가 실패를 관측한 그 명령)
- `./_build/default/test/test_keeper_librarian_retry.exe` → **25/25 PASS**

## 왜 CI 가 못 잡았나

`test_keeper_librarian_retry` 가 CI 실행 목록에 없다. #28594 와 같은 종류의 공백이다. 그 이슈는 다른 suite 하나를 배선하는 #28597 로 처리 중이고, 이 suite 는 이 PR 범위 밖으로 뒀다 — main 을 먼저 살리는 게 우선이고, 배선은 별개 판단이 필요하다.

Draft 로 두지 않았다. main 이 깨진 상태라 검토 후 바로 머지 가능하도록 했다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)