### PR TITLE
feat(keeper): compose typed shell artifact outputs

### DIFF
--- a/lib/keeper/keeper_tool_composition_surface.ml
+++ b/lib/keeper/keeper_tool_composition_surface.ml
@@ -730,17 +730,15 @@ let make_tools
         invalid_arg "validated async composition retained a terminal completion"
     in
     let tool_externalization_error =
-      match entry.execution, completion with
-      | Catalog.Async, _
-      | Catalog.Inline, Agent_core.Tool_contract.Continue_after_success ->
-        None
-      | Catalog.Inline, Agent_core.Tool_contract.Terminal_after_success _ ->
-        on_externalization_error
+      match entry.execution with
+      | Catalog.Async -> None
+      | Catalog.Inline -> on_externalization_error
     in
     Tool_bridge.agent_core_tool_of_masc_with_execution_env
       ~descriptor
       ~base_path:config.base_path
       ?on_externalization_error:tool_externalization_error
+      ~externalization_error_recoverable:false
       ~name:tool_name
       ~description:
         (Option.value
@@ -860,7 +858,33 @@ let make_tools
                   ; _
                   } ->
                 ());
-             result_of_execution ~tool_name ~start_time execution))))
+             let result =
+               result_of_execution ~tool_name ~start_time execution
+             in
+             (match
+                Tool_bridge.attach_artifact_manifest
+                  ~base_path:config.base_path
+                  result
+              with
+              | Ok result -> result
+              | Error { message; _ } ->
+                let diagnostic =
+                  "composition result manifest persistence failed: " ^ message
+                in
+                Option.iter
+                  (fun mark_failed ->
+                     mark_failed
+                       { Keeper_tools_agent_core.failure_class =
+                           Tool_result.Runtime_failure
+                       ; effect_disposition = Tool_result.Effect_outcome_unknown
+                       ; diagnostic
+                       })
+                  on_failed;
+                Tool_result.make_err
+                  ~tool_name
+                  ~class_:Tool_result.Runtime_failure
+                  ~start_time
+                  "composition result manifest persistence failed"))))
   in
   let has_async =
     Catalog.entries catalog

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -639,8 +639,70 @@ let with_composable_output composable_output descriptor =
   { descriptor with composable_output }
 ;;
 
