### PR TITLE
fix(dashboard): retain librarian selected slot evidence

### DIFF
--- a/dashboard/src/api/dashboard-exact-lane-runs.test.ts
+++ b/dashboard/src/api/dashboard-exact-lane-runs.test.ts
@@ -16,11 +16,13 @@ describe('parseExactLaneRunsResponse', () => {
         started_at: 1,
         status: 'succeeded',
         elapsed_s: 0.4,
+        selected_slot: 'librarian-primary',
       }],
     })
     expect(parsed.runs[0]).toMatchObject({
       lane: 'librarian_exact',
       status: 'succeeded',
+      selectedSlot: 'librarian-primary',
     })
   })
 
@@ -90,6 +92,7 @@ describe('parseExactLaneRunsResponse', () => {
           intended_code: 'model_error',
           intended_detail: 'typed failure detail',
           elapsed_s: 0.4,
+          selected_slot: null,
           persistence_error: 'append rejected before commit',
           persistence_state: 'not_persisted',
         },
@@ -102,6 +105,7 @@ describe('parseExactLaneRunsResponse', () => {
           status: 'completion_durability_unknown',
           intended_status: 'succeeded',
           elapsed_s: 0.5,
+          selected_slot: 'librarian-secondary',
           persistence_error: 'rollback settlement failed',
           persistence_state: 'durability_unknown',
         },
@@ -113,11 +117,13 @@ describe('parseExactLaneRunsResponse', () => {
       intendedCode: 'model_error',
       intendedDetail: 'typed failure detail',
       persistenceState: 'not_persisted',
+      selectedSlot: null,
     })
     expect(parsed.runs[1]).toMatchObject({
       status: 'completion_durability_unknown',
       intendedStatus: 'succeeded',
       persistenceState: 'durability_unknown',
+      selectedSlot: 'librarian-secondary',
     })
   })
 
@@ -136,10 +142,29 @@ describe('parseExactLaneRunsResponse', () => {
         status: 'completion_persistence_failed',
         intended_status: 'succeeded',
         elapsed_s: 0.4,
+        selected_slot: null,
         persistence_error: 'append failed',
         persistence_state: 'durability_unknown',
       }],
     })).toThrow('persistence_state must be')
+  })
+
+  it('rejects a terminal row that omits the current selected-slot contract', () => {
+    expect(() => parseExactLaneRunsResponse({
+      generated_at: '2026-08-11T00:00:00Z',
+      count: 1,
+      total: 1,
+      has_more: false,
+      runs: [{
+        run_id: 'legacy-terminal',
+        lane: 'librarian_exact',
+        subject_id: 'trace',
+        actor: 'keeper-a',
+        started_at: 1,
+        status: 'succeeded',
+        elapsed_s: 0.4,
+      }],
+    })).toThrow('missing=[selected_slot]')
   })
 })
 
@@ -155,12 +180,14 @@ describe('parseExactLaneRunResponse', () => {
         started_at: 1,
         status: 'succeeded',
         elapsed_s: 0.4,
+        selected_slot: null,
         input: { kind: 'exact', payload: { message_count: 4 } },
         output: { fact_count: 3 },
       },
     })
     expect(run.input).toEqual({ kind: 'exact', payload: { message_count: 4 } })
     expect(run.output).toEqual({ fact_count: 3 })
