### PR TITLE
feat(dashboard): open exact schedule routes

### DIFF
--- a/dashboard/src/api/dashboard-scheduled-automation.test.ts
+++ b/dashboard/src/api/dashboard-scheduled-automation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, afterEach } from 'vitest'
 import {
+  decodeScheduledAutomationLookup,
   fetchDashboardScheduledAutomation,
   normalizeScheduledAutomation,
 } from './dashboard-scheduled-automation'
@@ -115,6 +116,60 @@ describe('normalizeScheduledAutomation', () => {
     })
 
     expect(normalized.state).toBe('unavailable')
+  })
+})
+
+describe('decodeScheduledAutomationLookup', () => {
+  it('accepts the owner envelope and keeps the exact request identity', () => {
+    const decoded = decodeScheduledAutomationLookup({
+      schema: 'masc.dashboard.scheduled_automation.lookup.v1',
+      source: 'schedule_store',
+      generated_at: '2026-08-14T00:00:00Z',
+      status: 'found',
+      schedule_id: 'sched-exact',
+      request: {
+        schedule_id: 'sched-exact',
+        status: 'due',
+        source: 'operator_request',
+        payload_kind: 'keeper.review',
+      },
+    }, 'sched-exact')
+
+    expect(decoded).toEqual({
+      status: 'found',
+      scheduleId: 'sched-exact',
+      request: {
+        schedule_id: 'sched-exact',
+        status: 'due',
+        source: 'operator_request',
+        payload_kind: 'keeper.review',
+      },
+    })
+  })
+
+  it('rejects a request row that does not belong to the requested identity', () => {
+    expect(() => decodeScheduledAutomationLookup({
+      schema: 'masc.dashboard.scheduled_automation.lookup.v1',
+      source: 'schedule_store',
+      generated_at: '2026-08-14T00:00:00Z',
+      status: 'found',
+      schedule_id: 'sched-exact',
+      request: {
+        schedule_id: 'sched-other',
+        status: 'due',
+        source: 'operator_request',
+      },
+    }, 'sched-exact')).toThrow('request identity mismatch')
+  })
+
+  it('rejects an envelope returned for a different route identity', () => {
+    expect(() => decodeScheduledAutomationLookup({
+      schema: 'masc.dashboard.scheduled_automation.lookup.v1',
+      source: 'schedule_store',
+      generated_at: '2026-08-14T00:00:00Z',
+      status: 'not_found',
+      schedule_id: 'sched-other',
+    }, 'sched-exact')).toThrow('envelope identity mismatch')
   })
 })
 

