### PR TITLE
fix(dashboard): 스트림 소유권과 서버 수락을 분리한다 (#28616 후속)

### DIFF
--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -572,6 +572,27 @@ describe('sendKeeperThreadMessage operation stream', () => {
     expect(cancelKeeperChatOperation).toHaveBeenCalledWith('echo', acceptedOperationId)
   })
 
+  it('aborts locally without server cancel before operation acceptance', async () => {
+    streamKeeperMessage.mockImplementation(async (
+      _name: string,
+      _message: string,
+      opts: { signal: AbortSignal },
+    ) => new Promise<{ terminal: boolean }>((_resolve, reject) => {
+      opts.signal.addEventListener('abort', () => {
+        const error = new Error('Aborted')
+        error.name = 'AbortError'
+        reject(error)
+      }, { once: true })
+    }))
+
+    const send = sendKeeperThreadMessage('echo', 'cancel before accept').catch(() => undefined)
+    await Promise.resolve()
+    await cancelActiveKeeperThreadMessage('echo')
+    await send
+
+    expect(cancelKeeperChatOperation).not.toHaveBeenCalled()
+  })
+
   it('streams thinking, tool use, and final text after operation acceptance', async () => {
     streamKeeperMessage.mockImplementation(async (
       _name: string,

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -53,6 +53,7 @@ import {
   normalizeStatusDetail,
   removeThreadEntries,
   liveSendOwnsRequest,
+  markLiveSendRequestAccepted,
   releaseLiveSendRequest,
   setActiveStream,
   setRecordValue,
@@ -982,6 +983,7 @@ export async function sendKeeperThreadMessage(
             throw new Error('Keeper operation acceptance identity mismatch')
           }
           requestId = acceptedOperationId
+          markLiveSendRequestAccepted(acceptedOperationId)
           stampPlaceholderRequestId(
             keeperName,
             [localId, assistantId],

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -68,6 +68,11 @@ const keeperActiveStreams = new Map<string, Map<string, KeeperActiveStream>>()
 // Module state, so it survives unmount/remount exactly like the controller
 // maps above; a full page reload resets it, leaving cold-start resume intact.
 const liveSendRequestOwners = new Map<string, string>()
+// A locally minted id is owned before the POST starts so observer broadcasts
+// cannot race the direct stream. Server-side mutation is safe only after the
+// direct stream has observed KEEPER_CHAT_OPERATION_ACCEPTED, so keep that
+// stronger fact independently.
+const acceptedLiveSendRequestIds = new Set<string>()
 
 export function _resetActiveKeeperStreamsForTests(): void {
   keeperActiveStreams.clear()
@@ -1623,13 +1628,14 @@ export function getStreamController(name: string): AbortController | undefined {
 
 export function setActiveStreamRequestId(name: string, requestId: string): void {
   claimLiveSendRequest(requestId, name)
+  markLiveSendRequestAccepted(requestId)
 }
 
 export function activeStreamRequestId(name: string): string | null {
   const keeperName = name.trim()
   if (!keeperName) return null
   for (const [requestId, owner] of liveSendRequestOwners) {
-    if (owner === keeperName) return requestId
+    if (owner === keeperName && acceptedLiveSendRequestIds.has(requestId)) return requestId
   }
   return null
 }
@@ -1638,7 +1644,10 @@ export function clearActiveStreamRequestId(name: string): void {
   const keeperName = name.trim()
   if (!keeperName) return
   for (const [requestId, owner] of liveSendRequestOwners) {
-    if (owner === keeperName) liveSendRequestOwners.delete(requestId)
+    if (owner === keeperName) {
+      liveSendRequestOwners.delete(requestId)
+      acceptedLiveSendRequestIds.delete(requestId)
+    }
   }
 }
 
@@ -1649,6 +1658,7 @@ export function clearActiveStreamRequestId(name: string): void {
 export function releaseActiveStreamRequestId(requestId: string): boolean {
   const id = requestId.trim()
   if (!id) return false
+  acceptedLiveSendRequestIds.delete(id)
   return liveSendRequestOwners.delete(id)
 }
 
@@ -1661,8 +1671,15 @@ export function claimLiveSendRequest(requestId: string, name: string): void {
   liveSendRequestOwners.set(id, keeperName)
 }
 
+export function markLiveSendRequestAccepted(requestId: string): void {
+  const id = requestId.trim()
+  if (liveSendRequestOwners.has(id)) acceptedLiveSendRequestIds.add(id)
+}
+
 export function releaseLiveSendRequest(requestId: string): void {
-  liveSendRequestOwners.delete(requestId.trim())
+  const id = requestId.trim()
+  liveSendRequestOwners.delete(id)
+  acceptedLiveSendRequestIds.delete(id)
 }
 
 export function liveSendOwnsRequest(requestId: string): boolean {
@@ -1671,4 +1688,5 @@ export function liveSendOwnsRequest(requestId: string): boolean {
 
 export function _resetLiveSendRequestOwnersForTests(): void {
   liveSendRequestOwners.clear()
+  acceptedLiveSendRequestIds.clear()
 }

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -219,6 +219,31 @@ describe('Keeper operation stream projection', () => {
     expect(entry?.text).toBe('')
   })
 
+  it('lets the observer resume an interrupted pre-acceptance placeholder', () => {
+    appendThreadEntry('sangsu', {
+      id: 'reply-interrupted',
+      role: 'assistant',
+      source: 'direct_assistant',
+      label: 'sangsu',
+      text: '',
+      rawText: '',
+      timestamp: null,
+      requestId: 'kmsg-interrupted',
+      delivery: 'interrupted',
+      streamState: null,
+      details: null,
+    })
+
+    applyKeeperOperationTurnEvent('sangsu', {
+      operationId: 'kmsg-interrupted',
+      event: { type: 'TEXT_MESSAGE_CONTENT', delta: 'observer recovered' },
+    })
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-interrupted')
+    expect(entry?.text).toBe('observer recovered')
+    expect(entry?.delivery).toBe('streaming')
+  })
+
   it('accepts observer events immediately after the direct owner exits', () => {
     directlyStreamingBubble()
     setActiveStream(

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -441,6 +441,7 @@ export function applyKeeperOperationTurnEvent(
     && matched.delivery !== 'queued'
     && matched.delivery !== 'sending'
     && matched.delivery !== 'streaming'
+    && matched.delivery !== 'interrupted'
   ) {
     return null
   }


### PR DESCRIPTION
## 배경 — 이 PR 이 따로 존재하는 이유

masc#28616 머지(01:28:28) **31초 뒤**(01:28:59) 같은 브랜치에 올라온 커밋입니다. squash 머지 + `--delete-branch` 로 원격 브랜치가 사라져 main 에 도달하지 못했습니다. 로컬 객체에서 회수해 최신 main 위로 cherry-pick 했습니다 (충돌 없음).

원 커밋: `f839f16eff fix(dashboard): separate stream ownership from acceptance`

## 무엇을 고치나

#28616 에서 소유권 claim 시점을 `KEEPER_CHAT_OPERATION_ACCEPTED` 수신 후 → `setActiveStream`(POST 이전, 클라이언트가 operation id 를 발행하는 시점)으로 앞당겼습니다. 브로드캐스트가 ACCEPTED 를 앞질러 도착하는 레이스를 닫기 위해서였고, 그건 맞습니다.

그런데 그 결과 `activeStreamRequestId` 가 **서버가 아직 수락하지 않은 id** 를 반환하게 됩니다. 이 값은 서버 측 취소 같은 원격 변경의 대상을 고르는 데 쓰이므로, 수락 전 id 를 넘기면 서버가 모르는 operation 을 지목합니다.

두 사실의 유효 시점이 다른데 한 자료구조가 둘을 겸하고 있었습니다.

| 사실 | 언제 참이 되나 | 무엇에 쓰나 |
|---|---|---|
| 이 세션이 이 요청을 스트리밍한다 | 로컬에서 id 발행 시 (POST 이전) | 브로드캐스트 메아리 차단 |
| 서버가 이 요청을 수락했다 | `KEEPER_CHAT_OPERATION_ACCEPTED` 관측 시 | 서버 측 변경(취소 등)의 대상 선택 |

`acceptedLiveSendRequestIds` 를 분리해 후자를 독립적으로 들고, `activeStreamRequestId` 는 수락된 id 만 반환합니다. 소유권 가드는 이른 시점 그대로 유지되므로 #28616 이 닫은 레이스는 계속 닫혀 있습니다.

## 검증

- `keeper-stream.test.ts` + `keeper-actions.test.ts` **73/73 통과** (원 커밋이 가져온 테스트 포함: `keeper-actions.test.ts` +21줄, `keeper-stream.test.ts` +25줄)
- `tsc --noEmit` 통과, `eslint` 통과
- 최신 main(`a7f641fa28`, #28616 squash) 위에서 cherry-pick, 충돌 없음

## 재발 방지 메모

`--delete-branch` 는 머지 시점의 head 만 보고, 그 뒤 도착하는 push 를 막지 못합니다. 이번엔 31초 차이였습니다. 같은 사고가 이 저장소에서 이미 있었습니다 (masc#5303, 16개 브랜치의 post-merge 커밋 누락). 브랜치에 다른 세션이 붙어 있을 때는 머지 직전 head 재확인만으로 부족하고, 그 세션이 끝났다는 신호가 필요합니다.