### PR TITLE
fix(keeper): preserve irreducible compaction identity

### DIFF
--- a/lib/keeper/keeper_compact_policy.mli
+++ b/lib/keeper/keeper_compact_policy.mli
@@ -16,6 +16,7 @@ type compaction_rejection =
   | Invalid_compaction_plan
   | Invalid_structure of Keeper_compaction_unit.structural_error
   | No_eligible_history
+  | No_reducible_boundary
   | Invalid_structural_evidence of
       Keeper_compaction_evidence.decode_error
       * Keeper_compaction_outcome.exact_execution_terminal

--- a/lib/keeper/keeper_compact_rejection.ml
+++ b/lib/keeper/keeper_compact_rejection.ml
@@ -11,6 +11,7 @@ type compaction_rejection =
   | Invalid_compaction_plan
   | Invalid_structure of Keeper_compaction_unit.structural_error
   | No_eligible_history
+  | No_reducible_boundary
   | Invalid_structural_evidence of
       Keeper_compaction_evidence.decode_error
       * Keeper_compaction_outcome.exact_execution_terminal
@@ -30,6 +31,7 @@ let compaction_rejection_to_tag = function
   | Invalid_structure error ->
     "invalid_structure:" ^ Keeper_compaction_unit.show_structural_error error
   | No_eligible_history -> "no_eligible_history"
+  | No_reducible_boundary -> "no_reducible_boundary"
   | Invalid_structural_evidence _ -> "invalid_structural_evidence"
 ;;
 
@@ -63,6 +65,6 @@ let summarization_rejection = function
   | Keeper_compaction_llm_summarizer.Exact_execution_terminal terminal ->
     Exact_execution_terminal terminal
   | Keeper_compaction_llm_summarizer.No_reducible_boundary ->
-    No_eligible_history
+    No_reducible_boundary
   | Keeper_compaction_llm_summarizer.Invalid_plan -> Invalid_compaction_plan
 ;;

--- a/lib/keeper/keeper_compact_rejection.mli
+++ b/lib/keeper/keeper_compact_rejection.mli
@@ -11,6 +11,7 @@ type compaction_rejection =
   | Invalid_compaction_plan
   | Invalid_structure of Keeper_compaction_unit.structural_error
   | No_eligible_history
+  | No_reducible_boundary
   | Invalid_structural_evidence of
       Keeper_compaction_evidence.decode_error
       * Keeper_compaction_outcome.exact_execution_terminal

--- a/lib/keeper/keeper_compaction_outcome.ml
+++ b/lib/keeper/keeper_compaction_outcome.ml
@@ -22,6 +22,7 @@ type exact_execution_terminal =
 
 type no_compaction_reason =
   | No_eligible_history
+  | No_reducible_boundary
   | Invalid_structural_source
   | Exact_lane_unconfigured
   | Exact_execution_terminal of exact_execution_terminal
@@ -62,6 +63,7 @@ let exact_execution_terminal_to_string terminal =
 
 let no_compaction_reason_label = function
   | No_eligible_history -> "no_eligible_history"
+  | No_reducible_boundary -> "no_reducible_boundary"
   | Invalid_structural_source -> "invalid_structural_source"
   | Exact_lane_unconfigured -> "exact_lane_unconfigured"
   | Exact_execution_terminal terminal ->

--- a/lib/keeper/keeper_compaction_outcome.mli
+++ b/lib/keeper/keeper_compaction_outcome.mli
@@ -33,6 +33,7 @@ type exact_execution_terminal =
 
 type no_compaction_reason =
   | No_eligible_history
