### PR TITLE
feat(keeper): execute typed tool composition plans

### DIFF
--- a/lib/keeper/keeper_tool_composition_catalog.ml
+++ b/lib/keeper/keeper_tool_composition_catalog.ml
@@ -1,0 +1,382 @@
+module Toml = Keeper_toml_loader
+module Plan = Keeper_tool_plan
+
+type expected_value =
+  | String_value
+  | String_array_value
+  | Table_value
+  | Table_array_value
+  | Array_value
+
+type error =
+  | Toml_syntax of string
+  | Empty_catalog
+  | Unknown_field of
+      { path : string list
+      ; field : string
+      }
+  | Duplicate_field of
+      { path : string list
+      ; field : string
+      }
+  | Missing_field of
+      { path : string list
+      ; field : string
+      }
+  | Wrong_value_kind of
+      { path : string list
+      ; field : string
+      ; expected : expected_value
+      }
+  | Empty_name of { path : string list }
+  | Duplicate_composition_name of string
+  | Invalid_template_kind of
+      { path : string list
+      ; kind : string
+      }
+  | Invalid_node_id of
+      { path : string list
+      ; error : Plan.Node_id.error
+      }
+  | Invalid_json_pointer of
+      { path : string list
+      ; error : Plan.Json_pointer.syntax_error
+      }
+  | Duplicate_template_object_field of
+      { path : string list
+      ; field : string
+      }
+  | Plan_rejected of
+      { name : string
+      ; error : Plan.error
+      }
+
+type entry =
+  { name : string
+  ; description : string option
+  ; plan : Plan.t
+  }
+
+type t = entry list
+
+let entries catalog = catalog
+
+let find catalog name =
+  List.find_opt (fun entry -> String.equal entry.name name) catalog
+;;
+
+let first_duplicate fields =
+  let rec find_duplicate seen = function
+    | [] -> None
+    | (name, _) :: rest ->
+      if List.mem name seen then Some name else find_duplicate (name :: seen) rest
+  in
+  find_duplicate [] fields
+;;
+
+let validate_fields ~path ~allowed fields =
+  match first_duplicate fields with
+  | Some field -> Error (Duplicate_field { path; field })
+  | None ->
+    (match List.find_opt (fun (field, _) -> not (List.mem field allowed)) fields with
+     | Some (field, _) -> Error (Unknown_field { path; field })
+     | None -> Ok ())
+;;
+
+let required_field ~path field fields =
+  match List.assoc_opt field fields with
+  | Some value -> Ok value
+  | None -> Error (Missing_field { path; field })
+;;
+
+let string_value ~path ~field = function
+  | Toml.Toml_string value -> Ok value
+  | _ -> Error (Wrong_value_kind { path; field; expected = String_value })
+;;
+
+let required_string ~path field fields =
+  match required_field ~path field fields with
+  | Error _ as error -> error
+  | Ok value -> string_value ~path ~field value
+;;
+
+let required_nonempty_string ~path field fields =
+  match required_string ~path field fields with
+  | Error _ as error -> error
+  | Ok "" -> Error (Empty_name { path = path @ [ field ] })
+  | Ok value -> Ok value
+;;
+
+let optional_string ~path field fields =
+  match List.assoc_opt field fields with
+  | None -> Ok None
+  | Some value ->
+    (match string_value ~path ~field value with
+     | Ok value -> Ok (Some value)
+     | Error _ as error -> error)
+;;
+
+let table_fields ~path ~field = function
+  | Toml.Toml_table fields | Toml.Toml_inline_table fields -> Ok fields
+  | _ -> Error (Wrong_value_kind { path; field; expected = Table_value })
+;;
+
+let table_array ~path ~field = function
+  | Toml.Toml_table_array values -> Ok values
+  | _ -> Error (Wrong_value_kind { path; field; expected = Table_array_value })
+;;
+
+let array_values ~path ~field = function
+  | Toml.Toml_array values | Toml.Toml_table_array values -> Ok values
+  | Toml.Toml_string_array values ->
+    Ok (List.map (fun value -> Toml.Toml_string value) values)
+  | _ -> Error (Wrong_value_kind { path; field; expected = Array_value })
+;;
+
+let string_array ~path ~field = function
+  | Toml.Toml_string_array values -> Ok values
+  | Toml.Toml_array values ->
+    let rec strings parsed = function
+      | [] -> Ok (List.rev parsed)
+      | Toml.Toml_string value :: rest -> strings (value :: parsed) rest
+      | _ :: _ ->
+        Error (Wrong_value_kind { path; field; expected = String_array_value })
+    in
+    strings [] values
+  | _ -> Error (Wrong_value_kind { path; field; expected = String_array_value })
+;;
+
+let rec json_of_toml = function
+  | Toml.Toml_string value -> `String value
+  | Toml.Toml_int value -> `Int value
+  | Toml.Toml_float value -> `Float value
+  | Toml.Toml_bool value -> `Bool value
+  | Toml.Toml_string_array values ->
+    `List (List.map (fun value -> `String value) values)
+  | Toml.Toml_array values | Toml.Toml_table_array values ->
+    `List (List.map json_of_toml values)
+  | Toml.Toml_table fields | Toml.Toml_inline_table fields ->
+    `Assoc (List.map (fun (name, value) -> name, json_of_toml value) fields)
+  | Toml.Toml_offset_datetime value
+  | Toml.Toml_local_datetime value
+  | Toml.Toml_local_date value
+  | Toml.Toml_local_time value -> `String value
+;;
+
+let node_id ~path raw =
+  match Plan.Node_id.make raw with
+  | Ok id -> Ok id
+  | Error error -> Error (Invalid_node_id { path; error })
+;;
+
+let pointer ~path raw =
+  match Plan.Json_pointer.of_string raw with
+  | Ok pointer -> Ok pointer
+  | Error error -> Error (Invalid_json_pointer { path; error })
+;;
+
+let rec parse_template ~path value =
+  match table_fields ~path ~field:"template" value with
+  | Error _ as error -> error
+  | Ok fields ->
+    (match required_string ~path "kind" fields with
+     | Error _ as error -> error
+     | Ok "literal" -> parse_literal_template ~path fields
+     | Ok "output" -> parse_output_template ~path fields
+     | Ok "object" -> parse_object_template ~path fields
+     | Ok "array" -> parse_array_template ~path fields
+     | Ok kind -> Error (Invalid_template_kind { path; kind }))
+
+and parse_literal_template ~path fields =
+  match validate_fields ~path ~allowed:[ "kind"; "value" ] fields with
+  | Error _ as error -> error
+  | Ok () ->
+    (match required_field ~path "value" fields with
+     | Error _ as error -> error
+     | Ok value -> Ok (Plan.Json_template.literal (json_of_toml value)))
+
+and parse_output_template ~path fields =
+  match validate_fields ~path ~allowed:[ "kind"; "node"; "pointer" ] fields with
+  | Error _ as error -> error
+  | Ok () ->
+    (match required_nonempty_string ~path "node" fields with
+     | Error _ as error -> error
+     | Ok raw_node ->
+       (match required_string ~path "pointer" fields with
+        | Error _ as error -> error
+        | Ok raw_pointer ->
+          (match node_id ~path:(path @ [ "node" ]) raw_node with
+           | Error _ as error -> error
+           | Ok node_id ->
+             (match pointer ~path:(path @ [ "pointer" ]) raw_pointer with
+              | Error _ as error -> error
+              | Ok pointer -> Ok (Plan.Json_template.output ~node_id ~pointer)))))
+
+and parse_object_template ~path fields =
+  match validate_fields ~path ~allowed:[ "kind"; "fields" ] fields with
+  | Error _ as error -> error
+  | Ok () ->
+    (match required_field ~path "fields" fields with
+     | Error _ as error -> error
+     | Ok raw_fields ->
+       (match array_values ~path ~field:"fields" raw_fields with
+        | Error _ as error -> error
+        | Ok raw_fields ->
+          let rec parse_fields index parsed = function
+            | [] ->
+              (match Plan.Json_template.object_ (List.rev parsed) with
+               | Ok template -> Ok template
+               | Error (Plan.Json_template.Duplicate_field field) ->
+                 Error (Duplicate_template_object_field { path; field }))
+            | raw_field :: rest ->
+              let field_path = path @ [ "fields"; string_of_int index ] in
+              (match table_fields ~path:field_path ~field:"field" raw_field with
+               | Error _ as error -> error
+               | Ok field_fields ->
+                 (match
+                    validate_fields
+                      ~path:field_path
+                      ~allowed:[ "name"; "value" ]
+                      field_fields
+                  with
+                  | Error _ as error -> error
+                  | Ok () ->
+                    (match required_nonempty_string ~path:field_path "name" field_fields with
+                     | Error _ as error -> error
+                     | Ok name ->
+                       (match required_field ~path:field_path "value" field_fields with
+                        | Error _ as error -> error
+                        | Ok value ->
+                          (match parse_template ~path:(field_path @ [ "value" ]) value with
+                           | Error _ as error -> error
+                           | Ok value ->
+                             parse_fields (index + 1) ((name, value) :: parsed) rest)))))
+          in
+          parse_fields 0 [] raw_fields))
+
+and parse_array_template ~path fields =
+  match validate_fields ~path ~allowed:[ "kind"; "items" ] fields with
+  | Error _ as error -> error
+  | Ok () ->
+    (match required_field ~path "items" fields with
+     | Error _ as error -> error
+     | Ok raw_items ->
+       (match array_values ~path ~field:"items" raw_items with
+        | Error _ as error -> error
+        | Ok raw_items ->
+          let rec parse_items index parsed = function
+            | [] -> Ok (Plan.Json_template.array (List.rev parsed))
+            | item :: rest ->
+              (match parse_template ~path:(path @ [ "items"; string_of_int index ]) item with
+               | Error _ as error -> error
+               | Ok item -> parse_items (index + 1) (item :: parsed) rest)
+          in
+          parse_items 0 [] raw_items))
+;;
+
+let parse_node ~path value =
+  match table_fields ~path ~field:"node" value with
+  | Error _ as error -> error
+  | Ok fields ->
+    (match validate_fields ~path ~allowed:[ "id"; "tool"; "after"; "input" ] fields with
+     | Error _ as error -> error
+     | Ok () ->
+       (match required_nonempty_string ~path "id" fields with
+        | Error _ as error -> error
+        | Ok raw_id ->
+          (match required_nonempty_string ~path "tool" fields with
+           | Error _ as error -> error
+           | Ok tool_name ->
+             (match
+                match List.assoc_opt "after" fields with
+                | None -> Ok []
+                | Some value -> string_array ~path ~field:"after" value
+              with
+              | Error _ as error -> error
+              | Ok raw_after ->
+                (match required_field ~path "input" fields with
+                 | Error _ as error -> error
+                 | Ok raw_input ->
+                   (match node_id ~path:(path @ [ "id" ]) raw_id with
+                    | Error _ as error -> error
+                    | Ok id ->
+                      let rec parse_after index parsed = function
+                        | [] -> Ok (List.rev parsed)
+                        | raw :: rest ->
+                          (match node_id ~path:(path @ [ "after"; string_of_int index ]) raw with
+                           | Error _ as error -> error
+                           | Ok id -> parse_after (index + 1) (id :: parsed) rest)
+                      in
+                      (match parse_after 0 [] raw_after with
+                       | Error _ as error -> error
+                       | Ok after ->
+                         (match parse_template ~path:(path @ [ "input" ]) raw_input with
+                          | Error _ as error -> error
+                          | Ok input -> Ok (Plan.node ~id ~tool_name ~after ~input ())))))))))
+;;
+
+let parse_composition ~index value =
+  let path = [ "compositions"; string_of_int index ] in
+  match table_fields ~path ~field:"composition" value with
+  | Error _ as error -> error
+  | Ok fields ->
+    (match validate_fields ~path ~allowed:[ "name"; "description"; "nodes" ] fields with
+     | Error _ as error -> error
+     | Ok () ->
+       (match required_nonempty_string ~path "name" fields with
+        | Error _ as error -> error
+        | Ok name ->
+          (match optional_string ~path "description" fields with
+           | Error _ as error -> error
+           | Ok description ->
+             (match required_field ~path "nodes" fields with
+              | Error _ as error -> error
+              | Ok raw_nodes ->
+                (match table_array ~path ~field:"nodes" raw_nodes with
+                 | Error _ as error -> error
+                 | Ok raw_nodes ->
+                   let rec parse_nodes index parsed = function
+                     | [] -> Ok (List.rev parsed)
+                     | node :: rest ->
+                       (match parse_node ~path:(path @ [ "nodes"; string_of_int index ]) node with
+                        | Error _ as error -> error
+                        | Ok node -> parse_nodes (index + 1) (node :: parsed) rest)
+                   in
+                   (match parse_nodes 0 [] raw_nodes with
+                    | Error _ as error -> error
+                    | Ok nodes ->
+                      (match
+                         Plan.create
+                           ~descriptors:(Keeper_tool_descriptor.all_descriptors ())
+                           nodes
+                       with
+                       | Ok plan -> Ok { name; description; plan }
+                       | Error error -> Error (Plan_rejected { name; error }))))))))
+;;
+
+let parse content =
+  match Toml.parse_toml content with
+  | Error message -> Error (Toml_syntax message)
+  | Ok fields ->
+    (match validate_fields ~path:[] ~allowed:[ "compositions" ] fields with
+     | Error _ as error -> error
+     | Ok () ->
+       (match required_field ~path:[] "compositions" fields with
+        | Error _ -> Error Empty_catalog
+        | Ok raw_compositions ->
+          (match table_array ~path:[] ~field:"compositions" raw_compositions with
+           | Error _ as error -> error
+           | Ok [] -> Error Empty_catalog
+           | Ok raw_compositions ->
+             let rec parse_entries index parsed = function
+               | [] -> Ok (List.rev parsed)
+               | composition :: rest ->
+                 (match parse_composition ~index composition with
+                  | Error _ as error -> error
+                  | Ok entry ->
+                    (match List.find_opt (fun current -> String.equal current.name entry.name) parsed with
+                     | Some _ -> Error (Duplicate_composition_name entry.name)
+                     | None -> parse_entries (index + 1) (entry :: parsed) rest))
+             in
+             parse_entries 0 [] raw_compositions)))
+;;

--- a/lib/keeper/keeper_tool_composition_catalog.mli
+++ b/lib/keeper/keeper_tool_composition_catalog.mli
@@ -1,0 +1,72 @@
+(** TOML-backed catalog of immutable Keeper tool-composition plans.
+
+    The document grammar is closed and explicit. Input templates use tagged
+    [literal], [output], [object], and [array] nodes; strings are never scanned
+    for placeholders or inferred as references. Plan creation resolves tool
+    authority only through the process-owned descriptor registry. *)
+
+type expected_value =
+  | String_value
+  | String_array_value
+  | Table_value
+  | Table_array_value
+  | Array_value
+
+type error =
+  | Toml_syntax of string
+  | Empty_catalog
+  | Unknown_field of
+      { path : string list
+      ; field : string
+      }
+  | Duplicate_field of
+      { path : string list
+      ; field : string
+      }
+  | Missing_field of
+      { path : string list
+      ; field : string
+      }
+  | Wrong_value_kind of
+      { path : string list
+      ; field : string
+      ; expected : expected_value
+      }
+  | Empty_name of { path : string list }
+  | Duplicate_composition_name of string
+  | Invalid_template_kind of
+      { path : string list
+      ; kind : string
+      }
+  | Invalid_node_id of
+      { path : string list
+      ; error : Keeper_tool_plan.Node_id.error
+      }
+  | Invalid_json_pointer of
+      { path : string list
+      ; error : Keeper_tool_plan.Json_pointer.syntax_error
+      }
+  | Duplicate_template_object_field of
+      { path : string list
+      ; field : string
+      }
+  | Plan_rejected of
+      { name : string
+      ; error : Keeper_tool_plan.error
+      }
+
+type entry = private
+  { name : string
+  ; description : string option
+  ; plan : Keeper_tool_plan.t
+  }
+
+type t
+
+val parse : string -> (t, error) result
+(** Parse one complete TOML document and validate every composition against the
+    current canonical Keeper descriptor registry. Unknown fields and malformed
+    tagged templates fail closed. *)
+
+val entries : t -> entry list
+val find : t -> string -> entry option

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1959,6 +1959,10 @@ let internal_descriptors : t list =
 
 let all_descriptors () = public_descriptors @ internal_descriptors
 
+let find_id id =
+  List.find_opt (fun descriptor -> String.equal descriptor.id id) (all_descriptors ())
+;;
+
 let model_schema_errors descriptor =
   match descriptor.input_schema_source, descriptor.input_schema with
   | (Descriptor_owned | Canonical_registry | Keeper_projection), `Assoc _ ->

