### PR TITLE
feat(keeper): run readonly compositions asynchronously

### DIFF
--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -153,9 +153,7 @@ let expected_model_tool_names ~model_visible_descriptors ~composition_catalog =
   let composition_names =
     match composition_catalog with
     | None -> []
-    | Some catalog ->
-      Keeper_tool_composition_catalog.entries catalog
-      |> List.map Keeper_tool_composition_catalog.tool_name
+    | Some catalog -> Keeper_tool_composition_catalog.model_tool_names catalog
   in
   List.sort_uniq String.compare (descriptor_names @ composition_names)
 ;;

--- a/lib/keeper/keeper_tool_composition_catalog.ml
+++ b/lib/keeper/keeper_tool_composition_catalog.ml
@@ -38,6 +38,15 @@ type error =
       ; character : char
       }
   | Duplicate_composition_name of string
+  | Invalid_execution_mode of
+      { path : string list
+      ; mode : string
+      }
+  | Async_tool_not_statically_read_only of
+      { name : string
+      ; node_id : Plan.Node_id.t
+      ; tool_name : string
+      }
   | Invalid_template_kind of
       { path : string list
       ; kind : string
@@ -59,9 +68,14 @@ type error =
       ; error : Plan.error
       }
 
+type execution_mode =
+  | Inline
+  | Async
+
 type entry =
   { name : string
   ; description : string option
+  ; execution : execution_mode
   ; plan : Plan.t
   }
 
@@ -71,12 +85,27 @@ let tool_name_prefix = "keeper_compose_"
 let maximum_tool_name_bytes = 64
 let maximum_composition_name_bytes = maximum_tool_name_bytes - String.length tool_name_prefix
 let tool_name entry = tool_name_prefix ^ entry.name
+let status_tool_name = "keeper_composition_status"
+let cancel_tool_name = "keeper_composition_cancel"
+
+let execution_mode_to_string = function
+  | Inline -> "inline"
+  | Async -> "async"
+;;
+
 let path ~config_root = Filename.concat config_root "tool-compositions.toml"
 
 let entries catalog = catalog
 
 let find catalog name =
   List.find_opt (fun entry -> String.equal entry.name name) catalog
+;;
+
+let model_tool_names catalog =
+  let entry_names = List.map tool_name catalog in
+  if List.exists (fun entry -> entry.execution = Async) catalog
+  then entry_names @ [ status_tool_name; cancel_tool_name ]
+  else entry_names
 ;;
 
 let first_duplicate fields =
@@ -334,7 +363,12 @@ let parse_composition ~index value =
   match table_fields ~path ~field:"composition" value with
   | Error _ as error -> error
   | Ok fields ->
-    (match validate_fields ~path ~allowed:[ "name"; "description"; "nodes" ] fields with
+    (match
+       validate_fields
+         ~path
+         ~allowed:[ "name"; "description"; "execution"; "nodes" ]
+         fields
+     with
      | Error _ as error -> error
      | Ok () ->
        (match required_nonempty_string ~path "name" fields with
@@ -355,9 +389,19 @@ let parse_composition ~index value =
             | Some character ->
               Error (Invalid_composition_name_character { name; character })
             | None ->
-            (match optional_string ~path "description" fields with
+           (match optional_string ~path "description" fields with
            | Error _ as error -> error
            | Ok description ->
+             (match required_string ~path "execution" fields with
+              | Error _ as error -> error
+              | Ok raw_execution ->
+                (match raw_execution with
+                 | "inline" -> Ok Inline
+                 | "async" -> Ok Async
+                 | mode -> Error (Invalid_execution_mode { path; mode }))
+                |> (function
+                 | Error _ as error -> error
+                 | Ok execution ->
              (match required_field ~path "nodes" fields with
               | Error _ as error -> error
               | Ok raw_nodes ->
@@ -379,8 +423,30 @@ let parse_composition ~index value =
                            ~descriptors:(Keeper_tool_descriptor.all_descriptors ())
                            nodes
                        with
-                       | Ok plan -> Ok { name; description; plan }
-                       | Error error -> Error (Plan_rejected { name; error })))))))))
+                       | Error error -> Error (Plan_rejected { name; error })
+                       | Ok plan ->
+                         (match execution with
+                          | Inline -> Ok { name; description; execution; plan }
+                          | Async ->
+                            (match
+                               Plan.nodes plan
+                               |> List.find_map (fun node ->
+                                 match Plan.descriptor plan node.id with
+                                 | Some descriptor
+                                   when Keeper_tool_descriptor.readonly_static_hint
+                                          descriptor
+                                        = Some true ->
+                                   None
+                                 | Some _ | None -> Some node)
+                             with
+                             | None -> Ok { name; description; execution; plan }
+                             | Some node ->
+                               Error
+                                 (Async_tool_not_statically_read_only
+                                    { name
+                                    ; node_id = node.id
+                                    ; tool_name = node.tool_name
+                                    }))))))))))))
 ;;
 
 let parse content =
@@ -485,6 +551,17 @@ let error_to_string = function
   | Invalid_composition_name_character { name; character } ->
     Printf.sprintf "composition name %S contains unsupported character %C" name character
   | Duplicate_composition_name name -> "duplicate composition name: " ^ name
