### PR TITLE
fix(keeper): classify fenced provider effects

### DIFF
--- a/dashboard/e2e/keeper-composition-real-backend.mjs
+++ b/dashboard/e2e/keeper-composition-real-backend.mjs
@@ -21,6 +21,8 @@ if (!token) throw new Error('dashboard token file is empty')
 mkdirSync(artifactDir, { recursive: true })
 const screenshotPath = join(artifactDir, 'keeper-composition-inspector.png')
 const measurementPath = join(artifactDir, 'keeper-composition-inspector.json')
+const persistenceScreenshotPath = join(artifactDir, 'keeper-persistence-proof.png')
+const persistenceMeasurementPath = join(artifactDir, 'keeper-persistence-proof.json')
 const viewport = { width: 1440, height: 1000 }
 
 const healthResponse = await fetch(new URL('/health?full=1', dashboardUrl))
@@ -100,7 +102,142 @@ try {
     screenshot_sha256: createHash('sha256').update(screenshot).digest('hex'),
   }
   writeFileSync(measurementPath, `${JSON.stringify(measurement, null, 2)}\n`)
-  process.stdout.write(`${JSON.stringify(measurement)}\n`)
+
+  route.hash = 'workspace?section=verification'
+  await page.goto(route.toString())
+  const persistencePanel = page.getByTestId('keeper-persistence-proof-panel')
+  await persistencePanel.waitFor()
+  const persistenceCards = persistencePanel.locator('[data-tier-id][data-evidence-kind]')
+  await persistenceCards.first().waitFor()
+  const persistenceRefresh = page.getByTestId('keeper-persistence-proof-refresh')
+  const [persistenceResponse] = await Promise.all([
+    page.waitForResponse(response =>
+      response.url().includes('/api/v1/dashboard/keeper-feature-proof') && response.ok(),
+    ),
+    persistenceRefresh.click(),
+  ])
+  const refreshedPayload = await persistenceResponse.json()
+  const refreshedGeneratedAt = refreshedPayload?.generated_at
+  if (typeof refreshedGeneratedAt !== 'string' || !Number.isFinite(Date.parse(refreshedGeneratedAt))) {
+    throw new Error('manual refresh response has no generated_at')
+  }
+  const persistenceFeatures = Array.isArray(refreshedPayload?.features)
+    ? refreshedPayload.features.filter(feature => feature?.id === 'persistent_24h_turn_exchange')
+    : []
+  if (persistenceFeatures.length !== 1) {
+    throw new Error(`manual refresh response has ${persistenceFeatures.length} persistence features`)
+  }
+  const refreshedTiers = persistenceFeatures[0]?.duration_tiers
+  if (!Array.isArray(refreshedTiers) || refreshedTiers.length !== 4) {
+    throw new Error('manual refresh response has no exact persistence duration tiers')
+  }
+  await page.waitForFunction(expectedGeneratedAt => {
+    const panel = document.querySelector('[data-testid="keeper-persistence-proof-panel"]')
+    const button = document.querySelector('[data-testid="keeper-persistence-proof-refresh"]')
+    return panel?.getAttribute('data-proof-generated-at') === expectedGeneratedAt
+      && button instanceof HTMLButtonElement
+      && !button.disabled
+  }, refreshedGeneratedAt)
+  const renderedTiers = await persistenceCards.evaluateAll(nodes => {
+    const countAttribute = (node, name) => {
+      const raw = node.getAttribute(name)
+      const parsed = Number(raw)
+      if (raw == null || !Number.isSafeInteger(parsed) || parsed < 0 || String(parsed) !== raw) {
+        throw new Error(`${name} must be a canonical non-negative integer, observed=${raw}`)
+      }
+      return parsed
+    }
+    return nodes.map(node => ({
+      id: node.getAttribute('data-tier-id'),
+      status: node.getAttribute('data-proof-status'),
+      evidence_kind: node.getAttribute('data-evidence-kind'),
+      observed_count: countAttribute(node, 'data-observed-count'),
+      keeper_count: countAttribute(node, 'data-keeper-count'),
+      missing_count: countAttribute(node, 'data-missing-count'),
+    }))
+  })
+  const expectedTierIds = ['1h', '2h', '4h', '24h']
+  if (JSON.stringify(renderedTiers.map(tier => tier.id)) !== JSON.stringify(expectedTierIds)) {
+    throw new Error(`unexpected persistence tier order: ${JSON.stringify(renderedTiers)}`)
+  }
+  const tiers = renderedTiers.map((rendered, index) => {
+    const responseTier = refreshedTiers[index]
+    const observedKeepers = responseTier?.observed_keepers
+    const missingKeepers = responseTier?.missing_keepers
+    if (responseTier?.id !== rendered.id
+      || responseTier?.status !== rendered.status
+      || responseTier?.evidence_kind !== rendered.evidence_kind
+      || responseTier?.observed_count !== rendered.observed_count
+      || responseTier?.keeper_count !== rendered.keeper_count
+      || responseTier?.missing_count !== rendered.missing_count
+      || !Array.isArray(observedKeepers)
+      || !Array.isArray(missingKeepers)
+      || observedKeepers.some(name => typeof name !== 'string' || !name.trim())
+      || missingKeepers.some(name => typeof name !== 'string' || !name.trim())) {
+      throw new Error(`rendered persistence tier differs from response: ${JSON.stringify({ rendered, responseTier })}`)
+    }
+    return {
+      ...rendered,
+      observed_keepers: observedKeepers,
+      missing_keepers: missingKeepers,
+    }
+  })
+  const fleet = new Set([...tiers[0].observed_keepers, ...tiers[0].missing_keepers])
+  for (const [index, tier] of tiers.entries()) {
+    if (!['pass', 'warn', 'fail'].includes(tier.status)) {
+      throw new Error(`unexpected persistence status: ${JSON.stringify(tier)}`)
+    }
+    if (tier.evidence_kind !== 'durable_turn_span') {
+      throw new Error(`unexpected persistence evidence kind: ${JSON.stringify(tier)}`)
+    }
+    if (![tier.observed_count, tier.keeper_count, tier.missing_count].every(Number.isSafeInteger)) {
+      throw new Error(`non-integer persistence count: ${JSON.stringify(tier)}`)
+    }
+    if (tier.observed_count < 0 || tier.missing_count < 0
+      || tier.observed_count + tier.missing_count !== tier.keeper_count) {
+      throw new Error(`inconsistent persistence counts: ${JSON.stringify(tier)}`)
+    }
+    const observed = new Set(tier.observed_keepers)
+    const missing = new Set(tier.missing_keepers)
+    const tierFleet = new Set([...observed, ...missing])
+    if (observed.size !== tier.observed_count || missing.size !== tier.missing_count
+      || tierFleet.size !== tier.keeper_count
+      || tierFleet.size !== fleet.size
+      || [...fleet].some(name => !tierFleet.has(name))
+      || [...observed].some(name => missing.has(name))) {
+      throw new Error(`inconsistent persistence identities: ${JSON.stringify(tier)}`)
+    }
+    if (index > 0) {
+      const previous = tiers[index - 1]
+      const previousObserved = new Set(previous.observed_keepers)
+      const previousMissing = new Set(previous.missing_keepers)
+      if ([...observed].some(name => !previousObserved.has(name))
+        || [...previousMissing].some(name => !missing.has(name))) {
+        throw new Error(`non-monotonic persistence identities: ${JSON.stringify(tiers)}`)
+      }
+    }
+  }
+  const generatedAt = await persistencePanel.getAttribute('data-proof-generated-at')
+  if (!generatedAt) throw new Error('persistence proof generated_at is absent')
+  const persistenceScreenshot = await page.screenshot({
+    path: persistenceScreenshotPath,
+    fullPage: true,
+  })
+  const persistenceMeasurement = {
+    schema: 'masc.keeper_persistence_browser_evidence.v1',
+    generated_at: generatedAt,
+    interaction: 'manual_refresh',
+    tiers,
+    viewport,
+    screenshot_file: 'keeper-persistence-proof.png',
+    screenshot_bytes: persistenceScreenshot.byteLength,
+    screenshot_sha256: createHash('sha256').update(persistenceScreenshot).digest('hex'),
+  }
+  writeFileSync(
+    persistenceMeasurementPath,
+    `${JSON.stringify(persistenceMeasurement, null, 2)}\n`,
+  )
+  process.stdout.write(`${JSON.stringify({ composition: measurement, persistence: persistenceMeasurement })}\n`)
 } finally {
   await browser.close()
 }