--- a/lib/keeper/keeper_tool_descriptor.mli
+++ b/lib/keeper/keeper_tool_descriptor.mli
@@ -191,6 +191,12 @@ val public_descriptors : t list
     LLM-native vs workspace origin. *)
 val all_descriptors : unit -> t list
 
+(** Resolve the process-owned canonical descriptor for [id]. Callers that
+    accept descriptor records from another layer must resolve through this
+    function before treating execution, schema, or policy fields as runtime
+    authority. *)
+val find_id : string -> t option
+
 (** Objective schema-shape errors that prevent model projection. Empty means
     the descriptor has a resolved object schema whose structural fields are
     well-formed. *)

--- a/lib/keeper/keeper_tool_dispatch_runtime.ml
+++ b/lib/keeper/keeper_tool_dispatch_runtime.ml
@@ -88,6 +88,98 @@ let descriptor_route_invariant_error ~keeper_name ~tool_name descriptor =
 
 (* ── Tool execution dispatch ──────────────────────────────────── *)
 
+let runtime_context
+      ~config
+      ~meta
+      ~publication_recovery
+      ~ctx_work
+      ?turn_sandbox_factory
+      ?sw
+      ?clock
+      ?proc_mgr
+      ?net
+      ?mcp_session_id
+      ?continuation_channel
+      ?gate_context
+      ?gate_grant
+      ()
+  =
+  Keeper_tool_runtime.
+    { config
+    ; meta
+    ; publication_recovery
+    ; ctx_work
+    ; turn_sandbox_factory
+    ; sw
+    ; clock
+    ; proc_mgr
+    ; net
+    ; mcp_session_id
+    ; continuation_channel
+    ; gate_context
+    ; gate_grant
+    }
+;;
+
+let execute_keeper_tool_descriptor_with_outcome
+      ~(config : Workspace.config)
+      ~(meta : keeper_meta)
+      ~(publication_recovery :
+          Keeper_publication_recovery_availability.turn_context)
+      ~(ctx_work : working_context)
+      ?turn_sandbox_factory
+      ?sw
+      ?clock
+      ?proc_mgr
+      ?net
+      ?mcp_session_id
+      ?continuation_channel
+      ?gate_context
+      ?gate_grant
+      ~(descriptor : Keeper_tool_descriptor.t)
+      ~(input : Yojson.Safe.t)
+      ()
+  =
+  match Keeper_tool_descriptor.find_id descriptor.id with
+  | Some canonical when canonical == descriptor ->
+    let context =
+      runtime_context
+        ~config
+        ~meta
+        ~publication_recovery
+        ~ctx_work
+        ?turn_sandbox_factory
+        ?sw
+        ?clock
+        ?proc_mgr
+        ?net
+        ?mcp_session_id
+        ?continuation_channel
+        ?gate_context
+        ?gate_grant
+        ()
+    in
+    (match Keeper_tool_runtime.handle context ~descriptor ~args:input with
+     | Some execution -> execution
+     | None ->
+       descriptor_route_invariant_error
+         ~keeper_name:meta.name
+         ~tool_name:descriptor.internal_name
+         descriptor)
+  | Some _ | None ->
+    let data =
+      `Assoc
+        [ "ok", `Bool false
+        ; "error", `String "noncanonical_keeper_tool_descriptor"
+        ; "descriptor_id", `String descriptor.id
+        ]
+    in
+    Keeper_tool_execution.failure_data
+      ~class_:Tool_result.Runtime_failure
+      ~message:(Yojson.Safe.to_string data)
+      data
+;;
+
 let execute_keeper_tool_call_with_outcome
       ~(config : Workspace.config)
       ~(meta : keeper_meta)
@@ -112,24 +204,21 @@ let execute_keeper_tool_call_with_outcome
   =
   let args = input in
        let keeper_tool_runtime_context =
-         Keeper_tool_runtime.
-                       { config
-                       ; meta
-                       ; publication_recovery
-                       ; ctx_work
-                       ; turn_sandbox_factory
-           ; (* RFC-0182 Phase 5 PR-A.2: Eio resources threaded from
-                caller via labeled ? params.  Callers without Eio
-                context (AGENT_CORE handler, tests) leave them unset. *)
-             sw
-           ; clock
-           ; proc_mgr
-           ; net
-           ; mcp_session_id
-           ; continuation_channel
-           ; gate_context
-           ; gate_grant
-           }
+         runtime_context
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_work
+           ?turn_sandbox_factory
+           ?sw
+           ?clock
+           ?proc_mgr
+           ?net
+           ?mcp_session_id
+           ?continuation_channel
+           ?gate_context
+           ?gate_grant
+           ()
        in
        let descriptor_dispatch =
          match

