### PR TITLE
fix(keeper): bound the Antigravity turn prompt with the declared max-prompt-bytes

### DIFF
--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -59,13 +59,15 @@ let home_error_to_core_error error =
     (Runtime_antigravity_home.error_to_string error)
 ;;
 
+let history_role_label = function
+  | Agent_core.Types.System -> "SYSTEM:\n"
+  | Agent_core.Types.User -> "USER:\n"
+  | Agent_core.Types.Assistant -> "ASSISTANT:\n"
+  | Agent_core.Types.Tool -> "TOOL:\n"
+;;
+
 let render_message (message : Agent_core.Types.message) =
-  let text = Host.encode_history_message message in
-  match message.role with
-  | Agent_core.Types.System -> Ok ("SYSTEM:\n" ^ text)
-  | Agent_core.Types.User -> Ok ("USER:\n" ^ text)
-  | Agent_core.Types.Assistant -> Ok ("ASSISTANT:\n" ^ text)
-  | Agent_core.Types.Tool -> Ok ("TOOL:\n" ^ text)
+  Ok (history_role_label message.role ^ Host.encode_history_message message)
 ;;
 
 let render_messages messages =
@@ -86,8 +88,14 @@ let extra_system_context_messages messages =
     messages
 ;;
 
+let system_instructions_label = "SYSTEM INSTRUCTIONS:\n"
+let current_goal_label = "CURRENT GOAL:\n"
+let prompt_section_separator = "\n\n"
+
 let measure_model_input_message_bytes (message : Agent_core.Types.message) =
-  String.length (Host.encode_history_message message)
+  String.length (history_role_label message.role)
+  + String.length (Host.encode_history_message message)
+  + String.length prompt_section_separator
 ;;
 
 (* The declared per-model [max-prompt-bytes] is the only authority that can
@@ -107,13 +115,10 @@ let measure_model_input_message_bytes (message : Agent_core.Types.message) =
 
    [prompt_section_framing_reserved_bytes] is derived from the actual label
    literals [prompt_for_turn] concatenates, so a label change cannot silently
-   outgrow the reserve. Per-message role prefixes are not measured; the
-   declared capacity is expected to sit well under the client's observed
-   input cliff (~185KB), so the deployment margin absorbs that slack. *)
-let system_instructions_label = "SYSTEM INSTRUCTIONS:\n"
-let current_goal_label = "CURRENT GOAL:\n"
-let prompt_section_separator = "\n\n"
-
+   outgrow the reserve. Each history message is charged its actual role label
+   plus one separator; charging a separator for the last message too is a
+   deliberate conservative byte that keeps the rendered prompt within the
+   declared cap without depending on deployment margin. *)
 let prompt_section_framing_reserved_bytes =
   String.length system_instructions_label
   + String.length current_goal_label
@@ -922,5 +927,12 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
 module For_testing = struct
   let capacity_bounded_model_input_projection =
     capacity_bounded_model_input_projection
+  ;;
+
+  let start_prompt_bytes ~system_prompt ~goal messages =
+    let prepared : Host.prepared_turn =
+      { messages; system_prompt; tools = []; reasoning_effort = None }
+    in
+    Result.map String.length (prompt_for_turn ~is_resume:false ~goal prepared)
   ;;
 end

--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -86,6 +86,85 @@ let extra_system_context_messages messages =
     messages
 ;;
 