+let normalized_artifact_ref_schema =
+  `Assoc
+    [ "type", `String "object"
+    ; ( "properties"
+      , `Assoc
+          [ ( "_blob"
+            , `Assoc
+                [ "type", `String "object"
+                ; ( "properties"
+                  , `Assoc
+                      [ "sha256", `Assoc [ "type", `String "string" ]
+                      ; "bytes", `Assoc [ "type", `String "integer" ]
+                      ; "mime", `Assoc [ "type", `String "string" ]
+                      ; "preview", `Assoc [ "type", `String "string" ]
+                      ] )
+                ; ( "required"
+                  , `List
+                      (List.map
+                         (fun name -> `String name)
+                         [ "sha256"; "bytes"; "mime"; "preview" ]) )
+                ; "additionalProperties", `Bool false
+                ] )
+          ] )
+    ; "required", `List [ `String "_blob" ]
+    ; "additionalProperties", `Bool false
+    ]
+;;
+
+let execute_output_schema =
+  `Assoc
+    [ "type", `String "object"
+    ; ( "properties"
+      , `Assoc
+          [ "ok", `Assoc [ "type", `String "boolean" ]
+          ; ( "status"
+            , `Assoc
+                [ "type", `String "object"
+                ; ( "properties"
+                  , `Assoc
+                      [ "kind", `Assoc [ "type", `String "string" ]
+                      ; "code", `Assoc [ "type", `String "integer" ]
+                      ; "signal", `Assoc [ "type", `String "integer" ]
+                      ] )
+                ; "required", `List [ `String "kind" ]
+                ; "additionalProperties", `Bool false
+                ] )
+          ; "output", `Assoc [ "type", `String "string" ]
+          ; "output_artifact", normalized_artifact_ref_schema
+          ; "stdout_artifact", normalized_artifact_ref_schema
+          ; "stderr_artifact", normalized_artifact_ref_schema
+          ; "typed", `Assoc [ "type", `String "boolean" ]
+          ; "execution_time_ms", `Assoc [ "type", `String "integer" ]
+          ] )
+    ; ( "required"
+      , `List
+          (List.map
+             (fun name -> `String name)
+             [ "ok"; "status"; "typed"; "execution_time_ms" ]) )
+    ; "additionalProperties", `Bool true
+    ]
+;;
+
 let public_descriptors =
-  [ descriptor
+  [ (descriptor
       ~capability_identity:Internal_name_identity
       ~keeper_model_projection:Preferred_public_name
       ~input_schema_source:Descriptor_owned
@@ -654,7 +716,10 @@ let public_descriptors =
          I/O and typed env for environment variables. MASC validates the input \
          shape, path jail, sandbox target, and external-effect Gate but never \
          interprets program or subcommand meaning. The invoked program owns \
-         its syntax and exit result."
+         its syntax and exit result. A successful result exposes typed status, \
+         output and execution_time_ms fields to later composition nodes. Small \
+         output stays inline; oversized output is represented by canonical \
+         output/stdout/stderr artifact references."
       ~input_schema:execute_schema
       ~policy:
         (policy
@@ -674,6 +739,7 @@ let public_descriptors =
         ]
       ~input_translation:(Identity Validate_once_before_translation)
       ()
+     |> with_composable_output (Json_output { schema = execute_output_schema }))
   ; descriptor
       ~capability_identity:Internal_name_identity
       ~keeper_model_projection:Preferred_public_name

--- a/lib/keeper/keeper_tool_emission_hook.ml
+++ b/lib/keeper/keeper_tool_emission_hook.ml
@@ -58,9 +58,14 @@ let accumulator_size acc =
   Stdlib.Mutex.unlock acc.mutex;
   n
 
-let capture_typed_result acc = function
-  | `Assoc _ as data -> push acc data
-  | (`List _ | `String _ | `Bool _ | `Int _ | `Intlit _ | `Float _ | `Null) -> ()
+let capture_typed_result acc data =
+  match
+    ( Multimodal.Tool_emission.extract_kind_from_result data
+    , Multimodal.Tool_emission.extract_id_from_result data )
+  with
+  | Some _, Some _ -> push acc data
+  | None, _ | _, None -> ()
+;;
 
 let drain_into_working_context acc ~(working_context : Yojson.Safe.t option)
     : Yojson.Safe.t option =

--- a/lib/keeper/keeper_tool_emission_hook.mli
+++ b/lib/keeper/keeper_tool_emission_hook.mli
@@ -39,9 +39,11 @@ type accumulator
 (** Allocate a fresh empty accumulator. *)
 val create_accumulator : unit -> accumulator
 
-(** Capture one producer-owned typed result. Only a JSON object can carry the
-    reserved multimodal fields; every other JSON variant, including a
-    JSON-looking [`String], is ignored without reparsing. *)
+(** Capture one producer-owned typed result only when the canonical multimodal
+    detector finds both a supported [__multimodal_kind] and a string
+    [__multimodal_id]. Untagged typed objects and every other JSON variant,
+    including a JSON-looking [`String], are ignored without reparsing or being
+    retained until post-turn drain. *)
 val capture_typed_result : accumulator -> Yojson.Safe.t -> unit
 
 (** Drain the accumulator and merge any tagged tool results into

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -47,6 +47,7 @@ let model_execute_cwd_resolution_error ~config ~meta ~args ~cwd error =
   in
   Keeper_tool_execution.failure
     ~class_:Tool_result.Policy_rejection
+    ~effect_disposition:Tool_result.Proven_pre_effect
     (error_json ~fields message)
 
 let sandbox_target_label = function
@@ -108,6 +109,25 @@ let redact_execute_output redaction ~stdout ~stderr =
     if String.equal stderr "" then stdout else stdout ^ stderr
   in
   stdout, stderr, output
+
+let composable_output_fields ~base_path ~stdout ~stderr ~output =
+  if String.length output <= Tool_bridge.default_externalize_threshold_bytes
+  then Ok [ "output", `String output ]
+  else
+    try
+      let store = Tool_blob_store.create ~base_path in
+      let store_stream bytes =
+        Tool_blob_store.put_durable store ~bytes ~mime:"text/plain"
+        |> Tool_output.normalized_artifact_ref_to_json
+      in
+      Ok
+        [ "output_artifact", store_stream output
+        ; "stdout_artifact", store_stream stdout
+        ; "stderr_artifact", store_stream stderr
+        ]
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Error (Printexc.to_string exn)
 
 module For_testing = struct
   let elapsed_duration_ms = elapsed_duration_ms
@@ -222,6 +242,7 @@ let handle_tool_execute_typed
       | Error e ->
         Keeper_tool_execution.failure
           ~class_:Tool_result.Policy_rejection
+          ~effect_disposition:Tool_result.Proven_pre_effect
           (error_json
              ~fields:
                ([ "typed", `Bool true ] @ model_location_fields)
@@ -234,6 +255,7 @@ let handle_tool_execute_typed
            in
            Keeper_tool_execution.failure
              ~class_:Tool_result.Policy_rejection
+             ~effect_disposition:Tool_result.Proven_pre_effect
              (error_json ~fields (typed_validation_error_text e))
          | Ok () ->
         let cmd = typed_input_command_text input in
@@ -380,6 +402,7 @@ let handle_tool_execute_typed
           in
           Keeper_tool_execution.failure
             ~class_:Tool_result.Policy_rejection
+            ~effect_disposition:Tool_result.Proven_pre_effect
             (error_json ~fields (typed_validation_error_text e))
         | Ok ir ->
         let cmd_for_log =
@@ -405,6 +428,7 @@ let handle_tool_execute_typed
           =
           Keeper_tool_execution.failure
             ~class_
+            ~effect_disposition:Tool_result.Proven_pre_effect
             (error_json
                ~fields:(typed_context_fields @ extra_fields)
                msg)
@@ -642,23 +666,74 @@ let handle_tool_execute_typed
               | Unix.WEXITED 0, _ | _, "" -> []
               | _, stderr -> [ "error", `String stderr; "stderr", `String stderr ]
             in
-            let payload =
-              Yojson.Safe.to_string
-                (`Assoc
+            let output_fields =
+              if succeeded
+              then
+                composable_output_fields
+                  ~base_path:config.base_path
+                  ~stdout
+                  ~stderr
+                  ~output
+              else Ok [ "output", `String output ]
+            in
+            (match output_fields with
+             | Error detail ->
+               Log.Keeper.warn
+                 ~keeper_name:meta.name
+                 "execute output artifact persistence failed after process completion: %s"
+                 detail;
+               authorized
+                 (Keeper_tool_execution.failure
+                    ~effect_disposition:Tool_result.Proven_post_effect
+                    (error_json
+                       ~fields:
+                         ([ "typed", `Bool true
+                          ; "code", `String "execute_output_externalization_failed"
+                          ; "status", status_json
+                          ; "execution_time_ms", `Int elapsed_ms
+                          ]
+                          @ dispatched_model_location_fields)
+                       "Execute completed, but its oversized output artifact could not be persisted."))
+             | Ok output_fields ->
+               let payload =
+                 `Assoc
                    ([ "ok", `Bool succeeded
                     ; "status", status_json
-                    ; "output", `String output
-                    ; "typed", `Bool true
-                    ; "execution_time_ms", `Int elapsed_ms
                     ]
+                    @ output_fields
+                    @ [ "typed", `Bool true
+                      ; "execution_time_ms", `Int elapsed_ms
+                      ]
                     @ failure_error_fields
                     @ sandbox_extra_fields
-                    @ dispatched_model_location_fields))
-            in
-            authorized
-              (if succeeded
-               then Keeper_tool_execution.success payload
-               else Keeper_tool_execution.failure payload)
+                    @ dispatched_model_location_fields)
+               in
+               authorized
+                 (if succeeded
+                  then
+                    (match
+                       Tool_bridge.attach_artifact_manifest
+                         ~base_path:config.base_path
+                         (Tool_result.make_ok
+                            ~tool_name:"tool_execute"
+                            ~start_time:t0
+                            ~data:payload
+                            ())
+                     with
+                     | Ok result -> Keeper_tool_execution.of_tool_result result
+                     | Error _ ->
+                       Keeper_tool_execution.failure
+                         ~effect_disposition:Tool_result.Proven_post_effect
+                         (error_json
+                            ~fields:
+                              ([ "typed", `Bool true
+                               ; "code", `String "execute_result_manifest_failed"
+                               ; "status", status_json
+                               ; "execution_time_ms", `Int elapsed_ms
+                               ]
+                               @ dispatched_model_location_fields)
+                            "Execute completed, but its result manifest could not be persisted."))
+                  else Keeper_tool_execution.failure (Yojson.Safe.to_string payload)))
         )))))
 
 let handle_tool_execute_with_outcome
@@ -685,6 +760,7 @@ let handle_tool_execute_with_outcome
   else
     Keeper_tool_execution.failure
       ~class_:Tool_result.Policy_rejection
+      ~effect_disposition:Tool_result.Proven_pre_effect
       (error_json
          ~fields:[ "typed", `Bool true ]
          "Typed Shell IR input is required. Provide non-empty argv or pipeline.")

--- a/lib/keeper/keeper_tools_agent_core_bundle.ml
+++ b/lib/keeper/keeper_tools_agent_core_bundle.ml
@@ -274,7 +274,49 @@ let make_tool_bundle_for_descriptors
              , Some mark_completed_terminal_externalization_failed )
            | Keeper_tool_descriptor.Ordinary
                (Keeper_tool_descriptor.Serial | Keeper_tool_descriptor.Concurrent) ->
-             None, None, None
+             let on_failed =
+               match descriptor.runtime_handler with
+               | Keeper_tool_descriptor.Tool_execute ->
+                 Some mark_terminal_effect_failed
+               | ( Keeper_tool_descriptor.Tool_search_files
+                 | Keeper_tool_descriptor.Tool_read_file
+                 | Keeper_tool_descriptor.Tool_edit_file
+                 | Keeper_tool_descriptor.Tool_write_file
+                 | Keeper_tool_descriptor.Tool_time_now
+                 | Keeper_tool_descriptor.Tool_tools_list
+                 | Keeper_tool_descriptor.Tool_context_status
+                 | Keeper_tool_descriptor.Tool_artifact_read
+                 | Keeper_tool_descriptor.Tool_memory_search
+                 | Keeper_tool_descriptor.Tool_memory_write
+                 | Keeper_tool_descriptor.Tool_library_search
+                 | Keeper_tool_descriptor.Tool_library_read
+                 | Keeper_tool_descriptor.Tool_surface_read
+                 | Keeper_tool_descriptor.Tool_surface_post
+                 | Keeper_tool_descriptor.Tool_person_note_set
+                 | Keeper_tool_descriptor.Tool_ide_annotate
+                 | Keeper_tool_descriptor.Tool_voice_dispatch
+                 | Keeper_tool_descriptor.Tool_task_dispatch
+                 | Keeper_tool_descriptor.Tool_board_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_task_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_plan_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_run_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_agent_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_workspace_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_misc_dispatch
+                 | Keeper_tool_descriptor.Tool_web_search
+                 | Keeper_tool_descriptor.Tool_web_fetch
+                 | Keeper_tool_descriptor.Tool_masc_control_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_agent_timeline_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_schedule_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_keeper_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_fusion_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_fusion_status
+                 | Keeper_tool_descriptor.Tool_masc_library_dispatch
+                 | Keeper_tool_descriptor.Tool_masc_local_runtime_dispatch
+                 | Keeper_tool_descriptor.Tool_analyze_image ) ->
+                 None
+             in
+             None, on_failed, None
          in
          Keeper_tool_descriptor.keeper_model_names descriptor
          |> List.map (fun model_name ->

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -393,6 +393,13 @@ let blob_aware_output_json (output : string) : Yojson.Safe.t =
   | Tool_output.Not_marker | Tool_output.Invalid_marker _ -> `String output
 ;;
 
+let normalized_artifact_refs_in_typed_data data =
+  Tool_output.normalized_artifact_refs_in_json data
+  |> List.map (fun reference ->
+    Tool_output.with_preview reference ""
+    |> Tool_output.normalized_artifact_ref_to_json)
+;;
+
 let input_to_json (input : Yojson.Safe.t) : Yojson.Safe.t =
   (* Per-leaf marker-aware truncation. Previously
      [String.sub (Yojson.Safe.to_string input) 0 (max - suffix)] chopped
@@ -557,10 +564,16 @@ let log_call
             , Agent_core.Tool_contract.execution_mode_to_yojson value ) ]
         | None -> []
       in
-      let typed_disposition_field =
+      let typed_result_fields =
         match typed_result with
         | Some result ->
+          let artifact_refs =
+            normalized_artifact_refs_in_typed_data (Tool_result.data result)
+          in
           [ "disposition", `String (Tool_result.string_of_disposition result) ]
+          @ (if artifact_refs = []
+             then []
+             else [ "artifact_refs", `List artifact_refs ])
         | None -> []
       in
       let composition_fields =
@@ -688,7 +701,7 @@ let log_call
            @ batch_index_field
            @ batch_size_field
            @ execution_mode_field
-           @ typed_disposition_field
+           @ typed_result_fields
            @ composition_fields
            @ composition_execution_field
            @ trace_id_field

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -189,9 +189,14 @@ val log_call :
     [batch_size], and [execution_mode] preserve Agent Core's actual schedule
     rather than inferring concurrency from timing.
     [typed_result] serializes the producer-owned disposition when it is
-    available. The composition fields are an explicit observation envelope
-    supplied by the typed plan executor; readers must not reconstruct them
-    from [tool_use_id] or tool-name strings.
+    available. Any canonical normalized artifact references in its typed data
+    are also persisted as actual JSON under [artifact_refs], keeping the
+    content-addressed blobs visible to offline maintenance without parsing a
+    JSON-bearing model-output string. Those GC roots deliberately carry an
+    empty preview; model/UI preview projection remains owned by [output]. The
+    composition fields are an explicit observation envelope supplied by the
+    typed plan executor; readers must not reconstruct them from [tool_use_id]
+    or tool-name strings.
     [on_committed], when supplied, forces this row through the synchronous
     append boundary and runs only after that append succeeds. It is intended
     for exact completion notifications whose readers must not race the

--- a/lib/tool_blob_store/tool_blob_maintenance.ml
+++ b/lib/tool_blob_store/tool_blob_maintenance.ml
@@ -1,5 +1,14 @@
 module String_set = Set_util.StringSet
 
+module Artifact_reference_set = Set.Make (struct
+  type t = Tool_output.artifact_ref
+
+  let compare left right =
+    match String.compare left.Tool_output.sha256 right.Tool_output.sha256 with
+    | 0 -> String.compare left.mime right.mime
+    | order -> order
+end)
+
 type mode =
   | Observe_only
   | Delete_previous_candidates
@@ -26,6 +35,14 @@ type error =
   | Malformed_structured_artifact_reference of
       { path : string
       ; line : int
+      ; detail : string
+      }
+  | Artifact_manifest_read_failed of
+      { sha256 : string
+      ; reason : string
+      }
+  | Artifact_manifest_invalid of
+      { sha256 : string
       ; detail : string
       }
   | Candidate_snapshot_invalid of
@@ -74,6 +91,10 @@ let error_to_string = function
       path
       line
       detail
+  | Artifact_manifest_read_failed { sha256; reason } ->
+    Printf.sprintf "artifact manifest read failed sha256=%s: %s" sha256 reason
+  | Artifact_manifest_invalid { sha256; detail } ->
+    Printf.sprintf "artifact manifest invalid sha256=%s: %s" sha256 detail
   | Candidate_snapshot_invalid { path; detail } ->
     Printf.sprintf "blob maintenance candidate snapshot invalid path=%s: %s" path detail
   | Candidate_snapshot_read_failed { path; detail } ->
@@ -120,7 +141,7 @@ let add_references ~path ~line references text =
       Tool_output.encode_for_agent_core (Tool_output.Stored reference)
     in
     if String.equal text canonical
-    then Ok (String_set.add reference.Tool_output.sha256 references)
+    then Ok (Artifact_reference_set.add reference references)
     else
       Error
         (Malformed_artifact_reference
@@ -136,7 +157,7 @@ let rec references_in_json ~path ~line references = function
   | (`Assoc fields as json) ->
     (match Tool_output.normalized_artifact_ref_of_json json with
      | Tool_output.Decoded_normalized_artifact_ref reference ->
-       Ok (String_set.add reference.Tool_output.sha256 references)
+       Ok (Artifact_reference_set.add reference references)
      | Tool_output.Invalid_normalized_artifact_ref { detail } ->
        Error
          (Malformed_structured_artifact_reference
@@ -181,7 +202,7 @@ let references_in_file ~ownership_root path =
       references_in_json
         ~path
         ~line:1
-        String_set.empty
+        Artifact_reference_set.empty
         (Yojson.Safe.from_string payload)
     with
     | Yojson.Json_error _ ->
@@ -217,7 +238,7 @@ let references_in_file ~ownership_root path =
                         line)
               in
               line_number + 1, next)
-           (1, Ok String_set.empty)
+           (1, Ok Artifact_reference_set.empty)
       |> snd
 ;;
 
@@ -361,7 +382,7 @@ let live_references ~base_path =
       | Unix.S_DIR -> scan_directory path references
       | Unix.S_REG ->
         Result.map
-          (String_set.union references)
+          (Artifact_reference_set.union references)
           (references_in_file ~ownership_root:base_path path)
         | Unix.S_LNK ->
           Error
@@ -401,7 +422,62 @@ let live_references ~base_path =
   |> List.fold_left
        (fun result root ->
           Result.bind result (fun progress -> scan_directory root progress))
-       (Ok String_set.empty)
+       (Ok Artifact_reference_set.empty)
+;;
+
+let expand_artifact_manifests ~store references =
+  let rec expand expanded references = function
+    | [] -> Ok references
+    | reference :: rest
+      when not
+             (String.equal
+                reference.Tool_output.mime
+                Tool_output.artifact_manifest_mime) ->
+      expand expanded references rest
+    | reference :: rest
+      when String_set.mem reference.Tool_output.sha256 expanded ->
+      expand expanded references rest
+    | reference :: rest ->
+      let sha256 = reference.Tool_output.sha256 in
+      let expanded = String_set.add sha256 expanded in
+      (match Tool_blob_store.fetch store ~sha256 with
+       | Error error ->
+         Error
+           (Artifact_manifest_read_failed
+              { sha256; reason = Tool_blob_store.fetch_error_to_string error })
+       | Ok None ->
+         Error
+           (Artifact_manifest_read_failed
+              { sha256; reason = "referenced manifest blob is absent" })
+       | Ok (Some payload) ->
+         let decoded =
+           try
+             Yojson.Safe.from_string payload
+             |> Tool_output.artifact_manifest_of_json
+           with
+           | Yojson.Json_error detail ->
+             Tool_output.Invalid_artifact_manifest { detail }
+         in
+         (match decoded with
+          | Tool_output.Decoded_artifact_manifest { artifact_refs; _ } ->
+            let references, added =
+              List.fold_left
+                (fun (references, added) child ->
+                   if Artifact_reference_set.mem child references
+                   then references, added
+                   else Artifact_reference_set.add child references, child :: added)
+                (references, [])
+                artifact_refs
+            in
+            expand expanded references (List.rev_append added rest)
+          | Tool_output.Not_artifact_manifest ->
+            Error
+              (Artifact_manifest_invalid
+                 { sha256; detail = "manifest MIME requires the canonical schema" })
+          | Tool_output.Invalid_artifact_manifest { detail } ->
+            Error (Artifact_manifest_invalid { sha256; detail })))
+  in
+  expand String_set.empty references (Artifact_reference_set.elements references)
 ;;
 
 let candidate_snapshot_to_json candidates =
@@ -532,7 +608,15 @@ let run ~base_path ~mode =
   let open Result.Syntax in
   let* () = reject_uncoordinated_cluster_roots ~base_path in
   let store = Tool_blob_store.create ~base_path in
-  let* live = live_references ~base_path in
+  let* direct_live = live_references ~base_path in
+  let* live_references = expand_artifact_manifests ~store direct_live in
+  let live =
+    Artifact_reference_set.fold
+      (fun reference hashes ->
+         String_set.add reference.Tool_output.sha256 hashes)
+      live_references
+      String_set.empty
+  in
   let* previous_candidates = load_candidate_snapshot ~base_path in
   let* blob_list =
     match Tool_blob_store.list_all_result store with

--- a/lib/tool_blob_store/tool_blob_maintenance.mli
+++ b/lib/tool_blob_store/tool_blob_maintenance.mli
@@ -3,6 +3,9 @@
     Live references are the union of exact {!Tool_output} markers in the
     closed durable-consumer registry: Keeper state/checkpoints, Gate replay,
     tool-call logs, traces, messages, Keeper chat, and bounded wire captures.
+    A marker whose media type is {!Tool_output.artifact_manifest_mime} adds the
+    manifest's strictly decoded normalized children transitively. No other
+    blob content is parsed or treated as an ownership edge.
     Trajectory previews, repository mirrors, build products, operator config,
     and unrelated observational logs are not blob consumers and are never
     traversed. A new durable consumer must be added to this registry in the
@@ -46,6 +49,14 @@ type error =
   | Malformed_structured_artifact_reference of
       { path : string
       ; line : int
+      ; detail : string
+      }
+  | Artifact_manifest_read_failed of
+      { sha256 : string
+      ; reason : string
+      }
+  | Artifact_manifest_invalid of
+      { sha256 : string
       ; detail : string
       }
   | Candidate_snapshot_invalid of

--- a/lib/tool_blob_store/tool_output.ml
+++ b/lib/tool_blob_store/tool_output.ml
@@ -108,6 +108,96 @@ let normalized_artifact_ref_of_json = function
   | _ -> Not_normalized_artifact_ref
 ;;
 
+let collect_normalized_artifact_refs ~reject_invalid json =
+  let add_reference references reference =
+    if
+      List.exists
+        (fun existing ->
+           String.equal existing.sha256 reference.sha256
+           && String.equal existing.mime reference.mime)
+        references
+    then references
+    else reference :: references
+  in
+  let rec collect references = function
+    | (`Assoc fields as json) ->
+      (match normalized_artifact_ref_of_json json with
+       | Decoded_normalized_artifact_ref reference ->
+         Ok (add_reference references reference)
+       | Invalid_normalized_artifact_ref { detail } when reject_invalid ->
+         Error detail
+       | Invalid_normalized_artifact_ref _ | Not_normalized_artifact_ref ->
+         List.fold_left
+           (fun result (_, value) ->
+              Result.bind result (fun references -> collect references value))
+           (Ok references)
+           fields)
+    | `List values ->
+      List.fold_left
+        (fun result value ->
+           Result.bind result (fun references -> collect references value))
+        (Ok references)
+        values
+    | `String _ | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ ->
+      Ok references
+  in
+  Result.map List.rev (collect [] json)
+;;
+
+let normalized_artifact_refs_in_json json =
+  match collect_normalized_artifact_refs ~reject_invalid:false json with
+  | Ok references -> references
+  | Error _ -> []
+;;
+
+let normalized_artifact_refs_in_json_strict json =
+  collect_normalized_artifact_refs ~reject_invalid:true json
+;;
+
+let artifact_manifest_mime = "application/vnd.masc.tool-result-manifest+json"
+let artifact_manifest_schema = "masc.tool-result-artifact-manifest.v1"
+
+let artifact_manifest_to_json ~content ~structured_content =
+  `Assoc
+    [ "schema", `String artifact_manifest_schema
+    ; "content", `String content
+    ; "structured_content", structured_content
+    ]
+;;
+
+type artifact_manifest_decode =
+  | Not_artifact_manifest
+  | Invalid_artifact_manifest of { detail : string }
+  | Decoded_artifact_manifest of
+      { content : string
+      ; structured_content : Yojson.Safe.t
+      ; artifact_refs : artifact_ref list
+      }
+
+let artifact_manifest_of_json = function
+  | `Assoc
+      [ "schema", `String schema
+      ; "content", `String content
+      ; "structured_content", structured_content
+      ]
+    when String.equal schema artifact_manifest_schema ->
+    (match normalized_artifact_refs_in_json_strict structured_content with
+     | Ok artifact_refs ->
+       Decoded_artifact_manifest
+         { content; structured_content; artifact_refs }
+     | Error detail -> Invalid_artifact_manifest { detail })
+  | `Assoc fields when List.mem_assoc "schema" fields ->
+    (match List.assoc_opt "schema" fields with
+     | Some (`String schema) when not (String.equal schema artifact_manifest_schema) ->
+       Not_artifact_manifest
+     | _ ->
+       Invalid_artifact_manifest
+         { detail =
+             "expected exact fields schema, content, and structured_content"
+         })
+  | _ -> Not_artifact_manifest
+;;
+
 type t =
   | Inline of string
   | Stored of artifact_ref

--- a/lib/tool_blob_store/tool_output.mli
+++ b/lib/tool_blob_store/tool_output.mli
@@ -68,6 +68,45 @@ val normalized_artifact_ref_of_json :
     {!normalized_artifact_ref_to_json}. A malformed wrapper is reported
     explicitly so retention code fails closed. *)
 
+val normalized_artifact_refs_in_json : Yojson.Safe.t -> artifact_ref list
+(** Collect every valid normalized reference nested in typed JSON, deduplicated
+    by content address and declared media type in first-occurrence order.
+    Malformed wrappers are not references; authoritative decoders remain
+    responsible for rejecting them. *)
+
+val normalized_artifact_refs_in_json_strict :
+  Yojson.Safe.t -> (artifact_ref list, string) result
+(** As {!normalized_artifact_refs_in_json}, but reject the first malformed
+    reserved [_blob] wrapper. Durable manifest producers and consumers must
+    use this form so they share one closed validity contract. *)
+
+(** {1 Durable result manifests}
+
+    A tool result that itself contains normalized artifact references is
+    stored as one typed manifest blob. The durable transcript owns the
+    manifest through an exact AGENT_CORE marker, while offline maintenance
+    follows only this explicit MIME/schema edge to the referenced child
+    artifacts. Arbitrary JSON blobs are never traversed. *)
+
+val artifact_manifest_mime : string
+
+val artifact_manifest_to_json :
+  content:string -> structured_content:Yojson.Safe.t -> Yojson.Safe.t
+
+type artifact_manifest_decode =
+  | Not_artifact_manifest
+  | Invalid_artifact_manifest of { detail : string }
+  | Decoded_artifact_manifest of
+      { content : string
+      ; structured_content : Yojson.Safe.t
+      ; artifact_refs : artifact_ref list
+      }
+
+val artifact_manifest_of_json : Yojson.Safe.t -> artifact_manifest_decode
+(** Strictly decode the closed manifest envelope. The decoded child set is
+    derived only from [structured_content] using the normalized reference
+    codec above. *)
+
 (** {1 Wire codec} *)
 
 type t =

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -38,6 +38,88 @@ type externalization_error =
   ; message : string
   }
 
+let artifact_manifest_metadata_key = "masc.artifact_manifest"
+
+let metadata_with_artifact_manifest metadata reference =
+  let manifest = Tool_output.normalized_artifact_ref_to_json reference in
+  match metadata with
+  | None -> `Assoc [ artifact_manifest_metadata_key, manifest ]
+  | Some (`Assoc fields) ->
+    `Assoc
+      ((artifact_manifest_metadata_key, manifest)
+       :: List.remove_assoc artifact_manifest_metadata_key fields)
+  | Some payload ->
+    `Assoc
+      [ artifact_manifest_metadata_key, manifest
+      ; "masc.payload", payload
+      ]
+;;
+
+let artifact_manifest_from_metadata metadata =
+  let rec decode = function
+    | `Assoc fields ->
+      (match List.assoc_opt artifact_manifest_metadata_key fields with
+     | Some json ->
+       (match Tool_output.normalized_artifact_ref_of_json json with
+        | Tool_output.Decoded_normalized_artifact_ref reference
+          when String.equal reference.mime Tool_output.artifact_manifest_mime ->
+          Ok reference
+        | Tool_output.Decoded_normalized_artifact_ref _ ->
+          Error "artifact manifest metadata has the wrong media type"
+        | Tool_output.Not_normalized_artifact_ref ->
+          Error "artifact manifest metadata is not a normalized reference"
+        | Tool_output.Invalid_normalized_artifact_ref { detail } -> Error detail)
+     | None ->
+       (match List.assoc_opt "producer" fields with
+        | Some producer -> decode producer
+        | None ->
+          (match List.assoc_opt "masc.payload" fields with
+           | Some payload -> decode payload
+           | None -> Error "typed artifact result is missing its durable manifest")))
+    | `Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _ | `List _ ->
+      Error "typed artifact result is missing its durable manifest"
+  in
+  match metadata with
+  | Some metadata -> decode metadata
+  | None -> Error "typed artifact result is missing its durable manifest"
+;;
+
+let attach_artifact_manifest ~base_path (result : Tool_result.result) =
+  match
+    Tool_output.normalized_artifact_refs_in_json_strict
+      (Tool_result.data result)
+  with
+  | Error message -> Error { kind = Artifact_storage_failure; message }
+  | Ok [] -> Ok result
+  | Ok (_ :: _) ->
+    (try
+       let manifest =
+         Tool_output.artifact_manifest_to_json
+           ~content:(Tool_result.message result)
+           ~structured_content:(Tool_result.data result)
+         |> Yojson.Safe.to_string
+       in
+       let reference =
+         Tool_blob_store.put_durable
+           (Tool_blob_store.create ~base_path)
+           ~bytes:manifest
+           ~mime:Tool_output.artifact_manifest_mime
+         |> fun reference -> Tool_output.with_preview reference ""
+       in
+       Ok
+         (Tool_result.with_metadata
+            (metadata_with_artifact_manifest (Tool_result.metadata result) reference)
+            result)
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       let message = Printexc.to_string exn in
+       Log.Misc.error
+         "tool_bridge: result manifest persistence failed: %s"
+         message;
+       Error { kind = Artifact_storage_failure; message })
+;;
+
 let resolve_blob_store ?base_path () =
   match base_path with
   | None -> None
@@ -167,11 +249,28 @@ let project_result
       ?on_externalization_error
       ~externalization_error_recoverable
       ~model_projection
+      ~structured_content
+      ~metadata
       message
       on_content
   : Agent_core.Types.tool_result
   =
-  match project_content ?base_path ~model_projection message with
+  let project () = project_content ?base_path ~model_projection message in
+  let projected =
+    match Tool_output.normalized_artifact_refs_in_json structured_content with
+    | [] -> project ()
+    | _ :: _ when Option.is_none base_path -> project ()
+    | _ :: _ ->
+      (match Tool_output.normalized_artifact_refs_in_json_strict structured_content with
+       | Error message -> Error { kind = Artifact_storage_failure; message }
+       | Ok [] -> Error { kind = Artifact_storage_failure; message = "typed artifact result lost its normalized references" }
+       | Ok (_ :: _) ->
+         (match artifact_manifest_from_metadata metadata with
+          | Ok reference ->
+            Ok (Tool_output.encode_for_agent_core (Tool_output.Stored reference))
+          | Error message -> Error { kind = Artifact_storage_failure; message }))
+  in
+  match projected with
   | Ok content -> on_content content
   | Error error ->
     Option.iter (fun observe -> observe error) on_externalization_error;
@@ -195,6 +294,8 @@ let to_agent_core_typed_result
       ?on_externalization_error
       ~externalization_error_recoverable
       ~model_projection
+      ~structured_content:(Tool_result.data tr)
+      ~metadata:(Tool_result.metadata tr)
       (Tool_result.message tr)
       (fun content ->
          Ok { Agent_core.Types.content; _meta = output.metadata })
@@ -213,6 +314,8 @@ let to_agent_core_typed_result
       ?on_externalization_error
       ~externalization_error_recoverable
       ~model_projection
+      ~structured_content:(Tool_result.data tr)
+      ~metadata:(Tool_result.metadata tr)
       (Tool_result.message tr)
       (fun content ->
          Ok { Agent_core.Types.content; _meta = Some metadata })
@@ -233,6 +336,8 @@ let to_agent_core_typed_result
       ?on_externalization_error
       ~externalization_error_recoverable
       ~model_projection
+      ~structured_content:(Tool_result.data tr)
+      ~metadata:(Tool_result.metadata tr)
       message
       (fun message ->
        make_tool_error

--- a/lib/tool_bridge.mli
+++ b/lib/tool_bridge.mli
@@ -37,6 +37,15 @@ type externalization_error =
   ; message : string
   }
 
+val attach_artifact_manifest :
+  base_path:string ->
+  Tool_result.result ->
+  (Tool_result.result, externalization_error) result
+(** Persist and attach the canonical manifest for typed result data containing
+    normalized artifact references. Producers call this inside their effect
+    boundary, before returning the authoritative result. Results without
+    artifact references pass through unchanged. Cancellation propagates. *)
+
 val maybe_externalize :
   ?base_path:string ->
   ?mime:string ->
@@ -63,7 +72,14 @@ val to_agent_core_typed_result :
     to AGENT_CORE [recoverable]/[error_class]. [on_externalization_error] lets an
     owning runtime keep its terminal state consistent when storage fails.
     [externalization_error_recoverable] projects the owning tool's existing
-    retry policy; the provider receives only a bounded generic error. *)
+    retry policy; the provider receives only a bounded generic error.
+
+    When typed result data contains normalized artifact references, the
+    producer must first call {!attach_artifact_manifest}; the provider-facing
+    content then becomes that durable manifest's marker. Projection performs
+    no manifest I/O after the producer's effect boundary. This keeps the
+    transcript itself as the authoritative root while preserving the original
+    content and structured data inside the manifest. *)
 
 (** {1 Schema Conversion} *)
 

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -179,6 +179,20 @@ let parse_json raw =
   try Yojson.Safe.from_string raw with
   | Yojson.Json_error err -> fail ("invalid json: " ^ err)
 
+let structured_tool_output_exn ~base_path content =
+  match Tool_output.decode_from_agent_core content with
+  | Tool_output.Not_marker -> parse_json content
+  | Tool_output.Invalid_marker { detail } -> fail detail
+  | Tool_output.Decoded reference ->
+    if not (String.equal reference.mime Tool_output.artifact_manifest_mime)
+    then fail "tool output marker is not a typed result manifest";
+    let payload = fetch_artifact_exn ~base_path reference |> parse_json in
+    (match Tool_output.artifact_manifest_of_json payload with
+     | Tool_output.Decoded_artifact_manifest { structured_content; _ } ->
+       structured_content
+     | Tool_output.Not_artifact_manifest -> fail "typed result manifest is absent"
+     | Tool_output.Invalid_artifact_manifest { detail } -> fail detail)
+
 let outcome_label = function
   | Tool_result.Completed () -> "success"
   | Tool_result.Deferred () -> "deferred"
@@ -4773,6 +4787,67 @@ value = {}
 |}
 ;;
 
+let shell_output_composition =
+  {|[[compositions]]
+name = "shell-output"
+description = "Feed one typed Shell IR result into a later Keeper tool."
+execution = "inline"
+
+[[compositions.nodes]]
+id = "emit"
+tool = "Execute"
+[compositions.nodes.input]
+kind = "literal"
+value = { argv = ["printf", "shell-composition-marker"] }
+
+[[compositions.nodes]]
+id = "search"
+tool = "keeper_memory_search"
+after = ["emit"]
+[compositions.nodes.input]
+kind = "object"
+[[compositions.nodes.input.fields]]
+name = "query"
+[compositions.nodes.input.fields.value]
+kind = "output"
+node = "emit"
+pointer = "/output"
+|}
+;;
+
+let shell_artifact_composition () =
+  let oversized_output =
+    String.make (Masc.Tool_bridge.default_externalize_threshold_bytes + 1) 'x'
+  in
+  Printf.sprintf
+    {|[[compositions]]
+name = "shell-artifact"
+description = "Feed one typed Shell IR artifact identity into a later Keeper tool."
+execution = "inline"
+
+[[compositions.nodes]]
+id = "emit"
+tool = "Execute"
+[compositions.nodes.input]
+kind = "literal"
+value = { argv = ["printf", "%s"] }
+
+[[compositions.nodes]]
+id = "search"
+tool = "keeper_memory_search"
+after = ["emit"]
+[compositions.nodes.input]
+kind = "object"
+[[compositions.nodes.input.fields]]
+name = "query"
+[compositions.nodes.input.fields.value]
+kind = "output"
+node = "emit"
+pointer = "/output_artifact/_blob/sha256"
+|}
+    oversized_output
+;;
+
 let test_composition_catalog_materializes_and_executes_first_class_tool () =
   with_exec_fixture "composition-first-class-tool"
     (fun ~config ~meta ~publication_recovery ~ctx_work ->
@@ -4843,6 +4918,482 @@ let test_composition_catalog_materializes_and_executes_first_class_tool () =
                  (List.mem_assoc "data" fields)
              | _ -> fail "nested action result lost typed result shape")
           | _ -> fail "composition did not expose its single settled action"))
+;;
+
+let test_composition_feeds_typed_shell_ir_output_to_later_tool () =
+  with_exec_fixture
+    ~process:true
+    ~always_allow:true
+    "composition-shell-ir-output"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       let composition_catalog =
+         match Masc.Keeper_tool_composition_catalog.parse shell_output_composition with
+         | Ok catalog -> catalog
+         | Error error ->
+           fail (Masc.Keeper_tool_composition_catalog.error_to_string error)
+       in
+       let tools =
+         Masc.Keeper_tools_agent_core_bundle.make_tools
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot:ctx_work
+           ~composition_catalog
+           ()
+       in
+       let tool =
+         match find_tool_by_name tools "keeper_compose_shell-output" with
+         | Some tool -> tool
+         | None -> fail "Shell IR composition was not materialized"
+       in
+       match
+         Agent_core.Tool.execute
+           ~invocation:
+             (composition_invocation
+                ~completion:Agent_core.Tool_contract.Continue_after_success)
+           tool
+           (`Assoc [])
+       with
+       | Error error -> fail error.Agent_core.Types.message
+       | Ok output ->
+         let payload = parse_json output.content in
+         (match Yojson.Safe.Util.member "actions" payload with
+          | `List [ emit; search ] ->
+            check string
+              "Shell IR node"
+              "Execute"
+              Yojson.Safe.Util.(member "tool_name" emit |> to_string);
+            check bool
+              "Shell IR typed result"
+              true
+              Yojson.Safe.Util.
+                (member "result" emit |> member "data" |> member "typed" |> to_bool);
+            check string
+              "Shell IR exact output"
+              "shell-composition-marker"
+              Yojson.Safe.Util.
+                (member "result" emit |> member "data" |> member "output" |> to_string);
+            check string
+              "later node receives typed Shell IR output"
+              "shell-composition-marker"
+              Yojson.Safe.Util.(member "input" search |> member "query" |> to_string)
+          | _ -> fail "Shell IR composition did not settle both nodes in planned order"))
+;;
+
+let test_composition_externalizes_oversized_shell_ir_output () =
+  with_exec_fixture
+    ~process:true
+    ~always_allow:true
+    "composition-shell-ir-artifact"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       Masc.Keeper_tool_call_log.reset_for_testing ();
+       Masc.Keeper_tool_call_log.init ~base_path:config.base_path ();
+       let turn_ctx_cell = Masc.Keeper_tool_call_log.create_turn_ctx_cell () in
+       let composition_catalog =
+         match
+           Masc.Keeper_tool_composition_catalog.parse
+             (shell_artifact_composition ())
+         with
+         | Ok catalog -> catalog
+         | Error error ->
+           fail (Masc.Keeper_tool_composition_catalog.error_to_string error)
+       in
+       let tools =
+         Masc.Keeper_tools_agent_core_bundle.make_tools
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot:ctx_work
+           ~composition_catalog
+           ~turn_ctx_cell
+           ()
+       in
+       let tool =
+         match find_tool_by_name tools "keeper_compose_shell-artifact" with
+         | Some tool -> tool
+         | None -> fail "Shell IR artifact composition was not materialized"
+       in
+       match
+         Agent_core.Tool.execute
+           ~invocation:
+             (composition_invocation
+                ~completion:Agent_core.Tool_contract.Continue_after_success)
+           tool
+           (`Assoc [])
+       with
+       | Error error -> fail error.Agent_core.Types.message
+       | Ok output ->
+         let payload =
+           structured_tool_output_exn
+             ~base_path:config.base_path
+             output.content
+         in
+         (match Yojson.Safe.Util.member "actions" payload with
+          | `List [ emit; search ] ->
+            let data = Yojson.Safe.Util.(member "result" emit |> member "data") in
+            check
+              bool
+              "oversized output is not retained inline"
+              true
+              (Yojson.Safe.Util.member "output" data = `Null);
+            let artifact_ref field =
+              match
+                Yojson.Safe.Util.member field data
+                |> Tool_output.normalized_artifact_ref_of_json
+              with
+              | Tool_output.Decoded_normalized_artifact_ref reference -> reference
+              | Tool_output.Not_normalized_artifact_ref ->
+                failf
+                  "oversized Shell IR output has no normalized %s reference"
+                  field
+              | Tool_output.Invalid_normalized_artifact_ref { detail } -> fail detail
+            in
+            let output_ref = artifact_ref "output_artifact" in
+            let stdout_ref = artifact_ref "stdout_artifact" in
+            let stderr_ref = artifact_ref "stderr_artifact" in
+            check string "combined output equals stdout" output_ref.sha256 stdout_ref.sha256;
+            check int "empty stderr is still explicit" 0 stderr_ref.bytes;
+            let artifact =
+              fetch_artifact_exn ~base_path:config.base_path output_ref
+            in
+            check
+              int
+              "artifact retains every output byte"
+              (Masc.Tool_bridge.default_externalize_threshold_bytes + 1)
+              (String.length artifact);
+            let durable_root_present =
+              Masc.Keeper_tool_call_log.read_recent
+                ~keeper_name:meta.name
+                ~n:10
+                ()
+              |> List.exists (fun row ->
+                Safe_ops.json_string_opt "composition_node_id" row = Some "emit"
+                &&
+                match Yojson.Safe.Util.member "artifact_refs" row with
+                | `List roots ->
+                  List.exists
+                    (fun root ->
+                       let blob = Yojson.Safe.Util.member "_blob" root in
+                       Safe_ops.json_string_opt "sha256" blob
+                       = Some output_ref.sha256
+                       && Safe_ops.json_string_opt "preview" blob = Some "")
+                    roots
+                | _ -> false)
+            in
+            check
+              bool
+              "durable action log owns a preview-free artifact root"
+              true
+              durable_root_present;
+            let maintenance mode =
+              match
+                Tool_blob_maintenance.run ~base_path:config.base_path ~mode
+              with
+              | Ok report -> report
+              | Error error ->
+                fail (Tool_blob_maintenance.error_to_string error)
+            in
+            let observed = maintenance Tool_blob_maintenance.Observe_only in
+            check
+              bool
+              "durable action evidence roots the stream artifacts"
+              true
+              (observed.live_references >= 2);
+            ignore
+              (maintenance Tool_blob_maintenance.Delete_previous_candidates);
+            check
+              string
+              "maintenance preserves the referenced output"
+              artifact
+              (fetch_artifact_exn ~base_path:config.base_path output_ref);
+            check
+              string
+              "later node receives the artifact identity"
+              output_ref.sha256
+              Yojson.Safe.Util.(member "input" search |> member "query" |> to_string)
+          | _ ->
+            fail
+              "Shell IR artifact composition did not settle both nodes in planned order"))
+;;
+
+let test_direct_execute_artifact_manifest_survives_maintenance () =
+  with_exec_fixture
+    ~process:true
+    ~always_allow:true
+    "direct-shell-ir-artifact"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       let execute =
+         Masc.Keeper_tools_agent_core_bundle.make_tools
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot:ctx_work
+           ()
+         |> List.find_opt (fun (tool : Agent_core.Tool.t) ->
+           String.equal tool.schema.name "Execute")
+         |> function
+         | Some tool -> tool
+         | None -> fail "direct Execute tool is absent"
+       in
+       let oversized =
+         String.make (Masc.Tool_bridge.default_externalize_threshold_bytes + 1) 'd'
+       in
+       let output =
+         match
+           Agent_core.Tool.execute
+             ~invocation:
+               (composition_invocation
+                  ~completion:Agent_core.Tool_contract.Continue_after_success)
+             execute
+             (`Assoc [ "argv", `List [ `String "printf"; `String oversized ] ])
+         with
+         | Ok output -> output.Agent_core.Types.content
+         | Error error -> fail error.Agent_core.Types.message
+       in
+       let manifest_ref =
+         match Tool_output.decode_from_agent_core output with
+         | Tool_output.Decoded reference
+           when String.equal reference.mime Tool_output.artifact_manifest_mime ->
+           reference
+         | Tool_output.Decoded _ -> fail "direct Execute returned a non-manifest marker"
+         | Tool_output.Not_marker -> fail "direct Execute artifact result stayed inline"
+         | Tool_output.Invalid_marker { detail } -> fail detail
+       in
+       let durable_checkpoint =
+         Filename.concat
+           (Common.masc_dir_from_base_path ~base_path:config.base_path)
+           "keepers/direct-execute/checkpoint.json"
+       in
+       Fs_compat.mkdir_p (Filename.dirname durable_checkpoint);
+       Fs_compat.save_file
+         durable_checkpoint
+         (Yojson.Safe.to_string (`Assoc [ "tool_result", `String output ]));
+       let structured =
+         structured_tool_output_exn ~base_path:config.base_path output
+       in
+       let output_ref =
+         Yojson.Safe.Util.member "output_artifact" structured
+         |> Tool_output.normalized_artifact_ref_of_json
+         |> function
+         | Tool_output.Decoded_normalized_artifact_ref reference -> reference
+         | Tool_output.Not_normalized_artifact_ref ->
+           fail "direct Execute manifest lost its child output reference"
+         | Tool_output.Invalid_normalized_artifact_ref { detail } -> fail detail
+       in
+       let maintenance mode =
+         match Tool_blob_maintenance.run ~base_path:config.base_path ~mode with
+         | Ok report -> report
+         | Error error -> fail (Tool_blob_maintenance.error_to_string error)
+       in
+       let observed = maintenance Tool_blob_maintenance.Observe_only in
+       check bool
+         "direct checkpoint roots manifest and child streams"
+         true
+         (observed.live_references >= 3);
+       ignore (maintenance Tool_blob_maintenance.Delete_previous_candidates);
+       check string
+         "direct Execute child survives both maintenance passes"
+         oversized
+         (fetch_artifact_exn ~base_path:config.base_path output_ref);
+       check bool
+         "manifest itself survives both maintenance passes"
+         true
+         (match
+            Tool_blob_store.fetch
+              (Tool_blob_store.create ~base_path:config.base_path)
+              ~sha256:manifest_ref.sha256
+          with
+          | Ok (Some _) -> true
+          | Ok None | Error _ -> false))
+;;
+
+let test_direct_execute_post_effect_artifact_failure_closes_official_client_loop () =
+  with_exec_fixture
+    ~process:true
+    ~always_allow:true
+    "direct-shell-ir-post-effect-artifact-failure"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       let bundle =
+         Masc.Keeper_tools_agent_core_bundle.make_tool_bundle
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot:ctx_work
+           ()
+       in
+       Fun.protect
+         ~finally:bundle.cleanup
+         (fun () ->
+            let blob_root =
+              Tool_blob_store.create ~base_path:config.base_path
+              |> Tool_blob_store.root_dir
+            in
+            Fs_compat.mkdir_p (Filename.dirname blob_root);
+            Fs_compat.save_file blob_root "artifact persistence is blocked";
+            let marker = Filename.concat config.base_path "execute-invocations" in
+            let oversized =
+              String.make
+                (Masc.Tool_bridge.default_externalize_threshold_bytes + 1)
+                'p'
+            in
+            let terminal_error = ref None in
+            let projected =
+              match
+                Masc.Keeper_official_client_host.dynamic_tools
+                  ~runtime_label:"test-official-client"
+                  ~keeper_name:meta.name
+                  ~turn_count:1
+                  ~tools:bundle.tools
+                  ~hooks:Agent_core.Hooks.empty
+                  ~event_bus:None
+                  ~context_injector:None
+                  ~context:(Some (Agent_core.Context.create_sync ()))
+                  ~terminal_effect_state:bundle.terminal_effect_state
+                  ~terminal_error
+                  ~raw_trace_run:None
+              with
+              | Ok tools -> tools
+              | Error error -> fail (Agent_core.Error.to_string error)
+            in
+            let execute =
+              projected
+              |> List.find_opt
+                   (fun (tool : Masc.Keeper_official_client_host.dynamic_tool) ->
+                      String.equal tool.name "Execute")
+              |> function
+              | Some tool -> tool
+              | None -> fail "direct Execute tool was not projected"
+            in
+            let result =
+              execute.call
+                ~call_id:"direct-execute-post-effect-failure"
+                (`Assoc
+                   [ ( "argv"
+                     , `List
+                         [ `String "/bin/sh"
+                         ; `String "-c"
+                         ; `String "printf x >> \"$1\"; printf %s \"$2\""
+                         ; `String "keeper-execute-test"
+                         ; `String marker
+                         ; `String oversized
+                         ] )
+                   ])
+            in
+            check bool "artifact persistence failure is visible" false result.success;
+            check string
+              "the process effect occurs exactly once before settlement"
+              "x"
+              (read_file marker);
+            (match bundle.terminal_effect_state () with
+             | Masc.Keeper_tools_agent_core.Terminal_effect_failed
+                 { effect_disposition = Tool_result.Proven_post_effect; _ } ->
+               ()
+             | _ -> fail "ordinary Execute post-effect failure left bundle open");
+            match result.abort_turn with
+            | Some
+                (Masc.Keeper_official_client_host.Terminal_tool_boundary
+                  { tool_name = "Execute"
+                  ; outcome =
+                      Masc.Keeper_official_client_host.Terminal_failed
+                        { effect_disposition = Tool_result.Proven_post_effect; _ }
+                  }) ->
+              ()
+            | Some
+                (Masc.Keeper_official_client_host.Terminal_tool_boundary _)
+            | Some (Masc.Keeper_official_client_host.Repeated_tool_call _)
+            | None ->
+              fail "direct Execute post-effect failure remained provider-retryable"))
+;;
+
+let test_direct_pre_effect_and_readonly_failures_remain_correction_capable () =
+  with_exec_fixture
+    ~process:true
+    ~always_allow:true
+    "direct-pre-effect-correction"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       let bundle =
+         Masc.Keeper_tools_agent_core_bundle.make_tool_bundle
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot:ctx_work
+           ()
+       in
+       Fun.protect
+         ~finally:bundle.cleanup
+         (fun () ->
+            let terminal_error = ref None in
+            let projected =
+              match
+                Masc.Keeper_official_client_host.dynamic_tools
+                  ~runtime_label:"test-official-client"
+                  ~keeper_name:meta.name
+                  ~turn_count:1
+                  ~tools:bundle.tools
+                  ~hooks:Agent_core.Hooks.empty
+                  ~event_bus:None
+                  ~context_injector:None
+                  ~context:(Some (Agent_core.Context.create_sync ()))
+                  ~terminal_effect_state:bundle.terminal_effect_state
+                  ~terminal_error
+                  ~raw_trace_run:None
+              with
+              | Ok tools -> tools
+              | Error error -> fail (Agent_core.Error.to_string error)
+            in
+            let call name input =
+              let tool =
+                projected
+                |> List.find_opt
+                     (fun (tool : Masc.Keeper_official_client_host.dynamic_tool) ->
+                        String.equal tool.name name)
+                |> function
+                | Some tool -> tool
+                | None -> failf "%s was not projected" name
+              in
+              tool.call ~call_id:("correction-" ^ name) input
+            in
+            let invalid_execute =
+              call "Execute" (`Assoc [ "argv", `List [ `String "" ] ])
+            in
+            check bool "invalid Execute is a failure" false invalid_execute.success;
+            check
+              (option string)
+              "pre-effect Execute failure keeps the turn open"
+              None
+              (Option.map
+                 (fun _ -> "abort")
+                 invalid_execute.abort_turn);
+            let invalid_write =
+              call
+                "Write"
+                (`Assoc
+                   [ "file_path", `String ""
+                   ; "content", `String "must not be written"
+                   ])
+            in
+            check bool "invalid Write is a failure" false invalid_write.success;
+            check
+              (option string)
+              "unaudited ordinary producer keeps its prior correction behavior"
+              None
+              (Option.map (fun _ -> "abort") invalid_write.abort_turn);
+            let missing_artifact =
+              call
+                "keeper_artifact_read"
+                (`Assoc [ "sha256", `String (String.make 64 '0') ])
+            in
+            check bool "missing artifact is a failure" false missing_artifact.success;
+            check
+              (option string)
+              "read-only failure keeps the turn open"
+              None
+              (Option.map
+                 (fun _ -> "abort")
+                 missing_artifact.abort_turn);
+            match bundle.terminal_effect_state () with
+            | Masc.Keeper_tools_agent_core.Terminal_effect_open -> ()
+            | _ -> fail "correction-capable failures poisoned terminal state"))
 ;;
 
 let test_composition_action_commit_advances_revision_before_refresh_event () =
@@ -5784,6 +6335,16 @@ let () =
         test_composition_runtime_uses_canonical_descriptor;
       test_case "catalog composition is a first-class executable tool" `Quick
         test_composition_catalog_materializes_and_executes_first_class_tool;
+      test_case "composition feeds typed Shell IR output to later tool" `Quick
+        test_composition_feeds_typed_shell_ir_output_to_later_tool;
+      test_case "composition externalizes oversized Shell IR output" `Quick
+        test_composition_externalizes_oversized_shell_ir_output;
+      test_case "direct Execute artifact manifest survives maintenance" `Quick
+        test_direct_execute_artifact_manifest_survives_maintenance;
+      test_case "direct Execute artifact failure closes official-client loop" `Quick
+        test_direct_execute_post_effect_artifact_failure_closes_official_client_loop;
+      test_case "direct pre-effect and read-only failures remain correction-capable" `Quick
+        test_direct_pre_effect_and_readonly_failures_remain_correction_capable;
       test_case "composition action commit refreshes dashboard evidence" `Quick
         test_composition_action_commit_advances_revision_before_refresh_event;
       test_case "composition telemetry outage preserves execution" `Quick

--- a/test/test_keeper_tool_emission_hook.ml
+++ b/test/test_keeper_tool_emission_hook.ml
@@ -1,5 +1,6 @@
-(* Keeper tool-emission capture accepts only producer-owned typed objects.
-   JSON-looking text from the model-facing AGENT_CORE body is never reparsed. *)
+(* Keeper tool-emission capture retains only explicitly tagged,
+   producer-owned typed objects. JSON-looking text from the model-facing
+   AGENT_CORE body is never reparsed. *)
 
 module H = Masc.Keeper_tool_emission_hook
 
@@ -66,10 +67,11 @@ let test_snapshot_does_not_drain () =
   assert_size "snapshot preserves" 1 acc
 ;;
 
-let test_drain_skips_unmarked_object () =
+let test_capture_does_not_retain_unmarked_object () =
   let acc = H.create_accumulator () in
   H.capture_typed_result acc (tagged ~kind:"doc" ~id:"doc-2" []);
   H.capture_typed_result acc (`Assoc [ "echo", `String "hello" ]);
