### PR TITLE
feat(dashboard): expose Keeper persistence duration tiers

### DIFF
--- a/dashboard/e2e/keeper-composition-real-backend.mjs
+++ b/dashboard/e2e/keeper-composition-real-backend.mjs
@@ -21,6 +21,8 @@ if (!token) throw new Error('dashboard token file is empty')
 mkdirSync(artifactDir, { recursive: true })
 const screenshotPath = join(artifactDir, 'keeper-composition-inspector.png')
 const measurementPath = join(artifactDir, 'keeper-composition-inspector.json')
+const persistenceScreenshotPath = join(artifactDir, 'keeper-persistence-proof.png')
+const persistenceMeasurementPath = join(artifactDir, 'keeper-persistence-proof.json')
 const viewport = { width: 1440, height: 1000 }
 
 const healthResponse = await fetch(new URL('/health?full=1', dashboardUrl))
@@ -100,7 +102,142 @@ try {
     screenshot_sha256: createHash('sha256').update(screenshot).digest('hex'),
   }
   writeFileSync(measurementPath, `${JSON.stringify(measurement, null, 2)}\n`)
-  process.stdout.write(`${JSON.stringify(measurement)}\n`)
+
+  route.hash = 'workspace?section=verification'
+  await page.goto(route.toString())
+  const persistencePanel = page.getByTestId('keeper-persistence-proof-panel')
+  await persistencePanel.waitFor()
+  const persistenceCards = persistencePanel.locator('[data-tier-id][data-evidence-kind]')
+  await persistenceCards.first().waitFor()
+  const persistenceRefresh = page.getByTestId('keeper-persistence-proof-refresh')
+  const [persistenceResponse] = await Promise.all([
+    page.waitForResponse(response =>
+      response.url().includes('/api/v1/dashboard/keeper-feature-proof') && response.ok(),
+    ),
+    persistenceRefresh.click(),
+  ])
+  const refreshedPayload = await persistenceResponse.json()
+  const refreshedGeneratedAt = refreshedPayload?.generated_at
+  if (typeof refreshedGeneratedAt !== 'string' || !Number.isFinite(Date.parse(refreshedGeneratedAt))) {
+    throw new Error('manual refresh response has no generated_at')
+  }
+  const persistenceFeatures = Array.isArray(refreshedPayload?.features)
+    ? refreshedPayload.features.filter(feature => feature?.id === 'persistent_24h_turn_exchange')
+    : []
+  if (persistenceFeatures.length !== 1) {
+    throw new Error(`manual refresh response has ${persistenceFeatures.length} persistence features`)
+  }
+  const refreshedTiers = persistenceFeatures[0]?.duration_tiers
+  if (!Array.isArray(refreshedTiers) || refreshedTiers.length !== 4) {
+    throw new Error('manual refresh response has no exact persistence duration tiers')
+  }
+  await page.waitForFunction(expectedGeneratedAt => {
+    const panel = document.querySelector('[data-testid="keeper-persistence-proof-panel"]')
+    const button = document.querySelector('[data-testid="keeper-persistence-proof-refresh"]')
+    return panel?.getAttribute('data-proof-generated-at') === expectedGeneratedAt
+      && button instanceof HTMLButtonElement
+      && !button.disabled
+  }, refreshedGeneratedAt)
+  const renderedTiers = await persistenceCards.evaluateAll(nodes => {
+    const countAttribute = (node, name) => {
+      const raw = node.getAttribute(name)
+      const parsed = Number(raw)
+      if (raw == null || !Number.isSafeInteger(parsed) || parsed < 0 || String(parsed) !== raw) {
+        throw new Error(`${name} must be a canonical non-negative integer, observed=${raw}`)
+      }
+      return parsed
+    }
+    return nodes.map(node => ({
+      id: node.getAttribute('data-tier-id'),
+      status: node.getAttribute('data-proof-status'),
+      evidence_kind: node.getAttribute('data-evidence-kind'),
+      observed_count: countAttribute(node, 'data-observed-count'),
+      keeper_count: countAttribute(node, 'data-keeper-count'),
+      missing_count: countAttribute(node, 'data-missing-count'),
+    }))
+  })
+  const expectedTierIds = ['1h', '2h', '4h', '24h']
+  if (JSON.stringify(renderedTiers.map(tier => tier.id)) !== JSON.stringify(expectedTierIds)) {
+    throw new Error(`unexpected persistence tier order: ${JSON.stringify(renderedTiers)}`)
+  }
+  const tiers = renderedTiers.map((rendered, index) => {
+    const responseTier = refreshedTiers[index]
+    const observedKeepers = responseTier?.observed_keepers
+    const missingKeepers = responseTier?.missing_keepers
+    if (responseTier?.id !== rendered.id
+      || responseTier?.status !== rendered.status
+      || responseTier?.evidence_kind !== rendered.evidence_kind
+      || responseTier?.observed_count !== rendered.observed_count
+      || responseTier?.keeper_count !== rendered.keeper_count
+      || responseTier?.missing_count !== rendered.missing_count
+      || !Array.isArray(observedKeepers)
+      || !Array.isArray(missingKeepers)
+      || observedKeepers.some(name => typeof name !== 'string' || !name.trim())
+      || missingKeepers.some(name => typeof name !== 'string' || !name.trim())) {
+      throw new Error(`rendered persistence tier differs from response: ${JSON.stringify({ rendered, responseTier })}`)
+    }
+    return {
+      ...rendered,
+      observed_keepers: observedKeepers,
+      missing_keepers: missingKeepers,
+    }
+  })
+  const fleet = new Set([...tiers[0].observed_keepers, ...tiers[0].missing_keepers])
+  for (const [index, tier] of tiers.entries()) {
+    if (!['pass', 'warn', 'fail'].includes(tier.status)) {
+      throw new Error(`unexpected persistence status: ${JSON.stringify(tier)}`)
+    }
+    if (tier.evidence_kind !== 'durable_turn_span') {
+      throw new Error(`unexpected persistence evidence kind: ${JSON.stringify(tier)}`)
+    }
+    if (![tier.observed_count, tier.keeper_count, tier.missing_count].every(Number.isSafeInteger)) {
+      throw new Error(`non-integer persistence count: ${JSON.stringify(tier)}`)
+    }
+    if (tier.observed_count < 0 || tier.missing_count < 0
+      || tier.observed_count + tier.missing_count !== tier.keeper_count) {
+      throw new Error(`inconsistent persistence counts: ${JSON.stringify(tier)}`)
+    }
+    const observed = new Set(tier.observed_keepers)
+    const missing = new Set(tier.missing_keepers)
+    const tierFleet = new Set([...observed, ...missing])
+    if (observed.size !== tier.observed_count || missing.size !== tier.missing_count
+      || tierFleet.size !== tier.keeper_count
+      || tierFleet.size !== fleet.size
+      || [...fleet].some(name => !tierFleet.has(name))
+      || [...observed].some(name => missing.has(name))) {
+      throw new Error(`inconsistent persistence identities: ${JSON.stringify(tier)}`)
+    }
+    if (index > 0) {
+      const previous = tiers[index - 1]
+      const previousObserved = new Set(previous.observed_keepers)
+      const previousMissing = new Set(previous.missing_keepers)
+      if ([...observed].some(name => !previousObserved.has(name))
+        || [...previousMissing].some(name => !missing.has(name))) {
+        throw new Error(`non-monotonic persistence identities: ${JSON.stringify(tiers)}`)
+      }
+    }
+  }
+  const generatedAt = await persistencePanel.getAttribute('data-proof-generated-at')
+  if (!generatedAt) throw new Error('persistence proof generated_at is absent')
+  const persistenceScreenshot = await page.screenshot({
+    path: persistenceScreenshotPath,
+    fullPage: true,
+  })
+  const persistenceMeasurement = {
+    schema: 'masc.keeper_persistence_browser_evidence.v1',
+    generated_at: generatedAt,
+    interaction: 'manual_refresh',
+    tiers,
+    viewport,
+    screenshot_file: 'keeper-persistence-proof.png',
+    screenshot_bytes: persistenceScreenshot.byteLength,
+    screenshot_sha256: createHash('sha256').update(persistenceScreenshot).digest('hex'),
+  }
+  writeFileSync(
+    persistenceMeasurementPath,
+    `${JSON.stringify(persistenceMeasurement, null, 2)}\n`,
+  )
+  process.stdout.write(`${JSON.stringify({ composition: measurement, persistence: persistenceMeasurement })}\n`)
 } finally {
   await browser.close()
 }

--- a/dashboard/src/api/dashboard-keeper-feature-proof.test.ts
+++ b/dashboard/src/api/dashboard-keeper-feature-proof.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest'
+import { parseKeeperPersistenceProofResponse } from './dashboard-keeper-feature-proof'
+
+const tier = (
+  id: '1h' | '2h' | '4h' | '24h',
+  requiredSpanHours: number,
+  observedKeepers: string[],
+  missingKeepers: string[],
+) => ({
+  id,
+  evidence_kind: 'durable_turn_span',
+  required_span_hours: requiredSpanHours,
+  status: observedKeepers.length === 0
+    ? 'fail'
+    : missingKeepers.length === 0 ? 'pass' : 'warn',
+  keeper_count: observedKeepers.length + missingKeepers.length,
+  observed_count: observedKeepers.length,
+  missing_count: missingKeepers.length,
+  observed_keepers: observedKeepers,
+  missing_keepers: missingKeepers,
+})
+
+function payload() {
+  return {
+    generated_at: '2026-08-14T12:00:00Z',
+    status: 'warn',
+    summary: { feature_count: 5 },
+    features: [
+      {
+        id: 'persistent_24h_turn_exchange',
+        status: 'warn',
+        summary: '1/2 keepers have durable turn spans >= 24h',
+        duration_tiers: [
+          tier('1h', 1, ['keeper-a', 'keeper-b'], []),
+          tier('2h', 2, ['keeper-a', 'keeper-b'], []),
+          tier('4h', 4, ['keeper-a'], ['keeper-b']),
+          tier('24h', 24, ['keeper-a'], ['keeper-b']),
+        ],
+      },
+    ],
+    evidence_refs: [],
+  }
+}
+
+function persistenceFeature(raw: ReturnType<typeof payload>) {
+  const [feature] = raw.features
+  if (feature == null) throw new Error('persistence fixture is absent')
+  return feature
+}
+
+function durationTier(raw: ReturnType<typeof payload>, index: number) {
+  const value = persistenceFeature(raw).duration_tiers[index]
+  if (value == null) throw new Error(`duration tier fixture ${index} is absent`)
+  return value
+}
+
+describe('parseKeeperPersistenceProofResponse', () => {
+  it('projects the exact ordered durable turn-span tiers', () => {
+    const parsed = parseKeeperPersistenceProofResponse(payload())
+
+    expect(parsed.generatedAt).toBe('2026-08-14T12:00:00Z')
+    expect(parsed.status).toBe('warn')
+    expect(parsed.tiers.map(value => value.id)).toEqual(['1h', '2h', '4h', '24h'])
+    expect(parsed.tiers[2]).toEqual({
+      id: '4h',
+      requiredSpanHours: 4,
+      status: 'warn',
+      evidenceKind: 'durable_turn_span',
+      keeperCount: 2,
+      observedCount: 1,
+      missingCount: 1,
+      observedKeepers: ['keeper-a'],
+      missingKeepers: ['keeper-b'],
+    })
+  })
+
+  it('rejects a tier status that disagrees with its evidence counts', () => {
+    const raw = payload()
+    durationTier(raw, 2).status = 'pass'
+
+    expect(() => parseKeeperPersistenceProofResponse(raw)).toThrow(
+      'does not match derived status=warn',
+    )
+  })
+
+  it('rejects duplicate or overlapping keeper evidence', () => {
+    const duplicate = payload()
+    durationTier(duplicate, 0).observed_keepers = ['keeper-a', 'keeper-a']
+    expect(() => parseKeeperPersistenceProofResponse(duplicate)).toThrow(
+      'must not contain duplicate keepers',
+    )
+
+    const overlap = payload()
+    durationTier(overlap, 2).missing_keepers = ['keeper-a']
+    expect(() => parseKeeperPersistenceProofResponse(overlap)).toThrow(
+      'observed and missing keepers must not overlap',
+    )
+  })
+
+  it('rejects reordered tiers and a feature status that disagrees with 24h', () => {
+    const reordered = payload()
+    const tiers = persistenceFeature(reordered).duration_tiers
+    const first = durationTier(reordered, 0)
+    tiers[0] = durationTier(reordered, 1)
+    tiers[1] = first
+    expect(() => parseKeeperPersistenceProofResponse(reordered)).toThrow(
+      'duration_tiers[0].id must be 1h',
+    )
+
+    const mismatch = payload()
+    persistenceFeature(mismatch).status = 'pass'
+    expect(() => parseKeeperPersistenceProofResponse(mismatch)).toThrow(
+      'must match the 24h tier status',
+    )
+  })
+
+  it('rejects cross-tier fleet drift and non-monotonic duration evidence', () => {
+    const fleetDrift = payload()
+    durationTier(fleetDrift, 3).missing_keepers = ['keeper-c']
+    expect(() => parseKeeperPersistenceProofResponse(fleetDrift)).toThrow(
+      'must describe the same Keeper fleet',
+    )
+
+    const nonMonotonic = payload()
+    durationTier(nonMonotonic, 2).observed_keepers = ['keeper-b']
+    durationTier(nonMonotonic, 2).missing_keepers = ['keeper-a']
+    expect(() => parseKeeperPersistenceProofResponse(nonMonotonic)).toThrow(
+      'violates duration monotonicity',
+    )
+  })
+})

--- a/dashboard/src/api/dashboard-keeper-feature-proof.ts
+++ b/dashboard/src/api/dashboard-keeper-feature-proof.ts
@@ -1,0 +1,203 @@
+// MASC Dashboard — durable Keeper persistence proof projection.
+//
+// Backend: GET /api/v1/dashboard/keeper-feature-proof
+//
+// The endpoint carries several feature proofs. This decoder deliberately
+// projects only the persistence feature and rejects internally inconsistent
+// tier evidence instead of rendering plausible-looking counters.
+
+import { isRecord } from '../components/common/normalize'
+import { get, type AbortableRequestOptions } from './core'
+
+export type KeeperFeatureProofStatus = 'pass' | 'warn' | 'fail'
+export type KeeperPersistenceTierId = '1h' | '2h' | '4h' | '24h'
+export type KeeperPersistenceEvidenceKind = 'durable_turn_span'
+
+export interface KeeperPersistenceTierProof {
+  id: KeeperPersistenceTierId
+  requiredSpanHours: number
+  status: KeeperFeatureProofStatus
+  evidenceKind: KeeperPersistenceEvidenceKind
+  keeperCount: number
+  observedCount: number
+  missingCount: number
+  observedKeepers: string[]
+  missingKeepers: string[]
+}
+
+export interface DashboardKeeperPersistenceProofResponse {
+  generatedAt: string
+  status: KeeperFeatureProofStatus
+  summary: string
+  tiers: KeeperPersistenceTierProof[]
+}
+
+const EXPECTED_TIERS = [
+  { id: '1h', requiredSpanHours: 1 },
+  { id: '2h', requiredSpanHours: 2 },
+  { id: '4h', requiredSpanHours: 4 },
+  { id: '24h', requiredSpanHours: 24 },
+] as const
+
+function protocolError(message: string): never {
+  throw new Error(`Invalid Keeper persistence proof response: ${message}`)
+}
+
+function nonEmptyString(value: unknown, context: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    protocolError(`${context} must be a non-empty string`)
+  }
+  return value
+}
+
+function isoTimestamp(value: unknown, context: string): string {
+  const timestamp = nonEmptyString(value, context)
+  if (!Number.isFinite(Date.parse(timestamp))) {
+    protocolError(`${context} must be a valid timestamp`)
+  }
+  return timestamp
+}
+
+function nonNegativeInteger(value: unknown, context: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    protocolError(`${context} must be a non-negative safe integer`)
+  }
+  return value as number
+}
+
+function proofStatus(value: unknown, context: string): KeeperFeatureProofStatus {
+  if (value !== 'pass' && value !== 'warn' && value !== 'fail') {
+    protocolError(`${context} has unknown status ${JSON.stringify(value)}`)
+  }
+  return value
+}
+
+function keeperNames(value: unknown, context: string): string[] {
+  if (!Array.isArray(value)) protocolError(`${context} must be an array`)
+  const names = value.map((name, index) => nonEmptyString(name, `${context}[${index}]`))
+  if (new Set(names).size !== names.length) {
+    protocolError(`${context} must not contain duplicate keepers`)
+  }
+  return names
+}
+
+function expectedStatus(keeperCount: number, observedCount: number): KeeperFeatureProofStatus {
+  if (keeperCount === 0 || observedCount === 0) return 'fail'
+  if (observedCount === keeperCount) return 'pass'
+  return 'warn'
+}
+
+function sameNames(left: ReadonlySet<string>, right: ReadonlySet<string>): boolean {
+  return left.size === right.size && [...left].every(name => right.has(name))
+}
+
+function parseTier(
+  raw: unknown,
+  index: number,
+): KeeperPersistenceTierProof {
+  const context = `persistence.duration_tiers[${index}]`
+  if (!isRecord(raw)) protocolError(`${context} must be an object`)
+  const expected = EXPECTED_TIERS[index]
+  if (expected == null) protocolError('persistence.duration_tiers contains an unexpected tier')
+  if (raw.id !== expected.id) {
+    protocolError(`${context}.id must be ${expected.id}`)
+  }
+  if (raw.required_span_hours !== expected.requiredSpanHours) {
+    protocolError(`${context}.required_span_hours must be ${expected.requiredSpanHours}`)
+  }
+  if (raw.evidence_kind !== 'durable_turn_span') {
+    protocolError(`${context}.evidence_kind must be durable_turn_span`)
+  }
+  const keeperCount = nonNegativeInteger(raw.keeper_count, `${context}.keeper_count`)
+  const observedCount = nonNegativeInteger(raw.observed_count, `${context}.observed_count`)
+  const missingCount = nonNegativeInteger(raw.missing_count, `${context}.missing_count`)
+  const observedKeepers = keeperNames(raw.observed_keepers, `${context}.observed_keepers`)
+  const missingKeepers = keeperNames(raw.missing_keepers, `${context}.missing_keepers`)
+  if (observedCount !== observedKeepers.length || missingCount !== missingKeepers.length) {
+    protocolError(`${context} counts must match keeper arrays`)
+  }
+  if (observedCount + missingCount !== keeperCount) {
+    protocolError(`${context} observed_count + missing_count must equal keeper_count`)
+  }
+  const observed = new Set(observedKeepers)
+  if (missingKeepers.some(name => observed.has(name))) {
+    protocolError(`${context} observed and missing keepers must not overlap`)
+  }
+  const status = proofStatus(raw.status, `${context}.status`)
+  const derivedStatus = expectedStatus(keeperCount, observedCount)
+  if (status !== derivedStatus) {
+    protocolError(`${context}.status=${status} does not match derived status=${derivedStatus}`)
+  }
+  return {
+    id: expected.id,
+    requiredSpanHours: expected.requiredSpanHours,
+    status,
+    evidenceKind: 'durable_turn_span',
+    keeperCount,
+    observedCount,
+    missingCount,
+    observedKeepers,
+    missingKeepers,
+  }
+}
+
+export function parseKeeperPersistenceProofResponse(
+  raw: unknown,
+): DashboardKeeperPersistenceProofResponse {
+  if (!isRecord(raw)) protocolError('root must be an object')
+  const generatedAt = isoTimestamp(raw.generated_at, 'root.generated_at')
+  if (!Array.isArray(raw.features)) protocolError('root.features must be an array')
+  const matches = raw.features.filter(
+    feature => isRecord(feature) && feature.id === 'persistent_24h_turn_exchange',
+  )
+  if (matches.length !== 1) {
+    protocolError(`expected exactly one persistent_24h_turn_exchange feature, found ${matches.length}`)
+  }
+  const feature = matches[0]
+  if (!isRecord(feature)) protocolError('persistence feature must be an object')
+  if (!Array.isArray(feature.duration_tiers)) {
+    protocolError('persistence.duration_tiers must be an array')
+  }
+  if (feature.duration_tiers.length !== EXPECTED_TIERS.length) {
+    protocolError(`persistence.duration_tiers must contain ${EXPECTED_TIERS.length} tiers`)
+  }
+  const tiers = feature.duration_tiers.map(parseTier)
+  const firstTier = tiers[0]
+  if (firstTier == null) protocolError('persistence.duration_tiers must not be empty')
+  const fleet = new Set([...firstTier.observedKeepers, ...firstTier.missingKeepers])
+  for (let index = 1; index < tiers.length; index += 1) {
+    const previous = tiers[index - 1]
+    const current = tiers[index]
+    if (previous == null || current == null) {
+      protocolError(`persistence.duration_tiers[${index}] is absent`)
+    }
+    const currentFleet = new Set([...current.observedKeepers, ...current.missingKeepers])
+    if (current.keeperCount !== firstTier.keeperCount || !sameNames(fleet, currentFleet)) {
+      protocolError(`persistence.duration_tiers[${index}] must describe the same Keeper fleet`)
+    }
+    const previousObserved = new Set(previous.observedKeepers)
+    const currentMissing = new Set(current.missingKeepers)
+    if (current.observedKeepers.some(name => !previousObserved.has(name))
+      || previous.missingKeepers.some(name => !currentMissing.has(name))) {
+      protocolError(`persistence.duration_tiers[${index}] violates duration monotonicity`)
+    }
+  }
+  const status = proofStatus(feature.status, 'persistence.status')
+  const tier24h = tiers[tiers.length - 1]
+  if (tier24h == null || status !== tier24h.status) {
+    protocolError('persistence.status must match the 24h tier status')
+  }
+  return {
+    generatedAt,
+    status,
+    summary: nonEmptyString(feature.summary, 'persistence.summary'),
+    tiers,
+  }
+}
+
+export async function fetchKeeperPersistenceProof(
+  opts?: AbortableRequestOptions,
+): Promise<DashboardKeeperPersistenceProofResponse> {
+  const raw = await get<unknown>('/api/v1/dashboard/keeper-feature-proof', { signal: opts?.signal })
+  return parseKeeperPersistenceProofResponse(raw)
+}

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -62,6 +62,17 @@ export {
   parseVerificationRunsResponse,
   fetchVerificationRuns,
 } from './dashboard-verification-runs'
