### PR TITLE
fix(keeper): opt safe tools into concurrent batches

### DIFF
--- a/dashboard/src/api/dashboard-keeper-tool-calls.ts
+++ b/dashboard/src/api/dashboard-keeper-tool-calls.ts
@@ -42,6 +42,10 @@ export type ToolCallEntry = {
   // Agent Core model-tool occurrence slot. Together with turn it scopes provider ids
   // that may be blank or repeated.
   planned_index?: number
+  // Agent Core's actual batch assignment. These are schedule truth, not timing inference.
+  batch_index?: number
+  batch_size?: number
+  execution_mode?: 'serial' | 'concurrent'
   // Goal id(s) this call was attributed to (conditional on the row carrying
   // them), for goal-scoped drill-down alongside task_id/turn.
   goal_ids?: string[]
@@ -98,6 +102,12 @@ function decodeToolCallEntry(raw: unknown): ToolCallEntry | null {
     execution_id: asString(raw.execution_id),
     tool_use_id: typeof raw.tool_use_id === 'string' ? raw.tool_use_id : undefined,
     planned_index: asNumber(raw.planned_index),
+    batch_index: asNumber(raw.batch_index),
+    batch_size: asNumber(raw.batch_size),
+    execution_mode:
+      raw.execution_mode === 'serial' || raw.execution_mode === 'concurrent'
+        ? raw.execution_mode
+        : undefined,
     goal_ids: asStringArray(raw.goal_ids),
   }
 }

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -418,6 +418,9 @@ describe('keeper tool telemetry fetchers', () => {
             tool_use_id: '',
             turn: 6,
             planned_index: 2,
+            batch_index: 1,
+            batch_size: 3,
+            execution_mode: 'concurrent',
             goal_ids: ['g-1', 'g-2'],
           },
         ],
@@ -432,6 +435,9 @@ describe('keeper tool telemetry fetchers', () => {
     expect(entry?.tool_use_id).toBe('')
     expect(entry?.turn).toBe(6)
     expect(entry?.planned_index).toBe(2)
+    expect(entry?.batch_index).toBe(1)
+    expect(entry?.batch_size).toBe(3)
+    expect(entry?.execution_mode).toBe('concurrent')
   })
 
   it('keeps missing or malformed tool-call duration unmeasured', async () => {

--- a/dashboard/src/components/journey-panel.test.ts
+++ b/dashboard/src/components/journey-panel.test.ts
@@ -50,6 +50,10 @@ function toolCalls(): ToolCallsResponse {
         duration_ms: 120,
         trace_id: 'trace-1',
         turn: 1,
+        planned_index: 4,
+        batch_index: 0,
+        batch_size: 2,
+        execution_mode: 'concurrent',
       },
     ],
   }
@@ -198,6 +202,9 @@ describe('JourneyPanel', () => {
       expect(screen.getByText('fs_read')).toBeInTheDocument()
       expect(screen.getByText('agent turns 2')).toBeInTheDocument()
       expect(screen.getByText('trajectory + I/O')).toBeInTheDocument()
+      expect(screen.getByText('plan 4')).toBeInTheDocument()
+      expect(screen.getByText('batch 0 · size 2')).toBeInTheDocument()
+      expect(screen.getByText('mode concurrent')).toBeInTheDocument()
     })
 
     expect(fetchKeeperTrajectory).toHaveBeenCalledWith('keeper-a', 200, true, true)