+  assert_size "only tagged object retained" 1 acc;
   let context = H.drain_into_working_context acc ~working_context:None in
   let artifacts, _ =
     match Multimodal.Wirein_helpers.extract_raw_artifacts context with
@@ -122,9 +124,9 @@ let () =
         ; Alcotest.test_case "drain empties" `Quick test_drain_empties_accumulator
         ; Alcotest.test_case "snapshot preserves" `Quick test_snapshot_does_not_drain
         ; Alcotest.test_case
-            "unmarked object not emitted"
+            "unmarked object not retained"
             `Quick
-            test_drain_skips_unmarked_object
+            test_capture_does_not_retain_unmarked_object
         ] )
     ; ( "keeper registry"
       , [ Alcotest.test_case "isolates keepers" `Quick test_registry_isolates_keepers

--- a/test/test_tool_blob_store.ml
+++ b/test/test_tool_blob_store.ml
@@ -744,6 +744,95 @@ let test_maintenance_keeps_normalized_tool_call_blob_reference () =
         (Some "normalized tool-call output")
         (fetch_ok store ~sha256:reference.sha256))
 
+let test_maintenance_follows_typed_result_manifest () =
+  with_temp_dir (fun base_path ->
+      let store = B.create ~base_path in
+      let child =
+        B.put_durable store ~bytes:"manifest-owned child" ~mime:"text/plain"
+      in
+      let structured_content =
+        `Assoc [ "output_artifact", O.normalized_artifact_ref_to_json child ]
+      in
+      let manifest_payload =
+        O.artifact_manifest_to_json
+          ~content:(Yojson.Safe.to_string structured_content)
+          ~structured_content
+        |> Yojson.Safe.to_string
+      in
+      let manifest =
+        B.put_durable
+          store
+          ~bytes:manifest_payload
+          ~mime:O.artifact_manifest_mime
+      in
+      let checkpoint =
+        Filename.concat
+          (Common.masc_dir_from_base_path ~base_path)
+          "keepers/keeper-a/checkpoint.json"
+      in
+      Fs_compat.mkdir_p (Filename.dirname checkpoint);
+      Fs_compat.save_file
+        checkpoint
+        (Yojson.Safe.to_string
+           (`Assoc
+             [ ( "tool_result"
+               , `String (O.encode_for_agent_core (O.Stored manifest)) ) ]));
+      let observed = maintenance_ok ~base_path ~mode:M.Observe_only in
+      Alcotest.(check int)
+        "checkpoint marker roots manifest and child"
+        2
+        observed.live_references;
+      Alcotest.(check int) "manifest graph has no candidates" 0 observed.candidates_recorded;
+      let swept =
+        maintenance_ok ~base_path ~mode:M.Delete_previous_candidates
+      in
+      Alcotest.(check int) "manifest graph survives the second pass" 0 swept.deleted;
+      Alcotest.(check (option string))
+        "manifest-owned child remains readable"
+        (Some "manifest-owned child")
+        (fetch_ok store ~sha256:child.sha256))
+
+let test_maintenance_rejects_malformed_typed_result_manifest () =
+  with_temp_dir (fun base_path ->
+      let store = B.create ~base_path in
+      let survivor =
+        B.put_durable store ~bytes:"survive malformed manifest" ~mime:"text/plain"
+      in
+      let malformed =
+        O.artifact_manifest_to_json
+          ~content:"malformed"
+          ~structured_content:
+            (`Assoc
+               [ ( "output_artifact"
+                 , `Assoc [ "_blob", `Assoc [ "sha256", `String survivor.sha256 ] ]
+                 )
+               ])
+        |> Yojson.Safe.to_string
+      in
+      let manifest =
+        B.put_durable store ~bytes:malformed ~mime:O.artifact_manifest_mime
+      in
+      let checkpoint =
+        Filename.concat
+          (Common.masc_dir_from_base_path ~base_path)
+          "keepers/keeper-a/checkpoint.json"
+      in
+      Fs_compat.mkdir_p (Filename.dirname checkpoint);
+      Fs_compat.save_file
+        checkpoint
+        (Yojson.Safe.to_string
+           (`String (O.encode_for_agent_core (O.Stored manifest))));
+      (match M.run ~base_path ~mode:M.Delete_previous_candidates with
+       | Error (M.Artifact_manifest_invalid { sha256; _ }) ->
+         Alcotest.(check string) "exact malformed manifest" manifest.sha256 sha256
+       | Error error ->
+         Alcotest.failf "unexpected maintenance error: %s" (M.error_to_string error)
+       | Ok _ -> Alcotest.fail "malformed typed manifest reached deletion");
+      Alcotest.(check (option string))
+        "malformed manifest abort preserves unrelated blobs"
+        (Some "survive malformed manifest")
+        (fetch_ok store ~sha256:survivor.sha256))
+
 let test_maintenance_malformed_normalized_blob_fails_closed () =
   with_temp_dir (fun base_path ->
       let store = B.create ~base_path in
@@ -1150,6 +1239,14 @@ let () =
             "maintenance keeps normalized tool-call blob reference"
             `Quick
             test_maintenance_keeps_normalized_tool_call_blob_reference;
+          Alcotest.test_case
+            "maintenance follows typed result manifest"
+            `Quick
+            test_maintenance_follows_typed_result_manifest;
+          Alcotest.test_case
+            "maintenance rejects malformed typed result manifest"
+            `Quick
+            test_maintenance_rejects_malformed_typed_result_manifest;
           Alcotest.test_case
             "maintenance malformed normalized blob fails closed"
             `Quick

--- a/test/test_tool_bridge_externalize.ml
+++ b/test/test_tool_bridge_externalize.ml
@@ -83,6 +83,101 @@ let test_incident_sized_result_stays_inline () =
       Alcotest.(check bool) "no blob marker" false (O.is_marker content)
     | Error _ -> Alcotest.fail "expected inline result")
 
+let test_typed_artifact_result_becomes_durable_manifest () =
+  with_temp_base_path (fun base_path ->
+    let store = Tool_blob_store.create ~base_path in
+    let child =
+      Tool_blob_store.put_durable
+        store
+        ~bytes:"exact child output"
+        ~mime:"text/plain"
+    in
+    let structured_content =
+      `Assoc
+        [ "ok", `Bool true
+        ; "output_artifact", O.normalized_artifact_ref_to_json child
+        ]
+    in
+    let result =
+      Tool_result.make_ok
+        ~tool_name:"Execute"
+        ~start_time:0.0
+        ~data:structured_content
+        ()
+      |> B.attach_artifact_manifest ~base_path
+    in
+    let result =
+      match result with
+      | Ok result -> result
+      | Error { message; _ } -> Alcotest.fail message
+    in
+    (match B.to_agent_core_typed_result result with
+     | Ok { content; _ } ->
+       Alcotest.(check bool)
+         "manifest marker requires artifact-reader capability"
+         false
+         (O.is_marker content)
+     | Error { message; _ } -> Alcotest.fail message);
+    match B.to_agent_core_typed_result ~base_path result with
+    | Error { message; _ } -> Alcotest.fail message
+    | Ok { content; _ } ->
+      (match O.decode_from_agent_core content with
+       | O.Not_marker -> Alcotest.fail "typed artifact result stayed unrooted inline"
+       | O.Invalid_marker { detail } -> Alcotest.fail detail
+       | O.Decoded manifest_ref ->
+         Alcotest.(check string)
+           "typed manifest media type"
+           O.artifact_manifest_mime
+           manifest_ref.mime;
+         let manifest =
+           match Tool_blob_store.fetch store ~sha256:manifest_ref.sha256 with
+           | Ok (Some payload) -> Yojson.Safe.from_string payload
+           | Ok None -> Alcotest.fail "manifest blob is absent"
+           | Error error ->
+             Alcotest.fail (Tool_blob_store.fetch_error_to_string error)
+         in
+         (match O.artifact_manifest_of_json manifest with
+          | O.Decoded_artifact_manifest
+              { structured_content = restored; artifact_refs; _ } ->
+            Alcotest.(check bool)
+              "structured result is exact"
+              true
+              (Yojson.Safe.equal structured_content restored);
+            Alcotest.(check int) "one child ownership edge" 1 (List.length artifact_refs);
+            Alcotest.(check string)
+              "child identity is exact"
+              child.sha256
+              (List.hd artifact_refs).sha256
+          | O.Not_artifact_manifest -> Alcotest.fail "manifest schema is absent"
+          | O.Invalid_artifact_manifest { detail } -> Alcotest.fail detail)))
+
+let test_manifest_producer_rejects_mixed_malformed_reference () =
+  with_temp_base_path (fun base_path ->
+    let child =
+      Tool_blob_store.put_durable
+        (Tool_blob_store.create ~base_path)
+        ~bytes:"valid child"
+        ~mime:"text/plain"
+    in
+    let result =
+      Tool_result.make_ok
+        ~tool_name:"Execute"
+        ~start_time:0.0
+        ~data:
+          (`Assoc
+             [ "valid", O.normalized_artifact_ref_to_json child
+             ; "malformed", `Assoc [ "_blob", `Assoc [ "sha256", `String child.sha256 ] ]
+             ])
+        ()
+    in
+    match B.attach_artifact_manifest ~base_path result with
+    | Ok _ -> Alcotest.fail "mixed malformed artifact data produced a manifest"
+    | Error { message; _ } ->
+      Alcotest.(check bool)
+        "strict producer reports malformed reserved wrapper"
+        true
+        (String.length message > 0))
+
 let test_bounded_inline_rejects_oversized_result () =
   let payload = String.make (B.default_externalize_threshold_bytes + 1) 'x' in
   match
