### PR TITLE
fix(dashboard): reconcile Keeper chat via provenance SSOT

### DIFF
--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -356,7 +356,7 @@ describe('streamKeeperMessage', () => {
 
     const events: string[] = []
     await streamKeeperMessage('sangsu', 'ping', {
-      requestId: 'kmsg-stream-direct',
+      operationId: 'kmsg-stream-direct',
       onEvent: event => {
         events.push(event.type)
       },
@@ -387,7 +387,7 @@ describe('streamKeeperMessage', () => {
 
     const events: string[] = []
     await streamKeeperMessage('sangsu', 'ping', {
-      requestId: 'kmsg-stream-copilot',
+      operationId: 'kmsg-stream-copilot',
       onEvent: event => {
         events.push(event.type)
       },
@@ -431,6 +431,7 @@ describe('streamKeeperMessage', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     await streamKeeperMessage('sangsu', 'describe this', {
+      operationId: 'kmsg-stream-blocks',
       onEvent: () => {},
       attachments: [
         {
@@ -527,6 +528,7 @@ describe('streamKeeperMessage', () => {
 
     const events: string[] = []
     await streamKeeperMessage('sangsu', 'ping', {
+      operationId: 'kmsg-stream-retry-invalid-token',
       onEvent: event => {
         events.push(event.type)
       },
@@ -551,7 +553,10 @@ describe('streamKeeperMessage', () => {
       auth_error_code: 'actor_mismatch',
     })
 
-    await streamKeeperMessage('sangsu', 'ping', { onEvent: () => {} })
+    await streamKeeperMessage('sangsu', 'ping', {
+      operationId: 'kmsg-stream-retry-actor',
+      onEvent: () => {},
+    })
 
     expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
       '/api/v1/keepers/chat/stream',
@@ -577,7 +582,10 @@ describe('streamKeeperMessage', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     await expect(
-      streamKeeperMessage('sangsu', 'ping', { onEvent: () => {} }),
+      streamKeeperMessage('sangsu', 'ping', {
+        operationId: 'kmsg-stream-no-retry-origin',
+        onEvent: () => {},
+      }),
     ).rejects.toMatchObject({
       name: 'ApiRequestError',
       authErrorCode: 'same_origin_blocked',
@@ -597,7 +605,10 @@ describe('streamKeeperMessage', () => {
     })
 
     await expect(
-      streamKeeperMessage('sangsu', 'ping', { onEvent: () => {} }),
+      streamKeeperMessage('sangsu', 'ping', {
+        operationId: 'kmsg-stream-no-retry-untyped',
+        onEvent: () => {},
+      }),
     ).rejects.toThrow()
 
     expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -248,7 +248,7 @@ export interface KeeperChatOperation {
 }
 
 export interface StreamKeeperMessageOptions {
-  requestId?: string
+  operationId: string
   signal?: AbortSignal
   onEvent: (event: KeeperChatStreamEvent) => void
   attachments?: StreamAttachment[]
@@ -279,7 +279,7 @@ export async function streamKeeperMessage(
   name: string,
   message: string,
   {
-    requestId,
+    operationId,
     signal,
     onEvent,
     attachments,
@@ -298,9 +298,10 @@ export async function streamKeeperMessage(
   // network round-trip for every message while still preventing the common
   // freshly-loaded-dashboard failure.
   if (!jsonHeaders().Authorization) await ensureDevToken()
-  const operationId = requestId?.trim() || `kmsg-${crypto.randomUUID()}`
+  const exactOperationId = operationId.trim()
+  if (!exactOperationId) throw new Error('Keeper chat operation id is required')
   const body: Record<string, unknown> = {
-    request_id: operationId,
+    request_id: exactOperationId,
     name,
     message,
   }

--- a/dashboard/src/api/schemas/keeper-chat-delivery-provenance.ts
+++ b/dashboard/src/api/schemas/keeper-chat-delivery-provenance.ts
@@ -1,0 +1,98 @@
+import { Either, Schema } from 'effect'
+
+import type {
+  KeeperChatDeliveryProvenance,
+  KeeperChatDeliveryProvenanceDecode,
+} from '../../keeper-delivery-provenance'
+
+const KeeperRequestIdSchema = Schema.String.pipe(
+  Schema.filter(value => (
+    value.length > 0
+    && value.length <= 128
+    && value !== '.'
+    && value !== '..'
+    && /^[A-Za-z0-9_.-]+$/.test(value)
+  ) || 'invalid Keeper request id'),
+)
+
+const KeeperExecutionIdSchema = Schema.String.pipe(
+  Schema.filter(value => value.trim().length > 0 || 'tool execution id must not be blank'),
+)
+
+export const KeeperChatDeliveryKeySchema = Schema.Union(
+  Schema.Struct({
+    kind: Schema.Literal('operation'),
+    operation_id: KeeperRequestIdSchema,
+  }),
+  Schema.Struct({
+    kind: Schema.Literal('fusion_run'),
+    request_id: KeeperRequestIdSchema,
+  }),
+  Schema.Struct({
+    kind: Schema.Literal('continuation'),
+    intent_id: KeeperRequestIdSchema,
+  }),
+)
+
+export const KeeperChatTranscriptSlotSchema = Schema.Union(
+  Schema.Struct({ kind: Schema.Literal('accepted_user') }),
+  Schema.Struct({ kind: Schema.Literal('terminal_assistant') }),
+  Schema.Struct({
+    kind: Schema.Literal('tool_call'),
+    execution_id: KeeperExecutionIdSchema,
+    ordinal: Schema.NonNegativeInt,
+  }),
+)
+
+export const KeeperChatDeliveryProvenanceSchema = Schema.Struct({
+  delivery_key: KeeperChatDeliveryKeySchema,
+  transcript_slot: KeeperChatTranscriptSlotSchema,
+})
+
+const STRICT_PARSE_OPTIONS = {
+  errors: 'all',
+  onExcessProperty: 'error',
+} as const
+
+export function decodeKeeperChatDeliveryProvenance(
+  deliveryKey: unknown,
+  transcriptSlot: unknown,
+): KeeperChatDeliveryProvenanceDecode {
+  if (deliveryKey === undefined && transcriptSlot === undefined) {
+    return { status: 'absent', value: null }
+  }
+  if (deliveryKey === undefined || transcriptSlot === undefined) {
+    return { status: 'invalid', value: null }
+  }
+  const parsed = Schema.decodeUnknownEither(
+    KeeperChatDeliveryProvenanceSchema,
+    STRICT_PARSE_OPTIONS,
+  )({ delivery_key: deliveryKey, transcript_slot: transcriptSlot })
+  return Either.isRight(parsed)
+    ? { status: 'valid', value: parsed.right as KeeperChatDeliveryProvenance }
+    : { status: 'invalid', value: null }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/** Decode status-tool history rows at the same lazy Effect boundary as the
+ * REST chat-history endpoint. The UI state module only consumes this canonical
+ * projection, keeping Effect out of the initial dashboard chunk. */
+export function normalizeKeeperStatusPayloadDeliveryProvenance(data: unknown): unknown {
+  if (!isRecord(data) || !Array.isArray(data.history_tail)) return data
+  return {
+    ...data,
+    history_tail: data.history_tail.map((raw) => {
+      if (!isRecord(raw)) return raw
+      const { delivery_key, transcript_slot, ...message } = raw
+      const provenance = decodeKeeperChatDeliveryProvenance(delivery_key, transcript_slot)
+      return {
+        ...message,
+        delivery_provenance: provenance.value,
+        delivery_provenance_status: provenance.status,
+      }
+    }),
+  }
+}

--- a/dashboard/src/api/schemas/keeper-chat-history.test.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.test.ts
@@ -238,23 +238,43 @@ describe('safeParseKeeperChatHistoryMessage', () => {
     expect(out?.turn_ref).toBeUndefined()
   })
 
-  it('passes delivery_key through without dropping the row, whatever its shape', () => {
+  it('decodes the complete operation provenance pair', () => {
     const out = safeParseKeeperChatHistoryMessage(
-      validMessage({ delivery_key: { kind: 'operation', operation_id: 'kmsg-1' } }),
+      validMessage({
+        delivery_key: { kind: 'operation', operation_id: 'kmsg-1' },
+        transcript_slot: { kind: 'accepted_user' },
+      }),
     )
     expect(out).not.toBeNull()
-    expect(out?.delivery_key).toEqual({ kind: 'operation', operation_id: 'kmsg-1' })
-    // Malformed / unexpected shapes are tolerated too: the consumer extracts
-    // operation_id tolerantly, so the row must survive.
-    expect(
-      safeParseKeeperChatHistoryMessage(validMessage({ delivery_key: 'kmsg-1' })),
-    ).not.toBeNull()
-    expect(
-      safeParseKeeperChatHistoryMessage(validMessage({ delivery_key: 42 })),
-    ).not.toBeNull()
-    expect(
-      safeParseKeeperChatHistoryMessage(validMessage())?.delivery_key,
-    ).toBeUndefined()
+    expect(out?.delivery_provenance).toEqual({
+      delivery_key: { kind: 'operation', operation_id: 'kmsg-1' },
+      transcript_slot: { kind: 'accepted_user' },
+    })
+    expect(out?.delivery_provenance_status).toBe('valid')
+    expect(out).not.toHaveProperty('delivery_key')
+    expect(out).not.toHaveProperty('transcript_slot')
+  })
+
+  it('keeps malformed or half provenance visible but non-reconcilable', () => {
+    for (const raw of [
+      validMessage({ delivery_key: { kind: 'operation', operation_id: 'kmsg-1' } }),
+      validMessage({
+        delivery_key: { kind: 'operation', request_id: 'kmsg-1' },
+        transcript_slot: { kind: 'accepted_user' },
+      }),
+      validMessage({ delivery_key: 'kmsg-1', transcript_slot: { kind: 'accepted_user' } }),
+    ]) {
+      const out = safeParseKeeperChatHistoryMessage(raw)
+      expect(out).not.toBeNull()
+      expect(out?.delivery_provenance).toBeNull()
+      expect(out?.delivery_provenance_status).toBe('invalid')
+    }
+  })
+
+  it('marks a row without provenance as absent', () => {
+    const out = safeParseKeeperChatHistoryMessage(validMessage())
+    expect(out?.delivery_provenance).toBeNull()
+    expect(out?.delivery_provenance_status).toBe('absent')
   })
 
   it('returns null when turn_ref has the wrong type', () => {

--- a/dashboard/src/api/schemas/keeper-chat-history.test.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.test.ts
@@ -7,6 +7,7 @@ import {
 
 function validMessage(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
+    id: 'msg-current-1',
     role: 'user',
     content: 'hello keeper',
     ts: 1_712_000_000.25,
@@ -317,10 +318,13 @@ describe('safeParseKeeperChatHistoryMessage', () => {
     expect(out?.id).toBe('msg-0001700000000000-0')
   })
 
-  it('accepts rows without an id (pre-R3 backend during the deploy window)', () => {
-    const out = safeParseKeeperChatHistoryMessage(validMessage())
-    expect(out).not.toBeNull()
-    expect(out?.id).toBeUndefined()
+  it('rejects rows without a current producer id', () => {
+    const { id: _, ...withoutId } = validMessage()
+    expect(safeParseKeeperChatHistoryMessage(withoutId)).toBeNull()
+  })
+
+  it('rejects rows with a blank producer id', () => {
+    expect(safeParseKeeperChatHistoryMessage(validMessage({ id: '  ' }))).toBeNull()
   })
 
   it('composes in a filter chain — drops garbage entries silently', () => {

--- a/dashboard/src/api/schemas/keeper-chat-history.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.ts
@@ -31,6 +31,13 @@ import {
   unknown,
   type InferOutput,
 } from 'valibot'
+import {
+  decodeKeeperChatDeliveryProvenance,
+} from './keeper-chat-delivery-provenance'
+import type {
+  KeeperChatDeliveryProvenance,
+  KeeperChatDeliveryProvenanceDecode,
+} from '../../keeper-delivery-provenance'
 
 // Attachment row shape persisted by keeper_chat_store.ml (to_json_array
 // :848-861): snake_case mime_type and an open `type` string. Normalized to
@@ -311,12 +318,13 @@ export const KeeperChatHistoryMessageSchema = object({
   // :848-861). Without decoding these, a user's upload appears live but
   // vanishes on reload even though it is on disk.
   attachments: optional(array(KeeperChatHistoryAttachmentSchema)),
-  // Turn identity stamped by the backend on every dashboard-originated row
-  // (keeper_chat_store.ml delivery_key, e.g.
-  // `{"kind":"operation","operation_id":"kmsg-..."}`). Accepted as
-  // `unknown` so a shape drift never drops the row; the consumer extracts
-  // `operation_id` tolerantly (absent/malformed -> undefined).
+  // The raw provenance pair is decoded together immediately after this
+  // row-level tolerant schema succeeds. Keeping the two raw fields unknown at
+  // this first pass lets a malformed identity degrade to a visible but
+  // non-reconcilable row instead of deleting the message. Unknown does not
+  // escape this module; callers receive the closed delivery_provenance ADT.
   delivery_key: optional(unknown()),
+  transcript_slot: optional(unknown()),
   // RFC-0235 P3: server-parsed rich chat blocks. Carried on history rows so
   // reloads preserve the structured render instead of re-parsing plain text.
   blocks: optional(array(KeeperChatBlockSchema)),
@@ -332,11 +340,26 @@ export const KeeperChatHistoryMessageSchema = object({
   autonomous_turn: optional(KeeperAutonomousTurnSchema),
 })
 
-export type KeeperChatHistoryMessage = InferOutput<typeof KeeperChatHistoryMessageSchema>
+type RawKeeperChatHistoryMessage = InferOutput<typeof KeeperChatHistoryMessageSchema>
+
+export type KeeperChatHistoryMessage = Omit<
+  RawKeeperChatHistoryMessage,
+  'delivery_key' | 'transcript_slot'
+> & {
+  delivery_provenance: KeeperChatDeliveryProvenance | null
+  delivery_provenance_status: KeeperChatDeliveryProvenanceDecode['status']
+}
 
 export function safeParseKeeperChatHistoryMessage(
   data: unknown,
 ): KeeperChatHistoryMessage | null {
   const result = safeParse(KeeperChatHistoryMessageSchema, data)
-  return result.success ? result.output : null
+  if (!result.success) return null
+  const { delivery_key, transcript_slot, ...message } = result.output
+  const provenance = decodeKeeperChatDeliveryProvenance(delivery_key, transcript_slot)
+  return {
+    ...message,
+    delivery_provenance: provenance.value,
+    delivery_provenance_status: provenance.status,
+  }
 }

--- a/dashboard/src/api/schemas/keeper-chat-history.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.ts
@@ -268,13 +268,9 @@ const KeeperAutonomousTurnSchema = object({
 })
 
 export const KeeperChatHistoryMessageSchema = object({
-  // R3: producer-assigned stable message id (keeper_chat_store.ml mints it
-  // at append and the read boundary stamps legacy rows, so the backend now
-  // emits it on every row). Left optional for the deploy window — a
-  // dashboard deployed ahead of the backend would otherwise drop every
-  // message; the consumer falls back to a stable content-derived id when
-  // it is absent.
-  id: optional(string()),
+  // Current-record contract: keeper_chat_store mints a stable id on every
+  // append and rejects persisted rows whose id is absent or blank.
+  id: string(),
   role: string(),
   // Autonomous turns can complete through tools without terminal prose. The
   // backend keeps that distinct as null while still projecting the work trace.
@@ -356,6 +352,7 @@ export function safeParseKeeperChatHistoryMessage(
   const result = safeParse(KeeperChatHistoryMessageSchema, data)
   if (!result.success) return null
   const { delivery_key, transcript_slot, ...message } = result.output
+  if (!message.id.trim()) return null
   const provenance = decodeKeeperChatDeliveryProvenance(delivery_key, transcript_slot)
   return {
     ...message,

--- a/dashboard/src/components/chat/autonomous-turn-group.test.ts
+++ b/dashboard/src/components/chat/autonomous-turn-group.test.ts
@@ -204,6 +204,7 @@ describe('foldAutonomousRuns', () => {
 
 describe('chatHistoryEntriesFromRest — autonomous turn rows', () => {
   const autonomousRow = {
+    id: 'msg-autonomous-41',
     role: 'assistant',
     content: 'no work this cycle',
     ts: 1785770777,
@@ -263,8 +264,8 @@ describe('chatHistoryEntriesFromRest — autonomous turn rows', () => {
     // autonomous row between them must not consume that pairing.
     const entries = chatHistoryEntriesFromRest('lane-smith', [
       autonomousRow,
-      { role: 'user', content: 'PR 상태 정리해줘', ts: 1785770800 },
-      { role: 'assistant', content: '3건 확인했습니다', ts: 1785770801 },
+      { id: 'msg-direct-user', role: 'user', content: 'PR 상태 정리해줘', ts: 1785770800 },
+      { id: 'msg-direct-assistant', role: 'assistant', content: '3건 확인했습니다', ts: 1785770801 },
     ])
     expect(entries.map((e) => e.source)).toEqual([
       'autonomous_turn',
@@ -276,7 +277,7 @@ describe('chatHistoryEntriesFromRest — autonomous turn rows', () => {
   it('drops a row whose autonomous_turn payload carries no turn id', () => {
     // Unknown shape is not rendered as an empty bubble.
     const entries = chatHistoryEntriesFromRest('lane-smith', [
-      { role: 'assistant', content: 'x', ts: 1785770777, autonomous_turn: {} },
+      { id: 'msg-malformed-autonomous', role: 'assistant', content: 'x', ts: 1785770777, autonomous_turn: {} },
     ])
     expect(entries).toEqual([])
   })

--- a/dashboard/src/components/copilot-dock.ts
+++ b/dashboard/src/components/copilot-dock.ts
@@ -9,6 +9,7 @@ import { keepers } from '../store'
 import { DASHBOARD_NAV_ITEMS } from '../config/navigation'
 import { isSubmitEnter } from '../lib/keyboard'
 import { streamKeeperMessage } from '../api/keeper'
+import { newKeeperChatOperationId } from '../keeper-delivery-provenance'
 import { currentDashboardActor } from '../api/core'
 import { KeeperBadge } from './keeper-badge'
 import type { Keeper } from '../types'
@@ -264,6 +265,7 @@ export function useCopilotDock() {
       dockStreaming.value = { keeperId: kid, shown: '', full: '', sug: [] }
       let replyText = ''
       streamKeeperMessage(kid, text.trim(), {
+        operationId: newKeeperChatOperationId(),
         signal: abortController.signal,
         channel: 'copilot',
         channelWorkspaceId: currentDashboardActor(),

--- a/dashboard/src/demo/keeper-autonomous-public-history-fixture.ts
+++ b/dashboard/src/demo/keeper-autonomous-public-history-fixture.ts
@@ -9,6 +9,7 @@ import { chatHistoryEntriesFromRest } from '../keeper-state'
 
 const rawHistory = [
   {
+    id: 'msg-fixture-autonomous-1',
     role: 'assistant',
     content: null,
     ts: 1785770777,
@@ -29,6 +30,7 @@ const rawHistory = [
     },
   },
   {
+    id: 'msg-fixture-autonomous-2',
     role: 'assistant',
     content: 'Observed one healthy follow-up.',
     ts: 1785770837,

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -120,8 +120,8 @@ describe('noteKeeperChatAppended', () => {
     // A subsequent append for the open panel must converge (drop -> re-fetch)
     // rather than be skipped until the panel remounts.
     fetchKeeperChatHistory.mockResolvedValueOnce([
-      { role: 'user', content: 'hi', ts: 1_780_000_000 },
-      { role: 'assistant', content: 'recovered', ts: 1_780_000_000 },
+      { id: 'msg-recovered-user', role: 'user', content: 'hi', ts: 1_780_000_000 },
+      { id: 'msg-recovered-assistant', role: 'assistant', content: 'recovered', ts: 1_780_000_000 },
     ])
     noteKeeperChatAppended('echo')
     await vi.runAllTimersAsync()
@@ -134,7 +134,7 @@ describe('noteKeeperChatAppended', () => {
 
   it('debounces a burst of appends into one forced refetch', async () => {
     fetchKeeperChatHistory.mockResolvedValue([
-      { role: 'user', content: 'hi', ts: 1_780_000_000 },
+      { id: 'msg-debounce-user', role: 'user', content: 'hi', ts: 1_780_000_000 },
     ])
     await hydrateKeeperChatHistory('echo')
     expect(fetchKeeperChatHistory).toHaveBeenCalledTimes(1)
@@ -151,8 +151,8 @@ describe('noteKeeperChatAppended', () => {
 
   it('still refreshes history when an audio clip is attached', async () => {
     fetchKeeperChatHistory.mockResolvedValue([
-      { role: 'user', content: 'hi', ts: 1_780_000_000 },
-      { role: 'assistant', content: 'hello there', ts: 1_780_000_000 },
+      { id: 'msg-audio-user', role: 'user', content: 'hi', ts: 1_780_000_000 },
+      { id: 'msg-audio-assistant', role: 'assistant', content: 'hello there', ts: 1_780_000_000 },
     ])
     await hydrateKeeperChatHistory('echo')
     expect(fetchKeeperChatHistory).toHaveBeenCalledTimes(1)
@@ -179,8 +179,8 @@ describe('hydrateKeeperChatHistory', () => {
 
   it('merges the server transcript into the thread', async () => {
     fetchKeeperChatHistory.mockResolvedValue([
-      { role: 'user', content: 'hi', ts: 1_780_000_000 },
-      { role: 'assistant', content: 'hello there', ts: 1_780_000_000 },
+      { id: 'msg-hydrate-user', role: 'user', content: 'hi', ts: 1_780_000_000 },
+      { id: 'msg-hydrate-assistant', role: 'assistant', content: 'hello there', ts: 1_780_000_000 },
     ])
 
     await hydrateKeeperChatHistory('echo')
@@ -198,6 +198,7 @@ describe('hydrateKeeperChatHistory', () => {
   it('keeps backend stream contracts when hydrating server history', async () => {
     fetchKeeperChatHistory.mockResolvedValue([
       {
+        id: 'msg-contract-assistant',
         role: 'assistant',
         content: 'done',
         ts: 1_780_000_000,
@@ -292,7 +293,7 @@ describe('hydrateKeeperChatHistory', () => {
   it('allows a retry after a failed fetch', async () => {
     fetchKeeperChatHistory.mockRejectedValueOnce(new Error('HTTP 502'))
     fetchKeeperChatHistory.mockResolvedValueOnce([
-      { role: 'user', content: 'hi', ts: 1_780_000_000 },
+      { id: 'msg-retry-user', role: 'user', content: 'hi', ts: 1_780_000_000 },
     ])
 
     await hydrateKeeperChatHistory('echo')
@@ -375,7 +376,7 @@ describe('sendKeeperThreadMessage operation stream', () => {
       _name: string,
       _message: string,
       opts: {
-        requestId: string
+        operationId: string
         onEvent: (event: KeeperChatStreamEvent) => void
       },
     ) => {
@@ -383,7 +384,7 @@ describe('sendKeeperThreadMessage operation stream', () => {
         type: 'CUSTOM',
         name: 'KEEPER_CHAT_OPERATION_ACCEPTED',
         value: {
-          operation_id: opts.requestId,
+          operation_id: opts.operationId,
           state,
           queued_count: state === 'Queued' ? 1 : 0,
         },
@@ -403,7 +404,7 @@ describe('sendKeeperThreadMessage operation stream', () => {
     ])
 
     expect(streamKeeperMessage).toHaveBeenCalledTimes(2)
-    const operationIds = streamKeeperMessage.mock.calls.map(call => call[2].requestId)
+    const operationIds = streamKeeperMessage.mock.calls.map(call => call[2].operationId)
     expect(new Set(operationIds).size).toBe(2)
     expect(operationIds.every(id => id.startsWith('kmsg-'))).toBe(true)
   })
@@ -413,10 +414,10 @@ describe('sendKeeperThreadMessage operation stream', () => {
     // where the accept handler never runs and the placeholders are left with
     // whatever identity they were created with. The backend still accepted the
     // message, so history comes back carrying the operation's request id.
-    let submittedRequestId = ''
+    let submittedOperationId = ''
     streamKeeperMessage.mockImplementation(
-      async (_name: string, _message: string, opts: { requestId: string }) => {
-        submittedRequestId = opts.requestId
+      async (_name: string, _message: string, opts: { operationId: string }) => {
+        submittedOperationId = opts.operationId
         return { terminal: true }
       },
     )
@@ -425,16 +426,26 @@ describe('sendKeeperThreadMessage operation stream', () => {
 
     fetchKeeperChatHistory.mockResolvedValue([
       {
+        id: 'msg-disconnected-user',
         role: 'user',
         content: 'hi',
         ts: 1_780_000_000,
-        delivery_key: { kind: 'operation', operation_id: submittedRequestId },
+        delivery_provenance: {
+          delivery_key: { kind: 'operation', operation_id: submittedOperationId },
+          transcript_slot: { kind: 'accepted_user' },
+        },
+        delivery_provenance_status: 'valid',
       },
       {
+        id: 'msg-disconnected-assistant',
         role: 'assistant',
         content: 'hello there',
         ts: 1_780_000_001,
-        delivery_key: { kind: 'operation', operation_id: submittedRequestId },
+        delivery_provenance: {
+          delivery_key: { kind: 'operation', operation_id: submittedOperationId },
+          transcript_slot: { kind: 'terminal_assistant' },
+        },
+        delivery_provenance_status: 'valid',
       },
     ])
     await hydrateKeeperChatHistory('echo')
@@ -446,7 +457,7 @@ describe('sendKeeperThreadMessage operation stream', () => {
 
   it('does not abort the running operation when a second operation is accepted', async () => {
     const streams: Array<{
-      requestId: string
+      operationId: string
       signal: AbortSignal
       resolve: (value: { terminal: boolean }) => void
     }> = []
@@ -454,7 +465,7 @@ describe('sendKeeperThreadMessage operation stream', () => {
       _name: string,
       _message: string,
       opts: {
-        requestId: string
+        operationId: string
         signal: AbortSignal
         onEvent: (event: KeeperChatStreamEvent) => void
       },
@@ -463,13 +474,13 @@ describe('sendKeeperThreadMessage operation stream', () => {
         type: 'CUSTOM',
         name: 'KEEPER_CHAT_OPERATION_ACCEPTED',
         value: {
-          operation_id: opts.requestId,
+          operation_id: opts.operationId,
           state: streams.length === 0 ? 'Running' : 'Queued',
           queued_count: streams.length,
         },
       })
       return new Promise<{ terminal: boolean }>(resolve => {
-        streams.push({ requestId: opts.requestId, signal: opts.signal, resolve })
+        streams.push({ operationId: opts.operationId, signal: opts.signal, resolve })
       })
     })
 
@@ -493,15 +504,15 @@ describe('sendKeeperThreadMessage operation stream', () => {
 
   it('releases only the pre-acceptance stream that ended', async () => {
     const streams: Array<{
-      requestId: string
+      operationId: string
       resolve: (value: { terminal: boolean }) => void
     }> = []
     streamKeeperMessage.mockImplementation(async (
       _name: string,
       _message: string,
-      opts: { requestId: string },
+      opts: { operationId: string },
     ) => new Promise<{ terminal: boolean }>(resolve => {
-      streams.push({ requestId: opts.requestId, resolve })
+      streams.push({ operationId: opts.operationId, resolve })
     }))
 
     const first = sendKeeperThreadMessage('echo', 'first')
@@ -509,8 +520,8 @@ describe('sendKeeperThreadMessage operation stream', () => {
     const second = sendKeeperThreadMessage('echo', 'second')
     await Promise.resolve()
 
-    const firstId = streams[0]?.requestId ?? ''
-    const secondId = streams[1]?.requestId ?? ''
+    const firstId = streams[0]?.operationId ?? ''
+    const secondId = streams[1]?.operationId ?? ''
     expect(liveSendOwnsRequest(firstId)).toBe(true)
     expect(liveSendOwnsRequest(secondId)).toBe(true)
 
@@ -530,17 +541,17 @@ describe('sendKeeperThreadMessage operation stream', () => {
       _name: string,
       _message: string,
       opts: {
-        requestId: string
+        operationId: string
         signal: AbortSignal
         onEvent: (event: KeeperChatStreamEvent) => void
       },
     ) => {
-      acceptedOperationId = opts.requestId
+      acceptedOperationId = opts.operationId
       opts.onEvent({
         type: 'CUSTOM',
         name: 'KEEPER_CHAT_OPERATION_ACCEPTED',
         value: {
-          operation_id: opts.requestId,
+          operation_id: opts.operationId,
           state: 'Running',
           queued_count: 0,
         },
@@ -599,14 +610,14 @@ describe('sendKeeperThreadMessage operation stream', () => {
       _name: string,
       _message: string,
       opts: {
-        requestId: string
+        operationId: string
         onEvent: (event: KeeperChatStreamEvent) => void
       },
     ) => {
       opts.onEvent({
         type: 'CUSTOM',
         name: 'KEEPER_CHAT_OPERATION_ACCEPTED',
-        value: { operation_id: opts.requestId, state: 'Running', queued_count: 0 },
+        value: { operation_id: opts.operationId, state: 'Running', queued_count: 0 },
       })
       opts.onEvent({
         type: 'CUSTOM',

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -1,4 +1,9 @@
 import { keeperStreamContract } from './keeper-stream-contract'
+import {
+  newKeeperChatOperationId,
+  operationDeliveryProvenance,
+  sameDeliveryProvenance,
+} from './keeper-delivery-provenance'
 import { callMcpTool } from './api/mcp'
 import { runOperatorAction } from './api/core'
 import {
@@ -46,7 +51,6 @@ import {
   chatHistoryEntriesFromRest,
   clearActiveStream,
   finalizeAssistantEntry,
-  releaseActiveStreamRequestId,
   mergeServerHistoryEntries,
   normalizeKeeperProbeResult,
   normalizeKeeperRecoverResult,
@@ -58,7 +62,6 @@ import {
   setActiveStream,
   setRecordValue,
   setStatusDetail,
-  updateThreadEntry,
 } from './keeper-state'
 import {
   abortKeeperThreadMessage,
@@ -167,7 +170,7 @@ export function cancelKeeperThreadRequest(
     .then(result => {
       if (result.state.kind === 'cancelled') {
         removeTrackedKeeperChatOperation(id)
-        releaseActiveStreamRequestId(id)
+        releaseLiveSendRequest(id)
       }
       setRecordValue(keeperActionErrors, name, null)
       return 'cancelled' as const
@@ -262,6 +265,10 @@ export async function hydrateKeeperStatus(name: string, force = false): Promise<
     } catch {
       parsed = null
     }
+    const { normalizeKeeperStatusPayloadDeliveryProvenance } = await import(
+      './api/schemas/keeper-chat-delivery-provenance'
+    )
+    parsed = normalizeKeeperStatusPayloadDeliveryProvenance(parsed)
     const detail = normalizeStatusDetail(keeperName, text, parsed)
     setStatusDetail(keeperName, detail)
     return detail
@@ -372,62 +379,36 @@ const QUEUED_KEEPER_REQUEST_LOST_MESSAGE =
   '서버 재시작으로 대기 중이던 요청을 찾을 수 없습니다. 메시지를 다시 보내주세요.'
 const PENDING_KEEPER_CHAT_RESUME_FAILED_MESSAGE =
   '응답을 확인할 수 없어 메시지 복구를 중단했습니다. 다시 보내주세요.'
-const STREAM_FAILURE_HISTORY_SKEW_MS = 30_000
-
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
-function entryTimeMs(entry: KeeperConversationEntry): number | null {
-  if (!entry.timestamp) return null
-  const ms = Date.parse(entry.timestamp)
-  return Number.isFinite(ms) ? ms : null
-}
-
-function hasServerAssistantAfterLocalMessage(
+function hasCanonicalOperationTurn(
   entries: readonly KeeperConversationEntry[],
-  message: string,
-  sentAtMs: number | null,
+  operationId: string,
 ): boolean {
-  const expectedText = message.trim()
-  if (!expectedText) return false
-  let matchedUser = false
-
-  for (const entry of entries) {
-    const tsMs = entryTimeMs(entry)
-    if (
-      sentAtMs !== null
-      && tsMs !== null
-      && tsMs < sentAtMs - STREAM_FAILURE_HISTORY_SKEW_MS
-    ) {
-      continue
-    }
-
-    if (entry.role === 'user' && entry.text.trim() === expectedText) {
-      matchedUser = true
-      continue
-    }
-
-    if (matchedUser && entry.role === 'assistant' && entry.text.trim() !== '') {
-      return true
-    }
-  }
-
-  return false
+  const expectedUser = operationDeliveryProvenance(operationId, 'accepted_user')
+  const expectedAssistant = operationDeliveryProvenance(operationId, 'terminal_assistant')
+  const hasUser = entries.some(entry => (
+    entry.deliveryProvenance != null
+    && sameDeliveryProvenance(entry.deliveryProvenance, expectedUser)
+  ))
+  const hasAssistant = entries.some(entry => (
+    entry.deliveryProvenance != null
+    && sameDeliveryProvenance(entry.deliveryProvenance, expectedAssistant)
+  ))
+  return hasUser && hasAssistant
 }
 
 async function reconcileStreamFailureFromServerHistory(
   keeperName: string,
-  message: string,
+  operationId: string,
   localUserId: string,
   localAssistantId: string,
 ): Promise<boolean> {
-  const localUser = (keeperThreads.value[keeperName] ?? [])
-    .find(entry => entry.id === localUserId) ?? null
-  const sentAtMs = localUser ? entryTimeMs(localUser) : null
   const history = await fetchKeeperChatHistory(keeperName)
   const historyEntries = chatHistoryEntriesFromRest(keeperName, history)
-  if (!hasServerAssistantAfterLocalMessage(historyEntries, message, sentAtMs)) {
+  if (!hasCanonicalOperationTurn(historyEntries, operationId)) {
     return false
   }
 
@@ -436,22 +417,12 @@ async function reconcileStreamFailureFromServerHistory(
   return true
 }
 
-function operationUserEntryId(requestId: string): string {
-  return `pending-user-${requestId}`
+function operationUserEntryId(operationId: string): string {
+  return `pending-user-${operationId}`
 }
 
-function operationAssistantEntryId(requestId: string): string {
-  return `pending-assistant-${requestId}`
-}
-
-// The live-send placeholders are appended before the operation acceptance
-// arrives. Stamp the exact operation id onto both rows for reconnect joins.
-function stampPlaceholderRequestId(keeperName: string, entryIds: string[], requestId: string): void {
-  for (const entryId of entryIds) {
-    updateThreadEntry(keeperName, entryId, entry => (
-      entry.requestId === requestId ? entry : { ...entry, requestId }
-    ))
-  }
+function operationAssistantEntryId(operationId: string): string {
+  return `pending-assistant-${operationId}`
 }
 
 function isUnknownKeeperChatOperationError(err: unknown): boolean {
@@ -479,7 +450,7 @@ function ensureTrackedOperationThreadEntries(request: TrackedKeeperChatOperation
       timestamp: new Date(request.submittedAt).toISOString(),
       delivery: 'delivered',
       streamState: null,
-      requestId: request.operationId,
+      deliveryProvenance: operationDeliveryProvenance(request.operationId, 'accepted_user'),
       streamContract: keeperStreamContract('client_operation_store', 'client_placeholder', {
         requestId: request.operationId,
         reason: 'restored accepted operation from browser storage',
@@ -499,7 +470,7 @@ function ensureTrackedOperationThreadEntries(request: TrackedKeeperChatOperation
       timestamp: assistantDraft?.timestamp ?? null,
       delivery: assistantDraft?.delivery ?? 'queued',
       streamState: assistantDraft ? assistantDraft.streamState : 'opening',
-      requestId: request.operationId,
+      deliveryProvenance: operationDeliveryProvenance(request.operationId, 'terminal_assistant'),
       streamContract: keeperStreamContract('client_operation_store', 'client_placeholder', {
         requestId: request.operationId,
         reason: 'awaiting durable operation terminal state',
@@ -716,7 +687,6 @@ async function handoffCancelledStreamToOperationHydration(
 ): Promise<void> {
   removeThreadEntries(request.keeperName, localEntryIds)
   releaseLiveSendRequest(request.operationId)
-  releaseActiveStreamRequestId(request.operationId)
   await hydrateTrackedKeeperChatOperation(request)
 }
 
@@ -822,6 +792,10 @@ export async function loadFullKeeperHistory(name: string): Promise<void> {
       )
       parsed = null
     }
+    const { normalizeKeeperStatusPayloadDeliveryProvenance } = await import(
+      './api/schemas/keeper-chat-delivery-provenance'
+    )
+    parsed = normalizeKeeperStatusPayloadDeliveryProvenance(parsed)
     const detail = normalizeStatusDetail(keeperName, text, parsed)
     setStatusDetail(keeperName, detail)
   } catch (err) {
@@ -880,10 +854,6 @@ function fallbackMessageForUserBlocks(blocks: KeeperUserInputBlock[]): string {
     : `[첨부 ${media.length}개]`
 }
 
-function newKeeperChatOperationId(): string {
-  return `kmsg-${crypto.randomUUID()}`
-}
-
 export async function sendKeeperThreadMessage(
   name: string,
   prompt: string,
@@ -918,14 +888,7 @@ export async function sendKeeperThreadMessage(
   appendThreadEntry(keeperName, {
     id: localId,
     role: 'user',
-    // The operation id is the same value the backend stamps as the row's
-    // delivery_key request_id, so carrying it from the start lets the history
-    // merge recognise its own placeholder. Waiting for
-    // KEEPER_CHAT_OPERATION_ACCEPTED to stamp it leaves the row identity-less
-    // whenever the stream dies first, and sameConversationEntry reads
-    // "one side has a request id" as "different rows" — which renders the sent
-    // message twice, once local and once from history.
-    requestId: operationId,
+    deliveryProvenance: operationDeliveryProvenance(operationId, 'accepted_user'),
     source: 'direct_user',
     label: 'You',
     text: message,
@@ -943,7 +906,7 @@ export async function sendKeeperThreadMessage(
   appendThreadEntry(keeperName, {
     id: assistantId,
     role: 'assistant',
-    requestId: operationId,
+    deliveryProvenance: operationDeliveryProvenance(operationId, 'terminal_assistant'),
     source: 'direct_assistant',
     label: keeperName,
     text: '',
@@ -961,13 +924,13 @@ export async function sendKeeperThreadMessage(
   setRecordValue(keeperStreamStartedAt, keeperName, Date.now())
   const controller = new AbortController()
   setActiveStream(keeperName, operationId, assistantId, controller)
-  let requestId: string | null = null
+  let operationAccepted = false
   let toolCallEnded = false
   try {
     finalizeAssistantEntry(keeperName, localId, { delivery: 'delivered' })
 
     const outcome = await streamKeeperMessage(keeperName, message, {
-      requestId: operationId,
+      operationId,
       signal: controller.signal,
       attachments,
       userBlocks,
@@ -982,13 +945,8 @@ export async function sendKeeperThreadMessage(
           if (!acceptedOperationId || acceptedOperationId !== operationId) {
             throw new Error('Keeper operation acceptance identity mismatch')
           }
-          requestId = acceptedOperationId
+          operationAccepted = true
           markLiveSendRequestAccepted(acceptedOperationId)
-          stampPlaceholderRequestId(
-            keeperName,
-            [localId, assistantId],
-            acceptedOperationId,
-          )
           upsertTrackedKeeperChatOperation({
             operationId: acceptedOperationId,
             keeperName,
@@ -997,11 +955,20 @@ export async function sendKeeperThreadMessage(
             ...(attachments ? { attachments } : {}),
           })
         }
-        const error = applyKeeperStreamEvent(keeperName, assistantId, event)
+        const error = applyKeeperStreamEvent(
+          keeperName,
+          assistantId,
+          event,
+          { kind: 'operation', operationId },
+        )
         if (error) {
           throw new Error(error)
         }
-        persistTrackedOperationAssistantDraft(keeperName, requestId, assistantId)
+        persistTrackedOperationAssistantDraft(
+          keeperName,
+          operationAccepted ? operationId : null,
+          assistantId,
+        )
         if (event.type === 'TOOL_CALL_END') {
           toolCallEnded = true
         }
@@ -1017,14 +984,13 @@ export async function sendKeeperThreadMessage(
     const finalText = finalEntry?.text.trim() ?? ''
 
     if (!outcome.terminal) {
-      if (requestId) {
+      if (operationAccepted) {
         removeThreadEntries(keeperName, [localId, assistantId])
         // Hand off to resume: release ownership FIRST so our own resume
         // call below is not blocked by the guard we just set.
-        releaseLiveSendRequest(requestId)
-        releaseActiveStreamRequestId(requestId)
+        releaseLiveSendRequest(operationId)
         await hydrateTrackedKeeperChatOperation({
-          operationId: requestId,
+          operationId,
           keeperName,
           message,
           submittedAt: Date.now(),
@@ -1048,7 +1014,6 @@ export async function sendKeeperThreadMessage(
       })
       setRecordValue(keeperActionErrors, keeperName, cutMessage)
       if (toolCallEnded) void hydrateKeeperToolOutputs(keeperName)
-      releaseActiveStreamRequestId(operationId)
       return
     }
 
@@ -1076,9 +1041,8 @@ export async function sendKeeperThreadMessage(
         }),
       })
       setRecordValue(keeperActionErrors, keeperName, EMPTY_VISIBLE_REPLY_TEXT)
-      if (requestId) {
-        removeTrackedKeeperChatOperation(requestId)
-        releaseActiveStreamRequestId(requestId)
+      if (operationAccepted) {
+        removeTrackedKeeperChatOperation(operationId)
       }
       return
     }
@@ -1098,36 +1062,35 @@ export async function sendKeeperThreadMessage(
       }),
     })
     if (toolCallEnded) void hydrateKeeperToolOutputs(keeperName)
-    if (requestId) {
-      removeTrackedKeeperChatOperation(requestId)
-      releaseActiveStreamRequestId(requestId)
+    if (operationAccepted) {
+      removeTrackedKeeperChatOperation(operationId)
     }
   } catch (err) {
     flushPendingKeeperStreamDeltas(keeperName, assistantId)
     if (isAbortError(err)) {
-      const durablePendingRequest = requestId
+      const durablePendingRequest = operationAccepted
         ? trackedKeeperChatOperationsForKeeper(keeperName)
-          .find(candidate => candidate.operationId === requestId) ?? null
+          .find(candidate => candidate.operationId === operationId) ?? null
         : null
       const hasDurablePendingRequest = durablePendingRequest !== null
       const shouldAttemptServerCancel = Boolean(
-        requestId && (liveSendOwnsRequest(requestId) || hasDurablePendingRequest),
+        operationAccepted && (liveSendOwnsRequest(operationId) || hasDurablePendingRequest),
       )
       const serverCancelAlreadyFinalized = Boolean(
-        requestId
-        && !liveSendOwnsRequest(requestId)
+        operationAccepted
+        && !liveSendOwnsRequest(operationId)
         && !hasDurablePendingRequest,
       )
-      if (shouldAttemptServerCancel && requestId) {
+      if (shouldAttemptServerCancel) {
         const pendingRequest = withCurrentTrackedOperationAssistantDraft(durablePendingRequest ?? {
-          operationId: requestId,
+          operationId,
           keeperName,
           message,
           submittedAt: Date.now(),
           ...(attachments ? { attachments } : {}),
         }, assistantId)
         upsertTrackedKeeperChatOperation(pendingRequest)
-        void cancelKeeperThreadRequest(keeperName, requestId).then(outcome => {
+        void cancelKeeperThreadRequest(keeperName, operationId).then(outcome => {
           if (outcome === 'cancelling') {
             return handoffCancelledStreamToOperationHydration(
               pendingRequest,
@@ -1141,7 +1104,7 @@ export async function sendKeeperThreadMessage(
         delivery: 'cancelled',
         error: null,
         streamContract: keeperStreamContract('client_stream_failure', 'contract_gap', {
-          requestId: requestId ?? undefined,
+          requestId: operationAccepted ? operationId : undefined,
           reason: KEEPER_MESSAGE_CANCELLED_TEXT,
         }),
       })
@@ -1153,7 +1116,7 @@ export async function sendKeeperThreadMessage(
         error: null,
         timestamp: new Date().toISOString(),
         streamContract: keeperStreamContract('client_stream_failure', 'contract_gap', {
-          requestId: requestId ?? undefined,
+          requestId: operationAccepted ? operationId : undefined,
           reason: KEEPER_MESSAGE_CANCELLED_TEXT,
         }),
       })
@@ -1169,7 +1132,7 @@ export async function sendKeeperThreadMessage(
       error: errorMessage,
       timestamp: new Date().toISOString(),
       streamContract: keeperStreamContract('client_stream_failure', 'contract_gap', {
-        requestId: requestId ?? undefined,
+        requestId: operationAccepted ? operationId : undefined,
         reason: errorMessage,
       }),
     })
@@ -1181,14 +1144,14 @@ export async function sendKeeperThreadMessage(
       delivery: 'delivered',
       error: null,
       streamContract: keeperStreamContract('client_stream_failure', 'contract_gap', {
-        requestId: requestId ?? undefined,
+        requestId: operationAccepted ? operationId : undefined,
         reason: errorMessage,
       }),
     })
     try {
       const reconciled = await reconcileStreamFailureFromServerHistory(
         keeperName,
-        message,
+        operationId,
         localId,
         assistantId,
       )
@@ -1205,12 +1168,11 @@ export async function sendKeeperThreadMessage(
     setRecordValue(keeperActionErrors, keeperName, errorMessage)
     throw err
   } finally {
-    // Release ownership on every exit (success/abort/error). Idempotent:
-    // the non-terminal handoff above already released, so this is a no-op
-    // there; Map.delete of an absent key is harmless.
-    if (requestId) {
-      releaseLiveSendRequest(requestId)
-      releaseKeeperThreadCancelTracking(requestId)
+    // Release cancellation bookkeeping on every accepted exit. The exact
+    // operation ownership is released once by clearActiveStream below; the
+    // non-terminal handoff released it early so its own resume was not blocked.
+    if (operationAccepted) {
+      releaseKeeperThreadCancelTracking(operationId)
     }
     sendKeys.forEach(key => sendingKeeperThreadMessages.delete(key))
     clearActiveStream(keeperName, operationId)

--- a/dashboard/src/keeper-delivery-provenance.test.ts
+++ b/dashboard/src/keeper-delivery-provenance.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  isOperationDeliveryProvenance,
+  operationDeliveryProvenance,
+  sameDeliveryProvenance,
+  toolCallDeliveryProvenance,
+} from './keeper-delivery-provenance'
+import {
+  decodeKeeperChatDeliveryProvenance,
+  normalizeKeeperStatusPayloadDeliveryProvenance,
+} from './api/schemas/keeper-chat-delivery-provenance'
+
+describe('keeper chat delivery provenance', () => {
+  it.each([
+    [{ kind: 'operation', operation_id: 'kmsg-1' }, { kind: 'accepted_user' }],
+    [{ kind: 'fusion_run', request_id: 'fusion-1' }, { kind: 'terminal_assistant' }],
+    [{ kind: 'continuation', intent_id: 'intent-1' }, {
+      kind: 'tool_call',
+      execution_id: 'call-1',
+      ordinal: 0,
+    }],
+  ])('decodes every backend delivery-key variant with its transcript slot', (deliveryKey, slot) => {
+    const decoded = decodeKeeperChatDeliveryProvenance(deliveryKey, slot)
+    expect(decoded.status).toBe('valid')
+    expect(decoded.value).toEqual({ delivery_key: deliveryKey, transcript_slot: slot })
+  })
+
+  it.each([
+    [{ kind: 'operation', operation_id: 'kmsg-1', extra: true }, { kind: 'accepted_user' }],
+    [{ kind: 'operation', operation_id: 'bad id' }, { kind: 'accepted_user' }],
+    [{ kind: 'operation', operation_id: 'kmsg-1' }, {
+      kind: 'tool_call',
+      execution_id: 'call-1',
+      ordinal: -1,
+    }],
+    [{ kind: 'operation', operation_id: 'kmsg-1' }, {
+      kind: 'tool_call',
+      execution_id: ' ',
+      ordinal: 0,
+    }],
+  ])('rejects provenance that is outside the backend contract', (deliveryKey, slot) => {
+    expect(decodeKeeperChatDeliveryProvenance(deliveryKey, slot)).toEqual({
+      status: 'invalid',
+      value: null,
+    })
+  })
+
+  it('distinguishes an absent pair from a half-written pair', () => {
+    expect(decodeKeeperChatDeliveryProvenance(undefined, undefined).status).toBe('absent')
+    expect(
+      decodeKeeperChatDeliveryProvenance(
+        { kind: 'operation', operation_id: 'kmsg-1' },
+        undefined,
+      ).status,
+    ).toBe('invalid')
+  })
+
+  it('uses the complete pair for equality', () => {
+    const user = operationDeliveryProvenance('kmsg-1', 'accepted_user')
+    const assistant = operationDeliveryProvenance('kmsg-1', 'terminal_assistant')
+    expect(sameDeliveryProvenance(user, assistant)).toBe(false)
+    expect(sameDeliveryProvenance(user, { ...user })).toBe(true)
+    expect(isOperationDeliveryProvenance(user, 'kmsg-1', 'accepted_user')).toBe(true)
+    expect(isOperationDeliveryProvenance(user, 'kmsg-1', 'terminal_assistant')).toBe(false)
+  })
+
+  it('derives a tool slot without changing the parent delivery key', () => {
+    const parent = operationDeliveryProvenance('kmsg-1', 'terminal_assistant')
+    expect(toolCallDeliveryProvenance(parent, 'call-2', 1)).toEqual({
+      delivery_key: parent.delivery_key,
+      transcript_slot: { kind: 'tool_call', execution_id: 'call-2', ordinal: 1 },
+    })
+  })
+
+  it('normalizes status history through the same closed decoder', () => {
+    expect(normalizeKeeperStatusPayloadDeliveryProvenance({
+      history_tail: [{
+        role: 'user',
+        delivery_key: { kind: 'operation', operation_id: 'kmsg-1' },
+        transcript_slot: { kind: 'accepted_user' },
+      }],
+    })).toEqual({
+      history_tail: [{
+        role: 'user',
+        delivery_provenance: operationDeliveryProvenance('kmsg-1', 'accepted_user'),
+        delivery_provenance_status: 'valid',
+      }],
+    })
+  })
+})

--- a/dashboard/src/keeper-delivery-provenance.ts
+++ b/dashboard/src/keeper-delivery-provenance.ts
@@ -1,0 +1,93 @@
+export type KeeperChatDeliveryKey =
+  | { readonly kind: 'operation'; readonly operation_id: string }
+  | { readonly kind: 'fusion_run'; readonly request_id: string }
+  | { readonly kind: 'continuation'; readonly intent_id: string }
+
+export type KeeperChatTranscriptSlot =
+  | { readonly kind: 'accepted_user' }
+  | { readonly kind: 'terminal_assistant' }
+  | {
+      readonly kind: 'tool_call'
+      readonly execution_id: string
+      readonly ordinal: number
+    }
+
+export interface KeeperChatDeliveryProvenance {
+  readonly delivery_key: KeeperChatDeliveryKey
+  readonly transcript_slot: KeeperChatTranscriptSlot
+}
+
+export type KeeperChatDeliveryProvenanceDecode =
+  | { status: 'absent'; value: null }
+  | { status: 'invalid'; value: null }
+  | { status: 'valid'; value: KeeperChatDeliveryProvenance }
+
+export function operationDeliveryProvenance(
+  operationId: string,
+  slot: 'accepted_user' | 'terminal_assistant',
+): KeeperChatDeliveryProvenance {
+  return {
+    delivery_key: { kind: 'operation', operation_id: operationId },
+    transcript_slot: { kind: slot },
+  }
+}
+
+export function newKeeperChatOperationId(): string {
+  return `kmsg-${crypto.randomUUID()}`
+}
+
+export function toolCallDeliveryProvenance(
+  parent: KeeperChatDeliveryProvenance | null | undefined,
+  executionId: string,
+  ordinal: number,
+): KeeperChatDeliveryProvenance | null {
+  if (!parent) return null
+  return {
+    delivery_key: parent.delivery_key,
+    transcript_slot: {
+      kind: 'tool_call',
+      execution_id: executionId,
+      ordinal,
+    },
+  }
+}
+
+function sameDeliveryKey(left: KeeperChatDeliveryKey, right: KeeperChatDeliveryKey): boolean {
+  if (left.kind !== right.kind) return false
+  switch (left.kind) {
+    case 'operation':
+      return right.kind === 'operation' && left.operation_id === right.operation_id
+    case 'fusion_run':
+      return right.kind === 'fusion_run' && left.request_id === right.request_id
+    case 'continuation':
+      return right.kind === 'continuation' && left.intent_id === right.intent_id
+  }
+}
+
+function sameTranscriptSlot(
+  left: KeeperChatTranscriptSlot,
+  right: KeeperChatTranscriptSlot,
+): boolean {
+  if (left.kind !== right.kind) return false
+  if (left.kind !== 'tool_call') return true
+  return right.kind === 'tool_call'
+    && left.execution_id === right.execution_id
+    && left.ordinal === right.ordinal
+}
+
+export function sameDeliveryProvenance(
+  left: KeeperChatDeliveryProvenance,
+  right: KeeperChatDeliveryProvenance,
+): boolean {
+  return sameDeliveryKey(left.delivery_key, right.delivery_key)
+    && sameTranscriptSlot(left.transcript_slot, right.transcript_slot)
+}
+
+export function isOperationDeliveryProvenance(
+  provenance: KeeperChatDeliveryProvenance | null | undefined,
+  operationId: string,
+  slot: 'accepted_user' | 'terminal_assistant',
+): boolean {
+  return provenance != null
+    && sameDeliveryProvenance(provenance, operationDeliveryProvenance(operationId, slot))
+}

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -7,7 +7,7 @@ import {
   appendAssistantThinkingDelta,
   appendThreadEntry,
   attachKeeperAudioClip,
-  chatHistoryEntriesFromRest,
+  chatHistoryEntriesFromRest as normalizeChatHistoryEntriesFromRest,
   finalizeAssistantEntry,
   insertThreadEntryBefore,
   isDefaultVisibleConversationEntry,
@@ -17,11 +17,52 @@ import {
   markAssistantToolTraceEnded,
   mergeServerHistoryEntries,
   normalizeAudioClip,
-  normalizeStatusDetail,
+  normalizeStatusDetail as normalizeCurrentStatusDetail,
   removeThreadEntries,
   setStatusDetail,
 } from './keeper-state'
 import type { ChatBlock, ChatTraceStep, KeeperConversationEntry } from './types'
+import { operationDeliveryProvenance } from './keeper-delivery-provenance'
+
+type RestHistoryMessages = Parameters<typeof normalizeChatHistoryEntriesFromRest>[1]
+type RestHistoryMessage = RestHistoryMessages[number]
+type RestHistoryFixtureMessage = Omit<RestHistoryMessage, 'id'> & { id?: string }
+
+function withCurrentMessageIds(messages: RestHistoryFixtureMessage[]): RestHistoryMessages {
+  return messages.map((message, index) => ({
+    ...message,
+    id: message.id ?? `msg-fixture-${index}`,
+  }))
+}
+
+function chatHistoryEntriesFromRest(
+  keeperName: string,
+  messages: RestHistoryFixtureMessage[],
+): ReturnType<typeof normalizeChatHistoryEntriesFromRest> {
+  return normalizeChatHistoryEntriesFromRest(keeperName, withCurrentMessageIds(messages))
+}
+
+function normalizeStatusDetail(
+  name: string,
+  text: string,
+  rawStatus: unknown,
+): ReturnType<typeof normalizeCurrentStatusDetail> {
+  if (typeof rawStatus !== 'object' || rawStatus === null || Array.isArray(rawStatus)) {
+    return normalizeCurrentStatusDetail(name, text, rawStatus)
+  }
+  const record = rawStatus as Record<string, unknown>
+  const historyTail = Array.isArray(record.history_tail)
+    ? record.history_tail.map((entry, index) => (
+        typeof entry === 'object' && entry !== null && !Array.isArray(entry)
+          ? { id: `msg-status-fixture-${index}`, ...entry }
+          : entry
+      ))
+    : record.history_tail
+  return normalizeCurrentStatusDetail(name, text, {
+    ...record,
+    history_tail: historyTail,
+  })
+}
 
 describe('normalizeStatusDetail', () => {
   it('infers and hides internal keeper history from direct comms', () => {
@@ -167,10 +208,10 @@ describe('thread history merge & persistence', () => {
   })
 
   it('does not duplicate a local message when server history arrives with a different timestamp', () => {
-    appendThreadEntry('echo', entry({ id: 'local-1', text: 'gg', rawText: 'gg', requestId: 'kmsg-r1', timestamp: '2026-06-10T00:00:01.000Z' }))
+    appendThreadEntry('echo', entry({ id: 'local-1', text: 'gg', rawText: 'gg', deliveryProvenance: operationDeliveryProvenance('kmsg-r1', 'terminal_assistant'), timestamp: '2026-06-10T00:00:01.000Z' }))
 
     mergeServerHistoryEntries('echo', [
-      entry({ id: 'hist-1', text: 'gg', rawText: 'gg', requestId: 'kmsg-r1', delivery: 'history', timestamp: '2026-06-10T00:00:05.000Z' }),
+      entry({ id: 'hist-1', text: 'gg', rawText: 'gg', deliveryProvenance: operationDeliveryProvenance('kmsg-r1', 'terminal_assistant'), delivery: 'history', timestamp: '2026-06-10T00:00:05.000Z' }),
     ])
 
     const matches = (keeperThreads.value.echo ?? []).filter(e => e.text === 'gg')
@@ -184,7 +225,7 @@ describe('thread history merge & persistence', () => {
       role: 'assistant',
       text: 'final answer',
       rawText: 'final answer',
-      requestId: 'kmsg-r1',
+      deliveryProvenance: operationDeliveryProvenance('kmsg-r1', 'terminal_assistant'),
       delivery: 'streaming',
       streamState: 'streaming',
     }))
@@ -201,7 +242,7 @@ describe('thread history merge & persistence', () => {
         role: 'assistant',
         text: 'final answer',
         rawText: 'final answer',
-        requestId: 'kmsg-r1',
+        deliveryProvenance: operationDeliveryProvenance('kmsg-r1', 'terminal_assistant'),
         delivery: 'history',
         timestamp: '2026-06-10T00:00:05.000Z',
       }),
@@ -218,14 +259,14 @@ describe('thread history merge & persistence', () => {
 
   it('distributes identical-text assistant turns trace 1:1 across history rows (#21748)', () => {
     // Two local optimistic assistants with the SAME reply text but distinct
-    // thinking traces and distinct requestIds. Each history row must inherit
-    // its OWN turn's trace via the requestId join, never the other's.
+    // thinking traces and distinct provenance. Each history row must inherit
+    // its OWN turn's trace via the exact provenance join, never the other's.
     appendThreadEntry('echo', entry({
       id: 'local-a',
       role: 'assistant',
       text: 'done',
       rawText: 'done',
-      requestId: 'kmsg-ra',
+      deliveryProvenance: operationDeliveryProvenance('kmsg-ra', 'terminal_assistant'),
       delivery: 'delivered',
       streamState: null,
       timestamp: '2026-06-10T00:00:01.000Z',
@@ -235,7 +276,7 @@ describe('thread history merge & persistence', () => {
       role: 'assistant',
       text: 'done',
       rawText: 'done',
-      requestId: 'kmsg-rb',
+      deliveryProvenance: operationDeliveryProvenance('kmsg-rb', 'terminal_assistant'),
       delivery: 'delivered',
       streamState: null,
       timestamp: '2026-06-10T00:00:02.000Z',
@@ -244,8 +285,8 @@ describe('thread history merge & persistence', () => {
     appendAssistantThinkingDelta('echo', 'local-b', 'second turn reasoning')
 
     mergeServerHistoryEntries('echo', [
-      entry({ id: 'hist-a', role: 'assistant', text: 'done', rawText: 'done', requestId: 'kmsg-ra', delivery: 'history', timestamp: '2026-06-10T00:00:01.000Z' }),
-      entry({ id: 'hist-b', role: 'assistant', text: 'done', rawText: 'done', requestId: 'kmsg-rb', delivery: 'history', timestamp: '2026-06-10T00:00:02.000Z' }),
+      entry({ id: 'hist-a', role: 'assistant', text: 'done', rawText: 'done', deliveryProvenance: operationDeliveryProvenance('kmsg-ra', 'terminal_assistant'), delivery: 'history', timestamp: '2026-06-10T00:00:01.000Z' }),
+      entry({ id: 'hist-b', role: 'assistant', text: 'done', rawText: 'done', deliveryProvenance: operationDeliveryProvenance('kmsg-rb', 'terminal_assistant'), delivery: 'history', timestamp: '2026-06-10T00:00:02.000Z' }),
     ])
 
     const thread = keeperThreads.value.echo ?? []
@@ -302,7 +343,7 @@ describe('thread history merge & persistence', () => {
     expect(traceTextOf('hist-b')).toBe('turn-b reasoning')
   })
 
-  it('converges a stream-interrupted placeholder turn to a single assistant row via requestId', () => {
+  it('converges a stream-interrupted placeholder turn through exact provenance', () => {
     // Live stream died right after the tool events: the local assistant
     // placeholder keeps text='' with only the accumulated tool trace and
     // never received REPLY_DETAILS (turnRef stays null). The real reply
@@ -322,7 +363,7 @@ describe('thread history merge & persistence', () => {
       rawText: '질문',
       delivery: 'delivered',
       timestamp: '2026-06-10T00:00:01.000Z',
-      requestId: R,
+      deliveryProvenance: operationDeliveryProvenance(R, 'accepted_user'),
     }))
     appendThreadEntry('echo', entry({
       id: 'tool-call-1',
@@ -351,15 +392,15 @@ describe('thread history merge & persistence', () => {
       rawText: '',
       delivery: 'error',
       timestamp: '2026-06-10T00:00:04.000Z',
-      requestId: R,
+      deliveryProvenance: operationDeliveryProvenance(R, 'terminal_assistant'),
       traceSteps,
     }))
 
     const history = chatHistoryEntriesFromRest('echo', [
-      { role: 'user', content: '질문', ts: 1_780_000_001, delivery_key: { kind: 'operation', operation_id: R } },
-      { role: 'tool', content: '{"path":"a"}', ts: 1_780_000_002, tool_call_id: 'call-1', tool_call_name: 'read_file' },
-      { role: 'tool', content: '{"path":"b"}', ts: 1_780_000_003, tool_call_id: 'call-2', tool_call_name: 'write_file' },
-      { role: 'assistant', content: '답변', ts: 1_780_000_004, turn_ref: 'trace-x#1', delivery_key: { kind: 'operation', operation_id: R } },
+      { role: 'user', content: '질문', ts: 1_780_000_001, delivery_provenance: operationDeliveryProvenance(R, 'accepted_user'), delivery_provenance_status: 'valid' },
+      { role: 'tool', content: '{"path":"a"}', ts: 1_780_000_002, tool_call_id: 'call-1', tool_call_name: 'read_file', delivery_provenance: { delivery_key: { kind: 'operation', operation_id: R }, transcript_slot: { kind: 'tool_call', execution_id: 'call-1', ordinal: 0 } }, delivery_provenance_status: 'valid' },
+      { role: 'tool', content: '{"path":"b"}', ts: 1_780_000_003, tool_call_id: 'call-2', tool_call_name: 'write_file', delivery_provenance: { delivery_key: { kind: 'operation', operation_id: R }, transcript_slot: { kind: 'tool_call', execution_id: 'call-2', ordinal: 1 } }, delivery_provenance_status: 'valid' },
+      { role: 'assistant', content: '답변', ts: 1_780_000_004, turn_ref: 'trace-x#1', delivery_provenance: operationDeliveryProvenance(R, 'terminal_assistant'), delivery_provenance_status: 'valid' },
     ])
     mergeServerHistoryEntries('echo', history)
 
@@ -369,20 +410,24 @@ describe('thread history merge & persistence', () => {
     expect(assistants).toHaveLength(1)
     expect(assistants[0]?.text).toBe('답변')
     expect(assistants[0]?.delivery).toBe('history')
-    expect(assistants[0]?.requestId).toBe(R)
+    expect(assistants[0]?.deliveryProvenance).toEqual(
+      operationDeliveryProvenance(R, 'terminal_assistant'),
+    )
     // The interrupted placeholder's live tool trace is inherited.
     expect(assistants[0]?.traceSteps).toEqual(traceSteps)
     // The optimistic user row converges to the history row too.
     const users = thread.filter(e => e.role === 'user')
     expect(users).toHaveLength(1)
     expect(users[0]?.delivery).toBe('history')
-    expect(users[0]?.requestId).toBe(R)
+    expect(users[0]?.deliveryProvenance).toEqual(
+      operationDeliveryProvenance(R, 'accepted_user'),
+    )
     // Tool rows stay single (dedup by the tool-<tool_call_id> id shape).
     expect(thread.filter(e => e.role === 'tool')).toHaveLength(2)
   })
 
-  it('never merges a legacy local entry that carries no requestId (role+text fallback hard-cut)', () => {
-    // The legacy role+text heuristic was removed: without a requestId the
+  it('never merges a local entry that carries no provenance', () => {
+    // The role+text heuristic was removed: without provenance the
     // local row and the history row are distinct rows, even with identical
     // text. A text-less placeholder can no longer be reconciled by text.
     appendThreadEntry('echo', entry({
@@ -402,7 +447,7 @@ describe('thread history merge & persistence', () => {
     expect(thread.map(e => e.id)).toEqual(['local-legacy', 'hist-legacy'])
   })
 
-  it('converges rows through exact turnRef only when delivery keys are absent', () => {
+  it('does not use turnRef as row identity when provenance is absent', () => {
     appendThreadEntry('echo', entry({
       id: 'local-turn-ref',
       role: 'assistant',
@@ -425,12 +470,61 @@ describe('thread history merge & persistence', () => {
 
     const assistants = (keeperThreads.value.echo ?? [])
       .filter(candidate => candidate.role === 'assistant')
-    expect(assistants).toHaveLength(1)
-    expect(assistants[0]?.id).toBe('history-turn-ref')
+    expect(assistants.map(entry => entry.id).sort()).toEqual([
+      'history-turn-ref',
+      'local-turn-ref',
+    ])
   })
 
-  it('does not merge same-text rows that carry different requestIds', () => {
-    // Identical reply text across two distinct turns: requestId is the turn
+  it('does not collapse different transcript slots from the same operation', () => {
+    appendThreadEntry('echo', entry({
+      id: 'local-user',
+      role: 'user',
+      deliveryProvenance: operationDeliveryProvenance('kmsg-slot', 'accepted_user'),
+    }))
+
+    mergeServerHistoryEntries('echo', [
+      entry({
+        id: 'history-assistant',
+        role: 'assistant',
+        text: 'hello',
+        rawText: 'hello',
+        delivery: 'history',
+        deliveryProvenance: operationDeliveryProvenance('kmsg-slot', 'terminal_assistant'),
+      }),
+    ])
+
+    expect((keeperThreads.value.echo ?? []).map(candidate => candidate.id).sort()).toEqual([
+      'history-assistant',
+      'local-user',
+    ])
+  })
+
+  it('is idempotent when canonical history is merged repeatedly', () => {
+    appendThreadEntry('echo', entry({
+      id: 'local-assistant',
+      role: 'assistant',
+      text: 'done',
+      rawText: 'done',
+      deliveryProvenance: operationDeliveryProvenance('kmsg-repeat', 'terminal_assistant'),
+    }))
+    const history = [entry({
+      id: 'history-assistant',
+      role: 'assistant',
+      text: 'done',
+      rawText: 'done',
+      delivery: 'history',
+      deliveryProvenance: operationDeliveryProvenance('kmsg-repeat', 'terminal_assistant'),
+    })]
+
+    mergeServerHistoryEntries('echo', history)
+    mergeServerHistoryEntries('echo', history)
+
+    expect(keeperThreads.value.echo).toEqual(history)
+  })
+
+  it('does not merge same-text rows that carry different provenance', () => {
+    // Identical reply text across two distinct turns: provenance is the row
     // identity, so the history row of one request must not claim the local
     // row of another even when role+text coincide.
     appendThreadEntry('echo', entry({
@@ -440,12 +534,12 @@ describe('thread history merge & persistence', () => {
       rawText: 'done',
       delivery: 'delivered',
       timestamp: '2026-06-10T00:00:01.000Z',
-      requestId: 'kmsg_1',
+      deliveryProvenance: operationDeliveryProvenance('kmsg_1', 'terminal_assistant'),
       turnRef: 'trace-shared#1',
     }))
 
     mergeServerHistoryEntries('echo', [
-      entry({ id: 'hist-b', role: 'assistant', text: 'done', rawText: 'done', delivery: 'history', timestamp: '2026-06-10T00:00:02.000Z', requestId: 'kmsg_2', turnRef: 'trace-shared#1' }),
+      entry({ id: 'hist-b', role: 'assistant', text: 'done', rawText: 'done', delivery: 'history', timestamp: '2026-06-10T00:00:02.000Z', deliveryProvenance: operationDeliveryProvenance('kmsg_2', 'terminal_assistant'), turnRef: 'trace-shared#1' }),
     ])
 
     const ids = (keeperThreads.value.echo ?? []).map(e => e.id)
@@ -1257,40 +1351,18 @@ describe('R3 producer-assigned message id', () => {
     ])
   })
 
-  it('derives a stable content-keyed id when a row predates R3 (no id)', () => {
-    const first = chatHistoryEntriesFromRest('echo', [
-      { role: 'user', content: 'same text', ts: 1_780_000_000 },
-    ])
-    const second = chatHistoryEntriesFromRest('echo', [
-      { role: 'user', content: 'same text', ts: 1_780_000_000 },
-    ])
-    // Deterministic across calls — the former id was index/timestamp
-    // derived; the fallback is content derived so it never shifts.
-    expect(first[0]?.id).toBeTruthy()
-    expect(first[0]?.id).toBe(second[0]?.id)
+  it('rejects a row without a current producer-assigned id', () => {
+    const detail = normalizeCurrentStatusDetail('echo', '', {
+      history_tail: [{ role: 'user', content: 'same text', ts_unix: 1_780_000_000 }],
+    })
+    expect(detail.history).toHaveLength(0)
   })
 
-  it('keeps the fallback id stable regardless of page position (the old index bug)', () => {
-    const alone = chatHistoryEntriesFromRest('echo', [
-      { role: 'user', content: 'stable', ts: 1_780_000_000 },
-    ])
-    const shifted = chatHistoryEntriesFromRest('echo', [
-      { role: 'user', content: 'earlier', ts: 1_779_000_000 },
-      { role: 'assistant', content: 'reply', ts: 1_779_000_000 },
-      { role: 'user', content: 'stable', ts: 1_780_000_000 },
-    ])
-    const aloneId = alone.find(e => e.rawText === 'stable')?.id
-    const shiftedId = shifted.find(e => e.rawText === 'stable')?.id
-    expect(aloneId).toBeTruthy()
-    expect(shiftedId).toBe(aloneId)
-  })
-
-  it('gives different content different fallback ids', () => {
-    const entries = chatHistoryEntriesFromRest('echo', [
-      { role: 'user', content: 'one', ts: 1_780_000_000 },
-      { role: 'user', content: 'two', ts: 1_780_000_000 },
-    ])
-    expect(entries[0]?.id).not.toBe(entries[1]?.id)
+  it('rejects a row with a blank producer-assigned id', () => {
+    const detail = normalizeCurrentStatusDetail('echo', '', {
+      history_tail: [{ id: ' ', role: 'user', content: 'stable', ts_unix: 1_780_000_000 }],
+    })
+    expect(detail.history).toHaveLength(0)
   })
 })
 

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -6,6 +6,11 @@ import { isRecord, asString, asNumber, asBoolean, toIsoTimestamp } from './compo
 import { asStrictStringArray, withoutUndefined } from './lib/json-coerce'
 import { keeperStreamContract, normalizeStreamContract } from './keeper-stream-contract'
 import {
+  sameDeliveryProvenance,
+  type KeeperChatDeliveryProvenance,
+  type KeeperChatDeliveryProvenanceDecode,
+} from './keeper-delivery-provenance'
+import {
   nonBlankToolCallId,
   toolEntryIdFromCallId,
 } from './tool-call-output-store'
@@ -761,38 +766,25 @@ export function normalizeKeeperRecoverResult(raw: unknown): KeeperRecoverResult 
 
 // --- Thread state management ---
 
-// Stable fallback id for a message whose backend predates R3 and so
-// carries no producer-assigned id. Derived from the content (not the merge
-// index) so it does not shift when history pages are merged.
-function fallbackHistoryEntryId(
-  role: string,
-  timestamp: string | null | undefined,
-  text: string,
-): string {
-  let hash = 5381
-  for (let i = 0; i < text.length; i += 1) {
-    hash = ((hash << 5) + hash + text.charCodeAt(i)) | 0
+function deliveryProvenanceFromRaw(raw: Record<string, unknown>): KeeperChatDeliveryProvenanceDecode {
+  if (raw.delivery_provenance_status === 'invalid') {
+    return { status: 'invalid', value: null }
   }
-  return `${role}-${timestamp ?? 'entry'}-${(hash >>> 0).toString(36)}`
-}
-
-interface DeliveryIdentity {
-  requestId: string | null
-}
-
-// Typed delivery identity carried on persisted history rows. Unknown or
-// malformed shapes fail closed for reconciliation without dropping the row.
-function deliveryIdentityFromKey(raw: unknown): DeliveryIdentity {
-  if (!isRecord(raw)) return { requestId: null }
-  const kind = asString(raw.kind)
-  if (kind === 'operation') {
-    // keeper_chat_delivery_identity.ml serializes Operation as
-    // {kind:"operation", operation_id:"kmsg-..."} — the same id the live
-    // stream stamps as requestId (keeper-actions.ts request.operationId).
-    const requestId = asString(raw.operation_id)?.trim() ?? ''
-    return { requestId: requestId || null }
+  if (raw.delivery_provenance_status === 'valid') {
+    return isRecord(raw.delivery_provenance)
+      ? {
+          status: 'valid',
+          value: raw.delivery_provenance as unknown as KeeperChatDeliveryProvenance,
+        }
+      : { status: 'invalid', value: null }
   }
-  return { requestId: null }
+  if (raw.delivery_key !== undefined || raw.transcript_slot !== undefined) {
+    // Raw wire provenance must be decoded at the lazy API schema boundary.
+    // Failing closed here prevents an accidental direct caller from making
+    // malformed identity reconcilable.
+    return { status: 'invalid', value: null }
+  }
+  return { status: 'absent', value: null }
 }
 
 function normalizeHistoryEntry(
@@ -801,6 +793,8 @@ function normalizeHistoryEntry(
   previousSource: KeeperConversationSource | null = null,
 ): KeeperConversationEntry | null {
   if (!isRecord(raw)) return null
+  const id = asString(raw.id)?.trim() ?? ''
+  if (!id) return null
   const role = normalizeRole(raw.role)
   const rawText = asString(raw.content) ?? asString(raw.preview) ?? ''
   const attachments = normalizeAttachments(raw.attachments)
@@ -824,7 +818,7 @@ function normalizeHistoryEntry(
   const speakerAuthority = asString(raw.speaker_authority) ?? null
   // RFC-0233 §7: asString rejects malformed join keys instead of repairing them.
   const turnRef = asString(raw.turn_ref) ?? null
-  const deliveryIdentity = deliveryIdentityFromKey(raw.delivery_key)
+  const deliveryProvenance = deliveryProvenanceFromRaw(raw)
   // keeper_chat_store mints kind=transport_failure (row content is the
   // "Keeper request failed: ..." text) so a reload can tell a failed request
   // apart from a real reply. Preserve that writer-declared provenance as its
@@ -836,16 +830,16 @@ function normalizeHistoryEntry(
     ?? ((role === 'assistant' || role === 'system') && text
       ? parseTextToChatBlocks(text)
       : undefined)
-  const streamContract = normalizeStreamContract(raw.stream_contract)
-    ?? keeperStreamContract('rest_history', 'history_without_stream_events', {
-      reason: 'history rows do not carry stream lifecycle events',
-    })
+  const streamContract = deliveryProvenance.status === 'invalid'
+    ? keeperStreamContract('rest_history', 'contract_gap', {
+        reason: 'history row carries malformed or incomplete delivery provenance',
+      })
+    : normalizeStreamContract(raw.stream_contract)
+      ?? keeperStreamContract('rest_history', 'history_without_stream_events', {
+        reason: 'history rows do not carry stream lifecycle events',
+      })
   return {
-    // R3: key off the producer-assigned server id when present so the
-    // render key is stable across history-page merges (the former
-    // `${role}-${ts}-${index}` shifted with the merge index and remounted
-    // bubbles). Pre-R3 rows fall back to a stable content-derived id.
-    id: asString(raw.id) ?? fallbackHistoryEntryId(role, timestamp, rawText),
+    id,
     role,
     source,
     label,
@@ -853,7 +847,7 @@ function normalizeHistoryEntry(
     rawText,
     timestamp,
     turnRef,
-    requestId: deliveryIdentity.requestId,
+    deliveryProvenance: deliveryProvenance.value,
     delivery,
     error: delivery === 'transport_failure' ? rawText : null,
     streamState: null,
@@ -1260,28 +1254,22 @@ export function finalizeAssistantEntry(
   })
 }
 
-// Dedup key for merging server history with locally-appended entries.
-// Server ids win when both sides have already converged. User/assistant
-// rows converge through exact producer identities only: operation id first,
-// then turn_ref when neither side carries an operation identity. Conflicting
-// identities fail closed. Role+text is not an identity because it collapses
-// distinct same-text turns. Tool rows only dedup by their explicit
-// `tool-<tool_call_id>` id.
+// Dedup key for merging server history with locally-appended entries. Server
+// ids win when both sides already name the same row. Otherwise the atomic
+// append-once provenance pair is the sole convergence authority. Role, text,
+// timestamp, and turn_ref are projections/correlation data, never row identity.
 function sameConversationEntry(
   left: KeeperConversationEntry,
   right: KeeperConversationEntry,
 ): boolean {
   if (left.id === right.id) return true
-  if (left.role === 'tool' || right.role === 'tool') return false
-  if (left.role !== right.role) return false
-  const leftRequestId = left.requestId?.trim()
-  const rightRequestId = right.requestId?.trim()
-  if (leftRequestId && rightRequestId) return leftRequestId === rightRequestId
-  if (leftRequestId || rightRequestId) return false
-
-  const leftTurnRef = left.turnRef?.trim()
-  const rightTurnRef = right.turnRef?.trim()
-  return Boolean(leftTurnRef && rightTurnRef && leftTurnRef === rightTurnRef)
+  const leftProvenance = left.deliveryProvenance
+  const rightProvenance = right.deliveryProvenance
+  return Boolean(
+    leftProvenance
+    && rightProvenance
+    && sameDeliveryProvenance(leftProvenance, rightProvenance),
+  )
 }
 
 // Entries with no parseable timestamp (live placeholders, still-streaming
@@ -1297,36 +1285,35 @@ function mergeLocalAssistantTraceSteps(
   historyEntry: KeeperConversationEntry,
   localEntries: KeeperConversationEntry[],
   // Tracks local trace sources already claimed by an earlier history row.
-  // Join order: requestId (backend-stamped turn identity) first, then
-  // turn_ref when Agent Core/MASC provides it on both the live reply details and
-  // the persisted history row. There is no text-based fallback: a local
+  // Join order: exact delivery provenance first, then turn_ref only for trace
+  // correlation when neither row has provenance. There is no text fallback: a local
   // trace source that shares neither key with the history row stays
-  // unmerged (and is dropped by the same requestId rule in replaceThread
-  // once its turn converges). `consumed` keeps every match 1:1 instead of
+  // unmerged (and is dropped by exact provenance in replaceThread once its
+  // turn converges). `consumed` keeps every match 1:1 instead of
   // letting duplicate assistant text reuse the first local trace source
   // (#21748).
   consumed: Set<string>,
 ): KeeperConversationEntry {
   if (historyEntry.role !== 'assistant') return historyEntry
-  // requestId join first: a placeholder whose stream died before REPLY_DETAILS
-  // has no turnRef and possibly no text, but it does carry the request id.
-  const historyRequestId = historyEntry.requestId?.trim()
-  const localTraceSourceByRequestId = historyRequestId
+  const historyProvenance = historyEntry.deliveryProvenance
+  const localTraceSourceByProvenance = historyProvenance
     ? localEntries.find(
         entry =>
           entry.role === 'assistant'
           && (entry.traceSteps?.length ?? 0) > 0
           && !consumed.has(entry.id)
-          && entry.requestId?.trim() === historyRequestId,
+          && entry.deliveryProvenance != null
+          && sameDeliveryProvenance(entry.deliveryProvenance, historyProvenance),
       )
     : undefined
-  if (localTraceSourceByRequestId?.traceSteps?.length) {
-    consumed.add(localTraceSourceByRequestId.id)
+  if (localTraceSourceByProvenance?.traceSteps?.length) {
+    consumed.add(localTraceSourceByProvenance.id)
     return {
       ...historyEntry,
-      traceSteps: localTraceSourceByRequestId.traceSteps,
+      traceSteps: localTraceSourceByProvenance.traceSteps,
     }
   }
+  if (historyProvenance) return historyEntry
   const historyTurnRef = historyEntry.turnRef?.trim()
   const localTraceSourceByTurnRef = historyTurnRef
     ? localEntries.find(
@@ -1334,6 +1321,7 @@ function mergeLocalAssistantTraceSteps(
           entry.role === 'assistant'
           && (entry.traceSteps?.length ?? 0) > 0
           && !consumed.has(entry.id)
+          && entry.deliveryProvenance == null
           && entry.turnRef?.trim() === historyTurnRef,
       )
     : undefined
@@ -1417,7 +1405,7 @@ export function mergeServerHistoryEntries(
 }
 
 interface RestChatHistoryMessage {
-  id?: string
+  id: string
   role: string
   content: string | null
   ts: number
@@ -1432,9 +1420,11 @@ interface RestChatHistoryMessage {
   speaker_authority?: string
   // RFC-0233 §7: MASC-minted "<trace_id>#<absolute_turn>" turn join key.
   turn_ref?: string | null
-  // Backend-stamped delivery identity: direct/async request id or queue
-  // receipt ids. Unknown shapes are ignored without dropping the row.
-  delivery_key?: unknown
+  // Canonical append-once identity decoded at the HTTP boundary. Direct
+  // normalizeStatusDetail callers may still supply the raw sibling fields;
+  // normalizeHistoryEntry runs the same closed decoder for that path.
+  delivery_provenance?: KeeperChatDeliveryProvenance | null
+  delivery_provenance_status?: KeeperChatDeliveryProvenanceDecode['status']
   audio?: unknown
   // Persisted upload rows (snake_case from keeper_chat_store) — normalized to
   // KeeperConversationAttachment at consume time so reload keeps the cards.
@@ -1503,6 +1493,7 @@ function toolHistoryEntry(message: RestChatHistoryMessage): KeeperConversationEn
   const toolCallId = nonBlankToolCallId(message.tool_call_id)
   const toolCallName = message.tool_call_name?.trim()
   if (!toolCallId || !toolCallName || typeof message.content !== 'string') return null
+  const deliveryProvenance = message.delivery_provenance ?? null
   return {
     id: toolEntryIdFromCallId(toolCallId),
     role: 'tool',
@@ -1526,6 +1517,7 @@ function toolHistoryEntry(message: RestChatHistoryMessage): KeeperConversationEn
     // Tool rows share the same untrusted REST boundary; reject malformed
     // turn_ref values here too so this path matches normalizeHistoryEntry.
     turnRef: asString(message.turn_ref) ?? null,
+    deliveryProvenance,
   }
 }
 
@@ -1539,6 +1531,7 @@ export function chatHistoryEntriesFromRest(
   let previousSource: KeeperConversationSource | null = null
   const entries: KeeperConversationEntry[] = []
   messages.forEach((message) => {
+    if (!message.id.trim()) return
     if (message.autonomous_turn !== undefined) {
       // Nobody addressed the keeper, so this row must not advance the
       // user/assistant source chain that infers direct-conversation roles.
@@ -1571,7 +1564,8 @@ export function chatHistoryEntriesFromRest(
         kind: message.kind,
         blocks: message.blocks,
         turn_ref: message.turn_ref,
-        delivery_key: message.delivery_key,
+        delivery_provenance: message.delivery_provenance,
+        delivery_provenance_status: message.delivery_provenance_status,
         stream_contract: message.stream_contract,
       },
       keeperName,
@@ -1614,7 +1608,7 @@ export function clearActiveStream(name: string, operationId: string): void {
   const streams = keeperActiveStreams.get(name)
   streams?.delete(operationId)
   if (streams?.size === 0) keeperActiveStreams.delete(name)
-  releaseActiveStreamRequestId(operationId)
+  releaseLiveSendRequest(operationId)
 }
 
 export function activeStreamEntryId(name: string): string | null {
@@ -1629,40 +1623,11 @@ export function getStreamController(name: string): AbortController | undefined {
   return keeperActiveStreams.get(name)?.values().next().value?.controller
 }
 
-export function setActiveStreamRequestId(name: string, requestId: string): void {
-  claimLiveSendRequest(requestId, name)
-  markLiveSendRequestAccepted(requestId)
-}
-
 export function activeStreamRequestId(name: string): string | null {
-  const keeperName = name.trim()
-  if (!keeperName) return null
-  for (const [requestId, owner] of liveSendRequestOwners) {
-    if (owner === keeperName && acceptedLiveSendRequestIds.has(requestId)) return requestId
-  }
-  return null
-}
-
-export function clearActiveStreamRequestId(name: string): void {
-  const keeperName = name.trim()
-  if (!keeperName) return
-  for (const [requestId, owner] of liveSendRequestOwners) {
-    if (owner === keeperName) {
-      liveSendRequestOwners.delete(requestId)
-      acceptedLiveSendRequestIds.delete(requestId)
-    }
-  }
-}
-
-/** Release a specific request id from live-send ownership. Returns true if
- *  the id was owned. Use this for race-free cleanup after a confirmed server
- *  cancel so a stale cleanup cannot wipe a newer request id claimed for the
- *  same keeper. */
-export function releaseActiveStreamRequestId(requestId: string): boolean {
-  const id = requestId.trim()
-  if (!id) return false
-  acceptedLiveSendRequestIds.delete(id)
-  return liveSendRequestOwners.delete(id)
+  const operationId = activeStreamOperationId(name)
+  return operationId && acceptedLiveSendRequestIds.has(operationId)
+    ? operationId
+    : null
 }
 
 // --- Live send ownership (in-session, requestId-keyed) ---

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -17,6 +17,10 @@ import {
   applyKeeperStreamEvent,
 } from './keeper-stream'
 import { parseSSEMessage } from './schemas/sse'
+import {
+  operationDeliveryProvenance,
+  isOperationDeliveryProvenance,
+} from './keeper-delivery-provenance'
 
 function assistantEntry(): void {
   appendThreadEntry('sangsu', {
@@ -116,7 +120,9 @@ describe('Keeper operation stream projection', () => {
 
     const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
     expect(entry?.delivery).toBe('queued')
-    expect(entry?.requestId).toBe('kmsg-operation-1')
+    expect(entry?.deliveryProvenance).toEqual(
+      operationDeliveryProvenance('kmsg-operation-1', 'terminal_assistant'),
+    )
   })
 
   it('routes server-pushed events by exact operation id', () => {
@@ -129,7 +135,10 @@ describe('Keeper operation stream projection', () => {
         text: '',
         rawText: '',
         timestamp: null,
-        requestId: operationId,
+        deliveryProvenance: operationDeliveryProvenance(
+          operationId,
+          'terminal_assistant',
+        ),
         delivery: 'queued',
         streamState: null,
         details: null,
@@ -142,8 +151,16 @@ describe('Keeper operation stream projection', () => {
     })
 
     const entries = keeperThreads.value.sangsu ?? []
-    expect(entries.find(entry => entry.requestId === 'kmsg-operation-1')?.text).toBe('')
-    expect(entries.find(entry => entry.requestId === 'kmsg-operation-2')?.text).toBe('second')
+    expect(entries.find(entry => isOperationDeliveryProvenance(
+      entry.deliveryProvenance,
+      'kmsg-operation-1',
+      'terminal_assistant',
+    ))?.text).toBe('')
+    expect(entries.find(entry => isOperationDeliveryProvenance(
+      entry.deliveryProvenance,
+      'kmsg-operation-2',
+      'terminal_assistant',
+    ))?.text).toBe('second')
   })
 
   // The direct send stamps the accepted operation id onto the bubble it is

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -4,9 +4,10 @@ import {
   _resetLiveSendRequestOwnersForTests,
   activeStreamRequestId,
   appendThreadEntry,
+  claimLiveSendRequest,
   clearActiveStream,
+  markLiveSendRequestAccepted,
   setActiveStream,
-  setActiveStreamRequestId,
 } from './keeper-state'
 import { keeperThreads } from './keeper-state'
 import {
@@ -21,6 +22,11 @@ import {
   operationDeliveryProvenance,
   isOperationDeliveryProvenance,
 } from './keeper-delivery-provenance'
+import {
+  _clearTrackedKeeperChatOperationsForTests,
+  trackedKeeperChatOperationsForKeeper,
+  upsertTrackedKeeperChatOperation,
+} from './keeper-chat-operations-local'
 
 function assistantEntry(): void {
   appendThreadEntry('sangsu', {
@@ -42,6 +48,7 @@ describe('Keeper operation stream projection', () => {
     _resetKeeperStreamBuffersForTests()
     _resetLiveSendRequestOwnersForTests()
     _resetActiveKeeperStreamsForTests()
+    _clearTrackedKeeperChatOperationsForTests()
     keeperThreads.value = {}
   })
 
@@ -179,13 +186,17 @@ describe('Keeper operation stream projection', () => {
       text: '',
       rawText: '',
       timestamp: null,
-      requestId: 'kmsg-operation-1',
+      deliveryProvenance: operationDeliveryProvenance(
+        'kmsg-operation-1',
+        'terminal_assistant',
+      ),
       delivery: 'streaming',
       streamState: 'streaming',
       details: null,
     })
     // Mirrors keeper-actions: the direct send claims the accepted operation id.
-    setActiveStreamRequestId('sangsu', 'kmsg-operation-1')
+    claimLiveSendRequest('kmsg-operation-1', 'sangsu')
+    markLiveSendRequestAccepted('kmsg-operation-1')
   }
 
   // The server hands the very same AG-UI event to both transports
@@ -215,7 +226,10 @@ describe('Keeper operation stream projection', () => {
       text: '',
       rawText: '',
       timestamp: null,
-      requestId: 'kmsg-opening',
+      deliveryProvenance: operationDeliveryProvenance(
+        'kmsg-opening',
+        'terminal_assistant',
+      ),
       delivery: 'sending',
       streamState: 'opening',
       details: null,
@@ -245,7 +259,10 @@ describe('Keeper operation stream projection', () => {
       text: '',
       rawText: '',
       timestamp: null,
-      requestId: 'kmsg-interrupted',
+      deliveryProvenance: operationDeliveryProvenance(
+        'kmsg-interrupted',
+        'terminal_assistant',
+      ),
       delivery: 'interrupted',
       streamState: null,
       details: null,
@@ -343,7 +360,10 @@ describe('Keeper operation stream projection', () => {
       text: '',
       rawText: '',
       timestamp: null,
-      requestId: 'kmsg-operation-1',
+      deliveryProvenance: operationDeliveryProvenance(
+        'kmsg-operation-1',
+        'terminal_assistant',
+      ),
       delivery: 'streaming',
       streamState: 'streaming',
       details: null,
@@ -363,14 +383,72 @@ describe('Keeper operation stream projection', () => {
     const second = new AbortController()
     setActiveStream('sangsu', 'kmsg-operation-1', 'reply-1', first)
     setActiveStream('sangsu', 'kmsg-operation-2', 'reply-2', second)
-    setActiveStreamRequestId('sangsu', 'kmsg-operation-1')
-    setActiveStreamRequestId('sangsu', 'kmsg-operation-2')
+    markLiveSendRequestAccepted('kmsg-operation-1')
+    markLiveSendRequestAccepted('kmsg-operation-2')
 
     abortKeeperThreadMessage('sangsu')
 
     expect(first.signal.aborted).toBe(true)
     expect(second.signal.aborted).toBe(false)
     expect(activeStreamRequestId('sangsu')).toBe('kmsg-operation-2')
+  })
+
+  it('does not return a later accepted request when aborting the first pre-acceptance stream', () => {
+    const first = new AbortController()
+    const second = new AbortController()
+    setActiveStream('sangsu', 'kmsg-operation-1', 'reply-1', first)
+    setActiveStream('sangsu', 'kmsg-operation-2', 'reply-2', second)
+    markLiveSendRequestAccepted('kmsg-operation-2')
+
+    const aborted = abortKeeperThreadMessage('sangsu')
+
+    expect(aborted?.requestId).toBeNull()
+    expect(first.signal.aborted).toBe(true)
+    expect(second.signal.aborted).toBe(false)
+    expect(activeStreamRequestId('sangsu')).toBe('kmsg-operation-2')
+  })
+
+  it('persists a concurrent assistant draft under its own operation provenance', () => {
+    for (const [operationId, entryId] of [
+      ['kmsg-operation-1', 'reply-1'],
+      ['kmsg-operation-2', 'reply-2'],
+    ] as const) {
+      upsertTrackedKeeperChatOperation({
+        operationId,
+        keeperName: 'sangsu',
+        message: operationId,
+        submittedAt: 1,
+      })
+      appendThreadEntry('sangsu', {
+        id: entryId,
+        role: 'assistant',
+        source: 'direct_assistant',
+        label: 'sangsu',
+        text: '',
+        rawText: '',
+        timestamp: null,
+        deliveryProvenance: operationDeliveryProvenance(
+          operationId,
+          'terminal_assistant',
+        ),
+        delivery: 'streaming',
+        streamState: 'thinking',
+        details: null,
+      })
+    }
+
+    applyKeeperStreamEvent('sangsu', 'reply-2', {
+      type: 'CUSTOM',
+      name: 'KEEPER_THINKING_DELTA',
+      value: { delta: 'second operation' },
+    })
+    _flushPendingKeeperStreamDeltasForTests()
+
+    const operations = trackedKeeperChatOperationsForKeeper('sangsu')
+    expect(operations.find(item => item.operationId === 'kmsg-operation-1')?.assistantDraft)
+      .toBeUndefined()
+    expect(operations.find(item => item.operationId === 'kmsg-operation-2')?.assistantDraft?.traceSteps)
+      .toEqual([{ kind: 'think', text: 'second operation', ts: expect.any(String) }])
   })
 
   it('accepts the singular operation SSE envelope and rejects the removed event type', () => {

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -1,5 +1,10 @@
 import { keeperStreamContract } from './keeper-stream-contract'
 import {
+  operationDeliveryProvenance,
+  isOperationDeliveryProvenance,
+  toolCallDeliveryProvenance,
+} from './keeper-delivery-provenance'
+import {
   formatKeeperVisibleReply,
   keeperTurnOutcomeSuppressesReply,
   normalizeKeeperConversationDetails,
@@ -434,7 +439,12 @@ export function applyKeeperOperationTurnEvent(
 
   const entries = keeperThreads.value[keeperName] ?? []
   const matched = [...entries].reverse().find(
-    entry => entry.role === 'assistant' && entry.requestId === operationId,
+    entry => entry.role === 'assistant'
+      && isOperationDeliveryProvenance(
+        entry.deliveryProvenance,
+        operationId,
+        'terminal_assistant',
+      ),
   )
   if (
     matched
@@ -456,7 +466,7 @@ export function applyKeeperOperationTurnEvent(
       text: '',
       rawText: null,
       timestamp: null,
-      requestId: operationId,
+      deliveryProvenance: operationDeliveryProvenance(operationId, 'terminal_assistant'),
       delivery: 'sending',
       streamState: 'opening',
       streamContract: keeperStreamContract(
@@ -608,6 +618,16 @@ export function applyKeeperStreamEvent(
       promoteAssistantTextToProgress(keeperName, assistantEntryId, {
         agentCoreBlockIndex: takeAgentCoreTextBlockIndex(keeperName, assistantEntryId),
       })
+      const assistantEntry = (keeperThreads.value[keeperName] ?? [])
+        .find(entry => entry.id === assistantEntryId)
+      const toolSteps = assistantEntry?.traceSteps?.filter(step => step.kind === 'tool') ?? []
+      const existingOrdinal = toolSteps.findIndex(step => step.toolCallId === toolCallId)
+      const toolOrdinal = existingOrdinal >= 0 ? existingOrdinal : toolSteps.length
+      const deliveryProvenance = toolCallDeliveryProvenance(
+        assistantEntry?.deliveryProvenance,
+        toolCallId,
+        toolOrdinal,
+      )
       appendAssistantToolTraceStep(keeperName, assistantEntryId, {
         toolCallId,
         name: toolName,
@@ -623,6 +643,7 @@ export function applyKeeperStreamEvent(
         text: '',
         rawText: '',
         timestamp: new Date().toISOString(),
+        deliveryProvenance,
         delivery: 'streaming',
         streamState: 'streaming',
         streamContract: keeperStreamContract('sse_event', 'backend_stream_event', { eventName: 'TOOL_CALL_START' }),
@@ -707,7 +728,10 @@ export function applyKeeperStreamEvent(
         const queued = event.value.state === 'Queued'
         updateThreadEntry(keeperName, assistantEntryId, entry => ({
           ...entry,
-          requestId: operationId,
+          deliveryProvenance: operationDeliveryProvenance(
+            operationId,
+            'terminal_assistant',
+          ),
           text: queued ? 'Queued' : entry.text,
           rawText: queued ? 'Queued' : entry.rawText,
           delivery: queued ? 'queued' : 'sending',
@@ -983,7 +1007,13 @@ export function applyKeeperStreamEvent(
       clearTextMessageStreamState(keeperName, assistantEntryId)
       if (source.kind !== 'operation') return null
       updateThreadEntry(keeperName, assistantEntryId, entry => {
-        if (entry.requestId !== source.operationId) return entry
+        if (!isOperationDeliveryProvenance(
+          entry.deliveryProvenance,
+          source.operationId,
+          'terminal_assistant',
+        )) {
+          return entry
+        }
         const delivery =
           entry.delivery === 'no_reply'
             || (entry.delivery === 'queued'

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -122,12 +122,12 @@ function fullPendingThinkingText(pending: PendingThinkingState): string {
 }
 
 function persistActiveAssistantDraft(keeperName: string, assistantEntryId: string): void {
-  const requestId = activeStreamRequestId(keeperName)
-  if (!requestId) return
   const entry = (keeperThreads.value[keeperName] ?? [])
     .find(candidate => candidate.id === assistantEntryId) ?? null
   if (!entry) return
-  updateTrackedKeeperChatAssistantDraft(requestId, entry)
+  const deliveryKey = entry.deliveryProvenance?.delivery_key
+  if (deliveryKey?.kind !== 'operation') return
+  updateTrackedKeeperChatAssistantDraft(deliveryKey.operation_id, entry)
 }
 
 function flushPendingThinkingDeltas(

--- a/dashboard/src/sse.test.ts
+++ b/dashboard/src/sse.test.ts
@@ -5,6 +5,7 @@ import {
   recordServerPushEvent,
 } from './sse'
 import { appendThreadEntry, keeperThreads } from './keeper-state'
+import { operationDeliveryProvenance } from './keeper-delivery-provenance'
 
 describe('Keeper operation server push', () => {
   const operationId = 'kmsg-operation-1'
@@ -21,7 +22,10 @@ describe('Keeper operation server push', () => {
       timestamp: null,
       delivery: 'queued',
       streamState: null,
-      requestId: operationId,
+      deliveryProvenance: operationDeliveryProvenance(
+        operationId,
+        'terminal_assistant',
+      ),
       details: null,
     })
   })

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -1,5 +1,7 @@
 // MASC Dashboard — Core entity types (Agent, Task, Message, Board, Keeper)
 
+import type { KeeperChatDeliveryProvenance } from '../keeper-delivery-provenance'
+
 // --- Shared options ---
 
 export interface RefreshOptions {
@@ -924,13 +926,12 @@ export interface KeeperConversationEntry {
   text: string
   rawText?: string | null
   timestamp?: string | null
-  // RFC-0233 §7: MASC-minted "<trace_id>#<absolute_turn>" join key. Carries the
-  // chat message's originating turn so turn consumers can prefer exact matching
-  // over timestamp-window fallback.
+  // RFC-0233 §7: MASC-minted "<trace_id>#<absolute_turn>" correlation key.
+  // Carries the originating turn for trace attachment; it is not row identity.
   turnRef?: string | null
-  // Direct/async delivery identity for history reconciliation. Local
-  // placeholders carry the backend-minted request id once it is observed.
-  requestId?: string | null
+  // Exact append-once identity for history reconciliation. This preserves the
+  // backend SSOT pair instead of flattening it into a role-qualified request id.
+  deliveryProvenance?: KeeperChatDeliveryProvenance | null
   delivery: KeeperConversationDelivery
   streamState?: KeeperConversationStreamState
   streamContract?: KeeperConversationStreamContract | null

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -228,12 +228,13 @@ type chat_message = {
          stream response represented by this row. [None] means pre-K1f row or
          no lifecycle proof. Malformed persisted values are reported and read
          as [None], keeping the row valid. *)
-  delivery_key : Keeper_chat_delivery_identity.delivery_key option;
-      (* The exact delivery identity persisted by the idempotent append-once
-         paths.  [None] on rows written by the plain append paths and on rows
-         written before this field existed.  A malformed persisted value is
-         reported as a persistence read drop and reads as [None]; the row
-         stays valid. *)
+  delivery_provenance :
+    Keeper_chat_delivery_identity.delivery_provenance option;
+      (* The exact delivery identity and transcript slot persisted atomically
+         by the idempotent append-once paths.  [None] on rows written by the
+         plain append paths and on rows written before this pair existed.  A
+         malformed persisted value is reported as a persistence read drop and
+         reads as [None]; the row stays valid. *)
 }
 
 let redaction_for ~base_dir ~keeper_name =
@@ -1512,7 +1513,7 @@ let parse_line ~file_path (line : string) : chat_message option =
       | Some stream_lifecycle_json ->
           parse_stream_lifecycle ~path:file_path stream_lifecycle_json
     in
-    let delivery_key =
+    let delivery_provenance =
       (* Same read-drop convention as [turn_ref]: a malformed persisted
          value is surfaced and reads as [None] — the row stays valid.
          This reader only renders, so it can carry on without the
@@ -1526,8 +1527,7 @@ let parse_line ~file_path (line : string) : chat_message option =
             Keeper_chat_delivery_identity.delivery_provenance_of_fields fields
           with
           | Ok None -> None
-          | Ok (Some { Keeper_chat_delivery_identity.delivery_key; _ }) ->
-              Some delivery_key
+          | Ok (Some provenance) -> Some provenance
           | Error detail ->
               report_persistence_read_drop
                 ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
@@ -1577,7 +1577,8 @@ let parse_line ~file_path (line : string) : chat_message option =
                  { id; role; content; ts; attachments; tool_call_id;
                    tool_call_name; surface; conversation_id;
                    external_message_id; workspace_id; speaker; audio; blocks;
-                   mentions; kind; turn_ref; stream_lifecycle; delivery_key })
+                   mentions; kind; turn_ref; stream_lifecycle;
+                   delivery_provenance })
   with Yojson.Json_error detail ->
     report_persistence_read_drop
       ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
@@ -1596,11 +1597,11 @@ let is_tool_message (msg : chat_message) = Role.equal msg.role Role.Tool
 
 (* Old rows without either causal identity can become unrenderable when a
    window evicts their owning user row. Current tool-only continuations carry
-   [turn_ref] or an idempotent [delivery_key] and remain valid even when they
+   [turn_ref] or idempotent [delivery_provenance] and remain valid even when they
    are the first retained row. *)
 let drop_leading_orphan_tool_messages messages =
   let rec split anonymous_tools = function
-    | ({ turn_ref = None; delivery_key = None; _ } as msg) :: rest
+    | ({ turn_ref = None; delivery_provenance = None; _ } as msg) :: rest
       when is_tool_message msg ->
       split (msg :: anonymous_tools) rest
     | rest -> List.rev anonymous_tools, rest
@@ -1946,15 +1947,14 @@ let to_json_array ?base_dir ?trace_block_by_turn_ref
               @ blocks_fields_of_list (blocks_with_trace_block ~trace_block m)
               @ Json_util.string_field_if_present "turn_ref"
                   (Option.map Ids.Turn_ref.to_string m.turn_ref)
-              (* Expose the persisted delivery identity so the dashboard can
-                 reconcile a history reload against its optimistic turn rows
-                 on the exact delivery-key id (e.g. [operation_id]). *)
-              @ (match m.delivery_key with
+              (* Preserve the persisted provenance pair at the HTTP boundary.
+                 Dashboard convergence uses the same atomic identity as the
+                 append-once store instead of reconstructing a slot from role. *)
+              @ (match m.delivery_provenance with
                  | None -> []
-                 | Some key ->
-                     [ ( "delivery_key"
-                       , Keeper_chat_delivery_identity.delivery_key_to_yojson
-                           key ) ])))
+                 | Some provenance ->
+                     Keeper_chat_delivery_identity.delivery_provenance_fields
+                       provenance)))
        messages)
 
 (* RFC-0233 §7: a turn's transcript derived by an exact join on the

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -202,11 +202,12 @@ type chat_message = {
           the writer could not prove lifecycle events. Malformed persisted
           values are reported as persistence read drops and read as [None];
           the row stays valid. *)
-  delivery_key : Keeper_chat_delivery_identity.delivery_key option;
-      (** The exact delivery identity persisted by the idempotent append-once
-          paths ({!append_user_message_once} /
+  delivery_provenance :
+    Keeper_chat_delivery_identity.delivery_provenance option;
+      (** The exact delivery identity and transcript slot persisted atomically
+          by the idempotent append-once paths ({!append_user_message_once} /
           {!append_assistant_message_once}).  [None] on rows written by the
-          plain append paths and on rows written before this field existed.
+          plain append paths and on rows written before this pair existed.
 
           A malformed persisted value is reported as a persistence read drop
           and reads as [None] here; the row stays valid. That leniency is

--- a/lib/keeper/keeper_world_observation_message_scope.ml
+++ b/lib/keeper/keeper_world_observation_message_scope.ml
@@ -230,11 +230,11 @@ let acknowledged_turn_refs messages =
 let answered_delivery_keys messages =
   List.filter_map
     (fun (message : Keeper_chat_store.chat_message) ->
-      match message.role, message.kind, message.delivery_key with
+      match message.role, message.kind, message.delivery_provenance with
       | Keeper_chat_store.Role.Assistant,
         Keeper_chat_store.Row_kind.Utterance,
-        Some delivery_key ->
-        Some delivery_key
+        Some provenance ->
+        Some provenance.Keeper_chat_delivery_identity.delivery_key
       | Keeper_chat_store.Role.Assistant,
         Keeper_chat_store.Row_kind.Transport_failure,
         _
@@ -249,9 +249,10 @@ let answered_delivery_keys messages =
 
 let exact_delivery_was_answered answered = function
   | None -> false
-  | Some delivery_key ->
+  | Some provenance ->
     List.exists
-      (Keeper_chat_delivery_identity.delivery_key_equal delivery_key)
+      (Keeper_chat_delivery_identity.delivery_key_equal
+         provenance.Keeper_chat_delivery_identity.delivery_key)
       answered
 ;;
 
@@ -275,9 +276,15 @@ let pending_user_lines ?ack_id (messages : Keeper_chat_store.chat_message list) 
     match message.role, message.turn_ref with
     | Keeper_chat_store.Role.User, Some turn_ref ->
       not (StringSet.mem (Ids.Turn_ref.to_string turn_ref) acknowledged)
-      && not (exact_delivery_was_answered answered_deliveries message.delivery_key)
+      && not
+           (exact_delivery_was_answered
+              answered_deliveries
+              message.delivery_provenance)
     | Keeper_chat_store.Role.User, None ->
-      not (exact_delivery_was_answered answered_deliveries message.delivery_key)
+      not
+        (exact_delivery_was_answered
+           answered_deliveries
+           message.delivery_provenance)
     | Keeper_chat_store.Role.Assistant, _ | Keeper_chat_store.Role.Tool, _ -> false)
 ;;
 

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -820,7 +820,7 @@ let test_identified_tool_only_history_is_not_trimmed () =
         Alcotest.(check string) "identified tool-only row survives" "tool"
           (K.Role.to_label tool.role);
         Alcotest.(check bool) "durable identity remains available" true
-          (Option.is_some tool.delivery_key)
+          (Option.is_some tool.delivery_provenance)
       | messages ->
         Alcotest.failf "expected one identified tool row, got %d"
           (List.length messages))
@@ -1900,7 +1900,7 @@ let test_half_provenance_reads_none () =
            Alcotest.(check bool) "row survives the half pair" true
              (String.equal m.K.content "x");
            Alcotest.(check bool) "half pair reads as None" true
-             (m.K.delivery_key = None)
+             (m.K.delivery_provenance = None)
        | messages ->
            Alcotest.failf "expected 1 message, got %d" (List.length messages));
       Alcotest.(check (float 0.001)) "drop counted as invalid payload"
@@ -1910,7 +1910,7 @@ let test_half_provenance_reads_none () =
 (* The same undecodable row is not cosmetic: the append-once reader must
    fail rather than skip it, because skipping would report "not appended
    yet" for a delivery that may already be on disk. This pins the
-   [chat_message.delivery_key] contract in the .mli. *)
+   [chat_message.delivery_provenance] contract in the .mli. *)
 let test_half_provenance_blocks_append_once () =
   let base_dir = temp_base_path "keeper-chat-store-half-provenance-append" in
   Fun.protect
@@ -1938,10 +1938,9 @@ let test_half_provenance_blocks_append_once () =
           Alcotest.fail
             "append-once accepted a file holding an undecodable provenance row")
 
-(* The idempotent append-once paths persist the exact delivery identity on
-   the row; load decodes it back and to_json_array exposes it verbatim so the
-   dashboard can reconcile a history reload against its optimistic turn rows
-   on the exact [delivery_key.operation_id]. *)
+(* The idempotent append-once paths persist the exact delivery provenance on
+   the row; load and [to_json_array] preserve both the delivery key and the
+   transcript slot so every consumer uses the append-once SSOT. *)
 let test_delivery_key_round_trip_to_json_array () =
   let base_dir = temp_base_path "keeper-chat-store-delivery-key" in
   Fun.protect
@@ -1979,15 +1978,17 @@ let test_delivery_key_round_trip_to_json_array () =
       Alcotest.(check int) "two rows loaded" 2 (List.length messages);
       List.iter
         (fun (m : K.chat_message) ->
-          match m.delivery_key with
-          | Some key ->
+          match m.delivery_provenance with
+          | Some provenance ->
               Alcotest.(check bool)
                 (Printf.sprintf "delivery_key on %s row"
                    (K.Role.to_label m.role))
                 true
-                (Keeper_chat_delivery_identity.delivery_key_equal key
+                (Keeper_chat_delivery_identity.delivery_key_equal
+                   provenance.delivery_key
                    delivery_key)
-          | None -> Alcotest.fail "missing delivery_key on append-once row")
+          | None ->
+              Alcotest.fail "missing delivery_provenance on append-once row")
         messages;
       let open Yojson.Safe.Util in
       match K.to_json_array messages with
@@ -1999,7 +2000,15 @@ let test_delivery_key_round_trip_to_json_array () =
                 (key_json |> member "kind" |> to_string);
               Alcotest.(check string) "delivery_key operation_id"
                 "kmsg-turn-identity-1"
-                (key_json |> member "operation_id" |> to_string))
+                (key_json |> member "operation_id" |> to_string);
+              let slot_kind = row |> member "transcript_slot" |> member "kind" |> to_string in
+              let expected_slot =
+                match row |> member "role" |> to_string with
+                | "user" -> "accepted_user"
+                | "assistant" -> "terminal_assistant"
+                | role -> Alcotest.failf "unexpected role %s" role
+              in
+              Alcotest.(check string) "transcript slot kind" expected_slot slot_kind)
             rows
       | _ -> Alcotest.fail "to_json_array must return a list")
 
@@ -2017,7 +2026,7 @@ let test_delivery_key_absent_on_plain_append () =
       List.iter
         (fun (m : K.chat_message) ->
           Alcotest.(check bool) "plain append row has no delivery_key" true
-            (m.delivery_key = None))
+            (m.delivery_provenance = None))
         messages;
       let open Yojson.Safe.Util in
       match K.to_json_array messages with
@@ -2025,7 +2034,9 @@ let test_delivery_key_absent_on_plain_append () =
           List.iter
             (fun row ->
               Alcotest.(check bool) "delivery_key field omitted" true
-                (row |> member "delivery_key" |> ( = ) `Null))
+                (row |> member "delivery_key" |> ( = ) `Null);
+              Alcotest.(check bool) "transcript_slot field omitted" true
+                (row |> member "transcript_slot" |> ( = ) `Null))
             rows
       | _ -> Alcotest.fail "to_json_array must return a list")
 
@@ -2048,7 +2059,7 @@ let test_delivery_key_malformed_reads_none () =
       (match K.load ~base_dir ~keeper_name with
        | [ m ] ->
            Alcotest.(check bool) "malformed delivery_key reads as None" true
-             (m.delivery_key = None)
+             (m.delivery_provenance = None)
        | messages ->
            Alcotest.failf "expected 1 message, got %d" (List.length messages));
       Alcotest.(check (float 0.001)) "drop counted as invalid payload" 1.0

--- a/test/test_keeper_mention_scope.ml
+++ b/test/test_keeper_mention_scope.ml
@@ -66,7 +66,7 @@ let msg ~role ?(id = "test-msg") ?(ts = Some 1.0) ?(surface = None) ?(speaker = 
   ; kind
   ; turn_ref
   ; stream_lifecycle = None
-  ; delivery_key = None
+  ; delivery_provenance = None
   }
 ;;
 
@@ -216,7 +216,7 @@ let tool_line : Store.chat_message =
   ; kind = Store.Row_kind.Utterance
   ; turn_ref = None
   ; stream_lifecycle = None
-  ; delivery_key = None
+  ; delivery_provenance = None
   }
 ;;
 

--- a/test/test_keeper_surface_post.ml
+++ b/test/test_keeper_surface_post.ml
@@ -510,7 +510,7 @@ let roster_message ~surface ~speaker_id : Store.chat_message =
   ; kind = Store.Row_kind.Utterance
   ; turn_ref = None
   ; stream_lifecycle = None
-  ; delivery_key = None
+  ; delivery_provenance = None
   }
 
 let test_mentions_require_exact_resolved_target_roster () =

--- a/test/test_keeper_surface_read.ml
+++ b/test/test_keeper_surface_read.ml
@@ -35,7 +35,7 @@ let msg ?ts ?lane ?speaker ~role content : Store.chat_message =
     kind = Store.Row_kind.Utterance;
     turn_ref = None;
     stream_lifecycle = None;
-    delivery_key = None;
+    delivery_provenance = None;
   }
 
 let external_speaker ?name id : Store.speaker =


### PR DESCRIPTION
## Summary

- preserve the backend append-once `(delivery_key, transcript_slot)` pair through the Keeper chat store read model and HTTP projection
- reconcile optimistic, streamed, SSE, status, and REST history rows only through exact delivery provenance
- remove text, timestamp, role-only, request-id-only, and `turn_ref` row-identity heuristics
- keep malformed or incomplete provenance rows visible but non-reconcilable
- keep Effect Schema decoding at lazy API boundaries so the dashboard preload contract remains unchanged

## Root cause

The backend persisted a single message, but the dashboard flattened delivery identity incorrectly and decoded the operation key using the wrong field shape. The optimistic row and canonical history row therefore did not converge during the live session. Refresh discarded the optimistic in-memory row, making the duplicate appear to fix itself.

## Impact

Dashboard Keeper conversations now use the same atomic provenance SSOT as append-once persistence. User, tool, and assistant transcript slots from one operation remain distinct, while a canonical history row deterministically replaces its own optimistic row.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- focused Vitest: 230 tests across provenance, history schema, state merge, stream, actions, API, SSE, and preload contracts
- `scripts/dune-local.sh build lib/keeper test/test_keeper_chat_delivery_identity.exe test/test_keeper_chat_store.exe test/test_keeper_mention_scope.exe test/test_keeper_surface_read.exe`
- OCaml focused executables: 96 tests
- full dashboard sweep before final rebase: 8,933 of 8,934 passed; the sole preload-contract failure introduced by the first implementation was fixed, and its exact test plus the focused exact-head suite now pass
