### PR TITLE
RFC-0377 — 같은 대화의 밀린 메시지는 한 턴이 함께 본다 (구현)

### DIFF
--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -239,6 +239,7 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0374 | Keeper Capability Probe Lane | Draft | - |
 | 0375 | Closed day-file projection cache — stop replaying the ledger per read | Draft (not recommended as written — see §8) | - |
 | 0376 | 출력 목적지는 Keeper 가 판단한다 | Draft | - |
+| 0377 | 같은 대화의 밀린 메시지는 한 턴이 함께 본다 (Conversation-Batched Stimulus Intake) | Draft | - |
 | RFC-0034d-stale-agent-sync | d — release_stale_claims agent-side sync | Draft | - |
 | RFC-async-log-sink-durable-append-offload | Offload the structured-log durable append off the emitting fiber | Draft | - |
 | RFC-checkpoint-pinned-root-containment | Immutable boot-pinned root capability for checkpoint containment | Draft | - |

--- a/docs/rfc/RFC-0377-conversation-batched-stimulus-intake.md
+++ b/docs/rfc/RFC-0377-conversation-batched-stimulus-intake.md
@@ -1,0 +1,55 @@
+# RFC-0377 — 같은 대화의 밀린 메시지는 한 턴이 함께 본다 (Conversation-Batched Stimulus Intake)
+
+- Status: Draft
+- Depends on: RFC-0376 (출력 목적지는 Keeper 가 판단한다)
+- Scope: ambient lane (`Connector_attention` stimulus intake). Mention(triggered) lane 은 비범위.
+
+## 1. 문제 (실측)
+
+sangsu 라이브 데이터 (2026-08-08 ~ 08-13, `keepers/sangsu/` 기준):
+
+- 배달된 continuation obligation 48건 전수가 **서로 다른 단일 inbound message 에 1:1 바인딩**. 연속 turn id 28308→28336 이 snowflake 오름차순 inbound 를 하나씩 소비 — 관찰된 "위에서부터 하나씩 답장"의 구조적 원인.
+- inbound 메시지 발생 → 답장 배달 지연이 438s → 4,461s 로 단조 증가 (48건 중앙값 1,533s). 단건 드레인이 라이브 채널 유입 속도를 따라가지 못하는 시그니처.
+- 사용자 체감: 밀린 대화 5개에 5턴에 걸쳐 순서대로 5개의 답장이 도착. 앞선 답장이 만들어지는 동안 대화 맥락은 이미 흘러가 있음.
+
+## 2. 원인 (코드)
+
+한 턴은 구조적으로 stimulus 하나만 본다:
+
+| 지점 | 동작 |
+|---|---|
+| `lib/server/server_discord_in_process_gateway.ml` (`handle_ambient`) | inbound 메시지 1건 = `Connector_attention { event_id; channel(reply_to_message_id 포함) }` 1건 enqueue |
+| `lib/keeper/keeper_heartbeat_stimulus_intake.ml` (`consume_single_heartbeat_stimulus`) | RFC-0020 §3 Rule 4: 턴당 Event Layer stimulus **최대 1건** admit |
+| `lib/keeper_runtime/keeper_event_queue.ml` (`is_board_signal`) | board signal 은 `drain_board_all` 로 배치 드레인이 **이미 존재**하나 `Connector_attention` 은 제외 |
+
+즉 board 자극에는 이미 "쌓인 것을 한 턴이 함께 본다"는 선례가 있고, connector 자극만 단건 규칙에 남아 있다.
+
+## 3. 설계
+
+**Claim 시점 대화 단위 드레인.** intake 가 `Connector_attention` 을 선택하면, 같은 conversation
+(동일 connector channel 좌표)의 pending `Connector_attention` 전부를 그 턴에 함께 admit 한다.
+
+- 배치의 경계는 **claim 시각에 pending 인 것 전부**다. debounce window, 최대 개수, 대기 타이머 등
+  숫자 기반 장치는 두지 않는다 (배치 크기는 유입/드레인 속도의 사실적 결과이지 제어 대상이 아니다).
+- 턴 컨텍스트에는 배치 전 건이 도착 순서대로 투영된다. Keeper 는 전체를 보고 하나의 응답으로 묶을지,
+  개별로 응답할지, 무응답으로 넘길지 **스스로 판단**한다 (RFC-0376: 발화는 `connector_post` 도구로만).
+  reply 대상 message 선택도 Keeper 판단이다 — intake 는 사실 투영만 하고 행동을 강제하지 않는다.
+- 다른 conversation 의 stimulus 는 배치에 포함하지 않는다 (턴당 대화 하나 유지).
+- ack 은 RFC-0376 과 동일하게 **턴 완료 = 배치 전 건 ack**. 턴 실패 시 전 건이 기존 실패 경로대로 큐에 남는다.
+- 참조 선례: 이 harness 자체 — Claude Code 는 턴 진행 중 도착한 사용자 메시지를 다음 턴 컨텍스트에
+  묶어서 투영하고, 응답 방식은 모델이 판단한다.
+
+## 4. 비범위
+
+- Mention(triggered) lane 의 `Chat_operation_store.claim_next` (`LIMIT 1`) 배칭. mention 1건당 답장
+  1건은 그 자체로 결함이 아니다. 라이브 증거가 생기면 별도 RFC.
+- Cross-conversation 배칭, board/schedule/fusion 등 다른 stimulus 종류 (board 는 이미 자체 드레인 보유).
+- 응답 텍스트의 자동 병합·요약 — 응답 형태는 전적으로 Keeper 판단.
+
+## 5. 검증
+
+1. Feature test: 채널 A 에 5건 + 채널 B 에 2건 enqueue → intake 1회 → 턴 컨텍스트에 A 의 5건 전부
+   (도착순), B 의 2건은 큐 잔류 → 턴 완료 시 A 5건 전부 ack, B 2건 잔류.
+2. 턴 실패 경로: 배치 admit 후 턴 실패 → 5건 전부 큐 잔류 (부분 ack 없음).
+3. 라이브 재측정: sangsu 백로그 시나리오에서 inbound→응답 지연 중앙값과 턴당 소비 stimulus 수를
+   before/after 로 기록해 PR 에 첨부.

--- a/lib/keeper/keeper_external_attention.ml
+++ b/lib/keeper/keeper_external_attention.ml
@@ -391,6 +391,33 @@ let recorded_item_by_event_id events event_id =
       | Recorded _ | Resolved _ | Ignored _ -> None)
     events
 
+(* RFC-0377: [load_events] parses the whole file on every call, exactly the
+   O(file)-per-call shape the [dedup_window_bytes] comment above already
+   warns against for [record]'s dedup scan. A caller resolving a *batch* of
+   event_ids (e.g. every stimulus admitted into one turn) must not call
+   [load_events] once per id — that reintroduces the same O(N * file) trap
+   on the read side. Load once, then resolve every id against that one
+   in-memory list via a single pass building an id -> item table (first
+   [Recorded] occurrence per id wins, matching [recorded_item_by_event_id]
+   exactly), so the whole batch costs one file read regardless of size. *)
+let recorded_items_by_event_ids ~base_path ~keeper_name ~event_ids =
+  let events = load_events ~base_path ~keeper_name in
+  let wanted : (string, unit) Hashtbl.t = Hashtbl.create (List.length event_ids) in
+  List.iter (fun event_id -> Hashtbl.replace wanted event_id ()) event_ids;
+  let found : (string, item) Hashtbl.t = Hashtbl.create (List.length event_ids) in
+  List.iter
+    (function
+      | Recorded item
+        when Hashtbl.mem wanted item.event_id
+             && not (Hashtbl.mem found item.event_id) ->
+        Hashtbl.add found item.event_id item
+      | Recorded _ | Resolved _ | Ignored _ -> ())
+    events;
+  List.filter_map
+    (fun event_id ->
+       Option.map (fun item -> event_id, item) (Hashtbl.find_opt found event_id))
+    event_ids
+
 (* Read one bounded tail without parsing either boundary fragment. The writer
    may be mid-append, and [from] usually lands mid-line, so only bytes strictly
    between the first and last newline are complete records. *)

--- a/lib/keeper/keeper_external_attention.mli
+++ b/lib/keeper/keeper_external_attention.mli
@@ -155,6 +155,21 @@ val load_events_result :
 
 val load_events : base_path:string -> keeper_name:string -> event list
 
+val recorded_items_by_event_ids :
+  base_path:string -> keeper_name:string -> event_ids:string list ->
+  (string * item) list
+(** One-scan batch counterpart to [load_events] +
+    per-id [Recorded] lookup: loads the event log exactly once, then
+    resolves every id in [event_ids] against that one in-memory load
+    (first [Recorded] match per id, same semantics as looking each id up
+    individually). An id with no [Recorded] entry is simply absent from
+    the result; the returned pairs preserve [event_ids]' order. Calling
+    [load_events] once per id here is the same O(file)-per-call trap the
+    [dedup_window_bytes] comment above documents for [record]'s dedup
+    scan — this is the read-side counterpart, for RFC-0377's turn-batched
+    Connector_attention intake (N companions must not cost N full-file
+    reads). *)
+
 val load_recent_evidence_events :
   base_path:string -> keeper_name:string -> event list
 (** Read a bounded recent tail sized for prompt evidence rather than connector

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -341,6 +341,59 @@ let failed_source_disposition
            | Keeper_runtime_failure_route.Rotate_now _ -> Defer_to_queue_tail)))
 ;;
 
+(* RFC-0377 batch disposition: the queue action a turn outcome implies for
+   every stimulus admitted into that turn (the primary plus any
+   Connector_attention companions), extracted as a pure function of
+   [cycle_outcome] alone. Before this extraction the decision lived inline
+   in [run_keepalive_turn]'s closure, reachable only through the full Eio
+   ctx + durable-registry harness, so a regression from "ack the whole
+   batch" back to "ack only the primary" would still pass every existing
+   test (nothing exercised the decision directly — see
+   test_keeper_connector_attention_batch_disposition.ml). One turn always
+   produces one disposition applied uniformly to every admitted selection:
+   the outcome is a property of the turn, not of any individual stimulus. *)
+type batch_disposition =
+  | Batch_ack_completed of
+      { connector_attention_outcome : connector_attention_outcome }
+  | Batch_quarantine of { detail : string }
+  | Batch_defer of { reason : string }
+  | Batch_no_action
+
+let batch_disposition_of_cycle_outcome
+      (cycle_outcome : Keeper_heartbeat_loop_cycle.cycle_outcome option)
+  : batch_disposition
+  =
+  match cycle_outcome with
+  | Some (Cycle.Completed completion) ->
+    Batch_ack_completed
+      { connector_attention_outcome =
+          connector_attention_outcome_of_route completion.continuation_route
+      }
+  | Some (Cycle.Manual_compaction_applied _) ->
+    Batch_ack_completed { connector_attention_outcome = Attention_ignored }
+  | Some (Cycle.Failed { failure; _ }) ->
+    (match failed_source_disposition failure with
+     | Quarantine_source { detail } -> Batch_quarantine { detail }
+     | Defer_to_queue_tail -> Batch_defer { reason = "transient_turn_failure" }
+     | Preserve_for_deferred_runtime | Pause_keeper_for_integrity _ ->
+       Batch_no_action)
+  | Some (Cycle.Manual_compaction_failed { failure; _ }) ->
+    Batch_quarantine { detail = Keeper_manual_compaction.failure_to_string failure }
+  | Some (Cycle.Manual_compaction_not_applied { no_compaction; _ }) ->
+    Batch_quarantine
+      { detail =
+          Keeper_post_turn.compaction_recovery_error_to_string
+            (Keeper_post_turn.No_compaction no_compaction)
+      }
+  | Some
+      ( Cycle.Checkpointed _
+      | Cycle.Input_required _
+      | Cycle.Cancelled _
+      | Cycle.Skipped _ )
+  | None ->
+    Batch_no_action
+;;
+
 
 (* Pure: post-turn status event derived from the registry turn-failure
    counter. Extracted from the loop body so the crashed-cycle ->
@@ -875,52 +928,18 @@ let run_keepalive_unified_turn
                    ~keeper_name:meta_after_triage.name
                    event_ids)
            in
