### PR TITLE
fix(agent-core): preserve and dedupe producer event identity

### DIFF
--- a/dashboard/src/agent-core-runtime-store.test.ts
+++ b/dashboard/src/agent-core-runtime-store.test.ts
@@ -479,6 +479,57 @@ describe('agent-core-runtime-store', () => {
     ])
   })
 
+  it('releases queued live events when the latest replay finishes before a stale fetch', async () => {
+    type ReplayResponse = Awaited<ReturnType<typeof fetchTelemetry>>
+    let resolveStale: ((response: ReplayResponse) => void) | undefined
+    let resolveLatest: ((response: ReplayResponse) => void) | undefined
+    fetchTelemetryMock
+      .mockImplementationOnce(() => new Promise(resolve => {
+        resolveStale = resolve
+      }))
+      .mockImplementationOnce(() => new Promise(resolve => {
+        resolveLatest = resolve
+      }))
+
+    const staleReplay = replayAgentCoreRuntimeTelemetry()
+    const latestReplay = replayAgentCoreRuntimeTelemetry()
+    expect(applyAgentCoreRuntimeEvent({
+      type: 'agent_core:masc:trust_updated',
+      event_id: 'evt-live-after-stale-replay',
+      payload: {
+        agent_a: 'latest-live-agent',
+        agent_b: 'latest-live-peer',
+        trust_score: 0.9,
+      },
+    })).toBe(true)
+
+    resolveLatest?.({
+      generated_at: '2026-04-15T12:00:00Z',
+      count: 0,
+      offset: 0,
+      total_matching_entries: 0,
+      has_more: false,
+      entries: [],
+    })
+    await latestReplay
+
+    expect(agentCoreHealthSummary.value.totalEvents).toBe(1)
+    expect(agentCoreAgentEvents.value[0]?.event_id).toBe('evt-live-after-stale-replay')
+
+    resolveStale?.({
+      generated_at: '2026-04-15T12:00:00Z',
+      count: 0,
+      offset: 0,
+      total_matching_entries: 0,
+      has_more: false,
+      entries: [],
+    })
+    await staleReplay
+
+    expect(agentCoreHealthSummary.value.totalEvents).toBe(1)
+    expect(agentCoreAgentEvents.value[0]?.event_id).toBe('evt-live-after-stale-replay')
+  })
+
   it('increments total events above the replay baseline for live arrivals', async () => {
     fetchTelemetryMock.mockResolvedValue({
       generated_at: '2026-04-15T12:00:00Z',

--- a/dashboard/src/agent-core-runtime-store.test.ts
+++ b/dashboard/src/agent-core-runtime-store.test.ts
@@ -428,6 +428,57 @@ describe('agent-core-runtime-store', () => {
     expect(agentCoreAgentEvents.value[0]?.type).toBe('reputation_changed')
   })
 
+  it('preserves a live event accepted while initial replay hydration is in flight', async () => {
+    let resolveReplay: ((response: Awaited<ReturnType<typeof fetchTelemetry>>) => void) | undefined
+    fetchTelemetryMock.mockImplementation(() => new Promise(resolve => {
+      resolveReplay = resolve
+    }))
+
+    const replay = replayAgentCoreRuntimeTelemetry()
+    expect(applyAgentCoreRuntimeEvent({
+      type: 'agent_core:masc:trust_updated',
+      event_id: 'evt-live-during-replay',
+      ts_unix: 556,
+      run_id: 'run-live-during-replay',
+      payload: {
+        agent_a: 'live-agent',
+        agent_b: 'live-peer',
+        trust_score: 0.8,
+        timestamp: 556,
+      },
+    })).toBe(true)
+
+    resolveReplay?.({
+      generated_at: '2026-04-15T12:00:00Z',
+      count: 1,
+      offset: 0,
+      total_matching_entries: 1,
+      has_more: false,
+      entries: [{
+        source: 'agent_core_event',
+        type: 'agent_core:masc:trust_updated',
+        event_id: 'evt-replayed-snapshot',
+        ts_unix: 555,
+        run_id: 'run-replayed-snapshot',
+        payload: {
+          agent_a: 'replayed-agent',
+          agent_b: 'replayed-peer',
+          trust_score: 0.7,
+          timestamp: 555,
+        },
+      } as TelemetryEntry],
+    })
+    await replay
+
+    expect(agentCoreHealthSummary.value.totalEvents).toBe(2)
+    expect(agentCoreHealthSummary.value.replayLoadedEvents).toBe(1)
+    expect(agentCoreHealthSummary.value.agentEventsCount).toBe(2)
+    expect(agentCoreAgentEvents.value.map(event => event.event_id)).toEqual([
+      'evt-live-during-replay',
+      'evt-replayed-snapshot',
+    ])
+  })
+
   it('increments total events above the replay baseline for live arrivals', async () => {
     fetchTelemetryMock.mockResolvedValue({
       generated_at: '2026-04-15T12:00:00Z',
@@ -621,6 +672,54 @@ describe('agent-core-runtime-store', () => {
     expect(agentCoreHealthSummary.value.replayTruncated).toBe(false)
   })
 
+  it('keeps the fetched cursor separate from the deduplicated displayed count', async () => {
+    const duplicated = {
+      source: 'agent_core_event',
+      type: 'agent_core:masc:trust_updated',
+      event_id: 'evt-page-overlap',
+      run_id: 'run-page-overlap',
+      payload: { agent_a: 'a', agent_b: 'b', trust_score: 0.5 },
+    } as TelemetryEntry
+    fetchTelemetryMock.mockResolvedValue({
+      generated_at: '2026-04-15T12:00:00Z',
+      count: 1,
+      offset: 0,
+      total_matching_entries: 3,
+      has_more: true,
+      entries: [duplicated],
+    })
+    await replayAgentCoreRuntimeTelemetry()
+
+    fetchTelemetryMock.mockResolvedValue({
+      generated_at: '2026-04-15T12:00:00Z',
+      count: 1,
+      offset: 1,
+      total_matching_entries: 3,
+      has_more: true,
+      entries: [duplicated],
+    })
+    await loadMoreAgentCoreEvents()
+
+    expect(agentCoreHealthSummary.value.replayLoadedEvents).toBe(1)
+
+    fetchTelemetryMock.mockResolvedValue({
+      generated_at: '2026-04-15T12:00:00Z',
+      count: 0,
+      offset: 2,
+      total_matching_entries: 3,
+      has_more: true,
+      entries: [],
+    })
+    await loadMoreAgentCoreEvents()
+
+    expect(fetchTelemetryMock).toHaveBeenLastCalledWith({
+      source: 'agent_core_event',
+      n: 500,
+      offset: 2,
+      signal: undefined,
+    })
+  })
+
   it('stops at the telemetry offset cap without replaying a clamped page', async () => {
     const entry = (seq: number): TelemetryEntry => ({
       source: 'agent_core_event',
@@ -650,7 +749,7 @@ describe('agent-core-runtime-store', () => {
       offset: 5499,
       signal: undefined,
     })
-    expect(agentCoreHealthSummary.value.replayLoadedEvents).toBe(5499)
+    expect(agentCoreHealthSummary.value.replayLoadedEvents).toBe(1)
     expect(agentCoreHealthSummary.value.replayTruncated).toBe(false)
     expect(agentCoreHealthSummary.value.replayCapped).toBe(true)
     expect(agentCoreHealthSummary.value.hasMore).toBe(false)

--- a/dashboard/src/agent-core-runtime-store.test.ts
+++ b/dashboard/src/agent-core-runtime-store.test.ts
@@ -469,6 +469,48 @@ describe('agent-core-runtime-store', () => {
     expect(agentCoreHealthSummary.value.agentEventsCount).toBe(2)
   })
 
+  it('keeps live arrivals out of the replay-loaded page count', async () => {
+    const entry = (seq: number): TelemetryEntry => ({
+      source: 'agent_core_event',
+      type: 'agent_core:masc:trust_updated',
+      ts_unix: 700 + seq,
+      correlation_id: `corr-replay-${seq}`,
+      run_id: 'run-replay-pages',
+      seq,
+      payload: { agent_a: 'a', agent_b: 'b', trust_score: 0.5 },
+    }) as TelemetryEntry
+
+    fetchTelemetryMock.mockResolvedValue({
+      generated_at: '2026-04-15T12:00:00Z',
+      count: 1,
+      total_matching_entries: 3,
+      has_more: true,
+      entries: [entry(1)],
+    })
+    await replayAgentCoreRuntimeTelemetry()
+
+    expect(applyAgentCoreRuntimeEvent({
+      type: 'agent_core:masc:trust_updated',
+      ts_unix: 999,
+      correlation_id: 'corr-live-between-pages',
+      run_id: 'run-live-between-pages',
+      payload: { agent_a: 'live', agent_b: 'peer', trust_score: 0.6 },
+    })).toBe(true)
+
+    fetchTelemetryMock.mockResolvedValue({
+      generated_at: '2026-04-15T12:00:00Z',
+      count: 1,
+      total_matching_entries: 3,
+      has_more: true,
+      entries: [entry(2)],
+    })
+    await loadMoreAgentCoreEvents()
+
+    expect(agentCoreHealthSummary.value.replayLoadedEvents).toBe(2)
+    expect(agentCoreHealthSummary.value.replayTotalMatchingEvents).toBe(3)
+    expect(agentCoreHealthSummary.value.replayTruncated).toBe(true)
+  })
+
   it('keeps loading more from retiring hasMore before the window is exhausted', async () => {
     // A replayed row sits inside the server's total-matching count. Counting
     // it again made loaded exceed total, and noteAgentCoreReplayWindow reads

--- a/dashboard/src/agent-core-runtime-store.test.ts
+++ b/dashboard/src/agent-core-runtime-store.test.ts
@@ -116,6 +116,7 @@ describe('agent-core-runtime-store', () => {
   it('dedupes a live event already present in replayed telemetry', () => {
     const liveEvent = {
       type: 'agent_core:masc:trust_updated',
+      event_id: 'evt-live-replay',
       ts_unix: 123,
       correlation_id: 'corr-live',
       run_id: 'run-live',
@@ -271,6 +272,7 @@ describe('agent-core-runtime-store', () => {
       const driftEvent = {
         source: 'agent_core_event',
         type: 'agent_core:durable:llm_request',
+        event_id: 'evt-drift',
         correlation_id: 'corr-drift',
         run_id: 'run-drift',
         payload: {
@@ -290,6 +292,81 @@ describe('agent-core-runtime-store', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('preserves identical strings from distinct event identities', () => {
+    const event = (eventId: string) => ({
+      type: 'agent_core:masc:trust_updated',
+      event_id: eventId,
+      ts_unix: 600,
+      correlation_id: 'corr-shared',
+      run_id: 'run-shared',
+      payload: {
+        agent_a: 'same-agent',
+        agent_b: 'same-peer',
+        trust_score: 0.5,
+        timestamp: 600,
+      },
+    })
+
+    expect(applyAgentCoreRuntimeEvent(event('evt-distinct-a'))).toBe(true)
+    expect(applyAgentCoreRuntimeEvent(event('evt-distinct-b'))).toBe(true)
+    expect(agentCoreHealthSummary.value.totalEvents).toBe(2)
+    expect(agentCoreHealthSummary.value.agentEventsCount).toBe(2)
+  })
+
+  it('scopes a repeated producer event id to its run', () => {
+    const event = (runId: string) => ({
+      type: 'agent_core:masc:trust_updated',
+      event_id: 'evt-process-local',
+      run_id: runId,
+      payload: {
+        agent_a: 'same-agent',
+        agent_b: 'same-peer',
+        trust_score: 0.5,
+      },
+    })
+
+    expect(applyAgentCoreRuntimeEvent(event('run-a'))).toBe(true)
+    expect(applyAgentCoreRuntimeEvent(event('run-b'))).toBe(true)
+    expect(agentCoreHealthSummary.value.totalEvents).toBe(2)
+  })
+
+  it('preserves unidentified identical events instead of content-deduping them', () => {
+    const event = {
+      type: 'agent_core:masc:trust_updated',
+      ts_unix: 610,
+      correlation_id: 'corr-legacy',
+      run_id: 'run-legacy',
+      payload: {
+        agent_a: 'legacy-agent',
+        agent_b: 'legacy-peer',
+        trust_score: 0.4,
+        timestamp: 610,
+      },
+    }
+
+    expect(applyAgentCoreRuntimeEvent(event)).toBe(true)
+    expect(applyAgentCoreRuntimeEvent(event)).toBe(true)
+    expect(agentCoreHealthSummary.value.totalEvents).toBe(2)
+    expect(agentCoreHealthSummary.value.agentEventsCount).toBe(2)
+  })
+
+  it('dedupes one stable run sequence across replay and live delivery', () => {
+    const event = {
+      type: 'agent_core:masc:trust_updated',
+      run_id: 'run-sequenced',
+      seq: 7,
+      payload: {
+        agent_a: 'sequenced-agent',
+        agent_b: 'sequenced-peer',
+        trust_score: 0.7,
+      },
+    }
+
+    hydrateAgentCoreRuntimeFromTelemetryEntries([{ source: 'agent_core_event', ...event } as TelemetryEntry])
+    expect(applyAgentCoreRuntimeEvent(event)).toBe(false)
+    expect(agentCoreHealthSummary.value.totalEvents).toBe(1)
   })
 
   it('replays recent Agent Core telemetry via the dashboard API', async () => {

--- a/dashboard/src/agent-core-runtime-store.test.ts
+++ b/dashboard/src/agent-core-runtime-store.test.ts
@@ -516,6 +516,7 @@ describe('agent-core-runtime-store', () => {
     expect(agentCoreHealthSummary.value.replayLoadedEvents).toBe(2)
     expect(agentCoreHealthSummary.value.replayTotalMatchingEvents).toBe(3)
     expect(agentCoreHealthSummary.value.replayTruncated).toBe(true)
+    expect(agentCoreHealthSummary.value.totalEvents).toBe(4)
   })
 
   it('keeps loading more from retiring hasMore before the window is exhausted', async () => {

--- a/dashboard/src/agent-core-runtime-store.test.ts
+++ b/dashboard/src/agent-core-runtime-store.test.ts
@@ -7,6 +7,7 @@ vi.mock('./api/dashboard', () => ({
 import { fetchTelemetry, type TelemetryEntry } from './api/dashboard'
 import {
   applyAgentCoreRuntimeEvent,
+  appendAgentCoreRuntimeFromTelemetryEntries,
   hydrateAgentCoreRuntimeFromTelemetryEntries,
   replayAgentCoreRuntimeTelemetry,
   loadMoreAgentCoreEvents,
@@ -609,5 +610,39 @@ describe('agent-core-runtime-store', () => {
     })
     expect(agentCoreHealthSummary.value.replayLoadedEvents).toBe(2)
     expect(agentCoreHealthSummary.value.replayTruncated).toBe(false)
+  })
+
+  it('stops at the telemetry offset cap without replaying a clamped page', async () => {
+    const entry = (seq: number): TelemetryEntry => ({
+      source: 'agent_core_event',
+      type: 'agent_core:masc:trust_updated',
+      event_id: `evt-cap-${seq}`,
+      run_id: 'run-cap',
+      payload: { agent_a: 'a', agent_b: 'b', trust_score: 0.5 },
+    }) as TelemetryEntry
+
+    hydrateAgentCoreRuntimeFromTelemetryEntries([entry(1)])
+    fetchTelemetryMock.mockResolvedValue({
+      generated_at: '2026-04-15T12:00:00Z',
+      count: 1,
+      total_matching_entries: 6000,
+      offset: 5000,
+      has_more: true,
+      entries: [entry(2)],
+    })
+
+    // Simulate the first request beyond the server's 5000 offset cap.
+    appendAgentCoreRuntimeFromTelemetryEntries([], 5499)
+    await loadMoreAgentCoreEvents()
+
+    expect(fetchTelemetryMock).toHaveBeenLastCalledWith({
+      source: 'agent_core_event',
+      n: 500,
+      offset: 5499,
+      signal: undefined,
+    })
+    expect(agentCoreHealthSummary.value.replayLoadedEvents).toBe(5499)
+    expect(agentCoreHealthSummary.value.replayTruncated).toBe(false)
+    expect(agentCoreHealthSummary.value.agentEventsCount).toBe(1)
   })
 })

--- a/dashboard/src/agent-core-runtime-store.test.ts
+++ b/dashboard/src/agent-core-runtime-store.test.ts
@@ -140,6 +140,7 @@ describe('agent-core-runtime-store', () => {
     expect(applyAgentCoreRuntimeEvent(liveEvent)).toBe(false)
     expect(agentCoreHealthSummary.value.totalEvents).toBe(1)
     expect(agentCoreHealthSummary.value.agentEventsCount).toBe(1)
+    expect(agentCoreAgentEvents.value[0]?.event_id).toBe('evt-live-replay')
   })
 
   it('hydrates keeper lifecycle phase from Agent Core payload', () => {
@@ -317,7 +318,7 @@ describe('agent-core-runtime-store', () => {
     expect(agentCoreHealthSummary.value.agentEventsCount).toBe(2)
   })
 
-  it('scopes a repeated producer event id to its run', () => {
+  it('treats a repeated producer event id as the same occurrence across run drift', () => {
     const event = (runId: string) => ({
       type: 'agent_core:masc:trust_updated',
       event_id: 'evt-process-local',
@@ -330,19 +331,19 @@ describe('agent-core-runtime-store', () => {
     })
 
     expect(applyAgentCoreRuntimeEvent(event('run-a'))).toBe(true)
-    expect(applyAgentCoreRuntimeEvent(event('run-b'))).toBe(true)
-    expect(agentCoreHealthSummary.value.totalEvents).toBe(2)
+    expect(applyAgentCoreRuntimeEvent(event('run-b'))).toBe(false)
+    expect(agentCoreHealthSummary.value.totalEvents).toBe(1)
   })
 
-  it('preserves current native envelopes until the producer emits an identity', () => {
+  it('preserves envelopes that have no producer identity', () => {
     const event = {
       type: 'agent_core:masc:trust_updated',
       ts_unix: 610,
-      correlation_id: 'corr-legacy',
-      run_id: 'run-legacy',
+      correlation_id: 'corr-unidentified',
+      run_id: 'run-unidentified',
       payload: {
-        agent_a: 'legacy-agent',
-        agent_b: 'legacy-peer',
+        agent_a: 'unidentified-agent',
+        agent_b: 'unidentified-peer',
         trust_score: 0.4,
         timestamp: 610,
       },

--- a/dashboard/src/agent-core-runtime-store.test.ts
+++ b/dashboard/src/agent-core-runtime-store.test.ts
@@ -392,6 +392,7 @@ describe('agent-core-runtime-store', () => {
     fetchTelemetryMock.mockResolvedValue({
       generated_at: '2026-04-15T12:00:00Z',
       count: 1,
+      offset: 0,
       total_matching_entries: 1200,
       truncated: true,
       entries: [
@@ -430,6 +431,7 @@ describe('agent-core-runtime-store', () => {
     fetchTelemetryMock.mockResolvedValue({
       generated_at: '2026-04-15T12:00:00Z',
       count: 1,
+      offset: 0,
       total_matching_entries: 1200,
       truncated: true,
       entries: [
@@ -484,6 +486,7 @@ describe('agent-core-runtime-store', () => {
     fetchTelemetryMock.mockResolvedValue({
       generated_at: '2026-04-15T12:00:00Z',
       count: 1,
+      offset: 0,
       total_matching_entries: 3,
       has_more: true,
       entries: [entry(1)],
@@ -501,6 +504,7 @@ describe('agent-core-runtime-store', () => {
     fetchTelemetryMock.mockResolvedValue({
       generated_at: '2026-04-15T12:00:00Z',
       count: 1,
+      offset: 1,
       total_matching_entries: 3,
       has_more: true,
       entries: [entry(2)],
@@ -544,6 +548,7 @@ describe('agent-core-runtime-store', () => {
     fetchTelemetryMock.mockResolvedValue({
       generated_at: '2026-04-15T12:00:00Z',
       count: 2,
+      offset: 0,
       total_matching_entries: 1200,
       truncated: true,
       entries: [entry(1), entry(2)],
@@ -556,6 +561,7 @@ describe('agent-core-runtime-store', () => {
     fetchTelemetryMock.mockResolvedValue({
       generated_at: '2026-04-15T12:00:00Z',
       count: 2,
+      offset: 2,
       total_matching_entries: 1200,
       truncated: true,
       entries: [entry(3), entry(4)],
@@ -573,6 +579,7 @@ describe('agent-core-runtime-store', () => {
     fetchTelemetryMock.mockResolvedValue({
       generated_at: '2026-04-15T12:00:00Z',
       count: 1,
+      offset: 0,
       total_matching_entries: 2,
       has_more: true,
       entries: [{
@@ -590,6 +597,7 @@ describe('agent-core-runtime-store', () => {
     fetchTelemetryMock.mockResolvedValue({
       generated_at: '2026-04-15T12:00:00Z',
       count: 1,
+      offset: 1,
       total_matching_entries: 2,
       has_more: false,
       entries: [{
@@ -643,6 +651,8 @@ describe('agent-core-runtime-store', () => {
     })
     expect(agentCoreHealthSummary.value.replayLoadedEvents).toBe(5499)
     expect(agentCoreHealthSummary.value.replayTruncated).toBe(false)
+    expect(agentCoreHealthSummary.value.replayCapped).toBe(true)
+    expect(agentCoreHealthSummary.value.hasMore).toBe(false)
     expect(agentCoreHealthSummary.value.agentEventsCount).toBe(1)
   })
 })

--- a/dashboard/src/agent-core-runtime-store.test.ts
+++ b/dashboard/src/agent-core-runtime-store.test.ts
@@ -333,7 +333,7 @@ describe('agent-core-runtime-store', () => {
     expect(agentCoreHealthSummary.value.totalEvents).toBe(2)
   })
 
-  it('preserves unidentified identical events instead of content-deduping them', () => {
+  it('dedupes the current native envelope across replay and live delivery', () => {
     const event = {
       type: 'agent_core:masc:trust_updated',
       ts_unix: 610,
@@ -347,10 +347,27 @@ describe('agent-core-runtime-store', () => {
       },
     }
 
+    hydrateAgentCoreRuntimeFromTelemetryEntries([
+      { source: 'agent_core_event', ...event } as TelemetryEntry,
+    ])
+    expect(applyAgentCoreRuntimeEvent(event)).toBe(false)
+    expect(agentCoreHealthSummary.value.totalEvents).toBe(1)
+    expect(agentCoreHealthSummary.value.agentEventsCount).toBe(1)
+  })
+
+  it('preserves identical events with no producer identity', () => {
+    const event = {
+      type: 'agent_core:masc:trust_updated',
+      payload: {
+        agent_a: 'unidentified-agent',
+        agent_b: 'unidentified-peer',
+        trust_score: 0.4,
+      },
+    }
+
     expect(applyAgentCoreRuntimeEvent(event)).toBe(true)
     expect(applyAgentCoreRuntimeEvent(event)).toBe(true)
     expect(agentCoreHealthSummary.value.totalEvents).toBe(2)
-    expect(agentCoreHealthSummary.value.agentEventsCount).toBe(2)
   })
 
   it('dedupes one stable run sequence across replay and live delivery', () => {

--- a/dashboard/src/agent-core-runtime-store.test.ts
+++ b/dashboard/src/agent-core-runtime-store.test.ts
@@ -9,6 +9,7 @@ import {
   applyAgentCoreRuntimeEvent,
   hydrateAgentCoreRuntimeFromTelemetryEntries,
   replayAgentCoreRuntimeTelemetry,
+  loadMoreAgentCoreEvents,
 } from './agent-core-runtime-store'
 import {
   agentCoreAgentEvents,
@@ -449,5 +450,54 @@ describe('agent-core-runtime-store', () => {
 
     expect(agentCoreHealthSummary.value.totalEvents).toBe(1201)
     expect(agentCoreHealthSummary.value.agentEventsCount).toBe(2)
+  })
+
+  it('keeps loading more from retiring hasMore before the window is exhausted', async () => {
+    // A replayed row sits inside the server's total-matching count. Counting
+    // it again made loaded exceed total, and noteAgentCoreReplayWindow reads
+    // loaded >= total as "nothing left" — so the second page silently became
+    // the last one no matter how many rows the server still held.
+    const entry = (seq: number): TelemetryEntry =>
+      ({
+        source: 'agent_core_event',
+        type: 'agent_core:masc:trust_updated',
+        ts_unix: 500 + seq,
+        correlation_id: `corr-${seq}`,
+        run_id: 'run-page',
+        seq,
+        payload: {
+          agent_a: 'gamma',
+          agent_b: 'delta',
+          trust_score: 0.5,
+          timestamp: 500 + seq,
+        },
+      }) as TelemetryEntry
+
+    fetchTelemetryMock.mockResolvedValue({
+      generated_at: '2026-04-15T12:00:00Z',
+      count: 2,
+      total_matching_entries: 1200,
+      truncated: true,
+      entries: [entry(1), entry(2)],
+    })
+    await replayAgentCoreRuntimeTelemetry()
+
+    expect(agentCoreHealthSummary.value.replayLoadedEvents).toBe(2)
+    expect(agentCoreHealthSummary.value.replayTruncated).toBe(true)
+
+    fetchTelemetryMock.mockResolvedValue({
+      generated_at: '2026-04-15T12:00:00Z',
+      count: 2,
+      total_matching_entries: 1200,
+      truncated: true,
+      entries: [entry(3), entry(4)],
+    })
+    await loadMoreAgentCoreEvents()
+
+    // Four distinct rows loaded out of 1200 — the operator must still be able
+    // to ask for the rest.
+    expect(agentCoreHealthSummary.value.replayLoadedEvents).toBe(4)
+    expect(agentCoreHealthSummary.value.replayTotalMatchingEvents).toBe(1200)
+    expect(agentCoreHealthSummary.value.replayTruncated).toBe(true)
   })
 })

--- a/dashboard/src/agent-core-runtime-store.test.ts
+++ b/dashboard/src/agent-core-runtime-store.test.ts
@@ -333,7 +333,7 @@ describe('agent-core-runtime-store', () => {
     expect(agentCoreHealthSummary.value.totalEvents).toBe(2)
   })
 
-  it('dedupes the current native envelope across replay and live delivery', () => {
+  it('preserves current native envelopes until the producer emits an identity', () => {
     const event = {
       type: 'agent_core:masc:trust_updated',
       ts_unix: 610,
@@ -350,9 +350,9 @@ describe('agent-core-runtime-store', () => {
     hydrateAgentCoreRuntimeFromTelemetryEntries([
       { source: 'agent_core_event', ...event } as TelemetryEntry,
     ])
-    expect(applyAgentCoreRuntimeEvent(event)).toBe(false)
-    expect(agentCoreHealthSummary.value.totalEvents).toBe(1)
-    expect(agentCoreHealthSummary.value.agentEventsCount).toBe(1)
+    expect(applyAgentCoreRuntimeEvent(event)).toBe(true)
+    expect(agentCoreHealthSummary.value.totalEvents).toBe(2)
+    expect(agentCoreHealthSummary.value.agentEventsCount).toBe(2)
   })
 
   it('preserves identical events with no producer identity', () => {
@@ -506,6 +506,13 @@ describe('agent-core-runtime-store', () => {
     })
     await loadMoreAgentCoreEvents()
 
+    expect(fetchTelemetryMock).toHaveBeenLastCalledWith({
+      source: 'agent_core_event',
+      n: 500,
+      offset: 1,
+      signal: undefined,
+    })
+
     expect(agentCoreHealthSummary.value.replayLoadedEvents).toBe(2)
     expect(agentCoreHealthSummary.value.replayTotalMatchingEvents).toBe(3)
     expect(agentCoreHealthSummary.value.replayTruncated).toBe(true)
@@ -558,5 +565,48 @@ describe('agent-core-runtime-store', () => {
     expect(agentCoreHealthSummary.value.replayLoadedEvents).toBe(4)
     expect(agentCoreHealthSummary.value.replayTotalMatchingEvents).toBe(1200)
     expect(agentCoreHealthSummary.value.replayTruncated).toBe(true)
+  })
+
+  it('pages by fetched replay rows rather than projected Agent Core rows', async () => {
+    fetchTelemetryMock.mockResolvedValue({
+      generated_at: '2026-04-15T12:00:00Z',
+      count: 1,
+      total_matching_entries: 2,
+      has_more: true,
+      entries: [{
+        source: 'agent_core_event',
+        type: 'agent_core:durable:llm_request',
+        event_id: 'evt-page-1',
+        run_id: 'run-page-offset',
+        payload: { agent_name: 'alpha', model: 'gpt-5', input_tokens: 10 },
+      } as TelemetryEntry],
+    })
+    await replayAgentCoreRuntimeTelemetry()
+
+    expect(agentCoreAgentEvents.value).toHaveLength(0)
+
+    fetchTelemetryMock.mockResolvedValue({
+      generated_at: '2026-04-15T12:00:00Z',
+      count: 1,
+      total_matching_entries: 2,
+      has_more: false,
+      entries: [{
+        source: 'agent_core_event',
+        type: 'agent_core:durable:error_occurred',
+        event_id: 'evt-page-2',
+        run_id: 'run-page-offset',
+        payload: { agent_name: 'alpha', error_domain: 'tool' },
+      } as TelemetryEntry],
+    })
+    await loadMoreAgentCoreEvents()
+
+    expect(fetchTelemetryMock).toHaveBeenLastCalledWith({
+      source: 'agent_core_event',
+      n: 500,
+      offset: 1,
+      signal: undefined,
+    })
+    expect(agentCoreHealthSummary.value.replayLoadedEvents).toBe(2)
+    expect(agentCoreHealthSummary.value.replayTruncated).toBe(false)
   })
 })

--- a/dashboard/src/agent-core-runtime-store.ts
+++ b/dashboard/src/agent-core-runtime-store.ts
@@ -217,8 +217,7 @@ function stableRuntimeEventIdentity(event: AgentCoreRuntimeEnvelope): RuntimeEve
   const runId = asString(event.run_id) ?? asString(payload.run_id)
   const eventId = asString(event.event_id) ?? asString(payload.event_id)
   if (eventId) {
-    const scope = runId ?? asString(event.correlation_id) ?? asString(payload.correlation_id) ?? ''
-    return { kind: 'stable', key: `event:${scope}|${eventId}` }
+    return { kind: 'stable', key: `event:${eventId}` }
   }
 
   const seq = asNumber(event.seq) ?? asNumber(payload.seq)
@@ -244,6 +243,7 @@ function traceDetail(
   detail: Record<string, unknown>,
 ): Record<string, unknown> {
   return {
+    event_id: asString(event.event_id) ?? null,
     event_type: runtimeEventType(event),
     correlation_id: asString(event.correlation_id) ?? null,
     run_id: asString(event.run_id) ?? null,
@@ -275,6 +275,7 @@ function keeperLifecycleEvent(event: AgentCoreRuntimeEnvelope): AgentCoreKeeperL
     phase: toKeeperPhase(asString(payload.phase)),
     detail: asString(payload.detail),
     event_type: runtimeEventType(event),
+    event_id: asString(event.event_id),
     correlation_id: asString(event.correlation_id),
     run_id: asString(event.run_id),
     event_key: runtimeEventKey(event),
@@ -355,6 +356,7 @@ function ingestRuntimeProjection(
         secondary_agent: asString(payload.agent_b),
         trust_score: asNumber(payload.trust_score),
         event_type: runtimeEventType(event),
+        event_id: asString(event.event_id),
         correlation_id: asString(event.correlation_id),
         run_id: asString(event.run_id),
         event_key: runtimeEventKey(event),
@@ -370,6 +372,7 @@ function ingestRuntimeProjection(
         new_score: asNumber(payload.new_score),
         trend: asString(payload.trend),
         event_type: runtimeEventType(event),
+        event_id: asString(event.event_id),
         correlation_id: asString(event.correlation_id),
         run_id: asString(event.run_id),
         event_key: runtimeEventKey(event),

--- a/dashboard/src/agent-core-runtime-store.ts
+++ b/dashboard/src/agent-core-runtime-store.ts
@@ -568,7 +568,10 @@ export function hydrateAgentCoreRuntimeFromTelemetryEntries(entries: TelemetryEn
   })
 }
 
-export function appendAgentCoreRuntimeFromTelemetryEntries(entries: TelemetryEntry[]): void {
+export function appendAgentCoreRuntimeFromTelemetryEntries(
+  entries: TelemetryEntry[],
+  replayOffset = replayFetchedAgentCoreEventCount,
+): void {
   const ordered = [...entries].sort((a, b) => {
     const left = coerceAgentCoreRuntimeEnvelope(a)
     const right = coerceAgentCoreRuntimeEnvelope(b)
@@ -577,7 +580,7 @@ export function appendAgentCoreRuntimeFromTelemetryEntries(entries: TelemetryEnt
   for (const entry of ordered) {
     applyAgentCoreRuntimeEvent(entry, { origin: 'replay' })
   }
-  replayFetchedAgentCoreEventCount += entries.length
+  replayFetchedAgentCoreEventCount = replayOffset + entries.length
 }
 
 export async function replayAgentCoreRuntimeTelemetry(signal?: AbortSignal): Promise<void> {
@@ -616,7 +619,20 @@ export async function loadMoreAgentCoreEvents(signal?: AbortSignal): Promise<voi
     offset: currentOffset,
     signal,
   })
-  appendAgentCoreRuntimeFromTelemetryEntries(response.entries)
+  const responseOffset = response.offset ?? currentOffset
+  // The server caps telemetry offsets. Once it reports an earlier offset than
+  // requested, this is a replay of a page we already consumed: do not project
+  // it again or advance the cursor beyond reachable history.
+  if (responseOffset < currentOffset) {
+    noteAgentCoreReplayWindow({
+      loadedEvents: replayFetchedAgentCoreEventCount,
+      totalMatchingEvents: response.total_matching_entries ?? response.count,
+      truncated: false,
+      observedTotalEvents: agentCoreTotalEvents.value,
+    })
+    return
+  }
+  appendAgentCoreRuntimeFromTelemetryEntries(response.entries, responseOffset)
   noteAgentCoreReplayWindow({
     loadedEvents: replayFetchedAgentCoreEventCount,
     totalMatchingEvents: response.total_matching_entries ?? response.count,

--- a/dashboard/src/agent-core-runtime-store.ts
+++ b/dashboard/src/agent-core-runtime-store.ts
@@ -22,7 +22,12 @@ import type {
 type AgentCoreRuntimeEnvelope = Record<string, unknown> & {
   type: string
   payload: Record<string, unknown>
+  dashboard_event_key?: string
 }
+
+type RuntimeEventIdentity =
+  | { kind: 'stable'; key: string }
+  | { kind: 'unidentified' }
 
 type IngestOptions = {
   includeLiveTrace?: boolean
@@ -40,6 +45,7 @@ type EvidenceRefSets = {
 }
 
 const seenAgentCoreEventKeys = new Set<string>()
+let unidentifiedAgentCoreEventSequence = 0
 let replayGeneration = 0
 let initialReplayPromise: Promise<void> | null = null
 
@@ -206,41 +212,31 @@ function runtimeEventType(event: AgentCoreRuntimeEnvelope): string {
   return asString(event.event_type) ?? event.type
 }
 
-function runtimeEventKey(event: AgentCoreRuntimeEnvelope): string {
+function stableRuntimeEventIdentity(event: AgentCoreRuntimeEnvelope): RuntimeEventIdentity {
   const payload = eventPayload(event)
-  const type = runtimeEventType(event)
-  const correlationId = asString(event.correlation_id)
-  const runId = asString(event.run_id)
-  const reportedTsUnix = eventReportedUnixSeconds(event)
-  const agentName =
-    asString(event.agent_name)
-    ?? asString(payload.agent_name)
-    ?? asString(payload.agent)
-    ?? asString(payload.keeper_name)
-    ?? ''
-  const taskId = asString(event.task_id) ?? asString(payload.task_id) ?? ''
-  const toolName = asString(event.tool_name) ?? asString(payload.tool_name) ?? ''
-  const turn = asNumber(event.turn) ?? asNumber(payload.turn)
-  if (correlationId || runId || reportedTsUnix != null) {
-    return [
-      type,
-      agentName,
-      correlationId ?? '',
-      runId ?? '',
-      reportedTsUnix != null ? String(reportedTsUnix) : '',
-      taskId,
-      toolName,
-      turn != null ? String(turn) : '',
-    ].join('|')
+  const runId = asString(event.run_id) ?? asString(payload.run_id)
+  const eventId = asString(event.event_id) ?? asString(payload.event_id)
+  if (eventId) {
+    const scope = runId ?? asString(event.correlation_id) ?? asString(payload.correlation_id) ?? ''
+    return { kind: 'stable', key: `event:${scope}|${eventId}` }
   }
-  return JSON.stringify({
-    type,
-    agentName,
-    taskId,
-    toolName,
-    turn: turn ?? null,
-    payload,
-  })
+
+  const seq = asNumber(event.seq) ?? asNumber(payload.seq)
+  if (runId && seq != null && Number.isSafeInteger(seq) && seq >= 0) {
+    return { kind: 'stable', key: `run:${runId}|seq:${seq}` }
+  }
+
+  return { kind: 'unidentified' }
+}
+
+function runtimeEventKey(event: AgentCoreRuntimeEnvelope): string {
+  if (event.dashboard_event_key) return event.dashboard_event_key
+  const identity = stableRuntimeEventIdentity(event)
+  const key = identity.kind === 'stable'
+    ? identity.key
+    : `unidentified:${++unidentifiedAgentCoreEventSequence}`
+  event.dashboard_event_key = key
+  return key
 }
 
 function traceDetail(
@@ -534,23 +530,23 @@ function coerceAgentCoreRuntimeEnvelope(raw: unknown): AgentCoreRuntimeEnvelope 
 export function applyAgentCoreRuntimeEvent(raw: unknown, opts?: IngestOptions): boolean {
   const event = coerceAgentCoreRuntimeEnvelope(raw)
   if (!event) return false
-  const key = runtimeEventKey(event)
-  if (seenAgentCoreEventKeys.has(key)) {
-    return false
-  }
-  seenAgentCoreEventKeys.add(key)
-  ingestRuntimeProjection(event, opts)
-  if (opts?.origin === 'replay') {
-    agentCoreTotalEvents.value = seenAgentCoreEventKeys.size
+  const identity = stableRuntimeEventIdentity(event)
+  if (identity.kind === 'stable') {
+    if (seenAgentCoreEventKeys.has(identity.key)) return false
+    seenAgentCoreEventKeys.add(identity.key)
+    event.dashboard_event_key = identity.key
   } else {
-    agentCoreTotalEvents.value = Math.max(seenAgentCoreEventKeys.size, agentCoreTotalEvents.value + 1)
+    runtimeEventKey(event)
   }
+  ingestRuntimeProjection(event, opts)
+  agentCoreTotalEvents.value += 1
   return true
 }
 
 export function hydrateAgentCoreRuntimeFromTelemetryEntries(entries: TelemetryEntry[]): void {
   resetAgentCoreRuntimeSignals()
   seenAgentCoreEventKeys.clear()
+  unidentifiedAgentCoreEventSequence = 0
   const ordered = [...entries].sort((a, b) => {
     const left = coerceAgentCoreRuntimeEnvelope(a)
     const right = coerceAgentCoreRuntimeEnvelope(b)

--- a/dashboard/src/agent-core-runtime-store.ts
+++ b/dashboard/src/agent-core-runtime-store.ts
@@ -226,6 +226,21 @@ function stableRuntimeEventIdentity(event: AgentCoreRuntimeEnvelope): RuntimeEve
     return { kind: 'stable', key: `run:${runId}|seq:${seq}` }
   }
 
+  // Native Event_bus envelopes currently carry no event_id/seq. The server
+  // does, however, persist and replay this exact identity tuple, so use it
+  // until the producer grows a first-class event id. Requiring every member
+  // avoids reviving the old content-based heuristic for genuinely
+  // unidentified events.
+  const correlationId =
+    asString(event.correlation_id) ?? asString(payload.correlation_id)
+  const reportedTsUnix = eventReportedUnixSeconds(event)
+  if (runId && correlationId && reportedTsUnix != null) {
+    return {
+      kind: 'stable',
+      key: `envelope:${runtimeEventType(event)}|${runId}|${correlationId}|${reportedTsUnix}`,
+    }
+  }
+
   return { kind: 'unidentified' }
 }
 

--- a/dashboard/src/agent-core-runtime-store.ts
+++ b/dashboard/src/agent-core-runtime-store.ts
@@ -48,6 +48,7 @@ const seenAgentCoreEventKeys = new Set<string>()
 let unidentifiedAgentCoreEventSequence = 0
 let replayGeneration = 0
 let initialReplayPromise: Promise<void> | null = null
+let replayLoadedAgentCoreEventCount = 0
 
 function emptyEvidenceRefSets(): EvidenceRefSets {
   return {
@@ -554,6 +555,7 @@ export function applyAgentCoreRuntimeEvent(raw: unknown, opts?: IngestOptions): 
     runtimeEventKey(event)
   }
   ingestRuntimeProjection(event, opts)
+  if (opts?.origin === 'replay') replayLoadedAgentCoreEventCount += 1
   // A live arrival is news the replay window never counted, so it belongs
   // above the server's total. A replayed row is not: it is already inside
   // that total, and counting it again is what made "load more" claim 1700
@@ -562,24 +564,11 @@ export function applyAgentCoreRuntimeEvent(raw: unknown, opts?: IngestOptions): 
   return true
 }
 
-/** How many distinct events this store has actually loaded.
- *
- *  Separate from `agentCoreTotalEvents`, which `noteAgentCoreReplayWindow`
- *  assigns the server's total-matching count — feeding that number back as
- *  `loadedEvents` makes loaded and total equal by construction, which reads
- *  as "fully loaded" however little was fetched.
- *
- *  Both halves are already tracked: stable identities cannot double-count
- *  because the set rejects repeats, and unidentified events are numbered as
- *  they are keyed. */
-function loadedAgentCoreEventCount(): number {
-  return seenAgentCoreEventKeys.size + unidentifiedAgentCoreEventSequence
-}
-
 export function hydrateAgentCoreRuntimeFromTelemetryEntries(entries: TelemetryEntry[]): void {
   resetAgentCoreRuntimeSignals()
   seenAgentCoreEventKeys.clear()
   unidentifiedAgentCoreEventSequence = 0
+  replayLoadedAgentCoreEventCount = 0
   const ordered = [...entries].sort((a, b) => {
     const left = coerceAgentCoreRuntimeEnvelope(a)
     const right = coerceAgentCoreRuntimeEnvelope(b)
@@ -589,8 +578,8 @@ export function hydrateAgentCoreRuntimeFromTelemetryEntries(entries: TelemetryEn
     applyAgentCoreRuntimeEvent(entry, { origin: 'replay' })
   }
   noteAgentCoreReplayWindow({
-    loadedEvents: loadedAgentCoreEventCount(),
-    totalMatchingEvents: loadedAgentCoreEventCount(),
+    loadedEvents: replayLoadedAgentCoreEventCount,
+    totalMatchingEvents: replayLoadedAgentCoreEventCount,
     truncated: false,
   })
 }
@@ -616,7 +605,7 @@ export async function replayAgentCoreRuntimeTelemetry(signal?: AbortSignal): Pro
   if (generation !== replayGeneration) return
   hydrateAgentCoreRuntimeFromTelemetryEntries(response.entries)
   noteAgentCoreReplayWindow({
-    loadedEvents: loadedAgentCoreEventCount(),
+    loadedEvents: replayLoadedAgentCoreEventCount,
     totalMatchingEvents: response.total_matching_entries ?? response.count,
     truncated: response.has_more ?? response.truncated ?? false,
   })
@@ -644,7 +633,7 @@ export async function loadMoreAgentCoreEvents(signal?: AbortSignal): Promise<voi
   })
   appendAgentCoreRuntimeFromTelemetryEntries(response.entries)
   noteAgentCoreReplayWindow({
-    loadedEvents: loadedAgentCoreEventCount(),
+    loadedEvents: replayLoadedAgentCoreEventCount,
     totalMatchingEvents: response.total_matching_entries ?? response.count,
     truncated: response.has_more ?? response.truncated ?? false,
   })

--- a/dashboard/src/agent-core-runtime-store.ts
+++ b/dashboard/src/agent-core-runtime-store.ts
@@ -539,8 +539,26 @@ export function applyAgentCoreRuntimeEvent(raw: unknown, opts?: IngestOptions): 
     runtimeEventKey(event)
   }
   ingestRuntimeProjection(event, opts)
-  agentCoreTotalEvents.value += 1
+  // A live arrival is news the replay window never counted, so it belongs
+  // above the server's total. A replayed row is not: it is already inside
+  // that total, and counting it again is what made "load more" claim 1700
+  // of 1200 and retire `hasMore` with rows still unfetched.
+  if (opts?.origin !== 'replay') agentCoreTotalEvents.value += 1
   return true
+}
+
+/** How many distinct events this store has actually loaded.
+ *
+ *  Separate from `agentCoreTotalEvents`, which `noteAgentCoreReplayWindow`
+ *  assigns the server's total-matching count — feeding that number back as
+ *  `loadedEvents` makes loaded and total equal by construction, which reads
+ *  as "fully loaded" however little was fetched.
+ *
+ *  Both halves are already tracked: stable identities cannot double-count
+ *  because the set rejects repeats, and unidentified events are numbered as
+ *  they are keyed. */
+function loadedAgentCoreEventCount(): number {
+  return seenAgentCoreEventKeys.size + unidentifiedAgentCoreEventSequence
 }
 
 export function hydrateAgentCoreRuntimeFromTelemetryEntries(entries: TelemetryEntry[]): void {
@@ -556,8 +574,8 @@ export function hydrateAgentCoreRuntimeFromTelemetryEntries(entries: TelemetryEn
     applyAgentCoreRuntimeEvent(entry, { origin: 'replay' })
   }
   noteAgentCoreReplayWindow({
-    loadedEvents: agentCoreTotalEvents.value,
-    totalMatchingEvents: agentCoreTotalEvents.value,
+    loadedEvents: loadedAgentCoreEventCount(),
+    totalMatchingEvents: loadedAgentCoreEventCount(),
     truncated: false,
   })
 }
@@ -583,7 +601,7 @@ export async function replayAgentCoreRuntimeTelemetry(signal?: AbortSignal): Pro
   if (generation !== replayGeneration) return
   hydrateAgentCoreRuntimeFromTelemetryEntries(response.entries)
   noteAgentCoreReplayWindow({
-    loadedEvents: agentCoreTotalEvents.value,
+    loadedEvents: loadedAgentCoreEventCount(),
     totalMatchingEvents: response.total_matching_entries ?? response.count,
     truncated: response.has_more ?? response.truncated ?? false,
   })
@@ -611,7 +629,7 @@ export async function loadMoreAgentCoreEvents(signal?: AbortSignal): Promise<voi
   })
   appendAgentCoreRuntimeFromTelemetryEntries(response.entries)
   noteAgentCoreReplayWindow({
-    loadedEvents: agentCoreTotalEvents.value,
+    loadedEvents: loadedAgentCoreEventCount(),
     totalMatchingEvents: response.total_matching_entries ?? response.count,
     truncated: response.has_more ?? response.truncated ?? false,
   })

--- a/dashboard/src/agent-core-runtime-store.ts
+++ b/dashboard/src/agent-core-runtime-store.ts
@@ -55,7 +55,7 @@ let loadedUnidentifiedReplayEventCount = 0
 let replayGeneration = 0
 let initialReplayPromise: Promise<void> | null = null
 let replayFetchedAgentCoreEventCount = 0
-let fullReplayHydrationsInFlight = 0
+let activeFullReplayGeneration: number | null = null
 let queuedLiveRuntimeEvents: QueuedLiveRuntimeEvent[] = []
 
 function emptyEvidenceRefSets(): EvidenceRefSets {
@@ -569,20 +569,21 @@ function applyCoercedAgentCoreRuntimeEvent(
 export function applyAgentCoreRuntimeEvent(raw: unknown, opts?: IngestOptions): boolean {
   const event = coerceAgentCoreRuntimeEnvelope(raw)
   if (!event) return false
-  if (opts?.origin !== 'replay' && fullReplayHydrationsInFlight > 0) {
+  if (opts?.origin !== 'replay' && activeFullReplayGeneration !== null) {
     queuedLiveRuntimeEvents.push({ event, opts })
     return true
   }
   return applyCoercedAgentCoreRuntimeEvent(event, opts)
 }
 
-function beginFullReplayHydration(): void {
-  fullReplayHydrationsInFlight += 1
+function beginFullReplayHydration(generation: number): void {
+  activeFullReplayGeneration = generation
 }
 
-function finishFullReplayHydration(): void {
-  fullReplayHydrationsInFlight -= 1
-  if (fullReplayHydrationsInFlight > 0 || queuedLiveRuntimeEvents.length === 0) return
+function finishFullReplayHydration(generation: number): void {
+  if (activeFullReplayGeneration !== generation) return
+  activeFullReplayGeneration = null
+  if (queuedLiveRuntimeEvents.length === 0) return
   const pending = queuedLiveRuntimeEvents
   queuedLiveRuntimeEvents = []
   for (const { event, opts } of pending) {
@@ -630,7 +631,7 @@ export function appendAgentCoreRuntimeFromTelemetryEntries(
 
 export async function replayAgentCoreRuntimeTelemetry(signal?: AbortSignal): Promise<void> {
   const generation = ++replayGeneration
-  beginFullReplayHydration()
+  beginFullReplayHydration(generation)
   try {
     const response = await fetchTelemetry({
       source: 'agent_core_event',
@@ -645,7 +646,7 @@ export async function replayAgentCoreRuntimeTelemetry(signal?: AbortSignal): Pro
       truncated: response.has_more ?? response.truncated ?? false,
     })
   } finally {
-    finishFullReplayHydration()
+    finishFullReplayHydration(generation)
   }
 }
 

--- a/dashboard/src/agent-core-runtime-store.ts
+++ b/dashboard/src/agent-core-runtime-store.ts
@@ -5,7 +5,6 @@ import { fetchTelemetry, type TelemetryEntry } from './api/dashboard'
 import { AGENT_CORE_TELEMETRY_REPLAY_LIMIT, AGENT_CORE_EVENT_PREFIX } from './config/constants'
 import {
   agentCoreTotalEvents,
-  agentCoreAgentEvents,
   agentCoreReplayLoadedEvents,
   agentCoreReplayTotalMatchingEvents,
   noteAgentCoreReplayWindow,
@@ -48,7 +47,7 @@ const seenAgentCoreEventKeys = new Set<string>()
 let unidentifiedAgentCoreEventSequence = 0
 let replayGeneration = 0
 let initialReplayPromise: Promise<void> | null = null
-let replayLoadedAgentCoreEventCount = 0
+let replayFetchedAgentCoreEventCount = 0
 
 function emptyEvidenceRefSets(): EvidenceRefSets {
   return {
@@ -225,21 +224,6 @@ function stableRuntimeEventIdentity(event: AgentCoreRuntimeEnvelope): RuntimeEve
   const seq = asNumber(event.seq) ?? asNumber(payload.seq)
   if (runId && seq != null && Number.isSafeInteger(seq) && seq >= 0) {
     return { kind: 'stable', key: `run:${runId}|seq:${seq}` }
-  }
-
-  // Native Event_bus envelopes currently carry no event_id/seq. The server
-  // does, however, persist and replay this exact identity tuple, so use it
-  // until the producer grows a first-class event id. Requiring every member
-  // avoids reviving the old content-based heuristic for genuinely
-  // unidentified events.
-  const correlationId =
-    asString(event.correlation_id) ?? asString(payload.correlation_id)
-  const reportedTsUnix = eventReportedUnixSeconds(event)
-  if (runId && correlationId && reportedTsUnix != null) {
-    return {
-      kind: 'stable',
-      key: `envelope:${runtimeEventType(event)}|${runId}|${correlationId}|${reportedTsUnix}`,
-    }
   }
 
   return { kind: 'unidentified' }
@@ -555,7 +539,6 @@ export function applyAgentCoreRuntimeEvent(raw: unknown, opts?: IngestOptions): 
     runtimeEventKey(event)
   }
   ingestRuntimeProjection(event, opts)
-  if (opts?.origin === 'replay') replayLoadedAgentCoreEventCount += 1
   // A live arrival is news the replay window never counted, so it belongs
   // above the server's total. A replayed row is not: it is already inside
   // that total, and counting it again is what made "load more" claim 1700
@@ -568,7 +551,7 @@ export function hydrateAgentCoreRuntimeFromTelemetryEntries(entries: TelemetryEn
   resetAgentCoreRuntimeSignals()
   seenAgentCoreEventKeys.clear()
   unidentifiedAgentCoreEventSequence = 0
-  replayLoadedAgentCoreEventCount = 0
+  replayFetchedAgentCoreEventCount = 0
   const ordered = [...entries].sort((a, b) => {
     const left = coerceAgentCoreRuntimeEnvelope(a)
     const right = coerceAgentCoreRuntimeEnvelope(b)
@@ -577,9 +560,10 @@ export function hydrateAgentCoreRuntimeFromTelemetryEntries(entries: TelemetryEn
   for (const entry of ordered) {
     applyAgentCoreRuntimeEvent(entry, { origin: 'replay' })
   }
+  replayFetchedAgentCoreEventCount = entries.length
   noteAgentCoreReplayWindow({
-    loadedEvents: replayLoadedAgentCoreEventCount,
-    totalMatchingEvents: replayLoadedAgentCoreEventCount,
+    loadedEvents: replayFetchedAgentCoreEventCount,
+    totalMatchingEvents: replayFetchedAgentCoreEventCount,
     truncated: false,
   })
 }
@@ -593,6 +577,7 @@ export function appendAgentCoreRuntimeFromTelemetryEntries(entries: TelemetryEnt
   for (const entry of ordered) {
     applyAgentCoreRuntimeEvent(entry, { origin: 'replay' })
   }
+  replayFetchedAgentCoreEventCount += entries.length
 }
 
 export async function replayAgentCoreRuntimeTelemetry(signal?: AbortSignal): Promise<void> {
@@ -605,7 +590,7 @@ export async function replayAgentCoreRuntimeTelemetry(signal?: AbortSignal): Pro
   if (generation !== replayGeneration) return
   hydrateAgentCoreRuntimeFromTelemetryEntries(response.entries)
   noteAgentCoreReplayWindow({
-    loadedEvents: replayLoadedAgentCoreEventCount,
+    loadedEvents: replayFetchedAgentCoreEventCount,
     totalMatchingEvents: response.total_matching_entries ?? response.count,
     truncated: response.has_more ?? response.truncated ?? false,
   })
@@ -624,7 +609,7 @@ export function ensureAgentCoreRuntimeReplay(): Promise<void> {
 }
 
 export async function loadMoreAgentCoreEvents(signal?: AbortSignal): Promise<void> {
-  const currentOffset = agentCoreAgentEvents.value.length
+  const currentOffset = replayFetchedAgentCoreEventCount
   const response = await fetchTelemetry({
     source: 'agent_core_event',
     n: AGENT_CORE_TELEMETRY_REPLAY_LIMIT,
@@ -633,7 +618,7 @@ export async function loadMoreAgentCoreEvents(signal?: AbortSignal): Promise<voi
   })
   appendAgentCoreRuntimeFromTelemetryEntries(response.entries)
   noteAgentCoreReplayWindow({
-    loadedEvents: replayLoadedAgentCoreEventCount,
+    loadedEvents: replayFetchedAgentCoreEventCount,
     totalMatchingEvents: response.total_matching_entries ?? response.count,
     truncated: response.has_more ?? response.truncated ?? false,
   })

--- a/dashboard/src/agent-core-runtime-store.ts
+++ b/dashboard/src/agent-core-runtime-store.ts
@@ -33,6 +33,11 @@ type IngestOptions = {
   origin?: 'live' | 'replay'
 }
 
+type QueuedLiveRuntimeEvent = {
+  event: AgentCoreRuntimeEnvelope
+  opts?: IngestOptions
+}
+
 type EvidenceRefSets = {
   evidenceRefs: Set<string>
   artifactRefs: Set<string>
@@ -44,10 +49,14 @@ type EvidenceRefSets = {
 }
 
 const seenAgentCoreEventKeys = new Set<string>()
+const loadedReplayAgentCoreEventKeys = new Set<string>()
 let unidentifiedAgentCoreEventSequence = 0
+let loadedUnidentifiedReplayEventCount = 0
 let replayGeneration = 0
 let initialReplayPromise: Promise<void> | null = null
 let replayFetchedAgentCoreEventCount = 0
+let fullReplayHydrationsInFlight = 0
+let queuedLiveRuntimeEvents: QueuedLiveRuntimeEvent[] = []
 
 function emptyEvidenceRefSets(): EvidenceRefSets {
   return {
@@ -236,6 +245,10 @@ function runtimeEventKey(event: AgentCoreRuntimeEnvelope): string {
     : `unidentified:${++unidentifiedAgentCoreEventSequence}`
   event.dashboard_event_key = key
   return key
+}
+
+function loadedAgentCoreEventCount(): number {
+  return loadedReplayAgentCoreEventKeys.size + loadedUnidentifiedReplayEventCount
 }
 
 function traceDetail(
@@ -530,16 +543,19 @@ function coerceAgentCoreRuntimeEnvelope(raw: unknown): AgentCoreRuntimeEnvelope 
   }
 }
 
-export function applyAgentCoreRuntimeEvent(raw: unknown, opts?: IngestOptions): boolean {
-  const event = coerceAgentCoreRuntimeEnvelope(raw)
-  if (!event) return false
+function applyCoercedAgentCoreRuntimeEvent(
+  event: AgentCoreRuntimeEnvelope,
+  opts?: IngestOptions,
+): boolean {
   const identity = stableRuntimeEventIdentity(event)
   if (identity.kind === 'stable') {
     if (seenAgentCoreEventKeys.has(identity.key)) return false
     seenAgentCoreEventKeys.add(identity.key)
+    if (opts?.origin === 'replay') loadedReplayAgentCoreEventKeys.add(identity.key)
     event.dashboard_event_key = identity.key
   } else {
     runtimeEventKey(event)
+    if (opts?.origin === 'replay') loadedUnidentifiedReplayEventCount += 1
   }
   ingestRuntimeProjection(event, opts)
   // A live arrival is news the replay window never counted, so it belongs
@@ -550,10 +566,36 @@ export function applyAgentCoreRuntimeEvent(raw: unknown, opts?: IngestOptions): 
   return true
 }
 
+export function applyAgentCoreRuntimeEvent(raw: unknown, opts?: IngestOptions): boolean {
+  const event = coerceAgentCoreRuntimeEnvelope(raw)
+  if (!event) return false
+  if (opts?.origin !== 'replay' && fullReplayHydrationsInFlight > 0) {
+    queuedLiveRuntimeEvents.push({ event, opts })
+    return true
+  }
+  return applyCoercedAgentCoreRuntimeEvent(event, opts)
+}
+
+function beginFullReplayHydration(): void {
+  fullReplayHydrationsInFlight += 1
+}
+
+function finishFullReplayHydration(): void {
+  fullReplayHydrationsInFlight -= 1
+  if (fullReplayHydrationsInFlight > 0 || queuedLiveRuntimeEvents.length === 0) return
+  const pending = queuedLiveRuntimeEvents
+  queuedLiveRuntimeEvents = []
+  for (const { event, opts } of pending) {
+    applyCoercedAgentCoreRuntimeEvent(event, opts)
+  }
+}
+
 export function hydrateAgentCoreRuntimeFromTelemetryEntries(entries: TelemetryEntry[]): void {
   resetAgentCoreRuntimeSignals()
   seenAgentCoreEventKeys.clear()
+  loadedReplayAgentCoreEventKeys.clear()
   unidentifiedAgentCoreEventSequence = 0
+  loadedUnidentifiedReplayEventCount = 0
   replayFetchedAgentCoreEventCount = 0
   const ordered = [...entries].sort((a, b) => {
     const left = coerceAgentCoreRuntimeEnvelope(a)
@@ -565,8 +607,8 @@ export function hydrateAgentCoreRuntimeFromTelemetryEntries(entries: TelemetryEn
   }
   replayFetchedAgentCoreEventCount = entries.length
   noteAgentCoreReplayWindow({
-    loadedEvents: replayFetchedAgentCoreEventCount,
-    totalMatchingEvents: replayFetchedAgentCoreEventCount,
+    loadedEvents: loadedAgentCoreEventCount(),
+    totalMatchingEvents: entries.length,
     truncated: false,
   })
 }
@@ -588,18 +630,23 @@ export function appendAgentCoreRuntimeFromTelemetryEntries(
 
 export async function replayAgentCoreRuntimeTelemetry(signal?: AbortSignal): Promise<void> {
   const generation = ++replayGeneration
-  const response = await fetchTelemetry({
-    source: 'agent_core_event',
-    n: AGENT_CORE_TELEMETRY_REPLAY_LIMIT,
-    signal,
-  })
-  if (generation !== replayGeneration) return
-  hydrateAgentCoreRuntimeFromTelemetryEntries(response.entries)
-  noteAgentCoreReplayWindow({
-    loadedEvents: replayFetchedAgentCoreEventCount,
-    totalMatchingEvents: response.total_matching_entries ?? response.count,
-    truncated: response.has_more ?? response.truncated ?? false,
-  })
+  beginFullReplayHydration()
+  try {
+    const response = await fetchTelemetry({
+      source: 'agent_core_event',
+      n: AGENT_CORE_TELEMETRY_REPLAY_LIMIT,
+      signal,
+    })
+    if (generation !== replayGeneration) return
+    hydrateAgentCoreRuntimeFromTelemetryEntries(response.entries)
+    noteAgentCoreReplayWindow({
+      loadedEvents: loadedAgentCoreEventCount(),
+      totalMatchingEvents: response.total_matching_entries ?? response.count,
+      truncated: response.has_more ?? response.truncated ?? false,
+    })
+  } finally {
+    finishFullReplayHydration()
+  }
 }
 
 export function ensureAgentCoreRuntimeReplay(): Promise<void> {
@@ -627,7 +674,7 @@ export async function loadMoreAgentCoreEvents(signal?: AbortSignal): Promise<voi
   // it again or advance the cursor beyond reachable history.
   if (response.offset !== currentOffset) {
     noteAgentCoreReplayWindow({
-      loadedEvents: replayFetchedAgentCoreEventCount,
+      loadedEvents: loadedAgentCoreEventCount(),
       totalMatchingEvents: response.total_matching_entries ?? response.count,
       truncated: false,
       capped: true,
@@ -637,7 +684,7 @@ export async function loadMoreAgentCoreEvents(signal?: AbortSignal): Promise<voi
   }
   appendAgentCoreRuntimeFromTelemetryEntries(response.entries, response.offset)
   noteAgentCoreReplayWindow({
-    loadedEvents: replayFetchedAgentCoreEventCount,
+    loadedEvents: loadedAgentCoreEventCount(),
     totalMatchingEvents: response.total_matching_entries ?? response.count,
     truncated: response.has_more ?? response.truncated ?? false,
     observedTotalEvents: agentCoreTotalEvents.value,

--- a/dashboard/src/agent-core-runtime-store.ts
+++ b/dashboard/src/agent-core-runtime-store.ts
@@ -570,7 +570,7 @@ export function hydrateAgentCoreRuntimeFromTelemetryEntries(entries: TelemetryEn
 
 export function appendAgentCoreRuntimeFromTelemetryEntries(
   entries: TelemetryEntry[],
-  replayOffset = replayFetchedAgentCoreEventCount,
+  replayOffset: number,
 ): void {
   const ordered = [...entries].sort((a, b) => {
     const left = coerceAgentCoreRuntimeEnvelope(a)
@@ -619,20 +619,20 @@ export async function loadMoreAgentCoreEvents(signal?: AbortSignal): Promise<voi
     offset: currentOffset,
     signal,
   })
-  const responseOffset = response.offset ?? currentOffset
   // The server caps telemetry offsets. Once it reports an earlier offset than
   // requested, this is a replay of a page we already consumed: do not project
   // it again or advance the cursor beyond reachable history.
-  if (responseOffset < currentOffset) {
+  if (response.offset !== currentOffset) {
     noteAgentCoreReplayWindow({
       loadedEvents: replayFetchedAgentCoreEventCount,
       totalMatchingEvents: response.total_matching_entries ?? response.count,
       truncated: false,
+      capped: true,
       observedTotalEvents: agentCoreTotalEvents.value,
     })
     return
   }
-  appendAgentCoreRuntimeFromTelemetryEntries(response.entries, responseOffset)
+  appendAgentCoreRuntimeFromTelemetryEntries(response.entries, response.offset)
   noteAgentCoreReplayWindow({
     loadedEvents: replayFetchedAgentCoreEventCount,
     totalMatchingEvents: response.total_matching_entries ?? response.count,

--- a/dashboard/src/agent-core-runtime-store.ts
+++ b/dashboard/src/agent-core-runtime-store.ts
@@ -621,5 +621,6 @@ export async function loadMoreAgentCoreEvents(signal?: AbortSignal): Promise<voi
     loadedEvents: replayFetchedAgentCoreEventCount,
     totalMatchingEvents: response.total_matching_entries ?? response.count,
     truncated: response.has_more ?? response.truncated ?? false,
+    observedTotalEvents: agentCoreTotalEvents.value,
   })
 }

--- a/dashboard/src/api/dashboard-telemetry.ts
+++ b/dashboard/src/api/dashboard-telemetry.ts
@@ -34,7 +34,7 @@ export type TelemetryResponse = {
   query?: Record<string, unknown>
   count: number
   total_matching_entries?: number
-  offset?: number
+  offset: number
   has_more?: boolean
   truncated?: boolean
   entries: TelemetryEntry[]
@@ -115,7 +115,8 @@ function decodeTelemetryEntry(raw: unknown): TelemetryEntry | null {
 function decodeTelemetryResponse(raw: unknown): TelemetryResponse | null {
   if (!isRecord(raw)) return null
   const generatedAt = asString(raw.generated_at)
-  if (!generatedAt) return null
+  const offset = asNumber(raw.offset)
+  if (!generatedAt || offset == null || !Number.isSafeInteger(offset) || offset < 0) return null
   return {
     generated_at: generatedAt,
     generated_at_iso: asString(raw.generated_at_iso),
@@ -125,7 +126,7 @@ function decodeTelemetryResponse(raw: unknown): TelemetryResponse | null {
     query: isRecord(raw.query) ? raw.query : undefined,
     count: asNumber(raw.count, 0),
     total_matching_entries: asNumber(raw.total_matching_entries, asNumber(raw.count, 0)),
-    offset: asNumber(raw.offset, 0),
+    offset,
     has_more: asBoolean(raw.has_more, false),
     truncated: asBoolean(raw.truncated, false),
     entries: asRecordArray(raw.entries)

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1492,6 +1492,7 @@ describe('fetchTelemetrySummary', () => {
       retention: { window_days: 7 },
       query: { source: 'tool_metric', n: 100 },
       count: 1,
+      offset: 0,
       total_matching_entries: 2,
       truncated: true,
       entries: [
@@ -1518,6 +1519,7 @@ describe('fetchTelemetrySummary', () => {
     expect(result.source).toBe('telemetry_unified')
     expect(result.retention).toMatchObject({ window_days: 7 })
     expect(result.query).toMatchObject({ source: 'tool_metric', n: 100 })
+    expect(result.offset).toBe(0)
     expect(result.total_matching_entries).toBe(2)
     expect(result.truncated).toBe(true)
   })

--- a/dashboard/src/components/agent-core-health-chip.test.ts
+++ b/dashboard/src/components/agent-core-health-chip.test.ts
@@ -4,6 +4,7 @@ import { cleanup, render, waitFor } from '@testing-library/preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { TelemetryEntry } from '../api/dashboard'
 import { hydrateAgentCoreRuntimeFromTelemetryEntries } from '../agent-core-runtime-store'
+import { noteAgentCoreReplayWindow } from '../store'
 import { AgentCoreHealthChip } from './agent-core-health-chip'
 
 const fetchTelemetryMock = vi.hoisted(() => vi.fn())
@@ -85,6 +86,7 @@ describe('AgentCoreHealthChip', () => {
     fetchTelemetryMock.mockResolvedValue({
       generated_at: '2026-04-15T12:00:00Z',
       count: 0,
+      offset: 0,
       total_matching_entries: 0,
       truncated: false,
       entries: [],
@@ -111,5 +113,25 @@ describe('AgentCoreHealthChip', () => {
       expect(container.textContent).toContain('Agent Core 리플레이를 불러오지 못했습니다')
       expect(container.textContent).toContain('journal unavailable')
     })
+  })
+
+  it('shows the server replay cap without offering another duplicate page', () => {
+    hydrateAgentCoreRuntimeFromTelemetryEntries([{
+      source: 'agent_core_event',
+      type: 'agent_core:masc:trust_updated',
+      event_id: 'visible-capped-window',
+      payload: { agent_a: 'a', agent_b: 'b', trust_score: 0.5 },
+    }] as TelemetryEntry[])
+    noteAgentCoreReplayWindow({
+      loadedEvents: 5499,
+      totalMatchingEvents: 6000,
+      truncated: false,
+      capped: true,
+    })
+
+    const { container } = render(html`<${AgentCoreHealthChip} />`)
+
+    expect(container.textContent).toContain('서버 조회 한도')
+    expect(container.textContent).not.toContain('더 보기')
   })
 })

--- a/dashboard/src/components/agent-core-health-chip.test.ts
+++ b/dashboard/src/components/agent-core-health-chip.test.ts
@@ -123,7 +123,7 @@ describe('AgentCoreHealthChip', () => {
       payload: { agent_a: 'a', agent_b: 'b', trust_score: 0.5 },
     }] as TelemetryEntry[])
     noteAgentCoreReplayWindow({
-      loadedEvents: 5499,
+      loadedEvents: 1,
       totalMatchingEvents: 6000,
       truncated: false,
       capped: true,

--- a/dashboard/src/components/agent-core-health-chip.ts
+++ b/dashboard/src/components/agent-core-health-chip.ts
@@ -46,8 +46,11 @@ function describeAgentEvent(evt: AgentCoreAgentEvent): string {
 }
 
 function describeTotalEventsDetail(summary: Pick<AgentCoreHealthSummary,
-  'replayLoadedEvents' | 'replayTotalMatchingEvents' | 'replayTruncated'
+  'replayLoadedEvents' | 'replayTotalMatchingEvents' | 'replayTruncated' | 'replayCapped'
 >): string {
+  if (summary.replayCapped) {
+    return `최근 ${summary.replayLoadedEvents}개 표시 중 (서버 조회 한도)`
+  }
   if (summary.replayTruncated) {
     return `최근 ${summary.replayLoadedEvents}개 표시 중 (전체 ${summary.replayTotalMatchingEvents})`
   }

--- a/dashboard/src/components/telemetry-unified.test.ts
+++ b/dashboard/src/components/telemetry-unified.test.ts
@@ -14,6 +14,7 @@ const baseTelemetry: TelemetryResponse = {
   source: 'telemetry_unified',
   query: { source: 'tool_metric', n: 100 },
   count: 1,
+  offset: 0,
   entries: [
     {
       source: 'tool_metric',

--- a/dashboard/src/store.test.ts
+++ b/dashboard/src/store.test.ts
@@ -4,6 +4,7 @@ import {
   agentCoreReplayLoadedEvents,
   agentCoreReplayTotalMatchingEvents,
   agentCoreReplayTruncated,
+  agentCoreReplayCapped,
   agentCoreTotalLlmCalls,
   agentCoreTotalErrors,
   agentCoreLastLlmCallTs,
@@ -41,6 +42,7 @@ describe('agentCoreHealthSummary', () => {
     expect(agentCoreHealthSummary.value.replayLoadedEvents).toBe(0)
     expect(agentCoreHealthSummary.value.replayTotalMatchingEvents).toBe(0)
     expect(agentCoreHealthSummary.value.replayTruncated).toBe(false)
+    expect(agentCoreHealthSummary.value.replayCapped).toBe(false)
     expect(agentCoreHealthSummary.value.totalLlmCalls).toBe(4)
     expect(agentCoreHealthSummary.value.totalErrors).toBe(2)
     expect(agentCoreHealthSummary.value.evidenceRefsCount).toBe(0)
@@ -61,6 +63,20 @@ describe('agentCoreHealthSummary', () => {
     expect(agentCoreHealthSummary.value.replayLoadedEvents).toBe(500)
     expect(agentCoreHealthSummary.value.replayTotalMatchingEvents).toBe(1842)
     expect(agentCoreHealthSummary.value.replayTruncated).toBe(true)
+    expect(agentCoreHealthSummary.value.replayCapped).toBe(false)
+  })
+
+  it('marks a server-capped replay window without offering another page', () => {
+    noteAgentCoreReplayWindow({
+      loadedEvents: 5499,
+      totalMatchingEvents: 6000,
+      truncated: false,
+      capped: true,
+    })
+
+    expect(agentCoreReplayCapped.value).toBe(true)
+    expect(agentCoreHealthSummary.value.replayCapped).toBe(true)
+    expect(agentCoreHealthSummary.value.hasMore).toBe(false)
   })
 
   it('reflects agent event buffer length', () => {
@@ -119,6 +135,7 @@ describe('agentCoreHealthSummary', () => {
     expect(s.replayLoadedEvents).toBe(0)
     expect(s.replayTotalMatchingEvents).toBe(0)
     expect(s.replayTruncated).toBe(false)
+    expect(s.replayCapped).toBe(false)
     expect(s.totalLlmCalls).toBe(0)
     expect(s.totalErrors).toBe(0)
     expect(s.agentEventsCount).toBe(0)

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -356,6 +356,7 @@ export const agentCoreTotalEvents = signal(0)
 export const agentCoreReplayLoadedEvents = signal(0)
 export const agentCoreReplayTotalMatchingEvents = signal(0)
 export const agentCoreReplayTruncated = signal(false)
+export const agentCoreReplayCapped = signal(false)
 export const agentCoreTotalLlmCalls = signal(0)
 export const agentCoreTotalErrors = signal(0)
 export const agentCoreLastLlmCallTs = signal<number | null>(null)
@@ -376,6 +377,7 @@ export function resetAgentCoreRuntimeSignals(): void {
   agentCoreReplayLoadedEvents.value = 0
   agentCoreReplayTotalMatchingEvents.value = 0
   agentCoreReplayTruncated.value = false
+  agentCoreReplayCapped.value = false
   agentCoreTotalLlmCalls.value = 0
   agentCoreTotalErrors.value = 0
   agentCoreLastLlmCallTs.value = null
@@ -394,6 +396,7 @@ export function noteAgentCoreReplayWindow(input: {
   loadedEvents: number
   totalMatchingEvents: number
   truncated: boolean
+  capped?: boolean
   observedTotalEvents?: number
 }): void {
   const loadedEvents = Math.max(0, Math.floor(input.loadedEvents))
@@ -403,9 +406,11 @@ export function noteAgentCoreReplayWindow(input: {
     Math.floor(input.observedTotalEvents ?? totalMatchingEvents),
   )
   const truncated = input.truncated && totalMatchingEvents > loadedEvents
+  const capped = Boolean(input.capped) && totalMatchingEvents > loadedEvents
   agentCoreReplayLoadedEvents.value = loadedEvents
   agentCoreReplayTotalMatchingEvents.value = totalMatchingEvents
-  agentCoreReplayTruncated.value = truncated
+  agentCoreReplayTruncated.value = truncated && !capped
+  agentCoreReplayCapped.value = capped
   agentCoreTotalEvents.value = observedTotalEvents
 }
 
@@ -514,6 +519,7 @@ export const agentCoreHealthSummary: ReadonlySignal<AgentCoreHealthSummary> = co
   replayLoadedEvents: agentCoreReplayLoadedEvents.value,
   replayTotalMatchingEvents: agentCoreReplayTotalMatchingEvents.value,
   replayTruncated: agentCoreReplayTruncated.value,
+  replayCapped: agentCoreReplayCapped.value,
   hasMore: agentCoreReplayTruncated.value,
   totalLlmCalls: agentCoreTotalLlmCalls.value,
   totalErrors: agentCoreTotalErrors.value,

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -394,14 +394,19 @@ export function noteAgentCoreReplayWindow(input: {
   loadedEvents: number
   totalMatchingEvents: number
   truncated: boolean
+  observedTotalEvents?: number
 }): void {
   const loadedEvents = Math.max(0, Math.floor(input.loadedEvents))
   const totalMatchingEvents = Math.max(loadedEvents, Math.floor(input.totalMatchingEvents))
+  const observedTotalEvents = Math.max(
+    totalMatchingEvents,
+    Math.floor(input.observedTotalEvents ?? totalMatchingEvents),
+  )
   const truncated = input.truncated && totalMatchingEvents > loadedEvents
   agentCoreReplayLoadedEvents.value = loadedEvents
   agentCoreReplayTotalMatchingEvents.value = totalMatchingEvents
   agentCoreReplayTruncated.value = truncated
-  agentCoreTotalEvents.value = totalMatchingEvents
+  agentCoreTotalEvents.value = observedTotalEvents
 }
 
 function sameAgentCoreAgentEvent(left: AgentCoreAgentEvent, right: AgentCoreAgentEvent): boolean {

--- a/dashboard/src/types/agent-core.ts
+++ b/dashboard/src/types/agent-core.ts
@@ -57,6 +57,7 @@ export interface AgentCoreHealthSummary {
   replayLoadedEvents: number
   replayTotalMatchingEvents: number
   replayTruncated: boolean
+  replayCapped: boolean
   hasMore: boolean
   totalLlmCalls: number
   totalErrors: number

--- a/dashboard/src/types/agent-core.ts
+++ b/dashboard/src/types/agent-core.ts
@@ -6,6 +6,7 @@ import type { KeeperPhase } from './core'
 
 interface AgentCoreAgentEventBase {
   agent_name: string
+  event_id?: string
   event_type?: string
   correlation_id?: string
   run_id?: string

--- a/docs/spec/13-agent-core.md
+++ b/docs/spec/13-agent-core.md
@@ -60,7 +60,10 @@ validated against the same captured descriptor that is dispatched.
 
 `Keeper_event_bridge` subscribes to `Agent_core.Event_bus`, converts its closed
 payload variants to MASC SSE events, and appends replayable JSONL under
-`.masc/agent-core-events/`. MASC-owned domain events use the process-wide bus in
+`.masc/agent-core-events/`. Agent Core mints one producer-owned `event_id` per
+occurrence; the bridge preserves the same canonical envelope in JSONL and SSE
+so replay/live overlap is deduplicated by identity rather than content or
+timestamps. MASC-owned domain events use the process-wide bus in
 `Event_bus_slots`; they are not inferred from assistant text.
 
 ## State ownership

--- a/lib/keeper/keeper_event_bridge.ml
+++ b/lib/keeper/keeper_event_bridge.ml
@@ -8,14 +8,15 @@
     to a uniform JSON format with an "agent_core:" prefix so consumers can
     distinguish them from MASC-originated events.
 
-    Since AGENT_CORE 0.123.0 every event carries an envelope with
-    [correlation_id], [run_id], and [ts]. These are always emitted
-    in the SSE JSON so downstream consumers can join events into
-    causal chains offline.
+    Every event carries the canonical [Event_envelope] with a producer-owned
+    [event_id], correlation/run scope, event and observation time, and causal
+    pointers. The exact envelope is emitted into both durable JSONL and SSE so
+    downstream consumers can join and deduplicate one occurrence without
+    inspecting content.
 
     @since 2.96.0
     @modified 2.255.0 — accept AGENT_CORE native events (#5620)
-    @modified 2.260.0 — emit envelope correlation_id/run_id (agent-core boundary) *)
+    @modified 2.260.0 — emit canonical producer event identity *)
 
 open Keeper_event_bridge_inference
 open Keeper_event_bridge_error_json
@@ -136,16 +137,22 @@ let emit_native_event_log (evt : Agent_core.Event_bus.event) (json : Yojson.Safe
   | Agent_core.Event_bus.Custom _ -> ()
 ;;
 
-(** Build the SSE JSON wrapper. [correlation_id] and [run_id] are
-    mandatory (from the envelope); all other fields are optional.
+(** Build the durable/SSE JSON wrapper from the canonical event envelope.
+    [event_id], [correlation_id], and [run_id] are producer-owned mandatory
+    identity; adapters must not reconstruct them from content or timestamps.
     [caused_by] is the envelope's causation pointer (agent-core boundary) — for
     [agent_core:tool_completed] it equals the matching [agent_core:tool_called] row's
     [run_id], the only key that pairs the two rows. *)
 let wrap_event
-      ~ts
+      ~event_id
+      ~event_time
+      ~observed_at
       ~correlation_id
       ~run_id
+      ?seq
+      ?parent_event_id
       ?caused_by
+      ~source_clock
       ~event_type
       ~payload
       ?agent_name
@@ -157,10 +164,15 @@ let wrap_event
   `Assoc
     [ "type", `String ("agent_core:" ^ event_type)
     ; "event_type", `String event_type
-    ; "ts_unix", `Float ts
+    ; "event_id", `String event_id
+    ; "ts_unix", `Float event_time
+    ; "observed_at", `Float observed_at
     ; "correlation_id", `String correlation_id
     ; "run_id", `String run_id
+    ; "seq", Option.fold ~none:`Null ~some:(fun value -> `Int value) seq
+    ; "parent_event_id", Json_util.string_opt_to_json_trimmed parent_event_id
     ; "caused_by", Json_util.string_opt_to_json_trimmed caused_by
+    ; "source_clock", `String (Agent_core.Event_envelope.source_clock_to_string source_clock)
     ; "agent_name", Json_util.string_opt_to_json_trimmed agent_name
     ; "task_id", Json_util.string_opt_to_json_trimmed task_id
     ; "turn", Option.fold ~none:`Null ~some:(fun value -> `Int value) turn
@@ -181,8 +193,31 @@ let invocation_payload_fields invocation =
 ;;
 
 let native_event_to_json (evt : Agent_core.Event_bus.event) : Yojson.Safe.t option =
-  let { Agent_core.Event_bus.correlation_id; run_id; ts; caused_by; _ } = evt.meta in
-  let wrap = wrap_event ~ts ~correlation_id ~run_id ?caused_by in
+  let
+    { Agent_core.Event_envelope.event_id
+    ; correlation_id
+    ; run_id
+    ; event_time
+    ; observed_at
+    ; seq
+    ; parent_event_id
+    ; caused_by
+    ; source_clock
+    }
+    = evt.meta
+  in
+  let wrap =
+    wrap_event
+      ~event_id
+      ~event_time
+      ~observed_at
+      ~correlation_id
+      ~run_id
+      ?seq
+      ?parent_event_id
+      ?caused_by
+      ~source_clock
+  in
   match evt.payload with
   | Agent_core.Event_bus.AgentStarted { agent_name; task_id } ->
     let payload =
@@ -254,21 +289,19 @@ let native_event_to_json (evt : Agent_core.Event_bus.event) : Yojson.Safe.t opti
       (wrap ~event_type:"agent_input_required" ~payload ~agent_name ~task_id ())
   | Agent_core.Event_bus.AgentFailed { agent_name; task_id; error; elapsed } ->
     let projection = agent_failed_error_projection error in
+    let payload =
+      Sse_event.agent_failed_payload
+        ~agent_name
+        ~task_id
+        ~elapsed_s:elapsed
+        ~error:projection.error
+        ~error_domain:projection.error_domain
+        ~error_code:projection.error_code
+        ~error_retryable:projection.error_retryable
+        ~error_detail:projection.error_detail
+    in
     Some
-      (Sse_event.agent_failed
-         ?caused_by
-         ~ts_unix:ts
-         ~correlation_id
-         ~run_id
-         ~agent_name
-         ~task_id
-         ~elapsed_s:elapsed
-         ~error:projection.error
-         ~error_domain:projection.error_domain
-         ~error_code:projection.error_code
-         ~error_retryable:projection.error_retryable
-         ~error_detail:projection.error_detail
-         ())
+      (wrap ~event_type:"agent_failed" ~payload ~agent_name ~task_id ())
   | Agent_core.Event_bus.ToolCalled { invocation; agent_name; tool_name; _ } ->
     (* tool_called publishes before execution, so the keeper hook has not
        minted an execution_id yet — this row carries the provider call id

--- a/lib/sse_event/sse_event.ml
+++ b/lib/sse_event/sse_event.ml
@@ -465,9 +465,8 @@ let slot_scheduler_observed
 
 (** Append a caller-supplied addendum to an atd-emitted record JSON.
 
-    Used by [agent_completed] and [agent_failed] to splice the
-    runtime-local Result/Error projection ([result_fields] /
-    [error_fields]) onto the typed base record without forcing the
+    Used by [agent_completed] to splice the runtime-local Result projection
+    ([result_fields]) onto the typed base record without forcing the
     leaf event library to depend on [Agent_core] variant types.
 
     Field order is [<base record fields in atd declaration order> @
@@ -547,47 +546,4 @@ let agent_failed_payload
     }
   in
   Yojson.Safe.from_string (Sse_event_j.string_of_agent_failed_payload p)
-;;
-
-(** Emit an [agent_failed] envelope.  All five error fields are encoded in the
-    atd schema; the caller passes the simple projections directly. *)
-let agent_failed
-      ?caused_by
-      ~(ts_unix : float)
-      ~(correlation_id : string)
-      ~(run_id : string)
-      ~(agent_name : string)
-      ~(task_id : string)
-      ~(elapsed_s : float)
-      ~(error : string)
-      ~(error_domain : string)
-      ~(error_code : string)
-      ~(error_retryable : bool)
-      ~(error_detail : Yojson.Safe.t)
-      ()
-  : Yojson.Safe.t
-  =
-  let payload_json =
-    agent_failed_payload
-      ~agent_name
-      ~task_id
-      ~elapsed_s
-      ~error
-      ~error_domain
-      ~error_code
-      ~error_retryable
-      ~error_detail
-  in
-  wrap_envelope
-    { event_type = "agent_failed"
-    ; ts_unix
-    ; correlation_id
-    ; run_id
-    ; caused_by
-    ; agent_name = Some agent_name
-    ; task_id = Some task_id
-    ; turn = None
-    ; tool_name = None
-    }
-    payload_json
 ;;

--- a/lib/sse_event/sse_event.ml
+++ b/lib/sse_event/sse_event.ml
@@ -522,9 +522,35 @@ let agent_completed
     payload_json
 ;;
 
-(** Emit an [agent_failed] envelope.  All five error fields are
-    encoded in the atd schema; the caller passes the simple
-    projections directly. *)
+(** Encode the typed [agent_failed] payload independently from its delivery
+    envelope. *)
+let agent_failed_payload
+      ~(agent_name : string)
+      ~(task_id : string)
+      ~(elapsed_s : float)
+      ~(error : string)
+      ~(error_domain : string)
+      ~(error_code : string)
+      ~(error_retryable : bool)
+      ~(error_detail : Yojson.Safe.t)
+  : Yojson.Safe.t
+  =
+  let p : Sse_event_t.agent_failed_payload =
+    { agent_name
+    ; task_id
+    ; elapsed_s
+    ; error
+    ; error_domain
+    ; error_code
+    ; error_retryable
+    ; error_detail
+    }
+  in
+  Yojson.Safe.from_string (Sse_event_j.string_of_agent_failed_payload p)
+;;
+
+(** Emit an [agent_failed] envelope.  All five error fields are encoded in the
+    atd schema; the caller passes the simple projections directly. *)
 let agent_failed
       ?caused_by
       ~(ts_unix : float)
@@ -542,18 +568,15 @@ let agent_failed
   : Yojson.Safe.t
   =
   let payload_json =
-    let p : Sse_event_t.agent_failed_payload =
-      { agent_name
-      ; task_id
-      ; elapsed_s
-      ; error
-      ; error_domain
-      ; error_code
-      ; error_retryable
-      ; error_detail
-      }
-    in
-    Yojson.Safe.from_string (Sse_event_j.string_of_agent_failed_payload p)
+    agent_failed_payload
+      ~agent_name
+      ~task_id
+      ~elapsed_s
+      ~error
+      ~error_domain
+      ~error_code
+      ~error_retryable
+      ~error_detail
   in
   wrap_envelope
     { event_type = "agent_failed"

--- a/lib/sse_event/sse_event.mli
+++ b/lib/sse_event/sse_event.mli
@@ -137,12 +137,7 @@ val slot_scheduler_observed
     [(string * Yojson.Safe.t) list] and passes it via
     [~result_fields].  The list is appended to the atd-emitted base
     record in declaration order, preserving byte equality with the
-    previous inline `Assoc-construction path.
-
-    [agent_failed]'s five error fields are simple projections
-    (string/bool/Yojson.Safe.t) and are encoded directly in the atd
-    schema, so they are passed as labeled arguments instead of an
-    addendum list. *)
+    previous inline `Assoc-construction path. *)
 
 val agent_completed
   :  ts_unix:float
@@ -152,22 +147,6 @@ val agent_completed
   -> task_id:string
   -> elapsed_s:float
   -> result_fields:(string * Yojson.Safe.t) list
-  -> Yojson.Safe.t
-
-val agent_failed
-  :  ?caused_by:string
-  -> ts_unix:float
-  -> correlation_id:string
-  -> run_id:string
-  -> agent_name:string
-  -> task_id:string
-  -> elapsed_s:float
-  -> error:string
-  -> error_domain:string
-  -> error_code:string
-  -> error_retryable:bool
-  -> error_detail:Yojson.Safe.t
-  -> unit
   -> Yojson.Safe.t
 
 (** Encode the typed [agent_failed] payload without an envelope. Adapter

--- a/lib/sse_event/sse_event.mli
+++ b/lib/sse_event/sse_event.mli
@@ -169,3 +169,17 @@ val agent_failed
   -> error_detail:Yojson.Safe.t
   -> unit
   -> Yojson.Safe.t
+
+(** Encode the typed [agent_failed] payload without an envelope. Adapter
+    boundaries that own a richer canonical envelope can reuse the schema
+    encoder without decoding or rebuilding its fields. *)
+val agent_failed_payload
+  :  agent_name:string
+  -> task_id:string
+  -> elapsed_s:float
+  -> error:string
+  -> error_domain:string
+  -> error_code:string
+  -> error_retryable:bool
+  -> error_detail:Yojson.Safe.t
+  -> Yojson.Safe.t

--- a/lib/telemetry_unified/telemetry_unified.ml
+++ b/lib/telemetry_unified/telemetry_unified.ml
@@ -797,10 +797,7 @@ let read_unified_result ~base_path ~masc_root ?(sources = all_sources)
   (* Sort by timestamp descending (newest first) *)
   let sorted = sort_newest_first filtered in
   let total_matching_entries = List.length sorted in
-  let entries =
-    if total_matching_entries <= offset + n then sorted
-    else sorted |> List.drop offset |> take_first n
-  in
+  let entries = sorted |> List.drop offset |> take_first n in
   { entries; total_matching_entries; truncated = total_matching_entries > offset + n }
 
 let read_unified ~base_path ~masc_root ?sources ?keeper_name ?session_id

--- a/packages/agent_core/docs/EVENT-CATALOG.md
+++ b/packages/agent_core/docs/EVENT-CATALOG.md
@@ -51,20 +51,29 @@ Event_bus payloads.
 Every event carries a common envelope:
 
 ```ocaml
-type envelope = {
-  correlation_id: string;       (* session-level, stable across a run *)
-  run_id: string;               (* per-run identifier *)
-  ts: float;                    (* Unix epoch seconds *)
-  caused_by: string option;     (* optional causation link (#877) *)
+type envelope = Event_envelope.t = {
+  event_id: string;              (* producer-owned occurrence identity *)
+  correlation_id: string;        (* session-level, stable across a run *)
+  run_id: string;                (* per-run identifier *)
+  event_time: float;             (* producer event time *)
+  observed_at: float;            (* producer observation time *)
+  seq: int option;
+  parent_event_id: string option;
+  caused_by: string option;
+  source_clock: source_clock;
 }
 ```
 
-**Contract**: `correlation_id` is constant for all events belonging to the
-same logical session. `run_id` is unique per agent run. `caused_by`, when
-`Some id`, points at the prior `run_id` (or `correlation_id`) that
-causally triggered this event — enabling A→B→C cascade reconstruction
-within a session. Root events and legacy producers set `caused_by =
-None`. Envelopes are filled by producers, never rewritten by subscribers.
+**Contract**: `event_id` is minted once from operating-system entropy by the
+producer for one occurrence and is preserved unchanged by durable, replay, and
+live-delivery adapters. Entropy failure is explicit; clocks, process IDs,
+paths, and event content are not identity fallbacks.
+`correlation_id` is constant for all events belonging to the same logical
+session. `run_id` is unique per agent run. `caused_by`, when `Some id`, points
+at the prior `run_id` (or `correlation_id`) that causally triggered this event
+— enabling A→B→C cascade reconstruction within a session. Root events set
+`caused_by = None`. Envelopes are filled by producers, never reconstructed or
+rewritten by subscribers.
 
 ### 2.2 Native payload variants
 
@@ -89,7 +98,8 @@ Pattern-matchable OCaml sum type. **Stable across every provider.**
 
 **Invariants**:
 - **I1 Provider-agnostic**: every native payload field is meaningful regardless of which provider serves the underlying LLM.
-- **I2 Stable envelope**: envelope field set is identical across providers.
+- **I2 Stable envelope**: envelope field set is identical across providers and
+  every occurrence has a non-empty, producer-owned `event_id`.
 - **I6 Multi-vendor**: a native variant is only added if its semantic exists in ≥2 vendor SDKs.
 
 ### 2.3 Custom namespaces (reserved)

--- a/packages/agent_core/docs/schema-surfaces/runtime-output-surfaces.v1.json
+++ b/packages/agent_core/docs/schema-surfaces/runtime-output-surfaces.v1.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-07-21",
+  "updated_at": "2026-08-14",
   "description": "Operator-facing index of AGENT_CORE runtime output and schema surfaces. Entries whose producer referenced the deleted Runtime_server / Runtime_sync / Runtime_projection / Runtime_evidence cluster (removed in v0.217.x) are marked removed_in; their schema files under docs/schemas/ are retained for historical decode only.",
   "surfaces": [
     {
@@ -15,7 +15,7 @@
       "tests": ["test/test_event_bus.ml", "test/test_event_envelope.ml"],
       "stability": "evolving",
       "version_field": null,
-      "notes": "Native payloads stay provider-agnostic; downstream domain events should use Custom or a downstream bus."
+      "notes": "Native payloads stay provider-agnostic and every occurrence carries one producer-owned event_id preserved by durable and live adapters; downstream domain events should use Custom or a downstream bus."
     },
     {
       "id": "agent_core.runtime_protocol.v2",

--- a/packages/agent_core/lib/durable_event.ml
+++ b/packages/agent_core/lib/durable_event.ml
@@ -7,10 +7,6 @@
 
 (* ── Event types ──────────────────────────────────── *)
 
-type envelope_v2 = Event_envelope.t
-
-let mk_envelope_v2 = Event_envelope.make
-
 type event =
   | Turn_started of
       { turn : int

--- a/packages/agent_core/lib/durable_event.mli
+++ b/packages/agent_core/lib/durable_event.mli
@@ -18,24 +18,6 @@
 
 (** {1 Event types} *)
 
-(** Canonical envelope type for adapters that project durable journal events
-    across runtimes. Journal variants remain unchanged for compatibility.
-    @since 0.170.5 *)
-type envelope_v2 = Event_envelope.t
-
-val mk_envelope_v2
-  :  ?event_id:string
-  -> ?correlation_id:string
-  -> ?run_id:string
-  -> ?event_time:float
-  -> ?observed_at:float
-  -> ?seq:int
-  -> ?parent_event_id:string
-  -> ?caused_by:string
-  -> ?source_clock:Event_envelope.source_clock
-  -> unit
-  -> envelope_v2
-
 (** An agent loop event. Each variant captures the data needed
     to replay the action without re-executing it. *)
 type event =

--- a/packages/agent_core/lib/event_bus.ml
+++ b/packages/agent_core/lib/event_bus.ml
@@ -13,14 +13,7 @@ open Types
 
 (* ── Envelope ─────────────────────────────────────────────────────── *)
 
-type envelope =
-  { correlation_id : string
-  ; run_id : string
-  ; ts : float
-  ; caused_by : string option
-  }
-
-type envelope_v2 = Event_envelope.t
+type envelope = Event_envelope.t
 
 (* ── Payload type ─────────────────────────────────────────────────── *)
 
@@ -150,38 +143,18 @@ let payload_kind = function
 
 let fresh_id = Event_envelope.fresh_id
 
-let mk_envelope ?correlation_id ?run_id ?caused_by () =
-  let correlation_id =
-    match correlation_id with
-    | Some id -> id
-    | None -> fresh_id ()
-  in
-  let run_id =
-    match run_id with
-    | Some id -> id
-    | None -> fresh_id ()
-  in
-  { correlation_id; run_id; ts = Unix.gettimeofday (); caused_by }
-;;
-
-let mk_envelope_v2 = Event_envelope.make
-
-let envelope_v2_of_envelope ?event_id ?observed_at ?seq ?parent_event_id (env : envelope) =
+let mk_envelope ?event_id ?correlation_id ?run_id ?caused_by () =
   Event_envelope.make
     ?event_id
-    ~correlation_id:env.correlation_id
-    ~run_id:env.run_id
-    ~event_time:env.ts
-    ?observed_at
-    ?seq
-    ?parent_event_id
-    ?caused_by:env.caused_by
+    ?correlation_id
+    ?run_id
+    ?caused_by
     ~source_clock:Event_envelope.Wall
     ()
 ;;
 
-let mk_event ?correlation_id ?run_id ?caused_by payload =
-  { meta = mk_envelope ?correlation_id ?run_id ?caused_by (); payload }
+let mk_event ?event_id ?correlation_id ?run_id ?caused_by payload =
+  { meta = mk_envelope ?event_id ?correlation_id ?run_id ?caused_by (); payload }
 ;;
 
 (* ── Subscription ─────────────────────────────────────────────────── *)

--- a/packages/agent_core/lib/event_bus.mli
+++ b/packages/agent_core/lib/event_bus.mli
@@ -10,28 +10,10 @@
 
 (** {2 Envelope} *)
 
-(** Correlation metadata attached to every event. *)
-type envelope =
-  { correlation_id : string (** Session-level correlation (formerly session_id). *)
-  ; run_id : string (** Per-run identifier (formerly worker_run_id). *)
-  ; ts : float (** Event timestamp (Unix epoch). *)
-  ; caused_by : string option
-    (** Causal scope identifier. Distinct from [correlation_id]
-        (same-session scoping): [caused_by] points at a specific prior
-        [run_id] or [correlation_id] to reconstruct
-        A→B→C cascades within a session. [None] means "no known parent
-        event" (root of a causation chain). Convention:
-        [caused_by = Some parent.run_id] when the trigger is a concrete
-        event; [caused_by = Some parent.correlation_id] when the
-        trigger is the session as a whole. Anthropic Multi-Agent
-        Pattern 4 (Message Bus). @since 0.161.0 (#877) *)
-  }
-
-(** Richer, cross-runtime envelope with explicit event IDs, observation time,
-    and sequence/parent metadata. Existing {!envelope} remains the event bus
-    compatibility shape; new adapters should prefer [envelope_v2].
-    @since 0.170.5 *)
-type envelope_v2 = Event_envelope.t
+(** Canonical producer-owned identity and causality metadata attached to every
+    event. The event bus and its durable/SSE adapters share this exact envelope,
+    so one occurrence keeps one [event_id] across every delivery surface. *)
+type envelope = Event_envelope.t
 
 (** {2 Payload types} *)
 
@@ -219,45 +201,27 @@ val payload_kind : payload -> string
 
 (** {2 ID generation} *)
 
-(** Generate a process-local compatibility identifier. AGENT_CORE's private canonical
-    execution writer owns its own typed random identity. *)
+(** Generate a producer-owned, cross-process collision-resistant event
+    identifier. Raises {!Event_envelope.Entropy_unavailable} rather than
+    fabricating a clock- or content-derived fallback. *)
 val fresh_id : unit -> string
 
-(** Create an envelope with optional correlation/run IDs (defaults to fresh)
-    and an optional causation link.
+(** Create a canonical envelope. Event, correlation, and run IDs default to
+    fresh producer-owned values.
     @since 0.161.0 [?caused_by] added. *)
 val mk_envelope
-  :  ?correlation_id:string
-  -> ?run_id:string
-  -> ?caused_by:string
-  -> unit
-  -> envelope
-
-val mk_envelope_v2
   :  ?event_id:string
   -> ?correlation_id:string
   -> ?run_id:string
-  -> ?event_time:float
-  -> ?observed_at:float
-  -> ?seq:int
-  -> ?parent_event_id:string
   -> ?caused_by:string
-  -> ?source_clock:Event_envelope.source_clock
   -> unit
-  -> envelope_v2
-
-val envelope_v2_of_envelope
-  :  ?event_id:string
-  -> ?observed_at:float
-  -> ?seq:int
-  -> ?parent_event_id:string
   -> envelope
-  -> envelope_v2
 
 (** Create an event by wrapping a payload in a fresh envelope.
     @since 0.161.0 [?caused_by] added. *)
 val mk_event
-  :  ?correlation_id:string
+  :  ?event_id:string
+  -> ?correlation_id:string
   -> ?run_id:string
   -> ?caused_by:string
   -> payload

--- a/packages/agent_core/lib/event_envelope.ml
+++ b/packages/agent_core/lib/event_envelope.ml
@@ -16,12 +16,12 @@ type t =
   ; source_clock : source_clock
   }
 
-let id_counter = Atomic.make 0
+exception Entropy_unavailable of string
 
 let fresh_id () =
-  let n = Atomic.fetch_and_add id_counter 1 in
-  let now_us = Int.of_float (Unix.gettimeofday () *. 1e6) in
-  Printf.sprintf "evt-%x-%x-%x" (Unix.getpid ()) now_us n
+  match Llm_provider.Random_id.create () with
+  | Ok value -> "evt-" ^ value
+  | Error detail -> raise (Entropy_unavailable detail)
 ;;
 
 let source_clock_to_string = function

--- a/packages/agent_core/lib/event_envelope.mli
+++ b/packages/agent_core/lib/event_envelope.mli
@@ -1,8 +1,6 @@
-(** Canonical event envelope for cross-runtime causality evidence.
-
-    This module is intentionally independent from {!Event_bus}: existing
-    event bus envelopes remain backward-compatible, while new code can use
-    this richer envelope for durable event streams and adapter boundaries. *)
+(** Canonical event envelope for cross-runtime causality evidence. Event buses,
+    durable stores, and adapter boundaries carry this same producer-owned
+    identity instead of reconstructing identity from content or timestamps. *)
 
 type source_clock =
   | Wall
@@ -19,14 +17,17 @@ type t =
   ; seq : int option
   ; parent_event_id : string option
   ; caused_by : string option
-    (** Untyped compatibility causation field. Private canonical execution
-        events require this to be [None] and carry typed plural causes outside
-        this compatibility envelope. *)
+    (** External causation pointer. Private execution events carry typed plural
+        causes outside this envelope and require this field to be [None]. *)
   ; source_clock : source_clock
   }
 
-(** Generate a process-local compatibility identifier. AGENT_CORE's private canonical
-    execution writer owns its own typed random identity. *)
+(** Raised when the operating-system entropy source cannot mint an identity.
+    Identity creation never falls back to clocks, process IDs, paths, or event
+    content. *)
+exception Entropy_unavailable of string
+
+(** Generate a producer-owned, cross-process collision-resistant identifier. *)
 val fresh_id : unit -> string
 
 val source_clock_to_string : source_clock -> string

--- a/packages/agent_core/test/test_event_bus.ml
+++ b/packages/agent_core/test/test_event_bus.ml
@@ -987,14 +987,19 @@ let test_fresh_id_unique () =
 
 let test_mk_envelope_defaults () =
   let env = Event_bus.mk_envelope () in
+  check bool "event_id non-empty" true (String.length env.event_id > 0);
   check bool "correlation_id non-empty" true (String.length env.correlation_id > 0);
   check bool "run_id non-empty" true (String.length env.run_id > 0);
-  check bool "ts > 0" true (env.ts > 0.0);
+  check bool "event_time > 0" true (env.event_time > 0.0);
+  check bool "observed_at > 0" true (env.observed_at > 0.0);
   check (option string) "caused_by defaults to None" None env.caused_by
 ;;
 
 let test_mk_envelope_explicit () =
-  let env = Event_bus.mk_envelope ~correlation_id:"c" ~run_id:"r" () in
+  let env =
+    Event_bus.mk_envelope ~event_id:"e" ~correlation_id:"c" ~run_id:"r" ()
+  in
+  check string "event_id" "e" env.event_id;
   check string "correlation_id" "c" env.correlation_id;
   check string "run_id" "r" env.run_id;
   check (option string) "caused_by omitted stays None" None env.caused_by

--- a/packages/agent_core/test/test_multivendor_events.ml
+++ b/packages/agent_core/test/test_multivendor_events.ml
@@ -9,8 +9,8 @@
 
     Invariants checked (see docs/EVENT-CATALOG.md Invariants I1-I6):
 
-    - I1/I2: Envelope fields (correlation_id, run_id, ts) are present and
-      preserved across every native variant.
+    - I1/I2: Producer event identity, correlation/run scope, and event time are
+      present and preserved across every native variant.
     - Event_bus.payload_kind returns the canonical label for each native
       variant.
     - The golden lifecycle transcript (AgentStarted -> TurnStarted ->
@@ -105,11 +105,17 @@ let test_envelope_preserved_across_variants () =
   List.iter (fun p -> Event_bus.publish bus (mk p)) variants;
   let received = Event_bus.drain sub in
   check int "count" (List.length variants) (List.length received);
+  let event_ids = List.map (fun (event : Event_bus.event) -> event.meta.event_id) received in
+  check int "every occurrence has a distinct producer id"
+    (List.length event_ids)
+    (List.length (List.sort_uniq String.compare event_ids));
   List.iter
     (fun (e : Event_bus.event) ->
+       check bool "event_id populated" true (String.length e.meta.event_id > 0);
        check string "correlation_id preserved" corr e.meta.correlation_id;
        check string "run_id preserved" run_id e.meta.run_id;
-       check bool "ts populated" true (e.meta.ts > 0.0))
+       check bool "event time populated" true (e.meta.event_time > 0.0);
+       check bool "observation time populated" true (e.meta.observed_at > 0.0))
     received
 ;;
 

--- a/packages/agent_core/test/test_multivendor_live.ml
+++ b/packages/agent_core/test/test_multivendor_live.ml
@@ -24,7 +24,7 @@
 
     Invariants checked, per EVENT-CATALOG.md I1/I2:
     - Same native variant names across every provider.
-    - Envelope [correlation_id] / [run_id] present and preserved.
+    - Envelope [event_id] / [correlation_id] / [run_id] present and preserved.
 
     Run manually:
       dune exec --root . test/test_multivendor_live.exe *)
@@ -55,8 +55,19 @@ let assert_transcript ~provider ~names =
 ;;
 
 let assert_envelope ~provider events =
+  let event_ids = List.map (fun (event : Event_bus.event) -> event.meta.event_id) events in
+  check
+    int
+    (Printf.sprintf "[%s] every occurrence has a distinct producer id" provider)
+    (List.length event_ids)
+    (List.length (List.sort_uniq String.compare event_ids));
   List.iter
     (fun (e : Event_bus.event) ->
+       check
+         bool
+         (Printf.sprintf "[%s] event_id non-empty" provider)
+         true
+         (String.length e.meta.event_id > 0);
        check
          bool
          (Printf.sprintf "[%s] correlation_id non-empty" provider)
@@ -67,7 +78,16 @@ let assert_envelope ~provider events =
          (Printf.sprintf "[%s] run_id non-empty" provider)
          true
          (String.length e.meta.run_id > 0);
-       check bool (Printf.sprintf "[%s] ts populated" provider) true (e.meta.ts > 0.0))
+       check
+         bool
+         (Printf.sprintf "[%s] event time populated" provider)
+         true
+         (e.meta.event_time > 0.0);
+       check
+         bool
+         (Printf.sprintf "[%s] observation time populated" provider)
+         true
+         (e.meta.observed_at > 0.0))
     events
 ;;
 

--- a/test/sse_event/test_sse_event.ml
+++ b/test/sse_event/test_sse_event.ml
@@ -572,7 +572,7 @@ let test_slot_scheduler_observed_byte_equal () =
     typed
 ;;
 
-(* === PR-3b byte-equal cases: agent_completed (Ok + Error), agent_failed.
+(* === PR-3b byte-equal cases: agent_completed (Ok + Error), agent_failed payload.
 
    These three cases pin the caller-supplied-addendum splice path
    (Sse_event.merge_addendum_into_record) against the pre-PR-3b
@@ -600,23 +600,12 @@ let baseline_agent_completed ~agent_name ~task_id ~elapsed_s ~result_fields =
 ;;
 
 let baseline_agent_failed ~agent_name ~task_id ~elapsed_s ~error_fields =
-  let payload =
-    `Assoc
-      ([ "agent_name", `String agent_name
-       ; "task_id", `String task_id
-       ; "elapsed_s", `Float elapsed_s
-       ]
-       @ error_fields)
-  in
-  baseline_wrap_event
-    ~ts:common_ts
-    ~correlation_id:common_corr
-    ~run_id:common_run
-    ~event_type:"agent_failed"
-    ~payload
-    ~agent_name
-    ~task_id
-    ()
+  `Assoc
+    ([ "agent_name", `String agent_name
+     ; "task_id", `String task_id
+     ; "elapsed_s", `Float elapsed_s
+     ]
+     @ error_fields)
 ;;
 
 let agent_completed_ok_fields : (string * Yojson.Safe.t) list =
@@ -719,7 +708,7 @@ let test_agent_completed_error_byte_equal () =
     typed
 ;;
 
-let test_agent_failed_byte_equal () =
+let test_agent_failed_payload_byte_equal () =
   let baseline =
     Yojson.Safe.to_string
       (baseline_agent_failed
@@ -730,10 +719,7 @@ let test_agent_failed_byte_equal () =
   in
   let typed =
     Yojson.Safe.to_string
-      (Sse_event.agent_failed
-         ~ts_unix:common_ts
-         ~correlation_id:common_corr
-         ~run_id:common_run
+      (Sse_event.agent_failed_payload
          ~agent_name:"alpha"
          ~task_id:"task_42"
          ~elapsed_s:3.5
@@ -741,8 +727,7 @@ let test_agent_failed_byte_equal () =
          ~error_domain:agent_failed_error_domain
          ~error_code:agent_failed_error_code
          ~error_retryable:agent_failed_error_retryable
-         ~error_detail:agent_failed_error_detail
-         ())
+         ~error_detail:agent_failed_error_detail)
   in
   Alcotest.(check string) "agent_failed typed == baseline" baseline typed
 ;;
@@ -828,7 +813,8 @@ let () =
             test_agent_completed_ok_byte_equal
         ; Alcotest.test_case "agent_completed (Error)" `Quick
             test_agent_completed_error_byte_equal
-        ; Alcotest.test_case "agent_failed" `Quick test_agent_failed_byte_equal
+        ; Alcotest.test_case "agent_failed payload" `Quick
+            test_agent_failed_payload_byte_equal
         ; Alcotest.test_case "agent_completed (empty addendum)" `Quick
             test_agent_completed_empty_addendum_byte_equal
         ] )

--- a/test/test_keeper_execution_join.ml
+++ b/test/test_keeper_execution_join.ml
@@ -54,13 +54,16 @@ let test_rerecord_overwrites () =
 
 (* ── Bridge stamping ──────────────────────────────────── *)
 
-let mk_event ?caused_by payload : Agent_core.Event_bus.event =
-  { meta =
-      { correlation_id = "corr-1"
-      ; run_id = "run-1"
-      ; ts = 1781200000.0
-      ; caused_by
-      }
+let mk_event ?(event_id = "event-1") ?caused_by payload : Agent_core.Event_bus.event =
+  let meta =
+    Agent_core.Event_bus.mk_envelope
+      ~event_id
+      ~correlation_id:"corr-1"
+      ~run_id:"run-1"
+      ?caused_by
+      ()
+  in
+  { meta = { meta with event_time = 1781200000.0; observed_at = 1781200000.5 }
   ; payload
   }
 
@@ -357,7 +360,7 @@ let test_terminal_agent_failure_projection_redacts_detail () =
           }))
 ;;
 
-let test_agent_failed_matches_typed_sse_event () =
+let test_agent_failed_keeps_canonical_envelope_and_typed_error () =
   let agent_name = "agent_core-r1" in
   let task_id = "task-failed-1" in
   let elapsed_s = 4.25 in
@@ -380,30 +383,52 @@ let test_agent_failed_matches_typed_sse_event () =
   let actual =
     Bridge.native_event_to_json
       (mk_event
+         ~event_id:"event-agent-failed-1"
          ~caused_by
          (Agent_core.Event_bus.AgentFailed
             { agent_name; task_id; error; elapsed = elapsed_s }))
     |> Option.get
-    |> Yojson.Safe.to_string
   in
-  let expected =
-    Sse_event.agent_failed
-      ~caused_by
-      ~ts_unix:1781200000.0
-      ~correlation_id:"corr-1"
-      ~run_id:"run-1"
-      ~agent_name
-      ~task_id
-      ~elapsed_s
-      ~error:projection.error
-      ~error_domain:projection.error_domain
-      ~error_code:projection.error_code
-      ~error_retryable:projection.error_retryable
-      ~error_detail:projection.error_detail
-      ()
-    |> Yojson.Safe.to_string
+  check (option string) "producer event identity" (Some "event-agent-failed-1")
+    (string_of_field (member "event_id" actual));
+  check (option string) "causation survives" (Some caused_by)
+    (string_of_field (member "caused_by" actual));
+  check (option string) "serialized error domain" (Some projection.error_domain)
+    (string_of_field (payload_member "error_domain" actual));
+  check bool "serialized typed detail" true
+    (payload_member "error_detail" actual = Some projection.error_detail)
+
+let test_publish_to_bridge_preserves_one_producer_identity () =
+  Eio_main.run @@ fun _env ->
+  let bus = Agent_core.Event_bus.create () in
+  let config =
+    Agent_core.Event_bus.subscription_config
+      ~capacity:2
+      ~overflow:Agent_core.Event_bus.Drop_oldest
+    |> Result.get_ok
   in
-  check string "agent_failed bridge matches typed constructor" expected actual
+  let subscription = Agent_core.Event_bus.subscribe ~config bus in
+  let event =
+    Agent_core.Event_bus.mk_event
+      ~event_id:"event-publish-bridge-1"
+      ~correlation_id:"corr-publish-bridge"
+      ~run_id:"run-publish-bridge"
+      (Agent_core.Event_bus.TurnStarted { agent_name = "keeper-a"; turn = 3 })
+  in
+  Agent_core.Event_bus.publish bus event;
+  let delivered =
+    match Agent_core.Event_bus.drain subscription with
+    | [ delivered ] -> delivered
+    | events -> failf "expected one delivered event, got %d" (List.length events)
+  in
+  let first = Bridge.native_event_to_json delivered |> Option.get in
+  let retry = Bridge.native_event_to_json delivered |> Option.get in
+  check (option string) "published identity reaches adapter"
+    (Some "event-publish-bridge-1")
+    (string_of_field (member "event_id" first));
+  check string "re-serialization keeps exact occurrence identity"
+    (Yojson.Safe.to_string first)
+    (Yojson.Safe.to_string retry)
 
 let test_authorization_errors_have_typed_projection () =
   let check_projection label expected_domain error =
@@ -608,8 +633,10 @@ let () =
             test_empty_tool_use_id_omitted_from_payload
         ; test_case "non-terminal outcomes keep distinct wire types" `Quick
             test_non_terminal_agent_outcomes_keep_distinct_wire_types
-        ; test_case "agent_failed matches typed constructor" `Quick
-            test_agent_failed_matches_typed_sse_event
+        ; test_case "agent_failed keeps canonical envelope" `Quick
+            test_agent_failed_keeps_canonical_envelope_and_typed_error
+        ; test_case "publish to bridge preserves producer identity" `Quick
+            test_publish_to_bridge_preserves_one_producer_identity
         ; test_case "terminal agent failures redact raw detail" `Quick
             test_terminal_agent_failure_projection_redacts_detail
         ; test_case "authorization errors have typed projection" `Quick

--- a/test/test_keeper_unified_turn_event_bus.ml
+++ b/test/test_keeper_unified_turn_event_bus.ml
@@ -10,11 +10,11 @@ module EB = Masc.Keeper_unified_turn_event_bus
 
 let dummy_event payload =
   { Agent_core.Event_bus.meta =
-      { correlation_id = "c"
-      ; run_id = "r"
-      ; ts = 0.0
-      ; caused_by = None
-      }
+      Agent_core.Event_bus.mk_envelope
+        ~event_id:"event"
+        ~correlation_id:"c"
+        ~run_id:"r"
+        ()
   ; payload
   }
 ;;

--- a/test/test_telemetry_unified.ml
+++ b/test/test_telemetry_unified.ml
@@ -542,6 +542,33 @@ let test_n_limits_output () =
   in
   Alcotest.(check int) "limited to 10" 10 (List.length entries)
 
+let test_offset_windows_final_page () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "telem_offset_final_page" in
+  let telemetry_dir = Filename.concat dir ".masc/telemetry" in
+  Fs_compat.mkdir_p telemetry_dir;
+  write_jsonl telemetry_dir
+    (List.init 3 (fun i ->
+       `Assoc [ "timestamp", `Float (Float.of_int i); "i", `Int i ]));
+  let read offset =
+    Telemetry_unified.read_unified_result
+      ~base_path:dir
+      ~masc_root:(masc_root dir)
+      ~sources:[ Telemetry_unified.Agent_event ]
+      ~limit:(Telemetry_unified.read_limit_of_int 2)
+      ~offset
+      ()
+  in
+  let final_page = read 2 in
+  Alcotest.(check int) "total remains pre-page" 3
+    final_page.total_matching_entries;
+  Alcotest.(check bool) "final page is not truncated" false final_page.truncated;
+  Alcotest.(check (list int)) "offset drops the preceding rows" [ 0 ]
+    (List.map (json_int_field "i") final_page.entries);
+  Alcotest.(check int) "offset at end is empty" 0
+    (List.length (read 3).entries)
+
 let test_time_window_reports_total_before_limit () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1530,6 +1557,8 @@ let () =
             test_keeper_metrics_fast_path_sets_truncated_with_marker;
           Alcotest.test_case "sorted newest first" `Quick test_sorted_newest_first;
           Alcotest.test_case "n limits output" `Quick test_n_limits_output;
+          Alcotest.test_case "offset windows final page" `Quick
+            test_offset_windows_final_page;
           Alcotest.test_case "time window reports total before limit" `Quick
             test_time_window_reports_total_before_limit;
           Alcotest.test_case "time window reads matching day files" `Quick


### PR DESCRIPTION
## Summary
- include the dashboard replay paging/dedup stack from #28556 in the same end-to-end change
- make `Event_bus.envelope` the canonical `Event_envelope.t` and remove the remaining dead `envelope_v2`/`mk_envelope_v2` facade
- mint collision-resistant `event_id` once from OS entropy at native event creation; entropy failure is explicit and never falls back to clocks/PIDs/content
- preserve the exact envelope through Keeper JSONL/SSE serialization and key dashboard replay/live projection by that global event identity
- retain unidentified rows without content heuristics and retain `(run_id, seq)` only where a producer supplies that typed identity
- keep replay fetch cursor separate from the deduplicated materialized count shown to operators
- queue live arrivals across full replay hydration so reset cannot discard an accepted live event

## Why
The production dashboard could dedupe only identities the Keeper bridge did not emit. Keeping producer and consumer in separate merge units left both sides individually unable to prove the feature. This PR owns the complete occurrence path: EventBus creation → Keeper JSONL/SSE envelope → telemetry replay/live ingestion → one dashboard projection. It supersedes #28556 once exact-head CI/review pass.

## Verification
- focused dashboard Vitest: 3 files, 33 tests passed
- focused dashboard ESLint passed
- dashboard TypeScript typecheck passed
- `ocamlc -stop-after parsing` on changed `.ml`/`.mli`
- `ocamlformat --check` on changed `.ml`/`.mli`
- `GITHUB_BASE_REF=main python3 scripts/check_test_coverage.py`
- `git diff --check`
- no local Dune run; CI is the OCaml build/test authority

## Compatibility decision
This pre-release product uses a current-only contract. The unused `Event_bus.envelope_v2`, `Durable_event.envelope_v2`, conversion helpers, and the dead noncanonical `Sse_event.agent_failed` envelope constructor are deleted rather than retained behind deprecation facades.

## Merge policy
Draft and `status:do-not-merge` until exact-head CI and adversarial review are complete.
