### PR TITLE
fix(keeper): settle irreducible compaction windows

### DIFF
--- a/lib/keeper/keeper_compact_rejection.ml
+++ b/lib/keeper/keeper_compact_rejection.ml
@@ -62,5 +62,7 @@ let summarization_rejection = function
     Exact_flow_already_started
   | Keeper_compaction_llm_summarizer.Exact_execution_terminal terminal ->
     Exact_execution_terminal terminal
+  | Keeper_compaction_llm_summarizer.No_reducible_boundary ->
+    No_eligible_history
   | Keeper_compaction_llm_summarizer.Invalid_plan -> Invalid_compaction_plan
 ;;

--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -77,6 +77,7 @@ type summarization_failure =
   | Exact_execution_authority_rejected
   | Exact_flow_already_started
   | Exact_execution_terminal of Keeper_compaction_outcome.exact_execution_terminal
+  | No_reducible_boundary
   | Invalid_plan
 
 type summarizer =
@@ -796,6 +797,11 @@ let prepare_lane
         empty_lane_id;
       Error Exact_target_selection_failed
   | Ok { selected_slots } ->
+    let* () =
+      if planning_window_has_valid_boundary window
+      then Ok ()
+      else Error No_reducible_boundary
+    in
     let* window =
       largest_fitting_window ~keeper_name ~selected_slots window
     in
@@ -882,6 +888,7 @@ let summarization_failure_detail = function
   | Exact_flow_already_started -> "exact_flow_already_started"
   | Exact_execution_terminal terminal ->
     Keeper_compaction_outcome.exact_execution_terminal_to_string terminal
+  | No_reducible_boundary -> "no_reducible_boundary"
   | Invalid_plan -> "invalid_plan"
 ;;
 

--- a/lib/keeper/keeper_compaction_llm_summarizer.mli
+++ b/lib/keeper/keeper_compaction_llm_summarizer.mli
@@ -36,6 +36,7 @@ type summarization_failure =
   | Exact_execution_authority_rejected
   | Exact_flow_already_started
   | Exact_execution_terminal of Keeper_compaction_outcome.exact_execution_terminal
+  | No_reducible_boundary
   | Invalid_plan
 
 type summarizer =


### PR DESCRIPTION
## As-Is

A dedicated canary with one eligible Assistant source accepted `masc_keeper_compact`, durably enqueued the request, and signaled its owner. Planning produced a valid window, but that window had no legal reducible boundary. `largest_fitting_window` collapsed this normal no-op shape into generic `Invalid_plan`, so the queue terminal was a failure:

`recovery_error=compaction rejected: invalid_compaction_plan failure_dispatch=applied`

The checkpoint remained unchanged and `compaction_count` stayed 0, but the durable request was classified as failed instead of terminal no-compaction.

## To-Be

- A structurally valid planning window with no reducible boundary returns the new internal typed failure `No_reducible_boundary` before provider dispatch.
- That exact planner outcome maps to the existing policy terminal `No_eligible_history`.
- Exact lane resolution remains authoritative first, so an unconfigured or empty lane is not masked by the no-boundary result.
- Planning-window construction errors remain `Invalid_plan`.
- Malformed or schema-invalid model output still exhausts through `Domain_invalid_output`.
- Structural-invalid history remains rejected before summarizer dispatch.

No new framework, retry, runtime-name policy, or dashboard gate is added.

## Fast validation

- `ocamlformat --check` on all three production files
- `ocamlc -stop-after parsing` on all three production files
- `git diff --check`
- conflict-marker scan
- `scripts/ocaml-structure-ratchet.sh`
- independent source-only adversarial review; its lane-precedence P2 was fixed before publication

No new tests and no Dune build, per the feature-first campaign. Full CI, deployment, and live rerun remain pending.

# ci:skip-test-coverage