### PR TITLE
ci: run the librarian retry suite

### DIFF
--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=563
+UNWIRED_BASELINE=562
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -253,6 +253,7 @@ normal_targets=(
   @test/runtest-test_server_runtime_startup_maintenance
   @test/runtest-test_runtime_per_keeper_routing
   @test/runtest-test_ide_bridge
+  @test/runtest-test_keeper_librarian_retry
   @test/runtest-test_ide_lsp_join_key
   @test/runtest-test_dashboard_workspace
   @test/runtest-test_host_fd_pressure_poller


### PR DESCRIPTION
#28601 이 이 suite 를 고쳤다. 이 PR 은 같은 일이 다시 일어나지 않게 CI 에 배선한다.

## 왜 필요한가

`test_keeper_librarian_retry` 는 `test/dune` 에 선언돼 있어 로컬 `dune build .` 에서는 컴파일된다. 하지만 CI 매니페스트 어디에도 없다. 그래서 이 suite 를 깨뜨린 PR(#28598)의 체크는 전부 초록이었고, 깨진 채로 main 에 들어갔다.

배선하면 다음 번엔 그것을 유발한 PR 에서 빨간 체크로 잡힌다.

## 변경

- `scripts/ci-run-focused-tests.sh` 에 `@test/runtest-test_keeper_librarian_retry` 추가
- unwired 래칫 **563 → 562**. 가드가 직접 요구한 것이다:

  > Set UNWIRED_BASELINE=562. The gap is not slack to spend: leaving it lets a later change add an unwired suite and still pass.

## 검증

- `dune build @test/runtest-test_keeper_librarian_retry` → **25/25 PASS** (별칭이 실제로 실행됨을 확인, 빈 alias 가 아님)
- `scripts/audit-ci-test-targets.sh` → exit 0 (301 targets / 562 unwired, baseline)

## 나중에 머지하는 쪽이 볼 것

**#28597 이 같은 상수를 건드린다.** 그 PR 은 다른 suite(`test_keeper_run_tools_hooks`)를 배선하면서 역시 563 → 562 로 내린다.

둘 다 들어가면 unwired 집합에서 suite 가 **두 개** 빠지므로, 나중에 머지되는 쪽은 **561** 로 가야 한다. 562 를 유지하면 안 된다. 그대로 두면 가드가 exit 2 로 막으므로 조용히 넘어가지는 않는다.

## 범위 밖

나머지 unwired suite 561 개는 건드리지 않았다. 이 PR 은 실제로 main 을 깨뜨린 하나만 다룬다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)