### PR TITLE
fix(dashboard): operation delivery key의 operation_id를 읽어 라이브/history 이중 렌더 제거

### DIFF
--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -355,6 +355,7 @@ describe('sendKeeperThreadMessage operation stream', () => {
     keeperThreads.value = {}
     keeperActionErrors.value = {}
     keeperStreamLastEventAt.value = {}
+    _resetChatHydrationForTests()
     _clearTrackedKeeperChatOperationsForTests()
     _resetKeeperThreadMessageSendGuardsForTests()
     _resetLiveSendRequestOwnersForTests()

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -427,13 +427,13 @@ describe('sendKeeperThreadMessage operation stream', () => {
         role: 'user',
         content: 'hi',
         ts: 1_780_000_000,
-        delivery_key: { kind: 'operation', request_id: submittedRequestId },
+        delivery_key: { kind: 'operation', operation_id: submittedRequestId },
       },
       {
         role: 'assistant',
         content: 'hello there',
         ts: 1_780_000_001,
-        delivery_key: { kind: 'operation', request_id: submittedRequestId },
+        delivery_key: { kind: 'operation', operation_id: submittedRequestId },
       },
     ])
     await hydrateKeeperChatHistory('echo')

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -356,10 +356,10 @@ describe('thread history merge & persistence', () => {
     }))
 
     const history = chatHistoryEntriesFromRest('echo', [
-      { role: 'user', content: '질문', ts: 1_780_000_001, delivery_key: { kind: 'operation', request_id: R } },
+      { role: 'user', content: '질문', ts: 1_780_000_001, delivery_key: { kind: 'operation', operation_id: R } },
       { role: 'tool', content: '{"path":"a"}', ts: 1_780_000_002, tool_call_id: 'call-1', tool_call_name: 'read_file' },
       { role: 'tool', content: '{"path":"b"}', ts: 1_780_000_003, tool_call_id: 'call-2', tool_call_name: 'write_file' },
-      { role: 'assistant', content: '답변', ts: 1_780_000_004, turn_ref: 'trace-x#1', delivery_key: { kind: 'operation', request_id: R } },
+      { role: 'assistant', content: '답변', ts: 1_780_000_004, turn_ref: 'trace-x#1', delivery_key: { kind: 'operation', operation_id: R } },
     ])
     mergeServerHistoryEntries('echo', history)
 

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -786,7 +786,10 @@ function deliveryIdentityFromKey(raw: unknown): DeliveryIdentity {
   if (!isRecord(raw)) return { requestId: null }
   const kind = asString(raw.kind)
   if (kind === 'operation') {
-    const requestId = asString(raw.request_id)?.trim() ?? ''
+    // keeper_chat_delivery_identity.ml serializes Operation as
+    // {kind:"operation", operation_id:"kmsg-..."} — the same id the live
+    // stream stamps as requestId (keeper-actions.ts request.operationId).
+    const requestId = asString(raw.operation_id)?.trim() ?? ''
     return { requestId: requestId || null }
   }
   return { requestId: null }

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -1948,7 +1948,7 @@ let to_json_array ?base_dir ?trace_block_by_turn_ref
                   (Option.map Ids.Turn_ref.to_string m.turn_ref)
               (* Expose the persisted delivery identity so the dashboard can
                  reconcile a history reload against its optimistic turn rows
-                 on the exact [delivery_key.request_id]. *)
+                 on the exact delivery-key id (e.g. [operation_id]). *)
               @ (match m.delivery_key with
                  | None -> []
                  | Some key ->


### PR DESCRIPTION
## 증상

대시보드발 채팅 턴이 타임라인에 **2번씩** 렌더됨 — 같은 내용·같은 타임스탬프, 두 번째 사본에 `서버 replay` 배지. 실측: sangsu 02:18:27 농담 턴 (스토어에는 `msg-1786641507558152-1` **1행**만 존재 → 생산자 중복이 아니라 렌더 병합 실패).

## 기전

1. 서버(`keeper_chat_delivery_identity.ml`)는 Operation 키를 `{kind:"operation", operation_id:"kmsg-..."}`로 직렬화.
2. 라이브 항목은 `requestId = request.operationId` (같은 kmsg id)를 스탬프 (`keeper-actions.ts`).
3. history 파서 `deliveryIdentityFromKey`(keeper-state.ts:786)는 **존재하지 않는** `request_id` 필드를 읽음 → 항상 null. PR #27962가 kind를 `direct_request`→`operation`으로 hard-cut하면서 필드 읽기만 옛 이름으로 남은 것.
4. `sameConversationEntry`는 한쪽만 requestId를 가지면 fail closed → 라이브 턴과 그 history replay가 **둘 다 마운트 유지** (keeper-state.ts:1362 `coveredByHistory` 불성립).

## 수정

- `deliveryIdentityFromKey`: kind `operation`에서 `operation_id`를 읽음 (1곳). 호환 reader 없음 — 서버는 이 kind에 `request_id`를 쓴 적이 없고, unknown 필드는 서버 디코더가 거부함.
- 테스트 픽스처 4곳(keeper-state.test.ts, keeper-actions.test.ts)이 파서의 지어낸 형태(`request_id`)를 인코딩하고 있었음 → 생산자 형태(`operation_id`)로 교정.

## 검증

- `npm run typecheck` + 전체 dashboard vitest **exit 0** (113/113 대상 파일, 전체 스위트 green)
- **뮤테이션 체크**: 파서만 origin/main으로 원복 시 병합 테스트가 정확히 1건 실패 → 교정된 픽스처가 이 버그를 잡음
- 테스트 입력은 가설이 아니라 생산자(`delivery_key_to_yojson`)와 실데이터(sangsu.jsonl 2596행)에서 가져옴

관련: #28608 (멱등 우주 통일 — 서버측), RFC-0376 §4.1 (continuation kind 제거 예정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)