--- a/dashboard/src/components/journey-panel.ts
+++ b/dashboard/src/components/journey-panel.ts
@@ -281,6 +281,15 @@ function WaterfallEntryRow({
         ${entry.round != null
           ? html`<span class="font-mono text-3xs text-[var(--color-fg-disabled)]">round ${entry.round}</span>`
           : null}
+        ${isTool && entry.plannedIndex != null
+          ? html`<span class="font-mono text-3xs text-[var(--color-fg-disabled)]">plan ${entry.plannedIndex}</span>`
+          : null}
+        ${isTool && entry.batchIndex != null && entry.batchSize != null
+          ? html`<span class="font-mono text-3xs text-[var(--color-fg-disabled)]">batch ${entry.batchIndex} · size ${entry.batchSize}</span>`
+          : null}
+        ${isTool && entry.executionMode
+          ? html`<span class="font-mono text-3xs text-[var(--color-fg-disabled)]">mode ${entry.executionMode}</span>`
+          : null}
       </div>
 
       ${isTool

--- a/dashboard/src/components/journey-waterfall-state.test.ts
+++ b/dashboard/src/components/journey-waterfall-state.test.ts
@@ -156,6 +156,10 @@ describe('buildJourneyWaterfall', () => {
           duration_ms: 250,
           trace_id: 'trace-1',
           turn: 2,
+          planned_index: 3,
+          batch_index: 1,
+          batch_size: 2,
+          execution_mode: 'concurrent',
         },
       ]),
       runtimeTrace: runtimeTrace(),
@@ -170,6 +174,10 @@ describe('buildJourneyWaterfall', () => {
     expect(toolEntry?.source).toBe('trajectory+tool_call_log')
     expect(toolEntry?.toolArgs).toEqual({ file_path: '/tmp/current' })
     expect(toolEntry?.toolResult).toBe('current result')
+    expect(toolEntry?.plannedIndex).toBe(3)
+    expect(toolEntry?.batchIndex).toBe(1)
+    expect(toolEntry?.batchSize).toBe(2)
+    expect(toolEntry?.executionMode).toBe('concurrent')
   })
 
   it('keeps tool-call-log rows when trajectory is missing', () => {
@@ -187,6 +195,10 @@ describe('buildJourneyWaterfall', () => {
           duration_ms: 10,
           trace_id: 'trace-1',
           keeper_turn_id: 5,
+          planned_index: 4,
+          batch_index: 2,
+          batch_size: 1,
+          execution_mode: 'serial',
         },
       ]),
       runtimeTrace: null,
@@ -195,6 +207,10 @@ describe('buildJourneyWaterfall', () => {
     expect(model.turns).toHaveLength(1)
     expect(model.turns[0]?.turn).toBe(5)
     expect(model.turns[0]?.entries[0]?.source).toBe('tool_call_log')
+    expect(model.turns[0]?.entries[0]?.plannedIndex).toBe(4)
+    expect(model.turns[0]?.entries[0]?.batchIndex).toBe(2)
+    expect(model.turns[0]?.entries[0]?.batchSize).toBe(1)
+    expect(model.turns[0]?.entries[0]?.executionMode).toBe('serial')
     expect(model.turns[0]?.runtimeEvidence).toBeNull()
   })
 

--- a/dashboard/src/components/journey-waterfall-state.ts
+++ b/dashboard/src/components/journey-waterfall-state.ts
@@ -36,6 +36,10 @@ export interface JourneyWaterfallEntry {
   error: string | null
   sessionId: string | null
   traceId: string | null
+  plannedIndex: number | null
+  batchIndex: number | null
+  batchSize: number | null
+  executionMode: 'serial' | 'concurrent' | null
 }
 
 export interface JourneyWaterfallRuntimeEvidence {
@@ -136,6 +140,13 @@ function traceEventStatus(event: UnifiedTraceEvent): WaterfallEntryStatus {
   return 'unknown'
 }
 
+function traceEventExecutionMode(
+  event: UnifiedTraceEvent,
+): JourneyWaterfallEntry['executionMode'] {
+  const value = event.detail.execution_mode
+  return value === 'serial' || value === 'concurrent' ? value : null
+}
+
 function entryFromTraceEvent(event: UnifiedTraceEvent): JourneyWaterfallEntry | null {
   if (event.kind !== 'tool_call' && event.kind !== 'thinking') return null
   const status = traceEventStatus(event)
@@ -159,6 +170,10 @@ function entryFromTraceEvent(event: UnifiedTraceEvent): JourneyWaterfallEntry | 
     error: event.error ?? null,
     sessionId: event.sessionId ?? null,
     traceId: traceEventTraceId(event),
+    plannedIndex: numberValue(event.detail.planned_index),
+    batchIndex: numberValue(event.detail.batch_index),
+    batchSize: numberValue(event.detail.batch_size),
+    executionMode: traceEventExecutionMode(event),
   }
 }
 

--- a/dashboard/src/components/keeper-tool-call-inspector-render.test.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector-render.test.ts
@@ -246,6 +246,9 @@ describe('KeeperToolCallInspector render', () => {
           tool_use_id: '',
           turn: 9,
           planned_index: 4,
+          batch_index: 0,
+          batch_size: 2,
+          execution_mode: 'concurrent',
           lane: 'autonomous',
         },
       ],
@@ -270,7 +273,9 @@ describe('KeeperToolCallInspector render', () => {
     expect(text).toContain('Evidence links')
     expect(text).toContain('Code')
     expect(text).toContain('Task')
-    expect(text).toContain('turn 9 · plan 4 · tool_use_id (blank)')
+    expect(text).toContain(
+      'turn 9 · plan 4 · batch 0 · size 2 · mode concurrent · tool_use_id (blank)',
+    )
   })
 
   it('does not render Code links for unsafe absolute tool-call file inputs', async () => {

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -206,6 +206,10 @@ function entryScopeLabel(entry: ToolCallEntry): string {
   const parts = [
     typeof entry.turn === 'number' ? `turn ${entry.turn}` : null,
     typeof entry.planned_index === 'number' ? `plan ${entry.planned_index}` : null,
+    typeof entry.batch_index === 'number' && typeof entry.batch_size === 'number'
+      ? `batch ${entry.batch_index} · size ${entry.batch_size}`
+      : null,
+    entry.execution_mode ? `mode ${entry.execution_mode}` : null,
     entry.tool_use_id !== undefined
       ? `tool_use_id ${entry.tool_use_id === '' ? '(blank)' : entry.tool_use_id}`
       : null,

--- a/dashboard/src/components/session-trace/session-trace-state.test.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.test.ts
@@ -372,6 +372,10 @@ describe('buildTraceEvents', () => {
           keeper_turn_id: 1,
           task_id: 'task-1',
           lane: 'runtime_mcp',
+          planned_index: 4,
+          batch_index: 1,
+          batch_size: 2,
+          execution_mode: 'concurrent',
         }],
       },
     )
@@ -381,6 +385,10 @@ describe('buildTraceEvents', () => {
     expect(toolEvents[0]!.toolResult).toBe('full file contents')
     expect(toolEvents[0]!.detail.trace_origin).toBe('trajectory+tool_call_log')
     expect(toolEvents[0]!.detail.lane).toBe('runtime_mcp')
+    expect(toolEvents[0]!.detail.planned_index).toBe(4)
+    expect(toolEvents[0]!.detail.batch_index).toBe(1)
+    expect(toolEvents[0]!.detail.batch_size).toBe(2)
+    expect(toolEvents[0]!.detail.execution_mode).toBe('concurrent')
   })
 
   it('preserves trajectory duration when the richer tool-call row has no duration', () => {
@@ -466,6 +474,10 @@ describe('buildTraceEvents', () => {
           keeper_turn_id: 3,
           task_id: 'task-2',
           lane: 'runtime_mcp',
+          planned_index: 5,
+          batch_index: 2,
+          batch_size: 1,
+          execution_mode: 'serial',
         }],
       },
     )
@@ -474,6 +486,10 @@ describe('buildTraceEvents', () => {
     expect(events[0]!.toolName).toBe('Execute')
     expect(events[0]!.error).toBe('command exited 1')
     expect(events[0]!.detail.trace_origin).toBe('tool_call_log')
+    expect(events[0]!.detail.planned_index).toBe(5)
+    expect(events[0]!.detail.batch_index).toBe(2)
+    expect(events[0]!.detail.batch_size).toBe(1)
+    expect(events[0]!.detail.execution_mode).toBe('serial')
     expect(events[0]!.detail.lane).toBe('runtime_mcp')
   })
 

--- a/dashboard/src/components/session-trace/session-trace-state.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.ts
@@ -426,6 +426,10 @@ function toolCallMetadataDetail(entry: ToolCallEntry, traceOrigin: string): Reco
   if (entry.lane) detail.lane = entry.lane
   if (entry.model) detail.model = entry.model
   if (entry.execution_id) detail.execution_id = entry.execution_id
+  if (entry.planned_index != null) detail.planned_index = entry.planned_index
+  if (entry.batch_index != null) detail.batch_index = entry.batch_index
+  if (entry.batch_size != null) detail.batch_size = entry.batch_size
+  if (entry.execution_mode) detail.execution_mode = entry.execution_mode
   return detail
 }
 

--- a/lib/keeper/keeper_event_bridge.ml
+++ b/lib/keeper/keeper_event_bridge.ml
@@ -186,8 +186,13 @@ let wrap_event
     compile-time update requirement at this boundary. *)
 let invocation_payload_fields invocation =
   let tool_use_id = Agent_core.Tool_contract.Invocation.tool_use_id invocation in
+  let schedule = Agent_core.Tool_contract.Invocation.schedule invocation in
   [ "turn", `Int (Agent_core.Tool_contract.Invocation.turn invocation)
-  ; "planned_index", `Int (Agent_core.Tool_contract.Invocation.planned_index invocation)
+  ; "planned_index", `Int schedule.planned_index
+  ; "batch_index", `Int schedule.batch_index
+  ; "batch_size", `Int schedule.batch_size
+  ; ( "execution_mode"
+    , Agent_core.Tool_contract.execution_mode_to_yojson schedule.execution_mode )
   ]
   @ (if tool_use_id = "" then [] else [ "tool_use_id", `String tool_use_id ])
 ;;

--- a/lib/keeper/keeper_event_bridge_error_json.ml
+++ b/lib/keeper/keeper_event_bridge_error_json.ml
@@ -219,11 +219,16 @@ let core_agent_error_fields = function
     ]
   | Agent_core.Error.TerminalToolDurabilityFailed
       { invocation; effect_disposition; detail } ->
+    let schedule = Agent_core.Tool_contract.Invocation.schedule invocation in
     [ "variant", `String "terminal_tool_durability_failed"
     ; ( "tool_use_id"
       , `String (Agent_core.Tool_contract.Invocation.tool_use_id invocation) )
     ; "turn", `Int (Agent_core.Tool_contract.Invocation.turn invocation)
-    ; "planned_index", `Int (Agent_core.Tool_contract.Invocation.planned_index invocation)
+    ; "planned_index", `Int schedule.planned_index
+    ; "batch_index", `Int schedule.batch_index
+    ; "batch_size", `Int schedule.batch_size
+    ; ( "execution_mode"
+      , Agent_core.Tool_contract.execution_mode_to_yojson schedule.execution_mode )
     ; ( "effect_disposition"
       , `String (Keeper_agent_error.terminal_effect_disposition_to_wire effect_disposition) )
     ; "detail_digest", `String (sha256_hex detail)

--- a/lib/keeper/keeper_hooks_agent_core.ml
+++ b/lib/keeper/keeper_hooks_agent_core.ml
@@ -475,6 +475,7 @@ let make_hooks
            the log_call row and the trajectory entry below share the value
            so downstream views can join the two stores on a single key. *)
         let execution_id = Ids.Execution_id.generate () in
+        let schedule = Agent_core.Tool_contract.Invocation.schedule invocation in
         (* RFC-0233 PR-2: register the provider-call ↔ execution pair now,
            strictly before AGENT_CORE publishes ToolCompleted for this call, so the
            event bridge can stamp the same id onto the agent_core:tool_completed
@@ -494,7 +495,10 @@ let make_hooks
              ?prompt_fingerprint:tctx.prompt_fingerprint
              ~execution_id
              ~tool_use_id
-             ~planned_index:(Agent_core.Tool_contract.Invocation.planned_index invocation)
+             ~planned_index:schedule.planned_index
+             ~batch_index:schedule.batch_index
+             ~batch_size:schedule.batch_size
+             ~execution_mode:schedule.execution_mode
              ?trace_id:tctx.trace_id ?session_id:tctx.session_id
              ?generation:tctx.generation
              ?turn:invocation_turn ?keeper_turn_id:tctx.keeper_turn_id

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -15,7 +15,10 @@ open Keeper_agent_prompt_metrics
 
     AGENT_CORE hooks (before_turn, on_tool_executed) cannot return values, so
     they write into this single mutable record during Agent.run execution.
-    After execution completes, {!freeze} produces an immutable snapshot. *)
+    After execution completes, {!freeze} produces an immutable snapshot.
+    Concurrent tool completions serialize the whole [on_tool_executed]
+    observation transaction per run; observers must therefore remain bounded
+    and must not perform open-ended I/O while holding that boundary. *)
 type hook_accumulator =
   { mutable meta : Keeper_meta_contract.keeper_meta
   ; mutable tool_calls : tool_call_detail list

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -10,6 +10,22 @@ open Keeper_agent_prompt_metrics
 
 type hook_accumulator = Keeper_run_tools_hook_accumulator.hook_accumulator
 
+type tool_observer_serialization = (unit -> unit) -> unit
+
+let create_tool_observer_serialization () : tool_observer_serialization =
+  let mutex = Eio.Mutex.create () in
+  fun observe ->
+    Eio.Mutex.lock mutex;
+    (* The enclosing Agent-core hook reports a failed observer and continues.
+       [use_rw] would poison the per-run mutex on that reported exception and
+       reject every later completion. Unlock explicitly while protecting the
+       acquired critical section from cancellation, so one failed observation
+       cannot erase unrelated later receipts. *)
+    Fun.protect
+      ~finally:(fun () -> Eio.Mutex.unlock mutex)
+      (fun () -> Eio.Cancel.protect observe)
+;;
+
 type agent_setup =
   { tools : Agent_core.Tool.t list
   ; cleanup : unit -> unit
@@ -210,6 +226,13 @@ let assemble_hooks
       acc
       initial_schema_filter;
     let meta_ref = ref acc.meta in
+    (* Explicitly concurrent tools complete in sibling fibers. Their tool bodies
+       stay concurrent, but the post-tool observer is one transaction: it
+       refreshes [acc.meta], appends the receipt detail, derives the fallback
+       turn identity, and emits the observation/activity pair. A per-run Eio
+       mutex gives those effects one order without introducing a process-global
+       gate or serializing tool execution itself. *)
+    let serialize_tool_observer = create_tool_observer_serialization () in
     let base_hooks =
       Keeper_hooks_agent_core.make_hooks
         ~config
@@ -224,106 +247,107 @@ let assemble_hooks
         ~on_tool_executed:
           (fun
             ~tool_name ~input ~output_text ~success ~duration_ms ~provider ~typed_outcome ->
-          let route_evidence =
-            Keeper_tool_call_log.route_evidence_json_of_tool_io
-              ~tool_name
-              ~input
-              ~output_text
-          in
-          let progress_io_fingerprints =
-            Keeper_tool_progress_identity.digest_tool_io
-              ~tool_name
-              ~input
-              ~output_text
-          in
-          (match Keeper_registry.get ~base_path:config.base_path meta.name with
-           | Some entry ->
-             acc.meta <- entry.meta;
-             meta_ref := entry.meta
-           | None -> ());
-          let execution_outcome =
-            if success then Tool_result.Ok else Tool_result.Error
-          in
-          let task_id =
-            Keeper_run_tools_task_scope.task_id_scope_of_tool_call
-              ~tool_name
-              ~input
-              ~meta:acc.meta
-          in
-          acc.tool_calls
-          <- { tool_name
-             ; provider
-             ; execution_outcome
-             ; typed_outcome
-             ; latency_ms = duration_ms
-             ; task_id
-             ; route_evidence
-             ; input_fingerprint =
-                 Option.map
-                   (fun (d : Keeper_tool_progress_identity.io_fingerprints) ->
-                      d.input_fingerprint)
-                   progress_io_fingerprints
-             ; output_fingerprint =
-                 Option.map
-                   (fun (d : Keeper_tool_progress_identity.io_fingerprints) ->
-                      d.output_fingerprint)
-                   progress_io_fingerprints
-             }
-             :: acc.tool_calls;
-          (* Emit neutral agent observation events; UI adapters subscribe separately. *)
-          (let typed_outcome_str =
-             match typed_outcome with
-             | Some Keeper_tool_outcome.Progress -> "progress"
-             | Some (Keeper_tool_outcome.No_progress _) -> "no_progress"
-             | Some (Keeper_tool_outcome.Error _) -> "error"
-             | None -> Tool_result.string_of_tool_call_outcome execution_outcome
-           in
-           let turn_id =
-             match acc.meta.Keeper_meta_contract.current_task_id with
-             | Some t -> Keeper_id.Task_id.to_string t
-             | None -> "turn-" ^ string_of_int (List.length acc.tool_calls)
-           in
-           (* task-1733: resolve the partition from the tool's actual edited
-              file (input.path / input.file_path, with explicit cwd honoured
-              for relative paths), not from the [.masc] runtime root.
-              #23469: relative shapes anchor at this keeper's playground
-              sandbox root, matching the file tools' own resolution. *)
-           let partition, observed_file_path =
-             observation_partition_for_tool_input
-               ~config
-               ~meta:acc.meta
-               ~kind:"tool_event"
-               input
-           in
-           Agent_observation.emit_tool_event
-             { base_path = config.base_path
-             ; partition
-             ; file_path = observed_file_path
-             ; tool_name
-             ; keeper_id = acc.meta.name
-             ; turn_id
-             ; outcome = Tool_result.string_of_tool_call_outcome execution_outcome
-             ; typed_outcome = typed_outcome_str
-             ; duration_ms
-             ; output_text
-             ; input
-             };
-           (* #23540: keeper in-turn tool executions never reached the
-              activity log ([tool.called] is emitted only by the external MCP
-              path), so the agent timeline reported tool_calls = 0 for any
-              keeper working through its own turn. *)
-           Keeper_tool_activity.emit_tool_exec
-             ~config
-             ~meta:acc.meta
-             ~tool_name
-             ~success
-             ~duration_ms:(int_of_float (Float.round duration_ms))
-             ~typed_outcome
-             ~provider
-             ~keeper_turn_id:(Some keeper_turn_id)
-             ~agent_core_turn:acc.current_turn
-             ~task_id
-             ()))
+            serialize_tool_observer (fun () ->
+              let route_evidence =
+                Keeper_tool_call_log.route_evidence_json_of_tool_io
+                  ~tool_name
+                  ~input
+                  ~output_text
+              in
+              let progress_io_fingerprints =
+                Keeper_tool_progress_identity.digest_tool_io
+                  ~tool_name
+                  ~input
+                  ~output_text
+              in
+              (match Keeper_registry.get ~base_path:config.base_path meta.name with
+               | Some entry ->
+                 acc.meta <- entry.meta;
+                 meta_ref := entry.meta
+               | None -> ());
+              let execution_outcome =
+                if success then Tool_result.Ok else Tool_result.Error
+              in
+              let task_id =
+                Keeper_run_tools_task_scope.task_id_scope_of_tool_call
+                  ~tool_name
+                  ~input
+                  ~meta:acc.meta
+              in
+              acc.tool_calls
+              <- { tool_name
+                 ; provider
+                 ; execution_outcome
+                 ; typed_outcome
+                 ; latency_ms = duration_ms
+                 ; task_id
+                 ; route_evidence
+                 ; input_fingerprint =
+                     Option.map
+                       (fun (d : Keeper_tool_progress_identity.io_fingerprints) ->
+                          d.input_fingerprint)
+                       progress_io_fingerprints
+                 ; output_fingerprint =
+                     Option.map
+                       (fun (d : Keeper_tool_progress_identity.io_fingerprints) ->
+                          d.output_fingerprint)
+                       progress_io_fingerprints
+                 }
+                 :: acc.tool_calls;
+              (* Emit neutral agent observation events; UI adapters subscribe separately. *)
+              (let typed_outcome_str =
+                 match typed_outcome with
+                 | Some Keeper_tool_outcome.Progress -> "progress"
+                 | Some (Keeper_tool_outcome.No_progress _) -> "no_progress"
+                 | Some (Keeper_tool_outcome.Error _) -> "error"
+                 | None -> Tool_result.string_of_tool_call_outcome execution_outcome
+               in
+               let turn_id =
+                 match acc.meta.Keeper_meta_contract.current_task_id with
+                 | Some t -> Keeper_id.Task_id.to_string t
+                 | None -> "turn-" ^ string_of_int (List.length acc.tool_calls)
+               in
+               (* task-1733: resolve the partition from the tool's actual edited
+                  file (input.path / input.file_path, with explicit cwd honoured
+                  for relative paths), not from the [.masc] runtime root.
+                  #23469: relative shapes anchor at this keeper's playground
+                  sandbox root, matching the file tools' own resolution. *)
+               let partition, observed_file_path =
+                 observation_partition_for_tool_input
+                   ~config
+                   ~meta:acc.meta
+                   ~kind:"tool_event"
+                   input
+               in
+               Agent_observation.emit_tool_event
+                 { base_path = config.base_path
+                 ; partition
+                 ; file_path = observed_file_path
+                 ; tool_name
+                 ; keeper_id = acc.meta.name
+                 ; turn_id
+                 ; outcome = Tool_result.string_of_tool_call_outcome execution_outcome
+                 ; typed_outcome = typed_outcome_str
+                 ; duration_ms
+                 ; output_text
+                 ; input
+                 };
+               (* #23540: keeper in-turn tool executions never reached the
+                  activity log ([tool.called] is emitted only by the external MCP
+                  path), so the agent timeline reported tool_calls = 0 for any
+                  keeper working through its own turn. *)
+               Keeper_tool_activity.emit_tool_exec
+                 ~config
+                 ~meta:acc.meta
+                 ~tool_name
+                 ~success
+                 ~duration_ms:(int_of_float (Float.round duration_ms))
+                 ~typed_outcome
+                 ~provider
+                 ~keeper_turn_id:(Some keeper_turn_id)
+                 ~agent_core_turn:acc.current_turn
+                 ~task_id
+                 ())))
         ()
     in
     let before_turn_hook : Agent_core.Hooks.hooks =

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -21,9 +21,12 @@ let create_tool_observer_serialization () : tool_observer_serialization =
        reject every later completion. Unlock explicitly while protecting the
        acquired critical section from cancellation, so one failed observation
        cannot erase unrelated later receipts. *)
-    Fun.protect
-      ~finally:(fun () -> Eio.Mutex.unlock mutex)
-      (fun () -> Eio.Cancel.protect observe)
+    Eio.Cancel.protect (fun () ->
+      match observe () with
+      | () -> Eio.Mutex.unlock mutex
+      | exception exn ->
+        Eio.Mutex.unlock mutex;
+        raise exn)
 ;;
 
 type agent_setup =

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1092,6 +1092,7 @@ let in_process_descriptor_with_schema_source
 
 let in_process_descriptor ~keeper_model_projection ~id ~name ~description
       ~input_schema ~policy ?ordinary_execution_mode ~handler
+      ()
   =
   in_process_descriptor_with_schema_source
     ~capability_identity:Internal_name_identity
@@ -1495,6 +1496,7 @@ let internal_descriptors : t list =
       ~ordinary_execution_mode:Concurrent
       ~policy:(read_only_in_process_policy ())
       ~handler:Tool_time_now
+      ()
   ; (in_process_descriptor
        ~keeper_model_projection:Internal_name
        ~id:"keeper.tools_list"
@@ -1507,6 +1509,7 @@ let internal_descriptors : t list =
        ~input_schema:empty_object_schema
        ~policy:(read_only_in_process_policy ())
        ~handler:Tool_tools_list
+       ()
      |> with_eval_tags [ "capability_introspection" ])
     (* ── memory / context (RFC-0179 PR-3) ─────────────────────── *)
   ; in_process_descriptor
@@ -1520,6 +1523,7 @@ let internal_descriptors : t list =
       ~input_schema:empty_object_schema
       ~policy:(read_only_in_process_policy ())
       ~handler:Tool_context_status
+      ()
   ; (in_process_descriptor_with_schema_source
       ~capability_identity:Internal_name_identity
       ~keeper_model_projection:Internal_name
@@ -1564,6 +1568,7 @@ let internal_descriptors : t list =
       ~input_schema:library_search_schema
       ~policy:(read_only_in_process_policy ())
       ~handler:Tool_library_search
+      ()
   ; in_process_descriptor
       ~keeper_model_projection:Internal_name
       ~id:"keeper.library.read"
@@ -1572,6 +1577,7 @@ let internal_descriptors : t list =
       ~input_schema:library_read_schema
       ~policy:(read_only_in_process_policy ())
       ~handler:Tool_library_read
+      ()
     (* ── connector surfaces (RFC-0223 P3) ─────────────────────── *)
   ; (in_process_descriptor
        ~keeper_model_projection:Internal_name
@@ -1586,6 +1592,7 @@ let internal_descriptors : t list =
        ~input_schema:surface_read_schema
        ~policy:(read_only_in_process_policy ())
        ~handler:Tool_surface_read
+       ()
      |> with_eval_tags [ "surface_context_read" ])
   ; in_process_descriptor
       ~keeper_model_projection:Internal_name
@@ -1595,6 +1602,7 @@ let internal_descriptors : t list =
       ~input_schema:surface_post_schema
       ~policy:(write_in_process_policy ())
       ~handler:Tool_surface_post
+      ()
   ; in_process_descriptor
       ~keeper_model_projection:Internal_name
       ~id:"keeper.person.note_set"
@@ -1607,6 +1615,7 @@ let internal_descriptors : t list =
       ~input_schema:person_note_set_schema
       ~policy:(write_in_process_policy ())
       ~handler:Tool_person_note_set
+      ()
     (* ── IDE (RFC-0179 PR-3) ──────────────────────────────────── *)
   ; in_process_descriptor_with_schema_source
       ~capability_identity:Internal_name_identity

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -42,6 +42,20 @@ type input_schema_source =
 
 type readonly_of_input = Yojson.Safe.t -> bool option
 
+type ordinary_execution_mode =
+  | Serial
+  | Concurrent
+
+type execution =
+  | Ordinary of ordinary_execution_mode
+  | Terminal
+
+let execution_to_string = function
+  | Ordinary Serial -> "serial"
+  | Ordinary Concurrent -> "concurrent"
+  | Terminal -> "terminal"
+;;
+
 type identity_validation =
   | Validate_once_before_translation
   | Validate_once_after_translation
@@ -115,6 +129,7 @@ type t =
   ; description : string
   ; input_schema : Yojson.Safe.t
   ; model_output_projection : Tool_output.model_projection
+  ; execution : execution
   ; policy : policy
   ; executor : executor
   ; backend : backend
@@ -496,6 +511,7 @@ let descriptor
       ~description
       ~input_schema
       ?(model_output_projection = Tool_output.default_model_projection)
+      ?(ordinary_execution_mode = Serial)
       ~policy
       ~executor
       ~backend
@@ -506,6 +522,46 @@ let descriptor
   =
   let capability_id =
     capability_id_of_identity ~internal_name capability_identity
+  in
+  let execution =
+    match runtime_handler with
+    | Tool_surface_post -> Terminal
+    | ( Tool_execute
+      | Tool_search_files
+      | Tool_read_file
+      | Tool_edit_file
+      | Tool_write_file
+      | Tool_time_now
+      | Tool_tools_list
+      | Tool_context_status
+      | Tool_artifact_read
+      | Tool_memory_search
+      | Tool_memory_write
+      | Tool_library_search
+      | Tool_library_read
+      | Tool_surface_read
+      | Tool_person_note_set
+      | Tool_ide_annotate
+      | Tool_voice_dispatch
+      | Tool_task_dispatch
+      | Tool_board_dispatch
+      | Tool_masc_task_dispatch
+      | Tool_masc_plan_dispatch
+      | Tool_masc_run_dispatch
+      | Tool_masc_agent_dispatch
+      | Tool_masc_workspace_dispatch
+      | Tool_masc_misc_dispatch
+      | Tool_web_search
+      | Tool_web_fetch
+      | Tool_masc_control_dispatch
+      | Tool_masc_agent_timeline_dispatch
+      | Tool_masc_schedule_dispatch
+      | Tool_masc_keeper_dispatch
+      | Tool_masc_fusion_dispatch
+      | Tool_masc_fusion_status
+      | Tool_masc_library_dispatch
+      | Tool_masc_local_runtime_dispatch
+      | Tool_analyze_image ) -> Ordinary ordinary_execution_mode
   in
   let receipt_labels =
     [ "descriptor_id", id
@@ -518,6 +574,7 @@ let descriptor
     ; "backend", backend_to_string backend
     ; "sandbox", sandbox_to_string sandbox
     ; "runtime_handler", runtime_handler_to_string runtime_handler
+    ; "execution", execution_to_string execution
     ; ( "keeper_tool_group"
       , keeper_tool_group_to_string
           (keeper_tool_group_of_runtime_handler runtime_handler) )
@@ -538,6 +595,7 @@ let descriptor
   ; description
   ; input_schema
   ; model_output_projection
+  ; execution
   ; policy
   ; executor
   ; backend
@@ -1010,6 +1068,7 @@ let in_process_descriptor_with_schema_source
       ~capability_identity
       ~keeper_model_projection
       ~input_schema_source ~id ~name ~description ~input_schema ~policy ~handler
+      ?ordinary_execution_mode
       ()
   =
   descriptor
@@ -1021,6 +1080,7 @@ let in_process_descriptor_with_schema_source
     ~internal_name:name
     ~description
     ~input_schema
+    ?ordinary_execution_mode
     ~policy
     ~executor:In_process
     ~backend:Ocaml_runtime
@@ -1031,7 +1091,7 @@ let in_process_descriptor_with_schema_source
 ;;
 
 let in_process_descriptor ~keeper_model_projection ~id ~name ~description
-      ~input_schema ~policy ~handler
+      ~input_schema ~policy ?ordinary_execution_mode ~handler
   =
   in_process_descriptor_with_schema_source
     ~capability_identity:Internal_name_identity
@@ -1043,6 +1103,7 @@ let in_process_descriptor ~keeper_model_projection ~id ~name ~description
     ~input_schema
     ~policy
     ~handler
+    ?ordinary_execution_mode
     ()
 ;;
 
@@ -1120,6 +1181,30 @@ let masc_board_descriptor board_name =
   let name = Tool_name.Board_name.to_string board_name in
   let operation_policy = Board_tool_registry.operation_policy board_name in
   let readonly = operation_policy.readonly in
+  let ordinary_execution_mode =
+    match board_name with
+    | Tool_name.Board_name.Board_stats -> Concurrent
+    | ( Board_cleanup
+      | Board_comment
+      | Board_comment_vote
+      | Board_curation_read
+      | Board_curation_submit
+      | Board_delete
+      | Board_hearths
+      | Board_list
+      | Board_post
+      | Board_post_get
+      | Board_post_update
+      | Board_profile
+      | Board_reaction
+      | Board_search
+      | Board_sub_board_create
+      | Board_sub_board_delete
+      | Board_sub_board_get
+      | Board_sub_board_list
+      | Board_sub_board_update
+      | Board_vote ) -> Serial
+  in
   let policy = policy ~readonly ~retryable:readonly () in
   let canonical_keeper_input_schema =
     remove_schema_fields
@@ -1141,6 +1226,7 @@ let masc_board_descriptor board_name =
        ~name
        ~description
        ~input_schema
+       ~ordinary_execution_mode
        ~policy
        ~handler:Tool_board_dispatch
        ()
@@ -1406,6 +1492,7 @@ let internal_descriptors : t list =
         "Return the current wall-clock time as ISO 8601 and Unix epoch \
          seconds. No arguments."
       ~input_schema:empty_object_schema
+      ~ordinary_execution_mode:Concurrent
       ~policy:(read_only_in_process_policy ())
       ~handler:Tool_time_now
   ; (in_process_descriptor
@@ -1919,6 +2006,7 @@ let route_evidence_json d =
      ; "backend", `String (backend_to_string d.backend)
      ; "sandbox", `String (sandbox_to_string d.sandbox)
      ; "runtime_handler", `String (runtime_handler_to_string d.runtime_handler)
