### PR TITLE
docs(dashboard): 에코 가드 주석의 틀린 기전을 바로잡는다 (#28616 후속)

### DIFF
--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -430,9 +430,15 @@ export function applyKeeperOperationTurnEvent(
   // stamps the accepted operation id onto the bubble it is streaming into
   // (keeper-actions [stampPlaceholderRequestId]) and leaves it in 'streaming',
   // which is exactly the state this function treats as "still open, keep
-  // writing". Applying both transports to one bubble does not overwrite, it
-  // interleaves -- the two chunk the same text at different boundaries, so the
-  // operator sees every fragment twice ("오퍼레이터가 비" + "레이터가 비유/").
+  // writing". Both transports carry the same event: one Option.iter in
+  // server_routes_http_keeper_stream hands a single AG-UI event to
+  // Keeper_chat_broadcast.operation_event and publish_operation_live_event, so
+  // the deltas are byte-identical and TEXT_MESSAGE_CONTENT has no per-chunk
+  // sequence to dedupe on (messageId alone cannot: it is per message, not per
+  // chunk). Applying both to one bubble appends twice, and the broadcast copy
+  // starts after the direct stream has already written some deltas, so the two
+  // runs sit out of phase and the operator reads interleaved fragments
+  // ("오퍼레이터가 비" + "레이터가 비유/").
   // Live-send ownership already records which request this session is
   // streaming itself, so consult that rather than inferring it from state.
   if (liveSendOwnsRequest(operationId)) return null


### PR DESCRIPTION
`keeper-stream.ts` 의 live-send 소유권 가드 위 주석이 **반증된 기전**을 서술하고 있어 바로잡습니다.

## 무엇이 틀렸나

현재 main:

> Applying both transports to one bubble does not overwrite, it interleaves -- **the two chunk the same text at different boundaries**

두 전송이 각자 다르게 잘랐다는 서술인데, 생산자를 보면 그렇지 않습니다. `lib/server/server_routes_http_keeper_stream.ml:1961-1968` 의 `Option.iter` 하나가 **동일한 AG-UI event 객체**를 두 곳에 넘깁니다:

```ocaml
Option.iter
  (fun event ->
     Keeper_chat_broadcast.operation_event ~keeper_name ~operation_id ~event;
     publish_operation_live_event ~operation_id event)
  projected;
```

델타는 바이트 단위로 같습니다. 화면이 인터리브로 보인 건 **브로드캐스트 사본이 직접 스트림보다 늦게 붙어 앞 조각을 놓쳐 위상이 어긋난** 결과입니다.

## 근거

- 생산자: 위 `Option.iter` (조건 분기 없이 두 전송 모두 호출)
- envelope: `keeper_chat_broadcast.ml:110-118` 이 `ag_ui_event` 로 `Ag_ui.event_to_json event` 를 그대로 실어 보냄 — messageId·timestamp 포함 동일
- 이 PR 과 같이 들어간 테스트는 **이미 늦은 합류(late-join)로 서술**하고 있음 (`keeper-stream.test.ts:177-179`, `202-204`). 소스 주석만 옛 설명으로 남았습니다.

## 왜 고치나

틀린 기전 설명이 코드에 남으면 다음 작업자가 그걸 근거로 판단합니다. 실제로 이 문장 때문에 처음 재현 테스트를 *서로 다른 델타*로 지어냈고, 그건 재현이 아니라 가설의 자기확인이었습니다.

## 검증

- `vitest run src/keeper-stream.test.ts` — **30 passed**
- `tsc --noEmit` — 0
- `eslint src/keeper-stream.ts` — 0
- diff `+9/-3`, 변경된 모든 라인이 `//` 로 시작 (실행 라인 무변경)

## 범위 밖 (기록만)

실제 대시보드에서 라이브 턴 2회를 실측했고 렌더 텍스트가 서버 저장 원문과 바이트 단위로 일치했습니다(145자, 중복 없음). 다만 **에코가 실제로 도착해 가드가 막은 것인지**는 확인하지 못했습니다 — 두 번째 대시보드 세션에는 operation 이벤트가 도달하지 않았고, WS 가 Web Worker 안에서 실행돼 메인 스레드에서 프레임을 계측할 수 없었습니다. 이 PR 은 주석만 다루며, 그 관측은 별도 확인이 필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