+export type {
+  KeeperFeatureProofStatus,
+  KeeperPersistenceTierId,
+  KeeperPersistenceEvidenceKind,
+  KeeperPersistenceTierProof,
+  DashboardKeeperPersistenceProofResponse,
+} from './dashboard-keeper-feature-proof'
+export {
+  parseKeeperPersistenceProofResponse,
+  fetchKeeperPersistenceProof,
+} from './dashboard-keeper-feature-proof'
 export {
   fetchExactLaneRun,
   fetchExactLaneRuns,

--- a/dashboard/src/components/fsm-hub-types.test.ts
+++ b/dashboard/src/components/fsm-hub-types.test.ts
@@ -11,6 +11,7 @@ import {
   MAX_OBSERVATIONS,
   MAX_TRANSITION_HISTORY,
   initialHubState,
+  operatorDispositionReasonLabel,
 } from './fsm-hub-types'
 import type { KeeperCompositeSnapshot } from '../api/keeper'
 
@@ -182,6 +183,14 @@ describe('failureReasonLabel', () => {
     expect(failureReasonLabel(undefined)).toBeNull()
     expect(failureReasonLabel('')).toBeNull()
     expect(failureReasonLabel('   ')).toBeNull()
+  })
+})
+
+describe('operatorDispositionReasonLabel', () => {
+  it('labels a fenced provider effect without exposing the raw token', () => {
+    expect(operatorDispositionReasonLabel('provider_attempt_effect_fenced')).toBe(
+      'Provider 효과 결과 확인 필요',
+    )
   })
 })
 

--- a/dashboard/src/components/fsm-hub-types.test.ts
+++ b/dashboard/src/components/fsm-hub-types.test.ts
@@ -11,6 +11,7 @@ import {
   MAX_OBSERVATIONS,
   MAX_TRANSITION_HISTORY,
   initialHubState,
+  isTurnTerminalFailureCode,
   operatorDispositionReasonLabel,
 } from './fsm-hub-types'
 import type { KeeperCompositeSnapshot } from '../api/keeper'
@@ -191,6 +192,12 @@ describe('operatorDispositionReasonLabel', () => {
     expect(operatorDispositionReasonLabel('provider_attempt_effect_fenced')).toBe(
       'Provider 효과 결과 확인 필요',
     )
+  })
+})
+
+describe('isTurnTerminalFailureCode', () => {
+  it('treats a fenced provider attempt as terminal execution evidence', () => {
+    expect(isTurnTerminalFailureCode('provider_attempt_effect_fenced')).toBe(true)
   })
 })
 

--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -396,11 +396,14 @@ const OPERATOR_DISPOSITION_REASON_LABELS: Record<string, string> = {
   degraded_retry: '저하 상태 재시도',
   runtime_fallback: '런타임 폴백',
   transient_runtime_retry: '일시적 런타임 재시도',
+  capacity_backpressure: 'Provider 수용량 부족',
   provider_runtime_error: '런타임 호출 오류',
   internal_error: '내부 오류',
   input_required: '사용자 입력 대기',
   cancelled: '취소됨',
   phase_skipped: 'phase 건너뜀',
+  transcript_corruption: '대화 기록 손상 - 초기화 필요',
+  provider_attempt_effect_fenced: 'Provider 효과 결과 확인 필요',
   unmapped_runtime_state: '매핑되지 않은 runtime 상태',
 }
 

