### PR TITLE
fix(dashboard): expose Librarian exact run ID

### DIFF
--- a/dashboard/src/components/internal-agents-monitor.test.ts
+++ b/dashboard/src/components/internal-agents-monitor.test.ts
@@ -133,6 +133,7 @@ describe('InternalAgentsMonitor', () => {
     expect(within(filters).getByRole('button', { name: 'Auto Judge 1' })).toBeTruthy()
     expect(within(filters).getByRole('button', { name: 'Board Attention 1' })).toBeTruthy()
     expect(container.textContent).not.toContain('Board Judge')
+    expect(container.querySelector('code[translate="no"]')).toBeNull()
 
     fireEvent.click(within(filters).getByRole('button', { name: 'Auto Judge 1' }))
     expect(screen.getByRole('button', { name: /Auto Judge approval-1/i })).toBeTruthy()
@@ -203,6 +204,9 @@ describe('InternalAgentsMonitor', () => {
 
     const { container } = render(html`<${InternalAgentsMonitor} />`)
     const run = await screen.findByRole('button', { name: /Librarian trace-1/i })
+    const runIdentity = container.querySelector('code[translate="no"]')
+    expect(runIdentity?.textContent).toContain('run_id · exact-lib-1')
+    expect(runIdentity?.getAttribute('title')).toBe('exact-lib-1')
     fireEvent.click(run)
 
     expect(await screen.findByText('추가된 기억 1건')).toBeTruthy()

--- a/dashboard/src/components/internal-agents-monitor.ts
+++ b/dashboard/src/components/internal-agents-monitor.ts
@@ -623,6 +623,9 @@ export function InternalAgentsMonitor() {
                     <span class="min-w-0">
                       <strong class="block text-xs text-[var(--color-fg-primary)]">${laneLabel(row)}</strong>
                       <code class="block truncate text-3xs text-[var(--color-fg-muted)]" title=${subject(row)}>${subject(row)}</code>
+                      ${row.source === 'exact' && row.run.lane === 'librarian_exact'
+                        ? html`<code translate="no" class="block truncate text-3xs text-[var(--color-fg-muted)]" title=${row.run.runId}>run_id · ${row.run.runId}</code>`
+                        : null}
                     </span>
                     <span class="text-right text-3xs text-[var(--color-fg-muted)]">
                       <span class="block">${actor(row)}</span>


### PR DESCRIPTION
## Summary

- keep the Librarian trace subject visible in the Internal Agents timeline
- add the exact registry run_id as visible, non-translatable text with the full value in its title
- preserve existing disclosure and typed-detail behavior

## Why

The exact-lane API returned a stable Librarian run_id, but the dashboard rendered only subject_id. Operators could not correlate one displayed Librarian row with its exact registry run when a subject had multiple executions.

## Validation

- pnpm --dir dashboard exec vitest run src/components/internal-agents-monitor.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm --dir dashboard exec eslint src/components/internal-agents-monitor.ts
- pnpm --dir dashboard exec tsc --noEmit
- git diff --check

## Scope

One Dashboard component, three added lines. Schedule projection pagination is intentionally left for a separate follow-up.