### PR TITLE
fix(keeper): drain Librarian on graceful shutdown

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -1219,11 +1219,10 @@ let start_keepalive
             if graceful_librarian_boundary
             then (
               let librarian_result = handle_librarian () in
-              let terminal_result =
-                match librarian_result with
-                | Ok () -> terminalize ()
-                | Error _ -> Ok ()
-              in
+              (* A failed detached drain is still a terminal Keeper boundary.
+                 Resolve [done_p] before returning the cleanup error so stop,
+                 update, and restart waiters cannot hang after lane exit. *)
+              let terminal_result = terminalize () in
               terminal_result, librarian_result)
             else (
               (* Crash publication must not wait behind root-scoped provider

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -1066,7 +1066,7 @@ let start_keepalive
        | Ok outcome -> outcome
       and launch_registered _intake_token launch_token reg =
       (* Restore persisted tool usage stats from previous session *)
-      Keeper_registry_tool_usage_persistence.restore ~base_path:ctx.config.base_path m.name;
+      Keeper_registry_tool_usage_persistence.restore_for_lifecycle launch_token reg;
       (* Launch gate FIRST: every launch side effect (gRPC heartbeat fiber,
          grpc_close registration, live-meta bootstrap/update) must come after
          the registry FSM accepts [Fiber_started]. Starting the sidecar

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -1091,18 +1091,32 @@ let start_keepalive
             "fiber_start_rejected: %s"
             (Keeper_state_machine.transition_error_to_string err)
         in
-        Keeper_registry.set_failure_reason
-          ~base_path:ctx.config.base_path
-          m.name
-          (Some (Keeper_registry.Exception reason));
-        Keeper_registry.record_crash
-          ~base_path:ctx.config.base_path
-          m.name
-          (Time_compat.now ())
-          reason;
-        Keeper_registry_error_recording.record
-          ~base_path:ctx.config.base_path
-          m.name
+        ignore
+          (Keeper_registry.update_entry_exact_for_lifecycle
+             launch_token
+             reg
+             (fun current ->
+                { current with
+                  last_failure_reason = Some (Keeper_registry.Exception reason)
+                })
+           |> Keeper_registry.exact_update_succeeded
+                reg
+                ~site:"keepalive_launch_rejected.failure_reason");
+        ignore
+          (Keeper_registry.update_entry_exact_for_lifecycle
+             launch_token
+             reg
+             (fun current ->
+                Keeper_registry_error_tracking.record_crash_entry
+                  current
+                  (Time_compat.now ())
+                  reason)
+           |> Keeper_registry.exact_update_succeeded
+                reg
+                ~site:"keepalive_launch_rejected.crash_log");
+        Keeper_registry_error_recording.record_exact_for_lifecycle
+          launch_token
+          reg
           reason;
         if resolve_registry_done reg ~source:"keepalive_launch_rejected" (`Crashed reason)
         then

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -959,7 +959,7 @@ let start_keepalive
                  m.name
                  m
                |> Result.map_error (fun error -> `Registration error))
-           ~rollback:Keeper_keepalive_launch_transaction.rollback_remove_registered
+           ~rollback:Keeper_keepalive_launch_transaction.Remove_registered
            launch_registered
        with
        | Error (Keeper_keepalive_launch_transaction.Shutdown_reserved operation_id) ->
@@ -1064,7 +1064,7 @@ let start_keepalive
          Log.Keeper.error ~keeper_name:m.name "%s" detail;
          Keepalive_launch_callback_failed detail
        | Ok outcome -> outcome
-      and launch_registered launch_token reg =
+      and launch_registered _intake_token launch_token reg =
       (* Restore persisted tool usage stats from previous session *)
       Keeper_registry_tool_usage_persistence.restore ~base_path:ctx.config.base_path m.name;
       (* Launch gate FIRST: every launch side effect (gRPC heartbeat fiber,

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -704,6 +704,7 @@ type start_keepalive_outcome =
   | Keepalive_registration_rejected of Keeper_registry.registration_error
   | Keepalive_fiber_start_rejected of Keeper_state_machine.transition_error
   | Keepalive_memory_lane_not_ready of Keeper_memory_lane.lifecycle_open_error
+  | Keepalive_launch_callback_failed of string
   | Keepalive_lane_ownership_lost
   | Keepalive_fork_rejected of Keeper_lane.start_error
 
@@ -743,6 +744,7 @@ let start_keepalive_outcome_to_string = function
       (Keeper_state_machine.transition_error_to_string error)
   | Keepalive_memory_lane_not_ready error ->
     Keeper_memory_lane.lifecycle_open_error_to_string error
+  | Keepalive_launch_callback_failed detail -> detail
   | Keepalive_lane_ownership_lost -> "lane ownership lost before fiber fork"
   | Keepalive_fork_rejected error -> Keeper_lane.start_error_to_string error
 
@@ -905,51 +907,96 @@ let start_keepalive
         (Printf.sprintf "start_keepalive: skipped %s (already registered)" m.name);
       Keepalive_already_registered registered
     | None ->
-      (* Register in Keeper_registry first — single source of truth. *)
-      (match
-         match lifecycle_token with
-         | None ->
-           Keeper_registry.register_offline_if_admitted
-             ?intake_token
-             ~base_path:ctx.config.base_path
-             m.name
-             m
-         | Some token ->
-           Keeper_registry.register_offline_if_admitted_for_lifecycle
-             ?intake_token
-             token
-             ~base_path:ctx.config.base_path
-             m.name
-             m
+      let rec run_transaction () =
+        match
+         Keeper_keepalive_launch_transaction.run
+           ?lifecycle_token
+           ?intake_token
+           ~base_path:ctx.config.base_path
+           ~keeper_name:m.name
+           ~expected_generation:0
+           ~register:(fun token intake_token ->
+             match Keeper_registry.get ~base_path:ctx.config.base_path m.name with
+             | Some current -> Error (`Already_registered current)
+             | None ->
+               Keeper_registry.register_offline_if_admitted_for_lifecycle
+                 ~intake_token
+                 token
+                 ~base_path:ctx.config.base_path
+                 m.name
+                 m
+               |> Result.map_error (fun error -> `Registration error))
+           ~rollback:Keeper_keepalive_launch_transaction.rollback_remove_registered
+           launch_registered
        with
-       | Error (Keeper_registry.Registration_shutdown_reserved operation_id) ->
+       | Error (Keeper_keepalive_launch_transaction.Shutdown_reserved operation_id) ->
          Log.Keeper.warn
            "start_keepalive: skipped %s because shutdown operation %s owns admission"
            m.name
            (Keeper_shutdown_types.Operation_id.to_string operation_id);
          Keepalive_registration_rejected
            (Keeper_registry.Registration_shutdown_reserved operation_id)
-       | Error Keeper_registry.Registration_intake_token_not_live ->
+       | Error Keeper_keepalive_launch_transaction.Intake_token_not_live ->
          Log.Keeper.error
            "start_keepalive: inactive durable-intake token rejected %s"
            m.name;
          Keepalive_registration_rejected
            Keeper_registry.Registration_intake_token_not_live
-       | Error (Keeper_registry.Registration_lifecycle_reserved owner) ->
+       | Error
+           (Keeper_keepalive_launch_transaction.Reservation_unavailable owner) ->
          Log.Keeper.warn
            "start_keepalive: lifecycle reservation rejected %s: %s"
            m.name
            (Keeper_lifecycle_reservation.snapshot_to_string owner);
          Keepalive_registration_rejected
            (Keeper_registry.Registration_lifecycle_reserved owner)
-       | Error (Keeper_registry.Registration_invalid validation_error) ->
+       | Error
+           (Keeper_keepalive_launch_transaction.Registration_failed
+              (`Already_registered current)) ->
+         wake_queued_owner_operations ~base_path:ctx.config.base_path m.name;
+         Keepalive_already_registered current
+       | Error
+           (Keeper_keepalive_launch_transaction.Registration_failed
+              (`Registration
+                 (Keeper_registry.Registration_shutdown_reserved operation_id))) ->
+         Log.Keeper.warn
+           "start_keepalive: skipped %s because shutdown operation %s owns admission"
+           m.name
+           (Keeper_shutdown_types.Operation_id.to_string operation_id);
+         Keepalive_registration_rejected
+           (Keeper_registry.Registration_shutdown_reserved operation_id)
+       | Error
+           (Keeper_keepalive_launch_transaction.Registration_failed
+              (`Registration Keeper_registry.Registration_intake_token_not_live)) ->
+         Log.Keeper.error
+           "start_keepalive: inactive durable-intake token rejected during registration %s"
+           m.name;
+         Keepalive_registration_rejected
+           Keeper_registry.Registration_intake_token_not_live
+       | Error
+           (Keeper_keepalive_launch_transaction.Registration_failed
+              (`Registration
+                 (Keeper_registry.Registration_lifecycle_reserved owner))) ->
+         Log.Keeper.warn
+           "start_keepalive: lifecycle reservation rejected %s: %s"
+           m.name
+           (Keeper_lifecycle_reservation.snapshot_to_string owner);
+         Keepalive_registration_rejected
+           (Keeper_registry.Registration_lifecycle_reserved owner)
+       | Error
+           (Keeper_keepalive_launch_transaction.Registration_failed
+              (`Registration (Keeper_registry.Registration_invalid validation_error))) ->
          Log.Keeper.error
            "start_keepalive: registry validation rejected %s: %s"
            m.name
            (Keeper_registry.registry_entry_validation_error_to_string validation_error);
          Keepalive_registration_rejected
            (Keeper_registry.Registration_invalid validation_error)
-       | Error (Keeper_registry.Registration_event_queue_unavailable { keeper_name; detail }) ->
+       | Error
+           (Keeper_keepalive_launch_transaction.Registration_failed
+              (`Registration
+                 (Keeper_registry.Registration_event_queue_unavailable
+                    { keeper_name; detail }))) ->
          Log.Keeper.error
            "start_keepalive: registry event queue unavailable keeper=%s: %s"
            keeper_name
@@ -957,43 +1004,34 @@ let start_keepalive
          Keepalive_registration_rejected
            (Keeper_registry.Registration_event_queue_unavailable
               { keeper_name; detail })
-       | Ok reg ->
-      (match
-         Keeper_memory_lane.begin_librarian_lifecycle
-           ~base_path:ctx.config.base_path
-           ~keeper_name:m.name
-       with
-       | Error error ->
+       | Error
+           (Keeper_keepalive_launch_transaction.Lifecycle_open_failed
+              { error; rollback_error }) ->
          let detail = Keeper_memory_lane.lifecycle_open_error_to_string error in
          Log.Keeper.error
-           "start_keepalive: Librarian lifecycle not ready keeper=%s error=%s"
+           "start_keepalive: Librarian lifecycle not ready keeper=%s error=%s%s"
            m.name
-           detail;
-         (match Keeper_lane.reject_before_start reg.lane ~reason:(Failure detail) with
-          | Ok () -> ()
-          | Error lane_error ->
-            Log.Keeper.error
-              "start_keepalive: failed to close lane after Librarian lifecycle rejection keeper=%s error=%s"
-              m.name
-              (Keeper_lane.start_error_to_string lane_error));
-         (match
-            match lifecycle_token with
-            | None -> Keeper_registry.unregister_exact reg
-            | Some token -> Keeper_registry.unregister_exact_for_lifecycle token reg
-          with
-          | Keeper_registry.Exact_unregistered
-          | Keeper_registry.Exact_entry_missing -> ()
-          | Keeper_registry.Exact_entry_replaced ->
-            Log.Keeper.warn
-              "start_keepalive: newer registry entry replaced Librarian-rejected lane keeper=%s"
-              m.name
-          | Keeper_registry.Exact_unregister_lifecycle_reserved owner ->
-            Log.Keeper.warn
-              "start_keepalive: lifecycle reservation retained Librarian-rejected lane keeper=%s owner=%s"
-              m.name
-              (Keeper_lifecycle_reservation.snapshot_to_string owner));
+           detail
+           (match rollback_error with
+            | None -> ""
+            | Some rollback -> "; rollback failed: " ^ rollback);
          Keepalive_memory_lane_not_ready error
-       | Ok () ->
+       | Error
+           (Keeper_keepalive_launch_transaction.Launch_failed
+              { exception_detail; librarian_abort_error; rollback_error }) ->
+         let cleanup_detail label = function
+           | None -> ""
+           | Some detail -> "; " ^ label ^ " failed: " ^ detail
+         in
+         let detail =
+           "keepalive launch callback failed: " ^ exception_detail
+           ^ cleanup_detail "Librarian abort" librarian_abort_error
+           ^ cleanup_detail "registry rollback" rollback_error
+         in
+         Log.Keeper.error ~keeper_name:m.name "%s" detail;
+         Keepalive_launch_callback_failed detail
+       | Ok outcome -> outcome
+      and launch_registered launch_token reg =
       (* Restore persisted tool usage stats from previous session *)
       Keeper_registry_tool_usage_persistence.restore ~base_path:ctx.config.base_path m.name;
       (* Launch gate FIRST: every launch side effect (gRPC heartbeat fiber,
@@ -1003,15 +1041,11 @@ let start_keepalive
          rejected launch — the same half-commit class this change removes
          from the fiber-fork path. *)
       match
-        match lifecycle_token with
-        | None ->
-          dispatch_fiber_started ~base_path:ctx.config.base_path m.name
-        | Some token ->
-          dispatch_fiber_started
-            ~lifecycle_token:token
-            ~entry:reg
-            ~base_path:ctx.config.base_path
-            m.name
+        dispatch_fiber_started
+          ~lifecycle_token:launch_token
+          ~entry:reg
+          ~base_path:ctx.config.base_path
+          m.name
       with
       | Error err ->
         (* Fail closed: the registry FSM refused [Fiber_started], so no
@@ -1055,7 +1089,9 @@ let start_keepalive
       | Ok () ->
         let stop = reg.fiber_stop in
         let wakeup = reg.fiber_wakeup in
-        let live_meta = bootstrap_live_keeper_meta ?lifecycle_token ~ctx m in
+        let live_meta =
+          bootstrap_live_keeper_meta ~lifecycle_token:launch_token ~ctx m
+        in
         let live_meta_installed =
           match Keeper_registry.get ~base_path:ctx.config.base_path reg.name with
           | Some current ->
@@ -1179,56 +1215,17 @@ let start_keepalive
             | Keeper_lane.Shutdown_cancel_failed _
             | Keeper_lane.Failed _ -> false
           in
-          let terminalize () =
-            try
-              terminalize_lane outcome;
-              Ok ()
-            with
-            | exn -> Error (Printexc.to_string exn)
-          in
-          let handle_librarian () =
-            if graceful_librarian_boundary
-            then
-              match
-                Keeper_memory_lane.drain_and_join_librarian
-                  ~base_path:ctx.config.Workspace.base_path
-                  ~keeper_name:live_meta.name
-              with
-              | Ok Keeper_memory_lane.No_librarian_work
-              | Ok Keeper_memory_lane.Librarian_drained -> Ok ()
-              | Error error ->
-                Error (Keeper_memory_lane.librarian_drain_error_to_string error)
-            else
-              match
-                Keeper_memory_lane.abort_librarian
-                  ~base_path:ctx.config.Workspace.base_path
-                  ~keeper_name:live_meta.name
-              with
-              | Ok Keeper_memory_lane.Librarian_abort_idle
-              | Ok Keeper_memory_lane.Librarian_abort_requested
-              | Ok Keeper_memory_lane.Librarian_abort_already_in_progress
-              | Ok (Keeper_memory_lane.Librarian_abort_already_exited _) -> Ok ()
-              | Ok (Keeper_memory_lane.Librarian_abort_committed_with_failure exn) ->
-                Error
-                  ("Librarian cancellation committed with callback failure: "
-                   ^ Printexc.to_string exn)
-              | Error error ->
-                Error (Keeper_memory_lane.librarian_abort_error_to_string error)
-          in
-          let terminal_result, librarian_result =
-            if graceful_librarian_boundary
-            then (
-              let librarian_result = handle_librarian () in
-              (* A failed detached drain is still a terminal Keeper boundary.
-                 Resolve [done_p] before returning the cleanup error so stop,
-                 update, and restart waiters cannot hang after lane exit. *)
-              let terminal_result = terminalize () in
-              terminal_result, librarian_result)
-            else (
-              (* Crash publication must not wait behind root-scoped provider
-                 work. Record the lane outcome first, then fence and cancel the
-                 detached owner without joining it. *)
-              terminalize (), handle_librarian ())
+          let lifecycle_result =
+            Keeper_keepalive_launch_transaction.finish_lifecycle
+              ~boundary:
+                (if graceful_librarian_boundary
+                 then Keeper_keepalive_launch_transaction.Graceful
+                 else Keeper_keepalive_launch_transaction.Unexpected)
+              ~base_path:ctx.config.Workspace.base_path
+              ~keeper_name:live_meta.name
+              ~terminalize:(fun () ->
+                terminalize_lane outcome;
+                Ok ())
           in
           let tracking_result =
           try
@@ -1267,8 +1264,7 @@ let start_keepalive
             Error detail
           in
           let errors =
-            [ "terminal cleanup", terminal_result
-            ; "Librarian cleanup", librarian_result
+            [ "lifecycle cleanup", lifecycle_result
             ; "tracking cleanup", tracking_result
             ]
             |> List.filter_map (fun (label, result) ->
@@ -1327,7 +1323,8 @@ let start_keepalive
              ~keeper_name:live_meta.name
              ~failure_reason:(Keeper_registry.Exception detail);
            Keepalive_fork_rejected error))
-        ))
+      in
+      run_transaction ()
 ;;
 
 type joined_stop =

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -703,6 +703,7 @@ type start_keepalive_outcome =
   | Keepalive_identity_unrepairable
   | Keepalive_registration_rejected of Keeper_registry.registration_error
   | Keepalive_fiber_start_rejected of Keeper_state_machine.transition_error
+  | Keepalive_memory_lane_not_ready of Keeper_memory_lane.lifecycle_open_error
   | Keepalive_lane_ownership_lost
   | Keepalive_fork_rejected of Keeper_lane.start_error
 
@@ -740,6 +741,8 @@ let start_keepalive_outcome_to_string = function
     Printf.sprintf
       "Fiber_started rejected: %s"
       (Keeper_state_machine.transition_error_to_string error)
+  | Keepalive_memory_lane_not_ready error ->
+    Keeper_memory_lane.lifecycle_open_error_to_string error
   | Keepalive_lane_ownership_lost -> "lane ownership lost before fiber fork"
   | Keepalive_fork_rejected error -> Keeper_lane.start_error_to_string error
 
@@ -955,6 +958,38 @@ let start_keepalive
            (Keeper_registry.Registration_event_queue_unavailable
               { keeper_name; detail })
        | Ok reg ->
+      (match
+         Keeper_memory_lane.begin_librarian_lifecycle
+           ~base_path:ctx.config.base_path
+           ~keeper_name:m.name
+       with
+       | Error error ->
+         let detail = Keeper_memory_lane.lifecycle_open_error_to_string error in
+         Log.Keeper.error
+           "start_keepalive: Librarian lifecycle not ready keeper=%s error=%s"
+           m.name
+           detail;
+         (match Keeper_lane.reject_before_start reg.lane ~reason:(Failure detail) with
+          | Ok () -> ()
+          | Error lane_error ->
+            Log.Keeper.error
+              "start_keepalive: failed to close lane after Librarian lifecycle rejection keeper=%s error=%s"
+              m.name
+              (Keeper_lane.start_error_to_string lane_error));
+         (match Keeper_registry.unregister_exact reg with
+          | Keeper_registry.Exact_unregistered
+          | Keeper_registry.Exact_entry_missing -> ()
+          | Keeper_registry.Exact_entry_replaced ->
+            Log.Keeper.warn
+              "start_keepalive: newer registry entry replaced Librarian-rejected lane keeper=%s"
+              m.name
+          | Keeper_registry.Exact_unregister_lifecycle_reserved owner ->
+            Log.Keeper.warn
+              "start_keepalive: lifecycle reservation retained Librarian-rejected lane keeper=%s owner=%s"
+              m.name
+              (Keeper_lifecycle_reservation.snapshot_to_string owner));
+         Keepalive_memory_lane_not_ready error
+       | Ok () ->
       (* Restore persisted tool usage stats from previous session *)
       Keeper_registry_tool_usage_persistence.restore ~base_path:ctx.config.base_path m.name;
       (* Launch gate FIRST: every launch side effect (gRPC heartbeat fiber,
@@ -1132,13 +1167,14 @@ let start_keepalive
         let cleanup_tracking outcome =
           let librarian_join_result =
             match
-              Keeper_memory_lane.cancel_and_join_librarian
+              Keeper_memory_lane.drain_and_join_librarian
                 ~base_path:ctx.config.Workspace.base_path
                 ~keeper_name:live_meta.name
             with
-            | Keeper_memory_lane.No_librarian_work
-            | Keeper_memory_lane.Librarian_joined _ -> Ok ()
-            | Keeper_memory_lane.Librarian_join_failed detail -> Error detail
+            | Ok Keeper_memory_lane.No_librarian_work
+            | Ok Keeper_memory_lane.Librarian_drained -> Ok ()
+            | Error error ->
+              Error (Keeper_memory_lane.librarian_drain_error_to_string error)
           in
           let terminal_result =
             match librarian_join_result with
@@ -1243,7 +1279,7 @@ let start_keepalive
              ~keeper_name:live_meta.name
              ~failure_reason:(Keeper_registry.Exception detail);
            Keepalive_fork_rejected error))
-        )
+        ))
 ;;
 
 type joined_stop =

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -976,7 +976,11 @@ let start_keepalive
               "start_keepalive: failed to close lane after Librarian lifecycle rejection keeper=%s error=%s"
               m.name
               (Keeper_lane.start_error_to_string lane_error));
-         (match Keeper_registry.unregister_exact reg with
+         (match
+            match lifecycle_token with
+            | None -> Keeper_registry.unregister_exact reg
+            | Some token -> Keeper_registry.unregister_exact_for_lifecycle token reg
+          with
           | Keeper_registry.Exact_unregistered
           | Keeper_registry.Exact_entry_missing -> ()
           | Keeper_registry.Exact_entry_replaced ->
@@ -1165,26 +1169,67 @@ let start_keepalive
            invokes it only after the child-owning switch and all children
            finish. *)
         let cleanup_tracking outcome =
-          let librarian_join_result =
-            match
-              Keeper_memory_lane.drain_and_join_librarian
-                ~base_path:ctx.config.Workspace.base_path
-                ~keeper_name:live_meta.name
-            with
-            | Ok Keeper_memory_lane.No_librarian_work
-            | Ok Keeper_memory_lane.Librarian_drained -> Ok ()
-            | Error error ->
-              Error (Keeper_memory_lane.librarian_drain_error_to_string error)
+          let graceful_librarian_boundary =
+            match outcome with
+            | Keeper_lane.Completed
+            | Keeper_lane.Shutdown_before_start
+            | Keeper_lane.Shutdown_requested -> true
+            | Keeper_lane.Cancelled_by_parent _ ->
+              Atomic.get stop || Shutdown.is_shutting_down_global ()
+            | Keeper_lane.Shutdown_cancel_failed _
+            | Keeper_lane.Failed _ -> false
           in
-          let terminal_result =
-            match librarian_join_result with
-            | Error _ as error -> error
-            | Ok () ->
-              (try
-                 terminalize_lane outcome;
-                 Ok ()
-               with
-               | exn -> Error (Printexc.to_string exn))
+          let terminalize () =
+            try
+              terminalize_lane outcome;
+              Ok ()
+            with
+            | exn -> Error (Printexc.to_string exn)
+          in
+          let handle_librarian () =
+            if graceful_librarian_boundary
+            then
+              match
+                Keeper_memory_lane.drain_and_join_librarian
+                  ~base_path:ctx.config.Workspace.base_path
+                  ~keeper_name:live_meta.name
+              with
+              | Ok Keeper_memory_lane.No_librarian_work
+              | Ok Keeper_memory_lane.Librarian_drained -> Ok ()
+              | Error error ->
+                Error (Keeper_memory_lane.librarian_drain_error_to_string error)
+            else
+              match
+                Keeper_memory_lane.abort_librarian
+                  ~base_path:ctx.config.Workspace.base_path
+                  ~keeper_name:live_meta.name
+              with
+              | Ok Keeper_memory_lane.Librarian_abort_idle
+              | Ok Keeper_memory_lane.Librarian_abort_requested
+              | Ok Keeper_memory_lane.Librarian_abort_already_in_progress
+              | Ok (Keeper_memory_lane.Librarian_abort_already_exited _) -> Ok ()
+              | Ok (Keeper_memory_lane.Librarian_abort_committed_with_failure exn) ->
+                Error
+                  ("Librarian cancellation committed with callback failure: "
+                   ^ Printexc.to_string exn)
+              | Error error ->
+                Error (Keeper_memory_lane.librarian_abort_error_to_string error)
+          in
+          let terminal_result, librarian_result =
+            if graceful_librarian_boundary
+            then (
+              let librarian_result = handle_librarian () in
+              let terminal_result =
+                match librarian_result with
+                | Ok () -> terminalize ()
+                | Error _ -> Ok ()
+              in
+              terminal_result, librarian_result)
+            else (
+              (* Crash publication must not wait behind root-scoped provider
+                 work. Record the lane outcome first, then fence and cancel the
+                 detached owner without joining it. *)
+              terminalize (), handle_librarian ())
           in
           let tracking_result =
           try
@@ -1222,15 +1267,19 @@ let start_keepalive
                  detail);
             Error detail
           in
-          match terminal_result, tracking_result with
-          | Ok (), Ok () -> Ok ()
-          | Error detail, Ok () | Ok (), Error detail -> Error detail
-          | Error terminal_detail, Error tracking_detail ->
-            Error
-              (Printf.sprintf
-                 "terminal cleanup failed: %s; tracking cleanup failed: %s"
-                 terminal_detail
-                 tracking_detail)
+          let errors =
+            [ "terminal cleanup", terminal_result
+            ; "Librarian cleanup", librarian_result
+            ; "tracking cleanup", tracking_result
+            ]
+            |> List.filter_map (fun (label, result) ->
+              match result with
+              | Ok () -> None
+              | Error detail -> Some (label ^ " failed: " ^ detail))
+          in
+          match errors with
+          | [] -> Ok ()
+          | errors -> Error (String.concat "; " errors)
         in
         publish_keeper_started ~live_meta;
         (match

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -619,10 +619,17 @@ let resolve_registry_done
 ;;
 
 let dispatch_event_exact_unit
+      ?lifecycle_token
       (entry : Keeper_registry.registry_entry)
       event
   =
-  match Keeper_registry.dispatch_event_exact entry event with
+  let result =
+    match lifecycle_token with
+    | None -> Keeper_registry.dispatch_event_exact entry event
+    | Some token ->
+      Keeper_registry.dispatch_event_exact_for_lifecycle token entry event
+  in
+  match result with
   | Ok _ -> true
   | Error error ->
     Otel_metric_store.inc_counter
@@ -638,6 +645,7 @@ let dispatch_event_exact_unit
 ;;
 
 let record_keeper_stopped
+      ?lifecycle_token
       (entry : Keeper_registry.registry_entry)
       ~base_path:_
       ~keeper_name
@@ -646,10 +654,20 @@ let record_keeper_stopped
   =
   if resolve_registry_done entry ~source:"keepalive_record_stopped" `Stopped
   then (
-    (match dispatch_event_exact_unit entry Keeper_state_machine.Stop_requested with
+    (match
+       dispatch_event_exact_unit
+         ?lifecycle_token
+         entry
+         Keeper_state_machine.Stop_requested
+     with
      | false -> ()
      | true ->
-       (match dispatch_event_exact_unit entry Keeper_state_machine.Drain_complete with
+       (match
+          dispatch_event_exact_unit
+            ?lifecycle_token
+            entry
+            Keeper_state_machine.Drain_complete
+        with
         | true | false -> ()));
     publish_keeper_phase_lifecycle
       ~phase:Keeper_state_machine.Stopped
@@ -661,6 +679,7 @@ let record_keeper_stopped
 ;;
 
 let record_keeper_crashed
+      ?lifecycle_token
       (entry : Keeper_registry.registry_entry)
       ~base_path:_
       ~keeper_name
@@ -671,22 +690,36 @@ let record_keeper_crashed
   if resolve_registry_done entry ~source:"keepalive_record_crashed" (`Crashed reason)
   then (
     let outcome = reason in
+    let update_exact f =
+      match lifecycle_token with
+      | None -> Keeper_registry.update_entry_exact entry f
+      | Some token -> Keeper_registry.update_entry_exact_for_lifecycle token entry f
+    in
     ignore
-      (Keeper_registry.set_failure_reason_exact entry (Some failure_reason)
+      (update_exact (fun current ->
+         { current with last_failure_reason = Some failure_reason })
        |> Keeper_registry.exact_update_succeeded
             entry
             ~site:"record_keeper_crashed.failure_reason");
     ignore
       (dispatch_event_exact_unit
+         ?lifecycle_token
          entry
          (Keeper_state_machine.Fiber_terminated
             { outcome; provider_id = None; http_status = None }));
     ignore
-      (Keeper_registry.record_crash_exact entry (Time_compat.now ()) reason
+      (update_exact (fun current ->
+         Keeper_registry_error_tracking.record_crash_entry
+           current
+           (Time_compat.now ())
+           reason)
        |> Keeper_registry.exact_update_succeeded
             entry
             ~site:"record_keeper_crashed.crash_log");
-    Keeper_registry_error_recording.record_exact entry reason;
+    (match lifecycle_token with
+     | None -> Keeper_registry_error_recording.record_exact entry reason
+     | Some token ->
+       Keeper_registry_error_recording.record_exact_for_lifecycle token entry reason);
     publish_keeper_phase_lifecycle
       ~phase:Keeper_state_machine.Crashed
       ~keeper_name
@@ -1104,6 +1137,7 @@ let start_keepalive
         then (
           let failure_reason = Keeper_registry.Exception "lane_ownership_lost_before_fork" in
           record_keeper_crashed
+            ~lifecycle_token:launch_token
             reg
             ~base_path:ctx.config.base_path
             ~keeper_name:live_meta.name
@@ -1137,6 +1171,7 @@ let start_keepalive
         in
         let record_crash failure_reason =
           record_keeper_crashed
+            ~lifecycle_token:launch_token
             reg
             ~base_path:ctx.config.base_path
             ~keeper_name:live_meta.name
@@ -1145,6 +1180,7 @@ let start_keepalive
         let record_stopped detail =
           ignore
             (record_keeper_stopped
+               ~lifecycle_token:launch_token
                reg
                ~base_path:ctx.config.base_path
                ~keeper_name:live_meta.name
@@ -1229,7 +1265,11 @@ let start_keepalive
           in
           let tracking_result =
           try
-            (match Keeper_registry.cleanup_tracking_exact reg with
+            (match
+               Keeper_registry.cleanup_tracking_exact_for_lifecycle
+                 launch_token
+                 reg
+             with
              | Keeper_registry.Exact_updated
              | Keeper_registry.Exact_update_missing -> Ok ()
              | Keeper_registry.Exact_update_replaced ->
@@ -1318,6 +1358,7 @@ let start_keepalive
          | Error error ->
            let detail = Keeper_lane.start_error_to_string error in
            record_keeper_crashed
+             ~lifecycle_token:launch_token
              reg
              ~base_path:ctx.config.base_path
              ~keeper_name:live_meta.name

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -107,6 +107,7 @@ type start_keepalive_outcome =
   | Keepalive_registration_rejected of Keeper_registry.registration_error
   | Keepalive_fiber_start_rejected of Keeper_state_machine.transition_error
   | Keepalive_memory_lane_not_ready of Keeper_memory_lane.lifecycle_open_error
+  | Keepalive_launch_callback_failed of string
   | Keepalive_lane_ownership_lost
   | Keepalive_fork_rejected of Keeper_lane.start_error
 

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -106,6 +106,7 @@ type start_keepalive_outcome =
   | Keepalive_identity_unrepairable
   | Keepalive_registration_rejected of Keeper_registry.registration_error
   | Keepalive_fiber_start_rejected of Keeper_state_machine.transition_error
+  | Keepalive_memory_lane_not_ready of Keeper_memory_lane.lifecycle_open_error
   | Keepalive_lane_ownership_lost
   | Keepalive_fork_rejected of Keeper_lane.start_error
 

--- a/lib/keeper/keeper_keepalive_launch_transaction.ml
+++ b/lib/keeper/keeper_keepalive_launch_transaction.ml
@@ -156,13 +156,22 @@ let combine first_label first second_label second =
 ;;
 
 let finish_lifecycle ~boundary ~base_path ~keeper_name ~terminalize =
-  match boundary with
-  | Graceful ->
-    let librarian = drain_result ~base_path ~keeper_name in
-    let terminal = terminalize_safely terminalize in
-    combine "Librarian cleanup" librarian "terminal cleanup" terminal
-  | Unexpected ->
-    let terminal = terminalize_safely terminalize in
-    let librarian = abort_result ~base_path ~keeper_name in
-    combine "terminal cleanup" terminal "Librarian cleanup" librarian
+  (* Exit settlement commonly runs after the lane has observed cancellation.
+     Keep the ordered Librarian/terminal transaction outside that cancelled
+     context; otherwise the first drain/abort suspension can raise immediately
+     and the lane cleanup may reinterpret a graceful stop as an unexpected
+     abort. *)
+  Eio.Cancel.protect (fun () ->
+    try
+      match boundary with
+      | Graceful ->
+        let librarian = drain_result ~base_path ~keeper_name in
+        let terminal = terminalize_safely terminalize in
+        combine "Librarian cleanup" librarian "terminal cleanup" terminal
+      | Unexpected ->
+        let terminal = terminalize_safely terminalize in
+        let librarian = abort_result ~base_path ~keeper_name in
+        combine "terminal cleanup" terminal "Librarian cleanup" librarian
+    with
+    | exn -> Error (Printexc.to_string exn))
 ;;

--- a/lib/keeper/keeper_keepalive_launch_transaction.ml
+++ b/lib/keeper/keeper_keepalive_launch_transaction.ml
@@ -147,16 +147,26 @@ let run
                    let exception_detail = Printexc.to_string exn in
                    let librarian_abort_error, rollback_error =
                      Eio.Cancel.protect (fun () ->
-                       match reject_for_rollback reg with
-                       | Error detail -> None, Some detail
-                       | Ok () ->
-                         let librarian_abort_error = abort_open_lifecycle () in
-                         let rollback_error =
-                           match rollback_registry rollback token reg with
-                           | Ok () -> None
-                           | Error detail -> Some detail
-                         in
-                         librarian_abort_error, rollback_error)
+                       match rollback with
+                       | Retain_registered ->
+                         (* This is an existing Offline authority intended for
+                            a later retry. Rejecting its not-yet-started lane
+                            made the registry retain an entry that could never
+                            fork. If the callback crossed the start boundary,
+                            the same choice also leaves terminal cleanup with
+                            its exact registry and Librarian ownership. *)
+                         None, None
+                       | Remove_registered | Restore_previous _ ->
+                         (match reject_for_rollback reg with
+                          | Error detail -> None, Some detail
+                          | Ok () ->
+                            let librarian_abort_error = abort_open_lifecycle () in
+                            let rollback_error =
+                              match rollback_registry rollback token reg with
+                              | Ok () -> None
+                              | Error detail -> Some detail
+                            in
+                            librarian_abort_error, rollback_error))
                    in
                    (match exn with
                     | Eio.Cancel.Cancelled _ -> raise exn

--- a/lib/keeper/keeper_keepalive_launch_transaction.ml
+++ b/lib/keeper/keeper_keepalive_launch_transaction.ml
@@ -118,7 +118,11 @@ let run
         ~finally:(fun () ->
           if owns_token then Eio.Cancel.protect (fun () -> release_owned token))
         (fun () ->
-           match register token intake_token with
+           (* Registration may load durable state before committing its final
+              registry CAS. Keep the callback cancellation-protected so the
+              transaction always obtains the exact entry needed for rollback
+              after that commit. *)
+           match Eio.Cancel.protect (fun () -> register token intake_token) with
            | Error error -> Error (Registration_failed error)
            | Ok reg ->
              (match
@@ -149,13 +153,14 @@ let run
                      Eio.Cancel.protect (fun () ->
                        match rollback with
                        | Retain_registered ->
-                         (* This is an existing Offline authority intended for
-                            a later retry. Rejecting its not-yet-started lane
-                            made the registry retain an entry that could never
-                            fork. If the callback crossed the start boundary,
-                            the same choice also leaves terminal cleanup with
-                            its exact registry and Librarian ownership. *)
-                         None, None
+                         (* Retain the registry authority in both cases, but a
+                            pre-start callback failure owns no live fiber that
+                            can settle the Librarian lifecycle. Close that
+                            lifecycle so the exact Offline lane is retryable.
+                            A started lane keeps terminal cleanup ownership. *)
+                         if Keeper_lane.crossed_start_boundary reg.lane
+                         then None, None
+                         else abort_open_lifecycle (), None
                        | Remove_registered | Restore_previous _ ->
                          (match reject_for_rollback reg with
                           | Error detail -> None, Some detail

--- a/lib/keeper/keeper_keepalive_launch_transaction.ml
+++ b/lib/keeper/keeper_keepalive_launch_transaction.ml
@@ -1,10 +1,22 @@
 type 'registration_error error =
+  | Shutdown_reserved of Keeper_shutdown_types.Operation_id.t
+  | Intake_token_not_live
   | Reservation_unavailable of Keeper_lifecycle_reservation.snapshot
   | Registration_failed of 'registration_error
   | Lifecycle_open_failed of
       { error : Keeper_memory_lane.lifecycle_open_error
       ; rollback_error : string option
       }
+  | Launch_failed of
+      { exception_detail : string
+      ; librarian_abort_error : string option
+      ; rollback_error : string option
+      }
+
+type rollback =
+  | Remove_registered
+  | Restore_previous of Keeper_registry.registry_entry
+  | Retain_registered
 
 let release_owned token =
   match Keeper_lifecycle_reservation.release token with
@@ -15,62 +27,17 @@ let release_owned token =
       (Keeper_lifecycle_reservation.release_outcome_to_string outcome)
 ;;
 
-let run
-      ?lifecycle_token
-      ~base_path
-      ~keeper_name
-      ~expected_generation
-      ~register
-      ~rollback
-      launch
-  =
-  let ownership =
-    match lifecycle_token with
-    | Some token -> Ok (token, false)
-    | None ->
-      (match
-         Keeper_lifecycle_reservation.acquire
-           ~base_path
-           ~keeper_name
-           ~expected_generation
-           ~purpose:Keeper_lifecycle_reservation.Keepalive_launch
-       with
-       | Ok token -> Ok (token, true)
-       | Error (Keeper_lifecycle_reservation.Already_reserved owner) ->
-         Error (Reservation_unavailable owner))
-  in
-  match ownership with
-  | Error _ as error -> error
-  | Ok (token, owns_token) ->
-    Fun.protect
-      ~finally:(fun () -> if owns_token then release_owned token)
-      (fun () ->
-         match register token with
-         | Error error -> Error (Registration_failed error)
-         | Ok reg ->
-           (match
-              Keeper_memory_lane.begin_librarian_lifecycle
-                ~base_path
-                ~keeper_name
-            with
-            | Ok () -> Ok (launch token reg)
-            | Error error ->
-              let rollback_error =
-                match rollback token reg with
-                | Ok () -> None
-                | Error detail -> Some detail
-              in
-              Error (Lifecycle_open_failed { error; rollback_error })))
-;;
-
-let reject_before_start reg =
+let reject_for_rollback reg =
   match
     Keeper_lane.reject_before_start
       reg.Keeper_registry.lane
       ~reason:(Failure "keepalive launch transaction rolled back")
   with
   | Ok () -> Ok ()
-  | Error error -> Error (Keeper_lane.start_error_to_string error)
+  | Error error ->
+    Error
+      ("launch rollback retained a lane that crossed the start boundary: "
+       ^ Keeper_lane.start_error_to_string error)
 ;;
 
 let unregister token reg =
@@ -85,33 +52,142 @@ let unregister token reg =
        ^ Keeper_lifecycle_reservation.snapshot_to_string owner)
 ;;
 
-let rollback_remove_registered token reg =
-  let lane_result = reject_before_start reg in
-  let registry_result = unregister token reg in
-  match lane_result, registry_result with
-  | Ok (), Ok () -> Ok ()
-  | Error detail, Ok () | Ok (), Error detail -> Error detail
-  | Error lane_detail, Error registry_detail ->
-    Error (lane_detail ^ "; " ^ registry_detail)
+let rollback_registry rollback token reg =
+  match rollback with
+  | Retain_registered -> Ok ()
+  | Remove_registered -> unregister token reg
+  | Restore_previous previous ->
+    (match unregister token reg with
+     | Error _ as error -> error
+     | Ok () ->
+       (match Keeper_registry.restore_entry_if_absent_for_lifecycle token previous with
+        | Keeper_registry.Entry_restored -> Ok ()
+        | Keeper_registry.Entry_restore_occupied _ ->
+          Error "restart rollback found an occupied registry key"
+        | Keeper_registry.Entry_restore_invalid error ->
+          Error (Keeper_registry.registry_entry_validation_error_to_string error)
+        | Keeper_registry.Entry_restore_lifecycle_reserved owner ->
+          Error
+            ("restart rollback lost lifecycle ownership: "
+             ^ Keeper_lifecycle_reservation.snapshot_to_string owner)))
 ;;
 
-let rollback_restore_previous ~previous token reg =
-  match rollback_remove_registered token reg with
-  | Error _ as error -> error
-  | Ok () ->
-    (match Keeper_registry.restore_entry_if_absent_for_lifecycle token previous with
-     | Keeper_registry.Entry_restored -> Ok ()
-     | Keeper_registry.Entry_restore_occupied _ ->
-       Error "restart rollback found an occupied registry key"
-     | Keeper_registry.Entry_restore_invalid error ->
-       Error (Keeper_registry.registry_entry_validation_error_to_string error)
-     | Keeper_registry.Entry_restore_lifecycle_reserved owner ->
-       Error
-         ("restart rollback lost lifecycle ownership: "
-          ^ Keeper_lifecycle_reservation.snapshot_to_string owner))
+let run
+      ?lifecycle_token
+      ?intake_token
+      ~base_path
+      ~keeper_name
+      ~expected_generation
+      ~register
+      ~rollback
+      launch
+  =
+  let abort_open_lifecycle () =
+    match Keeper_memory_lane.abort_librarian ~base_path ~keeper_name with
+    | Ok Keeper_memory_lane.Librarian_abort_idle
+    | Ok Keeper_memory_lane.Librarian_abort_requested
+    | Ok Keeper_memory_lane.Librarian_abort_already_in_progress
+    | Ok (Keeper_memory_lane.Librarian_abort_already_exited _) -> None
+    | Ok (Keeper_memory_lane.Librarian_abort_committed_with_failure exn) ->
+      Some
+        ("Librarian cancellation committed with callback failure: "
+         ^ Printexc.to_string exn)
+    | Error error ->
+      Some (Keeper_memory_lane.librarian_abort_error_to_string error)
+  in
+  let run_admitted intake_token =
+    let ownership =
+      match lifecycle_token with
+      | Some token -> Ok (token, false)
+      | None ->
+        (match
+           Keeper_lifecycle_reservation.acquire
+             ~base_path
+             ~keeper_name
+             ~expected_generation
+             ~purpose:Keeper_lifecycle_reservation.Keepalive_launch
+         with
+         | Ok token -> Ok (token, true)
+         | Error (Keeper_lifecycle_reservation.Already_reserved owner) ->
+           Error (Reservation_unavailable owner))
+    in
+    match ownership with
+    | Error _ as error -> error
+    | Ok (token, owns_token) ->
+      Fun.protect
+        ~finally:(fun () ->
+          if owns_token then Eio.Cancel.protect (fun () -> release_owned token))
+        (fun () ->
+           match register token intake_token with
+           | Error error -> Error (Registration_failed error)
+           | Ok reg ->
+             (match
+                Keeper_memory_lane.begin_librarian_lifecycle
+                  ~base_path
+                  ~keeper_name
+              with
+              | Error error ->
+                let rollback_error =
+                  match rollback with
+                  | Retain_registered -> None
+                  | Remove_registered | Restore_previous _ ->
+                    (match reject_for_rollback reg with
+                     | Error detail -> Some detail
+                     | Ok () ->
+                       (match rollback_registry rollback token reg with
+                        | Ok () -> None
+                        | Error detail -> Some detail))
+                in
+                Error (Lifecycle_open_failed { error; rollback_error })
+              | Ok () ->
+                (try
+                   Ok (launch intake_token token reg)
+                 with
+                 | exn ->
+                   let exception_detail = Printexc.to_string exn in
+                   let librarian_abort_error, rollback_error =
+                     Eio.Cancel.protect (fun () ->
+                       match reject_for_rollback reg with
+                       | Error detail -> None, Some detail
+                       | Ok () ->
+                         let librarian_abort_error = abort_open_lifecycle () in
+                         let rollback_error =
+                           match rollback_registry rollback token reg with
+                           | Ok () -> None
+                           | Error detail -> Some detail
+                         in
+                         librarian_abort_error, rollback_error)
+                   in
+                   (match exn with
+                    | Eio.Cancel.Cancelled _ -> raise exn
+                    | _ ->
+                      Error
+                        (Launch_failed
+                           { exception_detail
+                           ; librarian_abort_error
+                           ; rollback_error
+                           })))))
+  in
+  match intake_token with
+  | Some token ->
+    if
+      Keeper_shutdown_intake_fence.intake_token_matches
+        token
+        ~base_path
+        ~keeper_name
+    then run_admitted token
+    else Error Intake_token_not_live
+  | None ->
+    (match
+       Keeper_shutdown_intake_fence.run_durable_intake_if_open
+         ~base_path
+         ~keeper_name
+         run_admitted
+     with
+     | Keeper_shutdown_intake_fence.Intake_committed result -> result
+     | Keeper_shutdown_intake_fence.Intake_shutdown_reserved operation_id ->
+       Error (Shutdown_reserved operation_id))
 ;;
-
-let rollback_retain_registered _token _reg = Ok ()
 
 type exit_boundary =
   | Graceful

--- a/lib/keeper/keeper_keepalive_launch_transaction.ml
+++ b/lib/keeper/keeper_keepalive_launch_transaction.ml
@@ -1,0 +1,168 @@
+type 'registration_error error =
+  | Reservation_unavailable of Keeper_lifecycle_reservation.snapshot
+  | Registration_failed of 'registration_error
+  | Lifecycle_open_failed of
+      { error : Keeper_memory_lane.lifecycle_open_error
+      ; rollback_error : string option
+      }
+
+let release_owned token =
+  match Keeper_lifecycle_reservation.release token with
+  | Keeper_lifecycle_reservation.Released -> ()
+  | outcome ->
+    Log.Keeper.warn
+      "keepalive launch lifecycle reservation release was not clean: %s"
+      (Keeper_lifecycle_reservation.release_outcome_to_string outcome)
+;;
+
+let run
+      ?lifecycle_token
+      ~base_path
+      ~keeper_name
+      ~expected_generation
+      ~register
+      ~rollback
+      launch
+  =
+  let ownership =
+    match lifecycle_token with
+    | Some token -> Ok (token, false)
+    | None ->
+      (match
+         Keeper_lifecycle_reservation.acquire
+           ~base_path
+           ~keeper_name
+           ~expected_generation
+           ~purpose:Keeper_lifecycle_reservation.Keepalive_launch
+       with
+       | Ok token -> Ok (token, true)
+       | Error (Keeper_lifecycle_reservation.Already_reserved owner) ->
+         Error (Reservation_unavailable owner))
+  in
+  match ownership with
+  | Error _ as error -> error
+  | Ok (token, owns_token) ->
+    Fun.protect
+      ~finally:(fun () -> if owns_token then release_owned token)
+      (fun () ->
+         match register token with
+         | Error error -> Error (Registration_failed error)
+         | Ok reg ->
+           (match
+              Keeper_memory_lane.begin_librarian_lifecycle
+                ~base_path
+                ~keeper_name
+            with
+            | Ok () -> Ok (launch token reg)
+            | Error error ->
+              let rollback_error =
+                match rollback token reg with
+                | Ok () -> None
+                | Error detail -> Some detail
+              in
+              Error (Lifecycle_open_failed { error; rollback_error })))
+;;
+
+let reject_before_start reg =
+  match
+    Keeper_lane.reject_before_start
+      reg.Keeper_registry.lane
+      ~reason:(Failure "keepalive launch transaction rolled back")
+  with
+  | Ok () -> Ok ()
+  | Error error -> Error (Keeper_lane.start_error_to_string error)
+;;
+
+let unregister token reg =
+  match Keeper_registry.unregister_exact_for_lifecycle token reg with
+  | Keeper_registry.Exact_unregistered
+  | Keeper_registry.Exact_entry_missing -> Ok ()
+  | Keeper_registry.Exact_entry_replaced ->
+    Error "launch rollback found a newer registry lane"
+  | Keeper_registry.Exact_unregister_lifecycle_reserved owner ->
+    Error
+      ("launch rollback lost lifecycle ownership: "
+       ^ Keeper_lifecycle_reservation.snapshot_to_string owner)
+;;
+
+let rollback_remove_registered token reg =
+  let lane_result = reject_before_start reg in
+  let registry_result = unregister token reg in
+  match lane_result, registry_result with
+  | Ok (), Ok () -> Ok ()
+  | Error detail, Ok () | Ok (), Error detail -> Error detail
+  | Error lane_detail, Error registry_detail ->
+    Error (lane_detail ^ "; " ^ registry_detail)
+;;
+
+let rollback_restore_previous ~previous token reg =
+  match rollback_remove_registered token reg with
+  | Error _ as error -> error
+  | Ok () ->
+    (match Keeper_registry.restore_entry_if_absent_for_lifecycle token previous with
+     | Keeper_registry.Entry_restored -> Ok ()
+     | Keeper_registry.Entry_restore_occupied _ ->
+       Error "restart rollback found an occupied registry key"
+     | Keeper_registry.Entry_restore_invalid error ->
+       Error (Keeper_registry.registry_entry_validation_error_to_string error)
+     | Keeper_registry.Entry_restore_lifecycle_reserved owner ->
+       Error
+         ("restart rollback lost lifecycle ownership: "
+          ^ Keeper_lifecycle_reservation.snapshot_to_string owner))
+;;
+
+let rollback_retain_registered _token _reg = Ok ()
+
+type exit_boundary =
+  | Graceful
+  | Unexpected
+
+let terminalize_safely terminalize =
+  try terminalize () with
+  | exn -> Error (Printexc.to_string exn)
+;;
+
+let abort_result ~base_path ~keeper_name =
+  match Keeper_memory_lane.abort_librarian ~base_path ~keeper_name with
+  | Ok Keeper_memory_lane.Librarian_abort_idle
+  | Ok Keeper_memory_lane.Librarian_abort_requested
+  | Ok Keeper_memory_lane.Librarian_abort_already_in_progress
+  | Ok (Keeper_memory_lane.Librarian_abort_already_exited _) -> Ok ()
+  | Ok (Keeper_memory_lane.Librarian_abort_committed_with_failure exn) ->
+    Error
+      ("Librarian cancellation committed with callback failure: "
+       ^ Printexc.to_string exn)
+  | Error error ->
+    Error (Keeper_memory_lane.librarian_abort_error_to_string error)
+;;
+
+let drain_result ~base_path ~keeper_name =
+  match Keeper_memory_lane.drain_and_join_librarian ~base_path ~keeper_name with
+  | Ok Keeper_memory_lane.No_librarian_work
+  | Ok Keeper_memory_lane.Librarian_drained -> Ok ()
+  | Error error ->
+    Error (Keeper_memory_lane.librarian_drain_error_to_string error)
+;;
+
+let combine first_label first second_label second =
+  match first, second with
+  | Ok (), Ok () -> Ok ()
+  | Error detail, Ok () -> Error (first_label ^ " failed: " ^ detail)
+  | Ok (), Error detail -> Error (second_label ^ " failed: " ^ detail)
+  | Error first_detail, Error second_detail ->
+    Error
+      (first_label ^ " failed: " ^ first_detail ^ "; " ^ second_label
+       ^ " failed: " ^ second_detail)
+;;
+
+let finish_lifecycle ~boundary ~base_path ~keeper_name ~terminalize =
+  match boundary with
+  | Graceful ->
+    let librarian = drain_result ~base_path ~keeper_name in
+    let terminal = terminalize_safely terminalize in
+    combine "Librarian cleanup" librarian "terminal cleanup" terminal
+  | Unexpected ->
+    let terminal = terminalize_safely terminalize in
+    let librarian = abort_result ~base_path ~keeper_name in
+    combine "terminal cleanup" terminal "Librarian cleanup" librarian
+;;

--- a/lib/keeper/keeper_keepalive_launch_transaction.ml
+++ b/lib/keeper/keeper_keepalive_launch_transaction.ml
@@ -132,15 +132,16 @@ let run
               with
               | Error error ->
                 let rollback_error =
-                  match rollback with
-                  | Retain_registered -> None
-                  | Remove_registered | Restore_previous _ ->
-                    (match reject_for_rollback reg with
-                     | Error detail -> Some detail
-                     | Ok () ->
-                       (match rollback_registry rollback token reg with
-                        | Ok () -> None
-                        | Error detail -> Some detail))
+                  Eio.Cancel.protect (fun () ->
+                    match rollback with
+                    | Retain_registered -> None
+                    | Remove_registered | Restore_previous _ ->
+                      (match reject_for_rollback reg with
+                       | Error detail -> Some detail
+                       | Ok () ->
+                         (match rollback_registry rollback token reg with
+                          | Ok () -> None
+                          | Error detail -> Some detail)))
                 in
                 Error (Lifecycle_open_failed { error; rollback_error })
               | Ok () ->
@@ -260,9 +261,12 @@ let finish_lifecycle ~boundary ~base_path ~keeper_name ~terminalize =
         let terminal = terminalize_safely terminalize in
         combine "Librarian cleanup" librarian "terminal cleanup" terminal
       | Unexpected ->
-        let terminal = terminalize_safely terminalize in
         let librarian = abort_result ~base_path ~keeper_name in
-        combine "terminal cleanup" terminal "Librarian cleanup" librarian
+        (* Fence this lifecycle's Librarian intake before publishing a terminal
+           state that may admit its replacement. A name-only abort after
+           publication could otherwise close the newly reopened lifecycle. *)
+        let terminal = terminalize_safely terminalize in
+        combine "Librarian cleanup" librarian "terminal cleanup" terminal
     with
     | exn -> Error (Printexc.to_string exn))
 ;;

--- a/lib/keeper/keeper_keepalive_launch_transaction.mli
+++ b/lib/keeper/keeper_keepalive_launch_transaction.mli
@@ -4,20 +4,29 @@
     memory-lifecycle ownership. *)
 
 type 'registration_error error =
+  | Shutdown_reserved of Keeper_shutdown_types.Operation_id.t
+  | Intake_token_not_live
   | Reservation_unavailable of Keeper_lifecycle_reservation.snapshot
   | Registration_failed of 'registration_error
   | Lifecycle_open_failed of
       { error : Keeper_memory_lane.lifecycle_open_error
       ; rollback_error : string option
       }
+  | Launch_failed of
+      { exception_detail : string
+      ; librarian_abort_error : string option
+      ; rollback_error : string option
+      }
 
 val run
   :  ?lifecycle_token:Keeper_lifecycle_reservation.token
+  -> ?intake_token:Keeper_shutdown_intake_fence.intake_token
   -> base_path:string
   -> keeper_name:string
   -> expected_generation:int
   -> register:
        (Keeper_lifecycle_reservation.token ->
+        Keeper_shutdown_intake_fence.intake_token ->
         (Keeper_registry.registry_entry, 'registration_error) result)
   -> rollback:
        (Keeper_lifecycle_reservation.token ->
@@ -27,11 +36,19 @@ val run
       Keeper_registry.registry_entry ->
       'a)
   -> ('a, 'registration_error error) result
-(** Acquire launch ownership unless the caller already owns a lifecycle token,
-    commit the supplied registry admission, open the Librarian lifecycle, and
-    invoke the launch callback. A failed open runs the exact supplied rollback
-    while the same token still owns the key. Borrowed tokens are never released
-    here; tokens acquired by this function are always released. *)
+(** Own durable intake across registry admission, Librarian lifecycle open, and
+    the launch callback. A caller that already owns intake may lend its exact
+    token; otherwise this transaction acquires one and fails closed when
+    shutdown owns admission.
+
+    Acquire launch ownership unless the caller already owns a lifecycle token,
+    then commit the supplied registry admission. A failed lifecycle open runs
+    the exact supplied rollback while the same tokens still own the key. A
+    non-cancellation launch exception aborts the opened Librarian lifecycle,
+    rolls the registry back, and returns [Launch_failed]; cancellation performs
+    the same protected cleanup and is re-raised. Borrowed lifecycle tokens are
+    never released here; lifecycle tokens acquired by this function are always
+    released. *)
 
 val rollback_remove_registered
   :  Keeper_lifecycle_reservation.token

--- a/lib/keeper/keeper_keepalive_launch_transaction.mli
+++ b/lib/keeper/keeper_keepalive_launch_transaction.mli
@@ -1,0 +1,65 @@
+(** One authority boundary for Keeper registry admission and its detached
+    Librarian lifecycle. Both direct and supervisor launch paths use this
+    transaction so neither can publish a lane between registry admission and
+    memory-lifecycle ownership. *)
+
+type 'registration_error error =
+  | Reservation_unavailable of Keeper_lifecycle_reservation.snapshot
+  | Registration_failed of 'registration_error
+  | Lifecycle_open_failed of
+      { error : Keeper_memory_lane.lifecycle_open_error
+      ; rollback_error : string option
+      }
+
+val run
+  :  ?lifecycle_token:Keeper_lifecycle_reservation.token
+  -> base_path:string
+  -> keeper_name:string
+  -> expected_generation:int
+  -> register:
+       (Keeper_lifecycle_reservation.token ->
+        (Keeper_registry.registry_entry, 'registration_error) result)
+  -> rollback:
+       (Keeper_lifecycle_reservation.token ->
+        Keeper_registry.registry_entry ->
+        (unit, string) result)
+  -> (Keeper_lifecycle_reservation.token ->
+      Keeper_registry.registry_entry ->
+      'a)
+  -> ('a, 'registration_error error) result
+(** Acquire launch ownership unless the caller already owns a lifecycle token,
+    commit the supplied registry admission, open the Librarian lifecycle, and
+    invoke the launch callback. A failed open runs the exact supplied rollback
+    while the same token still owns the key. Borrowed tokens are never released
+    here; tokens acquired by this function are always released. *)
+
+val rollback_remove_registered
+  :  Keeper_lifecycle_reservation.token
+  -> Keeper_registry.registry_entry
+  -> (unit, string) result
+
+val rollback_restore_previous
+  :  previous:Keeper_registry.registry_entry
+  -> Keeper_lifecycle_reservation.token
+  -> Keeper_registry.registry_entry
+  -> (unit, string) result
+
+val rollback_retain_registered
+  :  Keeper_lifecycle_reservation.token
+  -> Keeper_registry.registry_entry
+  -> (unit, string) result
+
+type exit_boundary =
+  | Graceful
+  | Unexpected
+
+val finish_lifecycle
+  :  boundary:exit_boundary
+  -> base_path:string
+  -> keeper_name:string
+  -> terminalize:(unit -> (unit, string) result)
+  -> (unit, string) result
+(** Apply the shared terminal ordering. Graceful exits drain accepted
+    Librarian work before terminal publication. Unexpected exits publish their
+    terminal state first, then fence and request cancellation without joining
+    root-scoped provider work. *)

--- a/lib/keeper/keeper_keepalive_launch_transaction.mli
+++ b/lib/keeper/keeper_keepalive_launch_transaction.mli
@@ -18,6 +18,11 @@ type 'registration_error error =
       ; rollback_error : string option
       }
 
+type rollback =
+  | Remove_registered
+  | Restore_previous of Keeper_registry.registry_entry
+  | Retain_registered
+
 val run
   :  ?lifecycle_token:Keeper_lifecycle_reservation.token
   -> ?intake_token:Keeper_shutdown_intake_fence.intake_token
@@ -28,11 +33,9 @@ val run
        (Keeper_lifecycle_reservation.token ->
         Keeper_shutdown_intake_fence.intake_token ->
         (Keeper_registry.registry_entry, 'registration_error) result)
-  -> rollback:
-       (Keeper_lifecycle_reservation.token ->
-        Keeper_registry.registry_entry ->
-        (unit, string) result)
-  -> (Keeper_lifecycle_reservation.token ->
+  -> rollback:rollback
+  -> (Keeper_shutdown_intake_fence.intake_token ->
+      Keeper_lifecycle_reservation.token ->
       Keeper_registry.registry_entry ->
       'a)
   -> ('a, 'registration_error error) result
@@ -43,28 +46,18 @@ val run
 
     Acquire launch ownership unless the caller already owns a lifecycle token,
     then commit the supplied registry admission. A failed lifecycle open runs
-    the exact supplied rollback while the same tokens still own the key. A
-    non-cancellation launch exception aborts the opened Librarian lifecycle,
-    rolls the registry back, and returns [Launch_failed]; cancellation performs
-    the same protected cleanup and is re-raised. Borrowed lifecycle tokens are
-    never released here; lifecycle tokens acquired by this function are always
-    released. *)
+    the exact supplied rollback while the same tokens still own the key.
+    The launch callback receives the active intake token so nested durable
+    mutations remain inside the same intake epoch instead of reacquiring its
+    non-reentrant lock.
 
-val rollback_remove_registered
-  :  Keeper_lifecycle_reservation.token
-  -> Keeper_registry.registry_entry
-  -> (unit, string) result
-
-val rollback_restore_previous
-  :  previous:Keeper_registry.registry_entry
-  -> Keeper_lifecycle_reservation.token
-  -> Keeper_registry.registry_entry
-  -> (unit, string) result
-
-val rollback_retain_registered
-  :  Keeper_lifecycle_reservation.token
-  -> Keeper_registry.registry_entry
-  -> (unit, string) result
+    A launch exception rolls back only while the lane can still be atomically
+    rejected before start. Once the lane has started, its registry and
+    Librarian ownership are retained for the lane's terminal cleanup rather
+    than detached by rollback. Cancellation follows the same protected
+    cleanup decision and is re-raised. Borrowed lifecycle tokens are never
+    released here; lifecycle tokens acquired by this function are always
+    released outside cancellation. *)
 
 type exit_boundary =
   | Graceful

--- a/lib/keeper/keeper_lane.ml
+++ b/lib/keeper/keeper_lane.ml
@@ -113,6 +113,17 @@ let exited t = t.exited_p
 let peek_exit t = Eio.Promise.peek t.exited_p
 let await_exit t = Eio.Promise.await t.exited_p
 
+let crossed_start_boundary t =
+  match Atomic.get t.state with
+  | Not_started -> false
+  | Starting | Running _ | Cancellation_requested | Finalizing -> true
+  | Exited ->
+    (match Eio.Promise.peek t.exited_p with
+     | Some { outcome = Shutdown_before_start; _ } -> false
+     | Some _ -> true
+     | None -> true)
+;;
+
 let rec claim_start t =
   if Atomic.compare_and_set t.state Not_started Starting
   then Ok ()

--- a/lib/keeper/keeper_lane.mli
+++ b/lib/keeper/keeper_lane.mli
@@ -90,3 +90,8 @@ val classify_cancellation_cause : exn -> cancellation_origin
 val exited : t -> exit Eio.Promise.t
 val peek_exit : t -> exit option
 val await_exit : t -> exit
+
+(** Whether this lane crossed the exact-once start boundary. A lane rejected
+    while still [Not_started] reports [false], including after its
+    [Shutdown_before_start] receipt is settled. *)
+val crossed_start_boundary : t -> bool

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -619,8 +619,10 @@ let run_best_effort
                     "memory os librarian cancelled lane=%s before commit"
                     exact_lane_id)
                  (* Cancellation is not the pass declining its own turn, so the
-                    cadence counter is left alone and the next due turn retries
-                    as it would after any other incomplete pass. *)
+                    cadence counter remains due. A later turn can schedule a
+                    new pass, but it does not replay this immutable input;
+                    graceful lifecycle boundaries therefore drain accepted
+                    work instead of cancelling it. *)
                ~cadence_deferred:false);
            raise exn
          | exn ->

--- a/lib/keeper/keeper_lifecycle_reservation.ml
+++ b/lib/keeper/keeper_lifecycle_reservation.ml
@@ -2,6 +2,7 @@ module StringMap = Set_util.StringMap
 
 type purpose = Keeper_registry_types.lifecycle_transaction_purpose =
   | Paused_work_disposition
+  | Keepalive_launch
 
 type snapshot = Keeper_registry_types.lifecycle_reservation_snapshot =
   { owner_id : string
@@ -47,6 +48,7 @@ let key_locks_mutex = Mutex.create ()
 
 let purpose_to_string = function
   | Paused_work_disposition -> "paused_work_disposition"
+  | Keepalive_launch -> "keepalive_launch"
 ;;
 
 let snapshot_to_string snapshot =

--- a/lib/keeper/keeper_lifecycle_reservation.mli
+++ b/lib/keeper/keeper_lifecycle_reservation.mli
@@ -7,6 +7,7 @@
 
 type purpose = Keeper_registry_types.lifecycle_transaction_purpose =
   | Paused_work_disposition
+  | Keepalive_launch
 
 type token
 

--- a/lib/keeper/keeper_memory_lane.ml
+++ b/lib/keeper/keeper_memory_lane.ml
@@ -185,13 +185,12 @@ let begin_librarian_lifecycle ~base_path ~keeper_name =
     | None, Some owner_lane when Option.is_none (Keeper_lane.peek_exit owner_lane) ->
       Error Librarian_drain_still_active
     | None, (None | Some _) ->
-      (* A closed prior lifecycle has no active work, so its terminal receipt
-         is no longer relevant. Reopening an already accepting lifecycle is a
-         no-op. Do not clear the receipt during lane cleanup: shutdown may begin
-         only after a failed/cancelled owner has already exited. *)
-      (match entry.lifecycle with
-       | Draining -> entry.last_owner_lane <- None
-       | Accepting -> ());
+      (* A new admitted Keeper lifecycle owns no work from the prior one. Keep
+         terminal receipts until this boundary so shutdown can still observe a
+         failed/cancelled owner, then clear them even if that owner exited while
+         the entry was still [Accepting] (for example, a pre-fork executor
+         drop). *)
+      entry.last_owner_lane <- None;
       entry.lifecycle <- Accepting;
       Ok ())
 ;;
@@ -430,6 +429,17 @@ type librarian_drain_error =
   | Librarian_interrupted of Keeper_lane.outcome
   | Librarian_cleanup_failed of string
 
+type librarian_abort_outcome =
+  | Librarian_abort_idle
+  | Librarian_abort_requested
+  | Librarian_abort_already_in_progress
+  | Librarian_abort_already_exited of Keeper_lane.exit
+  | Librarian_abort_committed_with_failure of exn
+
+type librarian_abort_error =
+  | Librarian_abort_wrong_domain
+  | Librarian_abort_not_committed of exn
+
 let librarian_lane_outcome_to_string = function
   | Keeper_lane.Completed -> "completed"
   | Keeper_lane.Shutdown_before_start -> "shutdown_before_start"
@@ -446,6 +456,40 @@ let librarian_drain_error_to_string = function
     "Librarian drain ended without completion: "
     ^ librarian_lane_outcome_to_string outcome
   | Librarian_cleanup_failed detail -> "Librarian cleanup failed: " ^ detail
+;;
+
+let librarian_abort_error_to_string = function
+  | Librarian_abort_wrong_domain ->
+    "Librarian cancellation was requested from a non-owner domain"
+  | Librarian_abort_not_committed exn ->
+    "Librarian cancellation was not committed: " ^ Printexc.to_string exn
+;;
+
+let abort_librarian ~base_path ~keeper_name =
+  let entry = entry_for ~base_path ~keeper_name in
+  let owner_lane =
+    Stdlib.Mutex.protect entry.state_mu (fun () ->
+      entry.lifecycle <- Draining;
+      match entry.librarian_drain with
+      | Some drain -> Some drain.owner_lane
+      | None -> entry.last_owner_lane)
+  in
+  match owner_lane with
+  | None -> Ok Librarian_abort_idle
+  | Some owner_lane ->
+    (match Keeper_lane.peek_exit owner_lane with
+     | Some exit -> Ok (Librarian_abort_already_exited exit)
+     | None ->
+       (match Keeper_lane.request_cancel owner_lane with
+        | Keeper_lane.Cancel_requested -> Ok Librarian_abort_requested
+        | Keeper_lane.Cancel_already_requested
+        | Keeper_lane.Cancel_already_exiting ->
+          Ok Librarian_abort_already_in_progress
+        | Keeper_lane.Cancel_committed_with_failure exn ->
+          Ok (Librarian_abort_committed_with_failure exn)
+        | Keeper_lane.Cancel_wrong_domain -> Error Librarian_abort_wrong_domain
+        | Keeper_lane.Cancel_not_committed exn ->
+          Error (Librarian_abort_not_committed exn)))
 ;;
 
 let drain_and_join_librarian ~base_path ~keeper_name =

--- a/lib/keeper/keeper_memory_lane.ml
+++ b/lib/keeper/keeper_memory_lane.ml
@@ -405,17 +405,25 @@ let submit ~base_path ~keeper_name f =
   match current_sw () with
   | None ->
     (* Not initialized: run inline. The caller is still inside the per-keeper
-       turn lane, so single-fiber-per-keeper memory access is preserved. A
-       raising unit is contained and counted rather than escaping. *)
-    (try f () with
-     | Eio.Cancel.Cancelled _ as e -> raise e
-     | exn ->
-       record_counter ~keeper_name MemoryLaneUnitFailures;
-       Log.Keeper.warn ~keeper_name
-         "memory lane unit failed (inline): %s"
-         (Printexc.to_string exn));
-    record_counter ~keeper_name MemoryLaneRanInline;
-    Ran_inline
+       turn lane, so single-fiber-per-keeper memory access is preserved. The
+       lifecycle fence still applies before the executor switch exists: a
+       launch rollback or terminal drain must not be bypassed by the inline
+       fallback. A raising admitted unit is contained and counted rather than
+       escaping. *)
+    let entry = entry_for ~base_path ~keeper_name in
+    if
+      Stdlib.Mutex.protect entry.state_mu (fun () -> entry.lifecycle = Draining)
+    then Rejected_draining
+    else (
+      (try f () with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+         record_counter ~keeper_name MemoryLaneUnitFailures;
+         Log.Keeper.warn ~keeper_name
+           "memory lane unit failed (inline): %s"
+           (Printexc.to_string exn));
+      record_counter ~keeper_name MemoryLaneRanInline;
+      Ran_inline)
   | Some sw ->
     let entry = entry_for ~base_path ~keeper_name in
     submit_librarian ~keeper_name entry sw f

--- a/lib/keeper/keeper_memory_lane.ml
+++ b/lib/keeper/keeper_memory_lane.ml
@@ -11,16 +11,24 @@ type librarian_drain =
 
 type entry =
   { state_mu : Stdlib.Mutex.t
-    (* Guards [pending] and [librarian_drain]. Critical sections never yield. *)
+    (* Guards [lifecycle], [pending], [librarian_drain], and
+       [last_owner_lane]. Critical sections never yield. *)
+  ; mutable lifecycle : lifecycle
   ; mutable pending : int
   ; mutable librarian_drain : librarian_drain option
+  ; mutable last_owner_lane : Keeper_lane.t option
   }
+
+and lifecycle =
+  | Accepting
+  | Draining
 
 type outcome =
   | Submitted
   | Coalesced
   | Ran_inline
   | Dropped
+  | Rejected_draining
 
 let entries : (string, entry) Hashtbl.t = Hashtbl.create 16
 
@@ -42,15 +50,22 @@ let entry_key ~base_path ~keeper_name =
   Keeper_registry_types.registry_key ~base_path keeper_name ^ "#" ^ lane_label
 ;;
 
+let make_entry lifecycle =
+  { state_mu = Stdlib.Mutex.create ()
+  ; lifecycle
+  ; pending = 0
+  ; librarian_drain = None
+  ; last_owner_lane = None
+  }
+;;
+
 let entry_for ~base_path ~keeper_name =
   let key = entry_key ~base_path ~keeper_name in
   Stdlib.Mutex.protect registry_mu (fun () ->
     match Hashtbl.find_opt entries key with
     | Some e -> e
     | None ->
-      let e =
-        { state_mu = Stdlib.Mutex.create (); pending = 0; librarian_drain = None }
-      in
+      let e = make_entry Accepting in
       Hashtbl.add entries key e;
       e)
 ;;
@@ -121,6 +136,7 @@ type librarian_submission =
   | Start_drain of librarian_drain
   | Queue_latest
   | Replace_latest
+  | Reject_draining
 
 type librarian_drain_step =
   | Drain_stopped
@@ -129,8 +145,9 @@ type librarian_drain_step =
 
 let librarian_reserve entry f =
   Stdlib.Mutex.protect entry.state_mu (fun () ->
-    match entry.librarian_drain with
-    | None ->
+    match entry.lifecycle, entry.librarian_drain with
+    | Draining, _ -> Reject_draining
+    | Accepting, None ->
       let drain =
         { latest = None
         ; in_flight = false
@@ -139,9 +156,10 @@ let librarian_reserve entry f =
         }
       in
       entry.librarian_drain <- Some drain;
+      entry.last_owner_lane <- Some drain.owner_lane;
       entry.pending <- 1;
       Start_drain drain
-    | Some drain ->
+    | Accepting, Some drain ->
       (match drain.latest with
        | None ->
          drain.latest <- Some f;
@@ -150,6 +168,32 @@ let librarian_reserve entry f =
        | Some _ ->
          drain.latest <- Some f;
          Replace_latest))
+;;
+
+type lifecycle_open_error = Librarian_drain_still_active
+
+let lifecycle_open_error_to_string = function
+  | Librarian_drain_still_active ->
+    "a prior Keeper lifecycle still owns active Librarian work"
+;;
+
+let begin_librarian_lifecycle ~base_path ~keeper_name =
+  let entry = entry_for ~base_path ~keeper_name in
+  Stdlib.Mutex.protect entry.state_mu (fun () ->
+    match entry.librarian_drain, entry.last_owner_lane with
+    | Some _, _ -> Error Librarian_drain_still_active
+    | None, Some owner_lane when Option.is_none (Keeper_lane.peek_exit owner_lane) ->
+      Error Librarian_drain_still_active
+    | None, (None | Some _) ->
+      (* A closed prior lifecycle has no active work, so its terminal receipt
+         is no longer relevant. Reopening an already accepting lifecycle is a
+         no-op. Do not clear the receipt during lane cleanup: shutdown may begin
+         only after a failed/cancelled owner has already exited. *)
+      (match entry.lifecycle with
+       | Draining -> entry.last_owner_lane <- None
+       | Accepting -> ());
+      entry.lifecycle <- Accepting;
+      Ok ())
 ;;
 
 let librarian_drain_is_active entry drain =
@@ -287,6 +331,11 @@ let rec run_librarian_drain ~keeper_name entry drain sw current =
 
 let submit_librarian ~keeper_name entry sw f =
   match librarian_reserve entry f with
+  | Reject_draining ->
+    record_counter ~keeper_name MemoryLaneRejectedDraining;
+    Log.Keeper.warn ~keeper_name
+      "memory lane rejected post-turn unit after lifecycle drain began (lane=librarian)";
+    Rejected_draining
   | Queue_latest ->
     inc_pending ~keeper_name ();
     inc_latest_pending ~keeper_name ();
@@ -304,6 +353,13 @@ let submit_librarian ~keeper_name entry sw f =
     arm_librarian_switch_release ~keeper_name entry drain sw;
     if not (librarian_drain_is_active entry drain)
     then (
+      let reason = Failure "Librarian executor switch released before lane start" in
+      (match Keeper_lane.reject_before_start drain.owner_lane ~reason with
+       | Ok () -> ()
+       | Error _ ->
+         (* Rejection only fails after another path has already claimed this
+            exact owner receipt; either way it is no longer [Not_started]. *)
+         ());
       record_counter ~keeper_name MemoryLaneDropped;
       Log.Keeper.warn ~keeper_name
         "memory lane executor switch unavailable (lane=librarian): dropping post-turn \
@@ -366,41 +422,60 @@ let submit ~base_path ~keeper_name f =
     submit_librarian ~keeper_name entry sw f
 ;;
 
-type librarian_join_outcome =
+type librarian_drain_outcome =
   | No_librarian_work
-  | Librarian_joined of Keeper_lane.outcome
-  | Librarian_join_failed of string
+  | Librarian_drained
 
-let cancel_and_join_librarian ~base_path ~keeper_name =
+type librarian_drain_error =
+  | Librarian_interrupted of Keeper_lane.outcome
+  | Librarian_cleanup_failed of string
+
+let librarian_lane_outcome_to_string = function
+  | Keeper_lane.Completed -> "completed"
+  | Keeper_lane.Shutdown_before_start -> "shutdown_before_start"
+  | Keeper_lane.Shutdown_requested -> "shutdown_requested"
+  | Keeper_lane.Shutdown_cancel_failed failure ->
+    "shutdown_cancel_failed: " ^ Printexc.to_string failure.cause
+  | Keeper_lane.Cancelled_by_parent exn ->
+    "cancelled_by_parent: " ^ Printexc.to_string exn
+  | Keeper_lane.Failed exn -> "failed: " ^ Printexc.to_string exn
+;;
+
+let librarian_drain_error_to_string = function
+  | Librarian_interrupted outcome ->
+    "Librarian drain ended without completion: "
+    ^ librarian_lane_outcome_to_string outcome
+  | Librarian_cleanup_failed detail -> "Librarian cleanup failed: " ^ detail
+;;
+
+let drain_and_join_librarian ~base_path ~keeper_name =
   let entry =
     let key = entry_key ~base_path ~keeper_name in
-    Stdlib.Mutex.protect registry_mu (fun () -> Hashtbl.find_opt entries key)
+    Stdlib.Mutex.protect registry_mu (fun () ->
+      match Hashtbl.find_opt entries key with
+      | Some entry -> entry
+      | None ->
+        let entry = make_entry Draining in
+        Hashtbl.add entries key entry;
+        entry)
   in
-  match entry with
-  | None -> No_librarian_work
-  | Some entry ->
-    let owner_lane =
-      Stdlib.Mutex.protect entry.state_mu (fun () ->
-        Option.map (fun drain -> drain.owner_lane) entry.librarian_drain)
-    in
-    (match owner_lane with
-     | None -> No_librarian_work
-     | Some owner_lane ->
-    (match Keeper_lane.request_cancel owner_lane with
-     | Keeper_lane.Cancel_wrong_domain ->
-       Librarian_join_failed
-         "librarian cancellation requested from a non-owning domain"
-     | Keeper_lane.Cancel_not_committed exn ->
-       Librarian_join_failed
-         ("librarian cancellation was not committed: " ^ Printexc.to_string exn)
-     | Keeper_lane.Cancel_committed_with_failure _
-     | Keeper_lane.Cancel_requested
-     | Keeper_lane.Cancel_already_requested
-     | Keeper_lane.Cancel_already_exiting ->
-       let exit = Keeper_lane.await_exit owner_lane in
-       (match exit.cleanup_error with
-        | Some detail -> Librarian_join_failed detail
-        | None -> Librarian_joined exit.outcome)))
+  let owner_lane =
+    Stdlib.Mutex.protect entry.state_mu (fun () ->
+      entry.lifecycle <- Draining;
+      match entry.librarian_drain with
+      | Some drain -> Some drain.owner_lane
+      | None -> entry.last_owner_lane)
+  in
+  match owner_lane with
+  | None -> Ok No_librarian_work
+  | Some owner_lane ->
+    let exit = Keeper_lane.await_exit owner_lane in
+    (match exit.cleanup_error with
+     | Some detail -> Error (Librarian_cleanup_failed detail)
+     | None ->
+       (match exit.outcome with
+        | Keeper_lane.Completed -> Ok Librarian_drained
+        | outcome -> Error (Librarian_interrupted outcome)))
 ;;
 
 module For_testing = struct

--- a/lib/keeper/keeper_memory_lane.mli
+++ b/lib/keeper/keeper_memory_lane.mli
@@ -36,6 +36,22 @@ type outcome =
   | Dropped
       (** The executor switch could not own the unit. Saturation returns
           {!Coalesced}, not [Dropped]. The drop is counted, never silent. *)
+  | Rejected_draining
+      (** The Keeper lifecycle has begun draining this lane. No post-turn unit
+          may cross that terminal boundary; a later Keeper lifecycle must call
+          {!begin_librarian_lifecycle} before it can submit. *)
+
+type lifecycle_open_error = Librarian_drain_still_active
+
+val begin_librarian_lifecycle
+  :  base_path:string
+  -> keeper_name:string
+  -> (unit, lifecycle_open_error) result
+(** Open the Librarian entry for one newly admitted Keeper lifecycle. This is
+    idempotent while the entry is idle and fails when a prior lifecycle still
+    owns active work. *)
+
+val lifecycle_open_error_to_string : lifecycle_open_error -> string
 
 val init : sw:Eio.Switch.t -> unit
 (** Record the long-lived switch that owns detached memory fibers. Call once at
@@ -53,18 +69,30 @@ val submit
     counted rather than escaping. Outcomes and per-keeper state are exported as
     metrics. *)
 
-type librarian_join_outcome =
+type librarian_drain_outcome =
   | No_librarian_work
-  | Librarian_joined of Keeper_lane.outcome
-  | Librarian_join_failed of string
+  | Librarian_drained
 
-val cancel_and_join_librarian
+type librarian_drain_error =
+  | Librarian_interrupted of Keeper_lane.outcome
+  | Librarian_cleanup_failed of string
+
+val librarian_drain_error_to_string : librarian_drain_error -> string
+
+val drain_and_join_librarian
   :  base_path:string
   -> keeper_name:string
-  -> librarian_join_outcome
-(** Cancel the exact detached Librarian drain owned by [keeper_name] and wait
-    until its provider/tool scope and cleanup have joined. A Keeper lifecycle
-    boundary must call this before publishing its own terminal state. *)
+  -> (librarian_drain_outcome, librarian_drain_error) result
+(** Wait for the exact detached Librarian drain owned by [keeper_name] to
+    finish its current unit and any retained latest unit, then join its
+    provider/tool scope and cleanup. The entry becomes closed to new
+    submissions before its owner is inspected, so an accepted unit cannot race
+    behind the join. The exact terminal receipt remains available if the owner
+    exits before this function is called. Only a [Completed] owner lane returns
+    [Librarian_drained]; every other terminal outcome is a typed error. A
+    graceful Keeper lifecycle boundary must call this before publishing its own terminal state.
+    Parent-switch cancellation still interrupts the drain during process
+    shutdown. *)
 
 module For_testing : sig
   val reset : unit -> unit

--- a/lib/keeper/keeper_memory_lane.mli
+++ b/lib/keeper/keeper_memory_lane.mli
@@ -79,6 +79,29 @@ type librarian_drain_error =
 
 val librarian_drain_error_to_string : librarian_drain_error -> string
 
+type librarian_abort_outcome =
+  | Librarian_abort_idle
+  | Librarian_abort_requested
+  | Librarian_abort_already_in_progress
+  | Librarian_abort_already_exited of Keeper_lane.exit
+  | Librarian_abort_committed_with_failure of exn
+
+type librarian_abort_error =
+  | Librarian_abort_wrong_domain
+  | Librarian_abort_not_committed of exn
+
+val librarian_abort_error_to_string : librarian_abort_error -> string
+
+val abort_librarian
+  :  base_path:string
+  -> keeper_name:string
+  -> (librarian_abort_outcome, librarian_abort_error) result
+(** Fence new submissions and request cancellation of the exact Librarian
+    owner without joining it. Unexpected Keeper exits use this fail-fast path
+    so a slow provider cannot delay crash publication or registry cleanup.
+    Cancellation outcomes distinguish a committed signal from a request that
+    was not delivered; callers must not retry a committed cancellation. *)
+
 val drain_and_join_librarian
   :  base_path:string
   -> keeper_name:string

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -298,18 +298,8 @@ let record_crash ~base_path name ts msg =
   Error_tracking.record_crash ~base_path name ts msg ~update_entry:update_entry_unit
 ;;
 
-let set_failure_reason_exact entry reason =
-  update_entry_exact entry (fun current -> { current with last_failure_reason = reason })
-;;
-
 let set_last_error_exact entry err =
   update_entry_exact entry (fun current -> { current with last_error = Some err })
-;;
-
-let record_crash_exact entry ts msg =
-  Log.Keeper.error "registry: recording exact-lane crash name=%s msg=%s" entry.name msg;
-  update_entry_exact entry (fun current ->
-    Error_tracking.record_crash_entry current ts msg)
 ;;
 
 let exact_update_succeeded entry ~site = function
@@ -614,10 +604,6 @@ let cleanup_tracking_entry current =
   ; board_cursor_ts = 0.0
   ; board_cursor_post_id = None
   }
-;;
-
-let cleanup_tracking_exact (entry : registry_entry) =
-  update_entry_exact entry cleanup_tracking_entry
 ;;
 
 let cleanup_tracking_exact_for_lifecycle token (entry : registry_entry) =

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -607,14 +607,21 @@ let cleanup_tracking ~base_path name =
   | None -> ()
 ;;
 
+let cleanup_tracking_entry current =
+  { current with
+    board_wakeups = StringMap.empty
+  ; tool_usage = StringMap.empty
+  ; board_cursor_ts = 0.0
+  ; board_cursor_post_id = None
+  }
+;;
+
 let cleanup_tracking_exact (entry : registry_entry) =
-  update_entry_exact entry (fun current ->
-    { current with
-      board_wakeups = StringMap.empty
-    ; tool_usage = StringMap.empty
-    ; board_cursor_ts = 0.0
-    ; board_cursor_post_id = None
-    })
+  update_entry_exact entry cleanup_tracking_entry
+;;
+
+let cleanup_tracking_exact_for_lifecycle token (entry : registry_entry) =
+  update_entry_exact_for_lifecycle token entry cleanup_tracking_entry
 ;;
 
 let clear () =

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -71,6 +71,11 @@ val register_restarting :
   base_path:string -> string -> keeper_meta ->
   (registry_entry, register_restarting_error) result
 
+val register_restarting_for_lifecycle :
+  Keeper_lifecycle_reservation.token ->
+  base_path:string -> string -> keeper_meta ->
+  (registry_entry, register_restarting_error) result
+
 (** Prepare a registry entry for a newly launched keepalive fiber.
     Clears stale per-fiber atomic latches before applying [Fiber_started] so
     the runtime stop flag matches the state machine's restart semantics. *)

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -372,14 +372,7 @@ val get_turn_failures : base_path:string -> string -> int
 (** Record a crash entry in the crash log (keeps last 5). *)
 val record_crash : base_path:string -> string -> float -> string -> unit
 
-(** Failure mutations scoped to the exact lane captured by [entry]. *)
-val set_failure_reason_exact :
-  registry_entry -> failure_reason option -> exact_update_result
-
 val set_last_error_exact : registry_entry -> string -> exact_update_result
-
-val record_crash_exact :
-  registry_entry -> float -> string -> exact_update_result
 
 (** Observe an exact-lane update without discarding why it did not commit.
     Returns [true] only for [Exact_updated]; all other outcomes are logged with
@@ -520,9 +513,6 @@ val restore_supervisor_state :
 
 (** Reset tracking state (agent count + board wakeups) for a keeper. *)
 val cleanup_tracking : base_path:string -> string -> unit
-
-(** Reset tracking only if [entry]'s lane still owns its registry key. *)
-val cleanup_tracking_exact : registry_entry -> exact_update_result
 
 val cleanup_tracking_exact_for_lifecycle :
   Keeper_lifecycle_reservation.token -> registry_entry -> exact_update_result

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -57,6 +57,7 @@ val register_offline_if_admitted_for_lifecycle :
 
 type register_restarting_error =
   | Restart_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
+  | Restart_intake_token_not_live
   | Restart_lifecycle_reserved of Keeper_lifecycle_reservation.snapshot
   | Restart_event_queue_unavailable of
       { keeper_name : string
@@ -72,6 +73,7 @@ val register_restarting :
   (registry_entry, register_restarting_error) result
 
 val register_restarting_for_lifecycle :
+  ?intake_token:Keeper_shutdown_intake_fence.intake_token ->
   Keeper_lifecycle_reservation.token ->
   base_path:string -> string -> keeper_meta ->
   (registry_entry, register_restarting_error) result

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -522,6 +522,9 @@ val cleanup_tracking : base_path:string -> string -> unit
 (** Reset tracking only if [entry]'s lane still owns its registry key. *)
 val cleanup_tracking_exact : registry_entry -> exact_update_result
 
+val cleanup_tracking_exact_for_lifecycle :
+  Keeper_lifecycle_reservation.token -> registry_entry -> exact_update_result
+
 (** Get board event cursor token. Returns [(0.0, None)] if not found. *)
 val get_board_cursor : base_path:string -> string -> float * string option
 

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -544,7 +544,8 @@ val tool_usage_of : base_path:string -> string ->
 (** Replace (or insert) a single per-tool usage entry on a registered keeper.
     Goes through the registry's CAS retry loop. Used by
     [Keeper_registry_tool_usage_persistence.restore] to replay persisted
-    counters on re-registration. *)
+    counters outside a lifecycle transaction. Launch-time replay uses the
+    exact, token-qualified update exposed to the persistence module. *)
 val set_tool_usage_entry :
   base_path:string -> name:string -> tool_name:string
   -> Keeper_types.tool_call_entry -> unit

--- a/lib/keeper/keeper_registry_error_recording.ml
+++ b/lib/keeper/keeper_registry_error_recording.ml
@@ -54,3 +54,30 @@ let record_exact ?details (entry : Keeper_registry.registry_entry) err =
         entry.name
         (Keeper_registry.registry_entry_validation_error_to_string validation_error))
 ;;
+
+let record_exact_for_lifecycle
+      token
+      ?details
+      (entry : Keeper_registry.registry_entry)
+      err
+  =
+  record_common ?details entry.name err (fun () ->
+    match
+      Keeper_registry.update_entry_exact_for_lifecycle token entry (fun current ->
+        { current with last_error = Some err })
+    with
+    | Keeper_registry.Exact_updated -> ()
+    | Keeper_registry.Exact_update_missing ->
+      Log.Keeper.warn
+        "registry: lifecycle exact error record skipped because lane is no longer registered name=%s"
+        entry.name
+    | Keeper_registry.Exact_update_replaced ->
+      Log.Keeper.warn
+        "registry: lifecycle exact error record retained newer same-name lane name=%s"
+        entry.name
+    | Keeper_registry.Exact_update_invalid validation_error ->
+      Log.Keeper.warn
+        "registry: lifecycle exact error record validation failed name=%s error=%s"
+        entry.name
+        (Keeper_registry.registry_entry_validation_error_to_string validation_error))
+;;

--- a/lib/keeper/keeper_registry_error_recording.mli
+++ b/lib/keeper/keeper_registry_error_recording.mli
@@ -13,3 +13,10 @@ val record :
     same-name lane's [last_error]. *)
 val record_exact :
   ?details:Yojson.Safe.t -> Keeper_registry.registry_entry -> string -> unit
+
+val record_exact_for_lifecycle :
+  Keeper_lifecycle_reservation.token ->
+  ?details:Yojson.Safe.t ->
+  Keeper_registry.registry_entry ->
+  string ->
+  unit

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -201,6 +201,7 @@ let authorize_durable_intake_owner ~base_path ~keeper_name =
        | Keeper_shutdown_types.Retain_dead_tombstone -> false)
     | Keeper_shutdown_types.Finalized { meta_removed = false; _ }
     | Keeper_shutdown_types.Prepared
+    | Keeper_shutdown_types.Joining_lanes
     | Keeper_shutdown_types.Joined_idle
     | Keeper_shutdown_types.Finalizing_tasks _
     | Keeper_shutdown_types.Cleanup_ready _

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -676,13 +676,14 @@ let register_offline_if_admitted_for_lifecycle
 
 type register_restarting_error =
   | Restart_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
+  | Restart_intake_token_not_live
   | Restart_lifecycle_reserved of Keeper_lifecycle_reservation.snapshot
   | Restart_event_queue_unavailable of
       { keeper_name : string
       ; detail : string
       }
 
-let register_restarting_internal ?lifecycle_token ~base_path name meta
+let register_restarting_internal ?lifecycle_token ?intake_token ~base_path name meta
   : (registry_entry, register_restarting_error) result
   =
   let base_path = canonical_base_path_exn base_path in
@@ -775,19 +776,33 @@ let register_restarting_internal ?lifecycle_token ~base_path name meta
     | Error owner -> Error (Restart_lifecycle_reserved owner)
     | Ok () -> loop ()
   in
-  (* Key lock outside the admission fence — see the register path for why
-     nesting it inside would wedge the domain. *)
-  match
+  (* The launch transaction already owns the durable-intake epoch when it
+     supplies [intake_token]. Validate that exact ownership instead of
+     reacquiring/checking the shutdown slot midway through the transaction. *)
+  let commit_result =
     Keeper_lifecycle_reservation.with_key_lock ~base_path ~keeper_name:name (fun () ->
-      Keeper_shutdown_intake_fence.commit_registration_if_open
-        ~base_path
-        ~keeper_name:name
-        guarded_loop_key_locked)
-  with
-  | Keeper_shutdown_intake_fence.Registration_shutdown_reserved operation_id ->
-    Error (Restart_shutdown_reserved operation_id)
-  | Keeper_shutdown_intake_fence.Registration_committed (Error _ as error) -> error
-  | Keeper_shutdown_intake_fence.Registration_committed (Ok registered) ->
+      match intake_token with
+      | Some token
+        when Keeper_shutdown_intake_fence.intake_token_matches
+               token
+               ~base_path
+               ~keeper_name:name ->
+        guarded_loop_key_locked ()
+      | Some _ -> Error Restart_intake_token_not_live
+      | None ->
+        (match
+           Keeper_shutdown_intake_fence.commit_registration_if_open
+             ~base_path
+             ~keeper_name:name
+             guarded_loop_key_locked
+         with
+         | Keeper_shutdown_intake_fence.Registration_shutdown_reserved operation_id ->
+           Error (Restart_shutdown_reserved operation_id)
+         | Keeper_shutdown_intake_fence.Registration_committed result -> result))
+  in
+  match commit_result with
+  | Error _ as error -> error
+  | Ok registered ->
     Log.Keeper.info
       "registry: registering keeper name=%s base_path=%s phase=%s"
       name
@@ -800,8 +815,13 @@ let register_restarting ~base_path name meta =
   register_restarting_internal ~base_path name meta
 ;;
 
-let register_restarting_for_lifecycle token ~base_path name meta =
-  register_restarting_internal ~lifecycle_token:token ~base_path name meta
+let register_restarting_for_lifecycle ?intake_token token ~base_path name meta =
+  register_restarting_internal
+    ~lifecycle_token:token
+    ?intake_token
+    ~base_path
+    name
+    meta
 ;;
 
 type unregister_exact_result =

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -682,7 +682,7 @@ type register_restarting_error =
       ; detail : string
       }
 
-let register_restarting ~base_path name meta
+let register_restarting_internal ?lifecycle_token ~base_path name meta
   : (registry_entry, register_restarting_error) result
   =
   let base_path = canonical_base_path_exn base_path in
@@ -691,7 +691,11 @@ let register_restarting ~base_path name meta
   in
   let key = registry_key ~base_path name in
   match
-    Keeper_lifecycle_reservation.authorize ~base_path ~keeper_name:name ()
+    Keeper_lifecycle_reservation.authorize
+      ?token:lifecycle_token
+      ~base_path
+      ~keeper_name:name
+      ()
   with
   | Error owner -> Error (Restart_lifecycle_reserved owner)
   | Ok () ->
@@ -761,7 +765,13 @@ let register_restarting ~base_path name meta
   in
   (* Runs with the lifecycle key lock already held, so it never suspends. *)
   let guarded_loop_key_locked () =
-    match Keeper_lifecycle_reservation.authorize ~base_path ~keeper_name:name () with
+    match
+      Keeper_lifecycle_reservation.authorize
+        ?token:lifecycle_token
+        ~base_path
+        ~keeper_name:name
+        ()
+    with
     | Error owner -> Error (Restart_lifecycle_reserved owner)
     | Ok () -> loop ()
   in
@@ -784,6 +794,14 @@ let register_restarting ~base_path name meta
       base_path
       (Keeper_state_machine.phase_to_string phase);
     Ok registered
+;;
+
+let register_restarting ~base_path name meta =
+  register_restarting_internal ~base_path name meta
+;;
+
+let register_restarting_for_lifecycle token ~base_path name meta =
+  register_restarting_internal ~lifecycle_token:token ~base_path name meta
 ;;
 
 type unregister_exact_result =

--- a/lib/keeper/keeper_registry_tool_usage_persistence.ml
+++ b/lib/keeper/keeper_registry_tool_usage_persistence.ml
@@ -167,26 +167,54 @@ let report_restore_failure name reason =
   Log.Keeper.warn "restore_tool_usage %s: %s" name reason
 ;;
 
-let restore ~base_path name =
+let restore_with ~base_path name apply =
   let path = tool_usage_path ~base_path name in
   if not (Fs_compat.file_exists path)
   then ()
   else (
+    try
+      let content = Fs_compat.load_file path in
+      let json = Yojson.Safe.from_string content in
+      (match decode_tool_usage ~expected_keeper:name json with
+       | Ok tools -> apply tools
+       | Error reason -> report_restore_failure name reason)
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn -> report_restore_failure name (Printexc.to_string exn))
+;;
+
+let restore ~base_path name =
+  let path = tool_usage_path ~base_path name in
+  if Fs_compat.file_exists path
+  then
     match Keeper_registry.get ~base_path name with
     | None -> report_restore_failure name "keeper is not registered"
     | Some _entry ->
-      (try
-         let content = Fs_compat.load_file path in
-         let json = Yojson.Safe.from_string content in
-         (match decode_tool_usage ~expected_keeper:name json with
-          | Ok tools ->
-            List.iter
-              (fun (tool_name, entry) ->
-                 Keeper_registry.set_tool_usage_entry
-                   ~base_path ~name ~tool_name entry)
-              tools
-          | Error reason -> report_restore_failure name reason)
-       with
-       | Eio.Cancel.Cancelled _ as e -> raise e
-       | exn -> report_restore_failure name (Printexc.to_string exn)))
+      restore_with ~base_path name (fun tools ->
+        List.iter
+          (fun (tool_name, entry) ->
+             Keeper_registry.set_tool_usage_entry ~base_path ~name ~tool_name entry)
+          tools)
+;;
+
+let restore_for_lifecycle token (expected : registry_entry) =
+  let base_path = expected.base_path in
+  let name = expected.name in
+  restore_with ~base_path name (fun tools ->
+    let result =
+      Keeper_registry.update_entry_exact_for_lifecycle token expected (fun current ->
+        let tool_usage =
+          List.fold_left
+            (fun usage (tool_name, entry) -> StringMap.add tool_name entry usage)
+            current.tool_usage
+            tools
+        in
+        { current with tool_usage })
+    in
+    if not
+         (Keeper_registry.exact_update_succeeded
+            expected
+            ~site:"restore_tool_usage_for_lifecycle"
+            result)
+    then report_restore_failure name "lifecycle-owned registry update was rejected")
 ;;

--- a/lib/keeper/keeper_registry_tool_usage_persistence.mli
+++ b/lib/keeper/keeper_registry_tool_usage_persistence.mli
@@ -16,3 +16,9 @@ val flush_all_dirty : unit -> unit
     Reads JSON from [tool_usage_path]; replays each entry via
     [Keeper_registry.set_tool_usage_entry]. *)
 val restore : base_path:string -> string -> unit
+
+(** Restore persisted usage while [expected]'s launch transaction owns the
+    lifecycle reservation. The replay is exact to that registry lane and uses
+    [token] as its mutation authority. *)
+val restore_for_lifecycle :
+  Keeper_lifecycle_reservation.token -> Keeper_registry_types.registry_entry -> unit

--- a/lib/keeper/keeper_registry_tool_usage_persistence.mli
+++ b/lib/keeper/keeper_registry_tool_usage_persistence.mli
@@ -21,4 +21,4 @@ val restore : base_path:string -> string -> unit
     lifecycle reservation. The replay is exact to that registry lane and uses
     [token] as its mutation authority. *)
 val restore_for_lifecycle :
-  Keeper_lifecycle_reservation.token -> Keeper_registry_types.registry_entry -> unit
+  Keeper_lifecycle_reservation.token -> Keeper_registry.registry_entry -> unit

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -93,6 +93,7 @@ type done_resolution = [ `Stopped | `Crashed of string ]
 
 type lifecycle_transaction_purpose =
   | Paused_work_disposition
+  | Keepalive_launch
 
 type lifecycle_reservation_snapshot =
   { owner_id : string

--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -368,6 +368,7 @@ type done_resolution = [ `Stopped | `Crashed of string ]
 
 type lifecycle_transaction_purpose =
   | Paused_work_disposition
+  | Keepalive_launch
 
 type lifecycle_reservation_snapshot =
   { owner_id : string

--- a/lib/keeper/keeper_shutdown_finalize.ml
+++ b/lib/keeper/keeper_shutdown_finalize.ml
@@ -693,6 +693,7 @@ let deliver_finalized_completion ~config ?successor_operation_id operation =
             ?successor_operation_id
             persisted))
   | Prepared
+  | Joining_lanes
   | Joined_idle
   | Finalizing_tasks _
   | Cleanup_ready _
@@ -856,6 +857,7 @@ let run ~config ~entry ?successor_operation_id operation =
   | Finalized _ ->
     deliver_finalized_completion ~config ?successor_operation_id operation
   | Prepared
+  | Joining_lanes
   | Reconciliation_required _
   | Blocked _
   | Superseded _ -> Error Unsupported_phase

--- a/lib/keeper/keeper_shutdown_prepare_join.ml
+++ b/lib/keeper/keeper_shutdown_prepare_join.ml
@@ -17,6 +17,7 @@ type error =
   | Prepare_persist_failed of Keeper_shutdown_store.error
   | Cancellation_failed of Keeper_shutdown_types.t
   | Join_failed of Keeper_shutdown_types.t
+  | Join_phase_mismatch of Keeper_shutdown_types.t
   | Join_record_update_failed of Keeper_shutdown_store.error
 
 let error_to_string = function
@@ -44,6 +45,10 @@ let error_to_string = function
     Printf.sprintf
       "Keeper shutdown join blocked in operation %s"
       (Operation_id.to_string operation.operation_id)
+  | Join_phase_mismatch operation ->
+    Printf.sprintf
+      "Keeper shutdown operation is not joinable at revision %d"
+      operation.revision
   | Join_record_update_failed error -> Keeper_shutdown_store.error_to_string error
 ;;
 
@@ -158,6 +163,44 @@ let cancellation_error ~config operation stage detail =
   match persist_blocked ~config operation stage detail with
   | Ok blocked -> Error (Cancellation_failed blocked)
   | Error error -> Error (Join_record_update_failed error)
+;;
+
+let join_error ~config operation detail =
+  match persist_blocked ~config operation Lane_join detail with
+  | Ok blocked -> Error (Join_failed blocked)
+  | Error error -> Error (Join_record_update_failed error)
+;;
+
+let enter_joining_lanes ~config operation =
+  match operation.phase with
+  | Joining_lanes ->
+    join_error
+      ~config
+      operation
+      "a prior live lane-join attempt ended without a durable terminal receipt; refusing to replay safety-sensitive turn cancellation"
+  | Prepared ->
+    let joining =
+      { operation with
+        revision = operation.revision + 1
+      ; phase = Joining_lanes
+      ; updated_at = Masc_domain.now_iso ()
+      }
+    in
+    (match
+       Keeper_shutdown_store.replace
+         ~config
+         ~expected_revision:operation.revision
+         joining
+     with
+     | Ok () -> Ok joining
+     | Error error -> Error (Join_record_update_failed error))
+  | Joined_idle
+  | Finalizing_tasks _
+  | Cleanup_ready _
+  | Reconciliation_required _
+  | Finalized _
+  | Blocked _
+  | Superseded _ -> Error (Join_phase_mismatch operation)
 ;;
 
 let lane_outcome = function
@@ -349,6 +392,9 @@ let join_prepared ~config ~(entry : Keeper_registry.registry_entry) ~operation =
               Keeper_lane.Id.equal (Keeper_lane.id current.lane) lane_id
             | Dormant_meta -> false) -> Error Registry_lane_replaced
   | Ok current ->
+    (match enter_joining_lanes ~config operation with
+     | Error _ as error -> error
+     | Ok operation ->
     Keeper_keepalive.request_entry_stop current;
     let turn_cancel = Keeper_registry.interrupt_current_turn_exact current in
     let turn_cancel_error =
@@ -382,9 +428,11 @@ let join_prepared ~config ~(entry : Keeper_registry.registry_entry) ~operation =
                ~keeper_name:current.name
            with
            | Error error ->
-             Error
-               (Owner_command_failed
-                  (Keeper_owner_registry.command_error_to_string error))
+             join_error
+               ~config
+               operation
+               ("Keeper Owner shutdown command failed: "
+                ^ Keeper_owner_registry.command_error_to_string error)
            | Ok () ->
           let lane_exit = Keeper_lane.await_exit current.lane in
           (match lane_exit.outcome with
@@ -410,13 +458,14 @@ let join_prepared ~config ~(entry : Keeper_registry.registry_entry) ~operation =
            | Keeper_lane.Failed _ -> ());
           let memory_join_error =
             match
-              Keeper_memory_lane.cancel_and_join_librarian
+              Keeper_memory_lane.drain_and_join_librarian
                 ~base_path:config.Workspace.base_path
                 ~keeper_name:current.name
             with
-            | Keeper_memory_lane.No_librarian_work
-            | Keeper_memory_lane.Librarian_joined _ -> None
-            | Keeper_memory_lane.Librarian_join_failed detail -> Some detail
+            | Ok Keeper_memory_lane.No_librarian_work
+            | Ok Keeper_memory_lane.Librarian_drained -> None
+            | Error error ->
+              Some (Keeper_memory_lane.librarian_drain_error_to_string error)
           in
           let cleanup_error =
             match lane_exit.cleanup_error, memory_join_error with
@@ -430,22 +479,7 @@ let join_prepared ~config ~(entry : Keeper_registry.registry_entry) ~operation =
                    memory_detail)
           in
           (match cleanup_error with
-           | Some detail ->
-             let blocked =
-               { operation with
-                 revision = operation.revision + 1
-               ; phase = Blocked { stage = Lane_join; detail }
-               ; updated_at = Masc_domain.now_iso ()
-               }
-             in
-             (match
-                Keeper_shutdown_store.replace
-                  ~config
-                  ~expected_revision:operation.revision
-                  blocked
-              with
-              | Ok () -> Error (Join_failed blocked)
-              | Error error -> Error (Join_record_update_failed error))
+           | Some detail -> join_error ~config operation detail
            | None ->
           let terminal_result = Eio.Promise.await current.done_p in
           let evidence =
@@ -494,7 +528,7 @@ let join_prepared ~config ~(entry : Keeper_registry.registry_entry) ~operation =
                joined
            with
            | Ok () -> Ok joined
-           | Error error -> Error (Join_record_update_failed error))))))
+           | Error error -> Error (Join_record_update_failed error)))))))
 ;;
 
 let run ~config ~entry ~request =