+  | Invalid_execution_mode { path; mode } ->
+    Printf.sprintf
+      "invalid execution mode %S at %s (expected inline or async)"
+      mode
+      (String.concat "." path)
+  | Async_tool_not_statically_read_only { name; node_id; tool_name } ->
+    Printf.sprintf
+      "async composition %S node %S tool %S is not statically read-only"
+      name
+      (node_id_to_string node_id)
+      tool_name
   | Invalid_template_kind { path; kind } ->
     Printf.sprintf "invalid template kind %S at %s" kind (String.concat "." path)
   | Invalid_node_id { path; _ } -> "invalid node id at " ^ String.concat "." path

--- a/lib/keeper/keeper_tool_composition_catalog.ml
+++ b/lib/keeper/keeper_tool_composition_catalog.ml
@@ -430,7 +430,7 @@ let parse_composition ~index value =
                           | Async ->
                             (match
                                Plan.nodes plan
-                               |> List.find_map (fun node ->
+                               |> List.find_map (fun (node : Plan.node) ->
                                  match Plan.descriptor plan node.id with
                                  | Some descriptor
                                    when Keeper_tool_descriptor.readonly_static_hint
@@ -446,7 +446,7 @@ let parse_composition ~index value =
                                     { name
                                     ; node_id = node.id
                                     ; tool_name = node.tool_name
-                                    }))))))))))))
+                                    })))))))))))))
 ;;
 
 let parse content =

--- a/lib/keeper/keeper_tool_composition_catalog.mli
+++ b/lib/keeper/keeper_tool_composition_catalog.mli
@@ -42,6 +42,15 @@ type error =
       ; character : char
       }
   | Duplicate_composition_name of string
+  | Invalid_execution_mode of
+      { path : string list
+      ; mode : string
+      }
+  | Async_tool_not_statically_read_only of
+      { name : string
+      ; node_id : Keeper_tool_plan.Node_id.t
+      ; tool_name : string
+      }
   | Invalid_template_kind of
       { path : string list
       ; kind : string
@@ -63,9 +72,14 @@ type error =
       ; error : Keeper_tool_plan.error
       }
 
+type execution_mode =
+  | Inline
+  | Async
+
 type entry = private
   { name : string
   ; description : string option
+  ; execution : execution_mode
   ; plan : Keeper_tool_plan.t
   }
 
@@ -80,6 +94,15 @@ val entries : t -> entry list
 val find : t -> string -> entry option
 val tool_name : entry -> string
 (** Stable model-visible name for this materialized composition. *)
+
+val execution_mode_to_string : execution_mode -> string
+
+val model_tool_names : t -> string list
+(** Exact model-visible composition surface, including the shared status and
+    cancel controls when at least one async composition is declared. *)
+
+val status_tool_name : string
+val cancel_tool_name : string
 
 val error_to_string : error -> string
 

--- a/lib/keeper/keeper_tool_composition_surface.ml
+++ b/lib/keeper/keeper_tool_composition_surface.ml
@@ -289,12 +289,12 @@ let async_parent_invocation ~request_id source =
 ;;
 
 let async_worker_result
-      ~entry
+      ~(entry : Catalog.entry)
       ~tool_name
       ~request_id
       ~source_invocation
       ~request_sw
-      ~config
+      ~(config : Workspace.config)
       ~meta
       ~publication_recovery
       ~ctx_snapshot
@@ -338,8 +338,8 @@ let async_submission_result
       ~entry
       ~tool_name
       ~parent_invocation
-      ~config
-      ~meta
+      ~(config : Workspace.config)
+      ~(meta : Keeper_meta_contract.keeper_meta)
       ~publication_recovery
       ~ctx_snapshot
       ?clock
@@ -423,7 +423,11 @@ let async_submission_result
          data)
 ;;
 
-let status_result ~config ~meta ~request_id =
+let status_result
+      ~(config : Workspace.config)
+      ~(meta : Keeper_meta_contract.keeper_meta)
+      ~request_id
+  =
   let tool_name = Catalog.status_tool_name in
   let start_time = Time_compat.now () in
   match
@@ -473,7 +477,11 @@ let status_result ~config ~meta ~request_id =
           ])
 ;;
 
-let cancel_result ~config ~meta ~request_id =
+let cancel_result
+      ~(config : Workspace.config)
+      ~(meta : Keeper_meta_contract.keeper_meta)
+      ~request_id
+  =
   let tool_name = Catalog.cancel_tool_name in
   let start_time = Time_compat.now () in
   let result =
@@ -520,7 +528,7 @@ let cancel_result ~config ~meta ~request_id =
 ;;
 
 let make_request_control_tool
-      ~config
+      ~(config : Workspace.config)
       ~name
       ~description
       ~descriptor

--- a/lib/keeper/keeper_tool_composition_surface.ml
+++ b/lib/keeper/keeper_tool_composition_surface.ml
@@ -10,6 +10,30 @@ let empty_input_schema =
     ]
 ;;
 
