### PR TITLE
feat(connectors): render rich Slack and safe mentions

### DIFF
--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -487,14 +487,27 @@ let pp_send_error fmt = function
   | Rest_error e ->
     Format.fprintf fmt "discord rest error: %a" Discord_rest_client.pp_error e
 
-let send_message ~channel_id ~content ?reply_to_message_id () =
+let send_message ~channel_id ~content ?reply_to_message_id
+    ?(mention_user_ids = []) () =
   match bot_token_opt () with
   | None -> Error Missing_token
   | Some token ->
+    let content =
+      match mention_user_ids with
+      | [] -> content
+      | user_ids ->
+        let mentions =
+          user_ids |> List.map (Printf.sprintf "<@%s>") |> String.concat " "
+        in
+        mentions ^ "\n" ^ content
+    in
     let limit = Discord_rest_client.message_content_limit in
     let len = String.length content in
     if len <= limit then
-      (match Discord_rest_client.send_message ~token ~channel_id ~content ?reply_to_message_id () with
+      (match
+         Discord_rest_client.send_message ~token ~channel_id ~content
+           ?reply_to_message_id ~allowed_user_mentions:mention_user_ids ()
+       with
        | Ok id -> Ok id
        | Error e -> Error (Rest_error e))
     else
@@ -509,7 +522,11 @@ let send_message ~channel_id ~content ?reply_to_message_id () =
           if remaining_str = "" then None else Some remaining_str
         in
         let ref_id = if first then reply_to_message_id else None in
-        match Discord_rest_client.send_message ~token ~channel_id ~content:chunk ?reply_to_message_id:ref_id () with
+        match
+          Discord_rest_client.send_message ~token ~channel_id ~content:chunk
+            ?reply_to_message_id:ref_id
+            ~allowed_user_mentions:mention_user_ids ()
+        with
         | Ok id ->
             (match remaining with
              | None -> Ok id

--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -487,53 +487,102 @@ let pp_send_error fmt = function
   | Rest_error e ->
     Format.fprintf fmt "discord rest error: %a" Discord_rest_client.pp_error e
 
+type outbound_message =
+  { content : string
+  ; allowed_user_mentions : string list
+  }
+
+let text_chunks ~limit content =
+  let rec split acc rest =
+    if String.equal rest "" then List.rev acc
+    else
+      let chunk, remaining = Discord_rest_client.split_at_codepoint rest ~limit in
+      split (chunk :: acc) remaining
+  in
+  match split [] content with
+  | [] -> [ "" ]
+  | chunks -> chunks
+
+let mention_messages ~limit mention_user_ids =
+  let flush content ids acc =
+    if ids = [] then acc
+    else
+      { content; allowed_user_mentions = List.rev ids } :: acc
+  in
+  let rec group content ids acc = function
+    | [] -> List.rev (flush content ids acc)
+    | id :: rest ->
+      let token = Printf.sprintf "<@%s>" id in
+      let candidate = if ids = [] then token else content ^ " " ^ token in
+      if String.length candidate <= limit
+      then group candidate (id :: ids) acc rest
+      else
+        group token [ id ] (flush content ids acc) rest
+  in
+  group "" [] [] mention_user_ids
+
+let message_chunks_with_mentions ~limit ~content ~mention_user_ids =
+  match mention_user_ids with
+  | [] ->
+    text_chunks ~limit content
+    |> List.map (fun content -> { content; allowed_user_mentions = [] })
+  | user_ids ->
+    let prefix =
+      user_ids |> List.map (Printf.sprintf "<@%s>") |> String.concat " "
+    in
+    let combined = prefix ^ "\n" ^ content in
+    if String.length combined <= limit
+    then [ { content = combined; allowed_user_mentions = user_ids } ]
+    else
+      mention_messages ~limit user_ids
+      @ (text_chunks ~limit content
+         |> List.map (fun content -> { content; allowed_user_mentions = [] }))
+
+module For_testing = struct
+  type nonrec outbound_message = outbound_message =
+    { content : string
+    ; allowed_user_mentions : string list
+    }
+
+  let message_chunks_with_mentions = message_chunks_with_mentions
+end
+
 let send_message ~channel_id ~content ?reply_to_message_id
     ?(mention_user_ids = []) () =
   match bot_token_opt () with
   | None -> Error Missing_token
   | Some token ->
-    let content =
-      match mention_user_ids with
-      | [] -> content
-      | user_ids ->
-        let mentions =
-          user_ids |> List.map (Printf.sprintf "<@%s>") |> String.concat " "
-        in
-        mentions ^ "\n" ^ content
-    in
     let limit = Discord_rest_client.message_content_limit in
-    let len = String.length content in
-    if len <= limit then
-      (match
-         Discord_rest_client.send_message ~token ~channel_id ~content
-           ?reply_to_message_id ~allowed_user_mentions:mention_user_ids ()
-       with
-       | Ok id -> Ok id
-       | Error e -> Error (Rest_error e))
-    else
-      let rec send_chunks first rest =
-        (* Split on a codepoint boundary: the Discord limit is in Unicode
-           scalar values, and a mid-codepoint byte cut yields invalid
-           UTF-8 that Discord rejects with a 400. *)
-        let chunk, remaining_str =
-          Discord_rest_client.split_at_codepoint rest ~limit
-        in
-        let remaining =
-          if remaining_str = "" then None else Some remaining_str
-        in
+    let messages =
+      message_chunks_with_mentions ~limit ~content ~mention_user_ids
+    in
+    let rec send_chunks first last_id = function
+      | [] ->
+        (match last_id with
+         | Some id -> Ok id
+         | None ->
+           Error
+             (Rest_error
+                (Discord_rest_client.Other
+                   { request_id = ""
+                   ; reason = "Discord message chunker produced no output"
+                   ; body_bytes = 0
+                   })))
+      | message :: rest ->
         let ref_id = if first then reply_to_message_id else None in
         match
-          Discord_rest_client.send_message ~token ~channel_id ~content:chunk
+          Discord_rest_client.send_message
+            ~token
+            ~channel_id
+            ~content:message.content
             ?reply_to_message_id:ref_id
-            ~allowed_user_mentions:mention_user_ids ()
+            ~allowed_user_mentions:message.allowed_user_mentions
+            ()
         with
-        | Ok id ->
-            (match remaining with
-             | None -> Ok id
-             | Some next -> send_chunks false next)
+        | Ok id -> send_chunks false (Some id) rest
         | Error e -> Error (Rest_error e)
-      in
-      send_chunks true content
+    in
+    send_chunks true None messages
 
 let edit_message ~channel_id ~message_id ~content () =
   match bot_token_opt () with

--- a/lib/gate/channel_gate_discord_state.mli
+++ b/lib/gate/channel_gate_discord_state.mli
@@ -193,3 +193,16 @@ val trigger_typing :
 (** Trigger Discord's typing indicator for [channel_id]. Bot token is
     resolved from [DISCORD_BOT_TOKEN] at call time, matching
     {!send_message}. *)
+
+module For_testing : sig
+  type outbound_message =
+    { content : string
+    ; allowed_user_mentions : string list
+    }
+
+  val message_chunks_with_mentions :
+    limit:int ->
+    content:string ->
+    mention_user_ids:string list ->
+    outbound_message list
+end

--- a/lib/gate/channel_gate_discord_state.mli
+++ b/lib/gate/channel_gate_discord_state.mli
@@ -159,12 +159,15 @@ val send_message :
   channel_id:string ->
   content:string ->
   ?reply_to_message_id:string ->
+  ?mention_user_ids:string list ->
   unit ->
   (string, send_error) result
 (** Post a single message to a Discord channel.  When
     [reply_to_message_id] is provided, the message is sent as a
-    reply (Discord threads the conversation).  Returns the created
-    message id on success.  Bot token is resolved from
+    reply (Discord threads the conversation). [mention_user_ids] are prefixed
+    as visible mentions and are the only user ids Discord is allowed to
+    notify; absent means all mention kinds are suppressed. Returns the created
+    message id on success. Bot token is resolved from
     [DISCORD_BOT_TOKEN] at call time so a token rotation doesn't
     require a server restart.
 

--- a/lib/gate/discord_rest_client.ml
+++ b/lib/gate/discord_rest_client.ml
@@ -55,7 +55,15 @@ let auth_headers ~token =
   ; "User-Agent", user_agent
   ]
 
-let build_request ~token ~channel_id ~content ?reply_to_message_id () =
+let allowed_mentions_json user_ids =
+  match user_ids with
+  | [] -> `Assoc [ "parse", `List [] ]
+  | user_ids ->
+    `Assoc
+      [ "users", `List (List.map (fun id -> `String (snowflake_to_string id)) user_ids) ]
+
+let build_request ~token ~channel_id ~content ?reply_to_message_id
+    ?(allowed_user_mentions = []) () =
   let url =
     Printf.sprintf
       "%s/channels/%s/messages"
@@ -64,7 +72,11 @@ let build_request ~token ~channel_id ~content ?reply_to_message_id () =
   let headers =
     ("Content-Type", "application/json") :: auth_headers ~token
   in
-  let fields = [ "content", `String content ] in
+  let fields =
+    [ "content", `String content
+    ; "allowed_mentions", allowed_mentions_json allowed_user_mentions
+    ]
+  in
   let fields =
     match reply_to_message_id with
     | None -> fields
@@ -242,17 +254,29 @@ let parse_empty_response ?request_id ~status ~body () =
   else Error (error_of_non2xx ~request_id ~status ~body)
 
 let send_message ?clock ?(timeout_sec = Masc_http_client.default_request_timeout_sec)
-    ~token ~channel_id ~content ?reply_to_message_id () =
+    ~token ~channel_id ~content ?reply_to_message_id
+    ?(allowed_user_mentions = []) () =
   match snowflake_of_string channel_id with
   | Error message -> Error (Network message)
   | Ok channel_id ->
-    (match reply_to_message_id with
+    let rec decode_mentions acc = function
+      | [] -> Ok (List.rev acc)
+      | value :: rest ->
+        (match snowflake_of_string value with
+         | Ok id -> decode_mentions (id :: acc) rest
+         | Error message -> Error (Network message))
+    in
+    (match decode_mentions [] allowed_user_mentions with
+     | Error _ as error -> error
+     | Ok allowed_user_mentions ->
+    match reply_to_message_id with
      | Some value ->
        (match snowflake_of_string value with
         | Error message -> Error (Network message)
         | Ok reply_to_message_id ->
           let (url, headers, body) =
-            build_request ~token ~channel_id ~content ~reply_to_message_id ()
+            build_request ~token ~channel_id ~content ~reply_to_message_id
+              ~allowed_user_mentions ()
           in
           (match
              Masc_http_client.post_sync ?clock ~timeout_sec ~url ~headers ~body
@@ -264,14 +288,14 @@ let send_message ?clock ?(timeout_sec = Masc_http_client.default_request_timeout
                ()))
      | None ->
        let (url, headers, body) =
-         build_request ~token ~channel_id ~content ()
+          build_request ~token ~channel_id ~content ~allowed_user_mentions ()
        in
        (match
           Masc_http_client.post_sync ?clock ~timeout_sec ~url ~headers ~body ()
         with
         | Error msg -> Error (Network msg)
         | Ok (status, body) ->
-          parse_response ~request_id:(next_request_id "send") ~status ~body
+            parse_response ~request_id:(next_request_id "send") ~status ~body
             ()))
 
 (* Byte length of the UTF-8 sequence whose lead byte is [c]. An invalid

--- a/lib/gate/discord_rest_client.mli
+++ b/lib/gate/discord_rest_client.mli
@@ -61,13 +61,16 @@ val send_message :
   channel_id:string ->
   content:string ->
   ?reply_to_message_id:string ->
+  ?allowed_user_mentions:string list ->
   unit ->
   (string, error) result
 (** [send_message ~token ~channel_id ~content ?reply_to_message_id ()]
     posts to [POST /api/v10/channels/{channel_id}/messages].
     When [reply_to_message_id] is provided, the message is sent as
-    a reply (Discord threads the conversation). Returns the created
-    message id on [Ok].
+    a reply (Discord threads the conversation). [allowed_user_mentions]
+    contains the only user snowflakes Discord may notify; when omitted or
+    empty, user, role, and everyone mentions are all suppressed. Returns the
+    created message id on [Ok].
 
     Works for guild text channels, DM channels, and threads.
 
@@ -213,11 +216,13 @@ val build_request :
   channel_id:snowflake ->
   content:string ->
   ?reply_to_message_id:snowflake ->
+  ?allowed_user_mentions:snowflake list ->
   unit ->
   string * (string * string) list * string
 (** [(url, headers, body) = build_request ~token ~channel_id ~content
     ?reply_to_message_id ()].  Headers include Authorization (Bot
-    scheme), Content-Type, and a Discord-required User-Agent.  When
+    scheme), Content-Type, a fail-closed [allowed_mentions] object, and a
+    Discord-required User-Agent. When
     [reply_to_message_id] is provided, the body includes a
     [message_reference] field so Discord threads the reply. *)
 

--- a/lib/keeper/keeper_chat_slack.ml
+++ b/lib/keeper/keeper_chat_slack.ml
@@ -17,6 +17,7 @@ let pp_error fmt = function
 let slack_message_limit = 4000
 let slack_max_blocks = 50
 let slack_block_text_limit = 3000
+let slack_markdown_limit = 12_000
 let min_edit_interval_s = Slack_rest_client.streaming_update_min_interval_sec
 
 let redact content = Observability_redact.redact_text content
@@ -181,6 +182,25 @@ let status_block_json ({ Keeper_chat_blocks.kind } : Keeper_chat_blocks.status_b
     ; ("text", `Assoc [ ("type", `String "mrkdwn"); ("text", `String body) ])
     ]
 
+let markdown_block_json text =
+  let text =
+    redact text
+    |> escape_mrkdwn_text
+    |> fun value -> truncate_to_limit value slack_markdown_limit
+  in
+  `Assoc [ "type", `String "markdown"; "text", `String text ]
+
+let mention_block_json user_ids =
+  let text =
+    user_ids
+    |> List.map (Printf.sprintf "<@%s>")
+    |> String.concat " "
+  in
+  `Assoc
+    [ "type", `String "section"
+    ; "text", `Assoc [ "type", `String "mrkdwn"; "text", `String text ]
+    ]
+
 (* ── Content → Slack blocks ──────────────────────────────────────── *)
 
 let slack_block_of_chat_block = function
@@ -214,9 +234,38 @@ let slack_block_of_chat_block = function
   | Keeper_chat_blocks.Thinking _ -> None
 
 let content_blocks_of_text text =
-  text
-  |> Keeper_chat_blocks.parse_text_to_blocks
-  |> List.filter_map slack_block_of_chat_block
+  if String.trim text = "" then []
+  else
+    let media_blocks =
+      text
+      |> Keeper_chat_blocks.parse_text_to_blocks
+      |> List.filter_map (function
+        | Keeper_chat_blocks.Image _ as block -> slack_block_of_chat_block block
+        | Keeper_chat_blocks.Text _
+        | Keeper_chat_blocks.Heading _
+        | Keeper_chat_blocks.Unordered_list _
+        | Keeper_chat_blocks.Callout _
+        | Keeper_chat_blocks.Table _
+        | Keeper_chat_blocks.Code _
+        | Keeper_chat_blocks.Mermaid _
+        | Keeper_chat_blocks.Svg _
+        | Keeper_chat_blocks.Voice _
+        | Keeper_chat_blocks.Attach _
+        | Keeper_chat_blocks.Link _
+        | Keeper_chat_blocks.Fusion _
+        | Keeper_chat_blocks.Status _
+        | Keeper_chat_blocks.Trace _
+        | Keeper_chat_blocks.Thinking _ -> None)
+    in
+    markdown_block_json text :: media_blocks
+
+let message_blocks_of_text ~mention_user_ids text =
+  let mention_blocks =
+    match mention_user_ids with
+    | [] -> []
+    | user_ids -> [ mention_block_json user_ids ]
+  in
+  mention_blocks @ content_blocks_of_text text
 
 let final_message_blocks ~content ~event_blocks =
   content_blocks_of_text content @ event_blocks
@@ -317,10 +366,19 @@ let set_thread_status ?clock
 
 let send_message_with_blocks ?clock
     ?(timeout_sec = Masc_http_client.default_request_timeout_sec)
-    ?thread_ts ~token ~channel ~content ~blocks () =
-  let content =
+    ?thread_ts ?(mention_user_ids = []) ~token ~channel ~content ~blocks () =
+  let fallback_content =
     redact content |> escape_mrkdwn_text |> fun s ->
     truncate_to_limit s slack_message_limit
+  in
+  let content =
+    match mention_user_ids with
+    | [] -> fallback_content
+    | user_ids ->
+      let mentions =
+        user_ids |> List.map (Printf.sprintf "<@%s>") |> String.concat " "
+      in
+      truncate_to_limit (mentions ^ "\n" ^ fallback_content) slack_message_limit
   in
   let blocks = limit_blocks_for_slack blocks in
   let body_json = build_message_body ~channel ~content ~blocks ?thread_ts () in
@@ -629,8 +687,8 @@ let adapter_loop_with_transport
              "keeper_chat_slack: protocol diagnostic delivery failed: %s"
              (Format.asprintf "%a" pp_error error));
         continue ()
