### PR TITLE
fix(keeper): fence Antigravity after tool entry

### DIFF
--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -223,6 +223,20 @@ let tool_result (result : Host.dynamic_tool_result) =
   }
 ;;
 
+let antigravity_dynamic_tool ~observe_effect_attempted (tool : Host.dynamic_tool) =
+  { tool with
+    call =
+      (fun ~call_id input ->
+        (* Close the outer same-turn retry boundary before entering user/tool
+           code. The handler may commit and then raise or be cancelled, so
+           observing only its returned value would reopen a duplicate-effect
+           window. Process spawn and provider generation alone do not produce
+           a MASC product effect. *)
+        observe_effect_attempted ();
+        tool.call ~call_id input)
+  }
+;;
+
 let find_tool tools name =
   List.find_opt (fun (tool : Host.dynamic_tool) -> String.equal tool.name name) tools
 ;;
@@ -302,7 +316,8 @@ let stream_projection ~turn_count on_event =
 
 let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
     ~system_prompt ~tools ~initial_messages ~model_input_projection ~hooks
-    ~context_injector ~context ~event_bus ~raw_trace ~on_event ~effect_disposition
+    ~context_injector ~context ~event_bus ~raw_trace ~on_event
+    ~observe_effect_attempted
     ~(config : Runtime_execution.antigravity_cli) =
   match Eio_context.get_env_opt (), Eio_context.get_clock_opt () with
   | None, _ ->
@@ -499,6 +514,9 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
         ~terminal_error
         ~raw_trace_run
     in
+    let dynamic_tools =
+      List.map (antigravity_dynamic_tool ~observe_effect_attempted) dynamic_tools
+    in
     let* claimed_session =
       match
         Session_store.claim
@@ -668,10 +686,6 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
                    (Runtime_antigravity.run_turn
                       ~conversation_mode
                       ~home_dir:(Runtime_antigravity_home.home_dir home)
-                      ~on_spawned:(fun () ->
-                        Atomic.set
-                          effect_disposition
-                          Keeper_provider_attempt_effect.Observation_unavailable)
                       ~mgr:process_mgr
                       ~clock
                       ~cwd:process_cwd
@@ -900,6 +914,9 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
   let effect_disposition =
     Atomic.make Keeper_provider_attempt_effect.No_effect_observed
   in
+  let observe_effect_attempted () =
+    Atomic.set effect_disposition Keeper_provider_attempt_effect.Effect_attempted
+  in
   let result =
     Host.with_run_lifecycle_events ~event_bus ~keeper_name (fun () ->
       run_without_lifecycle
@@ -918,7 +935,7 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
         ~event_bus
         ~raw_trace
         ~on_event
-        ~effect_disposition
+        ~observe_effect_attempted
         ~config)
   in
   { result; effect_disposition = Atomic.get effect_disposition }

--- a/lib/keeper/keeper_antigravity_runtime.mli
+++ b/lib/keeper/keeper_antigravity_runtime.mli
@@ -5,8 +5,9 @@ type attempt_outcome =
   ; effect_disposition : Keeper_provider_attempt_effect.t
   }
 (** One Antigravity candidate result plus its typed effect observation.
-    Validation/setup and a typed process-spawn failure are provably
-    pre-dispatch; all other client outcomes remain fail-closed. *)
+    Validation, setup, process spawn, and provider work before the first
+    dynamic tool invocation are provably effect-free. Entering a dynamic tool
+    closes the same-turn retry boundary before user/tool code can run. *)
 
 val run :
   runtime_id:string ->

--- a/test/test_keeper_antigravity_runtime.ml
+++ b/test/test_keeper_antigravity_runtime.ml
@@ -600,24 +600,17 @@ let test_blank_success_requires_fresh_conversation () =
                   (match run () with
                    | Error error ->
                      (match Keeper_turn_driver.classify_masc_internal_error error with
-                      | Some
-                          (Keeper_turn_driver.Provider_attempt_effect_fenced
-                             { runtime_id = "antigravity.gemini"
-                             ; effect_disposition =
-                                 Keeper_provider_attempt_effect
-                                 .Observation_unavailable
-                             ; diagnostic
-                             }) ->
+                      | None ->
                         check bool
-                          "effect fence retains the blank-success provider diagnostic"
+                          "blank success remains a provider failure before any tool effect"
                           true
                           (String_util.contains_substring
-                             diagnostic
+                             (Agent_core.Error.to_string error)
                              "successful result response has no deliverable content")
                       | Some other ->
                         fail
                           (Keeper_turn_driver.kind_of_masc_internal_error other)
-                      | None -> fail (Agent_core.Error.to_string error))
+                      )
                    | Ok _ -> fail "blank Antigravity result settled as success");
                   let failed_session =
                     Keeper_official_client_session_store.load


### PR DESCRIPTION
## As-Is

Antigravity marked the provider attempt as observation_unavailable immediately after spawning the CLI process. A blank response, timeout, or provider failure before any dynamic tool ran was therefore converted to provider_attempt_effect_fenced and could not naturally rotate to the next runtime candidate.

Live evidence on code-reviewer showed this typed fence. The latest timed-out turn had already run tools, so that turn must remain fenced; earlier blank-response failures had no tool evidence but were fenced identically.

## To-Be

Keep process spawn and provider generation at No_effect_observed. Close the retry boundary immediately before entering an actual dynamic tool callback, matching the existing Codex contract. Hook or handler commit followed by exception or cancellation remains fenced.

## Scope

- 2 production files and 1 existing feature fixture
- no new policy, gate, timeout, framework, or public type
- Antigravity session settlement and recovery remain unchanged
- Claude/HITL are outside this slice

## Fast checks

- ocamlformat --check: pass
- ocamlc -stop-after parsing on all 3 changed files: pass
- git diff --check: pass
- independent adversarial source review: no P1/P2
- local Dune: not run by campaign policy
- CI/deploy/live rerun: pending

# ci:skip-test-coverage