--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -353,6 +353,7 @@ const TURN_TERMINAL_FAILURE_CODES = new Set<string>([
   'provider_runtime_error',
   'fiber_unresolved',
   'stale_turn_timeout',
+  'provider_attempt_effect_fenced',
 ])
 
 export function isTurnTerminalFailureCode(code: string | null | undefined): boolean {

--- a/dashboard/src/components/keeper-detail-alert-strip.test.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.test.ts
@@ -68,6 +68,7 @@ describe('KeeperRuntimeAlertStrip', () => {
     ['runtime_exhausted', '런타임 후보 소진'],
     ['unmapped_runtime_state', '매핑되지 않은 runtime 상태'],
     ['transient_runtime_retry', '일시적 런타임 재시도'],
+    ['provider_attempt_effect_fenced', 'Provider 효과 결과 확인 필요'],
   ])('labels receipt-derived attention reason %s distinctly', (reason, label) => {
     const { container } = render(h(KeeperRuntimeAlertStrip, {
       keeper: keeper({
@@ -79,6 +80,22 @@ describe('KeeperRuntimeAlertStrip', () => {
     const text = container.textContent ?? ''
     expect(text).toContain(label)
     expect(text).not.toContain(reason)
+  })
+
+  it('humanizes the fenced provider effect in the operator disposition line', () => {
+    const { container } = render(h(KeeperRuntimeAlertStrip, {
+      keeper: keeper({
+        needs_attention: true,
+        trust: {
+          operator_disposition_reason: 'provider_attempt_effect_fenced',
+        },
+      }),
+    }))
+
+    const text = container.textContent ?? ''
+    expect(text).toContain('운영자 판단')
+    expect(text).toContain('Provider 효과 결과 확인 필요')
+    expect(text).not.toContain('provider_attempt_effect_fenced')
   })
 
   // First-class status_bridge reasons keep their OWN labels — they are no

--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -15,6 +15,7 @@ import { StrongSecondary, RuntimeBadge } from './keeper-detail-primitives'
 import {
   trustDispositionLabel,
   isTurnTerminalFailureCode,
+  operatorDispositionReasonLabel,
   type RuntimeAttemptObservation,
 } from './fsm-hub-types'
 import { keeperNeedsDiagnosticAttention, refreshAfterRuntimeAction } from './keeper-detail-helpers'
@@ -149,6 +150,7 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
     && !isTurnTerminalFailureCode(latestTerminalCode)
   const latestNextAction = canonicalNextHumanAction(keeper.trust?.latest_next_action?.trim() || null)
   const operatorDispositionReason = keeper.trust?.operator_disposition_reason?.trim() || null
+  const operatorDispositionReasonText = operatorDispositionReasonLabel(operatorDispositionReason)
   const shouldShowOperatorDispositionReason =
     operatorDispositionReason !== null && operatorDispositionReason !== trustSummary
   const executionSummary = keeper.trust?.execution_summary ?? null
@@ -366,7 +368,7 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
           ? html`<span title=${latestNextAction}><strong class="text-[var(--color-fg-secondary)]">권장 조치</strong> · ${nextHumanActionLabel(latestNextAction)}</span>`
           : null}
         ${shouldShowOperatorDispositionReason && operatorDispositionReason
-          ? html`<span><${StrongSecondary}>운영자 판단</${StrongSecondary}> · ${operatorDispositionReason}</span>`
+          ? html`<span><${StrongSecondary}>운영자 판단</${StrongSecondary}> · ${operatorDispositionReasonText}</span>`
           : null}
         ${trustDisposition
           ? html`

--- a/dashboard/src/components/keeper-persistence-proof-panel.test.ts
+++ b/dashboard/src/components/keeper-persistence-proof-panel.test.ts
@@ -1,0 +1,102 @@
+import { html } from 'htm/preact'
+import { cleanup, render, screen, waitFor, within } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import '@testing-library/jest-dom'
+
+const fetchProofMock = vi.hoisted(() => vi.fn())
+const unregisterMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../api/dashboard', () => ({
+  fetchKeeperPersistenceProof: fetchProofMock,
+}))
+
+vi.mock('../sse-store', () => ({
+  registerInternalAgentRefresh: vi.fn(() => unregisterMock),
+}))
+
+import { KeeperPersistenceProofPanel, keeperProofTone } from './keeper-persistence-proof-panel'
+
+const response = {
+  generatedAt: '2026-08-14T12:00:00Z',
+  status: 'warn' as const,
+  summary: '1/2 keepers have durable turn spans >= 24h',
+  tiers: [
+    {
+      id: '1h' as const,
+      requiredSpanHours: 1,
+      status: 'pass' as const,
+      evidenceKind: 'durable_turn_span' as const,
+      keeperCount: 2,
+      observedCount: 2,
+      missingCount: 0,
+      observedKeepers: ['keeper-a', 'keeper-b'],
+      missingKeepers: [],
+    },
+    {
+      id: '2h' as const,
+      requiredSpanHours: 2,
+      status: 'pass' as const,
+      evidenceKind: 'durable_turn_span' as const,
+      keeperCount: 2,
+      observedCount: 2,
+      missingCount: 0,
+      observedKeepers: ['keeper-a', 'keeper-b'],
+      missingKeepers: [],
+    },
+    {
+      id: '4h' as const,
+      requiredSpanHours: 4,
+      status: 'warn' as const,
+      evidenceKind: 'durable_turn_span' as const,
+      keeperCount: 2,
+      observedCount: 1,
+      missingCount: 1,
+      observedKeepers: ['keeper-a'],
+      missingKeepers: ['keeper-b'],
+    },
+    {
+      id: '24h' as const,
+      requiredSpanHours: 24,
+      status: 'warn' as const,
+      evidenceKind: 'durable_turn_span' as const,
+      keeperCount: 2,
+      observedCount: 1,
+      missingCount: 1,
+      observedKeepers: ['keeper-a'],
+      missingKeepers: ['keeper-b'],
+    },
+  ],
+}
+
+describe('KeeperPersistenceProofPanel', () => {
+  beforeEach(() => {
+    fetchProofMock.mockReset()
+    fetchProofMock.mockResolvedValue(response)
+    unregisterMock.mockClear()
+  })
+
+  afterEach(() => cleanup())
+
+  it('maps the closed proof status vocabulary to semantic tones', () => {
+    expect(keeperProofTone('pass')).toBe('ok')
+    expect(keeperProofTone('warn')).toBe('warn')
+    expect(keeperProofTone('fail')).toBe('bad')
+  })
+
+  it('renders all durable tiers and exposes missing Keeper evidence', async () => {
+    render(html`<${KeeperPersistenceProofPanel} />`)
+
+    const panel = await screen.findByTestId('keeper-persistence-proof-panel')
+    await waitFor(() => expect(fetchProofMock).toHaveBeenCalledTimes(1))
+    await screen.findByTestId('keeper-persistence-tier-24h')
+    expect(within(panel).getByText(/무중단 uptime 증거가 아닙니다/)).toBeTruthy()
+    expect(panel.getAttribute('data-proof-generated-at')).toBe(response.generatedAt)
+    for (const id of ['1h', '2h', '4h', '24h']) {
+      expect(within(panel).getByTestId(`keeper-persistence-tier-${id}`)).toBeTruthy()
+    }
+    const tier24h = within(panel).getByTestId('keeper-persistence-tier-24h')
+    expect(tier24h).toHaveAttribute('data-proof-status', 'warn')
+    expect(tier24h).toHaveAttribute('data-evidence-kind', 'durable_turn_span')
+    expect(within(tier24h).getByText('keeper-b')).toBeTruthy()
+  })
+})

--- a/dashboard/src/components/keeper-persistence-proof-panel.ts
+++ b/dashboard/src/components/keeper-persistence-proof-panel.ts
@@ -1,0 +1,162 @@
+// Verification workspace projection for durable Keeper turn-span evidence.
+//
+// This is deliberately not an uptime panel. A tier passes only when the
+// decision log contains enough ordered turn history; the explicit evidence
+// label keeps operators from reading durable history as process continuity.
+
+import { html } from 'htm/preact'
+import { useEffect } from 'preact/hooks'
+import {
+  fetchKeeperPersistenceProof,
+  type DashboardKeeperPersistenceProofResponse,
+  type KeeperFeatureProofStatus,
+  type KeeperPersistenceTierProof,
+} from '../api/dashboard'
+import type { ManagedAsyncResource } from '../lib/async-state'
+import { relativeTime } from '../lib/format-time'
+import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
+import { registerInternalAgentRefresh } from '../sse-store'
+import { Btn } from './btn'
+import { EmptyState, ErrorState } from './common/feedback-state'
+import { StatusBadge, type StatusBadgeTone } from './common/status-badge'
+
+export function keeperProofTone(status: KeeperFeatureProofStatus): StatusBadgeTone {
+  switch (status) {
+    case 'pass':
+      return 'ok'
+    case 'warn':
+      return 'warn'
+    case 'fail':
+      return 'bad'
+  }
+}
+
+function keeperProofLabel(status: KeeperFeatureProofStatus): string {
+  switch (status) {
+    case 'pass':
+      return '충족'
+    case 'warn':
+      return '부분 충족'
+    case 'fail':
+      return '미충족'
+  }
+}
+
+async function loadData(resource: ManagedAsyncResource<DashboardKeeperPersistenceProofResponse>) {
+  await resource.load(async signal => fetchKeeperPersistenceProof({ signal }))
+}
+
+function KeeperPersistenceTierCard({ tier }: { tier: KeeperPersistenceTierProof }) {
+  const observedLabel = tier.keeperCount === 0
+    ? '관찰할 Keeper 없음'
+    : `${tier.observedCount}/${tier.keeperCount} Keeper`
+  return html`
+    <article
+      class="rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] p-3"
+      data-testid=${`keeper-persistence-tier-${tier.id}`}
+      data-tier-id=${tier.id}
+      data-proof-status=${tier.status}
+      data-evidence-kind=${tier.evidenceKind}
+      data-observed-count=${tier.observedCount}
+      data-keeper-count=${tier.keeperCount}
+      data-missing-count=${tier.missingCount}
+    >
+      <div class="flex items-center justify-between gap-2">
+        <strong class="text-base tabular-nums text-[var(--color-fg-primary)]">${tier.id}</strong>
+        <${StatusBadge}
+          tone=${keeperProofTone(tier.status)}
+          label=${keeperProofLabel(tier.status)}
+        />
+      </div>
+      <div class="mt-2 text-sm font-medium tabular-nums text-[var(--color-fg-primary)]">
+        ${observedLabel}
+      </div>
+      <div class="mt-1 text-xs text-[var(--color-fg-muted)]">
+        durable turn span ≥ ${tier.requiredSpanHours}h
+      </div>
+      ${tier.missingKeepers.length > 0
+        ? html`
+            <details class="mt-2 text-xs text-[var(--color-fg-secondary)]">
+              <summary class="cursor-pointer">근거 부족 ${tier.missingCount}</summary>
+              <div class="mt-1 break-words" data-testid=${`keeper-persistence-missing-${tier.id}`}>
+                ${tier.missingKeepers.join(', ')}
+              </div>
+            </details>
+          `
+        : null}
+    </article>
+  `
+}
+
+export function KeeperPersistenceProofPanel() {
+  const resource = useManagedAsyncResource<DashboardKeeperPersistenceProofResponse>()
+
+  useEffect(() => {
+    void loadData(resource)
+    const unregister = registerInternalAgentRefresh(() => { void loadData(resource) })
+    return () => {
+      unregister()
+      resource.cancel()
+    }
+  }, [resource])
+
+  const current = resource.state.value
+  const data = current.data ?? null
+
+  return html`
+    <section
+      class="v2-workspace-surface flex flex-col gap-3"
+      data-testid="keeper-persistence-proof-panel"
+      data-proof-generated-at=${data?.generatedAt ?? ''}
+      aria-labelledby="keeper-persistence-proof-heading"
+    >
+      <div class="flex items-center gap-3 flex-wrap">
+        <h2
+          id="keeper-persistence-proof-heading"
+          class="text-sm font-semibold text-[var(--color-fg-primary)]"
+        >
+          Keeper 지속성 근거
+        </h2>
+        ${data
+          ? html`<${StatusBadge}
+              tone=${keeperProofTone(data.status)}
+              label=${keeperProofLabel(data.status)}
+            />`
+          : null}
+        <${Btn}
+          class="v2-workspace-action"
+          testId="keeper-persistence-proof-refresh"
+          disabled=${current.loading}
+          onClick=${() => void loadData(resource)}
+        >
+          새로고침
+        <//>
+        ${current.loading
+          ? html`<span class="text-xs text-[var(--color-fg-muted)]" role="status">로딩 중...</span>`
+          : null}
+        ${data?.generatedAt
+          ? html`<span class="text-xs text-[var(--color-fg-muted)]">
+              updated · ${relativeTime(data.generatedAt)}
+            </span>`
+          : null}
+      </div>
+
+      <p class="text-xs text-[var(--color-fg-muted)]">
+        decision log의 <strong>durable turn span</strong> 근거입니다. 무중단 uptime 증거가 아닙니다.
+      </p>
+
+      ${current.error
+        ? html`<${ErrorState}>Keeper 지속성 근거를 불러오지 못했습니다: ${current.error}<//>`
+        : data == null && !current.loading
+          ? html`<${EmptyState}>지속성 근거가 없습니다.<//>`
+          : data
+            ? html`
+                <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                  ${data.tiers.map(tier => html`<${KeeperPersistenceTierCard} key=${tier.id} tier=${tier} />`)}
+                </div>
+                <p class="text-xs text-[var(--color-fg-secondary)]">${data.summary}</p>
+              `
+            : null}
+    </section>
+  `
+}

--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -59,6 +59,14 @@ vi.mock('./verification-requests-panel', () => ({
   VerificationRequestsPanel: () => html`<div data-testid="verification-panel">Verification</div>`,
 }))
 
+vi.mock('./verification-runs-panel', () => ({
+  VerificationRunsPanel: () => html`<div data-testid="verification-runs-panel">Verification runs</div>`,
+}))
+
+vi.mock('./keeper-persistence-proof-panel', () => ({
+  KeeperPersistenceProofPanel: () => html`<div data-testid="keeper-persistence-proof-panel">Persistence proof</div>`,
+}))
+
 vi.mock('./repository-management', () => ({
   RepositoryManagement: () => html`<div data-testid="repository-panel">Repositories</div>`,
 }))
@@ -220,6 +228,8 @@ describe('Work', () => {
     render(html`<${Work} />`)
 
     expect(screen.getByTestId('verification-panel')).toBeTruthy()
+    expect(screen.getByTestId('verification-runs-panel')).toBeTruthy()
+    expect(screen.getByTestId('keeper-persistence-proof-panel')).toBeTruthy()
     expect(screen.queryByTestId('work-kpis')).toBeNull()
   })
 

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -16,6 +16,7 @@ import { SubBoardSurface } from './board/sub-board-surface'
 import { PlanningPanel } from './planning-panel'
 import { VerificationRequestsPanel } from './verification-requests-panel'
 import { VerificationRunsPanel } from './verification-runs-panel'
+import { KeeperPersistenceProofPanel } from './keeper-persistence-proof-panel'
 import { ErrorBoundary } from './common/error-boundary'
 import { LoadingState } from './common/feedback-state'
 import { SectionNav } from './common/section-nav'
@@ -1651,6 +1652,7 @@ export function Work() {
           `
           : html`
             <div class="flex flex-col gap-4">
+              <${KeeperPersistenceProofPanel} />
               <${VerificationRequestsPanel} />
               <${VerificationRunsPanel} />
             </div>

--- a/dashboard/src/lib/keeper-attention-labels.drift.test.ts
+++ b/dashboard/src/lib/keeper-attention-labels.drift.test.ts
@@ -1,7 +1,8 @@
 // Build-time drift guard for the keeper attention vocabulary.
 //
 // The backend is the single source of truth for `attention_reason` /
-// `next_human_action` wire codes — they are string literals emitted from OCaml.
+// `next_human_action` wire codes — they are literals or canonical shared
+// constants emitted from OCaml.
 // keeper-attention-labels.ts hand-mirrors that vocabulary, and that mirror
 // silently drifted before: the backend emitted `stale_turn_timeout` for a
 // release while the frontend union had no arm for it, so the dashboard showed
@@ -84,20 +85,41 @@ function executionReceiptAttentionReasons(): string[] {
     'operator_disposition_reason_to_string present in keeper_execution_receipt.ml',
   ).toBeGreaterThan(-1)
   const body = src.slice(start, src.indexOf(';;', start))
-  return [...body.matchAll(/-> "([a-z_]+)"/g)]
+  const literalReasons = [...body.matchAll(/-> "([a-z_]+)"/g)]
     .map((m) => m[1])
     .filter((token): token is string => token !== undefined)
+  const internalErrorSrc = read('lib/keeper_runtime/keeper_internal_error.ml')
+  const internalErrorConstants = new Map<string, string>()
+  for (const match of internalErrorSrc.matchAll(/^let ([a-z_]+) = "([a-z_]+)"$/gm)) {
+    const name = match[1]
+    const value = match[2]
+    if (name !== undefined && value !== undefined) internalErrorConstants.set(name, value)
+  }
+  const sharedConstantReasons = [
+    ...body.matchAll(/->\s*Keeper_internal_error\.([a-z_]+)/g),
+  ].map((m) => {
+    const name = m[1]
+    const value = name === undefined ? undefined : internalErrorConstants.get(name)
+    expect(
+      value,
+      `Keeper_internal_error.${name ?? '<missing>'} resolves to a canonical string`,
+    ).toBeDefined()
+    return value as string
+  })
+  return [...literalReasons, ...sharedConstantReasons]
 }
 
 // keeper_runtime_trust_snapshot.ml only promotes receipt disposition reasons to
 // `attention_reason` when the derived display disposition needs attention.
-// These receipt reasons are tied to pass/skipped dispositions and should stay
-// out of the attention label union unless the backend changes that contract.
-const EXECUTION_RECEIPT_PASS_ONLY_REASONS: ReadonlySet<string> = new Set([
+// These receipt reasons currently map to display dispositions that do not
+// require attention. They should stay out of the attention label union unless
+// the backend changes that contract.
+const EXECUTION_RECEIPT_NON_ATTENTION_REASONS: ReadonlySet<string> = new Set([
   'healthy',
   'runtime_fallback',
   'phase_skipped',
   'input_required',
+  'capacity_backpressure',
 ])
 
 describe('keeper attention vocabulary drift guard', () => {
@@ -108,6 +130,9 @@ describe('keeper attention vocabulary drift guard', () => {
     expect(statusBridgeStandaloneActions().length).toBeGreaterThan(0)
     expect(dispositionActions().length).toBeGreaterThan(2)
     expect(executionReceiptAttentionReasons().length).toBeGreaterThan(4)
+    expect(executionReceiptAttentionReasons()).toContain(
+      'provider_attempt_effect_fenced',
+    )
   })
 
   it('every keeper_status_bridge attention_reason has a frontend label', () => {
@@ -143,7 +168,7 @@ describe('keeper attention vocabulary drift guard', () => {
 
   it('every dashboard attention-worthy execution receipt reason has a frontend label', () => {
     const attentionWorthy = executionReceiptAttentionReasons().filter(
-      (reason) => !EXECUTION_RECEIPT_PASS_ONLY_REASONS.has(reason),
+      (reason) => !EXECUTION_RECEIPT_NON_ATTENTION_REASONS.has(reason),
     )
     const missing = [...new Set(attentionWorthy)].filter((reason) => !isAttentionReason(reason))
     expect(

--- a/dashboard/src/lib/keeper-attention-labels.test.ts
+++ b/dashboard/src/lib/keeper-attention-labels.test.ts
@@ -17,6 +17,15 @@ describe('keeper attention labels', () => {
     expect(warn).not.toHaveBeenCalled()
   })
 
+  it('labels a fenced provider effect without exposing the raw token', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    expect(attentionReasonLabel('provider_attempt_effect_fenced', false)).toBe(
+      'Provider 효과 결과 확인 필요',
+    )
+    expect(warn).not.toHaveBeenCalled()
+  })
+
   it('labels typed next actions without warning', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 

--- a/dashboard/src/lib/keeper-attention-labels.ts
+++ b/dashboard/src/lib/keeper-attention-labels.ts
@@ -57,6 +57,7 @@ export const ATTENTION_REASONS = [
   'internal_error',
   'cancelled',
   'transcript_corruption',
+  'provider_attempt_effect_fenced',
   'unmapped_runtime_state',
 ] as const
 export type AttentionReason = typeof ATTENTION_REASONS[number]
@@ -78,6 +79,7 @@ const ATTENTION_REASON_LABELS: Record<AttentionReason, string> = {
   internal_error: '내부 오류',
   cancelled: '취소됨',
   transcript_corruption: '대화 기록 손상 - 초기화 필요',
+  provider_attempt_effect_fenced: 'Provider 효과 결과 확인 필요',
   unmapped_runtime_state: '매핑되지 않은 runtime 상태',
 }
 

--- a/lib/dashboard/dashboard_keeper_decision_log_proof.ml
+++ b/lib/dashboard/dashboard_keeper_decision_log_proof.ml
@@ -194,7 +194,7 @@ type segment_head_scan =
   | Complete_without_turn
   | Scan_exhausted
 
-let earliest_turn_ts_in_segment path =
+let earliest_turn_ts_in_segment ~now path =
   let slice = Fs_compat.read_slice ~path ~from:0 ~len:decision_head_max_bytes in
   let turn =
     String.split_on_char '\n' slice
@@ -206,7 +206,10 @@ let earliest_turn_ts_in_segment path =
         | exception Yojson.Json_error _ -> None
         | json ->
           if is_turn_exchange_channel (Safe_ops.json_string_opt "channel" json)
-          then decision_ts_unix json
+          then
+            (match decision_ts_unix json with
+             | Some ts when ts <= now -> Some ts
+             | Some _ | None -> None)
           else None)
   in
   match turn with
@@ -216,29 +219,30 @@ let earliest_turn_ts_in_segment path =
      | Some size when size <= String.length slice -> Complete_without_turn
      | Some _ | None -> Scan_exhausted)
 
-let earliest_turn_ts segments =
+let earliest_turn_ts ~now segments =
   let rec scan = function
     | [] -> None, No_turn_row_in_history
     | (rotation, path) :: rest ->
-      (match earliest_turn_ts_in_segment path with
+      (match earliest_turn_ts_in_segment ~now path with
        | Turn_found ts -> Some ts, History_head rotation
        | Complete_without_turn -> scan rest
        | Scan_exhausted -> None, History_scan_exhausted rotation)
   in
   scan segments
 
-let turn_span_stats ~config keeper_name =
+let turn_span_stats ~config ~now keeper_name =
   let tail =
     fold_keeper_decision_log ~config keeper_name ~init:empty_tail_scan
       ~f:(fun scan json ->
         if is_turn_exchange_channel (Safe_ops.json_string_opt "channel" json) then
           match decision_ts_unix json with
-          | Some ts -> update_tail_scan scan ts
+          | Some ts when ts <= now -> update_tail_scan scan ts
+          | Some _ -> scan
           | None -> scan
         else scan)
   in
   let segments = decision_log_segments ~config keeper_name in
-  let first_ts, first_ts_origin = earliest_turn_ts segments in
+  let first_ts, first_ts_origin = earliest_turn_ts ~now segments in
   {
     recent_interaction_count = tail.count;
     first_ts;

--- a/lib/dashboard/dashboard_keeper_decision_log_proof.ml
+++ b/lib/dashboard/dashboard_keeper_decision_log_proof.ml
@@ -293,7 +293,6 @@ let latest_age_hours_json ~now stat =
 let has_persistent_turn_span_for ~required_span_hours ~now stat =
   Float.is_finite required_span_hours
   && required_span_hours > 0.0
-  && stat.recent_interaction_count >= 2
   &&
   match stat.first_ts, stat.latest_ts with
   | Some first, Some latest ->

--- a/lib/dashboard/dashboard_keeper_decision_log_proof.ml
+++ b/lib/dashboard/dashboard_keeper_decision_log_proof.ml
@@ -35,6 +35,20 @@ type turn_span_stat = {
 let seconds_per_hour = Masc_time_constants.hour
 let persistent_turn_window_hours = 24.0
 let recent_turn_max_age_hours = 24.0
+
+type persistence_tier =
+  { id : string
+  ; required_span_hours : float
+  }
+
+let persistence_tiers =
+  [ { id = "1h"; required_span_hours = 1.0 }
+  ; { id = "2h"; required_span_hours = 2.0 }
+  ; { id = "4h"; required_span_hours = 4.0 }
+  ; { id = "24h"; required_span_hours = persistent_turn_window_hours }
+  ]
+;;
+
 let decision_tail_max_bytes = 512 * 1024
 let decision_tail_max_lines = 5000
 
@@ -272,14 +286,25 @@ let latest_age_hours_json ~now stat =
   | Some latest -> `Float (latest_age_hours ~now latest)
   | None -> `Null
 
-let has_persistent_turn_span ~now stat =
-  stat.recent_interaction_count >= 2
+let has_persistent_turn_span_for ~required_span_hours ~now stat =
+  Float.is_finite required_span_hours
+  && required_span_hours > 0.0
+  && stat.recent_interaction_count >= 2
   &&
   match stat.first_ts, stat.latest_ts with
   | Some first, Some latest ->
-    hours_between first latest >= persistent_turn_window_hours
+    first <= latest
+    && latest <= now
+    && hours_between first latest >= required_span_hours
     && latest_age_hours ~now latest <= recent_turn_max_age_hours
   | _ -> false
+
+let has_persistent_turn_span ~now stat =
+  has_persistent_turn_span_for
+    ~required_span_hours:persistent_turn_window_hours
+    ~now
+    stat
+;;
 
 let turn_span_evidence_json ~now keeper_name stat =
   `Assoc [

--- a/lib/dashboard/dashboard_keeper_decision_log_proof.mli
+++ b/lib/dashboard/dashboard_keeper_decision_log_proof.mli
@@ -23,6 +23,7 @@ val scheduled_evidence_json : scheduled_stat -> Yojson.Safe.t
 
 val turn_span_stats :
   config:Workspace.config ->
+  now:float ->
   string ->
   turn_span_stat
 

--- a/lib/dashboard/dashboard_keeper_decision_log_proof.mli
+++ b/lib/dashboard/dashboard_keeper_decision_log_proof.mli
@@ -7,6 +7,11 @@ type scheduled_stat = {
 
 type turn_span_stat
 
+type persistence_tier =
+  { id : string
+  ; required_span_hours : float
+  }
+
 val empty_scheduled_stat : scheduled_stat
 
 val scheduled_stats :
@@ -26,8 +31,15 @@ val has_persistent_turn_span :
   turn_span_stat ->
   bool
 
+val has_persistent_turn_span_for :
+  required_span_hours:float ->
+  now:float ->
+  turn_span_stat ->
+  bool
+
 val persistent_turn_window_hours : float
 val recent_turn_max_age_hours : float
+val persistence_tiers : persistence_tier list
 
 val turn_span_evidence_json :
   now:float ->

--- a/lib/dashboard/dashboard_keeper_feature_proof.ml
+++ b/lib/dashboard/dashboard_keeper_feature_proof.ml
@@ -214,12 +214,12 @@ let persistent_turn_exchange_feature ~config ~now snapshots =
   let stats =
     snapshots
     |> List.map (fun snapshot ->
-      snapshot.keeper_name, Decision.turn_span_stats ~config snapshot.keeper_name)
+      snapshot.keeper_name, Decision.turn_span_stats ~config ~now snapshot.keeper_name)
   in
   let stat_for keeper_name =
     match List.assoc_opt keeper_name stats with
     | Some stat -> stat
-    | None -> Decision.turn_span_stats ~config keeper_name
+    | None -> Decision.turn_span_stats ~config ~now keeper_name
   in
   let observed =
     snapshots

--- a/lib/dashboard/dashboard_keeper_feature_proof.ml
+++ b/lib/dashboard/dashboard_keeper_feature_proof.ml
@@ -249,6 +249,46 @@ let persistent_turn_exchange_feature ~config ~now snapshots =
       Decision.turn_span_evidence_json ~now snapshot.keeper_name
         (stat_for snapshot.keeper_name))
   in
+  let duration_tiers =
+    Decision.persistence_tiers
+    |> List.map (fun (tier : Decision.persistence_tier) ->
+      let observed_keepers, missing_keepers =
+        snapshots
+        |> List.partition (fun snapshot ->
+          Decision.has_persistent_turn_span_for
+            ~required_span_hours:tier.required_span_hours
+            ~now
+            (stat_for snapshot.keeper_name))
+      in
+      let observed_keepers =
+        observed_keepers
+        |> List.map (fun snapshot -> snapshot.keeper_name)
+        |> uniq_sorted
+      in
+      let missing_keepers =
+        missing_keepers
+        |> List.map (fun snapshot -> snapshot.keeper_name)
+        |> uniq_sorted
+      in
+      let tier_status =
+        if total = 0 || observed_keepers = []
+        then Fail
+        else if List.length observed_keepers = total
+        then Pass
+        else Warn
+      in
+      `Assoc
+        [ "id", `String tier.id
+        ; "evidence_kind", `String "durable_turn_span"
+        ; "required_span_hours", `Float tier.required_span_hours
+        ; "status", `String (status_to_string tier_status)
+        ; "keeper_count", `Int total
+        ; "observed_count", `Int (List.length observed_keepers)
+        ; "missing_count", `Int (List.length missing_keepers)
+        ; "observed_keepers", Json_util.json_string_list observed_keepers
+        ; "missing_keepers", Json_util.json_string_list missing_keepers
+        ])
+  in
   `Assoc [
     ("id", `String "persistent_24h_turn_exchange");
     ("label", `String "24h persistent turn exchange");
@@ -273,6 +313,7 @@ let persistent_turn_exchange_feature ~config ~now snapshots =
        ("read_errors", `List (keeper_read_errors snapshots));
        ("per_keeper", `List per_keeper);
      ]);
+    ("duration_tiers", `List duration_tiers);
     ( "evidence_refs",
       `List [
         evidence_ref ~kind:"store" ~id:"keeper_decision_log"

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -95,6 +95,7 @@ type operator_disposition_reason =
   | Reason_cancelled
   | Reason_phase_skipped
   | Reason_transcript_corruption
+  | Reason_provider_attempt_effect_fenced
   | Reason_unmapped_runtime_state
 
 let operator_disposition_reason_to_string = function
@@ -111,6 +112,8 @@ let operator_disposition_reason_to_string = function
   | Reason_cancelled -> "cancelled"
   | Reason_phase_skipped -> "phase_skipped"
   | Reason_transcript_corruption -> "transcript_corruption"
+  | Reason_provider_attempt_effect_fenced ->
+    Keeper_internal_error.provider_attempt_effect_fenced_kind
   | Reason_unmapped_runtime_state -> "unmapped_runtime_state"
 ;;
 
@@ -156,6 +159,12 @@ let operator_disposition (receipt : t)
   | _ when input_required -> Disp_pass, Reason_input_required
   | Keeper_terminal_reason.Transcript_corruption _ ->
     Disp_operator_reset_required, Reason_transcript_corruption
+  | Keeper_terminal_reason.Provider_attempt_effect_fenced _ ->
+    (* Same-turn replay stays forbidden, and the runtime lifecycle remains
+       responsible for selecting a later turn. Keep the operator alert, but
+       classify the canonical typed failure instead of incrementing the
+       unmapped-state regression metric. *)
+    Disp_unknown, Reason_provider_attempt_effect_fenced
   | Keeper_terminal_reason.Runtime_exhausted _ ->
     Disp_fail_open_next_runtime, Reason_runtime_exhausted
   | Keeper_terminal_reason.Capacity_backpressure _ ->
@@ -223,6 +232,7 @@ let operator_disposition (receipt : t)
        | Config_or_auth _
        | Provider_runtime_failure _
        | Transcript_corruption _
+       | Provider_attempt_effect_fenced _
        | Internal_error _
        | Unknown _ -> false)
     then Disp_pass, Reason_healthy

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -212,6 +212,10 @@ type operator_disposition_reason =
   | Reason_cancelled
   | Reason_phase_skipped
   | Reason_transcript_corruption
+  | Reason_provider_attempt_effect_fenced
+  (** The provider attempt did not prove whether an effect occurred. Paired
+      with [Disp_unknown] so operator attention remains required, while the
+      receipt is no longer counted as an unmapped classifier regression. *)
   | Reason_unmapped_runtime_state
 
 val operator_disposition_reason_to_string : operator_disposition_reason -> string

--- a/lib/keeper/keeper_tool_composition_surface.ml
+++ b/lib/keeper/keeper_tool_composition_surface.ml
@@ -884,7 +884,7 @@ let make_tools
                   ~tool_name
                   ~class_:Tool_result.Runtime_failure
                   ~start_time
-                  "composition result manifest persistence failed"))))
+                  "composition result manifest persistence failed")))))
   in
   let has_async =
     Catalog.entries catalog

--- a/lib/keeper/keeper_tool_composition_surface.ml
+++ b/lib/keeper/keeper_tool_composition_surface.ml
@@ -571,12 +571,22 @@ let status_result
       request_id
   with
   | Keeper_msg_async.Found entry ->
-    result_from_json
-      ~tool_name
-      ~start_time
-      ~class_:Tool_result.Runtime_failure
-      ~ok:true
-      (Keeper_msg_async.entry_to_json entry)
+    let result =
+      result_from_json
+        ~tool_name
+        ~start_time
+        ~class_:Tool_result.Runtime_failure
+        ~ok:true
+        (Keeper_msg_async.entry_to_json entry)
+    in
+    (match Tool_bridge.attach_artifact_manifest ~base_path:config.base_path result with
+     | Ok result -> result
+     | Error { message; _ } ->
+       Tool_result.make_err
+         ~tool_name
+         ~class_:Tool_result.Runtime_failure
+         ~start_time
+         ("async composition status manifest persistence failed: " ^ message))
   | Keeper_msg_async.Absent ->
     result_from_json
       ~tool_name
@@ -610,6 +620,10 @@ let status_result
           ; "reason", Keeper_msg_async.access_rejection_to_json rejection
           ])
 ;;
+
+module For_testing = struct
+  let status_result = status_result
+end
 
 let cancel_result
       ~(config : Workspace.config)

--- a/lib/keeper/keeper_tool_composition_surface.ml
+++ b/lib/keeper/keeper_tool_composition_surface.ml
@@ -730,17 +730,15 @@ let make_tools
         invalid_arg "validated async composition retained a terminal completion"
     in
     let tool_externalization_error =
-      match entry.execution, completion with
-      | Catalog.Async, _
-      | Catalog.Inline, Agent_core.Tool_contract.Continue_after_success ->
-        None
-      | Catalog.Inline, Agent_core.Tool_contract.Terminal_after_success _ ->
-        on_externalization_error
+      match entry.execution with
+      | Catalog.Async -> None
+      | Catalog.Inline -> on_externalization_error
     in
     Tool_bridge.agent_core_tool_of_masc_with_execution_env
       ~descriptor
       ~base_path:config.base_path
       ?on_externalization_error:tool_externalization_error
+      ~externalization_error_recoverable:false
       ~name:tool_name
       ~description:
         (Option.value
@@ -860,7 +858,33 @@ let make_tools
                   ; _
                   } ->
                 ());
-             result_of_execution ~tool_name ~start_time execution))))
+             let result =
+               result_of_execution ~tool_name ~start_time execution
+             in
+             (match
+                Tool_bridge.attach_artifact_manifest
+                  ~base_path:config.base_path
+                  result
+              with
+              | Ok result -> result
+              | Error { message; _ } ->
+                let diagnostic =
+                  "composition result manifest persistence failed: " ^ message
+                in
+                Option.iter
+                  (fun mark_failed ->
+                     mark_failed
+                       { Keeper_tools_agent_core.failure_class =
+                           Tool_result.Runtime_failure
+                       ; effect_disposition = Tool_result.Effect_outcome_unknown
+                       ; diagnostic
+                       })
+                  on_failed;
+                Tool_result.make_err
+                  ~tool_name
+                  ~class_:Tool_result.Runtime_failure
+                  ~start_time
+                  "composition result manifest persistence failed"))))
   in
   let has_async =
     Catalog.entries catalog

--- a/lib/keeper/keeper_tool_composition_surface.mli
+++ b/lib/keeper/keeper_tool_composition_surface.mli
@@ -22,3 +22,11 @@ val make_tools
   -> ?on_externalization_error:(Tool_bridge.externalization_error -> unit)
   -> unit
   -> Agent_core.Tool.t list
+
+module For_testing : sig
+  val status_result :
+    config:Workspace.config ->
+    meta:Keeper_meta_contract.keeper_meta ->
+    request_id:string ->
+    Tool_result.result
+end

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -639,8 +639,70 @@ let with_composable_output composable_output descriptor =
   { descriptor with composable_output }
 ;;
 
+let normalized_artifact_ref_schema =
+  `Assoc
+    [ "type", `String "object"
+    ; ( "properties"
+      , `Assoc
+          [ ( "_blob"
+            , `Assoc
+                [ "type", `String "object"
+                ; ( "properties"
+                  , `Assoc
+                      [ "sha256", `Assoc [ "type", `String "string" ]
+                      ; "bytes", `Assoc [ "type", `String "integer" ]
+                      ; "mime", `Assoc [ "type", `String "string" ]
+                      ; "preview", `Assoc [ "type", `String "string" ]
+                      ] )
+                ; ( "required"
+                  , `List
+                      (List.map
+                         (fun name -> `String name)
+                         [ "sha256"; "bytes"; "mime"; "preview" ]) )
+                ; "additionalProperties", `Bool false
+                ] )
+          ] )
+    ; "required", `List [ `String "_blob" ]
+    ; "additionalProperties", `Bool false
+    ]
+;;
+
+let execute_output_schema =
+  `Assoc
+    [ "type", `String "object"
+    ; ( "properties"
+      , `Assoc
+          [ "ok", `Assoc [ "type", `String "boolean" ]
+          ; ( "status"
+            , `Assoc
+                [ "type", `String "object"
+                ; ( "properties"
+                  , `Assoc
+                      [ "kind", `Assoc [ "type", `String "string" ]
+                      ; "code", `Assoc [ "type", `String "integer" ]
+                      ; "signal", `Assoc [ "type", `String "integer" ]
+                      ] )
+                ; "required", `List [ `String "kind" ]
+                ; "additionalProperties", `Bool false
+                ] )
+          ; "output", `Assoc [ "type", `String "string" ]
+          ; "output_artifact", normalized_artifact_ref_schema
+          ; "stdout_artifact", normalized_artifact_ref_schema
+          ; "stderr_artifact", normalized_artifact_ref_schema
+          ; "typed", `Assoc [ "type", `String "boolean" ]
+          ; "execution_time_ms", `Assoc [ "type", `String "integer" ]
+          ] )
+    ; ( "required"
+      , `List
+          (List.map
+             (fun name -> `String name)
+             [ "ok"; "status"; "typed"; "execution_time_ms" ]) )
+    ; "additionalProperties", `Bool true
+    ]
+;;
+
 let public_descriptors =
-  [ descriptor
+  [ (descriptor
       ~capability_identity:Internal_name_identity
       ~keeper_model_projection:Preferred_public_name
       ~input_schema_source:Descriptor_owned
@@ -654,7 +716,10 @@ let public_descriptors =
          I/O and typed env for environment variables. MASC validates the input \
          shape, path jail, sandbox target, and external-effect Gate but never \
          interprets program or subcommand meaning. The invoked program owns \
-         its syntax and exit result."
+         its syntax and exit result. A successful result exposes typed status, \
+         output and execution_time_ms fields to later composition nodes. Small \
+         output stays inline; oversized output is represented by canonical \
+         output/stdout/stderr artifact references."
       ~input_schema:execute_schema
       ~policy:
         (policy
@@ -674,6 +739,7 @@ let public_descriptors =
         ]
       ~input_translation:(Identity Validate_once_before_translation)
       ()
+     |> with_composable_output (Json_output { schema = execute_output_schema }))
   ; descriptor
       ~capability_identity:Internal_name_identity
       ~keeper_model_projection:Preferred_public_name

--- a/lib/keeper/keeper_tool_emission_hook.ml
+++ b/lib/keeper/keeper_tool_emission_hook.ml
@@ -58,9 +58,14 @@ let accumulator_size acc =
   Stdlib.Mutex.unlock acc.mutex;
   n
 
-let capture_typed_result acc = function
-  | `Assoc _ as data -> push acc data
-  | (`List _ | `String _ | `Bool _ | `Int _ | `Intlit _ | `Float _ | `Null) -> ()
+let capture_typed_result acc data =
+  match
+    ( Multimodal.Tool_emission.extract_kind_from_result data
+    , Multimodal.Tool_emission.extract_id_from_result data )
+  with
+  | Some _, Some _ -> push acc data
+  | None, _ | _, None -> ()
+;;
 
 let drain_into_working_context acc ~(working_context : Yojson.Safe.t option)
     : Yojson.Safe.t option =

--- a/lib/keeper/keeper_tool_emission_hook.mli
+++ b/lib/keeper/keeper_tool_emission_hook.mli
@@ -39,9 +39,11 @@ type accumulator
 (** Allocate a fresh empty accumulator. *)
 val create_accumulator : unit -> accumulator
 
-(** Capture one producer-owned typed result. Only a JSON object can carry the
-    reserved multimodal fields; every other JSON variant, including a
-    JSON-looking [`String], is ignored without reparsing. *)
+(** Capture one producer-owned typed result only when the canonical multimodal
+    detector finds both a supported [__multimodal_kind] and a string
+    [__multimodal_id]. Untagged typed objects and every other JSON variant,
+    including a JSON-looking [`String], are ignored without reparsing or being
+    retained until post-turn drain. *)
 val capture_typed_result : accumulator -> Yojson.Safe.t -> unit
 
 (** Drain the accumulator and merge any tagged tool results into

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -47,6 +47,7 @@ let model_execute_cwd_resolution_error ~config ~meta ~args ~cwd error =
   in
   Keeper_tool_execution.failure
     ~class_:Tool_result.Policy_rejection
+    ~effect_disposition:Tool_result.Proven_pre_effect
     (error_json ~fields message)
 
 let sandbox_target_label = function
@@ -108,6 +109,25 @@ let redact_execute_output redaction ~stdout ~stderr =
     if String.equal stderr "" then stdout else stdout ^ stderr
   in
   stdout, stderr, output
+
+let composable_output_fields ~base_path ~stdout ~stderr ~output =
+  if String.length output <= Tool_bridge.default_externalize_threshold_bytes
+  then Ok [ "output", `String output ]
+  else
+    try
+      let store = Tool_blob_store.create ~base_path in
+      let store_stream bytes =
+        Tool_blob_store.put_durable store ~bytes ~mime:"text/plain"
+        |> Tool_output.normalized_artifact_ref_to_json
+      in
+      Ok
+        [ "output_artifact", store_stream output
+        ; "stdout_artifact", store_stream stdout
+        ; "stderr_artifact", store_stream stderr
+        ]
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Error (Printexc.to_string exn)
 
 module For_testing = struct
   let elapsed_duration_ms = elapsed_duration_ms
@@ -222,6 +242,7 @@ let handle_tool_execute_typed
       | Error e ->
         Keeper_tool_execution.failure
           ~class_:Tool_result.Policy_rejection
+          ~effect_disposition:Tool_result.Proven_pre_effect
           (error_json
              ~fields:
                ([ "typed", `Bool true ] @ model_location_fields)
@@ -234,6 +255,7 @@ let handle_tool_execute_typed
            in
            Keeper_tool_execution.failure
              ~class_:Tool_result.Policy_rejection
+             ~effect_disposition:Tool_result.Proven_pre_effect
              (error_json ~fields (typed_validation_error_text e))
          | Ok () ->
         let cmd = typed_input_command_text input in
@@ -380,6 +402,7 @@ let handle_tool_execute_typed
           in
           Keeper_tool_execution.failure
             ~class_:Tool_result.Policy_rejection
+            ~effect_disposition:Tool_result.Proven_pre_effect
             (error_json ~fields (typed_validation_error_text e))
         | Ok ir ->
         let cmd_for_log =
@@ -405,6 +428,7 @@ let handle_tool_execute_typed
           =
           Keeper_tool_execution.failure
             ~class_
+            ~effect_disposition:Tool_result.Proven_pre_effect
             (error_json
                ~fields:(typed_context_fields @ extra_fields)
                msg)
@@ -642,23 +666,74 @@ let handle_tool_execute_typed
               | Unix.WEXITED 0, _ | _, "" -> []
               | _, stderr -> [ "error", `String stderr; "stderr", `String stderr ]
             in
-            let payload =
-              Yojson.Safe.to_string
-                (`Assoc
+            let output_fields =
+              if succeeded
+              then
+                composable_output_fields
+                  ~base_path:config.base_path
+                  ~stdout
+                  ~stderr
+                  ~output
+              else Ok [ "output", `String output ]
+            in
+            (match output_fields with
+             | Error detail ->
+               Log.Keeper.warn
+                 ~keeper_name:meta.name
+                 "execute output artifact persistence failed after process completion: %s"
+                 detail;
+               authorized
+                 (Keeper_tool_execution.failure
+                    ~effect_disposition:Tool_result.Proven_post_effect
+                    (error_json
+                       ~fields:
+                         ([ "typed", `Bool true
+                          ; "code", `String "execute_output_externalization_failed"
+                          ; "status", status_json
+                          ; "execution_time_ms", `Int elapsed_ms
+                          ]
+                          @ dispatched_model_location_fields)
+                       "Execute completed, but its oversized output artifact could not be persisted."))
+             | Ok output_fields ->
+               let payload =
+                 `Assoc
                    ([ "ok", `Bool succeeded
                     ; "status", status_json
-                    ; "output", `String output
-                    ; "typed", `Bool true
-                    ; "execution_time_ms", `Int elapsed_ms
                     ]
+                    @ output_fields
+                    @ [ "typed", `Bool true
+                      ; "execution_time_ms", `Int elapsed_ms
+                      ]
                     @ failure_error_fields
                     @ sandbox_extra_fields
-                    @ dispatched_model_location_fields))
-            in
-            authorized
-              (if succeeded
-               then Keeper_tool_execution.success payload
-               else Keeper_tool_execution.failure payload)
+                    @ dispatched_model_location_fields)
+               in
+               authorized
+                 (if succeeded
+                  then
+                    (match
+                       Tool_bridge.attach_artifact_manifest
+                         ~base_path:config.base_path
+                         (Tool_result.make_ok
+                            ~tool_name:"tool_execute"
+                            ~start_time:t0
+                            ~data:payload
+                            ())
+                     with
+                     | Ok result -> Keeper_tool_execution.of_tool_result result
+                     | Error _ ->
+                       Keeper_tool_execution.failure
+                         ~effect_disposition:Tool_result.Proven_post_effect
+                         (error_json
+                            ~fields:
+                              ([ "typed", `Bool true
+                               ; "code", `String "execute_result_manifest_failed"
+                               ; "status", status_json
+                               ; "execution_time_ms", `Int elapsed_ms
+                               ]
+                               @ dispatched_model_location_fields)
+                            "Execute completed, but its result manifest could not be persisted."))
+                  else Keeper_tool_execution.failure (Yojson.Safe.to_string payload)))
         )))))
 
 let handle_tool_execute_with_outcome