--- a/lib/keeper/keeper_tool_dispatch_runtime.mli
+++ b/lib/keeper/keeper_tool_dispatch_runtime.mli
@@ -27,6 +27,30 @@ end
     outcome enum is introduced between Keeper execution and {!Tool_result}. *)
 type executed_tool_result = Keeper_tool_execution.t
 
+(** Execute the exact canonical descriptor already admitted by a typed caller.
+    Unlike name dispatch, this path never resolves a second descriptor and so
+    cannot drift from the schema, execution mode, policy, or handler authority
+    that the caller validated. *)
+val execute_keeper_tool_descriptor_with_outcome
+  :  config:Workspace.config
+  -> meta:keeper_meta
+  -> publication_recovery:
+       Keeper_publication_recovery_availability.turn_context
+  -> ctx_work:working_context
+  -> ?turn_sandbox_factory:Keeper_sandbox_factory.t
+  -> ?sw:Eio.Switch.t
+  -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t
+  -> ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> ?mcp_session_id:string
+  -> ?continuation_channel:Keeper_continuation_channel.t
+  -> ?gate_context:(unit -> Keeper_gate.causal_context)
+  -> ?gate_grant:Keeper_gate.cycle_grant
+  -> descriptor:Keeper_tool_descriptor.t
+  -> input:Yojson.Safe.t
+  -> unit
+  -> executed_tool_result
+
 val execute_keeper_tool_call_with_outcome
   :  config:Workspace.config
   -> meta:keeper_meta

--- a/lib/keeper/keeper_tool_plan.ml
+++ b/lib/keeper/keeper_tool_plan.ml
@@ -811,7 +811,6 @@ let validate_terminal_dependency_boundary descriptors nodes =
              (Terminal_node_missing_dependency
                 { terminal_node_id = terminal.id; node_id = node.id }))
       nodes
-  | _ -> assert false
 ;;
 
 let create ~descriptors nodes =
@@ -852,7 +851,7 @@ let create ~descriptors nodes =
                                  { identity = Atomic.fetch_and_add next_plan_identity 1
                                  ; nodes
                                  ; descriptors
-                                 }))))))))
+                                 })))))))))
 ;;
 
 let dependency_layers plan =

--- a/lib/keeper/keeper_tool_plan.ml
+++ b/lib/keeper/keeper_tool_plan.ml
@@ -559,6 +559,8 @@ and validate_schema_array ~path schema_fields value =
     Error (Type_mismatch { path; expected = Array_type; actual = json_type other })
 ;;
 
