### PR TITLE
refactor(keeper): drop the continuation delivery identity kind

### DIFF
--- a/lib/keeper_chat_delivery_identity/keeper_chat_delivery_identity.ml
+++ b/lib/keeper_chat_delivery_identity/keeper_chat_delivery_identity.ml
@@ -34,7 +34,6 @@ end
 type delivery_key =
   | Operation of Request_id.t
   | Fusion_run of Request_id.t
-  | Continuation of Request_id.t
 
 type transcript_slot =
   | Accepted_user
@@ -91,11 +90,6 @@ let delivery_key_to_yojson = function
       [ "kind", `String "fusion_run"
       ; "request_id", `String (Request_id.to_string request_id)
       ]
-  | Continuation intent_id ->
-    `Assoc
-      [ "kind", `String "continuation"
-      ; "intent_id", `String (Request_id.to_string intent_id)
-      ]
 ;;
 
 let delivery_key_of_yojson = function
@@ -122,16 +116,6 @@ let delivery_key_of_yojson = function
        let* request_id = string_field "request_id" fields in
        let* request_id = Request_id.of_string request_id in
        Ok (Fusion_run request_id)
-     | "continuation" ->
-       let* () =
-         validate_fields
-           ~context:"continuation delivery identity"
-           ~expected:[ "kind"; "intent_id" ]
-           fields
-       in
-       let* intent_id = string_field "intent_id" fields in
-       let* intent_id = Request_id.of_string intent_id in
-       Ok (Continuation intent_id)
      | _ -> Error (Printf.sprintf "unsupported delivery identity kind %S" kind))
   | _ -> Error "delivery identity must be an object"
 ;;
@@ -140,10 +124,7 @@ let delivery_key_equal left right =
   match left, right with
   | Operation left, Operation right -> Request_id.equal left right
   | Fusion_run left, Fusion_run right -> Request_id.equal left right
-  | Continuation left, Continuation right -> Request_id.equal left right
-  | (Operation _ | Fusion_run _ | Continuation _),
-    (Operation _ | Fusion_run _ | Continuation _) ->
-    false
+  | Operation _, Fusion_run _ | Fusion_run _, Operation _ -> false
 ;;
 
 let transcript_slot_to_yojson = function

--- a/lib/keeper_chat_delivery_identity/keeper_chat_delivery_identity.mli
+++ b/lib/keeper_chat_delivery_identity/keeper_chat_delivery_identity.mli
@@ -13,11 +13,6 @@ end
 type delivery_key =
   | Operation of Request_id.t
   | Fusion_run of Request_id.t
-  | Continuation of Request_id.t
-(** [Continuation] identifies the terminal transcript row owned by one
-    autonomous continuation-delivery intent.  It is deliberately distinct
-    from the producer's operation or Fusion identity: the deterministic
-    intent id is the idempotency authority at this projection boundary. *)
 
 type transcript_slot =
   | Accepted_user

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -204,9 +204,6 @@ type t =
   | WireCaptureResponseSuppressed (* counter: keeper-visible response suppressed before wire capture *)
   | WireCaptureWriteFailures    (* counter: wire-capture write raised an exception *)
   | WireCaptureRecordSkipped    (* counter: wire-capture record dropped by current-file byte cap *)
-      (* counter: RFC-0320 W3c continuation delivery outcome; label=outcome_tag
-         (Delivered/Skipped_unrouted/Skipped_already_replied/Skipped_empty/Failed).
-         G5 observability — a dropped/unrouted continuation must never be silent. *)
 [@@deriving enumerate]
 
 (** String conversion

--- a/test/test_keeper_chat_delivery_identity.ml
+++ b/test/test_keeper_chat_delivery_identity.ml
@@ -37,24 +37,6 @@ let test_fusion_roundtrip () =
     (Identity.delivery_key_equal key (Identity.Operation request_id))
 ;;
 
-let test_continuation_roundtrip () =
-  let request_id =
-    Identity.Request_id.of_string "kdelivery-continuation-test" |> expect_ok
-  in
-  let key = Identity.Continuation request_id in
-  let decoded =
-    Identity.delivery_key_to_yojson key
-    |> Identity.delivery_key_of_yojson
-    |> expect_ok
-  in
-  check bool "continuation identity roundtrips" true
-    (Identity.delivery_key_equal key decoded);
-  check bool "continuation namespace differs from operation" false
-    (Identity.delivery_key_equal key (Identity.Operation request_id));
-  check bool "continuation namespace differs from Fusion" false
-    (Identity.delivery_key_equal key (Identity.Fusion_run request_id))
-;;
-
 let test_transcript_slot_roundtrip () =
   let slots =
     [ Identity.Accepted_user
@@ -159,10 +141,6 @@ let () =
             "Fusion run roundtrip"
             `Quick
             test_fusion_roundtrip
