### PR TITLE
fix(board): defer discoverable fanout to owner cursors

### DIFF
--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -69,6 +69,9 @@ val effective_keepalive_meta :
 
 val wakeup_relevant_keeper_for_board_signal :
   config:Workspace.config -> Board_dispatch.addressed_board_signal -> unit
+(** Addressed signals are durably routed immediately. Discoverable posts are
+    left to the existing per-Keeper durable Board cursor because they have no
+    immediate wake target. *)
 
 (** Fork the Board-attention judgment worker as a sibling of the heartbeat
     loop on the same Keeper lane switch. Both lane-start paths call this, so

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -396,13 +396,19 @@ let record_board_attention_candidate
          ~base_path:config.base_path
          candidate
      with
-     | Ok _ ->
+     | Ok acceptance ->
+       let persistence =
+         match acceptance.persistence with
+         | Keeper_board_attention_candidate.Candidate_recorded -> "recorded"
+         | Keeper_board_attention_candidate.Candidate_already_present -> "duplicate"
+       in
        Otel_metric_store.inc_counter
          Keeper_metrics.(to_string BoardSignalAttentionCandidateTotal)
          ~labels:
            [ ("keeper", meta.name)
            ; ("kind", signal_kind_label)
            ; ("audience", Keeper_board_audience.label Keeper_board_audience.Discoverable)
+           ; ("persistence", persistence)
            ]
          ()
      | Error err ->
@@ -520,10 +526,6 @@ let wakeup_relevant_keeper_for_board_signal
       (addressed : Board_dispatch.addressed_board_signal)
   =
   let signal = addressed.signal in
-  let registry_entries =
-    Keeper_registry.all ~base_path:config.base_path ()
-    |> List.filter board_signal_entry_accepts_delivery
-  in
   let signal_kind_label =
     match signal.kind with
     | Board_dispatch.Board_post_created -> "post_created"
@@ -547,17 +549,107 @@ let wakeup_relevant_keeper_for_board_signal
       signal.post_id
       (Keeper_board_audience.classification_error_to_string error)
   | Ok audience ->
-    Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string BoardSignalRoutedTotal)
-      ~labels:
-        [ ("kind", signal_kind_label)
-        ; ("audience", Keeper_board_audience.label audience)
-        ]
-      ();
-    (* Every lane is independent: persist and signal each addressed Keeper
-       without a fleet-wide cap, ordering dependency, or content debounce. *)
-    let board_ym = Eio_guard.create_yield_meter () in
-    List.iter
+    (match audience with
+     | Keeper_board_audience.Discoverable ->
+       (* An unaddressed post has no immediate wake target. The Keeper owner
+          already scans the durable Board with its per-lane cursor and owns
+          candidate creation. Repeating that fleet-wide scan in the HTTP
+          producer duplicated candidate writes and retained successful Board
+          receipts behind every Keeper metadata/evidence lock. *)
+       let uninitialized_entries =
+         Keeper_registry.all ~base_path:config.base_path ()
+         |> List.filter (fun (entry : Keeper_registry.registry_entry) ->
+           board_signal_entry_accepts_delivery entry
+           && Float.equal entry.board_cursor_ts 0.0)
+       in
+       Otel_metric_store.inc_counter
+         Keeper_metrics.(to_string BoardSignalCursorDeferredTotal)
+         ~labels:
+           [ ("kind", signal_kind_label)
+           ; ("audience", Keeper_board_audience.label audience)
+           ; ( "first_cursor_fallback"
+             , if uninitialized_entries = [] then "none" else "required" )
+           ]
+         ();
+       Log.Keeper.debug
+         "board discoverable signal deferred to owner cursors: post=%s first_cursor_fallback=%b"
+         signal.post_id
+         (uninitialized_entries <> []);
+       (* A first cursor initializes at the current Board head. Preserve posts
+          written during startup/warmup by recording only those exceptional
+          lanes now; established lanes stay on the owner cursor path above. *)
+       let board_ym = Eio_guard.create_yield_meter () in
+       List.iter
+         (fun (entry : Keeper_registry.registry_entry) ->
+            (match read_meta config entry.name with
+             | Error detail ->
+               Otel_metric_store.inc_counter
+                 Keeper_metrics.(to_string KeepaliveSignalFailures)
+                 ~labels:
+                   [ ("keeper", entry.name); ("phase", "board_meta_read") ]
+                 ();
+               Log.Keeper.warn
+                 "board signal Keeper metadata unavailable: keeper=%s error=%s"
+                 entry.name
+                 detail
+             | Ok None ->
+               Otel_metric_store.inc_counter
+                 Keeper_metrics.(to_string KeepaliveSignalFailures)
+                 ~labels:
+                   [ ("keeper", entry.name); ("phase", "board_meta_missing") ]
+                 ();
+               Log.Keeper.warn
+                 "board signal Keeper metadata missing: keeper=%s"
+                 entry.name
+             | Ok (Some meta) ->
+               (match route_for_keeper_with_bounded_retry ~audience ~meta signal with
+                | Keeper_world_observation_board_signal.Available
+                    Keeper_board_audience.Judge_discoverable ->
+                  record_board_attention_candidate
+                    ~config
+                    ~signal_kind_label
+                    ~meta
+                    signal
+                | Keeper_world_observation_board_signal.Available
+                    Keeper_board_audience.Ignore -> ()
+                | Keeper_world_observation_board_signal.Available
+                    (Keeper_board_audience.Deliver _) ->
+                  Log.Keeper.error
+                    "board discoverable fallback returned direct delivery: keeper=%s post=%s"
+                    meta.name
+                    signal.post_id
+                | Keeper_world_observation_board_signal.Unavailable unavailable ->
+                  Otel_metric_store.inc_counter
+                    Keeper_metrics.(to_string KeepaliveSignalFailures)
+                    ~labels:
+                      [ ("keeper", meta.name); ("phase", "board_signal_read") ]
+                    ();
+                  Log.Keeper.warn
+                    "board discoverable fallback unavailable: keeper=%s post=%s error=%s"
+                    meta.name
+                    signal.post_id
+                    (Keeper_world_observation_board_signal.unavailable_to_string
+                       unavailable)));
+            Eio_guard.yield_step board_ym)
+         uninitialized_entries
+     | ( Keeper_board_audience.Targets _
+       | Keeper_board_audience.Broadcast
+       | Keeper_board_audience.Thread_participants ) ->
+       Otel_metric_store.inc_counter
+         Keeper_metrics.(to_string BoardSignalRoutedTotal)
+         ~labels:
+           [ ("kind", signal_kind_label)
+           ; ("audience", Keeper_board_audience.label audience)
+           ]
+         ();
+       let registry_entries =
+         Keeper_registry.all ~base_path:config.base_path ()
+         |> List.filter board_signal_entry_accepts_delivery
+       in
+       (* Every addressed lane is independent: persist and signal it without
+          a fleet-wide cap, ordering dependency, or content debounce. *)
+       let board_ym = Eio_guard.create_yield_meter () in
+       List.iter
       (fun (entry : Keeper_registry.registry_entry) ->
          (try
             match read_meta config entry.name with
@@ -625,24 +717,19 @@ let wakeup_relevant_keeper_for_board_signal
                ()
            | Keeper_world_observation_board_signal.Available
                Keeper_board_audience.Judge_discoverable ->
-             (* Intentionally counted under [BoardSignalNoWakeTotal]:
-                [Judge_discoverable] issues no wake for this keeper — the
-                signal is recorded as an attention candidate below
-                instead. The [audience] label keeps this distinguishable
-                from the [Ignore] branch, which shares the counter. *)
+             (* The outer audience match excludes [Discoverable]. Keep this
+                fail-visible if a future routing rule violates that boundary. *)
              Otel_metric_store.inc_counter
-               Keeper_metrics.(to_string BoardSignalNoWakeTotal)
+               Keeper_metrics.(to_string KeepaliveSignalFailures)
                ~labels:
                  [ ("keeper", meta.name)
-                 ; ("kind", signal_kind_label)
-                 ; ("audience", Keeper_board_audience.label audience)
+                 ; ("phase", "unexpected_discoverable_immediate_route")
                  ]
                ();
-             record_board_attention_candidate
-               ~config
-               ~signal_kind_label
-               ~meta
-               signal
+             Log.Keeper.error
+               "board immediate route returned discoverable judgment: keeper=%s post=%s"
+               meta.name
+               signal.post_id
            | Keeper_world_observation_board_signal.Available
                (Keeper_board_audience.Deliver reason) ->
              (match deliver_addressed_board_signal ~config ~reason ~signal meta with
@@ -718,7 +805,7 @@ let wakeup_relevant_keeper_for_board_signal
               signal.post_id
               (Printexc.to_string exn));
          Eio_guard.yield_step board_ym)
-      registry_entries
+      registry_entries)
 ;;
 
 (* Per-stage timing accumulator for Phase 0 profiling.

--- a/lib/keeper/keeper_keepalive_signal.mli
+++ b/lib/keeper/keeper_keepalive_signal.mli
@@ -135,6 +135,10 @@ val wakeup_keeper :
 
 val wakeup_relevant_keeper_for_board_signal :
   config:Workspace.config -> Board_dispatch.addressed_board_signal -> unit
+(** Route typed immediate audiences to durable Keeper stimulus queues.
+    Discoverable posts have no immediate recipient, so their durable Board
+    record is consumed by each Keeper owner's cursor instead of performing a
+    fleet-wide metadata/candidate write on the Board producer fiber. *)
 
 (** Test hook (#25600): force the next [count] board-signal relevance
     computations to report a transient store read failure, exercising the

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -1007,7 +1007,23 @@ let collect_board_events_with_cursor_policy
                           ~base_path
                           candidate
                       with
-                      | Ok _ -> ()
+                      | Ok acceptance ->
+                        let persistence =
+                          match acceptance.persistence with
+                          | Keeper_board_attention_candidate.Candidate_recorded ->
+                            "recorded"
+                          | Keeper_board_attention_candidate.Candidate_already_present ->
+                            "duplicate"
+                        in
+                        Otel_metric_store.inc_counter
+                          Keeper_metrics.(to_string BoardSignalAttentionCandidateTotal)
+                          ~labels:
+                            [ "keeper", meta.name
+                            ; "kind", "post_created"
+                            ; "audience", Board_audience.label audience
+                            ; "persistence", persistence
+                            ]
+                          ()
                       | Error detail ->
                         raise
                           (Keeper_board_attention_candidate.Candidate_unavailable

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -74,6 +74,7 @@ type t =
   | CrashPersistenceFailures
   | KeepaliveSignalFailures
   | BoardSignalRoutedTotal
+  | BoardSignalCursorDeferredTotal
   | BoardSignalDeliveryTotal
   | BoardSignalNoWakeTotal
   | BoardSignalAttentionCandidateTotal
@@ -281,6 +282,8 @@ let to_string = function
   | CrashPersistenceFailures -> "masc_keeper_crash_persistence_failures_total"
   | KeepaliveSignalFailures -> "masc_keeper_keepalive_signal_failures_total"
   | BoardSignalRoutedTotal -> "masc_keeper_board_signal_routed_total"
+  | BoardSignalCursorDeferredTotal ->
+    "masc_keeper_board_signal_cursor_deferred_total"
   | BoardSignalDeliveryTotal -> "masc_keeper_board_signal_delivery_total"
   | BoardSignalNoWakeTotal -> "masc_keeper_board_signal_no_wake_total"
   | BoardSignalAttentionCandidateTotal ->

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -65,6 +65,7 @@ type t =
   | CrashPersistenceFailures
   | KeepaliveSignalFailures
   | BoardSignalRoutedTotal
+  | BoardSignalCursorDeferredTotal
   | BoardSignalDeliveryTotal
   | BoardSignalNoWakeTotal
   | BoardSignalAttentionCandidateTotal

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -227,6 +227,7 @@ normal_targets=(
   @test/runtest-test_keeper_surface_presence_prompt
   @test/runtest-test_keeper_board_attention_partition
   @test/runtest-test_keeper_board_attention_candidate
+  @test/runtest-test_keeper_board_discoverable_cursor
   @test/runtest-test_keeper_lifecycle_global_gate
   @test/runtest-test_tool_blob_store
   @test/runtest-test_keeper_tool_call_log

--- a/test/dune
+++ b/test/dune
@@ -2026,6 +2026,12 @@
 
 (include stanzas/test_keeper_keepalive_helpers.inc)
 
+(test
+ (name test_keeper_board_discoverable_cursor)
+ (libraries
+  masc_test_deps masc masc.config masc.keeper_metrics masc.keeper_runtime
+  masc_workspace masc_types masc.keeper_registry alcotest eio eio_main unix))
+
 (include stanzas/test_sse_retry_ssot.inc)
 
 (include stanzas/test_sse_storm_e2e.inc)

--- a/test/dune
+++ b/test/dune
@@ -2028,6 +2028,7 @@
 
 (test
  (name test_keeper_board_discoverable_cursor)
+ (modules test_keeper_board_discoverable_cursor)
  (libraries
   masc_test_deps masc masc.config masc.keeper_metrics masc.keeper_runtime
   masc_workspace masc_types masc.keeper_registry alcotest eio eio_main unix))

--- a/test/test_keeper_board_discoverable_cursor.ml
+++ b/test/test_keeper_board_discoverable_cursor.ml
@@ -1,0 +1,181 @@
+open Alcotest
+open Masc
+
+module KKS = Keeper_keepalive_signal
+module KBAC = Keeper_board_attention_candidate
+
+let rec remove_tree path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path
+      |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+      Unix.rmdir path)
+    else Sys.remove path
+;;
+
+let with_temp_workspace f =
+  let base_path = Filename.temp_dir "keeper-board-cursor" "" in
+  let config = Workspace.default_config base_path in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_registry.For_testing.clear ();
+      Board_dispatch.reset_for_test ();
+      Board.reset_global_for_test ();
+      remove_tree base_path)
+    (fun () ->
+       ignore (Workspace.init config ~agent_name:None : string);
+       Board_dispatch.reset_for_test ();
+       Board.reset_global_for_test ();
+       f config)
+;;
+
+let keeper_meta name =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+          [ "name", `String name
+          ; "agent_name", `String (Keeper_identity.keeper_agent_name name)
+          ; "trace_id", `String ("trace-" ^ name)
+          ])
+  with
+  | Ok meta -> meta
+  | Error detail -> fail detail
+;;
+
+let register config meta =
+  (match Keeper_meta_store.replace_snapshot config meta with
+   | Ok () -> ()
+   | Error detail -> fail detail);
+  ignore
+    (Keeper_registry.For_testing.register
+       ~base_path:config.Workspace.base_path
+       meta.Keeper_meta_contract.name
+       meta)
+;;
+
+let attention_count config keeper_name =
+  match KBAC.load_candidates ~base_path:config.Workspace.base_path ~keeper_name with
+  | Ok candidates -> List.length candidates
+  | Error detail -> fail detail
+;;
+
+let queue_length config keeper_name =
+  match
+    Keeper_registry_event_queue.snapshot_result
+      ~base_path:config.Workspace.base_path
+      keeper_name
+  with
+  | Ok queue -> Keeper_event_queue.length queue
+  | Error detail -> fail detail
+;;
+
+let persist_discoverable signal =
+  match
+    Board_dispatch.create_post
+      ~author:signal.Board_dispatch.author
+      ~content:signal.content
+      ~title:signal.title
+      ~post_kind:Board.Human_post
+      ~visibility:Board.Internal
+      ()
+  with
+  | Error error -> fail (Board.show_board_error error)
+  | Ok post ->
+    { Board_dispatch.signal =
+        { signal with post_id = Board.Post_id.to_string post.id }
+    ; audience = Board.Discoverable
+    }
+;;
+
+let signal ~post_id ~author ~title ~content : Board_dispatch.board_signal =
+  { kind = Board_dispatch.Board_post_created
+  ; post_id
+  ; author
+  ; title
+  ; content
+  ; hearth = None
+  ; updated_at = Some 1.0
+  }
+;;
+
+let test_initialized_lane_uses_owner_cursor () =
+  Eio_main.run @@ fun _env ->
+  with_temp_workspace @@ fun config ->
+  let meta = keeper_meta "discoverablelane" in
+  register config meta;
+  ignore
+    (persist_discoverable
+       (signal
+          ~post_id:"cursor-baseline"
+          ~author:meta.agent_name
+          ~title:"cursor baseline"
+          ~content:"establish a non-empty cursor"));
+  ignore
+    (Keeper_world_observation.collect_board_events
+       ~base_path:config.base_path
+       ~meta);
+  let addressed =
+    persist_discoverable
+      (signal
+         ~post_id:"discoverable"
+         ~author:"external-author"
+         ~title:"unaddressed research"
+         ~content:"new evidence without an explicit recipient")
+  in
+  KKS.wakeup_relevant_keeper_for_board_signal ~config addressed;
+  check int "producer candidate count" 0 (attention_count config meta.name);
+  check int "direct queue count" 0 (queue_length config meta.name);
+  let events, post_count, mention_count =
+    Keeper_world_observation.collect_board_events
+      ~base_path:config.base_path
+      ~meta
+  in
+  check int "judgment-only replay events" 0 (List.length events);
+  check int "owner cursor post count" 1 post_count;
+  check int "owner cursor mention count" 0 mention_count;
+  check int "owner cursor candidate count" 1 (attention_count config meta.name)
+;;
+
+let test_zero_cursor_lane_keeps_producer_fallback () =
+  Eio_main.run @@ fun _env ->
+  with_temp_workspace @@ fun config ->
+  let meta = keeper_meta "firstcursorlane" in
+  register config meta;
+  let addressed =
+    persist_discoverable
+      (signal
+         ~post_id:"before-first-cursor"
+         ~author:"external-author"
+         ~title:"startup evidence"
+         ~content:"persist before the owner cursor initializes")
+  in
+  KKS.wakeup_relevant_keeper_for_board_signal ~config addressed;
+  check int "fallback candidate count" 1 (attention_count config meta.name);
+  let events, post_count, mention_count =
+    Keeper_world_observation.collect_board_events
+      ~base_path:config.base_path
+      ~meta
+  in
+  check int "first cursor events" 0 (List.length events);
+  check int "first cursor post delta" 0 post_count;
+  check int "first cursor mention delta" 0 mention_count;
+  check int "preserved fallback candidate" 1 (attention_count config meta.name)
+;;
+
+let () =
+  run
+    "keeper Board discoverable cursor"
+    [ ( "producer and owner boundary"
+      , [ test_case
+            "initialized lane defers to owner cursor"
+            `Quick
+            test_initialized_lane_uses_owner_cursor
+        ; test_case
+            "zero cursor lane keeps durable producer fallback"
+            `Quick
+            test_zero_cursor_lane_keeps_producer_fallback
+        ] )
+    ]
+;;


### PR DESCRIPTION
## What changed

- stop scanning every Keeper and writing per-Keeper attention candidates on the Board producer fiber for an unaddressed `Discoverable` post
- leave those posts on the existing durable per-Keeper Board cursor path, whose owner already creates and wakes the judgment candidate
- preserve the old producer-side durable candidate path only for registered lanes whose first Board cursor is still uninitialized
- keep direct mentions, broadcasts, comments, and reactions on their existing synchronous durable delivery path
- distinguish cursor deferral with/without the first-cursor fallback, and distinguish recorded vs duplicate candidates
- add an isolated focused feature suite for the initialized and first-cursor paths

## Why

A live unique canary persisted successfully, but the HTTP 201 receipt took 46.836s. The following Board read took 92.007s and exact-id cleanup took 27.081s. The browser interaction matrix therefore timed out on its first post at 20s.

The post-commit Board signal hook was redoing discoverable attention work across the entire Keeper fleet on the request fiber, although each Keeper owner already has a durable Board cursor that owns the same candidate creation.

## Semantics

This is not a timeout increase, queue-capacity gate, background in-memory outbox, or delivery drop. The first async draft was rejected after adversarial review because it could grow without bound and lose Activity/SSE effects on crash. This revision keeps Board JSONL and Keeper candidate/event ledgers authoritative.

A post created before any Keeper is registered remains outside this PR's scope; that bootstrap window already existed because the prior producer hook also enumerated only registered lanes.

## Validation

- `git diff --check`
- `scripts/audit-ci-test-targets.sh`: 303 CI targets declared; 561 unwired suites at baseline
- ocamlformat 0.29.0 on changed OCaml files
- adversarial review: unbounded queue/crash-loss design removed; first-cursor registered-lane regression covered
- local build intentionally not run; exact-head GitHub CI is authoritative
