### PR TITLE
docs(rfc): RFC-0379 — keeper monitor event-driven wake

### DIFF
--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -241,6 +241,7 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0376 | 출력 목적지는 Keeper 가 판단한다 | Draft | - |
 | 0377 | 같은 대화의 밀린 메시지는 한 턴이 함께 본다 (Conversation-Batched Stimulus Intake) | Draft | - |
 | 0378 | Code fact 는 태어날 때 주소를 받는다 — typed address, code-fact 전용 store, anchor 계약 통일 | Draft | - |
+| 0379 | Keeper Monitor: 조건 전이가 Keeper 를 깨운다 (Event-Driven Wake) | Draft | - |
 | 0380 | 대기 나이는 홀더의 사이클을 알아야 한다 — work liveness 판정 축 정정 | Draft | - |
 | RFC-0034d-stale-agent-sync | d — release_stale_claims agent-side sync | Draft | - |
 | RFC-async-log-sink-durable-append-offload | Offload the structured-log durable append off the emitting fiber | Draft | - |

--- a/docs/rfc/RFC-0379-keeper-monitor-event-wake.md
+++ b/docs/rfc/RFC-0379-keeper-monitor-event-wake.md
@@ -25,7 +25,6 @@ type trigger =
   | Port_up of { host : string; port : int }
   | Port_down of { host : string; port : int }
   | File_changed of { path : string }          (* mtime 또는 inode 변화 *)
