### PR TITLE
fix(keeper): run independent read tools concurrently

### DIFF
--- a/lib/keeper/keeper_tools_agent_core_bundle.ml
+++ b/lib/keeper/keeper_tools_agent_core_bundle.ml
@@ -231,8 +231,22 @@ let make_tool_bundle_for_descriptors
     List.concat_map
       (fun (descriptor : Keeper_tool_descriptor.t) ->
          let internal = descriptor.internal_name in
+         let completion_boundary =
+           completion_boundary_of_runtime_handler descriptor.runtime_handler
+         in
+         let agent_core_descriptor =
+           (* Only a descriptor's static read-only proof can admit sibling
+              execution. Input-dependent and mutating tools remain serial. *)
+           match completion_boundary, descriptor.policy.readonly_hint with
+           | Continue_after_success, Some true ->
+             Some
+               (Agent_core.Tool.ordinary_descriptor
+                  Agent_core.Tool_contract.Concurrent)
+           | (Continue_after_success | Terminal_effect), (None | Some false) -> None
+           | Terminal_effect, Some true -> None
+         in
          let on_completed, on_failed, on_externalization_error =
-           match completion_boundary_of_runtime_handler descriptor.runtime_handler with
+           match completion_boundary with
            | Terminal_effect ->
              ( Some
                  (function
@@ -276,6 +290,7 @@ let make_tool_bundle_for_descriptors
                  ()
              in
              Tool_bridge.agent_core_tool_of_masc_with_execution_env
+               ?descriptor:agent_core_descriptor
                ~base_path:config.base_path
                ~model_projection:descriptor.model_output_projection
                ?on_externalization_error


### PR DESCRIPTION
## Outcome

Keeper sibling tool calls now use Agent Core's existing concurrent batch only when the owning descriptor has a static `readonly_hint=true` proof.

## Live failure reproduced

An isolated Keeper emitted `keeper_time_now` and `masc_board_stats` as sibling ToolUse blocks in one assistant response. The deployed bridge omitted Agent Core execution descriptors, so both calls defaulted to `Serial`; the second started only after the first finished.

## Change

- pass `Tool.ordinary_descriptor Concurrent` for statically read-only, continue-after-success tools
- keep mutating, input-dependent, and terminal-effect tools on the existing serial default
- reuse the existing descriptor policy SSOT and Agent Core batch planner; no name matching or fallback

## Fast local evidence

- `ocamlformat --inplace lib/keeper/keeper_tools_agent_core_bundle.ml`
- `ocamlc -stop-after parsing -impl lib/keeper/keeper_tools_agent_core_bundle.ml`
- `git diff --check`
- `scripts/check-ssot.sh` passed
- `scripts/ocaml-structure-ratchet.sh` passed
- `scripts/check-agent-core-boundary.sh` passed
- `scripts/check_silent_failure.sh` reports the same 3 pre-existing findings outside this diff

Local Dune and new tests were intentionally not run per campaign instruction. CI and post-deploy live timing remain pending. Keep Draft; do not merge.
