### PR TITLE
fix(runtime): align Ollama probe effect authority

### DIFF
--- a/docs/PERFORMANCE-SLO.md
+++ b/docs/PERFORMANCE-SLO.md
@@ -14,7 +14,7 @@
 추가 지표:
 
 - `initialize + notifications/initialized` 세션 생성 비용은 별도 추적
-- raw local runtime 비용은 `masc_runtime_verify`로 MCP read-path와 분리해서 읽음
+- raw local runtime 비용은 Admin-only effectful diagnostic인 `masc_runtime_verify`로 MCP read-path와 분리해서 측정
 
 ### REST API
 - /api/v1/status P95 < 150ms
@@ -56,13 +56,16 @@ agent core RFC-agent core-020이 요구하는 consumer SLO를 추가하려면 ag
 - `benchmark.sh`는 `session`, `read`, `workspace collaboration`, `runtime`, `a2a`, `lock` lane을 분리하고 `avg/p50/p95/max`를 CSV로 남긴다.
 - `benchmark.sh`는 기본적으로 tool lane당 warmup 1회를 제외하고, 결과 CSV 옆에 metadata와 baseline diff를 같이 남긴다.
 - `runtime` lane 숫자는 MCP transport가 아니라 local runtime ceiling 영향을 크게 받는다.
+- 인증이 켜진 서버에서 `quick-bench.sh` 또는 `runtime` lane을 실행할 때는
+  `MASC_TOKEN`에 Admin credential이 필요하다. `masc_runtime_verify`는 endpoint마다
+  실제 chat completion을 호출하므로 read-only benchmark가 아니다.
 - `local64`는 target runtime profile 이름이지 achieved fact가 아니다. 실제 용량은 `masc_runtime_verify`의 `configured_capacity`, `healthy_runtime_count`로 확인한다.
 
 환경 변수:
 ```
 MASC_URL=http://127.0.0.1:8935/mcp
 MASC_AGENT=bench
-MASC_TOKEN=<optional>
+MASC_TOKEN=<Admin token required for quick-bench/runtime lane when auth is enabled>
 ```
 
 ## 경고 기준

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1371,13 +1371,23 @@ let masc_library_descriptors =
 let masc_local_runtime_descriptor
       (definition : Tool_schemas_local_runtime.definition) =
   let schema = definition.schema in
-  cluster_descriptor_with_schema_source
+  let keeper_model_projection =
+    match Tool_schemas_local_runtime.keeper_model_exposure definition.operation with
+    | Tool_schemas_local_runtime.Keeper_callable -> Internal_name
+    | Tool_schemas_local_runtime.Operator_diagnostic -> Operator_only
+  in
+  let execution_policy =
+    Tool_schemas_local_runtime.execution_policy definition.operation
+  in
+  let policy =
+    policy
+      ~readonly:execution_policy.read_only
+      ~retryable:execution_policy.retryable
+      ()
+  in
+  in_process_descriptor_with_schema_source
     ~capability_identity:Internal_name_identity
-    ~keeper_model_projection:
-      (Tool_schemas_local_runtime.keeper_model_exposure definition.operation
-       |> function
-       | Tool_schemas_local_runtime.Keeper_callable -> Internal_name
-       | Tool_schemas_local_runtime.Operator_diagnostic -> Operator_only)
+    ~keeper_model_projection
     ~input_schema_source:Canonical_registry
     ~input_schema:schema.input_schema
     ~id:
@@ -1386,7 +1396,7 @@ let masc_local_runtime_descriptor
     ~name:schema.name
     ~description:schema.description
     ~handler:Tool_masc_local_runtime_dispatch
-    ~readonly:true
+    ~policy
     ()
 ;;
 

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -22,6 +22,7 @@ let standard_cache_ttl_s = Server_dashboard_http_core_cache.standard_cache_ttl_s
 let live_cache_ttl_s = Server_dashboard_http_core_cache.live_cache_ttl_s
 let feature_health_cache_ttl_s = Server_dashboard_http_core_cache.feature_health_cache_ttl_s
 let exact_lane_run_permission = Masc_domain.CanAdmin
