### PR TITLE
fix(keeper): fence creation before durable writes

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -723,6 +723,9 @@ let start_keepalive_outcome_to_string = function
       "shutdown operation %s owns keeper admission"
       (Keeper_shutdown_types.Operation_id.to_string operation_id)
   | Keepalive_registration_rejected
+      Keeper_registry.Registration_intake_token_not_live ->
+    "registry registration rejected an inactive durable-intake token"
+  | Keepalive_registration_rejected
       (Keeper_registry.Registration_lifecycle_reserved owner) ->
     Printf.sprintf
       "keeper lifecycle reservation conflict: %s"
@@ -795,6 +798,7 @@ let record_lifecycle_start_denial
 let start_keepalive
       ?(proactive_warmup_sec = 0)
       ?lifecycle_token
+      ?intake_token
       (ctx : _ context)
   (m : keeper_meta)
   : start_keepalive_outcome
@@ -903,11 +907,13 @@ let start_keepalive
          match lifecycle_token with
          | None ->
            Keeper_registry.register_offline_if_admitted
+             ?intake_token
              ~base_path:ctx.config.base_path
              m.name
              m
          | Some token ->
            Keeper_registry.register_offline_if_admitted_for_lifecycle
+             ?intake_token
              token
              ~base_path:ctx.config.base_path
              m.name
@@ -920,6 +926,12 @@ let start_keepalive
            (Keeper_shutdown_types.Operation_id.to_string operation_id);
          Keepalive_registration_rejected
            (Keeper_registry.Registration_shutdown_reserved operation_id)
+       | Error Keeper_registry.Registration_intake_token_not_live ->
+         Log.Keeper.error
+           "start_keepalive: inactive durable-intake token rejected %s"
+           m.name;
+         Keepalive_registration_rejected
+           Keeper_registry.Registration_intake_token_not_live
        | Error (Keeper_registry.Registration_lifecycle_reserved owner) ->
          Log.Keeper.warn
            "start_keepalive: lifecycle reservation rejected %s: %s"

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -113,10 +113,12 @@ val start_keepalive_outcome_to_string : start_keepalive_outcome -> string
 
 (** Launch one keeper lane and return the exact typed admission/launch
     outcome. Rejections remain logged and observable, but are never collapsed
-    into [unit]; lifecycle transactions use the result to commit or roll back. *)
+    into [unit]; lifecycle transactions use the result to commit or roll back.
+    [intake_token] keeps a create transaction live through registry handoff. *)
 val start_keepalive :
   ?proactive_warmup_sec:int ->
   ?lifecycle_token:Keeper_lifecycle_reservation.token ->
+  ?intake_token:Keeper_shutdown_intake_fence.intake_token ->
   'a context ->
   keeper_meta ->
   start_keepalive_outcome

--- a/lib/keeper/keeper_owner_registry.ml
+++ b/lib/keeper/keeper_owner_registry.ml
@@ -615,46 +615,60 @@ let cancel_queued_operation ~base_path ~keeper_name operation_id =
     Keeper_owner.cancel_queued_operation owner operation_id)
 ;;
 
-let create_meta ~base_path meta =
-  match
-    Keeper_shutdown_intake_fence.run_durable_intake_if_open
+let create_meta_unfenced ~base_path meta =
+  match find_pool base_path with
+  | Error error -> Error (Command_lookup_failed error)
+  | Ok pool ->
+    Keeper_lifecycle_reservation.with_key_lock
       ~base_path
       ~keeper_name:meta.Keeper_meta_contract.name