-    | Tool_call_start _ ->
-        update_activity "필요한 작업을 진행하고 있어요…";
+    | Tool_call_start { tool_call_name; _ } ->
+        update_activity (Printf.sprintf "🔧 %s 사용 중…" tool_call_name);
         continue ()
     | Tool_call_args _ | Tool_call_args_snapshot _ | Tool_call_end _
     | Tool_result_ready _ ->
@@ -696,6 +754,9 @@ module For_testing = struct
   let image_block_json = image_block_json
   let audio_block_json = audio_block_json
   let content_blocks_of_text = content_blocks_of_text
+  let message_blocks_of_text = message_blocks_of_text
+  let markdown_block_json = markdown_block_json
+  let mention_block_json = mention_block_json
   let final_message_blocks = final_message_blocks
   let build_message_body = build_message_body
   let build_thread_status_body = build_thread_status_body

--- a/lib/keeper/keeper_chat_slack.ml
+++ b/lib/keeper/keeper_chat_slack.ml
@@ -182,10 +182,30 @@ let status_block_json ({ Keeper_chat_blocks.kind } : Keeper_chat_blocks.status_b
     ; ("text", `Assoc [ ("type", `String "mrkdwn"); ("text", `String body) ])
     ]
 
+let escape_markdown_mentions text =
+  let length = String.length text in
+  let buffer = Buffer.create length in
+  let rec copy index =
+    if index < length then
+      if
+        text.[index] = '<'
+        && index + 1 < length
+        && (text.[index + 1] = '@' || text.[index + 1] = '!')
+      then (
+        Buffer.add_string buffer "&lt;";
+        copy (index + 1)
+      ) else (
+        Buffer.add_char buffer text.[index];
+        copy (index + 1)
+      )
+  in
+  copy 0;
+  Buffer.contents buffer
+
 let markdown_block_json text =
   let text =
     redact text
-    |> escape_mrkdwn_text
+    |> escape_markdown_mentions
     |> fun value -> truncate_to_limit value slack_markdown_limit
   in
   `Assoc [ "type", `String "markdown"; "text", `String text ]

--- a/lib/keeper/keeper_chat_slack.mli
+++ b/lib/keeper/keeper_chat_slack.mli
@@ -29,21 +29,26 @@ val send_message_with_blocks :
   ?clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
   ?timeout_sec:float ->
   ?thread_ts:string ->
+  ?mention_user_ids:string list ->
   token:string -> channel:string -> content:string -> blocks:Yojson.Safe.t list -> unit -> (unit, error) result
 (** [send_message_with_blocks ~token ~channel ~content ~blocks] posts to
-    [chat.postMessage] with the given Block Kit [blocks]. Logs errors via
-    [Log.Keeper.warn] and returns the outcome. *)
+    [chat.postMessage] with the given Block Kit [blocks]. Stable Slack ids in
+    [mention_user_ids] are emitted both in the accessible fallback and the
+    visible blocks assembled by the caller. Logs errors via [Log.Keeper.warn]
+    and returns the outcome. *)
 
 val content_blocks_of_text : string -> Yojson.Safe.t list
-(** [content_blocks_of_text text] projects server chat blocks into Slack
-    Block Kit blocks:
-    - Markdown images [![alt](url)] become image blocks.
-    - Standalone image URLs (png/jpg/gif/webp/svg) become image blocks.
-    - Other standalone URLs become link blocks with a hostname-derived title.
-    Code and Mermaid fences become section code-block sections.
-    Text and most other block kinds are omitted because primary text is
-    already delivered via the [content] field; fusion cards also have no
-    Slack-native projection yet. *)
+(** [content_blocks_of_text text] puts the complete LLM-authored standard
+    Markdown in Slack's native [markdown] block, which renders headings,
+    emphasis, lists, links, code, task lists, and tables without a local
+    Markdown-to-mrkdwn heuristic. Safe image chat blocks are also projected as
+    image blocks. Blank text produces no block. *)
+
+val message_blocks_of_text :
+  mention_user_ids:string list -> string -> Yojson.Safe.t list
+(** Prepend one visible mrkdwn mention section to
+    {!content_blocks_of_text}. Ids must already have passed the surface-post
+    validator. *)
 
 val link_block_json :
   url:string -> title:string -> description:string option -> Yojson.Safe.t
@@ -114,6 +119,13 @@ module For_testing : sig
 
   val content_blocks_of_text : string -> Yojson.Safe.t list
   (** Same as {!content_blocks_of_text}; exposed for unit testing. *)
+
+  val message_blocks_of_text :
+    mention_user_ids:string list -> string -> Yojson.Safe.t list
+
+  val markdown_block_json : string -> Yojson.Safe.t
+
+  val mention_block_json : string list -> Yojson.Safe.t
 
   val final_message_blocks :
     content:string -> event_blocks:Yojson.Safe.t list -> Yojson.Safe.t list

--- a/lib/keeper/keeper_surface_post.ml
+++ b/lib/keeper/keeper_surface_post.ml
@@ -13,6 +13,69 @@ let dashboard_label = "dashboard"
 let discord_label = "discord"
 let slack_label = "slack"
 
+let max_user_mentions = 100
+
+let is_ascii_upper_or_digit = function
+  | 'A' .. 'Z' | '0' .. '9' -> true
+  | _ -> false
+
+let valid_slack_user_id value =
+  let length = String.length value in
+  length >= 2
+  && (value.[0] = 'U' || value.[0] = 'W')
+  && String.for_all is_ascii_upper_or_digit value
+
+let valid_discord_user_id value =
+  value <> ""
+  && String.for_all (function '0' .. '9' -> true | _ -> false) value
+
+let user_mentions_of_args ~surface args =
+  let values =
+    match args with
+    | `Assoc fields ->
+      (match List.filter (fun (name, _) -> name = "mention_user_ids") fields with
+       | [] -> Ok []
+       | [ (_, `List values) ] ->
+         let rec strings acc = function
+           | [] -> Ok (List.rev acc)
+           | `String value :: rest when String.trim value <> "" ->
+             strings (String.trim value :: acc) rest
+           | `String _ :: _ -> Error "mention_user_ids cannot contain blank ids"
+           | _ :: _ -> Error "mention_user_ids must contain only strings"
+         in
+         strings [] values
+       | [ _ ] -> Error "mention_user_ids must be an array of strings"
+       | _ -> Error "mention_user_ids must not be repeated")
+    | _ -> Error "keeper_surface_post arguments must be an object"
+  in
+  Result.bind values (fun values ->
+    let values = List.sort_uniq String.compare values in
+    if List.length values > max_user_mentions then
+      Error
+        (Printf.sprintf
+           "mention_user_ids supports at most %d users"
+           max_user_mentions)
+    else if values = [] then Ok []
+    else if String.equal surface slack_label then
+      (match List.find_opt (fun value -> not (valid_slack_user_id value)) values with
+       | None -> Ok values
+       | Some value ->
+         Error
+           (Printf.sprintf
+              "Slack mention_user_ids must be stable U... or W... ids from the participant roster; invalid id %S"
+              value))
+    else if String.equal surface discord_label then
+      (match List.find_opt (fun value -> not (valid_discord_user_id value)) values with
+       | None -> Ok values
+       | Some value ->
+         Error
+           (Printf.sprintf
+              "Discord mention_user_ids must be decimal user snowflakes from the participant roster; invalid id %S"
+              value))
+    else
+      Error
+        "mention_user_ids is supported only for Slack and Discord posts")
+
 type delivery_target =
   | Delivered_to_dashboard
   | Delivered_to_discord of { channel_id : string }