+let runtime_probe_read_permission = Masc_domain.CanReadState
 
 (* The panel draws a table; a page an operator can actually scan is ~50 rows.
    The ceiling exists so a caller cannot ask for the whole store back and
@@ -579,6 +580,7 @@ module For_testing = struct
 
   let gate_mode_change_json = gate_mode_change_json
   let exact_lane_run_permission = exact_lane_run_permission
+  let runtime_probe_read_permission = runtime_probe_read_permission
 end
 
 let handle_gate_mode_body state operator_name request reqd body_str =
@@ -987,7 +989,7 @@ let add_routes ~sw ~clock router =
          let json = dashboard_runtime_probe_http_json ~force () in
          Http.Response.json_value ~compress:true ~request:req json reqd
        in
-       with_tool_auth ~tool_name:"masc_runtime_ollama_probe" handle request reqd)
+       with_permission_auth ~permission:runtime_probe_read_permission handle request reqd)
   |> Http.Router.get "/api/v1/dashboard/runtime-defaults" (fun request reqd ->
        (* Structured, already-resolved runtime defaults / model routing for the
           Settings surface. Read-only projection of the runtime.toml SSOT

--- a/lib/server/server_routes_http_routes_dashboard.mli
+++ b/lib/server/server_routes_http_routes_dashboard.mli
@@ -18,6 +18,7 @@ val add_routes :
 
 module For_testing : sig
   val exact_lane_run_permission : Masc_domain.permission
+  val runtime_probe_read_permission : Masc_domain.permission
 
   type gate_mode_recovery =
     | Recovery_completed of Keeper_gate.operator_recovery_report

--- a/lib/tool/dune
+++ b/lib/tool/dune
@@ -36,6 +36,7 @@
   masc_core
   masc_config
   masc.tool_types
+  masc.tool_schemas_specs
   masc.tool_catalog_surfaces
   time_compat
   yojson

--- a/lib/tool/tool_catalog.ml
+++ b/lib/tool/tool_catalog.ml
@@ -183,6 +183,14 @@ let init_tool = with_required_permission Masc_domain.CanInit mutating_tool
 let reset_tool = with_required_permission Masc_domain.CanReset mutating_tool
 let admin_tool = with_required_permission Masc_domain.CanAdmin mutating_tool
 
+let local_runtime_tool operation =
+  let policy = Local_runtime_tool_policy.execution_policy operation in
+  with_execution_policy
+    ~readonly:policy.read_only
+    ~idempotent:policy.idempotent
+    (default_metadata ~required_permission:policy.required_permission)
+;;
+
 let hidden_runtime_tool reason meta =
   {
     meta with
@@ -310,8 +318,9 @@ let explicit_metadata : (string * metadata) list =
     ("masc_operator_snapshot", read_state_tool);
     ("masc_operator_digest", read_state_tool);
     ("masc_operator_confirm", broadcast_tool);
-    ("masc_runtime_verify", read_state_tool);
-    ("masc_runtime_ollama_probe", read_state_tool);
+    ("masc_runtime_verify", local_runtime_tool Local_runtime_tool_policy.Verify);
+    ( "masc_runtime_ollama_probe"
+    , local_runtime_tool Local_runtime_tool_policy.Ollama_probe );
     ("masc_board_hearths", read_state_tool);
     ("masc_board_search", read_state_tool);
     ("masc_board_profile", read_state_tool);

--- a/lib/tool_local_runtime.ml
+++ b/lib/tool_local_runtime.ml
@@ -55,6 +55,9 @@ let run_runtime_verify args : Core.tool_result =
           ?runtime_pool ?expected_slots ?expected_ctx ?expected_model () );
     ]
 
+(* TEL-OK: this adapter only requests the shared external-effect authorization
+   and delegates the completion. The authorizer owns the Gate decision receipt;
+   the outer MCP tool-call boundary owns duration and result telemetry. *)
 let handle_runtime_verify (ctx : Core.context) args : Core.tool_result =
   let continue () = run_runtime_verify args in
   match ctx.authorize_external_effect with

--- a/lib/tool_local_runtime.ml
+++ b/lib/tool_local_runtime.ml
@@ -173,6 +173,9 @@ let () =
   List.iter
     (fun (definition : Tool_schemas_local_runtime.definition) ->
       let s = definition.schema in
+      let policy =
+        Tool_schemas_local_runtime.execution_policy definition.operation
+      in
       Tool_spec.register
         (Tool_spec.create
            ~name:s.name
@@ -180,8 +183,8 @@ let () =
            ~module_tag:Tool_dispatch.Mod_local_runtime
            ~input_schema:s.input_schema
            ~handler_binding:Tag_dispatch
-           ~is_read_only:true
-           ~is_idempotent:true
+           ~is_read_only:policy.read_only
+           ~is_idempotent:policy.idempotent
            ()))
     Tool_schemas_local_runtime.definitions
 

--- a/lib/tool_local_runtime.ml
+++ b/lib/tool_local_runtime.ml
@@ -29,7 +29,7 @@ let err_response ~tool_name ~start_time ~class_ msg : Core.tool_result =
     (Yojson.Safe.to_string data)
 ;;
 
-let handle_runtime_verify _ctx args : Core.tool_result =
+let run_runtime_verify args : Core.tool_result =
   let tool_name = "masc_runtime_verify" in
   let start_time = Time_compat.now () in
   let runtime_pool = Json_util.get_string args "runtime_pool" in
@@ -54,6 +54,17 @@ let handle_runtime_verify _ctx args : Core.tool_result =
         Tool_local_runtime_verify.runtime_verify_json
           ?runtime_pool ?expected_slots ?expected_ctx ?expected_model () );
     ]
+
+let handle_runtime_verify (ctx : Core.context) args : Core.tool_result =
+  let continue () = run_runtime_verify args in
+  match ctx.authorize_external_effect with
+  | None -> continue ()
+  | Some authorize ->
+    authorize
+      ~operation:"masc_runtime_verify"
+      ~input:args
+      ~continue
+;;
 
 let run_runtime_ollama_probe ?timeout_sec args : Core.tool_result =
   let tool_name = "masc_runtime_ollama_probe" in

--- a/lib/tool_local_runtime_verify.ml
+++ b/lib/tool_local_runtime_verify.ml
@@ -11,25 +11,42 @@ let safe_discovery_endpoints () =
   | Stdlib.Effect.Unhandled _ -> None
   | _ -> None
 