-      (fun _intake_token ->
-         match find_pool base_path with
-         | Error error -> Error (Command_lookup_failed error)
-         | Ok pool ->
-           Keeper_lifecycle_reservation.with_key_lock
+      (fun () ->
+         match
+           Keeper_lifecycle_reservation.authorize
              ~base_path
              ~keeper_name:meta.name
-             (fun () ->
-                match
-                  Keeper_lifecycle_reservation.authorize
-                    ~base_path
-                    ~keeper_name:meta.name
-                    ()
-                with
-                | Error reservation -> Error (Command_lifecycle_reserved reservation)
-                | Ok () ->
-                  (match ensure_empty_in_pool pool meta.name with
-                   | Error error -> Error (Command_lookup_failed error)
-                   | Ok owner ->
-                     (match
-                        Keeper_owner.apply_meta
-                          owner
-                          (Keeper_owner_reducer.Create meta)
-                      with
-                      | Error error -> Error (Command_rejected error)
-                      | Ok committed -> Ok committed))))
-  with
-  | Keeper_shutdown_intake_fence.Intake_committed result -> result
-  | Keeper_shutdown_intake_fence.Intake_shutdown_reserved operation_id ->
-    Error
-      (shutdown_fence_error
-         (Printf.sprintf
-            "keeper=%s create_meta_operation=%s"
-            meta.name
-            (Keeper_shutdown_types.Operation_id.to_string operation_id)))
+             ()
+         with
+         | Error reservation -> Error (Command_lifecycle_reserved reservation)
+         | Ok () ->
+           (match ensure_empty_in_pool pool meta.name with
+            | Error error -> Error (Command_lookup_failed error)
+            | Ok owner ->
+              (match
+                 Keeper_owner.apply_meta owner (Keeper_owner_reducer.Create meta)
+               with
+               | Error error -> Error (Command_rejected error)
+               | Ok committed -> Ok committed)))
+;;
+
+let create_meta ?intake_token ~base_path meta =
+  match intake_token with
+  | Some token ->
+    if
+      Keeper_shutdown_intake_fence.intake_token_matches
+        token
+        ~base_path
+        ~keeper_name:meta.Keeper_meta_contract.name
+    then create_meta_unfenced ~base_path meta
+    else
+      Error
+        (shutdown_fence_error
+           (Printf.sprintf "keeper=%s create_meta_intake_token_not_live" meta.name))
+  | None ->
+    (match
+       Keeper_shutdown_intake_fence.run_durable_intake_if_open
+         ~base_path
+         ~keeper_name:meta.Keeper_meta_contract.name
+         (fun _intake_token -> create_meta_unfenced ~base_path meta)
+     with
+     | Keeper_shutdown_intake_fence.Intake_committed result -> result
+     | Keeper_shutdown_intake_fence.Intake_shutdown_reserved operation_id ->
+       Error
+         (shutdown_fence_error
+            (Printf.sprintf
+               "keeper=%s create_meta_operation=%s"
+               meta.name
+               (Keeper_shutdown_types.Operation_id.to_string operation_id))))
 ;;
 
 let all_projections ~base_path =

--- a/lib/keeper/keeper_owner_registry.mli
+++ b/lib/keeper/keeper_owner_registry.mli
@@ -126,14 +126,17 @@ val commit_turn_runtime
     to the actor's current snapshot; callers cannot overwrite the record. *)
 
 val create_meta
-  :  base_path:string
+  :  ?intake_token:Keeper_shutdown_intake_fence.intake_token
+  -> base_path:string
   -> Keeper_meta_contract.keeper_meta
   -> (Keeper_meta_contract.keeper_meta option, command_error) result
 (** Under the durable-intake fence, install an empty actor for a new Keeper,
     then commit its first snapshot via the closed [Create] command. A failed
     commit leaves the empty actor in place so same-name retries remain
     mailbox-linearized. An active shutdown reservation rejects creation before
-    an empty actor is installed. *)
+    an empty actor is installed. When [intake_token] is supplied, the caller's
+    already-open exact-name intake transaction is reused instead of reacquiring
+    the same fence. *)
 
 val exact_operation
   :  base_path:string

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -27,6 +27,7 @@ val register_offline : base_path:string -> string -> keeper_meta -> registry_ent
 
 type registration_error =
   | Registration_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
+  | Registration_intake_token_not_live
   | Registration_lifecycle_reserved of Keeper_lifecycle_reservation.snapshot
   | Registration_invalid of registry_entry_validation_error
   | Registration_event_queue_unavailable of
