### PR TITLE
fix(ci): evaluate release truth on PR merge result

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -448,7 +448,11 @@ jobs:
         if: github.event_name == 'pull_request' && github.base_ref == 'main'
         env:
           BASE_REF: origin/${{ github.base_ref }}
-          HEAD_REF: ${{ github.event.pull_request.head.sha }}
+          # actions/checkout checks out the pull request's synthetic merge
+          # commit.  Release truth must be evaluated on that merge result:
+          # an untouched stale head legitimately inherits dune-project from
+          # current main, while a real downgrade remains present in HEAD.
+          HEAD_REF: HEAD
         run: |
           chmod +x scripts/check-release-train-guard.sh
           # No --depth here. This guard only runs `git show` and `git tag`, so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          # Full history so origin/<base> and the PR head commit exist locally;
-          # the version-drift gate below reads dune-project from both refs.
+          # Full history so origin/<base>, the PR head, and the synthetic merge
+          # commit all exist locally for identity and version-truth checks.
           fetch-depth: 0
 
       - name: Verify PR sync
@@ -50,12 +50,14 @@ jobs:
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           BASE_REF: origin/${{ github.base_ref }}
+          VERSION_REF: HEAD
         run: |
           chmod +x scripts/check-pr-sync.sh
           scripts/check-pr-sync.sh \
             --head-branch "$PR_HEAD_REF" \
             --pr-number "$PR_NUMBER" \
             --base-ref "$BASE_REF" \
+            --version-ref "$VERSION_REF" \
             --expected-head-sha "$PR_HEAD_SHA"
 
   pr-live-gate:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1083,6 +1083,7 @@ jobs:
             @test/runtest-test_otel_port_ssot \
             @test/runtest-test_prompt_asset_sync \
             @test/runtest-test_prompt_registry_defaults \
+            @test/runtest-test_pr_sync_script \
             @test/runtest-test_release_train_guard_script \
             @test/runtest-test_rfc_0086_keeper_namespace_invariant \
             @test/runtest-test_server_base_path_guard \

--- a/scripts/check-pr-sync.sh
+++ b/scripts/check-pr-sync.sh
@@ -6,14 +6,19 @@ HEAD_BRANCH=""
 EXPECTED_HEAD_SHA=""
 PR_NUMBER=""
 BASE_REF=""
+VERSION_REF=""
 
 usage() {
   cat <<'EOF'
 Usage: scripts/check-pr-sync.sh --head-branch <branch> --expected-head-sha <sha> [--pr-number <num>] [--remote <remote>]
-or --base-ref <ref>
+       [--base-ref <ref>] [--version-ref <ref>]
 
 Checks that the current pull-request run is still aligned with the latest remote branch head.
 Fails when the branch has advanced since the workflow payload was created.
+
+When --base-ref is provided, package-version drift is evaluated against --version-ref.
+The version ref defaults to the exact PR head for standalone callers; pull-request CI should
+pass the checked-out synthetic merge commit so unchanged files inherit current base truth.
 EOF
 }
 
@@ -39,6 +44,10 @@ while [[ $# -gt 0 ]]; do
       BASE_REF="${2:-}"
       shift 2
       ;;
+    --version-ref)
+      VERSION_REF="${2:-}"
+      shift 2
+      ;;
     -h|--help)
       usage
       exit 0
@@ -55,6 +64,10 @@ if [[ -z "$HEAD_BRANCH" || -z "$EXPECTED_HEAD_SHA" ]]; then
   echo "--head-branch and --expected-head-sha are required" >&2
   usage >&2
   exit 2
