### PR TITLE
docs(tool): surface_post 설명에 thread_ts/blocks 능력 명시 (#28646 후속)

### DIFF
--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -928,7 +928,9 @@ let surface_post_schema =
         "content"
         "string"
         "Standard Markdown message to deliver. Discord renders it natively; \
-         Slack renders it through the official Block Kit markdown block."
+         Slack renders it through the official Block Kit markdown block. \
+         When blocks is provided, content is only the Slack notification \
+         fallback text."
     ; property
         "channel_id"
         "string"

--- a/lib/tool_surface/tool_shard_types_schemas_surface.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_surface.ml
@@ -7,7 +7,9 @@ let keeper_surface_post_description =
    Markdown is rendered natively by Discord and by Slack's Block Kit \
    markdown block. To create a real highlighted user mention, pass stable \
    participant-roster ids in mention_user_ids; never guess ids from display \
-   names. Posting to an unbound surface is an error. These endpoints \
+   names. A Slack post may reply inside an existing thread (thread_ts) \
+   or carry Block Kit blocks; see those parameters. Posting to an unbound \
+   surface is an error. These endpoints \
    are read by a person, so an unchanged status reposted every cycle \
    crowds their view and says nothing the previous one did not; when \
    there is nothing new, the turn ends without a post."


### PR DESCRIPTION
#28646 머지 직전 push 되어 유실된 self-review 후속 커밋의 재상륙 (squash 머지 후 브랜치 push 는 main 에 도달하지 않음 — masc#5303 패턴).

- `content` property: custom blocks 제공 시 content 가 Slack notification fallback 전용임을 명시
- 도구 description: thread_ts / blocks 파라미터 발견성 문장 추가

코드 변경 없음 (docs/스키마 설명 문자열만). 원 커밋: `8ba0bd162e`.