+let validate_composable_schema schema = validate_schema_contract ~path:[] schema
+
 type node =
   { id : Node_id.t
   ; tool_name : string
@@ -570,6 +572,7 @@ let node ~id ~tool_name ?(after = []) ~input () = { id; tool_name; input; after 
 
 type error =
   | Empty_plan
+  | Unknown_descriptor_id of string
   | Duplicate_node_id of Node_id.t
   | Duplicate_tool_name of string
   | Unknown_tool of
@@ -595,6 +598,11 @@ type error =
       { node_id : Node_id.t
       ; tool_name : string
       ; error : schema_contract_error
+      }
+  | Multiple_terminal_nodes of Node_id.t list
+  | Terminal_node_missing_dependency of
+      { terminal_node_id : Node_id.t
+      ; node_id : Node_id.t
       }
   | Dependency_cycle of Node_id.t list
 
@@ -626,6 +634,17 @@ let descriptor_entries descriptors =
        Keeper_tool_descriptor.keeper_model_names descriptor
        |> List.map (fun name -> name, descriptor))
     descriptors
+;;
+
+let canonicalize_descriptors descriptors =
+  let rec canonicalize resolved = function
+    | [] -> Ok (List.rev resolved)
+    | descriptor :: rest ->
+      (match Keeper_tool_descriptor.find_id descriptor.Keeper_tool_descriptor.id with
+       | None -> Error (Unknown_descriptor_id descriptor.id)
+       | Some canonical -> canonicalize (canonical :: resolved) rest)
+  in
+  canonicalize [] descriptors
 ;;
 
 let first_duplicate equal values =
@@ -709,7 +728,7 @@ let validate_output_schemas descriptors nodes =
          (match descriptor.Keeper_tool_descriptor.composable_output with
           | Keeper_tool_descriptor.Opaque_output -> None
           | Keeper_tool_descriptor.Json_output { schema } ->
-            (match validate_schema_contract ~path:[] schema with
+            (match validate_composable_schema schema with
              | Ok () -> None
              | Error error ->
                Some
@@ -752,37 +771,88 @@ let dependency_cycle nodes =
   visit_all [] nodes
 ;;
 
+let validate_terminal_dependency_boundary descriptors nodes =
+  let terminal_nodes =
+    List.filter
+      (fun node ->
+         match descriptor_for_name descriptors node.tool_name with
+         | Some { Keeper_tool_descriptor.execution = Keeper_tool_descriptor.Terminal; _ } ->
+           true
+         | Some
+             { execution =
+                 Keeper_tool_descriptor.Ordinary
+                   (Keeper_tool_descriptor.Serial | Keeper_tool_descriptor.Concurrent)
+             ; _
+             }
+         | None -> false)
+      nodes
+  in
+  match terminal_nodes with
+  | [] -> None
+  | _ :: _ :: _ -> Some (Multiple_terminal_nodes (List.map (fun node -> node.id) terminal_nodes))
+  | [ terminal ] ->
+    let rec ancestors visited node_id =
+      if List.exists (Node_id.equal node_id) visited
+      then visited
+      else
+        match node_for_id nodes node_id with
+        | None -> visited
+        | Some node ->
+          List.fold_left ancestors (node_id :: visited) (dependencies node)
+    in
+    let terminal_ancestors = ancestors [] terminal.id in
+    List.find_map
+      (fun node ->
+         if Node_id.equal node.id terminal.id
+            || List.exists (Node_id.equal node.id) terminal_ancestors
+         then None
+         else
+           Some
+             (Terminal_node_missing_dependency
+                { terminal_node_id = terminal.id; node_id = node.id }))
+      nodes
+  | _ -> assert false
+;;
+
 let create ~descriptors nodes =
   match nodes with
   | [] -> Error Empty_plan
   | _ ->
-    (match first_duplicate Node_id.equal (List.map (fun node -> node.id) nodes) with
-     | Some id -> Error (Duplicate_node_id id)
-     | None ->
-       let descriptors = descriptor_entries descriptors in
-       (match first_duplicate String.equal (List.map fst descriptors) with
-        | Some name -> Error (Duplicate_tool_name name)
+    (match canonicalize_descriptors descriptors with
+     | Error _ as error -> error
+     | Ok canonical_descriptors ->
+       (match first_duplicate Node_id.equal (List.map (fun node -> node.id) nodes) with
+        | Some id -> Error (Duplicate_node_id id)
         | None ->
-          (match validate_known_tools descriptors nodes with
-           | Some error -> Error error
+          let descriptors = descriptor_entries canonical_descriptors in
+          (match first_duplicate String.equal (List.map fst descriptors) with
+           | Some name -> Error (Duplicate_tool_name name)
            | None ->
-             (match validate_output_schemas descriptors nodes with
+             (match validate_known_tools descriptors nodes with
               | Some error -> Error error
               | None ->
-                (match validate_dependencies nodes with
+                (match validate_output_schemas descriptors nodes with
                  | Some error -> Error error
                  | None ->
-                   (match validate_output_references descriptors nodes with
+                   (match validate_dependencies nodes with
                     | Some error -> Error error
                     | None ->
-                      (match dependency_cycle nodes with
-                       | Some cycle -> Error (Dependency_cycle cycle)
+                      (match validate_output_references descriptors nodes with
+                       | Some error -> Error error
                        | None ->
-                         Ok
-                           { identity = Atomic.fetch_and_add next_plan_identity 1
-                           ; nodes
-                           ; descriptors
-                           })))))))
+                         (match dependency_cycle nodes with
+                          | Some cycle -> Error (Dependency_cycle cycle)
+                          | None ->
+                            (match
+                               validate_terminal_dependency_boundary descriptors nodes
+                             with
+                             | Some error -> Error error
+                             | None ->
+                               Ok
+                                 { identity = Atomic.fetch_and_add next_plan_identity 1
+                                 ; nodes
+                                 ; descriptors
+                                 }))))))))
 ;;
 
 let dependency_layers plan =

--- a/lib/keeper/keeper_tool_plan.mli
+++ b/lib/keeper/keeper_tool_plan.mli
@@ -149,6 +149,13 @@ type schema_contract_error =
       ; field : string
       }
 
+(** Validate the closed schema language used by composable declared outputs.
+    This pure entry point is also used by configuration readers before they
+    construct any runtime plan. *)
+val validate_composable_schema
+  :  Yojson.Safe.t
+  -> (unit, schema_contract_error) result
+
 type node = private
   { id : Node_id.t
   ; tool_name : string
@@ -166,6 +173,7 @@ val node
 
 type error =
   | Empty_plan
+  | Unknown_descriptor_id of string
   | Duplicate_node_id of Node_id.t
   | Duplicate_tool_name of string
   | Unknown_tool of
@@ -191,6 +199,11 @@ type error =
       { node_id : Node_id.t
       ; tool_name : string
       ; error : schema_contract_error
+      }
+  | Multiple_terminal_nodes of Node_id.t list
+  | Terminal_node_missing_dependency of
+      { terminal_node_id : Node_id.t
+      ; node_id : Node_id.t
       }
   | Dependency_cycle of Node_id.t list
 

--- a/lib/keeper/keeper_tool_plan_executor.ml
+++ b/lib/keeper/keeper_tool_plan_executor.ml
@@ -1,0 +1,356 @@
+type scheduled_node =
+  { node : Keeper_tool_plan.node
+  ; descriptor : Keeper_tool_descriptor.t
+  ; schedule : Agent_core.Tool_contract.schedule
+  }
+
+type batch =
+  | Serial_batch of scheduled_node
+  | Concurrent_batch of scheduled_node list
+
+type unscheduled_batch =
+  | Unscheduled_serial of Keeper_tool_plan.node * Keeper_tool_descriptor.t
+  | Unscheduled_concurrent of (Keeper_tool_plan.node * Keeper_tool_descriptor.t) list
+
+let execution_mode_of_descriptor descriptor =
+  match descriptor.Keeper_tool_descriptor.execution with
+  | Keeper_tool_descriptor.Ordinary Keeper_tool_descriptor.Concurrent ->
+    Agent_core.Tool_contract.Concurrent
+  | Keeper_tool_descriptor.Ordinary Keeper_tool_descriptor.Serial
+  | Keeper_tool_descriptor.Terminal -> Agent_core.Tool_contract.Serial
+;;
+
+let descriptor_exn plan node =
+  match Keeper_tool_plan.descriptor plan node.Keeper_tool_plan.id with
+  | Some descriptor -> descriptor
+  | None ->
+    invalid_arg
+      (Printf.sprintf
+         "validated composition plan lost descriptor for node %s"
+         (Keeper_tool_plan.Node_id.to_string node.id))
+;;
+
+let unscheduled_layer plan nodes =
+  let flush_concurrent batches = function
+    | [] -> batches
+    | concurrent -> Unscheduled_concurrent (List.rev concurrent) :: batches
+  in
+  let rec build batches concurrent = function
+    | [] -> List.rev (flush_concurrent batches concurrent)
+    | node :: rest ->
+      let descriptor = descriptor_exn plan node in
+      (match descriptor.Keeper_tool_descriptor.execution with
+       | Keeper_tool_descriptor.Ordinary Keeper_tool_descriptor.Concurrent ->
+         build batches ((node, descriptor) :: concurrent) rest
+       | Keeper_tool_descriptor.Ordinary Keeper_tool_descriptor.Serial
+       | Keeper_tool_descriptor.Terminal ->
+         let batches = flush_concurrent batches concurrent in
+         build (Unscheduled_serial (node, descriptor) :: batches) [] rest)
+  in
+  build [] [] nodes
+;;
+
+let schedule plan =
+  let planned_indexes =
+    Keeper_tool_plan.nodes plan
+    |> List.mapi (fun index node -> node.Keeper_tool_plan.id, index)
+  in
+  let planned_index node =
+    match
+      List.find_opt
+        (fun (id, _) -> Keeper_tool_plan.Node_id.equal id node.Keeper_tool_plan.id)
+        planned_indexes
+    with
+    | Some (_, index) -> index
+    | None -> invalid_arg "validated composition plan lost a canonical node"
+  in
+  Keeper_tool_plan.dependency_layers plan
+  |> List.concat_map (unscheduled_layer plan)
+  |> List.mapi (fun batch_index batch ->
+    let scheduled_node ~batch_size (node, descriptor) =
+      { node
+      ; descriptor
+      ; schedule =
+          { Agent_core.Tool_contract.planned_index = planned_index node
+          ; batch_index
+          ; batch_size
+          ; execution_mode = execution_mode_of_descriptor descriptor
+          }
+      }
+    in
+    match batch with
+    | Unscheduled_serial node -> Serial_batch (scheduled_node ~batch_size:1 node)
+    | Unscheduled_concurrent nodes ->
+      let batch_size = List.length nodes in
+      Concurrent_batch (List.map (scheduled_node ~batch_size) nodes))
+;;
+
+let outer_completion plan =
+  if
+    List.exists
+      (fun node ->
+         match Keeper_tool_plan.descriptor plan node.Keeper_tool_plan.id with
+         | Some { Keeper_tool_descriptor.execution = Keeper_tool_descriptor.Terminal; _ } ->
+           true
+         | Some
+             { execution =
+                 Keeper_tool_descriptor.Ordinary
+                   (Keeper_tool_descriptor.Serial | Keeper_tool_descriptor.Concurrent)
+             ; _
+             }
+         | None -> false)
+      (Keeper_tool_plan.nodes plan)
+  then
+    Agent_core.Tool_contract.Terminal_after_success
+      Agent_core.Tool_contract.Effect_outcome_unknown
+  else Agent_core.Tool_contract.Continue_after_success
+;;
+
+type node_result =
+  { node_id : Keeper_tool_plan.Node_id.t
+  ; tool_name : string
+  ; input : Yojson.Safe.t
+  ; schedule : Agent_core.Tool_contract.schedule
+  ; result : Tool_result.result
+  }
+
+type cause =
+  | Plan_execution_failed of
+      { node_id : Keeper_tool_plan.Node_id.t
+      ; schedule : Agent_core.Tool_contract.schedule
+      ; error : Keeper_tool_plan.execution_error
+      }
+  | Tool_did_not_complete of node_result
+  | Outer_completion_mismatch of
+      { expected : Agent_core.Tool_contract.completion
+      ; actual : Agent_core.Tool_contract.completion
+      }
+
+type failure =
+  { settled : node_result list
+  ; cause : cause
+  }
+
+type dispatch =
+  node:Keeper_tool_plan.node
+  -> descriptor:Keeper_tool_descriptor.t
+  -> schedule:Agent_core.Tool_contract.schedule
+  -> input:Yojson.Safe.t
+  -> Tool_result.result
+
+type node_settlement =
+  { result : node_result option
+  ; output : Keeper_tool_plan.output option
+  ; cause : cause option
+  }
+
+let execute_one ~plan ~run_id ~outputs ~dispatch scheduled =
+  let node = scheduled.node in
+  let node_id = node.Keeper_tool_plan.id in
+  let plan_failure error =
+    { result = None
+    ; output = None
+    ; cause = Some (Plan_execution_failed { node_id; schedule = scheduled.schedule; error })
+    }
+  in
+  match
+    Keeper_tool_plan.resolve_input
+      plan
+      ~run_id
+      ~node_id
+      ~lookup:(fun dependency ->
+        List.find_map
+          (fun (id, output) ->
+             if Keeper_tool_plan.Node_id.equal id dependency then Some output else None)
+          outputs)
+  with
+  | Error error -> plan_failure error
+  | Ok input ->
+    let start_time = Time_compat.now () in
+    let result =
+      Cancel_safe.protect
+        ~on_exn:(fun exn ->
+          Tool_result.make_err_of_exn
+            ~class_:Tool_result.Runtime_failure
+            ~tool_name:node.tool_name
+            ~start_time
+            exn)
+        (fun () ->
+           dispatch
+             ~node
+             ~descriptor:scheduled.descriptor
+             ~schedule:scheduled.schedule
+             ~input)
+    in
+    let node_result =
+      { node_id
+      ; tool_name = node.tool_name
+      ; input
+      ; schedule = scheduled.schedule
+      ; result
+      }
+    in
+    (match result with
+     | Tool_result.Deferred _ | Tool_result.Failed _ ->
+       { result = Some node_result
+       ; output = None
+       ; cause = Some (Tool_did_not_complete node_result)
+       }
+     | Tool_result.Completed _ ->
+       (match scheduled.descriptor.Keeper_tool_descriptor.composable_output with
+        | Keeper_tool_descriptor.Opaque_output ->
+          { result = Some node_result; output = None; cause = None }
+        | Keeper_tool_descriptor.Json_output _ ->
+          (match
+             Keeper_tool_plan.validate_output
+               plan
+               ~run_id
+               ~node_id
+               (Tool_result.data result)
+           with
+           | Ok output ->
+             { result = Some node_result; output = Some output; cause = None }
+           | Error error ->
+             { result = Some node_result
+             ; output = None
+             ; cause =
+                 Some
+                   (Plan_execution_failed
+                      { node_id; schedule = scheduled.schedule; error })
+             })))
+;;
+
+let execute ~plan ~run_id ~dispatch () =
+  let rec run_batches settled outputs = function
+    | [] -> Ok settled
+    | batch :: rest ->
+      let execute scheduled = execute_one ~plan ~run_id ~outputs ~dispatch scheduled in
+      let settlements =
+        match batch with
+        | Serial_batch scheduled -> [ execute scheduled ]
+        | Concurrent_batch scheduled -> Eio.Fiber.List.map execute scheduled
+      in
+      let batch_results = List.filter_map (fun settlement -> settlement.result) settlements in
+      let settled = settled @ batch_results in
+      (match List.find_map (fun settlement -> settlement.cause) settlements with
+       | Some cause -> Error { settled; cause }
+       | None ->
+         let outputs =
+           List.fold_left
+             (fun outputs settlement ->
+                match settlement.output with
+                | None -> outputs
+                | Some output ->
+                  (Keeper_tool_plan.output_node_id output, output) :: outputs)
+             outputs
+             settlements
+         in
+         run_batches settled outputs rest)
+  in
+  run_batches [] [] (schedule plan)
+;;
+
+let nested_tool_use_id parent_invocation node_id =
+  let parent = Agent_core.Tool_contract.Invocation.tool_use_id parent_invocation in
+  let node = Keeper_tool_plan.Node_id.to_string node_id in
+  Printf.sprintf "composition:%d:%s:%d:%s" (String.length parent) parent (String.length node) node
+;;
+
+let equal_failure_effect left right =
+  match left, right with
+  | Agent_core.Tool_contract.Proven_pre_effect, Agent_core.Tool_contract.Proven_pre_effect
+  | Agent_core.Tool_contract.Proven_post_effect, Agent_core.Tool_contract.Proven_post_effect
+  | Agent_core.Tool_contract.Effect_outcome_unknown, Agent_core.Tool_contract.Effect_outcome_unknown -> true
+  | ( Agent_core.Tool_contract.Proven_pre_effect
+    | Agent_core.Tool_contract.Proven_post_effect
+    | Agent_core.Tool_contract.Effect_outcome_unknown )
+  , ( Agent_core.Tool_contract.Proven_pre_effect
+    | Agent_core.Tool_contract.Proven_post_effect
+    | Agent_core.Tool_contract.Effect_outcome_unknown ) -> false
+;;
+
+let equal_completion left right =
+  match left, right with
+  | Agent_core.Tool_contract.Continue_after_success, Agent_core.Tool_contract.Continue_after_success -> true
+  | Agent_core.Tool_contract.Terminal_after_success left,
+    Agent_core.Tool_contract.Terminal_after_success right ->
+    equal_failure_effect left right
+  | Agent_core.Tool_contract.Continue_after_success,
+    Agent_core.Tool_contract.Terminal_after_success _
+  | Agent_core.Tool_contract.Terminal_after_success _,
+    Agent_core.Tool_contract.Continue_after_success -> false
+;;
+
+let execute_keeper
+      ~plan
+      ~run_id
+      ~parent_invocation
+      ~config
+      ~meta
+      ~publication_recovery
+      ~ctx_snapshot
+      ?turn_sandbox_factory
+      ?clock
+      ?continuation_channel
+      ?gate_context
+      ?gate_grant
+      ?record_gate_result
+      ?on_completed
+      ?on_deferred
+      ?on_external_effect_deferred
+      ?on_failed
+      ()
+  =
+  let expected_completion = outer_completion plan in
+  let actual_completion =
+    Agent_core.Tool_contract.Invocation.completion parent_invocation
+  in
+  if not (equal_completion expected_completion actual_completion)
+  then
+    Error
+      { settled = []
+      ; cause =
+          Outer_completion_mismatch
+            { expected = expected_completion; actual = actual_completion }
+      }
+  else
+  let dispatch ~node ~descriptor ~schedule ~input =
+    let terminal_on_completed, terminal_on_failed =
+      match descriptor.Keeper_tool_descriptor.execution with
+      | Keeper_tool_descriptor.Terminal -> on_completed, on_failed
+      | Keeper_tool_descriptor.Ordinary
+          (Keeper_tool_descriptor.Serial | Keeper_tool_descriptor.Concurrent) -> None, None
+    in
+    let handler =
+      Keeper_tools_agent_core_handler.make_keeper_tool_handler
+        ~name:descriptor.internal_name
+        ~descriptor
+        ~model_name:node.tool_name
+        ~input_schema:descriptor.input_schema
+        ~config
+        ~meta
+        ~publication_recovery
+        ~ctx_snapshot
+        ?turn_sandbox_factory
+        ?clock
+        ?continuation_channel
+        ?gate_context
+        ?gate_grant
+        ?record_gate_result
+        ?on_completed:terminal_on_completed
+        ?on_deferred
+        ?on_external_effect_deferred
+        ?on_failed:terminal_on_failed
+        ()
+    in
+    let invocation =
+      Agent_core.Tool_contract.Invocation.create
+        ~tool_use_id:(nested_tool_use_id parent_invocation node.id)
+        ~turn:(Agent_core.Tool_contract.Invocation.turn parent_invocation)
+        ~schedule
+        ~completion:Agent_core.Tool_contract.Continue_after_success
+    in
+    handler ~agent_core_invocation:invocation input
+  in
+  execute ~plan ~run_id ~dispatch ()
+;;

--- a/lib/keeper/keeper_tool_plan_executor.ml
+++ b/lib/keeper/keeper_tool_plan_executor.ml
@@ -79,7 +79,8 @@ let schedule plan =
       }
     in
     match batch with
-    | Unscheduled_serial node -> Serial_batch (scheduled_node ~batch_size:1 node)
+    | Unscheduled_serial (node, descriptor) ->
+      Serial_batch (scheduled_node ~batch_size:1 (node, descriptor))
     | Unscheduled_concurrent nodes ->
       let batch_size = List.length nodes in
       Concurrent_batch (List.map (scheduled_node ~batch_size) nodes))
@@ -314,7 +315,7 @@ let execute_keeper
             { expected = expected_completion; actual = actual_completion }
       }
   else
-  let dispatch ~node ~descriptor ~schedule ~input =
+  let dispatch ~(node : Keeper_tool_plan.node) ~descriptor ~schedule ~input =
     let terminal_on_completed, terminal_on_failed =
       match descriptor.Keeper_tool_descriptor.execution with
       | Keeper_tool_descriptor.Terminal -> on_completed, on_failed

--- a/lib/keeper/keeper_tool_plan_executor.mli
+++ b/lib/keeper/keeper_tool_plan_executor.mli
@@ -59,7 +59,9 @@ type dispatch =
 (** Execute dependency batches to completion. Concurrent siblings are all
     settled before the lowest-planned-index cause is selected. A [Deferred]
     or [Failed] tool result is carried unchanged in [Tool_did_not_complete];
-    no text or payload inference is performed. *)
+    no text or payload inference is performed. A deferred node produces no
+    composable output, so it cannot satisfy a downstream output reference and
+    terminates the plan instead of being resumed as a producer. *)
 val execute
   :  plan:Keeper_tool_plan.t
   -> run_id:Keeper_tool_plan.Run_id.t

--- a/lib/keeper/keeper_tool_plan_executor.mli
+++ b/lib/keeper/keeper_tool_plan_executor.mli
@@ -1,0 +1,93 @@
+(** Descriptor-aware execution of a validated Keeper tool-composition plan.
+
+    The executor schedules only explicit dependency layers. Descriptor
+    [Serial], [Concurrent], and [Terminal] values determine execution batches;
+    display groups and tool names never do. Every node result retains the
+    canonical {!Tool_result.disposition}. *)
+
+type scheduled_node = private
+  { node : Keeper_tool_plan.node
+  ; descriptor : Keeper_tool_descriptor.t
+  ; schedule : Agent_core.Tool_contract.schedule
+  }
+
+type batch = private
+  | Serial_batch of scheduled_node
+  | Concurrent_batch of scheduled_node list
+
+(** Exact immutable schedule derived from dependency edges and descriptor
+    execution declarations. *)
+val schedule : Keeper_tool_plan.t -> batch list
+
+(** Completion declaration for the outer composite tool. Nested actions always
+    continue into executor settlement; a final terminal descriptor makes the
+    single outer composite invocation terminal. *)
+val outer_completion : Keeper_tool_plan.t -> Agent_core.Tool_contract.completion
+
+type node_result = private
+  { node_id : Keeper_tool_plan.Node_id.t
+  ; tool_name : string
+  ; input : Yojson.Safe.t
+  ; schedule : Agent_core.Tool_contract.schedule
+  ; result : Tool_result.result
+  }
+
+type cause =
+  | Plan_execution_failed of
+      { node_id : Keeper_tool_plan.Node_id.t
+      ; schedule : Agent_core.Tool_contract.schedule
+      ; error : Keeper_tool_plan.execution_error
+      }
+  | Tool_did_not_complete of node_result
+  | Outer_completion_mismatch of
+      { expected : Agent_core.Tool_contract.completion
+      ; actual : Agent_core.Tool_contract.completion
+      }
+
+type failure = private
+  { settled : node_result list
+  ; cause : cause
+  }
+
+type dispatch =
+  node:Keeper_tool_plan.node
+  -> descriptor:Keeper_tool_descriptor.t
+  -> schedule:Agent_core.Tool_contract.schedule
+  -> input:Yojson.Safe.t
+  -> Tool_result.result
+
+(** Execute dependency batches to completion. Concurrent siblings are all
+    settled before the lowest-planned-index cause is selected. A [Deferred]
+    or [Failed] tool result is carried unchanged in [Tool_did_not_complete];
+    no text or payload inference is performed. *)
+val execute
+  :  plan:Keeper_tool_plan.t
+  -> run_id:Keeper_tool_plan.Run_id.t
+  -> dispatch:dispatch
+  -> unit
+  -> (node_result list, failure) result
+
+(** Runtime adapter through the ordinary Keeper Agent-Core handler. This keeps
+    descriptor input translation, Gate, Shell IR routing, tool-call telemetry,
+    and per-action I/O previews on the same boundary as a direct Keeper call. *)
+val execute_keeper
+  :  plan:Keeper_tool_plan.t
+  -> run_id:Keeper_tool_plan.Run_id.t
+  -> parent_invocation:Agent_core.Tool_contract.Invocation.t
+  -> config:Workspace.config
+  -> meta:Keeper_meta_contract.keeper_meta
+  -> publication_recovery:Keeper_publication_recovery_availability.turn_context
+  -> ctx_snapshot:Keeper_types.working_context
+  -> ?turn_sandbox_factory:Keeper_sandbox_factory.t
+  -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?continuation_channel:Keeper_continuation_channel.t
+  -> ?gate_context:(unit -> Keeper_gate.causal_context)
+  -> ?gate_grant:Keeper_gate.cycle_grant
+  -> ?record_gate_result:
+       (operation:string -> input:Yojson.Safe.t -> Tool_result.result -> unit)
+  -> ?on_completed:(Keeper_tool_execution.terminal_effect_receipt option -> unit)
+  -> ?on_deferred:(unit -> unit)
+  -> ?on_external_effect_deferred:(unit -> unit)
+  -> ?on_failed:(Keeper_tools_agent_core.terminal_effect_failure -> unit)
+  -> unit
+  -> (node_result list, failure) result

--- a/lib/keeper/keeper_tools_agent_core_handler.ml
+++ b/lib/keeper/keeper_tools_agent_core_handler.ml
@@ -10,6 +10,8 @@ open Keeper_tools_agent_core_handler_telemetry
 
 let make_keeper_tool_handler
       ~(name : string)
+      ?descriptor
+      ?model_name
       ~(input_schema : Yojson.Safe.t)
       ~(config : Workspace.config)
       ~(meta : Keeper_meta_contract.keeper_meta)
@@ -26,15 +28,44 @@ let make_keeper_tool_handler
       ?on_deferred
       ?on_external_effect_deferred
       ?on_failed
-      ?(prepare_input = fun input ->
+      ?prepare_input
+      ()
+  : ?agent_core_invocation:Agent_core.Tool_contract.Invocation.t -> Yojson.Safe.t -> Tool_result.result
+  =
+  let input_schema =
+    match descriptor with
+    | None -> input_schema
+    | Some supplied ->
+      (match Keeper_tool_descriptor.find_id supplied.Keeper_tool_descriptor.id with
+       | Some canonical
+         when canonical == supplied
+              && String.equal name canonical.Keeper_tool_descriptor.internal_name ->
+         canonical.input_schema
+       | Some _ | None ->
+         invalid_arg
+           "make_keeper_tool_handler: exact descriptor dispatch requires process-owned canonical authority")
+  in
+  let prepare_input =
+    match descriptor, model_name, prepare_input with
+    | Some canonical, Some model_name, _ ->
+      Keeper_tool_descriptor_resolution.prepare_model_input_for_descriptor
+        ~tool_name:model_name
+        canonical
+    | Some _, None, _ ->
+      invalid_arg
+        "make_keeper_tool_handler: exact descriptor dispatch requires its model-visible name"
+    | None, Some _, _ ->
+      invalid_arg
+        "make_keeper_tool_handler: model-visible name requires exact descriptor authority"
+    | None, None, Some prepare -> prepare
+    | None, None, None ->
+      fun input ->
         Tool_input_validation.validate_args
           ~schema:input_schema
           ~name
           ~args:input
-          ())
-      ()
-  : ?agent_core_invocation:Agent_core.Tool_contract.Invocation.t -> Yojson.Safe.t -> Tool_result.result
-  =
+          ()
+  in
   let record_result ~input result =
     Option.iter
       (fun record -> record ~operation:name ~input result)
@@ -159,6 +190,7 @@ let make_keeper_tool_handler
             let execution =
               Keeper_tools_agent_core_handler_exec.execute_with_observers
                 ~name
+                ?descriptor
                 ~config
                 ~meta
                 ~publication_recovery

--- a/lib/keeper/keeper_tools_agent_core_handler.ml
+++ b/lib/keeper/keeper_tools_agent_core_handler.ml
@@ -48,9 +48,11 @@ let make_keeper_tool_handler
   let prepare_input =
     match descriptor, model_name, prepare_input with
     | Some canonical, Some model_name, _ ->
-      Keeper_tool_descriptor_resolution.prepare_model_input_for_descriptor
-        ~tool_name:model_name
-        canonical
+      fun input ->
+        Keeper_tool_descriptor_resolution.prepare_model_input_for_descriptor
+          ~tool_name:model_name
+          canonical
+          ~input
     | Some _, None, _ ->
       invalid_arg
         "make_keeper_tool_handler: exact descriptor dispatch requires its model-visible name"

--- a/lib/keeper/keeper_tools_agent_core_handler.mli
+++ b/lib/keeper/keeper_tools_agent_core_handler.mli
@@ -16,6 +16,8 @@
     descriptor's typed policy before dispatch. *)
 val make_keeper_tool_handler
   :  name:string
+  -> ?descriptor:Keeper_tool_descriptor.t
+  -> ?model_name:string
   -> input_schema:Yojson.Safe.t
   -> config:Workspace.config
   -> meta:Keeper_meta_contract.keeper_meta

--- a/lib/keeper/keeper_tools_agent_core_handler_exec.ml
+++ b/lib/keeper/keeper_tools_agent_core_handler_exec.ml
@@ -17,6 +17,7 @@ let producer_payload ~raw = function
 
 let execute_with_observers
       ~(name : string)
+      ?descriptor
       ~(config : Workspace.config)
       ~(meta : Keeper_meta_contract.keeper_meta)
       ~(publication_recovery :
@@ -50,23 +51,43 @@ let execute_with_observers
   try
     let result, duration_ms =
       Inference_utils.timed (fun () ->
-        Keeper_tool_dispatch_runtime.execute_keeper_tool_call_with_outcome
-          ~config
-          ~meta
-          ~publication_recovery
-          ~ctx_work:ctx_snapshot
-          ?turn_sandbox_factory
-          ?sw
-          ?clock
-          ?proc_mgr
-          ?net
-          ?mcp_session_id
-          ?continuation_channel
-          ?gate_context
-          ?gate_grant
-          ~name
-          ~input
-          ())
+        match descriptor with
+        | None ->
+          Keeper_tool_dispatch_runtime.execute_keeper_tool_call_with_outcome
+            ~config
+            ~meta
+            ~publication_recovery
+            ~ctx_work:ctx_snapshot
+            ?turn_sandbox_factory
+            ?sw
+            ?clock
+            ?proc_mgr
+            ?net
+            ?mcp_session_id
+            ?continuation_channel
+            ?gate_context
+            ?gate_grant
+            ~name
+            ~input
+            ()
+        | Some descriptor ->
+          Keeper_tool_dispatch_runtime.execute_keeper_tool_descriptor_with_outcome
+            ~config
+            ~meta
+            ~publication_recovery
+            ~ctx_work:ctx_snapshot
+            ?turn_sandbox_factory
+            ?sw
+            ?clock
+            ?proc_mgr
+            ?net
+            ?mcp_session_id
+            ?continuation_channel
+            ?gate_context
+            ?gate_grant
+            ~descriptor
+            ~input
+            ())
     in
     let raw_result = result.Keeper_tool_execution.raw_output in
     let producer_data = result.data in

--- a/lib/keeper/keeper_tools_agent_core_handler_exec.mli
+++ b/lib/keeper/keeper_tools_agent_core_handler_exec.mli
@@ -15,6 +15,7 @@ type execution_result =
     [make_keeper_tool_handler] closure are passed explicitly. *)
 val execute_with_observers
   :  name:string
