### PR TITLE
fix(keeper): wake live owners for durable demand

### DIFF
--- a/lib/keeper/keeper_activation_readiness.ml
+++ b/lib/keeper/keeper_activation_readiness.ml
@@ -238,8 +238,31 @@ let classify_owner_execution =
   classify_owner_execution_with ~require_proactive:true
 ;;
 
-let classify_durable_demand_execution =
-  classify_owner_execution_with ~require_proactive:false
+let classify_durable_demand_execution
+      ~shutdown_operation_id
+      ~runtime
+      meta_result
+  =
+  match
+    classify_owner_execution_with
+      ~require_proactive:false
+      ~shutdown_operation_id
+      ~runtime
+      meta_result,
+    runtime,
+    meta_result
+  with
+  | Retained_disabled Retained_autoboot_disabled,
+    Owner_registered
+      { phase = Keeper_state_machine.Running; live_fiber = true; _ },
+    Ok meta
+      when (not meta.autoboot_enabled)
+           && (Keeper_lifecycle_gate_env.global ()).autonomous ->
+    (* [autoboot_enabled] controls whether an absent owner may be started. It
+       must not suppress an explicit durable wake for an owner that is already
+       running. Lifecycle and shutdown fences were resolved before this arm. *)
+    Executable
+  | truth, _, _ -> truth
 ;;
 
 let of_meta meta =

--- a/lib/keeper/keeper_activation_readiness.mli
+++ b/lib/keeper/keeper_activation_readiness.mli
@@ -95,8 +95,10 @@ val classify_durable_demand_execution :
   (Keeper_meta_contract.keeper_meta, string) result ->
   owner_execution_truth
 (** Classify activation for an already-persisted explicit demand such as a due
-    schedule or HITL continuation. Lifecycle, shutdown, and autoboot policy
-    still apply, but [proactive_enabled] does not: that flag controls
-    unsolicited scheduled-autonomous turns, not reactive durable work. *)
+    schedule or HITL continuation. Lifecycle and shutdown policy still apply.
+    [autoboot_enabled] controls recovery of an absent owner, but does not block
+    an owner that is already running. [proactive_enabled] does not apply: that
+    flag controls unsolicited scheduled-autonomous turns, not reactive durable
+    work. *)
 
 val to_yojson : t -> Yojson.Safe.t

--- a/test/test_keeper_lifecycle_global_gate.ml
+++ b/test/test_keeper_lifecycle_global_gate.ml
@@ -348,6 +348,71 @@ let test_durable_demand_does_not_require_proactive () =
      | Readiness.Unknown _ -> false)
 ;;
 