@@ -36,14 +37,18 @@ type registration_error =
 
 (** Production registration gate: the final registry CAS is serialized with
     Keeper shutdown reservation. Event-queue loading remains outside the
-    non-yielding fence critical section. *)
+    non-yielding fence critical section. A live [intake_token] preserves an
+    already-open create transaction through registry installation without
+    reacquiring the same per-Keeper intake mutex. *)
 val register_offline_if_admitted :
+  ?intake_token:Keeper_shutdown_intake_fence.intake_token ->
   base_path:string ->
   string ->
   keeper_meta ->
   (registry_entry, registration_error) result
 
 val register_offline_if_admitted_for_lifecycle :
+  ?intake_token:Keeper_shutdown_intake_fence.intake_token ->
   Keeper_lifecycle_reservation.token ->
   base_path:string ->
   string ->

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -433,6 +433,7 @@ let update_entry_if_registered ~base_path name f =
 
 type registration_error =
   | Registration_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
+  | Registration_intake_token_not_live
   | Registration_lifecycle_reserved of Keeper_lifecycle_reservation.snapshot
   | Registration_invalid of registry_entry_validation_error
   | Registration_event_queue_unavailable of
@@ -442,6 +443,7 @@ type registration_error =
 
 let register_with_state_result
       ?lifecycle_token
+      ?intake_token
       ~respect_shutdown_fence
       ~base_path
       name
@@ -526,15 +528,28 @@ let register_with_state_result
      | Some _ | None -> ());
     put_entry_key_locked ?lifecycle_token ~base_path name entry
   in