--- a/lib/keeper/keeper_shutdown_prepare_join.ml
+++ b/lib/keeper/keeper_shutdown_prepare_join.ml
@@ -383,6 +383,16 @@ let prepare_dormant
 ;;
 
 let join_prepared ~config ~(entry : Keeper_registry.registry_entry) ~operation =
+  match operation.phase with
+  | Joining_lanes -> enter_joining_lanes ~config operation
+  | Prepared
+  | Joined_idle
+  | Finalizing_tasks _
+  | Cleanup_ready _
+  | Reconciliation_required _
+  | Finalized _
+  | Blocked _
+  | Superseded _ ->
   match current_entry ~config entry with
   | Error error -> Error error
   | Ok current

--- a/lib/keeper/keeper_shutdown_prepare_join.mli
+++ b/lib/keeper/keeper_shutdown_prepare_join.mli
@@ -20,6 +20,7 @@ type error =
   | Prepare_persist_failed of Keeper_shutdown_store.error
   | Cancellation_failed of Keeper_shutdown_types.t
   | Join_failed of Keeper_shutdown_types.t
+  | Join_phase_mismatch of Keeper_shutdown_types.t
   | Join_record_update_failed of Keeper_shutdown_store.error
 
 val error_to_string : error -> string
@@ -47,9 +48,12 @@ val prepare_dormant :
   request:request ->
   (Keeper_shutdown_types.t, error) result
 