--- a/dashboard/src/api/dashboard-scheduled-automation.ts
+++ b/dashboard/src/api/dashboard-scheduled-automation.ts
@@ -120,6 +120,7 @@ function parseLookupRequest(
 
 export function decodeScheduledAutomationLookup(
   raw: unknown,
+  expectedScheduleId: string,
 ): DashboardScheduledAutomationLookup {
   const record = asRecord(raw)
   if (!record) throw new Error('Invalid scheduled-automation lookup response: envelope must be an object')
@@ -134,6 +135,9 @@ export function decodeScheduledAutomationLookup(
     throw new Error('Invalid scheduled-automation lookup response: invalid generated_at or schedule_id')
   }
   const scheduleId = record.schedule_id
+  if (scheduleId !== expectedScheduleId) {
+    throw new Error('Invalid scheduled-automation lookup response: envelope identity mismatch')
+  }
   switch (record.status) {
     case 'found':
       exactFields(record, ['schema', 'source', 'generated_at', 'status', 'schedule_id', 'request'], 'envelope')
@@ -311,5 +315,5 @@ export async function fetchDashboardScheduledAutomationLookup(
   const raw = await get<unknown>(`/api/v1/dashboard/scheduled-automation?${query}`, {
     signal: opts?.signal,
   })
-  return decodeScheduledAutomationLookup(raw)
+  return decodeScheduledAutomationLookup(raw, scheduleId)
 }

--- a/dashboard/src/api/dashboard-scheduled-automation.ts
+++ b/dashboard/src/api/dashboard-scheduled-automation.ts
@@ -10,7 +10,16 @@ import { ensureDevToken } from './dev-token'
 import type {
   DashboardScheduledAutomation,
   DashboardScheduledAutomationFsm,
+  DashboardScheduledAutomationRequest,
 } from './dashboard-tools-prompts'
+
+const SCHEDULE_LOOKUP_SCHEMA = 'masc.dashboard.scheduled_automation.lookup.v1'
+
+export type DashboardScheduledAutomationLookup =
+  | { status: 'found'; scheduleId: string; request: DashboardScheduledAutomationRequest }
+  | { status: 'not_found'; scheduleId: string }
+  | { status: 'unavailable'; scheduleId: string; reason: string }
+  | { status: 'invalid_id'; scheduleId: string; reason: string }
 
 export interface DashboardScheduledAutomationPage {
   /** Rows materialized in this response. */
@@ -66,6 +75,87 @@ function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : null
+}
+
+function exactFields(
+  record: Record<string, unknown>,
+  required: readonly string[],
+  context: string,
+): void {
+  const expected = new Set(required)
+  const missing = required.filter(field => !(field in record))
+  const unknown = Object.keys(record).filter(field => !expected.has(field))
+  if (missing.length > 0 || unknown.length > 0) {
+    throw new Error(
+      `${context} fields mismatch (missing=[${missing.join(',')}], unknown=[${unknown.join(',')}])`,
+    )
+  }
+}
+
+function parseLookupRequest(
+  value: unknown,
+  expectedScheduleId: string,
+): DashboardScheduledAutomationRequest {
+  const request = asRecord(value)
+  if (!request || request.schedule_id !== expectedScheduleId) {
+    throw new Error('Invalid scheduled-automation lookup response: request identity mismatch')
+  }
+  switch (request.status) {
+    case 'scheduled':
+    case 'due':
+    case 'running':
+    case 'succeeded':
+    case 'failed':
+    case 'cancelled':
+    case 'expired':
+      break
+    default:
+      throw new Error('Invalid scheduled-automation lookup response: invalid request status')
+  }
+  if (typeof request.source !== 'string' || request.source.trim() === '') {
+    throw new Error('Invalid scheduled-automation lookup response: invalid request source')
+  }
+  return request as unknown as DashboardScheduledAutomationRequest
+}
+
+export function decodeScheduledAutomationLookup(
+  raw: unknown,
+): DashboardScheduledAutomationLookup {
+  const record = asRecord(raw)
+  if (!record) throw new Error('Invalid scheduled-automation lookup response: envelope must be an object')
+  if (record.schema !== SCHEDULE_LOOKUP_SCHEMA || record.source !== 'schedule_store') {
+    throw new Error('Invalid scheduled-automation lookup response: unsupported schema or source')
+  }
+  if (
+    typeof record.generated_at !== 'string'
+    || record.generated_at.trim() === ''
+    || typeof record.schedule_id !== 'string'
+  ) {
+    throw new Error('Invalid scheduled-automation lookup response: invalid generated_at or schedule_id')
+  }
+  const scheduleId = record.schedule_id
+  switch (record.status) {
+    case 'found':
+      exactFields(record, ['schema', 'source', 'generated_at', 'status', 'schedule_id', 'request'], 'envelope')
+      return { status: 'found', scheduleId, request: parseLookupRequest(record.request, scheduleId) }
+    case 'not_found':
+      exactFields(record, ['schema', 'source', 'generated_at', 'status', 'schedule_id'], 'envelope')
+      return { status: 'not_found', scheduleId }
+    case 'unavailable':
+      exactFields(record, ['schema', 'source', 'generated_at', 'status', 'schedule_id', 'reason'], 'envelope')
+      if (typeof record.reason !== 'string' || record.reason.trim() === '') {
+        throw new Error('Invalid scheduled-automation lookup response: invalid reason')
+      }
+      return { status: 'unavailable', scheduleId, reason: record.reason }
+    case 'invalid_id':
+      exactFields(record, ['schema', 'source', 'generated_at', 'status', 'schedule_id', 'reason'], 'envelope')
+      if (typeof record.reason !== 'string' || record.reason.trim() === '') {
+        throw new Error('Invalid scheduled-automation lookup response: invalid reason')
+      }
+      return { status: 'invalid_id', scheduleId, reason: record.reason }
+    default:
+      throw new Error(`Invalid scheduled-automation lookup response: unknown status ${JSON.stringify(record.status)}`)
+  }
 }
 
 /** A count the server reported, or null when it reported none.
@@ -210,4 +300,16 @@ export async function fetchDashboardScheduledAutomation(
     signal: opts?.signal,
   })
   return normalizeScheduledAutomation(raw)
+}
+
+export async function fetchDashboardScheduledAutomationLookup(
+  scheduleId: string,
+  opts?: AbortableRequestOptions,
+): Promise<DashboardScheduledAutomationLookup> {
+  await ensureDevToken()
+  const query = new URLSearchParams({ schedule_id: scheduleId })
+  const raw = await get<unknown>(`/api/v1/dashboard/scheduled-automation?${query}`, {
+    signal: opts?.signal,
+  })
+  return decodeScheduledAutomationLookup(raw)
 }

--- a/dashboard/src/components/schedule/schedule-surface.test.ts
+++ b/dashboard/src/components/schedule/schedule-surface.test.ts
@@ -6,6 +6,7 @@ import type {
   DashboardKeeperWaitingInventory,
   DashboardScheduledAutomationAvailableData,
   DashboardScheduledAutomationProjection,
+  DashboardScheduledAutomationRequest,
 } from '../../api'
 
 type MockToolsResponse = {
@@ -26,6 +27,15 @@ const mocks = vi.hoisted(() => ({
   scheduledAutomationError: { value: null as string | null },
   subscribeScheduledAutomationRefresh: vi.fn(() => () => {}),
   pruneSchedules: vi.fn(),
+  fetchScheduledAutomationLookup: vi.fn(),
+  replaceRoute: vi.fn(),
+  route: {
+    value: {
+      tab: 'schedule',
+      params: {} as Record<string, string>,
+      postId: null,
+    },
+  },
 }))
 
 vi.mock('../tools/tool-state', () => ({
@@ -44,6 +54,21 @@ vi.mock('./schedule-state', () => ({
 
 vi.mock('../../api/dashboard-schedule', () => ({
   pruneSchedules: mocks.pruneSchedules,
+}))
+
+vi.mock('../../api/dashboard-scheduled-automation', async () => {
+  const actual = await vi.importActual<typeof import('../../api/dashboard-scheduled-automation')>(
+    '../../api/dashboard-scheduled-automation',
+  )
+  return {
+    ...actual,
+    fetchDashboardScheduledAutomationLookup: mocks.fetchScheduledAutomationLookup,
+  }
+})
+
+vi.mock('../../router', () => ({
+  route: mocks.route,
+  replaceRoute: mocks.replaceRoute,
 }))
 
 import { ScheduleSurface } from './schedule-surface'
@@ -198,6 +223,9 @@ describe('ScheduleSurface', () => {
     mocks.scheduledAutomationProjection.value = null
     mocks.scheduledAutomationLoading.value = false
     mocks.scheduledAutomationError.value = null
+    mocks.fetchScheduledAutomationLookup.mockReset()
+    mocks.replaceRoute.mockReset()
+    mocks.route.value = { tab: 'schedule', params: {}, postId: null }
   })
 
   afterEach(() => {
@@ -516,5 +544,53 @@ describe('ScheduleSurface', () => {
     // Only the interval schedule survives the 폴링 cadence filter in the list.
     expect(container.querySelector('[data-schedule-id="sched-interval"]')).not.toBeNull()
     expect(container.querySelector('[data-schedule-id="sched-oneshot"]')).toBeNull()
+  })
+
+  it('opens an exact route that is outside the truncated aggregate page', async () => {
+    const exactRequest: DashboardScheduledAutomationRequest = {
+      ...sampleAutomation().requests[0]!,
+      schedule_id: 'sched-outside-page',
+      payload_summary: 'Exact route payload',
+    }
+    setAutomation(sampleAutomation())
+    mocks.route.value = {
+      tab: 'schedule',
+      params: { schedule_id: exactRequest.schedule_id, view: 'calendar' },
+      postId: null,
+    }
+    mocks.fetchScheduledAutomationLookup.mockResolvedValue({
+      status: 'found',
+      scheduleId: exactRequest.schedule_id,
+      request: exactRequest,
+    })
+
+    render(html`<${ScheduleSurface} />`, container)
+    await flush()
+
+    expect(mocks.fetchScheduledAutomationLookup).toHaveBeenCalledWith(
+      exactRequest.schedule_id,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+    expect(container.querySelector(
+      '[data-schedule-detail-panel="sched-outside-page"]',
+    )?.textContent).toContain('Exact route payload')
+
+    container.querySelector<HTMLButtonElement>('.turn-close')?.click()
+    expect(mocks.replaceRoute).toHaveBeenCalledWith('schedule', { view: 'calendar' })
+  })
+
+  it('uses an in-page route row without issuing a redundant exact lookup', async () => {
+    setAutomation(sampleAutomation())
+    mocks.route.value = {
+      tab: 'schedule',
+      params: { schedule_id: 'sched-1' },
+      postId: null,
+    }
+
+    render(html`<${ScheduleSurface} />`, container)
+    await flush()
+
+    expect(mocks.fetchScheduledAutomationLookup).not.toHaveBeenCalled()
+    expect(container.querySelector('[data-schedule-detail-panel="sched-1"]')).not.toBeNull()
   })
 })

--- a/dashboard/src/components/schedule/schedule-surface.ts
+++ b/dashboard/src/components/schedule/schedule-surface.ts
@@ -14,6 +14,11 @@
 import { html } from 'htm/preact'
 import { useEffect, useState } from 'preact/hooks'
 import type { DashboardScheduledAutomation } from '../../api'
+import {
+  fetchDashboardScheduledAutomationLookup,
+  type DashboardScheduledAutomationLookup,
+} from '../../api/dashboard-scheduled-automation'
+import { replaceRoute, route } from '../../router'
 import { ErrorState, LoadingState } from '../common/feedback-state'
 import { ActionButton } from '../common/button'
 import { StatusChip } from '../common/status-chip'
@@ -43,6 +48,12 @@ import {
 import { pruneSchedules } from '../../api/dashboard-schedule'
 
 type ScheduleView = 'calendar' | 'list'
+
+type ExactScheduleState =
+  | { kind: 'idle' }
+  | { kind: 'loading'; scheduleId: string }
+  | { kind: 'resolved'; lookup: DashboardScheduledAutomationLookup }
+  | { kind: 'failed'; scheduleId: string; reason: string }
 
 function countLabel(count: number | null): string {
   return count === null ? '—' : count.toLocaleString()
@@ -97,6 +108,10 @@ export function ScheduleSurface() {
     ? null
     : dueCount + runningCount
   const requests = automation?.requests ?? []
+  const routeScheduleId = route.value.params.schedule_id ?? null
+  const inPageRequest = routeScheduleId === null
+    ? null
+    : requests.find(request => request.schedule_id === routeScheduleId) ?? null
   const totalCount = page?.totalCount ?? null
   const cadCounts = cadenceCounts(requests)
   // Scheduled keeper wakes that were dispatched but are in neither queue AND
@@ -106,9 +121,8 @@ export function ScheduleSurface() {
   const [view, setView] = useState<ScheduleView>('calendar')
   const [cadenceFilter, setCadenceFilter] = useState<Cadence | null>(null)
   const [pruning, setPruning] = useState(false)
-  // Detail-overlay selection is lifted here so the calendar view, the list
-  // panel, and the operations aside all drive the same overlay.
-  const [selectedScheduleId, setSelectedScheduleId] = useState<string | null>(null)
+  const selectedScheduleId = routeScheduleId
+  const [exactSchedule, setExactSchedule] = useState<ExactScheduleState>({ kind: 'idle' })
   // Keeper-lane wake evidence + background are large operator diagnostics
   // (a card per keeper, dozens of lane rows). Collapsed AND unmounted by default
   // so the schedule stays the light, primary content; the panels only mount when
@@ -122,10 +136,43 @@ export function ScheduleSurface() {
     return stopScheduleRefresh
   }, [])
 
+  useEffect(() => {
+    if (
+      selectedScheduleId === null
+      || projection?.state !== 'available'
+      || inPageRequest !== null
+    ) {
+      setExactSchedule({ kind: 'idle' })
+      return
+    }
+    const controller = new AbortController()
+    setExactSchedule({ kind: 'loading', scheduleId: selectedScheduleId })
+    void fetchDashboardScheduledAutomationLookup(selectedScheduleId, {
+      signal: controller.signal,
+    })
+      .then(lookup => { setExactSchedule({ kind: 'resolved', lookup }) })
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) return
+        setExactSchedule({
+          kind: 'failed',
+          scheduleId: selectedScheduleId,
+          reason: error instanceof Error ? error.message : String(error),
+        })
+      })
+    return () => { controller.abort() }
+  }, [selectedScheduleId, projection?.state, inPageRequest !== null])
+
+  function selectSchedule(scheduleId: string | null) {
+    const params = { ...route.value.params }
+    if (scheduleId === null) delete params.schedule_id
+    else params.schedule_id = scheduleId
+    replaceRoute('schedule', params)
+  }
+
   function switchView(next: ScheduleView) {
     // Clear selection so a drawer opened in one view does not linger into the
     // other (the list panel renders its own overlay from the same id).
-    setSelectedScheduleId(null)
+    selectSchedule(null)
     setView(next)
   }
 
@@ -152,10 +199,33 @@ export function ScheduleSurface() {
   }
   // In the calendar view the list panel is unmounted, so the surface owns the
   // overlay; the list panel renders its own overlay from the same selection.
-  const selectedRequest =
-    view === 'calendar' && selectedScheduleId
-      ? requests.find(request => request.schedule_id === selectedScheduleId) ?? null
+  const exactRequest =
+    exactSchedule.kind === 'resolved'
+    && exactSchedule.lookup.status === 'found'
+    && exactSchedule.lookup.scheduleId === selectedScheduleId
+      ? exactSchedule.lookup.request
       : null
+  const selectedRequest =
+    view === 'calendar' && selectedScheduleId !== null
+      ? inPageRequest ?? exactRequest
+      : null
+  const exactLookupMessage = (() => {
+    if (selectedScheduleId === null) return null
+    if (exactSchedule.kind === 'loading' && exactSchedule.scheduleId === selectedScheduleId) {
+      return '정확한 예약을 조회하는 중입니다.'
+    }
+    if (exactSchedule.kind === 'failed' && exactSchedule.scheduleId === selectedScheduleId) {
+      return exactSchedule.reason
+    }
+    if (
+      exactSchedule.kind !== 'resolved'
+      || exactSchedule.lookup.scheduleId !== selectedScheduleId
+      || exactSchedule.lookup.status === 'found'
+    ) return null
+    return exactSchedule.lookup.status === 'not_found'
+      ? 'schedule store에서 정확한 예약을 찾지 못했습니다.'
+      : exactSchedule.lookup.reason
+  })()
 
   return html`
     <main class="ov ov-2col sch-surf" data-screen-label="예약" data-testid="schedule-surface">
@@ -216,6 +286,14 @@ export function ScheduleSurface() {
             `
           : null}
 
+        ${exactLookupMessage
+          ? html`
+              <div class="ov-card mb-3 text-xs text-[var(--color-fg-muted)]" data-testid="schedule-exact-lookup-status">
+                <span class="mono">${selectedScheduleId}</span> · ${exactLookupMessage}
+              </div>
+            `
+          : null}
+
         ${blockingError
           ? html`
               <div class="ov-card mb-4 text-sm text-[var(--color-fg-muted)]" data-testid="schedule-ledger-unknown">
@@ -253,13 +331,14 @@ export function ScheduleSurface() {
                 requests=${requests}
                 nowMs=${Date.now()}
                 cadenceFilter=${cadenceFilter}
-                onOpen=${setSelectedScheduleId}
+                onOpen=${selectSchedule}
               />`
             : html`<${ScheduledAutomationPanel}
                 automation=${automation ? filterAutomationByCadence(automation, cadenceFilter) : automation}
                 variant="v2"
                 selectedScheduleId=${selectedScheduleId}
-                onSelectSchedule=${setSelectedScheduleId}
+                selectedRequest=${inPageRequest ?? exactRequest}
+                onSelectSchedule=${selectSchedule}
               />`}
 
         ${'' /* Secondary diagnostics live BELOW the schedule and are unmounted
@@ -307,13 +386,13 @@ export function ScheduleSurface() {
         ? html`<${ScheduleAside}
             requests=${automation.requests ?? []}
             sum=${{ scheduled: scheduledCount, dueRunning, total: totalCount }}
-            onOpen=${setSelectedScheduleId}
+            onOpen=${selectSchedule}
           />`
         : null}
       ${selectedRequest
         ? html`<${SchDetail}
             request=${selectedRequest}
-            onClose=${() => setSelectedScheduleId(null)}
+            onClose=${() => selectSchedule(null)}
           />`
         : null}
     </main>

--- a/dashboard/src/components/tools/scheduled-automation-panel.test.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.test.ts
@@ -437,6 +437,28 @@ describe('ScheduledAutomationPanel', () => {
     expect(container.textContent).toContain('페이로드')
   })
 
+  it('renders a controlled exact request that is absent from aggregate rows', () => {
+    const selectedRequest = request({
+      schedule_id: 'sched-outside-page',
+      payload_summary: 'Exact route payload',
+    })
+
+    render(
+      html`<${ScheduledAutomationPanel}
+        automation=${automation([])}
+        variant="v2"
+        selectedScheduleId=${selectedRequest.schedule_id}
+        selectedRequest=${selectedRequest}
+        onSelectSchedule=${vi.fn()}
+      />`,
+      container,
+    )
+
+    expect(container.querySelector(
+      '[data-schedule-detail-panel="sched-outside-page"]',
+    )?.textContent).toContain('Exact route payload')
+  })
+
   it('renders keeper wake dispatch receipts as queue proof in diagnostics and v2', async () => {
     const auto = automation([
       request({

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -1820,12 +1820,14 @@ function SchWakeReceipt({
 function SchedulePrototypeSurface({
   automation,
   selectedScheduleId: controlledSelectedId,
+  selectedRequest: controlledSelectedRequest,
   onSelectSchedule,
 }: {
   automation: DashboardScheduledAutomation
   // Optional controlled selection so a sibling (the operations aside) can drive
   // the same detail overlay. Uncontrolled (internal state) when omitted.
   selectedScheduleId?: string | null
+  selectedRequest?: DashboardScheduledAutomationRequest | null
   onSelectSchedule?: (scheduleId: string | null) => void
 }) {
   const [tab, setTab] = useState<SchTabKey>('scheduled')
@@ -1844,7 +1846,9 @@ function SchedulePrototypeSurface({
   const durableSignalContract = durableWakeSignalContract(automation)
   const durableSignals = durableSignalContract.visibleSignals
   const selected = selectedScheduleId
-    ? rows.find(request => request.schedule_id === selectedScheduleId) ?? null
+    ? controlledSelectedRequest?.schedule_id === selectedScheduleId
+      ? controlledSelectedRequest
+      : rows.find(request => request.schedule_id === selectedScheduleId) ?? null
     : null
   const payloadSummary = payloadSupportSummary(automation)
 
@@ -2080,12 +2084,14 @@ export function ScheduledAutomationPanel({
   automation,
   variant = 'diagnostics',
   selectedScheduleId: controlledSelectedId,
+  selectedRequest: controlledSelectedRequest,
   onSelectSchedule,
 }: {
   automation?: DashboardScheduledAutomation | null
   variant?: 'diagnostics' | 'v2'
   // Forwarded to the v2 surface so the schedule aside can control the overlay.
   selectedScheduleId?: string | null
+  selectedRequest?: DashboardScheduledAutomationRequest | null
   onSelectSchedule?: (scheduleId: string | null) => void
 }) {
   const [activeFilter, setActiveFilter] = useState<ScheduleFilterKey>('all')
@@ -2103,6 +2109,7 @@ export function ScheduledAutomationPanel({
     return html`<${SchedulePrototypeSurface}
       automation=${automation}
       selectedScheduleId=${controlledSelectedId}
+      selectedRequest=${controlledSelectedRequest}
       onSelectSchedule=${onSelectSchedule}
     />`
   }


### PR DESCRIPTION
## Summary
- decode the closed `lookup.v1` envelope and enforce both envelope/request identity
- make `#schedule?schedule_id=<raw>` the detail-selection SSOT
- open aggregate rows immediately without another request
- issue one exact lookup only after the aggregate is available and the requested ID is out of page
- route durable/orphan signal clicks through the same lookup and existing detail drawer

## Stack
- Parent API: #28611
- Parent route identity: #28613 (`44607f508cc2b823df31562ce8c451c65b6c4ddd`)
- This PR is frontend-only.

## Verification
- focused Vitest: 3 files, 65 tests passed
- focused ESLint passed
- `pnpm --dir dashboard typecheck`
- `GITHUB_BASE_REF=agent/dashboard-route-raw-query python3 scripts/check_test_coverage.py`
- `git diff --check`

Local Dune was not run. Aggregate resource/filter/polling/cap/pagination are unchanged.