-  | Http_ok of { url : string }                (* 2xx 로의 전이 *)
 ```
 
 - **Edge-triggered**: 발화는 관측된 상태 전이에서만 일어난다. 최초 관측은 baseline 설정이며
@@ -73,6 +72,7 @@ catalog/schema/dispatch 결. create 입력: trigger, payload(opaque), expires_at
 | capability token / allowlist / audit | single-user; 게이트는 목표 달성 후 (운영 원칙) |
 | `arm`/`disarm`, `history`, versioned API | v1 수명이 one-shot 중심이라 상태 기계가 없다 |
 | `log_pattern` trigger | tail+regex 는 string 분류기 축 재개방. 로그가 아니라 상태를 관측한다 |
+| `Http_ok` trigger | v1.1 유예: 저장소에 Eio HTTP 클라이언트 실사용 선례가 없고, TCP 도달성으로 2xx 를 흉내내면 트리거 이름이 거짓말이 된다 |
 | process(pidfd) trigger | v1 대상 사례(서버 재기동)는 Port_up/Port_down 으로 충분 |
 | cooldown | max_fires=1 이 대체한다. 반복 monitor 는 v2 에서 전이 시맨틱과 함께 |
 

--- a/docs/rfc/RFC-0379-keeper-monitor-event-wake.md
+++ b/docs/rfc/RFC-0379-keeper-monitor-event-wake.md
@@ -1,0 +1,92 @@
+# RFC-0379 — Keeper Monitor: 조건 전이가 Keeper 를 깨운다 (Event-Driven Wake)
+
+- Status: draft
+- Author: dashboard-admin (Claude)
+- Origin: Fusion run `kmsg-27be397a51c68df14db74dfef17f0c36` (rondo, trio/refine, 2026-08-14)
+
+## 1. 문제
+
+Keeper 의 wake 소스는 시간뿐이다 (`masc_schedule_*`: one_shot / interval / daily / cron).
+런타임 조건의 **전이** — 서버 프로세스 재기동, 파일 변경, 포트 개통, HTTP 응답 회복 — 를 기다렸다가
+깨어나는 방법이 없다. 그래서 keeper 는 조건을 기다리려면 짧은 interval schedule 로 폴링 턴을
+소모하거나 (턴 낭비 + noop 판정 오염), 아예 포기한다.
+
+실측 동기: 2026-08-14 dashboard-admin 이 "서버 정지 감시 → purge → 부팅 감시 → 검증 배터리"
+흐름을 세션 외부 Monitor 로 수행했다. rondo 가 이 패턴을 관찰하고 fusion 으로 설계를 요청했다
+(run 위). 같은 날 keeper 관점의 결핍 사례: 재기동 후 새 빌드 검증을 keeper 가 스스로 이어받을
+방법이 없다.
+
+## 2. 설계 (v1)
+
+### 2.1 Trigger — 조건이 아니라 전이
+
+```
+type trigger =
+  | Port_up of { host : string; port : int }
+  | Port_down of { host : string; port : int }
+  | File_changed of { path : string }          (* mtime 또는 inode 변화 *)
+  | Http_ok of { url : string }                (* 2xx 로의 전이 *)
+```
+
+- **Edge-triggered**: 발화는 관측된 상태 전이에서만 일어난다. 최초 관측은 baseline 설정이며
+  발화하지 않는다 (부팅 직후 monitor 전체가 일제히 발화하는 boot-storm 을 구조적으로 차단).
+- 근거: "대기자 확인 없는 알림은 무조건 발화가 된다" — 2026-08 keeper 턴율 13.3배 사고의 교훈.
+  level-triggered 는 v1 에 존재하지 않는다.
+
+### 2.2 수명 — 기본은 one-shot
+
+- `max_fires` 기본 1. 발화 즉시 monitor 레코드 삭제 (죽은 행을 남기지 않는다).
+- `expires_at` 필수. 만료 시 sweep 이 삭제한다. 미발화 만료는 wake 없이 조용히 사라진다.
+- keeper 당 활성 monitor 상한 (상수, `max_active_monitors_per_keeper`).
+
+### 2.3 Wake — 기존 파이프라인 재사용
+
+발화는 schedule 과 동일한 wake 경로로 들어간다: 새 stimulus class `monitor_fired`,
+payload 는 keeper 가 create 시 넣은 opaque 값 그대로 + monitor id + 관측된 전이
+(`{ from; to; observed_at }`). 새 배달 경로·큐·계약을 만들지 않는다.
+
+### 2.4 Engine — 데몬이 아니라 서버 fiber
+
+masc 서버 자체가 sandbox 밖 상주 프로세스다. `Monitor_runner` 는 schedule runner 와 같은
+자리(server bootstrap)에서 도는 Eio fiber 하나이며, 적응형 인터벌로 관측한다
+(조건 미충족 시 2s, 충족 상태 유지 시 10s — fusion 패널 합의값). inotify/kqueue/pidfd 같은
+OS 이벤트 프리미티브는 v1 에서 쓰지 않는다 (macOS/Linux 이식성, 관측 대상 수가 작음).
+
+### 2.5 Store
+
+`<base-path>/.masc/monitors/` 아래 schedule store 와 같은 방식의 typed 저장.
+서버 재기동 시 리로드하되 **last_state 는 리로드하지 않는다** — 재기동 후 최초 관측이 새
+baseline 이다 (재기동 동안의 전이를 소급 발화하지 않는다; 그 시맨틱이 필요한 keeper 는
+one_shot schedule 로 즉시 확인 턴을 함께 건다).
+
+### 2.6 Tools
+
+`masc_monitor_create` / `masc_monitor_list` / `masc_monitor_cancel` — schedule 도구와 같은
+catalog/schema/dispatch 결. create 입력: trigger, payload(opaque), expires_at, (max_fires).
+반환: monitor id + 수락된 trigger 의 정규화 형태.
+
+## 3. 비범위 (fusion 패널 제안 중 기각)
+
+| 제안 | 기각 근거 |
+| --- | --- |
+| 별도 monitor 데몬 | masc 서버가 이미 그 데몬이다. 새 프로세스 = 새 운영 표면 |
+| capability token / allowlist / audit | single-user; 게이트는 목표 달성 후 (운영 원칙) |
+| `arm`/`disarm`, `history`, versioned API | v1 수명이 one-shot 중심이라 상태 기계가 없다 |
+| `log_pattern` trigger | tail+regex 는 string 분류기 축 재개방. 로그가 아니라 상태를 관측한다 |
+| process(pidfd) trigger | v1 대상 사례(서버 재기동)는 Port_up/Port_down 으로 충분 |
+| cooldown | max_fires=1 이 대체한다. 반복 monitor 는 v2 에서 전이 시맨틱과 함께 |
+
+## 4. 구현 계획
+
+1. `lib/monitor/`: `monitor_domain.ml(i)` (trigger/record/전이 판정 순수 함수),
+   `monitor_store.ml(i)`, `monitor_runner.ml(i)`
+2. tool schemas + catalog dispatch arms + surfaces 등록 (schedule 미러)
+3. server bootstrap 에 runner 기동 1줄
+4. `keeper_event_queue` 에 `monitor_fired` class 추가 (continuation 아님 — 자율 wake)
+
+## 5. 검증
+
+- 전이 판정 순수 함수 테스트: baseline 무발화, Up→Down/Down→Up 발화, 동일 상태 무발화,
+  만료 삭제, max_fires 소진 삭제 (suite 는 CI focused allowlist 에 배선)
+- 라이브: keeper 가 `Port_down(:8935)`+`Port_up(:8935)` monitor 를 걸고 서버 재기동을
+  관측해 검증 턴을 스스로 실행하는 것 — rondo 의 원 시나리오 재현이 완료 기준

--- a/lib/dune
+++ b/lib/dune
@@ -66,6 +66,7 @@
   masc.time_codec
   masc.sse_wire
   masc_schedule
+  masc_monitor
   ;; Shared leaf helpers extracted out of include_subdirs-unqualified ownership.
   masc.lockfree_atomic
   masc.run_registry_core

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -163,7 +163,8 @@ let connector_attention_event_ids_of_stimuli stimuli =
       | Keeper_event_queue.Goal_assigned _
       | Keeper_event_queue.Goal_reconciliation_ready _
       | Keeper_event_queue.Completion_authority_rejected _
-      | Keeper_event_queue.Task_cancelled _ ->
+      | Keeper_event_queue.Task_cancelled _
+      | Keeper_event_queue.Monitor_fired _ ->
         None)
     stimuli
 ;;
@@ -184,7 +185,8 @@ let record_replay_owned_turn_started_reactions ~ctx ~keeper_name stimuli =
        | Keeper_event_queue.Goal_assigned _
        | Keeper_event_queue.Goal_reconciliation_ready _
        | Keeper_event_queue.Completion_authority_rejected _
-       | Keeper_event_queue.Task_cancelled _ -> ())
+       | Keeper_event_queue.Task_cancelled _
+       | Keeper_event_queue.Monitor_fired _ -> ())
     stimuli
 ;;
 

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -66,7 +66,8 @@ let pending_board_event_of_stimulus ~meta_after_triage stim =
   | Keeper_event_queue.Goal_assigned _
   | Keeper_event_queue.Goal_reconciliation_ready _
   | Keeper_event_queue.Completion_authority_rejected _
-  | Keeper_event_queue.Task_cancelled _ ->
+  | Keeper_event_queue.Task_cancelled _
+  | Keeper_event_queue.Monitor_fired _ ->
     Keeper_world_observation.pending_board_event_of_stimulus
       ~meta:meta_after_triage
       stim
@@ -220,6 +221,11 @@ let event_queue_trigger_of_stimulus (stim : Keeper_event_queue.stimulus) =
      the 96%-of-turns scheduled channel and the cancellation reads as noise. *)
   | Keeper_event_queue.Task_cancelled _ ->
     Some Keeper_world_observation.Task_cancellation_stimulus
+  (* RFC-0379: dedicated turn_reason for the same reason as cancellations —
+     the keeper must be able to tell "my monitor fired" from an autonomous
+     tick, or the wake reads as noise. *)
+  | Keeper_event_queue.Monitor_fired _ ->
+    Some Keeper_world_observation.Monitor_fired_stimulus
 ;;
 
 let consume_single_heartbeat_stimulus
@@ -252,6 +258,14 @@ let consume_single_heartbeat_stimulus
         "turn entry: scheduled wake delivered schedule_id=%s due_at=%.3f (keeper=%s)"
         sw.schedule_id
         sw.due_at
+        meta_after_triage.name;
+      pending_board_events_of_stimulus_result ~meta_after_triage stim
+    | Keeper_event_queue.Monitor_fired mw ->
+      Log.Keeper.info
+        "turn entry: monitor fired monitor_id=%s from=%s to=%s (keeper=%s)"
+        mw.mw_monitor_id
+        (Monitor_domain.observation_label mw.mw_from)
+        (Monitor_domain.observation_label mw.mw_to)
         meta_after_triage.name;
       pending_board_events_of_stimulus_result ~meta_after_triage stim
     | Keeper_event_queue.Goal_assigned ga ->
@@ -384,7 +398,8 @@ let stimulus_ready_for_intake ~base_path (stimulus : Keeper_event_queue.stimulus
   | Keeper_event_queue.Goal_assigned _
   | Keeper_event_queue.Goal_reconciliation_ready _
   | Keeper_event_queue.Completion_authority_rejected _
-  | Keeper_event_queue.Task_cancelled _ ->
+  | Keeper_event_queue.Task_cancelled _
+  | Keeper_event_queue.Monitor_fired _ ->
     true
 ;;
 
@@ -404,7 +419,7 @@ let reconcile_spent_selection
       (selection : Keeper_event_queue_state.pending_selection)
   =
   match selection.source.Keeper_event_queue.payload with
-  | Schedule_due _ -> Ok Selection_actionable
+  | Schedule_due _ | Monitor_fired _ -> Ok Selection_actionable
   | Hitl_resolved
       { approval_id; decision = Keeper_event_queue.Hitl_approved; _ } ->
     (* An approved grant is one-shot, but consumption alone is not terminal:
@@ -515,7 +530,8 @@ let heartbeat_event_intake
       | Keeper_event_queue.Goal_assigned _
       | Keeper_event_queue.Goal_reconciliation_ready _
       | Keeper_event_queue.Completion_authority_rejected _
-      | Keeper_event_queue.Task_cancelled _ ->
+      | Keeper_event_queue.Task_cancelled _
+      | Keeper_event_queue.Monitor_fired _ ->
         false
     in
     match select_pending_matching manual_compaction_ready with
@@ -585,7 +601,8 @@ let heartbeat_event_intake
     | Keeper_event_queue.Goal_assigned _
     | Keeper_event_queue.Goal_reconciliation_ready _
     | Keeper_event_queue.Completion_authority_rejected _
-    | Keeper_event_queue.Task_cancelled _ ->
+    | Keeper_event_queue.Task_cancelled _
+    | Keeper_event_queue.Monitor_fired _ ->
       None
   in
   (* RFC-0377 P1-1: preload every batch member's recorded attention item in
@@ -741,7 +758,8 @@ let heartbeat_event_intake
             | Keeper_world_observation.Goal_assigned
             | Keeper_world_observation.Goal_reconciliation_ready
             | Keeper_world_observation.Completion_authority_rejected _
-            | Keeper_world_observation.Task_cancelled _ ->
+            | Keeper_world_observation.Task_cancelled _
+            | Keeper_world_observation.Monitor_fired _ ->
               Log.Keeper.info
                 "turn entry: promoted queued observation post_id=%s keeper=%s"
                 event.Keeper_world_observation.post_id

--- a/lib/keeper/keeper_monitor_runner.ml
+++ b/lib/keeper/keeper_monitor_runner.ml
@@ -1,0 +1,195 @@
+(** RFC-0379 monitor runner. *)
+
+let sweep_interval_sec = 1.0
+let probe_timeout_sec = 1.0
+let unmet_probe_interval_sec = 2.0
+let met_probe_interval_sec = 10.0
+
+type baseline =
+  { observation : Monitor_domain.observation
+  ; next_probe_at : float
+  }
+
+let observe_reachability ~net ~clock ~host ~port =
+  match
+    Eio.Time.with_timeout clock probe_timeout_sec (fun () ->
+      Eio.Switch.run
+      @@ fun sw ->
+      match Eio.Net.getaddrinfo_stream net host ~service:(string_of_int port) with
+      | [] -> Error `Timeout
+      | addr :: _ ->
+        let flow = Eio.Net.connect ~sw net addr in
+        Eio.Flow.close flow;
+        Ok ())
+  with
+  | Ok () -> Monitor_domain.Reachable
+  | Error `Timeout -> Monitor_domain.Unreachable
+  | exception (Eio.Cancel.Cancelled _ as exn) ->
+    let bt = Printexc.get_raw_backtrace () in
+    Printexc.raise_with_backtrace exn bt
+  | exception _ -> Monitor_domain.Unreachable
+;;
+
+let observe_file ~path =
+  match Unix.stat path with
+  | stat ->
+    Some
+      (Monitor_domain.File_snapshot
+         { mtime = stat.Unix.st_mtime; inode = stat.Unix.st_ino })
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> Some Monitor_domain.File_absent
+  | exception Unix.Unix_error (code, _, _) ->
+    Log.Server.warn
+      "monitor_runner: stat %s failed (%s); skipping this probe"
+      path
+      (Unix.error_message code);
+    None
+;;
+
+let observe ~net ~clock (trigger : Monitor_domain.trigger) =
+  match trigger with
+  | Monitor_domain.Port_up { host; port } | Monitor_domain.Port_down { host; port }
+    -> Some (observe_reachability ~net ~clock ~host ~port)
+  | Monitor_domain.File_changed { path } -> observe_file ~path
+;;
+
+(* Resting means the watched edge cannot be the next transition: a Port_up
+   monitor that already sees the port up has nothing to wait for except a
+   later drop, so it probes slowly. Files have no resting state. *)
+let probe_interval ~trigger ~(observation : Monitor_domain.observation) =
+  match trigger, observation with
+  | Monitor_domain.Port_up _, Monitor_domain.Reachable
+  | Monitor_domain.Port_down _, Monitor_domain.Unreachable ->
+    met_probe_interval_sec
+  | Monitor_domain.Port_up _, _
+  | Monitor_domain.Port_down _, _
+  | Monitor_domain.File_changed _, _ -> unmet_probe_interval_sec
+;;
+
+let fire ~base_path (record : Monitor_domain.t) ~from_ ~to_ ~now =
+  let wake =
+    { Keeper_event_queue.mw_monitor_id = record.id
+    ; mw_from = from_
+    ; mw_to = to_
+    ; mw_observed_at = now
+    ; mw_payload = record.payload
+    }
+  in
+  let stimulus =
+    { Keeper_event_queue.post_id = Keeper_event_queue.monitor_fired_post_id wake
+    ; urgency = Keeper_event_queue.Normal
+    ; arrived_at = now
+    ; payload = Keeper_event_queue.Monitor_fired wake
+    }
+  in
+  match
+    try
+      Keeper_registry_event_queue.enqueue_durable_result
+        ~base_path
+        record.keeper
+        stimulus
+    with
+    | Eio.Cancel.Cancelled _ as exn ->
+      let bt = Printexc.get_raw_backtrace () in
+      Printexc.raise_with_backtrace exn bt
+    | exn -> Error (Printexc.to_string exn)
+  with
+  | Error reason ->
+    (* Baseline stays uncommitted upstream, so the next sweep observes the
+       same edge and retries; the queue's identity projection collapses the
+       repeat into one pending wake. *)
+    Log.Server.error
+      "monitor_runner: wake enqueue failed monitor_id=%s keeper=%s: %s"
+      record.id
+      record.keeper
+      reason;
+    false
+  | Ok () ->
+    (match Keeper_monitor_store.record_fire ~base_path ~id:record.id with
+     | Ok Keeper_monitor_store.Fire_recorded_removed ->
+       Log.Server.info
+         "monitor_runner: fired and consumed monitor_id=%s keeper=%s %s->%s"
+         record.id
+         record.keeper
+         (Monitor_domain.observation_label from_)
+         (Monitor_domain.observation_label to_)
+     | Ok Keeper_monitor_store.Fire_recorded_retained ->
+       Log.Server.info
+         "monitor_runner: fired monitor_id=%s keeper=%s %s->%s (%d/%d)"
+         record.id
+         record.keeper
+         (Monitor_domain.observation_label from_)
+         (Monitor_domain.observation_label to_)
+         (record.fired_count + 1)
+         record.max_fires
+     | Error reason ->
+       Log.Server.warn
+         "monitor_runner: fire recorded in queue but not in store monitor_id=%s: %s"
+         record.id
+         reason);
+    true
+;;
+
+let sweep ~net ~clock ~base_path ~(baselines : (string, baseline) Hashtbl.t) ~now =
+  match Keeper_monitor_store.remove_expired ~base_path ~now with
+  | Error reason -> Log.Server.warn "monitor_runner: expiry sweep failed: %s" reason
+  | Ok expired ->
+    List.iter
+      (fun id ->
+         Hashtbl.remove baselines id;
+         Log.Server.info "monitor_runner: expired monitor_id=%s" id)
+      expired;
+    (match Keeper_monitor_store.load ~base_path with
+     | Error reason -> Log.Server.warn "monitor_runner: store load failed: %s" reason
+     | Ok records ->
+       let live_ids = List.map (fun (r : Monitor_domain.t) -> r.id) records in
+       Hashtbl.iter
+         (fun id _ ->
+            if not (List.mem id live_ids) then Hashtbl.remove baselines id)
+         (Hashtbl.copy baselines);
+       List.iter
+         (fun (record : Monitor_domain.t) ->
+            let due =
+              match Hashtbl.find_opt baselines record.id with
+              | None -> true
+              | Some { next_probe_at; _ } -> Float.compare now next_probe_at >= 0
+            in
+            if due
+            then (
+              match observe ~net ~clock record.trigger with
+              | None -> ()
+              | Some current ->
+                let prev =
+                  Option.map
+                    (fun { observation; _ } -> observation)
+                    (Hashtbl.find_opt baselines record.id)
+                in
+                let commit () =
+                  Hashtbl.replace
+                    baselines
+                    record.id
+                    { observation = current
+                    ; next_probe_at =
+                        now +. probe_interval ~trigger:record.trigger ~observation:current
+                    }
+                in
+                (match Monitor_domain.decide record.trigger ~prev ~current with
+                 | Monitor_domain.Hold -> commit ()
+                 | Monitor_domain.Fire { from_; to_ } ->
+                   if fire ~base_path record ~from_ ~to_ ~now then commit ())))
+         records)
+;;
+
+let run ~net ~clock ~base_path () =
+  let baselines : (string, baseline) Hashtbl.t = Hashtbl.create 16 in
+  let rec loop () =
+    (try sweep ~net ~clock ~base_path ~baselines ~now:(Time_compat.now ()) with
+     | Eio.Cancel.Cancelled _ as exn ->
+       let bt = Printexc.get_raw_backtrace () in
+       Printexc.raise_with_backtrace exn bt
+     | exn ->
+       Log.Server.warn "monitor_runner: sweep crashed: %s" (Printexc.to_string exn));
+    Eio.Time.sleep clock sweep_interval_sec;
+    loop ()
+  in
+  loop ()
+;;

--- a/lib/keeper/keeper_monitor_runner.mli
+++ b/lib/keeper/keeper_monitor_runner.mli
@@ -12,6 +12,21 @@ val probe_timeout_sec : float
 val unmet_probe_interval_sec : float
 val met_probe_interval_sec : float
 
+type baseline
+(** One monitor's in-memory observation state: the baseline for edge
+    detection plus its next probe deadline. Never persisted. *)
+
+val sweep :
+  net:'a Eio.Net.t ->
+  clock:'b Eio.Time.clock ->
+  base_path:string ->
+  baselines:(string, baseline) Hashtbl.t ->
+  now:float ->
+  unit
+(** One full pass: expiry sweep, store reload, baseline pruning, due probes,
+    edge decisions, and wake enqueues. [run] is exactly this in a loop; tests
+    drive single passes against a real store and real sockets. *)
+
 val run :
   net:'a Eio.Net.t ->
   clock:'b Eio.Time.clock ->

--- a/lib/keeper/keeper_monitor_runner.mli
+++ b/lib/keeper/keeper_monitor_runner.mli
@@ -1,0 +1,23 @@
+(** RFC-0379 monitor runner: a server fiber that observes registered monitor
+    conditions and enqueues a [Monitor_fired] wake when one crosses its edge.
+
+    The runner is the only observer. It keeps each monitor's baseline in
+    memory only — the first observation after boot establishes a baseline and
+    never fires — probes with adaptive intervals (2s while the watched edge
+    has not arrived, 10s while resting), and lets [Monitor_domain.decide]
+    make every fire decision. *)
+
+val sweep_interval_sec : float
+val probe_timeout_sec : float
+val unmet_probe_interval_sec : float
+val met_probe_interval_sec : float
+
+val run :
+  net:'a Eio.Net.t ->
+  clock:'b Eio.Time.clock ->
+  base_path:string ->
+  unit ->
+  unit
+(** Loops until the enclosing switch is cancelled. Store errors and probe
+    failures are logged and retried on the next sweep; only
+    [Eio.Cancel.Cancelled] escapes. *)

--- a/lib/keeper/keeper_monitor_store.ml
+++ b/lib/keeper/keeper_monitor_store.ml
@@ -1,0 +1,137 @@
+(** Durable store for RFC-0379 keeper monitors. *)
+
+let store_path ~base_path =
+  Filename.concat
+    (Filename.concat (Common.masc_dir_from_base_path ~base_path) "monitors")
+    "monitors-v1.json"
+;;
+
+let ( let* ) = Result.bind
+
+let decode_records content =
+  if String.equal (String.trim content) ""
+  then Ok []
+  else (
+    match Yojson.Safe.from_string content with
+    | `List items ->
+      List.fold_left
+        (fun acc item ->
+           let* acc = acc in
+           let* record = Monitor_domain.of_yojson item in
+           Ok (record :: acc))
+        (Ok [])
+        items
+      |> Result.map List.rev
+    | _ -> Error "monitor store must be a JSON array"
+    | exception Yojson.Json_error message ->
+      Error (Printf.sprintf "monitor store is not valid JSON: %s" message))
+;;
+
+let encode_records records =
+  Yojson.Safe.pretty_to_string
+    (`List (List.map Monitor_domain.to_yojson records))
+  ^ "\n"
+;;
+
+(* One locked read-decide-rewrite transaction over the whole store. [decide]
+   returns the records to persist ([None] = no write) plus the caller value.
+   Decode failure aborts the transaction: a malformed store is surfaced, never
+   silently replaced. *)
+let transact ~base_path decide =
+  match
+    Fs_compat.rewrite_private_file_durable_locked_result
+      (store_path ~base_path)
+      (fun existing ->
+         match decode_records existing with
+         | Error message -> None, Error message
+         | Ok records ->
+           (match decide records with
+            | Error message -> None, Error message
+            | Ok (None, value) -> None, Ok value
+            | Ok (Some records', value) -> Some (encode_records records'), Ok value))
+  with
+  | Ok result -> result
+  | Error message -> Error message
+;;
+
+let load ~base_path =
+  transact ~base_path (fun records -> Ok (None, records))
+;;
+
+let create ~base_path (record : Monitor_domain.t) =
+  transact ~base_path (fun records ->
+    if List.exists (fun (r : Monitor_domain.t) -> String.equal r.id record.id) records
+    then Error (Printf.sprintf "monitor id %s already exists" record.id)
+    else (
+      let owned =
+        List.length
+          (List.filter
+             (fun (r : Monitor_domain.t) -> String.equal r.keeper record.keeper)
+             records)
+      in
+      if owned >= Monitor_domain.max_active_monitors_per_keeper
+      then
+        Error
+          (Printf.sprintf
+             "keeper %s already holds %d active monitors (cap %d)"
+             record.keeper
+             owned
+             Monitor_domain.max_active_monitors_per_keeper)
+      else Ok (Some (records @ [ record ]), ())))
+;;
+
+let cancel ~base_path ~keeper ~id =
+  transact ~base_path (fun records ->
+    match
+      List.find_opt (fun (r : Monitor_domain.t) -> String.equal r.id id) records
+    with
+    | None -> Ok (None, false)
+    | Some record when not (String.equal record.keeper keeper) ->
+      Error
+        (Printf.sprintf "monitor %s belongs to keeper %s" id record.keeper)
+    | Some _ ->
+      let records' =
+        List.filter (fun (r : Monitor_domain.t) -> not (String.equal r.id id)) records
+      in
+      Ok (Some records', true))
+;;
+
+type fire_outcome =
+  | Fire_recorded_retained
+  | Fire_recorded_removed
+
+let record_fire ~base_path ~id =
+  transact ~base_path (fun records ->
+    match
+      List.find_opt (fun (r : Monitor_domain.t) -> String.equal r.id id) records
+    with
+    | None -> Error (Printf.sprintf "monitor %s is no longer stored" id)
+    | Some record ->
+      let fired = { record with Monitor_domain.fired_count = record.fired_count + 1 } in
+      if Monitor_domain.exhausted fired
+      then (
+        let records' =
+          List.filter
+            (fun (r : Monitor_domain.t) -> not (String.equal r.id id))
+            records
+        in
+        Ok (Some records', Fire_recorded_removed))
+      else (
+        let records' =
+          List.map
+            (fun (r : Monitor_domain.t) -> if String.equal r.id id then fired else r)
+            records
+        in
+        Ok (Some records', Fire_recorded_retained)))
+;;
+
+let remove_expired ~base_path ~now =
+  transact ~base_path (fun records ->
+    let expired, live =
+      List.partition (fun record -> Monitor_domain.expired record ~now) records
+    in
+    match expired with
+    | [] -> Ok (None, [])
+    | _ ->
+      Ok (Some live, List.map (fun (r : Monitor_domain.t) -> r.id) expired))
+;;

--- a/lib/keeper/keeper_monitor_store.mli
+++ b/lib/keeper/keeper_monitor_store.mli
@@ -1,0 +1,35 @@
+(** Durable store for RFC-0379 keeper monitors.
+
+    One locked JSON array at [<masc>/monitors/monitors-v1.json], rewritten
+    atomically under the shared per-path mutex. Records reload without their
+    observation baseline ([Monitor_domain.of_yojson] drops it), so a server
+    restart re-baselines every monitor instead of firing transitions that
+    happened while the server was down. *)
+
+val load : base_path:string -> (Monitor_domain.t list, string) result
+(** Locked read. An absent store file is an empty list; a malformed store is
+    an error, never a silent reset. *)
+
+val create : base_path:string -> Monitor_domain.t -> (unit, string) result
+(** Fails when the id already exists or the keeper already holds
+    {!Monitor_domain.max_active_monitors_per_keeper} active monitors. *)
+
+val cancel :
+  base_path:string -> keeper:string -> id:string -> (bool, string) result
+(** [Ok true] when the keeper's own monitor was removed, [Ok false] when no
+    monitor with that id exists. A monitor owned by another keeper is an
+    error, not a removal. *)
+
+type fire_outcome =
+  | Fire_recorded_retained
+  | Fire_recorded_removed
+      (** The fire consumed the record's last remaining allowance
+          ([fired_count] reached [max_fires]); the record was deleted so no
+          exhausted rows persist. *)
+
+val record_fire : base_path:string -> id:string -> (fire_outcome, string) result
+(** An unknown id is an error: the runner observed a record that the store no
+    longer holds (raced cancel), and the caller decides how loudly to say so. *)
+
+val remove_expired : base_path:string -> now:float -> (string list, string) result
+(** Deletes every expired record and returns the removed ids. *)

--- a/lib/keeper/keeper_paused_work_disposition_receipt.ml
+++ b/lib/keeper/keeper_paused_work_disposition_receipt.ml
@@ -63,7 +63,8 @@ let continuation_binding_of_source source =
   | Keeper_event_queue.Goal_assigned _
   | Keeper_event_queue.Goal_reconciliation_ready _
   | Keeper_event_queue.Completion_authority_rejected _
-  | Keeper_event_queue.Task_cancelled _ ->
+  | Keeper_event_queue.Task_cancelled _
+  | Keeper_event_queue.Monitor_fired _ ->
     No_channel
 ;;
 

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -12,6 +12,8 @@ type stimulus_kind =
   | Goal_reconciliation_ready
   | Completion_authority_rejected
   | Task_cancelled
+  | Monitor_fired
+      (* RFC-0379: a registered monitor observed its condition transition. *)
 
 type reaction_kind =
   | Turn_started
@@ -39,6 +41,7 @@ let stimulus_kind_to_string = function
   | Goal_reconciliation_ready -> "goal_reconciliation_ready"
   | Completion_authority_rejected -> "completion_authority_rejected"
   | Task_cancelled -> "task_cancelled"
+  | Monitor_fired -> "monitor_fired"
 ;;
 
 (* stimulus_kind_to_string의 역. 닫힌 합에 없는 문자열(스키마 드리프트/손상 row)은
@@ -57,6 +60,7 @@ let stimulus_kind_of_string = function
   | "goal_reconciliation_ready" -> Some Goal_reconciliation_ready
   | "completion_authority_rejected" -> Some Completion_authority_rejected
   | "task_cancelled" -> Some Task_cancelled
+  | "monitor_fired" -> Some Monitor_fired
   | _ -> None
 ;;
 
@@ -94,6 +98,7 @@ let stimulus_kind_of_event_queue (stimulus : Keeper_event_queue.stimulus) =
   | Keeper_event_queue.Completion_authority_rejected _ ->
     Completion_authority_rejected
   | Keeper_event_queue.Task_cancelled _ -> Task_cancelled
+  | Keeper_event_queue.Monitor_fired _ -> Monitor_fired
 ;;
 
 let stimulus_id_of_event_queue (stimulus : Keeper_event_queue.stimulus) =
@@ -103,6 +108,7 @@ let stimulus_id_of_event_queue (stimulus : Keeper_event_queue.stimulus) =
   | Keeper_event_queue.Board_signal _, Board_signal ->
     board_stimulus_id ~post_id:stimulus.post_id
   | Keeper_event_queue.Schedule_due _, Schedule_due -> stimulus.post_id
+  | Keeper_event_queue.Monitor_fired _, Monitor_fired -> stimulus.post_id
   | Keeper_event_queue.Completion_authority_rejected _, Completion_authority_rejected ->
     stimulus.post_id
   | _, kind ->
@@ -205,6 +211,12 @@ let stimulus_payload_preview (payload : Keeper_event_queue.stimulus_payload) =
       "task_cancelled task_id=%s cancelled_by=%s"
       cancellation.tc_task_id
       cancellation.tc_cancelled_by
+  | Keeper_event_queue.Monitor_fired wake ->
+    Printf.sprintf
+      "monitor_fired monitor_id=%s from=%s to=%s"
+      wake.mw_monitor_id
+      (Monitor_domain.observation_label wake.mw_from)
+      (Monitor_domain.observation_label wake.mw_to)
 ;;
 
 let stimulus_json ~keeper_name (stimulus : Keeper_event_queue.stimulus) =
@@ -225,6 +237,7 @@ let stimulus_json ~keeper_name (stimulus : Keeper_event_queue.stimulus) =
     | Keeper_event_queue.Goal_reconciliation_ready _ -> None
     | Keeper_event_queue.Completion_authority_rejected _ -> None
     | Keeper_event_queue.Task_cancelled _ -> None
+    | Keeper_event_queue.Monitor_fired _ -> None
   in
   `Assoc
     (base_fields
@@ -837,7 +850,8 @@ let decode_current_row ~keeper_name row =
         | Goal_assigned
         | Goal_reconciliation_ready
         | Completion_authority_rejected
-        | Task_cancelled ),
+        | Task_cancelled
+        | Monitor_fired ),
         _ -> Ok ()
     in
     let expected_event_id = digest_id "krl" (stimulus_id ^ "|stimulus") in