+let select_endpoint_urls_for_pool ?runtime_pool endpoint_urls =
+  match Option.bind runtime_pool String_util.trim_to_option with
+  | None -> if endpoint_urls = [] then None else Some endpoint_urls
+  | Some pool
+    when String.equal pool Local_runtime_pool.default_pool_label
+         || String.equal pool "default" ->
+      if endpoint_urls = [] then None else Some endpoint_urls
+  | Some pool ->
+      let matches url =
+        String.equal pool url
+        || String.equal pool (Local_runtime_pool.runtime_id_of_base_url url)
+      in
+      (match List.filter matches endpoint_urls with
+       | [] -> None
+      | selected -> Some selected)
+;;
+
+module For_testing = struct
+  let select_endpoint_urls_for_pool = select_endpoint_urls_for_pool
+end
+
 let discovery_endpoints_for_pool runtime_pool =
   match safe_discovery_endpoints () with
   | None -> None
   | Some [] -> None
   | Some endpoints ->
-      let matches_pool (endpoint : Discovery_cache.endpoint_info) =
-        match Option.bind runtime_pool String_util.trim_to_option with
-        | None -> true
-        | Some pool
-          when String.equal pool Local_runtime_pool.default_pool_label
-               || String.equal pool "default" ->
-            true
-        | Some pool ->
-            String.equal pool endpoint.url
-            || String.equal pool
-                 (Local_runtime_pool.runtime_id_of_base_url endpoint.url)
+      let endpoint_urls =
+        List.map (fun (endpoint : Discovery_cache.endpoint_info) -> endpoint.url) endpoints
       in
-      let filtered = List.filter matches_pool endpoints in
-      Some (if Stdlib.List.length filtered = 0 then endpoints else filtered)
+      Option.map
+        (fun selected_urls ->
+          List.filter
+            (fun (endpoint : Discovery_cache.endpoint_info) ->
+              List.mem endpoint.url selected_urls)
+            endpoints)
+        (select_endpoint_urls_for_pool ?runtime_pool endpoint_urls)
 
 let endpoint_model_id (endpoint : Discovery_cache.endpoint_info) =
   match endpoint.models with

--- a/lib/tool_local_runtime_verify.mli
+++ b/lib/tool_local_runtime_verify.mli
@@ -10,6 +10,12 @@
     renderer behind {!runtime_verify_json}.  The old single-host legacy
     probe fallback is gone; verification now requires AGENT_CORE discovery. *)
 
+module For_testing : sig
+  val select_endpoint_urls_for_pool :
+    ?runtime_pool:string -> string list -> string list option
+  (** Regression seam for the fail-closed explicit-pool selector. *)
+end
+
 val provider_health_reachable : status:int option -> bool
 (** [provider_health_reachable ~status] is [true] iff
     [status = Some 200].  The health endpoint is a status-code-only
@@ -66,9 +72,10 @@ val runtime_verify_json :
 
     Returns a JSON object with health/slot/ctx/model
     diagnostics + the {!classify_runtime_blocker} verdict.  [?runtime_pool]
-    selects the pool by name; default behaviour is "use the
-    default pool" via {!Local_runtime_pool.default_pool_label}.  When
-    discovery has no resolvable endpoints, the local-runtime diagnostic fails
+    selects the pool by name; default behaviour verifies every discovered
+    endpoint. An explicit pool that matches no endpoint fails closed rather
+    than probing the full pool. When discovery has no resolvable endpoints,
+    the local-runtime diagnostic fails
     closed with [runtime_blocker = "agent_core_discovery_unavailable"]. The
     response also pins [verification_scope =
     "local_openai_compatible_runtime_pool"], [blocks_keeper_turns = false],

--- a/lib/tool_schemas/tool_schemas_local_runtime.ml
+++ b/lib/tool_schemas/tool_schemas_local_runtime.ml
@@ -2,7 +2,7 @@
 
 open Masc_domain
 
-type operation =
+type operation = Local_runtime_tool_policy.operation =
   | Verify
   | Ollama_probe
 
@@ -11,31 +11,19 @@ type definition =
   ; schema : Masc_domain.tool_schema
   }
 
-let operation_id = function
-  | Verify -> "verify"
-  | Ollama_probe -> "ollama_probe"
-;;
+let operation_id = Local_runtime_tool_policy.operation_id
 
-(* Who the tool is for. Both operations stay registered in the catalog — the
-   dashboard route /api/v1/dashboard/runtime-probe authorizes through
-   [with_tool_auth ~tool_name:"masc_runtime_ollama_probe"], and
-   [authorize_tool_for_role] refuses any name it cannot find there. The
-   question this answers is narrower: does the autonomous Keeper model see the
-   schema in its tool list every turn. *)
-type keeper_model_exposure =
+(* Who the tool is for. Both operations stay registered in the catalog. The
+   native Ollama probe is an explicit Admin operation; the metadata-only
+   dashboard runtime probe has its own [CanReadState] route authority and does
+   not reuse this tool identity. The question this answers is narrower: does
+   the autonomous Keeper model see the schema in its tool list every turn. *)
+type keeper_model_exposure = Local_runtime_tool_policy.model_exposure =
   | Keeper_callable
   | Operator_diagnostic
 
