### PR TITLE
feat(ide): Addressed-only 영속 + turn 방출 사슬 삭제 (RFC-0378 B)

### DIFF
--- a/dashboard/src/components/ide/ide-activity-panel.test.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.test.ts
@@ -8,14 +8,6 @@ import { lspDiagnosticSnapshot } from './ide-lsp-client'
 import { clearTraces, keeperTraceState } from './keeper-trace-store'
 import { goals, tasks } from '../../store'
 
-const turnRecordsMocks = vi.hoisted(() => ({
-  fetchKeeperTurnRecords: vi.fn(),
-}))
-
-vi.mock('../../api/dashboard-turn-records', () => ({
-  fetchKeeperTurnRecords: turnRecordsMocks.fetchKeeperTurnRecords,
-}))
-
 const renderedContainers = new Set<Parameters<typeof preactRender>[1]>()
 
 const render = (...args: Parameters<typeof preactRender>): ReturnType<typeof preactRender> => {
@@ -34,8 +26,6 @@ function stubEmptyActivityFetch(): void {
 
 beforeEach(() => {
   stubEmptyActivityFetch()
-  turnRecordsMocks.fetchKeeperTurnRecords.mockReset()
-  turnRecordsMocks.fetchKeeperTurnRecords.mockResolvedValue({ entries: [] })
   clearTraces()
 })
 
@@ -759,8 +749,21 @@ describe('IdeActivityPanel', () => {
     expect(container.querySelector('[data-testid="ide-activity-no-scope"]')).not.toBeNull()
   })
 
-  it('degrades the refresh tone when the keeper turn-record fetch fails', async () => {
-    turnRecordsMocks.fetchKeeperTurnRecords.mockRejectedValue(new Error('turn records unavailable'))
+  it('degrades the refresh tone when the keeper lane fetch fails', async () => {
+    const fetchMock = vi.fn(async input => {
+      const url = String(input)
+      if (url.includes('/api/v1/ide/events')) {
+        return new Response(JSON.stringify({ ok: false, error: 'lane unavailable' }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      return new Response(JSON.stringify({ events: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
 
     const container = document.createElement('div')
     render(h(IdeActivityPanel, { activeFile: 'lib/runtime.ml', keeperLane: 'sangsu' }), container)
@@ -768,27 +771,35 @@ describe('IdeActivityPanel', () => {
     await waitFor(() => {
       expect(container.querySelector('.ide-activity-refresh-status')?.textContent).toBe('offline 1 failed')
     })
-    expect(turnRecordsMocks.fetchKeeperTurnRecords).toHaveBeenCalledWith('sangsu', 50)
+    const laneUrl = fetchMock.mock.calls
+      .map(call => String(call[0]))
+      .find(url => url.includes('/api/v1/ide/events'))
+    expect(laneUrl).toContain('keeper_lane=sangsu')
   })
 
-  it('merges durable keeper turn records into the feed', async () => {
-    turnRecordsMocks.fetchKeeperTurnRecords.mockResolvedValue({
-      entries: [{
-        record: {
-          keeper: 'sangsu',
-          turn_ref: 'trace-lane#7',
-          absolute_turn: 7,
-          turn_kind: 'autonomous',
-          ts: 1_717_400_000,
-          finish_reason: 'end_turn',
-          model: 'test-model',
-          raw_trace_run_ref: {
-            worker_run_id: 'run-lane-1',
+  it('merges keeper lane events into the feed when the lane fetch succeeds', async () => {
+    const fetchMock = vi.fn(async input => {
+      const url = String(input)
+      if (url.includes('/api/v1/ide/events')) {
+        return new Response(JSON.stringify({
+          ok: true,
+          data: {
+            events: [{
+              type: 'turn',
+              keeper_id: 'sangsu',
+              turn_id: 'turn-lane-1',
+              phase: 'completed',
+              timestamp_ms: 1717400000000,
+            }],
           },
-        },
-        diff_vs_prev: null,
-      }],
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      return new Response(JSON.stringify({ events: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
     })
+    vi.stubGlobal('fetch', fetchMock)
 
     const container = document.createElement('div')
     render(h(IdeActivityPanel, { activeFile: 'lib/runtime.ml', keeperLane: 'sangsu' }), container)
@@ -798,8 +809,6 @@ describe('IdeActivityPanel', () => {
       expect(container.querySelector('.ide-activity-refresh-status')?.textContent).toBe('loaded')
     })
     expect(container.textContent).toContain('sangsu')
-    expect(container.textContent).toContain('turn:7')
-    expect(turnRecordsMocks.fetchKeeperTurnRecords).toHaveBeenCalledWith('sangsu', 50)
   })
 
   it('renders active run goal progress from activity goal and task links', async () => {

--- a/dashboard/src/components/ide/ide-activity-panel.test.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.test.ts
@@ -8,6 +8,14 @@ import { lspDiagnosticSnapshot } from './ide-lsp-client'
 import { clearTraces, keeperTraceState } from './keeper-trace-store'
 import { goals, tasks } from '../../store'
 
+const turnRecordsMocks = vi.hoisted(() => ({
+  fetchKeeperTurnRecords: vi.fn(),
+}))
+
+vi.mock('../../api/dashboard-turn-records', () => ({
+  fetchKeeperTurnRecords: turnRecordsMocks.fetchKeeperTurnRecords,
+}))
+
 const renderedContainers = new Set<Parameters<typeof preactRender>[1]>()
 
 const render = (...args: Parameters<typeof preactRender>): ReturnType<typeof preactRender> => {
@@ -26,6 +34,8 @@ function stubEmptyActivityFetch(): void {
 
 beforeEach(() => {
   stubEmptyActivityFetch()
+  turnRecordsMocks.fetchKeeperTurnRecords.mockReset()
+  turnRecordsMocks.fetchKeeperTurnRecords.mockResolvedValue({ entries: [] })
   clearTraces()
 })
 
@@ -749,21 +759,8 @@ describe('IdeActivityPanel', () => {
     expect(container.querySelector('[data-testid="ide-activity-no-scope"]')).not.toBeNull()
   })
 
-  it('degrades the refresh tone when the keeper lane fetch fails', async () => {
-    const fetchMock = vi.fn(async input => {
-      const url = String(input)
-      if (url.includes('/api/v1/ide/events')) {
-        return new Response(JSON.stringify({ ok: false, error: 'lane unavailable' }), {
-          status: 500,
-          headers: { 'Content-Type': 'application/json' },
-        })
-      }
-      return new Response(JSON.stringify({ events: [] }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    })
-    vi.stubGlobal('fetch', fetchMock)
+  it('degrades the refresh tone when the keeper turn-record fetch fails', async () => {
+    turnRecordsMocks.fetchKeeperTurnRecords.mockRejectedValue(new Error('turn records unavailable'))
 
     const container = document.createElement('div')
     render(h(IdeActivityPanel, { activeFile: 'lib/runtime.ml', keeperLane: 'sangsu' }), container)
@@ -771,35 +768,27 @@ describe('IdeActivityPanel', () => {
     await waitFor(() => {
       expect(container.querySelector('.ide-activity-refresh-status')?.textContent).toBe('offline 1 failed')
     })
-    const laneUrl = fetchMock.mock.calls
-      .map(call => String(call[0]))
-      .find(url => url.includes('/api/v1/ide/events'))
-    expect(laneUrl).toContain('keeper_lane=sangsu')
+    expect(turnRecordsMocks.fetchKeeperTurnRecords).toHaveBeenCalledWith('sangsu', 50)
   })
 
-  it('merges keeper lane events into the feed when the lane fetch succeeds', async () => {
-    const fetchMock = vi.fn(async input => {
-      const url = String(input)
-      if (url.includes('/api/v1/ide/events')) {
-        return new Response(JSON.stringify({
-          ok: true,
-          data: {
-            events: [{
-              type: 'turn',
-              keeper_id: 'sangsu',
-              turn_id: 'turn-lane-1',
-              phase: 'completed',
-              timestamp_ms: 1717400000000,
-            }],
+  it('merges durable keeper turn records into the feed', async () => {
+    turnRecordsMocks.fetchKeeperTurnRecords.mockResolvedValue({
+      entries: [{
+        record: {
+          keeper: 'sangsu',
+          turn_ref: 'trace-lane#7',
+          absolute_turn: 7,
+          turn_kind: 'autonomous',
+          ts: 1_717_400_000,
+          finish_reason: 'end_turn',
+          model: 'test-model',
+          raw_trace_run_ref: {
+            worker_run_id: 'run-lane-1',
           },
-        }), { status: 200, headers: { 'Content-Type': 'application/json' } })
-      }
-      return new Response(JSON.stringify({ events: [] }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
+        },
+        diff_vs_prev: null,
+      }],
     })
-    vi.stubGlobal('fetch', fetchMock)
 
     const container = document.createElement('div')
     render(h(IdeActivityPanel, { activeFile: 'lib/runtime.ml', keeperLane: 'sangsu' }), container)
@@ -809,6 +798,8 @@ describe('IdeActivityPanel', () => {
       expect(container.querySelector('.ide-activity-refresh-status')?.textContent).toBe('loaded')
     })
     expect(container.textContent).toContain('sangsu')
+    expect(container.textContent).toContain('turn:7')
+    expect(turnRecordsMocks.fetchKeeperTurnRecords).toHaveBeenCalledWith('sangsu', 50)
   })
 
   it('renders active run goal progress from activity goal and task links', async () => {

--- a/dashboard/src/components/ide/ide-activity-panel.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.ts
@@ -4,10 +4,6 @@ import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { useSignalValue, useStoreSubscription } from './use-signal-value'
 import { get } from '../../api/core'
 import { fetchIdeEvents, type IdeBridgeEvent } from '../../api/ide'
-import {
-  fetchKeeperTurnRecords,
-  type TurnRecordRow,
-} from '../../api/dashboard-turn-records'
 import { asRecord, isPositiveSafeInteger } from '../common/normalize'
 import { keeperHueIndex } from '../../../design-system/headless-core/keeper-line-ownership'
 import type { IdeAnnotation } from '../../api/schemas/ide-annotations'
@@ -247,30 +243,23 @@ interface BridgeFetchResult {
 }
 
 /**
- * Repo-scoped events cover addressed code observations. Keeper turns are
- * projected from their durable turn-record store; the IDE observation store
- * deliberately stopped persisting a second copy in RFC-0378 B. A failure in
- * either source is reported through [ok=false] rather than silently
- * collapsing to an empty feed.
+ * Repo-scoped events cover file-attributed observations. The keeper-lane
+ * endpoint is the authorized server projection over lifecycle receipts,
+ * live registry state, and pathless tool-call records. Both scopes are
+ * queried, and a failure in either is reported through [ok=false] rather
+ * than silently collapsing to an empty feed.
  */
 async function fetchIdeBridgeRunActivityEvents(
   workspaceId: string,
   repoId?: string | null,
   keeperLane?: string | null,
 ): Promise<BridgeFetchResult> {
-  const sources: Array<Promise<ReadonlyArray<RunActivityEvent>>> = []
+  const sources: Array<Promise<ReadonlyArray<IdeBridgeEvent>>> = []
   const repo = repoId?.trim()
-  if (repo) {
-    sources.push(
-      fetchIdeEvents({ limit: 50, repoId: repo })
-        .then(events => events.map((event, index) =>
-          mapIdeBridgeEvent(event, workspaceId, index),
-        )),
-    )
-  }
+  if (repo) sources.push(fetchIdeEvents({ limit: 50, repoId: repo }))
   const lane = keeperLane?.trim()
   if (lane) {
-    sources.push(fetchKeeperTurnActivityEvents(workspaceId, lane))
+    sources.push(fetchIdeEvents({ limit: 50, scope: { kind: 'keeper_lane', keeperId: lane } }))
   }
   // Neither scope is set: there is nothing to query, not a request that
   // happened to find zero events. The caller derives the visible no-scope
@@ -282,47 +271,13 @@ async function fetchIdeBridgeRunActivityEvents(
   for (const result of settled) {
     if (result.status === 'fulfilled') {
       for (const event of result.value) {
-        events.push(event)
+        events.push(mapIdeBridgeEvent(event, workspaceId, events.length))
       }
     } else {
       ok = false
     }
   }
   return { events, ok }
-}
-
-async function fetchKeeperTurnActivityEvents(
-  workspaceId: string,
-  keeperId: string,
-): Promise<ReadonlyArray<RunActivityEvent>> {
-  const response = await fetchKeeperTurnRecords(keeperId, 50)
-  return response.entries.map(row => mapKeeperTurnRecord(row, workspaceId))
-}
-
-function mapKeeperTurnRecord(
-  row: TurnRecordRow,
-  workspaceId: string,
-): RunActivityEvent {
-  const record = row.record
-  const detail = [record.finish_reason, record.model]
-    .filter((item): item is string => typeof item === 'string' && item.trim() !== '')
-    .join(' · ')
-  const context: MutableRunActivityContext = { log_id: record.turn_ref }
-  if (record.raw_trace_run_ref?.worker_run_id) {
-    context.worker_run_id = record.raw_trace_run_ref.worker_run_id
-  }
-  return {
-    id: `turn-record-${record.turn_ref}`,
-    run_id: workspaceId,
-    timestamp_ms: record.ts * 1_000,
-    keeper_id: record.keeper,
-    verb: 'noted',
-    target: `turn:${record.absolute_turn}`,
-    detail: detail || record.turn_kind,
-    kind: 'keeper.turn_record.completed',
-    tags: [`turn:${record.turn_ref}`, `turn-kind:${record.turn_kind}`],
-    context,
-  }
 }
 
 function mergeRunActivityEvents(

--- a/dashboard/src/components/ide/ide-activity-panel.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.ts
@@ -4,6 +4,10 @@ import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { useSignalValue, useStoreSubscription } from './use-signal-value'
 import { get } from '../../api/core'
 import { fetchIdeEvents, type IdeBridgeEvent } from '../../api/ide'
+import {
+  fetchKeeperTurnRecords,
+  type TurnRecordRow,
+} from '../../api/dashboard-turn-records'
 import { asRecord, isPositiveSafeInteger } from '../common/normalize'
 import { keeperHueIndex } from '../../../design-system/headless-core/keeper-line-ownership'
 import type { IdeAnnotation } from '../../api/schemas/ide-annotations'
@@ -243,23 +247,30 @@ interface BridgeFetchResult {
 }
 
 /**
- * Repo-scoped events cover file-attributed observations; the keeper lane
- * covers turn/coordination events that carry no file and live in the
- * repo-unattributed bucket, unreachable through any repo scope. Both
- * sources are queried, and a failure in either is reported through
- * [ok=false] rather than silently collapsing to an empty feed.
+ * Repo-scoped events cover addressed code observations. Keeper turns are
+ * projected from their durable turn-record store; the IDE observation store
+ * deliberately stopped persisting a second copy in RFC-0378 B. A failure in
+ * either source is reported through [ok=false] rather than silently
+ * collapsing to an empty feed.
  */
 async function fetchIdeBridgeRunActivityEvents(
   workspaceId: string,
   repoId?: string | null,
   keeperLane?: string | null,
 ): Promise<BridgeFetchResult> {
-  const sources: Array<Promise<ReadonlyArray<IdeBridgeEvent>>> = []
+  const sources: Array<Promise<ReadonlyArray<RunActivityEvent>>> = []
   const repo = repoId?.trim()
-  if (repo) sources.push(fetchIdeEvents({ limit: 50, repoId: repo }))
+  if (repo) {
+    sources.push(
+      fetchIdeEvents({ limit: 50, repoId: repo })
+        .then(events => events.map((event, index) =>
+          mapIdeBridgeEvent(event, workspaceId, index),
+        )),
+    )
+  }
   const lane = keeperLane?.trim()
   if (lane) {
-    sources.push(fetchIdeEvents({ limit: 50, scope: { kind: 'keeper_lane', keeperId: lane } }))
+    sources.push(fetchKeeperTurnActivityEvents(workspaceId, lane))
   }
   // Neither scope is set: there is nothing to query, not a request that
   // happened to find zero events. The caller derives the visible no-scope
@@ -271,13 +282,47 @@ async function fetchIdeBridgeRunActivityEvents(
   for (const result of settled) {
     if (result.status === 'fulfilled') {
       for (const event of result.value) {
-        events.push(mapIdeBridgeEvent(event, workspaceId, events.length))
+        events.push(event)
       }
     } else {
       ok = false
     }
   }
   return { events, ok }
+}
+
+async function fetchKeeperTurnActivityEvents(
+  workspaceId: string,
+  keeperId: string,
+): Promise<ReadonlyArray<RunActivityEvent>> {
+  const response = await fetchKeeperTurnRecords(keeperId, 50)
+  return response.entries.map(row => mapKeeperTurnRecord(row, workspaceId))
+}
+
+function mapKeeperTurnRecord(
+  row: TurnRecordRow,
+  workspaceId: string,
+): RunActivityEvent {
+  const record = row.record
+  const detail = [record.finish_reason, record.model]
+    .filter((item): item is string => typeof item === 'string' && item.trim() !== '')
+    .join(' · ')
+  const context: MutableRunActivityContext = { log_id: record.turn_ref }
+  if (record.raw_trace_run_ref?.worker_run_id) {
+    context.worker_run_id = record.raw_trace_run_ref.worker_run_id
+  }
+  return {
+    id: `turn-record-${record.turn_ref}`,
+    run_id: workspaceId,
+    timestamp_ms: record.ts * 1_000,
+    keeper_id: record.keeper,
+    verb: 'noted',
+    target: `turn:${record.absolute_turn}`,
+    detail: detail || record.turn_kind,
+    kind: 'keeper.turn_record.completed',
+    tags: [`turn:${record.turn_ref}`, `turn-kind:${record.turn_kind}`],
+    context,
+  }
 }
 
 function mergeRunActivityEvents(

--- a/lib/agent_observation/agent_observation.ml
+++ b/lib/agent_observation/agent_observation.ml
@@ -258,22 +258,6 @@ type tool_event =
   ; input : Yojson.Safe.t
   }
 
-(* A turn is a keeper-timeline fact by definition (RFC-0378 §1): it can
-   touch any number of codebases, so it carries no attribution — the
-   per-codebase timeline is derived by joining addressed tool facts on
-   [turn_id]. *)
-type turn_event =
-  { base_path : string
-  ; turn_id : string
-  ; keeper_id : string
-  ; phase : string
-  ; model_used : string option
-  ; tools_used : string list
-  ; stop_reason : string option
-  ; duration_ms : int option
-  ; timestamp_ms : int64
-  }
-
 type write_region_event =
   { base_path : string
   ; attribution : file_attribution
@@ -392,7 +376,6 @@ type annotation_result =
   }
 
 type tool_event_sink = tool_event -> unit
-type turn_event_sink = turn_event -> unit
 type write_region_error =
   | Write_region_sink_not_installed
   | Write_region_sink_failed
@@ -406,17 +389,14 @@ type write_region_sink = write_region_event -> (unit, write_region_error) result
 type annotation_sink = annotation_request -> (annotation_result, string) result
 
 let noop_tool_event_sink (_ : tool_event) = ()
-let noop_turn_event_sink (_ : turn_event) = ()
 let noop_write_region_sink (_ : write_region_event) = Error Write_region_sink_not_installed
 let noop_annotation_sink (_ : annotation_request) = Error "annotation sink is not installed"
 
 let tool_event_sink = Atomic.make noop_tool_event_sink
-let turn_event_sink = Atomic.make noop_turn_event_sink
 let write_region_sink = Atomic.make noop_write_region_sink
 let annotation_sink = Atomic.make noop_annotation_sink
 
 let register_tool_event_sink sink = Atomic.set tool_event_sink sink
-let register_turn_event_sink sink = Atomic.set turn_event_sink sink
 let register_write_region_sink sink = Atomic.set write_region_sink sink
 let register_annotation_sink sink = Atomic.set annotation_sink sink
 
@@ -424,18 +404,11 @@ let register_annotation_sink sink = Atomic.set annotation_sink sink
 
 type snapshot =
   { tool_events : tool_event list
-  ; turn_events : turn_event list
   ; write_regions : write_region_event list
   ; annotations : annotation_request list
   }
 
-let empty_snapshot =
-  { tool_events = []
-  ; turn_events = []
-  ; write_regions = []
-  ; annotations = []
-  }
-;;
+let empty_snapshot = { tool_events = []; write_regions = []; annotations = [] }
 
 let current_snapshot = Atomic.make empty_snapshot
 
@@ -447,7 +420,6 @@ let rec update_snapshot f =
 
 let reverse_snapshot snap =
   { tool_events = List.rev snap.tool_events
-  ; turn_events = List.rev snap.turn_events
   ; write_regions = List.rev snap.write_regions
   ; annotations = List.rev snap.annotations
   }
@@ -493,16 +465,6 @@ let tool_event_to_json (e : tool_event) =
     ]
 ;;
 
-let turn_event_to_json (e : turn_event) =
-  `Assoc
-    [ ("base_path", `String e.base_path)
-    ; ("turn_id", `String e.turn_id)
-    ; ("keeper_id", `String e.keeper_id)
-    ; ("phase", `String e.phase)
-    ; ("timestamp_ms", `Int (Int64.to_int e.timestamp_ms))
-    ]
-;;
-
 let write_region_to_json (e : write_region_event) =
   `Assoc
     [ ("base_path", `String e.base_path)
@@ -528,13 +490,11 @@ let annotation_to_json (a : annotation_request) =
 let snapshot_to_json (snap : snapshot) =
   `Assoc
     [ ("tool_events", `List (List.map tool_event_to_json snap.tool_events))
-    ; ("turn_events", `List (List.map turn_event_to_json snap.turn_events))
     ; ("write_regions", `List (List.map write_region_to_json snap.write_regions))
     ; ("annotations", `List (List.map annotation_to_json snap.annotations))
     ; ( "summary"
       , `Assoc
           [ ("tool_event_count", `Int (List.length snap.tool_events))
-          ; ("turn_event_count", `Int (List.length snap.turn_events))
           ; ("write_region_count", `Int (List.length snap.write_regions))
           ; ("annotation_count", `Int (List.length snap.annotations))
           ] )
@@ -550,11 +510,6 @@ let emit_tool_event event =
   Atomic.get tool_event_sink event
 ;;
 
-let emit_turn_event event =
-  update_snapshot (fun snap -> { snap with turn_events = event :: snap.turn_events });
-  Atomic.get turn_event_sink event
-;;
-
 let emit_write_region_event event =
   update_snapshot (fun snap -> { snap with write_regions = event :: snap.write_regions });
   Atomic.get write_region_sink event
@@ -567,7 +522,6 @@ let emit_annotation_request request =
 
 let reset_for_testing () =
   Atomic.set tool_event_sink noop_tool_event_sink;
-  Atomic.set turn_event_sink noop_turn_event_sink;
   Atomic.set write_region_sink noop_write_region_sink;
   Atomic.set annotation_sink noop_annotation_sink;
   Atomic.set current_snapshot empty_snapshot

--- a/lib/agent_observation/agent_observation.mli
+++ b/lib/agent_observation/agent_observation.mli
@@ -129,21 +129,10 @@ type tool_event =
   ; input : Yojson.Safe.t
   }
 
-type turn_event =
-  { base_path : string
-  ; turn_id : string
-  ; keeper_id : string
-  ; phase : string
-  ; model_used : string option
-  ; tools_used : string list
-  ; stop_reason : string option
-  ; duration_ms : int option
-  ; timestamp_ms : int64
-  }
-(** A turn is a keeper-timeline fact by definition (RFC-0378): it can
-    touch any number of codebases, so it carries no attribution — the
-    per-codebase timeline is derived by joining addressed tool facts on
-    [turn_id]. *)
+(** A turn is a keeper-timeline fact (RFC-0378): its durable record is
+    the keeper turn-records store, and the per-codebase timeline is
+    derived by joining addressed tool facts on [turn_id]. The
+    observation bus carries no turn events. *)
 
 type write_region_event =
   { base_path : string
@@ -203,7 +192,6 @@ type annotation_result =
   }
 
 type tool_event_sink = tool_event -> unit
-type turn_event_sink = turn_event -> unit
 type write_region_error =
   | Write_region_sink_not_installed
   | Write_region_sink_failed
@@ -214,12 +202,10 @@ type write_region_sink = write_region_event -> (unit, write_region_error) result
 type annotation_sink = annotation_request -> (annotation_result, string) result
 
 val register_tool_event_sink : tool_event_sink -> unit
-val register_turn_event_sink : turn_event_sink -> unit
 val register_write_region_sink : write_region_sink -> unit
 val register_annotation_sink : annotation_sink -> unit
 
 val emit_tool_event : tool_event -> unit
-val emit_turn_event : turn_event -> unit
 val emit_write_region_event : write_region_event -> (unit, write_region_error) result
 val emit_annotation_request : annotation_request -> (annotation_result, string) result
 

--- a/lib/agent_observation/agent_observation.mli
+++ b/lib/agent_observation/agent_observation.mli
@@ -53,7 +53,14 @@ module Code_address : sig
   (** Rejects rather than repairs: the codebase must already be a
       canonical slug and the path must already be a normalized relative
       path — malformed paths (including NUL bytes), [.], [..], empty
-      segments, and absolute paths are errors, not inputs to fix. *)
+      segments, and absolute paths are errors, not inputs to fix.
+
+      Layering: the keeper write resolver lexically collapses dot
+      segments in raw tool arguments before minting, so on that path
+      these rejections guard the resolver's own invariant. Wire-facing
+      callers (RFC-0378 §5.3 — annotate and the REST annotation POST)
+      hand user input to [v] directly; that is where the rejections
+      fire as typed contract errors. *)
 
   val codebase : t -> string
   val path : t -> string

--- a/lib/ide/ide_bridge.ml
+++ b/lib/ide/ide_bridge.ml
@@ -15,22 +15,10 @@ let storage_partition_of_file_attribution = function
   | Agent_observation.Unaddressed _ -> default_partition
 ;;
 
-let storage_partition_of_attribution = function
-  | Agent_observation.File file_attribution ->
-    storage_partition_of_file_attribution file_attribution
-  | Agent_observation.Pathless -> default_partition
-;;
-
 let file_path_of_file_attribution = function
   | Agent_observation.Addressed { address; _ } ->
     Agent_observation.Code_address.path address
   | Agent_observation.Unaddressed { attempted_path; _ } -> attempted_path
-;;
-
-let file_path_of_attribution = function
-  | Agent_observation.File file_attribution ->
-    Some (file_path_of_file_attribution file_attribution)
-  | Agent_observation.Pathless -> None
 ;;
 
 type event_kind =
@@ -497,41 +485,6 @@ let ingest_tool_event
    | exn ->
      Printf.eprintf "Ide_bridge.ingest_tool_event error: %s\n%!" (Printexc.to_string exn))
 
-let ingest_turn_event
-    ~base_path
-    ~turn_id
-    ~keeper_id
-    ~phase
-    ~model_used
-    ~tools_used
-    ~stop_reason
-    ~duration_ms
-    ~timestamp_ms
-  =
-  (* RFC-0378: a turn is a keeper-timeline fact — it can touch any number
-     of codebases, so it carries no attribution and the per-codebase
-     timeline is a join on [turn_id]. Routed to the shared orphan
-     directory until the B rung gives keeper facts their own store. *)
-  let partition = default_partition in
-  let event =
-    Turn_event
-      { turn_id
-      ; keeper_id
-      ; phase
-      ; model_used
-      ; tools_used
-      ; stop_reason
-      ; duration_ms
-      ; timestamp_ms
-      }
-  in
-  (try append_event ~base_dir:base_path ~partition ~event
-   with
-   | Eio.Cancel.Cancelled _ as e ->
-     Printexc.raise_with_backtrace e (Printexc.get_raw_backtrace ())
-   | exn ->
-     Printf.eprintf "Ide_bridge.ingest_turn_event error: %s\n%!" (Printexc.to_string exn))
-
 let cursor_line_of_input input =
   match int_field "line" input with
   | Some n -> Some n
@@ -743,9 +696,17 @@ let ingest_tool_event_from_hook
      [input] here is what put absolute host paths, sandbox-rooted
      [repos/<id>/…] paths, and repo-relative paths in one partition, none
      of which a reader can join against the region and annotation rows
-     the same resolver produced (masc#28582). *)
-  let partition = storage_partition_of_attribution attribution in
-  let file_path = file_path_of_attribution attribution in
+     the same resolver produced (masc#28582).
+
+     RFC-0378 §5.2: the ide store persists addressed code facts only.
+     Pathless and unaddressed tool facts stay on the bus; their durable
+     record is the keeper tool_calls store. *)
+  match attribution with
+  | Agent_observation.Pathless
+  | Agent_observation.File (Agent_observation.Unaddressed _) -> ()
+  | Agent_observation.File (Agent_observation.Addressed _ as addressed) ->
+  let partition = storage_partition_of_file_attribution addressed in
+  let file_path = Some (file_path_of_file_attribution addressed) in
   let summary =
     String_util.utf8_safe ~max_bytes:200 ~suffix:"" output_text
     |> String_util.to_string
@@ -807,28 +768,21 @@ let install_agent_observation_sinks () =
           ~duration_ms:event.duration_ms
           ~output_text:event.output_text
           ~input:event.input));
-  Agent_observation.register_turn_event_sink
-    (fun (event : Agent_observation.turn_event) ->
-      Ide_ingest_queue.submit (fun () ->
-        ingest_turn_event
-          ~base_path:event.base_path
-          ~turn_id:event.turn_id
-          ~keeper_id:event.keeper_id
-          ~phase:event.phase
-          ~model_used:event.model_used
-          ~tools_used:event.tools_used
-          ~stop_reason:event.stop_reason
-          ~duration_ms:event.duration_ms
-          ~timestamp_ms:event.timestamp_ms));
   Agent_observation.register_write_region_sink
     (fun (event : Agent_observation.write_region_event) ->
       try
-        Ide_region_tracker.ingest_tool_call
-          ~base_dir:event.base_path
-          ~partition:(storage_partition_of_file_attribution event.attribution)
-          ~keeper_id:event.keeper_id
-          ~turn:event.turn
-          event.tool_call_json;
+        (match event.attribution with
+         | Agent_observation.Unaddressed _ ->
+           (* RFC-0378 §5.2: not persisted here — the durable record of an
+              unattributed write is the keeper tool_calls store. *)
+           ()
+         | Agent_observation.Addressed _ as addressed ->
+           Ide_region_tracker.ingest_tool_call
+             ~base_dir:event.base_path
+             ~partition:(storage_partition_of_file_attribution addressed)
+             ~keeper_id:event.keeper_id
+             ~turn:event.turn
+             event.tool_call_json);
         Ok ()
       with
       | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -850,12 +804,23 @@ let install_agent_observation_sinks () =
            ; references
            }
           : Agent_observation.annotation_request) ->
+      match attribution with
+      | Agent_observation.Unaddressed { reason; attempted_path } ->
+        (* RFC-0378 §5.3: an annotation that fails attribution is a typed
+           reject, never an ok:true burial in a partition no repo-scoped
+           read can see. *)
+        Error
+          (Printf.sprintf
+             "annotation target failed attribution (%s): %s"
+             (Agent_observation.Unattributed.reason_to_string reason)
+             attempted_path)
+      | Agent_observation.Addressed _ as addressed ->
       match
         Ide_annotations.create
           ~base_dir:base_path
-          ~partition:(storage_partition_of_file_attribution attribution)
+          ~partition:(storage_partition_of_file_attribution addressed)
           ~keeper_id
-          ~file_path:(file_path_of_file_attribution attribution)
+          ~file_path:(file_path_of_file_attribution addressed)
           ~line_start
           ~line_end
           ~kind

--- a/lib/ide/ide_bridge.mli
+++ b/lib/ide/ide_bridge.mli
@@ -83,20 +83,6 @@ val ingest_tool_event :
     {!ingest_tool_event_from_hook}, which projects both from the fact's
     attribution. *)
 
-val ingest_turn_event :
-  base_path:string ->
-  turn_id:string ->
-  keeper_id:string ->
-  phase:string ->
-  model_used:string option ->
-  tools_used:string list ->
-  stop_reason:string option ->
-  duration_ms:int option ->
-  timestamp_ms:int64 ->
-  unit
-(** RFC-0378: a turn is a keeper-timeline fact and carries no
-    attribution — the per-codebase timeline is a join on [turn_id]. *)
-
 (** Extract and ingest tool event from raw hook parameters.
     [typed_outcome_str] is pre-computed from [Keeper_tool_outcome.t]. *)
 val ingest_tool_event_from_hook :

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -15,11 +15,6 @@ let progress_keeper_tool_names_for_contract =
   Contract_helpers.progress_keeper_tool_names_for_contract
 ;;
 
-let observation_timestamp_ms () =
-  (* NDT-OK: wall-clock timestamp for IDE observation telemetry only; keeper
-     control flow does not branch on this value. *)
-  Int64.of_float (Unix.gettimeofday () *. 1000.0)
-;;
 
 let normalize_response_text_for_finalization
       ~runtime_id
@@ -431,59 +426,12 @@ let run_turn
   in
   let user_message = Keeper_run_prompt.sanitize_user_message user_message in
   Masc_runtime_events.emit_turn_start ();
-  Agent_observation.emit_turn_event
-    { base_path = config.base_path
-    ; turn_id =
-        (match meta.current_task_id with
-         | Some t -> Keeper_id.Task_id.to_string t
-         | None -> "turn-" ^ meta.name)
-    ; keeper_id = meta.name
-    ; phase = "started"
-    ; model_used = None
-    ; tools_used = []
-    ; stop_reason = None
-    ; duration_ms = None
-    ; timestamp_ms = observation_timestamp_ms ()
-    };
   (* Cancel-safe cleanup (#9747): [Eio_guard.protect] already uses
      [Eio.Switch.on_release], so cleanup runs under cooperative cancellation
-     and does not mask the outer [Eio.Cancel.Cancelled]. We still need to
-     preserve the *terminal state* through the finally block: a cancelled
-     turn must emit phase="cancelled" in the observation event so receipts
-     and registry consumers agree with the FSM terminal [Cancelled _].
-     The [turn_cancelled] ref is set only when the turn body actually raises
-     [Eio.Cancel.Cancelled]; the finally block inspects it to pick the
-     observation phase. *)
-  let turn_start_time = Unix.gettimeofday () in
-  let turn_cancelled = ref None in
-  let emit_observation_turn_end ~phase ~stop_reason () =
-    let duration_ms = int_of_float ((Unix.gettimeofday () -. turn_start_time) *. 1000.0) in
-    let turn_id = match meta.current_task_id with Some t -> Keeper_id.Task_id.to_string t | None -> "turn-" ^ meta.name in
-    Agent_observation.emit_turn_event
-      { base_path = config.base_path
-      ; turn_id
-      ; keeper_id = meta.name
-      ; phase
-      ; model_used = None
-      ; tools_used = []
-      ; stop_reason
-      ; duration_ms = Some duration_ms
-      ; timestamp_ms = observation_timestamp_ms ()
-      }
-  in
-  let safe_emit_turn_end () =
-    let phase, stop_reason =
-      match !turn_cancelled with
-      | Some exn -> "cancelled", Some (Printexc.to_string exn)
-      | None -> "completed", None
-    in
-    (try emit_observation_turn_end ~phase ~stop_reason ()
-     with Eio.Cancel.Cancelled _ as ce -> raise ce
-     | exn ->
-       Log.Keeper.warn "keeper:%s emit_observation_turn_end failed: %s"
-         meta.name (Printexc.to_string exn));
-    Turn_helpers.emit_turn_end_safely ~keeper_name:meta.name ()
-  in
+     and does not mask the outer [Eio.Cancel.Cancelled]. The turn's durable
+     record is the keeper turn-records store (RFC-0378 §5.2); the
+     observation bus carries no turn events. *)
+  let safe_emit_turn_end () = Turn_helpers.emit_turn_end_safely ~keeper_name:meta.name () in
   Eio_guard.protect ~finally:safe_emit_turn_end
   @@ fun () ->
   try
@@ -1389,10 +1337,8 @@ let run_turn
        receipt_result)
 with
 | Eio.Cancel.Cancelled Keeper_registry.Operator_interrupt as ce ->
-  turn_cancelled := Some ce;
   Keeper_registry.set_failure_reason
     ~base_path:config.base_path meta.name (Some Keeper_registry.Operator_interrupt);
   raise ce
 | Eio.Cancel.Cancelled _ as ce ->
-  turn_cancelled := Some ce;
   raise ce

--- a/lib/server/dune
+++ b/lib/server/dune
@@ -84,6 +84,7 @@
   masc.agent_core
   masc.agent_core.base
   masc.agent_core.llm_provider
+  masc.agent_observation
   masc_schedule
   masc.tool_types
   masc.time_codec

--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -417,9 +417,13 @@ let keeper_id_param uri =
    observation bus.  Receipts own terminal outcomes (including cancellation),
    the registry owns the live turn, and the tool-call log owns pathless calls. *)
 let keeper_lane_event_timestamp_ms json =
-  match Safe_ops.json_int_opt "timestamp_ms" json with
-  | Some value -> Int64.of_int value
-  | None -> 0L
+  match Json_util.assoc_member_opt "timestamp_ms" json with
+  | Some (`Int value) -> Int64.of_int value
+  | Some (`Intlit value) | Some (`String value) ->
+    Option.value ~default:0L (Int64.of_string_opt value)
+  | Some (`Float value) when Float.is_finite value -> Int64.of_float value
+  | Some (`Float _) | Some (`Bool _) | Some (`List _) | Some (`Assoc _)
+  | Some `Null | None -> 0L
 ;;
 
 let keeper_lane_compare_events left right =
@@ -547,6 +551,37 @@ let keeper_lane_live_event ~(config : Workspace.config) ~keeper_id =
   | Some _ | None -> None
 ;;
 
+let keeper_lane_tool_row_is_lane_only
+      ~(config : Workspace.config)
+      ~keeper_id
+      json
+  =
+  let input =
+    match Json_util.assoc_member_opt "input" json with
+    | Some input -> input
+    | None -> `Assoc []
+  in
+  match Tool_input_path.tool_input_file_path input with
+  | None -> true
+  | Some _ ->
+    (match Keeper_meta_store.read_meta config keeper_id with
+     | Ok (Some meta) ->
+       (match
+          Keeper_run_tools_hooks.observation_attribution_for_tool_input
+            ~config
+            ~meta
+            input
+        with
+        | Agent_observation.Pathless
+        | Agent_observation.File (Agent_observation.Unaddressed _) -> true
+        | Agent_observation.File (Agent_observation.Addressed _) -> false)
+     | Ok None | Error _ ->
+       (* Without the same Keeper metadata used by the producer, a path-shaped
+          row cannot be proven lane-only.  Excluding it avoids duplicating an
+          addressed repo event under a second, pathless representation. *)
+       false)
+;;
+
 let list_keeper_lane_events ~(config : Workspace.config) ~keeper_id ?kind ~limit ~offset () =
   let scan_limit = min 1000 (max limit (limit + offset) * 5) in
   let turns =
@@ -572,6 +607,7 @@ let list_keeper_lane_events ~(config : Workspace.config) ~keeper_id ?kind ~limit
       |> Keeper_tool_call_log.filter_rows_for_keeper
            ~keeper_name:keeper_id
            ~n:scan_limit
+      |> List.filter (keeper_lane_tool_row_is_lane_only ~config ~keeper_id)
       |> List.map (keeper_lane_tool_event ~keeper_id)
   in
   turns @ tools

--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -411,6 +411,175 @@ let keeper_id_param uri =
      | _ -> None)
 ;;
 
+(* Keeper-lane activity is a server projection over the authoritative Keeper
+   stores.  Keeping the join here preserves the lane-token authorization on
+   [/api/v1/ide/events] while avoiding a second turn JSONL written by the IDE
+   observation bus.  Receipts own terminal outcomes (including cancellation),
+   the registry owns the live turn, and the tool-call log owns pathless calls. *)
+let keeper_lane_event_timestamp_ms json =
+  match Safe_ops.json_int_opt "timestamp_ms" json with
+  | Some value -> Int64.of_int value
+  | None -> 0L
+;;
+
+let keeper_lane_compare_events left right =
+  Int64.compare
+    (keeper_lane_event_timestamp_ms right)
+    (keeper_lane_event_timestamp_ms left)
+;;
+
+let keeper_lane_drop count items =
+  let rec loop remaining = function
+    | items when remaining <= 0 -> items
+    | [] -> []
+    | _ :: rest -> loop (remaining - 1) rest
+  in
+  loop count items
+;;
+
+let keeper_lane_take count items =
+  let rec loop remaining acc = function
+    | [] -> List.rev acc
+    | _ when remaining <= 0 -> List.rev acc
+    | item :: rest -> loop (remaining - 1) (item :: acc) rest
+  in
+  loop count [] items
+;;
+
+let keeper_lane_receipt_event ~keeper_id json =
+  let trace_id =
+    Safe_ops.json_string_nonempty_opt "trace_id" json
+    |> Option.value ~default:("turn-" ^ keeper_id)
+  in
+  let outcome = Safe_ops.json_string ~default:"receipt_done" "outcome" json in
+  let phase =
+    match outcome with
+    | "receipt_cancelled" | "cancelled" -> "cancelled"
+    | "receipt_failed" | "error" -> "failed"
+    | _ -> "completed"
+  in
+  let timestamp_ms =
+    (match Safe_ops.json_string_nonempty_opt "recorded_at" json with
+     | Some recorded_at -> Masc_domain.parse_iso8601_opt recorded_at
+     | None -> None)
+    |> Option.value ~default:0.0
+    |> fun seconds -> Int64.of_float (seconds *. 1000.0)
+  in
+  let model_used =
+    Safe_ops.json_assoc "runtime" json
+    |> fun runtime -> Safe_ops.json_string_nonempty_opt "selected_model" (`Assoc runtime)
+  in
+  `Assoc
+    [ "type", `String "turn"
+    ; "turn_id", `String trace_id
+    ; "keeper_id", `String keeper_id
+    ; "phase", `String phase
+    ; "model_used", (match model_used with Some model -> `String model | None -> `Null)
+    ; "tools_used", `List []
+    ; ( "stop_reason"
+      , match Safe_ops.json_string_nonempty_opt "terminal_reason_code" json with
+        | Some reason -> `String reason
+        | None -> `Null )
+    ; "duration_ms", `Null
+    ; "timestamp_ms", `Intlit (Int64.to_string timestamp_ms)
+    ]
+;;
+
+let keeper_lane_tool_event ~keeper_id json =
+  let trace_id =
+    Safe_ops.json_string_nonempty_opt "trace_id" json
+    |> Option.value ~default:("turn-" ^ keeper_id)
+  in
+  let success = Safe_ops.json_bool ~default:false "success" json in
+  let output =
+    match json with
+    | `Assoc fields -> Option.value ~default:`Null (List.assoc_opt "output" fields)
+    | _ -> `Null
+  in
+  let summary =
+    match output with
+    | `String value -> value
+    | value -> Yojson.Safe.to_string value
+  in
+  let summary =
+    String_util.utf8_safe ~max_bytes:200 ~suffix:"..." summary
+    |> String_util.to_string
+  in
+  let timestamp_ms =
+    Safe_ops.json_float ~default:0.0 "ts" json
+    |> fun seconds -> Int64.of_float (seconds *. 1000.0)
+  in
+  `Assoc
+    [ "type", `String "tool"
+    ; "tool_name", `String (Safe_ops.json_string ~default:"unknown" "tool" json)
+    ; "keeper_id", `String keeper_id
+    ; "turn_id", `String trace_id
+    ; "outcome", `String (if success then "ok" else "error")
+    ; "typed_outcome", `String (if success then "ok" else "error")
+    ; "latency_ms", `Int (int_of_float (Safe_ops.json_float ~default:0.0 "duration_ms" json))
+    ; "summary", `String summary
+    ; "file_path", `Null
+    ; "timestamp_ms", `Intlit (Int64.to_string timestamp_ms)
+    ]
+;;
+
+let keeper_lane_live_event ~(config : Workspace.config) ~keeper_id =
+  match Keeper_registry.get ~base_path:config.base_path keeper_id with
+  | Some { current_turn_observation = Some observation; _ } ->
+    Some
+      (`Assoc
+        [ "type", `String "turn"
+        ; "turn_id", `String (Printf.sprintf "turn-%d" observation.turn_id)
+        ; "keeper_id", `String keeper_id
+        ; "phase", `String "started"
+        ; ( "model_used"
+          , match observation.selected_model with
+            | Some model -> `String model
+            | None -> `Null )
+        ; "tools_used", `List []
+        ; "stop_reason", `Null
+        ; "duration_ms", `Null
+        ; ( "timestamp_ms"
+          , `Intlit
+              (Int64.to_string
+                 (Int64.of_float (observation.started_at *. 1000.0))) )
+        ])
+  | Some _ | None -> None
+;;
+
+let list_keeper_lane_events ~(config : Workspace.config) ~keeper_id ?kind ~limit ~offset () =
+  let scan_limit = min 1000 (max limit (limit + offset) * 5) in
+  let turns =
+    match kind with
+    | Some Ide_bridge.Tool -> []
+    | Some Ide_bridge.Turn | None ->
+      let store = Keeper_types_support.keeper_execution_receipt_store config keeper_id in
+      let terminal =
+        Dated_jsonl.read_recent store scan_limit
+        |> List.map (keeper_lane_receipt_event ~keeper_id)
+      in
+      (match keeper_lane_live_event ~config ~keeper_id with
+       | Some live -> live :: terminal
+       | None -> terminal)
+  in
+  let tools =
+    match kind with
+    | Some Ide_bridge.Turn -> []
+    | Some Ide_bridge.Tool | None ->
+      Keeper_tool_call_log.read_recent_rows
+        ~n:(scan_limit * Keeper_tool_call_log.read_over_scan_factor)
+        ()
+      |> Keeper_tool_call_log.filter_rows_for_keeper
+           ~keeper_name:keeper_id
+           ~n:scan_limit
+      |> List.map (keeper_lane_tool_event ~keeper_id)
+  in
+  turns @ tools
+  |> List.sort keeper_lane_compare_events
+  |> keeper_lane_drop offset
+  |> keeper_lane_take limit
+;;
+
 let file_path_param uri =
   match Uri.get_query_param uri "file_path" with
   | Some p when String.trim p <> "" -> Some (String.trim p)
@@ -934,16 +1103,25 @@ let add_routes router =
                     respond_ide_error ~status:`Bad_request ~request err reqd
                   | Ok keeper_id ->
                     with_keeper_lane_read_auth ~state ~request ~reqd ~scope (fun () ->
-                    let partition = partition_of_ide_scope scope in
                     let events =
-                      Ide_bridge.list_events
-                        ~base_path:base
-                        ~partition
-                        ?kind
-                        ?keeper_id
-                        ~limit
-                        ~offset
-                        ()
+                      match scope with
+                      | Scope_keeper_lane { keeper_id } ->
+                        list_keeper_lane_events
+                          ~config:(Mcp_server.workspace_config state)
+                          ~keeper_id
+                          ?kind
+                          ~limit
+                          ~offset
+                          ()
+                      | Scope_canonical_url _ | Scope_repo_id _ ->
+                        Ide_bridge.list_events
+                          ~base_path:base
+                          ~partition:(partition_of_ide_scope scope)
+                          ?kind
+                          ?keeper_id
+                          ~limit
+                          ~offset
+                          ()
                     in
                     let kind_json =
                       match kind with

--- a/test/test_agent_observation_bridge.ml
+++ b/test/test_agent_observation_bridge.ml
@@ -55,7 +55,9 @@ let test_tool_observation_reaches_ide_storage_and_cursor () =
     install_fresh_ide_sink ();
     Agent_observation.emit_tool_event
       { base_path = base_dir
-      ; attribution = Agent_observation.File (unattributed_file "lib/test.ml")
+      ; attribution =
+          Agent_observation.File
+            (addressed_file ~codebase:"github.com_owner_repo" ~path:"lib/test.ml")
         (* The producer mints this from the resolver; the raw [input]
            below still carries the argument the keeper typed. *)
       ; tool_name = "keeper_ide_annotate"
@@ -72,37 +74,28 @@ let test_tool_observation_reaches_ide_storage_and_cursor () =
             ; "focus_mode", `String "editing"
             ]
       };
-    (match Ide_bridge.list_events ~base_path:base_dir ~kind:Ide_bridge.Tool ~limit:1 () with
+    (match
+       Ide_bridge.list_events
+         ~base_path:base_dir
+         ~partition:(Ide_paths.By_url "github.com_owner_repo")
+         ~kind:Ide_bridge.Tool
+         ~limit:1
+         ()
+     with
      | [ event ] ->
        check string "tool_name" "keeper_ide_annotate" (json_string "tool_name" event);
        check string "keeper_id" "keeper-alpha" (json_string "keeper_id" event)
      | _ -> fail "expected one tool event");
-    match Ide_bridge.list_cursors ~base_path:base_dir () with
+    match
+      Ide_bridge.list_cursors
+        ~base_path:base_dir
+        ~partition:(Ide_paths.By_url "github.com_owner_repo")
+        ()
+    with
     | [ cursor ] ->
       check string "cursor file" "lib/test.ml" (json_string "file_path" cursor);
       check int "cursor line" 42 (json_int "line" cursor)
     | _ -> fail "expected one cursor")
-;;
-
-let test_turn_observation_reaches_ide_storage () =
-  with_temp_dir (fun base_dir ->
-    install_fresh_ide_sink ();
-    Agent_observation.emit_turn_event
-      { base_path = base_dir
-      ; turn_id = "turn-10"
-      ; keeper_id = "keeper-beta"
-      ; phase = "completed"
-      ; model_used = Some "test-model"
-      ; tools_used = [ "execute" ]
-      ; stop_reason = Some "end_turn"
-      ; duration_ms = Some 123
-      ; timestamp_ms = 1717400000000L
-      };
-    match Ide_bridge.list_events ~base_path:base_dir ~kind:Ide_bridge.Turn ~limit:1 () with
-    | [ event ] ->
-      check string "phase" "completed" (json_string "phase" event);
-      check string "keeper_id" "keeper-beta" (json_string "keeper_id" event)
-    | _ -> fail "expected one turn event")
 ;;
 
 let test_write_region_observation_reaches_ide_storage () =
@@ -187,7 +180,8 @@ let test_annotation_request_reaches_ide_storage () =
     let result =
       Agent_observation.emit_annotation_request
         { base_path = base_dir
-        ; attribution = unattributed_file "lib/annotated.ml"
+        ; attribution =
+            addressed_file ~codebase:"github.com_owner_repo" ~path:"lib/annotated.ml"
         ; keeper_id = "keeper-epsilon"
         ; line_start = 7
         ; line_end = 9
@@ -212,7 +206,13 @@ let test_annotation_request_reaches_ide_storage () =
         ; task_id = None
         }
       in
-      (match Ide_annotations.list ~base_dir ~filter () with
+      (match
+         Ide_annotations.list
+           ~base_dir
+           ~partition:(Ide_paths.By_url "github.com_owner_repo")
+           ~filter
+           ()
+       with
        | [ annotation ] ->
          check string "id" created.id annotation.id;
          check string "content" "route through neutral observation bus" annotation.content;
@@ -376,7 +376,6 @@ let () =
             "tool observation reaches IDE storage and cursor"
             `Quick
             test_tool_observation_reaches_ide_storage_and_cursor
-        ; test_case "turn observation reaches IDE storage" `Quick test_turn_observation_reaches_ide_storage
         ; test_case
             "write-region observation reaches IDE storage"
             `Quick

--- a/test/test_ide_bridge.ml
+++ b/test/test_ide_bridge.ml
@@ -54,27 +54,58 @@ let test_ingest_tool_event () =
     check string "keeper_id" "keeper-alpha" keeper_id)
 ;;
 
-let test_ingest_turn_event () =
+(* RFC-0378 B: the bus carries no turn events. Tests that exercise the
+   turn read path seed the stored row directly — standing in for the
+   pre-existing data the readers serve until rung E. *)
+let rec mkdir_p path =
+  if path = "" || path = "/" || Sys.file_exists path
+  then ()
+  else (
+    mkdir_p (Filename.dirname path);
+    try Unix.mkdir path 0o755 with
+    | Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+;;
+
+let seed_turn_row ~base_dir ~turn_id ~keeper_id ~phase ~timestamp_ms =
+  let dir = Ide_paths.partition_store_dir ~base_dir Ide_paths.Legacy_default in
+  mkdir_p dir;
+  let row =
+    Ide_event_types.ide_event_to_json
+      (Ide_event_types.Turn_event
+         { turn_id
+         ; keeper_id
+         ; phase
+         ; model_used = None
+         ; tools_used = []
+         ; stop_reason = None
+         ; duration_ms = None
+         ; timestamp_ms
+         })
+  in
+  let oc =
+    open_out_gen
+      [ Open_append; Open_creat ]
+      0o644
+      (Filename.concat dir "turn_events.jsonl")
+  in
+  output_string oc (Yojson.Safe.to_string row ^ "\n");
+  close_out oc
+;;
+
+let test_turn_rows_remain_readable () =
   with_temp_dir (fun base_dir ->
-    Ide_bridge.ingest_turn_event
-      ~base_path:base_dir
+    seed_turn_row
+      ~base_dir
       ~turn_id:"turn-456"
       ~keeper_id:"keeper-beta"
       ~phase:"completed"
-      ~model_used:(Some "claude-sonnet-4-6")
-      ~tools_used:["fs_write"; "execute"]
-      ~stop_reason:(Some "end_turn")
-      ~duration_ms:(Some 5000)
       ~timestamp_ms:1717400000000L;
-    let dir = Ide_paths.partition_store_dir ~base_dir:base_dir Ide_paths.Legacy_default in
-    let path = Filename.concat dir "turn_events.jsonl" in
-    check bool "file exists" true (Sys.file_exists path);
-    let ic = open_in path in
-    let line = input_line ic in
-    close_in ic;
-    let json = Yojson.Safe.from_string line in
-    let phase = Yojson.Safe.Util.member "phase" json |> Yojson.Safe.Util.to_string in
-    check string "phase" "completed" phase)
+    match Ide_bridge.list_events ~base_path:base_dir ~kind:Ide_bridge.Turn () with
+    | [ event ] ->
+      let field key = Yojson.Safe.Util.(member key event |> to_string) in
+      check string "turn_id" "turn-456" (field "turn_id");
+      check string "phase" "completed" (field "phase")
+    | events -> Alcotest.failf "expected one turn event, got %d" (List.length events))
 ;;
 
 let test_ingest_multiple_events () =
@@ -206,15 +237,11 @@ let test_list_events_merges_kinds_newest_first () =
       ~file_path:None
       ~timestamp_ms:1000L
       ();
-    Ide_bridge.ingest_turn_event
-      ~base_path:base_dir
+    seed_turn_row
+      ~base_dir
       ~turn_id:"t-turn"
       ~keeper_id:"k1"
       ~phase:"completed"
-      ~model_used:None
-      ~tools_used:[]
-      ~stop_reason:None
-      ~duration_ms:None
       ~timestamp_ms:3000L;
     let events = Ide_bridge.list_events ~base_path:base_dir ~limit:2 () in
     check (list string) "newest-first types" [ "turn"; "tool" ]
@@ -243,7 +270,7 @@ let test_hook_row_carries_the_resolved_path_not_the_raw_argument () =
     in
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
-      ~attribution:(unattributed_file resolved)
+      ~attribution:(addressed_file ~codebase:"github.com_x_y" ~path:resolved)
       ~tool_name:"edit_file"
       ~keeper_id:"analyst"
       ~turn_id:"turn-3"
@@ -252,11 +279,22 @@ let test_hook_row_carries_the_resolved_path_not_the_raw_argument () =
       ~duration_ms:4.0
       ~output_text:"edited"
       ~input;
-    (match Ide_bridge.list_events ~base_path:base_dir ~kind:Ide_bridge.Tool () with
+    (match
+       Ide_bridge.list_events
+         ~base_path:base_dir
+         ~partition:(Ide_paths.By_url "github.com_x_y")
+         ~kind:Ide_bridge.Tool
+         ()
+     with
      | [ event ] ->
        check string "event carries the resolved path" resolved (json_string "file_path" event)
      | events -> Alcotest.failf "expected one tool event, got %d" (List.length events));
-    match Ide_bridge.list_cursors ~base_path:base_dir () with
+    match
+      Ide_bridge.list_cursors
+        ~base_path:base_dir
+        ~partition:(Ide_paths.By_url "github.com_x_y")
+        ()
+    with
     | [ cursor ] ->
       check string "cursor carries the same resolved path" resolved (json_string "file_path" cursor)
     | cursors -> Alcotest.failf "expected one cursor, got %d" (List.length cursors))
@@ -277,12 +315,42 @@ let test_pathless_hook_stores_no_document () =
       ~duration_ms:1.0
       ~output_text:"sent"
       ~input:(`Assoc [ "message", `String "hello"; "focus_mode", `String "editing" ]);
+    (* RFC-0378 §5.2: nothing is persisted — the keeper-timeline record of
+       a pathless call lives in the tool_calls store, not here. *)
     (match Ide_bridge.list_events ~base_path:base_dir ~kind:Ide_bridge.Tool () with
-     | [ event ] ->
-       check bool "no document on the row" true (json_field_is_null "file_path" event)
-     | events -> Alcotest.failf "expected one tool event, got %d" (List.length events));
+     | [] -> ()
+     | events ->
+       Alcotest.failf "pathless call must persist nothing, got %d" (List.length events));
     check int "no cursor" 0 (List.length (Ide_bridge.list_cursors ~base_path:base_dir ()))
   )
+;;
+
+(* RFC-0378 §5.2: an unaddressed write is a keeper fact — the ide store
+   persists no row and no cursor for it; its durable record is the
+   tool_calls store. *)
+let test_unaddressed_hook_persists_nothing () =
+  with_temp_dir (fun base_dir ->
+    Ide_bridge.ingest_tool_event_from_hook
+      ~base_path:base_dir
+      ~attribution:(unattributed_file "/outside/tree.ml")
+      ~tool_name:"edit_file"
+      ~keeper_id:"k1"
+      ~turn_id:"t1"
+      ~outcome:"ok"
+      ~typed_outcome_str:"progress"
+      ~duration_ms:1.0
+      ~output_text:"x"
+      ~input:
+        (`Assoc
+           [ "path", `String "/outside/tree.ml"
+           ; "line_start", `Int 1
+           ; "focus_mode", `String "editing"
+           ]);
+    (match Ide_bridge.list_events ~base_path:base_dir ~kind:Ide_bridge.Tool () with
+     | [] -> ()
+     | events ->
+       Alcotest.failf "unaddressed call must persist nothing, got %d" (List.length events));
+    check int "no cursor" 0 (List.length (Ide_bridge.list_cursors ~base_path:base_dir ())))
 ;;
 
 let test_cursor_from_hook_uses_real_file_and_line () =
@@ -298,7 +366,7 @@ let test_cursor_from_hook_uses_real_file_and_line () =
     in
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
-      ~attribution:(unattributed_file "lib/test.ml")
+      ~attribution:(addressed_file ~codebase:"github.com_x_y" ~path:"lib/test.ml")
       ~tool_name:"keeper_ide_annotate"
       ~keeper_id:"k1"
       ~turn_id:"turn-7"
@@ -307,7 +375,12 @@ let test_cursor_from_hook_uses_real_file_and_line () =
       ~duration_ms:10.0
       ~output_text:"annotated"
       ~input;
-    match Ide_bridge.list_cursors ~base_path:base_dir () with
+    match
+      Ide_bridge.list_cursors
+        ~base_path:base_dir
+        ~partition:(Ide_paths.By_url "github.com_x_y")
+        ()
+    with
     | [ cursor ] ->
       check string "keeper_id" "k1" (json_string "keeper_id" cursor);
       check string "file_path" "lib/test.ml" (json_string "file_path" cursor);
@@ -332,7 +405,7 @@ let test_cursor_from_hook_notifies_after_persist () =
       (fun () ->
         Ide_bridge.ingest_tool_event_from_hook
           ~base_path:base_dir
-          ~attribution:(unattributed_file "lib/test.ml")
+          ~attribution:(addressed_file ~codebase:"github.com_x_y" ~path:"lib/test.ml")
           ~tool_name:"keeper_ide_annotate"
           ~keeper_id:"k1"
           ~turn_id:"turn-7"
@@ -349,7 +422,11 @@ let test_cursor_from_hook_notifies_after_persist () =
         check (option string) "durable cursor notification keeper" (Some "k1")
           !notified_keeper;
         check int "cursor is durable before notification returns" 1
-          (List.length (Ide_bridge.list_cursors ~base_path:base_dir ()))))
+          (List.length
+             (Ide_bridge.list_cursors
+                ~base_path:base_dir
+                ~partition:(Ide_paths.By_url "github.com_x_y")
+                ()))))
 ;;
 
 let test_cursor_notifications_reraise_cancellation () =
@@ -371,7 +448,7 @@ let test_cursor_notifications_reraise_cancellation () =
           raises_cancel (fun () ->
             Ide_bridge.ingest_tool_event_from_hook
               ~base_path:base_dir
-              ~attribution:(unattributed_file "lib/test.ml")
+              ~attribution:(addressed_file ~codebase:"github.com_x_y" ~path:"lib/test.ml")
               ~tool_name:"keeper_ide_annotate"
               ~keeper_id:"k1"
               ~turn_id:"turn-7"
@@ -406,7 +483,7 @@ let test_cursor_from_hook_skips_missing_line () =
     let input = `Assoc [ "file_path", `String "lib/test.ml" ] in
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
-      ~attribution:(unattributed_file "lib/test.ml")
+      ~attribution:(addressed_file ~codebase:"github.com_x_y" ~path:"lib/test.ml")
       ~tool_name:"keeper_ide_annotate"
       ~keeper_id:"k1"
       ~turn_id:"turn-7"
@@ -426,7 +503,7 @@ let test_cursor_from_hook_skips_missing_focus_mode () =
     in
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
-      ~attribution:(unattributed_file "lib/test.ml")
+      ~attribution:(addressed_file ~codebase:"github.com_x_y" ~path:"lib/test.ml")
       ~tool_name:"keeper_ide_annotate"
       ~keeper_id:"k1"
       ~turn_id:"turn-7"
@@ -458,14 +535,11 @@ let test_hook_no_file_path () =
       ~duration_ms:10.0
       ~output_text:"file1.ml\nfile2.ml"
       ~input;
+    (* RFC-0378 §5.2: a pathless call is a keeper fact — the ide store
+       persists nothing for it, in any partition. *)
     let dir = Ide_paths.partition_store_dir ~base_dir:base_dir Ide_paths.Legacy_default in
     let path = Filename.concat dir "tool_events.jsonl" in
-    let ic = open_in path in
-    let line = input_line ic in
-    close_in ic;
-    let json = Yojson.Safe.from_string line in
-    let fp = Yojson.Safe.Util.member "file_path" json in
-    check bool "file_path is null" true (fp = `Null))
+    check bool "pathless call persists no ide row" false (Sys.file_exists path))
 ;;
 
 let test_hook_summary_truncation () =
@@ -474,7 +548,7 @@ let test_hook_summary_truncation () =
     let input = `Assoc [] in
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
-      ~attribution:Agent_observation.Pathless
+      ~attribution:(addressed_file ~codebase:"github.com_x_y" ~path:"lib/test.ml")
       ~tool_name:"execute"
       ~keeper_id:"k1"
       ~turn_id:"t1"
@@ -483,7 +557,11 @@ let test_hook_summary_truncation () =
       ~duration_ms:10.0
       ~output_text:long_output
       ~input;
-    let dir = Ide_paths.partition_store_dir ~base_dir:base_dir Ide_paths.Legacy_default in
+    let dir =
+      Ide_paths.partition_store_dir
+        ~base_dir:base_dir
+        (Ide_paths.By_url "github.com_x_y")
+    in
     let path = Filename.concat dir "tool_events.jsonl" in
     let ic = open_in path in
     let line = input_line ic in
@@ -498,7 +576,7 @@ let test_hook_typed_outcome_mapping () =
     let input = `Assoc [] in
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
-      ~attribution:Agent_observation.Pathless
+      ~attribution:(addressed_file ~codebase:"github.com_x_y" ~path:"lib/test.ml")
       ~tool_name:"execute"
       ~keeper_id:"k1"
       ~turn_id:"t1"
@@ -507,7 +585,11 @@ let test_hook_typed_outcome_mapping () =
       ~duration_ms:10.0
       ~output_text:"command failed"
       ~input;
-    let dir = Ide_paths.partition_store_dir ~base_dir:base_dir Ide_paths.Legacy_default in
+    let dir =
+      Ide_paths.partition_store_dir
+        ~base_dir:base_dir
+        (Ide_paths.By_url "github.com_x_y")
+    in
     let path = Filename.concat dir "tool_events.jsonl" in
     let ic = open_in path in
     let line = input_line ic in
@@ -850,7 +932,7 @@ let test_partition_legacy_default_isolated_from_by_url () =
     in
     Ide_bridge.ingest_tool_event_from_hook
       ~base_path:base_dir
-      ~attribution:(unattributed_file "lib/test.ml")
+      ~attribution:(addressed_file ~codebase:"github.com_x_y" ~path:"lib/test.ml")
       ~tool_name:"keeper_ide_annotate"
       ~keeper_id:"k1"
       ~turn_id:"turn-1"
@@ -859,18 +941,19 @@ let test_partition_legacy_default_isolated_from_by_url () =
       ~duration_ms:5.0
       ~output_text:"{}"
       ~input;
-    let orphan_events =
-      Ide_bridge.list_events ~base_path:base_dir
-        ~partition:Ide_paths.Legacy_default ()
-    in
-    check bool "legacy write lands in orphan" true
-      (List.length orphan_events >= 1);
     let by_url_events =
-      Ide_bridge.list_events ~base_path:base_dir
-        ~partition:(Ide_paths.By_url "github.com/jeong-sik/wkbl") ()
+      Ide_bridge.list_events
+        ~base_path:base_dir
+        ~partition:(Ide_paths.By_url "github.com_x_y")
+        ()
     in
-    check int "by-url read does not see the orphan write" 0
-      (List.length by_url_events))
+    check bool "addressed write lands in its by-url partition" true
+      (List.length by_url_events >= 1);
+    let orphan_events =
+      Ide_bridge.list_events ~base_path:base_dir ~partition:Ide_paths.Legacy_default ()
+    in
+    check int "orphan read does not see the addressed write" 0
+      (List.length orphan_events))
 ;;
 
 let () =
@@ -878,13 +961,13 @@ let () =
     "ide_bridge"
     [ ( "ingest"
       , [ test_case "tool event" `Quick test_ingest_tool_event
-        ; test_case "turn event" `Quick test_ingest_turn_event
+        ; test_case "seeded turn rows remain readable" `Quick test_turn_rows_remain_readable
         ; test_case "multiple events" `Quick test_ingest_multiple_events
         ] )
     ; ( "partition_attribution"
       , [ test_case "by-url routes tool event + cursor" `Quick
             test_partition_routes_tool_event_and_cursor_by_url
-        ; test_case "legacy_default isolated from by-url" `Quick
+        ; test_case "addressed write isolated from orphan" `Quick
             test_partition_legacy_default_isolated_from_by_url
         ] )
     ; ( "read"
@@ -920,7 +1003,8 @@ let () =
             test_pathless_hook_stores_no_document
         ] )
     ; ( "cursor"
-      , [ test_case "from hook uses real file and line" `Quick test_cursor_from_hook_uses_real_file_and_line
+      , [ test_case "unaddressed hook persists nothing" `Quick test_unaddressed_hook_persists_nothing
+        ; test_case "from hook uses real file and line" `Quick test_cursor_from_hook_uses_real_file_and_line
         ; test_case
             "from hook notifies after persist"
             `Quick

--- a/test/test_server_ide_http.ml
+++ b/test/test_server_ide_http.ml
@@ -1004,51 +1004,29 @@ let test_memory_response_honors_canonical_url_scope () =
    to the lane keeper, conflicts with repo scopes, and never authorizes
    mutations. *)
 
-(* RFC-0378 B: the bus carries no turn events; lane-read tests seed the
-   stored row directly — standing in for the pre-existing data the read
-   path serves until rung E. *)
-let rec seed_mkdir_p path =
-  if path = "" || path = "/" || Sys.file_exists path
-  then ()
-  else (
-    seed_mkdir_p (Filename.dirname path);
-    try Unix.mkdir path 0o755 with
-    | Unix.Unix_error (Unix.EEXIST, _, _) -> ())
-;;
-
-let seed_lane_turn_event ~base_path ~keeper_id ~turn_id ~timestamp_ms =
-  let dir = Ide_paths.partition_store_dir ~base_dir:base_path Ide_paths.Legacy_default in
-  seed_mkdir_p dir;
-  let row =
-    Ide_event_types.ide_event_to_json
-      (Ide_event_types.Turn_event
-         { turn_id
-         ; keeper_id
-         ; phase = "completed"
-         ; model_used = None
-         ; tools_used = []
-         ; stop_reason = None
-         ; duration_ms = Some 10
-         ; timestamp_ms
-         })
-  in
-  let oc =
-    open_out_gen
-      [ Open_append; Open_creat ]
-      0o644
-      (Filename.concat dir "turn_events.jsonl")
-  in
-  output_string oc (Yojson.Safe.to_string row ^ "\n");
-  close_out oc
+(* RFC-0378 B: Keeper lanes are projections over authoritative Keeper stores,
+   not a second IDE turn log. *)
+let seed_lane_receipt ~config ~keeper_id ~turn_id ~outcome ~recorded_at =
+  let store = Masc.Keeper_types_support.keeper_execution_receipt_store config keeper_id in
+  Dated_jsonl.append
+    store
+    (`Assoc
+      [ "keeper_name", `String keeper_id
+      ; "trace_id", `String turn_id
+      ; "outcome", `String outcome
+      ; "terminal_reason_code", `String outcome
+      ; "recorded_at", `String recorded_at
+      ])
 ;;
 
 let test_events_keeper_lane_returns_only_lane_events () =
-  with_ide_server (fun ~base_path ~state:_ ~router ->
+  with_ide_server (fun ~base_path ~state ~router ->
     let token = create_worker_token base_path "alice" in
-    seed_lane_turn_event ~base_path ~keeper_id:"alice" ~turn_id:"turn-alice-1"
-      ~timestamp_ms:1700000000000L;
-    seed_lane_turn_event ~base_path ~keeper_id:"bob" ~turn_id:"turn-bob-1"
-      ~timestamp_ms:1700000001000L;
+    let config = Masc.Mcp_server.workspace_config state in
+    seed_lane_receipt ~config ~keeper_id:"alice" ~turn_id:"turn-alice-1"
+      ~outcome:"receipt_done" ~recorded_at:"2023-11-14T22:13:20Z";
+    seed_lane_receipt ~config ~keeper_id:"bob" ~turn_id:"turn-bob-1"
+      ~outcome:"receipt_done" ~recorded_at:"2023-11-14T22:13:21Z";
     let request =
       http_request
         ~meth:`GET
@@ -1065,6 +1043,40 @@ let test_events_keeper_lane_returns_only_lane_events () =
       check string "lane keeper only" "alice"
         (json_string_member "lane event" "keeper_id" event)
     | events -> failf "expected exactly alice's event, got %d" (List.length events))
+;;
+
+let test_events_keeper_lane_projects_cancelled_receipts_and_tool_calls () =
+  with_ide_server (fun ~base_path ~state ~router ->
+    let token = create_worker_token base_path "alice" in
+    let config = Masc.Mcp_server.workspace_config state in
+    seed_lane_receipt ~config ~keeper_id:"alice" ~turn_id:"turn-cancelled"
+      ~outcome:"receipt_cancelled" ~recorded_at:"2023-11-14T22:13:20Z";
+    Masc.Keeper_tool_call_log.init ~base_path ();
+    Masc.Keeper_tool_call_log.log_call
+      ~keeper_name:"alice"
+      ~tool_name:"masc_board_read"
+      ~input:(`Assoc [])
+      ~output_text:"ok"
+      ~success:true
+      ~duration_ms:2.0
+      ~trace_id:"turn-cancelled"
+      ();
+    let request =
+      http_request
+        ~meth:`GET
+        ~path:"/api/v1/ide/events?keeper_lane=alice"
+        ~token:(Some token)
+        ()
+    in
+    let response = dispatch router request in
+    check_status "GET keeper-lane durable projection succeeds" 200 response;
+    let json = response |> response_body |> Yojson.Safe.from_string in
+    let events = json_list_member "lane events" "events" (Json.member "data" json) in
+    check int "receipt and tool call projected" 2 (List.length events);
+    let phases = List.filter_map (Safe_ops.json_string_opt "phase") events in
+    let tools = List.filter_map (Safe_ops.json_string_opt "tool_name") events in
+    check bool "cancelled receipt remains visible" true (List.mem "cancelled" phases);
+    check bool "pathless tool call remains visible" true (List.mem "masc_board_read" tools))
 ;;
 
 let test_events_keeper_lane_conflicts_with_repo_scope () =
@@ -1100,8 +1112,6 @@ let test_events_keeper_lane_rejects_mismatched_keeper_filter () =
 let test_events_keeper_lane_rejects_other_keeper_token () =
   with_ide_server (fun ~base_path ~state:_ ~router ->
     let token = create_worker_token base_path "bob" in
-    seed_lane_turn_event ~base_path ~keeper_id:"alice" ~turn_id:"turn-alice-1"
-      ~timestamp_ms:1700000000000L;
     let request =
       http_request
         ~meth:`GET
@@ -1259,6 +1269,10 @@ let () =
     ; ( "keeper_lane_scope"
       , [ test_case "GET events keeper_lane returns only lane events" `Quick
             test_events_keeper_lane_returns_only_lane_events
+        ; test_case
+            "GET events keeper_lane projects cancelled receipts and tool calls"
+            `Quick
+            test_events_keeper_lane_projects_cancelled_receipts_and_tool_calls
         ; test_case "keeper_lane conflicts with repo scope" `Quick
             test_events_keeper_lane_conflicts_with_repo_scope
         ; test_case "keeper_lane rejects mismatched keeper filter" `Quick

--- a/test/test_server_ide_http.ml
+++ b/test/test_server_ide_http.ml
@@ -1079,6 +1079,57 @@ let test_events_keeper_lane_projects_cancelled_receipts_and_tool_calls () =
     check bool "pathless tool call remains visible" true (List.mem "masc_board_read" tools))
 ;;
 
+let test_events_keeper_lane_sorts_intlit_and_excludes_addressed_tools () =
+  with_ide_server (fun ~base_path ~state ~router ->
+    let token = create_worker_token base_path "alice" in
+    let config = Masc.Mcp_server.workspace_config state in
+    let masc_path, _ = seed_annotation_scope_repos base_path in
+    let meta =
+      match Masc_test_deps.meta_of_json_fixture (`Assoc [ "name", `String "alice" ]) with
+      | Ok meta -> meta
+      | Error detail -> fail detail
+    in
+    (match Masc.Keeper_meta_store.replace_snapshot config meta with
+     | Ok () -> ()
+     | Error detail -> fail detail);
+    seed_lane_receipt ~config ~keeper_id:"alice" ~turn_id:"turn-old"
+      ~outcome:"receipt_done" ~recorded_at:"2023-11-14T22:13:20Z";
+    Masc.Keeper_tool_call_log.init ~base_path ();
+    Masc.Keeper_tool_call_log.log_call
+      ~keeper_name:"alice"
+      ~tool_name:"masc_board_read"
+      ~input:(`Assoc [])
+      ~output_text:"newest"
+      ~success:true
+      ~duration_ms:2.0
+      ~trace_id:"turn-new"
+      ();
+    Masc.Keeper_tool_call_log.log_call
+      ~keeper_name:"alice"
+      ~tool_name:"write"
+      ~input:(`Assoc [ "file_path", `String (Filename.concat masc_path "lib/a.ml") ])
+      ~output_text:"addressed"
+      ~success:true
+      ~duration_ms:2.0
+      ~trace_id:"turn-addressed"
+      ();
+    let request =
+      http_request
+        ~meth:`GET
+        ~path:"/api/v1/ide/events?keeper_lane=alice&limit=1"
+        ~token:(Some token)
+        ()
+    in
+    let response = dispatch router request in
+    check_status "GET keeper-lane filtered projection succeeds" 200 response;
+    let json = response |> response_body |> Yojson.Safe.from_string in
+    match json_list_member "lane events" "events" (Json.member "data" json) with
+    | [ event ] ->
+      check string "Intlit timestamps keep newest event first" "masc_board_read"
+        (json_string_member "lane tool event" "tool_name" event)
+    | events -> failf "expected one newest pathless event, got %d" (List.length events))
+;;
+
 let test_events_keeper_lane_conflicts_with_repo_scope () =
   with_ide_server (fun ~base_path:_ ~state:_ ~router ->
     let request =
@@ -1273,6 +1324,10 @@ let () =
             "GET events keeper_lane projects cancelled receipts and tool calls"
             `Quick
             test_events_keeper_lane_projects_cancelled_receipts_and_tool_calls
+        ; test_case
+            "GET events keeper_lane sorts Intlit and excludes addressed tools"
+            `Quick
+            test_events_keeper_lane_sorts_intlit_and_excludes_addressed_tools
         ; test_case "keeper_lane conflicts with repo scope" `Quick
             test_events_keeper_lane_conflicts_with_repo_scope
         ; test_case "keeper_lane rejects mismatched keeper filter" `Quick

--- a/test/test_server_ide_http.ml
+++ b/test/test_server_ide_http.ml
@@ -586,11 +586,13 @@ let test_hook_cursors_broadcast_ws_invalidation () =
         Ide_bridge.ingest_tool_event_from_hook
           ~base_path
           ~attribution:
-            (Agent_observation.File
-               (Agent_observation.Unaddressed
-                  { reason = Agent_observation.Unattributed.Unregistered_path
-                  ; attempted_path = "lib/a.ml"
-                  }))
+            (match
+               Agent_observation.Code_address.v ~codebase:"github.com_x_y" ~path:"lib/a.ml"
+             with
+             | Ok address ->
+               Agent_observation.File
+                 (Agent_observation.Addressed { address; checkout = None })
+             | Error _ -> failwith "test address must mint")
           ~tool_name:"keeper_ide_annotate"
           ~keeper_id:"alice"
           ~turn_id:"turn-7"
@@ -1002,17 +1004,42 @@ let test_memory_response_honors_canonical_url_scope () =
    to the lane keeper, conflicts with repo scopes, and never authorizes
    mutations. *)
 
+(* RFC-0378 B: the bus carries no turn events; lane-read tests seed the
+   stored row directly — standing in for the pre-existing data the read
+   path serves until rung E. *)
+let rec seed_mkdir_p path =
+  if path = "" || path = "/" || Sys.file_exists path
+  then ()
+  else (
+    seed_mkdir_p (Filename.dirname path);
+    try Unix.mkdir path 0o755 with
+    | Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+;;
+
 let seed_lane_turn_event ~base_path ~keeper_id ~turn_id ~timestamp_ms =
-  Ide_bridge.ingest_turn_event
-    ~base_path
-    ~turn_id
-    ~keeper_id
-    ~phase:"completed"
-    ~model_used:None
-    ~tools_used:[]
-    ~stop_reason:None
-    ~duration_ms:(Some 10)
-    ~timestamp_ms
+  let dir = Ide_paths.partition_store_dir ~base_dir:base_path Ide_paths.Legacy_default in
+  seed_mkdir_p dir;
+  let row =
+    Ide_event_types.ide_event_to_json
+      (Ide_event_types.Turn_event
+         { turn_id
+         ; keeper_id
+         ; phase = "completed"
+         ; model_used = None
+         ; tools_used = []
+         ; stop_reason = None
+         ; duration_ms = Some 10
+         ; timestamp_ms
+         })
+  in
+  let oc =
+    open_out_gen
+      [ Open_append; Open_creat ]
+      0o644
+      (Filename.concat dir "turn_events.jsonl")
+  in
+  output_string oc (Yojson.Safe.to_string row ^ "\n");
+  close_out oc
 ;;
 
 let test_events_keeper_lane_returns_only_lane_events () =


### PR DESCRIPTION
## 목표

RFC-0378 §7 사다리 B (A2 #28664 위 stacked)이에요. ide store가 **addressed code fact 전용**이 됩니다.

## 핵심

- **turn 방출 사슬 통삭제**: agent_run emit 2곳 + bus `turn_event` 타입/sink + bridge ingest — `keepers/<k>/turn-records/`가 이미 24필드 superset(강한 key)을 소유하는데 ide 사본은 약한 key의 중복 투영이었어요. base_path 자기귀속이 turn 146MiB 전량 orphan의 원인이었고, 타입이 사라지며 그 호출 자체가 소멸해요
- **sink Addressed-only**: tool hook·region·annotation sink가 Addressed만 영속. Pathless/Unaddressed는 bus에 흐르되(durable 증거는 tool_calls) ide store에 안 써요. **unaddressed annotation은 typed reject** — `ok:true` 매장이 계약상 불가능해져요
- production 경로의 orphan 신규 쓰기 0 → E에서 데이터와 함께 삭제

## 테스트

- 신규 pin 3: pathless→무영속, unaddressed→무영속, addressed→자기 by-url에만
- turn read는 E까지 기존 행을 서빙하므로 lane 테스트는 행 직접 시드로 전환
- 낙진 플립: 영속 역학 테스트들은 addressed 픽스처+by-url 읽기로 이행 (목적 보존)

## 검증 (stacked base라 풀 CI 부재 — #28664 코멘트의 같은 예외)

- `dune build @check` clean
- 7 스위트 green: code_address · agent_observation_bridge · ide_bridge · ide_canonical_url_join · keeper_run_tools_hooks(27) · ide_annotations · server_ide_http
- ocamlformat 전 변경 파일 적용

RFC: #28645 · A1: #28649 · A2: #28664

🤖 Generated with [Claude Code](https://claude.com/claude-code)