+fi
+
+if [[ -z "$VERSION_REF" ]]; then
+  VERSION_REF="$EXPECTED_HEAD_SHA"
 fi
 
 extract_dune_project_version() {
@@ -117,6 +130,7 @@ echo "[pr-sync] remote=${REMOTE}"
 echo "[pr-sync] head_branch=${HEAD_BRANCH}"
 echo "[pr-sync] expected_head_sha=${EXPECTED_HEAD_SHA}"
 echo "[pr-sync] remote_head_sha=${REMOTE_HEAD_SHA}"
+echo "[pr-sync] version_ref=${VERSION_REF}"
 
 if [[ "$REMOTE_HEAD_SHA" != "$EXPECTED_HEAD_SHA" ]]; then
   echo "::warning title=Stale PR run detected::workflow payload head ${EXPECTED_HEAD_SHA} is stale; remote ${HEAD_BRANCH} is now ${REMOTE_HEAD_SHA}"
@@ -161,7 +175,7 @@ if [[ -n "$BASE_REF" ]]; then
   # package floor, fail fast with a clear remediation instead of letting
   # later guard stages decide the outcome.
   BASE_VERSION="$(extract_dune_project_version "$BASE_REF")"
-  HEAD_VERSION="$(extract_dune_project_version "$EXPECTED_HEAD_SHA")"
+  VERSION_REF_VERSION="$(extract_dune_project_version "$VERSION_REF")"
 
   # Fail loud instead of warning-only: with a shallow checkout (default
   # actions/checkout depth 1) neither origin/<base> nor the head commit
@@ -173,14 +187,14 @@ if [[ -n "$BASE_REF" ]]; then
     exit 1
   fi
 
-  if [[ -z "$HEAD_VERSION" ]]; then
-    echo "::error title=PR head package version unreadable::Could not read version from ${EXPECTED_HEAD_SHA}:dune-project. Ensure the PR head commit is fetched locally."
+  if [[ -z "$VERSION_REF_VERSION" ]]; then
+    echo "::error title=PR package version unreadable::Could not read version from ${VERSION_REF}:dune-project. Ensure the version ref is fetched locally."
     exit 1
   fi
 
-  if version_gt "$BASE_VERSION" "$HEAD_VERSION"; then
-    echo "::error title=PR base package version drift::Base (${BASE_REF}) is on package ${BASE_VERSION} but PR head ${EXPECTED_HEAD_SHA} is still ${HEAD_VERSION}."
-    echo "  Rebase this branch onto ${BASE_REF}, then re-run CI."
+  if version_gt "$BASE_VERSION" "$VERSION_REF_VERSION"; then
+    echo "::error title=PR base package version drift::Base (${BASE_REF}) is on package ${BASE_VERSION} but evaluated result ${VERSION_REF} is still ${VERSION_REF_VERSION}."
+    echo "  Update the branch so its merge result preserves package version ${BASE_VERSION} or newer, then re-run CI."
 
     if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
       {
@@ -188,9 +202,9 @@ if [[ -n "$BASE_REF" ]]; then
         echo ""
         echo "- Branch: \`${HEAD_BRANCH}\`"
         echo "- PR base reference: \`${BASE_REF}\` (${BASE_VERSION})"
-        echo "- PR head: \`${EXPECTED_HEAD_SHA}\` (${HEAD_VERSION})"
-        echo "- Failure: package version in PR head is behind base"
-        echo "- Recommended fix: rebase branch onto ${BASE_REF}"
+        echo "- Package version ref: \`${VERSION_REF}\` (${VERSION_REF_VERSION})"
+        echo "- Failure: package version in the evaluated result is behind base"
+        echo "- Recommended fix: update the branch so its merge result preserves package version ${BASE_VERSION} or newer"
       } >> "$GITHUB_STEP_SUMMARY"
     fi
     exit 1

--- a/test/dune
+++ b/test/dune
@@ -2022,6 +2022,8 @@
 
 (include stanzas/test_pr_open_script.inc)
 
+(include stanzas/test_pr_sync_script.inc)
+
 
 (include stanzas/test_release_train_guard_script.inc)
 

--- a/test/stanzas/test_pr_sync_script.inc
+++ b/test/stanzas/test_pr_sync_script.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_pr_sync_script)
+ (modules test_pr_sync_script)
+ (libraries alcotest unix masc.string_util))

