### PR TITLE
fix(keeper): count live reactive capacity

### DIFF
--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -595,7 +595,7 @@ let keeper_execution_snapshot config =
             Keeper_activation_readiness.Unknown
               (Keeper_owner_registry.lookup_error_to_string error)
           | Ok shutdown_operation_id ->
-            Keeper_activation_readiness.classify_owner_execution
+            Keeper_activation_readiness.classify_durable_demand_execution
               ~shutdown_operation_id
               ~runtime
               meta_result

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -3011,6 +3011,7 @@ let test_health_json_blocked_count_matches_blocked_names_with_non_target_capacit
             ~name:"non-target-running"
             ~trace_id:"trace-non-target-running"
             ()
+          |> fun meta -> { meta with proactive = { enabled = false } }
         in
         List.iter
           (write_keeper_meta_exn config)
@@ -3021,7 +3022,9 @@ let test_health_json_blocked_count_matches_blocked_names_with_non_target_capacit
             let json = Server_routes_http_runtime.make_health_json request in
             let open Yojson.Safe.Util in
             let fleet_safety = json |> member "keeper_fleet_safety" in
-            Alcotest.(check int) "health counts all live executable capacity" 2
+            Alcotest.(check int)
+              "proactive-disabled Running keeper counts as reaction capacity"
+              2
               (fleet_safety |> member "executable_keeper_fiber_count" |> to_int);
             Alcotest.(check int) "capacity shortfall remains numeric capacity" 1
               (fleet_safety |> member "reaction_capacity_shortfall_count" |> to_int);


### PR DESCRIPTION
## As-Is

The live full-health verdict reports only one operator-action reason: reaction_capacity_below_target. rtprobe is phase Running with a live fiber and autoboot enabled, but proactive_enabled=false makes the autonomous classifier exclude it from the field explicitly named reaction_capacity.

## To-Be

Build the canonical execution snapshot with the existing durable-demand classifier. This ignores only the proactive gate for explicit/reactive work while preserving lifecycle denial, shutdown fencing, autoboot/global autonomous admission, terminal phase, and live-fiber checks. The supervisor remains on the proactive-required classifier.

## Evidence

- live /health?full=1: target=8, executable=7, sole blocked keeper rtprobe, non_executable_cause=proactive_disabled, phase=running
- source diff: one production file, one changed call
- independent adversarial source review: P1/P2 none

## Fast checks

- ocamlformat --check changed file
- ocamlc -stop-after parsing changed file
- git diff --check
- OCaml structure ratchet

No local Dune build. CI, merge, deployment, and post-deploy live/browser verification are pending.

# ci:skip-test-coverage