### PR TITLE
fix(dashboard): project effective keeper config

### DIFF
--- a/dashboard/src/api/dashboard-keeper-config.test.ts
+++ b/dashboard/src/api/dashboard-keeper-config.test.ts
@@ -55,4 +55,35 @@ describe('keeper config source projection', () => {
       live_value: true,
     }])
   })
+
+  it('rejects unavailable effective config instead of normalizing raw defaults', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        name: 'rtprobe',
+        effective_config: null,
+        config_error: {
+          keeper: 'rtprobe',
+          keeper_path: '/workspace/.masc/config/keepers/rtprobe.toml',
+          failing_path: '/workspace/.masc/config/keepers/rtprobe.toml',
+          kind: 'profile_error',
+          detail: 'missing required sandbox_profile',
+          terminal_reason: 'config_invalid',
+          severity: 'error',
+          blocking: true,
+          operator_action_required: true,
+          next_action: 'fix_keeper_toml_config',
+        },
+        sources: {
+          live_meta_path: '/workspace/.masc/keepers/rtprobe.json',
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ))
+
+    await expect(fetchKeeperConfig('rtprobe')).rejects.toThrow(
+      'Keeper config unavailable for rtprobe: profile_error at /workspace/.masc/config/keepers/rtprobe.toml: missing required sandbox_profile',
+    )
+  })
 })

--- a/dashboard/src/api/dashboard-keeper-config.ts
+++ b/dashboard/src/api/dashboard-keeper-config.ts
@@ -156,8 +156,41 @@ function normalizeOverrideFieldSources(raw: unknown): KeeperConfigOverrideFieldS
     .filter((row): row is KeeperConfigOverrideFieldSource => row !== null)
 }
 
