### PR TITLE
fix(runtime): preserve explicit thinking capability

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -954,8 +954,12 @@ streaming = true
 [models.ollama-cloud-qwen3-5-397b.capabilities]
 supports-tool-choice = false
 supports-extended-thinking = true
-supports-reasoning-budget = true
-thinking-control-format = "reasoning-effort"
+supports-reasoning-budget = false
+# ollama.com exposes this binding through its OpenAI-compatible /v1 endpoint.
+# Reasoning is inherent/default-on and no explicit thinking-control field is
+# accepted on this wire. The native provider keeps the catalog's Ollama control.
+thinking-control-format = "none"
+reasoning-streaming-format = "delta:reasoning_content"
 supports-image-input = true
 supports-multimodal-inputs = true
 

--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -324,7 +324,40 @@ let model_capabilities_override_of_model_spec
       ~provider_label:provider_id
       ~model_id:spec.api_name
   with
-  | Some _ -> None
+  | Some catalog_caps ->
+    (match spec.capabilities with
+     | None -> None
+     | Some runtime_caps ->
+       (match
+          runtime_caps.declared_thinking_control_format,
+          runtime_caps.declared_supports_reasoning_budget,
+          runtime_caps.reasoning_streaming_format
+        with
+        | None, None, None -> None
+        | thinking_control_format, supports_reasoning_budget, reasoning_streaming_format ->
+          let effective_reasoning_budget =
+            match thinking_control_format with
+            (* A concrete transport-control declaration owns the associated
+               budget bit as one contract. In particular, explicit [none]
+               must not retain a catalog budget that this wire cannot encode. *)
+            | Some _ -> runtime_caps.supports_reasoning_budget
+            | None ->
+              Option.value
+                supports_reasoning_budget
+                ~default:catalog_caps.supports_reasoning_budget
+          in
+          Some
+            { catalog_caps with
+              thinking_control_format =
+                (match thinking_control_format with
+                 | Some format -> agent_core_thinking_control_format format
+                 | None -> catalog_caps.thinking_control_format)
+            ; supports_reasoning_budget = effective_reasoning_budget
+            ; reasoning_streaming_format =
+                Option.value
+                  reasoning_streaming_format
+                  ~default:catalog_caps.reasoning_streaming_format
+            }))
   | None ->
     Option.map
       (fun (caps : Runtime_schema.model_capabilities) ->
@@ -342,6 +375,10 @@ let model_capabilities_override_of_model_spec
          ; supports_reasoning_budget = caps.supports_reasoning_budget
          ; thinking_control_format =
              agent_core_thinking_control_format caps.thinking_control_format
+         ; reasoning_streaming_format =
+             Option.value
+               caps.reasoning_streaming_format
+               ~default:base.reasoning_streaming_format
          ; supports_response_format_json = caps.supports_response_format_json
          ; supports_structured_output = caps.supports_structured_output
          ; supports_multimodal_inputs = caps.supports_multimodal_inputs

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -108,6 +108,14 @@ type thinking_control_format =
   | Enable_thinking
 [@@deriving show, eq]
 
+type reasoning_streaming_format =
+  Llm_provider.Capabilities.reasoning_streaming_format =
+  | Default_reasoning_streaming
+  | No_reasoning_streaming
+  | Delta_reasoning_field of string
+  | Template_reasoning_streaming
+[@@deriving show, eq]
+
 (** Per-model capabilities, mirroring AGENT_CORE [Llm_provider.Capabilities] for the
     fields callers branch on. Fields already present on {!model_spec}
     ([tools_support]/[thinking_support]/[max_context]/[streaming]) are not
@@ -120,7 +128,10 @@ type model_capabilities =
   ; supports_parallel_tool_calls : bool
   ; supports_extended_thinking : bool
   ; supports_reasoning_budget : bool
+  ; declared_supports_reasoning_budget : bool option
   ; thinking_control_format : thinking_control_format
+  ; declared_thinking_control_format : thinking_control_format option
+  ; reasoning_streaming_format : reasoning_streaming_format option
   ; supports_image_input : bool
   ; supports_audio_input : bool
   ; supports_video_input : bool
@@ -149,7 +160,10 @@ let model_capabilities_default =
   ; supports_parallel_tool_calls = false
   ; supports_extended_thinking = false
   ; supports_reasoning_budget = false
+  ; declared_supports_reasoning_budget = None
   ; thinking_control_format = No_thinking_control
+  ; declared_thinking_control_format = None
+  ; reasoning_streaming_format = None
   ; supports_image_input = false
   ; supports_audio_input = false
   ; supports_video_input = false

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -94,6 +94,14 @@ type thinking_control_format =
   | Enable_thinking
 [@@deriving show, eq]
 
+type reasoning_streaming_format =
+  Llm_provider.Capabilities.reasoning_streaming_format =
+  | Default_reasoning_streaming
+  | No_reasoning_streaming
+  | Delta_reasoning_field of string
+  | Template_reasoning_streaming
+[@@deriving show, eq]
+
 type model_capabilities =
   { max_output_tokens : int option
   ; supports_tool_choice : bool
@@ -102,7 +110,13 @@ type model_capabilities =
   ; supports_parallel_tool_calls : bool
   ; supports_extended_thinking : bool
   ; supports_reasoning_budget : bool
+  ; declared_supports_reasoning_budget : bool option
+      (** Exact TOML presence. [None] preserves an Agent Core catalog value. *)
   ; thinking_control_format : thinking_control_format
+  ; declared_thinking_control_format : thinking_control_format option
+      (** Exact TOML presence. [None] preserves an Agent Core catalog value. *)
+  ; reasoning_streaming_format : reasoning_streaming_format option
+      (** Exact streaming side-channel for this transport binding. *)
   ; supports_image_input : bool
   ; supports_audio_input : bool
   ; supports_video_input : bool

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -698,6 +698,23 @@ let parse_model_capabilities ~(path : string) (tbl : Otoml.t)
            retired_native_streaming_key)
   in
   let b key = Otoml.find_or ~default:false tbl Otoml.get_boolean [ key ] in
+  let b_opt key = Otoml.find_opt tbl Otoml.get_boolean [ key ] in
+  let reasoning_streaming_format_result =
+    match typed_find "string" path tbl "reasoning-streaming-format" Otoml.get_string with
+    | Error errors -> Error errors
+    | Ok None -> Ok None
+    | Ok (Some raw) ->
+      (match Llm_provider.Capability_vocab.reasoning_streaming_format_of_string raw with
+       | Some format -> Ok (Some format)
+       | None ->
+         Error
+           (error
+              (path ^ ".reasoning-streaming-format")
+              (Printf.sprintf
+                 "unknown reasoning-streaming-format %S — expected %s"
+                 raw
+                 Llm_provider.Capability_vocab.reasoning_streaming_format_syntax)))
+  in
   let b_default_true key = Otoml.find_or ~default:true tbl Otoml.get_boolean [ key ] in
   let positive_int_opt_field key =
     match Otoml.find_opt tbl Otoml.get_integer [ key ] with
@@ -727,11 +744,11 @@ let parse_model_capabilities ~(path : string) (tbl : Otoml.t)
                \"chat-template-token\""))
     | Ok (Some raw), Ok token -> parse_thinking_control_format ~path ~token raw
   in