-let keeper_model_exposure = function
-  | Verify -> Keeper_callable
-  | Ollama_probe ->
-    (* Native Ollama timing probe: repeated /api/generate calls whose output is
-       load/prompt-eval timings and a prefix-reuse inference. That is operator
-       diagnostics, and the operator reads it through the dashboard route. It
-       cost every Keeper turn 1,219 bytes of tool schema and was called 0 times
-       in the 6 days to 2026-08-06 (the workspace tool_usage store). *)
-    Operator_diagnostic
-;;
+let keeper_model_exposure = Local_runtime_tool_policy.model_exposure
+let execution_policy = Local_runtime_tool_policy.execution_policy
 
 let definitions : definition list =
   [
@@ -60,7 +48,7 @@ let definitions : definition list =
     { operation = Ollama_probe; schema = {
       name = "masc_runtime_ollama_probe";
       description =
-        "Probe native Ollama timing behavior with repeated /api/generate calls. Returns loaded models from /api/ps, per-run load/prompt-eval/generation timings, tok/sec estimates, and a timing-based repeated-prefix reuse inference. This does not expose direct KV occupancy or hit-rate.";
+        "Admin-only native Ollama timing probe with repeated /api/generate calls. It may load a model and change warm/cache state, so it is not read-only or idempotent. Returns loaded models from /api/ps, per-run load/prompt-eval/generation timings, tok/sec estimates, and a timing-based repeated-prefix reuse inference. This does not expose direct KV occupancy or hit-rate.";
       input_schema =
         `Assoc
           [

--- a/lib/tool_schemas/tool_schemas_local_runtime.ml
+++ b/lib/tool_schemas/tool_schemas_local_runtime.ml
@@ -14,7 +14,8 @@ type definition =
 let operation_id = Local_runtime_tool_policy.operation_id
 
 (* Who the tool is for. Both operations stay registered in the catalog. The
-   native Ollama probe is an explicit Admin operation; the metadata-only
+   completion-backed contract check and native Ollama probe are explicit Admin
+   operations; the metadata-only
    dashboard runtime probe has its own [CanReadState] route authority and does
    not reuse this tool identity. The question this answers is narrower: does
    the autonomous Keeper model see the schema in its tool list every turn. *)
@@ -30,7 +31,7 @@ let definitions : definition list =
     { operation = Verify; schema = {
       name = "masc_runtime_verify";
       description =
-        "Verify only the optional typed local OpenAI-compatible runtime pool used for local benchmarks. Returns reachability, chat-completions contract status, model match, slots, ctx, configured capacity, active slots, and local blocker codes. Missing local discovery does not assess or block official-client, CLI, or remote Keeper provider lanes.";
+        "Admin-only contract probe for the optional typed local OpenAI-compatible runtime pool used for local benchmarks. It issues one real chat completion per selected endpoint and may load models or change warm/cache state, so it is not read-only or idempotent. An explicit runtime_pool that matches no endpoint fails closed. Returns reachability, chat-completions contract status, model match, slots, ctx, configured capacity, active slots, and local blocker codes. Missing local discovery does not assess or block official-client, CLI, or remote Keeper provider lanes.";
       input_schema =
         `Assoc
           [

--- a/lib/tool_schemas/tool_schemas_local_runtime.mli
+++ b/lib/tool_schemas/tool_schemas_local_runtime.mli
@@ -1,4 +1,4 @@
-type operation =
+type operation = Local_runtime_tool_policy.operation =
   | Verify
   | Ollama_probe
 
@@ -9,14 +9,16 @@ type definition =
 
 (** Whether the autonomous Keeper model carries this operation's schema in its
     per-turn tool list. Both operations stay registered in the catalog either
-    way: [Operator_diagnostic] withholds only the model projection, and the
-    dashboard route still authorizes by tool name through
-    [Auth.authorize_tool_for_role], which refuses any unregistered name. *)
-type keeper_model_exposure =
+    way. [Operator_diagnostic] withholds only the model projection; execution
+    permission remains catalog-owned. The metadata-only dashboard runtime probe
+    has a separate [CanReadState] route authority and does not borrow this native
+    probe's identity. *)
+type keeper_model_exposure = Local_runtime_tool_policy.model_exposure =
   | Keeper_callable
   | Operator_diagnostic
 
 val operation_id : operation -> string
 val keeper_model_exposure : operation -> keeper_model_exposure
+val execution_policy : operation -> Local_runtime_tool_policy.t
 val definitions : definition list
 val schemas : Masc_domain.tool_schema list

--- a/lib/tool_schemas_specs/dune
+++ b/lib/tool_schemas_specs/dune
@@ -7,5 +7,7 @@
  ; RFC-0071 §3.4 Phase 5 ratchet: warning 4 enabled. Leaf util sublib. + unused-value ratchet (warning 32)
  (flags
   (:standard -w +4 -w +33 -w +37))
- (libraries yojson)
- (modules tool_schemas_specs_types))
+ (libraries yojson masc_types)
+ (modules
+  local_runtime_tool_policy
+  tool_schemas_specs_types))

--- a/lib/tool_schemas_specs/local_runtime_tool_policy.ml
+++ b/lib/tool_schemas_specs/local_runtime_tool_policy.ml
@@ -1,0 +1,42 @@
+open Masc_domain
+
+type operation =
+  | Verify
+  | Ollama_probe
+
+type model_exposure =
+  | Keeper_callable
+  | Operator_diagnostic
+
+type t =
+  { required_permission : permission
+  ; read_only : bool
+  ; idempotent : bool
+  ; retryable : bool
+  }
+
+let operation_id = function
+  | Verify -> "verify"
+  | Ollama_probe -> "ollama_probe"
+;;
+
+let model_exposure = function
+  | Verify -> Keeper_callable
+  | Ollama_probe -> Operator_diagnostic
+;;
+
+let execution_policy = function
+  | Verify ->
+    { required_permission = CanReadState
+    ; read_only = true
+    ; idempotent = true
+    ; retryable = true
+    }
+  | Ollama_probe ->
+    (* [/api/generate] can load a model and changes warm/cache state. *)
+    { required_permission = CanAdmin
+    ; read_only = false
+    ; idempotent = false
+    ; retryable = false
+    }
+;;

--- a/lib/tool_schemas_specs/local_runtime_tool_policy.ml
+++ b/lib/tool_schemas_specs/local_runtime_tool_policy.ml
@@ -21,16 +21,18 @@ let operation_id = function
 ;;
 
 let model_exposure = function
-  | Verify -> Keeper_callable
+  | Verify -> Operator_diagnostic
   | Ollama_probe -> Operator_diagnostic
 ;;
 
 let execution_policy = function
   | Verify ->
-    { required_permission = CanReadState
-    ; read_only = true
-    ; idempotent = true
-    ; retryable = true
+    (* The contract check issues one real chat-completion per selected
+       discovery endpoint. That can load a model and changes warm/cache state. *)
+    { required_permission = CanAdmin
+    ; read_only = false
+    ; idempotent = false
+    ; retryable = false
     }
   | Ollama_probe ->
     (* [/api/generate] can load a model and changes warm/cache state. *)

--- a/lib/tool_schemas_specs/local_runtime_tool_policy.mli
+++ b/lib/tool_schemas_specs/local_runtime_tool_policy.mli
@@ -1,0 +1,18 @@
+type operation =
+  | Verify
+  | Ollama_probe
+
+type model_exposure =
+  | Keeper_callable
+  | Operator_diagnostic
+
+type t =
+  { required_permission : Masc_domain.permission
+  ; read_only : bool
+  ; idempotent : bool
+  ; retryable : bool
+  }
+
+val operation_id : operation -> string
+val model_exposure : operation -> model_exposure
+val execution_policy : operation -> t

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -184,24 +184,11 @@ let test_internal_exact_lane_registry_is_admin_only () =
      = Masc_domain.CanAdmin)
 
 let test_runtime_probe_route_owns_read_permission () =
-  let source = read_file "lib/server/server_routes_http_routes_dashboard.ml" in
   check bool
     "metadata-only runtime probe remains a read route"
     true
     (Server_routes_http_routes_dashboard.For_testing.runtime_probe_read_permission
-     = Masc_domain.CanReadState);
-  check bool
-    "runtime probe route consumes its own read permission"
-    true
-    (String_util.contains_substring
-       source
-       "with_permission_auth ~permission:runtime_probe_read_permission");
-  check bool
-    "runtime probe route does not borrow the native effectful tool authority"
-    false
-    (String_util.contains_substring
-       source
-       "with_tool_auth ~tool_name:\"masc_runtime_ollama_probe\"")
+     = Masc_domain.CanReadState)
 
 let test_event_queue_operator_routes_are_exact () =
   check (option string) "event operator route is exact" (Some "idealist")

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -183,6 +183,26 @@ let test_internal_exact_lane_registry_is_admin_only () =
     (Server_routes_http_routes_dashboard.For_testing.exact_lane_run_permission
      = Masc_domain.CanAdmin)
 
+let test_runtime_probe_route_owns_read_permission () =
+  let source = read_file "lib/server/server_routes_http_routes_dashboard.ml" in
+  check bool
+    "metadata-only runtime probe remains a read route"
+    true
+    (Server_routes_http_routes_dashboard.For_testing.runtime_probe_read_permission
+     = Masc_domain.CanReadState);
+  check bool
+    "runtime probe route consumes its own read permission"
+    true
+    (String_util.contains_substring
+       source
+       "with_permission_auth ~permission:runtime_probe_read_permission");
+  check bool
+    "runtime probe route does not borrow the native effectful tool authority"
+    false
+    (String_util.contains_substring
+       source
+       "with_tool_auth ~tool_name:\"masc_runtime_ollama_probe\"")
+
 let test_event_queue_operator_routes_are_exact () =
   check (option string) "event operator route is exact" (Some "idealist")
     (Server_dashboard_http_keeper_event_queue_operator.route
@@ -3615,6 +3635,8 @@ let () =
             test_keeper_sensitive_get_permissions_are_exact;
           test_case "internal exact lane registry is Admin-only" `Quick
             test_internal_exact_lane_registry_is_admin_only;
+          test_case "runtime probe route owns read permission" `Quick
+            test_runtime_probe_route_owns_read_permission;
           test_case "event queue operator routes are exact" `Quick
             test_event_queue_operator_routes_are_exact;
           test_case "event operator keeps exact source refs across queue changes" `Quick

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -319,9 +319,6 @@ let test_registered_cluster_model_projections_are_explicit () =
   let keeper_model_names = Policy.keeper_model_tool_names () in
   List.iter
     (fun name -> check_projection name Descriptor.Internal_name)
-    [ "masc_runtime_verify" ];
-  List.iter
-    (fun name -> check_projection name Descriptor.Internal_name)
     [ "keeper_library_read"
     ; "keeper_library_search"
     ; "masc_library_add"
@@ -344,12 +341,13 @@ let test_registered_cluster_model_projections_are_explicit () =
       "masc_status"
     ; "masc_pause"
     ; "masc_resume"
-      (* Native Ollama timing probe. Its output is load/prompt-eval timings and
-         a prefix-reuse inference — an explicit Admin diagnostic, distinct from
-         [/api/v1/dashboard/runtime-probe], which reads metadata only. It carried
-         1,219 bytes of schema into every Keeper turn and was called 0 times in
-         the 6 days to 2026-08-06. Registration is unchanged; the metadata-only
-         dashboard route owns a separate [CanReadState] authority. *)
+      (* Completion-backed runtime verification and the native Ollama timing
+         probe are explicit Admin diagnostics, distinct from
+         [/api/v1/dashboard/runtime-probe], which reads metadata only. Both can
+         load a model or change warm/cache state. Registration is unchanged;
+         the metadata-only dashboard route owns separate [CanReadState]
+         authority. *)
+    ; "masc_runtime_verify"
     ; "masc_runtime_ollama_probe"
     ];
   List.iter
@@ -364,10 +362,10 @@ let test_registered_cluster_model_projections_are_explicit () =
 let test_local_runtime_effect_policy_is_explicit () =
   let verify = required_internal_descriptor "masc_runtime_verify" in
   Alcotest.(check (option bool))
-    "verify is read-only"
-    (Some true)
+    "verify is not read-only"
+    (Some false)
     verify.policy.readonly_hint;
-  Alcotest.(check bool) "verify is retryable" true verify.policy.retryable;
+  Alcotest.(check bool) "verify is not retryable" false verify.policy.retryable;
   let probe = required_internal_descriptor "masc_runtime_ollama_probe" in
   Alcotest.(check (option bool))
     "native probe is not read-only"

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -345,12 +345,11 @@ let test_registered_cluster_model_projections_are_explicit () =
     ; "masc_pause"
     ; "masc_resume"
       (* Native Ollama timing probe. Its output is load/prompt-eval timings and
-         a prefix-reuse inference — operator diagnostics, read through
-         /api/v1/dashboard/runtime-probe. It carried 1,219 bytes of schema into
-         every Keeper turn and was called 0 times in the 6 days to 2026-08-06.
-         Registration is unchanged: that dashboard route authorizes with
-         [with_tool_auth ~tool_name:"masc_runtime_ollama_probe"], and
-         [Auth.authorize_tool_for_role] refuses any unregistered name. *)
+         a prefix-reuse inference — an explicit Admin diagnostic, distinct from
+         [/api/v1/dashboard/runtime-probe], which reads metadata only. It carried
+         1,219 bytes of schema into every Keeper turn and was called 0 times in
+         the 6 days to 2026-08-06. Registration is unchanged; the metadata-only
+         dashboard route owns a separate [CanReadState] authority. *)
     ; "masc_runtime_ollama_probe"
     ];
   List.iter
