### PR TITLE
feat(dashboard): add exact schedule lookup

### DIFF
--- a/dashboard/src/api/dashboard-scheduled-automation.test.ts
+++ b/dashboard/src/api/dashboard-scheduled-automation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, afterEach } from 'vitest'
 import {
+  decodeScheduledAutomationLookup,
   fetchDashboardScheduledAutomation,
   normalizeScheduledAutomation,
 } from './dashboard-scheduled-automation'
@@ -115,6 +116,60 @@ describe('normalizeScheduledAutomation', () => {
     })
 
     expect(normalized.state).toBe('unavailable')
+  })
+})
+
+describe('decodeScheduledAutomationLookup', () => {
+  it('accepts the owner envelope and keeps the exact request identity', () => {
+    const decoded = decodeScheduledAutomationLookup({
+      schema: 'masc.dashboard.scheduled_automation.lookup.v1',
+      source: 'schedule_store',
+      generated_at: '2026-08-14T00:00:00Z',
+      status: 'found',
+      schedule_id: 'sched-exact',
+      request: {
+        schedule_id: 'sched-exact',
+        status: 'due',
+        source: 'operator_request',
+        payload_kind: 'keeper.review',
+      },
+    }, 'sched-exact')
+
+    expect(decoded).toEqual({
+      status: 'found',
+      scheduleId: 'sched-exact',
+      request: {
+        schedule_id: 'sched-exact',
+        status: 'due',
+        source: 'operator_request',
+        payload_kind: 'keeper.review',
+      },
+    })
+  })
+
+  it('rejects a request row that does not belong to the requested identity', () => {
+    expect(() => decodeScheduledAutomationLookup({
+      schema: 'masc.dashboard.scheduled_automation.lookup.v1',
+      source: 'schedule_store',
+      generated_at: '2026-08-14T00:00:00Z',
+      status: 'found',
+      schedule_id: 'sched-exact',
+      request: {
+        schedule_id: 'sched-other',
+        status: 'due',
+        source: 'operator_request',
+      },
+    }, 'sched-exact')).toThrow('request identity mismatch')
+  })
+
+  it('rejects an envelope returned for a different route identity', () => {
+    expect(() => decodeScheduledAutomationLookup({
+      schema: 'masc.dashboard.scheduled_automation.lookup.v1',
+      source: 'schedule_store',
+      generated_at: '2026-08-14T00:00:00Z',
+      status: 'not_found',
+      schedule_id: 'sched-other',
+    }, 'sched-exact')).toThrow('envelope identity mismatch')
   })
 })
 

--- a/dashboard/src/api/dashboard-scheduled-automation.ts
+++ b/dashboard/src/api/dashboard-scheduled-automation.ts
@@ -10,7 +10,16 @@ import { ensureDevToken } from './dev-token'
 import type {
   DashboardScheduledAutomation,
   DashboardScheduledAutomationFsm,
+  DashboardScheduledAutomationRequest,
 } from './dashboard-tools-prompts'
