### PR TITLE
fix(workspace): deliver mentioned broadcasts to Keeper intake

### DIFF
--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -90,10 +90,20 @@ let persisted_keeper_name_for_agent_name config ~agent_name =
 
 let persisted_keeper_for_mention_target config ~mention_target =
   let target = String.trim mention_target in
+  let read_effective keeper_name =
+    match read_meta_file_path (keeper_meta_path config keeper_name) with
+    | Error _ as error -> error
+    | Ok None -> Ok None
+    | Ok (Some meta) ->
+      Keeper_meta_contract.effective_meta_result
+        ~base_path:config.Workspace.base_path
+        meta
+      |> Result.map Option.some
+  in
   let rec collect matches = function
     | [] -> Ok (List.rev matches)
     | keeper_name :: rest ->
-      (match read_meta_file_path (keeper_meta_path config keeper_name) with
+      (match read_effective keeper_name with
        | Error detail -> Error detail
        | Ok None -> collect matches rest
        | Ok (Some meta) ->

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -89,7 +89,7 @@ let persisted_keeper_name_for_agent_name config ~agent_name =
 ;;
 
 let persisted_keeper_for_mention_target config ~mention_target =
-  let target = String.trim mention_target in
+  let target = Keeper_identity.Keeper_id.of_string mention_target in
   let read_effective keeper_name =
     match read_meta_file_path (keeper_meta_path config keeper_name) with
     | Error _ as error -> error
@@ -107,11 +107,18 @@ let persisted_keeper_for_mention_target config ~mention_target =
        | Error detail -> Error detail
        | Ok None -> collect matches rest
        | Ok (Some meta) ->
-         if List.exists (String.equal target) meta.mention_targets
+         if
+           List.exists
+             (fun alias ->
+                match Keeper_identity.Keeper_id.of_string alias, target with
+                | Some alias_id, Some target_id ->
+                  Keeper_identity.Keeper_id.equal alias_id target_id
+                | None, _ | _, None -> false)
+             meta.mention_targets
          then collect ((keeper_name, meta) :: matches) rest
          else collect matches rest)
   in
-  if target = ""
+  if Option.is_none target
   then Ok None
   else
     match persisted_keeper_names_result config with
@@ -125,7 +132,7 @@ let persisted_keeper_for_mention_target config ~mention_target =
          Error
            (Printf.sprintf
               "multiple persisted Keepers claim mention_target=%s: %s"
-              target
+              (String.trim mention_target)
               (matches |> List.map fst |> String.concat ",")))
 ;;
 

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -88,6 +88,37 @@ let persisted_keeper_name_for_agent_name config ~agent_name =
             (String.concat "," keeper_names)))
 ;;
 