--- a/dashboard/src/api/dashboard-keeper-feature-proof.test.ts
+++ b/dashboard/src/api/dashboard-keeper-feature-proof.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest'
+import { parseKeeperPersistenceProofResponse } from './dashboard-keeper-feature-proof'
+
+const tier = (
+  id: '1h' | '2h' | '4h' | '24h',
+  requiredSpanHours: number,
+  observedKeepers: string[],
+  missingKeepers: string[],
+) => ({
+  id,
+  evidence_kind: 'durable_turn_span',
+  required_span_hours: requiredSpanHours,
+  status: observedKeepers.length === 0
+    ? 'fail'
+    : missingKeepers.length === 0 ? 'pass' : 'warn',
+  keeper_count: observedKeepers.length + missingKeepers.length,
+  observed_count: observedKeepers.length,
+  missing_count: missingKeepers.length,
+  observed_keepers: observedKeepers,
+  missing_keepers: missingKeepers,
+})
+
+function payload() {
+  return {
+    generated_at: '2026-08-14T12:00:00Z',
+    status: 'warn',
+    summary: { feature_count: 5 },
+    features: [
+      {
+        id: 'persistent_24h_turn_exchange',
+        status: 'warn',
+        summary: '1/2 keepers have durable turn spans >= 24h',
+        duration_tiers: [
+          tier('1h', 1, ['keeper-a', 'keeper-b'], []),
+          tier('2h', 2, ['keeper-a', 'keeper-b'], []),
+          tier('4h', 4, ['keeper-a'], ['keeper-b']),
+          tier('24h', 24, ['keeper-a'], ['keeper-b']),
+        ],
+      },
+    ],
+    evidence_refs: [],
+  }
+}
+
+function persistenceFeature(raw: ReturnType<typeof payload>) {
+  const [feature] = raw.features
+  if (feature == null) throw new Error('persistence fixture is absent')
+  return feature
+}
+
+function durationTier(raw: ReturnType<typeof payload>, index: number) {
+  const value = persistenceFeature(raw).duration_tiers[index]
+  if (value == null) throw new Error(`duration tier fixture ${index} is absent`)
+  return value
+}
+
+describe('parseKeeperPersistenceProofResponse', () => {
+  it('projects the exact ordered durable turn-span tiers', () => {
+    const parsed = parseKeeperPersistenceProofResponse(payload())
+
+    expect(parsed.generatedAt).toBe('2026-08-14T12:00:00Z')
+    expect(parsed.status).toBe('warn')
+    expect(parsed.tiers.map(value => value.id)).toEqual(['1h', '2h', '4h', '24h'])
+    expect(parsed.tiers[2]).toEqual({
+      id: '4h',
+      requiredSpanHours: 4,
+      status: 'warn',
+      evidenceKind: 'durable_turn_span',
+      keeperCount: 2,
+      observedCount: 1,
+      missingCount: 1,
+      observedKeepers: ['keeper-a'],
+      missingKeepers: ['keeper-b'],
+    })
+  })
+
+  it('rejects a tier status that disagrees with its evidence counts', () => {
+    const raw = payload()
+    durationTier(raw, 2).status = 'pass'
+
+    expect(() => parseKeeperPersistenceProofResponse(raw)).toThrow(
+      'does not match derived status=warn',
+    )
+  })
+
+  it('rejects duplicate or overlapping keeper evidence', () => {
+    const duplicate = payload()
+    durationTier(duplicate, 0).observed_keepers = ['keeper-a', 'keeper-a']
+    expect(() => parseKeeperPersistenceProofResponse(duplicate)).toThrow(
+      'must not contain duplicate keepers',
+    )
+
+    const overlap = payload()
+    durationTier(overlap, 2).missing_keepers = ['keeper-a']
+    expect(() => parseKeeperPersistenceProofResponse(overlap)).toThrow(
+      'observed and missing keepers must not overlap',
+    )
+  })
+
+  it('rejects reordered tiers and a feature status that disagrees with 24h', () => {
+    const reordered = payload()
+    const tiers = persistenceFeature(reordered).duration_tiers
+    const first = durationTier(reordered, 0)
+    tiers[0] = durationTier(reordered, 1)
+    tiers[1] = first
+    expect(() => parseKeeperPersistenceProofResponse(reordered)).toThrow(
+      'duration_tiers[0].id must be 1h',
+    )
+
+    const mismatch = payload()
+    persistenceFeature(mismatch).status = 'pass'
+    expect(() => parseKeeperPersistenceProofResponse(mismatch)).toThrow(
+      'must match the 24h tier status',
+    )
+  })
+
+  it('rejects cross-tier fleet drift and non-monotonic duration evidence', () => {
+    const fleetDrift = payload()
+    durationTier(fleetDrift, 3).missing_keepers = ['keeper-c']
+    expect(() => parseKeeperPersistenceProofResponse(fleetDrift)).toThrow(
+      'must describe the same Keeper fleet',
+    )
+
+    const nonMonotonic = payload()
+    durationTier(nonMonotonic, 2).observed_keepers = ['keeper-b']
+    durationTier(nonMonotonic, 2).missing_keepers = ['keeper-a']
+    expect(() => parseKeeperPersistenceProofResponse(nonMonotonic)).toThrow(
+      'violates duration monotonicity',
+    )
+  })
+})

--- a/dashboard/src/api/dashboard-keeper-feature-proof.ts
+++ b/dashboard/src/api/dashboard-keeper-feature-proof.ts
@@ -1,0 +1,203 @@
+// MASC Dashboard — durable Keeper persistence proof projection.
+//
+// Backend: GET /api/v1/dashboard/keeper-feature-proof
+//
+// The endpoint carries several feature proofs. This decoder deliberately
+// projects only the persistence feature and rejects internally inconsistent
+// tier evidence instead of rendering plausible-looking counters.
+
+import { isRecord } from '../components/common/normalize'
+import { get, type AbortableRequestOptions } from './core'
+
+export type KeeperFeatureProofStatus = 'pass' | 'warn' | 'fail'
+export type KeeperPersistenceTierId = '1h' | '2h' | '4h' | '24h'
+export type KeeperPersistenceEvidenceKind = 'durable_turn_span'
+
+export interface KeeperPersistenceTierProof {
+  id: KeeperPersistenceTierId
+  requiredSpanHours: number
+  status: KeeperFeatureProofStatus
+  evidenceKind: KeeperPersistenceEvidenceKind
+  keeperCount: number
+  observedCount: number
+  missingCount: number
+  observedKeepers: string[]
+  missingKeepers: string[]
+}
+
+export interface DashboardKeeperPersistenceProofResponse {
+  generatedAt: string
+  status: KeeperFeatureProofStatus
+  summary: string
+  tiers: KeeperPersistenceTierProof[]
+}
+
+const EXPECTED_TIERS = [
+  { id: '1h', requiredSpanHours: 1 },
+  { id: '2h', requiredSpanHours: 2 },
+  { id: '4h', requiredSpanHours: 4 },
+  { id: '24h', requiredSpanHours: 24 },
+] as const
+
+function protocolError(message: string): never {
+  throw new Error(`Invalid Keeper persistence proof response: ${message}`)
+}
+
+function nonEmptyString(value: unknown, context: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    protocolError(`${context} must be a non-empty string`)
+  }
+  return value
+}
+
+function isoTimestamp(value: unknown, context: string): string {
+  const timestamp = nonEmptyString(value, context)
+  if (!Number.isFinite(Date.parse(timestamp))) {
+    protocolError(`${context} must be a valid timestamp`)
+  }
+  return timestamp
+}
+
+function nonNegativeInteger(value: unknown, context: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    protocolError(`${context} must be a non-negative safe integer`)
+  }
+  return value as number
+}
+
+function proofStatus(value: unknown, context: string): KeeperFeatureProofStatus {
+  if (value !== 'pass' && value !== 'warn' && value !== 'fail') {
+    protocolError(`${context} has unknown status ${JSON.stringify(value)}`)
+  }
+  return value
+}
+
+function keeperNames(value: unknown, context: string): string[] {
+  if (!Array.isArray(value)) protocolError(`${context} must be an array`)
+  const names = value.map((name, index) => nonEmptyString(name, `${context}[${index}]`))
+  if (new Set(names).size !== names.length) {
+    protocolError(`${context} must not contain duplicate keepers`)
+  }
+  return names
+}
+
+function expectedStatus(keeperCount: number, observedCount: number): KeeperFeatureProofStatus {
+  if (keeperCount === 0 || observedCount === 0) return 'fail'
+  if (observedCount === keeperCount) return 'pass'
+  return 'warn'
+}
+
+function sameNames(left: ReadonlySet<string>, right: ReadonlySet<string>): boolean {
+  return left.size === right.size && [...left].every(name => right.has(name))
+}
+
+function parseTier(
+  raw: unknown,
+  index: number,
+): KeeperPersistenceTierProof {
+  const context = `persistence.duration_tiers[${index}]`
+  if (!isRecord(raw)) protocolError(`${context} must be an object`)
+  const expected = EXPECTED_TIERS[index]
+  if (expected == null) protocolError('persistence.duration_tiers contains an unexpected tier')
+  if (raw.id !== expected.id) {
+    protocolError(`${context}.id must be ${expected.id}`)
+  }
+  if (raw.required_span_hours !== expected.requiredSpanHours) {
+    protocolError(`${context}.required_span_hours must be ${expected.requiredSpanHours}`)
+  }
+  if (raw.evidence_kind !== 'durable_turn_span') {
+    protocolError(`${context}.evidence_kind must be durable_turn_span`)
+  }
+  const keeperCount = nonNegativeInteger(raw.keeper_count, `${context}.keeper_count`)
+  const observedCount = nonNegativeInteger(raw.observed_count, `${context}.observed_count`)
+  const missingCount = nonNegativeInteger(raw.missing_count, `${context}.missing_count`)
+  const observedKeepers = keeperNames(raw.observed_keepers, `${context}.observed_keepers`)
+  const missingKeepers = keeperNames(raw.missing_keepers, `${context}.missing_keepers`)
+  if (observedCount !== observedKeepers.length || missingCount !== missingKeepers.length) {
+    protocolError(`${context} counts must match keeper arrays`)
+  }
+  if (observedCount + missingCount !== keeperCount) {
+    protocolError(`${context} observed_count + missing_count must equal keeper_count`)
+  }
+  const observed = new Set(observedKeepers)
+  if (missingKeepers.some(name => observed.has(name))) {
+    protocolError(`${context} observed and missing keepers must not overlap`)
+  }
+  const status = proofStatus(raw.status, `${context}.status`)
+  const derivedStatus = expectedStatus(keeperCount, observedCount)
+  if (status !== derivedStatus) {
+    protocolError(`${context}.status=${status} does not match derived status=${derivedStatus}`)
+  }
+  return {
+    id: expected.id,
+    requiredSpanHours: expected.requiredSpanHours,
+    status,
+    evidenceKind: 'durable_turn_span',
+    keeperCount,
+    observedCount,
+    missingCount,
+    observedKeepers,
+    missingKeepers,
+  }
+}
+
+export function parseKeeperPersistenceProofResponse(
+  raw: unknown,
+): DashboardKeeperPersistenceProofResponse {
+  if (!isRecord(raw)) protocolError('root must be an object')
+  const generatedAt = isoTimestamp(raw.generated_at, 'root.generated_at')
+  if (!Array.isArray(raw.features)) protocolError('root.features must be an array')
+  const matches = raw.features.filter(
+    feature => isRecord(feature) && feature.id === 'persistent_24h_turn_exchange',
+  )
+  if (matches.length !== 1) {
+    protocolError(`expected exactly one persistent_24h_turn_exchange feature, found ${matches.length}`)
+  }
+  const feature = matches[0]
+  if (!isRecord(feature)) protocolError('persistence feature must be an object')
+  if (!Array.isArray(feature.duration_tiers)) {
+    protocolError('persistence.duration_tiers must be an array')
+  }
+  if (feature.duration_tiers.length !== EXPECTED_TIERS.length) {
+    protocolError(`persistence.duration_tiers must contain ${EXPECTED_TIERS.length} tiers`)
+  }
+  const tiers = feature.duration_tiers.map(parseTier)
+  const firstTier = tiers[0]
+  if (firstTier == null) protocolError('persistence.duration_tiers must not be empty')
+  const fleet = new Set([...firstTier.observedKeepers, ...firstTier.missingKeepers])
+  for (let index = 1; index < tiers.length; index += 1) {
+    const previous = tiers[index - 1]
+    const current = tiers[index]
+    if (previous == null || current == null) {
+      protocolError(`persistence.duration_tiers[${index}] is absent`)
+    }
+    const currentFleet = new Set([...current.observedKeepers, ...current.missingKeepers])
+    if (current.keeperCount !== firstTier.keeperCount || !sameNames(fleet, currentFleet)) {
+      protocolError(`persistence.duration_tiers[${index}] must describe the same Keeper fleet`)
+    }
+    const previousObserved = new Set(previous.observedKeepers)
+    const currentMissing = new Set(current.missingKeepers)
+    if (current.observedKeepers.some(name => !previousObserved.has(name))
+      || previous.missingKeepers.some(name => !currentMissing.has(name))) {
+      protocolError(`persistence.duration_tiers[${index}] violates duration monotonicity`)
+    }
+  }
+  const status = proofStatus(feature.status, 'persistence.status')
+  const tier24h = tiers[tiers.length - 1]
+  if (tier24h == null || status !== tier24h.status) {
+    protocolError('persistence.status must match the 24h tier status')
+  }
+  return {
+    generatedAt,
+    status,
+    summary: nonEmptyString(feature.summary, 'persistence.summary'),
+    tiers,
+  }
+}
+
+export async function fetchKeeperPersistenceProof(
+  opts?: AbortableRequestOptions,
+): Promise<DashboardKeeperPersistenceProofResponse> {
+  const raw = await get<unknown>('/api/v1/dashboard/keeper-feature-proof', { signal: opts?.signal })
+  return parseKeeperPersistenceProofResponse(raw)
+}

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -62,6 +62,17 @@ export {
   parseVerificationRunsResponse,
   fetchVerificationRuns,
 } from './dashboard-verification-runs'