-           match !cycle_outcome_ref with
-           | Some (Cycle.Completed completion) ->
-             remove_completed_selections
-               ~connector_attention_outcome:
-                 (connector_attention_outcome_of_route
-                    completion.continuation_route)
-           | Some (Cycle.Manual_compaction_applied _) ->
-             remove_completed_selections
-               ~connector_attention_outcome:Attention_ignored
-           | Some (Cycle.Failed { failure; _ }) ->
-             (match failed_source_disposition failure with
-                | Quarantine_source { detail } ->
-                  List.iter
-                    (fun selection -> terminalize_failed_selection ~selection ~detail)
-                    selections
-                | Defer_to_queue_tail ->
-                  List.iter
-                    (fun selection ->
-                       defer_selection_to_queue_tail
-                         ~selection
-                         ~reason:"transient_turn_failure")
-                    selections
-                | Preserve_for_deferred_runtime
-                | Pause_keeper_for_integrity _ ->
-                  ())
-           | Some (Cycle.Manual_compaction_failed { failure; _ }) ->
-             let detail = Keeper_manual_compaction.failure_to_string failure in
+           match batch_disposition_of_cycle_outcome !cycle_outcome_ref with
+           | Batch_ack_completed { connector_attention_outcome } ->
+             remove_completed_selections ~connector_attention_outcome
+           | Batch_quarantine { detail } ->
              List.iter
                (fun selection -> terminalize_failed_selection ~selection ~detail)
                selections
-           | Some (Cycle.Manual_compaction_not_applied { no_compaction; _ }) ->
-             let detail =
-               Keeper_post_turn.compaction_recovery_error_to_string
-                 (Keeper_post_turn.No_compaction no_compaction)
-             in
+           | Batch_defer { reason } ->
              List.iter
-               (fun selection -> terminalize_failed_selection ~selection ~detail)
+               (fun selection -> defer_selection_to_queue_tail ~selection ~reason)
                selections
-           | Some
-               ( Cycle.Checkpointed _
-               | Cycle.Input_required _
-               | Cycle.Cancelled _ ) ->
-             ()
-           | Some (Cycle.Skipped _) -> ()
-           | None ->
-             ());
+           | Batch_no_action -> ());
       (let compaction_outcomes =
          match !cycle_outcome_ref with
          | Some outcome -> compaction_outcomes_of_cycle_outcome outcome

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -52,6 +52,7 @@ type heartbeat_event_intake = Stimulus_intake.heartbeat_event_intake = {
   consumed_stimulus_count : int;
   consumed_stimuli : Keeper_event_queue.stimulus list;
   pending_selection : Keeper_event_queue_state.pending_selection option;
+  consumed_selections : Keeper_event_queue_state.pending_selection list;
   event_queue_intake_error : Stimulus_intake.event_queue_intake_error option;
   event_queue_triggers : Keeper_world_observation.event_queue_trigger list;
 }
@@ -379,6 +380,19 @@ let run_keepalive_unified_turn
       =
       ref None
     in
+    (* RFC-0377: [pending_selection] above stays the single primary entry
+       (transient-board-withdrawal reporting and pre-dispatch validation are
+       unchanged by batching). [consumed_selections] is the full admitted
+       batch — [[]], a singleton mirroring [pending_selection], or the
+       primary plus every same-conversation Connector_attention companion.
+       Turn completion/failure disposition acks or defers every entry in
+       this list, not just the primary, so a companion is never left
+       durably stuck once its turn has already run. *)
+    let consumed_selections
+      : Keeper_event_queue_state.pending_selection list ref
+      =
+      ref []
+    in
     let cycle_outcome_ref = ref None in
     let selection_acked = ref false in
     let event_queue_failed = ref false in
@@ -432,6 +446,7 @@ let run_keepalive_unified_turn
       in
       consumed_stimuli := event_intake.consumed_stimuli;
       pending_selection := event_intake.pending_selection;
+      consumed_selections := event_intake.consumed_selections;
       let selected_source_authority () =
         match
           Keeper_meta_store.read_effective_meta
@@ -444,13 +459,28 @@ let run_keepalive_unified_turn
         | Ok (Some current) when current.paused ->
           Error "keeper paused before dispatch"
         | Ok (Some _) ->
-          (match !pending_selection with
-           | None -> Ok ()
-           | Some selection ->
-             Keeper_registry_event_queue.validate_pending_selection_result
-               ~base_path:ctx.config.base_path
-               meta_after_triage.name
-               ~selection)
+          (* Batch case: validate every admitted selection, not only the
+             primary, so a companion whose durable entry changed out from
+             under this turn is caught before dispatch instead of only at
+             ack time. Falls back to the pre-batch single [pending_selection]
+             when nothing was consumed as a batch (e.g. the transient-board
+             withdrawal case, which never populates [consumed_selections]). *)
+          let selections_to_validate =
+            match !consumed_selections with
+            | [] -> Option.to_list !pending_selection
+            | (_ :: _) as selections -> selections
+          in
+          List.fold_left
+            (fun result selection ->
+               match result with
+               | Error _ as error -> error
+               | Ok () ->
+                 Keeper_registry_event_queue.validate_pending_selection_result
+                   ~base_path:ctx.config.base_path
+                   meta_after_triage.name
+                   ~selection)
+            (Ok ())
+            selections_to_validate
       in
       (match
          Keeper_turn_dispatch_authority.install
@@ -814,11 +844,21 @@ let run_keepalive_unified_turn
            | Cycle.Manual_compaction_not_applied _ )
        | None ->
          ());