+let persisted_keeper_for_mention_target config ~mention_target =
+  let target = String.trim mention_target in
+  let rec collect matches = function
+    | [] -> Ok (List.rev matches)
+    | keeper_name :: rest ->
+      (match read_meta_file_path (keeper_meta_path config keeper_name) with
+       | Error detail -> Error detail
+       | Ok None -> collect matches rest
+       | Ok (Some meta) ->
+         if List.exists (String.equal target) meta.mention_targets
+         then collect ((keeper_name, meta) :: matches) rest
+         else collect matches rest)
+  in
+  if target = ""
+  then Ok None
+  else
+    match persisted_keeper_names_result config with
+    | Error _ as error -> error
+    | Ok keeper_names ->
+      (match collect [] keeper_names with
+       | Error _ as error -> error
+       | Ok [] -> Ok None
+       | Ok [ match_ ] -> Ok (Some match_)
+       | Ok matches ->
+         Error
+           (Printf.sprintf
+              "multiple persisted Keepers claim mention_target=%s: %s"
+              target
+              (matches |> List.map fst |> String.concat ",")))
+;;
+
 let configured_keeper_names config =
   Keeper_types_profile.discover_keepers_toml
     (Config_dir_resolver.keepers_dir_for_base_path

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -23,10 +23,11 @@ val persisted_keeper_names : Workspace.config -> string list
 val persisted_keeper_name_for_agent_name :
   Workspace.config -> agent_name:string -> (string option, string) result
 
-(** Resolve an exact configured [mention_target] against persisted metadata.
-    The canonical filename and the same metadata snapshot are returned
-    together so delivery and pending-message classification use one authority.
-    Duplicate claims and metadata read failures are explicit errors. *)
+(** Resolve an exact configured [mention_target] against effective metadata.
+    The canonical filename and the same TOML-overlaid metadata snapshot are
+    returned together so delivery and pending-message classification use one
+    authority. Duplicate claims, configuration errors, and metadata read
+    failures are explicit errors. *)
 val persisted_keeper_for_mention_target :
   Workspace.config ->
   mention_target:string ->

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -23,6 +23,15 @@ val persisted_keeper_names : Workspace.config -> string list
 val persisted_keeper_name_for_agent_name :
   Workspace.config -> agent_name:string -> (string option, string) result
 
+(** Resolve an exact configured [mention_target] against persisted metadata.
+    The canonical filename and the same metadata snapshot are returned
+    together so delivery and pending-message classification use one authority.
+    Duplicate claims and metadata read failures are explicit errors. *)
+val persisted_keeper_for_mention_target :
+  Workspace.config ->
+  mention_target:string ->
+  ((string * Keeper_meta_contract.keeper_meta) option, string) result
+
 (** List keeper names declared in TOML config (overlay sources). *)
 val configured_keeper_names : Workspace.config -> string list
 

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -466,16 +466,26 @@ let handle_keeper_task_tool_with_outcome
         ~class_:Tool_result.Policy_rejection
         (error_json "message is required. Good: message='Build complete, all tests pass.'.")
     else (
-      let _ =
-        Workspace.broadcast config ~from_agent:(keeper_agent_sender ~meta) ~content:message
-      in
-      Keeper_tool_execution.success
-        (Yojson.Safe.to_string
-           (`Assoc
-              [ "ok", `Bool true
-              ; "broadcast", `String message
-              ; "typed_outcome", Keeper_tool_outcome.to_json Keeper_tool_outcome.Progress
-              ])))
+      match
+        Workspace.broadcast
+          config
+          ~from_agent:(keeper_agent_sender ~meta)
+          ~content:message
+      with
+      | Error error ->
+        Keeper_tool_execution.failure
+          ~class_:Tool_result.Runtime_failure
+          (error_json
+             ("broadcast was not persisted: "
+              ^ Workspace.broadcast_error_to_string error))
+      | Ok _ ->
+        Keeper_tool_execution.success
+          (Yojson.Safe.to_string
+             (`Assoc
+                [ "ok", `Bool true
+                ; "broadcast", `String message
+                ; "typed_outcome", Keeper_tool_outcome.to_json Keeper_tool_outcome.Progress
+                ])))
     | Task_create ->
     let title = Safe_ops.json_string ~default:"" "title" args |> String.trim in
     let description = Safe_ops.json_string ~default:"" "description" args |> String.trim in

--- a/lib/keeper_chat_delivery_identity/keeper_chat_delivery_identity.ml
+++ b/lib/keeper_chat_delivery_identity/keeper_chat_delivery_identity.ml
@@ -34,6 +34,7 @@ end
 type delivery_key =
   | Operation of Request_id.t
   | Fusion_run of Request_id.t
+  | Workspace_message of Request_id.t
 
 type transcript_slot =
   | Accepted_user
@@ -90,6 +91,11 @@ let delivery_key_to_yojson = function
       [ "kind", `String "fusion_run"
       ; "request_id", `String (Request_id.to_string request_id)
       ]
+  | Workspace_message request_id ->
+    `Assoc
+      [ "kind", `String "workspace_message"
+      ; "request_id", `String (Request_id.to_string request_id)
+      ]
 ;;
 
 let delivery_key_of_yojson = function
@@ -116,6 +122,16 @@ let delivery_key_of_yojson = function
        let* request_id = string_field "request_id" fields in
        let* request_id = Request_id.of_string request_id in
        Ok (Fusion_run request_id)
+     | "workspace_message" ->
+       let* () =
+         validate_fields
+           ~context:"workspace message delivery identity"
+           ~expected:[ "kind"; "request_id" ]
+           fields
+       in
+       let* request_id = string_field "request_id" fields in
+       let* request_id = Request_id.of_string request_id in
+       Ok (Workspace_message request_id)
      | _ -> Error (Printf.sprintf "unsupported delivery identity kind %S" kind))
   | _ -> Error "delivery identity must be an object"
 ;;
@@ -124,7 +140,10 @@ let delivery_key_equal left right =
   match left, right with
   | Operation left, Operation right -> Request_id.equal left right
   | Fusion_run left, Fusion_run right -> Request_id.equal left right
-  | Operation _, Fusion_run _ | Fusion_run _, Operation _ -> false
+  | Workspace_message left, Workspace_message right -> Request_id.equal left right
+  | (Operation _ | Fusion_run _ | Workspace_message _),
+    (Operation _ | Fusion_run _ | Workspace_message _) ->
+    false
 ;;
 
 let transcript_slot_to_yojson = function

--- a/lib/keeper_chat_delivery_identity/keeper_chat_delivery_identity.mli
+++ b/lib/keeper_chat_delivery_identity/keeper_chat_delivery_identity.mli
@@ -13,6 +13,11 @@ end
 type delivery_key =
   | Operation of Request_id.t
   | Fusion_run of Request_id.t
+  | Workspace_message of Request_id.t
+
+(** [Workspace_message] identifies one producer-minted workspace broadcast.
+    It lets a mentioned Keeper append that exact broadcast to its durable
+    transcript once without treating the broadcast as a chat operation. *)
 
 type transcript_slot =
   | Accepted_user

--- a/lib/mcp_tool_runtime_comm.ml
+++ b/lib/mcp_tool_runtime_comm.ml
@@ -48,21 +48,19 @@ let handle_broadcast ~tool_name ~start_time (ctx : context) : tool_result option
   else
     let trace_context = Otel_trace_context.from_ambient () in
     let delivery =
-      try
-        Ok
-          (Workspace.broadcast ?trace_context config
-             ~from_agent:agent_name ~content:message)
-      with
-      | Workspace_broadcast.Broadcast_not_persisted detail -> Error detail
+      Workspace.broadcast ?trace_context config
+        ~from_agent:agent_name ~content:message
     in
     match delivery with
-    | Error detail ->
+    | Error error ->
       Some
         (Tool_result.error
            ~failure_class:Tool_result.Runtime_failure
            ~tool_name
            ~start_time
-           (Printf.sprintf "Broadcast was not persisted: %s" detail))
+           (Printf.sprintf
+              "Broadcast was not persisted: %s"
+              (Workspace.broadcast_error_to_string error)))
     | Ok delivery ->
       let from_agent = delivery.from_agent in
       let mention = delivery.mention in

--- a/lib/mcp_tool_runtime_comm.ml
+++ b/lib/mcp_tool_runtime_comm.ml
@@ -48,34 +48,47 @@ let handle_broadcast ~tool_name ~start_time (ctx : context) : tool_result option
   else
     let trace_context = Otel_trace_context.from_ambient () in
     let delivery =
-      Workspace.broadcast ?trace_context config
-        ~from_agent:agent_name ~content:message
+      try
+        Ok
+          (Workspace.broadcast ?trace_context config
+             ~from_agent:agent_name ~content:message)
+      with
+      | Workspace_broadcast.Broadcast_not_persisted detail -> Error detail
     in
-    let from_agent = delivery.from_agent in
-    let mention = delivery.mention in
-    let message = delivery.content in
-    let _ =
-      Session.push_message registry ~from_agent ~content:message ~mention
-    in
-    let notification_fields =
-      [ ("type", `String "masc/broadcast")
-      ; ("from", `String from_agent)
-      ; ("content", `String message)
-      ; ("mention", Json_util.string_opt_to_json mention)
-      ; ("timestamp", `Float (Time_compat.now ()))
-      ]
-    in
-    let notification =
-      `Assoc (Otel_trace_context.inject_json notification_fields trace_context)
-    in
-    Mcp_server.sse_broadcast state notification;
-    Subscriptions.push_event_to_sessions notification;
-    (match mention with
-     | Some target ->
-       Notify.notify_mention ~from_agent ~target_agent:target ~message ()
-     | None -> ());
-    Audit_log.log_broadcast config ~agent_id:from_agent ~message_preview:message ();
-    Some (Tool_result.ok ~tool_name ~start_time delivery.rendered)
+    match delivery with
+    | Error detail ->
+      Some
+        (Tool_result.error
+           ~failure_class:Tool_result.Runtime_failure
+           ~tool_name
+           ~start_time
+           (Printf.sprintf "Broadcast was not persisted: %s" detail))
+    | Ok delivery ->
+      let from_agent = delivery.from_agent in
+      let mention = delivery.mention in
+      let message = delivery.content in
+      let _ =
+        Session.push_message registry ~from_agent ~content:message ~mention
+      in
+      let notification_fields =
+        [ ("type", `String "masc/broadcast")
+        ; ("from", `String from_agent)
+        ; ("content", `String message)
+        ; ("mention", Json_util.string_opt_to_json mention)
+        ; ("timestamp", `Float (Time_compat.now ()))
+        ]
+      in
+      let notification =
+        `Assoc (Otel_trace_context.inject_json notification_fields trace_context)
+      in
+      Mcp_server.sse_broadcast state notification;
+      Subscriptions.push_event_to_sessions notification;
+      (match mention with
+       | Some target ->
+         Notify.notify_mention ~from_agent ~target_agent:target ~message ()
+       | None -> ());
+      Audit_log.log_broadcast config ~agent_id:from_agent ~message_preview:message ();
+      Some (Tool_result.ok ~tool_name ~start_time delivery.rendered)
 
 (** masc_messages — retrieve recent messages *)
 let handle_messages ~tool_name ~start_time (ctx : context) : tool_result option =

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -79,8 +79,9 @@ let execute_workspace_action (ctx : 'a context) (request : action_request) =
         require_payload_field request.payload "message"
           "payload.message is required"
       in
-      let result = Workspace.broadcast ctx.config ~from_agent:request.actor ~content:message in
-      workspace_action_result request (`String result.rendered)
+      (match Workspace.broadcast ctx.config ~from_agent:request.actor ~content:message with
+       | Ok result -> workspace_action_result request (`String result.rendered)
+       | Error error -> Error (Workspace.broadcast_error_to_string error))
   | "namespace_pause" ->
       let* () = validate_target_type Operator_action_constants.Workspace request in
       let reason =

--- a/lib/server/masc_grpc_service.ml
+++ b/lib/server/masc_grpc_service.ml
@@ -71,8 +71,13 @@ let handle_broadcast (workspace_config : Workspace_utils_backend_setup.config) (
           in
           mention_prefix ^ " " ^ req.message)
       in
-      let _msg = Workspace.broadcast workspace_config ~from_agent:req.agent_name ~content in
-      T.BroadcastResponse.{ success = true; seq = now_ms () }
+      (match Workspace.broadcast workspace_config ~from_agent:req.agent_name ~content with
+       | Ok _ -> T.BroadcastResponse.{ success = true; seq = now_ms () }
+       | Error error ->
+         Log.Transport.error
+           "gRPC broadcast was not persisted: %s"
+           (Workspace.broadcast_error_to_string error);
+         T.BroadcastResponse.{ success = false; seq = 0L })
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | exn ->

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1210,11 +1210,71 @@ let start_keeper_loops_owned
      fanout so one broad announcement cannot create a fleet-wide turn storm.
      Board signals have their own capped keeper wake path above. *)
   let broadcast_mention_handler =
-    fun mention ->
-    match broadcast_mention_wakeup_action mention with
+    fun (delivery : Workspace_broadcast.broadcast_delivery) ->
+    match broadcast_mention_wakeup_action delivery.mention with
     | `Wake_keeper target ->
-      Keeper_keepalive.wakeup_keeper ~base_path:(Mcp_server.workspace_config state).base_path target;
-      Log.Keeper.info "broadcast mention → wakeup keeper %s" target
+      let base_path = (Mcp_server.workspace_config state).base_path in
+      let config = Mcp_server.workspace_config state in
+      let delivery_key =
+        Keeper_chat_delivery_identity.Request_id.of_string delivery.request_id
+        |> Result.map (fun request_id ->
+          Keeper_chat_delivery_identity.Workspace_message request_id)
+      in
+      (match
+         ( Keeper_meta_store.read_meta config target
+         , Keeper_identity.Keeper_id.of_string target
+         , delivery_key )
+       with
+       | Ok (Some _), Some target_id, Ok delivery_key ->
+         let speaker : Keeper_chat_store.speaker =
+           { speaker_id = Some delivery.from_agent
+           ; speaker_name = Some delivery.from_agent
+           ; speaker_authority = Keeper_chat_store.External
+           }
+         in
+         (match
+            Keeper_chat_store.append_user_message_once
+              ~base_dir:base_path
+              ~keeper_name:target
+              ~delivery_key
+              ~content:delivery.content
+              ~surface:Surface_ref.Agent
+              ~external_message_id:delivery.request_id
+              ~speaker
+              ~extra_mentions:[ target_id ]
+              ()
+          with
+          | Ok (Keeper_chat_store.Appended _ | Keeper_chat_store.Already_present _) ->
+            (match Keeper_registry.get ~base_path target with
+             | Some _ ->
+               Keeper_keepalive.wakeup_keeper ~base_path target;
+               Log.Keeper.info
+                 "broadcast mention delivered → wakeup keeper %s request_id=%s seq=%d"
+                 target delivery.request_id delivery.seq
+             | None ->
+               Log.Keeper.info
+                 "broadcast mention persisted for stopped keeper; wake deferred keeper=%s request_id=%s seq=%d"
+                 target delivery.request_id delivery.seq)
+          | Error message ->
+            Log.Keeper.error
+              "broadcast mention intake failed; wake suppressed keeper=%s request_id=%s seq=%d: %s"
+              target delivery.request_id delivery.seq message)
+       | Ok None, _, _ ->
+         Log.Keeper.warn
+           "broadcast mention target has no persisted Keeper metadata; delivery suppressed keeper=%s request_id=%s seq=%d"
+           target delivery.request_id delivery.seq
+       | Error message, _, _ ->
+         Log.Keeper.error
+           "broadcast mention target metadata is unavailable; delivery suppressed keeper=%s request_id=%s seq=%d: %s"
+           target delivery.request_id delivery.seq message
+       | Ok (Some _), None, _ ->
+         Log.Keeper.error
+           "broadcast mention target identity is invalid; delivery suppressed keeper=%s request_id=%s seq=%d"
+           target delivery.request_id delivery.seq
+       | Ok (Some _), Some _, Error message ->
+         Log.Keeper.error
+           "broadcast mention request identity is invalid; delivery suppressed keeper=%s request_id=%s seq=%d: %s"
+           target delivery.request_id delivery.seq message)
     | `Suppress_no_target ->
       Log.Keeper.info
         "broadcast without mention -> keeper wakeup suppressed (passive fanout)"

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -157,10 +157,73 @@ let broadcast_mention_wakeup_action = function
   | Some target when String.trim target <> "" -> `Wake_keeper target
   | Some _ | None -> `Suppress_no_target
 
+type broadcast_mention_delivery_outcome =
+  | Broadcast_without_target
+  | Broadcast_target_missing_meta of string
+  | Broadcast_target_meta_unavailable of string * string
+  | Broadcast_target_invalid of string
+  | Broadcast_request_invalid of string * string
+  | Broadcast_intake_failed of string * string
+  | Broadcast_persisted_and_woken of string
+  | Broadcast_persisted_wake_deferred of string
+
+let deliver_broadcast_mention
+      ~config
+      ~base_path
+      ~is_running
+      ~wakeup
+      (delivery : Workspace_broadcast.broadcast_delivery)
+  =
+  match broadcast_mention_wakeup_action delivery.mention with
+  | `Suppress_no_target -> Broadcast_without_target
+  | `Wake_keeper target ->
+    let delivery_key =
+      Keeper_chat_delivery_identity.Request_id.of_string delivery.request_id
+      |> Result.map (fun request_id ->
+        Keeper_chat_delivery_identity.Workspace_message request_id)
+    in
+    (match
+       ( Keeper_meta_store.read_meta config target
+       , Keeper_identity.Keeper_id.of_string target
+       , delivery_key )
+     with
+     | Ok (Some _), Some target_id, Ok delivery_key ->
+       let speaker : Keeper_chat_store.speaker =
+         { speaker_id = Some delivery.from_agent
+         ; speaker_name = Some delivery.from_agent
+         ; speaker_authority = Keeper_chat_store.External
+         }
+       in
+       (match
+          Keeper_chat_store.append_user_message_once
+            ~base_dir:base_path
+            ~keeper_name:target
+            ~delivery_key
+            ~content:delivery.content
+            ~surface:Surface_ref.Agent
+            ~external_message_id:delivery.request_id
+            ~speaker
+            ~extra_mentions:[ target_id ]
+            ()
+        with
+        | Ok (Keeper_chat_store.Appended _ | Keeper_chat_store.Already_present _) ->
+          if is_running target
+          then (
+            wakeup target;
+            Broadcast_persisted_and_woken target)
+          else Broadcast_persisted_wake_deferred target
+        | Error message -> Broadcast_intake_failed (target, message))
+     | Ok None, _, _ -> Broadcast_target_missing_meta target
+     | Error message, _, _ -> Broadcast_target_meta_unavailable (target, message)
+     | Ok (Some _), None, _ -> Broadcast_target_invalid target
+     | Ok (Some _), Some _, Error message ->
+       Broadcast_request_invalid (target, message))
+
 module Projection_for_testing = struct
   let autoboot_proactive_warmup_sec = autoboot_proactive_warmup_sec
   let board_sse_event_params = board_sse_event_params
   let broadcast_mention_wakeup_action = broadcast_mention_wakeup_action
+  let deliver_broadcast_mention = deliver_broadcast_mention
 end
 
 let fork_logged_fiber = Server_bootstrap_loops_fiber.fork_logged_fiber
@@ -1211,73 +1274,48 @@ let start_keeper_loops_owned
      Board signals have their own capped keeper wake path above. *)
   let broadcast_mention_handler =
     fun (delivery : Workspace_broadcast.broadcast_delivery) ->
-    match broadcast_mention_wakeup_action delivery.mention with
-    | `Wake_keeper target ->
-      let base_path = (Mcp_server.workspace_config state).base_path in
-      let config = Mcp_server.workspace_config state in
-      let delivery_key =
-        Keeper_chat_delivery_identity.Request_id.of_string delivery.request_id
-        |> Result.map (fun request_id ->
-          Keeper_chat_delivery_identity.Workspace_message request_id)
-      in
-      (match
-         ( Keeper_meta_store.read_meta config target
-         , Keeper_identity.Keeper_id.of_string target
-         , delivery_key )
-       with
-       | Ok (Some _), Some target_id, Ok delivery_key ->
-         let speaker : Keeper_chat_store.speaker =
-           { speaker_id = Some delivery.from_agent
-           ; speaker_name = Some delivery.from_agent
-           ; speaker_authority = Keeper_chat_store.External
-           }
-         in
-         (match
-            Keeper_chat_store.append_user_message_once
-              ~base_dir:base_path
-              ~keeper_name:target
-              ~delivery_key
-              ~content:delivery.content
-              ~surface:Surface_ref.Agent
-              ~external_message_id:delivery.request_id
-              ~speaker
-              ~extra_mentions:[ target_id ]
-              ()
-          with
-          | Ok (Keeper_chat_store.Appended _ | Keeper_chat_store.Already_present _) ->
-            (match Keeper_registry.get ~base_path target with
-             | Some _ ->
-               Keeper_keepalive.wakeup_keeper ~base_path target;
-               Log.Keeper.info
-                 "broadcast mention delivered → wakeup keeper %s request_id=%s seq=%d"
-                 target delivery.request_id delivery.seq
-             | None ->
-               Log.Keeper.info
-                 "broadcast mention persisted for stopped keeper; wake deferred keeper=%s request_id=%s seq=%d"
-                 target delivery.request_id delivery.seq)
-          | Error message ->
-            Log.Keeper.error
-              "broadcast mention intake failed; wake suppressed keeper=%s request_id=%s seq=%d: %s"
-              target delivery.request_id delivery.seq message)
-       | Ok None, _, _ ->
-         Log.Keeper.warn
-           "broadcast mention target has no persisted Keeper metadata; delivery suppressed keeper=%s request_id=%s seq=%d"
-           target delivery.request_id delivery.seq
-       | Error message, _, _ ->
-         Log.Keeper.error
-           "broadcast mention target metadata is unavailable; delivery suppressed keeper=%s request_id=%s seq=%d: %s"
-           target delivery.request_id delivery.seq message
-       | Ok (Some _), None, _ ->
-         Log.Keeper.error
-           "broadcast mention target identity is invalid; delivery suppressed keeper=%s request_id=%s seq=%d"
-           target delivery.request_id delivery.seq
-       | Ok (Some _), Some _, Error message ->
-         Log.Keeper.error
-           "broadcast mention request identity is invalid; delivery suppressed keeper=%s request_id=%s seq=%d: %s"
-           target delivery.request_id delivery.seq message)
-    | `Suppress_no_target ->
+    let config = Mcp_server.workspace_config state in
+    let base_path = config.base_path in
+    match
+      deliver_broadcast_mention
+        ~config
+        ~base_path
+        ~is_running:(fun target ->
+          Option.is_some (Keeper_registry.get ~base_path target))
+        ~wakeup:(Keeper_keepalive.wakeup_keeper ~base_path)
+        delivery
+    with
+    | Broadcast_without_target ->
       Log.Keeper.info
         "broadcast without mention -> keeper wakeup suppressed (passive fanout)"
+    | Broadcast_persisted_and_woken target ->
+      Log.Keeper.info
+        "broadcast mention delivered → wakeup keeper %s request_id=%s seq=%d"
+        target delivery.request_id delivery.seq
+    | Broadcast_persisted_wake_deferred target ->
+      Log.Keeper.info
+        "broadcast mention persisted for stopped keeper; wake deferred keeper=%s request_id=%s seq=%d"
+        target delivery.request_id delivery.seq
+    | Broadcast_target_missing_meta target ->
+      Log.Keeper.warn
+        "broadcast mention target has no persisted Keeper metadata; delivery suppressed keeper=%s request_id=%s seq=%d"
+        target delivery.request_id delivery.seq
+    | Broadcast_target_meta_unavailable (target, message) ->
+      Log.Keeper.error
+        "broadcast mention target metadata is unavailable; delivery suppressed keeper=%s request_id=%s seq=%d: %s"
+        target delivery.request_id delivery.seq message
+    | Broadcast_target_invalid target ->
+      Log.Keeper.error
+        "broadcast mention target identity is invalid; delivery suppressed keeper=%s request_id=%s seq=%d"
+        target delivery.request_id delivery.seq
+    | Broadcast_request_invalid (target, message) ->
+      Log.Keeper.error
+        "broadcast mention request identity is invalid; delivery suppressed keeper=%s request_id=%s seq=%d: %s"
+        target delivery.request_id delivery.seq message
+    | Broadcast_intake_failed (target, message) ->
+      Log.Keeper.error
+        "broadcast mention intake failed; wake suppressed keeper=%s request_id=%s seq=%d: %s"
+        target delivery.request_id delivery.seq message
   in
   Workspace_broadcast.set_on_broadcast_mention broadcast_mention_handler;
   (* Orchestrator needs synchronous registration for shutdown hook *)

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -170,15 +170,18 @@ type broadcast_mention_delivery_outcome =
 let resolve_broadcast_mention_target ~config target =
   match Keeper_meta_store.read_meta config target with
   | Error detail -> Error detail
-  | Ok (Some _) -> Ok (Some target)
+  | Ok (Some meta) -> Ok (Some (target, meta))
   | Ok None ->
     (match Keeper_identity_binding.resolve ~config ~agent_name:target with
      | Keeper_identity_binding.Unique keeper_name ->
        (match Keeper_meta_store.read_meta config keeper_name with
-        | Ok (Some _) -> Ok (Some keeper_name)
+        | Ok (Some meta) -> Ok (Some (keeper_name, meta))
         | Ok None -> Ok None
         | Error detail -> Error detail)
-     | Keeper_identity_binding.Not_found -> Ok None
+     | Keeper_identity_binding.Not_found ->
+       Keeper_meta_store.persisted_keeper_for_mention_target
+         config
+         ~mention_target:target
      | Keeper_identity_binding.Ambiguous candidates ->
        Error
          (Printf.sprintf
@@ -206,14 +209,19 @@ let deliver_broadcast_mention
      | Error message ->
        Broadcast_target_meta_unavailable (requested_target, message)
      | Ok None -> Broadcast_target_missing_meta requested_target
-     | Ok (Some target) ->
+     | Ok (Some (target, meta)) ->
        (match Keeper_identity.Keeper_id.of_string target, delivery_key with
-        | Some target_id, Ok delivery_key ->
+        | Some _target_id, Ok delivery_key ->
        let speaker : Keeper_chat_store.speaker =
          { speaker_id = Some delivery.from_agent
          ; speaker_name = Some delivery.from_agent
          ; speaker_authority = Keeper_chat_store.External
          }
+       in
+       let mention_ids =
+         target :: meta.Keeper_meta_contract.mention_targets
+         |> List.filter_map Keeper_identity.Keeper_id.of_string
+         |> List.sort_uniq Keeper_identity.Keeper_id.compare
        in
        (match
           Keeper_chat_store.append_user_message_once
@@ -224,7 +232,7 @@ let deliver_broadcast_mention
             ~surface:Surface_ref.Agent
             ~external_message_id:delivery.request_id
             ~speaker
-            ~extra_mentions:[ target_id ]
+            ~extra_mentions:mention_ids
             ()
         with
         | Ok (Keeper_chat_store.Appended _ | Keeper_chat_store.Already_present _) ->

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -167,6 +167,26 @@ type broadcast_mention_delivery_outcome =
   | Broadcast_persisted_and_woken of string
   | Broadcast_persisted_wake_deferred of string
 
+let resolve_broadcast_mention_target ~config target =
+  match Keeper_meta_store.read_meta config target with
+  | Error detail -> Error detail
+  | Ok (Some _) -> Ok (Some target)
+  | Ok None ->
+    (match Keeper_identity_binding.resolve ~config ~agent_name:target with
+     | Keeper_identity_binding.Unique keeper_name ->
+       (match Keeper_meta_store.read_meta config keeper_name with
+        | Ok (Some _) -> Ok (Some keeper_name)
+        | Ok None -> Ok None
+        | Error detail -> Error detail)
+     | Keeper_identity_binding.Not_found -> Ok None
+     | Keeper_identity_binding.Ambiguous candidates ->
+       Error
+         (Printf.sprintf
+            "broadcast mention agent identity %S is ambiguous: %s"
+            target
+            (String.concat ", " candidates))
+     | Keeper_identity_binding.Lookup_failed detail -> Error detail)
+
 let deliver_broadcast_mention
       ~config
       ~base_path
@@ -176,18 +196,19 @@ let deliver_broadcast_mention
   =
   match broadcast_mention_wakeup_action delivery.mention with
   | `Suppress_no_target -> Broadcast_without_target
-  | `Wake_keeper target ->
+  | `Wake_keeper requested_target ->
     let delivery_key =
       Keeper_chat_delivery_identity.Request_id.of_string delivery.request_id
       |> Result.map (fun request_id ->
         Keeper_chat_delivery_identity.Workspace_message request_id)
     in
-    (match
-       ( Keeper_meta_store.read_meta config target
-       , Keeper_identity.Keeper_id.of_string target
-       , delivery_key )
-     with
-     | Ok (Some _), Some target_id, Ok delivery_key ->
+    (match resolve_broadcast_mention_target ~config requested_target with
+     | Error message ->
+       Broadcast_target_meta_unavailable (requested_target, message)
+     | Ok None -> Broadcast_target_missing_meta requested_target
+     | Ok (Some target) ->
+       (match Keeper_identity.Keeper_id.of_string target, delivery_key with
+        | Some target_id, Ok delivery_key ->
        let speaker : Keeper_chat_store.speaker =
          { speaker_id = Some delivery.from_agent
          ; speaker_name = Some delivery.from_agent
@@ -213,11 +234,8 @@ let deliver_broadcast_mention
             Broadcast_persisted_and_woken target)
           else Broadcast_persisted_wake_deferred target
         | Error message -> Broadcast_intake_failed (target, message))
-     | Ok None, _, _ -> Broadcast_target_missing_meta target
-     | Error message, _, _ -> Broadcast_target_meta_unavailable (target, message)
-     | Ok (Some _), None, _ -> Broadcast_target_invalid target
-     | Ok (Some _), Some _, Error message ->
-       Broadcast_request_invalid (target, message))
+        | None, _ -> Broadcast_target_invalid target
+        | Some _, Error message -> Broadcast_request_invalid (target, message)))
 
 module Projection_for_testing = struct
   let autoboot_proactive_warmup_sec = autoboot_proactive_warmup_sec

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -168,13 +168,13 @@ type broadcast_mention_delivery_outcome =
   | Broadcast_persisted_wake_deferred of string
 
 let resolve_broadcast_mention_target ~config target =
-  match Keeper_meta_store.read_meta config target with
+  match Keeper_meta_store.read_effective_meta config target with
   | Error detail -> Error detail
   | Ok (Some meta) -> Ok (Some (target, meta))
   | Ok None ->
     (match Keeper_identity_binding.resolve ~config ~agent_name:target with
      | Keeper_identity_binding.Unique keeper_name ->
-       (match Keeper_meta_store.read_meta config keeper_name with
+       (match Keeper_meta_store.read_effective_meta config keeper_name with
         | Ok (Some meta) -> Ok (Some (keeper_name, meta))
         | Ok None -> Ok None
         | Error detail -> Error detail)

--- a/lib/server/server_bootstrap_loops.mli
+++ b/lib/server/server_bootstrap_loops.mli
@@ -119,6 +119,16 @@ val keeper_persistence_claim_error_to_string :
 val keeper_persistence_start_error_to_string :
   keeper_persistence_start_error -> string
 
+type broadcast_mention_delivery_outcome =
+  | Broadcast_without_target
+  | Broadcast_target_missing_meta of string
+  | Broadcast_target_meta_unavailable of string * string
+  | Broadcast_target_invalid of string
+  | Broadcast_request_invalid of string * string
+  | Broadcast_intake_failed of string * string
+  | Broadcast_persisted_and_woken of string
+  | Broadcast_persisted_wake_deferred of string
+
 val start_keeper_loops :
   claimed_persistence:claimed_keeper_persistence ->
   sw:Eio.Switch.t ->
@@ -145,6 +155,14 @@ module For_testing : sig
 
   val broadcast_mention_wakeup_action :
     string option -> [ `Suppress_no_target | `Wake_keeper of string ]
+
+  val deliver_broadcast_mention :
+    config:Workspace.config ->
+    base_path:string ->
+    is_running:(string -> bool) ->
+    wakeup:(string -> unit) ->
+    Workspace_broadcast.broadcast_delivery ->
+    broadcast_mention_delivery_outcome
 
   val reset_keeper_persistence_lifecycle : unit -> unit
 

--- a/lib/server/server_routes_http_dashboard_handlers.ml
+++ b/lib/server/server_routes_http_dashboard_handlers.ml
@@ -30,8 +30,10 @@ let handle_broadcast state agent_name reqd body_str =
     match Json_util.assoc_member_opt "message" json with
     | Some (`String message) ->
         let config = (Mcp_server.workspace_config state) in
-        let _ = Workspace.broadcast config ~from_agent:agent_name ~content:message in
-        reply true None
+        (match Workspace.broadcast config ~from_agent:agent_name ~content:message with
+         | Ok _ -> reply true None
+         | Error error ->
+           reply false (Some (Workspace.broadcast_error_to_string error)))
     | Some `Null -> reply false (Some "missing required field: message")
     | None | Some _ -> reply false (Some "field 'message' must be a string")
   with

--- a/lib/workspace/workspace_broadcast.ml
+++ b/lib/workspace/workspace_broadcast.ml
@@ -6,7 +6,11 @@
 open Masc_domain
 open Workspace_utils
 
-exception Broadcast_not_persisted of string
+type broadcast_error = Broadcast_not_persisted of string
+
+let broadcast_error_to_string = function
+  | Broadcast_not_persisted detail -> detail
+;;
 
 type broadcast_delivery =
   { request_id : string
@@ -65,6 +69,8 @@ let on_broadcast_mention : mention_handler Atomic.t =
 
 let set_on_broadcast_mention handler =
   Atomic.set on_broadcast_mention handler
+
+let write_json_commit = Atomic.make write_json_commit_result
 
 let broadcast ?trace_context ?(msg_type = "broadcast") config ~from_agent ~content =
   let started_at = Time_compat.now () in
@@ -165,13 +171,12 @@ let broadcast ?trace_context ?(msg_type = "broadcast") config ~from_agent ~conte
     ; msg_type = safe_msg_type
     }
   in
-  (match write_json_commit_result config msg_file (message_to_yojson msg) with
+  (match (Atomic.get write_json_commit) config msg_file (message_to_yojson msg) with
    | Error message ->
      Log.Misc.error
        "workspace broadcast authoritative write failed request_id=%s seq=%d: %s"
        request_id seq message;
-     observe safe_msg_type;
-     raise (Broadcast_not_persisted message)
+     Error (Broadcast_not_persisted message)
    | Ok { mirror_error } ->
      Option.iter
        (fun message ->
@@ -197,9 +202,11 @@ let broadcast ?trace_context ?(msg_type = "broadcast") config ~from_agent ~conte
         Log.Misc.warn "on_broadcast_mention callback failed: %s"
           (Printexc.to_string exn));
      observe safe_msg_type;
-     delivery)
+     Ok delivery)
 
 module For_testing = struct
   let replace_on_broadcast_mention handler =
     Atomic.exchange on_broadcast_mention handler
+
+  let replace_write_json_commit handler = Atomic.exchange write_json_commit handler
 end

--- a/lib/workspace/workspace_broadcast.ml
+++ b/lib/workspace/workspace_broadcast.ml
@@ -6,8 +6,12 @@
 open Masc_domain
 open Workspace_utils
 
+exception Broadcast_not_persisted of string
+
 type broadcast_delivery =
-  { rendered : string
+  { request_id : string
+  ; seq : int
+  ; rendered : string
   ; from_agent : string
   ; content : string
   ; mention : string option
@@ -54,10 +58,10 @@ let emit_message_activity config ~from_agent ~content ~mention
 let broadcast_channel config =
   Printf.sprintf "broadcast:%s:default" (project_prefix config)
 
-type mention_handler = string option -> unit
+type mention_handler = broadcast_delivery -> unit
 
 let on_broadcast_mention : mention_handler Atomic.t =
-  Atomic.make (fun _mention -> ())
+  Atomic.make (fun _delivery -> ())
 
 let set_on_broadcast_mention handler =
   Atomic.set on_broadcast_mention handler
@@ -124,6 +128,7 @@ let broadcast ?trace_context ?(msg_type = "broadcast") config ~from_agent ~conte
     else (content, msg_type)
   in
   let seq = Workspace_state.next_seq config in
+  let request_id = Random_id.prefixed ~prefix:"wmsg-" ~bytes:16 in
   let mention = pre_extract_mention in
   let safe_content = sanitize_message content in
   let safe_agent = sanitize_agent_name from_agent in
@@ -144,32 +149,55 @@ let broadcast ?trace_context ?(msg_type = "broadcast") config ~from_agent ~conte
   } in
   let msg_file =
     Filename.concat (messages_dir config)
-      (Printf.sprintf "%09d_%s_broadcast.json" seq (safe_filename from_agent))
+      (Printf.sprintf
+         "%09d_%s_%s_broadcast.json"
+         seq
+         (safe_filename from_agent)
+         request_id)
   in
-  write_json config msg_file (message_to_yojson msg);
-  (match backend_publish config ~channel:(broadcast_channel config)
-      ~message:(Yojson.Safe.to_string (message_to_yojson msg)) with
-   | Ok _ -> ()
-   | Error (Backend_types.BackendNotSupported msg) when String.starts_with ~prefix:"FileSystem backend" msg ->
-       Log.Misc.debug "broadcast publish skipped: %s" msg
-   | Error ((Backend_types.BackendNotSupported _
-            | Backend_types.NotFound _ | Backend_types.AlreadyExists _
-            | Backend_types.IOError _ | Backend_types.InvalidKey _
-            | Backend_types.ConnectionFailed _) as e) ->
-       Log.Misc.error "broadcast publish failed: %s" (Backend_types.show_error e));
-  emit_message_activity config ~from_agent:safe_agent ~content:safe_content
-    ~mention ();
-  (try (Atomic.get on_broadcast_mention) mention
-   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-     Log.Misc.warn "on_broadcast_mention callback failed: %s"
-       (Printexc.to_string exn));
-  observe safe_msg_type;
-  { rendered = Printf.sprintf "\xF0\x9F\x93\xA2 [%s] %s" safe_agent safe_content
-  ; from_agent = safe_agent
-  ; content = safe_content
-  ; mention
-  ; msg_type = safe_msg_type
-  }
+  let delivery =
+    { request_id
+    ; seq
+    ; rendered = Printf.sprintf "\xF0\x9F\x93\xA2 [%s] %s" safe_agent safe_content
+    ; from_agent = safe_agent
+    ; content = safe_content
+    ; mention
+    ; msg_type = safe_msg_type
+    }
+  in
+  (match write_json_commit_result config msg_file (message_to_yojson msg) with
+   | Error message ->
+     Log.Misc.error
+       "workspace broadcast authoritative write failed request_id=%s seq=%d: %s"
+       request_id seq message;
+     observe safe_msg_type;
+     raise (Broadcast_not_persisted message)
+   | Ok { mirror_error } ->
+     Option.iter
+       (fun message ->
+          Log.Misc.warn
+            "workspace broadcast local mirror write failed request_id=%s seq=%d: %s"
+            request_id seq message)
+       mirror_error;
+     (match backend_publish config ~channel:(broadcast_channel config)
+         ~message:(Yojson.Safe.to_string (message_to_yojson msg)) with
+      | Ok _ -> ()
+      | Error (Backend_types.BackendNotSupported msg)
+        when String.starts_with ~prefix:"FileSystem backend" msg ->
+        Log.Misc.debug "broadcast publish skipped: %s" msg
+      | Error ((Backend_types.BackendNotSupported _
+               | Backend_types.NotFound _ | Backend_types.AlreadyExists _
+               | Backend_types.IOError _ | Backend_types.InvalidKey _
+               | Backend_types.ConnectionFailed _) as e) ->
+        Log.Misc.error "broadcast publish failed: %s" (Backend_types.show_error e));
+     emit_message_activity config ~from_agent:safe_agent ~content:safe_content
+       ~mention ();
+     (try (Atomic.get on_broadcast_mention) delivery
+      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+        Log.Misc.warn "on_broadcast_mention callback failed: %s"
+          (Printexc.to_string exn));
+     observe safe_msg_type;
+     delivery)
 
 module For_testing = struct
   let replace_on_broadcast_mention handler =

--- a/lib/workspace/workspace_broadcast.mli
+++ b/lib/workspace/workspace_broadcast.mli
@@ -2,7 +2,9 @@
     accompanying message-activity event. *)
 
 
-exception Broadcast_not_persisted of string
+type broadcast_error = Broadcast_not_persisted of string
+
+val broadcast_error_to_string : broadcast_error -> string
 
 type broadcast_delivery =
   { request_id : string
@@ -32,10 +34,24 @@ val set_on_broadcast_mention : (broadcast_delivery -> unit) -> unit
 val broadcast : ?trace_context:string ->
            ?msg_type:string ->
            Workspace_utils_backend_setup.config ->
-           from_agent:string -> content:string -> broadcast_delivery
+           from_agent:string -> content:string ->
+           (broadcast_delivery, broadcast_error) result
 
 module For_testing : sig
   (** Replace the handler and return the prior one. Test isolation only. *)
   val replace_on_broadcast_mention :
     (broadcast_delivery -> unit) -> broadcast_delivery -> unit
+
+  (** Replace the authoritative write boundary and return the prior function.
+      Tests use this to prove failure fanout without depending on filesystem
+      permission behavior. *)
+  val replace_write_json_commit :
+    (Workspace_utils_backend_setup.config ->
+     string ->
+     Yojson.Safe.t ->
+     (Workspace_utils.write_json_commit, string) result) ->
+    (Workspace_utils_backend_setup.config ->
+     string ->
+     Yojson.Safe.t ->
+     (Workspace_utils.write_json_commit, string) result)
 end

--- a/lib/workspace/workspace_broadcast.mli
+++ b/lib/workspace/workspace_broadcast.mli
@@ -2,8 +2,12 @@
     accompanying message-activity event. *)
 
 
+exception Broadcast_not_persisted of string
+
 type broadcast_delivery =
-  { rendered : string
+  { request_id : string
+  ; seq : int
+  ; rendered : string
   ; from_agent : string
   ; content : string
   ; mention : string option
@@ -20,8 +24,10 @@ val emit_message_activity : Workspace_utils_backend_setup.config ->
            ?evidence_refs:string list -> unit -> unit
 val broadcast_channel : Workspace_utils_backend_setup.config -> string
 
-(** Atomically replace the process-wide mention notification handler. *)
-val set_on_broadcast_mention : (string option -> unit) -> unit
+(** Atomically replace the process-wide committed-broadcast notification
+    handler. The handler runs only after the authoritative workspace message
+    write commits. *)
+val set_on_broadcast_mention : (broadcast_delivery -> unit) -> unit
 
 val broadcast : ?trace_context:string ->
            ?msg_type:string ->
@@ -31,5 +37,5 @@ val broadcast : ?trace_context:string ->
 module For_testing : sig
   (** Replace the handler and return the prior one. Test isolation only. *)
   val replace_on_broadcast_mention :
-    (string option -> unit) -> string option -> unit
+    (broadcast_delivery -> unit) -> broadcast_delivery -> unit
 end

--- a/lib/workspace/workspace_hooks.ml
+++ b/lib/workspace/workspace_hooks.ml
@@ -204,13 +204,15 @@ let tool_assigned_fn
      string) Atomic.t
   = Atomic.make (fun ~agent_id:_ ~profile:_ ~tool_list:_ ?config_hash:_ ?reason:_ () -> "")
 
-(** Wall-clock latency of [Workspace_broadcast.broadcast] including
+(** Wall-clock latency of a successfully committed
+    [Workspace_broadcast.broadcast], including
     [next_seq] (state.json file lock + read + write), agent.json read
     for the cache-invariant check, msg.json write, [backend_publish],
     [emit_message_activity], and the [on_broadcast_mention] callback.
     Labelled by [msg_type] so [cache_invalidated] follow-ups (which
     skip the agent.json read + use the rewritten content) are
-    distinguishable from regular broadcasts.  Default no-op; emit
+    distinguishable from regular broadcasts. Authoritative write failures do
+    not emit this success observation. Default no-op; emit
     lives in [lib/workspace.ml] to avoid a [masc_workspace → Otel_metric_store] dep
     cycle. *)
 let workspace_broadcast_observed_fn

--- a/lib/workspace/workspace_hooks.mli
+++ b/lib/workspace/workspace_hooks.mli
@@ -92,13 +92,14 @@ val tool_assigned_fn : (agent_id:string ->
             tool_list:string list ->
             ?config_hash:string -> ?reason:string -> unit -> string)
            Atomic.t
-(** Fires once per [Workspace_broadcast.broadcast] return, with the wall-clock
+(** Fires once per successful [Workspace_broadcast.broadcast] commit, with the wall-clock
     duration of the broadcast body (next_seq + agent.json read +
     msg.json write + activity emit + on_broadcast_mention).  Wired at
     startup ([lib/workspace.ml]) to a Otel_metric_store histogram
     [masc_workspace_broadcast_duration_seconds] labelled by [msg_type] so
     operators can compare regular broadcasts against
-    [cache_invalidated] / mention follow-ups. *)
+    [cache_invalidated] / mention follow-ups. Authoritative write failures are
+    excluded rather than merged into the success latency distribution. *)
 val workspace_broadcast_observed_fn :
   (msg_type:string -> elapsed_s:float -> unit) Atomic.t
 

--- a/lib/workspace/workspace_lifecycle.ml
+++ b/lib/workspace/workspace_lifecycle.ml
@@ -29,6 +29,16 @@ let agent_parse_error_snapshot ~agent_name ~agent_file =
       if raw_head = "" then `Null else `String raw_head);
   ]
 
+let log_lifecycle_broadcast_result ~operation ~agent_name = function
+  | Ok _ -> ()
+  | Error error ->
+    Log.Workspace.error
+      "agent lifecycle committed but broadcast was not persisted operation=%s agent=%s detail=%s"
+      operation
+      agent_name
+      (broadcast_error_to_string error)
+;;
+
 (** Bind agent session - with auto-generated nickname and metadata *)
 let bind_session config ~agent_name ?(agent_type_override=None) ~capabilities
     ?(pid=None) ?(hostname=None) ?(tty=None)
@@ -106,11 +116,12 @@ let bind_session config ~agent_name ?(agent_type_override=None) ~capabilities
            let agents = nickname :: List.filter ((<>) nickname) s.active_agents in
            { s with active_agents = agents }
          ) in
-         let _ =
-           broadcast config ~from_agent:nickname
-             ~msg_type:"session_rebound"
-             ~content:(Printf.sprintf "%s rebound the namespace session" nickname)
-         in
+         broadcast config ~from_agent:nickname
+           ~msg_type:"session_rebound"
+           ~content:(Printf.sprintf "%s rebound the namespace session" nickname)
+         |> log_lifecycle_broadcast_result
+              ~operation:"session_rebound"
+              ~agent_name:nickname;
          log_event config (`Assoc [
            ("type", `String "agent_session_bound");
            ("agent", `String nickname);
@@ -175,11 +186,12 @@ let bind_session config ~agent_name ?(agent_type_override=None) ~capabilities
   ) in
 
   (* Broadcast session binding *)
-  let _ =
-    broadcast config ~from_agent:nickname
-      ~msg_type:"session_bound"
-      ~content:(Printf.sprintf "%s bound the namespace session" nickname)
-  in
+  broadcast config ~from_agent:nickname
+    ~msg_type:"session_bound"
+    ~content:(Printf.sprintf "%s bound the namespace session" nickname)
+  |> log_lifecycle_broadcast_result
+       ~operation:"session_bound"
+       ~agent_name:nickname;
 
   (* Log event with metadata *)
   log_event config (`Assoc [
@@ -241,11 +253,12 @@ let end_session config ~agent_name =
       { s with active_agents = List.filter ((<>) actual_name) s.active_agents }
     ) in
 
-    let _ =
-      broadcast config ~from_agent:"system"
-        ~msg_type:"session_ended"
-        ~content:(Printf.sprintf "%s ended the namespace session" actual_name)
-    in
+    broadcast config ~from_agent:"system"
+      ~msg_type:"session_ended"
+      ~content:(Printf.sprintf "%s ended the namespace session" actual_name)
+    |> log_lifecycle_broadcast_result
+         ~operation:"session_ended"
+         ~agent_name:actual_name;
 
     (* Log event *)
     log_event config (`Assoc [

--- a/lib/workspace/workspace_task_create.ml
+++ b/lib/workspace/workspace_task_create.ml
@@ -358,7 +358,14 @@ let batch_add_tasks_internal_with_result ?created_by config tasks =
                     (List.length added_tasks)
                     summary
                 in
-                let _ = broadcast config ~from_agent:actor ~content:msg in
+                (match broadcast config ~from_agent:actor ~content:msg with
+                 | Ok _ -> ()
+                 | Error error ->
+                   Log.Workspace.error
+                     "batch task creation committed but broadcast was not persisted actor=%s task_ids=%s detail=%s"
+                     actor
+                     summary
+                     (broadcast_error_to_string error));
                 let count = List.length added_tasks in
                 let task_ids = List.map (fun (task : Masc_domain.task) -> task.id) added_tasks in
                 let summary = Printf.sprintf "Added %d tasks: %s" count summary in

--- a/lib/workspace/workspace_task_transitions.ml
+++ b/lib/workspace/workspace_task_transitions.ml
@@ -520,10 +520,15 @@ let transition_task_outcome_r
            | None -> ()
            | Some content ->
              (try
-                let (_ : Workspace_broadcast.broadcast_delivery) =
-                  broadcast config ~from_agent:agent_name ~content
-                in
-                ()
+                match broadcast config ~from_agent:agent_name ~content with
+                | Ok _ -> ()
+                | Error error ->
+                  Log.TaskState.error
+                    "task transition committed but broadcast was not persisted task_id=%s agent=%s action=%s detail=%s"
+                    task_id
+                    agent_name
+                    action_s
+                    (broadcast_error_to_string error)
               with
               | Eio.Cancel.Cancelled _ as exn -> raise exn
               | exn ->

--- a/test/test_broadcast_wakeup_policy.ml
+++ b/test/test_broadcast_wakeup_policy.ml
@@ -19,10 +19,9 @@ let test_blank_is_passive () =
   | `Suppress_no_target -> ()
   | `Wake_keeper target -> failf "unexpected blank-target wake: %s" target
 
-let make_meta ?(mention_targets = []) name =
+let make_meta name =
   match Masc_test_deps.meta_of_json_fixture (`Assoc [ "name", `String name ]) with
-  | Ok meta ->
-    { meta with Keeper_meta_contract.mention_targets = mention_targets }
+  | Ok meta -> meta
   | Error detail -> failf "keeper meta fixture failed: %s" detail
 ;;
 
@@ -52,10 +51,61 @@ let with_workspace f =
     (fun () -> f config)
 ;;
 
-let persist_meta ?mention_targets config name =
-  match Keeper_meta_store.replace_snapshot config (make_meta ?mention_targets name) with
+let persist_meta config name =
+  match Keeper_meta_store.replace_snapshot config (make_meta name) with
   | Ok () -> ()
   | Error detail -> failf "keeper meta persistence failed: %s" detail
+;;
+
+let rec mkdir_p path =
+  if not (Sys.file_exists path)
+  then (
+    let parent = Filename.dirname path in
+    if not (String.equal parent path) then mkdir_p parent;
+    Unix.mkdir path 0o755)
+;;
+
+let write_file path content =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+;;
+
+let configure_mention_targets config name mention_targets =
+  let keepers_dir =
+    Config_dir_resolver.keepers_dir_for_base_path
+      ~base_path:config.Workspace.base_path
+  in
+  mkdir_p keepers_dir;
+  let keeper_dir = Filename.concat keepers_dir name in
+  mkdir_p keeper_dir;
+  write_file
+    (Filename.concat keeper_dir "AGENT.md")
+    "You are a focused test Keeper.\n";
+  let path = Filename.concat keepers_dir (name ^ ".toml") in
+  let rendered_targets =
+    mention_targets
+    |> List.map (Printf.sprintf "%S")
+    |> String.concat ", "
+  in
+  write_file
+    path
+    (Printf.sprintf
+       "[keeper]\nsandbox_profile = \"local\"\nmention_targets = [%s]\n"
+       rendered_targets)
+;;
+
+let check_effective_mention_targets config name expected =
+  match Keeper_meta_store.read_effective_meta config name with
+  | Error detail -> failf "effective metadata read failed: %s" detail
+  | Ok None -> fail "effective metadata disappeared"
+  | Ok (Some meta) ->
+    check
+      (list string)
+      "effective mention targets"
+      expected
+      meta.Keeper_meta_contract.mention_targets
 ;;
 
 let count_delivery_rows ~base_path ~keeper_name ~request_id =
@@ -154,7 +204,9 @@ let test_configured_mention_alias_resolves_and_stamps_feed_target () =
   let keeper_name = "rondo" in
   let alias = "sangsu" in
   let request_id = "wmsg-1122334455667788" in
-  persist_meta ~mention_targets:[ alias ] config keeper_name;
+  persist_meta config keeper_name;
+  configure_mention_targets config keeper_name [ alias ];
+  check_effective_mention_targets config keeper_name [ alias ];
   let outcome =
     Broadcast_wakeup.deliver_broadcast_mention
       ~config
@@ -182,7 +234,9 @@ let test_canonical_delivery_stamps_configured_feed_target () =
   let keeper_name = "rondo" in
   let alias = "sangsu" in
   let request_id = "wmsg-8877665544332211" in
-  persist_meta ~mention_targets:[ alias ] config keeper_name;
+  persist_meta config keeper_name;
+  configure_mention_targets config keeper_name [ alias ];
+  check_effective_mention_targets config keeper_name [ alias ];
   ignore
     (Broadcast_wakeup.deliver_broadcast_mention
        ~config

--- a/test/test_broadcast_wakeup_policy.ml
+++ b/test/test_broadcast_wakeup_policy.ml
@@ -19,9 +19,10 @@ let test_blank_is_passive () =
   | `Suppress_no_target -> ()
   | `Wake_keeper target -> failf "unexpected blank-target wake: %s" target
 
-let make_meta name =
+let make_meta ?(mention_targets = []) name =
   match Masc_test_deps.meta_of_json_fixture (`Assoc [ "name", `String name ]) with
-  | Ok meta -> meta
+  | Ok meta ->
+    { meta with Keeper_meta_contract.mention_targets = mention_targets }
   | Error detail -> failf "keeper meta fixture failed: %s" detail
 ;;
 
@@ -51,8 +52,8 @@ let with_workspace f =
     (fun () -> f config)
 ;;
 
-let persist_meta config name =
-  match Keeper_meta_store.replace_snapshot config (make_meta name) with
+let persist_meta ?mention_targets config name =
+  match Keeper_meta_store.replace_snapshot config (make_meta ?mention_targets name) with
   | Ok () -> ()
   | Error detail -> failf "keeper meta persistence failed: %s" detail
 ;;
@@ -142,6 +143,63 @@ let test_runtime_agent_alias_resolves_before_delivery () =
     (count_delivery_rows ~base_path:config.base_path ~keeper_name:target ~request_id)
 ;;
 
+let delivery_message ~base_path ~keeper_name ~request_id =
+  Keeper_chat_store.load_all ~base_dir:base_path ~keeper_name
+  |> List.find_opt (fun (message : Keeper_chat_store.chat_message) ->
+    message.external_message_id = Some request_id)
+;;
+
+let test_configured_mention_alias_resolves_and_stamps_feed_target () =
+  with_workspace @@ fun config ->
+  let keeper_name = "rondo" in
+  let alias = "sangsu" in
+  let request_id = "wmsg-1122334455667788" in
+  persist_meta ~mention_targets:[ alias ] config keeper_name;
+  let outcome =
+    Broadcast_wakeup.deliver_broadcast_mention
+      ~config
+      ~base_path:config.base_path
+      ~is_running:(String.equal keeper_name)
+      ~wakeup:(fun _ -> ())
+      (delivery ~target:alias ~request_id ~seq:4 ~content:"alias delivery")
+  in
+  (match outcome with
+   | Server_bootstrap_loops.Broadcast_persisted_and_woken actual ->
+     check string "alias resolves to canonical Keeper" keeper_name actual
+   | _ -> fail "configured mention alias did not resolve");
+  match delivery_message ~base_path:config.base_path ~keeper_name ~request_id with
+  | None -> fail "configured alias delivery was not persisted"
+  | Some message ->
+    let mentions =
+      List.map Keeper_identity.Keeper_id.to_string message.mentions
+    in
+    check bool "persisted row carries configured feed target" true
+      (List.mem alias mentions)
+;;
+
+let test_canonical_delivery_stamps_configured_feed_target () =
+  with_workspace @@ fun config ->
+  let keeper_name = "rondo" in
+  let alias = "sangsu" in
+  let request_id = "wmsg-8877665544332211" in
+  persist_meta ~mention_targets:[ alias ] config keeper_name;
+  ignore
+    (Broadcast_wakeup.deliver_broadcast_mention
+       ~config
+       ~base_path:config.base_path
+       ~is_running:(fun _ -> false)
+       ~wakeup:(fun _ -> ())
+       (delivery ~target:keeper_name ~request_id ~seq:5 ~content:"canonical delivery"));
+  match delivery_message ~base_path:config.base_path ~keeper_name ~request_id with
+  | None -> fail "canonical delivery was not persisted"
+  | Some message ->
+    let mentions =
+      List.map Keeper_identity.Keeper_id.to_string message.mentions
+    in
+    check bool "canonical row carries configured feed target" true
+      (List.mem alias mentions)
+;;
+
 let () =
   run
     "broadcast_wakeup_policy"
@@ -157,5 +215,9 @@ let () =
             test_stopped_keeper_persists_without_wake
         ; test_case "runtime agent alias resolves before delivery" `Quick
             test_runtime_agent_alias_resolves_before_delivery
+        ; test_case "configured mention alias resolves and stamps feed target" `Quick
+            test_configured_mention_alias_resolves_and_stamps_feed_target
+        ; test_case "canonical delivery stamps configured feed target" `Quick
+            test_canonical_delivery_stamps_configured_feed_target
         ] )
     ]

--- a/test/test_broadcast_wakeup_policy.ml
+++ b/test/test_broadcast_wakeup_policy.ml
@@ -202,18 +202,23 @@ let delivery_message ~base_path ~keeper_name ~request_id =
 let test_configured_mention_alias_resolves_and_stamps_feed_target () =
   with_workspace @@ fun config ->
   let keeper_name = "rondo" in
-  let alias = "sangsu" in
+  let configured_alias = "Sangsu" in
+  let delivery_target = "sangsu" in
   let request_id = "wmsg-1122334455667788" in
   persist_meta config keeper_name;
-  configure_mention_targets config keeper_name [ alias ];
-  check_effective_mention_targets config keeper_name [ alias ];
+  configure_mention_targets config keeper_name [ configured_alias ];
+  check_effective_mention_targets config keeper_name [ configured_alias ];
   let outcome =
     Broadcast_wakeup.deliver_broadcast_mention
       ~config
       ~base_path:config.base_path
       ~is_running:(String.equal keeper_name)
       ~wakeup:(fun _ -> ())
-      (delivery ~target:alias ~request_id ~seq:4 ~content:"alias delivery")
+      (delivery
+         ~target:delivery_target
+         ~request_id
+         ~seq:4
+         ~content:"alias delivery")
   in
   (match outcome with
    | Server_bootstrap_loops.Broadcast_persisted_and_woken actual ->
@@ -226,7 +231,7 @@ let test_configured_mention_alias_resolves_and_stamps_feed_target () =
       List.map Keeper_identity.Keeper_id.to_string message.mentions
     in
     check bool "persisted row carries configured feed target" true
-      (List.mem alias mentions)
+      (List.mem delivery_target mentions)
 ;;
 
 let test_canonical_delivery_stamps_configured_feed_target () =

--- a/test/test_broadcast_wakeup_policy.ml
+++ b/test/test_broadcast_wakeup_policy.ml
@@ -113,6 +113,35 @@ let test_stopped_keeper_persists_without_wake () =
   check int "stopped Keeper not woken" 0 !wakes
 ;;
 
+let test_runtime_agent_alias_resolves_before_delivery () =
+  with_workspace @@ fun config ->
+  let keeper_name = "rondo" in
+  let target = Keeper_identity.keeper_agent_name keeper_name in
+  let request_id = "wmsg-aabbccddeeff0011" in
+  persist_meta config keeper_name;
+  let woken = ref None in
+  let outcome =
+    Broadcast_wakeup.deliver_broadcast_mention
+      ~config
+      ~base_path:config.base_path
+      ~is_running:(String.equal keeper_name)
+      ~wakeup:(fun name -> woken := Some name)
+      (delivery ~target ~request_id ~seq:3 ~content:"agent alias delivery")
+  in
+  (match outcome with
+   | Server_bootstrap_loops.Broadcast_persisted_and_woken actual ->
+     check string "canonical delivery target" keeper_name actual
+   | _ -> fail "runtime agent alias did not resolve to the canonical Keeper");
+  check (option string) "canonical wake target" (Some keeper_name) !woken;
+  check int "delivery stored under canonical Keeper" 1
+    (count_delivery_rows
+       ~base_path:config.base_path
+       ~keeper_name
+       ~request_id);
+  check int "no alias-named chat store" 0
+    (count_delivery_rows ~base_path:config.base_path ~keeper_name:target ~request_id)
+;;
+
 let () =
   run
     "broadcast_wakeup_policy"
@@ -126,5 +155,7 @@ let () =
             test_delivery_appends_once_before_wake
         ; test_case "stopped Keeper persists without wake" `Quick
             test_stopped_keeper_persists_without_wake
+        ; test_case "runtime agent alias resolves before delivery" `Quick
+            test_runtime_agent_alias_resolves_before_delivery
         ] )
     ]

--- a/test/test_broadcast_wakeup_policy.ml
+++ b/test/test_broadcast_wakeup_policy.ml
@@ -1,4 +1,5 @@
 open Alcotest
+open Masc
 
 module Broadcast_wakeup = Server_bootstrap_loops.For_testing
 
@@ -18,6 +19,100 @@ let test_blank_is_passive () =
   | `Suppress_no_target -> ()
   | `Wake_keeper target -> failf "unexpected blank-target wake: %s" target
 
+let make_meta name =
+  match Masc_test_deps.meta_of_json_fixture (`Assoc [ "name", `String name ]) with
+  | Ok meta -> meta
+  | Error detail -> failf "keeper meta fixture failed: %s" detail
+;;
+
+let delivery ~target ~request_id ~seq ~content : Workspace_broadcast.broadcast_delivery =
+  { request_id
+  ; seq
+  ; rendered = content
+  ; from_agent = "external-agent"
+  ; content
+  ; mention = Some target
+  ; msg_type = "broadcast"
+  }
+;;
+
+let with_workspace f =
+  let root = Filename.temp_file "broadcast-wakeup-" "" in
+  Sys.remove root;
+  Unix.mkdir root 0o755;
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let config = Workspace.default_config root in
+  ignore (Workspace.init config ~agent_name:None);
+  Fun.protect
+    ~finally:(fun () ->
+      ignore (Workspace.reset config);
+      Unix.rmdir root)
+    (fun () -> f config)
+;;
+
+let persist_meta config name =
+  match Keeper_meta_store.replace_snapshot config (make_meta name) with
+  | Ok () -> ()
+  | Error detail -> failf "keeper meta persistence failed: %s" detail
+;;
+
+let count_delivery_rows ~base_path ~keeper_name ~request_id =
+  Keeper_chat_store.load_all ~base_dir:base_path ~keeper_name
+  |> List.filter (fun (message : Keeper_chat_store.chat_message) ->
+    message.external_message_id = Some request_id)
+  |> List.length
+;;
+
+let test_delivery_appends_once_before_wake () =
+  with_workspace @@ fun config ->
+  let target = "rondo" in
+  let request_id = "wmsg-0011223344556677" in
+  persist_meta config target;
+  let wakes = ref 0 in
+  let delivery = delivery ~target ~request_id ~seq:1 ~content:"review this" in
+  let deliver () =
+    Broadcast_wakeup.deliver_broadcast_mention
+      ~config
+      ~base_path:config.base_path
+      ~is_running:(fun _ -> true)
+      ~wakeup:(fun _ -> incr wakes)
+      delivery
+  in
+  (match deliver () with
+   | Server_bootstrap_loops.Broadcast_persisted_and_woken "rondo" -> ()
+   | _ -> fail "committed delivery did not wake the running keeper");
+  (match deliver () with
+   | Server_bootstrap_loops.Broadcast_persisted_and_woken "rondo" -> ()
+   | _ -> fail "idempotent replay did not preserve wake eligibility");
+  check int "one accepted-user row" 1
+    (count_delivery_rows ~base_path:config.base_path ~keeper_name:target ~request_id);
+  check int "wake only follows successful append outcomes" 2 !wakes
+;;
+
+let test_stopped_keeper_persists_without_wake () =
+  with_workspace @@ fun config ->
+  let target = "stopped-keeper" in
+  let request_id = "wmsg-8899aabbccddeeff" in
+  persist_meta config target;
+  let wakes = ref 0 in
+  let outcome =
+    Broadcast_wakeup.deliver_broadcast_mention
+      ~config
+      ~base_path:config.base_path
+      ~is_running:(fun _ -> false)
+      ~wakeup:(fun _ -> incr wakes)
+      (delivery ~target ~request_id ~seq:2 ~content:"persist while stopped")
+  in
+  (match outcome with
+   | Server_bootstrap_loops.Broadcast_persisted_wake_deferred actual ->
+     check string "deferred target" target actual
+   | _ -> fail "stopped Keeper delivery was not durably deferred");
+  check int "stopped delivery persisted" 1
+    (count_delivery_rows ~base_path:config.base_path ~keeper_name:target ~request_id);
+  check int "stopped Keeper not woken" 0 !wakes
+;;
+
 let () =
   run
     "broadcast_wakeup_policy"
@@ -27,5 +122,9 @@ let () =
           test_case "explicit mention wakes target" `Quick test_mention_wakes_target
         ; test_case "no mention is passive" `Quick test_none_is_passive
         ; test_case "blank mention is passive" `Quick test_blank_is_passive
+        ; test_case "delivery appends once before wake" `Quick
+            test_delivery_appends_once_before_wake
+        ; test_case "stopped Keeper persists without wake" `Quick
+            test_stopped_keeper_persists_without_wake
         ] )
     ]

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -231,7 +231,10 @@ let test_broadcast_message () =
   let _ = Workspace.init config ~agent_name:(Some "claude") in
 
   (* Broadcast *)
-  let result = Workspace.broadcast config ~from_agent:"claude" ~content:"Hello @gemini!" in
+  let result =
+    Workspace.broadcast config ~from_agent:"claude" ~content:"Hello @gemini!"
+    |> Result.get_ok
+  in
   Alcotest.(check bool) "broadcast success" true (String.contains result.rendered '[');
 
   (* Get messages *)
@@ -297,6 +300,7 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
   in
   let result =
     Workspace.broadcast config ~from_agent:"taskmaster-jade-heron" ~content:stale_message
+    |> Result.get_ok
   in
   Alcotest.(check bool)
     "broadcast reports invalidation"
@@ -337,6 +341,7 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
   in
   let normal_result =
     Workspace.broadcast config ~from_agent:"taskmaster-jade-heron" ~content:normal_update
+    |> Result.get_ok
   in
   Alcotest.(check bool)
     "normal task mention is not invalidated"
@@ -344,6 +349,7 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
     (str_contains normal_result.rendered "[cache_invalidated]");
   let operator_result =
     Workspace.broadcast config ~from_agent:"operator" ~content:stale_message
+    |> Result.get_ok
   in
   Alcotest.(check bool)
     "non-taskmaster stale-looking prose is not invalidated"
@@ -364,7 +370,10 @@ let test_event_log () =
   let _ = Workspace.init config ~agent_name:None in
 
   (* Broadcast should create event log *)
-  let result = Workspace.broadcast config ~from_agent:"claude" ~content:"Test event" in
+  let result =
+    Workspace.broadcast config ~from_agent:"claude" ~content:"Test event"
+    |> Result.get_ok
+  in
 
   (* Verify broadcast returned a valid response (contains timestamp marker) *)
   Alcotest.(check bool) "broadcast returns response" true (String.length result.rendered > 0);
@@ -575,7 +584,10 @@ let test_special_chars_in_message () =
   with_test_env (fun config ->
     (* Test special characters, unicode, JSON-unsafe chars *)
     let msg = "Hello \"world\" with 'quotes' and\nnewlines\tand\t한글!" in
-    let result = Workspace.broadcast config ~from_agent:"claude" ~content:msg in
+    let result =
+      Workspace.broadcast config ~from_agent:"claude" ~content:msg
+      |> Result.get_ok
+    in
     Alcotest.(check bool) "special chars handled" true (String.length result.rendered > 0)
   )
 
@@ -1025,7 +1037,10 @@ let test_emoji_in_message () =
   with_test_env (fun config ->
     (* Emoji characters should be preserved *)
     let msg = "🚀 Launching feature! 🎉" in
-    let result = Workspace.broadcast config ~from_agent:"claude" ~content:msg in
+    let result =
+      Workspace.broadcast config ~from_agent:"claude" ~content:msg
+      |> Result.get_ok
+    in
     Alcotest.(check bool) "emoji preserved" true (str_contains result.rendered "🚀")
   )
 
@@ -1083,7 +1098,10 @@ let test_reinit_after_reset () =
 let test_very_long_message () =
   with_test_env (fun config ->
     let long_msg = String.make 10000 'x' in
-    let result = Workspace.broadcast config ~from_agent:"claude" ~content:long_msg in
+    let result =
+      Workspace.broadcast config ~from_agent:"claude" ~content:long_msg
+      |> Result.get_ok
+    in
     Alcotest.(check bool) "long message handled" true (String.length result.rendered > 0)
   )
 
@@ -1091,7 +1109,10 @@ let test_message_with_json_chars () =
   with_test_env (fun config ->
     (* JSON special characters should be escaped properly *)
     let msg = "{\"key\": \"value\", \"array\": [1,2,3]}" in
-    let result = Workspace.broadcast config ~from_agent:"claude" ~content:msg in
+    let result =
+      Workspace.broadcast config ~from_agent:"claude" ~content:msg
+      |> Result.get_ok
+    in
     Alcotest.(check bool) "json chars handled" true (String.length result.rendered > 0)
   )
 
@@ -1150,7 +1171,10 @@ let test_xss_in_message () =
   with_test_env (fun config ->
     ignore (Workspace.bind_session config ~agent_name:"tester" ~capabilities:[] ());
     let xss_payload = "<script>alert('xss')</script>" in
-    let result = Workspace.broadcast config ~from_agent:"tester" ~content:xss_payload in
+    let result =
+      Workspace.broadcast config ~from_agent:"tester" ~content:xss_payload
+      |> Result.get_ok
+    in
     (* Check that raw script tags are not in the result *)
     let has_raw_script =
       str_contains result.rendered "<script>"

--- a/test/test_workspace_messages_raw.ml
+++ b/test/test_workspace_messages_raw.ml
@@ -147,6 +147,73 @@ let test_repeated_mention_delivers_each_canonical_event () =
     Alcotest.(check (list (option string))) "mention wake hooks"
       [ Some "gemini"; Some "gemini" ] (List.rev !wakes))
 
+let test_failed_authoritative_write_suppresses_fanout () =
+  with_test_env (fun config ->
+    let previous_activity = Atomic.get Workspace_hooks.activity_emit_fn in
+    let previous_observer =
+      Atomic.get Workspace_hooks.workspace_broadcast_observed_fn
+    in
+    let previous_mention =
+      Workspace_broadcast.For_testing.replace_on_broadcast_mention ignore
+    in
+    let previous_write =
+      Workspace_broadcast.For_testing.replace_write_json_commit
+        (fun _config _path _json -> Error "injected authoritative failure")
+    in
+    Fun.protect
+      ~finally:(fun () ->
+        Atomic.set Workspace_hooks.activity_emit_fn previous_activity;
+        Atomic.set
+          Workspace_hooks.workspace_broadcast_observed_fn
+          previous_observer;
+        Workspace_broadcast.set_on_broadcast_mention previous_mention;
+        let (_ :
+          Workspace_utils_backend_setup.config ->
+          string ->
+          Yojson.Safe.t ->
+          (Workspace_utils.write_json_commit, string) result) =
+          Workspace_broadcast.For_testing.replace_write_json_commit
+            previous_write
+        in
+        ())
+      (fun () ->
+        let publications = ref 0 in
+        let activities = ref 0 in
+        let mentions = ref 0 in
+        let observations = ref 0 in
+        (match
+           Workspace.backend_subscribe
+             config
+             ~channel:(Workspace.broadcast_channel config)
+             ~callback:(fun _ -> incr publications)
+         with
+         | Ok () -> ()
+         | Error error ->
+           Alcotest.failf "subscribe failed: %s" (Backend_types.show_error error));
+        Atomic.set Workspace_hooks.activity_emit_fn
+          (fun _config ~actor:_ ?subject:_ ~kind:_ ~payload:_ ~tags:_ () ->
+            incr activities);
+        Atomic.set Workspace_hooks.workspace_broadcast_observed_fn
+          (fun ~msg_type:_ ~elapsed_s:_ -> incr observations);
+        Workspace_broadcast.set_on_broadcast_mention (fun _ -> incr mentions);
+        (match
+           Workspace.broadcast
+             config
+             ~from_agent:"claude"
+             ~content:"@gemini must not fan out"
+         with
+         | Error (Workspace_broadcast.Broadcast_not_persisted detail) ->
+           Alcotest.(check string)
+             "typed write failure"
+             "injected authoritative failure"
+             detail
+         | Ok _ -> Alcotest.fail "failed write reported a committed broadcast");
+        Alcotest.(check int) "backend publication suppressed" 0 !publications;
+        Alcotest.(check int) "activity suppressed" 0 !activities;
+        Alcotest.(check int) "mention callback suppressed" 0 !mentions;
+        Alcotest.(check int) "success latency observation suppressed" 0 !observations))
+;;
+
 let () =
   Alcotest.run "Workspace raw message regression" [
     ("messages_raw", [
@@ -158,5 +225,7 @@ let () =
         test_get_messages_raw_large_history_keeps_newest_window;
       Alcotest.test_case "identical mentions each deliver" `Quick
         test_repeated_mention_delivers_each_canonical_event;
+      Alcotest.test_case "failed write suppresses fanout" `Quick
+        test_failed_authoritative_write_suppresses_fanout;
     ]);
   ]

--- a/test/test_workspace_messages_raw.ml
+++ b/test/test_workspace_messages_raw.ml
@@ -95,7 +95,7 @@ let test_repeated_mention_delivers_each_canonical_event () =
         in
         activities := (kind, subject) :: !activities);
     Workspace_broadcast.set_on_broadcast_mention
-      (fun mention -> wakes := mention :: !wakes);
+      (fun delivery -> wakes := delivery.mention :: !wakes);
     let content = "@gemini review the canonical event" in
     ignore (Workspace.broadcast config ~from_agent:"claude" ~content);
     ignore (Workspace.broadcast config ~from_agent:"claude" ~content);


### PR DESCRIPTION
## As-Is

An explicit `@keeper` workspace broadcast committed a workspace message and flipped the Keeper wake signal, but the Keeper reads its durable chat transcript. The Keeper therefore woke with no input. An authoritative workspace write failure could also leak into success fanout.

## To-Be

- Mint one opaque `wmsg-*` producer identity per broadcast and bind it to the committed workspace filename.
- Make `Workspace.broadcast` return a typed result; all production callers handle persistence failure explicitly.
- Run publish/activity/mention delivery and success metrics only after the authoritative commit.
- Append mentioned broadcasts once as External accepted-user Keeper transcript rows.
- Persist for stopped/restarting Keepers; wake a live Keeper only after `Appended` or `Already_present`.
- Keep broadcasts without an explicit Keeper mention passive.
- Return typed MCP/Keeper runtime failures and negative HTTP/gRPC/operator outcomes when the write did not commit.

## Exact boundary

Base after rebase: `1487385def42fb4a7c3cae3e2fc5287fd9843983`

Head: `3d51d3c739`

No outbox, automatic replay, retry, compensation, runtime-name policy, role policy, or admission framework is added.

## Exact-head validation

- `dune build @check`
- `test_workspace_messages_raw.exe`: 5/5
- `test_broadcast_wakeup_policy.exe`: 5/5
- `test_workspace.exe`: 82/82
- prior pre-rebase `dune build @all`
- ocamlformat and `git diff --check`

The regressions pin authoritative write failure → typed error with zero backend/activity/mention/metric fanout, append-once delivery before wake, and stopped-Keeper durable persistence without wake.

## Explicit remaining gap

The workspace message store and Keeper transcript remain two durability domains. A crash after workspace commit but before transcript append is `Outcome_unknown`. The request identity is durable and transcript append is idempotent, but this PR does not claim crash-proof exactly-once execution.

Exact-head GitHub CI, merge, deployment, and live rerun remain pending.