### PR TITLE
fix(dashboard): hydrate durable workspace messages

### DIFF
--- a/dashboard/src/api/dashboard-workspace.ts
+++ b/dashboard/src/api/dashboard-workspace.ts
@@ -1,0 +1,54 @@
+import type { Message } from '../types'
+import { isRecord } from '../lib/type-guards'
+import { get, type AbortableRequestOptions } from './core'
+
+function requiredString(
+  record: Record<string, unknown>,
+  field: string,
+  index: number,
+): string {
+  const value = record[field]
+  if (typeof value !== 'string') {
+    throw new Error(`Workspace message ${index}.${field} must be a string`)
+  }
+  return value
+}
+
+function decodeDashboardWorkspaceMessage(raw: unknown, index: number): Message {
+  if (!isRecord(raw)) {
+    throw new Error(`Workspace message ${index} must be an object`)
+  }
+  return {
+    id: requiredString(raw, 'id', index),
+    from: requiredString(raw, 'sender', index),
+    content: requiredString(raw, 'body', index),
+    timestamp: requiredString(raw, 'ts', index),
+    type: requiredString(raw, 'type', index),
+    workspace: requiredString(raw, 'workspace_id', index),
+    mentions: requiredStringArray(raw, 'mentions', index),
+  }
+}
+
+function requiredStringArray(
+  record: Record<string, unknown>,
+  field: string,
+  index: number,
+): string[] {
+  const value = record[field]
+  if (!Array.isArray(value) || !value.every(item => typeof item === 'string')) {
+    throw new Error(`Workspace message ${index}.${field} must be a string array`)
+  }
+  return value
+}
+
+export async function fetchDashboardWorkspaceMessages(
+  opts?: AbortableRequestOptions,
+): Promise<Message[]> {
+  const response = await get<unknown>('/api/v1/dashboard/workspace', {
+    signal: opts?.signal,
+  })
+  if (!isRecord(response) || !Array.isArray(response.messages)) {
+    throw new Error('Workspace messages response must contain a messages array')
+  }
+  return response.messages.map(decodeDashboardWorkspaceMessage)
+}

--- a/dashboard/src/components/board/message-workspace-timeline.ts
+++ b/dashboard/src/components/board/message-workspace-timeline.ts
@@ -1,16 +1,24 @@
 import { html } from 'htm/preact'
-import { useMemo, useState } from 'preact/hooks'
+import { useEffect, useMemo, useState } from 'preact/hooks'
 import { ArrowLeft, AtSign } from 'lucide-preact'
 import { ActionButton } from '../common/button'
-import { EmptyState } from '../common/feedback-state'
+import { EmptyState, ErrorState, LoadingState } from '../common/feedback-state'
 import { RichContent } from '../common/rich-content'
 import { TimeAgo } from '../common/time-ago'
 import { SYSTEM_MESSAGE_FROM, boardMessageRowKey, previewBoardMessage } from '../../lib/board-utils'
-import { messages } from '../../store'
+import {
+  cancelDashboardWorkspaceMessagesRefresh,
+  messages,
+  refreshDashboardWorkspaceMessages,
+  serverStatus,
+  workspaceMessagesError,
+  workspaceMessagesLoading,
+} from '../../store'
 import type { Message } from '../../types'
 import { ComposerV2 } from './composer-v2'
 import { extractMentionTargets } from './mention-inbox'
 import { navigateBoard } from './board-route'