--- a/test/test_pr_sync_script.ml
+++ b/test/test_pr_sync_script.ml
@@ -1,0 +1,160 @@
+open Alcotest
+
+let source_root () =
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root -> root
+  | None -> Sys.getcwd ()
+
+let script_path () = Filename.concat (source_root ()) "scripts/check-pr-sync.sh"
+let read_file path = In_channel.with_open_bin path In_channel.input_all
+let write_file path content = Out_channel.with_open_bin path (fun oc -> output_string oc content)
+
+let rec mkdir_p path =
+  if path = "" || path = "." || path = "/" then
+    ()
+  else if Sys.file_exists path then
+    ()
+  else begin
+    mkdir_p (Filename.dirname path);
+    Unix.mkdir path 0o755
+  end
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Sys.remove path
+
+let with_temp_dir prefix f =
+  let dir = Filename.temp_file prefix "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+
+let run_process ~cwd prog argv =
+  let out = Filename.temp_file "pr-sync-out" ".txt" in
+  let err = Filename.temp_file "pr-sync-err" ".txt" in
+  let out_fd = Unix.openfile out [ Unix.O_WRONLY; Unix.O_TRUNC ] 0o600 in
+  let err_fd = Unix.openfile err [ Unix.O_WRONLY; Unix.O_TRUNC ] 0o600 in
+  let original_cwd = Sys.getcwd () in
+  let pid =
+    Fun.protect
+      ~finally:(fun () ->
+        Sys.chdir original_cwd;
+        Unix.close out_fd;
+        Unix.close err_fd)
+      (fun () ->
+        Sys.chdir cwd;
+        Unix.create_process prog argv Unix.stdin out_fd err_fd)
+  in
+  let _, status = Unix.waitpid [] pid in
+  let code =
+    match status with
+    | Unix.WEXITED code -> code
+    | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> 255
+  in
+  let stdout = read_file out in
+  let stderr = read_file err in
+  Sys.remove out;
+  Sys.remove err;
+  (code, stdout, stderr)
+
+let run_ok ~cwd prog args =
+  let argv = Array.of_list (prog :: args) in
+  let code, stdout, stderr = run_process ~cwd prog argv in
+  if code <> 0 then
+    failf "command failed (%d): %s\nstdout:\n%s\nstderr:\n%s" code prog stdout stderr;
+  String.trim stdout
+
+let git_ok ~cwd args = ignore (run_ok ~cwd "git" args)
+let git_output ~cwd args = run_ok ~cwd "git" args
+
+let write_dune_project ~dir ~version =
+  write_file (Filename.concat dir "dune-project")
+    (Printf.sprintf "(lang dune 3.17)\n\n(name masc)\n(version %s)\n" version)
+
+let commit_all ~dir ~message =
+  git_ok ~cwd:dir [ "add"; "." ];
+  git_ok ~cwd:dir [ "-c"; "core.hooksPath=/dev/null"; "commit"; "-q"; "-m"; message ]
+
+let install_script_under_test dir =
+  let target = Filename.concat dir "scripts/check-pr-sync.sh" in
+  mkdir_p (Filename.dirname target);
+  write_file target (read_file (script_path ()));
+  Unix.chmod target 0o755;
+  target
+
+let with_stale_feature_and_merge_result f =
+  with_temp_dir "pr-sync" (fun root ->
+      let repo = Filename.concat root "repo" in
+      let remote = Filename.concat root "remote.git" in
+      Unix.mkdir repo 0o755;
+      git_ok ~cwd:repo [ "init"; "-q" ];
+      git_ok ~cwd:repo [ "config"; "user.email"; "test@example.com" ];
+      git_ok ~cwd:repo [ "config"; "user.name"; "tester" ];
+      git_ok ~cwd:repo [ "checkout"; "-qb"; "main" ];
+      write_dune_project ~dir:repo ~version:"0.21.2";
+      commit_all ~dir:repo ~message:"old base";
+      git_ok ~cwd:repo [ "checkout"; "-qb"; "stale-feature" ];
+      write_file (Filename.concat repo "feature.txt") "unrelated change\n";
+      commit_all ~dir:repo ~message:"feature";
+      let feature_sha = git_output ~cwd:repo [ "rev-parse"; "HEAD" ] in
+      git_ok ~cwd:repo [ "checkout"; "main" ];
+      write_dune_project ~dir:repo ~version:"0.22.0";
+      commit_all ~dir:repo ~message:"new package floor";
+      git_ok ~cwd:repo [ "checkout"; "-qb"; "merge-result" ];
+      git_ok ~cwd:repo [ "merge"; "--no-edit"; "stale-feature" ];
+      git_ok ~cwd:root [ "init"; "--bare"; "-q"; remote ];
+      git_ok ~cwd:repo [ "remote"; "add"; "origin"; remote ];
+      git_ok ~cwd:repo [ "push"; "-q"; "origin"; "stale-feature" ];
+      let script = install_script_under_test repo in
+      f ~repo ~script ~feature_sha)
+
+let run_guard ~repo ~script ~feature_sha extra_args =
+  run_process ~cwd:repo script
+    (Array.of_list
+       (script
+       :: [
+            "--head-branch";
+            "stale-feature";
+            "--expected-head-sha";
+            feature_sha;
+            "--base-ref";
+            "main";
+          ]
+       @ extra_args))
+
+let test_merge_result_inherits_current_base_version () =
+  with_stale_feature_and_merge_result (fun ~repo ~script ~feature_sha ->
+      let code, stdout, stderr =
+        run_guard ~repo ~script ~feature_sha [ "--version-ref"; "merge-result" ]
+      in
+      if code <> 0 then
+        failf "guard failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout stderr;
+      check bool "keeps exact remote head identity" true
+        (String_util.contains_substring stdout
+           ("expected_head_sha=" ^ feature_sha));
+      check bool "evaluates merge result" true
+        (String_util.contains_substring stdout "version_ref=merge-result"))
+
+let test_default_version_ref_still_checks_exact_head () =
+  with_stale_feature_and_merge_result (fun ~repo ~script ~feature_sha ->
+      let code, _stdout, stderr = run_guard ~repo ~script ~feature_sha [] in
+      check bool "stale package truth fails without merge result" true (code <> 0);
+      check bool "reports evaluated head version" true
+        (String_util.contains_substring stderr
+           ("evaluated result " ^ feature_sha ^ " is still 0.21.2")))
+
+let () =
+  run "pr_sync_script"
+    [
+      ( "script",
+        [
+          test_case "merge result inherits current base package version" `Quick
+            test_merge_result_inherits_current_base_version;
+          test_case "default version ref checks exact head" `Quick
+            test_default_version_ref_still_checks_exact_head;
+        ] );
+    ]