+  | No_reducible_boundary
   | Invalid_structural_source
   | Exact_lane_unconfigured
       (** The configured runtime has no exact-output lane for compaction. This

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -355,6 +355,8 @@ type rejection_disposition =
 let rejection_disposition = function
   | Keeper_compact_policy.No_eligible_history ->
     Terminal_no_compaction Keeper_compaction_outcome.No_eligible_history
+  | No_reducible_boundary ->
+    Terminal_no_compaction Keeper_compaction_outcome.No_reducible_boundary
   | Invalid_structure _ ->
     Terminal_no_compaction Keeper_compaction_outcome.Invalid_structural_source
   | Exact_execution_terminal terminal ->

--- a/test/test_compaction_exact_output_conformance.ml
+++ b/test/test_compaction_exact_output_conformance.ml
@@ -207,11 +207,44 @@ let test_missing_compaction_lane_is_explicit_degraded_state () =
       ~keeper_name
       ~registry
       ~lane_id:"compaction_exact"
-      ~units
+      ~units:
+        [ U.Ordinary_message
+            (message T.Assistant "one valid but irreducible source")
+        ]
   with
   | Error C.Exact_lane_unconfigured -> ()
+  | Error C.No_reducible_boundary ->
+    Alcotest.fail "lane resolution must precede irreducible-window classification"
   | Error _ -> Alcotest.fail "missing lane returned the wrong typed failure"
   | Ok _ -> Alcotest.fail "missing lane must not be synthesized"
+;;
+
+let test_irreducible_window_is_a_distinct_terminal_noop () =
+  let slot_id = "irreducible-window-slot" in
+  let snapshot =
+    F.resolver_snapshot
+      ~source:"irreducible compaction window"
+      [ { id = slot_id; base_url = "http://127.0.0.1:9" } ]
+  in
+  let registry = publish_exn ~slot_ids:[ slot_id ] snapshot in
+  let keeper_name = "keeper-irreducible-window" in
+  let source_units =
+    [ U.Ordinary_message (message T.Assistant "only eligible source") ]
+  in
+  ensure_registered_keeper ~base_path:exact_flow_base_path keeper_name;
+  match
+    C.prepare_lane
+      ~base_path:exact_flow_base_path
+      ~keeper_name
+      ~registry
+      ~lane_id:conformance_lane_id
+      ~units:source_units
+  with
+  | Error C.No_reducible_boundary -> ()
+  | Error C.Invalid_plan ->
+    Alcotest.fail "a valid irreducible window regressed to invalid_plan"
+  | Error _ -> Alcotest.fail "irreducible window returned the wrong typed failure"
+  | Ok _ -> Alcotest.fail "a one-source window cannot produce a reducing boundary"
 ;;
 
 let test_preparation_freezes_order_generation_and_defers_attempt_identity () =
@@ -983,6 +1016,10 @@ let () =
             "missing lane is explicit"
             `Quick
             test_missing_compaction_lane_is_explicit_degraded_state
+        ; Alcotest.test_case
+            "irreducible window is a terminal no-op"
+            `Quick
+            test_irreducible_window_is_a_distinct_terminal_noop
         ; Alcotest.test_case
             "order and generation freeze before attempt allocation"
             `Quick

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -189,6 +189,61 @@ let make_checkpoint () =
     ; working_context = None
     }
 
+let make_irreducible_checkpoint ~name ~trace_id () =
+  { (make_checkpoint ()) with
+    session_id = trace_id
+  ; agent_name = name
+  ; messages =
+      [ Agent_core.Types.text_message
+          Agent_core.Types.Assistant
+          "one valid but irreducible source"
+      ]
+  }
+
+let persist_checkpoint_source_exn
+      ~label
+      config
+      (meta : Masc.Keeper_meta_contract.keeper_meta)
+      (checkpoint : Agent_core.Checkpoint.t)
+  =
+  let session =
+    Masc.Keeper_context_core.create_session
+      ~session_id:checkpoint.Agent_core.Checkpoint.session_id
+      ~base_dir:(Masc.Keeper_types_profile.session_base_dir config)
+  in
+  let context =
+    Masc.Keeper_context_core.context_of_agent_core_checkpoint checkpoint
+  in
+  match
+    Masc.Keeper_context_core.save_agent_core_checkpoint_classified
+      ~multimodal_policy:meta.multimodal_policy
+      ~keeper_name:meta.name
+      ~session
+      ~agent_name:meta.agent_name
+      ~ctx:context
+      ~generation:1
+  with
+  | Error detail ->
+    failf
+      "%s checkpoint fixture failed: %s"
+      label
+      (Masc.Keeper_context_core.checkpoint_write_error_to_string
+         ~persistence_error_to_string:(fun detail -> detail)
+         detail)
+  | Ok _ ->
+    (match
+       Masc.Keeper_checkpoint_store.load_agent_core_with_ref
+         ~session_dir:session.session_dir
+         ~session_id:checkpoint.session_id
+     with
+     | Ok (_, source) -> source
+     | Error error ->
+       failf
+         "%s checkpoint source fixture failed: %s"
+         label
+         (Post_turn.compaction_recovery_error_to_string
+            (Post_turn.Checkpoint_ref_load_failed error)))
+
 let block_message role content : Agent_core.Types.message =
   { role; content; name = None; tool_call_id = None; metadata = [] }
 
@@ -341,41 +396,18 @@ let test_missing_exact_lane_is_source_bound_no_compaction () =
        let config = Masc.Workspace.default_config base_path in
        ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
        init_runtime_fixture ();
-       let checkpoint = make_checkpoint () in
-       let session =
-         Masc.Keeper_context_core.create_session
-           ~session_id:checkpoint.session_id
-           ~base_dir:(Masc.Keeper_types_profile.session_base_dir config)
+       let checkpoint =
+         make_irreducible_checkpoint
+           ~name:meta.name
+           ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+           ()
        in
-       let context = Masc.Keeper_context_core.context_of_agent_core_checkpoint checkpoint in
        let expected_source =
-         match
-          Masc.Keeper_context_core.save_agent_core_checkpoint_classified
-            ~multimodal_policy:meta.multimodal_policy
-            ~keeper_name:meta.name
-            ~session
-            ~agent_name:meta.agent_name
-            ~ctx:context
-            ~generation:1
-        with
-        | Ok _ ->
-          (match
-             Masc.Keeper_checkpoint_store.load_agent_core_with_ref
-               ~session_dir:session.session_dir
-               ~session_id:checkpoint.session_id
-           with
-           | Ok (_, source) -> source
-           | Error error ->
-             failf
-               "missing-lane checkpoint source fixture failed: %s"
-               (Post_turn.compaction_recovery_error_to_string
-                  (Post_turn.Checkpoint_ref_load_failed error)))
-        | Error detail ->
-          failf
-            "missing-lane checkpoint fixture failed: %s"
-            (Masc.Keeper_context_core.checkpoint_write_error_to_string
-               ~persistence_error_to_string:(fun detail -> detail)
-               detail)
+         persist_checkpoint_source_exn
+           ~label:"missing-lane irreducible"
+           config
+           meta
+           checkpoint
        in
        let resolver_snapshot =
          Exact_fixture.resolver_snapshot
@@ -425,6 +457,88 @@ let test_missing_exact_lane_is_source_bound_no_compaction () =
            "missing exact lane returned a retryable error: %s"
            (Post_turn.compaction_recovery_error_to_string error)
        | Ok _ -> fail "missing exact lane unexpectedly prepared compaction")
+;;
+
+let test_irreducible_window_is_source_bound_no_compaction () =
+  Eio_main.run @@ fun env ->
+  Masc_test_deps.init_eio_clock env;
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio.Switch.run @@ fun sw ->
+  with_eio_context env sw @@ fun () ->
+  let base_path = Masc_test_deps.setup_test_workspace () in
+  let runtime_snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () ->
+      Runtime.For_testing.restore runtime_snapshot;
+      Masc_test_deps.cleanup_test_workspace base_path)
+    (fun () ->
+       let name = "post-turn-irreducible-window" in
+       let trace_id = "trace-post-turn-irreducible-window" in
+       let meta = make_meta ~name ~trace_id () in
+       let config = Masc.Workspace.default_config base_path in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       init_runtime_fixture ();
+       let checkpoint = make_irreducible_checkpoint ~name ~trace_id () in
+       let expected_source =
+         persist_checkpoint_source_exn
+           ~label:"irreducible-window"
+           config
+           meta
+           checkpoint
+       in
+       let slot_id = "irreducible-post-turn-slot" in
+       let resolver_snapshot =
+         Exact_fixture.resolver_snapshot
+           ~source:"post-turn irreducible exact lane"
+           [ ({ id = slot_id; base_url = "http://127.0.0.1:9" }
+              : Exact_fixture.target_fixture)
+           ]
+       in
+       ignore
+         (Exact_fixture.publish_registry
+            ~lane_id:"compaction_exact"
+            ~slot_ids:[ slot_id ]
+            resolver_snapshot);
+       ensure_registered_keeper ~base_path:config.base_path meta;
+       match
+         Post_turn.prepare_compaction
+           ~base_path:config.base_path
+           ~base_dir:(Masc.Keeper_types_profile.session_base_dir config)
+           ~meta
+           ~trigger:Compaction_trigger.Manual
+           ()
+       with
+       | Error
+           (Post_turn.No_compaction
+              ({ source
+               ; reason = Keeper_compaction_outcome.No_reducible_boundary
+               } as no_compaction)) ->
+         check string
+           "terminal evidence retains checkpoint trace"
+           (Keeper_id.Trace_id.to_string expected_source.trace_id)
+           (Keeper_id.Trace_id.to_string source.trace_id);
+         check int
+           "terminal evidence retains checkpoint turn"
+           expected_source.turn_count
+           source.turn_count;
+         check int
+           "terminal evidence retains checkpoint generation"
+           expected_source.generation
+           source.generation;
+         check string
+           "terminal evidence retains checkpoint digest"
+           expected_source.sha256
+           source.sha256;
+         check string
+           "terminal receipt keeps irreducible identity"
+           "no_compaction:no_reducible_boundary"
+           (Post_turn.compaction_recovery_error_to_tag
+              (Post_turn.No_compaction no_compaction))
+       | Error error ->
+         failf
+           "irreducible window returned the wrong product result: %s"
+           (Post_turn.compaction_recovery_error_to_string error)
+       | Ok _ -> fail "irreducible window unexpectedly prepared compaction")
 ;;
 
 let test_malformed_structure_preserves_checkpoint () =
@@ -1050,5 +1164,7 @@ let () =
         `Quick test_reactive_prepare_has_no_retry_gate;
       test_case "missing exact lane is source-bound no-compaction"
         `Quick test_missing_exact_lane_is_source_bound_no_compaction;
+      test_case "irreducible window is source-bound no-compaction"
+        `Quick test_irreducible_window_is_source_bound_no_compaction;
     ];
   ]


### PR DESCRIPTION
Follow-up to #28644.

As-Is: a valid compaction history with no reducible boundary was collapsed into `No_eligible_history`, so the durable terminal receipt could not distinguish absent history from present-but-irreducible history.

To-Be: `No_reducible_boundary` remains a closed typed product identity from exact planning through compaction rejection, post-turn terminal settlement, and durable `no_compaction:no_reducible_boundary` observability. Lane resolution still precedes irreducible classification.

Evidence: feature-boundary tests cover the combined missing-lane + irreducible case and a persisted checkpoint through public `Keeper_post_turn.prepare_compaction`, including exact checkpoint source identity. Independent adversarial source review found P0-P2 none.

Validation: ocamlformat check, parse-only checks, diff-check, variant sync, cross-module exhaustive match audit, and OCaml structure ratchet passed. Per campaign policy, no local Dune build or test was run; exact-head CI is authoritative.