### PR TITLE
fix(dashboard): separate binary and checkout identity

### DIFF
--- a/dashboard/src/components/dashboard-shell-build-identity.test.ts
+++ b/dashboard/src/components/dashboard-shell-build-identity.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { h, render } from 'preact'
+
+import { serverStatus } from '../store'
+import { BuildIdentityBadge } from './dashboard-shell'
+
+describe('BuildIdentityBadge executable identity', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    serverStatus.value = null
+  })
+
+  it('does not present a runtime checkout fallback as the binary commit', () => {
+    serverStatus.value = {
+      version: '0.22.0',
+      build: {
+        release_version: '0.22.0',
+        commit: '13dd32a37a',
+        commit_source: 'runtime_repo_head',
+        binary_commit: null,
+        binary_commit_source: null,
+        repo_head_commit: '13dd32a37a',
+        repo_head_commit_source: 'runtime_repo_head',
+        started_at: '2026-08-14T02:07:29Z',
+        uptime_seconds: 19,
+      },
+    }
+
+    render(h(BuildIdentityBadge, {}), container)
+
+    const button = container.querySelector('button')
+    expect(button).toHaveTextContent('v0.22.0 · binary unknown')
+    expect(button).toHaveAttribute('aria-label', 'Server build v0.22.0 · binary unknown')
+    expect(button?.getAttribute('title')).toContain('binary commit unknown')
+    expect(button?.getAttribute('title')).toContain('Checkout 13dd32a37a')
+  })
+
+  it('shows the exact binary commit when deployment provenance is present', () => {
+    serverStatus.value = {
+      version: '0.22.0',
+      build: {
+        release_version: '0.22.0',
+        commit: '0123456789abcdef',
+        commit_source: 'env:MASC_BUILD_GIT_COMMIT',
+        binary_commit: '0123456789abcdef',
+        binary_commit_source: 'env:MASC_BUILD_GIT_COMMIT',
+        repo_head_commit: 'fedcba9876543210',
+        repo_head_commit_source: 'runtime_repo_head',
+        started_at: '2026-08-14T02:07:29Z',
+        uptime_seconds: 19,
+      },
+    }
+
+    render(h(BuildIdentityBadge, {}), container)
+
+    const button = container.querySelector('button')
+    expect(button).toHaveTextContent('v0.22.0 · 0123456789')
+    expect(button?.getAttribute('title')).toContain('v0.22.0 · 0123456789')
+    expect(button?.getAttribute('title')).toContain('Checkout fedcba9876')
+  })
+
+  it('does not infer a dev binary when the build payload is unavailable', () => {
+    serverStatus.value = { version: '0.22.0' }
+
+    render(h(BuildIdentityBadge, {}), container)
+
+    const button = container.querySelector('button')
+    expect(button).toHaveTextContent('v0.22.0 · binary unknown')
+    expect(button).toHaveAttribute('aria-label', 'Server build v0.22.0 · binary unknown')
+    expect(button?.getAttribute('title')).toContain('binary commit unknown')
+  })
+})

--- a/dashboard/src/components/dashboard-shell-build-identity.test.ts
+++ b/dashboard/src/components/dashboard-shell-build-identity.test.ts
@@ -38,8 +38,8 @@ describe('BuildIdentityBadge executable identity', () => {
     render(h(BuildIdentityBadge, {}), container)
 
     const button = container.querySelector('button')
-    expect(button).toHaveTextContent('v0.22.0 · binary unknown')
-    expect(button).toHaveAttribute('aria-label', 'Server build v0.22.0 · binary unknown')
+    expect(button?.textContent).toContain('v0.22.0 · binary unknown')
+    expect(button?.getAttribute('aria-label')).toBe('Server build v0.22.0 · binary unknown')
     expect(button?.getAttribute('title')).toContain('binary commit unknown')
     expect(button?.getAttribute('title')).toContain('Checkout 13dd32a37a')
   })
@@ -63,7 +63,7 @@ describe('BuildIdentityBadge executable identity', () => {
     render(h(BuildIdentityBadge, {}), container)
 
     const button = container.querySelector('button')
-    expect(button).toHaveTextContent('v0.22.0 · 0123456789')
+    expect(button?.textContent).toContain('v0.22.0 · 0123456789')
     expect(button?.getAttribute('title')).toContain('v0.22.0 · 0123456789')
     expect(button?.getAttribute('title')).toContain('Checkout fedcba9876')
   })