+  -> ?descriptor:Keeper_tool_descriptor.t
   -> config:Workspace.config
   -> meta:Keeper_meta_contract.keeper_meta
   -> publication_recovery:

--- a/test/dune
+++ b/test/dune
@@ -283,6 +283,7 @@
   test_keeper_tool_call_sse_io_preview
   test_keeper_tool_descriptor_registry_integrity
   test_keeper_tool_plan
+  test_keeper_tool_composition_catalog
   test_voice_command_descriptor_parity
   test_disk_hygiene_script
   test_run_local_script
@@ -584,6 +585,7 @@
   test_keeper_tool_call_sse_io_preview
   test_keeper_tool_descriptor_registry_integrity
   test_keeper_tool_plan
+  test_keeper_tool_composition_catalog
   test_voice_command_descriptor_parity
   test_disk_hygiene_script
   test_run_local_script

--- a/test/dune
+++ b/test/dune
@@ -1827,6 +1827,8 @@
 
 (include stanzas/test_keeper_tool_dispatch_runtime.inc)
 
+(include stanzas/test_keeper_tool_plan_executor.inc)
+
 (include stanzas/test_keeper_fs.inc)
 
 (include stanzas/test_keeper_fs_edit_containment.inc)

--- a/test/stanzas/test_keeper_tool_plan_executor.inc
+++ b/test/stanzas/test_keeper_tool_plan_executor.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_tool_plan_executor)
+ (modules test_keeper_tool_plan_executor)
+ (libraries masc_test_deps))