@@ -685,6 +760,7 @@ let handle_tool_execute_with_outcome
   else
     Keeper_tool_execution.failure
       ~class_:Tool_result.Policy_rejection
+      ~effect_disposition:Tool_result.Proven_pre_effect
       (error_json
          ~fields:[ "typed", `Bool true ]
          "Typed Shell IR input is required. Provide non-empty argv or pipeline.")

--- a/lib/keeper/keeper_tools_agent_core_bundle.ml
+++ b/lib/keeper/keeper_tools_agent_core_bundle.ml
@@ -274,7 +274,49 @@ let make_tool_bundle_for_descriptors
              , Some mark_completed_terminal_externalization_failed )
            | Keeper_tool_descriptor.Ordinary
                (Keeper_tool_descriptor.Serial | Keeper_tool_descriptor.Concurrent) ->
-             None, None, None
+             let on_failed =
+               match descriptor.runtime_handler with
+               | Keeper_tool_descriptor.Tool_execute ->
+                 Some mark_terminal_effect_failed
+               | ( Keeper_tool_descriptor.Tool_search_files
+                 | Keeper_tool_descriptor.Tool_read_file
+                 | Keeper_tool_descriptor.Tool_edit_file
+                 | Keeper_tool_descriptor.Tool_write_file
+                 | Keeper_tool_descriptor.Tool_time_now
+                 | Keeper_tool_descriptor.Tool_tools_list
+                 | Keeper_tool_descriptor.Tool_context_status
+                 | Keeper_tool_descriptor.Tool_artifact_read
+                 | Keeper_tool_descriptor.Tool_memory_search
+                 | Keeper_tool_descriptor.Tool_memory_write
+                 | Keeper_tool_descriptor.Tool_library_search
+                 | Keeper_tool_descriptor.Tool_library_read
+                 | Keeper_tool_descriptor.Tool_surface_read
+                 | Keeper_tool_descriptor.Tool_surface_post
+                 | Keeper_tool_descriptor.Tool_person_note_set
+                 | Keeper_tool_descriptor.Tool_ide_annotate
+                 | Keeper_tool_descriptor.Tool_voice_dispatch
+                 | Keeper_tool_descriptor.Tool_task_dispatch
+                 | Keeper_tool_descriptor.Tool_board_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_task_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_plan_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_run_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_agent_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_workspace_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_misc_dispatch
+                 | Keeper_tool_descriptor.Tool_web_search
+                 | Keeper_tool_descriptor.Tool_web_fetch
+                 | Keeper_tool_descriptor.Tool_masc_control_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_agent_timeline_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_schedule_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_keeper_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_fusion_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_fusion_status
+                 | Keeper_tool_descriptor.Tool_masc_library_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_local_runtime_dispatch
+                 | Keeper_tool_descriptor.Tool_analyze_image ) ->
+                 None
+             in
+             None, on_failed, None
          in
          Keeper_tool_descriptor.keeper_model_names descriptor
          |> List.map (fun model_name ->

--- a/lib/keeper_runtime/keeper_internal_error.ml
+++ b/lib/keeper_runtime/keeper_internal_error.ml
@@ -24,6 +24,7 @@ let runtime_id_to_string (s : string) = s
    this value so recoverability cannot drift through duplicated literals. *)
 let capacity_backpressure_kind = "capacity_backpressure"
 let incomplete_tool_transcript_kind = "incomplete_tool_transcript"
+let provider_attempt_effect_fenced_kind = "provider_attempt_effect_fenced"
 
 type provider_rejection = {
   provider_label : string;
@@ -516,7 +517,7 @@ let masc_internal_error_to_json = function
   | Provider_attempt_effect_fenced
       { runtime_id; effect_disposition; diagnostic } ->
     `Assoc
-      [ "kind", `String "provider_attempt_effect_fenced"
+      [ "kind", `String provider_attempt_effect_fenced_kind
       ; "runtime_id", `String runtime_id
       ; ( "effect_disposition"
         , `String (Keeper_provider_attempt_effect_core.to_string effect_disposition) )
@@ -669,7 +670,7 @@ let kind_of_masc_internal_error = function
   | Internal_contract_rejected _ -> "internal_contract_rejected"
   | Incomplete_tool_transcript _ -> incomplete_tool_transcript_kind
   | Terminal_effect_failed _ -> "terminal_effect_failed"
-  | Provider_attempt_effect_fenced _ -> "provider_attempt_effect_fenced"
+  | Provider_attempt_effect_fenced _ -> provider_attempt_effect_fenced_kind
   | Receipt_persistence_failed _ -> "receipt_persistence_failed"
   | Gate_replay_repair_required _ -> "gate_replay_repair_required"
 
@@ -931,10 +932,11 @@ let parse_masc_internal_error_json (json : Yojson.Safe.t) :
                     { failure_class; effect_disposition; diagnostic })
              | _ -> None)
           | _ -> None)