-(** Cancel and join the exact lane captured by [prepare]. Never call this
-    from that Keeper's admitted turn; lifecycle tools fork it on the server
-    switch after returning the accepted operation id. *)
+(** Cancel and join the exact Keeper lane captured by [prepare], and gracefully
+    drain its detached Librarian lane. [Prepared] begins the join. Re-entry with
+    [Joining_lanes] fails closed as durable [Blocked/Lane_join], because replaying
+    turn cancellation could erase a safety verdict that failed to persist.
+    Never call this from that Keeper's admitted turn; lifecycle tools fork it
+    on the server switch after returning the accepted operation id. *)
 val join_prepared :
   config:Workspace.config ->
   entry:Keeper_registry.registry_entry ->

--- a/lib/keeper/keeper_shutdown_runtime.ml
+++ b/lib/keeper/keeper_shutdown_runtime.ml
@@ -307,6 +307,7 @@ let finalize_if_ready ~config ~entry (operation : Keeper_shutdown_types.t) =
          (worker_key operation)
          (Keeper_shutdown_finalize.error_to_string error))
   | Prepared
+  | Joining_lanes
   | Reconciliation_required _
   | Blocked _
   | Superseded _ -> ()
@@ -314,7 +315,8 @@ let finalize_if_ready ~config ~entry (operation : Keeper_shutdown_types.t) =
 
 let run_worker ~config ~entry (operation : Keeper_shutdown_types.t) =
   match operation.phase with
-  | Prepared ->
+  | Prepared
+  | Joining_lanes ->
     (match entry with
      | None ->
        persist_unhandled_failure
@@ -509,6 +511,19 @@ let settled_reconciliation_state
   }
 ;;
 
+let blocked_interrupted_join_state (operation : Keeper_shutdown_types.t) =
+  { operation with
+    revision = operation.revision + 1
+  ; phase =
+      Blocked
+        { stage = Lane_join
+        ; detail =
+            "server process ended while joining Keeper and Librarian lanes; Librarian completion is unknown"
+        }
+  ; updated_at = Masc_domain.now_iso ()
+  }
+;;
+
 let recover_operation
     ~config
     ?successor_operation_id
@@ -527,6 +542,7 @@ let recover_operation
   let operation_result =
     match operation.phase with
     | Prepared -> persist_recovered (recovered_join_state operation)
+    | Joining_lanes -> persist_recovered (blocked_interrupted_join_state operation)
     | Reconciliation_required turn ->
       persist_recovered (settled_reconciliation_state operation turn)
     | Joined_idle
@@ -551,6 +567,7 @@ let recover_operation
          recovered
        |> Result.map_error Keeper_shutdown_finalize.error_to_string
      | Prepared
+     | Joining_lanes
      | Reconciliation_required _
      | Blocked _
      | Superseded _ -> Ok recovered)

--- a/lib/keeper/keeper_shutdown_store.ml
+++ b/lib/keeper/keeper_shutdown_store.ml
@@ -317,6 +317,7 @@ let cleanup_reason_to_json = function
 
 let phase_to_json = function
   | Prepared -> `Assoc [ "kind", `String "prepared" ]