--- a/lib/keeper/keeper_surface_post.ml
+++ b/lib/keeper/keeper_surface_post.ml
@@ -76,6 +76,47 @@ let user_mentions_of_args ~surface args =
       Error
         "mention_user_ids is supported only for Slack and Discord posts")
 
+let message_matches_target target (message : Keeper_chat_store.chat_message) =
+  match target, message.surface with
+  | To_discord { channel_id = target_channel },
+    Some (Surface_ref.Discord { channel_id; _ }) ->
+    String.equal target_channel channel_id
+  | To_slack
+      { channel_id = target_channel; thread_ts = target_thread; blocks = _ },
+    Some (Surface_ref.Slack { channel_id; thread_ts; _ }) ->
+    String.equal target_channel channel_id && target_thread = thread_ts
+  | To_dashboard, _
+  | To_discord _, _
+  | To_slack _, _ -> false
+
+let validate_user_mentions_against_roster ~target ~messages mention_user_ids =
+  if mention_user_ids = [] then Ok ()
+  else
+    let roster = Hashtbl.create 8 in
+    List.iter
+      (fun (message : Keeper_chat_store.chat_message) ->
+         if
+           Keeper_chat_store.Role.equal message.role Keeper_chat_store.Role.User
+           && message_matches_target target message
+         then
+           match message.speaker with
+           | Some { speaker_id = Some id; _ } when String.trim id <> "" ->
+             Hashtbl.replace roster (String.trim id) ()
+           | Some { speaker_id = Some _; _ }
+           | Some { speaker_id = None; _ }
+           | None -> ())
+      messages;
+    let missing =
+      List.filter (fun id -> not (Hashtbl.mem roster id)) mention_user_ids
+    in
+    match missing with
+    | [] -> Ok ()
+    | _ ->
+      Error
+        (Printf.sprintf
+           "mention_user_ids are not in the current participant roster for the resolved target: %s"
+           (String.concat ", " missing))
+
 type delivery_target =
   | Delivered_to_dashboard
   | Delivered_to_discord of { channel_id : string }