-  (* The key lock is taken OUTSIDE the admission fence. Nesting it inside
-     [commit_registration_if_open] would suspend the fiber while it owns the
-     admission slot's [Stdlib.Mutex], wedging the whole domain. The fence check
-     and the registry install still happen together under that mutex, so
-     shutdown reservation and same-name lane installation stay totally
-     ordered. *)
+  (* Ordinary registration takes the key lock before the non-yielding
+     [commit_registration_if_open] state check. A caller-supplied intake token
+     already owns the fiber-aware per-Keeper intake mutex, so it validates that
+     exact transaction and commits without trying to reacquire the same gate.
+     In both paths the registry install remains ordered with shutdown. *)
   let commit_result =
     Keeper_lifecycle_reservation.with_key_lock ~base_path ~keeper_name:name (fun () ->
-      if respect_shutdown_fence
+      if Option.is_some intake_token
+      then (
+        match intake_token with
+        | Some token
+          when Keeper_shutdown_intake_fence.intake_token_matches
+                 token
+                 ~base_path
+                 ~keeper_name:name ->
+          (match commit_key_locked () with
+           | Ok () -> Ok ()
+           | Error (Lifecycle_transaction_reserved owner) ->
+             Error (Registration_lifecycle_reserved owner)
+           | Error validation_error -> Error (Registration_invalid validation_error))
+        | Some _ | None -> Error Registration_intake_token_not_live)
+      else if respect_shutdown_fence
       then (
         match
           Keeper_shutdown_intake_fence.commit_registration_if_open
@@ -589,6 +604,8 @@ let register_with_state ~base_path name meta ~phase ~conditions =
          detail)
   | Error (Registration_shutdown_reserved _) ->
     invalid_arg "unchecked registry registration observed a shutdown fence"
+  | Error Registration_intake_token_not_live ->
+    invalid_arg "unchecked registry registration observed an inactive intake token"
   | Error (Registration_lifecycle_reserved owner) ->
     invalid_arg
       (Printf.sprintf
@@ -616,7 +633,7 @@ let register_offline ~base_path name meta =
   register_with_state ~base_path name meta ~phase ~conditions
 ;;
 
-let register_offline_if_admitted ~base_path name meta =
+let register_offline_if_admitted ?intake_token ~base_path name meta =
   let conditions =
     { Keeper_state_machine.default_conditions with
       launch_pending = true
@@ -624,6 +641,7 @@ let register_offline_if_admitted ~base_path name meta =
   in
   let phase = Keeper_state_machine.derive_phase conditions in
   register_with_state_result
+    ?intake_token
     ~respect_shutdown_fence:true
     ~base_path
     name
@@ -632,7 +650,13 @@ let register_offline_if_admitted ~base_path name meta =
     ~conditions
 ;;
 
-let register_offline_if_admitted_for_lifecycle token ~base_path name meta =
+let register_offline_if_admitted_for_lifecycle
+      ?intake_token
+      token
+      ~base_path
+      name
+      meta
+  =
   let conditions =
     { Keeper_state_machine.default_conditions with
       launch_pending = true
@@ -641,6 +665,7 @@ let register_offline_if_admitted_for_lifecycle token ~base_path name meta =
   let phase = Keeper_state_machine.derive_phase conditions in
   register_with_state_result
     ~lifecycle_token:token
+    ?intake_token
     ~respect_shutdown_fence:true
     ~base_path
     name

--- a/lib/keeper/keeper_supervisor_supervise_keepalive.ml
+++ b/lib/keeper/keeper_supervisor_supervise_keepalive.ml
@@ -138,6 +138,10 @@ let supervise_keepalive
         "supervisor launch skipped %s because shutdown operation %s owns admission"
         meta.name
         (Keeper_shutdown_types.Operation_id.to_string operation_id)
+    | Error Keeper_registry.Registration_intake_token_not_live ->
+      Log.Keeper.error
+        "supervisor launch rejected an unexpected inactive durable-intake token for %s"
+        meta.name
     | Error (Keeper_registry.Registration_lifecycle_reserved owner) ->
       Log.Keeper.warn
         "supervisor launch skipped %s because lifecycle transaction owns admission: %s"

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -13,8 +13,13 @@ open Keeper_execution
 open Keeper_turn_up_args
 
 
-let write_initial_meta config meta =
-  match Keeper_owner_registry.create_meta ~base_path:config.Workspace.base_path meta with
+let write_initial_meta ~intake_token config meta =
+  match
+    Keeper_owner_registry.create_meta
+      ~intake_token
+      ~base_path:config.Workspace.base_path
+      meta
+  with
   | Ok (Some _) -> Ok ()
   | Ok None -> Error "Keeper owner removed metadata during create"
   | Error error -> Error (Keeper_owner_registry.command_error_to_string error)
@@ -115,6 +120,11 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
                   Progress.stop_tracking task_id;
                   tool_result_error "internal keeper trace_id generation failed"
               | Ok trace_id_t ->
+                  (match
+                     Keeper_shutdown_intake_fence.run_durable_intake_if_open
+                       ~base_path:ctx.config.base_path
+                       ~keeper_name:p.name
+                       (fun intake_token ->
                   let base_dir = session_base_dir ctx.config in
                   (* Ensure full session dir tree, not just base_dir (issue #3019) *)
                   ignore (Keeper_fs.ensure_dir (Filename.concat base_dir trace_id));
@@ -326,7 +336,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
            (Printf.sprintf "declarative keeper config write failed: %s" e)
        | Ok _ ->
       Progress.Tracker.step tracker ~message:"Writing keeper metadata" ();
-      match write_initial_meta ctx.config meta with
+      match write_initial_meta ~intake_token ctx.config meta with
       | Error e ->
         Otel_metric_store.inc_counter Keeper_metrics.(to_string WriteMetaFailures)
           ~labels:[("keeper", p.name); ("phase", "create_keeper")] ();
@@ -341,7 +351,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
           p.name (Keeper_id.Trace_id.to_string meta.runtime.trace_id);
         Progress.Tracker.step tracker ~message:"Starting keepalive loop" ();
         Log.Keeper.info "create_keeper: starting keepalive for name=%s" p.name;
-        let launch_outcome = start_keepalive ctx meta in
+        let launch_outcome = start_keepalive ~intake_token ctx meta in
         (match launch_outcome with
          | Keepalive_started _ ->
         Progress.Tracker.complete tracker ~message:"Keeper created" ();
@@ -368,4 +378,25 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
            tool_result_error
              (Printf.sprintf
                 "keeper metadata was created but lane launch failed: %s"
-                (start_keepalive_outcome_to_string rejected)))))
+                (start_keepalive_outcome_to_string rejected))))))
+                   with
+                   | Keeper_shutdown_intake_fence.Intake_committed result ->
+                     result
+                   | Keeper_shutdown_intake_fence.Intake_shutdown_reserved
+                       operation_id ->
+                     let detail =
+                       Printf.sprintf
+                         "keeper creation rejected by shutdown admission: keeper=%s operation=%s"
+                         p.name
+                         (Keeper_shutdown_types.Operation_id.to_string operation_id)
+                     in
+                     Otel_metric_store.inc_counter
+                       Keeper_metrics.(to_string LifecycleDispatchRejections)
+                       ~labels:
+                         [ ("keeper", p.name)
+                         ; ("event", "create_shutdown_admission")
+                         ]
+                       ();
+                     Log.Keeper.warn "%s" detail;
+                     Progress.stop_tracking task_id;
+                     tool_result_error detail)