--- a/test/test_keeper_tool_composition_catalog.ml
+++ b/test/test_keeper_tool_composition_catalog.ml
@@ -1,0 +1,200 @@
+open Alcotest
+
+module Catalog = Masc.Keeper_tool_composition_catalog
+module Plan = Masc.Keeper_tool_plan
+
+let valid_catalog =
+  {|[[compositions]]
+name = "time-memory-query"
+description = "Feed the exact clock result into memory search."
+
+[[compositions.nodes]]
+id = "time"
+tool = "keeper_time_now"
+[compositions.nodes.input]
+kind = "literal"
+value = {}
+
+[[compositions.nodes]]
+id = "search"
+tool = "keeper_memory_search"
+after = ["time"]
+[compositions.nodes.input]
+kind = "object"
+[[compositions.nodes.input.fields]]
+name = "query"
+[compositions.nodes.input.fields.value]
+kind = "output"
+node = "time"
+pointer = "/now_iso"
+|}
+;;
+
+let node_id value =
+  match Plan.Node_id.make value with
+  | Ok id -> id
+  | Error Plan.Node_id.Empty -> fail "unexpected empty node id"
+;;
+
+let test_catalog_builds_executable_typed_plan () =
+  let catalog =
+    match Catalog.parse valid_catalog with
+    | Ok catalog -> catalog
+    | Error _ -> fail "valid composition catalog was rejected"
+  in
+  check int "one catalog entry" 1 (List.length (Catalog.entries catalog));
+  let entry =
+    match Catalog.find catalog "time-memory-query" with
+    | Some entry -> entry
+    | None -> fail "composition lookup missed exact name"
+  in
+  check
+    (option string)
+    "description"
+    (Some "Feed the exact clock result into memory search.")
+    entry.description;
+  let layers = Plan.dependency_layers entry.plan in
+  check
+    (list (list string))
+    "typed dependency layers"
+    [ [ "time" ]; [ "search" ] ]
+    (List.map
+       (List.map (fun node -> Plan.Node_id.to_string node.Plan.id))
+       layers);
+  let run_id = Plan.Run_id.fresh () in
+  let time_output =
+    match
+      Plan.validate_output
+        entry.plan
+        ~run_id
+        ~node_id:(node_id "time")
+        (`Assoc
+            [ "now_iso", `String "2026-08-14T00:00:00Z"
+            ; "now_unix", `Float 0.0
+            ])
+    with
+    | Ok output -> output
+    | Error _ -> fail "valid clock output was rejected"
+  in
+  match
+    Plan.resolve_input
+      entry.plan
+      ~run_id
+      ~node_id:(node_id "search")
+      ~lookup:(fun id ->
+        if Plan.Node_id.equal id (node_id "time") then Some time_output else None)
+  with
+  | Ok (`Assoc [ ("query", `String "2026-08-14T00:00:00Z") ]) -> ()
+  | Ok value ->
+    failf "resolved catalog input changed shape: %s" (Yojson.Safe.to_string value)
+  | Error _ -> fail "catalog output reference did not resolve"
+;;
+
+let test_catalog_rejects_unknown_fields () =
+  let document =
+    {|[[compositions]]
+name = "bad"
+guess = true
+[[compositions.nodes]]
+id = "time"
+tool = "keeper_time_now"
+input = { kind = "literal", value = {} }
+|}
+  in
+  match Catalog.parse document with
+  | Error
+      (Catalog.Unknown_field
+        { path = [ "compositions"; "0" ]; field = "guess" }) -> ()
+  | Error _ | Ok _ -> fail "unknown composition field was not rejected"
+;;
+
+let test_catalog_rejects_malformed_output_pointer () =
+  let document =
+    {|[[compositions]]
+name = "bad-pointer"
+[[compositions.nodes]]
+id = "time"
+tool = "keeper_time_now"
+[compositions.nodes.input]
+kind = "literal"
+value = {}
+[[compositions.nodes]]
+id = "search"
+tool = "keeper_memory_search"
+[compositions.nodes.input]
+kind = "object"
+[[compositions.nodes.input.fields]]
+name = "query"
+[compositions.nodes.input.fields.value]
+kind = "output"
+node = "time"
+pointer = "now_iso"
+|}
+  in
+  match Catalog.parse document with
+  | Error
+      (Catalog.Invalid_json_pointer
+        { error = Plan.Json_pointer.Missing_initial_slash; _ }) -> ()
+  | Error _ | Ok _ -> fail "non-RFC6901 output pointer was accepted"
+;;
+
+let one_node_composition name =
+  Printf.sprintf
+    {|[[compositions]]
+name = %S
+[[compositions.nodes]]
+id = "time"
+tool = "keeper_time_now"
+input = { kind = "literal", value = {} }
+|}
+    name
+;;
+
+let test_catalog_rejects_duplicate_composition_names () =
+  let document = one_node_composition "same" ^ one_node_composition "same" in
+  match Catalog.parse document with
+  | Error (Catalog.Duplicate_composition_name "same") -> ()
+  | Error _ | Ok _ -> fail "duplicate composition name was accepted"
+;;
+
+let test_catalog_rejects_unknown_tool_through_plan_authority () =
+  let document =
+    {|[[compositions]]
+name = "unknown-tool"
+[[compositions.nodes]]
+id = "unknown"
+tool = "invented_tool"
+input = { kind = "literal", value = {} }
+|}
+  in
+  match Catalog.parse document with
+  | Error
+      (Catalog.Plan_rejected
+        { error = Plan.Unknown_tool { tool_name = "invented_tool"; _ }; _ }) -> ()
+  | Error _ | Ok _ -> fail "catalog bypassed canonical plan tool authority"
+;;
+
+let () =
+  run
+    "keeper_tool_composition_catalog"
+    [ ( "catalog"
+      , [ test_case
+            "builds executable typed plan"
+            `Quick
+            test_catalog_builds_executable_typed_plan
+        ; test_case "rejects unknown fields" `Quick test_catalog_rejects_unknown_fields
+        ; test_case
+            "rejects malformed pointer"
+            `Quick
+            test_catalog_rejects_malformed_output_pointer
+        ; test_case
+            "rejects duplicate names"
+            `Quick
+            test_catalog_rejects_duplicate_composition_names
+        ; test_case
+            "rejects unknown tools"
+            `Quick
+            test_catalog_rejects_unknown_tool_through_plan_authority
+        ] )
+    ]
+;;

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -4619,6 +4619,128 @@ let test_surface_post_append_failure_does_not_complete_terminal_effect () =
             ()))
 ;;
 
