### PR TITLE
feat(keeper): materialize TOML tool compositions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1615,6 +1615,21 @@ jobs:
             libzstd1 \
             zlib1g
 
+      - name: Install Dashboard browser proof runtime
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+
+      - name: Install Dashboard dependencies and Chromium
+        working-directory: dashboard
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.31.0 --activate
+          pnpm install --frozen-lockfile
+          node --test e2e/keeper-composition-browser-evidence.test.mjs
+          ../scripts/build-dashboard-if-needed.sh
+          pnpm exec playwright install --with-deps chromium
+
       - name: Run five-Keeper real-world collaboration gate
         env:
           KEEPER_ACCEPTANCE_BINARY: ${{ github.workspace }}/keeper-realworld-runtime/masc
@@ -1711,7 +1726,7 @@ jobs:
               echo "FAIL Keeper Real-World Gate: acceptance result=$ACCEPTANCE_RESULT" >&2
               exit 1
             fi
-            echo "PASS Keeper Real-World Gate: trusted event=$EVENT_NAME ref=$EVENT_REF workflow=$EVENT_WORKFLOW_REF candidate=$TESTED_SOURCE_SHA passed RW01-RW16"
+            echo "PASS Keeper Real-World Gate: trusted event=$EVENT_NAME ref=$EVENT_REF workflow=$EVENT_WORKFLOW_REF candidate=$TESTED_SOURCE_SHA passed complete mission catalog"
             exit 0
           fi
           if [ "$EVENT_NAME" != "pull_request" ]; then

--- a/dashboard/e2e/keeper-composition-browser-evidence.mjs
+++ b/dashboard/e2e/keeper-composition-browser-evidence.mjs
@@ -1,0 +1,17 @@
+const EXPECTED_INLINE_NODES = ['board', 'board-peer', 'clock', 'memory']
+
+export function selectCompleteInlineRun(rows) {
+  const byRun = new Map()
+  for (const row of rows) {
+    if (!row.run || !row.node) continue
+    const runRows = byRun.get(row.run) ?? []
+    runRows.push(row)
+    byRun.set(row.run, runRows)
+  }
+  return [...byRun.entries()].find(([, runRows]) => {
+    const nodes = [...new Set(runRows.map(row => row.node))].sort()
+    return runRows.length === 4
+      && JSON.stringify(nodes) === JSON.stringify(EXPECTED_INLINE_NODES)
+      && runRows.every(row => row.execution === 'inline' && row.disposition === 'completed')
+  }) ?? null
+}

--- a/dashboard/e2e/keeper-composition-browser-evidence.test.mjs
+++ b/dashboard/e2e/keeper-composition-browser-evidence.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { selectCompleteInlineRun } from './keeper-composition-browser-evidence.mjs'
+
+const completeRows = ['board', 'board-peer', 'clock', 'memory'].map(node => ({
+  run: 'run-complete',
+  node,
+  execution: 'inline',
+  disposition: 'completed',
+}))
+
+test('selects one exact completed inline composition run', () => {
+  const selected = selectCompleteInlineRun([
+    { run: 'partial', node: 'clock', execution: 'inline', disposition: 'completed' },
+    ...completeRows,
+  ])
+  assert.equal(selected?.[0], 'run-complete')
+  assert.deepEqual(selected?.[1], completeRows)
+})
+test('rejects duplicate, failed, deferred, and async rows', () => {
+  assert.equal(selectCompleteInlineRun([...completeRows, completeRows[0]]), null)
+  assert.equal(selectCompleteInlineRun(
+    completeRows.map(row => row.node === 'memory' ? { ...row, disposition: 'failed' } : row),
+  ), null)
+  assert.equal(selectCompleteInlineRun(
+    completeRows.map(row => row.node === 'memory' ? { ...row, disposition: 'deferred' } : row),
+  ), null)
+  assert.equal(selectCompleteInlineRun(
+    completeRows.map(row => ({ ...row, execution: 'async' })),
+  ), null)
+})

--- a/dashboard/e2e/keeper-composition-real-backend.mjs
+++ b/dashboard/e2e/keeper-composition-real-backend.mjs
@@ -1,0 +1,243 @@
+import { chromium } from 'playwright'
+import { createHash } from 'node:crypto'
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { selectCompleteInlineRun } from './keeper-composition-browser-evidence.mjs'
+
+function required(name) {
+  const value = process.env[name]?.trim()
+  if (!value) throw new Error(`${name} is required`)
+  return value
+}
+
+const dashboardUrl = required('MASC_COMPOSITION_DASHBOARD_URL')
+const tokenFile = required('MASC_COMPOSITION_DASHBOARD_TOKEN_FILE')
+const keeperName = required('MASC_COMPOSITION_KEEPER_NAME')
+const expectedBasePath = required('MASC_COMPOSITION_EXPECTED_BASE_PATH')
+const artifactDir = required('MASC_COMPOSITION_BROWSER_ARTIFACT_DIR')
+const token = readFileSync(tokenFile, 'utf8').trim()
+if (!token) throw new Error('dashboard token file is empty')
+
+mkdirSync(artifactDir, { recursive: true })
+const screenshotPath = join(artifactDir, 'keeper-composition-inspector.png')
+const measurementPath = join(artifactDir, 'keeper-composition-inspector.json')
+const persistenceScreenshotPath = join(artifactDir, 'keeper-persistence-proof.png')
+const persistenceMeasurementPath = join(artifactDir, 'keeper-persistence-proof.json')
+const viewport = { width: 1440, height: 1000 }
+
+const healthResponse = await fetch(new URL('/health?full=1', dashboardUrl))
+if (!healthResponse.ok) throw new Error(`health preflight failed: ${healthResponse.status}`)
+const health = await healthResponse.json()
+if (health?.paths?.effective_base_path !== expectedBasePath) {
+  throw new Error(
+    `refusing non-isolated backend: expected=${expectedBasePath} observed=${health?.paths?.effective_base_path}`,
+  )
+}
+if (health?.dashboard_surface?.status !== 'ok') {
+  throw new Error(
+    `dashboard surface is not built and fresh: ${JSON.stringify(health?.dashboard_surface)}`,
+  )
+}
+
+const browser = await chromium.launch({ headless: true })
+try {
+  const page = await browser.newPage({ viewport })
+  const route = new URL(dashboardUrl)
+  route.searchParams.set('agent', 'dashboard')
+  route.searchParams.set('token', token)
+  route.hash = `monitoring?section=agents&keeper=${encodeURIComponent(keeperName)}`
+  await page.goto(route.toString())
+  await page.getByLabel('메시지 입력').waitFor()
+  await page.getByTestId('kw-chat-command-menu-toggle').click()
+  await page.getByTestId('kw-chat-command-detail').click()
+  await page.getByRole('tab', { name: '진단', exact: true }).click()
+
+  const runtimeDiagnostics = page.locator('details').filter({
+    has: page.getByText('런타임 진단', { exact: true }),
+  })
+  await runtimeDiagnostics.locator('summary').click()
+  const compositionRows = page.locator('[data-composition-node][data-composition-run]')
+  await compositionRows.first().waitFor()
+
+  const rows = await compositionRows.evaluateAll(nodes => nodes.map(node => ({
+    run: node.getAttribute('data-composition-run'),
+    node: node.getAttribute('data-composition-node'),
+    execution: node.getAttribute('data-composition-execution'),
+    disposition: node.getAttribute('data-tool-call-disposition'),
+  })))
+  const complete = selectCompleteInlineRun(rows)
+  if (!complete) {
+    throw new Error(`no complete inline composition run in inspector rows: ${JSON.stringify(rows)}`)
+  }
+
+  const [compositionRunId, runRows] = complete
+  const exactMemoryRow = page.locator(
+    `[data-composition-run="${compositionRunId}"][data-composition-node="memory"]`,
+  )
+  await exactMemoryRow.locator('button[aria-expanded="false"]').click()
+  await exactMemoryRow.getByLabel('도구 호출 입력 복사').waitFor()
+  await exactMemoryRow.getByLabel('도구 호출 출력 복사').waitFor()
+
+  const pageMeasurements = await page.evaluate(() => ({
+    document_width: document.documentElement.scrollWidth,
+    document_height: document.documentElement.scrollHeight,
+    device_pixel_ratio: window.devicePixelRatio,
+  }))
+  const screenshot = await page.screenshot({ path: screenshotPath, fullPage: true })
+  const measurement = {
+    schema: 'masc.keeper_composition_browser_evidence.v1',
+    keeper: keeperName,
+    composition_run_id: compositionRunId,
+    nodes: runRows.map(row => row.node).sort(),
+    execution: 'inline',
+    dispositions: runRows.map(row => row.disposition),
+    visible_composition_rows: rows.length,
+    expanded_node: 'memory',
+    input_visible: await exactMemoryRow.getByLabel('도구 호출 입력 복사').isVisible(),
+    output_visible: await exactMemoryRow.getByLabel('도구 호출 출력 복사').isVisible(),
+    viewport,
+    ...pageMeasurements,
+    screenshot_file: 'keeper-composition-inspector.png',
+    screenshot_bytes: screenshot.byteLength,
+    screenshot_sha256: createHash('sha256').update(screenshot).digest('hex'),
+  }
+  writeFileSync(measurementPath, `${JSON.stringify(measurement, null, 2)}\n`)
+
+  route.hash = 'workspace?section=verification'
+  await page.goto(route.toString())
+  const persistencePanel = page.getByTestId('keeper-persistence-proof-panel')
+  await persistencePanel.waitFor()
+  const persistenceCards = persistencePanel.locator('[data-tier-id][data-evidence-kind]')
+  await persistenceCards.first().waitFor()
+  const persistenceRefresh = page.getByTestId('keeper-persistence-proof-refresh')
+  const [persistenceResponse] = await Promise.all([
+    page.waitForResponse(response =>
+      response.url().includes('/api/v1/dashboard/keeper-feature-proof') && response.ok(),
+    ),
+    persistenceRefresh.click(),
+  ])
+  const refreshedPayload = await persistenceResponse.json()
+  const refreshedGeneratedAt = refreshedPayload?.generated_at
+  if (typeof refreshedGeneratedAt !== 'string' || !Number.isFinite(Date.parse(refreshedGeneratedAt))) {
+    throw new Error('manual refresh response has no generated_at')
+  }
+  const persistenceFeatures = Array.isArray(refreshedPayload?.features)
+    ? refreshedPayload.features.filter(feature => feature?.id === 'persistent_24h_turn_exchange')
+    : []
+  if (persistenceFeatures.length !== 1) {
+    throw new Error(`manual refresh response has ${persistenceFeatures.length} persistence features`)
+  }
+  const refreshedTiers = persistenceFeatures[0]?.duration_tiers
+  if (!Array.isArray(refreshedTiers) || refreshedTiers.length !== 4) {
+    throw new Error('manual refresh response has no exact persistence duration tiers')
+  }
+  await page.waitForFunction(expectedGeneratedAt => {
+    const panel = document.querySelector('[data-testid="keeper-persistence-proof-panel"]')
+    const button = document.querySelector('[data-testid="keeper-persistence-proof-refresh"]')
+    return panel?.getAttribute('data-proof-generated-at') === expectedGeneratedAt
+      && button instanceof HTMLButtonElement
+      && !button.disabled
+  }, refreshedGeneratedAt)
+  const renderedTiers = await persistenceCards.evaluateAll(nodes => {
+    const countAttribute = (node, name) => {
+      const raw = node.getAttribute(name)
+      const parsed = Number(raw)
+      if (raw == null || !Number.isSafeInteger(parsed) || parsed < 0 || String(parsed) !== raw) {
+        throw new Error(`${name} must be a canonical non-negative integer, observed=${raw}`)
+      }
+      return parsed
+    }
+    return nodes.map(node => ({
+      id: node.getAttribute('data-tier-id'),
+      status: node.getAttribute('data-proof-status'),
+      evidence_kind: node.getAttribute('data-evidence-kind'),
+      observed_count: countAttribute(node, 'data-observed-count'),
+      keeper_count: countAttribute(node, 'data-keeper-count'),
+      missing_count: countAttribute(node, 'data-missing-count'),
+    }))
+  })
+  const expectedTierIds = ['1h', '2h', '4h', '24h']
+  if (JSON.stringify(renderedTiers.map(tier => tier.id)) !== JSON.stringify(expectedTierIds)) {
+    throw new Error(`unexpected persistence tier order: ${JSON.stringify(renderedTiers)}`)
+  }
+  const tiers = renderedTiers.map((rendered, index) => {
+    const responseTier = refreshedTiers[index]
+    const observedKeepers = responseTier?.observed_keepers
+    const missingKeepers = responseTier?.missing_keepers
+    if (responseTier?.id !== rendered.id
+      || responseTier?.status !== rendered.status
+      || responseTier?.evidence_kind !== rendered.evidence_kind
+      || responseTier?.observed_count !== rendered.observed_count
+      || responseTier?.keeper_count !== rendered.keeper_count
+      || responseTier?.missing_count !== rendered.missing_count
+      || !Array.isArray(observedKeepers)
+      || !Array.isArray(missingKeepers)
+      || observedKeepers.some(name => typeof name !== 'string' || !name.trim())
+      || missingKeepers.some(name => typeof name !== 'string' || !name.trim())) {
+      throw new Error(`rendered persistence tier differs from response: ${JSON.stringify({ rendered, responseTier })}`)
+    }
+    return {
+      ...rendered,
+      observed_keepers: observedKeepers,
+      missing_keepers: missingKeepers,
+    }
+  })
+  const fleet = new Set([...tiers[0].observed_keepers, ...tiers[0].missing_keepers])
+  for (const [index, tier] of tiers.entries()) {
+    if (!['pass', 'warn', 'fail'].includes(tier.status)) {
+      throw new Error(`unexpected persistence status: ${JSON.stringify(tier)}`)
+    }
+    if (tier.evidence_kind !== 'durable_turn_span') {
+      throw new Error(`unexpected persistence evidence kind: ${JSON.stringify(tier)}`)
+    }
+    if (![tier.observed_count, tier.keeper_count, tier.missing_count].every(Number.isSafeInteger)) {
+      throw new Error(`non-integer persistence count: ${JSON.stringify(tier)}`)
+    }
+    if (tier.observed_count < 0 || tier.missing_count < 0
+      || tier.observed_count + tier.missing_count !== tier.keeper_count) {
+      throw new Error(`inconsistent persistence counts: ${JSON.stringify(tier)}`)
+    }
+    const observed = new Set(tier.observed_keepers)
+    const missing = new Set(tier.missing_keepers)
+    const tierFleet = new Set([...observed, ...missing])
+    if (observed.size !== tier.observed_count || missing.size !== tier.missing_count
+      || tierFleet.size !== tier.keeper_count
+      || tierFleet.size !== fleet.size
+      || [...fleet].some(name => !tierFleet.has(name))
+      || [...observed].some(name => missing.has(name))) {
+      throw new Error(`inconsistent persistence identities: ${JSON.stringify(tier)}`)
+    }
+    if (index > 0) {
+      const previous = tiers[index - 1]
+      const previousObserved = new Set(previous.observed_keepers)
+      const previousMissing = new Set(previous.missing_keepers)
+      if ([...observed].some(name => !previousObserved.has(name))
+        || [...previousMissing].some(name => !missing.has(name))) {
+        throw new Error(`non-monotonic persistence identities: ${JSON.stringify(tiers)}`)
+      }
+    }
+  }
+  const generatedAt = await persistencePanel.getAttribute('data-proof-generated-at')
+  if (!generatedAt) throw new Error('persistence proof generated_at is absent')
+  const persistenceScreenshot = await page.screenshot({
+    path: persistenceScreenshotPath,
+    fullPage: true,
+  })
+  const persistenceMeasurement = {
+    schema: 'masc.keeper_persistence_browser_evidence.v1',
+    generated_at: generatedAt,
+    interaction: 'manual_refresh',
+    tiers,
+    viewport,
+    screenshot_file: 'keeper-persistence-proof.png',
+    screenshot_bytes: persistenceScreenshot.byteLength,
+    screenshot_sha256: createHash('sha256').update(persistenceScreenshot).digest('hex'),
+  }
+  writeFileSync(
+    persistenceMeasurementPath,
+    `${JSON.stringify(persistenceMeasurement, null, 2)}\n`,
+  )
+  process.stdout.write(`${JSON.stringify({ composition: measurement, persistence: persistenceMeasurement })}\n`)
+} finally {
+  await browser.close()
+}

--- a/dashboard/src/api/dashboard-execution.ts
+++ b/dashboard/src/api/dashboard-execution.ts
@@ -71,6 +71,7 @@ export type ToolQualityResponse = TelemetryFreshnessMetadata & {
   total: number
   success: number
   failure: number
+  deferred?: number
   success_rate: number
   by_tool: ToolQualityToolStat[]
   by_keeper: ToolQualityKeeperStat[]

--- a/dashboard/src/api/dashboard-keeper-feature-proof.test.ts
+++ b/dashboard/src/api/dashboard-keeper-feature-proof.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest'
+import { parseKeeperPersistenceProofResponse } from './dashboard-keeper-feature-proof'
+
+const tier = (
+  id: '1h' | '2h' | '4h' | '24h',
+  requiredSpanHours: number,
+  observedKeepers: string[],
+  missingKeepers: string[],
+) => ({
+  id,
+  evidence_kind: 'durable_turn_span',
+  required_span_hours: requiredSpanHours,
+  status: observedKeepers.length === 0
+    ? 'fail'
+    : missingKeepers.length === 0 ? 'pass' : 'warn',
+  keeper_count: observedKeepers.length + missingKeepers.length,
+  observed_count: observedKeepers.length,
+  missing_count: missingKeepers.length,
+  observed_keepers: observedKeepers,
+  missing_keepers: missingKeepers,
+})
+
+function payload() {
+  return {
+    generated_at: '2026-08-14T12:00:00Z',
+    status: 'warn',
+    summary: { feature_count: 5 },
+    features: [
+      {
+        id: 'persistent_24h_turn_exchange',
+        status: 'warn',
+        summary: '1/2 keepers have durable turn spans >= 24h',
+        duration_tiers: [
+          tier('1h', 1, ['keeper-a', 'keeper-b'], []),
+          tier('2h', 2, ['keeper-a', 'keeper-b'], []),
+          tier('4h', 4, ['keeper-a'], ['keeper-b']),
+          tier('24h', 24, ['keeper-a'], ['keeper-b']),
+        ],
+      },
+    ],
+    evidence_refs: [],
+  }
+}
+
+function persistenceFeature(raw: ReturnType<typeof payload>) {
+  const [feature] = raw.features
+  if (feature == null) throw new Error('persistence fixture is absent')
+  return feature
+}
+
+function durationTier(raw: ReturnType<typeof payload>, index: number) {
+  const value = persistenceFeature(raw).duration_tiers[index]
+  if (value == null) throw new Error(`duration tier fixture ${index} is absent`)
+  return value
+}
+
+describe('parseKeeperPersistenceProofResponse', () => {
+  it('projects the exact ordered durable turn-span tiers', () => {
+    const parsed = parseKeeperPersistenceProofResponse(payload())
+
+    expect(parsed.generatedAt).toBe('2026-08-14T12:00:00Z')
+    expect(parsed.status).toBe('warn')
+    expect(parsed.tiers.map(value => value.id)).toEqual(['1h', '2h', '4h', '24h'])
+    expect(parsed.tiers[2]).toEqual({
+      id: '4h',
+      requiredSpanHours: 4,
+      status: 'warn',
+      evidenceKind: 'durable_turn_span',
+      keeperCount: 2,
+      observedCount: 1,
+      missingCount: 1,
+      observedKeepers: ['keeper-a'],
+      missingKeepers: ['keeper-b'],
+    })
+  })
+
+  it('rejects a tier status that disagrees with its evidence counts', () => {
+    const raw = payload()
+    durationTier(raw, 2).status = 'pass'
+
+    expect(() => parseKeeperPersistenceProofResponse(raw)).toThrow(
+      'does not match derived status=warn',
+    )
+  })
+
+  it('rejects duplicate or overlapping keeper evidence', () => {
+    const duplicate = payload()
+    durationTier(duplicate, 0).observed_keepers = ['keeper-a', 'keeper-a']
+    expect(() => parseKeeperPersistenceProofResponse(duplicate)).toThrow(
+      'must not contain duplicate keepers',
+    )
+
+    const overlap = payload()
+    durationTier(overlap, 2).missing_keepers = ['keeper-a']
+    expect(() => parseKeeperPersistenceProofResponse(overlap)).toThrow(
+      'observed and missing keepers must not overlap',
+    )
+  })
+
+  it('rejects reordered tiers and a feature status that disagrees with 24h', () => {
+    const reordered = payload()
+    const tiers = persistenceFeature(reordered).duration_tiers
+    const first = durationTier(reordered, 0)
+    tiers[0] = durationTier(reordered, 1)
+    tiers[1] = first
+    expect(() => parseKeeperPersistenceProofResponse(reordered)).toThrow(
+      'duration_tiers[0].id must be 1h',
+    )
+
+    const mismatch = payload()
+    persistenceFeature(mismatch).status = 'pass'
+    expect(() => parseKeeperPersistenceProofResponse(mismatch)).toThrow(
+      'must match the 24h tier status',
+    )
+  })
+
+  it('rejects cross-tier fleet drift and non-monotonic duration evidence', () => {
+    const fleetDrift = payload()
+    durationTier(fleetDrift, 3).missing_keepers = ['keeper-c']
+    expect(() => parseKeeperPersistenceProofResponse(fleetDrift)).toThrow(
+      'must describe the same Keeper fleet',
+    )
+
+    const nonMonotonic = payload()
+    durationTier(nonMonotonic, 2).observed_keepers = ['keeper-b']
+    durationTier(nonMonotonic, 2).missing_keepers = ['keeper-a']
+    expect(() => parseKeeperPersistenceProofResponse(nonMonotonic)).toThrow(
+      'violates duration monotonicity',
+    )
+  })
+})

--- a/dashboard/src/api/dashboard-keeper-feature-proof.ts
+++ b/dashboard/src/api/dashboard-keeper-feature-proof.ts
@@ -1,0 +1,203 @@
+// MASC Dashboard — durable Keeper persistence proof projection.
+//
+// Backend: GET /api/v1/dashboard/keeper-feature-proof
+//
+// The endpoint carries several feature proofs. This decoder deliberately
+// projects only the persistence feature and rejects internally inconsistent
+// tier evidence instead of rendering plausible-looking counters.
+
+import { isRecord } from '../components/common/normalize'
+import { get, type AbortableRequestOptions } from './core'
+
+export type KeeperFeatureProofStatus = 'pass' | 'warn' | 'fail'
+export type KeeperPersistenceTierId = '1h' | '2h' | '4h' | '24h'
+export type KeeperPersistenceEvidenceKind = 'durable_turn_span'
+
+export interface KeeperPersistenceTierProof {
+  id: KeeperPersistenceTierId
+  requiredSpanHours: number
+  status: KeeperFeatureProofStatus
+  evidenceKind: KeeperPersistenceEvidenceKind
+  keeperCount: number
+  observedCount: number
+  missingCount: number
+  observedKeepers: string[]
+  missingKeepers: string[]
+}
+
+export interface DashboardKeeperPersistenceProofResponse {
+  generatedAt: string
+  status: KeeperFeatureProofStatus
+  summary: string
+  tiers: KeeperPersistenceTierProof[]
+}
+
+const EXPECTED_TIERS = [
+  { id: '1h', requiredSpanHours: 1 },
+  { id: '2h', requiredSpanHours: 2 },
+  { id: '4h', requiredSpanHours: 4 },
+  { id: '24h', requiredSpanHours: 24 },
+] as const
+
+function protocolError(message: string): never {
+  throw new Error(`Invalid Keeper persistence proof response: ${message}`)
+}
+
+function nonEmptyString(value: unknown, context: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    protocolError(`${context} must be a non-empty string`)
+  }
+  return value
+}
+
+function isoTimestamp(value: unknown, context: string): string {
+  const timestamp = nonEmptyString(value, context)
+  if (!Number.isFinite(Date.parse(timestamp))) {
+    protocolError(`${context} must be a valid timestamp`)
+  }
+  return timestamp
+}
+
+function nonNegativeInteger(value: unknown, context: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    protocolError(`${context} must be a non-negative safe integer`)
+  }
+  return value as number
+}
+
+function proofStatus(value: unknown, context: string): KeeperFeatureProofStatus {
+  if (value !== 'pass' && value !== 'warn' && value !== 'fail') {
+    protocolError(`${context} has unknown status ${JSON.stringify(value)}`)
+  }
+  return value
+}
+
+function keeperNames(value: unknown, context: string): string[] {
+  if (!Array.isArray(value)) protocolError(`${context} must be an array`)
+  const names = value.map((name, index) => nonEmptyString(name, `${context}[${index}]`))
+  if (new Set(names).size !== names.length) {
+    protocolError(`${context} must not contain duplicate keepers`)
+  }
+  return names
+}
+
+function expectedStatus(keeperCount: number, observedCount: number): KeeperFeatureProofStatus {
+  if (keeperCount === 0 || observedCount === 0) return 'fail'
+  if (observedCount === keeperCount) return 'pass'
+  return 'warn'
+}
+
+function sameNames(left: ReadonlySet<string>, right: ReadonlySet<string>): boolean {
+  return left.size === right.size && [...left].every(name => right.has(name))
+}
+
+function parseTier(
+  raw: unknown,
+  index: number,
+): KeeperPersistenceTierProof {
+  const context = `persistence.duration_tiers[${index}]`
+  if (!isRecord(raw)) protocolError(`${context} must be an object`)
+  const expected = EXPECTED_TIERS[index]
+  if (expected == null) protocolError('persistence.duration_tiers contains an unexpected tier')
+  if (raw.id !== expected.id) {
+    protocolError(`${context}.id must be ${expected.id}`)
+  }
+  if (raw.required_span_hours !== expected.requiredSpanHours) {
+    protocolError(`${context}.required_span_hours must be ${expected.requiredSpanHours}`)
+  }
+  if (raw.evidence_kind !== 'durable_turn_span') {
+    protocolError(`${context}.evidence_kind must be durable_turn_span`)
+  }
+  const keeperCount = nonNegativeInteger(raw.keeper_count, `${context}.keeper_count`)
+  const observedCount = nonNegativeInteger(raw.observed_count, `${context}.observed_count`)
+  const missingCount = nonNegativeInteger(raw.missing_count, `${context}.missing_count`)
+  const observedKeepers = keeperNames(raw.observed_keepers, `${context}.observed_keepers`)
+  const missingKeepers = keeperNames(raw.missing_keepers, `${context}.missing_keepers`)
+  if (observedCount !== observedKeepers.length || missingCount !== missingKeepers.length) {
+    protocolError(`${context} counts must match keeper arrays`)
+  }
+  if (observedCount + missingCount !== keeperCount) {
+    protocolError(`${context} observed_count + missing_count must equal keeper_count`)
+  }
+  const observed = new Set(observedKeepers)
+  if (missingKeepers.some(name => observed.has(name))) {
+    protocolError(`${context} observed and missing keepers must not overlap`)
+  }
+  const status = proofStatus(raw.status, `${context}.status`)
+  const derivedStatus = expectedStatus(keeperCount, observedCount)
+  if (status !== derivedStatus) {
+    protocolError(`${context}.status=${status} does not match derived status=${derivedStatus}`)
+  }
+  return {
+    id: expected.id,
+    requiredSpanHours: expected.requiredSpanHours,
+    status,
+    evidenceKind: 'durable_turn_span',
+    keeperCount,
+    observedCount,
+    missingCount,
+    observedKeepers,
+    missingKeepers,
+  }
+}
+
+export function parseKeeperPersistenceProofResponse(
+  raw: unknown,
+): DashboardKeeperPersistenceProofResponse {
+  if (!isRecord(raw)) protocolError('root must be an object')
+  const generatedAt = isoTimestamp(raw.generated_at, 'root.generated_at')
+  if (!Array.isArray(raw.features)) protocolError('root.features must be an array')
+  const matches = raw.features.filter(
+    feature => isRecord(feature) && feature.id === 'persistent_24h_turn_exchange',
+  )
+  if (matches.length !== 1) {
+    protocolError(`expected exactly one persistent_24h_turn_exchange feature, found ${matches.length}`)
+  }
+  const feature = matches[0]
+  if (!isRecord(feature)) protocolError('persistence feature must be an object')
+  if (!Array.isArray(feature.duration_tiers)) {
+    protocolError('persistence.duration_tiers must be an array')
+  }
+  if (feature.duration_tiers.length !== EXPECTED_TIERS.length) {
+    protocolError(`persistence.duration_tiers must contain ${EXPECTED_TIERS.length} tiers`)
+  }
+  const tiers = feature.duration_tiers.map(parseTier)
+  const firstTier = tiers[0]
+  if (firstTier == null) protocolError('persistence.duration_tiers must not be empty')
+  const fleet = new Set([...firstTier.observedKeepers, ...firstTier.missingKeepers])
+  for (let index = 1; index < tiers.length; index += 1) {
+    const previous = tiers[index - 1]
+    const current = tiers[index]
+    if (previous == null || current == null) {
+      protocolError(`persistence.duration_tiers[${index}] is absent`)
+    }
+    const currentFleet = new Set([...current.observedKeepers, ...current.missingKeepers])
+    if (current.keeperCount !== firstTier.keeperCount || !sameNames(fleet, currentFleet)) {
+      protocolError(`persistence.duration_tiers[${index}] must describe the same Keeper fleet`)
+    }
+    const previousObserved = new Set(previous.observedKeepers)
+    const currentMissing = new Set(current.missingKeepers)
+    if (current.observedKeepers.some(name => !previousObserved.has(name))
+      || previous.missingKeepers.some(name => !currentMissing.has(name))) {
+      protocolError(`persistence.duration_tiers[${index}] violates duration monotonicity`)
+    }
+  }
+  const status = proofStatus(feature.status, 'persistence.status')
+  const tier24h = tiers[tiers.length - 1]
+  if (tier24h == null || status !== tier24h.status) {
+    protocolError('persistence.status must match the 24h tier status')
+  }
+  return {
+    generatedAt,
+    status,
+    summary: nonEmptyString(feature.summary, 'persistence.summary'),
+    tiers,
+  }
+}
+
+export async function fetchKeeperPersistenceProof(
+  opts?: AbortableRequestOptions,
+): Promise<DashboardKeeperPersistenceProofResponse> {
+  const raw = await get<unknown>('/api/v1/dashboard/keeper-feature-proof', { signal: opts?.signal })
+  return parseKeeperPersistenceProofResponse(raw)
+}

--- a/dashboard/src/api/dashboard-keeper-tool-calls.ts
+++ b/dashboard/src/api/dashboard-keeper-tool-calls.ts
@@ -17,6 +17,9 @@ export type ToolCallOutputBlob = {
   }
 }
 
+export type ToolCallDisposition = 'completed' | 'deferred' | 'failed'
+export type ToolCallCompositionExecution = 'inline' | 'async'
+
 export type ToolCallEntry = {
   ts: number
   keeper: string
@@ -34,6 +37,8 @@ export type ToolCallEntry = {
   lane?: string
   // RFC-0233: canonical execution identity minted at dispatch (absent on pre-PR-1 rows)
   execution_id?: string
+  result_bytes?: number
+  truncated_to?: number
   // RFC-0233 PR-2: provider call id (agent-core-event join key). Equals the chat tool
   // row's tool_call_id for the same execution, so the chat ToolCallBubble can
   // join this entry's output onto the transcript. Absent when the call carried
@@ -46,6 +51,14 @@ export type ToolCallEntry = {
   batch_index?: number
   batch_size?: number
   execution_mode?: 'serial' | 'concurrent'
+  // Typed nested-composition identity. These fields are emitted directly by
+  // the executor observer; the dashboard never reconstructs them from names.
+  disposition?: ToolCallDisposition
+  composition_tool?: string
+  composition_run_id?: string
+  composition_node_id?: string
+  composition_execution?: ToolCallCompositionExecution
+  parent_tool_use_id?: string
   // Goal id(s) this call was attributed to (conditional on the row carrying
   // them), for goal-scoped drill-down alongside task_id/turn.
   goal_ids?: string[]
@@ -100,6 +113,8 @@ function decodeToolCallEntry(raw: unknown): ToolCallEntry | null {
     task_id: asString(raw.task_id),
     lane: asString(raw.lane),
     execution_id: asString(raw.execution_id),
+    result_bytes: asNumber(raw.result_bytes),
+    truncated_to: asNumber(raw.truncated_to),
     tool_use_id: typeof raw.tool_use_id === 'string' ? raw.tool_use_id : undefined,
     planned_index: asNumber(raw.planned_index),
     batch_index: asNumber(raw.batch_index),
@@ -108,6 +123,21 @@ function decodeToolCallEntry(raw: unknown): ToolCallEntry | null {
       raw.execution_mode === 'serial' || raw.execution_mode === 'concurrent'
         ? raw.execution_mode
         : undefined,
+    disposition:
+      raw.disposition === 'completed' ||
+      raw.disposition === 'deferred' ||
+      raw.disposition === 'failed'
+        ? raw.disposition
+        : undefined,
+    composition_tool: asString(raw.composition_tool),
+    composition_run_id: asString(raw.composition_run_id),
+    composition_node_id: asString(raw.composition_node_id),
+    composition_execution:
+      raw.composition_execution === 'inline' || raw.composition_execution === 'async'
+        ? raw.composition_execution
+        : undefined,
+    parent_tool_use_id:
+      typeof raw.parent_tool_use_id === 'string' ? raw.parent_tool_use_id : undefined,
     goal_ids: asStringArray(raw.goal_ids),
   }
 }

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -421,6 +421,12 @@ describe('keeper tool telemetry fetchers', () => {
             batch_index: 1,
             batch_size: 3,
             execution_mode: 'concurrent',
+            disposition: 'deferred',
+            composition_tool: 'keeper_research_pipeline',
+            composition_run_id: 'run-42',
+            composition_node_id: 'fetch_sources',
+            composition_execution: 'async',
+            parent_tool_use_id: 'outer-7',
             goal_ids: ['g-1', 'g-2'],
           },
         ],
@@ -438,6 +444,12 @@ describe('keeper tool telemetry fetchers', () => {
     expect(entry?.batch_index).toBe(1)
     expect(entry?.batch_size).toBe(3)
     expect(entry?.execution_mode).toBe('concurrent')
+    expect(entry?.disposition).toBe('deferred')
+    expect(entry?.composition_tool).toBe('keeper_research_pipeline')
+    expect(entry?.composition_run_id).toBe('run-42')
+    expect(entry?.composition_node_id).toBe('fetch_sources')
+    expect(entry?.composition_execution).toBe('async')
+    expect(entry?.parent_tool_use_id).toBe('outer-7')
   })
 
   it('keeps missing or malformed tool-call duration unmeasured', async () => {

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -62,6 +62,17 @@ export {
   parseVerificationRunsResponse,
   fetchVerificationRuns,
 } from './dashboard-verification-runs'
+export type {
+  KeeperFeatureProofStatus,
+  KeeperPersistenceTierId,
+  KeeperPersistenceEvidenceKind,
+  KeeperPersistenceTierProof,
+  DashboardKeeperPersistenceProofResponse,
+} from './dashboard-keeper-feature-proof'
+export {
+  parseKeeperPersistenceProofResponse,
+  fetchKeeperPersistenceProof,
+} from './dashboard-keeper-feature-proof'
 export {
   fetchExactLaneRun,
   fetchExactLaneRuns,

--- a/dashboard/src/components/fleet-health-panel.test.ts
+++ b/dashboard/src/components/fleet-health-panel.test.ts
@@ -367,6 +367,7 @@ describe('summarizeToolMonitorQuality', () => {
 
     expect(summary.total).toBe(30)
     expect(summary.failure).toBe(3)
+    expect(summary.deferred).toBe(0)
     expect(summary.rows.map(row => row.name)).toEqual([
       'masc_board_post',
       'keeper_task_claim',

--- a/dashboard/src/components/fleet-health-panel.ts
+++ b/dashboard/src/components/fleet-health-panel.ts
@@ -90,6 +90,7 @@ export interface ToolMonitorSummary {
   total: number
   successRate: number
   failure: number
+  deferred: number
   rows: ToolMonitorTool[]
 }
 
@@ -104,6 +105,7 @@ export function summarizeToolMonitorQuality(
     total: quality?.total ?? 0,
     successRate: quality?.success_rate ?? 0,
     failure: quality?.failure ?? 0,
+    deferred: quality?.deferred ?? 0,
     rows: quality?.by_tool ?? [],
   }
 }
@@ -552,7 +554,7 @@ function ToolMonitorDefaultBoard() {
         ` : null}
       </div>
 
-      <div class="grid grid-cols-1 gap-3 sm:grid-cols-3">
+      <div class="grid grid-cols-1 gap-3 sm:grid-cols-4">
         <${StatTile}
           label="Success"
           value=${`${summary.successRate.toFixed(1)}%`}
@@ -564,6 +566,10 @@ function ToolMonitorDefaultBoard() {
         <${StatTile}
           label="Failures"
           value=${formatNumber(summary.failure)}
+        />
+        <${StatTile}
+          label="Deferred"
+          value=${formatNumber(summary.deferred)}
         />
       </div>
 

--- a/dashboard/src/components/fsm-hub-types.test.ts
+++ b/dashboard/src/components/fsm-hub-types.test.ts
@@ -11,6 +11,8 @@ import {
   MAX_OBSERVATIONS,
   MAX_TRANSITION_HISTORY,
   initialHubState,
+  isTurnTerminalFailureCode,
+  operatorDispositionReasonLabel,
 } from './fsm-hub-types'
 import type { KeeperCompositeSnapshot } from '../api/keeper'
 
@@ -182,6 +184,20 @@ describe('failureReasonLabel', () => {
     expect(failureReasonLabel(undefined)).toBeNull()
     expect(failureReasonLabel('')).toBeNull()
     expect(failureReasonLabel('   ')).toBeNull()
+  })
+})
+
+describe('operatorDispositionReasonLabel', () => {
+  it('labels a fenced provider effect without exposing the raw token', () => {
+    expect(operatorDispositionReasonLabel('provider_attempt_effect_fenced')).toBe(
+      'Provider 효과 결과 확인 필요',
+    )
+  })
+})
+
+describe('isTurnTerminalFailureCode', () => {
+  it('treats a fenced provider attempt as terminal execution evidence', () => {
+    expect(isTurnTerminalFailureCode('provider_attempt_effect_fenced')).toBe(true)
   })
 })
 

--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -353,6 +353,7 @@ const TURN_TERMINAL_FAILURE_CODES = new Set<string>([
   'provider_runtime_error',
   'fiber_unresolved',
   'stale_turn_timeout',
+  'provider_attempt_effect_fenced',
 ])
 
 export function isTurnTerminalFailureCode(code: string | null | undefined): boolean {
@@ -396,11 +397,14 @@ const OPERATOR_DISPOSITION_REASON_LABELS: Record<string, string> = {
   degraded_retry: '저하 상태 재시도',
   runtime_fallback: '런타임 폴백',
   transient_runtime_retry: '일시적 런타임 재시도',
+  capacity_backpressure: 'Provider 수용량 부족',
   provider_runtime_error: '런타임 호출 오류',
   internal_error: '내부 오류',
   input_required: '사용자 입력 대기',
   cancelled: '취소됨',
   phase_skipped: 'phase 건너뜀',
+  transcript_corruption: '대화 기록 손상 - 초기화 필요',
+  provider_attempt_effect_fenced: 'Provider 효과 결과 확인 필요',
   unmapped_runtime_state: '매핑되지 않은 runtime 상태',
 }
 

--- a/dashboard/src/components/keeper-detail-alert-strip.test.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.test.ts
@@ -68,6 +68,7 @@ describe('KeeperRuntimeAlertStrip', () => {
     ['runtime_exhausted', '런타임 후보 소진'],
     ['unmapped_runtime_state', '매핑되지 않은 runtime 상태'],
     ['transient_runtime_retry', '일시적 런타임 재시도'],
+    ['provider_attempt_effect_fenced', 'Provider 효과 결과 확인 필요'],
   ])('labels receipt-derived attention reason %s distinctly', (reason, label) => {
     const { container } = render(h(KeeperRuntimeAlertStrip, {
       keeper: keeper({
@@ -79,6 +80,22 @@ describe('KeeperRuntimeAlertStrip', () => {
     const text = container.textContent ?? ''
     expect(text).toContain(label)
     expect(text).not.toContain(reason)
+  })
+
+  it('humanizes the fenced provider effect in the operator disposition line', () => {
+    const { container } = render(h(KeeperRuntimeAlertStrip, {
+      keeper: keeper({
+        needs_attention: true,
+        trust: {
+          operator_disposition_reason: 'provider_attempt_effect_fenced',
+        },
+      }),
+    }))
+
+    const text = container.textContent ?? ''
+    expect(text).toContain('운영자 판단')
+    expect(text).toContain('Provider 효과 결과 확인 필요')
+    expect(text).not.toContain('provider_attempt_effect_fenced')
   })
 
   // First-class status_bridge reasons keep their OWN labels — they are no

--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -15,6 +15,7 @@ import { StrongSecondary, RuntimeBadge } from './keeper-detail-primitives'
 import {
   trustDispositionLabel,
   isTurnTerminalFailureCode,
+  operatorDispositionReasonLabel,
   type RuntimeAttemptObservation,
 } from './fsm-hub-types'
 import { keeperNeedsDiagnosticAttention, refreshAfterRuntimeAction } from './keeper-detail-helpers'
@@ -149,6 +150,7 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
     && !isTurnTerminalFailureCode(latestTerminalCode)
   const latestNextAction = canonicalNextHumanAction(keeper.trust?.latest_next_action?.trim() || null)
   const operatorDispositionReason = keeper.trust?.operator_disposition_reason?.trim() || null
+  const operatorDispositionReasonText = operatorDispositionReasonLabel(operatorDispositionReason)
   const shouldShowOperatorDispositionReason =
     operatorDispositionReason !== null && operatorDispositionReason !== trustSummary
   const executionSummary = keeper.trust?.execution_summary ?? null
@@ -366,7 +368,7 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
           ? html`<span title=${latestNextAction}><strong class="text-[var(--color-fg-secondary)]">권장 조치</strong> · ${nextHumanActionLabel(latestNextAction)}</span>`
           : null}
         ${shouldShowOperatorDispositionReason && operatorDispositionReason
-          ? html`<span><${StrongSecondary}>운영자 판단</${StrongSecondary}> · ${operatorDispositionReason}</span>`
+          ? html`<span><${StrongSecondary}>운영자 판단</${StrongSecondary}> · ${operatorDispositionReasonText}</span>`
           : null}
         ${trustDisposition
           ? html`

--- a/dashboard/src/components/keeper-detail.test.ts
+++ b/dashboard/src/components/keeper-detail.test.ts
@@ -365,8 +365,11 @@ describe('KeeperDetailPage', () => {
 
     // Secondary inspectors live in the standalone-style overflow. Opening the
     // menu and choosing "상세" flips to the reused full tabbed detail body.
-    fireEvent.click(screen.getByRole('button', { name: '대화 도구' }))
-    fireEvent.click(screen.getByRole('menuitemcheckbox', { name: '상세' }))
+    fireEvent.click(screen.getByTestId('kw-chat-command-menu-toggle'))
+    const detailCommand = screen.getByTestId('kw-chat-command-detail')
+    expect(detailCommand.getAttribute('role')).toBe('menuitemcheckbox')
+    expect(detailCommand.textContent).toContain('상세')
+    fireEvent.click(detailCommand)
     const statusTab = await screen.findByRole('tab', { name: '상태' })
     fireEvent.click(statusTab)
     expect(statusTab.getAttribute('aria-selected')).toBe('true')

--- a/dashboard/src/components/keeper-persistence-proof-panel.test.ts
+++ b/dashboard/src/components/keeper-persistence-proof-panel.test.ts
@@ -1,0 +1,102 @@
+import { html } from 'htm/preact'
+import { cleanup, render, screen, waitFor, within } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import '@testing-library/jest-dom'
+
+const fetchProofMock = vi.hoisted(() => vi.fn())
+const unregisterMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../api/dashboard', () => ({
+  fetchKeeperPersistenceProof: fetchProofMock,
+}))
+
+vi.mock('../sse-store', () => ({
+  registerInternalAgentRefresh: vi.fn(() => unregisterMock),
+}))
+
+import { KeeperPersistenceProofPanel, keeperProofTone } from './keeper-persistence-proof-panel'
+
+const response = {
+  generatedAt: '2026-08-14T12:00:00Z',
+  status: 'warn' as const,
+  summary: '1/2 keepers have durable turn spans >= 24h',
+  tiers: [
+    {
+      id: '1h' as const,
+      requiredSpanHours: 1,
+      status: 'pass' as const,
+      evidenceKind: 'durable_turn_span' as const,
+      keeperCount: 2,
+      observedCount: 2,
+      missingCount: 0,
+      observedKeepers: ['keeper-a', 'keeper-b'],
+      missingKeepers: [],
+    },
+    {
+      id: '2h' as const,
+      requiredSpanHours: 2,
+      status: 'pass' as const,
+      evidenceKind: 'durable_turn_span' as const,
+      keeperCount: 2,
+      observedCount: 2,
+      missingCount: 0,
+      observedKeepers: ['keeper-a', 'keeper-b'],
+      missingKeepers: [],
+    },
+    {
+      id: '4h' as const,
+      requiredSpanHours: 4,
+      status: 'warn' as const,
+      evidenceKind: 'durable_turn_span' as const,
+      keeperCount: 2,
+      observedCount: 1,
+      missingCount: 1,
+      observedKeepers: ['keeper-a'],
+      missingKeepers: ['keeper-b'],
+    },
+    {
+      id: '24h' as const,
+      requiredSpanHours: 24,
+      status: 'warn' as const,
+      evidenceKind: 'durable_turn_span' as const,
+      keeperCount: 2,
+      observedCount: 1,
+      missingCount: 1,
+      observedKeepers: ['keeper-a'],
+      missingKeepers: ['keeper-b'],
+    },
+  ],
+}
+
+describe('KeeperPersistenceProofPanel', () => {
+  beforeEach(() => {
+    fetchProofMock.mockReset()
+    fetchProofMock.mockResolvedValue(response)
+    unregisterMock.mockClear()
+  })
+
+  afterEach(() => cleanup())
+
+  it('maps the closed proof status vocabulary to semantic tones', () => {
+    expect(keeperProofTone('pass')).toBe('ok')
+    expect(keeperProofTone('warn')).toBe('warn')
+    expect(keeperProofTone('fail')).toBe('bad')
+  })
+
+  it('renders all durable tiers and exposes missing Keeper evidence', async () => {
+    render(html`<${KeeperPersistenceProofPanel} />`)
+
+    const panel = await screen.findByTestId('keeper-persistence-proof-panel')
+    await waitFor(() => expect(fetchProofMock).toHaveBeenCalledTimes(1))
+    await screen.findByTestId('keeper-persistence-tier-24h')
+    expect(within(panel).getByText(/무중단 uptime 증거가 아닙니다/)).toBeTruthy()
+    expect(panel.getAttribute('data-proof-generated-at')).toBe(response.generatedAt)
+    for (const id of ['1h', '2h', '4h', '24h']) {
+      expect(within(panel).getByTestId(`keeper-persistence-tier-${id}`)).toBeTruthy()
+    }
+    const tier24h = within(panel).getByTestId('keeper-persistence-tier-24h')
+    expect(tier24h).toHaveAttribute('data-proof-status', 'warn')
+    expect(tier24h).toHaveAttribute('data-evidence-kind', 'durable_turn_span')
+    expect(within(tier24h).getByText('keeper-b')).toBeTruthy()
+  })
+})

--- a/dashboard/src/components/keeper-persistence-proof-panel.ts
+++ b/dashboard/src/components/keeper-persistence-proof-panel.ts
@@ -1,0 +1,162 @@
+// Verification workspace projection for durable Keeper turn-span evidence.
+//
+// This is deliberately not an uptime panel. A tier passes only when the
+// decision log contains enough ordered turn history; the explicit evidence
+// label keeps operators from reading durable history as process continuity.
+
+import { html } from 'htm/preact'
+import { useEffect } from 'preact/hooks'
+import {
+  fetchKeeperPersistenceProof,
+  type DashboardKeeperPersistenceProofResponse,
+  type KeeperFeatureProofStatus,
+  type KeeperPersistenceTierProof,
+} from '../api/dashboard'
+import type { ManagedAsyncResource } from '../lib/async-state'
+import { relativeTime } from '../lib/format-time'
+import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
+import { registerInternalAgentRefresh } from '../sse-store'
+import { Btn } from './btn'
+import { EmptyState, ErrorState } from './common/feedback-state'
+import { StatusBadge, type StatusBadgeTone } from './common/status-badge'
+
+export function keeperProofTone(status: KeeperFeatureProofStatus): StatusBadgeTone {
+  switch (status) {
+    case 'pass':
+      return 'ok'
+    case 'warn':
+      return 'warn'
+    case 'fail':
+      return 'bad'
+  }
+}
+
+function keeperProofLabel(status: KeeperFeatureProofStatus): string {
+  switch (status) {
+    case 'pass':
+      return '충족'
+    case 'warn':
+      return '부분 충족'
+    case 'fail':
+      return '미충족'
+  }
+}
+
+async function loadData(resource: ManagedAsyncResource<DashboardKeeperPersistenceProofResponse>) {
+  await resource.load(async signal => fetchKeeperPersistenceProof({ signal }))
+}
+
+function KeeperPersistenceTierCard({ tier }: { tier: KeeperPersistenceTierProof }) {
+  const observedLabel = tier.keeperCount === 0
+    ? '관찰할 Keeper 없음'
+    : `${tier.observedCount}/${tier.keeperCount} Keeper`
+  return html`
+    <article
+      class="rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] p-3"
+      data-testid=${`keeper-persistence-tier-${tier.id}`}
+      data-tier-id=${tier.id}
+      data-proof-status=${tier.status}
+      data-evidence-kind=${tier.evidenceKind}
+      data-observed-count=${tier.observedCount}
+      data-keeper-count=${tier.keeperCount}
+      data-missing-count=${tier.missingCount}
+    >
+      <div class="flex items-center justify-between gap-2">
+        <strong class="text-base tabular-nums text-[var(--color-fg-primary)]">${tier.id}</strong>
+        <${StatusBadge}
+          tone=${keeperProofTone(tier.status)}
+          label=${keeperProofLabel(tier.status)}
+        />
+      </div>
+      <div class="mt-2 text-sm font-medium tabular-nums text-[var(--color-fg-primary)]">
+        ${observedLabel}
+      </div>
+      <div class="mt-1 text-xs text-[var(--color-fg-muted)]">
+        durable turn span ≥ ${tier.requiredSpanHours}h
+      </div>
+      ${tier.missingKeepers.length > 0
+        ? html`
+            <details class="mt-2 text-xs text-[var(--color-fg-secondary)]">
+              <summary class="cursor-pointer">근거 부족 ${tier.missingCount}</summary>
+              <div class="mt-1 break-words" data-testid=${`keeper-persistence-missing-${tier.id}`}>
+                ${tier.missingKeepers.join(', ')}
+              </div>
+            </details>
+          `
+        : null}
+    </article>
+  `
+}
+
+export function KeeperPersistenceProofPanel() {
+  const resource = useManagedAsyncResource<DashboardKeeperPersistenceProofResponse>()
+
+  useEffect(() => {
+    void loadData(resource)
+    const unregister = registerInternalAgentRefresh(() => { void loadData(resource) })
+    return () => {
+      unregister()
+      resource.cancel()
+    }
+  }, [resource])
+
+  const current = resource.state.value
+  const data = current.data ?? null
+
+  return html`
+    <section
+      class="v2-workspace-surface flex flex-col gap-3"
+      data-testid="keeper-persistence-proof-panel"
+      data-proof-generated-at=${data?.generatedAt ?? ''}
+      aria-labelledby="keeper-persistence-proof-heading"
+    >
+      <div class="flex items-center gap-3 flex-wrap">
+        <h2
+          id="keeper-persistence-proof-heading"
+          class="text-sm font-semibold text-[var(--color-fg-primary)]"
+        >
+          Keeper 지속성 근거
+        </h2>
+        ${data
+          ? html`<${StatusBadge}
+              tone=${keeperProofTone(data.status)}
+              label=${keeperProofLabel(data.status)}
+            />`
+          : null}
+        <${Btn}
+          class="v2-workspace-action"
+          testId="keeper-persistence-proof-refresh"
+          disabled=${current.loading}
+          onClick=${() => void loadData(resource)}
+        >
+          새로고침
+        <//>
+        ${current.loading
+          ? html`<span class="text-xs text-[var(--color-fg-muted)]" role="status">로딩 중...</span>`
+          : null}
+        ${data?.generatedAt
+          ? html`<span class="text-xs text-[var(--color-fg-muted)]">
+              updated · ${relativeTime(data.generatedAt)}
+            </span>`
+          : null}
+      </div>
+
+      <p class="text-xs text-[var(--color-fg-muted)]">
+        decision log의 <strong>durable turn span</strong> 근거입니다. 무중단 uptime 증거가 아닙니다.
+      </p>
+
+      ${current.error
+        ? html`<${ErrorState}>Keeper 지속성 근거를 불러오지 못했습니다: ${current.error}<//>`
+        : data == null && !current.loading
+          ? html`<${EmptyState}>지속성 근거가 없습니다.<//>`
+          : data
+            ? html`
+                <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                  ${data.tiers.map(tier => html`<${KeeperPersistenceTierCard} key=${tier.id} tier=${tier} />`)}
+                </div>
+                <p class="text-xs text-[var(--color-fg-secondary)]">${data.summary}</p>
+              `
+            : null}
+    </section>
+  `
+}

--- a/dashboard/src/components/keeper-sse-match.test.ts
+++ b/dashboard/src/components/keeper-sse-match.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import type { SSEEvent } from '../types'
 import {
   isKeeperToolActivityEvent,
+  isKeeperToolEvidenceCommittedEvent,
   sseEventMatchesKeeper,
   sseKeeperName,
 } from './keeper-sse-match'
@@ -18,6 +19,12 @@ describe('keeper SSE matching', () => {
     expect(sseEventMatchesKeeper(event, 'sangsu')).toBe(true)
     expect(sseEventMatchesKeeper(event, 'keeper-sangsu-agent')).toBe(true)
     expect(sseEventMatchesKeeper(event, 'other')).toBe(false)
+  })
+
+  it('distinguishes committed evidence refresh from physical tool execution', () => {
+    const event = { type: 'keeper_tool_call_evidence_committed' } as SSEEvent
+    expect(isKeeperToolEvidenceCommittedEvent(event)).toBe(true)
+    expect(isKeeperToolActivityEvent(event)).toBe(false)
   })
 
   it('recognizes tool-call events across canonical and MASC alias wire types', () => {

--- a/dashboard/src/components/keeper-sse-match.ts
+++ b/dashboard/src/components/keeper-sse-match.ts
@@ -25,3 +25,7 @@ export function isKeeperToolActivityEvent(event: SSEEvent): boolean {
   const type = normalizeSSEDispatchType(event.type)
   return type === 'keeper_tool_call' || type === 'keeper_tool_skipped'
 }
+
+export function isKeeperToolEvidenceCommittedEvent(event: SSEEvent): boolean {
+  return event.type === 'keeper_tool_call_evidence_committed'
+}

--- a/dashboard/src/components/keeper-tool-call-inspector-render.test.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector-render.test.ts
@@ -249,6 +249,12 @@ describe('KeeperToolCallInspector render', () => {
           batch_index: 0,
           batch_size: 2,
           execution_mode: 'concurrent',
+          disposition: 'failed',
+          composition_tool: 'keeper_research_pipeline',
+          composition_run_id: 'run-42',
+          composition_node_id: 'publish_report',
+          composition_execution: 'inline',
+          parent_tool_use_id: 'outer-7',
           lane: 'autonomous',
         },
       ],
@@ -274,8 +280,58 @@ describe('KeeperToolCallInspector render', () => {
     expect(text).toContain('Code')
     expect(text).toContain('Task')
     expect(text).toContain(
-      'turn 9 · plan 4 · batch 0 · size 2 · mode concurrent · tool_use_id (blank)',
+      'turn 9 · plan 4 · batch 0 · size 2 · mode concurrent · result failed',
     )
+    expect(text).toContain('composition keeper_research_pipeline')
+    expect(text).toContain('node publish_report')
+    expect(text).toContain('execution inline')
+    expect(text).toContain('parent_tool_use_id outer-7')
+    const compositionRow = container.querySelector('[data-composition-node="publish_report"]')
+    expect(compositionRow).not.toBeNull()
+    expect(compositionRow?.getAttribute('data-composition-run')).toBe('run-42')
+    expect(compositionRow?.getAttribute('data-composition-execution')).toBe('inline')
+    expect(compositionRow?.getAttribute('data-tool-call-disposition')).toBe('failed')
+    expect(compositionRow?.textContent).toContain('↳ publish_report · inline')
+  })
+
+  it('renders a typed deferred composition action without counting it as failed', async () => {
+    const fetchKeeperToolCalls = vi.fn().mockResolvedValue({
+      keeper: 'analyst',
+      count: 1,
+      source: 'tool_call_io',
+      health: 'fresh',
+      entry_count: 1,
+      entries: [
+        {
+          ts: 1_777_100_020,
+          keeper: 'analyst',
+          tool: 'keeper_board_await',
+          input: {},
+          output: 'waiting',
+          success: false,
+          duration_ms: 15,
+          disposition: 'deferred',
+          composition_tool: 'keeper_watch_pipeline',
+          composition_run_id: 'run-43',
+          composition_node_id: 'wait_for_board',
+          composition_execution: 'async',
+          parent_tool_use_id: 'outer-8',
+        },
+      ],
+    })
+
+    const { KeeperToolCallInspector } = await loadInspector(fetchKeeperToolCalls)
+    await act(async () => {
+      render(html`<${KeeperToolCallInspector} keeperName="analyst" />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    const dossier = container.querySelector('[data-testid="keeper-tool-call-dossier"]')
+    expect(dossier?.textContent).toContain('1 deferred / 1')
+    expect(dossier?.textContent).toContain('no failed calls in this window')
+    expect(container.querySelector('[title="deferred"]')?.textContent).toBe('D')
+    expect(container.querySelector('[data-composition-node="wait_for_board"]')).not.toBeNull()
   })
 
   it('does not render Code links for unsafe absolute tool-call file inputs', async () => {

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -26,7 +26,11 @@ import {
   routeLinksForContext,
   type IdeContextRouteLink,
 } from './ide/ide-context-lens'
-import { isKeeperToolActivityEvent, sseEventMatchesKeeper } from './keeper-sse-match'
+import {
+  isKeeperToolActivityEvent,
+  isKeeperToolEvidenceCommittedEvent,
+  sseEventMatchesKeeper,
+} from './keeper-sse-match'
 
 // Delegated to lib/format-time (SSOT)
 const formatTimestamp = formatTimeHms
@@ -210,6 +214,14 @@ function entryScopeLabel(entry: ToolCallEntry): string {
       ? `batch ${entry.batch_index} · size ${entry.batch_size}`
       : null,
     entry.execution_mode ? `mode ${entry.execution_mode}` : null,
+    entry.disposition ? `result ${entry.disposition}` : null,
+    entry.composition_tool ? `composition ${entry.composition_tool}` : null,
+    entry.composition_run_id ? `run ${entry.composition_run_id}` : null,
+    entry.composition_node_id ? `node ${entry.composition_node_id}` : null,
+    entry.composition_execution ? `execution ${entry.composition_execution}` : null,
+    entry.parent_tool_use_id !== undefined
+      ? `parent_tool_use_id ${entry.parent_tool_use_id === '' ? '(blank)' : entry.parent_tool_use_id}`
+      : null,
     entry.tool_use_id !== undefined
       ? `tool_use_id ${entry.tool_use_id === '' ? '(blank)' : entry.tool_use_id}`
       : null,
@@ -225,11 +237,19 @@ function entryScopeLabel(entry: ToolCallEntry): string {
 }
 
 function toolCallSucceeded(entry: ToolCallEntry): boolean {
-  return entry.success
+  return entry.disposition === 'completed' || (entry.disposition === undefined && entry.success)
+}
+
+function toolCallDeferred(entry: ToolCallEntry): boolean {
+  return entry.disposition === 'deferred'
+}
+
+function toolCallFailed(entry: ToolCallEntry): boolean {
+  return entry.disposition === 'failed' || (entry.disposition === undefined && !entry.success)
 }
 
 function toolCallStatusLabel(entry: ToolCallEntry): string {
-  return toolCallSucceeded(entry) ? 'ok' : 'failed'
+  return entry.disposition ?? (toolCallSucceeded(entry) ? 'completed' : 'failed')
 }
 
 export function deriveKeeperToolCallDossier(
@@ -238,7 +258,8 @@ export function deriveKeeperToolCallDossier(
 ): KeeperToolCallDossier {
   const latest = newestToolCall(entries)
   const slowest = slowestToolCall(entries)
-  const failed = entries.filter(entry => !toolCallSucceeded(entry))
+  const failed = entries.filter(toolCallFailed)
+  const deferred = entries.filter(toolCallDeferred)
   const toolCounts = countByTool(entries)
   const hotTool = toolCounts[0] ?? null
   const evidenceLinks = countEvidenceLinks(entries)
@@ -247,14 +268,17 @@ export function deriveKeeperToolCallDossier(
   const rows = typeof response?.entry_count === 'number' ? response.entry_count : entries.length
   const totalCalls = entries.length
   const failedCount = failed.length
+  const deferredCount = deferred.length
   let latestTone: StatusChipTone = 'neutral'
   if (latest !== null) {
-    latestTone = toolCallSucceeded(latest) ? 'ok' : 'bad'
+    latestTone = toolCallSucceeded(latest) ? 'ok' : toolCallDeferred(latest) ? 'warn' : 'bad'
   }
 
   let headline = 'no calls'
   if (totalCalls > 0 && failedCount > 0) {
     headline = `${failedCount} failed / ${totalCalls}`
+  } else if (totalCalls > 0 && deferredCount > 0) {
+    headline = `${deferredCount} deferred / ${totalCalls}`
   } else if (totalCalls > 0) {
     headline = `${totalCalls} calls clean`
   }
@@ -262,6 +286,8 @@ export function deriveKeeperToolCallDossier(
   let tone: StatusChipTone = 'neutral'
   if (failedCount > 0) {
     tone = 'bad'
+  } else if (deferredCount > 0) {
+    tone = 'warn'
   } else if (totalCalls > 0) {
     tone = 'ok'
   }
@@ -482,6 +508,10 @@ function ToolCallRow({ entry }: { entry: ToolCallEntry }) {
 
   return html`
     <div
+      data-composition-node=${entry.composition_node_id}
+      data-composition-run=${entry.composition_run_id}
+      data-composition-execution=${entry.composition_execution}
+      data-tool-call-disposition=${entry.disposition}
       class="border-b border-[var(--color-border-default)] hover:bg-[var(--color-bg-hover)] transition-colors v2-monitoring-row"
     >
       <button
@@ -493,14 +523,24 @@ function ToolCallRow({ entry }: { entry: ToolCallEntry }) {
         <span class="font-mono ${cat.color} w-4 text-center flex-shrink-0">${cat.icon}</span>
         <span class="font-mono text-[var(--color-fg-secondary)] flex-shrink-0 w-16">${formatTimestamp(entry.ts)}</span>
         <span class="font-mono font-medium text-[var(--color-fg-secondary)] truncate flex-1" title=${entry.tool}>${entry.tool}</span>
+        ${entry.composition_node_id ? html`
+          <span
+            class="max-w-40 truncate rounded-[var(--r-1)] border border-[var(--color-accent-border)] bg-[var(--color-accent-muted)] px-1.5 py-0.5 font-mono text-3xs text-[var(--color-accent-fg)]"
+            title=${`${entry.composition_tool ?? 'composition'} / ${entry.composition_node_id} / ${entry.composition_execution ?? 'unknown'}`}
+          >↳ ${entry.composition_node_id} · ${entry.composition_execution ?? 'unknown'}</span>
+        ` : null}
         <span class=${`font-mono flex-shrink-0 w-16 text-right ${entry.duration_ms != null ? durationColor(entry.duration_ms) : 'text-[var(--color-fg-disabled)]'}`}>
           ${entry.duration_ms != null ? formatMsCompact(entry.duration_ms) : NO_DURATION_LABEL}
         </span>
         <span
-          class=${`flex-shrink-0 w-5 text-center ${toolCallSucceeded(entry) ? 'text-[var(--color-status-ok)]' : 'text-[var(--color-status-err)]'}`}
-          title=${entry.success ? 'ok' : 'failed'}
+          class=${`flex-shrink-0 w-5 text-center ${toolCallSucceeded(entry)
+            ? 'text-[var(--color-status-ok)]'
+            : toolCallDeferred(entry)
+              ? 'text-[var(--color-status-warn)]'
+              : 'text-[var(--color-status-err)]'}`}
+          title=${toolCallStatusLabel(entry)}
         >
-          ${toolCallSucceeded(entry) ? 'O' : 'X'}
+          ${toolCallSucceeded(entry) ? 'O' : toolCallDeferred(entry) ? 'D' : 'X'}
         </span>
         <span class="flex-shrink-0 w-4 text-[var(--color-fg-muted)] text-center">
           ${expanded.value ? '-' : '+'}
@@ -627,7 +667,7 @@ export function KeeperToolCallInspector({ keeperName }: { keeperName: string }) 
   useEffect(() => {
     const unsubscribe = lastEvent.subscribe((event) => {
       if (!event) return
-      if (!isKeeperToolActivityEvent(event)) return
+      if (!isKeeperToolActivityEvent(event) && !isKeeperToolEvidenceCommittedEvent(event)) return
       if (!sseEventMatchesKeeper(event, keeperName)) return
       void resource.load(loadToolCalls)
     })

--- a/dashboard/src/components/session-trace/session-trace-state.test.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.test.ts
@@ -697,6 +697,45 @@ describe('buildTraceEvents', () => {
     expect(events[0]!.executionId).toBe('exec-1712397700000-00ff')
   })
 
+  it('preserves deferred composition rows without classifying them as failures', () => {
+    const events = buildTraceEvents(
+      {
+        agent: 'test',
+        period: { from: '', to: '' },
+        events: [],
+        summary: { tasks_completed: 0, tasks_claimed: 0, messages_sent: 0, active_duration_minutes: 0, total_events: 0 },
+      },
+      null,
+      {
+        keeper: 'test',
+        count: 1,
+        entries: [{
+          ts: 1712397700,
+          keeper: 'test',
+          tool: 'keeper_memory_write',
+          input: { title: 'wait' },
+          output: 'approval required',
+          success: false,
+          disposition: 'deferred',
+          duration_ms: 12,
+          execution_id: 'exec-deferred-composition',
+          result_bytes: 17,
+          truncated_to: 12,
+          composition_tool: 'keeper_compose_write',
+          composition_run_id: 'composition-run-1',
+          composition_node_id: 'write',
+          composition_execution: 'inline',
+        }],
+      },
+    )
+    expect(events).toHaveLength(1)
+    expect(events[0]!.error).toBeNull()
+    expect(events[0]!.toolResult).toBe('approval required')
+    expect(events[0]!.detail.disposition).toBe('deferred')
+    expect(events[0]!.detail.result_bytes).toBe(17)
+    expect(events[0]!.detail.truncated_to).toBe(12)
+  })
+
 })
 
 describe('getTraceSummary', () => {

--- a/dashboard/src/components/session-trace/session-trace-state.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.ts
@@ -426,6 +426,9 @@ function toolCallMetadataDetail(entry: ToolCallEntry, traceOrigin: string): Reco
   if (entry.lane) detail.lane = entry.lane
   if (entry.model) detail.model = entry.model
   if (entry.execution_id) detail.execution_id = entry.execution_id
+  if (entry.disposition) detail.disposition = entry.disposition
+  if (entry.result_bytes != null) detail.result_bytes = entry.result_bytes
+  if (entry.truncated_to != null) detail.truncated_to = entry.truncated_to
   if (entry.planned_index != null) detail.planned_index = entry.planned_index
   if (entry.batch_index != null) detail.batch_index = entry.batch_index
   if (entry.batch_size != null) detail.batch_size = entry.batch_size
@@ -449,6 +452,10 @@ function toolEventTurn(event: UnifiedTraceEvent): number | undefined {
 
 function toolEventSuccess(event: UnifiedTraceEvent): boolean {
   return event.gate?.status !== 'reject' && event.error == null
+}
+
+function toolCallEntryIsFailure(entry: ToolCallEntry): boolean {
+  return entry.disposition ? entry.disposition === 'failed' : !entry.success
 }
 
 function toolCallEntryMatchesTraceEvent(
@@ -489,7 +496,7 @@ function toolCallEntryMatchesTraceEvent(
     && entry.duration_ms != null
     && Math.abs(event.duration_ms - entry.duration_ms) > 1
   ) return false
-  if (toolEventSuccess(event) !== entry.success) return false
+  if (toolEventSuccess(event) === toolCallEntryIsFailure(entry)) return false
 
   return Math.abs(event.ts - (entry.ts * 1000)) <= TOOL_CALL_MATCH_WINDOW_MS
 }
@@ -528,7 +535,8 @@ function enrichToolCallTrace(
   entry: ToolCallEntry,
 ): UnifiedTraceEvent {
   const outputText = formatToolCallOutput(entry)
-  const error = entry.success ? null : outputText || event.error || 'tool call failed'
+  const isFailure = toolCallEntryIsFailure(entry)
+  const error = isFailure ? outputText || event.error || 'tool call failed' : null
   return {
     ...event,
     agentName: entry.keeper,
@@ -537,7 +545,7 @@ function enrichToolCallTrace(
     detail: { ...event.detail, ...toolCallMetadataDetail(entry, 'trajectory+tool_call_log') },
     toolName: entry.tool,
     toolArgs: normalizeToolCallInput(entry.input) ?? event.toolArgs,
-    toolResult: entry.success ? outputText : null,
+    toolResult: isFailure ? null : outputText,
     duration_ms: entry.duration_ms ?? event.duration_ms,
     // Trajectory turn is trace-relative and pairs with `round`; the log's
     // session-absolute turn stays readable as detail.turn. Mixing the two
@@ -551,6 +559,7 @@ function enrichToolCallTrace(
 function toolCallEntryToSyntheticTrace(entry: ToolCallEntry, index: number): UnifiedTraceEvent {
   const ts = entry.ts * 1000
   const outputText = formatToolCallOutput(entry)
+  const isFailure = toolCallEntryIsFailure(entry)
   return {
     // execution_id is unique per physical execution — a stable row id that
     // survives refetch; the composite form remains for pre-PR-1 rows.
@@ -567,11 +576,11 @@ function toolCallEntryToSyntheticTrace(entry: ToolCallEntry, index: number): Uni
     sessionId: entry.session_id ?? null,
     toolName: entry.tool,
     toolArgs: normalizeToolCallInput(entry.input),
-    toolResult: entry.success ? outputText : null,
+    toolResult: isFailure ? null : outputText,
     duration_ms: entry.duration_ms ?? undefined,
     turn: entry.turn ?? entry.keeper_turn_id,
     executionId: entry.execution_id,
-    error: entry.success ? null : outputText || 'tool call failed',
+    error: isFailure ? outputText || 'tool call failed' : null,
   }
 }
 

--- a/dashboard/src/components/tool-quality-panel.test.ts
+++ b/dashboard/src/components/tool-quality-panel.test.ts
@@ -168,6 +168,28 @@ describe('ToolQualityPanel', () => {
     expect(fetchToolQuality).toHaveBeenCalledTimes(2)
   })
 
+  it('renders typed deferred observations without treating them as failures', async () => {
+    const fetchToolQuality = vi.fn().mockResolvedValue({
+      ...payload,
+      total: 0,
+      success: 0,
+      failure: 0,
+      deferred: 1,
+      success_rate: 0,
+    })
+    const { ToolQualityPanel } = await loadPanel({ fetchToolQuality })
+
+    await act(async () => {
+      render(html`<${ToolQualityPanel} />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    expect(container.textContent).not.toContain('도구 호출 데이터 없음')
+    expect(container.textContent).toContain('대기')
+    expect(container.textContent).toContain('1')
+  })
+
   it('normalizes missing tool metric fields before rendering', async () => {
     const fetchMock = vi.fn().mockResolvedValue(okJson(payloadWithMissingToolMetrics))
     vi.stubGlobal('fetch', fetchMock)

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -392,7 +392,7 @@ export function ToolQualityPanel() {
   const d = data.value
   if (loading.value && !d) return html`<${LoadingState}>도구 품질 불러오는 중...<//>`
   if (error.value) return html`<${ErrorState} message=${error.value} class="m-4" />`
-  if (!d || d.total === 0) return html`<div class="p-4 text-2xs text-[var(--color-fg-disabled)]">도구 호출 데이터 없음</div>`
+  if (!d || (d.total === 0 && (d.deferred ?? 0) === 0)) return html`<div class="p-4 text-2xs text-[var(--color-fg-disabled)]">도구 호출 데이터 없음</div>`
   const coverageGap = coverageGapDisplay(d)
 
   return html`
@@ -426,7 +426,7 @@ export function ToolQualityPanel() {
         </div>
       </div>
 
-      <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+      <div class="grid grid-cols-1 sm:grid-cols-4 gap-3">
         <div class="text-center">
           <div class="text-lg font-mono ${successColor.value}">${d.success_rate.toFixed(1)}%</div>
           <div class="text-3xs text-[var(--color-fg-disabled)] uppercase">성공률</div>
@@ -440,6 +440,10 @@ export function ToolQualityPanel() {
         <div class="text-center">
           <div class="text-lg font-mono text-[var(--bad-light)]/80">${d.failure}</div>
           <div class="text-3xs text-[var(--color-fg-disabled)] uppercase">실패</div>
+        </div>
+        <div class="text-center">
+          <div class="text-lg font-mono text-[var(--color-status-warn)]">${d.deferred ?? 0}</div>
+          <div class="text-3xs text-[var(--color-fg-disabled)] uppercase">대기</div>
         </div>
       </div>
 

--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -59,6 +59,14 @@ vi.mock('./verification-requests-panel', () => ({
   VerificationRequestsPanel: () => html`<div data-testid="verification-panel">Verification</div>`,
 }))
 
+vi.mock('./verification-runs-panel', () => ({
+  VerificationRunsPanel: () => html`<div data-testid="verification-runs-panel">Verification runs</div>`,
+}))
+
+vi.mock('./keeper-persistence-proof-panel', () => ({
+  KeeperPersistenceProofPanel: () => html`<div data-testid="keeper-persistence-proof-panel">Persistence proof</div>`,
+}))
+
 vi.mock('./repository-management', () => ({
   RepositoryManagement: () => html`<div data-testid="repository-panel">Repositories</div>`,
 }))
@@ -220,6 +228,8 @@ describe('Work', () => {
     render(html`<${Work} />`)
 
     expect(screen.getByTestId('verification-panel')).toBeTruthy()
+    expect(screen.getByTestId('verification-runs-panel')).toBeTruthy()
+    expect(screen.getByTestId('keeper-persistence-proof-panel')).toBeTruthy()
     expect(screen.queryByTestId('work-kpis')).toBeNull()
   })
 

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -16,6 +16,7 @@ import { SubBoardSurface } from './board/sub-board-surface'
 import { PlanningPanel } from './planning-panel'
 import { VerificationRequestsPanel } from './verification-requests-panel'
 import { VerificationRunsPanel } from './verification-runs-panel'
+import { KeeperPersistenceProofPanel } from './keeper-persistence-proof-panel'
 import { ErrorBoundary } from './common/error-boundary'
 import { LoadingState } from './common/feedback-state'
 import { SectionNav } from './common/section-nav'
@@ -1651,6 +1652,7 @@ export function Work() {
           `
           : html`
             <div class="flex flex-col gap-4">
+              <${KeeperPersistenceProofPanel} />
               <${VerificationRequestsPanel} />
               <${VerificationRunsPanel} />
             </div>

--- a/dashboard/src/lib/keeper-attention-labels.drift.test.ts
+++ b/dashboard/src/lib/keeper-attention-labels.drift.test.ts
@@ -1,7 +1,8 @@
 // Build-time drift guard for the keeper attention vocabulary.
 //
 // The backend is the single source of truth for `attention_reason` /
-// `next_human_action` wire codes — they are string literals emitted from OCaml.
+// `next_human_action` wire codes — they are literals or canonical shared
+// constants emitted from OCaml.
 // keeper-attention-labels.ts hand-mirrors that vocabulary, and that mirror
 // silently drifted before: the backend emitted `stale_turn_timeout` for a
 // release while the frontend union had no arm for it, so the dashboard showed
@@ -84,20 +85,41 @@ function executionReceiptAttentionReasons(): string[] {
     'operator_disposition_reason_to_string present in keeper_execution_receipt.ml',
   ).toBeGreaterThan(-1)
   const body = src.slice(start, src.indexOf(';;', start))
-  return [...body.matchAll(/-> "([a-z_]+)"/g)]
+  const literalReasons = [...body.matchAll(/-> "([a-z_]+)"/g)]
     .map((m) => m[1])
     .filter((token): token is string => token !== undefined)
+  const internalErrorSrc = read('lib/keeper_runtime/keeper_internal_error.ml')
+  const internalErrorConstants = new Map<string, string>()
+  for (const match of internalErrorSrc.matchAll(/^let ([a-z_]+) = "([a-z_]+)"$/gm)) {
+    const name = match[1]
+    const value = match[2]
+    if (name !== undefined && value !== undefined) internalErrorConstants.set(name, value)
+  }
+  const sharedConstantReasons = [
+    ...body.matchAll(/->\s*Keeper_internal_error\.([a-z_]+)/g),
+  ].map((m) => {
+    const name = m[1]
+    const value = name === undefined ? undefined : internalErrorConstants.get(name)
+    expect(
+      value,
+      `Keeper_internal_error.${name ?? '<missing>'} resolves to a canonical string`,
+    ).toBeDefined()
+    return value as string
+  })
+  return [...literalReasons, ...sharedConstantReasons]
 }
 
 // keeper_runtime_trust_snapshot.ml only promotes receipt disposition reasons to
 // `attention_reason` when the derived display disposition needs attention.
-// These receipt reasons are tied to pass/skipped dispositions and should stay
-// out of the attention label union unless the backend changes that contract.
-const EXECUTION_RECEIPT_PASS_ONLY_REASONS: ReadonlySet<string> = new Set([
+// These receipt reasons currently map to display dispositions that do not
+// require attention. They should stay out of the attention label union unless
+// the backend changes that contract.
+const EXECUTION_RECEIPT_NON_ATTENTION_REASONS: ReadonlySet<string> = new Set([
   'healthy',
   'runtime_fallback',
   'phase_skipped',
   'input_required',
+  'capacity_backpressure',
 ])
 
 describe('keeper attention vocabulary drift guard', () => {
@@ -108,6 +130,9 @@ describe('keeper attention vocabulary drift guard', () => {
     expect(statusBridgeStandaloneActions().length).toBeGreaterThan(0)
     expect(dispositionActions().length).toBeGreaterThan(2)
     expect(executionReceiptAttentionReasons().length).toBeGreaterThan(4)
+    expect(executionReceiptAttentionReasons()).toContain(
+      'provider_attempt_effect_fenced',
+    )
   })
 
   it('every keeper_status_bridge attention_reason has a frontend label', () => {
@@ -143,7 +168,7 @@ describe('keeper attention vocabulary drift guard', () => {
 
   it('every dashboard attention-worthy execution receipt reason has a frontend label', () => {
     const attentionWorthy = executionReceiptAttentionReasons().filter(
-      (reason) => !EXECUTION_RECEIPT_PASS_ONLY_REASONS.has(reason),
+      (reason) => !EXECUTION_RECEIPT_NON_ATTENTION_REASONS.has(reason),
     )
     const missing = [...new Set(attentionWorthy)].filter((reason) => !isAttentionReason(reason))
     expect(

--- a/dashboard/src/lib/keeper-attention-labels.test.ts
+++ b/dashboard/src/lib/keeper-attention-labels.test.ts
@@ -17,6 +17,15 @@ describe('keeper attention labels', () => {
     expect(warn).not.toHaveBeenCalled()
   })
 
+  it('labels a fenced provider effect without exposing the raw token', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    expect(attentionReasonLabel('provider_attempt_effect_fenced', false)).toBe(
+      'Provider 효과 결과 확인 필요',
+    )
+    expect(warn).not.toHaveBeenCalled()
+  })
+
   it('labels typed next actions without warning', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 

--- a/dashboard/src/lib/keeper-attention-labels.ts
+++ b/dashboard/src/lib/keeper-attention-labels.ts
@@ -57,6 +57,7 @@ export const ATTENTION_REASONS = [
   'internal_error',
   'cancelled',
   'transcript_corruption',
+  'provider_attempt_effect_fenced',
   'unmapped_runtime_state',
 ] as const
 export type AttentionReason = typeof ATTENTION_REASONS[number]
@@ -78,6 +79,7 @@ const ATTENTION_REASON_LABELS: Record<AttentionReason, string> = {
   internal_error: '내부 오류',
   cancelled: '취소됨',
   transcript_corruption: '대화 기록 손상 - 초기화 필요',
+  provider_attempt_effect_fenced: 'Provider 효과 결과 확인 필요',
   unmapped_runtime_state: '매핑되지 않은 runtime 상태',
 }
 

--- a/dashboard/src/schemas/sse.test.ts
+++ b/dashboard/src/schemas/sse.test.ts
@@ -527,6 +527,60 @@ describe('parseSSEMessage', () => {
     warnSpy.mockRestore()
   })
 
+  it('keeps committed composition evidence at the websocket parse boundary', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const msg = parseSSEMessage({
+      type: 'keeper_tool_call_evidence_committed',
+      name: 'analyst',
+      tool_name: 'keeper_time_now',
+      composition_tool: 'keeper_compose_mission-snapshot',
+      composition_run_id: '019d1234-5678-7abc-8def-0123456789ab',
+      composition_node_id: 'clock',
+      composition_execution: 'inline',
+      parent_tool_use_id: '',
+      tool_use_id: 'nested-call',
+      turn: 7,
+      planned_index: 0,
+      batch_index: 0,
+      batch_size: 3,
+      execution_mode: 'concurrent',
+      ts_unix: 1_786_588_800,
+    })
+
+    expect(msg).toMatchObject({
+      type: 'keeper_tool_call_evidence_committed',
+      name: 'analyst',
+      composition_node_id: 'clock',
+      parent_tool_use_id: '',
+      tool_use_id: 'nested-call',
+    })
+    expect(warnSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
+  it('rejects committed composition evidence without exact join identity', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(parseSSEMessage({
+      type: 'keeper_tool_call_evidence_committed',
+      name: 'analyst',
+      tool_name: 'keeper_time_now',
+      composition_tool: 'keeper_compose_mission-snapshot',
+      composition_run_id: '',
+      composition_node_id: 'clock',
+      composition_execution: 'inline',
+      parent_tool_use_id: 'outer-call',
+      tool_use_id: 'nested-call',
+      turn: 7,
+      planned_index: 0,
+      batch_index: 0,
+      batch_size: 3,
+      execution_mode: 'concurrent',
+      ts_unix: 1_786_588_800,
+    })).toBeNull()
+    expect(warnSpy).toHaveBeenCalledOnce()
+    warnSpy.mockRestore()
+  })
+
   it('keeps gate_mode_changed events instead of dropping them as schema drift', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const msg = parseSSEMessage({

--- a/dashboard/src/schemas/sse.ts
+++ b/dashboard/src/schemas/sse.ts
@@ -68,6 +68,7 @@ const FIXED_SSE_EVENT_TYPES = new Set([
   'ide_cursor_changed',
   'keeper_tool_call',
   'masc/keeper_tool_call',
+  'keeper_tool_call_evidence_committed',
   'keeper_tool_skipped',
   'keeper_turn_complete',
   'masc/keeper_turn_complete',
@@ -143,6 +144,13 @@ const STRING_FIELDS = new Set([
   'error_text',
   'tool_args_preview',
   'tool_output_preview',
+  'composition_tool',
+  'composition_run_id',
+  'composition_node_id',
+  'composition_execution',
+  'parent_tool_use_id',
+  'tool_use_id',
+  'execution_mode',
   'reason_code',
   'phase',
   'from_state',
@@ -175,6 +183,9 @@ const NUMBER_FIELDS = new Set([
   'revision',
   'duration_ms',
   'turn',
+  'planned_index',
+  'batch_index',
+  'batch_size',
   'input_tokens',
   'output_tokens',
   'cost_usd',
@@ -785,6 +796,39 @@ export const SSEMessageSchema = schema<SSEMessage>((value) => {
         'disposition',
         'Expected keeper_tool_call disposition to be completed, deferred, or failed',
       )
+    }
+  }
+
+  if (value.type === 'keeper_tool_call_evidence_committed') {
+    const requiredStrings = [
+      'name',
+      'tool_name',
+      'composition_tool',
+      'composition_run_id',
+      'composition_node_id',
+      'tool_use_id',
+    ] as const
+    for (const field of requiredStrings) {
+      const candidate = value[field]
+      if (typeof candidate !== 'string' || candidate.trim() === '') {
+        return fail(field, `Expected a non-empty ${field}`)
+      }
+    }
+    if (typeof value.parent_tool_use_id !== 'string') {
+      return fail('parent_tool_use_id', 'Expected parent_tool_use_id to be a string')
+    }
+    if (value.composition_execution !== 'inline' && value.composition_execution !== 'async') {
+      return fail('composition_execution', 'Expected inline or async composition_execution')
+    }
+    if (value.execution_mode !== 'serial' && value.execution_mode !== 'concurrent') {
+      return fail('execution_mode', 'Expected serial or concurrent execution_mode')
+    }
+    for (const field of ['turn', 'planned_index', 'batch_index', 'batch_size'] as const) {
+      const candidate = value[field]
+      const minimum = field === 'batch_size' ? 1 : 0
+      if (typeof candidate !== 'number' || !Number.isInteger(candidate) || candidate < minimum) {
+        return fail(field, `Expected an integer ${field}`)
+      }
     }
   }
 

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -40,6 +40,7 @@ export type SSEEventType =
   | 'ide_cursor_changed'
   | 'keeper_tool_call'
   | 'masc/keeper_tool_call'
+  | 'keeper_tool_call_evidence_committed'
   | 'keeper_tool_skipped'
   | 'keeper_turn_complete'
   | 'masc/keeper_turn_complete'
@@ -203,6 +204,16 @@ export interface SSEEvent {
   tool_args_preview?: string
   tool_output_preview?: string
   tool_io_redacted?: boolean
+  composition_tool?: string
+  composition_run_id?: string
+  composition_node_id?: string
+  composition_execution?: 'inline' | 'async'
+  parent_tool_use_id?: string
+  tool_use_id?: string
+  planned_index?: number
+  batch_index?: number
+  batch_size?: number
+  execution_mode?: 'serial' | 'concurrent'
   reason_code?: string
   turn?: number
   phase?: string

--- a/lib/dashboard/dashboard_http_tool_quality.ml
+++ b/lib/dashboard/dashboard_http_tool_quality.ml
@@ -77,6 +77,9 @@ let tool_success_of_record record =
   | Some value -> value
   | None -> false
 
+let tool_record_is_deferred record =
+  Safe_ops.json_string_opt "disposition" record = Some "deferred"
+
 let hour_key_of_record record =
   let hour_of_unix ts =
     let tm = Unix.gmtime ts in
@@ -133,7 +136,7 @@ let source_metadata_fields () =
   Dashboard_tool_source_freshness.keeper_tool_call_io_fields
     ~dashboard_surface ()
 
-let empty_summary ~window_hours ~n ~sampling_mode =
+let empty_summary ~window_hours ~n ~sampling_mode ~deferred =
   `Assoc
     (source_metadata_fields ()
     @ [ ("generated_at", `String (Masc_domain.now_iso ()))
@@ -149,6 +152,7 @@ let empty_summary ~window_hours ~n ~sampling_mode =
     ; ("total", `Int 0)
     ; ("success", `Int 0)
     ; ("failure", `Int 0)
+    ; ("deferred", `Int deferred)
     ; ("success_rate", `Float 0.0)
     ; ("by_tool", `List [])
     ; ("by_keeper", `List [])
@@ -171,8 +175,10 @@ let aggregate ?(n = 5000) ?window_hours () : Yojson.Safe.t =
     | _ ->
       (Keeper_tool_call_log.read_recent ~n (), "recent_n", None)
   in
+  let deferred_records, records = List.partition tool_record_is_deferred records in
+  let deferred = List.length deferred_records in
   if records = [] then
-    empty_summary ~window_hours ~n ~sampling_mode
+    empty_summary ~window_hours ~n ~sampling_mode ~deferred
   else
   let total = ref 0 in
   let success = ref 0 in
@@ -400,6 +406,7 @@ let aggregate ?(n = 5000) ?window_hours () : Yojson.Safe.t =
     ("total", `Int total_n);
     ("success", `Int success_n);
     ("failure", `Int (total_n - success_n));
+    ("deferred", `Int deferred);
     ("success_rate", `Float (Float.round (rate *. 100.0) /. 100.0));
     ("by_tool", `List by_tool);
     ("by_keeper", `List by_keeper);

--- a/lib/dashboard/dashboard_http_tool_quality.mli
+++ b/lib/dashboard/dashboard_http_tool_quality.mli
@@ -33,4 +33,5 @@ val aggregate :
     the last [window_hours] hours. The payload includes per-tool /
     per-keeper / per-thinking-mode / per-hour rate tables plus the
     source-metadata envelope and the canonical
-    [dashboard_surface] tag. *)
+    [dashboard_surface] tag. Typed deferred records are reported in
+    [deferred] and excluded from settled success/failure rates. *)

--- a/lib/dashboard/dashboard_keeper_decision_log_proof.ml
+++ b/lib/dashboard/dashboard_keeper_decision_log_proof.ml
@@ -35,6 +35,20 @@ type turn_span_stat = {
 let seconds_per_hour = Masc_time_constants.hour
 let persistent_turn_window_hours = 24.0
 let recent_turn_max_age_hours = 24.0
+
+type persistence_tier =
+  { id : string
+  ; required_span_hours : float
+  }
+
+let persistence_tiers =
+  [ { id = "1h"; required_span_hours = 1.0 }
+  ; { id = "2h"; required_span_hours = 2.0 }
+  ; { id = "4h"; required_span_hours = 4.0 }
+  ; { id = "24h"; required_span_hours = persistent_turn_window_hours }
+  ]
+;;
+
 let decision_tail_max_bytes = 512 * 1024
 let decision_tail_max_lines = 5000
 
@@ -180,7 +194,7 @@ type segment_head_scan =
   | Complete_without_turn
   | Scan_exhausted
 
-let earliest_turn_ts_in_segment path =
+let earliest_turn_ts_in_segment ~now path =
   let slice = Fs_compat.read_slice ~path ~from:0 ~len:decision_head_max_bytes in
   let turn =
     String.split_on_char '\n' slice
@@ -192,7 +206,10 @@ let earliest_turn_ts_in_segment path =
         | exception Yojson.Json_error _ -> None
         | json ->
           if is_turn_exchange_channel (Safe_ops.json_string_opt "channel" json)
-          then decision_ts_unix json
+          then
+            (match decision_ts_unix json with
+             | Some ts when ts <= now -> Some ts
+             | Some _ | None -> None)
           else None)
   in
   match turn with
@@ -202,29 +219,30 @@ let earliest_turn_ts_in_segment path =
      | Some size when size <= String.length slice -> Complete_without_turn
      | Some _ | None -> Scan_exhausted)
 
-let earliest_turn_ts segments =
+let earliest_turn_ts ~now segments =
   let rec scan = function
     | [] -> None, No_turn_row_in_history
     | (rotation, path) :: rest ->
-      (match earliest_turn_ts_in_segment path with
+      (match earliest_turn_ts_in_segment ~now path with
        | Turn_found ts -> Some ts, History_head rotation
        | Complete_without_turn -> scan rest
        | Scan_exhausted -> None, History_scan_exhausted rotation)
   in
   scan segments
 
-let turn_span_stats ~config keeper_name =
+let turn_span_stats ~config ~now keeper_name =
   let tail =
     fold_keeper_decision_log ~config keeper_name ~init:empty_tail_scan
       ~f:(fun scan json ->
         if is_turn_exchange_channel (Safe_ops.json_string_opt "channel" json) then
           match decision_ts_unix json with
-          | Some ts -> update_tail_scan scan ts
+          | Some ts when ts <= now -> update_tail_scan scan ts
+          | Some _ -> scan
           | None -> scan
         else scan)
   in
   let segments = decision_log_segments ~config keeper_name in
-  let first_ts, first_ts_origin = earliest_turn_ts segments in
+  let first_ts, first_ts_origin = earliest_turn_ts ~now segments in
   {
     recent_interaction_count = tail.count;
     first_ts;
@@ -272,14 +290,24 @@ let latest_age_hours_json ~now stat =
   | Some latest -> `Float (latest_age_hours ~now latest)
   | None -> `Null
 
-let has_persistent_turn_span ~now stat =
-  stat.recent_interaction_count >= 2
+let has_persistent_turn_span_for ~required_span_hours ~now stat =
+  Float.is_finite required_span_hours
+  && required_span_hours > 0.0
   &&
   match stat.first_ts, stat.latest_ts with
   | Some first, Some latest ->
-    hours_between first latest >= persistent_turn_window_hours
+    first <= latest
+    && latest <= now
+    && hours_between first latest >= required_span_hours
     && latest_age_hours ~now latest <= recent_turn_max_age_hours
   | _ -> false
+
+let has_persistent_turn_span ~now stat =
+  has_persistent_turn_span_for
+    ~required_span_hours:persistent_turn_window_hours
+    ~now
+    stat
+;;
 
 let turn_span_evidence_json ~now keeper_name stat =
   `Assoc [

--- a/lib/dashboard/dashboard_keeper_decision_log_proof.mli
+++ b/lib/dashboard/dashboard_keeper_decision_log_proof.mli
@@ -7,6 +7,11 @@ type scheduled_stat = {
 
 type turn_span_stat
 
+type persistence_tier =
+  { id : string
+  ; required_span_hours : float
+  }
+
 val empty_scheduled_stat : scheduled_stat
 
 val scheduled_stats :
@@ -18,6 +23,7 @@ val scheduled_evidence_json : scheduled_stat -> Yojson.Safe.t
 
 val turn_span_stats :
   config:Workspace.config ->
+  now:float ->
   string ->
   turn_span_stat
 
@@ -26,8 +32,15 @@ val has_persistent_turn_span :
   turn_span_stat ->
   bool
 
+val has_persistent_turn_span_for :
+  required_span_hours:float ->
+  now:float ->
+  turn_span_stat ->
+  bool
+
 val persistent_turn_window_hours : float
 val recent_turn_max_age_hours : float
+val persistence_tiers : persistence_tier list
 
 val turn_span_evidence_json :
   now:float ->

--- a/lib/dashboard/dashboard_keeper_feature_proof.ml
+++ b/lib/dashboard/dashboard_keeper_feature_proof.ml
@@ -214,12 +214,12 @@ let persistent_turn_exchange_feature ~config ~now snapshots =
   let stats =
     snapshots
     |> List.map (fun snapshot ->
-      snapshot.keeper_name, Decision.turn_span_stats ~config snapshot.keeper_name)
+      snapshot.keeper_name, Decision.turn_span_stats ~config ~now snapshot.keeper_name)
   in
   let stat_for keeper_name =
     match List.assoc_opt keeper_name stats with
     | Some stat -> stat
-    | None -> Decision.turn_span_stats ~config keeper_name
+    | None -> Decision.turn_span_stats ~config ~now keeper_name
   in
   let observed =
     snapshots
@@ -249,6 +249,46 @@ let persistent_turn_exchange_feature ~config ~now snapshots =
       Decision.turn_span_evidence_json ~now snapshot.keeper_name
         (stat_for snapshot.keeper_name))
   in
+  let duration_tiers =
+    Decision.persistence_tiers
+    |> List.map (fun (tier : Decision.persistence_tier) ->
+      let observed_keepers, missing_keepers =
+        snapshots
+        |> List.partition (fun snapshot ->
+          Decision.has_persistent_turn_span_for
+            ~required_span_hours:tier.required_span_hours
+            ~now
+            (stat_for snapshot.keeper_name))
+      in
+      let observed_keepers =
+        observed_keepers
+        |> List.map (fun snapshot -> snapshot.keeper_name)
+        |> uniq_sorted
+      in
+      let missing_keepers =
+        missing_keepers
+        |> List.map (fun snapshot -> snapshot.keeper_name)
+        |> uniq_sorted
+      in
+      let tier_status =
+        if total = 0 || observed_keepers = []
+        then Fail
+        else if List.length observed_keepers = total
+        then Pass
+        else Warn
+      in
+      `Assoc
+        [ "id", `String tier.id
+        ; "evidence_kind", `String "durable_turn_span"
+        ; "required_span_hours", `Float tier.required_span_hours
+        ; "status", `String (status_to_string tier_status)
+        ; "keeper_count", `Int total
+        ; "observed_count", `Int (List.length observed_keepers)
+        ; "missing_count", `Int (List.length missing_keepers)
+        ; "observed_keepers", Json_util.json_string_list observed_keepers
+        ; "missing_keepers", Json_util.json_string_list missing_keepers
+        ])
+  in
   `Assoc [
     ("id", `String "persistent_24h_turn_exchange");
     ("label", `String "24h persistent turn exchange");
@@ -273,6 +313,7 @@ let persistent_turn_exchange_feature ~config ~now snapshots =
        ("read_errors", `List (keeper_read_errors snapshots));
        ("per_keeper", `List per_keeper);
      ]);
+    ("duration_tiers", `List duration_tiers);
     ( "evidence_refs",
       `List [
         evidence_ref ~kind:"store" ~id:"keeper_decision_log"

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -943,6 +943,7 @@ let run_turn
                       ~yield_on_tool
                       ~context_injector
                       ~context:shared_context
+                      ~terminal_effect_state:s.terminal_effect_state
                       ~enable_thinking:(Keeper_config.keeper_enable_thinking ())
                       ?cooperative_yield_probe
                       ?agent_core_checkpoint:resume_agent_core_checkpoint

--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -913,7 +913,7 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
     ~tools ~initial_messages ~model_input_projection ~hooks ~context_injector
     ~context
     ?(terminal_effect_state = fun () -> Keeper_tools_agent_core.Terminal_effect_open)
-    ~event_bus ~raw_trace ~on_event ~config =
+    ~event_bus ~raw_trace ~on_event ~config () =
   let effect_disposition =
     Atomic.make Keeper_provider_attempt_effect.No_effect_observed
   in

--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -316,7 +316,7 @@ let stream_projection ~turn_count on_event =
 
 let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
     ~system_prompt ~tools ~initial_messages ~model_input_projection ~hooks
-    ~context_injector ~context ~event_bus ~raw_trace ~on_event
+    ~context_injector ~context ~terminal_effect_state ~event_bus ~raw_trace ~on_event
     ~observe_effect_attempted
     ~(config : Runtime_execution.antigravity_cli) =
   match Eio_context.get_env_opt (), Eio_context.get_clock_opt () with
@@ -445,6 +445,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
         ~event_bus
         ~context_injector
         ~context
+        ~terminal_effect_state
         ~terminal_error
         ~raw_trace_run:None
     in
@@ -511,6 +512,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
         ~event_bus
         ~context_injector
         ~context
+        ~terminal_effect_state
         ~terminal_error
         ~raw_trace_run
     in
@@ -616,13 +618,12 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
             internal_error ("Antigravity host-stop settlement failed: " ^ detail))
         in
         session_state := settled;
-        Ok
-          (Host.repeated_tool_call_result
-             ~model:config.model
-             ~session_id
-             ~turn_id
-             ~turns_used:turn_count
-             stop)
+        Host.host_stop_result
+          ~model:config.model
+          ~session_id
+          ~turn_id
+          ~turns_used:turn_count
+          stop
       | Ready | Start _ | Active _ | Recovery_required _ | Settled _ ->
         Error
           (internal_error
@@ -910,7 +911,9 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
 
 let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
     ~tools ~initial_messages ~model_input_projection ~hooks ~context_injector
-    ~context ~event_bus ~raw_trace ~on_event ~config =
+    ~context
+    ?(terminal_effect_state = fun () -> Keeper_tools_agent_core.Terminal_effect_open)
+    ~event_bus ~raw_trace ~on_event ~config =
   let effect_disposition =
     Atomic.make Keeper_provider_attempt_effect.No_effect_observed
   in
@@ -932,6 +935,7 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
         ~hooks
         ~context_injector
         ~context
+        ~terminal_effect_state
         ~event_bus
         ~raw_trace
         ~on_event

--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -605,6 +605,25 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
           | _, Turn_inflight { turn_id = Some _; _ } -> Ok ()
           | _, _ -> assert false
         in
+        let projected =
+          Host.host_stop_result
+            ~model:config.model
+            ~session_id
+            ~turn_id
+            ~turns_used:turn_count
+            stop
+        in
+        let* () =
+          match projected with
+          | Error _ -> Ok ()
+          | Ok result ->
+            Host.invoke_turn_completion_hooks
+              ~runtime_label
+              ~keeper_name
+              ~turn_count
+              ~hooks
+              result.response
+        in
         recovery_failure := Session_store.State_persistence_failed;
         let* settled =
           Session_store.settle
@@ -618,12 +637,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
             internal_error ("Antigravity host-stop settlement failed: " ^ detail))
         in
         session_state := settled;
-        Host.host_stop_result
-          ~model:config.model
-          ~session_id
-          ~turn_id
-          ~turns_used:turn_count
-          stop
+        projected
       | Ready | Start _ | Active _ | Recovery_required _ | Settled _ ->
         Error
           (internal_error
@@ -784,34 +798,12 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
             }
           in
           let* () =
-            match
-              Host.invoke_turn_hook
-                ~keeper_name
-                ~turn_count:turn.num_turns
-                ~hook_name:"after_turn"
-                hooks.after_turn
-                (Agent_core.Hooks.AfterTurn { turn = turn.num_turns; response })
-            with
-            | Continue -> Ok ()
-            | HookFailed { stage; detail } ->
-              Error (Host.hook_error ~runtime_label ~hook_name:"after_turn" ~stage detail)
-            | decision ->
-              Error (Host.illegal_hook_decision ~runtime_label ~hook_name:"after_turn" decision)
-          in
-          let* () =
-            match
-              Host.invoke_turn_hook
-                ~keeper_name
-                ~turn_count:turn.num_turns
-                ~hook_name:"on_stop"
-                hooks.on_stop
-                (Agent_core.Hooks.OnStop { reason = response.stop_reason; response })
-            with
-            | Continue -> Ok ()
-            | HookFailed { stage; detail } ->
-              Error (Host.hook_error ~runtime_label ~hook_name:"on_stop" ~stage detail)
-            | decision ->
-              Error (Host.illegal_hook_decision ~runtime_label ~hook_name:"on_stop" decision)
+            Host.invoke_turn_completion_hooks
+              ~runtime_label
+              ~keeper_name
+              ~turn_count:turn.num_turns
+              ~hooks
+              response
           in
           recovery_failure := Session_store.State_persistence_failed;
           let* () =

--- a/lib/keeper/keeper_antigravity_runtime.mli
+++ b/lib/keeper/keeper_antigravity_runtime.mli
@@ -27,6 +27,7 @@ val run :
   raw_trace:Agent_core.Raw_trace.t option ->
   on_event:(Agent_core.Types.sse_event -> unit) option ->
   config:Runtime_execution.antigravity_cli ->
+  unit ->
   attempt_outcome
 
 module For_testing : sig

--- a/lib/keeper/keeper_antigravity_runtime.mli
+++ b/lib/keeper/keeper_antigravity_runtime.mli
@@ -22,6 +22,7 @@ val run :
   hooks:Agent_core.Hooks.hooks option ->
   context_injector:Agent_core.Hooks.context_injector option ->
   context:Agent_core.Context.t option ->
+  ?terminal_effect_state:(unit -> Keeper_tools_agent_core.terminal_effect_state) ->
   event_bus:Agent_core.Event_bus.t option ->
   raw_trace:Agent_core.Raw_trace.t option ->
   on_event:(Agent_core.Types.sse_event -> unit) option ->

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -877,7 +877,7 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
     ~tools ~initial_messages ~model_input_projection ~hooks ~context_injector
     ~context
     ?(terminal_effect_state = fun () -> Keeper_tools_agent_core.Terminal_effect_open)
-    ~event_bus ~raw_trace ~on_event ~config =
+    ~event_bus ~raw_trace ~on_event ~config () =
   let effect_disposition =
     Atomic.make Keeper_provider_attempt_effect.No_effect_observed
   in

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -576,6 +576,25 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
           | _, Turn_inflight { turn_id = Some _; _ } -> Ok ()
           | _, _ -> assert false
         in
+        let projected =
+          Host.host_stop_result
+            ~model:(Option.value config.model ~default:runtime_id)
+            ~session_id
+            ~turn_id
+            ~turns_used:turn_count
+            stop
+        in
+        let* () =
+          match projected with
+          | Error _ -> Ok ()
+          | Ok result ->
+            Host.invoke_turn_completion_hooks
+              ~runtime_label
+              ~keeper_name
+              ~turn_count
+              ~hooks
+              result.response
+        in
         recovery_failure := Session_store.State_persistence_failed;
         (match
            Session_store.settle
@@ -592,12 +611,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
                 ("Claude Code host-stop settlement failed: " ^ detail))
          | Ok settled ->
            session_state := settled;
-           Host.host_stop_result
-             ~model:(Option.value config.model ~default:runtime_id)
-             ~session_id
-             ~turn_id
-             ~turns_used:turn_count
-             stop)
+           projected)
       | Ready | Start _ | Active _ | Recovery_required _ | Settled _ ->
         Error
           (internal_error
@@ -713,55 +727,13 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
                    }
              }
            in
-           let after_turn =
-             Host.invoke_turn_hook
+           let* () =
+             Host.invoke_turn_completion_hooks
+               ~runtime_label
                ~keeper_name
                ~turn_count
-               ~hook_name:"after_turn"
-               hooks.after_turn
-               (Agent_core.Hooks.AfterTurn { turn = turn_count; response })
-           in
-           let* () =
-             match after_turn with
-             | Continue -> Ok ()
-             | HookFailed { stage; detail } ->
-               Error
-                 (Host.hook_error
-                    ~runtime_label
-                    ~hook_name:"after_turn"
-                    ~stage
-                    detail)
-             | decision ->
-               Error
-                 (Host.illegal_hook_decision
-                    ~runtime_label
-                    ~hook_name:"after_turn"
-                    decision)
-           in
-           let on_stop =
-             Host.invoke_turn_hook
-               ~keeper_name
-               ~turn_count
-               ~hook_name:"on_stop"
-               hooks.on_stop
-               (Agent_core.Hooks.OnStop { reason = response.stop_reason; response })
-           in
-           let* () =
-             match on_stop with
-             | Continue -> Ok ()
-             | HookFailed { stage; detail } ->
-               Error
-                 (Host.hook_error
-                    ~runtime_label
-                    ~hook_name:"on_stop"
-                    ~stage
-                    detail)
-             | decision ->
-               Error
-                 (Host.illegal_hook_decision
-                    ~runtime_label
-                    ~hook_name:"on_stop"
-                    decision)
+               ~hooks
+               response
            in
            recovery_failure := Session_store.State_persistence_failed;
            let* () =

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -272,7 +272,7 @@ let recovery_failure_of_client_error = function
 
 let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
     ~tools ~initial_messages ~model_input_projection ~hooks ~context_injector
-    ~context ~event_bus ~raw_trace ~on_event ~effect_disposition
+    ~context ~terminal_effect_state ~event_bus ~raw_trace ~on_event ~effect_disposition
     ~context_overflow_retry_safe
     ~(config : Runtime_execution.claude_code) =
   context_overflow_retry_safe := false;
@@ -399,6 +399,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
         ~event_bus
         ~context_injector
         ~context
+        ~terminal_effect_state
         ~terminal_error
         ~raw_trace_run:None
     in
@@ -452,6 +453,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
         ~event_bus
         ~context_injector
         ~context
+        ~terminal_effect_state
         ~terminal_error
         ~raw_trace_run
     in
@@ -590,13 +592,12 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
                 ("Claude Code host-stop settlement failed: " ^ detail))
          | Ok settled ->
            session_state := settled;
-           Ok
-             (Host.repeated_tool_call_result
-                ~model:(Option.value config.model ~default:runtime_id)
-                ~session_id
-                ~turn_id
-                ~turns_used:turn_count
-                stop))
+           Host.host_stop_result
+             ~model:(Option.value config.model ~default:runtime_id)
+             ~session_id
+             ~turn_id
+             ~turns_used:turn_count
+             stop)
       | Ready | Start _ | Active _ | Recovery_required _ | Settled _ ->
         Error
           (internal_error
@@ -874,7 +875,9 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
 
 let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
     ~tools ~initial_messages ~model_input_projection ~hooks ~context_injector
-    ~context ~event_bus ~raw_trace ~on_event ~config =
+    ~context
+    ?(terminal_effect_state = fun () -> Keeper_tools_agent_core.Terminal_effect_open)
+    ~event_bus ~raw_trace ~on_event ~config =
   let effect_disposition =
     Atomic.make Keeper_provider_attempt_effect.No_effect_observed
   in
@@ -933,9 +936,10 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
                     ~observed_floor_capacity_bytes
                     model_input_projection))
             ~hooks
-            ~context_injector
-            ~context
-            ~event_bus
+          ~context_injector
+          ~context
+          ~terminal_effect_state
+          ~event_bus
             ~raw_trace
             ~on_event
             ~effect_disposition

--- a/lib/keeper/keeper_claude_code_runtime.mli
+++ b/lib/keeper/keeper_claude_code_runtime.mli
@@ -40,4 +40,5 @@ val run :
   raw_trace:Agent_core.Raw_trace.t option ->
   on_event:(Agent_core.Types.sse_event -> unit) option ->
   config:Runtime_execution.claude_code ->
+  unit ->
   attempt_outcome

--- a/lib/keeper/keeper_claude_code_runtime.mli
+++ b/lib/keeper/keeper_claude_code_runtime.mli
@@ -35,6 +35,7 @@ val run :
   hooks:Agent_core.Hooks.hooks option ->
   context_injector:Agent_core.Hooks.context_injector option ->
   context:Agent_core.Context.t option ->
+  ?terminal_effect_state:(unit -> Keeper_tools_agent_core.terminal_effect_state) ->
   event_bus:Agent_core.Event_bus.t option ->
   raw_trace:Agent_core.Raw_trace.t option ->
   on_event:(Agent_core.Types.sse_event -> unit) option ->

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -388,7 +388,7 @@ let recovery_failure_of_client_error = function
 
 let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
     ~system_prompt ~tools ~initial_messages ~model_input_projection ~hooks
-    ~context_injector ~context ~event_bus ~raw_trace ~on_event
+    ~context_injector ~context ~terminal_effect_state ~event_bus ~raw_trace ~on_event
     ~observe_effect_attempted ~observe_successful_tool_completion
     ~(config : Runtime_execution.codex_app_server) =
   match Eio_context.get_env_opt (), Eio_context.get_clock_opt () with
@@ -544,6 +544,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
         ~event_bus
         ~context_injector
         ~context
+        ~terminal_effect_state
         ~terminal_error
         ~raw_trace_run:None
     in
@@ -617,6 +618,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
         ~event_bus
         ~context_injector
         ~context
+        ~terminal_effect_state
         ~terminal_error
         ~raw_trace_run
     in
@@ -721,13 +723,12 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
            Error (internal_error ("Codex host-stop settlement failed: " ^ detail))
          | Ok settled ->
            session_state := settled;
-           Ok
-             (Host.repeated_tool_call_result
-                ~model:(Option.value client_config.model ~default:runtime_id)
-                ~session_id
-                ~turn_id
-                ~turns_used:turn_count
-                stop))
+           Host.host_stop_result
+             ~model:(Option.value client_config.model ~default:runtime_id)
+             ~session_id
+             ~turn_id
+             ~turns_used:turn_count
+             stop)
       | Ready | Start _ | Active _ | Turn_inflight { turn_id = None; _ }
       | Recovery_required _ | Settled _ ->
         Error
@@ -952,7 +953,9 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
 
 let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
     ~system_prompt ~tools ~initial_messages ~model_input_projection ~hooks
-    ~context_injector ~context ~event_bus ~raw_trace ~on_event ~config =
+    ~context_injector ~context
+    ?(terminal_effect_state = fun () -> Keeper_tools_agent_core.Terminal_effect_open)
+    ~event_bus ~raw_trace ~on_event ~config =
   let effect_disposition =
     Atomic.make Keeper_provider_attempt_effect.No_effect_observed
   in
@@ -1016,6 +1019,7 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
           ~hooks
           ~context_injector
           ~context
+          ~terminal_effect_state
           ~event_bus
           ~raw_trace
           ~on_event

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -709,6 +709,25 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
     let settle_host_stop stop =
       match (!session_state).Keeper_official_client_session_store.phase with
       | Turn_inflight { session_id; turn_id = Some turn_id; _ } ->
+        let projected =
+          Host.host_stop_result
+            ~model:(Option.value client_config.model ~default:runtime_id)
+            ~session_id
+            ~turn_id
+            ~turns_used:turn_count
+            stop
+        in
+        let* () =
+          match projected with
+          | Error _ -> Ok ()
+          | Ok result ->
+            Host.invoke_turn_completion_hooks
+              ~runtime_label
+              ~keeper_name
+              ~turn_count
+              ~hooks
+              result.response
+        in
         recovery_failure := Keeper_official_client_session_store.State_persistence_failed;
         (match
            Keeper_official_client_session_store.settle
@@ -723,12 +742,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
            Error (internal_error ("Codex host-stop settlement failed: " ^ detail))
          | Ok settled ->
            session_state := settled;
-           Host.host_stop_result
-             ~model:(Option.value client_config.model ~default:runtime_id)
-             ~session_id
-             ~turn_id
-             ~turns_used:turn_count
-             stop)
+           projected)
       | Ready | Start _ | Active _ | Turn_inflight { turn_id = None; _ }
       | Recovery_required _ | Settled _ ->
         Error
@@ -821,35 +835,13 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
                }
          }
        in
-       let after_turn =
-         Host.invoke_turn_hook
+       let* () =
+         Host.invoke_turn_completion_hooks
+           ~runtime_label
            ~keeper_name
            ~turn_count
-           ~hook_name:"after_turn"
-           hooks.after_turn
-           (Agent_core.Hooks.AfterTurn { turn = turn_count; response })
-       in
-       let* () =
-         match after_turn with
-         | Continue -> Ok ()
-         | HookFailed { stage; detail } ->
-           Error (Host.hook_error ~runtime_label ~hook_name:"after_turn" ~stage detail)
-         | decision -> Error (Host.illegal_hook_decision ~runtime_label ~hook_name:"after_turn" decision)
-       in
-       let on_stop =
-         Host.invoke_turn_hook
-           ~keeper_name
-           ~turn_count
-           ~hook_name:"on_stop"
-           hooks.on_stop
-           (Agent_core.Hooks.OnStop { reason = response.stop_reason; response })
-       in
-       let* () =
-         match on_stop with
-         | Continue -> Ok ()
-         | HookFailed { stage; detail } ->
-           Error (Host.hook_error ~runtime_label ~hook_name:"on_stop" ~stage detail)
-         | decision -> Error (Host.illegal_hook_decision ~runtime_label ~hook_name:"on_stop" decision)
+           ~hooks
+           response
        in
        recovery_failure := Keeper_official_client_session_store.State_persistence_failed;
        let* () =

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -955,7 +955,7 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
     ~system_prompt ~tools ~initial_messages ~model_input_projection ~hooks
     ~context_injector ~context
     ?(terminal_effect_state = fun () -> Keeper_tools_agent_core.Terminal_effect_open)
-    ~event_bus ~raw_trace ~on_event ~config =
+    ~event_bus ~raw_trace ~on_event ~config () =
   let effect_disposition =
     Atomic.make Keeper_provider_attempt_effect.No_effect_observed
   in

--- a/lib/keeper/keeper_codex_runtime.mli
+++ b/lib/keeper/keeper_codex_runtime.mli
@@ -33,6 +33,7 @@ val run :
   raw_trace:Agent_core.Raw_trace.t option ->
   on_event:(Agent_core.Types.sse_event -> unit) option ->
   config:Runtime_execution.codex_app_server ->
+  unit ->
   attempt_outcome
 
 module For_testing : sig

--- a/lib/keeper/keeper_codex_runtime.mli
+++ b/lib/keeper/keeper_codex_runtime.mli
@@ -28,6 +28,7 @@ val run :
   hooks:Agent_core.Hooks.hooks option ->
   context_injector:Agent_core.Hooks.context_injector option ->
   context:Agent_core.Context.t option ->
+  ?terminal_effect_state:(unit -> Keeper_tools_agent_core.terminal_effect_state) ->
   event_bus:Agent_core.Event_bus.t option ->
   raw_trace:Agent_core.Raw_trace.t option ->
   on_event:(Agent_core.Types.sse_event -> unit) option ->

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -95,6 +95,7 @@ type operator_disposition_reason =
   | Reason_cancelled
   | Reason_phase_skipped
   | Reason_transcript_corruption
+  | Reason_provider_attempt_effect_fenced
   | Reason_unmapped_runtime_state
 
 let operator_disposition_reason_to_string = function
@@ -111,6 +112,8 @@ let operator_disposition_reason_to_string = function
   | Reason_cancelled -> "cancelled"
   | Reason_phase_skipped -> "phase_skipped"
   | Reason_transcript_corruption -> "transcript_corruption"
+  | Reason_provider_attempt_effect_fenced ->
+    Keeper_internal_error.provider_attempt_effect_fenced_kind
   | Reason_unmapped_runtime_state -> "unmapped_runtime_state"
 ;;
 
@@ -156,6 +159,12 @@ let operator_disposition (receipt : t)
   | _ when input_required -> Disp_pass, Reason_input_required
   | Keeper_terminal_reason.Transcript_corruption _ ->
     Disp_operator_reset_required, Reason_transcript_corruption
+  | Keeper_terminal_reason.Provider_attempt_effect_fenced _ ->
+    (* Same-turn replay stays forbidden, and the runtime lifecycle remains
+       responsible for selecting a later turn. Keep the operator alert, but
+       classify the canonical typed failure instead of incrementing the
+       unmapped-state regression metric. *)
+    Disp_unknown, Reason_provider_attempt_effect_fenced
   | Keeper_terminal_reason.Runtime_exhausted _ ->
     Disp_fail_open_next_runtime, Reason_runtime_exhausted
   | Keeper_terminal_reason.Capacity_backpressure _ ->
@@ -223,6 +232,7 @@ let operator_disposition (receipt : t)
        | Config_or_auth _
        | Provider_runtime_failure _
        | Transcript_corruption _
+       | Provider_attempt_effect_fenced _
        | Internal_error _
        | Unknown _ -> false)
     then Disp_pass, Reason_healthy

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -212,6 +212,10 @@ type operator_disposition_reason =
   | Reason_cancelled
   | Reason_phase_skipped
   | Reason_transcript_corruption
+  | Reason_provider_attempt_effect_fenced
+  (** The provider attempt did not prove whether an effect occurred. Paired
+      with [Disp_unknown] so operator attention remains required, while the
+      receipt is no longer counted as an unmapped classifier regression. *)
   | Reason_unmapped_runtime_state
 
 val operator_disposition_reason_to_string : operator_disposition_reason -> string

--- a/lib/keeper/keeper_official_client_host.ml
+++ b/lib/keeper/keeper_official_client_host.ml
@@ -698,10 +698,38 @@ let dynamic_tool_of_agent_core ~runtime_label ~keeper_name ~turn_count ~context 
         | result ->
           let result = settle result in
           let terminal_boundary =
-            match Agent_core.Tool.completion tool with
-            | Agent_core.Tool_contract.Continue_after_success -> None
-            | Agent_core.Tool_contract.Terminal_after_success _ ->
-              (match terminal_effect_state () with
+            match terminal_effect_state () with
+            | Keeper_tools_agent_core.Terminal_effect_failed
+                ({ effect_disposition =
+                     ( Tool_result.Proven_post_effect
+                     | Tool_result.Effect_outcome_unknown )
+                 ; _
+                 } as failure) ->
+              (* A composition may be statically ordinary yet fail after a
+                 nested effect.  Producer-owned aggregate evidence outranks
+                 the outer success-completion declaration: allowing the
+                 provider to retry would repeat an already-applied or
+                 indeterminate effect. *)
+              Some
+                (Terminal_tool_boundary
+                   { tool_name = tool.schema.name
+                   ; outcome =
+                       Terminal_failed
+                         { failure_class = failure.failure_class
+                         ; effect_disposition = failure.effect_disposition
+                         ; diagnostic = failure.diagnostic
+                         }
+                   })
+            | ( Keeper_tools_agent_core.Terminal_effect_open
+              | Keeper_tools_agent_core.Deferred_tool_result
+              | Keeper_tools_agent_core.External_effect_deferred
+              | Keeper_tools_agent_core.Terminal_effect_completed _
+              | Keeper_tools_agent_core.Terminal_effect_failed
+                  { effect_disposition = Tool_result.Proven_pre_effect; _ } ) as state ->
+              (match Agent_core.Tool.completion tool with
+               | Agent_core.Tool_contract.Continue_after_success -> None
+               | Agent_core.Tool_contract.Terminal_after_success _ ->
+                 (match state with
                | Keeper_tools_agent_core.Terminal_effect_completed _
                  ->
                  Some
@@ -722,25 +750,16 @@ let dynamic_tool_of_agent_core ~runtime_label ~keeper_name ~turn_count ~context 
                       ; outcome = Durable_stimulus_deferred
                       })
                | Keeper_tools_agent_core.Terminal_effect_failed
-                   ({ effect_disposition =
+                   { effect_disposition = Tool_result.Proven_pre_effect; _ }
+               | Keeper_tools_agent_core.Terminal_effect_open ->
+                 None
+               | Keeper_tools_agent_core.Terminal_effect_failed
+                   { effect_disposition =
                        ( Tool_result.Proven_post_effect
                        | Tool_result.Effect_outcome_unknown )
                    ; _
-                   } as failure) ->
-                 Some
-                   (Terminal_tool_boundary
-                      { tool_name = tool.schema.name
-                      ; outcome =
-                          Terminal_failed
-                            { failure_class = failure.failure_class
-                            ; effect_disposition = failure.effect_disposition
-                            ; diagnostic = failure.diagnostic
-                            }
-                      })
-               | Keeper_tools_agent_core.Terminal_effect_failed
-                   { effect_disposition = Tool_result.Proven_pre_effect; _ }
-               | Keeper_tools_agent_core.Terminal_effect_open ->
-                 None)
+                   } ->
+                 assert false))
           in
           let result =
             match terminal_boundary with

--- a/lib/keeper/keeper_official_client_host.ml
+++ b/lib/keeper/keeper_official_client_host.ml
@@ -6,10 +6,24 @@ let config_error ~field detail =
 
 let internal_error detail = Agent_core.Error.Internal detail
 
+type terminal_boundary_outcome = Runtime_official_client_tool.terminal_boundary_outcome =
+  | Terminal_completed
+  | Durable_stimulus_deferred
+  | External_effect_deferred
+  | Terminal_failed of
+      { failure_class : Tool_result.tool_failure_class
+      ; effect_disposition : Tool_result.failure_effect_disposition
+      ; diagnostic : string
+      }
+
 type host_stop = Runtime_official_client_tool.host_stop =
   | Repeated_tool_call of
       { tool_name : string
       ; repeated_count : int
+      }
+  | Terminal_tool_boundary of
+      { tool_name : string
+      ; outcome : terminal_boundary_outcome
       }
 
 let text_of_blocks ~runtime_label ~field blocks =
@@ -122,8 +136,24 @@ let with_run_lifecycle_events ~event_bus ~keeper_name run =
     run
 ;;
 
-let repeated_tool_call_result ~model ~session_id ~turn_id ~turns_used = function
-  | Repeated_tool_call { tool_name; repeated_count } ->
+let host_stop_result ~model ~session_id ~turn_id ~turns_used stop =
+  match stop with
+  | Terminal_tool_boundary
+      { outcome = Terminal_failed { failure_class; effect_disposition; diagnostic }
+      ; _
+      } ->
+    Error
+      (Keeper_internal_error.core_error_of_masc_internal_error
+         (Keeper_internal_error.Terminal_effect_failed
+            { failure_class; effect_disposition; diagnostic }))
+  | ( Repeated_tool_call _
+    | Terminal_tool_boundary
+        { outcome =
+            ( Terminal_completed
+            | Durable_stimulus_deferred
+            | External_effect_deferred )
+        ; _
+        } ) ->
     let response : Agent_core.Types.api_response =
       { id = turn_id
       ; model
@@ -137,17 +167,29 @@ let repeated_tool_call_result ~model ~session_id ~turn_id ~turns_used = function
             }
       }
     in
-    { Runtime_agent.response
-    ; checkpoint = None
-    ; session_id
-    ; turns = turns_used
-    ; trace_ref = None
-    ; run_validation = None
-    ; runtime_observation = None
-    ; stop_reason =
+    let stop_reason =
+      match stop with
+      | Repeated_tool_call { tool_name; repeated_count } ->
         Runtime_agent.Yielded_after_repeated_tool_call
           { turns_used; tool_name; repeated_count }
-    }
+      | Terminal_tool_boundary { outcome = Terminal_completed; _ } ->
+        Runtime_agent.Completed
+      | Terminal_tool_boundary { outcome = Durable_stimulus_deferred; _ } ->
+        Runtime_agent.Yielded_to_durable_stimulus { turns_used }
+      | Terminal_tool_boundary { outcome = External_effect_deferred; _ } ->
+        Runtime_agent.Awaiting_external_effect { turns_used }
+      | Terminal_tool_boundary { outcome = Terminal_failed _; _ } -> assert false
+    in
+    Ok
+      { Runtime_agent.response
+      ; checkpoint = None
+      ; session_id
+      ; turns = turns_used
+      ; trace_ref = None
+      ; run_validation = None
+      ; runtime_observation = None
+      ; stop_reason
+      }
 ;;
 
 type prepared_turn =
@@ -528,8 +570,9 @@ let apply_context_injection ~runtime_label ~terminal_error ~context
 ;;
 
 let dynamic_tool_of_agent_core ~runtime_label ~keeper_name ~turn_count ~context ~tools
-    ~(hooks : Agent_core.Hooks.hooks) ~event_bus ~context_injector ~terminal_error
-    ~raw_trace_run ~next_dynamic_invocation_index ~repeated_call_state
+    ~(hooks : Agent_core.Hooks.hooks) ~event_bus ~context_injector
+    ~terminal_effect_state ~terminal_error ~raw_trace_run
+    ~next_dynamic_invocation_index ~repeated_call_state
     (tool : Agent_core.Tool.t) =
   { name = tool.schema.name
   ; description = tool.schema.description
@@ -654,6 +697,56 @@ let dynamic_tool_of_agent_core ~runtime_label ~keeper_name ~turn_count ~context 
         match execute () with
         | result ->
           let result = settle result in
+          let terminal_boundary =
+            match Agent_core.Tool.completion tool with
+            | Agent_core.Tool_contract.Continue_after_success -> None
+            | Agent_core.Tool_contract.Terminal_after_success _ ->
+              (match terminal_effect_state () with
+               | Keeper_tools_agent_core.Terminal_effect_completed _
+                 ->
+                 Some
+                   (Terminal_tool_boundary
+                      { tool_name = tool.schema.name
+                      ; outcome = Terminal_completed
+                      })
+               | Keeper_tools_agent_core.External_effect_deferred ->
+                 Some
+                   (Terminal_tool_boundary
+                      { tool_name = tool.schema.name
+                      ; outcome = External_effect_deferred
+                      })
+               | Keeper_tools_agent_core.Deferred_tool_result ->
+                 Some
+                   (Terminal_tool_boundary
+                      { tool_name = tool.schema.name
+                      ; outcome = Durable_stimulus_deferred
+                      })
+               | Keeper_tools_agent_core.Terminal_effect_failed
+                   ({ effect_disposition =
+                       ( Tool_result.Proven_post_effect
+                       | Tool_result.Effect_outcome_unknown )
+                   ; _
+                   } as failure) ->
+                 Some
+                   (Terminal_tool_boundary
+                      { tool_name = tool.schema.name
+                      ; outcome =
+                          Terminal_failed
+                            { failure_class = failure.failure_class
+                            ; effect_disposition = failure.effect_disposition
+                            ; diagnostic = failure.diagnostic
+                            }
+                      })
+               | Keeper_tools_agent_core.Terminal_effect_failed
+                   { effect_disposition = Tool_result.Proven_pre_effect; _ }
+               | Keeper_tools_agent_core.Terminal_effect_open ->
+                 None)
+          in
+          let result =
+            match terminal_boundary with
+            | Some abort_turn -> { result with abort_turn = Some abort_turn }
+            | None -> result
+          in
           let fingerprint =
             dynamic_tool_fingerprint ~tool_name:tool.schema.name ~input result
           in
@@ -686,7 +779,7 @@ let dynamic_tool_of_agent_core ~runtime_label ~keeper_name ~turn_count ~context 
 ;;
 
 let dynamic_tools ~runtime_label ~keeper_name ~turn_count ~tools ~hooks ~event_bus
-    ~context_injector ~context ~terminal_error ~raw_trace_run =
+    ~context_injector ~context ~terminal_effect_state ~terminal_error ~raw_trace_run =
   match tools, context with
   | [], _ -> Ok []
   | _ :: _, None ->
@@ -708,6 +801,7 @@ let dynamic_tools ~runtime_label ~keeper_name ~turn_count ~tools ~hooks ~event_b
             ~hooks
             ~event_bus
             ~context_injector
+            ~terminal_effect_state
             ~terminal_error
             ~raw_trace_run
             ~next_dynamic_invocation_index

--- a/lib/keeper/keeper_official_client_host.ml
+++ b/lib/keeper/keeper_official_client_host.ml
@@ -111,6 +111,38 @@ let invoke_turn_hook ~keeper_name ~turn_count ~hook_name hook event =
     event
 ;;
 
+let invoke_turn_completion_hooks ~runtime_label ~keeper_name ~turn_count ~hooks
+    (response : Agent_core.Types.api_response) =
+  let* () =
+    match
+      invoke_turn_hook
+        ~keeper_name
+        ~turn_count
+        ~hook_name:"after_turn"
+        hooks.Agent_core.Hooks.after_turn
+        (Agent_core.Hooks.AfterTurn { turn = turn_count; response })
+    with
+    | Continue -> Ok ()
+    | HookFailed { stage; detail } ->
+      Error (hook_error ~runtime_label ~hook_name:"after_turn" ~stage detail)
+    | decision ->
+      Error (illegal_hook_decision ~runtime_label ~hook_name:"after_turn" decision)
+  in
+  match
+    invoke_turn_hook
+      ~keeper_name
+      ~turn_count
+      ~hook_name:"on_stop"
+      hooks.on_stop
+      (Agent_core.Hooks.OnStop { reason = response.stop_reason; response })
+  with
+  | Continue -> Ok ()
+  | HookFailed { stage; detail } ->
+    Error (hook_error ~runtime_label ~hook_name:"on_stop" ~stage detail)
+  | decision ->
+    Error (illegal_hook_decision ~runtime_label ~hook_name:"on_stop" decision)
+;;
+
 let lifecycle_outcome = function
   | Error error -> Agent_core.Agent_lifecycle_events.Failed error
   | Ok ({ response; stop_reason; _ } : Runtime_agent.run_result) ->

--- a/lib/keeper/keeper_official_client_host.mli
+++ b/lib/keeper/keeper_official_client_host.mli
@@ -135,6 +135,17 @@ val invoke_turn_hook :
   Agent_core.Hooks.hook_event ->
   Agent_core.Hooks.hook_decision
 
+val invoke_turn_completion_hooks :
+  runtime_label:string ->
+  keeper_name:string ->
+  turn_count:int ->
+  hooks:Agent_core.Hooks.hooks ->
+  Agent_core.Types.api_response ->
+  (unit, Agent_core.Error.t) result
+(** Run the Agent Core [after_turn] and [on_stop] lifecycle for a completed
+    official-client turn. Host-stop projections use the same hook order as a
+    provider-emitted terminal before their durable session is settled. *)
+
 val measure_message_bytes : Agent_core.Types.message -> int
 (** Bytes one message contributes to the start-turn seed budget, in the
     canonical MASC encoding. At or above what any adapter's own rendering

--- a/lib/keeper/keeper_official_client_host.mli
+++ b/lib/keeper/keeper_official_client_host.mli
@@ -20,10 +20,24 @@ type prepared_turn =
   ; reasoning_effort : Llm_provider.Reasoning_effort.t option
   }
 
+type terminal_boundary_outcome = Runtime_official_client_tool.terminal_boundary_outcome =
+  | Terminal_completed
+  | Durable_stimulus_deferred
+  | External_effect_deferred
+  | Terminal_failed of
+      { failure_class : Tool_result.tool_failure_class
+      ; effect_disposition : Tool_result.failure_effect_disposition
+      ; diagnostic : string
+      }
+
 type host_stop = Runtime_official_client_tool.host_stop =
   | Repeated_tool_call of
       { tool_name : string
       ; repeated_count : int
+      }
+  | Terminal_tool_boundary of
+      { tool_name : string
+      ; outcome : terminal_boundary_outcome
       }
 
 type dynamic_tool_result = Runtime_official_client_tool.dynamic_tool_result =
@@ -162,6 +176,7 @@ val dynamic_tools :
   event_bus:Agent_core.Event_bus.t option ->
   context_injector:Agent_core.Hooks.context_injector option ->
   context:Agent_core.Context.t option ->
+  terminal_effect_state:(unit -> Keeper_tools_agent_core.terminal_effect_state) ->
   terminal_error:string option ref ->
   raw_trace_run:Agent_core.Raw_trace.active_run option ->
   (dynamic_tool list, Agent_core.Error.t) result
@@ -180,13 +195,13 @@ val with_run_lifecycle_events :
     Official clients own their internal model loop, so this host boundary is
     the single MASC owner for those events. *)
 
-val repeated_tool_call_result :
+val host_stop_result :
   model:string ->
   session_id:string ->
   turn_id:string ->
   turns_used:int ->
   host_stop ->
-  Runtime_agent.run_result
+  (Runtime_agent.run_result, Agent_core.Error.t) result
 (** Build the provider-neutral checkpoint terminal after an official-client
     adapter stops its vendor-owned loop. The external client session is the
     durable continuation owner, so no Agent Core checkpoint is synthesized. *)

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -97,6 +97,54 @@ let gate_causal_initial
     ]
 ;;
 
+let composition_catalog_config_error detail =
+  Agent_core.Error.Config
+    (Agent_core.Error.InvalidConfig
+       { field = "tool-compositions.toml"; detail })
+;;
+
+let composition_catalog_io_error ~op ~path exn =
+  Agent_core.Error.Io
+    (Agent_core.Error.FileOpFailed
+       { op; path; detail = Printexc.to_string exn })
+;;
+
+let load_composition_catalog ~config_root =
+  let path = Keeper_tool_composition_catalog.path ~config_root in
+  match
+    try Ok (Fs_compat.exact_path_kind path) with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Error (composition_catalog_io_error ~op:"inspect" ~path exn)
+  with
+  | Error _ as error -> error
+  | Ok Fs_compat.Exact_missing -> Ok None
+  | Ok (Fs_compat.Exact_kind Unix.S_REG) ->
+    (match
+       try Ok (Fs_compat.load_file path) with
+       | Eio.Cancel.Cancelled _ as exn -> raise exn
+       | exn -> Error (composition_catalog_io_error ~op:"read" ~path exn)
+     with
+     | Error _ as error -> error
+     | Ok content ->
+       (match Keeper_tool_composition_catalog.parse content with
+        | Ok catalog -> Ok (Some catalog)
+        | Error error ->
+          Error
+            (composition_catalog_config_error
+               (Keeper_tool_composition_catalog.error_to_string error))))
+  | Ok
+      (Fs_compat.Exact_kind
+        ( Unix.S_DIR
+        | Unix.S_CHR
+        | Unix.S_BLK
+        | Unix.S_LNK
+        | Unix.S_FIFO
+        | Unix.S_SOCK )) ->
+    Error (composition_catalog_config_error "catalog path is not a regular file")
+  | Ok Fs_compat.Exact_unknown ->
+    Error (composition_catalog_config_error "catalog path kind is unavailable")
+;;
+
 let prepare_agent_setup
       ~(config : Workspace.config)
       ~(meta : Keeper_meta_contract.keeper_meta)
@@ -143,6 +191,7 @@ let prepare_agent_setup
            ~dynamic_context)
   in
   let agent_name = meta.agent_name in
+  let* composition_catalog = load_composition_catalog ~config_root in
   let acc : Keeper_run_tools_hook_accumulator.hook_accumulator =
     { meta
     ; tool_calls = []
@@ -176,6 +225,7 @@ let prepare_agent_setup
       ?continuation_channel
       ~gate_context
       ?hitl_resolution
+      ?composition_catalog
       ()
   in
   let replay_delivery =

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -239,6 +239,7 @@ let prepare_agent_setup
       ~gate_context
       ?hitl_resolution
       ?composition_catalog
+      ~turn_ctx_cell
       ()
   in
   let replay_delivery =

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -153,9 +153,7 @@ let expected_model_tool_names ~model_visible_descriptors ~composition_catalog =
   let composition_names =
     match composition_catalog with
     | None -> []
-    | Some catalog ->
-      Keeper_tool_composition_catalog.entries catalog
-      |> List.map Keeper_tool_composition_catalog.tool_name
+    | Some catalog -> Keeper_tool_composition_catalog.model_tool_names catalog
   in
   List.sort_uniq String.compare (descriptor_names @ composition_names)
 ;;

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -145,6 +145,21 @@ let load_composition_catalog ~config_root =
     Error (composition_catalog_config_error "catalog path kind is unavailable")
 ;;
 
+let expected_model_tool_names ~model_visible_descriptors ~composition_catalog =
+  let descriptor_names =
+    model_visible_descriptors
+    |> List.concat_map Keeper_tool_descriptor.keeper_model_names
+  in
+  let composition_names =
+    match composition_catalog with
+    | None -> []
+    | Some catalog ->
+      Keeper_tool_composition_catalog.entries catalog
+      |> List.map Keeper_tool_composition_catalog.tool_name
+  in
+  List.sort_uniq String.compare (descriptor_names @ composition_names)
+;;
+
 let prepare_agent_setup
       ~(config : Workspace.config)
       ~(meta : Keeper_meta_contract.keeper_meta)
@@ -349,9 +364,9 @@ let prepare_agent_setup
     List.map (fun (tool : Agent_core.Tool.t) -> tool.schema.name) keeper_tools
   in
   let expected_model_names =
-    model_visible_descriptors
-    |> List.concat_map Keeper_tool_descriptor.keeper_model_names
-    |> List.sort_uniq String.compare
+    expected_model_tool_names
+      ~model_visible_descriptors
+      ~composition_catalog
   in
   let actual_model_names = List.sort_uniq String.compare all_tool_names in
   let all_model_eligible_tools_visible =

--- a/lib/keeper/keeper_tool_composition_catalog.ml
+++ b/lib/keeper/keeper_tool_composition_catalog.ml
@@ -223,6 +223,7 @@ and parse_output_template ~path fields =
            | Error _ as error -> error
            | Ok node_id ->
              (match pointer ~path:(path @ [ "pointer" ]) raw_pointer with
+              | Error _ as error -> error
               | Ok pointer -> Ok (Plan.Json_template.output ~node_id ~pointer)))))
 
 and parse_object_template ~path fields =

--- a/lib/keeper/keeper_tool_composition_catalog.ml
+++ b/lib/keeper/keeper_tool_composition_catalog.ml
@@ -38,6 +38,15 @@ type error =
       ; character : char
       }
   | Duplicate_composition_name of string
+  | Invalid_execution_mode of
+      { path : string list
+      ; mode : string
+      }
+  | Async_tool_not_statically_read_only of
+      { name : string
+      ; node_id : Plan.Node_id.t
+      ; tool_name : string
+      }
   | Invalid_template_kind of
       { path : string list
       ; kind : string
@@ -59,9 +68,14 @@ type error =
       ; error : Plan.error
       }
 
+type execution_mode =
+  | Inline
+  | Async
+
 type entry =
   { name : string
   ; description : string option
+  ; execution : execution_mode
   ; plan : Plan.t
   }
 
@@ -71,12 +85,27 @@ let tool_name_prefix = "keeper_compose_"
 let maximum_tool_name_bytes = 64
 let maximum_composition_name_bytes = maximum_tool_name_bytes - String.length tool_name_prefix
 let tool_name entry = tool_name_prefix ^ entry.name
+let status_tool_name = "keeper_composition_status"
+let cancel_tool_name = "keeper_composition_cancel"
+
+let execution_mode_to_string = function
+  | Inline -> "inline"
+  | Async -> "async"
+;;
+
 let path ~config_root = Filename.concat config_root "tool-compositions.toml"
 
 let entries catalog = catalog
 
 let find catalog name =
   List.find_opt (fun entry -> String.equal entry.name name) catalog
+;;
+
+let model_tool_names catalog =
+  let entry_names = List.map tool_name catalog in
+  if List.exists (fun entry -> entry.execution = Async) catalog
+  then entry_names @ [ status_tool_name; cancel_tool_name ]
+  else entry_names
 ;;
 
 let first_duplicate fields =
@@ -334,7 +363,12 @@ let parse_composition ~index value =
   match table_fields ~path ~field:"composition" value with
   | Error _ as error -> error
   | Ok fields ->
-    (match validate_fields ~path ~allowed:[ "name"; "description"; "nodes" ] fields with
+    (match
+       validate_fields
+         ~path
+         ~allowed:[ "name"; "description"; "execution"; "nodes" ]
+         fields
+     with
      | Error _ as error -> error
      | Ok () ->
        (match required_nonempty_string ~path "name" fields with
@@ -355,9 +389,19 @@ let parse_composition ~index value =
             | Some character ->
               Error (Invalid_composition_name_character { name; character })
             | None ->
-            (match optional_string ~path "description" fields with
+           (match optional_string ~path "description" fields with
            | Error _ as error -> error
            | Ok description ->
+             (match required_string ~path "execution" fields with
+              | Error _ as error -> error
+              | Ok raw_execution ->
+                (match raw_execution with
+                 | "inline" -> Ok Inline
+                 | "async" -> Ok Async
+                 | mode -> Error (Invalid_execution_mode { path; mode }))
+                |> (function
+                 | Error _ as error -> error
+                 | Ok execution ->
              (match required_field ~path "nodes" fields with
               | Error _ as error -> error
               | Ok raw_nodes ->
@@ -379,8 +423,30 @@ let parse_composition ~index value =
                            ~descriptors:(Keeper_tool_descriptor.all_descriptors ())
                            nodes
                        with
-                       | Ok plan -> Ok { name; description; plan }
-                       | Error error -> Error (Plan_rejected { name; error })))))))))
+                       | Error error -> Error (Plan_rejected { name; error })
+                       | Ok plan ->
+                         (match execution with
+                          | Inline -> Ok { name; description; execution; plan }
+                          | Async ->
+                            (match
+                               Plan.nodes plan
+                               |> List.find_map (fun (node : Plan.node) ->
+                                 match Plan.descriptor plan node.id with
+                                 | Some descriptor
+                                   when Keeper_tool_descriptor.readonly_static_hint
+                                          descriptor
+                                        = Some true ->
+                                   None
+                                 | Some _ | None -> Some node)
+                             with
+                             | None -> Ok { name; description; execution; plan }
+                             | Some node ->
+                               Error
+                                 (Async_tool_not_statically_read_only
+                                    { name
+                                    ; node_id = node.id
+                                    ; tool_name = node.tool_name
+                                    })))))))))))))
 ;;
 
 let parse content =
@@ -485,6 +551,17 @@ let error_to_string = function
   | Invalid_composition_name_character { name; character } ->
     Printf.sprintf "composition name %S contains unsupported character %C" name character
   | Duplicate_composition_name name -> "duplicate composition name: " ^ name
+  | Invalid_execution_mode { path; mode } ->
+    Printf.sprintf
+      "invalid execution mode %S at %s (expected inline or async)"
+      mode
+      (String.concat "." path)
+  | Async_tool_not_statically_read_only { name; node_id; tool_name } ->
+    Printf.sprintf
+      "async composition %S node %S tool %S is not statically read-only"
+      name
+      (node_id_to_string node_id)
+      tool_name
   | Invalid_template_kind { path; kind } ->
     Printf.sprintf "invalid template kind %S at %s" kind (String.concat "." path)
   | Invalid_node_id { path; _ } -> "invalid node id at " ^ String.concat "." path

--- a/lib/keeper/keeper_tool_composition_catalog.ml
+++ b/lib/keeper/keeper_tool_composition_catalog.ml
@@ -29,6 +29,14 @@ type error =
       ; expected : expected_value
       }
   | Empty_name of { path : string list }
+  | Composition_name_too_long of
+      { name : string
+      ; maximum_bytes : int
+      }
+  | Invalid_composition_name_character of
+      { name : string
+      ; character : char
+      }
   | Duplicate_composition_name of string
   | Invalid_template_kind of
       { path : string list
@@ -58,6 +66,12 @@ type entry =
   }
 
 type t = entry list
+
+let tool_name_prefix = "keeper_compose_"
+let maximum_tool_name_bytes = 64
+let maximum_composition_name_bytes = maximum_tool_name_bytes - String.length tool_name_prefix
+let tool_name entry = tool_name_prefix ^ entry.name
+let path ~config_root = Filename.concat config_root "tool-compositions.toml"
 
 let entries catalog = catalog
 
@@ -209,7 +223,6 @@ and parse_output_template ~path fields =
            | Error _ as error -> error
            | Ok node_id ->
              (match pointer ~path:(path @ [ "pointer" ]) raw_pointer with
-              | Error _ as error -> error
               | Ok pointer -> Ok (Plan.Json_template.output ~node_id ~pointer)))))
 
 and parse_object_template ~path fields =
@@ -324,9 +337,24 @@ let parse_composition ~index value =
      | Error _ as error -> error
      | Ok () ->
        (match required_nonempty_string ~path "name" fields with
-        | Error _ as error -> error
-        | Ok name ->
-          (match optional_string ~path "description" fields with
+       | Error _ as error -> error
+       | Ok name ->
+         if String.length name > maximum_composition_name_bytes
+         then
+           Error
+             (Composition_name_too_long
+                { name; maximum_bytes = maximum_composition_name_bytes })
+         else
+           (match
+              String.to_seq name
+              |> Seq.find (function
+                | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '-' -> false
+                | _ -> true)
+            with
+            | Some character ->
+              Error (Invalid_composition_name_character { name; character })
+            | None ->
+            (match optional_string ~path "description" fields with
            | Error _ as error -> error
            | Ok description ->
              (match required_field ~path "nodes" fields with
@@ -351,7 +379,7 @@ let parse_composition ~index value =
                            nodes
                        with
                        | Ok plan -> Ok { name; description; plan }
-                       | Error error -> Error (Plan_rejected { name; error }))))))))
+                       | Error error -> Error (Plan_rejected { name; error })))))))))
 ;;
 
 let parse content =
@@ -379,4 +407,93 @@ let parse content =
                      | None -> parse_entries (index + 1) (entry :: parsed) rest))
              in
              parse_entries 0 [] raw_compositions)))
+;;
+
+let node_id_to_string = Keeper_tool_plan.Node_id.to_string
+
+let plan_error_to_string = function
+  | Keeper_tool_plan.Empty_plan -> "plan has no nodes"
+  | Keeper_tool_plan.Unknown_descriptor_id id ->
+    Printf.sprintf "descriptor id %S is not canonical" id
+  | Keeper_tool_plan.Duplicate_node_id node_id ->
+    Printf.sprintf "duplicate node id %S" (node_id_to_string node_id)
+  | Keeper_tool_plan.Duplicate_tool_name tool_name ->
+    Printf.sprintf "descriptor tool name %S is ambiguous" tool_name
+  | Keeper_tool_plan.Unknown_tool { node_id; tool_name } ->
+    Printf.sprintf
+      "node %S names unknown tool %S"
+      (node_id_to_string node_id)
+      tool_name
+  | Keeper_tool_plan.Missing_dependency { node_id; dependency } ->
+    Printf.sprintf
+      "node %S depends on missing node %S"
+      (node_id_to_string node_id)
+      (node_id_to_string dependency)
+  | Keeper_tool_plan.Opaque_output_reference
+      { node_id; source_node_id; source_tool_name } ->
+    Printf.sprintf
+      "node %S references opaque output from node %S (%s)"
+      (node_id_to_string node_id)
+      (node_id_to_string source_node_id)
+      source_tool_name
+  | Keeper_tool_plan.Invalid_output_pointer
+      { node_id; source_node_id; pointer; _ } ->
+    Printf.sprintf
+      "node %S has invalid output pointer /%s for node %S"
+      (node_id_to_string node_id)
+      (String.concat "/" (Keeper_tool_plan.Json_pointer.segments pointer))
+      (node_id_to_string source_node_id)
+  | Keeper_tool_plan.Invalid_output_schema { node_id; tool_name; _ } ->
+    Printf.sprintf
+      "node %S tool %S declares an invalid composable output schema"
+      (node_id_to_string node_id)
+      tool_name
+  | Keeper_tool_plan.Multiple_terminal_nodes node_ids ->
+    Printf.sprintf
+      "plan has multiple terminal nodes: %s"
+      (node_ids |> List.map node_id_to_string |> String.concat ", ")
+  | Keeper_tool_plan.Terminal_node_missing_dependency
+      { terminal_node_id; node_id } ->
+    Printf.sprintf
+      "terminal node %S does not depend on node %S"
+      (node_id_to_string terminal_node_id)
+      (node_id_to_string node_id)
+  | Keeper_tool_plan.Dependency_cycle node_ids ->
+    Printf.sprintf
+      "plan dependency cycle: %s"
+      (node_ids |> List.map node_id_to_string |> String.concat " -> ")
+;;
+
+let error_to_string = function
+  | Toml_syntax detail -> "invalid TOML: " ^ detail
+  | Empty_catalog -> "catalog must declare at least one composition"
+  | Unknown_field { path; field } ->
+    Printf.sprintf "unknown field %S at %s" field (String.concat "." path)
+  | Duplicate_field { path; field } ->
+    Printf.sprintf "duplicate field %S at %s" field (String.concat "." path)
+  | Missing_field { path; field } ->
+    Printf.sprintf "missing field %S at %s" field (String.concat "." path)
+  | Wrong_value_kind { path; field; _ } ->
+    Printf.sprintf "wrong value kind for %S at %s" field (String.concat "." path)
+  | Empty_name { path } -> "empty name at " ^ String.concat "." path
+  | Composition_name_too_long { name; maximum_bytes } ->
+    Printf.sprintf
+      "composition name %S exceeds %d bytes"
+      name
+      maximum_bytes
+  | Invalid_composition_name_character { name; character } ->
+    Printf.sprintf "composition name %S contains unsupported character %C" name character
+  | Duplicate_composition_name name -> "duplicate composition name: " ^ name
+  | Invalid_template_kind { path; kind } ->
+    Printf.sprintf "invalid template kind %S at %s" kind (String.concat "." path)
+  | Invalid_node_id { path; _ } -> "invalid node id at " ^ String.concat "." path
+  | Invalid_json_pointer { path; _ } ->
+    "invalid JSON pointer at " ^ String.concat "." path
+  | Duplicate_template_object_field { path; field } ->
+    Printf.sprintf
+      "duplicate template object field %S at %s"
+      field
+      (String.concat "." path)
+  | Plan_rejected { name; error } ->
+    Printf.sprintf "composition %S rejected: %s" name (plan_error_to_string error)
 ;;

--- a/lib/keeper/keeper_tool_composition_catalog.mli
+++ b/lib/keeper/keeper_tool_composition_catalog.mli
@@ -42,6 +42,15 @@ type error =
       ; character : char
       }
   | Duplicate_composition_name of string
+  | Invalid_execution_mode of
+      { path : string list
+      ; mode : string
+      }
+  | Async_tool_not_statically_read_only of
+      { name : string
+      ; node_id : Keeper_tool_plan.Node_id.t
+      ; tool_name : string
+      }
   | Invalid_template_kind of
       { path : string list
       ; kind : string
@@ -63,9 +72,14 @@ type error =
       ; error : Keeper_tool_plan.error
       }
 
+type execution_mode =
+  | Inline
+  | Async
+
 type entry = private
   { name : string
   ; description : string option
+  ; execution : execution_mode
   ; plan : Keeper_tool_plan.t
   }
 
@@ -80,6 +94,15 @@ val entries : t -> entry list
 val find : t -> string -> entry option
 val tool_name : entry -> string
 (** Stable model-visible name for this materialized composition. *)
+
+val execution_mode_to_string : execution_mode -> string
+
+val model_tool_names : t -> string list
+(** Exact model-visible composition surface, including the shared status and
+    cancel controls when at least one async composition is declared. *)
+
+val status_tool_name : string
+val cancel_tool_name : string
 
 val error_to_string : error -> string
 

--- a/lib/keeper/keeper_tool_composition_catalog.mli
+++ b/lib/keeper/keeper_tool_composition_catalog.mli
@@ -33,6 +33,14 @@ type error =
       ; expected : expected_value
       }
   | Empty_name of { path : string list }
+  | Composition_name_too_long of
+      { name : string
+      ; maximum_bytes : int
+      }
+  | Invalid_composition_name_character of
+      { name : string
+      ; character : char
+      }
   | Duplicate_composition_name of string
   | Invalid_template_kind of
       { path : string list
@@ -70,3 +78,10 @@ val parse : string -> (t, error) result
 
 val entries : t -> entry list
 val find : t -> string -> entry option
+val tool_name : entry -> string
+(** Stable model-visible name for this materialized composition. *)
+
+val error_to_string : error -> string
+
+val path : config_root:string -> string
+(** Dedicated catalog path below the resolved MASC config root. *)

--- a/lib/keeper/keeper_tool_composition_surface.ml
+++ b/lib/keeper/keeper_tool_composition_surface.ml
@@ -10,6 +10,30 @@ let empty_input_schema =
     ]
 ;;
 
+let request_id_input_schema =
+  `Assoc
+    [ "type", `String "object"
+    ; ( "properties"
+      , `Assoc
+          [ ( "request_id"
+            , `Assoc
+                [ "type", `String "string"
+                ; "minLength", `Int 1
+                ] )
+          ] )
+    ; "required", `List [ `String "request_id" ]
+    ; "additionalProperties", `Bool false
+    ]
+;;
+
+let request_id_of_validated_input = function
+  | `Assoc fields ->
+    (match List.assoc_opt "request_id" fields with
+     | Some (`String request_id) -> Some request_id
+     | Some _ | None -> None)
+  | _ -> None
+;;
+
 let schedule_to_json (schedule : Agent_core.Tool_contract.schedule) =
   `Assoc
     [ "planned_index", `Int schedule.planned_index
@@ -256,6 +280,286 @@ let result_of_execution ~tool_name ~start_time = function
       (Yojson.Safe.to_string data)
 ;;
 
+let async_parent_invocation ~request_id source =
+  Agent_core.Tool_contract.Invocation.create
+    ~tool_use_id:("composition-async:" ^ request_id)
+    ~turn:(Agent_core.Tool_contract.Invocation.turn source)
+    ~schedule:(Agent_core.Tool_contract.Invocation.schedule source)
+    ~completion:Agent_core.Tool_contract.Continue_after_success
+;;
+
+let async_worker_result
+      ~(entry : Catalog.entry)
+      ~tool_name
+      ~request_id
+      ~source_invocation
+      ~request_sw
+      ~(config : Workspace.config)
+      ~meta
+      ~publication_recovery
+      ~ctx_snapshot
+      ?clock
+      ()
+  =
+  Eio_context.with_turn_switch request_sw
+  @@ fun () ->
+  let sandbox_factory = Keeper_sandbox_factory.create ~config ~meta () in
+  Eio.Switch.on_release request_sw (fun () ->
+    Keeper_sandbox_factory.cleanup sandbox_factory);
+  let start_time = Time_compat.now () in
+  Executor.execute_keeper
+    ~plan:entry.plan
+    ~run_id:(Keeper_tool_plan.Run_id.fresh ())
+    ~parent_invocation:
+      (async_parent_invocation ~request_id source_invocation)
+    ~config
+    ~meta
+    ~publication_recovery
+    ~ctx_snapshot
+    ~turn_sandbox_factory:sandbox_factory
+    ?clock
+    ()
+  |> result_of_execution ~tool_name ~start_time
+;;
+
+let result_from_json ~tool_name ~start_time ~class_ ~ok data =
+  if ok
+  then Tool_result.make_ok ~tool_name ~start_time ~data ()
+  else
+    Tool_result.make_err
+      ~tool_name
+      ~class_
+      ~start_time
+      ~data
+      (Yojson.Safe.to_string data)
+;;
+
+let async_submission_result
+      ~entry
+      ~tool_name
+      ~parent_invocation
+      ~(config : Workspace.config)
+      ~(meta : Keeper_meta_contract.keeper_meta)
+      ~publication_recovery
+      ~ctx_snapshot
+      ?clock
+      ()
+  =
+  let start_time = Time_compat.now () in
+  match Keeper_msg_async.server_background_switch () with
+  | Error error ->
+    let data = Keeper_msg_async.submit_error_to_json error in
+    result_from_json
+      ~tool_name
+      ~start_time
+      ~class_:Tool_result.Runtime_failure
+      ~ok:false
+      data
+  | Ok background_sw ->
+    (match
+       Keeper_msg_async.submit_with_request_id
+         ~background_sw
+         ~base_path:config.base_path
+         ~caller:meta.name
+         ~keeper_name:meta.name
+         ~f:(fun ~request_id request_sw ->
+           async_worker_result
+             ~entry
+             ~tool_name
+             ~request_id
+             ~source_invocation:parent_invocation
+             ~request_sw
+             ~config
+             ~meta
+             ~publication_recovery
+             ~ctx_snapshot
+             ?clock
+             ())
+         ()
+     with
+     | Error error ->
+       let data = Keeper_msg_async.submit_error_to_json error in
+       result_from_json
+         ~tool_name
+         ~start_time
+         ~class_:Tool_result.Runtime_failure
+         ~ok:false
+         data
+     | Ok
+         ({ Keeper_msg_async.acceptance = Keeper_msg_async.Durably_accepted
+          ; request_id
+          } as outcome) ->
+       let data =
+         `Assoc
+           [ "composition_tool", `String tool_name
+           ; "execution", `String "async"
+           ; "request_id", `String request_id
+           ; "submission", Keeper_msg_async.submit_outcome_to_json outcome
+           ]
+       in
+       result_from_json
+         ~tool_name
+         ~start_time
+         ~class_:Tool_result.Runtime_failure
+         ~ok:true
+         data
+     | Ok
+         ({ Keeper_msg_async.acceptance =
+              Keeper_msg_async.Reconciliation_required _
+          ; _
+          } as outcome) ->
+       let data =
+         `Assoc
+           [ "composition_tool", `String tool_name
+           ; "execution", `String "async"
+           ; "submission", Keeper_msg_async.submit_outcome_to_json outcome
+           ]
+       in
+       result_from_json
+         ~tool_name
+         ~start_time
+         ~class_:Tool_result.Runtime_failure
+         ~ok:false
+         data)
+;;
+
+let status_result
+      ~(config : Workspace.config)
+      ~(meta : Keeper_meta_contract.keeper_meta)
+      ~request_id
+  =
+  let tool_name = Catalog.status_tool_name in
+  let start_time = Time_compat.now () in
+  match
+    Keeper_msg_async.poll
+      ~base_path:config.base_path
+      ~caller:meta.name
+      request_id
+  with
+  | Keeper_msg_async.Found entry ->
+    result_from_json
+      ~tool_name
+      ~start_time
+      ~class_:Tool_result.Runtime_failure
+      ~ok:true
+      (Keeper_msg_async.entry_to_json entry)
+  | Keeper_msg_async.Absent ->
+    result_from_json
+      ~tool_name
+      ~start_time
+      ~class_:Tool_result.Workflow_rejection
+      ~ok:false
+      (`Assoc
+          [ "error", `String "request_id_not_found"
+          ; "request_id", `String request_id
+          ])
+  | Keeper_msg_async.Unreadable reason ->
+    result_from_json
+      ~tool_name
+      ~start_time
+      ~class_:Tool_result.Runtime_failure
+      ~ok:false
+      (`Assoc
+          [ "error", `String "request_record_unreadable"
+          ; "request_id", `String request_id
+          ; "reason", `String reason
+          ])
+  | Keeper_msg_async.Rejected rejection ->
+    result_from_json
+      ~tool_name
+      ~start_time
+      ~class_:Tool_result.Policy_rejection
+      ~ok:false
+      (`Assoc
+          [ "error", `String "request_access_rejected"
+          ; "request_id", `String request_id
+          ; "reason", Keeper_msg_async.access_rejection_to_json rejection
+          ])
+;;
+
+let cancel_result
+      ~(config : Workspace.config)
+      ~(meta : Keeper_meta_contract.keeper_meta)
+      ~request_id
+  =
+  let tool_name = Catalog.cancel_tool_name in
+  let start_time = Time_compat.now () in
+  let result =
+    Keeper_msg_async.cancel
+      ~base_path:config.base_path
+      ~caller:meta.name
+      request_id
+  in
+  let data = Keeper_msg_async.cancel_result_to_json ~request_id result in
+  match result with
+  | Keeper_msg_async.Cancellation_requested _ ->
+    result_from_json
+      ~tool_name
+      ~start_time
+      ~class_:Tool_result.Runtime_failure
+      ~ok:true
+      data
+  | Keeper_msg_async.Cancel_not_found
+  | Keeper_msg_async.Cancel_already_terminal _ ->
+    result_from_json
+      ~tool_name
+      ~start_time
+      ~class_:Tool_result.Workflow_rejection
+      ~ok:false
+      data
+  | Keeper_msg_async.Cancel_rejected _ ->
+    result_from_json
+      ~tool_name
+      ~start_time
+      ~class_:Tool_result.Policy_rejection
+      ~ok:false
+      data
+  | Keeper_msg_async.Cancel_unreadable _
+  | Keeper_msg_async.Cancel_worker_ownership_unknown _
+  | Keeper_msg_async.Cancel_persistence_failed _
+  | Keeper_msg_async.Cancel_worker_signal_failed _
+  | Keeper_msg_async.Cancel_state_invariant_failed _ ->
+    result_from_json
+      ~tool_name
+      ~start_time
+      ~class_:Tool_result.Runtime_failure
+      ~ok:false
+      data
+;;
+
+let make_request_control_tool
+      ~(config : Workspace.config)
+      ~name
+      ~description
+      ~descriptor
+      ~handle
+  =
+  Tool_bridge.agent_core_tool_of_masc_with_execution_env
+    ~descriptor
+    ~base_path:config.base_path
+    ~name
+    ~description
+    ~input_schema:request_id_input_schema
+    (fun _execution_env input ->
+      let start_time = Time_compat.now () in
+      match
+        Tool_input_validation.validate_args
+          ~schema:request_id_input_schema
+          ~name
+          ~args:input
+          ()
+      with
+      | Error rejection -> rejection
+      | Ok _ ->
+        (match request_id_of_validated_input input with
+         | Some request_id -> handle request_id
+         | None ->
+           Tool_result.runtime_err
+             ~tool_name:name
+             ~start_time
+             "validated composition request input lost request_id"))
+;;
+
 let make_tools
       ~catalog
       ~(config : Workspace.config)
@@ -275,21 +579,27 @@ let make_tools
       ?on_externalization_error
       ()
   =
-  Catalog.entries catalog
-  |> List.map (fun (entry : Catalog.entry) ->
+  let composition_tools =
+    Catalog.entries catalog
+    |> List.map (fun (entry : Catalog.entry) ->
     let tool_name = Catalog.tool_name entry in
     let completion = Executor.outer_completion entry.plan in
     let descriptor =
-      match completion with
-      | Agent_core.Tool_contract.Continue_after_success ->
+      match entry.execution, completion with
+      | Catalog.Async, Agent_core.Tool_contract.Continue_after_success
+      | Catalog.Inline, Agent_core.Tool_contract.Continue_after_success ->
         Agent_core.Tool.ordinary_descriptor Agent_core.Tool_contract.Serial
-      | Agent_core.Tool_contract.Terminal_after_success disposition ->
+      | Catalog.Inline, Agent_core.Tool_contract.Terminal_after_success disposition ->
         Agent_core.Tool.terminal_descriptor disposition
+      | Catalog.Async, Agent_core.Tool_contract.Terminal_after_success _ ->
+        invalid_arg "validated async composition retained a terminal completion"
     in
     let tool_externalization_error =
-      match completion with
-      | Agent_core.Tool_contract.Continue_after_success -> None
-      | Agent_core.Tool_contract.Terminal_after_success _ ->
+      match entry.execution, completion with
+      | Catalog.Async, _
+      | Catalog.Inline, Agent_core.Tool_contract.Continue_after_success ->
+        None
+      | Catalog.Inline, Agent_core.Tool_contract.Terminal_after_success _ ->
         on_externalization_error
     in
     Tool_bridge.agent_core_tool_of_masc_with_execution_env
@@ -299,7 +609,14 @@ let make_tools
       ~name:tool_name
       ~description:
         (Option.value
-           ~default:("Execute the validated Keeper composition " ^ entry.name ^ ".")
+           ~default:
+             (match entry.execution with
+              | Catalog.Inline ->
+                "Execute the validated Keeper composition " ^ entry.name ^ "."
+              | Catalog.Async ->
+                "Start the validated read-only Keeper composition "
+                ^ entry.name
+                ^ " and return its durable request id.")
            entry.description)
       ~input_schema:empty_input_schema
       (fun execution_env input ->
@@ -320,6 +637,19 @@ let make_tools
                ~start_time
                "composition execution requires Agent-Core invocation identity"
            | Some parent_invocation ->
+             (match entry.execution with
+              | Catalog.Async ->
+                async_submission_result
+                  ~entry
+                  ~tool_name
+                  ~parent_invocation
+                  ~config
+                  ~meta
+                  ~publication_recovery
+                  ~ctx_snapshot
+                  ?clock
+                  ()
+              | Catalog.Inline ->
              let execution =
                Executor.execute_keeper
                  ~plan:entry.plan
@@ -372,5 +702,33 @@ let make_tools
                   ; _
                   } ->
                 ());
-             result_of_execution ~tool_name ~start_time execution)))
+             result_of_execution ~tool_name ~start_time execution))))
+  in
+  let has_async =
+    Catalog.entries catalog
+    |> List.exists (fun (entry : Catalog.entry) -> entry.execution = Catalog.Async)
+  in
+  if not has_async
+  then composition_tools
+  else
+    let status_tool =
+      make_request_control_tool
+        ~config
+        ~name:Catalog.status_tool_name
+        ~description:
+          "Read the exact durable status and structured result of one async Keeper composition request."
+        ~descriptor:
+          (Agent_core.Tool.ordinary_descriptor Agent_core.Tool_contract.Concurrent)
+        ~handle:(fun request_id -> status_result ~config ~meta ~request_id)
+    in
+    let cancel_tool =
+      make_request_control_tool
+        ~config
+        ~name:Catalog.cancel_tool_name
+        ~description:
+          "Request cancellation of one async Keeper composition by its exact durable request id."
+        ~descriptor:(Agent_core.Tool.ordinary_descriptor Agent_core.Tool_contract.Serial)
+        ~handle:(fun request_id -> cancel_result ~config ~meta ~request_id)
+    in
+    composition_tools @ [ status_tool; cancel_tool ]
 ;;

--- a/lib/keeper/keeper_tool_composition_surface.ml
+++ b/lib/keeper/keeper_tool_composition_surface.ml
@@ -58,14 +58,123 @@ let deferred_kind_to_json = function
 let node_result_to_json (result : Executor.node_result) =
   `Assoc
     [ "node_id", `String (Keeper_tool_plan.Node_id.to_string result.node_id)
+    ; "execution_id", Ids.Execution_id.to_yojson result.execution_id
     ; "tool_name", `String result.tool_name
     ; "input", result.input
     ; "schedule", schedule_to_json result.schedule
     ; "result", Tool_result.to_json result.result
+    ; "tool_use_id", `String result.tool_use_id
     ; ( "failure_effect_disposition"
       , failure_effect_disposition_to_json result.failure_effect_disposition )
     ; "deferred_kind", deferred_kind_to_json result.deferred_kind
+    ; "result_bytes", `Int result.result_bytes
+    ; "truncated_to", Json_util.int_opt_to_json result.truncated_to
     ]
+;;
+
+let observe_node_result
+      ~composition_tool
+      ~composition_execution
+      ~composition_run_id
+      ~parent_invocation
+      ~meta
+      ~(turn_context : Keeper_tool_call_log_context.turn_context)
+      (result : Executor.node_result)
+  =
+  let observe () =
+    let context = turn_context in
+    let schedule = result.schedule in
+    let committed = ref false in
+    Keeper_tool_call_log.log_call
+      ~keeper_name:meta.Keeper_meta_contract.name
+      ~tool_name:result.tool_name
+      ~input:result.input
+      ~output_text:(Tool_result.message result.result)
+      ~success:(Tool_result.is_success result.result)
+      ~duration_ms:(Tool_result.duration_ms result.result)
+      ~model:(Keeper_hooks_agent_core_types.current_keeper_model meta)
+      ?agent_name:context.agent_name
+      ?lane:context.lane
+      ?tool_choice:context.tool_choice
+      ?thinking_enabled:context.thinking_enabled
+      ?thinking_budget:context.thinking_budget
+      ?prompt_fingerprint:context.prompt_fingerprint
+      ~execution_id:result.execution_id
+      ~tool_use_id:result.tool_use_id
+      ~planned_index:schedule.planned_index
+      ~batch_index:schedule.batch_index
+      ~batch_size:schedule.batch_size
+      ~execution_mode:schedule.execution_mode
+      ~typed_result:result.result
+      ~result_bytes:result.result_bytes
+      ?truncated_to:result.truncated_to
+      ~composition_tool
+      ~composition_run_id:
+        (Keeper_tool_plan.Composition_run_id.to_string composition_run_id)
+      ~composition_node_id:(Keeper_tool_plan.Node_id.to_string result.node_id)
+      ~composition_execution
+      ~parent_tool_use_id:
+        (Agent_core.Tool_contract.Invocation.tool_use_id parent_invocation)
+      ?trace_id:context.trace_id
+      ?session_id:context.session_id
+      ?generation:context.generation
+      ~turn:(Agent_core.Tool_contract.Invocation.turn parent_invocation)
+      ?keeper_turn_id:context.keeper_turn_id
+      ?task_id:context.task_id
+      ?goal_ids:context.goal_ids
+      ?sandbox_profile:context.sandbox_profile
+      ?sandbox_root:context.sandbox_root
+      ?allowed_paths:context.allowed_paths
+      ?network_mode:context.network_mode
+      ?runtime_profile:context.runtime_profile
+      ~on_committed:(fun () -> committed := true)
+      ();
+    if not !committed
+    then failwith "composition telemetry commit callback was not delivered";
+    let fields =
+      [ "type", `String "keeper_tool_call_evidence_committed"
+      ; "name", `String meta.name
+      ; "tool_name", `String result.tool_name
+      ; ( "composition_run_id"
+        , `String
+            (Keeper_tool_plan.Composition_run_id.to_string composition_run_id) )
+      ; ( "composition_node_id"
+        , `String (Keeper_tool_plan.Node_id.to_string result.node_id) )
+      ; "composition_tool", `String composition_tool
+      ; ( "composition_execution"
+        , `String
+            (Keeper_tool_composition_catalog.execution_mode_to_string
+               composition_execution) )
+      ; ( "parent_tool_use_id"
+        , `String
+            (Agent_core.Tool_contract.Invocation.tool_use_id parent_invocation) )
+      ; "turn", `Int (Agent_core.Tool_contract.Invocation.turn parent_invocation)
+      ; "execution_id", Ids.Execution_id.to_yojson result.execution_id
+      ; "result_bytes", `Int result.result_bytes
+      ; "truncated_to", Json_util.int_opt_to_json result.truncated_to
+      ; "planned_index", `Int schedule.planned_index
+      ; "batch_index", `Int schedule.batch_index
+      ; "batch_size", `Int schedule.batch_size
+      ; ( "execution_mode"
+        , Agent_core.Tool_contract.execution_mode_to_yojson schedule.execution_mode )
+      ; "ts_unix", `Float (Time_compat.now ())
+      ; "tool_use_id", `String result.tool_use_id
+      ]
+    in
+    Sse.broadcast (`Assoc fields)
+  in
+  try
+    observe ();
+    Ok ()
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Log.Keeper.warn
+      "composition action telemetry degraded without changing execution: tool=%s node=%s error=%s"
+      composition_tool
+      (Keeper_tool_plan.Node_id.to_string result.node_id)
+      (Printexc.to_string exn);
+    Ok ()
 ;;
 
 let json_type_to_string = function
@@ -195,6 +304,12 @@ let cause_to_json = function
       [ "kind", `String "tool_did_not_complete"
       ; "node", node_result_to_json result
       ]
+  | Executor.Node_observation_failed { node; detail } ->
+    `Assoc
+      [ "kind", `String "node_observation_failed"
+      ; "node", node_result_to_json node
+      ; "detail", `String detail
+      ]
   | Executor.Plan_execution_failed { node_id; schedule; error } ->
     `Assoc
       [ "kind", `String "plan_execution_failed"
@@ -228,7 +343,9 @@ let failure_class (failure : Executor.failure) =
     Option.value
       ~default:Tool_result.Runtime_failure
       (Tool_result.failure_class result.result)
-  | Executor.Plan_execution_failed _ | Executor.Outer_completion_mismatch _ ->
+  | Executor.Plan_execution_failed _
+  | Executor.Node_observation_failed _
+  | Executor.Outer_completion_mismatch _ ->
     Tool_result.Runtime_failure
 ;;
 
@@ -298,6 +415,7 @@ let async_worker_result
       ~meta
       ~publication_recovery
       ~ctx_snapshot
+      ~turn_context
       ?clock
       ()
   =
@@ -307,9 +425,12 @@ let async_worker_result
   Eio.Switch.on_release request_sw (fun () ->
     Keeper_sandbox_factory.cleanup sandbox_factory);
   let start_time = Time_compat.now () in
+  let run_id = Keeper_tool_plan.Run_id.fresh () in
+  let composition_run_id = Keeper_tool_plan.Composition_run_id.fresh () in
   Executor.execute_keeper
     ~plan:entry.plan
-    ~run_id:(Keeper_tool_plan.Run_id.fresh ())
+    ~run_id
+    ~composition_run_id
     ~parent_invocation:
       (async_parent_invocation ~request_id source_invocation)
     ~config
@@ -317,6 +438,17 @@ let async_worker_result
     ~publication_recovery
     ~ctx_snapshot
     ~turn_sandbox_factory:sandbox_factory
+    ?observe_node_result:
+      (Option.map
+         (fun turn_context ->
+            observe_node_result
+              ~composition_tool:tool_name
+              ~composition_execution:entry.execution
+              ~composition_run_id
+              ~parent_invocation:source_invocation
+              ~meta
+              ~turn_context)
+         turn_context)
     ?clock
     ()
   |> result_of_execution ~tool_name ~start_time
@@ -342,6 +474,7 @@ let async_submission_result
       ~(meta : Keeper_meta_contract.keeper_meta)
       ~publication_recovery
       ~ctx_snapshot
+      ~turn_context
       ?clock
       ()
   =
@@ -373,6 +506,7 @@ let async_submission_result
              ~meta
              ~publication_recovery
              ~ctx_snapshot
+             ~turn_context
              ?clock
              ())
          ()
@@ -437,12 +571,22 @@ let status_result
       request_id
   with
   | Keeper_msg_async.Found entry ->
-    result_from_json
-      ~tool_name
-      ~start_time
-      ~class_:Tool_result.Runtime_failure
-      ~ok:true
-      (Keeper_msg_async.entry_to_json entry)
+    let result =
+      result_from_json
+        ~tool_name
+        ~start_time
+        ~class_:Tool_result.Runtime_failure
+        ~ok:true
+        (Keeper_msg_async.entry_to_json entry)
+    in
+    (match Tool_bridge.attach_artifact_manifest ~base_path:config.base_path result with
+     | Ok result -> result
+     | Error { message; _ } ->
+       Tool_result.make_err
+         ~tool_name
+         ~class_:Tool_result.Runtime_failure
+         ~start_time
+         ("async composition status manifest persistence failed: " ^ message))
   | Keeper_msg_async.Absent ->
     result_from_json
       ~tool_name
@@ -476,6 +620,10 @@ let status_result
           ; "reason", Keeper_msg_async.access_rejection_to_json rejection
           ])
 ;;
+
+module For_testing = struct
+  let status_result = status_result
+end
 
 let cancel_result
       ~(config : Workspace.config)
@@ -567,6 +715,7 @@ let make_tools
       ~publication_recovery
       ~ctx_snapshot
       ?turn_sandbox_factory
+      ?turn_ctx_cell
       ?clock
       ?continuation_channel
       ?gate_context
@@ -595,17 +744,15 @@ let make_tools
         invalid_arg "validated async composition retained a terminal completion"
     in
     let tool_externalization_error =
-      match entry.execution, completion with
-      | Catalog.Async, _
-      | Catalog.Inline, Agent_core.Tool_contract.Continue_after_success ->
-        None
-      | Catalog.Inline, Agent_core.Tool_contract.Terminal_after_success _ ->
-        on_externalization_error
+      match entry.execution with
+      | Catalog.Async -> None
+      | Catalog.Inline -> on_externalization_error
     in
     Tool_bridge.agent_core_tool_of_masc_with_execution_env
       ~descriptor
       ~base_path:config.base_path
       ?on_externalization_error:tool_externalization_error
+      ~externalization_error_recoverable:false
       ~name:tool_name
       ~description:
         (Option.value
@@ -637,6 +784,14 @@ let make_tools
                ~start_time
                "composition execution requires Agent-Core invocation identity"
            | Some parent_invocation ->
+             let turn_context =
+               Option.map
+                 (fun cell ->
+                    Keeper_tool_call_log_context.get_turn_context_record
+                      ~cell
+                      ())
+                 turn_ctx_cell
+             in
              (match entry.execution with
               | Catalog.Async ->
                 async_submission_result
@@ -647,13 +802,17 @@ let make_tools
                   ~meta
                   ~publication_recovery
                   ~ctx_snapshot
+                  ~turn_context
                   ?clock
                   ()
               | Catalog.Inline ->
+             let run_id = Keeper_tool_plan.Run_id.fresh () in
+             let composition_run_id = Keeper_tool_plan.Composition_run_id.fresh () in
              let execution =
                Executor.execute_keeper
                  ~plan:entry.plan
-                 ~run_id:(Keeper_tool_plan.Run_id.fresh ())
+                 ~run_id
+                 ~composition_run_id
                  ~parent_invocation
                  ~config
                  ~meta
@@ -669,6 +828,17 @@ let make_tools
                  ?on_deferred
                  ?on_external_effect_deferred
                  ?on_failed
+                 ?observe_node_result:
+                   (Option.map
+                      (fun turn_context ->
+                         observe_node_result
+                           ~composition_tool:tool_name
+                           ~composition_execution:entry.execution
+                           ~composition_run_id
+                           ~parent_invocation
+                           ~meta
+                           ~turn_context)
+                      turn_context)
                  ()
              in
              (match execution with
@@ -702,7 +872,33 @@ let make_tools
                   ; _
                   } ->
                 ());
-             result_of_execution ~tool_name ~start_time execution))))
+             let result =
+               result_of_execution ~tool_name ~start_time execution
+             in
+             (match
+                Tool_bridge.attach_artifact_manifest
+                  ~base_path:config.base_path
+                  result
+              with
+              | Ok result -> result
+              | Error { message; _ } ->
+                let diagnostic =
+                  "composition result manifest persistence failed: " ^ message
+                in
+                Option.iter
+                  (fun mark_failed ->
+                     mark_failed
+                       { Keeper_tools_agent_core.failure_class =
+                           Tool_result.Runtime_failure
+                       ; effect_disposition = Tool_result.Effect_outcome_unknown
+                       ; diagnostic
+                       })
+                  on_failed;
+                Tool_result.make_err
+                  ~tool_name
+                  ~class_:Tool_result.Runtime_failure
+                  ~start_time
+                  "composition result manifest persistence failed")))))
   in
   let has_async =
     Catalog.entries catalog

--- a/lib/keeper/keeper_tool_composition_surface.ml
+++ b/lib/keeper/keeper_tool_composition_surface.ml
@@ -20,6 +20,17 @@ let schedule_to_json (schedule : Agent_core.Tool_contract.schedule) =
     ]
 ;;
 
+let failure_effect_disposition_to_json = function
+  | None -> `Null
+  | Some disposition ->
+    `String (Tool_result.failure_effect_disposition_to_string disposition)
+;;
+
+let deferred_kind_to_json = function
+  | None -> `Null
+  | Some kind -> `String (Keeper_tool_execution.deferred_kind_to_string kind)
+;;
+
 let node_result_to_json (result : Executor.node_result) =
   `Assoc
     [ "node_id", `String (Keeper_tool_plan.Node_id.to_string result.node_id)
@@ -27,6 +38,9 @@ let node_result_to_json (result : Executor.node_result) =
     ; "input", result.input
     ; "schedule", schedule_to_json result.schedule
     ; "result", Tool_result.to_json result.result
+    ; ( "failure_effect_disposition"
+      , failure_effect_disposition_to_json result.failure_effect_disposition )
+    ; "deferred_kind", deferred_kind_to_json result.deferred_kind
     ]
 ;;
 
@@ -327,23 +341,15 @@ let make_tools
                  ?on_failed
                  ()
              in
-             (match completion, execution with
-              | ( Agent_core.Tool_contract.Terminal_after_success _
-                , Error failure )
-                when failure.effect_disposition <> Tool_result.Proven_pre_effect
-                     && not
-                          (match failure.cause with
-                           | Executor.Tool_did_not_complete
-                               { result = Tool_result.Deferred _; _ } ->
-                             true
-                           | Executor.Tool_did_not_complete
-                               { result =
-                                   (Tool_result.Completed _ | Tool_result.Failed _)
-                               ; _
-                               }
-                           | Executor.Plan_execution_failed _
-                           | Executor.Outer_completion_mismatch _ ->
-                             false) ->
+             (match execution with
+              | Error failure
+                when failure.effect_disposition <> Tool_result.Proven_pre_effect ->
+                (* The aggregate is computed from every settled sibling and all
+                   earlier batches.  It is the boundary authority: a selected
+                   Deferred cause must not hide an earlier committed write or
+                   a sibling's unknown/post-effect failure.  Composition
+                   execution has no persisted cursor, so only an entirely
+                   proven-pre-effect defer may remain resumable. *)
                 Option.iter
                   (fun mark_failed ->
                      let diagnostic =
@@ -356,13 +362,11 @@ let make_tools
                        ; diagnostic
                        })
                   on_failed
-              | Agent_core.Tool_contract.Continue_after_success, _
-              | Agent_core.Tool_contract.Terminal_after_success _, Ok _
-              | ( Agent_core.Tool_contract.Terminal_after_success _
-                , Error
-                    { Executor.effect_disposition = Tool_result.Proven_pre_effect
-                    ; _
-                    } ) ->
+              | Ok _
+              | Error
+                  { Executor.effect_disposition = Tool_result.Proven_pre_effect
+                  ; _
+                  } ->
                 ());
              result_of_execution ~tool_name ~start_time execution)))
 ;;

--- a/lib/keeper/keeper_tool_composition_surface.ml
+++ b/lib/keeper/keeper_tool_composition_surface.ml
@@ -1,0 +1,315 @@
+module Catalog = Keeper_tool_composition_catalog
+module Executor = Keeper_tool_plan_executor
+
+let empty_input_schema =
+  `Assoc
+    [ "type", `String "object"
+    ; "properties", `Assoc []
+    ; "required", `List []
+    ; "additionalProperties", `Bool false
+    ]
+;;
+
+let schedule_to_json (schedule : Agent_core.Tool_contract.schedule) =
+  `Assoc
+    [ "planned_index", `Int schedule.planned_index
+    ; "batch_index", `Int schedule.batch_index
+    ; "batch_size", `Int schedule.batch_size
+    ; ( "execution_mode"
+      , Agent_core.Tool_contract.execution_mode_to_yojson schedule.execution_mode )
+    ]
+;;
+
+let node_result_to_json (result : Executor.node_result) =
+  `Assoc
+    [ "node_id", `String (Keeper_tool_plan.Node_id.to_string result.node_id)
+    ; "tool_name", `String result.tool_name
+    ; "input", result.input
+    ; "schedule", schedule_to_json result.schedule
+    ; "result", Tool_result.to_json result.result
+    ]
+;;
+
+let json_type_to_string = function
+  | Keeper_tool_plan.Null_type -> "null"
+  | Keeper_tool_plan.Boolean_type -> "boolean"
+  | Keeper_tool_plan.Integer_type -> "integer"
+  | Keeper_tool_plan.Number_type -> "number"
+  | Keeper_tool_plan.String_type -> "string"
+  | Keeper_tool_plan.Array_type -> "array"
+  | Keeper_tool_plan.Object_type -> "object"
+;;
+
+let path_to_json path = `List (List.map (fun segment -> `String segment) path)
+
+let schema_value_error_to_json = function
+  | Keeper_tool_plan.Unsupported_schema_type schema ->
+    `Assoc
+      [ "kind", `String "unsupported_schema_type"
+      ; "schema", schema
+      ]
+  | Keeper_tool_plan.Missing_required_field { path; field } ->
+    `Assoc
+      [ "kind", `String "missing_required_field"
+      ; "path", path_to_json path
+      ; "field", `String field
+      ]
+  | Keeper_tool_plan.Unexpected_field { path; field } ->
+    `Assoc
+      [ "kind", `String "unexpected_field"
+      ; "path", path_to_json path
+      ; "field", `String field
+      ]
+  | Keeper_tool_plan.Duplicate_value_field { path; field } ->
+    `Assoc
+      [ "kind", `String "duplicate_value_field"
+      ; "path", path_to_json path
+      ; "field", `String field
+      ]
+  | Keeper_tool_plan.Type_mismatch { path; expected; actual } ->
+    `Assoc
+      [ "kind", `String "type_mismatch"
+      ; "path", path_to_json path
+      ; "expected", `String (json_type_to_string expected)
+      ; "actual", `String (json_type_to_string actual)
+      ]
+;;
+
+let pointer_resolution_error_to_json = function
+  | Keeper_tool_plan.Json_pointer.Missing_object_field field ->
+    `Assoc
+      [ "kind", `String "missing_object_field"
+      ; "field", `String field
+      ]
+  | Keeper_tool_plan.Json_pointer.Ambiguous_object_field field ->
+    `Assoc
+      [ "kind", `String "ambiguous_object_field"
+      ; "field", `String field
+      ]
+  | Keeper_tool_plan.Json_pointer.Invalid_array_index index ->
+    `Assoc
+      [ "kind", `String "invalid_array_index"
+      ; "index", `String index
+      ]
+  | Keeper_tool_plan.Json_pointer.Array_index_out_of_bounds index ->
+    `Assoc
+      [ "kind", `String "array_index_out_of_bounds"
+      ; "index", `Int index
+      ]
+  | Keeper_tool_plan.Json_pointer.Expected_container segment ->
+    `Assoc
+      [ "kind", `String "expected_container"
+      ; "segment", `String segment
+      ]
+;;
+
+let template_resolution_error_to_json = function
+  | Keeper_tool_plan.Json_template.Missing_output node_id ->
+    `Assoc
+      [ "kind", `String "missing_output"
+      ; "source_node_id", `String (Keeper_tool_plan.Node_id.to_string node_id)
+      ]
+  | Keeper_tool_plan.Json_template.Pointer_resolution_failed { node_id; error } ->
+    `Assoc
+      [ "kind", `String "pointer_resolution_failed"
+      ; "source_node_id", `String (Keeper_tool_plan.Node_id.to_string node_id)
+      ; "error", pointer_resolution_error_to_json error
+      ]
+;;
+
+let plan_execution_error_to_json = function
+  | Keeper_tool_plan.Unknown_node_id node_id ->
+    `Assoc
+      [ "kind", `String "unknown_node_id"
+      ; "node_id", `String (Keeper_tool_plan.Node_id.to_string node_id)
+      ]
+  | Keeper_tool_plan.Input_template_resolution_failed { node_id; error } ->
+    `Assoc
+      [ "kind", `String "input_template_resolution_failed"
+      ; "node_id", `String (Keeper_tool_plan.Node_id.to_string node_id)
+      ; "error", template_resolution_error_to_json error
+      ]
+  | Keeper_tool_plan.Input_validation_failed { node_id; tool_name; rejection } ->
+    `Assoc
+      [ "kind", `String "input_validation_failed"
+      ; "node_id", `String (Keeper_tool_plan.Node_id.to_string node_id)
+      ; "tool_name", `String tool_name
+      ; "rejection", Tool_result.to_json rejection
+      ]
+  | Keeper_tool_plan.Output_validation_failed { node_id; tool_name; error } ->
+    `Assoc
+      [ "kind", `String "output_validation_failed"
+      ; "node_id", `String (Keeper_tool_plan.Node_id.to_string node_id)
+      ; "tool_name", `String tool_name
+      ; "error", schema_value_error_to_json error
+      ]
+  | Keeper_tool_plan.Output_not_composable { node_id; tool_name } ->
+    `Assoc
+      [ "kind", `String "output_not_composable"
+      ; "node_id", `String (Keeper_tool_plan.Node_id.to_string node_id)
+      ; "tool_name", `String tool_name
+      ]
+;;
+
+let cause_to_json = function
+  | Executor.Tool_did_not_complete result ->
+    `Assoc
+      [ "kind", `String "tool_did_not_complete"
+      ; "node", node_result_to_json result
+      ]
+  | Executor.Plan_execution_failed { node_id; schedule; error } ->
+    `Assoc
+      [ "kind", `String "plan_execution_failed"
+      ; "node_id", `String (Keeper_tool_plan.Node_id.to_string node_id)
+      ; "schedule", schedule_to_json schedule
+      ; "error", plan_execution_error_to_json error
+      ]
+  | Executor.Outer_completion_mismatch { expected; actual } ->
+    `Assoc
+      [ "kind", `String "outer_completion_mismatch"
+      ; "expected", Agent_core.Tool_contract.completion_to_yojson expected
+      ; "actual", Agent_core.Tool_contract.completion_to_yojson actual
+      ]
+;;
+
+let failure_data ~tool_name (failure : Executor.failure) =
+  `Assoc
+    [ "composition_tool", `String tool_name
+    ; "settled", `List (List.map node_result_to_json failure.settled)
+    ; "cause", cause_to_json failure.cause
+    ]
+;;
+
+let result_of_execution ~tool_name ~start_time = function
+  | Ok settled ->
+    Tool_result.make_ok
+      ~tool_name
+      ~start_time
+      ~data:
+        (`Assoc
+            [ "composition_tool", `String tool_name
+            ; "actions", `List (List.map node_result_to_json settled)
+            ])
+      ()
+  | Error
+      ({ Executor.cause = Executor.Tool_did_not_complete result; _ } as failure :
+        Executor.failure) ->
+    let data = failure_data ~tool_name failure in
+    (match result.result with
+     | Tool_result.Deferred payload ->
+       Tool_result.make_deferred
+         ~tool_name
+         ~start_time
+         ~data
+         ?metadata:payload.metadata
+         ()
+     | Tool_result.Failed payload ->
+       Tool_result.make_err
+         ~tool_name
+         ~class_:payload.class_
+         ~start_time
+         ~data
+         ?metadata:payload.metadata
+         (Yojson.Safe.to_string data)
+     | Tool_result.Completed _ ->
+       Tool_result.make_err
+         ~tool_name
+         ~class_:Tool_result.Runtime_failure
+         ~start_time
+         ~data
+         "composition executor reported a completed result as incomplete")
+  | Error failure ->
+    let data = failure_data ~tool_name failure in
+    Tool_result.make_err
+      ~tool_name
+      ~class_:Tool_result.Runtime_failure
+      ~start_time
+      ~data
+      (Yojson.Safe.to_string data)
+;;
+
+let make_tools
+      ~catalog
+      ~config
+      ~meta
+      ~publication_recovery
+      ~ctx_snapshot
+      ?turn_sandbox_factory
+      ?clock
+      ?continuation_channel
+      ?gate_context
+      ?gate_grant
+      ?record_gate_result
+      ?on_completed
+      ?on_deferred
+      ?on_external_effect_deferred
+      ?on_failed
+      ?on_externalization_error
+      ()
+  =
+  Catalog.entries catalog
+  |> List.map (fun (entry : Catalog.entry) ->
+    let tool_name = Catalog.tool_name entry in
+    let completion = Executor.outer_completion entry.plan in
+    let descriptor =
+      match completion with
+      | Agent_core.Tool_contract.Continue_after_success ->
+        Agent_core.Tool.ordinary_descriptor Agent_core.Tool_contract.Serial
+      | Agent_core.Tool_contract.Terminal_after_success disposition ->
+        Agent_core.Tool.terminal_descriptor disposition
+    in
+    let tool_externalization_error =
+      match completion with
+      | Agent_core.Tool_contract.Continue_after_success -> None
+      | Agent_core.Tool_contract.Terminal_after_success _ ->
+        on_externalization_error
+    in
+    Tool_bridge.agent_core_tool_of_masc_with_execution_env
+      ~descriptor
+      ~base_path:config.base_path
+      ?on_externalization_error:tool_externalization_error
+      ~name:tool_name
+      ~description:
+        (Option.value
+           ~default:("Execute the validated Keeper composition " ^ entry.name ^ ".")
+           entry.description)
+      ~input_schema:empty_input_schema
+      (fun execution_env input ->
+        let start_time = Time_compat.now () in
+        match
+          Tool_input_validation.validate_args
+            ~schema:empty_input_schema
+            ~name:tool_name
+            ~args:input
+            ()
+        with
+        | Error rejection -> rejection
+        | Ok _ ->
+          (match Agent_core.Tool.Execution_env.invocation execution_env with
+           | None ->
+             Tool_result.runtime_err
+               ~tool_name
+               ~start_time
+               "composition execution requires Agent-Core invocation identity"
+           | Some parent_invocation ->
+             Executor.execute_keeper
+               ~plan:entry.plan
+               ~run_id:(Keeper_tool_plan.Run_id.fresh ())
+               ~parent_invocation
+               ~config
+               ~meta
+               ~publication_recovery
+               ~ctx_snapshot
+               ?turn_sandbox_factory
+               ?clock
+               ?continuation_channel
+               ?gate_context
+               ?gate_grant
+               ?record_gate_result
+               ?on_completed
+               ?on_deferred
+               ?on_external_effect_deferred
+               ?on_failed
+               ()
+             |> result_of_execution ~tool_name ~start_time)))
+;;

--- a/lib/keeper/keeper_tool_composition_surface.ml
+++ b/lib/keeper/keeper_tool_composition_surface.ml
@@ -258,7 +258,7 @@ let result_of_execution ~tool_name ~start_time = function
 
 let make_tools
       ~catalog
-      ~config
+      ~(config : Workspace.config)
       ~meta
       ~publication_recovery
       ~ctx_snapshot
@@ -342,8 +342,12 @@ let make_tools
                  ()
              in
              (match execution with
-              | Error failure
-                when failure.effect_disposition <> Tool_result.Proven_pre_effect ->
+              | Error
+                  ({ Executor.effect_disposition =
+                       ( Tool_result.Proven_post_effect
+                       | Tool_result.Effect_outcome_unknown )
+                   ; _
+                   } as failure) ->
                 (* The aggregate is computed from every settled sibling and all
                    earlier batches.  It is the boundary authority: a selected
                    Deferred cause must not hide an earlier committed write or

--- a/lib/keeper/keeper_tool_composition_surface.ml
+++ b/lib/keeper/keeper_tool_composition_surface.ml
@@ -177,7 +177,21 @@ let failure_data ~tool_name (failure : Executor.failure) =
     [ "composition_tool", `String tool_name
     ; "settled", `List (List.map node_result_to_json failure.settled)
     ; "cause", cause_to_json failure.cause
+    ; ( "effect_disposition"
+      , `String
+          (Tool_result.failure_effect_disposition_to_string
+             failure.effect_disposition) )
     ]
+;;
+
+let failure_class (failure : Executor.failure) =
+  match failure.cause with
+  | Executor.Tool_did_not_complete result ->
+    Option.value
+      ~default:Tool_result.Runtime_failure
+      (Tool_result.failure_class result.result)
+  | Executor.Plan_execution_failed _ | Executor.Outer_completion_mismatch _ ->
+    Tool_result.Runtime_failure
 ;;
 
 let result_of_execution ~tool_name ~start_time = function
@@ -292,24 +306,63 @@ let make_tools
                ~start_time
                "composition execution requires Agent-Core invocation identity"
            | Some parent_invocation ->
-             Executor.execute_keeper
-               ~plan:entry.plan
-               ~run_id:(Keeper_tool_plan.Run_id.fresh ())
-               ~parent_invocation
-               ~config
-               ~meta
-               ~publication_recovery
-               ~ctx_snapshot
-               ?turn_sandbox_factory
-               ?clock
-               ?continuation_channel
-               ?gate_context
-               ?gate_grant
-               ?record_gate_result
-               ?on_completed
-               ?on_deferred
-               ?on_external_effect_deferred
-               ?on_failed
-               ()
-             |> result_of_execution ~tool_name ~start_time)))
+             let execution =
+               Executor.execute_keeper
+                 ~plan:entry.plan
+                 ~run_id:(Keeper_tool_plan.Run_id.fresh ())
+                 ~parent_invocation
+                 ~config
+                 ~meta
+                 ~publication_recovery
+                 ~ctx_snapshot
+                 ?turn_sandbox_factory
+                 ?clock
+                 ?continuation_channel
+                 ?gate_context
+                 ?gate_grant
+                 ?record_gate_result
+                 ?on_completed
+                 ?on_deferred
+                 ?on_external_effect_deferred
+                 ?on_failed
+                 ()
+             in
+             (match completion, execution with
+              | ( Agent_core.Tool_contract.Terminal_after_success _
+                , Error failure )
+                when failure.effect_disposition <> Tool_result.Proven_pre_effect
+                     && not
+                          (match failure.cause with
+                           | Executor.Tool_did_not_complete
+                               { result = Tool_result.Deferred _; _ } ->
+                             true
+                           | Executor.Tool_did_not_complete
+                               { result =
+                                   (Tool_result.Completed _ | Tool_result.Failed _)
+                               ; _
+                               }
+                           | Executor.Plan_execution_failed _
+                           | Executor.Outer_completion_mismatch _ ->
+                             false) ->
+                Option.iter
+                  (fun mark_failed ->
+                     let diagnostic =
+                       failure_data ~tool_name failure |> Yojson.Safe.to_string
+                     in
+                     mark_failed
+                       { Keeper_tools_agent_core.failure_class =
+                           failure_class failure
+                       ; effect_disposition = failure.effect_disposition
+                       ; diagnostic
+                       })
+                  on_failed
+              | Agent_core.Tool_contract.Continue_after_success, _
+              | Agent_core.Tool_contract.Terminal_after_success _, Ok _
+              | ( Agent_core.Tool_contract.Terminal_after_success _
+                , Error
+                    { Executor.effect_disposition = Tool_result.Proven_pre_effect
+                    ; _
+                    } ) ->
+                ());
+             result_of_execution ~tool_name ~start_time execution)))
 ;;

--- a/lib/keeper/keeper_tool_composition_surface.mli
+++ b/lib/keeper/keeper_tool_composition_surface.mli
@@ -8,6 +8,7 @@ val make_tools
        Keeper_publication_recovery_availability.turn_context
   -> ctx_snapshot:Keeper_types.working_context
   -> ?turn_sandbox_factory:Keeper_sandbox_factory.t
+  -> ?turn_ctx_cell:Keeper_tool_call_log.turn_ctx_cell
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
   -> ?continuation_channel:Keeper_continuation_channel.t
   -> ?gate_context:(unit -> Keeper_gate.causal_context)
@@ -21,3 +22,11 @@ val make_tools
   -> ?on_externalization_error:(Tool_bridge.externalization_error -> unit)
   -> unit
   -> Agent_core.Tool.t list
+
+module For_testing : sig
+  val status_result :
+    config:Workspace.config ->
+    meta:Keeper_meta_contract.keeper_meta ->
+    request_id:string ->
+    Tool_result.result
+end

--- a/lib/keeper/keeper_tool_composition_surface.mli
+++ b/lib/keeper/keeper_tool_composition_surface.mli
@@ -1,0 +1,23 @@
+(** Materialize validated catalog entries as first-class Agent-Core tools. *)
+
+val make_tools
+  :  catalog:Keeper_tool_composition_catalog.t
+  -> config:Workspace.config
+  -> meta:Keeper_meta_contract.keeper_meta
+  -> publication_recovery:
+       Keeper_publication_recovery_availability.turn_context
+  -> ctx_snapshot:Keeper_types.working_context
+  -> ?turn_sandbox_factory:Keeper_sandbox_factory.t
+  -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?continuation_channel:Keeper_continuation_channel.t
+  -> ?gate_context:(unit -> Keeper_gate.causal_context)
+  -> ?gate_grant:Keeper_gate.cycle_grant
+  -> ?record_gate_result:
+       (operation:string -> input:Yojson.Safe.t -> Tool_result.result -> unit)
+  -> ?on_completed:(Keeper_tool_execution.terminal_effect_receipt option -> unit)
+  -> ?on_deferred:(unit -> unit)
+  -> ?on_external_effect_deferred:(unit -> unit)
+  -> ?on_failed:(Keeper_tools_agent_core.terminal_effect_failure -> unit)
+  -> ?on_externalization_error:(Tool_bridge.externalization_error -> unit)
+  -> unit
+  -> Agent_core.Tool.t list

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -639,8 +639,70 @@ let with_composable_output composable_output descriptor =
   { descriptor with composable_output }
 ;;
 
+let normalized_artifact_ref_schema =
+  `Assoc
+    [ "type", `String "object"
+    ; ( "properties"
+      , `Assoc
+          [ ( "_blob"
+            , `Assoc
+                [ "type", `String "object"
+                ; ( "properties"
+                  , `Assoc
+                      [ "sha256", `Assoc [ "type", `String "string" ]
+                      ; "bytes", `Assoc [ "type", `String "integer" ]
+                      ; "mime", `Assoc [ "type", `String "string" ]
+                      ; "preview", `Assoc [ "type", `String "string" ]
+                      ] )
+                ; ( "required"
+                  , `List
+                      (List.map
+                         (fun name -> `String name)
+                         [ "sha256"; "bytes"; "mime"; "preview" ]) )
+                ; "additionalProperties", `Bool false
+                ] )
+          ] )
+    ; "required", `List [ `String "_blob" ]
+    ; "additionalProperties", `Bool false
+    ]
+;;
+
+let execute_output_schema =
+  `Assoc
+    [ "type", `String "object"
+    ; ( "properties"
+      , `Assoc
+          [ "ok", `Assoc [ "type", `String "boolean" ]
+          ; ( "status"
+            , `Assoc
+                [ "type", `String "object"
+                ; ( "properties"
+                  , `Assoc
+                      [ "kind", `Assoc [ "type", `String "string" ]
+                      ; "code", `Assoc [ "type", `String "integer" ]
+                      ; "signal", `Assoc [ "type", `String "integer" ]
+                      ] )
+                ; "required", `List [ `String "kind" ]
+                ; "additionalProperties", `Bool false
+                ] )
+          ; "output", `Assoc [ "type", `String "string" ]
+          ; "output_artifact", normalized_artifact_ref_schema
+          ; "stdout_artifact", normalized_artifact_ref_schema
+          ; "stderr_artifact", normalized_artifact_ref_schema
+          ; "typed", `Assoc [ "type", `String "boolean" ]
+          ; "execution_time_ms", `Assoc [ "type", `String "integer" ]
+          ] )
+    ; ( "required"
+      , `List
+          (List.map
+             (fun name -> `String name)
+             [ "ok"; "status"; "typed"; "execution_time_ms" ]) )
+    ; "additionalProperties", `Bool true
+    ]
+;;
+
 let public_descriptors =
-  [ descriptor
+  [ (descriptor
       ~capability_identity:Internal_name_identity
       ~keeper_model_projection:Preferred_public_name
       ~input_schema_source:Descriptor_owned
@@ -654,7 +716,10 @@ let public_descriptors =
          I/O and typed env for environment variables. MASC validates the input \
          shape, path jail, sandbox target, and external-effect Gate but never \
          interprets program or subcommand meaning. The invoked program owns \
-         its syntax and exit result."
+         its syntax and exit result. A successful result exposes typed status, \
+         output and execution_time_ms fields to later composition nodes. Small \
+         output stays inline; oversized output is represented by canonical \
+         output/stdout/stderr artifact references."
       ~input_schema:execute_schema
       ~policy:
         (policy
@@ -674,6 +739,7 @@ let public_descriptors =
         ]
       ~input_translation:(Identity Validate_once_before_translation)
       ()
+     |> with_composable_output (Json_output { schema = execute_output_schema }))
   ; descriptor
       ~capability_identity:Internal_name_identity
       ~keeper_model_projection:Preferred_public_name

--- a/lib/keeper/keeper_tool_emission_hook.ml
+++ b/lib/keeper/keeper_tool_emission_hook.ml
@@ -58,9 +58,14 @@ let accumulator_size acc =
   Stdlib.Mutex.unlock acc.mutex;
   n
 
-let capture_typed_result acc = function
-  | `Assoc _ as data -> push acc data
-  | (`List _ | `String _ | `Bool _ | `Int _ | `Intlit _ | `Float _ | `Null) -> ()
+let capture_typed_result acc data =
+  match
+    ( Multimodal.Tool_emission.extract_kind_from_result data
+    , Multimodal.Tool_emission.extract_id_from_result data )
+  with
+  | Some _, Some _ -> push acc data
+  | None, _ | _, None -> ()
+;;
 
 let drain_into_working_context acc ~(working_context : Yojson.Safe.t option)
     : Yojson.Safe.t option =

--- a/lib/keeper/keeper_tool_emission_hook.mli
+++ b/lib/keeper/keeper_tool_emission_hook.mli
@@ -39,9 +39,11 @@ type accumulator
 (** Allocate a fresh empty accumulator. *)
 val create_accumulator : unit -> accumulator
 
-(** Capture one producer-owned typed result. Only a JSON object can carry the
-    reserved multimodal fields; every other JSON variant, including a
-    JSON-looking [`String], is ignored without reparsing. *)
+(** Capture one producer-owned typed result only when the canonical multimodal
+    detector finds both a supported [__multimodal_kind] and a string
+    [__multimodal_id]. Untagged typed objects and every other JSON variant,
+    including a JSON-looking [`String], are ignored without reparsing or being
+    retained until post-turn drain. *)
 val capture_typed_result : accumulator -> Yojson.Safe.t -> unit
 
 (** Drain the accumulator and merge any tagged tool results into

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -47,6 +47,7 @@ let model_execute_cwd_resolution_error ~config ~meta ~args ~cwd error =
   in
   Keeper_tool_execution.failure
     ~class_:Tool_result.Policy_rejection
+    ~effect_disposition:Tool_result.Proven_pre_effect
     (error_json ~fields message)
 
 let sandbox_target_label = function
@@ -108,6 +109,25 @@ let redact_execute_output redaction ~stdout ~stderr =
     if String.equal stderr "" then stdout else stdout ^ stderr
   in
   stdout, stderr, output
+
+let composable_output_fields ~base_path ~stdout ~stderr ~output =
+  if String.length output <= Tool_bridge.default_externalize_threshold_bytes
+  then Ok [ "output", `String output ]
+  else
+    try
+      let store = Tool_blob_store.create ~base_path in
+      let store_stream bytes =
+        Tool_blob_store.put_durable store ~bytes ~mime:"text/plain"
+        |> Tool_output.normalized_artifact_ref_to_json
+      in
+      Ok
+        [ "output_artifact", store_stream output
+        ; "stdout_artifact", store_stream stdout
+        ; "stderr_artifact", store_stream stderr
+        ]
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Error (Printexc.to_string exn)
 
 module For_testing = struct
   let elapsed_duration_ms = elapsed_duration_ms
@@ -222,6 +242,7 @@ let handle_tool_execute_typed
       | Error e ->
         Keeper_tool_execution.failure
           ~class_:Tool_result.Policy_rejection
+          ~effect_disposition:Tool_result.Proven_pre_effect
           (error_json
              ~fields:
                ([ "typed", `Bool true ] @ model_location_fields)
@@ -234,6 +255,7 @@ let handle_tool_execute_typed
            in
            Keeper_tool_execution.failure
              ~class_:Tool_result.Policy_rejection
+             ~effect_disposition:Tool_result.Proven_pre_effect
              (error_json ~fields (typed_validation_error_text e))
          | Ok () ->
         let cmd = typed_input_command_text input in
@@ -380,6 +402,7 @@ let handle_tool_execute_typed
           in
           Keeper_tool_execution.failure
             ~class_:Tool_result.Policy_rejection
+            ~effect_disposition:Tool_result.Proven_pre_effect
             (error_json ~fields (typed_validation_error_text e))
         | Ok ir ->
         let cmd_for_log =
@@ -405,6 +428,7 @@ let handle_tool_execute_typed
           =
           Keeper_tool_execution.failure
             ~class_
+            ~effect_disposition:Tool_result.Proven_pre_effect
             (error_json
                ~fields:(typed_context_fields @ extra_fields)
                msg)
@@ -642,23 +666,74 @@ let handle_tool_execute_typed
               | Unix.WEXITED 0, _ | _, "" -> []
               | _, stderr -> [ "error", `String stderr; "stderr", `String stderr ]
             in
-            let payload =
-              Yojson.Safe.to_string
-                (`Assoc
+            let output_fields =
+              if succeeded
+              then
+                composable_output_fields
+                  ~base_path:config.base_path
+                  ~stdout
+                  ~stderr
+                  ~output
+              else Ok [ "output", `String output ]
+            in
+            (match output_fields with
+             | Error detail ->
+               Log.Keeper.warn
+                 ~keeper_name:meta.name
+                 "execute output artifact persistence failed after process completion: %s"
+                 detail;
+               authorized
+                 (Keeper_tool_execution.failure
+                    ~effect_disposition:Tool_result.Proven_post_effect
+                    (error_json
+                       ~fields:
+                         ([ "typed", `Bool true
+                          ; "code", `String "execute_output_externalization_failed"
+                          ; "status", status_json
+                          ; "execution_time_ms", `Int elapsed_ms
+                          ]
+                          @ dispatched_model_location_fields)
+                       "Execute completed, but its oversized output artifact could not be persisted."))
+             | Ok output_fields ->
+               let payload =
+                 `Assoc
                    ([ "ok", `Bool succeeded
                     ; "status", status_json
-                    ; "output", `String output
-                    ; "typed", `Bool true
-                    ; "execution_time_ms", `Int elapsed_ms
                     ]
+                    @ output_fields
+                    @ [ "typed", `Bool true
+                      ; "execution_time_ms", `Int elapsed_ms
+                      ]
                     @ failure_error_fields
                     @ sandbox_extra_fields
-                    @ dispatched_model_location_fields))
-            in
-            authorized
-              (if succeeded
-               then Keeper_tool_execution.success payload
-               else Keeper_tool_execution.failure payload)
+                    @ dispatched_model_location_fields)
+               in
+               authorized
+                 (if succeeded
+                  then
+                    (match
+                       Tool_bridge.attach_artifact_manifest
+                         ~base_path:config.base_path
+                         (Tool_result.make_ok
+                            ~tool_name:"tool_execute"
+                            ~start_time:t0
+                            ~data:payload
+                            ())
+                     with
+                     | Ok result -> Keeper_tool_execution.of_tool_result result
+                     | Error _ ->
+                       Keeper_tool_execution.failure
+                         ~effect_disposition:Tool_result.Proven_post_effect
+                         (error_json
+                            ~fields:
+                              ([ "typed", `Bool true
+                               ; "code", `String "execute_result_manifest_failed"
+                               ; "status", status_json
+                               ; "execution_time_ms", `Int elapsed_ms
+                               ]
+                               @ dispatched_model_location_fields)
+                            "Execute completed, but its result manifest could not be persisted."))
+                  else Keeper_tool_execution.failure (Yojson.Safe.to_string payload)))
         )))))
 
 let handle_tool_execute_with_outcome
@@ -685,6 +760,7 @@ let handle_tool_execute_with_outcome
   else
     Keeper_tool_execution.failure
       ~class_:Tool_result.Policy_rejection
+      ~effect_disposition:Tool_result.Proven_pre_effect
       (error_json
          ~fields:[ "typed", `Bool true ]
          "Typed Shell IR input is required. Provide non-empty argv or pipeline.")

--- a/lib/keeper/keeper_tool_execution.ml
+++ b/lib/keeper/keeper_tool_execution.ml
@@ -2,6 +2,11 @@ type deferred_kind =
   | Generic_deferred
   | External_effect_deferred
 
+let deferred_kind_to_string = function
+  | Generic_deferred -> "generic_deferred"
+  | External_effect_deferred -> "external_effect_deferred"
+;;
+
 type terminal_effect_receipt =
   | Surface_post_completed of Keeper_surface_post.post_target
 

--- a/lib/keeper/keeper_tool_execution.mli
+++ b/lib/keeper/keeper_tool_execution.mli
@@ -7,6 +7,9 @@ type deferred_kind =
   | Generic_deferred
   | External_effect_deferred
 
+val deferred_kind_to_string : deferred_kind -> string
+(** Stable producer-owned wire label for deferred settlement evidence. *)
+
 type terminal_effect_receipt =
   | Surface_post_completed of Keeper_surface_post.post_target
 (** Producer-owned proof of the concrete terminal effect that completed. *)

--- a/lib/keeper/keeper_tool_plan.ml
+++ b/lib/keeper/keeper_tool_plan.ml
@@ -279,6 +279,14 @@ module Run_id = struct
   let equal = Int.equal
 end
 
+module Composition_run_id = struct
+  type t = string
+
+  let fresh = Random_id.uuid_v7
+  let to_string value = value
+  let equal = String.equal
+end
+
 type json_type =
   | Null_type
   | Boolean_type

--- a/lib/keeper/keeper_tool_plan.mli
+++ b/lib/keeper/keeper_tool_plan.mli
@@ -84,6 +84,17 @@ module Run_id : sig
   val equal : t -> t -> bool
 end
 
+(** Globally unique durable observation identity for one composition
+    invocation. Unlike {!Run_id}, this UUID crosses process and fleet storage
+    boundaries and is never used to control plan execution. *)
+module Composition_run_id : sig
+  type t
+
+  val fresh : unit -> t
+  val to_string : t -> string
+  val equal : t -> t -> bool
+end
+
 type json_type =
   | Null_type
   | Boolean_type

--- a/lib/keeper/keeper_tool_plan_executor.ml
+++ b/lib/keeper/keeper_tool_plan_executor.ml
@@ -113,7 +113,19 @@ type node_result =
   ; input : Yojson.Safe.t
   ; schedule : Agent_core.Tool_contract.schedule
   ; result : Tool_result.result
+  ; failure_effect_disposition : Tool_result.failure_effect_disposition option
+  ; deferred_kind : Keeper_tool_execution.deferred_kind option
   }
+
+type dispatch_result =
+  { result : Tool_result.result
+  ; failure_effect_disposition : Tool_result.failure_effect_disposition option
+  ; deferred_kind : Keeper_tool_execution.deferred_kind option
+  }
+
+let dispatch_result ?failure_effect_disposition ?deferred_kind result =
+  { result; failure_effect_disposition; deferred_kind }
+;;
 
 type cause =
   | Plan_execution_failed of
@@ -130,6 +142,7 @@ type cause =
 type failure =
   { settled : node_result list
   ; cause : cause
+  ; effect_disposition : Tool_result.failure_effect_disposition
   }
 
 type dispatch =
@@ -137,7 +150,7 @@ type dispatch =
   -> descriptor:Keeper_tool_descriptor.t
   -> schedule:Agent_core.Tool_contract.schedule
   -> input:Yojson.Safe.t
-  -> Tool_result.result
+  -> dispatch_result
 
 type node_settlement =
   { result : node_result option
@@ -171,11 +184,13 @@ let execute_one ~plan ~run_id ~outputs ~dispatch scheduled =
     let result =
       Cancel_safe.protect
         ~on_exn:(fun exn ->
-          Tool_result.make_err_of_exn
-            ~class_:Tool_result.Runtime_failure
-            ~tool_name:node.tool_name
-            ~start_time
-            exn)
+          dispatch_result
+            ~failure_effect_disposition:Tool_result.Effect_outcome_unknown
+            (Tool_result.make_err_of_exn
+               ~class_:Tool_result.Runtime_failure
+               ~tool_name:node.tool_name
+               ~start_time
+               exn))
         (fun () ->
            dispatch
              ~node
@@ -188,10 +203,12 @@ let execute_one ~plan ~run_id ~outputs ~dispatch scheduled =
       ; tool_name = node.tool_name
       ; input
       ; schedule = scheduled.schedule
-      ; result
+      ; result = result.result
+      ; failure_effect_disposition = result.failure_effect_disposition
+      ; deferred_kind = result.deferred_kind
       }
     in
-    (match result with
+    (match result.result with
      | Tool_result.Deferred _ | Tool_result.Failed _ ->
        { result = Some node_result
        ; output = None
@@ -207,7 +224,7 @@ let execute_one ~plan ~run_id ~outputs ~dispatch scheduled =
                plan
                ~run_id
                ~node_id
-               (Tool_result.data result)
+               (Tool_result.data result.result)
            with
            | Ok output ->
              { result = Some node_result; output = Some output; cause = None }
@@ -222,6 +239,36 @@ let execute_one ~plan ~run_id ~outputs ~dispatch scheduled =
 ;;
 
 let execute ~plan ~run_id ~dispatch () =
+  let node_effect_disposition result =
+    match result.result with
+    | Tool_result.Deferred _ -> Tool_result.Proven_pre_effect
+    | Tool_result.Failed _ ->
+      Option.value
+        ~default:Tool_result.Effect_outcome_unknown
+        result.failure_effect_disposition
+    | Tool_result.Completed _ ->
+      (match Keeper_tool_plan.descriptor plan result.node_id with
+       | Some descriptor
+         when Keeper_tool_descriptor.readonly_for_input descriptor ~input:result.input
+              = Some true ->
+         Tool_result.Proven_pre_effect
+       | Some _ | None -> Tool_result.Proven_post_effect)
+  in
+  let aggregate_effect_disposition settled =
+    List.fold_left
+      (fun aggregate result ->
+         match aggregate, node_effect_disposition result with
+         | Tool_result.Proven_post_effect, _
+         | _, Tool_result.Proven_post_effect ->
+           Tool_result.Proven_post_effect
+         | Tool_result.Effect_outcome_unknown, _
+         | _, Tool_result.Effect_outcome_unknown ->
+           Tool_result.Effect_outcome_unknown
+         | Tool_result.Proven_pre_effect, Tool_result.Proven_pre_effect ->
+           Tool_result.Proven_pre_effect)
+      Tool_result.Proven_pre_effect
+      settled
+  in
   let rec run_batches settled outputs = function
     | [] -> Ok settled
     | batch :: rest ->
@@ -234,7 +281,12 @@ let execute ~plan ~run_id ~dispatch () =
       let batch_results = List.filter_map (fun settlement -> settlement.result) settlements in
       let settled = settled @ batch_results in
       (match List.find_map (fun settlement -> settlement.cause) settlements with
-       | Some cause -> Error { settled; cause }
+       | Some cause ->
+         Error
+           { settled
+           ; cause
+           ; effect_disposition = aggregate_effect_disposition settled
+           }
        | None ->
          let outputs =
            List.fold_left
@@ -313,6 +365,7 @@ let execute_keeper
       ; cause =
           Outer_completion_mismatch
             { expected = expected_completion; actual = actual_completion }
+      ; effect_disposition = Tool_result.Proven_pre_effect
       }
   else
   let dispatch ~(node : Keeper_tool_plan.node) ~descriptor ~schedule ~input =
@@ -322,6 +375,7 @@ let execute_keeper
       | Keeper_tool_descriptor.Ordinary
           (Keeper_tool_descriptor.Serial | Keeper_tool_descriptor.Concurrent) -> None, None
     in
+    let execution_evidence = ref None in
     let handler =
       Keeper_tools_agent_core_handler.make_keeper_tool_handler
         ~name:descriptor.internal_name
@@ -338,6 +392,8 @@ let execute_keeper
         ?gate_context
         ?gate_grant
         ?record_gate_result
+        ~observe_execution_evidence:(fun ~failure_effect_disposition ~deferred_kind ->
+          execution_evidence := Some (failure_effect_disposition, deferred_kind))
         ?on_completed:terminal_on_completed
         ?on_deferred
         ?on_external_effect_deferred
@@ -351,7 +407,14 @@ let execute_keeper
         ~schedule
         ~completion:Agent_core.Tool_contract.Continue_after_success
     in
-    handler ~agent_core_invocation:invocation input
+    let result = handler ~agent_core_invocation:invocation input in
+    match !execution_evidence with
+    | Some (failure_effect_disposition, deferred_kind) ->
+      { result; failure_effect_disposition; deferred_kind }
+    | None ->
+      dispatch_result
+        ~failure_effect_disposition:Tool_result.Effect_outcome_unknown
+        result
   in
   execute ~plan ~run_id ~dispatch ()
 ;;

--- a/lib/keeper/keeper_tool_plan_executor.ml
+++ b/lib/keeper/keeper_tool_plan_executor.ml
@@ -109,22 +109,39 @@ let outer_completion plan =
 
 type node_result =
   { node_id : Keeper_tool_plan.Node_id.t
+  ; execution_id : Ids.Execution_id.t
   ; tool_name : string
   ; input : Yojson.Safe.t
   ; schedule : Agent_core.Tool_contract.schedule
   ; result : Tool_result.result
+  ; tool_use_id : string
   ; failure_effect_disposition : Tool_result.failure_effect_disposition option
   ; deferred_kind : Keeper_tool_execution.deferred_kind option
+  ; result_bytes : int
+  ; truncated_to : int option
   }
 
 type dispatch_result =
   { result : Tool_result.result
   ; failure_effect_disposition : Tool_result.failure_effect_disposition option
   ; deferred_kind : Keeper_tool_execution.deferred_kind option
+  ; result_bytes : int option
+  ; truncated_to : int option
   }
 
-let dispatch_result ?failure_effect_disposition ?deferred_kind result =
-  { result; failure_effect_disposition; deferred_kind }
+let dispatch_result
+      ?failure_effect_disposition
+      ?deferred_kind
+      ?result_bytes
+      ?truncated_to
+      result
+  =
+  { result
+  ; failure_effect_disposition
+  ; deferred_kind
+  ; result_bytes
+  ; truncated_to
+  }
 ;;
 
 type cause =
@@ -134,6 +151,10 @@ type cause =
       ; error : Keeper_tool_plan.execution_error
       }
   | Tool_did_not_complete of node_result
+  | Node_observation_failed of
+      { node : node_result
+      ; detail : string
+      }
   | Outer_completion_mismatch of
       { expected : Agent_core.Tool_contract.completion
       ; actual : Agent_core.Tool_contract.completion
@@ -146,7 +167,8 @@ type failure =
   }
 
 type dispatch =
-  node:Keeper_tool_plan.node
+  tool_use_id:string
+  -> node:Keeper_tool_plan.node
   -> descriptor:Keeper_tool_descriptor.t
   -> schedule:Agent_core.Tool_contract.schedule
   -> input:Yojson.Safe.t
@@ -158,7 +180,15 @@ type node_settlement =
   ; cause : cause option
   }
 
-let execute_one ~plan ~run_id ~outputs ~dispatch scheduled =
+let execute_one
+      ~plan
+      ~run_id
+      ~outputs
+      ~tool_use_id_for_node
+      ~dispatch
+      ?observe_node_result
+      scheduled
+  =
   let node = scheduled.node in
   let node_id = node.Keeper_tool_plan.id in
   let plan_failure error =
@@ -180,6 +210,11 @@ let execute_one ~plan ~run_id ~outputs ~dispatch scheduled =
   with
   | Error error -> plan_failure error
   | Ok input ->
+    (* The executor owns both occurrence identities. Mint them before entering
+       dispatch so success, Deferred/Failed settlement, and the exception
+       wrapper all project the exact same non-optional join key. *)
+    let execution_id = Ids.Execution_id.generate () in
+    let tool_use_id = tool_use_id_for_node ~execution_id node in
     let start_time = Time_compat.now () in
     let result =
       Cancel_safe.protect
@@ -193,22 +228,51 @@ let execute_one ~plan ~run_id ~outputs ~dispatch scheduled =
                exn))
         (fun () ->
            dispatch
+             ~tool_use_id
              ~node
              ~descriptor:scheduled.descriptor
              ~schedule:scheduled.schedule
              ~input)
     in
+    let result_bytes =
+      Option.value
+        ~default:(String.length (Tool_result.message result.result))
+        result.result_bytes
+    in
     let node_result =
       { node_id
+      ; execution_id
       ; tool_name = node.tool_name
       ; input
       ; schedule = scheduled.schedule
       ; result = result.result
+      ; tool_use_id
       ; failure_effect_disposition = result.failure_effect_disposition
       ; deferred_kind = result.deferred_kind
+      ; result_bytes
+      ; truncated_to = result.truncated_to
       }
     in
-    (match result.result with
+    let observation_error =
+      match observe_node_result with
+      | None -> None
+      | Some observe ->
+        (try
+           match observe node_result with
+           | Ok () -> None
+           | Error detail -> Some detail
+         with
+         | Eio.Cancel.Cancelled _ as exn -> raise exn
+         | exn -> Some (Printexc.to_string exn))
+    in
+    (match observation_error with
+     | Some detail ->
+       { result = Some node_result
+       ; output = None
+       ; cause = Some (Node_observation_failed { node = node_result; detail })
+       }
+     | None ->
+       (match result.result with
      | Tool_result.Deferred _ | Tool_result.Failed _ ->
        { result = Some node_result
        ; output = None
@@ -235,10 +299,17 @@ let execute_one ~plan ~run_id ~outputs ~dispatch scheduled =
                  Some
                    (Plan_execution_failed
                       { node_id; schedule = scheduled.schedule; error })
-             })))
+             }))))
 ;;
 
-let execute ~plan ~run_id ~dispatch () =
+let execute_with_tool_use_id
+      ~plan
+      ~run_id
+      ~tool_use_id_for_node
+      ~dispatch
+      ?observe_node_result
+      ()
+  =
   let node_effect_disposition (result : node_result) =
     match result.result with
     | Tool_result.Deferred _ -> Tool_result.Proven_pre_effect
@@ -272,7 +343,16 @@ let execute ~plan ~run_id ~dispatch () =
   let rec run_batches settled outputs = function
     | [] -> Ok settled
     | batch :: rest ->
-      let execute scheduled = execute_one ~plan ~run_id ~outputs ~dispatch scheduled in
+      let execute scheduled =
+        execute_one
+          ~plan
+          ~run_id
+          ~outputs
+          ~tool_use_id_for_node
+          ~dispatch
+          ?observe_node_result
+          scheduled
+      in
       let settlements =
         match batch with
         | Serial_batch scheduled -> [ execute scheduled ]
@@ -303,10 +383,31 @@ let execute ~plan ~run_id ~dispatch () =
   run_batches [] [] (schedule plan)
 ;;
 
-let nested_tool_use_id parent_invocation node_id =
+let execute ~plan ~run_id ~dispatch ?observe_node_result () =
+  let tool_use_id_for_node ~execution_id _node =
+    "composition-node:" ^ Ids.Execution_id.to_string execution_id
+  in
+  execute_with_tool_use_id
+    ~plan
+    ~run_id
+    ~tool_use_id_for_node
+    ~dispatch
+    ?observe_node_result
+    ()
+;;
+
+let nested_tool_use_id ~composition_run_id parent_invocation node_id =
   let parent = Agent_core.Tool_contract.Invocation.tool_use_id parent_invocation in
   let node = Keeper_tool_plan.Node_id.to_string node_id in
-  Printf.sprintf "composition:%d:%s:%d:%s" (String.length parent) parent (String.length node) node
+  let run = Keeper_tool_plan.Composition_run_id.to_string composition_run_id in
+  Printf.sprintf
+    "composition:%d:%s:%d:%s:%d:%s"
+    (String.length run)
+    run
+    (String.length parent)
+    parent
+    (String.length node)
+    node
 ;;
 
 let equal_failure_effect left right =
@@ -337,6 +438,7 @@ let equal_completion left right =
 let execute_keeper
       ~plan
       ~run_id
+      ?composition_run_id
       ~parent_invocation
       ~config
       ~meta
@@ -352,8 +454,14 @@ let execute_keeper
       ?on_deferred
       ?on_external_effect_deferred
       ?on_failed
+      ?observe_node_result
       ()
   =
+  let composition_run_id =
+    Option.value
+      ~default:(Keeper_tool_plan.Composition_run_id.fresh ())
+      composition_run_id
+  in
   let expected_completion = outer_completion plan in
   let actual_completion =
     Agent_core.Tool_contract.Invocation.completion parent_invocation
@@ -368,7 +476,7 @@ let execute_keeper
       ; effect_disposition = Tool_result.Proven_pre_effect
       }
   else
-  let dispatch ~(node : Keeper_tool_plan.node) ~descriptor ~schedule ~input =
+  let dispatch ~tool_use_id ~(node : Keeper_tool_plan.node) ~descriptor ~schedule ~input =
     let terminal_on_completed, terminal_on_failed =
       match descriptor.Keeper_tool_descriptor.execution with
       | Keeper_tool_descriptor.Terminal -> on_completed, on_failed
@@ -402,19 +510,43 @@ let execute_keeper
     in
     let invocation =
       Agent_core.Tool_contract.Invocation.create
-        ~tool_use_id:(nested_tool_use_id parent_invocation node.id)
+        ~tool_use_id
         ~turn:(Agent_core.Tool_contract.Invocation.turn parent_invocation)
         ~schedule
         ~completion:Agent_core.Tool_contract.Continue_after_success
     in
     let result = handler ~agent_core_invocation:invocation input in
+    let original_bytes, truncated_to =
+      Keeper_tool_call_log.consume_truncation_info ~invocation ()
+    in
+    let result_bytes =
+      if original_bytes > 0
+      then original_bytes
+      else String.length (Tool_result.message result)
+    in
     match !execution_evidence with
     | Some (failure_effect_disposition, deferred_kind) ->
-      { result; failure_effect_disposition; deferred_kind }
+      { result
+      ; failure_effect_disposition
+      ; deferred_kind
+      ; result_bytes = Some result_bytes
+      ; truncated_to
+      }
     | None ->
       dispatch_result
         ~failure_effect_disposition:Tool_result.Effect_outcome_unknown
+        ~result_bytes
+        ?truncated_to
         result
   in
-  execute ~plan ~run_id ~dispatch ()
+  let tool_use_id_for_node ~execution_id:_ node =
+    nested_tool_use_id ~composition_run_id parent_invocation node.Keeper_tool_plan.id
+  in
+  execute_with_tool_use_id
+    ~plan
+    ~run_id
+    ~tool_use_id_for_node
+    ~dispatch
+    ?observe_node_result
+    ()
 ;;

--- a/lib/keeper/keeper_tool_plan_executor.ml
+++ b/lib/keeper/keeper_tool_plan_executor.ml
@@ -239,7 +239,7 @@ let execute_one ~plan ~run_id ~outputs ~dispatch scheduled =
 ;;
 
 let execute ~plan ~run_id ~dispatch () =
-  let node_effect_disposition result =
+  let node_effect_disposition (result : node_result) =
     match result.result with
     | Tool_result.Deferred _ -> Tool_result.Proven_pre_effect
     | Tool_result.Failed _ ->

--- a/lib/keeper/keeper_tool_plan_executor.mli
+++ b/lib/keeper/keeper_tool_plan_executor.mli
@@ -30,7 +30,20 @@ type node_result = private
   ; input : Yojson.Safe.t
   ; schedule : Agent_core.Tool_contract.schedule
   ; result : Tool_result.result
+  ; failure_effect_disposition : Tool_result.failure_effect_disposition option
+  ; deferred_kind : Keeper_tool_execution.deferred_kind option
   }
+
+type dispatch_result
+
+(** Construct a low-level dispatch settlement. Callers that own more precise
+    producer evidence must supply it; absent failure evidence is conservatively
+    treated as an unknown effect outcome. *)
+val dispatch_result
+  :  ?failure_effect_disposition:Tool_result.failure_effect_disposition
+  -> ?deferred_kind:Keeper_tool_execution.deferred_kind
+  -> Tool_result.result
+  -> dispatch_result
 
 type cause =
   | Plan_execution_failed of
@@ -47,6 +60,7 @@ type cause =
 type failure = private
   { settled : node_result list
   ; cause : cause
+  ; effect_disposition : Tool_result.failure_effect_disposition
   }
 
 type dispatch =
@@ -54,7 +68,7 @@ type dispatch =
   -> descriptor:Keeper_tool_descriptor.t
   -> schedule:Agent_core.Tool_contract.schedule
   -> input:Yojson.Safe.t
-  -> Tool_result.result
+  -> dispatch_result
 
 (** Execute dependency batches to completion. Concurrent siblings are all
     settled before the lowest-planned-index cause is selected. A [Deferred]

--- a/lib/keeper/keeper_tool_plan_executor.mli
+++ b/lib/keeper/keeper_tool_plan_executor.mli
@@ -26,12 +26,16 @@ val outer_completion : Keeper_tool_plan.t -> Agent_core.Tool_contract.completion
 
 type node_result = private
   { node_id : Keeper_tool_plan.Node_id.t
+  ; execution_id : Ids.Execution_id.t
   ; tool_name : string
   ; input : Yojson.Safe.t
   ; schedule : Agent_core.Tool_contract.schedule
   ; result : Tool_result.result
+  ; tool_use_id : string
   ; failure_effect_disposition : Tool_result.failure_effect_disposition option
   ; deferred_kind : Keeper_tool_execution.deferred_kind option
+  ; result_bytes : int
+  ; truncated_to : int option
   }
 
 type dispatch_result
@@ -42,6 +46,8 @@ type dispatch_result
 val dispatch_result
   :  ?failure_effect_disposition:Tool_result.failure_effect_disposition
   -> ?deferred_kind:Keeper_tool_execution.deferred_kind
+  -> ?result_bytes:int
+  -> ?truncated_to:int
   -> Tool_result.result
   -> dispatch_result
 
@@ -52,6 +58,10 @@ type cause =
       ; error : Keeper_tool_plan.execution_error
       }
   | Tool_did_not_complete of node_result
+  | Node_observation_failed of
+      { node : node_result
+      ; detail : string
+      }
   | Outer_completion_mismatch of
       { expected : Agent_core.Tool_contract.completion
       ; actual : Agent_core.Tool_contract.completion
@@ -64,7 +74,8 @@ type failure = private
   }
 
 type dispatch =
-  node:Keeper_tool_plan.node
+  tool_use_id:string
+  -> node:Keeper_tool_plan.node
   -> descriptor:Keeper_tool_descriptor.t
   -> schedule:Agent_core.Tool_contract.schedule
   -> input:Yojson.Safe.t
@@ -75,11 +86,17 @@ type dispatch =
     or [Failed] tool result is carried unchanged in [Tool_did_not_complete];
     no text or payload inference is performed. A deferred node produces no
     composable output, so it cannot satisfy a downstream output reference and
-    terminates the plan instead of being resumed as a producer. *)
+    terminates the plan instead of being resumed as a producer.
+    The executor mints one non-empty [tool_use_id] before calling [dispatch];
+    the dispatch, exception settlement, durable row, and live refresh all share
+    that identity. [observe_node_result], when supplied, is part of settlement: an observation
+    error becomes [Node_observation_failed] after every sibling in the current
+    batch has settled, preserving the aggregate effect disposition. *)
 val execute
   :  plan:Keeper_tool_plan.t
   -> run_id:Keeper_tool_plan.Run_id.t
   -> dispatch:dispatch
+  -> ?observe_node_result:(node_result -> (unit, string) result)
   -> unit
   -> (node_result list, failure) result
 
@@ -89,6 +106,7 @@ val execute
 val execute_keeper
   :  plan:Keeper_tool_plan.t
   -> run_id:Keeper_tool_plan.Run_id.t
+  -> ?composition_run_id:Keeper_tool_plan.Composition_run_id.t
   -> parent_invocation:Agent_core.Tool_contract.Invocation.t
   -> config:Workspace.config
   -> meta:Keeper_meta_contract.keeper_meta
@@ -105,5 +123,6 @@ val execute_keeper
   -> ?on_deferred:(unit -> unit)
   -> ?on_external_effect_deferred:(unit -> unit)
   -> ?on_failed:(Keeper_tools_agent_core.terminal_effect_failure -> unit)
+  -> ?observe_node_result:(node_result -> (unit, string) result)
   -> unit
   -> (node_result list, failure) result

--- a/lib/keeper/keeper_tools_agent_core_bundle.ml
+++ b/lib/keeper/keeper_tools_agent_core_bundle.ml
@@ -49,6 +49,7 @@ let make_tool_bundle_for_descriptors
       ?continuation_channel
       ?gate_context
       ?hitl_resolution
+      ?composition_catalog
       ~(descriptors : Keeper_tool_descriptor.t list)
       ()
   : tool_bundle
@@ -317,7 +318,38 @@ let make_tool_bundle_for_descriptors
                    input)))
       descriptors
   in
-  { tools = descriptor_tools
+  let composition_tools =
+    match composition_catalog with
+    | None -> []
+    | Some catalog ->
+      Keeper_tool_composition_surface.make_tools
+        ~catalog
+        ~config
+        ~meta
+        ~publication_recovery
+        ~ctx_snapshot
+        ?turn_sandbox_factory
+        ?clock
+        ?continuation_channel
+        ?gate_context:gate_context_provider
+        ?gate_grant
+        ?record_gate_result
+        ~on_completed:(function
+          | Some receipt -> mark_terminal_effect_completed receipt
+          | None ->
+            mark_terminal_effect_failed
+              { failure_class = Tool_result.Runtime_failure
+              ; effect_disposition = Tool_result.Effect_outcome_unknown
+              ; diagnostic =
+                  "terminal composition completed without a typed target receipt"
+              })
+        ~on_deferred:mark_deferred_tool_result
+        ~on_external_effect_deferred:mark_external_effect_deferred
+        ~on_failed:mark_terminal_effect_failed
+        ~on_externalization_error:mark_completed_terminal_externalization_failed
+        ()
+  in
+  { tools = descriptor_tools @ composition_tools
   ; cleanup =
       (fun () ->
         Option.iter Keeper_sandbox_factory.cleanup turn_sandbox_factory)
@@ -336,6 +368,7 @@ let make_tool_bundle
       ?continuation_channel
       ?gate_context
       ?hitl_resolution
+      ?composition_catalog
       ()
   =
   make_tool_bundle_for_descriptors
@@ -347,6 +380,7 @@ let make_tool_bundle
     ?continuation_channel
     ?gate_context
     ?hitl_resolution
+    ?composition_catalog
     ~descriptors:(Keeper_tool_descriptor.model_visible_descriptors ())
     ()
 ;;
@@ -358,6 +392,7 @@ let make_tools
           Keeper_publication_recovery_availability.turn_context)
       ~(ctx_snapshot : Keeper_types.working_context)
       ?clock
+      ?composition_catalog
       ()
   : Agent_core.Tool.t list
   =
@@ -367,6 +402,7 @@ let make_tools
      ~publication_recovery
      ~ctx_snapshot
      ?clock
+     ?composition_catalog
      ())
     .tools
 ;;

--- a/lib/keeper/keeper_tools_agent_core_bundle.ml
+++ b/lib/keeper/keeper_tools_agent_core_bundle.ml
@@ -50,6 +50,7 @@ let make_tool_bundle_for_descriptors
       ?gate_context
       ?hitl_resolution
       ?composition_catalog
+      ?turn_ctx_cell
       ~(descriptors : Keeper_tool_descriptor.t list)
       ()
   : tool_bundle
@@ -273,7 +274,49 @@ let make_tool_bundle_for_descriptors
              , Some mark_completed_terminal_externalization_failed )
            | Keeper_tool_descriptor.Ordinary
                (Keeper_tool_descriptor.Serial | Keeper_tool_descriptor.Concurrent) ->
-             None, None, None
+             let on_failed =
+               match descriptor.runtime_handler with
+               | Keeper_tool_descriptor.Tool_execute ->
+                 Some mark_terminal_effect_failed
+               | ( Keeper_tool_descriptor.Tool_search_files
+                 | Keeper_tool_descriptor.Tool_read_file
+                 | Keeper_tool_descriptor.Tool_edit_file
+                 | Keeper_tool_descriptor.Tool_write_file
+                 | Keeper_tool_descriptor.Tool_time_now
+                 | Keeper_tool_descriptor.Tool_tools_list
+                 | Keeper_tool_descriptor.Tool_context_status
+                 | Keeper_tool_descriptor.Tool_artifact_read
+                 | Keeper_tool_descriptor.Tool_memory_search
+                 | Keeper_tool_descriptor.Tool_memory_write
+                 | Keeper_tool_descriptor.Tool_library_search
+                 | Keeper_tool_descriptor.Tool_library_read
+                 | Keeper_tool_descriptor.Tool_surface_read
+                 | Keeper_tool_descriptor.Tool_surface_post
+                 | Keeper_tool_descriptor.Tool_person_note_set
+                 | Keeper_tool_descriptor.Tool_ide_annotate
+                 | Keeper_tool_descriptor.Tool_voice_dispatch
+                 | Keeper_tool_descriptor.Tool_task_dispatch
+                 | Keeper_tool_descriptor.Tool_board_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_task_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_plan_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_run_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_agent_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_workspace_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_misc_dispatch
+                 | Keeper_tool_descriptor.Tool_web_search
+                 | Keeper_tool_descriptor.Tool_web_fetch
+                 | Keeper_tool_descriptor.Tool_masc_control_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_agent_timeline_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_schedule_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_keeper_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_fusion_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_fusion_status
+                 | Keeper_tool_descriptor.Tool_masc_library_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_local_runtime_dispatch
+                 | Keeper_tool_descriptor.Tool_analyze_image ) ->
+                 None
+             in
+             None, on_failed, None
          in
          Keeper_tool_descriptor.keeper_model_names descriptor
          |> List.map (fun model_name ->
@@ -329,6 +372,7 @@ let make_tool_bundle_for_descriptors
         ~publication_recovery
         ~ctx_snapshot
         ?turn_sandbox_factory
+        ?turn_ctx_cell
         ?clock
         ?continuation_channel
         ?gate_context:gate_context_provider
@@ -369,6 +413,7 @@ let make_tool_bundle
       ?gate_context
       ?hitl_resolution
       ?composition_catalog
+      ?turn_ctx_cell
       ()
   =
   make_tool_bundle_for_descriptors
@@ -381,6 +426,7 @@ let make_tool_bundle
     ?gate_context
     ?hitl_resolution
     ?composition_catalog
+    ?turn_ctx_cell
     ~descriptors:(Keeper_tool_descriptor.model_visible_descriptors ())
     ()
 ;;
@@ -393,6 +439,7 @@ let make_tools
       ~(ctx_snapshot : Keeper_types.working_context)
       ?clock
       ?composition_catalog
+      ?turn_ctx_cell
       ()
   : Agent_core.Tool.t list
   =
@@ -403,6 +450,7 @@ let make_tools
      ~ctx_snapshot
      ?clock
      ?composition_catalog
+     ?turn_ctx_cell
      ())
     .tools
 ;;

--- a/lib/keeper/keeper_tools_agent_core_bundle.mli
+++ b/lib/keeper/keeper_tools_agent_core_bundle.mli
@@ -14,6 +14,7 @@ val make_tool_bundle
   -> ?continuation_channel:Keeper_continuation_channel.t
   -> ?gate_context:Keeper_gate_causal_context.t
   -> ?hitl_resolution:Keeper_event_queue.hitl_resolution
+  -> ?composition_catalog:Keeper_tool_composition_catalog.t
   -> unit
   -> Keeper_tools_agent_core.tool_bundle
 
@@ -25,6 +26,7 @@ val make_tools
        Keeper_publication_recovery_availability.turn_context
   -> ctx_snapshot:Keeper_types.working_context
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?composition_catalog:Keeper_tool_composition_catalog.t
   -> unit
   -> Agent_core.Tool.t list
 

--- a/lib/keeper/keeper_tools_agent_core_bundle.mli
+++ b/lib/keeper/keeper_tools_agent_core_bundle.mli
@@ -15,6 +15,7 @@ val make_tool_bundle
   -> ?gate_context:Keeper_gate_causal_context.t
   -> ?hitl_resolution:Keeper_event_queue.hitl_resolution
   -> ?composition_catalog:Keeper_tool_composition_catalog.t
+  -> ?turn_ctx_cell:Keeper_tool_call_log.turn_ctx_cell
   -> unit
   -> Keeper_tools_agent_core.tool_bundle
 
@@ -27,6 +28,7 @@ val make_tools
   -> ctx_snapshot:Keeper_types.working_context
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
   -> ?composition_catalog:Keeper_tool_composition_catalog.t
+  -> ?turn_ctx_cell:Keeper_tool_call_log.turn_ctx_cell
   -> unit
   -> Agent_core.Tool.t list
 

--- a/lib/keeper/keeper_tools_agent_core_handler.ml
+++ b/lib/keeper/keeper_tools_agent_core_handler.ml
@@ -24,6 +24,7 @@ let make_keeper_tool_handler
       ?gate_context
       ?gate_grant
       ?record_gate_result
+      ?observe_execution_evidence
       ?on_completed
       ?on_deferred
       ?on_external_effect_deferred
@@ -116,6 +117,12 @@ let make_keeper_tool_handler
   fun ?agent_core_invocation raw_input ->
     let invocation_fields = agent_core_invocation_fields agent_core_invocation in
     let handle_validation_error ~input validation_result =
+      Option.iter
+        (fun observe ->
+           observe
+             ~failure_effect_disposition:(Some Tool_result.Proven_pre_effect)
+             ~deferred_kind:None)
+        observe_execution_evidence;
       let output_text = Tool_result.message validation_result in
       let duration_ms = 0 in
       let disposition = Tool_result.string_of_disposition validation_result in
@@ -209,6 +216,13 @@ let make_keeper_tool_handler
                 ~input
                 ()
             in
+            Option.iter
+              (fun observe ->
+                 observe
+                   ~failure_effect_disposition:
+                     execution.failure_effect_disposition
+                   ~deferred_kind:execution.deferred_kind)
+              observe_execution_evidence;
             execution.tool_result
             |> record_result ~input
             |> observe_terminal_execution_result

--- a/lib/keeper/keeper_tools_agent_core_handler.mli
+++ b/lib/keeper/keeper_tools_agent_core_handler.mli
@@ -31,6 +31,10 @@ val make_keeper_tool_handler
   -> ?gate_grant:Keeper_gate.cycle_grant
   -> ?record_gate_result:
        (operation:string -> input:Yojson.Safe.t -> Tool_result.result -> unit)
+  -> ?observe_execution_evidence:
+       (failure_effect_disposition:Tool_result.failure_effect_disposition option
+        -> deferred_kind:Keeper_tool_execution.deferred_kind option
+        -> unit)
   -> ?on_completed:
        (Keeper_tool_execution.terminal_effect_receipt option -> unit)
   -> ?on_deferred:(unit -> unit)

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -80,6 +80,19 @@ let selected_runtime_result (runtime : Runtime.t) result =
     result
 ;;
 
+let apply_official_client_accept ~runtime_id ~accept ~terminal_effect_state
+    (run_result : Runtime_agent.run_result) =
+  match run_result.stop_reason, terminal_effect_state () with
+  | ( Runtime_agent.Completed
+    , Keeper_tools_agent_core.Terminal_effect_completed _ ) ->
+    Ok run_result
+  | _ ->
+    Keeper_turn_driver_try_provider.apply_accept
+      ~runtime_id
+      ~accept
+      run_result
+;;
+
 type deferred_runtime_lane =
   { assignment_id : string
   ; failed_runtime_id : string
@@ -932,14 +945,16 @@ let run_named
                  when String.trim text = "" ->
                  Ok run_result
                | _ ->
-                 Keeper_turn_driver_try_provider.apply_accept
+                 apply_official_client_accept
                    ~runtime_id:attempt_runtime_id
                    ~accept
+                   ~terminal_effect_state
                    run_result)
             | Keeper_codex_runtime.No_successful_tool_completion ->
-              Keeper_turn_driver_try_provider.apply_accept
+              apply_official_client_accept
                 ~runtime_id:attempt_runtime_id
                 ~accept
+                ~terminal_effect_state
                 run_result)
         in
         (match codex_result with
@@ -1013,9 +1028,10 @@ let run_named
         Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
         let antigravity_result =
           Result.bind antigravity_attempt.result (fun run_result ->
-            Keeper_turn_driver_try_provider.apply_accept
+            apply_official_client_accept
               ~runtime_id:attempt_runtime_id
               ~accept
+              ~terminal_effect_state
               run_result)
         in
         (match antigravity_result with
@@ -1093,9 +1109,10 @@ let run_named
         Option.iter (fun consume -> consume ()) on_deferred_runtime_consumed;
         let claude_result =
           Result.bind claude_attempt.result (fun run_result ->
-            Keeper_turn_driver_try_provider.apply_accept
+            apply_official_client_accept
               ~runtime_id:attempt_runtime_id
               ~accept
+              ~terminal_effect_state
               run_result)
         in
         (match claude_result with
@@ -1265,6 +1282,7 @@ module For_testing = struct
     resolve_runtime_candidate_for_attempt
 
   let selected_runtime_result = selected_runtime_result
+  let apply_official_client_accept = apply_official_client_accept
 
 	  let media_degrade_manifest_decision = media_degrade_manifest_decision
 	  let attempt_inference_policy = attempt_inference_policy

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -874,6 +874,7 @@ let run_named
             ~raw_trace
             ~on_event
             ~config
+            ()
         in
         let codex_attempt =
           match provider_config_transform, agent_core_checkpoint with
@@ -970,6 +971,7 @@ let run_named
             ~raw_trace
             ~on_event
             ~config
+            ()
         in
         let run_antigravity_with_history () =
           run_antigravity ~initial_messages ()
@@ -1047,6 +1049,7 @@ let run_named
             ~raw_trace
             ~on_event
             ~config
+            ()
         in
         let claude_attempt =
           match provider_config_transform, agent_core_checkpoint with

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -532,6 +532,7 @@ let run_named
     ?checkpoint_sink
     ?context_injector
     ?context
+    ?(terminal_effect_state = fun () -> Keeper_tools_agent_core.Terminal_effect_open)
     ?enable_thinking
     ?cooperative_yield_probe
     ?agent_core_checkpoint
@@ -868,6 +869,7 @@ let run_named
             ~hooks
             ~context_injector
             ~context
+            ~terminal_effect_state
             ~event_bus
             ~raw_trace
             ~on_event
@@ -963,6 +965,7 @@ let run_named
             ~hooks
             ~context_injector
             ~context
+            ~terminal_effect_state
             ~event_bus
             ~raw_trace
             ~on_event
@@ -1039,6 +1042,7 @@ let run_named
             ~hooks
             ~context_injector
             ~context
+            ~terminal_effect_state
             ~event_bus
             ~raw_trace
             ~on_event

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -121,6 +121,7 @@ val run_named :
   ?checkpoint_sink:Agent_core.Agent.checkpoint_sink ->
   ?context_injector:Agent_core.Hooks.context_injector ->
   ?context:Agent_core.Context.t ->
+  ?terminal_effect_state:(unit -> Keeper_tools_agent_core.terminal_effect_state) ->
   ?enable_thinking:bool ->
   ?cooperative_yield_probe:Runtime_agent.cooperative_yield_probe ->
   ?agent_core_checkpoint:Agent_core.Checkpoint.t ->

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -193,6 +193,13 @@ module For_testing : sig
     Runtime_agent.run_result ->
     (Runtime_agent.run_result, Agent_core.Error.t) result
 
+  val apply_official_client_accept :
+    runtime_id:string ->
+    accept:(Agent_core.Types.api_response -> bool) ->
+    terminal_effect_state:(unit -> Keeper_tools_agent_core.terminal_effect_state) ->
+    Runtime_agent.run_result ->
+    (Runtime_agent.run_result, Agent_core.Error.t) result
+
   val first_runtime_after_modality_reroute :
     keeper_name:string ->
     assignment_id:string ->

--- a/lib/keeper_runtime/keeper_internal_error.ml
+++ b/lib/keeper_runtime/keeper_internal_error.ml
@@ -24,6 +24,7 @@ let runtime_id_to_string (s : string) = s
    this value so recoverability cannot drift through duplicated literals. *)
 let capacity_backpressure_kind = "capacity_backpressure"
 let incomplete_tool_transcript_kind = "incomplete_tool_transcript"
+let provider_attempt_effect_fenced_kind = "provider_attempt_effect_fenced"
 
 type provider_rejection = {
   provider_label : string;
@@ -516,7 +517,7 @@ let masc_internal_error_to_json = function
   | Provider_attempt_effect_fenced
       { runtime_id; effect_disposition; diagnostic } ->
     `Assoc
-      [ "kind", `String "provider_attempt_effect_fenced"
+      [ "kind", `String provider_attempt_effect_fenced_kind
       ; "runtime_id", `String runtime_id
       ; ( "effect_disposition"
         , `String (Keeper_provider_attempt_effect_core.to_string effect_disposition) )
@@ -669,7 +670,7 @@ let kind_of_masc_internal_error = function
   | Internal_contract_rejected _ -> "internal_contract_rejected"
   | Incomplete_tool_transcript _ -> incomplete_tool_transcript_kind
   | Terminal_effect_failed _ -> "terminal_effect_failed"
-  | Provider_attempt_effect_fenced _ -> "provider_attempt_effect_fenced"
+  | Provider_attempt_effect_fenced _ -> provider_attempt_effect_fenced_kind
   | Receipt_persistence_failed _ -> "receipt_persistence_failed"
   | Gate_replay_repair_required _ -> "gate_replay_repair_required"
 
@@ -931,10 +932,11 @@ let parse_masc_internal_error_json (json : Yojson.Safe.t) :
                     { failure_class; effect_disposition; diagnostic })
              | _ -> None)
           | _ -> None)
-      | Some (`String "provider_attempt_effect_fenced")
-        when exact_fields
-               [ "kind"; "runtime_id"; "effect_disposition"; "diagnostic" ]
-               fields ->
+      | Some (`String kind)
+        when String.equal kind provider_attempt_effect_fenced_kind
+             && exact_fields
+                  [ "kind"; "runtime_id"; "effect_disposition"; "diagnostic" ]
+                  fields ->
         (match
            string_opt_of_assoc "runtime_id" json,
            string_opt_of_assoc "effect_disposition" json,

--- a/lib/keeper_runtime/keeper_internal_error.mli
+++ b/lib/keeper_runtime/keeper_internal_error.mli
@@ -4,9 +4,13 @@
 (** Canonical wire kind emitted for {!Capacity_backpressure}.  Receipt
     terminal projection and decoding consume this same value. *)
 val capacity_backpressure_kind : string
-val incomplete_tool_transcript_kind : string
 (** Canonical wire kind for structural transcript corruption rejected before
     provider dispatch. *)
+val incomplete_tool_transcript_kind : string
+
+(** Canonical wire kind for a provider-attempt failure whose effect disposition
+    forbids same-turn replay. *)
+val provider_attempt_effect_fenced_kind : string
 
 type provider_rejection = {
   provider_label : string;

--- a/lib/keeper_runtime/keeper_terminal_reason.ml
+++ b/lib/keeper_runtime/keeper_terminal_reason.ml
@@ -29,6 +29,7 @@ type t =
   | Config_or_auth of string
   | Provider_runtime_failure of string
   | Transcript_corruption of string
+  | Provider_attempt_effect_fenced of string
   | Internal_error of string
   | Pre_dispatch_success of string
   | Unknown of string
@@ -44,8 +45,9 @@ let is_config_or_auth_wire = function
 
 (* Priority-ranked partition. The bucket order replicates the [if/else]
    order of the pre-typing [operator_disposition] string predicates, with the
-   exact canonical [Capacity_backpressure] policy bucket inserted before the
-   opaque internal-error fall-through;
+   exact canonical policy buckets for [Capacity_backpressure] and
+   [Provider_attempt_effect_fenced] inserted before the opaque internal-error
+   fall-through;
    [of_wire] returns the FIRST matching bucket. Capacity backpressure is an
    exact producer-owned wire kind; casing variants remain opaque rather than
    inheriting its non-pageable policy. The original
@@ -68,6 +70,9 @@ let of_wire wire =
   else if
     String.equal wire Keeper_internal_error.incomplete_tool_transcript_kind
   then Transcript_corruption wire
+  else if
+    String.equal wire Keeper_internal_error.provider_attempt_effect_fenced_kind
+  then Provider_attempt_effect_fenced wire
   else if String.equal wire "internal_error"
   then Internal_error wire
   else if String.equal wire "pre_dispatch_success"
@@ -85,6 +90,7 @@ let to_wire = function
   | Config_or_auth wire -> wire
   | Provider_runtime_failure wire -> wire
   | Transcript_corruption wire -> wire
+  | Provider_attempt_effect_fenced wire -> wire
   | Internal_error wire -> wire
   | Pre_dispatch_success wire -> wire
   | Unknown wire -> wire
@@ -113,6 +119,7 @@ let is_transient_provider_runtime_failure = function
   | Capacity_backpressure _
   | Config_or_auth _
   | Transcript_corruption _
+  | Provider_attempt_effect_fenced _
   | Internal_error _
   | Pre_dispatch_success _
   | Unknown _ -> false

--- a/lib/keeper_runtime/keeper_terminal_reason.mli
+++ b/lib/keeper_runtime/keeper_terminal_reason.mli
@@ -27,8 +27,9 @@
 
     [of_wire] is a {e priority-ranked partition}: it tests the buckets in
     the same order the old [operator_disposition] [if/else] chain tested
-    its string predicates, plus the exact canonical
-    [Capacity_backpressure] policy bucket, and returns the first match.
+    its string predicates, plus exact canonical policy buckets for
+    [Capacity_backpressure] and [Provider_attempt_effect_fenced], and returns
+    the first match.
     Only canonical producer wire forms select specialized buckets. The order
     remains load-bearing for canonical overlaps; see the [.ml] for the ranked
     list.
@@ -69,6 +70,12 @@ type t =
       {!Keeper_internal_error.incomplete_tool_transcript_kind}. Provider
       dispatch did not occur; automatic retry is forbidden until an operator
       resets the corrupted checkpoint. *)
+  | Provider_attempt_effect_fenced of string
+  (** Exact canonical wire
+      {!Keeper_internal_error.provider_attempt_effect_fenced_kind}. A provider
+      attempt may have crossed an effect boundary, so same-turn replay is
+      forbidden and the operator-facing receipt must retain an explicit alert
+      rather than treating it as an unmapped internal state. *)
   | Internal_error of string
   (** Exact wire ["internal_error"]. Payload is the original
           string, carried only for [to_wire] round-trip fidelity. *)

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -86,6 +86,9 @@ type store_state =
   }
 
 let store_state = Atomic.make { store = None; configured = None }
+let committed_revision_ref = Atomic.make 0
+
+let committed_revision () = Atomic.get committed_revision_ref
 
 type append_entry =
   { store : Dated_jsonl.t
@@ -171,6 +174,7 @@ let init ?cluster_name ~base_path () =
 
 let reset_for_testing () =
   Atomic.set store_state { store = None; configured = None };
+  Atomic.set committed_revision_ref 0;
   Atomic.set async_append_active false;
   Atomic.set append_queue_dropped 0;
   with_append_queue_lock (fun () -> Stdlib.Queue.clear append_queue);
@@ -262,6 +266,7 @@ let record_unavailable_coverage_gap ~keeper_name ~tool_name ?trace_id () =
 let append_to_store_result (entry : append_entry) =
   try
     Dated_jsonl.append entry.store entry.json;
+    ignore (Atomic.fetch_and_add committed_revision_ref 1 : int);
     Ok ()
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -388,6 +393,13 @@ let blob_aware_output_json (output : string) : Yojson.Safe.t =
   | Tool_output.Not_marker | Tool_output.Invalid_marker _ -> `String output
 ;;
 
+let normalized_artifact_refs_in_typed_data data =
+  Tool_output.normalized_artifact_refs_in_json data
+  |> List.map (fun reference ->
+    Tool_output.with_preview reference ""
+    |> Tool_output.normalized_artifact_ref_to_json)
+;;
+
 let input_to_json (input : Yojson.Safe.t) : Yojson.Safe.t =
   (* Per-leaf marker-aware truncation. Previously
      [String.sub (Yojson.Safe.to_string input) 0 (max - suffix)] chopped
@@ -421,6 +433,12 @@ let log_call
       ?batch_index
       ?batch_size
       ?execution_mode
+      ?typed_result
+      ?composition_tool
+      ?composition_run_id
+      ?composition_node_id
+      ?composition_execution
+      ?parent_tool_use_id
       ?trace_id
       ?session_id
       ?generation
@@ -464,6 +482,15 @@ let log_call
         match result_bytes with
         | Some n -> [ "result_bytes", `Int n ]
         | None -> []
+      in
+      (* The dated log itself clamps [output_text] to [max_output_len].  Derive
+         the observation truncation marker here when callers supplied exact
+         producer bytes but no stricter upstream clamp.  This keeps direct and
+         composed invocations on the same metric contract. *)
+      let truncated_to =
+        match truncated_to, result_bytes with
+        | None, Some n when n > max_output_len -> Some max_output_len
+        | explicit, _ -> explicit
       in
       let truncated_to_field =
         match truncated_to with
@@ -535,6 +562,36 @@ let log_call
         | Some value ->
           [ ( "execution_mode"
             , Agent_core.Tool_contract.execution_mode_to_yojson value ) ]
+        | None -> []
+      in
+      let typed_result_fields =
+        match typed_result with
+        | Some result ->
+          let artifact_refs =
+            normalized_artifact_refs_in_typed_data (Tool_result.data result)
+          in
+          [ "disposition", `String (Tool_result.string_of_disposition result) ]
+          @ (if artifact_refs = []
+             then []
+             else [ "artifact_refs", `List artifact_refs ])
+        | None -> []
+      in
+      let composition_fields =
+        [ "composition_tool", composition_tool
+        ; "composition_run_id", composition_run_id
+        ; "composition_node_id", composition_node_id
+        ; "parent_tool_use_id", parent_tool_use_id
+        ]
+        |> List.filter_map (fun (key, value) ->
+          Option.map (fun value -> key, `String value) value)
+      in
+      let composition_execution_field =
+        match composition_execution with
+        | Some value ->
+          [ ( "composition_execution"
+            , `String
+                (Keeper_tool_composition_catalog.execution_mode_to_string value) )
+          ]
         | None -> []
       in
       let session_id_field =
@@ -644,6 +701,9 @@ let log_call
            @ batch_index_field
            @ batch_size_field
            @ execution_mode_field
+           @ typed_result_fields
+           @ composition_fields
+           @ composition_execution_field
            @ trace_id_field
            @ session_id_field
            @ generation_field

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -130,6 +130,11 @@ val configured_masc_root : unit -> string option
     [init], even if the store failed to open. Runtime sidecars use this to
     keep their durable projections in the same cluster namespace. *)
 
+val committed_revision : unit -> int
+(** Monotonic in-process revision advanced exactly after each successful
+    durable tool-call append. Readers use it to invalidate derived caches
+    without making the persistence owner depend on a dashboard module. *)
+
 val log_call :
   keeper_name:string ->
   tool_name:string ->
@@ -150,6 +155,12 @@ val log_call :
   ?batch_index:int ->
   ?batch_size:int ->
   ?execution_mode:Agent_core.Tool_contract.execution_mode ->
+  ?typed_result:Tool_result.result ->
+  ?composition_tool:string ->
+  ?composition_run_id:string ->
+  ?composition_node_id:string ->
+  ?composition_execution:Keeper_tool_composition_catalog.execution_mode ->
+  ?parent_tool_use_id:string ->
   ?trace_id:string ->
   ?session_id:string ->
   ?generation:int ->
@@ -177,6 +188,15 @@ val log_call :
     [planned_index], so they are persisted unchanged. [batch_index],
     [batch_size], and [execution_mode] preserve Agent Core's actual schedule
     rather than inferring concurrency from timing.
+    [typed_result] serializes the producer-owned disposition when it is
+    available. Any canonical normalized artifact references in its typed data
+    are also persisted as actual JSON under [artifact_refs], keeping the
+    content-addressed blobs visible to offline maintenance without parsing a
+    JSON-bearing model-output string. Those GC roots deliberately carry an
+    empty preview; model/UI preview projection remains owned by [output]. The
+    composition fields are an explicit observation envelope supplied by the
+    typed plan executor; readers must not reconstruct them from [tool_use_id]
+    or tool-name strings.
     [on_committed], when supplied, forces this row through the synchronous
     append boundary and runs only after that append succeeds. It is intended
     for exact completion notifications whose readers must not race the

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -753,20 +753,33 @@ let parse_result ~expected_session_id ~rate_limit ~tool_effect_attempted
          context-window rejection ("Prompt is too long" / "Input is too long
          for requested model", either status, or a 413 naming the window). A
          frame that carries the verdict is authoritative in both directions,
-         like the codex lane's [codexErrorInfo]. Frames from CLIs that predate
-         the enum carry no [terminal_reason]; only those fall back to the
-         historical exact-prefix 400, unchanged in scope (RFC amendment
-         2026-08-12). *)
+         like the codex lane's [codexErrorInfo]. Frames that omit the enum
+         carry no [terminal_reason]; only those fall back to the compatibility
+         evidence below. The exact statusless sentence is the live Claude Code
+         2.1.232 wire; older verbose frames retain the
+         historical exact-prefix 400 rule (RFC amendment 2026-08-12). *)
       match terminal_reason with
       | Some reason -> String.equal reason "prompt_too_long"
       | None ->
-        Option.equal Int.equal api_error_status (Some 400)
-        && Option.exists
-             (fun detail ->
-                String.starts_with
-                  ~prefix:"Prompt is too long"
-                  (String.trim detail))
-             result
+        let canonical_statusless_rejection =
+          (* Live Claude Code 2.1.232 emitted the canonical provider verdict
+             with neither [terminal_reason] nor [api_error_status]. Admit that
+             exact wire sentence only; do not infer overflow from arbitrary
+             prose that merely contains it. *)
+          Option.is_none api_error_status
+          && Option.exists
+               (fun detail -> String.equal (String.trim detail) "Prompt is too long")
+               result
+        in
+        canonical_statusless_rejection
+        ||
+        (Option.equal Int.equal api_error_status (Some 400)
+         && Option.exists
+              (fun detail ->
+                 String.starts_with
+                   ~prefix:"Prompt is too long"
+                   (String.trim detail))
+              result)
     in
     if structurally_quota_blocked
     then Error (Quota_blocked { api_error_status; rate_limit })

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -80,10 +80,24 @@ type turn_result =
   ; usage : turn_usage option
   }
 
+type terminal_boundary_outcome = Runtime_official_client_tool.terminal_boundary_outcome =
+  | Terminal_completed
+  | Durable_stimulus_deferred
+  | External_effect_deferred
+  | Terminal_failed of
+      { failure_class : Tool_result.tool_failure_class
+      ; effect_disposition : Tool_result.failure_effect_disposition
+      ; diagnostic : string
+      }
+
 type host_stop = Runtime_official_client_tool.host_stop =
   | Repeated_tool_call of
       { tool_name : string
       ; repeated_count : int
+      }
+  | Terminal_tool_boundary of
+      { tool_name : string
+      ; outcome : terminal_boundary_outcome
       }
 
 type dynamic_tool_result = Runtime_official_client_tool.dynamic_tool_result =
@@ -185,6 +199,8 @@ let error_to_string = function
       "Claude Code stopped after repeated tool call: tool=%s count=%d"
       tool_name
       repeated_count
+  | Stopped_by_host (Terminal_tool_boundary { tool_name; _ }) ->
+    Printf.sprintf "Claude Code stopped at terminal tool boundary: tool=%s" tool_name
   | Quota_blocked { api_error_status; rate_limit } ->
     let status =
       Option.fold

--- a/lib/runtime/runtime_claude_code.mli
+++ b/lib/runtime/runtime_claude_code.mli
@@ -66,10 +66,24 @@ type turn_result =
   ; usage : turn_usage option
   }
 
+type terminal_boundary_outcome = Runtime_official_client_tool.terminal_boundary_outcome =
+  | Terminal_completed
+  | Durable_stimulus_deferred
+  | External_effect_deferred
+  | Terminal_failed of
+      { failure_class : Tool_result.tool_failure_class
+      ; effect_disposition : Tool_result.failure_effect_disposition
+      ; diagnostic : string
+      }
+
 type host_stop = Runtime_official_client_tool.host_stop =
   | Repeated_tool_call of
       { tool_name : string
       ; repeated_count : int
+      }
+  | Terminal_tool_boundary of
+      { tool_name : string
+      ; outcome : terminal_boundary_outcome
       }
 
 type dynamic_tool_result = Runtime_official_client_tool.dynamic_tool_result =

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -61,10 +61,24 @@ type turn_result =
   ; resumed : bool
   }
 
+type terminal_boundary_outcome = Runtime_official_client_tool.terminal_boundary_outcome =
+  | Terminal_completed
+  | Durable_stimulus_deferred
+  | External_effect_deferred
+  | Terminal_failed of
+      { failure_class : Tool_result.tool_failure_class
+      ; effect_disposition : Tool_result.failure_effect_disposition
+      ; diagnostic : string
+      }
+
 type host_stop = Runtime_official_client_tool.host_stop =
   | Repeated_tool_call of
       { tool_name : string
       ; repeated_count : int
+      }
+  | Terminal_tool_boundary of
+      { tool_name : string
+      ; outcome : terminal_boundary_outcome
       }
 
 type dynamic_tool_result = Runtime_official_client_tool.dynamic_tool_result =
@@ -170,6 +184,8 @@ let error_to_string = function
       "Codex app-server stopped after repeated tool call: tool=%s count=%d"
       tool_name
       repeated_count
+  | Stopped_by_host (Terminal_tool_boundary { tool_name; _ }) ->
+    Printf.sprintf "Codex app-server stopped at terminal tool boundary: tool=%s" tool_name
   | Turn_interrupted -> "Codex app-server turn was interrupted"
   | Process_exited detail -> "Codex app-server exited before completion: " ^ detail
   | Timeout { seconds; turn_accepted } ->

--- a/lib/runtime/runtime_codex_app_server.mli
+++ b/lib/runtime/runtime_codex_app_server.mli
@@ -49,10 +49,24 @@ type turn_result =
   ; resumed : bool
   }
 
+type terminal_boundary_outcome = Runtime_official_client_tool.terminal_boundary_outcome =
+  | Terminal_completed
+  | Durable_stimulus_deferred
+  | External_effect_deferred
+  | Terminal_failed of
+      { failure_class : Tool_result.tool_failure_class
+      ; effect_disposition : Tool_result.failure_effect_disposition
+      ; diagnostic : string
+      }
+
 type host_stop = Runtime_official_client_tool.host_stop =
   | Repeated_tool_call of
       { tool_name : string
       ; repeated_count : int
+      }
+  | Terminal_tool_boundary of
+      { tool_name : string
+      ; outcome : terminal_boundary_outcome
       }
 
 type dynamic_tool_result = Runtime_official_client_tool.dynamic_tool_result =

--- a/lib/runtime/runtime_official_client_tool.ml
+++ b/lib/runtime/runtime_official_client_tool.ml
@@ -1,7 +1,21 @@
+type terminal_boundary_outcome =
+  | Terminal_completed
+  | Durable_stimulus_deferred
+  | External_effect_deferred
+  | Terminal_failed of
+      { failure_class : Tool_result.tool_failure_class
+      ; effect_disposition : Tool_result.failure_effect_disposition
+      ; diagnostic : string
+      }
+
 type host_stop =
   | Repeated_tool_call of
       { tool_name : string
       ; repeated_count : int
+      }
+  | Terminal_tool_boundary of
+      { tool_name : string
+      ; outcome : terminal_boundary_outcome
       }
 
 type dynamic_tool_result =

--- a/lib/runtime/runtime_official_client_tool.mli
+++ b/lib/runtime/runtime_official_client_tool.mli
@@ -10,13 +10,29 @@
     here once and the three re-export it by type equation, which makes those
     copies unnecessary rather than merely shorter. *)
 
+type terminal_boundary_outcome =
+  | Terminal_completed
+  | Durable_stimulus_deferred
+  | External_effect_deferred
+  | Terminal_failed of
+      { failure_class : Tool_result.tool_failure_class
+      ; effect_disposition : Tool_result.failure_effect_disposition
+      ; diagnostic : string
+      }
+
 type host_stop =
   | Repeated_tool_call of
       { tool_name : string
       ; repeated_count : int
       }
-(** A host-owned, non-failure terminal that must stop a vendor-owned model
-    loop after the current tool outcome has been returned. *)
+  | Terminal_tool_boundary of
+      { tool_name : string
+      ; outcome : terminal_boundary_outcome
+      }
+(** A host-owned terminal that must stop a vendor-owned model loop after the
+    current tool outcome has been returned. The Keeper bundle remains the
+    authority for terminal effect completion/failure; this value carries only
+    the transport stop reason. *)
 
 type dynamic_tool_result =
   { success : bool

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -310,8 +310,39 @@ module Recovery_for_testing = struct
   let consume_owner_projection_batch = consume_owner_projection_batch
 end
 
+let recover_keeper_msg_requests_on_startup ~base_path =
+  let report = Keeper_msg_async.recover_lost_disk_records ~base_path () in
+  if
+    report.lost > 0
+    || report.finalized > 0
+    || report.cleaned > 0
+    || report.unreadable > 0
+    || report.failed > 0
+    || report.staging_files_deleted > 0
+    || report.staging_files_preserved > 0
+  then
+    Log.Server.info
+      "keeper_msg_async: startup recovery lost=%d finalized=%d cleaned=%d unreadable=%d failed=%d staging_inspected=%d staging_deleted=%d staging_preserved=%d"
+      report.lost
+      report.finalized
+      report.cleaned
+      report.unreadable
+      report.failed
+      report.staging_files_inspected
+      report.staging_files_deleted
+      report.staging_files_preserved;
+  report
+;;
+
 let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_state) =
   let config = Mcp_server.workspace_config state in
+  (* Exclusive startup ownership: before any new server request can submit a
+     worker, settle disk-only nonterminal rows left by the prior process.  Poll
+     and cancel deliberately cannot infer process death, so this bootstrap
+     boundary is the sole production authority for that transition. *)
+  ignore
+    (recover_keeper_msg_requests_on_startup ~base_path:config.base_path
+      : Keeper_msg_async.recovery_report);
   let recovery_ctx : _ Keeper_types_profile.context =
     { config
     ; agent_name = "keeper-maintenance-recovery"

--- a/lib/server/server_bootstrap_maintenance.mli
+++ b/lib/server/server_bootstrap_maintenance.mli
@@ -6,6 +6,11 @@ val wake_enqueue_counts_of_dispatches :
   Schedule_runner.dispatch_result list -> Schedule_runner_status.wake_enqueue_counts
 (** Derive keeper-wake delivery counts from typed production consumer receipts. *)
 
+val recover_keeper_msg_requests_on_startup :
+  base_path:string -> Keeper_msg_async.recovery_report
+(** Settle durable async request rows that cannot have a live owner after a
+    process restart. Called synchronously before background server work starts. *)
+
 val start_background_maintenance :
   sw:Eio.Switch.t ->
   clock:float Eio.Time.clock_ty Eio.Resource.t ->

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -15,6 +15,25 @@ let freshness_slo_s = Server_dashboard_http_core_cache.freshness_slo_s
 let keeper_hot_path_cache_ttl_s = 30.0
 let keeper_composite_cache_ttl_s = 5.0
 
+let tool_calls_fleet_cache_revision_mu = Stdlib.Mutex.create ()
+let tool_calls_fleet_cache_revisions : (string, int) Hashtbl.t = Hashtbl.create 4
+
+let tool_calls_fleet_cache_key ~masc_root =
+  let key = Printf.sprintf "keeper:tool-calls:fleet-rows:%s" masc_root in
+  let revision = Keeper_tool_call_log.committed_revision () in
+  Stdlib.Mutex.protect tool_calls_fleet_cache_revision_mu (fun () ->
+    match Hashtbl.find_opt tool_calls_fleet_cache_revisions masc_root with
+    | Some previous when previous = revision -> ()
+    | Some _ | None ->
+      (* Publish the observed revision only after the old value is gone.
+         Otherwise a concurrent reader can observe the new revision between
+         [replace] and [invalidate], treat the cache as current, and return the
+         stale rows for the full TTL. *)
+      Dashboard_cache.invalidate key;
+      Hashtbl.replace tool_calls_fleet_cache_revisions masc_root revision);
+  key
+;;
+
 (* Bounded dashboard hydration defaults for the operator compaction inspector.
    These cap best-effort filesystem scans; [scan_truncated] in the response makes
    the bound observable when there are more manifest segments than scanned. *)
@@ -1872,7 +1891,7 @@ let handle_keeper_get_subroutes state req request reqd =
       let fleet_rows =
         match
           Dashboard_cache.get_or_compute
-            (Printf.sprintf "keeper:tool-calls:fleet-rows:%s" masc_root)
+            (tool_calls_fleet_cache_key ~masc_root)
             ~ttl:keeper_hot_path_cache_ttl_s (fun () ->
               Domain_pool_ref.submit_cpu_or_inline (fun () ->
                 `List

--- a/lib/server/server_dashboard_http_keeper_api.mli
+++ b/lib/server/server_dashboard_http_keeper_api.mli
@@ -9,6 +9,10 @@
 module Http = Http_server_eio
 (** Alias used internally for the Eio HTTP server module. *)
 
+val tool_calls_fleet_cache_key : masc_root:string -> string
+(** Return the bounded fleet-row cache key after invalidating its cached value
+    when the durable tool-call revision has advanced. *)
+
 (** {1 Trajectory projection} *)
 
 val handle_keeper_catchup_judge_post :

--- a/lib/tool_blob_store/tool_blob_maintenance.ml
+++ b/lib/tool_blob_store/tool_blob_maintenance.ml
@@ -1,5 +1,14 @@
 module String_set = Set_util.StringSet
 
+module Artifact_reference_set = Set.Make (struct
+  type t = Tool_output.artifact_ref
+
+  let compare left right =
+    match String.compare left.Tool_output.sha256 right.Tool_output.sha256 with
+    | 0 -> String.compare left.mime right.mime
+    | order -> order
+end)
+
 type mode =
   | Observe_only
   | Delete_previous_candidates
@@ -26,6 +35,14 @@ type error =
   | Malformed_structured_artifact_reference of
       { path : string
       ; line : int
+      ; detail : string
+      }
+  | Artifact_manifest_read_failed of
+      { sha256 : string
+      ; reason : string
+      }
+  | Artifact_manifest_invalid of
+      { sha256 : string
       ; detail : string
       }
   | Candidate_snapshot_invalid of
@@ -74,6 +91,10 @@ let error_to_string = function
       path
       line
       detail
+  | Artifact_manifest_read_failed { sha256; reason } ->
+    Printf.sprintf "artifact manifest read failed sha256=%s: %s" sha256 reason
+  | Artifact_manifest_invalid { sha256; detail } ->
+    Printf.sprintf "artifact manifest invalid sha256=%s: %s" sha256 detail
   | Candidate_snapshot_invalid { path; detail } ->
     Printf.sprintf "blob maintenance candidate snapshot invalid path=%s: %s" path detail
   | Candidate_snapshot_read_failed { path; detail } ->
@@ -120,7 +141,7 @@ let add_references ~path ~line references text =
       Tool_output.encode_for_agent_core (Tool_output.Stored reference)
     in
     if String.equal text canonical
-    then Ok (String_set.add reference.Tool_output.sha256 references)
+    then Ok (Artifact_reference_set.add reference references)
     else
       Error
         (Malformed_artifact_reference
@@ -136,7 +157,7 @@ let rec references_in_json ~path ~line references = function
   | (`Assoc fields as json) ->
     (match Tool_output.normalized_artifact_ref_of_json json with
      | Tool_output.Decoded_normalized_artifact_ref reference ->
-       Ok (String_set.add reference.Tool_output.sha256 references)
+       Ok (Artifact_reference_set.add reference references)
      | Tool_output.Invalid_normalized_artifact_ref { detail } ->
        Error
          (Malformed_structured_artifact_reference
@@ -181,7 +202,7 @@ let references_in_file ~ownership_root path =
       references_in_json
         ~path
         ~line:1
-        String_set.empty
+        Artifact_reference_set.empty
         (Yojson.Safe.from_string payload)
     with
     | Yojson.Json_error _ ->
@@ -217,7 +238,7 @@ let references_in_file ~ownership_root path =
                         line)
               in
               line_number + 1, next)
-           (1, Ok String_set.empty)
+           (1, Ok Artifact_reference_set.empty)
       |> snd
 ;;
 
@@ -361,7 +382,7 @@ let live_references ~base_path =
       | Unix.S_DIR -> scan_directory path references
       | Unix.S_REG ->
         Result.map
-          (String_set.union references)
+          (Artifact_reference_set.union references)
           (references_in_file ~ownership_root:base_path path)
         | Unix.S_LNK ->
           Error
@@ -401,7 +422,62 @@ let live_references ~base_path =
   |> List.fold_left
        (fun result root ->
           Result.bind result (fun progress -> scan_directory root progress))
-       (Ok String_set.empty)
+       (Ok Artifact_reference_set.empty)
+;;
+
+let expand_artifact_manifests ~store references =
+  let rec expand expanded references = function
+    | [] -> Ok references
+    | reference :: rest
+      when not
+             (String.equal
+                reference.Tool_output.mime
+                Tool_output.artifact_manifest_mime) ->
+      expand expanded references rest
+    | reference :: rest
+      when String_set.mem reference.Tool_output.sha256 expanded ->
+      expand expanded references rest
+    | reference :: rest ->
+      let sha256 = reference.Tool_output.sha256 in
+      let expanded = String_set.add sha256 expanded in
+      (match Tool_blob_store.fetch store ~sha256 with
+       | Error error ->
+         Error
+           (Artifact_manifest_read_failed
+              { sha256; reason = Tool_blob_store.fetch_error_to_string error })
+       | Ok None ->
+         Error
+           (Artifact_manifest_read_failed
+              { sha256; reason = "referenced manifest blob is absent" })
+       | Ok (Some payload) ->
+         let decoded =
+           try
+             Yojson.Safe.from_string payload
+             |> Tool_output.artifact_manifest_of_json
+           with
+           | Yojson.Json_error detail ->
+             Tool_output.Invalid_artifact_manifest { detail }
+         in
+         (match decoded with
+          | Tool_output.Decoded_artifact_manifest { artifact_refs; _ } ->
+            let references, added =
+              List.fold_left
+                (fun (references, added) child ->
+                   if Artifact_reference_set.mem child references
+                   then references, added
+                   else Artifact_reference_set.add child references, child :: added)
+                (references, [])
+                artifact_refs
+            in
+            expand expanded references (List.rev_append added rest)
+          | Tool_output.Not_artifact_manifest ->
+            Error
+              (Artifact_manifest_invalid
+                 { sha256; detail = "manifest MIME requires the canonical schema" })
+          | Tool_output.Invalid_artifact_manifest { detail } ->
+            Error (Artifact_manifest_invalid { sha256; detail })))
+  in
+  expand String_set.empty references (Artifact_reference_set.elements references)
 ;;
 
 let candidate_snapshot_to_json candidates =
@@ -532,7 +608,15 @@ let run ~base_path ~mode =
   let open Result.Syntax in
   let* () = reject_uncoordinated_cluster_roots ~base_path in
   let store = Tool_blob_store.create ~base_path in
-  let* live = live_references ~base_path in
+  let* direct_live = live_references ~base_path in
+  let* live_references = expand_artifact_manifests ~store direct_live in
+  let live =
+    Artifact_reference_set.fold
+      (fun reference hashes ->
+         String_set.add reference.Tool_output.sha256 hashes)
+      live_references
+      String_set.empty
+  in
   let* previous_candidates = load_candidate_snapshot ~base_path in
   let* blob_list =
     match Tool_blob_store.list_all_result store with

--- a/lib/tool_blob_store/tool_blob_maintenance.mli
+++ b/lib/tool_blob_store/tool_blob_maintenance.mli
@@ -3,6 +3,9 @@
     Live references are the union of exact {!Tool_output} markers in the
     closed durable-consumer registry: Keeper state/checkpoints, Gate replay,
     tool-call logs, traces, messages, Keeper chat, and bounded wire captures.
+    A marker whose media type is {!Tool_output.artifact_manifest_mime} adds the
+    manifest's strictly decoded normalized children transitively. No other
+    blob content is parsed or treated as an ownership edge.
     Trajectory previews, repository mirrors, build products, operator config,
     and unrelated observational logs are not blob consumers and are never
     traversed. A new durable consumer must be added to this registry in the
@@ -46,6 +49,14 @@ type error =
   | Malformed_structured_artifact_reference of
       { path : string
       ; line : int
+      ; detail : string
+      }
+  | Artifact_manifest_read_failed of
+      { sha256 : string
+      ; reason : string
+      }
+  | Artifact_manifest_invalid of
+      { sha256 : string
       ; detail : string
       }
   | Candidate_snapshot_invalid of

--- a/lib/tool_blob_store/tool_output.ml
+++ b/lib/tool_blob_store/tool_output.ml
@@ -108,6 +108,96 @@ let normalized_artifact_ref_of_json = function
   | _ -> Not_normalized_artifact_ref
 ;;
 
+let collect_normalized_artifact_refs ~reject_invalid json =
+  let add_reference references reference =
+    if
+      List.exists
+        (fun existing ->
+           String.equal existing.sha256 reference.sha256
+           && String.equal existing.mime reference.mime)
+        references
+    then references
+    else reference :: references
+  in
+  let rec collect references = function
+    | (`Assoc fields as json) ->
+      (match normalized_artifact_ref_of_json json with
+       | Decoded_normalized_artifact_ref reference ->
+         Ok (add_reference references reference)
+       | Invalid_normalized_artifact_ref { detail } when reject_invalid ->
+         Error detail
+       | Invalid_normalized_artifact_ref _ | Not_normalized_artifact_ref ->
+         List.fold_left
+           (fun result (_, value) ->
+              Result.bind result (fun references -> collect references value))
+           (Ok references)
+           fields)
+    | `List values ->
+      List.fold_left
+        (fun result value ->
+           Result.bind result (fun references -> collect references value))
+        (Ok references)
+        values
+    | `String _ | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ ->
+      Ok references
+  in
+  Result.map List.rev (collect [] json)
+;;
+
+let normalized_artifact_refs_in_json json =
+  match collect_normalized_artifact_refs ~reject_invalid:false json with
+  | Ok references -> references
+  | Error _ -> []
+;;
+
+let normalized_artifact_refs_in_json_strict json =
+  collect_normalized_artifact_refs ~reject_invalid:true json
+;;
+
+let artifact_manifest_mime = "application/vnd.masc.tool-result-manifest+json"
+let artifact_manifest_schema = "masc.tool-result-artifact-manifest.v1"
+
+let artifact_manifest_to_json ~content ~structured_content =
+  `Assoc
+    [ "schema", `String artifact_manifest_schema
+    ; "content", `String content
+    ; "structured_content", structured_content
+    ]
+;;
+
+type artifact_manifest_decode =
+  | Not_artifact_manifest
+  | Invalid_artifact_manifest of { detail : string }
+  | Decoded_artifact_manifest of
+      { content : string
+      ; structured_content : Yojson.Safe.t
+      ; artifact_refs : artifact_ref list
+      }
+
+let artifact_manifest_of_json = function
+  | `Assoc
+      [ "schema", `String schema
+      ; "content", `String content
+      ; "structured_content", structured_content
+      ]
+    when String.equal schema artifact_manifest_schema ->
+    (match normalized_artifact_refs_in_json_strict structured_content with
+     | Ok artifact_refs ->
+       Decoded_artifact_manifest
+         { content; structured_content; artifact_refs }
+     | Error detail -> Invalid_artifact_manifest { detail })
+  | `Assoc fields when List.mem_assoc "schema" fields ->
+    (match List.assoc_opt "schema" fields with
+     | Some (`String schema) when not (String.equal schema artifact_manifest_schema) ->
+       Not_artifact_manifest
+     | _ ->
+       Invalid_artifact_manifest
+         { detail =
+             "expected exact fields schema, content, and structured_content"
+         })
+  | _ -> Not_artifact_manifest
+;;
+
 type t =
   | Inline of string
   | Stored of artifact_ref

--- a/lib/tool_blob_store/tool_output.mli
+++ b/lib/tool_blob_store/tool_output.mli
@@ -68,6 +68,45 @@ val normalized_artifact_ref_of_json :
     {!normalized_artifact_ref_to_json}. A malformed wrapper is reported
     explicitly so retention code fails closed. *)
 
+val normalized_artifact_refs_in_json : Yojson.Safe.t -> artifact_ref list
+(** Collect every valid normalized reference nested in typed JSON, deduplicated
+    by content address and declared media type in first-occurrence order.
+    Malformed wrappers are not references; authoritative decoders remain
+    responsible for rejecting them. *)
+
+val normalized_artifact_refs_in_json_strict :
+  Yojson.Safe.t -> (artifact_ref list, string) result
+(** As {!normalized_artifact_refs_in_json}, but reject the first malformed
+    reserved [_blob] wrapper. Durable manifest producers and consumers must
+    use this form so they share one closed validity contract. *)
+
+(** {1 Durable result manifests}
+
+    A tool result that itself contains normalized artifact references is
+    stored as one typed manifest blob. The durable transcript owns the
+    manifest through an exact AGENT_CORE marker, while offline maintenance
+    follows only this explicit MIME/schema edge to the referenced child
+    artifacts. Arbitrary JSON blobs are never traversed. *)
+
+val artifact_manifest_mime : string
+
+val artifact_manifest_to_json :
+  content:string -> structured_content:Yojson.Safe.t -> Yojson.Safe.t
+
+type artifact_manifest_decode =
+  | Not_artifact_manifest
+  | Invalid_artifact_manifest of { detail : string }
+  | Decoded_artifact_manifest of
+      { content : string
+      ; structured_content : Yojson.Safe.t
+      ; artifact_refs : artifact_ref list
+      }
+
+val artifact_manifest_of_json : Yojson.Safe.t -> artifact_manifest_decode
+(** Strictly decode the closed manifest envelope. The decoded child set is
+    derived only from [structured_content] using the normalized reference
+    codec above. *)
+
 (** {1 Wire codec} *)
 
 type t =

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -38,6 +38,88 @@ type externalization_error =
   ; message : string
   }
 
+let artifact_manifest_metadata_key = "masc.artifact_manifest"
+
+let metadata_with_artifact_manifest metadata reference =
+  let manifest = Tool_output.normalized_artifact_ref_to_json reference in
+  match metadata with
+  | None -> `Assoc [ artifact_manifest_metadata_key, manifest ]
+  | Some (`Assoc fields) ->
+    `Assoc
+      ((artifact_manifest_metadata_key, manifest)
+       :: List.remove_assoc artifact_manifest_metadata_key fields)
+  | Some payload ->
+    `Assoc
+      [ artifact_manifest_metadata_key, manifest
+      ; "masc.payload", payload
+      ]
+;;
+
+let artifact_manifest_from_metadata metadata =
+  let rec decode = function
+    | `Assoc fields ->
+      (match List.assoc_opt artifact_manifest_metadata_key fields with
+     | Some json ->
+       (match Tool_output.normalized_artifact_ref_of_json json with
+        | Tool_output.Decoded_normalized_artifact_ref reference
+          when String.equal reference.mime Tool_output.artifact_manifest_mime ->
+          Ok reference
+        | Tool_output.Decoded_normalized_artifact_ref _ ->
+          Error "artifact manifest metadata has the wrong media type"
+        | Tool_output.Not_normalized_artifact_ref ->
+          Error "artifact manifest metadata is not a normalized reference"
+        | Tool_output.Invalid_normalized_artifact_ref { detail } -> Error detail)
+     | None ->
+       (match List.assoc_opt "producer" fields with
+        | Some producer -> decode producer
+        | None ->
+          (match List.assoc_opt "masc.payload" fields with
+           | Some payload -> decode payload
+           | None -> Error "typed artifact result is missing its durable manifest")))
+    | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ ->
+      Error "typed artifact result is missing its durable manifest"
+  in
+  match metadata with
+  | Some metadata -> decode metadata
+  | None -> Error "typed artifact result is missing its durable manifest"
+;;
+
+let attach_artifact_manifest ~base_path (result : Tool_result.result) =
+  match
+    Tool_output.normalized_artifact_refs_in_json_strict
+      (Tool_result.data result)
+  with
+  | Error message -> Error { kind = Artifact_storage_failure; message }
+  | Ok [] -> Ok result
+  | Ok (_ :: _) ->
+    (try
+       let manifest =
+         Tool_output.artifact_manifest_to_json
+           ~content:(Tool_result.message result)
+           ~structured_content:(Tool_result.data result)
+         |> Yojson.Safe.to_string
+       in
+       let reference =
+         Tool_blob_store.put_durable
+           (Tool_blob_store.create ~base_path)
+           ~bytes:manifest
+           ~mime:Tool_output.artifact_manifest_mime
+         |> fun reference -> Tool_output.with_preview reference ""
+       in
+       Ok
+         (Tool_result.with_metadata
+            (metadata_with_artifact_manifest (Tool_result.metadata result) reference)
+            result)
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       let message = Printexc.to_string exn in
+       Log.Misc.error
+         "tool_bridge: result manifest persistence failed: %s"
+         message;
+       Error { kind = Artifact_storage_failure; message })
+;;
+
 let resolve_blob_store ?base_path () =
   match base_path with
   | None -> None
@@ -167,11 +249,28 @@ let project_result
       ?on_externalization_error
       ~externalization_error_recoverable
       ~model_projection
+      ~structured_content
+      ~metadata
       message
       on_content
   : Agent_core.Types.tool_result
   =
-  match project_content ?base_path ~model_projection message with
+  let project () = project_content ?base_path ~model_projection message in
+  let projected =
+    match Tool_output.normalized_artifact_refs_in_json structured_content with
+    | [] -> project ()
+    | _ :: _ when Option.is_none base_path -> project ()
+    | _ :: _ ->
+      (match Tool_output.normalized_artifact_refs_in_json_strict structured_content with
+       | Error message -> Error { kind = Artifact_storage_failure; message }
+       | Ok [] -> Error { kind = Artifact_storage_failure; message = "typed artifact result lost its normalized references" }
+       | Ok (_ :: _) ->
+         (match artifact_manifest_from_metadata metadata with
+          | Ok reference ->
+            Ok (Tool_output.encode_for_agent_core (Tool_output.Stored reference))
+          | Error message -> Error { kind = Artifact_storage_failure; message }))
+  in
+  match projected with
   | Ok content -> on_content content
   | Error error ->
     Option.iter (fun observe -> observe error) on_externalization_error;
@@ -195,6 +294,8 @@ let to_agent_core_typed_result
       ?on_externalization_error
       ~externalization_error_recoverable
       ~model_projection
+      ~structured_content:(Tool_result.data tr)
+      ~metadata:(Tool_result.metadata tr)
       (Tool_result.message tr)
       (fun content ->
          Ok { Agent_core.Types.content; _meta = output.metadata })
@@ -213,6 +314,8 @@ let to_agent_core_typed_result
       ?on_externalization_error
       ~externalization_error_recoverable
       ~model_projection
+      ~structured_content:(Tool_result.data tr)
+      ~metadata:(Tool_result.metadata tr)
       (Tool_result.message tr)
       (fun content ->
          Ok { Agent_core.Types.content; _meta = Some metadata })
@@ -233,6 +336,8 @@ let to_agent_core_typed_result
       ?on_externalization_error
       ~externalization_error_recoverable
       ~model_projection
+      ~structured_content:(Tool_result.data tr)
+      ~metadata:(Tool_result.metadata tr)
       message
       (fun message ->
        make_tool_error

--- a/lib/tool_bridge.mli
+++ b/lib/tool_bridge.mli
@@ -37,6 +37,15 @@ type externalization_error =
   ; message : string
   }
 
+val attach_artifact_manifest :
+  base_path:string ->
+  Tool_result.result ->
+  (Tool_result.result, externalization_error) result
+(** Persist and attach the canonical manifest for typed result data containing
+    normalized artifact references. Producers call this inside their effect
+    boundary, before returning the authoritative result. Results without
+    artifact references pass through unchanged. Cancellation propagates. *)
+
 val maybe_externalize :
   ?base_path:string ->
   ?mime:string ->
@@ -63,7 +72,14 @@ val to_agent_core_typed_result :
     to AGENT_CORE [recoverable]/[error_class]. [on_externalization_error] lets an
     owning runtime keep its terminal state consistent when storage fails.
     [externalization_error_recoverable] projects the owning tool's existing
-    retry policy; the provider receives only a bounded generic error. *)
+    retry policy; the provider receives only a bounded generic error.
+
+    When typed result data contains normalized artifact references, the
+    producer must first call {!attach_artifact_manifest}; the provider-facing
+    content then becomes that durable manifest's marker. Projection performs
+    no manifest I/O after the producer's effect boundary. This keeps the
+    transcript itself as the authoritative root while preserving the original
+    content and structured data inside the manifest. *)
 
 (** {1 Schema Conversion} *)
 

--- a/scripts/ci/run-keeper-realworld-acceptance.sh
+++ b/scripts/ci/run-keeper-realworld-acceptance.sh
@@ -96,6 +96,8 @@ mkdir -p "$OUTPUT_DIR" "$base_path/.masc/config"
 cp "$ROOT_DIR/config/runtime.toml" "$base_path/.masc/config/runtime.toml"
 cp "$ROOT_DIR/config/agent-core-models-overlay.toml" \
   "$base_path/.masc/config/agent-core-models-overlay.toml"
+cp "$ROOT_DIR/scripts/fixtures/keeper-multi-collaboration/tool-compositions.toml" \
+  "$base_path/.masc/config/tool-compositions.toml"
 cp "$MANIFEST" "$OUTPUT_DIR/runtime-artifact-manifest.json"
 
 server_log="$OUTPUT_DIR/server.log"
@@ -179,6 +181,7 @@ common_args=(
   --expected-base-path "$base_path"
   --expected-source-sha "$EXPECTED_SHA"
   --timeout "$TURN_TIMEOUT_SEC"
+  --browser-proof-script "$ROOT_DIR/dashboard/e2e/keeper-composition-real-backend.mjs"
 )
 
 python3 "$ROOT_DIR/scripts/harness/workload/keeper_multi_collaboration_acceptance.py" \

--- a/scripts/fixtures/keeper-multi-collaboration/missions.json
+++ b/scripts/fixtures/keeper-multi-collaboration/missions.json
@@ -40,7 +40,10 @@
     "masc_board_post",
     "masc_goal_list",
     "masc_fusion",
-    "masc_schedule_get"
+    "masc_schedule_get",
+    "keeper_compose_mission-snapshot",
+    "keeper_compose_background-snapshot",
+    "keeper_composition_status"
   ],
   "missions": [
     {
@@ -202,6 +205,43 @@
       "user_story": "Goal, Task, Board, Schedule, Fusion, IDE, Memory 결과가 하나의 mission id와 source SHA로 다시 검증된다.",
       "assertions": ["correlation_marker_complete", "artifact_bundle_complete"],
       "evidence": ["bundle.json", "bundle.md", "raw/*.json"]
+    },
+    {
+      "id": "RW17",
+      "phase": "tool_composition",
+      "name": "typed_inline_and_async_tool_composition",
+      "actors": ["coordinator", "builder-a", "builder-b", "reviewer", "researcher"],
+      "capabilities": ["Tool", "Parallel Tool", "Async Tool", "Batch Tool", "TOML", "Dashboard", "Observability"],
+      "user_story": "TOML로 선언한 합성 도구가 실제 Keeper turn에서 병렬 read batch, 순차 typed dataflow, durable async 실행을 수행하고 각 action의 정확한 입출력과 실행 맥락을 Dashboard store에 남긴다.",
+      "assertions": [
+        "composition_inline_observed",
+        "composition_parallel_schedule_observed",
+        "composition_sequential_dataflow_observed",
+        "composition_async_observed",
+        "composition_turn_context_observed",
+        "composition_dashboard_browser_observed"
+      ],
+      "evidence": ["observations/tool-calls-*.json", "turns/parallel-*.json", "browser/keeper-composition-inspector.json", "browser/keeper-composition-inspector.png"]
+    },
+    {
+      "id": "RW18",
+      "phase": "long_continuity",
+      "name": "same_keeper_eleven_linked_turn_restart_recall",
+      "actors": ["coordinator"],
+      "capabilities": ["MultiTurn", "Memory", "Context", "Restart", "Tool Composition"],
+      "user_story": "같은 Keeper가 서로 다른 runtime turn identity를 가진 11개 요청 turn을 순서대로 완료하고 첫 turn의 secret을 반복 입력받지 않은 채 중간 Board 연쇄와 재시작 뒤 기억을 복원한다.",
+      "assertions": ["same_keeper_eleven_linked_turns", "context_secret_recalled"],
+      "evidence": ["turns/continuity-*.json", "turns/context-after-restart.json", "observations/board-post.json"]
+    },
+    {
+      "id": "RW19",
+      "phase": "persistence_observability",
+      "name": "durable_turn_span_dashboard_projection",
+      "actors": ["coordinator", "builder-a", "builder-b", "reviewer", "researcher"],
+      "capabilities": ["Keeper", "Dashboard", "Observability", "Persistence"],
+      "user_story": "Verification 화면이 격리된 5-Keeper fleet의 decision-log durable turn span을 1h, 2h, 4h, 24h tier별 pass, warn, fail 상태와 함께 실제 backend 응답 그대로 표시하며 이를 무중단 uptime으로 과장하지 않는다.",
+      "assertions": ["persistence_tiers_dashboard_projection_observed"],
+      "evidence": ["browser/keeper-persistence-proof.json", "browser/keeper-persistence-proof.png"]
     }
   ]
 }

--- a/scripts/fixtures/keeper-multi-collaboration/tool-compositions.toml
+++ b/scripts/fixtures/keeper-multi-collaboration/tool-compositions.toml
@@ -1,0 +1,57 @@
+[[compositions]]
+name = "mission-snapshot"
+description = "Read clock, board, and tool state concurrently, then search durable memory with the exact clock output."
+execution = "inline"
+
+[[compositions.nodes]]
+id = "clock"
+tool = "keeper_time_now"
+[compositions.nodes.input]
+kind = "literal"
+value = {}
+
+[[compositions.nodes]]
+id = "board"
+tool = "masc_board_stats"
+[compositions.nodes.input]
+kind = "literal"
+value = {}
+
+[[compositions.nodes]]
+id = "board-peer"
+tool = "masc_board_stats"
+[compositions.nodes.input]
+kind = "literal"
+value = {}
+
+[[compositions.nodes]]
+id = "memory"
+tool = "keeper_memory_search"
+after = ["clock"]
+[compositions.nodes.input]
+kind = "object"
+[[compositions.nodes.input.fields]]
+name = "query"
+[compositions.nodes.input.fields.value]
+kind = "output"
+node = "clock"
+pointer = "/now_iso"
+
+[[compositions]]
+name = "background-snapshot"
+description = "Collect independent clock and board state through the durable async broker."
+execution = "async"
+
+[[compositions.nodes]]
+id = "clock"
+tool = "keeper_time_now"
+[compositions.nodes.input]
+kind = "literal"
+value = {}
+
+[[compositions.nodes]]
+id = "board"
+tool = "masc_board_stats"
+[compositions.nodes.input]
+kind = "literal"
+value = {}

--- a/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
+++ b/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
@@ -76,6 +76,14 @@ KNOWN_ASSERTIONS = {
     "all_surfaces_observed",
     "correlation_marker_complete",
     "artifact_bundle_complete",
+    "same_keeper_eleven_linked_turns",
+    "composition_inline_observed",
+    "composition_parallel_schedule_observed",
+    "composition_sequential_dataflow_observed",
+    "composition_async_observed",
+    "composition_turn_context_observed",
+    "composition_dashboard_browser_observed",
+    "persistence_tiers_dashboard_projection_observed",
 }
 
 
@@ -139,6 +147,101 @@ def sha256_file(path: pathlib.Path) -> str:
     return digest.hexdigest()
 
 
+def validate_persistence_browser_evidence(
+    proof: Any,
+    screenshot_path: pathlib.Path,
+    expected_keepers: set[str],
+) -> tuple[bool, str]:
+    errors: list[str] = []
+    if not isinstance(proof, dict):
+        return False, "persistence browser proof is not an object"
+    if proof.get("schema") != "masc.keeper_persistence_browser_evidence.v1":
+        errors.append("schema mismatch")
+    generated_at = proof.get("generated_at")
+    if not isinstance(generated_at, str) or not generated_at:
+        errors.append("generated_at is absent")
+    else:
+        try:
+            dt.datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
+        except ValueError:
+            errors.append("generated_at is invalid")
+    if proof.get("interaction") != "manual_refresh":
+        errors.append("manual refresh was not observed")
+    if not expected_keepers:
+        errors.append("expected Keeper fleet is absent")
+    tiers = proof.get("tiers")
+    if not isinstance(tiers, list) or len(tiers) != 4:
+        errors.append("duration tiers must be an exact four-element list")
+        tiers = []
+    if all(isinstance(tier, dict) for tier in tiers):
+        if [tier.get("id") for tier in tiers] != ["1h", "2h", "4h", "24h"]:
+            errors.append("duration tier ids are not exact and ordered")
+        previous_observed: set[str] | None = None
+        previous_missing: set[str] | None = None
+        for tier in tiers:
+            status = tier.get("status")
+            evidence_kind = tier.get("evidence_kind")
+            observed_count = tier.get("observed_count")
+            keeper_count = tier.get("keeper_count")
+            missing_count = tier.get("missing_count")
+            observed_names = tier.get("observed_keepers")
+            missing_names = tier.get("missing_keepers")
+            if status not in {"pass", "warn", "fail"}:
+                errors.append(f"tier {tier.get('id')} status is invalid")
+            if evidence_kind != "durable_turn_span":
+                errors.append(f"tier {tier.get('id')} evidence kind is invalid")
+            counts = (observed_count, keeper_count, missing_count)
+            if not all(type(value) is int and value >= 0 for value in counts):
+                errors.append(f"tier {tier.get('id')} counts are invalid")
+                continue
+            if not isinstance(observed_names, list) or not isinstance(missing_names, list):
+                errors.append(f"tier {tier.get('id')} Keeper identities are absent")
+                continue
+            if not all(isinstance(name, str) and bool(name.strip()) for name in observed_names + missing_names):
+                errors.append(f"tier {tier.get('id')} Keeper identities are invalid")
+                continue
+            observed = set(observed_names)
+            missing = set(missing_names)
+            if len(observed) != len(observed_names) or len(missing) != len(missing_names):
+                errors.append(f"tier {tier.get('id')} Keeper identities contain duplicates")
+            if observed & missing or observed | missing != expected_keepers:
+                errors.append(f"tier {tier.get('id')} does not describe the exact run fleet")
+            if len(observed) != observed_count or len(missing) != missing_count:
+                errors.append(f"tier {tier.get('id')} counts do not match identities")
+            if observed_count + missing_count != keeper_count or keeper_count != len(expected_keepers):
+                errors.append(f"tier {tier.get('id')} Keeper total is inconsistent")
+            derived_status = (
+                "fail"
+                if keeper_count == 0 or observed_count == 0
+                else "pass"
+                if observed_count == keeper_count
+                else "warn"
+            )
+            if status != derived_status:
+                errors.append(f"tier {tier.get('id')} status disagrees with counts")
+            if previous_observed is not None and previous_missing is not None and (
+                not observed <= previous_observed or not missing >= previous_missing
+            ):
+                errors.append(f"tier {tier.get('id')} violates duration monotonicity")
+            previous_observed = observed
+            previous_missing = missing
+    elif tiers:
+        errors.append("duration tiers contain non-object values")
+    screenshot_digest = proof.get("screenshot_sha256")
+    if proof.get("screenshot_file") != "keeper-persistence-proof.png":
+        errors.append("screenshot filename is invalid")
+    if not isinstance(screenshot_digest, str) or re.fullmatch(r"[0-9a-f]{64}", screenshot_digest) is None:
+        errors.append("screenshot digest is invalid")
+    elif not screenshot_path.is_file():
+        errors.append("screenshot is absent")
+    else:
+        if sha256_file(screenshot_path) != screenshot_digest:
+            errors.append("screenshot digest mismatch")
+        if proof.get("screenshot_bytes") != screenshot_path.stat().st_size:
+            errors.append("screenshot byte count mismatch")
+    return not errors, "; ".join(errors) if errors else "exact refreshed persistence projection and screenshot verified"
+
+
 def source_sha() -> str:
     try:
         return subprocess.check_output(
@@ -156,6 +259,14 @@ def parse_json_maybe(text: str) -> Any:
     if isinstance(value, dict) and value.get("result") is not None:
         return value["result"]
     return value
+
+
+def parse_json_exact(text: str) -> Any:
+    """Decode the tool's exact JSON envelope without unwrapping its result field."""
+    try:
+        return json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        return text
 
 
 def text_contains(value: Any, needle: str) -> bool:
@@ -352,12 +463,12 @@ def load_catalog(path: pathlib.Path) -> dict[str, Any]:
     if catalog.get("schema") != "masc.keeper_multi_collaboration_missions.v1":
         raise AcceptanceError("mission catalog schema mismatch")
     missions = catalog.get("missions")
-    if not isinstance(missions, list) or len(missions) != 16:
-        raise AcceptanceError("mission catalog must contain exactly 16 missions")
+    if not isinstance(missions, list) or len(missions) != 19:
+        raise AcceptanceError("mission catalog must contain exactly 19 missions")
     ids = [mission.get("id") for mission in missions]
-    expected_ids = [f"RW{index:02d}" for index in range(1, 17)]
+    expected_ids = [f"RW{index:02d}" for index in range(1, 20)]
     if ids != expected_ids:
-        raise AcceptanceError("mission ids must be ordered exactly RW01 through RW16")
+        raise AcceptanceError("mission ids must be ordered exactly RW01 through RW19")
     roles = catalog.get("roles")
     if not isinstance(roles, list) or set(roles) != EXPECTED_ROLES:
         raise AcceptanceError("catalog must define the exact five collaboration roles")
@@ -495,6 +606,9 @@ class MissionRun:
         timeout: float,
         run_id: str,
         runtime_id: str | None,
+        token_file: pathlib.Path,
+        browser_proof_script: pathlib.Path,
+        expected_base_path: str,
     ) -> None:
         self.catalog = catalog
         self.client = client
@@ -506,6 +620,9 @@ class MissionRun:
         self.slug = safe_slug(run_id, 16)
         self.marker = f"keeper-collab-{self.slug}"
         self.runtime_id = runtime_id
+        self.token_file = token_file
+        self.browser_proof_script = browser_proof_script
+        self.expected_base_path = expected_base_path
         self.secret = f"memory-{uuid.uuid4().hex[:12]}"
         self.goal_id = f"goal-{self.marker}"
         self.schedule_id = f"schedule-{self.marker}"
@@ -520,6 +637,9 @@ class MissionRun:
         self.turns: dict[str, TurnObservation] = {}
         self.statuses: dict[str, Any] = {}
         self.observations: dict[str, ToolObservation] = {}
+        self.tool_call_rows: dict[str, list[dict[str, Any]]] = {}
+        self.browser_proof: dict[str, Any] = {}
+        self.persistence_browser_proof: dict[str, Any] = {}
 
     def call(self, label: str, tool: str, arguments: dict[str, Any]) -> ToolObservation:
         observation = self.client.call_tool(tool, arguments)
@@ -530,6 +650,24 @@ class MissionRun:
         client = McpClient(self.endpoint, self.token, self.timeout)
         client.initialize()
         return client
+
+    def dashboard_get(self, path: str) -> dict[str, Any]:
+        parsed = urllib.parse.urlparse(self.endpoint)
+        url = urllib.parse.urlunparse(
+            (parsed.scheme, parsed.netloc, path, "", "", "")
+        )
+        headers = {"Accept": "application/json"}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        request = urllib.request.Request(url, headers=headers, method="GET")
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                value = json.loads(response.read().decode("utf-8"))
+        except (urllib.error.HTTPError, urllib.error.URLError, json.JSONDecodeError) as error:
+            raise AcceptanceError(f"Dashboard GET {path} failed: {error}") from error
+        if not isinstance(value, dict):
+            raise AcceptanceError(f"Dashboard GET {path} returned a non-object payload")
+        return value
 
     def role_instructions(self, role: str) -> str:
         shared = (
@@ -603,7 +741,7 @@ class MissionRun:
                 "id": self.goal_id,
                 "title": f"Multi-Keeper real-world mission {self.marker}",
                 "metric": "correlated product outcomes",
-                "target_value": "16/16 missions",
+                "target_value": f"{len(self.catalog['missions'])}/{len(self.catalog['missions'])} missions",
                 "priority": 1,
             },
         )
@@ -785,9 +923,13 @@ class MissionRun:
         return turn
 
     def run_parallel_wave(self, post_id: str) -> None:
+        composition_instruction = (
+            "먼저 keeper_compose_mission-snapshot을 정확히 한 번 호출하고 그 typed 결과를 확인하세요. "
+        )
         prompts = {
             "coordinator": (
-                f"Mission {self.marker}. Board post {post_id}, Goal {self.goal_id}, Schedule "
+                composition_instruction
+                + f"Mission {self.marker}. Board post {post_id}, Goal {self.goal_id}, Schedule "
                 f"{self.schedule_id}를 각각 실제 도구로 읽으세요. mission marker를 가진 별도 Board "
                 "coordination summary post도 하나 생성하세요. "
                 f"keeper_memory_write로 continuity secret {self.secret}를 durable memory에 기록한 뒤, "
@@ -795,7 +937,8 @@ class MissionRun:
                 "다른 Keeper 작업을 기다리며 polling하지 마세요."
             ),
             "builder-a": (
-                f"Mission {self.marker}. exact Task {self.task_ids['builder-a']}를 claim하세요. "
+                composition_instruction
+                + f"Mission {self.marker}. exact Task {self.task_ids['builder-a']}를 claim하세요. "
                 f"Write(tool_write_file)로 playground의 artifacts/{self.marker}-builder-a.md에 "
                 "구체적인 구현 결과를 실제로 쓰고, "
                 f"keeper_ide_annotate로 그 파일 1행을 Task {self.task_ids['builder-a']}와 Goal "
@@ -803,7 +946,8 @@ class MissionRun:
                 f"Board post {post_id}에 BUILDER_A_DONE comment를 남기세요."
             ),
             "builder-b": (
-                f"Mission {self.marker}. exact Task {self.task_ids['builder-b']}를 claim하세요. "
+                composition_instruction
+                + f"Mission {self.marker}. exact Task {self.task_ids['builder-b']}를 claim하세요. "
                 f"Write(tool_write_file)로 playground의 artifacts/{self.marker}-builder-b.md에 "
                 "구체적인 구현 결과를 실제로 쓰고, "
                 f"keeper_ide_annotate로 그 파일 1행을 Task {self.task_ids['builder-b']}와 Goal "
@@ -811,15 +955,21 @@ class MissionRun:
                 f"Board post {post_id}에 BUILDER_B_DONE comment를 남기세요."
             ),
             "reviewer": (
-                f"Mission {self.marker}. Board post {post_id}와 Goal {self.goal_id}, active Tasks를 읽고 "
+                composition_instruction
+                + f"Mission {self.marker}. Board post {post_id}와 Goal {self.goal_id}, active Tasks를 읽고 "
                 f"post {post_id}에 REVIEWER_OBSERVED라는 독립 review comment를 남기세요. "
                 "다른 Keeper playground 파일은 직접 읽지 마세요."
             ),
             "researcher": (
-                f"Mission {self.marker}. masc_fusion으로 'How should five resident agents preserve "
-                "progress when one work source fails?'를 비동기로 시작하세요. 기다리거나 polling하지 말고 "
+                composition_instruction
+                + "keeper_compose_background-snapshot을 정확히 한 번 제출하고 request_id를 보존하세요. "
+                + f"Mission {self.marker}. masc_fusion으로 'How should five resident agents preserve "
+                "progress when one work source fails?'를 비동기로 시작하세요. Fusion을 기다리거나 polling하지 말고 "
                 f"즉시 exact Task {self.task_ids['researcher']}를 claim하고, Board post {post_id}에 "
-                "FUSION_STARTED와 run_id를 comment한 뒤 Task evidence를 제출하세요."
+                "FUSION_STARTED와 run_id를 comment한 뒤 Task evidence를 제출하세요. 마지막으로 보존한 "
+                "request_id로 keeper_composition_status를 호출하세요. status가 queued 또는 running이면 "
+                "동일한 request_id만 사용해 터미널 상태가 될 때까지 상태를 다시 확인하고, "
+                "done이 되면 즉시 중단하세요. 외부 composition을 다시 제출하지 마세요."
             ),
         }
         with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
@@ -829,6 +979,68 @@ class MissionRun:
             }
             for future in concurrent.futures.as_completed(futures):
                 future.result()
+
+    def run_continuity_chain(self, post_id: str) -> None:
+        for step in range(1, 10):
+            previous = "COORDINATOR_READY" if step == 1 else f"CONTINUITY_STEP_{step - 1}"
+            self.run_turn(
+                "coordinator",
+                f"continuity-{step}",
+                (
+                    f"Mission {self.marker}, continuity step {step}. "
+                    "keeper_compose_mission-snapshot을 정확히 한 번 호출하세요. "
+                    f"Board post {post_id}에서 {previous}를 확인한 다음 CONTINUITY_STEP_{step} "
+                    "comment를 남기세요. 최초 turn의 continuity secret은 다시 쓰거나 추측하지 마세요."
+                ),
+            )
+
+    def capture_browser_proof(self) -> None:
+        browser_dir = self.writer.output_dir / "browser"
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "MASC_COMPOSITION_DASHBOARD_URL": default_health_url(
+                    self.endpoint
+                ).removesuffix("/health?full=1"),
+                "MASC_COMPOSITION_DASHBOARD_TOKEN_FILE": str(self.token_file),
+                "MASC_COMPOSITION_KEEPER_NAME": self.roles["coordinator"],
+                "MASC_COMPOSITION_EXPECTED_BASE_PATH": self.expected_base_path,
+                "MASC_COMPOSITION_BROWSER_ARTIFACT_DIR": str(browser_dir),
+            }
+        )
+        completed = subprocess.run(
+            ["node", str(self.browser_proof_script)],
+            cwd=REPO_ROOT,
+            env=environment,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if completed.returncode != 0:
+            raise AcceptanceError(
+                "composition browser proof failed: "
+                + (completed.stderr.strip() or completed.stdout.strip())
+            )
+
+        def read_measurement(filename: str) -> dict[str, Any]:
+            measurement_path = browser_dir / filename
+            try:
+                measurement = json.loads(measurement_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as error:
+                raise AcceptanceError(
+                    f"invalid browser proof measurement {filename}: {error}"
+                ) from error
+            if not isinstance(measurement, dict):
+                raise AcceptanceError(
+                    f"browser proof measurement {filename} must be an object"
+                )
+            return measurement
+
+        self.browser_proof = read_measurement("keeper-composition-inspector.json")
+        self.persistence_browser_proof = read_measurement(
+            "keeper-persistence-proof.json"
+        )
 
     def run_contention(self, post_id: str) -> None:
         prompts = {
@@ -984,6 +1196,21 @@ class MissionRun:
                     "data": timeline.data,
                 },
             )
+            encoded_keeper = urllib.parse.quote(self.roles[role], safe="")
+            tool_calls = self.dashboard_get(
+                f"/api/v1/keepers/{encoded_keeper}/tool-calls?limit=200"
+            )
+            entries = tool_calls.get("entries")
+            if not isinstance(entries, list) or not all(
+                isinstance(entry, dict) for entry in entries
+            ):
+                raise AcceptanceError(
+                    f"tool-call inspector returned malformed rows for {role}"
+                )
+            self.tool_call_rows[role] = entries
+            self.writer.write_json(
+                f"observations/tool-calls-{role}.json", tool_calls
+            )
         calls = {
             "goals": ("masc_goal_list", {}),
             "tasks": ("masc_tasks", {"include_done": True, "include_cancelled": True}),
@@ -1058,6 +1285,299 @@ class MissionRun:
         parallel_turns = [
             turn for label, turn in self.turns.items() if label.startswith("parallel-")
         ]
+        coordinator_turns = [
+            turn for turn in self.turns.values() if turn.role == "coordinator"
+        ]
+        required_inline_turn_labels = {
+            *(f"parallel-{role}" for role in self.roles),
+            *(f"continuity-{step}" for step in range(1, 10)),
+        }
+        required_coordinator_turn_labels = {
+            "parallel-coordinator",
+            *(f"continuity-{step}" for step in range(1, 10)),
+            "context-after-restart",
+        }
+
+        def rows_for_turn(role: str, turn: TurnObservation) -> list[dict[str, Any]]:
+            return [
+                row
+                for row in self.tool_call_rows.get(role, [])
+                if isinstance(row.get("ts"), (int, float))
+                and turn.started_epoch_seconds <= float(row["ts"])
+                <= turn.finished_epoch_seconds
+            ]
+
+        def composition_runs(
+            composition_tool: str,
+        ) -> dict[tuple[str, str], list[dict[str, Any]]]:
+            runs: dict[tuple[str, str], list[dict[str, Any]]] = {}
+            for role, rows in self.tool_call_rows.items():
+                for row in rows:
+                    if row.get("composition_tool") != composition_tool:
+                        continue
+                    run_id = row.get("composition_run_id")
+                    if isinstance(run_id, str) and run_id:
+                        runs.setdefault((role, run_id), []).append(row)
+            return runs
+
+        def has_nested_settlement_evidence(row: dict[str, Any]) -> bool:
+            execution_id = row.get("execution_id")
+            tool_use_id = row.get("tool_use_id")
+            result_bytes = row.get("result_bytes")
+            truncated_to = row.get("truncated_to")
+            output = row.get("output")
+            return (
+                isinstance(execution_id, str)
+                and bool(execution_id.strip())
+                and isinstance(tool_use_id, str)
+                and bool(tool_use_id.strip())
+                and isinstance(result_bytes, int)
+                and not isinstance(result_bytes, bool)
+                and result_bytes >= 0
+                and truncated_to is None
+                and isinstance(output, str)
+                and result_bytes == len(output.encode("utf-8"))
+            )
+
+        def has_unique_nested_identities(
+            rows: list[dict[str, Any]], expected_count: int
+        ) -> bool:
+            return (
+                len({row.get("execution_id") for row in rows}) == expected_count
+                and len({row.get("tool_use_id") for row in rows}) == expected_count
+            )
+
+        inline_runs = composition_runs("keeper_compose_mission-snapshot")
+        async_runs = composition_runs("keeper_compose_background-snapshot")
+        composition_rows = [row for rows in inline_runs.values() for row in rows]
+        inline_turn_runs: dict[str, tuple[str, list[dict[str, Any]]]] = {}
+        inline_turn_errors: list[str] = []
+        attributed_inline_run_keys: set[tuple[str, str]] = set()
+        for label in sorted(required_inline_turn_labels):
+            role = label.removeprefix("parallel-") if label.startswith("parallel-") else "coordinator"
+            turn = self.turns.get(label)
+            if turn is None:
+                inline_turn_errors.append(f"{label}:missing_turn")
+                continue
+            turn_rows = [
+                row
+                for row in rows_for_turn(role, turn)
+                if row.get("composition_tool") == "keeper_compose_mission-snapshot"
+            ]
+            run_ids = {
+                row.get("composition_run_id")
+                for row in turn_rows
+                if isinstance(row.get("composition_run_id"), str)
+                and row.get("composition_run_id")
+            }
+            if len(run_ids) != 1:
+                inline_turn_errors.append(f"{label}:runs={sorted(run_ids)}")
+                continue
+            run_id = next(iter(run_ids))
+            run_rows = [row for row in turn_rows if row.get("composition_run_id") == run_id]
+            outer_rows = [
+                row
+                for row in rows_for_turn(role, turn)
+                if row.get("tool") == "keeper_compose_mission-snapshot"
+            ]
+            parent_ids = {row.get("parent_tool_use_id") for row in run_rows}
+            node_ids = {row.get("composition_node_id") for row in run_rows}
+            if (
+                len(run_rows) != 4
+                or len(outer_rows) != 1
+                or node_ids != {"clock", "board", "board-peer", "memory"}
+                or len(parent_ids) != 1
+                or next(iter(parent_ids)) != outer_rows[0].get("tool_use_id")
+                or not all(row.get("disposition") == "completed" for row in run_rows)
+                or not all(has_nested_settlement_evidence(row) for row in run_rows)
+                or not has_unique_nested_identities(run_rows, 4)
+            ):
+                inline_turn_errors.append(f"{label}:invalid_rows={len(run_rows)}")
+                continue
+            inline_turn_runs[label] = (run_id, run_rows)
+            attributed_inline_run_keys.add((role, run_id))
+        unattributed_inline_runs = set(inline_runs) - attributed_inline_run_keys
+        inline_run_ids_globally_unique = (
+            len({run_id for run_id, _ in inline_turn_runs.values()})
+            == len(required_inline_turn_labels)
+        )
+        inline_action_rows = [
+            row for _, rows in inline_turn_runs.values() for row in rows
+        ]
+        accepted_inline_row_identities = {
+            (
+                label.removeprefix("parallel-")
+                if label.startswith("parallel-")
+                else "coordinator",
+                run_id,
+                row.get("execution_id"),
+                row.get("tool_use_id"),
+            )
+            for label, (run_id, rows) in inline_turn_runs.items()
+            for row in rows
+        }
+        full_inline_action_rows = [
+            row for rows in inline_runs.values() for row in rows
+        ]
+        full_inline_row_identities = {
+            (role, run_id, row.get("execution_id"), row.get("tool_use_id"))
+            for (role, run_id), rows in inline_runs.items()
+            for row in rows
+        }
+        inline_row_universe_exact = (
+            len(inline_action_rows) == 56
+            and len(full_inline_action_rows) == 56
+            and len(accepted_inline_row_identities) == 56
+            and full_inline_row_identities == accepted_inline_row_identities
+        )
+        inline_action_identities_globally_unique = (
+            len(inline_action_rows) == 56
+            and len({row.get("execution_id") for row in inline_action_rows}) == 56
+            and len({row.get("tool_use_id") for row in inline_action_rows}) == 56
+        )
+
+        researcher_turn = self.turns.get("parallel-researcher")
+        researcher_rows = (
+            rows_for_turn("researcher", researcher_turn)
+            if researcher_turn is not None
+            else []
+        )
+        async_submit_rows = [
+            row
+            for row in researcher_rows
+            if row.get("tool") == "keeper_compose_background-snapshot"
+        ]
+        async_status_rows = [
+            row for row in researcher_rows if row.get("tool") == "keeper_composition_status"
+        ]
+        async_request_id: str | None = None
+        async_outer_terminal = False
+        if len(async_submit_rows) == 1 and async_status_rows:
+            submission_output = parse_json_maybe(async_submit_rows[0].get("output", ""))
+            candidate_request_id = (
+                submission_output.get("request_id")
+                if isinstance(submission_output, dict)
+                else None
+            )
+            if isinstance(candidate_request_id, str) and candidate_request_id:
+                async_request_id = candidate_request_id
+                ordered_status_rows = sorted(
+                    async_status_rows, key=lambda row: float(row.get("ts", 0.0))
+                )
+                status_evidence = [
+                    (row.get("input"), parse_json_exact(row.get("output", "")))
+                    for row in ordered_status_rows
+                ]
+                final_output = status_evidence[-1][1]
+                async_outer_terminal = (
+                    all(
+                        isinstance(status_input, dict)
+                        and status_input.get("request_id") == async_request_id
+                        and isinstance(status_output, dict)
+                        and status_output.get("request_id") == async_request_id
+                        and status_output.get("status") in {"queued", "running", "done"}
+                        for status_input, status_output in status_evidence
+                    )
+                    and all(
+                        status_output.get("status") in {"queued", "running"}
+                        for _, status_output in status_evidence[:-1]
+                    )
+                    and final_output.get("status") == "done"
+                    and final_output.get("ok") is True
+                )
+        async_action_rows = [row for rows in async_runs.values() for row in rows]
+        all_nested_action_rows = inline_action_rows + async_action_rows
+        all_composition_run_ids = {
+            run_id for _, run_id in set(inline_runs) | set(async_runs)
+        }
+        composition_run_ids_globally_unique = (
+            len(inline_runs) == 14
+            and len(async_runs) == 1
+            and len(all_composition_run_ids) == 15
+        )
+        all_nested_action_identities_globally_unique = (
+            len(all_nested_action_rows) == 58
+            and len({row.get("execution_id") for row in all_nested_action_rows}) == 58
+            and len({row.get("tool_use_id") for row in all_nested_action_rows}) == 58
+        )
+
+        coordinator_runtime_turn_ids: dict[str, int] = {}
+        coordinator_turn_evidence_errors: list[str] = []
+        for label in sorted(required_coordinator_turn_labels):
+            turn = self.turns.get(label)
+            if turn is None:
+                coordinator_turn_evidence_errors.append(f"{label}:missing_turn")
+                continue
+            keeper_turn_ids = {
+                row.get("keeper_turn_id")
+                for row in rows_for_turn("coordinator", turn)
+                if isinstance(row.get("keeper_turn_id"), int)
+            }
+            if len(keeper_turn_ids) != 1:
+                coordinator_turn_evidence_errors.append(
+                    f"{label}:keeper_turn_ids={sorted(keeper_turn_ids)}"
+                )
+                continue
+            coordinator_runtime_turn_ids[label] = next(iter(keeper_turn_ids))
+        required_inline_rows = [rows for _, rows in inline_turn_runs.values()]
+        parallel_schedule_observed = len(required_inline_rows) == 14 and all(
+            all(
+                any(
+                    row.get("composition_node_id") == node
+                    and row.get("batch_index") == 0
+                    and row.get("batch_size") == 3
+                    and row.get("execution_mode") == "concurrent"
+                    for row in rows
+                )
+                for node in ("clock", "board", "board-peer")
+            )
+            for rows in required_inline_rows
+        )
+        sequential_dataflow_observed = len(required_inline_rows) == 14 and all(
+            any(
+                isinstance(row.get("input"), dict)
+                and row["input"].get("query") == clock_output.get("now_iso")
+                and row.get("batch_index") == 1
+                and row.get("batch_size") == 1
+                and row.get("execution_mode") == "serial"
+                and row.get("disposition") == "completed"
+                for row in rows
+                if row.get("composition_node_id") == "memory"
+            )
+            for rows in required_inline_rows
+            for clock_output in [
+                parse_json_maybe(
+                    next(
+                        row.get("output", "")
+                        for row in rows
+                        if row.get("composition_node_id") == "clock"
+                    )
+                )
+            ]
+            if isinstance(clock_output, dict)
+        )
+        typed_context_observed = bool(composition_rows) and all(
+            isinstance(row.get("composition_run_id"), str)
+            and bool(row.get("composition_run_id"))
+            and isinstance(row.get("composition_node_id"), str)
+            and row.get("composition_execution") == "inline"
+            and isinstance(row.get("parent_tool_use_id"), str)
+            and row.get("disposition") in {"completed", "deferred", "failed"}
+            for row in composition_rows
+        )
+        browser_screenshot = (
+            self.writer.output_dir / "browser" / "keeper-composition-inspector.png"
+        )
+        persistence_browser_screenshot = (
+            self.writer.output_dir / "browser" / "keeper-persistence-proof.png"
+        )
+        persistence_projection_passed, persistence_projection_detail = (
+            validate_persistence_browser_evidence(
+                self.persistence_browser_proof,
+                persistence_browser_screenshot,
+                set(self.roles.values()),
+            )
+        )
         parallel_events = sorted(
             [
                 (turn.started_epoch_seconds, 1)
@@ -1301,6 +1821,87 @@ class MissionRun:
                 and (self.writer.output_dir / "preflight.json").is_file(),
                 f"{len(artifact_files)} JSON evidence artifacts before bundle emission",
             ),
+            "same_keeper_eleven_linked_turns": (
+                set(coordinator_runtime_turn_ids) == required_coordinator_turn_labels
+                and len(set(coordinator_runtime_turn_ids.values())) == 11
+                and len({turn.operation_id for turn in coordinator_turns}) == 11
+                and all(turn.status == "passed" for turn in coordinator_turns)
+                and all(text_contains(board, f"CONTINUITY_STEP_{step}") for step in range(1, 10))
+                and text_contains(board, f"MEMORY_RECALLED={self.secret}"),
+                "eleven distinct runtime keeper_turn_id values join the requested operations, "
+                f"errors={coordinator_turn_evidence_errors}",
+            ),
+            "composition_inline_observed": (
+                set(inline_turn_runs) == required_inline_turn_labels
+                and not inline_turn_errors
+                and not unattributed_inline_runs
+                and inline_run_ids_globally_unique
+                and inline_row_universe_exact
+                and inline_action_identities_globally_unique,
+                f"exact completed inline runs={len(inline_turn_runs)}/14 "
+                f"errors={inline_turn_errors} unattributed={sorted(unattributed_inline_runs)}",
+            ),
+            "composition_parallel_schedule_observed": (
+                parallel_schedule_observed,
+                "clock/board/board-peer share exact concurrent batch 0 of size 3",
+            ),
+            "composition_sequential_dataflow_observed": (
+                sequential_dataflow_observed,
+                "memory node receives typed clock output in serial batch 1",
+            ),
+            "composition_async_observed": (
+                len(async_runs) == 1
+                and async_outer_terminal
+                and all(
+                    role == "researcher"
+                    and len(rows) == 2
+                    and {row.get("composition_node_id") for row in rows}
+                    == {"clock", "board"}
+                    and all(
+                        row.get("composition_execution") == "async"
+                        and row.get("disposition") == "completed"
+                        and has_nested_settlement_evidence(row)
+                        for row in rows
+                    )
+                    and all(
+                        row.get("parent_tool_use_id")
+                        == async_submit_rows[0].get("tool_use_id")
+                        for row in rows
+                    )
+                    and has_unique_nested_identities(rows, 2)
+                    for (role, _), rows in async_runs.items()
+                )
+                and composition_run_ids_globally_unique
+                and all_nested_action_identities_globally_unique,
+                f"async runs={len(async_runs)} request_id={async_request_id} "
+                f"submit_rows={len(async_submit_rows)} status_rows={len(async_status_rows)} terminal={async_outer_terminal}",
+            ),
+            "composition_turn_context_observed": (
+                typed_context_observed,
+                f"typed composition rows={len(composition_rows)}",
+            ),
+            "composition_dashboard_browser_observed": (
+                self.browser_proof.get("schema")
+                == "masc.keeper_composition_browser_evidence.v1"
+                and self.browser_proof.get("keeper") == self.roles["coordinator"]
+                and self.browser_proof.get("nodes")
+                == ["board", "board-peer", "clock", "memory"]
+                and self.browser_proof.get("execution") == "inline"
+                and self.browser_proof.get("dispositions")
+                == ["completed", "completed", "completed", "completed"]
+                and self.browser_proof.get("input_visible") is True
+                and self.browser_proof.get("output_visible") is True
+                and isinstance(self.browser_proof.get("screenshot_sha256"), str)
+                and len(self.browser_proof["screenshot_sha256"]) == 64
+                and browser_screenshot.is_file()
+                and sha256_file(browser_screenshot)
+                == self.browser_proof["screenshot_sha256"],
+                "actual dashboard inspector renders one complete typed run with expanded input/output",
+            ),
+            "persistence_tiers_dashboard_projection_observed": (
+                persistence_projection_passed,
+                persistence_projection_detail,
+            ),
         }
         malformed = [
             name
@@ -1321,9 +1922,11 @@ class MissionRun:
         self.run_parallel_wave(post_id)
         self.run_contention(post_id)
         self.run_failure_recovery(post_id)
+        self.run_continuity_chain(post_id)
         self.restart_and_recall(post_id)
         self.wait_for_async_sources()
         self.collect_product_observations(post_id)
+        self.capture_browser_proof()
         return post_id, self.evaluate_assertions(post_id)
 
 
@@ -1478,7 +2081,9 @@ def verify_bundle(
     if bundle.get("passed_count") != passed_count:
         errors.append("passed count mismatch")
     if passed_count != len(expected_ids) or bundle.get("status") != "passed":
-        errors.append(f"real-world status is not 16/16: {passed_count}/{len(expected_ids)}")
+        errors.append(
+            f"real-world status is not complete: {passed_count}/{len(expected_ids)}"
+        )
     if expected_source_sha:
         if bundle.get("source_sha") != expected_source_sha:
             errors.append("bundle runtime binary SHA does not match expected source SHA")
@@ -1523,6 +2128,36 @@ def verify_bundle(
                 errors.append(
                     f"missing catalog evidence for {mission['id']}: {pattern}"
                 )
+    persistence_proof_path = output_dir / "browser" / "keeper-persistence-proof.json"
+    persistence_screenshot_path = output_dir / "browser" / "keeper-persistence-proof.png"
+    try:
+        persistence_proof = json.loads(
+            persistence_proof_path.read_text(encoding="utf-8")
+        )
+    except (OSError, json.JSONDecodeError) as error:
+        errors.append(f"persistence browser proof is unreadable: {error}")
+    else:
+        resources = bundle.get("resources")
+        keepers = resources.get("keepers") if isinstance(resources, dict) else None
+        exact_role_map = (
+            isinstance(keepers, dict)
+            and set(keepers) == EXPECTED_ROLES
+            and all(
+                isinstance(value, str) and bool(value.strip())
+                for value in keepers.values()
+            )
+            and len(set(keepers.values())) == len(EXPECTED_ROLES)
+        )
+        if not exact_role_map:
+            errors.append("bundle resources do not name five distinct exact role Keepers")
+        expected_keepers = set(keepers.values()) if exact_role_map else set()
+        persistence_valid, persistence_detail = validate_persistence_browser_evidence(
+            persistence_proof,
+            persistence_screenshot_path,
+            expected_keepers,
+        )
+        if not persistence_valid:
+            errors.append(f"persistence browser proof is invalid: {persistence_detail}")
     seed = {
         "source_sha": bundle.get("source_sha"),
         "runner_source_sha": bundle.get("runner_source_sha"),
@@ -1571,6 +2206,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--mcp-url", default=os.environ.get("MCP_URL", "http://127.0.0.1:8935/mcp"))
     parser.add_argument("--health-url")
     parser.add_argument("--token-file")
+    parser.add_argument("--browser-proof-script")
     parser.add_argument("--expected-base-path")
     parser.add_argument("--expected-source-sha")
     parser.add_argument("--allow-mutation", action="store_true")
@@ -1640,6 +2276,10 @@ def main() -> int:
             raise AcceptanceError("--run requires exact --expected-source-sha")
         if not args.output_dir:
             raise AcceptanceError("--run requires --output-dir")
+        if not args.token_file:
+            raise AcceptanceError("--run requires --token-file")
+        if not args.browser_proof_script:
+            raise AcceptanceError("--run requires --browser-proof-script")
         output_dir = pathlib.Path(args.output_dir).resolve()
         prepare_output_dir(output_dir)
         writer = EvidenceWriter(output_dir)
@@ -1657,6 +2297,9 @@ def main() -> int:
             timeout=args.timeout,
             run_id=run_id,
             runtime_id=args.runtime_id,
+            token_file=pathlib.Path(args.token_file).resolve(),
+            browser_proof_script=pathlib.Path(args.browser_proof_script).resolve(),
+            expected_base_path=args.expected_base_path,
         )
         try:
             post_id, assertions = mission_run.run()

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -3557,6 +3557,45 @@ let test_cached_surface_success_clears_the_previous_error () =
     (Yojson.Safe.to_string succeeded.Cache.json)
 ;;
 
+let test_tool_call_fleet_cache_tracks_durable_revision () =
+  let base_path = test_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Dashboard_cache.invalidate_all ();
+      Masc.Keeper_tool_call_log.reset_for_testing ();
+      cleanup_dir base_path)
+    (fun () ->
+       Masc.Keeper_tool_call_log.reset_for_testing ();
+       Masc.Keeper_tool_call_log.init ~base_path ();
+       let masc_root =
+         match Masc.Keeper_tool_call_log.configured_masc_root () with
+         | Some value -> value
+         | None -> fail "tool-call log did not retain its MASC root"
+       in
+       let key =
+         Server_dashboard_http_keeper_api.tool_calls_fleet_cache_key ~masc_root
+       in
+       ignore
+         (Dashboard_cache.get_or_compute key ~ttl:30.0 (fun () -> `List []));
+       check bool "fleet cache is seeded" true (Option.is_some (Dashboard_cache.peek key));
+       Masc.Keeper_tool_call_log.log_call
+         ~keeper_name:"analyst"
+         ~tool_name:"keeper_time_now"
+         ~input:(`Assoc [])
+         ~output_text:"ok"
+         ~success:true
+         ~duration_ms:1.0
+         ();
+       check int "durable append advances revision" 1
+         (Masc.Keeper_tool_call_log.committed_revision ());
+       let same_key =
+         Server_dashboard_http_keeper_api.tool_calls_fleet_cache_key ~masc_root
+       in
+       check string "cache identity remains bounded" key same_key;
+       check bool "revision change invalidates stale fleet rows" true
+         (Option.is_none (Dashboard_cache.peek key)))
+;;
+
 let () =
   run "dashboard_http_core"
     [
@@ -3582,6 +3621,8 @@ let () =
             test_dashboard_shell_http_json_prefers_light_last_good_while_prewarming;
           test_case "operator snapshot hydrates on first default request" `Quick
             test_operator_snapshot_default_route_hydrates_first_success;
+          test_case "tool-call fleet cache follows durable revision" `Quick
+            test_tool_call_fleet_cache_tracks_durable_revision;
           test_case "dashboard query cache segment normalizes missing values" `Quick
             test_dashboard_query_cache_segment_normalizes_missing_values;
           test_case "dashboard query cache key partitions route params" `Quick

--- a/test/test_dashboard_keeper_feature_proof.ml
+++ b/test/test_dashboard_keeper_feature_proof.ml
@@ -104,6 +104,22 @@ let keeper_names feature key =
   |> List.sort compare
 ;;
 
+let duration_tier feature id =
+  feature
+  |> U.member "duration_tiers"
+  |> U.to_list
+  |> List.find_opt (fun tier -> U.member "id" tier |> U.to_string = id)
+  |> function
+  | Some tier -> tier
+  | None -> failf "duration tier %s absent from persistence proof" id
+;;
+
+let append_turn_exchange config keeper_name ts =
+  Masc.Keeper_types_support.append_jsonl_line
+    (Masc.Keeper_types_support.keeper_decision_log_path config keeper_name)
+    (`Assoc [ "channel", `String "turn"; "ts_unix", `Float ts ])
+;;
+
 let test_stale_keeper_fails_runtime_liveness () =
   with_workspace
   @@ fun config ->
@@ -236,6 +252,57 @@ let test_stopped_keeper_fails_board_reactive_autonomy () =
     (U.member "status" feature |> U.to_string)
 ;;
 
+let test_persistence_duration_tiers_use_durable_turn_history () =
+  with_workspace
+  @@ fun config ->
+  seed_keeper config ~name:"four-hours" ~last_turn_ts:(now -. hour_seconds) ();
+  seed_keeper config ~name:"twenty-four-hours" ~last_turn_ts:(now -. hour_seconds) ();
+  append_turn_exchange config "four-hours" (now -. (5.0 *. hour_seconds));
+  append_turn_exchange config "four-hours" (now -. (0.5 *. hour_seconds));
+  append_turn_exchange config "twenty-four-hours" (now -. (24.0 *. hour_seconds));
+  append_turn_exchange config "twenty-four-hours" now;
+  let feature =
+    Feature_proof.json ~config ~now ()
+    |> fun payload -> feature_by_id payload "persistent_24h_turn_exchange"
+  in
+  List.iter
+    (fun id ->
+      let tier = duration_tier feature id in
+      check
+        string
+        (id ^ " tier names its evidence semantics")
+        "durable_turn_span"
+        U.(member "evidence_kind" tier |> to_string);
+      check string (id ^ " tier passes for both keepers") "pass" U.(member "status" tier |> to_string);
+      check int (id ^ " tier observes both keepers") 2 U.(member "observed_count" tier |> to_int))
+    [ "1h"; "2h"; "4h" ];
+  let tier_24h = duration_tier feature "24h" in
+  check string "24h tier stays partial" "warn" U.(member "status" tier_24h |> to_string);
+  check
+    (list string)
+    "24h tier names only the keeper with sufficient durable history"
+    [ "twenty-four-hours" ]
+    (tier_24h |> U.member "observed_keepers" |> U.to_list |> List.map U.to_string)
+;;
+
+let test_persistence_duration_tiers_reject_future_turns () =
+  with_workspace
+  @@ fun config ->
+  seed_keeper config ~name:"future" ~last_turn_ts:(now -. hour_seconds) ();
+  append_turn_exchange config "future" (now -. (25.0 *. hour_seconds));
+  append_turn_exchange config "future" (now +. hour_seconds);
+  let feature =
+    Feature_proof.json ~config ~now ()
+    |> fun payload -> feature_by_id payload "persistent_24h_turn_exchange"
+  in
+  List.iter
+    (fun id ->
+      let tier = duration_tier feature id in
+      check string (id ^ " tier rejects a future latest turn") "fail" U.(member "status" tier |> to_string);
+      check int (id ^ " tier observes no keeper with future evidence") 0 U.(member "observed_count" tier |> to_int))
+    [ "1h"; "2h"; "4h"; "24h" ]
+;;
+
 let () =
   run
     "dashboard_keeper_feature_proof"
@@ -256,6 +323,16 @@ let () =
             "stopped keeper fails board_reactive_autonomy"
             `Quick
             test_stopped_keeper_fails_board_reactive_autonomy
+        ] )
+    ; ( "persistence_duration_tiers"
+      , [ test_case
+            "durable history proves 1h 2h 4h and 24h tiers"
+            `Quick
+            test_persistence_duration_tiers_use_durable_turn_history
+        ; test_case
+            "future timestamps cannot prove a duration tier"
+            `Quick
+            test_persistence_duration_tiers_reject_future_turns
         ] )
     ]
 ;;

--- a/test/test_keeper_antigravity_runtime.ml
+++ b/test/test_keeper_antigravity_runtime.ml
@@ -706,6 +706,7 @@ let test_spawn_failure_is_pre_dispatch () =
                       ~raw_trace:None
                       ~on_event:None
                       ~config
+                      ()
                   in
                   (match attempt.result with
                    | Error

--- a/test/test_keeper_claude_code_runtime.ml
+++ b/test/test_keeper_claude_code_runtime.ml
@@ -1122,7 +1122,8 @@ let run_direct_attempt ?hooks ~base_path ~cli_path ~goal ~tools () =
                     ~event_bus:None
                     ~raw_trace:None
                     ~on_event:None
-                    ~config)))))
+                    ~config
+                    ())))))
 ;;
 
 let check_pre_dispatch_attempt label attempt =

--- a/test/test_keeper_claude_code_runtime.ml
+++ b/test/test_keeper_claude_code_runtime.ml
@@ -35,6 +35,10 @@ let prompt_too_long_result =
   {|{"type":"result","subtype":"success","is_error":true,"session_id":"__SESSION__","uuid":"turn-overflow-1","result":"Prompt is too long · the request is ~250000 tokens (limit 200000)","api_error_status":400}|}
 ;;
 
+let prompt_too_long_statusless_result =
+  {|{"type":"result","subtype":"success","is_error":true,"session_id":"__SESSION__","uuid":"turn-statusless-overflow-1","result":"Prompt is too long"}|}
+;;
+
 let mcp_initialize =
   {|{"type":"control_request","request_id":"mcp-init-1","request":{"subtype":"mcp_message","server_name":"masc","message":{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"claude-code-fixture","version":"1"}}}}}|}
 ;;
@@ -755,7 +759,7 @@ let history_uses_current_schema history =
     history
 ;;
 
-let test_keeper_shrinks_history_after_typed_context_error () =
+let test_keeper_shrinks_history_after_statusless_context_error () =
   let base_path = temp_workspace () in
   let first_prompt_marker = Filename.concat base_path "overflow-full-prompt.json" in
   let second_prompt_marker = Filename.concat base_path "overflow-shrunk-prompt.json" in
@@ -778,7 +782,7 @@ let test_keeper_shrinks_history_after_typed_context_error () =
        with_fixture_sequence
          ~first_prompt_marker
          ~second_prompt_marker
-         [ Emit prompt_too_long_result ]
+         [ Emit prompt_too_long_statusless_result ]
          [ Emit (assistant ~turn_id:"turn-shrunk" "MASC_CLAUDE_SHRUNK")
          ; Emit (result ~turn_id:"turn-shrunk" "MASC_CLAUDE_SHRUNK")
          ]
@@ -1295,9 +1299,9 @@ let () =
             `Quick
             test_agent_core_checkpoint_starts_official_client_turn
         ; test_case
-            "shrinks history after typed context error"
+            "shrinks history after statusless context error"
             `Quick
-            test_keeper_shrinks_history_after_typed_context_error
+            test_keeper_shrinks_history_after_statusless_context_error
         ; test_case
             "projects typed tool history and lifecycle"
             `Quick

--- a/test/test_keeper_multi_collaboration_acceptance.py
+++ b/test/test_keeper_multi_collaboration_acceptance.py
@@ -1,0 +1,118 @@
+import hashlib
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = (
+    REPO_ROOT
+    / "scripts"
+    / "harness"
+    / "workload"
+    / "keeper_multi_collaboration_acceptance.py"
+)
+CATALOG_PATH = (
+    REPO_ROOT
+    / "scripts"
+    / "fixtures"
+    / "keeper-multi-collaboration"
+    / "missions.json"
+)
+
+
+def load_acceptance_module():
+    spec = importlib.util.spec_from_file_location(
+        "keeper_multi_collaboration_acceptance",
+        SCRIPT_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+acceptance = load_acceptance_module()
+
+
+class KeeperMultiCollaborationAcceptanceTest(unittest.TestCase):
+    def test_catalog_has_exact_rw19_persistence_projection_mission(self):
+        catalog = acceptance.load_catalog(CATALOG_PATH)
+
+        self.assertEqual(len(catalog["missions"]), 19)
+        self.assertEqual(catalog["missions"][-1]["id"], "RW19")
+        self.assertEqual(
+            catalog["missions"][-1]["assertions"],
+            ["persistence_tiers_dashboard_projection_observed"],
+        )
+
+    def test_persistence_browser_validator_requires_exact_monotonic_fleet(self):
+        expected = {"keeper-a", "keeper-b"}
+        with tempfile.TemporaryDirectory() as tmp_name:
+            screenshot = Path(tmp_name) / "keeper-persistence-proof.png"
+            screenshot.write_bytes(b"png-evidence")
+            digest = hashlib.sha256(screenshot.read_bytes()).hexdigest()
+            proof = {
+                "schema": "masc.keeper_persistence_browser_evidence.v1",
+                "generated_at": "2026-08-14T12:00:00Z",
+                "interaction": "manual_refresh",
+                "tiers": [
+                    self.tier("1h", ["keeper-a", "keeper-b"], []),
+                    self.tier("2h", ["keeper-a"], ["keeper-b"]),
+                    self.tier("4h", ["keeper-a"], ["keeper-b"]),
+                    self.tier("24h", [], ["keeper-a", "keeper-b"]),
+                ],
+                "screenshot_file": screenshot.name,
+                "screenshot_bytes": screenshot.stat().st_size,
+                "screenshot_sha256": digest,
+            }
+
+            valid, detail = acceptance.validate_persistence_browser_evidence(
+                proof,
+                screenshot,
+                expected,
+            )
+            self.assertTrue(valid, detail)
+
+            proof["tiers"][2] = self.tier(
+                "4h",
+                ["keeper-b"],
+                ["keeper-a"],
+            )
+            valid, detail = acceptance.validate_persistence_browser_evidence(
+                proof,
+                screenshot,
+                expected,
+            )
+            self.assertFalse(valid)
+            self.assertIn("duration monotonicity", detail)
+
+    @staticmethod
+    def tier(tier_id, observed, missing):
+        keeper_count = len(observed) + len(missing)
+        observed_count = len(observed)
+        status = (
+            "fail"
+            if keeper_count == 0 or observed_count == 0
+            else "pass"
+            if observed_count == keeper_count
+            else "warn"
+        )
+        return {
+            "id": tier_id,
+            "status": status,
+            "evidence_kind": "durable_turn_span",
+            "keeper_count": keeper_count,
+            "observed_count": observed_count,
+            "missing_count": len(missing),
+            "observed_keepers": observed,
+            "missing_keepers": missing,
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_keeper_official_client_host.ml
+++ b/test/test_keeper_official_client_host.ml
@@ -369,6 +369,44 @@ let test_terminal_post_effect_failure_aborts_the_official_client_turn () =
       fail "post-effect terminal failure did not close the official-client loop")
 ;;
 
+let test_ordinary_post_effect_failure_aborts_the_official_client_turn () =
+  with_active_raw_trace (fun ~path:_ ~active ->
+    let state = ref Masc.Keeper_tools_agent_core.Terminal_effect_open in
+    let tool, _terminal_error =
+      one_dynamic_tool
+        ~descriptor:
+          (Agent_core.Tool.ordinary_descriptor Agent_core.Tool_contract.Serial)
+        ~terminal_effect_state:(fun () -> !state)
+        ~active
+        (fun _input ->
+           state :=
+             Masc.Keeper_tools_agent_core.Terminal_effect_failed
+               { failure_class = Tool_result.Runtime_failure
+               ; effect_disposition = Tool_result.Effect_outcome_unknown
+               ; diagnostic = "ordinary composition effect is indeterminate"
+               };
+           Error
+             { Agent_core.Types.message = "ordinary composition failed"
+             ; recoverable = false
+             ; error_class = Some Agent_core.Types.Deterministic
+             })
+    in
+    let result = tool.call ~call_id:"ordinary-post-effect" (`Assoc []) in
+    match result.abort_turn with
+    | Some
+        (Terminal_tool_boundary
+          { tool_name = "effect"
+          ; outcome =
+              Terminal_failed
+                { effect_disposition = Tool_result.Effect_outcome_unknown; _ }
+          }) ->
+      ()
+    | Some (Terminal_tool_boundary _)
+    | Some (Repeated_tool_call _)
+    | None ->
+      fail "ordinary post-effect failure remained provider-retryable")
+;;
+
 let test_terminal_pre_effect_failure_remains_correction_capable () =
   with_active_raw_trace (fun ~path:_ ~active ->
     let tool, _terminal_error =
@@ -925,6 +963,10 @@ let () =
             "terminal post-effect failure aborts official-client turn"
             `Quick
             test_terminal_post_effect_failure_aborts_the_official_client_turn
+        ; test_case
+            "ordinary post-effect failure aborts official-client turn"
+            `Quick
+            test_ordinary_post_effect_failure_aborts_the_official_client_turn
         ; test_case
             "terminal pre-effect failure stays correction-capable"
             `Quick

--- a/test/test_keeper_official_client_host.ml
+++ b/test/test_keeper_official_client_host.ml
@@ -88,9 +88,16 @@ let with_active_raw_trace body =
          body ~path ~active))
 ;;
 
-let one_dynamic_tool ~active handler =
+let one_dynamic_tool
+      ?descriptor
+      ?(terminal_effect_state = fun () ->
+        Masc.Keeper_tools_agent_core.Terminal_effect_open)
+      ~active
+      handler
+  =
   let tool =
     Agent_core.Tool.create
+      ?descriptor
       ~name:"effect"
       ~description:"test effect"
       ~parameters:[]
@@ -107,6 +114,7 @@ let one_dynamic_tool ~active handler =
       ~event_bus:None
       ~context_injector:None
       ~context:(Some (Agent_core.Context.create_sync ()))
+      ~terminal_effect_state
       ~terminal_error
       ~raw_trace_run:(Some active)
   in
@@ -252,6 +260,8 @@ let test_repeated_exact_dynamic_tool_call_aborts_the_turn () =
           to the hand-built stop below, which never goes through the host. *)
        check string "repeated tool" "effect" tool_name;
        check int "repeat count" 3 repeated_count
+     | Some (Terminal_tool_boundary _) ->
+       fail "ordinary repeated tool produced a terminal-tool stop"
      | None -> fail "reordered object did not produce a typed host stop");
     check (option string) "host stop is not a terminal error" None !terminal_error)
 ;;
@@ -287,12 +297,16 @@ let test_dynamic_tool_progress_does_not_trip_the_repeat_guard () =
 
 let test_repeated_tool_host_stop_is_a_checkpoint_yield () =
   let result =
-    Host.repeated_tool_call_result
-      ~model:"official-client-model"
-      ~session_id:"session-1"
-      ~turn_id:"turn-2"
-      ~turns_used:2
-      (Repeated_tool_call { tool_name = "masc_probe"; repeated_count = 3 })
+    match
+      Host.host_stop_result
+        ~model:"official-client-model"
+        ~session_id:"session-1"
+        ~turn_id:"turn-2"
+        ~turns_used:2
+        (Repeated_tool_call { tool_name = "masc_probe"; repeated_count = 3 })
+    with
+    | Ok result -> result
+    | Error error -> fail (Agent_core.Error.to_string error)
   in
   check string "session" "session-1" result.session_id;
   check int "turns" 2 result.turns;
@@ -305,6 +319,176 @@ let test_repeated_tool_host_stop_is_a_checkpoint_yield () =
     check string "typed tool" "masc_probe" tool_name;
     check int "typed count" 3 repeated_count
   | _ -> fail "host stop was not projected as a repeated-tool checkpoint yield"
+;;
+
+let test_terminal_post_effect_failure_aborts_the_official_client_turn () =
+  with_active_raw_trace (fun ~path:_ ~active ->
+    let state = ref Masc.Keeper_tools_agent_core.Terminal_effect_open in
+    let tool, _terminal_error =
+      one_dynamic_tool
+        ~descriptor:
+          (Agent_core.Tool.terminal_descriptor
+             Agent_core.Tool_contract.Effect_outcome_unknown)
+        ~terminal_effect_state:(fun () -> !state)
+        ~active
+        (fun _input ->
+           state :=
+             Masc.Keeper_tools_agent_core.Terminal_effect_failed
+               { failure_class = Tool_result.Runtime_failure
+               ; effect_disposition = Tool_result.Proven_post_effect
+               ; diagnostic = "prior composition action committed"
+               };
+           Error
+             { Agent_core.Types.message = "terminal node rejected"
+             ; recoverable = false
+             ; error_class = Some Agent_core.Types.Deterministic
+             })
+    in
+    let result = tool.call ~call_id:"terminal-post-effect" (`Assoc []) in
+    match result.abort_turn with
+    | Some
+        (Terminal_tool_boundary
+          { tool_name
+          ; outcome = Terminal_failed { effect_disposition; _ }
+          }) ->
+      check string
+        "typed failure effect"
+        "proven_post_effect"
+        (Tool_result.failure_effect_disposition_to_string effect_disposition);
+      check string "terminal tool" "effect" tool_name
+    | Some
+        (Terminal_tool_boundary
+          { outcome =
+              ( Terminal_completed
+              | Durable_stimulus_deferred
+              | External_effect_deferred )
+          ; _
+          })
+    | Some (Repeated_tool_call _)
+    | None ->
+      fail "post-effect terminal failure did not close the official-client loop")
+;;
+
+let test_terminal_pre_effect_failure_remains_correction_capable () =
+  with_active_raw_trace (fun ~path:_ ~active ->
+    let tool, _terminal_error =
+      one_dynamic_tool
+        ~descriptor:
+          (Agent_core.Tool.terminal_descriptor
+             Agent_core.Tool_contract.Effect_outcome_unknown)
+        ~active
+        (fun _input ->
+           Error
+             { Agent_core.Types.message = "validation rejected before effect"
+             ; recoverable = false
+             ; error_class = Some Agent_core.Types.Deterministic
+             })
+    in
+    let result = tool.call ~call_id:"terminal-pre-effect" (`Assoc []) in
+    check bool
+      "pre-effect failure allows provider correction"
+      true
+      (Option.is_none result.abort_turn))
+;;
+
+let test_terminal_external_deferral_keeps_pending_stop () =
+  with_active_raw_trace (fun ~path:_ ~active ->
+    let state = ref Masc.Keeper_tools_agent_core.Terminal_effect_open in
+    let tool, _terminal_error =
+      one_dynamic_tool
+        ~descriptor:
+          (Agent_core.Tool.terminal_descriptor
+             Agent_core.Tool_contract.Effect_outcome_unknown)
+        ~terminal_effect_state:(fun () -> !state)
+        ~active
+        (fun _input ->
+           state := Masc.Keeper_tools_agent_core.External_effect_deferred;
+           Error
+             { Agent_core.Types.message = "waiting for durable approval"
+             ; recoverable = true
+             ; error_class = Some Agent_core.Types.Transient
+             })
+    in
+    let result = tool.call ~call_id:"terminal-deferred" (`Assoc []) in
+    match result.abort_turn with
+    | Some
+        (Terminal_tool_boundary
+          { outcome = External_effect_deferred; tool_name = "effect" }) ->
+      ()
+    | Some (Terminal_tool_boundary _)
+    | Some (Repeated_tool_call _)
+    | None ->
+      fail "external deferral did not retain its pending terminal stop")
+;;
+
+let test_terminal_generic_deferral_keeps_durable_stimulus_stop () =
+  with_active_raw_trace (fun ~path:_ ~active ->
+    let state = ref Masc.Keeper_tools_agent_core.Terminal_effect_open in
+    let tool, _terminal_error =
+      one_dynamic_tool
+        ~descriptor:
+          (Agent_core.Tool.terminal_descriptor
+             Agent_core.Tool_contract.Effect_outcome_unknown)
+        ~terminal_effect_state:(fun () -> !state)
+        ~active
+        (fun _input ->
+           state := Masc.Keeper_tools_agent_core.Deferred_tool_result;
+           Error
+             { Agent_core.Types.message = "waiting for durable stimulus"
+             ; recoverable = true
+             ; error_class = Some Agent_core.Types.Transient
+             })
+    in
+    let result = tool.call ~call_id:"terminal-generic-deferred" (`Assoc []) in
+    match result.abort_turn with
+    | Some
+        (Terminal_tool_boundary
+          { outcome = Durable_stimulus_deferred; tool_name = "effect" }) ->
+      ()
+    | Some (Terminal_tool_boundary _)
+    | Some (Repeated_tool_call _)
+    | None ->
+      fail "generic deferral did not retain its durable-stimulus terminal stop")
+;;
+
+let test_terminal_host_stop_preserves_completed_deferred_and_failed () =
+  let project outcome =
+    Host.host_stop_result
+      ~model:"official-client-model"
+      ~session_id:"session-terminal"
+      ~turn_id:"turn-terminal"
+      ~turns_used:4
+      (Terminal_tool_boundary { tool_name = "terminal"; outcome })
+  in
+  (match project Terminal_completed with
+   | Ok { Runtime_agent.stop_reason = Runtime_agent.Completed; _ } -> ()
+   | Ok _ | Error _ -> fail "terminal completion changed outcome");
+  (match project Durable_stimulus_deferred with
+   | Ok
+       { Runtime_agent.stop_reason =
+           Runtime_agent.Yielded_to_durable_stimulus { turns_used = 4 }
+       ; _
+       } ->
+     ()
+   | Ok _ | Error _ -> fail "generic deferral changed outcome");
+  (match project External_effect_deferred with
+   | Ok
+       { Runtime_agent.stop_reason =
+           Runtime_agent.Awaiting_external_effect { turns_used = 4 }
+       ; _
+       } ->
+     ()
+   | Ok _ | Error _ -> fail "external deferral changed outcome");
+  match
+    project
+      (Terminal_failed
+         { failure_class = Tool_result.Runtime_failure
+         ; effect_disposition = Tool_result.Effect_outcome_unknown
+         ; diagnostic = "terminal uncertainty"
+         })
+  with
+  | Error _ -> ()
+  | Ok _ -> fail "terminal failure became a completed host stop"
 ;;
 
 let msg role content : Agent_core.Types.message =
@@ -737,6 +921,26 @@ let () =
             "repeated host stop is a checkpoint yield"
             `Quick
             test_repeated_tool_host_stop_is_a_checkpoint_yield
+        ; test_case
+            "terminal post-effect failure aborts official-client turn"
+            `Quick
+            test_terminal_post_effect_failure_aborts_the_official_client_turn
+        ; test_case
+            "terminal pre-effect failure stays correction-capable"
+            `Quick
+            test_terminal_pre_effect_failure_remains_correction_capable
+        ; test_case
+            "terminal external deferral keeps pending stop"
+            `Quick
+            test_terminal_external_deferral_keeps_pending_stop
+        ; test_case
+            "terminal generic deferral keeps durable-stimulus stop"
+            `Quick
+            test_terminal_generic_deferral_keeps_durable_stimulus_stop
+        ; test_case
+            "terminal host stop preserves exact outcome"
+            `Quick
+            test_terminal_host_stop_preserves_completed_deferred_and_failed
         ] )
     ; ( "history encoding"
       , [ test_case

--- a/test/test_keeper_official_client_host.ml
+++ b/test/test_keeper_official_client_host.ml
@@ -529,6 +529,57 @@ let test_terminal_host_stop_preserves_completed_deferred_and_failed () =
   | Ok _ -> fail "terminal failure became a completed host stop"
 ;;
 
+let test_terminal_host_stop_runs_completion_hooks_in_order () =
+  let observed = ref [] in
+  let hooks =
+    { Agent_core.Hooks.empty with
+      after_turn =
+        Some
+          (function
+            | Agent_core.Hooks.AfterTurn { turn; response } ->
+              observed := Printf.sprintf "after:%d:%s" turn response.id :: !observed;
+              Continue
+            | _ -> fail "after_turn received the wrong event")
+    ; on_stop =
+        Some
+          (function
+            | Agent_core.Hooks.OnStop { response; _ } ->
+              observed := ("stop:" ^ response.id) :: !observed;
+              Continue
+            | _ -> fail "on_stop received the wrong event")
+    }
+  in
+  let projected =
+    Host.host_stop_result
+      ~model:"official-client-model"
+      ~session_id:"session-terminal"
+      ~turn_id:"turn-terminal"
+      ~turns_used:4
+      (Terminal_tool_boundary
+         { tool_name = "terminal"; outcome = Terminal_completed })
+  in
+  let response =
+    match projected with
+    | Ok result -> result.response
+    | Error error -> fail (Agent_core.Error.to_string error)
+  in
+  (match
+     Host.invoke_turn_completion_hooks
+       ~runtime_label:"Official client"
+       ~keeper_name:"keeper-terminal"
+       ~turn_count:4
+       ~hooks
+       response
+   with
+   | Ok () -> ()
+   | Error error -> fail (Agent_core.Error.to_string error));
+  check
+    (list string)
+    "after_turn precedes on_stop for the synthetic terminal"
+    [ "after:4:turn-terminal"; "stop:turn-terminal" ]
+    (List.rev !observed)
+;;
+
 let msg role content : Agent_core.Types.message =
   { role; content; name = None; tool_call_id = None; metadata = [] }
 ;;
@@ -983,6 +1034,10 @@ let () =
             "terminal host stop preserves exact outcome"
             `Quick
             test_terminal_host_stop_preserves_completed_deferred_and_failed
+        ; test_case
+            "terminal host stop runs completion hooks in order"
+            `Quick
+            test_terminal_host_stop_runs_completion_hooks_in_order
         ] )
     ; ( "history encoding"
       , [ test_case

--- a/test/test_keeper_persistence_span_history.ml
+++ b/test/test_keeper_persistence_span_history.ml
@@ -81,7 +81,7 @@ let oversized_heartbeat_row ts =
 
 let evidence ~now ~base ~keeper =
   let config = Workspace.default_config base in
-  let stat = Proof.turn_span_stats ~config keeper in
+  let stat = Proof.turn_span_stats ~config ~now keeper in
   (stat, Proof.turn_span_evidence_json ~now keeper stat)
 
 let json_field name = function
@@ -158,6 +158,27 @@ let single_segment_control () =
       check string "control: first_ts comes from the current segment" "current"
         (origin_segment json))
 
+let rotated_first_and_single_current_latest_satisfy_tiers () =
+  let base = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base)
+    (fun () ->
+      let now = 1_700_000_000.0 in
+      write_segment base ~keeper:"sparse" ~rotation:(Some 1)
+        [ turn_row (now -. (5.0 *. hour)) ];
+      write_segment base ~keeper:"sparse" ~rotation:None
+        [ turn_row (now -. 60.0) ];
+      let stat, json = evidence ~now ~base ~keeper:"sparse" in
+      check bool "distinct persisted endpoints satisfy the 4h tier" true
+        (Proof.has_persistent_turn_span_for ~required_span_hours:4.0 ~now stat);
+      check (option int) "current segment contains one recent interaction"
+        (Some 1)
+        (match json_field "recent_interaction_count" json with
+         | Some (`Int n) -> Some n
+         | _ -> None);
+      check string "first endpoint is attributed to rotated history" "rotated"
+        (origin_segment json))
+
 (* Recency is a separate requirement from span: a long history whose last turn
    is a day stale must still fail, or a stopped keeper reads as healthy. *)
 let stale_latest_turn_fails () =
@@ -216,14 +237,59 @@ let head_budget_exhaustion_is_explicit () =
          | Some (`Int n) -> Some n
          | _ -> None))
 
+let post_snapshot_turn_does_not_poison_valid_span () =
+  let base = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base)
+    (fun () ->
+      let now = 1_700_000_000.0 in
+      write_segment base ~keeper:"racing" ~rotation:None
+        [ turn_row (now -. (48.0 *. hour))
+        ; turn_row (now -. 60.0)
+        ; turn_row (now +. 1.0)
+        ];
+      let stat, json = evidence ~now ~base ~keeper:"racing" in
+      check bool "valid snapshot-relative span still passes" true
+        (Proof.has_persistent_turn_span ~now stat);
+      check (option (float 0.0)) "latest excludes the post-snapshot row"
+        (Some (now -. 60.0))
+        (float_field "latest_ts_unix" json);
+      check (option int) "post-snapshot row is not counted"
+        (Some 2)
+        (match json_field "recent_interaction_count" json with
+         | Some (`Int n) -> Some n
+         | _ -> None))
+
+let future_only_turns_do_not_prove_persistence () =
+  let base = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base)
+    (fun () ->
+      let now = 1_700_000_000.0 in
+      write_segment base ~keeper:"future" ~rotation:None
+        [ turn_row (now +. 1.0); turn_row (now +. hour) ];
+      let stat, json = evidence ~now ~base ~keeper:"future" in
+      check bool "future-only rows fail closed" false
+        (Proof.has_persistent_turn_span ~now stat);
+      check (option (float 0.0)) "future-only latest remains absent" None
+        (float_field "latest_ts_unix" json);
+      check string "future-only head is not accepted as history" "none"
+        (origin_segment json))
+
 let () =
   run "keeper persistence span history"
     [ ( "turn span"
       , [ test_case "rotated segment is reached" `Quick rotated_segment_reached
         ; test_case "control: single segment" `Quick single_segment_control
+        ; test_case "rotated first plus one current latest" `Quick
+            rotated_first_and_single_current_latest_satisfy_tiers
         ; test_case "stale latest turn fails" `Quick stale_latest_turn_fails
         ; test_case "no turn rows is explicit" `Quick no_turn_rows_is_explicit
         ; test_case "head budget exhaustion is explicit" `Quick
             head_budget_exhaustion_is_explicit
+        ; test_case "post-snapshot row is ignored" `Quick
+            post_snapshot_turn_does_not_poison_valid_span
+        ; test_case "future-only rows fail closed" `Quick
+            future_only_turns_do_not_prove_persistence
         ] )
     ]

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -89,6 +89,7 @@ let roundtrip_corpus =
     "runtime_exhausted"
   ; Keeper_internal_error.capacity_backpressure_kind
   ; Keeper_internal_error.incomplete_tool_transcript_kind
+  ; Keeper_internal_error.provider_attempt_effect_fenced_kind
   ; "internal_error"
   ; "pre_dispatch_success"
   ; "provider_error"
@@ -178,6 +179,11 @@ let frozen_operator_disposition (receipt : R.t)
   else if
     String.equal terminal_reason Keeper_internal_error.incomplete_tool_transcript_kind
   then R.Disp_operator_reset_required, R.Reason_transcript_corruption
+  else if
+    String.equal
+      terminal_reason
+      Keeper_internal_error.provider_attempt_effect_fenced_kind
+  then R.Disp_unknown, R.Reason_provider_attempt_effect_fenced
   else if preflight_config_failure
   then R.Disp_fail_open_next_runtime, R.Reason_preflight_config_error
   else if
@@ -308,7 +314,72 @@ let () =
      = (R.Disp_operator_reset_required, R.Reason_transcript_corruption));
   check
     "transcript corruption emits operator broadcast"
-    (R.needs_operator_broadcast (fst transcript_corruption))
+    (R.needs_operator_broadcast (fst transcript_corruption));
+  let fenced_error =
+    Keeper_internal_error.Provider_attempt_effect_fenced
+      { runtime_id = "antigravity_subscription.gemini-3-6-flash-high"
+      ; effect_disposition = Keeper_provider_attempt_effect_core.Effect_attempted
+      ; diagnostic = "provider response did not prove whether the tool effect settled"
+      }
+  in
+  let fenced_json = Keeper_internal_error.masc_internal_error_to_json fenced_error in
+  check
+    "provider-attempt fence codec emits the canonical kind"
+    (Json_util.get_string fenced_json "kind"
+     = Some Keeper_internal_error.provider_attempt_effect_fenced_kind);
+  check
+    "provider-attempt fence codec round-trips the typed evidence"
+    (Keeper_internal_error.parse_masc_internal_error_json fenced_json
+     = Some fenced_error);
+  let fenced_wire = Keeper_internal_error.provider_attempt_effect_fenced_kind in
+  let producer_wire =
+    fenced_error
+    |> Keeper_internal_error.core_error_of_masc_internal_error
+    |> Masc.Keeper_agent_error.terminal_reason_code_of_core_error
+  in
+  check
+    "provider-attempt fence producer projects the canonical terminal wire"
+    (String.equal producer_wire fenced_wire);
+  check
+    "provider-attempt fence wire decodes to the closed terminal variant"
+    (match Tr.of_wire fenced_wire with
+     | Tr.Provider_attempt_effect_fenced wire -> String.equal wire fenced_wire
+     | _ -> false);
+  check
+    "provider-attempt fence terminal wire round-trips byte-identically"
+    (String.equal (Tr.to_wire (Tr.of_wire fenced_wire)) fenced_wire);
+  let unmapped_metric = Keeper_metrics.(to_string ReceiptUnmappedDisposition) in
+  let unmapped_before = Masc.Otel_metric_store.metric_value_or_zero unmapped_metric () in
+  let fenced_disposition =
+    R.operator_disposition
+      { base_receipt with
+        terminal_reason_code = fenced_wire
+      ; error_kind = Some (R.error_kind_of_string "internal")
+      ; outcome = `Error
+      ; runtime_outcome = R.Runtime_failed
+      }
+  in
+  let unmapped_after = Masc.Otel_metric_store.metric_value_or_zero unmapped_metric () in
+  check
+    "provider-attempt fence keeps operator attention with a typed reason"
+    (fenced_disposition
+     = (R.Disp_unknown, R.Reason_provider_attempt_effect_fenced));
+  check
+    "provider-attempt fence reason has the canonical dashboard wire"
+    (String.equal
+       (R.operator_disposition_reason_to_string (snd fenced_disposition))
+       fenced_wire);
+  check
+    "attempted provider effect still forbids same-turn retry"
+    (not
+       (Keeper_provider_attempt_effect_core.allows_same_turn_retry
+          Keeper_provider_attempt_effect_core.Effect_attempted));
+  check
+    "provider-attempt fence still emits an operator broadcast"
+    (R.needs_operator_broadcast (fst fenced_disposition));
+  check
+    "provider-attempt fence does not increment the unmapped regression metric"
+    (Float.equal unmapped_before unmapped_after)
 ;;
 
 let () =

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -300,6 +300,47 @@ let test_exact_agent_core_occurrence_persisted () =
         (Safe_ops.json_string_opt "execution_mode" entry)
     | _ -> Alcotest.fail "expected exactly one entry")
 
+let test_composition_action_context_persisted () =
+  with_tmp_log (fun () ->
+    let typed_result =
+      Tool_result.Completed
+        { Tool_result.tool_name = "keeper_fs_read"
+        ; data = `Assoc [ "content", `String "typed output" ]
+        ; metadata = None
+        ; duration_ms = 12.5
+        }
+    in
+    Keeper_tool_call_log.log_call
+      ~keeper_name:"analyst"
+      ~tool_name:"keeper_fs_read"
+      ~input:(`Assoc [ "path", `String "lib/runtime.ml" ])
+      ~output_text:"typed output"
+      ~success:true
+      ~duration_ms:12.5
+      ~typed_result
+      ~composition_tool:"keeper_research_pipeline"
+      ~composition_run_id:"run-42"
+      ~composition_node_id:"fetch_sources"
+      ~composition_execution:Keeper_tool_composition_catalog.Async
+      ~parent_tool_use_id:"outer-7"
+      ();
+    match Keeper_tool_call_log.read_recent ~n:1 () with
+    | [ entry ] ->
+      List.iter
+        (fun (label, key, expected) ->
+           Alcotest.(check (option string))
+             label
+             (Some expected)
+             (Safe_ops.json_string_opt key entry))
+        [ "typed disposition", "disposition", "completed"
+        ; "composition tool", "composition_tool", "keeper_research_pipeline"
+        ; "composition run", "composition_run_id", "run-42"
+        ; "composition node", "composition_node_id", "fetch_sources"
+        ; "composition execution", "composition_execution", "async"
+        ; "outer provider call", "parent_tool_use_id", "outer-7"
+        ]
+    | _ -> Alcotest.fail "expected exactly one composition action entry")
+
 (* ── Redaction: tool names do not suppress evidence ────────────── *)
 
 let test_sensitive_named_tool_logged_with_redaction () =
@@ -1028,6 +1069,42 @@ let test_dashboard_aggregate_missing_runtime_profile_is_unknown () =
       1
       (Safe_ops.json_int ~default:0 "calls" unknown_bucket))
 
+let test_dashboard_aggregate_excludes_typed_deferred_from_failure_rate () =
+  with_tmp_log (fun () ->
+    let result =
+      Tool_result.make_deferred
+        ~tool_name:"keeper_wait"
+        ~start_time:(Time_compat.now ())
+        ~data:(`Assoc [ "reason", `String "external_effect_pending" ])
+        ()
+    in
+    Keeper_tool_call_log.log_call
+      ~keeper_name:"k-deferred"
+      ~tool_name:"keeper_wait"
+      ~input:(`Assoc [])
+      ~output_text:(Tool_result.message result)
+      ~success:(Tool_result.is_success result)
+      ~duration_ms:(Tool_result.duration_ms result)
+      ~typed_result:result
+      ();
+    let summary = Dashboard_http_tool_quality.aggregate ~n:10 () in
+    Alcotest.(check int)
+      "deferred remains visible as typed neutral outcome"
+      1
+      (Safe_ops.json_int ~default:0 "deferred" summary);
+    Alcotest.(check int)
+      "deferred excluded from settled quality total"
+      0
+      (Safe_ops.json_int ~default:(-1) "total" summary);
+    Alcotest.(check int)
+      "deferred is not a failure"
+      0
+      (Safe_ops.json_int ~default:(-1) "failure" summary);
+    Alcotest.(check bool)
+      "deferred is absent from settled per-tool rates"
+      true
+      Yojson.Safe.Util.(member "by_tool" summary |> to_list |> List.is_empty))
+
 let test_dashboard_hourly_trend_numeric_ts () =
   with_tmp_log_dir (fun dir ->
     let store =
@@ -1314,6 +1391,30 @@ let test_output_inline_string_preserved () =
         "small inline result" s
     | _ -> Alcotest.fail "expected exactly one entry")
 
+let test_output_preview_derives_truncation_metadata () =
+  with_tmp_log (fun () ->
+    let output_text = String.make 5000 'x' in
+    Keeper_tool_call_log.log_call
+      ~keeper_name:"k"
+      ~tool_name:"tool_large"
+      ~input:(`Assoc [])
+      ~output_text
+      ~result_bytes:(String.length output_text)
+      ~success:true
+      ~duration_ms:1.0
+      ();
+    match Keeper_tool_call_log.read_recent ~n:1 () with
+    | [ `Assoc fields ] ->
+      Alcotest.(check (option int))
+        "producer bytes retained"
+        (Some 5000)
+        (List.assoc_opt "result_bytes" fields |> Option.map Yojson.Safe.Util.to_int);
+      Alcotest.(check (option int))
+        "log preview clamp is explicit"
+        (Some 4000)
+        (List.assoc_opt "truncated_to" fields |> Option.map Yojson.Safe.Util.to_int)
+    | _ -> Alcotest.fail "expected exactly one object entry")
+
 let test_string_input_keeps_action_radius () =
   with_tmp_log (fun () ->
     Keeper_tool_call_log.log_call
@@ -1445,6 +1546,8 @@ let () =
         ; eio_test "unfiltered read is exactly n; filtered still finds n"
             test_unfiltered_read_is_exactly_n_and_filtered_still_finds_n
         ; eio_test "exact AGENT_CORE occurrence" test_exact_agent_core_occurrence_persisted
+        ; eio_test "composition action context"
+            test_composition_action_context_persisted
         ] )
     ; ( "redaction",
         [ eio_test "sensitive-named tool logged with redaction"
@@ -1480,6 +1583,8 @@ let () =
             test_dashboard_aggregate_groups_runtime_fields
         ; eio_test "dashboard aggregate marks missing runtime profile unknown"
             test_dashboard_aggregate_missing_runtime_profile_is_unknown
+        ; eio_test "dashboard aggregate keeps deferred neutral"
+            test_dashboard_aggregate_excludes_typed_deferred_from_failure_rate
         ; eio_test "dashboard hourly trend buckets numeric ts"
             test_dashboard_hourly_trend_numeric_ts
         ; eio_test "dashboard aggregate window hours"
@@ -1502,6 +1607,8 @@ let () =
             test_output_blob_marker_normalized
         ; eio_test "inline string output stays a JSON string"
             test_output_inline_string_preserved
+        ; eio_test "large output records preview truncation"
+            test_output_preview_derives_truncation_metadata
         ] )
     ; ( "action_radius",
         [ eio_test "string input does not break action radius"

--- a/test/test_keeper_tool_composition_catalog.ml
+++ b/test/test_keeper_tool_composition_catalog.ml
@@ -145,9 +145,46 @@ name = %S
 [[compositions.nodes]]
 id = "time"
 tool = "keeper_time_now"
-input = { kind = "literal", value = {} }
+[compositions.nodes.input]
+kind = "literal"
+value = {}
 |}
     name
+;;
+
+let test_catalog_projects_stable_tool_name_and_path () =
+  let catalog =
+    match Catalog.parse (one_node_composition "clock-check") with
+    | Ok catalog -> catalog
+    | Error _ -> fail "valid named composition was rejected"
+  in
+  let entry =
+    match Catalog.find catalog "clock-check" with
+    | Some entry -> entry
+    | None -> fail "named composition lookup failed"
+  in
+  check string "model-visible tool name" "keeper_compose_clock-check"
+    (Catalog.tool_name entry);
+  check string "resolved catalog path" "config/tool-compositions.toml"
+    (Catalog.path ~config_root:"config")
+;;
+
+let test_catalog_rejects_name_outside_tool_alphabet () =
+  match Catalog.parse (one_node_composition "clock check") with
+  | Error
+      (Catalog.Invalid_composition_name_character
+        { name = "clock check"; character = ' ' }) -> ()
+  | Error _ | Ok _ -> fail "composition name outside the tool alphabet was accepted"
+;;
+
+let test_catalog_rejects_name_beyond_provider_limit () =
+  let name = String.make 50 'a' in
+  match Catalog.parse (one_node_composition name) with
+  | Error
+      (Catalog.Composition_name_too_long
+        { name = actual; maximum_bytes = 49 }) ->
+    check string "rejected exact name" name actual
+  | Error _ | Ok _ -> fail "composition name beyond provider limit was accepted"
 ;;
 
 let test_catalog_rejects_duplicate_composition_names () =
@@ -164,7 +201,9 @@ name = "unknown-tool"
 [[compositions.nodes]]
 id = "unknown"
 tool = "invented_tool"
-input = { kind = "literal", value = {} }
+[compositions.nodes.input]
+kind = "literal"
+value = {}
 |}
   in
   match Catalog.parse document with
@@ -172,6 +211,43 @@ input = { kind = "literal", value = {} }
       (Catalog.Plan_rejected
         { error = Plan.Unknown_tool { tool_name = "invented_tool"; _ }; _ }) -> ()
   | Error _ | Ok _ -> fail "catalog bypassed canonical plan tool authority"
+;;
+
+let test_catalog_loader_distinguishes_missing_valid_and_invalid () =
+  let config_root = Filename.temp_file "keeper-composition-loader" "" in
+  Unix.unlink config_root;
+  Unix.mkdir config_root 0o755;
+  let catalog_path = Catalog.path ~config_root in
+  Fun.protect
+    ~finally:(fun () ->
+      if Sys.file_exists catalog_path then Unix.unlink catalog_path;
+      Unix.rmdir config_root)
+    (fun () ->
+       (match Masc.Keeper_run_tools_setup.load_composition_catalog ~config_root with
+        | Ok None -> ()
+        | Ok (Some _) | Error _ -> fail "missing catalog did not remain optional");
+       let write content =
+         let channel = open_out_bin catalog_path in
+         Fun.protect
+           ~finally:(fun () -> close_out channel)
+           (fun () -> output_string channel content)
+       in
+       write (one_node_composition "loaded");
+       (match Masc.Keeper_run_tools_setup.load_composition_catalog ~config_root with
+        | Ok (Some catalog) ->
+          check bool "valid catalog loaded" true (Option.is_some (Catalog.find catalog "loaded"))
+        | Ok None | Error _ -> fail "existing valid catalog was not loaded");
+       write "[[compositions]]\nname = \"broken\"\n";
+       match Masc.Keeper_run_tools_setup.load_composition_catalog ~config_root with
+       | Error
+           (Agent_core.Error.Config
+             (Agent_core.Error.InvalidConfig
+               { field = "tool-compositions.toml"; detail })) ->
+         check bool
+           "parse detail remains visible"
+           true
+           (String.length detail > 0)
+       | Ok _ | Error _ -> fail "invalid catalog did not return typed config error")
 ;;
 
 let () =
@@ -192,9 +268,25 @@ let () =
             `Quick
             test_catalog_rejects_duplicate_composition_names
         ; test_case
+            "projects stable tool name and path"
+            `Quick
+            test_catalog_projects_stable_tool_name_and_path
+        ; test_case
+            "rejects unsupported name characters"
+            `Quick
+            test_catalog_rejects_name_outside_tool_alphabet
+        ; test_case
+            "rejects name beyond provider limit"
+            `Quick
+            test_catalog_rejects_name_beyond_provider_limit
+        ; test_case
             "rejects unknown tools"
             `Quick
             test_catalog_rejects_unknown_tool_through_plan_authority
+        ; test_case
+            "loader distinguishes missing valid and invalid"
+            `Quick
+            test_catalog_loader_distinguishes_missing_valid_and_invalid
         ] )
     ]
 ;;

--- a/test/test_keeper_tool_composition_catalog.ml
+++ b/test/test_keeper_tool_composition_catalog.ml
@@ -7,6 +7,7 @@ let valid_catalog =
   {|[[compositions]]
 name = "time-memory-query"
 description = "Feed the exact clock result into memory search."
+execution = "inline"
 
 [[compositions.nodes]]
 id = "time"
@@ -94,6 +95,7 @@ let test_catalog_rejects_unknown_fields () =
   let document =
     {|[[compositions]]
 name = "bad"
+execution = "inline"
 guess = true
 [[compositions.nodes]]
 id = "time"
@@ -112,6 +114,7 @@ let test_catalog_rejects_malformed_output_pointer () =
   let document =
     {|[[compositions]]
 name = "bad-pointer"
+execution = "inline"
 [[compositions.nodes]]
 id = "time"
 tool = "keeper_time_now"
@@ -142,6 +145,7 @@ let one_node_composition name =
   Printf.sprintf
     {|[[compositions]]
 name = %S
+execution = "inline"
 [[compositions.nodes]]
 id = "time"
 tool = "keeper_time_now"
@@ -150,6 +154,86 @@ kind = "literal"
 value = {}
 |}
     name
+;;
+
+let one_node_async_composition name =
+  Printf.sprintf
+    {|[[compositions]]
+name = %S
+execution = "async"
+[[compositions.nodes]]
+id = "time"
+tool = "keeper_time_now"
+[compositions.nodes.input]
+kind = "literal"
+value = {}
+|}
+    name
+;;
+
+let test_catalog_requires_explicit_execution_mode () =
+  let document =
+    {|[[compositions]]
+name = "missing-execution"
+[[compositions.nodes]]
+id = "time"
+tool = "keeper_time_now"
+[compositions.nodes.input]
+kind = "literal"
+value = {}
+|}
+  in
+  match Catalog.parse document with
+  | Error
+      (Catalog.Missing_field
+        { path = [ "compositions"; "0" ]; field = "execution" }) ->
+    ()
+  | Error _ | Ok _ -> fail "composition execution mode was inferred"
+;;
+
+let test_catalog_accepts_async_only_for_statically_read_only_tools () =
+  let catalog =
+    match Catalog.parse (one_node_async_composition "clock-background") with
+    | Ok catalog -> catalog
+    | Error error -> fail (Catalog.error_to_string error)
+  in
+  let entry =
+    match Catalog.find catalog "clock-background" with
+    | Some entry -> entry
+    | None -> fail "async composition lookup failed"
+  in
+  (match entry.execution with
+   | Catalog.Async -> ()
+   | Catalog.Inline -> fail "async execution mode was rewritten");
+  check
+    (list string)
+    "async model surface includes exact controls"
+    [ "keeper_compose_clock-background"
+    ; "keeper_composition_status"
+    ; "keeper_composition_cancel"
+    ]
+    (Catalog.model_tool_names catalog)
+;;
+
+let test_catalog_rejects_async_effectful_tool () =
+  let document =
+    {|[[compositions]]
+name = "write-background"
+execution = "async"
+[[compositions.nodes]]
+id = "write"
+tool = "keeper_memory_write"
+[compositions.nodes.input]
+kind = "literal"
+value = { title = "not admitted", content = "effectful async" }
+|}
+  in
+  match Catalog.parse document with
+  | Error
+      (Catalog.Async_tool_not_statically_read_only
+        { name = "write-background"; node_id; tool_name = "keeper_memory_write" }) ->
+    check string "rejected node" "write" (Plan.Node_id.to_string node_id)
+  | Error _ | Ok _ -> fail "effectful async composition was admitted"
 ;;
 
 let test_catalog_projects_stable_tool_name_and_path () =
@@ -198,6 +282,7 @@ let test_catalog_rejects_unknown_tool_through_plan_authority () =
   let document =
     {|[[compositions]]
 name = "unknown-tool"
+execution = "inline"
 [[compositions.nodes]]
 id = "unknown"
 tool = "invented_tool"
@@ -294,6 +379,18 @@ let () =
             "rejects duplicate names"
             `Quick
             test_catalog_rejects_duplicate_composition_names
+        ; test_case
+            "requires explicit execution mode"
+            `Quick
+            test_catalog_requires_explicit_execution_mode
+        ; test_case
+            "accepts async statically read-only plan"
+            `Quick
+            test_catalog_accepts_async_only_for_statically_read_only_tools
+        ; test_case
+            "rejects async effectful tool"
+            `Quick
+            test_catalog_rejects_async_effectful_tool
         ; test_case
             "projects stable tool name and path"
             `Quick

--- a/test/test_keeper_tool_composition_catalog.ml
+++ b/test/test_keeper_tool_composition_catalog.ml
@@ -250,6 +250,33 @@ let test_catalog_loader_distinguishes_missing_valid_and_invalid () =
        | Ok _ | Error _ -> fail "invalid catalog did not return typed config error")
 ;;
 
+let test_catalog_tools_join_runtime_projection_authority () =
+  let catalog =
+    match Catalog.parse (one_node_composition "projected") with
+    | Ok catalog -> catalog
+    | Error _ -> fail "valid projection catalog was rejected"
+  in
+  let descriptors = Masc.Keeper_tool_descriptor.model_visible_descriptors () in
+  let descriptor_names =
+    descriptors
+    |> List.concat_map Masc.Keeper_tool_descriptor.keeper_model_names
+    |> List.sort_uniq String.compare
+  in
+  let expected =
+    Masc.Keeper_run_tools_setup.expected_model_tool_names
+      ~model_visible_descriptors:descriptors
+      ~composition_catalog:(Some catalog)
+  in
+  check bool
+    "dynamic composition joins descriptor projection"
+    true
+    (List.mem "keeper_compose_projected" expected);
+  check int
+    "projection adds exactly one composition tool"
+    (List.length descriptor_names + 1)
+    (List.length expected)
+;;
+
 let () =
   run
     "keeper_tool_composition_catalog"
@@ -287,6 +314,10 @@ let () =
             "loader distinguishes missing valid and invalid"
             `Quick
             test_catalog_loader_distinguishes_missing_valid_and_invalid
+        ; test_case
+            "catalog tools join runtime projection authority"
+            `Quick
+            test_catalog_tools_join_runtime_projection_authority
         ] )
     ]
 ;;

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -4648,6 +4648,200 @@ let composition_invocation ~completion =
     ~completion
 ;;
 
+let one_node_clock_composition =
+  {|[[compositions]]
+name = "clock"
+description = "Read the exact Keeper clock."
+
+[[compositions.nodes]]
+id = "time"
+tool = "keeper_time_now"
+[compositions.nodes.input]
+kind = "literal"
+value = {}
+|}
+;;
+
+let one_node_terminal_composition =
+  {|[[compositions]]
+name = "surface"
+
+[[compositions.nodes]]
+id = "post"
+tool = "keeper_surface_post"
+[compositions.nodes.input]
+kind = "literal"
+value = { surface = "dashboard", content = "composition terminal" }
+|}
+;;
+
+let invalid_clock_input_composition =
+  {|[[compositions]]
+name = "invalid-clock-input"
+
+[[compositions.nodes]]
+id = "time"
+tool = "keeper_time_now"
+[compositions.nodes.input]
+kind = "literal"
+value = { unsupported = true }
+|}
+;;
+
+let test_composition_catalog_materializes_and_executes_first_class_tool () =
+  with_exec_fixture "composition-first-class-tool"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       let composition_catalog =
+         match
+           Masc.Keeper_tool_composition_catalog.parse one_node_clock_composition
+         with
+         | Ok catalog -> catalog
+         | Error _ -> fail "valid clock composition catalog was rejected"
+       in
+       let tools =
+         Masc.Keeper_tools_agent_core_bundle.make_tools
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot:ctx_work
+           ~composition_catalog
+           ()
+       in
+       let tool =
+         match find_tool_by_name tools "keeper_compose_clock" with
+         | Some tool -> tool
+         | None -> fail "catalog entry was not materialized as an Agent-Core tool"
+       in
+       check string
+         "catalog description reaches model-visible schema"
+         "Read the exact Keeper clock."
+         tool.Agent_core.Tool.schema.description;
+       (match Agent_core.Tool.completion tool with
+        | Agent_core.Tool_contract.Continue_after_success -> ()
+        | Agent_core.Tool_contract.Terminal_after_success _ ->
+          fail "ordinary composition was materialized as terminal");
+       match
+         Agent_core.Tool.execute
+           ~invocation:
+             (composition_invocation
+                ~completion:Agent_core.Tool_contract.Continue_after_success)
+           tool
+           (`Assoc [])
+       with
+       | Error error ->
+         failf "materialized composition failed: %s" error.Agent_core.Types.message
+       | Ok output ->
+         let payload = parse_json output.Agent_core.Types.content in
+         check string
+           "outer composition identity"
+           "keeper_compose_clock"
+           Yojson.Safe.Util.(member "composition_tool" payload |> to_string);
+         (match Yojson.Safe.Util.member "actions" payload with
+          | `List [ action ] ->
+            check string
+              "nested node identity"
+              "time"
+              Yojson.Safe.Util.(member "node_id" action |> to_string);
+            check string
+              "nested tool identity"
+              "keeper_time_now"
+              Yojson.Safe.Util.(member "tool_name" action |> to_string);
+            check int
+              "nested planned index"
+              0
+              Yojson.Safe.Util.(member "schedule" action |> member "planned_index" |> to_int);
+            (match Yojson.Safe.Util.member "result" action with
+             | `Assoc fields ->
+               check bool
+                 "nested result exposes typed data"
+                 true
+                 (List.mem_assoc "data" fields)
+             | _ -> fail "nested action result lost typed result shape")
+          | _ -> fail "composition did not expose its single settled action"))
+;;
+
+let test_terminal_composition_materializes_terminal_completion () =
+  with_exec_fixture "composition-terminal-surface"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       let composition_catalog =
+         match
+           Masc.Keeper_tool_composition_catalog.parse one_node_terminal_composition
+         with
+         | Ok catalog -> catalog
+         | Error _ -> fail "valid terminal composition catalog was rejected"
+       in
+       let tools =
+         Masc.Keeper_tools_agent_core_bundle.make_tools
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot:ctx_work
+           ~composition_catalog
+           ()
+       in
+       let tool =
+         match find_tool_by_name tools "keeper_compose_surface" with
+         | Some tool -> tool
+         | None -> fail "terminal catalog entry was not materialized"
+       in
+       match Agent_core.Tool.completion tool with
+       | Agent_core.Tool_contract.Terminal_after_success
+           Agent_core.Tool_contract.Effect_outcome_unknown -> ()
+       | Agent_core.Tool_contract.Continue_after_success
+       | Agent_core.Tool_contract.Terminal_after_success _ ->
+         fail "terminal composition lost its outer completion contract")
+;;
+
+let test_composition_plan_failure_exposes_typed_cause () =
+  with_exec_fixture "composition-typed-plan-failure"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       let composition_catalog =
+         match
+           Masc.Keeper_tool_composition_catalog.parse invalid_clock_input_composition
+         with
+         | Ok catalog -> catalog
+         | Error _ -> fail "composition with runtime-invalid input was rejected too early"
+       in
+       let tool =
+         Masc.Keeper_tools_agent_core_bundle.make_tools
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot:ctx_work
+           ~composition_catalog
+           ()
+         |> List.find_opt (fun (tool : Agent_core.Tool.t) ->
+           String.equal tool.schema.name "keeper_compose_invalid-clock-input")
+         |> function
+         | Some tool -> tool
+         | None -> fail "invalid-input composition was not materialized"
+       in
+       match
+         Agent_core.Tool.execute
+           ~invocation:
+             (composition_invocation
+                ~completion:Agent_core.Tool_contract.Continue_after_success)
+           tool
+           (`Assoc [])
+       with
+       | Ok _ -> fail "runtime-invalid composition input unexpectedly succeeded"
+       | Error error ->
+         let payload = parse_json error.Agent_core.Types.message in
+         check string
+           "failed outer composition identity"
+           "keeper_compose_invalid-clock-input"
+           Yojson.Safe.Util.(member "composition_tool" payload |> to_string);
+         let cause = Yojson.Safe.Util.member "cause" payload in
+         check string
+           "typed executor cause"
+           "plan_execution_failed"
+           Yojson.Safe.Util.(member "kind" cause |> to_string);
+         check string
+           "typed plan failure"
+           "input_validation_failed"
+           Yojson.Safe.Util.(member "error" cause |> member "kind" |> to_string))
+;;
+
 let test_composition_runtime_uses_canonical_descriptor () =
   with_exec_fixture "composition-canonical-descriptor"
     (fun ~config ~meta ~publication_recovery ~ctx_work ->
@@ -4835,6 +5029,12 @@ let () =
         test_surface_post_append_failure_does_not_complete_terminal_effect;
       test_case "composition dispatch uses canonical descriptor authority" `Quick
         test_composition_runtime_uses_canonical_descriptor;
+      test_case "catalog composition is a first-class executable tool" `Quick
+        test_composition_catalog_materializes_and_executes_first_class_tool;
+      test_case "terminal catalog composition keeps terminal completion" `Quick
+        test_terminal_composition_materializes_terminal_completion;
+      test_case "composition failure exposes typed plan cause" `Quick
+        test_composition_plan_failure_exposes_typed_cause;
       test_case "terminal composition requires terminal outer invocation" `Quick
         test_composition_terminal_requires_terminal_outer_invocation;
     ]);

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -4688,6 +4688,79 @@ value = { unsupported = true }
 |}
 ;;
 
+let post_effect_terminal_failure_composition =
+  {|[[compositions]]
+name = "write-then-invalid-post"
+
+[[compositions.nodes]]
+id = "write"
+tool = "keeper_memory_write"
+[compositions.nodes.input]
+kind = "literal"
+value = { title = "composition effect", content = "must execute exactly once" }
+
+[[compositions.nodes]]
+id = "post"
+tool = "keeper_surface_post"
+after = ["write"]
+[compositions.nodes.input]
+kind = "literal"
+value = {}
+|}
+;;
+
+let unknown_effect_terminal_failure_composition =
+  {|[[compositions]]
+name = "unknown-write-before-post"
+
+[[compositions.nodes]]
+id = "write"
+tool = "keeper_memory_write"
+[compositions.nodes.input]
+kind = "literal"
+value = { title = "composition unknown", content = "do not retry an uncertain write" }
+
+[[compositions.nodes]]
+id = "post"
+tool = "keeper_surface_post"
+after = ["write"]
+[compositions.nodes.input]
+kind = "literal"
+value = { surface = "dashboard", content = "must not be reached" }
+|}
+;;
+
+let write_then_unchanged_board_then_terminal_composition ~revision =
+  Printf.sprintf
+    {|[[compositions]]
+name = "write-then-durable-wait"
+
+[[compositions.nodes]]
+id = "write"
+tool = "keeper_memory_write"
+[compositions.nodes.input]
+kind = "literal"
+value = { title = "composition before wait", content = "must execute exactly once before yielding" }
+
+[[compositions.nodes]]
+id = "wait"
+tool = "masc_board_list"
+after = ["write"]
+[compositions.nodes.input]
+kind = "literal"
+value = { if_revision = %S }
+
+[[compositions.nodes]]
+id = "post"
+tool = "keeper_surface_post"
+after = ["wait"]
+[compositions.nodes.input]
+kind = "literal"
+value = { surface = "dashboard", content = "must not be reached" }
+|}
+    revision
+;;
+
 let test_composition_catalog_materializes_and_executes_first_class_tool () =
   with_exec_fixture "composition-first-class-tool"
     (fun ~config ~meta ~publication_recovery ~ctx_work ->
@@ -4842,6 +4915,308 @@ let test_composition_plan_failure_exposes_typed_cause () =
            Yojson.Safe.Util.(member "error" cause |> member "kind" |> to_string))
 ;;
 
+let test_terminal_composition_post_effect_failure_closes_official_client_loop () =
+  with_exec_fixture "composition-post-effect-terminal-failure"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       (match
+          Masc.Keeper_gate_mode.set
+            config
+            ~actor:"composition-test"
+            Masc.Keeper_gate_mode.Always_allow
+        with
+        | Ok _ -> ()
+        | Error detail -> fail ("failed to allow composition effect: " ^ detail));
+       let catalog =
+         match
+           Masc.Keeper_tool_composition_catalog.parse
+             post_effect_terminal_failure_composition
+         with
+         | Ok catalog -> catalog
+         | Error error ->
+           fail (Masc.Keeper_tool_composition_catalog.error_to_string error)
+       in
+       let bundle =
+         Masc.Keeper_tools_agent_core_bundle.make_tool_bundle
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot:ctx_work
+           ~composition_catalog:catalog
+           ()
+       in
+       Fun.protect
+         ~finally:bundle.cleanup
+         (fun () ->
+            let terminal_error = ref None in
+            let projected =
+              match
+                Masc.Keeper_official_client_host.dynamic_tools
+                  ~runtime_label:"test-official-client"
+                  ~keeper_name:meta.name
+                  ~turn_count:7
+                  ~tools:bundle.tools
+                  ~hooks:Agent_core.Hooks.empty
+                  ~event_bus:None
+                  ~context_injector:None
+                  ~context:(Some (Agent_core.Context.create_sync ()))
+                  ~terminal_effect_state:bundle.terminal_effect_state
+                  ~terminal_error
+                  ~raw_trace_run:None
+              with
+              | Ok tools -> tools
+              | Error error -> fail (Agent_core.Error.to_string error)
+            in
+            let tool =
+              projected
+              |> List.find_opt
+                   (fun (tool : Masc.Keeper_official_client_host.dynamic_tool) ->
+                      String.equal
+                        tool.name
+                        "keeper_compose_write-then-invalid-post")
+              |> function
+              | Some tool -> tool
+              | None -> fail "terminal composition was not projected"
+            in
+            let result = tool.call ~call_id:"post-effect-composition" (`Assoc []) in
+            check bool "terminal node failure is visible" false result.success;
+            (match bundle.terminal_effect_state () with
+             | Masc.Keeper_tools_agent_core.Terminal_effect_failed failure ->
+               check string
+                 "aggregate effect disposition"
+                 "proven_post_effect"
+                 (Tool_result.failure_effect_disposition_to_string
+                    failure.effect_disposition)
+             | _ -> fail "prior memory effect did not terminalize the bundle");
+            match result.abort_turn with
+            | Some
+                (Masc.Keeper_official_client_host.Terminal_tool_boundary
+                  { tool_name
+                  ; outcome =
+                      Masc.Keeper_official_client_host.Terminal_failed
+                        { effect_disposition = Tool_result.Proven_post_effect; _ }
+                  }) ->
+              check string
+                "official-client terminal tool"
+                "keeper_compose_write-then-invalid-post"
+                tool_name
+            | Some
+                (Masc.Keeper_official_client_host.Terminal_tool_boundary _)
+            | Some (Masc.Keeper_official_client_host.Repeated_tool_call _)
+            | None ->
+              fail "official-client provider loop remained open after prior effect"))
+;;
+
+let test_terminal_composition_unknown_write_failure_closes_official_client_loop () =
+  with_exec_fixture "composition-unknown-effect-terminal-failure"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       (match
+          Masc.Keeper_gate_mode.set
+            config
+            ~actor:"composition-test"
+            Masc.Keeper_gate_mode.Always_allow
+        with
+        | Ok _ -> ()
+        | Error detail -> fail ("failed to allow composition effect: " ^ detail));
+       let keepers_dir =
+         Config_dir_resolver.keepers_dir_for_base_path
+           ~base_path:config.base_path
+       in
+       let snapshot_path =
+         Masc.Keeper_memory_os_current.path_for_keepers_dir
+           ~keepers_dir
+           ~keeper_id:meta.name
+       in
+       (* A directory at the canonical snapshot path forces the writable
+          producer to report its exact unknown-effect persistence failure. *)
+       Fs_compat.mkdir_p snapshot_path;
+       let catalog =
+         match
+           Masc.Keeper_tool_composition_catalog.parse
+             unknown_effect_terminal_failure_composition
+         with
+         | Ok catalog -> catalog
+         | Error error ->
+           fail (Masc.Keeper_tool_composition_catalog.error_to_string error)
+       in
+       let bundle =
+         Masc.Keeper_tools_agent_core_bundle.make_tool_bundle
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot:ctx_work
+           ~composition_catalog:catalog
+           ()
+       in
+       Fun.protect
+         ~finally:bundle.cleanup
+         (fun () ->
+            let terminal_error = ref None in
+            let projected =
+              match
+                Masc.Keeper_official_client_host.dynamic_tools
+                  ~runtime_label:"test-official-client"
+                  ~keeper_name:meta.name
+                  ~turn_count:8
+                  ~tools:bundle.tools
+                  ~hooks:Agent_core.Hooks.empty
+                  ~event_bus:None
+                  ~context_injector:None
+                  ~context:(Some (Agent_core.Context.create_sync ()))
+                  ~terminal_effect_state:bundle.terminal_effect_state
+                  ~terminal_error
+                  ~raw_trace_run:None
+              with
+              | Ok tools -> tools
+              | Error error -> fail (Agent_core.Error.to_string error)
+            in
+            let tool =
+              projected
+              |> List.find_opt
+                   (fun (tool : Masc.Keeper_official_client_host.dynamic_tool) ->
+                      String.equal
+                        tool.name
+                        "keeper_compose_unknown-write-before-post")
+              |> function
+              | Some tool -> tool
+              | None -> fail "unknown-effect composition was not projected"
+            in
+            let result = tool.call ~call_id:"unknown-effect-composition" (`Assoc []) in
+            check bool "ordinary writable failure is visible" false result.success;
+            (match bundle.terminal_effect_state () with
+             | Masc.Keeper_tools_agent_core.Terminal_effect_failed failure ->
+               check string
+                 "producer-owned unknown disposition"
+                 "effect_outcome_unknown"
+                 (Tool_result.failure_effect_disposition_to_string
+                    failure.effect_disposition)
+             | _ -> fail "unknown writable failure did not terminalize the bundle");
+            match result.abort_turn with
+            | Some
+                (Masc.Keeper_official_client_host.Terminal_tool_boundary
+                  { tool_name
+                  ; outcome =
+                      Masc.Keeper_official_client_host.Terminal_failed
+                        { effect_disposition = Tool_result.Effect_outcome_unknown; _ }
+                  }) ->
+              check string
+                "official-client unknown-effect terminal tool"
+                "keeper_compose_unknown-write-before-post"
+                tool_name
+            | Some
+                (Masc.Keeper_official_client_host.Terminal_tool_boundary _)
+            | Some (Masc.Keeper_official_client_host.Repeated_tool_call _)
+            | None ->
+              fail "official-client provider loop remained open after unknown effect"))
+;;
+
+let test_terminal_composition_generic_defer_yields_to_durable_stimulus () =
+  with_exec_fixture "composition-generic-defer-terminal-boundary"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       (match
+          Masc.Keeper_gate_mode.set
+            config
+            ~actor:"composition-test"
+            Masc.Keeper_gate_mode.Always_allow
+        with
+        | Ok _ -> ()
+        | Error detail -> fail ("failed to allow composition effect: " ^ detail));
+       let direct_bundle =
+         Masc.Keeper_tools_agent_core_bundle.make_tool_bundle
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot:ctx_work
+           ()
+       in
+       let revision =
+         Fun.protect
+           ~finally:direct_bundle.cleanup
+           (fun () ->
+              let board_list =
+                match find_tool_by_name direct_bundle.tools "masc_board_list" with
+                | Some tool -> tool
+                | None -> fail "masc_board_list missing from Keeper tool bundle"
+              in
+              match Agent_core.Tool.execute board_list (`Assoc []) with
+              | Error error -> fail error.Agent_core.Types.message
+              | Ok output ->
+                Yojson.Safe.Util.
+                  (parse_json output.content |> member "revision" |> to_string))
+       in
+       let catalog =
+         match
+           Masc.Keeper_tool_composition_catalog.parse
+             (write_then_unchanged_board_then_terminal_composition ~revision)
+         with
+         | Ok catalog -> catalog
+         | Error error ->
+           fail (Masc.Keeper_tool_composition_catalog.error_to_string error)
+       in
+       let bundle =
+         Masc.Keeper_tools_agent_core_bundle.make_tool_bundle
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot:ctx_work
+           ~composition_catalog:catalog
+           ()
+       in
+       Fun.protect
+         ~finally:bundle.cleanup
+         (fun () ->
+            let terminal_error = ref None in
+            let projected =
+              match
+                Masc.Keeper_official_client_host.dynamic_tools
+                  ~runtime_label:"test-official-client"
+                  ~keeper_name:meta.name
+                  ~turn_count:9
+                  ~tools:bundle.tools
+                  ~hooks:Agent_core.Hooks.empty
+                  ~event_bus:None
+                  ~context_injector:None
+                  ~context:(Some (Agent_core.Context.create_sync ()))
+                  ~terminal_effect_state:bundle.terminal_effect_state
+                  ~terminal_error
+                  ~raw_trace_run:None
+              with
+              | Ok tools -> tools
+              | Error error -> fail (Agent_core.Error.to_string error)
+            in
+            let tool =
+              projected
+              |> List.find_opt
+                   (fun (tool : Masc.Keeper_official_client_host.dynamic_tool) ->
+                      String.equal
+                        tool.name
+                        "keeper_compose_write-then-durable-wait")
+              |> function
+              | Some tool -> tool
+              | None -> fail "generic-deferred composition was not projected"
+            in
+            let result = tool.call ~call_id:"generic-deferred-composition" (`Assoc []) in
+            check bool "generic-deferred composition is incomplete" false result.success;
+            (match bundle.terminal_effect_state () with
+             | Masc.Keeper_tools_agent_core.Deferred_tool_result -> ()
+             | _ -> fail "generic deferred node did not retain its typed bundle state");
+            match result.abort_turn with
+            | Some
+                (Masc.Keeper_official_client_host.Terminal_tool_boundary
+                  { tool_name
+                  ; outcome =
+                      Masc.Keeper_official_client_host.Durable_stimulus_deferred
+                  }) ->
+              check string
+                "official-client durable-stimulus terminal tool"
+                "keeper_compose_write-then-durable-wait"
+                tool_name
+            | Some
+                (Masc.Keeper_official_client_host.Terminal_tool_boundary _)
+            | Some (Masc.Keeper_official_client_host.Repeated_tool_call _)
+            | None ->
+              fail "official-client provider loop remained open after durable wait"))
+;;
+
 let test_composition_runtime_uses_canonical_descriptor () =
   with_exec_fixture "composition-canonical-descriptor"
     (fun ~config ~meta ~publication_recovery ~ctx_work ->
@@ -4930,6 +5305,7 @@ let test_composition_terminal_requires_terminal_outer_invocation () =
                        Agent_core.Tool_contract.Effect_outcome_unknown
                  ; actual = Agent_core.Tool_contract.Continue_after_success
                  }
+           ; effect_disposition = Tool_result.Proven_pre_effect
            } -> ()
        | Error _ | Ok _ ->
          fail "terminal composition accepted an ordinary outer invocation")
@@ -5035,6 +5411,12 @@ let () =
         test_terminal_composition_materializes_terminal_completion;
       test_case "composition failure exposes typed plan cause" `Quick
         test_composition_plan_failure_exposes_typed_cause;
+      test_case "post-effect composition closes official-client loop" `Quick
+        test_terminal_composition_post_effect_failure_closes_official_client_loop;
+      test_case "unknown-effect composition closes official-client loop" `Quick
+        test_terminal_composition_unknown_write_failure_closes_official_client_loop;
+      test_case "generic-deferred composition yields to durable stimulus" `Quick
+        test_terminal_composition_generic_defer_yields_to_durable_stimulus;
       test_case "terminal composition requires terminal outer invocation" `Quick
         test_composition_terminal_requires_terminal_outer_invocation;
     ]);

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -4652,6 +4652,7 @@ let one_node_clock_composition =
   {|[[compositions]]
 name = "clock"
 description = "Read the exact Keeper clock."
+execution = "inline"
 
 [[compositions.nodes]]
 id = "time"
@@ -4665,6 +4666,7 @@ value = {}
 let one_node_terminal_composition =
   {|[[compositions]]
 name = "surface"
+execution = "inline"
 
 [[compositions.nodes]]
 id = "post"
@@ -4678,6 +4680,7 @@ value = { surface = "dashboard", content = "composition terminal" }
 let invalid_clock_input_composition =
   {|[[compositions]]
 name = "invalid-clock-input"
+execution = "inline"
 
 [[compositions.nodes]]
 id = "time"
@@ -4691,6 +4694,7 @@ value = { unsupported = true }
 let post_effect_terminal_failure_composition =
   {|[[compositions]]
 name = "write-then-invalid-post"
+execution = "inline"
 
 [[compositions.nodes]]
 id = "write"
@@ -4712,6 +4716,7 @@ value = {}
 let unknown_effect_terminal_failure_composition =
   {|[[compositions]]
 name = "unknown-write-before-post"
+execution = "inline"
 
 [[compositions.nodes]]
 id = "write"
@@ -4734,6 +4739,7 @@ let write_then_unchanged_board_composition ~revision =
   Printf.sprintf
     {|[[compositions]]
 name = "write-then-durable-wait"
+execution = "inline"
 
 [[compositions.nodes]]
 id = "write"
@@ -4751,6 +4757,20 @@ kind = "literal"
 value = { if_revision = %S }
 |}
     revision
+;;
+
+let one_node_async_clock_composition =
+  {|[[compositions]]
+name = "clock-background"
+execution = "async"
+
+[[compositions.nodes]]
+id = "time"
+tool = "keeper_time_now"
+[compositions.nodes.input]
+kind = "literal"
+value = {}
+|}
 ;;
 
 let test_composition_catalog_materializes_and_executes_first_class_tool () =
@@ -5246,6 +5266,120 @@ let test_terminal_composition_post_effect_defer_closes_without_resume () =
               fail "official-client provider loop remained retryable after post-effect defer"))
 ;;
 
+let test_async_composition_uses_durable_request_status_surface () =
+  with_exec_fixture
+    ~bind_eio_context:true
+    "composition-async-durable-status"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       let catalog =
+         match
+           Masc.Keeper_tool_composition_catalog.parse
+             one_node_async_clock_composition
+         with
+         | Ok catalog -> catalog
+         | Error error ->
+           fail (Masc.Keeper_tool_composition_catalog.error_to_string error)
+       in
+       let tools =
+         Masc.Keeper_tools_agent_core_bundle.make_tools
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot:ctx_work
+           ~composition_catalog:catalog
+           ()
+       in
+       let async_tool =
+         match find_tool_by_name tools "keeper_compose_clock-background" with
+         | Some tool -> tool
+         | None -> fail "async composition tool was not materialized"
+       in
+       let status_tool =
+         match find_tool_by_name tools "keeper_composition_status" with
+         | Some tool -> tool
+         | None -> fail "async composition status tool was not materialized"
+       in
+       (match Agent_core.Tool.execution_mode status_tool with
+        | Agent_core.Tool_contract.Concurrent -> ()
+        | Agent_core.Tool_contract.Serial -> fail "status tool lost read-only concurrency");
+       let request_id =
+         match
+           Agent_core.Tool.execute
+             ~invocation:
+               (composition_invocation
+                  ~completion:Agent_core.Tool_contract.Continue_after_success)
+             async_tool
+             (`Assoc [])
+         with
+         | Error error -> fail error.Agent_core.Types.message
+         | Ok output ->
+           let payload = parse_json output.content in
+           check string
+             "async acceptance mode"
+             "async"
+             Yojson.Safe.Util.(member "execution" payload |> to_string);
+           Yojson.Safe.Util.(member "request_id" payload |> to_string)
+       in
+       let rec await_terminal () =
+         match
+           Masc.Keeper_msg_async.poll
+             ~base_path:config.base_path
+             ~caller:meta.name
+             request_id
+         with
+         | Masc.Keeper_msg_async.Found
+             ({ status = Masc.Keeper_msg_async.Done _; _ } as entry) ->
+           entry
+         | Masc.Keeper_msg_async.Found
+             { status =
+                 ( Masc.Keeper_msg_async.Queued
+                 | Masc.Keeper_msg_async.Running
+                 | Masc.Keeper_msg_async.Cancelling _ )
+             ; _
+             } ->
+           Eio.Fiber.yield ();
+           await_terminal ()
+         | Masc.Keeper_msg_async.Found
+             { status =
+                 ( Masc.Keeper_msg_async.Lost _
+                 | Masc.Keeper_msg_async.Cancelled _
+                 | Masc.Keeper_msg_async.Persistence_failed _ )
+             ; _
+             } ->
+           fail "async read-only composition did not complete"
+         | Masc.Keeper_msg_async.Absent -> fail "durable async request disappeared"
+         | Masc.Keeper_msg_async.Unreadable reason -> fail reason
+         | Masc.Keeper_msg_async.Rejected _ -> fail "async request access was rejected"
+       in
+       let clock =
+         match Eio_context.get_clock_opt () with
+         | Some clock -> clock
+         | None -> fail "async composition test lost its bound Eio clock"
+       in
+       ignore
+         (Eio.Time.with_timeout_exn clock 5.0 await_terminal
+           : Masc.Keeper_msg_async.entry);
+       match
+         Agent_core.Tool.execute
+           ~invocation:
+             (composition_invocation
+                ~completion:Agent_core.Tool_contract.Continue_after_success)
+           status_tool
+           (`Assoc [ "request_id", `String request_id ])
+       with
+       | Error error -> fail error.Agent_core.Types.message
+       | Ok output ->
+         let payload = parse_json output.content in
+         check string
+           "durable terminal status"
+           "done"
+           Yojson.Safe.Util.(member "status" payload |> to_string);
+         check string
+           "durable structured composition result"
+           "keeper_compose_clock-background"
+           Yojson.Safe.Util.(member "result" payload |> member "composition_tool" |> to_string))
+;;
+
 let test_composition_runtime_uses_canonical_descriptor () =
   with_exec_fixture "composition-canonical-descriptor"
     (fun ~config ~meta ~publication_recovery ~ctx_work ->
@@ -5446,6 +5580,8 @@ let () =
         test_terminal_composition_unknown_write_failure_closes_official_client_loop;
       test_case "post-effect deferred composition closes without resume" `Quick
         test_terminal_composition_post_effect_defer_closes_without_resume;
+      test_case "async composition exposes durable status" `Quick
+        test_async_composition_uses_durable_request_status_surface;
       test_case "terminal composition requires terminal outer invocation" `Quick
         test_composition_terminal_requires_terminal_outer_invocation;
     ]);

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -179,6 +179,20 @@ let parse_json raw =
   try Yojson.Safe.from_string raw with
   | Yojson.Json_error err -> fail ("invalid json: " ^ err)
 
+let structured_tool_output_exn ~base_path content =
+  match Tool_output.decode_from_agent_core content with
+  | Tool_output.Not_marker -> parse_json content
+  | Tool_output.Invalid_marker { detail } -> fail detail
+  | Tool_output.Decoded reference ->
+    if not (String.equal reference.mime Tool_output.artifact_manifest_mime)
+    then fail "tool output marker is not a typed result manifest";
+    let payload = fetch_artifact_exn ~base_path reference |> parse_json in
+    (match Tool_output.artifact_manifest_of_json payload with
+     | Tool_output.Decoded_artifact_manifest { structured_content; _ } ->
+       structured_content
+     | Tool_output.Not_artifact_manifest -> fail "typed result manifest is absent"
+     | Tool_output.Invalid_artifact_manifest { detail } -> fail detail)
+
 let outcome_label = function
   | Tool_result.Completed () -> "success"
   | Tool_result.Deferred () -> "deferred"
@@ -4773,6 +4787,67 @@ value = {}
 |}
 ;;
 
+let shell_output_composition =
+  {|[[compositions]]
+name = "shell-output"
+description = "Feed one typed Shell IR result into a later Keeper tool."
+execution = "inline"
+
+[[compositions.nodes]]
+id = "emit"
+tool = "Execute"
+[compositions.nodes.input]
+kind = "literal"
+value = { argv = ["printf", "shell-composition-marker"] }
+
+[[compositions.nodes]]
+id = "search"
+tool = "keeper_memory_search"
+after = ["emit"]
+[compositions.nodes.input]
+kind = "object"
+[[compositions.nodes.input.fields]]
+name = "query"
+[compositions.nodes.input.fields.value]
+kind = "output"
+node = "emit"
+pointer = "/output"
+|}
+;;
+
+let shell_artifact_composition () =
+  let oversized_output =
+    String.make (Masc.Tool_bridge.default_externalize_threshold_bytes + 1) 'x'
+  in
+  Printf.sprintf
+    {|[[compositions]]
+name = "shell-artifact"
+description = "Feed one typed Shell IR artifact identity into a later Keeper tool."
+execution = "inline"
+
+[[compositions.nodes]]
+id = "emit"
+tool = "Execute"
+[compositions.nodes.input]
+kind = "literal"
+value = { argv = ["printf", "%s"] }
+
+[[compositions.nodes]]
+id = "search"
+tool = "keeper_memory_search"
+after = ["emit"]
+[compositions.nodes.input]
+kind = "object"
+[[compositions.nodes.input.fields]]
+name = "query"
+[compositions.nodes.input.fields.value]
+kind = "output"
+node = "emit"
+pointer = "/output_artifact/_blob/sha256"
+|}
+    oversized_output
+;;
+
 let test_composition_catalog_materializes_and_executes_first_class_tool () =
   with_exec_fixture "composition-first-class-tool"
     (fun ~config ~meta ~publication_recovery ~ctx_work ->
@@ -4843,6 +4918,694 @@ let test_composition_catalog_materializes_and_executes_first_class_tool () =
                  (List.mem_assoc "data" fields)
              | _ -> fail "nested action result lost typed result shape")
           | _ -> fail "composition did not expose its single settled action"))
+;;
+
+let test_composition_feeds_typed_shell_ir_output_to_later_tool () =
+  with_exec_fixture
+    ~process:true
+    ~always_allow:true
+    "composition-shell-ir-output"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       let composition_catalog =
+         match Masc.Keeper_tool_composition_catalog.parse shell_output_composition with
+         | Ok catalog -> catalog
+         | Error error ->
+           fail (Masc.Keeper_tool_composition_catalog.error_to_string error)
+       in
+       let tools =
+         Masc.Keeper_tools_agent_core_bundle.make_tools
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot:ctx_work
+           ~composition_catalog
+           ()
+       in
+       let tool =
+         match find_tool_by_name tools "keeper_compose_shell-output" with
+         | Some tool -> tool
+         | None -> fail "Shell IR composition was not materialized"
+       in
+       match
+         Agent_core.Tool.execute
+           ~invocation:
+             (composition_invocation
+                ~completion:Agent_core.Tool_contract.Continue_after_success)
+           tool
+           (`Assoc [])
+       with
+       | Error error -> fail error.Agent_core.Types.message
+       | Ok output ->
+         let payload = parse_json output.content in
+         (match Yojson.Safe.Util.member "actions" payload with
+          | `List [ emit; search ] ->
+            check string
+              "Shell IR node"
+              "Execute"
+              Yojson.Safe.Util.(member "tool_name" emit |> to_string);
+            check bool
+              "Shell IR typed result"
+              true
+              Yojson.Safe.Util.
+                (member "result" emit |> member "data" |> member "typed" |> to_bool);
+            check string
+              "Shell IR exact output"
+              "shell-composition-marker"
+              Yojson.Safe.Util.
+                (member "result" emit |> member "data" |> member "output" |> to_string);
+            check string
+              "later node receives typed Shell IR output"
+              "shell-composition-marker"
+              Yojson.Safe.Util.(member "input" search |> member "query" |> to_string)
+          | _ -> fail "Shell IR composition did not settle both nodes in planned order"))
+;;
+
+let test_composition_externalizes_oversized_shell_ir_output () =
+  with_exec_fixture
+    ~process:true
+    ~always_allow:true
+    "composition-shell-ir-artifact"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       Masc.Keeper_tool_call_log.reset_for_testing ();
+       Masc.Keeper_tool_call_log.init ~base_path:config.base_path ();
+       let turn_ctx_cell = Masc.Keeper_tool_call_log.create_turn_ctx_cell () in
+       let composition_catalog =
+         match
+           Masc.Keeper_tool_composition_catalog.parse
+             (shell_artifact_composition ())
+         with
+         | Ok catalog -> catalog
+         | Error error ->
+           fail (Masc.Keeper_tool_composition_catalog.error_to_string error)
+       in
+       let tools =
+         Masc.Keeper_tools_agent_core_bundle.make_tools
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot:ctx_work
+           ~composition_catalog
+           ~turn_ctx_cell
+           ()
+       in
+       let tool =
+         match find_tool_by_name tools "keeper_compose_shell-artifact" with
+         | Some tool -> tool
+         | None -> fail "Shell IR artifact composition was not materialized"
+       in
+       match
+         Agent_core.Tool.execute
+           ~invocation:
+             (composition_invocation
+                ~completion:Agent_core.Tool_contract.Continue_after_success)
+           tool
+           (`Assoc [])
+       with
+       | Error error -> fail error.Agent_core.Types.message
+       | Ok output ->
+         let payload =
+           structured_tool_output_exn
+             ~base_path:config.base_path
+             output.content
+         in
+         (match Yojson.Safe.Util.member "actions" payload with
+          | `List [ emit; search ] ->
+            let data = Yojson.Safe.Util.(member "result" emit |> member "data") in
+            check
+              bool
+              "oversized output is not retained inline"
+              true
+              (Yojson.Safe.Util.member "output" data = `Null);
+            let artifact_ref field =
+              match
+                Yojson.Safe.Util.member field data
+                |> Tool_output.normalized_artifact_ref_of_json
+              with
+              | Tool_output.Decoded_normalized_artifact_ref reference -> reference
+              | Tool_output.Not_normalized_artifact_ref ->
+                failf
+                  "oversized Shell IR output has no normalized %s reference"
+                  field
+              | Tool_output.Invalid_normalized_artifact_ref { detail } -> fail detail
+            in
+            let output_ref = artifact_ref "output_artifact" in
+            let stdout_ref = artifact_ref "stdout_artifact" in
+            let stderr_ref = artifact_ref "stderr_artifact" in
+            check string "combined output equals stdout" output_ref.sha256 stdout_ref.sha256;
+            check int "empty stderr is still explicit" 0 stderr_ref.bytes;
+            let artifact =
+              fetch_artifact_exn ~base_path:config.base_path output_ref
+            in
+            check
+              int
+              "artifact retains every output byte"
+              (Masc.Tool_bridge.default_externalize_threshold_bytes + 1)
+              (String.length artifact);
+            let durable_root_present =
+              Masc.Keeper_tool_call_log.read_recent
+                ~keeper_name:meta.name
+                ~n:10
+                ()
+              |> List.exists (fun row ->
+                Safe_ops.json_string_opt "composition_node_id" row = Some "emit"
+                &&
+                match Yojson.Safe.Util.member "artifact_refs" row with
+                | `List roots ->
+                  List.exists
+                    (fun root ->
+                       let blob = Yojson.Safe.Util.member "_blob" root in
+                       Safe_ops.json_string_opt "sha256" blob
+                       = Some output_ref.sha256
+                       && Safe_ops.json_string_opt "preview" blob = Some "")
+                    roots
+                | _ -> false)
+            in
+            check
+              bool
+              "durable action log owns a preview-free artifact root"
+              true
+              durable_root_present;
+            let maintenance mode =
+              match
+                Tool_blob_maintenance.run ~base_path:config.base_path ~mode
+              with
+              | Ok report -> report
+              | Error error ->
+                fail (Tool_blob_maintenance.error_to_string error)
+            in
+            let observed = maintenance Tool_blob_maintenance.Observe_only in
+            check
+              bool
+              "durable action evidence roots the stream artifacts"
+              true
+              (observed.live_references >= 2);
+            ignore
+              (maintenance Tool_blob_maintenance.Delete_previous_candidates);
+            check
+              string
+              "maintenance preserves the referenced output"
+              artifact
+              (fetch_artifact_exn ~base_path:config.base_path output_ref);
+            check
+              string
+              "later node receives the artifact identity"
+              output_ref.sha256
+              Yojson.Safe.Util.(member "input" search |> member "query" |> to_string)
+          | _ ->
+            fail
+              "Shell IR artifact composition did not settle both nodes in planned order"))
+;;
+
+let test_direct_execute_artifact_manifest_survives_maintenance () =
+  with_exec_fixture
+    ~process:true
+    ~always_allow:true
+    "direct-shell-ir-artifact"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       let execute =
+         Masc.Keeper_tools_agent_core_bundle.make_tools
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot:ctx_work
+           ()
+         |> List.find_opt (fun (tool : Agent_core.Tool.t) ->
+           String.equal tool.schema.name "Execute")
+         |> function
+         | Some tool -> tool
+         | None -> fail "direct Execute tool is absent"
+       in
+       let oversized =
+         String.make (Masc.Tool_bridge.default_externalize_threshold_bytes + 1) 'd'
+       in
+       let output =
+         match
+           Agent_core.Tool.execute
+             ~invocation:
+               (composition_invocation
+                  ~completion:Agent_core.Tool_contract.Continue_after_success)
+             execute
+             (`Assoc [ "argv", `List [ `String "printf"; `String oversized ] ])
+         with
+         | Ok output -> output.Agent_core.Types.content
+         | Error error -> fail error.Agent_core.Types.message
+       in
+       let manifest_ref =
+         match Tool_output.decode_from_agent_core output with
+         | Tool_output.Decoded reference
+           when String.equal reference.mime Tool_output.artifact_manifest_mime ->
+           reference
+         | Tool_output.Decoded _ -> fail "direct Execute returned a non-manifest marker"
+         | Tool_output.Not_marker -> fail "direct Execute artifact result stayed inline"
+         | Tool_output.Invalid_marker { detail } -> fail detail
+       in
+       let durable_checkpoint =
+         Filename.concat
+           (Common.masc_dir_from_base_path ~base_path:config.base_path)
+           "keepers/direct-execute/checkpoint.json"
+       in
+       Fs_compat.mkdir_p (Filename.dirname durable_checkpoint);
+       Fs_compat.save_file
+         durable_checkpoint
+         (Yojson.Safe.to_string (`Assoc [ "tool_result", `String output ]));
+       let structured =
+         structured_tool_output_exn ~base_path:config.base_path output
+       in
+       let output_ref =
+         Yojson.Safe.Util.member "output_artifact" structured
+         |> Tool_output.normalized_artifact_ref_of_json
+         |> function
+         | Tool_output.Decoded_normalized_artifact_ref reference -> reference
+         | Tool_output.Not_normalized_artifact_ref ->
+           fail "direct Execute manifest lost its child output reference"
+         | Tool_output.Invalid_normalized_artifact_ref { detail } -> fail detail
+       in
+       let maintenance mode =
+         match Tool_blob_maintenance.run ~base_path:config.base_path ~mode with
+         | Ok report -> report
+         | Error error -> fail (Tool_blob_maintenance.error_to_string error)
+       in
+       let observed = maintenance Tool_blob_maintenance.Observe_only in
+       check bool
+         "direct checkpoint roots manifest and child streams"
+         true
+         (observed.live_references >= 3);
+       ignore (maintenance Tool_blob_maintenance.Delete_previous_candidates);
+       check string
+         "direct Execute child survives both maintenance passes"
+         oversized
+         (fetch_artifact_exn ~base_path:config.base_path output_ref);
+       check bool
+         "manifest itself survives both maintenance passes"
+         true
+         (match
+            Tool_blob_store.fetch
+              (Tool_blob_store.create ~base_path:config.base_path)
+              ~sha256:manifest_ref.sha256
+          with
+          | Ok (Some _) -> true
+          | Ok None | Error _ -> false))
+;;
+
+let test_direct_execute_post_effect_artifact_failure_closes_official_client_loop () =
+  with_exec_fixture
+    ~process:true
+    ~always_allow:true
+    "direct-shell-ir-post-effect-artifact-failure"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       let bundle =
+         Masc.Keeper_tools_agent_core_bundle.make_tool_bundle
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot:ctx_work
+           ()
+       in
+       Fun.protect
+         ~finally:bundle.cleanup
+         (fun () ->
+            let blob_root =
+              Tool_blob_store.create ~base_path:config.base_path
+              |> Tool_blob_store.root_dir
+            in
+            Fs_compat.mkdir_p (Filename.dirname blob_root);
+            Fs_compat.save_file blob_root "artifact persistence is blocked";
+            let marker = Filename.concat config.base_path "execute-invocations" in
+            let oversized =
+              String.make
+                (Masc.Tool_bridge.default_externalize_threshold_bytes + 1)
+                'p'
+            in
+            let terminal_error = ref None in
+            let projected =
+              match
+                Masc.Keeper_official_client_host.dynamic_tools
+                  ~runtime_label:"test-official-client"
+                  ~keeper_name:meta.name
+                  ~turn_count:1
+                  ~tools:bundle.tools
+                  ~hooks:Agent_core.Hooks.empty
+                  ~event_bus:None
+                  ~context_injector:None
+                  ~context:(Some (Agent_core.Context.create_sync ()))
+                  ~terminal_effect_state:bundle.terminal_effect_state
+                  ~terminal_error
+                  ~raw_trace_run:None
+              with
+              | Ok tools -> tools
+              | Error error -> fail (Agent_core.Error.to_string error)
+            in
+            let execute =
+              projected
+              |> List.find_opt
+                   (fun (tool : Masc.Keeper_official_client_host.dynamic_tool) ->
+                      String.equal tool.name "Execute")
+              |> function
+              | Some tool -> tool
+              | None -> fail "direct Execute tool was not projected"
+            in
+            let result =
+              execute.call
+                ~call_id:"direct-execute-post-effect-failure"
+                (`Assoc
+                   [ ( "argv"
+                     , `List
+                         [ `String "/bin/sh"
+                         ; `String "-c"
+                         ; `String "printf x >> \"$1\"; printf %s \"$2\""
+                         ; `String "keeper-execute-test"
+                         ; `String marker
+                         ; `String oversized
+                         ] )
+                   ])
+            in
+            check bool "artifact persistence failure is visible" false result.success;
+            check string
+              "the process effect occurs exactly once before settlement"
+              "x"
+              (read_file marker);
+            (match bundle.terminal_effect_state () with
+             | Masc.Keeper_tools_agent_core.Terminal_effect_failed
+                 { effect_disposition = Tool_result.Proven_post_effect; _ } ->
+               ()
+             | _ -> fail "ordinary Execute post-effect failure left bundle open");
+            match result.abort_turn with
+            | Some
+                (Masc.Keeper_official_client_host.Terminal_tool_boundary
+                  { tool_name = "Execute"
+                  ; outcome =
+                      Masc.Keeper_official_client_host.Terminal_failed
+                        { effect_disposition = Tool_result.Proven_post_effect; _ }
+                  }) ->
+              ()
+            | Some
+                (Masc.Keeper_official_client_host.Terminal_tool_boundary _)
+            | Some (Masc.Keeper_official_client_host.Repeated_tool_call _)
+            | None ->
+              fail "direct Execute post-effect failure remained provider-retryable"))
+;;
+
+let test_direct_pre_effect_and_readonly_failures_remain_correction_capable () =
+  with_exec_fixture
+    ~process:true
+    ~always_allow:true
+    "direct-pre-effect-correction"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       let bundle =
+         Masc.Keeper_tools_agent_core_bundle.make_tool_bundle
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot:ctx_work
+           ()
+       in
+       Fun.protect
+         ~finally:bundle.cleanup
+         (fun () ->
+            let terminal_error = ref None in
+            let projected =
+              match
+                Masc.Keeper_official_client_host.dynamic_tools
+                  ~runtime_label:"test-official-client"
+                  ~keeper_name:meta.name
+                  ~turn_count:1
+                  ~tools:bundle.tools
+                  ~hooks:Agent_core.Hooks.empty
+                  ~event_bus:None
+                  ~context_injector:None
+                  ~context:(Some (Agent_core.Context.create_sync ()))
+                  ~terminal_effect_state:bundle.terminal_effect_state
+                  ~terminal_error
+                  ~raw_trace_run:None
+              with
+              | Ok tools -> tools
+              | Error error -> fail (Agent_core.Error.to_string error)
+            in
+            let call name input =
+              let tool =
+                projected
+                |> List.find_opt
+                     (fun (tool : Masc.Keeper_official_client_host.dynamic_tool) ->
+                        String.equal tool.name name)
+                |> function
+                | Some tool -> tool
+                | None -> failf "%s was not projected" name
+              in
+              tool.call ~call_id:("correction-" ^ name) input
+            in
+            let invalid_execute =
+              call "Execute" (`Assoc [ "argv", `List [ `String "" ] ])
+            in
+            check bool "invalid Execute is a failure" false invalid_execute.success;
+            check
+              (option string)
+              "pre-effect Execute failure keeps the turn open"
+              None
+              (Option.map
+                 (fun _ -> "abort")
+                 invalid_execute.abort_turn);
+            let invalid_write =
+              call
+                "Write"
+                (`Assoc
+                   [ "file_path", `String ""
+                   ; "content", `String "must not be written"
+                   ])
+            in
+            check bool "invalid Write is a failure" false invalid_write.success;
+            check
+              (option string)
+              "unaudited ordinary producer keeps its prior correction behavior"
+              None
+              (Option.map (fun _ -> "abort") invalid_write.abort_turn);
+            let missing_artifact =
+              call
+                "keeper_artifact_read"
+                (`Assoc [ "sha256", `String (String.make 64 '0') ])
+            in
+            check bool "missing artifact is a failure" false missing_artifact.success;
+            check
+              (option string)
+              "read-only failure keeps the turn open"
+              None
+              (Option.map
+                 (fun _ -> "abort")
+                 missing_artifact.abort_turn);
+            match bundle.terminal_effect_state () with
+            | Masc.Keeper_tools_agent_core.Terminal_effect_open -> ()
+            | _ -> fail "correction-capable failures poisoned terminal state"))
+;;
+
+let test_composition_action_commit_advances_revision_before_refresh_event () =
+  with_exec_fixture "composition-action-commit-refresh"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       let subscriber_id = "composition-action-commit-refresh" in
+       let frames = ref [] in
+       Masc.Keeper_tool_call_log.reset_for_testing ();
+       Masc.Keeper_tool_call_log.init ~base_path:config.base_path ();
+       let revision_before = Masc.Keeper_tool_call_log.committed_revision () in
+       Masc.Sse.subscribe_external
+         ~id:subscriber_id
+         ~callback:(fun event ->
+           let frame = event.Masc.Sse.ext_frame in
+           frames := frame :: !frames)
+         ();
+       Fun.protect
+         ~finally:(fun () ->
+           Masc.Sse.unsubscribe_external subscriber_id;
+           Masc.Keeper_tool_call_log.reset_for_testing ())
+         (fun () ->
+            let composition_catalog =
+              match
+                Masc.Keeper_tool_composition_catalog.parse one_node_clock_composition
+              with
+              | Ok catalog -> catalog
+              | Error _ -> fail "valid clock composition catalog was rejected"
+            in
+            let turn_ctx_cell = Masc.Keeper_tool_call_log.create_turn_ctx_cell () in
+            let tool =
+              Masc.Keeper_tools_agent_core_bundle.make_tools
+                ~config
+                ~meta
+                ~publication_recovery
+                ~ctx_snapshot:ctx_work
+                ~composition_catalog
+                ~turn_ctx_cell
+                ()
+              |> List.find_opt (fun tool ->
+                String.equal tool.Agent_core.Tool.schema.name "keeper_compose_clock")
+              |> Option.get
+            in
+            (match
+               Agent_core.Tool.execute
+                 ~invocation:
+                   (composition_invocation
+                      ~completion:Agent_core.Tool_contract.Continue_after_success)
+                 tool
+                 (`Assoc [])
+             with
+             | Ok _ -> ()
+             | Error error ->
+               failf "materialized composition failed: %s" error.Agent_core.Types.message);
+            let rows =
+              Masc.Keeper_tool_call_log.read_recent ~keeper_name:meta.name ~n:1 ()
+            in
+            let committed_row =
+              match rows with
+              | [ row ] ->
+               check
+                 (option string)
+                 "committed nested row is immediately readable"
+                 (Some "time")
+                 (Safe_ops.json_string_opt "composition_node_id" row);
+               check
+                 (option string)
+                 "committed nested row preserves the runtime model bucket"
+                 (Some
+                    (Keeper_hooks_agent_core_types.current_keeper_model meta))
+                 (Safe_ops.json_string_opt "model" row);
+               check bool
+                 "committed nested row has canonical execution identity"
+                 true
+                 (match Safe_ops.json_string_opt "execution_id" row with
+                  | Some value -> String.trim value <> ""
+                  | None -> false);
+               check bool
+                 "committed nested row has producer byte count"
+                 true
+                 (match row with
+                  | `Assoc fields -> List.mem_assoc "result_bytes" fields
+                  | _ -> false);
+               row
+              | _ -> fail "expected one synchronously committed nested action row"
+            in
+            check
+              int
+              "durable revision advances before refresh"
+              (revision_before + 1)
+              (Masc.Keeper_tool_call_log.committed_revision ());
+            let committed_refresh =
+              List.find_map
+                (fun frame ->
+                   match Masc.Sse.data_payload_of_frame frame with
+                   | Error Masc.Sse.Missing_data_payload -> None
+                   | Ok payload ->
+                     let json = Yojson.Safe.from_string payload in
+                     if Safe_ops.json_string_opt "composition_node_id" json = Some "time"
+                     then Some json
+                     else None)
+                !frames
+            in
+            let committed_refresh =
+              match committed_refresh with
+              | Some event -> event
+              | None -> fail "post-commit refresh event was not broadcast"
+            in
+            let physical_tool_call_events =
+              List.filter_map
+                (fun frame ->
+                   match Masc.Sse.data_payload_of_frame frame with
+                   | Error Masc.Sse.Missing_data_payload -> None
+                   | Ok payload ->
+                     let json = Yojson.Safe.from_string payload in
+                     if Safe_ops.json_string_opt "type" json = Some "keeper_tool_call"
+                     then Some json
+                     else None)
+                !frames
+            in
+            check
+              int
+              "one physical tool execution event"
+              1
+              (List.length physical_tool_call_events);
+            check
+              (option string)
+              "commit refresh has a distinct event type"
+              (Some "keeper_tool_call_evidence_committed")
+              (Safe_ops.json_string_opt "type" committed_refresh);
+            List.iter
+              (fun field ->
+                 check
+                   (option string)
+                   (field ^ " joins committed row and refresh event")
+                   (Safe_ops.json_string_opt field committed_row)
+                   (Safe_ops.json_string_opt field committed_refresh))
+              [ "tool_use_id"; "composition_run_id" ]))
+;;
+
+let test_composition_telemetry_failure_does_not_change_execution () =
+  with_exec_fixture "composition-telemetry-best-effort"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       let frames = ref [] in
+       let subscriber_id = "composition-telemetry-best-effort" in
+       Masc.Keeper_tool_call_log.reset_for_testing ();
+       Masc.Sse.subscribe_external
+         ~id:subscriber_id
+         ~callback:(fun event -> frames := event.Masc.Sse.ext_frame :: !frames)
+         ();
+       Fun.protect
+         ~finally:(fun () ->
+           Masc.Sse.unsubscribe_external subscriber_id;
+           Masc.Keeper_tool_call_log.reset_for_testing ())
+         (fun () ->
+            let composition_catalog =
+              match
+                Masc.Keeper_tool_composition_catalog.parse one_node_clock_composition
+              with
+              | Ok catalog -> catalog
+              | Error _ -> fail "valid clock composition catalog was rejected"
+            in
+            let turn_ctx_cell = Masc.Keeper_tool_call_log.create_turn_ctx_cell () in
+            let tool =
+              Masc.Keeper_tools_agent_core_bundle.make_tools
+                ~config
+                ~meta
+                ~publication_recovery
+                ~ctx_snapshot:ctx_work
+                ~composition_catalog
+                ~turn_ctx_cell
+                ()
+              |> List.find_opt (fun tool ->
+                String.equal tool.Agent_core.Tool.schema.name "keeper_compose_clock")
+              |> Option.get
+            in
+            (match
+               Agent_core.Tool.execute
+                 ~invocation:
+                   (composition_invocation
+                      ~completion:Agent_core.Tool_contract.Continue_after_success)
+                 tool
+                 (`Assoc [])
+             with
+             | Ok _ -> ()
+             | Error error ->
+               failf
+                 "telemetry outage changed composition execution: %s"
+                 error.Agent_core.Types.message);
+            check
+              int
+              "unavailable store does not fabricate a durable revision"
+              0
+              (Masc.Keeper_tool_call_log.committed_revision ());
+            let committed_refreshes =
+              List.filter_map
+                (fun frame ->
+                   match Masc.Sse.data_payload_of_frame frame with
+                   | Error Masc.Sse.Missing_data_payload -> None
+                   | Ok payload ->
+                     let json = Yojson.Safe.from_string payload in
+                     if
+                       Safe_ops.json_string_opt "type" json
+                       = Some "keeper_tool_call_evidence_committed"
+                     then Some json
+                     else None)
+                !frames
+            in
+            check
+              int
+              "no durable-commit refresh is emitted without a durable commit"
+              0
+              (List.length committed_refreshes)))
 ;;
 
 let test_terminal_composition_materializes_terminal_completion () =
@@ -5380,6 +6143,118 @@ let test_async_composition_uses_durable_request_status_surface () =
            Yojson.Safe.Util.(member "result" payload |> member "composition_tool" |> to_string))
 ;;
 
+let test_async_composition_status_preserves_artifact_manifest () =
+  with_exec_fixture
+    ~bind_eio_context:true
+    "composition-async-artifact-status"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       ignore publication_recovery;
+       ignore ctx_work;
+       let artifact_reference =
+         Tool_blob_store.put_durable
+           (Tool_blob_store.create ~base_path:config.base_path)
+           ~bytes:"async artifact payload"
+           ~mime:"text/plain"
+       in
+       let structured_data =
+         `Assoc
+           [ ( "output_artifact"
+             , Tool_output.normalized_artifact_ref_to_json artifact_reference )
+           ]
+       in
+       let background_sw =
+         match Masc.Keeper_msg_async.server_background_switch () with
+         | Ok sw -> sw
+         | Error error ->
+           fail
+             (Masc.Keeper_msg_async.submit_error_to_json error
+              |> Yojson.Safe.to_string)
+       in
+       let request_id =
+         match Masc.Keeper_msg_async.submit
+                 ~background_sw
+                 ~base_path:config.base_path
+                 ~caller:meta.name
+                 ~keeper_name:meta.name
+                 ~f:(fun _request_sw ->
+                   Tool_result.make_ok
+                     ~tool_name:"keeper_compose_artifact-fixture"
+                     ~start_time:(Time_compat.now ())
+                     ~data:structured_data
+                     ())
+                 ()
+         with
+         | Ok outcome -> outcome.request_id
+         | Error error ->
+           fail
+             (Masc.Keeper_msg_async.submit_error_to_json error
+              |> Yojson.Safe.to_string)
+       in
+       let rec await_terminal () =
+         match
+           Masc.Keeper_msg_async.poll
+             ~base_path:config.base_path
+             ~caller:meta.name
+             request_id
+         with
+         | Masc.Keeper_msg_async.Found
+             ({ status = Masc.Keeper_msg_async.Done _; _ } as entry) ->
+           entry
+         | Masc.Keeper_msg_async.Found
+             { status =
+                 ( Masc.Keeper_msg_async.Queued
+                 | Masc.Keeper_msg_async.Running
+                 | Masc.Keeper_msg_async.Cancelling _ )
+             ; _
+             } ->
+           Eio.Fiber.yield ();
+           await_terminal ()
+         | Masc.Keeper_msg_async.Found _ ->
+           fail "async artifact composition did not complete"
+         | Masc.Keeper_msg_async.Absent -> fail "async artifact request disappeared"
+         | Masc.Keeper_msg_async.Unreadable reason -> fail reason
+         | Masc.Keeper_msg_async.Rejected _ ->
+           fail "async artifact request access was rejected"
+       in
+       let clock =
+         match Eio_context.get_clock_opt () with
+         | Some clock -> clock
+         | None -> fail "async artifact test lost its bound Eio clock"
+       in
+       ignore
+         (Eio.Time.with_timeout_exn clock 5.0 await_terminal
+           : Masc.Keeper_msg_async.entry);
+       let status_result =
+         Masc.Keeper_tool_composition_surface.For_testing.status_result
+           ~config
+           ~meta
+           ~request_id
+       in
+       match Masc.Tool_bridge.to_agent_core_typed_result
+               ~base_path:config.base_path
+               status_result
+       with
+       | Error error -> fail error.Agent_core.Types.message
+       | Ok output ->
+         let payload =
+           structured_tool_output_exn
+             ~base_path:config.base_path
+             output.content
+         in
+         check string "artifact status remains terminal" "done"
+           Yojson.Safe.Util.(member "status" payload |> to_string);
+         let artifact =
+           Yojson.Safe.Util.
+             (member "result" payload
+              |> member "output_artifact")
+         in
+         match Tool_output.normalized_artifact_ref_of_json artifact with
+         | Tool_output.Decoded_normalized_artifact_ref _ -> ()
+         | Tool_output.Not_normalized_artifact_ref ->
+           fail "async status dropped its normalized artifact reference"
+         | Tool_output.Invalid_normalized_artifact_ref { detail } -> fail detail)
+;;
+
 let test_composition_runtime_uses_canonical_descriptor () =
   with_exec_fixture "composition-canonical-descriptor"
     (fun ~config ~meta ~publication_recovery ~ctx_work ->
@@ -5408,6 +6283,7 @@ let test_composition_runtime_uses_canonical_descriptor () =
          Masc.Keeper_tool_plan_executor.execute_keeper
            ~plan
            ~run_id:(Masc.Keeper_tool_plan.Run_id.fresh ())
+           ~composition_run_id:(Masc.Keeper_tool_plan.Composition_run_id.fresh ())
            ~parent_invocation:
              (composition_invocation
                 ~completion:Agent_core.Tool_contract.Continue_after_success)
@@ -5450,6 +6326,7 @@ let test_composition_terminal_requires_terminal_outer_invocation () =
          Masc.Keeper_tool_plan_executor.execute_keeper
            ~plan
            ~run_id:(Masc.Keeper_tool_plan.Run_id.fresh ())
+           ~composition_run_id:(Masc.Keeper_tool_plan.Composition_run_id.fresh ())
            ~parent_invocation:
              (composition_invocation
                 ~completion:Agent_core.Tool_contract.Continue_after_success)
@@ -5570,6 +6447,20 @@ let () =
         test_composition_runtime_uses_canonical_descriptor;
       test_case "catalog composition is a first-class executable tool" `Quick
         test_composition_catalog_materializes_and_executes_first_class_tool;
+      test_case "composition feeds typed Shell IR output to later tool" `Quick
+        test_composition_feeds_typed_shell_ir_output_to_later_tool;
+      test_case "composition externalizes oversized Shell IR output" `Quick
+        test_composition_externalizes_oversized_shell_ir_output;
+      test_case "direct Execute artifact manifest survives maintenance" `Quick
+        test_direct_execute_artifact_manifest_survives_maintenance;
+      test_case "direct Execute artifact failure closes official-client loop" `Quick
+        test_direct_execute_post_effect_artifact_failure_closes_official_client_loop;
+      test_case "direct pre-effect and read-only failures remain correction-capable" `Quick
+        test_direct_pre_effect_and_readonly_failures_remain_correction_capable;
+      test_case "composition action commit refreshes dashboard evidence" `Quick
+        test_composition_action_commit_advances_revision_before_refresh_event;
+      test_case "composition telemetry outage preserves execution" `Quick
+        test_composition_telemetry_failure_does_not_change_execution;
       test_case "terminal catalog composition keeps terminal completion" `Quick
         test_terminal_composition_materializes_terminal_completion;
       test_case "composition failure exposes typed plan cause" `Quick
@@ -5582,6 +6473,8 @@ let () =
         test_terminal_composition_post_effect_defer_closes_without_resume;
       test_case "async composition exposes durable status" `Quick
         test_async_composition_uses_durable_request_status_surface;
+      test_case "async composition status preserves artifact manifest" `Quick
+        test_async_composition_status_preserves_artifact_manifest;
       test_case "terminal composition requires terminal outer invocation" `Quick
         test_composition_terminal_requires_terminal_outer_invocation;
     ]);

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -4730,7 +4730,7 @@ value = { surface = "dashboard", content = "must not be reached" }
 |}
 ;;
 
-let write_then_unchanged_board_then_terminal_composition ~revision =
+let write_then_unchanged_board_composition ~revision =
   Printf.sprintf
     {|[[compositions]]
 name = "write-then-durable-wait"
@@ -4749,14 +4749,6 @@ after = ["write"]
 [compositions.nodes.input]
 kind = "literal"
 value = { if_revision = %S }
-
-[[compositions.nodes]]
-id = "post"
-tool = "keeper_surface_post"
-after = ["wait"]
-[compositions.nodes.input]
-kind = "literal"
-value = { surface = "dashboard", content = "must not be reached" }
 |}
     revision
 ;;
@@ -4987,6 +4979,15 @@ let test_terminal_composition_post_effect_failure_closes_official_client_loop ()
                  (Tool_result.failure_effect_disposition_to_string
                     failure.effect_disposition)
              | _ -> fail "prior memory effect did not terminalize the bundle");
+            let failure_payload = parse_json result.content in
+            check string
+              "nested failed node retains producer-owned disposition"
+              "proven_pre_effect"
+              Yojson.Safe.Util.
+                (member "cause" failure_payload
+                 |> member "node"
+                 |> member "failure_effect_disposition"
+                 |> to_string);
             match result.abort_turn with
             | Some
                 (Masc.Keeper_official_client_host.Terminal_tool_boundary
@@ -5109,7 +5110,7 @@ let test_terminal_composition_unknown_write_failure_closes_official_client_loop 
               fail "official-client provider loop remained open after unknown effect"))
 ;;
 
-let test_terminal_composition_generic_defer_yields_to_durable_stimulus () =
+let test_terminal_composition_post_effect_defer_closes_without_resume () =
   with_exec_fixture "composition-generic-defer-terminal-boundary"
     (fun ~config ~meta ~publication_recovery ~ctx_work ->
        (match
@@ -5146,7 +5147,7 @@ let test_terminal_composition_generic_defer_yields_to_durable_stimulus () =
        let catalog =
          match
            Masc.Keeper_tool_composition_catalog.parse
-             (write_then_unchanged_board_then_terminal_composition ~revision)
+             (write_then_unchanged_board_composition ~revision)
          with
          | Ok catalog -> catalog
          | Error error ->
@@ -5164,6 +5165,19 @@ let test_terminal_composition_generic_defer_yields_to_durable_stimulus () =
        Fun.protect
          ~finally:bundle.cleanup
          (fun () ->
+            let composition_tool =
+              match
+                find_tool_by_name
+                  bundle.tools
+                  "keeper_compose_write-then-durable-wait"
+              with
+              | Some tool -> tool
+              | None -> fail "ordinary generic-deferred composition was not materialized"
+            in
+            (match Agent_core.Tool.completion composition_tool with
+             | Agent_core.Tool_contract.Continue_after_success -> ()
+             | Agent_core.Tool_contract.Terminal_after_success _ ->
+               fail "composition without a terminal node became statically terminal");
             let terminal_error = ref None in
             let projected =
               match
@@ -5197,24 +5211,39 @@ let test_terminal_composition_generic_defer_yields_to_durable_stimulus () =
             let result = tool.call ~call_id:"generic-deferred-composition" (`Assoc []) in
             check bool "generic-deferred composition is incomplete" false result.success;
             (match bundle.terminal_effect_state () with
-             | Masc.Keeper_tools_agent_core.Deferred_tool_result -> ()
-             | _ -> fail "generic deferred node did not retain its typed bundle state");
+             | Masc.Keeper_tools_agent_core.Terminal_effect_failed failure ->
+               check string
+                 "prior write prevents false resumability"
+                 "proven_post_effect"
+                 (Tool_result.failure_effect_disposition_to_string
+                    failure.effect_disposition)
+             | _ -> fail "post-effect defer did not terminalize the composition");
+            let deferred_payload = parse_json result.content in
+            check string
+              "nested deferred node retains producer-owned kind"
+              "generic_deferred"
+              Yojson.Safe.Util.
+                (member "cause" deferred_payload
+                 |> member "node"
+                 |> member "deferred_kind"
+                 |> to_string);
             match result.abort_turn with
             | Some
                 (Masc.Keeper_official_client_host.Terminal_tool_boundary
                   { tool_name
                   ; outcome =
-                      Masc.Keeper_official_client_host.Durable_stimulus_deferred
+                      Masc.Keeper_official_client_host.Terminal_failed
+                        { effect_disposition = Tool_result.Proven_post_effect; _ }
                   }) ->
               check string
-                "official-client durable-stimulus terminal tool"
+                "official-client post-effect defer terminal tool"
                 "keeper_compose_write-then-durable-wait"
                 tool_name
             | Some
                 (Masc.Keeper_official_client_host.Terminal_tool_boundary _)
             | Some (Masc.Keeper_official_client_host.Repeated_tool_call _)
             | None ->
-              fail "official-client provider loop remained open after durable wait"))
+              fail "official-client provider loop remained retryable after post-effect defer"))
 ;;
 
 let test_composition_runtime_uses_canonical_descriptor () =
@@ -5415,8 +5444,8 @@ let () =
         test_terminal_composition_post_effect_failure_closes_official_client_loop;
       test_case "unknown-effect composition closes official-client loop" `Quick
         test_terminal_composition_unknown_write_failure_closes_official_client_loop;
-      test_case "generic-deferred composition yields to durable stimulus" `Quick
-        test_terminal_composition_generic_defer_yields_to_durable_stimulus;
+      test_case "post-effect deferred composition closes without resume" `Quick
+        test_terminal_composition_post_effect_defer_closes_without_resume;
       test_case "terminal composition requires terminal outer invocation" `Quick
         test_composition_terminal_requires_terminal_outer_invocation;
     ]);

--- a/test/test_keeper_tool_emission_hook.ml
+++ b/test/test_keeper_tool_emission_hook.ml
@@ -1,5 +1,6 @@
-(* Keeper tool-emission capture accepts only producer-owned typed objects.
-   JSON-looking text from the model-facing AGENT_CORE body is never reparsed. *)
+(* Keeper tool-emission capture retains only explicitly tagged,
+   producer-owned typed objects. JSON-looking text from the model-facing
+   AGENT_CORE body is never reparsed. *)
 
 module H = Masc.Keeper_tool_emission_hook
 
@@ -66,10 +67,11 @@ let test_snapshot_does_not_drain () =
   assert_size "snapshot preserves" 1 acc
 ;;
 
-let test_drain_skips_unmarked_object () =
+let test_capture_does_not_retain_unmarked_object () =
   let acc = H.create_accumulator () in
   H.capture_typed_result acc (tagged ~kind:"doc" ~id:"doc-2" []);
   H.capture_typed_result acc (`Assoc [ "echo", `String "hello" ]);
+  assert_size "only tagged object retained" 1 acc;
   let context = H.drain_into_working_context acc ~working_context:None in
   let artifacts, _ =
     match Multimodal.Wirein_helpers.extract_raw_artifacts context with
@@ -122,9 +124,9 @@ let () =
         ; Alcotest.test_case "drain empties" `Quick test_drain_empties_accumulator
         ; Alcotest.test_case "snapshot preserves" `Quick test_snapshot_does_not_drain
         ; Alcotest.test_case
-            "unmarked object not emitted"
+            "unmarked object not retained"
             `Quick
-            test_drain_skips_unmarked_object
+            test_capture_does_not_retain_unmarked_object
         ] )
     ; ( "keeper registry"
       , [ Alcotest.test_case "isolates keepers" `Quick test_registry_isolates_keepers

--- a/test/test_keeper_tool_plan.ml
+++ b/test/test_keeper_tool_plan.ml
@@ -429,12 +429,25 @@ let test_composable_output_registry_is_closed () =
     json_names
 ;;
 
+let test_composition_run_id_is_uuid_v7_identity () =
+  let first = Plan.Composition_run_id.fresh () in
+  let second = Plan.Composition_run_id.fresh () in
+  check bool "fresh composition identities differ" false (Plan.Composition_run_id.equal first second);
+  List.iter
+    (fun value ->
+       match Uuidm.of_string (Plan.Composition_run_id.to_string value) with
+       | Some uuid -> check int "composition run id UUID version" 7 (Uuidm.version uuid)
+       | None -> fail "composition run id is not a UUID")
+    [ first; second ]
+;;
+
 let () =
   Eio_main.run @@ fun _env ->
   run
     "keeper_tool_plan"
     [ ( "typed-values"
       , [ test_case "node id" `Quick test_node_id_rejects_empty
+        ; test_case "composition run UUID" `Quick test_composition_run_id_is_uuid_v7_identity
         ; test_case "JSON pointer" `Quick test_json_pointer_is_exact_rfc6901_navigation
         ; test_case "JSON template" `Quick test_json_template_preserves_declared_structure
         ] )

--- a/test/test_keeper_tool_plan_executor.ml
+++ b/test/test_keeper_tool_plan_executor.ml
@@ -170,6 +170,45 @@ let test_failed_sibling_stops_downstream_after_batch_settlement () =
        fail "tool failure became a plan error")
 ;;
 
+let test_deferred_cause_does_not_mask_unknown_sibling () =
+  Eio_main.run @@ fun _env ->
+  let plan = fixture () in
+  let dispatch ~node ~descriptor:_ ~schedule:_ ~input:_ =
+    match node_name node with
+    | "left" ->
+      Executor.dispatch_result
+        ~deferred_kind:Masc.Keeper_tool_execution.Generic_deferred
+        (Tool_result.make_deferred ~tool_name:"left" ~start_time:0.0 ())
+    | "right" ->
+      Executor.dispatch_result
+        ~failure_effect_disposition:Tool_result.Effect_outcome_unknown
+        (Tool_result.make_err
+           ~tool_name:"right"
+           ~class_:Tool_result.Runtime_failure
+           ~start_time:0.0
+           "right outcome unknown")
+    | _ ->
+      Executor.dispatch_result
+        (completed ~tool_name:node.Plan.tool_name ~data:(valid_data_for_node node))
+  in
+  match Executor.execute ~plan ~run_id:(Plan.Run_id.fresh ()) ~dispatch () with
+  | Ok _ -> fail "deferred and failed siblings did not stop the plan"
+  | Error failure ->
+    (match failure.cause with
+     | Executor.Tool_did_not_complete result ->
+       check string "lowest planned cause" "left" (Plan.Node_id.to_string result.node_id);
+       (match result.result with
+        | Tool_result.Deferred _ -> ()
+        | Tool_result.Completed _ | Tool_result.Failed _ ->
+          fail "lower-index deferred cause changed")
+     | Executor.Plan_execution_failed _ | Executor.Outer_completion_mismatch _ ->
+       fail "deferred cause became a plan error");
+    check string
+      "unknown sibling dominates deferred cause"
+      "effect_outcome_unknown"
+      (Tool_result.failure_effect_disposition_to_string failure.effect_disposition)
+;;
+
 let test_malformed_declared_output_stops_before_consumer () =
   Eio_main.run @@ fun _env ->
   let plan = fixture () in
@@ -228,6 +267,10 @@ let () =
             "failed sibling stops downstream"
             `Quick
             test_failed_sibling_stops_downstream_after_batch_settlement
+        ; test_case
+            "deferred cause does not mask unknown sibling"
+            `Quick
+            test_deferred_cause_does_not_mask_unknown_sibling
         ; test_case
             "malformed producer stops consumers"
             `Quick

--- a/test/test_keeper_tool_plan_executor.ml
+++ b/test/test_keeper_tool_plan_executor.ml
@@ -104,9 +104,13 @@ let test_schedule_and_parallel_dataflow () =
        (left.schedule.execution_mode = Agent_core.Tool_contract.Concurrent)
    | _ -> fail "descriptor-aware schedule shape changed");
   let sibling_count = Atomic.make 0 in
+  let observed = ref [] in
+  let dispatched = ref [] in
+  let execution_ids = ref [] in
   let both_started, release = Eio.Promise.create () in
-  let dispatch ~node ~descriptor:_ ~schedule:_ ~input =
+  let dispatch ~tool_use_id ~node ~descriptor:_ ~schedule:_ ~input =
     let name = node_name node in
+    dispatched := (name, tool_use_id) :: !dispatched;
     if String.equal name "left" || String.equal name "right"
     then (
       check string "parallel input" "{}" (Yojson.Safe.to_string input);
@@ -115,7 +119,23 @@ let test_schedule_and_parallel_dataflow () =
     Executor.dispatch_result
       (completed ~tool_name:node.Plan.tool_name ~data:(valid_data_for_node node))
   in
-  match Executor.execute ~plan ~run_id:(Plan.Run_id.fresh ()) ~dispatch () with
+  let observe_node_result result =
+    execution_ids := Ids.Execution_id.to_string result.Executor.execution_id :: !execution_ids;
+    observed
+      := ( Plan.Node_id.to_string result.Executor.node_id
+         , result.Executor.tool_use_id
+         , result.Executor.schedule.planned_index )
+         :: !observed;
+    Ok ()
+  in
+  match
+    Executor.execute
+      ~plan
+      ~run_id:(Plan.Run_id.fresh ())
+      ~dispatch
+      ~observe_node_result
+      ()
+  with
   | Error _ -> fail "valid parallel plan stopped"
   | Ok results ->
     check
@@ -123,14 +143,36 @@ let test_schedule_and_parallel_dataflow () =
       "settled execution order"
       [ "producer"; "left"; "right"; "final" ]
       (List.map (fun result -> Plan.Node_id.to_string result.Executor.node_id) results);
-    check int "both siblings entered before either returned" 2 (Atomic.get sibling_count)
+    check int "both siblings entered before either returned" 2 (Atomic.get sibling_count);
+    check int "one execution id per settled node" 4 (List.length !execution_ids);
+    check int
+      "execution ids are unique"
+      4
+      (List.sort_uniq String.compare !execution_ids |> List.length);
+    check
+      (list (pair string string))
+      "observer receives the exact pre-dispatch tool identity"
+      (List.sort compare !dispatched)
+      (List.map (fun (name, tool_use_id, _) -> name, tool_use_id) !observed
+       |> List.sort compare);
+    check int
+      "tool identities are unique"
+      4
+      (List.map snd !dispatched |> List.sort_uniq String.compare |> List.length);
+    List.iter
+      (fun (_, tool_use_id) ->
+         check bool
+           "tool identity is non-empty"
+           true
+           (String.length (String.trim tool_use_id) > 0))
+      !dispatched
 ;;
 
 let test_failed_sibling_stops_downstream_after_batch_settlement () =
   Eio_main.run @@ fun _env ->
   let plan = fixture () in
   let called = ref [] in
-  let dispatch ~node ~descriptor:_ ~schedule:_ ~input:_ =
+  let dispatch ~tool_use_id:_ ~node ~descriptor:_ ~schedule:_ ~input:_ =
     let name = node_name node in
     called := !called @ [ name ];
     if String.equal name "left"
@@ -166,14 +208,97 @@ let test_failed_sibling_stops_downstream_after_batch_settlement () =
        | Tool_result.Failed { class_ = Tool_result.Workflow_rejection; _ } -> ()
         | Tool_result.Completed _ | Tool_result.Deferred _ | Tool_result.Failed _ ->
           fail "canonical failed disposition changed")
-     | Executor.Plan_execution_failed _ | Executor.Outer_completion_mismatch _ ->
+     | Executor.Plan_execution_failed _
+     | Executor.Node_observation_failed _
+     | Executor.Outer_completion_mismatch _ ->
        fail "tool failure became a plan error")
+;;
+
+let test_observation_failure_settles_siblings_and_stops_downstream () =
+  Eio_main.run @@ fun _env ->
+  let plan = fixture () in
+  let observed = ref [] in
+  let dispatch ~tool_use_id:_ ~node ~descriptor:_ ~schedule:_ ~input:_ =
+    Executor.dispatch_result
+      (completed ~tool_name:node.Plan.tool_name ~data:(valid_data_for_node node))
+  in
+  let observe_node_result result =
+    let name = Plan.Node_id.to_string result.Executor.node_id in
+    observed := name :: !observed;
+    if String.equal name "left" then Error "durable append failed" else Ok ()
+  in
+  match
+    Executor.execute
+      ~plan
+      ~run_id:(Plan.Run_id.fresh ())
+      ~dispatch
+      ~observe_node_result
+      ()
+  with
+  | Ok _ -> fail "observation failure did not stop the plan"
+  | Error failure ->
+    check
+      (list string)
+      "all current siblings observed before stop"
+      [ "left"; "producer"; "right" ]
+      (List.sort String.compare !observed);
+    (match failure.cause with
+     | Executor.Node_observation_failed { node; detail } ->
+       check string "failed observation node" "left" (Plan.Node_id.to_string node.node_id);
+       check string "exact observation error" "durable append failed" detail
+     | Executor.Plan_execution_failed _
+     | Executor.Tool_did_not_complete _
+     | Executor.Outer_completion_mismatch _ ->
+       fail "observation failure lost its typed cause")
+;;
+
+let test_dispatch_exception_preserves_pre_minted_tool_identity () =
+  Eio_main.run @@ fun _env ->
+  let plan = fixture () in
+  let dispatched_id = ref None in
+  let observed_id = ref None in
+  let dispatch ~tool_use_id ~node:_ ~descriptor:_ ~schedule:_ ~input:_ =
+    dispatched_id := Some tool_use_id;
+    failwith "dispatch exploded before returning evidence"
+  in
+  let observe_node_result result =
+    observed_id := Some result.Executor.tool_use_id;
+    Ok ()
+  in
+  match
+    Executor.execute
+      ~plan
+      ~run_id:(Plan.Run_id.fresh ())
+      ~dispatch
+      ~observe_node_result
+      ()
+  with
+  | Ok _ -> fail "dispatch exception did not stop the plan"
+  | Error failure ->
+    check (option string) "observer keeps dispatch identity" !dispatched_id !observed_id;
+    (match !observed_id with
+     | Some tool_use_id ->
+       check bool
+         "exception identity is non-empty"
+         true
+         (String.length (String.trim tool_use_id) > 0)
+     | None -> fail "exception settlement was not observed");
+    (match failure.cause with
+     | Executor.Tool_did_not_complete result ->
+       check string
+         "failure carries the same identity"
+         (Option.get !dispatched_id)
+         result.tool_use_id
+     | Executor.Plan_execution_failed _
+     | Executor.Node_observation_failed _
+     | Executor.Outer_completion_mismatch _ ->
+       fail "dispatch exception lost its settled tool result")
 ;;
 
 let test_deferred_cause_does_not_mask_unknown_sibling () =
   Eio_main.run @@ fun _env ->
   let plan = fixture () in
-  let dispatch ~node ~descriptor:_ ~schedule:_ ~input:_ =
+  let dispatch ~tool_use_id:_ ~node ~descriptor:_ ~schedule:_ ~input:_ =
     match node_name node with
     | "left" ->
       Executor.dispatch_result
@@ -201,7 +326,9 @@ let test_deferred_cause_does_not_mask_unknown_sibling () =
         | Tool_result.Deferred _ -> ()
         | Tool_result.Completed _ | Tool_result.Failed _ ->
           fail "lower-index deferred cause changed")
-     | Executor.Plan_execution_failed _ | Executor.Outer_completion_mismatch _ ->
+     | Executor.Plan_execution_failed _
+     | Executor.Node_observation_failed _
+     | Executor.Outer_completion_mismatch _ ->
        fail "deferred cause became a plan error");
     check string
       "unknown sibling dominates deferred cause"
@@ -213,7 +340,7 @@ let test_malformed_declared_output_stops_before_consumer () =
   Eio_main.run @@ fun _env ->
   let plan = fixture () in
   let called = ref [] in
-  let dispatch ~node ~descriptor:_ ~schedule:_ ~input:_ =
+  let dispatch ~tool_use_id:_ ~node ~descriptor:_ ~schedule:_ ~input:_ =
     called := node_name node :: !called;
     Executor.dispatch_result
       (completed ~tool_name:node.tool_name ~data:(`Assoc [ "now_iso", `Int 7 ]))
@@ -228,6 +355,7 @@ let test_malformed_declared_output_stops_before_consumer () =
        when Plan.Node_id.equal failed (node_id "producer") -> ()
      | Executor.Plan_execution_failed _
      | Executor.Tool_did_not_complete _
+     | Executor.Node_observation_failed _
      | Executor.Outer_completion_mismatch _ ->
        fail "malformed producer did not retain its typed validation cause")
 ;;
@@ -267,6 +395,14 @@ let () =
             "failed sibling stops downstream"
             `Quick
             test_failed_sibling_stops_downstream_after_batch_settlement
+        ; test_case
+            "observation failure settles siblings and stops downstream"
+            `Quick
+            test_observation_failure_settles_siblings_and_stops_downstream
+        ; test_case
+            "dispatch exception preserves pre-minted identity"
+            `Quick
+            test_dispatch_exception_preserves_pre_minted_tool_identity
         ; test_case
             "deferred cause does not mask unknown sibling"
             `Quick

--- a/test/test_keeper_tool_plan_executor.ml
+++ b/test/test_keeper_tool_plan_executor.ml
@@ -112,7 +112,8 @@ let test_schedule_and_parallel_dataflow () =
       check string "parallel input" "{}" (Yojson.Safe.to_string input);
       if Atomic.fetch_and_add sibling_count 1 = 1 then Eio.Promise.resolve release ();
       Eio.Promise.await both_started);
-    completed ~tool_name:node.Plan.tool_name ~data:(valid_data_for_node node)
+    Executor.dispatch_result
+      (completed ~tool_name:node.Plan.tool_name ~data:(valid_data_for_node node))
   in
   match Executor.execute ~plan ~run_id:(Plan.Run_id.fresh ()) ~dispatch () with
   | Error _ -> fail "valid parallel plan stopped"
@@ -134,13 +135,16 @@ let test_failed_sibling_stops_downstream_after_batch_settlement () =
     called := !called @ [ name ];
     if String.equal name "left"
     then
-      Tool_result.make_err
-        ~tool_name:name
-        ~class_:Tool_result.Workflow_rejection
-        ~start_time:0.0
-        "left rejected"
+      Executor.dispatch_result
+        ~failure_effect_disposition:Tool_result.Proven_pre_effect
+        (Tool_result.make_err
+           ~tool_name:name
+           ~class_:Tool_result.Workflow_rejection
+           ~start_time:0.0
+           "left rejected")
     else
-      completed ~tool_name:node.Plan.tool_name ~data:(valid_data_for_node node)
+      Executor.dispatch_result
+        (completed ~tool_name:node.Plan.tool_name ~data:(valid_data_for_node node))
   in
   match Executor.execute ~plan ~run_id:(Plan.Run_id.fresh ()) ~dispatch () with
   | Ok _ -> fail "failed sibling did not stop the plan"
@@ -172,7 +176,8 @@ let test_malformed_declared_output_stops_before_consumer () =
   let called = ref [] in
   let dispatch ~node ~descriptor:_ ~schedule:_ ~input:_ =
     called := node_name node :: !called;
-    completed ~tool_name:node.tool_name ~data:(`Assoc [ "now_iso", `Int 7 ])
+    Executor.dispatch_result
+      (completed ~tool_name:node.tool_name ~data:(`Assoc [ "now_iso", `Int 7 ]))
   in
   match Executor.execute ~plan ~run_id:(Plan.Run_id.fresh ()) ~dispatch () with
   | Ok _ -> fail "malformed producer output was accepted"

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -254,6 +254,60 @@ let test_input_required_bypasses_response_accept () =
     0
     !accept_calls
 
+let test_terminal_tool_completion_bypasses_empty_response_rejection () =
+  let accept_calls = ref 0 in
+  let reject (_ : Agent_core.Types.api_response) =
+    incr accept_calls;
+    false
+  in
+  let completed_state () =
+    Masc.Keeper_tools_agent_core.Terminal_effect_completed
+      (Masc.Keeper_tool_execution.Surface_post_completed
+         Masc.Keeper_surface_post.To_dashboard)
+  in
+  (match
+     Masc.Keeper_turn_driver.For_testing.apply_official_client_accept
+       ~runtime_id:"runtime.official-client"
+       ~accept:reject
+       ~terminal_effect_state:completed_state
+       (run_result ~content:[] ())
+   with
+   | Ok _ -> ()
+   | Error error ->
+     Alcotest.failf
+       "settled terminal tool completion was rejected: %s"
+       (Agent_core.Error.to_string error));
+  Alcotest.(check int)
+    "terminal completion does not invoke response-content acceptance"
+    0
+    !accept_calls
+
+let test_open_terminal_state_keeps_empty_response_rejection () =
+  match
+    Masc.Keeper_turn_driver.For_testing.apply_official_client_accept
+      ~runtime_id:"runtime.official-client"
+      ~accept:Keeper_tooling.Response.response_has_text_or_tool_progress
+      ~terminal_effect_state:(fun () ->
+        Masc.Keeper_tools_agent_core.Terminal_effect_open)
+      (run_result ~content:[] ())
+  with
+  | Error error ->
+    (match Keeper_internal_error.classify_masc_internal_error error with
+     | Some (Keeper_internal_error.Accept_rejected { reason; _ }) ->
+       Alcotest.(check bool)
+         "ordinary empty response remains typed no-progress"
+         true
+         (contains ~needle:"response rejected by accept" reason)
+     | Some other ->
+       Alcotest.failf
+         "ordinary empty response produced %s"
+         (Keeper_internal_error.kind_of_masc_internal_error other)
+     | None ->
+       Alcotest.failf
+         "ordinary empty response produced the wrong rejection: %s"
+         (Agent_core.Error.to_string error))
+  | Ok _ -> Alcotest.fail "ordinary empty response was incorrectly accepted"
+
 let test_replay_projection_failure_preserves_provider_success () =
   let open Agent_core.Types in
   let canonical_prefix =
@@ -1772,6 +1826,14 @@ let () =
             "InputRequired bypasses response acceptance"
             `Quick
             test_input_required_bypasses_response_accept;
+          Alcotest.test_case
+            "terminal tool completion bypasses empty response rejection"
+            `Quick
+            test_terminal_tool_completion_bypasses_empty_response_rejection;
+          Alcotest.test_case
+            "open terminal state keeps empty response rejection"
+            `Quick
+            test_open_terminal_state_keeps_empty_response_rejection;
           Alcotest.test_case
             "replay projection failure preserves provider success"
             `Quick

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -404,6 +404,18 @@ let prompt_too_long_result =
   {|{"type":"result","subtype":"success","is_error":true,"session_id":"__SESSION__","uuid":"turn-400-1","result":"Prompt is too long · the request is ~250000 tokens (limit 200000)","api_error_status":400}|}
 ;;
 
+let prompt_too_long_statusless_result =
+  {|{"type":"result","subtype":"success","is_error":true,"session_id":"__SESSION__","uuid":"turn-statusless-overflow-1","result":"Prompt is too long"}|}
+;;
+
+let statusless_overflow_prose_result =
+  {|{"type":"result","subtype":"success","is_error":true,"session_id":"__SESSION__","uuid":"turn-statusless-generic-1","result":"gateway diagnostic mentioned Prompt is too long for an unrelated rejection"}|}
+;;
+
+let explicit_non_overflow_status_result =
+  {|{"type":"result","subtype":"success","is_error":true,"session_id":"__SESSION__","uuid":"turn-explicit-status-1","result":"Prompt is too long","api_error_status":500}|}
+;;
+
 let generic_400_result =
   {|{"type":"result","subtype":"success","is_error":true,"session_id":"__SESSION__","uuid":"turn-400-generic","result":"request rejected; diagnostic mentioned Prompt is too long without the provider prefix","api_error_status":400}|}
 ;;
@@ -439,6 +451,52 @@ let test_terminal_prompt_too_long_is_typed () =
         (Astring.String.is_infix ~affix:"api_status=400" message)
     | Error error -> fail (Runtime_claude_code.error_to_string error)
     | Ok _ -> fail "an is_error terminal was reported as completion")
+;;
+
+let test_statusless_canonical_prompt_too_long_is_typed () =
+  with_fixture [ Emit prompt_too_long_statusless_result ] (fun path ->
+    match run_fixture path with
+    | Error
+        (Runtime_claude_code.Context_window_exceeded
+          { message; tool_effect_attempted = false; response_emitted = false }) ->
+      check
+        bool
+        "canonical provider verdict survives into the typed failure"
+        true
+        (Astring.String.is_infix ~affix:"Prompt is too long" message);
+      check
+        bool
+        "missing status remains explicit"
+        true
+        (Astring.String.is_infix ~affix:"api_status=unknown" message)
+    | Error error -> fail (Runtime_claude_code.error_to_string error)
+    | Ok _ -> fail "a canonical statusless overflow was reported as completion")
+;;
+
+let test_statusless_overflow_prose_remains_turn_failed () =
+  with_fixture [ Emit statusless_overflow_prose_result ] (fun path ->
+    match run_fixture path with
+    | Error (Runtime_claude_code.Turn_failed detail) ->
+      check
+        bool
+        "unrelated statusless rejection keeps its diagnostic"
+        true
+        (Astring.String.is_infix ~affix:"unrelated rejection" detail)
+    | Error error -> fail (Runtime_claude_code.error_to_string error)
+    | Ok _ -> fail "unrelated statusless prose was reported as completion")
+;;
+
+let test_exact_overflow_sentence_with_non_overflow_status_remains_turn_failed () =
+  with_fixture [ Emit explicit_non_overflow_status_result ] (fun path ->
+    match run_fixture path with
+    | Error (Runtime_claude_code.Turn_failed detail) ->
+      check
+        bool
+        "explicit non-overflow status remains authoritative"
+        true
+        (Astring.String.is_infix ~affix:"api_status=500" detail)
+    | Error error -> fail (Runtime_claude_code.error_to_string error)
+    | Ok _ -> fail "an explicit non-overflow status was reported as completion")
 ;;
 
 let test_unrelated_400_remains_turn_failed () =
@@ -1246,6 +1304,18 @@ let () =
             "terminal_reason prompt_too_long is typed"
             `Quick
             test_terminal_reason_prompt_too_long_is_typed
+        ; test_case
+            "statusless canonical prompt too long is typed"
+            `Quick
+            test_statusless_canonical_prompt_too_long_is_typed
+        ; test_case
+            "statusless overflow prose remains turn failed"
+            `Quick
+            test_statusless_overflow_prose_remains_turn_failed
+        ; test_case
+            "exact overflow sentence with non-overflow status remains turn failed"
+            `Quick
+            test_exact_overflow_sentence_with_non_overflow_status_remains_turn_failed
         ; test_case
             "non-overflow terminal_reason beats prefix prose"
             `Quick

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -175,6 +175,52 @@ let rec mkdir_p path =
     Unix.mkdir path 0o755
   end
 
+let test_keeper_msg_startup_recovery_settles_disk_only_running_request () =
+  with_temp_dir "keeper-msg-startup-recovery" (fun base_path ->
+    Eio_main.run @@ fun env ->
+    Fs_compat.set_fs (Eio.Stdenv.fs env);
+    let request_id = "startup_recovery_running_0" in
+    let active_path =
+      match
+        Keeper_msg_async.For_testing.active_record_path ~base_path ~request_id
+      with
+      | Some path -> path
+      | None -> Alcotest.fail "startup recovery request id was rejected"
+    in
+    mkdir_p (Filename.dirname active_path);
+    `Assoc
+      [ "schema_version", `Int Keeper_msg_async.For_testing.record_schema_version
+      ; "request_id", `String request_id
+      ; "keeper_name", `String "startup-recovery-keeper"
+      ; "base_path", `String (Fs_compat.realpath base_path)
+      ; "submitted_by", `String "startup-recovery-caller"
+      ; "status", `String "running"
+      ; "submitted_at", `Float 1.0
+      ]
+    |> Yojson.Safe.to_string
+    |> Fs_compat.save_file active_path;
+    let report =
+      Server_bootstrap_maintenance.recover_keeper_msg_requests_on_startup
+        ~base_path
+    in
+    Alcotest.(check int) "startup recovered one request" 1 report.lost;
+    match
+      Keeper_msg_async.poll
+        ~base_path
+        ~caller:"startup-recovery-caller"
+        request_id
+    with
+    | Keeper_msg_async.Found { status = Keeper_msg_async.Lost _; _ } -> ()
+    | Keeper_msg_async.Found entry ->
+      Alcotest.failf
+        "startup recovery retained status=%s"
+        (Keeper_msg_async.status_to_string entry.status)
+    | Keeper_msg_async.Absent
+    | Keeper_msg_async.Unreadable _
+    | Keeper_msg_async.Rejected _ ->
+      Alcotest.fail "startup recovery lost the durable request row")
+;;
+
 (* The example keeper must satisfy the fail-closed profile contract
    (#24144/#24226): a TOML without inline instructions requires a non-empty
    keepers/<name>/AGENT.md, and a keeper whose profile fails to load is
@@ -5439,6 +5485,10 @@ let () =
             test_startup_state_readiness_before_init;
           Alcotest.test_case "readiness true after init" `Quick
             test_startup_state_readiness_after_init;
+          Alcotest.test_case
+            "startup recovery settles disk-only keeper message request"
+            `Quick
+            test_keeper_msg_startup_recovery_settles_disk_only_running_request;
           Alcotest.test_case "MCP requires explicit readiness" `Quick
             test_mcp_transport_requires_explicit_readiness;
           Alcotest.test_case

--- a/test/test_tool_blob_store.ml
+++ b/test/test_tool_blob_store.ml
@@ -744,6 +744,95 @@ let test_maintenance_keeps_normalized_tool_call_blob_reference () =
         (Some "normalized tool-call output")
         (fetch_ok store ~sha256:reference.sha256))
 
+let test_maintenance_follows_typed_result_manifest () =
+  with_temp_dir (fun base_path ->
+      let store = B.create ~base_path in
+      let child =
+        B.put_durable store ~bytes:"manifest-owned child" ~mime:"text/plain"
+      in
+      let structured_content =
+        `Assoc [ "output_artifact", O.normalized_artifact_ref_to_json child ]
+      in
+      let manifest_payload =
+        O.artifact_manifest_to_json
+          ~content:(Yojson.Safe.to_string structured_content)
+          ~structured_content
+        |> Yojson.Safe.to_string
+      in
+      let manifest =
+        B.put_durable
+          store
+          ~bytes:manifest_payload
+          ~mime:O.artifact_manifest_mime
+      in
+      let checkpoint =
+        Filename.concat
+          (Common.masc_dir_from_base_path ~base_path)
+          "keepers/keeper-a/checkpoint.json"
+      in
+      Fs_compat.mkdir_p (Filename.dirname checkpoint);
+      Fs_compat.save_file
+        checkpoint
+        (Yojson.Safe.to_string
+           (`Assoc
+             [ ( "tool_result"
+               , `String (O.encode_for_agent_core (O.Stored manifest)) ) ]));
+      let observed = maintenance_ok ~base_path ~mode:M.Observe_only in
+      Alcotest.(check int)
+        "checkpoint marker roots manifest and child"
+        2
+        observed.live_references;
+      Alcotest.(check int) "manifest graph has no candidates" 0 observed.candidates_recorded;
+      let swept =
+        maintenance_ok ~base_path ~mode:M.Delete_previous_candidates
+      in
+      Alcotest.(check int) "manifest graph survives the second pass" 0 swept.deleted;
+      Alcotest.(check (option string))
+        "manifest-owned child remains readable"
+        (Some "manifest-owned child")
+        (fetch_ok store ~sha256:child.sha256))
+
+let test_maintenance_rejects_malformed_typed_result_manifest () =
+  with_temp_dir (fun base_path ->
+      let store = B.create ~base_path in
+      let survivor =
+        B.put_durable store ~bytes:"survive malformed manifest" ~mime:"text/plain"
+      in
+      let malformed =
+        O.artifact_manifest_to_json
+          ~content:"malformed"
+          ~structured_content:
+            (`Assoc
+               [ ( "output_artifact"
+                 , `Assoc [ "_blob", `Assoc [ "sha256", `String survivor.sha256 ] ]
+                 )
+               ])
+        |> Yojson.Safe.to_string
+      in
+      let manifest =
+        B.put_durable store ~bytes:malformed ~mime:O.artifact_manifest_mime
+      in
+      let checkpoint =
+        Filename.concat
+          (Common.masc_dir_from_base_path ~base_path)
+          "keepers/keeper-a/checkpoint.json"
+      in
+      Fs_compat.mkdir_p (Filename.dirname checkpoint);
+      Fs_compat.save_file
+        checkpoint
+        (Yojson.Safe.to_string
+           (`String (O.encode_for_agent_core (O.Stored manifest))));
+      (match M.run ~base_path ~mode:M.Delete_previous_candidates with
+       | Error (M.Artifact_manifest_invalid { sha256; _ }) ->
+         Alcotest.(check string) "exact malformed manifest" manifest.sha256 sha256
+       | Error error ->
+         Alcotest.failf "unexpected maintenance error: %s" (M.error_to_string error)
+       | Ok _ -> Alcotest.fail "malformed typed manifest reached deletion");
+      Alcotest.(check (option string))
+        "malformed manifest abort preserves unrelated blobs"
+        (Some "survive malformed manifest")
+        (fetch_ok store ~sha256:survivor.sha256))
+
 let test_maintenance_malformed_normalized_blob_fails_closed () =
   with_temp_dir (fun base_path ->
       let store = B.create ~base_path in
@@ -1150,6 +1239,14 @@ let () =
             "maintenance keeps normalized tool-call blob reference"
             `Quick
             test_maintenance_keeps_normalized_tool_call_blob_reference;
+          Alcotest.test_case
+            "maintenance follows typed result manifest"
+            `Quick
+            test_maintenance_follows_typed_result_manifest;
+          Alcotest.test_case
+            "maintenance rejects malformed typed result manifest"
+            `Quick
+            test_maintenance_rejects_malformed_typed_result_manifest;
           Alcotest.test_case
             "maintenance malformed normalized blob fails closed"
             `Quick

--- a/test/test_tool_bridge_externalize.ml
+++ b/test/test_tool_bridge_externalize.ml
@@ -83,6 +83,101 @@ let test_incident_sized_result_stays_inline () =
       Alcotest.(check bool) "no blob marker" false (O.is_marker content)
     | Error _ -> Alcotest.fail "expected inline result")
 
+let test_typed_artifact_result_becomes_durable_manifest () =
+  with_temp_base_path (fun base_path ->
+    let store = Tool_blob_store.create ~base_path in
+    let child =
+      Tool_blob_store.put_durable
+        store
+        ~bytes:"exact child output"
+        ~mime:"text/plain"
+    in
+    let structured_content =
+      `Assoc
+        [ "ok", `Bool true
+        ; "output_artifact", O.normalized_artifact_ref_to_json child
+        ]
+    in
+    let result =
+      Tool_result.make_ok
+        ~tool_name:"Execute"
+        ~start_time:0.0
+        ~data:structured_content
+        ()
+      |> B.attach_artifact_manifest ~base_path
+    in
+    let result =
+      match result with
+      | Ok result -> result
+      | Error { message; _ } -> Alcotest.fail message
+    in
+    (match B.to_agent_core_typed_result result with
+     | Ok { content; _ } ->
+       Alcotest.(check bool)
+         "manifest marker requires artifact-reader capability"
+         false
+         (O.is_marker content)
+     | Error { message; _ } -> Alcotest.fail message);
+    match B.to_agent_core_typed_result ~base_path result with
+    | Error { message; _ } -> Alcotest.fail message
+    | Ok { content; _ } ->
+      (match O.decode_from_agent_core content with
+       | O.Not_marker -> Alcotest.fail "typed artifact result stayed unrooted inline"
+       | O.Invalid_marker { detail } -> Alcotest.fail detail
+       | O.Decoded manifest_ref ->
+         Alcotest.(check string)
+           "typed manifest media type"
+           O.artifact_manifest_mime
+           manifest_ref.mime;
+         let manifest =
+           match Tool_blob_store.fetch store ~sha256:manifest_ref.sha256 with
+           | Ok (Some payload) -> Yojson.Safe.from_string payload
+           | Ok None -> Alcotest.fail "manifest blob is absent"
+           | Error error ->
+             Alcotest.fail (Tool_blob_store.fetch_error_to_string error)
+         in
+         (match O.artifact_manifest_of_json manifest with
+          | O.Decoded_artifact_manifest
+              { structured_content = restored; artifact_refs; _ } ->
+            Alcotest.(check bool)
+              "structured result is exact"
+              true
+              (Yojson.Safe.equal structured_content restored);
+            Alcotest.(check int) "one child ownership edge" 1 (List.length artifact_refs);
+            Alcotest.(check string)
+              "child identity is exact"
+              child.sha256
+              (List.hd artifact_refs).sha256
+          | O.Not_artifact_manifest -> Alcotest.fail "manifest schema is absent"
+          | O.Invalid_artifact_manifest { detail } -> Alcotest.fail detail)))
+
+let test_manifest_producer_rejects_mixed_malformed_reference () =
+  with_temp_base_path (fun base_path ->
+    let child =
+      Tool_blob_store.put_durable
+        (Tool_blob_store.create ~base_path)
+        ~bytes:"valid child"
+        ~mime:"text/plain"
+    in
+    let result =
+      Tool_result.make_ok
+        ~tool_name:"Execute"
+        ~start_time:0.0
+        ~data:
+          (`Assoc
+             [ "valid", O.normalized_artifact_ref_to_json child
+             ; "malformed", `Assoc [ "_blob", `Assoc [ "sha256", `String child.sha256 ] ]
+             ])
+        ()
+    in
+    match B.attach_artifact_manifest ~base_path result with
+    | Ok _ -> Alcotest.fail "mixed malformed artifact data produced a manifest"
+    | Error { message; _ } ->
+      Alcotest.(check bool)
+        "strict producer reports malformed reserved wrapper"
+        true
+        (String.length message > 0))
+
 let test_bounded_inline_rejects_oversized_result () =
   let payload = String.make (B.default_externalize_threshold_bytes + 1) 'x' in
   match
@@ -412,6 +507,10 @@ let () =
           Alcotest.test_case "small inlined" `Quick test_to_agent_core_typed_small_inlined;
           Alcotest.test_case "2.5KB result stays inline" `Quick
             test_incident_sized_result_stays_inline;
+          Alcotest.test_case "typed artifact result owns durable manifest" `Quick
+            test_typed_artifact_result_becomes_durable_manifest;
+          Alcotest.test_case "manifest producer rejects malformed child" `Quick
+            test_manifest_producer_rejects_mixed_malformed_reference;
           Alcotest.test_case "bounded inline rejects oversize" `Quick
             test_bounded_inline_rejects_oversized_result;
           Alcotest.test_case "artifact reader owns inline projection" `Quick


### PR DESCRIPTION
## Summary
- materialize validated TOML compositions as first-class Agent-Core tools over the canonical Keeper handler
- preserve Gate, Shell IR, schedules, telemetry, per-action I/O, typed failure disposition, and deferred kind
- serialize nested evidence through both settled actions and the selected cause without text inference
- use the all-settled aggregate as boundary authority for terminal and ordinary compositions
- fail closed when a selected Deferred cause follows a committed effect or masks a sibling unknown/post-effect failure
- let only entirely proven-pre-effect deferral remain resumable because this slice has no persisted composition cursor
- make official-client hosts stop on producer-owned post/unknown failure even when the outer tool is statically ordinary

## Exact stack
- base: 90b08025e73c047cc3b00d209f8628789ae1db30
- head: 03a49e5fa5c6738382b83ed872aadb5aadb0a7af
- parent PR: #28665

## Verification
- ocamlformat --check: pass
- git diff --check: pass
- local builds/tests: intentionally not run; CI is the only build/test authority
- regressions cover terminal and ordinary post-effect boundaries, nested failure/defer evidence, ordinary writable unknown failure, post-effect Deferred no-resume closure, and lower-index Deferred with an unknown sibling