+let measure_model_input_message_bytes (message : Agent_core.Types.message) =
+  String.length (Host.encode_history_message message)
+;;
+
+(* The declared per-model [max-prompt-bytes] is the only authority that can
+   bound this provider's turn prompt. The reactive shrink contract the other
+   official clients rely on has no stimulus here: agy 1.1.12 does not refuse
+   an oversized prompt with a typed overflow — it silently truncates the
+   stdin payload (11,386,764 bytes sent, 185,751-byte USER_INPUT recorded by
+   the client, 2026-08-14) so the goal at the tail never reaches the model,
+   and while stalled on the oversized payload its print-mode response
+   subscriber is killed ("Publish killing slow subscriber ... stalled for
+   5s"), after which the result event reports SUCCESS with an empty
+   response. Six of six spawns failed exactly that way on 2026-08-14, each
+   parking the session and re-sending the full history to a fresh
+   conversation. Windowing the provider-bound history up front to the
+   declared capacity is therefore this runtime's admission contract, not a
+   second authority over a provider-owned window.
+
+   [prompt_section_framing_reserved_bytes] covers the constant section labels
+   [prompt_for_turn] adds ("SYSTEM INSTRUCTIONS:\n", "CURRENT GOAL:\n",
+   separators). Per-message role prefixes are not measured; the declared
+   capacity is expected to sit well under the client's observed input cliff
+   (~185KB), so the deployment margin absorbs that slack. *)
+let prompt_section_framing_reserved_bytes = 64
+
+let bounded_history_projection ~capacity_bytes ~reserved_bytes source_projection
+  : Agent_core.Agent.model_input_projection
+  =
+  fun messages ->
+  let windowed =
+    Domain_pool_ref.submit_cpu_or_inline (fun () ->
+      match
+        Runtime_model_input_tail_window.project
+          ~allow_empty_history:true
+          ~measure_message_bytes:measure_model_input_message_bytes
+          ~capacity_bytes
+          ~reserved_bytes
+          messages
+      with
+      | Ok projected -> Ok projected
+      | Error error ->
+        Error (Runtime_model_input_tail_window.budget_error_to_string error))
+  in
+  match windowed, source_projection with
+  | (Error _ as error), _ -> error
+  | Ok windowed, None -> Ok windowed
+  | Ok windowed, Some project -> project windowed
+;;
+
+let capacity_bounded_model_input_projection ~declared_max_prompt_bytes
+    ~system_prompt ~goal source_projection
+  =
+  match declared_max_prompt_bytes with
+  | None -> Ok source_projection
+  | Some capacity_bytes ->
+    let reserved_bytes =
+      String.length system_prompt
+      + String.length goal
+      + prompt_section_framing_reserved_bytes
+    in
+    if reserved_bytes >= capacity_bytes
+    then
+      Error
+        (config_error
+           ~field:"max_prompt_bytes"
+           (Printf.sprintf
+              "Antigravity fixed prompt sections (system prompt and goal) measure %d bytes, at or above the declared max-prompt-bytes %d; no history window can fit"
+              reserved_bytes
+              capacity_bytes))
+    else
+      Ok
+        (Some
+           (bounded_history_projection
+              ~capacity_bytes
+              ~reserved_bytes
+              source_projection))
+;;
+
 let prompt_for_turn ~is_resume ~goal (prepared : Host.prepared_turn) =
   if is_resume
   then (
@@ -264,6 +343,21 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
     in
     let is_resume = Option.is_some claim_plan.previous_settlement in
     let turn_count = claim_plan.turn_count in
+    let* goal =
+      match goal_blocks with
+      | None -> Ok goal
+      | Some blocks -> Host.text_of_blocks ~runtime_label ~field:"goal_blocks" blocks
+    in
+    let declared_max_prompt_bytes =
+      Runtime_inference.resolve_max_prompt_bytes ~runtime_id
+    in
+    let* model_input_projection =
+      capacity_bounded_model_input_projection
+        ~declared_max_prompt_bytes
+        ~system_prompt
+        ~goal
+        model_input_projection
+    in
     let* prepared =
       Host.prepare_turn
         ~configured_reasoning_effort:
@@ -291,12 +385,22 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
              ~field:"reasoning_effort"
              "Antigravity effort must be declared by its runtime provider")
     in
-    let* goal =
-      match goal_blocks with
-      | None -> Ok goal
-      | Some blocks -> Host.text_of_blocks ~runtime_label ~field:"goal_blocks" blocks
-    in
     let* prompt = prompt_for_turn ~is_resume ~goal prepared in
+    (* Recording the half this process controls, mirroring the Codex and
+       Claude Code composition lines: an oversized prompt was invisible until
+       the client's own log showed promptLength=11,386,764 (2026-08-14). *)
+    Log.Keeper.info
+      ~keeper_name
+      "%s turn composition: mode=%s prompt_bytes=%d system_prompt_bytes=%d \
+       goal_bytes=%d declared_max_prompt_bytes=%s"
+      runtime_label
+      (if is_resume then "resume" else "start")
+      (String.length prompt)
+      (String.length prepared.system_prompt)
+      (String.length goal)
+      (match declared_max_prompt_bytes with
+       | None -> "undeclared"
+       | Some bytes -> string_of_int bytes);
     let terminal_error = ref None in
     let* dynamic_tools =
       Host.dynamic_tools
@@ -801,3 +905,9 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
   in
   { result; effect_disposition = Atomic.get effect_disposition }
 ;;
+
+module For_testing = struct
+  let capacity_bounded_model_input_projection =
+    capacity_bounded_model_input_projection
+  ;;
+end

--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -935,4 +935,14 @@ module For_testing = struct
     in
     Result.map String.length (prompt_for_turn ~is_resume:false ~goal prepared)
   ;;
+
+  (* One byte more than this is the smallest admissible declared capacity.
+     This is not the rendered empty-history prompt: the reserve charges both
+     separators (the with-history worst case), while an empty-history render
+     joins its two sections with one. *)
+  let reserved_prompt_bytes ~system_prompt ~goal =
+    String.length system_prompt
+    + String.length goal
+    + prompt_section_framing_reserved_bytes
+  ;;
 end

--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -105,35 +105,48 @@ let measure_model_input_message_bytes (message : Agent_core.Types.message) =
    declared capacity is therefore this runtime's admission contract, not a
    second authority over a provider-owned window.
 
-   [prompt_section_framing_reserved_bytes] covers the constant section labels
-   [prompt_for_turn] adds ("SYSTEM INSTRUCTIONS:\n", "CURRENT GOAL:\n",
-   separators). Per-message role prefixes are not measured; the declared
-   capacity is expected to sit well under the client's observed input cliff
-   (~185KB), so the deployment margin absorbs that slack. *)
-let prompt_section_framing_reserved_bytes = 64
+   [prompt_section_framing_reserved_bytes] is derived from the actual label
+   literals [prompt_for_turn] concatenates, so a label change cannot silently
+   outgrow the reserve. Per-message role prefixes are not measured; the
+   declared capacity is expected to sit well under the client's observed
+   input cliff (~185KB), so the deployment margin absorbs that slack. *)
+let system_instructions_label = "SYSTEM INSTRUCTIONS:\n"
+let current_goal_label = "CURRENT GOAL:\n"
+let prompt_section_separator = "\n\n"
 
