### PR TITLE
fix(keeper): join async users into turn transcripts

### DIFF
--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -1957,14 +1957,12 @@ let to_json_array ?base_dir ?trace_block_by_turn_ref
                        provenance)))
        messages)
 
-(* RFC-0233 §7: a turn's transcript derived by an exact join on the
-   persisted [turn_ref] ("<trace_id>#<absolute_turn>"). The inspector
-   needs the operator request that opened the turn and the keeper reply
-   it produced; both are stamped with the same turn_ref by
-   {!append_turn} on the dashboard reply path
-   (server_routes_http_keeper_stream.ml). Tool rows are excluded — they
-   carry only the call args, while the full tool I/O (input + output) is
-   surfaced by the tool-call store keyed on [execution_id]. *)
+(* RFC-0233 §7: a turn's terminal assistant row is selected by exact persisted
+   [turn_ref] ("<trace_id>#<absolute_turn>"). Direct/queued accepted-user rows
+   are persisted before the turn exists, so they carry no [turn_ref]; they join
+   through the same typed delivery key and the [Accepted_user] transcript slot.
+   Tool rows are excluded — they carry only the call args, while the full tool
+   I/O is surfaced by the tool-call store keyed on [execution_id]. *)
 type turn_transcript = {
   user : chat_message list;
   assistant : chat_message list;
@@ -1972,22 +1970,48 @@ type turn_transcript = {
 
 let transcript_of_messages (messages : chat_message list) ~turn_ref :
     turn_transcript =
-  let matches (m : chat_message) =
+  let matches_turn_ref (m : chat_message) =
     match m.turn_ref with
     | Some tr -> Ids.Turn_ref.equal tr turn_ref
     | None -> false
   in
+  let assistant_delivery_keys =
+    List.filter_map
+      (fun (m : chat_message) ->
+         match m.role, m.delivery_provenance with
+         | ( Role.Assistant
+           , Some
+               { Keeper_chat_delivery_identity.delivery_key
+               ; transcript_slot = Keeper_chat_delivery_identity.Terminal_assistant
+               } )
+           when matches_turn_ref m ->
+           Some delivery_key
+         | (Role.Assistant | Role.User | Role.Tool), _ -> None)
+      messages
+  in
+  let matches_accepted_user_delivery (m : chat_message) =
+    match m.role, m.delivery_provenance with
+    | ( Role.User
+      , Some
+          { Keeper_chat_delivery_identity.delivery_key
+          ; transcript_slot = Keeper_chat_delivery_identity.Accepted_user
+          } ) ->
+      List.exists
+        (Keeper_chat_delivery_identity.delivery_key_equal delivery_key)
+        assistant_delivery_keys
+    | (Role.Assistant | Role.User | Role.Tool), _ -> false
+  in
   let user, assistant =
     List.fold_left
       (fun (user, assistant) (m : chat_message) ->
-        if not (matches m) then (user, assistant)
-        else
-          match m.role with
-          | Role.User -> (m :: user, assistant)
-          | Role.Assistant -> (user, m :: assistant)
-          (* Tool rows join via execution_id in the tool-call store, not
-             via the transcript. *)
-          | Role.Tool -> (user, assistant))
+         match m.role with
+         | Role.User when matches_turn_ref m || matches_accepted_user_delivery m ->
+           m :: user, assistant
+         | Role.Assistant when matches_turn_ref m -> user, m :: assistant
+         | Role.User | Role.Assistant | Role.Tool ->
+           (* Tool rows join via execution_id in the tool-call store, not
+              via the transcript. *)
+           user, assistant)
       ([], []) messages
   in
   { user = List.rev user; assistant = List.rev assistant }

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -460,13 +460,13 @@ val to_json_array :
 
 (** {1 Turn transcript (RFC-0233 §7)} *)
 
-(** A keeper turn's transcript, derived by an exact join on the persisted
-    [turn_ref]. [user] holds the operator request line(s) that opened the
-    turn; [assistant] holds the keeper response line(s) (utterance and
-    typed transport-failure markers). Tool rows are excluded — their full
-    I/O is surfaced by the tool-call store keyed on [execution_id]. Both
-    lists are empty when no persisted row carries the requested
-    [turn_ref] (old rows, redacted, or outside the retained window). *)
+(** A keeper turn's transcript. The terminal assistant row is selected by
+    exact persisted [turn_ref]; an accepted-user row may join either by that
+    same [turn_ref] or by the assistant's exact typed delivery provenance.
+    [assistant] includes utterances and typed transport-failure markers. Tool
+    rows are excluded — their full I/O is surfaced by the tool-call store keyed
+    on [execution_id]. Both lists are empty when no persisted row carries the
+    requested [turn_ref] (old rows, redacted, or outside the retained window). *)
 type turn_transcript = {
   user : chat_message list;
   assistant : chat_message list;
@@ -474,11 +474,11 @@ type turn_transcript = {
 
 val transcript_of_messages :
   chat_message list -> turn_ref:Ids.Turn_ref.t -> turn_transcript
-(** [transcript_of_messages msgs ~turn_ref] partitions the rows whose
-    persisted [turn_ref] equals [turn_ref] into operator [user] lines and
-    keeper [assistant] lines, preserving input order. A row with a
-    different or absent [turn_ref] is excluded — exact-key join only, no
-    timestamp-window fuzzing (RFC-0233 §7 "no fuzzy attribution"). Pass
+(** [transcript_of_messages msgs ~turn_ref] selects keeper [assistant] lines
+    whose persisted [turn_ref] equals [turn_ref], then includes operator [user]
+    lines carrying either that [turn_ref] or the same typed delivery key in an
+    [Accepted_user] provenance slot. Input order is preserved. There is no
+    timestamp/text fallback (RFC-0233 §7 "no fuzzy attribution"). Pass
     {!load}-produced messages so the content is already the redacted view
     (RFC-0132); this function does not re-redact. *)
 

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -2064,6 +2064,81 @@ let test_delivery_key_malformed_reads_none () =
            Alcotest.failf "expected 1 message, got %d" (List.length messages));
       Alcotest.(check (float 0.001)) "drop counted as invalid payload" 1.0
         (drop_value invalid_payload -. before))
+
+let operation_delivery_key value =
+  match Keeper_chat_delivery_identity.Request_id.of_string value with
+  | Ok request_id -> Keeper_chat_delivery_identity.Operation request_id
+  | Error detail -> Alcotest.fail detail
+
+(* Async/queued user rows are accepted before a turn_ref exists. The terminal
+   assistant's typed delivery key is the only authority that may join that
+   user row into the exact turn transcript; a different operation must not
+   leak in even when it is adjacent in the same chat file. *)
+let test_transcript_joins_accepted_user_by_delivery_key () =
+  let base_dir = temp_base_path "keeper-chat-store-transcript-delivery" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-transcript-delivery" in
+      let matching_key = operation_delivery_key "kmsg-transcript-match" in
+      let other_key = operation_delivery_key "kmsg-transcript-other" in
+      let turn_ref =
+        Ids.Turn_ref.make ~trace_id:"trace-delivery" ~absolute_turn:7
+      in
+      (match
+         K.append_user_message_once
+           ~base_dir
+           ~keeper_name
+           ~delivery_key:matching_key
+           ~content:"accepted before turn"
+           ()
+       with
+       | Ok (K.Appended _) -> ()
+       | Ok (K.Already_present _) -> Alcotest.fail "matching user already present"
+       | Error detail -> Alcotest.fail detail);
+      (match
+         K.append_user_message_once
+           ~base_dir
+           ~keeper_name
+           ~delivery_key:other_key
+           ~content:"different operation"
+           ()
+       with
+       | Ok (K.Appended _) -> ()
+       | Ok (K.Already_present _) -> Alcotest.fail "other user already present"
+       | Error detail -> Alcotest.fail detail);
+      (match
+         K.append_assistant_message_once
+           ~base_dir
+           ~keeper_name
+           ~delivery_key:matching_key
+           ~content:"terminal reply"
+           ~turn_ref
+           ()
+       with
+       | Ok (K.Appended _) -> ()
+       | Ok (K.Already_present _) -> Alcotest.fail "assistant already present"
+       | Error detail -> Alcotest.fail detail);
+      let transcript =
+        K.load ~base_dir ~keeper_name
+        |> K.transcript_of_messages ~turn_ref
+      in
+      (match transcript.user with
+       | [ message ] ->
+         Alcotest.(check string)
+           "matching accepted user"
+           "accepted before turn"
+           message.content
+       | rows ->
+         Alcotest.failf "expected one joined user row, got %d" (List.length rows));
+      (match transcript.assistant with
+       | [ message ] ->
+         Alcotest.(check string) "terminal assistant" "terminal reply" message.content
+       | rows ->
+         Alcotest.failf
+           "expected one terminal assistant row, got %d"
+           (List.length rows)))
+
 let test_transcript_of_messages_joins_turn_ref () =
   let base_dir = temp_base_path "keeper-chat-store-transcript" in
   Fun.protect
@@ -2266,6 +2341,9 @@ let () =
           Alcotest.test_case
             "transcript_of_messages joins turn_ref (RFC-0233 §7)" `Quick
             test_transcript_of_messages_joins_turn_ref;
+          Alcotest.test_case
+            "transcript joins accepted user by exact delivery key" `Quick
+            test_transcript_joins_accepted_user_by_delivery_key;
           Alcotest.test_case
             "transcript absent returns empty + found=false (RFC-0233 §7)"
             `Quick test_transcript_absent_returns_empty;


### PR DESCRIPTION
## Stack

- Parent: #28619
- parent exact head: `c2df7af5a8e1f4179088ef1670f4ecd3cb7cbbf4`
- parent typed provenance 변경 뒤 병합해야 해용.

## 변경

- terminal assistant는 exact `turn_ref`로 선택
- accepted User는 assistant와 같은 typed delivery key + `Accepted_user` slot일 때만 join
- 텍스트·timestamp·role·prefix fallback 없음
- 입력 순서와 transport-failure kind 유지

## 검증

- exact head: `5d8ca9f5e85a40bd884aad7de758a8a8e702257b`
- matching operation의 turn_ref 없는 accepted User가 join되고, 다른 operation은 배제되는 회귀 테스트 추가
- ocamlformat, OCaml parse, diff-check, coverage gate 통과
- 로컬 Dune은 실행하지 않았고 CI가 build/test 권위예용.

CI·Draft 해제·merge·deploy·live rerun은 별도 남은 gate예용.