@@ -412,6 +507,10 @@ let () =
           Alcotest.test_case "small inlined" `Quick test_to_agent_core_typed_small_inlined;
           Alcotest.test_case "2.5KB result stays inline" `Quick
             test_incident_sized_result_stays_inline;
+          Alcotest.test_case "typed artifact result owns durable manifest" `Quick
+            test_typed_artifact_result_becomes_durable_manifest;
+          Alcotest.test_case "manifest producer rejects malformed child" `Quick
+            test_manifest_producer_rejects_mixed_malformed_reference;
           Alcotest.test_case "bounded inline rejects oversize" `Quick
             test_bounded_inline_rejects_oversized_result;
           Alcotest.test_case "artifact reader owns inline projection" `Quick


### PR DESCRIPTION
## Summary

- expose successful typed Shell IR output as composable JSON, with normalized durable artifact references for oversized streams
- persist a closed typed result manifest so checkpoints and maintenance retain the complete artifact graph without parsing JSON-bearing strings
- preserve producer-owned effect disposition through direct Execute failures and close the official-client loop only for the audited Execute handler
- add production-path regressions for inline composition, oversized composition, direct checkpoint retention, manifest graph maintenance, emission filtering, and pre/post-effect settlement

## Stack

- stacked on #28685 (`feat/keeper-persistence-duration-tiers`)
- Draft and do-not-merge until the stack lands and CI is green

## Verification

- `ocamlformat --check` on every changed OCaml interface/source
- `git diff --check`
- two independent adversarial source reviews: no remaining BLOCKING/HIGH findings
- exact restack range-diff `=`; stable patch-id preserved
- no local build or test run, per repository workflow; CI only