+let prompt_section_framing_reserved_bytes =
+  String.length system_instructions_label
+  + String.length current_goal_label
+  + (2 * String.length prompt_section_separator)
+;;
+
+(* The source projection runs first: the one production source appends a
+   bounded typed Gate replay reference (keeper_agent_run.ml), and on this
+   lane the window is the only authority over the transmitted bytes — there
+   is no provider refusal to catch an append that lands after the cut, so
+   the window must see everything that ships. The appended reference is the
+   newest material and survives the tail window. *)
 let bounded_history_projection ~capacity_bytes ~reserved_bytes source_projection
   : Agent_core.Agent.model_input_projection
   =
   fun messages ->
-  let windowed =
-    Domain_pool_ref.submit_cpu_or_inline (fun () ->
-      match
-        Runtime_model_input_tail_window.project
-          ~allow_empty_history:true
-          ~measure_message_bytes:measure_model_input_message_bytes
-          ~capacity_bytes
-          ~reserved_bytes
-          messages
-      with
-      | Ok projected -> Ok projected
-      | Error error ->
-        Error (Runtime_model_input_tail_window.budget_error_to_string error))
+  let* messages =
+    match source_projection with
+    | None -> Ok messages
+    | Some project -> project messages
   in
-  match windowed, source_projection with
-  | (Error _ as error), _ -> error
-  | Ok windowed, None -> Ok windowed
-  | Ok windowed, Some project -> project windowed
+  Domain_pool_ref.submit_cpu_or_inline (fun () ->
+    match
+      Runtime_model_input_tail_window.project
+        ~allow_empty_history:true
+        ~measure_message_bytes:measure_model_input_message_bytes
+        ~capacity_bytes
+        ~reserved_bytes
+        messages
+    with
+    | Ok projected -> Ok projected
+    | Error error ->
+      Error (Runtime_model_input_tail_window.budget_error_to_string error))
 ;;
 
 let capacity_bounded_model_input_projection ~declared_max_prompt_bytes
@@ -178,17 +191,17 @@ let prompt_for_turn ~is_resume ~goal (prepared : Host.prepared_turn) =
     in
     match String_util.trim_to_option context with
     | None -> Ok goal
-    | Some context -> Ok (context ^ "\n\n" ^ goal))
+    | Some context -> Ok (context ^ prompt_section_separator ^ goal))
   else
     let* history = render_messages prepared.messages in
     Ok
       ([ String_util.trim_to_option prepared.system_prompt
-         |> Option.map (fun value -> "SYSTEM INSTRUCTIONS:\n" ^ value)
+         |> Option.map (fun value -> system_instructions_label ^ value)
       ; String_util.trim_to_option history
-      ; Some ("CURRENT GOAL:\n" ^ goal)
+      ; Some (current_goal_label ^ goal)
       ]
       |> List.filter_map Fun.id
-      |> String.concat "\n\n")
+      |> String.concat prompt_section_separator)
 ;;
 
 let tool_spec (tool : Host.dynamic_tool) =

--- a/lib/keeper/keeper_antigravity_runtime.mli
+++ b/lib/keeper/keeper_antigravity_runtime.mli
@@ -43,4 +43,12 @@ module For_testing : sig
       those fixed sections alone leave no room. agy truncates oversized stdin
       prompts silently instead of refusing them, so this window is the only
       bound the turn gets. *)
+
+  val start_prompt_bytes :
+    system_prompt:string ->
+    goal:string ->
+    Agent_core.Types.message list ->
+    (int, string) result
+  (** Render through the production start-turn formatter and return the exact
+      transmitted prompt byte count. *)
 end

--- a/lib/keeper/keeper_antigravity_runtime.mli
+++ b/lib/keeper/keeper_antigravity_runtime.mli
@@ -51,4 +51,13 @@ module For_testing : sig
     (int, string) result
   (** Render through the production start-turn formatter and return the exact
       transmitted prompt byte count. *)
+
+  val reserved_prompt_bytes : system_prompt:string -> goal:string -> int
+  (** The bytes the admission contract reserves for the fixed prompt sections
+      out of a declared capacity. One byte more than this is the smallest
+      admissible declared capacity; the tail window can still refuse such a
+      capacity when its constant undroppable preamble does not fit in what
+      remains. Not the rendered empty-history prompt: the reserve charges
+      both separators (the with-history worst case), while an empty-history
+      render joins its two sections with one. *)
 end