--- a/lib/keeper/keeper_turn_up_create.mli
+++ b/lib/keeper/keeper_turn_up_create.mli
@@ -10,7 +10,10 @@ open Keeper_types_profile
 
 (** Commit a freshly-built Keeper metadata snapshot through its Owner. *)
 val write_initial_meta :
-  Workspace.config -> keeper_meta -> (unit, string) result
+  intake_token:Keeper_shutdown_intake_fence.intake_token ->
+  Workspace.config ->
+  keeper_meta ->
+  (unit, string) result
 
 (** Create a new keeper from parsed args: build initial meta,
     write checkpoint, start keepalive, return the [keeper_up]

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -98,6 +98,7 @@ normal_targets=(
   @test/runtest-test_keeper_persistence_span_history
   @test/runtest-test_keeper_rotation_eligibility_census
   @test/runtest-test_keeper_shutdown_ownerless_admission_release
+  @test/runtest-test_keeper_create_admission_transaction
   @test/runtest-test_keeper_toml_accessor_matrix
   @test/runtest-test_keeper_turn_dispatch_authority
   @test/runtest-test_runtime_quota_window

--- a/test/dune
+++ b/test/dune
@@ -212,6 +212,7 @@
   test_keeper_playground_checkout_discovery
   test_keeper_meta_cwd_resilience
   test_keeper_effective_meta_overlay
+  test_keeper_create_admission_transaction
   test_metrics_rotation
   test_tool_error
   test_tool_token
@@ -511,6 +512,7 @@
   test_keeper_playground_checkout_discovery
   test_keeper_meta_cwd_resilience
   test_keeper_effective_meta_overlay
+  test_keeper_create_admission_transaction
   test_metrics_rotation
   test_tool_error
   test_tool_token

--- a/test/test_keeper_create_admission_transaction.ml
+++ b/test/test_keeper_create_admission_transaction.ml
@@ -1,0 +1,323 @@
+open Alcotest
+
+module Fence = Masc.Keeper_shutdown_intake_fence
+module Operation_id = Masc.Keeper_shutdown_types.Operation_id
+module Owner_registry = Masc.Keeper_owner_registry
+module Profile = Masc.Keeper_types_profile
+module Store = Masc.Keeper_meta_store
+module Turn_up = Masc.Keeper_turn_up
+module Workspace = Masc.Workspace
+
+let temp_dir prefix =
+  let path = Filename.temp_file prefix "" in
+  Unix.unlink path;
+  Unix.mkdir path 0o755;
+  path
+;;
+
+let rec mkdir_p path =
+  if not (Sys.file_exists path)
+  then (
+    let parent = Filename.dirname path in
+    if not (String.equal parent path) then mkdir_p parent;
+    Unix.mkdir path 0o755)
+;;
+
+let rec remove_tree path =
+  match Unix.lstat path with
+  | { Unix.st_kind = Unix.S_DIR; _ } ->
+    Array.iter (fun name -> remove_tree (Filename.concat path name)) (Sys.readdir path);
+    Unix.rmdir path
+  | _ -> Unix.unlink path
+  | exception Unix.Unix_error _ -> ()
+;;
+
+let write_file path content =
+  let channel = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr channel)
+    (fun () -> output_string channel content)
+;;
+
+let read_file path =
+  let channel = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr channel)
+    (fun () -> really_input_string channel (in_channel_length channel))
+;;
+
+let runtime_toml =
+  {|
+[runtime]
+default = "test_provider.test_model"
+
+[providers.test_provider]
+display-name = "Test Provider"
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:1"
+
+[models.test_model]
+api-name = "test-model"
+max-context = 8192
+tools-support = true
+streaming = true
+
+[test_provider.test_model]
+is-default = true
+max-concurrent = 1
+|}
+;;
+
+let restore_env name = function
+  | Some value -> Unix.putenv name value
+  | None -> Unix.putenv name ""
+;;
+
+let sorted_dir_entries path =
+  Sys.readdir path |> Array.to_list |> List.sort String.compare
+;;
+
+let with_workspace f =
+  let base_path = temp_dir "keeper-create-admission-" in
+  let config_dir = Filename.concat base_path ".masc/config" in
+  let runtime_path = Filename.concat config_dir "runtime.toml" in
+  let previous_config_dir = Sys.getenv_opt "MASC_CONFIG_DIR" in
+  Fun.protect
+    ~finally:(fun () ->
+      restore_env "MASC_CONFIG_DIR" previous_config_dir;
+      Config_dir_resolver.reset ();
+      Fence.For_testing.reset ();
+      Masc.Keeper_registry.For_testing.clear ();
+      remove_tree base_path)
+    (fun () ->
+       mkdir_p config_dir;
+       write_file runtime_path runtime_toml;
+       Unix.putenv "MASC_CONFIG_DIR" config_dir;
+       Config_dir_resolver.reset ();
+       let keepers_dir =
+         Config_dir_resolver.keepers_dir_for_base_path ~base_path
+       in
+       mkdir_p keepers_dir;
+       Eio_main.run @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       Fun.protect
+         ~finally:Fs_compat.clear_fs
+         (fun () ->
+            let config = Workspace.default_config base_path in
+            ignore (Workspace.init config ~agent_name:None : string);
+            (match Runtime.init_default ~config_path:runtime_path with
+             | Ok () -> ()
+             | Error error -> failf "runtime fixture rejected: %s" error);
+            Eio.Switch.run @@ fun sw ->
+            (match
+               Owner_registry.install_from_store
+                 ~sw
+                 ~operation_runner:None
+                 ~on_turn_slot_released:None
+                 config
+             with
+             | Ok 0 -> ()
+             | Ok count -> failf "unexpected initial owner count: %d" count
+             | Error error ->
+               fail (Owner_registry.install_error_to_string error));
+            f ~env ~sw ~config ~keepers_dir ~runtime_path))
+;;
+
+let test_shutdown_rejection_precedes_all_creation_writes () =
+  with_workspace @@ fun ~env ~sw ~config ~keepers_dir ~runtime_path ->
+  let keeper_name = "admission-transaction-probe" in
+  let trace_root = Filename.concat (Workspace.masc_root_dir config) "traces" in
+  mkdir_p trace_root;
+  let trace_entries_before = sorted_dir_entries trace_root in
+  let runtime_config_before = read_file runtime_path in
+  let runtime_assignment_before = Runtime.runtime_id_for_keeper keeper_name in
+  let toml_path = Filename.concat keepers_dir (keeper_name ^ ".toml") in
+  let agent_path = Filename.concat (Filename.concat keepers_dir keeper_name) "AGENT.md" in
+  let operation_id = Operation_id.generate () in
+  (match
+     Fence.begin_shutdown
+       ~base_path:config.base_path
+       ~keeper_name
+       ~operation_id
+   with
+   | Fence.Reserved _ -> ()
+   | Fence.Already_reserved _ -> fail "fresh shutdown fence was already reserved");
+  Fun.protect
+    ~finally:(fun () ->
+      ignore
+        (Fence.rollback_shutdown
+           ~base_path:config.base_path
+           ~keeper_name
+           ~operation_id
+          : Fence.rollback_result))
+    (fun () ->
+       let ctx : _ Profile.context =
+         { config
+         ; agent_name = "test-agent"
+         ; sw
+         ; clock = Eio.Stdenv.clock env
+         ; proc_mgr = None
+         ; net = None
+         ; publication_recovery_provider =
+             Masc_test_deps.non_runtime_publication_recovery_provider
+         }
+       in
+       let result =
+         Turn_up.handle_keeper_up
+           ctx
+           (`Assoc
+             [ "name", `String keeper_name
+             ; "instructions", `String "must not be persisted"
+             ; "sandbox_profile", `String "local"
+             ; "runtime_id", `String "test_provider.test_model"
+             ; "proactive_enabled", `Bool false
+             ; "autoboot_enabled", `Bool false
+             ])
+       in
+       check bool "keeper_up is rejected" false (Profile.tool_result_success result);
+       check (list string)
+         "no session or checkpoint directory is created"
+         trace_entries_before
+         (sorted_dir_entries trace_root);
+       check bool "keeper TOML is absent" false (Sys.file_exists toml_path);
+       check bool "keeper instructions are absent" false (Sys.file_exists agent_path);
+       (match Store.read_meta config keeper_name with
+        | Ok None -> ()
+        | Ok (Some _) -> fail "runtime metadata was created before admission"
+        | Error error -> failf "metadata absence check failed: %s" error);
+       (match Owner_registry.get ~base_path:config.base_path ~keeper_name with
+        | Error (Owner_registry.Owner_not_found actual) ->
+          check string "no owner actor is installed" keeper_name actual
+        | Error error ->
+          failf
+            "unexpected owner lookup result: %s"
+            (Owner_registry.lookup_error_to_string error)
+        | Ok _ -> fail "owner actor was installed before admission");
+       check bool
+         "no live registry entry is installed"
+         true
+         (Option.is_none
+            (Masc.Keeper_registry.get ~base_path:config.base_path keeper_name));
+       check (option string)
+         "runtime assignment is unchanged"
+         runtime_assignment_before
+         (Runtime.runtime_id_for_keeper keeper_name);
+       check string
+         "runtime configuration is unchanged"
+         runtime_config_before
+         (read_file runtime_path);
+       match Fence.shutdown_operation_id ~base_path:config.base_path ~keeper_name with
+       | Some actual ->
+         check bool
+           "rejected create does not release the shutdown owner"
+           true
+           (Operation_id.equal operation_id actual)
+       | None -> fail "rejected create released the shutdown fence")
+;;
+
+let test_create_wins_intake_fence_overlap_through_production_handoff () =
+  with_workspace @@ fun ~env ~sw ~config ~keepers_dir ~runtime_path:_ ->
+  let keeper_name = "admission-handoff-probe" in
+  let toml_path = Filename.concat keepers_dir (keeper_name ^ ".toml") in
+  let lock_held, resolve_lock_held = Eio.Promise.create () in
+  let release_lock, resolve_release_lock = Eio.Promise.create () in
+  let create_done, resolve_create_done = Eio.Promise.create () in
+  Eio.Fiber.fork ~sw (fun () ->
+    Masc.Keeper_lifecycle_reservation.with_key_lock
+      ~base_path:config.base_path
+      ~keeper_name
+      (fun () ->
+         Eio.Promise.resolve resolve_lock_held ();
+         Eio.Promise.await release_lock));
+  Eio.Promise.await lock_held;
+  let ctx : _ Profile.context =
+    { config
+    ; agent_name = "test-agent"
+    ; sw
+    ; clock = Eio.Stdenv.clock env
+    ; proc_mgr = None
+    ; net = None
+    ; publication_recovery_provider =
+        Masc_test_deps.non_runtime_publication_recovery_provider
+    }
+  in
+  Eio.Fiber.fork ~sw (fun () ->
+    let result =
+      Turn_up.handle_keeper_up
+        ctx
+        (`Assoc
+          [ "name", `String keeper_name
+          ; "instructions", `String "create must retain its admission epoch"
+          ; "sandbox_profile", `String "local"
+          ; "proactive_enabled", `Bool false
+          ; "autoboot_enabled", `Bool false
+          ])
+    in
+    Eio.Promise.resolve resolve_create_done result);
+  let rec await_config_write () =
+    if Sys.file_exists toml_path
+    then ()
+    else
+      match Eio.Promise.peek create_done with
+      | Some result ->
+        failf
+          "production create returned before the persistence barrier: %s"
+          (Profile.tool_result_body result)
+      | None ->
+        Eio.Fiber.yield ();
+        await_config_write ()
+  in
+  await_config_write ();
+  let operation_id = Operation_id.generate () in
+  (match
+     Fence.begin_shutdown
+      ~base_path:config.base_path
+      ~keeper_name
+      ~operation_id
+   with
+   | Fence.Reserved _ -> ()
+   | Fence.Already_reserved _ -> fail "fresh shutdown fence was already reserved");
+  Eio.Promise.resolve resolve_release_lock ();
+  Fun.protect
+    ~finally:(fun () ->
+      ignore
+        (Fence.rollback_shutdown
+           ~base_path:config.base_path
+           ~keeper_name
+           ~operation_id
+          : Fence.rollback_result);
+      Masc.Keeper_keepalive.stop_keepalive keeper_name)
+    (fun () ->
+       let result = Eio.Promise.await create_done in
+       check bool
+         "production create keeps its admitted epoch through launch"
+         true
+         (Profile.tool_result_success result);
+       (match Masc.Keeper_registry.get ~base_path:config.base_path keeper_name with
+        | Some entry ->
+          check string "exact launched keeper registered" keeper_name entry.name
+        | None -> fail "production create returned without a registry lane");
+       match Fence.shutdown_operation_id ~base_path:config.base_path ~keeper_name with
+       | Some actual ->
+         check bool
+           "create handoff does not erase the later shutdown reservation"
+           true
+           (Operation_id.equal operation_id actual)
+       | None -> fail "create handoff erased the later shutdown reservation")
+;;
+
+let () =
+  Alcotest.run
+    "keeper_create_admission_transaction"
+    [ ( "feature"
+      , [ test_case
+            "shutdown rejection precedes session config runtime and owner writes"
+            `Quick
+            test_shutdown_rejection_precedes_all_creation_writes
+        ; test_case
+    "production create keeps create-wins intake admission through lane fork"
+    `Quick
+    test_create_wins_intake_fence_overlap_through_production_handoff
+        ] )
+    ]
+;;


### PR DESCRIPTION
## What changed

- hold the existing per-Keeper durable-intake transaction before creating session, checkpoint, runtime assignment, declarative config, or Owner metadata
- pass the live intake token through Owner creation and keepalive registry handoff so a later shutdown reservation cannot split persistence from launch
- add production-path feature tests for preexisting shutdown rejection and create-wins overlap through lane launch
- wire the suite into focused CI without increasing the unwired-test baseline

## Root cause

`create_keeper` performed all durable side effects before `Keeper_owner_registry.create_meta` acquired the shutdown admission fence. A same-name shutdown conflict could therefore reject only the final Owner commit after session/config/runtime state had already changed. Separating persistence from keepalive registration also permits an ABA handoff unless both stay inside the same admitted intake epoch.

## Validation

- `ocamlc -stop-after parsing` on every changed `.ml` file
- `ocamlformat --check` on every changed OCaml interface/implementation
- `git diff --check`
- `bash -n scripts/ci-run-focused-tests.sh`
- `bash scripts/audit-ci-test-targets.sh` — 306 CI targets declared, 558 unwired baseline unchanged

Per project constraint, no local Dune build or test execution was run. GitHub CI is the execution authority.