--- a/lib/keeper/keeper_surface_post.mli
+++ b/lib/keeper/keeper_surface_post.mli
@@ -41,6 +41,16 @@ val user_mentions_of_args :
     ids are collapsed and more than {!max_user_mentions} ids are rejected.
     Non-empty mentions on dashboard or another surface are invalid. *)
 
+val validate_user_mentions_against_roster :
+  target:post_target ->
+  messages:Keeper_chat_store.chat_message list ->
+  string list ->
+  (unit, string) result
+(** Fail closed unless every requested mention id appears as a user speaker on
+    the exact resolved Discord channel or Slack channel/thread in [messages].
+    The persisted chat lane is the roster SSOT; syntactically valid but stale,
+    hallucinated, or cross-channel ids are rejected before any effect. *)
+
 type delivery_target =
   | Delivered_to_dashboard
   | Delivered_to_discord of { channel_id : string }

--- a/lib/keeper/keeper_surface_post.mli
+++ b/lib/keeper/keeper_surface_post.mli
@@ -31,6 +31,16 @@ val dashboard_label : string
 val discord_label : string
 val slack_label : string
 
+val max_user_mentions : int
+
+val user_mentions_of_args :
+  surface:string -> Yojson.Safe.t -> (string list, string) result
+(** Decode and validate the optional [mention_user_ids] tool argument.
+    Slack accepts only stable [U...]/[W...] participant ids; Discord accepts
+    only decimal user snowflakes. Display names are never guessed. Duplicate
+    ids are collapsed and more than {!max_user_mentions} ids are rejected.
+    Non-empty mentions on dashboard or another surface are invalid. *)
+
 type delivery_target =
   | Delivered_to_dashboard
   | Delivered_to_discord of { channel_id : string }

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -922,15 +922,28 @@ let surface_post_schema =
     [ property
         "surface"
         "string"
-        "Lane to post to: 'dashboard' or 'discord'. Posting to a surface \
+        "Lane to post to: 'dashboard', 'discord', or 'slack'. Posting to a surface \
          this keeper is not bound to is an error, not a no-op."
-    ; property "content" "string" "Message text to deliver on the lane."
+    ; property
+        "content"
+        "string"
+        "Standard Markdown message to deliver. Discord renders it natively; \
+         Slack renders it through the official Block Kit markdown block."
     ; property
         "channel_id"
         "string"
-        "Discord channel snowflake. Required only when more than one \
-         channel is bound to this keeper; must be one of the bound \
-         channels."
+        "Bound Discord or Slack channel id. Required only when more than one \
+         channel is bound for the selected surface; must be one of those \
+         bindings."
+    ; ( "mention_user_ids"
+      , `Assoc
+          [ "type", `String "array"
+          ; "items", `Assoc [ "type", `String "string" ]
+          ; "maxItems", `Int Keeper_surface_post.max_user_mentions
+          ; ( "description"
+            , `String
+                "Stable ids from keeper_surface_read participants to visibly mention. Slack requires U.../W... ids; Discord requires decimal user snowflakes. Never guess an id from a display name; plain @name text is not an API mention." )
+          ] )
     ]
 ;;
 

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -907,8 +907,8 @@ let handle_person_note_set ~config ~meta ~args =
    gateway and Owner connector delivery — rather than a direct env lookup here. *)
 let slack_token_opt = Env_config_slack.bot_token_opt
 
-let connector_post_gate_input ~connector ~channel_id ~content ?thread_ts ?blocks
-    () =
+let connector_post_gate_input ~connector ~channel_id ~content ~mention_user_ids
+    ?thread_ts ?blocks () =
   let thread_ts_fields =
     match thread_ts with
     | None -> []
@@ -923,6 +923,7 @@ let connector_post_gate_input ~connector ~channel_id ~content ?thread_ts ?blocks
     ([ "connector", `String connector
      ; "channel_id", `String channel_id
      ; "content", `String content
+     ; "mention_user_ids", Json_util.json_string_list mention_user_ids
      ]
      @ thread_ts_fields
      @ block_fields)
@@ -935,6 +936,7 @@ type connector_post_replay =
       { input : Yojson.Safe.t
       ; channel_id : string
       ; content : string
+      ; mention_user_ids : string list
       }
   | Replay_slack_post of
       { input : Yojson.Safe.t
@@ -942,6 +944,7 @@ type connector_post_replay =
       ; thread_ts : string option
       ; content : string
       ; blocks : Yojson.Safe.t list
+      ; mention_user_ids : string list
       }
 
 let connector_post_replay_of_gate_input input =
@@ -985,6 +988,31 @@ let connector_post_replay_of_gate_input input =
     | _ ->
       Error (Printf.sprintf "approved connector_post repeats %s" key)
   in
+  let required_string_list key fields =
+    match
+      List.filter_map
+        (fun (name, value) -> if String.equal name key then Some value else None)
+        fields
+    with
+    | [ `List values ] ->
+      let rec decode acc = function
+        | [] -> Ok (List.rev acc)
+        | `String value :: rest when String.trim value <> "" ->
+          decode (String.trim value :: acc) rest
+        | `String _ :: _ ->
+          Error (Printf.sprintf "approved connector_post %s contains a blank id" key)
+        | _ :: _ ->
+          Error
+            (Printf.sprintf
+               "approved connector_post %s must contain only strings"
+               key)
+      in
+      decode [] values
+    | [ _ ] ->
+      Error (Printf.sprintf "approved connector_post %s must be an array" key)
+    | [] -> Error (Printf.sprintf "approved connector_post is missing %s" key)
+    | _ -> Error (Printf.sprintf "approved connector_post repeats %s" key)
+  in
   let reject_unknown ~allowed fields =
     match
       fields
@@ -1005,20 +1033,40 @@ let connector_post_replay_of_gate_input input =
     let* connector = required_string "connector" fields in
     let* channel_id = required_string "channel_id" fields in
     let* content = required_string "content" fields in
+    let* mention_user_ids = required_string_list "mention_user_ids" fields in
+    let* validated_mention_user_ids =
+      Keeper_surface_post.user_mentions_of_args
+        ~surface:connector
+        (`Assoc [ "mention_user_ids", Json_util.json_string_list mention_user_ids ])
+    in
+    let* mention_user_ids =
+      if validated_mention_user_ids = mention_user_ids then Ok mention_user_ids
+      else
+        Error
+          "approved connector_post mention_user_ids must be sorted and unique"
+    in
     if String.equal connector Keeper_surface_post.discord_label
     then (
       let* () =
         reject_unknown
-          ~allowed:[ "connector"; "channel_id"; "content" ]
+          ~allowed:[ "connector"; "channel_id"; "content"; "mention_user_ids" ]
           fields
       in
-      Ok (Replay_discord_post { input; channel_id; content }))
+      Ok
+        (Replay_discord_post
+           { input; channel_id; content; mention_user_ids }))
     else if String.equal connector Keeper_surface_post.slack_label
     then (
       let* () =
         reject_unknown
           ~allowed:
-            [ "connector"; "channel_id"; "thread_ts"; "content"; "blocks" ]
+            [ "connector"
+            ; "channel_id"
+            ; "thread_ts"
+            ; "content"
+            ; "blocks"
+            ; "mention_user_ids"
+            ]
           fields
       in
       let* thread_ts = optional_string "thread_ts" fields in
@@ -1029,7 +1077,9 @@ let connector_post_replay_of_gate_input input =
           fields
       with
       | [ `List blocks ] ->
-        Ok (Replay_slack_post { input; channel_id; thread_ts; content; blocks })
+        Ok
+          (Replay_slack_post
+             { input; channel_id; thread_ts; content; blocks; mention_user_ids })
       | [ _ ] ->
         Error "approved connector_post blocks must be an array"
       | [] ->
@@ -1098,7 +1148,7 @@ let replay_connector_post_with_outcome
          (Printf.sprintf "%s send applied: %s" connector detail))
   in
   function
-  | Replay_discord_post { input; channel_id; content } ->
+  | Replay_discord_post { input; channel_id; content; mention_user_ids } ->
     with_connector_post_gate_execution
       ~config
       ~meta
@@ -1107,7 +1157,10 @@ let replay_connector_post_with_outcome
       ?gate_grant
       ~input
     @@ fun () ->
-    (match Channel_gate_discord_state.send_message ~channel_id ~content () with
+    (match
+       Channel_gate_discord_state.send_message ~channel_id ~content
+         ~mention_user_ids ()
+     with
      | Error send_error ->
        fail
          Keeper_surface_post.discord_label
@@ -1141,7 +1194,8 @@ let replay_connector_post_with_outcome
             ~content
             ();
           succeed Keeper_surface_post.discord_label ~message_id ()))
-  | Replay_slack_post { input; channel_id; thread_ts; content; blocks } ->
+  | Replay_slack_post
+      { input; channel_id; thread_ts; content; blocks; mention_user_ids } ->
     with_connector_post_gate_execution
       ~config
       ~meta
@@ -1164,6 +1218,7 @@ let replay_connector_post_with_outcome
             ~channel:channel_id
             ~content
             ~blocks
+            ~mention_user_ids
             ()
         with
         | Error send_error ->