--- a/lib/keeper/keeper_antigravity_runtime.mli
+++ b/lib/keeper/keeper_antigravity_runtime.mli
@@ -36,9 +36,11 @@ module For_testing : sig
     -> (Agent_core.Agent.model_input_projection option, Agent_core.Error.t) result
   (** The admission contract over the provider-bound history. [None] declared
       capacity passes the source projection through unchanged. A declared
-      capacity returns a projection that windows history to the capacity
-      minus the bytes the fixed prompt sections always occupy, and refuses
-      with a typed config error when those fixed sections alone leave no
-      room. agy truncates oversized stdin prompts silently instead of
-      refusing them, so this is the only bound the turn gets. *)
+      capacity returns a projection that runs the source projection first
+      (the production source appends a bounded typed Gate replay reference)
+      and then windows the result to the capacity minus the bytes the fixed
+      prompt sections always occupy, refusing with a typed config error when
+      those fixed sections alone leave no room. agy truncates oversized stdin
+      prompts silently instead of refusing them, so this window is the only
+      bound the turn gets. *)
 end

--- a/lib/keeper/keeper_antigravity_runtime.mli
+++ b/lib/keeper/keeper_antigravity_runtime.mli
@@ -26,3 +26,19 @@ val run :
   on_event:(Agent_core.Types.sse_event -> unit) option ->
   config:Runtime_execution.antigravity_cli ->
   attempt_outcome
+
+module For_testing : sig
+  val capacity_bounded_model_input_projection
+    :  declared_max_prompt_bytes:int option
+    -> system_prompt:string
+    -> goal:string
+    -> Agent_core.Agent.model_input_projection option
+    -> (Agent_core.Agent.model_input_projection option, Agent_core.Error.t) result
+  (** The admission contract over the provider-bound history. [None] declared
+      capacity passes the source projection through unchanged. A declared
+      capacity returns a projection that windows history to the capacity
+      minus the bytes the fixed prompt sections always occupy, and refuses
+      with a typed config error when those fixed sections alone leave no
+      room. agy truncates oversized stdin prompts silently instead of
+      refusing them, so this is the only bound the turn gets. *)
+end

--- a/lib/runtime/runtime_antigravity_home.ml
+++ b/lib/runtime/runtime_antigravity_home.ml
@@ -164,6 +164,22 @@ let ensure_private_child parent leaf =
   | Ok () -> Result.map (fun () -> path) (verify_private_directory path)
 ;;
 