-      (match !pending_selection with
-       | None -> ()
-       | Some selection ->
-           let remove_completed_selection ~connector_attention_outcome =
-             if terminalize_completed_selection ~selection
+      (* RFC-0377: every entry admitted into this turn (the primary plus any
+         Connector_attention batch companions) shares the turn's outcome. A
+         turn completion acks all of them; a turn failure applies the same
+         quarantine/defer/preserve disposition to all of them, so a
+         companion is never silently left un-acked while the primary is. *)
+      (match !consumed_selections with
+       | [] -> ()
+       | (_ :: _) as selections ->
+           let remove_completed_selections ~connector_attention_outcome =
+             let all_acked =
+               List.for_all
+                 (fun selection -> terminalize_completed_selection ~selection)
+                 selections
+             in
+             if all_acked
              then (
                let event_ids =
                  connector_attention_event_ids_of_stimuli !consumed_stimuli
@@ -837,34 +877,42 @@ let run_keepalive_unified_turn
            in
            match !cycle_outcome_ref with
            | Some (Cycle.Completed completion) ->
-             remove_completed_selection
+             remove_completed_selections
                ~connector_attention_outcome:
                  (connector_attention_outcome_of_route
                     completion.continuation_route)
            | Some (Cycle.Manual_compaction_applied _) ->
-             remove_completed_selection
+             remove_completed_selections
                ~connector_attention_outcome:Attention_ignored
            | Some (Cycle.Failed { failure; _ }) ->
              (match failed_source_disposition failure with
                 | Quarantine_source { detail } ->
-                  terminalize_failed_selection ~selection ~detail
+                  List.iter
+                    (fun selection -> terminalize_failed_selection ~selection ~detail)
+                    selections
                 | Defer_to_queue_tail ->
-                  defer_selection_to_queue_tail
-                    ~selection
-                    ~reason:"transient_turn_failure"
+                  List.iter
+                    (fun selection ->
+                       defer_selection_to_queue_tail
+                         ~selection
+                         ~reason:"transient_turn_failure")
+                    selections
                 | Preserve_for_deferred_runtime
                 | Pause_keeper_for_integrity _ ->
                   ())
            | Some (Cycle.Manual_compaction_failed { failure; _ }) ->
-             terminalize_failed_selection
-               ~selection
-               ~detail:(Keeper_manual_compaction.failure_to_string failure)
+             let detail = Keeper_manual_compaction.failure_to_string failure in
+             List.iter
+               (fun selection -> terminalize_failed_selection ~selection ~detail)
+               selections
            | Some (Cycle.Manual_compaction_not_applied { no_compaction; _ }) ->
-             terminalize_failed_selection
-               ~selection
-               ~detail:
-                 (Keeper_post_turn.compaction_recovery_error_to_string
-                    (Keeper_post_turn.No_compaction no_compaction))
+             let detail =
+               Keeper_post_turn.compaction_recovery_error_to_string
+                 (Keeper_post_turn.No_compaction no_compaction)
+             in
+             List.iter
+               (fun selection -> terminalize_failed_selection ~selection ~detail)
+               selections
            | Some
                ( Cycle.Checkpointed _
                | Cycle.Input_required _

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -53,6 +53,7 @@ type heartbeat_event_intake = {
   consumed_stimulus_count : int;
   consumed_stimuli : Keeper_event_queue.stimulus list;
   pending_selection : Keeper_event_queue_state.pending_selection option;
+  consumed_selections : Keeper_event_queue_state.pending_selection list;
   event_queue_intake_error :
     Keeper_heartbeat_stimulus_intake.event_queue_intake_error option;
   event_queue_triggers : Keeper_world_observation.event_queue_trigger list;

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -168,6 +168,26 @@ type connector_attention_outcome =
   | Attention_resolved
   | Attention_ignored
 
+type batch_disposition =
+  | Batch_ack_completed of
+      { connector_attention_outcome : connector_attention_outcome }
+  | Batch_quarantine of { detail : string }
+  | Batch_defer of { reason : string }
+  | Batch_no_action
+
+val batch_disposition_of_cycle_outcome :
+  Keeper_heartbeat_loop_cycle.cycle_outcome option -> batch_disposition
+(** RFC-0377: the single queue action ([Batch_ack_completed] /
+    [Batch_quarantine] / [Batch_defer] / [Batch_no_action]) a turn's
+    [cycle_outcome] implies for every stimulus admitted into that turn — the
+    primary selection plus any Connector_attention batch companions. The
+    caller applies the returned action uniformly to every admitted
+    selection ([List.for_all]/[List.iter] over
+    [heartbeat_event_intake.consumed_selections]); this function decides
+    only *what* to do, never *to which* selection, so a batch of any size
+    shares one disposition by construction. Pure: composes the route ->
+    [connector_attention_outcome] mapping with {!failed_source_disposition},
+    both already pure. *)
 
 (** Pure: post-turn status event derived from the registry
     turn-failure counter. [turn_fail_count > 0] maps to [Turn_failed];

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -225,6 +225,7 @@ let event_queue_trigger_of_stimulus (stim : Keeper_event_queue.stimulus) =
 let consume_single_heartbeat_stimulus
       ~(ctx : _ context)
       ~meta_after_triage
+      ?connector_attention_items
       (stim : Keeper_event_queue.stimulus)
   =
   let class_str = Keeper_event_queue.payload_kind_label stim.payload in
@@ -303,13 +304,22 @@ let consume_single_heartbeat_stimulus
          Keeper_external_attention. Load it here and promote it to a pending
          observation so the turn has real connector context instead of a
          contentless wake reason. *)
-      let pending_events =
-        match
+      let recorded_item =
+        match connector_attention_items with
+        | Some preloaded ->
+          (* RFC-0377 P1-1: the caller already loaded every batch member's
+             attention item in one scan (see
+             [connector_attention_items_of_batch] below) — reuse it instead
+             of re-scanning the whole event log for this one id. *)
+          List.assoc_opt ca.event_id preloaded
+        | None ->
           recorded_attention_item_by_event_id
             ~base_path:ctx.config.base_path
             ~keeper_name:meta_after_triage.name
             ~event_id:ca.event_id
-        with
+      in
+      let pending_events =
+        match recorded_item with
         | Some item ->
           [ Keeper_world_observation.pending_board_event_of_external_attention
               ~meta:meta_after_triage
@@ -562,6 +572,54 @@ let heartbeat_event_intake
            message;
          [])
   in
+  let connector_attention_event_id (s : Keeper_event_queue.stimulus) =
+    match s.Keeper_event_queue.payload with
+    | Keeper_event_queue.Connector_attention { event_id; _ } -> Some event_id
+    | Keeper_event_queue.Board_signal _
+    | Keeper_event_queue.Board_attention _
+    | Keeper_event_queue.Bootstrap
+    | Keeper_event_queue.Fusion_completed _
+    | Keeper_event_queue.Schedule_due _
+    | Keeper_event_queue.Hitl_resolved _
+    | Keeper_event_queue.Manual_compaction_requested
+    | Keeper_event_queue.Goal_assigned _
+    | Keeper_event_queue.Goal_reconciliation_ready _
+    | Keeper_event_queue.Completion_authority_rejected _
+    | Keeper_event_queue.Task_cancelled _ ->
+      None
+  in
+  (* RFC-0377 P1-1: preload every batch member's recorded attention item in
+     one [Keeper_external_attention] scan instead of letting each
+     [consume_single_heartbeat_stimulus] call re-scan the whole event log
+     for its own event_id — an O(N) rescans regression on exactly the
+     backlog scenario this RFC drains (see the [dedup_window_bytes]
+     comment in keeper_external_attention.ml for the same O(file)-per-call
+     trap on the write side). [None] when the primary is not itself
+     Connector_attention, or has no companions: a preload there would
+     still cost one full scan, so that single lookup is left to
+     [consume_single_heartbeat_stimulus]'s own one-id fallback instead of
+     duplicating the cost here. *)
+  let connector_attention_items_of_batch
+        (selection : Keeper_event_queue_state.pending_selection)
+        (companions : Keeper_event_queue_state.pending_selection list)
+    =
+    match connector_attention_event_id selection.source, companions with
+    | None, _ | Some _, [] -> None
+    | Some _, _ :: _ ->
+      let event_ids =
+        List.filter_map
+          connector_attention_event_id
+          (selection.source
+           :: List.map
+                (fun (c : Keeper_event_queue_state.pending_selection) -> c.source)
+                companions)
+      in
+      Some
+        (Keeper_external_attention.recorded_items_by_event_ids
+           ~base_path
+           ~keeper_name
+           ~event_ids)
+  in
   (* [first_withdrawn] keeps the first transient failure of the cycle so the
      reported error still names the entry that was actually unavailable, even
      when a later entry supplies the turn. *)
@@ -579,14 +637,18 @@ let heartbeat_event_intake
        | Some (selection, unavailable) ->
          [], [], Some selection, [], Some (Transient_board_read unavailable))
     | Ok (Some selection) ->
+      let companions = connector_attention_batch_of_selection selection in
+      let connector_attention_items =
+        connector_attention_items_of_batch selection companions
+      in
       (match
          consume_single_heartbeat_stimulus
            ~ctx
            ~meta_after_triage
+           ?connector_attention_items
            selection.source
        with
        | Stimulus_consumed primary_observations ->
-         let companions = connector_attention_batch_of_selection selection in
          let companion_observations =
            List.concat_map
              (fun (companion : Keeper_event_queue_state.pending_selection) ->
@@ -594,6 +656,7 @@ let heartbeat_event_intake
                   consume_single_heartbeat_stimulus
                     ~ctx
                     ~meta_after_triage
+                    ?connector_attention_items
                     companion.source
                 with
                 | Stimulus_consumed observations -> observations

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -172,6 +172,7 @@ type heartbeat_event_intake = {
   consumed_stimulus_count : int;
   consumed_stimuli : Keeper_event_queue.stimulus list;
   pending_selection : Keeper_event_queue_state.pending_selection option;
+  consumed_selections : Keeper_event_queue_state.pending_selection list;
   event_queue_intake_error : event_queue_intake_error option;
   event_queue_triggers : Keeper_world_observation.event_queue_trigger list;
 }
@@ -533,6 +534,34 @@ let heartbeat_event_intake
            keeper_name;
          select_pending_after_spent_reconciliation ())
   in
+  (* RFC-0377: once the primary selection is a Connector_attention stimulus,
+     drain every OTHER pending stimulus for the same conversation and admit
+     the whole backlog in this turn instead of one message per turn. The
+     durable read is skipped for every other payload kind, so non-connector
+     turns pay no extra cost. *)
+  let connector_attention_batch_of_selection
+        (selection : Keeper_event_queue_state.pending_selection)
+    =
+    match
+      Keeper_event_queue.connector_attention_channel selection.source.payload
+    with
+    | None -> []
+    | Some _channel ->
+      (match
+         Keeper_registry_event_queue.connector_attention_conversation_batch_result
+           ~base_path
+           keeper_name
+           ~primary:selection
+       with
+       | Ok companions -> companions
+       | Error message ->
+         Log.Keeper.warn
+           "turn entry: connector attention conversation batch lookup \
+            failed, admitting single stimulus keeper=%s: %s"
+           keeper_name
+           message;
+         [])
+  in
   (* [first_withdrawn] keeps the first transient failure of the cycle so the
      reported error still names the entry that was actually unavailable, even
      when a later entry supplies the turn. *)
@@ -543,12 +572,12 @@ let heartbeat_event_intake
         "turn entry: event queue selection failed keeper=%s: %s"
         keeper_name
         message;
-      [], [], None, Some (Pending_selection_failed message)
+      [], [], None, [], Some (Pending_selection_failed message)
     | Ok None ->
       (match first_withdrawn with
-       | None -> [], [], None, None
+       | None -> [], [], None, [], None
        | Some (selection, unavailable) ->
-         [], [], Some selection, Some (Transient_board_read unavailable))
+         [], [], Some selection, [], Some (Transient_board_read unavailable))
     | Ok (Some selection) ->
       (match
          consume_single_heartbeat_stimulus
@@ -556,8 +585,43 @@ let heartbeat_event_intake
            ~meta_after_triage
            selection.source
        with
-       | Stimulus_consumed observations ->
-         observations, [ selection.source ], Some selection, None
+       | Stimulus_consumed primary_observations ->
+         let companions = connector_attention_batch_of_selection selection in
+         let companion_observations =
+           List.concat_map
+             (fun (companion : Keeper_event_queue_state.pending_selection) ->
+                match
+                  consume_single_heartbeat_stimulus
+                    ~ctx
+                    ~meta_after_triage
+                    companion.source
+                with
+                | Stimulus_consumed observations -> observations
+                | Stimulus_retry_later _ ->
+                  (* Unreachable in practice: [consume_single_heartbeat_stimulus]
+                     only returns [Stimulus_retry_later] for a Board/Fusion/etc.
+                     transient read, never for [Connector_attention], and every
+                     batch companion is itself a [Connector_attention] stimulus
+                     (see [connector_attention_batch_of_selection] above). Matched
+                     exhaustively rather than assumed away: treat it as "no
+                     observation from this companion" instead of dropping it
+                     from the batch, so an unforeseen future change here fails
+                     safe (companion stays consumed and acked, just contributes
+                     nothing to the turn context) instead of silently. *)
+                  [])
+             companions
+         in
+         let selections = selection :: companions in
+         let stimuli =
+           List.map
+             (fun (s : Keeper_event_queue_state.pending_selection) -> s.source)
+             selections
+         in
+         ( primary_observations @ companion_observations
+         , stimuli
+         , Some selection
+         , selections
+         , None )
        | Stimulus_retry_later unavailable ->
          withdrawn_this_cycle := selection.source :: !withdrawn_this_cycle;
          Log.Keeper.info
@@ -573,11 +637,19 @@ let heartbeat_event_intake
          in
          intake_selection first_withdrawn)
   in
-  let queued_observations, consumed_stimuli, pending_selection, event_queue_intake_error =
+  let ( queued_observations
+      , consumed_stimuli
+      , pending_selection
+      , consumed_selections
+      , event_queue_intake_error )
+    =
     intake_selection None
   in
   let consumed_stimulus_count = List.length consumed_stimuli in
-  let event_queue_triggers = List.filter_map event_queue_trigger_of_stimulus consumed_stimuli in
+  let event_queue_triggers =
+    List.filter_map event_queue_trigger_of_stimulus consumed_stimuli
+    |> List.sort_uniq compare
+  in
   let pending_board_events =
     List.fold_left
       (fun acc (event : Keeper_world_observation.pending_board_event) ->
@@ -619,6 +691,7 @@ let heartbeat_event_intake
   ; consumed_stimulus_count
   ; consumed_stimuli
   ; pending_selection
+  ; consumed_selections
   ; event_queue_intake_error
   ; event_queue_triggers
   }

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.mli
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.mli
@@ -90,6 +90,7 @@ type heartbeat_event_intake = {
   consumed_stimulus_count : int;
   consumed_stimuli : Keeper_event_queue.stimulus list;
   pending_selection : Keeper_event_queue_state.pending_selection option;
+  consumed_selections : Keeper_event_queue_state.pending_selection list;
   event_queue_intake_error : event_queue_intake_error option;
   event_queue_triggers : Keeper_world_observation.event_queue_trigger list;
 }
@@ -121,13 +122,25 @@ val reconcile_spent_selection
 
 (** [heartbeat_event_intake ~ctx ~meta_after_triage
      ~pending_board_events]
-    peeks at most one ready Event-Layer stimulus (per RFC-0020 §3 Rule 4).
-    A pending [Manual_compaction_requested] is the sole runtime
+    peeks at most one ready Event-Layer *selection* per turn (per RFC-0020
+    §3 Rule 4). A pending [Manual_compaction_requested] is the sole runtime
     exception: it is selected ahead of data-plane stimuli so an in-flight
     source checkpoint can yield, compact, and then resume from the unchanged
-    durable queue. The selected observation is merged with the
-    [pending_board_events] already accumulated by the caller, deduplicating by
-    [post_id]. A
+    durable queue.
+
+    RFC-0377: when that selection is a [Connector_attention] stimulus, every
+    OTHER pending [Connector_attention] stimulus for the same conversation
+    (same {!Keeper_continuation_channel.same_conversation} channel) is
+    admitted into this same turn too, in arrival order — one turn sees the
+    whole backlog for that conversation instead of one message per turn.
+    [consumed_stimuli]/[consumed_selections] then hold every admitted
+    stimulus (primary first), not only the primary; [pending_selection]
+    stays the primary alone. Other conversations' stimuli, and every
+    non-[Connector_attention] payload, keep the pre-RFC-0377 single-stimulus
+    behavior.
+
+    The selected observation(s) are merged with the [pending_board_events]
+    already accumulated by the caller, deduplicating by [post_id]. A
     [Hitl_resolved] stimulus remains queued until its exact approval id has
     left the pending map, while later ready stimuli can still be selected.
     A transient Board read returns no consumed stimuli, keeps the exact

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.mli
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.mli
@@ -98,10 +98,22 @@ type heartbeat_event_intake = {
 (** [consume_single_heartbeat_stimulus ~ctx ~meta_after_triage stim]
     increments Otel_metric_store and logs only after consumption is known.
     A transient Board read returns [Stimulus_retry_later] without incrementing
-    the consumed counter. *)
+    the consumed counter.
+
+    [?connector_attention_items] (RFC-0377 P1-1): for a [Connector_attention]
+    stimulus, a preloaded (event_id, item) association to resolve [stim]'s
+    recorded item from instead of a fresh
+    {!Keeper_external_attention.load_events} scan. The caller supplies this
+    when consuming a batch of Connector_attention stimuli (the primary plus
+    same-conversation companions) so the whole batch costs one scan
+    ({!Keeper_external_attention.recorded_items_by_event_ids}) rather than
+    one scan per stimulus. Omitted (or [None]), this falls back to the
+    original one-id-at-a-time lookup — unchanged for every non-batched
+    call. Ignored for every other payload kind. *)
 val consume_single_heartbeat_stimulus
   :  ctx:_ context
   -> meta_after_triage:keeper_meta
+  -> ?connector_attention_items:(string * Keeper_external_attention.item) list
   -> Keeper_event_queue.stimulus
   -> stimulus_intake_result
 

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -685,6 +685,16 @@ let select_when_result ~base_path name ~ready =
       ~ready
 ;;
 
+let connector_attention_conversation_batch_result ~base_path name ~primary =
+  match Keeper_registry.get ~base_path name with
+  | None -> Error (Printf.sprintf "keeper not registered: %s" name)
+  | Some _ ->
+    Keeper_event_queue_persistence.connector_attention_conversation_batch_result
+      ~base_path
+      ~keeper_name:name
+      ~primary
+;;
+
 let validate_pending_selection_result ~base_path name ~selection =
   Keeper_event_queue_persistence.validate_pending_selection_result
     ~base_path

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -84,6 +84,16 @@ val select_when_result :
   ready:(Keeper_event_queue.stimulus -> bool) ->
   (Keeper_event_queue_state.pending_selection option, string) result
 
+val connector_attention_conversation_batch_result :
+  base_path:string ->
+  string ->
+  primary:Keeper_event_queue_state.pending_selection ->
+  (Keeper_event_queue_state.pending_selection list, string) result
+(** Every OTHER pending [Connector_attention] entry for [primary]'s
+    conversation, in arrival order (RFC-0377). [[]] when [primary] is not a
+    [Connector_attention] selection. See
+    {!Keeper_event_queue_state.connector_attention_conversation_batch}. *)
+
 val validate_pending_selection_result :
   base_path:string ->
   string ->

--- a/lib/keeper_runtime/keeper_continuation_channel.ml
+++ b/lib/keeper_runtime/keeper_continuation_channel.ml
@@ -181,6 +181,42 @@ let same_route a b =
   | (Dashboard _ | Discord _ | Slack _ | Unrouted _), (Dashboard _ | Discord _ | Slack _ | Unrouted _)
     -> false
 
+(* RFC-0377: batching pending Connector_attention stimuli needs "is this the
+   same conversation", which is deliberately looser than [same_route].
+   [reply_to_message_id] (Discord) is stamped with the inbound message's own
+   id at enqueue time (server_discord_in_process_gateway.handle_ambient), so
+   every ambient message gets a distinct value there — comparing it would
+   make two pending messages from the same channel never coalesce, which
+   defeats the batch this predicate exists to build. [thread_ts] (Slack) has
+   the same per-message shape at the ambient producer. [channel_id] alone is
+   already the exact conversation coordinate: an existing comment on
+   [slack_conversation_id] establishes this for Slack ("threads share the
+   parent channel id, so the conversation id is keyed on the channel
+   alone"), and the Discord producer sets [thread_id = Some channel_id] when
+   [channel_id] is itself a tracked thread, so [channel_id] alone already
+   disambiguates thread vs. parent channel. [user_id] is the message's
+   author, not the conversation's location, so two different users posting
+   into the same channel still share one conversation coordinate — the
+   Keeper decides per RFC-0377 §3 whether to answer each individually. *)
+let same_conversation a b =
+  match a, b with
+  | Dashboard { thread_id = left }, Dashboard { thread_id = right } ->
+    String.equal left right
+  | ( Discord { guild_id = left_guild; channel_id = left_channel; _ }
+    , Discord { guild_id = right_guild; channel_id = right_channel; _ } ) ->
+    same_string_option left_guild right_guild
+    && String.equal left_channel right_channel
+  | ( Slack { channel_id = left_channel; _ }
+    , Slack { channel_id = right_channel; _ } ) ->
+    String.equal left_channel right_channel
+  | Unrouted _, Unrouted _ -> false
+  (* Distinct-constructor pairs share no conversation. Listing the
+     constructors explicitly (not [_]) keeps this exhaustive: a new
+     connector forces a compile error here rather than silently
+     defaulting to [false]. *)
+  | (Dashboard _ | Discord _ | Slack _ | Unrouted _), (Dashboard _ | Discord _ | Slack _ | Unrouted _)
+    -> false
+
 let option_string_fields fields =
   List.filter_map
     (fun (name, value) -> Option.map (fun value -> name, `String value) value)

--- a/lib/keeper_runtime/keeper_continuation_channel.ml
+++ b/lib/keeper_runtime/keeper_continuation_channel.ml
@@ -189,23 +189,27 @@ let same_route a b =
    make two pending messages from the same channel never coalesce, which
    defeats the batch this predicate exists to build. [thread_ts] (Slack) has
    the same per-message shape at the ambient producer. [channel_id] alone is
-   already the exact conversation coordinate: an existing comment on
-   [slack_conversation_id] establishes this for Slack ("threads share the
-   parent channel id, so the conversation id is keyed on the channel
-   alone"), and the Discord producer sets [thread_id = Some channel_id] when
-   [channel_id] is itself a tracked thread, so [channel_id] alone already
-   disambiguates thread vs. parent channel. [user_id] is the message's
-   author, not the conversation's location, so two different users posting
-   into the same channel still share one conversation coordinate — the
-   Keeper decides per RFC-0377 §3 whether to answer each individually. *)
+   already the exact conversation coordinate, for both connectors:
+   - Discord channel ids are Discord-global-unique snowflakes (never reused
+     across guilds), so comparing [guild_id] too would be redundant, not
+     more precise — [channel_id] alone is compared here. The Discord
+     producer additionally sets [thread_id = Some channel_id] when
+     [channel_id] is itself a tracked thread, so [channel_id] alone already
+     disambiguates thread vs. parent channel too.
+   - An existing comment on [slack_conversation_id] establishes the same for
+     Slack ("threads share the parent channel id, so the conversation id is
+     keyed on the channel alone").
+   [user_id] is the message's author, not the conversation's location, so
+   two different users posting into the same channel still share one
+   conversation coordinate — the Keeper decides per RFC-0377 §3 whether to
+   answer each individually. *)
 let same_conversation a b =
   match a, b with
   | Dashboard { thread_id = left }, Dashboard { thread_id = right } ->
     String.equal left right
-  | ( Discord { guild_id = left_guild; channel_id = left_channel; _ }
-    , Discord { guild_id = right_guild; channel_id = right_channel; _ } ) ->
-    same_string_option left_guild right_guild
-    && String.equal left_channel right_channel
+  | ( Discord { channel_id = left_channel; _ }
+    , Discord { channel_id = right_channel; _ } ) ->
+    String.equal left_channel right_channel
   | ( Slack { channel_id = left_channel; _ }
     , Slack { channel_id = right_channel; _ } ) ->
     String.equal left_channel right_channel

--- a/lib/keeper_runtime/keeper_continuation_channel.mli
+++ b/lib/keeper_runtime/keeper_continuation_channel.mli
@@ -79,6 +79,16 @@ val describe : t -> string
     destination to share). *)
 val same_route : t -> t -> bool
 
+(** [same_conversation a b] is [true] when two channels identify the same
+    connector conversation for stimulus-batching purposes (RFC-0377): same
+    channel/thread location, regardless of which specific message a reply
+    would target. This is deliberately looser than {!same_route}: Discord's
+    [reply_to_message_id] and Slack's [thread_ts] are stamped per inbound
+    message at the ambient producer, so two pending messages from the same
+    conversation almost never share a {!same_route} value. Two [Unrouted]
+    values are never the same conversation, matching {!same_route}. *)
+val same_conversation : t -> t -> bool
+
 (** [to_yojson t] serializes to a tagged object [{ "kind": <tag>; ... }]. *)
 val to_yojson : t -> Yojson.Safe.t
 

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -362,6 +362,18 @@ let is_board_signal = function
   | Task_cancelled _ ->
     false
 
+(* RFC-0377: the batch-intake predicate needs the routed channel without
+   repeating the payload match at every call site. Exhaustive on purpose,
+   like [is_board_signal] above: a new payload kind must decide here at
+   compile time whether it carries a conversation channel. *)
+let connector_attention_channel = function
+  | Connector_attention { channel; _ } -> Some channel
+  | Board_signal _ | Board_attention _ | Bootstrap | Fusion_completed _
+  | Schedule_due _ | Hitl_resolved _ | Manual_compaction_requested
+  | Goal_assigned _ | Goal_reconciliation_ready _
+  | Completion_authority_rejected _ | Task_cancelled _ ->
+    None
+
 let drain_board_all (queue : t) : stimulus list * t =
   let board, rest =
     List.partition (fun s -> is_board_signal s.payload) (to_list queue)

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -317,6 +317,12 @@ val urgency_of_string : string -> (urgency, string) result
 val is_board_signal : stimulus_payload -> bool
 (** [true] iff the payload is a [Board_signal]. *)
 
+val connector_attention_channel :
+  stimulus_payload -> Keeper_continuation_channel.t option
+(** [Some channel] iff the payload is [Connector_attention], carrying its
+    routed channel. [None] for every other payload kind (RFC-0377 batch
+    intake). *)
+
 val drain_board_all : t -> stimulus list * t
 (** [drain_board_all q] separates every board-signal stimulus from the
     rest of the queue, regardless of arrival time (RFC-0334 W2: the turn

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -972,6 +972,13 @@ let select_when_result ~base_path ~keeper_name ~ready =
   | Ok state -> Ok (State.select_when ~ready state)
 ;;
 
+let connector_attention_conversation_batch_result ~base_path ~keeper_name ~primary =
+  match load_state_result ~base_path ~keeper_name with
+  | Error _ as error -> error
+  | Ok state ->
+    Ok (State.connector_attention_conversation_batch ~primary state)
+;;
+
 let validate_pending_selection_result ~base_path ~keeper_name ~selection =
   match load_state_result ~base_path ~keeper_name with
   | Error _ as error -> error

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -113,6 +113,15 @@ val select_when_result :
   ready:(Keeper_event_queue.stimulus -> bool) ->
   (Keeper_event_queue_state.pending_selection option, string) result
 
+val connector_attention_conversation_batch_result :
+  base_path:string ->
+  keeper_name:string ->
+  primary:Keeper_event_queue_state.pending_selection ->
+  (Keeper_event_queue_state.pending_selection list, string) result
+(** Durable read wrapper over
+    {!Keeper_event_queue_state.connector_attention_conversation_batch}
+    (RFC-0377). *)
+
 val validate_pending_selection_result :
   base_path:string ->
   keeper_name:string ->

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -261,6 +261,36 @@ let peek_when ~ready state =
 
 let select_when ~ready state = first_ready_entry ~ready state.pending_entries
 
+(* RFC-0377: once [select_when] has picked a Connector_attention primary,
+   gather every OTHER pending entry for the same conversation so one turn
+   admits the whole backlog instead of one message per turn. Read-only, like
+   [select_when] — it removes nothing from [state]; the caller is
+   responsible for admitting and later acknowledging each returned entry
+   through the normal pending-selection lifecycle (RFC-0020 §3 claim
+   semantics unchanged). [state.pending_entries] preserves arrival order
+   among same-urgency entries ([Keeper_event_queue.enqueue] only appends,
+   and [sort_by_urgency] is a stable sort), and every Connector_attention
+   stimulus is enqueued at [Low] urgency, so the returned list is already in
+   arrival order. *)
+let connector_attention_conversation_batch ~(primary : pending_selection) state =
+  match
+    Keeper_event_queue.connector_attention_channel primary.source.Keeper_event_queue.payload
+  with
+  | None -> []
+  | Some primary_channel ->
+    List.filter
+      (fun (entry : pending_selection) ->
+         (not (entry = primary))
+         &&
+         match
+           Keeper_event_queue.connector_attention_channel
+             entry.source.Keeper_event_queue.payload
+         with
+         | Some entry_channel ->
+           Keeper_continuation_channel.same_conversation primary_channel entry_channel
+         | None -> false)
+      state.pending_entries
+
 let validate_pending_selection
       ~(selection : pending_selection)
       state

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -133,6 +133,17 @@ val peek_when :
 val select_when :
   ready:(Keeper_event_queue.stimulus -> bool) -> t -> pending_selection option
 
+val connector_attention_conversation_batch :
+  primary:pending_selection -> t -> pending_selection list
+(** [connector_attention_conversation_batch ~primary state] returns every
+    OTHER pending entry in [state] whose payload is [Connector_attention]
+    and whose channel is the same conversation
+    ({!Keeper_continuation_channel.same_conversation}) as [primary]'s
+    channel, in their existing FIFO order (RFC-0377). [[]] when [primary]
+    is not itself a [Connector_attention] selection, or no other pending
+    entry shares its conversation. A pure read like {!select_when}: it does
+    not remove anything from [state]. *)
+
 val validate_pending_selection :
   selection:pending_selection ->
   t ->

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -255,6 +255,7 @@ normal_targets=(
   @test/runtest-test_ide_bridge
   @test/runtest-test_keeper_librarian_retry
   @test/runtest-test_keeper_run_tools_hooks
+  @test/runtest-test_keeper_connector_attention_batch
   @test/runtest-test_ide_lsp_join_key
   @test/runtest-test_dashboard_workspace
   @test/runtest-test_host_fd_pressure_poller

--- a/test/dune
+++ b/test/dune
@@ -769,6 +769,17 @@
  (modules test_keeper_board_unavailable)
  (libraries masc_test_deps))
 
+; RFC-0377: conversation-batched Connector_attention intake. A backlog of
+; pending messages in the same connector conversation is admitted into one
+; turn instead of draining one message per turn. Uses the same Eio ctx +
+; durable-registry harness as test_keeper_board_unavailable above, so it owns
+; its own executable stanza rather than the pure-synchronous test group.
+
+(test
+ (name test_keeper_connector_attention_batch)
+ (modules test_keeper_connector_attention_batch)
+ (libraries masc_test_deps))
+
 ; #26348: explicit owner-lane manual compaction preempts a checkpointed
 ; data-plane source, then the unchanged durable source resumes.
 

--- a/test/keeper_continuation_channel/test_keeper_continuation_channel.ml
+++ b/test/keeper_continuation_channel/test_keeper_continuation_channel.ml
@@ -3,7 +3,8 @@
    Covers the closed-variant contract:
      - codec round-trips for every constructor,
      - fail-closed parsing (unknown kind / missing or malformed field / legacy alias -> Error),
-     - the routing helpers (is_routable, kind_label, same_route). *)
+     - the routing helpers (is_routable, kind_label, same_route,
+       same_conversation). *)
 
 open Keeper_continuation_channel
 
@@ -284,6 +285,111 @@ let test_same_route () =
   (* two Unrouted values never share a route (no destination to share) *)
   assert (not (same_route (unrouted "a") (unrouted "a")))
 
+(* RFC-0377: [same_conversation] batches pending Connector_attention
+   stimuli by "same channel/thread location", deliberately looser than
+   [same_route] (which requires the full per-message coordinate, including
+   [reply_to_message_id]/[thread_ts], to match). *)
+let test_same_conversation () =
+  (* same location, differing per-message coordinates -> same conversation
+     (this is the entire point: two pending ambient messages never share a
+     [reply_to_message_id], so [same_route] alone could never batch them). *)
+  assert (
+    same_conversation
+      (discord_channel
+         ~guild_id:(Some "g")
+         ~channel_id:"c"
+         ~parent_channel_id:(Some "p")
+         ~thread_id:(Some "t")
+         ~reply_to_message_id:"message-1"
+         ~user_id:"user-a"
+         ())
+      (discord_channel
+         ~guild_id:(Some "g")
+         ~channel_id:"c"
+         ~parent_channel_id:None
+         ~thread_id:None
+         ~reply_to_message_id:"message-2"
+         ~user_id:"user-b"
+         ()));
+  (* P2-3: Discord channel ids are Discord-global-unique snowflakes, so
+     [guild_id] is redundant with [channel_id], not an additional
+     precision — None vs Some for the same [channel_id] must still be the
+     same conversation. *)
+  assert (
+    same_conversation
+      (discord_channel
+         ~guild_id:None
+         ~channel_id:"c"
+         ~parent_channel_id:None
+         ~thread_id:None
+         ~user_id:"user-a"
+         ())
+      (discord_channel
+         ~guild_id:(Some "some-guild")
+         ~channel_id:"c"
+         ~parent_channel_id:None
+         ~thread_id:None
+         ~user_id:"user-b"
+         ()));
+  (* different channel -> different conversation *)
+  assert (
+    not
+      (same_conversation
+         (discord_channel
+            ~guild_id:(Some "g")
+            ~channel_id:"c1"
+            ~parent_channel_id:None
+            ~thread_id:None
+            ~user_id:"u"
+            ())
+         (discord_channel
+            ~guild_id:(Some "g")
+            ~channel_id:"c2"
+            ~parent_channel_id:None
+            ~thread_id:None
+            ~user_id:"u"
+            ())));
+  (* Slack: same channel, differing per-message thread_ts/team_id/user_id ->
+     same conversation (channel_id alone is the coordinate, matching the
+     existing [slack_conversation_id] precedent). *)
+  assert (
+    same_conversation
+      (slack_channel
+         ~team_id:(Some "team-1")
+         ~channel_id:"general"
+         ~thread_ts:(Some "1.000001")
+         ~user_id:"user-a")
+      (slack_channel
+         ~team_id:None
+         ~channel_id:"general"
+         ~thread_ts:(Some "2.000002")
+         ~user_id:"user-b"));
+  assert (
+    not
+      (same_conversation
+         (slack_channel
+            ~team_id:(Some "team-1")
+            ~channel_id:"general"
+            ~thread_ts:None
+            ~user_id:"u")
+         (slack_channel
+            ~team_id:(Some "team-1")
+            ~channel_id:"random"
+            ~thread_ts:None
+            ~user_id:"u")));
+  (* Dashboard: thread_id is the whole coordinate, no per-message field to
+     strip. *)
+  assert (same_conversation (dashboard_channel "t1") (dashboard_channel "t1"));
+  assert (not (same_conversation (dashboard_channel "t1") (dashboard_channel "t2")));
+  (* different constructor -> never the same conversation *)
+  assert (
+    not
+      (same_conversation
+         (dashboard_channel "t")
+         (slack_channel ~team_id:None ~channel_id:"c" ~thread_ts:None ~user_id:"u")));
+  (* two Unrouted values never share a conversation, matching [same_route] *)
+  assert (not (same_conversation (unrouted "a") (unrouted "a")))
+
 let test_discord_thread_parent_preserves_thread_target () =
   let channel =
     discord_channel
@@ -325,5 +431,6 @@ let () =
   test_is_routable ();
   test_kind_label ();
   test_same_route ();
+  test_same_conversation ();
   test_discord_thread_parent_preserves_thread_target ();
   print_endline "Keeper_continuation_channel: all tests passed"

--- a/test/test_keeper_connector_attention_batch.ml
+++ b/test/test_keeper_connector_attention_batch.ml
@@ -1,0 +1,398 @@
+(* test_keeper_connector_attention_batch.ml — RFC-0377: conversation-batched
+   stimulus intake.
+
+   sangsu live data (2026-08-08..08-13) showed every delivered continuation
+   obligation (48/48) bound 1:1 to a single distinct inbound message: a turn
+   admitted exactly one Connector_attention stimulus (RFC-0020 Rule 4), so a
+   backlog of N pending messages in the same conversation took N turns to
+   drain, and inbound-to-reply lag grew monotonically (438s to 4,461s,
+   median 1,533s) as live traffic outran the one-per-turn drain rate.
+
+   This suite pins the fix: once [heartbeat_event_intake]'s primary
+   selection is a [Connector_attention] stimulus, it drains every OTHER
+   pending [Connector_attention] stimulus for the same conversation into the
+   same turn, in arrival order (RFC-0377 S3) — and the durable queue
+   lifecycle applies to every admitted member, not only the primary: a turn
+   completion acks the whole batch, a turn failure leaves the whole batch
+   queued (no partial ack). *)
+
+open Alcotest
+open Masc
+module Q = Keeper_event_queue
+module A = Keeper_external_attention
+
+let contains ~needle haystack =
+  let nl = String.length needle in
+  let hl = String.length haystack in
+  let rec loop i =
+    (i + nl <= hl)
+    && (String.equal (String.sub haystack i nl) needle || loop (i + 1))
+  in
+  nl = 0 || loop 0
+;;
+
+let test_meta name =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+         [ "name", `String name
+         ; "agent_name", `String ("keeper-" ^ name ^ "-agent")
+         ; "trace_id", `String ("trace-" ^ name)
+         ])
+  with
+  | Ok meta -> meta
+  | Error detail -> failf "meta fixture failed: %s" detail
+;;
+
+let enqueue_exn ~base_path keeper_name source =
+  match
+    Keeper_registry_event_queue.enqueue_durable_result
+      ~base_path
+      keeper_name
+      source
+  with
+  | Ok () -> ()
+  | Error detail -> failf "durable enqueue failed: %s" detail
+;;
+
+let discord_surface ~channel_id =
+  A.Discord
+    { guild_id = Some "guild-batch"
+    ; channel_id
+    ; parent_channel_id = None
+    ; thread_id = None
+    }
+;;
+
+(* Mirrors [server_discord_in_process_gateway.handle_ambient]: every ambient
+   message is recorded as its own [Keeper_external_attention] item and
+   enqueued as its own [Connector_attention] stimulus whose channel carries
+   [reply_to_message_id = message_id] — the message's OWN id, distinct per
+   message. That is exactly why [Keeper_continuation_channel.same_route]
+   cannot be the batching predicate: two pending messages from the same
+   conversation never share a [same_route] value. [same_conversation]
+   (channel_id-only, RFC-0377) is what lets this batch form at all. *)
+let connector_attention_stimulus
+      ~base_path ~keeper_name ~channel_id ~message_id ~arrived_at ~content
+  : Q.stimulus
+  =
+  let event_id = Printf.sprintf "evt-%s-%s" channel_id message_id in
+  let item : A.item =
+    { A.event_id
+    ; dedupe_key = event_id
+    ; keeper_name
+    ; conversation =
+        { conversation_id = "discord:" ^ channel_id
+        ; surface = discord_surface ~channel_id
+        }
+    ; external_message =
+        Some
+          { surface = discord_surface ~channel_id
+          ; message_id
+          ; reply_to_message_id = None
+          }
+    ; source_label = "discord"
+    ; actor =
+        { actor_id = Some "user-batch"
+        ; display_name = Some "Batch User"
+        ; authority = Keeper_chat_store.External
+        }
+    ; urgency = A.Ambient
+    ; content_preview = content
+    ; content_ref = None
+    ; received_at = arrived_at
+    ; metadata = [ "route", "ambient" ]
+    }
+  in
+  (match A.record ~base_path item with
+   | `Recorded -> ()
+   | `Duplicate _ -> failf "unexpected duplicate external attention: %s" event_id
+   | `Error detail -> failf "external attention record failed: %s" detail);
+  let channel =
+    match
+      Keeper_continuation_channel.discord
+        ~guild_id:(Some "guild-batch")
+        ~channel_id
+        ~parent_channel_id:None
+        ~thread_id:None
+        ~reply_to_message_id:message_id
+        ~user_id:"user-batch"
+        ()
+    with
+    | Ok channel -> channel
+    | Error detail -> failf "channel fixture failed: %s" detail
+  in
+  { Q.post_id = event_id
+  ; urgency = Q.Low
+  ; arrived_at
+  ; payload = Q.Connector_attention { event_id; channel }
+  }
+;;
+
+(* A Board_signal distractor that is never expected to be read: it exists
+   only to prove the batch filter skips a non-[Connector_attention] entry
+   sitting between two conversation matches instead of taking a naive
+   contiguous prefix. *)
+let board_distractor_stimulus ~post_id ~arrived_at : Q.stimulus =
+  { Q.post_id
+  ; urgency = Q.Normal
+  ; arrived_at
+  ; payload =
+      Q.Board_signal
+        { kind = Q.Post_created
+        ; author = "external-author"
+        ; title = "distractor"
+        ; content = "never consumed by this suite"
+        ; hearth = None
+        ; updated_at = None
+        }
+  }
+;;
+
+let connector_event_ids_of_queue queue =
+  Q.to_list queue
+  |> List.filter_map (fun (s : Q.stimulus) ->
+       match s.Q.payload with
+       | Q.Connector_attention { event_id; _ } -> Some event_id
+       | Q.Board_signal _ | Q.Board_attention _ | Q.Bootstrap
+       | Q.Fusion_completed _ | Q.Schedule_due _ | Q.Hitl_resolved _
+       | Q.Manual_compaction_requested | Q.Goal_assigned _
+       | Q.Goal_reconciliation_ready _ | Q.Completion_authority_rejected _
+       | Q.Task_cancelled _ -> None)
+  |> List.sort String.compare
+;;
+
+let with_ctx keeper_name f =
+  Eio_main.run
+  @@ fun env ->
+  Masc_test_deps.ensure_rng_initialized ();
+  Masc_test_deps.init_eio_clock env;
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio.Switch.run
+  @@ fun sw ->
+  let base_path = Masc_test_deps.setup_test_workspace () in
+  Keeper_registry.For_testing.clear ();
+  Fun.protect
+    ~finally:(fun () -> Keeper_registry.For_testing.clear ())
+  @@ fun () ->
+  let config = Workspace.default_config base_path in
+  let meta = test_meta keeper_name in
+  ignore (Keeper_registry.For_testing.register ~base_path keeper_name meta);
+  let ctx : _ Keeper_types_profile.context =
+    { config
+    ; agent_name = "connector-attention-batch-test"
+    ; sw
+    ; clock = Eio.Stdenv.clock env
+    ; proc_mgr = None
+    ; net = None
+    ; publication_recovery_provider =
+        Masc_test_deps.non_runtime_publication_recovery_provider
+    }
+  in
+  f ~base_path ~keeper_name ~meta ~ctx
+;;
+
+(* RFC-0377 S5.1: channel A has 3 pending Connector_attention + channel B
+   has 2, interleaved on the queue (A1, B1, A2, B2, A3) so the batch filter
+   must select past channel B's entries, not just take a prefix. One intake
+   admits A's 3 in arrival order; B's 2 stay queued untouched. *)
+let test_batch_admits_same_conversation_in_arrival_order_leaves_other_channel_queued
+      ()
+  =
+  with_ctx "connector-batch-channels" (fun ~base_path ~keeper_name ~meta ~ctx ->
+    let a1 =
+      connector_attention_stimulus ~base_path ~keeper_name ~channel_id:"chan-A"
+        ~message_id:"a1" ~arrived_at:1.0 ~content:"MARK-CHAN-A-1"
+    in
+    let b1 =
+      connector_attention_stimulus ~base_path ~keeper_name ~channel_id:"chan-B"
+        ~message_id:"b1" ~arrived_at:1.5 ~content:"MARK-CHAN-B-1"
+    in
+    let a2 =
+      connector_attention_stimulus ~base_path ~keeper_name ~channel_id:"chan-A"
+        ~message_id:"a2" ~arrived_at:2.0 ~content:"MARK-CHAN-A-2"
+    in
+    let b2 =
+      connector_attention_stimulus ~base_path ~keeper_name ~channel_id:"chan-B"
+        ~message_id:"b2" ~arrived_at:2.5 ~content:"MARK-CHAN-B-2"
+    in
+    let a3 =
+      connector_attention_stimulus ~base_path ~keeper_name ~channel_id:"chan-A"
+        ~message_id:"a3" ~arrived_at:3.0 ~content:"MARK-CHAN-A-3"
+    in
+    List.iter (enqueue_exn ~base_path keeper_name) [ a1; b1; a2; b2; a3 ];
+    let intake =
+      Keeper_heartbeat_stimulus_intake.heartbeat_event_intake
+        ~ctx
+        ~meta_after_triage:meta
+        ~pending_board_events:[]
+    in
+    check int "channel A's 3 pending messages are all admitted in one turn" 3
+      intake.consumed_stimulus_count;
+    check
+      (list string)
+      "consumed_stimuli are exactly channel A's, in arrival order"
+      [ a1.Q.post_id; a2.Q.post_id; a3.Q.post_id ]
+      (List.map (fun (s : Q.stimulus) -> s.Q.post_id) intake.consumed_stimuli);
+    check int "consumed_selections mirrors the same batch" 3
+      (List.length intake.consumed_selections);
+    check
+      (list string)
+      "consumed_selections carries channel A's sources, in arrival order"
+      [ a1.Q.post_id; a2.Q.post_id; a3.Q.post_id ]
+      (List.map
+         (fun (s : Keeper_event_queue_state.pending_selection) -> s.source.Q.post_id)
+         intake.consumed_selections);
+    check int "the turn context carries all 3 observations" 3
+      (List.length intake.pending_board_events);
+    List.iteri
+      (fun i marker ->
+         match List.nth_opt intake.pending_board_events i with
+         | None -> failf "missing pending_board_event at index %d" i
+         | Some (ev : Keeper_world_observation.pending_board_event) ->
+           check bool
+             (Printf.sprintf "observation %d carries %s in arrival order" i marker)
+             true
+             (contains ~needle:marker ev.preview))
+      [ "MARK-CHAN-A-1"; "MARK-CHAN-A-2"; "MARK-CHAN-A-3" ];
+    let queued =
+      match Keeper_registry_event_queue.snapshot_result ~base_path keeper_name with
+      | Ok queue -> queue
+      | Error detail -> failf "queue reload failed: %s" detail
+    in
+    check int
+      "intake alone never acks: all 5 durable entries are still pending" 5
+      (Q.length queued);
+    check
+      (list string)
+      "channel B's 2 messages remain queued, untouched by A's batch"
+      [ b1.Q.post_id; b2.Q.post_id ]
+      (connector_event_ids_of_queue queued
+       |> List.filter (fun id -> List.mem id [ b1.Q.post_id; b2.Q.post_id ])
+       |> List.sort String.compare))
+;;
+
+(* RFC-0377 S3: "Non-Connector_attention payloads keep single-stimulus
+   behavior." A board signal sitting between two same-conversation
+   Connector_attention entries must not be admitted into the batch and must
+   not block the batch filter from finding the connector entry behind it. *)
+let test_batch_skips_a_non_connector_entry_between_matches () =
+  with_ctx "connector-batch-mixed" (fun ~base_path ~keeper_name ~meta ~ctx ->
+    let a1 =
+      connector_attention_stimulus ~base_path ~keeper_name ~channel_id:"chan-A"
+        ~message_id:"a1" ~arrived_at:1.0 ~content:"MARK-MIXED-1"
+    in
+    let board = board_distractor_stimulus ~post_id:"board-distractor" ~arrived_at:2.0 in
+    let a2 =
+      connector_attention_stimulus ~base_path ~keeper_name ~channel_id:"chan-A"
+        ~message_id:"a2" ~arrived_at:3.0 ~content:"MARK-MIXED-2"
+    in
+    List.iter (enqueue_exn ~base_path keeper_name) [ a1; board; a2 ];
+    let intake =
+      Keeper_heartbeat_stimulus_intake.heartbeat_event_intake
+        ~ctx
+        ~meta_after_triage:meta
+        ~pending_board_events:[]
+    in
+    check int "only the two connector entries are admitted, not the board signal"
+      2 intake.consumed_stimulus_count;
+    check
+      (list string)
+      "batch is exactly the two connector entries, in arrival order"
+      [ a1.Q.post_id; a2.Q.post_id ]
+      (List.map (fun (s : Q.stimulus) -> s.Q.post_id) intake.consumed_stimuli);
+    let queued =
+      match Keeper_registry_event_queue.snapshot_result ~base_path keeper_name with
+      | Ok queue -> queue
+      | Error detail -> failf "queue reload failed: %s" detail
+    in
+    check int "the board distractor is still durably queued, never consumed" 3
+      (Q.length queued);
+    check bool "the board distractor's own identity is unchanged" true
+      (List.exists
+         (fun (s : Q.stimulus) -> String.equal s.Q.post_id "board-distractor")
+         (Q.to_list queued)))
+;;
+
+(* RFC-0377 S5.2: batch admitted, then the turn fails. The disposition
+   [keeper_heartbeat_loop.ml] applies on a transient turn failure
+   ([Defer_to_queue_tail]) must run over every entry in
+   [consumed_selections], not only the primary, or a companion is silently
+   stranded — acked by nobody, deferred by nobody, yet also never retried
+   because it no longer looks "new". This pins: applying that exact
+   disposition to the whole batch loses nothing (no partial ack) and every
+   member is independently re-selectable afterward. *)
+let test_batch_turn_failure_leaves_every_member_queued () =
+  with_ctx "connector-batch-failure" (fun ~base_path ~keeper_name ~meta ~ctx ->
+    let a1 =
+      connector_attention_stimulus ~base_path ~keeper_name ~channel_id:"chan-A"
+        ~message_id:"a1" ~arrived_at:1.0 ~content:"MARK-FAIL-1"
+    in
+    let a2 =
+      connector_attention_stimulus ~base_path ~keeper_name ~channel_id:"chan-A"
+        ~message_id:"a2" ~arrived_at:2.0 ~content:"MARK-FAIL-2"
+    in
+    let a3 =
+      connector_attention_stimulus ~base_path ~keeper_name ~channel_id:"chan-A"
+        ~message_id:"a3" ~arrived_at:3.0 ~content:"MARK-FAIL-3"
+    in
+    List.iter (enqueue_exn ~base_path keeper_name) [ a1; a2; a3 ];
+    let intake =
+      Keeper_heartbeat_stimulus_intake.heartbeat_event_intake
+        ~ctx
+        ~meta_after_triage:meta
+        ~pending_board_events:[]
+    in
+    check int "all 3 admitted as one batch" 3 intake.consumed_stimulus_count;
+    check int "consumed_selections mirrors the batch" 3
+      (List.length intake.consumed_selections);
+    (* Simulate the [Defer_to_queue_tail] failure disposition
+       [keeper_heartbeat_loop.ml] now applies to every [consumed_selections]
+       member on a transient turn failure (RFC-0377): nothing is acked,
+       every member is deferred to the tail of its urgency lane. *)
+    List.iter
+      (fun (selection : Keeper_event_queue_state.pending_selection) ->
+         match
+           Keeper_registry_event_queue.defer_pending_result
+             ~base_path
+             keeper_name
+             ~selection
+         with
+         | Ok _ -> ()
+         | Error detail ->
+           failf "defer failed for %s: %s" selection.source.Q.post_id detail)
+      intake.consumed_selections;
+    let queued =
+      match Keeper_registry_event_queue.snapshot_result ~base_path keeper_name with
+      | Ok queue -> queue
+      | Error detail -> failf "queue reload failed: %s" detail
+    in
+    check int "turn failure loses nothing: all 3 batch members remain queued" 3
+      (Q.length queued);
+    check
+      (list string)
+      "no partial ack: the exact same 3 events remain, none dropped"
+      (List.sort String.compare [ a1.Q.post_id; a2.Q.post_id; a3.Q.post_id ])
+      (connector_event_ids_of_queue queued))
+;;
+
+let () =
+  run
+    "keeper_connector_attention_batch"
+    [ ( "RFC-0377 conversation-batched intake"
+      , [ test_case
+            "admits a channel's whole backlog in arrival order, leaves other \
+             channels queued"
+            `Quick
+            test_batch_admits_same_conversation_in_arrival_order_leaves_other_channel_queued
+        ; test_case
+            "skips a non-connector entry sitting between two matches"
+            `Quick
+            test_batch_skips_a_non_connector_entry_between_matches
+        ; test_case
+            "turn failure defers the whole batch: no partial ack"
+            `Quick
+            test_batch_turn_failure_leaves_every_member_queued
+        ] )
+    ]
+;;

--- a/test/test_keeper_connector_attention_batch.ml
+++ b/test/test_keeper_connector_attention_batch.ml
@@ -55,6 +55,58 @@ let enqueue_exn ~base_path keeper_name source =
   | Error detail -> failf "durable enqueue failed: %s" detail
 ;;
 
+(* --- cycle_outcome fixtures for Keeper_heartbeat_loop.batch_disposition_of_cycle_outcome ---
+
+   These build the minimum valid [Keeper_heartbeat_loop_cycle.cycle_outcome]
+   payload for each branch under test. [Manual_compaction_failed] /
+   [Manual_compaction_not_applied] / [Manual_compaction_applied] are not
+   fixture-built here: [batch_disposition_of_cycle_outcome]'s arms for them
+   ignore their payload entirely (always Batch_quarantine / Batch_ack_completed
+   regardless of failure/receipt detail), and their payload types nest deep
+   unrelated fixtures (checkpoint installation, post-install lifecycle) with
+   no additional signal for what this suite is pinning. Exhaustiveness is the
+   guard for those three arms, not a fixture test. *)
+
+let completed_outcome ~addressed meta : Keeper_heartbeat_loop_cycle.cycle_outcome =
+  Keeper_heartbeat_loop_cycle.Completed
+    { meta
+    ; continuation_route =
+        (if addressed
+         then Keeper_unified_turn.Continuation_route_addressed
+         else Keeper_unified_turn.Continuation_route_not_addressed)
+    }
+;;
+
+let failed_outcome ~source_disposition ~route ~deferred_runtime_lane meta
+  : Keeper_heartbeat_loop_cycle.cycle_outcome
+  =
+  Keeper_heartbeat_loop_cycle.Failed
+    { meta
+    ; failure =
+        { Keeper_unified_turn.error = Agent_core.Error.Internal "test fixture"
+        ; runtime_id = "test-runtime"
+        ; route
+        ; source_disposition
+        ; deferred_runtime_lane
+        }
+    }
+;;
+
+let transient_retry_route =
+  Keeper_runtime_failure_route.Retry_after_observed
+    { retry_class = Keeper_runtime_failure_route.Network_transient
+    ; retry_after = None
+    }
+;;
+
+let deterministic_route ~detail =
+  Keeper_runtime_failure_route.Exhausted_visible_alive
+    { terminal = Keeper_runtime_failure_route.Deterministic_request
+    ; provenance = Keeper_runtime_failure_route.Agent_core_api_error
+    ; detail
+    }
+;;
+
 let discord_surface ~channel_id =
   A.Discord
     { guild_id = Some "guild-batch"
@@ -192,6 +244,89 @@ let with_ctx keeper_name f =
   f ~base_path ~keeper_name ~meta ~ctx
 ;;
 
+(* Adversarial review P1-2: the turn-completion/failure batch disposition
+   was inline in keeper_heartbeat_loop.ml's closure, reachable only through
+   the full Eio ctx + durable registry harness — a regression from
+   per-selection disposition back to primary-only would still pass every
+   selection/consumption test in this file, because none of them drove the
+   actual decision function. Now that the decision is the pure
+   [Keeper_heartbeat_loop.batch_disposition_of_cycle_outcome], pin its
+   branches directly: no queue, no Eio, no registry. *)
+let test_batch_disposition_of_cycle_outcome_pure_branches () =
+  let meta = test_meta "batch-disposition-pure" in
+  (match
+     Keeper_heartbeat_loop.batch_disposition_of_cycle_outcome
+       (Some (completed_outcome ~addressed:true meta))
+   with
+   | Keeper_heartbeat_loop.Batch_ack_completed
+       { connector_attention_outcome = Keeper_heartbeat_loop.Attention_resolved }
+     -> ()
+   | _ ->
+     fail "Completed + addressed route must drive Batch_ack_completed/Attention_resolved");
+  (match
+     Keeper_heartbeat_loop.batch_disposition_of_cycle_outcome
+       (Some (completed_outcome ~addressed:false meta))
+   with
+   | Keeper_heartbeat_loop.Batch_ack_completed
+       { connector_attention_outcome = Keeper_heartbeat_loop.Attention_ignored }
+     -> ()
+   | _ ->
+     fail
+       "Completed + not-addressed route must drive Batch_ack_completed/Attention_ignored");
+  (match
+     Keeper_heartbeat_loop.batch_disposition_of_cycle_outcome
+       (Some
+          (failed_outcome
+             ~source_disposition:Keeper_unified_turn.Follow_failure_route
+             ~route:transient_retry_route
+             ~deferred_runtime_lane:None
+             meta))
+   with
+   | Keeper_heartbeat_loop.Batch_defer { reason = "transient_turn_failure" } -> ()
+   | _ ->
+     fail
+       "a transient retry route with no deferred lane must drive \
+        Batch_defer \"transient_turn_failure\"");
+  (match
+     Keeper_heartbeat_loop.batch_disposition_of_cycle_outcome
+       (Some
+          (failed_outcome
+             ~source_disposition:Keeper_unified_turn.Follow_failure_route
+             ~route:(deterministic_route ~detail:"deterministic rejection")
+             ~deferred_runtime_lane:None
+             meta))
+   with
+   | Keeper_heartbeat_loop.Batch_quarantine { detail = "deterministic rejection" } -> ()
+   | _ ->
+     fail
+       "a deterministic-rejection route with no deferred lane must drive \
+        Batch_quarantine with the route's detail");
+  (match
+     Keeper_heartbeat_loop.batch_disposition_of_cycle_outcome
+       (Some
+          (failed_outcome
+             ~source_disposition:
+               (Keeper_unified_turn.Pause_after_transcript_corruption
+                  { detail = "corrupt transcript" })
+             ~route:transient_retry_route
+             ~deferred_runtime_lane:None
+             meta))
+   with
+   | Keeper_heartbeat_loop.Batch_no_action -> ()
+   | _ -> fail "transcript-corruption pause must drive Batch_no_action, not ack/defer/quarantine");
+  List.iter
+    (fun (outcome : Keeper_heartbeat_loop_cycle.cycle_outcome option) ->
+       match Keeper_heartbeat_loop.batch_disposition_of_cycle_outcome outcome with
+       | Keeper_heartbeat_loop.Batch_no_action -> ()
+       | _ -> fail "a non-terminal or absent cycle outcome must drive Batch_no_action")
+    [ None
+    ; Some (Keeper_heartbeat_loop_cycle.Checkpointed meta)
+    ; Some (Keeper_heartbeat_loop_cycle.Input_required meta)
+    ; Some (Keeper_heartbeat_loop_cycle.Cancelled meta)
+    ; Some (Keeper_heartbeat_loop_cycle.Skipped meta)
+    ]
+;;
+
 (* RFC-0377 S5.1: channel A has 3 pending Connector_attention + channel B
    has 2, interleaved on the queue (A1, B1, A2, B2, A3) so the batch filter
    must select past channel B's entries, not just take a prefix. One intake
@@ -314,14 +449,19 @@ let test_batch_skips_a_non_connector_entry_between_matches () =
          (Q.to_list queued)))
 ;;
 
-(* RFC-0377 S5.2: batch admitted, then the turn fails. The disposition
-   [keeper_heartbeat_loop.ml] applies on a transient turn failure
-   ([Defer_to_queue_tail]) must run over every entry in
+(* RFC-0377 S5.2: batch admitted, then the turn fails with a transient
+   provider failure. Unlike the earlier version of this test (which
+   assumed [Defer_to_queue_tail] and drove [defer_pending_result]
+   directly), the disposition here comes from a REAL
+   [Keeper_heartbeat_loop_cycle.cycle_outcome] fixture through
+   [Keeper_heartbeat_loop.batch_disposition_of_cycle_outcome] — the exact
+   function [keeper_heartbeat_loop.ml] now calls. A regression in that
+   function (e.g. reverting to primary-only, or a match-arm mistake) fails
+   this test even though nothing here re-implements the loop's own control
+   flow (adversarial review P1-2). The action must run over every entry in
    [consumed_selections], not only the primary, or a companion is silently
    stranded — acked by nobody, deferred by nobody, yet also never retried
-   because it no longer looks "new". This pins: applying that exact
-   disposition to the whole batch loses nothing (no partial ack) and every
-   member is independently re-selectable afterward. *)
+   because it no longer looks "new". *)
 let test_batch_turn_failure_leaves_every_member_queued () =
   with_ctx "connector-batch-failure" (fun ~base_path ~keeper_name ~meta ~ctx ->
     let a1 =
@@ -346,22 +486,40 @@ let test_batch_turn_failure_leaves_every_member_queued () =
     check int "all 3 admitted as one batch" 3 intake.consumed_stimulus_count;
     check int "consumed_selections mirrors the batch" 3
       (List.length intake.consumed_selections);
-    (* Simulate the [Defer_to_queue_tail] failure disposition
-       [keeper_heartbeat_loop.ml] now applies to every [consumed_selections]
-       member on a transient turn failure (RFC-0377): nothing is acked,
-       every member is deferred to the tail of its urgency lane. *)
-    List.iter
-      (fun (selection : Keeper_event_queue_state.pending_selection) ->
-         match
-           Keeper_registry_event_queue.defer_pending_result
-             ~base_path
-             keeper_name
-             ~selection
-         with
-         | Ok _ -> ()
-         | Error detail ->
-           failf "defer failed for %s: %s" selection.source.Q.post_id detail)
-      intake.consumed_selections;
+    let failed_cycle_outcome =
+      failed_outcome
+        ~source_disposition:Keeper_unified_turn.Follow_failure_route
+        ~route:transient_retry_route
+        ~deferred_runtime_lane:None
+        meta
+    in
+    (match
+       Keeper_heartbeat_loop.batch_disposition_of_cycle_outcome
+         (Some failed_cycle_outcome)
+     with
+     | Keeper_heartbeat_loop.Batch_defer { reason } ->
+       (* This is the loop's own application step (List.iter over
+          consumed_selections), reproduced here only because
+          defer_selection_to_queue_tail itself is a private closure inside
+          run_keepalive_turn — the DECISION under test already came from
+          the real function above. *)
+       List.iter
+         (fun (selection : Keeper_event_queue_state.pending_selection) ->
+            match
+              Keeper_registry_event_queue.defer_pending_result
+                ~base_path
+                keeper_name
+                ~selection
+            with
+            | Ok _ -> ()
+            | Error detail ->
+              failf "defer failed for %s: %s" selection.source.Q.post_id detail)
+         intake.consumed_selections;
+       check string "deferred for the expected reason" "transient_turn_failure" reason
+     | Keeper_heartbeat_loop.Batch_ack_completed _
+     | Keeper_heartbeat_loop.Batch_quarantine _
+     | Keeper_heartbeat_loop.Batch_no_action ->
+       fail "the transient-failure fixture must drive Batch_defer");
     let queued =
       match Keeper_registry_event_queue.snapshot_result ~base_path keeper_name with
       | Ok queue -> queue
@@ -374,6 +532,73 @@ let test_batch_turn_failure_leaves_every_member_queued () =
       "no partial ack: the exact same 3 events remain, none dropped"
       (List.sort String.compare [ a1.Q.post_id; a2.Q.post_id; a3.Q.post_id ])
       (connector_event_ids_of_queue queued))
+;;
+
+(* RFC-0377: the completion counterpart to the failure test above — batch
+   admitted, then the turn completes. This is genuinely new coverage: no
+   prior test in this suite exercised the completion-ack path at all.
+   Drives the same real [batch_disposition_of_cycle_outcome] function,
+   then applies its [Batch_ack_completed] action to every
+   [consumed_selections] member the way [remove_completed_selections]
+   does (List.for_all over terminalize_completed_selection), proving a
+   turn completion acks the WHOLE admitted batch, not only the primary. *)
+let test_batch_completion_acks_every_member () =
+  with_ctx "connector-batch-completion" (fun ~base_path ~keeper_name ~meta ~ctx ->
+    let a1 =
+      connector_attention_stimulus ~base_path ~keeper_name ~channel_id:"chan-A"
+        ~message_id:"a1" ~arrived_at:1.0 ~content:"MARK-DONE-1"
+    in
+    let a2 =
+      connector_attention_stimulus ~base_path ~keeper_name ~channel_id:"chan-A"
+        ~message_id:"a2" ~arrived_at:2.0 ~content:"MARK-DONE-2"
+    in
+    let a3 =
+      connector_attention_stimulus ~base_path ~keeper_name ~channel_id:"chan-A"
+        ~message_id:"a3" ~arrived_at:3.0 ~content:"MARK-DONE-3"
+    in
+    List.iter (enqueue_exn ~base_path keeper_name) [ a1; a2; a3 ];
+    let intake =
+      Keeper_heartbeat_stimulus_intake.heartbeat_event_intake
+        ~ctx
+        ~meta_after_triage:meta
+        ~pending_board_events:[]
+    in
+    check int "all 3 admitted as one batch" 3 intake.consumed_stimulus_count;
+    check int "consumed_selections mirrors the batch" 3
+      (List.length intake.consumed_selections);
+    (match
+       Keeper_heartbeat_loop.batch_disposition_of_cycle_outcome
+         (Some (completed_outcome ~addressed:true meta))
+     with
+     | Keeper_heartbeat_loop.Batch_ack_completed _ ->
+       let acked =
+         List.for_all
+           (fun (selection : Keeper_event_queue_state.pending_selection) ->
+              match
+                Keeper_registry_event_queue.terminalize_pending_turn_completed_result
+                  ~base_path
+                  keeper_name
+                  ~current_owner_nonce:meta.Keeper_meta_contract.runtime.nonce
+                  ~applied_at:1000.0
+                  ~selection
+              with
+              | Ok _ -> true
+              | Error detail ->
+                failf "ack failed for %s: %s" selection.source.Q.post_id detail)
+           intake.consumed_selections
+       in
+       check bool "every batch member acks cleanly" true acked
+     | Keeper_heartbeat_loop.Batch_quarantine _
+     | Keeper_heartbeat_loop.Batch_defer _
+     | Keeper_heartbeat_loop.Batch_no_action ->
+       fail "a completed, addressed outcome must drive Batch_ack_completed");
+    let queued =
+      match Keeper_registry_event_queue.snapshot_result ~base_path keeper_name with
+      | Ok queue -> queue
+      | Error detail -> failf "queue reload failed: %s" detail
+    in
+    check int "turn completion acks all 3 batch members: none remain queued" 0
+      (Q.length queued))
 ;;
 
 let () =
@@ -393,6 +618,16 @@ let () =
             "turn failure defers the whole batch: no partial ack"
             `Quick
             test_batch_turn_failure_leaves_every_member_queued
+        ; test_case
+            "turn completion acks every batch member, not only the primary"
+            `Quick
+            test_batch_completion_acks_every_member
+        ] )
+    ; ( "batch_disposition_of_cycle_outcome (P1-2)"
+      , [ test_case
+            "pins every branch of the pure disposition function"
+            `Quick
+            test_batch_disposition_of_cycle_outcome_pure_branches
         ] )
     ]
 ;;


### PR DESCRIPTION
## 문제 (실측)

sangsu 라이브 데이터 (2026-08-08 ~ 08-13, `keepers/sangsu/` 기준):

- 배달된 continuation obligation 48건 전수가 **서로 다른 단일 inbound message 에 1:1 바인딩**. 연속 turn id 28308→28336 이 snowflake 오름차순 inbound 를 하나씩 소비.
- inbound 메시지 발생 → 답장 배달 지연이 438s → 4,461s 로 단조 증가 (48건 중앙값 **1,533s**). 턴당 `Connector_attention` stimulus 최대 1건 admit (RFC-0020 §3 Rule 4) 이 라이브 채널 유입 속도를 따라가지 못하는 시그니처.

상세: `docs/rfc/RFC-0377-conversation-batched-stimulus-intake.md`

## 설계

Claim 시점에, 선택된 stimulus 가 `Connector_attention` 이면 같은 conversation(channel 좌표)의 pending `Connector_attention` 전부를 그 턴에 함께 admit. 배치 경계는 claim 시각에 pending 인 것 전부(숫자 상한/타이머 없음). 다른 conversation 은 배치에 포함하지 않음. Non-`Connector_attention` payload 는 기존 단건 동작 유지.

## 변경 파일

**구현** (`feat(keeper): batch same-conversation Connector_attention stimuli per turn`, 14 files, +314/-38):
- `lib/keeper_runtime/keeper_continuation_channel.ml{,i}` — `same_conversation` 추가 (아래 "설계 이탈" 참고)
- `lib/keeper_runtime/keeper_event_queue.ml{,i}` — `connector_attention_channel` (exhaustive payload → channel option)
- `lib/keeper_runtime/keeper_event_queue_state.ml{,i}` — `connector_attention_conversation_batch` (pending_entries 위 순수 read, mutation 없음, `select_when` 과 동일 claim semantics)
- `lib/keeper_runtime/keeper_event_queue_persistence.ml{,i}`, `lib/keeper/keeper_registry_event_queue.ml{,i}` — `select_when_result` 3-layer 패턴을 그대로 따라 위 함수를 durable read 로 wrapping
- `lib/keeper/keeper_heartbeat_stimulus_intake.ml{,i}` — `heartbeat_event_intake` 가 primary 가 `Connector_attention` 일 때만 companion 을 모아 각각 `consume_single_heartbeat_stimulus` 로 소비, arrival order 로 concat. `consumed_selections : pending_selection list` 필드 신설(`pending_selection` 은 primary 단일 유지)
- `lib/keeper/keeper_heartbeat_loop.ml{,i}` — dispatch 검증 + 턴 완료/실패 disposition 블록을 `consumed_selections` 전체에 대해 반복하도록 확장 (아래 "critical correctness check" 참고)

**테스트** (`test(keeper): pin RFC-0377 conversation-batched intake behavior`, 2 files, +409):
- `test/test_keeper_connector_attention_batch.ml` (신규 실행 파일, `test/dune`)

## Critical correctness check — consumed_sources ack-flow

`pending_selection`(단수) 는 turn dispatch 검증과 transcript-corruption pause quarantine 용으로 **primary 만** 유지합니다 (기존 동작 불변, 배치와 무관한 두 경로). 반면 턴 완료/실패 disposition 은 배치 전체를 봐야 하므로 신설한 `consumed_selections`(리스트) 를 사용하도록 바꿨습니다:

- `lib/keeper/keeper_heartbeat_loop.ml:860` — `match !consumed_selections with [] -> () | selections -> ...` 로 게이팅 변경 (기존: `!pending_selection` 단수)
- `lib/keeper/keeper_heartbeat_loop.ml:863-874` — `remove_completed_selections`: `List.for_all (fun selection -> terminalize_completed_selection ~selection) selections` — **턴 완료 시 배치 전 건을 ack** (기존: `terminalize_completed_selection ~selection` 1건)
- `lib/keeper/keeper_heartbeat_loop.ml:898-905` — 턴 실패(`Quarantine_source`/`Defer_to_queue_tail`)의 disposition 을 `List.iter` 로 배치 전 건에 동일 적용 — **턴 실패 시 배치 전 건이 동일 경로로 큐에 남음** (`Preserve_for_deferred_runtime`/`Pause_keeper_for_integrity` 는 원래도 아무 것도 안 하므로 자동으로 전 건 잔류)
- `lib/keeper/keeper_heartbeat_loop.ml:444-478` (`selected_source_authority`) — dispatch 직전 검증도 `consumed_selections` 전체로 확장 (companion 하나가 동시에 무효화되어도 dispatch 전에 잡히도록; 배치가 없을 때는 기존 `pending_selection` 단수로 fallback)

`select_when`/`connector_attention_conversation_batch` 는 `pending_entries` 를 **읽기만** 하고 mutate 하지 않으므로 (`keeper_event_queue_state.ml`), 배치 멤버는 이 턴 동안 "claim" 상태(pending_entries 에 남아있지만 이번 사이클엔 다시 선택되지 않음)이고, ack/defer 를 명시적으로 받기 전까지는 자연히 durable queue 에 남습니다.

## 설계 이탈 (spec 대비)

원 지시는 `Keeper_continuation_channel` 에 "structural, field-by-field, exhaustive" `equal` 추가를 요청했지만, **전체 필드 동등 비교로는 이 RFC 목적을 달성할 수 없다는 걸 코드에서 확인**하고 `same_conversation`(channel_id 만 비교) 로 이탈했습니다. 근거:
- `server_discord_in_process_gateway.ml`(`handle_ambient`) 의 유일한 Discord `Connector_attention` producer 가 `reply_to_message_id:message_id` — **매 메시지 자신의 id** 를 채널에 심습니다. 기존 `same_route`(전체 필드 비교) 를 쓰면 같은 채널의 두 pending 메시지가 절대 같은 값을 공유하지 않아 배치가 항상 크기 1이 되어 이 RFC 가 사실상 no-op 이 됩니다.
- Slack 쪽은 이미 `slack_conversation_id ~channel_id` 라는 정확히 동일한 취지의 기존 주석/전례가 있습니다 ("Slack threads share the parent channel id, so the conversation id is keyed on the channel alone").
- `same_conversation` 은 exhaustive match(신규 connector 추가 시 컴파일 에러), `Unrouted` 는 `same_route` 와 동일하게 항상 false. `.mli` 에 `same_route` 와의 차이를 명시.

## Base 변경 사유

원래 base 로 지시받은 `impl/rfc-0376-drop-continuation-delivery` 브랜치는 작업 중 #28596 으로 **squash-merge 후 삭제**됐습니다 (`main` 에 커밋 `a157997abf`로 반영, 그 위에 추가 fix 커밋도 이미 main 에 있음). 3개 커밋을 `git rebase --onto origin/main <구-base> HEAD` 로 `main` 위로 재배치하고 재빌드/재테스트 후 이 PR 은 `main` 을 base 로 엽니다.

## 로컬 검증

```
dune build --root . @check                    # PASS (no output)
```

실행한 테스트 (전부 `dune exec --root . <target>.exe`, exit 0):

| suite | 결과 |
|---|---|
| `test_keeper_connector_attention_batch` (신규) | 3/3 OK |
| `test_keeper_board_unavailable` | 6/6 OK |
| `test_keeper_manual_compaction_preemption` | 4/4 OK |
| `test_keeper_connector_attention_wake` | 5/5 OK |
| `test_keeper_event_queue_state_v2` | 17/17 OK |
| `keeper_event_queue/test_keeper_event_queue` | OK |
| `keeper_continuation_channel/test_keeper_continuation_channel` | OK |
| `test_keeper_event_queue_owner_lock` | OK |
| `test_keeper_event_queue` (2182 lines, ASSERT 스타일) | exit 0 |

신규 테스트가 실제로 새 동작을 검증하는지: `lib/` 변경만 stash 하고(신규 테스트 파일은 유지) 재빌드 → `Error: ... There is no field consumed_selections within type Keeper_heartbeat_stimulus_intake.heartbeat_event_intake` 로 컴파일 실패 확인 후 stash pop. Vacuous pass 가 아님을 확인했습니다. rebase 이후 위 4개 suite 재실행으로 재확인 완료.

## 미검증

- 전체 CI (원격 러너 미실행, 로컬 `@check` + 개별 test executable 실행만 완료)
- 라이브 재측정 (RFC §5.3 — sangsu 백로그 시나리오 before/after 지연·턴당 소비 stimulus 수. 배포 후 별도 기록 필요)
- `test_keeper_event_queue.ml`(2182줄) 는 exit code 만 확인, 개별 assertion 라인 단위 리뷰는 하지 않음
