### PR TITLE
fix(runtime): admit statusless Claude overflow frames via the CLI sentence table

### DIFF
--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -737,20 +737,25 @@ let parse_result ~expected_session_id ~rate_limit ~tool_effect_attempted
          context-window rejection ("Prompt is too long" / "Input is too long
          for requested model", either status, or a 413 naming the window). A
          frame that carries the verdict is authoritative in both directions,
-         like the codex lane's [codexErrorInfo]. Frames from CLIs that predate
-         the enum carry no [terminal_reason]; only those fall back to the
-         historical exact-prefix 400, unchanged in scope (RFC amendment
-         2026-08-12). *)
+         like the codex lane's [codexErrorInfo].
+
+         Frames without the enum fall back to the CLI's own sentence table,
+         with no status requirement. The historical 400 requirement missed
+         real frames: on 2026-08-14 the CLI reported three resumed-session
+         overflows as [subtype=success, is_error=true] with no
+         [api_error_status] and no [terminal_reason] — only the sentence —
+         so the overflow fell to the generic-failure path and surfaced as an
+         unmapped internal error. Both sentences appear verbatim in the CLI
+         binary (2.1.232). *)
       match terminal_reason with
       | Some reason -> String.equal reason "prompt_too_long"
       | None ->
-        Option.equal Int.equal api_error_status (Some 400)
-        && Option.exists
-             (fun detail ->
-                String.starts_with
-                  ~prefix:"Prompt is too long"
-                  (String.trim detail))
-             result
+        Option.exists
+          (fun detail ->
+             let detail = String.trim detail in
+             String.starts_with ~prefix:"Prompt is too long" detail
+             || String.starts_with ~prefix:"Input is too long for requested model" detail)
+          result
     in
     if structurally_quota_blocked
     then Error (Quota_blocked { api_error_status; rate_limit })

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -416,11 +416,27 @@ let non_overflow_reason_with_prefix_prose_result =
   {|{"type":"result","subtype":"success","is_error":true,"session_id":"__SESSION__","uuid":"turn-400-misprose","result":"Prompt is too long · gateway relayed the sentence for an unrelated rejection","api_error_status":400,"terminal_reason":"api_error"}|}
 ;;
 
+(* 2026-08-14: three live resumed-session overflows arrived as
+   [subtype=success, is_error=true] with no [terminal_reason] and no
+   [api_error_status] — only the sentence. The frame shape the 400-bound
+   fallback missed. *)
+let statusless_prompt_too_long_result =
+  {|{"type":"result","subtype":"success","is_error":true,"session_id":"__SESSION__","uuid":"turn-nostatus-1","result":"Prompt is too long"}|}
+;;
+
+let statusless_input_too_long_result =
+  {|{"type":"result","subtype":"success","is_error":true,"session_id":"__SESSION__","uuid":"turn-nostatus-2","result":"Input is too long for requested model"}|}
+;;
+
+let statusless_generic_error_result =
+  {|{"type":"result","subtype":"success","is_error":true,"session_id":"__SESSION__","uuid":"turn-nostatus-3","result":"stream closed before completion"}|}
+;;
+
 (* A live keeper reported Claude's explicit "prompt is too long" terminal as a
    generic 400, so the provider-bound history shrinker never saw the typed
    ContextOverflow it consumes. This fixture carries no [terminal_reason], so
-   it now exercises the pre-enum fallback: the status and provider sentence
-   together are the admission evidence; unrelated 400s stay generic below. *)
+   it exercises the sentence-table fallback: the provider sentence alone is
+   the admission evidence, any status; non-prefix prose stays generic below. *)
 let test_terminal_prompt_too_long_is_typed () =
   with_fixture [ Emit prompt_too_long_result ] (fun path ->
     match run_fixture path with
@@ -452,6 +468,52 @@ let test_unrelated_400_remains_turn_failed () =
         (Astring.String.is_infix ~affix:"diagnostic mentioned" detail)
     | Error error -> fail (Runtime_claude_code.error_to_string error)
     | Ok _ -> fail "an unrelated 400 terminal was reported as completion")