@@ -1254,7 +1309,12 @@ let handle_surface_post_with_outcome
     fail
       ~effect_disposition:Tool_result.Proven_pre_effect
       (Keeper_surface_post.error_json "content is required and must be non-empty.")
-  else
+  else match Keeper_surface_post.user_mentions_of_args ~surface args with
+  | Error message ->
+    fail
+      ~effect_disposition:Tool_result.Proven_pre_effect
+      (Keeper_surface_post.error_json message)
+  | Ok mention_user_ids ->
     match
       Channel_gate_discord_state.bound_channels_result ~keeper_name:meta.name
     with
@@ -1310,6 +1370,7 @@ let handle_surface_post_with_outcome
           ~connector:surface
           ~channel_id
           ~content:safe_content
+          ~mention_user_ids
           ()
       in
       replay_connector_post_with_outcome
@@ -1318,19 +1379,21 @@ let handle_surface_post_with_outcome
         ?continuation_channel
         ?gate_context
         ?gate_grant
-        (Replay_discord_post { input; channel_id; content = safe_content })
+        (Replay_discord_post
+           { input; channel_id; content = safe_content; mention_user_ids })
       |> Keeper_tool_execution.with_surface_post_receipt target
     | Ok
         (Keeper_surface_post.To_slack { channel_id; thread_ts; blocks = _ } as
          target) ->
       let slack_blocks =
-        Keeper_chat_slack.content_blocks_of_text safe_content
+        Keeper_chat_slack.message_blocks_of_text ~mention_user_ids safe_content
       in
       let input =
         connector_post_gate_input
           ~connector:surface
           ~channel_id
           ~content:safe_content
+          ~mention_user_ids
           ?thread_ts
           ~blocks:slack_blocks
           ()
@@ -1347,6 +1410,7 @@ let handle_surface_post_with_outcome
            ; thread_ts
            ; content = safe_content
            ; blocks = slack_blocks
+           ; mention_user_ids
            })
       |> Keeper_tool_execution.with_surface_post_receipt target)
 ;;

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -988,7 +988,7 @@ let connector_post_replay_of_gate_input input =
     | _ ->
       Error (Printf.sprintf "approved connector_post repeats %s" key)
   in
-  let required_string_list key fields =
+  let optional_string_list key fields =
     match
       List.filter_map
         (fun (name, value) -> if String.equal name key then Some value else None)
@@ -1010,7 +1010,7 @@ let connector_post_replay_of_gate_input input =
       decode [] values
     | [ _ ] ->
       Error (Printf.sprintf "approved connector_post %s must be an array" key)
-    | [] -> Error (Printf.sprintf "approved connector_post is missing %s" key)
+    | [] -> Ok []
     | _ -> Error (Printf.sprintf "approved connector_post repeats %s" key)
   in
   let reject_unknown ~allowed fields =
@@ -1033,7 +1033,11 @@ let connector_post_replay_of_gate_input input =
     let* connector = required_string "connector" fields in
     let* channel_id = required_string "channel_id" fields in
     let* content = required_string "content" fields in
-    let* mention_user_ids = required_string_list "mention_user_ids" fields in
+    (* Approvals persisted before rich mentions have no field at all. New
+       producers always write the canonical empty list, while replay keeps the
+       exact old no-mention meaning instead of making an approved effect
+       undecodable across the upgrade. *)
+    let* mention_user_ids = optional_string_list "mention_user_ids" fields in
     let* validated_mention_user_ids =
       Keeper_surface_post.user_mentions_of_args
         ~surface:connector
@@ -1342,7 +1346,23 @@ let handle_surface_post_with_outcome
         fail
           ~effect_disposition:Tool_result.Proven_pre_effect
           (Keeper_surface_post.error_json message)
-      | Ok Keeper_surface_post.To_dashboard ->
+      | Ok target ->
+        let messages =
+          Keeper_chat_store.load
+            ~base_dir:config.Workspace.base_path
+            ~keeper_name:meta.name
+        in
+        (match
+           Keeper_surface_post.validate_user_mentions_against_roster
+             ~target ~messages mention_user_ids
+         with
+         | Error message ->
+           fail
+             ~effect_disposition:Tool_result.Proven_pre_effect
+             (Keeper_surface_post.error_json message)
+         | Ok () ->
+         match target with
+         | Keeper_surface_post.To_dashboard ->
         (match
            Keeper_chat_store.append_assistant_message_result
              ~base_dir:config.Workspace.base_path
@@ -1364,7 +1384,7 @@ let handle_surface_post_with_outcome
            succeed
              Keeper_surface_post.To_dashboard
              (Keeper_surface_post.ok_json ~surface ()))
-    | Ok (Keeper_surface_post.To_discord { channel_id } as target) ->
+         | Keeper_surface_post.To_discord { channel_id } ->
       let input =
         connector_post_gate_input
           ~connector:surface
@@ -1382,9 +1402,7 @@ let handle_surface_post_with_outcome
         (Replay_discord_post
            { input; channel_id; content = safe_content; mention_user_ids })
       |> Keeper_tool_execution.with_surface_post_receipt target
-    | Ok
-        (Keeper_surface_post.To_slack { channel_id; thread_ts; blocks = _ } as
-         target) ->
+         | Keeper_surface_post.To_slack { channel_id; thread_ts; blocks = _ } ->
       let slack_blocks =
         Keeper_chat_slack.message_blocks_of_text ~mention_user_ids safe_content
       in
@@ -1412,7 +1430,7 @@ let handle_surface_post_with_outcome
            ; blocks = slack_blocks
            ; mention_user_ids
            })
-      |> Keeper_tool_execution.with_surface_post_receipt target)
+      |> Keeper_tool_execution.with_surface_post_receipt target))
 ;;
 
 let handle_ide_annotate ~config ~(meta : keeper_meta) ~args =

--- a/lib/keeper/keeper_tool_in_process_runtime.mli
+++ b/lib/keeper/keeper_tool_in_process_runtime.mli
@@ -31,6 +31,7 @@ type connector_post_replay =
       { input : Yojson.Safe.t
       ; channel_id : string
       ; content : string
+      ; mention_user_ids : string list
       }
   | Replay_slack_post of
       { input : Yojson.Safe.t
@@ -38,14 +39,16 @@ type connector_post_replay =
       ; thread_ts : string option
       ; content : string
       ; blocks : Yojson.Safe.t list
+      ; mention_user_ids : string list
       }
 
 val connector_post_replay_of_gate_input :
   Yojson.Safe.t -> (connector_post_replay, string) result
 (** Decode the exact durable connector request emitted by
     [handle_surface_post_with_outcome]. The original JSON value is retained
-    and used for one-shot Gate consumption; content and blocks are never
-    truncated or reconstructed for replay. *)
+    and used for one-shot Gate consumption; content, blocks, and the exact
+    validated mention allowlist are never truncated or reconstructed for
+    replay. *)
 
 val connector_post_replay_target :
   connector_post_replay -> Keeper_surface_post.post_target

--- a/lib/tool_surface/tool_shard_types_schemas_surface.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_surface.ml
@@ -3,8 +3,11 @@
 
 let keeper_surface_post_description =
   "Post a message to one conversation endpoint: 'dashboard' (appears \
-   in the operator's chat transcript) or 'discord' (sends to the bound \
-   channel). Posting to an unbound surface is an error. Both endpoints \
+   in the operator's chat transcript), 'discord', or 'slack'. Standard \
+   Markdown is rendered natively by Discord and by Slack's Block Kit \
+   markdown block. To create a real highlighted user mention, pass stable \
+   participant-roster ids in mention_user_ids; never guess ids from display \
+   names. Posting to an unbound surface is an error. These endpoints \
    are read by a person, so an unchanged status reposted every cycle \
    crowds their view and says nothing the previous one did not; when \
    there is nothing new, the turn ends without a post."
