### PR TITLE
fix(keeper): board candidate identity를 typed event key로 — post당 68회 재판정 제거 (#28607)

### DIFF
--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -126,7 +126,10 @@ type record_acceptance =
 
 exception Candidate_unavailable of string
 
-let schema_version = 3
+(* v4: post_created candidate identity became the typed event key
+   (keeper, kind, post_id) — v3 rows hash volatile fields and fail the
+   read-time identity check, so v3 ledgers are retired at deploy, not read. *)
+let schema_version = 4
 
 let quarantine_failure_category_to_string = function
   | Candidate_membership_conflict -> "candidate_membership_conflict"
@@ -275,15 +278,52 @@ let keeper_context_to_yojson (meta : Keeper_meta_contract.keeper_meta) =
          ])
 ;;
 
-let candidate_id_of_signal ~keeper_name signal =
+let candidate_id_of_signal ~keeper_name (signal : Board_dispatch.board_signal) =
   let identity =
-    `Assoc
-      [ "keeper_name", `String keeper_name
-      ; "signal", signal_to_yojson signal
-      ]
-    |> Yojson.Safe.to_string
+    match signal.kind with
+    | Board_dispatch.Board_post_created ->
+      (* Identity is the typed event key only. The world-observation backlog
+         scanner re-synthesizes [Board_post_created] with the post's *current*
+         [updated_at] on every cycle, so any volatile field (updated_at,
+         content) in this hash defeats [Candidate_already_present] idempotence:
+         one post minted 68 candidates = 68 model judgments (#28607). *)
+      `Assoc
+        [ "keeper_name", `String keeper_name
+        ; "kind", `String (signal_kind_to_string signal.kind)
+        ; "post_id", `String signal.post_id
+        ]
+    | Board_dispatch.Board_comment_added
+    | Board_dispatch.Board_reaction_changed _ ->
+      `Assoc
+        [ "keeper_name", `String keeper_name
+        ; "signal", signal_to_yojson signal
+        ]
   in
-  Digestif.SHA256.(digest_string identity |> to_hex)
+  Digestif.SHA256.(digest_string (Yojson.Safe.to_string identity) |> to_hex)
+;;
+
+(* Must stay in lockstep with [candidate_id_of_signal]: two signals are
+   identity-equal exactly when that function hashes them identically for the
+   same keeper. [record] uses this to converge a re-scanned signal whose
+   volatile fields (updated_at, content) drifted onto the persisted candidate. *)
+let signal_identity_equal
+      (left : Board_dispatch.board_signal)
+      (right : Board_dispatch.board_signal)
+  =
+  match left.kind, right.kind with
+  | Board_dispatch.Board_post_created, Board_dispatch.Board_post_created ->
+    String.equal left.post_id right.post_id
+  | Board_dispatch.Board_comment_added, Board_dispatch.Board_comment_added ->
+    left = right
+  | Board_dispatch.Board_reaction_changed _, Board_dispatch.Board_reaction_changed _ ->
+    left = right
+  | Board_dispatch.Board_post_created,
+    (Board_dispatch.Board_comment_added | Board_dispatch.Board_reaction_changed _)
+  | Board_dispatch.Board_comment_added,
+    (Board_dispatch.Board_post_created | Board_dispatch.Board_reaction_changed _)
+  | Board_dispatch.Board_reaction_changed _,
+    (Board_dispatch.Board_post_created | Board_dispatch.Board_comment_added) ->
+    false
 ;;
 
 let of_board_evidence
@@ -1516,11 +1556,12 @@ let record ~base_path candidate =
          (fun candidates ->
             match find_candidate candidates candidate.candidate_id with
             | None -> Ok (Some candidate, Recorded candidate)
-            | Some existing when existing.signal = candidate.signal ->
+            | Some existing
+              when signal_identity_equal existing.signal candidate.signal ->
               Ok (None, Duplicate existing)
             | Some _ ->
               Error
-                "candidate identity conflict: the same candidate_id has a different Board signal")
+                "candidate identity conflict: the same candidate_id has a different Board signal identity")
      with
      | Ok result -> result
      | Error detail -> Record_error detail)