@@ -360,6 +359,21 @@ let test_registered_cluster_model_projections_are_explicit () =
     ; "masc_library_search", "keeper_library_search"
     ; "masc_tasks", "keeper_tasks_list"
     ]
+;;
+
+let test_local_runtime_effect_policy_is_explicit () =
+  let verify = required_internal_descriptor "masc_runtime_verify" in
+  Alcotest.(check (option bool))
+    "verify is read-only"
+    (Some true)
+    verify.policy.readonly_hint;
+  Alcotest.(check bool) "verify is retryable" true verify.policy.retryable;
+  let probe = required_internal_descriptor "masc_runtime_ollama_probe" in
+  Alcotest.(check (option bool))
+    "native probe is not read-only"
+    (Some false)
+    probe.policy.readonly_hint;
+  Alcotest.(check bool) "native probe is not retryable" false probe.policy.retryable
 ;;
 
 let test_keeper_management_projection_is_explicit () =
@@ -1549,6 +1563,10 @@ let () =
             "registered cluster model projections are explicit"
             `Quick
             test_registered_cluster_model_projections_are_explicit
+        ; test_case
+            "local runtime effect policy is explicit"
+            `Quick
+            test_local_runtime_effect_policy_is_explicit
         ; test_case
             "Keeper management projection is explicit"
             `Quick

--- a/test/test_tool_local_runtime_probe.ml
+++ b/test/test_tool_local_runtime_probe.ml
@@ -311,36 +311,88 @@ let required_runtime_metadata name =
 
 let test_runtime_tool_authority_matches_effects () =
   let verify = required_runtime_metadata "masc_runtime_verify" in
-  check bool "verify remains Worker-readable" true
-    (verify.required_permission = Masc_domain.CanReadState);
-  check (option bool) "verify remains read-only" (Some true) verify.readonly;
-  check (option bool) "verify remains idempotent" (Some true) verify.idempotent;
+  check bool "verify requires operator authority" true
+    (verify.required_permission = Masc_domain.CanAdmin);
+  check (option bool) "verify is not read-only" (Some false) verify.readonly;
+  check (option bool) "verify is not idempotent" (Some false) verify.idempotent;
   let probe = required_runtime_metadata "masc_runtime_ollama_probe" in
   check bool "probe requires operator authority" true
     (probe.required_permission = Masc_domain.CanAdmin);
   check (option bool) "probe is not read-only" (Some false) probe.readonly;
   check (option bool) "probe is not idempotent" (Some false) probe.idempotent;
+  List.iter
+    (fun tool_name ->
+      (match
+         Auth.authorize_tool_for_role
+           ~agent_name:"runtime-probe-worker"
+           ~role:Masc_domain.Worker
+           ~tool_name
+       with
+       | Error (Masc_domain.Auth (Masc_domain.Auth_error.Forbidden _)) -> ()
+       | Ok () -> failf "Worker must not invoke operator tool %s" tool_name
+       | Error error ->
+         failf "unexpected Worker authorization error: %s"
+           (Masc_domain.masc_error_to_string error));
+      match
+        Auth.authorize_tool_for_role
+          ~agent_name:"runtime-probe-admin"
+          ~role:Masc_domain.Admin
+          ~tool_name
+      with
+      | Ok () -> ()
+      | Error error ->
+        failf "Admin must retain %s access: %s" tool_name
+          (Masc_domain.masc_error_to_string error))
+    [ "masc_runtime_verify"; "masc_runtime_ollama_probe" ]
+;;
+
+let test_runtime_verify_pool_selection_fails_closed () =
+  let select ?runtime_pool () =
+    Masc.Tool_local_runtime_verify.For_testing.select_endpoint_urls_for_pool
+      ?runtime_pool
+      [ "http://127.0.0.1:19001"; "http://127.0.0.1:19002" ]
+  in
+  check (option (list string)) "default selects the discovered pool"
+    (Some [ "http://127.0.0.1:19001"; "http://127.0.0.1:19002" ])
+    (select ());
+  check (option (list string)) "runtime id selects one endpoint"
+    (Some [ "http://127.0.0.1:19002" ])
+    (select ~runtime_pool:"local-19002" ());
+  check (option (list string)) "unknown explicit pool selects nothing"
+    None
+    (select ~runtime_pool:"missing-pool" ())
+;;
+
+let test_runtime_verify_requests_external_effect_authorization () =
+  let calls = ref [] in
+  let authorize_external_effect ~operation ~input ~continue:_ =
+    calls := (operation, input) :: !calls;
+    Tool_result.ok
+      ~tool_name:operation
+      ~start_time:0.0
+      {|{"ok":true,"effect":"intercepted"}|}
+  in
+  let args = `Assoc [ "runtime_pool", `String "local-19002" ] in
+  let context : Masc.Tool_local_runtime_core.context =
+    { config = Masc.Workspace.default_config "/tmp"
+    ; agent_name = "runtime-verify-effect-test"
+    ; authorize_external_effect = Some authorize_external_effect
+    }
+  in
   (match
-     Auth.authorize_tool_for_role
-       ~agent_name:"runtime-probe-worker"
-       ~role:Masc_domain.Worker
-       ~tool_name:"masc_runtime_ollama_probe"
+     Masc.Tool_local_runtime.dispatch context ~name:"masc_runtime_verify" ~args
    with
-   | Error (Masc_domain.Auth (Masc_domain.Auth_error.Forbidden _)) -> ()
-   | Ok () -> fail "Worker must not invoke the operator runtime probe"
-   | Error error ->
-     failf "unexpected Worker authorization error: %s"
-       (Masc_domain.masc_error_to_string error));
-  match
-    Auth.authorize_tool_for_role
-      ~agent_name:"runtime-probe-admin"
-      ~role:Masc_domain.Admin
-      ~tool_name:"masc_runtime_ollama_probe"
-  with
-  | Ok () -> ()
-  | Error error ->
-    failf "Admin must retain runtime probe access: %s"
-      (Masc_domain.masc_error_to_string error)
+   | Some result ->
+     check bool "authorizer intercepts before completion" true
+       (Tool_result.is_success result)
+   | None -> fail "runtime verify handler was not selected");
+  match !calls with
+  | [ operation, input ] ->
+    check string "exact operation" "masc_runtime_verify" operation;
+    check string "complete input"
+      (Yojson.Safe.to_string args)
+      (Yojson.Safe.to_string input)
+  | calls -> failf "expected one authorization request, got %d" (List.length calls)
 ;;
 
 let () =
@@ -397,5 +449,9 @@ let () =
         [
           test_case "authority and execution policy match effects" `Quick
             test_runtime_tool_authority_matches_effects;
+          test_case "explicit runtime pool selection fails closed" `Quick
+            test_runtime_verify_pool_selection_fails_closed;
+          test_case "runtime verify requests external effect authorization" `Quick
+            test_runtime_verify_requests_external_effect_authorization;
         ] );
     ]

