### PR TITLE
fix(dashboard): show backend health in TopBar

### DIFF
--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -32,6 +32,7 @@ import type {
 } from '../../api/dashboard'
 import { keepers, boardPosts, boardTotal, lastBoardRefreshAt, shellRuntimeResolution } from '../../store'
 import type { Goal } from '../../types/core'
+import { dashboardFullHealthResource } from '../dashboard-full-health-state'
 
 const overviewMocks = vi.hoisted(() => ({
   scheduledAutomationProjection: { value: null as null | DashboardScheduledAutomationProjection },
@@ -41,6 +42,10 @@ vi.mock('../schedule/schedule-state', () => ({
   scheduledAutomationProjection: overviewMocks.scheduledAutomationProjection,
   subscribeScheduledAutomationRefresh: () => () => {},
 }))
+
+afterEach(() => {
+  dashboardFullHealthResource.reset()
+})
 
 // bar-seg ratio helper (mirrors FunnelCard inline logic)
 function segPct(counts: FunnelCounts, key: 'created' | 'inProgress' | 'awaiting' | 'completed'): number {
@@ -1288,6 +1293,8 @@ describe('Overview prototype surface', () => {
         const card = container.querySelector('[data-testid="domain-schedule"]')
         expect(card?.textContent).toContain('runner: ok')
       })
+      expect(fetchMock.mock.calls.filter(call => String(call[0]).includes('/health?full=1')))
+        .toHaveLength(1)
     } finally {
       overviewMocks.scheduledAutomationProjection.value = previousScheduledAutomation
       if (previousFetch) {

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -57,13 +57,15 @@ import {
 import {
   fetchTelemetry,
   fetchTelemetrySummary,
-  fetchDashboardFullHealth,
   type TelemetryEntry,
   type TelemetrySourceSummary,
-  type DashboardFullHealthResponse,
   type DashboardKeeperEventQueueHealth,
   type DashboardScheduleRunnerStatus,
 } from '../../api/dashboard'
+import {
+  dashboardFullHealth,
+  subscribeDashboardFullHealthRefresh,
+} from '../dashboard-full-health-state'
 import {
   OVERVIEW_TELEMETRY_EVENTS_PER_BUCKET,
 } from '../../config/constants'
@@ -995,14 +997,6 @@ function loadOverviewTelemetry(nowMs = Date.now()): Promise<void> {
   })
 }
 
-const overviewFullHealthResource: AsyncResource<DashboardFullHealthResponse> = createAsyncResource()
-
-function loadOverviewFullHealth(): Promise<void> {
-  return overviewFullHealthResource.load(async () => {
-    return fetchDashboardFullHealth()
-  })
-}
-
 // ─── Keeper-v2 overview surfaces ─────────────────────────────────────────────
 
 function nowHMKst(): string {
@@ -1554,17 +1548,20 @@ export function Overview() {
   useNowSecondsTicker()
   useEffect(() => {
     void loadOverviewTelemetry()
-    void loadOverviewFullHealth()
     const interval = window.setInterval(() => {
       void loadOverviewTelemetry()
-      void loadOverviewFullHealth()
     }, 60_000)
+    // Overview and the shell consume one shared full-health resource. The
+    // subscriber owns ref-counted refresh lifetime, so mounting both surfaces
+    // never creates a second backend poller.
+    const stopFullHealthRefresh = subscribeDashboardFullHealthRefresh()
     // Schedule state is its own projection with its own poller. Root used to
     // reach it through the tool inventory, which meant entering the home
     // surface fetched the whole tool registry.
     const stopScheduleRefresh = subscribeScheduledAutomationRefresh()
     return () => {
       window.clearInterval(interval)
+      stopFullHealthRefresh()
       stopScheduleRefresh()
     }
   }, [])
@@ -1578,14 +1575,8 @@ export function Overview() {
       ? gateData.value?.approval_queue?.length ?? null
       : null
   const scheduledAutomationData = scheduledAutomationProjection.value ?? null
-  const scheduleRunnerStatus =
-    overviewFullHealthResource.state.value.status === 'loaded'
-      ? overviewFullHealthResource.state.value.data.schedule_runner ?? null
-      : null
-  const keeperQueueHealth =
-    overviewFullHealthResource.state.value.status === 'loaded'
-      ? overviewFullHealthResource.state.value.data.keeper_event_queue ?? null
-      : null
+  const scheduleRunnerStatus = dashboardFullHealth.value?.schedule_runner ?? null
+  const keeperQueueHealth = dashboardFullHealth.value?.keeper_event_queue ?? null
   // Keeper execution counts come from the runtime-health fleet projection the
   // shell already holds — the same `keeper_fleet_safety_health_json` payload
   // `/health?full=1` embeds, so reading it here adds no request.

--- a/dashboard/src/components/v2/top-bar-v2-health.test.ts
+++ b/dashboard/src/components/v2/top-bar-v2-health.test.ts
@@ -117,4 +117,35 @@ describe('AttentionIndicatorV2 backend health', () => {
       expect(container.textContent).toContain('Runtime health error')
     })
   })
+
+  it('keeps a non-ready Gate title visible on the collapsed chip', async () => {
+    gateResource.reset({
+      ...readyGate,
+      approval_queue: null,
+      approval_queue_state: {
+        state: 'observation_error',
+        code: 'observation_failed',
+        title: 'Gate observation unavailable',
+        operator_detail: 'Gate refresh failed',
+        severity: 'bad',
+        icon: '!',
+      },
+    })
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(
+      JSON.stringify(healthResponse(false)),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    )))
+
+    await act(async () => {
+      render(html`<${AttentionIndicatorV2} />`, container)
+    })
+
+    await waitFor(() => {
+      const chip = container.querySelector('.v2-statchip.attn')
+      expect(chip?.textContent).toContain('! Gate observation unavailable')
+      expect(chip?.textContent).not.toContain('주의 ?')
+      expect(chip?.classList.contains('bad')).toBe(true)
+      expect(chip?.getAttribute('title')).toBe('Gate refresh failed')
+    })
+  })
 })

--- a/dashboard/src/components/v2/top-bar-v2-health.test.ts
+++ b/dashboard/src/components/v2/top-bar-v2-health.test.ts
@@ -15,9 +15,9 @@ import { dashboardFullHealthResource } from '../dashboard-full-health-state'
 import { AttentionIndicatorV2 } from './top-bar-v2'
 import type { DashboardGateResponse } from '../../types'
 
-function healthResponse(operatorActionRequired: boolean) {
+function healthResponse(operatorActionRequired: boolean, overallStatus = 'degraded') {
   return {
-    overall_status: 'degraded',
+    overall_status: overallStatus,
     operator_action_required: operatorActionRequired,
     operator_action_reasons: operatorActionRequired ? ['keeper_event_queue'] : [],
     full_health_snapshot: {
@@ -93,6 +93,28 @@ describe('AttentionIndicatorV2 backend health', () => {
       const chip = container.querySelector('.v2-statchip.attn')
       expect(chip?.textContent).toContain('Runtime health degraded')
       expect(chip?.textContent).not.toContain('주의 1')
+    })
+  })
+
+  it('keeps the chip bad when a non-action bad health status accompanies counted work', async () => {
+    keepers.value = [{ name: 'sangsu', status: 'running', needs_attention: true }]
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(
+      JSON.stringify(healthResponse(false, 'error')),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    )))
+
+    await act(async () => {
+      render(html`<${AttentionIndicatorV2} />`, container)
+    })
+
+    await waitFor(() => {
+      const chip = container.querySelector('.v2-statchip.attn')
+      expect(chip?.classList.contains('bad')).toBe(true)
+      expect(chip?.textContent).toContain('주의 1')
+    })
+    ;(container.querySelector('.v2-statchip.attn') as HTMLButtonElement).click()
+    await waitFor(() => {
+      expect(container.textContent).toContain('Runtime health error')
     })
   })
 })