--- a/lib/keeper/keeper_board_attention_candidate.mli
+++ b/lib/keeper/keeper_board_attention_candidate.mli
@@ -175,6 +175,14 @@ val status_view : status -> status_view
     quarantine provenance without forcing callers to inspect [status] again. *)
 val signal_to_yojson : Board_dispatch.board_signal -> Yojson.Safe.t
 
+val candidate_id_of_signal :
+  keeper_name:string -> Board_dispatch.board_signal -> string
+(** Typed event identity of a Board signal for one keeper. [Board_post_created]
+    hashes (keeper, kind, post_id) only — volatile post fields (updated_at,
+    content) must not participate, or the backlog scanner's re-synthesized
+    signals mint a fresh candidate per post update (#28607). Exported so test
+    fixtures derive ids from this function instead of copying the formula. *)
+
 val singleton_judgment_request : candidate -> (Yojson.Safe.t, string) result
 (** Validate the current durable request schema and its outer candidate,
     Keeper, and signal identity, then return the one-item exact-flow input.

--- a/scripts/check-runtime-deployment-preflight.sh
+++ b/scripts/check-runtime-deployment-preflight.sh
@@ -190,17 +190,21 @@ run_gate() {
   if [[ -e "$candidates_root" || -L "$candidates_root" ]]; then
     [[ -d "$candidates_root" && ! -L "$candidates_root" ]] \
       || fail "board attention candidate store is not an exact directory: $candidates_root"
+    reject_symlinks_below "$candidates_root" "board attention candidate store"
     local candidate_ledger_path
     local stale_row_report
     while IFS= read -r -d '' candidate_ledger_path; do
+      [[ -f "$candidate_ledger_path" && ! -L "$candidate_ledger_path" ]] \
+        || fail "board attention candidate ledger is not an exact regular file: $candidate_ledger_path"
       if [[ ! -s "$candidate_ledger_path" ]]; then
         continue
       fi
       # -R + fromjson: a torn or non-JSON line is reported instead of skipped —
       # the runtime reader is fail-total per file, so it would stall on it too.
       stale_row_report="$(jq -Rr \
-        'select(test("\\S")) | try (fromjson | select(.schema_version != 4) | "schema_version=\(.schema_version)") catch "unparseable row"' \
-        "$candidate_ledger_path" | head -1)"
+        'first(select(test("\\S")) | try (fromjson | select(.schema_version != 4) | "schema_version=\(.schema_version)") catch "unparseable row") // empty' \
+        "$candidate_ledger_path")" \
+        || fail "board attention candidate ledger could not be inspected: $candidate_ledger_path"
       [[ -z "$stale_row_report" ]] \
         || fail "board attention candidate ledger has a pre-v4 or unreadable row ($stale_row_report): $candidate_ledger_path — retire the store before restart: mv $candidates_root ${runtime_root}/board_attention_candidates-retired-$(date +%Y%m%d)"
     done < <(find "$candidates_root" -name '*.jsonl' -print0)
@@ -271,6 +275,18 @@ if [[ "$SELF_TEST" -eq 1 ]]; then
     fi
   }
 
+  expect_failure_contains() {
+    local case_name="$1"
+    local target_root="$2"
+    local expected_text="$3"
+    local output
+    if output="$("$0" --base-path "$target_root" 2>&1)"; then
+      fail "self-test expected failure: $case_name"
+    fi
+    [[ "$output" == *"$expected_text"* ]] \
+      || fail "self-test failure omitted expected detail for $case_name: $expected_text"
+  }
+
   safe_root="$fixture_root/safe"
   write_schedules "$safe_root" succeeded
   write_signal "$safe_root" true
@@ -326,6 +342,26 @@ if [[ "$SELF_TEST" -eq 1 ]]; then
   printf '{"schema_version": 3, "candidate_id": "fixture"}\n' \
     >"$stale_candidate_root/.masc/board_attention_candidates/fixture.jsonl"
   expect_failure stale_board_attention_candidate_ledger "$stale_candidate_root"
+
+  many_stale_candidate_root="$fixture_root/candidate-many-pre-v4"
+  write_schedules "$many_stale_candidate_root" running
+  mkdir -p "$many_stale_candidate_root/.masc/board_attention_candidates"
+  jq -nc 'range(0; 5000) | {schema_version: 3, candidate_id: "fixture"}' \
+    >"$many_stale_candidate_root/.masc/board_attention_candidates/fixture.jsonl"
+  expect_failure_contains \
+    many_stale_board_attention_candidate_rows \
+    "$many_stale_candidate_root" \
+    "retire the store before restart"
+
+  symlinked_candidate_root="$fixture_root/candidate-symlink"
+  write_schedules "$symlinked_candidate_root" running
+  mkdir -p "$symlinked_candidate_root/.masc/board_attention_candidates"
+  ln -s "$stale_candidate_root/.masc/board_attention_candidates/fixture.jsonl" \
+    "$symlinked_candidate_root/.masc/board_attention_candidates/fixture.jsonl"
+  expect_failure_contains \
+    symlinked_board_attention_candidate_ledger \
+    "$symlinked_candidate_root" \
+    "board attention candidate store contains a symlink"
 
   torn_candidate_root="$fixture_root/candidate-torn"
   write_schedules "$torn_candidate_root" running

--- a/scripts/check-runtime-deployment-preflight.sh
+++ b/scripts/check-runtime-deployment-preflight.sh
@@ -182,6 +182,30 @@ run_gate() {
     done < <(find "$signals_root" -name '*.jsonl' -print0)
   fi
 
+  # Board attention candidate ledgers are schema_version 4 (typed post_created
+  # identity). parse_rows is fail-total per file, so one pre-v4 row silently
+  # stalls that keeper's board attention after restart. There is deliberately
+  # no legacy reader: retire old ledgers instead of starting on top of them.
+  local candidates_root="$runtime_root/board_attention_candidates"
+  if [[ -e "$candidates_root" || -L "$candidates_root" ]]; then
+    [[ -d "$candidates_root" && ! -L "$candidates_root" ]] \
+      || fail "board attention candidate store is not an exact directory: $candidates_root"
+    local candidate_ledger_path
+    local stale_row_report
+    while IFS= read -r -d '' candidate_ledger_path; do
+      if [[ ! -s "$candidate_ledger_path" ]]; then
+        continue
+      fi
+      # -R + fromjson: a torn or non-JSON line is reported instead of skipped —
+      # the runtime reader is fail-total per file, so it would stall on it too.
+      stale_row_report="$(jq -Rr \
+        'select(test("\\S")) | try (fromjson | select(.schema_version != 4) | "schema_version=\(.schema_version)") catch "unparseable row"' \
+        "$candidate_ledger_path" | head -1)"
+      [[ -z "$stale_row_report" ]] \
+        || fail "board attention candidate ledger has a pre-v4 or unreadable row ($stale_row_report): $candidate_ledger_path — retire the store before restart: mv $candidates_root ${runtime_root}/board_attention_candidates-retired-$(date +%Y%m%d)"
+    done < <(find "$candidates_root" -name '*.jsonl' -print0)
+  fi
+
   printf '[runtime-deployment-preflight] OK: base_path=%s schedule_ledgers=%d signal_files=%d signal_rows=%d current_owners=%d in_progress=%d\n' \
     "$BASE_PATH" "$schedule_ledger_count" "$signal_file_count" \
     "$signal_row_count" "$current_owner_count" "$in_progress_count_total"
@@ -288,6 +312,27 @@ if [[ "$SELF_TEST" -eq 1 ]]; then
   write_schedules "$current_root" running
   write_current_queue "$current_root"
   "$0" --base-path "$current_root" >/dev/null
+
+  candidate_v4_root="$fixture_root/candidate-v4"
+  write_schedules "$candidate_v4_root" running
+  mkdir -p "$candidate_v4_root/.masc/board_attention_candidates"
+  printf '{"schema_version": 4, "candidate_id": "fixture"}\n' \
+    >"$candidate_v4_root/.masc/board_attention_candidates/fixture.jsonl"
+  "$0" --base-path "$candidate_v4_root" >/dev/null
+
+  stale_candidate_root="$fixture_root/candidate-pre-v4"
+  write_schedules "$stale_candidate_root" running
+  mkdir -p "$stale_candidate_root/.masc/board_attention_candidates"
+  printf '{"schema_version": 3, "candidate_id": "fixture"}\n' \
+    >"$stale_candidate_root/.masc/board_attention_candidates/fixture.jsonl"
+  expect_failure stale_board_attention_candidate_ledger "$stale_candidate_root"
+
+  torn_candidate_root="$fixture_root/candidate-torn"
+  write_schedules "$torn_candidate_root" running
+  mkdir -p "$torn_candidate_root/.masc/board_attention_candidates"
+  printf '{"schema_version": 4}\n{"schema_ver' \
+    >"$torn_candidate_root/.masc/board_attention_candidates/fixture.jsonl"
+  expect_failure torn_board_attention_candidate_ledger "$torn_candidate_root"
 
   malformed_current_root="$fixture_root/malformed-current"
   write_schedules "$malformed_current_root" running

--- a/test/test_keeper_board_attention_candidate.ml
+++ b/test/test_keeper_board_attention_candidate.ml
@@ -34,7 +34,7 @@ let ok label = function
   | Error detail -> Alcotest.failf "%s: %s" label detail
 ;;
 
-let signal ?(content = "Persisted Board evidence") post_id :
+let signal ?(content = "Persisted Board evidence") ?(updated_at = 42.0) post_id :
   Masc.Board_dispatch.board_signal
   =
   { kind = Masc.Board_dispatch.Board_post_created
@@ -43,7 +43,7 @@ let signal ?(content = "Persisted Board evidence") post_id :
   ; title = "Board update"
   ; content
   ; hearth = Some "hearth-1"
-  ; updated_at = Some 42.0
+  ; updated_at = Some updated_at
   }
 ;;
 
@@ -139,15 +139,7 @@ let candidate ?(context = keeper_context ()) signal :
   A.candidate
   =
   let keeper_name = "sangsu" in
-  let candidate_id =
-    `Assoc
-      [ "keeper_name", `String keeper_name
-      ; "signal", A.signal_to_yojson signal
-      ]
-    |> Yojson.Safe.to_string
-    |> Digestif.SHA256.digest_string
-    |> Digestif.SHA256.to_hex
-  in
+  let candidate_id = A.candidate_id_of_signal ~keeper_name signal in
   { candidate_id
   ; keeper_name
   ; signal
@@ -722,8 +714,25 @@ let test_record_dedupes_exact_identity_and_rejects_conflict () =
    | A.Duplicate duplicate ->
      Alcotest.(check bool) "exact duplicate" true (duplicate = persisted)
    | A.Recorded _ | A.Record_error _ -> Alcotest.fail "exact duplicate was not deduped");
+  (* #28607 regression: the backlog scanner re-synthesizes the same post's
+     [Board_post_created] signal with a moved [updated_at]/[content] every
+     cycle. Under the typed event identity (keeper, kind, post_id) that
+     re-mint must converge to the already-persisted candidate instead of
+     minting a fresh one (68 candidates = 68 model judgments for one post). *)
+  (* Both volatile axes drift on a real re-scan: a comment bumps the post's
+     updated_at, and edits change content. The fixture must move both or a
+     hash that quietly re-admits one of them survives this test. *)
+  let rescanned =
+    candidate
+      (signal ~content:"different evidence" ~updated_at:99.5 "post-record")
+  in
+  (match A.record ~base_path rescanned with
+   | A.Duplicate duplicate ->
+     Alcotest.(check bool) "re-scan converges to original" true (duplicate = persisted)
+   | A.Recorded _ -> Alcotest.fail "re-scanned post minted a second candidate"
+   | A.Record_error _ -> Alcotest.fail "re-scanned post was rejected");
   let conflicting =
-    { original with signal = signal ~content:"different evidence" "post-record" }
+    { original with signal = signal "post-other" }
   in
   (match A.record ~base_path conflicting with
    | A.Record_error _ -> ()

--- a/test/test_keeper_board_attention_exact_flow.ml
+++ b/test/test_keeper_board_attention_exact_flow.ml
@@ -157,15 +157,7 @@ let comment_of_signal (signal : Board_dispatch.board_signal) : Board.comment =
 let candidate post_id : Candidate.candidate =
   let signal = signal post_id in
   let keeper_name = "sangsu" in
-  let candidate_id =
-    `Assoc
-      [ "keeper_name", `String keeper_name
-      ; "signal", Candidate.signal_to_yojson signal
-      ]
-    |> Yojson.Safe.to_string
-    |> Digestif.SHA256.digest_string
-    |> Digestif.SHA256.to_hex
-  in
+  let candidate_id = Candidate.candidate_id_of_signal ~keeper_name signal in
   { candidate_id
   ; keeper_name
   ; signal

--- a/test/test_keeper_board_attention_worker.ml
+++ b/test/test_keeper_board_attention_worker.ml
@@ -110,15 +110,7 @@ let post_of_signal (signal : Masc.Board_dispatch.board_signal) : Masc.Board.post
 let candidate ?(id = "candidate-worker") ?(recorded_at = 1.0) () : A.candidate =
   let keeper_name = "sangsu" in
   let signal = signal id in
-  let candidate_id =
-    `Assoc
-      [ "keeper_name", `String keeper_name
-      ; "signal", A.signal_to_yojson signal
-      ]
-    |> Yojson.Safe.to_string
-    |> Digestif.SHA256.digest_string
-    |> Digestif.SHA256.to_hex
-  in
+  let candidate_id = A.candidate_id_of_signal ~keeper_name signal in
   { candidate_id
   ; keeper_name
   ; signal


### PR DESCRIPTION
Closes #28607

## 증상 (실측)

post 하나가 sangsu에게 candidate **68개**로 재발행 (p-411c17… 34개, lane-smith에선 65개). candidate마다 model 판정이 스케줄되므로 이미 `not_relevant`로 판정·소비된 post가 **글이 갱신될 때마다 다시 판정**됐습니다. 재기동 후 9.4시간 창에서도 post 2건이 ×2 재발행 — 기전은 라이브.

## 기전

`keeper_world_observation.ml:945-953` 백로그 스캐너가 self-comment 없는 post마다 `Board_post_created` signal을 **현재 updated_at**으로 재합성 → `candidate_id_of_signal`이 signal 전체(updated_at·content 포함)를 SHA256 → 댓글/반응이 updated_at만 올려도 새 해시 → `Candidate_already_present` 멱등 무력화 → 재mint + 재판정.

## 수정 (새 상태·watermark·게이트 없음)

1. **`candidate_id_of_signal`**: `Board_post_created` identity = (keeper, kind, post_id). 휘발 필드 배제. comment/reaction kind는 현행 유지 — 측정된 candidate 저장소 3,170행 전수에서 **두 kind 모두 0건**이고, 올바른 typed key(comment_id)는 signal shape 변경(3중 enum 양방향 매핑 파급)이 필요해 범위 밖.
2. **`record`**: Duplicate 판정을 구조적 동등 대신 typed `signal_identity_equal`로 — 재스캔 드리프트가 conflict 에러가 아니라 기존 candidate로 수렴. kind 쌍 9개 전부 명시 match (catch-all 없음).
3. **`schema_version` 3→4 hard-cut**: 읽기 경로가 저장된 signal에서 id를 재검증하므로 v3 행은 새 공식과 양립 불가. `parse_rows`는 파일 단위 fail-total → **배포 시 `<base>/.masc/board_attention_candidates/` retire 필수** (아래 배포 절차).
4. **해시 공식 3중 복제 제거**: 테스트 픽스처 3파일이 각자 공식을 인라인 복제 중 → `candidate_id_of_signal` mli export + 픽스처가 실함수 호출.

## 검증

- board_attention 스위트: candidate **13/13**, worker·partition green.
- **뮤테이션 매트릭스**: 해시에 updated_at 재삽입 → 회귀 테스트 정확히 1건 실패. content 재삽입 → 동일. 원복 → 13/13. (첫 시도에서 픽스처가 updated_at을 고정해 뮤테이션이 살아남는 걸 발견 → 실제 생산자의 드리프트 축대로 양 축 모두 변화시키도록 교정)
- **대조군**: `test_keeper_board_attention_exact_flow` 3건 실패는 detached origin/main에서도 **동일 재현** — 이 PR과 무관한 기존 결손 (CI 미배선이라 은폐돼 있었음, 별도 이슈 예정).

## 배포 절차

머지 후 재기동 전: `mv ~/me/.masc/board_attention_candidates ~/me/.masc-retired-board-candidates-v3-$(date +%Y%m%d)` — v4 ledger가 빈 상태에서 시작하고, 미처리 post는 백로그 스캐너가 (이제 안정된 identity로) 재발견합니다.

## 관측성

`BoardSignalAttentionCandidateTotal{persistence=duplicate}`가 재스캔 수렴을 셉니다 — 수정 효과를 라이브에서 바로 측정 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)