+let test_durable_demand_bypasses_autoboot_only_for_live_running_owner () =
+  without_overrides @@ fun () ->
+  let autoboot_disabled = { (ready_meta ()) with autoboot_enabled = false } in
+  let classify ?(shutdown_operation_id = None) runtime =
+    Readiness.classify_durable_demand_execution
+      ~shutdown_operation_id
+      ~runtime
+      (Ok autoboot_disabled)
+  in
+  check bool "live running owner accepts persisted demand" true
+    (match
+       classify (owner_runtime ~phase:State_machine.Running ~live_fiber:true)
+     with
+     | Readiness.Executable -> true
+     | Readiness.Recoverable
+     | Readiness.Retained_disabled _
+     | Readiness.Paused_dead _
+     | Readiness.Shutdown_fenced _
+     | Readiness.Unknown _ -> false);
+  let remains_autoboot_disabled runtime =
+    match classify runtime with
+    | Readiness.Retained_disabled Readiness.Retained_autoboot_disabled -> true
+    | Readiness.Executable
+    | Readiness.Recoverable
+    | Readiness.Retained_disabled _
+    | Readiness.Paused_dead _
+    | Readiness.Shutdown_fenced _
+    | Readiness.Unknown _ -> false
+  in
+  check bool "absent owner is not autobooted" true
+    (remains_autoboot_disabled Readiness.Owner_unregistered);
+  check bool "dead fiber is not treated as executable" true
+    (remains_autoboot_disabled
+       (owner_runtime ~phase:State_machine.Running ~live_fiber:false));
+  check bool "terminal owner is not treated as executable" true
+    (remains_autoboot_disabled
+       (owner_runtime ~phase:State_machine.Stopped ~live_fiber:true));
+  let operation_id = Shutdown_types.Operation_id.generate () in
+  check bool "shutdown fence still dominates the live-owner exception" true
+    (match
+       classify
+         ~shutdown_operation_id:(Some operation_id)
+         (owner_runtime ~phase:State_machine.Running ~live_fiber:true)
+     with
+     | Readiness.Shutdown_fenced actual ->
+       Shutdown_types.Operation_id.equal operation_id actual
+     | Readiness.Executable
+     | Readiness.Recoverable
+     | Readiness.Retained_disabled _
+     | Readiness.Paused_dead _
+     | Readiness.Unknown _ -> false);
+  with_flag "MASC_KEEPER_AUTONOMOUS_ENABLED" "false" @@ fun () ->
+  check bool "global autonomous kill-switch still dominates" true
+    (match
+       classify (owner_runtime ~phase:State_machine.Running ~live_fiber:true)
+     with
+     | Readiness.Retained_disabled Readiness.Retained_autoboot_disabled -> true
+     | Readiness.Executable
+     | Readiness.Recoverable
+     | Readiness.Retained_disabled _
+     | Readiness.Paused_dead _
+     | Readiness.Shutdown_fenced _
+     | Readiness.Unknown _ -> false)
+;;
+
 let test_owner_execution_shutdown_fence_blocks_boot () =
   without_overrides @@ fun () ->
   let operation_id = Shutdown_types.Operation_id.generate () in
@@ -588,6 +653,8 @@ let () =
             test_owner_execution_requires_live_fiber
         ; test_case "durable demand bypasses proactive policy" `Quick
             test_durable_demand_does_not_require_proactive
+        ; test_case "durable demand bypasses autoboot only for live owner" `Quick
+            test_durable_demand_bypasses_autoboot_only_for_live_running_owner
         ; test_case "shutdown fence blocks boot" `Quick
             test_owner_execution_shutdown_fence_blocks_boot
         ; test_case "unknown owner truth fails closed" `Quick


### PR DESCRIPTION
## As-Is

A live isolated Keeper was explicitly running with per-Keeper autoboot=false and proactive=false. A 15-second recurring schedule dispatched two distinct durable occurrences successfully, but both remained pending because durable-demand classification returned autoboot_disabled. The scheduler treated a future-boot preference as a veto on waking an already-running owner.

Evidence:
- schedule_id: canary-rec2-1786638568
- occurrence IDs: 803be4ed271150e122b7f5a471d34079ddcd1088368e37f51b146a7433030e1f and 080f3d3d964d85bc0e310c585df31134765f92996bc1d4064fd53632676df358
- both dispatch receipts: succeeded / awaiting_ack / activation deferred autoboot_disabled
- owner at dispatch: Running with live fiber
- queue remained pending=2 beyond 60 seconds
- schedule was cancelled after the second dispatch

## To-Be

For an already-persisted explicit demand, a per-Keeper autoboot=false only controls whether that absent owner may be started. Map the exact state Retained_autoboot_disabled + Running + live_fiber=true + meta.autoboot_enabled=false to Executable. Lifecycle, shutdown, global autonomous kill-switch, owner absence, terminal phase, and dead-fiber verdicts remain unchanged. The schedule consumer still rechecks lifecycle and Running phase before signaling.

## Scope

- Base: main@a7f641fa28c39ac5a50f3477347642613c64ca90
- Two production contract files, no new framework or admission gate
- No runtime-name/provider policy
- No config mutation in source

## Fast checks

- ocamlformat --check: pass
- ocamlc parse-only: pass
- git diff --check: pass
- OCaml structure ratchet: pass
- Adversarial review issue resolved: global kill-switch remains retained
- Local Dune: not run by instruction
- New tests: not added by instruction

CI, merged binary, deployment, and the post-deploy recurrence rerun remain separate and pending.

# ci:skip-test-coverage

Coverage tests are explicitly deferred by campaign instruction; this source-only slice fixes the reproduced durable-demand wake boundary without adding test code.
