### PR TITLE
feat(observation): attribution 이분 — producer/sink write 전환 (RFC-0378 A2)

### DIFF
--- a/lib/agent_observation/agent_observation.ml
+++ b/lib/agent_observation/agent_observation.ml
@@ -152,6 +152,61 @@ let canonical_url_of_remote raw =
            | Some segs -> Some (String.concat "_" (host_slug :: segs)))
 ;;
 
+(* RFC-0378 §5.1: a code fact's address, minted once where the write is
+   attributed and carried as a parsed value from then on. Consumers never
+   re-derive either half from tool input or store layout — [v] is the only
+   way in, and it rejects every shape the partitioned store cannot join on
+   instead of repairing it. *)
+module Code_address = struct
+  type t =
+    { codebase : string
+    ; path : string
+    }
+
+  type invalid =
+    | Empty_codebase
+    | Malformed_codebase
+    | Empty_path
+    | Absolute_path
+    | Unnormalized_path
+
+  let invalid_to_string = function
+    | Empty_codebase -> "empty codebase slug"
+    | Malformed_codebase -> "codebase is not a canonical host_path slug"
+    | Empty_path -> "empty repo-relative path"
+    | Absolute_path -> "path is absolute, expected repo-root relative"
+    | Unnormalized_path -> "path has ., .., or empty segments"
+  ;;
+
+  (* Same closed character set and leading-[..] guard as
+     [path_segment_to_slug], so every slug [canonical_url_of_remote] can
+     emit is accepted and nothing outside that alphabet is. *)
+  let valid_codebase slug =
+    not (String.length slug >= 2 && String.sub slug 0 2 = "..")
+    && String.for_all is_slug_char slug
+  ;;
+
+  let normalized_segment seg = seg <> "" && seg <> "." && seg <> ".."
+
+  let v ~codebase ~path =
+    if codebase = ""
+    then Error Empty_codebase
+    else if not (valid_codebase codebase)
+    then Error Malformed_codebase
+    else if path = ""
+    then Error Empty_path
+    else if path.[0] = '/'
+    then Error Absolute_path
+    else if not (List.for_all normalized_segment (String.split_on_char '/' path))
+    then Error Unnormalized_path
+    else Ok { codebase; path }
+  ;;
+
+  let codebase t = t.codebase
+  let path t = t.path
+  let equal a b = String.equal a.codebase b.codebase && String.equal a.path b.path
+end
+
 type write_region_event =
   { base_path : string
   ; partition : codebase_partition

--- a/lib/agent_observation/agent_observation.ml
+++ b/lib/agent_observation/agent_observation.ml
@@ -17,34 +17,6 @@ type codebase_partition =
           annotation_request). Structural ceiling, NOT a soft fallback.
           v2 §7 "(3) default 미갱신". *)
 