+function keeperConfigUnavailableMessage(raw: unknown): string {
+  if (!isRecord(raw)) {
+    throw new Error('Invalid keeper config response: config_error must be a typed object')
+  }
+  const keeper = asNullableString(raw.keeper)
+  const keeperPath = asNullableString(raw.keeper_path)
+  const kind = asNullableString(raw.kind)
+  const failingPath = asNullableString(raw.failing_path)
+  const detail = asNullableString(raw.detail)
+  const validKind = kind === 'read_error'
+    || kind === 'parse_error'
+    || kind === 'profile_error'
+    || kind === 'invalid_name'
+  if (
+    !keeper
+    || !keeperPath
+    || !validKind
+    || !failingPath
+    || !detail
+    || raw.terminal_reason !== 'config_invalid'
+    || raw.severity !== 'error'
+    || raw.blocking !== true
+    || raw.operator_action_required !== true
+    || raw.next_action !== 'fix_keeper_toml_config'
+  ) {
+    throw new Error('Invalid keeper config response: config_error must be a typed object')
+  }
+  return `Keeper config unavailable for ${keeper}: ${kind} at ${failingPath}: ${detail}`
+}
+
 function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfig {
   const data = isRecord(raw) ? raw : {}
+  if (data.config_error !== undefined && data.config_error !== null) {
+    throw new Error(keeperConfigUnavailableMessage(data.config_error))
+  }
   const prompt = isRecord(data.prompt) ? data.prompt : {}
   const promptBlocks = isRecord(prompt.system_prompt_blocks) ? prompt.system_prompt_blocks : {}
   const execution = isRecord(data.execution) ? data.execution : {}

--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -45,22 +45,42 @@ let keeper_config_json (config : Workspace.config) (name : string)
       (`Not_found,
        `Assoc [ ("error", `String (Printf.sprintf "keeper %S not found" name)) ])
   | Ok (Some (m : Keeper_meta_contract.keeper_meta)) ->
+      let raw_meta = m in
       (* bootstrap_runtime is called at server startup — skip here to
          avoid blocking the HTTP handler with Eio.Mutex + file I/O (#3335). *)
-      let defaults, profile_config_error =
+      let defaults, effective_meta, config_error =
         match
           Keeper_types_profile.load_keeper_profile_defaults_result_for_base_path
             ~base_path:config.base_path
             m.name
         with
-        | Ok defaults -> defaults, None
+        | Ok defaults ->
+          (match Keeper_meta_contract.effective_meta_of_profile_defaults defaults m with
+           | Ok meta -> defaults, meta, None
+           | Error detail ->
+             let keeper_path =
+               Option.value
+                 ~default:(Keeper_types_profile.keeper_meta_path config m.name)
+                 defaults.manifest_path
+             in
+             ( defaults
+             , m
+             , Some
+                 { Keeper_types_profile.keeper_name = m.name
+                 ; keeper_path
+                 ; failing_path = keeper_path
+                 ; kind = Keeper_types_profile.Profile_error
+                 ; detail
+                 } ))
         | Error error ->
           ( Keeper_types_profile.empty_keeper_profile_defaults
+          , m
           , Some
               (Keeper_types_profile.keeper_toml_config_error_of_load_error
                  ~keeper_name:m.name
                  error) )
       in
+      let m = effective_meta in
       let active_goals =
         List.filter_map
           (fun goal_id ->
@@ -278,21 +298,30 @@ let keeper_config_json (config : Workspace.config) (name : string)
          ( "autonomous_wake_prompt",
            Json_util.string_opt_to_json
              defaults.Keeper_types_profile.autonomous_wake_prompt );
-         ("sandbox_profile", `String (Keeper_types_profile_sandbox.sandbox_profile_to_string m.sandbox_profile));
-         ("network_mode", `String (Keeper_types_profile_sandbox.network_mode_to_string m.network_mode));         ("sandbox_last_error", Json_util.string_opt_to_json sandbox_last_error);
-         ("allowed_paths",
-           `List (List.map (fun s -> `String s) m.allowed_paths));
-	         ("effective_allowed_paths",
-	           `List (List.map (fun s -> `String s)
-	             (Keeper_alerting_path.effective_allowed_paths ~meta:m)));
-	         ("pipeline_stage", `String pipeline_stage);
-	         ("lifecycle_phase", Json_util.string_opt_to_json lifecycle_phase);
-	         ("pipeline_stage_detail", `String pipeline_stage_detail);
+         ( "sandbox_profile"
+         , `String
+             (Keeper_types_profile_sandbox.sandbox_profile_to_string
+                m.sandbox_profile) );
+         ( "network_mode"
+         , `String
+             (Keeper_types_profile_sandbox.network_mode_to_string
+                m.network_mode) );
+         ("sandbox_last_error", Json_util.string_opt_to_json sandbox_last_error);
+         ( "allowed_paths"
+         , `List (List.map (fun s -> `String s) m.allowed_paths) );
+         ( "effective_allowed_paths"
+         , `List
+             (List.map
+                (fun s -> `String s)
+                (Keeper_alerting_path.effective_allowed_paths ~meta:m)) );
+         ("pipeline_stage", `String pipeline_stage);
+         ("lifecycle_phase", Json_util.string_opt_to_json lifecycle_phase);
+         ("pipeline_stage_detail", `String pipeline_stage_detail);
 	         ("state_diagram", `String state_diagram);
          ( "config_error",
            Json_util.option_to_yojson
              Keeper_types_profile.keeper_toml_config_error_to_json
-             profile_config_error );
+             config_error );
          ("prompt", prompt);
          ("execution", execution);
          ("proactive", proactive);
@@ -301,7 +330,7 @@ let keeper_config_json (config : Workspace.config) (name : string)
          ("runtime", runtime_surface_json config m);
          ("runtime_trust", runtime_trust);
          ("workspace", workspace);
-         ("sources", source_provenance_json config m);
+         ("sources", source_provenance_json config raw_meta);
          ("metrics", metrics);
        ]
       in

--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -48,7 +48,7 @@ let keeper_config_json (config : Workspace.config) (name : string)
       let raw_meta = m in
       (* bootstrap_runtime is called at server startup — skip here to
          avoid blocking the HTTP handler with Eio.Mutex + file I/O (#3335). *)
-      let defaults, effective_meta, config_error =
+      let effective_meta =
         match
           Keeper_types_profile.load_keeper_profile_defaults_result_for_base_path
             ~base_path:config.base_path
@@ -56,31 +56,40 @@ let keeper_config_json (config : Workspace.config) (name : string)
         with
         | Ok defaults ->
           (match Keeper_meta_contract.effective_meta_of_profile_defaults defaults m with
-           | Ok meta -> defaults, meta, None
+           | Ok meta -> Ok (defaults, meta)
            | Error detail ->
              let keeper_path =
                Option.value
                  ~default:(Keeper_types_profile.keeper_meta_path config m.name)
                  defaults.manifest_path
              in
-             ( defaults
-             , m
-             , Some
-                 { Keeper_types_profile.keeper_name = m.name
-                 ; keeper_path
-                 ; failing_path = keeper_path
-                 ; kind = Keeper_types_profile.Profile_error
-                 ; detail
-                 } ))
+             Error
+               { Keeper_types_profile.keeper_name = m.name
+               ; keeper_path
+               ; failing_path = keeper_path
+               ; kind = Keeper_types_profile.Profile_error
+               ; detail
+               })
         | Error error ->
-          ( Keeper_types_profile.empty_keeper_profile_defaults
-          , m
-          , Some
-              (Keeper_types_profile.keeper_toml_config_error_of_load_error
-                 ~keeper_name:m.name
-                 error) )
+          Error
+            (Keeper_types_profile.keeper_toml_config_error_of_load_error
+               ~keeper_name:m.name
+               error)
       in
-      let m = effective_meta in
+      (match effective_meta with
+       | Error config_error ->
+         let body =
+           `Assoc
+             [ "name", `String raw_meta.name
+             ; "effective_config", `Null
+             ; ( "config_error"
+               , Keeper_types_profile.keeper_toml_config_error_to_json
+                   config_error )
+             ; "sources", source_provenance_json config raw_meta
+             ]
+         in
+         `OK, with_keeper_config_field_presence body
+       | Ok (defaults, m) ->
       let active_goals =
         List.filter_map
           (fun goal_id ->
@@ -319,9 +328,7 @@ let keeper_config_json (config : Workspace.config) (name : string)
          ("pipeline_stage_detail", `String pipeline_stage_detail);
 	         ("state_diagram", `String state_diagram);
          ( "config_error",
-           Json_util.option_to_yojson
-             Keeper_types_profile.keeper_toml_config_error_to_json
-             config_error );
+           `Null );
          ("prompt", prompt);
          ("execution", execution);
          ("proactive", proactive);
@@ -334,7 +341,7 @@ let keeper_config_json (config : Workspace.config) (name : string)
          ("metrics", metrics);
        ]
       in
-      (`OK, with_keeper_config_field_presence body)
+      (`OK, with_keeper_config_field_presence body))
 
 (** Per-keeper cost/latency aggregates for the O4 cost dashboard.
 

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -1250,7 +1250,7 @@ let test_config_snapshot_does_not_fallback_to_raw_meta () =
 |};
   let config = Workspace.default_config base in
   ignore (seed_runtime_meta config name : Masc.Keeper_meta_contract.keeper_meta);
-  match Masc.Dashboard_http_keeper_snapshot.keeper_config_json config name with
+  match Dashboard_http_keeper_snapshot.keeper_config_json config name with
   | `Not_found, _ -> Alcotest.fail "expected a typed unavailable config snapshot"
   | `OK, json ->
     Alcotest.(check (option string))

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -1240,6 +1240,44 @@ let test_keeper_list_row_surfaces_effective_meta_errors () =
              (List.mem_assoc "effective_meta_error" fields)
        | _ -> Alcotest.fail "expected object row")
 
+let test_config_snapshot_does_not_fallback_to_raw_meta () =
+  with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
+  let name = "bad-config-snapshot" in
+  write_keeper_agent ~keepers_dir ~name "Missing sandbox profile";
+  write_file
+    (Filename.concat keepers_dir (name ^ ".toml"))
+    {|[keeper]
+|};
+  let config = Workspace.default_config base in
+  ignore (seed_runtime_meta config name : Masc.Keeper_meta_contract.keeper_meta);
+  match Masc.Dashboard_http_keeper_snapshot.keeper_config_json config name with
+  | `Not_found, _ -> Alcotest.fail "expected a typed unavailable config snapshot"
+  | `OK, json ->
+    Alcotest.(check (option string))
+      "snapshot preserves the raw keeper identity"
+      (Some name)
+      (json_string_field "name" json);
+    Alcotest.(check bool)
+      "effective config is explicitly unavailable"
+      true
+      (json_field "effective_config" json = Some `Null);
+    Alcotest.(check bool)
+      "raw sandbox defaults are not projected as effective"
+      true
+      (json_field "sandbox_profile" json = None);
+    Alcotest.(check bool)
+      "typed config error remains visible"
+      true
+      (match json_field "config_error" json with
+       | Some (`Assoc _) -> true
+       | Some _ | None -> false);
+    Alcotest.(check bool)
+      "raw source provenance remains visible"
+      true
+      (match json_field "sources" json with
+       | Some (`Assoc _) -> true
+       | Some _ | None -> false)
+
 let test_keeper_list_error_row_preserves_keepalive_state () =
   with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
   let name = "badprofile-running" in
@@ -1324,6 +1362,9 @@ let () =
             test_status_surfaces_chat_operation_runtime;
           Alcotest.test_case "keeper list surfaces effective meta errors"
             `Quick test_keeper_list_row_surfaces_effective_meta_errors;
+          Alcotest.test_case
+            "config snapshot never falls back to raw effective fields"
+            `Quick test_config_snapshot_does_not_fallback_to_raw_meta;
           Alcotest.test_case
             "keeper list error row preserves keepalive state"
             `Quick test_keeper_list_error_row_preserves_keepalive_state;


### PR DESCRIPTION
## As-Is

The live `analyst` Keeper TOML declares `sandbox_profile = "docker"`, while the public config endpoint currently reports `sandbox_profile = "local"` and `network_mode = "inherit"`. The snapshot serializes raw runtime-meta defaults instead of the already available effective Keeper profile.

## To-Be

- Resolve the Keeper profile once at the config snapshot boundary.
- On success, use that single effective meta for editable policy, prompt/world preview, active workspace goals, runtime surface, and runtime trust.
- Preserve raw meta only for explicit source provenance.
- On profile load or effective-resolution failure, return `effective_config: null` plus the existing typed `config_error`; do not render raw defaults as usable configuration.
- The frontend rejects the error arm before applying normal config defaults.

## Exact stack

- parent PR: #28585
- base: `be40d9101c72c7b978231b88d8c2e122bebb12bc`
- head: `e10aa9adc780bfa16990a258de06fc669e97e8b7`
- diff: 2 production files and 2 existing test files

## Boundary

- No runtime-name or lane policy
- No live config mutation or process restart
- No new framework or execution gate

## Current-head validation

- OCaml changed-file format and parse-only checks: pass
- `git diff --check`: pass
- Dashboard `tsc --noEmit`: pass
- Changed-file ESLint: pass
- Independent adversarial source review: in progress
- Exact-head CI: in progress
- No local Dune build

CI, merge, deployment, and post-deploy browser verification remain separate.