@@ -106,7 +109,8 @@ let surface_tools : Masc_domain.tool_schema list =
                   , `Assoc
                       [ "type", `String "string"
                       ; ( "description"
-                        , `String "Lane to post to: 'dashboard' or 'discord'" )
+                        , `String
+                            "Lane to post to: 'dashboard', 'discord', or 'slack'" )
                       ] )
                 ; ( "content"
                   , `Assoc
@@ -119,8 +123,17 @@ let surface_tools : Masc_domain.tool_schema list =
                       [ "type", `String "string"
                       ; ( "description"
                         , `String
-                            "Discord channel snowflake; required only when \
-                             more than one channel is bound" )
+                            "Bound Discord or Slack channel id; required only \
+                             when more than one channel is bound for the selected surface" )
+                      ] )
+                ; ( "mention_user_ids"
+                  , `Assoc
+                      [ "type", `String "array"
+                      ; "items", `Assoc [ "type", `String "string" ]
+                      ; "maxItems", `Int 100
+                      ; ( "description"
+                        , `String
+                            "Stable ids from keeper_surface_read participants to visibly mention. Slack requires U.../W... ids; Discord requires decimal user snowflakes. Display names such as @Vincent do not create API mentions." )
                       ] )
                 ] )
           ; "required", `List [ `String "surface"; `String "content" ]

--- a/test/test_channel_gate_discord_state.ml
+++ b/test/test_channel_gate_discord_state.ml
@@ -486,6 +486,42 @@ let test_thread_registry_round_trip () =
     (Discord_state.is_known_thread ~channel_id:thread_id);
   check int "count restored" before (Discord_state.registered_thread_count ())
 
+let test_large_mention_allowlist_keeps_tokens_whole () =
+  let user_ids =
+    List.init 100 (fun index -> Printf.sprintf "12345678901234%04d" index)
+  in
+  let messages =
+    Discord_state.For_testing.message_chunks_with_mentions
+      ~limit:2000
+      ~content:"body"
+      ~mention_user_ids:user_ids
+  in
+  check bool "large allowlist uses multiple messages" true
+    (List.length messages > 1);
+  check (list string) "every allowed id is retained exactly once" user_ids
+    (List.concat_map
+       (fun (message : Discord_state.For_testing.outbound_message) ->
+          message.allowed_user_mentions)
+       messages);
+  List.iter
+    (fun (message : Discord_state.For_testing.outbound_message) ->
+       check bool "message remains within Discord limit" true
+         (String.length message.content <= 2000);
+       List.iter
+         (fun user_id ->
+            check bool "allowed mention has a complete visible token" true
+              (String_util.contains_substring
+                 message.content
+                 (Printf.sprintf "<@%s>" user_id)))
+         message.allowed_user_mentions)
+    messages;
+  match List.rev messages with
+  | last :: _ ->
+    check string "content is delivered after mention groups" "body" last.content;
+    check (list string) "content does not reopen mentions" []
+      last.allowed_user_mentions
+  | [] -> fail "mention chunker produced no messages"
+
 let () =
   Eio_main.run @@ fun _env ->
   run "channel_gate_discord_state"
@@ -535,5 +571,10 @@ let () =
         [
           test_case "register lookup update unregister" `Quick
             test_thread_registry_round_trip;
+        ] );
+      ( "message_chunks",
+        [
+          test_case "large mention allowlist keeps tokens whole" `Quick
+            test_large_mention_allowlist_keeps_tokens_whole;
         ] );
     ]

--- a/test/test_discord_rest_client.ml
+++ b/test/test_discord_rest_client.ml
@@ -54,11 +54,29 @@ let test_build_request_body_is_content_object () =
   in
   let json = Yojson.Safe.from_string body in
   match json with
-  | `Assoc [ ("content", `String "hello \"world\"") ] -> ()
+  | `Assoc
+      [ ("content", `String "hello \"world\"")
+      ; ("allowed_mentions", `Assoc [ ("parse", `List []) ])
+      ] -> ()
   | _ ->
       failf
         "body shape wrong: %s"
         (Yojson.Safe.to_string json)