+    expect(run.selectedSlot).toBeNull()
   })
 
   it('rejects removed research input instead of replaying it', () => {

--- a/dashboard/src/api/dashboard-exact-lane-runs.ts
+++ b/dashboard/src/api/dashboard-exact-lane-runs.ts
@@ -125,7 +125,9 @@ function parseRun(raw: unknown, index: number, withPayloads: boolean): ExactLane
   const base = ['run_id', 'lane', 'subject_id', 'actor', 'started_at', 'status']
     .concat(withPayloads ? ['input'] : [])
   // `output` rides with the payloads; a summary never carries it.
-  const completion = withPayloads ? ['elapsed_s', 'output'] : ['elapsed_s']
+  const completion = withPayloads
+    ? ['elapsed_s', 'output', 'selected_slot']
+    : ['elapsed_s', 'selected_slot']
   const persistenceFailure = status === 'completion_persistence_failed'
     || status === 'completion_durability_unknown'
   const intendedStatus = persistenceFailure
@@ -149,7 +151,7 @@ function parseRun(raw: unknown, index: number, withPayloads: boolean): ExactLane
       : status === 'failed'
         ? [...base, ...completion, 'code', 'detail']
         : [...base, ...completion]
-  exactFields(raw, required, ['selected_slot'], context)
+  exactFields(raw, required, [], context)
   const persistenceState = persistenceFailure
     ? string(raw.persistence_state, `${context}.persistence_state`)
     : undefined
@@ -161,10 +163,7 @@ function parseRun(raw: unknown, index: number, withPayloads: boolean): ExactLane
   if (persistenceState !== expectedPersistenceState) {
     fail(`${context}.persistence_state must be ${JSON.stringify(expectedPersistenceState)}`)
   }
-  if (status === 'running' && 'selected_slot' in raw) {
-    fail(`${context}.selected_slot is only valid after completion`)
-  }
-  const selectedSlot = !('selected_slot' in raw)
+  const selectedSlot = status === 'running'
     ? undefined
     : raw.selected_slot === null
       ? null

--- a/dashboard/src/api/dashboard-exact-lane-runs.ts
+++ b/dashboard/src/api/dashboard-exact-lane-runs.ts
@@ -38,6 +38,9 @@ export interface ExactLaneRunSummary {
   intendedDetail?: string
   persistenceError?: string
   persistenceState?: ExactLanePersistenceState
+  // Opaque configured exact-lane slot. This is not separately authoritative
+  // provider/model attribution, and older retained rows have no value.
+  selectedSlot?: string | null
 }
 
 // One opened run, payloads included.
@@ -146,7 +149,7 @@ function parseRun(raw: unknown, index: number, withPayloads: boolean): ExactLane
       : status === 'failed'
         ? [...base, ...completion, 'code', 'detail']
         : [...base, ...completion]
-  exactFields(raw, required, [], context)
+  exactFields(raw, required, ['selected_slot'], context)
   const persistenceState = persistenceFailure
     ? string(raw.persistence_state, `${context}.persistence_state`)
     : undefined
@@ -158,6 +161,14 @@ function parseRun(raw: unknown, index: number, withPayloads: boolean): ExactLane
   if (persistenceState !== expectedPersistenceState) {
     fail(`${context}.persistence_state must be ${JSON.stringify(expectedPersistenceState)}`)
   }
+  if (status === 'running' && 'selected_slot' in raw) {
+    fail(`${context}.selected_slot is only valid after completion`)
+  }
+  const selectedSlot = !('selected_slot' in raw)
+    ? undefined
+    : raw.selected_slot === null
+      ? null
+      : string(raw.selected_slot, `${context}.selected_slot`)
   return {
     runId: string(raw.run_id, `${context}.run_id`),
     lane: lane as ExactLane,
@@ -181,6 +192,7 @@ function parseRun(raw: unknown, index: number, withPayloads: boolean): ExactLane
       ? string(raw.persistence_error, `${context}.persistence_error`)
       : undefined,
     persistenceState: persistenceState as ExactLanePersistenceState | undefined,
+    selectedSlot,
   }
 }
 

--- a/dashboard/src/api/dashboard-exact-lane-runs.ts
+++ b/dashboard/src/api/dashboard-exact-lane-runs.ts
@@ -39,7 +39,7 @@ export interface ExactLaneRunSummary {
   persistenceError?: string
   persistenceState?: ExactLanePersistenceState
   // Opaque configured exact-lane slot. This is not separately authoritative
-  // provider/model attribution, and older retained rows have no value.
+  // provider/model attribution. Running rows have no terminal value yet.
   selectedSlot?: string | null
 }
 

--- a/dashboard/src/components/internal-agents-monitor.test.ts
+++ b/dashboard/src/components/internal-agents-monitor.test.ts
@@ -159,6 +159,7 @@ describe('InternalAgentsMonitor', () => {
         startedAt: 1786000000,
         status: 'succeeded',
         elapsedSeconds: 2,
+        selectedSlot: 'librarian-primary',
       }],
     })
     // The listing carries no payloads; opening the row is what fetches them.
