### PR TITLE
feat(keeper): Slack 쓰레드 답글(thread_ts) + Block Kit blocks 도구 입력 (task-327/328)

### DIFF
--- a/lib/keeper/keeper_surface_post.ml
+++ b/lib/keeper/keeper_surface_post.ml
@@ -15,6 +15,10 @@ let slack_label = "slack"
 
 let max_user_mentions = 100
 
+(* Slack chat.postMessage rejects more than 50 top-level blocks per message
+   (official Block Kit limit). *)
+let max_rich_blocks = 50
+
 let is_ascii_upper_or_digit = function
   | 'A' .. 'Z' | '0' .. '9' -> true
   | _ -> false
@@ -75,6 +79,63 @@ let user_mentions_of_args ~surface args =
     else
       Error
         "mention_user_ids is supported only for Slack and Discord posts")
+
+let thread_ts_of_args ~surface args =
+  match args with
+  | `Assoc fields ->
+    (match List.filter (fun (name, _) -> name = "thread_ts") fields with
+     | [] -> Ok None
+     | [ (_, `String value) ] ->
+       let value = String.trim value in
+       if value = "" then
+         Error "thread_ts must be a non-empty Slack thread timestamp"
+       else if String.equal surface slack_label then Ok (Some value)
+       else Error "thread_ts is supported only for Slack posts"
+     | [ _ ] -> Error "thread_ts must be a string"
+     | _ -> Error "thread_ts must not be repeated")
+  | _ -> Error "keeper_surface_post arguments must be an object"
+
+let blocks_of_args ~surface args =
+  match args with
+  | `Assoc fields ->
+    (match List.filter (fun (name, _) -> name = "blocks") fields with
+     | [] -> Ok None
+     | [ (_, `List items) ] ->
+       if not (String.equal surface slack_label) then
+         Error "blocks is supported only for Slack posts"
+       else if items = [] then
+         Error "blocks must not be empty; omit it to render content instead"
+       else if List.length items > max_rich_blocks then
+         Error
+           (Printf.sprintf
+              "blocks supports at most %d Block Kit blocks per message"
+              max_rich_blocks)
+       else (
+         let block_type_error =
+           List.find_mapi
+             (fun index item ->
+                match item with
+                | `Assoc block_fields ->
+                  (match List.assoc_opt "type" block_fields with
+                   | Some (`String block_type)
+                     when String.trim block_type <> "" -> None
+                   | Some _ | None ->
+                     Some
+                       (Printf.sprintf
+                          "blocks[%d] must carry a non-empty string \"type\" \
+                           member (Block Kit block)"
+                          index))
+                | _ ->
+                  Some
+                    (Printf.sprintf "blocks[%d] must be a JSON object" index))
+             items
+         in
+         match block_type_error with
+         | Some message -> Error message
+         | None -> Ok (Some items))
+     | [ _ ] -> Error "blocks must be an array of Block Kit block objects"
+     | _ -> Error "blocks must not be repeated")
+  | _ -> Error "keeper_surface_post arguments must be an object"
 
 let message_matches_target target (message : Keeper_chat_store.chat_message) =
   match target, message.surface with
@@ -174,6 +235,7 @@ let delivery_target_of_yojson json =
 let delivery_target_wire_key = "external_effect_target"
 
 let resolve_target ~surface ~channel_id ?continuation_channel
+    ?requested_thread_ts
     ?(bound_discord_channels = [])
     ?(bound_slack_channels = []) () : (post_target, string) result =
   let surface = String.trim surface in
@@ -203,15 +265,19 @@ let resolve_target ~surface ~channel_id ?continuation_channel
     | None ->
       None, None, None
   in
-  (* A Slack [thread_ts] names a conversation inside one channel, so it only
-     travels with a post that lands on the continuation's own channel; an
-     explicit different channel gets a root post (a foreign thread_ts would be
-     rejected by Slack). *)
+  (* An explicit [thread_ts] from the tool call names the destination thread
+     directly and wins. Otherwise the continuation's [thread_ts] only travels
+     with a post that lands on the continuation's own channel; an explicit
+     different channel gets a root post (a foreign thread_ts would be rejected
+     by Slack). *)
   let slack_thread_ts_for ~channel_id =
