### PR TITLE
fix(runtime): match qwen cloud thinking wire

### DIFF
--- a/packages/agent_core/models.toml
+++ b/packages/agent_core/models.toml
@@ -1079,7 +1079,11 @@ supports_tool_choice = false
 supports_reasoning = true
 supports_extended_thinking = true
 supports_reasoning_budget = true
-thinking_control_format = "ollama_think"
+# ollama.com exposes this model through its OpenAI-compatible /v1 endpoint.
+# That wire cannot encode Ollama's native top-level [think] field; reasoning is
+# inherent/default-on for this deployment, so an explicit enable is satisfied
+# without emitting a control field.
+thinking_control_format = "none"
 supports_multimodal_inputs = true
 supports_image_input = true
 modality_priority = "visual_first"

--- a/packages/agent_core/test/test_capabilities.ml
+++ b/packages/agent_core/test/test_capabilities.ml
@@ -890,20 +890,20 @@ let test_ollama_cloud_grouped_rows_have_required_axes () =
      one of these axes to a generic text-only profile. JSON response-format
      support is an exact per-model contract rather than a provider-wide rule. *)
   let cases =
-    [ "qwen3.5:397b", false
-    ; "gemma4:31b", true
-    ; "kimi-k2.7-code", false
-    ; "minimax-m3", true
-    ; "nemotron-3-ultra", false
-    ; "deepseek-v4-flash", false
-    ; "deepseek-v4-pro", false
-    ; "glm-5.2", false
-    ; "gpt-oss:20b", false
-    ; "gpt-oss:120b", false
+    [ "qwen3.5:397b", false, Capabilities.No_thinking_control
+    ; "gemma4:31b", true, Capabilities.Ollama_think
+    ; "kimi-k2.7-code", false, Capabilities.Ollama_think
+    ; "minimax-m3", true, Capabilities.Ollama_think
+    ; "nemotron-3-ultra", false, Capabilities.Ollama_think
+    ; "deepseek-v4-flash", false, Capabilities.Ollama_think
+    ; "deepseek-v4-pro", false, Capabilities.Ollama_think
+    ; "glm-5.2", false, Capabilities.Ollama_think
+    ; "gpt-oss:20b", false, Capabilities.Ollama_think
+    ; "gpt-oss:120b", false, Capabilities.Ollama_think
     ]
   in
   List.iter
-    (fun (model_id, expected_json) ->
+    (fun (model_id, expected_json, expected_thinking_control) ->
        match
          Capabilities.for_provider_model_id
            ~allow_bare_fallback:false
@@ -922,8 +922,8 @@ let test_ollama_cloud_grouped_rows_have_required_axes () =
            expected_json
            c.supports_response_format_json;
          check_thinking_control
-           (model_id ^ " uses Ollama native think")
-           Capabilities.Ollama_think
+           (model_id ^ " uses its exact endpoint thinking control")
+           expected_thinking_control
            c.thinking_control_format)
     cases
 ;;


### PR DESCRIPTION
## What changed

- declare the provider-scoped Ollama Cloud `qwen3.5:397b` row as inherent/default-on reasoning with no explicit thinking-control wire
- keep the provider-independent/native Ollama row unchanged
- make the existing capability test assert each model's exact endpoint dialect instead of assuming every grouped Cloud model uses `ollama_think`

## Why

The live multimodal Keeper turn reached the vision-capable runtime but failed before provider completion. The binding uses Ollama Cloud's OpenAI-compatible `/v1` path, while the provider-scoped catalog selected the native Ollama `think` dialect. Agent Core correctly rejected `enable_thinking=true` because that native field cannot be encoded on the selected wire.

With `supports_reasoning=true` and `thinking_control_format=none`, explicit enable is satisfied by the deployment's inherent/default-on reasoning contract without inventing an unsupported field. Image and multimodal capabilities remain unchanged.

## Validation

- `ocamlformat --check packages/agent_core/test/test_capabilities.ml`
- `ocamlc -stop-after parsing packages/agent_core/test/test_capabilities.ml`
- `git diff --check`
- TOML syntax check with `taplo check`

No local Dune build was run. CI, deployment, and the live image rerun remain pending.

# ci:skip-test-coverage
