### PR TITLE
fix(keeper): attribute direct turns reactively

### DIFF
--- a/lib/keeper/keeper_unified_metrics.mli
+++ b/lib/keeper/keeper_unified_metrics.mli
@@ -169,6 +169,7 @@ val append_decision_record :
   observation:Keeper_world_observation.world_observation ->
   latency_ms:int ->
   outcome:string ->
+  ?channel:Keeper_world_observation.keeper_cycle_channel ->
   ?degraded_retry_applied:bool ->
   ?degraded_retry_runtime:string ->
   ?fallback_reason:string ->

--- a/lib/keeper/keeper_unified_metrics_decision.ml
+++ b/lib/keeper/keeper_unified_metrics_decision.ml
@@ -19,6 +19,7 @@ let append_decision_record
     ~(observation : Keeper_world_observation.world_observation)
     ~(latency_ms : int)
     ~(outcome : string)
+    ?channel
     ?(degraded_retry_applied = false)
     ?degraded_retry_runtime
     ?fallback_reason
@@ -28,6 +29,11 @@ let append_decision_record
     ?terminal_reason
     () : unit =
   let now_ts = Time_compat.now () in
+  let channel =
+    Option.value
+      ~default:(decision_channel_of_observation observation)
+      channel
+  in
   let claimable_task_count = Keeper_world_observation.claimable_task_count observation in
   let trigger_signals = observed_triggers_of_observation observation in
   let affordances = observed_affordances_of_observation observation in
@@ -143,7 +149,7 @@ let append_decision_record
         ( "channel",
           `String
             (Keeper_world_observation.channel_to_string
-               (decision_channel_of_observation observation)) );
+               channel) );
         ("outcome", `String outcome);
         ("degraded_retry_applied", `Bool degraded_retry_applied);
         ( "degraded_retry_runtime",

--- a/lib/keeper/keeper_unified_metrics_decision.mli
+++ b/lib/keeper/keeper_unified_metrics_decision.mli
@@ -7,6 +7,7 @@ val append_decision_record :
   observation:Keeper_world_observation.world_observation ->
   latency_ms:int ->
   outcome:string ->
+  ?channel:Keeper_world_observation.keeper_cycle_channel ->
   ?degraded_retry_applied:bool ->
   ?degraded_retry_runtime:string ->
   ?fallback_reason:string ->

--- a/lib/keeper/keeper_unified_metrics_result.ml
+++ b/lib/keeper/keeper_unified_metrics_result.ml
@@ -52,7 +52,8 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
     has_substantive_tools || has_validated_evidence
   in
   let is_scheduled_autonomous_cycle =
-    is_scheduled_autonomous_cycle_of_observation observation
+    is_autonomous_turn
+    && is_scheduled_autonomous_cycle_of_observation observation
   in
   let is_board_reactive =
     Keeper_world_observation.has_pending_board_activity observation

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -631,6 +631,7 @@ let handle
       ~outcome:
         (decision_outcome_to_label
            (decision_outcome_of_terminal_outcome terminal_outcome))
+      ~channel
       ~degraded_retry_applied
       ?degraded_retry_runtime
       ?fallback_reason:


### PR DESCRIPTION
## As-Is

A direct durable Keeper operation could complete with an empty world observation. Success metrics inferred scheduled autonomy only from that observation, despite the existing typed execution outcome being `Direct`. The result incremented `proactive_count_total`, changed `last_proactive_ts`, and wrote decision channel `scheduled_autonomous` for a direct turn.

Live evidence: dedicated canary clear operation completed at turn_ref `#1`, while Keeper metadata recorded `proactive_count_total=1`, set `last_proactive_ts`, and the latest decision channel was `scheduled_autonomous`.

## To-Be

- Scheduled proactive accounting requires both the existing `is_autonomous_turn` evidence and a scheduled-autonomous observation.
- Successful decision records receive the existing typed channel from `Keeper_execution_outcome.metrics_channel`.
- Direct turns therefore project as `reactive`; autonomous scheduled and board or mention semantics remain unchanged.
- Failure decision callers omit the new optional channel and preserve their existing observation-derived default.

No runtime-name policy, gate, framework, or retry behavior is added.

## Fast validation

- `ocamlformat --check` on all five changed production files
- `ocamlc -stop-after parsing` on all five changed production files
- `git diff --check`
- conflict-marker scan
- `scripts/ocaml-structure-ratchet.sh`
- source-only adversarial review of direct, autonomous, board, mention, failure-default, and optional-argument semantics: no P1/P2

No new tests and no Dune build, per the feature-first campaign. Full CI, deployment, and live rerun remain pending.

# ci:skip-test-coverage