### PR TITLE
feat(observation): Code_address 발행 타입 (RFC-0378 A1)

### DIFF
--- a/lib/agent_observation/agent_observation.ml
+++ b/lib/agent_observation/agent_observation.ml
@@ -138,7 +138,29 @@ module Code_address = struct
      [path_segment_to_slug], so every slug [canonical_url_of_remote] can
      emit is accepted and nothing outside that alphabet is. *)
   let valid_codebase slug =
-    not (String.equal slug ".")
+    (* [canonical_url_of_remote] joins a non-empty host and at least one
+       non-empty repository path segment with [_].  Requiring both the join
+       marker and the shortest possible [a_b] shape keeps callers from
+       inventing host-only partitions that the resolver can never emit. *)
+    let joins =
+      String.fold_left
+        (fun count char -> if Char.equal char '_' then count + 1 else count)
+        0
+        slug
+    in
+    let single_join_suffix_is_dotdot =
+      match String.index_opt slug '_' with
+      | Some join when joins = 1 && String.length slug - join - 1 >= 2 ->
+        String.sub slug (join + 1) 2 = ".."
+      | Some _ | None -> false
+    in
+    let rec has_interior_join index =
+      index < String.length slug - 1
+      && (Char.equal slug.[index] '_' || has_interior_join (index + 1))
+    in
+    String.length slug >= 3
+    && has_interior_join 1
+    && not single_join_suffix_is_dotdot
     && not (String.length slug >= 2 && String.sub slug 0 2 = "..")
     && String.for_all is_slug_char slug
   ;;

--- a/test/test_code_address.ml
+++ b/test/test_code_address.ml
@@ -115,6 +115,26 @@ let () =
             "dot codebase"
             `Quick
             (check_rejected ~codebase:"." ~path:"lib/x.ml" A.Malformed_codebase)
+        ; Alcotest.test_case
+            "host-only codebase"
+            `Quick
+            (check_rejected ~codebase:"github.com" ~path:"lib/x.ml" A.Malformed_codebase)
+        ; Alcotest.test_case
+            "separator without host and path"
+            `Quick
+            (check_rejected ~codebase:"_" ~path:"lib/x.ml" A.Malformed_codebase)
+        ; Alcotest.test_case
+            "orphan partition is not a codebase"
+            `Quick
+            (check_rejected ~codebase:"_orphan" ~path:"lib/x.ml" A.Malformed_codebase)
+        ; Alcotest.test_case
+            "separator without repository path"
+            `Quick
+            (check_rejected ~codebase:"github.com_" ~path:"lib/x.ml" A.Malformed_codebase)
+        ; Alcotest.test_case
+            "single joined repository segment cannot start with dotdot"
+            `Quick
+            (check_rejected ~codebase:"a_..repo" ~path:"lib/x.ml" A.Malformed_codebase)
         ] )
     ]
 ;;


### PR DESCRIPTION
## 목표

RFC-0378 §5.1 사다리 첫 단(A1)이에요. code fact의 주소 `(canonical slug, repo-root 상대 경로)`를 abstract 타입 + rejecting constructor로 도입합니다 — raw string이 파싱된 주소 행세를 못 하게 하는 타입 기반이에요.

## 변경

- `Agent_observation.Code_address` nested module (abstract `t`, `v : codebase:string -> path:string -> (t, invalid) result`)
- 거부 규칙: 절대경로 / `.`·`..`·빈 세그먼트 / 비-slug codebase — **수리하지 않고 거부** (Parse, don't validate)
- slug 가드는 `canonical_url_of_remote`와 동일 문자셋·동일 leading-`..` 규칙 공유 (resolver 출력은 항상 구성 가능)
- 테스트: resolver 출력 구성 가능성 + 전송 철자 2종(scp/https)이 같은 주소로 join + 거부 테이블 9종
- CI 배선: `ci-run-focused-tests.sh`에 `runtest-test_code_address` 추가

## Zero callers by design

RFC-0128 PR-1a 패턴이에요. A2(다음 단, stacked)가 producer와 sink write path를 이 타입 위로 옮깁니다. 구 partition 타입은 RFC-0378 §7대로 read-path 어휘로 D까지 생존해요.

## 검증

- `audit-ci-test-targets.sh` 실측: **306 CI targets 전부 declared, 558 unwired at baseline (불변)**
- 컴파일 판정은 원칙 16(로컬 빌드 금지)대로 PR CI가 수행해요
- RFC: #28645 (Draft)

🤖 Generated with [Claude Code](https://claude.com/claude-code)