@@ -170,6 +171,7 @@ describe('InternalAgentsMonitor', () => {
       startedAt: 1786000000,
       status: 'succeeded',
       elapsedSeconds: 2,
+      selectedSlot: 'librarian-primary',
       input: {
         kind: 'exact',
         payload: { current_fact_count: 1, message_count: 5 },
@@ -211,6 +213,7 @@ describe('InternalAgentsMonitor', () => {
     expect(container.textContent).toContain('낡은 기억')
     expect(container.textContent).toContain('새 근거로 대체됨')
     expect(container.textContent).toContain('TOOL-FREE')
+    expect(container.textContent).toContain('선택 slot librarian-primary')
     expect(container.textContent).toContain('외부 research/RAW 입력을 받지 않습니다')
     expect(memoryApi.fetchKeeperMemoryJournal).toHaveBeenCalledWith(
       'kidsnote',

--- a/dashboard/src/components/internal-agents-monitor.ts
+++ b/dashboard/src/components/internal-agents-monitor.ts
@@ -336,6 +336,9 @@ function ExactRunDetail({ runId }: { runId: string }) {
           <${EvidenceBadge} kind="typed" />
           <strong>Exact-output registry metadata</strong>
           <span class="text-[var(--color-fg-muted)]">Admin-only 실제 typed 값 · Librarian exact에는 research RAW 입력 없음</span>
+          ${run.selectedSlot === undefined
+            ? null
+            : html`<span class="text-[var(--color-fg-muted)]">선택 slot <code>${run.selectedSlot ?? '미기록'}</code></span>`}
           <a class="ml-auto text-[var(--color-accent)] hover:underline" href=${keeperHref(run.actor)}>Keeper 전체 evidence 열기 →</a>
         </div>
         <div class="grid gap-3 lg:grid-cols-2">

--- a/lib/exact_lane_run_registry.ml
+++ b/lib/exact_lane_run_registry.ml
@@ -382,6 +382,7 @@ let mark_completed_internal t ~run_id ~outcome ~elapsed_s ~selected_slot ~output
     notify_changed ();
     Ok ()
   | Error Unknown_run -> Error Unknown_run
+  | Error Invalid_selected_slot -> Error Invalid_selected_slot
   | Error (Persistence_failed _ as error) ->
     notify_changed ();
     Error error

--- a/lib/exact_lane_run_registry.ml
+++ b/lib/exact_lane_run_registry.ml
@@ -27,11 +27,13 @@ type run_status =
       { outcome : outcome
       ; elapsed_s : float
       ; output : Yojson.Safe.t
+      ; selected_slot : string option
       }
   | Completion_persistence_failed of
       { intended_outcome : outcome
       ; elapsed_s : float
       ; output : Yojson.Safe.t
+      ; selected_slot : string option
       ; failure : persistence_failure
       }
 
@@ -98,6 +100,7 @@ module Payload = struct
     { outcome : outcome
     ; elapsed_s : float
     ; output : Yojson.Safe.t
+    ; selected_slot : string option
     }
 
   let name = "exact_lane_run_registry"
@@ -167,6 +170,9 @@ module Payload = struct
        ; "elapsed_s", `Float completion.elapsed_s
        ; "output", completion.output
        ]
+       @ (match completion.selected_slot with
+          | None -> []
+          | Some selected_slot -> [ "selected_slot", `String selected_slot ])
        @ detail)
   ;;
 
@@ -184,6 +190,7 @@ module Payload = struct
     let* () =
       Run_registry_core.Json.exact_fields
         ~required:([ "outcome"; "elapsed_s"; "output" ] @ detail_fields)
+        ~optional:[ "selected_slot" ]
         fields
     in
     let* elapsed_s = Run_registry_core.Json.float_field "elapsed_s" fields in
@@ -202,7 +209,14 @@ module Payload = struct
         Ok (Failed { code; detail })
       | value -> Error (Printf.sprintf "unknown exact lane outcome %S" value)
     in
-    Ok { outcome; elapsed_s; output }
+    let* selected_slot =
+      match List.assoc_opt "selected_slot" fields with
+      | None -> Ok None
+      | Some (`String selected_slot) when String.trim selected_slot <> "" ->
+        Ok (Some selected_slot)
+      | Some _ -> Error "field selected_slot must be a non-empty string"
+    in
+    Ok { outcome; elapsed_s; output; selected_slot }
   ;;
 end
 
@@ -212,6 +226,7 @@ type failed_completion =
   { intended_outcome : outcome
   ; elapsed_s : float
   ; output : Yojson.Safe.t
+  ; selected_slot : string option
   ; failure : persistence_failure
   }
 
@@ -262,6 +277,7 @@ let run_of_entry failed_completions (entry : Store.entry) =
         { intended_outcome = failed.intended_outcome
         ; elapsed_s = failed.elapsed_s
         ; output = failed.output
+        ; selected_slot = failed.selected_slot
         ; failure = failed.failure
         }
     | None, Store.Running -> Running
@@ -272,6 +288,7 @@ let run_of_entry failed_completions (entry : Store.entry) =
         { outcome = completion.outcome
         ; elapsed_s = completion.elapsed_s
         ; output = completion.output
+        ; selected_slot = completion.selected_slot
         }
   in
   { run_id = entry.id
@@ -331,8 +348,8 @@ let register_running t ~run_id ~lane ~subject_id ~actor ~started_at ~input =
   notify_changed ()
 ;;
 
-let mark_completed t ~run_id ~outcome ~elapsed_s ~output =
-  let completion = { Payload.outcome; elapsed_s; output } in
+let mark_completed_internal t ~run_id ~outcome ~elapsed_s ~selected_slot ~output =
+  let completion = { Payload.outcome; elapsed_s; output; selected_slot } in
   let result =
     Cross_context_mutex.with_durable_lock t.observation_mutex (fun () ->
       match Store.complete t.store ~id:run_id ~completion with
@@ -348,7 +365,9 @@ let mark_completed t ~run_id ~outcome ~elapsed_s ~output =
           | Run_registry_core.Durability_unknown -> Durability_unknown
         in
         let failure = { detail = failure.detail; state } in
-        let failed = { intended_outcome = outcome; elapsed_s; output; failure } in
+        let failed =
+          { intended_outcome = outcome; elapsed_s; output; selected_slot; failure }
+        in
         Atomic.set
           t.failed_completions
           ((run_id, failed) :: List.remove_assoc run_id (Atomic.get t.failed_completions));
@@ -363,6 +382,33 @@ let mark_completed t ~run_id ~outcome ~elapsed_s ~output =
   | Error (Persistence_failed _ as error) ->
     notify_changed ();
     Error error
+;;
+
+let mark_completed t ~run_id ~outcome ~elapsed_s ~output =
+  mark_completed_internal
+    t
+    ~run_id
+    ~outcome
+    ~elapsed_s
+    ~selected_slot:None
+    ~output
+;;
+
+let mark_completed_with_slot
+      t
+      ~run_id
+      ~outcome
+      ~elapsed_s
+      ~selected_slot
+      ~output
+  =
+  mark_completed_internal
+    t
+    ~run_id
+    ~outcome
+    ~elapsed_s
+    ~selected_slot:(Some selected_slot)
+    ~output
 ;;
 
 (* [total] counts every retained run, not the page, so a caller can say
@@ -439,16 +485,22 @@ let run_summary_fields run =
   let completion =
     match run.status with
     | Running -> []
-    | Completed { outcome; elapsed_s; output = _ } ->
+    | Completed { outcome; elapsed_s; output = _; selected_slot } ->
       let detail =
         match outcome with
         | Succeeded | Cancelled -> []
         | Failed { code; detail } ->
           [ "code", `String code; "detail", `String detail ]
       in
-      [ "elapsed_s", `Float elapsed_s ] @ detail
+      [ "elapsed_s", `Float elapsed_s
+      ; ( "selected_slot"
+        , match selected_slot with
+          | None -> `Null
+          | Some selected_slot -> `String selected_slot )
+      ]
+      @ detail
     | Completion_persistence_failed
-        { intended_outcome; elapsed_s; output = _; failure } ->
+        { intended_outcome; elapsed_s; output = _; selected_slot; failure } ->
       let intended_failure =
         match intended_outcome with
         | Succeeded | Cancelled -> []
@@ -457,6 +509,10 @@ let run_summary_fields run =
       in
       [ "intended_status", `String (outcome_label intended_outcome)
       ; "elapsed_s", `Float elapsed_s
+      ; ( "selected_slot"
+        , match selected_slot with
+          | None -> `Null
+          | Some selected_slot -> `String selected_slot )
       ; "persistence_error", `String failure.detail
       ; ( "persistence_state"
         , `String

--- a/lib/exact_lane_run_registry.ml
+++ b/lib/exact_lane_run_registry.ml
@@ -169,10 +169,11 @@ module Payload = struct
       ([ "outcome", `String (outcome_label completion.outcome)
        ; "elapsed_s", `Float completion.elapsed_s
        ; "output", completion.output
+       ; ( "selected_slot"
+         , match completion.selected_slot with
+           | None -> `Null
+           | Some selected_slot -> `String selected_slot )
        ]
-       @ (match completion.selected_slot with
-          | None -> []
-          | Some selected_slot -> [ "selected_slot", `String selected_slot ])
        @ detail)
   ;;
 
@@ -189,8 +190,7 @@ module Payload = struct
     let* detail_fields = detail_fields in
     let* () =
       Run_registry_core.Json.exact_fields
-        ~required:([ "outcome"; "elapsed_s"; "output" ] @ detail_fields)
-        ~optional:[ "selected_slot" ]
+        ~required:([ "outcome"; "elapsed_s"; "output"; "selected_slot" ] @ detail_fields)
         fields
     in
     let* elapsed_s = Run_registry_core.Json.float_field "elapsed_s" fields in
@@ -211,10 +211,11 @@ module Payload = struct
     in
     let* selected_slot =
       match List.assoc_opt "selected_slot" fields with
-      | None -> Ok None
+      | Some `Null -> Ok None
       | Some (`String selected_slot) when String.trim selected_slot <> "" ->
         Ok (Some selected_slot)
       | Some _ -> Error "field selected_slot must be a non-empty string"
+      | None -> Error "missing field selected_slot"
     in
     Ok { outcome; elapsed_s; output; selected_slot }
   ;;
@@ -239,14 +240,16 @@ type t =
 
 type completion_error =
   | Unknown_run
+  | Invalid_selected_slot
   | Persistence_failed of persistence_failure
 
 let completion_error_to_string = function
   | Unknown_run -> "completion referenced an unknown exact-lane run"
+  | Invalid_selected_slot -> "selected exact-lane slot must be non-blank"
   | Persistence_failed failure -> failure.detail
 ;;
 
-let storage_filename = "exact-lane-runs-v3.jsonl"
+let storage_filename = "exact-lane-runs-v4.jsonl"
 
 (* Re-exported from the store rather than re-derived from [Payload], so the
    bound a test reads is the bound [prune] applies. *)
@@ -384,31 +387,11 @@ let mark_completed_internal t ~run_id ~outcome ~elapsed_s ~selected_slot ~output
     Error error
 ;;
 
-let mark_completed t ~run_id ~outcome ~elapsed_s ~output =
-  mark_completed_internal
-    t
-    ~run_id
-    ~outcome
-    ~elapsed_s
-    ~selected_slot:None
-    ~output
-;;
-
-let mark_completed_with_slot
-      t
-      ~run_id
-      ~outcome
-      ~elapsed_s
-      ~selected_slot
-      ~output
-  =
-  mark_completed_internal
-    t
-    ~run_id
-    ~outcome
-    ~elapsed_s
-    ~selected_slot:(Some selected_slot)
-    ~output
+let mark_completed t ~run_id ~outcome ~elapsed_s ~selected_slot ~output =
+  match selected_slot with
+  | Some selected_slot when String.trim selected_slot = "" -> Error Invalid_selected_slot
+  | None | Some _ ->
+    mark_completed_internal t ~run_id ~outcome ~elapsed_s ~selected_slot ~output
 ;;
 
 (* [total] counts every retained run, not the page, so a caller can say

--- a/lib/exact_lane_run_registry.mli
+++ b/lib/exact_lane_run_registry.mli
@@ -56,6 +56,7 @@ type t
 
 type completion_error =
   | Unknown_run
+  | Invalid_selected_slot
   | Persistence_failed of persistence_failure
 
 val completion_error_to_string : completion_error -> string
@@ -89,25 +90,16 @@ val mark_completed
   -> run_id:string
   -> outcome:outcome
   -> elapsed_s:float
+  -> selected_slot:string option
   -> output:Yojson.Safe.t
   -> (unit, completion_error) result
 (** Record an observation-plane completion without taking ownership of the
     caller's primary lifecycle. Persistence failures are returned rather than
     raised. The durable core entry remains [Running], while [get]/[list_runs]
     expose [Completion_persistence_failed] with an explicit durability state;
-    callers never silently present a terminal run as still executing. *)
-
-val mark_completed_with_slot
-  :  t
-  -> run_id:string
-  -> outcome:outcome
-  -> elapsed_s:float
-  -> selected_slot:string
-  -> output:Yojson.Safe.t
-  -> (unit, completion_error) result
-(** Complete a run with the exact configured slot selected by the producer's
-    accepted flow receipt. Producers without that receipt use [mark_completed]
-    and project missing evidence instead of guessing. *)
+    callers never silently present a terminal run as still executing. The
+    labelled [selected_slot] argument forces every producer to state whether it
+    owns an accepted exact-flow receipt. Blank slot identities are rejected. *)
 
 val list_runs : t -> run list
 

--- a/lib/exact_lane_run_registry.mli
+++ b/lib/exact_lane_run_registry.mli
@@ -30,11 +30,13 @@ type run_status =
       { outcome : outcome
       ; elapsed_s : float
       ; output : Yojson.Safe.t
+      ; selected_slot : string option
       }
   | Completion_persistence_failed of
       { intended_outcome : outcome
       ; elapsed_s : float
       ; output : Yojson.Safe.t
+      ; selected_slot : string option
       ; failure : persistence_failure
       }
 
@@ -94,6 +96,18 @@ val mark_completed
     raised. The durable core entry remains [Running], while [get]/[list_runs]
     expose [Completion_persistence_failed] with an explicit durability state;
     callers never silently present a terminal run as still executing. *)
+
+val mark_completed_with_slot
+  :  t
+  -> run_id:string
+  -> outcome:outcome
+  -> elapsed_s:float
+  -> selected_slot:string
+  -> output:Yojson.Safe.t
+  -> (unit, completion_error) result
+(** Complete a run with the exact configured slot selected by the producer's
+    accepted flow receipt. Producers without that receipt use [mark_completed]
+    and project missing evidence instead of guessing. *)
 
 val list_runs : t -> run list
 

--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -1235,6 +1235,7 @@ let spawn_with
           ~run_id
           ~outcome
           ~elapsed_s:(Time_compat.now () -. started_at)
+          ~selected_slot:None
           ~output
       with
       | Ok () -> ()

--- a/lib/keeper/keeper_board_attention_exact_flow.ml
+++ b/lib/keeper/keeper_board_attention_exact_flow.ml
@@ -389,6 +389,7 @@ let execute_current ?clock ~before_dispatch ~before_advance prepared =
         ~run_id
         ~outcome
         ~elapsed_s:(Time_compat.now () -. started_at)
+        ~selected_slot:None
         ~output
     with
     | Ok () -> ()

--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -929,6 +929,7 @@ let execute_prepared_lane_current
         ~run_id
         ~outcome
         ~elapsed_s:(Time_compat.now () -. started_at)
+        ~selected_slot:None
         ~output
     with
     | Ok () -> ()

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -523,22 +523,13 @@ let run_best_effort
         let complete ?selected_slot outcome output =
           let elapsed_s = Eio.Time.now clock -. started_at_monotonic in
           let completion =
-            match selected_slot with
-            | None ->
-              Exact_lane_run_registry.mark_completed
-                registry
-                ~run_id
-                ~outcome
-                ~elapsed_s
-                ~output
-            | Some selected_slot ->
-              Exact_lane_run_registry.mark_completed_with_slot
-                registry
-                ~run_id
-                ~outcome
-                ~elapsed_s
-                ~selected_slot
-                ~output
+            Exact_lane_run_registry.mark_completed
+              registry
+              ~run_id
+              ~outcome
+              ~elapsed_s
+              ~selected_slot
+              ~output
           in
           match completion with
           | Ok () -> ()

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -126,7 +126,10 @@ type extraction_error =
   | Exact_setup_failed of exact_setup_error
   | Exact_execution_failed of exact_execution_error
   | Domain_output_invalid of string
-  | Memory_snapshot_write_failed of string
+  | Memory_snapshot_write_failed of
+      { detail : string
+      ; selected_slot : string
+      }
 
 let extraction_error_kind : extraction_error -> Keeper_memory_os_current.librarian_failure_kind
   = function
@@ -176,8 +179,18 @@ let extraction_error_to_string = function
       detail
   | Domain_output_invalid detail ->
     "librarian domain output invalid: " ^ detail
-  | Memory_snapshot_write_failed detail ->
+  | Memory_snapshot_write_failed { detail; selected_slot = _ } ->
     "memory os current snapshot write failed: " ^ detail
+;;
+
+let selected_slot_of_extraction_error = function
+  | Memory_snapshot_write_failed { selected_slot; _ } -> Some selected_slot
+  | Prompt_render_failed _
+  | Execution_clock_unavailable
+  | Exact_setup_failed _
+  | Exact_execution_failed _
+  | Domain_output_invalid _ ->
+    None
 ;;
 
 let should_record_cadence_backoff_after_error = function
@@ -356,7 +369,13 @@ let execute_exact_output_classified
       ~validate
       attempt
   with
-  | Ok success -> Ok success.accepted
+  | Ok success ->
+    let selected_slot =
+      success.transport_success
+      |> Exact_output.flow_success_candidate
+      |> fun candidate -> candidate.visit.identity.candidate_id
+    in
+    Ok (success.accepted, selected_slot)
   | Error (Exact_output.Flow_execution_terminal { cause; _ }) ->
     Error (Exact_execution_failed (exact_execution_error cause))
   | Error
@@ -501,15 +520,27 @@ let run_best_effort
                   ; ( "max_recall_fact_bytes"
                     , `Int prompt_input.max_recall_fact_bytes )
                   ]));
-        let complete outcome output =
-          match
-            Exact_lane_run_registry.mark_completed
-              registry
-              ~run_id
-              ~outcome
-              ~elapsed_s:(Eio.Time.now clock -. started_at_monotonic)
-              ~output
-          with
+        let complete ?selected_slot outcome output =
+          let elapsed_s = Eio.Time.now clock -. started_at_monotonic in
+          let completion =
+            match selected_slot with
+            | None ->
+              Exact_lane_run_registry.mark_completed
+                registry
+                ~run_id
+                ~outcome
+                ~elapsed_s
+                ~output
+            | Some selected_slot ->
+              Exact_lane_run_registry.mark_completed_with_slot
+                registry
+                ~run_id
+                ~outcome
+                ~elapsed_s
+                ~selected_slot
+                ~output
+          in
+          match completion with
           | Ok () -> ()
           | Error error ->
             Log.Keeper.error
@@ -525,7 +556,7 @@ let run_best_effort
                render_librarian_prompt prompt_input
                |> Result.map_error (fun detail -> Prompt_render_failed detail)
              in
-             let* selection, exact_output =
+             let* (selection, exact_output), selected_slot =
                execute_exact_output_classified
                  ~clock
                  ~net
@@ -548,13 +579,14 @@ let run_best_effort
                ~facts:selection.facts
                ()
              |> Result.map_error (fun detail ->
-               Memory_snapshot_write_failed detail)
+               Memory_snapshot_write_failed { detail; selected_slot })
              in
-             snapshot, exact_output
+             snapshot, exact_output, selected_slot
            in
            match result with
-           | Ok (snapshot, exact_output) ->
+           | Ok (snapshot, exact_output, selected_slot) ->
              complete
+               ~selected_slot
                Exact_lane_run_registry.Succeeded
                (completed_output ~inp ~exact_output snapshot);
              cadence_record_success ~keeper_id ~trace_id;
@@ -568,6 +600,7 @@ let run_best_effort
            | Error error ->
              let detail = extraction_error_to_string error in
              complete
+               ?selected_slot:(selected_slot_of_extraction_error error)
                (Exact_lane_run_registry.Failed
                   { code = "librarian_failed"
                   ; detail =

--- a/test/test_exact_lane_run_registry.ml
+++ b/test/test_exact_lane_run_registry.ml
@@ -56,7 +56,7 @@ let test_round_trip_preserves_exact_evidence () =
     ~run_id:"run-1"
     ~outcome:R.Succeeded
     ~elapsed_s:0.5
-    ~selected_slot:"librarian-primary"
+    ~selected_slot:(Some "librarian-primary")
     ~output:(`Assoc [ "fact_count", `Int 3 ]);
   let replayed = R.replay path in
   let original = R.get registry ~run_id:"run-1" |> Option.get |> R.run_to_yojson in

--- a/test/test_exact_lane_run_registry.ml
+++ b/test/test_exact_lane_run_registry.ml
@@ -7,7 +7,7 @@ let remove_if_exists path =
 ;;
 
 let mark_completed_exn t ~run_id ~outcome ~elapsed_s ~output =
-  match R.mark_completed t ~run_id ~outcome ~elapsed_s ~output with
+  match R.mark_completed t ~run_id ~outcome ~elapsed_s ~selected_slot:None ~output with
   | Ok () -> ()
   | Error error ->
     failf
@@ -15,9 +15,16 @@ let mark_completed_exn t ~run_id ~outcome ~elapsed_s ~output =
       (R.completion_error_to_string error)
 ;;
 
-let mark_completed_with_slot_exn t ~run_id ~outcome ~elapsed_s ~selected_slot ~output =
+let mark_completed_with_selected_slot_exn
+      t
+      ~run_id
+      ~outcome
+      ~elapsed_s
+      ~selected_slot
+      ~output
+  =
   match
-    R.mark_completed_with_slot
+    R.mark_completed
       t
       ~run_id
       ~outcome
@@ -44,7 +51,7 @@ let test_round_trip_preserves_exact_evidence () =
     ~actor:"keeper-a"
     ~started_at:10.0
     ~input:(R.Exact_input (`Assoc [ "message_count", `Int 4 ]));
-  mark_completed_with_slot_exn
+  mark_completed_with_selected_slot_exn
     registry
     ~run_id:"run-1"
     ~outcome:R.Succeeded
@@ -60,6 +67,110 @@ let test_round_trip_preserves_exact_evidence () =
      check string "selected slot" "librarian-primary" selected_slot
    | _ -> fail "selected slot did not survive durable replay");
   remove_if_exists path
+;;
+
+let test_completion_without_slot_receipt_writes_explicit_null () =
+  let path = Filename.temp_file "exact-lane-null-slot-" ".jsonl" in
+  remove_if_exists path;
+  let registry = R.create ~path () in
+  R.register_running
+    registry
+    ~run_id:"run-no-receipt"
+    ~lane:R.Board_attention
+    ~subject_id:"candidate-1"
+    ~actor:"keeper-a"
+    ~started_at:10.0
+    ~input:(R.Exact_input `Null);
+  mark_completed_exn
+    registry
+    ~run_id:"run-no-receipt"
+    ~outcome:R.Succeeded
+    ~elapsed_s:0.5
+    ~output:`Null;
+  let lines = Fs_compat.load_file path |> String.split_on_char '\n' in
+  let completion_event = Yojson.Safe.from_string (List.nth lines 1) in
+  (match completion_event with
+   | `Assoc fields ->
+     (match List.assoc_opt "completion" fields with
+      | Some (`Assoc completion_fields) ->
+        check bool "None is explicit durable evidence" true
+          (List.assoc_opt "selected_slot" completion_fields = Some `Null)
+      | _ -> fail "completion event must carry an object payload")
+   | _ -> fail "completion event must be an object");
+  remove_if_exists path
+;;
+
+let test_missing_selected_slot_is_not_replayed () =
+  let path = Filename.temp_file "exact-lane-legacy-slot-" ".jsonl" in
+  remove_if_exists path;
+  let registry = R.create ~path () in
+  R.register_running
+    registry
+    ~run_id:"legacy-run"
+    ~lane:R.Board_attention
+    ~subject_id:"candidate-1"
+    ~actor:"keeper-a"
+    ~started_at:10.0
+    ~input:(R.Exact_input `Null);
+  mark_completed_exn
+    registry
+    ~run_id:"legacy-run"
+    ~outcome:R.Succeeded
+    ~elapsed_s:0.5
+    ~output:`Null;
+  let lines = Fs_compat.load_file path |> String.split_on_char '\n' in
+  let completion_event =
+    match Yojson.Safe.from_string (List.nth lines 1) with
+    | `Assoc fields ->
+      `Assoc
+        (List.map
+           (fun (name, value) ->
+              if String.equal name "completion"
+              then (
+                match value with
+                | `Assoc completion_fields ->
+                  name, `Assoc (List.remove_assoc "selected_slot" completion_fields)
+                | _ -> fail "completion event must carry an object payload")
+              else name, value)
+           fields)
+    | _ -> fail "completion event must be an object"
+  in
+  Fs_compat.save_file
+    path
+    (String.concat
+       "\n"
+       [ List.nth lines 0; Yojson.Safe.to_string completion_event; "" ]);
+  let replayed = R.replay path in
+  check (option string) "pre-v4 completion is rejected, not projected as None" None
+    (R.get replayed ~run_id:"legacy-run" |> Option.map (fun run -> R.status_label run.R.status));
+  remove_if_exists path
+;;
+
+let test_blank_selected_slot_is_rejected_before_write () =
+  let registry = R.create () in
+  R.register_running
+    registry
+    ~run_id:"blank-slot"
+    ~lane:R.Librarian
+    ~subject_id:"trace-1"
+    ~actor:"keeper-a"
+    ~started_at:10.0
+    ~input:(R.Exact_input `Null);
+  let result =
+    R.mark_completed
+      registry
+      ~run_id:"blank-slot"
+      ~outcome:R.Succeeded
+      ~elapsed_s:0.5
+      ~selected_slot:(Some " \t")
+      ~output:`Null
+  in
+  check bool "blank selected slot is a typed writer error" true
+    (match result with
+     | Error R.Invalid_selected_slot -> true
+     | Error R.Unknown_run | Error (R.Persistence_failed _) | Ok () -> false);
+  check string "invalid completion leaves the registered run running" "running"
+    (R.get registry ~run_id:"blank-slot" |> Option.get |> fun run -> R.status_label run.R.status)
 ;;
 
 let test_running_shape_has_no_invented_completion () =
@@ -82,7 +193,7 @@ let test_running_shape_has_no_invented_completion () =
 ;;
 
 let test_current_storage_generation () =
-  check string "current store file" "exact-lane-runs-v3.jsonl" R.storage_filename
+  check string "current store file" "exact-lane-runs-v4.jsonl" R.storage_filename
 ;;
 
 (* The retained-run bound exists to serve the internal-agents monitor, which
@@ -213,6 +324,7 @@ let test_failed_durable_completion_is_explicitly_visible () =
       ~run_id:"completion-not-published"
       ~outcome:(R.Failed { code = "model_error"; detail = "typed failure detail" })
       ~elapsed_s:0.1
+      ~selected_slot:None
       ~output:(`String "must-not-publish")
   in
   (match completion with
@@ -220,6 +332,7 @@ let test_failed_durable_completion_is_explicitly_visible () =
      check bool "failure retains durable detail" true
        (String.trim failure.detail <> "")
    | Error R.Unknown_run -> fail "registered run became unknown"
+   | Error R.Invalid_selected_slot -> fail "explicit None slot became invalid"
    | Ok () -> fail "directory unexpectedly received durable completion");
   let run = R.get registry ~run_id:"completion-not-published" |> Option.get in
   check bool "failed completion is not reported as running" true
@@ -391,6 +504,12 @@ let () =
     "exact_lane_run_registry"
     [ ( "registry"
       , [ test_case "durable exact evidence" `Quick test_round_trip_preserves_exact_evidence
+        ; test_case "missing receipt is explicit null" `Quick
+            test_completion_without_slot_receipt_writes_explicit_null
+        ; test_case "pre-v4 completion is rejected" `Quick
+            test_missing_selected_slot_is_not_replayed
+        ; test_case "blank selected slot is rejected before write" `Quick
+            test_blank_selected_slot_is_rejected_before_write
         ; test_case "running shape" `Quick test_running_shape_has_no_invented_completion
         ; test_case "current storage generation" `Quick test_current_storage_generation
         ; test_case "exact history is not cross-lane pruned" `Quick

--- a/test/test_exact_lane_run_registry.ml
+++ b/test/test_exact_lane_run_registry.ml
@@ -15,6 +15,23 @@ let mark_completed_exn t ~run_id ~outcome ~elapsed_s ~output =
       (R.completion_error_to_string error)
 ;;
 
+let mark_completed_with_slot_exn t ~run_id ~outcome ~elapsed_s ~selected_slot ~output =
+  match
+    R.mark_completed_with_slot
+      t
+      ~run_id
+      ~outcome
+      ~elapsed_s
+      ~selected_slot
+      ~output
+  with
+  | Ok () -> ()
+  | Error error ->
+    failf
+      "exact-lane completion with slot failed: %s"
+      (R.completion_error_to_string error)
+;;
+
 let test_round_trip_preserves_exact_evidence () =
   let path = Filename.temp_file "exact-lane-runs-" ".jsonl" in
   remove_if_exists path;
@@ -27,16 +44,21 @@ let test_round_trip_preserves_exact_evidence () =
     ~actor:"keeper-a"
     ~started_at:10.0
     ~input:(R.Exact_input (`Assoc [ "message_count", `Int 4 ]));
-  mark_completed_exn
+  mark_completed_with_slot_exn
     registry
     ~run_id:"run-1"
     ~outcome:R.Succeeded
     ~elapsed_s:0.5
+    ~selected_slot:"librarian-primary"
     ~output:(`Assoc [ "fact_count", `Int 3 ]);
   let replayed = R.replay path in
   let original = R.get registry ~run_id:"run-1" |> Option.get |> R.run_to_yojson in
   let restored = R.get replayed ~run_id:"run-1" |> Option.get |> R.run_to_yojson in
   check string "round trip" (Yojson.Safe.to_string original) (Yojson.Safe.to_string restored);
+  (match R.get replayed ~run_id:"run-1" |> Option.get with
+   | { status = R.Completed { selected_slot = Some selected_slot; _ }; _ } ->
+     check string "selected slot" "librarian-primary" selected_slot
+   | _ -> fail "selected slot did not survive durable replay");
   remove_if_exists path
 ;;
 

--- a/test/test_run_registry_concurrent_mutation.ml
+++ b/test/test_run_registry_concurrent_mutation.ml
@@ -191,6 +191,7 @@ let test_exact_lane_completion_against_registration () =
                  ~run_id:"exact-first"
                  ~outcome:Ex.Succeeded
                  ~elapsed_s:1.0
+                 ~selected_slot:None
                  ~output:(`Assoc [])))
           (fun () -> register_exact t ~run_id:"exact-second"));
       check


### PR DESCRIPTION
## As-Is

A successful exact-lane run retained its lane/outcome but discarded the exact configured slot selected by Agent Core. Live Librarian rows could prove success, but not which configured slot produced it.

## To-Be

- Preserve the accepted Librarian flow candidate's opaque `selected_slot` in the current exact-lane completion record.
- Preserve the same evidence when model execution succeeds but the Memory snapshot write fails.
- Replay older v3 rows as `None`, project terminal missing evidence as JSON `null`, and keep running rows without a terminal slot.
- Decode and display the typed slot in Internal Agents without calling it a provider, model, or runtime ID.

## Scope

- Base: `f47b5fd0315a8bc3fa32b7b2508904ea933f299a`
- Head: `268a547c74851947e34926a3ad682aaf17176bd9`
- 5 production files, no new test files.
- Existing 2-file Dashboard suites: 14/14 passed.
- Dashboard TypeScript and changed-file ESLint passed.
- OCaml format, parse-only, SSOT and Agent Core boundary checks passed.
- Local Dune was not run.
- CI, deployment, and live post-deploy Librarian evidence are pending.


# ci:skip-test-coverage

Coverage tests are explicitly deferred by campaign instruction. Existing focused Dashboard suites were run; no new test code is added in this feature-first slice.