-    match continuation_channel_id with
-    | Some continuation_id when String.equal channel_id continuation_id ->
-      continuation_slack_thread_ts
-    | Some _ | None -> None
+    match requested_thread_ts with
+    | Some _ -> requested_thread_ts
+    | None ->
+      (match continuation_channel_id with
+       | Some continuation_id when String.equal channel_id continuation_id ->
+         continuation_slack_thread_ts
+       | Some _ | None -> None)
   in
   let channel_id =
     match channel_id with

--- a/lib/keeper/keeper_surface_post.mli
+++ b/lib/keeper/keeper_surface_post.mli
@@ -21,10 +21,11 @@ type post_target =
       ; thread_ts : string option
       ; blocks : rich_block list option
       }
-      (** Post to a bound Slack channel. [thread_ts] carries the continuation
-          thread coordinate when the post lands on the continuation's own
-          channel, so a threaded question is answered in its thread instead of
-          the channel root. [blocks] may carry Slack Block Kit rich blocks to
+      (** Post to a bound Slack channel. [thread_ts] carries the explicit
+          thread requested by the tool call, else the continuation thread
+          coordinate when the post lands on the continuation's own channel,
+          so a threaded question is answered in its thread instead of the
+          channel root. [blocks] may carry Slack Block Kit rich blocks to
           render alongside the plain-text fallback. *)
 
 val dashboard_label : string
@@ -32,6 +33,10 @@ val discord_label : string
 val slack_label : string
 
 val max_user_mentions : int
+
+val max_rich_blocks : int
+(** Slack chat.postMessage rejects more than this many top-level Block Kit
+    blocks per message. *)
 
 val user_mentions_of_args :
   surface:string -> Yojson.Safe.t -> (string list, string) result
@@ -50,6 +55,21 @@ val validate_user_mentions_against_roster :
     the exact resolved Discord channel or Slack channel/thread in [messages].
     The persisted chat lane is the roster SSOT; syntactically valid but stale,
     hallucinated, or cross-channel ids are rejected before any effect. *)
+
+val thread_ts_of_args :
+  surface:string -> Yojson.Safe.t -> (string option, string) result
+(** Decode the optional [thread_ts] tool argument: the Slack timestamp of an
+    existing thread's root message. Slack-only; blank or non-string values are
+    rejected. The value is passed to Slack verbatim — a foreign or expired
+    timestamp fails at the connector, not silently as a root post. *)
+
+val blocks_of_args :
+  surface:string -> Yojson.Safe.t -> (rich_block list option, string) result
+(** Decode the optional [blocks] tool argument: Slack Block Kit blocks for
+    chat.postMessage. Slack-only. The array must be non-empty, carry at most
+    {!max_rich_blocks} entries, and every entry must be a JSON object with a
+    non-empty string ["type"] member. Content stays the notification fallback
+    text. *)
 
 type delivery_target =
   | Delivered_to_dashboard
@@ -81,6 +101,7 @@ val resolve_target :
   surface:string ->
   channel_id:string option ->
   ?continuation_channel:Keeper_continuation_channel.t ->
+  ?requested_thread_ts:string ->
   ?bound_discord_channels:string list ->
   ?bound_slack_channels:string list ->
   unit ->
@@ -95,8 +116,9 @@ val resolve_target :
       keeps its thread channel as the target while authorizing it through
       the bound parent channel; an error names the bound channels when
       ambiguous, unbound, or foreign.
-    - ["slack"] → same semantics against [bound_slack_channels]. A typed
-      Slack continuation also supplies its [thread_ts], which travels with
+    - ["slack"] → same semantics against [bound_slack_channels]. An explicit
+      [requested_thread_ts] wins and travels with any bound channel. Otherwise
+      a typed Slack continuation supplies its [thread_ts], which travels with
       the target only when the post lands on the continuation's own channel.
       A continuation for another connector never supplies an id.
     - any other label → error: P4 ships discord + dashboard + slack

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -935,6 +935,27 @@ let surface_post_schema =
         "Bound Discord or Slack channel id. Required only when more than one \
          channel is bound for the selected surface; must be one of those \
          bindings."
