### PR TITLE
fix(dashboard): own backend health truth once

### DIFF
--- a/dashboard/src/api/dashboard-tools-prompts.ts
+++ b/dashboard/src/api/dashboard-tools-prompts.ts
@@ -569,8 +569,26 @@ export interface DashboardKeeperEventQueueHealth {
   work_liveness: DashboardKeeperQueueWorkLiveness | null
 }
 
+export type DashboardFullHealthSnapshotStatus =
+  | 'ready'
+  | 'warming'
+  | 'stale'
+  | 'timeout'
+  | 'error'
+
+export interface DashboardFullHealthSnapshot {
+  status: DashboardFullHealthSnapshotStatus
+  stale_reason: string | null
+  last_good_available: boolean
+  component_timed_out: boolean
+}
+
 export interface DashboardFullHealthResponse {
   health_detail?: string
+  overall_status?: string | null
+  operator_action_required?: boolean | null
+  operator_action_reasons?: string[]
+  full_health_snapshot?: DashboardFullHealthSnapshot | null
   schedule_runner?: DashboardScheduleRunnerStatus | null
   keeper_event_queue?: DashboardKeeperEventQueueHealth | null
 }
@@ -802,10 +820,49 @@ export function normalizeFullHealthResponse(
 ): DashboardFullHealthResponse {
   const scheduleRunner = normalizeScheduleRunnerStatus(raw.schedule_runner)
   const keeperEventQueue = normalizeKeeperEventQueueHealth(raw.keeper_event_queue)
+  const fullHealthSnapshot = normalizeFullHealthSnapshot(raw.full_health_snapshot)
   return {
     ...raw,
+    overall_status: typeof raw.overall_status === 'string' ? raw.overall_status : null,
+    operator_action_required:
+      typeof raw.operator_action_required === 'boolean' ? raw.operator_action_required : null,
+    operator_action_reasons: Array.isArray(raw.operator_action_reasons)
+      ? raw.operator_action_reasons.filter((value): value is string => typeof value === 'string')
+      : [],
+    full_health_snapshot: fullHealthSnapshot,
     ...(scheduleRunner ? { schedule_runner: scheduleRunner } : {}),
     ...(keeperEventQueue ? { keeper_event_queue: keeperEventQueue } : {}),
+  }
+}
+
+const FULL_HEALTH_SNAPSHOT_STATUSES: ReadonlySet<DashboardFullHealthSnapshotStatus> = new Set([
+  'ready',
+  'warming',
+  'stale',
+  'timeout',
+  'error',
+])
+
+function normalizeFullHealthSnapshot(raw: unknown): DashboardFullHealthSnapshot | null {
+  const record = asRecord(raw)
+  if (!record) return null
+  const status = typeof record.status === 'string' ? record.status : null
+  if (!status || !FULL_HEALTH_SNAPSHOT_STATUSES.has(status as DashboardFullHealthSnapshotStatus)) {
+    return null
+  }
+  const staleReason = record.stale_reason
+  if (
+    !(staleReason === null || typeof staleReason === 'string')
+    || typeof record.last_good_available !== 'boolean'
+    || typeof record.component_timed_out !== 'boolean'
+  ) {
+    return null
+  }
+  return {
+    status: status as DashboardFullHealthSnapshotStatus,
+    stale_reason: staleReason,
+    last_good_available: record.last_good_available,
+    component_timed_out: record.component_timed_out,
   }
 }
 

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1226,6 +1226,15 @@ describe('fetchDashboardFullHealth', () => {
   it('uses the full health path', async () => {
     const rawResponse = {
       health_detail: 'full',
+      full_health_snapshot: {
+        status: 'ready',
+        stale_reason: null,
+        last_good_available: true,
+        component_timed_out: false,
+      },
+      overall_status: 'degraded',
+      operator_action_required: true,
+      operator_action_reasons: ['keeper_fleet_safety', 'keeper_event_queue'],
       schedule_runner: {
         schema: 'masc.schedule.runner_status.v1',
         status: 'ok',
@@ -1281,6 +1290,17 @@ describe('fetchDashboardFullHealth', () => {
 
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/health?full=1')
     expect(result.health_detail).toBe('full')
+    expect(result).toMatchObject({
+      full_health_snapshot: {
+        status: 'ready',
+        stale_reason: null,
+        last_good_available: true,
+        component_timed_out: false,
+      },
+      overall_status: 'degraded',
+      operator_action_required: true,
+      operator_action_reasons: ['keeper_fleet_safety', 'keeper_event_queue'],
+    })
     expect(result.schedule_runner).toMatchObject({
       schema: 'masc.schedule.runner_status.v1',
       status: 'ok',

--- a/dashboard/src/components/dashboard-full-health-state.test.ts
+++ b/dashboard/src/components/dashboard-full-health-state.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { DashboardFullHealthResponse } from '../api/dashboard'
+import {
+  dashboardFullHealth,
+  dashboardFullHealthResource,
+} from './dashboard-full-health-state'
+
+const health = {
+  overall_status: 'degraded',
+  operator_action_required: true,
+  operator_action_reasons: ['keeper_event_queue'],
+} as DashboardFullHealthResponse
+
+describe('dashboardFullHealth', () => {
+  afterEach(() => dashboardFullHealthResource.reset())
+
+  it('retains the last backend verdict while its replacement is loading', () => {
+    dashboardFullHealthResource.state.value = {
+      data: health,
+      loading: true,
+      error: null,
+    }
+
+    expect(dashboardFullHealth.value).toBe(health)
+  })
+
+  it('retains the last backend verdict after a transient refresh failure', () => {
+    dashboardFullHealthResource.state.value = {
+      data: health,
+      loading: false,
+      error: 'network down',
+    }
+
+    expect(dashboardFullHealth.value).toBe(health)
+  })
+
+  it('keeps never-observed health unavailable', () => {
+    dashboardFullHealthResource.state.value = {
+      data: null,
+      loading: true,
+      error: null,
+    }
+
+    expect(dashboardFullHealth.value).toBeNull()
+  })
+})

--- a/dashboard/src/components/dashboard-full-health-state.ts
+++ b/dashboard/src/components/dashboard-full-health-state.ts
@@ -7,7 +7,7 @@ export const dashboardFullHealthResource = createManagedAsyncResource<DashboardF
 
 export const dashboardFullHealth = computed(() => {
   const state = dashboardFullHealthResource.state.value
-  return state.loading || state.error !== null ? null : state.data
+  return state.data
 })
 
 export function loadDashboardFullHealth(): Promise<void> {

--- a/dashboard/src/components/dashboard-full-health-state.ts
+++ b/dashboard/src/components/dashboard-full-health-state.ts
@@ -1,0 +1,41 @@
+import { computed } from '@preact/signals'
+import { fetchDashboardFullHealth, type DashboardFullHealthResponse } from '../api/dashboard'
+import { createManagedAsyncResource } from '../lib/async-state'
+import { setupVisibleAutoRefresh } from '../lib/auto-refresh'
+
+export const dashboardFullHealthResource = createManagedAsyncResource<DashboardFullHealthResponse>()
+
+export const dashboardFullHealth = computed(() => {
+  const state = dashboardFullHealthResource.state.value
+  return state.loading || state.error !== null ? null : state.data
+})
+
+export function loadDashboardFullHealth(): Promise<void> {
+  return dashboardFullHealthResource
+    .load(signal => fetchDashboardFullHealth({ signal }))
+    .then(() => undefined)
+}
+
+export const DASHBOARD_FULL_HEALTH_REFRESH_MS = 60_000
+
+let subscriberCount = 0
+let stopRefresh: (() => void) | null = null
+
+/** Share one visibility-aware /health poller between global chrome and Overview. */
+export function subscribeDashboardFullHealthRefresh(): () => void {
+  subscriberCount += 1
+  if (subscriberCount === 1) {
+    void loadDashboardFullHealth()
+    stopRefresh = setupVisibleAutoRefresh(() => {
+      void loadDashboardFullHealth()
+    }, DASHBOARD_FULL_HEALTH_REFRESH_MS)
+  }
+  return () => {
+    subscriberCount -= 1
+    if (subscriberCount === 0) {
+      stopRefresh?.()
+      stopRefresh = null
+      dashboardFullHealthResource.cancel()
+    }
+  }
+}

--- a/dashboard/src/lib/dashboard-composite-health.test.ts
+++ b/dashboard/src/lib/dashboard-composite-health.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+
+import { projectDashboardCompositeHealth } from './dashboard-composite-health'
+
+describe('projectDashboardCompositeHealth', () => {
+  it('preserves missing backend health as unavailable', () => {
+    expect(projectDashboardCompositeHealth(null)).toEqual({
+      state: 'unavailable',
+      issueCount: 0,
+      issues: [],
+    })
+  })
+
+  it('reports healthy only from an explicit fresh backend verdict', () => {
+    expect(projectDashboardCompositeHealth({
+      overall_status: 'ok',
+      operator_action_required: false,
+      full_health_snapshot: {
+        status: 'ready',
+        stale_reason: null,
+        last_good_available: true,
+        component_timed_out: false,
+      },
+    })).toEqual({ state: 'healthy', issueCount: 0, issues: [] })
+  })
+
+  it('never suppresses an explicit backend action requirement', () => {
+    const result = projectDashboardCompositeHealth({
+      overall_status: 'degraded',
+      operator_action_required: true,
+      operator_action_reasons: ['keeper_event_queue'],
+      full_health_snapshot: {
+        status: 'stale',
+        stale_reason: 'refresh_failed',
+        last_good_available: true,
+        component_timed_out: false,
+      },
+    })
+
+    expect(result).toMatchObject({
+      state: 'attention',
+      severity: 'warn',
+      issueCount: 1,
+    })
+    expect(result.issues[0]?.detail).toContain('keeper_event_queue')
+  })
+
+  it('never projects a timed-out component as healthy', () => {
+    expect(projectDashboardCompositeHealth({
+      overall_status: 'ok',
+      operator_action_required: false,
+      full_health_snapshot: {
+        status: 'ready',
+        stale_reason: null,
+        last_good_available: true,
+        component_timed_out: true,
+      },
+    })).toMatchObject({
+      state: 'status',
+      severity: 'bad',
+      issueCount: 0,
+    })
+  })
+})

--- a/dashboard/src/lib/dashboard-composite-health.test.ts
+++ b/dashboard/src/lib/dashboard-composite-health.test.ts
@@ -37,12 +37,46 @@ describe('projectDashboardCompositeHealth', () => {
       },
     })
 
+    // This fixture is the live 2026-08-14 payload: `Health_status.rank` puts
+    // `degraded` below the operator-action threshold while the backend still
+    // sets `operator_action_required`. The two axes are independent, so the
+    // explicit requirement — not the rank — decides the tone.
     expect(result).toMatchObject({
       state: 'attention',
-      severity: 'warn',
+      severity: 'bad',
       issueCount: 1,
     })
     expect(result.issues[0]?.detail).toContain('keeper_event_queue')
+  })
+
+  it('treats a status outside the backend vocabulary as loud, not as a warning', () => {
+    const result = projectDashboardCompositeHealth({
+      overall_status: 'brand_new_backend_state',
+      operator_action_required: false,
+      full_health_snapshot: {
+        status: 'ready',
+        stale_reason: null,
+        last_good_available: true,
+        component_timed_out: false,
+      },
+    })
+
+    expect(result).toMatchObject({ severity: 'bad' })
+  })
+
+  it('keeps a ranked-but-not-actionable status quiet', () => {
+    const result = projectDashboardCompositeHealth({
+      overall_status: 'degraded',
+      operator_action_required: false,
+      full_health_snapshot: {
+        status: 'ready',
+        stale_reason: null,
+        last_good_available: true,
+        component_timed_out: false,
+      },
+    })
+
+    expect(result).toMatchObject({ severity: 'warn' })
   })
 
   it('never projects a timed-out component as healthy', () => {

--- a/dashboard/src/lib/dashboard-composite-health.test.ts
+++ b/dashboard/src/lib/dashboard-composite-health.test.ts
@@ -61,4 +61,17 @@ describe('projectDashboardCompositeHealth', () => {
       issueCount: 0,
     })
   })
+
+  it('preserves a decoded top-level status when the detailed snapshot is absent', () => {
+    expect(projectDashboardCompositeHealth({
+      overall_status: 'degraded',
+      operator_action_required: false,
+      full_health_snapshot: null,
+    })).toMatchObject({
+      state: 'status',
+      severity: 'warn',
+      issueCount: 0,
+      issues: [{ label: 'Runtime health degraded' }],
+    })
+  })
 })

--- a/dashboard/src/lib/dashboard-composite-health.ts
+++ b/dashboard/src/lib/dashboard-composite-health.ts
@@ -39,6 +39,75 @@ export type DashboardCompositeHealthVerdict =
  * item only when the backend explicitly requests action; non-ok or non-fresh
  * status remains visible without being recounted as operator work.
  */
+/**
+ * The closed set `overall_status` can carry, mirroring OCaml
+ * `Health_status.to_string` (`lib/types/health_status.mli`). Kept as a parsed
+ * view rather than the wire field's type: the field stays `string` because
+ * that is what the transport delivers, and an unrecognized value is a fact the
+ * dashboard must react to rather than a shape it can assume away.
+ */
+type FleetStatus =
+  | 'ok'
+  | 'warming'
+  | 'snapshot_not_ready'
+  | 'degraded'
+  | 'stale'
+  | 'warning'
+  | 'unavailable'
+  | 'unknown'
+  | 'blocked'
+  | 'error'
+  | 'timeout'
+
+/**
+ * Mirrors `Health_status.rank status >= 3`. The switch is exhaustive on
+ * purpose: a status added to the OCaml variant without a decision here becomes
+ * a compile error instead of silently ranking as a warning.
+ */
+function rankThreeStatus(status: FleetStatus): boolean {
+  switch (status) {
+    case 'blocked':
+    case 'error':
+    case 'timeout':
+      return true
+    case 'ok':
+    case 'warming':
+    case 'snapshot_not_ready':
+    case 'degraded':
+    case 'stale':
+    case 'warning':
+    case 'unavailable':
+    case 'unknown':
+      return false
+  }
+}
+
+const FLEET_STATUSES: readonly FleetStatus[] = [
+  'ok',
+  'warming',
+  'snapshot_not_ready',
+  'degraded',
+  'stale',
+  'warning',
+  'unavailable',
+  'unknown',
+  'blocked',
+  'error',
+  'timeout',
+]
+
+/**
+ * True when the backend's fleet status warrants the loud tone. An unrecognized
+ * status also returns true: the dashboard and the backend disagree about the
+ * vocabulary, and an operator should see that rather than have it rendered as
+ * a warning indistinguishable from a healthy-but-busy fleet.
+ */
+function fleetStatusIsBad(status: string | null): boolean {
+  if (status === null) return false
+  const known = FLEET_STATUSES.find(candidate => candidate === status)
+  return known === undefined ? true : rankThreeStatus(known)
+}
+
 export function projectDashboardCompositeHealth(
   health: DashboardCompositeHealthSource | null | undefined,
 ): DashboardCompositeHealthVerdict {
@@ -53,11 +122,19 @@ export function projectDashboardCompositeHealth(
   }
 
   const effectiveStatus = status ?? snapshotStatus ?? 'unavailable'
-  const severity = effectiveStatus === 'blocked' || effectiveStatus === 'error'
-    || effectiveStatus === 'timeout' || snapshotStatus === 'error'
-    || snapshotStatus === 'timeout' || snapshot?.component_timed_out === true
-    ? 'bad'
-    : 'warn'
+  // Two independent backend axes, judged separately. `overall_status` carries
+  // `Health_status.rank`; `operator_action_required` is computed from component
+  // flags and can be true while the rank sits below 3 (live 2026-08-14:
+  // overall_status=degraded with operator_action_required=true). Folding them
+  // into one string comparison dropped the second axis.
+  const severity: 'warn' | 'bad' =
+    requiresAction === true
+    || fleetStatusIsBad(status)
+    || snapshotStatus === 'error'
+    || snapshotStatus === 'timeout'
+    || snapshot?.component_timed_out === true
+      ? 'bad'
+      : 'warn'
   const reasons = health?.operator_action_reasons?.filter(reason => reason.trim() !== '') ?? []
   const snapshotDetails = snapshotUnhealthy
     ? [

--- a/dashboard/src/lib/dashboard-composite-health.ts
+++ b/dashboard/src/lib/dashboard-composite-health.ts
@@ -48,7 +48,7 @@ export function projectDashboardCompositeHealth(
   const requiresAction = health?.operator_action_required
   const snapshotUnhealthy = snapshotStatus !== null
     && (snapshotStatus !== 'ready' || snapshot?.component_timed_out === true)
-  if (requiresAction !== true && snapshotStatus === null) {
+  if (requiresAction !== true && snapshotStatus === null && status === null) {
     return { state: 'unavailable', issueCount: 0, issues: [] }
   }
 

--- a/dashboard/src/lib/dashboard-composite-health.ts
+++ b/dashboard/src/lib/dashboard-composite-health.ts
@@ -1,0 +1,107 @@
+export interface DashboardCompositeHealthSource {
+  overall_status?: string | null
+  operator_action_required?: boolean | null
+  operator_action_reasons?: readonly string[]
+  full_health_snapshot?: {
+    status?: 'ready' | 'warming' | 'stale' | 'timeout' | 'error' | null
+    stale_reason?: string | null
+    last_good_available?: boolean | null
+    component_timed_out?: boolean | null
+  } | null
+}
+
+export interface DashboardCompositeHealthIssue {
+  kind: 'runtime-health'
+  severity: 'warn' | 'bad'
+  label: string
+  detail: string
+}
+
+export type DashboardCompositeHealthVerdict =
+  | { state: 'unavailable'; issueCount: 0; issues: readonly [] }
+  | { state: 'healthy'; issueCount: 0; issues: readonly [] }
+  | {
+    state: 'status'
+    severity: 'warn' | 'bad'
+    issueCount: 0
+    issues: readonly [DashboardCompositeHealthIssue]
+  }
+  | {
+    state: 'attention'
+    severity: 'warn' | 'bad'
+    issueCount: 1
+    issues: readonly [DashboardCompositeHealthIssue]
+  }
+
+/**
+ * Projects the backend-owned /health composite verdict without reimplementing
+ * its subsystem policy. A composite verdict contributes one operator-attention
+ * item only when the backend explicitly requests action; non-ok or non-fresh
+ * status remains visible without being recounted as operator work.
+ */
+export function projectDashboardCompositeHealth(
+  health: DashboardCompositeHealthSource | null | undefined,
+): DashboardCompositeHealthVerdict {
+  const snapshot = health?.full_health_snapshot
+  const snapshotStatus = snapshot?.status ?? null
+  const status = health?.overall_status?.trim() || null
+  const requiresAction = health?.operator_action_required
+  const snapshotUnhealthy = snapshotStatus !== null
+    && (snapshotStatus !== 'ready' || snapshot?.component_timed_out === true)
+  if (requiresAction !== true && snapshotStatus === null) {
+    return { state: 'unavailable', issueCount: 0, issues: [] }
+  }
+
+  const effectiveStatus = status ?? snapshotStatus ?? 'unavailable'
+  const severity = effectiveStatus === 'blocked' || effectiveStatus === 'error'
+    || effectiveStatus === 'timeout' || snapshotStatus === 'error'
+    || snapshotStatus === 'timeout' || snapshot?.component_timed_out === true
+    ? 'bad'
+    : 'warn'
+  const reasons = health?.operator_action_reasons?.filter(reason => reason.trim() !== '') ?? []
+  const snapshotDetails = snapshotUnhealthy
+    ? [
+        `snapshot=${snapshotStatus}`,
+        snapshot?.component_timed_out === true ? 'component_timed_out=true' : null,
+        snapshot?.stale_reason ? `reason=${snapshot.stale_reason}` : null,
+        snapshot?.last_good_available === true ? 'last_good_available=true' : null,
+      ].filter((detail): detail is string => detail !== null)
+    : []
+  const issue: DashboardCompositeHealthIssue = {
+    kind: 'runtime-health',
+    severity,
+    label: `Runtime health ${effectiveStatus}`,
+    detail: [
+      status ? `status=${status}` : null,
+      typeof requiresAction === 'boolean'
+        ? `operator_action_required=${requiresAction}`
+        : null,
+      ...reasons,
+      ...snapshotDetails,
+    ].filter((detail): detail is string => detail !== null).join(' · '),
+  }
+
+  if (requiresAction !== true) {
+    if (
+      status === 'ok'
+      && requiresAction === false
+      && snapshotStatus === 'ready'
+      && snapshot?.component_timed_out === false
+    ) {
+      return { state: 'healthy', issueCount: 0, issues: [] }
+    }
+    return {
+      state: 'status',
+      severity,
+      issueCount: 0,
+      issues: [issue],
+    }
+  }
+
+  return {
+    state: 'attention',
+    severity,
+    issueCount: 1,
+    issues: [issue],
+  }
+}


### PR DESCRIPTION
## As-Is

TopBar and Overview could not share the backend-owned `/health?full=1` verdict. The only fetch owner lived inside Overview, so global chrome either ignored composite health or had to infer it from partial shell signals.

## To-Be

- Strictly decode the existing top-level overall/action fields and full-health snapshot metadata.
- Add one subscriber-counted, visibility-aware managed resource for the existing full-health endpoint.
- Project a closed `unavailable | healthy | status | attention` sum without overriding backend operator-action truth.
- Snapshot stale/timeout remains visible, but never suppresses `operator_action_required=true`; `ready + component_timed_out` cannot appear healthy.

## Stack

Parent: #28634 exact head `1771b987f227b9d4e16b552dc610b2370c1655ae`. This foundation does not yet alter TopBar or Overview rendering.

## Fast checks

- Existing API Vitest: 146/146
- Dashboard typecheck
- changed-file ESLint
- git diff --check
- no new test files; no local Dune

CI, deployment, and live browser verification remain pending.

# ci:skip-test-coverage

Coverage tests are deferred by campaign instruction; an existing API test was adapted and no new test file was added.