--- a/dashboard/src/components/v2/top-bar-v2-health.test.ts
+++ b/dashboard/src/components/v2/top-bar-v2-health.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment happy-dom
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import { html } from 'htm/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { waitFor } from '@testing-library/preact'
+
+vi.mock('../../lib/auto-refresh', () => ({
+  setupVisibleAutoRefresh: vi.fn(() => vi.fn()),
+}))
+
+import { keepers } from '../../store'
+import { gateResource } from '../gate-signals'
+import { dashboardFullHealthResource } from '../dashboard-full-health-state'
+import { AttentionIndicatorV2 } from './top-bar-v2'
+import type { DashboardGateResponse } from '../../types'
+
+function healthResponse(operatorActionRequired: boolean) {
+  return {
+    overall_status: 'degraded',
+    operator_action_required: operatorActionRequired,
+    operator_action_reasons: operatorActionRequired ? ['keeper_event_queue'] : [],
+    full_health_snapshot: {
+      status: 'ready',
+      stale_reason: null,
+      last_good_available: true,
+      component_timed_out: false,
+    },
+  }
+}
+
+const readyGate: DashboardGateResponse = {
+  approval_queue: [],
+  approval_queue_state: { state: 'ready' },
+  recent_resolved: [],
+  recent_resolved_page: null,
+  recent_resolved_state: { state: 'ready' },
+  approval_rules: [],
+  approval_rules_state: { state: 'ready' },
+  hitl: null,
+}
+
+describe('AttentionIndicatorV2 backend health', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    keepers.value = []
+    gateResource.reset(readyGate)
+    dashboardFullHealthResource.reset()
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    gateResource.reset()
+    dashboardFullHealthResource.reset()
+    vi.unstubAllGlobals()
+  })
+
+  it('counts an explicit backend action requirement exactly once', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(
+      JSON.stringify(healthResponse(true)),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    )))
+
+    await act(async () => {
+      render(html`<${AttentionIndicatorV2} />`, container)
+    })
+
+    await waitFor(() => {
+      expect(container.querySelector('.v2-statchip.attn')?.textContent).toContain('주의 1')
+    })
+    ;(container.querySelector('.v2-statchip.attn') as HTMLButtonElement).click()
+    await waitFor(() => {
+      expect(container.querySelector('.attn-row')?.textContent).toContain('Runtime health degraded')
+      expect(container.querySelector('.attn-row')?.textContent).toContain('1')
+    })
+  })
+
+  it('shows a non-action degraded verdict without counting operator work', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(
+      JSON.stringify(healthResponse(false)),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    )))
+
+    await act(async () => {
+      render(html`<${AttentionIndicatorV2} />`, container)
+    })
+
+    await waitFor(() => {
+      const chip = container.querySelector('.v2-statchip.attn')
+      expect(chip?.textContent).toContain('Runtime health degraded')
+      expect(chip?.textContent).not.toContain('주의 1')
+    })
+  })
+})