+export type {
+  KeeperFeatureProofStatus,
+  KeeperPersistenceTierId,
+  KeeperPersistenceEvidenceKind,
+  KeeperPersistenceTierProof,
+  DashboardKeeperPersistenceProofResponse,
+} from './dashboard-keeper-feature-proof'
+export {
+  parseKeeperPersistenceProofResponse,
+  fetchKeeperPersistenceProof,
+} from './dashboard-keeper-feature-proof'
 export {
   fetchExactLaneRun,
   fetchExactLaneRuns,

--- a/dashboard/src/components/fsm-hub-types.test.ts
+++ b/dashboard/src/components/fsm-hub-types.test.ts
@@ -11,6 +11,7 @@ import {
   MAX_OBSERVATIONS,
   MAX_TRANSITION_HISTORY,
   initialHubState,
+  operatorDispositionReasonLabel,
 } from './fsm-hub-types'
 import type { KeeperCompositeSnapshot } from '../api/keeper'
 
@@ -182,6 +183,14 @@ describe('failureReasonLabel', () => {
     expect(failureReasonLabel(undefined)).toBeNull()
     expect(failureReasonLabel('')).toBeNull()
     expect(failureReasonLabel('   ')).toBeNull()
+  })
+})
+
+describe('operatorDispositionReasonLabel', () => {
+  it('labels a fenced provider effect without exposing the raw token', () => {
+    expect(operatorDispositionReasonLabel('provider_attempt_effect_fenced')).toBe(
+      'Provider 효과 결과 확인 필요',
+    )
   })
 })
 

--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -396,11 +396,14 @@ const OPERATOR_DISPOSITION_REASON_LABELS: Record<string, string> = {
   degraded_retry: '저하 상태 재시도',
   runtime_fallback: '런타임 폴백',
   transient_runtime_retry: '일시적 런타임 재시도',
+  capacity_backpressure: 'Provider 수용량 부족',
   provider_runtime_error: '런타임 호출 오류',
   internal_error: '내부 오류',
   input_required: '사용자 입력 대기',
   cancelled: '취소됨',
   phase_skipped: 'phase 건너뜀',
+  transcript_corruption: '대화 기록 손상 - 초기화 필요',
+  provider_attempt_effect_fenced: 'Provider 효과 결과 확인 필요',
   unmapped_runtime_state: '매핑되지 않은 runtime 상태',
 }
 