-      | Some (`String "provider_attempt_effect_fenced")
-        when exact_fields
-               [ "kind"; "runtime_id"; "effect_disposition"; "diagnostic" ]
-               fields ->
+      | Some (`String kind)
+        when String.equal kind provider_attempt_effect_fenced_kind
+             && exact_fields
+                  [ "kind"; "runtime_id"; "effect_disposition"; "diagnostic" ]
+                  fields ->
         (match
            string_opt_of_assoc "runtime_id" json,
            string_opt_of_assoc "effect_disposition" json,

--- a/lib/keeper_runtime/keeper_internal_error.mli
+++ b/lib/keeper_runtime/keeper_internal_error.mli
@@ -4,9 +4,13 @@
 (** Canonical wire kind emitted for {!Capacity_backpressure}.  Receipt
     terminal projection and decoding consume this same value. *)
 val capacity_backpressure_kind : string
-val incomplete_tool_transcript_kind : string
 (** Canonical wire kind for structural transcript corruption rejected before
     provider dispatch. *)
+val incomplete_tool_transcript_kind : string
+
+(** Canonical wire kind for a provider-attempt failure whose effect disposition
+    forbids same-turn replay. *)
+val provider_attempt_effect_fenced_kind : string
 
 type provider_rejection = {
   provider_label : string;

--- a/lib/keeper_runtime/keeper_terminal_reason.ml
+++ b/lib/keeper_runtime/keeper_terminal_reason.ml
@@ -29,6 +29,7 @@ type t =
   | Config_or_auth of string
   | Provider_runtime_failure of string
   | Transcript_corruption of string
+  | Provider_attempt_effect_fenced of string
   | Internal_error of string
   | Pre_dispatch_success of string
   | Unknown of string
@@ -44,8 +45,9 @@ let is_config_or_auth_wire = function
 
 (* Priority-ranked partition. The bucket order replicates the [if/else]
    order of the pre-typing [operator_disposition] string predicates, with the
-   exact canonical [Capacity_backpressure] policy bucket inserted before the
-   opaque internal-error fall-through;
+   exact canonical policy buckets for [Capacity_backpressure] and
+   [Provider_attempt_effect_fenced] inserted before the opaque internal-error
+   fall-through;
    [of_wire] returns the FIRST matching bucket. Capacity backpressure is an
    exact producer-owned wire kind; casing variants remain opaque rather than
    inheriting its non-pageable policy. The original
@@ -68,6 +70,9 @@ let of_wire wire =
   else if
     String.equal wire Keeper_internal_error.incomplete_tool_transcript_kind
   then Transcript_corruption wire
+  else if
+    String.equal wire Keeper_internal_error.provider_attempt_effect_fenced_kind
+  then Provider_attempt_effect_fenced wire
   else if String.equal wire "internal_error"
   then Internal_error wire
   else if String.equal wire "pre_dispatch_success"
@@ -85,6 +90,7 @@ let to_wire = function
   | Config_or_auth wire -> wire
   | Provider_runtime_failure wire -> wire
   | Transcript_corruption wire -> wire
+  | Provider_attempt_effect_fenced wire -> wire
   | Internal_error wire -> wire
   | Pre_dispatch_success wire -> wire
   | Unknown wire -> wire
@@ -113,6 +119,7 @@ let is_transient_provider_runtime_failure = function
   | Capacity_backpressure _
   | Config_or_auth _
   | Transcript_corruption _
+  | Provider_attempt_effect_fenced _
   | Internal_error _
   | Pre_dispatch_success _
   | Unknown _ -> false

--- a/lib/keeper_runtime/keeper_terminal_reason.mli
+++ b/lib/keeper_runtime/keeper_terminal_reason.mli
@@ -27,8 +27,9 @@
 
     [of_wire] is a {e priority-ranked partition}: it tests the buckets in
     the same order the old [operator_disposition] [if/else] chain tested
-    its string predicates, plus the exact canonical
-    [Capacity_backpressure] policy bucket, and returns the first match.
+    its string predicates, plus exact canonical policy buckets for
+    [Capacity_backpressure] and [Provider_attempt_effect_fenced], and returns
+    the first match.
     Only canonical producer wire forms select specialized buckets. The order
     remains load-bearing for canonical overlaps; see the [.ml] for the ranked
     list.
@@ -69,6 +70,12 @@ type t =
       {!Keeper_internal_error.incomplete_tool_transcript_kind}. Provider
       dispatch did not occur; automatic retry is forbidden until an operator
       resets the corrupted checkpoint. *)
+  | Provider_attempt_effect_fenced of string
+  (** Exact canonical wire
+      {!Keeper_internal_error.provider_attempt_effect_fenced_kind}. A provider
+      attempt may have crossed an effect boundary, so same-turn replay is
+      forbidden and the operator-facing receipt must retain an explicit alert
+      rather than treating it as an unmapped internal state. *)
   | Internal_error of string
   (** Exact wire ["internal_error"]. Payload is the original
           string, carried only for [to_wire] round-trip fidelity. *)

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -393,6 +393,13 @@ let blob_aware_output_json (output : string) : Yojson.Safe.t =
   | Tool_output.Not_marker | Tool_output.Invalid_marker _ -> `String output
 ;;
 
+let normalized_artifact_refs_in_typed_data data =
+  Tool_output.normalized_artifact_refs_in_json data
+  |> List.map (fun reference ->
+    Tool_output.with_preview reference ""
+    |> Tool_output.normalized_artifact_ref_to_json)
+;;
+
 let input_to_json (input : Yojson.Safe.t) : Yojson.Safe.t =
   (* Per-leaf marker-aware truncation. Previously
      [String.sub (Yojson.Safe.to_string input) 0 (max - suffix)] chopped
@@ -557,10 +564,16 @@ let log_call
             , Agent_core.Tool_contract.execution_mode_to_yojson value ) ]
         | None -> []
       in
-      let typed_disposition_field =
+      let typed_result_fields =
         match typed_result with
         | Some result ->
+          let artifact_refs =
+            normalized_artifact_refs_in_typed_data (Tool_result.data result)
+          in
           [ "disposition", `String (Tool_result.string_of_disposition result) ]
+          @ (if artifact_refs = []
+             then []
+             else [ "artifact_refs", `List artifact_refs ])
         | None -> []
       in
       let composition_fields =
@@ -688,7 +701,7 @@ let log_call
            @ batch_index_field
            @ batch_size_field
            @ execution_mode_field
-           @ typed_disposition_field
+           @ typed_result_fields
            @ composition_fields
            @ composition_execution_field
            @ trace_id_field

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -189,9 +189,14 @@ val log_call :
     [batch_size], and [execution_mode] preserve Agent Core's actual schedule
     rather than inferring concurrency from timing.
     [typed_result] serializes the producer-owned disposition when it is
-    available. The composition fields are an explicit observation envelope
-    supplied by the typed plan executor; readers must not reconstruct them
-    from [tool_use_id] or tool-name strings.
+    available. Any canonical normalized artifact references in its typed data
+    are also persisted as actual JSON under [artifact_refs], keeping the
+    content-addressed blobs visible to offline maintenance without parsing a
+    JSON-bearing model-output string. Those GC roots deliberately carry an
+    empty preview; model/UI preview projection remains owned by [output]. The
+    composition fields are an explicit observation envelope supplied by the
+    typed plan executor; readers must not reconstruct them from [tool_use_id]
+    or tool-name strings.
     [on_committed], when supplied, forces this row through the synchronous
     append boundary and runs only after that append succeeds. It is intended
     for exact completion notifications whose readers must not race the

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -753,20 +753,33 @@ let parse_result ~expected_session_id ~rate_limit ~tool_effect_attempted
          context-window rejection ("Prompt is too long" / "Input is too long
          for requested model", either status, or a 413 naming the window). A
          frame that carries the verdict is authoritative in both directions,
-         like the codex lane's [codexErrorInfo]. Frames from CLIs that predate
-         the enum carry no [terminal_reason]; only those fall back to the
-         historical exact-prefix 400, unchanged in scope (RFC amendment
-         2026-08-12). *)
+         like the codex lane's [codexErrorInfo]. Frames that omit the enum
+         carry no [terminal_reason]; only those fall back to the compatibility
+         evidence below. The exact statusless sentence is the live Claude Code
+         2.1.232 wire; older verbose frames retain the
+         historical exact-prefix 400 rule (RFC amendment 2026-08-12). *)
       match terminal_reason with
       | Some reason -> String.equal reason "prompt_too_long"
       | None ->
-        Option.equal Int.equal api_error_status (Some 400)
-        && Option.exists
-             (fun detail ->
-                String.starts_with
-                  ~prefix:"Prompt is too long"
-                  (String.trim detail))
-             result
+        let canonical_statusless_rejection =
+          (* Live Claude Code 2.1.232 emitted the canonical provider verdict
+             with neither [terminal_reason] nor [api_error_status]. Admit that
+             exact wire sentence only; do not infer overflow from arbitrary
+             prose that merely contains it. *)
+          Option.is_none api_error_status
+          && Option.exists
+               (fun detail -> String.equal (String.trim detail) "Prompt is too long")
+               result
+        in
+        canonical_statusless_rejection
+        ||
+        (Option.equal Int.equal api_error_status (Some 400)
+         && Option.exists
+              (fun detail ->
+                 String.starts_with
+                   ~prefix:"Prompt is too long"
+                   (String.trim detail))
+              result)
     in
     if structurally_quota_blocked
     then Error (Quota_blocked { api_error_status; rate_limit })

--- a/lib/tool_blob_store/tool_blob_maintenance.ml
+++ b/lib/tool_blob_store/tool_blob_maintenance.ml
@@ -1,5 +1,14 @@
 module String_set = Set_util.StringSet
 
+module Artifact_reference_set = Set.Make (struct
+  type t = Tool_output.artifact_ref
+
+  let compare left right =
+    match String.compare left.Tool_output.sha256 right.Tool_output.sha256 with
+    | 0 -> String.compare left.mime right.mime
+    | order -> order
+end)
+
 type mode =
   | Observe_only
   | Delete_previous_candidates
@@ -26,6 +35,14 @@ type error =
   | Malformed_structured_artifact_reference of
       { path : string
       ; line : int
+      ; detail : string
+      }
+  | Artifact_manifest_read_failed of
+      { sha256 : string
+      ; reason : string
+      }
+  | Artifact_manifest_invalid of
+      { sha256 : string
       ; detail : string
       }
   | Candidate_snapshot_invalid of
@@ -74,6 +91,10 @@ let error_to_string = function
       path
       line
       detail
+  | Artifact_manifest_read_failed { sha256; reason } ->
+    Printf.sprintf "artifact manifest read failed sha256=%s: %s" sha256 reason
+  | Artifact_manifest_invalid { sha256; detail } ->
+    Printf.sprintf "artifact manifest invalid sha256=%s: %s" sha256 detail
   | Candidate_snapshot_invalid { path; detail } ->
     Printf.sprintf "blob maintenance candidate snapshot invalid path=%s: %s" path detail
   | Candidate_snapshot_read_failed { path; detail } ->
@@ -120,7 +141,7 @@ let add_references ~path ~line references text =
       Tool_output.encode_for_agent_core (Tool_output.Stored reference)
     in
     if String.equal text canonical
-    then Ok (String_set.add reference.Tool_output.sha256 references)
+    then Ok (Artifact_reference_set.add reference references)
     else
       Error
         (Malformed_artifact_reference
@@ -136,7 +157,7 @@ let rec references_in_json ~path ~line references = function
   | (`Assoc fields as json) ->
     (match Tool_output.normalized_artifact_ref_of_json json with
      | Tool_output.Decoded_normalized_artifact_ref reference ->
-       Ok (String_set.add reference.Tool_output.sha256 references)
+       Ok (Artifact_reference_set.add reference references)
      | Tool_output.Invalid_normalized_artifact_ref { detail } ->
        Error
          (Malformed_structured_artifact_reference
@@ -181,7 +202,7 @@ let references_in_file ~ownership_root path =
       references_in_json
         ~path
         ~line:1
-        String_set.empty
+        Artifact_reference_set.empty
         (Yojson.Safe.from_string payload)
     with
     | Yojson.Json_error _ ->
@@ -217,7 +238,7 @@ let references_in_file ~ownership_root path =
                         line)
               in
               line_number + 1, next)
-           (1, Ok String_set.empty)
+           (1, Ok Artifact_reference_set.empty)
       |> snd
 ;;
 
@@ -361,7 +382,7 @@ let live_references ~base_path =
       | Unix.S_DIR -> scan_directory path references
       | Unix.S_REG ->
         Result.map
-          (String_set.union references)
+          (Artifact_reference_set.union references)
           (references_in_file ~ownership_root:base_path path)
         | Unix.S_LNK ->
           Error
@@ -401,7 +422,62 @@ let live_references ~base_path =
   |> List.fold_left
        (fun result root ->
           Result.bind result (fun progress -> scan_directory root progress))
-       (Ok String_set.empty)
+       (Ok Artifact_reference_set.empty)
+;;
+
+let expand_artifact_manifests ~store references =
+  let rec expand expanded references = function
+    | [] -> Ok references
+    | reference :: rest
+      when not
+             (String.equal
+                reference.Tool_output.mime
+                Tool_output.artifact_manifest_mime) ->
+      expand expanded references rest
+    | reference :: rest
+      when String_set.mem reference.Tool_output.sha256 expanded ->
+      expand expanded references rest
+    | reference :: rest ->
+      let sha256 = reference.Tool_output.sha256 in
+      let expanded = String_set.add sha256 expanded in
+      (match Tool_blob_store.fetch store ~sha256 with
+       | Error error ->
+         Error
+           (Artifact_manifest_read_failed
+              { sha256; reason = Tool_blob_store.fetch_error_to_string error })
+       | Ok None ->
+         Error
+           (Artifact_manifest_read_failed
+              { sha256; reason = "referenced manifest blob is absent" })
+       | Ok (Some payload) ->
+         let decoded =
+           try
+             Yojson.Safe.from_string payload
+             |> Tool_output.artifact_manifest_of_json
+           with
+           | Yojson.Json_error detail ->
+             Tool_output.Invalid_artifact_manifest { detail }
+         in
+         (match decoded with
+          | Tool_output.Decoded_artifact_manifest { artifact_refs; _ } ->
+            let references, added =
+              List.fold_left
+                (fun (references, added) child ->
+                   if Artifact_reference_set.mem child references
+                   then references, added
+                   else Artifact_reference_set.add child references, child :: added)
+                (references, [])
+                artifact_refs
+            in
+            expand expanded references (List.rev_append added rest)
+          | Tool_output.Not_artifact_manifest ->
+            Error
+              (Artifact_manifest_invalid
+                 { sha256; detail = "manifest MIME requires the canonical schema" })
+          | Tool_output.Invalid_artifact_manifest { detail } ->
+            Error (Artifact_manifest_invalid { sha256; detail })))
+  in
+  expand String_set.empty references (Artifact_reference_set.elements references)
 ;;
 
 let candidate_snapshot_to_json candidates =
@@ -532,7 +608,15 @@ let run ~base_path ~mode =
   let open Result.Syntax in
   let* () = reject_uncoordinated_cluster_roots ~base_path in
   let store = Tool_blob_store.create ~base_path in
-  let* live = live_references ~base_path in
+  let* direct_live = live_references ~base_path in
+  let* live_references = expand_artifact_manifests ~store direct_live in
+  let live =
+    Artifact_reference_set.fold
+      (fun reference hashes ->
+         String_set.add reference.Tool_output.sha256 hashes)
+      live_references
+      String_set.empty
+  in
   let* previous_candidates = load_candidate_snapshot ~base_path in
   let* blob_list =
     match Tool_blob_store.list_all_result store with

--- a/lib/tool_blob_store/tool_blob_maintenance.mli
+++ b/lib/tool_blob_store/tool_blob_maintenance.mli
@@ -3,6 +3,9 @@
     Live references are the union of exact {!Tool_output} markers in the
     closed durable-consumer registry: Keeper state/checkpoints, Gate replay,
     tool-call logs, traces, messages, Keeper chat, and bounded wire captures.
+    A marker whose media type is {!Tool_output.artifact_manifest_mime} adds the
+    manifest's strictly decoded normalized children transitively. No other
+    blob content is parsed or treated as an ownership edge.
     Trajectory previews, repository mirrors, build products, operator config,
     and unrelated observational logs are not blob consumers and are never
     traversed. A new durable consumer must be added to this registry in the
@@ -46,6 +49,14 @@ type error =
   | Malformed_structured_artifact_reference of
       { path : string
       ; line : int
+      ; detail : string
+      }
+  | Artifact_manifest_read_failed of
+      { sha256 : string
+      ; reason : string
+      }
+  | Artifact_manifest_invalid of
+      { sha256 : string
       ; detail : string
       }
   | Candidate_snapshot_invalid of

--- a/lib/tool_blob_store/tool_output.ml
+++ b/lib/tool_blob_store/tool_output.ml
@@ -108,6 +108,96 @@ let normalized_artifact_ref_of_json = function
   | _ -> Not_normalized_artifact_ref
 ;;
 
+let collect_normalized_artifact_refs ~reject_invalid json =
+  let add_reference references reference =
+    if
+      List.exists
+        (fun existing ->
+           String.equal existing.sha256 reference.sha256
+           && String.equal existing.mime reference.mime)
+        references
+    then references
+    else reference :: references
+  in
+  let rec collect references = function
+    | (`Assoc fields as json) ->
+      (match normalized_artifact_ref_of_json json with
+       | Decoded_normalized_artifact_ref reference ->
+         Ok (add_reference references reference)
+       | Invalid_normalized_artifact_ref { detail } when reject_invalid ->
+         Error detail
+       | Invalid_normalized_artifact_ref _ | Not_normalized_artifact_ref ->
+         List.fold_left
+           (fun result (_, value) ->
+              Result.bind result (fun references -> collect references value))
+           (Ok references)
+           fields)
+    | `List values ->
+      List.fold_left
+        (fun result value ->
+           Result.bind result (fun references -> collect references value))
+        (Ok references)
+        values
+    | `String _ | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ ->
+      Ok references
+  in
+  Result.map List.rev (collect [] json)
+;;
+
+let normalized_artifact_refs_in_json json =
+  match collect_normalized_artifact_refs ~reject_invalid:false json with
+  | Ok references -> references
+  | Error _ -> []
+;;
+
+let normalized_artifact_refs_in_json_strict json =
+  collect_normalized_artifact_refs ~reject_invalid:true json
+;;
+
+let artifact_manifest_mime = "application/vnd.masc.tool-result-manifest+json"
+let artifact_manifest_schema = "masc.tool-result-artifact-manifest.v1"
+
+let artifact_manifest_to_json ~content ~structured_content =
+  `Assoc
+    [ "schema", `String artifact_manifest_schema
+    ; "content", `String content
+    ; "structured_content", structured_content
+    ]
+;;
+
+type artifact_manifest_decode =
+  | Not_artifact_manifest
+  | Invalid_artifact_manifest of { detail : string }
+  | Decoded_artifact_manifest of
+      { content : string
+      ; structured_content : Yojson.Safe.t
+      ; artifact_refs : artifact_ref list
+      }
+
+let artifact_manifest_of_json = function
+  | `Assoc
+      [ "schema", `String schema
+      ; "content", `String content
+      ; "structured_content", structured_content
+      ]
+    when String.equal schema artifact_manifest_schema ->
+    (match normalized_artifact_refs_in_json_strict structured_content with
+     | Ok artifact_refs ->
+       Decoded_artifact_manifest
+         { content; structured_content; artifact_refs }
+     | Error detail -> Invalid_artifact_manifest { detail })
+  | `Assoc fields when List.mem_assoc "schema" fields ->
+    (match List.assoc_opt "schema" fields with
+     | Some (`String schema) when not (String.equal schema artifact_manifest_schema) ->
+       Not_artifact_manifest
+     | _ ->
+       Invalid_artifact_manifest
+         { detail =
+             "expected exact fields schema, content, and structured_content"
+         })
+  | _ -> Not_artifact_manifest
+;;
+
 type t =
   | Inline of string
   | Stored of artifact_ref

--- a/lib/tool_blob_store/tool_output.mli
+++ b/lib/tool_blob_store/tool_output.mli
@@ -68,6 +68,45 @@ val normalized_artifact_ref_of_json :
     {!normalized_artifact_ref_to_json}. A malformed wrapper is reported
     explicitly so retention code fails closed. *)
 
+val normalized_artifact_refs_in_json : Yojson.Safe.t -> artifact_ref list
+(** Collect every valid normalized reference nested in typed JSON, deduplicated
+    by content address and declared media type in first-occurrence order.
+    Malformed wrappers are not references; authoritative decoders remain
+    responsible for rejecting them. *)
+
+val normalized_artifact_refs_in_json_strict :
+  Yojson.Safe.t -> (artifact_ref list, string) result
+(** As {!normalized_artifact_refs_in_json}, but reject the first malformed
+    reserved [_blob] wrapper. Durable manifest producers and consumers must
+    use this form so they share one closed validity contract. *)
+
+(** {1 Durable result manifests}
+
+    A tool result that itself contains normalized artifact references is
+    stored as one typed manifest blob. The durable transcript owns the
+    manifest through an exact AGENT_CORE marker, while offline maintenance
+    follows only this explicit MIME/schema edge to the referenced child
+    artifacts. Arbitrary JSON blobs are never traversed. *)
+
+val artifact_manifest_mime : string
+
+val artifact_manifest_to_json :
+  content:string -> structured_content:Yojson.Safe.t -> Yojson.Safe.t
+
+type artifact_manifest_decode =
+  | Not_artifact_manifest
+  | Invalid_artifact_manifest of { detail : string }
+  | Decoded_artifact_manifest of
+      { content : string
+      ; structured_content : Yojson.Safe.t
+      ; artifact_refs : artifact_ref list
+      }
+
+val artifact_manifest_of_json : Yojson.Safe.t -> artifact_manifest_decode
+(** Strictly decode the closed manifest envelope. The decoded child set is
+    derived only from [structured_content] using the normalized reference
+    codec above. *)
+
 (** {1 Wire codec} *)
 
 type t =

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -38,6 +38,88 @@ type externalization_error =
   ; message : string
   }
 
+let artifact_manifest_metadata_key = "masc.artifact_manifest"
+
+let metadata_with_artifact_manifest metadata reference =
+  let manifest = Tool_output.normalized_artifact_ref_to_json reference in
+  match metadata with
+  | None -> `Assoc [ artifact_manifest_metadata_key, manifest ]
+  | Some (`Assoc fields) ->
+    `Assoc
+      ((artifact_manifest_metadata_key, manifest)
+       :: List.remove_assoc artifact_manifest_metadata_key fields)
+  | Some payload ->
+    `Assoc
+      [ artifact_manifest_metadata_key, manifest
+      ; "masc.payload", payload
+      ]
+;;
+
+let artifact_manifest_from_metadata metadata =
+  let rec decode = function
+    | `Assoc fields ->
+      (match List.assoc_opt artifact_manifest_metadata_key fields with
+     | Some json ->
+       (match Tool_output.normalized_artifact_ref_of_json json with
+        | Tool_output.Decoded_normalized_artifact_ref reference
+          when String.equal reference.mime Tool_output.artifact_manifest_mime ->
+          Ok reference
+        | Tool_output.Decoded_normalized_artifact_ref _ ->
+          Error "artifact manifest metadata has the wrong media type"
+        | Tool_output.Not_normalized_artifact_ref ->
+          Error "artifact manifest metadata is not a normalized reference"
+        | Tool_output.Invalid_normalized_artifact_ref { detail } -> Error detail)
+     | None ->
+       (match List.assoc_opt "producer" fields with
+        | Some producer -> decode producer
+        | None ->
+          (match List.assoc_opt "masc.payload" fields with
+           | Some payload -> decode payload
+           | None -> Error "typed artifact result is missing its durable manifest")))
+    | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ ->
+      Error "typed artifact result is missing its durable manifest"
+  in
+  match metadata with
+  | Some metadata -> decode metadata
+  | None -> Error "typed artifact result is missing its durable manifest"
+;;
+
+let attach_artifact_manifest ~base_path (result : Tool_result.result) =
+  match
+    Tool_output.normalized_artifact_refs_in_json_strict
+      (Tool_result.data result)
+  with
+  | Error message -> Error { kind = Artifact_storage_failure; message }
+  | Ok [] -> Ok result
+  | Ok (_ :: _) ->
+    (try
+       let manifest =
+         Tool_output.artifact_manifest_to_json
+           ~content:(Tool_result.message result)
+           ~structured_content:(Tool_result.data result)
+         |> Yojson.Safe.to_string
+       in
+       let reference =
+         Tool_blob_store.put_durable
+           (Tool_blob_store.create ~base_path)
+           ~bytes:manifest
+           ~mime:Tool_output.artifact_manifest_mime
+         |> fun reference -> Tool_output.with_preview reference ""
+       in
+       Ok
+         (Tool_result.with_metadata
+            (metadata_with_artifact_manifest (Tool_result.metadata result) reference)
+            result)
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       let message = Printexc.to_string exn in
+       Log.Misc.error
+         "tool_bridge: result manifest persistence failed: %s"
+         message;
+       Error { kind = Artifact_storage_failure; message })
+;;
+
 let resolve_blob_store ?base_path () =
   match base_path with
   | None -> None
@@ -167,11 +249,28 @@ let project_result
       ?on_externalization_error
       ~externalization_error_recoverable
       ~model_projection
+      ~structured_content
+      ~metadata
       message
       on_content
   : Agent_core.Types.tool_result
   =
-  match project_content ?base_path ~model_projection message with
+  let project () = project_content ?base_path ~model_projection message in
+  let projected =
+    match Tool_output.normalized_artifact_refs_in_json structured_content with
+    | [] -> project ()
+    | _ :: _ when Option.is_none base_path -> project ()
+    | _ :: _ ->
+      (match Tool_output.normalized_artifact_refs_in_json_strict structured_content with
+       | Error message -> Error { kind = Artifact_storage_failure; message }
+       | Ok [] -> Error { kind = Artifact_storage_failure; message = "typed artifact result lost its normalized references" }
+       | Ok (_ :: _) ->
+         (match artifact_manifest_from_metadata metadata with
+          | Ok reference ->
+            Ok (Tool_output.encode_for_agent_core (Tool_output.Stored reference))
+          | Error message -> Error { kind = Artifact_storage_failure; message }))
+  in
+  match projected with
   | Ok content -> on_content content
   | Error error ->
     Option.iter (fun observe -> observe error) on_externalization_error;
@@ -195,6 +294,8 @@ let to_agent_core_typed_result
       ?on_externalization_error
       ~externalization_error_recoverable
       ~model_projection
+      ~structured_content:(Tool_result.data tr)
+      ~metadata:(Tool_result.metadata tr)
       (Tool_result.message tr)
       (fun content ->
          Ok { Agent_core.Types.content; _meta = output.metadata })
@@ -213,6 +314,8 @@ let to_agent_core_typed_result
       ?on_externalization_error
       ~externalization_error_recoverable
       ~model_projection
+      ~structured_content:(Tool_result.data tr)
+      ~metadata:(Tool_result.metadata tr)
       (Tool_result.message tr)
       (fun content ->
          Ok { Agent_core.Types.content; _meta = Some metadata })
@@ -233,6 +336,8 @@ let to_agent_core_typed_result
       ?on_externalization_error
       ~externalization_error_recoverable
       ~model_projection
+      ~structured_content:(Tool_result.data tr)
+      ~metadata:(Tool_result.metadata tr)
       message
       (fun message ->
        make_tool_error

--- a/lib/tool_bridge.mli
+++ b/lib/tool_bridge.mli
@@ -37,6 +37,15 @@ type externalization_error =
   ; message : string
   }
 
+val attach_artifact_manifest :
+  base_path:string ->
+  Tool_result.result ->
+  (Tool_result.result, externalization_error) result
+(** Persist and attach the canonical manifest for typed result data containing
+    normalized artifact references. Producers call this inside their effect
+    boundary, before returning the authoritative result. Results without
+    artifact references pass through unchanged. Cancellation propagates. *)
+
 val maybe_externalize :
   ?base_path:string ->
   ?mime:string ->
@@ -63,7 +72,14 @@ val to_agent_core_typed_result :
     to AGENT_CORE [recoverable]/[error_class]. [on_externalization_error] lets an
     owning runtime keep its terminal state consistent when storage fails.
     [externalization_error_recoverable] projects the owning tool's existing
-    retry policy; the provider receives only a bounded generic error. *)
+    retry policy; the provider receives only a bounded generic error.
+
+    When typed result data contains normalized artifact references, the
+    producer must first call {!attach_artifact_manifest}; the provider-facing
+    content then becomes that durable manifest's marker. Projection performs
+    no manifest I/O after the producer's effect boundary. This keeps the
+    transcript itself as the authoritative root while preserving the original
+    content and structured data inside the manifest. *)
 
 (** {1 Schema Conversion} *)
 

--- a/scripts/fixtures/keeper-multi-collaboration/missions.json
+++ b/scripts/fixtures/keeper-multi-collaboration/missions.json
@@ -232,6 +232,16 @@
       "user_story": "같은 Keeper가 서로 다른 runtime turn identity를 가진 11개 요청 turn을 순서대로 완료하고 첫 turn의 secret을 반복 입력받지 않은 채 중간 Board 연쇄와 재시작 뒤 기억을 복원한다.",
       "assertions": ["same_keeper_eleven_linked_turns", "context_secret_recalled"],
       "evidence": ["turns/continuity-*.json", "turns/context-after-restart.json", "observations/board-post.json"]
+    },
+    {
+      "id": "RW19",
+      "phase": "persistence_observability",
+      "name": "durable_turn_span_dashboard_projection",
+      "actors": ["coordinator", "builder-a", "builder-b", "reviewer", "researcher"],
+      "capabilities": ["Keeper", "Dashboard", "Observability", "Persistence"],
+      "user_story": "Verification 화면이 격리된 5-Keeper fleet의 decision-log durable turn span을 1h, 2h, 4h, 24h tier별 pass, warn, fail 상태와 함께 실제 backend 응답 그대로 표시하며 이를 무중단 uptime으로 과장하지 않는다.",
+      "assertions": ["persistence_tiers_dashboard_projection_observed"],
+      "evidence": ["browser/keeper-persistence-proof.json", "browser/keeper-persistence-proof.png"]
     }
   ]
 }

--- a/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
+++ b/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
@@ -83,6 +83,7 @@ KNOWN_ASSERTIONS = {
     "composition_async_observed",
     "composition_turn_context_observed",
     "composition_dashboard_browser_observed",
+    "persistence_tiers_dashboard_projection_observed",
 }
 
 
@@ -144,6 +145,101 @@ def sha256_file(path: pathlib.Path) -> str:
         for chunk in iter(lambda: source.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def validate_persistence_browser_evidence(
+    proof: Any,
+    screenshot_path: pathlib.Path,
+    expected_keepers: set[str],
+) -> tuple[bool, str]:
+    errors: list[str] = []
+    if not isinstance(proof, dict):
+        return False, "persistence browser proof is not an object"
+    if proof.get("schema") != "masc.keeper_persistence_browser_evidence.v1":
+        errors.append("schema mismatch")
+    generated_at = proof.get("generated_at")
+    if not isinstance(generated_at, str) or not generated_at:
+        errors.append("generated_at is absent")
+    else:
+        try:
+            dt.datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
+        except ValueError:
+            errors.append("generated_at is invalid")
+    if proof.get("interaction") != "manual_refresh":
+        errors.append("manual refresh was not observed")
+    if not expected_keepers:
+        errors.append("expected Keeper fleet is absent")
+    tiers = proof.get("tiers")
+    if not isinstance(tiers, list) or len(tiers) != 4:
+        errors.append("duration tiers must be an exact four-element list")
+        tiers = []
+    if all(isinstance(tier, dict) for tier in tiers):
+        if [tier.get("id") for tier in tiers] != ["1h", "2h", "4h", "24h"]:
+            errors.append("duration tier ids are not exact and ordered")
+        previous_observed: set[str] | None = None
+        previous_missing: set[str] | None = None
+        for tier in tiers:
+            status = tier.get("status")
+            evidence_kind = tier.get("evidence_kind")
+            observed_count = tier.get("observed_count")
+            keeper_count = tier.get("keeper_count")
+            missing_count = tier.get("missing_count")
+            observed_names = tier.get("observed_keepers")
+            missing_names = tier.get("missing_keepers")
+            if status not in {"pass", "warn", "fail"}:
+                errors.append(f"tier {tier.get('id')} status is invalid")
+            if evidence_kind != "durable_turn_span":
+                errors.append(f"tier {tier.get('id')} evidence kind is invalid")
+            counts = (observed_count, keeper_count, missing_count)
+            if not all(type(value) is int and value >= 0 for value in counts):
+                errors.append(f"tier {tier.get('id')} counts are invalid")
+                continue
+            if not isinstance(observed_names, list) or not isinstance(missing_names, list):
+                errors.append(f"tier {tier.get('id')} Keeper identities are absent")
+                continue
+            if not all(isinstance(name, str) and bool(name.strip()) for name in observed_names + missing_names):
+                errors.append(f"tier {tier.get('id')} Keeper identities are invalid")
+                continue
+            observed = set(observed_names)
+            missing = set(missing_names)
+            if len(observed) != len(observed_names) or len(missing) != len(missing_names):
+                errors.append(f"tier {tier.get('id')} Keeper identities contain duplicates")
+            if observed & missing or observed | missing != expected_keepers:
+                errors.append(f"tier {tier.get('id')} does not describe the exact run fleet")
+            if len(observed) != observed_count or len(missing) != missing_count:
+                errors.append(f"tier {tier.get('id')} counts do not match identities")
+            if observed_count + missing_count != keeper_count or keeper_count != len(expected_keepers):
+                errors.append(f"tier {tier.get('id')} Keeper total is inconsistent")
+            derived_status = (
+                "fail"
+                if keeper_count == 0 or observed_count == 0
+                else "pass"
+                if observed_count == keeper_count
+                else "warn"
+            )
+            if status != derived_status:
+                errors.append(f"tier {tier.get('id')} status disagrees with counts")
+            if previous_observed is not None and previous_missing is not None and (
+                not observed <= previous_observed or not missing >= previous_missing
+            ):
+                errors.append(f"tier {tier.get('id')} violates duration monotonicity")
+            previous_observed = observed
+            previous_missing = missing
+    elif tiers:
+        errors.append("duration tiers contain non-object values")
+    screenshot_digest = proof.get("screenshot_sha256")
+    if proof.get("screenshot_file") != "keeper-persistence-proof.png":
+        errors.append("screenshot filename is invalid")
+    if not isinstance(screenshot_digest, str) or re.fullmatch(r"[0-9a-f]{64}", screenshot_digest) is None:
+        errors.append("screenshot digest is invalid")
+    elif not screenshot_path.is_file():
+        errors.append("screenshot is absent")
+    else:
+        if sha256_file(screenshot_path) != screenshot_digest:
+            errors.append("screenshot digest mismatch")
+        if proof.get("screenshot_bytes") != screenshot_path.stat().st_size:
+            errors.append("screenshot byte count mismatch")
+    return not errors, "; ".join(errors) if errors else "exact refreshed persistence projection and screenshot verified"
 
 
 def source_sha() -> str:
@@ -367,12 +463,12 @@ def load_catalog(path: pathlib.Path) -> dict[str, Any]:
     if catalog.get("schema") != "masc.keeper_multi_collaboration_missions.v1":
         raise AcceptanceError("mission catalog schema mismatch")
     missions = catalog.get("missions")
-    if not isinstance(missions, list) or len(missions) != 18:
-        raise AcceptanceError("mission catalog must contain exactly 18 missions")
+    if not isinstance(missions, list) or len(missions) != 19:
+        raise AcceptanceError("mission catalog must contain exactly 19 missions")
     ids = [mission.get("id") for mission in missions]
-    expected_ids = [f"RW{index:02d}" for index in range(1, 19)]
+    expected_ids = [f"RW{index:02d}" for index in range(1, 20)]
     if ids != expected_ids:
-        raise AcceptanceError("mission ids must be ordered exactly RW01 through RW18")
+        raise AcceptanceError("mission ids must be ordered exactly RW01 through RW19")
     roles = catalog.get("roles")
     if not isinstance(roles, list) or set(roles) != EXPECTED_ROLES:
         raise AcceptanceError("catalog must define the exact five collaboration roles")
@@ -543,6 +639,7 @@ class MissionRun:
         self.observations: dict[str, ToolObservation] = {}
         self.tool_call_rows: dict[str, list[dict[str, Any]]] = {}
         self.browser_proof: dict[str, Any] = {}
+        self.persistence_browser_proof: dict[str, Any] = {}
 
     def call(self, label: str, tool: str, arguments: dict[str, Any]) -> ToolObservation:
         observation = self.client.call_tool(tool, arguments)
@@ -925,14 +1022,25 @@ class MissionRun:
                 "composition browser proof failed: "
                 + (completed.stderr.strip() or completed.stdout.strip())
             )
-        measurement_path = browser_dir / "keeper-composition-inspector.json"
-        try:
-            measurement = json.loads(measurement_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError) as error:
-            raise AcceptanceError(f"invalid browser proof measurement: {error}") from error
-        if not isinstance(measurement, dict):
-            raise AcceptanceError("browser proof measurement must be an object")
-        self.browser_proof = measurement
+
+        def read_measurement(filename: str) -> dict[str, Any]:
+            measurement_path = browser_dir / filename
+            try:
+                measurement = json.loads(measurement_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as error:
+                raise AcceptanceError(
+                    f"invalid browser proof measurement {filename}: {error}"
+                ) from error
+            if not isinstance(measurement, dict):
+                raise AcceptanceError(
+                    f"browser proof measurement {filename} must be an object"
+                )
+            return measurement
+
+        self.browser_proof = read_measurement("keeper-composition-inspector.json")
+        self.persistence_browser_proof = read_measurement(
+            "keeper-persistence-proof.json"
+        )
 
     def run_contention(self, post_id: str) -> None:
         prompts = {
@@ -1460,6 +1568,16 @@ class MissionRun:
         browser_screenshot = (
             self.writer.output_dir / "browser" / "keeper-composition-inspector.png"
         )
+        persistence_browser_screenshot = (
+            self.writer.output_dir / "browser" / "keeper-persistence-proof.png"
+        )
+        persistence_projection_passed, persistence_projection_detail = (
+            validate_persistence_browser_evidence(
+                self.persistence_browser_proof,
+                persistence_browser_screenshot,
+                set(self.roles.values()),
+            )
+        )
         parallel_events = sorted(
             [
                 (turn.started_epoch_seconds, 1)
@@ -1780,6 +1898,10 @@ class MissionRun:
                 == self.browser_proof["screenshot_sha256"],
                 "actual dashboard inspector renders one complete typed run with expanded input/output",
             ),
+            "persistence_tiers_dashboard_projection_observed": (
+                persistence_projection_passed,
+                persistence_projection_detail,
+            ),
         }
         malformed = [
             name
@@ -2006,6 +2128,36 @@ def verify_bundle(
                 errors.append(
                     f"missing catalog evidence for {mission['id']}: {pattern}"
                 )
+    persistence_proof_path = output_dir / "browser" / "keeper-persistence-proof.json"
+    persistence_screenshot_path = output_dir / "browser" / "keeper-persistence-proof.png"
+    try:
+        persistence_proof = json.loads(
+            persistence_proof_path.read_text(encoding="utf-8")
+        )
+    except (OSError, json.JSONDecodeError) as error:
+        errors.append(f"persistence browser proof is unreadable: {error}")
+    else:
+        resources = bundle.get("resources")
+        keepers = resources.get("keepers") if isinstance(resources, dict) else None
+        exact_role_map = (
+            isinstance(keepers, dict)
+            and set(keepers) == EXPECTED_ROLES
+            and all(
+                isinstance(value, str) and bool(value.strip())
+                for value in keepers.values()
+            )
+            and len(set(keepers.values())) == len(EXPECTED_ROLES)
+        )
+        if not exact_role_map:
+            errors.append("bundle resources do not name five distinct exact role Keepers")
+        expected_keepers = set(keepers.values()) if exact_role_map else set()
+        persistence_valid, persistence_detail = validate_persistence_browser_evidence(
+            persistence_proof,
+            persistence_screenshot_path,
+            expected_keepers,
+        )
+        if not persistence_valid:
+            errors.append(f"persistence browser proof is invalid: {persistence_detail}")
     seed = {
         "source_sha": bundle.get("source_sha"),
         "runner_source_sha": bundle.get("runner_source_sha"),

--- a/test/test_dashboard_keeper_feature_proof.ml
+++ b/test/test_dashboard_keeper_feature_proof.ml
@@ -104,6 +104,22 @@ let keeper_names feature key =
   |> List.sort compare
 ;;
 
+let duration_tier feature id =
+  feature
+  |> U.member "duration_tiers"
+  |> U.to_list
+  |> List.find_opt (fun tier -> U.member "id" tier |> U.to_string = id)
+  |> function
+  | Some tier -> tier
+  | None -> failf "duration tier %s absent from persistence proof" id
+;;
+
+let append_turn_exchange config keeper_name ts =
+  Masc.Keeper_types_support.append_jsonl_line
+    (Masc.Keeper_types_support.keeper_decision_log_path config keeper_name)
+    (`Assoc [ "channel", `String "turn"; "ts_unix", `Float ts ])
+;;
+
 let test_stale_keeper_fails_runtime_liveness () =
   with_workspace
   @@ fun config ->
@@ -236,6 +252,57 @@ let test_stopped_keeper_fails_board_reactive_autonomy () =
     (U.member "status" feature |> U.to_string)
 ;;
 
+let test_persistence_duration_tiers_use_durable_turn_history () =
+  with_workspace
+  @@ fun config ->
+  seed_keeper config ~name:"four-hours" ~last_turn_ts:(now -. hour_seconds) ();
+  seed_keeper config ~name:"twenty-four-hours" ~last_turn_ts:(now -. hour_seconds) ();
+  append_turn_exchange config "four-hours" (now -. (5.0 *. hour_seconds));
+  append_turn_exchange config "four-hours" (now -. (0.5 *. hour_seconds));
+  append_turn_exchange config "twenty-four-hours" (now -. (24.0 *. hour_seconds));
+  append_turn_exchange config "twenty-four-hours" now;
+  let feature =
+    Feature_proof.json ~config ~now ()
+    |> fun payload -> feature_by_id payload "persistent_24h_turn_exchange"
+  in
+  List.iter
+    (fun id ->
+      let tier = duration_tier feature id in
+      check
+        string
+        (id ^ " tier names its evidence semantics")
+        "durable_turn_span"
+        U.(member "evidence_kind" tier |> to_string);
+      check string (id ^ " tier passes for both keepers") "pass" U.(member "status" tier |> to_string);
+      check int (id ^ " tier observes both keepers") 2 U.(member "observed_count" tier |> to_int))
+    [ "1h"; "2h"; "4h" ];
+  let tier_24h = duration_tier feature "24h" in
+  check string "24h tier stays partial" "warn" U.(member "status" tier_24h |> to_string);
+  check
+    (list string)
+    "24h tier names only the keeper with sufficient durable history"
+    [ "twenty-four-hours" ]
+    (tier_24h |> U.member "observed_keepers" |> U.to_list |> List.map U.to_string)
+;;
+
+let test_persistence_duration_tiers_reject_future_turns () =
+  with_workspace
+  @@ fun config ->
+  seed_keeper config ~name:"future" ~last_turn_ts:(now -. hour_seconds) ();
+  append_turn_exchange config "future" (now -. (25.0 *. hour_seconds));
+  append_turn_exchange config "future" (now +. hour_seconds);
+  let feature =
+    Feature_proof.json ~config ~now ()
+    |> fun payload -> feature_by_id payload "persistent_24h_turn_exchange"
+  in
+  List.iter
+    (fun id ->
+      let tier = duration_tier feature id in
+      check string (id ^ " tier rejects a future latest turn") "fail" U.(member "status" tier |> to_string);
+      check int (id ^ " tier observes no keeper with future evidence") 0 U.(member "observed_count" tier |> to_int))
+    [ "1h"; "2h"; "4h"; "24h" ]
+;;
+
 let () =
   run
     "dashboard_keeper_feature_proof"
@@ -256,6 +323,16 @@ let () =
             "stopped keeper fails board_reactive_autonomy"
             `Quick
             test_stopped_keeper_fails_board_reactive_autonomy
+        ] )
+    ; ( "persistence_duration_tiers"
+      , [ test_case
+            "durable history proves 1h 2h 4h and 24h tiers"
+            `Quick
+            test_persistence_duration_tiers_use_durable_turn_history
+        ; test_case
+            "future timestamps cannot prove a duration tier"
+            `Quick
+            test_persistence_duration_tiers_reject_future_turns
         ] )
     ]
 ;;

--- a/test/test_keeper_claude_code_runtime.ml
+++ b/test/test_keeper_claude_code_runtime.ml
@@ -35,6 +35,10 @@ let prompt_too_long_result =
   {|{"type":"result","subtype":"success","is_error":true,"session_id":"__SESSION__","uuid":"turn-overflow-1","result":"Prompt is too long · the request is ~250000 tokens (limit 200000)","api_error_status":400}|}
 ;;
 
+let prompt_too_long_statusless_result =
+  {|{"type":"result","subtype":"success","is_error":true,"session_id":"__SESSION__","uuid":"turn-statusless-overflow-1","result":"Prompt is too long"}|}
+;;
+
 let mcp_initialize =
   {|{"type":"control_request","request_id":"mcp-init-1","request":{"subtype":"mcp_message","server_name":"masc","message":{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"claude-code-fixture","version":"1"}}}}}|}
 ;;
@@ -755,7 +759,7 @@ let history_uses_current_schema history =
     history
 ;;
 
-let test_keeper_shrinks_history_after_typed_context_error () =
+let test_keeper_shrinks_history_after_statusless_context_error () =
   let base_path = temp_workspace () in
   let first_prompt_marker = Filename.concat base_path "overflow-full-prompt.json" in
   let second_prompt_marker = Filename.concat base_path "overflow-shrunk-prompt.json" in
@@ -778,7 +782,7 @@ let test_keeper_shrinks_history_after_typed_context_error () =
        with_fixture_sequence
          ~first_prompt_marker
          ~second_prompt_marker
-         [ Emit prompt_too_long_result ]
+         [ Emit prompt_too_long_statusless_result ]
          [ Emit (assistant ~turn_id:"turn-shrunk" "MASC_CLAUDE_SHRUNK")
          ; Emit (result ~turn_id:"turn-shrunk" "MASC_CLAUDE_SHRUNK")
          ]
@@ -1295,9 +1299,9 @@ let () =
             `Quick
             test_agent_core_checkpoint_starts_official_client_turn
         ; test_case
-            "shrinks history after typed context error"
+            "shrinks history after statusless context error"
             `Quick
-            test_keeper_shrinks_history_after_typed_context_error
+            test_keeper_shrinks_history_after_statusless_context_error
         ; test_case
             "projects typed tool history and lifecycle"
             `Quick

--- a/test/test_keeper_multi_collaboration_acceptance.py
+++ b/test/test_keeper_multi_collaboration_acceptance.py
@@ -1,0 +1,118 @@
+import hashlib
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = (
+    REPO_ROOT
+    / "scripts"
+    / "harness"
+    / "workload"
+    / "keeper_multi_collaboration_acceptance.py"
+)
+CATALOG_PATH = (
+    REPO_ROOT
+    / "scripts"
+    / "fixtures"
+    / "keeper-multi-collaboration"
+    / "missions.json"
+)
+
+
+def load_acceptance_module():
+    spec = importlib.util.spec_from_file_location(
+        "keeper_multi_collaboration_acceptance",
+        SCRIPT_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+acceptance = load_acceptance_module()
+
+
+class KeeperMultiCollaborationAcceptanceTest(unittest.TestCase):
+    def test_catalog_has_exact_rw19_persistence_projection_mission(self):
+        catalog = acceptance.load_catalog(CATALOG_PATH)
+
+        self.assertEqual(len(catalog["missions"]), 19)
+        self.assertEqual(catalog["missions"][-1]["id"], "RW19")
+        self.assertEqual(
+            catalog["missions"][-1]["assertions"],
+            ["persistence_tiers_dashboard_projection_observed"],
+        )
+
+    def test_persistence_browser_validator_requires_exact_monotonic_fleet(self):
+        expected = {"keeper-a", "keeper-b"}
+        with tempfile.TemporaryDirectory() as tmp_name:
+            screenshot = Path(tmp_name) / "keeper-persistence-proof.png"
+            screenshot.write_bytes(b"png-evidence")
+            digest = hashlib.sha256(screenshot.read_bytes()).hexdigest()
+            proof = {
+                "schema": "masc.keeper_persistence_browser_evidence.v1",
+                "generated_at": "2026-08-14T12:00:00Z",
+                "interaction": "manual_refresh",
+                "tiers": [
+                    self.tier("1h", ["keeper-a", "keeper-b"], []),
+                    self.tier("2h", ["keeper-a"], ["keeper-b"]),
+                    self.tier("4h", ["keeper-a"], ["keeper-b"]),
+                    self.tier("24h", [], ["keeper-a", "keeper-b"]),
+                ],
+                "screenshot_file": screenshot.name,
+                "screenshot_bytes": screenshot.stat().st_size,
+                "screenshot_sha256": digest,
+            }
+
+            valid, detail = acceptance.validate_persistence_browser_evidence(
+                proof,
+                screenshot,
+                expected,
+            )
+            self.assertTrue(valid, detail)
+
+            proof["tiers"][2] = self.tier(
+                "4h",
+                ["keeper-b"],
+                ["keeper-a"],
+            )
+            valid, detail = acceptance.validate_persistence_browser_evidence(
+                proof,
+                screenshot,
+                expected,
+            )
+            self.assertFalse(valid)
+            self.assertIn("duration monotonicity", detail)
+
+    @staticmethod
+    def tier(tier_id, observed, missing):
+        keeper_count = len(observed) + len(missing)
+        observed_count = len(observed)
+        status = (
+            "fail"
+            if keeper_count == 0 or observed_count == 0
+            else "pass"
+            if observed_count == keeper_count
+            else "warn"
+        )
+        return {
+            "id": tier_id,
+            "status": status,
+            "evidence_kind": "durable_turn_span",
+            "keeper_count": keeper_count,
+            "observed_count": observed_count,
+            "missing_count": len(missing),
+            "observed_keepers": observed,
+            "missing_keepers": missing,
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_keeper_persistence_span_history.ml
+++ b/test/test_keeper_persistence_span_history.ml
@@ -158,6 +158,27 @@ let single_segment_control () =
       check string "control: first_ts comes from the current segment" "current"
         (origin_segment json))
 
+let rotated_first_and_single_current_latest_satisfy_tiers () =
+  let base = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base)
+    (fun () ->
+      let now = 1_700_000_000.0 in
+      write_segment base ~keeper:"sparse" ~rotation:(Some 1)
+        [ turn_row (now -. (5.0 *. hour)) ];
+      write_segment base ~keeper:"sparse" ~rotation:None
+        [ turn_row (now -. 60.0) ];
+      let stat, json = evidence ~now ~base ~keeper:"sparse" in
+      check bool "distinct persisted endpoints satisfy the 4h tier" true
+        (Proof.has_persistent_turn_span_for ~required_span_hours:4.0 ~now stat);
+      check (option int) "current segment contains one recent interaction"
+        (Some 1)
+        (match json_field "recent_interaction_count" json with
+         | Some (`Int n) -> Some n
+         | _ -> None);
+      check string "first endpoint is attributed to rotated history" "rotated"
+        (origin_segment json))
+
 (* Recency is a separate requirement from span: a long history whose last turn
    is a day stale must still fail, or a stopped keeper reads as healthy. *)
 let stale_latest_turn_fails () =