+  | Joining_lanes -> `Assoc [ "kind", `String "joining_lanes" ]
   | Joined_idle -> `Assoc [ "kind", `String "joined_idle" ]
   | Finalizing_tasks settled_task_ids ->
     `Assoc
@@ -609,6 +610,7 @@ let phase_of_json json =
   let* kind = string "kind" json in
   match kind with
   | "prepared" -> Ok Prepared
+  | "joining_lanes" -> Ok Joining_lanes
   | "joined_idle" -> Ok Joined_idle
   | "finalizing_tasks" ->
     let* settled_task_ids = task_ids_field_of_json "settled_task_ids" json in
@@ -1043,7 +1045,8 @@ let persist_blocked_latest ~config ~identity ~failure ~now =
            (match existing.phase with
             | Finalized _ | Blocked _ | Reconciliation_required _ | Superseded _ ->
               Ok (State_preserved existing)
-            | Prepared | Joined_idle | Finalizing_tasks _ | Cleanup_ready _ ->
+            | Prepared | Joining_lanes | Joined_idle | Finalizing_tasks _
+            | Cleanup_ready _ ->
               let blocked =
                 { existing with
                   revision = existing.revision + 1

--- a/lib/keeper/keeper_shutdown_types.ml
+++ b/lib/keeper/keeper_shutdown_types.ml
@@ -149,6 +149,7 @@ type supersession =
 
 type phase =
   | Prepared
+  | Joining_lanes
   | Joined_idle
   | Finalizing_tasks of Keeper_id.Task_id.t list
   | Cleanup_ready of cleanup_evidence
@@ -202,6 +203,7 @@ let requires_admission_fence operation =
       { completion = (Completion_not_requested | Completion_delivered _); _ }
   | Superseded _ -> false
   | Prepared
+  | Joining_lanes
   | Joined_idle
   | Finalizing_tasks _
   | Cleanup_ready _
@@ -369,6 +371,7 @@ let validate operation =
          | Dashboard_keeper_purge _ ) as cleanup_reason ->
          Error (Superseded_cleanup_reason_mismatch cleanup_reason))
     | Prepared
+    | Joining_lanes
     | Joined_idle
     | Finalizing_tasks _
     | Cleanup_ready _

--- a/lib/keeper/keeper_shutdown_types.mli
+++ b/lib/keeper/keeper_shutdown_types.mli
@@ -143,6 +143,13 @@ type supersession =
 
 type phase =
   | Prepared
+  | Joining_lanes
+      (** The durable shutdown worker has committed its intent to join the
+          Keeper lane and its detached Librarian lane. This phase is visible
+          for the full cooperative wait; no implicit duration limit is added.
+          If the server process ends here, boot recovery preserves the
+          admission fence as [Blocked Lane_join] because Librarian completion
+          cannot be inferred from the process boundary. *)
   | Joined_idle
   | Finalizing_tasks of Keeper_id.Task_id.t list
   | Cleanup_ready of cleanup_evidence

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -258,7 +258,7 @@ let sweep_and_recover ~load_or_materialize_keeper_meta (ctx : _ context)
               ~base_path
               ~keeper_name:old_entry.name
               ~expected_generation:old_entry.transition_seq
-              ~register:(fun token ->
+              ~register:(fun token intake_token ->
                 match Keeper_registry.get ~base_path old_entry.name with
                 | Some current
                   when Keeper_lane.Id.equal
@@ -274,6 +274,7 @@ let sweep_and_recover ~load_or_materialize_keeper_meta (ctx : _ context)
                    | Ok _ ->
                      (match
                         Keeper_registry.register_restarting_for_lifecycle
+                          ~intake_token
                           token
                           ~base_path
                           old_entry.name
@@ -314,6 +315,23 @@ let sweep_and_recover ~load_or_materialize_keeper_meta (ctx : _ context)
                   meta
                   reg)
           with
+          | Error (Keeper_keepalive_launch_transaction.Shutdown_reserved operation_id) ->
+            Log.Keeper.warn
+              "%s: restart skipped because shutdown operation %s owns admission"
+              old_entry.name
+              (Keeper_shutdown_types.Operation_id.to_string operation_id);
+            Otel_metric_store.inc_counter
+              Keeper_metrics.(to_string RestartOutcomes)
+              ~labels:[ "keeper", old_entry.name; "outcome", "shutdown_reserved" ]
+              ()
+          | Error Keeper_keepalive_launch_transaction.Intake_token_not_live ->
+            Log.Keeper.error
+              "%s: restart transaction rejected an inactive durable-intake token"
+              old_entry.name;
+            Otel_metric_store.inc_counter
+              Keeper_metrics.(to_string RestartOutcomes)
+              ~labels:[ "keeper", old_entry.name; "outcome", "intake_token_not_live" ]
+              ()
           | Error (Keeper_keepalive_launch_transaction.Reservation_unavailable owner) ->
             Log.Keeper.info
               "%s: supervisor restart deferred to lifecycle transaction owner: %s"
@@ -329,6 +347,16 @@ let sweep_and_recover ~load_or_materialize_keeper_meta (ctx : _ context)
             Otel_metric_store.inc_counter
               Keeper_metrics.(to_string RestartOutcomes)
               ~labels:[ "keeper", old_entry.name; "outcome", "shutdown_reserved" ]
+              ()
+          | Error
+              (Keeper_keepalive_launch_transaction.Registration_failed
+                 (`Restart Keeper_registry.Restart_intake_token_not_live)) ->
+            Log.Keeper.error
+              "%s: restart registry rejected an inactive durable-intake token"
+              old_entry.name;
+            Otel_metric_store.inc_counter
+              Keeper_metrics.(to_string RestartOutcomes)
+              ~labels:[ "keeper", old_entry.name; "outcome", "intake_token_not_live" ]
               ()
           | Error
               (Keeper_keepalive_launch_transaction.Registration_failed
@@ -393,6 +421,23 @@ let sweep_and_recover ~load_or_materialize_keeper_meta (ctx : _ context)
             Otel_metric_store.inc_counter
               Keeper_metrics.(to_string RestartOutcomes)
               ~labels:[ "keeper", old_entry.name; "outcome", "librarian_deferred" ]
+              ()
+          | Error
+              (Keeper_keepalive_launch_transaction.Launch_failed
+                 { exception_detail; librarian_abort_error; rollback_error }) ->
+            let cleanup_detail label = function
+              | None -> ""
+              | Some detail -> "; " ^ label ^ " failed: " ^ detail
+            in
+            Log.Keeper.error
+              "%s: supervisor restart launch callback failed: %s%s%s"
+              old_entry.name
+              exception_detail
+              (cleanup_detail "Librarian abort" librarian_abort_error)
+              (cleanup_detail "registry rollback" rollback_error);
+            Otel_metric_store.inc_counter
+              Keeper_metrics.(to_string RestartOutcomes)
+              ~labels:[ "keeper", old_entry.name; "outcome", "launch_callback_failed" ]
               ()
           | Ok launch_result ->
             (match launch_result with

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -248,37 +248,80 @@ let sweep_and_recover ~load_or_materialize_keeper_meta (ctx : _ context)
               old_entry.name
               reason
           | Keeper_lifecycle_admission.Autonomous_admitted ->
-           (match
-              Keeper_memory_lane.begin_librarian_lifecycle
-                ~base_path
-                ~keeper_name:old_entry.name
-            with
-            | Error error ->
-              (* Keep the crashed registry entry claimable until the exact
-                 root-scoped Librarian owner exits. Registering [Restarting]
-                 first would strand a replacement behind the old drain fence. *)
-              Otel_metric_store.inc_counter
-                Keeper_metrics.(to_string RestartOutcomes)
-                ~labels:[ "keeper", old_entry.name; "outcome", "librarian_active" ]
-                ();
-              Log.Keeper.info
-                "%s: supervisor restart deferred until prior Librarian owner exits: %s"
-                old_entry.name
-                (Keeper_memory_lane.lifecycle_open_error_to_string error)
-            | Ok () ->
             Otel_metric_store.inc_counter
               Keeper_metrics.(to_string RestartAttempts)
               ~labels:[ "keeper", old_entry.name ]
               ();
-            (* Dispatch restart intent only after lifecycle admission. A
-               paused or tombstoned lane never enters the restarting FSM. *)
-            Keeper_registry.dispatch_event_unit
-              ~base_path
-              old_entry.name
-              (Keeper_state_machine.Supervisor_restart_attempt { attempt });
             let old_crash_log = old_entry.crash_log in
-         (match Keeper_registry.register_restarting ~base_path old_entry.name meta with
-          | Error (Keeper_registry.Restart_shutdown_reserved operation_id) ->
+         (match
+            Keeper_keepalive_launch_transaction.run
+              ~base_path
+              ~keeper_name:old_entry.name
+              ~expected_generation:old_entry.transition_seq
+              ~register:(fun token ->
+                match Keeper_registry.get ~base_path old_entry.name with
+                | Some current
+                  when Keeper_lane.Id.equal
+                         (Keeper_lane.id current.lane)
+                         (Keeper_lane.id old_entry.lane) ->
+                  (match
+                     Keeper_registry.dispatch_event_exact_for_lifecycle
+                       token
+                       old_entry
+                       (Keeper_state_machine.Supervisor_restart_attempt { attempt })
+                   with
+                   | Error error -> Error (`Transition error)
+                   | Ok _ ->
+                     (match
+                        Keeper_registry.register_restarting_for_lifecycle
+                          token
+                          ~base_path
+                          old_entry.name
+                          meta
+                      with
+                      | Ok registered -> Ok registered
+                      | Error error ->
+                        ignore
+                          (Keeper_registry.update_entry_exact_for_lifecycle
+                             token
+                             old_entry
+                             (fun _current -> old_entry)
+                            : Keeper_registry.exact_update_result);
+                        Error (`Restart error)))
+                | Some current -> Error (`Replaced current)
+                | None -> Error `Missing)
+              ~rollback:
+                (Keeper_keepalive_launch_transaction.rollback_restore_previous
+                   ~previous:old_entry)
+              (fun token reg ->
+                ignore
+                  (Keeper_registry.update_entry_exact_for_lifecycle
+                     token
+                     reg
+                     (fun current ->
+                        { current with
+                          restart_count = attempt
+                        ; last_restart_ts = now
+                        ; dead_since_ts = None
+                        ; crash_log = keep_last_n 5 (now, crash_msg) old_crash_log
+                        ; last_failure_reason = None
+                        })
+                    : Keeper_registry.exact_update_result);
+                launch_supervised_fiber
+                  ~lifecycle_token:token
+                  ~proactive_warmup_sec:0
+                  ctx
+                  meta
+                  reg)
+          with
+          | Error (Keeper_keepalive_launch_transaction.Reservation_unavailable owner) ->
+            Log.Keeper.info
+              "%s: supervisor restart deferred to lifecycle transaction owner: %s"
+              old_entry.name
+              (Keeper_lifecycle_reservation.snapshot_to_string owner)
+          | Error
+              (Keeper_keepalive_launch_transaction.Registration_failed
+                 (`Restart (Keeper_registry.Restart_shutdown_reserved operation_id))) ->
             Log.Keeper.warn
               "%s: restart skipped because shutdown operation %s owns admission"
               old_entry.name
@@ -287,12 +330,29 @@ let sweep_and_recover ~load_or_materialize_keeper_meta (ctx : _ context)
               Keeper_metrics.(to_string RestartOutcomes)
               ~labels:[ "keeper", old_entry.name; "outcome", "shutdown_reserved" ]
               ()
-          | Error (Keeper_registry.Restart_lifecycle_reserved owner) ->
+          | Error
+              (Keeper_keepalive_launch_transaction.Registration_failed
+                 (`Transition error)) ->
+            Log.Keeper.warn
+              "%s: supervisor restart intent was rejected: %s"
+              old_entry.name
+              (Keeper_state_machine.transition_error_to_string error);
+            Otel_metric_store.inc_counter
+              Keeper_metrics.(to_string RestartOutcomes)
+              ~labels:[ "keeper", old_entry.name; "outcome", "transition_rejected" ]
+              ()
+          | Error
+              (Keeper_keepalive_launch_transaction.Registration_failed
+                 (`Restart (Keeper_registry.Restart_lifecycle_reserved owner))) ->
             Log.Keeper.info
               "%s: supervisor restart deferred to lifecycle transaction owner: %s"
               old_entry.name
               (Keeper_lifecycle_reservation.snapshot_to_string owner)
-          | Error (Keeper_registry.Restart_event_queue_unavailable { keeper_name; detail }) ->
+          | Error
+              (Keeper_keepalive_launch_transaction.Registration_failed
+                 (`Restart
+                    (Keeper_registry.Restart_event_queue_unavailable
+                       { keeper_name; detail }))) ->
             Log.Keeper.error
               "%s: restart refused because durable event queue is unavailable: %s"
               keeper_name
@@ -301,14 +361,41 @@ let sweep_and_recover ~load_or_materialize_keeper_meta (ctx : _ context)
               Keeper_metrics.(to_string RestartOutcomes)
               ~labels:[ "keeper", keeper_name; "outcome", "event_queue_unavailable" ]
               ()
-          | Ok reg ->
-            Keeper_registry.restore_supervisor_state
-              ~base_path
+          | Error
+              (Keeper_keepalive_launch_transaction.Registration_failed
+                 (`Replaced current)) ->
+            Log.Keeper.info
+              "%s: supervisor restart retained newer lane phase=%s"
               old_entry.name
-              ~restart_count:attempt
-              ~last_restart_ts:now
-              ~crash_log:(keep_last_n 5 (now, crash_msg) old_crash_log);
-            (match launch_supervised_fiber ~proactive_warmup_sec:0 ctx meta reg with
+              (Keeper_state_machine.phase_to_string current.Keeper_registry.phase)
+          | Error
+              (Keeper_keepalive_launch_transaction.Registration_failed `Missing) ->
+            Log.Keeper.info
+              "%s: supervisor restart deferred because crashed lane disappeared"
+              old_entry.name
+          | Error
+              (Keeper_keepalive_launch_transaction.Lifecycle_open_failed
+                 { error; rollback_error }) ->
+            Log.Keeper.warn
+              "%s: supervisor restart deferred until Librarian owner exits: %s%s"
+              old_entry.name
+              (Keeper_memory_lane.lifecycle_open_error_to_string error)
+              (match rollback_error with
+               | None -> ""
+               | Some detail -> "; rollback failed: " ^ detail);
+            ignore
+              (Keeper_memory_lane.abort_librarian
+                 ~base_path
+                 ~keeper_name:old_entry.name
+                : (Keeper_memory_lane.librarian_abort_outcome,
+                   Keeper_memory_lane.librarian_abort_error)
+                    result);
+            Otel_metric_store.inc_counter
+              Keeper_metrics.(to_string RestartOutcomes)
+              ~labels:[ "keeper", old_entry.name; "outcome", "librarian_deferred" ]
+              ()
+          | Ok launch_result ->
+            (match launch_result with
              | Error _ ->
                (* Launch gate aborted fail-closed (no fiber; done resolved and
                   Crashed published by the gate). Announcing Restarted/Running
@@ -333,7 +420,7 @@ let sweep_and_recover ~load_or_materialize_keeper_meta (ctx : _ context)
                  ~labels:[ "keeper", old_entry.name; "outcome", "started" ]
                  ();
                Log.Keeper.info "%s: restarted (attempt %d)" old_entry.name attempt);
-            )))
+            ))
        | _ ->
          Otel_metric_store.inc_counter
            Keeper_metrics.(to_string RestartOutcomes)

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -248,25 +248,6 @@ let sweep_and_recover ~load_or_materialize_keeper_meta (ctx : _ context)
               old_entry.name
               reason
           | Keeper_lifecycle_admission.Autonomous_admitted ->
-           (match
-              Keeper_memory_lane.begin_librarian_lifecycle
-                ~base_path
-                ~keeper_name:old_entry.name
-            with
-            | Error error ->
-              (* Crash cleanup fences and requests cancellation without joining
-                 root-scoped provider work. Do not publish a replacement Keeper
-                 until that exact Librarian owner has exited; the next sweep
-                 retries this admission boundary. *)
-              Otel_metric_store.inc_counter
-                Keeper_metrics.(to_string RestartOutcomes)
-                ~labels:[ "keeper", old_entry.name; "outcome", "librarian_active" ]
-                ();
-              Log.Keeper.info
-                "%s: supervisor restart deferred until prior Librarian owner exits: %s"
-                old_entry.name
-                (Keeper_memory_lane.lifecycle_open_error_to_string error)
-            | Ok () ->
             Otel_metric_store.inc_counter
               Keeper_metrics.(to_string RestartAttempts)
               ~labels:[ "keeper", old_entry.name ]
@@ -334,7 +315,7 @@ let sweep_and_recover ~load_or_materialize_keeper_meta (ctx : _ context)
                  ~labels:[ "keeper", old_entry.name; "outcome", "started" ]
                  ();
                Log.Keeper.info "%s: restarted (attempt %d)" old_entry.name attempt);
-            )))
+            ))
        | _ ->
          Otel_metric_store.inc_counter
            Keeper_metrics.(to_string RestartOutcomes)

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -248,6 +248,24 @@ let sweep_and_recover ~load_or_materialize_keeper_meta (ctx : _ context)
               old_entry.name
               reason
           | Keeper_lifecycle_admission.Autonomous_admitted ->
+           (match
+              Keeper_memory_lane.begin_librarian_lifecycle
+                ~base_path
+                ~keeper_name:old_entry.name
+            with
+            | Error error ->
+              (* Keep the crashed registry entry claimable until the exact
+                 root-scoped Librarian owner exits. Registering [Restarting]
+                 first would strand a replacement behind the old drain fence. *)
+              Otel_metric_store.inc_counter
+                Keeper_metrics.(to_string RestartOutcomes)
+                ~labels:[ "keeper", old_entry.name; "outcome", "librarian_active" ]
+                ();
+              Log.Keeper.info
+                "%s: supervisor restart deferred until prior Librarian owner exits: %s"
+                old_entry.name
+                (Keeper_memory_lane.lifecycle_open_error_to_string error)
+            | Ok () ->
             Otel_metric_store.inc_counter
               Keeper_metrics.(to_string RestartAttempts)
               ~labels:[ "keeper", old_entry.name ]
@@ -315,7 +333,7 @@ let sweep_and_recover ~load_or_materialize_keeper_meta (ctx : _ context)
                  ~labels:[ "keeper", old_entry.name; "outcome", "started" ]
                  ();
                Log.Keeper.info "%s: restarted (attempt %d)" old_entry.name attempt);
-            ))
+            )))
        | _ ->
          Otel_metric_store.inc_counter
            Keeper_metrics.(to_string RestartOutcomes)

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -291,9 +291,8 @@ let sweep_and_recover ~load_or_materialize_keeper_meta (ctx : _ context)
                 | Some current -> Error (`Replaced current)
                 | None -> Error `Missing)
               ~rollback:
-                (Keeper_keepalive_launch_transaction.rollback_restore_previous
-                   ~previous:old_entry)
-              (fun token reg ->
+                (Keeper_keepalive_launch_transaction.Restore_previous old_entry)
+              (fun intake_token token reg ->
                 ignore
                   (Keeper_registry.update_entry_exact_for_lifecycle
                      token
@@ -308,6 +307,7 @@ let sweep_and_recover ~load_or_materialize_keeper_meta (ctx : _ context)
                         })
                     : Keeper_registry.exact_update_result);
                 launch_supervised_fiber
+                  ~intake_token
                   ~lifecycle_token:token
                   ~proactive_warmup_sec:0
                   ctx

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -248,6 +248,25 @@ let sweep_and_recover ~load_or_materialize_keeper_meta (ctx : _ context)
               old_entry.name
               reason
           | Keeper_lifecycle_admission.Autonomous_admitted ->
+           (match
+              Keeper_memory_lane.begin_librarian_lifecycle
+                ~base_path
+                ~keeper_name:old_entry.name
+            with
+            | Error error ->
+              (* Crash cleanup fences and requests cancellation without joining
+                 root-scoped provider work. Do not publish a replacement Keeper
+                 until that exact Librarian owner has exited; the next sweep
+                 retries this admission boundary. *)
+              Otel_metric_store.inc_counter
+                Keeper_metrics.(to_string RestartOutcomes)
+                ~labels:[ "keeper", old_entry.name; "outcome", "librarian_active" ]
+                ();
+              Log.Keeper.info
+                "%s: supervisor restart deferred until prior Librarian owner exits: %s"
+                old_entry.name
+                (Keeper_memory_lane.lifecycle_open_error_to_string error)
+            | Ok () ->
             Otel_metric_store.inc_counter
               Keeper_metrics.(to_string RestartAttempts)
               ~labels:[ "keeper", old_entry.name ]
@@ -315,7 +334,7 @@ let sweep_and_recover ~load_or_materialize_keeper_meta (ctx : _ context)
                  ~labels:[ "keeper", old_entry.name; "outcome", "started" ]
                  ();
                Log.Keeper.info "%s: restarted (attempt %d)" old_entry.name attempt);
-            ))
+            )))
        | _ ->
          Otel_metric_store.inc_counter
            Keeper_metrics.(to_string RestartOutcomes)

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -61,6 +61,7 @@ let restart_launch_noop_enabled_for_test = Keeper_supervisor_restart_noop.enable
 let with_restart_launch_noop_for_test = Keeper_supervisor_restart_noop.with_noop
 
 let launch_supervised_fiber_body
+      ~lifecycle_token
       ~proactive_warmup_sec
       ctx
       (meta : keeper_meta)
@@ -71,6 +72,18 @@ let launch_supervised_fiber_body
   if restart_launch_noop_enabled_for_test ()
   then (* test no-op launch: nothing forked, but not a fork rejection *) Ok ()
   else (
+    let lifecycle_result = Atomic.make None in
+    let finish_lifecycle boundary terminalize =
+      let result =
+        Keeper_keepalive_launch_transaction.finish_lifecycle
+          ~boundary
+          ~base_path
+          ~keeper_name:meta.name
+          ~terminalize
+      in
+      Atomic.set lifecycle_result (Some result);
+      result
+    in
     (* Task 137: Inject bootstrap signal to ensure at least one warm-up turn runs
      and break the initial proactive deadlock. *)
     let bootstrap_signal : Keeper_event_queue.stimulus =
@@ -81,69 +94,19 @@ let launch_supervised_fiber_body
       }
     in
     Keeper_registry_event_queue.enqueue ~base_path meta.name bootstrap_signal;
-    let librarian_settlement_started = Atomic.make false in
-    let librarian_settlement_result = Atomic.make None in
-    let settle_librarian ~graceful =
-      if Atomic.compare_and_set librarian_settlement_started false true
-      then (
-        let result =
-          Eio.Cancel.protect (fun () ->
-            try
-              if graceful
-              then
-                match
-                  Keeper_memory_lane.drain_and_join_librarian
-                    ~base_path
-                    ~keeper_name:meta.name
-                with
-                | Ok Keeper_memory_lane.No_librarian_work
-                | Ok Keeper_memory_lane.Librarian_drained -> Ok ()
-                | Error error ->
-                  Error (Keeper_memory_lane.librarian_drain_error_to_string error)
-              else
-                match
-                  Keeper_memory_lane.abort_librarian
-                    ~base_path
-                    ~keeper_name:meta.name
-                with
-                | Ok Keeper_memory_lane.Librarian_abort_idle
-                | Ok Keeper_memory_lane.Librarian_abort_requested
-                | Ok Keeper_memory_lane.Librarian_abort_already_in_progress
-                | Ok (Keeper_memory_lane.Librarian_abort_already_exited _) -> Ok ()
-                | Ok (Keeper_memory_lane.Librarian_abort_committed_with_failure exn) ->
-                  Error
-                    ("Librarian cancellation committed with callback failure: "
-                     ^ Printexc.to_string exn)
-                | Error error ->
-                  Error (Keeper_memory_lane.librarian_abort_error_to_string error)
-            with
-            | exn -> Error (Printexc.to_string exn))
-        in
-        Atomic.set librarian_settlement_result (Some result);
-        result)
-      else
-        match Atomic.get librarian_settlement_result with
-        | Some result -> result
-        | None -> Error "Librarian settlement is still in progress"
-    in
     let fork_body body =
       match
         Keeper_lane.fork
           ~sw:ctx.sw
           reg.lane
           ~run:body
-          ~cleanup:(fun outcome ->
-            let graceful =
-              match outcome with
-              | Keeper_lane.Completed
-              | Keeper_lane.Shutdown_before_start
-              | Keeper_lane.Shutdown_requested -> true
-              | Keeper_lane.Cancelled_by_parent _ ->
-                Atomic.get reg.fiber_stop || Shutdown.is_shutting_down_global ()
-              | Keeper_lane.Shutdown_cancel_failed _
-              | Keeper_lane.Failed _ -> false
-            in
-            settle_librarian ~graceful)
+          ~cleanup:(fun _ ->
+            match Atomic.get lifecycle_result with
+            | Some result -> result
+            | None ->
+              finish_lifecycle
+                Keeper_keepalive_launch_transaction.Unexpected
+                (fun () -> Error "supervisor lane exited without terminal disposition"))
       with
       | Ok () -> Ok ()
       | Error error ->
@@ -167,16 +130,21 @@ let launch_supervised_fiber_body
         if owns_terminal_signal
         then (
           let _failure_reason_recorded =
-            Keeper_registry.set_failure_reason_exact
+            Keeper_registry.update_entry_exact_for_lifecycle
+              lifecycle_token
               reg
-              (Some (Keeper_registry.Exception detail))
+              (fun current ->
+                { current with
+                  last_failure_reason = Some (Keeper_registry.Exception detail)
+                })
             |> Keeper_registry.exact_update_succeeded
                  reg
                  ~site:"supervisor_lane_start_rejected.failure_reason"
           in
           let terminalized =
             match
-              Keeper_registry.dispatch_event_exact
+              Keeper_registry.dispatch_event_exact_for_lifecycle
+                lifecycle_token
                 reg
                 (Keeper_state_machine.Fiber_terminated
                    { outcome = detail; provider_id = None; http_status = None })
@@ -193,15 +161,22 @@ let launch_supervised_fiber_body
               false
           in
           let _crash_recorded =
-            Keeper_registry.record_crash_exact
+            Keeper_registry.update_entry_exact_for_lifecycle
+              lifecycle_token
               reg
-              (Time_compat.now ())
-              detail
+              (fun current ->
+                Keeper_registry_error_tracking.record_crash_entry
+                  current
+                  (Time_compat.now ())
+                  detail)
             |> Keeper_registry.exact_update_succeeded
                  reg
                  ~site:"supervisor_lane_start_rejected.crash_log"
           in
-          Keeper_registry_error_recording.record_exact reg detail;
+          Keeper_registry_error_recording.record_exact_for_lifecycle
+            lifecycle_token
+            reg
+            detail;
           if terminalized
           then
             publish_phase_lifecycle
@@ -210,7 +185,9 @@ let launch_supervised_fiber_body
               detail
               ()
           else
-            match Keeper_registry.unregister_exact reg with
+            match
+              Keeper_registry.unregister_exact_for_lifecycle lifecycle_token reg
+            with
             | Keeper_registry.Exact_unregistered ->
               Log.Keeper.error
                 "supervisor: removed non-terminalizable fork-rejected lane name=%s"
@@ -291,7 +268,7 @@ let launch_supervised_fiber_body
                ~finally:stop_board_worker;
              (* A normal return is an explicit stop/shutdown path. Observed
                 idle/progress ages never rewrite it into a crash. *)
-               ignore (settle_librarian ~graceful:true : (unit, string) result);
+             let terminalize_normal () =
                (match
                   Keeper_registry.dispatch_event
                     ~base_path
@@ -330,7 +307,14 @@ let launch_supervised_fiber_body
                    ~phase:Keeper_state_machine.Stopped
                    meta.name
                    "normal exit"
-                   ()
+                   ();
+               Ok ()
+             in
+             ignore
+               (finish_lifecycle
+                  Keeper_keepalive_launch_transaction.Graceful
+                  terminalize_normal
+                : (unit, string) result)
            with
            | Eio.Cancel.Cancelled cause ->
              (match Keeper_lane.classify_cancellation_cause cause with
@@ -344,6 +328,7 @@ let launch_supervised_fiber_body
                 Keeper_fiber_crash carries no payload — failure_reason is
                 pre-stored in registry by the raise site.
                 For unexpected exceptions, wrap in Exception variant. *)
+             let terminalize_crash () =
              let fr =
                match exn with
                | Keeper_registry.Keeper_fiber_crash ->
@@ -357,7 +342,6 @@ let launch_supervised_fiber_body
 	             in
 	             let reason = Keeper_registry.failure_reason_to_string fr in
 	             let outcome = reason in
-	             ignore (settle_librarian ~graceful:false : (unit, string) result);
 	             Keeper_registry.set_failure_reason ~base_path meta.name (Some fr);
 	             (match
 	                Keeper_registry.dispatch_event
@@ -396,7 +380,14 @@ let launch_supervised_fiber_body
                  ~phase:Keeper_state_machine.Crashed
                  meta.name
                  reason
-                 ())
+                 ();
+             Ok ()
+             in
+             ignore
+               (finish_lifecycle
+                  Keeper_keepalive_launch_transaction.Unexpected
+                  terminalize_crash
+                : (unit, string) result))
         ~finally:(fun () ->
           (* Finally runs best-effort. Any exception raised here (including
            Eio.Cancel.Cancelled, which propagates during concurrent fiber
@@ -409,10 +400,17 @@ let launch_supervised_fiber_body
             Keeper_registry.cleanup_tracking ~base_path meta.name;
             Keeper_turn_attempt_observer.reset_keeper ~base_path ~keeper:meta.name;
             if not (Atomic.get resolved)
-            then
+            then (
+              let boundary =
+                if
+                  Shutdown.is_shutting_down_global ()
+                  || Atomic.get cancelled_by_shutdown_request
+                then Keeper_keepalive_launch_transaction.Graceful
+                else Keeper_keepalive_launch_transaction.Unexpected
+              in
+              let terminalize_unresolved () =
               if Shutdown.is_shutting_down_global ()
               then (
-                ignore (settle_librarian ~graceful:true : (unit, string) result);
                 (* Issue #18901: graceful-shutdown branch. Tag the failure
                    reason with [Graceful_shutdown] cause so the cohort
                    key splits away from the legacy "fiber_unresolved"
@@ -439,7 +437,6 @@ let launch_supervised_fiber_body
                      (`Crashed "shutdown")))
               else if Atomic.get cancelled_by_shutdown_request
               then (
-                ignore (settle_librarian ~graceful:true : (unit, string) result);
                 (* Exact exception identity distinguishes an operator lane
                    shutdown from parent cancellation. A requested shutdown is
                    a graceful stop, so the operator observes a joined stop
@@ -488,7 +485,6 @@ let launch_supervised_fiber_body
                     ())
               else if Atomic.get cancelled_by_parent
               then (
-                ignore (settle_librarian ~graceful:false : (unit, string) result);
                 (* Issue #18901 follow-up: parent-cancel branch. The
                    body's try/with caught [Eio.Cancel.Cancelled] and set
                    the flag before re-raising. Shutdown was not in
@@ -518,8 +514,7 @@ let launch_supervised_fiber_body
                      ~source:"supervisor_parent_cancel_cleanup"
                      (`Crashed "cancelled_by_parent")))
               else (
-	                ignore (settle_librarian ~graceful:false : (unit, string) result);
-		                let reason =
+	                let reason =
 	                  Keeper_registry.failure_reason_to_string
 	                    (Keeper_registry.Fiber_unresolved Unexpected)
 	                in
@@ -588,7 +583,12 @@ let launch_supervised_fiber_body
                     ~phase:Keeper_state_machine.Crashed
                     meta.name
                     reason
-                    ()))
+                    ());
+                Ok ()
+              in
+              ignore
+                (finish_lifecycle boundary terminalize_unresolved
+                  : (unit, string) result)))
           with
           | Cleanup_completed -> ()
           | Cleanup_cancelled ->
@@ -624,13 +624,14 @@ let launch_supervised_fiber_body
     case nothing was forked, no [Started]/[Running] event may be published
     by the caller, and [done_p] has been resolved through the crash path. *)
 let launch_supervised_fiber
+      ~lifecycle_token
       ~proactive_warmup_sec
       ctx
       (meta : keeper_meta)
       (reg : Keeper_registry.registry_entry)
   =
   let base_path = ctx.config.base_path in