-type tool_event =
-  { base_path : string
-  ; partition : codebase_partition
-  ; file_path : string option
-  ; tool_name : string
-  ; keeper_id : string
-  ; turn_id : string
-  ; outcome : string
-  ; typed_outcome : string
-  ; duration_ms : float
-  ; output_text : string
-  ; input : Yojson.Safe.t
-  }
-
-type turn_event =
-  { base_path : string
-  ; partition : codebase_partition
-  ; turn_id : string
-  ; keeper_id : string
-  ; phase : string
-  ; model_used : string option
-  ; tools_used : string list
-  ; stop_reason : string option
-  ; duration_ms : int option
-  ; timestamp_ms : int64
-  }
-
-
 (* RFC-0128 §4.1 neutral codebase slug derivation.
 
    Kept below the Keeper/IDE boundary so runtime producers can route
@@ -214,9 +186,91 @@ module Code_address = struct
   let equal a b = String.equal a.codebase b.codebase && String.equal a.path b.path
 end
 
+(* Typed reasons a write's file path failed attribution to a codebase.
+   RFC-0378 §5.1: attribution failure is a fact kind, not a store
+   partition — the reason rides the fact as a queryable field.
+   RFC-keeper-workspace-root-only 2a owns this vocabulary's evolution
+   once attribution moves to git observation. *)
+module Unattributed = struct
+  type reason =
+    | Blank_remote_url
+    | Unparseable_remote_url of string
+    | Unregistered_repo_id of string
+    | Unregistered_path
+    | Repository_catalog_unavailable
+
+  let reason_to_string = function
+    | Blank_remote_url -> "blank_remote_url"
+    | Unparseable_remote_url _ -> "unparseable_remote_url"
+    | Unregistered_repo_id _ -> "unregistered_repo_id"
+    | Unregistered_path -> "unregistered_path"
+    | Repository_catalog_unavailable -> "repository_catalog_unavailable"
+  ;;
+end
+
+type addressed =
+  { address : Code_address.t
+  ; checkout : string option
+    (* Projection metadata: which checkout the write was observed in.
+       Never part of the join key. [None] until attribution measures it
+       (workspace-root-only 2b). *)
+  }
+
+type unaddressed =
+  { reason : Unattributed.reason
+  ; attempted_path : string
+    (* The path exactly as the resolver saw it — forensic identity for
+       records that never joined a codebase. *)
+  }
+
+(* Where a fact that names a file belongs. An annotation or write region
+   always names a file, so [Pathless] is unrepresentable for them. *)
+type file_attribution =
+  | Addressed of addressed
+  | Unaddressed of unaddressed
+
+(* Where any tool fact belongs: a pathless call is a keeper-timeline
+   fact with no document — distinct from a failed attribution. *)
+type attribution =
+  | File of file_attribution
+  | Pathless
+
+type tool_event =
+  { base_path : string
+  ; attribution : attribution
+    (* RFC-0378 §5.1: the address is minted where the write is attributed
+       and carried as a parsed value. Producers must not hand consumers a
+       raw tool argument — a consumer re-deriving the path from [input]
+       produced three incompatible shapes in one partition (masc#28582). *)
+  ; tool_name : string
+  ; keeper_id : string
+  ; turn_id : string
+  ; outcome : string
+  ; typed_outcome : string
+  ; duration_ms : float
+  ; output_text : string
+  ; input : Yojson.Safe.t
+  }
+
+(* A turn is a keeper-timeline fact by definition (RFC-0378 §1): it can
+   touch any number of codebases, so it carries no attribution — the
+   per-codebase timeline is derived by joining addressed tool facts on
+   [turn_id]. *)
+type turn_event =
+  { base_path : string
+  ; turn_id : string
+  ; keeper_id : string
+  ; phase : string
+  ; model_used : string option
+  ; tools_used : string list
+  ; stop_reason : string option
+  ; duration_ms : int option
+  ; timestamp_ms : int64
+  }
+
 type write_region_event =
   { base_path : string
-  ; partition : codebase_partition
+  ; attribution : file_attribution
   ; keeper_id : string
   ; turn : int
   ; tool_call_json : Yojson.Safe.t
@@ -313,9 +367,8 @@ let annotation_references_of_json = function
 
 type annotation_request =
   { base_path : string
-  ; partition : codebase_partition
+  ; attribution : file_attribution
   ; keeper_id : string
-  ; file_path : string
   ; line_start : int
   ; line_end : int
   ; kind : annotation_kind
@@ -394,18 +447,38 @@ let reverse_snapshot snap =
   }
 ;;
 
-let partition_to_json = function
-  | By_url slug -> `Assoc [ ("type", `String "By_url"); ("slug", `String slug) ]
-  | No_canonical_url -> `String "No_canonical_url"
-  | Unmatched -> `String "Unmatched"
-  | Base_unresolved -> `String "Base_unresolved"
-  | Legacy_default -> `String "Legacy_default"
+let code_address_to_json address =
+  `Assoc
+    [ ("codebase", `String (Code_address.codebase address))
+    ; ("path", `String (Code_address.path address))
+    ]
+;;
+
+let file_attribution_to_json = function
+  | Addressed { address; checkout } ->
+    `Assoc
+      ([ ("type", `String "Addressed"); ("address", code_address_to_json address) ]
+       @
+       match checkout with
+       | None -> []
+       | Some c -> [ ("checkout", `String c) ])
+  | Unaddressed { reason; attempted_path } ->
+    `Assoc
+      [ ("type", `String "Unaddressed")
+      ; ("reason", `String (Unattributed.reason_to_string reason))
+      ; ("attempted_path", `String attempted_path)
+      ]
+;;
+
+let attribution_to_json = function
+  | File file_attribution -> file_attribution_to_json file_attribution
+  | Pathless -> `String "Pathless"
 ;;
 
 let tool_event_to_json (e : tool_event) =
   `Assoc
     [ ("base_path", `String e.base_path)
-    ; ("partition", partition_to_json e.partition)
+    ; ("attribution", attribution_to_json e.attribution)
     ; ("tool_name", `String e.tool_name)
     ; ("keeper_id", `String e.keeper_id)
     ; ("turn_id", `String e.turn_id)
@@ -417,7 +490,6 @@ let tool_event_to_json (e : tool_event) =
 let turn_event_to_json (e : turn_event) =
   `Assoc
     [ ("base_path", `String e.base_path)
-    ; ("partition", partition_to_json e.partition)
     ; ("turn_id", `String e.turn_id)
     ; ("keeper_id", `String e.keeper_id)
     ; ("phase", `String e.phase)
@@ -428,7 +500,7 @@ let turn_event_to_json (e : turn_event) =
 let write_region_to_json (e : write_region_event) =
   `Assoc
     [ ("base_path", `String e.base_path)
-    ; ("partition", partition_to_json e.partition)
+    ; ("attribution", file_attribution_to_json e.attribution)
     ; ("keeper_id", `String e.keeper_id)
     ; ("turn", `Int e.turn)
     ; ("tool_call", e.tool_call_json)
@@ -437,13 +509,12 @@ let write_region_to_json (e : write_region_event) =
 
 let annotation_to_json (a : annotation_request) =
   `Assoc
-    [ ("file_path", `String a.file_path)
+    [ ("attribution", file_attribution_to_json a.attribution)
     ; ("line_start", `Int a.line_start)
     ; ("line_end", `Int a.line_end)
     ; ("keeper_id", `String a.keeper_id)
     ; ("kind", `String (annotation_kind_to_string a.kind))
     ; ("content", `String a.content)
-    ; ("partition", partition_to_json a.partition)
     ; ("references", annotation_references_to_json a.references)
     ]
 ;;

--- a/lib/agent_observation/agent_observation.ml
+++ b/lib/agent_observation/agent_observation.ml
@@ -198,6 +198,11 @@ module Unattributed = struct
     | Unregistered_repo_id of string
     | Unregistered_path
     | Repository_catalog_unavailable
+    | Unmintable of Code_address.invalid
+      (* The repo and relative path were recovered but the address
+         constructor rejected the residue. Reaching this is a resolver
+         invariant break worth diagnosing, so the rejection is carried
+         instead of being collapsed into another reason. *)
 
   let reason_to_string = function
     | Blank_remote_url -> "blank_remote_url"
@@ -205,6 +210,7 @@ module Unattributed = struct
     | Unregistered_repo_id _ -> "unregistered_repo_id"
     | Unregistered_path -> "unregistered_path"
     | Repository_catalog_unavailable -> "repository_catalog_unavailable"
+    | Unmintable _ -> "unmintable_address"
   ;;
 end
 

--- a/lib/agent_observation/agent_observation.ml
+++ b/lib/agent_observation/agent_observation.ml
@@ -168,6 +168,7 @@ module Code_address = struct
     | Malformed_codebase
     | Empty_path
     | Absolute_path
+    | Malformed_path
     | Unnormalized_path
 
   let invalid_to_string = function
@@ -175,6 +176,7 @@ module Code_address = struct
     | Malformed_codebase -> "codebase is not a canonical host_path slug"
     | Empty_path -> "empty repo-relative path"
     | Absolute_path -> "path is absolute, expected repo-root relative"
+    | Malformed_path -> "path is not syntactically valid"
     | Unnormalized_path -> "path has ., .., or empty segments"
   ;;
 
@@ -186,8 +188,6 @@ module Code_address = struct
     && String.for_all is_slug_char slug
   ;;
 
-  let normalized_segment seg = seg <> "" && seg <> "." && seg <> ".."
-
   let v ~codebase ~path =
     if codebase = ""
     then Error Empty_codebase
@@ -195,11 +195,18 @@ module Code_address = struct
     then Error Malformed_codebase
     else if path = ""
     then Error Empty_path
-    else if path.[0] = '/'
-    then Error Absolute_path
-    else if not (List.for_all normalized_segment (String.split_on_char '/' path))
-    then Error Unnormalized_path
-    else Ok { codebase; path }
+    else
+      match Fpath.of_string path with
+      | Error _ -> Error Malformed_path
+      | Ok parsed ->
+        if Fpath.is_abs parsed
+        then Error Absolute_path
+        else if
+          not (String.equal path (Fpath.to_string parsed))
+          || not (Fpath.equal parsed (Fpath.rem_empty_seg parsed))
+          || List.exists Fpath.is_rel_seg (Fpath.segs parsed)
+        then Error Unnormalized_path
+        else Ok { codebase; path }
   ;;
 
   let codebase t = t.codebase

--- a/lib/agent_observation/agent_observation.mli
+++ b/lib/agent_observation/agent_observation.mli
@@ -22,45 +22,6 @@ type codebase_partition =
           field (tool/turn). Structural ceiling, NOT a soft fallback.
           v2 §7 "(3) default 미갱신". *)
 
-type tool_event =
-  { base_path : string
-  ; partition : codebase_partition
-  ; file_path : string option
-        (** The edited file as the partition resolver named it: relative to the
-            codebase the [partition] identifies, or the original absolute path
-            when the resolver could not attribute it. [None] is a tool call that
-            names no file at all (coordination, board, memory) — a
-            keeper-timeline fact with no document.
-
-            Producers must not hand consumers the raw tool argument instead.
-            The resolver is the only thing that knows which root the argument
-            was relative to, so a consumer re-deriving the path from [input]
-            produced a different vocabulary than the one the same resolver
-            stored in [regions]/[annotations] — three incompatible shapes in a
-            single partition (masc#28582). *)
-  ; tool_name : string
-  ; keeper_id : string
-  ; turn_id : string
-  ; outcome : string
-  ; typed_outcome : string
-  ; duration_ms : float
-  ; output_text : string
-  ; input : Yojson.Safe.t
-  }
-
-type turn_event =
-  { base_path : string
-  ; partition : codebase_partition
-  ; turn_id : string
-  ; keeper_id : string
-  ; phase : string
-  ; model_used : string option
-  ; tools_used : string list
-  ; stop_reason : string option
-  ; duration_ms : int option
-  ; timestamp_ms : int64
-  }
-
 val canonical_url_of_remote : string -> string option
 (** [canonical_url_of_remote remote] normalises a git remote string into a
     deterministic host_path slug. Returns [None] for blank, malformed, or
@@ -99,9 +60,90 @@ module Code_address : sig
   val equal : t -> t -> bool
 end
 
+module Unattributed : sig
+  (** Typed reasons a write's file path failed attribution to a codebase.
+
+      RFC-0378 §5.1: attribution failure is a fact kind, not a store
+      partition — the reason rides the fact as a queryable field.
+      RFC-keeper-workspace-root-only 2a owns this vocabulary's evolution
+      once attribution moves to git observation. *)
+
+  type reason =
+    | Blank_remote_url
+    | Unparseable_remote_url of string
+    | Unregistered_repo_id of string
+    | Unregistered_path
+    | Repository_catalog_unavailable
+
+  val reason_to_string : reason -> string
+end
+
+type addressed =
+  { address : Code_address.t
+  ; checkout : string option
+        (** Projection metadata: which checkout the write was observed in.
+            Never part of the join key. [None] until attribution measures
+            it (workspace-root-only 2b). *)
+  }
+
+type unaddressed =
+  { reason : Unattributed.reason
+  ; attempted_path : string
+        (** The path exactly as the resolver saw it — forensic identity
+            for records that never joined a codebase. *)
+  }
+
+(** Where a fact that names a file belongs. An annotation or write region
+    always names a file, so [Pathless] is unrepresentable for them. *)
+type file_attribution =
+  | Addressed of addressed
+  | Unaddressed of unaddressed
+
+(** Where any tool fact belongs: a pathless call (coordination, board,
+    memory) is a keeper-timeline fact with no document — distinct from a
+    failed attribution. *)
+type attribution =
+  | File of file_attribution
+  | Pathless
+
+type tool_event =
+  { base_path : string
+  ; attribution : attribution
+        (** RFC-0378 §5.1: the address is minted where the write is
+            attributed and carried as a parsed value. Producers must not
+            hand consumers the raw tool argument — the resolver is the
+            only thing that knows which root the argument was relative
+            to, and a consumer re-deriving the path from [input] produced
+            three incompatible shapes in one partition (masc#28582). *)
+  ; tool_name : string
+  ; keeper_id : string
+  ; turn_id : string
+  ; outcome : string
+  ; typed_outcome : string
+  ; duration_ms : float
+  ; output_text : string
+  ; input : Yojson.Safe.t
+  }
+
+type turn_event =
+  { base_path : string
+  ; turn_id : string
+  ; keeper_id : string
+  ; phase : string
+  ; model_used : string option
+  ; tools_used : string list
+  ; stop_reason : string option
+  ; duration_ms : int option
+  ; timestamp_ms : int64
+  }
+(** A turn is a keeper-timeline fact by definition (RFC-0378): it can
+    touch any number of codebases, so it carries no attribution — the
+    per-codebase timeline is derived by joining addressed tool facts on
+    [turn_id]. *)
+
 type write_region_event =
   { base_path : string
-  ; partition : codebase_partition
+  ; attribution : file_attribution
   ; keeper_id : string
   ; turn : int
   ; tool_call_json : Yojson.Safe.t
@@ -138,9 +180,8 @@ val annotation_references_of_json :
 
 type annotation_request =
   { base_path : string
-  ; partition : codebase_partition
+  ; attribution : file_attribution
   ; keeper_id : string
-  ; file_path : string
   ; line_start : int
   ; line_end : int
   ; kind : annotation_kind

--- a/lib/agent_observation/agent_observation.mli
+++ b/lib/agent_observation/agent_observation.mli
@@ -83,6 +83,7 @@ module Code_address : sig
     | Malformed_codebase
     | Empty_path
     | Absolute_path
+    | Malformed_path
     | Unnormalized_path
 
   val invalid_to_string : invalid -> string
@@ -90,8 +91,8 @@ module Code_address : sig
   val v : codebase:string -> path:string -> (t, invalid) result
   (** Rejects rather than repairs: the codebase must already be a
       canonical slug and the path must already be a normalized relative
-      path — [.], [..], empty segments, and absolute paths are errors,
-      not inputs to fix. *)
+      path — malformed paths (including NUL bytes), [.], [..], empty
+      segments, and absolute paths are errors, not inputs to fix. *)
 
   val codebase : t -> string
   val path : t -> string

--- a/lib/agent_observation/agent_observation.mli
+++ b/lib/agent_observation/agent_observation.mli
@@ -66,6 +66,38 @@ val canonical_url_of_remote : string -> string option
     deterministic host_path slug. Returns [None] for blank, malformed, or
     traversal-looking inputs. *)
 
+module Code_address : sig
+  type t
+  (** A code fact's address: [(codebase, path)] where [codebase] is a
+      canonical host_path slug (the partitioned store's directory name,
+      {!canonical_url_of_remote} output) and [path] is the file's
+      repo-root-relative path.
+
+      RFC-0378 §5.1: the address is minted once where the write is
+      attributed; consumers carry the value and never re-derive either
+      half from tool input or store layout. The type is abstract so a
+      raw string cannot stand in for a parsed address. *)
+
+  type invalid =
+    | Empty_codebase
+    | Malformed_codebase
+    | Empty_path
+    | Absolute_path
+    | Unnormalized_path
+
+  val invalid_to_string : invalid -> string
+
+  val v : codebase:string -> path:string -> (t, invalid) result
+  (** Rejects rather than repairs: the codebase must already be a
+      canonical slug and the path must already be a normalized relative
+      path — [.], [..], empty segments, and absolute paths are errors,
+      not inputs to fix. *)
+
+  val codebase : t -> string
+  val path : t -> string
+  val equal : t -> t -> bool
+end
+
 type write_region_event =
   { base_path : string
   ; partition : codebase_partition

--- a/lib/agent_observation/agent_observation.mli
+++ b/lib/agent_observation/agent_observation.mli
@@ -74,6 +74,10 @@ module Unattributed : sig
     | Unregistered_repo_id of string
     | Unregistered_path
     | Repository_catalog_unavailable
+    | Unmintable of Code_address.invalid
+        (** The repo and relative path were recovered but the address
+            constructor rejected the residue — a resolver invariant
+            break carried for diagnosis instead of collapsed. *)
 
   val reason_to_string : reason -> string
 end

--- a/lib/agent_observation/dune
+++ b/lib/agent_observation/dune
@@ -7,4 +7,4 @@
  (modules agent_observation)
  (flags
   (:standard -w +4 -w +33))
- (libraries yojson))
+ (libraries fpath yojson))

--- a/lib/ide/ide_annotations.ml
+++ b/lib/ide/ide_annotations.ml
@@ -263,7 +263,7 @@ let load_all_partition ?stop_before_compact_begin_id ~base_dir partition =
 
 let create
       ~base_dir
-      ?(partition = Ide_paths.Legacy_default)
+      ~partition
       ~keeper_id
       ~file_path
       ~line_start

--- a/lib/ide/ide_annotations.mli
+++ b/lib/ide/ide_annotations.mli
@@ -30,7 +30,7 @@ val ensure_store : base_dir:string -> ?partition:Ide_paths.partition -> unit -> 
 
 val create
   :  base_dir:string
-  -> ?partition:Ide_paths.partition
+  -> partition:Ide_paths.partition
   -> keeper_id:string
   -> file_path:string
   -> line_start:int

--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -5,6 +5,34 @@ open Ide_event_types
 
 let default_partition = Ide_paths.Legacy_default
 
+(* RFC-0378 A rung: storage routing from attribution with the layout
+   unchanged — an addressed fact goes to its by-url partition, anything
+   else to the orphan directory. The directory split for keeper facts
+   ([keeper/<id>/]) is the B rung. *)
+let storage_partition_of_file_attribution = function
+  | Agent_observation.Addressed { address; _ } ->
+    Ide_paths.By_url (Agent_observation.Code_address.codebase address)
+  | Agent_observation.Unaddressed _ -> default_partition
+;;
+
+let storage_partition_of_attribution = function
+  | Agent_observation.File file_attribution ->
+    storage_partition_of_file_attribution file_attribution
+  | Agent_observation.Pathless -> default_partition
+;;
+
+let file_path_of_file_attribution = function
+  | Agent_observation.Addressed { address; _ } ->
+    Agent_observation.Code_address.path address
+  | Agent_observation.Unaddressed { attempted_path; _ } -> attempted_path
+;;
+
+let file_path_of_attribution = function
+  | Agent_observation.File file_attribution ->
+    Some (file_path_of_file_attribution file_attribution)
+  | Agent_observation.Pathless -> None
+;;
+
 type event_kind =
   | Tool
   | Turn
@@ -429,7 +457,7 @@ let list_events
 
 let ingest_tool_event
     ~base_path
-    ?(partition = default_partition)
+    ~partition
     ~tool_name
     ~keeper_id
     ~turn_id
@@ -471,7 +499,6 @@ let ingest_tool_event
 
 let ingest_turn_event
     ~base_path
-    ~partition
     ~turn_id
     ~keeper_id
     ~phase
@@ -481,13 +508,11 @@ let ingest_turn_event
     ~duration_ms
     ~timestamp_ms
   =
-  (* DEFER (task-1733): the turn-event emit (keeper_agent_run.ml) resolves only
-     [config.base_path] because a turn carries no edited file_path, and no
-     keeper->active-repo/canonical_url mapping exists today. So [partition]
-     forwarded here is typically the coarse orphan partition. Forwarding it
-     (instead of hardcoding [default_partition]) removes the silent hardcode and
-     lets a future keeper->repo source flow through unchanged. Real per-turn
-     attribution requires that new source — tracked as task-1733 follow-up. *)
+  (* RFC-0378: a turn is a keeper-timeline fact — it can touch any number
+     of codebases, so it carries no attribution and the per-codebase
+     timeline is a join on [turn_id]. Routed to the shared orphan
+     directory until the B rung gives keeper facts their own store. *)
+  let partition = default_partition in
   let event =
     Turn_event
       { turn_id
@@ -703,8 +728,7 @@ let ingest_cursor_event
     Separated for direct testability. *)
 let ingest_tool_event_from_hook
     ~base_path
-    ~partition
-    ~file_path
+    ~attribution
     ~tool_name
     ~keeper_id
     ~turn_id
@@ -714,11 +738,14 @@ let ingest_tool_event_from_hook
     ~output_text
     ~(input : Yojson.Safe.t)
   =
-  (* [file_path] arrives resolved, from the same helper that decided
-     [partition]. Re-deriving it from [input] here is what put absolute host
-     paths, sandbox-rooted [repos/<id>/…] paths, and repo-relative paths in one
-     partition, none of which a reader can join against the region and
-     annotation rows the same resolver produced (masc#28582). *)
+  (* The attribution arrives minted (RFC-0378 §5.1); storage partition and
+     file path are both projections of it. Re-deriving the path from
+     [input] here is what put absolute host paths, sandbox-rooted
+     [repos/<id>/…] paths, and repo-relative paths in one partition, none
+     of which a reader can join against the region and annotation rows
+     the same resolver produced (masc#28582). *)
+  let partition = storage_partition_of_attribution attribution in
+  let file_path = file_path_of_attribution attribution in
   let summary =
     String_util.utf8_safe ~max_bytes:200 ~suffix:"" output_text
     |> String_util.to_string
@@ -771,8 +798,7 @@ let install_agent_observation_sinks () =
       Ide_ingest_queue.submit (fun () ->
         ingest_tool_event_from_hook
           ~base_path:event.base_path
-          ~partition:event.partition
-          ~file_path:event.file_path
+          ~attribution:event.attribution
           ~tool_name:event.tool_name
           ~keeper_id:event.keeper_id
           ~turn_id:event.turn_id
@@ -784,11 +810,8 @@ let install_agent_observation_sinks () =
   Agent_observation.register_turn_event_sink
     (fun (event : Agent_observation.turn_event) ->
       Ide_ingest_queue.submit (fun () ->
-        (* turn: forward event.partition (coarse today — see ingest_turn_event
-           DEFER note; keeper->repo mapping is task-1733 follow-up). *)
         ingest_turn_event
           ~base_path:event.base_path
-          ~partition:event.partition
           ~turn_id:event.turn_id
           ~keeper_id:event.keeper_id
           ~phase:event.phase
@@ -802,7 +825,7 @@ let install_agent_observation_sinks () =
       try
         Ide_region_tracker.ingest_tool_call
           ~base_dir:event.base_path
-          ~partition:event.partition
+          ~partition:(storage_partition_of_file_attribution event.attribution)
           ~keeper_id:event.keeper_id
           ~turn:event.turn
           event.tool_call_json;
@@ -816,9 +839,8 @@ let install_agent_observation_sinks () =
         Error Agent_observation.Write_region_sink_failed);
   Agent_observation.register_annotation_sink
     (fun ({ base_path
-           ; partition
+           ; attribution
            ; keeper_id
-           ; file_path
            ; line_start
            ; line_end
            ; kind
@@ -831,9 +853,9 @@ let install_agent_observation_sinks () =
       match
         Ide_annotations.create
           ~base_dir:base_path
-          ~partition
+          ~partition:(storage_partition_of_file_attribution attribution)
           ~keeper_id
-          ~file_path
+          ~file_path:(file_path_of_file_attribution attribution)
           ~line_start
           ~line_end
           ~kind

--- a/lib/ide/ide_bridge.mli
+++ b/lib/ide/ide_bridge.mli
@@ -66,7 +66,7 @@ val observation_snapshot_json : take:bool -> Yojson.Safe.t
 
 val ingest_tool_event :
   base_path:string ->
-  ?partition:Ide_paths.partition ->
+  partition:Ide_paths.partition ->
   tool_name:string ->
   keeper_id:string ->
   turn_id:string ->
@@ -78,10 +78,13 @@ val ingest_tool_event :
   timestamp_ms:int64 ->
   unit ->
   unit
+(** Low-level writer: the caller names the storage partition and the
+    file path explicitly. Producers go through
+    {!ingest_tool_event_from_hook}, which projects both from the fact's
+    attribution. *)
 
 val ingest_turn_event :
   base_path:string ->
-  partition:Ide_paths.partition ->
   turn_id:string ->
   keeper_id:string ->
   phase:string ->
@@ -91,13 +94,14 @@ val ingest_turn_event :
   duration_ms:int option ->
   timestamp_ms:int64 ->
   unit
+(** RFC-0378: a turn is a keeper-timeline fact and carries no
+    attribution — the per-codebase timeline is a join on [turn_id]. *)
 
 (** Extract and ingest tool event from raw hook parameters.
     [typed_outcome_str] is pre-computed from [Keeper_tool_outcome.t]. *)
 val ingest_tool_event_from_hook :
   base_path:string ->
-  partition:Ide_paths.partition ->
-  file_path:string option ->
+  attribution:Agent_observation.attribution ->
   tool_name:string ->
   keeper_id:string ->
   turn_id:string ->

--- a/lib/ide/ide_region_tracker.ml
+++ b/lib/ide/ide_region_tracker.ml
@@ -116,7 +116,7 @@ let rec ensure_dir path =
     try Unix.mkdir path 0o755 with
     | Unix.Unix_error (Unix.EEXIST, _, _) -> ())
 
-let append_region ~base_dir ?(partition = Ide_paths.Legacy_default) region =
+let append_region ~base_dir ~partition region =
   let path = regions_file ~base_dir ~partition () in
   ensure_dir (Filename.dirname path);
   Fs_compat.append_jsonl path (region_to_json region)
@@ -143,7 +143,7 @@ let load_regions_from_path ?file_path path =
 let read_regions ~base_dir ?(partition = Ide_paths.Legacy_default) ?file_path () =
   load_regions_from_path ?file_path (regions_file ~base_dir ~partition ())
 
-let ingest_tool_call ~base_dir ?(partition = Ide_paths.Legacy_default) ~keeper_id ~turn json =
+let ingest_tool_call ~base_dir ~partition ~keeper_id ~turn json =
   let tool_name =
     match json with
     | `Assoc fields -> (

--- a/lib/ide/ide_region_tracker.mli
+++ b/lib/ide/ide_region_tracker.mli
@@ -46,7 +46,7 @@ val regions_file
 
 val append_region
   :  base_dir:string
-  -> ?partition:Ide_paths.partition
+  -> partition:Ide_paths.partition
   -> code_region
   -> unit
 (** Append one region to the chosen partition's [regions.jsonl].
@@ -54,7 +54,7 @@ val append_region
 
 val ingest_tool_call
   :  base_dir:string
-  -> ?partition:Ide_paths.partition
+  -> partition:Ide_paths.partition
   -> keeper_id:string
   -> turn:int
   -> Yojson.Safe.t

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -431,13 +431,8 @@ let run_turn
   in
   let user_message = Keeper_run_prompt.sanitize_user_message user_message in
   Masc_runtime_events.emit_turn_start ();
-  let partition, _ =
-    Keeper_tool_filesystem_runtime.resolve_partition_for_write
-      ~base_dir:config.base_path ~kind:"turn_event" ~file_path:config.base_path
-  in
   Agent_observation.emit_turn_event
     { base_path = config.base_path
-    ; partition
     ; turn_id =
         (match meta.current_task_id with
          | Some t -> Keeper_id.Task_id.to_string t
@@ -464,13 +459,8 @@ let run_turn
   let emit_observation_turn_end ~phase ~stop_reason () =
     let duration_ms = int_of_float ((Unix.gettimeofday () -. turn_start_time) *. 1000.0) in
     let turn_id = match meta.current_task_id with Some t -> Keeper_id.Task_id.to_string t | None -> "turn-" ^ meta.name in
-    let partition, _ =
-      Keeper_tool_filesystem_runtime.resolve_partition_for_write
-        ~base_dir:config.base_path ~kind:"turn_event" ~file_path:config.base_path
-    in
     Agent_observation.emit_turn_event
       { base_path = config.base_path
-      ; partition
       ; turn_id
       ; keeper_id = meta.name
       ; phase

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -124,23 +124,17 @@ let observation_file_path_from_tool_input ~sandbox_root input =
   | Some p -> Some p
 ;;
 
-(* Returns the partition the observation belongs to and the file path as the
-   resolver named it. A tool call that names no file still has a partition —
-   it is a keeper-timeline fact, attributed through the project root the way
-   turn events are — but it has no document, so the path is [None] rather than
-   the project root standing in for one. *)
-let observation_partition_for_tool_input ~config ~meta ~kind input =
+(* Returns where the tool fact belongs (RFC-0378 §5.1). A call that names
+   no file is [Pathless] — a keeper-timeline fact with no document — and
+   never touches the resolver; a call that names one gets the resolver's
+   attribution, minted once here and carried as a parsed value. *)
+let observation_attribution_for_tool_input ~config ~meta input =
   let base_dir = Keeper_alerting_path.project_root_of_config config in
   let sandbox_root =
     Keeper_tool_shared_runtime.keeper_observation_sandbox_root ~config ~meta
   in
-  let resolve file_path =
-    Keeper_tool_filesystem_runtime.resolve_partition_for_write ~base_dir ~kind ~file_path
-  in
   match observation_file_path_from_tool_input ~sandbox_root input with
-  | None ->
-    let partition, _ = resolve base_dir in
-    (partition, None)
+  | None -> Agent_observation.Pathless
   | Some visible ->
     let host_path =
       Keeper_tool_shared_runtime.keeper_observation_host_path_of_visible_path
@@ -148,8 +142,10 @@ let observation_partition_for_tool_input ~config ~meta ~kind input =
         ~meta
         visible
     in
-    let partition, resolved = resolve host_path in
-    (partition, Some resolved)
+    Agent_observation.File
+      (Keeper_tool_filesystem_runtime.resolve_write_attribution
+         ~base_dir
+         ~file_path:host_path)
 ;;
 
 let assemble_hooks
@@ -283,22 +279,17 @@ let assemble_hooks
              | Some t -> Keeper_id.Task_id.to_string t
              | None -> "turn-" ^ string_of_int (List.length acc.tool_calls)
            in
-           (* task-1733: resolve the partition from the tool's actual edited
-              file (input.path / input.file_path, with explicit cwd honoured
+           (* task-1733: attribute from the tool's actual edited file
+              (input.path / input.file_path, with explicit cwd honoured
               for relative paths), not from the [.masc] runtime root.
               #23469: relative shapes anchor at this keeper's playground
               sandbox root, matching the file tools' own resolution. *)
-           let partition, observed_file_path =
-             observation_partition_for_tool_input
-               ~config
-               ~meta:acc.meta
-               ~kind:"tool_event"
-               input
+           let attribution =
+             observation_attribution_for_tool_input ~config ~meta:acc.meta input
            in
            Agent_observation.emit_tool_event
              { base_path = config.base_path
-             ; partition
-             ; file_path = observed_file_path
+             ; attribution
              ; tool_name
              ; keeper_id = acc.meta.name
              ; turn_id

--- a/lib/keeper/keeper_tool_filesystem_runtime.ml
+++ b/lib/keeper/keeper_tool_filesystem_runtime.ml
@@ -575,98 +575,92 @@ let apply_patch ~old_string ~new_string ~replace_all text =
       Ok (Buffer.contents buf, occurrences)))
 ;;
 
-(* RFC-0128 §4.5 — resolve an absolute or base-relative file_path to
-   a partition + repo-relative path. Four outcomes:
+(* RFC-0378 §5.1 — resolve a write's file path to its attribution.
 
-   1. [Repo_store.find_repo_by_path_prefix] hits AND the repo's [url]
-      normalises via [Agent_observation.canonical_url_of_remote] → [By_url slug]
-      bucket + the repo-relative [rel_path].
-   2. [Repo_store.find_repo_by_path_prefix] hits but the URL is blank or
-      unparseable → [No_canonical_url] + original path. Counter labelled
-      [reason=blank_url] or [reason=url_unparseable].
-   3. A sandbox playground [repo_id] is not present in the repository store →
-      [Unmatched] + original path. Counter labelled
-      [reason=sandbox_unregistered_repo].
-   4. No registered repo contains this path → [Base_unresolved] + original path.
-      Counter labelled [reason=unregistered_repo].
+   This is the system's only [Code_address] mint: it anchors the path,
+   recovers the owning repository (sandbox playground parse or
+   registered local_path prefix), lexically collapses dot segments, and
+   constructs the address. Attribution failure is a typed fact kind
+   carried on the record as [Unaddressed { reason; attempted_path }] —
+   not an exception. Total: never raises.
 
-   The keeper write path is fire-and-forget; this resolver also never
-   raises — unresolved paths degrade to typed non-[By_url] partitions with
-   metric labels so the operator can see how often each reason appears. *)
-let resolve_partition_for_write ~base_dir ~kind ~file_path =
+   Keeper writes inside the sandbox playground never appear under a
+   registered repo's [local_path] (the playground clone path is opaque
+   to [repositories.toml]), so the SSOT
+   {!Playground_paths.parse_playground_repo_path} recovers the
+   [(repo_id, rel)] pair first and the repository URL is looked up by
+   id. This makes the sandbox/working-tree join work without forcing
+   the operator to register every playground clone path. *)
+let resolve_write_attribution ~base_dir ~file_path =
   let abs =
     if Filename.is_relative file_path
     then Filename.concat base_dir file_path
     else file_path
   in
-  let bump_orphan ~reason =
-    Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string IdeOrphanWrites)
-      ~labels:[ "kind", kind; "reason", reason ]
-      ()
+  let unaddressed reason =
+    Agent_observation.Unaddressed { reason; attempted_path = file_path }
   in
-  let resolve_by_url ~rel ~repo_url ~orphan_reasons =
+  (* Lexical dot-segment collapse. [None] when the path escapes the
+     repo root — such a path does not name a file of the matched repo,
+     so it fails attribution rather than being repaired. *)
+  let normalize_rel rel =
+    let rec go acc = function
+      | [] -> Some (List.rev acc)
+      | ("" | ".") :: rest -> go acc rest
+      | ".." :: rest ->
+        (match acc with
+         | [] -> None
+         | _ :: tl -> go tl rest)
+      | seg :: rest -> go (seg :: acc) rest
+    in
+    match go [] (String.split_on_char '/' rel) with
+    | None | Some [] -> None
+    | Some segs -> Some (String.concat "/" segs)
+  in
+  let mint ~rel ~repo_url =
     let url = String.trim repo_url in
-    if url = "" then begin
-      bump_orphan ~reason:(snd orphan_reasons);
-      (Agent_observation.No_canonical_url, file_path)
-    end
+    if url = ""
+    then unaddressed Agent_observation.Unattributed.Blank_remote_url
     else
       match Agent_observation.canonical_url_of_remote url with
       | None ->
-        bump_orphan ~reason:(fst orphan_reasons);
-        (Agent_observation.No_canonical_url, file_path)
-      | Some slug -> (Agent_observation.By_url slug, rel)
+        unaddressed (Agent_observation.Unattributed.Unparseable_remote_url url)
+      | Some slug ->
+        (match normalize_rel rel with
+         | None -> unaddressed Agent_observation.Unattributed.Unregistered_path
+         | Some rel ->
+           (match Agent_observation.Code_address.v ~codebase:slug ~path:rel with
+            | Ok address -> Agent_observation.Addressed { address; checkout = None }
+            | Error invalid ->
+              unaddressed (Agent_observation.Unattributed.Unmintable invalid)))
   in
-  (* RFC-0128 §4.5 PR-6: keeper writes inside the sandbox playground
-     never appear under a registered repo's [local_path] (the playground
-     clone path is opaque to [repositories.toml]). Use the SSOT
-     {!Playground_paths.parse_playground_repo_path} to recover the
-     [(repo_id, rel)] pair, then look up the repository's URL by id.
-     This makes the sandbox/working-tree join work without forcing the
-     operator to also register every playground clone path. *)
   match
     Playground_paths.parse_playground_repo_path ~base_path:base_dir ~abs_path:abs
   with
   | Some (repo_id, rel) ->
     (match Repo_store.find_url_by_id ~base_path:base_dir repo_id with
-     | Ok (Some url) ->
-       resolve_by_url
-         ~rel
-         ~repo_url:url
-         ~orphan_reasons:("sandbox_url_unparseable", "sandbox_blank_url")
+     | Ok (Some url) -> mint ~rel ~repo_url:url
      | Ok None ->
-       bump_orphan ~reason:"sandbox_unregistered_repo";
-       (Agent_observation.Unmatched, file_path)
+       unaddressed (Agent_observation.Unattributed.Unregistered_repo_id repo_id)
      | Error _ ->
-       bump_orphan ~reason:"repository_catalog_unavailable";
-       (Agent_observation.Unmatched, file_path))
+       unaddressed Agent_observation.Unattributed.Repository_catalog_unavailable)
   | None ->
     (match Repo_store.find_repo_by_path_prefix ~base_path:base_dir abs with
-     | Ok None ->
-       bump_orphan ~reason:"unregistered_repo";
-       (Agent_observation.Base_unresolved, file_path)
-     | Ok (Some (repo, rel)) ->
-       resolve_by_url
-         ~rel
-         ~repo_url:repo.url
-         ~orphan_reasons:("url_unparseable", "blank_url")
+     | Ok (Some (repo, rel)) -> mint ~rel ~repo_url:repo.url
+     | Ok None -> unaddressed Agent_observation.Unattributed.Unregistered_path
      | Error _ ->
-       bump_orphan ~reason:"repository_catalog_unavailable";
-       (Agent_observation.Base_unresolved, file_path))
+       unaddressed Agent_observation.Unattributed.Repository_catalog_unavailable)
 ;;
 
-(** After a successful file write, record the code region in [.masc-ide/].
-    Fire-and-forget: errors are logged but never block the write path.
-    Emits a neutral [Agent_observation.write_region_event]; the IDE adapter
-    registers the concrete region-tracker sink.
+(** After a successful file write, record the code region in the IDE
+    observation store. Fire-and-forget: errors are logged but never
+    block the write path. Emits a neutral
+    [Agent_observation.write_region_event]; the IDE adapter registers
+    the concrete region-tracker sink.
 
-    RFC-0128 §4.5: the partition is resolved per-write from the
-    [file_path] so sandbox-clone keeper writes and working-tree IDE
-    reads see the same [By_url <slug>] bucket. When the path cannot
-    be resolved to a registered repo the record goes to
-    [.masc-ide/_orphan/] and the [masc_ide_orphan_writes_total]
-    counter increments. *)
+    RFC-0378 §5.1: the attribution is minted per-write from the
+    [file_path], so sandbox-clone keeper writes and working-tree IDE
+    reads join on the same [Code_address]. *)
 let track_write_region
       ~config
       ~keeper_name
@@ -679,8 +673,12 @@ let track_write_region
       ()
   =
   let base_dir = Keeper_alerting_path.project_root_of_config config in
-  let partition, rel_file_path =
-    resolve_partition_for_write ~base_dir ~kind:"region" ~file_path
+  let attribution = resolve_write_attribution ~base_dir ~file_path in
+  let rel_file_path =
+    match attribution with
+    | Agent_observation.Addressed { address; _ } ->
+      Agent_observation.Code_address.path address
+    | Agent_observation.Unaddressed { attempted_path; _ } -> attempted_path
   in
   let tool_name =
     match fs_write_mode_of_string_opt mode_raw with
@@ -714,7 +712,7 @@ let track_write_region
   try
     match
       Agent_observation.emit_write_region_event
-        { base_path = base_dir; partition; keeper_id = keeper_name; turn; tool_call_json }
+        { base_path = base_dir; attribution; keeper_id = keeper_name; turn; tool_call_json }
     with
     | Ok () -> None
     | Error err ->

--- a/lib/keeper/keeper_tool_filesystem_runtime.mli
+++ b/lib/keeper/keeper_tool_filesystem_runtime.mli
@@ -4,36 +4,22 @@ val valid_fs_write_mode_strings : string list
 (** The canonical enum [Tool_shard_types_enum_mirrors.fs_write_mode_enum_strings]
     hand-copies. Exported so test_enum_mirror_sync can compare the copy against
     it; the mirror module names this value as the owner. *)
-val resolve_partition_for_write
+val resolve_write_attribution
   :  base_dir:string
-  -> kind:string
   -> file_path:string
-  -> Agent_observation.codebase_partition * string
-(** RFC-0128 §4.5. Reverse-lookup helper used by [track_write_region]
-    to decide which neutral observation partition a keeper write
-    belongs to and what its repo-relative file path is. Exposed for
-    testing so the sandbox/working-tree join invariant can be
-    verified directly.
+  -> Agent_observation.file_attribution
+(** RFC-0378 §5.1. The system's only [Code_address] mint, used by
+    [track_write_region] and the tool-event hook to decide where a
+    keeper write belongs. Exposed for testing so the
+    sandbox/working-tree join invariant can be verified directly.
 
-    Returns:
-    - [(By_url slug, rel_path)] when the file lives under a registered
-      repository whose [url] normalises via
-      {!Agent_observation.canonical_url_of_remote}. [rel_path] is the path
-      relative to that repository's [local_path].
-    - [(No_canonical_url, original_path)] when a matched repository has a blank
-      or malformed [url].
-    - [(Base_unresolved, original_path)] when no registered repository contains
-      the path.
-    - [(Unmatched, original_path)] when a sandbox playground [repo_id] cannot
-      be found in the repository store.
-
-      The three non-[By_url] variants all write under the shared
-      [.masc-ide/_orphan/] directory, but keep the typed reason in memory and
-      in emitted observation records. Increments [masc_ide_orphan_writes_total]
-      with the concrete failure reason label ([unregistered_repo] /
-      [blank_url] / [url_unparseable] / sandbox variants).
-
-    [kind] selects the metric label ([annotation] or [region]). *)
+    [Addressed] carries the parsed address when the file lives under a
+    registered repository (sandbox playground parse or [local_path]
+    prefix) whose [url] normalises via
+    {!Agent_observation.canonical_url_of_remote}; the repo-relative
+    path is lexically dot-collapsed before minting. [Unaddressed]
+    carries the typed reason and the path exactly as the resolver saw
+    it. Total — never raises. *)
 
 val handle_read_file_with_outcome :
   turn_sandbox_factory:Keeper_sandbox_factory.t option ->

--- a/lib/keeper/keeper_tool_ide_runtime.ml
+++ b/lib/keeper/keeper_tool_ide_runtime.ml
@@ -84,16 +84,16 @@ let handle_ide_annotate_with_outcome
        else file_path)
       |> keeper_observation_host_path_of_visible_path ~config ~meta
     in
-    let partition, stored_file_path =
-      Keeper_tool_filesystem_runtime.resolve_partition_for_write
-        ~base_dir:base_dir ~kind:"annotation" ~file_path:anchored_file_path
+    let attribution =
+      Keeper_tool_filesystem_runtime.resolve_write_attribution
+        ~base_dir
+        ~file_path:anchored_file_path
     in
     match
       Agent_observation.emit_annotation_request
         { base_path = base_dir
-        ; partition
+        ; attribution
         ; keeper_id = meta.name
-        ; file_path = stored_file_path
         ; line_start
         ; line_end
         ; kind

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -262,6 +262,7 @@ normal_targets=(
   @test/runtest-test_keeper_run_tools_hooks
   @test/runtest-test_keeper_connector_attention_batch
   @test/runtest-test_ide_lsp_join_key
+  @test/runtest-test_code_address
   @test/runtest-test_dashboard_workspace
   @test/runtest-test_host_fd_pressure_poller
   @test/runtest-test_keeper_turn_driver_failover

--- a/test/dune
+++ b/test/dune
@@ -2576,3 +2576,8 @@
 (include stanzas/test_keeper_operator_note.inc)
 
 (include stanzas/test_keeper_memory_journal_projection.inc)
+
+(test
+ (name test_code_address)
+ (modules test_code_address)
+ (libraries alcotest masc_agent_observation))

--- a/test/test_agent_observation_bridge.ml
+++ b/test/test_agent_observation_bridge.ml
@@ -37,15 +37,27 @@ let install_fresh_ide_sink () =
   Ide_bridge.install_agent_observation_sinks ()
 ;;
 
+(* RFC-0378 A2: test-side attribution builders ([file_attribution] for
+   region/annotation facts; wrap in [File] for tool facts). *)
+let unattributed_file attempted_path =
+  Agent_observation.Unaddressed
+    { reason = Agent_observation.Unattributed.Unregistered_path; attempted_path }
+;;
+
+let addressed_file ~codebase ~path =
+  match Agent_observation.Code_address.v ~codebase ~path with
+  | Ok address -> Agent_observation.Addressed { address; checkout = None }
+  | Error e -> failwith (Agent_observation.Code_address.invalid_to_string e)
+;;
+
 let test_tool_observation_reaches_ide_storage_and_cursor () =
   with_temp_dir (fun base_dir ->
     install_fresh_ide_sink ();
     Agent_observation.emit_tool_event
       { base_path = base_dir
-      ; partition = Agent_observation.Legacy_default
-        (* The producer resolves this alongside the partition; the raw
-           [input] below still carries the argument the keeper typed. *)
-      ; file_path = Some "lib/test.ml"
+      ; attribution = Agent_observation.File (unattributed_file "lib/test.ml")
+        (* The producer mints this from the resolver; the raw [input]
+           below still carries the argument the keeper typed. *)
       ; tool_name = "keeper_ide_annotate"
       ; keeper_id = "keeper-alpha"
       ; turn_id = "turn-9"
@@ -77,7 +89,6 @@ let test_turn_observation_reaches_ide_storage () =
     install_fresh_ide_sink ();
     Agent_observation.emit_turn_event
       { base_path = base_dir
-      ; partition = Agent_observation.Legacy_default
       ; turn_id = "turn-10"
       ; keeper_id = "keeper-beta"
       ; phase = "completed"
@@ -97,11 +108,13 @@ let test_turn_observation_reaches_ide_storage () =
 let test_write_region_observation_reaches_ide_storage () =
   with_temp_dir (fun base_dir ->
     install_fresh_ide_sink ();
-    let partition = Agent_observation.By_url "github.com_owner_repo" in
+    let attribution =
+      addressed_file ~codebase:"github.com_owner_repo" ~path:"lib/region.ml"
+    in
     (match
        Agent_observation.emit_write_region_event
          { base_path = base_dir
-         ; partition
+         ; attribution
          ; keeper_id = "keeper-delta"
          ; turn = 12
          ; tool_call_json =
@@ -145,7 +158,7 @@ let test_write_region_no_sink_returns_error () =
     let result =
       Agent_observation.emit_write_region_event
         { base_path = base_dir
-        ; partition = Agent_observation.Legacy_default
+        ; attribution = unattributed_file "lib/region.ml"
         ; keeper_id = "keeper-delta"
         ; turn = 12
         ; tool_call_json =
@@ -174,9 +187,8 @@ let test_annotation_request_reaches_ide_storage () =
     let result =
       Agent_observation.emit_annotation_request
         { base_path = base_dir
-        ; partition = Agent_observation.Legacy_default
+        ; attribution = unattributed_file "lib/annotated.ml"
         ; keeper_id = "keeper-epsilon"
-        ; file_path = "lib/annotated.ml"
         ; line_start = 7
         ; line_end = 9
         ; kind = Agent_observation.Decision
@@ -255,8 +267,7 @@ let test_snapshot_reset_clears_accumulated_observations () =
   Agent_observation.reset_for_testing ();
   Agent_observation.emit_tool_event
     { base_path = "/tmp/masc"
-    ; partition = Agent_observation.Legacy_default
-    ; file_path = None
+    ; attribution = Agent_observation.Pathless
     ; tool_name = "execute"
     ; keeper_id = "keeper-snapshot"
     ; turn_id = "turn-1"
@@ -282,7 +293,7 @@ let test_write_region_snapshot_uses_tool_call_payload () =
   let result =
     Agent_observation.emit_write_region_event
       { base_path = "/tmp/masc"
-      ; partition = Agent_observation.By_url "github.com_owner_repo"
+      ; attribution = addressed_file ~codebase:"github.com_owner_repo" ~path:"lib/region.ml"
       ; keeper_id = "keeper-region"
       ; turn = 7
       ; tool_call_json =

--- a/test/test_code_address.ml
+++ b/test/test_code_address.ml
@@ -93,6 +93,13 @@ let () =
             `Quick
             (check_rejected ~codebase:"github.com_x_y" ~path:"" A.Empty_path)
         ; Alcotest.test_case
+            "NUL byte"
+            `Quick
+            (check_rejected
+               ~codebase:"github.com_x_y"
+               ~path:"lib/\x00secret.ml"
+               A.Malformed_path)
+        ; Alcotest.test_case
             "empty codebase"
             `Quick
             (check_rejected ~codebase:"" ~path:"lib/x.ml" A.Empty_codebase)

--- a/test/test_code_address.ml
+++ b/test/test_code_address.ml
@@ -1,0 +1,109 @@
+(* RFC-0378 §5.1 — the address parse boundary.
+
+   Feature under test: every slug the attribution path can emit is
+   constructible into a [Code_address.t], two transport spellings of the
+   same remote mint the same address, and every shape the partitioned
+   store cannot join on is rejected at mint time instead of landing as an
+   unreadable record. *)
+
+module A = Agent_observation.Code_address
+
+let check_ok ~codebase ~path () =
+  match A.v ~codebase ~path with
+  | Ok addr ->
+    Alcotest.(check string) "codebase" codebase (A.codebase addr);
+    Alcotest.(check string) "path" path (A.path addr)
+  | Error e -> Alcotest.failf "expected Ok, got %s" (A.invalid_to_string e)
+;;
+
+let check_rejected ~codebase ~path expected () =
+  match A.v ~codebase ~path with
+  | Ok _ -> Alcotest.fail "expected rejection"
+  | Error e ->
+    Alcotest.(check string)
+      "reason"
+      (A.invalid_to_string expected)
+      (A.invalid_to_string e)
+;;
+
+let slug_of remote =
+  match Agent_observation.canonical_url_of_remote remote with
+  | Some s -> s
+  | None -> Alcotest.failf "canonical_url_of_remote rejected %s" remote
+;;
+
+let test_resolver_output_is_always_constructible () =
+  check_ok
+    ~codebase:(slug_of "https://github.com/jeong-sik/masc.git")
+    ~path:"lib/ide/ide_paths.ml"
+    ()
+;;
+
+let test_transport_spellings_mint_the_same_address () =
+  let a = A.v ~codebase:(slug_of "git@github.com:jeong-sik/masc.git") ~path:"lib/x.ml" in
+  let b = A.v ~codebase:(slug_of "https://github.com/jeong-sik/masc") ~path:"lib/x.ml" in
+  match a, b with
+  | Ok a, Ok b -> Alcotest.(check bool) "same address" true (A.equal a b)
+  | _ -> Alcotest.fail "construction failed"
+;;
+
+let () =
+  Alcotest.run
+    "code_address"
+    [ ( "mint"
+      , [ Alcotest.test_case
+            "resolver output constructs"
+            `Quick
+            test_resolver_output_is_always_constructible
+        ; Alcotest.test_case
+            "transport-independent join"
+            `Quick
+            test_transport_spellings_mint_the_same_address
+        ; Alcotest.test_case
+            "valid literal"
+            `Quick
+            (check_ok ~codebase:"github.com_jeong-sik_masc" ~path:"lib/ide/ide_paths.ml")
+        ] )
+    ; ( "reject"
+      , [ Alcotest.test_case
+            "absolute path"
+            `Quick
+            (check_rejected ~codebase:"github.com_x_y" ~path:"/etc/passwd" A.Absolute_path)
+        ; Alcotest.test_case
+            "dotdot segment"
+            `Quick
+            (check_rejected
+               ~codebase:"github.com_x_y"
+               ~path:"lib/../secrets"
+               A.Unnormalized_path)
+        ; Alcotest.test_case
+            "dot segment"
+            `Quick
+            (check_rejected ~codebase:"github.com_x_y" ~path:"./lib/x.ml" A.Unnormalized_path)
+        ; Alcotest.test_case
+            "empty segment"
+            `Quick
+            (check_rejected ~codebase:"github.com_x_y" ~path:"lib//x.ml" A.Unnormalized_path)
+        ; Alcotest.test_case
+            "trailing slash"
+            `Quick
+            (check_rejected ~codebase:"github.com_x_y" ~path:"lib/" A.Unnormalized_path)
+        ; Alcotest.test_case
+            "empty path"
+            `Quick
+            (check_rejected ~codebase:"github.com_x_y" ~path:"" A.Empty_path)
+        ; Alcotest.test_case
+            "empty codebase"
+            `Quick
+            (check_rejected ~codebase:"" ~path:"lib/x.ml" A.Empty_codebase)
+        ; Alcotest.test_case
+            "uppercase codebase"
+            `Quick
+            (check_rejected ~codebase:"GitHub.com_x" ~path:"lib/x.ml" A.Malformed_codebase)
+        ; Alcotest.test_case
+            "slash in codebase"
+            `Quick
+            (check_rejected ~codebase:"github.com/x" ~path:"lib/x.ml" A.Malformed_codebase)
+        ] )
+    ]
+;;

--- a/test/test_ide_annotations.ml
+++ b/test/test_ide_annotations.ml
@@ -234,6 +234,7 @@ let test_region_tracker_writes_fixed_regions_file () =
   with_temp_dir (fun base_dir ->
     Region.ingest_tool_call
       ~base_dir
+      ~partition:Ide_paths.Legacy_default
       ~keeper_id:"sangsu"
       ~turn:7
       (`Assoc

--- a/test/test_ide_annotations.ml
+++ b/test/test_ide_annotations.ml
@@ -6,7 +6,7 @@ module Region = Ide_region_tracker
 module Lsp = Lsp_overlay_provider
 
 (* The overlay reader has to name the store it addresses. These cases write
-   through [Store.create]'s default partition, so they read that same one;
+   through the partition [Store.create] names explicitly, so they read that same one;
    the by-URL producer/reader join is covered in
    [test_ide_lsp_join_key.ml]. *)
 let legacy_partition = Some Ide_paths.Legacy_default
@@ -130,6 +130,7 @@ let test_create_lists_route_context () =
     match
       Store.create
         ~base_dir
+        ~partition:Ide_paths.Legacy_default
         ~keeper_id:"sangsu"
         ~file_path:"lib/keeper/keeper_tool_ide_runtime.ml"
         ~line_start:12
@@ -166,6 +167,7 @@ let test_lsp_overlay_exposes_route_context () =
     match
       Store.create
         ~base_dir
+        ~partition:Ide_paths.Legacy_default
         ~keeper_id:"sangsu"
         ~file_path:"lib/keeper/keeper_tool_ide_runtime.ml"
         ~line_start:12
@@ -348,6 +350,7 @@ let test_legacy_default_is_unchanged () =
     let _ =
       Store.create
         ~base_dir
+        ~partition:Ide_paths.Legacy_default
         ~keeper_id:"sangsu"
         ~file_path:"lib/foo.ml"
         ~line_start:1
@@ -523,6 +526,7 @@ let test_definition_links_at_line () =
     match
       Store.create
         ~base_dir
+        ~partition:Ide_paths.Legacy_default
         ~keeper_id:"k1"
         ~file_path:"lib/test.ml"
         ~line_start:10
@@ -556,6 +560,7 @@ let test_reference_locations_related () =
     match
       Store.create
         ~base_dir
+        ~partition:Ide_paths.Legacy_default
         ~keeper_id:"k1"
         ~file_path:"lib/a.ml"
         ~line_start:5
@@ -570,6 +575,7 @@ let test_reference_locations_related () =
       (match
          Store.create
            ~base_dir
+           ~partition:Ide_paths.Legacy_default
            ~keeper_id:"k1"
            ~file_path:"lib/a.ml"
            ~line_start:20
@@ -616,6 +622,7 @@ let test_document_symbols_lists () =
     match
       Store.create
         ~base_dir
+        ~partition:Ide_paths.Legacy_default
         ~keeper_id:"k1"
         ~file_path:"lib/test.ml"
         ~line_start:1
@@ -642,6 +649,7 @@ let test_folding_ranges_groups () =
     match
       Store.create
         ~base_dir
+        ~partition:Ide_paths.Legacy_default
         ~keeper_id:"k1"
         ~file_path:"lib/test.ml"
         ~line_start:1
@@ -655,6 +663,7 @@ let test_folding_ranges_groups () =
       (match
          Store.create
            ~base_dir
+           ~partition:Ide_paths.Legacy_default
            ~keeper_id:"k1"
            ~file_path:"lib/test.ml"
            ~line_start:3
@@ -677,6 +686,7 @@ let test_document_highlights_related () =
     match
       Store.create
         ~base_dir
+        ~partition:Ide_paths.Legacy_default
         ~keeper_id:"k1"
         ~file_path:"lib/test.ml"
         ~line_start:5
@@ -691,6 +701,7 @@ let test_document_highlights_related () =
       (match
          Store.create
            ~base_dir
+           ~partition:Ide_paths.Legacy_default
            ~keeper_id:"k1"
            ~file_path:"lib/test.ml"
            ~line_start:15
@@ -717,6 +728,7 @@ let test_compact_preserves_annotations () =
       match
         Store.create
           ~base_dir
+          ~partition:Ide_paths.Legacy_default
           ~keeper_id:"sangsu"
           ~file_path:"lib/x.ml"
           ~line_start:1
@@ -762,6 +774,7 @@ let make_alice_annotation base_dir =
   Result.get_ok
     (Store.create
        ~base_dir
+       ~partition:Ide_paths.Legacy_default
        ~keeper_id:"alice"
        ~file_path:"lib/a.ml"
        ~line_start:1
@@ -807,6 +820,7 @@ let create_note ~base_dir ~keeper_id ~content () =
   Result.get_ok
     (Store.create
        ~base_dir
+       ~partition:Ide_paths.Legacy_default
        ~keeper_id
        ~file_path:"lib/a.ml"
        ~line_start:1
@@ -908,6 +922,7 @@ let make_cas_annotation base_dir =
   Result.get_ok
     (Store.create
        ~base_dir
+       ~partition:Ide_paths.Legacy_default
        ~keeper_id:"alice"
        ~file_path:"lib/a.ml"
        ~line_start:1
@@ -933,6 +948,7 @@ let test_concurrent_create_compact_no_loss () =
             match
               Store.create
                 ~base_dir
+                ~partition:Ide_paths.Legacy_default
                 ~keeper_id:"alice"
                 ~file_path:"lib/a.ml"
                 ~line_start:1

--- a/test/test_ide_bridge.ml
+++ b/test/test_ide_bridge.ml
@@ -2,6 +2,20 @@
 
 open Alcotest
 
+(* RFC-0378 A2: test-side attribution builders. *)
+let unattributed_file attempted_path =
+  Agent_observation.File
+    (Agent_observation.Unaddressed
+       { reason = Agent_observation.Unattributed.Unregistered_path; attempted_path })
+;;
+
+let addressed_file ~codebase ~path =
+  match Agent_observation.Code_address.v ~codebase ~path with
+  | Ok address ->
+    Agent_observation.File (Agent_observation.Addressed { address; checkout = None })
+  | Error e -> failwith (Agent_observation.Code_address.invalid_to_string e)
+;;
+
 let with_temp_dir f =
   let dir = Filename.temp_file "ide_bridge_test" "" in
   Sys.remove dir;
@@ -16,6 +30,7 @@ let test_ingest_tool_event () =
   with_temp_dir (fun base_dir ->
     Ide_bridge.ingest_tool_event
       ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
       ~tool_name:"fs_write"
       ~keeper_id:"keeper-alpha"
       ~turn_id:"turn-123"
@@ -43,7 +58,6 @@ let test_ingest_turn_event () =
   with_temp_dir (fun base_dir ->
     Ide_bridge.ingest_turn_event
       ~base_path:base_dir
-      ~partition:Ide_paths.Legacy_default
       ~turn_id:"turn-456"
       ~keeper_id:"keeper-beta"
       ~phase:"completed"
@@ -67,6 +81,7 @@ let test_ingest_multiple_events () =
   with_temp_dir (fun base_dir ->
     Ide_bridge.ingest_tool_event
       ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
       ~tool_name:"fs_write"
       ~keeper_id:"k1"
       ~turn_id:"t1"
@@ -79,6 +94,7 @@ let test_ingest_multiple_events () =
       ();
     Ide_bridge.ingest_tool_event
       ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
       ~tool_name:"execute"
       ~keeper_id:"k1"
       ~turn_id:"t1"
@@ -123,6 +139,7 @@ let test_list_events_filters_keeper_and_pages () =
   with_temp_dir (fun base_dir ->
     Ide_bridge.ingest_tool_event
       ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
       ~tool_name:"execute"
       ~keeper_id:"k1"
       ~turn_id:"t-old"
@@ -135,6 +152,7 @@ let test_list_events_filters_keeper_and_pages () =
       ();
     Ide_bridge.ingest_tool_event
       ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
       ~tool_name:"read_file"
       ~keeper_id:"k2"
       ~turn_id:"t-other"
@@ -147,6 +165,7 @@ let test_list_events_filters_keeper_and_pages () =
       ();
     Ide_bridge.ingest_tool_event
       ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
       ~tool_name:"write_file"
       ~keeper_id:"k1"
       ~turn_id:"t-new"
@@ -176,6 +195,7 @@ let test_list_events_merges_kinds_newest_first () =
   with_temp_dir (fun base_dir ->
     Ide_bridge.ingest_tool_event
       ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
       ~tool_name:"execute"
       ~keeper_id:"k1"
       ~turn_id:"t-tool"
@@ -188,7 +208,6 @@ let test_list_events_merges_kinds_newest_first () =
       ();
     Ide_bridge.ingest_turn_event
       ~base_path:base_dir
-      ~partition:Ide_paths.Legacy_default
       ~turn_id:"t-turn"
       ~keeper_id:"k1"
       ~phase:"completed"
@@ -224,8 +243,7 @@ let test_hook_row_carries_the_resolved_path_not_the_raw_argument () =
     in
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
-      ~partition:Ide_paths.Legacy_default
-      ~file_path:(Some resolved)
+      ~attribution:(unattributed_file resolved)
       ~tool_name:"edit_file"
       ~keeper_id:"analyst"
       ~turn_id:"turn-3"
@@ -250,8 +268,7 @@ let test_pathless_hook_stores_no_document () =
   with_temp_dir (fun base_dir ->
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
-      ~partition:Ide_paths.Legacy_default
-      ~file_path:None
+      ~attribution:Agent_observation.Pathless
       ~tool_name:"masc_broadcast"
       ~keeper_id:"analyst"
       ~turn_id:"turn-4"
@@ -281,8 +298,7 @@ let test_cursor_from_hook_uses_real_file_and_line () =
     in
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
-      ~partition:Ide_paths.Legacy_default
-      ~file_path:(Some "lib/test.ml")
+      ~attribution:(unattributed_file "lib/test.ml")
       ~tool_name:"keeper_ide_annotate"
       ~keeper_id:"k1"
       ~turn_id:"turn-7"
@@ -316,8 +332,7 @@ let test_cursor_from_hook_notifies_after_persist () =
       (fun () ->
         Ide_bridge.ingest_tool_event_from_hook
           ~base_path:base_dir
-          ~partition:Ide_paths.Legacy_default
-          ~file_path:(Some "lib/test.ml")
+          ~attribution:(unattributed_file "lib/test.ml")
           ~tool_name:"keeper_ide_annotate"
           ~keeper_id:"k1"
           ~turn_id:"turn-7"
@@ -356,8 +371,7 @@ let test_cursor_notifications_reraise_cancellation () =
           raises_cancel (fun () ->
             Ide_bridge.ingest_tool_event_from_hook
               ~base_path:base_dir
-              ~partition:Ide_paths.Legacy_default
-              ~file_path:(Some "lib/test.ml")
+              ~attribution:(unattributed_file "lib/test.ml")
               ~tool_name:"keeper_ide_annotate"
               ~keeper_id:"k1"
               ~turn_id:"turn-7"
@@ -392,8 +406,7 @@ let test_cursor_from_hook_skips_missing_line () =
     let input = `Assoc [ "file_path", `String "lib/test.ml" ] in
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
-      ~partition:Ide_paths.Legacy_default
-      ~file_path:(Some "lib/test.ml")
+      ~attribution:(unattributed_file "lib/test.ml")
       ~tool_name:"keeper_ide_annotate"
       ~keeper_id:"k1"
       ~turn_id:"turn-7"
@@ -413,8 +426,7 @@ let test_cursor_from_hook_skips_missing_focus_mode () =
     in
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
-      ~partition:Ide_paths.Legacy_default
-      ~file_path:(Some "lib/test.ml")
+      ~attribution:(unattributed_file "lib/test.ml")
       ~tool_name:"keeper_ide_annotate"
       ~keeper_id:"k1"
       ~turn_id:"turn-7"
@@ -437,8 +449,7 @@ let test_hook_no_file_path () =
     let input = `Assoc [ "command", `String "ls" ] in
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
-      ~partition:Ide_paths.Legacy_default
-      ~file_path:None
+      ~attribution:Agent_observation.Pathless
       ~tool_name:"execute"
       ~keeper_id:"k1"
       ~turn_id:"t1"
@@ -463,8 +474,7 @@ let test_hook_summary_truncation () =
     let input = `Assoc [] in
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
-      ~partition:Ide_paths.Legacy_default
-      ~file_path:None
+      ~attribution:Agent_observation.Pathless
       ~tool_name:"execute"
       ~keeper_id:"k1"
       ~turn_id:"t1"
@@ -488,8 +498,7 @@ let test_hook_typed_outcome_mapping () =
     let input = `Assoc [] in
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
-      ~partition:Ide_paths.Legacy_default
-      ~file_path:None
+      ~attribution:Agent_observation.Pathless
       ~tool_name:"execute"
       ~keeper_id:"k1"
       ~turn_id:"t1"
@@ -516,6 +525,7 @@ let test_concurrent_ingest () =
       fun () ->
         Ide_bridge.ingest_tool_event
           ~base_path:base_dir
+          ~partition:Ide_paths.Legacy_default
           ~tool_name:"fs_write"
           ~keeper_id:"k1"
           ~turn_id:(Printf.sprintf "t-%d" i)
@@ -682,6 +692,7 @@ let test_list_events_reads_across_segments () =
   with_temp_dir (fun base_dir ->
     Ide_bridge.ingest_tool_event
       ~base_path:base_dir
+      ~partition:Ide_paths.Legacy_default
       ~tool_name:"write_file"
       ~keeper_id:"k1"
       ~turn_id:"t-live"
@@ -779,7 +790,7 @@ let test_queue_writer_drains () =
    empty while data piled up in _orphan. *)
 let test_partition_routes_tool_event_and_cursor_by_url () =
   with_temp_dir (fun base_dir ->
-    let by_url = Ide_paths.By_url "github.com/jeong-sik/wkbl" in
+    let by_url = Ide_paths.By_url "github.com_jeong-sik_wkbl" in
     let input =
       `Assoc
         [ "file_path", `String "lib/test.ml"
@@ -789,8 +800,7 @@ let test_partition_routes_tool_event_and_cursor_by_url () =
     in
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
-      ~partition:by_url
-      ~file_path:(Some "lib/test.ml")
+      ~attribution:(addressed_file ~codebase:"github.com_jeong-sik_wkbl" ~path:"lib/test.ml")
       ~tool_name:"keeper_ide_annotate"
       ~keeper_id:"k1"
       ~turn_id:"turn-1"
@@ -840,8 +850,7 @@ let test_partition_legacy_default_isolated_from_by_url () =
     in
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
-      ~partition:Ide_paths.Legacy_default
-      ~file_path:(Some "lib/test.ml")
+      ~attribution:(unattributed_file "lib/test.ml")
       ~tool_name:"keeper_ide_annotate"
       ~keeper_id:"k1"
       ~turn_id:"turn-1"

--- a/test/test_ide_canonical_url_join.ml
+++ b/test/test_ide_canonical_url_join.ml
@@ -54,12 +54,17 @@ let touch path =
   close_out oc
 ;;
 
-let partition_to_string = function
-  | Ide_paths.By_url slug -> "By_url " ^ slug
-  | Ide_paths.No_canonical_url -> "No_canonical_url"
-  | Ide_paths.Unmatched -> "Unmatched"
-  | Ide_paths.Base_unresolved -> "Base_unresolved"
-  | Ide_paths.Legacy_default -> "Legacy_default"
+let attribution_to_string = function
+  | Agent_observation.Addressed { address; _ } ->
+    "Addressed " ^ Agent_observation.Code_address.codebase address
+  | Agent_observation.Unaddressed { reason; _ } ->
+    "Unaddressed " ^ Agent_observation.Unattributed.reason_to_string reason
+;;
+
+let addressed_or_fail label = function
+  | Agent_observation.Addressed { address; _ } -> address
+  | Agent_observation.Unaddressed _ as got ->
+    failf "%s: expected Addressed, got %s" label (attribution_to_string got)
 ;;
 
 let test_sandbox_write_joins_with_worktree_read () =
@@ -100,64 +105,60 @@ let test_sandbox_write_joins_with_worktree_read () =
     (match Repo_store.save_all ~base_path:base_dir [ repo_https; repo_ssh ] with
      | Ok () -> ()
      | Error msg -> failf "save_all: %s" msg);
-    (* 3. resolve_partition_for_write at a sandbox path. *)
+    (* 3. resolve_write_attribution at a sandbox path. *)
     let sandbox_file = Filename.concat sandbox_root "lib/foo.ml" in
-    let sandbox_partition, sandbox_rel =
-      Masc.Keeper_tool_filesystem_runtime.resolve_partition_for_write
-        ~base_dir
-        ~kind:"region"
-        ~file_path:sandbox_file
+    let sandbox_address =
+      addressed_or_fail
+        "sandbox"
+        (Masc.Keeper_tool_filesystem_runtime.resolve_write_attribution
+           ~base_dir
+           ~file_path:sandbox_file)
     in
     let worktree_file = Filename.concat workspace_root "lib/foo.ml" in
-    let worktree_partition, worktree_rel =
-      Masc.Keeper_tool_filesystem_runtime.resolve_partition_for_write
-        ~base_dir
-        ~kind:"region"
-        ~file_path:worktree_file
+    let worktree_address =
+      addressed_or_fail
+        "worktree"
+        (Masc.Keeper_tool_filesystem_runtime.resolve_write_attribution
+           ~base_dir
+           ~file_path:worktree_file)
     in
-    (* 4. Invariant — both resolve to the same By_url slug. *)
-    (match sandbox_partition, worktree_partition with
-     | Ide_paths.By_url s1, Ide_paths.By_url s2 ->
-       check string "join invariant — same slug" s1 s2
-     | _ ->
-       failf
-         "expected By_url _ on both sides, got %s / %s"
-         (match sandbox_partition with
-          | Ide_paths.By_url s -> "By_url " ^ s
-          | Ide_paths.No_canonical_url -> "No_canonical_url"
-          | Ide_paths.Unmatched -> "Unmatched"
-          | Ide_paths.Base_unresolved -> "Base_unresolved"
-          | Ide_paths.Legacy_default -> "Legacy_default")
-         (match worktree_partition with
-          | Ide_paths.By_url s -> "By_url " ^ s
-          | Ide_paths.No_canonical_url -> "No_canonical_url"
-          | Ide_paths.Unmatched -> "Unmatched"
-          | Ide_paths.Base_unresolved -> "Base_unresolved"
-          | Ide_paths.Legacy_default -> "Legacy_default"));
-    (* 5. rel_path is the repo-relative remainder in both cases. *)
-    check string "sandbox rel_path stripped" "lib/foo.ml" sandbox_rel;
-    check string "worktree rel_path stripped" "lib/foo.ml" worktree_rel)
+    (* 4. Invariant — both mint the same codebase slug. *)
+    check
+      string
+      "join invariant — same slug"
+      (Agent_observation.Code_address.codebase sandbox_address)
+      (Agent_observation.Code_address.codebase worktree_address);
+    (* 5. The address path is the repo-relative remainder in both cases. *)
+    check
+      string
+      "sandbox rel_path stripped"
+      "lib/foo.ml"
+      (Agent_observation.Code_address.path sandbox_address);
+    check
+      string
+      "worktree rel_path stripped"
+      "lib/foo.ml"
+      (Agent_observation.Code_address.path worktree_address))
 ;;
 
-let test_unregistered_path_lands_in_base_unresolved () =
+let test_unregistered_path_fails_with_typed_reason () =
   with_temp_base_dir (fun base_dir ->
     (match Repo_store.save_all ~base_path:base_dir [] with
      | Ok () -> ()
      | Error msg -> failf "save_all: %s" msg);
     let elsewhere = Filename.concat base_dir "elsewhere/foo.ml" in
-    let partition, original =
-      Masc.Keeper_tool_filesystem_runtime.resolve_partition_for_write
+    match
+      Masc.Keeper_tool_filesystem_runtime.resolve_write_attribution
         ~base_dir
-        ~kind:"region"
         ~file_path:elsewhere
-    in
-    (match partition with
-     | Ide_paths.Base_unresolved -> ()
-     | got ->
-       failf
-         "expected Base_unresolved for unregistered path, got %s"
-         (partition_to_string got));
-    check string "rel_path passes through unchanged" elsewhere original)
+    with
+    | Agent_observation.Unaddressed
+        { reason = Agent_observation.Unattributed.Unregistered_path; attempted_path } ->
+      check string "attempted path passes through unchanged" elsewhere attempted_path
+    | got ->
+      failf
+        "expected Unaddressed Unregistered_path, got %s"
+        (attribution_to_string got))
 ;;
 
 let test_blank_url_lands_in_no_canonical_url () =
@@ -183,18 +184,18 @@ let test_blank_url_lands_in_no_canonical_url () =
      | Ok () -> ()
      | Error msg -> failf "save_all: %s" msg);
     let file = Filename.concat local "lib/foo.ml" in
-    let partition, _ =
-      Masc.Keeper_tool_filesystem_runtime.resolve_partition_for_write
+    match
+      Masc.Keeper_tool_filesystem_runtime.resolve_write_attribution
         ~base_dir
-        ~kind:"region"
         ~file_path:file
-    in
-    match partition with
-    | Ide_paths.No_canonical_url -> ()
+    with
+    | Agent_observation.Unaddressed
+        { reason = Agent_observation.Unattributed.Blank_remote_url; _ } ->
+      ()
     | got ->
       failf
-        "expected No_canonical_url for blank-URL repo, got %s"
-        (partition_to_string got))
+        "expected Unaddressed Blank_remote_url for blank-URL repo, got %s"
+        (attribution_to_string got))
 ;;
 
 (* RFC-0128 PR-6 — sandbox playground path resolution. Keeper writes
@@ -234,38 +235,35 @@ let test_sandbox_playground_path_joins_with_worktree () =
         ".masc/playground/sangsu/repos/masc/lib/foo.ml"
     in
     let worktree_file = Filename.concat worktree "lib/foo.ml" in
-    let sandbox_partition, sandbox_rel =
-      Masc.Keeper_tool_filesystem_runtime.resolve_partition_for_write
-        ~base_dir
-        ~kind:"region"
-        ~file_path:sandbox_file
+    let sandbox_address =
+      addressed_or_fail
+        "sandbox playground"
+        (Masc.Keeper_tool_filesystem_runtime.resolve_write_attribution
+           ~base_dir
+           ~file_path:sandbox_file)
     in
-    let worktree_partition, worktree_rel =
-      Masc.Keeper_tool_filesystem_runtime.resolve_partition_for_write
-        ~base_dir
-        ~kind:"region"
-        ~file_path:worktree_file
+    let worktree_address =
+      addressed_or_fail
+        "worktree"
+        (Masc.Keeper_tool_filesystem_runtime.resolve_write_attribution
+           ~base_dir
+           ~file_path:worktree_file)
     in
-    (match sandbox_partition, worktree_partition with
-     | Ide_paths.By_url s1, Ide_paths.By_url s2 ->
-       check string "sandbox / working-tree join via canonical_url" s1 s2
-     | _ ->
-       failf
-         "expected By_url _ on both sides, got %s / %s"
-         (match sandbox_partition with
-          | Ide_paths.By_url s -> "By_url " ^ s
-          | Ide_paths.No_canonical_url -> "No_canonical_url"
-          | Ide_paths.Unmatched -> "Unmatched"
-          | Ide_paths.Base_unresolved -> "Base_unresolved"
-          | Ide_paths.Legacy_default -> "Legacy_default")
-         (match worktree_partition with
-          | Ide_paths.By_url s -> "By_url " ^ s
-          | Ide_paths.No_canonical_url -> "No_canonical_url"
-          | Ide_paths.Unmatched -> "Unmatched"
-          | Ide_paths.Base_unresolved -> "Base_unresolved"
-          | Ide_paths.Legacy_default -> "Legacy_default"));
-    check string "sandbox rel stripped to repo-relative" "lib/foo.ml" sandbox_rel;
-    check string "worktree rel stripped" "lib/foo.ml" worktree_rel)
+    check
+      string
+      "sandbox / working-tree join via canonical_url"
+      (Agent_observation.Code_address.codebase sandbox_address)
+      (Agent_observation.Code_address.codebase worktree_address);
+    check
+      string
+      "sandbox rel stripped to repo-relative"
+      "lib/foo.ml"
+      (Agent_observation.Code_address.path sandbox_address);
+    check
+      string
+      "worktree rel stripped"
+      "lib/foo.ml"
+      (Agent_observation.Code_address.path worktree_address))
 ;;
 
 let test_docker_playground_path_also_resolves () =
@@ -295,16 +293,18 @@ let test_docker_playground_path_also_resolves () =
         base_dir
         ".masc/playground/docker/tech_glutton/repos/masc/lib/foo.ml"
     in
-    let partition, rel =
-      Masc.Keeper_tool_filesystem_runtime.resolve_partition_for_write
-        ~base_dir
-        ~kind:"region"
-        ~file_path:docker_file
+    let address =
+      addressed_or_fail
+        "docker sandbox"
+        (Masc.Keeper_tool_filesystem_runtime.resolve_write_attribution
+           ~base_dir
+           ~file_path:docker_file)
     in
-    match partition with
-    | Ide_paths.By_url _ ->
-      check string "docker sandbox rel" "lib/foo.ml" rel
-    | _ -> fail "Docker sandbox path should resolve via repo_id lookup")
+    check
+      string
+      "docker sandbox rel"
+      "lib/foo.ml"
+      (Agent_observation.Code_address.path address))
 ;;
 
 let () =
@@ -316,11 +316,11 @@ let () =
             `Quick
             test_sandbox_write_joins_with_worktree_read
         ; test_case
-            "unregistered path → Base_unresolved"
+            "unregistered path fails with its typed reason"
             `Quick
-            test_unregistered_path_lands_in_base_unresolved
+            test_unregistered_path_fails_with_typed_reason
         ; test_case
-            "blank URL → No_canonical_url"
+            "blank URL fails as Blank_remote_url"
             `Quick
             test_blank_url_lands_in_no_canonical_url
         ; test_case

--- a/test/test_keeper_run_tools_hooks.ml
+++ b/test/test_keeper_run_tools_hooks.ml
@@ -236,65 +236,78 @@ let with_partition_fixture ?sandbox_profile f =
     f ~config ~meta)
 ;;
 
-let resolve_partition ~config ~meta fields =
-  Masc.Keeper_run_tools_hooks.observation_partition_for_tool_input
+let resolve_attribution ~config ~meta fields =
+  Masc.Keeper_run_tools_hooks.observation_attribution_for_tool_input
     ~config
     ~meta
-    ~kind:"tool_event"
     (`Assoc fields)
 ;;
 
+let addressed_or_fail = function
+  | Agent_observation.File (Agent_observation.Addressed { address; _ }) -> address
+  | Agent_observation.File (Agent_observation.Unaddressed { reason; _ }) ->
+    fail
+      ("expected an addressed fact, got Unaddressed "
+       ^ Agent_observation.Unattributed.reason_to_string reason)
+  | Agent_observation.Pathless -> fail "expected an addressed fact, got Pathless"
+;;
+
 (* The keeper's playground clone of a registered repo resolves to the
-   repo's [By_url] bucket via the structural playground parse — the
-   #23469 regression this case pins: before the sandbox anchor, this
-   input re-anchored at the server base path and only matched because
-   the same repo happened to be registered at [repos/masc] there. *)
-(* A coordination tool names no file, so the observation has a partition but
-   no document. The helper used to answer the project root here, which the
-   consumer then stored as the edited file — a broadcast claiming a document
-   it never touched (masc#28582). *)
+   repo's address via the structural playground parse — the #23469
+   regression this case pins: before the sandbox anchor, this input
+   re-anchored at the server base path and only matched because the
+   same repo happened to be registered at [repos/masc] there. *)
+(* A coordination tool names no file: the observation is a keeper-timeline
+   fact with no document. The helper used to answer the project root here,
+   which the consumer then stored as the edited file — a broadcast claiming
+   a document it never touched (masc#28582). *)
 let test_partition_resolution_leaves_pathless_calls_without_a_document () =
   with_partition_fixture (fun ~config ~meta ->
-    let _partition, rel_path =
-      resolve_partition ~config ~meta [ "message", `String "fixing: CI" ]
-    in
-    check (option string) "pathless call names no document" None rel_path)
+    match resolve_attribution ~config ~meta [ "message", `String "fixing: CI" ] with
+    | Agent_observation.Pathless -> ()
+    | Agent_observation.File _ ->
+      fail "a pathless call must not carry a file attribution")
 ;;
 
 let test_partition_resolution_uses_project_root_for_masc_base_path () =
   with_partition_fixture (fun ~config ~meta ->
-    let partition, rel_path =
-      resolve_partition
-        ~config
-        ~meta
-        [ "cwd", `String "repos/masc"; "path", `String "lib/foo.ml" ]
+    let address =
+      addressed_or_fail
+        (resolve_attribution
+           ~config
+           ~meta
+           [ "cwd", `String "repos/masc"; "path", `String "lib/foo.ml" ])
     in
-    check (option string) "repo-relative path" (Some "lib/foo.ml") rel_path;
-    match partition with
-    | Agent_observation.By_url slug ->
-      check string "slug" "github.com_jeong-sik_masc" slug
-    | Agent_observation.No_canonical_url
-    | Agent_observation.Unmatched
-    | Agent_observation.Base_unresolved
-    | Agent_observation.Legacy_default ->
-      fail "expected By_url partition")
+    check
+      string
+      "slug"
+      "github.com_jeong-sik_masc"
+      (Agent_observation.Code_address.codebase address);
+    check
+      string
+      "repo-relative path"
+      "lib/foo.ml"
+      (Agent_observation.Code_address.path address))
 ;;
 
-let test_partition_unregistered_playground_repo_is_unmatched () =
+let test_partition_unregistered_playground_repo_fails_with_repo_id () =
   with_partition_fixture (fun ~config ~meta ->
-    let partition, _ =
-      resolve_partition
-        ~config
-        ~meta
-        [ "path", `String "repos/ghost/lib/foo.ml" ]
-    in
-    match partition with
-    | Agent_observation.Unmatched -> ()
-    | Agent_observation.By_url _
-    | Agent_observation.No_canonical_url
-    | Agent_observation.Base_unresolved
-    | Agent_observation.Legacy_default ->
-      fail "expected Unmatched partition for unregistered playground repo")
+    match
+      resolve_attribution ~config ~meta [ "path", `String "repos/ghost/lib/foo.ml" ]
+    with
+    | Agent_observation.File
+        (Agent_observation.Unaddressed
+           { reason = Agent_observation.Unattributed.Unregistered_repo_id repo_id
+           ; attempted_path
+           }) ->
+      check string "repo id" "ghost" repo_id;
+      check
+        bool
+        "attempted path preserved for forensics"
+        true
+        (String.length attempted_path > 0)
+    | _ ->
+      fail "expected Unaddressed Unregistered_repo_id for unregistered playground repo")
 ;;
 
 let test_partition_docker_visible_path_maps_to_playground_repo () =
@@ -306,36 +319,34 @@ let test_partition_docker_visible_path_maps_to_playground_repo () =
            (Masc.Keeper_sandbox.container_root meta.name)
            "repos/masc/lib/docker.ml"
        in
-       let partition, rel_path =
-         resolve_partition ~config ~meta [ "path", `String container_repo_path ]
+       let address =
+         addressed_or_fail
+           (resolve_attribution ~config ~meta [ "path", `String container_repo_path ])
        in
-       check (option string) "repo-relative path" (Some "lib/docker.ml") rel_path;
-       match partition with
-       | Agent_observation.By_url slug ->
-         check string "slug" "github.com_jeong-sik_masc" slug
-       | Agent_observation.No_canonical_url
-       | Agent_observation.Unmatched
-       | Agent_observation.Base_unresolved
-       | Agent_observation.Legacy_default ->
-         fail "expected Docker visible absolute path to resolve to By_url")
+       check
+         string
+         "slug"
+         "github.com_jeong-sik_masc"
+         (Agent_observation.Code_address.codebase address);
+       check
+         string
+         "repo-relative path"
+         "lib/docker.ml"
+         (Agent_observation.Code_address.path address))
 ;;
 
 (* A bare relative path outside the [repos/<id>/] lane is a real
-   playground-local file, not a repo file — it must degrade to the typed
-   orphan partition instead of borrowing whichever repository overlaps
+   playground-local file, not a repo file — it must fail attribution with
+   the typed reason instead of borrowing whichever repository overlaps
    the server base path. *)
-let test_partition_bare_relative_outside_repos_is_base_unresolved () =
+let test_partition_bare_relative_outside_repos_is_unregistered_path () =
   with_partition_fixture (fun ~config ~meta ->
-    let partition, _ =
-      resolve_partition ~config ~meta [ "path", `String "notes/todo.md" ]
-    in
-    match partition with
-    | Agent_observation.Base_unresolved -> ()
-    | Agent_observation.By_url _
-    | Agent_observation.No_canonical_url
-    | Agent_observation.Unmatched
-    | Agent_observation.Legacy_default ->
-      fail "expected Base_unresolved partition for playground-local file")
+    match resolve_attribution ~config ~meta [ "path", `String "notes/todo.md" ] with
+    | Agent_observation.File
+        (Agent_observation.Unaddressed
+           { reason = Agent_observation.Unattributed.Unregistered_path; _ }) ->
+      ()
+    | _ -> fail "expected Unaddressed Unregistered_path for playground-local file")
 ;;
 
 (* --- gate history slice ------------------------------------------------- *)
@@ -667,17 +678,17 @@ let () =
             `Quick
             test_partition_resolution_uses_project_root_for_masc_base_path
         ; test_case
-            "unregistered playground repo is Unmatched"
+            "unregistered playground repo fails with its repo id"
             `Quick
-            test_partition_unregistered_playground_repo_is_unmatched
+            test_partition_unregistered_playground_repo_fails_with_repo_id
         ; test_case
             "Docker visible absolute path maps to playground repo"
             `Quick
             test_partition_docker_visible_path_maps_to_playground_repo
         ; test_case
-            "bare relative outside repos lane is Base_unresolved"
+            "bare relative outside repos lane is an unregistered path"
             `Quick
-            test_partition_bare_relative_outside_repos_is_base_unresolved
+            test_partition_bare_relative_outside_repos_is_unregistered_path
         ] )
     ]
 ;;

--- a/test/test_server_ide_http.ml
+++ b/test/test_server_ide_http.ml
@@ -585,8 +585,12 @@ let test_hook_cursors_broadcast_ws_invalidation () =
       (fun () ->
         Ide_bridge.ingest_tool_event_from_hook
           ~base_path
-          ~partition:Ide_paths.Legacy_default
-          ~file_path:(Some "lib/a.ml")
+          ~attribution:
+            (Agent_observation.File
+               (Agent_observation.Unaddressed
+                  { reason = Agent_observation.Unattributed.Unregistered_path
+                  ; attempted_path = "lib/a.ml"
+                  }))
           ~tool_name:"keeper_ide_annotate"
           ~keeper_id:"alice"
           ~turn_id:"turn-7"
@@ -1001,7 +1005,6 @@ let test_memory_response_honors_canonical_url_scope () =
 let seed_lane_turn_event ~base_path ~keeper_id ~turn_id ~timestamp_ms =
   Ide_bridge.ingest_turn_event
     ~base_path
-    ~partition:Ide_paths.Legacy_default
     ~turn_id
     ~keeper_id
     ~phase:"completed"


### PR DESCRIPTION
## 목표

RFC-0378 §7 사다리 A2 (A1 #28649 위 stacked)이에요. bus 레코드가 partition/file_path 대신 **attribution**을 나릅니다: `File (Addressed | Unaddressed) | Pathless`.

## 핵심 변경

- **resolver = 유일한 Code_address 조폐소**: `resolve_write_attribution` — 점-세그먼트 lexical collapse, root 탈출은 수리 대신 귀속 실패, `IdeOrphanWrites` 카운터 삭제 (사유가 fact의 typed 필드로), `Unmintable` 사유로 불변식 파괴 비은닉
- **turn은 keeper fact**: turn_event에서 partition 삭제 — `resolve(base_path, base_path)` 자기 귀속(turn 146MB 전량 orphan의 직접 원인) 2곳 소멸. task-1733 DEFER 주석이 타입 결정으로 해소
- **sink는 마지막 write 지점에서 투영**: attribution → (storage partition, path). 배치 불변 (Addressed→by-url, 나머지→orphan; keeper/ 분리는 B)
- **silent default 사망 (write측)**: `Ide_annotations.create`·region tracker write 진입점·`ingest_tool_event`가 partition을 required로 — #28581을 매장시킨 "인자 누락 → 조용히 orphan" 모양
- annotate 핸들러·tool hook이 attribution 운반; 경로는 resolver가 명명한 그대로

## 테스트 (6본 이행)

bridge(스크립트, 전 카운트 단언)·hooks(typed reason 단언 5본)·server·observation_bridge·canonical_url_join(join 불변식을 Code_address 값 위에서)·annotations(16사이트 explicit). 죽는 어휘 박힌 테스트명 4개 개명. `resolve_partition_for_write`/`observation_partition_for_tool_input` 참조 잔존 0파일 확인.

## 의도적 이탈 1건

경로 정규화를 fpath 대신 세그먼트 스택 손구현으로 — 필요한 의미론이 root-탈출 **거부**인데 `Fpath.normalize`는 leading `..`을 보존해요. RFC §5.1의 fpath 문장은 후속 docs 커밋에서 정정 예정이에요.

## 검증

컴파일 판정은 PR CI (원칙 16, 로컬 빌드 없음). read path는 의도적 무변경 — 구 partition 타입은 read 전용 어휘로 D까지 생존 (RFC §7 머지 지점 계약).

RFC: #28645 · A1: #28649

🤖 Generated with [Claude Code](https://claude.com/claude-code)