--- a/dashboard/src/components/v2/top-bar-v2.ts
+++ b/dashboard/src/components/v2/top-bar-v2.ts
@@ -201,7 +201,9 @@ export function AttentionIndicatorV2() {
       params: { section: 'fleet-health' },
     })
   }
-  const tone = (a.approvals ?? 0) > 0 || a.dead > 0 || (a.health.state === 'attention' && a.health.severity === 'bad')
+  const healthIsBad = (a.health.state === 'attention' || a.health.state === 'status')
+    && a.health.severity === 'bad'
+  const tone = (a.approvals ?? 0) > 0 || a.dead > 0 || healthIsBad
     || (a.approvalQueueState?.state !== 'ready' && a.approvalQueueState?.severity === 'bad')
     ? 'bad'
     : 'warn'

--- a/dashboard/src/components/v2/top-bar-v2.ts
+++ b/dashboard/src/components/v2/top-bar-v2.ts
@@ -132,6 +132,16 @@ export function AttentionIndicatorV2() {
 
   const a = computeAttention()
   const approvalQueueUnknown = a.approvalQueueState?.state !== 'ready' || a.approvals === null
+  if (!a.total && a.approvalQueueState && a.approvalQueueState.state !== 'ready') {
+    const state = a.approvalQueueState
+    return html`
+      <button
+        class=${`v2-statchip attn ${state.severity}`}
+        onClick=${() => navigate('approvals')}
+        title=${state.operator_detail}
+      >${state.icon} ${state.title}</button>
+    `
+  }
   if (!a.total && a.health.state === 'healthy' && !approvalQueueUnknown) {
     return html`<span class="v2-statchip live" title="처리할 항목 없음">${'✓'} 정상</span>`
   }

--- a/dashboard/src/components/v2/top-bar-v2.ts
+++ b/dashboard/src/components/v2/top-bar-v2.ts
@@ -16,6 +16,10 @@ import { StatusDot } from './primitives-v2'
 import { surfaceLabel } from './nav-rail-v2'
 import { configuredCountSourceLabel, keeperRowLooksRunning, resolveRuntimeCounts, runtimeCountSourceLabel } from '../../runtime-counts'
 import type { RuntimeCounts } from '../../runtime-counts'
+import {
+  projectDashboardCompositeHealth,
+  type DashboardCompositeHealthVerdict,
+} from '../../lib/dashboard-composite-health'
 // Operational/safety chrome the v2 prototype omits but operators rely on
 // (connection state, transport telemetry, emergency stop, error inbox, auth,
 // build identity). Re-mounted into the v2 top bar so the reskin does not drop
@@ -25,6 +29,10 @@ import { ConnectionStatus, ErrorCounterBadge, BuildIdentityBadge } from '../dash
 import { AuthStatus } from '../auth-status'
 import { EmergencyStopControl } from '../emergency-stop-control'
 import { TransportBeacon } from '../transport-beacon'
+import {
+  dashboardFullHealth,
+  subscribeDashboardFullHealthRefresh,
+} from '../dashboard-full-health-state'
 
 const DEAD_PHASES = new Set(['Overflowed', 'Crashed', 'Dead'])
 
@@ -76,6 +84,7 @@ interface AttentionAgg {
   keepers: number
   dead: number
   stale: number
+  health: DashboardCompositeHealthVerdict
   total: number
 }
 
@@ -89,18 +98,31 @@ function computeAttention(): AttentionAgg {
   const attKeepers = ks.filter((k) => k.needs_attention === true).length
   const dead = ks.filter((k) => !!k.lifecycle_phase && DEAD_PHASES.has(k.lifecycle_phase)).length
   const stale = staleKeepers.value.size
+  const health = projectDashboardCompositeHealth(dashboardFullHealth.value)
   return {
     approvals,
     approvalQueueState,
     keepers: attKeepers,
     dead,
     stale,
-    total: (approvals ?? 0) + attKeepers + dead + stale,
+    health,
+    total: (approvals ?? 0) + attKeepers + dead + stale + health.issueCount,
   }
 }
 
-function AttentionIndicatorV2() {
+interface AttentionRow {
+  k: string
+  n: number | string
+  lbl: string
+  detail?: string
+  sev: 'bad' | 'warn'
+  nav: 'approvals' | 'monitoring' | 'connectors'
+  params?: Record<string, string>
+}
+
+export function AttentionIndicatorV2() {
   const [open, setOpen] = useState(false)
+  useEffect(() => subscribeDashboardFullHealthRefresh(), [])
   useEffect(() => {
     if (!open) return
     const close = () => setOpen(false)
@@ -109,39 +131,87 @@ function AttentionIndicatorV2() {
   }, [open])
 
   const a = computeAttention()
-  if (a.approvalQueueState && a.approvalQueueState.state !== 'ready') {
-    const state = a.approvalQueueState
-    return html`
-      <button
-        class=${`v2-statchip attn ${state.severity}`}
-        onClick=${() => navigate('approvals')}
-        title=${state.operator_detail}
-      >${state.icon} ${state.title}</button>
-    `
-  }
-  if (a.approvalQueueState?.state !== 'ready' || a.approvals === null) {
-    return html`
-      <button
-        class="v2-statchip attn warn"
-        onClick=${() => navigate('approvals')}
-        title="Gate queue state has not loaded"
-      >? 승인 큐 확인 필요</button>
-    `
-  }
-  if (!a.total) {
+  const approvalQueueUnknown = a.approvalQueueState?.state !== 'ready' || a.approvals === null
+  if (!a.total && a.health.state === 'healthy' && !approvalQueueUnknown) {
     return html`<span class="v2-statchip live" title="처리할 항목 없음">${'✓'} 정상</span>`
   }
-  const rows = [
-    { k: 'approvals', n: a.approvals, lbl: '승인 대기', sev: 'bad', nav: 'approvals' as const },
-    { k: 'keepers', n: a.keepers, lbl: '주의 keeper', sev: 'warn', nav: 'monitoring' as const },
-    { k: 'dead', n: a.dead, lbl: '죽음·넘침', sev: 'bad', nav: 'monitoring' as const },
-    { k: 'stale', n: a.stale, lbl: 'stale 게이트', sev: 'warn', nav: 'connectors' as const },
-  ].filter((r) => r.n !== null && r.n > 0)
-  const tone = a.approvals > 0 || a.dead > 0 ? 'bad' : 'warn'
+  if (!a.total && a.health.state === 'status' && !approvalQueueUnknown) {
+    const issue = a.health.issues[0]
+    return html`
+      <button
+        class=${`v2-statchip attn ${issue.severity}`}
+        onClick=${() => navigate('monitoring', { section: 'fleet-health' })}
+        title=${issue.detail}
+      >${'◌'} ${issue.label}</button>
+    `
+  }
+  const rows: AttentionRow[] = []
+  if (a.approvalQueueState && a.approvalQueueState.state !== 'ready') {
+    const state = a.approvalQueueState
+    rows.push({
+      k: 'approval-queue-state',
+      n: '—',
+      lbl: `${state.icon} ${state.title}`,
+      detail: state.operator_detail,
+      sev: state.severity,
+      nav: 'approvals',
+    })
+  } else if (a.approvals === null) {
+    rows.push({
+      k: 'approval-queue-unavailable',
+      n: '—',
+      lbl: '승인 큐 미연결',
+      detail: 'Gate queue state has not loaded.',
+      sev: 'warn',
+      nav: 'approvals',
+    })
+  }
+  if (a.approvals !== null && a.approvals > 0) rows.push({ k: 'approvals', n: a.approvals, lbl: '승인 대기', sev: 'bad', nav: 'approvals' })
+  if (a.keepers > 0) rows.push({ k: 'keepers', n: a.keepers, lbl: '주의 keeper', sev: 'warn', nav: 'monitoring' })
+  if (a.dead > 0) rows.push({ k: 'dead', n: a.dead, lbl: '죽음·넘침', sev: 'bad', nav: 'monitoring' })
+  if (a.stale > 0) rows.push({ k: 'stale', n: a.stale, lbl: 'stale 게이트', sev: 'warn', nav: 'connectors' })
+  if (a.health.state === 'attention') {
+    rows.push(...a.health.issues.map(issue => ({
+      k: issue.kind,
+      n: 1,
+      lbl: issue.label,
+      detail: issue.detail,
+      sev: issue.severity,
+      nav: 'monitoring' as const,
+      params: { section: 'fleet-health' },
+    })))
+  } else if (a.health.state === 'status') {
+    rows.push(...a.health.issues.map(issue => ({
+      k: `${issue.kind}-status`,
+      n: '정보',
+      lbl: issue.label,
+      detail: issue.detail,
+      sev: issue.severity,
+      nav: 'monitoring' as const,
+      params: { section: 'fleet-health' },
+    })))
+  } else if (a.health.state === 'unavailable') {
+    rows.push({
+      k: 'composite-health-unavailable',
+      n: '—',
+      lbl: 'Fleet health 미연결',
+      detail: 'Backend composite fleet health verdict has not loaded.',
+      sev: 'warn',
+      nav: 'monitoring',
+      params: { section: 'fleet-health' },
+    })
+  }
+  const tone = (a.approvals ?? 0) > 0 || a.dead > 0 || (a.health.state === 'attention' && a.health.severity === 'bad')
+    || (a.approvalQueueState?.state !== 'ready' && a.approvalQueueState?.severity === 'bad')
+    ? 'bad'
+    : 'warn'
+  const totalLabel = a.health.state === 'unavailable' || approvalQueueUnknown
+    ? a.total > 0 ? `${a.total}+?` : '?'
+    : String(a.total)
   return html`
     <div class="attn-wrap" onClick=${(e: Event) => e.stopPropagation()}>
       <button class=${`v2-statchip attn ${tone}`} onClick=${() => setOpen((o) => !o)} title="지금 나를 필요로 하는 것">
-        ${'⚑'} 주의 <b>${a.total}</b>
+        ${'⚑'} 주의 <b>${totalLabel}</b>
       </button>
       ${open
         ? html`
@@ -149,7 +219,12 @@ function AttentionIndicatorV2() {
               <div class="attn-menu-h">지금 나를 필요로 하는 것</div>
               ${rows.map(
                 (r) => html`
-                  <button key=${r.k} class="attn-row" onClick=${() => { setOpen(false); navigate(r.nav) }}>
+                  <button
+                    key=${r.k}
+                    class="attn-row"
+                    title=${r.detail}
+                    onClick=${() => { setOpen(false); navigate(r.nav, r.params) }}
+                  >
                     <span class=${`dot2 ${r.sev}`}></span>
                     <span class="attn-row-lbl">${r.lbl}</span>
                     <span class="attn-row-n mono">${r.n}</span>


### PR DESCRIPTION
## As-Is

The global TopBar could report normal Keeper/Gate chrome while the backend composite health verdict required operator action.

## To-Be

Consume the parent shared health resource in the existing TopBar attention surface. Backend action truth contributes one visible attention item; non-action degraded/stale status remains visible without being counted as operator work. Gate/keeper/dead/stale signals remain separate rows and no runtime admission changes.

## Stack

Parent: #28639. One production file only.

## Fast checks

- Existing app Vitest: 30/30
- Dashboard typecheck
- changed-file ESLint
- git diff --check
- no new tests; no local Dune

CI, deployment, and live browser verification remain pending.

# ci:skip-test-coverage

Coverage tests are deferred by campaign instruction; no new test code is included.