### PR TITLE
fix(workspace): seed the file tree breadth-first

### DIFF
--- a/lib/server/server_routes_http_routes_workspace.ml
+++ b/lib/server/server_routes_http_routes_workspace.ml
@@ -482,78 +482,92 @@ let file_tree_node ~diff_by_path ~path ~label ~depth ~parent ~has_children =
          ; ("hasChildren", `Bool has_children)
          ; ("diff", diff); ("keeperId", `Null); ("hueIndex", `Null) ]
 
-let rec scan_dir_bounded ?diff_by_path ~base ~depth ~max_depth ~remaining acc dir =
-  if depth > max_depth || remaining <= 0 then (acc, remaining)
-  else
-    let raw_entries =
-      workspace_or_default
-        ~site:"tree_readdir"
-        ~path:dir
-        ~default:[]
-        (fun () -> Sys.readdir dir |> Array.to_list)
-    in
-    (* Sort alphabetically, then partition directories-first so that
-       the node limit (default 750) is consumed by directory trees
-       (lib/, src/) before leaf files ( *.py, *.md).  Without this,
-       a flat directory like ~/me with hundreds of root-level files
-       exhausts the limit before important subdirectories appear. *)
-    let entries =
-      let sorted = List.sort String.compare raw_entries in
-      let dirs, files = List.partition (fun name ->
-        let full = Filename.concat dir name in
-        workspace_or_default
-          ~warn_on_failure:false
-          ~site:"tree_is_directory_partition"
-          ~path:full
-          ~default:false
-          (fun () -> Sys.is_directory full)
-      ) sorted in
-      dirs @ files
-    in
-    let rec fold acc remaining = function
-      | [] -> (acc, remaining)
-      | _ when remaining <= 0 -> (acc, 0)
-      | f :: rest ->
-        if f = "." || f = ".." then fold acc remaining rest
-        else if component_is_confidential f || List.mem f tree_noise_dirs then
-          fold acc remaining rest
-        else
-          let full = Filename.concat dir f in
-          let is_dir =
-            workspace_or_default
-              ~warn_on_failure:false
-              ~site:"tree_is_directory"
-              ~path:full
-              ~default:false
-              (fun () ->
-                 match Unix.lstat full with
-                 | { Unix.st_kind = Unix.S_LNK; _ } -> false
-                 | _ -> Sys.is_directory full)
-          in
-          let rel = rel_under base full in
-          (* With /api/v1/workspace/children lazy-loading a directory's entries
-             on first expand, a directory is expandable regardless of the
-             initial scan depth. Decoupling [has_children] from
-             [depth < max_depth] keeps the chevron on boundary directories; the
-             recursion guard below stays depth-bounded, so the initial scan
-             shape is unchanged and only the boundary display flag flips. *)
-          let has_children = is_dir in
-          let parent = if depth = 0 then "" else Filename.dirname rel in
-          let node = file_tree_node ~diff_by_path
-              ~path:rel ~label:f ~depth ~parent ~has_children in
-          let acc' = node :: acc in
-          let remaining' = remaining - 1 in
-          let acc'', remaining'' =
-            if is_dir && depth < max_depth then
-              scan_dir_bounded
-                ?diff_by_path
-                ~base ~depth:(depth + 1) ~max_depth ~remaining:remaining'
-                acc' full
-            else (acc', remaining')
-          in
-          fold acc'' remaining'' rest
-    in
-    fold acc remaining entries
+(* One directory's entries, alphabetical with directories first, minus the
+   components the tree never shows. Directories lead so that a level's budget
+   reaches subdirectories before a wide directory's leaf files consume it. *)
+let tree_entries dir =
+  let raw_entries =
+    workspace_or_default
+      ~site:"tree_readdir"
+      ~path:dir
+      ~default:[]
+      (fun () -> Sys.readdir dir |> Array.to_list)
+  in
+  let keep name =
+    not (name = "." || name = ".." || component_is_confidential name
+         || List.mem name tree_noise_dirs)
+  in
+  let sorted = List.sort String.compare (List.filter keep raw_entries) in
+  let dirs, files =
+    List.partition
+      (fun name ->
+         let full = Filename.concat dir name in
+         workspace_or_default
+           ~warn_on_failure:false
+           ~site:"tree_is_directory_partition"
+           ~path:full
+           ~default:false
+           (fun () -> Sys.is_directory full))
+      sorted
+  in
+  dirs @ files
+;;
+
+(* Breadth-first, deliberately.
+
+   A depth-first walk spends the node budget on whatever sorts first: on a
+   repository with 11k source files the default 750 nodes were exhausted
+   partway through [dashboard/], so [lib/] — where most of the activity is —
+   never appeared in the response at all, and no amount of clicking could
+   reach it. The budget is a response-size bound, not a statement about which
+   directories matter, and a walk order that makes it act like one leaves a
+   large repository unnavigable.
+
+   Breadth-first spends the same budget on the shallowest nodes, so every
+   top-level entry is present before any subtree is expanded. That is what the
+   seed is for: the client fetches a directory's real contents from
+   [/api/v1/workspace/children] when it is expanded, so anything the budget
+   cuts is one click away instead of unreachable. *)
+let scan_dir_bounded ?diff_by_path ~base ~depth ~max_depth ~remaining acc dir =
+  let pending = Queue.create () in
+  if depth <= max_depth then Queue.add (dir, depth) pending;
+  let acc = ref acc in
+  let remaining = ref remaining in
+  while (not (Queue.is_empty pending)) && !remaining > 0 do
+    let dir, depth = Queue.pop pending in
+    List.iter
+      (fun name ->
+         if !remaining > 0
+         then begin
+           let full = Filename.concat dir name in
+           let is_dir =
+             workspace_or_default
+               ~warn_on_failure:false
+               ~site:"tree_is_directory"
+               ~path:full
+               ~default:false
+               (fun () ->
+                  match Unix.lstat full with
+                  | { Unix.st_kind = Unix.S_LNK; _ } -> false
+                  | _ -> Sys.is_directory full)
+           in
+           let rel = rel_under base full in
+           (* A directory is expandable regardless of the scan depth it was
+              reached at: [/api/v1/workspace/children] loads its entries on
+              first expand, so the chevron stays on boundary directories. *)
+           let has_children = is_dir in
+           let parent = if depth = 0 then "" else Filename.dirname rel in
+           acc
+           := file_tree_node ~diff_by_path ~path:rel ~label:name ~depth ~parent
+                ~has_children
+              :: !acc;
+           remaining := !remaining - 1;
+           if is_dir && depth < max_depth then Queue.add (full, depth + 1) pending
+         end)
+      (tree_entries dir)
+  done;
+  (!acc, !remaining)
+;;
 
 let scan_dir ?diff_by_path ~base ~depth ~max_depth ~max_nodes acc dir =
   fst (scan_dir_bounded ?diff_by_path ~base ~depth ~max_depth ~remaining:max_nodes acc dir)

--- a/test/test_workspace_file_confidentiality.ml
+++ b/test/test_workspace_file_confidentiality.ml
@@ -323,6 +323,33 @@ let test_tree_does_not_follow_symlinked_dir_escape () =
           (List.mem "link/outside_secret_name" ps)))
 ;;
 
+(* The node budget bounds the response; it must not decide which directories
+   are reachable. A depth-first walk spent the whole budget inside whatever
+   sorted first, so on a real repository [lib/] was absent from the tree and
+   the client had nothing to expand — the seed has to cover breadth, and the
+   client loads a directory's real contents on expand. *)
+let test_tree_seed_reaches_every_top_level_directory () =
+  with_temp_dir (fun base ->
+    (* An early directory deep and wide enough to exhaust the budget on its
+       own, and a later one holding the file we must still be able to reach. *)
+    for i = 0 to 19 do
+      let branch = Printf.sprintf "aaa_early/branch_%02d" i in
+      mkdir_p (Filename.concat base branch);
+      for j = 0 to 19 do
+        touch (Filename.concat base (Printf.sprintf "%s/leaf_%02d.ml" branch j))
+      done
+    done;
+    mkdir_p (Filename.concat base "zzz_late");
+    touch (Filename.concat base "zzz_late/wanted.ml");
+    let ps = paths (W.scan_dir ~base ~depth:0 ~max_depth:8 ~max_nodes:100 [] base) in
+    check bool "early directory is present" true (List.mem "aaa_early" ps);
+    check
+      bool
+      "late directory survives the budget"
+      true
+      (List.mem "zzz_late" ps))
+;;
+
 let test_noise_dirs_not_confidential () =
   (* Noise dirs are hidden from the tree but are NOT secrets: a read under
      them is allowed, so [component_is_confidential] must stay false for
@@ -376,6 +403,10 @@ let () =
             `Quick
             test_tree_does_not_follow_symlinked_dir_escape
         ; test_case "noise dirs are not confidential" `Quick test_noise_dirs_not_confidential
+        ; test_case
+            "tree seed reaches every top-level directory"
+            `Quick
+            test_tree_seed_reaches_every_top_level_directory
         ] )
     ]
 ;;


