### PR TITLE
fix(runtime): accept Codex tool-only completion

### DIFF
--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -5,9 +5,14 @@ let internal_error = Keeper_official_client_host.internal_error
 
 module Host = Keeper_official_client_host
 
+type successful_tool_completion =
+  | No_successful_tool_completion
+  | Successful_tool_completion
+
 type attempt_outcome =
   { result : (Runtime_agent.run_result, Agent_core.Error.t) result
   ; effect_disposition : Keeper_provider_attempt_effect.t
+  ; successful_tool_completion : successful_tool_completion
   }
 
 let runtime_label = "Codex"
@@ -195,7 +200,8 @@ let model_input_projection_for_capacity
   Ok projected
 ;;
 
-let codex_dynamic_tool ~observe_effect_attempted (tool : Host.dynamic_tool) :
+let codex_dynamic_tool ~observe_effect_attempted ~observe_successful_tool_completion
+    (tool : Host.dynamic_tool) :
     Runtime_codex_app_server.dynamic_tool =
   { tool with
     call =
@@ -205,7 +211,12 @@ let codex_dynamic_tool ~observe_effect_attempted (tool : Host.dynamic_tool) :
            observing only its returned value would reopen a duplicate-effect
            window. *)
         observe_effect_attempted ();
-        tool.call ~call_id input)
+        let result = tool.call ~call_id input in
+        (* This is evidence that the handler returned a successful tool result,
+           which is sufficient to accept a tool-only provider terminal. It is
+           not durable-effect truth and grants no retry authority. *)
+        if result.success then observe_successful_tool_completion ();
+        result)
   }
 ;;
 
@@ -378,7 +389,7 @@ let recovery_failure_of_client_error = function
 let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
     ~system_prompt ~tools ~initial_messages ~model_input_projection ~hooks
     ~context_injector ~context ~event_bus ~raw_trace ~on_event
-    ~observe_effect_attempted
+    ~observe_effect_attempted ~observe_successful_tool_completion
     ~(config : Runtime_execution.codex_app_server) =
   match Eio_context.get_env_opt (), Eio_context.get_clock_opt () with
   | None, _ ->
@@ -537,7 +548,11 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
         ~raw_trace_run:None
     in
     let dynamic_tools =
-      List.map (codex_dynamic_tool ~observe_effect_attempted) host_dynamic_tools
+      List.map
+        (codex_dynamic_tool
+           ~observe_effect_attempted
+           ~observe_successful_tool_completion)
+        host_dynamic_tools
     in
     (* The only size this tree reports for a turn is
        [keeper_unified_turn.ml]'s [system_and_user_bytes], which sums
@@ -606,7 +621,11 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
         ~raw_trace_run
     in
     let dynamic_tools =
-      List.map (codex_dynamic_tool ~observe_effect_attempted) host_dynamic_tools
+      List.map
+        (codex_dynamic_tool
+           ~observe_effect_attempted
+           ~observe_successful_tool_completion)
+        host_dynamic_tools
     in
     let* claimed_session =
       match
@@ -940,6 +959,10 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
   let observe_effect_attempted () =
     Atomic.set effect_disposition Keeper_provider_attempt_effect.Effect_attempted
   in
+  let successful_tool_completion = Atomic.make No_successful_tool_completion in
+  let observe_successful_tool_completion () =
+    Atomic.set successful_tool_completion Successful_tool_completion
+  in
   let observed_next_shrink_capacity_bytes = ref None in
   let starting_capacity_bytes =
     Keeper_context_overflow_shrink_state.starting_capacity_bytes
@@ -997,10 +1020,14 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
           ~raw_trace
           ~on_event
           ~observe_effect_attempted
+          ~observe_successful_tool_completion
           ~config)
       ())
   in
-  { result; effect_disposition = Atomic.get effect_disposition }
+  { result
+  ; effect_disposition = Atomic.get effect_disposition
+  ; successful_tool_completion = Atomic.get successful_tool_completion
+  }
 ;;
 
 module For_testing = struct