-  match Keeper_registry.prepare_fiber_launch ~base_path meta.name with
+  match Keeper_registry.prepare_fiber_launch_for_lifecycle lifecycle_token reg with
   | Error err ->
     (* Fail closed: a rejected [Fiber_started] (terminal state, invalid
        transition, precondition violation) means the registry refuses a
@@ -678,7 +679,12 @@ let launch_supervised_fiber
     (* Propagate the fork outcome: a rejected [Keeper_lane.fork] returns
        [Error] here so the caller suppresses the Started/Running lifecycle
        for a keeper whose lane was never forked. *)
-    launch_supervised_fiber_body ~proactive_warmup_sec ctx meta reg
+    launch_supervised_fiber_body
+      ~lifecycle_token
+      ~proactive_warmup_sec
+      ctx
+      meta
+      reg
 ;;
 
 let supervise_keepalive ~proactive_warmup_sec (ctx : _ context) (meta : keeper_meta) =

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -626,11 +626,10 @@ let launch_supervised_fiber_body
 let launch_supervised_fiber
       ~lifecycle_token
       ~proactive_warmup_sec
-      ctx
-      (meta : keeper_meta)
-      (reg : Keeper_registry.registry_entry)
+  ctx
+  (meta : keeper_meta)
+  (reg : Keeper_registry.registry_entry)
   =
-  let base_path = ctx.config.base_path in
   match Keeper_registry.prepare_fiber_launch_for_lifecycle lifecycle_token reg with
   | Error err ->
     (* Fail closed: a rejected [Fiber_started] (terminal state, invalid

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -660,12 +660,33 @@ let launch_supervised_fiber
         ; ("site", Keeper_supervisor_cleanup_failure_site.(to_label Fiber_start_rejected))
         ]
       ();
-    Keeper_registry.set_failure_reason
-      ~base_path
-      meta.name
-      (Some (Keeper_registry.Exception reason));
-    Keeper_registry.record_crash ~base_path meta.name (Time_compat.now ()) reason;
-    Keeper_registry_error_recording.record ~base_path meta.name reason;
+    ignore
+      (Keeper_registry.update_entry_exact_for_lifecycle
+         lifecycle_token
+         reg
+         (fun current ->
+            { current with
+              last_failure_reason = Some (Keeper_registry.Exception reason)
+            })
+       |> Keeper_registry.exact_update_succeeded
+            reg
+            ~site:"supervisor_launch_rejected.failure_reason");
+    ignore
+      (Keeper_registry.update_entry_exact_for_lifecycle
+         lifecycle_token
+         reg
+         (fun current ->
+            Keeper_registry_error_tracking.record_crash_entry
+              current
+              (Time_compat.now ())
+              reason)
+       |> Keeper_registry.exact_update_succeeded
+            reg
+            ~site:"supervisor_launch_rejected.crash_log");
+    Keeper_registry_error_recording.record_exact_for_lifecycle
+      lifecycle_token
+      reg
+      reason;
     if
       Keeper_registry.resolve_done reg ~source:"supervisor_launch_rejected" (`Crashed reason)
       |> done_signal_of_registry_result

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -81,13 +81,69 @@ let launch_supervised_fiber_body
       }
     in
     Keeper_registry_event_queue.enqueue ~base_path meta.name bootstrap_signal;
+    let librarian_settlement_started = Atomic.make false in
+    let librarian_settlement_result = Atomic.make None in
+    let settle_librarian ~graceful =
+      if Atomic.compare_and_set librarian_settlement_started false true
+      then (
+        let result =
+          Eio.Cancel.protect (fun () ->
+            try
+              if graceful
+              then
+                match
+                  Keeper_memory_lane.drain_and_join_librarian
+                    ~base_path
+                    ~keeper_name:meta.name
+                with
+                | Ok Keeper_memory_lane.No_librarian_work
+                | Ok Keeper_memory_lane.Librarian_drained -> Ok ()
+                | Error error ->
+                  Error (Keeper_memory_lane.librarian_drain_error_to_string error)
+              else
+                match
+                  Keeper_memory_lane.abort_librarian
+                    ~base_path
+                    ~keeper_name:meta.name
+                with
+                | Ok Keeper_memory_lane.Librarian_abort_idle
+                | Ok Keeper_memory_lane.Librarian_abort_requested
+                | Ok Keeper_memory_lane.Librarian_abort_already_in_progress
+                | Ok (Keeper_memory_lane.Librarian_abort_already_exited _) -> Ok ()
+                | Ok (Keeper_memory_lane.Librarian_abort_committed_with_failure exn) ->
+                  Error
+                    ("Librarian cancellation committed with callback failure: "
+                     ^ Printexc.to_string exn)
+                | Error error ->
+                  Error (Keeper_memory_lane.librarian_abort_error_to_string error)
+            with
+            | exn -> Error (Printexc.to_string exn))
+        in
+        Atomic.set librarian_settlement_result (Some result);
+        result)
+      else
+        match Atomic.get librarian_settlement_result with
+        | Some result -> result
+        | None -> Error "Librarian settlement is still in progress"
+    in
     let fork_body body =
       match
         Keeper_lane.fork
           ~sw:ctx.sw
           reg.lane
           ~run:body
-          ~cleanup:(fun _ -> Ok ())
+          ~cleanup:(fun outcome ->
+            let graceful =
+              match outcome with
+              | Keeper_lane.Completed
+              | Keeper_lane.Shutdown_before_start
+              | Keeper_lane.Shutdown_requested -> true
+              | Keeper_lane.Cancelled_by_parent _ ->
+                Atomic.get reg.fiber_stop || Shutdown.is_shutting_down_global ()
+              | Keeper_lane.Shutdown_cancel_failed _
+              | Keeper_lane.Failed _ -> false
+            in
+            settle_librarian ~graceful)
       with
       | Ok () -> Ok ()
       | Error error ->
@@ -235,6 +291,7 @@ let launch_supervised_fiber_body
                ~finally:stop_board_worker;
              (* A normal return is an explicit stop/shutdown path. Observed
                 idle/progress ages never rewrite it into a crash. *)
+               ignore (settle_librarian ~graceful:true : (unit, string) result);
                (match
                   Keeper_registry.dispatch_event
                     ~base_path
@@ -300,6 +357,7 @@ let launch_supervised_fiber_body
 	             in
 	             let reason = Keeper_registry.failure_reason_to_string fr in
 	             let outcome = reason in
+	             ignore (settle_librarian ~graceful:false : (unit, string) result);
 	             Keeper_registry.set_failure_reason ~base_path meta.name (Some fr);
 	             (match
 	                Keeper_registry.dispatch_event
@@ -354,6 +412,7 @@ let launch_supervised_fiber_body
             then
               if Shutdown.is_shutting_down_global ()
               then (
+                ignore (settle_librarian ~graceful:true : (unit, string) result);
                 (* Issue #18901: graceful-shutdown branch. Tag the failure
                    reason with [Graceful_shutdown] cause so the cohort
                    key splits away from the legacy "fiber_unresolved"
@@ -380,6 +439,7 @@ let launch_supervised_fiber_body
                      (`Crashed "shutdown")))
               else if Atomic.get cancelled_by_shutdown_request
               then (
+                ignore (settle_librarian ~graceful:true : (unit, string) result);
                 (* Exact exception identity distinguishes an operator lane
                    shutdown from parent cancellation. A requested shutdown is
                    a graceful stop, so the operator observes a joined stop
@@ -428,6 +488,7 @@ let launch_supervised_fiber_body
                     ())
               else if Atomic.get cancelled_by_parent
               then (
+                ignore (settle_librarian ~graceful:false : (unit, string) result);
                 (* Issue #18901 follow-up: parent-cancel branch. The
                    body's try/with caught [Eio.Cancel.Cancelled] and set
                    the flag before re-raising. Shutdown was not in
@@ -457,7 +518,8 @@ let launch_supervised_fiber_body
                      ~source:"supervisor_parent_cancel_cleanup"
                      (`Crashed "cancelled_by_parent")))
               else (
-	                let reason =
+	                ignore (settle_librarian ~graceful:false : (unit, string) result);
+		                let reason =
 	                  Keeper_registry.failure_reason_to_string
 	                    (Keeper_registry.Fiber_unresolved Unexpected)
 	                in

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -61,6 +61,7 @@ let restart_launch_noop_enabled_for_test = Keeper_supervisor_restart_noop.enable
 let with_restart_launch_noop_for_test = Keeper_supervisor_restart_noop.with_noop
 
 let launch_supervised_fiber_body
+      ?intake_token
       ~lifecycle_token
       ~proactive_warmup_sec
       ctx
@@ -93,7 +94,11 @@ let launch_supervised_fiber_body
       ; payload = Keeper_event_queue.Bootstrap
       }
     in
-    Keeper_registry_event_queue.enqueue ~base_path meta.name bootstrap_signal;
+    Keeper_registry_event_queue.enqueue
+      ?intake_token
+      ~base_path
+      meta.name
+      bootstrap_signal;
     let fork_body body =
       match
         Keeper_lane.fork
@@ -624,6 +629,7 @@ let launch_supervised_fiber_body
     case nothing was forked, no [Started]/[Running] event may be published
     by the caller, and [done_p] has been resolved through the crash path. *)
 let launch_supervised_fiber
+      ?intake_token
       ~lifecycle_token
       ~proactive_warmup_sec
   ctx
@@ -679,6 +685,7 @@ let launch_supervised_fiber
        [Error] here so the caller suppresses the Started/Running lifecycle
        for a keeper whose lane was never forked. *)
     launch_supervised_fiber_body
+      ?intake_token
       ~lifecycle_token
       ~proactive_warmup_sec
       ctx
@@ -689,7 +696,8 @@ let launch_supervised_fiber
 let supervise_keepalive ~proactive_warmup_sec (ctx : _ context) (meta : keeper_meta) =
   Keeper_supervisor_supervise_keepalive.supervise_keepalive
     ~publish_lifecycle
-    ~launch_supervised_fiber
+    ~launch_supervised_fiber:(fun ~intake_token ->
+      launch_supervised_fiber ~intake_token)
     ~proactive_warmup_sec
     ctx
     meta

--- a/lib/keeper/keeper_supervisor_supervise_keepalive.ml
+++ b/lib/keeper/keeper_supervisor_supervise_keepalive.ml
@@ -53,6 +53,7 @@ let supervise_keepalive
          event:Keeper_lifecycle_events.lifecycle_event ->
          string -> string -> unit -> unit)
       ~(launch_supervised_fiber :
+         intake_token:Keeper_shutdown_intake_fence.intake_token ->
          lifecycle_token:Keeper_lifecycle_reservation.token ->
          proactive_warmup_sec:int ->
          _ context ->
@@ -114,7 +115,7 @@ let supervise_keepalive
         meta.name
         (Keeper_owner_registry.command_error_to_string error)
   in
-  let launch_registered lifecycle_token reg =
+  let launch_registered intake_token lifecycle_token reg =
     (try
        if not (Workspace_utils.is_initialized ctx.config)
        then (
@@ -130,6 +131,7 @@ let supervise_keepalive
        Log.Keeper.error "supervisor workspace init failed: %s" (Printexc.to_string exn));
     match
       launch_supervised_fiber
+        ~intake_token
         ~lifecycle_token
         ~proactive_warmup_sec
         ctx
@@ -139,15 +141,25 @@ let supervise_keepalive
     | Error _ -> ()
     | Ok () ->
       wake_queued_owner_operations ();
-      publish_lifecycle
-        ~event:
-          (Keeper_lifecycle_events.Custom_event
-             { verb = Keeper_lifecycle_events.Started
-             ; phase = Some Keeper_state_machine.Running
-             })
-        meta.name
-        "supervised"
-        ()
+      (try
+         publish_lifecycle
+           ~event:
+             (Keeper_lifecycle_events.Custom_event
+                { verb = Keeper_lifecycle_events.Started
+                ; phase = Some Keeper_state_machine.Running
+                })
+           meta.name
+           "supervised"
+           ()
+       with
+       | exn ->
+         (* The lane crossed its start boundary successfully. Observation
+            failure must not escape into launch rollback and detach it from
+            the registry. *)
+         Log.Keeper.error
+           "supervisor launch lifecycle publication failed keeper=%s: %s"
+           meta.name
+           (Printexc.to_string exn))
   in
   let log_transaction_error = function
     | Keeper_keepalive_launch_transaction.Reservation_unavailable owner ->
@@ -229,7 +241,7 @@ let supervise_keepalive
             meta.name
             meta
           |> Result.map_error (fun error -> `Registration error))
-      ~rollback:Keeper_keepalive_launch_transaction.rollback_remove_registered
+      ~rollback:Keeper_keepalive_launch_transaction.Remove_registered
   in
   match execution_truth with
   | Keeper_activation_readiness.Unknown detail ->
@@ -277,7 +289,7 @@ let supervise_keepalive
                 Ok current
               | Some current -> Error (`Occupied current)
               | None -> Error (`Occupied reg))
-            ~rollback:Keeper_keepalive_launch_transaction.rollback_retain_registered
+            ~rollback:Keeper_keepalive_launch_transaction.Retain_registered
         | Keeper_state_machine.Running
         | Keeper_state_machine.Failing
         | Keeper_state_machine.Overflowed

--- a/lib/keeper/keeper_supervisor_supervise_keepalive.ml
+++ b/lib/keeper/keeper_supervisor_supervise_keepalive.ml
@@ -38,6 +38,7 @@ let supervise_keepalive
          event:Keeper_lifecycle_events.lifecycle_event ->
          string -> string -> unit -> unit)
       ~(launch_supervised_fiber :
+         lifecycle_token:Keeper_lifecycle_reservation.token ->
          proactive_warmup_sec:int ->
          _ context ->
          keeper_meta ->
@@ -98,80 +99,122 @@ let supervise_keepalive
         meta.name
         (Keeper_owner_registry.command_error_to_string error)
   in
-  let librarian_lifecycle_ready () =
-    match Keeper_memory_lane.begin_librarian_lifecycle ~base_path ~keeper_name:meta.name with
-    | Error error ->
-      Log.Keeper.info
-        "supervisor launch deferred until prior Librarian owner exits keeper=%s error=%s"
+  let launch_registered lifecycle_token reg =
+    (try
+       if not (Workspace_utils.is_initialized ctx.config)
+       then (
+         let (_init_msg : string) = Workspace.init ctx.config ~agent_name:None in
+         ())
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn ->
+       Otel_metric_store.inc_counter
+         Keeper_metrics.(to_string WorkspaceInitFailures)
+         ~labels:[ "keeper", meta.name ]
+         ();
+       Log.Keeper.error "supervisor workspace init failed: %s" (Printexc.to_string exn));
+    match
+      launch_supervised_fiber
+        ~lifecycle_token
+        ~proactive_warmup_sec
+        ctx
+        meta
+        reg
+    with
+    | Error _ -> ()
+    | Ok () ->
+      wake_queued_owner_operations ();
+      publish_lifecycle
+        ~event:
+          (Keeper_lifecycle_events.Custom_event
+             { verb = Keeper_lifecycle_events.Started
+             ; phase = Some Keeper_state_machine.Running
+             })
         meta.name
-        (Keeper_memory_lane.lifecycle_open_error_to_string error);
-      false
-    | Ok () -> true
+        "supervised"
+        ()
   in
-  let launch_registered reg =
-    if librarian_lifecycle_ready ()
-    then (
-      (try
-         if not (Workspace_utils.is_initialized ctx.config)
-         then (
-           let (_init_msg : string) = Workspace.init ctx.config ~agent_name:None in
-           ())
-       with
-       | Eio.Cancel.Cancelled _ as e -> raise e
-       | exn ->
-         Otel_metric_store.inc_counter
-           Keeper_metrics.(to_string WorkspaceInitFailures)
-           ~labels:[ "keeper", meta.name ]
-           ();
-         Log.Keeper.error "supervisor workspace init failed: %s" (Printexc.to_string exn));
-      (match launch_supervised_fiber ~proactive_warmup_sec ctx meta reg with
-       | Error _ -> ()
-       | Ok () ->
-         wake_queued_owner_operations ();
-         publish_lifecycle
-           ~event:
-             (Keeper_lifecycle_events.Custom_event
-                { verb = Keeper_lifecycle_events.Started
-                ; phase = Some Keeper_state_machine.Running
-                })
+  let log_transaction_error = function
+    | Keeper_keepalive_launch_transaction.Reservation_unavailable owner ->
+      Log.Keeper.info
+        "supervisor launch deferred to lifecycle transaction owner keeper=%s owner=%s"
+        meta.name
+        (Keeper_lifecycle_reservation.snapshot_to_string owner)
+    | Keeper_keepalive_launch_transaction.Registration_failed (`Occupied current) ->
+      Log.Keeper.info
+        "supervisor launch retained concurrently registered lane keeper=%s phase=%s"
+        meta.name
+        (Keeper_state_machine.phase_to_string current.Keeper_registry.phase)
+    | Keeper_keepalive_launch_transaction.Registration_failed (`Registration error) ->
+      (match error with
+       | Keeper_registry.Registration_shutdown_reserved operation_id ->
+         Log.Keeper.warn
+           "supervisor launch skipped %s because shutdown operation %s owns admission"
            meta.name
-           "supervised"
-           ()))
-  in
-  let register_and_launch () =
-    if librarian_lifecycle_ready ()
-    then
-      match
-         Keeper_registry.register_offline_if_admitted
-           ~base_path
+           (Keeper_shutdown_types.Operation_id.to_string operation_id)
+       | Keeper_registry.Registration_intake_token_not_live ->
+         Log.Keeper.error
+           "supervisor launch rejected an unexpected inactive durable-intake token for %s"
            meta.name
-           meta
-       with
-         | Error (Keeper_registry.Registration_shutdown_reserved operation_id) ->
-           Log.Keeper.warn
-             "supervisor launch skipped %s because shutdown operation %s owns admission"
-             meta.name
-             (Keeper_shutdown_types.Operation_id.to_string operation_id)
-         | Error Keeper_registry.Registration_intake_token_not_live ->
-           Log.Keeper.error
-             "supervisor launch rejected an unexpected inactive durable-intake token for %s"
-             meta.name
-         | Error (Keeper_registry.Registration_lifecycle_reserved owner) ->
+       | Keeper_registry.Registration_lifecycle_reserved owner ->
          Log.Keeper.warn
            "supervisor launch skipped %s because lifecycle transaction owns admission: %s"
            meta.name
            (Keeper_lifecycle_reservation.snapshot_to_string owner)
-       | Error (Keeper_registry.Registration_invalid validation_error) ->
+       | Keeper_registry.Registration_invalid validation_error ->
          Log.Keeper.error
            "supervisor registry validation rejected %s: %s"
            meta.name
            (Keeper_registry.registry_entry_validation_error_to_string validation_error)
-       | Error (Keeper_registry.Registration_event_queue_unavailable { keeper_name; detail }) ->
+       | Keeper_registry.Registration_event_queue_unavailable { keeper_name; detail } ->
          Log.Keeper.error
            "supervisor registry event queue unavailable keeper=%s: %s"
            keeper_name
-           detail
-         | Ok reg -> launch_registered reg
+           detail)
+    | Keeper_keepalive_launch_transaction.Lifecycle_open_failed
+        { error; rollback_error } ->
+      Log.Keeper.warn
+        "supervisor launch deferred until Librarian owner exits keeper=%s error=%s%s"
+        meta.name
+        (Keeper_memory_lane.lifecycle_open_error_to_string error)
+        (match rollback_error with
+         | None -> ""
+         | Some detail -> "; rollback failed: " ^ detail);
+      ignore
+        (Keeper_memory_lane.abort_librarian
+           ~base_path
+           ~keeper_name:meta.name
+          : (Keeper_memory_lane.librarian_abort_outcome,
+             Keeper_memory_lane.librarian_abort_error)
+              result)
+  in
+  let run_launch_transaction ~expected_generation ~register ~rollback =
+    match
+      Keeper_keepalive_launch_transaction.run
+        ~base_path
+        ~keeper_name:meta.name
+        ~expected_generation
+        ~register
+        ~rollback
+        launch_registered
+    with
+    | Ok () -> ()
+    | Error error -> log_transaction_error error
+  in
+  let register_and_launch () =
+    run_launch_transaction
+      ~expected_generation:0
+      ~register:(fun token ->
+        match Keeper_registry.get ~base_path meta.name with
+        | Some current -> Error (`Occupied current)
+        | None ->
+          Keeper_registry.register_offline_if_admitted_for_lifecycle
+            token
+            ~base_path
+            meta.name
+            meta
+          |> Result.map_error (fun error -> `Registration error))
+      ~rollback:Keeper_keepalive_launch_transaction.rollback_remove_registered
   in
   match execution_truth with
   | Keeper_activation_readiness.Unknown detail ->
@@ -210,7 +253,18 @@ let supervise_keepalive
      | None -> register_and_launch ()
      | Some reg ->
        (match reg.phase with
-        | Keeper_state_machine.Offline -> launch_registered reg
+        | Keeper_state_machine.Offline ->
+          run_launch_transaction
+            ~expected_generation:reg.transition_seq
+            ~register:(fun _token ->
+              match Keeper_registry.get ~base_path meta.name with
+              | Some current
+                when Keeper_lane.Id.equal
+                       (Keeper_lane.id current.lane)
+                       (Keeper_lane.id reg.lane) -> Ok current
+              | Some current -> Error (`Occupied current)
+              | None -> Error (`Occupied reg))
+            ~rollback:Keeper_keepalive_launch_transaction.rollback_retain_registered
         | Keeper_state_machine.Running
         | Keeper_state_machine.Failing
         | Keeper_state_machine.Overflowed

--- a/lib/keeper/keeper_supervisor_supervise_keepalive.ml
+++ b/lib/keeper/keeper_supervisor_supervise_keepalive.ml
@@ -33,6 +33,21 @@ open Keeper_types_profile
 open Keeper_execution
 module Startup_helpers = Keeper_supervisor_startup_helpers
 
+let same_offline_generation
+      ~(expected : Keeper_registry.registry_entry)
+      (current : Keeper_registry.registry_entry)
+  =
+  Keeper_lane.Id.equal
+    (Keeper_lane.id current.lane)
+    (Keeper_lane.id expected.lane)
+  && current.phase = Keeper_state_machine.Offline
+  && Int.equal current.transition_seq expected.transition_seq
+;;
+
+module For_testing = struct
+  let same_offline_generation = same_offline_generation
+end
+
 let supervise_keepalive
       ~(publish_lifecycle :
          event:Keeper_lifecycle_events.lifecycle_event ->
@@ -258,10 +273,8 @@ let supervise_keepalive
             ~expected_generation:reg.transition_seq
             ~register:(fun _token ->
               match Keeper_registry.get ~base_path meta.name with
-              | Some current
-                when Keeper_lane.Id.equal
-                       (Keeper_lane.id current.lane)
-                       (Keeper_lane.id reg.lane) -> Ok current
+              | Some current when same_offline_generation ~expected:reg current ->
+                Ok current
               | Some current -> Error (`Occupied current)
               | None -> Error (`Occupied reg))
             ~rollback:Keeper_keepalive_launch_transaction.rollback_retain_registered

--- a/lib/keeper/keeper_supervisor_supervise_keepalive.ml
+++ b/lib/keeper/keeper_supervisor_supervise_keepalive.ml
@@ -162,6 +162,15 @@ let supervise_keepalive
            (Printexc.to_string exn))
   in
   let log_transaction_error = function
+    | Keeper_keepalive_launch_transaction.Shutdown_reserved operation_id ->
+      Log.Keeper.warn
+        "supervisor launch skipped %s because shutdown operation %s owns admission"
+        meta.name
+        (Keeper_shutdown_types.Operation_id.to_string operation_id)
+    | Keeper_keepalive_launch_transaction.Intake_token_not_live ->
+      Log.Keeper.error
+        "supervisor launch rejected an inactive durable-intake token for %s"
+        meta.name
     | Keeper_keepalive_launch_transaction.Reservation_unavailable owner ->
       Log.Keeper.info
         "supervisor launch deferred to lifecycle transaction owner keeper=%s owner=%s"
@@ -214,6 +223,18 @@ let supervise_keepalive
           : (Keeper_memory_lane.librarian_abort_outcome,
              Keeper_memory_lane.librarian_abort_error)
               result)
+    | Keeper_keepalive_launch_transaction.Launch_failed
+        { exception_detail; librarian_abort_error; rollback_error } ->
+      let cleanup_detail label = function
+        | None -> ""
+        | Some detail -> "; " ^ label ^ " failed: " ^ detail
+      in
+      Log.Keeper.error
+        "supervisor launch callback failed keeper=%s error=%s%s%s"
+        meta.name
+        exception_detail
+        (cleanup_detail "Librarian abort" librarian_abort_error)
+        (cleanup_detail "registry rollback" rollback_error)
   in
   let run_launch_transaction ~expected_generation ~register ~rollback =
     match
@@ -231,11 +252,12 @@ let supervise_keepalive
   let register_and_launch () =
     run_launch_transaction
       ~expected_generation:0
-      ~register:(fun token ->
+      ~register:(fun token intake_token ->
         match Keeper_registry.get ~base_path meta.name with
         | Some current -> Error (`Occupied current)
         | None ->
           Keeper_registry.register_offline_if_admitted_for_lifecycle
+            ~intake_token
             token
             ~base_path
             meta.name
@@ -283,7 +305,7 @@ let supervise_keepalive
         | Keeper_state_machine.Offline ->
           run_launch_transaction
             ~expected_generation:reg.transition_seq
-            ~register:(fun _token ->
+            ~register:(fun _token _intake_token ->
               match Keeper_registry.get ~base_path meta.name with
               | Some current when same_offline_generation ~expected:reg current ->
                 Ok current

--- a/lib/keeper/keeper_supervisor_supervise_keepalive.ml
+++ b/lib/keeper/keeper_supervisor_supervise_keepalive.ml
@@ -98,66 +98,80 @@ let supervise_keepalive
         meta.name
         (Keeper_owner_registry.command_error_to_string error)
   in
-  let launch_registered reg =
-    (try
-       if not (Workspace_utils.is_initialized ctx.config)
-       then (
-         let (_init_msg : string) = Workspace.init ctx.config ~agent_name:None in
-         ())
-     with
-     | Eio.Cancel.Cancelled _ as e -> raise e
-     | exn ->
-       Otel_metric_store.inc_counter
-         Keeper_metrics.(to_string WorkspaceInitFailures)
-         ~labels:[ "keeper", meta.name ]
-         ();
-       Log.Keeper.error "supervisor workspace init failed: %s" (Printexc.to_string exn));
-    match launch_supervised_fiber ~proactive_warmup_sec ctx meta reg with
-    | Error _ -> ()
-    | Ok () ->
-      wake_queued_owner_operations ();
-      publish_lifecycle
-        ~event:
-          (Keeper_lifecycle_events.Custom_event
-             { verb = Keeper_lifecycle_events.Started
-             ; phase = Some Keeper_state_machine.Running
-             })
+  let librarian_lifecycle_ready () =
+    match Keeper_memory_lane.begin_librarian_lifecycle ~base_path ~keeper_name:meta.name with
+    | Error error ->
+      Log.Keeper.info
+        "supervisor launch deferred until prior Librarian owner exits keeper=%s error=%s"
         meta.name
-        "supervised"
-        ()
+        (Keeper_memory_lane.lifecycle_open_error_to_string error);
+      false
+    | Ok () -> true
+  in
+  let launch_registered reg =
+    if librarian_lifecycle_ready ()
+    then (
+      (try
+         if not (Workspace_utils.is_initialized ctx.config)
+         then (
+           let (_init_msg : string) = Workspace.init ctx.config ~agent_name:None in
+           ())
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+         Otel_metric_store.inc_counter
+           Keeper_metrics.(to_string WorkspaceInitFailures)
+           ~labels:[ "keeper", meta.name ]
+           ();
+         Log.Keeper.error "supervisor workspace init failed: %s" (Printexc.to_string exn));
+      (match launch_supervised_fiber ~proactive_warmup_sec ctx meta reg with
+       | Error _ -> ()
+       | Ok () ->
+         wake_queued_owner_operations ();
+         publish_lifecycle
+           ~event:
+             (Keeper_lifecycle_events.Custom_event
+                { verb = Keeper_lifecycle_events.Started
+                ; phase = Some Keeper_state_machine.Running
+                })
+           meta.name
+           "supervised"
+           ()))
   in
   let register_and_launch () =
-    match
-      Keeper_registry.register_offline_if_admitted
-        ~base_path
-        meta.name
-        meta
-    with
-    | Error (Keeper_registry.Registration_shutdown_reserved operation_id) ->
-      Log.Keeper.warn
-        "supervisor launch skipped %s because shutdown operation %s owns admission"
-        meta.name
-        (Keeper_shutdown_types.Operation_id.to_string operation_id)
-    | Error Keeper_registry.Registration_intake_token_not_live ->
-      Log.Keeper.error
-        "supervisor launch rejected an unexpected inactive durable-intake token for %s"
-        meta.name
-    | Error (Keeper_registry.Registration_lifecycle_reserved owner) ->
-      Log.Keeper.warn
-        "supervisor launch skipped %s because lifecycle transaction owns admission: %s"
-        meta.name
-        (Keeper_lifecycle_reservation.snapshot_to_string owner)
-    | Error (Keeper_registry.Registration_invalid validation_error) ->
-      Log.Keeper.error
-        "supervisor registry validation rejected %s: %s"
-        meta.name
-        (Keeper_registry.registry_entry_validation_error_to_string validation_error)
-    | Error (Keeper_registry.Registration_event_queue_unavailable { keeper_name; detail }) ->
-      Log.Keeper.error
-        "supervisor registry event queue unavailable keeper=%s: %s"
-        keeper_name
-        detail
-    | Ok reg -> launch_registered reg
+    if librarian_lifecycle_ready ()
+    then
+      match
+         Keeper_registry.register_offline_if_admitted
+           ~base_path
+           meta.name
+           meta
+       with
+         | Error (Keeper_registry.Registration_shutdown_reserved operation_id) ->
+           Log.Keeper.warn
+             "supervisor launch skipped %s because shutdown operation %s owns admission"
+             meta.name
+             (Keeper_shutdown_types.Operation_id.to_string operation_id)
+         | Error Keeper_registry.Registration_intake_token_not_live ->
+           Log.Keeper.error
+             "supervisor launch rejected an unexpected inactive durable-intake token for %s"
+             meta.name
+         | Error (Keeper_registry.Registration_lifecycle_reserved owner) ->
+         Log.Keeper.warn
+           "supervisor launch skipped %s because lifecycle transaction owns admission: %s"
+           meta.name
+           (Keeper_lifecycle_reservation.snapshot_to_string owner)
+       | Error (Keeper_registry.Registration_invalid validation_error) ->
+         Log.Keeper.error
+           "supervisor registry validation rejected %s: %s"
+           meta.name
+           (Keeper_registry.registry_entry_validation_error_to_string validation_error)
+       | Error (Keeper_registry.Registration_event_queue_unavailable { keeper_name; detail }) ->
+         Log.Keeper.error
+           "supervisor registry event queue unavailable keeper=%s: %s"
+           keeper_name
+           detail
+         | Ok reg -> launch_registered reg
   in
   match execution_truth with
   | Keeper_activation_readiness.Unknown detail ->

--- a/lib/keeper/keeper_supervisor_supervise_keepalive.mli
+++ b/lib/keeper/keeper_supervisor_supervise_keepalive.mli
@@ -15,7 +15,8 @@ val supervise_keepalive :
      unit ->
      unit) ->
   launch_supervised_fiber:
-    (lifecycle_token:Keeper_lifecycle_reservation.token ->
+    (intake_token:Keeper_shutdown_intake_fence.intake_token ->
+     lifecycle_token:Keeper_lifecycle_reservation.token ->
      proactive_warmup_sec:int ->
      'a Keeper_types_profile.context ->
      Keeper_meta_contract.keeper_meta ->

--- a/lib/keeper/keeper_supervisor_supervise_keepalive.mli
+++ b/lib/keeper/keeper_supervisor_supervise_keepalive.mli
@@ -1,5 +1,12 @@
 (** Keepalive supervision entry point for the keeper supervisor. *)
 
+module For_testing : sig
+  val same_offline_generation :
+    expected:Keeper_registry.registry_entry ->
+    Keeper_registry.registry_entry ->
+    bool
+end
+
 val supervise_keepalive :
   publish_lifecycle:
     (event:Keeper_lifecycle_events.lifecycle_event ->

--- a/lib/keeper/keeper_supervisor_supervise_keepalive.mli
+++ b/lib/keeper/keeper_supervisor_supervise_keepalive.mli
@@ -8,7 +8,8 @@ val supervise_keepalive :
      unit ->
      unit) ->
   launch_supervised_fiber:
-    (proactive_warmup_sec:int ->
+    (lifecycle_token:Keeper_lifecycle_reservation.token ->
+     proactive_warmup_sec:int ->
      'a Keeper_types_profile.context ->
      Keeper_meta_contract.keeper_meta ->
      Keeper_registry.registry_entry ->

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -372,6 +372,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
            | Keepalive_identity_unrepairable
            | Keepalive_registration_rejected _
            | Keepalive_fiber_start_rejected _
+           | Keepalive_memory_lane_not_ready _
            | Keepalive_lane_ownership_lost
            | Keepalive_fork_rejected _ ) as rejected ->
            Progress.stop_tracking task_id;

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -373,6 +373,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
            | Keepalive_registration_rejected _
            | Keepalive_fiber_start_rejected _
            | Keepalive_memory_lane_not_ready _
+           | Keepalive_launch_callback_failed _
            | Keepalive_lane_ownership_lost
            | Keepalive_fork_rejected _ ) as rejected ->
            Progress.stop_tracking task_id;

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -434,6 +434,7 @@ let update_keeper ?(preserve_prompt_defaults = false)
                   | Keepalive_registration_rejected _
                   | Keepalive_fiber_start_rejected _
                   | Keepalive_memory_lane_not_ready _
+                  | Keepalive_launch_callback_failed _
                   | Keepalive_lane_ownership_lost
                   | Keepalive_fork_rejected _ ) as rejected ->
                   tool_result_error

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -433,6 +433,7 @@ let update_keeper ?(preserve_prompt_defaults = false)
                   | Keepalive_identity_unrepairable
                   | Keepalive_registration_rejected _
                   | Keepalive_fiber_start_rejected _
+                  | Keepalive_memory_lane_not_ready _
                   | Keepalive_lane_ownership_lost
                   | Keepalive_fork_rejected _ ) as rejected ->
                   tool_result_error

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -136,6 +136,7 @@ type t =
   | MemoryLaneSubmitted
   | MemoryLaneRanInline
   | MemoryLaneDropped
+  | MemoryLaneRejectedDraining
   | MemoryLaneCoalesced
   | MemoryLanePending
   | MemoryLaneInFlight
@@ -347,6 +348,8 @@ let to_string = function
   | MemoryLaneSubmitted -> "masc_keeper_memory_lane_submitted_total"
   | MemoryLaneRanInline -> "masc_keeper_memory_lane_ran_inline_total"
   | MemoryLaneDropped -> "masc_keeper_memory_lane_dropped_total"
+  | MemoryLaneRejectedDraining ->
+    "masc_keeper_memory_lane_rejected_draining_total"
   | MemoryLaneCoalesced -> "masc_keeper_memory_lane_coalesced_total"
   | MemoryLanePending -> "masc_keeper_memory_lane_pending"
   | MemoryLaneInFlight -> "masc_keeper_memory_lane_in_flight"

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -127,6 +127,7 @@ type t =
   | MemoryLaneSubmitted
   | MemoryLaneRanInline
   | MemoryLaneDropped
+  | MemoryLaneRejectedDraining
   | MemoryLaneCoalesced
   | MemoryLanePending
   | MemoryLaneInFlight

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=556
+UNWIRED_BASELINE=557
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=557
+UNWIRED_BASELINE=556
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=558
+UNWIRED_BASELINE=557
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -211,6 +211,7 @@ normal_targets=(
   @test/runtest-test_tool_call_quality_benchmark
   @test/runtest-test_client_identity
   @test/runtest-test_mcp_session_task_lifecycle
+  @test/runtest-test_mcp_server_eio
   @test/runtest-test_keeper_sandbox_docker_cwd_response
   @test/runtest-test_goal_store
   @test/runtest-test_keeper_goal_phase_projection

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -211,7 +211,6 @@ normal_targets=(
   @test/runtest-test_tool_call_quality_benchmark
   @test/runtest-test_client_identity
   @test/runtest-test_mcp_session_task_lifecycle
-  @test/runtest-test_mcp_server_eio
   @test/runtest-test_keeper_sandbox_docker_cwd_response
   @test/runtest-test_goal_store
   @test/runtest-test_keeper_goal_phase_projection

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -92,6 +92,7 @@ normal_targets=(
   @test/runtest-test_file_kind_vocabulary
   @test/runtest-test_http_auth_strict_flag
   @test/runtest-test_keeper_chat_broadcast
+  @test/runtest-test_keeper_memory_lane
   @test/runtest-test_server_dashboard_http_keeper_chat_page
   @test/runtest-test_keeper_codex_effort_clamp
   @test/runtest-test_keeper_codex_error_carriage

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -40,6 +40,7 @@ module Keeper_meta_contract = Masc.Keeper_meta_contract
 module Keeper_meta_json = Masc.Keeper_meta_json
 module Keeper_meta_store = Masc.Keeper_meta_store
 module Keeper_owner_registry = Masc.Keeper_owner_registry
+module Keeper_lifecycle_reservation = Masc.Keeper_lifecycle_reservation
 module Keeper_types_support = Masc.Keeper_types_support
 module Keeper_fs = Masc.Keeper_fs
 module Lifecycle_hooks = Masc.Keeper_lifecycle_hooks
@@ -2414,9 +2415,7 @@ let test_keeper_shutdown_prepare_joins_idle_lane () =
       install_owner_inventory_exn ~sw config;
       let name = "shutdown-idle-lane" in
       let meta = make_meta name in
-      (match Keeper_meta_store.replace_snapshot config meta with
-       | Ok () -> ()
-       | Error detail -> fail detail);
+      create_owner_meta_exn config meta;
       let entry = R.For_testing.register ~base_path:config.base_path name meta in
       Memory_lane.init ~sw:parent_sw;
       let never_p, _never_r = Eio.Promise.create () in
@@ -2729,6 +2728,7 @@ let test_keeper_shutdown_blocks_join_replay_after_record_failure () =
 let test_keeper_shutdown_prepare_joins_not_started_lane () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir "shutdown-prepare-not-started" in
   Fun.protect
     ~finally:(fun () ->
@@ -2739,11 +2739,10 @@ let test_keeper_shutdown_prepare_joins_not_started_lane () =
       let (_init_message : string) =
         Masc.Workspace.init config ~agent_name:(Some "operator")
       in
+      install_owner_inventory_exn ~sw config;
       let name = "shutdown-not-started-lane" in
       let meta = make_meta name in
-      (match Keeper_meta_store.replace_snapshot config meta with
-       | Ok () -> ()
-       | Error detail -> fail detail);
+      create_owner_meta_exn config meta;
       let entry = R.For_testing.register ~base_path:config.base_path name meta in
       let operation =
         match

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -50,6 +50,7 @@ module Dashboard_purge = Masc.Keeper_dashboard_purge
 module Dashboard_delete = Server_dashboard_http_delete_actions
 
 exception Librarian_executor_cancel
+exception Cancel_direct_keepalive_parent
 
 let bp = "/tmp/test-heartbeat-integ"
 
@@ -707,6 +708,60 @@ let test_direct_start_keepalive_resolves_done_on_stop () =
          | Some (`Crashed reason) ->
            fail ("expected stopped promise, got crashed: " ^ reason)
          | None -> fail "expected done_p to resolve on stop"))
+
+let test_direct_start_terminalizes_fork_rejection_under_launch_reservation () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  R.For_testing.clear ();
+  Memory_lane.For_testing.reset ();
+  let base_dir = temp_dir "direct-keepalive-fork-reject" in
+  let keeper_name = "direct-fork-reject" in
+  Fun.protect
+    ~finally:(fun () ->
+      Memory_lane.For_testing.reset ();
+      R.For_testing.clear ();
+      cleanup_dir base_dir)
+    (fun () ->
+      ensure_default_runtime ();
+      let config = Masc.Workspace.default_config base_dir in
+      ignore (Masc.Workspace.init config ~agent_name:(Some "tester"));
+      let meta = make_meta keeper_name in
+      seed_keeper_sandbox_profile ~base_dir keeper_name;
+      let launch_outcome = ref None in
+      (try
+         Eio.Switch.run @@ fun cancelling_sw ->
+         let ctx : _ Keeper_types_profile.context =
+           { config
+           ; agent_name = "tester"
+           ; sw = cancelling_sw
+           ; clock = Eio.Stdenv.clock env
+           ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
+           ; net = None
+           ; publication_recovery_provider =
+               Masc_test_deps.publication_recovery_provider
+                 (publication_recovery_registry env cancelling_sw config)
+           }
+         in
+         Eio.Switch.fail cancelling_sw Cancel_direct_keepalive_parent;
+         launch_outcome := Some (Masc.Keeper_keepalive.start_keepalive ctx meta)
+       with
+       | Cancel_direct_keepalive_parent -> ());
+      (match !launch_outcome with
+       | Some (Masc.Keeper_keepalive.Keepalive_fork_rejected _) -> ()
+       | Some outcome ->
+         failf
+           "cancelled parent returned unexpected launch outcome: %s"
+           (Masc.Keeper_keepalive.start_keepalive_outcome_to_string outcome)
+       | None -> fail "cancelled parent did not return a launch outcome");
+      match R.get ~base_path:config.base_path keeper_name with
+      | None -> fail "fork-rejected direct lane disappeared"
+      | Some entry ->
+        check string "fork rejection is durably crashed" "crashed"
+          (KSM.phase_to_string entry.phase);
+        (match Eio.Promise.peek entry.done_p with
+         | Some (`Crashed _) -> ()
+         | Some `Stopped -> fail "fork rejection resolved as stopped"
+         | None -> fail "fork rejection left the terminal promise unresolved"))
 
 let test_direct_stop_resolves_done_after_librarian_drain_failure () =
   Eio_main.run @@ fun env ->
@@ -2787,6 +2842,7 @@ let test_keeper_shutdown_blocks_join_replay_after_record_failure () =
        | Error error -> fail (Shutdown_prepare_join.error_to_string error)
        | Ok _ -> fail "missing shutdown record did not fail final join persistence");
       Unix.rename held_path operation_path;
+      R.For_testing.unregister ~base_path:config.base_path name;
       let blocked =
         match Shutdown_prepare_join.join_prepared ~config ~entry ~operation:joining with
         | Error (Shutdown_prepare_join.Join_failed blocked) -> blocked
@@ -4629,6 +4685,8 @@ let () =
     "direct_keepalive", [
       test_case "stop resolves done after lane exit" `Quick
         test_direct_start_keepalive_resolves_done_on_stop;
+      test_case "fork rejection terminalizes under launch reservation" `Quick
+        test_direct_start_terminalizes_fork_rejection_under_launch_reservation;
       test_case "stop resolves done after Librarian drain failure" `Quick
         test_direct_stop_resolves_done_after_librarian_drain_failure;
       test_case "lane join waits for children and cleanup" `Quick

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -49,6 +49,8 @@ module Tombstone_cleanup = Masc.Keeper_supervisor_cleanup_tombstone
 module Dashboard_purge = Masc.Keeper_dashboard_purge
 module Dashboard_delete = Server_dashboard_http_delete_actions
 
+exception Librarian_executor_cancel
+
 let bp = "/tmp/test-heartbeat-integ"
 
 let temp_dir prefix =
@@ -705,6 +707,83 @@ let test_direct_start_keepalive_resolves_done_on_stop () =
          | Some (`Crashed reason) ->
            fail ("expected stopped promise, got crashed: " ^ reason)
          | None -> fail "expected done_p to resolve on stop"))
+
+let test_direct_stop_resolves_done_after_librarian_drain_failure () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  R.For_testing.clear ();
+  Memory_lane.For_testing.reset ();
+  let base_dir = temp_dir "direct-keepalive-librarian-failure" in
+  let keeper_name = "direct-librarian-failure" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_keepalive.stop_keepalive ~base_path:base_dir keeper_name;
+      Memory_lane.For_testing.reset ();
+      R.For_testing.clear ();
+      cleanup_dir base_dir)
+    (fun () ->
+      ensure_default_runtime ();
+      let config = Masc.Workspace.default_config base_dir in
+      ignore (Masc.Workspace.init config ~agent_name:(Some "tester"));
+      let meta = make_meta keeper_name in
+      Eio.Switch.run @@ fun keeper_sw ->
+      let ctx : _ Keeper_types_profile.context =
+        { config
+        ; agent_name = "tester"
+        ; sw = keeper_sw
+        ; clock = Eio.Stdenv.clock env
+        ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
+        ; net = None
+        ; publication_recovery_provider =
+            Masc_test_deps.publication_recovery_provider
+              (publication_recovery_registry env keeper_sw config)
+        }
+      in
+      seed_keeper_sandbox_profile ~base_dir keeper_name;
+      (try
+         Eio.Switch.run @@ fun librarian_sw ->
+         Memory_lane.init ~sw:librarian_sw;
+         (match Masc.Keeper_keepalive.start_keepalive ctx meta with
+          | Masc.Keeper_keepalive.Keepalive_started _ -> ()
+          | outcome ->
+            failf
+              "direct Librarian fixture failed to start: %s"
+              (Masc.Keeper_keepalive.start_keepalive_outcome_to_string outcome));
+         Eio.Time.sleep ctx.clock 0.05;
+         let started, resolve_started = Eio.Promise.create () in
+         let never, _resolve_never = Eio.Promise.create () in
+         (match
+            Memory_lane.submit
+              ~base_path:config.base_path
+              ~keeper_name
+              (fun () ->
+                 Eio.Promise.resolve resolve_started ();
+                 Eio.Promise.await never)
+          with
+          | Memory_lane.Submitted -> ()
+          | Memory_lane.Coalesced
+          | Memory_lane.Ran_inline
+          | Memory_lane.Dropped
+          | Memory_lane.Rejected_draining ->
+            fail "failed Librarian receipt fixture was not submitted");
+         Eio.Promise.await started;
+         Eio.Switch.fail librarian_sw Librarian_executor_cancel
+       with
+       | Librarian_executor_cancel -> ());
+      match
+        Masc.Keeper_keepalive.stop_keepalive_and_await
+          ~base_path:config.base_path
+          keeper_name
+      with
+      | Masc.Keeper_keepalive.Keeper_not_registered ->
+        fail "failed-drain keeper disappeared before joined stop"
+      | Masc.Keeper_keepalive.Keeper_joined
+          { terminal = `Stopped; lane_exit = { cleanup_error = Some _; _ } } -> ()
+      | Masc.Keeper_keepalive.Keeper_joined
+          { terminal = `Stopped; lane_exit = { cleanup_error = None; _ } } ->
+        fail "failed Librarian drain was not preserved as lane cleanup evidence"
+      | Masc.Keeper_keepalive.Keeper_joined { terminal = `Crashed reason; _ } ->
+        fail ("failed Librarian drain changed explicit stop into crash: " ^ reason))
 
 let test_keeper_lane_join_waits_for_children_and_cleanup () =
   Eio_main.run @@ fun _env ->
@@ -4550,6 +4629,8 @@ let () =
     "direct_keepalive", [
       test_case "stop resolves done after lane exit" `Quick
         test_direct_start_keepalive_resolves_done_on_stop;
+      test_case "stop resolves done after Librarian drain failure" `Quick
+        test_direct_stop_resolves_done_after_librarian_drain_failure;
       test_case "lane join waits for children and cleanup" `Quick
         test_keeper_lane_join_waits_for_children_and_cleanup;
       test_case "lane join surfaces cleanup failure" `Quick

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -955,14 +955,37 @@ let test_keeper_shutdown_store_round_trip_and_identity_guard () =
            (Lane.Id.equal expected actual)
        | (Shutdown_types.Registered_lane _ | Shutdown_types.Dormant_meta), _ ->
          fail "shutdown lane ownership changed during round-trip");
-      let joined =
+      let joining =
         { loaded with
           revision = loaded.revision + 1
+        ; phase = Shutdown_types.Joining_lanes
+        ; updated_at = Masc_domain.now_iso ()
+        }
+      in
+      (match Shutdown_store.replace ~config ~expected_revision:loaded.revision joining with
+       | Ok () -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error));
+      let joining_loaded =
+        match Shutdown_store.load ~config ~keeper_name:meta.name operation_id with
+        | Ok loaded -> loaded
+        | Error error -> fail (Shutdown_store.error_to_string error)
+      in
+      (match joining_loaded.phase with
+       | Shutdown_types.Joining_lanes -> ()
+       | _ -> fail "durable lane-join phase did not round-trip");
+      let joined =
+        { joining_loaded with
+          revision = joining_loaded.revision + 1
         ; phase = Shutdown_types.Joined_idle
         ; updated_at = Masc_domain.now_iso ()
         }
       in