### PR DESCRIPTION
IDE 에서 저장소를 열어도 아무 표식이 안 보인다는 보고에서 출발했다. 원인은 관측 데이터가 아니라 **파일 트리가 그 파일들에 도달하지 못하는 것**이었다.

## 증상

브라우저에서 그대로 재현된다. `#code` → 저장소 `masc` 선택 → 탐색기에 `.ci`, `.githooks`, `.github`, `archive`, `assets` … 만 보인다. 필터에 `types_core` 를 입력하면 `0/111 VISIBLE`. `lib` 노드 자체가 **트리에 없다.**

라이브 인스턴스 실측:

```
GET /api/v1/workspace/tree?repo_id=masc
→ 750 nodes, 마지막: dashboard/src/components/tk.ts
→ lib 없음, test 없음, docs 없음
```

`lib/` 아래에 keeper regions 대부분(814건)이 있는데, 탐색기로는 그 파일을 **열 방법이 없다.** 접혀 있는 게 아니라 응답에 아예 없어서 펼칠 노드가 없고, 클라이언트 필터는 받은 노드만 검색한다.

## 원인

`scan_dir_bounded` 가 노드 예산(기본 750) 아래에서 **깊이 우선**으로 걷는다. 알파벳 순으로 먼저 오는 디렉터리를 끝까지 내려가며 예산을 소진해서, `dashboard/` 중간에서 끊기고 그 뒤 top-level 은 하나도 나오지 않는다.

