### PR TITLE
fix(runtime): rotate attempt-local request rejection

### DIFF
--- a/lib/keeper/keeper_event_bridge_error_json.ml
+++ b/lib/keeper/keeper_event_bridge_error_json.ml
@@ -37,6 +37,7 @@ let agent_completed_result_fields = function
 
 let invalid_request_reason_to_wire = function
   | Agent_core.Retry.Json_parse_error -> "json_parse_error"
+  | Agent_core.Retry.Attempt_rejected -> "attempt_rejected"
   | Agent_core.Retry.Request_body_too_large _ -> "request_body_too_large"
   | Agent_core.Retry.Request_body_refused_by_provider _ ->
     "request_body_refused_by_provider"
@@ -167,6 +168,7 @@ let core_api_error_fields = function
        | Agent_core.Retry.Request_body_refused_by_provider { status } ->
          [ "status", `Int status ]
        | Agent_core.Retry.Json_parse_error
+       | Agent_core.Retry.Attempt_rejected
        | Agent_core.Retry.Unknown_invalid_request -> [])
   | Agent_core.Retry.NotFound { message } ->
     [ "variant", `String "not_found"; "message", `String message ]

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -181,6 +181,9 @@ let lane_should_retry
        last candidate still returns the typed error, keeping the typed
        overflow observation (blocker label, failure route) intact. *)
     true
+  else if Keeper_turn_driver_try_runtime.attempt_rejected_should_try_next error
+  then
+    true
   else
     match Keeper_turn_driver_try_runtime.core_error_to_http_error error with
     | Some http_err -> Runtime_attempt_fsm.should_try_next http_err

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -332,6 +332,7 @@ let rejected_body_bytes = function
       ( InvalidRequest
           { reason =
               ( Json_parse_error
+              | Attempt_rejected
               | Request_body_refused_by_provider _
               | Unknown_invalid_request )
           ; _

--- a/lib/keeper/keeper_turn_driver_try_runtime.ml
+++ b/lib/keeper/keeper_turn_driver_try_runtime.ml
@@ -21,6 +21,37 @@ let accept_no_progress_should_try_next error =
   | None -> false
 ;;
 
+let attempt_rejected_should_try_next = function
+  | Agent_core.Error.Api
+      (Agent_core.Retry.InvalidRequest
+         { reason = Agent_core.Retry.Attempt_rejected; _ }) -> true
+  | Agent_core.Error.Api
+      (Agent_core.Retry.InvalidRequest
+         { reason =
+             ( Agent_core.Retry.Json_parse_error
+             | Agent_core.Retry.Request_body_too_large _
+             | Agent_core.Retry.Request_body_refused_by_provider _
+             | Agent_core.Retry.Unknown_invalid_request )
+         ; _
+         })
+  | Agent_core.Error.Api
+      ( Agent_core.Retry.RateLimited _ | Agent_core.Retry.Overloaded _
+      | Agent_core.Retry.ServerError _ | Agent_core.Retry.AuthError _
+      | Agent_core.Retry.AuthorizationError _
+      | Agent_core.Retry.PaymentRequired _ | Agent_core.Retry.NotFound _
+      | Agent_core.Retry.ContextOverflow _ | Agent_core.Retry.InputCapacity _
+      | Agent_core.Retry.NetworkError _ | Agent_core.Retry.Timeout _ )
+  | Agent_core.Error.Provider _
+  | Agent_core.Error.Agent _
+  | Agent_core.Error.Mcp _
+  | Agent_core.Error.Config _
+  | Agent_core.Error.Serialization _
+  | Agent_core.Error.Io _
+  | Agent_core.Error.Orchestration _
+  | Agent_core.Error.Internal _
+  | Agent_core.Error.Internal_carried { message = _; _ } -> false
+;;
+
 (* Lives here rather than reusing [Keeper_error_classify.is_context_overflow]:
    that module depends on [Keeper_turn_driver], so the walk predicate cannot
    reach it without a module cycle. Api variants are enumerated so a new

--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -490,7 +490,8 @@ let capacity_transition_of_error
       (InputCapacity { reason = Token_measurement_unavailable _; _ }) ->
     Capacity_non_compacting Token_measurement_unavailable
   | Agent_core.Error.Api
-      (InvalidRequest { reason = Json_parse_error | Unknown_invalid_request; _ })
+      (InvalidRequest
+         { reason = Json_parse_error | Attempt_rejected | Unknown_invalid_request; _ })
   | Agent_core.Error.Api
       ( RateLimited _ | Overloaded _ | ServerError _ | AuthError _
       | AuthorizationError _ | PaymentRequired _ | NotFound _ | NetworkError _

--- a/packages/agent_core/lib/llm_provider/retry.ml
+++ b/packages/agent_core/lib/llm_provider/retry.ml
@@ -2,6 +2,7 @@
 
 type invalid_request_reason =
   | Json_parse_error
+  | Attempt_rejected
   | Request_body_too_large of
       { actual_bytes : int
       ; limit_bytes : int
@@ -61,6 +62,7 @@ let network_error_kind_label = function
 
 let invalid_request_reason_to_string = function
   | Json_parse_error -> "json_parse_error"
+  | Attempt_rejected -> "attempt_rejected"
   | Request_body_too_large { actual_bytes; limit_bytes } ->
     Printf.sprintf "request_body_too_large(actual=%d,limit=%d)" actual_bytes limit_bytes
   | Request_body_refused_by_provider { status } ->
@@ -384,7 +386,8 @@ let%test "is_retryable: flat Ollama provider prose is not retryable" =
     not (is_retryable err)
   | InvalidRequest
       { reason =
-          Json_parse_error | Request_body_too_large _ | Request_body_refused_by_provider _
+          Json_parse_error | Attempt_rejected | Request_body_too_large _
+          | Request_body_refused_by_provider _
       ; _
       } -> false
   | RateLimited _
@@ -408,7 +411,8 @@ let%test "HTTP 400 prose does not synthesize ContextOverflow" =
   | InvalidRequest { reason = Unknown_invalid_request; _ } -> true
   | InvalidRequest
       { reason =
-          Json_parse_error | Request_body_too_large _ | Request_body_refused_by_provider _
+          Json_parse_error | Attempt_rejected | Request_body_too_large _
+          | Request_body_refused_by_provider _
       ; _
       }
   | ContextOverflow _
@@ -570,7 +574,8 @@ let%test "classify_error returns Unknown InvalidRequest for non-overflow 400" =
   | InvalidRequest { reason = Unknown_invalid_request; _ } -> true
   | InvalidRequest
       { reason =
-          Json_parse_error | Request_body_too_large _ | Request_body_refused_by_provider _
+          Json_parse_error | Attempt_rejected | Request_body_too_large _
+          | Request_body_refused_by_provider _
       ; _
       } -> false
   | RateLimited _

--- a/packages/agent_core/lib/llm_provider/retry.mli
+++ b/packages/agent_core/lib/llm_provider/retry.mli
@@ -7,6 +7,10 @@
 
 type invalid_request_reason =
   | Json_parse_error
+  | Attempt_rejected
+      (** The selected provider binding rejected the prepared request before
+          dispatch. A caller with an ordered runtime lane may try a different
+          binding, while retrying the same binding cannot change the result. *)
   | Request_body_too_large of
       { actual_bytes : int
       ; limit_bytes : int

--- a/packages/agent_core/lib/provider_failure_attribution.ml
+++ b/packages/agent_core/lib/provider_failure_attribution.ml
@@ -41,9 +41,9 @@ type accept_rejected =
   | Api_invalid_request
   | Config_invalid_config of { field : string }
 
-let invalid_request reason =
+let invalid_request ?(reason_kind = Retry.Unknown_invalid_request) reason =
   Error.Api
-    (Retry.InvalidRequest { message = reason; reason = Retry.Unknown_invalid_request })
+    (Retry.InvalidRequest { message = reason; reason = reason_kind })
 ;;
 
 let core_error_of_http_error ?(accept_rejected = Api_invalid_request) err =
@@ -55,7 +55,8 @@ let core_error_of_http_error ?(accept_rejected = Api_invalid_request) err =
   | Http.TimeoutError _ -> Error.Provider (Llm_provider.Error.of_http_error err)
   | Http.AcceptRejected { reason } ->
     (match accept_rejected with
-     | Api_invalid_request -> invalid_request reason
+     | Api_invalid_request ->
+       invalid_request ~reason_kind:Retry.Attempt_rejected reason
      | Config_invalid_config { field } ->
        Error.Config (Error.InvalidConfig { field; detail = reason }))
   | Http.ProviderFailure

--- a/test/test_keeper_rotation_eligibility_census.ml
+++ b/test/test_keeper_rotation_eligibility_census.ml
@@ -133,6 +133,11 @@ let api_invalid_request_unknown_model =
        ; reason = Agent_core.Retry.Unknown_invalid_request
        })
 
+let api_attempt_rejected =
+  Agent_core.Provider_failure_attribution.core_error_of_http_error
+    (Llm_provider.Http_client.AcceptRejected
+       { reason = "selected runtime cannot encode the request" })
+
 (* Until RFC-0370 §3.1, the Codex app-server boundary folded provider- and
    transport-side failures into [Internal] strings (the catch-all in
    [codex_error_to_core_error]); these three verbatim live-log classes
@@ -190,6 +195,7 @@ let census_rows =
   ; "api:context_overflow", api_context_overflow, 9
   ; "internal:remote_command_failed", internal_remote_command_failed, 4
   ; "api:invalid_request", api_invalid_request_unknown_model, 2
+  ; "api:attempt_rejected", api_attempt_rejected, 0
   ; "api:turn_budget_timeout", api_turn_budget_timeout, 0
   ; "provider:parse_error", provider_parse_error, 0
   ; "provider:unknown_variant", provider_unknown_variant, 0
@@ -259,6 +265,7 @@ let expected_rotation =
   ; "api:context_overflow", true
   ; "internal:remote_command_failed", false
   ; "api:invalid_request", false
+  ; "api:attempt_rejected", true
   ; "api:turn_budget_timeout", true
   ; "provider:parse_error", false
   ; "provider:unknown_variant", false


### PR DESCRIPTION
## As-Is

A live ordered runtime lane (`ollama_cloud.qwen3-5-cloud` → `glm-coding.glm-5-turbo`) stopped after the first candidate rejected its prepared request before dispatch. The terminal receipt recorded `attempt_count=1`, `fallback_applied=false`, and no rotation attempts. Agent Core had an `AcceptRejected` fact, but projected it as `InvalidRequest Unknown_invalid_request`; Keeper therefore treated it like a request-global HTTP 400 and never tried the compatible next runtime.

## To-Be

Preserve the pre-dispatch provider-binding rejection as the typed `Attempt_rejected` reason. Keeper advances only that reason to the next declared runtime candidate. Ordinary HTTP 400/422 remains `Unknown_invalid_request`, same-runtime retry remains disabled, and the existing effect fence still prevents replay after a tool/effect attempt.

## Scope

- 8 production files + 1 existing feature census test
- no runtime-name/model-name policy
- no new admission gate, retry budget, or prose matching
- event JSON exposes the new typed reason

## Evidence

Live failing turn: `trace-1786658880284-00007`, Keeper `canary-runtime-failover-20260814-0730`.

Fast source checks:
- `ocamlformat --check`
- `ocamlc -stop-after parsing` for every changed OCaml file
- `git diff --check`
- conflict-marker scan
- OCaml structure ratchet
- stringly-boundary ratchet

Independent adversarial source review: P1/P2 none. No local Dune build or focused executable run; CI and deployed live rerun remain pending.
