### PR TITLE
fix(workspace): expose mention delivery receipts

### DIFF
--- a/dashboard/src/api/actions.test.ts
+++ b/dashboard/src/api/actions.test.ts
@@ -1,14 +1,19 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mcpMocks = vi.hoisted(() => ({
+  callMcpTool: vi.fn(() => Promise.resolve('{}')),
+  mcpCallFailureDisposition: vi.fn(),
+  mcpStructuredContentFromError: vi.fn(),
+}))
 
 // claimTask must reach the server. The pre-existing Work-board bug was that a
 // claim only touched local React state and vanished on refresh (#46); this
 // test pins the contract that a claim is routed through the persisted
 // masc_transition FSM tool.
-vi.mock('./mcp', () => ({ callMcpTool: vi.fn(() => Promise.resolve('{}')) }))
+vi.mock('./mcp', () => mcpMocks)
 vi.mock('./core', () => ({ get: vi.fn(), post: vi.fn(() => Promise.resolve({ ok: true })) }))
 
-import { callMcpTool } from './mcp'
-import { claimTask, deleteTask } from './actions'
+import { claimTask, deleteTask, sendBroadcast } from './actions'
 
 describe('claimTask', () => {
   beforeEach(() => {
@@ -17,15 +22,15 @@ describe('claimTask', () => {
 
   it('routes an operator claim through masc_transition (todo -> claimed)', async () => {
     await claimTask('task-123')
-    expect(callMcpTool).toHaveBeenCalledTimes(1)
-    expect(callMcpTool).toHaveBeenCalledWith('masc_transition', {
+    expect(mcpMocks.callMcpTool).toHaveBeenCalledTimes(1)
+    expect(mcpMocks.callMcpTool).toHaveBeenCalledWith('masc_transition', {
       task_id: 'task-123',
       action: 'claim',
     })
   })
 
   it('propagates a transition failure so the caller can roll back the optimistic flag', async () => {
-    vi.mocked(callMcpTool).mockRejectedValueOnce(new Error('todo -> claimed rejected'))
+    mcpMocks.callMcpTool.mockRejectedValueOnce(new Error('todo -> claimed rejected'))
     await expect(claimTask('task-err')).rejects.toThrow('todo -> claimed rejected')
   })
 })
@@ -34,5 +39,30 @@ describe('deleteTask (unchanged path, regression guard)', () => {
   it('posts to the dashboard delete route', async () => {
     const ok = await deleteTask('task-9')
     expect(ok).toBe(true)
+  })
+})
+
+describe('sendBroadcast delivery truth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('preserves uncertainty for a malformed executed-tool receipt', async () => {
+    const error = new Error('tool response could not be decoded')
+    mcpMocks.callMcpTool.mockRejectedValue(error)
+    mcpMocks.mcpStructuredContentFromError.mockReturnValue({
+      ok: false,
+      request_id: 'wmsg-0123456789abcdef0123456789abcdef',
+      mention_delivery: { kind: 'accepted' },
+    })
+    mcpMocks.mcpCallFailureDisposition.mockReturnValue('known_tool_response')
+
+    await expect(sendBroadcast('dashboard', '@gemini check')).resolves.toEqual({
+      ok: false,
+      requestId: null,
+      deliveryKind: 'outcome_unknown',
+      reason: 'Broadcast returned a malformed delivery receipt.',
+      workspacePersisted: null,
+    })
   })
 })

--- a/dashboard/src/api/actions.ts
+++ b/dashboard/src/api/actions.ts
@@ -1,12 +1,101 @@
 import { get, post } from './core'
-import { callMcpTool } from './mcp'
+import {
+  callMcpTool,
+  mcpCallFailureDisposition,
+  mcpStructuredContentFromError,
+} from './mcp'
 
 // --- Control Dock ---
 
-export async function sendBroadcast(_actorHint: string, message: string): Promise<void> {
-  await callMcpTool('masc_broadcast', {
-    message,
-  })
+export type BroadcastSendReceipt = {
+  ok: boolean
+  requestId: string | null
+  deliveryKind: 'passive' | 'accepted' | 'already_accepted' | 'pending' | 'deferred' | 'rejected' | 'outcome_unknown'
+  reason: string | null
+  workspacePersisted: boolean | null
+}
+
+export function broadcastReceiptMessage(receipt: BroadcastSendReceipt): string {
+  if (receipt.ok) return 'Message sent.'
+  if (receipt.deliveryKind === 'outcome_unknown') {
+    return 'Broadcast outcome unknown. Do not resend until the workspace timeline is checked.'
+  }
+  const reason = receipt.reason ? `: ${receipt.reason}` : ''
+  return `Workspace message persisted; Keeper intake ${receipt.deliveryKind}${reason}. Do not resend. request_id=${receipt.requestId}`
+}
+
+function parseBroadcastReceipt(receipt: unknown): BroadcastSendReceipt {
+  if (typeof receipt !== 'object' || receipt === null || Array.isArray(receipt)) {
+    throw new Error('Broadcast returned a malformed delivery receipt.')
+  }
+  const fields = receipt as Record<string, unknown>
+  const requestId = typeof fields.request_id === 'string' ? fields.request_id : ''
+  const delivery = fields.mention_delivery
+  if (
+    typeof fields.ok !== 'boolean'
+    || !requestId
+    || typeof delivery !== 'object'
+    || delivery === null
+    || Array.isArray(delivery)
+  ) {
+    throw new Error('Broadcast returned a malformed delivery receipt.')
+  }
+  const deliveryFields = delivery as Record<string, unknown>
+  const kind = deliveryFields.kind
+  if (
+    kind !== 'passive'
+    && kind !== 'accepted'
+    && kind !== 'already_accepted'
+    && kind !== 'pending'
+    && kind !== 'deferred'
+    && kind !== 'rejected'
+  ) {
+    throw new Error('Broadcast returned a malformed delivery receipt.')
+  }
+  const expectedOk = kind === 'passive' || kind === 'accepted' || kind === 'already_accepted'
+  if (fields.ok !== expectedOk) {
+    throw new Error('Broadcast returned a contradictory delivery receipt.')
+  }
+  return {
+    ok: fields.ok,
+    requestId,
+    deliveryKind: kind,
+    reason: typeof deliveryFields.reason === 'string' ? deliveryFields.reason : null,
+    workspacePersisted: true,
+  }
+}
+
+export async function sendBroadcast(_actorHint: string, message: string): Promise<BroadcastSendReceipt> {
+  try {
+    const text = await callMcpTool('masc_broadcast', { message })
+    return parseBroadcastReceipt(JSON.parse(text))
+  } catch (error) {
+    const structured = mcpStructuredContentFromError(error)
+    if (structured != null) {
+      try {
+        return parseBroadcastReceipt(structured)
+      } catch {
+        // A contradictory or malformed response cannot prove that the
+        // workspace commit did not happen. Preserve uncertainty instead of
+        // encouraging a duplicate resend.
+        return {
+          ok: false,
+          requestId: null,
+          deliveryKind: 'outcome_unknown',
+          reason: 'Broadcast returned a malformed delivery receipt.',
+          workspacePersisted: null,
+        }
+      }
+    }
+    if (mcpCallFailureDisposition(error) !== 'outcome_unknown') throw error
+    return {
+      ok: false,
+      requestId: null,
+      deliveryKind: 'outcome_unknown',
+      reason: error instanceof Error ? error.message : 'unknown transport failure',
+      workspacePersisted: null,
+    }
+  }
 }
 
 export async function fetchWorkspaceMessages(limit = 40): Promise<string[]> {

--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -238,17 +238,58 @@ interface McpCallResponse {
     isError?: boolean
     structuredContent?: unknown
   }
-  error?: { message?: string }
+  error?: { message?: string; code?: number }
+}
+
+class McpProtocolError extends Error {
+  readonly code: number | null
+
+  constructor(message: string, code: number | null) {
+    super(message)
+    this.name = 'McpProtocolError'
+    this.code = code
+  }
 }
 
 class McpToolCallError extends Error {
   readonly authErrorCode: unknown
+  readonly structuredContent: unknown
 
-  constructor(message: string, authErrorCode: unknown) {
+  constructor(message: string, authErrorCode: unknown, structuredContent: unknown) {
     super(message)
     this.name = 'McpToolCallError'
     this.authErrorCode = authErrorCode
+    this.structuredContent = structuredContent
   }
+}
+
+export function mcpStructuredContentFromError(error: unknown): unknown {
+  return error instanceof McpToolCallError ? error.structuredContent : null
+}
+
+export type McpCallFailureDisposition =
+  | 'known_tool_response'
+  | 'known_pre_effect'
+  | 'outcome_unknown'
+
+export function mcpCallFailureDisposition(error: unknown): McpCallFailureDisposition {
+  if (error instanceof McpToolCallError) return 'known_tool_response'
+  if (error instanceof McpProtocolError && error.code === -32001) {
+    return 'known_pre_effect'
+  }
+  if (
+    error instanceof ApiRequestError
+    && !error.timeout
+    && error.status !== undefined
+    && error.status >= 400
+    && error.status < 500
+  ) {
+    return 'known_pre_effect'
+  }
+  if (error instanceof Error && error.message === MCP_BLOCKED_MESSAGE) {
+    return 'known_pre_effect'
+  }
+  return 'outcome_unknown'
 }
 
 function structuredAuthErrorCode(value: unknown): unknown {
@@ -263,12 +304,18 @@ function parseMcpHttpResponse(raw: string): McpCallResponse {
 }
 
 function extractMcpText(res: McpCallResponse): string {
-  if (res.error?.message) throw new Error(res.error.message)
+  if (res.error?.message) {
+    throw new McpProtocolError(
+      res.error.message,
+      typeof res.error.code === 'number' ? res.error.code : null,
+    )
+  }
   if (res.result?.isError) {
     const err = res.result.content?.[0]?.text ?? 'MCP tool call failed'
     throw new McpToolCallError(
       err,
       structuredAuthErrorCode(res.result.structuredContent),
+      res.result.structuredContent,
     )
   }
   return res.result?.content?.[0]?.text ?? ''

--- a/dashboard/src/components/agent-detail-state.ts
+++ b/dashboard/src/components/agent-detail-state.ts
@@ -10,7 +10,7 @@ import {
   tasks,
 } from '../store'
 import { findKeeper } from '../lib/keeper-utils'
-import { currentDashboardActor, fetchWorkspaceMessages, fetchTaskHistory, sendBroadcast, fetchAgentTimeline, type AgentTimelineResponse } from '../api'
+import { broadcastReceiptMessage, currentDashboardActor, fetchWorkspaceMessages, fetchTaskHistory, sendBroadcast, fetchAgentTimeline, type AgentTimelineResponse } from '../api'
 import { callMcpTool } from '../api/mcp'
 import { journal } from '../sse'
 import { route, navigate } from '../router'
@@ -241,9 +241,12 @@ export async function submitMention(): Promise<void> {
 
   sendingMention.value = true
   try {
-    await sendBroadcast(currentDashboardActor(), `@${target} ${text}`)
+    const receipt = await sendBroadcast(currentDashboardActor(), `@${target} ${text}`)
     mentionText.value = ''
-    showToast(`${target}에게 멘션 전송 완료`, 'success')
+    showToast(
+      receipt.ok ? `${target}에게 멘션 전송 완료` : broadcastReceiptMessage(receipt),
+      receipt.ok ? 'success' : 'warning',
+    )
     void refreshAgentDetail()
   } catch (err) {
     const msg = err instanceof Error ? err.message : '멘션 전송 실패'

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -30,6 +30,7 @@ import {
   fetchWorkspaceMessages,
   fetchTaskHistory,
   sendBroadcast,
+  broadcastReceiptMessage,
   fetchAgentTimeline,
   fetchAgentRelations,
   currentDashboardActor,
@@ -161,9 +162,12 @@ async function submitMention(target: string): Promise<void> {
   if (!target || !text) return
   sendingMention.value = true
   try {
-    await sendBroadcast(currentDashboardActor(), `@${target} ${text}`)
+    const receipt = await sendBroadcast(currentDashboardActor(), `@${target} ${text}`)
     mentionText.value = ''
-    showToast(`${target}에게 전송`, 'success')
+    showToast(
+      receipt.ok ? `${target}에게 전송` : broadcastReceiptMessage(receipt),
+      receipt.ok ? 'success' : 'warning',
+    )
     void loadProfile(target)
   } catch (err) {
     showToast(err instanceof Error ? err.message : '실패', 'error')

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -52,6 +52,7 @@ vi.mock('../../api', () => ({
   commentPost: vi.fn(),
   createPost: vi.fn(),
   sendBroadcast: vi.fn(),
+  broadcastReceiptMessage: vi.fn(() => 'broadcast receipt'),
 }))
 
 vi.mock('../../api/actions', () => ({

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -14,7 +14,7 @@ import { CursorPagination } from '../common/pagination'
 import { route } from '../../router'
 import { keepers as dashboardKeepers, messages, refreshExecution } from '../../store'
 import { votePost } from '../../api/board'
-import { createPost, currentDashboardActor, sendBroadcast } from '../../api'
+import { broadcastReceiptMessage, createPost, currentDashboardActor, sendBroadcast } from '../../api'
 import { deleteBoardPost, setBoardPostPinned } from '../../api/actions'
 import { dispatchOperatorAction, operatorActionBusy } from '../../operator-store'
 import { registerBoardHearthsRefresh } from '../../sse-store'
@@ -904,7 +904,14 @@ function BdComposer() {
           payload: { message },
         })
       } else {
-        await sendBroadcast(currentDashboardActor(), message)
+        const receipt = await sendBroadcast(currentDashboardActor(), message)
+        if (!receipt.ok) {
+          setLocalBody('')
+          resetMobileMentionDrafts()
+          setMobileOpen(false)
+          showToast(broadcastReceiptMessage(receipt), 'warning')
+          return
+        }
       }
       setLocalBody('')
       resetMobileMentionDrafts()

--- a/dashboard/src/components/board/composer-v2.test.ts
+++ b/dashboard/src/components/board/composer-v2.test.ts
@@ -26,6 +26,7 @@ const voiceInputState = vi.hoisted(() => ({
 vi.mock('../../api', () => ({
   currentDashboardActor: currentDashboardActorMock,
   sendBroadcast: sendBroadcastMock,
+  broadcastReceiptMessage: vi.fn(() => 'broadcast receipt'),
 }))
 
 vi.mock('../../operator-store', async (importOriginal) => {
@@ -124,7 +125,13 @@ describe('ComposerV2', () => {
   beforeEach(() => {
     currentDashboardActorMock.mockReturnValue('dashboard-test')
     sendBroadcastMock.mockReset()
-    sendBroadcastMock.mockResolvedValue(undefined)
+    sendBroadcastMock.mockResolvedValue({
+      ok: true,
+      requestId: 'wmsg-test',
+      deliveryKind: 'passive',
+      reason: null,
+      workspacePersisted: true,
+    })
     dispatchOperatorActionMock.mockReset()
     dispatchOperatorActionMock.mockResolvedValue({
       status: 'ok',

--- a/dashboard/src/components/board/composer-v2.ts
+++ b/dashboard/src/components/board/composer-v2.ts
@@ -1,7 +1,7 @@
 import { html } from 'htm/preact'
 import { useCallback, useEffect, useRef, useState } from 'preact/hooks'
 import { AtSign, Megaphone, Mic, Paperclip, Send, Square, UserRound, X } from 'lucide-preact'
-import { currentDashboardActor, sendBroadcast } from '../../api'
+import { broadcastReceiptMessage, currentDashboardActor, sendBroadcast } from '../../api'
 import { keepers as dashboardKeepers, refreshExecution } from '../../store'
 import {
   dispatchOperatorAction,
@@ -349,7 +349,12 @@ export function ComposerV2({
           payload: { message: request.compose.body },
         })
       } else {
-        await sendBroadcast(currentDashboardActor(), request.compose.body)
+        const receipt = await sendBroadcast(currentDashboardActor(), request.compose.body)
+        if (!receipt.ok) {
+          resetDraft()
+          showToast(broadcastReceiptMessage(receipt), 'warning')
+          return
+        }
       }
       if (keeperId) setKeeperTarget(`keeper:${keeperId}`)
       resetDraft()

--- a/dashboard/src/components/board/message-workspace-timeline.ts
+++ b/dashboard/src/components/board/message-workspace-timeline.ts
@@ -100,6 +100,12 @@ function TimelineMessage({ row }: { row: TimelineRow }) {
           ${row.message.type
             ? html`<span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] px-2 py-0.5 text-2xs font-medium uppercase tracking-[var(--track-caps)] text-[var(--color-fg-secondary)]">${row.message.type}</span>`
             : null}
+          ${row.message.mentionDelivery
+            ? html`<span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] px-2 py-0.5 text-2xs font-medium uppercase tracking-[var(--track-caps)] text-[var(--color-fg-secondary)]">${row.message.mentionDelivery === 'passive' ? 'Passive fanout' : `Keeper intake ${row.message.mentionDelivery}`}</span>`
+            : null}
+          ${row.message.requestId
+            ? html`<span class="max-w-48 truncate font-mono text-2xs text-[var(--color-fg-muted)]" title=${row.message.requestId} translate="no">${row.message.requestId}</span>`
+            : null}
         </div>
         <div class="mt-2 text-sm leading-paragraph text-[var(--color-fg-primary)]">
           <${RichContent} text=${preview} previewLimit=${2} />

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -792,6 +792,10 @@ function deliveryIdentityFromKey(raw: unknown): DeliveryIdentity {
     const requestId = asString(raw.operation_id)?.trim() ?? ''
     return { requestId: requestId || null }
   }
+  if (kind === 'workspace_message') {
+    const requestId = asString(raw.request_id)?.trim() ?? ''
+    return { requestId: requestId || null }
+  }
   return { requestId: null }
 }
 

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -141,14 +141,24 @@ export function normalizeMessage(raw: unknown): Message | null {
   const content = asString(raw.content) ?? ''
   const timestamp = asString(raw.timestamp)
   const workspace = asString(raw.workspace) ?? asString(raw.workspace_id) ?? asString(raw.channel)
+  const rawMentionDelivery = asString(raw.mention_delivery)
+  const mentionDelivery =
+    rawMentionDelivery === 'passive'
+    || rawMentionDelivery === 'pending'
+    || rawMentionDelivery === 'accepted'
+    || rawMentionDelivery === 'rejected'
+      ? rawMentionDelivery
+      : undefined
   return {
     id: asString(raw.id),
+    requestId: asString(raw.request_id),
     seq: asNumber(raw.seq),
     from,
     content,
     timestamp,
     type: asString(raw.type),
     workspace,
+    mentionDelivery,
   }
 }
 
@@ -883,6 +893,7 @@ export function messageSortKey(message: Message): number {
 }
 
 function messageIdentityKey(message: Message): string {
+  if (message.requestId) return JSON.stringify(['request_id', message.requestId])
   if (typeof message.seq === 'number' && Number.isFinite(message.seq)) {
     return JSON.stringify(['seq', message.seq])
   }

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -95,12 +95,14 @@ interface TaskHandoffContext {
 
 export interface Message {
   id?: string
+  requestId?: string
   seq?: number
   from?: string
   content: string
   timestamp?: string
   type?: string
   workspace?: string
+  mentionDelivery?: 'passive' | 'pending' | 'accepted' | 'rejected'
 }
 
 // --- Board ---

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -478,14 +478,25 @@ let handle_keeper_task_tool_with_outcome
           (error_json
              ("broadcast was not persisted: "
               ^ Workspace.broadcast_error_to_string error))
-      | Ok _ ->
-        Keeper_tool_execution.success
-          (Yojson.Safe.to_string
-             (`Assoc
-                [ "ok", `Bool true
-                ; "broadcast", `String message
-                ; "typed_outcome", Keeper_tool_outcome.to_json Keeper_tool_outcome.Progress
-                ])))
+      | Ok delivery ->
+        let data = Workspace_broadcast.broadcast_delivery_to_yojson delivery in
+        (match delivery.mention_delivery with
+         | Workspace_broadcast.Passive
+         | Workspace_broadcast.Accepted
+         | Workspace_broadcast.Already_accepted ->
+           Keeper_tool_execution.success_data data
+         | Workspace_broadcast.Pending
+         | Workspace_broadcast.Deferred _ ->
+           Keeper_tool_execution.deferred_data data
+         | Workspace_broadcast.Rejected _ ->
+           Keeper_tool_execution.failure_data
+             ~class_:Tool_result.Workflow_rejection
+             ~effect_disposition:Tool_result.Proven_post_effect
+             ~message:
+               (Printf.sprintf
+                  "Broadcast persisted, but the explicit Keeper delivery was rejected; do not resend; request_id=%s"
+                  delivery.request_id)
+             data))
     | Task_create ->
     let title = Safe_ops.json_string ~default:"" "title" args |> String.trim in
     let description = Safe_ops.json_string ~default:"" "description" args |> String.trim in

--- a/lib/mcp_tool_runtime_comm.ml
+++ b/lib/mcp_tool_runtime_comm.ml
@@ -65,28 +65,63 @@ let handle_broadcast ~tool_name ~start_time (ctx : context) : tool_result option
       let from_agent = delivery.from_agent in
       let mention = delivery.mention in
       let message = delivery.content in
-      let _ =
-        Session.push_message registry ~from_agent ~content:message ~mention
+      let project_auxiliary label project =
+        try project () with
+        | Eio.Cancel.Cancelled _ as exn -> raise exn
+        | exn ->
+          Log.Mcp.warn
+            "broadcast auxiliary projection failed projection=%s request_id=%s: %s"
+            label
+            delivery.request_id
+            (Printexc.to_string exn)
       in
+      project_auxiliary "session" (fun () ->
+        ignore (Session.push_message registry ~from_agent ~content:message ~mention));
       let notification_fields =
         [ ("type", `String "masc/broadcast")
+        ; ("request_id", `String delivery.request_id)
         ; ("from", `String from_agent)
         ; ("content", `String message)
         ; ("mention", Json_util.string_opt_to_json mention)
+        ; ( "mention_delivery"
+          , Workspace_broadcast.mention_delivery_to_yojson
+              delivery.mention_delivery )
         ; ("timestamp", `Float (Time_compat.now ()))
         ]
       in
       let notification =
         `Assoc (Otel_trace_context.inject_json notification_fields trace_context)
       in
-      Mcp_server.sse_broadcast state notification;
-      Subscriptions.push_event_to_sessions notification;
-      (match mention with
-       | Some target ->
-         Notify.notify_mention ~from_agent ~target_agent:target ~message ()
-       | None -> ());
-      Audit_log.log_broadcast config ~agent_id:from_agent ~message_preview:message ();
-      Some (Tool_result.ok ~tool_name ~start_time delivery.rendered)
+      project_auxiliary "sse" (fun () ->
+        Mcp_server.sse_broadcast state notification);
+      project_auxiliary "subscriptions" (fun () ->
+        Subscriptions.push_event_to_sessions notification);
+      project_auxiliary "notification" (fun () ->
+        match mention with
+        | Some target ->
+          Notify.notify_mention ~from_agent ~target_agent:target ~message ()
+        | None -> ());
+      project_auxiliary "audit" (fun () ->
+        Audit_log.log_broadcast config ~agent_id:from_agent ~message_preview:message ());
+      let data = Workspace_broadcast.broadcast_delivery_to_yojson delivery in
+      Some
+        (match delivery.mention_delivery with
+         | Workspace_broadcast.Passive
+         | Workspace_broadcast.Accepted
+         | Workspace_broadcast.Already_accepted ->
+           Tool_result.make_ok ~tool_name ~start_time ~data ()
+         | Workspace_broadcast.Pending
+         | Workspace_broadcast.Deferred _ ->
+           Tool_result.make_deferred ~tool_name ~start_time ~data ()
+         | Workspace_broadcast.Rejected _ ->
+           Tool_result.make_err
+             ~tool_name
+             ~class_:Tool_result.Workflow_rejection
+             ~start_time
+             ~data
+             (Printf.sprintf
+                "Broadcast persisted, but the explicit Keeper delivery was rejected; do not resend; request_id=%s"
+                delivery.request_id))
 
 (** masc_messages — retrieve recent messages *)
 let handle_messages ~tool_name ~start_time (ctx : context) : tool_result option =

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -67,9 +67,9 @@ let keeper_recovery_outcome after_diagnostic =
 
 (** {1 Domain-specific action handlers} *)
 
-let workspace_action_result request result =
+let workspace_action_result ?(result_status = ActionOk) request result =
   let* tool_name = delegated_tool_for request.action_type in
-  Ok (`Assoc [ ("tool_name", `String tool_name); ("result", result) ])
+  Ok (`Assoc [ ("tool_name", `String tool_name); ("result", result) ], result_status)
 
 let execute_workspace_action (ctx : 'a context) (request : action_request) =
   match request.action_type with
@@ -79,9 +79,24 @@ let execute_workspace_action (ctx : 'a context) (request : action_request) =
         require_payload_field request.payload "message"
           "payload.message is required"
       in
-      (match Workspace.broadcast ctx.config ~from_agent:request.actor ~content:message with
-       | Ok result -> workspace_action_result request (`String result.rendered)
-       | Error error -> Error (Workspace.broadcast_error_to_string error))
+      let* result =
+        match
+          Workspace.broadcast ctx.config ~from_agent:request.actor ~content:message
+        with
+        | Ok result -> Ok result
+        | Error error -> Error (Workspace.broadcast_error_to_string error)
+      in
+      let result_status =
+        match result.mention_delivery with
+        | Workspace_broadcast.Passive
+        | Workspace_broadcast.Accepted
+        | Workspace_broadcast.Already_accepted -> ActionOk
+        | Workspace_broadcast.Pending
+        | Workspace_broadcast.Deferred _ -> ActionDeferred
+        | Workspace_broadcast.Rejected _ -> ActionError
+      in
+      workspace_action_result ~result_status request
+        (Workspace_broadcast.broadcast_delivery_to_yojson result)
   | "namespace_pause" ->
       let* () = validate_target_type Operator_action_constants.Workspace request in
       let reason =
@@ -223,12 +238,12 @@ let execute_keeper_action (ctx : 'a context) (request : action_request) =
   | _ -> Error (Printf.sprintf "not a keeper action: %s" request.action_type)
 
 let execute_action (ctx : 'a context) (request : action_request) :
-    (Yojson.Safe.t, string) result =
+    (Yojson.Safe.t * action_result_status, string) result =
   match request.action_type with
   | "broadcast" | "namespace_pause" | "namespace_resume" | "task_inject" ->
       execute_workspace_action ctx request
   | "keeper_probe" | "keeper_recover" | "keeper_message" ->
-      execute_keeper_action ctx request
+      execute_keeper_action ctx request |> Result.map (fun result -> result, ActionOk)
   | "" -> Error "action_type is required"
   | other -> Error (Printf.sprintf "unsupported action_type: %s" other)
 
@@ -292,7 +307,7 @@ let action_json ?actor_hint (ctx : _ context) args :
            ("expires_at", `String expires_at);
          ]))
   else
-    let* executed = execute_action ctx request in
+    let* executed, result_status = execute_action ctx request in
     let latency_ms = int_of_float ((Unix.gettimeofday () -. started_at) *. 1000.0) in
     append_action_log ctx.config
       {
@@ -305,18 +320,22 @@ let action_json ?actor_hint (ctx : _ context) args :
         target_id = request.target_id;
         delegated_tool;
         confirmation_state = Immediate;
-        result_status = ActionOk;
+        result_status;
         latency_ms;
         created_at = Masc_domain.now_iso ();
       };
+    let fields =
+      [ ("trace_id", `String trace_id)
+      ; ("confirm_required", `Bool false)
+      ; ("tool_name", `String delegated_tool)
+      ; ("result", executed)
+      ]
+    in
     Ok
-      (Tool_args.ok_assoc
-         [
-           ("trace_id", `String trace_id);
-           ("confirm_required", `Bool false);
-           ("tool_name", `String delegated_tool);
-           ("result", executed);
-         ])
+      (match result_status with
+       | ActionOk -> Tool_args.ok_assoc fields
+       | ActionDeferred -> `Assoc (("status", `String "deferred") :: fields)
+       | ActionError -> Tool_args.error_assoc fields)
 
 let confirm_json ?actor_hint (ctx : _ context) args :
     (Yojson.Safe.t, string) result =
@@ -422,7 +441,7 @@ let confirm_json ?actor_hint (ctx : _ context) args :
               }
             in
             let* () = remove_pending_confirm ctx.config confirm_token in
-            let* executed = execute_action ctx request in
+            let* executed, result_status = execute_action ctx request in
             let latency_ms = int_of_float ((Unix.gettimeofday () -. started_at) *. 1000.0) in
             append_action_log ctx.config
               {
@@ -435,7 +454,7 @@ let confirm_json ?actor_hint (ctx : _ context) args :
                 target_id = entry.target_id;
                 delegated_tool = entry.delegated_tool;
                 confirmation_state = Confirmed;
-                result_status = ActionOk;
+                result_status;
                 latency_ms;
                 created_at = Masc_domain.now_iso ();
               };
@@ -443,12 +462,16 @@ let confirm_json ?actor_hint (ctx : _ context) args :
               ~agent_id:entry.actor ~trace_id:entry.trace_id
               ~decision:Audit_log.Gate_confirm ~action_type:entry.action_type
               ~confirmation_state:(confirmation_state_to_string Confirmed) ();
+            let fields =
+              [ ("trace_id", `String entry.trace_id)
+              ; ("decision", `String "confirm")
+              ; ("tool_name", `String entry.delegated_tool)
+              ; ("result", executed)
+              ; ("executed_action", pending_confirm_to_yojson entry)
+              ]
+            in
             Ok
-              (Tool_args.ok_assoc
-                 [
-                   ("trace_id", `String entry.trace_id);
-                   ("decision", `String "confirm");
-                   ("tool_name", `String entry.delegated_tool);
-                   ("result", executed);
-                   ("executed_action", pending_confirm_to_yojson entry);
-                 ]))
+              (match result_status with
+               | ActionOk -> Tool_args.ok_assoc fields
+               | ActionDeferred -> `Assoc (("status", `String "deferred") :: fields)
+               | ActionError -> Tool_args.error_assoc fields))

--- a/lib/operator/operator_control_snapshot.mli
+++ b/lib/operator/operator_control_snapshot.mli
@@ -118,7 +118,7 @@ val remote_confirm_ttl_seconds : float
     {!Operator_control} reads it via the runtime-include
     of this module to compute expiration timestamps. *)
 
-type action_result_status = ActionOk | ActionError
+type action_result_status = ActionOk | ActionDeferred | ActionError
 
 type confirmation_state =
   | Preview

--- a/lib/operator/operator_control_snapshot_action_log.ml
+++ b/lib/operator/operator_control_snapshot_action_log.ml
@@ -22,10 +22,12 @@
 
 type action_result_status =
   | ActionOk
+  | ActionDeferred
   | ActionError
 
 let action_result_status_to_string = function
   | ActionOk -> "ok"
+  | ActionDeferred -> "deferred"
   | ActionError -> "error"
 ;;
 

--- a/lib/operator/operator_control_snapshot_action_log.mli
+++ b/lib/operator/operator_control_snapshot_action_log.mli
@@ -2,6 +2,7 @@
 
 type action_result_status =
   | ActionOk
+  | ActionDeferred
   | ActionError
 
 val action_result_status_to_string : action_result_status -> string

--- a/lib/operator/operator_tool.ml
+++ b/lib/operator/operator_tool.ml
@@ -41,7 +41,18 @@ let task_recovery_tool_name =
 
 let result_of_json ~tool_name ~start_time = function
   | Ok json ->
-      Tool_result.make_ok ~tool_name ~start_time ~data:json ()
+      (match Json_util.assoc_string_opt "status" json with
+       | Some "deferred" ->
+         Tool_result.make_deferred ~tool_name ~start_time ~data:json ()
+       | Some "error" ->
+         Tool_result.make_err
+           ~tool_name
+           ~class_:Tool_result.Workflow_rejection
+           ~start_time
+           ~data:json
+           "Workspace message persisted, but Keeper delivery was rejected; do not resend"
+       | Some _ | None ->
+         Tool_result.make_ok ~tool_name ~start_time ~data:json ())
   | Error message ->
       let data = Tool_args.error_assoc [ "message", `String message ] in
       Tool_result.make_err

--- a/lib/server/masc_grpc_service.ml
+++ b/lib/server/masc_grpc_service.ml
@@ -61,7 +61,18 @@ let handle_broadcast (workspace_config : Workspace_utils_backend_setup.config) (
     decode_request_or_raise ~rpc:"Broadcast" T.BroadcastRequest.of_bytes_result bytes
   in
   let result =
-    try
+    if List.length req.mentions > 1
+    then
+      T.BroadcastResponse.
+        { success = false
+        ; seq = 0L
+        ; request_id = None
+        ; delivery_status = Delivery_not_persisted
+        ; delivery_reason = Some "multiple_mention_targets_unsupported"
+        ; workspace_persistence_status = Workspace_not_persisted
+        ; retry_disposition = Retry_allowed
+        }
+    else try
       let content =
         if req.mentions = []
         then req.message
@@ -72,17 +83,59 @@ let handle_broadcast (workspace_config : Workspace_utils_backend_setup.config) (
           mention_prefix ^ " " ^ req.message)
       in
       (match Workspace.broadcast workspace_config ~from_agent:req.agent_name ~content with
-       | Ok _ -> T.BroadcastResponse.{ success = true; seq = now_ms () }
+       | Ok delivery ->
+         let success =
+           match delivery.mention_delivery with
+           | Workspace_broadcast.Passive
+           | Workspace_broadcast.Accepted
+           | Workspace_broadcast.Already_accepted -> true
+           | Workspace_broadcast.Pending
+           | Workspace_broadcast.Deferred _
+           | Workspace_broadcast.Rejected _ -> false
+         in
+         T.BroadcastResponse.
+           { success
+           ; seq = Int64.of_int delivery.seq
+           ; request_id = Some delivery.request_id
+           ; delivery_status =
+               (match delivery.mention_delivery with
+                | Workspace_broadcast.Passive -> Delivery_passive
+                | Workspace_broadcast.Accepted -> Delivery_accepted
+                | Workspace_broadcast.Already_accepted -> Delivery_already_accepted
+                | Workspace_broadcast.Pending -> Delivery_pending
+                | Workspace_broadcast.Deferred _ -> Delivery_deferred
+                | Workspace_broadcast.Rejected _ -> Delivery_rejected)
+           ; delivery_reason =
+               Workspace_broadcast.mention_delivery_reason delivery.mention_delivery
+           ; workspace_persistence_status = Workspace_persisted
+           ; retry_disposition = Retry_do_not_resend
+           }
        | Error error ->
          Log.Transport.error
            "gRPC broadcast was not persisted: %s"
            (Workspace.broadcast_error_to_string error);
-         T.BroadcastResponse.{ success = false; seq = 0L })
+         T.BroadcastResponse.
+           { success = false
+           ; seq = 0L
+           ; request_id = None
+           ; delivery_status = Delivery_not_persisted
+           ; delivery_reason = Some (Workspace.broadcast_error_to_string error)
+           ; workspace_persistence_status = Workspace_not_persisted
+           ; retry_disposition = Retry_allowed
+           })
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | exn ->
       Log.Transport.error "gRPC broadcast failed: %s" (Printexc.to_string exn);
-      T.BroadcastResponse.{ success = false; seq = 0L }
+      T.BroadcastResponse.
+        { success = false
+        ; seq = 0L
+        ; request_id = None
+        ; delivery_status = Delivery_outcome_unknown
+        ; delivery_reason = Some (Printexc.to_string exn)
+        ; workspace_persistence_status = Workspace_persistence_unknown
+        ; retry_disposition = Retry_outcome_unknown
+        }
   in
   T.BroadcastResponse.to_bytes result
 ;;

--- a/lib/server/masc_grpc_types.ml
+++ b/lib/server/masc_grpc_types.ml
@@ -383,18 +383,118 @@ module BroadcastRequest = struct
 end
 
 module BroadcastResponse = struct
+  type delivery_status =
+    | Delivery_passive
+    | Delivery_accepted
+    | Delivery_already_accepted
+    | Delivery_pending
+    | Delivery_deferred
+    | Delivery_rejected
+    | Delivery_not_persisted
+    | Delivery_outcome_unknown
+
+  type retry_disposition =
+    | Retry_do_not_resend
+    | Retry_allowed
+    | Retry_outcome_unknown
+
+  type workspace_persistence_status =
+    | Workspace_persisted
+    | Workspace_not_persisted
+    | Workspace_persistence_unknown
+
   type t =
     { success : bool
     ; seq : int64
+    ; request_id : string option
+    ; delivery_status : delivery_status
+    ; delivery_reason : string option
+    ; workspace_persistence_status : workspace_persistence_status
+    ; retry_disposition : retry_disposition
     }
+
+  let delivery_status_to_wire = function
+    | Delivery_passive -> "passive"
+    | Delivery_accepted -> "accepted"
+    | Delivery_already_accepted -> "already_accepted"
+    | Delivery_pending -> "pending"
+    | Delivery_deferred -> "deferred"
+    | Delivery_rejected -> "rejected"
+    | Delivery_not_persisted -> "not_persisted"
+    | Delivery_outcome_unknown -> "outcome_unknown"
+  ;;
+
+  let delivery_status_of_wire = function
+    | "passive" -> Delivery_passive
+    | "accepted" -> Delivery_accepted
+    | "already_accepted" -> Delivery_already_accepted
+    | "pending" -> Delivery_pending
+    | "deferred" -> Delivery_deferred
+    | "rejected" -> Delivery_rejected
+    | "not_persisted" -> Delivery_not_persisted
+    | "outcome_unknown" -> Delivery_outcome_unknown
+    | value -> invalid_arg (Printf.sprintf "unknown BroadcastResponse.delivery_status: %S" value)
+  ;;
+
+  let retry_disposition_to_wire = function
+    | Retry_do_not_resend -> "do_not_resend"
+    | Retry_allowed -> "retry_allowed"
+    | Retry_outcome_unknown -> "outcome_unknown"
+  ;;
+
+  let retry_disposition_of_wire = function
+    | "do_not_resend" -> Retry_do_not_resend
+    | "retry_allowed" -> Retry_allowed
+    | "outcome_unknown" -> Retry_outcome_unknown
+    | value -> invalid_arg (Printf.sprintf "unknown BroadcastResponse.retry_disposition: %S" value)
+  ;;
+
+  let workspace_persistence_status_to_wire = function
+    | Workspace_persisted -> "persisted"
+    | Workspace_not_persisted -> "not_persisted"
+    | Workspace_persistence_unknown -> "outcome_unknown"
+  ;;
+
+  let workspace_persistence_status_of_wire = function
+    | "persisted" -> Workspace_persisted
+    | "not_persisted" -> Workspace_not_persisted
+    | "outcome_unknown" -> Workspace_persistence_unknown
+    | value ->
+      invalid_arg
+        (Printf.sprintf
+           "unknown BroadcastResponse.workspace_persistence_status: %S"
+           value)
+  ;;
+
+  let nonempty_option value =
+    if String.trim value = "" then None else Some value
+  ;;
 
   let of_bytes bytes =
     let p = decode ~type_name:"BroadcastResponse" P.BroadcastResponse.from_proto bytes in
-    { success = p.success; seq = p.seq }
+    { success = p.success
+    ; seq = p.seq
+    ; request_id = nonempty_option p.request_id
+    ; delivery_status = delivery_status_of_wire p.delivery_status
+    ; delivery_reason = nonempty_option p.delivery_reason
+    ; workspace_persistence_status =
+        workspace_persistence_status_of_wire p.workspace_persistence_status
+    ; retry_disposition = retry_disposition_of_wire p.retry_disposition
+    }
   ;;
 
   let to_bytes (t : t) =
-    encode P.BroadcastResponse.to_proto { success = t.success; seq = t.seq }
+    encode
+      P.BroadcastResponse.to_proto
+      { success = t.success
+      ; seq = t.seq
+      ; request_id = Option.value t.request_id ~default:""
+      ; delivery_status = delivery_status_to_wire t.delivery_status
+      ; delivery_reason = Option.value t.delivery_reason ~default:""
+      ; workspace_persistence_status =
+          workspace_persistence_status_to_wire t.workspace_persistence_status
+      ; retry_disposition = retry_disposition_to_wire t.retry_disposition
+      }
   ;;
 end
 

--- a/lib/server/masc_grpc_types.mli
+++ b/lib/server/masc_grpc_types.mli
@@ -132,9 +132,34 @@ module BroadcastRequest : sig
 end
 
 module BroadcastResponse : sig
+  type delivery_status =
+    | Delivery_passive
+    | Delivery_accepted
+    | Delivery_already_accepted
+    | Delivery_pending
+    | Delivery_deferred
+    | Delivery_rejected
+    | Delivery_not_persisted
+    | Delivery_outcome_unknown
+
+  type retry_disposition =
+    | Retry_do_not_resend
+    | Retry_allowed
+    | Retry_outcome_unknown
+
+  type workspace_persistence_status =
+    | Workspace_persisted
+    | Workspace_not_persisted
+    | Workspace_persistence_unknown
+
   type t =
     { success : bool
     ; seq : int64
+    ; request_id : string option
+    ; delivery_status : delivery_status
+    ; delivery_reason : string option
+    ; workspace_persistence_status : workspace_persistence_status
+    ; retry_disposition : retry_disposition
     }
 
   val of_bytes : string -> t

--- a/lib/server/server_routes_http_dashboard_handlers.ml
+++ b/lib/server/server_routes_http_dashboard_handlers.ml
@@ -25,13 +25,18 @@ let handle_broadcast state agent_name reqd body_str =
     in
     Http.Response.json_value (`Assoc fields) reqd
   in
+  let reply_delivery delivery =
+    Http.Response.json_value
+      (Workspace_broadcast.broadcast_delivery_to_yojson delivery)
+      reqd
+  in
   try
     let json = Yojson.Safe.from_string body_str in
     match Json_util.assoc_member_opt "message" json with
     | Some (`String message) ->
         let config = (Mcp_server.workspace_config state) in
         (match Workspace.broadcast config ~from_agent:agent_name ~content:message with
-         | Ok _ -> reply true None
+         | Ok delivery -> reply_delivery delivery
          | Error error ->
            reply false (Some (Workspace.broadcast_error_to_string error)))
     | Some `Null -> reply false (Some "missing required field: message")

--- a/proto/masc_workspace.proto
+++ b/proto/masc_workspace.proto
@@ -106,6 +106,16 @@ message BroadcastRequest {
 message BroadcastResponse {
   bool success = 1;
   int64 seq = 2;
+  // Exact producer identity for observing a committed broadcast.
+  string request_id = 3;
+  // passive | accepted | already_accepted | pending | deferred | rejected
+  // | not_persisted | outcome_unknown
+  string delivery_status = 4;
+  string delivery_reason = 5;
+  // persisted | not_persisted | outcome_unknown
+  string workspace_persistence_status = 6;
+  // do_not_resend | retry_allowed | outcome_unknown
+  string retry_disposition = 7;
 }
 
 // ===== Status =====

--- a/test/test_grpc_client.ml
+++ b/test/test_grpc_client.ml
@@ -120,7 +120,17 @@ let test_broadcast_request_roundtrip () =
   Alcotest.(check (list string)) "mentions" req.mentions decoded.mentions
 
 let test_broadcast_response_roundtrip () =
-  let resp = T.BroadcastResponse.{ success = true; seq = 42L } in
+  let resp =
+    T.BroadcastResponse.
+      { success = true
+      ; seq = 42L
+      ; request_id = Some "wmsg-0123456789abcdef0123456789abcdef"
+      ; delivery_status = Delivery_accepted
+      ; delivery_reason = None
+      ; workspace_persistence_status = Workspace_persisted
+      ; retry_disposition = Retry_do_not_resend
+      }
+  in
   let bytes = T.BroadcastResponse.to_bytes resp in
   let decoded = T.BroadcastResponse.of_bytes bytes in
   Alcotest.(check bool) "success" true decoded.success;

--- a/test/test_grpc_workspace.ml
+++ b/test/test_grpc_workspace.ml
@@ -132,7 +132,17 @@ let test_broadcast_request_roundtrip () =
 ;;
 
 let test_broadcast_response_roundtrip () =
-  let resp = T.BroadcastResponse.{ success = true; seq = 42L } in
+  let resp =
+    T.BroadcastResponse.
+      { success = true
+      ; seq = 42L
+      ; request_id = Some "wmsg-0123456789abcdef0123456789abcdef"
+      ; delivery_status = Delivery_accepted
+      ; delivery_reason = None
+      ; workspace_persistence_status = Workspace_persisted
+      ; retry_disposition = Retry_do_not_resend
+      }
+  in
   let bytes = T.BroadcastResponse.to_bytes resp in
   let decoded = T.BroadcastResponse.of_bytes bytes in
   Alcotest.(check bool) "success" true decoded.success;


### PR DESCRIPTION
## As-Is
After a workspace broadcast committed, MCP auxiliary projection failures could erase the authoritative receipt. Operator and gRPC collapsed deferred/rejected/unknown outcomes into an unsafe boolean.

## To-Be
- MCP/Keeper/Operator/HTTP return the exact committed request receipt and distinguish accepted, deferred, rejected, and not persisted.
- Auxiliary Session/SSE/notification/audit projections are best-effort after the authoritative receipt exists.
- gRPC rejects multiple mention targets before persistence and returns request identity, delivery status/reason, tri-state workspace persistence, and retry disposition.
- Operator logs deferred separately and treats terminal rejection as an error with do-not-resend evidence.

Parent: `agent/broadcast-keeper-recovery` exact `bf357faa6b79e74b76a3bed52deff3de65d0e052`
Head: `3948aa4006178b0752784e8d2ebd687a68fc0f27`

Fast checks: OCaml parse/format, diff-check, ratchets. Existing gRPC record fixtures adapted for the new exhaustive type. No new tests. No local Dune build. Independent exact-head review: no P1/P2.

CI, merge, deployment, and live rerun remain pending.

# ci:skip-test-coverage