+(* Only the whole-tool pattern [tool(*)] matches in agy 1.1.12: a path-scoped
+   argument such as [read_file(<dir>/*)] matched neither a direct child nor a
+   nested file in either list (measured 2026-08-14), so "deny everything
+   except the client's own artifact files" is not expressible. [read_file]
+   therefore stays denied wholesale even though that also denies the client's
+   own large-MCP-output artifacts (results over ~10KB are materialized to a
+   brain file the model is told to view): the workspace masc passes as
+   [--add-dir] is the operator checkout, whose [.masc/auth] tokens a
+   workspace-wide read grant would expose. A rule denial comes back to the
+   model as a typed tool error and the turn continues; an unlisted tool would
+   instead take the review path, which auto-denies in print mode and ends the
+   turn with an empty SUCCESS response.
+
+   No [toolPermission] key: agy 1.1.12 does not read it (the client rewrites
+   this file without it and initializes toolPermission=request-review from
+   its own default). *)
 let settings_json () =
   `Assoc
     [ ( "permissions"
@@ -181,7 +197,6 @@ let settings_json () =
                    ; "unsandboxed(*)"
                    ]) )
           ] )
-    ; "toolPermission", `String "request-review"
     ]
 ;;
 

--- a/test/test_keeper_antigravity_runtime.ml
+++ b/test/test_keeper_antigravity_runtime.ml
@@ -857,11 +857,19 @@ let test_capacity_bounds_an_appending_source_projection () =
         | [] -> fail "projection emptied the history"))
 ;;
 
+(* The tail window charges the constant synthetic User preamble before any
+   atom (it can never be cut), so the smallest workable capacity sits above
+   that constant plus the reserve. 4096 is comfortably above it and still
+   small enough that 100 framed messages must be cut. *)
 let test_capacity_counts_rendered_role_framing () =
-  let history = List.init 100 (fun _ -> plain_user_message "") in
+  let history =
+    List.init 100 (fun index ->
+      plain_user_message
+        (Printf.sprintf "history-%02d:%s" index (String.make 64 'x')))
+  in
   match
     capacity_projection
-      ~declared_max_prompt_bytes:(Some 256)
+      ~declared_max_prompt_bytes:(Some 4096)
       ~system_prompt:"system"
       ~goal:"goal"
       None
@@ -885,7 +893,28 @@ let test_capacity_counts_rendered_role_framing () =
          | Error detail -> fail detail
        in
        check bool "role-framed prompt stays inside capacity" true
-         (prompt_bytes <= 256))
+         (prompt_bytes <= 4096))
+;;
+
+let test_capacity_below_preamble_constant_is_a_typed_refusal () =
+  let history = List.init 100 (fun _ -> plain_user_message "") in
+  match
+    capacity_projection
+      ~declared_max_prompt_bytes:(Some 256)
+      ~system_prompt:"system"
+      ~goal:"goal"
+      None
+  with
+  | Error error -> fail (Agent_core.Error.to_string error)
+  | Ok None -> fail "declared capacity produced no projection"
+  | Ok (Some project) ->
+    (match project history with
+     | Error _ -> ()
+     | Ok projected ->
+       fail
+         (Printf.sprintf
+            "a capacity below the undroppable preamble constant admitted %d messages"
+            (List.length projected)))
 ;;
 
 let test_capacity_refuses_oversized_fixed_sections () =
@@ -950,6 +979,10 @@ let () =
               "role framing is charged to the prompt capacity"
               `Quick
               test_capacity_counts_rendered_role_framing
+          ; test_case
+              "a capacity below the preamble constant is refused"
+              `Quick
+              test_capacity_below_preamble_constant_is_a_typed_refusal
           ; test_case
               "oversized fixed sections are refused"
               `Quick

--- a/test/test_keeper_antigravity_runtime.ml
+++ b/test/test_keeper_antigravity_runtime.ml
@@ -857,19 +857,26 @@ let test_capacity_bounds_an_appending_source_projection () =
         | [] -> fail "projection emptied the history"))
 ;;
 
-(* The tail window charges the constant synthetic User preamble before any
-   atom (it can never be cut), so the smallest workable capacity sits above
-   that constant plus the reserve. 4096 is comfortably above it and still
-   small enough that 100 framed messages must be cut. *)
 let test_capacity_counts_rendered_role_framing () =
-  let history =
-    List.init 100 (fun index ->
-      plain_user_message
-        (Printf.sprintf "history-%02d:%s" index (String.make 64 'x')))
+  let history = List.init 100 (fun _ -> plain_user_message "") in
+  let unprojected_prompt_bytes =
+    match
+      Keeper_antigravity_runtime.For_testing.start_prompt_bytes
+        ~system_prompt:"system"
+        ~goal:"goal"
+        history
+    with
+    | Ok bytes -> bytes
+    | Error detail -> fail detail
   in
+  (* One byte below the exact unprojected prompt is a structural boundary:
+     retaining every message is impossible. A payload-only estimator used to
+     admit the whole history here because it omitted every rendered role label
+     and separator. *)
+  let capacity_bytes = unprojected_prompt_bytes - 1 in
   match
     capacity_projection
-      ~declared_max_prompt_bytes:(Some 4096)
+      ~declared_max_prompt_bytes:(Some capacity_bytes)
       ~system_prompt:"system"
       ~goal:"goal"
       None
@@ -893,14 +900,27 @@ let test_capacity_counts_rendered_role_framing () =
          | Error detail -> fail detail
        in
        check bool "role-framed prompt stays inside capacity" true
-         (prompt_bytes <= 4096))
+         (prompt_bytes <= capacity_bytes))
 ;;
 
 let test_capacity_below_preamble_constant_is_a_typed_refusal () =
   let history = List.init 100 (fun _ -> plain_user_message "") in
+  let fixed_prompt_bytes =
+    match
+      Keeper_antigravity_runtime.For_testing.start_prompt_bytes
+        ~system_prompt:"system"
+        ~goal:"goal"
+        []
+    with
+    | Ok bytes -> bytes
+    | Error detail -> fail detail
+  in
+  (* Leave exactly one history byte beyond the real fixed prompt. The
+     undroppable omission preamble cannot fit in that budget. *)
+  let capacity_bytes = fixed_prompt_bytes + 1 in
   match
     capacity_projection
-      ~declared_max_prompt_bytes:(Some 256)
+      ~declared_max_prompt_bytes:(Some capacity_bytes)
       ~system_prompt:"system"
       ~goal:"goal"
       None

--- a/test/test_keeper_antigravity_runtime.ml
+++ b/test/test_keeper_antigravity_runtime.ml
@@ -832,20 +832,21 @@ let test_capacity_bounds_an_appending_source_projection () =
     (match project history with
      | Error detail -> fail detail
      | Ok projected ->
-       let projected_bytes =
-         List.fold_left
-           (fun total (message : Agent_core.Types.message) ->
-             total
-             + String.length
-                 (Keeper_official_client_host.encode_history_message message))
-           0
-           projected
+       let prompt_bytes =
+         match
+           Keeper_antigravity_runtime.For_testing.start_prompt_bytes
+             ~system_prompt:"system"
+             ~goal:"goal"
+             projected
+         with
+         | Ok bytes -> bytes
+         | Error detail -> fail detail
        in
        check
          bool
-         "appended material is inside the declared capacity"
+         "actual rendered prompt is inside the declared capacity"
          true
-         (projected_bytes <= 8192);
+         (prompt_bytes <= 8192);
        (match List.rev projected with
         | last :: _ ->
           check
@@ -854,6 +855,37 @@ let test_capacity_bounds_an_appending_source_projection () =
             true
             (last.Agent_core.Types.content = marker.content)
         | [] -> fail "projection emptied the history"))
+;;
+
+let test_capacity_counts_rendered_role_framing () =
+  let history = List.init 100 (fun _ -> plain_user_message "") in
+  match
+    capacity_projection
+      ~declared_max_prompt_bytes:(Some 256)
+      ~system_prompt:"system"
+      ~goal:"goal"
+      None
+  with
+  | Error error -> fail (Agent_core.Error.to_string error)
+  | Ok None -> fail "declared capacity produced no projection"
+  | Ok (Some project) ->
+    (match project history with
+     | Error detail -> fail detail
+     | Ok projected ->
+       check bool "role framing forces a history cut" true
+         (List.length projected < List.length history);
+       let prompt_bytes =
+         match
+           Keeper_antigravity_runtime.For_testing.start_prompt_bytes
+             ~system_prompt:"system"
+             ~goal:"goal"
+             projected
+         with
+         | Ok bytes -> bytes
+         | Error detail -> fail detail
+       in
+       check bool "role-framed prompt stays inside capacity" true
+         (prompt_bytes <= 256))
 ;;
 
 let test_capacity_refuses_oversized_fixed_sections () =
@@ -914,6 +946,10 @@ let () =
               "an appending source projection stays inside the window"
               `Quick
               test_capacity_bounds_an_appending_source_projection
+          ; test_case
+              "role framing is charged to the prompt capacity"
+              `Quick
+              test_capacity_counts_rendered_role_framing
           ; test_case
               "oversized fixed sections are refused"
               `Quick

--- a/test/test_keeper_antigravity_runtime.ml
+++ b/test/test_keeper_antigravity_runtime.ml
@@ -728,6 +728,148 @@ let test_spawn_failure_is_pre_dispatch () =
                        attempt.effect_disposition))))))
 ;;
 
+let plain_user_message text : Agent_core.Types.message =
+  { role = User
+  ; content = [ Text text ]
+  ; name = None
+  ; tool_call_id = None
+  ; metadata = []
+  }
+;;
+
+let capacity_projection ~declared_max_prompt_bytes ~system_prompt ~goal source =
+  Keeper_antigravity_runtime.For_testing.capacity_bounded_model_input_projection
+    ~declared_max_prompt_bytes
+    ~system_prompt
+    ~goal
+    source
+;;
+
+let test_capacity_undeclared_passes_source_through () =
+  (match
+     capacity_projection
+       ~declared_max_prompt_bytes:None
+       ~system_prompt:"system"
+       ~goal:"goal"
+       None
+   with
+   | Ok None -> ()
+   | Ok (Some _) -> fail "undeclared capacity invented a projection"
+   | Error error -> fail (Agent_core.Error.to_string error));
+  let marker = plain_user_message "source-projection-marker" in
+  let source = Some (fun messages -> Ok (messages @ [ marker ])) in
+  match
+    capacity_projection
+      ~declared_max_prompt_bytes:None
+      ~system_prompt:"system"
+      ~goal:"goal"
+      source
+  with
+  | Ok (Some project) ->
+    (match project [ plain_user_message "only" ] with
+     | Ok projected ->
+       check int "source projection untouched" 2 (List.length projected)
+     | Error detail -> fail detail)
+  | Ok None -> fail "undeclared capacity dropped the source projection"
+  | Error error -> fail (Agent_core.Error.to_string error)
+;;
+
+let test_capacity_windows_history_to_tail () =
+  let history =
+    List.init 10 (fun index ->
+      plain_user_message
+        (Printf.sprintf "history-%02d:%s" index (String.make 1024 'x')))
+  in
+  match
+    capacity_projection
+      ~declared_max_prompt_bytes:(Some 8192)
+      ~system_prompt:"system"
+      ~goal:"goal"
+      None
+  with
+  | Error error -> fail (Agent_core.Error.to_string error)
+  | Ok None -> fail "declared capacity produced no projection"
+  | Ok (Some project) ->
+    (match project history with
+     | Error detail -> fail detail
+     | Ok windowed ->
+       let kept = List.length windowed in
+       check bool "capacity drops oldest history" true (kept < 10);
+       check bool "capacity keeps a non-empty tail" true (kept > 0);
+       let tail_of_history =
+         List.filteri (fun index _ -> index >= 10 - kept) history
+       in
+       check
+         bool
+         "kept messages are the newest suffix"
+         true
+         (List.for_all2
+            (fun (kept_message : Agent_core.Types.message)
+                 (expected : Agent_core.Types.message) ->
+              kept_message.content = expected.content)
+            windowed
+            tail_of_history))
+;;
+
+let test_capacity_composes_source_projection_after_window () =
+  let history =
+    List.init 10 (fun index ->
+      plain_user_message
+        (Printf.sprintf "history-%02d:%s" index (String.make 1024 'x')))
+  in
+  let marker = plain_user_message "source-projection-marker" in
+  let source = Some (fun messages -> Ok (messages @ [ marker ])) in
+  match
+    capacity_projection
+      ~declared_max_prompt_bytes:(Some 8192)
+      ~system_prompt:"system"
+      ~goal:"goal"
+      source
+  with
+  | Error error -> fail (Agent_core.Error.to_string error)
+  | Ok None -> fail "declared capacity produced no projection"
+  | Ok (Some project) ->
+    (match project history with
+     | Error detail -> fail detail
+     | Ok projected ->
+       (match List.rev projected with
+        | last :: _ ->
+          check
+            bool
+            "source projection runs after the window"
+            true
+            (last.Agent_core.Types.content = marker.content)
+        | [] -> fail "projection emptied the history"))
+;;
+
+let test_capacity_refuses_oversized_fixed_sections () =
+  match
+    capacity_projection
+      ~declared_max_prompt_bytes:(Some 128)
+      ~system_prompt:(String.make 256 's')
+      ~goal:"goal"
+      None
+  with
+  | Error error ->
+    let detail = Agent_core.Error.to_string error in
+    let contains ~needle haystack =
+      let needle_len = String.length needle in
+      let limit = String.length haystack - needle_len in
+      let rec probe index =
+        index <= limit
+        && (String.equal (String.sub haystack index needle_len) needle
+            || probe (index + 1))
+      in
+      probe 0
+    in
+    check
+      bool
+      "refusal names the declared capacity field"
+      true
+      (contains ~needle:"max_prompt_bytes" detail)
+  | Ok _ -> fail "oversized fixed prompt sections were admitted"
+;;
+
 let () =
   run
     "keeper_antigravity_runtime"
@@ -744,6 +886,24 @@ let () =
               "spawn failure is pre-dispatch"
               `Quick
               test_spawn_failure_is_pre_dispatch
+        ] )
+    ; ( "prompt capacity"
+        , [ test_case
+              "undeclared capacity passes source through"
+              `Quick
+              test_capacity_undeclared_passes_source_through
+          ; test_case
+              "declared capacity windows history to the newest tail"
+              `Quick
+              test_capacity_windows_history_to_tail
+          ; test_case
+              "source projection composes after the window"
+              `Quick
+              test_capacity_composes_source_projection_after_window
+          ; test_case
+              "oversized fixed sections are refused"
+              `Quick
+              test_capacity_refuses_oversized_fixed_sections
         ] )
     ]
 ;;

--- a/test/test_keeper_antigravity_runtime.ml
+++ b/test/test_keeper_antigravity_runtime.ml
@@ -905,19 +905,18 @@ let test_capacity_counts_rendered_role_framing () =
 
 let test_capacity_below_preamble_constant_is_a_typed_refusal () =
   let history = List.init 100 (fun _ -> plain_user_message "") in
-  let fixed_prompt_bytes =
-    match
-      Keeper_antigravity_runtime.For_testing.start_prompt_bytes
-        ~system_prompt:"system"
-        ~goal:"goal"
-        []
-    with
-    | Ok bytes -> bytes
-    | Error detail -> fail detail
+  (* One byte above the admission reserve is the smallest capacity that gets a
+     projection at all (at or below it the fixed sections are refused before
+     any window exists). The rendered empty-history prompt is two bytes less
+     than the reserve — it joins its two sections with one separator while the
+     reserve charges both — so that one-byte history budget cannot fit the
+     window's constant undroppable omission preamble. *)
+  let capacity_bytes =
+    Keeper_antigravity_runtime.For_testing.reserved_prompt_bytes
+      ~system_prompt:"system"
+      ~goal:"goal"
+    + 1
   in
-  (* Leave exactly one history byte beyond the real fixed prompt. The
-     undroppable omission preamble cannot fit in that budget. *)
-  let capacity_bytes = fixed_prompt_bytes + 1 in
   match
     capacity_projection
       ~declared_max_prompt_bytes:(Some capacity_bytes)

--- a/test/test_keeper_antigravity_runtime.ml
+++ b/test/test_keeper_antigravity_runtime.ml
@@ -811,7 +811,7 @@ let test_capacity_windows_history_to_tail () =
             tail_of_history))
 ;;
 
-let test_capacity_composes_source_projection_after_window () =
+let test_capacity_bounds_an_appending_source_projection () =
   let history =
     List.init 10 (fun index ->
       plain_user_message
@@ -832,11 +832,25 @@ let test_capacity_composes_source_projection_after_window () =
     (match project history with
      | Error detail -> fail detail
      | Ok projected ->
+       let projected_bytes =
+         List.fold_left
+           (fun total (message : Agent_core.Types.message) ->
+             total
+             + String.length
+                 (Keeper_official_client_host.encode_history_message message))
+           0
+           projected
+       in
+       check
+         bool
+         "appended material is inside the declared capacity"
+         true
+         (projected_bytes <= 8192);
        (match List.rev projected with
         | last :: _ ->
           check
             bool
-            "source projection runs after the window"
+            "the appended newest material survives the window"
             true
             (last.Agent_core.Types.content = marker.content)
         | [] -> fail "projection emptied the history"))
@@ -897,9 +911,9 @@ let () =
               `Quick
               test_capacity_windows_history_to_tail
           ; test_case
-              "source projection composes after the window"
+              "an appending source projection stays inside the window"
               `Quick
-              test_capacity_composes_source_projection_after_window
+              test_capacity_bounds_an_appending_source_projection
           ; test_case
               "oversized fixed sections are refused"
               `Quick

--- a/test/test_runtime_antigravity_home.ml
+++ b/test/test_runtime_antigravity_home.ml
@@ -61,6 +61,14 @@ let test_prepares_private_home_with_oauth_seed () =
     (Yojson.Safe.equal
        (Runtime_antigravity_home.For_testing.settings_json ())
        (Yojson.Safe.from_file paths.settings_path));
+  (match Runtime_antigravity_home.For_testing.settings_json () with
+   | `Assoc fields ->
+     check
+       bool
+       "no dead toolPermission key"
+       false
+       (List.mem_assoc "toolPermission" fields)
+   | _ -> fail "settings must be a JSON object");
   check bool "oauth target is a regular file" true
     ((Unix.lstat paths.oauth_path).Unix.st_kind = Unix.S_REG);
   check int "managed oauth mode" 0o600 (permission paths.oauth_path);


### PR DESCRIPTION
## 증상

1. antigravity lane keeper 턴이 전부 `Turn_failed: successful result response has no deliverable content` 로 실패 (08-12 120건, 08-14 새벽 code-reviewer 6/6 스폰 전부).
2. 사용자 관측: agy 가 키체인만 계속 물어보고 스턱.

## 근본 원인 (실측 기반)

- `printmode.go:160` 로그 실측: masc 가 매 턴 **11,386,764 bytes** 프롬프트를 stdin 으로 전송.
- agy 1.1.12 는 oversized prompt 를 **typed error 로 거부하지 않는다**. 두 가지가 동시에 일어난다:
  - 조용한 절단: brain 의 `USER_INPUT` 기록은 185,751 bytes — 프롬프트 꼬리의 `CURRENT GOAL` 이 모델에 도달하지 않음. (재현: 256KiB 프롬프트도 goal 소실, 131,072 bytes 는 정상 도달)
  - `pubsub: Publish killing slow subscriber ... stalled for 5s` — print-mode 응답 수집 구독자가 살해되어, 모델이 최종 텍스트를 내도(각 대화 brain 에 존재 확인) result event 는 `SUCCESS + response:""`. 08-14 스폰 6개 전부 kill 1회 ↔ 턴 실패 6/6 정확히 상관.
- masc 는 blank 를 `Turn_failed` → 세션 park → 다음 턴 fresh conversation 에 **전체 히스토리 재전송** → 영구 실패 루프.
- `#28185` 가 official-client seed bound 를 제거한 근거("provider 가 typed overflow 로 거부하고 shrink sequence 가 반응")는 이 provider 에는 **자극이 존재하지 않는다**. `max-prompt-bytes` 는 파싱만 되고 소비자 0 (`resolve_max_prompt_bytes` 의 유일한 참조가 자기 정의). runtime.toml 주석의 진단("#28062 가 argv 120KiB 제약을 없애며 상한 대체가 없었다")과 일치.

## 수정

- `keeper_antigravity_runtime`: 선언된 per-model `max-prompt-bytes` 로 provider-bound 히스토리를 tail-window projection (형제 official-client 들이 쓰는 동일 메커니즘, `Runtime_model_input_tail_window.project`). system prompt + goal 이 항상 차지하는 바이트는 reserve, 고정 섹션만으로 용량 초과면 typed config error 로 거부. 미선언 시 기존 동작(무제한) 유지.
- 형제 런타임과 동일한 turn composition 로그 추가 (11MB 프롬프트가 지금까지 비가시였음).
- `runtime_antigravity_home.settings_json`: agy 1.1.12 가 읽지 않는 죽은 `toolPermission` 키 제거 (CLI 가 파일 재작성 시 버리고 자체 기본값 request-review 사용, 실측).
- `read_file(*)` deny 는 **유지** + 사유 주석: agy 1.1.12 권한 문법은 `tool(*)` 전량 형태만 매치하고 경로 스코프 패턴은 allow/deny 양쪽에서 조용히 불일치(직계 자식조차, 실측 08-14). 워크스페이스(`--add-dir`)가 operator checkout 이라 read 전면 허용은 `.masc/auth/*.token` 노출.

## 검증

- `dune build @check` 통과, `test_keeper_antigravity_runtime` 7/7 (신규 4: passthrough / tail-window / source-projection 합성 / oversized 거부), `test_runtime_antigravity_home` 6/6 (toolPermission 부재 어서션 추가).
- `test_runtime_antigravity` 의 stream-json 17/20 은 부하 상태에서 실행마다 다른 테스트가 실패하는 기존 타이밍 플레이크 (본 diff 는 해당 모듈 미변경).

## 배포 노트 (코드 머지와 별도)

1. `~/me/.masc/config/runtime.toml` 의 `[models.gemini-3-6-flash-high] max-prompt-bytes` 를 `262144 → 131072` 로 하향 필요 — 실측상 262144 는 agy 입력 절벽(~185KB) 밖이라 goal 이 여전히 소실된다. 131072 는 goal 도달 확인.
2. masc 서버 재기동 필요 (runtime.toml 부팅 1회 로드).

## 남는 것 (별도 트랙)

- 대형 MCP 결과(>10KB)는 agy 가 brain 파일로 낙하시키고 모델에게 view_file 을 시키는데 `read_file(*)` deny 가 이를 차단 → 결과 열람 불가로 턴 품질 저하 (한 재현 턴에서 57s/104K tokens 낭비). 경로 스코프 권한이 CLI 에서 불가능하므로, masc MCP bridge 의 typed pagination 이 근본 해결 — RFC 트랙.
- 키체인: agy 는 keyring(macOS Keychain service `gemini`/account `antigravity`) 우선 인증이며, 키체인 항목이 08-10 이후 stale 인 채 매 갱신 시 `Failed to save token to keyring ... exit status 154` (스폰 로그 70+ 건). isolated HOME 은 keychain 을 격리하지 못한다. 코드 밖 1회성 복구 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