-      (match Shutdown_store.replace ~config ~expected_revision:loaded.revision joined with
+      (match
+         Shutdown_store.replace
+           ~config
+           ~expected_revision:joining_loaded.revision
+           joined
+       with
        | Ok () -> ()
        | Error error -> fail (Shutdown_store.error_to_string error));
       let stale =
@@ -1073,6 +1096,7 @@ let test_keeper_shutdown_store_round_trip_and_identity_guard () =
            (Printexc.to_string worker_failure)
            detail
        | Shutdown_types.Prepared
+       | Shutdown_types.Joining_lanes
        | Shutdown_types.Joined_idle
        | Shutdown_types.Finalizing_tasks _
        | Shutdown_types.Cleanup_ready _
@@ -2417,15 +2441,19 @@ let test_keeper_shutdown_prepare_joins_idle_lane () =
        | Error error -> fail (Lane.start_error_to_string error));
       Eio.Fiber.yield ();
       let librarian_started, resolve_librarian_started = Eio.Promise.create () in
-      let librarian_never, _resolve_librarian_never = Eio.Promise.create () in
+      let librarian_release, resolve_librarian_release = Eio.Promise.create () in
       let librarian_cancelled = ref false in
+      let librarian_completed = ref false in
       (match
          Memory_lane.submit
            ~base_path:config.base_path
            ~keeper_name:name
            (fun () ->
               Eio.Promise.resolve resolve_librarian_started ();
-              try Eio.Promise.await librarian_never with
+              try
+                Eio.Promise.await librarian_release;
+                librarian_completed := true
+              with
               | Eio.Cancel.Cancelled _ as exn ->
                 librarian_cancelled := true;
                 raise exn)
@@ -2433,24 +2461,65 @@ let test_keeper_shutdown_prepare_joins_idle_lane () =
        | Memory_lane.Submitted -> ()
        | Memory_lane.Coalesced
        | Memory_lane.Ran_inline
-       | Memory_lane.Dropped -> fail "shutdown Librarian was not submitted");
+       | Memory_lane.Dropped
+       | Memory_lane.Rejected_draining ->
+         fail "shutdown Librarian was not submitted");
       Eio.Promise.await librarian_started;
+      let shutdown_done, resolve_shutdown_done = Eio.Promise.create () in
+      Eio.Fiber.fork ~sw (fun () ->
+        Eio.Promise.resolve
+          resolve_shutdown_done
+          (Shutdown_prepare_join.run
+             ~config
+             ~entry
+             ~request:
+               { actor = "operator"
+               ; cleanup_intent = retain_operator_cleanup
+               }));
+      let rec await_durable_joining_lanes () =
+        match Eio.Promise.peek shutdown_done with
+        | Some (Ok _) -> fail "shutdown completed before Librarian release"
+        | Some (Error error) -> fail (Shutdown_prepare_join.error_to_string error)
+        | None ->
+          (match
+             owner_shutdown_operation_id_exn
+               ~base_path:config.base_path
+               ~keeper_name:name
+           with
+           | None ->
+             Eio.Fiber.yield ();
+             await_durable_joining_lanes ()
+           | Some operation_id ->
+             (match Shutdown_store.load ~config ~keeper_name:name operation_id with
+              | Ok { phase = Shutdown_types.Joining_lanes; _ } -> operation_id
+              | Ok { phase = Shutdown_types.Prepared; _ } ->
+                Eio.Fiber.yield ();
+                await_durable_joining_lanes ()
+              | Ok operation ->
+                fail
+                  (Printf.sprintf
+                     "Librarian wait entered unexpected durable revision=%d"
+                     operation.revision)
+              | Error (Shutdown_store.Not_found _) ->
+                Eio.Fiber.yield ();
+                await_durable_joining_lanes ()
+              | Error error -> fail (Shutdown_store.error_to_string error)))
+      in
+      let _joining_operation_id = await_durable_joining_lanes () in
+      check bool
+        "shutdown remains pending while accepted Librarian work runs"
+        true
+        (Option.is_none (Eio.Promise.peek shutdown_done));
+      Eio.Promise.resolve resolve_librarian_release ();
       let operation =
-        match
-          Shutdown_prepare_join.run
-            ~config
-            ~entry
-            ~request:
-              { actor = "operator"
-              ; cleanup_intent = retain_operator_cleanup
-              }
-        with
+        match Eio.Promise.await shutdown_done with
         | Ok operation -> operation
         | Error error -> fail (Shutdown_prepare_join.error_to_string error)
       in
       (match operation.phase with
        | Shutdown_types.Joined_idle -> ()
        | Shutdown_types.Prepared
+       | Shutdown_types.Joining_lanes
        | Shutdown_types.Finalizing_tasks _
        | Shutdown_types.Cleanup_ready _
        | Shutdown_types.Reconciliation_required _
@@ -2462,9 +2531,13 @@ let test_keeper_shutdown_prepare_joins_idle_lane () =
         true
         (Option.is_some operation.join_evidence);
       check bool
-        "shutdown cancelled the detached Librarian before returning"
-        true
+        "shutdown preserved the detached Librarian through completion"
+        false
         !librarian_cancelled;
+      check bool
+        "shutdown drained the detached Librarian before returning"
+        true
+        !librarian_completed;
       check
         (option int)
         "shutdown joined the detached Librarian"
@@ -2482,8 +2555,176 @@ let test_keeper_shutdown_prepare_joins_idle_lane () =
            "shutdown admission fence retains operation identity"
            true
            (Shutdown_types.Operation_id.equal operation.operation_id operation_id)
-      | None ->
+       | None ->
          fail "shutdown admission fence reopened before finalization"))
+
+let test_keeper_shutdown_owner_failure_persists_blocked_join () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir "shutdown-owner-failure" in
+  Fun.protect
+    ~finally:(fun () ->
+      R.For_testing.clear ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      let (_init_message : string) =
+        Masc.Workspace.init config ~agent_name:(Some "operator")
+      in
+      let name = "shutdown-owner-failure-lane" in
+      let meta = make_meta name in
+      (match Keeper_meta_store.replace_snapshot config meta with
+       | Ok () -> ()
+       | Error detail -> fail detail);
+      let prepared = ref None in
+      let exception Close_owner_before_join in
+      (try
+         Eio.Switch.run @@ fun owner_sw ->
+         install_owner_inventory_exn ~sw:owner_sw config;
+         let entry = R.For_testing.register ~base_path:config.base_path name meta in
+         let operation =
+           match
+             Shutdown_prepare_join.prepare
+               ~config
+               ~entry
+               ~request:
+                 { actor = "operator"
+                 ; cleanup_intent = retain_operator_cleanup
+                 }
+           with
+           | Ok operation -> operation
+           | Error error -> fail (Shutdown_prepare_join.error_to_string error)
+         in
+         prepared := Some (entry, operation);
+         Eio.Switch.fail owner_sw Close_owner_before_join
+       with
+       | Close_owner_before_join -> ());
+      let entry, operation =
+        match !prepared with
+        | Some prepared -> prepared
+        | None -> fail "shutdown owner failure fixture was not prepared"
+      in
+      let blocked =
+        match Shutdown_prepare_join.join_prepared ~config ~entry ~operation with
+        | Error (Shutdown_prepare_join.Join_failed blocked) -> blocked
+        | Error error -> fail (Shutdown_prepare_join.error_to_string error)
+        | Ok _ -> fail "closed owner was reported as a successful lane join"
+      in
+      (match blocked.phase with
+       | Shutdown_types.Blocked { stage = Shutdown_types.Lane_join; detail } ->
+         check bool "owner failure records a non-empty join detail" true
+           (String.length detail > 0)
+       | _ -> fail "owner failure did not become durable Blocked/Lane_join");
+      let loaded =
+        match
+          Shutdown_store.load
+            ~config
+            ~keeper_name:name
+            operation.operation_id
+        with
+        | Ok loaded -> loaded
+        | Error error -> fail (Shutdown_store.error_to_string error)
+      in
+      match loaded.phase with
+      | Shutdown_types.Blocked { stage = Shutdown_types.Lane_join; _ } -> ()
+      | _ -> fail "reloaded owner failure remained stranded in Joining_lanes")
+
+let test_keeper_shutdown_blocks_join_replay_after_record_failure () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir "shutdown-join-record-retry" in
+  Fun.protect
+    ~finally:(fun () ->
+      Memory_lane.For_testing.reset ();
+      R.For_testing.clear ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      let (_init_message : string) =
+        Masc.Workspace.init config ~agent_name:(Some "operator")
+      in
+      let name = "shutdown-join-record-retry-lane" in
+      let meta = make_meta name in
+      (match Keeper_meta_store.replace_snapshot config meta with
+       | Ok () -> ()
+       | Error detail -> fail detail);
+      install_owner_inventory_exn ~sw config;
+      let entry = R.For_testing.register ~base_path:config.base_path name meta in
+      Memory_lane.init ~sw;
+      let librarian_started, resolve_librarian_started = Eio.Promise.create () in
+      let librarian_release, resolve_librarian_release = Eio.Promise.create () in
+      (match
+         Memory_lane.submit
+           ~base_path:config.base_path
+           ~keeper_name:name
+           (fun () ->
+              Eio.Promise.resolve resolve_librarian_started ();
+              Eio.Promise.await librarian_release)
+       with
+       | Memory_lane.Submitted -> ()
+       | Memory_lane.Coalesced
+       | Memory_lane.Ran_inline
+       | Memory_lane.Dropped
+       | Memory_lane.Rejected_draining ->
+         fail "record retry Librarian fixture was not submitted");
+      Eio.Promise.await librarian_started;
+      let operation =
+        match
+          Shutdown_prepare_join.prepare
+            ~config
+            ~entry
+            ~request:
+              { actor = "operator"
+              ; cleanup_intent = retain_operator_cleanup
+              }
+        with
+        | Ok operation -> operation
+        | Error error -> fail (Shutdown_prepare_join.error_to_string error)
+      in
+      let first_join, resolve_first_join = Eio.Promise.create () in
+      Eio.Fiber.fork ~sw (fun () ->
+        Eio.Promise.resolve
+          resolve_first_join
+          (Shutdown_prepare_join.join_prepared ~config ~entry ~operation));
+      let rec await_joining () =
+        match Shutdown_store.load ~config ~keeper_name:name operation.operation_id with
+        | Ok ({ phase = Shutdown_types.Joining_lanes; _ } as joining) -> joining
+        | Ok _ | Error (Shutdown_store.Not_found _) ->
+          Eio.Fiber.yield ();
+          await_joining ()
+        | Error error -> fail (Shutdown_store.error_to_string error)
+      in
+      let joining = await_joining () in
+      let operation_path =
+        match Shutdown_store.path ~config ~keeper_name:name operation.operation_id with
+        | Ok path -> path
+        | Error error -> fail (Shutdown_store.error_to_string error)
+      in
+      let held_path = operation_path ^ ".held" in
+      Unix.rename operation_path held_path;
+      Eio.Promise.resolve resolve_librarian_release ();
+      (match Eio.Promise.await first_join with
+       | Error (Shutdown_prepare_join.Join_record_update_failed _) -> ()
+       | Error error -> fail (Shutdown_prepare_join.error_to_string error)
+       | Ok _ -> fail "missing shutdown record did not fail final join persistence");
+      Unix.rename held_path operation_path;
+      let blocked =
+        match Shutdown_prepare_join.join_prepared ~config ~entry ~operation:joining with
+        | Error (Shutdown_prepare_join.Join_failed blocked) -> blocked
+        | Error error -> fail (Shutdown_prepare_join.error_to_string error)
+        | Ok _ -> fail "Joining_lanes replay guessed a successful prior join"
+      in
+      (match blocked.phase with
+       | Shutdown_types.Blocked { stage = Shutdown_types.Lane_join; _ } -> ()
+       | _ -> fail "join replay did not fail closed as Blocked/Lane_join");
+      match
+        Shutdown_store.load ~config ~keeper_name:name operation.operation_id
+      with
+      | Ok { phase = Shutdown_types.Blocked { stage = Shutdown_types.Lane_join; _ }; _ } ->
+        ()
+      | Ok _ -> fail "reloaded join replay remained stranded in Joining_lanes"
+      | Error error -> fail (Shutdown_store.error_to_string error))
 
 let test_keeper_shutdown_prepare_joins_not_started_lane () =
   Eio_main.run @@ fun env ->
@@ -2520,6 +2761,7 @@ let test_keeper_shutdown_prepare_joins_not_started_lane () =
       (match operation.phase with
        | Shutdown_types.Joined_idle -> ()
        | Shutdown_types.Prepared
+       | Shutdown_types.Joining_lanes
        | Shutdown_types.Finalizing_tasks _
        | Shutdown_types.Cleanup_ready _
        | Shutdown_types.Reconciliation_required _
@@ -2783,6 +3025,7 @@ let test_keeper_shutdown_finalizes_idle_operation () =
        | Shutdown_types.Finalized evidence ->
          check int "no pending confirms" 0 evidence.cleanup.pending_confirms_removed
        | Shutdown_types.Prepared
+       | Shutdown_types.Joining_lanes
        | Shutdown_types.Joined_idle
        | Shutdown_types.Finalizing_tasks _
        | Shutdown_types.Cleanup_ready _
@@ -3093,6 +3336,7 @@ let test_keeper_shutdown_delivers_dead_tombstone_completion_after_receipt () =
            ; _
            } -> check bool "exact dead lane unregistered" true registry_unregistered
        | Shutdown_types.Prepared
+       | Shutdown_types.Joining_lanes
        | Shutdown_types.Joined_idle
        | Shutdown_types.Finalizing_tasks _
        | Shutdown_types.Cleanup_ready _
@@ -3159,6 +3403,7 @@ let test_keeper_shutdown_delivers_dead_tombstone_completion_after_receipt () =
            registry_unregistered;
          check bool "dead tombstone meta retained" false meta_removed
        | Shutdown_types.Prepared
+       | Shutdown_types.Joining_lanes
        | Shutdown_types.Joined_idle
        | Shutdown_types.Finalizing_tasks _
        | Shutdown_types.Cleanup_ready _
@@ -4256,6 +4501,10 @@ let () =
         test_dashboard_purge_resolution_is_fail_closed;
       test_case "shutdown prepare joins idle lane" `Quick
         test_keeper_shutdown_prepare_joins_idle_lane;
+      test_case "shutdown owner failure persists blocked join" `Quick
+        test_keeper_shutdown_owner_failure_persists_blocked_join;
+      test_case "shutdown blocks join replay after record failure" `Quick
+        test_keeper_shutdown_blocks_join_replay_after_record_failure;
       test_case "shutdown prepare joins not-started lane" `Quick
         test_keeper_shutdown_prepare_joins_not_started_lane;
       test_case "shutdown prepare failure rolls back admission fence" `Quick

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -4044,6 +4044,84 @@ let test_keeper_shutdown_recovers_committed_task_receipt () =
       | Ok _ -> fail "task receipt recovery did not reach Finalized"
       | Error error -> fail (Shutdown_finalize.error_to_string error))
 
+let test_librarian_rejection_unregisters_with_lifecycle_authority () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  R.For_testing.clear ();
+  Memory_lane.For_testing.reset ();
+  let base_dir = temp_dir "librarian-lifecycle-rejection" in
+  let keeper_name = "librarian-lifecycle-rejection" in
+  Fun.protect
+    ~finally:(fun () ->
+      R.For_testing.clear ();
+      Memory_lane.For_testing.reset ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      ignore (Masc.Workspace.init config ~agent_name:(Some "tester"));
+      let meta = make_meta keeper_name in
+      Eio.Switch.run @@ fun sw ->
+      Memory_lane.init ~sw;
+      let librarian_started, resolve_librarian_started = Eio.Promise.create () in
+      let librarian_release, resolve_librarian_release = Eio.Promise.create () in
+      (match
+         Memory_lane.submit
+           ~base_path:config.base_path
+           ~keeper_name
+           (fun () ->
+              Eio.Promise.resolve resolve_librarian_started ();
+              Eio.Promise.await librarian_release)
+       with
+       | Memory_lane.Submitted -> ()
+       | Memory_lane.Coalesced
+       | Memory_lane.Ran_inline
+       | Memory_lane.Dropped
+       | Memory_lane.Rejected_draining ->
+         fail "Librarian lifecycle rejection fixture was not submitted");
+      Eio.Promise.await librarian_started;
+      let token =
+        match
+          Keeper_lifecycle_reservation.acquire
+            ~base_path:config.base_path
+            ~keeper_name
+            ~expected_generation:meta.generation
+            ~purpose:Keeper_lifecycle_reservation.Paused_work_disposition
+        with
+        | Ok token -> token
+        | Error _ -> fail "failed to acquire lifecycle rejection fixture token"
+      in
+      let ctx : _ Keeper_types_profile.context =
+        { config
+        ; agent_name = "tester"
+        ; sw
+        ; clock = Eio.Stdenv.clock env
+        ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
+        ; net = None
+        ; publication_recovery_provider =
+            Masc_test_deps.publication_recovery_provider
+              (publication_recovery_registry env sw config)
+        }
+      in
+      seed_keeper_sandbox_profile ~base_dir keeper_name;
+      (match Masc.Keeper_keepalive.start_keepalive ~lifecycle_token:token ctx meta with
+       | Masc.Keeper_keepalive.Keepalive_memory_lane_not_ready
+           Memory_lane.Librarian_drain_still_active -> ()
+       | outcome ->
+         failf
+           "Librarian rejection returned unexpected launch outcome: %s"
+           (Masc.Keeper_keepalive.start_keepalive_outcome_to_string outcome));
+      check bool
+        "lifecycle-authorized rejection removed fresh registry entry"
+        false
+        (R.is_registered ~base_path:config.base_path keeper_name);
+      (match Keeper_lifecycle_reservation.release token with
+       | Keeper_lifecycle_reservation.Released -> ()
+       | outcome ->
+         fail
+           ("failed to release lifecycle rejection fixture: "
+            ^ Keeper_lifecycle_reservation.release_outcome_to_string outcome));
+      Eio.Promise.resolve resolve_librarian_release ())
+
 let test_start_keepalive_denies_dead_tombstone_before_registration () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -4499,6 +4577,8 @@ let () =
         test_unsupported_shutdown_schema_retains_exact_fence;
       test_case "dashboard purge resolution is fail closed" `Quick
         test_dashboard_purge_resolution_is_fail_closed;
+      test_case "Librarian rejection unregisters with lifecycle authority" `Quick
+        test_librarian_rejection_unregisters_with_lifecycle_authority;
       test_case "shutdown prepare joins idle lane" `Quick
         test_keeper_shutdown_prepare_joins_idle_lane;
       test_case "shutdown owner failure persists blocked join" `Quick

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -4084,7 +4084,7 @@ let test_librarian_rejection_unregisters_with_lifecycle_authority () =
           Keeper_lifecycle_reservation.acquire
             ~base_path:config.base_path
             ~keeper_name
-            ~expected_generation:meta.generation
+            ~expected_generation:meta.runtime.nonce
             ~purpose:Keeper_lifecycle_reservation.Paused_work_disposition
         with
         | Ok token -> token

--- a/test/test_keeper_keepalive_launch_order_ast.ml
+++ b/test/test_keeper_keepalive_launch_order_ast.ml
@@ -73,6 +73,23 @@ let test_board_worker_has_one_fork_site () =
        ~callee:"Keeper_keepalive.fork_board_attention_worker")
 ;;
 
+let test_launch_restores_tool_usage_with_lifecycle_authority () =
+  check int
+    "start_keepalive uses the token-qualified restore"
+    1
+    (Ast_grep.count_calls_in_value_binding
+       ~module_path:"lib/keeper/keeper_keepalive.ml"
+       ~binding_name:"start_keepalive"
+       ~callee:"Keeper_registry_tool_usage_persistence.restore_for_lifecycle");
+  check int
+    "start_keepalive does not use the name-only restore"
+    0
+    (Ast_grep.count_calls_in_value_binding
+       ~module_path:"lib/keeper/keeper_keepalive.ml"
+       ~binding_name:"start_keepalive"
+       ~callee:"Keeper_registry_tool_usage_persistence.restore")
+;;
+
 let cleanup_protect_count ~module_path ~binding_name =
   Ast_grep.count_applications_with_label_containing_call_in_value_binding
     ~module_path
@@ -136,6 +153,10 @@ let () =
             "board attention worker has one fork site"
             `Quick
             test_board_worker_has_one_fork_site
+        ; test_case
+            "launch restores tool usage with lifecycle authority"
+            `Quick
+            test_launch_restores_tool_usage_with_lifecycle_authority
         ] )
     ]
 ;;

--- a/test/test_keeper_memory_lane.ml
+++ b/test/test_keeper_memory_lane.ml
@@ -68,6 +68,8 @@ let test_inline_when_uninitialized () =
   | Lane.Submitted -> Alcotest.fail "expected Ran_inline, got Submitted"
   | Lane.Coalesced -> Alcotest.fail "expected Ran_inline, got Coalesced"
   | Lane.Dropped -> Alcotest.fail "expected Ran_inline, got Dropped"
+  | Lane.Rejected_draining ->
+    Alcotest.fail "expected Ran_inline, got Rejected_draining"
 ;;
 
 (* A raising unit in the inline path is contained and returns Ran_inline. *)
@@ -81,6 +83,8 @@ let test_inline_contains_raise () =
   | Lane.Submitted -> Alcotest.fail "expected Ran_inline, got Submitted"
   | Lane.Coalesced -> Alcotest.fail "expected Ran_inline, got Coalesced"
   | Lane.Dropped -> Alcotest.fail "expected Ran_inline, got Dropped"
+  | Lane.Rejected_draining ->
+    Alcotest.fail "expected Ran_inline, got Rejected_draining"
 ;;
 
 (* Two units for the same keeper run one after another: the second only starts
@@ -257,12 +261,16 @@ let test_releases_on_cancel () =
           | Lane.Submitted -> ()
           | Lane.Coalesced -> Alcotest.fail "first cancel unit unexpectedly coalesced"
           | Lane.Ran_inline -> Alcotest.fail "cancel test unexpectedly ran inline"
-          | Lane.Dropped -> Alcotest.fail "cancel test unexpectedly dropped");
+          | Lane.Dropped -> Alcotest.fail "cancel test unexpectedly dropped"
+          | Lane.Rejected_draining ->
+            Alcotest.fail "cancel test unexpectedly crossed a drain boundary");
          (match latest with
           | Lane.Submitted -> ()
           | Lane.Coalesced -> Alcotest.fail "first latest unit unexpectedly coalesced"
-         | Lane.Ran_inline -> Alcotest.fail "latest cancel unit unexpectedly ran inline"
-          | Lane.Dropped -> Alcotest.fail "latest cancel unit unexpectedly dropped");
+          | Lane.Ran_inline -> Alcotest.fail "latest cancel unit unexpectedly ran inline"
+          | Lane.Dropped -> Alcotest.fail "latest cancel unit unexpectedly dropped"
+          | Lane.Rejected_draining ->
+            Alcotest.fail "latest cancel unit unexpectedly crossed a drain boundary");
          Eio.Promise.await started;
          Eio.Switch.fail sw Cancel_lane_test))
    with
@@ -274,48 +282,190 @@ let test_releases_on_cancel () =
   | None -> Alcotest.fail "keeper entry missing after cancel"
 ;;
 
-let test_keeper_shutdown_cancels_and_joins_librarian () =
+let test_keeper_shutdown_drains_and_joins_librarian () =
   Lane.For_testing.reset ();
   let cancelled = ref false in
+  let current_completed = ref false in
+  let latest_completed = ref false in
+  let raced_after_drain_ran = ref false in
+  let reopened_completed = ref false in
   Eio_main.run (fun _env ->
     Eio.Switch.run (fun sw ->
       Lane.init ~sw;
       let started, set_started = Eio.Promise.create () in
-      let never, _set_never = Eio.Promise.create () in
+      let release, set_release = Eio.Promise.create () in
       let submitted =
         Lane.submit
           ~base_path
           ~keeper_name:"shutdown-owner"
           (fun () ->
              Eio.Promise.resolve set_started ();
-             try Eio.Promise.await never with
+             try
+               Eio.Promise.await release;
+               current_completed := true
+             with
              | Eio.Cancel.Cancelled _ as exn ->
                cancelled := true;
                raise exn)
       in
       (match submitted with
        | Lane.Submitted -> ()
-       | Lane.Coalesced | Lane.Ran_inline | Lane.Dropped ->
+       | Lane.Coalesced | Lane.Ran_inline | Lane.Dropped
+       | Lane.Rejected_draining ->
          Alcotest.fail "shutdown Librarian was not submitted");
       Eio.Promise.await started;
       (match
-         Lane.cancel_and_join_librarian
+         Lane.submit
            ~base_path
            ~keeper_name:"shutdown-owner"
+           (fun () -> latest_completed := true)
        with
-       | Lane.Librarian_joined Keeper_lane.Shutdown_requested -> ()
-       | Lane.Librarian_joined _ ->
-         Alcotest.fail "shutdown Librarian joined with a non-shutdown outcome"
-       | Lane.No_librarian_work -> Alcotest.fail "shutdown missed active Librarian"
-       | Lane.Librarian_join_failed detail -> Alcotest.fail detail);
-      Alcotest.(check bool) "provider scope observed cancellation" true !cancelled;
+       | Lane.Submitted -> ()
+       | Lane.Coalesced | Lane.Ran_inline | Lane.Dropped
+       | Lane.Rejected_draining ->
+         Alcotest.fail "latest Librarian unit was not submitted");
+      let joined, set_joined = Eio.Promise.create () in
+      Eio.Fiber.fork ~sw (fun () ->
+        Eio.Promise.resolve
+          set_joined
+          (Lane.drain_and_join_librarian
+             ~base_path
+             ~keeper_name:"shutdown-owner"));
+      Eio.Fiber.yield ();
+      (match
+         Lane.submit
+           ~base_path
+           ~keeper_name:"shutdown-owner"
+           (fun () -> raced_after_drain_ran := true)
+       with
+       | Lane.Rejected_draining -> ()
+       | Lane.Submitted | Lane.Coalesced | Lane.Ran_inline | Lane.Dropped ->
+         Alcotest.fail "post-drain submission crossed the lifecycle boundary");
+      (match Lane.begin_librarian_lifecycle ~base_path ~keeper_name:"shutdown-owner" with
+       | Error Lane.Librarian_drain_still_active -> ()
+       | Ok () -> Alcotest.fail "new lifecycle opened while the prior drain was active");
+      Alcotest.(check bool)
+        "join waits for the accepted current unit"
+        true
+        (Option.is_none (Eio.Promise.peek joined));
+      Alcotest.(check bool) "provider scope was not cancelled" false !cancelled;
+      Eio.Promise.resolve set_release ();
+      (match Eio.Promise.await joined with
+       | Ok Lane.Librarian_drained -> ()
+       | Ok Lane.No_librarian_work -> Alcotest.fail "shutdown missed active Librarian"
+       | Error error -> Alcotest.fail (Lane.librarian_drain_error_to_string error));
+      Alcotest.(check bool) "current unit completed" true !current_completed;
+      Alcotest.(check bool) "accepted latest unit completed" true !latest_completed;
+      Alcotest.(check bool)
+        "racing post-drain unit did not run"
+        false
+        !raced_after_drain_ran;
+      Alcotest.(check bool) "provider scope stayed uncancelled" false !cancelled;
       Alcotest.(check (option int))
         "terminal join drained all Librarian work"
         (Some 0)
         (Lane.For_testing.pending
            ~base_path
+           ~keeper_name:"shutdown-owner");
+      (match
+         Lane.submit
+           ~base_path
            ~keeper_name:"shutdown-owner"
-)))
+           (fun () -> Alcotest.fail "closed lifecycle accepted later work")
+       with
+       | Lane.Rejected_draining -> ()
+       | Lane.Submitted | Lane.Coalesced | Lane.Ran_inline | Lane.Dropped ->
+         Alcotest.fail "terminal drain fence reopened without a new lifecycle");
+      (match Lane.begin_librarian_lifecycle ~base_path ~keeper_name:"shutdown-owner" with
+       | Ok () -> ()
+       | Error error -> Alcotest.fail (Lane.lifecycle_open_error_to_string error));
+      let reopened_done, set_reopened_done = Eio.Promise.create () in
+      (match
+         Lane.submit
+           ~base_path
+           ~keeper_name:"shutdown-owner"
+           (fun () ->
+              reopened_completed := true;
+              Eio.Promise.resolve set_reopened_done ())
+       with
+       | Lane.Submitted -> ()
+       | Lane.Coalesced | Lane.Ran_inline | Lane.Dropped
+       | Lane.Rejected_draining ->
+         Alcotest.fail "new lifecycle could not submit Librarian work");
+      Eio.Promise.await reopened_done;
+      Alcotest.(check bool) "new lifecycle work completed" true !reopened_completed))
+;;
+
+let test_empty_drain_fences_late_submission () =
+  Lane.For_testing.reset ();
+  let late_ran = ref false in
+  Eio_main.run (fun _env ->
+    Eio.Switch.run (fun sw ->
+      Lane.init ~sw;
+      (match
+         Lane.drain_and_join_librarian
+           ~base_path
+           ~keeper_name:"empty-drain-owner"
+       with
+       | Ok Lane.No_librarian_work -> ()
+       | Ok Lane.Librarian_drained ->
+         Alcotest.fail "empty drain reported completed work"
+       | Error error ->
+         Alcotest.fail (Lane.librarian_drain_error_to_string error));
+      (match
+         Lane.submit
+           ~base_path
+           ~keeper_name:"empty-drain-owner"
+           (fun () -> late_ran := true)
+       with
+       | Lane.Rejected_draining -> ()
+       | Lane.Submitted | Lane.Coalesced | Lane.Ran_inline | Lane.Dropped ->
+         Alcotest.fail "empty drain left no lifecycle fence");
+      Alcotest.(check bool) "late empty-drain unit did not run" false !late_ran))
+;;
+
+let test_drain_reports_parent_cancellation () =
+  Lane.For_testing.reset ();
+  Eio_main.run (fun _env ->
+    Eio.Switch.run (fun _root_sw ->
+      (try
+         Eio.Switch.run (fun executor_sw ->
+           Lane.init ~sw:executor_sw;
+           let started, set_started = Eio.Promise.create () in
+           let never, _set_never = Eio.Promise.create () in
+           (match
+              Lane.submit
+                ~base_path
+                ~keeper_name:"cancelled-drain-owner"
+                (fun () ->
+                   Eio.Promise.resolve set_started ();
+                   Eio.Promise.await never)
+            with
+            | Lane.Submitted -> ()
+            | Lane.Coalesced | Lane.Ran_inline | Lane.Dropped
+           | Lane.Rejected_draining ->
+              Alcotest.fail "cancellation fixture was not submitted");
+           Eio.Promise.await started;
+           Eio.Switch.fail executor_sw Cancel_lane_test)
+       with
+       | Cancel_lane_test -> ());
+      (* The owner and its cleanup have already finished. Shutdown must still
+         observe that exact terminal receipt instead of treating the detached
+         entry as ownerless success. *)
+      match
+        Lane.drain_and_join_librarian
+          ~base_path
+          ~keeper_name:"cancelled-drain-owner"
+      with
+      | Error (Lane.Librarian_interrupted (Keeper_lane.Cancelled_by_parent _)) -> ()
+      | Error error ->
+        Alcotest.failf
+          "unexpected typed drain error: %s"
+          (Lane.librarian_drain_error_to_string error)
+      | Ok Lane.No_librarian_work ->
+        Alcotest.fail "cancelled active drain was reported as no work"
+      | Ok Lane.Librarian_drained ->
+        Alcotest.fail "parent-cancelled drain was reported as completed"))
 ;;
 
 (* Submitting against a finished executor switch must not leak the pending
@@ -341,9 +491,27 @@ let test_finished_switch_drops_without_leak () =
    | Lane.Dropped -> ()
    | Lane.Submitted -> Alcotest.fail "expected Dropped, got Submitted"
    | Lane.Coalesced -> Alcotest.fail "expected Dropped, got Coalesced"
-   | Lane.Ran_inline -> Alcotest.fail "expected Dropped, got Ran_inline");
+   | Lane.Ran_inline -> Alcotest.fail "expected Dropped, got Ran_inline"
+   | Lane.Rejected_draining ->
+     Alcotest.fail "expected Dropped, got Rejected_draining");
   match Lane.For_testing.pending ~base_path ~keeper_name:"k1" with
-  | Some 0 -> ()
+  | Some 0 ->
+    (match Lane.drain_and_join_librarian ~base_path ~keeper_name:"k1" with
+     | Error (Lane.Librarian_interrupted (Keeper_lane.Failed _)) -> ()
+     | Error error ->
+       Alcotest.failf
+         "finished-switch drain returned an unexpected error: %s"
+         (Lane.librarian_drain_error_to_string error)
+     | Ok Lane.No_librarian_work ->
+       Alcotest.fail "finished-switch drop lost its terminal owner receipt"
+     | Ok Lane.Librarian_drained ->
+       Alcotest.fail "finished-switch drop was reported as completed");
+    (match Lane.begin_librarian_lifecycle ~base_path ~keeper_name:"k1" with
+     | Ok () -> ()
+     | Error error ->
+       Alcotest.fail
+         ("finished-switch receipt prevented lifecycle reopen: "
+          ^ Lane.lifecycle_open_error_to_string error))
   | Some n -> Alcotest.failf "pending leaked after finished switch submit: %d" n
   | None -> Alcotest.fail "keeper entry missing after finished switch submit"
 ;;
@@ -428,7 +596,8 @@ let test_post_turn_librarian_live_config_boundaries () =
         in
         (match blocker with
          | Lane.Submitted -> ()
-         | Lane.Coalesced | Lane.Ran_inline | Lane.Dropped ->
+         | Lane.Coalesced | Lane.Ran_inline | Lane.Dropped
+         | Lane.Rejected_draining ->
            Alcotest.fail "Librarian blocker was not submitted");
         Eio.Promise.await started;
         run_post_turn ~config ~meta ~turn;
@@ -489,9 +658,17 @@ let () =
         ; Alcotest.test_case "releases on raise" `Quick test_releases_on_raise
         ; Alcotest.test_case "releases on cancel" `Quick test_releases_on_cancel
         ; Alcotest.test_case
-            "Keeper shutdown cancels and joins Librarian"
+            "Keeper shutdown drains and joins Librarian"
             `Quick
-            test_keeper_shutdown_cancels_and_joins_librarian
+            test_keeper_shutdown_drains_and_joins_librarian
+        ; Alcotest.test_case
+            "drain reports parent cancellation"
+            `Quick
+            test_drain_reports_parent_cancellation
+        ; Alcotest.test_case
+            "empty drain fences late submission"
+            `Quick
+            test_empty_drain_fences_late_submission
         ; Alcotest.test_case
             "finished switch drops without leak"
             `Quick

--- a/test/test_keeper_memory_lane.ml
+++ b/test/test_keeper_memory_lane.ml
@@ -573,6 +573,47 @@ let test_finished_switch_drops_without_leak () =
   | None -> Alcotest.fail "keeper entry missing after finished switch submit"
 ;;
 
+let test_accepting_reopen_clears_exited_owner_receipt () =
+  Lane.For_testing.reset ();
+  let finished_sw = ref None in
+  Eio_main.run (fun _env ->
+    Eio.Switch.run (fun sw ->
+      Lane.init ~sw;
+      finished_sw := Some sw));
+  let sw =
+    match !finished_sw with
+    | Some sw -> sw
+    | None -> Alcotest.fail "missing captured switch"
+  in
+  Lane.init ~sw;
+  (match Lane.submit ~base_path ~keeper_name:"accepting-reopen" (fun () -> raise Test_boom) with
+   | Lane.Dropped -> ()
+   | Lane.Submitted | Lane.Coalesced | Lane.Ran_inline
+   | Lane.Rejected_draining ->
+     Alcotest.fail "finished executor did not drop the Librarian unit");
+  (* Reopen before a drain can change [Accepting] to [Draining]. This exact
+     ordering used to carry the prior failed receipt into the new lifecycle. *)
+  (match
+     Lane.begin_librarian_lifecycle
+       ~base_path
+       ~keeper_name:"accepting-reopen"
+   with
+   | Ok () -> ()
+   | Error error -> Alcotest.fail (Lane.lifecycle_open_error_to_string error));
+  match
+    Lane.drain_and_join_librarian
+      ~base_path
+      ~keeper_name:"accepting-reopen"
+  with
+  | Ok Lane.No_librarian_work -> ()
+  | Ok Lane.Librarian_drained ->
+    Alcotest.fail "reopened lifecycle inherited completed prior work"
+  | Error error ->
+    Alcotest.failf
+      "reopened accepting lifecycle inherited stale owner receipt: %s"
+      (Lane.librarian_drain_error_to_string error)
+;;
+
 (* The Librarian setting is live while lane work is asynchronous. The
    post-turn entrypoint must reject OFF/INVALID before submission, then fence
    an already queued ON unit again before snapshot I/O when the setting changes
@@ -734,6 +775,10 @@ let () =
             "finished switch drops without leak"
             `Quick
             test_finished_switch_drops_without_leak
+        ; Alcotest.test_case
+            "accepting reopen clears exited owner receipt"
+            `Quick
+            test_accepting_reopen_clears_exited_owner_receipt
         ; Alcotest.test_case
             "post-turn Librarian live config boundaries"
             `Quick

--- a/test/test_keeper_memory_lane.ml
+++ b/test/test_keeper_memory_lane.ml
@@ -468,6 +468,55 @@ let test_drain_reports_parent_cancellation () =
         Alcotest.fail "parent-cancelled drain was reported as completed"))
 ;;
 
