### PR TITLE
fix(ide): reads never seed the store, slugs must be structural

### DIFF
--- a/lib/agent_observation/agent_observation.ml
+++ b/lib/agent_observation/agent_observation.ml
@@ -138,8 +138,8 @@ module Code_address = struct
      [path_segment_to_slug], so every slug [canonical_url_of_remote] can
      emit is accepted and nothing outside that alphabet is. Structure is
      part of the acceptance too: every canonical slug joins a host and at
-     least one path segment with ['_'], so a bare token ("github") is not
-     an address. Live proof 2026-08-14: minutes after the RFC-0378 cut a
+     least one path segment with ['_'], so a bare host token is not an
+     address. Live proof 2026-08-14: minutes after the RFC-0378 cut a
      bare-token scope probe passed this check and seeded a second store
      directory beside the canonical one. *)
   let valid_codebase slug =

--- a/lib/agent_observation/agent_observation.ml
+++ b/lib/agent_observation/agent_observation.ml
@@ -136,11 +136,17 @@ module Code_address = struct
 
   (* Same closed character set and leading-[..] guard as
      [path_segment_to_slug], so every slug [canonical_url_of_remote] can
-     emit is accepted and nothing outside that alphabet is. *)
+     emit is accepted and nothing outside that alphabet is. Structure is
+     part of the acceptance too: every canonical slug joins a host and at
+     least one path segment with ['_'], so a bare token ("github") is not
+     an address. Live proof 2026-08-14: minutes after the RFC-0378 cut a
+     bare-token scope probe passed this check and seeded a second store
+     directory beside the canonical one. *)
   let valid_codebase slug =
     not (String.equal slug ".")
     && not (String.length slug >= 2 && String.sub slug 0 2 = "..")
     && String.for_all is_slug_char slug
+    && String.contains slug '_'
   ;;
 
   let v ~codebase ~path =

--- a/lib/agent_observation/agent_observation.ml
+++ b/lib/agent_observation/agent_observation.ml
@@ -143,10 +143,31 @@ module Code_address = struct
      bare-token scope probe passed this check and seeded a second store
      directory beside the canonical one. *)
   let valid_codebase slug =
-    not (String.equal slug ".")
+    (* [canonical_url_of_remote] joins a non-empty host and at least one
+       non-empty repository path segment with [_]. Requiring both the join
+       marker and the shortest possible [a_b] shape keeps callers from
+       inventing host-only partitions that the resolver can never emit. *)
+    let joins =
+      String.fold_left
+        (fun count char -> if Char.equal char '_' then count + 1 else count)
+        0
+        slug
+    in
+    let single_join_suffix_is_dotdot =
+      match String.index_opt slug '_' with
+      | Some join when joins = 1 && String.length slug - join - 1 >= 2 ->
+        String.sub slug (join + 1) 2 = ".."
+      | Some _ | None -> false
+    in
+    let rec has_interior_join index =
+      index < String.length slug - 1
+      && (Char.equal slug.[index] '_' || has_interior_join (index + 1))
+    in
+    String.length slug >= 3
+    && has_interior_join 1
+    && not single_join_suffix_is_dotdot
     && not (String.length slug >= 2 && String.sub slug 0 2 = "..")
     && String.for_all is_slug_char slug
-    && String.contains slug '_'
   ;;
 
   let v ~codebase ~path =

--- a/lib/ide/ide_annotations.ml
+++ b/lib/ide/ide_annotations.ml
@@ -319,8 +319,11 @@ let create
     Ok annotation
 ;;
 
+(* Reads never create the store: [load_all_for_codebase] answers [] for an
+   absent file, and a GET that mkdirs seeds a directory for whatever slug
+   the query named (live proof 2026-08-14: a scope probe left an empty
+   [by-url/github/] beside the canonical store). *)
 let list ~base_dir ~codebase ~filter () =
-  ensure_store ~base_dir ~codebase ();
   let all : annotation list = load_all_for_codebase ~base_dir codebase in
   let by_file =
     match filter.file_path with
@@ -370,7 +373,8 @@ let compact ~base_dir ~codebase () =
 ;;
 
 let delete ~base_dir ~codebase ~id ~keeper_id ?expected_version () =
-  ensure_store ~base_dir ~codebase ();
+  (* No ensure_store: a delete that finds its target appends a tombstone to
+     a file that already exists; a miss must not seed the directory. *)
   let all = load_all_for_codebase ~base_dir codebase in
   match List.find_opt (fun a -> a.id = id && a.keeper_id = keeper_id) all with
   | None -> Error "annotation not found or keeper mismatch"

--- a/lib/ide/ide_annotations.ml
+++ b/lib/ide/ide_annotations.ml
@@ -321,8 +321,8 @@ let create
 
 (* Reads never create the store: [load_all_for_codebase] answers [] for an
    absent file, and a GET that mkdirs seeds a directory for whatever slug
-   the query named (live proof 2026-08-14: a scope probe left an empty
-   [by-url/github/] beside the canonical store). *)
+   the query named (live proof 2026-08-14: a bare-token scope probe left an
+   empty store directory beside the canonical one). *)
 let list ~base_dir ~codebase ~filter () =
   let all : annotation list = load_all_for_codebase ~base_dir codebase in
   let by_file =