--- a/lib/keeper/keeper_codex_runtime.mli
+++ b/lib/keeper/keeper_codex_runtime.mli
@@ -1,12 +1,19 @@
 (** Keeper projection for the official Codex app-server turn runtime. *)
 
+type successful_tool_completion =
+  | No_successful_tool_completion
+  | Successful_tool_completion
+
 type attempt_outcome =
   { result : (Runtime_agent.run_result, Agent_core.Error.t) result
   ; effect_disposition : Keeper_provider_attempt_effect.t
+  ; successful_tool_completion : successful_tool_completion
   }
-(** One Codex candidate result plus the typed tool-effect fact observed while
-    producing it. The outer runtime-lane owner consumes [effect_disposition]
-    directly; provider error strings carry no retry authority. *)
+(** One Codex candidate result plus two distinct typed tool facts observed
+    while producing it. The outer runtime-lane owner consumes
+    [effect_disposition] as retry authority; [successful_tool_completion]
+    only proves that a handler returned a successful result and can therefore
+    support accepting a tool-only terminal. *)
 
 val run :
   runtime_id:string ->

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -887,6 +887,8 @@ let run_named
                         }))
             ; effect_disposition =
                 Keeper_provider_attempt_effect.No_effect_observed
+            ; successful_tool_completion =
+                Keeper_codex_runtime.No_successful_tool_completion
             }
           | None, checkpoint ->
             (* The official-client session store is the start-or-resume
@@ -917,10 +919,25 @@ let run_named
         Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
         let codex_result =
           Result.bind codex_attempt.result (fun run_result ->
-            Keeper_turn_driver_try_provider.apply_accept
-              ~runtime_id:attempt_runtime_id
-              ~accept
-              run_result)
+            match codex_attempt.successful_tool_completion with
+            | Keeper_codex_runtime.Successful_tool_completion ->
+              (match
+                 run_result.Runtime_agent.stop_reason,
+                 run_result.response.content
+               with
+               | Runtime_agent.Completed, [ Agent_core.Types.Text text ]
+                 when String.trim text = "" ->
+                 Ok run_result
+               | _ ->
+                 Keeper_turn_driver_try_provider.apply_accept
+                   ~runtime_id:attempt_runtime_id
+                   ~accept
+                   run_result)
+            | Keeper_codex_runtime.No_successful_tool_completion ->
+              Keeper_turn_driver_try_provider.apply_accept
+                ~runtime_id:attempt_runtime_id
+                ~accept
+                run_result)
         in
         (match codex_result with
          | Ok run_result ->

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -571,7 +571,10 @@ let terminal_result ~thread_id ~turn_id ~seen_final ~seen_fallback
       | "completed" ->
         let* items = required_member stage "items" turn_fields in
         let* terminal_final, terminal_fallback = messages_of_items ~stage items in
-        let visible_text = Option.filter (fun text -> String.trim text <> "") in
+        let visible_text = function
+          | Some text when String.trim text <> "" -> Some text
+          | Some _ | None -> None
+        in
         let text =
           match
             visible_text terminal_final,
@@ -661,7 +664,9 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
       if String.equal method_ "item/agentMessage/delta"
       then (
         emit_stream_event on_stream_event (Text_delta delta);
-        Some (Option.value seen_fallback ~default:"" ^ delta))
+        match seen_fallback with
+        | None -> Some delta
+        | Some text -> Some (text ^ delta))
       else seen_fallback
     in
     await_turn_terminal

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -480,9 +480,13 @@ let agent_message_of_item ~stage item =
   let* fields = assoc_at stage item in
   match List.assoc_opt "type" fields with
   | Some (`String "agentMessage") ->
-    let* text = required_string stage "text" fields in
+    (* The app-server schema requires [text] to be a string, not a non-empty
+       string. In particular, a tool-only turn may complete an agent-message
+       item with empty text after the tool result has been committed. Such an
+       item is valid protocol but is not a visible assistant-message candidate. *)
+    let* text = required_string_any stage "text" fields in
     let* phase = optional_string stage "phase" fields in
-    Ok (Some (phase, text))
+    if String.trim text = "" then Ok None else Ok (Some (phase, text))
   | Some (`String _) -> Ok None
   | Some _ -> protocol_error stage "item type must be a string"
   | None -> protocol_error stage "item is missing type"