-        ; test_case
-            "continuation roundtrip"
-            `Quick
-            test_continuation_roundtrip
         ; test_case
             "transcript slots roundtrip"
             `Quick


### PR DESCRIPTION
## 목적

RFC-0376 (#28596) 이 continuation delivery 서브시스템을 삭제한 뒤, `Keeper_chat_delivery_identity.Continuation` kind 는 죽은 서브시스템이 남긴 행을 decode 하기 위해서만 생존해 있었다 (RFC-0376 §4.1 에 예고된 stacked 후속). 이 PR 이 그 마지막 잔재를 제거한다.

## 범위 (+1/−50, 4 files)

- `lib/keeper_chat_delivery_identity/keeper_chat_delivery_identity.ml` — `Continuation` constructor + encode/decode/equality arm 제거. equality 는 catch-all 없이 2-constructor 명시 쌍으로 재작성.
- `.mli` — constructor + doc 제거.
- `lib/keeper_metrics/keeper_metrics.ml` — 이미 삭제된 counter variant 의 고아 주석 3줄 제거 (variant 없이 주석만 남아 있었음).
- `test/test_keeper_chat_delivery_identity.ml` — 제거된 kind 의 roundtrip 테스트 삭제 (기능 제거 → 테스트 제거).

`server_routes_http_keeper_stream.ml` 의 `Continuation_checkpoint` 매치는 다른 개념(`Keeper_turn_outcome`)이며 이 PR 은 건드리지 않는다.

## 배포 계약 (fresh-state hard cut)

append-once 리더 `Keeper_chat_store.provenance_of_line` 은 decode `Error` 에서 **트랜잭션 전체를 실패**시킨다 (렌더 리더는 read-drop 으로 행을 유지). 따라서 이 코드가 부팅되기 전에 잔존 데이터 정리가 선행되어야 한다:

- 대상: `"kind":"continuation"` delivery_key 행 74건 / 6파일 (sangsu 48, kidsnote 10, rtprobe 8, analyst 3, canary-fusion 3, rondo 2) + `continuation_delivery_obligations_v1/` 디렉터리 6개
- 실행 시점: 다음 재기동 윈도우 (SIGTERM 후, 새 부팅 전 — 라이브 append 와의 경합 회피)
- 검증: `rg -c '"kind":"continuation"' ~/me/.masc/keeper_chat/*.jsonl` → 매치 0

호환 reader / migration code 는 만들지 않는다 (masc 구현 경계 원칙).

## 검증

- 로컬: `dune build --root . test/test_keeper_chat_delivery_identity.exe` green, suite 5/5 통과 (6→5, continuation roundtrip 제거분)
- 어휘 sweep: `rg -cin 'continuation' <4 touched files>` → 매치 0
- 소비자 전수: `Continuation` constructor 참조는 모듈 자신 + 삭제된 테스트 1곳뿐 (rg 로 lib/test/bin 전수)
- 전체 컴파일 판정은 CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)