+let test_abort_cancels_without_joining_provider_work () =
+  Lane.For_testing.reset ();
+  let cancelled = ref false in
+  Eio_main.run (fun _env ->
+    Eio.Switch.run (fun sw ->
+      Lane.init ~sw;
+      let started, set_started = Eio.Promise.create () in
+      let never, _set_never = Eio.Promise.create () in
+      (match
+         Lane.submit
+           ~base_path
+           ~keeper_name:"crashed-owner"
+           (fun () ->
+              Eio.Promise.resolve set_started ();
+              try Eio.Promise.await never with
+              | Eio.Cancel.Cancelled _ as exn ->
+                cancelled := true;
+                raise exn)
+       with
+       | Lane.Submitted -> ()
+       | Lane.Coalesced | Lane.Ran_inline | Lane.Dropped
+       | Lane.Rejected_draining ->
+         Alcotest.fail "crash-abort Librarian was not submitted");
+      Eio.Promise.await started;
+      (match Lane.abort_librarian ~base_path ~keeper_name:"crashed-owner" with
+       | Ok Lane.Librarian_abort_requested
+       | Ok Lane.Librarian_abort_already_in_progress -> ()
+       | Ok Lane.Librarian_abort_idle ->
+         Alcotest.fail "active crash-abort Librarian was reported idle"
+       | Ok (Lane.Librarian_abort_already_exited _) ->
+         Alcotest.fail "active crash-abort Librarian had already exited"
+       | Ok (Lane.Librarian_abort_committed_with_failure exn) ->
+         Alcotest.failf
+           "crash-abort cancellation callback failed: %s"
+           (Printexc.to_string exn)
+       | Error error -> Alcotest.fail (Lane.librarian_abort_error_to_string error));
+      match Lane.drain_and_join_librarian ~base_path ~keeper_name:"crashed-owner" with
+      | Error (Lane.Librarian_interrupted Keeper_lane.Shutdown_requested) ->
+        Alcotest.(check bool) "provider work was cancelled" true !cancelled
+      | Error error ->
+        Alcotest.failf
+          "unexpected crash-abort receipt: %s"
+          (Lane.librarian_drain_error_to_string error)
+      | Ok Lane.No_librarian_work ->
+        Alcotest.fail "crash-abort lost the exact owner receipt"
+      | Ok Lane.Librarian_drained ->
+        Alcotest.fail "cancelled crash-abort work was reported drained"))
+;;
+
 (* Submitting against a finished executor switch must not leak the pending
    reservation. Eio.Fiber.fork does not raise to the caller for an off switch, so
    the lane needs its own executor-switch release fallback. *)
@@ -511,7 +560,15 @@ let test_finished_switch_drops_without_leak () =
      | Error error ->
        Alcotest.fail
          ("finished-switch receipt prevented lifecycle reopen: "
-          ^ Lane.lifecycle_open_error_to_string error))
+          ^ Lane.lifecycle_open_error_to_string error));
+    (match Lane.drain_and_join_librarian ~base_path ~keeper_name:"k1" with
+     | Ok Lane.No_librarian_work -> ()
+     | Ok Lane.Librarian_drained ->
+       Alcotest.fail "reopened empty lifecycle retained stale completed work"
+     | Error error ->
+       Alcotest.failf
+         "reopened lifecycle retained stale owner receipt: %s"
+         (Lane.librarian_drain_error_to_string error))
   | Some n -> Alcotest.failf "pending leaked after finished switch submit: %d" n
   | None -> Alcotest.fail "keeper entry missing after finished switch submit"
 ;;
@@ -665,6 +722,10 @@ let () =
             "drain reports parent cancellation"
             `Quick
             test_drain_reports_parent_cancellation
+        ; Alcotest.test_case
+            "crash abort cancels without joining provider work"
+            `Quick
+            test_abort_cancels_without_joining_provider_work
         ; Alcotest.test_case
             "empty drain fences late submission"
             `Quick

--- a/test/test_keeper_memory_lane.ml
+++ b/test/test_keeper_memory_lane.ml
@@ -87,6 +87,33 @@ let test_inline_contains_raise () =
     Alcotest.fail "expected Ran_inline, got Rejected_draining"
 ;;
 
+(* The startup inline fallback is still behind the lifecycle fence. A failed
+   launch closes Librarian admission before the long-lived executor switch is
+   installed, so falling back to inline execution must not reopen it. *)
+let test_inline_rejects_draining_lifecycle () =
+  Lane.For_testing.reset ();
+  let ran = ref false in
+  (match
+     Lane.drain_and_join_librarian
+       ~base_path
+       ~keeper_name:"inline-draining"
+   with
+   | Ok Lane.No_librarian_work -> ()
+   | Ok Lane.Librarian_drained ->
+     Alcotest.fail "empty inline drain reported completed work"
+   | Error error -> Alcotest.fail (Lane.librarian_drain_error_to_string error));
+  (match
+     Lane.submit
+       ~base_path
+       ~keeper_name:"inline-draining"
+       (fun () -> ran := true)
+   with
+   | Lane.Rejected_draining -> ()
+   | Lane.Submitted | Lane.Coalesced | Lane.Ran_inline | Lane.Dropped ->
+     Alcotest.fail "inline fallback bypassed the lifecycle fence");
+  Alcotest.(check bool) "draining inline unit did not run" false !ran
+;;
+
 (* Two units for the same keeper run one after another: the second only starts
    after the first releases the keeper's mutex. *)
 let test_serializes_within_keeper () =
@@ -741,6 +768,10 @@ let () =
             "inline contains raise"
             `Quick
             test_inline_contains_raise
+        ; Alcotest.test_case
+            "inline rejects draining lifecycle"
+            `Quick
+            test_inline_rejects_draining_lifecycle
         ; Alcotest.test_case
             "serializes within keeper"
             `Quick

--- a/test/test_keeper_registry_hardening.ml
+++ b/test/test_keeper_registry_hardening.ml
@@ -497,6 +497,73 @@ let cleanup_dir path =
   | exception Unix.Unix_error (Unix.ENOENT, _, _) -> ()
 ;;
 
+let test_tool_usage_restore_uses_lifecycle_authority () =
+  let dir = temp_dir "registry_tool_usage_restore" in
+  Fun.protect
+    ~finally:(fun () ->
+      KR.For_testing.clear ();
+      cleanup_dir dir)
+    (fun () ->
+       Eio_main.run @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       KR.For_testing.clear ();
+       let meta = make_meta "lifecycle-restore" in
+       let registered = KR.For_testing.register ~base_path:dir meta.name meta in
+       let path =
+         Filename.concat
+           dir
+           ".masc/keepers/tool_usage/lifecycle-restore.json"
+       in
+       Fs_compat.mkdir_p (Filename.dirname path);
+       Fs_compat.save_file
+         path
+         (Yojson.Safe.to_string
+            (`Assoc
+              [ "schema_version", `Int 2
+              ; "keeper", `String meta.name
+              ; "flushed_at", `Float 1.0
+              ; ( "tools"
+                , `List
+                    [ `Assoc
+                        [ "tool", `String "masc_status"
+                        ; "count", `Int 1
+                        ; "successes", `Int 1
+                        ; "deferred", `Int 0
+                        ; "failures", `Int 0
+                        ; "last_used_at", `Float 1.0
+                        ]
+                    ] )
+              ])
+          ^ "\n");
+       let token =
+         match
+           Reservation.acquire
+             ~base_path:dir
+             ~keeper_name:meta.name
+             ~expected_generation:registered.transition_seq
+             ~purpose:Reservation.Keepalive_launch
+         with
+         | Ok token -> token
+         | Error _ -> fail "failed to reserve Keeper launch lifecycle"
+       in
+       Fun.protect
+         ~finally:(fun () ->
+           ignore (Reservation.release token : Reservation.release_outcome))
+         (fun () ->
+            Masc.Keeper_registry_tool_usage_persistence.restore
+              ~base_path:dir
+              meta.name;
+            check (list string) "name-only restore is fenced" []
+              (KR.tool_usage_of ~base_path:dir meta.name |> List.map fst);
+            Masc.Keeper_registry_tool_usage_persistence.restore_for_lifecycle
+              token
+              registered;
+            check (option int) "token-qualified restore keeps exact count" (Some 1)
+              (KR.tool_usage_of ~base_path:dir meta.name
+               |> List.assoc_opt "masc_status"
+               |> Option.map (fun entry -> entry.Keeper_types.count))))
+;;
+
 let test_reactive_wakeup_defers_offline_lane_after_queue_commit () =
   let dir = temp_dir "registry_reactive_offline_wakeup" in
   Fun.protect
@@ -1390,6 +1457,12 @@ let () =
             "rejects fork on an already-cancelling switch"
             `Quick
             test_lane_fork_rejects_cancelling_switch
+        ] )
+    ; ( "tool_usage_restore"
+      , [ test_case
+            "uses exact lifecycle authority"
+            `Quick
+            test_tool_usage_restore_uses_lifecycle_authority
         ] )
     ; ( "get_with_health"
       , [ test_case "get filters corrupted entry" `Quick test_get_filters_corrupted_entry ] )

--- a/test/test_keeper_shutdown_reconciliation_settlement.ml
+++ b/test/test_keeper_shutdown_reconciliation_settlement.ml
@@ -141,6 +141,7 @@ let recover_exn ~config operation =
 let phase_label operation =
   match operation.phase with
   | Prepared -> "prepared"
+  | Joining_lanes -> "joining_lanes"
   | Joined_idle -> "joined_idle"
   | Finalizing_tasks _ -> "finalizing_tasks"
   | Cleanup_ready _ -> "cleanup_ready"
@@ -241,6 +242,44 @@ let test_recovery_still_settles_prepared_without_turn () =
       (requires_admission_fence recovered))
 ;;
 
+(* [Joining_lanes] proves that the previous process crossed the point where
+   the primary and Librarian lanes were being joined. Unlike [Prepared], boot
+   cannot infer whether the accepted Librarian input committed. Recovery must
+   retain admission and name that uncertainty instead of silently finalizing. *)
+let test_recovery_blocks_interrupted_lane_join () =
+  with_workspace (fun ~config ->
+    let operation =
+      make_operation
+        ~keeper_name:"reconciliation-joining-lanes"
+        ~phase:Joining_lanes
+        ~turn_disposition:No_inflight_turn
+    in
+    write_keeper_meta_exn ~config ~keeper_name:operation.keeper_name;
+    persist_exn ~config operation;
+    let recovered = recover_exn ~config operation in
+    (match recovered.phase with
+     | Blocked { stage = Lane_join; detail } ->
+       check string
+         "blocked evidence names unknown Librarian completion"
+         "server process ended while joining Keeper and Librarian lanes; Librarian completion is unknown"
+         detail
+     | _ -> fail "interrupted lane join did not recover as blocked");
+    check bool "interrupted join retains admission" true (requires_admission_fence recovered);
+    match
+      Keeper_shutdown_store.load
+        ~config
+        ~keeper_name:operation.keeper_name
+        operation.operation_id
+    with
+    | Ok { phase = Blocked { stage = Lane_join; _ }; _ } -> ()
+    | Ok persisted ->
+      failf "durable interrupted join phase=%s" (phase_label persisted)
+    | Error error ->
+      failf
+        "durable interrupted join missing: %s"
+        (Keeper_shutdown_store.error_to_string error))
+;;
+
 (* A shutdown whose lane is unregistered by a concurrent fiber (supervisor,
    keepalive, or a sibling shutdown) must not block. Reading the registry one
    step earlier already returns [Ok ()] for an absent lane, so blocking when
@@ -282,6 +321,10 @@ let () =
             "still settles a prepared operation without a turn"
             `Quick
             test_recovery_still_settles_prepared_without_turn
+        ; test_case
+            "blocks a process interrupted during lane join"
+            `Quick
+            test_recovery_blocks_interrupted_lane_join
         ] )
     ]
 ;;

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -901,6 +901,7 @@ let test_supervise_keepalive_retains_sweep_owned_entries () =
   let launched = ref [] in
   let publish_lifecycle ~event:_ _name _detail () = () in
   let launch_supervised_fiber
+        ~intake_token:_
         ~lifecycle_token:_
         ~proactive_warmup_sec:_
         _ctx
@@ -1078,6 +1079,7 @@ let test_supervise_keepalive_wakes_ready_operation_drain () =
        let ctx = keeper_runtime_context env sw config in
        let publish_lifecycle ~event:_ _name _detail () = () in
        let launch_supervised_fiber
+             ~intake_token:_
              ~lifecycle_token:_
              ~proactive_warmup_sec:_
              _ctx
@@ -2555,10 +2557,15 @@ let test_active_librarian_abort_defers_then_retries_restart () =
            ~base_path:config.base_path
            ~keeper_name:name
            ~expected_generation:previous.transition_seq
-           ~register:(fun token ->
-             Reg.register_restarting_for_lifecycle token ~base_path:config.base_path name meta)
-           ~rollback:(Launch_transaction.rollback_restore_previous ~previous)
-           (fun _token replacement -> replacement)
+           ~register:(fun token intake_token ->
+             Reg.register_restarting_for_lifecycle
+               ~intake_token
+               token
+               ~base_path:config.base_path
+               name
+               meta)
+           ~rollback:(Launch_transaction.Restore_previous previous)
+           (fun _intake_token _token replacement -> replacement)
        in
        (match run_restart crashed with
         | Error (Launch_transaction.Lifecycle_open_failed _) -> ()
@@ -2592,6 +2599,303 @@ let test_active_librarian_abort_defers_then_retries_restart () =
            : (Memory_lane.librarian_drain_outcome,
               Memory_lane.librarian_drain_error)
                result))
+
+let crashed_restart_fixture ~base_path name meta =
+  let initial = Reg.For_testing.register ~base_path name meta in
+  (match
+     Reg.dispatch_event_exact
+       initial
+       (KSM.Fiber_terminated
+          { outcome = "fixture crash"; provider_id = None; http_status = None })
+   with
+   | Ok _ -> ()
+   | Error error -> fail (KSM.transition_error_to_string error));
+  match Reg.get ~base_path name with
+  | Some entry -> entry
+  | None -> fail "crashed restart fixture disappeared"
+;;
+
+let register_restart ~base_path ~name ~meta token intake_token =
+  Reg.register_restarting_for_lifecycle
+    ~intake_token
+    token
+    ~base_path
+    name
+    meta
+;;
+
+let test_launch_callback_failure_rolls_back_restart_transaction () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  ensure_test_runtime ();
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Reg.For_testing.clear ();
+      Memory_lane.For_testing.reset ();
+      Masc.Keeper_shutdown_intake_fence.For_testing.reset ();
+      Masc.Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_dir in
+       ignore (Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name));
+       Memory_lane.For_testing.reset ();
+       let name = "librarian-launch-exception-rollback" in
+       let meta = make_meta name in
+       let crashed = crashed_restart_fixture ~base_path:config.base_path name meta in
+       (match
+          Launch_transaction.run
+            ~base_path:config.base_path
+            ~keeper_name:name
+            ~expected_generation:crashed.transition_seq
+            ~register:(register_restart ~base_path:config.base_path ~name ~meta)
+            ~rollback:(Launch_transaction.Restore_previous crashed)
+            (fun _intake_token _token _replacement ->
+              failwith "injected launch callback failure")
+        with
+        | Error
+            (Launch_transaction.Launch_failed
+               { librarian_abort_error = None; rollback_error = None; _ }) -> ()
+        | Error _ -> fail "launch exception produced the wrong transaction outcome"
+        | Ok _ -> fail "launch exception unexpectedly committed");
+       (match Reg.get ~base_path:config.base_path name with
+        | Some current ->
+          check bool "launch exception restores exact crashed authority" true
+            (Lane.Id.equal (Lane.id current.lane) (Lane.id crashed.lane))
+        | None -> fail "launch exception removed the durable restart authority");
+       (match Memory_lane.submit ~base_path:config.base_path ~keeper_name:name ignore with
+        | Memory_lane.Rejected_draining -> ()
+        | _ -> fail "failed launch left Librarian admission open");
+       match
+         Launch_transaction.run
+           ~base_path:config.base_path
+           ~keeper_name:name
+           ~expected_generation:crashed.transition_seq
+           ~register:(register_restart ~base_path:config.base_path ~name ~meta)
+           ~rollback:(Launch_transaction.Restore_previous crashed)
+           (fun _intake_token _token replacement -> replacement)
+       with
+       | Ok replacement ->
+         check bool "retry installs a fresh restart lane" false
+           (Lane.Id.equal (Lane.id replacement.lane) (Lane.id crashed.lane))
+       | Error _ -> fail "retry did not reopen the rolled-back Librarian lifecycle")
+;;
+
+let test_launch_callback_cancellation_rolls_back_restart_transaction () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  ensure_test_runtime ();
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Reg.For_testing.clear ();
+      Memory_lane.For_testing.reset ();
+      Masc.Keeper_shutdown_intake_fence.For_testing.reset ();
+      Masc.Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_dir in
+       ignore (Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name));
+       Memory_lane.For_testing.reset ();
+       let name = "librarian-launch-cancellation-rollback" in
+       let meta = make_meta name in
+       let crashed = crashed_restart_fixture ~base_path:config.base_path name meta in
+       let cancel_context, resolve_cancel_context = Eio.Promise.create () in
+       let launch_entered, resolve_launch_entered = Eio.Promise.create () in
+       let cancelled, resolve_cancelled = Eio.Promise.create () in
+       let never, _resolve_never = Eio.Promise.create () in
+       Eio.Fiber.fork ~sw (fun () ->
+         let saw_cancellation =
+           try
+             Eio.Cancel.sub (fun context ->
+               Eio.Promise.resolve resolve_cancel_context context;
+               ignore
+                 (Launch_transaction.run
+                    ~base_path:config.base_path
+                    ~keeper_name:name
+                    ~expected_generation:crashed.transition_seq
+                    ~register:
+                      (register_restart ~base_path:config.base_path ~name ~meta)
+                    ~rollback:(Launch_transaction.Restore_previous crashed)
+                    (fun _intake_token _token _replacement ->
+                       Eio.Promise.resolve resolve_launch_entered ();
+                       Eio.Promise.await never)
+                   : (_, _) result);
+               false)
+           with
+           | Eio.Cancel.Cancelled _ -> true
+         in
+         Eio.Promise.resolve resolve_cancelled saw_cancellation);
+       let context = Eio.Promise.await cancel_context in
+       Eio.Promise.await launch_entered;
+       Eio.Cancel.cancel context (Failure "cancel injected launch callback");
+       check bool "launch cancellation propagates after rollback" true
+         (Eio.Promise.await cancelled);
+       (match Reg.get ~base_path:config.base_path name with
+        | Some current ->
+          check bool "launch cancellation restores exact crashed authority" true
+            (Lane.Id.equal (Lane.id current.lane) (Lane.id crashed.lane))
+        | None -> fail "launch cancellation removed the durable restart authority");
+       (match
+          Lifecycle_reservation.current
+            ~base_path:config.base_path
+            ~keeper_name:name
+        with
+        | None -> ()
+        | Some owner ->
+          fail
+            ("launch cancellation leaked lifecycle reservation: "
+             ^ Lifecycle_reservation.snapshot_to_string owner));
+       match Memory_lane.submit ~base_path:config.base_path ~keeper_name:name ignore with
+       | Memory_lane.Rejected_draining -> ()
+       | _ -> fail "cancelled launch left Librarian admission open")
+;;
+
+let test_started_launch_exception_retains_registered_lane () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  ensure_test_runtime ();
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Reg.For_testing.clear ();
+      Memory_lane.For_testing.reset ();
+      Masc.Keeper_shutdown_intake_fence.For_testing.reset ();
+      Masc.Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_dir in
+       ignore (Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name));
+       let name = "started-launch-exception-retained" in
+       let meta = make_meta name in
+       let crashed = crashed_restart_fixture ~base_path:config.base_path name meta in
+       let started = ref None in
+       (match
+          Launch_transaction.run
+            ~base_path:config.base_path
+            ~keeper_name:name
+            ~expected_generation:crashed.transition_seq
+            ~register:(register_restart ~base_path:config.base_path ~name ~meta)
+            ~rollback:(Launch_transaction.Restore_previous crashed)
+            (fun _intake_token _token replacement ->
+               (match
+                  Lane.fork
+                    ~sw
+                    replacement.lane
+                    ~run:(fun _ -> ())
+                    ~cleanup:(fun _ -> Ok ())
+                with
+                | Ok () -> started := Some replacement
+                | Error error -> fail (Lane.start_error_to_string error));
+               failwith "post-fork observation failure")
+        with
+        | Error (Launch_transaction.Launch_failed { rollback_error = Some _; _ }) -> ()
+        | Error _ -> fail "started launch failure lost its retention evidence"
+        | Ok _ -> fail "started launch exception unexpectedly committed");
+       let expected = Option.get !started in
+       match Reg.get ~base_path:config.base_path name with
+       | Some current ->
+         check bool "started lane remains registry-owned" true
+           (Lane.Id.equal (Lane.id current.lane) (Lane.id expected.lane))
+       | None -> fail "started launch exception detached the live lane")
+;;
+
+let test_restart_intake_epoch_survives_shutdown_overlap () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  ensure_test_runtime ();
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Reg.For_testing.clear ();
+      Memory_lane.For_testing.reset ();
+      Masc.Keeper_shutdown_intake_fence.For_testing.reset ();
+      Masc.Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_dir in
+       ignore (Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name));
+       Memory_lane.For_testing.reset ();
+       let name = "restart-intake-shutdown-overlap" in
+       let meta = make_meta name in
+       let crashed = crashed_restart_fixture ~base_path:config.base_path name meta in
+       let registered, resolve_registered = Eio.Promise.create () in
+       let continue_launch, resolve_continue_launch = Eio.Promise.create () in
+       let finished, resolve_finished = Eio.Promise.create () in
+       Eio.Fiber.fork ~sw (fun () ->
+         let result =
+           Launch_transaction.run
+             ~base_path:config.base_path
+             ~keeper_name:name
+             ~expected_generation:crashed.transition_seq
+             ~register:(fun token intake_token ->
+               match
+                 register_restart
+                   ~base_path:config.base_path
+                   ~name
+                   ~meta
+                   token
+                   intake_token
+               with
+               | Error _ as error -> error
+               | Ok replacement as ok ->
+                 Eio.Promise.resolve resolve_registered replacement;
+                 Eio.Promise.await continue_launch;
+                 ok)
+             ~rollback:(Launch_transaction.Restore_previous crashed)
+             (fun intake_token _token replacement ->
+               let bootstrap : Keeper_event_queue.stimulus =
+                 { post_id = "restart-intake-token-bootstrap"
+                 ; urgency = Keeper_event_queue.Normal
+                 ; arrived_at = Unix.gettimeofday ()
+                 ; payload = Keeper_event_queue.Bootstrap
+                 }
+               in
+               Masc.Keeper_registry_event_queue.enqueue
+                 ~intake_token
+                 ~base_path:config.base_path
+                 name
+                 bootstrap;
+               replacement)
+         in
+         Eio.Promise.resolve resolve_finished result);
+       let registered_entry = Eio.Promise.await registered in
+       let operation_id = Shutdown_types.Operation_id.generate () in
+       (match
+          Masc.Keeper_shutdown_intake_fence.begin_shutdown
+            ~base_path:config.base_path
+            ~keeper_name:name
+            ~operation_id
+        with
+        | Masc.Keeper_shutdown_intake_fence.Reserved _ -> ()
+        | Masc.Keeper_shutdown_intake_fence.Already_reserved _ ->
+          fail "fresh shutdown operation was already reserved");
+       Eio.Promise.resolve resolve_continue_launch ();
+       (match Eio.Promise.await finished with
+        | Ok launched ->
+          check bool "same registered lane crosses Librarian and launch handoff" true
+            (Lane.Id.equal (Lane.id launched.lane) (Lane.id registered_entry.lane))
+        | Error _ -> fail "create-wins restart epoch was rejected after registration");
+       (match
+          Masc.Keeper_shutdown_intake_fence.shutdown_operation_id
+            ~base_path:config.base_path
+            ~keeper_name:name
+        with
+        | Some actual ->
+          check bool "launch does not erase the later shutdown owner" true
+            (Shutdown_types.Operation_id.equal operation_id actual)
+        | None -> fail "launch erased the later shutdown reservation");
+       ignore
+         (Masc.Keeper_shutdown_intake_fence.rollback_shutdown
+            ~base_path:config.base_path
+            ~keeper_name:name
+            ~operation_id
+          : Masc.Keeper_shutdown_intake_fence.rollback_result))
+;;
 
 let () =
   run "keeper_supervisor" [
@@ -2673,6 +2977,14 @@ let () =
         test_restart_denies_persisted_dead_tombstone;
       test_case "active Librarian abort defers then retries restart" `Quick
         test_active_librarian_abort_defers_then_retries_restart;
+      test_case "launch callback failure rolls back restart transaction" `Quick
+        test_launch_callback_failure_rolls_back_restart_transaction;
+      test_case "launch callback cancellation rolls back restart transaction" `Quick
+        test_launch_callback_cancellation_rolls_back_restart_transaction;
+      test_case "started launch exception retains registered lane" `Quick
+        test_started_launch_exception_retains_registered_lane;
+      test_case "restart intake epoch survives shutdown overlap" `Quick
+        test_restart_intake_epoch_survives_shutdown_overlap;
     ];
     "dead_state_alert", [
       test_case "sweep cleanup fires Tombstone_reaped hook" `Quick

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -21,7 +21,6 @@ module KSS = Masc.Keeper_supervisor_supervise_keepalive
 module Chat_operation = Masc.Keeper_owner.Chat_operation
 module Supervisor_launch = Masc.Keeper_supervisor_launch
 module Lane = Masc.Keeper_lane
-module Memory_lane = Masc.Keeper_memory_lane
 module Shutdown_finalize = Masc.Keeper_shutdown_finalize
 module Shutdown_store = Masc.Keeper_shutdown_store
 module Shutdown_types = Masc.Keeper_shutdown_types
@@ -1375,61 +1374,6 @@ let test_restart_path_emits_attempt_and_started_outcome_metrics () =
       | Some entry ->
           check int "restart count restored to attempt" 1 entry.restart_count)
 
-let test_restart_reopens_crash_aborted_librarian_lifecycle () =
-  with_restart_launch_noop @@ fun () ->
-  Eio_main.run @@ fun env ->
-  ensure_fs env;
-  Eio.Switch.run @@ fun sw ->
-  with_config_dir @@ fun config_dir ->
-  let base_dir = temp_dir () in
-  let name = "restart-reopens-librarian" in
-  Fun.protect
-    ~finally:(fun () ->
-      Memory_lane.For_testing.reset ();
-      Reg.For_testing.clear ();
-      Masc.Keeper_runtime.reset_test_state base_dir;
-      cleanup_dir base_dir)
-    (fun () ->
-      Memory_lane.For_testing.reset ();
-      let config = Masc.Workspace.default_config base_dir in
-      ignore (Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name));
-      write_keeper_toml config_dir ~name;
-      let meta = make_meta name in
-      (match Keeper_meta_store.replace_snapshot config meta with
-       | Ok () -> ()
-       | Error err -> fail err);
-      let reg = Reg.For_testing.register ~base_path:config.base_path name meta in
-      resolve_done_for_test reg (`Crashed "ordinary crash");
-      (match Memory_lane.abort_librarian ~base_path:config.base_path ~keeper_name:name with
-       | Ok Memory_lane.Librarian_abort_idle -> ()
-       | Ok _ -> fail "empty crash-abort fixture unexpectedly owned Librarian work"
-       | Error error -> fail (Memory_lane.librarian_abort_error_to_string error));
-      let ctx : _ Keeper_types_profile.context =
-        { config
-        ; agent_name = supervisor_agent_name
-        ; sw
-        ; clock = Eio.Stdenv.clock env
-        ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
-        ; net = Some (Eio.Stdenv.net env)
-        ; publication_recovery_provider =
-            Masc_test_deps.publication_recovery_provider
-              (publication_recovery_registry env sw config)
-        }
-      in
-      sweep_and_recover_no_materialize ctx;
-      (match Reg.get ~base_path:config.base_path name with
-       | Some entry ->
-         check bool "supervisor published replacement registry lane" true
-           (entry.done_p != reg.done_p)
-       | None -> fail "supervisor restart removed the Keeper registry entry");
-      match Memory_lane.submit ~base_path:config.base_path ~keeper_name:name (fun () -> ()) with
-      | Memory_lane.Ran_inline -> ()
-      | Memory_lane.Submitted | Memory_lane.Coalesced -> ()
-      | Memory_lane.Dropped -> fail "restarted Librarian submission was dropped"
-      | Memory_lane.Rejected_draining ->
-        fail "supervisor restart left the Librarian lifecycle fenced")
-;;
-
 let test_restart_path_emits_meta_unavailable_outcome_metric () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
@@ -2294,8 +2238,6 @@ let () =
     "restart_metrics", [
       test_case "restart path emits attempt and started outcome metrics" `Quick
         test_restart_path_emits_attempt_and_started_outcome_metrics;
-      test_case "restart reopens crash-aborted Librarian lifecycle" `Quick
-        test_restart_reopens_crash_aborted_librarian_lifecycle;
       test_case "restart path emits missing-meta outcome metrics" `Quick
         test_restart_path_emits_meta_unavailable_outcome_metric;
       test_case "restart denies persisted dead tombstone" `Quick

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -8,6 +8,8 @@ module Keeper_meta_contract = Masc.Keeper_meta_contract
 module Keeper_meta_store = Masc.Keeper_meta_store
 module Keeper_meta_json_parse = Masc.Keeper_meta_json_parse
 module Keeper_types_profile = Masc.Keeper_types_profile
+module Keeper_owner_registry = Masc.Keeper_owner_registry
+module Workspace = Masc.Workspace
 module Reg = Masc.Keeper_registry
 module KT = Keeper_types
 module KR = Masc.Keeper_runtime
@@ -30,6 +32,8 @@ module Tombstone_cleanup = Masc.Keeper_supervisor_cleanup_tombstone
 module Process_switch = Masc.Keeper_process_switch
 module Tool_accumulator = Masc.Keeper_tool_emission_hook
 module Latched_reason = Keeper_latched_reason
+module Lifecycle_reservation = Masc.Keeper_lifecycle_reservation
+module Launch_transaction = Masc.Keeper_keepalive_launch_transaction
 
 (* Test-local shim for the excised [Keeper_approval_queue.resolve] wrapper:
    unit projection over [resolve_with_policy] (production resolution path). *)
@@ -40,6 +44,26 @@ let aq_resolve ~base_path ~id ~decision =
 ;;
 
 let supervisor_agent_name = Sup.supervisor_agent_name
+
+let with_launch_token ~base_path ~keeper_name ~expected_generation f =
+  match
+    Lifecycle_reservation.acquire
+      ~base_path
+      ~keeper_name
+      ~expected_generation
+      ~purpose:Lifecycle_reservation.Keepalive_launch
+  with
+  | Error (Lifecycle_reservation.Already_reserved owner) ->
+    fail
+      ("launch lifecycle already reserved: "
+       ^ Lifecycle_reservation.snapshot_to_string owner)
+  | Ok token ->
+    Fun.protect
+      ~finally:(fun () ->
+        ignore
+          (Lifecycle_reservation.release token
+            : Lifecycle_reservation.release_outcome))
+      (fun () -> f token)
 
 let temp_dir () =
   let dir = Filename.temp_file "test_keeper_supervisor_" "" in
@@ -87,6 +111,31 @@ let rec mkdir_p path =
 let write_file path content =
   Out_channel.with_open_bin path (fun oc -> output_string oc content)
 
+let install_owner_inventory_exn ~sw config =
+  match
+    Keeper_owner_registry.install_from_store
+      ~sw
+      ~operation_runner:None
+      ~on_turn_slot_released:None
+      config
+  with
+  | Ok _ -> ()
+  | Error error ->
+    fail (Keeper_owner_registry.install_error_to_string error)
+;;
+
+let create_owner_meta_exn config meta =
+  match
+    Keeper_owner_registry.create_meta
+      ~base_path:config.Workspace.base_path
+      meta
+  with
+  | Ok (Some _) -> ()
+  | Ok None -> fail "owner metadata creation removed its snapshot"
+  | Error error ->
+    fail (Keeper_owner_registry.command_error_to_string error)
+;;
+
 let resolve_done_for_test reg value =
   ignore (Reg.resolve_done reg ~source:"test_fixture" value);
   match
@@ -123,6 +172,9 @@ let with_config_dir f =
       f config_dir)
 
 let write_keeper_toml config_dir ~name =
+  let profile_dir = Filename.concat (Filename.concat config_dir "keepers") name in
+  mkdir_p profile_dir;
+  write_file (Filename.concat profile_dir "AGENT.md") ("# " ^ name ^ "\n");
   write_file
     (Filename.concat (Filename.concat config_dir "keepers") (name ^ ".toml"))
     (Printf.sprintf
@@ -135,6 +187,9 @@ sandbox_profile = "local"
        name)
 
 let write_keeper_toml_with_instructions config_dir ~name ~instructions =
+  let profile_dir = Filename.concat (Filename.concat config_dir "keepers") name in
+  mkdir_p profile_dir;
+  write_file (Filename.concat profile_dir "AGENT.md") (instructions ^ "\n");
   write_file
     (Filename.concat (Filename.concat config_dir "keepers") (name ^ ".toml"))
     (Printf.sprintf
@@ -149,6 +204,9 @@ instructions = "%s"
   Keeper_types_profile.invalidate_keeper_profile_defaults_cache name
 
 let write_empty_keeper_toml config_dir ~name =
+  let profile_dir = Filename.concat (Filename.concat config_dir "keepers") name in
+  mkdir_p profile_dir;
+  write_file (Filename.concat profile_dir "AGENT.md") ("# " ^ name ^ "\n");
   write_file
     (Filename.concat (Filename.concat config_dir "keepers") (name ^ ".toml"))
     (Printf.sprintf
@@ -491,6 +549,7 @@ let test_declarative_boot_materializes_instructions () =
       KR.reset_test_state base_dir);
   let config = Masc.Workspace.default_config base_dir in
   let _init_msg = Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name) in
+  install_owner_inventory_exn ~sw config;
   let ctx = keeper_runtime_context env sw config in
   Fun.protect
     ~finally:(fun () -> KR.stop_keepalive ~base_path:config.base_path name)
@@ -519,6 +578,7 @@ let test_declarative_boot_allows_empty_goal_links () =
       KR.reset_test_state base_dir);
   let config = Masc.Workspace.default_config base_dir in
   let _init_msg = Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name) in
+  install_owner_inventory_exn ~sw config;
   let ctx = keeper_runtime_context env sw config in
   Fun.protect
     ~finally:(fun () -> KR.stop_keepalive ~base_path:config.base_path name)
@@ -841,6 +901,7 @@ let test_supervise_keepalive_retains_sweep_owned_entries () =
   let launched = ref [] in
   let publish_lifecycle ~event:_ _name _detail () = () in
   let launch_supervised_fiber
+        ~lifecycle_token:_
         ~proactive_warmup_sec:_
         _ctx
         _meta
@@ -991,6 +1052,7 @@ let test_supervise_keepalive_wakes_ready_operation_drain () =
        let ctx = keeper_runtime_context env sw config in
        let publish_lifecycle ~event:_ _name _detail () = () in
        let launch_supervised_fiber
+             ~lifecycle_token:_
              ~proactive_warmup_sec:_
              _ctx
              _meta
@@ -1518,6 +1580,7 @@ let test_restart_denies_persisted_dead_tombstone () =
       (match Keeper_meta_store.replace_snapshot config dead_meta with
        | Ok () -> ()
        | Error err -> fail err);
