### PR TITLE
fix(keeper): preserve selected model on turn records

### DIFF
--- a/dashboard/src/api/dashboard-turn-records.test.ts
+++ b/dashboard/src/api/dashboard-turn-records.test.ts
@@ -160,6 +160,11 @@ describe('keeper turn record cache token counts', () => {
     await expect(fetchKeeperTurnRecords('sangsu')).rejects.toThrow(
       '유효하지 않은 keeper turn record payload',
     )
+
+    getMock.mockResolvedValue(payload(entry({ selected_model: ' ' })))
+    await expect(fetchKeeperTurnRecords('sangsu')).rejects.toThrow(
+      '유효하지 않은 keeper turn record payload',
+    )
   })
 
   it('projects the record identity fields the writer always emits', async () => {
@@ -244,8 +249,8 @@ describe('keeper turn record cache token counts', () => {
     )
   })
 
-  it('rejects fields outside the exact current nested record', async () => {
-    getMock.mockResolvedValue(payload(entry({ retired_field: 'invalid' })))
+  it('rejects the retired unversioned model field', async () => {
+    getMock.mockResolvedValue(payload(entry({ model: 'runtime' })))
 
     await expect(fetchKeeperTurnRecords('sangsu')).rejects.toThrow(
       '유효하지 않은 keeper turn record payload',

--- a/dashboard/src/api/dashboard-turn-records.ts
+++ b/dashboard/src/api/dashboard-turn-records.ts
@@ -82,10 +82,10 @@ export type TurnRecordEntry = {
   request_runtime_profile: string | null
   request_body_bytes: number | null
   runtime_profile: string
-  // RFC-0233 §2.3 — grounded from the backend turn record (boundary-redacted
-  // model label + keeper stop reason). Absent (undefined) on error turns and
-  // pre-grounding rows; the inspector renders absence, never a fabricated value.
-  model?: string
+  // RFC-0233 §2.3 — exact selected model from the successful runtime attempt.
+  // Absent (undefined) when the producer observed no selected model; the
+  // inspector renders absence, never a fabricated value.
+  selected_model?: string
   finish_reason?: string
   temperature?: number
   top_p?: number
@@ -326,7 +326,7 @@ function hasNoUnknownKeys(raw: Record<string, unknown>, allowed: readonly string
 }
 
 function decodeExactNonEmptyString(raw: unknown): string | null {
-  return typeof raw === 'string' && raw.length > 0 ? raw : null
+  return typeof raw === 'string' && raw.trim().length > 0 ? raw : null
 }
 
 function decodeNullableString(raw: unknown): string | null | undefined {
@@ -502,7 +502,7 @@ function decodeTurnRecordEntry(raw: unknown): TurnRecordEntry | null {
     'request_runtime_profile',
     'request_body_bytes',
     'runtime_profile',
-    'model',
+    'selected_model',
     'finish_reason',
     'context_window',
     'price_input_per_million',
@@ -551,7 +551,7 @@ function decodeTurnRecordEntry(raw: unknown): TurnRecordEntry | null {
       : request_runtime_profile === null && request_body_bytes === null
         ? { request_runtime_profile: null, request_body_bytes: null }
         : null
-  const model = decodeOptionalField(raw, 'model', decodeExactNonEmptyString)
+  const selected_model = decodeOptionalField(raw, 'selected_model', decodeExactNonEmptyString)
   const finish_reason = decodeOptionalField(raw, 'finish_reason', decodeExactNonEmptyString)
   const context_window = decodeOptionalField(raw, 'context_window', decodeNonNegativeSafeInteger)
   const price_input_per_million =
@@ -598,7 +598,7 @@ function decodeTurnRecordEntry(raw: unknown): TurnRecordEntry | null {
     || requestWireObservation === null
     || !Array.isArray(raw.execution_ids)
     || !raw.execution_ids.every((id): id is string => typeof id === 'string' && id.length > 0)
-    || model === null
+    || selected_model === null
     || finish_reason === null
     || context_window === null
     || price_input_per_million === null
@@ -632,7 +632,7 @@ function decodeTurnRecordEntry(raw: unknown): TurnRecordEntry | null {
     input_components,
     ...requestWireObservation,
     runtime_profile,
-    model,
+    selected_model,
     finish_reason,
     temperature,
     top_p,

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -468,7 +468,7 @@ describe('keeper tool telemetry fetchers', () => {
     expect(result.entries.map(entry => entry.duration_ms)).toEqual([null, null])
   })
 
-  it('grounds turn-record model / finish_reason, leaving absent fields undefined', async () => {
+  it('grounds turn-record selected_model / finish_reason, leaving absent fields undefined', async () => {
     const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(
       new Response(JSON.stringify({
         keeper: 'keeper-alpha',
@@ -511,7 +511,7 @@ describe('keeper tool telemetry fetchers', () => {
               turn_ref: 'trace-grounded#7',
               ts: 10,
               runtime_profile: 'local',
-              model: 'deepseek-v4-flash',
+              selected_model: 'deepseek-v4-flash',
               finish_reason: 'completed',
               blocks: [],
               input_components: [],
@@ -522,7 +522,7 @@ describe('keeper tool telemetry fetchers', () => {
             diff_vs_prev: null,
           },
           {
-            // RFC-0233 §2.3: error turn omits model/finish_reason — must
+            // RFC-0233 §2.3: error turn omits selected_model/finish_reason — must
             // decode to undefined, never a fabricated "stop"/placeholder.
             record: {
               keeper: 'keeper-alpha',
@@ -551,9 +551,9 @@ describe('keeper tool telemetry fetchers', () => {
     const result = await fetchKeeperTurnRecords('keeper-alpha')
 
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/keepers/keeper-alpha/turn-records')
-    expect(result.entries[0]?.record.model).toBe('deepseek-v4-flash')
+    expect(result.entries[0]?.record.selected_model).toBe('deepseek-v4-flash')
     expect(result.entries[0]?.record.finish_reason).toBe('completed')
-    expect(result.entries[1]?.record.model).toBeUndefined()
+    expect(result.entries[1]?.record.selected_model).toBeUndefined()
     expect(result.entries[1]?.record.finish_reason).toBeUndefined()
   })
 

--- a/dashboard/src/components/keeper-turn-inspector.test.ts
+++ b/dashboard/src/components/keeper-turn-inspector.test.ts
@@ -267,6 +267,27 @@ describe('KeeperTurnInspector v2 drawer', () => {
     })
   })
 
+  it('distinguishes incompatible retained rows from an empty turn history', async () => {
+    fetchKeeperTurnRecordsMock.mockResolvedValue({
+      ...turnRecordsWithMemoryOs(),
+      health: 'incompatible',
+      stale_reason: 'incompatible_rows',
+      skipped_rows: 3,
+      count: 0,
+      entries: [],
+      latest_ts_unix: null,
+      latest_ts_iso: null,
+      latest_age_s: null,
+    })
+
+    const { container } = render(html`<${KeeperTurnInspector} keeperName="albini" />`)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('current decoder가 최근 3행을 모두 거부했습니다')
+    })
+    expect(container.textContent).not.toContain('턴 레코드 없음')
+  })
+
   it('renders the detail drawer when a turn row is clicked', async () => {
     fetchKeeperTurnRecordsMock.mockResolvedValue(turnRecordsWithMemoryOs())
 

--- a/dashboard/src/components/keeper-turn-inspector.test.ts
+++ b/dashboard/src/components/keeper-turn-inspector.test.ts
@@ -154,7 +154,7 @@ function turnRecordsWithMemoryOs(): TurnRecordsResponse {
           turn_ref: 'trace-active#42',
           ts: 1_781_587_560,
           runtime_profile: 'local',
-          model: 'deepseek-v4-flash',
+          selected_model: 'deepseek-v4-flash',
           finish_reason: 'completed',
           input_tokens: 2400,
           output_tokens: 280,
@@ -505,7 +505,7 @@ describe('KeeperTurnInspector v2 drawer', () => {
     ).toBe(false)
   })
 
-  it('grounds model / finish_reason from the record and marks deferred fields n/a', async () => {
+  it('grounds selected_model / finish_reason from the record and marks deferred fields n/a', async () => {
     fetchKeeperTurnRecordsMock.mockResolvedValue(turnRecordsWithMemoryOs())
 
     const { container } = render(html`<${KeeperTurnInspector} keeperName="albini" />`)
@@ -542,7 +542,7 @@ describe('KeeperTurnInspector v2 drawer', () => {
       ...response.entries[1]!,
       record: {
         ...response.entries[1]!.record,
-        model: undefined,
+        selected_model: undefined,
         finish_reason: undefined,
       },
     }

--- a/dashboard/src/components/keeper-turn-inspector.ts
+++ b/dashboard/src/components/keeper-turn-inspector.ts
@@ -438,7 +438,7 @@ function buildInjectedCtx(record: TurnRecordEntry, ctxPct: number | null, tokIn:
     : `미상   (${tokIn.toLocaleString()} / 미상 tok, runtime 미구성)`
   return `# world snapshot
 fsm.state      = n/a
-model          = ${record.model ?? 'n/a'}
+selected model = ${record.selected_model ?? 'n/a'}
 finish_reason  = ${record.finish_reason ?? 'n/a'}
 ctx.window     = ${ctxLine}
 keeper.turn    = T${record.absolute_turn}
@@ -970,7 +970,7 @@ function MetaTab({ record, t, source }: { record: TurnRecordEntry; t: TurnDetail
       </div>
       <div class="kti-sec-h" style=${{ marginTop: '16px' }}><h4>실행 메타데이터</h4></div>
       <div class="kti-kv">
-        <span class="k">model</span><span class="v">${record.model ?? 'n/a'}</span>
+        <span class="k">selected model</span><span class="v">${record.selected_model ?? 'n/a'}</span>
         <span class="k">runtime</span><span class="v">${record.runtime_profile}</span>
         <span class="k">fsm.state</span><span class="v">n/a</span>
         <span class="k">input tokens</span><span class="v">${t.tokIn.toLocaleString()}</span>

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -78,7 +78,7 @@ vi.mock('../../api/dashboard', async (importOriginal) => {
             request_runtime_profile: null,
             request_body_bytes: null,
             runtime_profile: 'agent-core-seoul-1',
-            model: 'runtime',
+            selected_model: 'gpt-5.4',
             finish_reason: 'completed',
             input_tokens: 33000,
             output_tokens: 120,

--- a/docs/rfc/RFC-0132-redaction-ssot.md
+++ b/docs/rfc/RFC-0132-redaction-ssot.md
@@ -55,7 +55,7 @@ Plan SSOT cross-reference:
 - Bundle research artifact PR #16480 §RFC B candidate
 
 Memory cross-reference:
-- `memory/feedback_runtime_lens_boundary_carve_out.md` (2026-05-13~14, PRs #15040 / #15070 / #15089) — establishes the *external surface redact `"runtime"` / internal observability real provider* boundary as a runtime invariant.
+- `memory/feedback_runtime_lens_boundary_carve_out.md` (2026-05-13~14, PRs #15040 / #15070 / #15089) — establishes the *aggregate telemetry redact `"runtime"` / exact execution evidence keeps the observed provider and model* boundary as a runtime invariant.
 
 Workaround Rejection Bar cross-reference (`instructions/software-development.md` §AI 코드 생성 안티패턴):
 - Pattern **1. 하드코딩 산포 (Scattered Hardcoded Defaults)** — exact match.
@@ -71,7 +71,7 @@ Related RFCs:
 
 ## 1. Problem statement
 
-The literal string `"runtime"` is used today as a **boundary redaction label** for external surfaces (dashboard SSE, OAS bridge, keeper telemetry) where the *real* provider/model identity is intentionally suppressed. The label is **scattered as inline literals or local module-level constants** across `lib/runtime/` and `lib/keeper/` with no compiler-enforced SSOT.
+The literal string `"runtime"` is used today as a **boundary redaction label** for aggregate surfaces (dashboard SSE, OAS bridge, keeper telemetry) where the *real* provider/model identity is intentionally suppressed. Exact per-turn evidence such as execution receipts and turn records is outside this label policy. The label is **scattered as inline literals or local module-level constants** across `lib/runtime/` and `lib/keeper/` with no compiler-enforced SSOT.
 
 Direct measurement on `origin/main` (commit `aceefd562a`, 2026-05-19):
 
@@ -123,6 +123,12 @@ Decomposed by shape:
 
 Sites in `keeper_unified_metrics.mli` (lines 113, 141) are doc-comment mentions of the redacted lane, not emit sites — they remain as documentation referencing `Boundary_redaction.runtime_provider_label`.
 
+The table above records the measured 2026-05 source. The current contract
+classifies turn records and execution receipts as operator-owned per-turn
+evidence: their model field carries the selected attempt's observed model and
+is not part of this aggregate-label redaction policy. Dashboard telemetry
+aggregates and AGENT_CORE bridge labels remain redacted through this module.
+
 ### Why this is a problem
 
 1. **No compiler enforcement.** A new Runtime or Keeper module can introduce `"runtime"` as an inline literal without any lint or type signal. The `feedback_runtime_lens_boundary_carve_out` regression (#15040 / #15070 / #15089) is the empirical case — three separate PRs reintroduced inline literals because the boundary discipline lived only in commit history and runbooks.
@@ -154,16 +160,17 @@ Introduce a private-type SSOT module that owns the redaction label vocabulary an
 `lib/types_boundary/boundary_redaction.mli`:
 
 ```ocaml
-(** Boundary redaction labels — SSOT for external surface label vocabulary.
+(** Boundary redaction labels — SSOT for aggregate surface label vocabulary.
 
-    External surfaces (dashboard SSE, OAS bridge, keeper telemetry exposed to
+    Aggregate surfaces (dashboard SSE, OAS bridge, keeper telemetry exposed to
     the operator UI) intentionally redact the real provider/model identity
     behind a fixed label. This module is the only place that holds the label
-    string. All emit sites must route through {!to_string}.
+    string. Emit sites governed by that aggregate contract must route through
+    {!to_string}.
 
-    Internal observability (logs, real provider records, FSM event payloads
-    that stay inside the OCaml runtime) MUST continue to use the actual
-    provider/model identity — do not route those through this module.
+    Internal observability and operator-owned exact execution evidence MUST
+    continue to use the actual provider/model identity — do not route those
+    through this module.
 
     Reference: RFC-0132. *)
 

--- a/docs/rfc/RFC-0233-turn-observability-execution-identity.md
+++ b/docs/rfc/RFC-0233-turn-observability-execution-identity.md
@@ -122,6 +122,7 @@ type turn_record =
   ; absolute_turn : int
   ; blocks : prompt_block list            (* assembly order *)
   ; runtime_profile : string
+  ; selected_model : string option        (* selected successful attempt *)
   ; sampling : { temperature : float option
                ; thinking_budget : int option
                ; enable_thinking : bool option }
@@ -439,7 +440,7 @@ view-side-repair violation of §2.3.
   no re-parse.
 - All three are `option`: `None` when the runtime is unknown or the operator
   left the rates unset in runtime.toml. The view renders "미상" (unknown),
-  never a fabricated value — the same absence contract `model` and
+  never a fabricated value — the same absence contract `selected_model` and
   `finish_reason` already follow (§2.3).
 - Cost is **not** stored: the view derives it from `price_*_per_million ×
   real token counts`, per the views-derive principle (§2.3).
@@ -476,7 +477,7 @@ the shared-record field addition catches every literal construction site
 
 1. **Type + codec** — `lib/types/turn_record.{mli,ml}`: three option fields
    on `t`; `to_json` via `opt_field`, `of_json` via `opt_member` (mirrors
-   `model`/`finish_reason`/`temperature`).
+   `selected_model`/`finish_reason`/`temperature`).
 2. **Runtime projection** — `lib/runtime/runtime.{ml,mli}`:
    `pricing_of_runtime_id : string -> float option * float option`, sibling
    to `max_context_of_runtime_id`.

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -992,13 +992,15 @@ let run_turn
           Agent.run. Post-run episode creation requires an explicit
           flush_incremental call since AfterTurn already fired. *)
                  let text = Agent_core.Types.text_of_content result.response.content in
-                 (* RFC-0132 PR-2: receipt model surface = external boundary; redact via SSOT. *)
-                 let model =
+                 let manifest_model_label =
                    Boundary_redaction.to_string
                      Boundary_redaction.runtime_model_label
                  in
                  receipt_turn_count_ref := Some result.turns;
-                 receipt_model_used_ref := Some model;
+                 receipt_model_used_ref :=
+                   Option.bind
+                     result.runtime_observation
+                     (fun observation -> observation.selected_model);
                  receipt_stop_reason_ref := Some result.stop_reason;
                  receipt_runtime_observation_ref := result.runtime_observation;
                  (* Thinking is now persisted per-turn inside the after_turn
@@ -1105,7 +1107,8 @@ let run_turn
                              ~ctx_snapshot:ctx_work
                              ~generation ~profile_defaults
                              ~manifest_keeper_turn_id
-                             ~session ~append_manifest ~model
+                             ~session ~append_manifest
+                             ~model:manifest_model_label
                              ~acc
                              ~actual_keeper_tool_names
                              ~result
@@ -1269,9 +1272,9 @@ let run_turn
           | Error _ -> None
         in
         (* RFC-0233 §2.3 — views derive, no view-side repair: ground the
-           inspector's [model] and [finish_reason] in the same refs the
-           execution receipt already records this turn. [model] is the
-           RFC-0132 boundary-redacted runtime label; [finish_reason] is
+           inspector's [selected_model] and [finish_reason] in the same refs
+           the execution receipt already records this turn. [selected_model]
+           is the successful attempt's observed model; [finish_reason] is
            the keeper stop reason serialized through the receipt SSOT
            ([Keeper_execution_receipt.stop_reason_to_string]). Both are
            [None] on the error path (receipt refs unset), never a
@@ -1346,7 +1349,7 @@ let run_turn
           ~trace_id
           ~absolute_turn:manifest_keeper_turn_id
           ~runtime_profile:settled_runtime_id
-          ~model:!receipt_model_used_ref
+          ~selected_model:!receipt_model_used_ref
           ~finish_reason:
             (Option.map
                Keeper_execution_receipt.stop_reason_to_string

--- a/lib/keeper/keeper_turn_record_writer.ml
+++ b/lib/keeper/keeper_turn_record_writer.ml
@@ -7,7 +7,7 @@ let write
       ~trace_id
       ~absolute_turn
       ~runtime_profile
-      ~model
+      ~selected_model
       ~finish_reason
       ~context_window
       ~price_input_per_million
@@ -35,7 +35,7 @@ let write
     ; blocks
     ; input_components
     ; runtime_profile
-    ; model
+    ; selected_model
     ; finish_reason
     ; context_window
     ; price_input_per_million

--- a/lib/keeper/keeper_turn_record_writer.mli
+++ b/lib/keeper/keeper_turn_record_writer.mli
@@ -17,7 +17,7 @@ val write :
   trace_id:string ->
   absolute_turn:int ->
   runtime_profile:string ->
-  model:string option ->
+  selected_model:string option ->
   finish_reason:string option ->
   context_window:int option ->
   price_input_per_million:float option ->

--- a/lib/server/server_dashboard_http_keeper_api_types.ml
+++ b/lib/server/server_dashboard_http_keeper_api_types.ml
@@ -19,6 +19,7 @@ let keeper_suffix_paused_work = "/paused-work"
 let keeper_suffix_raw_traces = "/raw-traces"
 let keeper_suffix_raw_trace = "/raw-trace"
 let keeper_suffix_memory_journal = "/memory-journal"
+let keeper_suffix_turn_records = "/turn-records"
 let keeper_suffix_catchup_judge = "/catchup-judge"
 let keeper_suffix_fusion = "/fusion"
 let keeper_suffix_operator_note = "/operator-note"
@@ -164,7 +165,9 @@ let is_keeper_paused_work_get_path req_path =
   keeper_path_ends_with req_path keeper_suffix_paused_work
 
 let keeper_get_permission req_path =
-  if
+  if keeper_path_ends_with req_path keeper_suffix_turn_records
+  then Some Masc_domain.CanReadState
+  else if
     is_keeper_checkpoints_get_path req_path
     || is_keeper_paused_work_get_path req_path
     || keeper_path_ends_with req_path keeper_suffix_github_identity

--- a/lib/server/server_dashboard_http_keeper_api_types.mli
+++ b/lib/server/server_dashboard_http_keeper_api_types.mli
@@ -27,6 +27,7 @@ val keeper_suffix_paused_work : string
 val keeper_suffix_catchup_judge : string
 val keeper_suffix_fusion : string
 val keeper_suffix_operator_note : string
+val keeper_suffix_turn_records : string
 
 (** {1 Dashboard cache keys} *)
 
@@ -99,9 +100,9 @@ val is_keeper_paused_work_get_path : string -> bool
 
 val keeper_get_permission : string -> Masc_domain.permission option
 (** Mandatory token-bound permission for sensitive keeper GET sub-routes.
-    Raw retained traces, Memory OS change journals, checkpoint state, and
-    paused-work operator state all require [CanAdmin]. [None] leaves the route
-    on its existing public-read policy. *)
+    Exact turn evidence requires [CanReadState]. Raw retained traces, Memory OS
+    change journals, checkpoint state, and paused-work operator state require
+    [CanAdmin]. [None] leaves the route on its existing public-read policy. *)
 
 (** {1 Trajectory preview helpers} *)
 

--- a/lib/types/turn_record.ml
+++ b/lib/types/turn_record.ml
@@ -68,7 +68,7 @@ type t =
   ; blocks : prompt_block list
   ; input_components : input_component list option
   ; runtime_profile : string
-  ; model : string option
+  ; selected_model : string option
   ; finish_reason : string option
   ; context_window : int option
   ; price_input_per_million : float option
@@ -165,7 +165,7 @@ let to_json (r : t) : Yojson.Safe.t =
          | Some run_ref -> raw_trace_run_ref_to_json run_ref
          | None -> `Null )
      ]
-    @ opt_field "model" (fun v -> `String v) r.model
+    @ opt_field "selected_model" (fun v -> `String v) r.selected_model
     @ opt_field "finish_reason" (fun v -> `String v) r.finish_reason
     @ opt_field "context_window" (fun v -> `Int v) r.context_window
     @ opt_field "price_input_per_million" (fun v -> `Float v) r.price_input_per_million
@@ -426,7 +426,7 @@ let of_json (json : Yojson.Safe.t) : (t, string) result =
             ; "request_runtime_profile"
             ; "request_body_bytes"
             ; "raw_trace_run_ref"
-            ; "model"
+            ; "selected_model"
             ; "finish_reason"
             ; "context_window"
             ; "price_input_per_million"
@@ -532,7 +532,7 @@ let of_json (json : Yojson.Safe.t) : (t, string) result =
           in
           Ok (Some run_ref)
       in
-      let* model = opt_member "model" fields as_string in
+      let* selected_model = opt_member "selected_model" fields as_nonempty_string in
       let* finish_reason = opt_member "finish_reason" fields as_string in
       let* context_window = opt_member "context_window" fields as_int in
       let* price_input_per_million = opt_member "price_input_per_million" fields as_float in
@@ -566,7 +566,7 @@ let of_json (json : Yojson.Safe.t) : (t, string) result =
         ; blocks
         ; input_components
         ; runtime_profile
-        ; model
+        ; selected_model
         ; finish_reason
         ; context_window
         ; price_input_per_million

--- a/lib/types/turn_record.mli
+++ b/lib/types/turn_record.mli
@@ -101,10 +101,11 @@ type t =
        never substituted for, [request_wire_observation]. [None] means exact
        attribution was unavailable; an observed empty input is [Some []]. *)
   ; runtime_profile : string
-  ; model : string option
-    (* RFC-0233 §2.2/§2.3 — boundary-redacted runtime model label, the
-       same value the execution receipt surfaces (RFC-0132 redaction
-       SSOT). [None] on error turns before runtime grounding; the inspector
+  ; selected_model : string option
+    (* RFC-0233 §2.2/§2.3 — exact model selected by the successful runtime
+       attempt, sourced from that attempt's [Runtime_observation]. This is
+       durable operator evidence, not an aggregate telemetry label. [None]
+       when the turn completed without selected-model evidence; the inspector
        renders absence rather than a fabricated name. *)
   ; finish_reason : string option
     (* RFC-0233 §2.3 — keeper turn stop reason, serialized via the

--- a/lib/types_boundary/boundary_redaction.mli
+++ b/lib/types_boundary/boundary_redaction.mli
@@ -1,14 +1,14 @@
 (** Boundary redaction SSOT.
 
-    External-surface emit sites (dashboard telemetry, AGENT_CORE boundary,
-    operator log) must redact provider/model identity to a small set
-    of [public_label] values. The [private string] type prevents
-    callers from constructing arbitrary labels — the only labels are
-    the constructors exposed below.
+    Aggregate telemetry emit sites whose owning contract suppresses exact
+    provider/model identity use a small set of [public_label] values. The
+    [private string] type prevents callers from constructing arbitrary labels
+    — the only labels are the constructors exposed below.
 
     Internal observability paths (real provider tracking, internal
-    metrics) MUST NOT use this module — they should emit the real
-    string. RFC-0132 §3 enumerates the boundary classification.
+    metrics) and operator-owned exact execution evidence (receipts and turn
+    records) MUST NOT use this module — they should emit the observed value.
+    RFC-0132 §3 enumerates the boundary classification.
 
     Adding a new public label requires both: a new constructor here,
     and a row in RFC-0132 §3 explaining the surface that emits it. *)

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -173,6 +173,11 @@ let test_keeper_sensitive_get_permissions_are_exact () =
     [ "raw-traces"; "raw-trace"; "memory-journal" ];
   check bool "checkpoint permission" true
     (permission "/api/v1/keepers/idealist/checkpoints" = Some Masc_domain.CanAdmin);
+  check bool "turn records require authenticated state read" true
+    (permission "/api/v1/keepers/idealist/turn-records"
+     = Some Masc_domain.CanReadState);
+  check bool "turn records route rejects trailing segment" true
+    (permission "/api/v1/keepers/idealist/turn-records/extra" = None);
   check bool "ordinary keeper read stays public" true
     (permission "/api/v1/keepers/idealist/trajectory" = None)
 

--- a/test/test_keeper_autonomous_turn_source.ml
+++ b/test/test_keeper_autonomous_turn_source.ml
@@ -122,7 +122,7 @@ let write_turn_record config ~absolute_turn ~generation ~turn_kind ~raw_trace_ru
     ~trace_id
     ~absolute_turn
     ~runtime_profile:"test-runtime"
-    ~model:(Some "public-model")
+    ~selected_model:(Some "public-model")
     ~finish_reason:(Some "completed")
     ~context_window:None
     ~price_input_per_million:None

--- a/test/test_keeper_context_observation_projection.ml
+++ b/test/test_keeper_context_observation_projection.ml
@@ -44,7 +44,7 @@ let sample_record
       ]
   ; input_components = Some [ { component = Turn_record.Tool_schemas; bytes = 8192 } ]
   ; runtime_profile = "glm-coding.glm-5-turbo"
-  ; model = Some "glm-5-turbo"
+  ; selected_model = Some "glm-5-turbo"
   ; finish_reason = Some "completed"
   ; context_window
   ; price_input_per_million = None

--- a/test/test_keeper_raw_trace_sink.ml
+++ b/test/test_keeper_raw_trace_sink.ml
@@ -125,7 +125,7 @@ let write_turn_record config ~(meta : Keeper_meta_contract.keeper_meta) ~turn
     ~trace_id
     ~absolute_turn:turn
     ~runtime_profile:"test-runtime"
-    ~model:(Some "test-model")
+    ~selected_model:(Some "test-model")
     ~finish_reason:(Some "completed")
     ~context_window:None
     ~price_input_per_million:None

--- a/test/test_turn_record.ml
+++ b/test/test_turn_record.ml
@@ -71,7 +71,7 @@ let sample_record () : Turn_record.t =
         ; { component = Turn_record.Message_user; bytes = 256 }
         ]
   ; runtime_profile = "ollama_cloud.deepseek-v4-flash"
-  ; model = Some "deepseek-v4-flash"
+  ; selected_model = Some "deepseek-v4-flash"
   ; finish_reason = Some "completed"
   ; context_window = Some 131072
   ; price_input_per_million = Some 0.15
@@ -183,7 +183,7 @@ let test_codec_roundtrip () =
          (fun (component : Turn_record.input_component) -> component.bytes)
          (input_components_or_fail decoded.input_components));
     check string "runtime_profile" record.runtime_profile decoded.runtime_profile;
-    check (option string) "model" record.model decoded.model;
+    check (option string) "selected_model" record.selected_model decoded.selected_model;
     check (option string) "finish_reason" record.finish_reason decoded.finish_reason;
     check (option int) "context_window" record.context_window decoded.context_window;
     check (option (float 0.0001)) "price_input_per_million"
@@ -238,7 +238,7 @@ let test_codec_roundtrip () =
 let test_codec_optional_fields_absent () =
   let record =
     { (sample_record ()) with
-      model = None
+      selected_model = None
     ; finish_reason = None
     ; context_window = None
     ; price_input_per_million = None
@@ -263,14 +263,14 @@ let test_codec_optional_fields_absent () =
   in
   let json = Turn_record.to_json record in
   (* RFC-0233 §2.3/§8: absent meta fields are omitted from the wire, never
-     emitted as a fabricated value (no "stop", no placeholder model, no
+     emitted as a fabricated value (no "stop", no placeholder selected model, no
      fabricated 200K window or Claude $3/$15 price). *)
   (match json with
    | `Assoc fields ->
      check bool "finish_reason key omitted when None" false
        (List.mem_assoc "finish_reason" fields);
-     check bool "model key omitted when None" false
-       (List.mem_assoc "model" fields);
+     check bool "selected_model key omitted when None" false
+       (List.mem_assoc "selected_model" fields);
      check bool "top_p key omitted when None" false
        (List.mem_assoc "top_p" fields);
      check bool "max_tokens key omitted when None" false
@@ -295,7 +295,8 @@ let test_codec_optional_fields_absent () =
   match Turn_record.of_json json with
   | Error e -> failf "decode failed: %s" e
   | Ok decoded ->
-    check (option string) "model absent stays None" None decoded.model;
+    check (option string) "selected_model absent stays None" None
+      decoded.selected_model;
     check (option string) "finish_reason absent stays None (not \"stop\")" None
       decoded.finish_reason;
     check (option int) "context_window absent stays None" None decoded.context_window;
@@ -329,6 +330,19 @@ let test_codec_rejects_malformed () =
   (match Turn_record.of_json (`String "not a record") with
    | Ok _ -> fail "decoded a non-object"
    | Error _ -> ());
+  (match Turn_record.to_json (sample_record ()) with
+   | `Assoc fields ->
+     let blank_selected_model =
+       `Assoc
+         (("selected_model", `String " ")
+          :: List.remove_assoc "selected_model" fields)
+     in
+     (match Turn_record.of_json blank_selected_model with
+      | Ok _ -> fail "decoded a blank selected_model"
+      | Error message ->
+        check bool "blank selected_model is explicit" true
+          (Astring.String.is_infix ~affix:"selected_model" message))
+   | _ -> fail "sample turn record is not an object");
   match Turn_record.of_json (`Assoc [ ("keeper", `String "x") ]) with
   | Ok _ -> fail "decoded a row with missing fields"
   | Error msg ->
@@ -563,7 +577,7 @@ let test_codec_rejects_unknown_fields () =
   let record_json = Turn_record.to_json (sample_record ()) in
   let with_unknown_record_field =
     match record_json with
-    | `Assoc fields -> `Assoc (("retired_cursor", `String "old") :: fields)
+    | `Assoc fields -> `Assoc (("model", `String "runtime") :: fields)
     | other -> other
   in
   (match Turn_record.of_json with_unknown_record_field with


### PR DESCRIPTION
## As-Is

A live 10-turn direct canary on `codex_subscription.gpt-5.4` completed all ten durable operations on one trace/generation, but `/api/v1/keepers/:name/turn-records` and the Dashboard turn inspector rendered `model = runtime`. The authoritative execution receipt for the same turn already carried `runtime.selected_model = gpt-5.4`.

## To-Be

- Persist the final successful runtime attempt's observed model as `selected_model` on the TurnRecord.
- Hard-cut the retired unversioned `model` field. Old `model: "runtime"` rows are incompatible/skipped; there is no migration, alias, sentinel inference, or compatibility reader.
- Keep missing selected-model evidence as `None` / absent JSON.
- Require token-bound `CanReadState` for the exact `/turn-records` evidence endpoint; aggregate telemetry redaction is unchanged.
- Render `selected model` from the strict current-only Dashboard decoder.

## Live evidence before the fix

- 10/10 durable chat operations succeeded with unique `operation_id` and `turn_ref` values.
- Turn records were direct turns 1..10 on one trace and generation.
- Turn 10 visibly recalled the nine prior distinct facts without restating them in the prompt.
- Dashboard/API: runtime `codex_subscription.gpt-5.4`, model `runtime`.
- Execution receipt: selected model `gpt-5.4`.
- Screenshot: `/tmp/masc-multiturn-turn-record-meta-as-is-20260814.png`.

No hidden-CoT/raw thinking content was inspected.

## Validation

- Existing targeted Dashboard Vitest: 4 files, 256 tests passed.
- Dashboard TypeScript typecheck passed.
- Changed Dashboard files ESLint passed.
- Changed OCaml files ocamlformat check and parse-only checks passed.
- `git diff --check` passed.
- OCaml structure, Agent Core boundary, stringly boundary, and RFC-0132 literal ratchets passed.
- Independent adversarial source review: no P1/P2.
- No local Dune build and no new test file. Existing strict regression cases were adapted to the current schema.

## Still not proven

- CI is not yet complete.
- This PR is not merged, built, deployed, or live-canary verified.
- Rollout must remove obsolete canary TurnRecord rows before generating current-schema evidence; no compatibility migration is provided.