+import { registerWorkspaceMessagesRefresh } from '../../sse-store'
 
 interface TimelineRow {
   message: Message
@@ -56,7 +64,7 @@ export function buildMessageWorkspaceModel(messageList: readonly Message[]): Mes
   let totalMentions = 0
 
   messageList.forEach((message, index) => {
-    const mentionTargets = extractMentionTargets(message.content)
+    const mentionTargets = message.mentions ?? extractMentionTargets(message.content)
     totalMentions += mentionTargets.length
     const workspace = normalizeWorkspace(message.workspace)
     const rows = byWorkspace.get(workspace) ?? []
@@ -123,6 +131,7 @@ function TimelineMessage({ row }: { row: TimelineRow }) {
 
 export function MessageWorkspaceTimeline() {
   const model = useMemo(() => buildMessageWorkspaceModel(messages.value), [messages.value])
+  const project = serverStatus.value?.project ?? null
   const [selectedWorkspace, setSelectedWorkspace] = useState<string | null>(null)
   const activeWorkspace = model.workspaces.some(workspace => workspace.workspace === selectedWorkspace)
     ? selectedWorkspace
@@ -130,8 +139,24 @@ export function MessageWorkspaceTimeline() {
   const active = activeWorkspace ? model.workspaces.find(workspace => workspace.workspace === activeWorkspace) ?? null : null
   const composerWorkspace = activeWorkspace ?? 'default'
 
+  useEffect(() => {
+    const refresh = () => {
+      void refreshDashboardWorkspaceMessages(project)
+    }
+    const unregister = registerWorkspaceMessagesRefresh(refresh)
+    refresh()
+    return () => {
+      unregister()
+      cancelDashboardWorkspaceMessagesRefresh()
+    }
+  }, [project])
+
   return html`
-    <section class="grid gap-4" aria-labelledby="message-workspace-timeline-heading">
+    <section
+      class="grid gap-4"
+      aria-labelledby="message-workspace-timeline-heading"
+      aria-busy=${workspaceMessagesLoading.value}
+    >
       <div class="flex flex-wrap items-start justify-between gap-3">
         <div class="min-w-0">
           <div class="text-2xs font-bold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-secondary)]">Messages</div>
@@ -164,10 +189,18 @@ export function MessageWorkspaceTimeline() {
         </div>
       </div>
 
+      ${workspaceMessagesError.value
+        ? html`<${ErrorState} message=${workspaceMessagesError.value} />`
+        : null}
+
       ${model.workspaces.length === 0
         ? html`
             <${ComposerV2} workspaceId=${composerWorkspace} />
-            <${EmptyState} message="메시지 타임라인 없음" compact />
+            ${workspaceMessagesError.value
+              ? null
+              : workspaceMessagesLoading.value
+              ? html`<${LoadingState}>메시지 타임라인 불러오는 중…<//>`
+              : html`<${EmptyState} message="메시지 타임라인 없음" compact />`}
           `
         : html`
             <div class="flex flex-wrap gap-2" role="tablist" aria-label="Message workspaces">

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -146,6 +146,14 @@ export function registerActivityRefresh(fn: () => void): () => void {
   }
 }
 
+const _refreshWorkspaceMessageFns = new Set<() => void>()
+export function registerWorkspaceMessagesRefresh(fn: () => void): () => void {
+  _refreshWorkspaceMessageFns.add(fn)
+  return () => {
+    _refreshWorkspaceMessageFns.delete(fn)
+  }
+}
+
 const _refreshInternalAgentFns = new Set<() => void>()
 export function registerInternalAgentRefresh(fn: () => void): () => void {
   _refreshInternalAgentFns.add(fn)
@@ -626,6 +634,11 @@ export function routeServerPushEvent(event: SSEEvent): void {
   }
 
   const routedType = normalizeSSEDispatchType(event.type)
+  if (normalizeMascEventType(routedType) === 'broadcast') {
+    scheduleRefresh('workspace-messages', () => {
+      for (const refresh of _refreshWorkspaceMessageFns) refresh()
+    })
+  }
   const simpleRoute = SIMPLE_ROUTES[routedType]
   if (simpleRoute) {
     const refreshFn =

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -149,6 +149,7 @@ export function normalizeMessage(raw: unknown): Message | null {
     timestamp,
     type: asString(raw.type),
     workspace,
+    mentions: Array.isArray(raw.mentions) ? asStringArray(raw.mentions) : undefined,
   }
 }
 

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -29,6 +29,7 @@ import { fetchDashboardBootstrap, fetchDashboardShell } from './api/dashboard-ho
 import { journal } from './sse'
 import { showToast } from './components/common/toast'
 import { errorMessageOr } from './lib/format-string'
+import { isAbortError } from './lib/async-state'
 import {
   keeperFreshnessTs,
   normalizeKeepers,
@@ -91,6 +92,8 @@ export const shellRuntimeResolution = signal<DashboardRuntimeResolution | null>(
 export const agents = signal<Agent[]>([])
 export const tasks = signal<Task[]>([])
 export const messages = signal<Message[]>([])
+export const workspaceMessagesLoading = signal(false)
+export const workspaceMessagesError = signal<string | null>(null)
 export const keepers = signal<Keeper[]>([])
 export const serverStatus = signal<ServerStatus | null>(null)
 // Authoritative backlog size from the execution payload's `task_counts.total`.
@@ -652,7 +655,76 @@ export const staleKeepers: ReadonlySignal<Set<string>> = computed(() => {
 let inflightDashboardRefresh: Promise<void> | null = null
 let inflightShellRefresh: Promise<boolean> | null = null
 let inflightShellRefreshLight = false
+let inflightWorkspaceMessagesRefresh: Promise<void> | null = null
+let workspaceMessagesRefreshController: AbortController | null = null
+let workspaceMessagesRefreshGeneration = 0
+let workspaceMessagesRefreshInvalidated = false
 let lastShellRefreshAt = 0
+
+export function refreshDashboardWorkspaceMessages(
+  expectedProject = serverStatus.value?.project ?? null,
+): Promise<void> {
+  if (inflightWorkspaceMessagesRefresh) {
+    workspaceMessagesRefreshInvalidated = true
+    return inflightWorkspaceMessagesRefresh
+  }
+
+  workspaceMessagesLoading.value = true
+  workspaceMessagesError.value = null
+  workspaceMessagesRefreshInvalidated = false
+  const generation = ++workspaceMessagesRefreshGeneration
+  const controller = new AbortController()
+  workspaceMessagesRefreshController = controller
+  inflightWorkspaceMessagesRefresh = (async () => {
+    try {
+      const { fetchDashboardWorkspaceMessages } = await import('./api/dashboard-workspace')
+      let settled = false
+      while (!settled && generation === workspaceMessagesRefreshGeneration) {
+        workspaceMessagesRefreshInvalidated = false
+        const nextMessages = await fetchDashboardWorkspaceMessages({
+          signal: controller.signal,
+        })
+        if (generation !== workspaceMessagesRefreshGeneration || controller.signal.aborted) {
+          return
+        }
+        if (workspaceMessagesRefreshInvalidated) {
+          continue
+        }
+        if ((serverStatus.value?.project ?? null) === expectedProject) {
+          // This endpoint is the durable Workspace message SSOT. Replace the
+          // execution-derived cache instead of merging rows that the light
+          // execution response intentionally omits.
+          messages.value = nextMessages
+        }
+        settled = true
+      }
+    } catch (error) {
+      if (generation === workspaceMessagesRefreshGeneration && !isAbortError(error)) {
+        workspaceMessagesError.value = errorMessageOr(
+          error,
+          'Workspace messages failed to load',
+        )
+        console.warn('[Workspace messages] fetch error:', error)
+      }
+    } finally {
+      if (generation === workspaceMessagesRefreshGeneration) {
+        workspaceMessagesLoading.value = false
+        workspaceMessagesRefreshController = null
+        inflightWorkspaceMessagesRefresh = null
+      }
+    }
+  })()
+  return inflightWorkspaceMessagesRefresh
+}
+
+export function cancelDashboardWorkspaceMessagesRefresh(): void {
+  workspaceMessagesRefreshGeneration += 1
+  workspaceMessagesRefreshInvalidated = false
+  workspaceMessagesRefreshController?.abort()
+  workspaceMessagesRefreshController = null
+  inflightWorkspaceMessagesRefresh = null
+  workspaceMessagesLoading.value = false
+}
 
 export function invalidateDashboardCache(): void {
   // Projection endpoints are intentionally fresh-first after the operator-console rewrite.
@@ -892,6 +964,7 @@ export function hydrateExecutionSnapshot(data: DashboardExecutionResponse): void
     previousProject != null
     && normalizedStatus?.project != null
     && previousProject !== normalizedStatus.project
+  if (workspaceChanged) cancelDashboardWorkspaceMessagesRefresh()
   const normalizedAgents = (Array.isArray(data.agents) ? data.agents : [])
     .map(normalizeAgent)
     .filter((row): row is Agent => row !== null)

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -101,6 +101,7 @@ export interface Message {
   timestamp?: string
   type?: string
   workspace?: string
+  mentions?: string[]
 }
 
 // --- Board ---

--- a/lib/dashboard/dashboard_workspace.ml
+++ b/lib/dashboard/dashboard_workspace.ml
@@ -215,6 +215,15 @@ let compute_json ~config ?me ~limit () =
    compute on a worker domain via Domain_pool. *)
 let cache_ttl_sec = 5.0
 
+let install_persistence_cache_invalidation () =
+  Atomic.set Workspace_hooks.workspace_message_persisted_fn (fun config ->
+    let base_path = config.Workspace.base_path in
+    Dashboard_cache.invalidate_prefix
+      (Printf.sprintf "dashboard.workspace:%s;" base_path);
+    Dashboard_cache.invalidate_prefix
+      (Printf.sprintf "workspace:%s:" base_path))
+;;
+
 let json ~config ?me ~limit () =
   let key =
     Printf.sprintf

--- a/lib/dashboard/dashboard_workspace.mli
+++ b/lib/dashboard/dashboard_workspace.mli
@@ -1,5 +1,9 @@
 val json : config:Workspace.config -> ?me:string -> limit:int -> unit -> Yojson.Safe.t
 
+(** Install the workspace persistence hook that invalidates this projection and
+    the server response cache before a broadcast notification is published. *)
+val install_persistence_cache_invalidation : unit -> unit
+
 val mentions_of_message : Masc_domain.message -> string list
 (** Every agent name this message mentions: the typed [mention] field first,
     then [@word] tokens parsed from the body, deduplicated in order. The one

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -537,6 +537,7 @@ let create_server_state ~sw ~base_path ?input_base_path ~clock ~mono_clock ~net
         ~category:Log.Boundary
         "keeper stream idle timeout resolved: disabled (no inter-line idle bound)");
   Keeper_task_owner_backend.install_hooks ();
+  Dashboard_workspace.install_persistence_cache_invalidation ();
   let state =
     Mcp_eio.create_state_eio ~sw ~proc_mgr ~fs ~clock
       ~mono_clock ~net

--- a/lib/workspace/workspace_broadcast.ml
+++ b/lib/workspace/workspace_broadcast.ml
@@ -146,7 +146,17 @@ let broadcast ?trace_context ?(msg_type = "broadcast") config ~from_agent ~conte
     Filename.concat (messages_dir config)
       (Printf.sprintf "%09d_%s_broadcast.json" seq (safe_filename from_agent))
   in
-  write_json config msg_file (message_to_yojson msg);
+  (match write_json_commit_result config msg_file (message_to_yojson msg) with
+   | Ok { mirror_error } ->
+     Option.iter
+       (fun message -> Log.Misc.warn "workspace message mirror write failed: %s" message)
+       mirror_error;
+     (try (Atomic.get Workspace_hooks.workspace_message_persisted_fn) config
+      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+        Log.Misc.warn "workspace message projection invalidation failed: %s"
+          (Printexc.to_string exn))
+   | Error message ->
+     Log.Misc.warn "write_json failed for %s: %s" msg_file message);
   (match backend_publish config ~channel:(broadcast_channel config)
       ~message:(Yojson.Safe.to_string (message_to_yojson msg)) with
    | Ok _ -> ()

--- a/lib/workspace/workspace_hooks.ml
+++ b/lib/workspace/workspace_hooks.ml
@@ -217,6 +217,10 @@ let workspace_broadcast_observed_fn
   : (msg_type:string -> elapsed_s:float -> unit) Atomic.t
   = Atomic.make (fun ~msg_type:_ ~elapsed_s:_ -> ())
 
+let workspace_message_persisted_fn
+  : (Workspace_utils_backend_setup.config -> unit) Atomic.t
+  = Atomic.make (fun _config -> ())
+
 (** #13460: stale task-state cache emission observability.
     Workspace sub-modules fire this when they replace a stale active-task
     broadcast/mention with a cache invalidation message. [lib/workspace.ml]

--- a/lib/workspace/workspace_hooks.mli
+++ b/lib/workspace/workspace_hooks.mli
@@ -102,6 +102,12 @@ val tool_assigned_fn : (agent_id:string ->
 val workspace_broadcast_observed_fn :
   (msg_type:string -> elapsed_s:float -> unit) Atomic.t
 
+(** Fires immediately after a broadcast message is durably written. Runtime
+    wiring uses this ownership boundary to invalidate read projections without
+    introducing a workspace-to-dashboard dependency. *)
+val workspace_message_persisted_fn :
+  (Workspace_utils_backend_setup.config -> unit) Atomic.t
+
 val cache_desync_cleared_fn :
   (Workspace_utils_backend_setup.config ->
    module_name:string -> task_id:string -> status:string -> unit) Atomic.t


### PR DESCRIPTION
## What changed

- hydrate Message Workspace from the durable `/api/v1/dashboard/workspace` projection instead of the light execution snapshot
- preserve backend-owned `mentions` and display load/error state without hiding cached rows
- refresh the mounted surface on broadcast SSE with generation, namespace, cancellation, and in-flight invalidation fencing
- invalidate both workspace Dashboard caches immediately after the authoritative message commit, before publish/SSE

## Root cause

Message Workspace only consumed the light `/dashboard/execution` payload, which intentionally omits durable messages. Even an SSE-triggered exact read could receive a pre-broadcast snapshot from the nested 5s Dashboard cache and the H1 response cache. The UI could therefore remain empty or stale after a successful broadcast.

Cache invalidation is wired at the workspace persistence ownership boundary. It is installed before backend construction so Memory fallback behaves the same as FileSystem. Authoritative commit success invalidates the projections; a local mirror failure is reported separately and does not erase the committed result.

## Live evidence

The live workspace endpoint returned durable message `msg-000001007` with backend-owned mention targets, while the mounted Message Workspace surface had no durable producer. Deployment and browser rerun remain pending; this Draft is source-only until merged and deployed.

## Validation

- `ocamlformat --check` on changed OCaml files
- `ocamlc -stop-after parsing` on changed OCaml files
- `git diff --check`
- existing focused Vitest: 3 files, 76 tests passed
- Dashboard `tsc --noEmit`
- changed-file ESLint
- independent adversarial source review: no P1/P2 findings

No local Dune build and no new tests were run, per campaign instructions.

## Scope

Base: `main@372edb534d4def1996fa57a1fce9344784e5be45`

This is an independent small Draft PR. It does not claim CI, merge, deployment, or live browser evidence.

# ci:skip-test-coverage