+
+const SCHEDULE_LOOKUP_SCHEMA = 'masc.dashboard.scheduled_automation.lookup.v1'
+
+export type DashboardScheduledAutomationLookup =
+  | { status: 'found'; scheduleId: string; request: DashboardScheduledAutomationRequest }
+  | { status: 'not_found'; scheduleId: string }
+  | { status: 'unavailable'; scheduleId: string; reason: string }
+  | { status: 'invalid_id'; scheduleId: string; reason: string }
 
 export interface DashboardScheduledAutomationPage {
   /** Rows materialized in this response. */
@@ -66,6 +75,91 @@ function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : null
+}
+
+function exactFields(
+  record: Record<string, unknown>,
+  required: readonly string[],
+  context: string,
+): void {
+  const expected = new Set(required)
+  const missing = required.filter(field => !(field in record))
+  const unknown = Object.keys(record).filter(field => !expected.has(field))
+  if (missing.length > 0 || unknown.length > 0) {
+    throw new Error(
+      `${context} fields mismatch (missing=[${missing.join(',')}], unknown=[${unknown.join(',')}])`,
+    )
+  }
+}
+
+function parseLookupRequest(
+  value: unknown,
+  expectedScheduleId: string,
+): DashboardScheduledAutomationRequest {
+  const request = asRecord(value)
+  if (!request || request.schedule_id !== expectedScheduleId) {
+    throw new Error('Invalid scheduled-automation lookup response: request identity mismatch')
+  }
+  switch (request.status) {
+    case 'scheduled':
+    case 'due':
+    case 'running':
+    case 'succeeded':
+    case 'failed':
+    case 'cancelled':
+    case 'expired':
+      break
+    default:
+      throw new Error('Invalid scheduled-automation lookup response: invalid request status')
+  }
+  if (typeof request.source !== 'string' || request.source.trim() === '') {
+    throw new Error('Invalid scheduled-automation lookup response: invalid request source')
+  }
+  return request as unknown as DashboardScheduledAutomationRequest
+}
+
+export function decodeScheduledAutomationLookup(
+  raw: unknown,
+  expectedScheduleId: string,
+): DashboardScheduledAutomationLookup {
+  const record = asRecord(raw)
+  if (!record) throw new Error('Invalid scheduled-automation lookup response: envelope must be an object')
+  if (record.schema !== SCHEDULE_LOOKUP_SCHEMA || record.source !== 'schedule_store') {
+    throw new Error('Invalid scheduled-automation lookup response: unsupported schema or source')
+  }
+  if (
+    typeof record.generated_at !== 'string'
+    || record.generated_at.trim() === ''
+    || typeof record.schedule_id !== 'string'
+  ) {
+    throw new Error('Invalid scheduled-automation lookup response: invalid generated_at or schedule_id')
+  }
+  const scheduleId = record.schedule_id
+  if (scheduleId !== expectedScheduleId) {
+    throw new Error('Invalid scheduled-automation lookup response: envelope identity mismatch')
+  }
+  switch (record.status) {
+    case 'found':
+      exactFields(record, ['schema', 'source', 'generated_at', 'status', 'schedule_id', 'request'], 'envelope')
+      return { status: 'found', scheduleId, request: parseLookupRequest(record.request, scheduleId) }
+    case 'not_found':
+      exactFields(record, ['schema', 'source', 'generated_at', 'status', 'schedule_id'], 'envelope')
+      return { status: 'not_found', scheduleId }
+    case 'unavailable':
+      exactFields(record, ['schema', 'source', 'generated_at', 'status', 'schedule_id', 'reason'], 'envelope')
+      if (typeof record.reason !== 'string' || record.reason.trim() === '') {
+        throw new Error('Invalid scheduled-automation lookup response: invalid reason')
+      }
+      return { status: 'unavailable', scheduleId, reason: record.reason }
+    case 'invalid_id':
+      exactFields(record, ['schema', 'source', 'generated_at', 'status', 'schedule_id', 'reason'], 'envelope')
+      if (typeof record.reason !== 'string' || record.reason.trim() === '') {
+        throw new Error('Invalid scheduled-automation lookup response: invalid reason')
+      }
+      return { status: 'invalid_id', scheduleId, reason: record.reason }
+    default:
+      throw new Error(`Invalid scheduled-automation lookup response: unknown status ${JSON.stringify(record.status)}`)
+  }
 }
 
 /** A count the server reported, or null when it reported none.
@@ -210,4 +304,16 @@ export async function fetchDashboardScheduledAutomation(
     signal: opts?.signal,
   })
   return normalizeScheduledAutomation(raw)
+}
+
+export async function fetchDashboardScheduledAutomationLookup(
+  scheduleId: string,
+  opts?: AbortableRequestOptions,
+): Promise<DashboardScheduledAutomationLookup> {
+  await ensureDevToken()
+  const query = new URLSearchParams({ schedule_id: scheduleId })
+  const raw = await get<unknown>(`/api/v1/dashboard/scheduled-automation?${query}`, {
+    signal: opts?.signal,
+  })
+  return decodeScheduledAutomationLookup(raw, scheduleId)
 }

--- a/dashboard/src/components/schedule/schedule-surface.test.ts
+++ b/dashboard/src/components/schedule/schedule-surface.test.ts
@@ -6,6 +6,7 @@ import type {
   DashboardKeeperWaitingInventory,
   DashboardScheduledAutomationAvailableData,
   DashboardScheduledAutomationProjection,
+  DashboardScheduledAutomationRequest,
 } from '../../api'
 
 type MockToolsResponse = {
@@ -26,6 +27,15 @@ const mocks = vi.hoisted(() => ({
   scheduledAutomationError: { value: null as string | null },
   subscribeScheduledAutomationRefresh: vi.fn(() => () => {}),
   pruneSchedules: vi.fn(),
+  fetchScheduledAutomationLookup: vi.fn(),
+  replaceRoute: vi.fn(),
+  route: {
+    value: {
+      tab: 'schedule',
+      params: {} as Record<string, string>,
+      postId: null,
+    },
+  },
 }))
 
 vi.mock('../tools/tool-state', () => ({
@@ -44,6 +54,21 @@ vi.mock('./schedule-state', () => ({
 
 vi.mock('../../api/dashboard-schedule', () => ({
   pruneSchedules: mocks.pruneSchedules,
+}))
+
+vi.mock('../../api/dashboard-scheduled-automation', async () => {
+  const actual = await vi.importActual<typeof import('../../api/dashboard-scheduled-automation')>(
+    '../../api/dashboard-scheduled-automation',
+  )
+  return {
+    ...actual,
+    fetchDashboardScheduledAutomationLookup: mocks.fetchScheduledAutomationLookup,
+  }
+})
+
+vi.mock('../../router', () => ({
+  route: mocks.route,
+  replaceRoute: mocks.replaceRoute,
 }))
 
 import { ScheduleSurface } from './schedule-surface'
@@ -198,6 +223,9 @@ describe('ScheduleSurface', () => {
     mocks.scheduledAutomationProjection.value = null
     mocks.scheduledAutomationLoading.value = false
     mocks.scheduledAutomationError.value = null
+    mocks.fetchScheduledAutomationLookup.mockReset()
+    mocks.replaceRoute.mockReset()
+    mocks.route.value = { tab: 'schedule', params: {}, postId: null }
   })
 
   afterEach(() => {
@@ -516,5 +544,53 @@ describe('ScheduleSurface', () => {
     // Only the interval schedule survives the 폴링 cadence filter in the list.
     expect(container.querySelector('[data-schedule-id="sched-interval"]')).not.toBeNull()
     expect(container.querySelector('[data-schedule-id="sched-oneshot"]')).toBeNull()
+  })
+
+  it('opens an exact route that is outside the truncated aggregate page', async () => {
+    const exactRequest: DashboardScheduledAutomationRequest = {
+      ...sampleAutomation().requests[0]!,
+      schedule_id: 'sched-outside-page',
+      payload_summary: 'Exact route payload',
+    }
+    setAutomation(sampleAutomation())
+    mocks.route.value = {
+      tab: 'schedule',
+      params: { schedule_id: exactRequest.schedule_id, view: 'calendar' },
+      postId: null,
+    }
+    mocks.fetchScheduledAutomationLookup.mockResolvedValue({
+      status: 'found',
+      scheduleId: exactRequest.schedule_id,
+      request: exactRequest,
+    })
+
+    render(html`<${ScheduleSurface} />`, container)
+    await flush()
+
+    expect(mocks.fetchScheduledAutomationLookup).toHaveBeenCalledWith(
+      exactRequest.schedule_id,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+    expect(container.querySelector(
+      '[data-schedule-detail-panel="sched-outside-page"]',
+    )?.textContent).toContain('Exact route payload')
+
+    container.querySelector<HTMLButtonElement>('.turn-close')?.click()
+    expect(mocks.replaceRoute).toHaveBeenCalledWith('schedule', { view: 'calendar' })
+  })
+
+  it('uses an in-page route row without issuing a redundant exact lookup', async () => {
+    setAutomation(sampleAutomation())
+    mocks.route.value = {
+      tab: 'schedule',
+      params: { schedule_id: 'sched-1' },
+      postId: null,
+    }
+
+    render(html`<${ScheduleSurface} />`, container)
+    await flush()
+
+    expect(mocks.fetchScheduledAutomationLookup).not.toHaveBeenCalled()
+    expect(container.querySelector('[data-schedule-detail-panel="sched-1"]')).not.toBeNull()
   })
 })

--- a/dashboard/src/components/schedule/schedule-surface.ts
+++ b/dashboard/src/components/schedule/schedule-surface.ts
@@ -14,6 +14,11 @@
 import { html } from 'htm/preact'
 import { useEffect, useState } from 'preact/hooks'
 import type { DashboardScheduledAutomation } from '../../api'
+import {
+  fetchDashboardScheduledAutomationLookup,
+  type DashboardScheduledAutomationLookup,
+} from '../../api/dashboard-scheduled-automation'
+import { replaceRoute, route } from '../../router'
 import { ErrorState, LoadingState } from '../common/feedback-state'
 import { ActionButton } from '../common/button'
 import { StatusChip } from '../common/status-chip'
@@ -43,6 +48,12 @@ import {
 import { pruneSchedules } from '../../api/dashboard-schedule'
 
 type ScheduleView = 'calendar' | 'list'
+
+type ExactScheduleState =
+  | { kind: 'idle' }
+  | { kind: 'loading'; scheduleId: string }
+  | { kind: 'resolved'; lookup: DashboardScheduledAutomationLookup }
+  | { kind: 'failed'; scheduleId: string; reason: string }
 
 function countLabel(count: number | null): string {
   return count === null ? '—' : count.toLocaleString()
@@ -97,6 +108,10 @@ export function ScheduleSurface() {
     ? null
     : dueCount + runningCount
   const requests = automation?.requests ?? []
+  const routeScheduleId = route.value.params.schedule_id ?? null
+  const inPageRequest = routeScheduleId === null
+    ? null
+    : requests.find(request => request.schedule_id === routeScheduleId) ?? null
   const totalCount = page?.totalCount ?? null
   const cadCounts = cadenceCounts(requests)
   // Scheduled keeper wakes that were dispatched but are in neither queue AND
@@ -106,9 +121,8 @@ export function ScheduleSurface() {
   const [view, setView] = useState<ScheduleView>('calendar')
   const [cadenceFilter, setCadenceFilter] = useState<Cadence | null>(null)
   const [pruning, setPruning] = useState(false)
-  // Detail-overlay selection is lifted here so the calendar view, the list
-  // panel, and the operations aside all drive the same overlay.
-  const [selectedScheduleId, setSelectedScheduleId] = useState<string | null>(null)
+  const selectedScheduleId = routeScheduleId
+  const [exactSchedule, setExactSchedule] = useState<ExactScheduleState>({ kind: 'idle' })
   // Keeper-lane wake evidence + background are large operator diagnostics
   // (a card per keeper, dozens of lane rows). Collapsed AND unmounted by default
   // so the schedule stays the light, primary content; the panels only mount when
@@ -122,10 +136,43 @@ export function ScheduleSurface() {
     return stopScheduleRefresh
   }, [])
 
+  useEffect(() => {
+    if (
+      selectedScheduleId === null
+      || projection?.state !== 'available'
+      || inPageRequest !== null
+    ) {
+      setExactSchedule({ kind: 'idle' })
+      return
+    }
+    const controller = new AbortController()
+    setExactSchedule({ kind: 'loading', scheduleId: selectedScheduleId })
+    void fetchDashboardScheduledAutomationLookup(selectedScheduleId, {
+      signal: controller.signal,
+    })
+      .then(lookup => { setExactSchedule({ kind: 'resolved', lookup }) })
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) return
+        setExactSchedule({
+          kind: 'failed',
+          scheduleId: selectedScheduleId,
+          reason: error instanceof Error ? error.message : String(error),
+        })
+      })
+    return () => { controller.abort() }
+  }, [selectedScheduleId, projection?.state, inPageRequest !== null])
+
+  function selectSchedule(scheduleId: string | null) {
+    const params = { ...route.value.params }
+    if (scheduleId === null) delete params.schedule_id
+    else params.schedule_id = scheduleId
+    replaceRoute('schedule', params)
+  }
+
   function switchView(next: ScheduleView) {
     // Clear selection so a drawer opened in one view does not linger into the
     // other (the list panel renders its own overlay from the same id).
-    setSelectedScheduleId(null)
+    selectSchedule(null)
     setView(next)
   }
 
@@ -152,10 +199,33 @@ export function ScheduleSurface() {
   }
   // In the calendar view the list panel is unmounted, so the surface owns the
   // overlay; the list panel renders its own overlay from the same selection.
-  const selectedRequest =
-    view === 'calendar' && selectedScheduleId
-      ? requests.find(request => request.schedule_id === selectedScheduleId) ?? null
+  const exactRequest =
+    exactSchedule.kind === 'resolved'
+    && exactSchedule.lookup.status === 'found'
+    && exactSchedule.lookup.scheduleId === selectedScheduleId
+      ? exactSchedule.lookup.request
       : null
+  const selectedRequest =
+    view === 'calendar' && selectedScheduleId !== null
+      ? inPageRequest ?? exactRequest
+      : null
+  const exactLookupMessage = (() => {
+    if (selectedScheduleId === null) return null
+    if (exactSchedule.kind === 'loading' && exactSchedule.scheduleId === selectedScheduleId) {
+      return '정확한 예약을 조회하는 중입니다.'
+    }
+    if (exactSchedule.kind === 'failed' && exactSchedule.scheduleId === selectedScheduleId) {
+      return exactSchedule.reason
+    }
+    if (
+      exactSchedule.kind !== 'resolved'
+      || exactSchedule.lookup.scheduleId !== selectedScheduleId
+      || exactSchedule.lookup.status === 'found'
+    ) return null
+    return exactSchedule.lookup.status === 'not_found'
+      ? 'schedule store에서 정확한 예약을 찾지 못했습니다.'
+      : exactSchedule.lookup.reason
+  })()
 
   return html`
     <main class="ov ov-2col sch-surf" data-screen-label="예약" data-testid="schedule-surface">
@@ -216,6 +286,14 @@ export function ScheduleSurface() {
             `
           : null}
 
+        ${exactLookupMessage
+          ? html`
+              <div class="ov-card mb-3 text-xs text-[var(--color-fg-muted)]" data-testid="schedule-exact-lookup-status">
+                <span class="mono">${selectedScheduleId}</span> · ${exactLookupMessage}
+              </div>
+            `
+          : null}
+
         ${blockingError
           ? html`
               <div class="ov-card mb-4 text-sm text-[var(--color-fg-muted)]" data-testid="schedule-ledger-unknown">
@@ -253,13 +331,14 @@ export function ScheduleSurface() {
                 requests=${requests}
                 nowMs=${Date.now()}
                 cadenceFilter=${cadenceFilter}
-                onOpen=${setSelectedScheduleId}
+                onOpen=${selectSchedule}
               />`
             : html`<${ScheduledAutomationPanel}
                 automation=${automation ? filterAutomationByCadence(automation, cadenceFilter) : automation}
                 variant="v2"
                 selectedScheduleId=${selectedScheduleId}
-                onSelectSchedule=${setSelectedScheduleId}
+                selectedRequest=${inPageRequest ?? exactRequest}
+                onSelectSchedule=${selectSchedule}
               />`}
 
         ${'' /* Secondary diagnostics live BELOW the schedule and are unmounted
@@ -307,13 +386,13 @@ export function ScheduleSurface() {
         ? html`<${ScheduleAside}
             requests=${automation.requests ?? []}
             sum=${{ scheduled: scheduledCount, dueRunning, total: totalCount }}
-            onOpen=${setSelectedScheduleId}
+            onOpen=${selectSchedule}
           />`
         : null}
       ${selectedRequest
         ? html`<${SchDetail}
             request=${selectedRequest}
-            onClose=${() => setSelectedScheduleId(null)}
+            onClose=${() => selectSchedule(null)}
           />`
         : null}
     </main>

--- a/dashboard/src/components/tools/scheduled-automation-panel.test.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.test.ts
@@ -437,6 +437,28 @@ describe('ScheduledAutomationPanel', () => {
     expect(container.textContent).toContain('페이로드')
   })
 
+  it('renders a controlled exact request that is absent from aggregate rows', () => {
+    const selectedRequest = request({
+      schedule_id: 'sched-outside-page',
+      payload_summary: 'Exact route payload',
+    })
+
+    render(
+      html`<${ScheduledAutomationPanel}
+        automation=${automation([])}
+        variant="v2"
+        selectedScheduleId=${selectedRequest.schedule_id}
+        selectedRequest=${selectedRequest}
+        onSelectSchedule=${vi.fn()}
+      />`,
+      container,
+    )
+
+    expect(container.querySelector(
+      '[data-schedule-detail-panel="sched-outside-page"]',
+    )?.textContent).toContain('Exact route payload')
+  })
+
   it('renders keeper wake dispatch receipts as queue proof in diagnostics and v2', async () => {
     const auto = automation([
       request({

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -1820,12 +1820,14 @@ function SchWakeReceipt({
 function SchedulePrototypeSurface({
   automation,
   selectedScheduleId: controlledSelectedId,
+  selectedRequest: controlledSelectedRequest,
   onSelectSchedule,
 }: {
   automation: DashboardScheduledAutomation
   // Optional controlled selection so a sibling (the operations aside) can drive
   // the same detail overlay. Uncontrolled (internal state) when omitted.
   selectedScheduleId?: string | null
+  selectedRequest?: DashboardScheduledAutomationRequest | null
   onSelectSchedule?: (scheduleId: string | null) => void
 }) {
   const [tab, setTab] = useState<SchTabKey>('scheduled')
@@ -1844,7 +1846,9 @@ function SchedulePrototypeSurface({
   const durableSignalContract = durableWakeSignalContract(automation)
   const durableSignals = durableSignalContract.visibleSignals
   const selected = selectedScheduleId
-    ? rows.find(request => request.schedule_id === selectedScheduleId) ?? null
+    ? controlledSelectedRequest?.schedule_id === selectedScheduleId
+      ? controlledSelectedRequest
+      : rows.find(request => request.schedule_id === selectedScheduleId) ?? null
     : null
   const payloadSummary = payloadSupportSummary(automation)
 
@@ -2080,12 +2084,14 @@ export function ScheduledAutomationPanel({
   automation,
   variant = 'diagnostics',
   selectedScheduleId: controlledSelectedId,
+  selectedRequest: controlledSelectedRequest,
   onSelectSchedule,
 }: {
   automation?: DashboardScheduledAutomation | null
   variant?: 'diagnostics' | 'v2'
   // Forwarded to the v2 surface so the schedule aside can control the overlay.
   selectedScheduleId?: string | null
+  selectedRequest?: DashboardScheduledAutomationRequest | null
   onSelectSchedule?: (scheduleId: string | null) => void
 }) {
   const [activeFilter, setActiveFilter] = useState<ScheduleFilterKey>('all')
@@ -2103,6 +2109,7 @@ export function ScheduledAutomationPanel({
     return html`<${SchedulePrototypeSurface}
       automation=${automation}
       selectedScheduleId=${controlledSelectedId}
+      selectedRequest=${controlledSelectedRequest}
       onSelectSchedule=${onSelectSchedule}
     />`
   }

--- a/dashboard/src/router.test.ts
+++ b/dashboard/src/router.test.ts
@@ -489,4 +489,13 @@ describe('deep links written by hand', () => {
     expect(route.value.tab).toBe('monitoring')
     expect(route.value.params.section).toBe('internal-agents')
   })
+
+  it('decodes query values exactly once', () => {
+    bootWith(
+      '/dashboard',
+      '?tab=monitoring&section=agents&keeper=a%2Bb%2520c',
+    )
+    expect(route.value.tab).toBe('monitoring')
+    expect(route.value.params.keeper).toBe('a+b%20c')
+  })
 })

--- a/dashboard/src/router.ts
+++ b/dashboard/src/router.ts
@@ -117,7 +117,7 @@ function canonicalRoute(tab: TabId, params: Record<string, string>): RouteState 
 
 function normalizeSegments(pathPart: string): string[] {
   const normalized = pathPart.replace(/^\/+/, '')
-  const segments = normalized.split('/').filter(Boolean)
+  const segments = normalized.split('/').filter(Boolean).map(decodeSafe)
   if (segments[0] === 'dashboard') return segments.slice(1)
   return segments
 }
@@ -133,7 +133,7 @@ function parseSegments(
 
   if (segments[0] === 'command' && segments[1]) {
     const nextParams = { ...params }
-    const second = decodeSafe(segments[1])
+    const second = segments[1]
     if (
       `command:${second}` in CROSS_SURFACE_SECTION_REDIRECTS
       || `command:${second}` in SECTION_REDIRECTS
@@ -153,7 +153,7 @@ function parseSegments(
     && segments[1]
   ) {
     const tab = segments[0] as 'monitoring' | 'workspace' | 'lab' | 'code'
-    const nextParams = { ...params, section: decodeSafe(segments[1]) }
+    const nextParams = { ...params, section: segments[1] }
     return canonicalRoute(tab, nextParams)
   }
 
@@ -171,18 +171,17 @@ function parseHash(hash: string): RouteState {
   const raw = (hash || '').replace(/^#/, '').trim()
   if (!raw) return DEFAULT_ROUTE
 
-  const decoded = decodeSafe(raw)
-  let pathPart = decoded
+  let pathPart = raw
   let queryPart: string | undefined
 
-  if (decoded.startsWith('?')) {
+  if (raw.startsWith('?')) {
     pathPart = ''
-    queryPart = decoded.slice(1)
+    queryPart = raw.slice(1)
   } else {
-    const qIndex = decoded.indexOf('?')
+    const qIndex = raw.indexOf('?')
     if (qIndex >= 0) {
-      pathPart = decoded.slice(0, qIndex)
-      queryPart = decoded.slice(qIndex + 1)
+      pathPart = raw.slice(0, qIndex)
+      queryPart = raw.slice(qIndex + 1)
     }
   }
 
@@ -204,7 +203,11 @@ function hashLooksLikeQuery(rawHashBody: string): boolean {
 }
 
 function parsePathname(pathname: string, search: string): RouteState | null {
-  const segments = pathname.replace(/^\/+/, '').split('/').filter(Boolean)
+  const segments = pathname
+    .replace(/^\/+/, '')
+    .split('/')
+    .filter(Boolean)
+    .map(decodeSafe)
   // The server serves the dashboard at both / and /dashboard, so a link
   // written as /?tab=monitoring is the same request as /dashboard?tab=…. It
   // used to fall through to the default route, which is a silent answer to a

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -283,8 +283,8 @@ let dashboard_proof_compute ~config ~limit () : Yojson.Safe.t =
 
    [live_cache_ttl_s] is the 30 s tier documented for "frequently-changing data
    such as active keeper state" — schedule state belongs there rather than in
-   the 120 s projection tier. The response takes no query parameters, so
-   base_path is the whole key. *)
+   the 120 s projection tier. The aggregate response takes no selectors, so
+   base_path is the whole key. Exact lookups bypass this aggregate cache below. *)
 let dashboard_scheduled_automation_http_json ~(config : Workspace.config) :
   Yojson.Safe.t
   =
@@ -301,6 +301,20 @@ let dashboard_scheduled_automation_http_json ~(config : Workspace.config) :
       Domain_pool_ref.submit_io_or_inline (fun () ->
         Server_dashboard_schedule_projection.scheduled_automation_dashboard_json
           config))
+;;
+
+let dashboard_scheduled_automation_query_http_json
+  ~(config : Workspace.config)
+  (request : Httpun.Request.t)
+  : Yojson.Safe.t
+  =
+  match Server_utils.query_param request "schedule_id" with
+  | None -> dashboard_scheduled_automation_http_json ~config
+  | Some schedule_id ->
+    Domain_pool_ref.submit_io_or_inline (fun () ->
+      Server_dashboard_schedule_projection.scheduled_automation_exact_lookup_json
+        config
+        ~schedule_id)
 ;;
 
 let dashboard_proof_http_json ~config request : Yojson.Safe.t =

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -314,6 +314,9 @@ let dashboard_scheduled_automation_query_http_json
     Domain_pool_ref.submit_io_or_inline (fun () ->
       Server_dashboard_schedule_projection.scheduled_automation_exact_lookup_json
         config
+        (* NDT-OK: the request boundary is where wall-clock enters, so the
+           projection stays a pure function of (state, now). *)
+        ~now:(Unix.gettimeofday ())
         ~schedule_id)
 ;;
 

--- a/lib/server/server_dashboard_http.mli
+++ b/lib/server/server_dashboard_http.mli
@@ -79,6 +79,12 @@ val dashboard_scheduled_automation_http_json :
     rather than the projection directly, so the two transports cannot serve
     different data or drift on cache policy. *)
 
+val dashboard_scheduled_automation_query_http_json :
+  config:Workspace.config -> Httpun.Request.t -> Yojson.Safe.t
+(** Query-aware owner for the scheduled-automation route. With no [schedule_id]
+    it delegates to {!dashboard_scheduled_automation_http_json}; an exact lookup
+    reads the schedule store without populating a client-controlled cache key. *)
+
 val dashboard_proof_http_json :
   config:Workspace.config -> Httpun.Request.t -> Yojson.Safe.t
 

--- a/lib/server/server_dashboard_schedule_projection.ml
+++ b/lib/server/server_dashboard_schedule_projection.ml
@@ -978,7 +978,7 @@ let exact_lookup_json ~schedule_id status fields =
      @ fields)
 ;;
 
-let scheduled_automation_exact_lookup_json config ~schedule_id:raw_schedule_id =
+let scheduled_automation_exact_lookup_json config ~now ~schedule_id:raw_schedule_id =
   if String.trim raw_schedule_id = ""
   then
     exact_lookup_json
@@ -1008,7 +1008,7 @@ let scheduled_automation_exact_lookup_json config ~schedule_id:raw_schedule_id =
           let requests =
             schedule_request_rows_dashboard_json
               ~config
-              ~now:(Unix.gettimeofday ())
+              ~now
               state
               [ request ]
           in

--- a/lib/server/server_dashboard_schedule_projection.ml
+++ b/lib/server/server_dashboard_schedule_projection.ml
@@ -834,6 +834,33 @@ let schedule_live_supported_non_terminal_evidence_json schedules =
     ]
 ;;
 
+let schedule_request_rows_dashboard_json ~config ~now state request_rows =
+  let request_rows_with_wakes =
+    List.map
+      (fun (request : Schedule_domain.schedule_request) ->
+         let last_wake =
+           Schedule_store.last_wake_for_schedule_instance state
+             ~schedule_instance_id:request.Schedule_domain.schedule_instance_id
+             ~schedule_id:request.Schedule_domain.schedule_id
+         in
+         request, last_wake)
+      request_rows
+  in
+  let evidence_snapshot =
+    schedule_evidence_snapshot
+      ~config
+      (List.map snd request_rows_with_wakes)
+  in
+  List.map
+    (fun (request, last_wake) ->
+       schedule_request_dashboard_json
+         ~now
+         ~evidence_snapshot
+         ?last_wake
+         request)
+    request_rows_with_wakes
+;;
+
 let scheduled_automation_dashboard_json (config : Workspace.config) : Yojson.Safe.t =
   (* Read-only projection; the schedule store remains the status SSOT. *)
   let now = Unix.gettimeofday () in
@@ -901,21 +928,8 @@ let scheduled_automation_dashboard_json (config : Workspace.config) : Yojson.Saf
         | _ -> String.compare left.schedule_id right.schedule_id)
     in
     let request_rows = take schedule_projection_request_limit sorted in
-    let request_rows_with_wakes =
-      List.map
-        (fun (request : Schedule_domain.schedule_request) ->
-           let last_wake =
-             Schedule_store.last_wake_for_schedule_instance state
-               ~schedule_instance_id:request.Schedule_domain.schedule_instance_id
-               ~schedule_id:request.Schedule_domain.schedule_id
-           in
-           request, last_wake)
-        request_rows
-    in
-    let evidence_snapshot =
-      schedule_evidence_snapshot
-        ~config
-        (List.map snd request_rows_with_wakes)
+    let request_jsons =
+      schedule_request_rows_dashboard_json ~config ~now state request_rows
     in
     `Assoc
       (base_fields
@@ -936,15 +950,74 @@ let scheduled_automation_dashboard_json (config : Workspace.config) : Yojson.Saf
                ; "terminal_count", `Int terminal_count
                ; "next_due_at", unix_iso_option_json (schedule_next_due_at schedules)
                ] )
-         ; ( "requests"
-           , `List
-               (List.map
-                  (fun (request, last_wake) ->
-                     schedule_request_dashboard_json
-                       ~now
-                       ~evidence_snapshot
-                       ?last_wake
-                       request)
-                  request_rows_with_wakes) )
+         ; "requests", `List request_jsons
          ])
+;;
+
+type exact_lookup_status =
+  | Found
+  | Not_found
+  | Unavailable
+  | Invalid_id
+
+let exact_lookup_status_to_string = function
+  | Found -> "found"
+  | Not_found -> "not_found"
+  | Unavailable -> "unavailable"
+  | Invalid_id -> "invalid_id"
+;;
+
+let exact_lookup_json ~schedule_id status fields =
+  `Assoc
+    ([ "schema", `String "masc.dashboard.scheduled_automation.lookup.v1"
+     ; "source", `String "schedule_store"
+     ; "generated_at", `String (Masc_domain.now_iso ())
+     ; "status", `String (exact_lookup_status_to_string status)
+     ; "schedule_id", `String schedule_id
+     ]
+     @ fields)
+;;
+
+let scheduled_automation_exact_lookup_json config ~schedule_id:raw_schedule_id =
+  if String.trim raw_schedule_id = ""
+  then
+    exact_lookup_json
+      ~schedule_id:raw_schedule_id
+      Invalid_id
+      [ "reason", `String "schedule_id must be non-empty" ]
+  else
+    let schedule_id = raw_schedule_id in
+    (match Schedule_store.read_state_result config with
+     | Error err ->
+       let reason =
+         "schedule store read failed: " ^ Schedule_store.read_error_to_string err
+       in
+       exact_lookup_json
+         ~schedule_id
+         Unavailable
+         [ "reason", `String reason ]
+     | Ok state ->
+       (match
+          List.find_opt
+            (fun (request : Schedule_domain.schedule_request) ->
+               String.equal request.schedule_id schedule_id)
+            state.schedules
+        with
+        | None -> exact_lookup_json ~schedule_id Not_found []
+        | Some request ->
+          let requests =
+            schedule_request_rows_dashboard_json
+              ~config
+              ~now:(Unix.gettimeofday ())
+              state
+              [ request ]
+          in
+          (match requests with
+           | [ request_json ] ->
+             exact_lookup_json ~schedule_id Found [ "request", request_json ]
+           | [] | _ :: _ :: _ ->
+             exact_lookup_json
+               ~schedule_id
+               Unavailable
+               [ "reason", `String "exact schedule projection cardinality mismatch" ])))
 ;;

--- a/lib/server/server_dashboard_schedule_projection.ml
+++ b/lib/server/server_dashboard_schedule_projection.ml
@@ -967,11 +967,11 @@ let exact_lookup_status_to_string = function
   | Invalid_id -> "invalid_id"
 ;;
 
-let exact_lookup_json ~schedule_id status fields =
+let exact_lookup_json ~now ~schedule_id status fields =
   `Assoc
     ([ "schema", `String "masc.dashboard.scheduled_automation.lookup.v1"
      ; "source", `String "schedule_store"
-     ; "generated_at", `String (Masc_domain.now_iso ())
+     ; "generated_at", `String (Masc_domain.iso8601_of_unix_seconds now)
      ; "status", `String (exact_lookup_status_to_string status)
      ; "schedule_id", `String schedule_id
      ]
@@ -982,6 +982,7 @@ let scheduled_automation_exact_lookup_json config ~now ~schedule_id:raw_schedule
   if String.trim raw_schedule_id = ""
   then
     exact_lookup_json
+      ~now
       ~schedule_id:raw_schedule_id
       Invalid_id
       [ "reason", `String "schedule_id must be non-empty" ]
@@ -993,6 +994,7 @@ let scheduled_automation_exact_lookup_json config ~now ~schedule_id:raw_schedule
          "schedule store read failed: " ^ Schedule_store.read_error_to_string err
        in
        exact_lookup_json
+         ~now
          ~schedule_id
          Unavailable
          [ "reason", `String reason ]
@@ -1003,7 +1005,7 @@ let scheduled_automation_exact_lookup_json config ~now ~schedule_id:raw_schedule
                String.equal request.schedule_id schedule_id)
             state.schedules
         with
-        | None -> exact_lookup_json ~schedule_id Not_found []
+        | None -> exact_lookup_json ~now ~schedule_id Not_found []
         | Some request ->
           let requests =
             schedule_request_rows_dashboard_json
@@ -1014,9 +1016,10 @@ let scheduled_automation_exact_lookup_json config ~now ~schedule_id:raw_schedule
           in
           (match requests with
            | [ request_json ] ->
-             exact_lookup_json ~schedule_id Found [ "request", request_json ]
+             exact_lookup_json ~now ~schedule_id Found [ "request", request_json ]
            | [] | _ :: _ :: _ ->
              exact_lookup_json
+               ~now
                ~schedule_id
                Unavailable
                [ "reason", `String "exact schedule projection cardinality mismatch" ])))

--- a/lib/server/server_dashboard_schedule_projection.mli
+++ b/lib/server/server_dashboard_schedule_projection.mli
@@ -22,3 +22,9 @@ val scheduled_automation_dashboard_json : Workspace.config -> Yojson.Safe.t
     [counts] / [request_count] / [fsm.active_count] are [null], and
     [schedule_store_read_error] carries the reason. Consumers must render that
     as unknown rather than as zero schedules. *)
+
+val scheduled_automation_exact_lookup_json :
+  Workspace.config -> schedule_id:string -> Yojson.Safe.t
+(** Renders one exact schedule through the same request-row encoder as the
+    aggregate projection. The closed [status] is [found], [not_found],
+    [unavailable], or [invalid_id]. *)

--- a/lib/server/server_dashboard_schedule_projection.mli
+++ b/lib/server/server_dashboard_schedule_projection.mli
@@ -24,7 +24,7 @@ val scheduled_automation_dashboard_json : Workspace.config -> Yojson.Safe.t
     as unknown rather than as zero schedules. *)
 
 val scheduled_automation_exact_lookup_json :
-  Workspace.config -> schedule_id:string -> Yojson.Safe.t
+  Workspace.config -> now:float -> schedule_id:string -> Yojson.Safe.t
 (** Renders one exact schedule through the same request-row encoder as the
     aggregate projection. The closed [status] is [found], [not_found],
     [unavailable], or [invalid_id]. *)

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -855,8 +855,9 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
       | `GET, "/api/v1/dashboard/scheduled-automation" ->
           with_h2_public_read h2_reqd (fun state ->
             let json =
-              dashboard_scheduled_automation_http_json
+              dashboard_scheduled_automation_query_http_json
                 ~config:(Mcp_server.workspace_config state)
+                httpun_request
             in
             h2_respond_json_value h2_reqd json ~extra_headers:cors)
 

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -1705,16 +1705,15 @@ let add_routes ~sw ~clock router =
            in
          Http.Response.json_value ~compress:true ~request:req ~extra_headers:(Server_timing.extra_header timing) json reqd
        ) request reqd)
-  (* Schedule projection, served by its owner. Previously reachable only as a
-     nested field of /api/v1/dashboard/tools, which made a surface that needs
-     schedule state fetch the whole tool inventory. No cache: the owner reads a
-     single ledger file, and a TTL here would be staler than what the tools
-     snapshot used to provide. *)
+  (* Schedule projection, served by its owner. The no-query aggregate keeps its
+     shared live cache; an exact schedule_id lookup reads the same ledger and
+     row encoder without adding a client-controlled cache key. *)
   |> Http.Router.get "/api/v1/dashboard/scheduled-automation" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let json =
-           Server_dashboard_http.dashboard_scheduled_automation_http_json
+           Server_dashboard_http.dashboard_scheduled_automation_query_http_json
              ~config:(Mcp_server.workspace_config state)
+             req
          in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -1446,6 +1446,31 @@ let test_scheduled_automation_reads_its_cache_key () =
         (cache_sentinel cache_key)
         (Server_dashboard_http.dashboard_scheduled_automation_http_json ~config))
 
+(* The exact lookup answers with a closed status, so a blank id is a named
+   outcome rather than a not_found that reads like "no such schedule". Pin the
+   two the caller can reach without a store: an empty id is invalid_id, and the
+   projection stays a function of the clock it is handed. *)
+let test_schedule_exact_lookup_rejects_blank_id () =
+  with_test_env @@ fun ~env:_ ~sw:_ ~config ->
+  let body =
+    Server_dashboard_schedule_projection.scheduled_automation_exact_lookup_json
+      config
+      ~now:1_700_000_000.0
+      ~schedule_id:"   "
+  in
+  let field name =
+    match body with
+    | `Assoc fields ->
+      (match List.assoc_opt name fields with Some (`String s) -> Some s | _ -> None)
+    | _ -> None
+  in
+  check (option string) "blank id is named, not not_found" (Some "invalid_id") (field "status");
+  check
+    (option string)
+    "the echoed id is the caller's, untrimmed"
+    (Some "   ")
+    (field "schedule_id")
+
 (* The window selects which rows the scan covers, so two windows must not share
    an entry. Seeding only the 24 h key and asking for 1 h has to miss. *)
 let test_agent_activity_keys_on_its_window () =
@@ -3645,6 +3670,8 @@ let () =
             test_dashboard_proof_http_json_surfaces_submission_index;
           test_case "scheduled-automation reads its cache key" `Quick
             test_scheduled_automation_reads_its_cache_key;
+          test_case "schedule exact lookup names a blank id" `Quick
+            test_schedule_exact_lookup_rejects_blank_id;
           test_case "agent-activity keys on its window" `Quick
             test_agent_activity_keys_on_its_window;
           test_case "execution trust uses narrow Keeper projection" `Quick

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -1452,10 +1452,11 @@ let test_scheduled_automation_reads_its_cache_key () =
    projection stays a function of the clock it is handed. *)
 let test_schedule_exact_lookup_rejects_blank_id () =
   with_test_env @@ fun ~env:_ ~sw:_ ~config ->
+  let now = 1_700_000_000.0 in
   let body =
     Server_dashboard_schedule_projection.scheduled_automation_exact_lookup_json
       config
-      ~now:1_700_000_000.0
+      ~now
       ~schedule_id:"   "
   in
   let field name =
@@ -1469,7 +1470,12 @@ let test_schedule_exact_lookup_rejects_blank_id () =
     (option string)
     "the echoed id is the caller's, untrimmed"
     (Some "   ")
-    (field "schedule_id")
+    (field "schedule_id");
+  check
+    (option string)
+    "generated_at uses the same injected projection clock"
+    (Some (Masc_domain.iso8601_of_unix_seconds now))
+    (field "generated_at")
 
 (* The window selects which rows the scan covers, so two windows must not share
    an entry. Seeding only the 24 h key and asking for 1 h has to miss. *)


### PR DESCRIPTION
## Summary

- add `GET /api/v1/dashboard/scheduled-automation?schedule_id=<exact>` as a closed exact-lookup projection
- preserve the no-query aggregate schema, ordering, 20-row cap, and shared cache path
- reuse the schedule-store owner read and existing dashboard request-row encoder
- route HTTP/1 and H2 through the same query-aware wrapper

## Contract

The exact response uses `masc.dashboard.scheduled_automation.lookup.v1` with one of four statuses:

- `found` with the existing dashboard-encoded `request`
- `not_found`
- `unavailable` with a typed reason
- `invalid_id` for a blank identifier

Exact identity is byte-preserving after blank validation; no trimming is applied to lookup or response identity. Exact lookups bypass the aggregate cache so client-controlled IDs do not create cache entries.

## As-Is → To-Be

Previously, the API exposed only the first 20 active-first ordered rows, so an exact terminal schedule could remain in the Schedule_store SSOT but be unavailable to a dashboard client. The query mode now projects that exact stored row without changing aggregate behavior.

## Validation

No new tests were added and no Dune build was run, per scope. Completed:

- `ocamlc -stop-after parsing -c` for all six changed OCaml interfaces/implementations
- `ocamlformat --check` for all changed OCaml files
- `git diff --check origin/main...HEAD`
- `python3 scripts/ci/check_h2_route_auth_parity.py`
- `scripts/ci/check-telemetry-coverage.sh`
- `scripts/ocaml-structure-ratchet.sh`
- `scripts/stringly-boundary-ratchet.sh`
- `scripts/silent-failure-ratchet.sh`

## Out of scope

Frontend consumption, offset pagination, UI filters, new tests, CI completion, and live deployment verification remain separate follow-ups.