+     ; "execution", `String (execution_to_string d.execution)
      ; "receipt_labels", receipt_labels_json d
      ; "eval_tags", eval_tags_json d
      ]
@@ -1953,6 +2041,7 @@ let discovery_fields d =
    ; "backend", `String (backend_to_string d.backend)
    ; "sandbox", `String (sandbox_to_string d.sandbox)
    ; "runtime_handler", `String (runtime_handler_to_string d.runtime_handler)
+   ; "execution", `String (execution_to_string d.execution)
    ; "policy", discovery_policy_json d.policy
    ; "schema_shape", Tool_input_validation.schema_shape_json d.input_schema
    ]

--- a/lib/keeper/keeper_tool_descriptor.mli
+++ b/lib/keeper/keeper_tool_descriptor.mli
@@ -57,6 +57,17 @@ type input_schema_source =
 
 type readonly_of_input = Yojson.Safe.t -> bool option
 
+type ordinary_execution_mode =
+  | Serial
+  | Concurrent
+
+type execution =
+  | Ordinary of ordinary_execution_mode
+  | Terminal
+(** Descriptor-owned execution contract. Read-only classification does not
+    imply concurrency safety, and terminal concurrent execution is not
+    representable. *)
+
 type identity_validation =
   | Validate_once_before_translation
   | Validate_once_after_translation
@@ -135,6 +146,7 @@ type t =
   ; description : string
   ; input_schema : Yojson.Safe.t
   ; model_output_projection : Tool_output.model_projection
+  ; execution : execution
   ; policy : policy
   ; executor : executor
   ; backend : backend

--- a/lib/keeper/keeper_tools_agent_core_bundle.ml
+++ b/lib/keeper/keeper_tools_agent_core_bundle.ml
@@ -253,9 +253,22 @@ let make_tool_bundle_for_descriptors
     List.concat_map
       (fun (descriptor : Keeper_tool_descriptor.t) ->
          let internal = descriptor.internal_name in
+         let agent_core_descriptor =
+           match descriptor.execution with
+           | Keeper_tool_descriptor.Ordinary Keeper_tool_descriptor.Serial
+             -> None
+           | Keeper_tool_descriptor.Ordinary Keeper_tool_descriptor.Concurrent ->
+             Some
+               (Agent_core.Tool.ordinary_descriptor
+                  Agent_core.Tool_contract.Concurrent)
+           | Keeper_tool_descriptor.Terminal ->
+             Some
+               (Agent_core.Tool.terminal_descriptor
+                  Agent_core.Tool_contract.Effect_outcome_unknown)
+         in
          let on_completed, on_failed, on_externalization_error =
-           match completion_boundary_of_runtime_handler descriptor.runtime_handler with
-           | Terminal_effect ->
+           match descriptor.execution with
+           | Keeper_tool_descriptor.Terminal ->
              ( Some
                  (function
                    | Some receipt -> mark_terminal_effect_completed receipt
@@ -268,7 +281,9 @@ let make_tool_bundle_for_descriptors
                        })
              , Some mark_terminal_effect_failed
              , Some mark_completed_terminal_externalization_failed )
-           | Continue_after_success -> None, None, None
+           | Keeper_tool_descriptor.Ordinary
+               (Keeper_tool_descriptor.Serial | Keeper_tool_descriptor.Concurrent) ->
+             None, None, None
          in
          Keeper_tool_descriptor.keeper_model_names descriptor
          |> List.map (fun model_name ->
@@ -298,6 +313,7 @@ let make_tool_bundle_for_descriptors
                  ()
              in
              Tool_bridge.agent_core_tool_of_masc_with_execution_env
+               ?descriptor:agent_core_descriptor
                ~base_path:config.base_path
                ~model_projection:descriptor.model_output_projection
                ?on_externalization_error

--- a/lib/keeper/keeper_tools_agent_core_bundle.ml
+++ b/lib/keeper/keeper_tools_agent_core_bundle.ml
@@ -9,18 +9,6 @@
 
 open Keeper_tools_agent_core
 
-type completion_boundary =
-  | Continue_after_success
-  | Terminal_effect
-
-(* A connected-surface post is the reply deliverable for this Keeper turn.
-   Classify it from the closed runtime-handler ADT: no tool-name comparison,
-   payload inspection, retry count, or elapsed-time threshold participates. *)
-let completion_boundary_of_runtime_handler = function
-  | Keeper_tool_descriptor.Tool_surface_post -> Terminal_effect
-  | _ -> Continue_after_success
-;;
-
 let terminal_externalization_failure
       state
       ({ message; _ } : Tool_bridge.externalization_error)
@@ -255,8 +243,9 @@ let make_tool_bundle_for_descriptors
          let internal = descriptor.internal_name in
          let agent_core_descriptor =
            match descriptor.execution with
-           | Keeper_tool_descriptor.Ordinary Keeper_tool_descriptor.Serial
-             -> None
+           | Keeper_tool_descriptor.Ordinary Keeper_tool_descriptor.Serial ->
+             Some
+               (Agent_core.Tool.ordinary_descriptor Agent_core.Tool_contract.Serial)
            | Keeper_tool_descriptor.Ordinary Keeper_tool_descriptor.Concurrent ->
              Some
                (Agent_core.Tool.ordinary_descriptor
@@ -383,12 +372,6 @@ let make_tools
 ;;
 
 module For_testing = struct
-  let is_terminal_effect_handler handler =
-    match completion_boundary_of_runtime_handler handler with
-    | Terminal_effect -> true
-    | Continue_after_success -> false
-  ;;
-
   let initial_terminal_effect_state = initial_terminal_effect_state
 
   let terminal_externalization_failure =

--- a/lib/keeper/keeper_tools_agent_core_bundle.mli
+++ b/lib/keeper/keeper_tools_agent_core_bundle.mli
@@ -29,8 +29,6 @@ val make_tools
   -> Agent_core.Tool.t list
 
 module For_testing : sig
-  val is_terminal_effect_handler : Keeper_tool_descriptor.runtime_handler -> bool
-
   val initial_terminal_effect_state :
     Keeper_tools_agent_core.gate_replay_delivery option ->
     Keeper_tools_agent_core.terminal_effect_state

--- a/lib/keeper/keeper_tools_agent_core_handler_telemetry.ml
+++ b/lib/keeper/keeper_tools_agent_core_handler_telemetry.ml
@@ -62,9 +62,14 @@ let tool_io_preview_fields ~tool_name ~input ?output () =
 let agent_core_invocation_fields = function
   | None -> []
   | Some invocation ->
+    let schedule = Agent_core.Tool_contract.Invocation.schedule invocation in
     [ "tool_use_id", `String (Agent_core.Tool_contract.Invocation.tool_use_id invocation)
     ; "turn", `Int (Agent_core.Tool_contract.Invocation.turn invocation)
-    ; "planned_index", `Int (Agent_core.Tool_contract.Invocation.planned_index invocation)
+    ; "planned_index", `Int schedule.planned_index
+    ; "batch_index", `Int schedule.batch_index
+    ; "batch_size", `Int schedule.batch_size
+    ; ( "execution_mode"
+      , Agent_core.Tool_contract.execution_mode_to_yojson schedule.execution_mode )
     ]
 ;;
 

--- a/lib/keeper/keeper_tools_agent_core_handler_telemetry.mli
+++ b/lib/keeper/keeper_tools_agent_core_handler_telemetry.mli
@@ -23,8 +23,10 @@ val tool_io_preview_fields
   -> unit
   -> (string * Yojson.Safe.t) list
 
-(** Exact AGENT_CORE model-tool occurrence fields. Blank or repeated [tool_use_id]
-    values are preserved because [turn] and [planned_index] provide the scope. *)
+(** Exact AGENT_CORE model-tool occurrence and schedule fields. Blank or repeated
+    [tool_use_id] values are preserved because [turn] and [planned_index]
+    provide the scope. The batch fields and execution mode come directly from
+    the invocation rather than elapsed-time inference. *)
 val agent_core_invocation_fields
   :  Agent_core.Tool_contract.Invocation.t option
   -> (string * Yojson.Safe.t) list

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -418,6 +418,9 @@ let log_call
       ?execution_id
       ?tool_use_id
       ?planned_index
+      ?batch_index
+      ?batch_size
+      ?execution_mode
       ?trace_id
       ?session_id
       ?generation
@@ -515,6 +518,23 @@ let log_call
       let planned_index_field =
         match planned_index with
         | Some value -> [ "planned_index", `Int value ]