@@ -1307,7 +1321,8 @@ let board_stimulus_token metadata stimulus_kind =
   | Goal_assigned
   | Goal_reconciliation_ready
   | Completion_authority_rejected
-  | Task_cancelled -> None
+  | Task_cancelled
+  | Monitor_fired -> None
 ;;
 
 let summarize_rows ~keeper_name ~limit rows =

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -22,6 +22,7 @@ type stimulus_kind =
   | Completion_authority_rejected
       (** System completion authority rejected Keeper evidence. *)
   | Task_cancelled
+  | Monitor_fired
       (** Another Keeper cancelled a Task this Keeper authored. *)
 
 type reaction_kind =

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -358,7 +358,8 @@ let board_attention_event_id (stimulus : Keeper_event_queue.stimulus) =
   | Keeper_event_queue.Goal_assigned _
   | Keeper_event_queue.Goal_reconciliation_ready _
   | Keeper_event_queue.Completion_authority_rejected _
-  | Keeper_event_queue.Task_cancelled _ ->
+  | Keeper_event_queue.Task_cancelled _
+  | Keeper_event_queue.Monitor_fired _ ->
     None
 ;;
 

--- a/lib/keeper/keeper_tag_dispatch.ml
+++ b/lib/keeper/keeper_tag_dispatch.ml
@@ -25,6 +25,7 @@ let string_of_tag (tag : Tool_dispatch.module_tag) : string =
   | Mod_control -> "control"
   | Mod_agent_timeline -> "agent_timeline"
   | Mod_schedule -> "schedule"
+  | Mod_monitor -> "monitor"
   | Mod_misc -> "misc"
   | Mod_inline -> "inline"
   | Mod_operator -> "operator"
@@ -118,6 +119,8 @@ let dispatch
         }
         ~name
         ~args
+    | Mod_monitor ->
+      Tool_monitor.dispatch { Tool_monitor.config; agent_name } ~name ~args
     | Mod_misc ->
       Tool_misc.dispatch
         { Tool_misc.config

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -103,6 +103,7 @@ type runtime_handler =
   | Tool_masc_control_dispatch
   | Tool_masc_agent_timeline_dispatch
   | Tool_masc_schedule_dispatch
+  | Tool_masc_monitor_dispatch
   | Tool_masc_keeper_dispatch
   | Tool_masc_fusion_dispatch
   | Tool_masc_fusion_status
@@ -221,6 +222,7 @@ let runtime_handler_to_string = function
   | Tool_masc_control_dispatch -> "tool_masc_control_dispatch"
   | Tool_masc_agent_timeline_dispatch -> "tool_masc_agent_timeline_dispatch"
   | Tool_masc_schedule_dispatch -> "tool_masc_schedule_dispatch"
+  | Tool_masc_monitor_dispatch -> "tool_masc_monitor_dispatch"
   | Tool_masc_keeper_dispatch -> "tool_masc_keeper_dispatch"
   | Tool_masc_fusion_dispatch -> "tool_masc_fusion_dispatch"
   | Tool_masc_fusion_status -> "tool_masc_fusion_status"
@@ -243,6 +245,7 @@ let keeper_tool_group_of_runtime_handler = function
   | Tool_masc_control_dispatch
   | Tool_masc_agent_timeline_dispatch
   | Tool_masc_schedule_dispatch
+  | Tool_masc_monitor_dispatch
   | Tool_masc_keeper_dispatch
   | Tool_masc_fusion_dispatch
   | Tool_masc_fusion_status
@@ -556,6 +559,7 @@ let descriptor
       | Tool_masc_control_dispatch
       | Tool_masc_agent_timeline_dispatch
       | Tool_masc_schedule_dispatch
+  | Tool_masc_monitor_dispatch
       | Tool_masc_keeper_dispatch
       | Tool_masc_fusion_dispatch
       | Tool_masc_fusion_status
@@ -1379,6 +1383,21 @@ let masc_agent_timeline_descriptor name description ~readonly =
     ()
 ;;
 
+let masc_monitor_descriptor (definition : Tool_schemas_monitor.definition) =
+  let schema : Masc_domain.tool_schema = definition.schema in
+  cluster_descriptor_with_schema_source
+    ~capability_identity:Internal_name_identity
+    ~keeper_model_projection:Internal_name
+    ~input_schema_source:Canonical_registry
+    ~input_schema:schema.input_schema
+    ~id:("masc.monitor." ^ definition.id)
+    ~name:schema.name
+    ~description:schema.description
+    ~handler:Tool_masc_monitor_dispatch
+    ~readonly:definition.read_only
+    ()
+;;
+
 let masc_schedule_descriptor (definition : Tool_schemas_schedule.definition) =
   let schema : Masc_domain.tool_schema = definition.schema in
   cluster_descriptor_with_schema_source
@@ -1849,6 +1868,8 @@ let internal_descriptors : t list =
   (* ── RFC-0234 — scheduled internal automation (6 entries) ─────── *)
   ]
   @ List.map masc_schedule_descriptor Tool_schemas_schedule.definitions
+  (* ── RFC-0379 — keeper condition monitors (3 entries) ────────── *)
+  @ List.map masc_monitor_descriptor Tool_schemas_monitor.definitions
   @ [
   (* ── RFC-0182 §3.1 — masc_keeper cluster ──── *)
     masc_keeper_descriptor ~keeper_model_projection:Operator_only "list" "masc_keeper_list"

--- a/lib/keeper/keeper_tool_descriptor.mli
+++ b/lib/keeper/keeper_tool_descriptor.mli
@@ -120,6 +120,7 @@ type runtime_handler =
   | Tool_masc_control_dispatch
   | Tool_masc_agent_timeline_dispatch
   | Tool_masc_schedule_dispatch
+  | Tool_masc_monitor_dispatch
   | Tool_masc_keeper_dispatch
   | Tool_masc_fusion_dispatch
   | Tool_masc_fusion_status

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -1629,6 +1629,16 @@ let handle_masc_schedule_with_outcome
   Tool_schedule.dispatch ctx ~name ~args |> dispatch_option_to_execution ~name
 ;;
 
+let handle_masc_monitor_with_outcome
+      ~(config : Workspace.config)
+      ~(meta : keeper_meta)
+      ~name
+      ~args
+  =
+  Tool_monitor.dispatch { Tool_monitor.config; agent_name = meta.name } ~name ~args
+  |> dispatch_option_to_execution ~name
+;;
+
 (* RFC-0252 — masc_fusion out-of-band panel+judge deliberation.  The
    gate -> fiber fork -> orchestrator logic lives in [Fusion_tool.handle];
    this handler only gathers the keeper context and loads the [fusion] policy

--- a/lib/keeper/keeper_tool_in_process_runtime.mli
+++ b/lib/keeper/keeper_tool_in_process_runtime.mli
@@ -260,6 +260,15 @@ val handle_masc_schedule_with_outcome
   -> unit
   -> Keeper_tool_execution.t
 
+(** RFC-0379 — [handle_masc_monitor_with_outcome] is the descriptor-projection
+    cluster handler for [masc_monitor_*] tools. *)
+val handle_masc_monitor_with_outcome
+  :  config:Workspace.config
+  -> meta:keeper_meta
+  -> name:string
+  -> args:Yojson.Safe.t
+  -> Keeper_tool_execution.t
+
 (** RFC-0252 — [handle_masc_fusion_with_outcome] is the in-process handler for the
     [masc_fusion] out-of-band panel+judge deliberation tool.  It loads the
     [fusion] policy from runtime.toml and delegates durable async submission to

--- a/lib/keeper/keeper_tool_runtime.ml
+++ b/lib/keeper/keeper_tool_runtime.ml
@@ -90,6 +90,7 @@ let handle_filesystem ctx descriptor args =
   | Tool_masc_control_dispatch
   | Tool_masc_agent_timeline_dispatch
   | Tool_masc_schedule_dispatch
+  | Tool_masc_monitor_dispatch
   | Tool_masc_keeper_dispatch
   | Tool_masc_fusion_dispatch
   | Tool_masc_fusion_status
@@ -149,6 +150,7 @@ let handle_shell_ir ctx descriptor args =
   | Tool_masc_control_dispatch
   | Tool_masc_agent_timeline_dispatch
   | Tool_masc_schedule_dispatch
+  | Tool_masc_monitor_dispatch
   | Tool_masc_keeper_dispatch
   | Tool_masc_fusion_dispatch
   | Tool_masc_fusion_status
@@ -345,6 +347,13 @@ let handle_in_process ctx descriptor args =
          ~name
          ~args
          ())
+  | Tool_masc_monitor_dispatch ->
+    Some
+      (Keeper_tool_in_process_runtime.handle_masc_monitor_with_outcome
+         ~config:ctx.config
+         ~meta:ctx.meta
+         ~name
+         ~args)
   | Tool_masc_keeper_dispatch ->
     Some
       (Keeper_tool_in_process_runtime.handle_masc_keeper_with_outcome

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -214,6 +214,7 @@ let board_event_kind_label = function
   | Keeper_world_observation.Completion_authority_rejected _ ->
     "completion_authority_rejected"
   | Keeper_world_observation.Task_cancelled _ -> "task_cancelled"
+  | Keeper_world_observation.Monitor_fired _ -> "monitor_fired"
 ;;
 
 let quote_prompt_field value =
@@ -303,7 +304,8 @@ let board_event_note_fields = function
   | Keeper_world_observation.Goal_assigned
   | Keeper_world_observation.Goal_reconciliation_ready
   | Keeper_world_observation.Completion_authority_rejected _
-  | Keeper_world_observation.Task_cancelled _ -> []
+  | Keeper_world_observation.Task_cancelled _
+  | Keeper_world_observation.Monitor_fired _ -> []
 ;;
 
 let board_event_fields
@@ -475,10 +477,57 @@ let format_scheduled_wake_observations
          | Keeper_world_observation.Goal_assigned
          | Keeper_world_observation.Goal_reconciliation_ready
          | Keeper_world_observation.Completion_authority_rejected _
-         | Keeper_world_observation.Task_cancelled _ -> ())
+         | Keeper_world_observation.Task_cancelled _
+         | Keeper_world_observation.Monitor_fired _ -> ())
       events;
     Buffer.add_char ubuf '\n';
     Some (Buffer.contents ubuf))