@@ -567,14 +571,21 @@ let terminal_result ~thread_id ~turn_id ~seen_final ~seen_fallback
       | "completed" ->
         let* items = required_member stage "items" turn_fields in
         let* terminal_final, terminal_fallback = messages_of_items ~stage items in
+        let visible_text = Option.filter (fun text -> String.trim text <> "") in
         let text =
-          match terminal_final, seen_final, terminal_fallback, seen_fallback with
+          match
+            visible_text terminal_final,
+            visible_text seen_final,
+            visible_text terminal_fallback,
+            visible_text seen_fallback
+          with
           | Some text, _, _, _ | None, Some text, _, _
           | None, None, Some text, _ | None, None, None, Some text -> Some text
           | None, None, None, None -> None
         in
         (match text with
          | Some text -> Ok text
+         | None when tool_effect_attempted -> Ok ""
          | None -> protocol_error stage "completed turn has no assistant message")
       | other -> protocol_error stage (Printf.sprintf "unknown turn status %S" other)
 ;;
@@ -646,8 +657,13 @@ let rec await_turn_terminal io ~tools ~tool_call_count ~thread_id ~turn_id ~seen
       } ->
     let* delta = item_delta_notification ~method_ ~thread_id ~turn_id params
     in
-    if String.equal method_ "item/agentMessage/delta"
-    then emit_stream_event on_stream_event (Text_delta delta);
+    let seen_fallback =
+      if String.equal method_ "item/agentMessage/delta"
+      then (
+        emit_stream_event on_stream_event (Text_delta delta);
+        Some (Option.value seen_fallback ~default:"" ^ delta))
+      else seen_fallback
+    in
     await_turn_terminal
       io
       ~tools


### PR DESCRIPTION
## As-Is

A live `codex_subscription.gpt-5.6-sol` Keeper turn on the `codex_app_server` lane invoked `keeper_time_now`, completed its tool call/output, and then emitted a legal terminal `agentMessage` with empty text. MASC decoded `text` through the non-empty string helper and failed the turn with `Codex app-server protocol error during item/completed: field "text" must be a non-empty string`.

## To-Be

- Keep agent-message identity/type strict while accepting `text` by presence and JSON string type. Blank text is not a visible assistant candidate.
- Accumulate only agent-message stream deltas as a fallback when terminal aggregate text is absent; command/file/plan deltas remain excluded.
- Accept a blank completed carrier only when this exact Codex candidate has authoritative evidence that a dynamic tool handler returned a successful result.
- Keep no-tool/no-text, pre-hook blocked, failed-tool-only, host-stop, and terminal-error paths rejected.
- Preserve the existing effect-disposition retry authority; no fake `ToolUse`, runtime-name policy, compatibility gate, or shared decoder change.

## Evidence and scope

The source path was traced from `Runtime_codex_app_server.run_turn` through `Keeper_codex_runtime` into the Codex branch of `Keeper_turn_driver`. The successful-tool evidence is per candidate and is set only after the host handler returns `success=true`; it is distinct from durable-effect/retry authority. No hidden reasoning content was inspected or included.

Changed production files only:

- `lib/runtime/runtime_codex_app_server.ml`
- `lib/keeper/keeper_codex_runtime.ml`
- `lib/keeper/keeper_codex_runtime.mli`
- `lib/keeper/keeper_turn_driver.ml`

## Validation

Passed locally:

- `ocamlformat --check` on all four files
- `ocamlc -stop-after parsing` on all four files
- `git diff --check`
- exact four-file scope and conflict-marker ratchets

No new tests were added. Local Dune build and test suite were intentionally not run. CI, deployment, and live runtime re-probe are pending.

# ci:skip-test-coverage

Tests are intentionally deferred per the active campaign instruction; this PR retains the live reproduction and focused parse/format evidence.