+        | None -> []
+      in
+      let batch_index_field =
+        match batch_index with
+        | Some value -> [ "batch_index", `Int value ]
+        | None -> []
+      in
+      let batch_size_field =
+        match batch_size with
+        | Some value -> [ "batch_size", `Int value ]
+        | None -> []
+      in
+      let execution_mode_field =
+        match execution_mode with
+        | Some value ->
+          [ ( "execution_mode"
+            , Agent_core.Tool_contract.execution_mode_to_yojson value ) ]
         | None -> []
       in
       let session_id_field =
@@ -621,6 +641,9 @@ let log_call
            @ execution_id_field
            @ tool_use_id_field
            @ planned_index_field
+           @ batch_index_field
+           @ batch_size_field
+           @ execution_mode_field
            @ trace_id_field
            @ session_id_field
            @ generation_field

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -147,6 +147,9 @@ val log_call :
   ?execution_id:Ids.Execution_id.t ->
   ?tool_use_id:string ->
   ?planned_index:int ->
+  ?batch_index:int ->
+  ?batch_size:int ->
+  ?execution_mode:Agent_core.Tool_contract.execution_mode ->
   ?trace_id:string ->
   ?session_id:string ->
   ?generation:int ->
@@ -171,7 +174,9 @@ val log_call :
     same execution (when the dispatch lane has one) — the key that the
     agent_core:tool_called/agent_core:tool_completed event rows also carry. Blank and
     repeated provider ids remain meaningful when scoped by [turn] and