+let composition_node_id value =
+  match Masc.Keeper_tool_plan.Node_id.make value with
+  | Ok id -> id
+  | Error Masc.Keeper_tool_plan.Node_id.Empty -> fail "composition node id is empty"
+;;
+
+let composition_descriptor name =
+  Masc.Keeper_tool_descriptor.all_descriptors ()
+  |> List.find_opt (fun descriptor ->
+    Masc.Keeper_tool_descriptor.keeper_model_names descriptor
+    |> List.exists (String.equal name))
+  |> function
+  | Some descriptor -> descriptor
+  | None -> fail ("composition descriptor missing: " ^ name)
+;;
+
+let composition_invocation ~completion =
+  Agent_core.Tool_contract.Invocation.create
+    ~tool_use_id:"composition-parent"
+    ~turn:7
+    ~schedule:
+      { Agent_core.Tool_contract.planned_index = 0
+      ; batch_index = 0
+      ; batch_size = 1
+      ; execution_mode = Agent_core.Tool_contract.Serial
+      }
+    ~completion
+;;
+
+let test_composition_runtime_uses_canonical_descriptor () =
+  with_exec_fixture "composition-canonical-descriptor"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       let canonical = composition_descriptor "keeper_time_now" in
+       let supplied =
+         { canonical with
+           Masc.Keeper_tool_descriptor.execution =
+             Masc.Keeper_tool_descriptor.Ordinary Masc.Keeper_tool_descriptor.Serial
+         ; input_schema = `Assoc [ "type", `String "string" ]
+         ; composable_output = Masc.Keeper_tool_descriptor.Opaque_output
+         }
+       in
+       let node =
+         Masc.Keeper_tool_plan.node
+           ~id:(composition_node_id "time")
+           ~tool_name:"keeper_time_now"
+           ~input:(Masc.Keeper_tool_plan.Json_template.literal (`Assoc []))
+           ()
+       in
+       let plan =
+         match Masc.Keeper_tool_plan.create ~descriptors:[ supplied ] [ node ] with
+         | Ok plan -> plan
+         | Error _ -> fail "canonicalized composition plan was rejected"
+       in
+       match
+         Masc.Keeper_tool_plan_executor.execute_keeper
+           ~plan
+           ~run_id:(Masc.Keeper_tool_plan.Run_id.fresh ())
+           ~parent_invocation:
+             (composition_invocation
+                ~completion:Agent_core.Tool_contract.Continue_after_success)
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot:ctx_work
+           ()
+       with
+       | Error _ -> fail "canonical exact-descriptor composition execution failed"
+       | Ok [ result ] ->
+         (match result.Masc.Keeper_tool_plan_executor.result with
+          | Tool_result.Completed _ -> ()
+          | Tool_result.Deferred _ | Tool_result.Failed _ ->
+            fail "canonical time descriptor did not complete");
+         check bool
+           "canonical concurrent schedule"
+           true
+           (result.schedule.execution_mode = Agent_core.Tool_contract.Concurrent)
+       | Ok _ -> fail "single-node composition settled an unexpected result count")
+;;
+
+let test_composition_terminal_requires_terminal_outer_invocation () =
+  with_exec_fixture "composition-terminal-outer-contract"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       let descriptor = composition_descriptor "keeper_surface_post" in
+       let node =
+         Masc.Keeper_tool_plan.node
+           ~id:(composition_node_id "terminal")
+           ~tool_name:"keeper_surface_post"
+           ~input:(Masc.Keeper_tool_plan.Json_template.literal (`Assoc []))
+           ()
+       in
+       let plan =
+         match Masc.Keeper_tool_plan.create ~descriptors:[ descriptor ] [ node ] with
+         | Ok plan -> plan
+         | Error _ -> fail "terminal composition plan was rejected"
+       in
+       match
+         Masc.Keeper_tool_plan_executor.execute_keeper
+           ~plan
+           ~run_id:(Masc.Keeper_tool_plan.Run_id.fresh ())
+           ~parent_invocation:
+             (composition_invocation
+                ~completion:Agent_core.Tool_contract.Continue_after_success)
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot:ctx_work
+           ()
+       with
+       | Error
+           { settled = []
+           ; cause =
+               Masc.Keeper_tool_plan_executor.Outer_completion_mismatch
+                 { expected =
+                     Agent_core.Tool_contract.Terminal_after_success
+                       Agent_core.Tool_contract.Effect_outcome_unknown
+                 ; actual = Agent_core.Tool_contract.Continue_after_success
+                 }
+           } -> ()
+       | Error _ | Ok _ ->
+         fail "terminal composition accepted an ordinary outer invocation")
+;;
+
 let () =
   Masc_test_deps.init_unified_tool_registry ();
   run "Keeper_tool_dispatch_runtime" [
@@ -4711,6 +4833,10 @@ let () =
         test_invalid_surface_post_input_stays_correction_capable;
       test_case "surface append failure is not terminal completion" `Quick
         test_surface_post_append_failure_does_not_complete_terminal_effect;
+      test_case "composition dispatch uses canonical descriptor authority" `Quick
+        test_composition_runtime_uses_canonical_descriptor;
+      test_case "terminal composition requires terminal outer invocation" `Quick
+        test_composition_terminal_requires_terminal_outer_invocation;
     ]);
     ("exact_registered_dispatch", [
       test_case "raw Board runtime respects typed projection" `Quick

--- a/test/test_keeper_tool_plan.ml
+++ b/test/test_keeper_tool_plan.ml
@@ -332,18 +332,12 @@ let test_plan_rejects_invalid_graphs_and_output_edges () =
 ;;
 
 let test_plan_rejects_unsupported_output_schema_keywords () =
-  let time = descriptor "keeper_time_now" in
-  let time_node = node ~id:"time" ~tool_name:"keeper_time_now" literal_object in
-  let with_schema schema =
-    { time with Descriptor.composable_output = Descriptor.Json_output { schema } }
-  in
   let enum_schema =
     `Assoc [ "type", `String "string"; "enum", `List [ `String "ok" ] ]
   in
-  (match Plan.create ~descriptors:[ with_schema enum_schema ] [ time_node ] with
+  (match Plan.validate_composable_schema enum_schema with
    | Error
-       (Plan.Invalid_output_schema
-         { error = Plan.Unsupported_schema_keyword { keyword = "enum"; _ }; _ }) -> ()
+       (Plan.Unsupported_schema_keyword { keyword = "enum"; _ }) -> ()
    | Error _ | Ok _ -> fail "unsupported enum output contract was accepted");
   let schema_valued_additional_properties =
     `Assoc
@@ -352,18 +346,66 @@ let test_plan_rejects_unsupported_output_schema_keywords () =
       ; "additionalProperties", `Assoc [ "type", `String "string" ]
       ]
   in
-  match
-    Plan.create
-      ~descriptors:[ with_schema schema_valued_additional_properties ]
-      [ time_node ]
-  with
+  match Plan.validate_composable_schema schema_valued_additional_properties with
   | Error
-      (Plan.Invalid_output_schema
-        { error = Plan.Invalid_schema_keyword_value
-            { keyword = "additionalProperties"; _ }
-        ; _
-        }) -> ()
+      (Plan.Invalid_schema_keyword_value
+        { keyword = "additionalProperties"; _ }) -> ()
   | Error _ | Ok _ -> fail "schema-valued additionalProperties was accepted"
+;;
+
+let test_terminal_node_is_unique_and_depends_on_every_prior_node () =
+  let terminal = descriptor "keeper_surface_post" in
+  let first = node ~id:"first" ~tool_name:"keeper_surface_post" literal_object in
+  let second = node ~id:"second" ~tool_name:"keeper_surface_post" literal_object in
+  (match Plan.create ~descriptors:[ terminal ] [ first; second ] with
+   | Error (Plan.Multiple_terminal_nodes [ first_id; second_id ])
+     when Plan.Node_id.equal first_id (node_id "first")
+          && Plan.Node_id.equal second_id (node_id "second") -> ()
+   | Error _ | Ok _ -> fail "multiple terminal nodes were accepted");
+  let ordinary = descriptor "masc_board_stats" in
+  let ordinary_node = node ~id:"ordinary" ~tool_name:"masc_board_stats" literal_object in
+  let lone_terminal = node ~id:"terminal" ~tool_name:"keeper_surface_post" literal_object in
+  (match
+     Plan.create ~descriptors:[ ordinary; terminal ] [ ordinary_node; lone_terminal ]
+   with
+   | Error
+       (Plan.Terminal_node_missing_dependency { terminal_node_id; node_id = missing })
+     when Plan.Node_id.equal terminal_node_id (node_id "terminal")
+          && Plan.Node_id.equal missing (node_id "ordinary") -> ()
+   | Error _ | Ok _ -> fail "terminal node without explicit ancestry was accepted");
+  let dependent_terminal =
+    node
+      ~id:"terminal"
+      ~tool_name:"keeper_surface_post"
+      ~after:[ node_id "ordinary" ]
+      literal_object
+  in
+  match
+    Plan.create ~descriptors:[ ordinary; terminal ] [ ordinary_node; dependent_terminal ]
+  with
+  | Ok _ -> ()
+  | Error _ -> fail "terminal node with complete explicit ancestry was rejected"
+;;
+
+let test_plan_uses_process_owned_descriptor_authority () =
+  let canonical = descriptor "keeper_time_now" in
+  let supplied =
+    { canonical with
+      Descriptor.execution = Descriptor.Ordinary Descriptor.Serial
+    ; input_schema = `Assoc [ "type", `String "string" ]
+    ; composable_output = Descriptor.Opaque_output
+    }
+  in
+  let time_node = node ~id:"time" ~tool_name:"keeper_time_now" literal_object in
+  match Plan.create ~descriptors:[ supplied ] [ time_node ] with
+  | Error _ -> fail "canonical descriptor id was not resolved"
+  | Ok plan ->
+    (match Plan.descriptor plan (node_id "time") with
+     | Some descriptor when descriptor == canonical ->
+       (match descriptor.Descriptor.execution, descriptor.composable_output with
+        | Descriptor.Ordinary Descriptor.Concurrent, Descriptor.Json_output _ -> ()
+        | _ -> fail "record-updated descriptor fields became plan authority")
+     | Some _ | None -> fail "plan did not retain process-owned descriptor authority")
 ;;
 
 let test_composable_output_registry_is_closed () =
@@ -417,6 +459,14 @@ let () =
             "unsupported output schema keywords"
             `Quick
             test_plan_rejects_unsupported_output_schema_keywords
+        ; test_case
+            "terminal dependency boundary"
+            `Quick
+            test_terminal_node_is_unique_and_depends_on_every_prior_node
+        ; test_case
+            "canonical descriptor authority"
+            `Quick
+            test_plan_uses_process_owned_descriptor_authority
         ] )
     ]
 ;;