--- a/test/test_tool_local_runtime_probe.ml
+++ b/test/test_tool_local_runtime_probe.ml
@@ -303,6 +303,46 @@ let test_generate_probe_decision_reports_typed_reasons () =
     (decision ~before_status:200 ~generate_when_unloaded:false
        ~effective_model_loaded_before:true ())
 
+let required_runtime_metadata name =
+  match Tool_catalog.registered_metadata name with
+  | Some metadata -> metadata
+  | None -> failf "missing runtime metadata for %s" name
+;;
+
+let test_runtime_tool_authority_matches_effects () =
+  let verify = required_runtime_metadata "masc_runtime_verify" in
+  check bool "verify remains Worker-readable" true
+    (verify.required_permission = Masc_domain.CanReadState);
+  check (option bool) "verify remains read-only" (Some true) verify.readonly;
+  check (option bool) "verify remains idempotent" (Some true) verify.idempotent;
+  let probe = required_runtime_metadata "masc_runtime_ollama_probe" in
+  check bool "probe requires operator authority" true
+    (probe.required_permission = Masc_domain.CanAdmin);
+  check (option bool) "probe is not read-only" (Some false) probe.readonly;
+  check (option bool) "probe is not idempotent" (Some false) probe.idempotent;
+  (match
+     Auth.authorize_tool_for_role
+       ~agent_name:"runtime-probe-worker"
+       ~role:Masc_domain.Worker
+       ~tool_name:"masc_runtime_ollama_probe"
+   with
+   | Error (Masc_domain.Auth (Masc_domain.Auth_error.Forbidden _)) -> ()
+   | Ok () -> fail "Worker must not invoke the operator runtime probe"
+   | Error error ->
+     failf "unexpected Worker authorization error: %s"
+       (Masc_domain.masc_error_to_string error));
+  match
+    Auth.authorize_tool_for_role
+      ~agent_name:"runtime-probe-admin"
+      ~role:Masc_domain.Admin
+      ~tool_name:"masc_runtime_ollama_probe"
+  with
+  | Ok () -> ()
+  | Error error ->
+    failf "Admin must retain runtime probe access: %s"
+      (Masc_domain.masc_error_to_string error)
+;;
+
 let () =
   run "tool_local_runtime_probe"
     [
@@ -352,5 +392,10 @@ let () =
             test_kv_cache_assessment_requires_two_successful_runs;
           test_case "generate probe decision reports typed reasons" `Quick
             test_generate_probe_decision_reports_typed_reasons;
+        ] );
+      ( "policy",
+        [
+          test_case "authority and execution policy match effects" `Quick
+            test_runtime_tool_authority_matches_effects;
         ] );
     ]