+
+let test_build_request_allows_only_explicit_users () =
+  let _, _, body =
+    R.build_request ~token:"t" ~channel_id:(sf "1")
+      ~content:"<@123> @everyone <@&456>"
+      ~allowed_user_mentions:[ sf "123" ] ()
+  in
+  let open Yojson.Safe.Util in
+  let allowed =
+    Yojson.Safe.from_string body |> member "allowed_mentions"
+  in
+  check (list string) "only explicit user snowflakes"
+    [ "123" ] (allowed |> member "users" |> to_list |> List.map to_string);
+  check bool "broad parse modes absent" true
+    (allowed |> member "parse" = `Null)
 
 let test_build_typing_request_url_targets_channel () =
   let url, _, body =
@@ -524,6 +542,8 @@ let () =
             test_build_request_user_agent_present
         ; test_case "body is { content: <content> } JSON" `Quick
             test_build_request_body_is_content_object
+        ; test_case "only explicit user mentions are allowed" `Quick
+            test_build_request_allows_only_explicit_users
         ; test_case "typing URL targets channel" `Quick
             test_build_typing_request_url_targets_channel
         ; test_case "typing Authorization uses Bot scheme" `Quick

--- a/test/test_keeper_chat_slack.ml
+++ b/test/test_keeper_chat_slack.ml
@@ -103,16 +103,20 @@ let test_limit_blocks_adds_visible_omission_notice () =
 
 (* ── content_blocks_of_text ─────────────────────────────────────── *)
 
-let test_content_blocks_empty_for_plain_text () =
-  let blocks = S.content_blocks_of_text "just plain text" in
-  check int "no blocks" 0 (List.length blocks)
+let test_content_blocks_use_native_markdown_for_plain_text () =
+  let blocks = S.content_blocks_of_text "**just plain text**" in
+  check int "one markdown block" 1 (List.length blocks);
+  let s = json_string (List.hd blocks) in
+  check bool "native markdown block" true (contains s "\"type\":\"markdown\"");
+  check bool "standard markdown stays intact" true
+    (contains s "**just plain text**")
 
 let test_content_blocks_detects_markdown_image () =
   let blocks =
     S.content_blocks_of_text "Hello ![alt text](https://example.com/img.png) world"
   in
-  check int "one block" 1 (List.length blocks);
-  let s = json_string (List.hd blocks) in
+  check int "markdown plus image block" 2 (List.length blocks);
+  let s = json_string (List.nth blocks 1) in
   check bool "type image" true (contains s "\"type\":\"image\"");
   check bool "image_url" true
     (contains s "\"image_url\":\"https://example.com/img.png\"");
@@ -120,8 +124,8 @@ let test_content_blocks_detects_markdown_image () =
 
 let test_content_blocks_detects_bare_image_url () =
   let blocks = S.content_blocks_of_text "https://example.com/photo.jpg" in
-  check int "one block" 1 (List.length blocks);
-  let s = json_string (List.hd blocks) in
+  check int "markdown plus image block" 2 (List.length blocks);
+  let s = json_string (List.nth blocks 1) in
   check bool "type image" true (contains s "\"type\":\"image\"");
   check bool "image_url" true
     (contains s "\"image_url\":\"https://example.com/photo.jpg\"")
@@ -130,8 +134,9 @@ let test_content_blocks_detects_link () =
   let blocks = S.content_blocks_of_text "https://example.com/page" in
   check int "one block" 1 (List.length blocks);
   let s = json_string (List.hd blocks) in
-  check bool "type section" true (contains s "\"type\":\"section\"");
-  check bool "link syntax" true (contains s "*<https://example.com/page|example.com>*")
+  check bool "type markdown" true (contains s "\"type\":\"markdown\"");
+  check bool "link retained for Slack translation" true
+    (contains s "https://example.com/page")
 
 let test_content_blocks_detects_code () =
   let blocks = S.content_blocks_of_text "```ocaml\nlet x = 1 + 2\n```" in
@@ -159,16 +164,18 @@ let test_content_blocks_redacts_text_derived_image_secrets () =
       (Printf.sprintf "![%s](https://example.com/diagram.png?token=%s)"
          secret secret)
   in
-  check int "one image block" 1 (List.length blocks);
-  let s = json_string (List.hd blocks) in
+  check int "markdown plus image block" 2 (List.length blocks);
+  let s = json_string (List.nth blocks 1) in
   check bool "raw secret removed" false (contains s secret);
   check bool "redaction marker present" true (contains s "[REDACTED]")
 
-let test_content_blocks_suppresses_credential_url () =
+let test_content_blocks_keeps_standard_markdown_contract_for_credential_url () =
   let blocks =
     S.content_blocks_of_text "https://user:pass@example.com/diagram.png"
   in
-  check int "credential URL does not become block" 0 (List.length blocks)
+  check int "no image block for credential URL" 1 (List.length blocks);
+  check bool "remaining block is markdown" true
+    (contains (json_string (List.hd blocks)) "\"type\":\"markdown\"")
 
 let test_final_message_blocks_merges_text_and_event_blocks () =
   let event_block =
@@ -180,13 +187,28 @@ let test_final_message_blocks_merges_text_and_event_blocks () =
       ~content:"https://example.com/photo.jpg"
       ~event_blocks:[ event_block ]
   in
-  check int "text block plus event block" 2 (List.length blocks);
+  check int "markdown, image, and event block" 3 (List.length blocks);
   let first = json_string (List.hd blocks) in
-  check bool "text-derived image first" true
-    (contains first "\"image_url\":\"https://example.com/photo.jpg\"");
-  let second = json_string (List.nth blocks 1) in
+  check bool "native markdown first" true
+    (contains first "\"type\":\"markdown\"");
+  let second = json_string (List.nth blocks 2) in
   check bool "event block preserved" true
     (contains second "https://event.example.com")
+
+let test_message_blocks_render_visible_stable_mentions () =
+  let blocks =
+    S.message_blocks_of_text ~mention_user_ids:[ "U060QL6SV1V" ]
+      "**PR report** raw <@U_UNTRUSTED>"
+  in
+  check int "mention plus markdown" 2 (List.length blocks);
+  let mention = json_string (List.hd blocks) in
+  check bool "Slack wire mention remains visible" true
+    (contains mention "<@U060QL6SV1V>");
+  let markdown = json_string (List.nth blocks 1) in
+  check bool "report uses native markdown" true
+    (contains markdown "**PR report**");
+  check bool "raw mention syntax is escaped" false
+    (contains markdown "<@U_UNTRUSTED>")
 
 let run_adapter ?post_stream ?edit_stream ?edit_blocks ?delete_stream ?now ?sleep
     ?set_activity_status events ~send_plain ~send_blocks =
@@ -244,8 +266,12 @@ let test_adapter_streams_one_edited_reply () =
     "rate-limited incremental edit"
     [ "hello world " ]
     (List.rev !stream_edits);
-  check int "unchanged terminal content skips duplicate edit" 0
-    (List.length !final_edits)
+  (match List.rev !final_edits with
+   | [ (content, [ block ]) ] ->
+     check string "final rich edit keeps complete text" "hello world " content;
+     check bool "final rich edit adds native markdown" true
+       (contains (json_string block) "\"type\":\"markdown\"")
+   | _ -> fail "streamed reply must receive one terminal rich edit")
 ;;
 
 let test_adapter_stream_error_edits_accepted_reply () =
@@ -386,6 +412,7 @@ let test_terminal_edit_waits_for_slack_interval () =
   let clock = ref 0.0 in
   let sleeps = ref [] in
   let edits = ref [] in
+  let final_edits = ref [] in
   let outcomes =
     run_adapter
       ~now:(fun () -> !clock)
@@ -396,8 +423,9 @@ let test_terminal_edit_waits_for_slack_interval () =
       ~edit_stream:(fun ~message_id ~content ->
         edits := (message_id, content) :: !edits;
         Ok ())
-      ~edit_blocks:(fun ~message_id:_ ~content:_ ~blocks:_ ->
-        fail "unchanged terminal content must not be edited twice")
+      ~edit_blocks:(fun ~message_id ~content ~blocks ->
+        final_edits := (message_id, content, blocks) :: !final_edits;
+        Ok ())
       ~delete_stream:(fun ~message_id:_ ->
         fail "successful streaming reply must not be deleted")
       [ Masc.Keeper_chat_events.Text_delta "hello "
@@ -410,9 +438,16 @@ let test_terminal_edit_waits_for_slack_interval () =
         fail "streaming success must not create a second message")
   in
   check (list (float 0.0001)) "terminal edit sleeps for remaining interval"
-    [ 3.0 ] (List.rev !sleeps);
+    [ 3.0; 3.0 ] (List.rev !sleeps);
   check (list (pair string string)) "terminal edit uses accepted message"
     [ "slack-paced", "hello world" ] (List.rev !edits);
+  (match List.rev !final_edits with
+   | [ (message_id, content, [ block ]) ] ->
+     check string "rich edit keeps accepted message" "slack-paced" message_id;
+     check string "rich edit keeps complete content" "hello world" content;
+     check bool "rich edit carries markdown block" true
+       (contains (json_string block) "\"type\":\"markdown\"")
+   | _ -> fail "terminal delivery must add one rich edit");
   check bool "paced delivery settles successfully" true (outcomes = [ Ok () ])
 
 let test_adapter_external_effect_status_is_terminal_success () =
@@ -497,7 +532,7 @@ let test_native_activity_failure_does_not_affect_delivery () =
         Ok ())
   in
   check (list string) "typed activity lifecycle"
-    [ "답변을 준비하고 있어요…"; "필요한 작업을 진행하고 있어요…"; "" ]
+    [ "답변을 준비하고 있어요…"; "🔧 keeper_surface_post 사용 중…"; "" ]
     (List.rev !statuses);
   check (list string) "tool context is not exposed" [ "final" ]
     (List.rev !sends);
@@ -528,8 +563,8 @@ let () =
             test_limit_blocks_adds_visible_omission_notice
         ] )
     ; ( "content-blocks"
-      , [ test_case "empty for plain text" `Quick
-            test_content_blocks_empty_for_plain_text
+      , [ test_case "plain text uses native markdown" `Quick
+            test_content_blocks_use_native_markdown_for_plain_text
         ; test_case "detects markdown image" `Quick
             test_content_blocks_detects_markdown_image
         ; test_case "detects code fences" `Quick
@@ -542,10 +577,12 @@ let () =
         ; test_case "mixed content" `Quick test_content_blocks_mixed_content
         ; test_case "redacts text-derived image secrets" `Quick
             test_content_blocks_redacts_text_derived_image_secrets
-        ; test_case "suppresses credential URL blocks" `Quick
-            test_content_blocks_suppresses_credential_url
+        ; test_case "credential URL gets no image block" `Quick
+            test_content_blocks_keeps_standard_markdown_contract_for_credential_url
         ; test_case "final delivery merges text and event blocks" `Quick
             test_final_message_blocks_merges_text_and_event_blocks
+        ; test_case "stable mentions are visible" `Quick
+            test_message_blocks_render_visible_stable_mentions
         ] )
     ; ( "terminal-receipt"
       , [ test_case "terminal success settles once" `Quick

--- a/test/test_keeper_chat_slack.ml
+++ b/test/test_keeper_chat_slack.ml
@@ -104,12 +104,17 @@ let test_limit_blocks_adds_visible_omission_notice () =
 (* ── content_blocks_of_text ─────────────────────────────────────── *)
 
 let test_content_blocks_use_native_markdown_for_plain_text () =
-  let blocks = S.content_blocks_of_text "**just plain text**" in
+  let blocks = S.content_blocks_of_text "> quoted\n\n**just plain text**\n<@U123> <!channel>" in
   check int "one markdown block" 1 (List.length blocks);
   let s = json_string (List.hd blocks) in
   check bool "native markdown block" true (contains s "\"type\":\"markdown\"");
   check bool "standard markdown stays intact" true
-    (contains s "**just plain text**")
+    (contains s "**just plain text**");
+  check bool "blockquote marker stays intact" true (contains s "> quoted");
+  check bool "raw user mention is suppressed" false (contains s "<@U123>");
+  check bool "raw broadcast mention is suppressed" false (contains s "<!channel>");
+  check bool "user mention is escaped" true (contains s "&lt;@U123>");
+  check bool "broadcast mention is escaped" true (contains s "&lt;!channel>")
 
 let test_content_blocks_detects_markdown_image () =
   let blocks =

--- a/test/test_keeper_gate_replay.ml
+++ b/test/test_keeper_gate_replay.ml
@@ -721,6 +721,7 @@ let test_large_connector_post_preserves_exact_durable_request () =
       ; "channel_id", `String "C-exact"
       ; "content", `String content
       ; "blocks", `List blocks
+      ; "mention_user_ids", `List [ `String "U123ABC" ]
       ]
   in
   match
@@ -734,6 +735,7 @@ let test_large_connector_post_preserves_exact_durable_request () =
          ; thread_ts
          ; content = decoded_content
          ; blocks = decoded_blocks
+         ; mention_user_ids
          }) ->
     Alcotest.check json "exact durable request retained" input decoded_input;
     Alcotest.check Alcotest.string "channel retained" "C-exact" channel_id;
@@ -747,7 +749,9 @@ let test_large_connector_post_preserves_exact_durable_request () =
       (Alcotest.list json)
       "large blocks retained"
       blocks
-      decoded_blocks
+      decoded_blocks;
+    Alcotest.check (Alcotest.list Alcotest.string) "mention ids retained"
+      [ "U123ABC" ] mention_user_ids
   | Ok (Replay_discord_post _) ->
     Alcotest.fail "Slack request decoded as Discord"
   | Error detail -> Alcotest.fail detail
@@ -762,6 +766,7 @@ let test_slack_connector_post_retains_thread_ts () =
       ; "thread_ts", `String "1700000000.000100"
       ; "content", `String "threaded reply"
       ; "blocks", `List []
+      ; "mention_user_ids", `List []
       ]
   in
   match
@@ -787,6 +792,7 @@ let test_connector_post_replay_retains_terminal_target () =
       [ "connector", `String "discord"
       ; "channel_id", `String "D-exact"
       ; "content", `String "approved reply"
+      ; "mention_user_ids", `List []
       ]
   in
   match connector_post_replay_of_gate_input input with
@@ -819,6 +825,12 @@ let test_connector_post_rejects_heuristic_or_truncated_input () =
         [ "connector", `String "slack"
         ; "channel_id", `String "C-exact"
         ; "content", `String "missing exact blocks"
+        ]
+    ; `Assoc
+        [ "connector", `String "discord"
+        ; "channel_id", `String "D-exact"
+        ; "content", `String "exact"
+        ; "mention_user_ids", `List [ `String "123"; `String "123" ]
         ]
     ; `Assoc
         [ "connector", `String "discord"

--- a/test/test_keeper_gate_replay.ml
+++ b/test/test_keeper_gate_replay.ml
@@ -810,6 +810,25 @@ let test_connector_post_replay_retains_terminal_target () =
   | Error detail -> Alcotest.fail detail
 ;;
 
+let test_connector_post_replay_defaults_legacy_mentions () =
+  let open Masc.Keeper_tool_in_process_runtime in
+  let input =
+    `Assoc
+      [ "connector", `String "discord"
+      ; "channel_id", `String "D-before-mentions"
+      ; "content", `String "already approved"
+      ]
+  in
+  match connector_post_replay_of_gate_input input with
+  | Ok (Replay_discord_post { mention_user_ids; input = decoded_input; _ }) ->
+    Alcotest.check (Alcotest.list Alcotest.string)
+      "missing legacy field means no mentions" [] mention_user_ids;
+    Alcotest.check json "durable input is not rewritten" input decoded_input
+  | Ok (Replay_slack_post _) ->
+    Alcotest.fail "Discord request decoded as Slack"
+  | Error detail -> Alcotest.fail detail
+;;
+
 let test_connector_post_rejects_heuristic_or_truncated_input () =
   List.iter
     (fun input ->
@@ -952,6 +971,10 @@ let () =
             "connector replay retains terminal target"
             `Quick
             test_connector_post_replay_retains_terminal_target
+        ; Alcotest.test_case
+            "legacy connector replay defaults missing mentions"
+            `Quick
+            test_connector_post_replay_defaults_legacy_mentions
         ; Alcotest.test_case
             "memory write replay keeps exact input"
             `Quick

--- a/test/test_keeper_surface_post.ml
+++ b/test/test_keeper_surface_post.ml
@@ -486,6 +486,92 @@ let test_dashboard_rejects_nonempty_mentions () =
   | Error _ -> ()
   | Ok _ -> fail "dashboard accepted connector mention ids"
 
+let roster_message ~surface ~speaker_id : Store.chat_message =
+  { id = "roster-message"
+  ; role = Store.Role.User
+  ; content = "hello"
+  ; ts = Some 1.0
+  ; attachments = None
+  ; tool_call_id = None
+  ; tool_call_name = None
+  ; surface = Some surface
+  ; conversation_id = None
+  ; external_message_id = None
+  ; workspace_id = None
+  ; speaker =
+      Some
+        { Store.speaker_id = Some speaker_id
+        ; speaker_name = None
+        ; speaker_authority = Store.External
+        }
+  ; audio = None
+  ; blocks = None
+  ; mentions = []
+  ; kind = Store.Row_kind.Utterance
+  ; turn_ref = None
+  ; stream_lifecycle = None
+  ; delivery_key = None
+  }
+
+let test_mentions_require_exact_resolved_target_roster () =
+  let messages =
+    [ roster_message
+        ~surface:
+          (Masc.Surface_ref.Discord
+             { guild_id = None
+             ; channel_id = "D-current"
+             ; parent_channel_id = None
+             ; thread_id = None
+             })
+        ~speaker_id:"1234567890"
+    ; roster_message
+        ~surface:
+          (Masc.Surface_ref.Discord
+             { guild_id = None
+             ; channel_id = "D-other"
+             ; parent_channel_id = None
+             ; thread_id = None
+             })
+        ~speaker_id:"9999999999"
+    ; roster_message
+        ~surface:
+          (Masc.Surface_ref.Slack
+             { team_id = None
+             ; channel_id = "C-current"
+             ; thread_ts = Some "thread-other"
+             })
+        ~speaker_id:"UOTHER"
+    ]
+  in
+  check (result unit string) "current Discord participant is allowed" (Ok ())
+    (SP.validate_user_mentions_against_roster
+       ~target:(SP.To_discord { channel_id = "D-current" })
+       ~messages
+       [ "1234567890" ]);
+  (match
+     SP.validate_user_mentions_against_roster
+       ~target:(SP.To_discord { channel_id = "D-current" })
+       ~messages
+       [ "9999999999" ]
+   with
+   | Error message ->
+     check bool "cross-channel id is named" true
+       (Astring.String.is_infix ~affix:"9999999999" message)
+   | Ok () -> fail "cross-channel Discord participant was mentionable");
+  match
+    SP.validate_user_mentions_against_roster
+      ~target:
+        (SP.To_slack
+           { channel_id = "C-current"
+           ; thread_ts = Some "thread-current"
+           ; blocks = None
+           })
+      ~messages
+      [ "UOTHER" ]
+  with
+  | Error _ -> ()
+  | Ok () -> fail "participant from another Slack thread was mentionable"
+
 let () =
   run "keeper_surface_post"
     [
@@ -536,6 +622,8 @@ let () =
             test_discord_mentions_reject_broad_or_named_targets
         ; test_case "dashboard rejects connector mentions" `Quick
             test_dashboard_rejects_nonempty_mentions
+        ; test_case "requires exact resolved target roster" `Quick
+            test_mentions_require_exact_resolved_target_roster
         ] );
       ( "terminal receipt",
         [

--- a/test/test_keeper_surface_post.ml
+++ b/test/test_keeper_surface_post.ml
@@ -444,6 +444,48 @@ let test_assistant_message_persists_with_typed_surface () =
         (Option.map Masc.Surface_ref.lane_label m.Store.surface);
       check bool "no speaker on keeper output" true (m.Store.speaker = None))
 
+let test_slack_mentions_require_stable_ids () =
+  let args =
+    `Assoc
+      [ "mention_user_ids"
+      , `List [ `String "U060QL6SV1V"; `String "W123ABC"; `String "U060QL6SV1V" ]
+      ]
+  in
+  check (result (list string) string) "deduplicated stable ids"
+    (Ok [ "U060QL6SV1V"; "W123ABC" ])
+    (SP.user_mentions_of_args ~surface:"slack" args);
+  match
+    SP.user_mentions_of_args ~surface:"slack"
+      (`Assoc [ "mention_user_ids", `List [ `String "Vincent" ] ])
+  with
+  | Error message ->
+    check bool "error points to participant ids" true
+      (Astring.String.is_infix ~affix:"participant roster" message)
+  | Ok _ -> fail "Slack display name became a mention id"
+
+let test_discord_mentions_reject_broad_or_named_targets () =
+  check (result (list string) string) "decimal snowflakes"
+    (Ok [ "1234567890" ])
+    (SP.user_mentions_of_args ~surface:"discord"
+       (`Assoc [ "mention_user_ids", `List [ `String "1234567890" ] ]));
+  List.iter
+    (fun value ->
+       match
+         SP.user_mentions_of_args ~surface:"discord"
+           (`Assoc [ "mention_user_ids", `List [ `String value ] ])
+       with
+       | Error _ -> ()
+       | Ok _ -> failf "Discord accepted unsafe mention target %S" value)
+    [ "@everyone"; "Vincent"; "<@123>" ]
+
+let test_dashboard_rejects_nonempty_mentions () =
+  match
+    SP.user_mentions_of_args ~surface:"dashboard"
+      (`Assoc [ "mention_user_ids", `List [ `String "U123" ] ])
+  with
+  | Error _ -> ()
+  | Ok _ -> fail "dashboard accepted connector mention ids"
+
 let () =
   run "keeper_surface_post"
     [
@@ -486,6 +528,14 @@ let () =
             test_set_blocks_attaches_to_slack;
           test_case "ignores non-slack targets" `Quick
             test_set_blocks_ignores_other_targets;
+        ] );
+      ( "mentions",
+        [ test_case "Slack uses stable ids" `Quick
+            test_slack_mentions_require_stable_ids
+        ; test_case "Discord rejects named or broad targets" `Quick
+            test_discord_mentions_reject_broad_or_named_targets
+        ; test_case "dashboard rejects connector mentions" `Quick
+            test_dashboard_rejects_nonempty_mentions
         ] );
       ( "terminal receipt",
         [

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -2692,6 +2692,7 @@ let test_durable_connector_replay_settles_terminal_turn () =
            [ "connector", `String "discord"
            ; "channel_id", `String "D-approved"
            ; "content", `String "approved reply already delivered"
+           ; "mention_user_ids", `List []
            ]
        in
        let approval_id =


### PR DESCRIPTION
## Summary

- render Keeper Slack replies with Block Kit `markdown` blocks so LLM-authored standard Markdown is displayed correctly
- add typed `mention_user_ids` using stable Slack/Discord roster IDs and preserve the exact allowlist through durable Gate replay
- fail closed Discord `allowed_mentions` and show the active Slack tool name through the native assistant thread status

## Official API basis

- Slack Markdown block: https://docs.slack.dev/reference/block-kit/blocks/markdown-block/
- Slack mentions: https://docs.slack.dev/messaging/formatting-message-text/#mentioning-users
- Slack assistant thread status: https://docs.slack.dev/reference/methods/assistant.threads.setStatus/
- Discord allowed mentions: https://docs.discord.com/developers/resources/message#allowed-mentions-object
- Discord Components V2 is intentionally not used here because it disables the traditional `content` and `embeds` fields: https://docs.discord.com/developers/components/overview

## Validation

- focused builds via `scripts/dune-local.sh build` for all nine affected test executables
- 266 focused tests passed across surface validation, Slack rendering, Discord REST/state, Gate replay, descriptors, and Keeper runtime dispatch
- `ocamlformat --check` passed for all 17 touched OCaml files
- `git diff --check` passed

## Live scope

- no Slack or Discord message was sent during validation
- no Keeper process was restarted or deployed