--- a/test/test_keeper_tool_plan_executor.ml
+++ b/test/test_keeper_tool_plan_executor.ml
@@ -1,0 +1,236 @@
+open Alcotest
+
+module Descriptor = Masc.Keeper_tool_descriptor
+module Plan = Masc.Keeper_tool_plan
+module Executor = Masc.Keeper_tool_plan_executor
+
+let node_id value =
+  match Plan.Node_id.make value with
+  | Ok id -> id
+  | Error Plan.Node_id.Empty -> failf "unexpected empty node id: %S" value
+;;
+
+let canonical_descriptor name =
+  Descriptor.all_descriptors ()
+  |> List.find_opt (fun descriptor ->
+    Descriptor.keeper_model_names descriptor |> List.exists (String.equal name))
+  |> function
+  | Some descriptor -> descriptor
+  | None -> failf "canonical descriptor is missing: %s" name
+;;
+
+let fixture () =
+  let producer = canonical_descriptor "keeper_time_now" in
+  let parallel = canonical_descriptor "masc_board_stats" in
+  let final = canonical_descriptor "keeper_tools_list" in
+  let producer_node =
+    Plan.node
+      ~id:(node_id "producer")
+      ~tool_name:"keeper_time_now"
+      ~input:(Plan.Json_template.literal (`Assoc []))
+      ()
+  in
+  let left_node =
+    Plan.node
+      ~id:(node_id "left")
+      ~tool_name:"masc_board_stats"
+      ~after:[ node_id "producer" ]
+      ~input:(Plan.Json_template.literal (`Assoc []))
+      ()
+  in
+  let right_node =
+    Plan.node
+      ~id:(node_id "right")
+      ~tool_name:"masc_board_stats"
+      ~after:[ node_id "producer" ]
+      ~input:(Plan.Json_template.literal (`Assoc []))
+      ()
+  in
+  let final_node =
+    Plan.node
+      ~id:(node_id "final")
+      ~tool_name:"keeper_tools_list"
+      ~after:[ node_id "left"; node_id "right" ]
+      ~input:(Plan.Json_template.literal (`Assoc []))
+      ()
+  in
+  match
+    Plan.create
+      ~descriptors:[ producer; parallel; final ]
+      [ producer_node; left_node; right_node; final_node ]
+  with
+  | Ok plan -> plan
+  | Error _ -> fail "valid executor fixture plan was rejected"
+;;
+
+let completed ~tool_name ~data =
+  Tool_result.make_ok ~tool_name ~start_time:0.0 ~data ()
+;;
+
+let node_name node = Plan.Node_id.to_string node.Plan.id
+
+let valid_data_for_node node =
+  match node_name node with
+  | "producer" -> `Assoc [ "now_iso", `String "2026-08-14T00:00:00Z"; "now_unix", `Float 0.0 ]
+  | "left" | "right" ->
+    `Assoc
+      [ "post_count", `Int 0
+      ; "comment_count", `Int 0
+      ; "expired_pending", `Int 0
+      ; "last_sweep", `Float 0.0
+      ; "backend", `String "test"
+      ]
+  | "final" -> `Assoc [ "tools", `List [] ]
+  | name -> failf "unexpected fixture node: %s" name
+;;
+
+let test_schedule_and_parallel_dataflow () =
+  Eio_main.run @@ fun _env ->
+  let plan = fixture () in
+  let batches = Executor.schedule plan in
+  (match batches with
+   | [ Executor.Concurrent_batch [ producer ]
+     ; Executor.Concurrent_batch [ left; right ]
+     ; Executor.Serial_batch final
+     ] ->
+     check int "producer batch index" 0 producer.schedule.batch_index;
+     check int "parallel batch index" 1 left.schedule.batch_index;
+     check int "left batch size" 2 left.schedule.batch_size;
+     check int "right batch size" 2 right.schedule.batch_size;
+     check int "final batch index" 2 final.schedule.batch_index;
+     check bool
+       "parallel execution mode"
+       true
+       (left.schedule.execution_mode = Agent_core.Tool_contract.Concurrent)
+   | _ -> fail "descriptor-aware schedule shape changed");
+  let sibling_count = Atomic.make 0 in
+  let both_started, release = Eio.Promise.create () in
+  let dispatch ~node ~descriptor:_ ~schedule:_ ~input =
+    let name = node_name node in
+    if String.equal name "left" || String.equal name "right"
+    then (
+      check string "parallel input" "{}" (Yojson.Safe.to_string input);
+      if Atomic.fetch_and_add sibling_count 1 = 1 then Eio.Promise.resolve release ();
+      Eio.Promise.await both_started);
+    completed ~tool_name:node.Plan.tool_name ~data:(valid_data_for_node node)
+  in
+  match Executor.execute ~plan ~run_id:(Plan.Run_id.fresh ()) ~dispatch () with
+  | Error _ -> fail "valid parallel plan stopped"
+  | Ok results ->
+    check
+      (list string)
+      "settled execution order"
+      [ "producer"; "left"; "right"; "final" ]
+      (List.map (fun result -> Plan.Node_id.to_string result.Executor.node_id) results);
+    check int "both siblings entered before either returned" 2 (Atomic.get sibling_count)
+;;
+
+let test_failed_sibling_stops_downstream_after_batch_settlement () =
+  Eio_main.run @@ fun _env ->
+  let plan = fixture () in
+  let called = ref [] in
+  let dispatch ~node ~descriptor:_ ~schedule:_ ~input:_ =
+    let name = node_name node in
+    called := !called @ [ name ];
+    if String.equal name "left"
+    then
+      Tool_result.make_err
+        ~tool_name:name
+        ~class_:Tool_result.Workflow_rejection
+        ~start_time:0.0
+        "left rejected"
+    else
+      completed ~tool_name:node.Plan.tool_name ~data:(valid_data_for_node node)
+  in
+  match Executor.execute ~plan ~run_id:(Plan.Run_id.fresh ()) ~dispatch () with
+  | Ok _ -> fail "failed sibling did not stop the plan"
+  | Error failure ->
+    check
+      (list string)
+      "downstream was not dispatched"
+      [ "left"; "producer"; "right" ]
+      (List.sort String.compare !called);
+    check
+      (list string)
+      "successful sibling remains settled"
+      [ "producer"; "left"; "right" ]
+      (List.map (fun result -> Plan.Node_id.to_string result.Executor.node_id) failure.settled);
+    (match failure.cause with
+     | Executor.Tool_did_not_complete result ->
+       check string "lowest planned cause" "left" (Plan.Node_id.to_string result.node_id);
+       (match result.result with
+       | Tool_result.Failed { class_ = Tool_result.Workflow_rejection; _ } -> ()
+        | Tool_result.Completed _ | Tool_result.Deferred _ | Tool_result.Failed _ ->
+          fail "canonical failed disposition changed")
+     | Executor.Plan_execution_failed _ | Executor.Outer_completion_mismatch _ ->
+       fail "tool failure became a plan error")
+;;
+
+let test_malformed_declared_output_stops_before_consumer () =
+  Eio_main.run @@ fun _env ->
+  let plan = fixture () in
+  let called = ref [] in
+  let dispatch ~node ~descriptor:_ ~schedule:_ ~input:_ =
+    called := node_name node :: !called;
+    completed ~tool_name:node.tool_name ~data:(`Assoc [ "now_iso", `Int 7 ])
+  in
+  match Executor.execute ~plan ~run_id:(Plan.Run_id.fresh ()) ~dispatch () with
+  | Ok _ -> fail "malformed producer output was accepted"
+  | Error failure ->
+    check (list string) "only producer dispatched" [ "producer" ] (List.rev !called);
+    (match failure.cause with
+     | Executor.Plan_execution_failed
+         { error = Plan.Output_validation_failed { node_id = failed; _ }; _ }
+       when Plan.Node_id.equal failed (node_id "producer") -> ()
+     | Executor.Plan_execution_failed _
+     | Executor.Tool_did_not_complete _
+     | Executor.Outer_completion_mismatch _ ->
+       fail "malformed producer did not retain its typed validation cause")
+;;
+
+let test_outer_completion_owns_terminal_boundary () =
+  let terminal_descriptor = canonical_descriptor "keeper_surface_post" in
+  let terminal_node =
+    Plan.node
+      ~id:(node_id "terminal")
+      ~tool_name:"keeper_surface_post"
+      ~input:(Plan.Json_template.literal (`Assoc []))
+      ()
+  in
+  let terminal_plan =
+    match Plan.create ~descriptors:[ terminal_descriptor ] [ terminal_node ] with
+    | Ok plan -> plan
+    | Error _ -> fail "single terminal composition was rejected"
+  in
+  (match Executor.outer_completion terminal_plan with
+   | Agent_core.Tool_contract.Terminal_after_success
+       Agent_core.Tool_contract.Effect_outcome_unknown -> ()
+   | Agent_core.Tool_contract.Continue_after_success
+   | Agent_core.Tool_contract.Terminal_after_success _ ->
+     fail "terminal boundary was not projected to the outer composition");
+  match Executor.outer_completion (fixture ()) with
+  | Agent_core.Tool_contract.Continue_after_success -> ()
+  | Agent_core.Tool_contract.Terminal_after_success _ ->
+    fail "ordinary composition became terminal"
+;;
+
+let () =
+  run
+    "keeper_tool_plan_executor"
+    [ ( "execution"
+      , [ test_case "parallel dataflow schedule" `Quick test_schedule_and_parallel_dataflow
+        ; test_case
+            "failed sibling stops downstream"
+            `Quick
+            test_failed_sibling_stops_downstream_after_batch_settlement
+        ; test_case
+            "malformed producer stops consumers"
+            `Quick
+            test_malformed_declared_output_stops_before_consumer
+        ; test_case
+            "outer completion owns terminal boundary"
+            `Quick
+            test_outer_completion_owns_terminal_boundary
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

- execute validated Keeper composition plans as dependency-ordered serial and concurrent batches
- route every action through the ordinary Keeper Agent-Core handler with exact schedule, Gate, Shell IR, telemetry, and I/O preview context
- validate declared producer output before any consumer can read it and retain canonical `Tool_result` failures/deferred results without payload inference
- derive outer terminal completion from the plan and reject mismatched parent invocation authority before any action dispatch
- canonicalize descriptor records through the process-owned registry and execute that exact descriptor instead of resolving a second authority by name

## Stack

- base PR: #28656
- exact base: `70462f438882e2d198aa28313ade9024b7ef0040`
- exact head: `2768fe324edd6936890cdc9cad1d088828a3ae3f`

## Verification

- no local build or tests were run, per project instruction; GitHub CI is authoritative
- `ocamlformat` applied to changed OCaml files
- `git diff --check` passes
- feature regressions cover parallel batch barriers, deterministic settlement, malformed producer output, descriptor canonicalization through the real runtime, and terminal outer-invocation rejection
- exact-patch adversarial source re-review found no BLOCKING or HIGH findings before the parent-only restack

## Review state

- Draft until stacked parents and exact-head CI settle