### PR DESCRIPTION
Closes #28652

## Summary

The oldest merged PR in the current seven-day audit window, #27267, correctly withheld the native Ollama timing probe from the autonomous Keeper model but left its direct MCP execution policy classified as Worker-readable, read-only, and idempotent. The first revision of this PR exposed the same inconsistency in sibling `masc_runtime_verify`: it issues real chat completions while claiming read-only/retryable semantics.

This change introduces one closed per-operation policy SSOT for both local-runtime diagnostics and projects it into all three consumers:

- `Tool_catalog`: both completion-generating diagnostics require `CanAdmin` and are mutating/non-idempotent.
- `Tool_spec`: execution hints come from the same typed operation policy instead of a shared hard-coded value.
- Keeper descriptor: both diagnostics are operator-only and non-retryable.

`masc_runtime_verify` now also passes through the Keeper external-effect authorizer. An explicit `runtime_pool` that matches nothing fails closed instead of broadening the completion probe to every discovered endpoint.

The metadata-only dashboard route remains a separate read path: `/api/v1/dashboard/runtime-probe` owns explicit `CanReadState` route authority and does not borrow either effectful tool identity.

## Blast radius and parity

| Surface | Before | After |
| --- | --- | --- |
| Worker direct MCP call to native Ollama probe | Allowed | Denied |
| Worker direct MCP call to completion-backed Verify | Allowed | Denied |
| Admin direct MCP calls | Allowed | Allowed |
| Keeper model projection | Ollama withheld; Verify visible | Both withheld |
| Keeper external-effect Gate | Ollama only | Both diagnostics |
| Unknown explicit Verify pool | Probed every endpoint | Fails closed |
| Dashboard metadata runtime probe | Borrowed native tool authority | Own `CanReadState` authority |

