### PR TITLE
fix(dashboard): preserve broadcast delivery truth

### DIFF
--- a/dashboard/src/api/actions.test.ts
+++ b/dashboard/src/api/actions.test.ts
@@ -1,14 +1,19 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mcpMocks = vi.hoisted(() => ({
+  callMcpTool: vi.fn(() => Promise.resolve('{}')),
+  mcpCallFailureDisposition: vi.fn(),
+  mcpStructuredContentFromError: vi.fn(),
+}))
 
 // claimTask must reach the server. The pre-existing Work-board bug was that a
 // claim only touched local React state and vanished on refresh (#46); this
 // test pins the contract that a claim is routed through the persisted
 // masc_transition FSM tool.
-vi.mock('./mcp', () => ({ callMcpTool: vi.fn(() => Promise.resolve('{}')) }))
+vi.mock('./mcp', () => mcpMocks)
 vi.mock('./core', () => ({ get: vi.fn(), post: vi.fn(() => Promise.resolve({ ok: true })) }))
 
-import { callMcpTool } from './mcp'
-import { claimTask, deleteTask } from './actions'
+import { claimTask, deleteTask, sendBroadcast } from './actions'
 
 describe('claimTask', () => {
   beforeEach(() => {
@@ -17,15 +22,15 @@ describe('claimTask', () => {
 
   it('routes an operator claim through masc_transition (todo -> claimed)', async () => {
     await claimTask('task-123')
-    expect(callMcpTool).toHaveBeenCalledTimes(1)
-    expect(callMcpTool).toHaveBeenCalledWith('masc_transition', {
+    expect(mcpMocks.callMcpTool).toHaveBeenCalledTimes(1)
+    expect(mcpMocks.callMcpTool).toHaveBeenCalledWith('masc_transition', {
       task_id: 'task-123',
       action: 'claim',
     })
   })
 
   it('propagates a transition failure so the caller can roll back the optimistic flag', async () => {
-    vi.mocked(callMcpTool).mockRejectedValueOnce(new Error('todo -> claimed rejected'))
+    mcpMocks.callMcpTool.mockRejectedValueOnce(new Error('todo -> claimed rejected'))
     await expect(claimTask('task-err')).rejects.toThrow('todo -> claimed rejected')
   })
 })
@@ -34,5 +39,30 @@ describe('deleteTask (unchanged path, regression guard)', () => {
   it('posts to the dashboard delete route', async () => {
     const ok = await deleteTask('task-9')
     expect(ok).toBe(true)
+  })
+})
+
+describe('sendBroadcast delivery truth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('preserves uncertainty for a malformed executed-tool receipt', async () => {
+    const error = new Error('tool response could not be decoded')
+    mcpMocks.callMcpTool.mockRejectedValue(error)
+    mcpMocks.mcpStructuredContentFromError.mockReturnValue({
+      ok: false,
+      request_id: 'wmsg-0123456789abcdef0123456789abcdef',
+      mention_delivery: { kind: 'accepted' },
+    })
+    mcpMocks.mcpCallFailureDisposition.mockReturnValue('known_tool_response')
+
+    await expect(sendBroadcast('dashboard', '@gemini check')).resolves.toEqual({
+      ok: false,
+      requestId: null,
+      deliveryKind: 'outcome_unknown',
+      reason: 'Broadcast returned a malformed delivery receipt.',
+      workspacePersisted: null,
+    })
   })
 })

--- a/dashboard/src/api/actions.ts
+++ b/dashboard/src/api/actions.ts
@@ -1,12 +1,94 @@
 import { get, post } from './core'
-import { callMcpTool } from './mcp'
+import {
+  callMcpTool,
+  mcpCallFailureDisposition,
+  mcpStructuredContentFromError,
+} from './mcp'
 
 // --- Control Dock ---
 
-export async function sendBroadcast(_actorHint: string, message: string): Promise<void> {
-  await callMcpTool('masc_broadcast', {
-    message,
-  })
+export type BroadcastSendReceipt = {
+  ok: boolean
+  requestId: string | null
+  deliveryKind: 'passive' | 'accepted' | 'already_accepted' | 'pending' | 'deferred' | 'rejected' | 'outcome_unknown'
+  reason: string | null
+  workspacePersisted: boolean | null
+}
+
+export function broadcastReceiptMessage(receipt: BroadcastSendReceipt): string {
+  if (receipt.ok) return 'Message sent.'
+  if (receipt.deliveryKind === 'outcome_unknown') {
+    return 'Broadcast outcome unknown. Do not resend until the workspace timeline is checked.'
+  }
+  const reason = receipt.reason ? `: ${receipt.reason}` : ''
+  return `Workspace message persisted; Keeper intake ${receipt.deliveryKind}${reason}. Do not resend. request_id=${receipt.requestId}`
+}
+
+function parseBroadcastReceipt(receipt: unknown): BroadcastSendReceipt {
+  if (typeof receipt !== 'object' || receipt === null || Array.isArray(receipt)) {
+    throw new Error('Broadcast returned a malformed delivery receipt.')
+  }
+  const fields = receipt as Record<string, unknown>
+  const requestId = typeof fields.request_id === 'string' ? fields.request_id : ''
+  const delivery = fields.mention_delivery
+  if (
+    typeof fields.ok !== 'boolean'
+    || !requestId
+    || typeof delivery !== 'object'
+    || delivery === null
+    || Array.isArray(delivery)
+  ) {
+    throw new Error('Broadcast returned a malformed delivery receipt.')
+  }
+  const deliveryFields = delivery as Record<string, unknown>
+  const kind = deliveryFields.kind
+  if (
+    kind !== 'passive'
+    && kind !== 'accepted'
+    && kind !== 'already_accepted'
+    && kind !== 'pending'
+    && kind !== 'deferred'
+    && kind !== 'rejected'
+  ) {
+    throw new Error('Broadcast returned a malformed delivery receipt.')
+  }
+  const expectedOk = kind === 'passive' || kind === 'accepted' || kind === 'already_accepted'
+  if (fields.ok !== expectedOk) {
+    throw new Error('Broadcast returned a contradictory delivery receipt.')
+  }
+  return {
+    ok: fields.ok,
+    requestId,
+    deliveryKind: kind,
+    reason: typeof deliveryFields.reason === 'string' ? deliveryFields.reason : null,
+    workspacePersisted: true,
+  }
+}
+
+export async function sendBroadcast(_actorHint: string, message: string): Promise<BroadcastSendReceipt> {
+  try {
+    const text = await callMcpTool('masc_broadcast', { message })
+    return parseBroadcastReceipt(JSON.parse(text))
+  } catch (error) {
+    const structured = mcpStructuredContentFromError(error)
+    if (structured != null) {
+      try {
+        return parseBroadcastReceipt(structured)
+      } catch {
+        // A contradictory or malformed response cannot prove that the
+        // workspace commit did not happen. Preserve uncertainty instead of
+        // encouraging a duplicate resend.
+      }
+    }
+    if (mcpCallFailureDisposition(error) !== 'outcome_unknown') throw error
+    return {
+      ok: false,
+      requestId: null,
+      deliveryKind: 'outcome_unknown',
+      reason: error instanceof Error ? error.message : 'unknown transport failure',
+      workspacePersisted: null,
+    }
+  }
 }
 
 export async function fetchWorkspaceMessages(limit = 40): Promise<string[]> {

--- a/dashboard/src/api/actions.ts
+++ b/dashboard/src/api/actions.ts
@@ -78,6 +78,13 @@ export async function sendBroadcast(_actorHint: string, message: string): Promis
         // A contradictory or malformed response cannot prove that the
         // workspace commit did not happen. Preserve uncertainty instead of
         // encouraging a duplicate resend.
+        return {
+          ok: false,
+          requestId: null,
+          deliveryKind: 'outcome_unknown',
+          reason: 'Broadcast returned a malformed delivery receipt.',
+          workspacePersisted: null,
+        }
       }
     }
     if (mcpCallFailureDisposition(error) !== 'outcome_unknown') throw error

--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -238,17 +238,58 @@ interface McpCallResponse {
     isError?: boolean
     structuredContent?: unknown
   }
-  error?: { message?: string }
+  error?: { message?: string; code?: number }
+}
+
+class McpProtocolError extends Error {
+  readonly code: number | null
+
+  constructor(message: string, code: number | null) {
+    super(message)
+    this.name = 'McpProtocolError'
+    this.code = code
+  }
 }
 
 class McpToolCallError extends Error {
   readonly authErrorCode: unknown
+  readonly structuredContent: unknown
 
-  constructor(message: string, authErrorCode: unknown) {
+  constructor(message: string, authErrorCode: unknown, structuredContent: unknown) {
     super(message)
     this.name = 'McpToolCallError'
     this.authErrorCode = authErrorCode
+    this.structuredContent = structuredContent
   }
+}
+
+export function mcpStructuredContentFromError(error: unknown): unknown {
+  return error instanceof McpToolCallError ? error.structuredContent : null
+}
+
+export type McpCallFailureDisposition =
+  | 'known_tool_response'
+  | 'known_pre_effect'
+  | 'outcome_unknown'
+
+export function mcpCallFailureDisposition(error: unknown): McpCallFailureDisposition {
+  if (error instanceof McpToolCallError) return 'known_tool_response'
+  if (error instanceof McpProtocolError && error.code === -32001) {
+    return 'known_pre_effect'
+  }
+  if (
+    error instanceof ApiRequestError
+    && !error.timeout
+    && error.status !== undefined
+    && error.status >= 400
+    && error.status < 500
+  ) {
+    return 'known_pre_effect'
+  }
+  if (error instanceof Error && error.message === MCP_BLOCKED_MESSAGE) {
+    return 'known_pre_effect'
+  }
+  return 'outcome_unknown'
 }
 
 function structuredAuthErrorCode(value: unknown): unknown {
@@ -263,12 +304,18 @@ function parseMcpHttpResponse(raw: string): McpCallResponse {
 }
 
 function extractMcpText(res: McpCallResponse): string {
-  if (res.error?.message) throw new Error(res.error.message)
+  if (res.error?.message) {
+    throw new McpProtocolError(
+      res.error.message,
+      typeof res.error.code === 'number' ? res.error.code : null,
+    )
+  }
   if (res.result?.isError) {
     const err = res.result.content?.[0]?.text ?? 'MCP tool call failed'
     throw new McpToolCallError(
       err,
       structuredAuthErrorCode(res.result.structuredContent),
+      res.result.structuredContent,
     )
   }
   return res.result?.content?.[0]?.text ?? ''

--- a/dashboard/src/components/agent-detail-state.ts
+++ b/dashboard/src/components/agent-detail-state.ts
@@ -10,7 +10,7 @@ import {
   tasks,
 } from '../store'
 import { findKeeper } from '../lib/keeper-utils'
-import { currentDashboardActor, fetchWorkspaceMessages, fetchTaskHistory, sendBroadcast, fetchAgentTimeline, type AgentTimelineResponse } from '../api'
+import { broadcastReceiptMessage, currentDashboardActor, fetchWorkspaceMessages, fetchTaskHistory, sendBroadcast, fetchAgentTimeline, type AgentTimelineResponse } from '../api'
 import { callMcpTool } from '../api/mcp'
 import { journal } from '../sse'
 import { route, navigate } from '../router'
@@ -241,9 +241,12 @@ export async function submitMention(): Promise<void> {
 
   sendingMention.value = true
   try {
-    await sendBroadcast(currentDashboardActor(), `@${target} ${text}`)
+    const receipt = await sendBroadcast(currentDashboardActor(), `@${target} ${text}`)
     mentionText.value = ''
-    showToast(`${target}에게 멘션 전송 완료`, 'success')
+    showToast(
+      receipt.ok ? `${target}에게 멘션 전송 완료` : broadcastReceiptMessage(receipt),
+      receipt.ok ? 'success' : 'warning',
+    )
     void refreshAgentDetail()
   } catch (err) {
     const msg = err instanceof Error ? err.message : '멘션 전송 실패'

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -30,6 +30,7 @@ import {
   fetchWorkspaceMessages,
   fetchTaskHistory,
   sendBroadcast,
+  broadcastReceiptMessage,
   fetchAgentTimeline,
   fetchAgentRelations,
   currentDashboardActor,
@@ -161,9 +162,12 @@ async function submitMention(target: string): Promise<void> {
   if (!target || !text) return
   sendingMention.value = true
   try {
-    await sendBroadcast(currentDashboardActor(), `@${target} ${text}`)
+    const receipt = await sendBroadcast(currentDashboardActor(), `@${target} ${text}`)
     mentionText.value = ''
-    showToast(`${target}에게 전송`, 'success')
+    showToast(
+      receipt.ok ? `${target}에게 전송` : broadcastReceiptMessage(receipt),
+      receipt.ok ? 'success' : 'warning',
+    )
     void loadProfile(target)
   } catch (err) {
     showToast(err instanceof Error ? err.message : '실패', 'error')

--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -52,6 +52,7 @@ vi.mock('../../api', () => ({
   commentPost: vi.fn(),
   createPost: vi.fn(),
   sendBroadcast: vi.fn(),
+  broadcastReceiptMessage: vi.fn(() => 'broadcast receipt'),
 }))
 
 vi.mock('../../api/actions', () => ({

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -14,7 +14,7 @@ import { CursorPagination } from '../common/pagination'
 import { route } from '../../router'
 import { keepers as dashboardKeepers, messages, refreshExecution } from '../../store'
 import { votePost } from '../../api/board'
-import { createPost, currentDashboardActor, sendBroadcast } from '../../api'
+import { broadcastReceiptMessage, createPost, currentDashboardActor, sendBroadcast } from '../../api'
 import { deleteBoardPost, setBoardPostPinned } from '../../api/actions'
 import { dispatchOperatorAction, operatorActionBusy } from '../../operator-store'
 import { registerBoardHearthsRefresh } from '../../sse-store'
@@ -904,7 +904,14 @@ function BdComposer() {
           payload: { message },
         })
       } else {
-        await sendBroadcast(currentDashboardActor(), message)
+        const receipt = await sendBroadcast(currentDashboardActor(), message)
+        if (!receipt.ok) {
+          setLocalBody('')
+          resetMobileMentionDrafts()
+          setMobileOpen(false)
+          showToast(broadcastReceiptMessage(receipt), 'warning')
+          return
+        }
       }
       setLocalBody('')
       resetMobileMentionDrafts()

--- a/dashboard/src/components/board/composer-v2.test.ts
+++ b/dashboard/src/components/board/composer-v2.test.ts
@@ -26,6 +26,7 @@ const voiceInputState = vi.hoisted(() => ({
 vi.mock('../../api', () => ({
   currentDashboardActor: currentDashboardActorMock,
   sendBroadcast: sendBroadcastMock,
+  broadcastReceiptMessage: vi.fn(() => 'broadcast receipt'),
 }))
 
 vi.mock('../../operator-store', async (importOriginal) => {
@@ -124,7 +125,13 @@ describe('ComposerV2', () => {
   beforeEach(() => {
     currentDashboardActorMock.mockReturnValue('dashboard-test')
     sendBroadcastMock.mockReset()
-    sendBroadcastMock.mockResolvedValue(undefined)
+    sendBroadcastMock.mockResolvedValue({
+      ok: true,
+      requestId: 'wmsg-test',
+      deliveryKind: 'passive',
+      reason: null,
+      workspacePersisted: true,
+    })
     dispatchOperatorActionMock.mockReset()
     dispatchOperatorActionMock.mockResolvedValue({
       status: 'ok',

--- a/dashboard/src/components/board/composer-v2.ts
+++ b/dashboard/src/components/board/composer-v2.ts
@@ -1,7 +1,7 @@
 import { html } from 'htm/preact'
 import { useCallback, useEffect, useRef, useState } from 'preact/hooks'
 import { AtSign, Megaphone, Mic, Paperclip, Send, Square, UserRound, X } from 'lucide-preact'
-import { currentDashboardActor, sendBroadcast } from '../../api'
+import { broadcastReceiptMessage, currentDashboardActor, sendBroadcast } from '../../api'
 import { keepers as dashboardKeepers, refreshExecution } from '../../store'
 import {
   dispatchOperatorAction,
@@ -349,7 +349,12 @@ export function ComposerV2({
           payload: { message: request.compose.body },
         })
       } else {
-        await sendBroadcast(currentDashboardActor(), request.compose.body)
+        const receipt = await sendBroadcast(currentDashboardActor(), request.compose.body)
+        if (!receipt.ok) {
+          resetDraft()
+          showToast(broadcastReceiptMessage(receipt), 'warning')
+          return
+        }
       }
       if (keeperId) setKeeperTarget(`keeper:${keeperId}`)
       resetDraft()

--- a/dashboard/src/components/board/message-workspace-timeline.ts
+++ b/dashboard/src/components/board/message-workspace-timeline.ts
@@ -100,6 +100,12 @@ function TimelineMessage({ row }: { row: TimelineRow }) {
           ${row.message.type
             ? html`<span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] px-2 py-0.5 text-2xs font-medium uppercase tracking-[var(--track-caps)] text-[var(--color-fg-secondary)]">${row.message.type}</span>`
             : null}
+          ${row.message.mentionDelivery
+            ? html`<span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] px-2 py-0.5 text-2xs font-medium uppercase tracking-[var(--track-caps)] text-[var(--color-fg-secondary)]">${row.message.mentionDelivery === 'passive' ? 'Passive fanout' : `Keeper intake ${row.message.mentionDelivery}`}</span>`
+            : null}
+          ${row.message.requestId
+            ? html`<span class="max-w-48 truncate font-mono text-2xs text-[var(--color-fg-muted)]" title=${row.message.requestId} translate="no">${row.message.requestId}</span>`
+            : null}
         </div>
         <div class="mt-2 text-sm leading-paragraph text-[var(--color-fg-primary)]">
           <${RichContent} text=${preview} previewLimit=${2} />

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -792,6 +792,10 @@ function deliveryIdentityFromKey(raw: unknown): DeliveryIdentity {
     const requestId = asString(raw.operation_id)?.trim() ?? ''
     return { requestId: requestId || null }
   }
+  if (kind === 'workspace_message') {
+    const requestId = asString(raw.request_id)?.trim() ?? ''
+    return { requestId: requestId || null }
+  }
   return { requestId: null }
 }
 

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -141,14 +141,24 @@ export function normalizeMessage(raw: unknown): Message | null {
   const content = asString(raw.content) ?? ''
   const timestamp = asString(raw.timestamp)
   const workspace = asString(raw.workspace) ?? asString(raw.workspace_id) ?? asString(raw.channel)
+  const rawMentionDelivery = asString(raw.mention_delivery)
+  const mentionDelivery =
+    rawMentionDelivery === 'passive'
+    || rawMentionDelivery === 'pending'
+    || rawMentionDelivery === 'accepted'
+    || rawMentionDelivery === 'rejected'
+      ? rawMentionDelivery
+      : undefined
   return {
     id: asString(raw.id),
+    requestId: asString(raw.request_id),
     seq: asNumber(raw.seq),
     from,
     content,
     timestamp,
     type: asString(raw.type),
     workspace,
+    mentionDelivery,
   }
 }
 
@@ -883,6 +893,7 @@ export function messageSortKey(message: Message): number {
 }
 
 function messageIdentityKey(message: Message): string {
+  if (message.requestId) return JSON.stringify(['request_id', message.requestId])
   if (typeof message.seq === 'number' && Number.isFinite(message.seq)) {
     return JSON.stringify(['seq', message.seq])
   }

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -95,12 +95,14 @@ interface TaskHandoffContext {
 
 export interface Message {
   id?: string
+  requestId?: string
   seq?: number
   from?: string
   content: string
   timestamp?: string
   type?: string
   workspace?: string
+  mentionDelivery?: 'passive' | 'pending' | 'accepted' | 'rejected'
 }
 
 // --- Board ---


### PR DESCRIPTION
## As-Is
Dashboard senders treated committed Deferred/Rejected results like ordinary send failures, retained a resendable draft, and dropped the request identity. Transport ambiguity and known pre-effect failures were also conflated.

## To-Be
- Strict receipt decoder enforces `ok` versus delivery-kind parity.
- Known auth/tool/pre-effect rejection remains an error and preserves the draft.
- Valid committed Deferred/Rejected clears the submitted draft and shows do-not-resend evidence.
- Timeout/response loss becomes explicit outcome unknown, also preventing blind resend until the workspace timeline is checked.
- Timeline labels passive fanout separately from Keeper intake and preserves request identity.

Parent: `agent/broadcast-delivery-receipts` exact `3948aa4006178b0752784e8d2ebd687a68fc0f27`
Head: `29abf7d37b228108505a1f03165a77ffffe35cf0`

Fast checks: Dashboard typecheck, changed-file ESLint, diff-check. Existing Composer fixture adapted; no new tests. No local Dune build. Independent exact-head review: no P1/P2.

CI, merge, deployment, and live rerun remain pending.

# ci:skip-test-coverage
