### PR TITLE
fix(tools): declare title on the masc_board_post schema

### DIFF
--- a/lib/tool_surface/tool_shard_types_board_keeper_projection.ml
+++ b/lib/tool_surface/tool_shard_types_board_keeper_projection.ml
@@ -19,7 +19,15 @@ let schemas : Masc_domain.tool_schema list =
           [ "type", `String "object"
           ; ( "properties"
             , `Assoc
-                [ ( "content"
+                [ ( "title"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "description"
+                        , `String
+                            "Optional post title shown in board lists. Must not be blank \
+                             when present; omit for short untitled posts." )
+                      ] )
+                ; ( "content"
                   , `Assoc
                       [ "type", `String "string"
                       ; "description", `String "Post body text"

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -601,6 +601,62 @@ let test_validate_args_masc_board_post_accepts_sources_array () =
       "expected masc_board_post sources array to pass validation, got %s"
       (Yojson.Safe.to_string (Tool_result.data result))
 
+(* Live keepers titled their posts 44 times on 2026-08-13 and every attempt
+   was rejected as an undeclared field, even though the handler
+   (Board_tool_post.handle_post_create) and the store both carry titles.
+   The schema is the only layer that hid the field. *)
+let test_validate_args_masc_board_post_accepts_title () =
+  match
+    Tool_input_validation.validate_args
+      ~schema:keeper_model_board_post_schema
+      ~name:"masc_board_post"
+      ~args:
+        (`Assoc
+          [ "title", `String "Turn continuity findings"
+          ; "content", `String "Keeper board post with a list title"
+          ; "hearth", `String "ops"
+          ])
+      ()
+  with
+  | Ok forwarded ->
+    (match Yojson.Safe.Util.member "title" forwarded with
+     | `String value ->
+       Alcotest.(check string) "title preserved" "Turn continuity findings" value
+     | other ->
+       Alcotest.failf
+         "expected title to be preserved, got %s"
+         (Yojson.Safe.to_string other))
+  | Error result ->
+    Alcotest.failf
+      "expected masc_board_post title to pass validation, got %s"
+      (Yojson.Safe.to_string (Tool_result.data result))
+
+(* Declaring title must not loosen the closed schema: tags stays undeclared
+   and rejected. *)
+let test_validate_args_masc_board_post_still_rejects_tags () =
+  match
+    Tool_input_validation.validate_args
+      ~schema:keeper_model_board_post_schema
+      ~name:"masc_board_post"
+      ~args:
+        (`Assoc
+          [ "title", `String "Turn continuity findings"
+          ; "content", `String "body"
+          ; "tags", `List [ `String "ops" ]
+          ])
+      ()
+  with
+  | Ok forwarded ->
+    Alcotest.failf
+      "expected tags to be rejected, but it passed: %s"
+      (Yojson.Safe.to_string forwarded)
+  | Error result ->
+    let msg = Yojson.Safe.to_string (Tool_result.data result) in
+    Alcotest.(check bool)
+      "error names tags"
+      true
+      (string_contains msg "unsupported field(s): tags")
+
 let test_registered_hook_masc_board_post_accepts_sources_array () =
   let blocked, forwarded =
     run_registered_hook
@@ -2257,6 +2313,10 @@ let () =
         test_validate_args_uses_explicit_schema_without_registry;
       Alcotest.test_case "direct masc_board_post accepts sources array" `Quick
         test_validate_args_masc_board_post_accepts_sources_array;
+      Alcotest.test_case "direct masc_board_post accepts title" `Quick
+        test_validate_args_masc_board_post_accepts_title;
+      Alcotest.test_case "direct masc_board_post still rejects tags" `Quick
+        test_validate_args_masc_board_post_still_rejects_tags;
       Alcotest.test_case "masc_transition rejects to/note aliases" `Quick
         test_registered_hook_transition_rejects_to_and_note;
       Alcotest.test_case "masc_transition canonical action value" `Quick


### PR DESCRIPTION
## 문제 (라이브 실측)

2026-08-13 하루 동안 keeper들이 board post에 제목을 달려는 시도 **44건**이 전부 거부됐습니다:

```
Tool 'masc_board_post' received unsupported field(s): tags, title   (23건)
Tool 'masc_board_post' received unsupported field(s): category, title (21건)
```

거부당한 keeper는 4초 뒤 title 없이 재시도해 성공합니다 — 기능 실패는 아니지만 매번 거부 왕복 1회 + 에러 로그 3줄이 낭비됩니다.

## 원인 — 3층 중 스키마만 title을 숨김

| 층 | title 지원 |
|---|---|
| 저장 (`board_posts.jsonl` 레코드, `create_post ?title`) | ✓ |
| 핸들러 (`Board_tool_post.handle_post_create` — 파싱 + 공백 거부까지 구현) | ✓ |
| 도구 스키마 (`tool_shard_types_board_keeper_projection.ml`) | ✗ ← 유일한 구멍 |

keeper의 title 시도는 통념 환각이 아니라 저장소가 이미 지원하는 정당한 표면 요구였고, `additionalProperties: false` 검증이 핸들러 도달 전에 끊고 있었습니다.

## 수정

- 스키마 properties에 `title` (optional string) 선언 — 핸들러/저장과 정렬
- 닫힌 스키마는 유지: `tags`/`category`/`sub_board`는 여전히 거부 (저장 모델에 없음; hearth가 채널 표면)

## 테스트 (`test_tool_input_validation`)

- `direct masc_board_post accepts title` — model-visible 실스키마 기반이라 **수정 전 코드에서는 FAIL** (title이 unsupported로 거부됨)
- `direct masc_board_post still rejects tags` — title 선언이 닫힌 스키마를 느슨하게 만들지 않음을 고정

## 검증 명령

```
rg -c "masc_board_post' received unsupported" ~/me/.masc/logs/system_log_2026-08-13.jsonl   # 47 (수정 전 실측)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)