### PR TITLE
fix(runtime): honor explicit binding capabilities

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -954,8 +954,12 @@ streaming = true
 [models.ollama-cloud-qwen3-5-397b.capabilities]
 supports-tool-choice = false
 supports-extended-thinking = true
-supports-reasoning-budget = true
-thinking-control-format = "reasoning-effort"
+supports-reasoning-budget = false
+# ollama.com exposes this binding through its OpenAI-compatible /v1 endpoint.
+# Reasoning is inherent/default-on here; the endpoint has no explicit control
+# field, while the native /api/chat binding keeps its separate Ollama think
+# contract through [ollama_cloud_native].
+thinking-control-format = "none"
 supports-image-input = true
 supports-multimodal-inputs = true
 

--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -309,28 +309,31 @@ let agent_core_thinking_control_format = function
 ;;
 
 (** A runtime [api-name] is an opaque deployment string, not automatically an
-    AGENT_CORE catalog model. When AGENT_CORE has no exact provider/model row, project the
-    complete typed runtime declaration into the Provider_config override that
-    AGENT_CORE exposes for concrete endpoint contracts. Catalogued models keep the AGENT_CORE
-    row unchanged; an absent runtime capability block remains absent and is
-    rejected later by the normal startup gate. *)
+    AGENT_CORE catalog model. A present runtime capability block is the complete
+    declaration for this concrete transport binding, so project every exposed
+    runtime axis over the exact provider/model catalog row. Axes that runtime.toml
+    does not expose (for example reasoning-stream parsing) remain catalog-owned.
+    An absent runtime capability block remains absent and resolves through the
+    normal catalog/startup path. *)
 let model_capabilities_override_of_model_spec
       ~(provider_id : string)
       (spec : Runtime_schema.model_spec)
   =
-  match
-    Llm_provider.Capabilities.for_provider_model_id
-      ~allow_bare_fallback:false
-      ~provider_label:provider_id
-      ~model_id:spec.api_name
-  with
-  | Some _ -> None
-  | None ->
-    Option.map
+  Option.map
       (fun (caps : Runtime_schema.model_capabilities) ->
-         let base = Llm_provider.Capabilities.default_capabilities in
+         let base =
+           Option.value
+             ~default:Llm_provider.Capabilities.default_capabilities
+             (Llm_provider.Capabilities.for_provider_model_id
+                ~allow_bare_fallback:false
+                ~provider_label:provider_id
+                ~model_id:spec.api_name)
+         in
          { base with
-           max_context_tokens = spec.max_context
+           max_context_tokens =
+             (match spec.max_context with
+              | Some _ as max_context -> max_context
+              | None -> base.max_context_tokens)
          ; max_output_tokens = caps.max_output_tokens
          ; supports_tools = spec.tools_support
          ; supports_tool_choice = caps.supports_tool_choice

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -1094,6 +1094,59 @@ max_context_tokens = 160000
             provider-scoped row required)"
        | None -> ())
 
+let test_runtime_capabilities_override_catalog_transport_axes () =
+  with_model_catalog
+    {|
+[[models]]
+id_prefix = "qwen"
+provider_name = "runpod_mtp"
+supports_reasoning = true
+supports_reasoning_budget = true
+thinking_control_format = "ollama_think"
+reasoning_streaming_format = "delta:reasoning_content"
+|}
+    (fun () ->
+       let runtime_caps =
+         { Runtime_schema.model_capabilities_default with
+           supports_extended_thinking = true
+         ; supports_reasoning_budget = false
+         ; thinking_control_format = Runtime_schema.No_thinking_control
+         ; supports_image_input = true
+         ; supports_multimodal_inputs = true
+         }
+       in
+       let model = { qwen_model with capabilities = Some runtime_caps } in
+       let cfg =
+         { Runtime_schema.providers = [ runpod_provider ]
+         ; models = [ model ]
+         ; bindings = [ runpod_binding ]
+         ; default_runtime_id = Some "runpod_mtp.qwen"
+         ; cross_verifier_runtime_id = None
+         ; keeper_assignments = []
+         ; media_failover = []
+         ; lane_decls = []
+         ; exact_output_lane_decls = []
+         }
+       in
+       let provider_cfg =
+         match Runtime_adapter.binding_to_provider_config cfg runpod_binding with
+         | Ok provider_cfg -> provider_cfg
+         | Error msg -> failf "unexpected adapter error: %s" msg
+       in
+       match Llm_provider.Provider_config.capabilities_for_config_model provider_cfg with
+       | None -> fail "runtime capability override should resolve"
+       | Some caps ->
+         check bool "runtime thinking control wins" true
+           (caps.thinking_control_format
+            = Llm_provider.Capabilities.No_thinking_control);
+         check bool "runtime reasoning budget wins" false caps.supports_reasoning_budget;
+         check bool "runtime image input wins" true caps.supports_image_input;
+         check bool "runtime multimodal input wins" true caps.supports_multimodal_inputs;
+         check bool "catalog reasoning remains" true caps.supports_reasoning;
+         check bool "catalog stream parser remains" true
+           (caps.reasoning_streaming_format
+            = Llm_provider.Capabilities.Delta_reasoning_field "reasoning_content"))
+
 (* Audit F2: TOML keep-alive / num-ctx must reach the wire-level
    Provider_config. Before the fix the adapter dropped both binding
    fields, so keep_alive fell back to AGENT_CORE_OLLAMA_KEEP_ALIVE / "-1" and
@@ -1965,6 +2018,10 @@ let () =
             "bare catalog row stays fail-closed for declared provider"
             `Quick
             test_bare_catalog_row_stays_fail_closed_for_declared_provider
+        ; test_case
+            "runtime capability block overrides catalog transport axes"
+            `Quick
+            test_runtime_capabilities_override_catalog_transport_axes
         ; test_case
             "runtime adapter carries auth in api_key only"
             `Quick


### PR DESCRIPTION
## What changed

- honor a present runtime.toml model capability block even when Agent Core already has an exact provider/model catalog row
- overlay only the capability axes owned by runtime.toml while preserving catalog-only axes such as reasoning stream parsing
- declare the seeded Ollama Cloud Qwen 3.5 `/v1` binding as inherent reasoning with no explicit thinking-control wire or budget
- add a focused adapter contract test for runtime transport truth over catalog defaults

## Root cause

The live image turn selected `ollama_cloud.qwen3-5-cloud`, but failed before provider completion. Its runtime declaration says the OpenAI-compatible endpoint has no thinking-control field. `Runtime_adapter.model_capabilities_override_of_model_spec` discarded that entire declaration whenever a catalog row existed, so Agent Core instead selected the provider-scoped native `ollama_think` dialect and rejected `enable_thinking=true` on `/v1`.

The replacement keeps the catalog as the base, preserving axes runtime.toml does not model, and overlays the complete runtime capability block for the concrete binding. Native `/api/chat` remains a separate provider/binding contract.

## Validation

- `ocamlformat --check` for both changed OCaml files
- `ocamlc -stop-after parsing` for both changed OCaml files
- `git diff --check`

No local Dune build was run. CI, deployment, and the exact live image rerun remain pending.