-    [planned_index], so they are persisted unchanged.
+    [planned_index], so they are persisted unchanged. [batch_index],
+    [batch_size], and [execution_mode] preserve Agent Core's actual schedule
+    rather than inferring concurrency from timing.
     [on_committed], when supplied, forces this row through the synchronous
     append boundary and runs only after that append succeeds. It is intended
     for exact completion notifications whose readers must not race the

--- a/test/test_keeper_execution_join.ml
+++ b/test/test_keeper_execution_join.ml
@@ -23,16 +23,23 @@ let int_of_field = function
   | Some (`Int value) -> Some value
   | _ -> None
 
-let invocation ?(turn = 0) ?(planned_index = 0) tool_use_id =
+let invocation
+      ?(turn = 0)
+      ?(planned_index = 0)
+      ?(batch_index = 0)
+      ?(batch_size = 1)
+      ?(execution_mode = Agent_core.Tool_contract.Serial)
+      tool_use_id
+  =
   Agent_core.Tool_contract.Invocation.create
     ~tool_use_id
     ~turn
     ~completion:Agent_core.Tool_contract.Continue_after_success
     ~schedule:
       { planned_index
-      ; batch_index = 0
-      ; batch_size = 1
-      ; execution_mode = Agent_core.Tool_contract.Serial
+      ; batch_index
+      ; batch_size
+      ; execution_mode
       }
 
 (* ── Join table semantics ─────────────────────────────── *)
@@ -109,7 +116,12 @@ let test_tool_called_carries_tool_use_id () =
     Bridge.native_event_to_json
       (mk_event
          (Agent_core.Event_bus.ToolCalled
-            { invocation = invocation "tu-3"
+            { invocation =
+                invocation
+                  ~batch_index:2
+                  ~batch_size:3
+                  ~execution_mode:Agent_core.Tool_contract.Concurrent
+                  "tu-3"
             ; agent_name = "agent_core-r1"
             ; tool_name = "Read"
             ; input = `Null
@@ -122,6 +134,12 @@ let test_tool_called_carries_tool_use_id () =
     (int_of_field (payload_member "turn" json));
   check (option int) "payload planned_index" (Some 0)
     (int_of_field (payload_member "planned_index" json));
+  check (option int) "payload batch_index" (Some 2)
+    (int_of_field (payload_member "batch_index" json));
+  check (option int) "payload batch_size" (Some 3)
+    (int_of_field (payload_member "batch_size" json));
+  check (option string) "payload execution_mode" (Some "concurrent")
+    (string_of_field (payload_member "execution_mode" json));
   check bool "tool_called has no execution_id (mint happens after publish)"
     true
     (payload_member "execution_id" json = None)

--- a/test/test_keeper_run_tools_hooks.ml
+++ b/test/test_keeper_run_tools_hooks.ml
@@ -595,6 +595,59 @@ let test_completed_calls_short_list_is_whole () =
   check int "every call is kept" 3 (List.length kept)
 ;;
 
+let test_concurrent_tool_observers_commit_as_transactions () =
+  Eio_main.run @@ fun _env ->
+  let serialize =
+    Masc.Keeper_run_tools_hooks.create_tool_observer_serialization ()
+  in
+  let trace = ref [] in
+  let record event = trace := event :: !trace in
+  let first_entered, resolve_first_entered = Eio.Promise.create () in
+  let release_first, resolve_release_first = Eio.Promise.create () in
+  let second_attempting, resolve_second_attempting = Eio.Promise.create () in
+  Eio.Switch.run (fun sw ->
+    Eio.Fiber.fork ~sw (fun () ->
+      serialize (fun () ->
+        record "receipt:first";
+        Eio.Promise.resolve resolve_first_entered ();
+        Eio.Promise.await release_first;
+        record "activity:first"));
+    Eio.Promise.await first_entered;
+    Eio.Fiber.fork ~sw (fun () ->
+      Eio.Promise.resolve resolve_second_attempting ();
+      serialize (fun () ->
+        record "receipt:second";
+        record "activity:second"));
+    Eio.Promise.await second_attempting;
+    (* Give the second fiber a scheduling turn while the first observer is
+       suspended. Without the production serialization boundary this would put
+       the second receipt/activity pair inside the first pair. *)
+    Eio.Fiber.yield ();
+    Eio.Promise.resolve resolve_release_first ());
+  check
+    (list string)
+    "receipt and activity effects share one completion order"
+    [ "receipt:first"
+    ; "activity:first"
+    ; "receipt:second"
+    ; "activity:second"
+    ]
+    (List.rev !trace)
+;;
+
+let test_failed_tool_observer_releases_next_completion () =
+  Eio_main.run @@ fun _env ->
+  let serialize =
+    Masc.Keeper_run_tools_hooks.create_tool_observer_serialization ()
+  in
+  (match serialize (fun () -> raise Exit) with
+   | () -> fail "failed observer unexpectedly returned"
+   | exception Exit -> ());
+  let observed = ref false in
+  serialize (fun () -> observed := true);
+  check bool "a reported observer failure does not poison later receipts" true !observed
+;;
+
 let () =
   run
     "keeper_run_tools_hooks"
@@ -678,6 +731,16 @@ let () =
             "bare relative outside repos lane is Base_unresolved"
             `Quick
             test_partition_bare_relative_outside_repos_is_base_unresolved
+        ] )
+    ; ( "concurrent_tool_observer"
+      , [ test_case
+            "commits receipt and activity as one transaction"
+            `Quick
+            test_concurrent_tool_observers_commit_as_transactions
+        ; test_case
+            "releases the next completion after a reported failure"
+            `Quick
+            test_failed_tool_observer_releases_next_completion
         ] )
     ]
 ;;

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -268,6 +268,9 @@ let test_exact_agent_core_occurrence_persisted () =
       ~tool_use_id:""
       ~turn:9
       ~planned_index:4
+      ~batch_index:2
+      ~batch_size:3
+      ~execution_mode:Agent_core.Tool_contract.Concurrent
       ();
     match Keeper_tool_call_log.read_recent ~n:1 () with
     | [ entry ] ->
@@ -282,7 +285,19 @@ let test_exact_agent_core_occurrence_persisted () =
       Alcotest.(check int)
         "planned index persisted"
         4
-        (Safe_ops.json_int ~default:(-1) "planned_index" entry)
+        (Safe_ops.json_int ~default:(-1) "planned_index" entry);
+      Alcotest.(check int)
+        "batch index persisted"
+        2
+        (Safe_ops.json_int ~default:(-1) "batch_index" entry);
+      Alcotest.(check int)
+        "batch size persisted"
+        3
+        (Safe_ops.json_int ~default:(-1) "batch_size" entry);
+      Alcotest.(check (option string))
+        "execution mode persisted"
+        (Some "concurrent")
+        (Safe_ops.json_string_opt "execution_mode" entry)
     | _ -> Alcotest.fail "expected exactly one entry")
 
 (* ── Redaction: tool names do not suppress evidence ────────────── *)

--- a/test/test_keeper_tool_call_sse_io_preview.ml
+++ b/test/test_keeper_tool_call_sse_io_preview.ml
@@ -112,9 +112,9 @@ let test_agent_core_invocation_fields_preserve_exact_occurrence () =
       ~completion:Agent_core.Tool_contract.Continue_after_success
       ~schedule:
         { planned_index = 3
-        ; batch_index = 0
-        ; batch_size = 1
-        ; execution_mode = Agent_core.Tool_contract.Serial
+        ; batch_index = 2
+        ; batch_size = 4
+        ; execution_mode = Agent_core.Tool_contract.Concurrent
         }
   in
   let json =
@@ -130,7 +130,19 @@ let test_agent_core_invocation_fields_preserve_exact_occurrence () =
   Alcotest.(check int)
     "planned index preserved"
     3
-    Yojson.Safe.Util.(member "planned_index" json |> to_int)
+    Yojson.Safe.Util.(member "planned_index" json |> to_int);
+  Alcotest.(check int)
+    "batch index preserved"
+    2
+    Yojson.Safe.Util.(member "batch_index" json |> to_int);
+  Alcotest.(check int)
+    "batch size preserved"
+    4
+    Yojson.Safe.Util.(member "batch_size" json |> to_int);
+  Alcotest.(check string)
+    "execution mode preserved"
+    "concurrent"
+    Yojson.Safe.Util.(member "execution_mode" json |> to_string)
 ;;
 
 let () =

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -1213,6 +1213,20 @@ let test_readonly_policy_projection_is_descriptor_owned () =
     false
     (List.mem "tool_write_file" projected)
 
+let test_concurrent_execution_opt_ins_are_exact () =
+  let concurrent_internal_names =
+    all_descriptors ()
+    |> List.filter_map (fun (descriptor : Descriptor.t) ->
+      match descriptor.execution with
+      | Descriptor.Ordinary Descriptor.Concurrent -> Some descriptor.internal_name
+      | Descriptor.Ordinary Descriptor.Serial | Descriptor.Terminal -> None)
+    |> List.sort_uniq String.compare
+  in
+  Alcotest.(check (list string))
+    "only explicitly audited handlers opt into concurrent batches"
+    [ "keeper_time_now"; "masc_board_stats" ]
+    concurrent_internal_names
+
 let test_readonly_policy_is_descriptor_input_aware () =
   let public_input =
     `Assoc [ "pattern", `String "Keeper_tool_descriptor"; "op", `String "rm" ]
@@ -1663,6 +1677,10 @@ let () =
         ] )
     ; ( "policy-projection"
       , [ test_case
+            "concurrent execution opt-ins are exact"
+            `Quick
+            test_concurrent_execution_opt_ins_are_exact
+        ; test_case
             "descriptor owns the read-only metadata projection"
             `Quick
             test_readonly_policy_projection_is_descriptor_owned

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -419,17 +419,6 @@ let test_autonomous_yield_boundary_contract () =
      | Runtime_agent.Yielded_after_repeated_tool_call _
      | Runtime_agent.InputRequired _ -> false)
 
-let test_terminal_effect_handler_contract () =
-  let is_terminal =
-    Masc.Keeper_tools_agent_core_bundle.For_testing.is_terminal_effect_handler
-  in
-  check bool "surface post is a terminal effect" true
-    (is_terminal Masc.Keeper_tool_descriptor.Tool_surface_post);
-  check bool "surface read is not a terminal effect" false
-    (is_terminal Masc.Keeper_tool_descriptor.Tool_surface_read);
-  check bool "filesystem write is not a reply terminal" false
-    (is_terminal Masc.Keeper_tool_descriptor.Tool_write_file)
-
 let test_terminal_externalization_failure_contract () =
   let classify =
     Masc.Keeper_tools_agent_core_bundle.For_testing.terminal_externalization_failure
@@ -804,8 +793,6 @@ let () =
             test_repeated_exact_tool_call_boundary;
           test_case "autonomous yield boundary contract" `Quick
             test_autonomous_yield_boundary_contract;
-          test_case "terminal effect handler contract" `Quick
-            test_terminal_effect_handler_contract;
           test_case "terminal externalization failure contract" `Quick
             test_terminal_externalization_failure_contract;
         ] );

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -308,7 +308,7 @@ let test_explicit_concurrent_tools_enter_one_agent_core_batch () =
             let entered_schedules_mu = Stdlib.Mutex.create () in
             let both_entered, resolve_both_entered = Eio.Promise.create () in
             let release, resolve_release = Eio.Promise.create () in
-            let wrap tool =
+            let wrap (tool : Agent_core.Tool.t) =
               { tool with
                 handler =
                   (fun execution_env _input ->

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -203,7 +203,199 @@ let test_bundle_exactly_matches_model_visible_descriptors () =
             expected_names
             actual_names;
           check int "bundle contains no duplicate model names" (List.length actual_names)
-            (List.length bundle.tools)))
+            (List.length bundle.tools);
+          List.iter
+            (fun (tool : Agent_core.Tool.t) ->
+               let name = tool.schema.name in
+               let descriptor =
+                 match
+                   Keeper_tool_descriptor_resolution.descriptor_for_tool_name name
+                 with
+                 | Some descriptor -> descriptor
+                 | None -> failf "bundle tool %s has no descriptor owner" name
+               in
+               check bool
+                 (name ^ " has an explicit Agent Core descriptor")
+                 true
+                 (Option.is_some (Agent_core.Tool.descriptor tool));
+               (match descriptor.execution with
+                | Keeper_tool_descriptor.Ordinary expected_mode ->
+                  let expected_mode =
+                    match expected_mode with
+                    | Keeper_tool_descriptor.Serial -> Agent_core.Tool_contract.Serial
+                    | Keeper_tool_descriptor.Concurrent ->
+                      Agent_core.Tool_contract.Concurrent
+                  in
+                  check bool
+                    (name ^ " execution mode matches its descriptor")
+                    true
+                    (Agent_core.Tool.execution_mode tool = expected_mode);
+                  check bool
+                    (name ^ " continues after success")
+                    true
+                    (Agent_core.Tool.completion tool
+                     = Agent_core.Tool_contract.Continue_after_success)
+                | Keeper_tool_descriptor.Terminal ->
+                  check bool
+                    (name ^ " terminal tools are serial")
+                    true
+                    (Agent_core.Tool.execution_mode tool
+                     = Agent_core.Tool_contract.Serial);
+                  check bool
+                    (name ^ " terminal completion preserves unknown effect outcome")
+                    true
+                    (Agent_core.Tool.completion tool
+                     = Agent_core.Tool_contract.Terminal_after_success
+                         Agent_core.Tool_contract.Effect_outcome_unknown)))
+            bundle.tools))
+
+let test_explicit_concurrent_tools_enter_one_agent_core_batch () =
+  ignore (init_registry ());
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc_test_concurrent_tool_batch_%d" (Random.int 1_000_000))
+  in
+  (try Unix.mkdir dir 0o755 with
+   | Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  Fun.protect
+    ~finally:(fun () ->
+      try Unix.rmdir dir with
+      | _ -> ())
+    (fun () ->
+       Eio_main.run
+       @@ fun env ->
+       Eio.Switch.run
+       @@ fun sw ->
+       Masc_test_deps.with_publication_recovery_registry
+         ~sw
+         ~fs:(Eio.Stdenv.fs env)
+         ~registry_root:dir
+       @@ fun publication_recovery_registry ->
+       let config = Workspace.default_config dir in
+       let meta = make_meta ~name:"test-concurrent-tool-batch" () in
+       let publication_recovery =
+         publication_recovery_turn_context
+           ~registry:publication_recovery_registry
+           ~keeper_name:meta.name
+       in
+       let ctx_snapshot =
+         Keeper_context_runtime.create ~eio:false ~system_prompt:"test"
+       in
+       let bundle =
+         Keeper_tools_agent_core_bundle.make_tool_bundle
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot
+           ()
+       in
+       Fun.protect
+         ~finally:bundle.cleanup
+         (fun () ->
+            let require_tool name =
+              match
+                List.find_opt
+                  (fun (tool : Agent_core.Tool.t) ->
+                     String.equal tool.schema.name name)
+                  bundle.tools
+              with
+              | Some tool -> tool
+              | None -> failf "missing bundle tool %s" name
+            in
+            let entered_count = Atomic.make 0 in
+            let entered_schedules = ref [] in
+            let entered_schedules_mu = Stdlib.Mutex.create () in
+            let both_entered, resolve_both_entered = Eio.Promise.create () in
+            let release, resolve_release = Eio.Promise.create () in
+            let wrap tool =
+              { tool with
+                handler =
+                  (fun execution_env _input ->
+                     let invocation =
+                       match Agent_core.Tool.Execution_env.invocation execution_env with
+                       | Some invocation -> invocation
+                       | None -> failwith "scheduled tool omitted invocation"
+                     in
+                     let schedule =
+                       Agent_core.Tool_contract.Invocation.schedule invocation
+                     in
+                     Stdlib.Mutex.lock entered_schedules_mu;
+                     Fun.protect
+                       ~finally:(fun () -> Stdlib.Mutex.unlock entered_schedules_mu)
+                       (fun () ->
+                          entered_schedules := schedule :: !entered_schedules);
+                     let prior = Atomic.fetch_and_add entered_count 1 in
+                     if prior = 1 then Eio.Promise.resolve resolve_both_entered ();
+                     Eio.Promise.await release;
+                     Ok { Agent_core.Types.content = "barrier passed"; _meta = None })
+              }
+            in
+            let tools =
+              [ wrap (require_tool "keeper_time_now")
+              ; wrap (require_tool "masc_board_stats")
+              ]
+            in
+            let report = ref None in
+            Eio.Time.with_timeout_exn
+              (Eio.Stdenv.clock env)
+              2.0
+              (fun () ->
+                 Eio.Fiber.both
+                   (fun () ->
+                      report :=
+                        Some
+                          (Agent_core.Agent_tools.execute_tools
+                             ~context:(Agent_core.Context.create ())
+                             ~tools
+                             ~hooks:Agent_core.Hooks.empty
+                             ~event_bus:None
+                             ~tracer:Agent_core.Tracing.null
+                             ~agent_name:"test-concurrent-tool-batch-agent"
+                             ~turn_count:7
+                             ~usage:Agent_core.Types.empty_usage
+                             [ Agent_core.Types.ToolUse
+                                 { id = "time-1"
+                                 ; name = "keeper_time_now"
+                                 ; input = `Assoc []
+                                 }
+                             ; Agent_core.Types.ToolUse
+                                 { id = "stats-1"
+                                 ; name = "masc_board_stats"
+                                 ; input = `Assoc []
+                                 }
+                             ]))
+                   (fun () ->
+                      Eio.Promise.await both_entered;
+                      Eio.Promise.resolve resolve_release ()));
+            (match !report with
+             | Some (Ok { completed_results; _ }) ->
+               check int "both calls completed" 2 (List.length completed_results)
+             | Some (Error _) -> fail "concurrent batch returned an execution failure"
+             | None -> fail "concurrent batch returned no report");
+            let schedules =
+              !entered_schedules
+              |> List.sort (fun left right ->
+                Int.compare left.planned_index right.planned_index)
+            in
+            check int "both handlers crossed the barrier" 2 (List.length schedules);
+            List.iter
+              (fun (schedule : Agent_core.Tool_contract.schedule) ->
+                 check int "one shared batch index" 0 schedule.batch_index;
+                 check int "batch carries both calls" 2 schedule.batch_size;
+                 check bool
+                   "execution mode is concurrent"
+                   true
+                   (schedule.execution_mode = Agent_core.Tool_contract.Concurrent))
+              schedules;
+            check
+              (list int)
+              "results retain planned order"
+              [ 0; 1 ]
+              (List.map
+                 (fun (schedule : Agent_core.Tool_contract.schedule) ->
+                    schedule.planned_index)
+                 schedules)))
 
 let test_missing_current_task_reconciled_before_transition_hint () =
   ignore (init_registry ());
@@ -436,6 +628,8 @@ let () =
             test_fusion_default_descriptor_is_bundle_visible;
           test_case "bundle exactly matches model-visible descriptors" `Quick
             test_bundle_exactly_matches_model_visible_descriptors;
+          test_case "explicit concurrent tools enter one Agent Core batch" `Quick
+            test_explicit_concurrent_tools_enter_one_agent_core_batch;
           test_case "missing current task reconciles before transition hint" `Quick
             test_missing_current_task_reconciled_before_transition_hint;
           test_case "bundle assembly does not emit assignment" `Quick

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -375,7 +375,9 @@ let test_explicit_concurrent_tools_enter_one_agent_core_batch () =
              | None -> fail "concurrent batch returned no report");
             let schedules =
               !entered_schedules
-              |> List.sort (fun left right ->
+              |> List.sort (fun
+                (left : Agent_core.Tool_contract.schedule)
+                (right : Agent_core.Tool_contract.schedule) ->
                 Int.compare left.planned_index right.planned_index)
             in
             check int "both handlers crossed the barrier" 2 (List.length schedules);


### PR DESCRIPTION
## Stack

Parent: #28605 (`f2a3a10ddd6e0b40d965ff13d41a781d37d983ab`)

## Outcome

Keeper descriptors can explicitly opt proven-reentrant ordinary tools into Agent Core's existing concurrent batch planner, and the resulting schedule remains visible from durable logs through the Dashboard Journey.

## Live failure reproduced

One isolated Keeper emitted sibling `keeper_time_now` and `masc_board_stats` ToolUse blocks. Both were projected without execution metadata and therefore ran as two serial batches.

## Change

- add descriptor-owned closed `Ordinary (Serial | Concurrent) | Terminal` execution contract, defaulting to `Serial`
- opt in only `keeper_time_now` and typed `Board_stats`
- project `Concurrent` to Agent Core's ordinary tool descriptor
- persist `planned_index`, `batch_index`, `batch_size`, and `execution_mode` per physical execution
- expose the schedule in the tool-call API, inspector, unified trace, and Journey waterfall
- keep writes, terminal tools, other reads, and input-dependent policies serial

## Evidence at current head

- exact head: `6a725df0f0d87ff834a49b49e7ba1c53132d8651`
- exact parent: `f2a3a10ddd6e0b40d965ff13d41a781d37d983ab`
- 27 changed files, including 11 focused OCaml/TypeScript test files
- source review verified the descriptor census is closed and the two-handler barrier test proves a shared concurrent batch with stable planned output order
- `ocamlformat` and `git diff --check` passed during implementation
- no local Dune, Dashboard, or test execution; full exact-head CI remains required

This PR stays Draft and must not merge until full Build and Test, Dashboard, Health, and CI Gate have run against this exact head. The stacked base does not trigger the repository's main PR CI workflow, so the current small check set is not merge authority.