+      install_owner_inventory_exn ~sw config;
       let reg = Reg.For_testing.register ~base_path:config.base_path name active_meta in
       resolve_done_for_test reg (`Crashed "crash before terminal persist");
       Reg.restore_supervisor_state
@@ -1581,6 +1644,7 @@ let test_restart_denies_persisted_dead_tombstone () =
 let with_reap_ready_dead_keeper name f =
   Eio_main.run @@ fun env ->
   ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
@@ -1596,9 +1660,8 @@ let with_reap_ready_dead_keeper name f =
       let config = Masc.Workspace.default_config base_dir in
       let _init_msg = Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name) in
       let meta = make_meta name in
-      (match Keeper_meta_store.replace_snapshot config meta with
-       | Ok () -> ()
-       | Error err -> fail err);
+      install_owner_inventory_exn ~sw config;
+      create_owner_meta_exn config meta;
       ignore (Reg.For_testing.register ~base_path:config.base_path name meta);
       Reg.mark_dead ~base_path:config.base_path name ~at:0.0;
       let completion_bus = Agent_core.Event_bus.create () in
@@ -1608,7 +1671,6 @@ let with_reap_ready_dead_keeper name f =
         (fun _config ~target_type:_ ~target_id:_ -> Ok 0);
       Shutdown_finalize.register_completion_handler Tombstone_cleanup.handle_completion;
       let run_sweep () =
-        Eio.Switch.run @@ fun sw ->
         Sup.set_global_switch sw;
         let ctx : _ Keeper_types_profile.context =
           { config
@@ -1624,7 +1686,7 @@ let with_reap_ready_dead_keeper name f =
         in
         sweep_and_recover_no_materialize ctx
       in
-      f ~config ~run_sweep)
+      f ~config ~clock:(Eio.Stdenv.clock env) ~run_sweep)
 
 let event_label = function
   | KLH.Tombstone_reaped -> "tombstone_reaped"
@@ -1636,8 +1698,15 @@ let test_sweep_and_recover_fires_tombstone_reaped_hook () =
   let fired = ref [] in
   KLH.register (fun ~keeper_id event ->
     fired := (keeper_id, event_label event) :: !fired);
-  with_reap_ready_dead_keeper name @@ fun ~config ~run_sweep ->
+  with_reap_ready_dead_keeper name @@ fun ~config ~clock ~run_sweep ->
   run_sweep ();
+  check bool
+    "Tombstone_reaped completion arrived"
+    true
+    (wait_until
+       ~clock
+       ~deadline:(Eio.Time.now clock +. 1.0)
+       (fun () -> !fired <> []));
   check (list (pair string string))
     "single Tombstone_reaped event"
     [ (name, "tombstone_reaped") ] (List.rev !fired);
@@ -1654,8 +1723,15 @@ let test_sweep_and_recover_swallows_failing_tombstone_hook () =
     raise (Failure "intentional tombstone hook failure"));
   KLH.register (fun ~keeper_id event ->
     later_hook_events := (keeper_id, event_label event) :: !later_hook_events);
-  with_reap_ready_dead_keeper name @@ fun ~config ~run_sweep ->
+  with_reap_ready_dead_keeper name @@ fun ~config ~clock ~run_sweep ->
   run_sweep ();
+  check bool
+    "later hook observed asynchronous Tombstone_reaped completion"
+    true
+    (wait_until
+       ~clock
+       ~deadline:(Eio.Time.now clock +. 1.0)
+       (fun () -> !later_hook_events <> []));
   check int "failing hook invoked exactly once" 1 !failing_hook_calls;
   check (list (pair string string))
     "later hook still observes Tombstone_reaped"
@@ -1722,12 +1798,21 @@ let test_launch_rejected_terminal_state_does_not_announce_running () =
         }
       in
       Sup.with_restart_launch_noop_for_test (fun () ->
-        match
-          Masc.Keeper_supervisor_launch.launch_supervised_fiber
-            ~proactive_warmup_sec:0 ctx meta reg
-        with
-        | Ok () -> fail "expected Fiber_started to be rejected in terminal state"
-        | Error _ -> ());
+        with_launch_token
+          ~base_path:config.base_path
+          ~keeper_name:name
+          ~expected_generation:reg.transition_seq
+          (fun lifecycle_token ->
+             match
+               Masc.Keeper_supervisor_launch.launch_supervised_fiber
+                 ~lifecycle_token
+                 ~proactive_warmup_sec:0
+                 ctx
+                 meta
+                 reg
+             with
+             | Ok () -> fail "expected Fiber_started to be rejected in terminal state"
+             | Error _ -> ()));
       (match Reg.get_phase ~base_path:config.base_path name with
        | Some Keeper_state_machine.Dead -> ()
        | Some phase ->
@@ -1772,17 +1857,22 @@ let test_supervised_stop_joins_board_attention_worker () =
               (publication_recovery_registry env sw config)
         }
       in
-      (match
-         Masc.Keeper_supervisor_launch.launch_supervised_fiber
-           ~proactive_warmup_sec:0
-           ctx
-           meta
-           reg
-       with
-       | Ok () -> ()
-       | Error error ->
-         fail
-           (Keeper_state_machine.transition_error_to_string error));
+      with_launch_token
+        ~base_path:config.base_path
+        ~keeper_name:name
+        ~expected_generation:reg.transition_seq
+        (fun lifecycle_token ->
+           match
+             Masc.Keeper_supervisor_launch.launch_supervised_fiber
+               ~lifecycle_token
+               ~proactive_warmup_sec:0
+               ctx
+               meta
+               reg
+           with
+           | Ok () -> ()
+           | Error error ->
+             fail (Keeper_state_machine.transition_error_to_string error));
       let joined =
         Eio.Time.with_timeout_exn ctx.clock 5.0 (fun () ->
           Masc.Keeper_keepalive.stop_keepalive_and_await
@@ -1841,15 +1931,21 @@ let test_supervised_stop_drains_librarian_before_terminal () =
               (publication_recovery_registry env sw config)
         }
       in
-      (match
-         Masc.Keeper_supervisor_launch.launch_supervised_fiber
-           ~proactive_warmup_sec:0
-           ctx
-           meta
-           reg
-       with
-       | Ok () -> ()
-       | Error error -> fail (Keeper_state_machine.transition_error_to_string error));
+      with_launch_token
+        ~base_path:config.base_path
+        ~keeper_name:name
+        ~expected_generation:reg.transition_seq
+        (fun lifecycle_token ->
+           match
+             Masc.Keeper_supervisor_launch.launch_supervised_fiber
+               ~lifecycle_token
+               ~proactive_warmup_sec:0
+               ctx
+               meta
+               reg
+           with
+           | Ok () -> ()
+           | Error error -> fail (Keeper_state_machine.transition_error_to_string error));
       let librarian_started, resolve_librarian_started = Eio.Promise.create () in
       let librarian_release, resolve_librarian_release = Eio.Promise.create () in
       let librarian_cancelled = ref false in
@@ -1967,12 +2063,21 @@ let test_launch_fork_rejection_does_not_announce_running () =
               (publication_recovery_registry env sw config);
         }
       in
-      (match
-         Masc.Keeper_supervisor_launch.launch_supervised_fiber
-           ~proactive_warmup_sec:0 ctx meta reg
-       with
-       | Ok () -> fail "expected lane fork rejection to propagate as Error"
-       | Error _ -> ());
+      with_launch_token
+        ~base_path:config.base_path
+        ~keeper_name:name
+        ~expected_generation:reg.transition_seq
+        (fun lifecycle_token ->
+           match
+             Masc.Keeper_supervisor_launch.launch_supervised_fiber
+               ~lifecycle_token
+               ~proactive_warmup_sec:0
+               ctx
+               meta
+               reg
+           with
+           | Ok () -> fail "expected lane fork rejection to propagate as Error"
+           | Error _ -> ());
       check bool
         "fork-rejected launch resolves done through the crash path"
         true
@@ -2018,12 +2123,21 @@ let test_fork_rejection_preserves_replacement_lane () =
               (publication_recovery_registry env sw config)
         }
       in
-      (match
-         Masc.Keeper_supervisor_launch.launch_supervised_fiber_body
-           ~proactive_warmup_sec:0 ctx meta rejected
-       with
-       | Ok () -> fail "expected rejected lane to propagate as Error"
-       | Error _ -> ());
+      with_launch_token
+        ~base_path:config.base_path
+        ~keeper_name:name
+        ~expected_generation:rejected.transition_seq
+        (fun lifecycle_token ->
+           match
+             Masc.Keeper_supervisor_launch.launch_supervised_fiber_body
+               ~lifecycle_token
+               ~proactive_warmup_sec:0
+               ctx
+               meta
+               rejected
+           with
+           | Ok () -> fail "expected rejected lane to propagate as Error"
+           | Error _ -> ());
       check bool
         "newer same-name lane remains the registry owner"
         true
@@ -2071,12 +2185,21 @@ let test_fork_rejection_unregisters_non_terminalizable_owner () =
               (publication_recovery_registry env sw config)
         }
       in
-      (match
-         Masc.Keeper_supervisor_launch.launch_supervised_fiber_body
-           ~proactive_warmup_sec:0 ctx meta rejected
-       with
-       | Ok () -> fail "expected rejected terminal lane to propagate as Error"
-       | Error _ -> ());
+      with_launch_token
+        ~base_path:config.base_path
+        ~keeper_name:name
+        ~expected_generation:rejected.transition_seq
+        (fun lifecycle_token ->
+           match
+             Masc.Keeper_supervisor_launch.launch_supervised_fiber_body
+               ~lifecycle_token
+               ~proactive_warmup_sec:0
+               ctx
+               meta
+               rejected
+           with
+           | Ok () -> fail "expected rejected terminal lane to propagate as Error"
+           | Error _ -> ());
       check bool
         "non-terminalizable exact owner is unregistered"
         true
@@ -2343,6 +2466,107 @@ let test_persisted_blocker_survives_unregister () =
        | Ok None -> fail "meta missing after unregister"
        | Error err -> fail ("read_meta failed: " ^ err)))
 
+let test_active_librarian_abort_defers_then_retries_restart () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  ensure_test_runtime ();
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Reg.For_testing.clear ();
+      Memory_lane.For_testing.reset ();
+      Masc.Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_dir in
+       ignore (Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name));
+       Memory_lane.For_testing.reset ();
+       Memory_lane.init ~sw;
+       let name = "librarian-restart-rollback" in
+       let meta = make_meta name in
+       let initial = Reg.For_testing.register ~base_path:config.base_path name meta in
+       (match
+          Reg.dispatch_event_exact
+            initial
+            (KSM.Fiber_terminated
+               { outcome = "fixture crash"; provider_id = None; http_status = None })
+        with
+        | Ok _ -> ()
+        | Error error -> fail (KSM.transition_error_to_string error));
+       let crashed =
+         match Reg.get ~base_path:config.base_path name with
+         | Some entry -> entry
+         | None -> fail "crashed restart fixture disappeared"
+       in
+       let started, set_started = Eio.Promise.create () in
+       let cancellation_seen, set_cancellation_seen = Eio.Promise.create () in
+       let release_cleanup, set_release_cleanup = Eio.Promise.create () in
+       let never, _set_never = Eio.Promise.create () in
+       (match
+          Memory_lane.submit ~base_path:config.base_path ~keeper_name:name (fun () ->
+            Eio.Promise.resolve set_started ();
+            try Eio.Promise.await never with
+            | Eio.Cancel.Cancelled _ as exn ->
+              Eio.Promise.resolve set_cancellation_seen ();
+              Eio.Cancel.protect (fun () -> Eio.Promise.await release_cleanup);
+              raise exn)
+        with
+        | Memory_lane.Submitted -> ()
+        | Memory_lane.Coalesced
+        | Memory_lane.Ran_inline
+        | Memory_lane.Dropped
+        | Memory_lane.Rejected_draining -> fail "active Librarian fixture was not submitted");
+       Eio.Promise.await started;
+       (match Memory_lane.abort_librarian ~base_path:config.base_path ~keeper_name:name with
+        | Ok Memory_lane.Librarian_abort_requested
+        | Ok Memory_lane.Librarian_abort_already_in_progress -> ()
+        | Ok _ -> fail "active Librarian abort did not commit cancellation"
+        | Error error -> fail (Memory_lane.librarian_abort_error_to_string error));
+       Eio.Promise.await cancellation_seen;
+       let run_restart (previous : Reg.registry_entry) =
+         Launch_transaction.run
+           ~base_path:config.base_path
+           ~keeper_name:name
+           ~expected_generation:previous.transition_seq
+           ~register:(fun token ->
+             Reg.register_restarting_for_lifecycle token ~base_path:config.base_path name meta)
+           ~rollback:(Launch_transaction.rollback_restore_previous ~previous)
+           (fun _token replacement -> replacement)
+       in
+       (match run_restart crashed with
+        | Error (Launch_transaction.Lifecycle_open_failed _) -> ()
+        | Error _ -> fail "restart deferred for an unexpected transaction reason"
+        | Ok _ -> fail "restart crossed an active cancelled Librarian owner");
+       (match Reg.get ~base_path:config.base_path name with
+        | Some current ->
+          check bool "deferred restart restores the crashed lane" true
+            (Lane.Id.equal (Lane.id current.lane) (Lane.id crashed.lane))
+        | None -> fail "deferred restart lost its durable crashed authority");
+       Eio.Promise.resolve set_release_cleanup ();
+       (match
+          Memory_lane.drain_and_join_librarian
+            ~base_path:config.base_path
+            ~keeper_name:name
+        with
+        | Error (Memory_lane.Librarian_interrupted _) -> ()
+        | Error error -> fail (Memory_lane.librarian_drain_error_to_string error)
+        | Ok _ -> fail "cancelled Librarian was reported as gracefully drained");
+       let replacement =
+         match run_restart crashed with
+         | Ok replacement -> replacement
+         | Error _ -> fail "next restart sweep did not reopen the exited Librarian owner"
+       in
+       check bool "retry installs a distinct restart lane" false
+         (Lane.Id.equal (Lane.id replacement.lane) (Lane.id crashed.lane));
+       ignore
+         (Memory_lane.drain_and_join_librarian
+            ~base_path:config.base_path
+            ~keeper_name:name
+           : (Memory_lane.librarian_drain_outcome,
+              Memory_lane.librarian_drain_error)
+               result))
+
 let () =
   run "keeper_supervisor" [
     "keep_last_n", [
@@ -2419,6 +2643,8 @@ let () =
         test_restart_path_emits_meta_unavailable_outcome_metric;
       test_case "restart denies persisted dead tombstone" `Quick
         test_restart_denies_persisted_dead_tombstone;
+      test_case "active Librarian abort defers then retries restart" `Quick
+        test_active_librarian_abort_defers_then_retries_restart;
     ];
     "dead_state_alert", [
       test_case "sweep cleanup fires Tombstone_reaped hook" `Quick

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -980,7 +980,7 @@ let test_supervise_recovery_requires_same_offline_generation () =
       in
       let name = "recoverable-offline-generation" in
       let entry =
-        Reg.For_testing.register ~base_path:config.base_path name (make_meta name)
+        Reg.register_offline ~base_path:config.base_path name (make_meta name)
       in
       check bool "same Offline generation remains launchable" true
         (KSS.For_testing.same_offline_generation ~expected:entry entry);

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -21,6 +21,7 @@ module KSS = Masc.Keeper_supervisor_supervise_keepalive
 module Chat_operation = Masc.Keeper_owner.Chat_operation
 module Supervisor_launch = Masc.Keeper_supervisor_launch
 module Lane = Masc.Keeper_lane
+module Memory_lane = Masc.Keeper_memory_lane
 module Shutdown_finalize = Masc.Keeper_shutdown_finalize
 module Shutdown_store = Masc.Keeper_shutdown_store
 module Shutdown_types = Masc.Keeper_shutdown_types
@@ -1374,6 +1375,61 @@ let test_restart_path_emits_attempt_and_started_outcome_metrics () =
       | Some entry ->
           check int "restart count restored to attempt" 1 entry.restart_count)
 
+let test_restart_reopens_crash_aborted_librarian_lifecycle () =
+  with_restart_launch_noop @@ fun () ->
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  with_config_dir @@ fun config_dir ->
+  let base_dir = temp_dir () in
+  let name = "restart-reopens-librarian" in
+  Fun.protect
+    ~finally:(fun () ->
+      Memory_lane.For_testing.reset ();
+      Reg.For_testing.clear ();
+      Masc.Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      Memory_lane.For_testing.reset ();
+      let config = Masc.Workspace.default_config base_dir in
+      ignore (Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name));
+      write_keeper_toml config_dir ~name;
+      let meta = make_meta name in
+      (match Keeper_meta_store.replace_snapshot config meta with
+       | Ok () -> ()
+       | Error err -> fail err);
+      let reg = Reg.For_testing.register ~base_path:config.base_path name meta in
+      resolve_done_for_test reg (`Crashed "ordinary crash");
+      (match Memory_lane.abort_librarian ~base_path:config.base_path ~keeper_name:name with
+       | Ok Memory_lane.Librarian_abort_idle -> ()
+       | Ok _ -> fail "empty crash-abort fixture unexpectedly owned Librarian work"
+       | Error error -> fail (Memory_lane.librarian_abort_error_to_string error));
+      let ctx : _ Keeper_types_profile.context =
+        { config
+        ; agent_name = supervisor_agent_name
+        ; sw
+        ; clock = Eio.Stdenv.clock env
+        ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
+        ; net = Some (Eio.Stdenv.net env)
+        ; publication_recovery_provider =
+            Masc_test_deps.publication_recovery_provider
+              (publication_recovery_registry env sw config)
+        }
+      in
+      sweep_and_recover_no_materialize ctx;
+      (match Reg.get ~base_path:config.base_path name with
+       | Some entry ->
+         check bool "supervisor published replacement registry lane" true
+           (entry.done_p != reg.done_p)
+       | None -> fail "supervisor restart removed the Keeper registry entry");
+      match Memory_lane.submit ~base_path:config.base_path ~keeper_name:name (fun () -> ()) with
+      | Memory_lane.Ran_inline -> ()
+      | Memory_lane.Submitted | Memory_lane.Coalesced -> ()
+      | Memory_lane.Dropped -> fail "restarted Librarian submission was dropped"
+      | Memory_lane.Rejected_draining ->
+        fail "supervisor restart left the Librarian lifecycle fenced")
+;;
+
 let test_restart_path_emits_meta_unavailable_outcome_metric () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
@@ -2238,6 +2294,8 @@ let () =
     "restart_metrics", [
       test_case "restart path emits attempt and started outcome metrics" `Quick
         test_restart_path_emits_attempt_and_started_outcome_metrics;
+      test_case "restart reopens crash-aborted Librarian lifecycle" `Quick
+        test_restart_reopens_crash_aborted_librarian_lifecycle;
       test_case "restart path emits missing-meta outcome metrics" `Quick
         test_restart_path_emits_meta_unavailable_outcome_metric;
       test_case "restart denies persisted dead tombstone" `Quick

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -2803,6 +2803,63 @@ let test_started_launch_exception_retains_registered_lane () =
        | None -> fail "started launch exception detached the live lane")
 ;;
 
+let test_offline_launch_exception_retains_retryable_lane () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  ensure_test_runtime ();
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Reg.For_testing.clear ();
+      Memory_lane.For_testing.reset ();
+      Masc.Keeper_shutdown_intake_fence.For_testing.reset ();
+      Masc.Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_dir in
+       ignore (Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name));
+       let name = "offline-launch-exception-retry" in
+       let offline = Reg.register_offline ~base_path:config.base_path name (make_meta name) in
+       let run launch =
+         Launch_transaction.run
+           ~base_path:config.base_path
+           ~keeper_name:name
+           ~expected_generation:offline.transition_seq
+           ~register:(fun _token _intake_token -> Ok offline)
+           ~rollback:Launch_transaction.Retain_registered
+           launch
+       in
+       (match
+          run (fun _intake_token _token _entry ->
+            failwith "injected pre-start callback failure")
+        with
+        | Error
+            (Launch_transaction.Launch_failed
+               { librarian_abort_error = None; rollback_error = None; _ }) -> ()
+        | Error _ -> fail "offline callback failure produced the wrong transaction outcome"
+        | Ok _ -> fail "offline callback failure unexpectedly committed");
+       let forked = ref false in
+       (match
+          run (fun _intake_token _token entry ->
+            match
+              Lane.fork
+                ~sw
+                entry.lane
+                ~run:(fun _ -> forked := true)
+                ~cleanup:(fun _ -> Ok ())
+            with
+            | Ok () -> entry
+            | Error error -> fail (Lane.start_error_to_string error))
+        with
+        | Ok current ->
+          check bool "retry preserves exact Offline lane" true
+            (Lane.Id.equal (Lane.id current.lane) (Lane.id offline.lane))
+        | Error _ -> fail "retained Offline lane was not retryable");
+       Eio.Fiber.yield ();
+       check bool "retry started the retained Offline lane" true !forked)
+;;
+
 let test_restart_intake_epoch_survives_shutdown_overlap () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
@@ -2983,6 +3040,8 @@ let () =
         test_launch_callback_cancellation_rolls_back_restart_transaction;
       test_case "started launch exception retains registered lane" `Quick
         test_started_launch_exception_retains_registered_lane;
+      test_case "offline launch exception retains retryable lane" `Quick
+        test_offline_launch_exception_retains_retryable_lane;
       test_case "restart intake epoch survives shutdown overlap" `Quick
         test_restart_intake_epoch_survives_shutdown_overlap;
     ];

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -967,6 +967,32 @@ let test_supervise_keepalive_retains_sweep_owned_entries () =
        (fun (name, phase) -> name, KSM.phase_to_string phase)
        !launched)
 
+let test_supervise_recovery_requires_same_offline_generation () =
+  with_config_dir @@ fun config_dir ->
+  Eio_main.run @@ fun _env ->
+  let base_dir = Filename.dirname config_dir in
+  Fun.protect
+    ~finally:(fun () -> Reg.For_testing.clear ())
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      let _init_msg =
+        Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name)
+      in
+      let name = "recoverable-offline-generation" in
+      let entry =
+        Reg.For_testing.register ~base_path:config.base_path name (make_meta name)
+      in
+      check bool "same Offline generation remains launchable" true
+        (KSS.For_testing.same_offline_generation ~expected:entry entry);
+      (match Reg.dispatch_event_exact entry KSM.Fiber_started with
+       | Ok _ -> ()
+       | Error error -> fail (KSM.transition_error_to_string error));
+      match Reg.get ~base_path:config.base_path name with
+      | None -> fail "generation fixture disappeared"
+      | Some running ->
+        check bool "advanced generation cannot be launched again" false
+          (KSS.For_testing.same_offline_generation ~expected:entry running))
+
 let test_supervise_keepalive_wakes_ready_operation_drain () =
   Eio_main.run @@ fun env ->
   ensure_test_runtime ();
@@ -2595,6 +2621,8 @@ let () =
         test_reconcile_supervise_exception_continues;
       test_case "recoverable sweep-owned entries are not relaunched" `Quick
         test_supervise_keepalive_retains_sweep_owned_entries;
+      test_case "recoverable launch requires same Offline generation" `Quick
+        test_supervise_recovery_requires_same_offline_generation;
       test_case "supervised readiness wakes queued owner operation" `Quick
         test_supervise_keepalive_wakes_ready_operation_drain;
     ];

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -2600,6 +2600,53 @@ let test_active_librarian_abort_defers_then_retries_restart () =
               Memory_lane.librarian_drain_error)
                result))
 
+let test_unexpected_cleanup_cannot_close_reopened_librarian_lifecycle () =
+  Eio_main.run @@ fun _env ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Memory_lane.For_testing.reset ();
+      cleanup_dir base_dir)
+    (fun () ->
+       Memory_lane.For_testing.reset ();
+       let keeper_name = "unexpected-librarian-reopen" in
+       (match
+          Memory_lane.begin_librarian_lifecycle
+            ~base_path:base_dir
+            ~keeper_name
+        with
+        | Ok () -> ()
+        | Error error -> fail (Memory_lane.lifecycle_open_error_to_string error));
+       let replacement_opened = ref false in
+       (match
+          Launch_transaction.finish_lifecycle
+            ~boundary:Launch_transaction.Unexpected
+            ~base_path:base_dir
+            ~keeper_name
+            ~terminalize:(fun () ->
+              match
+                Memory_lane.begin_librarian_lifecycle
+                  ~base_path:base_dir
+                  ~keeper_name
+              with
+              | Ok () ->
+                replacement_opened := true;
+                Ok ()
+              | Error error ->
+                Error (Memory_lane.lifecycle_open_error_to_string error))
+        with
+        | Ok () -> ()
+        | Error detail -> fail detail);
+       check bool "terminal publication admitted replacement" true !replacement_opened;
+       match Memory_lane.submit ~base_path:base_dir ~keeper_name ignore with
+       | Memory_lane.Ran_inline -> ()
+       | Memory_lane.Submitted
+       | Memory_lane.Coalesced
+       | Memory_lane.Dropped
+       | Memory_lane.Rejected_draining ->
+         fail "stale unexpected cleanup closed the replacement lifecycle")
+;;
+
 let crashed_restart_fixture ~base_path name meta =
   let initial = Reg.For_testing.register ~base_path name meta in
   (match
@@ -3113,6 +3160,8 @@ let () =
         test_restart_denies_persisted_dead_tombstone;
       test_case "active Librarian abort defers then retries restart" `Quick
         test_active_librarian_abort_defers_then_retries_restart;
+      test_case "unexpected cleanup preserves reopened Librarian lifecycle" `Quick
+        test_unexpected_cleanup_cannot_close_reopened_librarian_lifecycle;
       test_case "launch callback failure rolls back restart transaction" `Quick
         test_launch_callback_failure_rolls_back_restart_transaction;
       test_case "launch callback cancellation rolls back restart transaction" `Quick

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -2753,6 +2753,82 @@ let test_launch_callback_cancellation_rolls_back_restart_transaction () =
        | _ -> fail "cancelled launch left Librarian admission open")
 ;;
 
+let test_register_cancellation_rolls_back_restart_transaction () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  ensure_test_runtime ();
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Reg.For_testing.clear ();
+      Memory_lane.For_testing.reset ();
+      Masc.Keeper_shutdown_intake_fence.For_testing.reset ();
+      Masc.Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_dir in
+       ignore (Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name));
+       Memory_lane.For_testing.reset ();
+       let name = "librarian-register-cancellation-rollback" in
+       let meta = make_meta name in
+       let crashed = crashed_restart_fixture ~base_path:config.base_path name meta in
+       let cancel_context, resolve_cancel_context = Eio.Promise.create () in
+       let registered, resolve_registered = Eio.Promise.create () in
+       let continue_registration, resolve_continue_registration = Eio.Promise.create () in
+       let cancelled, resolve_cancelled = Eio.Promise.create () in
+       Eio.Fiber.fork ~sw (fun () ->
+         let saw_cancellation =
+           try
+             Eio.Cancel.sub (fun context ->
+               Eio.Promise.resolve resolve_cancel_context context;
+               ignore
+                 (Launch_transaction.run
+                    ~base_path:config.base_path
+                    ~keeper_name:name
+                    ~expected_generation:crashed.transition_seq
+                    ~register:(fun token intake_token ->
+                      match
+                        register_restart
+                          ~base_path:config.base_path
+                          ~name
+                          ~meta
+                          token
+                          intake_token
+                      with
+                      | Error _ as error -> error
+                      | Ok replacement as ok ->
+                        Eio.Promise.resolve resolve_registered replacement;
+                        Eio.Promise.await continue_registration;
+                        ok)
+                    ~rollback:(Launch_transaction.Restore_previous crashed)
+                    (fun _intake_token _token _replacement ->
+                      Eio.Fiber.yield ();
+                      failwith "pending registration cancellation was not delivered")
+                  : (_, _) result);
+               false)
+           with
+           | Eio.Cancel.Cancelled _ -> true
+         in
+         Eio.Promise.resolve resolve_cancelled saw_cancellation);
+       let context = Eio.Promise.await cancel_context in
+       let replacement = Eio.Promise.await registered in
+       Eio.Cancel.cancel context (Failure "cancel injected after registration commit");
+       Eio.Promise.resolve resolve_continue_registration ();
+       check bool "registration cancellation propagates after rollback" true
+         (Eio.Promise.await cancelled);
+       (match Reg.get ~base_path:config.base_path name with
+        | Some current ->
+          check bool "registration cancellation restores exact crashed authority" true
+            (Lane.Id.equal (Lane.id current.lane) (Lane.id crashed.lane));
+          check bool "registration cancellation removed replacement authority" false
+            (Lane.Id.equal (Lane.id current.lane) (Lane.id replacement.lane))
+        | None -> fail "registration cancellation removed durable restart authority");
+       match Memory_lane.submit ~base_path:config.base_path ~keeper_name:name ignore with
+       | Memory_lane.Rejected_draining -> ()
+       | _ -> fail "registration cancellation left Librarian admission open")
+;;
+
 let test_started_launch_exception_retains_registered_lane () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
@@ -2839,6 +2915,9 @@ let test_offline_launch_exception_retains_retryable_lane () =
                { librarian_abort_error = None; rollback_error = None; _ }) -> ()
         | Error _ -> fail "offline callback failure produced the wrong transaction outcome"
         | Ok _ -> fail "offline callback failure unexpectedly committed");
+       (match Memory_lane.submit ~base_path:config.base_path ~keeper_name:name ignore with
+        | Memory_lane.Rejected_draining -> ()
+        | _ -> fail "pre-start Offline failure left Librarian admission open");
        let forked = ref false in
        (match
           run (fun _intake_token _token entry ->
@@ -3038,6 +3117,8 @@ let () =
         test_launch_callback_failure_rolls_back_restart_transaction;
       test_case "launch callback cancellation rolls back restart transaction" `Quick
         test_launch_callback_cancellation_rolls_back_restart_transaction;
+      test_case "register cancellation rolls back restart transaction" `Quick
+        test_register_cancellation_rolls_back_restart_transaction;
       test_case "started launch exception retains registered lane" `Quick
         test_started_launch_exception_retains_registered_lane;
       test_case "offline launch exception retains retryable lane" `Quick

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -1800,6 +1800,125 @@ let test_supervised_stop_joins_board_attention_worker () =
         true
         (Reg.lane_has_exited reg))
 
+let test_supervised_stop_drains_librarian_before_terminal () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  ensure_test_runtime ();
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Memory_lane.For_testing.reset ();
+      Reg.For_testing.clear ();
+      Masc.Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      ignore (Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name));
+      let name = "supervised-librarian-drain" in
+      let meta = make_meta name in
+      (match Keeper_meta_store.replace_snapshot config meta with
+       | Ok () -> ()
+       | Error err -> fail err);
+      Memory_lane.init ~sw;
+      (match
+         Memory_lane.begin_librarian_lifecycle
+           ~base_path:config.base_path
+           ~keeper_name:name
+       with
+       | Ok () -> ()
+       | Error error -> fail (Memory_lane.lifecycle_open_error_to_string error));
+      let reg = Reg.register_offline ~base_path:config.base_path name meta in
+      let ctx : _ Keeper_types_profile.context =
+        { config
+        ; agent_name = supervisor_agent_name
+        ; sw
+        ; clock = Eio.Stdenv.clock env
+        ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
+        ; net = Some (Eio.Stdenv.net env)
+        ; publication_recovery_provider =
+            Masc_test_deps.publication_recovery_provider
+              (publication_recovery_registry env sw config)
+        }
+      in
+      (match
+         Masc.Keeper_supervisor_launch.launch_supervised_fiber
+           ~proactive_warmup_sec:0
+           ctx
+           meta
+           reg
+       with
+       | Ok () -> ()
+       | Error error -> fail (Keeper_state_machine.transition_error_to_string error));
+      let librarian_started, resolve_librarian_started = Eio.Promise.create () in
+      let librarian_release, resolve_librarian_release = Eio.Promise.create () in
+      let librarian_cancelled = ref false in
+      let librarian_completed = ref false in
+      (match
+         Memory_lane.submit
+           ~base_path:config.base_path
+           ~keeper_name:name
+           (fun () ->
+              Eio.Promise.resolve resolve_librarian_started ();
+              try
+                Eio.Promise.await librarian_release;
+                librarian_completed := true
+              with
+              | Eio.Cancel.Cancelled _ as exn ->
+                librarian_cancelled := true;
+                raise exn)
+       with
+       | Memory_lane.Submitted
+       | Memory_lane.Coalesced -> ()
+       | Memory_lane.Ran_inline
+       | Memory_lane.Dropped
+       | Memory_lane.Rejected_draining ->
+         fail "supervised Librarian fixture was not submitted");
+      Eio.Promise.await librarian_started;
+      let stop_done, resolve_stop_done = Eio.Promise.create () in
+      Eio.Fiber.fork ~sw (fun () ->
+        Eio.Promise.resolve
+          resolve_stop_done
+          (Masc.Keeper_keepalive.stop_keepalive_and_await
+             ~base_path:config.base_path
+             name));
+      Eio.Time.sleep ctx.clock 0.05;
+      check bool
+        "supervised stop waits for accepted Librarian work"
+        true
+        (Option.is_none (Eio.Promise.peek stop_done));
+      check bool
+        "terminal promise stays pending until Librarian drain"
+        true
+        (Option.is_none (Eio.Promise.peek reg.done_p));
+      Eio.Promise.resolve resolve_librarian_release ();
+      let joined = Eio.Promise.await stop_done in
+      (match joined with
+       | Masc.Keeper_keepalive.Keeper_not_registered ->
+         fail "supervised Keeper disappeared before Librarian join"
+       | Masc.Keeper_keepalive.Keeper_joined
+           { lane_exit = { cleanup_error = None; _ }; terminal = `Stopped } -> ()
+       | Masc.Keeper_keepalive.Keeper_joined
+           { lane_exit = { cleanup_error = Some error; _ }; _ } ->
+         fail ("supervised Librarian cleanup failed: " ^ error)
+       | Masc.Keeper_keepalive.Keeper_joined { terminal = `Crashed reason; _ } ->
+         fail ("supervised Librarian stop resolved as crashed: " ^ reason));
+      check bool
+        "supervised stop preserves Librarian work"
+        false
+        !librarian_cancelled;
+      check bool
+        "supervised stop drains Librarian before terminal"
+        true
+        !librarian_completed;
+      check
+        (option int)
+        "supervised Librarian has no pending work after stop"
+        (Some 0)
+        (Memory_lane.For_testing.pending
+           ~base_path:config.base_path
+           ~keeper_name:name))
+
 (* Codex #24135 finding 5: a rejected [Keeper_lane.fork] (parent switch already
    cancelling, or [claim_start] refused) must propagate [Error] from
    [launch_supervised_fiber] and resolve the done promise through the crash
@@ -2314,6 +2433,8 @@ let () =
         test_launch_rejected_terminal_state_does_not_announce_running;
       test_case "supervised stop joins Board worker" `Quick
         test_supervised_stop_joins_board_attention_worker;
+      test_case "supervised stop drains Librarian before terminal" `Quick
+        test_supervised_stop_drains_librarian_before_terminal;
       test_case "lane fork reject does not announce Running" `Quick
         test_launch_fork_rejection_does_not_announce_running;
       test_case "fork reject preserves newer same-name lane" `Quick

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -14,6 +14,7 @@ module Tool_result = Tool_result
 module Keeper_types = Keeper_types
 module Keeper_identity = Masc.Keeper_identity
 module Keeper_registry = Masc.Keeper_registry
+module Keeper_lifecycle_reservation = Masc.Keeper_lifecycle_reservation
 module Masc_log = Log
 
 let () =
@@ -2177,7 +2178,39 @@ let test_handle_request_tools_call_records_keeper_usage_for_public_mcp () =
             (persisted |> member "tools" |> index 0 |> member "deferred" |> to_int);
           Keeper_registry.For_testing.unregister ~base_path keeper_name;
           ignore (Keeper_registry.For_testing.register ~base_path keeper_name keeper_meta);
-          Masc.Keeper_registry_tool_usage_persistence.restore ~base_path keeper_name;
+          let registered =
+            Keeper_registry.get ~base_path keeper_name
+            |> Option.get
+          in
+          let launch_token =
+            match
+              Keeper_lifecycle_reservation.acquire
+                ~base_path
+                ~keeper_name
+                ~expected_generation:registered.transition_seq
+                ~purpose:Keepalive_launch
+            with
+            | Ok token -> token
+            | Error _ -> Alcotest.fail "failed to reserve keeper launch lifecycle"
+          in
+          Fun.protect
+            ~finally:(fun () ->
+              ignore (Keeper_lifecycle_reservation.release launch_token))
+            (fun () ->
+              (* The ordinary replay is fenced while launch owns the key. The
+                 launch path must carry its exact mutation authority instead of
+                 silently dropping the persisted counters. *)
+              Masc.Keeper_registry_tool_usage_persistence.restore
+                ~base_path
+                keeper_name;
+              Alcotest.(check (list string))
+                "unqualified restore is fenced"
+                []
+                (Keeper_registry.tool_usage_of ~base_path keeper_name
+                 |> List.map fst);
+              Masc.Keeper_registry_tool_usage_persistence.restore_for_lifecycle
+                launch_token
+                registered);
           let restored =
             List.assoc_opt
               "masc_status"

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -168,7 +168,11 @@ let json_string_field_exn label json field =
         (Yojson.Safe.to_string json)
 
 let log_detail_string (entry : Masc_log.Ring.entry) field =
-  Yojson.Safe.Util.(entry.details |> member field |> to_string_option)
+  match Yojson.Safe.Util.member field entry.details with
+  | `String value | `Intlit value -> Some value
+  | `Int value -> Some (string_of_int value)
+  | `Null -> None
+  | _ -> None
 
 let find_mcp_tool_log_exn ~phase ~tool_name ~request_id entries =
   match
@@ -871,8 +875,8 @@ let test_handle_request_initialize_managed_profile () =
             in
             Alcotest.(check bool) "mentions managed profile" true
               (String_util.contains_substring instructions "managed-agent profile");
-            Alcotest.(check bool) "mentions canonical task control" true
-              (String_util.contains_substring instructions "masc_transition")
+            Alcotest.(check bool) "distinguishes public inventory" true
+              (String_util.contains_substring instructions "public /mcp surface")
         | _ -> Alcotest.fail "result not an object")
    | _ -> Alcotest.fail "response not an object");
   cleanup_dir base_path
@@ -1055,7 +1059,7 @@ let test_handle_request_tools_call_missing_params_records_duration () =
      -. before_count);
   cleanup_dir base_path
 
-let test_handle_request_tools_call_managed_translation_error_records_duration () =
+let test_handle_request_tools_call_managed_invalid_arguments_records_duration () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   Mcp_eio.set_net (Eio.Stdenv.net env);
@@ -1105,9 +1109,9 @@ let test_handle_request_tools_call_managed_translation_error_records_duration ()
       request
   in
   let response_text = Yojson.Safe.to_string response in
-  Alcotest.(check bool) "translation error is returned" true
-    (String_util.contains_substring response_text "managed agent tool translation failed");
-  Alcotest.(check (float 0.0001)) "translation error records duration count"
+  Alcotest.(check bool) "invalid arguments are rejected at admission" true
+    (String_util.contains_substring response_text "arguments must be an object");
+  Alcotest.(check (float 0.0001)) "admission error records duration count"
     1.0
     (Masc.Otel_metric_store.metric_value_or_zero (metric_name ^ "_count") ~labels ()
      -. before_count);
@@ -3097,8 +3101,8 @@ let eio_tests = [
     test_handle_request_tools_call_managed_profile_rejects_hidden_claim_alias;
   "handle tools/call missing params records duration", `Quick,
     test_handle_request_tools_call_missing_params_records_duration;
-  "handle tools/call managed translation error records duration", `Quick,
-    test_handle_request_tools_call_managed_translation_error_records_duration;
+  "handle tools/call managed invalid arguments record duration", `Quick,
+    test_handle_request_tools_call_managed_invalid_arguments_records_duration;
   "handle tools/call transition claim guidance", `Quick,
     test_handle_request_tools_call_transition_claim_guidance;
   "handle tools/call transition done requires LLM verdict", `Quick,


### PR DESCRIPTION
## What changed

- replace lifecycle cancellation of detached Librarian work with graceful drain-and-join
- atomically close Librarian admission before joining, including the empty-entry case
- preserve the exact owner receipt until a new lifecycle opens, so exit-before-drain failures and cleanup errors cannot become ownerless success
- persist a durable `Joining_lanes` shutdown phase before stopping either lane; interrupted boot recovery becomes admission-fenced `Blocked/Lane_join`
- fail closed as `Blocked/Lane_join` when a live `Joining_lanes` attempt is replayed, rather than re-running safety-sensitive turn cancellation and guessing away an earlier verdict
- reject a new Keeper lifecycle while prior Librarian ownership is still active
- settle pre-fork executor drops as typed owner failures instead of leaving an unresolved receipt
- keep process-wide shutdown cancellation owned by the existing server-root Eio switch

## Live root cause

The Codex ten-turn canary `canary-multiturn-codex-20260814-0042` completed all ten chat turns, but graceful `keeper_down` cancelled its final Librarian pass before commit:

- exact run: `librarian-exact-a7a2373a0f047458e8a85aadfd3f19f1`
- turn: `trace-1786635970987-00001#10`
- elapsed before cancellation: `106.097s`
- journal: `lane_cancelled`, `snapshot_present=true`, `cadence_deferred=false`
- prior snapshot remained at revision 3, last committed from turn 7

The cancelled turn-10 input contained the still-missing Harbor-3 and glasswing facts. A later cadence builds input from later turns; it does not replay that cancelled immutable input.

## Semantics

This changes graceful Keeper shutdown only. Accepted current-plus-latest Librarian work drains before terminal publication. No timeout, retry queue, capacity gate, second owner, or heuristic is introduced. Process shutdown can still cancel the root switch; durable `Joining_lanes` recovery then fails closed instead of guessing completion.

Crash/restart replay of uncommitted Librarian input remains outside this PR.
## Validation

Current exact head: `dc2b43bf2ed7c57ee0c71d57e29f79e46148a810`

- `dune build --root . @check test/test_keeper_registry_hardening.exe test/test_mcp_server_eio.exe`
- lifecycle-qualified tool-usage restore regression: PASS
- MCP Eio suite: 70/70 PASS
- CI target audit: 308 wired targets; unwired suite count remains at the 556 baseline
- `git diff --check`
- lifecycle restore runs through the exact reservation token while unqualified replay is fenced
- the repaired MCP Eio suite remains wired in focused CI; no baseline increase hides the newly exposed tests

Exact-head GitHub CI is running. The outstanding review thread remains unresolved until Build and Test succeeds.
