### PR TITLE
fix(keeper): propagate tool observer cancellation

### DIFF
--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -14,19 +14,12 @@ type tool_observer_serialization = (unit -> unit) -> unit
 
 let create_tool_observer_serialization () : tool_observer_serialization =
   let mutex = Eio.Mutex.create () in
-  fun observe ->
-    Eio.Mutex.lock mutex;
-    (* The enclosing Agent-core hook reports a failed observer and continues.
-       [use_rw] would poison the per-run mutex on that reported exception and
-       reject every later completion. Unlock explicitly while protecting the
-       acquired critical section from cancellation, so one failed observation
-       cannot erase unrelated later receipts. *)
-    Eio.Cancel.protect (fun () ->
-      match observe () with
-      | () -> Eio.Mutex.unlock mutex
-      | exception exn ->
-        Eio.Mutex.unlock mutex;
-        raise exn)
+  (* This mutex orders independent observer effects; it does not protect a
+     recoverable mutable invariant.  [use_ro] therefore gives the required
+     exception-safe unlock without masking cancellation across registry reads,
+     activity persistence, or SSE delivery.  A cancelled/failed observation
+     releases the boundary so later tool completions can still be reported. *)
+  fun observe -> Eio.Mutex.use_ro mutex observe
 ;;
 
 type agent_setup =

--- a/test/test_keeper_run_tools_hooks.ml
+++ b/test/test_keeper_run_tools_hooks.ml
@@ -648,6 +648,30 @@ let test_failed_tool_observer_releases_next_completion () =
   check bool "a reported observer failure does not poison later receipts" true !observed
 ;;
 
+let test_cancelled_tool_observer_releases_next_completion () =
+  Eio_main.run @@ fun _env ->
+  let serialize =
+    Masc.Keeper_run_tools_hooks.create_tool_observer_serialization ()
+  in
+  let continued_after_cancel = ref false in
+  let cancellation_escaped =
+    try
+      Eio.Cancel.sub (fun cancellation ->
+        serialize (fun () ->
+          Eio.Cancel.cancel cancellation (Failure "cancel tool observer");
+          Eio.Fiber.check ();
+          continued_after_cancel := true));
+      false
+    with
+    | Eio.Cancel.Cancelled _ -> true
+  in
+  check bool "observer cancellation escapes the serialization boundary" true cancellation_escaped;
+  check bool "cancelled observer does not continue its effects" false !continued_after_cancel;
+  let observed = ref false in
+  serialize (fun () -> observed := true);
+  check bool "cancellation releases the next completion" true !observed
+;;
+
 let () =
   run
     "keeper_run_tools_hooks"
@@ -741,6 +765,10 @@ let () =
             "releases the next completion after a reported failure"
             `Quick
             test_failed_tool_observer_releases_next_completion
+        ; test_case
+            "propagates cancellation and releases the next completion"
+            `Quick
+            test_cancelled_tool_observer_releases_next_completion
         ] )
     ]
 ;;


### PR DESCRIPTION
## Problem

Concurrent tool completions serialize the full observation transaction. The current boundary wraps registry reads, activity persistence, and SSE delivery in Eio.Cancel.protect, so cancellation or disconnect cannot preempt blocked observer I/O and later sibling observations wait behind it.

## Change

- use Eio.Mutex.use_ro for exception-safe, cancellable serialization
- prove cancellation escapes without running later effects
- prove the same serialization boundary remains reusable by the next completion

No new gate, timeout, retry budget, environment variable, string classifier, or compatibility layer.

## Verification

- git diff --check
- ocamlformat --check on both changed files
- local build/tests intentionally not run; GitHub CI is the execution authority