--- a/test/test_code_address.ml
+++ b/test/test_code_address.ml
@@ -115,6 +115,10 @@ let () =
             "dot codebase"
             `Quick
             (check_rejected ~codebase:"." ~path:"lib/x.ml" A.Malformed_codebase)
+        ; Alcotest.test_case
+            "bare token codebase"
+            `Quick
+            (check_rejected ~codebase:"github" ~path:"lib/x.ml" A.Malformed_codebase)
         ] )
     ]
 ;;

--- a/test/test_code_address.ml
+++ b/test/test_code_address.ml
@@ -119,6 +119,22 @@ let () =
             "bare token codebase"
             `Quick
             (check_rejected ~codebase:"github" ~path:"lib/x.ml" A.Malformed_codebase)
+        ; Alcotest.test_case
+            "separator without host and path"
+            `Quick
+            (check_rejected ~codebase:"_" ~path:"lib/x.ml" A.Malformed_codebase)
+        ; Alcotest.test_case
+            "orphan partition is not a codebase"
+            `Quick
+            (check_rejected ~codebase:"_orphan" ~path:"lib/x.ml" A.Malformed_codebase)
+        ; Alcotest.test_case
+            "separator without repository path"
+            `Quick
+            (check_rejected ~codebase:"github.com_" ~path:"lib/x.ml" A.Malformed_codebase)
+        ; Alcotest.test_case
+            "single joined repository segment cannot start with dotdot"
+            `Quick
+            (check_rejected ~codebase:"a_..repo" ~path:"lib/x.ml" A.Malformed_codebase)
         ] )
     ]
 ;;

--- a/test/test_ide_annotations.ml
+++ b/test/test_ide_annotations.ml
@@ -296,6 +296,22 @@ let test_create_isolates_codebases () =
     check int "other codebase is empty" 0 (List.length other))
 ;;
 
+(* A read must not seed the store: listing a codebase nobody wrote to
+   answers empty and leaves no directory behind (live 2026-08-14: a GET
+   scope probe created an empty [by-url/github/] beside the canonical
+   store). *)
+let test_list_does_not_create_store () =
+  with_temp_dir (fun base_dir ->
+    let slug = "github.com_owner_absent" in
+    let rows = Store.list ~base_dir ~codebase:slug ~filter:(make_filter ()) () in
+    check int "absent codebase lists empty" 0 (List.length rows);
+    check
+      bool
+      "store directory not created by the read"
+      false
+      (Sys.file_exists (Ide_paths.code_store_dir ~base_dir ~codebase:slug)))
+;;
+
 let test_codebases_hold_their_own_rows () =
   with_temp_dir (fun base_dir ->
     let slug = "github.com_owner_repo" in
@@ -925,6 +941,10 @@ let () =
             "create isolates codebases"
             `Quick
             test_create_isolates_codebases
+        ; test_case
+            "list does not create the store"
+            `Quick
+            test_list_does_not_create_store
         ; test_case
             "codebases hold their own rows"
             `Quick


### PR DESCRIPTION
## 발견 (착륙 직후 라이브 실측)

RFC-0378 cut 착륙 몇 분 뒤, IDE 표면 수용 실측 중 `GET /api/v1/ide/annotations?codebase=github` 프로브가 거부되지 않고 200 빈 배열을 반환했고, 디스크에는 `by-url/github/` **빈 디렉터리가 canonical store 옆에 생성**돼 있었습니다. 구멍 두 개가 겹친 결과입니다:

1. **`valid_codebase`가 알파벳만 보고 구조를 안 봄** — `canonical_url_of_remote`가 방출할 수 있는 slug는 전부 host와 path를 `_`로 잇습니다. bare token(`github`)은 주소가 아닌데 통과했습니다. keeper가 slug를 지어내면 같은 리포가 두 store로 갈라지는 씨앗입니다 ("one wire key, one store" 위반).
2. **읽기가 store를 만듦** — `Ide_annotations.list`(그리고 delete의 miss 경로)가 `ensure_store`를 호출해, 쿼리가 이름 붙인 어떤 slug든 GET만으로 디렉터리가 생겼습니다. `load_all_for_codebase`는 파일 부재 시 `[]`를 이미 보장하므로 ensure는 불필요했습니다.

## 수정

- `valid_codebase`에 `String.contains slug '_'` 추가 — canonical 산출물의 확실한 구조 불변식만 요구 (`localhost_repo` 같은 점 없는 host는 여전히 통과). scope 검증과 mint(`Code_address.v`)가 같은 함수라 양쪽이 동시에 강화됩니다.
- `list`/delete-miss에서 `ensure_store` 제거 — 읽기와 실패 경로는 디스크를 건드리지 않습니다. 쓰기(create/compact)의 ensure는 유지.
- 라이브 오염물 `by-url/github/` 제거 완료 (빈 디렉터리).

## 테스트

- `bare token codebase` → `Malformed_codebase` (수정 전 코드에서는 Ok로 통과해 FAIL)
- `list does not create the store` — 부재 codebase 조회가 빈 결과 + 디렉터리 미생성 (수정 전 코드에서는 디렉터리가 생겨 FAIL)

## 검증 명령

```
curl -s 'http://127.0.0.1:8935/api/v1/ide/annotations?codebase=github'   # 배포 후: invalid_codebase
ls ~/me/.masc-ide/by-url/                                                # canonical slug만
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)