@@ -260,6 +281,8 @@ let () =
     [ ( "turn span"
       , [ test_case "rotated segment is reached" `Quick rotated_segment_reached
         ; test_case "control: single segment" `Quick single_segment_control
+        ; test_case "rotated first plus one current latest" `Quick
+            rotated_first_and_single_current_latest_satisfy_tiers
         ; test_case "stale latest turn fails" `Quick stale_latest_turn_fails
         ; test_case "no turn rows is explicit" `Quick no_turn_rows_is_explicit
         ; test_case "head budget exhaustion is explicit" `Quick

--- a/test/test_keeper_persistence_span_history.ml
+++ b/test/test_keeper_persistence_span_history.ml
@@ -81,7 +81,7 @@ let oversized_heartbeat_row ts =
 
 let evidence ~now ~base ~keeper =
   let config = Workspace.default_config base in
-  let stat = Proof.turn_span_stats ~config keeper in
+  let stat = Proof.turn_span_stats ~config ~now keeper in
   (stat, Proof.turn_span_evidence_json ~now keeper stat)
 
 let json_field name = function
@@ -216,6 +216,45 @@ let head_budget_exhaustion_is_explicit () =
          | Some (`Int n) -> Some n
          | _ -> None))
 
+let post_snapshot_turn_does_not_poison_valid_span () =
+  let base = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base)
+    (fun () ->
+      let now = 1_700_000_000.0 in
+      write_segment base ~keeper:"racing" ~rotation:None
+        [ turn_row (now -. (48.0 *. hour))
+        ; turn_row (now -. 60.0)
+        ; turn_row (now +. 1.0)
+        ];
+      let stat, json = evidence ~now ~base ~keeper:"racing" in
+      check bool "valid snapshot-relative span still passes" true
+        (Proof.has_persistent_turn_span ~now stat);
+      check (option (float 0.0)) "latest excludes the post-snapshot row"
+        (Some (now -. 60.0))
+        (float_field "latest_ts_unix" json);
+      check (option int) "post-snapshot row is not counted"
+        (Some 2)
+        (match json_field "recent_interaction_count" json with
+         | Some (`Int n) -> Some n
+         | _ -> None))
+
+let future_only_turns_do_not_prove_persistence () =
+  let base = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base)
+    (fun () ->
+      let now = 1_700_000_000.0 in
+      write_segment base ~keeper:"future" ~rotation:None
+        [ turn_row (now +. 1.0); turn_row (now +. hour) ];
+      let stat, json = evidence ~now ~base ~keeper:"future" in
+      check bool "future-only rows fail closed" false
+        (Proof.has_persistent_turn_span ~now stat);
+      check (option (float 0.0)) "future-only latest remains absent" None
+        (float_field "latest_ts_unix" json);
+      check string "future-only head is not accepted as history" "none"
+        (origin_segment json))
+
 let () =
   run "keeper persistence span history"
     [ ( "turn span"
@@ -225,5 +264,9 @@ let () =
         ; test_case "no turn rows is explicit" `Quick no_turn_rows_is_explicit
         ; test_case "head budget exhaustion is explicit" `Quick
             head_budget_exhaustion_is_explicit
+        ; test_case "post-snapshot row is ignored" `Quick
+            post_snapshot_turn_does_not_poison_valid_span
+        ; test_case "future-only rows fail closed" `Quick
+            future_only_turns_do_not_prove_persistence
         ] )
     ]

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -89,6 +89,7 @@ let roundtrip_corpus =
     "runtime_exhausted"
   ; Keeper_internal_error.capacity_backpressure_kind
   ; Keeper_internal_error.incomplete_tool_transcript_kind
+  ; Keeper_internal_error.provider_attempt_effect_fenced_kind
   ; "internal_error"
   ; "pre_dispatch_success"
   ; "provider_error"
@@ -178,6 +179,11 @@ let frozen_operator_disposition (receipt : R.t)
   else if
     String.equal terminal_reason Keeper_internal_error.incomplete_tool_transcript_kind
   then R.Disp_operator_reset_required, R.Reason_transcript_corruption
+  else if
+    String.equal
+      terminal_reason
+      Keeper_internal_error.provider_attempt_effect_fenced_kind
+  then R.Disp_unknown, R.Reason_provider_attempt_effect_fenced
   else if preflight_config_failure
   then R.Disp_fail_open_next_runtime, R.Reason_preflight_config_error
   else if
@@ -308,7 +314,72 @@ let () =
      = (R.Disp_operator_reset_required, R.Reason_transcript_corruption));
   check
     "transcript corruption emits operator broadcast"