+let request_id_input_schema =
+  `Assoc
+    [ "type", `String "object"
+    ; ( "properties"
+      , `Assoc
+          [ ( "request_id"
+            , `Assoc
+                [ "type", `String "string"
+                ; "minLength", `Int 1
+                ] )
+          ] )
+    ; "required", `List [ `String "request_id" ]
+    ; "additionalProperties", `Bool false
+    ]
+;;
+
+let request_id_of_validated_input = function
+  | `Assoc fields ->
+    (match List.assoc_opt "request_id" fields with
+     | Some (`String request_id) -> Some request_id
+     | Some _ | None -> None)
+  | _ -> None
+;;
+
 let schedule_to_json (schedule : Agent_core.Tool_contract.schedule) =
   `Assoc
     [ "planned_index", `Int schedule.planned_index
@@ -256,6 +280,278 @@ let result_of_execution ~tool_name ~start_time = function
       (Yojson.Safe.to_string data)
 ;;
 
+let async_parent_invocation ~request_id source =
+  Agent_core.Tool_contract.Invocation.create
+    ~tool_use_id:("composition-async:" ^ request_id)
+    ~turn:(Agent_core.Tool_contract.Invocation.turn source)
+    ~schedule:(Agent_core.Tool_contract.Invocation.schedule source)
+    ~completion:Agent_core.Tool_contract.Continue_after_success
+;;
+
+let async_worker_result
+      ~entry
+      ~tool_name
+      ~request_id
+      ~source_invocation
+      ~request_sw
+      ~config
+      ~meta
+      ~publication_recovery
+      ~ctx_snapshot
+      ?clock
+      ()
+  =
+  Eio_context.with_turn_switch request_sw
+  @@ fun () ->
+  let sandbox_factory = Keeper_sandbox_factory.create ~config ~meta () in
+  Eio.Switch.on_release request_sw (fun () ->
+    Keeper_sandbox_factory.cleanup sandbox_factory);
+  let start_time = Time_compat.now () in
+  Executor.execute_keeper
+    ~plan:entry.plan
+    ~run_id:(Keeper_tool_plan.Run_id.fresh ())
+    ~parent_invocation:
+      (async_parent_invocation ~request_id source_invocation)
+    ~config
+    ~meta
+    ~publication_recovery
+    ~ctx_snapshot
+    ~turn_sandbox_factory:sandbox_factory
+    ?clock
+    ()
+  |> result_of_execution ~tool_name ~start_time
+;;
+
+let result_from_json ~tool_name ~start_time ~class_ ~ok data =
+  if ok
+  then Tool_result.make_ok ~tool_name ~start_time ~data ()
+  else
+    Tool_result.make_err
+      ~tool_name
+      ~class_
+      ~start_time
+      ~data
+      (Yojson.Safe.to_string data)
+;;
+
+let async_submission_result
+      ~entry
+      ~tool_name
+      ~parent_invocation
+      ~config
+      ~meta
+      ~publication_recovery
+      ~ctx_snapshot
+      ?clock
+      ()
+  =
+  let start_time = Time_compat.now () in
+  match Keeper_msg_async.server_background_switch () with
+  | Error error ->
+    let data = Keeper_msg_async.submit_error_to_json error in
+    result_from_json
+      ~tool_name
+      ~start_time
+      ~class_:Tool_result.Runtime_failure
+      ~ok:false
+      data
+  | Ok background_sw ->
+    (match
+       Keeper_msg_async.submit_with_request_id
+         ~background_sw
+         ~base_path:config.base_path
+         ~caller:meta.name
+         ~keeper_name:meta.name
+         ~f:(fun ~request_id request_sw ->
+           async_worker_result
+             ~entry
+             ~tool_name
+             ~request_id
+             ~source_invocation:parent_invocation
+             ~request_sw
+             ~config
+             ~meta
+             ~publication_recovery
+             ~ctx_snapshot
+             ?clock
+             ())
+         ()
+     with
+     | Error error ->
+       let data = Keeper_msg_async.submit_error_to_json error in
+       result_from_json
+         ~tool_name
+         ~start_time
+         ~class_:Tool_result.Runtime_failure
+         ~ok:false
+         data
+     | Ok
+         ({ Keeper_msg_async.acceptance = Keeper_msg_async.Durably_accepted
+          ; request_id
+          } as outcome) ->
+       let data =
+         `Assoc
+           [ "composition_tool", `String tool_name
+           ; "execution", `String "async"
+           ; "request_id", `String request_id
+           ; "submission", Keeper_msg_async.submit_outcome_to_json outcome
+           ]
+       in
+       result_from_json
+         ~tool_name
+         ~start_time
+         ~class_:Tool_result.Runtime_failure
+         ~ok:true
+         data
+     | Ok
+         ({ Keeper_msg_async.acceptance =
+              Keeper_msg_async.Reconciliation_required _
+          ; _
+          } as outcome) ->
+       let data =
+         `Assoc
+           [ "composition_tool", `String tool_name
+           ; "execution", `String "async"
+           ; "submission", Keeper_msg_async.submit_outcome_to_json outcome
+           ]
+       in
+       result_from_json
+         ~tool_name
+         ~start_time
+         ~class_:Tool_result.Runtime_failure
+         ~ok:false
+         data)
+;;
+
+let status_result ~config ~meta ~request_id =
+  let tool_name = Catalog.status_tool_name in
+  let start_time = Time_compat.now () in
+  match
+    Keeper_msg_async.poll
+      ~base_path:config.base_path
+      ~caller:meta.name
+      request_id
+  with
+  | Keeper_msg_async.Found entry ->
+    result_from_json
+      ~tool_name
+      ~start_time
+      ~class_:Tool_result.Runtime_failure
+      ~ok:true
+      (Keeper_msg_async.entry_to_json entry)
+  | Keeper_msg_async.Absent ->
+    result_from_json
+      ~tool_name
+      ~start_time
+      ~class_:Tool_result.Workflow_rejection
+      ~ok:false
+      (`Assoc
+          [ "error", `String "request_id_not_found"
+          ; "request_id", `String request_id
+          ])
+  | Keeper_msg_async.Unreadable reason ->
+    result_from_json
+      ~tool_name
+      ~start_time
+      ~class_:Tool_result.Runtime_failure
+      ~ok:false
+      (`Assoc
+          [ "error", `String "request_record_unreadable"
+          ; "request_id", `String request_id
+          ; "reason", `String reason
+          ])
+  | Keeper_msg_async.Rejected rejection ->
+    result_from_json
+      ~tool_name
+      ~start_time
+      ~class_:Tool_result.Policy_rejection
+      ~ok:false
+      (`Assoc
+          [ "error", `String "request_access_rejected"
+          ; "request_id", `String request_id
+          ; "reason", Keeper_msg_async.access_rejection_to_json rejection
+          ])
+;;
+
+let cancel_result ~config ~meta ~request_id =
+  let tool_name = Catalog.cancel_tool_name in
+  let start_time = Time_compat.now () in
+  let result =
+    Keeper_msg_async.cancel
+      ~base_path:config.base_path
+      ~caller:meta.name
+      request_id
+  in
+  let data = Keeper_msg_async.cancel_result_to_json ~request_id result in
+  match result with
+  | Keeper_msg_async.Cancellation_requested _ ->
+    result_from_json
+      ~tool_name
+      ~start_time
+      ~class_:Tool_result.Runtime_failure
+      ~ok:true
+      data
+  | Keeper_msg_async.Cancel_not_found
+  | Keeper_msg_async.Cancel_already_terminal _ ->
+    result_from_json
+      ~tool_name
+      ~start_time
+      ~class_:Tool_result.Workflow_rejection
+      ~ok:false
+      data
+  | Keeper_msg_async.Cancel_rejected _ ->
+    result_from_json
+      ~tool_name
+      ~start_time
+      ~class_:Tool_result.Policy_rejection
+      ~ok:false
+      data
+  | Keeper_msg_async.Cancel_unreadable _
+  | Keeper_msg_async.Cancel_worker_ownership_unknown _
+  | Keeper_msg_async.Cancel_persistence_failed _
+  | Keeper_msg_async.Cancel_worker_signal_failed _
+  | Keeper_msg_async.Cancel_state_invariant_failed _ ->
+    result_from_json
+      ~tool_name
+      ~start_time
+      ~class_:Tool_result.Runtime_failure
+      ~ok:false
+      data
+;;
+
+let make_request_control_tool
+      ~config
+      ~name
+      ~description
+      ~descriptor
+      ~handle
+  =
+  Tool_bridge.agent_core_tool_of_masc_with_execution_env
+    ~descriptor
+    ~base_path:config.base_path
+    ~name
+    ~description
+    ~input_schema:request_id_input_schema
+    (fun _execution_env input ->
+      let start_time = Time_compat.now () in
+      match
+        Tool_input_validation.validate_args
+          ~schema:request_id_input_schema
+          ~name
+          ~args:input
+          ()
+      with
+      | Error rejection -> rejection
+      | Ok _ ->
+        (match request_id_of_validated_input input with
+         | Some request_id -> handle request_id
+         | None ->
+           Tool_result.runtime_err
+             ~tool_name:name
+             ~start_time
+             "validated composition request input lost request_id"))
+;;
+
 let make_tools
       ~catalog
       ~(config : Workspace.config)
@@ -275,21 +571,27 @@ let make_tools
       ?on_externalization_error
       ()
   =
-  Catalog.entries catalog
-  |> List.map (fun (entry : Catalog.entry) ->
+  let composition_tools =
+    Catalog.entries catalog
+    |> List.map (fun (entry : Catalog.entry) ->
     let tool_name = Catalog.tool_name entry in
     let completion = Executor.outer_completion entry.plan in
     let descriptor =
-      match completion with
-      | Agent_core.Tool_contract.Continue_after_success ->
+      match entry.execution, completion with
+      | Catalog.Async, Agent_core.Tool_contract.Continue_after_success
+      | Catalog.Inline, Agent_core.Tool_contract.Continue_after_success ->
         Agent_core.Tool.ordinary_descriptor Agent_core.Tool_contract.Serial
-      | Agent_core.Tool_contract.Terminal_after_success disposition ->
+      | Catalog.Inline, Agent_core.Tool_contract.Terminal_after_success disposition ->
         Agent_core.Tool.terminal_descriptor disposition
+      | Catalog.Async, Agent_core.Tool_contract.Terminal_after_success _ ->
+        invalid_arg "validated async composition retained a terminal completion"
     in
     let tool_externalization_error =
-      match completion with
-      | Agent_core.Tool_contract.Continue_after_success -> None
-      | Agent_core.Tool_contract.Terminal_after_success _ ->
+      match entry.execution, completion with
+      | Catalog.Async, _
+      | Catalog.Inline, Agent_core.Tool_contract.Continue_after_success ->
+        None
+      | Catalog.Inline, Agent_core.Tool_contract.Terminal_after_success _ ->
         on_externalization_error
     in
     Tool_bridge.agent_core_tool_of_masc_with_execution_env
@@ -299,7 +601,14 @@ let make_tools
       ~name:tool_name
       ~description:
         (Option.value
-           ~default:("Execute the validated Keeper composition " ^ entry.name ^ ".")
+           ~default:
+             (match entry.execution with
+              | Catalog.Inline ->
+                "Execute the validated Keeper composition " ^ entry.name ^ "."
+              | Catalog.Async ->
+                "Start the validated read-only Keeper composition "
+                ^ entry.name
+                ^ " and return its durable request id.")
            entry.description)
       ~input_schema:empty_input_schema
       (fun execution_env input ->
@@ -320,6 +629,19 @@ let make_tools
                ~start_time
                "composition execution requires Agent-Core invocation identity"
            | Some parent_invocation ->
+             (match entry.execution with
+              | Catalog.Async ->
+                async_submission_result
+                  ~entry
+                  ~tool_name
+                  ~parent_invocation
+                  ~config
+                  ~meta
+                  ~publication_recovery
+                  ~ctx_snapshot
+                  ?clock
+                  ()
+              | Catalog.Inline ->
              let execution =
                Executor.execute_keeper
                  ~plan:entry.plan
@@ -372,5 +694,33 @@ let make_tools
                   ; _
                   } ->
                 ());
-             result_of_execution ~tool_name ~start_time execution)))
+             result_of_execution ~tool_name ~start_time execution))))
+  in
+  let has_async =
+    Catalog.entries catalog
+    |> List.exists (fun (entry : Catalog.entry) -> entry.execution = Catalog.Async)
+  in
+  if not has_async
+  then composition_tools
+  else
+    let status_tool =
+      make_request_control_tool
+        ~config
+        ~name:Catalog.status_tool_name
+        ~description:
+          "Read the exact durable status and structured result of one async Keeper composition request."
+        ~descriptor:
+          (Agent_core.Tool.ordinary_descriptor Agent_core.Tool_contract.Concurrent)
+        ~handle:(fun request_id -> status_result ~config ~meta ~request_id)
+    in
+    let cancel_tool =
+      make_request_control_tool
+        ~config
+        ~name:Catalog.cancel_tool_name
+        ~description:
+          "Request cancellation of one async Keeper composition by its exact durable request id."
+        ~descriptor:(Agent_core.Tool.ordinary_descriptor Agent_core.Tool_contract.Serial)
+        ~handle:(fun request_id -> cancel_result ~config ~meta ~request_id)
+    in
+    composition_tools @ [ status_tool; cancel_tool ]
 ;;

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -310,8 +310,39 @@ module Recovery_for_testing = struct
   let consume_owner_projection_batch = consume_owner_projection_batch
 end
 
