### PR TITLE
fix(keeper): key tool observations by invocation

### DIFF
--- a/dashboard/src/api/dashboard-keeper-tool-calls.ts
+++ b/dashboard/src/api/dashboard-keeper-tool-calls.ts
@@ -42,6 +42,10 @@ export type ToolCallEntry = {
   // Agent Core model-tool occurrence slot. Together with turn it scopes provider ids
   // that may be blank or repeated.
   planned_index?: number
+  // Agent Core's actual batch assignment. These are schedule truth, not timing inference.
+  batch_index?: number
+  batch_size?: number
+  execution_mode?: 'serial' | 'concurrent'
   // Goal id(s) this call was attributed to (conditional on the row carrying
   // them), for goal-scoped drill-down alongside task_id/turn.
   goal_ids?: string[]
@@ -98,6 +102,12 @@ function decodeToolCallEntry(raw: unknown): ToolCallEntry | null {
     execution_id: asString(raw.execution_id),
     tool_use_id: typeof raw.tool_use_id === 'string' ? raw.tool_use_id : undefined,
     planned_index: asNumber(raw.planned_index),
+    batch_index: asNumber(raw.batch_index),
+    batch_size: asNumber(raw.batch_size),
+    execution_mode:
+      raw.execution_mode === 'serial' || raw.execution_mode === 'concurrent'
+        ? raw.execution_mode
+        : undefined,
     goal_ids: asStringArray(raw.goal_ids),
   }
 }

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -418,6 +418,9 @@ describe('keeper tool telemetry fetchers', () => {
             tool_use_id: '',
             turn: 6,
             planned_index: 2,
+            batch_index: 1,
+            batch_size: 3,
+            execution_mode: 'concurrent',
             goal_ids: ['g-1', 'g-2'],
           },
         ],
@@ -432,6 +435,9 @@ describe('keeper tool telemetry fetchers', () => {
     expect(entry?.tool_use_id).toBe('')
     expect(entry?.turn).toBe(6)
     expect(entry?.planned_index).toBe(2)
+    expect(entry?.batch_index).toBe(1)
+    expect(entry?.batch_size).toBe(3)
+    expect(entry?.execution_mode).toBe('concurrent')
   })
 
   it('keeps missing or malformed tool-call duration unmeasured', async () => {

--- a/dashboard/src/components/journey-panel.test.ts
+++ b/dashboard/src/components/journey-panel.test.ts
@@ -50,6 +50,10 @@ function toolCalls(): ToolCallsResponse {
         duration_ms: 120,
         trace_id: 'trace-1',
         turn: 1,
+        planned_index: 4,
+        batch_index: 0,
+        batch_size: 2,
+        execution_mode: 'concurrent',
       },
     ],
   }
@@ -198,6 +202,9 @@ describe('JourneyPanel', () => {
       expect(screen.getByText('fs_read')).toBeInTheDocument()
       expect(screen.getByText('agent turns 2')).toBeInTheDocument()
       expect(screen.getByText('trajectory + I/O')).toBeInTheDocument()
+      expect(screen.getByText('plan 4')).toBeInTheDocument()
+      expect(screen.getByText('batch 0 · size 2')).toBeInTheDocument()
+      expect(screen.getByText('mode concurrent')).toBeInTheDocument()
     })
 
     expect(fetchKeeperTrajectory).toHaveBeenCalledWith('keeper-a', 200, true, true)