--- a/test/test_pr_sync_script.ml
+++ b/test/test_pr_sync_script.ml
@@ -141,11 +141,14 @@ let test_merge_result_inherits_current_base_version () =
 
 let test_default_version_ref_still_checks_exact_head () =
   with_stale_feature_and_merge_result (fun ~repo ~script ~feature_sha ->
-      let code, _stdout, stderr = run_guard ~repo ~script ~feature_sha [] in
+      let code, stdout, stderr = run_guard ~repo ~script ~feature_sha [] in
       check bool "stale package truth fails without merge result" true (code <> 0);
+      check bool "defaults evaluated version ref to exact head" true
+        (String_util.contains_substring stdout ("version_ref=" ^ feature_sha));
+      check bool "reports base package floor" true
+        (String_util.contains_substring stderr "package 0.22.0");
       check bool "reports evaluated head version" true
-        (String_util.contains_substring stderr
-           ("evaluated result " ^ feature_sha ^ " is still 0.21.2")))
+        (String_util.contains_substring stderr "0.21.2"))
 
 let () =
   run "pr_sync_script"

--- a/test/test_pr_sync_script.ml
+++ b/test/test_pr_sync_script.ml
@@ -141,14 +141,14 @@ let test_merge_result_inherits_current_base_version () =
 
 let test_default_version_ref_still_checks_exact_head () =
   with_stale_feature_and_merge_result (fun ~repo ~script ~feature_sha ->
-      let code, stdout, stderr = run_guard ~repo ~script ~feature_sha [] in
+      let code, stdout, _stderr = run_guard ~repo ~script ~feature_sha [] in
       check bool "stale package truth fails without merge result" true (code <> 0);
       check bool "defaults evaluated version ref to exact head" true
         (String_util.contains_substring stdout ("version_ref=" ^ feature_sha));
       check bool "reports base package floor" true
-        (String_util.contains_substring stderr "package 0.22.0");
+        (String_util.contains_substring stdout "package 0.22.0");
       check bool "reports evaluated head version" true
-        (String_util.contains_substring stderr "0.21.2"))
+        (String_util.contains_substring stdout "0.21.2"))
 
 let () =
   run "pr_sync_script"