+let recover_keeper_msg_requests_on_startup ~base_path =
+  let report = Keeper_msg_async.recover_lost_disk_records ~base_path () in
+  if
+    report.lost > 0
+    || report.finalized > 0
+    || report.cleaned > 0
+    || report.unreadable > 0
+    || report.failed > 0
+    || report.staging_files_deleted > 0
+    || report.staging_files_preserved > 0
+  then
+    Log.Server.info
+      "keeper_msg_async: startup recovery lost=%d finalized=%d cleaned=%d unreadable=%d failed=%d staging_inspected=%d staging_deleted=%d staging_preserved=%d"
+      report.lost
+      report.finalized
+      report.cleaned
+      report.unreadable
+      report.failed
+      report.staging_files_inspected
+      report.staging_files_deleted
+      report.staging_files_preserved;
+  report
+;;
+
 let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_state) =
   let config = Mcp_server.workspace_config state in
+  (* Exclusive startup ownership: before any new server request can submit a
+     worker, settle disk-only nonterminal rows left by the prior process.  Poll
+     and cancel deliberately cannot infer process death, so this bootstrap
+     boundary is the sole production authority for that transition. *)
+  ignore
+    (recover_keeper_msg_requests_on_startup ~base_path:config.base_path
+      : Keeper_msg_async.recovery_report);
   let recovery_ctx : _ Keeper_types_profile.context =
     { config
     ; agent_name = "keeper-maintenance-recovery"

--- a/lib/server/server_bootstrap_maintenance.mli
+++ b/lib/server/server_bootstrap_maintenance.mli
@@ -6,6 +6,11 @@ val wake_enqueue_counts_of_dispatches :
   Schedule_runner.dispatch_result list -> Schedule_runner_status.wake_enqueue_counts
 (** Derive keeper-wake delivery counts from typed production consumer receipts. *)
 
+val recover_keeper_msg_requests_on_startup :
+  base_path:string -> Keeper_msg_async.recovery_report
+(** Settle durable async request rows that cannot have a live owner after a
+    process restart. Called synchronously before background server work starts. *)
+
 val start_background_maintenance :
   sw:Eio.Switch.t ->
   clock:float Eio.Time.clock_ty Eio.Resource.t ->

--- a/test/test_keeper_tool_composition_catalog.ml
+++ b/test/test_keeper_tool_composition_catalog.ml
@@ -7,6 +7,7 @@ let valid_catalog =
   {|[[compositions]]
 name = "time-memory-query"
 description = "Feed the exact clock result into memory search."
+execution = "inline"
 
 [[compositions.nodes]]
 id = "time"
@@ -94,6 +95,7 @@ let test_catalog_rejects_unknown_fields () =
   let document =
     {|[[compositions]]
 name = "bad"
+execution = "inline"
 guess = true
 [[compositions.nodes]]
 id = "time"
@@ -112,6 +114,7 @@ let test_catalog_rejects_malformed_output_pointer () =
   let document =
     {|[[compositions]]
 name = "bad-pointer"
+execution = "inline"
 [[compositions.nodes]]
 id = "time"
 tool = "keeper_time_now"
@@ -142,6 +145,7 @@ let one_node_composition name =
   Printf.sprintf
     {|[[compositions]]
 name = %S
+execution = "inline"
 [[compositions.nodes]]
 id = "time"
 tool = "keeper_time_now"
@@ -150,6 +154,86 @@ kind = "literal"
 value = {}
 |}
     name
+;;
+
+let one_node_async_composition name =
+  Printf.sprintf
+    {|[[compositions]]
+name = %S
+execution = "async"
+[[compositions.nodes]]
+id = "time"
+tool = "keeper_time_now"
+[compositions.nodes.input]
+kind = "literal"
+value = {}
+|}
+    name
+;;
+
+let test_catalog_requires_explicit_execution_mode () =
+  let document =
+    {|[[compositions]]
+name = "missing-execution"
+[[compositions.nodes]]
+id = "time"
+tool = "keeper_time_now"
+[compositions.nodes.input]
+kind = "literal"
+value = {}
+|}
+  in
+  match Catalog.parse document with
+  | Error
+      (Catalog.Missing_field
+        { path = [ "compositions"; "0" ]; field = "execution" }) ->
+    ()
+  | Error _ | Ok _ -> fail "composition execution mode was inferred"
+;;
+
+let test_catalog_accepts_async_only_for_statically_read_only_tools () =
+  let catalog =
+    match Catalog.parse (one_node_async_composition "clock-background") with
+    | Ok catalog -> catalog
+    | Error error -> fail (Catalog.error_to_string error)
+  in
+  let entry =
+    match Catalog.find catalog "clock-background" with
+    | Some entry -> entry
+    | None -> fail "async composition lookup failed"
+  in
+  (match entry.execution with
+   | Catalog.Async -> ()
+   | Catalog.Inline -> fail "async execution mode was rewritten");
+  check
+    (list string)
+    "async model surface includes exact controls"
+    [ "keeper_compose_clock-background"
+    ; "keeper_composition_status"
+    ; "keeper_composition_cancel"
+    ]
+    (Catalog.model_tool_names catalog)
+;;
+
+let test_catalog_rejects_async_effectful_tool () =
+  let document =
+    {|[[compositions]]
+name = "write-background"
+execution = "async"
+[[compositions.nodes]]
+id = "write"
+tool = "keeper_memory_write"
+[compositions.nodes.input]
+kind = "literal"
+value = { title = "not admitted", content = "effectful async" }
+|}
+  in
+  match Catalog.parse document with
+  | Error
+      (Catalog.Async_tool_not_statically_read_only
+        { name = "write-background"; node_id; tool_name = "keeper_memory_write" }) ->
+    check string "rejected node" "write" (Plan.Node_id.to_string node_id)
+  | Error _ | Ok _ -> fail "effectful async composition was admitted"
 ;;
 
 let test_catalog_projects_stable_tool_name_and_path () =
@@ -198,6 +282,7 @@ let test_catalog_rejects_unknown_tool_through_plan_authority () =
   let document =
     {|[[compositions]]
 name = "unknown-tool"
+execution = "inline"
 [[compositions.nodes]]
 id = "unknown"
 tool = "invented_tool"
@@ -294,6 +379,18 @@ let () =
             "rejects duplicate names"
             `Quick
             test_catalog_rejects_duplicate_composition_names
+        ; test_case
+            "requires explicit execution mode"
+            `Quick
+            test_catalog_requires_explicit_execution_mode
+        ; test_case
+            "accepts async statically read-only plan"
+            `Quick
+            test_catalog_accepts_async_only_for_statically_read_only_tools
+        ; test_case
+            "rejects async effectful tool"
+            `Quick
+            test_catalog_rejects_async_effectful_tool
         ; test_case
             "projects stable tool name and path"
             `Quick

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -4652,6 +4652,7 @@ let one_node_clock_composition =
   {|[[compositions]]
 name = "clock"
 description = "Read the exact Keeper clock."
+execution = "inline"
 
 [[compositions.nodes]]
 id = "time"
@@ -4665,6 +4666,7 @@ value = {}
 let one_node_terminal_composition =
   {|[[compositions]]
 name = "surface"
+execution = "inline"
 
 [[compositions.nodes]]
 id = "post"
@@ -4678,6 +4680,7 @@ value = { surface = "dashboard", content = "composition terminal" }
 let invalid_clock_input_composition =
   {|[[compositions]]
 name = "invalid-clock-input"
+execution = "inline"
 
 [[compositions.nodes]]
 id = "time"
@@ -4691,6 +4694,7 @@ value = { unsupported = true }
 let post_effect_terminal_failure_composition =
   {|[[compositions]]
 name = "write-then-invalid-post"
+execution = "inline"
 
 [[compositions.nodes]]
 id = "write"
@@ -4712,6 +4716,7 @@ value = {}
 let unknown_effect_terminal_failure_composition =
   {|[[compositions]]
 name = "unknown-write-before-post"
+execution = "inline"
 
 [[compositions.nodes]]
 id = "write"
@@ -4734,6 +4739,7 @@ let write_then_unchanged_board_composition ~revision =
   Printf.sprintf
     {|[[compositions]]
 name = "write-then-durable-wait"
+execution = "inline"
 
 [[compositions.nodes]]
 id = "write"
@@ -4751,6 +4757,20 @@ kind = "literal"
 value = { if_revision = %S }
 |}
     revision
+;;
+
+let one_node_async_clock_composition =
+  {|[[compositions]]
+name = "clock-background"
+execution = "async"
+
+[[compositions.nodes]]
+id = "time"
+tool = "keeper_time_now"
+[compositions.nodes.input]
+kind = "literal"
+value = {}
+|}
 ;;
 
 let test_composition_catalog_materializes_and_executes_first_class_tool () =
@@ -5246,6 +5266,120 @@ let test_terminal_composition_post_effect_defer_closes_without_resume () =
               fail "official-client provider loop remained retryable after post-effect defer"))
 ;;
 
+let test_async_composition_uses_durable_request_status_surface () =
+  with_exec_fixture
+    ~bind_eio_context:true
+    "composition-async-durable-status"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       let catalog =
+         match
+           Masc.Keeper_tool_composition_catalog.parse
+             one_node_async_clock_composition
+         with
+         | Ok catalog -> catalog
+         | Error error ->
+           fail (Masc.Keeper_tool_composition_catalog.error_to_string error)
+       in
+       let tools =
+         Masc.Keeper_tools_agent_core_bundle.make_tools
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot:ctx_work
+           ~composition_catalog:catalog
+           ()
+       in
+       let async_tool =
+         match find_tool_by_name tools "keeper_compose_clock-background" with
+         | Some tool -> tool
+         | None -> fail "async composition tool was not materialized"
+       in
+       let status_tool =
+         match find_tool_by_name tools "keeper_composition_status" with
+         | Some tool -> tool
+         | None -> fail "async composition status tool was not materialized"
+       in
+       (match Agent_core.Tool.execution_mode status_tool with
+        | Agent_core.Tool_contract.Concurrent -> ()
+        | Agent_core.Tool_contract.Serial -> fail "status tool lost read-only concurrency");
+       let request_id =
+         match
+           Agent_core.Tool.execute
+             ~invocation:
+               (composition_invocation
+                  ~completion:Agent_core.Tool_contract.Continue_after_success)
+             async_tool
+             (`Assoc [])
+         with
+         | Error error -> fail error.Agent_core.Types.message
+         | Ok output ->
+           let payload = parse_json output.content in
+           check string
+             "async acceptance mode"
+             "async"
+             Yojson.Safe.Util.(member "execution" payload |> to_string);
+           Yojson.Safe.Util.(member "request_id" payload |> to_string)
+       in
+       let rec await_terminal () =
+         match
+           Masc.Keeper_msg_async.poll
+             ~base_path:config.base_path
+             ~caller:meta.name
+             request_id
+         with
+         | Masc.Keeper_msg_async.Found
+             ({ status = Masc.Keeper_msg_async.Done _; _ } as entry) ->
+           entry
+         | Masc.Keeper_msg_async.Found
+             { status =
+                 ( Masc.Keeper_msg_async.Queued
+                 | Masc.Keeper_msg_async.Running
+                 | Masc.Keeper_msg_async.Cancelling _ )
+             ; _
+             } ->
+           Eio.Fiber.yield ();
+           await_terminal ()
+         | Masc.Keeper_msg_async.Found
+             { status =
+                 ( Masc.Keeper_msg_async.Lost _
+                 | Masc.Keeper_msg_async.Cancelled _
+                 | Masc.Keeper_msg_async.Persistence_failed _ )
+             ; _
+             } ->
+           fail "async read-only composition did not complete"
+         | Masc.Keeper_msg_async.Absent -> fail "durable async request disappeared"
+         | Masc.Keeper_msg_async.Unreadable reason -> fail reason
+         | Masc.Keeper_msg_async.Rejected _ -> fail "async request access was rejected"
+       in
+       let clock =
+         match Eio_context.get_clock_opt () with
+         | Some clock -> clock
+         | None -> fail "async composition test lost its bound Eio clock"
+       in
+       ignore
+         (Eio.Time.with_timeout_exn clock 5.0 await_terminal
+           : Masc.Keeper_msg_async.entry);
+       match
+         Agent_core.Tool.execute
+           ~invocation:
+             (composition_invocation
+                ~completion:Agent_core.Tool_contract.Continue_after_success)
+           status_tool
+           (`Assoc [ "request_id", `String request_id ])
+       with
+       | Error error -> fail error.Agent_core.Types.message
+       | Ok output ->
+         let payload = parse_json output.content in
+         check string
+           "durable terminal status"
+           "done"
+           Yojson.Safe.Util.(member "status" payload |> to_string);
+         check string
+           "durable structured composition result"
+           "keeper_compose_clock-background"
+           Yojson.Safe.Util.(member "result" payload |> member "composition_tool" |> to_string))
+;;
+
 let test_composition_runtime_uses_canonical_descriptor () =
   with_exec_fixture "composition-canonical-descriptor"
     (fun ~config ~meta ~publication_recovery ~ctx_work ->
@@ -5446,6 +5580,8 @@ let () =
         test_terminal_composition_unknown_write_failure_closes_official_client_loop;
       test_case "post-effect deferred composition closes without resume" `Quick
         test_terminal_composition_post_effect_defer_closes_without_resume;
+      test_case "async composition exposes durable status" `Quick
+        test_async_composition_uses_durable_request_status_surface;
       test_case "terminal composition requires terminal outer invocation" `Quick
         test_composition_terminal_requires_terminal_outer_invocation;
     ]);

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -175,6 +175,52 @@ let rec mkdir_p path =
     Unix.mkdir path 0o755
   end
 
+let test_keeper_msg_startup_recovery_settles_disk_only_running_request () =
+  with_temp_dir "keeper-msg-startup-recovery" (fun base_path ->
+    Eio_main.run @@ fun env ->
+    Fs_compat.set_fs (Eio.Stdenv.fs env);
+    let request_id = "startup_recovery_running_0" in
+    let active_path =
+      match
+        Keeper_msg_async.For_testing.active_record_path ~base_path ~request_id
+      with
+      | Some path -> path
+      | None -> Alcotest.fail "startup recovery request id was rejected"
+    in
+    mkdir_p (Filename.dirname active_path);
+    `Assoc
+      [ "schema_version", `Int Keeper_msg_async.For_testing.record_schema_version
+      ; "request_id", `String request_id
+      ; "keeper_name", `String "startup-recovery-keeper"
+      ; "base_path", `String (Fs_compat.realpath base_path)
+      ; "submitted_by", `String "startup-recovery-caller"
+      ; "status", `String "running"
+      ; "submitted_at", `Float 1.0
+      ]
+    |> Yojson.Safe.to_string
+    |> Fs_compat.save_file active_path;
+    let report =
+      Server_bootstrap_maintenance.recover_keeper_msg_requests_on_startup
+        ~base_path
+    in
+    Alcotest.(check int) "startup recovered one request" 1 report.lost;
+    match
+      Keeper_msg_async.poll
+        ~base_path
+        ~caller:"startup-recovery-caller"
+        request_id
+    with
+    | Keeper_msg_async.Found { status = Keeper_msg_async.Lost _; _ } -> ()
+    | Keeper_msg_async.Found entry ->
+      Alcotest.failf
+        "startup recovery retained status=%s"
+        (Keeper_msg_async.status_to_string entry.status)
+    | Keeper_msg_async.Absent
+    | Keeper_msg_async.Unreadable _
+    | Keeper_msg_async.Rejected _ ->
+      Alcotest.fail "startup recovery lost the durable request row")
+;;
+
 (* The example keeper must satisfy the fail-closed profile contract
    (#24144/#24226): a TOML without inline instructions requires a non-empty
    keepers/<name>/AGENT.md, and a keeper whose profile fails to load is
@@ -5436,6 +5482,10 @@ let () =
             test_startup_state_readiness_before_init;
           Alcotest.test_case "readiness true after init" `Quick
             test_startup_state_readiness_after_init;
+          Alcotest.test_case
+            "startup recovery settles disk-only keeper message request"
+            `Quick
+            test_keeper_msg_startup_recovery_settles_disk_only_running_request;
           Alcotest.test_case "MCP requires explicit readiness" `Quick
             test_mcp_transport_requires_explicit_readiness;
           Alcotest.test_case


### PR DESCRIPTION
## Summary
- require an explicit TOML execution mode for every composition: `inline` or `async`
- admit async execution only when every canonical node descriptor is statically read-only
- reuse the Keeper durable async request lifecycle for accepted request IDs, polling, cancellation, recovery, and structured terminal results
- give each background worker its own request switch and sandbox factory, with cleanup owned by that switch
- run the broker's exclusive disk-only request recovery synchronously at server startup before new background work
- materialize shared concurrent status and serial cancel tools only when the catalog declares an async composition
- include those exact control names in model-projection integrity checks

## Exact stack
- base: f5ae882e908a605f800abadf5424d6030ba6c6eb
- head: f74bcefacf751b035a63f20e4b03239d5a5b0092
- parent PR: #28670

## Contract
- no inferred/default execution mode
- no async mutating or unknown-readonly tools
- no detached turn-local switch or shared sandbox lifetime
- durable request ID is returned synchronously; exact status and structured action evidence remain pollable
- restart recovery converts ownerless nonterminal rows to typed terminal Lost state

## Verification
- ocamlformat --check on all changed OCaml files: pass
- git diff --check: pass
- local builds/tests: intentionally not run; CI is the only build/test authority
- parser admission/projection, async start/poll/structured result, bounded wait, and production startup recovery regressions added