### PR TITLE
fix(dashboard): 채팅 스트림이 같은 턴을 두 경로로 겹쳐 쓰는 문제

### DIFF
--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -44,6 +44,7 @@ import {
   keeperStatusDetails,
   keeperStreamLastEventAt,
   keeperThreads,
+  liveSendOwnsRequest,
 } from './keeper-state'
 import {
   _resetCancelledKeeperThreadRequestsForTests,
@@ -487,6 +488,39 @@ describe('sendKeeperThreadMessage operation stream', () => {
       state: { kind: 'cancelled', completedAt: 1 },
     })
     await Promise.allSettled([first, second])
+  })
+
+  it('releases only the pre-acceptance stream that ended', async () => {
+    const streams: Array<{
+      requestId: string
+      resolve: (value: { terminal: boolean }) => void
+    }> = []
+    streamKeeperMessage.mockImplementation(async (
+      _name: string,
+      _message: string,
+      opts: { requestId: string },
+    ) => new Promise<{ terminal: boolean }>(resolve => {
+      streams.push({ requestId: opts.requestId, resolve })
+    }))
+
+    const first = sendKeeperThreadMessage('echo', 'first')
+    await Promise.resolve()
+    const second = sendKeeperThreadMessage('echo', 'second')
+    await Promise.resolve()
+
+    const firstId = streams[0]?.requestId ?? ''
+    const secondId = streams[1]?.requestId ?? ''
+    expect(liveSendOwnsRequest(firstId)).toBe(true)
+    expect(liveSendOwnsRequest(secondId)).toBe(true)
+
+    streams[0]?.resolve({ terminal: false })
+    await first
+
+    expect(liveSendOwnsRequest(firstId)).toBe(false)
+    expect(liveSendOwnsRequest(secondId)).toBe(true)
+
+    streams[1]?.resolve({ terminal: false })
+    await second
   })
 
   it('cancels the FIFO-head operation by exact operation id', async () => {

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -56,7 +56,6 @@ import {
   liveSendOwnsRequest,
   releaseLiveSendRequest,
   setActiveStream,
-  setActiveStreamRequestId,
   setRecordValue,
   setStatusDetail,
   updateThreadEntry,
@@ -989,7 +988,6 @@ export async function sendKeeperThreadMessage(
             [localId, assistantId],
             acceptedOperationId,
           )
-          setActiveStreamRequestId(keeperName, acceptedOperationId)
           upsertTrackedKeeperChatOperation({
             operationId: acceptedOperationId,
             keeperName,

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -45,7 +45,6 @@ import {
   attachKeeperAudioClip,
   chatHistoryEntriesFromRest,
   clearActiveStream,
-  clearActiveStreamRequestId,
   finalizeAssistantEntry,
   releaseActiveStreamRequestId,
   mergeServerHistoryEntries,
@@ -1047,7 +1046,7 @@ export async function sendKeeperThreadMessage(
       })
       setRecordValue(keeperActionErrors, keeperName, cutMessage)
       if (toolCallEnded) void hydrateKeeperToolOutputs(keeperName)
-      clearActiveStreamRequestId(keeperName)
+      releaseActiveStreamRequestId(operationId)
       return
     }
 

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -1596,6 +1596,10 @@ export function setActiveStream(
   const streams = keeperActiveStreams.get(name) ?? new Map<string, KeeperActiveStream>()
   streams.set(operationId, { entryId, controller })
   keeperActiveStreams.set(name, streams)
+  // The client mints the operation id before opening the direct response
+  // stream. Claim it at the same lifecycle boundary as the stream controller,
+  // before an observer broadcast can race the ACCEPTED event.
+  claimLiveSendRequest(operationId, name)
 }
 
 export function clearActiveStream(name: string, operationId: string): void {

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -148,9 +148,10 @@ describe('Keeper operation stream projection', () => {
   // The direct send stamps the accepted operation id onto the bubble it is
   // already streaming into (see [stampPlaceholderRequestId] in keeper-actions).
   // The server also broadcasts every operation event to all sessions, so the
-  // same turn arrives twice in the tab that issued it. The two transports chunk
-  // the text differently, so a second application does not overwrite the first
-  // -- it interleaves with it, which is what the operator sees on screen.
+  // same turn arrives twice in the tab that issued it. Both applications
+  // append, so each fragment lands twice. The echo joins late and misses the
+  // leading fragments, which puts the two copies out of phase -- that is why
+  // the operator sees them interleaved rather than cleanly repeated.
   const directlyStreamingBubble = (): void => {
     appendThreadEntry('sangsu', {
       id: 'reply-1',

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -4,6 +4,7 @@ import {
   _resetLiveSendRequestOwnersForTests,
   activeStreamRequestId,
   appendThreadEntry,
+  clearActiveStream,
   setActiveStream,
   setActiveStreamRequestId,
 } from './keeper-state'
@@ -216,6 +217,29 @@ describe('Keeper operation stream projection', () => {
 
     const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-opening')
     expect(entry?.text).toBe('')
+  })
+
+  it('accepts observer events immediately after the direct owner exits', () => {
+    directlyStreamingBubble()
+    setActiveStream(
+      'sangsu',
+      'kmsg-operation-1',
+      'reply-1',
+      new AbortController(),
+    )
+
+    applyKeeperOperationTurnEvent('sangsu', {
+      operationId: 'kmsg-operation-1',
+      event: { type: 'TEXT_MESSAGE_CONTENT', delta: 'owned echo' },
+    })
+    clearActiveStream('sangsu', 'kmsg-operation-1')
+    applyKeeperOperationTurnEvent('sangsu', {
+      operationId: 'kmsg-operation-1',
+      event: { type: 'TEXT_MESSAGE_CONTENT', delta: 'observer continuation' },
+    })
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+    expect(entry?.text).toBe('observer continuation')
   })
 
   // A late-attaching echo drops the leading fragments, so the two copies land

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -169,43 +169,72 @@ describe('Keeper operation stream projection', () => {
     setActiveStreamRequestId('sangsu', 'kmsg-operation-1')
   }
 
+  // The server hands the very same AG-UI event to both transports
+  // (server_routes_http_keeper_stream: broadcast then
+  // publish_operation_live_event), so the echo carries an identical delta.
   it('ignores the broadcast echo of a turn the direct stream already owns', () => {
+    directlyStreamingBubble()
+
+    for (const delta of ['오퍼레이터가 ', '비유/', '빈정거림']) {
+      applyKeeperStreamEvent('sangsu', 'reply-1', { type: 'TEXT_MESSAGE_CONTENT', delta })
+      applyKeeperOperationTurnEvent('sangsu', {
+        operationId: 'kmsg-operation-1',
+        event: { type: 'TEXT_MESSAGE_CONTENT', delta },
+      })
+    }
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+    expect(entry?.text).toBe('오퍼레이터가 비유/빈정거림')
+  })
+
+  // A late-attaching echo drops the leading fragments, so the two copies land
+  // out of phase and read as interleaved rather than as a clean repetition --
+  // this is the shape the operator reported.
+  it('ignores a broadcast echo that joined the turn late', () => {
     directlyStreamingBubble()
 
     applyKeeperStreamEvent('sangsu', 'reply-1', {
       type: 'TEXT_MESSAGE_CONTENT',
-      delta: '오퍼레이터가 비',
+      delta: '오퍼레이터가 ',
+    })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'TEXT_MESSAGE_CONTENT',
+      delta: '비유/',
     })
     applyKeeperOperationTurnEvent('sangsu', {
       operationId: 'kmsg-operation-1',
-      event: { type: 'TEXT_MESSAGE_CONTENT', delta: '레이터가 비유/' },
+      event: { type: 'TEXT_MESSAGE_CONTENT', delta: '비유/' },
     })
 
     const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
-    expect(entry?.text).toBe('오퍼레이터가 비')
+    expect(entry?.text).toBe('오퍼레이터가 비유/')
   })
 
   it('ignores the broadcast echo of thinking deltas the direct stream already owns', () => {
     directlyStreamingBubble()
 
-    applyKeeperStreamEvent('sangsu', 'reply-1', {
-      type: 'CUSTOM',
-      name: 'KEEPER_THINKING_DELTA',
-      value: { index: 0, delta: '오퍼레이터가 비' },
-    })
-    applyKeeperOperationTurnEvent('sangsu', {
-      operationId: 'kmsg-operation-1',
-      event: {
+    // Both paths enqueue into one pending buffer keyed by keeper+entry, so an
+    // echo appends into the same chunk array the direct stream is filling.
+    for (const delta of ['오퍼레이터가 ', '비유/']) {
+      applyKeeperStreamEvent('sangsu', 'reply-1', {
         type: 'CUSTOM',
         name: 'KEEPER_THINKING_DELTA',
-        value: { index: 0, delta: '레이터가 비유/' },
-      },
-    })
+        value: { index: 0, delta },
+      })
+      applyKeeperOperationTurnEvent('sangsu', {
+        operationId: 'kmsg-operation-1',
+        event: {
+          type: 'CUSTOM',
+          name: 'KEEPER_THINKING_DELTA',
+          value: { index: 0, delta },
+        },
+      })
+    }
     _flushPendingKeeperStreamDeltasForTests()
 
     const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
     const think = (entry?.traceSteps ?? []).filter(step => step.kind === 'think')
-    expect(think.map(step => step.text)).toEqual(['오퍼레이터가 비'])
+    expect(think.map(step => step.text)).toEqual(['오퍼레이터가 비유/'])
   })
 
   it('still applies broadcast events for a turn this session does not own', () => {

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -187,6 +187,36 @@ describe('Keeper operation stream projection', () => {
     expect(entry?.text).toBe('오퍼레이터가 비유/빈정거림')
   })
 
+  it('claims ownership before the direct stream receives acceptance', () => {
+    appendThreadEntry('sangsu', {
+      id: 'reply-opening',
+      role: 'assistant',
+      source: 'direct_assistant',
+      label: 'sangsu',
+      text: '',
+      rawText: '',
+      timestamp: null,
+      requestId: 'kmsg-opening',
+      delivery: 'sending',
+      streamState: 'opening',
+      details: null,
+    })
+    setActiveStream(
+      'sangsu',
+      'kmsg-opening',
+      'reply-opening',
+      new AbortController(),
+    )
+
+    applyKeeperOperationTurnEvent('sangsu', {
+      operationId: 'kmsg-opening',
+      event: { type: 'TEXT_MESSAGE_CONTENT', delta: 'observer raced acceptance' },
+    })
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-opening')
+    expect(entry?.text).toBe('')
+  })
+
   // A late-attaching echo drops the leading fragments, so the two copies land
   // out of phase and read as interleaved rather than as a clean repetition --
   // this is the shape the operator reported.

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -145,6 +145,93 @@ describe('Keeper operation stream projection', () => {
     expect(entries.find(entry => entry.requestId === 'kmsg-operation-2')?.text).toBe('second')
   })
 
+  // The direct send stamps the accepted operation id onto the bubble it is
+  // already streaming into (see [stampPlaceholderRequestId] in keeper-actions).
+  // The server also broadcasts every operation event to all sessions, so the
+  // same turn arrives twice in the tab that issued it. The two transports chunk
+  // the text differently, so a second application does not overwrite the first
+  // -- it interleaves with it, which is what the operator sees on screen.
+  const directlyStreamingBubble = (): void => {
+    appendThreadEntry('sangsu', {
+      id: 'reply-1',
+      role: 'assistant',
+      source: 'direct_assistant',
+      label: 'sangsu',
+      text: '',
+      rawText: '',
+      timestamp: null,
+      requestId: 'kmsg-operation-1',
+      delivery: 'streaming',
+      streamState: 'streaming',
+      details: null,
+    })
+    // Mirrors keeper-actions: the direct send claims the accepted operation id.
+    setActiveStreamRequestId('sangsu', 'kmsg-operation-1')
+  }
+
+  it('ignores the broadcast echo of a turn the direct stream already owns', () => {
+    directlyStreamingBubble()
+
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'TEXT_MESSAGE_CONTENT',
+      delta: '오퍼레이터가 비',
+    })
+    applyKeeperOperationTurnEvent('sangsu', {
+      operationId: 'kmsg-operation-1',
+      event: { type: 'TEXT_MESSAGE_CONTENT', delta: '레이터가 비유/' },
+    })
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+    expect(entry?.text).toBe('오퍼레이터가 비')
+  })
+
+  it('ignores the broadcast echo of thinking deltas the direct stream already owns', () => {
+    directlyStreamingBubble()
+
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_THINKING_DELTA',
+      value: { index: 0, delta: '오퍼레이터가 비' },
+    })
+    applyKeeperOperationTurnEvent('sangsu', {
+      operationId: 'kmsg-operation-1',
+      event: {
+        type: 'CUSTOM',
+        name: 'KEEPER_THINKING_DELTA',
+        value: { index: 0, delta: '레이터가 비유/' },
+      },
+    })
+    _flushPendingKeeperStreamDeltasForTests()
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+    const think = (entry?.traceSteps ?? []).filter(step => step.kind === 'think')
+    expect(think.map(step => step.text)).toEqual(['오퍼레이터가 비'])
+  })
+
+  it('still applies broadcast events for a turn this session does not own', () => {
+    appendThreadEntry('sangsu', {
+      id: 'reply-1',
+      role: 'assistant',
+      source: 'direct_assistant',
+      label: 'sangsu',
+      text: '',
+      rawText: '',
+      timestamp: null,
+      requestId: 'kmsg-operation-1',
+      delivery: 'streaming',
+      streamState: 'streaming',
+      details: null,
+    })
+
+    applyKeeperOperationTurnEvent('sangsu', {
+      operationId: 'kmsg-operation-1',
+      event: { type: 'TEXT_MESSAGE_CONTENT', delta: 'from another tab' },
+    })
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+    expect(entry?.text).toBe('from another tab')
+  })
+
   it('keeps concurrent operation controllers independent', () => {
     const first = new AbortController()
     const second = new AbortController()

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -30,6 +30,7 @@ import {
   keeperThreads,
   keeperSending,
   keeperStreamStartedAt,
+  liveSendOwnsRequest,
   setRecordValue,
 } from './keeper-state'
 import { isRecord, asNumber, asString } from './components/common/normalize'
@@ -417,6 +418,19 @@ export function applyKeeperOperationTurnEvent(
   const keeperName = name.trim()
   const operationId = operation.operationId.trim()
   if (!keeperName || !operationId) return null
+
+  // The server broadcasts every operation event to every session, including the
+  // one that issued the send and is already applying the same turn off its own
+  // response stream. [delivery] cannot tell the two apart: the direct stream
+  // stamps the accepted operation id onto the bubble it is streaming into
+  // (keeper-actions [stampPlaceholderRequestId]) and leaves it in 'streaming',
+  // which is exactly the state this function treats as "still open, keep
+  // writing". Applying both transports to one bubble does not overwrite, it
+  // interleaves -- the two chunk the same text at different boundaries, so the
+  // operator sees every fragment twice ("오퍼레이터가 비" + "레이터가 비유/").
+  // Live-send ownership already records which request this session is
+  // streaming itself, so consult that rather than inferring it from state.
+  if (liveSendOwnsRequest(operationId)) return null
 
   const entries = keeperThreads.value[keeperName] ?? []
   const matched = [...entries].reverse().find(


### PR DESCRIPTION
## 증상

턴 타임라인의 THINKING / PROGRESS 텍스트가 조각 단위로 겹쳐 보입니다.

```
오퍼레이터가 비레이터가 비유/유/빈정거림/빈정거림/말장말장난 공난 공격을 …
```

손상이 아니라 **같은 텍스트 두 벌이 어긋난 채 겹친 것**입니다. 기계적으로 분해하면 한 벌은 원문 66자와 정확히 일치하고, 나머지는 앞의 `오퍼` 와 끝의 ` 있다.` 만 빠진 같은 원문입니다.

## 원인

서버가 같은 AG-UI 이벤트를 두 경로로 내보내고, 대시보드가 그 둘을 같은 버블에 적용합니다.

`server_routes_http_keeper_stream.ml:1961-1968` — 한 이벤트가 나란히 두 곳으로 나갑니다.

```ocaml
Keeper_chat_broadcast.operation_event ~keeper_name ~operation_id ~event;  (* 모든 SSE observer *)
publish_operation_live_event ~operation_id event                          (* 요청자 스트림 *)
```

브로드캐스트에는 발신 세션을 제외할 인자가 없습니다 (`Sse.broadcast_to Sse.Observers`). 서버는 어느 WS 세션이 그 HTTP 요청의 발신자인지 알 수 없습니다.

클라이언트에서는:

1. direct 스트림이 버블에 `requestId = operationId` 를 찍습니다 (`keeper-actions.ts` `stampPlaceholderRequestId`).
2. 브로드캐스트 핸들러가 정확히 그 버블을 찾습니다 (`keeper-stream.ts:422-424`).
3. 가드는 버블이 더 이상 열려 있지 않을 때만 막는데, `delivery === 'streaming'` 은 그 가드가 **"아직 열려 있으니 계속 써라"** 로 읽는 상태입니다.

두 경로가 같은 델타를 각각 append 하므로 조각이 두 번씩 쌓입니다. 화면이 단순 반복이 아니라 인터리브로 보인 것은 **에코가 늦게 붙어 앞 조각을 놓쳤기 때문**입니다 — 두 벌의 위상이 어긋납니다. thinking 이 같이 깨지는 건 pending 버퍼가 `keeper + entryId` 하나로 키잉되어 두 경로가 같은 `chunks` 배열에 push 하기 때문입니다.

### 기존 messageId 멱등성은 왜 못 막나

`keeper-stream.ts` 상단이 이미 at-least-once 전달과 *"an overlapping observer socket can re-deliver the same operation event"* 를 다룹니다. 다만 그 가드는 같은 주석이 밝히듯 `messageId` 만 보고 **per-chunk sequence 가 없습니다**. 완료된 메시지의 재적용이나 재-START 는 막지만, **동시에 살아 있는 두 전송의 청크 단위 중복은 구조적으로 막을 수 없습니다.**

가드를 끄고 messageId 를 실어 확인했습니다:

```
messageId 있음 → '오퍼레이터가 오퍼레이터가 비유/비유/'
```

## 수정

```ts
if (liveSendOwnsRequest(operationId)) return null
```

중복 제거 계층을 새로 만들지 않았습니다. `liveSendOwnsRequest` 는 이미 있던 함수이고, direct 스트림은 operation 수락 시점에 이미 소유권을 등록합니다 (`setActiveStreamRequestId` → `claimLiveSendRequest`). `keeper-actions.ts:1023` 주석은 이 소유권을 이미 *"the guard we just set"* 이라고 부릅니다 — 가드는 설계되어 있었고 이 한 곳이 조회를 빠뜨렸습니다.

`delivery` 는 *상태*(streaming/queued)만 표현할 뿐 *경로*(내가 스트리밍 / 남이 스트리밍)를 구분하지 못합니다. 상태로 소유권을 판정하려 한 것이 결함의 뿌리입니다.

### 수정 층

서버에서 막으려면 "이 WS 세션이 그 HTTP 요청의 발신자인가"를 알아야 하는데, 두 연결은 서버 입장에서 별개라 세션 식별자를 wire 에 추가해야 합니다. 그 사실을 이미 아는 유일한 주체가 클라이언트라, 계약을 넓히지 않는 쪽을 택했습니다.

## 검증

- 대시보드 전체 스위트 **653 파일 / 8923 테스트 통과**
- `keeper-stream.test.ts` 25/25, `tsc --noEmit` 통과, `eslint` 통과
- **mutation check**: 가드를 끄면 추가한 3건이 전부 실패하고 정확히 중복 문자열을 만듭니다
  ```
  '오퍼레이터가 오퍼레이터가 비유/비유/빈정거림빈정거림'   (텍스트)
  '오퍼레이터가 비유/비유/'                              (늦게 붙은 에코)
  ['오퍼레이터가 오퍼레이터가 비유/비유/']                (thinking)
  ```
- 추가 테스트에는 **대조군**이 포함됩니다: 이 세션이 소유하지 않은 턴은 계속 정상 적용되어야 합니다. 소유권 검사가 과하면 다른 브라우저 세션의 정상 브로드캐스트가 죽습니다.

### 반대 방향 위험

소유권이 남아 브로드캐스트까지 막히면 화면이 멈춥니다. `keeper-actions.ts:1208-1215` 의 `finally` 가 성공/중단/에러 **모든 종료 경로에서** 해제하는 것을 확인했습니다.

## 범위 밖

조사 중 확인된 별개 항목 — 이번 증상의 경로는 아니라 손대지 않았습니다.

- masc#28621 — `dashboard-ws.ts:698` `applyDelta` 가 `seq` 를 단조성 검사 없이 덮어씁니다. 서버가 같은 구간을 재전송하면 그대로 재적용됩니다. 다만 서버가 실제로 재전송하는지는 확인하지 않았고, 이슈 본문에 그 한계와 착수 전 측정 항목을 적어 두었습니다.