--- a/dashboard/src/components/journey-panel.ts
+++ b/dashboard/src/components/journey-panel.ts
@@ -281,6 +281,15 @@ function WaterfallEntryRow({
         ${entry.round != null
           ? html`<span class="font-mono text-3xs text-[var(--color-fg-disabled)]">round ${entry.round}</span>`
           : null}
+        ${isTool && entry.plannedIndex != null
+          ? html`<span class="font-mono text-3xs text-[var(--color-fg-disabled)]">plan ${entry.plannedIndex}</span>`
+          : null}
+        ${isTool && entry.batchIndex != null && entry.batchSize != null
+          ? html`<span class="font-mono text-3xs text-[var(--color-fg-disabled)]">batch ${entry.batchIndex} · size ${entry.batchSize}</span>`
+          : null}
+        ${isTool && entry.executionMode
+          ? html`<span class="font-mono text-3xs text-[var(--color-fg-disabled)]">mode ${entry.executionMode}</span>`
+          : null}
       </div>
 
       ${isTool

--- a/dashboard/src/components/journey-waterfall-state.test.ts
+++ b/dashboard/src/components/journey-waterfall-state.test.ts
@@ -156,6 +156,10 @@ describe('buildJourneyWaterfall', () => {
           duration_ms: 250,
           trace_id: 'trace-1',
           turn: 2,
+          planned_index: 3,
+          batch_index: 1,
+          batch_size: 2,
+          execution_mode: 'concurrent',
         },
       ]),
       runtimeTrace: runtimeTrace(),
@@ -170,6 +174,10 @@ describe('buildJourneyWaterfall', () => {
     expect(toolEntry?.source).toBe('trajectory+tool_call_log')
     expect(toolEntry?.toolArgs).toEqual({ file_path: '/tmp/current' })
     expect(toolEntry?.toolResult).toBe('current result')
+    expect(toolEntry?.plannedIndex).toBe(3)
+    expect(toolEntry?.batchIndex).toBe(1)
+    expect(toolEntry?.batchSize).toBe(2)
+    expect(toolEntry?.executionMode).toBe('concurrent')
   })
 
   it('keeps tool-call-log rows when trajectory is missing', () => {
@@ -187,6 +195,10 @@ describe('buildJourneyWaterfall', () => {
           duration_ms: 10,
           trace_id: 'trace-1',
           keeper_turn_id: 5,
+          planned_index: 4,
+          batch_index: 2,
+          batch_size: 1,
+          execution_mode: 'serial',
         },
       ]),
       runtimeTrace: null,
@@ -195,6 +207,10 @@ describe('buildJourneyWaterfall', () => {
     expect(model.turns).toHaveLength(1)
     expect(model.turns[0]?.turn).toBe(5)
     expect(model.turns[0]?.entries[0]?.source).toBe('tool_call_log')
+    expect(model.turns[0]?.entries[0]?.plannedIndex).toBe(4)
+    expect(model.turns[0]?.entries[0]?.batchIndex).toBe(2)
+    expect(model.turns[0]?.entries[0]?.batchSize).toBe(1)
+    expect(model.turns[0]?.entries[0]?.executionMode).toBe('serial')
     expect(model.turns[0]?.runtimeEvidence).toBeNull()
   })
 

--- a/dashboard/src/components/journey-waterfall-state.ts
+++ b/dashboard/src/components/journey-waterfall-state.ts
@@ -36,6 +36,10 @@ export interface JourneyWaterfallEntry {
   error: string | null
   sessionId: string | null
   traceId: string | null
+  plannedIndex: number | null
+  batchIndex: number | null
+  batchSize: number | null
+  executionMode: 'serial' | 'concurrent' | null
 }
 
 export interface JourneyWaterfallRuntimeEvidence {
@@ -136,6 +140,13 @@ function traceEventStatus(event: UnifiedTraceEvent): WaterfallEntryStatus {
   return 'unknown'
 }
 
+function traceEventExecutionMode(
+  event: UnifiedTraceEvent,
+): JourneyWaterfallEntry['executionMode'] {
+  const value = event.detail.execution_mode
+  return value === 'serial' || value === 'concurrent' ? value : null
+}
+
 function entryFromTraceEvent(event: UnifiedTraceEvent): JourneyWaterfallEntry | null {
   if (event.kind !== 'tool_call' && event.kind !== 'thinking') return null
   const status = traceEventStatus(event)
@@ -159,6 +170,10 @@ function entryFromTraceEvent(event: UnifiedTraceEvent): JourneyWaterfallEntry | 
     error: event.error ?? null,
     sessionId: event.sessionId ?? null,
     traceId: traceEventTraceId(event),
+    plannedIndex: numberValue(event.detail.planned_index),
+    batchIndex: numberValue(event.detail.batch_index),
+    batchSize: numberValue(event.detail.batch_size),
+    executionMode: traceEventExecutionMode(event),
   }
 }
 

--- a/dashboard/src/components/keeper-tool-call-inspector-render.test.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector-render.test.ts
@@ -246,6 +246,9 @@ describe('KeeperToolCallInspector render', () => {
           tool_use_id: '',
           turn: 9,
           planned_index: 4,
+          batch_index: 0,
+          batch_size: 2,
+          execution_mode: 'concurrent',
           lane: 'autonomous',
         },
       ],
@@ -270,7 +273,9 @@ describe('KeeperToolCallInspector render', () => {
     expect(text).toContain('Evidence links')
     expect(text).toContain('Code')
     expect(text).toContain('Task')
-    expect(text).toContain('turn 9 · plan 4 · tool_use_id (blank)')
+    expect(text).toContain(
+      'turn 9 · plan 4 · batch 0 · size 2 · mode concurrent · tool_use_id (blank)',
+    )
   })
 
   it('does not render Code links for unsafe absolute tool-call file inputs', async () => {

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -206,6 +206,10 @@ function entryScopeLabel(entry: ToolCallEntry): string {
   const parts = [
     typeof entry.turn === 'number' ? `turn ${entry.turn}` : null,
     typeof entry.planned_index === 'number' ? `plan ${entry.planned_index}` : null,
+    typeof entry.batch_index === 'number' && typeof entry.batch_size === 'number'
+      ? `batch ${entry.batch_index} · size ${entry.batch_size}`
+      : null,
+    entry.execution_mode ? `mode ${entry.execution_mode}` : null,
     entry.tool_use_id !== undefined
       ? `tool_use_id ${entry.tool_use_id === '' ? '(blank)' : entry.tool_use_id}`
       : null,

--- a/dashboard/src/components/session-trace/session-trace-state.test.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.test.ts
@@ -372,6 +372,10 @@ describe('buildTraceEvents', () => {
           keeper_turn_id: 1,
           task_id: 'task-1',
           lane: 'runtime_mcp',
+          planned_index: 4,
+          batch_index: 1,
+          batch_size: 2,
+          execution_mode: 'concurrent',
         }],
       },
     )
@@ -381,6 +385,10 @@ describe('buildTraceEvents', () => {
     expect(toolEvents[0]!.toolResult).toBe('full file contents')
     expect(toolEvents[0]!.detail.trace_origin).toBe('trajectory+tool_call_log')
     expect(toolEvents[0]!.detail.lane).toBe('runtime_mcp')
+    expect(toolEvents[0]!.detail.planned_index).toBe(4)
+    expect(toolEvents[0]!.detail.batch_index).toBe(1)
+    expect(toolEvents[0]!.detail.batch_size).toBe(2)
+    expect(toolEvents[0]!.detail.execution_mode).toBe('concurrent')
   })
 
   it('preserves trajectory duration when the richer tool-call row has no duration', () => {
@@ -466,6 +474,10 @@ describe('buildTraceEvents', () => {
           keeper_turn_id: 3,
           task_id: 'task-2',
           lane: 'runtime_mcp',
+          planned_index: 5,
+          batch_index: 2,
+          batch_size: 1,
+          execution_mode: 'serial',
         }],
       },
     )
@@ -474,6 +486,10 @@ describe('buildTraceEvents', () => {
     expect(events[0]!.toolName).toBe('Execute')
     expect(events[0]!.error).toBe('command exited 1')
     expect(events[0]!.detail.trace_origin).toBe('tool_call_log')
+    expect(events[0]!.detail.planned_index).toBe(5)
+    expect(events[0]!.detail.batch_index).toBe(2)
+    expect(events[0]!.detail.batch_size).toBe(1)
+    expect(events[0]!.detail.execution_mode).toBe('serial')
     expect(events[0]!.detail.lane).toBe('runtime_mcp')
   })
 

--- a/dashboard/src/components/session-trace/session-trace-state.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.ts
@@ -426,6 +426,10 @@ function toolCallMetadataDetail(entry: ToolCallEntry, traceOrigin: string): Reco
   if (entry.lane) detail.lane = entry.lane
   if (entry.model) detail.model = entry.model
   if (entry.execution_id) detail.execution_id = entry.execution_id
+  if (entry.planned_index != null) detail.planned_index = entry.planned_index
+  if (entry.batch_index != null) detail.batch_index = entry.batch_index
+  if (entry.batch_size != null) detail.batch_size = entry.batch_size
+  if (entry.execution_mode) detail.execution_mode = entry.execution_mode
   return detail
 }
 

--- a/lib/keeper/keeper_event_bridge.ml
+++ b/lib/keeper/keeper_event_bridge.ml
@@ -313,16 +313,11 @@ let native_event_to_json (evt : Agent_core.Event_bus.event) : Yojson.Safe.t opti
     in
     Some (wrap ~event_type:"tool_called" ~payload ~agent_name ~tool_name ())
   | Agent_core.Event_bus.ToolCompleted { invocation; agent_name; tool_name; _ } ->
-    (* RFC-0233 PR-2: the keeper post_tool_use hook registered the
-       tool_use_id ↔ execution_id pair before AGENT_CORE published this event,
-       so the lookup is deterministic. A miss means the execution did not
-       go through a keeper hook (worker/eval lanes), not a failure. *)
-    let tool_use_id = Agent_core.Tool_contract.Invocation.tool_use_id invocation in
+    (* RFC-0233 PR-2: the keeper post_tool_use hook registered this exact
+       immutable invocation before AGENT_CORE published the event. Physical
+       invocation identity keeps blank/repeated provider ids distinct. *)
     let execution_id_fields =
-      match
-        if tool_use_id = "" then None
-        else Keeper_execution_join.take ~tool_use_id
-      with
+      match Keeper_execution_join.take ~invocation with
       | Some execution_id -> [ "execution_id", `String execution_id ]
       | None -> []
     in

--- a/lib/keeper/keeper_event_bridge.ml
+++ b/lib/keeper/keeper_event_bridge.ml
@@ -186,8 +186,13 @@ let wrap_event
     compile-time update requirement at this boundary. *)
 let invocation_payload_fields invocation =
   let tool_use_id = Agent_core.Tool_contract.Invocation.tool_use_id invocation in
+  let schedule = Agent_core.Tool_contract.Invocation.schedule invocation in
   [ "turn", `Int (Agent_core.Tool_contract.Invocation.turn invocation)
-  ; "planned_index", `Int (Agent_core.Tool_contract.Invocation.planned_index invocation)
+  ; "planned_index", `Int schedule.planned_index
+  ; "batch_index", `Int schedule.batch_index
+  ; "batch_size", `Int schedule.batch_size
+  ; ( "execution_mode"
+    , Agent_core.Tool_contract.execution_mode_to_yojson schedule.execution_mode )
   ]
   @ (if tool_use_id = "" then [] else [ "tool_use_id", `String tool_use_id ])
 ;;

--- a/lib/keeper/keeper_event_bridge_error_json.ml
+++ b/lib/keeper/keeper_event_bridge_error_json.ml
@@ -219,11 +219,16 @@ let core_agent_error_fields = function
     ]
   | Agent_core.Error.TerminalToolDurabilityFailed
       { invocation; effect_disposition; detail } ->
+    let schedule = Agent_core.Tool_contract.Invocation.schedule invocation in
     [ "variant", `String "terminal_tool_durability_failed"
     ; ( "tool_use_id"
       , `String (Agent_core.Tool_contract.Invocation.tool_use_id invocation) )
     ; "turn", `Int (Agent_core.Tool_contract.Invocation.turn invocation)
-    ; "planned_index", `Int (Agent_core.Tool_contract.Invocation.planned_index invocation)
+    ; "planned_index", `Int schedule.planned_index
+    ; "batch_index", `Int schedule.batch_index
+    ; "batch_size", `Int schedule.batch_size
+    ; ( "execution_mode"
+      , Agent_core.Tool_contract.execution_mode_to_yojson schedule.execution_mode )
     ; ( "effect_disposition"
       , `String (Keeper_agent_error.terminal_effect_disposition_to_wire effect_disposition) )
     ; "detail_digest", `String (sha256_hex detail)

--- a/lib/keeper/keeper_execution_join.ml
+++ b/lib/keeper/keeper_execution_join.ml
@@ -1,25 +1,32 @@
-(* See keeper_execution_join.mli for the happens-before argument that
-   makes this table deterministic rather than a time-window heuristic. *)
+(* See keeper_execution_join.mli for the happens-before and weak-ownership
+   arguments that make this deterministic without leaking cancelled calls. *)
 
-let table : (string, string) Hashtbl.t = Hashtbl.create 64
+module Invocation_key = struct
+  type t = Agent_core.Tool_contract.Invocation.t
+
+  let equal left right = left == right
+  let hash = Hashtbl.hash
+end
+
+module Invocation_table = Ephemeron.K1.Make (Invocation_key)
+
+let table : string Invocation_table.t = Invocation_table.create 64
 let lock = Mutex.create ()
 
-let record ~tool_use_id ~execution_id =
-  if tool_use_id <> "" then begin
-    Mutex.lock lock;
-    Fun.protect
-      ~finally:(fun () -> Mutex.unlock lock)
-      (fun () -> Hashtbl.replace table tool_use_id execution_id)
-  end
+let record ~invocation ~execution_id =
+  Mutex.lock lock;
+  Fun.protect
+    ~finally:(fun () -> Mutex.unlock lock)
+    (fun () -> Invocation_table.replace table invocation execution_id)
 
-let take ~tool_use_id =
+let take ~invocation =
   Mutex.lock lock;
   Fun.protect
     ~finally:(fun () -> Mutex.unlock lock)
     (fun () ->
-      match Hashtbl.find_opt table tool_use_id with
+      match Invocation_table.find_opt table invocation with
       | Some execution_id ->
-        Hashtbl.remove table tool_use_id;
+        Invocation_table.remove table invocation;
         Some execution_id
       | None -> None)
 
@@ -28,11 +35,13 @@ module For_testing = struct
     Mutex.lock lock;
     Fun.protect
       ~finally:(fun () -> Mutex.unlock lock)
-      (fun () -> Hashtbl.length table)
+      (fun () ->
+         Invocation_table.clean table;
+         Invocation_table.length table)
 
   let clear () =
     Mutex.lock lock;
     Fun.protect
       ~finally:(fun () -> Mutex.unlock lock)
-      (fun () -> Hashtbl.reset table)
+      (fun () -> Invocation_table.reset table)
 end

--- a/lib/keeper/keeper_execution_join.mli
+++ b/lib/keeper/keeper_execution_join.mli
@@ -1,4 +1,4 @@
-(** In-flight join table from provider [tool_use_id] to the
+(** In-flight join table from an exact Agent Core invocation to the
     [execution_id] minted at the masc dispatch boundary (RFC-0233 PR-2).
 
     The keeper [post_tool_use] hook records the pair synchronously inside
@@ -7,15 +7,20 @@
     publish, so a [take] at serialization time is deterministic:
     insert happens-before publish happens-before drain.
 
+    Invocation keys are weak and physically identified. The hook and event bus
+    carry the same immutable invocation value, while a cancelled publication
+    cannot leave the invocation alive through this table. Blank or repeated
+    provider tool-use ids therefore remain distinct occurrences.
+
     A missing entry is not an error — bus events from non-keeper agents
     (workers, evals) never get an entry because only keeper hooks mint
     execution ids. *)
 
-val record : tool_use_id:string -> execution_id:string -> unit
-(** Register an in-flight pair. An empty [tool_use_id] is ignored: the
-    provider supplied no call id, so no event-side join is possible. *)
+val record :
+  invocation:Agent_core.Tool_contract.Invocation.t -> execution_id:string -> unit
+(** Register the exact invocation/execution pair. *)
 
-val take : tool_use_id:string -> string option
+val take : invocation:Agent_core.Tool_contract.Invocation.t -> string option
 (** Look up and remove the pair. [None] means the event does not belong
     to a keeper execution (or the entry was already consumed). *)
 

--- a/lib/keeper/keeper_hooks_agent_core.ml
+++ b/lib/keeper/keeper_hooks_agent_core.ml
@@ -459,7 +459,6 @@ let make_hooks
         let tool_use_id = Agent_core.Tool_contract.Invocation.tool_use_id invocation in
         let original_bytes, truncated_to =
           Keeper_tool_call_log.consume_truncation_info
-            ~keeper_name:(!meta_ref).name
             ~invocation
             ()
         in
@@ -480,7 +479,7 @@ let make_hooks
            strictly before AGENT_CORE publishes ToolCompleted for this call, so the
            event bridge can stamp the same id onto the agent_core:tool_completed
            row (insert happens-before publish happens-before drain). *)
-        Keeper_execution_join.record ~tool_use_id
+        Keeper_execution_join.record ~invocation
           ~execution_id:(Ids.Execution_id.to_string execution_id);
         (try
            Keeper_tool_call_log.log_call

--- a/lib/keeper/keeper_hooks_agent_core.ml
+++ b/lib/keeper/keeper_hooks_agent_core.ml
@@ -460,7 +460,7 @@ let make_hooks
         let original_bytes, truncated_to =
           Keeper_tool_call_log.consume_truncation_info
             ~keeper_name:(!meta_ref).name
-            ~tool_use_id
+            ~invocation
             ()
         in
         let result_bytes = if original_bytes > 0 then original_bytes else out_len in

--- a/lib/keeper/keeper_hooks_agent_core.ml
+++ b/lib/keeper/keeper_hooks_agent_core.ml
@@ -475,6 +475,7 @@ let make_hooks
            the log_call row and the trajectory entry below share the value
            so downstream views can join the two stores on a single key. *)
         let execution_id = Ids.Execution_id.generate () in
+        let schedule = Agent_core.Tool_contract.Invocation.schedule invocation in
         (* RFC-0233 PR-2: register the provider-call ↔ execution pair now,
            strictly before AGENT_CORE publishes ToolCompleted for this call, so the
            event bridge can stamp the same id onto the agent_core:tool_completed
@@ -494,7 +495,10 @@ let make_hooks
              ?prompt_fingerprint:tctx.prompt_fingerprint
              ~execution_id
              ~tool_use_id
-             ~planned_index:(Agent_core.Tool_contract.Invocation.planned_index invocation)
+             ~planned_index:schedule.planned_index
+             ~batch_index:schedule.batch_index
+             ~batch_size:schedule.batch_size
+             ~execution_mode:schedule.execution_mode
              ?trace_id:tctx.trace_id ?session_id:tctx.session_id
              ?generation:tctx.generation
              ?turn:invocation_turn ?keeper_turn_id:tctx.keeper_turn_id

--- a/lib/keeper/keeper_hooks_agent_core.ml
+++ b/lib/keeper/keeper_hooks_agent_core.ml
@@ -144,7 +144,6 @@ let make_hooks
     ()
   : Agent_core.Hooks.hooks =
   let sse_turn_complete = "keeper_turn_complete" in
-  let tool_start_time = ref 0.0 in
   (* Per-turn tool call counter for SSE enrichment.
      Incremented in post_tool_use, reset in after_turn. *)
   let tool_call_count_ref = ref 0 in
@@ -156,13 +155,6 @@ let make_hooks
   in
   let hooks =
     { Agent_core.Hooks.empty with
-    pre_tool_use = Some (fun event ->
-      match event with
-      | Agent_core.Hooks.PreToolUse _ ->
-        tool_start_time := Time_compat.now ();
-        Agent_core.Hooks.Continue
-      | _event -> Agent_core.Hooks.Continue);
-
     before_turn = Some (fun event ->
       match event with
       | Agent_core.Hooks.BeforeTurn _ ->
@@ -445,14 +437,9 @@ let make_hooks
           "keeper:%s tool_call tool=%s params=[%s] input_shape=[%s] outcome=%s out_len=%d error_preview=%s"
           (!meta_ref).name tool_name input_keys input_shape outcome_s out_len
           error_preview;
-        (* Persistent tool call I/O log for dashboard inspector.
-           tool_start_time is keeper-local (one ref per make_hooks call).
-           Tool calls within Agent.run are sequential, so no race. *)
-        let duration_ms =
-          if hook_duration_ms > 0.0
-          then hook_duration_ms
-          else (Time_compat.now () -. !tool_start_time) *. ms_per_second
-        in
+        (* Agent Core measures duration per invocation. Do not reconstruct it
+           from Keeper-global mutable state: sibling calls may overlap. *)
+        let duration_ms = hook_duration_ms in
         let model =
           current_keeper_model !meta_ref
         in
@@ -469,9 +456,12 @@ let make_hooks
         (* Consume truncation info set by keeper_tools_agent_core before returning
            the (possibly truncated) result to AGENT_CORE. Falls back to out_len
            when no truncation info was set (e.g. AGENT_CORE-internal tool calls). *)
-        let (original_bytes, truncated_to) =
+        let tool_use_id = Agent_core.Tool_contract.Invocation.tool_use_id invocation in
+        let original_bytes, truncated_to =
           Keeper_tool_call_log.consume_truncation_info
-            ~keeper_name:(!meta_ref).name ()
+            ~keeper_name:(!meta_ref).name
+            ~tool_use_id
+            ()
         in
         let result_bytes = if original_bytes > 0 then original_bytes else out_len in
         (* Full record read: log_call no longer falls back to ambient
@@ -481,7 +471,6 @@ let make_hooks
           Keeper_tool_call_log_context.get_turn_context_record
             ~cell:turn_ctx_cell ()
         in
-        let tool_use_id = Agent_core.Tool_contract.Invocation.tool_use_id invocation in
         let invocation_turn = Some (Agent_core.Tool_contract.Invocation.turn invocation) in
         (* RFC-0233 PR-1: one mint per execution at this dispatch boundary;
            the log_call row and the trajectory entry below share the value

--- a/lib/keeper/keeper_hooks_agent_core_introspection.ml
+++ b/lib/keeper/keeper_hooks_agent_core_introspection.ml
@@ -61,11 +61,6 @@ let hook_introspection_json () : Yojson.Safe.t =
       slot
         ~active:true
         ~source:"keeper_hooks_agent_core"
-        ~features:[ "tool_start_timing" ]
-        "pre_tool_use";
-      slot
-        ~active:true
-        ~source:"keeper_hooks_agent_core"
         ~features:
           [
             "tool_callback";

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -15,7 +15,10 @@ open Keeper_agent_prompt_metrics
 
     AGENT_CORE hooks (before_turn, on_tool_executed) cannot return values, so
     they write into this single mutable record during Agent.run execution.
-    After execution completes, {!freeze} produces an immutable snapshot. *)
+    After execution completes, {!freeze} produces an immutable snapshot.
+    Concurrent tool completions serialize the whole [on_tool_executed]
+    observation transaction per run; observers must therefore remain bounded
+    and must not perform open-ended I/O while holding that boundary. *)
 type hook_accumulator =
   { mutable meta : Keeper_meta_contract.keeper_meta
   ; mutable tool_calls : tool_call_detail list

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -10,6 +10,25 @@ open Keeper_agent_prompt_metrics
 
 type hook_accumulator = Keeper_run_tools_hook_accumulator.hook_accumulator
 
+type tool_observer_serialization = (unit -> unit) -> unit
+
+let create_tool_observer_serialization () : tool_observer_serialization =
+  let mutex = Eio.Mutex.create () in
+  fun observe ->
+    Eio.Mutex.lock mutex;
+    (* The enclosing Agent-core hook reports a failed observer and continues.
+       [use_rw] would poison the per-run mutex on that reported exception and
+       reject every later completion. Unlock explicitly while protecting the
+       acquired critical section from cancellation, so one failed observation
+       cannot erase unrelated later receipts. *)
+    Eio.Cancel.protect (fun () ->
+      match observe () with
+      | () -> Eio.Mutex.unlock mutex
+      | exception exn ->
+        Eio.Mutex.unlock mutex;
+        raise exn)
+;;
+
 type agent_setup =
   { tools : Agent_core.Tool.t list
   ; cleanup : unit -> unit
@@ -210,6 +229,13 @@ let assemble_hooks
       acc
       initial_schema_filter;
     let meta_ref = ref acc.meta in
+    (* Explicitly concurrent tools complete in sibling fibers. Their tool bodies
+       stay concurrent, but the post-tool observer is one transaction: it
+       refreshes [acc.meta], appends the receipt detail, derives the fallback
+       turn identity, and emits the observation/activity pair. A per-run Eio
+       mutex gives those effects one order without introducing a process-global
+       gate or serializing tool execution itself. *)
+    let serialize_tool_observer = create_tool_observer_serialization () in
     let base_hooks =
       Keeper_hooks_agent_core.make_hooks
         ~config
@@ -224,106 +250,107 @@ let assemble_hooks
         ~on_tool_executed:
           (fun
             ~tool_name ~input ~output_text ~success ~duration_ms ~provider ~typed_outcome ->
-          let route_evidence =
-            Keeper_tool_call_log.route_evidence_json_of_tool_io
-              ~tool_name
-              ~input
-              ~output_text
-          in
-          let progress_io_fingerprints =
-            Keeper_tool_progress_identity.digest_tool_io
-              ~tool_name
-              ~input
-              ~output_text
-          in
-          (match Keeper_registry.get ~base_path:config.base_path meta.name with
-           | Some entry ->
-             acc.meta <- entry.meta;
-             meta_ref := entry.meta
-           | None -> ());
-          let execution_outcome =
-            if success then Tool_result.Ok else Tool_result.Error
-          in
-          let task_id =
-            Keeper_run_tools_task_scope.task_id_scope_of_tool_call
-              ~tool_name
-              ~input
-              ~meta:acc.meta
-          in
-          acc.tool_calls
-          <- { tool_name
-             ; provider
-             ; execution_outcome
-             ; typed_outcome
-             ; latency_ms = duration_ms
-             ; task_id
-             ; route_evidence
-             ; input_fingerprint =
-                 Option.map
-                   (fun (d : Keeper_tool_progress_identity.io_fingerprints) ->
-                      d.input_fingerprint)
-                   progress_io_fingerprints
-             ; output_fingerprint =
-                 Option.map
-                   (fun (d : Keeper_tool_progress_identity.io_fingerprints) ->
-                      d.output_fingerprint)
-                   progress_io_fingerprints
-             }
-             :: acc.tool_calls;
-          (* Emit neutral agent observation events; UI adapters subscribe separately. *)
-          (let typed_outcome_str =
-             match typed_outcome with
-             | Some Keeper_tool_outcome.Progress -> "progress"
-             | Some (Keeper_tool_outcome.No_progress _) -> "no_progress"
-             | Some (Keeper_tool_outcome.Error _) -> "error"
-             | None -> Tool_result.string_of_tool_call_outcome execution_outcome
-           in
-           let turn_id =
-             match acc.meta.Keeper_meta_contract.current_task_id with
-             | Some t -> Keeper_id.Task_id.to_string t
-             | None -> "turn-" ^ string_of_int (List.length acc.tool_calls)
-           in
-           (* task-1733: resolve the partition from the tool's actual edited
-              file (input.path / input.file_path, with explicit cwd honoured
-              for relative paths), not from the [.masc] runtime root.
-              #23469: relative shapes anchor at this keeper's playground
-              sandbox root, matching the file tools' own resolution. *)
-           let partition, observed_file_path =
-             observation_partition_for_tool_input
-               ~config
-               ~meta:acc.meta
-               ~kind:"tool_event"
-               input
-           in
-           Agent_observation.emit_tool_event
-             { base_path = config.base_path
-             ; partition
-             ; file_path = observed_file_path
-             ; tool_name
-             ; keeper_id = acc.meta.name
-             ; turn_id
-             ; outcome = Tool_result.string_of_tool_call_outcome execution_outcome
-             ; typed_outcome = typed_outcome_str
-             ; duration_ms
-             ; output_text
-             ; input
-             };
-           (* #23540: keeper in-turn tool executions never reached the
-              activity log ([tool.called] is emitted only by the external MCP
-              path), so the agent timeline reported tool_calls = 0 for any
-              keeper working through its own turn. *)
-           Keeper_tool_activity.emit_tool_exec
-             ~config
-             ~meta:acc.meta
-             ~tool_name
-             ~success
-             ~duration_ms:(int_of_float (Float.round duration_ms))
-             ~typed_outcome
-             ~provider
-             ~keeper_turn_id:(Some keeper_turn_id)
-             ~agent_core_turn:acc.current_turn
-             ~task_id
-             ()))
+            serialize_tool_observer (fun () ->
+              let route_evidence =
+                Keeper_tool_call_log.route_evidence_json_of_tool_io
+                  ~tool_name
+                  ~input
+                  ~output_text
+              in
+              let progress_io_fingerprints =
+                Keeper_tool_progress_identity.digest_tool_io
+                  ~tool_name
+                  ~input
+                  ~output_text
+              in
+              (match Keeper_registry.get ~base_path:config.base_path meta.name with
+               | Some entry ->
+                 acc.meta <- entry.meta;
+                 meta_ref := entry.meta
+               | None -> ());
+              let execution_outcome =
+                if success then Tool_result.Ok else Tool_result.Error
+              in
+              let task_id =
+                Keeper_run_tools_task_scope.task_id_scope_of_tool_call
+                  ~tool_name
+                  ~input
+                  ~meta:acc.meta
+              in
+              acc.tool_calls
+              <- { tool_name
+                 ; provider
+                 ; execution_outcome
+                 ; typed_outcome
+                 ; latency_ms = duration_ms
+                 ; task_id
+                 ; route_evidence
+                 ; input_fingerprint =
+                     Option.map
+                       (fun (d : Keeper_tool_progress_identity.io_fingerprints) ->
+                          d.input_fingerprint)
+                       progress_io_fingerprints
+                 ; output_fingerprint =
+                     Option.map
+                       (fun (d : Keeper_tool_progress_identity.io_fingerprints) ->
+                          d.output_fingerprint)
+                       progress_io_fingerprints
+                 }
+                 :: acc.tool_calls;
+              (* Emit neutral agent observation events; UI adapters subscribe separately. *)
+              (let typed_outcome_str =
+                 match typed_outcome with
+                 | Some Keeper_tool_outcome.Progress -> "progress"
+                 | Some (Keeper_tool_outcome.No_progress _) -> "no_progress"
+                 | Some (Keeper_tool_outcome.Error _) -> "error"
+                 | None -> Tool_result.string_of_tool_call_outcome execution_outcome
+               in
+               let turn_id =
+                 match acc.meta.Keeper_meta_contract.current_task_id with
+                 | Some t -> Keeper_id.Task_id.to_string t
+                 | None -> "turn-" ^ string_of_int (List.length acc.tool_calls)
+               in
+               (* task-1733: resolve the partition from the tool's actual edited
+                  file (input.path / input.file_path, with explicit cwd honoured
+                  for relative paths), not from the [.masc] runtime root.
+                  #23469: relative shapes anchor at this keeper's playground
+                  sandbox root, matching the file tools' own resolution. *)
+               let partition, observed_file_path =
+                 observation_partition_for_tool_input
+                   ~config
+                   ~meta:acc.meta
+                   ~kind:"tool_event"
+                   input
+               in
+               Agent_observation.emit_tool_event
+                 { base_path = config.base_path
+                 ; partition
+                 ; file_path = observed_file_path
+                 ; tool_name
+                 ; keeper_id = acc.meta.name
+                 ; turn_id
+                 ; outcome = Tool_result.string_of_tool_call_outcome execution_outcome
+                 ; typed_outcome = typed_outcome_str
+                 ; duration_ms
+                 ; output_text
+                 ; input
+                 };
+               (* #23540: keeper in-turn tool executions never reached the
+                  activity log ([tool.called] is emitted only by the external MCP
+                  path), so the agent timeline reported tool_calls = 0 for any
+                  keeper working through its own turn. *)
+               Keeper_tool_activity.emit_tool_exec
+                 ~config
+                 ~meta:acc.meta
+                 ~tool_name
+                 ~success
+                 ~duration_ms:(int_of_float (Float.round duration_ms))
+                 ~typed_outcome
+                 ~provider
+                 ~keeper_turn_id:(Some keeper_turn_id)
+                 ~agent_core_turn:acc.current_turn
+                 ~task_id
+                 ())))
         ()
     in
     let before_turn_hook : Agent_core.Hooks.hooks =

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -42,6 +42,20 @@ type input_schema_source =
 
 type readonly_of_input = Yojson.Safe.t -> bool option
 
+type ordinary_execution_mode =
+  | Serial
+  | Concurrent
+
+type execution =
+  | Ordinary of ordinary_execution_mode
+  | Terminal
+
+let execution_to_string = function
+  | Ordinary Serial -> "serial"
+  | Ordinary Concurrent -> "concurrent"
+  | Terminal -> "terminal"
+;;
+
 type identity_validation =
   | Validate_once_before_translation
   | Validate_once_after_translation
@@ -115,6 +129,7 @@ type t =
   ; description : string
   ; input_schema : Yojson.Safe.t
   ; model_output_projection : Tool_output.model_projection
+  ; execution : execution
   ; policy : policy
   ; executor : executor
   ; backend : backend
@@ -496,6 +511,7 @@ let descriptor
       ~description
       ~input_schema
       ?(model_output_projection = Tool_output.default_model_projection)
+      ?(ordinary_execution_mode = Serial)
       ~policy
       ~executor
       ~backend
@@ -506,6 +522,46 @@ let descriptor
   =
   let capability_id =
     capability_id_of_identity ~internal_name capability_identity
+  in
+  let execution =
+    match runtime_handler with
+    | Tool_surface_post -> Terminal
+    | ( Tool_execute
+      | Tool_search_files
+      | Tool_read_file
+      | Tool_edit_file
+      | Tool_write_file
+      | Tool_time_now
+      | Tool_tools_list
+      | Tool_context_status
+      | Tool_artifact_read
+      | Tool_memory_search
+      | Tool_memory_write
+      | Tool_library_search
+      | Tool_library_read
+      | Tool_surface_read
+      | Tool_person_note_set
+      | Tool_ide_annotate
+      | Tool_voice_dispatch
+      | Tool_task_dispatch
+      | Tool_board_dispatch
+      | Tool_masc_task_dispatch
+      | Tool_masc_plan_dispatch
+      | Tool_masc_run_dispatch
+      | Tool_masc_agent_dispatch
+      | Tool_masc_workspace_dispatch
+      | Tool_masc_misc_dispatch
+      | Tool_web_search
+      | Tool_web_fetch
+      | Tool_masc_control_dispatch
+      | Tool_masc_agent_timeline_dispatch
+      | Tool_masc_schedule_dispatch
+      | Tool_masc_keeper_dispatch
+      | Tool_masc_fusion_dispatch
+      | Tool_masc_fusion_status
+      | Tool_masc_library_dispatch
+      | Tool_masc_local_runtime_dispatch
+      | Tool_analyze_image ) -> Ordinary ordinary_execution_mode
   in
   let receipt_labels =
     [ "descriptor_id", id
@@ -518,6 +574,7 @@ let descriptor
     ; "backend", backend_to_string backend
     ; "sandbox", sandbox_to_string sandbox
     ; "runtime_handler", runtime_handler_to_string runtime_handler
+    ; "execution", execution_to_string execution
     ; ( "keeper_tool_group"
       , keeper_tool_group_to_string
           (keeper_tool_group_of_runtime_handler runtime_handler) )
@@ -538,6 +595,7 @@ let descriptor
   ; description
   ; input_schema
   ; model_output_projection
+  ; execution
   ; policy
   ; executor
   ; backend
@@ -1010,6 +1068,7 @@ let in_process_descriptor_with_schema_source
       ~capability_identity
       ~keeper_model_projection
       ~input_schema_source ~id ~name ~description ~input_schema ~policy ~handler
+      ?ordinary_execution_mode
       ()
   =
   descriptor
@@ -1021,6 +1080,7 @@ let in_process_descriptor_with_schema_source
     ~internal_name:name
     ~description
     ~input_schema
+    ?ordinary_execution_mode
     ~policy
     ~executor:In_process
     ~backend:Ocaml_runtime
@@ -1031,7 +1091,8 @@ let in_process_descriptor_with_schema_source
 ;;
 
 let in_process_descriptor ~keeper_model_projection ~id ~name ~description
-      ~input_schema ~policy ~handler
+      ~input_schema ~policy ?ordinary_execution_mode ~handler
+      ()
   =
   in_process_descriptor_with_schema_source
     ~capability_identity:Internal_name_identity
@@ -1043,6 +1104,7 @@ let in_process_descriptor ~keeper_model_projection ~id ~name ~description
     ~input_schema
     ~policy
     ~handler
+    ?ordinary_execution_mode
     ()
 ;;
 
@@ -1120,6 +1182,30 @@ let masc_board_descriptor board_name =
   let name = Tool_name.Board_name.to_string board_name in
   let operation_policy = Board_tool_registry.operation_policy board_name in
   let readonly = operation_policy.readonly in
+  let ordinary_execution_mode =
+    match board_name with
+    | Tool_name.Board_name.Board_stats -> Concurrent
+    | ( Board_cleanup
+      | Board_comment
+      | Board_comment_vote
+      | Board_curation_read
+      | Board_curation_submit
+      | Board_delete
+      | Board_hearths
+      | Board_list
+      | Board_post
+      | Board_post_get
+      | Board_post_update
+      | Board_profile
+      | Board_reaction
+      | Board_search
+      | Board_sub_board_create
+      | Board_sub_board_delete
+      | Board_sub_board_get
+      | Board_sub_board_list
+      | Board_sub_board_update
+      | Board_vote ) -> Serial
+  in
   let policy = policy ~readonly ~retryable:readonly () in
   let canonical_keeper_input_schema =
     remove_schema_fields
@@ -1141,6 +1227,7 @@ let masc_board_descriptor board_name =
        ~name
        ~description
        ~input_schema
+       ~ordinary_execution_mode
        ~policy
        ~handler:Tool_board_dispatch
        ()
@@ -1406,8 +1493,10 @@ let internal_descriptors : t list =
         "Return the current wall-clock time as ISO 8601 and Unix epoch \
          seconds. No arguments."
       ~input_schema:empty_object_schema
+      ~ordinary_execution_mode:Concurrent
       ~policy:(read_only_in_process_policy ())
       ~handler:Tool_time_now
+      ()
   ; (in_process_descriptor
        ~keeper_model_projection:Internal_name
        ~id:"keeper.tools_list"
@@ -1420,6 +1509,7 @@ let internal_descriptors : t list =
        ~input_schema:empty_object_schema
        ~policy:(read_only_in_process_policy ())
        ~handler:Tool_tools_list
+       ()
      |> with_eval_tags [ "capability_introspection" ])
     (* ── memory / context (RFC-0179 PR-3) ─────────────────────── *)
   ; in_process_descriptor
@@ -1433,6 +1523,7 @@ let internal_descriptors : t list =
       ~input_schema:empty_object_schema
       ~policy:(read_only_in_process_policy ())
       ~handler:Tool_context_status
+      ()
   ; (in_process_descriptor_with_schema_source
       ~capability_identity:Internal_name_identity
       ~keeper_model_projection:Internal_name
@@ -1477,6 +1568,7 @@ let internal_descriptors : t list =
       ~input_schema:library_search_schema
       ~policy:(read_only_in_process_policy ())
       ~handler:Tool_library_search
+      ()
   ; in_process_descriptor
       ~keeper_model_projection:Internal_name
       ~id:"keeper.library.read"
@@ -1485,6 +1577,7 @@ let internal_descriptors : t list =
       ~input_schema:library_read_schema
       ~policy:(read_only_in_process_policy ())
       ~handler:Tool_library_read
+      ()
     (* ── connector surfaces (RFC-0223 P3) ─────────────────────── *)
   ; (in_process_descriptor
        ~keeper_model_projection:Internal_name
@@ -1499,6 +1592,7 @@ let internal_descriptors : t list =
        ~input_schema:surface_read_schema
        ~policy:(read_only_in_process_policy ())
        ~handler:Tool_surface_read
+       ()
      |> with_eval_tags [ "surface_context_read" ])
   ; in_process_descriptor
       ~keeper_model_projection:Internal_name
@@ -1508,6 +1602,7 @@ let internal_descriptors : t list =
       ~input_schema:surface_post_schema
       ~policy:(write_in_process_policy ())
       ~handler:Tool_surface_post
+      ()
   ; in_process_descriptor
       ~keeper_model_projection:Internal_name
       ~id:"keeper.person.note_set"
@@ -1520,6 +1615,7 @@ let internal_descriptors : t list =
       ~input_schema:person_note_set_schema
       ~policy:(write_in_process_policy ())
       ~handler:Tool_person_note_set
+      ()
     (* ── IDE (RFC-0179 PR-3) ──────────────────────────────────── *)
   ; in_process_descriptor_with_schema_source
       ~capability_identity:Internal_name_identity
@@ -1919,6 +2015,7 @@ let route_evidence_json d =
      ; "backend", `String (backend_to_string d.backend)
      ; "sandbox", `String (sandbox_to_string d.sandbox)
      ; "runtime_handler", `String (runtime_handler_to_string d.runtime_handler)
+     ; "execution", `String (execution_to_string d.execution)
      ; "receipt_labels", receipt_labels_json d
      ; "eval_tags", eval_tags_json d
      ]
@@ -1953,6 +2050,7 @@ let discovery_fields d =
    ; "backend", `String (backend_to_string d.backend)
    ; "sandbox", `String (sandbox_to_string d.sandbox)
    ; "runtime_handler", `String (runtime_handler_to_string d.runtime_handler)
+   ; "execution", `String (execution_to_string d.execution)
    ; "policy", discovery_policy_json d.policy
    ; "schema_shape", Tool_input_validation.schema_shape_json d.input_schema
    ]

--- a/lib/keeper/keeper_tool_descriptor.mli
+++ b/lib/keeper/keeper_tool_descriptor.mli
@@ -57,6 +57,17 @@ type input_schema_source =
 
 type readonly_of_input = Yojson.Safe.t -> bool option
 
+type ordinary_execution_mode =
+  | Serial
+  | Concurrent
+
+type execution =
+  | Ordinary of ordinary_execution_mode
+  | Terminal
+(** Descriptor-owned execution contract. Read-only classification does not
+    imply concurrency safety, and terminal concurrent execution is not
+    representable. *)
+
 type identity_validation =
   | Validate_once_before_translation
   | Validate_once_after_translation
@@ -135,6 +146,7 @@ type t =
   ; description : string
   ; input_schema : Yojson.Safe.t
   ; model_output_projection : Tool_output.model_projection
+  ; execution : execution
   ; policy : policy
   ; executor : executor
   ; backend : backend

--- a/lib/keeper/keeper_tools_agent_core_bundle.ml
+++ b/lib/keeper/keeper_tools_agent_core_bundle.ml
@@ -9,18 +9,6 @@
 
 open Keeper_tools_agent_core
 
-type completion_boundary =
-  | Continue_after_success
-  | Terminal_effect
-
-(* A connected-surface post is the reply deliverable for this Keeper turn.
-   Classify it from the closed runtime-handler ADT: no tool-name comparison,
-   payload inspection, retry count, or elapsed-time threshold participates. *)
-let completion_boundary_of_runtime_handler = function
-  | Keeper_tool_descriptor.Tool_surface_post -> Terminal_effect
-  | _ -> Continue_after_success
-;;
-
 let terminal_externalization_failure
       state
       ({ message; _ } : Tool_bridge.externalization_error)
@@ -253,9 +241,23 @@ let make_tool_bundle_for_descriptors
     List.concat_map
       (fun (descriptor : Keeper_tool_descriptor.t) ->
          let internal = descriptor.internal_name in
+         let agent_core_descriptor =
+           match descriptor.execution with
+           | Keeper_tool_descriptor.Ordinary Keeper_tool_descriptor.Serial ->
+             Some
+               (Agent_core.Tool.ordinary_descriptor Agent_core.Tool_contract.Serial)
+           | Keeper_tool_descriptor.Ordinary Keeper_tool_descriptor.Concurrent ->
+             Some
+               (Agent_core.Tool.ordinary_descriptor
+                  Agent_core.Tool_contract.Concurrent)
+           | Keeper_tool_descriptor.Terminal ->
+             Some
+               (Agent_core.Tool.terminal_descriptor
+                  Agent_core.Tool_contract.Effect_outcome_unknown)
+         in
          let on_completed, on_failed, on_externalization_error =
-           match completion_boundary_of_runtime_handler descriptor.runtime_handler with
-           | Terminal_effect ->
+           match descriptor.execution with
+           | Keeper_tool_descriptor.Terminal ->
              ( Some
                  (function
                    | Some receipt -> mark_terminal_effect_completed receipt
@@ -268,7 +270,9 @@ let make_tool_bundle_for_descriptors
                        })
              , Some mark_terminal_effect_failed
              , Some mark_completed_terminal_externalization_failed )
-           | Continue_after_success -> None, None, None
+           | Keeper_tool_descriptor.Ordinary
+               (Keeper_tool_descriptor.Serial | Keeper_tool_descriptor.Concurrent) ->
+             None, None, None
          in
          Keeper_tool_descriptor.keeper_model_names descriptor
          |> List.map (fun model_name ->
@@ -298,6 +302,7 @@ let make_tool_bundle_for_descriptors
                  ()
              in
              Tool_bridge.agent_core_tool_of_masc_with_execution_env
+               ?descriptor:agent_core_descriptor
                ~base_path:config.base_path
                ~model_projection:descriptor.model_output_projection
                ?on_externalization_error
@@ -367,12 +372,6 @@ let make_tools
 ;;
 
 module For_testing = struct
-  let is_terminal_effect_handler handler =
-    match completion_boundary_of_runtime_handler handler with
-    | Terminal_effect -> true
-    | Continue_after_success -> false
-  ;;
-
   let initial_terminal_effect_state = initial_terminal_effect_state
 
   let terminal_externalization_failure =

--- a/lib/keeper/keeper_tools_agent_core_bundle.mli
+++ b/lib/keeper/keeper_tools_agent_core_bundle.mli
@@ -29,8 +29,6 @@ val make_tools
   -> Agent_core.Tool.t list
 
 module For_testing : sig
-  val is_terminal_effect_handler : Keeper_tool_descriptor.runtime_handler -> bool
-
   val initial_terminal_effect_state :
     Keeper_tools_agent_core.gate_replay_delivery option ->
     Keeper_tools_agent_core.terminal_effect_state

--- a/lib/keeper/keeper_tools_agent_core_handler_exec.ml
+++ b/lib/keeper/keeper_tools_agent_core_handler_exec.ml
@@ -42,7 +42,6 @@ let execute_with_observers
     Option.iter
       (fun invocation ->
          Keeper_tool_call_log.set_truncation_info
-           ~keeper_name:meta.name
            ~invocation
            ~original_bytes
            ())

--- a/lib/keeper/keeper_tools_agent_core_handler_exec.ml
+++ b/lib/keeper/keeper_tools_agent_core_handler_exec.ml
@@ -43,7 +43,7 @@ let execute_with_observers
       (fun invocation ->
          Keeper_tool_call_log.set_truncation_info
            ~keeper_name:meta.name
-           ~tool_use_id:(Agent_core.Tool_contract.Invocation.tool_use_id invocation)
+           ~invocation
            ~original_bytes
            ())
       agent_core_invocation

--- a/lib/keeper/keeper_tools_agent_core_handler_exec.ml
+++ b/lib/keeper/keeper_tools_agent_core_handler_exec.ml
@@ -38,6 +38,16 @@ let execute_with_observers
   =
   let t0 = Time_compat.now () in
   let invocation_fields = agent_core_invocation_fields agent_core_invocation in
+  let set_truncation_info ~original_bytes =
+    Option.iter
+      (fun invocation ->
+         Keeper_tool_call_log.set_truncation_info
+           ~keeper_name:meta.name
+           ~tool_use_id:(Agent_core.Tool_contract.Invocation.tool_use_id invocation)
+           ~original_bytes
+           ())
+      agent_core_invocation
+  in
   try
     let result, duration_ms =
       Inference_utils.timed (fun () ->
@@ -145,10 +155,7 @@ let execute_with_observers
             ; "error_preview", `String detail
             ]
              @ invocation_fields));
-      Keeper_tool_call_log.set_truncation_info
-        ~keeper_name:meta.name
-        ~original_bytes:(String.length projected_error)
-        ();
+      set_truncation_info ~original_bytes:(String.length projected_error);
       { tool_result = dispatch_result
       ; failure_effect_disposition = Some result.failure_effect_disposition
       ; deferred_kind = None
@@ -209,10 +216,7 @@ let execute_with_observers
              ; "disposition", `String disposition
              ]
              @ invocation_fields));
-      Keeper_tool_call_log.set_truncation_info
-        ~keeper_name:meta.name
-        ~original_bytes:original_len
-        ();
+      set_truncation_info ~original_bytes:original_len;
       { tool_result = observed_result
       ; failure_effect_disposition = None
       ; deferred_kind = None
@@ -269,10 +273,7 @@ let execute_with_observers
             ; "disposition", `String disposition
             ]
              @ invocation_fields));
-      Keeper_tool_call_log.set_truncation_info
-        ~keeper_name:meta.name
-        ~original_bytes:(String.length projected_result)
-        ();
+      set_truncation_info ~original_bytes:(String.length projected_result);
       { tool_result = observed_result
       ; failure_effect_disposition = None
       ; deferred_kind = result.deferred_kind
@@ -338,10 +339,7 @@ let execute_with_observers
           ; "error", `String error_text
           ]
            @ invocation_fields));
-    Keeper_tool_call_log.set_truncation_info
-      ~keeper_name:meta.name
-      ~original_bytes:(String.length projected_error)
-      ();
+    set_truncation_info ~original_bytes:(String.length projected_error);
     { tool_result = exception_result
     ; failure_effect_disposition = Some Tool_result.Effect_outcome_unknown
     ; deferred_kind = None

--- a/lib/keeper/keeper_tools_agent_core_handler_telemetry.ml
+++ b/lib/keeper/keeper_tools_agent_core_handler_telemetry.ml
@@ -62,9 +62,14 @@ let tool_io_preview_fields ~tool_name ~input ?output () =
 let agent_core_invocation_fields = function
   | None -> []
   | Some invocation ->
+    let schedule = Agent_core.Tool_contract.Invocation.schedule invocation in
     [ "tool_use_id", `String (Agent_core.Tool_contract.Invocation.tool_use_id invocation)
     ; "turn", `Int (Agent_core.Tool_contract.Invocation.turn invocation)
-    ; "planned_index", `Int (Agent_core.Tool_contract.Invocation.planned_index invocation)
+    ; "planned_index", `Int schedule.planned_index
+    ; "batch_index", `Int schedule.batch_index
+    ; "batch_size", `Int schedule.batch_size
+    ; ( "execution_mode"
+      , Agent_core.Tool_contract.execution_mode_to_yojson schedule.execution_mode )
     ]
 ;;
 

--- a/lib/keeper/keeper_tools_agent_core_handler_telemetry.mli
+++ b/lib/keeper/keeper_tools_agent_core_handler_telemetry.mli
@@ -23,8 +23,10 @@ val tool_io_preview_fields
   -> unit
   -> (string * Yojson.Safe.t) list
 
-(** Exact AGENT_CORE model-tool occurrence fields. Blank or repeated [tool_use_id]
-    values are preserved because [turn] and [planned_index] provide the scope. *)
+(** Exact AGENT_CORE model-tool occurrence and schedule fields. Blank or repeated
+    [tool_use_id] values are preserved because [turn] and [planned_index]
+    provide the scope. The batch fields and execution mode come directly from
+    the invocation rather than elapsed-time inference. *)
 val agent_core_invocation_fields
   :  Agent_core.Tool_contract.Invocation.t option
   -> (string * Yojson.Safe.t) list

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -177,6 +177,12 @@ let reset_for_testing () =
   with_pending_truncation_lock (fun () -> Invocation_table.reset pending_truncation)
 ;;
 
+let pending_truncation_count_for_testing () =
+  with_pending_truncation_lock (fun () ->
+    Invocation_table.clean pending_truncation;
+    Invocation_table.length pending_truncation)
+;;
+
 let store_dir () =
   match (Atomic.get store_state).store with
   | Some store -> Some (Dated_jsonl.base_dir store)

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -14,22 +14,25 @@
 
 let max_output_len = 4000
 
-(** Pre-truncation info, keyed by keeper name.
+(** Pre-truncation info, keyed by the exact Agent Core invocation.
     Set by the tool handler wrapper (keeper_tools_agent_core), consumed by the
-    AGENT_CORE on_tool_result hook (keeper_hooks_agent_core).  Per-keeper isolation
-    prevents cross-keeper corruption when multiple keepers call tools
-    concurrently. Within a single keeper's Agent.run, tool calls are
-    sequential so set→consume ordering is guaranteed. *)
-let pending_truncation : (string, int * int option) Hashtbl.t = Hashtbl.create 8
-
-let set_truncation_info ~keeper_name ~original_bytes ?truncated_to () =
-  Hashtbl.replace pending_truncation keeper_name (original_bytes, truncated_to)
+    AGENT_CORE on_tool_result hook (keeper_hooks_agent_core). *)
+let pending_truncation : ((string * string), int * int option) Hashtbl.t =
+  Hashtbl.create 8
 ;;
 
-let consume_truncation_info ~keeper_name () =
-  match Hashtbl.find_opt pending_truncation keeper_name with
+let set_truncation_info ~keeper_name ~tool_use_id ~original_bytes ?truncated_to () =
+  Hashtbl.replace
+    pending_truncation
+    (keeper_name, tool_use_id)
+    (original_bytes, truncated_to)
+;;
+
+let consume_truncation_info ~keeper_name ~tool_use_id () =
+  let key = keeper_name, tool_use_id in
+  match Hashtbl.find_opt pending_truncation key with
   | Some info ->
-    Hashtbl.remove pending_truncation keeper_name;
+    Hashtbl.remove pending_truncation key;
     info
   | None -> 0, None
 ;;

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -14,22 +14,39 @@
 
 let max_output_len = 4000
 
-(** Pre-truncation info, keyed by the exact Agent Core invocation.
-    Set by the tool handler wrapper (keeper_tools_agent_core), consumed by the
-    AGENT_CORE on_tool_result hook (keeper_hooks_agent_core). *)
-let pending_truncation : ((string * string), int * int option) Hashtbl.t =
+(** The provider call id is not an occurrence identity: it may be blank or
+    repeated. Agent Core scopes one occurrence by turn and planned index, so
+    keep those typed fields in the pending-observation key as well. *)
+type invocation_key =
+  { keeper_name : string
+  ; tool_use_id : string
+  ; turn : int
+  ; planned_index : int
+  }
+
+let invocation_key ~keeper_name invocation =
+  { keeper_name
+  ; tool_use_id = Agent_core.Tool_contract.Invocation.tool_use_id invocation
+  ; turn = Agent_core.Tool_contract.Invocation.turn invocation
+  ; planned_index = Agent_core.Tool_contract.Invocation.planned_index invocation
+  }
+;;
+
+(** Pre-truncation info, keyed by the exact Agent Core occurrence. Set by the
+    tool handler wrapper and consumed by the on-tool-result hook. *)
+let pending_truncation : (invocation_key, int * int option) Hashtbl.t =
   Hashtbl.create 8
 ;;
 
-let set_truncation_info ~keeper_name ~tool_use_id ~original_bytes ?truncated_to () =
+let set_truncation_info ~keeper_name ~invocation ~original_bytes ?truncated_to () =
   Hashtbl.replace
     pending_truncation
-    (keeper_name, tool_use_id)
+    (invocation_key ~keeper_name invocation)
     (original_bytes, truncated_to)
 ;;
 
-let consume_truncation_info ~keeper_name ~tool_use_id () =
-  let key = keeper_name, tool_use_id in
+let consume_truncation_info ~keeper_name ~invocation () =
+  let key = invocation_key ~keeper_name invocation in
   match Hashtbl.find_opt pending_truncation key with
   | Some info ->
     Hashtbl.remove pending_truncation key;

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -418,6 +418,9 @@ let log_call
       ?execution_id
       ?tool_use_id
       ?planned_index
+      ?batch_index
+      ?batch_size
+      ?execution_mode
       ?trace_id
       ?session_id
       ?generation
@@ -515,6 +518,23 @@ let log_call
       let planned_index_field =
         match planned_index with
         | Some value -> [ "planned_index", `Int value ]
+        | None -> []
+      in
+      let batch_index_field =
+        match batch_index with
+        | Some value -> [ "batch_index", `Int value ]
+        | None -> []
+      in
+      let batch_size_field =
+        match batch_size with
+        | Some value -> [ "batch_size", `Int value ]
+        | None -> []
+      in
+      let execution_mode_field =
+        match execution_mode with
+        | Some value ->
+          [ ( "execution_mode"
+            , Agent_core.Tool_contract.execution_mode_to_yojson value ) ]
         | None -> []
       in
       let session_id_field =
@@ -621,6 +641,9 @@ let log_call
            @ execution_id_field
            @ tool_use_id_field
            @ planned_index_field
+           @ batch_index_field
+           @ batch_size_field
+           @ execution_mode_field
            @ trace_id_field
            @ session_id_field
            @ generation_field

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -14,44 +14,46 @@
 
 let max_output_len = 4000
 
-(** The provider call id is not an occurrence identity: it may be blank or
-    repeated. Agent Core scopes one occurrence by turn and planned index, so
-    keep those typed fields in the pending-observation key as well. *)
-type invocation_key =
-  { keeper_name : string
-  ; tool_use_id : string
-  ; turn : int
-  ; planned_index : int
-  }
+module Invocation_key = struct
+  type t = Agent_core.Tool_contract.Invocation.t
 
-let invocation_key ~keeper_name invocation =
-  { keeper_name
-  ; tool_use_id = Agent_core.Tool_contract.Invocation.tool_use_id invocation
-  ; turn = Agent_core.Tool_contract.Invocation.turn invocation
-  ; planned_index = Agent_core.Tool_contract.Invocation.planned_index invocation
-  }
-;;
+  let equal left right = left == right
+  let hash = Hashtbl.hash
+end
+
+module Invocation_table = Ephemeron.K1.Make (Invocation_key)
 
 (** Pre-truncation info, keyed by the exact Agent Core occurrence. Set by the
-    tool handler wrapper and consumed by the on-tool-result hook. *)
-let pending_truncation : (invocation_key, int * int option) Hashtbl.t =
-  Hashtbl.create 8
+    tool handler wrapper and consumed by the on-tool-result hook. The weak key
+    prevents cancellation before that hook from retaining the invocation. *)
+let pending_truncation : (int * int option) Invocation_table.t =
+  Invocation_table.create 8
 ;;
 
-let set_truncation_info ~keeper_name ~invocation ~original_bytes ?truncated_to () =
-  Hashtbl.replace
-    pending_truncation
-    (invocation_key ~keeper_name invocation)
-    (original_bytes, truncated_to)
+let pending_truncation_mu = Stdlib.Mutex.create ()
+
+let with_pending_truncation_lock f =
+  Stdlib.Mutex.lock pending_truncation_mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock pending_truncation_mu)
+    f
 ;;
 
-let consume_truncation_info ~keeper_name ~invocation () =
-  let key = invocation_key ~keeper_name invocation in
-  match Hashtbl.find_opt pending_truncation key with
-  | Some info ->
-    Hashtbl.remove pending_truncation key;
-    info
-  | None -> 0, None
+let set_truncation_info ~invocation ~original_bytes ?truncated_to () =
+  with_pending_truncation_lock (fun () ->
+    Invocation_table.replace
+      pending_truncation
+      invocation
+      (original_bytes, truncated_to))
+;;
+
+let consume_truncation_info ~invocation () =
+  with_pending_truncation_lock (fun () ->
+    match Invocation_table.find_opt pending_truncation invocation with
+    | Some info ->
+      Invocation_table.remove pending_truncation invocation;
+      info
+    | None -> 0, None)
 ;;
 
 type turn_ctx_cell = Keeper_tool_call_log_context.cell
@@ -172,7 +174,7 @@ let reset_for_testing () =
   Atomic.set async_append_active false;
   Atomic.set append_queue_dropped 0;
   with_append_queue_lock (fun () -> Stdlib.Queue.clear append_queue);
-  Hashtbl.reset pending_truncation
+  with_pending_truncation_lock (fun () -> Invocation_table.reset pending_truncation)
 ;;
 
 let store_dir () =

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -147,6 +147,9 @@ val log_call :
   ?execution_id:Ids.Execution_id.t ->
   ?tool_use_id:string ->
   ?planned_index:int ->
+  ?batch_index:int ->
+  ?batch_size:int ->
+  ?execution_mode:Agent_core.Tool_contract.execution_mode ->
   ?trace_id:string ->
   ?session_id:string ->
   ?generation:int ->
@@ -171,7 +174,9 @@ val log_call :
     same execution (when the dispatch lane has one) — the key that the
     agent_core:tool_called/agent_core:tool_completed event rows also carry. Blank and
     repeated provider ids remain meaningful when scoped by [turn] and
-    [planned_index], so they are persisted unchanged.
+    [planned_index], so they are persisted unchanged. [batch_index],
+    [batch_size], and [execution_mode] preserve Agent Core's actual schedule
+    rather than inferring concurrency from timing.
     [on_committed], when supplied, forces this row through the synchronous
     append boundary and runs only after that append succeeds. It is intended
     for exact completion notifications whose readers must not race the

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -6,25 +6,24 @@
     @since 2.249.0 *)
 
 val set_truncation_info :
-  keeper_name:string ->
   invocation:Agent_core.Tool_contract.Invocation.t ->
   original_bytes:int ->
   ?truncated_to:int ->
   unit ->
   unit
-(** [set_truncation_info ~keeper_name ~invocation ~original_bytes ?truncated_to ()]
-    records pre-truncation output size for the given keeper. Called by
+(** [set_truncation_info ~invocation ~original_bytes ?truncated_to ()]
+    records pre-truncation output size for the exact invocation. Called by
     the tool handler wrapper before returning the (possibly truncated)
-    result to AGENT_CORE. The invocation's turn and planned index preserve
-    isolation even when a provider emits blank or repeated tool-use ids. *)
+    result to AGENT_CORE. Physical invocation identity preserves isolation even
+    when a provider emits blank or repeated tool-use ids. Weak ownership lets a
+    cancelled invocation release its pending observation. *)
 
 val consume_truncation_info :
-  keeper_name:string ->
   invocation:Agent_core.Tool_contract.Invocation.t ->
   unit ->
   int * int option
-(** [consume_truncation_info ~keeper_name ~invocation ()] returns
-    [(original_bytes, truncated_to)] for the given keeper and clears
+(** [consume_truncation_info ~invocation ()] returns
+    [(original_bytes, truncated_to)] for the exact invocation and clears
     the pending state. Returns [(0, None)] when no truncation info
     was set (e.g. AGENT_CORE-internal tool call that bypassed the wrapper). *)
 

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -7,21 +7,23 @@
 
 val set_truncation_info :
   keeper_name:string ->
+  tool_use_id:string ->
   original_bytes:int ->
   ?truncated_to:int ->
   unit ->
   unit
-(** [set_truncation_info ~keeper_name ~original_bytes ?truncated_to ()]
+(** [set_truncation_info ~keeper_name ~tool_use_id ~original_bytes ?truncated_to ()]
     records pre-truncation output size for the given keeper. Called by
     the tool handler wrapper before returning the (possibly truncated)
-    result to AGENT_CORE. Per-keeper isolation prevents cross-keeper corruption
-    under concurrent tool execution. *)
+    result to AGENT_CORE. The exact invocation identity prevents sibling tool
+    results from consuming one another's state. *)
 
 val consume_truncation_info :
   keeper_name:string ->
+  tool_use_id:string ->
   unit ->
   int * int option
-(** [consume_truncation_info ~keeper_name ()] returns
+(** [consume_truncation_info ~keeper_name ~tool_use_id ()] returns
     [(original_bytes, truncated_to)] for the given keeper and clears
     the pending state. Returns [(0, None)] when no truncation info
     was set (e.g. AGENT_CORE-internal tool call that bypassed the wrapper). *)

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -237,5 +237,8 @@ val read_latest :
 val reset_for_testing : unit -> unit
 (** Resets the in-memory store reference. For unit tests only. *)
 
+val pending_truncation_count_for_testing : unit -> int
+(** Number of live invocation-scoped truncation observations. Test only. *)
+
 val queued_count_for_testing : unit -> int
 (** Number of queued asynchronous append records. For unit tests only. *)

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -7,23 +7,23 @@
 
 val set_truncation_info :
   keeper_name:string ->
-  tool_use_id:string ->
+  invocation:Agent_core.Tool_contract.Invocation.t ->
   original_bytes:int ->
   ?truncated_to:int ->
   unit ->
   unit
-(** [set_truncation_info ~keeper_name ~tool_use_id ~original_bytes ?truncated_to ()]
+(** [set_truncation_info ~keeper_name ~invocation ~original_bytes ?truncated_to ()]
     records pre-truncation output size for the given keeper. Called by
     the tool handler wrapper before returning the (possibly truncated)
-    result to AGENT_CORE. The exact invocation identity prevents sibling tool
-    results from consuming one another's state. *)
+    result to AGENT_CORE. The invocation's turn and planned index preserve
+    isolation even when a provider emits blank or repeated tool-use ids. *)
 
 val consume_truncation_info :
   keeper_name:string ->
-  tool_use_id:string ->
+  invocation:Agent_core.Tool_contract.Invocation.t ->
   unit ->
   int * int option
-(** [consume_truncation_info ~keeper_name ~tool_use_id ()] returns
+(** [consume_truncation_info ~keeper_name ~invocation ()] returns
     [(original_bytes, truncated_to)] for the given keeper and clears
     the pending state. Returns [(0, None)] when no truncation info
     was set (e.g. AGENT_CORE-internal tool call that bypassed the wrapper). *)

--- a/test/test_keeper_execution_join.ml
+++ b/test/test_keeper_execution_join.ml
@@ -77,6 +77,17 @@ let test_distinct_occurrences_with_repeated_id_do_not_overwrite () =
     (Some "exec-1-000a")
     (Join.take ~invocation:first)
 
+let test_abandoned_join_is_released_with_invocation () =
+  Join.For_testing.clear ();
+  let record_abandoned () =
+    let abandoned = invocation ~turn:4 ~planned_index:2 "cancelled" in
+    Join.record ~invocation:abandoned ~execution_id:"exec-abandoned"
+  in
+  record_abandoned ();
+  Gc.full_major ();
+  Gc.full_major ();
+  check int "cancelled publication leaves no join entry" 0 (Join.For_testing.size ())
+
 (* ── Bridge stamping ──────────────────────────────────── *)
 
 let mk_event ?(event_id = "event-1") ?caused_by payload : Agent_core.Event_bus.event =
@@ -635,6 +646,8 @@ let () =
         ; test_case "missing entry is None" `Quick test_missing_entry_is_none
         ; test_case "repeated ids keep distinct occurrences" `Quick
             test_distinct_occurrences_with_repeated_id_do_not_overwrite
+        ; test_case "cancelled invocation releases abandoned join" `Quick
+            test_abandoned_join_is_released_with_invocation
         ] )
     ; ( "bridge_stamping"
       , [ test_case "tool_called carries tool_use_id" `Quick

--- a/test/test_keeper_execution_join.ml
+++ b/test/test_keeper_execution_join.ml
@@ -1,4 +1,4 @@
-(** Tests for RFC-0233 PR-2: the in-flight [tool_use_id ↔ execution_id]
+(** Tests for RFC-0233 PR-2: the in-flight [invocation ↔ execution_id]
     join table ([Keeper_execution_join]) and the event bridge stamping
     that consumes it ([Keeper_event_bridge.native_event_to_json]). *)
 
@@ -23,34 +23,59 @@ let int_of_field = function
   | Some (`Int value) -> Some value
   | _ -> None
 
+let invocation ?(turn = 0) ?(planned_index = 0) tool_use_id =
+  Agent_core.Tool_contract.Invocation.create
+    ~tool_use_id
+    ~turn
+    ~completion:Agent_core.Tool_contract.Continue_after_success
+    ~schedule:
+      { planned_index
+      ; batch_index = 0
+      ; batch_size = 1
+      ; execution_mode = Agent_core.Tool_contract.Serial
+      }
+
 (* ── Join table semantics ─────────────────────────────── *)
 
 let test_record_take_roundtrip () =
   Join.For_testing.clear ();
-  Join.record ~tool_use_id:"tu-1" ~execution_id:"exec-1-0001";
+  let invocation = invocation "tu-1" in
+  Join.record ~invocation ~execution_id:"exec-1-0001";
   check (option string) "take returns the pair" (Some "exec-1-0001")
-    (Join.take ~tool_use_id:"tu-1");
+    (Join.take ~invocation);
   check (option string) "take removes the entry" None
-    (Join.take ~tool_use_id:"tu-1");
+    (Join.take ~invocation);
   check int "table empty after take" 0 (Join.For_testing.size ())
 
-let test_empty_tool_use_id_ignored () =
+let test_blank_tool_use_id_joins_by_invocation () =
   Join.For_testing.clear ();
-  Join.record ~tool_use_id:"" ~execution_id:"exec-1-0002";
-  check int "empty id records nothing" 0 (Join.For_testing.size ());
-  check (option string) "empty id lookup is None" None (Join.take ~tool_use_id:"")
+  let invocation = invocation "" in
+  Join.record ~invocation ~execution_id:"exec-1-0002";
+  check (option string)
+    "blank provider id still joins"
+    (Some "exec-1-0002")
+    (Join.take ~invocation)
 
 let test_missing_entry_is_none () =
   Join.For_testing.clear ();
+  let invocation = invocation "tu-unknown" in
   check (option string) "unknown id is None" None
-    (Join.take ~tool_use_id:"tu-unknown")
+    (Join.take ~invocation)
 
-let test_rerecord_overwrites () =
+let test_distinct_occurrences_with_repeated_id_do_not_overwrite () =
   Join.For_testing.clear ();
-  Join.record ~tool_use_id:"tu-2" ~execution_id:"exec-1-000a";
-  Join.record ~tool_use_id:"tu-2" ~execution_id:"exec-1-000b";
-  check (option string) "last record wins" (Some "exec-1-000b")
-    (Join.take ~tool_use_id:"tu-2")
+  let first = invocation ~turn:1 ~planned_index:0 "tu-2" in
+  let second = invocation ~turn:1 ~planned_index:1 "tu-2" in
+  Join.record ~invocation:first ~execution_id:"exec-1-000a";
+  Join.record ~invocation:second ~execution_id:"exec-1-000b";
+  check (option string)
+    "second occurrence"
+    (Some "exec-1-000b")
+    (Join.take ~invocation:second);
+  check (option string)
+    "first occurrence remains"
+    (Some "exec-1-000a")
+    (Join.take ~invocation:first)
 
 (* ── Bridge stamping ──────────────────────────────────── *)
 
@@ -66,18 +91,6 @@ let mk_event ?(event_id = "event-1") ?caused_by payload : Agent_core.Event_bus.e
   { meta = { meta with event_time = 1781200000.0; observed_at = 1781200000.5 }
   ; payload
   }
-
-let invocation ?(turn = 0) ?(planned_index = 0) tool_use_id =
-  Agent_core.Tool_contract.Invocation.create
-    ~tool_use_id
-    ~turn
-    ~completion:Agent_core.Tool_contract.Continue_after_success
-    ~schedule:
-      { planned_index
-      ; batch_index = 0
-      ; batch_size = 1
-      ; execution_mode = Agent_core.Tool_contract.Serial
-      }
 
 let test_tool_called_carries_tool_use_id () =
   Join.For_testing.clear ();
@@ -105,12 +118,13 @@ let test_tool_called_carries_tool_use_id () =
 let test_tool_completed_stamps_execution_id () =
   Join.For_testing.clear ();
   (* The hook records the pair before AGENT_CORE publishes ToolCompleted. *)
-  Join.record ~tool_use_id:"tu-4" ~execution_id:"exec-2-0001";
+  let invocation = invocation ~turn:1 ~planned_index:3 "tu-4" in
+  Join.record ~invocation ~execution_id:"exec-2-0001";
   let json =
     Bridge.native_event_to_json
       (mk_event ~caused_by:"run-called-1"
          (Agent_core.Event_bus.ToolCompleted
-            { invocation = invocation ~turn:1 ~planned_index:3 "tu-4"
+            { invocation
             ; agent_name = "keeper-x-agent"
             ; tool_name = "Read"
             ; output = Ok { content = "ok"; _meta = None }
@@ -616,9 +630,11 @@ let () =
   run "keeper_execution_join"
     [ ( "join_table"
       , [ test_case "record/take roundtrip" `Quick test_record_take_roundtrip
-        ; test_case "empty tool_use_id ignored" `Quick test_empty_tool_use_id_ignored
+        ; test_case "blank tool_use_id joins by invocation" `Quick
+            test_blank_tool_use_id_joins_by_invocation
         ; test_case "missing entry is None" `Quick test_missing_entry_is_none
-        ; test_case "re-record overwrites" `Quick test_rerecord_overwrites
+        ; test_case "repeated ids keep distinct occurrences" `Quick
+            test_distinct_occurrences_with_repeated_id_do_not_overwrite
         ] )
     ; ( "bridge_stamping"
       , [ test_case "tool_called carries tool_use_id" `Quick

--- a/test/test_keeper_execution_join.ml
+++ b/test/test_keeper_execution_join.ml
@@ -23,16 +23,23 @@ let int_of_field = function
   | Some (`Int value) -> Some value
   | _ -> None
 
-let invocation ?(turn = 0) ?(planned_index = 0) tool_use_id =
+let invocation
+      ?(turn = 0)
+      ?(planned_index = 0)
+      ?(batch_index = 0)
+      ?(batch_size = 1)
+      ?(execution_mode = Agent_core.Tool_contract.Serial)
+      tool_use_id
+  =
   Agent_core.Tool_contract.Invocation.create
     ~tool_use_id
     ~turn
     ~completion:Agent_core.Tool_contract.Continue_after_success
     ~schedule:
       { planned_index
-      ; batch_index = 0
-      ; batch_size = 1
-      ; execution_mode = Agent_core.Tool_contract.Serial
+      ; batch_index
+      ; batch_size
+      ; execution_mode
       }
 
 (* ── Join table semantics ─────────────────────────────── *)
@@ -109,7 +116,12 @@ let test_tool_called_carries_tool_use_id () =
     Bridge.native_event_to_json
       (mk_event
          (Agent_core.Event_bus.ToolCalled
-            { invocation = invocation "tu-3"
+            { invocation =
+                invocation
+                  ~batch_index:2
+                  ~batch_size:3
+                  ~execution_mode:Agent_core.Tool_contract.Concurrent
+                  "tu-3"
             ; agent_name = "agent_core-r1"
             ; tool_name = "Read"
             ; input = `Null
@@ -122,6 +134,12 @@ let test_tool_called_carries_tool_use_id () =
     (int_of_field (payload_member "turn" json));
   check (option int) "payload planned_index" (Some 0)
     (int_of_field (payload_member "planned_index" json));
+  check (option int) "payload batch_index" (Some 2)
+    (int_of_field (payload_member "batch_index" json));
+  check (option int) "payload batch_size" (Some 3)
+    (int_of_field (payload_member "batch_size" json));
+  check (option string) "payload execution_mode" (Some "concurrent")
+    (string_of_field (payload_member "execution_mode" json));
   check bool "tool_called has no execution_id (mint happens after publish)"
     true
     (payload_member "execution_id" json = None)

--- a/test/test_keeper_hooks_agent_core_introspection.ml
+++ b/test/test_keeper_hooks_agent_core_introspection.ml
@@ -8,7 +8,6 @@
 
     - lib/keeper/keeper_hooks_agent_core.ml ([make_hooks]) — the keeper_hooks_agent_core slots
     - lib/keeper/keeper_run_tools.ml — before_turn_params
-    - lib/keeper/keeper_hooks_agent_core.ml — passive pre_tool_use timing
 
     [before_turn_params] is assembled by [Keeper_run_tools_hooks], not
     [make_hooks], so its source/active claim remains a sibling-module contract
@@ -42,13 +41,12 @@ let slot_active slot_name =
   | Some active -> active
   | None -> failwith ("introspection slot missing active bool: " ^ slot_name)
 
-(* The 9 slots the introspection claims are wired. Retired AGENT_CORE hook slots are
+(* The 8 slots the introspection claims are wired. Retired AGENT_CORE hook slots are
    absent rather than retained as inactive compatibility surface. *)
 let expected_active =
   [ "before_turn"
   ; "before_turn_params"
   ; "after_turn"
-  ; "pre_tool_use"
   ; "post_tool_use"
   ; "post_tool_use_failure"
   ; "on_stop"
@@ -59,7 +57,7 @@ let expected_active =
 let test_slot_set () =
   let names = List.map fst (slots_of json) |> List.sort compare in
   let expected = List.sort compare expected_active in
-  check (list string) "introspection exposes exactly the 9 current hook slots" expected names
+  check (list string) "introspection exposes exactly the 8 current hook slots" expected names
 
 let test_active_split () =
   List.iter
@@ -68,9 +66,7 @@ let test_active_split () =
 
 let test_sources () =
   (* before_turn_params comes from a sibling module; the remaining active
-     slots, including passive pre_tool_use timing, are keeper_hooks_agent_core. *)
-  check (option string) "pre_tool_use source" (Some "keeper_hooks_agent_core")
-    (slot_string "pre_tool_use" "source");
+     slots are keeper_hooks_agent_core. *)
   check (option string) "before_turn_params source" (Some "keeper_run_tools")
     (slot_string "before_turn_params" "source");
   check (option string) "after_turn source" (Some "keeper_hooks_agent_core")
@@ -105,7 +101,6 @@ let runtime_slots_of (hooks : Agent_core.Hooks.hooks) =
   [
     "before_turn", Option.is_some hooks.before_turn;
     "after_turn", Option.is_some hooks.after_turn;
-    "pre_tool_use", Option.is_some hooks.pre_tool_use;
     "post_tool_use", Option.is_some hooks.post_tool_use;
     "post_tool_use_failure", Option.is_some hooks.post_tool_use_failure;
     "on_stop", Option.is_some hooks.on_stop;
@@ -122,45 +117,13 @@ let test_runtime_active_claims_match_make_hooks () =
       active
       (slot_active slot_name))
 
-let test_pre_tool_use_is_observation_only () =
-  let hooks = make_runtime_hooks () in
-  let event =
-    Agent_core.Hooks.PreToolUse
-      { invocation =
-          Agent_core.Tool_contract.Invocation.create
-            ~tool_use_id:"toolu_observation_only"
-            ~turn:7
-            ~completion:Agent_core.Tool_contract.Continue_after_success
-            ~schedule:
-              { planned_index = 0
-              ; batch_index = 0
-              ; batch_size = 1
-              ; execution_mode = Agent_core.Tool_contract.Serial
-              }
-      ; tool_name = "opaque_internal_name"
-      ; input = `Assoc [ "command", `String "opaque external effect" ]
-      ; accumulated_cost_usd = 1234.0
-      }
-  in
-  match Agent_core.Hooks.invoke_validated hooks.pre_tool_use event with
-  | Agent_core.Hooks.Continue -> ()
-  | AdjustParams _ -> fail "pre_tool_use timing hook adjusted parameters"
-  | ElicitInput _ -> fail "pre_tool_use timing hook elicited input"
-  | ElicitToolApproval _ ->
-    fail "pre_tool_use timing hook elicited tool approval"
-  | Nudge _ -> fail "pre_tool_use timing hook returned Nudge"
-  | HookFailed _ -> fail "pre_tool_use timing hook failed"
-  | Block _ -> fail "pre_tool_use timing hook returned Block"
-
 let () =
   Alcotest.run "Keeper_hooks_agent_core_introspection"
     [ ( "slot contract"
-      , [ test_case "exactly the 9 current slots" `Quick test_slot_set
+      , [ test_case "exactly the 8 current slots" `Quick test_slot_set
         ; test_case "all current slots active" `Quick test_active_split
         ; test_case "slot sources" `Quick test_sources
         ; test_case "make_hooks active claims match runtime record" `Quick
             test_runtime_active_claims_match_make_hooks
-        ; test_case "pre_tool_use is observation only" `Quick
-            test_pre_tool_use_is_observation_only
         ] )
     ]

--- a/test/test_keeper_run_tools_hooks.ml
+++ b/test/test_keeper_run_tools_hooks.ml
@@ -595,6 +595,59 @@ let test_completed_calls_short_list_is_whole () =
   check int "every call is kept" 3 (List.length kept)
 ;;
 
+let test_concurrent_tool_observers_commit_as_transactions () =
+  Eio_main.run @@ fun _env ->
+  let serialize =
+    Masc.Keeper_run_tools_hooks.create_tool_observer_serialization ()
+  in
+  let trace = ref [] in
+  let record event = trace := event :: !trace in
+  let first_entered, resolve_first_entered = Eio.Promise.create () in
+  let release_first, resolve_release_first = Eio.Promise.create () in
+  let second_attempting, resolve_second_attempting = Eio.Promise.create () in
+  Eio.Switch.run (fun sw ->
+    Eio.Fiber.fork ~sw (fun () ->
+      serialize (fun () ->
+        record "receipt:first";
+        Eio.Promise.resolve resolve_first_entered ();
+        Eio.Promise.await release_first;
+        record "activity:first"));
+    Eio.Promise.await first_entered;
+    Eio.Fiber.fork ~sw (fun () ->
+      Eio.Promise.resolve resolve_second_attempting ();
+      serialize (fun () ->
+        record "receipt:second";
+        record "activity:second"));
+    Eio.Promise.await second_attempting;
+    (* Give the second fiber a scheduling turn while the first observer is
+       suspended. Without the production serialization boundary this would put
+       the second receipt/activity pair inside the first pair. *)
+    Eio.Fiber.yield ();
+    Eio.Promise.resolve resolve_release_first ());
+  check
+    (list string)
+    "receipt and activity effects share one completion order"
+    [ "receipt:first"
+    ; "activity:first"
+    ; "receipt:second"
+    ; "activity:second"
+    ]
+    (List.rev !trace)
+;;
+
+let test_failed_tool_observer_releases_next_completion () =
+  Eio_main.run @@ fun _env ->
+  let serialize =
+    Masc.Keeper_run_tools_hooks.create_tool_observer_serialization ()
+  in
+  (match serialize (fun () -> raise Exit) with
+   | () -> fail "failed observer unexpectedly returned"
+   | exception Exit -> ());
+  let observed = ref false in
+  serialize (fun () -> observed := true);
+  check bool "a reported observer failure does not poison later receipts" true !observed
+;;
+
 let () =
   run
     "keeper_run_tools_hooks"
@@ -678,6 +731,16 @@ let () =
             "bare relative outside repos lane is Base_unresolved"
             `Quick
             test_partition_bare_relative_outside_repos_is_base_unresolved
+        ] )
+    ; ( "concurrent_tool_observer"
+      , [ test_case
+            "commits receipt and activity as one transaction"
+            `Quick
+            test_concurrent_tool_observers_commit_as_transactions
+        ; test_case
+            "releases the next completion after a reported failure"
+            `Quick
+            test_failed_tool_observer_releases_next_completion
         ] )
     ]
 ;;

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -268,6 +268,9 @@ let test_exact_agent_core_occurrence_persisted () =
       ~tool_use_id:""
       ~turn:9
       ~planned_index:4
+      ~batch_index:2
+      ~batch_size:3
+      ~execution_mode:Agent_core.Tool_contract.Concurrent
       ();
     match Keeper_tool_call_log.read_recent ~n:1 () with
     | [ entry ] ->
@@ -282,7 +285,19 @@ let test_exact_agent_core_occurrence_persisted () =
       Alcotest.(check int)
         "planned index persisted"
         4
-        (Safe_ops.json_int ~default:(-1) "planned_index" entry)
+        (Safe_ops.json_int ~default:(-1) "planned_index" entry);
+      Alcotest.(check int)
+        "batch index persisted"
+        2
+        (Safe_ops.json_int ~default:(-1) "batch_index" entry);
+      Alcotest.(check int)
+        "batch size persisted"
+        3
+        (Safe_ops.json_int ~default:(-1) "batch_size" entry);
+      Alcotest.(check (option string))
+        "execution mode persisted"
+        (Some "concurrent")
+        (Safe_ops.json_string_opt "execution_mode" entry)
     | _ -> Alcotest.fail "expected exactly one entry")
 
 (* ── Redaction: tool names do not suppress evidence ────────────── *)

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -84,6 +84,24 @@ let test_pending_observations_are_occurrence_scoped () =
     (consume first)
 ;;
 
+let test_abandoned_observation_is_released_with_invocation () =
+  Keeper_tool_call_log.reset_for_testing ();
+  let record_abandoned () =
+    let abandoned = invocation ~tool_use_id:"cancelled" ~turn:9 ~planned_index:0 in
+    Keeper_tool_call_log.set_truncation_info
+      ~invocation:abandoned
+      ~original_bytes:99
+      ()
+  in
+  record_abandoned ();
+  Gc.full_major ();
+  Gc.full_major ();
+  Alcotest.(check int)
+    "settlement-skip observation is weakly released"
+    0
+    (Keeper_tool_call_log.pending_truncation_count_for_testing ())
+;;
+
 let with_tmp_log f =
   incr counter;
   let dir = Filename.concat (Filename.get_temp_dir_name ())
@@ -1398,6 +1416,10 @@ let () =
             "blank and repeated ids remain occurrence-scoped"
             `Quick
             test_pending_observations_are_occurrence_scoped
+        ; Alcotest.test_case
+            "cancelled invocation releases abandoned observation"
+            `Quick
+            test_abandoned_observation_is_released_with_invocation
         ] )
     ; ( "read_recent",
         [ eio_test "n=0 returns []" test_read_recent_n_zero

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -49,7 +49,6 @@ let test_pending_observations_are_occurrence_scoped () =
   List.iter
     (fun (invocation, original_bytes) ->
        Keeper_tool_call_log.set_truncation_info
-         ~keeper_name:"keeper-a"
          ~invocation
          ~original_bytes
          ())
@@ -60,7 +59,6 @@ let test_pending_observations_are_occurrence_scoped () =
     ];
   let consume invocation =
     Keeper_tool_call_log.consume_truncation_info
-      ~keeper_name:"keeper-a"
       ~invocation
       ()
   in

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -21,6 +21,71 @@ let artifact_ref_exn ~sha256 ~bytes ~preview ~mime =
 
 let counter = ref 0
 
+let invocation ~tool_use_id ~turn ~planned_index =
+  Agent_core.Tool_contract.Invocation.create
+    ~tool_use_id
+    ~turn
+    ~completion:Agent_core.Tool_contract.Continue_after_success
+    ~schedule:
+      { planned_index
+      ; batch_index = 0
+      ; batch_size = 2
+      ; execution_mode = Agent_core.Tool_contract.Concurrent
+      }
+;;
+
+let test_pending_observations_are_occurrence_scoped () =
+  Keeper_tool_call_log.reset_for_testing ();
+  let first = invocation ~tool_use_id:"" ~turn:7 ~planned_index:0 in
+  let sibling_with_same_blank_id =
+    invocation ~tool_use_id:"" ~turn:7 ~planned_index:1
+  in
+  let later_with_repeated_id =
+    invocation ~tool_use_id:"repeated" ~turn:8 ~planned_index:0
+  in
+  let earlier_with_repeated_id =
+    invocation ~tool_use_id:"repeated" ~turn:7 ~planned_index:2
+  in
+  List.iter
+    (fun (invocation, original_bytes) ->
+       Keeper_tool_call_log.set_truncation_info
+         ~keeper_name:"keeper-a"
+         ~invocation
+         ~original_bytes
+         ())
+    [ first, 11
+    ; sibling_with_same_blank_id, 22
+    ; earlier_with_repeated_id, 33
+    ; later_with_repeated_id, 44
+    ];
+  let consume invocation =
+    Keeper_tool_call_log.consume_truncation_info
+      ~keeper_name:"keeper-a"
+      ~invocation
+      ()
+  in
+  Alcotest.(check (pair int (option int)))
+    "blank-id sibling keeps its own observation"
+    (22, None)
+    (consume sibling_with_same_blank_id);
+  Alcotest.(check (pair int (option int)))
+    "first blank-id occurrence remains available"
+    (11, None)
+    (consume first);
+  Alcotest.(check (pair int (option int)))
+    "later repeated-id occurrence keeps its own observation"
+    (44, None)
+    (consume later_with_repeated_id);
+  Alcotest.(check (pair int (option int)))
+    "earlier repeated-id occurrence remains available"
+    (33, None)
+    (consume earlier_with_repeated_id);
+  Alcotest.(check (pair int (option int)))
+    "consumed occurrence is absent"
+    (0, None)
+    (consume first)
+;;
+
 let with_tmp_log f =
   incr counter;
   let dir = Filename.concat (Filename.get_temp_dir_name ())
@@ -1330,7 +1395,13 @@ let test_commit_callback_fails_closed_without_store () =
 
 let () =
   Alcotest.run "keeper_tool_call_log"
-    [ ( "read_recent",
+    [ ( "invocation observation",
+        [ Alcotest.test_case
+            "blank and repeated ids remain occurrence-scoped"
+            `Quick
+            test_pending_observations_are_occurrence_scoped
+        ] )
+    ; ( "read_recent",
         [ eio_test "n=0 returns []" test_read_recent_n_zero
         ; eio_test "n<0 returns []" test_read_recent_n_negative
         ; eio_test "keeper filter" test_read_recent_keeper_filter

--- a/test/test_keeper_tool_call_sse_io_preview.ml
+++ b/test/test_keeper_tool_call_sse_io_preview.ml
@@ -112,9 +112,9 @@ let test_agent_core_invocation_fields_preserve_exact_occurrence () =
       ~completion:Agent_core.Tool_contract.Continue_after_success
       ~schedule:
         { planned_index = 3
-        ; batch_index = 0
-        ; batch_size = 1
-        ; execution_mode = Agent_core.Tool_contract.Serial
+        ; batch_index = 2
+        ; batch_size = 4
+        ; execution_mode = Agent_core.Tool_contract.Concurrent
         }
   in
   let json =
@@ -130,7 +130,19 @@ let test_agent_core_invocation_fields_preserve_exact_occurrence () =
   Alcotest.(check int)
     "planned index preserved"
     3
-    Yojson.Safe.Util.(member "planned_index" json |> to_int)
+    Yojson.Safe.Util.(member "planned_index" json |> to_int);
+  Alcotest.(check int)
+    "batch index preserved"
+    2
+    Yojson.Safe.Util.(member "batch_index" json |> to_int);
+  Alcotest.(check int)
+    "batch size preserved"
+    4
+    Yojson.Safe.Util.(member "batch_size" json |> to_int);
+  Alcotest.(check string)
+    "execution mode preserved"
+    "concurrent"
+    Yojson.Safe.Util.(member "execution_mode" json |> to_string)
 ;;
 
 let () =

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -1213,6 +1213,20 @@ let test_readonly_policy_projection_is_descriptor_owned () =
     false
     (List.mem "tool_write_file" projected)
 
+let test_concurrent_execution_opt_ins_are_exact () =
+  let concurrent_internal_names =
+    all_descriptors ()
+    |> List.filter_map (fun (descriptor : Descriptor.t) ->
+      match descriptor.execution with
+      | Descriptor.Ordinary Descriptor.Concurrent -> Some descriptor.internal_name
+      | Descriptor.Ordinary Descriptor.Serial | Descriptor.Terminal -> None)
+    |> List.sort_uniq String.compare
+  in
+  Alcotest.(check (list string))
+    "only explicitly audited handlers opt into concurrent batches"
+    [ "keeper_time_now"; "masc_board_stats" ]
+    concurrent_internal_names
+
 let test_readonly_policy_is_descriptor_input_aware () =
   let public_input =
     `Assoc [ "pattern", `String "Keeper_tool_descriptor"; "op", `String "rm" ]
@@ -1663,6 +1677,10 @@ let () =
         ] )
     ; ( "policy-projection"
       , [ test_case
+            "concurrent execution opt-ins are exact"
+            `Quick
+            test_concurrent_execution_opt_ins_are_exact
+        ; test_case
             "descriptor owns the read-only metadata projection"
             `Quick
             test_readonly_policy_projection_is_descriptor_owned

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -850,6 +850,261 @@ let test_initializing_recovery_isolates_only_publication_writes () =
          (read_file existing_path))
 ;;
 
+let test_identical_keeper_invocations_join_across_production_boundaries () =
+  with_exec_fixture
+    ~bind_eio_context:true
+    "keeper_tool_observation_exact_invocation"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       let net =
+         match Eio_context.get_net_opt () with
+         | Some net -> net
+         | None -> fail "test Eio net missing"
+       in
+       Masc.Keeper_tool_call_log.reset_for_testing ();
+       Masc.Keeper_execution_join.For_testing.clear ();
+       Masc.Keeper_tool_call_log.init ~base_path:config.base_path ();
+       Masc.Keeper_chat_store.append_user_message
+         ~base_dir:config.base_path
+         ~keeper_name:meta.name
+         ~content:
+           (String.make
+              (Tool_bridge.default_externalize_threshold_bytes + 1)
+              'x')
+         ~surface:(Masc.Surface_ref.Dashboard { session_id = None })
+         ();
+       let bundle =
+         Masc.Keeper_tools_agent_core_bundle.make_tool_bundle
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot:ctx_work
+           ()
+       in
+       Fun.protect
+         ~finally:(fun () ->
+           Masc.Keeper_execution_join.For_testing.clear ();
+           Masc.Keeper_tool_call_log.reset_for_testing ();
+           bundle.cleanup ())
+         (fun () ->
+            let agent_name = Masc.Keeper_identity.keeper_agent_name meta.name in
+            let trace_id = "keeper-tool-observation-exact-invocation" in
+            let turn_ctx_cell = Masc.Keeper_tool_call_log.create_turn_ctx_cell () in
+            Masc.Keeper_tool_call_log.set_turn_context
+              ~cell:turn_ctx_cell
+              ~agent_name
+              ~trace_id
+              ~generation:0
+              ~turn:0
+              ~keeper_turn_id:1
+              ();
+            let hooks =
+              Masc.Keeper_hooks_agent_core.make_hooks
+                ~config
+                ~meta_ref:(ref meta)
+                ~turn_ctx_cell
+                ~generation:0
+                ~trace_id
+                ~keeper_turn_id:1
+                ~on_after_turn_ordinal:ignore
+                ()
+            in
+            let event_bus = Agent_core.Event_bus.create () in
+            let subscription =
+              Agent_core.Event_bus.subscribe
+                ~config:
+                  (Agent_core.Event_bus.subscription_config
+                     ~capacity:8
+                     ~overflow:Agent_core.Event_bus.Drop_oldest
+                   |> Result.get_ok)
+                event_bus
+            in
+            let agent =
+              Agent_core.Agent.create
+                ~net
+                ~config:
+                  { (Agent_core.Types.default_config ~model:"test-model") with
+                    name = agent_name
+                  }
+                ~tools:bundle.tools
+                ~options:{ Agent_core.Agent.default_options with hooks }
+                ()
+            in
+            let execute_identical_occurrence () =
+              let options = Agent_core.Agent.options agent in
+              match
+                Agent_core.Agent_tools.execute_tools
+                  ~context:(Agent_core.Agent.context agent)
+                  ~tools:
+                    (Agent_core.Tool_set.to_list (Agent_core.Agent.tools agent))
+                  ~hooks:options.hooks
+                  ?tool_approval:options.tool_approval
+                  ~event_bus:(Some event_bus)
+                  ~tracer:options.tracer
+                  ~agent_name
+                  ~turn_count:0
+                  ~usage:(Agent_core.Agent.state agent).usage
+                  [ Agent_core.Types.ToolUse
+                      { id = ""
+                      ; name = "keeper_surface_read"
+                      ; input =
+                          `Assoc
+                            [ "surface", `String "dashboard"
+                            ; "limit", `Int 1
+                            ]
+                      }
+                  ]
+              with
+              | Ok
+                  { Agent_core.Agent_tools.completed_results = [ result ]
+                  ; completion = Agent_core.Agent_tools.Continue_after_batch
+                  } ->
+                result
+              | Ok _ -> fail "identical Keeper invocation returned an unexpected report"
+              | Error _ -> fail "identical Keeper invocation failed"
+            in
+            (* Both calls deliberately have the same provider id, turn, planned
+               index, tool and input. Their heap identity is the only occurrence
+               discriminator, and neither completion is bridged until both hooks
+               have registered their joins. *)
+            let first = execute_identical_occurrence () in
+            let second = execute_identical_occurrence () in
+            check bool
+              "production dispatch creates distinct invocation objects"
+              false
+              (first.invocation == second.invocation);
+            check string
+              "provider ids are structurally identical"
+              (Agent_core.Tool_contract.Invocation.tool_use_id first.invocation)
+              (Agent_core.Tool_contract.Invocation.tool_use_id second.invocation);
+            check int
+              "turns are structurally identical"
+              (Agent_core.Tool_contract.Invocation.turn first.invocation)
+              (Agent_core.Tool_contract.Invocation.turn second.invocation);
+            check int
+              "planned indices are structurally identical"
+              (Agent_core.Tool_contract.Invocation.planned_index first.invocation)
+              (Agent_core.Tool_contract.Invocation.planned_index second.invocation);
+            check bool
+              "schedules are structurally identical"
+              true
+              (Agent_core.Tool_contract.Invocation.schedule first.invocation
+               = Agent_core.Tool_contract.Invocation.schedule second.invocation);
+            check bool
+              "completion contracts are structurally identical"
+              true
+              (Agent_core.Tool_contract.Invocation.completion first.invocation
+               = Agent_core.Tool_contract.Invocation.completion second.invocation);
+            let original_result_bytes =
+              List.map
+                (fun (result : Agent_core.Agent_tools.tool_execution_result) ->
+                   match Tool_output.decode_from_agent_core result.content with
+                   | Tool_output.Decoded reference ->
+                     let original =
+                       fetch_artifact_exn
+                         ~base_path:config.base_path
+                         reference
+                     in
+                     check bool
+                       "externalized result is smaller than its original payload"
+                       true
+                       (String.length result.content < String.length original);
+                     String.length original
+                   | Tool_output.Not_marker ->
+                     fail "production Keeper result was not externalized"
+                   | Tool_output.Invalid_marker { detail } ->
+                     failf "production Keeper result has invalid marker: %s" detail)
+                [ first; second ]
+            in
+            let expected_original_bytes =
+              match original_result_bytes with
+              | [ first_bytes; second_bytes ] ->
+                check int
+                  "identical reads externalize the same original byte count"
+                  first_bytes
+                  second_bytes;
+                first_bytes
+              | _ -> fail "expected original byte counts for two Keeper results"
+            in
+            let completion_json =
+              Agent_core.Event_bus.drain subscription
+              |> List.filter_map (fun (event : Agent_core.Event_bus.event) ->
+                match event.payload with
+                | Agent_core.Event_bus.ToolCompleted _ ->
+                  Masc.Keeper_event_bridge.native_event_to_json event
+                | _ -> None)
+            in
+            check int
+              "both production completions reach the bridge"
+              2
+              (List.length completion_json);
+            let string_member key = function
+              | `Assoc fields ->
+                (match List.assoc_opt key fields with
+                 | Some (`String value) -> Some value
+                 | _ -> None)
+              | _ -> None
+            in
+            let event_execution_ids =
+              List.map
+                (fun json ->
+                   match
+                     Option.bind
+                       (match json with
+                        | `Assoc fields -> List.assoc_opt "payload" fields
+                        | _ -> None)
+                       (string_member "execution_id")
+                   with
+                   | Some execution_id -> execution_id
+                   | None -> fail "bridged Keeper completion has no execution_id")
+                completion_json
+            in
+            check int
+              "each occurrence keeps a distinct execution id"
+              2
+              (List.length (List.sort_uniq String.compare event_execution_ids));
+            let log_rows =
+              Masc.Keeper_tool_call_log.read_recent
+                ~keeper_name:meta.name
+                ~n:2
+                ()
+            in
+            check int "both calls reach the durable tool log" 2 (List.length log_rows);
+            let log_execution_ids =
+              List.map
+                (fun row ->
+                   match string_member "execution_id" row with
+                   | Some execution_id -> execution_id
+                   | None -> fail "durable Keeper tool row has no execution_id")
+                log_rows
+            in
+            check
+              (list string)
+              "event and durable-log joins agree"
+              (List.sort String.compare log_execution_ids)
+              (List.sort String.compare event_execution_ids);
+            List.iter
+              (fun row ->
+                 match row with
+                 | `Assoc fields ->
+                   (match List.assoc_opt "result_bytes" fields with
+                    | Some (`Int bytes) ->
+                      check int
+                        "handler original-byte observation reaches durable row"
+                        expected_original_bytes
+                        bytes
+                    | _ -> fail "durable Keeper tool row has no result_bytes")
+                 | _ -> fail "durable Keeper tool row is not an object")
+              log_rows;
+            check int
+              "post hooks consume both handler observations"
+              0
+              (Masc.Keeper_tool_call_log.pending_truncation_count_for_testing ());
+            check int
+              "bridge consumes both exact joins"
+              0
+              (Masc.Keeper_execution_join.For_testing.size ())))
+;;
+
 let test_manual_gate_defers_publication_writes_before_recovery () =
   with_exec_fixture
     "keeper_tool_dispatch_manual_publication_gate"
@@ -4378,6 +4633,8 @@ let () =
         test_execute_with_outcome_missing_file_is_failure;
       test_case "initializing recovery isolates only publication writes" `Quick
         test_initializing_recovery_isolates_only_publication_writes;
+      test_case "identical Keeper invocations join across production boundaries" `Quick
+        test_identical_keeper_invocations_join_across_production_boundaries;
       test_case "Manual Gate defers writes before recovery acquisition" `Quick
         test_manual_gate_defers_publication_writes_before_recovery;
       test_case "Manual Gate defers memory write before persistence" `Quick

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -868,7 +868,7 @@ let test_identical_keeper_invocations_join_across_production_boundaries () =
          ~keeper_name:meta.name
          ~content:
            (String.make
-              (Tool_bridge.default_externalize_threshold_bytes + 1)
+              (Masc.Tool_bridge.default_externalize_threshold_bytes + 1)
               'x')
          ~surface:(Masc.Surface_ref.Dashboard { session_id = None })
          ();

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -419,17 +419,6 @@ let test_autonomous_yield_boundary_contract () =
      | Runtime_agent.Yielded_after_repeated_tool_call _
      | Runtime_agent.InputRequired _ -> false)
 
-let test_terminal_effect_handler_contract () =
-  let is_terminal =
-    Masc.Keeper_tools_agent_core_bundle.For_testing.is_terminal_effect_handler
-  in
-  check bool "surface post is a terminal effect" true
-    (is_terminal Masc.Keeper_tool_descriptor.Tool_surface_post);
-  check bool "surface read is not a terminal effect" false
-    (is_terminal Masc.Keeper_tool_descriptor.Tool_surface_read);
-  check bool "filesystem write is not a reply terminal" false
-    (is_terminal Masc.Keeper_tool_descriptor.Tool_write_file)
-
 let test_terminal_externalization_failure_contract () =
   let classify =
     Masc.Keeper_tools_agent_core_bundle.For_testing.terminal_externalization_failure
@@ -804,8 +793,6 @@ let () =
             test_repeated_exact_tool_call_boundary;
           test_case "autonomous yield boundary contract" `Quick
             test_autonomous_yield_boundary_contract;
-          test_case "terminal effect handler contract" `Quick
-            test_terminal_effect_handler_contract;
           test_case "terminal externalization failure contract" `Quick
             test_terminal_externalization_failure_contract;
         ] );

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -203,7 +203,201 @@ let test_bundle_exactly_matches_model_visible_descriptors () =
             expected_names
             actual_names;
           check int "bundle contains no duplicate model names" (List.length actual_names)
-            (List.length bundle.tools)))
+            (List.length bundle.tools);
+          List.iter
+            (fun (tool : Agent_core.Tool.t) ->
+               let name = tool.schema.name in
+               let descriptor =
+                 match
+                   Keeper_tool_descriptor_resolution.descriptor_for_tool_name name
+                 with
+                 | Some descriptor -> descriptor
+                 | None -> failf "bundle tool %s has no descriptor owner" name
+               in
+               check bool
+                 (name ^ " has an explicit Agent Core descriptor")
+                 true
+                 (Option.is_some (Agent_core.Tool.descriptor tool));
+               (match descriptor.execution with
+                | Keeper_tool_descriptor.Ordinary expected_mode ->
+                  let expected_mode =
+                    match expected_mode with
+                    | Keeper_tool_descriptor.Serial -> Agent_core.Tool_contract.Serial
+                    | Keeper_tool_descriptor.Concurrent ->
+                      Agent_core.Tool_contract.Concurrent
+                  in
+                  check bool
+                    (name ^ " execution mode matches its descriptor")
+                    true
+                    (Agent_core.Tool.execution_mode tool = expected_mode);
+                  check bool
+                    (name ^ " continues after success")
+                    true
+                    (Agent_core.Tool.completion tool
+                     = Agent_core.Tool_contract.Continue_after_success)
+                | Keeper_tool_descriptor.Terminal ->
+                  check bool
+                    (name ^ " terminal tools are serial")
+                    true
+                    (Agent_core.Tool.execution_mode tool
+                     = Agent_core.Tool_contract.Serial);
+                  check bool
+                    (name ^ " terminal completion preserves unknown effect outcome")
+                    true
+                    (Agent_core.Tool.completion tool
+                     = Agent_core.Tool_contract.Terminal_after_success
+                         Agent_core.Tool_contract.Effect_outcome_unknown)))
+            bundle.tools))
+
+let test_explicit_concurrent_tools_enter_one_agent_core_batch () =
+  ignore (init_registry ());
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc_test_concurrent_tool_batch_%d" (Random.int 1_000_000))
+  in
+  (try Unix.mkdir dir 0o755 with
+   | Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  Fun.protect
+    ~finally:(fun () ->
+      try Unix.rmdir dir with
+      | _ -> ())
+    (fun () ->
+       Eio_main.run
+       @@ fun env ->
+       Eio.Switch.run
+       @@ fun sw ->
+       Masc_test_deps.with_publication_recovery_registry
+         ~sw
+         ~fs:(Eio.Stdenv.fs env)
+         ~registry_root:dir
+       @@ fun publication_recovery_registry ->
+       let config = Workspace.default_config dir in
+       let meta = make_meta ~name:"test-concurrent-tool-batch" () in
+       let publication_recovery =
+         publication_recovery_turn_context
+           ~registry:publication_recovery_registry
+           ~keeper_name:meta.name
+       in
+       let ctx_snapshot =
+         Keeper_context_runtime.create ~eio:false ~system_prompt:"test"
+       in
+       let bundle =
+         Keeper_tools_agent_core_bundle.make_tool_bundle
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot
+           ()
+       in
+       Fun.protect
+         ~finally:bundle.cleanup
+         (fun () ->
+            let require_tool name =
+              match
+                List.find_opt
+                  (fun (tool : Agent_core.Tool.t) ->
+                     String.equal tool.schema.name name)
+                  bundle.tools
+              with
+              | Some tool -> tool
+              | None -> failf "missing bundle tool %s" name
+            in
+            let entered_count = Atomic.make 0 in
+            let entered_schedules = ref [] in
+            let entered_schedules_mu = Stdlib.Mutex.create () in
+            let both_entered, resolve_both_entered = Eio.Promise.create () in
+            let release, resolve_release = Eio.Promise.create () in
+            let wrap (tool : Agent_core.Tool.t) =
+              { tool with
+                handler =
+                  (fun execution_env _input ->
+                     let invocation =
+                       match Agent_core.Tool.Execution_env.invocation execution_env with
+                       | Some invocation -> invocation
+                       | None -> failwith "scheduled tool omitted invocation"
+                     in
+                     let schedule =
+                       Agent_core.Tool_contract.Invocation.schedule invocation
+                     in
+                     Stdlib.Mutex.lock entered_schedules_mu;
+                     Fun.protect
+                       ~finally:(fun () -> Stdlib.Mutex.unlock entered_schedules_mu)
+                       (fun () ->
+                          entered_schedules := schedule :: !entered_schedules);
+                     let prior = Atomic.fetch_and_add entered_count 1 in
+                     if prior = 1 then Eio.Promise.resolve resolve_both_entered ();
+                     Eio.Promise.await release;
+                     Ok { Agent_core.Types.content = "barrier passed"; _meta = None })
+              }
+            in
+            let tools =
+              [ wrap (require_tool "keeper_time_now")
+              ; wrap (require_tool "masc_board_stats")
+              ]
+            in
+            let report = ref None in
+            Eio.Time.with_timeout_exn
+              (Eio.Stdenv.clock env)
+              2.0
+              (fun () ->
+                 Eio.Fiber.both
+                   (fun () ->
+                      report :=
+                        Some
+                          (Agent_core.Agent_tools.execute_tools
+                             ~context:(Agent_core.Context.create ())
+                             ~tools
+                             ~hooks:Agent_core.Hooks.empty
+                             ~event_bus:None
+                             ~tracer:Agent_core.Tracing.null
+                             ~agent_name:"test-concurrent-tool-batch-agent"
+                             ~turn_count:7
+                             ~usage:Agent_core.Types.empty_usage
+                             [ Agent_core.Types.ToolUse
+                                 { id = "time-1"
+                                 ; name = "keeper_time_now"
+                                 ; input = `Assoc []
+                                 }
+                             ; Agent_core.Types.ToolUse
+                                 { id = "stats-1"
+                                 ; name = "masc_board_stats"
+                                 ; input = `Assoc []
+                                 }
+                             ]))
+                   (fun () ->
+                      Eio.Promise.await both_entered;
+                      Eio.Promise.resolve resolve_release ()));
+            (match !report with
+             | Some (Ok { completed_results; _ }) ->
+               check int "both calls completed" 2 (List.length completed_results)
+             | Some (Error _) -> fail "concurrent batch returned an execution failure"
+             | None -> fail "concurrent batch returned no report");
+            let schedules =
+              !entered_schedules
+              |> List.sort (fun
+                (left : Agent_core.Tool_contract.schedule)
+                (right : Agent_core.Tool_contract.schedule) ->
+                Int.compare left.planned_index right.planned_index)
+            in
+            check int "both handlers crossed the barrier" 2 (List.length schedules);
+            List.iter
+              (fun (schedule : Agent_core.Tool_contract.schedule) ->
+                 check int "one shared batch index" 0 schedule.batch_index;
+                 check int "batch carries both calls" 2 schedule.batch_size;
+                 check bool
+                   "execution mode is concurrent"
+                   true
+                   (schedule.execution_mode = Agent_core.Tool_contract.Concurrent))
+              schedules;
+            check
+              (list int)
+              "results retain planned order"
+              [ 0; 1 ]
+              (List.map
+                 (fun (schedule : Agent_core.Tool_contract.schedule) ->
+                    schedule.planned_index)
+                 schedules)))
 
 let test_missing_current_task_reconciled_before_transition_hint () =
   ignore (init_registry ());
@@ -436,6 +630,8 @@ let () =
             test_fusion_default_descriptor_is_bundle_visible;
           test_case "bundle exactly matches model-visible descriptors" `Quick
             test_bundle_exactly_matches_model_visible_descriptors;
+          test_case "explicit concurrent tools enter one Agent Core batch" `Quick
+            test_explicit_concurrent_tools_enter_one_agent_core_batch;
           test_case "missing current task reconciles before transition hint" `Quick
             test_missing_current_task_reconciled_before_transition_hint;
           test_case "bundle assembly does not emit assignment" `Quick


### PR DESCRIPTION
## Outcome

Keeper tool-call observability no longer shares truncation, duration, or event-join state between sibling Agent Core invocations.

## Reproduced boundary

Concurrent batches make provider ids insufficient occurrence keys: ids may be blank or repeated, and Keeper's former duration fallback used one mutable keeper-level timestamp.

## Change

- key pending truncation and execution-event joins by the exact immutable Agent Core invocation
- use weak ownership so abandoned/cancelled invocations do not leak observation state
- preserve blank and repeated provider ids without string inference
- consume the same invocation through PostToolUse and ToolCompleted
- use Agent Core's invocation-scoped duration directly
- retire the timing-only pre_tool_use slot and align introspection with the runtime record
- do not change tool execution mode in this PR

## Evidence

- production-boundary regression executes structurally identical Keeper calls through the tool bundle, Agent Core dispatch, post hook, event bus, bridge, blob store, and durable log
- durable rows and completion events agree on distinct execution ids
- abandoned weak-key entries are released; settled observations are consumed exactly once
- exact-head diff check and adversarial review report no BLOCKING/HIGH findings
- CI is the build/test authority; no local build or test is used as merge proof

This is the observation-safety parent of the explicit concurrency PR.