+;;
+
+(* RFC-0379: monitor-fired wakes render as their own block inside the
+   automation layer. The payload row is the keeper-authored instruction
+   recorded at masc_monitor_create; for a default one-shot the monitor record
+   is already consumed when this renders. *)
+let format_monitor_fired_observations
+    (events : Keeper_world_observation.pending_board_event list) =
+  let rows =
+    List.filter_map
+      (fun (event : Keeper_world_observation.pending_board_event) ->
+         match event.event_kind with
+         | Keeper_world_observation.Monitor_fired wake ->
+           Some
+             (format_prompt_row
+                [ "monitor_id", wake.Keeper_event_queue.mw_monitor_id
+                ; "from", Monitor_domain.observation_label wake.mw_from
+                ; "to", Monitor_domain.observation_label wake.mw_to
+                ; ( "payload"
+                  , match wake.mw_payload with
+                    | `String text -> text
+                    | other -> Yojson.Safe.to_string other )
+                ]
+              ^ "\n")
+         | Keeper_world_observation.Board_post_created
+         | Keeper_world_observation.Board_comment_added
+         | Keeper_world_observation.Board_reaction_changed _
+         | Keeper_world_observation.Fusion_completed
+         | Keeper_world_observation.Schedule_due _
+         | Keeper_world_observation.External_attention _
+         | Keeper_world_observation.Goal_assigned
+         | Keeper_world_observation.Goal_reconciliation_ready
+         | Keeper_world_observation.Completion_authority_rejected _
+         | Keeper_world_observation.Task_cancelled _ -> None)
+      events
+  in
+  match rows with
+  | [] -> None
+  | _ ->
+    Some
+      ("### Monitor Fired ("
+       ^ string_of_int (List.length rows)
+       ^ ")\nA condition this Keeper registered crossed its requested edge. \
+          The payload row is the exact instruction recorded at \
+          masc_monitor_create.\n"
+       ^ String.concat "" rows)
 ;;
 
 let format_completion_authority_rejection_observations
@@ -508,7 +557,8 @@ let format_completion_authority_rejection_observations
          | Keeper_world_observation.External_attention _
          | Keeper_world_observation.Goal_assigned
          | Keeper_world_observation.Goal_reconciliation_ready
-         | Keeper_world_observation.Task_cancelled _ -> None)
+         | Keeper_world_observation.Task_cancelled _
+         | Keeper_world_observation.Monitor_fired _ -> None)
       events
   in
   match rows with
@@ -560,7 +610,8 @@ let format_task_cancellation_observations
          | Keeper_world_observation.External_attention _
          | Keeper_world_observation.Goal_assigned
          | Keeper_world_observation.Goal_reconciliation_ready
-         | Keeper_world_observation.Completion_authority_rejected _ -> None)
+         | Keeper_world_observation.Completion_authority_rejected _
+         | Keeper_world_observation.Monitor_fired _ -> None)
       events
   in
   match rows with
@@ -1181,6 +1232,9 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta)
             (List.filter
                Keeper_world_observation.is_scheduled_automation_event
                observation.pending_board_events)
+          (* RFC-0379: monitor wakes share the automation layer position but
+             keep their own section vocabulary — a monitor is not a schedule. *)
+        ; format_monitor_fired_observations observation.pending_board_events
         ]
     (* 5b. Completion-authority decisions — a distinct system LLM boundary.
        These rows are not Board activity and must not be routed through the

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -194,7 +194,8 @@ let is_manual_compaction_payload = function
   | Keeper_event_queue.Goal_assigned _
   | Keeper_event_queue.Goal_reconciliation_ready _
   | Keeper_event_queue.Completion_authority_rejected _
-  | Keeper_event_queue.Task_cancelled _ ->
+  | Keeper_event_queue.Task_cancelled _
+  | Keeper_event_queue.Monitor_fired _ ->
     false
 ;;
 

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -24,6 +24,7 @@ type pending_board_event_kind =
   | Board_reaction_changed of board_reaction_event
   | Fusion_completed
   | Schedule_due of Keeper_event_queue.scheduled_wake
+  | Monitor_fired of Keeper_event_queue.monitor_wake
   | External_attention of Keeper_counterpart_observation.t
   | Goal_assigned
   | Goal_reconciliation_ready
@@ -63,7 +64,7 @@ let is_board_activity_event (event : pending_board_event) =
   | Goal_reconciliation_ready -> true
   (* Neither carries a Board post, so routing either here would count a
      non-existent post in [board_activity_count]. Each has its own renderer. *)
-  | Completion_authority_rejected _ | Task_cancelled _ -> false
+  | Completion_authority_rejected _ | Task_cancelled _ | Monitor_fired _ -> false
 ;;
 
 let is_scheduled_automation_event (event : pending_board_event) =
@@ -77,7 +78,8 @@ let is_scheduled_automation_event (event : pending_board_event) =
   | Goal_assigned
   | Goal_reconciliation_ready
   | Completion_authority_rejected _
-  | Task_cancelled _ -> false
+  | Task_cancelled _
+  | Monitor_fired _ -> false
 ;;
 
 let is_completion_authority_rejection_event (event : pending_board_event) =
@@ -91,7 +93,8 @@ let is_completion_authority_rejection_event (event : pending_board_event) =
   | External_attention _
   | Goal_assigned
   | Goal_reconciliation_ready
-  | Task_cancelled _ -> false
+  | Task_cancelled _
+  | Monitor_fired _ -> false
 ;;
 
 (* A cancellation of a Task this Keeper authored. Kept off the Board Activity
@@ -108,7 +111,25 @@ let is_task_cancellation_event (event : pending_board_event) =
   | External_attention _
   | Goal_assigned
   | Goal_reconciliation_ready
-  | Completion_authority_rejected _ -> false
+  | Completion_authority_rejected _
+  | Monitor_fired _ -> false
+;;
+
+(* RFC-0379: rendered by its own section inside the automation layer; not
+   Board activity (no post exists) and not a schedule dispatch. *)
+let is_monitor_fired_event (event : pending_board_event) =
+  match event.event_kind with
+  | Monitor_fired _ -> true
+  | Board_post_created
+  | Board_comment_added
+  | Board_reaction_changed _
+  | Fusion_completed
+  | Schedule_due _
+  | External_attention _
+  | Goal_assigned
+  | Goal_reconciliation_ready
+  | Completion_authority_rejected _
+  | Task_cancelled _ -> false
 ;;
 
 type scheduled_automation_item =
@@ -166,6 +187,7 @@ type event_queue_trigger =
   | Hitl_resolved_stimulus
   | Completion_authority_rejection_stimulus
   | Task_cancellation_stimulus
+  | Monitor_fired_stimulus
   | Manual_compaction_stimulus
 
 type turn_reason = Keeper_world_observation_turn_types.turn_reason =
@@ -177,6 +199,7 @@ type turn_reason = Keeper_world_observation_turn_types.turn_reason =
   | Hitl_resolved_pending
   | Completion_authority_rejection_pending
   | Task_cancellation_pending
+  | Monitor_fired_pending
   | Manual_compaction_pending
   | Scheduled_autonomous_turn
   | Scheduled_automation_due
@@ -535,6 +558,43 @@ let pending_board_event_of_fusion_completion
 
 let scheduled_automation_actor = "scheduled_automation"
 
+let monitor_fired_actor = "monitor"
+
+let monitor_payload_preview (payload : Yojson.Safe.t) =
+  match payload with
+  | `String text -> text
+  | other -> Yojson.Safe.to_string other
+;;
+
+let pending_board_event_of_monitor_wake
+      ~meta:(_ : keeper_meta)
+      ~post_id
+      ~(arrived_at : float)
+      (mw : Keeper_event_queue.monitor_wake)
+  : pending_board_event
+  =
+  { event_kind = Monitor_fired mw
+  ; post_id
+  ; author = monitor_fired_actor
+  ; title =
+      Printf.sprintf
+        "Monitor %s fired: %s -> %s"
+        mw.mw_monitor_id
+        (Monitor_domain.observation_label mw.mw_from)
+        (Monitor_domain.observation_label mw.mw_to)
+  ; preview = monitor_payload_preview mw.mw_payload
+  ; hearth = None
+  ; post_kind = Board.System_post
+  ; updated_at = arrived_at
+  ; explicit_mention = false
+  ; matched_targets = []
+  ; self_commented = false
+  ; new_external_since = 0
+  ; latest_external_author = None
+  ; latest_external_preview = None
+  }
+;;
+
 let pending_board_event_of_scheduled_wake
       ~meta:(_ : keeper_meta)
       ~post_id
@@ -809,6 +869,14 @@ let pending_board_event_of_stimulus
          (pending_board_event_of_task_cancellation
             ~arrived_at:stimulus.arrived_at
             cancellation))
+  | Keeper_event_queue.Monitor_fired mw ->
+    Ok
+      (Some
+         (pending_board_event_of_monitor_wake
+            ~meta
+            ~post_id:stimulus.post_id
+            ~arrived_at:stimulus.arrived_at
+            mw))
   | Keeper_event_queue.Bootstrap
   | Keeper_event_queue.Connector_attention _
   | Keeper_event_queue.Hitl_resolved _
@@ -1304,6 +1372,10 @@ let has_pending_task_cancellation (observation : world_observation) =
   List.exists is_task_cancellation_event observation.pending_board_events
 ;;
 
+let has_pending_monitor_fired (observation : world_observation) =
+  List.exists is_monitor_fired_event observation.pending_board_events
+;;
+
 let keeper_cycle_decision
       ?(event_queue_triggers = [])
       ~(meta : keeper_meta)
@@ -1350,6 +1422,7 @@ let keeper_cycle_decision
                  | Connector_attention_pending
                  | Hitl_resolved_pending
                  | Task_cancellation_pending
+                 | Monitor_fired_pending
                  | Manual_compaction_pending
                  | Scheduled_autonomous_turn
                  | Scheduled_automation_due
@@ -1366,6 +1439,15 @@ let keeper_cycle_decision
     if has_pending_task_cancellation observation
        && not (List.mem Task_cancellation_pending triggers)
     then triggers @ [ Task_cancellation_pending ]
+    else triggers
+    (* RFC-0379: same attribution rule as the two injections above — a
+       monitor-fired observation whose stimulus was consumed by an earlier
+       cycle still names this turn, or the wake reads as an unexplained
+       autonomous tick. *)
+  |> fun triggers ->
+    if has_pending_monitor_fired observation
+       && not (List.mem Monitor_fired_pending triggers)
+    then triggers @ [ Monitor_fired_pending ]
     else triggers
   in
   let blocked_channel =

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -30,6 +30,11 @@ type pending_board_event_kind =
           wake, not its only copy. Carrying the record mirrors
           {!Keeper_event_queue.Connector_attention}'s pointer discipline and
           {!Completion_authority_rejected}'s payload-carrying shape below. *)
+  | Monitor_fired of Keeper_event_queue.monitor_wake
+      (** RFC-0379: a keeper-registered monitor observed its condition cross
+          the requested edge. Kept typed like [Schedule_due]; the flat
+          [title]/[preview] are a rendering of the wake, and the payload is
+          the keeper-authored instruction recorded at creation. *)
   | External_attention of Keeper_counterpart_observation.t
       (** A typed projection of the host-authored connector identity and the
           untrusted speaker content. Unlike the flat event preview, it keeps
@@ -102,6 +107,11 @@ val is_scheduled_automation_event : pending_board_event -> bool
 val is_completion_authority_rejection_event : pending_board_event -> bool
 
 val is_task_cancellation_event : pending_board_event -> bool
+
+val is_monitor_fired_event : pending_board_event -> bool
+(** RFC-0379: a monitor-fired wake. Rendered by its own section inside the
+    automation layer; not Board activity (no post exists) and not a schedule
+    dispatch. *)
 (** A cancellation of a Task this Keeper authored. Disjoint from the Board
     Activity and Scheduled Automation predicates: it has no Board post to point
     at and no schedule behind it. *)
@@ -199,6 +209,7 @@ type event_queue_trigger =
   | Hitl_resolved_stimulus
   | Completion_authority_rejection_stimulus
   | Task_cancellation_stimulus
+  | Monitor_fired_stimulus
   | Manual_compaction_stimulus
 
 (** Typed reason for running a keeper cycle. Each variant corresponds to
@@ -212,6 +223,7 @@ type turn_reason =
   | Hitl_resolved_pending
   | Completion_authority_rejection_pending
   | Task_cancellation_pending
+  | Monitor_fired_pending
   | Manual_compaction_pending
   | Scheduled_autonomous_turn
   | Scheduled_automation_due

--- a/lib/keeper_contract/keeper_world_observation_turn_types.ml
+++ b/lib/keeper_contract/keeper_world_observation_turn_types.ml
@@ -48,6 +48,11 @@ type event_queue_trigger =
       (** Another Keeper cancelled a Task this Keeper authored. A distinct
           reactive input: it is not Board activity (no post exists), not
           scheduled work, and not a completion-authority decision. *)
+  | Monitor_fired_stimulus
+      (** RFC-0379: a monitor this Keeper registered observed its condition
+          cross the requested edge. A distinct reactive input with its own
+          turn reason, so the wake is distinguishable from an autonomous
+          tick and from scheduled work. *)
   | Manual_compaction_stimulus
 
 type turn_reason =
@@ -59,6 +64,7 @@ type turn_reason =
   | Hitl_resolved_pending
   | Completion_authority_rejection_pending
   | Task_cancellation_pending
+  | Monitor_fired_pending
   | Manual_compaction_pending
   | Scheduled_autonomous_turn
   | Scheduled_automation_due
@@ -90,6 +96,7 @@ let turn_reason_to_string = function
   | Completion_authority_rejection_pending ->
     "completion_authority_rejection_pending"
   | Task_cancellation_pending -> "task_cancellation_pending"
+  | Monitor_fired_pending -> "monitor_fired_pending"
   | Manual_compaction_pending -> "manual_compaction_pending"
   | Scheduled_autonomous_turn -> "scheduled_autonomous_turn"
   | Scheduled_automation_due -> "scheduled_automation_due"
@@ -105,6 +112,7 @@ let turn_reason_of_event_queue_trigger = function
   | Completion_authority_rejection_stimulus ->
     Completion_authority_rejection_pending
   | Task_cancellation_stimulus -> Task_cancellation_pending
+  | Monitor_fired_stimulus -> Monitor_fired_pending
   | Manual_compaction_stimulus -> Manual_compaction_pending
 ;;
 

--- a/lib/keeper_contract/keeper_world_observation_turn_types.mli
+++ b/lib/keeper_contract/keeper_world_observation_turn_types.mli
@@ -23,6 +23,11 @@ type event_queue_trigger =
       (** Another Keeper cancelled a Task this Keeper authored. A distinct
           reactive input: it is not Board activity (no post exists), not
           scheduled work, and not a completion-authority decision. *)
+  | Monitor_fired_stimulus
+      (** RFC-0379: a monitor this Keeper registered observed its condition
+          cross the requested edge. A distinct reactive input with its own
+          turn reason, so the wake is distinguishable from an autonomous
+          tick and from scheduled work. *)
   | Manual_compaction_stimulus
 
 type turn_reason =
@@ -34,6 +39,7 @@ type turn_reason =
   | Hitl_resolved_pending
   | Completion_authority_rejection_pending
   | Task_cancellation_pending
+  | Monitor_fired_pending
   | Manual_compaction_pending
   | Scheduled_autonomous_turn
   | Scheduled_automation_due

--- a/lib/keeper_runtime/dune
+++ b/lib/keeper_runtime/dune
@@ -27,6 +27,7 @@
  (flags
   (:standard -w +33))
  (libraries
+  masc_monitor
   masc.agent_core
   masc.agent_core.llm_provider
   eio

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -77,6 +77,7 @@ type stimulus_payload =
      Goal_reconciliation_ready targets the Goal owner — a Task with no Goal
      link reaches no one. This carries the cancellation to the Task's author. *)
   | Task_cancelled of task_cancellation
+  | Monitor_fired of monitor_wake
 
 and board_attention = {
   candidate_id : string;
@@ -165,7 +166,19 @@ and task_cancellation = {
   tc_reason : string option;
 }
 
+and monitor_wake = {
+  mw_monitor_id : string;
+  mw_from : Monitor_domain.observation;
+  mw_to : Monitor_domain.observation;
+  mw_observed_at : float;
+  mw_payload : Yojson.Safe.t;
+}
+
 let fusion_completion_post_id (fc : fusion_completion) = "fusion-run:" ^ fc.run_id
+
+let monitor_fired_post_id (mw : monitor_wake) =
+  Printf.sprintf "monitor-fired:%s:%.3f" mw.mw_monitor_id mw.mw_observed_at
+;;
 
 let hitl_resolution_post_id (r : hitl_resolution) = "hitl-approval:" ^ r.approval_id
 
@@ -230,6 +243,13 @@ let identity_payload = function
        retries of the same cancellation; identity is the task and who ended
        it. *)
     Task_cancelled { cancellation with tc_reason = None }
+  | Monitor_fired wake ->
+    (* One monitor crossing one edge is one event: the keeper-authored
+       payload is carried content and the observation timestamp varies per
+       probe, so identity is which monitor crossed which edge. A second
+       identical edge while the first wake is still queued adds no
+       information — a wake means "go look", not a counter. *)
+    Monitor_fired { wake with mw_observed_at = 0.; mw_payload = `Null }
   | ( Board_signal _ | Board_attention _ | Bootstrap | Fusion_completed _
     | Schedule_due _ | Connector_attention _ | Hitl_resolved _
     | Manual_compaction_requested | Goal_reconciliation_ready _
@@ -352,6 +372,7 @@ let payload_kind_label = function
   | Goal_reconciliation_ready _ -> "goal_reconciliation_ready"
   | Completion_authority_rejected _ -> "completion_authority_rejected"
   | Task_cancelled _ -> "task_cancelled"
+  | Monitor_fired _ -> "monitor_fired"
 
 let is_board_signal = function
   | Board_signal _ | Board_attention _ -> true
@@ -359,7 +380,7 @@ let is_board_signal = function
   | Schedule_due _ | Connector_attention _ | Hitl_resolved _
   | Manual_compaction_requested | Goal_assigned _
   | Goal_reconciliation_ready _ | Completion_authority_rejected _
-  | Task_cancelled _ ->
+  | Task_cancelled _ | Monitor_fired _ ->
     false
 
 (* RFC-0377: the batch-intake predicate needs the routed channel without
@@ -371,7 +392,7 @@ let connector_attention_channel = function
   | Board_signal _ | Board_attention _ | Bootstrap | Fusion_completed _
   | Schedule_due _ | Hitl_resolved _ | Manual_compaction_requested
   | Goal_assigned _ | Goal_reconciliation_ready _
-  | Completion_authority_rejected _ | Task_cancelled _ ->
+  | Completion_authority_rejected _ | Task_cancelled _ | Monitor_fired _ ->
     None
 
 let drain_board_all (queue : t) : stimulus list * t =
@@ -606,6 +627,15 @@ let payload_to_yojson = function
         , match cancellation.tc_reason with
           | None -> `Null
           | Some reason -> `String reason )
+      ]
+  | Monitor_fired wake ->
+    `Assoc
+      [ "kind", `String "monitor_fired"
+      ; "monitor_id", `String wake.mw_monitor_id
+      ; "from", Monitor_domain.observation_to_yojson wake.mw_from
+      ; "to", Monitor_domain.observation_to_yojson wake.mw_to
+      ; "observed_at", `Float wake.mw_observed_at
+      ; "payload", wake.mw_payload
       ]
 
 let continuation_channel_field fields =
@@ -882,6 +912,34 @@ let payload_of_yojson json =
     Ok
       (Task_cancelled
          { tc_task_id = task_id; tc_cancelled_by = cancelled_by; tc_reason = reason })
+  | "monitor_fired" ->
+    let* () =
+      exact_fields
+        ~context
+        ~expected:[ "kind"; "monitor_id"; "from"; "to"; "observed_at"; "payload" ]
+        fields
+    in
+    let* monitor_id = string_field ~context "monitor_id" fields in
+    let* from_json = required_field ~context:"stimulus.payload.monitor_fired" "from" fields in
+    let* mw_from = Monitor_domain.observation_of_yojson from_json in
+    let* to_json = required_field ~context:"stimulus.payload.monitor_fired" "to" fields in
+    let* mw_to = Monitor_domain.observation_of_yojson to_json in
+    let* observed_at =
+      match List.assoc_opt "observed_at" fields with
+      | Some (`Float value) -> Ok value
+      | Some (`Int value) -> Ok (float_of_int value)
+      | Some _ -> Error (context ^ ".observed_at must be a number")
+      | None -> Error (context ^ ".observed_at is missing")
+    in
+    let* mw_payload = required_field ~context:"stimulus.payload.monitor_fired" "payload" fields in
+    Ok
+      (Monitor_fired
+         { mw_monitor_id = monitor_id
+         ; mw_from
+         ; mw_to
+         ; mw_observed_at = observed_at
+         ; mw_payload
+         })
   | value -> Error (Printf.sprintf "unknown stimulus payload kind: %s" value)
 
 let stimulus_to_yojson (stimulus : stimulus) =
@@ -952,5 +1010,6 @@ let continuation_channel_of_payload = function
   | Goal_assigned _
   | Goal_reconciliation_ready _
   | Completion_authority_rejected _
-  | Task_cancelled _ -> None
+  | Task_cancelled _
+  | Monitor_fired _ -> None
 ;;

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -108,6 +108,14 @@ type stimulus_payload =
           with no Goal link reaches no one. The cancelling Keeper's reason is
           carried here because it is the author's only account of why the work
           it asked for stopped. *)
+  | Monitor_fired of monitor_wake
+      (** RFC-0379: a keeper-registered monitor observed its condition
+          transition. Edge-triggered by construction — the runner fires only
+          on an observed state change, never on a baseline observation — and
+          one-shot by default, so the default lifecycle delivers at most one
+          wake per registered monitor. Carries the keeper's opaque payload and
+          the exact transition; the default one-shot record is already deleted
+          when this stimulus is enqueued. *)
 (** Closed set of stimulus kinds. Replaces the prior [payload : string] +
     [classify] JSON-prefix round-trip: producers hold the typed value and
     consumers match it exhaustively, so an unrecognised stimulus is
@@ -211,6 +219,23 @@ and task_cancellation = {
 (** Payload for [Task_cancelled]. [tc_reason] is [None] when the canceller gave
     none; it is not defaulted to a placeholder, so the author can tell "no
     reason was given" from "the reason was empty text". *)
+
+and monitor_wake = {
+  mw_monitor_id : string;
+  mw_from : Monitor_domain.observation;
+  mw_to : Monitor_domain.observation;
+  mw_observed_at : float;
+  mw_payload : Yojson.Safe.t;
+}
+(** Payload for [Monitor_fired]. [mw_payload] is the keeper-authored opaque
+    value given to [masc_monitor_create], carried verbatim; the transition pair
+    reuses the typed observation vocabulary of [Monitor_domain]. *)
+
+val monitor_fired_post_id : monitor_wake -> post_id
+(** Dedup/correlation id for [Monitor_fired]:
+    ["monitor-fired:<monitor_id>:<observed_at>"]. The timestamp component
+    keeps distinct fires of a [max_fires > 1] monitor distinct while repeated
+    enqueues of one fire still collapse. *)
 
 val fusion_completion_post_id : fusion_completion -> post_id
 (** Canonical dedup/correlation id for [Fusion_completed], always

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -453,7 +453,8 @@ let source_terminal_receipt_of_stimulus source =
   | Keeper_event_queue.Goal_assigned _
   | Keeper_event_queue.Goal_reconciliation_ready _
   | Keeper_event_queue.Completion_authority_rejected _
-  | Keeper_event_queue.Task_cancelled _ ->
+  | Keeper_event_queue.Task_cancelled _
+  | Keeper_event_queue.Monitor_fired _ ->
     Error "source event does not carry a typed terminal receipt"
 ;;
 

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -378,6 +378,11 @@ let execute_tool_eio
                      }
                      ~name
                      ~args:coerced_args
+                 | Mod_monitor ->
+                   Tool_monitor.dispatch
+                     { Tool_monitor.config; agent_name }
+                     ~name
+                     ~args:coerced_args
                  | Mod_misc ->
                    Tool_misc.dispatch
                      { Tool_misc.config

--- a/lib/monitor/dune
+++ b/lib/monitor/dune
@@ -1,0 +1,10 @@
+(include_subdirs no)
+
+(library
+ (name masc_monitor)
+ (public_name masc.monitor)
+ (wrapped false)
+ (modules monitor_domain)
+ (flags
+  (:standard -w +4 -w +33))
+ (libraries yojson))

--- a/lib/monitor/monitor_domain.ml
+++ b/lib/monitor/monitor_domain.ml
@@ -163,6 +163,13 @@ let int_field name fields =
   | _ -> Error (Printf.sprintf "monitor field %S must be an integer" name)
 ;;
 
+let observation_label = function
+  | Reachable -> "reachable"
+  | Unreachable -> "unreachable"
+  | File_snapshot _ -> "file_snapshot"
+  | File_absent -> "file_absent"
+;;
+
 let trigger_to_yojson = function
   | Port_up { host; port } ->
     `Assoc [ "kind", `String "port_up"; "host", `String host; "port", `Int port ]

--- a/lib/monitor/monitor_domain.ml
+++ b/lib/monitor/monitor_domain.ml
@@ -1,0 +1,295 @@
+(** Pure domain for keeper monitors (RFC-0379). *)
+
+type trigger =
+  | Port_up of
+      { host : string
+      ; port : int
+      }
+  | Port_down of
+      { host : string
+      ; port : int
+      }
+  | File_changed of { path : string }
+  | Http_ok of { url : string }
+
+type observation =
+  | Reachable
+  | Unreachable
+  | File_snapshot of
+      { mtime : float
+      ; inode : int
+      }
+  | File_absent
+
+type t =
+  { id : string
+  ; keeper : string
+  ; trigger : trigger
+  ; payload : Yojson.Safe.t
+  ; expires_at : float
+  ; max_fires : int
+  ; fired_count : int
+  ; created_at : float
+  ; last_observation : observation option
+  }
+
+type fire_decision =
+  | Fire of
+      { from_ : observation
+      ; to_ : observation
+      }
+  | Hold
+
+let max_active_monitors_per_keeper = 8
+
+let file_snapshot_equal left right =
+  match left, right with
+  | File_snapshot a, File_snapshot b ->
+    Float.equal a.mtime b.mtime && Int.equal a.inode b.inode
+  | File_absent, File_absent -> true
+  | (Reachable | Unreachable), _
+  | _, (Reachable | Unreachable)
+  | File_snapshot _, File_absent
+  | File_absent, File_snapshot _ -> false
+;;
+
+let decide trigger ~prev ~current =
+  match prev with
+  | None -> Hold
+  | Some prev ->
+    (match trigger, prev, current with
+     (* Reachability triggers: fire on the named direction only. *)
+     | (Port_up _ | Http_ok _), Unreachable, Reachable ->
+       Fire { from_ = Unreachable; to_ = Reachable }
+     | (Port_up _ | Http_ok _), Reachable, Reachable
+     | (Port_up _ | Http_ok _), Unreachable, Unreachable
+     | (Port_up _ | Http_ok _), Reachable, Unreachable -> Hold
+     | Port_down _, Reachable, Unreachable ->
+       Fire { from_ = Reachable; to_ = Unreachable }
+     | Port_down _, Reachable, Reachable
+     | Port_down _, Unreachable, Unreachable
+     | Port_down _, Unreachable, Reachable -> Hold
+     (* File trigger: any change of the identity pair fires, including
+        absent <-> present. *)
+     | File_changed _, (File_snapshot _ | File_absent), (File_snapshot _ | File_absent)
+       ->
+       if file_snapshot_equal prev current
+       then Hold
+       else Fire { from_ = prev; to_ = current }
+     (* Incoherent pairs: the observation cannot belong to this trigger.
+        The runner produced a defective observation; never wake on it. *)
+     | (Port_up _ | Port_down _ | Http_ok _), (File_snapshot _ | File_absent), _
+     | (Port_up _ | Port_down _ | Http_ok _), _, (File_snapshot _ | File_absent)
+     | File_changed _, (Reachable | Unreachable), _
+     | File_changed _, _, (Reachable | Unreachable) -> Hold)
+;;
+
+let expired record ~now = Float.compare now record.expires_at >= 0
+let exhausted record = record.fired_count >= record.max_fires
+
+let trim_to_error ~field value =
+  if String.equal (String.trim value) ""
+  then Error (Printf.sprintf "monitor %s must not be blank" field)
+  else Ok ()
+;;
+
+let ( let* ) = Result.bind
+
+let validate_trigger = function
+  | Port_up { host; port } | Port_down { host; port } ->
+    let* () = trim_to_error ~field:"host" host in
+    if port >= 1 && port <= 65535
+    then Ok ()
+    else Error (Printf.sprintf "monitor port %d is outside 1-65535" port)
+  | File_changed { path } -> trim_to_error ~field:"path" path
+  | Http_ok { url } -> trim_to_error ~field:"url" url
+;;
+
+let validate_create ~keeper ~trigger ~expires_at ~max_fires ~now =
+  let* () = trim_to_error ~field:"keeper" keeper in
+  let* () = validate_trigger trigger in
+  let* () =
+    if Float.compare expires_at now > 0
+    then Ok ()
+    else Error "monitor expires_at must be in the future"
+  in
+  if max_fires >= 1 then Ok () else Error "monitor max_fires must be at least 1"
+;;
+
+(* --- closed JSON codecs (delivery-identity style: unknown/missing/duplicate
+   fields are errors, never defaults) --- *)
+
+let assoc_field name fields =
+  match List.assoc_opt name fields with
+  | Some value -> Ok value
+  | None -> Error (Printf.sprintf "missing monitor field %S" name)
+;;
+
+let validate_fields ~context ~expected fields =
+  let rec loop seen = function
+    | [] ->
+      (match List.find_opt (fun name -> not (List.mem name seen)) expected with
+       | Some name -> Error (Printf.sprintf "%s is missing field %S" context name)
+       | None -> Ok ())
+    | (name, _) :: rest ->
+      if List.mem name seen
+      then Error (Printf.sprintf "%s has duplicate field %S" context name)
+      else if not (List.mem name expected)
+      then Error (Printf.sprintf "%s has unknown field %S" context name)
+      else loop (name :: seen) rest
+  in
+  loop [] fields
+;;
+
+let string_field name fields =
+  let* value = assoc_field name fields in
+  match value with
+  | `String value -> Ok value
+  | _ -> Error (Printf.sprintf "monitor field %S must be a string" name)
+;;
+
+let number_field name fields =
+  let* value = assoc_field name fields in
+  match value with
+  | `Int value -> Ok (float_of_int value)
+  | `Float value -> Ok value
+  | _ -> Error (Printf.sprintf "monitor field %S must be a number" name)
+;;
+
+let int_field name fields =
+  let* value = assoc_field name fields in
+  match value with
+  | `Int value -> Ok value
+  | _ -> Error (Printf.sprintf "monitor field %S must be an integer" name)
+;;
+
+let trigger_to_yojson = function
+  | Port_up { host; port } ->
+    `Assoc [ "kind", `String "port_up"; "host", `String host; "port", `Int port ]
+  | Port_down { host; port } ->
+    `Assoc [ "kind", `String "port_down"; "host", `String host; "port", `Int port ]
+  | File_changed { path } ->
+    `Assoc [ "kind", `String "file_changed"; "path", `String path ]
+  | Http_ok { url } -> `Assoc [ "kind", `String "http_ok"; "url", `String url ]
+;;
+
+let trigger_of_yojson = function
+  | `Assoc fields ->
+    let* kind = string_field "kind" fields in
+    (match kind with
+     | "port_up" | "port_down" ->
+       let* () =
+         validate_fields
+           ~context:(Printf.sprintf "%s trigger" kind)
+           ~expected:[ "kind"; "host"; "port" ]
+           fields
+       in
+       let* host = string_field "host" fields in
+       let* port = int_field "port" fields in
+       if String.equal kind "port_up"
+       then Ok (Port_up { host; port })
+       else Ok (Port_down { host; port })
+     | "file_changed" ->
+       let* () =
+         validate_fields
+           ~context:"file_changed trigger"
+           ~expected:[ "kind"; "path" ]
+           fields
+       in
+       let* path = string_field "path" fields in
+       Ok (File_changed { path })
+     | "http_ok" ->
+       let* () =
+         validate_fields ~context:"http_ok trigger" ~expected:[ "kind"; "url" ] fields
+       in
+       let* url = string_field "url" fields in
+       Ok (Http_ok { url })
+     | _ -> Error (Printf.sprintf "unsupported monitor trigger kind %S" kind))
+  | _ -> Error "monitor trigger must be an object"
+;;
+
+let observation_to_yojson = function
+  | Reachable -> `Assoc [ "kind", `String "reachable" ]
+  | Unreachable -> `Assoc [ "kind", `String "unreachable" ]
+  | File_snapshot { mtime; inode } ->
+    `Assoc
+      [ "kind", `String "file_snapshot"; "mtime", `Float mtime; "inode", `Int inode ]
+  | File_absent -> `Assoc [ "kind", `String "file_absent" ]
+;;
+
+let observation_of_yojson = function
+  | `Assoc fields ->
+    let* kind = string_field "kind" fields in
+    (match kind with
+     | "reachable" ->
+       let* () =
+         validate_fields ~context:"reachable observation" ~expected:[ "kind" ] fields
+       in
+       Ok Reachable
+     | "unreachable" ->
+       let* () =
+         validate_fields ~context:"unreachable observation" ~expected:[ "kind" ] fields
+       in
+       Ok Unreachable
+     | "file_snapshot" ->
+       let* () =
+         validate_fields
+           ~context:"file_snapshot observation"
+           ~expected:[ "kind"; "mtime"; "inode" ]
+           fields
+       in
+       let* mtime = number_field "mtime" fields in
+       let* inode = int_field "inode" fields in
+       Ok (File_snapshot { mtime; inode })
+     | "file_absent" ->
+       let* () =
+         validate_fields ~context:"file_absent observation" ~expected:[ "kind" ] fields
+       in
+       Ok File_absent
+     | _ -> Error (Printf.sprintf "unsupported monitor observation kind %S" kind))
+  | _ -> Error "monitor observation must be an object"
+;;
+
+let record_fields =
+  [ "id"; "keeper"; "trigger"; "payload"; "expires_at"; "max_fires"; "fired_count"
+  ; "created_at" ]
+;;
+
+let to_yojson record =
+  `Assoc
+    [ "id", `String record.id
+    ; "keeper", `String record.keeper
+    ; "trigger", trigger_to_yojson record.trigger
+    ; "payload", record.payload
+    ; "expires_at", `Float record.expires_at
+    ; "max_fires", `Int record.max_fires
+    ; "fired_count", `Int record.fired_count
+    ; "created_at", `Float record.created_at
+    ]
+;;
+
+let of_yojson = function
+  | `Assoc fields ->
+    let* () = validate_fields ~context:"monitor record" ~expected:record_fields fields in
+    let* id = string_field "id" fields in
+    let* keeper = string_field "keeper" fields in
+    let* trigger_json = assoc_field "trigger" fields in
+    let* trigger = trigger_of_yojson trigger_json in
+    let* payload = assoc_field "payload" fields in
+    let* expires_at = number_field "expires_at" fields in
+    let* max_fires = int_field "max_fires" fields in
+    let* fired_count = int_field "fired_count" fields in
+    let* created_at = number_field "created_at" fields in
+    Ok
+      { id
+      ; keeper
+      ; trigger
+      ; payload
+      ; expires_at
+      ; max_fires
+      ; fired_count
+      ; created_at
+      ; last_observation = None
+      }
+  | _ -> Error "monitor record must be an object"
+;;

--- a/lib/monitor/monitor_domain.ml
+++ b/lib/monitor/monitor_domain.ml
@@ -10,7 +10,6 @@ type trigger =
       ; port : int
       }
   | File_changed of { path : string }
-  | Http_ok of { url : string }
 
 type observation =
   | Reachable
@@ -59,11 +58,11 @@ let decide trigger ~prev ~current =
   | Some prev ->
     (match trigger, prev, current with
      (* Reachability triggers: fire on the named direction only. *)
-     | (Port_up _ | Http_ok _), Unreachable, Reachable ->
+     | Port_up _, Unreachable, Reachable ->
        Fire { from_ = Unreachable; to_ = Reachable }
-     | (Port_up _ | Http_ok _), Reachable, Reachable
-     | (Port_up _ | Http_ok _), Unreachable, Unreachable
-     | (Port_up _ | Http_ok _), Reachable, Unreachable -> Hold
+     | Port_up _, Reachable, Reachable
+     | Port_up _, Unreachable, Unreachable
+     | Port_up _, Reachable, Unreachable -> Hold
      | Port_down _, Reachable, Unreachable ->
        Fire { from_ = Reachable; to_ = Unreachable }
      | Port_down _, Reachable, Reachable
@@ -78,8 +77,8 @@ let decide trigger ~prev ~current =
        else Fire { from_ = prev; to_ = current }
      (* Incoherent pairs: the observation cannot belong to this trigger.
         The runner produced a defective observation; never wake on it. *)
-     | (Port_up _ | Port_down _ | Http_ok _), (File_snapshot _ | File_absent), _
-     | (Port_up _ | Port_down _ | Http_ok _), _, (File_snapshot _ | File_absent)
+     | (Port_up _ | Port_down _), (File_snapshot _ | File_absent), _
+     | (Port_up _ | Port_down _), _, (File_snapshot _ | File_absent)
      | File_changed _, (Reachable | Unreachable), _
      | File_changed _, _, (Reachable | Unreachable) -> Hold)
 ;;
@@ -102,7 +101,6 @@ let validate_trigger = function
     then Ok ()
     else Error (Printf.sprintf "monitor port %d is outside 1-65535" port)
   | File_changed { path } -> trim_to_error ~field:"path" path
-  | Http_ok { url } -> trim_to_error ~field:"url" url
 ;;
 
 let validate_create ~keeper ~trigger ~expires_at ~max_fires ~now =
@@ -177,7 +175,6 @@ let trigger_to_yojson = function
     `Assoc [ "kind", `String "port_down"; "host", `String host; "port", `Int port ]
   | File_changed { path } ->
     `Assoc [ "kind", `String "file_changed"; "path", `String path ]
-  | Http_ok { url } -> `Assoc [ "kind", `String "http_ok"; "url", `String url ]
 ;;
 
 let trigger_of_yojson = function
@@ -205,12 +202,6 @@ let trigger_of_yojson = function
        in
        let* path = string_field "path" fields in
        Ok (File_changed { path })
-     | "http_ok" ->
-       let* () =
-         validate_fields ~context:"http_ok trigger" ~expected:[ "kind"; "url" ] fields
-       in
-       let* url = string_field "url" fields in
-       Ok (Http_ok { url })
      | _ -> Error (Printf.sprintf "unsupported monitor trigger kind %S" kind))
   | _ -> Error "monitor trigger must be an object"
 ;;

--- a/lib/monitor/monitor_domain.mli
+++ b/lib/monitor/monitor_domain.mli
@@ -1,0 +1,94 @@
+(** Pure domain for keeper monitors (RFC-0379).
+
+    A monitor watches one runtime condition and fires a wake when the
+    condition's observed state *transitions*. The first observation only
+    establishes the baseline and never fires, so a server boot cannot storm
+    every registered monitor at once. Decision logic here is pure; observing
+    and waking live in [Monitor_runner]. *)
+
+type trigger =
+  | Port_up of
+      { host : string
+      ; port : int
+      }
+  | Port_down of
+      { host : string
+      ; port : int
+      }
+  | File_changed of { path : string }
+  | Http_ok of { url : string }
+
+(** One observation of a trigger's target. Ports and HTTP collapse to
+    reachability; files carry the identity pair that detects rewrites even
+    when the mtime resolution would hide them. *)
+type observation =
+  | Reachable
+  | Unreachable
+  | File_snapshot of
+      { mtime : float
+      ; inode : int
+      }
+  | File_absent
+
+type t =
+  { id : string
+  ; keeper : string
+  ; trigger : trigger
+  ; payload : Yojson.Safe.t
+  ; expires_at : float
+  ; max_fires : int
+  ; fired_count : int
+  ; created_at : float
+  ; last_observation : observation option
+      (** [None] until the runner's first observation, and again after every
+          server restart: persisted records reload without their baseline, so
+          transitions that happened while the server was down are never fired
+          retroactively (RFC-0379 §2.5). *)
+  }
+
+type fire_decision =
+  | Fire of
+      { from_ : observation
+      ; to_ : observation
+      }
+  | Hold
+
+val decide : trigger -> prev:observation option -> current:observation -> fire_decision
+(** Exhaustive transition matrix. [prev = None] is always [Hold] (baseline).
+    [Port_up] fires only on [Unreachable] -> [Reachable]; [Port_down] on
+    [Reachable] -> [Unreachable]; [Http_ok] on [Unreachable] -> [Reachable];
+    [File_changed] on any change of the snapshot pair, including
+    absent -> present and present -> absent. Observations that cannot belong
+    to the trigger (a file snapshot for a port trigger) are [Hold]: the
+    runner produced an incoherent pair and must not wake anyone on it. *)
+
+val expired : t -> now:float -> bool
+val exhausted : t -> bool
+(** [exhausted] is true once [fired_count >= max_fires]; the store deletes
+    the record at that point, so persisted exhausted rows are a defect. *)
+
+val validate_create :
+  keeper:string ->
+  trigger:trigger ->
+  expires_at:float ->
+  max_fires:int ->
+  now:float ->
+  (unit, string) result
+(** Fail-closed creation checks: non-blank keeper, host/path/url non-blank,
+    port within 1-65535, [expires_at] strictly in the future, [max_fires]
+    at least 1. *)
+
+val max_active_monitors_per_keeper : int
+
+val trigger_to_yojson : trigger -> Yojson.Safe.t
+val trigger_of_yojson : Yojson.Safe.t -> (trigger, string) result
+val observation_to_yojson : observation -> Yojson.Safe.t
+val observation_of_yojson : Yojson.Safe.t -> (observation, string) result
+
+val to_yojson : t -> Yojson.Safe.t
+(** [last_observation] is intentionally not serialized (see the field doc). *)
+
+val of_yojson : Yojson.Safe.t -> (t, string) result
+(** Closed decode: unknown fields, missing fields, and unknown kinds are
+    errors, never defaults. Decoded records always carry
+    [last_observation = None]. *)

--- a/lib/monitor/monitor_domain.mli
+++ b/lib/monitor/monitor_domain.mli
@@ -16,7 +16,6 @@ type trigger =
       ; port : int
       }
   | File_changed of { path : string }
-  | Http_ok of { url : string }
 
 (** One observation of a trigger's target. Ports and HTTP collapse to
     reachability; files carry the identity pair that detects rewrites even
@@ -56,8 +55,7 @@ type fire_decision =
 val decide : trigger -> prev:observation option -> current:observation -> fire_decision
 (** Exhaustive transition matrix. [prev = None] is always [Hold] (baseline).
     [Port_up] fires only on [Unreachable] -> [Reachable]; [Port_down] on
-    [Reachable] -> [Unreachable]; [Http_ok] on [Unreachable] -> [Reachable];
-    [File_changed] on any change of the snapshot pair, including
+    [Reachable] -> [Unreachable]; [File_changed] on any change of the snapshot pair, including
     absent -> present and present -> absent. Observations that cannot belong
     to the trigger (a file snapshot for a port trigger) are [Hold]: the
     runner produced an incoherent pair and must not wake anyone on it. *)

--- a/lib/monitor/monitor_domain.mli
+++ b/lib/monitor/monitor_domain.mli
@@ -82,6 +82,10 @@ val max_active_monitors_per_keeper : int
 
 val trigger_to_yojson : trigger -> Yojson.Safe.t
 val trigger_of_yojson : Yojson.Safe.t -> (trigger, string) result
+val observation_label : observation -> string
+(** Stable short label per observation kind, identical to the codec's
+    ["kind"] value: reachable / unreachable / file_snapshot / file_absent. *)
+
 val observation_to_yojson : observation -> Yojson.Safe.t
 val observation_of_yojson : Yojson.Safe.t -> (observation, string) result
 

--- a/lib/server/dune
+++ b/lib/server/dune
@@ -12,6 +12,7 @@
   server_schedule_runner_policy)
  (flags :standard -open Masc -w +33)
  (libraries
+  masc_monitor
   masc
   masc.agent_observation
   masc.markup_document

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -338,6 +338,17 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
     ~sw
     ~on_error:(log_server_fiber_crash "ide_ingest_writer")
     (fun () -> Ide_ingest_queue.run_writer ());
+  (* RFC-0379 monitor runner: observes registered keeper monitors and
+     enqueues Monitor_fired wakes on condition transitions. *)
+  fork_logged_fiber
+    ~sw
+    ~on_error:(log_server_fiber_crash "monitor_runner")
+    (fun () ->
+       Keeper_monitor_runner.run
+         ~net:env#net
+         ~clock
+         ~base_path:(Mcp_server.workspace_config state).base_path
+         ());
   Shutdown.register ~name:"ide_ingest_drain" ~priority:26 Ide_ingest_queue.drain_pending;
   (* Host FD observation poller. It records sysmon WARN/CRIT signals through
      [Keeper_fd_pressure.engage_external] for health telemetry and never changes

--- a/lib/server/server_dashboard_http_keeper_event_queue_operator.ml
+++ b/lib/server/server_dashboard_http_keeper_event_queue_operator.ml
@@ -110,6 +110,13 @@ let pending_page ~after ~limit pending =
                @ (match cancellation.tc_reason with
                   | None -> []
                   | Some reason -> [ "cancelled_reason", `String reason ])
+             | Keeper_event_queue.Monitor_fired wake ->
+               [ "monitor_id", `String wake.mw_monitor_id
+               ; ( "monitor_from"
+                 , `String (Monitor_domain.observation_label wake.mw_from) )
+               ; ( "monitor_to"
+                 , `String (Monitor_domain.observation_label wake.mw_to) )
+               ]
              | Keeper_event_queue.Board_signal _
              | Keeper_event_queue.Board_attention _
              | Keeper_event_queue.Bootstrap

--- a/lib/server_keeper_waiting_inventory.ml
+++ b/lib/server_keeper_waiting_inventory.ml
@@ -27,6 +27,7 @@ type wake_producer =
   | External_attention_store
   | Schedule_store
   | Schedule_runner
+  | Monitor_runner
   | Operator_pending_confirm_store
   | Keeper_goal_assignment
   | Keeper_goal_reconciliation
@@ -95,6 +96,7 @@ let wake_producer_to_string = function
   | External_attention_store -> "external_attention_store"
   | Schedule_store -> "schedule_store"
   | Schedule_runner -> "schedule_runner"
+  | Monitor_runner -> "monitor_runner"
   | Operator_pending_confirm_store -> "operator_pending_confirm_store"
   | Keeper_goal_assignment -> "keeper_goal_assignment"
   | Keeper_goal_reconciliation -> "keeper_goal_reconciliation"
@@ -111,6 +113,7 @@ let wake_producer_of_payload : Keeper_event_queue.stimulus_payload -> wake_produ
   | Bootstrap -> Keeper_supervisor
   | Fusion_completed _ -> Fusion_sink
   | Schedule_due _ -> Schedule_runner
+  | Monitor_fired _ -> Monitor_runner
   | Connector_attention _ -> Connector_attention_hook
   | Hitl_resolved _ -> Hitl_resolution_hook
   | Manual_compaction_requested -> Keeper_compaction_request

--- a/lib/tool/tool_catalog.ml
+++ b/lib/tool/tool_catalog.ml
@@ -350,6 +350,9 @@ let explicit_metadata : (string * metadata) list =
     ("masc_schedule_list", read_state_tool);
     ("masc_schedule_get", read_state_tool);
     ("masc_schedule_cancel", broadcast_tool);
+    ("masc_monitor_create", broadcast_tool);
+    ("masc_monitor_list", read_state_tool);
+    ("masc_monitor_cancel", broadcast_tool);
     ("masc_fusion", broadcast_tool);
     ("masc_fusion_status", read_state_tool);
     ("masc_library_list", read_state_tool);

--- a/lib/tool/tool_dispatch.ml
+++ b/lib/tool/tool_dispatch.ml
@@ -213,7 +213,7 @@ type module_tag = Tool_tag_types.module_tag =
   | Mod_run
   | Mod_compact
   | Mod_agent | Mod_task | Mod_state
-  | Mod_control | Mod_agent_timeline | Mod_schedule | Mod_misc
+  | Mod_control | Mod_agent_timeline | Mod_schedule | Mod_monitor | Mod_misc
   | Mod_library | Mod_external
   | Mod_inline
   | Mod_keeper_task

--- a/lib/tool/tool_dispatch.mli
+++ b/lib/tool/tool_dispatch.mli
@@ -136,7 +136,7 @@ type module_tag =
   | Mod_run
   | Mod_compact
   | Mod_agent | Mod_task | Mod_state
-  | Mod_control | Mod_agent_timeline | Mod_schedule | Mod_misc
+  | Mod_control | Mod_agent_timeline | Mod_schedule | Mod_monitor | Mod_misc
   | Mod_library
   (* [Mod_external]: dispatched by a server-boundary handler in the
      composition root, not by a peer [Tool_*] module. The tool layer

--- a/lib/tool/tool_tag_types.ml
+++ b/lib/tool/tool_tag_types.ml
@@ -16,6 +16,7 @@ type module_tag =
   | Mod_control
   | Mod_agent_timeline
   | Mod_schedule
+  | Mod_monitor
   | Mod_misc
   | Mod_library
   | Mod_external

--- a/lib/tool/tool_tag_types.mli
+++ b/lib/tool/tool_tag_types.mli
@@ -17,6 +17,7 @@ type module_tag =
   | Mod_control
   | Mod_agent_timeline
   | Mod_schedule
+  | Mod_monitor
   | Mod_misc
   | Mod_library
   | Mod_external

--- a/lib/tool_monitor.ml
+++ b/lib/tool_monitor.ml
@@ -1,0 +1,194 @@
+(** RFC-0379 monitor tool handlers: masc_monitor_create / list / cancel.
+
+    The caller's agent name is the monitor owner; list and cancel never see
+    another keeper's monitors. Effects stay in {!Keeper_monitor_store}; the
+    server-side runner is the only observer and wake producer. *)
+
+type context =
+  { config : Workspace.config
+  ; agent_name : string
+  }
+
+let ( let* ) = Result.bind
+
+let string_opt args key =
+  match Json_util.get_string args key with
+  | None -> None
+  | Some value -> String_util.trim_nonempty value
+;;
+
+let required_string args key =
+  match string_opt args key with
+  | Some value -> Ok value
+  | None -> Error (Printf.sprintf "%s is required" key)
+;;
+
+let parse_trigger args =
+  let* kind = required_string args "trigger_kind" in
+  match kind with
+  | "port_up" | "port_down" ->
+    let* host = required_string args "host" in
+    let* port =
+      match Json_util.get_int args "port" with
+      | Some port -> Ok port
+      | None -> Error "port is required for port_up/port_down"
+    in
+    if String.equal kind "port_up"
+    then Ok (Monitor_domain.Port_up { host; port })
+    else Ok (Monitor_domain.Port_down { host; port })
+  | "file_changed" ->
+    let* path = required_string args "path" in
+    Ok (Monitor_domain.File_changed { path })
+  | other -> Error (Printf.sprintf "unsupported trigger_kind %S" other)
+;;
+
+let ok ~tool_name ~start_time data = Tool_result.make_ok ~tool_name ~start_time ~data ()
+
+let workflow_error ~tool_name ~start_time message =
+  Tool_result.make_err
+    ~tool_name
+    ~class_:Tool_result.Workflow_rejection
+    ~start_time
+    ~data:(Tool_args.error_assoc [ "message", `String message ])
+    message
+;;
+
+let runtime_error ~tool_name ~start_time message =
+  Tool_result.make_err
+    ~tool_name
+    ~class_:Tool_result.Runtime_failure
+    ~start_time
+    ~data:(Tool_args.error_assoc [ "message", `String message ])
+    message
+;;
+
+let monitor_json (record : Monitor_domain.t) =
+  `Assoc
+    [ "monitor_id", `String record.id
+    ; "trigger", Monitor_domain.trigger_to_yojson record.trigger
+    ; "payload", record.payload
+    ; "expires_at", `Float record.expires_at
+    ; "max_fires", `Int record.max_fires
+    ; "fired_count", `Int record.fired_count
+    ; "created_at", `Float record.created_at
+    ]
+;;
+
+let handle_create ~tool_name ~start_time ctx args =
+  let result =
+    let* trigger = parse_trigger args in
+    let* payload = required_string args "payload" in
+    let* expires_in_sec =
+      match Json_util.get_float args "expires_in_sec" with
+      | Some seconds when Float.compare seconds 0.0 > 0 -> Ok seconds
+      | Some _ -> Error "expires_in_sec must be greater than zero"
+      | None -> Error "expires_in_sec is required"
+    in
+    let max_fires =
+      match Json_util.get_int args "max_fires" with
+      | Some value -> value
+      | None -> 1
+    in
+    let now = Time_compat.now () in
+    let expires_at = now +. expires_in_sec in
+    let* () =
+      Monitor_domain.validate_create
+        ~keeper:ctx.agent_name
+        ~trigger
+        ~expires_at
+        ~max_fires
+        ~now
+    in
+    let record : Monitor_domain.t =
+      { id = Random_id.prefixed ~prefix:"mon-" ~bytes:8
+      ; keeper = ctx.agent_name
+      ; trigger
+      ; payload = `String payload
+      ; expires_at
+      ; max_fires
+      ; fired_count = 0
+      ; created_at = now
+      ; last_observation = None
+      }
+    in
+    let* () = Keeper_monitor_store.create ~base_path:ctx.config.base_path record in
+    Ok record
+  in
+  match result with
+  | Error message -> workflow_error ~tool_name ~start_time message
+  | Ok record ->
+    ok ~tool_name ~start_time
+      (`Assoc [ "status", `String "created"; "monitor", monitor_json record ])
+;;
+
+let handle_list ~tool_name ~start_time ctx (_ : Yojson.Safe.t) =
+  match Keeper_monitor_store.load ~base_path:ctx.config.base_path with
+  | Error message -> runtime_error ~tool_name ~start_time message
+  | Ok records ->
+    let own =
+      List.filter
+        (fun (record : Monitor_domain.t) ->
+           String.equal record.keeper ctx.agent_name)
+        records
+    in
+    ok ~tool_name ~start_time
+      (`Assoc
+        [ "status", `String "ok"
+        ; "monitors", `List (List.map monitor_json own)
+        ])
+;;
+
+let handle_cancel ~tool_name ~start_time ctx args =
+  match required_string args "monitor_id" with
+  | Error message -> workflow_error ~tool_name ~start_time message
+  | Ok monitor_id ->
+    (match
+       Keeper_monitor_store.cancel
+         ~base_path:ctx.config.base_path
+         ~keeper:ctx.agent_name
+         ~id:monitor_id
+     with
+     | Error message -> workflow_error ~tool_name ~start_time message
+     | Ok cancelled ->
+       ok ~tool_name ~start_time
+         (`Assoc
+           [ "status", `String (if cancelled then "cancelled" else "not_found")
+           ; "monitor_id", `String monitor_id
+           ]))
+;;
+
+let dispatch ctx ~name ~args : Tool_result.result option =
+  let start_time = Time_compat.now () in
+  let handle f =
+    try Some (f ~tool_name:name ~start_time ctx args) with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+      Some
+        (runtime_error ~tool_name:name ~start_time
+           (Printf.sprintf "monitor tool failed: %s" (Printexc.to_string exn)))
+  in
+  let open Tool_schemas_monitor in
+  match find_definition name with
+  | Some { action = Create_monitor; _ } -> handle handle_create
+  | Some { action = List_monitors; _ } -> handle handle_list
+  | Some { action = Cancel_monitor; _ } -> handle handle_cancel
+  | None -> None
+;;
+
+let schemas = Tool_schemas_monitor.schemas
+
+let () =
+  List.iter
+    (fun (definition : Tool_schemas_monitor.definition) ->
+       let schema : Masc_domain.tool_schema = definition.schema in
+       Tool_spec.register
+         (Tool_spec.create
+            ~name:schema.name
+            ~description:schema.description
+            ~module_tag:Tool_dispatch.Mod_monitor
+            ~input_schema:schema.input_schema
+            ~handler_binding:Tag_dispatch
+            ~is_read_only:definition.read_only
+            ()))
+    Tool_schemas_monitor.definitions
+;;

--- a/lib/tool_schemas/dune
+++ b/lib/tool_schemas/dune
@@ -11,6 +11,7 @@
   tool_schemas_workspace_extra
   tool_schemas_run
   tool_schemas_schedule
+  tool_schemas_monitor
   tool_schemas_library
   tool_schemas_local_runtime
   tools

--- a/lib/tool_schemas/tool_schemas_monitor.ml
+++ b/lib/tool_schemas/tool_schemas_monitor.ml
@@ -1,0 +1,138 @@
+(** Tool schemas for RFC-0379 keeper monitors. *)
+
+open Masc_domain
+
+let string_prop ?description ?enum name =
+  let fields =
+    [ "type", `String "string" ]
+    @ (match description with
+       | None -> []
+       | Some value -> [ "description", `String value ])
+    @ (match enum with
+       | None -> []
+       | Some values -> [ "enum", `List (List.map (fun value -> `String value) values) ])
+  in
+  name, `Assoc fields
+;;
+
+let number_prop ?description name =
+  let fields =
+    [ "type", `String "number" ]
+    @
+    match description with
+    | None -> []
+    | Some value -> [ "description", `String value ]
+  in
+  name, `Assoc fields
+;;
+
+let integer_prop ?description name =
+  let fields =
+    [ "type", `String "integer" ]
+    @
+    match description with
+    | None -> []
+    | Some value -> [ "description", `String value ]
+  in
+  name, `Assoc fields
+;;
+
+let object_schema ~properties ~required =
+  `Assoc
+    [ "type", `String "object"
+    ; "properties", `Assoc properties
+    ; "required", `List (List.map (fun name -> `String name) required)
+    ; "additionalProperties", `Bool false
+    ]
+;;
+
+let create_schema =
+  object_schema
+    ~properties:
+      [ string_prop
+          ~description:
+            "Which condition transition wakes you. port_up fires when the \
+             host:port becomes reachable, port_down when it stops being \
+             reachable, file_changed when the file's mtime/inode pair changes \
+             (including appearing or disappearing)."
+          ~enum:[ "port_up"; "port_down"; "file_changed" ]
+          "trigger_kind"
+      ; string_prop
+          ~description:"Host for port_up/port_down, e.g. 127.0.0.1."
+          "host"
+      ; integer_prop ~description:"TCP port for port_up/port_down (1-65535)." "port"
+      ; string_prop ~description:"Absolute file path for file_changed." "path"
+      ; string_prop
+          ~description:
+            "Delivered back verbatim in the wake: write the instruction your \
+             future turn should act on."
+          "payload"
+      ; number_prop
+          ~description:
+            "Seconds from now until the monitor expires unfired. Expiry \
+             deletes it silently."
+          "expires_in_sec"
+      ; integer_prop
+          ~description:
+            "Fires before the monitor is consumed. Omitted means 1: the \
+             monitor is one-shot and its record is deleted on the first fire."
+          "max_fires"
+      ]
+    ~required:[ "trigger_kind"; "payload"; "expires_in_sec" ]
+;;
+
+let list_schema = object_schema ~properties:[] ~required:[]
+
+let cancel_schema =
+  object_schema
+    ~properties:
+      [ string_prop ~description:"The monitor id returned by masc_monitor_create." "monitor_id" ]
+    ~required:[ "monitor_id" ]
+;;
+
+type action =
+  | Create_monitor
+  | List_monitors
+  | Cancel_monitor
+
+type definition =
+  { action : action
+  ; id : string
+  ; schema : Masc_domain.tool_schema
+  ; read_only : bool
+  }
+
+let definition ~action ~id ~name ~description ~input_schema ~read_only =
+  { action; id; schema = { name; description; input_schema }; read_only }
+;;
+
+let definitions : definition list =
+  [ definition ~action:Create_monitor ~id:"create" ~name:"masc_monitor_create"
+      ~description:
+        "Register an edge-triggered condition monitor (RFC-0379). The server \
+         observes the condition; when it transitions (never on the first \
+         observation), you receive a monitor_fired wake carrying your payload. \
+         One-shot by default: the record is deleted when it fires. A server \
+         restart re-baselines monitors instead of firing transitions that \
+         happened while it was down."
+      ~input_schema:create_schema ~read_only:false
+  ; definition ~action:List_monitors ~id:"list" ~name:"masc_monitor_list"
+      ~description:"List your own active monitors."
+      ~input_schema:list_schema ~read_only:true
+  ; definition ~action:Cancel_monitor ~id:"cancel" ~name:"masc_monitor_cancel"
+      ~description:"Cancel one of your own monitors before it fires or expires."
+      ~input_schema:cancel_schema ~read_only:false
+  ]
+;;
+
+let schemas : Masc_domain.tool_schema list =
+  List.map (fun definition -> definition.schema) definitions
+;;
+
+let find_definition name =
+  List.find_opt
+    (fun definition ->
+       let schema : Masc_domain.tool_schema = definition.schema in
+       String.equal schema.name name)
+    definitions
+;;

--- a/lib/unified_tool_registry.ml
+++ b/lib/unified_tool_registry.ml
@@ -76,6 +76,7 @@ let tag_of_runtime_handler
   | Tool_masc_control_dispatch -> Mod_control
   | Tool_masc_agent_timeline_dispatch -> Mod_agent_timeline
   | Tool_masc_schedule_dispatch -> Mod_schedule
+  | Tool_masc_monitor_dispatch -> Mod_monitor
   | Tool_masc_misc_dispatch | Tool_web_search | Tool_web_fetch -> Mod_misc
   | Tool_masc_local_runtime_dispatch -> Mod_local_runtime
   | Tool_masc_library_dispatch -> Mod_library

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -273,6 +273,8 @@ normal_targets=(
   @test/runtest-test_runtime_modality_reroute
   @test/runtest-test_runtime_agent_advanced_outcome
   @test/runtest-test_monitor_domain
+  @test/runtest-test_monitor_store
+  @test/runtest-test_monitor_runner_fire
   @test/runtest-test_runtime_model_input_tail_window
   @test/runtest-test_keeper_context_overflow_shrink
   @test/runtest-test_keeper_provider_call_deadline

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -272,6 +272,7 @@ normal_targets=(
   @test/runtest-test_keeper_vision_tool
   @test/runtest-test_runtime_modality_reroute
   @test/runtest-test_runtime_agent_advanced_outcome
+  @test/runtest-test_monitor_domain
   @test/runtest-test_runtime_model_input_tail_window
   @test/runtest-test_keeper_context_overflow_shrink
   @test/runtest-test_keeper_provider_call_deadline

--- a/test/dune
+++ b/test/dune
@@ -891,6 +891,21 @@
  (modules test_monitor_domain)
  (libraries masc_test_deps masc_monitor))
 
+; RFC-0379: locked monitor store CRUD, cap, ownership, fire accounting, expiry.
+
+(test
+ (name test_monitor_store)
+ (modules test_monitor_store)
+ (libraries masc_test_deps masc_monitor))
+
+; RFC-0379: in-process end-to-end fire — real socket edge, real store, real
+; runner sweep, durable Monitor_fired row in the keeper event-queue file.
+
+(test
+ (name test_monitor_runner_fire)
+ (modules test_monitor_runner_fire)
+ (libraries masc_test_deps masc_monitor eio_main))
+
 ; A keeper must not be offered its own authored tasks as claimable work —
 ; otherwise a routing/report keeper re-triggers on its own output.
 

--- a/test/dune
+++ b/test/dune
@@ -884,6 +884,13 @@
  (modules test_runtime_agent_advanced_outcome)
  (libraries masc_test_deps))
 
+; RFC-0379: monitor transition matrix, lifecycle, creation validation, codecs.
+
+(test
+ (name test_monitor_domain)
+ (modules test_monitor_domain)
+ (libraries masc_test_deps masc_monitor))
+
 ; A keeper must not be offered its own authored tasks as claimable work —
 ; otherwise a routing/report keeper re-triggers on its own output.
 

--- a/test/test_monitor_domain.ml
+++ b/test/test_monitor_domain.ml
@@ -1,0 +1,194 @@
+(* RFC-0379 monitor domain: transition matrix, lifecycle predicates,
+   creation validation, and closed codecs. *)
+
+open Alcotest
+module M = Monitor_domain
+
+let port_up = M.Port_up { host = "127.0.0.1"; port = 8935 }
+let port_down = M.Port_down { host = "127.0.0.1"; port = 8935 }
+let http_ok = M.Http_ok { url = "http://127.0.0.1:8935/health" }
+let file_changed = M.File_changed { path = "/tmp/watched" }
+let snapshot_a = M.File_snapshot { mtime = 100.0; inode = 7 }
+let snapshot_b = M.File_snapshot { mtime = 200.0; inode = 7 }
+let snapshot_c = M.File_snapshot { mtime = 100.0; inode = 9 }
+
+let fired = function
+  | M.Fire _ -> true
+  | M.Hold -> false
+;;
+
+let check_fire name expected trigger ~prev ~current =
+  check bool name expected (fired (M.decide trigger ~prev ~current))
+;;
+
+let test_baseline_never_fires () =
+  check_fire "port_up baseline" false port_up ~prev:None ~current:M.Reachable;
+  check_fire "port_down baseline" false port_down ~prev:None ~current:M.Unreachable;
+  check_fire "http_ok baseline" false http_ok ~prev:None ~current:M.Reachable;
+  check_fire "file baseline" false file_changed ~prev:None ~current:snapshot_a
+;;
+
+let test_reachability_edges () =
+  check_fire "port_up fires on down->up" true port_up
+    ~prev:(Some M.Unreachable) ~current:M.Reachable;
+  check_fire "port_up holds on up->up" false port_up
+    ~prev:(Some M.Reachable) ~current:M.Reachable;
+  check_fire "port_up holds on up->down" false port_up
+    ~prev:(Some M.Reachable) ~current:M.Unreachable;
+  check_fire "port_down fires on up->down" true port_down
+    ~prev:(Some M.Reachable) ~current:M.Unreachable;
+  check_fire "port_down holds on down->up" false port_down
+    ~prev:(Some M.Unreachable) ~current:M.Reachable;
+  check_fire "http_ok fires on down->up" true http_ok
+    ~prev:(Some M.Unreachable) ~current:M.Reachable;
+  check_fire "http_ok holds on steady up" false http_ok
+    ~prev:(Some M.Reachable) ~current:M.Reachable
+;;
+
+let test_file_edges () =
+  check_fire "same snapshot holds" false file_changed
+    ~prev:(Some snapshot_a) ~current:snapshot_a;
+  check_fire "mtime change fires" true file_changed
+    ~prev:(Some snapshot_a) ~current:snapshot_b;
+  check_fire "inode change fires" true file_changed
+    ~prev:(Some snapshot_a) ~current:snapshot_c;
+  check_fire "absent->present fires" true file_changed
+    ~prev:(Some M.File_absent) ~current:snapshot_a;
+  check_fire "present->absent fires" true file_changed
+    ~prev:(Some snapshot_a) ~current:M.File_absent;
+  check_fire "absent->absent holds" false file_changed
+    ~prev:(Some M.File_absent) ~current:M.File_absent
+;;
+
+let test_incoherent_pairs_hold () =
+  check_fire "port trigger with file prev holds" false port_up
+    ~prev:(Some snapshot_a) ~current:M.Reachable;
+  check_fire "port trigger with file current holds" false port_up
+    ~prev:(Some M.Unreachable) ~current:snapshot_a;
+  check_fire "file trigger with reachability holds" false file_changed
+    ~prev:(Some M.Reachable) ~current:M.Unreachable
+;;
+
+let record ?(max_fires = 1) ?(fired_count = 0) () : M.t =
+  { id = "mon-test"
+  ; keeper = "rondo"
+  ; trigger = port_up
+  ; payload = `Assoc [ "note", `String "verify boot" ]
+  ; expires_at = 1_000.0
+  ; max_fires
+  ; fired_count
+  ; created_at = 500.0
+  ; last_observation = None
+  }
+;;
+
+let test_lifecycle_predicates () =
+  check bool "not expired before expires_at" false
+    (M.expired (record ()) ~now:999.9);
+  check bool "expired at expires_at" true (M.expired (record ()) ~now:1_000.0);
+  check bool "fresh record is not exhausted" false (M.exhausted (record ()));
+  check bool "fired one-shot is exhausted" true
+    (M.exhausted (record ~fired_count:1 ()));
+  check bool "multi-fire below cap is not exhausted" false
+    (M.exhausted (record ~max_fires:3 ~fired_count:2 ()))
+;;
+
+let expect_error name = function
+  | Error _ -> ()
+  | Ok () -> fail (name ^ ": expected a validation error")
+;;
+
+let test_validate_create () =
+  (match
+     M.validate_create ~keeper:"rondo" ~trigger:port_up ~expires_at:200.0
+       ~max_fires:1 ~now:100.0
+   with
+   | Ok () -> ()
+   | Error e -> fail ("valid create rejected: " ^ e));
+  expect_error "blank keeper"
+    (M.validate_create ~keeper:" " ~trigger:port_up ~expires_at:200.0 ~max_fires:1
+       ~now:100.0);
+  expect_error "port zero"
+    (M.validate_create ~keeper:"rondo"
+       ~trigger:(M.Port_up { host = "127.0.0.1"; port = 0 })
+       ~expires_at:200.0 ~max_fires:1 ~now:100.0);
+  expect_error "port over 65535"
+    (M.validate_create ~keeper:"rondo"
+       ~trigger:(M.Port_up { host = "127.0.0.1"; port = 70_000 })
+       ~expires_at:200.0 ~max_fires:1 ~now:100.0);
+  expect_error "blank path"
+    (M.validate_create ~keeper:"rondo"
+       ~trigger:(M.File_changed { path = "" })
+       ~expires_at:200.0 ~max_fires:1 ~now:100.0);
+  expect_error "past expires_at"
+    (M.validate_create ~keeper:"rondo" ~trigger:port_up ~expires_at:99.0
+       ~max_fires:1 ~now:100.0);
+  expect_error "zero max_fires"
+    (M.validate_create ~keeper:"rondo" ~trigger:port_up ~expires_at:200.0
+       ~max_fires:0 ~now:100.0)
+;;
+
+let expect_ok = function
+  | Ok value -> value
+  | Error e -> fail ("unexpected decode error: " ^ e)
+;;
+
+let test_trigger_codec_roundtrip () =
+  List.iter
+    (fun trigger ->
+       let decoded = M.trigger_to_yojson trigger |> M.trigger_of_yojson |> expect_ok in
+       check bool "trigger roundtrips" true (decoded = trigger))
+    [ port_up; port_down; http_ok; file_changed ];
+  (match M.trigger_of_yojson (`Assoc [ "kind", `String "log_pattern" ]) with
+   | Error _ -> ()
+   | Ok _ -> fail "unknown trigger kind must be rejected")
+;;
+
+let test_observation_codec_roundtrip () =
+  List.iter
+    (fun observation ->
+       let decoded =
+         M.observation_to_yojson observation |> M.observation_of_yojson |> expect_ok
+       in
+       check bool "observation roundtrips" true (decoded = observation))
+    [ M.Reachable; M.Unreachable; snapshot_a; M.File_absent ]
+;;
+
+let test_record_codec () =
+  let source = { (record ()) with last_observation = Some M.Reachable } in
+  let decoded = M.to_yojson source |> M.of_yojson |> expect_ok in
+  check bool "identity fields roundtrip" true
+    (String.equal decoded.M.id source.M.id
+     && String.equal decoded.M.keeper source.M.keeper
+     && decoded.M.trigger = source.M.trigger
+     && decoded.M.payload = source.M.payload
+     && Float.equal decoded.M.expires_at source.M.expires_at);
+  check bool "baseline is dropped by persistence" true
+    (decoded.M.last_observation = None);
+  (match
+     M.of_yojson
+       (`Assoc [ "id", `String "mon-x"; "unknown_field", `String "boom" ])
+   with
+   | Error _ -> ()
+   | Ok _ -> fail "unknown record field must be rejected")
+;;
+
+let () =
+  run
+    "monitor domain"
+    [ ( "decide"
+      , [ test_case "baseline never fires" `Quick test_baseline_never_fires
+        ; test_case "reachability edges" `Quick test_reachability_edges
+        ; test_case "file edges" `Quick test_file_edges
+        ; test_case "incoherent pairs hold" `Quick test_incoherent_pairs_hold
+        ] )
+    ; ( "lifecycle"
+      , [ test_case "expiry and exhaustion" `Quick test_lifecycle_predicates
+        ; test_case "creation validation" `Quick test_validate_create
+        ] )
+    ; ( "codec"
+      , [ test_case "trigger roundtrip" `Quick test_trigger_codec_roundtrip
+        ; test_case "observation roundtrip" `Quick test_observation_codec_roundtrip
+        ; test_case "record closed decode" `Quick test_record_codec
+        ] )
+    ]

--- a/test/test_monitor_domain.ml
+++ b/test/test_monitor_domain.ml
@@ -6,7 +6,6 @@ module M = Monitor_domain
 
 let port_up = M.Port_up { host = "127.0.0.1"; port = 8935 }
 let port_down = M.Port_down { host = "127.0.0.1"; port = 8935 }
-let http_ok = M.Http_ok { url = "http://127.0.0.1:8935/health" }
 let file_changed = M.File_changed { path = "/tmp/watched" }
 let snapshot_a = M.File_snapshot { mtime = 100.0; inode = 7 }
 let snapshot_b = M.File_snapshot { mtime = 200.0; inode = 7 }
@@ -24,7 +23,6 @@ let check_fire name expected trigger ~prev ~current =
 let test_baseline_never_fires () =
   check_fire "port_up baseline" false port_up ~prev:None ~current:M.Reachable;
   check_fire "port_down baseline" false port_down ~prev:None ~current:M.Unreachable;
-  check_fire "http_ok baseline" false http_ok ~prev:None ~current:M.Reachable;
   check_fire "file baseline" false file_changed ~prev:None ~current:snapshot_a
 ;;
 
@@ -39,10 +37,8 @@ let test_reachability_edges () =
     ~prev:(Some M.Reachable) ~current:M.Unreachable;
   check_fire "port_down holds on down->up" false port_down
     ~prev:(Some M.Unreachable) ~current:M.Reachable;
-  check_fire "http_ok fires on down->up" true http_ok
-    ~prev:(Some M.Unreachable) ~current:M.Reachable;
-  check_fire "http_ok holds on steady up" false http_ok
-    ~prev:(Some M.Reachable) ~current:M.Reachable
+  check_fire "port_down holds on steady down" false port_down
+    ~prev:(Some M.Unreachable) ~current:M.Unreachable
 ;;
 
 let test_file_edges () =
@@ -138,7 +134,7 @@ let test_trigger_codec_roundtrip () =
     (fun trigger ->
        let decoded = M.trigger_to_yojson trigger |> M.trigger_of_yojson |> expect_ok in
        check bool "trigger roundtrips" true (decoded = trigger))
-    [ port_up; port_down; http_ok; file_changed ];
+    [ port_up; port_down; file_changed ];
   (match M.trigger_of_yojson (`Assoc [ "kind", `String "log_pattern" ]) with
    | Error _ -> ()
    | Ok _ -> fail "unknown trigger kind must be rejected")

--- a/test/test_monitor_runner_fire.ml
+++ b/test/test_monitor_runner_fire.ml
@@ -1,0 +1,129 @@
+(* RFC-0379 end-to-end fire inside one process: a real listener socket, the
+   real locked store, real runner sweeps, and the durable Monitor_fired row
+   in the keeper's event-queue file. This is the transport half of the RFC
+   §5 live scenario — the same edge a keeper watches across a server
+   restart, observed here by closing the listener between two sweeps. *)
+
+open Alcotest
+module D = Monitor_domain
+module R = Masc.Keeper_monitor_runner
+module S = Masc.Keeper_monitor_store
+
+let fresh_base_path () =
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-monitor-runner-test-%d" (Unix.getpid ()))
+  in
+  (try Unix.mkdir dir 0o700 with
+   | Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  dir
+;;
+
+let keeper_name = "rondo"
+
+let queue_mentions_monitor_fired ~base_path =
+  let keeper_dir =
+    Filename.concat (Filename.concat base_path ".masc") "keepers"
+    |> fun keepers -> Filename.concat keepers keeper_name
+  in
+  match Sys.readdir keeper_dir with
+  | entries ->
+    Array.exists
+      (fun entry ->
+         String.length entry >= 11
+         && String.sub entry 0 11 = "event-queue"
+         &&
+         let path = Filename.concat keeper_dir entry in
+         let ic = open_in_bin path in
+         Fun.protect
+           ~finally:(fun () -> close_in_noerr ic)
+           (fun () ->
+              let content = really_input_string ic (in_channel_length ic) in
+              (* The durable row is JSON; the closed kind tag is the
+                 discriminator the decoder consumes. *)
+              let contains needle haystack =
+                let n = String.length needle
+                and h = String.length haystack in
+                let rec loop i =
+                  i + n <= h && (String.sub haystack i n = needle || loop (i + 1))
+                in
+                loop 0
+              in
+              contains "monitor_fired" content))
+      entries
+  | exception Sys_error _ -> false
+;;
+
+let test_port_down_fire_lands_durably () =
+  Eio_main.run
+  @@ fun env ->
+  let net = env#net in
+  let clock = env#clock in
+  let base_path = fresh_base_path () in
+  let baselines : (string, R.baseline) Hashtbl.t = Hashtbl.create 4 in
+  let now = Unix.gettimeofday () in
+  (* Phase 1: a live listener; the first sweep only baselines (Reachable). *)
+  let port =
+    Eio.Switch.run
+    @@ fun listener_sw ->
+    let listening =
+      Eio.Net.listen
+        ~sw:listener_sw
+        ~backlog:1
+        ~reuse_addr:true
+        net
+        (`Tcp (Eio.Net.Ipaddr.V4.loopback, 0))
+    in
+    let port =
+      match Eio.Net.listening_addr listening with
+      | `Tcp (_, port) -> port
+      | `Unix _ -> fail "expected a tcp listening address"
+    in
+    S.create
+      ~base_path
+      { D.id = "mon-restart-probe"
+      ; keeper = keeper_name
+      ; trigger = D.Port_down { host = "127.0.0.1"; port }
+      ; payload = `String "the watched server went down; start verification"
+      ; expires_at = now +. 3_600.0
+      ; max_fires = 1
+      ; fired_count = 0
+      ; created_at = now
+      ; last_observation = None
+      }
+    |> (function
+     | Ok () -> ()
+     | Error message -> fail message);
+    R.sweep ~net ~clock ~base_path ~baselines ~now;
+    check bool "baseline sweep must not fire" false
+      (queue_mentions_monitor_fired ~base_path);
+    check int "store still holds the monitor" 1
+      (List.length
+         (match S.load ~base_path with
+          | Ok records -> records
+          | Error message -> fail message));
+    port
+  in
+  (* Phase 2: the listener is gone; the next due sweep observes the edge. *)
+  ignore (port : int);
+  R.sweep ~net ~clock ~base_path ~baselines ~now:(now +. 30.0);
+  check bool "the durable Monitor_fired row landed" true
+    (queue_mentions_monitor_fired ~base_path);
+  check int "the one-shot record was consumed" 0
+    (List.length
+       (match S.load ~base_path with
+        | Ok records -> records
+        | Error message -> fail message))
+;;
+
+let () =
+  run
+    "keeper monitor runner fire"
+    [ ( "fire"
+      , [ test_case
+            "port_down edge lands a durable wake"
+            `Quick
+            test_port_down_fire_lands_durably
+        ] )
+    ]

--- a/test/test_monitor_store.ml
+++ b/test/test_monitor_store.ml
@@ -1,0 +1,126 @@
+(* RFC-0379 monitor store: locked-file CRUD, per-keeper cap, owner-checked
+   cancel, fire accounting, and expiry sweep against a temp base path. *)
+
+open Alcotest
+module D = Monitor_domain
+module S = Masc.Keeper_monitor_store
+
+let fresh_base_path =
+  let counter = ref 0 in
+  fun () ->
+    incr counter;
+    let dir =
+      Filename.concat
+        (Filename.get_temp_dir_name ())
+        (Printf.sprintf "masc-monitor-store-test-%d-%d" (Unix.getpid ()) !counter)
+    in
+    Unix.mkdir dir 0o700;
+    dir
+;;
+
+let record ?(id = "mon-1") ?(keeper = "rondo") ?(max_fires = 1) () : D.t =
+  { id
+  ; keeper
+  ; trigger = D.Port_up { host = "127.0.0.1"; port = 18935 }
+  ; payload = `String "verify the reboot"
+  ; expires_at = 2_000.0
+  ; max_fires
+  ; fired_count = 0
+  ; created_at = 1_000.0
+  ; last_observation = None
+  }
+;;
+
+let expect_ok label = function
+  | Ok value -> value
+  | Error message -> fail (Printf.sprintf "%s: %s" label message)
+;;
+
+let test_create_load_roundtrip () =
+  let base_path = fresh_base_path () in
+  check (list string) "empty store loads as no records" []
+    (List.map
+       (fun (r : D.t) -> r.id)
+       (expect_ok "load empty" (S.load ~base_path)));
+  expect_ok "create" (S.create ~base_path (record ()));
+  (match S.load ~base_path with
+   | Ok [ loaded ] ->
+     check string "id survives" "mon-1" loaded.D.id;
+     check bool "baseline never persists" true (loaded.D.last_observation = None)
+   | Ok records -> fail (Printf.sprintf "expected 1 record, got %d" (List.length records))
+   | Error message -> fail message);
+  (match S.create ~base_path (record ()) with
+   | Error _ -> ()
+   | Ok () -> fail "duplicate id must be rejected")
+;;
+
+let test_per_keeper_cap () =
+  let base_path = fresh_base_path () in
+  for index = 1 to D.max_active_monitors_per_keeper do
+    expect_ok "create under cap"
+      (S.create ~base_path (record ~id:(Printf.sprintf "mon-%d" index) ()))
+  done;
+  (match S.create ~base_path (record ~id:"mon-over" ()) with
+   | Error _ -> ()
+   | Ok () -> fail "cap must reject the next create");
+  expect_ok "another keeper is unaffected"
+    (S.create ~base_path (record ~id:"mon-other" ~keeper:"kidsnote" ()))
+;;
+
+let test_cancel_ownership () =
+  let base_path = fresh_base_path () in
+  expect_ok "create" (S.create ~base_path (record ()));
+  (match S.cancel ~base_path ~keeper:"kidsnote" ~id:"mon-1" with
+   | Error _ -> ()
+   | Ok _ -> fail "foreign cancel must be an error, not a removal");
+  check bool "own cancel removes" true
+    (expect_ok "cancel" (S.cancel ~base_path ~keeper:"rondo" ~id:"mon-1"));
+  check bool "missing id reports false" false
+    (expect_ok "cancel missing" (S.cancel ~base_path ~keeper:"rondo" ~id:"mon-1"))
+;;
+
+let test_fire_accounting () =
+  let base_path = fresh_base_path () in
+  expect_ok "create one-shot" (S.create ~base_path (record ()));
+  (match S.record_fire ~base_path ~id:"mon-1" with
+   | Ok S.Fire_recorded_removed -> ()
+   | Ok S.Fire_recorded_retained -> fail "one-shot fire must remove the record"
+   | Error message -> fail message);
+  check (list string) "exhausted record is gone" []
+    (List.map (fun (r : D.t) -> r.D.id) (expect_ok "load" (S.load ~base_path)));
+  expect_ok "create multi" (S.create ~base_path (record ~id:"mon-3" ~max_fires:2 ()));
+  (match S.record_fire ~base_path ~id:"mon-3" with
+   | Ok S.Fire_recorded_retained -> ()
+   | Ok S.Fire_recorded_removed -> fail "first of two fires must retain"
+   | Error message -> fail message);
+  (match S.record_fire ~base_path ~id:"mon-3" with
+   | Ok S.Fire_recorded_removed -> ()
+   | Ok S.Fire_recorded_retained -> fail "second fire must exhaust"
+   | Error message -> fail message);
+  (match S.record_fire ~base_path ~id:"mon-3" with
+   | Error _ -> ()
+   | Ok _ -> fail "firing a removed record must be an error")
+;;
+
+let test_expiry_sweep () =
+  let base_path = fresh_base_path () in
+  expect_ok "create" (S.create ~base_path (record ()));
+  check (list string) "not yet expired" []
+    (expect_ok "sweep early" (S.remove_expired ~base_path ~now:1_500.0));
+  check (list string) "expired ids are returned" [ "mon-1" ]
+    (expect_ok "sweep late" (S.remove_expired ~base_path ~now:2_000.0));
+  check (list string) "store is empty after sweep" []
+    (List.map (fun (r : D.t) -> r.D.id) (expect_ok "load" (S.load ~base_path)))
+;;
+
+let () =
+  run
+    "keeper monitor store"
+    [ ( "store"
+      , [ test_case "create and load roundtrip" `Quick test_create_load_roundtrip
+        ; test_case "per-keeper cap" `Quick test_per_keeper_cap
+        ; test_case "cancel ownership" `Quick test_cancel_ownership
+        ; test_case "fire accounting" `Quick test_fire_accounting
+        ; test_case "expiry sweep" `Quick test_expiry_sweep
+        ] )
+    ]


### PR DESCRIPTION
rondo 의 fusion run `kmsg-27be397a51c68df14db74dfef17f0c36` (trio/refine, succeeded) 가 요청한 keeper 이벤트 wake 설계의 RFC 입니다.

핵심 결정 4개:
- **edge-triggered + 최초 관측은 baseline** (부팅 boot-storm 구조 차단, 턴율 13.3배 사고 교훈)
- **기본 one-shot** (`max_fires=1`, 발화 즉시 레코드 삭제 — cooldown 불필요)
- **데몬 없음** — masc 서버가 이미 sandbox 밖 상주 프로세스, runner 는 schedule runner 와 같은 자리의 Eio fiber
- **기존 wake 파이프라인 재사용** — 새 stimulus class `monitor_fired` 하나만 추가

fusion 패널 합의 중 기각분(데몬/capability token/audit/log trigger/cooldown)은 §3 표에 근거와 함께 기록했습니다. 구현은 이 브랜치에 stacked 로 이어집니다 (§4 파일 계획).

🤖 Generated with [Claude Code](https://claude.com/claude-code)