### PR TITLE
fix(dashboard): invalidate execution snapshots after task commits

### DIFF
--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -29,6 +29,8 @@ const invalidateDashboardCache = vi.fn<() => void>(() => {})
 const hydrateBoardSnapshot = vi.fn<(payload: unknown) => void>(() => {})
 const hydrateShellSnapshot = vi.fn<(payload: unknown, opts?: unknown) => void>(() => {})
 const hydrateExecutionSnapshot = vi.fn<(payload: unknown) => void>(() => {})
+const invalidateExecutionSnapshotGeneration = vi.fn<(epoch: string, generation: number) => boolean>(() => true)
+const resetExecutionSnapshotGeneration = vi.fn<() => void>(() => {})
 const hydratePlanningSnapshot = vi.fn<(payload: unknown) => void>(() => {})
 const removeBoardPost = vi.fn<(postId?: string) => void>(() => {})
 const refreshForRoute = vi.fn<(nextRoute: CurrentRoute) => void>()
@@ -59,6 +61,8 @@ async function loadSseStore() {
     hydrateBoardSnapshot,
     hydrateShellSnapshot,
     hydrateExecutionSnapshot,
+    invalidateExecutionSnapshotGeneration,
+    resetExecutionSnapshotGeneration,
     hydratePlanningSnapshot,
     refreshDashboard,
     refreshExecution,
@@ -126,6 +130,8 @@ describe('setupServerPushReaction reconnect hydration', () => {
     hydrateBoardSnapshot.mockClear()
     hydrateShellSnapshot.mockClear()
     hydrateExecutionSnapshot.mockClear()
+    invalidateExecutionSnapshotGeneration.mockClear()
+    resetExecutionSnapshotGeneration.mockClear()
     hydratePlanningSnapshot.mockClear()
     removeBoardPost.mockClear()
     refreshForRoute.mockClear()
@@ -179,6 +185,8 @@ describe('setupServerPushReaction reconnect hydration', () => {
     expect(showToast).toHaveBeenCalled()
     expect(replayAgentCoreRuntimeTelemetry).toHaveBeenCalledTimes(1)
     expect(requestNamespaceTruthNow).toHaveBeenCalledTimes(1)
+    expect(resetExecutionSnapshotGeneration).toHaveBeenCalledTimes(1)
+    expect(refreshExecution).toHaveBeenCalledWith({ force: true })
     expect(refreshDashboard).toHaveBeenCalledWith({ force: true })
 
     vi.clearAllTimers()

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -25,7 +25,9 @@ import type * as TransportHealth from './components/transport-health'
 import {
   keeperHeartbeats,
   invalidateDashboardCache,
+  invalidateExecutionSnapshotGeneration,
   hydrateExecutionSnapshot,
+  resetExecutionSnapshotGeneration,
   refreshDashboard,
   refreshExecution,
   refreshBoard,
@@ -369,6 +371,23 @@ function handleNamespaceTruthSnapshot(payload: unknown): void {
 /** Hydrate execution signals directly from a push payload — zero HTTP fetch. */
 function handleExecutionSnapshot(payload: unknown): void {
   try {
+    if (!isRecord(payload)) throw new Error('execution snapshot payload is invalid')
+    if (payload.execution_invalidated === true) {
+      const epoch = payload.execution_publication_epoch
+      const generation = payload.execution_publication_generation
+      if (
+        typeof epoch !== 'string'
+        || epoch.trim() === ''
+        || typeof generation !== 'number'
+        || !Number.isSafeInteger(generation)
+        || generation < 0
+        || !invalidateExecutionSnapshotGeneration(epoch, generation)
+      ) {
+        throw new Error('execution invalidation generation is invalid')
+      }
+      void refreshExecution({ force: true })
+      return
+    }
     hydrateExecutionSnapshot(payload as DashboardExecutionResponse)
   } catch (err) {
     console.warn('[server-push] execution snapshot hydration failed, will fallback to HTTP', err instanceof Error ? err.message : '')
@@ -493,6 +512,8 @@ function handleReconnect(): void {
   // If the server is still warming up after restart, the first fetch may fail.
   // Schedule a single retry after 3s to cover the warm-up window.
   invalidateDashboardCache()
+  resetExecutionSnapshotGeneration()
+  void refreshExecution({ force: true })
   pauseQueuedAgentCoreRuntimeIngress()
   void hydrateAfterReconnect()
     .finally(() => {

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -677,7 +677,10 @@ async function refreshDashboardFallback(opts?: RefreshOptions): Promise<void> {
   await Promise.all([refreshShell(opts), refreshExecution(opts)])
 }
 
-function hydrateDashboardBootstrap(data: DashboardBootstrapResponse): void {
+function hydrateDashboardBootstrap(
+  data: DashboardBootstrapResponse,
+  executionRequestGeneration: number,
+): void {
   if (!data.shell || bootstrapSliceError(data.shell)) {
     throw new Error('dashboard bootstrap shell slice unavailable')
   }
@@ -686,7 +689,7 @@ function hydrateDashboardBootstrap(data: DashboardBootstrapResponse): void {
   }
 
   hydrateShellSnapshot(data.shell, { light: true })
-  hydrateExecutionSnapshot(data.execution)
+  hydrateExecutionSnapshot(data.execution, { requestGeneration: executionRequestGeneration })
 
   if (data.planning && !bootstrapSliceError(data.planning)) {
     hydratePlanningSnapshot(data.planning)
@@ -714,11 +717,15 @@ export async function refreshDashboard(opts?: RefreshOptions): Promise<void> {
   if (inflightDashboardRefresh) return inflightDashboardRefresh
   dashboardLoading.value = true
   inflightDashboardRefresh = (async () => {
+    const executionRequestGeneration = executionSnapshotRequestGeneration()
     try {
       executionLoading.value = true
       executionError.value = null
       try {
-        hydrateDashboardBootstrap(await fetchDashboardBootstrap())
+        hydrateDashboardBootstrap(
+          await fetchDashboardBootstrap(),
+          executionRequestGeneration,
+        )
       } catch (bootstrapErr) {
         console.warn('[Dashboard] bootstrap refresh failed, falling back:', bootstrapErr)
         await refreshDashboardFallback(opts)
@@ -891,9 +898,138 @@ export async function refreshShell(opts?: RefreshOptions): Promise<boolean> {
   return inflightShellRefresh
 }
 
+let executionPublicationEpoch: string | null = null
+let executionReconnectPreviousEpoch: string | null = null
+let executionReconnectAwaitingHttp = false
+const executionReconnectInvalidationFloors = new Map<string, number>()
+let executionPublicationGenerationWatermark = -1
+let executionHydrationRequestGeneration = 0
+const retiredExecutionPublicationEpochs = new Set<string>()
+
+function retireExecutionPublicationEpoch(epoch: string): void {
+  retiredExecutionPublicationEpochs.add(epoch)
+}
+
+function executionSnapshotRequestGeneration(): number {
+  return executionHydrationRequestGeneration
+}
+
+function executionPublicationIdentityOf(
+  data: DashboardExecutionResponse,
+): { epoch: string; generation: number } | null {
+  const epoch = data.execution_publication_epoch
+  const generation = data.execution_publication_generation
+  return typeof epoch === 'string'
+    && epoch.trim() !== ''
+    && typeof generation === 'number'
+    && Number.isSafeInteger(generation)
+    && generation >= 0
+    ? { epoch, generation }
+    : null
+}
+
+export function invalidateExecutionSnapshotGeneration(
+  epoch: string,
+  generation: number,
+): boolean {
+  if (
+    epoch.trim() === ''
+    || !Number.isSafeInteger(generation)
+    || generation < 0
+    || retiredExecutionPublicationEpochs.has(epoch)
+  ) return false
+  if (executionReconnectAwaitingHttp) {
+    executionReconnectInvalidationFloors.set(
+      epoch,
+      Math.max(executionReconnectInvalidationFloors.get(epoch) ?? -1, generation),
+    )
+    return true
+  }
+  if (executionPublicationEpoch !== epoch) {
+    const previousEpoch = executionPublicationEpoch ?? executionReconnectPreviousEpoch
+    if (previousEpoch !== null && previousEpoch !== epoch) {
+      retireExecutionPublicationEpoch(previousEpoch)
+    }
+    executionPublicationEpoch = epoch
+    executionReconnectPreviousEpoch = null
+    executionPublicationGenerationWatermark = generation
+    return true
+  }
+  executionPublicationGenerationWatermark = Math.max(
+    executionPublicationGenerationWatermark,
+    generation,
+  )
+  return true
+}
+
+export function resetExecutionSnapshotGeneration(): void {
+  executionReconnectPreviousEpoch = executionPublicationEpoch
+  executionPublicationEpoch = null
+  executionPublicationGenerationWatermark = -1
+  executionReconnectAwaitingHttp = true
+  executionReconnectInvalidationFloors.clear()
+  executionHydrationRequestGeneration += 1
+}
+
 /** Hydrate all execution-related signals from a raw data payload.
  *  Shared by doFetchExecution (HTTP) and SSE execution_snapshot handler. */
-export function hydrateExecutionSnapshot(data: DashboardExecutionResponse): void {
+export function hydrateExecutionSnapshot(
+  data: DashboardExecutionResponse,
+  opts?: { requestGeneration?: number },
+): boolean {
+  if (
+    opts?.requestGeneration !== undefined
+    && opts.requestGeneration !== executionHydrationRequestGeneration
+  ) {
+    return false
+  }
+  const identity = executionPublicationIdentityOf(data)
+  if (executionReconnectAwaitingHttp && opts?.requestGeneration === undefined) {
+    return false
+  }
+  if (identity !== null && retiredExecutionPublicationEpochs.has(identity.epoch)) {
+    return false
+  }
+  if (
+    executionReconnectAwaitingHttp
+    && (
+      identity === null
+      || (
+        identity.generation
+        < (executionReconnectInvalidationFloors.get(identity.epoch) ?? -1)
+      )
+    )
+  ) {
+    return false
+  }
+  if (
+    executionPublicationEpoch !== null
+    && (
+      identity === null
+      || identity.epoch !== executionPublicationEpoch
+      || identity.generation < executionPublicationGenerationWatermark
+    )
+  ) {
+    return false
+  }
+  if (identity !== null) {
+    if (executionPublicationEpoch === null) {
+      if (
+        executionReconnectPreviousEpoch !== null
+        && executionReconnectPreviousEpoch !== identity.epoch
+      ) {
+        retireExecutionPublicationEpoch(executionReconnectPreviousEpoch)
+      }
+      executionPublicationEpoch = identity.epoch
+      executionReconnectPreviousEpoch = null
+      executionReconnectAwaitingHttp = false
+      executionReconnectInvalidationFloors.clear()
+    }
+    executionPublicationGenerationWatermark = Math.max(
+      executionPublicationGenerationWatermark,
+      identity.generation,
+    )
+  }
   const normalizedStatus = normalizeServerStatus(data.status, data.generated_at)
   const previousProject = serverStatus.value?.project
   if (normalizedStatus) {
@@ -928,6 +1064,7 @@ export function hydrateExecutionSnapshot(data: DashboardExecutionResponse): void
     .filter((row): row is DashboardExecutionContinuityBrief => row !== null)
   setArrayByKeyIfChanged(executionContinuityBriefs, normalizedContinuityBriefs, c => c.name, stableValueEqual)
   executionLoaded.value = true
+  return true
 }
 
 let nextExecutionForce = false
@@ -935,12 +1072,13 @@ let nextExecutionForce = false
 async function doFetchExecution(): Promise<void> {
   const force = nextExecutionForce
   nextExecutionForce = false
+  const requestGeneration = executionSnapshotRequestGeneration()
   executionLoading.value = true
   executionError.value = null
   try {
     const { fetchDashboardExecution } = await import('./api/dashboard-execution')
     const data = await fetchDashboardExecution({ force })
-    hydrateExecutionSnapshot(data)
+    hydrateExecutionSnapshot(data, { requestGeneration })
   } catch (err) {
     console.warn('[Dashboard] execution fetch error:', err)
     executionError.value = errorMessageOr(err, 'Execution projection load failed')

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -548,6 +548,9 @@ export interface DashboardExecutionContinuityBrief {
 }
 
 export interface DashboardExecutionResponse {
+  execution_publication_epoch?: string
+  execution_publication_generation?: number
+  execution_invalidated?: boolean
   generated_at?: string
   status?: ServerStatus
   summary?: DashboardExecutionSummary

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -176,17 +176,98 @@ let execution_cache : cached_surface =
 
 let execution_default_light_cache_key = "execution:default:light"
 let execution_default_light_http_body : string option Atomic.t = Atomic.make None
+let execution_publication_mu = Stdlib.Mutex.create ()
+let execution_publication_generation = ref 0
+let execution_publication_epoch =
+  (* NDT-OK: process-incarnation identity entropy only. *)
+  Uuidm.v4_gen (Random.State.make_self_init ()) () |> Uuidm.to_string
+;;
+
+let execution_publication_epoch_field = "execution_publication_epoch"
+let execution_publication_generation_field = "execution_publication_generation"
+let execution_invalidated_field = "execution_invalidated"
+
+let with_execution_publication_lock f =
+  Stdlib.Mutex.protect execution_publication_mu f
+;;
 
 let clear_execution_default_light_http_body () =
   Atomic.set execution_default_light_http_body None
 ;;
 
-let execution_surface_has_fresh_success () =
+let execution_surface_has_fresh_success_unlocked () =
   let execution_snapshot = Server_dashboard_http_cache.snapshot execution_cache in
   match execution_snapshot.last_success_unix, execution_snapshot.last_error_unix with
   | Some success_ts, Some error_ts when error_ts > success_ts -> false
   | Some _, _ -> true
   | None, _ -> false
+;;
+
+let begin_execution_publication_attempt () =
+  with_execution_publication_lock (fun () ->
+    let generation = !execution_publication_generation in
+    clear_execution_default_light_http_body ();
+    Server_dashboard_http_cache.mark_cached_surface_attempt execution_cache;
+    generation)
+;;
+
+let current_execution_publication_generation () =
+  with_execution_publication_lock (fun () -> !execution_publication_generation)
+;;
+
+let with_execution_publication_generation ~generation = function
+  | `Assoc fields ->
+    let fields =
+      fields
+      |> List.remove_assoc execution_publication_epoch_field
+      |> List.remove_assoc execution_publication_generation_field
+      |> List.remove_assoc execution_invalidated_field
+    in
+    `Assoc
+      ((execution_publication_epoch_field, `String execution_publication_epoch)
+       :: (execution_publication_generation_field, `Int generation)
+       :: (execution_invalidated_field, `Bool false)
+       :: fields)
+  | json ->
+    `Assoc
+      [ execution_publication_epoch_field, `String execution_publication_epoch
+      ; execution_publication_generation_field, `Int generation
+      ; execution_invalidated_field, `Bool false
+      ; "snapshot", json
+      ]
+;;
+
+let publish_execution_success_if_current ~generation json =
+  with_execution_publication_lock (fun () ->
+    if generation <> !execution_publication_generation
+    then false
+    else (
+      Server_dashboard_http_cache.mark_cached_surface_success
+        execution_cache
+        (with_execution_publication_generation ~generation json);
+      true))
+;;
+
+let publish_execution_error_if_current ~generation exn =
+  with_execution_publication_lock (fun () ->
+    if generation <> !execution_publication_generation
+    then false
+    else (
+      clear_execution_default_light_http_body ();
+      Server_dashboard_http_cache.mark_cached_surface_error execution_cache exn;
+      true))
+;;
+
+let publish_execution_error_message_if_current ~generation message =
+  with_execution_publication_lock (fun () ->
+    if generation <> !execution_publication_generation
+    then false
+    else (
+      clear_execution_default_light_http_body ();
+      Server_dashboard_http_cache.mark_cached_surface_error_message
+        execution_cache
+        message;
+      true))
 ;;
 
 let execution_trust_cache_key = "execution-trust:default"
@@ -217,9 +298,8 @@ let with_execution_trust_cache f =
 
 (** Invalidate the execution surface cache so the next
     [/api/v1/dashboard/execution] request recomputes fresh data.
-    Called via [Workspace_hooks.on_task_mutation_fn] after task add,
-    batch_add, and all transitions (claim, start, done, cancel,
-    release) routed through [observe_task_transition].
+    Called via [Workspace_hooks.on_task_mutation_fn] from the authoritative
+    backlog and goal-link commit boundaries.
     Best-effort: never raises — cache staleness must not break
     the mutation path. *)
 let record_invalidation_failure ~callback ~message exn =
@@ -236,14 +316,12 @@ let invalidate_execution_cache_with_hooks_for_testing
       ()
   =
   (try invalidate_execution_surface () with
-   | Eio.Cancel.Cancelled _ as e -> raise e
    | exn ->
      record_invalidation_failure
        ~callback:"execution_surface_cache_invalidate"
        ~message:"Failed to invalidate execution surface cache"
        exn);
   try invalidate_light_cache () with
-  | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
     record_invalidation_failure
       ~callback:"dashboard_execution_light_cache_invalidate"
@@ -252,22 +330,61 @@ let invalidate_execution_cache_with_hooks_for_testing
 ;;
 
 let invalidate_execution_cache () =
+  let invalidate () =
+  let invalidated_generation = ref None in
   invalidate_execution_cache_with_hooks_for_testing
     ~invalidate_execution_surface:(fun () ->
-      clear_execution_default_light_http_body ();
-      Server_dashboard_http_cache.invalidate_cached_surface execution_cache)
+      with_execution_publication_lock (fun () ->
+        incr execution_publication_generation;
+        invalidated_generation := Some !execution_publication_generation;
+        clear_execution_default_light_http_body ();
+        Server_dashboard_http_cache.invalidate_cached_surface execution_cache))
     ~invalidate_light_cache:(fun () ->
-      Dashboard_cache.invalidate execution_default_light_cache_key)
-    ()
+      Dashboard_cache.invalidate_prefix "execution:")
+    ();
+  Option.iter
+    (fun generation ->
+       try
+         broadcast_cached_surface
+           ~event_type:"execution_snapshot"
+           (`Assoc
+               [ execution_publication_epoch_field, `String execution_publication_epoch
+               ; execution_publication_generation_field, `Int generation
+               ; execution_invalidated_field, `Bool true
+               ])
+       with
+       | exn ->
+         record_invalidation_failure
+           ~callback:"execution_snapshot_invalidation_broadcast"
+           ~message:"Failed to broadcast execution cache invalidation"
+           exn)
+    !invalidated_generation
+  in
+  match Eio_guard.execution_context () with
+  | Eio_guard.Eio_fiber -> Eio.Cancel.protect invalidate
+  | Eio_guard.Non_eio -> invalidate ()
 ;;
+
+let install_task_mutation_cache_invalidation () =
+  Atomic.set Workspace_hooks.on_task_mutation_fn invalidate_execution_cache
+;;
+
+module For_testing = struct
+  let execution_publication_generation () =
+    with_execution_publication_lock (fun () -> !execution_publication_generation)
+  ;;
+
+  let publish_execution_success_if_current = publish_execution_success_if_current
+end
 
 (** Bypass the proactive warm-up guard so tests that call
     [dashboard_namespace_truth_http_json] get the full response instead of
     the "initializing" short-circuit. *)
 let seed_execution_cache_for_test () =
-  Server_dashboard_http_cache.mark_cached_surface_success
-    execution_cache
-    (`Assoc [ "status", `String "seeded_for_test" ])
+  with_execution_publication_lock (fun () ->
+    Server_dashboard_http_cache.mark_cached_surface_success
+      execution_cache
+      (`Assoc [ "status", `String "seeded_for_test" ]))
 ;;
 
 let transport_health_cache =
@@ -447,8 +564,8 @@ let execution_default_light_response_json ~config =
        ~query:default_light_execution_query
 ;;
 
-let cache_execution_default_light_http_body response_json =
-  if execution_surface_has_fresh_success ()
+let cache_execution_default_light_http_body_unlocked response_json =
+  if execution_surface_has_fresh_success_unlocked ()
   then
     Atomic.set
       execution_default_light_http_body
@@ -457,16 +574,60 @@ let cache_execution_default_light_http_body response_json =
 ;;
 
 let refresh_execution_default_light_http_body ~config =
-  let response_json = execution_default_light_response_json ~config in
-  cache_execution_default_light_http_body response_json;
-  response_json
+  with_execution_publication_lock (fun () ->
+    let response_json = execution_default_light_response_json ~config in
+    cache_execution_default_light_http_body_unlocked response_json;
+    response_json)
+;;
+
+let cached_execution_or_first_success_json ~clock ~timeout_sec compute =
+  let cached_success () =
+    with_execution_publication_lock (fun () ->
+      if execution_surface_has_fresh_success_unlocked ()
+      then Some (Server_dashboard_http_cache.cached_surface_json execution_cache)
+      else None)
+  in
+  match cached_success () with
+  | Some json -> json
+  | None ->
+    let compute_and_track () =
+      let generation = begin_execution_publication_attempt () in
+      try
+        let json = compute () in
+        let (_ : bool) = publish_execution_success_if_current ~generation json in
+        json
+      with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
+      | exn ->
+        let (_ : bool) = publish_execution_error_if_current ~generation exn in
+        raise exn
+    in
+    let json =
+      Dashboard_cache.get_or_compute_with_timeout
+        execution_default_light_cache_key
+        ~ttl:deep_surface_cache_ttl_s
+        ~clock
+        ~timeout_sec
+        compute_and_track
+    in
+    (match cached_success () with
+     | Some current -> current
+     | None ->
+       (* DET-OK: invalidation won the publication race, so this request may
+          receive only its own completed pre-invalidation value.  It is left
+          unstamped and cannot republish either cache; clients with a mutation
+          watermark reject identity-less late responses. *)
+       json)
 ;;
 
 let with_transport_health_metadata json =
   extend_projection_diagnostics json [ "source", `String "cached_surface" ]
 ;;
 
-let dashboard_execution_snapshot_json () = Server_dashboard_http_cache.cached_surface_json execution_cache
+let dashboard_execution_snapshot_json () =
+  with_execution_publication_lock (fun () ->
+    Server_dashboard_http_cache.cached_surface_json execution_cache)
+;;
 
 (* Cache patchers project a typed lifecycle transition onto dashboard row fields
    (keepalive_running / phase / pipeline_stage / paused). Phase-derived events
@@ -789,29 +950,34 @@ let patch_surface_json_for_running_keepers (config : Workspace.config) = functio
 ;;
 
 let patchexecution_cache_for_keeper ~keeper_name ~event ~keepalive_running =
-  clear_execution_default_light_http_body ();
-  match (Server_dashboard_http_cache.snapshot execution_cache).json with
-  | `Assoc fields ->
-    (match List.assoc_opt "keepers" fields with
-     | Some (`List rows) ->
-       let keeper_rows =
-         patch_keeper_rows ~keeper_name ~event ~keepalive_running rows
-       in
-       if keeper_rows <> rows
-       then
-         execution_cache.Server_dashboard_http_cache.current
-         <- { (Server_dashboard_http_cache.snapshot execution_cache) with
-              json =
-                `Assoc
-                  (replace_keeper_rows_and_rebuild_briefs
-                     ~now_ts:(Time_compat.now ())
-                     ~keeper_rows
-                     ~keepers_json:(`List keeper_rows)
-                     fields)
-            }
-     | Some _ -> ()
-     | None -> ())
-  | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> ()
+  with_execution_publication_lock (fun () ->
+    incr execution_publication_generation;
+    let generation = !execution_publication_generation in
+    clear_execution_default_light_http_body ();
+    match (Server_dashboard_http_cache.snapshot execution_cache).json with
+    | `Assoc fields ->
+      let json =
+        match List.assoc_opt "keepers" fields with
+        | Some (`List rows) ->
+          let keeper_rows =
+            patch_keeper_rows ~keeper_name ~event ~keepalive_running rows
+          in
+          if keeper_rows = rows
+          then `Assoc fields
+          else
+            `Assoc
+              (replace_keeper_rows_and_rebuild_briefs
+                 ~now_ts:(Time_compat.now ())
+                 ~keeper_rows
+                 ~keepers_json:(`List keeper_rows)
+                 fields)
+        | Some _ | None -> `Assoc fields
+      in
+      execution_cache.Server_dashboard_http_cache.current
+      <- { (Server_dashboard_http_cache.snapshot execution_cache) with
+           json = with_execution_publication_generation ~generation json
+         }
+    | `List _ | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `Null -> ())
 ;;
 
 let patch_keeper_dependent_caches ~keeper_name ~event =
@@ -843,33 +1009,36 @@ let start_execution_refresh_loop ~state ~sw ~clock ~net ~mono_clock =
       ~min_v:30.0
       ~max_v:300.0
   in
+  let attempt_generation = Atomic.make 0 in
   let compute () =
-    clear_execution_default_light_http_body ();
-    Server_dashboard_http_cache.mark_cached_surface_attempt execution_cache;
+    let generation = begin_execution_publication_attempt () in
+    Atomic.set attempt_generation generation;
     let started_at = Unix.gettimeofday () in
     try
-      run_dashboard_compute
-        ~mode:Offloaded_readonly
-        ~sw
-        ~clock
-        ~net
-        ~mono_clock
-        ~config:workspace_config
-        (fun ~config ~sw ->
-           Dashboard_execution.json ~light:true ~config ~sw ~clock ~proc_mgr ()
-           |> patch_surface_json_for_running_keepers config
-           |> with_projection_diagnostics
-                ~surface:"execution"
-                ~started_at
-                ~extra:
-                  [ ( "readonly_pool"
-                    , Workspace_utils.domain_local_pg_backend_diagnostics_json () )
-                  ])
+      let json =
+        run_dashboard_compute
+          ~mode:Offloaded_readonly
+          ~sw
+          ~clock
+          ~net
+          ~mono_clock
+          ~config:workspace_config
+          (fun ~config ~sw ->
+             Dashboard_execution.json ~light:true ~config ~sw ~clock ~proc_mgr ()
+             |> patch_surface_json_for_running_keepers config
+             |> with_projection_diagnostics
+                  ~surface:"execution"
+                  ~started_at
+                  ~extra:
+                    [ ( "readonly_pool"
+                      , Workspace_utils.domain_local_pg_backend_diagnostics_json () )
+                    ])
+      in
+      generation, json
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | exn ->
-      clear_execution_default_light_http_body ();
-      Server_dashboard_http_cache.mark_cached_surface_error execution_cache exn;
+      let (_ : bool) = publish_execution_error_if_current ~generation exn in
       raise exn
   in
   Proactive_refresh.start
@@ -881,19 +1050,20 @@ let start_execution_refresh_loop ~state ~sw ~clock ~net ~mono_clock =
       ; on_failure =
           Some
             (fun failure ->
-              clear_execution_default_light_http_body ();
-              Server_dashboard_http_cache.mark_cached_surface_error_message
-                execution_cache
-                (Proactive_refresh.failure_message failure))
+              ignore
+                (publish_execution_error_message_if_current
+                   ~generation:(Atomic.get attempt_generation)
+                   (Proactive_refresh.failure_message failure)))
       ; warm_delay_s = 0.0
       }
     ~compute
-    ~on_result:(fun json ->
-      Server_dashboard_http_cache.mark_cached_surface_success execution_cache json;
-      broadcast_cached_surface
-        ~event_type:"execution_snapshot"
-        (refresh_execution_default_light_http_body ~config:workspace_config);
-      !broadcast_namespace_truth_ref state)
+    ~on_result:(fun (generation, json) ->
+      if publish_execution_success_if_current ~generation json
+      then (
+        broadcast_cached_surface
+          ~event_type:"execution_snapshot"
+          (refresh_execution_default_light_http_body ~config:workspace_config);
+        !broadcast_namespace_truth_ref state))
 ;;
 
 let dashboard_execution_cached_http_body ~state request =
@@ -902,9 +1072,12 @@ let dashboard_execution_cached_http_body ~state request =
   let actor = execution_actor_for_request ~base_path:config.base_path request in
   let full_mode = bool_query_param request "full" ~default:false in
   let force = bool_query_param request "force" ~default:false in
-  match fixture, actor, full_mode, force, Atomic.get execution_default_light_http_body with
-  | None, None, false, false, Some body when execution_surface_has_fresh_success () ->
-    Some body
+  match fixture, actor, full_mode, force with
+  | None, None, false, false ->
+    with_execution_publication_lock (fun () ->
+      match Atomic.get execution_default_light_http_body with
+      | Some body when execution_surface_has_fresh_success_unlocked () -> Some body
+      | Some _ | None -> None)
   | _ -> None
 ;;
 
@@ -1050,21 +1223,23 @@ let dashboard_execution_http_json ~state ~sw ~clock request =
   match fixture, actor, full_mode with
   | None, None, false when force ->
     let timeout_sec = Env_config_runtime.Dashboard.execution_timeout_sec in
+    let attempt_generation = Atomic.make 0 in
     let compute_and_track () =
-      clear_execution_default_light_http_body ();
-      Server_dashboard_http_cache.mark_cached_surface_attempt execution_cache;
+      let generation = begin_execution_publication_attempt () in
+      Atomic.set attempt_generation generation;
       try
         let json = compute ~light:true () in
-        Server_dashboard_http_cache.mark_cached_surface_success execution_cache json;
-        let (_ : Yojson.Safe.t) =
-          refresh_execution_default_light_http_body ~config
-        in
-        Server_dashboard_http_cache.cached_surface_json execution_cache
+        if publish_execution_success_if_current ~generation json
+        then (
+          let (_ : Yojson.Safe.t) =
+            refresh_execution_default_light_http_body ~config
+          in
+          dashboard_execution_snapshot_json ())
+        else json
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | exn ->
-        clear_execution_default_light_http_body ();
-        Server_dashboard_http_cache.mark_cached_surface_error execution_cache exn;
+        let (_ : bool) = publish_execution_error_if_current ~generation exn in
         raise exn
     in
     (match
@@ -1075,8 +1250,10 @@ let dashboard_execution_http_json ~state ~sw ~clock request =
        let exn =
          Dashboard_cache.Compute_timeout (execution_default_light_cache_key, false)
        in
-       clear_execution_default_light_http_body ();
-       Server_dashboard_http_cache.mark_cached_surface_error execution_cache exn;
+       ignore
+         (publish_execution_error_if_current
+            ~generation:(Atomic.get attempt_generation)
+            exn);
        Log.Dashboard.warn
          "dashboard execution force refresh timed out: %s (%.0fs)"
          execution_default_light_cache_key
@@ -1103,10 +1280,7 @@ let dashboard_execution_http_json ~state ~sw ~clock request =
          serving the empty initializing payload forever when proactive warm-up
          misses its first build window. *)
     let json =
-      Server_dashboard_http_cache.cached_surface_or_first_success_json
-        execution_cache
-        ~cache_key:execution_default_light_cache_key
-        ~ttl:deep_surface_cache_ttl_s
+      cached_execution_or_first_success_json
         ~clock
         ~timeout_sec:Env_config_runtime.Dashboard.execution_timeout_sec
         (compute ~light:true)
@@ -1118,7 +1292,7 @@ let dashboard_execution_http_json ~state ~sw ~clock request =
         ~query
         json
     in
-    cache_execution_default_light_http_body response_json;
+    let (_ : Yojson.Safe.t) = refresh_execution_default_light_http_body ~config in
     response_json
   | _ ->
     (* Parameterized requests (fixture/actor/full): on-demand with SWR cache.
@@ -1130,12 +1304,17 @@ let dashboard_execution_http_json ~state ~sw ~clock request =
         (Option.value ~default:"" fixture)
         (if full_mode then "full" else "light")
     in
+    let compute_with_generation () =
+      let generation = current_execution_publication_generation () in
+      compute ?actor ?fixture ~light ()
+      |> with_execution_publication_generation ~generation
+    in
     Dashboard_cache.get_or_compute_with_timeout
       cache_key
       ~ttl:deep_surface_cache_ttl_s
       ~clock
       ~timeout_sec:Env_config_runtime.Dashboard.execution_timeout_sec
-      (compute ?actor ?fixture ~light)
+      compute_with_generation
     |> with_execution_metadata ~config ~cache_key ~query
 ;;
 

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -353,6 +353,7 @@ let invalidate_execution_cache () =
                ; execution_invalidated_field, `Bool true
                ])
        with
+       | Eio.Cancel.Cancelled _ as e -> raise e
        | exn ->
          record_invalidation_failure
            ~callback:"execution_snapshot_invalidation_broadcast"

--- a/lib/server/server_dashboard_http_execution_surfaces.mli
+++ b/lib/server/server_dashboard_http_execution_surfaces.mli
@@ -110,10 +110,21 @@ val execution_actor_for_request :
 
 val invalidate_execution_cache : unit -> unit
 (** Drops the cached execution surface so the next
-    snapshot read recomputes from upstream.  Swallows
-    [Eio.Cancel.Cancelled] re-raise plus logs and counts other
-    exceptions through
+    snapshot read recomputes from upstream. Runs the cache/tombstone
+    settlement cancellation-protected and logs/counts projection failures
+    through
     {!Keeper_metrics.(to_string LifecycleCallbackFailures)}. *)
+
+val install_task_mutation_cache_invalidation : unit -> unit
+(** Connects task mutation commits to {!invalidate_execution_cache}. Server
+    bootstrap installs this before Workspace mutation hooks become available. *)
+
+module For_testing : sig
+  val execution_publication_generation : unit -> int
+
+  val publish_execution_success_if_current :
+    generation:int -> Yojson.Safe.t -> bool
+end
 
 val invalidate_execution_cache_with_hooks_for_testing :
   invalidate_execution_surface:(unit -> unit) ->

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -537,6 +537,7 @@ let create_server_state ~sw ~base_path ?input_base_path ~clock ~mono_clock ~net
         ~category:Log.Boundary
         "keeper stream idle timeout resolved: disabled (no inter-line idle bound)");
   Keeper_task_owner_backend.install_hooks ();
+  Server_dashboard_http_execution_surfaces.install_task_mutation_cache_invalidation ();
   let state =
     Mcp_eio.create_state_eio ~sw ~proc_mgr ~fs ~clock
       ~mono_clock ~net

--- a/lib/workspace/workspace_backlog.ml
+++ b/lib/workspace/workspace_backlog.ml
@@ -142,6 +142,12 @@ let read_backlog_observation_r config =
 exception Backlog_read_failed of string
 exception Backlog_write_failed of string
 
+let protect_backlog_commit_settlement f =
+  match Eio_guard.execution_context () with
+  | Eio_guard.Eio_fiber -> Eio.Cancel.protect f
+  | Eio_guard.Non_eio -> f ()
+;;
+
 let read_backlog config =
   match read_backlog_with_source_r config with
   | Ok { observed_backlog; _ } -> observed_backlog
@@ -181,6 +187,7 @@ let write_backlog_result ?after_commit config backlog =
   match write_json_commit_result config primary_path json with
   | Error msg -> Error msg
   | Ok primary_commit ->
+    protect_backlog_commit_settlement (fun () ->
     Option.iter
       (fun message ->
          Log.TaskState.error
@@ -207,7 +214,21 @@ let write_backlog_result ?after_commit config backlog =
     in
     clear_backlog_cache_for primary_path;
     clear_backlog_cache_for recovery_path;
-    let post_commit_error =
+    let mutation_observer_error =
+      try
+        (Atomic.get Workspace_hooks.on_task_mutation_fn) ();
+        None
+      with
+      | exn ->
+        let message = Printexc.to_string exn in
+        Log.TaskState.error
+          "backlog primary committed but task mutation observer failed path=%s \
+           error=%s"
+          primary_path
+          message;
+        Some message
+    in
+    let caller_post_commit_error =
       match after_commit with
       | None -> None
       | Some f ->
@@ -215,7 +236,6 @@ let write_backlog_result ?after_commit config backlog =
            f ();
            None
          with
-         | Eio.Cancel.Cancelled _ as exn -> raise exn
          | exn ->
            let message = Printexc.to_string exn in
            Log.TaskState.error
@@ -225,12 +245,23 @@ let write_backlog_result ?after_commit config backlog =
              message;
            Some message)
     in
+    let post_commit_error =
+      match mutation_observer_error, caller_post_commit_error with
+      | None, None -> None
+      | Some message, None | None, Some message -> Some message
+      | Some observer_error, Some caller_error ->
+        Some
+          (Printf.sprintf
+             "task mutation observer: %s; caller post-commit: %s"
+             observer_error
+             caller_error)
+    in
     Ok
       { committed_revision = backlog.version
       ; primary_mirror_error = primary_commit.mirror_error
       ; recovery_error
       ; post_commit_error
-      }
+      })
 
 (** [write_backlog ?after_commit config backlog] persists the primary SSOT,
     then observes secondary recovery/mirror/projection failures without

--- a/lib/workspace/workspace_goal_index.ml
+++ b/lib/workspace/workspace_goal_index.ml
@@ -158,7 +158,31 @@ let verify_goal_task_links_write config ~path ~json ~expected_links ~label =
          (Printexc.to_string exn))
 ;;
 
-let write_goal_task_links_result ?(rollback_on_recovery_failure = true) ?previous_links config links =
+type task_mutation_notification =
+  | Notify_on_failure
+  | Notify_always
+
+let protect_goal_link_settlement f =
+  match Eio_guard.execution_context () with
+  | Eio_guard.Eio_fiber -> Eio.Cancel.protect f
+  | Eio_guard.Non_eio -> f ()
+;;
+
+let notify_task_mutation () =
+  try (Atomic.get Workspace_hooks.on_task_mutation_fn) () with
+  | exn ->
+    Log.Misc.warn
+      "goal-task link settlement observer failed: %s"
+      (Printexc.to_string exn)
+;;
+
+let write_goal_task_links_result_internal
+      ?(rollback_on_recovery_failure = true)
+      ?previous_links
+      ~task_mutation_notification
+      config
+      links
+  =
   let json = links_to_yojson links in
   let primary_path = goal_task_links_path config in
   let recovery_path = goal_task_links_recovery_path config in
@@ -212,16 +236,41 @@ let write_goal_task_links_result ?(rollback_on_recovery_failure = true) ?previou
            "write_goal_task_links_result: recovery rollback failed after write failure: %s"
            rollback_msg)
   in
-  match write_primary () with
-  | Error _ as error ->
-    rollback ();
-    error
-  | Ok () ->
-    (match write_recovery () with
-     | Ok () -> Ok ()
-     | Error _ as error ->
-       if rollback_on_recovery_failure then rollback ();
-       error)
+  let notify_after_settlement ~failed =
+    match task_mutation_notification, failed with
+    | Notify_on_failure, false -> ()
+    | Notify_on_failure, true | Notify_always, _ -> notify_task_mutation ()
+  in
+  protect_goal_link_settlement (fun () ->
+    match write_primary () with
+    | Error _ as error ->
+      rollback ();
+      notify_after_settlement ~failed:true;
+      error
+    | Ok () ->
+      let recovery_result = write_recovery () in
+      (match recovery_result with
+       | Ok () ->
+         notify_after_settlement ~failed:false;
+         Ok ()
+       | Error _ as error ->
+         if rollback_on_recovery_failure then rollback ();
+         notify_after_settlement ~failed:true;
+         error))
+;;
+
+let write_goal_task_links_result
+      ?rollback_on_recovery_failure
+      ?previous_links
+      config
+      links
+  =
+  write_goal_task_links_result_internal
+    ?rollback_on_recovery_failure
+    ?previous_links
+    ~task_mutation_notification:Notify_always
+    config
+    links
 ;;
 
 let write_goal_task_links config links =
@@ -301,7 +350,11 @@ let link_task_to_goal_result config ~goal_id ~task_id =
       | Error _ as error -> error
       | Ok links ->
         let new_links = add_link_to_links links ~goal_id ~task_id in
-        write_goal_task_links_result config ~previous_links:links new_links)
+        write_goal_task_links_result_internal
+          config
+          ~previous_links:links
+          ~task_mutation_notification:Notify_on_failure
+          new_links)
 ;;
 
 let before_unlink_task_from_goal_for_testing = Atomic.make None
@@ -316,10 +369,11 @@ let unlink_task_from_goal_result_impl config ~goal_id ~task_id =
       | Error _ as error -> error
       | Ok links ->
         let new_links = remove_link_from_links links ~goal_id ~task_id in
-        write_goal_task_links_result
+        write_goal_task_links_result_internal
           config
           ~rollback_on_recovery_failure:false
           ~previous_links:links
+          ~task_mutation_notification:Notify_always
           new_links)
 ;;
 
@@ -389,7 +443,11 @@ let link_tasks_to_goals_result config links =
             existing_links
             trimmed_links
         in
-        write_goal_task_links_result config ~previous_links:existing_links updated_links)
+        write_goal_task_links_result_internal
+          config
+          ~previous_links:existing_links
+          ~task_mutation_notification:Notify_on_failure
+          updated_links)
 ;;
 
 (** Build a reverse index from goal_id to its linked tasks.

--- a/lib/workspace/workspace_hooks.ml
+++ b/lib/workspace/workspace_hooks.ml
@@ -130,9 +130,9 @@ let observe_task_transition_fn
       (fun _config ~agent_name:_ ~task_id:_ ~transition:_
            ~details:_ -> ())
 
-(** Invalidate dashboard execution cache on task mutation (add, transition).
-    Wired by server bootstrap to avoid circular dependency between
-    Workspace sub-modules and server dashboard surfaces. *)
+(** Invalidate dashboard execution cache after an authoritative task backlog or
+    goal-link commit. Wired by server bootstrap to avoid a dependency from
+    Workspace sub-modules back to server dashboard surfaces. *)
 let on_task_mutation_fn
   : (unit -> unit) Atomic.t
   = Atomic.make (fun () -> ())

--- a/lib/workspace/workspace_query.ml
+++ b/lib/workspace/workspace_query.ml
@@ -58,8 +58,7 @@ let update_priority config ~task_id ~priority =
                     ; ("old", `Int old_priority)
                     ; ("new", `Int priority)
                     ; ("ts", `String (now_iso ()))
-                    ]);
-                (Atomic.get Workspace_hooks.on_task_mutation_fn) ()
+                    ])
               with
               | Eio.Cancel.Cancelled _ as e -> raise e
               | exn ->

--- a/lib/workspace/workspace_task_create.ml
+++ b/lib/workspace/workspace_task_create.ml
@@ -77,6 +77,12 @@ let append_goal_link_rollback_failures msg rollback_failures =
       (String.concat "; " failures)
 ;;
 
+let protect_task_create_settlement f =
+  match Eio_guard.execution_context () with
+  | Eio_guard.Eio_fiber -> Eio.Cancel.protect f
+  | Eio_guard.Non_eio -> f ()
+;;
+
 let rollback_goal_links config task_goal_ids =
   List.filter_map
     (fun (task_id, goal_id_opt) ->
@@ -115,6 +121,7 @@ let add_task_with_result
   let goal_id = Workspace_task_classify.trim_opt goal_id in
   let predecessor_task_id = Workspace_task_classify.trim_opt predecessor_task_id in
   try
+    protect_task_create_settlement (fun () ->
     with_file_lock config lock_path (fun () ->
       match read_backlog_r config with
       | Error msg -> Error (Backlog_read_failed msg)
@@ -215,7 +222,6 @@ let add_task_with_result
                                  | Some contract -> contract.strict
                                  | None -> false) )
                           ]);
-                  (Atomic.get Workspace_hooks.on_task_mutation_fn) ();
                   let _ =
                     broadcast
                       config
@@ -223,7 +229,7 @@ let add_task_with_result
                       ~content:(Printf.sprintf "New quest: %s" title)
                   in
                   let summary = Printf.sprintf "Added %s: %s" task_id title in
-                  Ok { task_id; summary; title; priority; description; goal_id }))))
+                  Ok { task_id; summary; title; priority; description; goal_id })))))
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | e -> Error (Unexpected_error (Printexc.to_string e))
@@ -250,6 +256,7 @@ let batch_add_tasks_internal_with_result ?created_by config tasks =
   ensure_initialized config;
   let lock_path = backlog_lock_path config in
   let actor = Option.value ~default:"system" created_by in
+  protect_task_create_settlement (fun () ->
   with_file_lock config lock_path (fun () ->
     match read_backlog_r config with
     | Error msg -> Error (Batch_backlog_read_failed msg)
@@ -351,7 +358,6 @@ let batch_add_tasks_internal_with_result ?created_by config tasks =
                     ", "
                     (List.map (fun (t : Masc_domain.task) -> t.id) added_tasks)
                 in
-                (Atomic.get Workspace_hooks.on_task_mutation_fn) ();
                 let msg =
                   Printf.sprintf
                     "New batch of %d quests added: %s"
@@ -365,7 +371,7 @@ let batch_add_tasks_internal_with_result ?created_by config tasks =
                 Ok { task_ids; summary; count }))
        with
        | Eio.Cancel.Cancelled _ as e -> raise e
-       | e -> Error (Batch_unexpected_error (Printexc.to_string e))))
+       | e -> Error (Batch_unexpected_error (Printexc.to_string e)))))
 ;;
 
 let batch_add_tasks_internal ?created_by config tasks =

--- a/lib/workspace_metric_hooks.ml
+++ b/lib/workspace_metric_hooks.ml
@@ -257,7 +257,6 @@ let install () =
   Atomic.set Workspace_hooks.observe_agent_lifecycle_fn (fun config ~agent_id ~event ~details ->
     observe_agent_lifecycle config ~agent_id ~event ~details);
   Atomic.set Workspace_hooks.observe_task_transition_fn (fun config ~agent_name ~task_id ~transition ~details ->
-    (Atomic.get Workspace_hooks.on_task_mutation_fn) ();
     observe_task_transition_event config ~agent_name ~task_id ~transition ~details);
 
   Atomic.set Workspace_hooks.activity_emit_fn (fun config ~actor ?subject ~kind ~payload ~tags () ->

--- a/test/test_dashboard_cache.ml
+++ b/test/test_dashboard_cache.ml
@@ -264,6 +264,59 @@ let test_invalidate_prefix () =
   Alcotest.(check int) "proof entries recomputed" 4 !proof_counter;
   Alcotest.(check int) "non-matching prefix preserved" 1 !mission_counter
 
+let test_task_mutation_hook_invalidates_all_execution_variants () =
+  Dashboard_cache.invalidate_all ();
+  let default_counter = ref 0 in
+  let full_counter = ref 0 in
+  let unrelated_counter = ref 0 in
+  let read key counter =
+    Dashboard_cache.get_or_compute key ~ttl:120.0 (fun () ->
+      incr counter;
+      `Int !counter)
+  in
+  ignore (read "execution:default:light" default_counter);
+  ignore (read "execution:operator::full" full_counter);
+  ignore (read "workspace:default" unrelated_counter);
+  let stale_generation =
+    Server_dashboard_http_execution_surfaces.For_testing
+    .execution_publication_generation ()
+  in
+  Alcotest.(check bool)
+    "initial execution publication accepted"
+    true
+    (Server_dashboard_http_execution_surfaces.For_testing
+     .publish_execution_success_if_current
+       ~generation:stale_generation
+       (`Assoc [ "tasks", `List [] ]));
+  let previous = Atomic.get Workspace_hooks.on_task_mutation_fn in
+  Fun.protect
+    ~finally:(fun () ->
+      Atomic.set Workspace_hooks.on_task_mutation_fn previous;
+      Dashboard_cache.invalidate_all ())
+    (fun () ->
+      Server_dashboard_http_execution_surfaces.install_task_mutation_cache_invalidation ();
+      (Atomic.get Workspace_hooks.on_task_mutation_fn) ();
+      Alcotest.(check bool)
+        "pre-mutation execution publication rejected"
+        false
+        (Server_dashboard_http_execution_surfaces.For_testing
+         .publish_execution_success_if_current
+           ~generation:stale_generation
+           (`Assoc [ "tasks", `List [ `String "stale" ] ]));
+      Alcotest.(check bool)
+        "stale publication did not resurrect execution success"
+        true
+        (Option.is_none
+           (Server_dashboard_http_cache.snapshot
+              Server_dashboard_http_execution_surfaces.execution_cache)
+             .last_success_unix);
+      ignore (read "execution:default:light" default_counter);
+      ignore (read "execution:operator::full" full_counter);
+      ignore (read "workspace:default" unrelated_counter);
+      Alcotest.(check int) "default execution recomputed" 2 !default_counter;
+      Alcotest.(check int) "full execution recomputed" 2 !full_counter;
+      Alcotest.(check int) "unrelated cache preserved" 1 !unrelated_counter)
+
 (* -- 5. Stats reports active + computing ------------------------------------ *)
 
 let test_stats () =
@@ -800,6 +853,8 @@ let () =
             test_projection_digest_cache_separates_actors;
           test_case "invalidate" `Quick test_invalidate;
           test_case "invalidate_prefix" `Quick test_invalidate_prefix;
+          test_case "task mutation invalidates every execution variant" `Quick
+            test_task_mutation_hook_invalidates_all_execution_variants;
           test_case "stats" `Quick test_stats;
           test_case "stats detail surface" `Quick test_stats_detail_surface;
           test_case "stats empty table" `Quick test_stats_handles_empty_table;

--- a/test/test_workspace_goal_index.ml
+++ b/test/test_workspace_goal_index.ml
@@ -104,7 +104,10 @@ let message_count config =
 
 let check_no_create_side_effects config ~message_count_before activity_count mutation_count =
   check_int "no task activity emitted" 0 (activity_count ());
-  check_int "no task mutation hook fired" 0 (mutation_count ());
+  (* A failed create can still fence Dashboard readers after a provisional
+     goal-link write has been rolled back.  That reconciliation callback is
+     not a published task side effect. *)
+  ignore (mutation_count ());
   check_int
     "no broadcast messages emitted"
     message_count_before
@@ -295,37 +298,39 @@ let test_open_count_all_terminal () =
 
 let test_add_task_persists_goal_link () =
   with_test_env (fun config ->
-    let result =
-      Workspace.add_task
-        ~goal_id:"goal-a"
-        config
-        ~title:"linked task"
-        ~priority:1
-        ~description:""
-    in
-    check_bool "add_task succeeds" true (String.starts_with ~prefix:"Added task-001" result);
-    let links = Workspace_goal_index.read_goal_task_links config in
-    check_bool
-      "registry records goal link"
-      true
-      (List.exists
-         (fun (goal_id, task_ids) ->
-            String.equal goal_id "goal-a" && List.mem "task-001" task_ids)
-         links);
-    let tasks = Workspace.get_tasks_safe config in
-    let index = Workspace_goal_index.build_goal_task_index_for_config config tasks in
-    check_list_len
-      "config-aware index sees linked task"
-      1
-      (Workspace_goal_index.tasks_for_goal index ~goal_id:"goal-a");
-    let task_goal_index =
-      Workspace_goal_index.build_task_goal_index_for_config config
-    in
-    check_bool
-      "reverse index sees linked goal"
-      true
-      (try List.mem "goal-a" (Hashtbl.find task_goal_index "task-001") with
-       | Not_found -> false))
+    with_mutation_counter (fun mutation_count ->
+      let result =
+        Workspace.add_task
+          ~goal_id:"goal-a"
+          config
+          ~title:"linked task"
+          ~priority:1
+          ~description:""
+      in
+      check_bool "add_task succeeds" true (String.starts_with ~prefix:"Added task-001" result);
+      check_int "committed task mutation observed once" 1 (mutation_count ());
+      let links = Workspace_goal_index.read_goal_task_links config in
+      check_bool
+        "registry records goal link"
+        true
+        (List.exists
+           (fun (goal_id, task_ids) ->
+              String.equal goal_id "goal-a" && List.mem "task-001" task_ids)
+           links);
+      let tasks = Workspace.get_tasks_safe config in
+      let index = Workspace_goal_index.build_goal_task_index_for_config config tasks in
+      check_list_len
+        "config-aware index sees linked task"
+        1
+        (Workspace_goal_index.tasks_for_goal index ~goal_id:"goal-a");
+      let task_goal_index =
+        Workspace_goal_index.build_task_goal_index_for_config config
+      in
+      check_bool
+        "reverse index sees linked goal"
+        true
+        (try List.mem "goal-a" (Hashtbl.find task_goal_index "task-001") with
+         | Not_found -> false)))
 ;;
 
 let test_prune_goal_links_preserves_other_goals () =
@@ -387,6 +392,10 @@ let test_add_task_goal_link_write_failure_does_not_publish_task () =
         | Ok created -> Alcotest.failf "expected failure, created %s" created.task_id);
         check_int "task was not published" 0 (List.length (Workspace.get_tasks_safe config));
         check_no_goal_link_files config ~goal_id:"goal-a" ~task_id:"task-001";
+        check_bool
+          "failed provisional link settlement fenced dashboard readers"
+          true
+          (mutation_count () > 0);
         check_no_create_side_effects
           config
           ~message_count_before
@@ -421,6 +430,10 @@ let test_batch_add_task_goal_link_write_failure_does_not_publish_tasks () =
            rollback checks below do not touch the backlog. *)
         check_no_goal_link_files config ~goal_id:"goal-a" ~task_id:"task-001";
         check_no_goal_link_files config ~goal_id:"goal-b" ~task_id:"task-002";
+        check_bool
+          "failed provisional batch link settlement fenced dashboard readers"
+          true
+          (mutation_count () > 0);
         check_no_create_side_effects
           config
           ~message_count_before
@@ -520,6 +533,10 @@ let test_add_task_goal_link_write_failure_surfaces_rollback_failure () =
              | Ok created -> Alcotest.failf "expected failure, created %s" created.task_id);
         (* Rollback failure is surfaced above; unlike the successful rollback
            cases, these paths cannot promise that goal_task_links was cleaned. *)
+        check_bool
+          "failed rollback settlement fenced dashboard readers"
+          true
+          (mutation_count () > 0);
         check_no_create_side_effects
           config
           ~message_count_before
@@ -558,6 +575,10 @@ let test_batch_add_task_goal_link_write_failure_surfaces_rollback_failure () =
                Alcotest.failf "expected failure, created %d tasks" created.count);
         (* Rollback failure is surfaced above; unlike the successful rollback
            cases, these paths cannot promise that goal_task_links was cleaned. *)
+        check_bool
+          "failed batch rollback settlement fenced dashboard readers"
+          true
+          (mutation_count () > 0);
         check_no_create_side_effects
           config
           ~message_count_before


### PR DESCRIPTION
## As-Is

- A committed batch task stayed absent from /api/v1/dashboard/execution until the 120s cache expired.
- Task mutations did not consistently invalidate every execution projection variant, and an older in-flight compute could republish stale mutable cache/body state.
- A stale execution SSE could arrive after a newer task commit and roll the live Dashboard back.

## To-Be

- The authoritative backlog and goal-link settlement boundaries notify one task-mutation hook after commit or rollback reconciliation.
- Default, force, actor, and full execution snapshots carry a process epoch plus monotonic publication generation.
- Cache invalidation fences in-flight computes, drops every execution cache variant, and emits an invalidation tombstone.
- Dashboard hydration rejects stale HTTP/SSE generations; reconnect epoch selection is established only by current-request HTTP/bootstrap, with per-epoch tombstone floors.
- Post-commit recovery, rollback, cache invalidation, and tombstone settlement are cancellation-protected without holding the publication mutex across SSE fanout.

## Evidence

- Live canary task-333/task-334 persisted immediately but the execution projection remained at 319 tasks for 120 seconds before reaching 321.
- Independent adversarial source review on the final diff: P0/P1/P2 none.

## Validation

- PASS: ocamlformat check for changed OCaml files
- PASS: ocamlc parse-only for changed OCaml files
- PASS: Dashboard tsc --noEmit using the existing checkout toolchain
- PASS: scoped Dashboard ESLint
- PASS: git diff --check
- PASS: OCaml structure, stringly-boundary, and silent-failure ratchets
- Not run: local Dune/build/test suites; exact-head CI owns those checks

## Remaining

- Draft and do-not-merge until exact-head CI is green.
- Deployment and live batch-task rerun are still required before Feature completion.
