### PR TITLE
fix(dashboard): show linked task ids in goal detail

### DIFF
--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -406,6 +406,11 @@ function TreeTask({ task }: { task: GoalTreeTask }) {
   return html`
     <div class="flex flex-wrap items-center gap-2 rounded-[var(--r-1)] bg-[var(--color-bg-surface)] px-2 py-1.5 text-xs">
       <span class="size-2 rounded-[var(--r-0)] shrink-0" style="background:${task.status_color}"></span>
+      <span
+        class="max-w-32 shrink truncate font-mono text-3xs text-text-dim"
+        title=${`Task ID · ${task.id}`}
+        translate="no"
+      >${task.id}</span>
       <span class="min-w-0 flex-1 truncate text-text-body">${task.title}</span>
       ${task.assignee ? html`
         <span class="rounded-[var(--r-1)] border border-[var(--accent-20)] bg-[var(--accent-10)] px-1.5 py-0.5 text-3xs font-medium text-accent-fg">${task.assignee}</span>


### PR DESCRIPTION
## What changed

- show the authoritative linked Task ID beside each Task title in Goal detail
- keep long IDs visually bounded while preserving the exact value in the title attribute

## Why

A live Goal → Task lifecycle canary created `task-326`, linked it to `goal-canary-lifecycle-20260814-0104`, and terminally cancelled it. The Goal detail API returned the exact Task ID, title, and status, but the Dashboard rendered only title and status. Same-title Tasks therefore could not be distinguished from the Goal detail surface.

## As-Is / To-Be

- As-Is: API identity exists; Goal detail DOM omits it.
- To-Be: the existing `GoalTreeTask.id` projection is shown directly. No extra fetch, lookup, policy, or fallback is added.

## Evidence

- live API digest: `3df7c753bc7a0f67423383ace5224727dc227dab67ad68d121ab35a0f02bf48a`
- As-Is screenshot SHA-256: `d95ab83461abc8d04ddd722eefadd0c86a700c92249a199ddd150349b61d934f`
- screenshot: `/tmp/masc-feature-evidence-20260814/goal-task-lifecycle-as-is.png`
- adversarial source review: P1/P2 none after bounding long IDs

## Checks

- `git diff --check`
- changed-file ESLint
- Dashboard `tsc --noEmit`
- existing `goal-tree.test.ts`: 4/4 passed

No local Dune build and no new test were added. CI, merged, deployed, and post-deploy browser states remain separate pending gates.