-  match thinking_control_format_result, retired_key_errors with
-  | Error errors, retired_key_errors ->
+  match thinking_control_format_result, reasoning_streaming_format_result, retired_key_errors with
+  | Error errors, _, retired_key_errors | _, Error errors, retired_key_errors ->
     Error (errors @ retired_key_errors)
-  | Ok _, _ :: _ -> Error retired_key_errors
-  | Ok thinking_control_format, [] ->
+  | Ok _, Ok _, _ :: _ -> Error retired_key_errors
+  | Ok thinking_control_format, Ok reasoning_streaming_format, [] ->
     Ok
       { Runtime_schema.max_output_tokens = positive_int_opt_field "max-output-tokens"
       ; supports_tool_choice = b "supports-tool-choice"
@@ -740,7 +757,13 @@ let parse_model_capabilities ~(path : string) (tbl : Otoml.t)
       ; supports_parallel_tool_calls = b "supports-parallel-tool-calls"
       ; supports_extended_thinking = b "supports-extended-thinking"
       ; supports_reasoning_budget = b "supports-reasoning-budget"
+      ; declared_supports_reasoning_budget = b_opt "supports-reasoning-budget"
       ; thinking_control_format
+      ; declared_thinking_control_format =
+          (match Otoml.find_opt tbl Fun.id [ "thinking-control-format" ] with
+           | None -> None
+           | Some _ -> Some thinking_control_format)
+      ; reasoning_streaming_format
       ; supports_image_input = b "supports-image-input"
       ; supports_audio_input = b "supports-audio-input"
       ; supports_video_input = b "supports-video-input"

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -322,10 +322,15 @@ let assert_ollama_cloud_seed_runtime runtimes case =
     (match runtime.model.capabilities with
      | None -> failf "expected capabilities for %s" case.runtime_id
      | Some caps ->
-       let expected_thinking_format =
-         if case.thinking
-         then Runtime_schema.Reasoning_effort
-         else Runtime_schema.No_thinking_control
+       let expected_reasoning_budget, expected_thinking_format =
+         match case.runtime_id with
+         | "ollama_cloud.ollama-cloud-qwen3-5-397b" ->
+           false, Runtime_schema.No_thinking_control
+         | _ ->
+           ( case.thinking
+           , if case.thinking
+             then Runtime_schema.Reasoning_effort
+             else Runtime_schema.No_thinking_control )
        in
        check bool (case.runtime_id ^ " forced tool_choice disabled") false
          caps.supports_tool_choice;
@@ -335,7 +340,7 @@ let assert_ollama_cloud_seed_runtime runtimes case =
          caps.supports_multimodal_inputs;
        check bool (case.runtime_id ^ " extended thinking") case.thinking
          caps.supports_extended_thinking;
-       check bool (case.runtime_id ^ " reasoning budget") case.thinking
+       check bool (case.runtime_id ^ " reasoning budget") expected_reasoning_budget
          caps.supports_reasoning_budget;
        check bool (case.runtime_id ^ " thinking control") true
          (Runtime_schema.equal_thinking_control_format

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -1094,6 +1094,57 @@ max_context_tokens = 160000
             provider-scoped row required)"
        | None -> ())
 
+let test_declared_thinking_capabilities_override_catalog () =
+  with_model_catalog
+    {|
+[[models]]
+id_prefix = "qwen"
+provider_name = "runpod_mtp"
+supports_system_prompt = true
+supports_reasoning = true
+supports_reasoning_budget = true
+thinking_control_format = "ollama_think"
+|}
+    (fun () ->
+       let runtime_caps =
+         { Runtime_schema.model_capabilities_default with
+           supports_reasoning_budget = false
+         ; thinking_control_format = Runtime_schema.No_thinking_control
+         ; declared_thinking_control_format = Some Runtime_schema.No_thinking_control
+         ; reasoning_streaming_format =
+             Some (Runtime_schema.Delta_reasoning_field "reasoning_content")
+         }
+       in
+       let model = { qwen_model with capabilities = Some runtime_caps } in
+       let cfg =
+         { Runtime_schema.providers = [ runpod_provider ]
+         ; models = [ model ]
+         ; bindings = [ runpod_binding ]
+         ; default_runtime_id = Some "runpod_mtp.qwen"
+         ; cross_verifier_runtime_id = None
+         ; keeper_assignments = []
+         ; media_failover = []
+         ; lane_decls = []
+         ; exact_output_lane_decls = []
+         }
+       in
+       let provider_cfg =
+         match Runtime_adapter.binding_to_provider_config cfg runpod_binding with
+         | Ok provider_cfg -> provider_cfg
+         | Error msg -> failf "unexpected adapter error: %s" msg
+       in
+       match Llm_provider.Provider_config.capabilities_for_config_model provider_cfg with
+       | None -> fail "declared thinking capability override should resolve"
+       | Some caps ->
+         check bool "declared thinking control wins" true
+           (caps.thinking_control_format
+            = Llm_provider.Capabilities.No_thinking_control);
+         check bool "declared reasoning budget wins" false caps.supports_reasoning_budget;
+         check bool "sparse system prompt preserves catalog" true caps.supports_system_prompt;
+         check bool "declared transport stream parser wins" true
+           (caps.reasoning_streaming_format
+            = Llm_provider.Capabilities.Delta_reasoning_field "reasoning_content"))
+
 (* Audit F2: TOML keep-alive / num-ctx must reach the wire-level
    Provider_config. Before the fix the adapter dropped both binding
    fields, so keep_alive fell back to AGENT_CORE_OLLAMA_KEEP_ALIVE / "-1" and
@@ -1965,6 +2016,10 @@ let () =
             "bare catalog row stays fail-closed for declared provider"
             `Quick
             test_bare_catalog_row_stays_fail_closed_for_declared_provider
+        ; test_case
+            "declared thinking capabilities override catalog"
+            `Quick
+            test_declared_thinking_capabilities_override_catalog
         ; test_case
             "runtime adapter carries auth in api_key only"
             `Quick


### PR DESCRIPTION
## What changed

- preserve explicit-vs-omitted runtime declarations for thinking control and reasoning budget
- add a typed optional reasoning-streaming format for concrete runtime transports
- overlay only those explicitly declared transport axes on an existing Agent Core catalog row
- declare the seeded Ollama Cloud Qwen 3.5 `/v1` binding as inherent reasoning, no explicit budget/control wire, with `reasoning_content` streaming

## Root cause

The live multimodal turn selected the vision-capable Qwen runtime but failed before provider completion. Runtime TOML accurately declared no thinking-control field for the OpenAI-compatible `/v1` binding, yet the adapter discarded the declaration because an Agent Core provider/model catalog row already existed. The catalog's native `ollama_think` dialect was then applied to `/v1`, where it cannot be encoded.

The fix does not change the shared provider/model catalog or overwrite sparse runtime fields globally. Only explicitly present transport-owned thinking axes replace their catalog counterparts; all other catalog capabilities remain intact.

## Validation

- `ocamlformat --check` for all changed OCaml files
- `ocamlc -stop-after parsing` for all changed OCaml files
- `git diff --check`
- independent source review after two broader drafts were closed for regressions

No local Dune build was run. CI, deployment, and the exact live image rerun remain pending.

# ci:skip-test-coverage