예산은 **응답 크기 한계**다. 깊이 우선은 그것을 "어떤 디렉터리가 존재하는가" 에 대한 판정으로 바꿔버리는데, 그건 예산이 내릴 수 있는 결정이 아니다.

## 변경

너비 우선으로 바꿨다. 같은 예산을 가장 얕은 노드에 쓰므로 어떤 subtree 를 펼치기 전에 모든 top-level 항목이 들어온다 — seed 가 해야 하는 일이 그것이다.

subtree 를 잘라도 잃는 게 없다: 클라이언트는 디렉터리를 처음 펼칠 때 `/api/v1/workspace/children` 로 실제 내용을 가져온다 (`file-tree-store.ts` 의 `loadChildren`). 예산이 자른 것은 사라지는 게 아니라 클릭 한 번 거리에 있다.

레벨 내 **디렉터리 우선 정렬은 유지**했다. 넓은 디렉터리의 말단 파일이 그 하위 디렉터리를 밀어내는 것을 여전히 막아준다. 필터링, 심볼릭 링크 처리, 확장 가능 플래그는 그대로다. 엔트리 나열은 `tree_entries` 로 빼서 순회가 순회로 읽히게 했다.

## 실측 (같은 저장소, 같은 기본 예산)

| | before (DFS) | after (BFS) |
|---|---|---|
| nodes | 750 | 750 |
| top-level 항목 | **13** | **64** |
| `lib` | 없음 | 있음 (하위 447 노드) |
| `test` / `docs` | 없음 | 있음 |

패치된 바이너리를 scratch base-path + 별 포트로 띄워 라이브(:8935, 미수정)와 나란히 측정했다. 라이브 인스턴스는 건드리지 않았고 측정 후 scratch 는 내렸다.

## 테스트

`test_tree_seed_reaches_every_top_level_directory` — 이른 디렉터리 하나가 예산을 다 쓰도록 만들고, 늦은 디렉터리가 살아남는지 본다.

**깊이 우선 구현에서 실패하는 것을 확인**했다 (구현만 `origin/main` 으로 되돌려 실행):

```
[FAIL] SSOT consistency  3  tree seed reaches every top-level directory
FAIL late directory survives the budget
```

통과만으로는 가드가 아니라 재진술이라서 확인한 것이다.

로컬: `dune build --root . @check` exit 0, `test_workspace_file_confidentiality` 15/15, `test_dashboard_workspace` PASS.

## 범위 밖 (별개로 남는 것)

- **기본 선택 저장소** — IDE 를 열면 `wkbl` 이 선택돼 있다. keeper 활동이 거의 없는 repo 라 여기서도 빈 화면을 본다. 트리와 무관한 별개 판단이라 건드리지 않았다.
- **탐색기 필터** — 받은 노드만 검색한다. 이 PR 로 top-level 은 전부 도달 가능해졌지만, 깊은 파일을 이름으로 바로 찾으려면 서버 측 검색이 필요하다.
- `max_tree_node_limit = 2000` 상한 자체는 그대로 뒀다. 이 PR 은 예산 사용처를 고치고 예산 크기는 논하지 않는다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)