-    (R.needs_operator_broadcast (fst transcript_corruption))
+    (R.needs_operator_broadcast (fst transcript_corruption));
+  let fenced_error =
+    Keeper_internal_error.Provider_attempt_effect_fenced
+      { runtime_id = "antigravity_subscription.gemini-3-6-flash-high"
+      ; effect_disposition = Keeper_provider_attempt_effect_core.Effect_attempted
+      ; diagnostic = "provider response did not prove whether the tool effect settled"
+      }
+  in
+  let fenced_json = Keeper_internal_error.masc_internal_error_to_json fenced_error in
+  check
+    "provider-attempt fence codec emits the canonical kind"
+    (Json_util.get_string fenced_json "kind"
+     = Some Keeper_internal_error.provider_attempt_effect_fenced_kind);
+  check
+    "provider-attempt fence codec round-trips the typed evidence"
+    (Keeper_internal_error.parse_masc_internal_error_json fenced_json
+     = Some fenced_error);
+  let fenced_wire = Keeper_internal_error.provider_attempt_effect_fenced_kind in
+  let producer_wire =
+    fenced_error
+    |> Keeper_internal_error.core_error_of_masc_internal_error
+    |> Masc.Keeper_agent_error.terminal_reason_code_of_core_error
+  in
+  check
+    "provider-attempt fence producer projects the canonical terminal wire"
+    (String.equal producer_wire fenced_wire);
+  check
+    "provider-attempt fence wire decodes to the closed terminal variant"
+    (match Tr.of_wire fenced_wire with
+     | Tr.Provider_attempt_effect_fenced wire -> String.equal wire fenced_wire
+     | _ -> false);
+  check
+    "provider-attempt fence terminal wire round-trips byte-identically"
+    (String.equal (Tr.to_wire (Tr.of_wire fenced_wire)) fenced_wire);
+  let unmapped_metric = Keeper_metrics.(to_string ReceiptUnmappedDisposition) in
+  let unmapped_before = Masc.Otel_metric_store.metric_value_or_zero unmapped_metric () in
+  let fenced_disposition =
+    R.operator_disposition
+      { base_receipt with
+        terminal_reason_code = fenced_wire
+      ; error_kind = Some (R.error_kind_of_string "internal")
+      ; outcome = `Error
+      ; runtime_outcome = R.Runtime_failed
+      }
+  in
+  let unmapped_after = Masc.Otel_metric_store.metric_value_or_zero unmapped_metric () in
+  check
+    "provider-attempt fence keeps operator attention with a typed reason"
+    (fenced_disposition
+     = (R.Disp_unknown, R.Reason_provider_attempt_effect_fenced));
+  check
+    "provider-attempt fence reason has the canonical dashboard wire"
+    (String.equal
+       (R.operator_disposition_reason_to_string (snd fenced_disposition))
+       fenced_wire);
+  check
+    "attempted provider effect still forbids same-turn retry"
+    (not
+       (Keeper_provider_attempt_effect_core.allows_same_turn_retry
+          Keeper_provider_attempt_effect_core.Effect_attempted));
+  check
+    "provider-attempt fence still emits an operator broadcast"
+    (R.needs_operator_broadcast (fst fenced_disposition));
+  check
+    "provider-attempt fence does not increment the unmapped regression metric"
+    (Float.equal unmapped_before unmapped_after)
 ;;
 
 let () =

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -179,6 +179,20 @@ let parse_json raw =
   try Yojson.Safe.from_string raw with
   | Yojson.Json_error err -> fail ("invalid json: " ^ err)
 
+let structured_tool_output_exn ~base_path content =
+  match Tool_output.decode_from_agent_core content with
+  | Tool_output.Not_marker -> parse_json content
+  | Tool_output.Invalid_marker { detail } -> fail detail
+  | Tool_output.Decoded reference ->
+    if not (String.equal reference.mime Tool_output.artifact_manifest_mime)
+    then fail "tool output marker is not a typed result manifest";
+    let payload = fetch_artifact_exn ~base_path reference |> parse_json in
+    (match Tool_output.artifact_manifest_of_json payload with
+     | Tool_output.Decoded_artifact_manifest { structured_content; _ } ->
+       structured_content
+     | Tool_output.Not_artifact_manifest -> fail "typed result manifest is absent"
+     | Tool_output.Invalid_artifact_manifest { detail } -> fail detail)
+
 let outcome_label = function
   | Tool_result.Completed () -> "success"
   | Tool_result.Deferred () -> "deferred"
@@ -4773,6 +4787,67 @@ value = {}
 |}
 ;;
 
+let shell_output_composition =
+  {|[[compositions]]
+name = "shell-output"
+description = "Feed one typed Shell IR result into a later Keeper tool."
+execution = "inline"
+
+[[compositions.nodes]]
+id = "emit"
+tool = "Execute"
+[compositions.nodes.input]
+kind = "literal"
+value = { argv = ["printf", "shell-composition-marker"] }
+
+[[compositions.nodes]]
+id = "search"
+tool = "keeper_memory_search"
+after = ["emit"]
+[compositions.nodes.input]
+kind = "object"
+[[compositions.nodes.input.fields]]
+name = "query"
+[compositions.nodes.input.fields.value]
+kind = "output"
+node = "emit"
+pointer = "/output"
+|}
+;;
+
+let shell_artifact_composition () =
+  let oversized_output =
+    String.make (Masc.Tool_bridge.default_externalize_threshold_bytes + 1) 'x'
+  in
+  Printf.sprintf
+    {|[[compositions]]
+name = "shell-artifact"
+description = "Feed one typed Shell IR artifact identity into a later Keeper tool."
+execution = "inline"
+
+[[compositions.nodes]]
+id = "emit"
+tool = "Execute"
+[compositions.nodes.input]
+kind = "literal"
+value = { argv = ["printf", "%s"] }
+
+[[compositions.nodes]]
+id = "search"
+tool = "keeper_memory_search"
+after = ["emit"]
+[compositions.nodes.input]
+kind = "object"
+[[compositions.nodes.input.fields]]
+name = "query"
+[compositions.nodes.input.fields.value]
+kind = "output"
+node = "emit"
+pointer = "/output_artifact/_blob/sha256"
+|}
+    oversized_output
+;;
+
 let test_composition_catalog_materializes_and_executes_first_class_tool () =
   with_exec_fixture "composition-first-class-tool"
     (fun ~config ~meta ~publication_recovery ~ctx_work ->
@@ -4843,6 +4918,482 @@ let test_composition_catalog_materializes_and_executes_first_class_tool () =
                  (List.mem_assoc "data" fields)
              | _ -> fail "nested action result lost typed result shape")
           | _ -> fail "composition did not expose its single settled action"))
+;;
+
+let test_composition_feeds_typed_shell_ir_output_to_later_tool () =
+  with_exec_fixture
+    ~process:true
+    ~always_allow:true
+    "composition-shell-ir-output"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       let composition_catalog =
+         match Masc.Keeper_tool_composition_catalog.parse shell_output_composition with
+         | Ok catalog -> catalog
+         | Error error ->
+           fail (Masc.Keeper_tool_composition_catalog.error_to_string error)
+       in
+       let tools =
+         Masc.Keeper_tools_agent_core_bundle.make_tools
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot:ctx_work
+           ~composition_catalog
+           ()
+       in
+       let tool =
+         match find_tool_by_name tools "keeper_compose_shell-output" with
+         | Some tool -> tool
+         | None -> fail "Shell IR composition was not materialized"
+       in
+       match
+         Agent_core.Tool.execute
+           ~invocation:
+             (composition_invocation
+                ~completion:Agent_core.Tool_contract.Continue_after_success)
+           tool
+           (`Assoc [])
+       with
+       | Error error -> fail error.Agent_core.Types.message
+       | Ok output ->
+         let payload = parse_json output.content in
+         (match Yojson.Safe.Util.member "actions" payload with
+          | `List [ emit; search ] ->
+            check string
+              "Shell IR node"
+              "Execute"
+              Yojson.Safe.Util.(member "tool_name" emit |> to_string);
+            check bool
+              "Shell IR typed result"
+              true
+              Yojson.Safe.Util.
+                (member "result" emit |> member "data" |> member "typed" |> to_bool);
+            check string
+              "Shell IR exact output"
+              "shell-composition-marker"
+              Yojson.Safe.Util.
+                (member "result" emit |> member "data" |> member "output" |> to_string);
+            check string
+              "later node receives typed Shell IR output"
+              "shell-composition-marker"
+              Yojson.Safe.Util.(member "input" search |> member "query" |> to_string)
+          | _ -> fail "Shell IR composition did not settle both nodes in planned order"))
+;;
+
+let test_composition_externalizes_oversized_shell_ir_output () =
+  with_exec_fixture
+    ~process:true
+    ~always_allow:true
+    "composition-shell-ir-artifact"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       Masc.Keeper_tool_call_log.reset_for_testing ();
+       Masc.Keeper_tool_call_log.init ~base_path:config.base_path ();
+       let turn_ctx_cell = Masc.Keeper_tool_call_log.create_turn_ctx_cell () in
+       let composition_catalog =
+         match
+           Masc.Keeper_tool_composition_catalog.parse
+             (shell_artifact_composition ())
+         with
+         | Ok catalog -> catalog
+         | Error error ->
+           fail (Masc.Keeper_tool_composition_catalog.error_to_string error)
+       in
+       let tools =
+         Masc.Keeper_tools_agent_core_bundle.make_tools
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot:ctx_work
+           ~composition_catalog
+           ~turn_ctx_cell
+           ()
+       in
+       let tool =
+         match find_tool_by_name tools "keeper_compose_shell-artifact" with
+         | Some tool -> tool
+         | None -> fail "Shell IR artifact composition was not materialized"
+       in
+       match
+         Agent_core.Tool.execute
+           ~invocation:
+             (composition_invocation
+                ~completion:Agent_core.Tool_contract.Continue_after_success)
+           tool
+           (`Assoc [])
+       with
+       | Error error -> fail error.Agent_core.Types.message
+       | Ok output ->
+         let payload =
+           structured_tool_output_exn
+             ~base_path:config.base_path
+             output.content
+         in
+         (match Yojson.Safe.Util.member "actions" payload with
+          | `List [ emit; search ] ->
+            let data = Yojson.Safe.Util.(member "result" emit |> member "data") in
+            check
+              bool
+              "oversized output is not retained inline"
+              true
+              (Yojson.Safe.Util.member "output" data = `Null);
+            let artifact_ref field =
+              match
+                Yojson.Safe.Util.member field data
+                |> Tool_output.normalized_artifact_ref_of_json
+              with
+              | Tool_output.Decoded_normalized_artifact_ref reference -> reference
+              | Tool_output.Not_normalized_artifact_ref ->
+                failf
+                  "oversized Shell IR output has no normalized %s reference"
+                  field
+              | Tool_output.Invalid_normalized_artifact_ref { detail } -> fail detail
+            in
+            let output_ref = artifact_ref "output_artifact" in
+            let stdout_ref = artifact_ref "stdout_artifact" in
+            let stderr_ref = artifact_ref "stderr_artifact" in
+            check string "combined output equals stdout" output_ref.sha256 stdout_ref.sha256;
+            check int "empty stderr is still explicit" 0 stderr_ref.bytes;
+            let artifact =
+              fetch_artifact_exn ~base_path:config.base_path output_ref
+            in
+            check
+              int
+              "artifact retains every output byte"
+              (Masc.Tool_bridge.default_externalize_threshold_bytes + 1)
+              (String.length artifact);
+            let durable_root_present =
+              Masc.Keeper_tool_call_log.read_recent
+                ~keeper_name:meta.name
+                ~n:10
+                ()
+              |> List.exists (fun row ->
+                Safe_ops.json_string_opt "composition_node_id" row = Some "emit"
+                &&
+                match Yojson.Safe.Util.member "artifact_refs" row with
+                | `List roots ->
+                  List.exists
+                    (fun root ->
+                       let blob = Yojson.Safe.Util.member "_blob" root in
+                       Safe_ops.json_string_opt "sha256" blob
+                       = Some output_ref.sha256
+                       && Safe_ops.json_string_opt "preview" blob = Some "")
+                    roots
+                | _ -> false)
+            in
+            check
+              bool
+              "durable action log owns a preview-free artifact root"
+              true
+              durable_root_present;
+            let maintenance mode =
+              match
+                Tool_blob_maintenance.run ~base_path:config.base_path ~mode
+              with
+              | Ok report -> report
+              | Error error ->
+                fail (Tool_blob_maintenance.error_to_string error)
+            in
+            let observed = maintenance Tool_blob_maintenance.Observe_only in
+            check
+              bool
+              "durable action evidence roots the stream artifacts"
+              true
+              (observed.live_references >= 2);
+            ignore
+              (maintenance Tool_blob_maintenance.Delete_previous_candidates);
+            check
+              string
+              "maintenance preserves the referenced output"
+              artifact
+              (fetch_artifact_exn ~base_path:config.base_path output_ref);
+            check
+              string
+              "later node receives the artifact identity"
+              output_ref.sha256
+              Yojson.Safe.Util.(member "input" search |> member "query" |> to_string)
+          | _ ->
+            fail
+              "Shell IR artifact composition did not settle both nodes in planned order"))
+;;
+
+let test_direct_execute_artifact_manifest_survives_maintenance () =
+  with_exec_fixture
+    ~process:true
+    ~always_allow:true
+    "direct-shell-ir-artifact"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       let execute =
+         Masc.Keeper_tools_agent_core_bundle.make_tools
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot:ctx_work
+           ()
+         |> List.find_opt (fun (tool : Agent_core.Tool.t) ->
+           String.equal tool.schema.name "Execute")
+         |> function
+         | Some tool -> tool
+         | None -> fail "direct Execute tool is absent"
+       in
+       let oversized =
+         String.make (Masc.Tool_bridge.default_externalize_threshold_bytes + 1) 'd'
+       in
+       let output =
+         match
+           Agent_core.Tool.execute
+             ~invocation:
+               (composition_invocation
+                  ~completion:Agent_core.Tool_contract.Continue_after_success)
+             execute
+             (`Assoc [ "argv", `List [ `String "printf"; `String oversized ] ])
+         with
+         | Ok output -> output.Agent_core.Types.content
+         | Error error -> fail error.Agent_core.Types.message
+       in
+       let manifest_ref =
+         match Tool_output.decode_from_agent_core output with
+         | Tool_output.Decoded reference
+           when String.equal reference.mime Tool_output.artifact_manifest_mime ->
+           reference
+         | Tool_output.Decoded _ -> fail "direct Execute returned a non-manifest marker"
+         | Tool_output.Not_marker -> fail "direct Execute artifact result stayed inline"
+         | Tool_output.Invalid_marker { detail } -> fail detail
+       in
+       let durable_checkpoint =
+         Filename.concat
+           (Common.masc_dir_from_base_path ~base_path:config.base_path)
+           "keepers/direct-execute/checkpoint.json"
+       in
+       Fs_compat.mkdir_p (Filename.dirname durable_checkpoint);
+       Fs_compat.save_file
+         durable_checkpoint
+         (Yojson.Safe.to_string (`Assoc [ "tool_result", `String output ]));
+       let structured =
+         structured_tool_output_exn ~base_path:config.base_path output
+       in
+       let output_ref =
+         Yojson.Safe.Util.member "output_artifact" structured
+         |> Tool_output.normalized_artifact_ref_of_json
+         |> function
+         | Tool_output.Decoded_normalized_artifact_ref reference -> reference
+         | Tool_output.Not_normalized_artifact_ref ->
+           fail "direct Execute manifest lost its child output reference"
+         | Tool_output.Invalid_normalized_artifact_ref { detail } -> fail detail
+       in
+       let maintenance mode =
+         match Tool_blob_maintenance.run ~base_path:config.base_path ~mode with
+         | Ok report -> report
+         | Error error -> fail (Tool_blob_maintenance.error_to_string error)
+       in
+       let observed = maintenance Tool_blob_maintenance.Observe_only in
+       check bool
+         "direct checkpoint roots manifest and child streams"
+         true
+         (observed.live_references >= 3);
+       ignore (maintenance Tool_blob_maintenance.Delete_previous_candidates);
+       check string
+         "direct Execute child survives both maintenance passes"
+         oversized
+         (fetch_artifact_exn ~base_path:config.base_path output_ref);
+       check bool
+         "manifest itself survives both maintenance passes"
+         true
+         (match
+            Tool_blob_store.fetch
+              (Tool_blob_store.create ~base_path:config.base_path)
+              ~sha256:manifest_ref.sha256
+          with
+          | Ok (Some _) -> true
+          | Ok None | Error _ -> false))
+;;
+
+let test_direct_execute_post_effect_artifact_failure_closes_official_client_loop () =
+  with_exec_fixture
+    ~process:true
+    ~always_allow:true
+    "direct-shell-ir-post-effect-artifact-failure"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       let bundle =
+         Masc.Keeper_tools_agent_core_bundle.make_tool_bundle
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot:ctx_work
+           ()
+       in
+       Fun.protect
+         ~finally:bundle.cleanup
+         (fun () ->
+            let blob_root =
+              Tool_blob_store.create ~base_path:config.base_path
+              |> Tool_blob_store.root_dir
+            in
+            Fs_compat.mkdir_p (Filename.dirname blob_root);
+            Fs_compat.save_file blob_root "artifact persistence is blocked";
+            let marker = Filename.concat config.base_path "execute-invocations" in
+            let oversized =
+              String.make
+                (Masc.Tool_bridge.default_externalize_threshold_bytes + 1)
+                'p'
+            in
+            let terminal_error = ref None in
+            let projected =
+              match
+                Masc.Keeper_official_client_host.dynamic_tools
+                  ~runtime_label:"test-official-client"
+                  ~keeper_name:meta.name
+                  ~turn_count:1
+                  ~tools:bundle.tools
+                  ~hooks:Agent_core.Hooks.empty
+                  ~event_bus:None
+                  ~context_injector:None
+                  ~context:(Some (Agent_core.Context.create_sync ()))
+                  ~terminal_effect_state:bundle.terminal_effect_state
+                  ~terminal_error
+                  ~raw_trace_run:None
+              with
+              | Ok tools -> tools
+              | Error error -> fail (Agent_core.Error.to_string error)
+            in
+            let execute =
+              projected
+              |> List.find_opt
+                   (fun (tool : Masc.Keeper_official_client_host.dynamic_tool) ->
+                      String.equal tool.name "Execute")
+              |> function
+              | Some tool -> tool
+              | None -> fail "direct Execute tool was not projected"
+            in
+            let result =
+              execute.call
+                ~call_id:"direct-execute-post-effect-failure"
+                (`Assoc
+                   [ ( "argv"
+                     , `List
+                         [ `String "/bin/sh"
+                         ; `String "-c"
+                         ; `String "printf x >> \"$1\"; printf %s \"$2\""
+                         ; `String "keeper-execute-test"
+                         ; `String marker
+                         ; `String oversized
+                         ] )
+                   ])
+            in
+            check bool "artifact persistence failure is visible" false result.success;
+            check string
+              "the process effect occurs exactly once before settlement"
+              "x"
+              (read_file marker);
+            (match bundle.terminal_effect_state () with
+             | Masc.Keeper_tools_agent_core.Terminal_effect_failed
+                 { effect_disposition = Tool_result.Proven_post_effect; _ } ->
+               ()
+             | _ -> fail "ordinary Execute post-effect failure left bundle open");
+            match result.abort_turn with
+            | Some
+                (Masc.Keeper_official_client_host.Terminal_tool_boundary
+                  { tool_name = "Execute"
+                  ; outcome =
+                      Masc.Keeper_official_client_host.Terminal_failed
+                        { effect_disposition = Tool_result.Proven_post_effect; _ }
+                  }) ->
+              ()
+            | Some
+                (Masc.Keeper_official_client_host.Terminal_tool_boundary _)
+            | Some (Masc.Keeper_official_client_host.Repeated_tool_call _)
+            | None ->
+              fail "direct Execute post-effect failure remained provider-retryable"))
+;;
+
+let test_direct_pre_effect_and_readonly_failures_remain_correction_capable () =
+  with_exec_fixture
+    ~process:true
+    ~always_allow:true
+    "direct-pre-effect-correction"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       let bundle =
+         Masc.Keeper_tools_agent_core_bundle.make_tool_bundle
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot:ctx_work
+           ()
+       in
+       Fun.protect
+         ~finally:bundle.cleanup
+         (fun () ->
+            let terminal_error = ref None in
+            let projected =
+              match
+                Masc.Keeper_official_client_host.dynamic_tools
+                  ~runtime_label:"test-official-client"
+                  ~keeper_name:meta.name
+                  ~turn_count:1
+                  ~tools:bundle.tools
+                  ~hooks:Agent_core.Hooks.empty
+                  ~event_bus:None
+                  ~context_injector:None
+                  ~context:(Some (Agent_core.Context.create_sync ()))
+                  ~terminal_effect_state:bundle.terminal_effect_state
+                  ~terminal_error
+                  ~raw_trace_run:None
+              with
+              | Ok tools -> tools
+              | Error error -> fail (Agent_core.Error.to_string error)
+            in
+            let call name input =
+              let tool =
+                projected
+                |> List.find_opt
+                     (fun (tool : Masc.Keeper_official_client_host.dynamic_tool) ->
+                        String.equal tool.name name)
+                |> function
+                | Some tool -> tool
+                | None -> failf "%s was not projected" name
+              in
+              tool.call ~call_id:("correction-" ^ name) input
+            in
+            let invalid_execute =
+              call "Execute" (`Assoc [ "argv", `List [ `String "" ] ])
+            in
+            check bool "invalid Execute is a failure" false invalid_execute.success;
+            check
+              (option string)
+              "pre-effect Execute failure keeps the turn open"
+              None
+              (Option.map
+                 (fun _ -> "abort")
+                 invalid_execute.abort_turn);
+            let invalid_write =
+              call
+                "Write"
+                (`Assoc
+                   [ "file_path", `String ""
+                   ; "content", `String "must not be written"
+                   ])
+            in
+            check bool "invalid Write is a failure" false invalid_write.success;
+            check
+              (option string)
+              "unaudited ordinary producer keeps its prior correction behavior"
+              None
+              (Option.map (fun _ -> "abort") invalid_write.abort_turn);
+            let missing_artifact =
+              call
+                "keeper_artifact_read"
+                (`Assoc [ "sha256", `String (String.make 64 '0') ])
+            in
+            check bool "missing artifact is a failure" false missing_artifact.success;
+            check
+              (option string)
+              "read-only failure keeps the turn open"
+              None
+              (Option.map
+                 (fun _ -> "abort")
+                 missing_artifact.abort_turn);
+            match bundle.terminal_effect_state () with
+            | Masc.Keeper_tools_agent_core.Terminal_effect_open -> ()
+            | _ -> fail "correction-capable failures poisoned terminal state"))
 ;;
 
 let test_composition_action_commit_advances_revision_before_refresh_event () =
@@ -5784,6 +6335,16 @@ let () =
         test_composition_runtime_uses_canonical_descriptor;
       test_case "catalog composition is a first-class executable tool" `Quick
         test_composition_catalog_materializes_and_executes_first_class_tool;
+      test_case "composition feeds typed Shell IR output to later tool" `Quick
+        test_composition_feeds_typed_shell_ir_output_to_later_tool;
+      test_case "composition externalizes oversized Shell IR output" `Quick
+        test_composition_externalizes_oversized_shell_ir_output;
+      test_case "direct Execute artifact manifest survives maintenance" `Quick
+        test_direct_execute_artifact_manifest_survives_maintenance;
+      test_case "direct Execute artifact failure closes official-client loop" `Quick
+        test_direct_execute_post_effect_artifact_failure_closes_official_client_loop;
+      test_case "direct pre-effect and read-only failures remain correction-capable" `Quick
+        test_direct_pre_effect_and_readonly_failures_remain_correction_capable;
       test_case "composition action commit refreshes dashboard evidence" `Quick
         test_composition_action_commit_advances_revision_before_refresh_event;
       test_case "composition telemetry outage preserves execution" `Quick

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -6143,6 +6143,118 @@ let test_async_composition_uses_durable_request_status_surface () =
            Yojson.Safe.Util.(member "result" payload |> member "composition_tool" |> to_string))
 ;;
 
+let test_async_composition_status_preserves_artifact_manifest () =
+  with_exec_fixture
+    ~bind_eio_context:true
+    "composition-async-artifact-status"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       ignore publication_recovery;
+       ignore ctx_work;
+       let artifact_reference =
+         Tool_blob_store.put_durable
+           (Tool_blob_store.create ~base_path:config.base_path)
+           ~bytes:"async artifact payload"
+           ~mime:"text/plain"
+       in
+       let structured_data =
+         `Assoc
+           [ ( "output_artifact"
+             , Tool_output.normalized_artifact_ref_to_json artifact_reference )
+           ]
+       in
+       let background_sw =
+         match Masc.Keeper_msg_async.server_background_switch () with
+         | Ok sw -> sw
+         | Error error ->
+           fail
+             (Masc.Keeper_msg_async.submit_error_to_json error
+              |> Yojson.Safe.to_string)
+       in
+       let request_id =
+         match Masc.Keeper_msg_async.submit
+                 ~background_sw
+                 ~base_path:config.base_path
+                 ~caller:meta.name
+                 ~keeper_name:meta.name
+                 ~f:(fun _request_sw ->
+                   Tool_result.make_ok
+                     ~tool_name:"keeper_compose_artifact-fixture"
+                     ~start_time:(Time_compat.now ())
+                     ~data:structured_data
+                     ())
+                 ()
+         with
+         | Ok outcome -> outcome.request_id
+         | Error error ->
+           fail
+             (Masc.Keeper_msg_async.submit_error_to_json error
+              |> Yojson.Safe.to_string)
+       in
+       let rec await_terminal () =
+         match
+           Masc.Keeper_msg_async.poll
+             ~base_path:config.base_path
+             ~caller:meta.name
+             request_id
+         with
+         | Masc.Keeper_msg_async.Found
+             ({ status = Masc.Keeper_msg_async.Done _; _ } as entry) ->
+           entry
+         | Masc.Keeper_msg_async.Found
+             { status =
+                 ( Masc.Keeper_msg_async.Queued
+                 | Masc.Keeper_msg_async.Running
+                 | Masc.Keeper_msg_async.Cancelling _ )
+             ; _
+             } ->
+           Eio.Fiber.yield ();
+           await_terminal ()
+         | Masc.Keeper_msg_async.Found _ ->
+           fail "async artifact composition did not complete"
+         | Masc.Keeper_msg_async.Absent -> fail "async artifact request disappeared"
+         | Masc.Keeper_msg_async.Unreadable reason -> fail reason
+         | Masc.Keeper_msg_async.Rejected _ ->
+           fail "async artifact request access was rejected"
+       in
+       let clock =
+         match Eio_context.get_clock_opt () with
+         | Some clock -> clock
+         | None -> fail "async artifact test lost its bound Eio clock"
+       in
+       ignore
+         (Eio.Time.with_timeout_exn clock 5.0 await_terminal
+           : Masc.Keeper_msg_async.entry);
+       let status_result =
+         Masc.Keeper_tool_composition_surface.For_testing.status_result
+           ~config
+           ~meta
+           ~request_id
+       in
+       match Masc.Tool_bridge.to_agent_core_typed_result
+               ~base_path:config.base_path
+               status_result
+       with
+       | Error error -> fail error.Agent_core.Types.message
+       | Ok output ->
+         let payload =
+           structured_tool_output_exn
+             ~base_path:config.base_path
+             output.content
+         in
+         check string "artifact status remains terminal" "done"
+           Yojson.Safe.Util.(member "status" payload |> to_string);
+         let artifact =
+           Yojson.Safe.Util.
+             (member "result" payload
+              |> member "output_artifact")
+         in
+         match Tool_output.normalized_artifact_ref_of_json artifact with
+         | Tool_output.Decoded_normalized_artifact_ref _ -> ()
+         | Tool_output.Not_normalized_artifact_ref ->
+           fail "async status dropped its normalized artifact reference"
+         | Tool_output.Invalid_normalized_artifact_ref { detail } -> fail detail)
+;;
+
 let test_composition_runtime_uses_canonical_descriptor () =
   with_exec_fixture "composition-canonical-descriptor"
     (fun ~config ~meta ~publication_recovery ~ctx_work ->
@@ -6361,6 +6473,8 @@ let () =
         test_terminal_composition_post_effect_defer_closes_without_resume;
       test_case "async composition exposes durable status" `Quick
         test_async_composition_uses_durable_request_status_surface;
+      test_case "async composition status preserves artifact manifest" `Quick
+        test_async_composition_status_preserves_artifact_manifest;
       test_case "terminal composition requires terminal outer invocation" `Quick
         test_composition_terminal_requires_terminal_outer_invocation;
     ]);

--- a/test/test_keeper_tool_emission_hook.ml
+++ b/test/test_keeper_tool_emission_hook.ml
@@ -1,5 +1,6 @@
-(* Keeper tool-emission capture accepts only producer-owned typed objects.
-   JSON-looking text from the model-facing AGENT_CORE body is never reparsed. *)
+(* Keeper tool-emission capture retains only explicitly tagged,
+   producer-owned typed objects. JSON-looking text from the model-facing
+   AGENT_CORE body is never reparsed. *)
 
 module H = Masc.Keeper_tool_emission_hook
 
@@ -66,10 +67,11 @@ let test_snapshot_does_not_drain () =
   assert_size "snapshot preserves" 1 acc
 ;;
 
-let test_drain_skips_unmarked_object () =
+let test_capture_does_not_retain_unmarked_object () =
   let acc = H.create_accumulator () in
   H.capture_typed_result acc (tagged ~kind:"doc" ~id:"doc-2" []);
   H.capture_typed_result acc (`Assoc [ "echo", `String "hello" ]);
+  assert_size "only tagged object retained" 1 acc;
   let context = H.drain_into_working_context acc ~working_context:None in
   let artifacts, _ =
     match Multimodal.Wirein_helpers.extract_raw_artifacts context with
@@ -122,9 +124,9 @@ let () =
         ; Alcotest.test_case "drain empties" `Quick test_drain_empties_accumulator
         ; Alcotest.test_case "snapshot preserves" `Quick test_snapshot_does_not_drain
         ; Alcotest.test_case
-            "unmarked object not emitted"
+            "unmarked object not retained"
             `Quick
-            test_drain_skips_unmarked_object
+            test_capture_does_not_retain_unmarked_object
         ] )
     ; ( "keeper registry"
       , [ Alcotest.test_case "isolates keepers" `Quick test_registry_isolates_keepers

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -404,6 +404,18 @@ let prompt_too_long_result =
   {|{"type":"result","subtype":"success","is_error":true,"session_id":"__SESSION__","uuid":"turn-400-1","result":"Prompt is too long · the request is ~250000 tokens (limit 200000)","api_error_status":400}|}
 ;;
 
+let prompt_too_long_statusless_result =
+  {|{"type":"result","subtype":"success","is_error":true,"session_id":"__SESSION__","uuid":"turn-statusless-overflow-1","result":"Prompt is too long"}|}
+;;
+
+let statusless_overflow_prose_result =
+  {|{"type":"result","subtype":"success","is_error":true,"session_id":"__SESSION__","uuid":"turn-statusless-generic-1","result":"gateway diagnostic mentioned Prompt is too long for an unrelated rejection"}|}
+;;
+
+let explicit_non_overflow_status_result =
+  {|{"type":"result","subtype":"success","is_error":true,"session_id":"__SESSION__","uuid":"turn-explicit-status-1","result":"Prompt is too long","api_error_status":500}|}
+;;
+
 let generic_400_result =
   {|{"type":"result","subtype":"success","is_error":true,"session_id":"__SESSION__","uuid":"turn-400-generic","result":"request rejected; diagnostic mentioned Prompt is too long without the provider prefix","api_error_status":400}|}
 ;;
@@ -439,6 +451,52 @@ let test_terminal_prompt_too_long_is_typed () =
         (Astring.String.is_infix ~affix:"api_status=400" message)
     | Error error -> fail (Runtime_claude_code.error_to_string error)
     | Ok _ -> fail "an is_error terminal was reported as completion")
+;;
+
+let test_statusless_canonical_prompt_too_long_is_typed () =
+  with_fixture [ Emit prompt_too_long_statusless_result ] (fun path ->
+    match run_fixture path with
+    | Error
+        (Runtime_claude_code.Context_window_exceeded
+          { message; tool_effect_attempted = false; response_emitted = false }) ->
+      check
+        bool
+        "canonical provider verdict survives into the typed failure"
+        true
+        (Astring.String.is_infix ~affix:"Prompt is too long" message);
+      check
+        bool
+        "missing status remains explicit"
+        true
+        (Astring.String.is_infix ~affix:"api_status=unknown" message)
+    | Error error -> fail (Runtime_claude_code.error_to_string error)
+    | Ok _ -> fail "a canonical statusless overflow was reported as completion")
+;;
+
+let test_statusless_overflow_prose_remains_turn_failed () =
+  with_fixture [ Emit statusless_overflow_prose_result ] (fun path ->
+    match run_fixture path with
+    | Error (Runtime_claude_code.Turn_failed detail) ->
+      check
+        bool
+        "unrelated statusless rejection keeps its diagnostic"
+        true
+        (Astring.String.is_infix ~affix:"unrelated rejection" detail)
+    | Error error -> fail (Runtime_claude_code.error_to_string error)
+    | Ok _ -> fail "unrelated statusless prose was reported as completion")
+;;
+
+let test_exact_overflow_sentence_with_non_overflow_status_remains_turn_failed () =
+  with_fixture [ Emit explicit_non_overflow_status_result ] (fun path ->
+    match run_fixture path with
+    | Error (Runtime_claude_code.Turn_failed detail) ->
+      check
+        bool
+        "explicit non-overflow status remains authoritative"
+        true
+        (Astring.String.is_infix ~affix:"api_status=500" detail)
+    | Error error -> fail (Runtime_claude_code.error_to_string error)
+    | Ok _ -> fail "an explicit non-overflow status was reported as completion")
 ;;
 
 let test_unrelated_400_remains_turn_failed () =
@@ -1246,6 +1304,18 @@ let () =
             "terminal_reason prompt_too_long is typed"
             `Quick
             test_terminal_reason_prompt_too_long_is_typed
+        ; test_case
+            "statusless canonical prompt too long is typed"
+            `Quick
+            test_statusless_canonical_prompt_too_long_is_typed
+        ; test_case
+            "statusless overflow prose remains turn failed"
+            `Quick
+            test_statusless_overflow_prose_remains_turn_failed
+        ; test_case
+            "exact overflow sentence with non-overflow status remains turn failed"
+            `Quick
+            test_exact_overflow_sentence_with_non_overflow_status_remains_turn_failed
         ; test_case
             "non-overflow terminal_reason beats prefix prose"
             `Quick

--- a/test/test_tool_blob_store.ml
+++ b/test/test_tool_blob_store.ml
@@ -744,6 +744,95 @@ let test_maintenance_keeps_normalized_tool_call_blob_reference () =
         (Some "normalized tool-call output")
         (fetch_ok store ~sha256:reference.sha256))
 
+let test_maintenance_follows_typed_result_manifest () =
+  with_temp_dir (fun base_path ->
+      let store = B.create ~base_path in
+      let child =
+        B.put_durable store ~bytes:"manifest-owned child" ~mime:"text/plain"
+      in
+      let structured_content =
+        `Assoc [ "output_artifact", O.normalized_artifact_ref_to_json child ]
+      in
+      let manifest_payload =
+        O.artifact_manifest_to_json
+          ~content:(Yojson.Safe.to_string structured_content)
+          ~structured_content
+        |> Yojson.Safe.to_string
+      in
+      let manifest =
+        B.put_durable
+          store
+          ~bytes:manifest_payload
+          ~mime:O.artifact_manifest_mime
+      in
+      let checkpoint =
+        Filename.concat
+          (Common.masc_dir_from_base_path ~base_path)
+          "keepers/keeper-a/checkpoint.json"
+      in
+      Fs_compat.mkdir_p (Filename.dirname checkpoint);
+      Fs_compat.save_file
+        checkpoint
+        (Yojson.Safe.to_string
+           (`Assoc
+             [ ( "tool_result"
+               , `String (O.encode_for_agent_core (O.Stored manifest)) ) ]));
+      let observed = maintenance_ok ~base_path ~mode:M.Observe_only in
+      Alcotest.(check int)
+        "checkpoint marker roots manifest and child"
+        2
+        observed.live_references;
+      Alcotest.(check int) "manifest graph has no candidates" 0 observed.candidates_recorded;
+      let swept =
+        maintenance_ok ~base_path ~mode:M.Delete_previous_candidates
+      in
+      Alcotest.(check int) "manifest graph survives the second pass" 0 swept.deleted;
+      Alcotest.(check (option string))
+        "manifest-owned child remains readable"
+        (Some "manifest-owned child")
+        (fetch_ok store ~sha256:child.sha256))
+
+let test_maintenance_rejects_malformed_typed_result_manifest () =
+  with_temp_dir (fun base_path ->
+      let store = B.create ~base_path in
+      let survivor =
+        B.put_durable store ~bytes:"survive malformed manifest" ~mime:"text/plain"
+      in
+      let malformed =
+        O.artifact_manifest_to_json
+          ~content:"malformed"
+          ~structured_content:
+            (`Assoc
+               [ ( "output_artifact"
+                 , `Assoc [ "_blob", `Assoc [ "sha256", `String survivor.sha256 ] ]
+                 )
+               ])
+        |> Yojson.Safe.to_string
+      in
+      let manifest =
+        B.put_durable store ~bytes:malformed ~mime:O.artifact_manifest_mime
+      in
+      let checkpoint =
+        Filename.concat
+          (Common.masc_dir_from_base_path ~base_path)
+          "keepers/keeper-a/checkpoint.json"
+      in
+      Fs_compat.mkdir_p (Filename.dirname checkpoint);
+      Fs_compat.save_file
+        checkpoint
+        (Yojson.Safe.to_string
+           (`String (O.encode_for_agent_core (O.Stored manifest))));
+      (match M.run ~base_path ~mode:M.Delete_previous_candidates with
+       | Error (M.Artifact_manifest_invalid { sha256; _ }) ->
+         Alcotest.(check string) "exact malformed manifest" manifest.sha256 sha256
+       | Error error ->
+         Alcotest.failf "unexpected maintenance error: %s" (M.error_to_string error)
+       | Ok _ -> Alcotest.fail "malformed typed manifest reached deletion");
+      Alcotest.(check (option string))
+        "malformed manifest abort preserves unrelated blobs"
+        (Some "survive malformed manifest")
+        (fetch_ok store ~sha256:survivor.sha256))
+
 let test_maintenance_malformed_normalized_blob_fails_closed () =
   with_temp_dir (fun base_path ->
       let store = B.create ~base_path in
@@ -1150,6 +1239,14 @@ let () =
             "maintenance keeps normalized tool-call blob reference"
             `Quick
             test_maintenance_keeps_normalized_tool_call_blob_reference;
+          Alcotest.test_case
+            "maintenance follows typed result manifest"
+            `Quick
+            test_maintenance_follows_typed_result_manifest;
+          Alcotest.test_case
+            "maintenance rejects malformed typed result manifest"
+            `Quick
+            test_maintenance_rejects_malformed_typed_result_manifest;
           Alcotest.test_case
             "maintenance malformed normalized blob fails closed"
             `Quick

--- a/test/test_tool_bridge_externalize.ml
+++ b/test/test_tool_bridge_externalize.ml
@@ -83,6 +83,101 @@ let test_incident_sized_result_stays_inline () =
       Alcotest.(check bool) "no blob marker" false (O.is_marker content)
     | Error _ -> Alcotest.fail "expected inline result")
 
+let test_typed_artifact_result_becomes_durable_manifest () =
+  with_temp_base_path (fun base_path ->
+    let store = Tool_blob_store.create ~base_path in
+    let child =
+      Tool_blob_store.put_durable
+        store
+        ~bytes:"exact child output"
+        ~mime:"text/plain"
+    in
+    let structured_content =
+      `Assoc
+        [ "ok", `Bool true
+        ; "output_artifact", O.normalized_artifact_ref_to_json child
+        ]
+    in
+    let result =
+      Tool_result.make_ok
+        ~tool_name:"Execute"
+        ~start_time:0.0
+        ~data:structured_content
+        ()
+      |> B.attach_artifact_manifest ~base_path
+    in
+    let result =
+      match result with
+      | Ok result -> result
+      | Error { message; _ } -> Alcotest.fail message
+    in
+    (match B.to_agent_core_typed_result result with
+     | Ok { content; _ } ->
+       Alcotest.(check bool)
+         "manifest marker requires artifact-reader capability"
+         false
+         (O.is_marker content)
+     | Error { message; _ } -> Alcotest.fail message);
+    match B.to_agent_core_typed_result ~base_path result with
+    | Error { message; _ } -> Alcotest.fail message
+    | Ok { content; _ } ->
+      (match O.decode_from_agent_core content with
+       | O.Not_marker -> Alcotest.fail "typed artifact result stayed unrooted inline"
+       | O.Invalid_marker { detail } -> Alcotest.fail detail
+       | O.Decoded manifest_ref ->
+         Alcotest.(check string)
+           "typed manifest media type"
+           O.artifact_manifest_mime
+           manifest_ref.mime;
+         let manifest =
+           match Tool_blob_store.fetch store ~sha256:manifest_ref.sha256 with
+           | Ok (Some payload) -> Yojson.Safe.from_string payload
+           | Ok None -> Alcotest.fail "manifest blob is absent"
+           | Error error ->
+             Alcotest.fail (Tool_blob_store.fetch_error_to_string error)
+         in
+         (match O.artifact_manifest_of_json manifest with
+          | O.Decoded_artifact_manifest
+              { structured_content = restored; artifact_refs; _ } ->
+            Alcotest.(check bool)
+              "structured result is exact"
+              true
+              (Yojson.Safe.equal structured_content restored);
+            Alcotest.(check int) "one child ownership edge" 1 (List.length artifact_refs);
+            Alcotest.(check string)
+              "child identity is exact"
+              child.sha256
+              (List.hd artifact_refs).sha256
+          | O.Not_artifact_manifest -> Alcotest.fail "manifest schema is absent"
+          | O.Invalid_artifact_manifest { detail } -> Alcotest.fail detail)))
+
+let test_manifest_producer_rejects_mixed_malformed_reference () =
+  with_temp_base_path (fun base_path ->
+    let child =
+      Tool_blob_store.put_durable
+        (Tool_blob_store.create ~base_path)
+        ~bytes:"valid child"
+        ~mime:"text/plain"
+    in
+    let result =
+      Tool_result.make_ok
+        ~tool_name:"Execute"
+        ~start_time:0.0
+        ~data:
+          (`Assoc
+             [ "valid", O.normalized_artifact_ref_to_json child
+             ; "malformed", `Assoc [ "_blob", `Assoc [ "sha256", `String child.sha256 ] ]
+             ])
+        ()
+    in
+    match B.attach_artifact_manifest ~base_path result with
+    | Ok _ -> Alcotest.fail "mixed malformed artifact data produced a manifest"
+    | Error { message; _ } ->
+      Alcotest.(check bool)
+        "strict producer reports malformed reserved wrapper"
+        true
+        (String.length message > 0))
+
 let test_bounded_inline_rejects_oversized_result () =
   let payload = String.make (B.default_externalize_threshold_bytes + 1) 'x' in
   match
@@ -412,6 +507,10 @@ let () =
           Alcotest.test_case "small inlined" `Quick test_to_agent_core_typed_small_inlined;
           Alcotest.test_case "2.5KB result stays inline" `Quick
             test_incident_sized_result_stays_inline;
+          Alcotest.test_case "typed artifact result owns durable manifest" `Quick
+            test_typed_artifact_result_becomes_durable_manifest;
+          Alcotest.test_case "manifest producer rejects malformed child" `Quick
+            test_manifest_producer_rejects_mixed_malformed_reference;
           Alcotest.test_case "bounded inline rejects oversize" `Quick
             test_bounded_inline_rejects_oversized_result;
           Alcotest.test_case "artifact reader owns inline projection" `Quick


### PR DESCRIPTION
## Summary

- preserve the existing `persistent_24h_turn_exchange` contract while adding typed 1h, 2h, 4h, and 24h durable-turn-span evidence
- reuse one rotated decision-history read per Keeper across all tiers and expose exact observed/missing Keeper identities
- reject unordered or future timestamps before they can satisfy persistence evidence

## Evidence semantics

Each tier is explicitly labeled `durable_turn_span`. It proves an ordered first/latest persisted turn span plus a recent latest turn; it does not claim uninterrupted uptime or infer continuity from two endpoints.

## Tests

- API-level fixture proves 1h/2h/4h for a 4.5h Keeper and pins the exact inclusive 24h boundary (`first = now - 24h`, `latest = now`)
- API-level future-timestamp fixture proves 1h/2h/4h/24h all fail closed
- existing 24h feature ID, status, summary, and public entry point remain unchanged

Per project policy, no local build or test suite was run. `ocamlformat` and `git diff --check` pass; CI is authoritative.

## Live motivation (not validation of this head)

The currently deployed older runtime reported 26 Keeper histories: 11 at >=1h, 11 at >=2h, 10 at >=4h, and 7 at >=24h with a latest turn <=24h. This additive API makes that gap first-class instead of requiring ad-hoc post-processing.

## Stack

- base: #28677 (`50d33901ec7264fe169f93c9274a86f05c16fe52`)
- head: `38de70f0ecfbd1f5c5434c29e282348b9b51ed6e`