--- a/dashboard/src/components/keeper-detail-alert-strip.test.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.test.ts
@@ -68,6 +68,7 @@ describe('KeeperRuntimeAlertStrip', () => {
     ['runtime_exhausted', '런타임 후보 소진'],
     ['unmapped_runtime_state', '매핑되지 않은 runtime 상태'],
     ['transient_runtime_retry', '일시적 런타임 재시도'],
+    ['provider_attempt_effect_fenced', 'Provider 효과 결과 확인 필요'],
   ])('labels receipt-derived attention reason %s distinctly', (reason, label) => {
     const { container } = render(h(KeeperRuntimeAlertStrip, {
       keeper: keeper({
@@ -79,6 +80,22 @@ describe('KeeperRuntimeAlertStrip', () => {
     const text = container.textContent ?? ''
     expect(text).toContain(label)
     expect(text).not.toContain(reason)
+  })
+
+  it('humanizes the fenced provider effect in the operator disposition line', () => {
+    const { container } = render(h(KeeperRuntimeAlertStrip, {
+      keeper: keeper({
+        needs_attention: true,
+        trust: {
+          operator_disposition_reason: 'provider_attempt_effect_fenced',
+        },
+      }),
+    }))
+
+    const text = container.textContent ?? ''
+    expect(text).toContain('운영자 판단')
+    expect(text).toContain('Provider 효과 결과 확인 필요')
+    expect(text).not.toContain('provider_attempt_effect_fenced')
   })
 
   // First-class status_bridge reasons keep their OWN labels — they are no

--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -15,6 +15,7 @@ import { StrongSecondary, RuntimeBadge } from './keeper-detail-primitives'
 import {
   trustDispositionLabel,
   isTurnTerminalFailureCode,
+  operatorDispositionReasonLabel,
   type RuntimeAttemptObservation,
 } from './fsm-hub-types'
 import { keeperNeedsDiagnosticAttention, refreshAfterRuntimeAction } from './keeper-detail-helpers'
@@ -149,6 +150,7 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
     && !isTurnTerminalFailureCode(latestTerminalCode)
   const latestNextAction = canonicalNextHumanAction(keeper.trust?.latest_next_action?.trim() || null)
   const operatorDispositionReason = keeper.trust?.operator_disposition_reason?.trim() || null
+  const operatorDispositionReasonText = operatorDispositionReasonLabel(operatorDispositionReason)
   const shouldShowOperatorDispositionReason =
     operatorDispositionReason !== null && operatorDispositionReason !== trustSummary
   const executionSummary = keeper.trust?.execution_summary ?? null
@@ -366,7 +368,7 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
           ? html`<span title=${latestNextAction}><strong class="text-[var(--color-fg-secondary)]">권장 조치</strong> · ${nextHumanActionLabel(latestNextAction)}</span>`
           : null}
         ${shouldShowOperatorDispositionReason && operatorDispositionReason
-          ? html`<span><${StrongSecondary}>운영자 판단</${StrongSecondary}> · ${operatorDispositionReason}</span>`
+          ? html`<span><${StrongSecondary}>운영자 판단</${StrongSecondary}> · ${operatorDispositionReasonText}</span>`
           : null}
         ${trustDisposition
           ? html`

--- a/dashboard/src/components/keeper-persistence-proof-panel.test.ts
+++ b/dashboard/src/components/keeper-persistence-proof-panel.test.ts
@@ -1,0 +1,102 @@
+import { html } from 'htm/preact'
+import { cleanup, render, screen, waitFor, within } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import '@testing-library/jest-dom'
+
+const fetchProofMock = vi.hoisted(() => vi.fn())
+const unregisterMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../api/dashboard', () => ({
+  fetchKeeperPersistenceProof: fetchProofMock,
+}))
+
+vi.mock('../sse-store', () => ({
+  registerInternalAgentRefresh: vi.fn(() => unregisterMock),
+}))
+
+import { KeeperPersistenceProofPanel, keeperProofTone } from './keeper-persistence-proof-panel'
+
+const response = {
+  generatedAt: '2026-08-14T12:00:00Z',
+  status: 'warn' as const,
+  summary: '1/2 keepers have durable turn spans >= 24h',
+  tiers: [
+    {
+      id: '1h' as const,
+      requiredSpanHours: 1,
+      status: 'pass' as const,
+      evidenceKind: 'durable_turn_span' as const,
+      keeperCount: 2,
+      observedCount: 2,
+      missingCount: 0,
+      observedKeepers: ['keeper-a', 'keeper-b'],
+      missingKeepers: [],
+    },
+    {
+      id: '2h' as const,
+      requiredSpanHours: 2,
+      status: 'pass' as const,
+      evidenceKind: 'durable_turn_span' as const,
+      keeperCount: 2,
+      observedCount: 2,
+      missingCount: 0,
+      observedKeepers: ['keeper-a', 'keeper-b'],
+      missingKeepers: [],
+    },
+    {
+      id: '4h' as const,
+      requiredSpanHours: 4,
+      status: 'warn' as const,
+      evidenceKind: 'durable_turn_span' as const,
+      keeperCount: 2,
+      observedCount: 1,
+      missingCount: 1,
+      observedKeepers: ['keeper-a'],
+      missingKeepers: ['keeper-b'],
+    },
+    {
+      id: '24h' as const,
+      requiredSpanHours: 24,
+      status: 'warn' as const,
+      evidenceKind: 'durable_turn_span' as const,
+      keeperCount: 2,
+      observedCount: 1,
+      missingCount: 1,
+      observedKeepers: ['keeper-a'],
+      missingKeepers: ['keeper-b'],
+    },
+  ],
+}
+
+describe('KeeperPersistenceProofPanel', () => {
+  beforeEach(() => {
+    fetchProofMock.mockReset()
+    fetchProofMock.mockResolvedValue(response)
+    unregisterMock.mockClear()
+  })
+
+  afterEach(() => cleanup())
+
+  it('maps the closed proof status vocabulary to semantic tones', () => {
+    expect(keeperProofTone('pass')).toBe('ok')
+    expect(keeperProofTone('warn')).toBe('warn')
+    expect(keeperProofTone('fail')).toBe('bad')
+  })
+
+  it('renders all durable tiers and exposes missing Keeper evidence', async () => {
+    render(html`<${KeeperPersistenceProofPanel} />`)
+
+    const panel = await screen.findByTestId('keeper-persistence-proof-panel')
+    await waitFor(() => expect(fetchProofMock).toHaveBeenCalledTimes(1))
+    await screen.findByTestId('keeper-persistence-tier-24h')
+    expect(within(panel).getByText(/무중단 uptime 증거가 아닙니다/)).toBeTruthy()
+    expect(panel.getAttribute('data-proof-generated-at')).toBe(response.generatedAt)
+    for (const id of ['1h', '2h', '4h', '24h']) {
+      expect(within(panel).getByTestId(`keeper-persistence-tier-${id}`)).toBeTruthy()
+    }
+    const tier24h = within(panel).getByTestId('keeper-persistence-tier-24h')
+    expect(tier24h).toHaveAttribute('data-proof-status', 'warn')
+    expect(tier24h).toHaveAttribute('data-evidence-kind', 'durable_turn_span')
+    expect(within(tier24h).getByText('keeper-b')).toBeTruthy()
+  })
+})

--- a/dashboard/src/components/keeper-persistence-proof-panel.ts
+++ b/dashboard/src/components/keeper-persistence-proof-panel.ts
@@ -1,0 +1,162 @@
+// Verification workspace projection for durable Keeper turn-span evidence.
+//
+// This is deliberately not an uptime panel. A tier passes only when the
+// decision log contains enough ordered turn history; the explicit evidence
+// label keeps operators from reading durable history as process continuity.
+
+import { html } from 'htm/preact'
+import { useEffect } from 'preact/hooks'
+import {
+  fetchKeeperPersistenceProof,
+  type DashboardKeeperPersistenceProofResponse,
+  type KeeperFeatureProofStatus,
+  type KeeperPersistenceTierProof,
+} from '../api/dashboard'
+import type { ManagedAsyncResource } from '../lib/async-state'
+import { relativeTime } from '../lib/format-time'
+import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
+import { registerInternalAgentRefresh } from '../sse-store'
+import { Btn } from './btn'
+import { EmptyState, ErrorState } from './common/feedback-state'
+import { StatusBadge, type StatusBadgeTone } from './common/status-badge'
+
+export function keeperProofTone(status: KeeperFeatureProofStatus): StatusBadgeTone {
+  switch (status) {
+    case 'pass':
+      return 'ok'
+    case 'warn':
+      return 'warn'
+    case 'fail':
+      return 'bad'
+  }
+}
+
+function keeperProofLabel(status: KeeperFeatureProofStatus): string {
+  switch (status) {
+    case 'pass':
+      return '충족'
+    case 'warn':
+      return '부분 충족'
+    case 'fail':
+      return '미충족'
+  }
+}
+
+async function loadData(resource: ManagedAsyncResource<DashboardKeeperPersistenceProofResponse>) {
+  await resource.load(async signal => fetchKeeperPersistenceProof({ signal }))
+}
+
+function KeeperPersistenceTierCard({ tier }: { tier: KeeperPersistenceTierProof }) {
+  const observedLabel = tier.keeperCount === 0
+    ? '관찰할 Keeper 없음'
+    : `${tier.observedCount}/${tier.keeperCount} Keeper`
+  return html`
+    <article
+      class="rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] p-3"
+      data-testid=${`keeper-persistence-tier-${tier.id}`}
+      data-tier-id=${tier.id}
+      data-proof-status=${tier.status}
+      data-evidence-kind=${tier.evidenceKind}
+      data-observed-count=${tier.observedCount}
+      data-keeper-count=${tier.keeperCount}
+      data-missing-count=${tier.missingCount}
+    >
+      <div class="flex items-center justify-between gap-2">
+        <strong class="text-base tabular-nums text-[var(--color-fg-primary)]">${tier.id}</strong>
+        <${StatusBadge}
+          tone=${keeperProofTone(tier.status)}
+          label=${keeperProofLabel(tier.status)}
+        />
+      </div>
+      <div class="mt-2 text-sm font-medium tabular-nums text-[var(--color-fg-primary)]">
+        ${observedLabel}
+      </div>
+      <div class="mt-1 text-xs text-[var(--color-fg-muted)]">
+        durable turn span ≥ ${tier.requiredSpanHours}h
+      </div>
+      ${tier.missingKeepers.length > 0
+        ? html`
+            <details class="mt-2 text-xs text-[var(--color-fg-secondary)]">
+              <summary class="cursor-pointer">근거 부족 ${tier.missingCount}</summary>
+              <div class="mt-1 break-words" data-testid=${`keeper-persistence-missing-${tier.id}`}>
+                ${tier.missingKeepers.join(', ')}
+              </div>
+            </details>
+          `
+        : null}
+    </article>
+  `
+}
+
+export function KeeperPersistenceProofPanel() {
+  const resource = useManagedAsyncResource<DashboardKeeperPersistenceProofResponse>()
+
+  useEffect(() => {
+    void loadData(resource)
+    const unregister = registerInternalAgentRefresh(() => { void loadData(resource) })
+    return () => {
+      unregister()
+      resource.cancel()
+    }
+  }, [resource])
+
+  const current = resource.state.value
+  const data = current.data ?? null
+
+  return html`
+    <section
+      class="v2-workspace-surface flex flex-col gap-3"
+      data-testid="keeper-persistence-proof-panel"
+      data-proof-generated-at=${data?.generatedAt ?? ''}
+      aria-labelledby="keeper-persistence-proof-heading"
+    >
+      <div class="flex items-center gap-3 flex-wrap">
+        <h2
+          id="keeper-persistence-proof-heading"
+          class="text-sm font-semibold text-[var(--color-fg-primary)]"
+        >
+          Keeper 지속성 근거
+        </h2>
+        ${data
+          ? html`<${StatusBadge}
+              tone=${keeperProofTone(data.status)}
+              label=${keeperProofLabel(data.status)}
+            />`
+          : null}
+        <${Btn}
+          class="v2-workspace-action"
+          testId="keeper-persistence-proof-refresh"
+          disabled=${current.loading}
+          onClick=${() => void loadData(resource)}
+        >
+          새로고침
+        <//>
+        ${current.loading
+          ? html`<span class="text-xs text-[var(--color-fg-muted)]" role="status">로딩 중...</span>`
+          : null}
+        ${data?.generatedAt
+          ? html`<span class="text-xs text-[var(--color-fg-muted)]">
+              updated · ${relativeTime(data.generatedAt)}
+            </span>`
+          : null}
+      </div>
+
+      <p class="text-xs text-[var(--color-fg-muted)]">
+        decision log의 <strong>durable turn span</strong> 근거입니다. 무중단 uptime 증거가 아닙니다.
+      </p>
+
+      ${current.error
+        ? html`<${ErrorState}>Keeper 지속성 근거를 불러오지 못했습니다: ${current.error}<//>`
+        : data == null && !current.loading
+          ? html`<${EmptyState}>지속성 근거가 없습니다.<//>`
+          : data
+            ? html`
+                <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                  ${data.tiers.map(tier => html`<${KeeperPersistenceTierCard} key=${tier.id} tier=${tier} />`)}
+                </div>
+                <p class="text-xs text-[var(--color-fg-secondary)]">${data.summary}</p>
+              `
+            : null}
+    </section>
+  `
+}

--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -59,6 +59,14 @@ vi.mock('./verification-requests-panel', () => ({
   VerificationRequestsPanel: () => html`<div data-testid="verification-panel">Verification</div>`,
 }))
 
+vi.mock('./verification-runs-panel', () => ({
+  VerificationRunsPanel: () => html`<div data-testid="verification-runs-panel">Verification runs</div>`,
+}))
+
+vi.mock('./keeper-persistence-proof-panel', () => ({
+  KeeperPersistenceProofPanel: () => html`<div data-testid="keeper-persistence-proof-panel">Persistence proof</div>`,
+}))
+
 vi.mock('./repository-management', () => ({
   RepositoryManagement: () => html`<div data-testid="repository-panel">Repositories</div>`,
 }))
@@ -220,6 +228,8 @@ describe('Work', () => {
     render(html`<${Work} />`)
 
     expect(screen.getByTestId('verification-panel')).toBeTruthy()
+    expect(screen.getByTestId('verification-runs-panel')).toBeTruthy()
+    expect(screen.getByTestId('keeper-persistence-proof-panel')).toBeTruthy()
     expect(screen.queryByTestId('work-kpis')).toBeNull()
   })
 

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -16,6 +16,7 @@ import { SubBoardSurface } from './board/sub-board-surface'
 import { PlanningPanel } from './planning-panel'
 import { VerificationRequestsPanel } from './verification-requests-panel'
 import { VerificationRunsPanel } from './verification-runs-panel'
+import { KeeperPersistenceProofPanel } from './keeper-persistence-proof-panel'
 import { ErrorBoundary } from './common/error-boundary'
 import { LoadingState } from './common/feedback-state'
 import { SectionNav } from './common/section-nav'
@@ -1651,6 +1652,7 @@ export function Work() {
           `
           : html`
             <div class="flex flex-col gap-4">
+              <${KeeperPersistenceProofPanel} />
               <${VerificationRequestsPanel} />
               <${VerificationRunsPanel} />
             </div>

--- a/dashboard/src/lib/keeper-attention-labels.drift.test.ts
+++ b/dashboard/src/lib/keeper-attention-labels.drift.test.ts
@@ -1,7 +1,8 @@
 // Build-time drift guard for the keeper attention vocabulary.
 //
 // The backend is the single source of truth for `attention_reason` /
-// `next_human_action` wire codes — they are string literals emitted from OCaml.
+// `next_human_action` wire codes — they are literals or canonical shared
+// constants emitted from OCaml.
 // keeper-attention-labels.ts hand-mirrors that vocabulary, and that mirror
 // silently drifted before: the backend emitted `stale_turn_timeout` for a
 // release while the frontend union had no arm for it, so the dashboard showed
@@ -84,20 +85,41 @@ function executionReceiptAttentionReasons(): string[] {
     'operator_disposition_reason_to_string present in keeper_execution_receipt.ml',
   ).toBeGreaterThan(-1)
   const body = src.slice(start, src.indexOf(';;', start))
-  return [...body.matchAll(/-> "([a-z_]+)"/g)]
+  const literalReasons = [...body.matchAll(/-> "([a-z_]+)"/g)]
     .map((m) => m[1])
     .filter((token): token is string => token !== undefined)
+  const internalErrorSrc = read('lib/keeper_runtime/keeper_internal_error.ml')
+  const internalErrorConstants = new Map<string, string>()
+  for (const match of internalErrorSrc.matchAll(/^let ([a-z_]+) = "([a-z_]+)"$/gm)) {
+    const name = match[1]
+    const value = match[2]
+    if (name !== undefined && value !== undefined) internalErrorConstants.set(name, value)
+  }
+  const sharedConstantReasons = [
+    ...body.matchAll(/->\s*Keeper_internal_error\.([a-z_]+)/g),
+  ].map((m) => {
+    const name = m[1]
+    const value = name === undefined ? undefined : internalErrorConstants.get(name)
+    expect(
+      value,
+      `Keeper_internal_error.${name ?? '<missing>'} resolves to a canonical string`,
+    ).toBeDefined()
+    return value as string
+  })
+  return [...literalReasons, ...sharedConstantReasons]
 }
 
 // keeper_runtime_trust_snapshot.ml only promotes receipt disposition reasons to
 // `attention_reason` when the derived display disposition needs attention.
-// These receipt reasons are tied to pass/skipped dispositions and should stay
-// out of the attention label union unless the backend changes that contract.
-const EXECUTION_RECEIPT_PASS_ONLY_REASONS: ReadonlySet<string> = new Set([
+// These receipt reasons currently map to display dispositions that do not
+// require attention. They should stay out of the attention label union unless
+// the backend changes that contract.
+const EXECUTION_RECEIPT_NON_ATTENTION_REASONS: ReadonlySet<string> = new Set([
   'healthy',
   'runtime_fallback',
   'phase_skipped',
   'input_required',
+  'capacity_backpressure',
 ])
 
 describe('keeper attention vocabulary drift guard', () => {
@@ -108,6 +130,9 @@ describe('keeper attention vocabulary drift guard', () => {
     expect(statusBridgeStandaloneActions().length).toBeGreaterThan(0)
     expect(dispositionActions().length).toBeGreaterThan(2)
     expect(executionReceiptAttentionReasons().length).toBeGreaterThan(4)
+    expect(executionReceiptAttentionReasons()).toContain(
+      'provider_attempt_effect_fenced',
+    )
   })
 
   it('every keeper_status_bridge attention_reason has a frontend label', () => {
@@ -143,7 +168,7 @@ describe('keeper attention vocabulary drift guard', () => {
 
   it('every dashboard attention-worthy execution receipt reason has a frontend label', () => {
     const attentionWorthy = executionReceiptAttentionReasons().filter(
-      (reason) => !EXECUTION_RECEIPT_PASS_ONLY_REASONS.has(reason),
+      (reason) => !EXECUTION_RECEIPT_NON_ATTENTION_REASONS.has(reason),
     )
     const missing = [...new Set(attentionWorthy)].filter((reason) => !isAttentionReason(reason))
     expect(

--- a/dashboard/src/lib/keeper-attention-labels.test.ts
+++ b/dashboard/src/lib/keeper-attention-labels.test.ts
@@ -17,6 +17,15 @@ describe('keeper attention labels', () => {
     expect(warn).not.toHaveBeenCalled()
   })
 
+  it('labels a fenced provider effect without exposing the raw token', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    expect(attentionReasonLabel('provider_attempt_effect_fenced', false)).toBe(
+      'Provider 효과 결과 확인 필요',
+    )
+    expect(warn).not.toHaveBeenCalled()
+  })
+
   it('labels typed next actions without warning', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 

--- a/dashboard/src/lib/keeper-attention-labels.ts
+++ b/dashboard/src/lib/keeper-attention-labels.ts
@@ -57,6 +57,7 @@ export const ATTENTION_REASONS = [
   'internal_error',
   'cancelled',
   'transcript_corruption',
+  'provider_attempt_effect_fenced',
   'unmapped_runtime_state',
 ] as const
 export type AttentionReason = typeof ATTENTION_REASONS[number]
@@ -78,6 +79,7 @@ const ATTENTION_REASON_LABELS: Record<AttentionReason, string> = {
   internal_error: '내부 오류',
   cancelled: '취소됨',
   transcript_corruption: '대화 기록 손상 - 초기화 필요',
+  provider_attempt_effect_fenced: 'Provider 효과 결과 확인 필요',
   unmapped_runtime_state: '매핑되지 않은 runtime 상태',
 }
 

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -95,6 +95,7 @@ type operator_disposition_reason =
   | Reason_cancelled
   | Reason_phase_skipped
   | Reason_transcript_corruption
+  | Reason_provider_attempt_effect_fenced
   | Reason_unmapped_runtime_state
 
 let operator_disposition_reason_to_string = function
@@ -111,6 +112,8 @@ let operator_disposition_reason_to_string = function
   | Reason_cancelled -> "cancelled"
   | Reason_phase_skipped -> "phase_skipped"
   | Reason_transcript_corruption -> "transcript_corruption"
+  | Reason_provider_attempt_effect_fenced ->
+    Keeper_internal_error.provider_attempt_effect_fenced_kind
   | Reason_unmapped_runtime_state -> "unmapped_runtime_state"
 ;;
 
@@ -156,6 +159,12 @@ let operator_disposition (receipt : t)
   | _ when input_required -> Disp_pass, Reason_input_required
   | Keeper_terminal_reason.Transcript_corruption _ ->
     Disp_operator_reset_required, Reason_transcript_corruption
+  | Keeper_terminal_reason.Provider_attempt_effect_fenced _ ->
+    (* Same-turn replay stays forbidden, and the runtime lifecycle remains
+       responsible for selecting a later turn. Keep the operator alert, but
+       classify the canonical typed failure instead of incrementing the
+       unmapped-state regression metric. *)
+    Disp_unknown, Reason_provider_attempt_effect_fenced
   | Keeper_terminal_reason.Runtime_exhausted _ ->
     Disp_fail_open_next_runtime, Reason_runtime_exhausted
   | Keeper_terminal_reason.Capacity_backpressure _ ->
@@ -223,6 +232,7 @@ let operator_disposition (receipt : t)
        | Config_or_auth _
        | Provider_runtime_failure _
        | Transcript_corruption _
+       | Provider_attempt_effect_fenced _
        | Internal_error _
        | Unknown _ -> false)
     then Disp_pass, Reason_healthy

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -212,6 +212,10 @@ type operator_disposition_reason =
   | Reason_cancelled
   | Reason_phase_skipped
   | Reason_transcript_corruption
+  | Reason_provider_attempt_effect_fenced
+  (** The provider attempt did not prove whether an effect occurred. Paired
+      with [Disp_unknown] so operator attention remains required, while the
+      receipt is no longer counted as an unmapped classifier regression. *)
   | Reason_unmapped_runtime_state
 
 val operator_disposition_reason_to_string : operator_disposition_reason -> string

--- a/lib/keeper_runtime/keeper_internal_error.ml
+++ b/lib/keeper_runtime/keeper_internal_error.ml
@@ -24,6 +24,7 @@ let runtime_id_to_string (s : string) = s
    this value so recoverability cannot drift through duplicated literals. *)
 let capacity_backpressure_kind = "capacity_backpressure"
 let incomplete_tool_transcript_kind = "incomplete_tool_transcript"
+let provider_attempt_effect_fenced_kind = "provider_attempt_effect_fenced"
 
 type provider_rejection = {
   provider_label : string;
@@ -516,7 +517,7 @@ let masc_internal_error_to_json = function
   | Provider_attempt_effect_fenced
       { runtime_id; effect_disposition; diagnostic } ->
     `Assoc
-      [ "kind", `String "provider_attempt_effect_fenced"
+      [ "kind", `String provider_attempt_effect_fenced_kind
       ; "runtime_id", `String runtime_id
       ; ( "effect_disposition"
         , `String (Keeper_provider_attempt_effect_core.to_string effect_disposition) )
@@ -669,7 +670,7 @@ let kind_of_masc_internal_error = function
   | Internal_contract_rejected _ -> "internal_contract_rejected"
   | Incomplete_tool_transcript _ -> incomplete_tool_transcript_kind
   | Terminal_effect_failed _ -> "terminal_effect_failed"
-  | Provider_attempt_effect_fenced _ -> "provider_attempt_effect_fenced"
+  | Provider_attempt_effect_fenced _ -> provider_attempt_effect_fenced_kind
   | Receipt_persistence_failed _ -> "receipt_persistence_failed"
   | Gate_replay_repair_required _ -> "gate_replay_repair_required"
 
@@ -931,10 +932,11 @@ let parse_masc_internal_error_json (json : Yojson.Safe.t) :
                     { failure_class; effect_disposition; diagnostic })
              | _ -> None)
           | _ -> None)
-      | Some (`String "provider_attempt_effect_fenced")
-        when exact_fields
-               [ "kind"; "runtime_id"; "effect_disposition"; "diagnostic" ]
-               fields ->
+      | Some (`String kind)
+        when String.equal kind provider_attempt_effect_fenced_kind
+             && exact_fields
+                  [ "kind"; "runtime_id"; "effect_disposition"; "diagnostic" ]
+                  fields ->
         (match
            string_opt_of_assoc "runtime_id" json,
            string_opt_of_assoc "effect_disposition" json,

--- a/lib/keeper_runtime/keeper_internal_error.mli
+++ b/lib/keeper_runtime/keeper_internal_error.mli
@@ -4,9 +4,13 @@
 (** Canonical wire kind emitted for {!Capacity_backpressure}.  Receipt
     terminal projection and decoding consume this same value. *)
 val capacity_backpressure_kind : string
-val incomplete_tool_transcript_kind : string
 (** Canonical wire kind for structural transcript corruption rejected before
     provider dispatch. *)
+val incomplete_tool_transcript_kind : string
+
+(** Canonical wire kind for a provider-attempt failure whose effect disposition
+    forbids same-turn replay. *)
+val provider_attempt_effect_fenced_kind : string
 
 type provider_rejection = {
   provider_label : string;

--- a/lib/keeper_runtime/keeper_terminal_reason.ml
+++ b/lib/keeper_runtime/keeper_terminal_reason.ml
@@ -29,6 +29,7 @@ type t =
   | Config_or_auth of string
   | Provider_runtime_failure of string
   | Transcript_corruption of string
+  | Provider_attempt_effect_fenced of string
   | Internal_error of string
   | Pre_dispatch_success of string
   | Unknown of string
@@ -44,8 +45,9 @@ let is_config_or_auth_wire = function
 
 (* Priority-ranked partition. The bucket order replicates the [if/else]
    order of the pre-typing [operator_disposition] string predicates, with the
-   exact canonical [Capacity_backpressure] policy bucket inserted before the
-   opaque internal-error fall-through;
+   exact canonical policy buckets for [Capacity_backpressure] and
+   [Provider_attempt_effect_fenced] inserted before the opaque internal-error
+   fall-through;
    [of_wire] returns the FIRST matching bucket. Capacity backpressure is an
    exact producer-owned wire kind; casing variants remain opaque rather than
    inheriting its non-pageable policy. The original
@@ -68,6 +70,9 @@ let of_wire wire =
   else if
     String.equal wire Keeper_internal_error.incomplete_tool_transcript_kind
   then Transcript_corruption wire
+  else if
+    String.equal wire Keeper_internal_error.provider_attempt_effect_fenced_kind
+  then Provider_attempt_effect_fenced wire
   else if String.equal wire "internal_error"
   then Internal_error wire
   else if String.equal wire "pre_dispatch_success"
@@ -85,6 +90,7 @@ let to_wire = function
   | Config_or_auth wire -> wire
   | Provider_runtime_failure wire -> wire
   | Transcript_corruption wire -> wire
+  | Provider_attempt_effect_fenced wire -> wire
   | Internal_error wire -> wire
   | Pre_dispatch_success wire -> wire
   | Unknown wire -> wire
@@ -113,6 +119,7 @@ let is_transient_provider_runtime_failure = function
   | Capacity_backpressure _
   | Config_or_auth _
   | Transcript_corruption _
+  | Provider_attempt_effect_fenced _
   | Internal_error _
   | Pre_dispatch_success _
   | Unknown _ -> false

--- a/lib/keeper_runtime/keeper_terminal_reason.mli
+++ b/lib/keeper_runtime/keeper_terminal_reason.mli
@@ -27,8 +27,9 @@
 
     [of_wire] is a {e priority-ranked partition}: it tests the buckets in
     the same order the old [operator_disposition] [if/else] chain tested
-    its string predicates, plus the exact canonical
-    [Capacity_backpressure] policy bucket, and returns the first match.
+    its string predicates, plus exact canonical policy buckets for
+    [Capacity_backpressure] and [Provider_attempt_effect_fenced], and returns
+    the first match.
     Only canonical producer wire forms select specialized buckets. The order
     remains load-bearing for canonical overlaps; see the [.ml] for the ranked
     list.
@@ -69,6 +70,12 @@ type t =
       {!Keeper_internal_error.incomplete_tool_transcript_kind}. Provider
       dispatch did not occur; automatic retry is forbidden until an operator
       resets the corrupted checkpoint. *)
+  | Provider_attempt_effect_fenced of string
+  (** Exact canonical wire
+      {!Keeper_internal_error.provider_attempt_effect_fenced_kind}. A provider
+      attempt may have crossed an effect boundary, so same-turn replay is
+      forbidden and the operator-facing receipt must retain an explicit alert
+      rather than treating it as an unmapped internal state. *)
   | Internal_error of string
   (** Exact wire ["internal_error"]. Payload is the original
           string, carried only for [to_wire] round-trip fidelity. *)

--- a/scripts/fixtures/keeper-multi-collaboration/missions.json
+++ b/scripts/fixtures/keeper-multi-collaboration/missions.json
@@ -232,6 +232,16 @@
       "user_story": "같은 Keeper가 서로 다른 runtime turn identity를 가진 11개 요청 turn을 순서대로 완료하고 첫 turn의 secret을 반복 입력받지 않은 채 중간 Board 연쇄와 재시작 뒤 기억을 복원한다.",
       "assertions": ["same_keeper_eleven_linked_turns", "context_secret_recalled"],
       "evidence": ["turns/continuity-*.json", "turns/context-after-restart.json", "observations/board-post.json"]
+    },
+    {
+      "id": "RW19",
+      "phase": "persistence_observability",
+      "name": "durable_turn_span_dashboard_projection",
+      "actors": ["coordinator", "builder-a", "builder-b", "reviewer", "researcher"],
+      "capabilities": ["Keeper", "Dashboard", "Observability", "Persistence"],
+      "user_story": "Verification 화면이 격리된 5-Keeper fleet의 decision-log durable turn span을 1h, 2h, 4h, 24h tier별 pass, warn, fail 상태와 함께 실제 backend 응답 그대로 표시하며 이를 무중단 uptime으로 과장하지 않는다.",
+      "assertions": ["persistence_tiers_dashboard_projection_observed"],
+      "evidence": ["browser/keeper-persistence-proof.json", "browser/keeper-persistence-proof.png"]
     }
   ]
 }

--- a/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
+++ b/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
@@ -83,6 +83,7 @@ KNOWN_ASSERTIONS = {
     "composition_async_observed",
     "composition_turn_context_observed",
     "composition_dashboard_browser_observed",
+    "persistence_tiers_dashboard_projection_observed",
 }
 
 
@@ -144,6 +145,101 @@ def sha256_file(path: pathlib.Path) -> str:
         for chunk in iter(lambda: source.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def validate_persistence_browser_evidence(
+    proof: Any,
+    screenshot_path: pathlib.Path,
+    expected_keepers: set[str],
+) -> tuple[bool, str]:
+    errors: list[str] = []
+    if not isinstance(proof, dict):
+        return False, "persistence browser proof is not an object"
+    if proof.get("schema") != "masc.keeper_persistence_browser_evidence.v1":
+        errors.append("schema mismatch")
+    generated_at = proof.get("generated_at")
+    if not isinstance(generated_at, str) or not generated_at:
+        errors.append("generated_at is absent")
+    else:
+        try:
+            dt.datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
+        except ValueError:
+            errors.append("generated_at is invalid")
+    if proof.get("interaction") != "manual_refresh":
+        errors.append("manual refresh was not observed")
+    if not expected_keepers:
+        errors.append("expected Keeper fleet is absent")
+    tiers = proof.get("tiers")
+    if not isinstance(tiers, list) or len(tiers) != 4:
+        errors.append("duration tiers must be an exact four-element list")
+        tiers = []
+    if all(isinstance(tier, dict) for tier in tiers):
+        if [tier.get("id") for tier in tiers] != ["1h", "2h", "4h", "24h"]:
+            errors.append("duration tier ids are not exact and ordered")
+        previous_observed: set[str] | None = None
+        previous_missing: set[str] | None = None
+        for tier in tiers:
+            status = tier.get("status")
+            evidence_kind = tier.get("evidence_kind")
+            observed_count = tier.get("observed_count")
+            keeper_count = tier.get("keeper_count")
+            missing_count = tier.get("missing_count")
+            observed_names = tier.get("observed_keepers")
+            missing_names = tier.get("missing_keepers")
+            if status not in {"pass", "warn", "fail"}:
+                errors.append(f"tier {tier.get('id')} status is invalid")
+            if evidence_kind != "durable_turn_span":
+                errors.append(f"tier {tier.get('id')} evidence kind is invalid")
+            counts = (observed_count, keeper_count, missing_count)
+            if not all(type(value) is int and value >= 0 for value in counts):
+                errors.append(f"tier {tier.get('id')} counts are invalid")
+                continue
+            if not isinstance(observed_names, list) or not isinstance(missing_names, list):
+                errors.append(f"tier {tier.get('id')} Keeper identities are absent")
+                continue
+            if not all(isinstance(name, str) and bool(name.strip()) for name in observed_names + missing_names):
+                errors.append(f"tier {tier.get('id')} Keeper identities are invalid")
+                continue
+            observed = set(observed_names)
+            missing = set(missing_names)
+            if len(observed) != len(observed_names) or len(missing) != len(missing_names):
+                errors.append(f"tier {tier.get('id')} Keeper identities contain duplicates")
+            if observed & missing or observed | missing != expected_keepers:
+                errors.append(f"tier {tier.get('id')} does not describe the exact run fleet")
+            if len(observed) != observed_count or len(missing) != missing_count:
+                errors.append(f"tier {tier.get('id')} counts do not match identities")
+            if observed_count + missing_count != keeper_count or keeper_count != len(expected_keepers):
+                errors.append(f"tier {tier.get('id')} Keeper total is inconsistent")
+            derived_status = (
+                "fail"
+                if keeper_count == 0 or observed_count == 0
+                else "pass"
+                if observed_count == keeper_count
+                else "warn"
+            )
+            if status != derived_status:
+                errors.append(f"tier {tier.get('id')} status disagrees with counts")
+            if previous_observed is not None and previous_missing is not None and (
+                not observed <= previous_observed or not missing >= previous_missing
+            ):
+                errors.append(f"tier {tier.get('id')} violates duration monotonicity")
+            previous_observed = observed
+            previous_missing = missing
+    elif tiers:
+        errors.append("duration tiers contain non-object values")
+    screenshot_digest = proof.get("screenshot_sha256")
+    if proof.get("screenshot_file") != "keeper-persistence-proof.png":
+        errors.append("screenshot filename is invalid")
+    if not isinstance(screenshot_digest, str) or re.fullmatch(r"[0-9a-f]{64}", screenshot_digest) is None:
+        errors.append("screenshot digest is invalid")
+    elif not screenshot_path.is_file():
+        errors.append("screenshot is absent")
+    else:
+        if sha256_file(screenshot_path) != screenshot_digest:
+            errors.append("screenshot digest mismatch")
+        if proof.get("screenshot_bytes") != screenshot_path.stat().st_size:
+            errors.append("screenshot byte count mismatch")
+    return not errors, "; ".join(errors) if errors else "exact refreshed persistence projection and screenshot verified"
 
 
 def source_sha() -> str:
@@ -367,12 +463,12 @@ def load_catalog(path: pathlib.Path) -> dict[str, Any]:
     if catalog.get("schema") != "masc.keeper_multi_collaboration_missions.v1":
         raise AcceptanceError("mission catalog schema mismatch")
     missions = catalog.get("missions")
-    if not isinstance(missions, list) or len(missions) != 18:
-        raise AcceptanceError("mission catalog must contain exactly 18 missions")
+    if not isinstance(missions, list) or len(missions) != 19:
+        raise AcceptanceError("mission catalog must contain exactly 19 missions")
     ids = [mission.get("id") for mission in missions]
-    expected_ids = [f"RW{index:02d}" for index in range(1, 19)]
+    expected_ids = [f"RW{index:02d}" for index in range(1, 20)]
     if ids != expected_ids:
-        raise AcceptanceError("mission ids must be ordered exactly RW01 through RW18")
+        raise AcceptanceError("mission ids must be ordered exactly RW01 through RW19")
     roles = catalog.get("roles")
     if not isinstance(roles, list) or set(roles) != EXPECTED_ROLES:
         raise AcceptanceError("catalog must define the exact five collaboration roles")
@@ -543,6 +639,7 @@ class MissionRun:
         self.observations: dict[str, ToolObservation] = {}
         self.tool_call_rows: dict[str, list[dict[str, Any]]] = {}
         self.browser_proof: dict[str, Any] = {}
+        self.persistence_browser_proof: dict[str, Any] = {}
 
     def call(self, label: str, tool: str, arguments: dict[str, Any]) -> ToolObservation:
         observation = self.client.call_tool(tool, arguments)
@@ -925,14 +1022,25 @@ class MissionRun:
                 "composition browser proof failed: "
                 + (completed.stderr.strip() or completed.stdout.strip())
             )
-        measurement_path = browser_dir / "keeper-composition-inspector.json"
-        try:
-            measurement = json.loads(measurement_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError) as error:
-            raise AcceptanceError(f"invalid browser proof measurement: {error}") from error
-        if not isinstance(measurement, dict):
-            raise AcceptanceError("browser proof measurement must be an object")
-        self.browser_proof = measurement
+
+        def read_measurement(filename: str) -> dict[str, Any]:
+            measurement_path = browser_dir / filename
+            try:
+                measurement = json.loads(measurement_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as error:
+                raise AcceptanceError(
+                    f"invalid browser proof measurement {filename}: {error}"
+                ) from error
+            if not isinstance(measurement, dict):
+                raise AcceptanceError(
+                    f"browser proof measurement {filename} must be an object"
+                )
+            return measurement
+
+        self.browser_proof = read_measurement("keeper-composition-inspector.json")
+        self.persistence_browser_proof = read_measurement(
+            "keeper-persistence-proof.json"
+        )
 
     def run_contention(self, post_id: str) -> None:
         prompts = {
@@ -1460,6 +1568,16 @@ class MissionRun:
         browser_screenshot = (
             self.writer.output_dir / "browser" / "keeper-composition-inspector.png"
         )
+        persistence_browser_screenshot = (
+            self.writer.output_dir / "browser" / "keeper-persistence-proof.png"
+        )
+        persistence_projection_passed, persistence_projection_detail = (
+            validate_persistence_browser_evidence(
+                self.persistence_browser_proof,
+                persistence_browser_screenshot,
+                set(self.roles.values()),
+            )
+        )
         parallel_events = sorted(
             [
                 (turn.started_epoch_seconds, 1)
@@ -1780,6 +1898,10 @@ class MissionRun:
                 == self.browser_proof["screenshot_sha256"],
                 "actual dashboard inspector renders one complete typed run with expanded input/output",
             ),
+            "persistence_tiers_dashboard_projection_observed": (
+                persistence_projection_passed,
+                persistence_projection_detail,
+            ),
         }
         malformed = [
             name
@@ -2006,6 +2128,36 @@ def verify_bundle(
                 errors.append(
                     f"missing catalog evidence for {mission['id']}: {pattern}"
                 )
+    persistence_proof_path = output_dir / "browser" / "keeper-persistence-proof.json"
+    persistence_screenshot_path = output_dir / "browser" / "keeper-persistence-proof.png"
+    try:
+        persistence_proof = json.loads(
+            persistence_proof_path.read_text(encoding="utf-8")
+        )
+    except (OSError, json.JSONDecodeError) as error:
+        errors.append(f"persistence browser proof is unreadable: {error}")
+    else:
+        resources = bundle.get("resources")
+        keepers = resources.get("keepers") if isinstance(resources, dict) else None
+        exact_role_map = (
+            isinstance(keepers, dict)
+            and set(keepers) == EXPECTED_ROLES
+            and all(
+                isinstance(value, str) and bool(value.strip())
+                for value in keepers.values()
+            )
+            and len(set(keepers.values())) == len(EXPECTED_ROLES)
+        )
+        if not exact_role_map:
+            errors.append("bundle resources do not name five distinct exact role Keepers")
+        expected_keepers = set(keepers.values()) if exact_role_map else set()
+        persistence_valid, persistence_detail = validate_persistence_browser_evidence(
+            persistence_proof,
+            persistence_screenshot_path,
+            expected_keepers,
+        )
+        if not persistence_valid:
+            errors.append(f"persistence browser proof is invalid: {persistence_detail}")
     seed = {
         "source_sha": bundle.get("source_sha"),
         "runner_source_sha": bundle.get("runner_source_sha"),

--- a/test/test_keeper_multi_collaboration_acceptance.py
+++ b/test/test_keeper_multi_collaboration_acceptance.py
@@ -1,0 +1,118 @@
+import hashlib
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = (
+    REPO_ROOT
+    / "scripts"
+    / "harness"
+    / "workload"
+    / "keeper_multi_collaboration_acceptance.py"
+)
+CATALOG_PATH = (
+    REPO_ROOT
+    / "scripts"
+    / "fixtures"
+    / "keeper-multi-collaboration"
+    / "missions.json"
+)
+
+
+def load_acceptance_module():
+    spec = importlib.util.spec_from_file_location(
+        "keeper_multi_collaboration_acceptance",
+        SCRIPT_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+acceptance = load_acceptance_module()
+
+
+class KeeperMultiCollaborationAcceptanceTest(unittest.TestCase):
+    def test_catalog_has_exact_rw19_persistence_projection_mission(self):
+        catalog = acceptance.load_catalog(CATALOG_PATH)
+
+        self.assertEqual(len(catalog["missions"]), 19)
+        self.assertEqual(catalog["missions"][-1]["id"], "RW19")
+        self.assertEqual(
+            catalog["missions"][-1]["assertions"],
+            ["persistence_tiers_dashboard_projection_observed"],
+        )
+
+    def test_persistence_browser_validator_requires_exact_monotonic_fleet(self):
+        expected = {"keeper-a", "keeper-b"}
+        with tempfile.TemporaryDirectory() as tmp_name:
+            screenshot = Path(tmp_name) / "keeper-persistence-proof.png"
+            screenshot.write_bytes(b"png-evidence")
+            digest = hashlib.sha256(screenshot.read_bytes()).hexdigest()
+            proof = {
+                "schema": "masc.keeper_persistence_browser_evidence.v1",
+                "generated_at": "2026-08-14T12:00:00Z",
+                "interaction": "manual_refresh",
+                "tiers": [
+                    self.tier("1h", ["keeper-a", "keeper-b"], []),
+                    self.tier("2h", ["keeper-a"], ["keeper-b"]),
+                    self.tier("4h", ["keeper-a"], ["keeper-b"]),
+                    self.tier("24h", [], ["keeper-a", "keeper-b"]),
+                ],
+                "screenshot_file": screenshot.name,
+                "screenshot_bytes": screenshot.stat().st_size,
+                "screenshot_sha256": digest,
+            }
+
+            valid, detail = acceptance.validate_persistence_browser_evidence(
+                proof,
+                screenshot,
+                expected,
+            )
+            self.assertTrue(valid, detail)
+
+            proof["tiers"][2] = self.tier(
+                "4h",
+                ["keeper-b"],
+                ["keeper-a"],
+            )
+            valid, detail = acceptance.validate_persistence_browser_evidence(
+                proof,
+                screenshot,
+                expected,
+            )
+            self.assertFalse(valid)
+            self.assertIn("duration monotonicity", detail)
+
+    @staticmethod
+    def tier(tier_id, observed, missing):
+        keeper_count = len(observed) + len(missing)
+        observed_count = len(observed)
+        status = (
+            "fail"
+            if keeper_count == 0 or observed_count == 0
+            else "pass"
+            if observed_count == keeper_count
+            else "warn"
+        )
+        return {
+            "id": tier_id,
+            "status": status,
+            "evidence_kind": "durable_turn_span",
+            "keeper_count": keeper_count,
+            "observed_count": observed_count,
+            "missing_count": len(missing),
+            "observed_keepers": observed,
+            "missing_keepers": missing,
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -89,6 +89,7 @@ let roundtrip_corpus =
     "runtime_exhausted"
   ; Keeper_internal_error.capacity_backpressure_kind
   ; Keeper_internal_error.incomplete_tool_transcript_kind
+  ; Keeper_internal_error.provider_attempt_effect_fenced_kind
   ; "internal_error"
   ; "pre_dispatch_success"
   ; "provider_error"
@@ -178,6 +179,11 @@ let frozen_operator_disposition (receipt : R.t)
   else if
     String.equal terminal_reason Keeper_internal_error.incomplete_tool_transcript_kind
   then R.Disp_operator_reset_required, R.Reason_transcript_corruption
+  else if
+    String.equal
+      terminal_reason
+      Keeper_internal_error.provider_attempt_effect_fenced_kind
+  then R.Disp_unknown, R.Reason_provider_attempt_effect_fenced
   else if preflight_config_failure
   then R.Disp_fail_open_next_runtime, R.Reason_preflight_config_error
   else if
@@ -308,7 +314,72 @@ let () =
      = (R.Disp_operator_reset_required, R.Reason_transcript_corruption));
   check
     "transcript corruption emits operator broadcast"
-    (R.needs_operator_broadcast (fst transcript_corruption))
+    (R.needs_operator_broadcast (fst transcript_corruption));
+  let fenced_error =
+    Keeper_internal_error.Provider_attempt_effect_fenced
+      { runtime_id = "antigravity_subscription.gemini-3-6-flash-high"
+      ; effect_disposition = Keeper_provider_attempt_effect_core.Effect_attempted
+      ; diagnostic = "provider response did not prove whether the tool effect settled"
+      }
+  in
+  let fenced_json = Keeper_internal_error.masc_internal_error_to_json fenced_error in
+  check
+    "provider-attempt fence codec emits the canonical kind"
+    (Json_util.get_string fenced_json "kind"
+     = Some Keeper_internal_error.provider_attempt_effect_fenced_kind);
+  check
+    "provider-attempt fence codec round-trips the typed evidence"
+    (Keeper_internal_error.parse_masc_internal_error_json fenced_json
+     = Some fenced_error);
+  let fenced_wire = Keeper_internal_error.provider_attempt_effect_fenced_kind in
+  let producer_wire =
+    fenced_error
+    |> Keeper_internal_error.core_error_of_masc_internal_error
+    |> Masc.Keeper_agent_error.terminal_reason_code_of_core_error
+  in
+  check
+    "provider-attempt fence producer projects the canonical terminal wire"
+    (String.equal producer_wire fenced_wire);
+  check
+    "provider-attempt fence wire decodes to the closed terminal variant"
+    (match Tr.of_wire fenced_wire with
+     | Tr.Provider_attempt_effect_fenced wire -> String.equal wire fenced_wire
+     | _ -> false);
+  check
+    "provider-attempt fence terminal wire round-trips byte-identically"
+    (String.equal (Tr.to_wire (Tr.of_wire fenced_wire)) fenced_wire);
+  let unmapped_metric = Keeper_metrics.(to_string ReceiptUnmappedDisposition) in
+  let unmapped_before = Masc.Otel_metric_store.metric_value_or_zero unmapped_metric () in
+  let fenced_disposition =
+    R.operator_disposition
+      { base_receipt with
+        terminal_reason_code = fenced_wire
+      ; error_kind = Some (R.error_kind_of_string "internal")
+      ; outcome = `Error
+      ; runtime_outcome = R.Runtime_failed
+      }
+  in
+  let unmapped_after = Masc.Otel_metric_store.metric_value_or_zero unmapped_metric () in
+  check
+    "provider-attempt fence keeps operator attention with a typed reason"
+    (fenced_disposition
+     = (R.Disp_unknown, R.Reason_provider_attempt_effect_fenced));
+  check
+    "provider-attempt fence reason has the canonical dashboard wire"
+    (String.equal
+       (R.operator_disposition_reason_to_string (snd fenced_disposition))
+       fenced_wire);
+  check
+    "attempted provider effect still forbids same-turn retry"
+    (not
+       (Keeper_provider_attempt_effect_core.allows_same_turn_retry
+          Keeper_provider_attempt_effect_core.Effect_attempted));
+  check
+    "provider-attempt fence still emits an operator broadcast"
+    (R.needs_operator_broadcast (fst fenced_disposition));
+  check
+    "provider-attempt fence does not increment the unmapped regression metric"
+    (Float.equal unmapped_before unmapped_after)
 ;;
 
 let () =


### PR DESCRIPTION
## Outcome

Classify the canonical `provider_attempt_effect_fenced` terminal reason explicitly instead of reporting it as an unmapped receipt state.

## Safety contract

- preserves `Disp_unknown`, so operator broadcast remains required
- preserves the producer-owned effect fence and same-turn retry prohibition
- removes false `ReceiptUnmappedDisposition` / unmapped-disposition failure increments
- shares one canonical wire across internal-error codec, terminal parser, receipt reason, and dashboard
- humanizes the reason in Keeper attention and FSM/operator surfaces

## Verification

- frozen independent disposition matrix includes the canonical fenced wire
- producer codec and terminal wire round-trip coverage
- unmapped metric non-increment assertion
- operator broadcast and no-same-turn-retry assertions
- dashboard label, alert-strip, FSM, and shared-constant drift regressions
- `ocamlformat`, parser-only OCaml syntax checks, and `git diff --check` pass
- two adversarial source reviews are CLEAN for BLOCKING/HIGH

No local builds or test suites were run; CI is authoritative per repository instruction.

## Stack

Depends on #28689 (`56c110546b2acc7ec3d05a6a6832581ad370cf7d`).