### PR TITLE
fix(dashboard): label healthy fleet rows precisely

### DIFF
--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -868,7 +868,38 @@ describe('AgentRoster live-only cards', () => {
     expect(text).not.toMatch(/항목 \d+개 표시/)
     // the real, data-backed health pills stay.
     expect(container.querySelector('.fl-health')).not.toBeNull()
-    expect(text).toContain('runtime rows')
+    expect(text).toContain('normal rows')
+  })
+
+  it('labels active-band rows as normal instead of claiming all runtime-capable keepers', async () => {
+    keepers.value = [
+      {
+        name: 'healthy',
+        status: 'active',
+        phase: 'Running',
+        registered: true,
+        keepalive_running: true,
+      } as Keeper,
+      {
+        name: 'needs-attention',
+        status: 'active',
+        phase: 'Running',
+        registered: true,
+        keepalive_running: true,
+        runtime_blocker_class: 'fiber_unresolved',
+        runtime_blocker_summary: 'fiber_unresolved',
+      } as Keeper,
+    ]
+
+    await act(async () => {
+      render(html`<${AgentRoster} keeperFilter="keeper-only" />`, container)
+    })
+    await flushUi()
+
+    const summary = container.querySelector('.fl-health')?.textContent ?? ''
+    expect(summary).toContain('정상 1')
+    expect(summary).toContain('주의 1')
+    expect(summary).not.toContain('런타임 가능')
   })
 
   it('renders the exact inference observation from the live operator projection', async () => {

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -1091,7 +1091,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
   // Health pills (fl-hpill) read from the same band counts as the rows. No title
   // here — the shell's SurfaceLead owns the "Keeper Fleet" header for this
   // surface (dashboard-shell SURFACE_OWN_LEAD).
-  const healthRun = counts.active
+  const healthNormal = counts.active
   const healthTransient = counts.transient
   const healthPaused = counts.paused
   const healthOffline = counts.offline
@@ -1268,7 +1268,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
           <h1 class="fl-title">Keeper Fleet</h1>
         </div>
         <div class="fl-health">
-          <span class="fl-hpill ok">런타임 가능 <b>${healthRun}</b></span>
+          <span class="fl-hpill ok">정상 <b>${healthNormal}</b></span>
           ${healthTransient > 0 ? html`<span class="fl-hpill busy">${KEEPER_TRANSIENT_LABEL_KO} <b>${healthTransient}</b></span>` : null}
           <span class="fl-hpill warn">일시정지 <b>${healthPaused}</b></span>
           <span class="fl-hpill">${KEEPER_STATUS_LABEL_KO.offline} <b>${healthOffline}</b></span>
@@ -1283,7 +1283,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
           onClick=${() => navigate('registry', {})}
         >＋ 새 Keeper</button>
         <div class="fl-meta"><span class="live">● live</span><span>${namespaceName}</span></div>
-        <span class="sr-only">실행 rows ${healthRun} · 전이 rows ${healthTransient} · 일시정지 rows ${healthPaused} · 중지 rows ${healthOffline}</span>
+        <span class="sr-only">정상 rows ${healthNormal} · 전이 rows ${healthTransient} · 일시정지 rows ${healthPaused} · 중지 rows ${healthOffline}</span>
       </header>
 
       ${showExecutionFallbackState
@@ -1549,7 +1549,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
       </div>
 
       <div class="fl-foot">
-        <span class="fl-tick"><span class="k">runtime rows</span><span class="v">active ${healthRun}/${rosterRows.length}</span></span>
+        <span class="fl-tick"><span class="k">normal rows</span><span class="v">${healthNormal}/${rosterRows.length}</span></span>
         <span class="fl-tick"><span class="k">transient rows</span><span class="v">${healthTransient}</span></span>
         <span class="fl-tick"><span class="k">paused rows</span><span class="v">${healthPaused}</span></span>
         <span class="fl-tick"><span class="k">offline rows</span><span class="v">${healthOffline}</span></span>


### PR DESCRIPTION
## Observed live failure

After the 0.22.0 restart, the same rendered session showed 8 running in TopBar and Overview while Keeper Fleet labeled only 7 rows as runtime-capable. The eighth Keeper, taskmaster, was running but classified into the attention band.

## Change

- Keep the existing closed runtime-band projection unchanged.
- Rename the active-band summary from 런타임 가능 to 정상.
- Keep attention as its orthogonal count, so the live state reads 정상 7 and 주의 1 instead of falsely claiming only 7 runtime-capable Keepers.
- Pin the mixed healthy plus running-attention scenario in the existing AgentRoster feature test.

## Coupling and policy

No new fetch, state owner, gate, timeout, environment variable, budget, string classifier, or magic threshold. This is a presentation-truth repair over the existing typed band sum.

## Validation

- live browser interaction: Overview to Monitor, 0.22.0, console/page/request errors all empty
- git diff --check: pass
- local dashboard and Dune tests intentionally not run; GitHub CI is the build authority

## Remaining proof

Exact-head Dashboard CI and a deployed browser recapture are still required before merge.