### PR TITLE
ci: produce trusted macOS arm64 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1563,6 +1563,302 @@ jobs:
             echo "::notice::main_eio.exe not found, skipping config-diagnostic"
           fi
 
+  trusted-macos-arm64-runtime:
+    name: Trusted macOS arm64 Runtime
+    runs-on: macos-14
+    needs: [pr-live-gate, changes, ci-gate]
+    if: >-
+      ${{
+        always() &&
+        !cancelled() &&
+        (
+          github.event_name == 'push' ||
+          github.event_name == 'workflow_dispatch'
+        ) &&
+        github.ref == 'refs/heads/main' &&
+        github.ref_protected == true &&
+        needs.pr-live-gate.outputs.run_heavy == 'true' &&
+        needs.changes.result == 'success' &&
+        needs.changes.outputs.keeper_realworld == 'true' &&
+        needs.ci-gate.result == 'success'
+      }}
+    timeout-minutes: 60
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout exact protected-main revision
+        uses: actions/checkout@v7
+
+      - name: Verify protected-main source provenance
+        env:
+          EXPECTED_SOURCE_SHA: ${{ github.sha }}
+          EXPECTED_SOURCE_REF: ${{ github.ref }}
+          EXPECTED_REF_PROTECTED: ${{ github.ref_protected }}
+          EXPECTED_WORKFLOW_REF: ${{ github.workflow_ref }}
+          EXPECTED_WORKFLOW_SHA: ${{ github.workflow_sha }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          expected_workflow_ref="${GITHUB_REPOSITORY}/.github/workflows/ci.yml@refs/heads/main"
+          case "$EVENT_NAME" in
+            push|workflow_dispatch) ;;
+            *)
+              echo "trusted macOS runtime requires push or workflow_dispatch, got $EVENT_NAME" >&2
+              exit 1
+              ;;
+          esac
+          if [ "$EXPECTED_SOURCE_REF" != "refs/heads/main" ]; then
+            echo "trusted macOS runtime requires refs/heads/main, got $EXPECTED_SOURCE_REF" >&2
+            exit 1
+          fi
+          if [ "$EXPECTED_REF_PROTECTED" != "true" ]; then
+            echo "trusted macOS runtime requires protected main" >&2
+            exit 1
+          fi
+          if [ "$EXPECTED_WORKFLOW_REF" != "$expected_workflow_ref" ]; then
+            echo "workflow ref mismatch: expected=$expected_workflow_ref actual=$EXPECTED_WORKFLOW_REF" >&2
+            exit 1
+          fi
+          if [ "$EXPECTED_WORKFLOW_SHA" != "$EXPECTED_SOURCE_SHA" ]; then
+            echo "workflow/source mismatch: workflow=$EXPECTED_WORKFLOW_SHA source=$EXPECTED_SOURCE_SHA" >&2
+            exit 1
+          fi
+          actual_source_sha="$(git rev-parse HEAD)"
+          if [ "$actual_source_sha" != "$EXPECTED_SOURCE_SHA" ]; then
+            echo "checkout mismatch: expected=$EXPECTED_SOURCE_SHA actual=$actual_source_sha" >&2
+            exit 1
+          fi
+
+      - name: Setup OCaml
+        uses: ./.github/actions/setup-ocaml-toolchain
+
+      - name: Install native dependencies
+        run: |
+          set -euo pipefail
+          brew install flock gmp libpq openssl@3 zstd
+
+          libpq_prefix="$(brew --prefix libpq)"
+          openssl_prefix="$(brew --prefix openssl@3)"
+
+          {
+            echo "$libpq_prefix/bin"
+            echo "$openssl_prefix/bin"
+          } >> "$GITHUB_PATH"
+
+          {
+            echo "PKG_CONFIG_PATH=$openssl_prefix/lib/pkgconfig:$libpq_prefix/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+            echo "CPATH=$openssl_prefix/include:${CPATH:-}"
+            echo "LIBRARY_PATH=$openssl_prefix/lib:${LIBRARY_PATH:-}"
+            echo "CPPFLAGS=-I$openssl_prefix/include ${CPPFLAGS:-}"
+            echo "LDFLAGS=-L$openssl_prefix/lib ${LDFLAGS:-}"
+          } >> "$GITHUB_ENV"
+
+      - name: Pin private dependencies
+        run: |
+          set -euo pipefail
+          command -v flock >/dev/null
+          chmod +x scripts/opam-pin-external-deps.sh
+          scripts/opam-pin-external-deps.sh --with-compact-protocol
+
+      - name: Install OCaml dependencies
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            opam install . --deps-only -y && break
+            if [ "$attempt" -eq 3 ]; then
+              echo "opam install failed after ${attempt} attempts" >&2
+              exit 1
+            fi
+            echo "opam install failed (attempt ${attempt}); retrying in 15s..." >&2
+            sleep 15
+          done
+
+      - name: Build macOS arm64 runtime
+        run: opam exec -- dune build --release bin/main_eio.exe
+
+      - name: Verify architecture, dylibs, and runtime smoke
+        env:
+          EXPECTED_SOURCE_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          binary=_build/default/bin/main_eio.exe
+          if [ "$RUNNER_OS" != "macOS" ]; then
+            echo "expected macOS runner, got $RUNNER_OS" >&2
+            exit 1
+          fi
+          machine="$(uname -m)"
+          if [ "$machine" != "arm64" ]; then
+            echo "expected arm64 runner, got $machine" >&2
+            exit 1
+          fi
+          file_output="$(file "$binary")"
+          printf '%s\n' "$file_output"
+          case "$file_output" in
+            *"Mach-O 64-bit executable arm64"*) ;;
+            *)
+              echo "runtime is not a Mach-O arm64 executable" >&2
+              exit 1
+              ;;
+          esac
+          lipo_archs="$(lipo -archs "$binary")"
+          if [ "$lipo_archs" != "arm64" ]; then
+            echo "expected only arm64 architecture, got: $lipo_archs" >&2
+            exit 1
+          fi
+          otool -L "$binary" | tee "$RUNNER_TEMP/masc-runtime-otool.txt"
+          while IFS= read -r dylib; do
+            case "$dylib" in
+              /usr/lib/*|/System/Library/*) ;;
+              /opt/homebrew/opt/gmp/*|/opt/homebrew/opt/libpq/*|/opt/homebrew/opt/openssl@3/*|/opt/homebrew/opt/zstd/*) ;;
+              *)
+                echo "runtime links an unsupported dylib path: $dylib" >&2
+                exit 1
+                ;;
+            esac
+          done < <(awk 'NR > 1 { print $1 }' "$RUNNER_TEMP/masc-runtime-otool.txt")
+          chmod +x scripts/release-binary-smoke.sh
+          MASC_BUILD_GIT_COMMIT="$EXPECTED_SOURCE_SHA" \
+            scripts/release-binary-smoke.sh "$binary"
+
+          identity_root="$(mktemp -d "$RUNNER_TEMP/masc-build-identity.XXXXXX")"
+          identity_log="$identity_root/server.log"
+          identity_health="$identity_root/health.json"
+          identity_port=18936
+          identity_pid=""
+          cleanup_identity_probe() {
+            if [ -n "$identity_pid" ]; then
+              kill "$identity_pid" 2>/dev/null || true
+              wait "$identity_pid" 2>/dev/null || true
+            fi
+            rm -rf "$identity_root"
+          }
+          trap cleanup_identity_probe EXIT
+          mkdir -p "$identity_root/.masc/config"
+          cp config/runtime.toml "$identity_root/.masc/config/runtime.toml"
+          MASC_BUILD_GIT_COMMIT="$EXPECTED_SOURCE_SHA" \
+          MASC_BASE_PATH="$identity_root" \
+          MASC_BASE_PATH_INPUT="$identity_root" \
+          MASC_KEEPER_AUTONOMOUS_ENABLED=false \
+          MASC_OTEL_ENABLED=0 \
+            "$binary" --base-path "$identity_root" --port "$identity_port" \
+            >"$identity_log" 2>&1 &
+          identity_pid=$!
+          identity_ready=false
+          for _attempt in $(seq 1 50); do
+            if curl -fsS --max-time 2 \
+                "http://127.0.0.1:${identity_port}/health" >"$identity_health"
+            then
+              identity_ready=true
+              break
+            fi
+            if ! kill -0 "$identity_pid" 2>/dev/null; then
+              echo "runtime exited before build-identity health probe" >&2
+              tail -50 "$identity_log" >&2
+              exit 1
+            fi
+            sleep 0.2
+          done
+          if [ "$identity_ready" != "true" ]; then
+            echo "runtime did not expose health for build-identity probe" >&2
+            tail -50 "$identity_log" >&2
+            exit 1
+          fi
+          actual_binary_commit="$(jq -r '.build.binary_commit // empty' "$identity_health")"
+          if [ "$actual_binary_commit" != "$EXPECTED_SOURCE_SHA" ]; then
+            echo "runtime build identity mismatch: expected=$EXPECTED_SOURCE_SHA actual=${actual_binary_commit:-null}" >&2
+            exit 1
+          fi
+          cleanup_identity_probe
+          trap - EXIT
+
+      - name: Package trusted macOS arm64 runtime
+        env:
+          EXPECTED_SOURCE_SHA: ${{ github.sha }}
+          EXPECTED_SOURCE_REF: ${{ github.ref }}
+          EXPECTED_REF_PROTECTED: ${{ github.ref_protected }}
+          EXPECTED_WORKFLOW_REF: ${{ github.workflow_ref }}
+          EXPECTED_WORKFLOW_SHA: ${{ github.workflow_sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_RUN_ID: ${{ github.run_id }}
+          WORKFLOW_RUN_ATTEMPT: ${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          runtime_dir=trusted-macos-arm64-runtime
+          mkdir -p "$runtime_dir"
+          cp _build/default/bin/main_eio.exe "$runtime_dir/masc"
+          chmod +x "$runtime_dir/masc"
+          binary_sha256="$(scripts/lib/runtime-artifact-contract.sh hash "$runtime_dir/masc")"
+          actual_source_sha="$(git rev-parse HEAD)"
+          linked_dylibs_json="$(
+            awk 'NR > 1 { print $1 }' "$RUNNER_TEMP/masc-runtime-otool.txt" \
+              | jq -Rsc 'split("\n") | map(select(length > 0))'
+          )"
+          jq -n \
+            --arg schema "masc.trusted_runtime.v1" \
+            --arg event_name "$EVENT_NAME" \
+            --arg source_sha "$actual_source_sha" \
+            --arg source_ref "$EXPECTED_SOURCE_REF" \
+            --argjson source_ref_protected "$EXPECTED_REF_PROTECTED" \
+            --arg workflow_ref "$EXPECTED_WORKFLOW_REF" \
+            --arg workflow_sha "$EXPECTED_WORKFLOW_SHA" \
+            --arg workflow_run_id "$WORKFLOW_RUN_ID" \
+            --arg workflow_run_attempt "$WORKFLOW_RUN_ATTEMPT" \
+            --arg target_os "macos" \
+            --arg target_arch "arm64" \
+            --arg binary_format "mach-o" \
+            --arg binary_sha256 "$binary_sha256" \
+            --argjson linked_dylibs "$linked_dylibs_json" \
+            '{
+              schema: $schema,
+              event_name: $event_name,
+              source_sha: $source_sha,
+              source_ref: $source_ref,
+              source_ref_protected: $source_ref_protected,
+              workflow_ref: $workflow_ref,
+              workflow_sha: $workflow_sha,
+              workflow_run_id: $workflow_run_id,
+              workflow_run_attempt: $workflow_run_attempt,
+              target_os: $target_os,
+              target_arch: $target_arch,
+              binary_format: $binary_format,
+              binary_sha256: $binary_sha256,
+              required_launch_env: {
+                MASC_BUILD_GIT_COMMIT: $source_sha
+              },
+              linked_dylibs: $linked_dylibs,
+              supported_homebrew_prefixes: [
+                "/opt/homebrew/opt/gmp/",
+                "/opt/homebrew/opt/libpq/",
+                "/opt/homebrew/opt/openssl@3/",
+                "/opt/homebrew/opt/zstd/"
+              ]
+            }' > "$runtime_dir/manifest.json"
+          jq -e \
+            --arg source_sha "$EXPECTED_SOURCE_SHA" \
+            --arg workflow_sha "$EXPECTED_WORKFLOW_SHA" \
+            --arg binary_sha256 "$binary_sha256" \
+            '.schema == "masc.trusted_runtime.v1" and
+             .source_sha == $source_sha and
+             .workflow_sha == $workflow_sha and
+             .source_ref == "refs/heads/main" and
+             .source_ref_protected == true and
+             .target_os == "macos" and
+             .target_arch == "arm64" and
+             .binary_format == "mach-o" and
+             .binary_sha256 == $binary_sha256 and
+             .required_launch_env.MASC_BUILD_GIT_COMMIT == $source_sha and
+             (.linked_dylibs | type == "array" and length > 0)' \
+            "$runtime_dir/manifest.json" >/dev/null
+
+      - name: Upload trusted macOS arm64 runtime
+        uses: actions/upload-artifact@v7
+        with:
+          name: masc-runtime-macos-arm64-${{ github.run_id }}-${{ github.run_attempt }}
+          path: trusted-macos-arm64-runtime/
+          if-no-files-found: error
+          retention-days: 7
+
   keeper-realworld-acceptance:
     name: Keeper Real-World Acceptance
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,16 +45,10 @@ jobs:
       - name: Setup OCaml
         uses: ./.github/actions/setup-ocaml-toolchain
 
-      - name: Pin private dependencies
-        run: |
-          chmod +x scripts/opam-pin-external-deps.sh
-          scripts/opam-pin-external-deps.sh --with-compact-protocol
-
-
       - name: Install native dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
-          brew install libpq openssl@3
+          brew install flock gmp libpq openssl@3 zstd
 
           libpq_prefix="$(brew --prefix libpq)"
           openssl_prefix="$(brew --prefix openssl@3)"
@@ -71,6 +65,11 @@ jobs:
             echo "CPPFLAGS=-I$openssl_prefix/include ${CPPFLAGS:-}"
             echo "LDFLAGS=-L$openssl_prefix/lib ${LDFLAGS:-}"
           } >> "$GITHUB_ENV"
+
+      - name: Pin private dependencies
+        run: |
+          chmod +x scripts/opam-pin-external-deps.sh
+          scripts/opam-pin-external-deps.sh --with-compact-protocol
 
       - name: Refresh apt index
         if: runner.os == 'Linux'

--- a/packages/agent_core/lib/llm_provider/capabilities.ml
+++ b/packages/agent_core/lib/llm_provider/capabilities.ml
@@ -1306,7 +1306,7 @@ let thinking_control_token_for_model_id_with_manifest manifest model_id =
   | None -> thinking_control_token_for_model_id_catalog model_id
 ;;
 
-let thinking_control_token_for_model_id model_id =
+let[@warning "-32"] thinking_control_token_for_model_id model_id =
   match Model_catalog.global () with
   | Some catalog ->
     (match Model_catalog.lookup catalog model_id with
@@ -1472,7 +1472,7 @@ let test_catalog_entry id_prefix : Model_catalog.model_entry =
   }
 ;;
 
-let test_manifest_entry id_prefix : Capability_manifest.entry =
+let[@warning "-32"] test_manifest_entry id_prefix : Capability_manifest.entry =
   { id_prefix
   ; base_label = None
   ; max_context_tokens = None
@@ -1707,7 +1707,7 @@ let test_catalog : Model_catalog.t = Model_catalog.of_model_entries test_catalog
 
 (* Installs [test_catalog] as the runtime override for the duration of [f],
    then clears the override so subsequent lookups use the embedded catalog. *)
-let with_test_catalog f =
+let[@warning "-32"] with_test_catalog f =
   Model_catalog.set_global test_catalog;
   Fun.protect ~finally:Model_catalog.clear_global f
 ;;

--- a/packages/agent_core/lib/llm_provider/pricing.ml
+++ b/packages/agent_core/lib/llm_provider/pricing.ml
@@ -129,12 +129,19 @@ let annotate_response_cost ?provider_id (response : Types.api_response) =
 
 let close_enough a b = Float.abs (a -. b) < 1e-9
 
-let option_close_enough expected = function
+let[@warning "-32"] option_close_enough expected = function
   | Some actual -> close_enough expected actual
   | None -> false
 ;;
 
-let test_catalog_entry ?provider_name ?input ?output ?cache_write ?cache_read id_prefix =
+let[@warning "-32"] test_catalog_entry
+      ?provider_name
+      ?input
+      ?output
+      ?cache_write
+      ?cache_read
+      id_prefix
+  =
   { Model_catalog.id_prefix
   ; base_label = None
   ; provider_name
@@ -184,7 +191,7 @@ let test_catalog_entry ?provider_name ?input ?output ?cache_write ?cache_read id
   }
 ;;
 
-let with_catalog entries f =
+let[@warning "-32"] with_catalog entries f =
   let original = Model_catalog.global () in
   Model_catalog.set_global (Model_catalog.of_model_entries entries);
   Fun.protect

--- a/packages/agent_core/lib/llm_provider/provider_admission_state.ml
+++ b/packages/agent_core/lib/llm_provider/provider_admission_state.ml
@@ -80,7 +80,9 @@ let find_scheduler key state =
     state
 ;;
 
-let test_key = key ~kind:"test" ~base_url:"https://provider.test" ~secret:None
+let[@warning "-32"] test_key =
+  key ~kind:"test" ~base_url:"https://provider.test" ~secret:None
+;;
 
 let%test "first declaration installs its scheduler" =
   let state, resolution =

--- a/packages/agent_core/lib/llm_provider/slot_scheduler.ml
+++ b/packages/agent_core/lib/llm_provider/slot_scheduler.ml
@@ -221,7 +221,7 @@ let permit_is_held p = p.state = Held
 [@@@coverage off]
 (* === Inline tests === *)
 
-let await_queue_length clock t expected =
+let[@warning "-32"] await_queue_length clock t expected =
   Eio.Time.with_timeout_exn clock 1.0 (fun () ->
     while queue_length t < expected do
       Eio.Fiber.yield ()

--- a/packages/agent_core/lib/llm_provider/tool_result_projection.ml
+++ b/packages/agent_core/lib/llm_provider/tool_result_projection.ml
@@ -183,13 +183,13 @@ let content resolved = resolved.content
 
 [@@@coverage off]
 
-let message role content : Types.message =
+let[@warning "-32"] message role content : Types.message =
   { role; content; name = None; tool_call_id = None; metadata = [] }
 ;;
 
-let tool_use id name = ToolUse { id; name; input = `Assoc [] }
+let[@warning "-32"] tool_use id name = ToolUse { id; name; input = `Assoc [] }
 
-let tool_result id =
+let[@warning "-32"] tool_result id =
   ToolResult
     { tool_use_id = id
     ; content = "ok"
@@ -199,7 +199,7 @@ let tool_result id =
     }
 ;;
 
-let projected_tool_names projection =
+let[@warning "-32"] projected_tool_names projection =
   projection |> messages |> List.concat_map content |> List.filter_map snd
 ;;
 

--- a/packages/agent_core/lib/llm_provider/utf8_sanitize.ml
+++ b/packages/agent_core/lib/llm_provider/utf8_sanitize.ml
@@ -62,7 +62,7 @@ let sanitize s =
 (* === Inline tests === *)
 
 (** Every sanitized output is, by construction, valid UTF-8. *)
-let is_valid out = String.is_valid_utf_8 out
+let[@warning "-32"] is_valid out = String.is_valid_utf_8 out
 
 let%test "ascii only unchanged" =
   let s = "Hello, world 123" in


### PR DESCRIPTION
## What

- add an independent hard-failing protected-main macOS arm64 runtime artifact job
- bind the artifact manifest to the exact source/workflow SHA, Mach-O arm64 bytes, SHA-256, supported dylibs, and required `MASC_BUILD_GIT_COMMIT`
- launch the exact built binary and assert `/health.build.binary_commit` before packaging
- install `flock` before private dependency pinning on macOS
- keep release-profile warning suppression binding-local to helpers used only by stripped inline tests

## Why

The existing trusted runtime artifact is Linux x86-64 and cannot restore the target macOS arm64 host. The current macOS release lane also failed before compilation because `opam-rw-lock` could not find `lockf` or `flock`; after that was repaired, release-profile compilation exposed inline-test-only helpers as unused when tests were stripped.

## Impact and boundaries

- the existing Linux real-world artifact and Ubuntu acceptance path are unchanged
- the new artifact is emitted only from protected `main` push/workflow-dispatch after the existing heavy CI gate
- unresolved `@rpath`/loader-relative or arbitrary Cellar dylibs are rejected; only system paths and four stable Homebrew opt prefixes are admitted
- deployment is not performed by this PR: the target host must verify manifest digest, Mach-O arm64, dylibs, candidate launch, and exact health identity before atomic promotion

## Checks

- `actionlint -shellcheck= .github/workflows/ci.yml .github/workflows/release.yml`
- `ocamlformat --check` on the six changed OCaml files
- `ocamlc -stop-after parsing` on the six changed OCaml files
- `git diff --check`
- independent adversarial source review: P0/P1/P2 none
- no local Dune build or test run; exact-head CI owns build/test proof

# ci:skip-test-coverage
