### PR TITLE
fix(ci): let main-push CI runs complete instead of cancelling them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,18 +16,22 @@ permissions:
   pull-requests: read
 
 concurrency:
-  # CI verifies the current branch state. A newer push contains every older
-  # main commit, so keeping all superseded 30-50 minute builds only multiplies
-  # cold compiles and delays the result for the state that can actually ship.
+  # Branch/PR runs verify the current branch state: a newer push supersedes
+  # the older run, so the older one cancels. Main is excluded from that rule:
+  # merges land minutes apart while a build takes 30-50, so cancelling
+  # in-progress main runs left main with no completed verdict at all (72% of
+  # main-push runs cancelled; on 2026-08-14 five consecutive heads were killed
+  # inside 40 minutes with zero completions). With cancel-in-progress off,
+  # GitHub still keeps at most one pending run per group — intermediate queued
+  # runs collapse into the newest — so main completes one verdict per build
+  # duration and is never more than one build behind, without a backlog.
   # TLA+ Main Verification remains independently SHA-scoped and preserves the
   # per-commit formal verification contract.
   group: >-
     ${{ github.workflow }}-${{ github.event_name }}-${{
       github.event.pull_request.number || github.ref_name || github.run_id
     }}
-  # Pushes supersede older CI for the same branch. Code-changing PR events
-  # likewise replace an outdated run for that PR.
-  cancel-in-progress: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && contains(fromJSON('["opened","synchronize","reopened","ready_for_review"]'), github.event.action)) }}
+  cancel-in-progress: ${{ (github.event_name == 'push' && github.ref != 'refs/heads/main') || (github.event_name == 'pull_request' && contains(fromJSON('["opened","synchronize","reopened","ready_for_review"]'), github.event.action)) }}
 
 jobs:
   pr-sync-check:


### PR DESCRIPTION
## 문제 (실측)

main 머지는 몇 분 간격, 빌드는 30-50분 — `cancel-in-progress`가 main push에도 걸려 있어서 **main에 완주한 컴파일 판정이 존재하지 않는 상태가 기본값**이었어요.

- 누적: main-push 런의 72% cancelled
- 2026-08-14: 40분 동안 head 5개 연속 kill, 완주 0회 — #28693 컴파일 판정을 로컬 빌드로 만들어야 했음
- ci.yml 의 main-push 안전망 주석("a lib/ regression is detected on the next main push")은 설계돼 있었지만 concurrency 가 그 run 을 계속 죽여서 실효가 없었음

## 수정 (1 expression)

main push 만 `cancel-in-progress` 에서 제외합니다. GitHub concurrency 는 그룹당 **in-progress 1개 + pending 1개(최신만)** 를 유지하므로 ([공식 문서](https://docs.github.com/en/actions/using-jobs/using-concurrency): "Any previously pending job or workflow in the concurrency group will be canceled"), 중간 push 들의 run 은 시작 전에 최신 것으로 대체돼요:

- main: 빌드 시간당 1회 완주 판정, 최대 한 빌드 뒤처짐, 백로그 없음
- 브랜치/PR: 기존 latest-wins 취소 유지 (비용 정책 불변)

## 검증

- `actionlint`: 내 hunk 에 신규 지적 없음 (기존 스타일 노트만)
- yaml parse OK
- 병합 후 실측 계획: 24시간 뒤 main-push run 완주율 재측정 (before 72% cancelled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)