--- a/test/test_pr_sync_script.ml
+++ b/test/test_pr_sync_script.ml
@@ -112,6 +112,32 @@ let with_stale_feature_and_merge_result f =
       let script = install_script_under_test repo in
       f ~repo ~script ~feature_sha)
 
+let with_current_base_downgrade_merge_result f =
+  with_temp_dir "pr-sync-downgrade" (fun root ->
+      let repo = Filename.concat root "repo" in
+      let remote = Filename.concat root "remote.git" in
+      Unix.mkdir repo 0o755;
+      git_ok ~cwd:repo [ "init"; "-q" ];
+      git_ok ~cwd:repo [ "config"; "user.email"; "test@example.com" ];
+      git_ok ~cwd:repo [ "config"; "user.name"; "tester" ];
+      git_ok ~cwd:repo [ "checkout"; "-qb"; "main" ];
+      write_dune_project ~dir:repo ~version:"0.22.0";
+      commit_all ~dir:repo ~message:"current package floor";
+      git_ok ~cwd:repo [ "checkout"; "-qb"; "stale-feature" ];
+      write_dune_project ~dir:repo ~version:"0.21.2";
+      commit_all ~dir:repo ~message:"downgrade package";
+      let feature_sha = git_output ~cwd:repo [ "rev-parse"; "HEAD" ] in
+      git_ok ~cwd:repo [ "checkout"; "main" ];
+      write_file (Filename.concat repo "base.txt") "new base work\n";
+      commit_all ~dir:repo ~message:"advance base";
+      git_ok ~cwd:repo [ "checkout"; "-qb"; "merge-result" ];
+      git_ok ~cwd:repo [ "merge"; "--no-edit"; "stale-feature" ];
+      git_ok ~cwd:root [ "init"; "--bare"; "-q"; remote ];
+      git_ok ~cwd:repo [ "remote"; "add"; "origin"; remote ];
+      git_ok ~cwd:repo [ "push"; "-q"; "origin"; "stale-feature" ];
+      let script = install_script_under_test repo in
+      f ~repo ~script ~feature_sha)
+
 let run_guard ~repo ~script ~feature_sha extra_args =
   run_process ~cwd:repo script
     (Array.of_list
@@ -129,15 +155,28 @@ let run_guard ~repo ~script ~feature_sha extra_args =
 let test_merge_result_inherits_current_base_version () =
   with_stale_feature_and_merge_result (fun ~repo ~script ~feature_sha ->
       let code, stdout, stderr =
-        run_guard ~repo ~script ~feature_sha [ "--version-ref"; "merge-result" ]
+        run_guard ~repo ~script ~feature_sha [ "--version-ref"; "HEAD" ]
       in
       if code <> 0 then
         failf "guard failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout stderr;
       check bool "keeps exact remote head identity" true
         (String_util.contains_substring stdout
            ("expected_head_sha=" ^ feature_sha));
-      check bool "evaluates merge result" true
-        (String_util.contains_substring stdout "version_ref=merge-result"))
+      check bool "evaluates checked-out merge result" true
+        (String_util.contains_substring stdout "version_ref=HEAD"))
+
+let test_merge_result_preserves_explicit_downgrade_failure () =
+  with_current_base_downgrade_merge_result (fun ~repo ~script ~feature_sha ->
+      let code, stdout, _stderr =
+        run_guard ~repo ~script ~feature_sha [ "--version-ref"; "HEAD" ]
+      in
+      check bool "downgrade in merge result fails" true (code <> 0);
+      check bool "evaluates checked-out merge result" true
+        (String_util.contains_substring stdout "version_ref=HEAD");
+      check bool "reports current base package floor" true
+        (String_util.contains_substring stdout "package 0.22.0");
+      check bool "reports downgraded merge-result version" true
+        (String_util.contains_substring stdout "0.21.2"))
 
 let test_default_version_ref_still_checks_exact_head () =
   with_stale_feature_and_merge_result (fun ~repo ~script ~feature_sha ->
@@ -157,6 +196,8 @@ let () =
         [
           test_case "merge result inherits current base package version" `Quick
             test_merge_result_inherits_current_base_version;
+          test_case "merge result preserves explicit downgrade failure" `Quick
+            test_merge_result_preserves_explicit_downgrade_failure;
           test_case "default version ref checks exact head" `Quick
             test_default_version_ref_still_checks_exact_head;
         ] );


### PR DESCRIPTION
## 문제

#28657 병합 뒤에도 두 CI 경로가 stale PR head의 `dune-project`를 직접 검사해, 현재 main과 깨끗하게 병합되며 `0.22.0`을 상속하는 무관 PR을 downgrade로 오판했습니다.

- Meta Guard의 release-train guard
- 선행 PR Sync의 package-version drift gate

## 수정

- Meta Guard는 `actions/checkout`이 만든 synthetic merge commit `HEAD`를 release-train guard 입력으로 사용합니다.
- PR Sync는 원격 branch identity는 계속 payload의 exact head SHA로 검증하고, package-version truth만 명시적인 `--version-ref HEAD`로 평가합니다.
- standalone 호출은 `--version-ref`를 생략하면 기존처럼 exact head를 검사합니다.
- stale head가 current base의 버전을 merge result에서 상속하는 회귀 테스트와 default exact-head 동작 테스트를 추가했습니다.
- 새 회귀 suite를 invariant/SSOT CI manifest에 연결해 compile-only 테스트가 되지 않도록 했습니다.

실제 downgrade는 merge result에도 남아 계속 차단됩니다.

## 검증

- exact commit: `21d22ba14168c6ce720d5b5a802da97816e36d8c`
- latest main `1487385def42fb4a7c3cae3e2fc5287fd9843983` 위로 rebase
- `bash -n scripts/check-pr-sync.sh` 통과
- `shellcheck scripts/check-pr-sync.sh` 통과
- `ocamlformat --check test/test_pr_sync_script.ml` 통과
- OCaml parse-only 통과
- `python3 scripts/check_test_coverage.py` 통과
- `bash scripts/audit-ci-test-targets.sh` 통과: 307 targets, unwired baseline 558
- `git diff --check` 통과
- `actionlint`: 새 YAML 오류 없음; 기존 SC2129 style 경고 3건만 유지
- 로컬 Dune 미실행 (CI authoritative)