The Admin-only native diagnostic still accepts an explicit `server_url`; this PR narrows caller authority and fixes policy truth without changing its operator contract. Benchmark scripts remain usable with an Admin token when authentication is enabled; the performance documentation now says that explicitly.

## Verification

Exact head `9e1e6cc03e25b93981be5d295335f43759e5c049`:

- local runtime policy/probe suite — 22/22
- Keeper descriptor registry integrity — 45/45
- Gate effect coverage — 8/8
- whole-repo `scripts/dune-local.sh build @all` — pass
- `git diff --check` — pass
- `ocamlformat --check` on every changed OCaml file — pass

Repository-wide `@fmt` remains independently red on pre-existing Dune stanza formatting outside this diff; no corrected unrelated files are included.

The separate `test_mcp_server_eio_tool_profile_capability` hidden-deny corpus sentinel fails identically on clean current `origin/main` after every enumerated admission/advertisement comparison passes. It remains grouped under #28156 rather than duplicated here.

## Issue grouping

- #28652 — P1 root defect fixed by this PR, including the Verify sibling found in follow-up review
- #26190 — related Gate replay work, not a duplicate
- #27358 — related #27267 provenance/measurement issue, not a duplicate
- #28156 — pre-existing empty hidden-deny test corpus, not caused by this change
- #28661 / #28663 — independent v0.22.0 release-train blocker and repair; this PR remains Draft until exact-head CI reports against the current head

## Current-main rebase

- exact base: `addf6e4f5c0dd3b1d96bc2a2831d9d57c5ba655c`
- exact head: `434607d2aa3f16ed9ad09a974cdf54536a51ab42`
- local proof: `dune build @all`; runtime probe 22/22; descriptor registry 45/45; `git diff --check origin/main...HEAD`
- prior package-version Meta Guard blocker is removed by current main 0.22.0; fresh exact-head CI is authoritative for final readiness.