+;;
+
+(* The 2026-08-14 live shape: is_error with the overflow sentence but no
+   [terminal_reason] and no [api_error_status]. The sentence table admits it
+   without a status requirement. *)
+let test_statusless_prompt_too_long_is_typed () =
+  with_fixture [ Emit statusless_prompt_too_long_result ] (fun path ->
+    match run_fixture path with
+    | Error
+        (Runtime_claude_code.Context_window_exceeded
+          { message; tool_effect_attempted = false; response_emitted = false }) ->
+      check
+        bool
+        "provider sentence survives into the typed failure"
+        true
+        (Astring.String.is_infix ~affix:"Prompt is too long" message)
+    | Error error -> fail (Runtime_claude_code.error_to_string error)
+    | Ok _ -> fail "a statusless overflow terminal was reported as completion")
+;;
+
+let test_statusless_input_too_long_is_typed () =
+  with_fixture [ Emit statusless_input_too_long_result ] (fun path ->
+    match run_fixture path with
+    | Error
+        (Runtime_claude_code.Context_window_exceeded
+          { message; tool_effect_attempted = false; response_emitted = false }) ->
+      check
+        bool
+        "provider sentence survives into the typed failure"
+        true
+        (Astring.String.is_infix ~affix:"Input is too long" message)
+    | Error error -> fail (Runtime_claude_code.error_to_string error)
+    | Ok _ -> fail "a statusless overflow terminal was reported as completion")
+;;
+
+let test_statusless_generic_error_remains_turn_failed () =
+  with_fixture [ Emit statusless_generic_error_result ] (fun path ->
+    match run_fixture path with
+    | Error (Runtime_claude_code.Turn_failed detail) ->
+      check
+        bool
+        "generic rejection reason survives"
+        true
+        (Astring.String.is_infix ~affix:"stream closed" detail)
+    | Error error -> fail (Runtime_claude_code.error_to_string error)
+    | Ok _ -> fail "a statusless generic error was reported as completion")
 ;;
 
 (* CLI 2.1.228+ states the loop outcome as [terminal_reason]; a live forced
@@ -1254,6 +1316,18 @@ let () =
             "unrelated 400 remains turn failed"
             `Quick
             test_unrelated_400_remains_turn_failed
+        ; test_case
+            "statusless prompt too long is typed"
+            `Quick
+            test_statusless_prompt_too_long_is_typed
+        ; test_case
+            "statusless input too long is typed"
+            `Quick
+            test_statusless_input_too_long_is_typed
+        ; test_case
+            "statusless generic error remains turn failed"
+            `Quick
+            test_statusless_generic_error_remains_turn_failed
         ; test_case
             "quota is structurally classified"
             `Quick


### PR DESCRIPTION
## 문제 (오늘 라이브 실측)

2026-08-14 09:09~09:19 KST, code-reviewer keeper의 claude_code.claude-sonnet-5 턴 3건이 연속 실패했습니다. result frame은:

```
subtype=success, is_error=true, api_error_status 없음, terminal_reason 없음, result="Prompt is too long"
```

이 프레임은 typed 경로(terminal_reason 소비, #28357)에도, fallback(400+prefix)에도 안 잡혀 generic `Turn_failed`로 떨어졌고, 하류에서 `provider_attempt_effect_fenced` + `operator_disposition: unmapped` WARN 8건으로 표면화됐습니다 (`keeper_execution_receipt.ml`의 catch-all은 설계 의도대로 동작 — 상류 미분류가 원인).

주목: `system_and_user_bytes=6215` — masc가 보낸 신규 입력은 6KB였고, overflow는 CLI가 resume 세션에 누적한 히스토리에서 났습니다. fresh `-p` 강제 overflow 라이브 캡처(2026-08-12)에서는 enum+400이 세트로 실렸으므로, 이 프레임은 CLI 분류기가 overflow로 승격하지 못하는 별도 실패 표면입니다.

## 수정

#28357 커밋 메시지가 인용한 CLI 자체 분류표 — 문구 2종, **any status** — 에 enum-less fallback을 정렬합니다:

- `Prompt is too long` / `Input is too long for requested model` 프리픽스 매치, status 요구 제거
- `terminal_reason` 실린 프레임은 변화 없음 (typed 1순위 유지)
- 두 문구는 CLI 2.1.232 바이너리에서 verbatim 확인

## 테스트

`terminal` 그룹에 3건 추가:
- `statusless prompt too long is typed` — 실측 프레임 모양 그대로 고정 (수정 전 코드에서는 `Turn_failed`로 떨어져 FAIL)
- `statusless input too long is typed` — 두 번째 문구
- `statusless generic error remains turn failed` — status 없는 축의 음성 대조 (과대 매치 방지)

기존 `unrelated 400 remains turn failed`(비-프리픽스 문구 음성 대조)는 그대로 통과합니다.

## 검증 명령

```
rg -c 'operator_disposition: unmapped' ~/me/.masc/logs/system_log_2026-08-14.jsonl   # 8 (수정 전 실측)
rg -ao 'Input is too long for requested model' ~/.local/share/claude/versions/2.1.232 | head -1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)