+    ; property
+        "thread_ts"
+        "string"
+        "Slack timestamp of an existing thread's root message (from \
+         keeper_surface_read). Posts this message as a reply inside that \
+         thread. Slack surface only; when both this and a continuation \
+         thread exist, this value wins."
+    ; ( "blocks"
+      , `Assoc
+          [ "type", `String "array"
+          ; "items", `Assoc [ "type", `String "object" ]
+          ; "maxItems", `Int Keeper_surface_post.max_rich_blocks
+          ; ( "description"
+            , `String
+                "Slack Block Kit blocks for chat.postMessage (at most 50, \
+                 each a block object with a \"type\" member). Slack surface \
+                 only. content stays the notification fallback text; when \
+                 omitted, content renders as one markdown block. Rendering \
+                 mentions inside custom blocks is the author's \
+                 responsibility; mention_user_ids are still roster-validated." )
+          ] )
     ; ( "mention_user_ids"
       , `Assoc
           [ "type", `String "array"

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -1319,6 +1319,23 @@ let handle_surface_post_with_outcome
       ~effect_disposition:Tool_result.Proven_pre_effect
       (Keeper_surface_post.error_json message)
   | Ok mention_user_ids ->
+    match Keeper_surface_post.thread_ts_of_args ~surface args with
+    | Error message ->
+      fail
+        ~effect_disposition:Tool_result.Proven_pre_effect
+        (Keeper_surface_post.error_json message)
+    | Ok requested_thread_ts ->
+    match Keeper_surface_post.blocks_of_args ~surface args with
+    | Error message ->
+      fail
+        ~effect_disposition:Tool_result.Proven_pre_effect
+        (Keeper_surface_post.error_json message)
+    | Ok requested_blocks ->
+    let requested_blocks =
+      Option.map
+        (List.map (Keeper_secret_redaction.redact_json redaction))
+        requested_blocks
+    in
     match
       Channel_gate_discord_state.bound_channels_result ~keeper_name:meta.name
     with
@@ -1340,6 +1357,7 @@ let handle_surface_post_with_outcome
        match
          Keeper_surface_post.resolve_target ~surface ~channel_id
            ?continuation_channel
+           ?requested_thread_ts
            ~bound_slack_channels ~bound_discord_channels ()
        with
       | Error message ->
@@ -1347,6 +1365,7 @@ let handle_surface_post_with_outcome
           ~effect_disposition:Tool_result.Proven_pre_effect
           (Keeper_surface_post.error_json message)
       | Ok target ->
+        let target = Keeper_surface_post.set_blocks target requested_blocks in
         let messages =
           Keeper_chat_store.load
             ~base_dir:config.Workspace.base_path
@@ -1402,9 +1421,12 @@ let handle_surface_post_with_outcome
         (Replay_discord_post
            { input; channel_id; content = safe_content; mention_user_ids })
       |> Keeper_tool_execution.with_surface_post_receipt target
-         | Keeper_surface_post.To_slack { channel_id; thread_ts; blocks = _ } ->
+         | Keeper_surface_post.To_slack { channel_id; thread_ts; blocks } ->
       let slack_blocks =
-        Keeper_chat_slack.message_blocks_of_text ~mention_user_ids safe_content
+        match blocks with
+        | Some blocks -> blocks
+        | None ->
+          Keeper_chat_slack.message_blocks_of_text ~mention_user_ids safe_content
       in
       let input =
         connector_post_gate_input

--- a/test/test_keeper_surface_post.ml
+++ b/test/test_keeper_surface_post.ml
@@ -572,6 +572,113 @@ let test_mentions_require_exact_resolved_target_roster () =
   | Error _ -> ()
   | Ok () -> fail "participant from another Slack thread was mentionable"
 
+(* ── thread_ts / blocks tool args ───────────────────────────────── *)
+
+let block ?(block_type = "section") () =
+  `Assoc [ ("type", `String block_type); ("text", `String "t") ]
+
+let test_thread_ts_args_decode () =
+  check (result (option string) string) "absent decodes to None" (Ok None)
+    (SP.thread_ts_of_args ~surface:"slack" (`Assoc []));
+  check (result (option string) string) "value decodes trimmed"
+    (Ok (Some "1755134336.123456"))
+    (SP.thread_ts_of_args ~surface:"slack"
+       (`Assoc [ ("thread_ts", `String " 1755134336.123456 ") ]));
+  (match
+     SP.thread_ts_of_args ~surface:"slack"
+       (`Assoc [ ("thread_ts", `String "  ") ])
+   with
+   | Error _ -> ()
+   | Ok _ -> fail "blank thread_ts was accepted");
+  (match
+     SP.thread_ts_of_args ~surface:"discord"
+       (`Assoc [ ("thread_ts", `String "1755134336.123456") ])
+   with
+   | Error _ -> ()
+   | Ok _ -> fail "thread_ts on a non-Slack surface was accepted");
+  match
+    SP.thread_ts_of_args ~surface:"slack" (`Assoc [ ("thread_ts", `Int 3) ])
+  with
+  | Error _ -> ()
+  | Ok _ -> fail "non-string thread_ts was accepted"
+
+let test_blocks_args_decode () =
+  check bool "absent decodes to None" true
+    (SP.blocks_of_args ~surface:"slack" (`Assoc []) = Ok None);
+  (match
+     SP.blocks_of_args ~surface:"slack"
+       (`Assoc [ ("blocks", `List [ block () ]) ])
+   with
+   | Ok (Some [ _ ]) -> ()
+   | Ok _ | Error _ -> fail "one valid block was rejected");
+  (match
+     SP.blocks_of_args ~surface:"discord"
+       (`Assoc [ ("blocks", `List [ block () ]) ])
+   with
+   | Error _ -> ()
+   | Ok _ -> fail "blocks on a non-Slack surface were accepted");
+  (match
+     SP.blocks_of_args ~surface:"slack" (`Assoc [ ("blocks", `List []) ])
+   with
+   | Error _ -> ()
+   | Ok _ -> fail "empty blocks array was accepted");
+  (match
+     SP.blocks_of_args ~surface:"slack"
+       (`Assoc [ ("blocks", `List [ `String "not-a-block" ]) ])
+   with
+   | Error _ -> ()
+   | Ok _ -> fail "non-object block was accepted");
+  (match
+     SP.blocks_of_args ~surface:"slack"
+       (`Assoc [ ("blocks", `List [ `Assoc [ ("text", `String "x") ] ]) ])
+   with
+   | Error _ -> ()
+   | Ok _ -> fail "block without a type member was accepted");
+  let too_many =
+    List.init (SP.max_rich_blocks + 1) (fun _ -> block ())
+  in
+  match
+    SP.blocks_of_args ~surface:"slack" (`Assoc [ ("blocks", `List too_many) ])
+  with
+  | Error _ -> ()
+  | Ok _ -> fail "more than max_rich_blocks blocks were accepted"
+
+let test_resolve_explicit_thread_ts_wins_over_continuation () =
+  let continuation_channel =
+    match
+      Keeper_continuation_channel.slack
+        ~team_id:(Some "team")
+        ~channel_id:"BBB"
+        ~thread_ts:(Some "continuation-thread")
+        ~user_id:"user"
+    with
+    | Ok channel -> channel
+    | Error message -> fail message
+  in
+  check (result target string) "explicit thread_ts wins"
+    (Ok
+       (SP.To_slack
+          { channel_id = "BBB"
+          ; thread_ts = Some "explicit-thread"
+          ; blocks = None
+          }))
+    (resolve ~surface:"slack" ~channel_id:None ~continuation_channel
+       ~requested_thread_ts:"explicit-thread"
+       ~bound_discord_channels:[] ~bound_slack_channels:[ "BBB" ] ())
+
+let test_resolve_explicit_thread_ts_without_continuation () =
+  check (result target string) "explicit thread_ts travels alone"
+    (Ok
+       (SP.To_slack
+          { channel_id = "AAA"
+          ; thread_ts = Some "explicit-thread"
+          ; blocks = None
+          }))
+    (resolve ~surface:"slack" ~channel_id:None
+       ~requested_thread_ts:"explicit-thread"
+       ~bound_discord_channels:[] ~bound_slack_channels:[ "AAA" ] ())
+
+
 let () =
   run "keeper_surface_post"
     [
@@ -624,6 +731,17 @@ let () =
             test_dashboard_rejects_nonempty_mentions
         ; test_case "requires exact resolved target roster" `Quick
             test_mentions_require_exact_resolved_target_roster
+        ] );
+      ( "thread and blocks args",
+        [
+          test_case "thread_ts decode closes its domain" `Quick
+            test_thread_ts_args_decode;
+          test_case "blocks decode closes its domain" `Quick
+            test_blocks_args_decode;
+          test_case "explicit thread_ts wins over continuation" `Quick
+            test_resolve_explicit_thread_ts_wins_over_continuation;
+          test_case "explicit thread_ts travels without continuation" `Quick
+            test_resolve_explicit_thread_ts_without_continuation;
         ] );
       ( "terminal receipt",
         [


### PR DESCRIPTION
## 목적

goal-1786643482500-99e4 의 두 task 구현. 전송층은 이미 준비돼 있었고(`Slack_rest_client.send_message ?thread_ts`, #28614 의 `send_message_with_blocks`), **도구 입력이 그 좌표를 명명할 수 없던 격차**만 닫는다.

- **task-327**: `keeper_surface_post` 에 `thread_ts` 입력 — 기존 쓰레드 타래에 답글 게시. 지금까지 thread 좌표는 continuation channel 로만 유입돼, 깨운 쓰레드에만 답할 수 있었다.
- **task-328**: `blocks` 입력 — 모델이 작성한 Block Kit 블록으로 게시. 지금까지 `To_slack.blocks` 필드는 핸들러에서 `blocks = _` 로 무시되고 content 자동 렌더만 발송됐다.

## 설계

| 결정 | 내용 |
|---|---|
| 닫힌 디코더 2개 | `thread_ts_of_args`(Slack 전용·non-blank·중복 거부), `blocks_of_args`(Slack 전용, 1..50개, 각 항목은 non-empty string `type` 을 가진 객체). 50 은 Slack chat.postMessage 공식 상한 — `max_rich_blocks` 상수로 노출 |
| thread 우선순위 | `resolve_target ?requested_thread_ts` — **명시 요청이 continuation 좌표를 이긴다** (출력 목적지 판단은 keeper 의 것, RFC-0376 계약과 정합). 요청이 없으면 기존 규칙 그대로(continuation 자기 채널에만 동반) |
| attention ledger 불변 | 명시적으로 다른 쓰레드에 게시하면 `matches_continuation_route` 는 false — 깨운 쓰레드를 답한 게 아니므로 resolved 로 마킹되지 않는 기존 exact-thread 의미 유지 |
| redaction | 모델 작성 blocks 는 `Keeper_secret_redaction.redact_json` 통과 후 발송 (content 와 동일 보호) |
| blocks 채택 시 | content 는 Slack notification fallback text 로 유지. 커스텀 블록 안의 멘션 렌더링은 작성자 책임, `mention_user_ids` roster 검증은 그대로 |
| thread_ts 형식 검증 없음 | Slack ts 는 공식적으로 opaque string — 형식 추정(regex)은 휴리스틱이라 배제. 오류는 커넥터의 typed 실패로 전파 |

## 검증

- `dune build --root . lib` exit 0
- `test_keeper_surface_post.exe`: **30 tests pass** (신규 4: 디코더 도메인 2 + thread 우선순위 2)
- 변경 파일 전부 ocamlformat clean
- 라이브 검증(머지 후): kidsnote keeper 로 (1) 기존 쓰레드 타래에 PR 링크 리포트 답글 (2) Block Kit 헤더/섹션 리포트 게시 — task 완료 기준 그대로

## 변경 파일

- `lib/keeper/keeper_surface_post.{ml,mli}` — 디코더 2 + `max_rich_blocks` + resolve 우선순위
- `lib/keeper/keeper_tool_descriptor.ml` — 스키마 property 2
- `lib/keeper/keeper_tool_in_process_runtime.ml` — 파싱·redaction·target blocks 실사용 (`blocks = _` 제거)
- `test/test_keeper_surface_post.ml` — 4 cases