@@ -74,8 +74,8 @@ describe('BuildIdentityBadge executable identity', () => {
     render(h(BuildIdentityBadge, {}), container)
 
     const button = container.querySelector('button')
-    expect(button).toHaveTextContent('v0.22.0 · binary unknown')
-    expect(button).toHaveAttribute('aria-label', 'Server build v0.22.0 · binary unknown')
+    expect(button?.textContent).toContain('v0.22.0 · binary unknown')
+    expect(button?.getAttribute('aria-label')).toBe('Server build v0.22.0 · binary unknown')
     expect(button?.getAttribute('title')).toContain('binary commit unknown')
   })
 })

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -748,17 +748,25 @@ function formatUptimeSecondsHuman(
     surface the one-glance summary on hover and reserve the click for
     \"deep details\". \n renders verbatim in native tooltips. */
 function composeBuildBadgeTitle(
-  build: { release_version?: string | null; commit?: string | null; uptime_seconds?: number | null } | null | undefined,
+  build: {
+    release_version?: string | null
+    binary_commit?: string | null
+    repo_head_commit?: string | null
+    uptime_seconds?: number | null
+  } | null | undefined,
   fallbackVersion: string | null | undefined,
 ): string {
   if (!build && !fallbackVersion) return 'Build unavailable'
   const lines: string[] = ['Server build']
   const version = build?.release_version ?? fallbackVersion
   if (version != null && version !== '') {
-    const commit = build?.commit != null && build.commit !== ''
-      ? ` · ${shortCommit(build.commit)}`
-      : ' · dev'
-    lines.push(`  · v${version}${commit}`)
+    const binary = build?.binary_commit != null && build.binary_commit !== ''
+      ? shortCommit(build.binary_commit)
+      : 'binary commit unknown'
+    lines.push(`  · v${version} · ${binary}`)
+  }
+  if (build?.repo_head_commit != null && build.repo_head_commit !== '') {
+    lines.push(`  · Checkout ${shortCommit(build.repo_head_commit)}`)
   }
   const uptime = formatUptimeSecondsHuman(build?.uptime_seconds)
   if (uptime !== 'Unknown') {
@@ -772,9 +780,9 @@ export function BuildIdentityBadge() {
   const status = serverStatus.value
   const build = status?.build
   const label = build
-    ? `v${build.release_version} · ${shortCommit(build.commit)}`
+    ? `v${build.release_version} · ${build.binary_commit ? shortCommit(build.binary_commit) : 'binary unknown'}`
     : status?.version
-      ? `v${status.version} · dev`
+      ? `v${status.version} · binary unknown`
       : 'Build unavailable'
   const hoverTitle = composeBuildBadgeTitle(build, status?.version)
 
@@ -797,8 +805,11 @@ export function BuildIdentityBadge() {
               <${BuildInfoRow} label="Release">
                 <strong class="text-[color:var(--color-fg-secondary)] text-right">${build?.release_version ?? status?.version ?? 'unknown'}</strong>
               <//>
-              <${BuildInfoRow} label="Commit">
-                <strong class="text-[color:var(--color-fg-secondary)] text-right">${build?.commit ?? 'git not detected (dev)'}</strong>
+              <${BuildInfoRow} label="Binary commit">
+                <strong class="text-[color:var(--color-fg-secondary)] text-right">${build?.binary_commit ?? 'Unknown (build identity absent)'}</strong>
+              <//>
+              <${BuildInfoRow} label="Checkout head">
+                <strong class="text-[color:var(--color-fg-secondary)] text-right">${build?.repo_head_commit ?? 'Unknown'}</strong>
               <//>
               <${BuildInfoRow} label="Server started">
                 <strong class="text-[color:var(--color-fg-secondary)] text-right">${build?.started_at ? html`<${TimeAgo} timestamp=${build.started_at} />` : 'Unknown'}</strong>

--- a/dashboard/src/components/keeper-detail-runtime.test.ts
+++ b/dashboard/src/components/keeper-detail-runtime.test.ts
@@ -910,13 +910,18 @@ describe('RuntimeLensSection', () => {
         server_repo_git_commit: '386514c1f9',
         workspace_git_commit: 'd0add960d7',
         server_repo_path: { path: '/repo/.worktrees/stale-server' },
+        build: {
+          binary_commit: 'a1b2c3d4e5f6',
+        },
       },
     })
 
     expect(summary.tone).toBe('warn')
     expect(summary.runtimeWarnings).toEqual(['Runtime build commit differs from server repo HEAD.'])
-    expect(summary.runtimeBuildLabel).toBe('386514c1f9 vs workspace d0add960d7')
-    expect(summary.runtimeRepoLabel).toBe('.worktrees/stale-server')
+    expect(summary.runtimeBuildLabel).toBe('a1b2c3d4e5')
+    expect(summary.runtimeRepoLabel).toBe(
+      '.worktrees/stale-server · head 386514c1f9 · workspace d0add960d7',
+    )
   })
 
   it('renders secret projection status without secret values', () => {

--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -493,7 +493,7 @@ function RuntimeTruthPanel({ runtimeResolution }: { runtimeResolution: Dashboard
         <${RuntimeMetaRow} label="effective base" value=${runtimeResolution.resolved_base_path.path ?? MISSING_DATA_DASH} />
         <${RuntimeMetaRow} label="effective .masc" value=${runtimeResolution.data_root.path ?? MISSING_DATA_DASH} />
         <${RuntimeMetaRow} label="server repo" value=${runtimeResolution.server_repo_path?.path ?? MISSING_DATA_DASH} />
-        <${RuntimeMetaRow} label="executable commit" value=${runtimeResolution.build.commit ?? MISSING_DATA_DASH} />
+        <${RuntimeMetaRow} label="executable commit" value=${runtimeResolution.build.binary_commit ?? MISSING_DATA_DASH} />
         <${RuntimeMetaRow} label="keeper fibers" value=${String(fleet?.keeper_fibers ?? MISSING_DATA_DASH)} />
         <${RuntimeMetaRow} label="fd active operations" value=${activeOperations == null ? MISSING_DATA_DASH : String(activeOperations)} />
         <${RuntimeMetaRow} label="fd resource errors (total)" value=${resourceErrors == null ? MISSING_DATA_DASH : String(resourceErrors)} />
@@ -808,7 +808,7 @@ export function ConfigResolutionPanel({
                 <${RuntimeMetaRow} label="server repo head" value=${runtimeResolution.server_repo_git_commit ?? MISSING_DATA_DASH} />
                 <${RuntimeMetaRow} label="workspace head" value=${runtimeResolution.workspace_git_commit ?? MISSING_DATA_DASH} />
                 <${RuntimeMetaRow} label="resolved base head" value=${runtimeResolution.resolved_base_git_commit ?? MISSING_DATA_DASH} />
-                <${RuntimeMetaRow} label="runtime build" value=${runtimeResolution.build.commit ?? runtimeResolution.build.release_version} />
+                <${RuntimeMetaRow} label="runtime build" value=${runtimeResolution.build.binary_commit ?? MISSING_DATA_DASH} />
                 <${RuntimeMetaRow} label="started at" value=${runtimeResolution.build.started_at} />
               </div>
 

--- a/dashboard/src/lib/keeper-runtime-projection.ts
+++ b/dashboard/src/lib/keeper-runtime-projection.ts
@@ -52,6 +52,7 @@ export interface KeeperRuntimeProjectionRuntimeInput {
   readonly workspace_git_commit?: string | null
   readonly build?: {
     readonly commit?: string | null
+    readonly binary_commit?: string | null
     readonly started_at?: string | null
   } | null
 }
@@ -180,18 +181,18 @@ export function deriveKeeperRuntimeProjection({
         ? `${formatDuration(keeper.last_turn_ago_s)} since turn`
         : 'idle age unknown'
   const runtimeReason = compactToken(opState.displaySummary, 'no blocker reason')
-  const runtimeCommit =
-    shortCommit(runtimeResolution?.server_repo_git_commit)
-    ?? shortCommit(runtimeResolution?.build?.commit)
+  const runtimeCommit = shortCommit(runtimeResolution?.build?.binary_commit)
   const workspaceCommit = shortCommit(runtimeResolution?.workspace_git_commit)
   const runtimeBuildLabel = runtimeCommit
-    ? workspaceCommit && workspaceCommit !== runtimeCommit
-      ? `${runtimeCommit} vs workspace ${workspaceCommit}`
-      : runtimeCommit
-    : null
-  const runtimeRepoLabel = runtimeResolution?.server_repo_path?.path
+  const runtimeRepoPath = runtimeResolution?.server_repo_path?.path
     ? runtimeResolution.server_repo_path.path.split('/').slice(-2).join('/')
     : null
+  const runtimeRepoCommit = shortCommit(runtimeResolution?.server_repo_git_commit)
+  const runtimeRepoLabel = [
+    runtimeRepoPath,
+    runtimeRepoCommit ? `head ${runtimeRepoCommit}` : null,
+    workspaceCommit ? `workspace ${workspaceCommit}` : null,
+  ].filter((value): value is string => value !== null).join(' · ') || null
 
   const signals = buildProjectionSignals({
     opState,

--- a/dashboard/src/namespace-truth-store.test.ts
+++ b/dashboard/src/namespace-truth-store.test.ts
@@ -69,6 +69,11 @@ describe('refreshNamespaceTruth', () => {
     expect(mergedBuild?.build).toEqual({
       release_version: '2.148.0',
       commit: '2897da06',
+      commit_source: null,
+      binary_commit: null,
+      binary_commit_source: null,
+      repo_head_commit: null,
+      repo_head_commit_source: null,
       started_at: '2026-03-25T08:05:54Z',
       uptime_seconds: 588,
     })

--- a/dashboard/src/store-normalizers.test.ts
+++ b/dashboard/src/store-normalizers.test.ts
@@ -15,6 +15,12 @@ import type { Message } from './types'
 const configItem = { path: '/tmp/masc', source: 'test', exists: true }
 const build = {
   release_version: 'dev',
+  commit: 'checkout-fallback',
+  commit_source: 'runtime_repo_head',
+  binary_commit: null,
+  binary_commit_source: null,
+  repo_head_commit: 'checkout-fallback',
+  repo_head_commit_source: 'runtime_repo_head',
   started_at: '2026-05-17T00:00:00Z',
   uptime_seconds: 12,
 }
@@ -255,6 +261,19 @@ describe('mergeMessages', () => {
 })
 
 describe('normalizeDashboardRuntimeResolution fleet safety', () => {
+  it('preserves binary and checkout identities as separate runtime facts', () => {
+    const result = normalizeDashboardRuntimeResolution(runtimeResolutionRaw())
+
+    expect(result?.build).toMatchObject({
+      commit: 'checkout-fallback',
+      commit_source: 'runtime_repo_head',
+      binary_commit: null,
+      binary_commit_source: null,
+      repo_head_commit: 'checkout-fallback',
+      repo_head_commit_source: 'runtime_repo_head',
+    })
+  })
+
   it('projects only the active stream and body timeout fields', () => {
     const result = normalizeDashboardRuntimeResolution(runtimeResolutionRaw({
       keeper_runtime: {

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -948,6 +948,11 @@ export function normalizeBuildIdentity(raw: unknown): ServerStatus['build'] | un
   return {
     release_version: releaseVersion,
     commit: asString(raw.commit) ?? null,
+    commit_source: asString(raw.commit_source) ?? null,
+    binary_commit: asString(raw.binary_commit) ?? null,
+    binary_commit_source: asString(raw.binary_commit_source) ?? null,
+    repo_head_commit: asString(raw.repo_head_commit) ?? null,
+    repo_head_commit_source: asString(raw.repo_head_commit_source) ?? null,
     started_at: startedAt,
     uptime_seconds: uptimeSeconds,
   }

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -447,6 +447,11 @@ export interface DashboardNamespaceTruthResponse {
 export interface ServerBuildIdentity {
   release_version: string
   commit?: string | null
+  commit_source?: string | null
+  binary_commit?: string | null
+  binary_commit_source?: string | null
+  repo_head_commit?: string | null
+  repo_head_commit_source?: string | null
   started_at: string
   uptime_seconds: number
 }


### PR DESCRIPTION
## As-Is

The Dashboard rendered `build.commit` as the executable commit even when `commit_source=runtime_repo_head`. A stale binary could therefore display the current checkout SHA while running older behavior.

Live reproduction: the running 0.22.0 process reported `commit=13dd32a37a` from `runtime_repo_head`, while `/api/v1/keepers/canary-sandbox-glm-20260814-0123/config` still returned the pre-fix raw `local/inherit/true/true` projection instead of its TOML `docker/none/false/false` policy.

## To-Be

- Preserve `binary_commit` and repo-head provenance through the shared Dashboard normalizer.
- Use only `binary_commit` for executable/build labels.
- Render repo path, repo head, and workspace head as separate observations.
- Render missing binary evidence as `binary unknown`; do not infer `dev` or promote checkout HEAD.
- Leave divergence judgment to the backend `source_mismatch`/warning contract.

## Scope and verification

- 9 Dashboard files, including focused feature fixtures.
- Independent adversarial source review: P0/P1/P2 none.
- PASS: Node 26 TypeScript syntax parse for every changed file; `git diff --check`.
- Not run locally: Dashboard typecheck/Vitest/ESLint because this clean worktree has no `node_modules`; exact-head CI owns them.
- No local Dune/build and no runtime mutation in this PR.
