### PR TITLE
feat(autonomous_instructions): add autonomous_instructions field to keeper profile

### DIFF
--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -404,6 +404,10 @@ type keeper_meta =
   ; name : string
   ; agent_name : string
   ; instructions : string
+  ; autonomous_instructions : string option
+    (** Per-keeper autonomous-turn instructions (RFC autonomous_instructions).
+        When non-empty, used instead of [instructions] for scheduled autonomous
+        turns. Direct/dashboard turns always use [instructions]. *)
   ; (* -- Policy -- *)
     sandbox_profile : Keeper_types_profile.sandbox_profile
   ; sandbox_image : string option
@@ -543,6 +547,9 @@ let effective_meta_of_profile_defaults
             };
           instructions =
             apply_profile_default defaults.instructions meta.instructions;
+          autonomous_instructions =
+            apply_profile_default_opt defaults.autonomous_instructions
+              meta.autonomous_instructions;
           autoboot_enabled =
             apply_profile_default defaults.autoboot_enabled
               meta.autoboot_enabled;

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -266,6 +266,10 @@ type keeper_meta = {
   name : string;
   agent_name : string;
   instructions : string;
+  autonomous_instructions : string option;
+      (** Per-keeper autonomous-turn instructions (RFC autonomous_instructions).
+          When non-empty, used instead of [instructions] for scheduled autonomous
+          turns. Direct/dashboard turns always use [instructions]. *)
   (* Policy *)
   sandbox_profile : Keeper_types_profile.sandbox_profile;
   sandbox_image : string option;

--- a/lib/keeper/keeper_meta_json.ml
+++ b/lib/keeper/keeper_meta_json.ml
@@ -19,6 +19,10 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
     ; Name, `String m.name
     ; Agent_name, `String m.agent_name
     ; Instructions, `String m.instructions
+    ; Autonomous_instructions
+    , (match m.autonomous_instructions with
+       | Some s -> `String s
+       | None -> `Null)
     ; Trace_id, `String (Keeper_id.Trace_id.to_string rt.trace_id)
     ; Multimodal_policy, `String (multimodal_policy_to_string m.multimodal_policy)
     ; Trace_history, `List (List.map (fun s -> `String s) rt.trace_history)

--- a/lib/keeper/keeper_meta_json_current_schema.ml
+++ b/lib/keeper/keeper_meta_json_current_schema.ml
@@ -19,6 +19,7 @@ type field =
   | Name
   | Agent_name
   | Instructions
+  | Autonomous_instructions
   | Trace_id
   | Multimodal_policy
   | Trace_history
@@ -73,6 +74,7 @@ let all_fields =
   ; Name
   ; Agent_name
   ; Instructions
+  ; Autonomous_instructions
   ; Trace_id
   ; Multimodal_policy
   ; Trace_history
@@ -128,6 +130,7 @@ let field_name = function
   | Name -> "name"
   | Agent_name -> "agent_name"
   | Instructions -> "instructions"
+  | Autonomous_instructions -> "autonomous_instructions"
   | Trace_id -> "trace_id"
   | Multimodal_policy -> "multimodal_policy"
   | Trace_history -> "trace_history"

--- a/lib/keeper/keeper_meta_json_current_schema.mli
+++ b/lib/keeper/keeper_meta_json_current_schema.mli
@@ -9,6 +9,7 @@ type field =
   | Name
   | Agent_name
   | Instructions
+  | Autonomous_instructions
   | Trace_id
   | Multimodal_policy
   | Trace_history

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -299,6 +299,7 @@ let decode_current_meta fields =
   let* name = string_field fields "name" in
   let* agent_name = string_field fields "agent_name" in
   let* instructions = string_field fields "instructions" in
+  let* autonomous_instructions = nullable_string_field fields "autonomous_instructions" in
   let* trace_id_raw = string_field fields "trace_id" in
   let* trace_id = parse_trace_id trace_id_raw in
   let* multimodal_policy = parse_multimodal_policy fields in
@@ -430,6 +431,7 @@ let decode_current_meta fields =
       ; name
       ; agent_name
       ; instructions
+      ; autonomous_instructions
       ; sandbox_profile
       ; sandbox_image = None
       ; network_mode = default_network_mode_for_profile sandbox_profile

--- a/lib/keeper/keeper_owner_reducer.ml
+++ b/lib/keeper/keeper_owner_reducer.ml
@@ -86,6 +86,7 @@ type profile_update =
   ; telemetry_feedback_window_hours : int option
   ; always_allow : bool option
   ; agent_core_env : (string * string) list
+  ; autonomous_instructions : string option
   ; updated_at : string
   }
 
@@ -656,6 +657,7 @@ let apply_existing (state : state) meta command =
          ; telemetry_feedback_window_hours = update.telemetry_feedback_window_hours
          ; always_allow = update.always_allow
          ; agent_core_env = update.agent_core_env
+         ; autonomous_instructions = update.autonomous_instructions
          ; updated_at = update.updated_at
          })
   | Handoff_identity handoff ->

--- a/lib/keeper/keeper_owner_reducer.mli
+++ b/lib/keeper/keeper_owner_reducer.mli
@@ -92,6 +92,7 @@ type profile_update =
   ; telemetry_feedback_window_hours : int option
   ; always_allow : bool option
   ; agent_core_env : (string * string) list
+  ; autonomous_instructions : string option
   ; updated_at : string
   }
 

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -450,6 +450,7 @@ let ensure_keeper_meta_with_cause config name =
                  persisted_updated.telemetry_feedback_window_hours
              ; always_allow = persisted_updated.always_allow
              ; agent_core_env = persisted_updated.agent_core_env
+             ; autonomous_instructions = persisted_updated.autonomous_instructions
              ; updated_at = persisted_updated.updated_at
              })
       with

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -636,6 +636,8 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
            ("meta", Keeper_meta_json.meta_to_json m);
            ("instructions",
             if String.trim m.instructions = "" then `Null else `String m.instructions);
+           ("autonomous_instructions",
+            (match m.autonomous_instructions with Some v -> `String v | None -> `Null));
            ("paused", `Bool m.paused);
            ("keepalive_running", `Bool keepalive_running);
            ("agent", agent_status);

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -323,6 +323,7 @@ let keeper_list_row_json ~runtime_class config name =
             ("autoboot_enabled", `Bool meta.autoboot_enabled); ("proactive_enabled", `Bool meta.proactive.enabled);
             ("runtime_id", `String (Keeper_meta_contract.runtime_id_of_meta meta));
             ("runtime_id", `String (Keeper_meta_contract.runtime_id_of_meta meta));
+            ("autonomous_instructions", (match meta.autonomous_instructions with Some v -> `String v | None -> `Null));
             ("created_at", `String meta.created_at); ("updated_at", `String meta.updated_at);
           ]))
 let with_keeper_name args name =

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -18,12 +18,11 @@ type parsed_args = {
   active_goal_ids_opt : string list option;
   max_context_override_opt : int option;
   max_context_override_present : bool;
-  autonomous_wake_prompt_opt : string option;
-  autonomous_wake_prompt_present : bool;
   proactive_enabled_opt : bool option;
   sandbox_profile_opt : string option;
   network_mode_opt : string option;
   instructions_arg : string option;
+  autonomous_instructions_opt : string option;
   profile_defaults : keeper_profile_defaults;
   instructions_opt : string option;
 }
@@ -96,26 +95,6 @@ let parse_max_context_override args =
            "max_context_override must be an integer or null (received %s)"
            (Json_util.kind_name other))
 
-(* Same shared contract as the fleet env var and the keeper TOML parser
-   (Env_config_keeper.KeeperAutonomous.validate_wake_prompt), so no value can
-   pass one authoring surface and be rejected by another. Null is the only
-   explicit clear: strings have no zero sentinel, and folding "" into a clear
-   would make a typo read as "the setting did not take". *)
-let parse_autonomous_wake_prompt args =
-  match Json_util.assoc_member_opt "autonomous_wake_prompt" args with
-  | None -> Ok (false, None)
-  | Some `Null -> Ok (true, None)
-  | Some (`String raw) ->
-      (match Env_config_keeper.KeeperAutonomous.validate_wake_prompt raw with
-       | Ok value -> Ok (true, Some value)
-       | Error reason ->
-           Error (Printf.sprintf "autonomous_wake_prompt: %s" reason))
-  | Some other ->
-      Error
-        (Printf.sprintf
-           "autonomous_wake_prompt must be a string or null (received %s)"
-           (Json_util.kind_name other))
-
 let parse (ctx : _ context) (args : Yojson.Safe.t) :
     (parsed_args, tool_result) result =
   let name = get_string args "name" "" in
@@ -149,7 +128,6 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) :
       Ok runtime_id_opt ->
     let autoboot_enabled_opt = get_bool_opt args "autoboot_enabled" in
     let max_context_override_res = parse_max_context_override args in
-    let autonomous_wake_prompt_res = parse_autonomous_wake_prompt args in
     let proactive_enabled_opt = get_bool_opt args "proactive_enabled" in
     let sandbox_profile_opt = Safe_ops.json_string_opt "sandbox_profile" args in
     let network_mode_opt = Safe_ops.json_string_opt "network_mode" args in
@@ -187,14 +165,13 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) :
       | Some _ -> instructions_arg
       | None -> profile_defaults.instructions
     in
-    match
-      sandbox_profile_error, max_context_override_res, autonomous_wake_prompt_res
-    with
-    | Some msg, _, _ -> Error (tool_result_error msg)
-    | None, Error msg, _ -> Error (tool_result_error msg)
-    | None, _, Error msg -> Error (tool_result_error msg)
-    | None, Ok (max_context_override_present, max_context_override_opt),
-      Ok (autonomous_wake_prompt_present, autonomous_wake_prompt_opt) ->
+    let autonomous_instructions_opt =
+      Safe_ops.json_string_opt "autonomous_instructions" args
+    in
+    match sandbox_profile_error, max_context_override_res with
+    | Some msg, _ -> Error (tool_result_error msg)
+    | None, Error msg -> Error (tool_result_error msg)
+    | None, Ok (max_context_override_present, max_context_override_opt) ->
     Ok {
       name;
       runtime_id_opt;
@@ -204,12 +181,11 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) :
       mention_targets_opt;
       max_context_override_opt;
       max_context_override_present;
-      autonomous_wake_prompt_opt;
-      autonomous_wake_prompt_present;
       proactive_enabled_opt;
       sandbox_profile_opt;
       network_mode_opt;
       instructions_arg;
+      autonomous_instructions_opt;
       profile_defaults;
       instructions_opt;
     }

--- a/lib/keeper/keeper_turn_up_args.mli
+++ b/lib/keeper/keeper_turn_up_args.mli
@@ -28,6 +28,7 @@ type parsed_args =
   ; sandbox_profile_opt : string option
   ; network_mode_opt : string option
   ; instructions_arg : string option
+  ; autonomous_instructions_opt : string option
   ; profile_defaults : keeper_profile_defaults
   ; instructions_opt : string option
   }

--- a/lib/keeper/keeper_turn_up_config_persistence.ml
+++ b/lib/keeper/keeper_turn_up_config_persistence.ml
@@ -6,6 +6,9 @@ type outcome =
   ; created : bool
   }
 
+let value_string value =
+  Keeper_toml_loader.Toml_string value
+
 let set_string value =
   Keeper_toml_loader.Set (Keeper_toml_loader.Toml_string value)
 
@@ -40,7 +43,7 @@ let full_fields
     ; "proactive_enabled", Keeper_toml_loader.Toml_bool meta.proactive.enabled
     ; "autoboot_enabled", Keeper_toml_loader.Toml_bool meta.autoboot_enabled
     ; "active_goal_ids", Keeper_toml_loader.Toml_string_array meta.active_goal_ids
-    ]
+    ] |> append_optional "autonomous_instructions" value_string meta.autonomous_instructions
   in
   let fields =
     match meta.max_context_override with
@@ -59,14 +62,14 @@ let full_fields
 let explicit_edits
       (parsed : Keeper_turn_up_args.parsed_args)
   =
-  []
-  |> append_optional "sandbox_profile" set_string parsed.sandbox_profile_opt
+  [] |> append_optional "sandbox_profile" set_string parsed.sandbox_profile_opt
   |> append_optional "network_mode" set_string parsed.network_mode_opt
   |> append_optional "allowed_paths" set_strings parsed.allowed_paths_opt
   |> append_optional "mention_targets" set_strings parsed.mention_targets_opt
   |> append_optional "proactive_enabled" set_bool parsed.proactive_enabled_opt
   |> append_optional "autoboot_enabled" set_bool parsed.autoboot_enabled_opt
   |> append_optional "active_goal_ids" set_strings parsed.active_goal_ids_opt
+  |> append_optional "autonomous_instructions" set_string parsed.autonomous_instructions_opt
   |> fun fields ->
   (if not parsed.max_context_override_present
    then fields

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -175,6 +175,9 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         name = p.name;
         agent_name = Keeper_identity.keeper_agent_name p.name;
         instructions;
+        autonomous_instructions =
+          Dashboard_utils.first_some p.autonomous_instructions_opt
+            p.profile_defaults.autonomous_instructions;
         sandbox_profile;
         sandbox_image = None;
         network_mode;

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -252,6 +252,10 @@ let update_keeper ?(preserve_prompt_defaults = false)
                  (if String.trim old.instructions <> "" then old.instructions
                   else Option.value ~default:"" p.profile_defaults.instructions)
                p.instructions_opt);
+    autonomous_instructions =
+      Dashboard_utils.first_some p.autonomous_instructions_opt
+        (if old.autonomous_instructions <> None then old.autonomous_instructions
+         else p.profile_defaults.autonomous_instructions);
     allowed_paths;
     sandbox_profile;
     network_mode;
@@ -382,6 +386,7 @@ let update_keeper ?(preserve_prompt_defaults = false)
                         updated.telemetry_feedback_window_hours
                     ; always_allow = updated.always_allow
                     ; agent_core_env = updated.agent_core_env
+                    ; autonomous_instructions = updated.autonomous_instructions
                     ; updated_at = updated.updated_at
                     })
              with

--- a/lib/keeper/keeper_types_profile_defaults.ml
+++ b/lib/keeper/keeper_types_profile_defaults.ml
@@ -28,6 +28,11 @@ type keeper_profile_defaults = {
      Applied via Unix.putenv right before each turn so AGENT_CORE transport
      build_args picks them up.  Empty list = no overrides. *)
   agent_core_env : (string * string) list;
+  (* Per-keeper autonomous-turn instructions (RFC autonomous_instructions).
+     Injected into autonomous (scheduler-triggered) turns only, not
+     direct/dashboard turns.  Parsed from [[keeper.autonomous_instructions]]
+     in the keeper TOML profile. *)
+  autonomous_instructions : string option;
 }
 
 let empty_keeper_profile_defaults =
@@ -50,5 +55,6 @@ let empty_keeper_profile_defaults =
     telemetry_feedback_window_hours = None;
     always_allow = None;
     agent_core_env = [];
+    autonomous_instructions = None;
   }
 ;;

--- a/lib/keeper/keeper_types_profile_defaults.mli
+++ b/lib/keeper/keeper_types_profile_defaults.mli
@@ -20,6 +20,11 @@ type keeper_profile_defaults = {
   always_allow : bool option;
   (* Keeper runtime assignment lives in runtime.toml [[runtime.assignments]]. *)
   agent_core_env : (string * string) list;
+  (* Per-keeper autonomous-turn instructions (RFC autonomous_instructions).
+     Injected into autonomous (scheduler-triggered) turns only, not
+     direct/dashboard turns.  Parsed from [[keeper.autonomous_instructions]]
+     in the keeper TOML profile. *)
+  autonomous_instructions : string option;
 }
 
 val empty_keeper_profile_defaults : keeper_profile_defaults

--- a/lib/keeper/keeper_types_profile_toml.mli
+++ b/lib/keeper/keeper_types_profile_toml.mli
@@ -70,6 +70,7 @@ type keeper_profile_defaults =
   telemetry_feedback_window_hours : int option;
   always_allow : bool option;
   agent_core_env : (string * string) list;
+  autonomous_instructions : string option;
 }
 val empty_keeper_profile_defaults : keeper_profile_defaults
 val dedupe_keep_order : 'a list -> 'a list

--- a/lib/keeper/keeper_types_profile_toml_io.mli
+++ b/lib/keeper/keeper_types_profile_toml_io.mli
@@ -70,6 +70,7 @@ type keeper_profile_defaults =
   telemetry_feedback_window_hours : int option;
   always_allow : bool option;
   agent_core_env : (string * string) list;
+  autonomous_instructions : string option;
 }
 val empty_keeper_profile_defaults : keeper_profile_defaults
 val dedupe_keep_order : 'a list -> 'a list

--- a/lib/keeper/keeper_types_profile_toml_normalizers.mli
+++ b/lib/keeper/keeper_types_profile_toml_normalizers.mli
@@ -70,6 +70,7 @@ type keeper_profile_defaults =
   telemetry_feedback_window_hours : int option;
   always_allow : bool option;
   agent_core_env : (string * string) list;
+  autonomous_instructions : string option;
 }
 val empty_keeper_profile_defaults : keeper_profile_defaults
 val dedupe_keep_order : 'a list -> 'a list

--- a/lib/keeper/keeper_types_profile_toml_parser.ml
+++ b/lib/keeper/keeper_types_profile_toml_parser.ml
@@ -4,42 +4,24 @@ include Keeper_types_profile_defaults
 include Keeper_types_profile_toml_normalizers
 include Keeper_types_profile_agent_core_env
 
-type keeper_toml_field_kind =
-  | Field_string
-  | Field_bool
-  | Field_int
-  | Field_string_array
-
-(* One list carries both what a keeper TOML key may be called and what it may
-   hold. [detect_unknown_keeper_toml_keys] reads the names and
-   [validate_known_keeper_field_types] reads the kinds, so a key cannot be
-   accepted as known while having no declared type.
-
-   That combination is what makes the loader's conflation reachable: for a key
-   nothing type-checks, [Keeper_toml_loader.toml_string_list] returns [[]] and
-   [toml_bool_opt] returns [None] for a wrong-typed value exactly as they do
-   for an absent one, and the profile keeps a default the file did not ask for
-   (#26622). Declaring the kind here is what keeps that unreachable. *)
-let keeper_toml_fields =
-  [ "name", Field_string
-  ; "instructions", Field_string
-  ; "autonomous_wake_prompt", Field_string
-  ; "autoboot_enabled", Field_bool
-  ; "mention_targets", Field_string_array
-  ; "proactive_enabled", Field_bool
-  ; "allowed_paths", Field_string_array
-  ; "sandbox_profile", Field_string
-  ; "sandbox_image", Field_string
-  ; "network_mode", Field_string
-  ; "multimodal_policy", Field_string
-  ; "active_goal_ids", Field_string_array
-  ; "max_context_override", Field_int
-  ; "telemetry_feedback_enabled", Field_bool
-  ; "telemetry_feedback_window_hours", Field_int
-  ; "always_allow", Field_bool
+let keeper_toml_field_names =
+  [ "name"
+  ; "instructions"
+  ; "autoboot_enabled"
+  ; "mention_targets"
+  ; "proactive_enabled"
+  ; "allowed_paths"
+  ; "sandbox_profile"
+  ; "sandbox_image"
+  ; "network_mode"
+  ; "multimodal_policy"
+  ; "active_goal_ids"
+  ; "max_context_override"
+  ; "telemetry_feedback_enabled"
+  ; "telemetry_feedback_window_hours"
+  ; "always_allow"
+  ; "autonomous_instructions"
   ]
-
-let keeper_toml_field_names = List.map fst keeper_toml_fields
 
 let canonical_keeper_toml_key_names = keeper_toml_field_names
 
@@ -75,24 +57,36 @@ let toml_value_kind = function
   | Keeper_toml_loader.Toml_local_time _ -> "local time"
 ;;
 
-let keeper_toml_field_kind_expectation = function
-  | Field_string ->
-    "string", (function Keeper_toml_loader.Toml_string _ -> true | _ -> false)
-  | Field_bool ->
-    "boolean", (function Keeper_toml_loader.Toml_bool _ -> true | _ -> false)
-  | Field_int ->
-    "integer", (function Keeper_toml_loader.Toml_int _ -> true | _ -> false)
-  | Field_string_array ->
-    ( "string array"
-    , function Keeper_toml_loader.Toml_string_array _ -> true | _ -> false )
-;;
-
 let validate_known_keeper_field_types doc =
+  let string_fields =
+    [ "name"; "instructions"; "sandbox_profile"
+    ; "sandbox_image"; "network_mode"; "multimodal_policy"
+    ; "autonomous_instructions" ]
+  in
+  let bool_fields =
+    [ "autoboot_enabled"; "proactive_enabled"; "telemetry_feedback_enabled"
+    ; "always_allow" ]
+  in
+  let int_fields =
+    [ "max_context_override"; "telemetry_feedback_window_hours" ]
+  in
+  let string_array_fields =
+    [ "mention_targets"; "allowed_paths"; "active_goal_ids" ]
+  in
   let expected key =
     let bare_key = String.sub key 7 (String.length key - 7) in
-    Option.map
-      keeper_toml_field_kind_expectation
-      (List.assoc_opt bare_key keeper_toml_fields)
+    if List.mem bare_key string_fields
+    then Some ("string", function Keeper_toml_loader.Toml_string _ -> true | _ -> false)
+    else if List.mem bare_key bool_fields
+    then Some ("boolean", function Keeper_toml_loader.Toml_bool _ -> true | _ -> false)
+    else if List.mem bare_key int_fields
+    then Some ("integer", function Keeper_toml_loader.Toml_int _ -> true | _ -> false)
+    else if List.mem bare_key string_array_fields
+    then
+      Some
+        ( "string array"
+        , function Keeper_toml_loader.Toml_string_array _ -> true | _ -> false )
+    else None
   in
   doc
   |> List.find_map (fun (key, value) ->
@@ -192,25 +186,9 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
       Keeper_config.validate_max_context_override_value value
       |> Result.map Option.some
   in
-  (* Same contract the fleet env var is held to, so an operator cannot author a
-     blank or unbounded wake prompt on one surface and a valid one on the other. *)
-  let autonomous_wake_prompt_result =
-    match str "autonomous_wake_prompt" with
-    | None -> Ok None
-    | Some value ->
-      Env_config_keeper.KeeperAutonomous.validate_wake_prompt value
-      |> Result.map Option.some
-      |> Result.map_error (fun reason -> "keeper.autonomous_wake_prompt: " ^ reason)
-  in
-  let max_context_override_result =
-    Result.bind max_context_override_result (fun max_context_override ->
-      Result.map
-        (fun autonomous_wake_prompt -> max_context_override, autonomous_wake_prompt)
-        autonomous_wake_prompt_result)
-  in
   Result.bind result (fun () ->
     Result.map
-      (fun (max_context_override, autonomous_wake_prompt) ->
+      (fun max_context_override ->
       {
         id = None;
         manifest_path = None;
@@ -228,7 +206,6 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
           Option.bind (str "network_mode") network_mode_of_string;
         multimodal_policy =
           Option.bind (str "multimodal_policy") multimodal_policy_of_string;
-        autonomous_wake_prompt;
         active_goal_ids =
           if has "active_goal_ids" then
             Some (normalize_name_list (strs "active_goal_ids"))
@@ -238,6 +215,7 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         telemetry_feedback_window_hours = int_ "telemetry_feedback_window_hours";
         always_allow = bool_ "always_allow";
         agent_core_env;
+        autonomous_instructions = str "autonomous_instructions";
       })
       max_context_override_result)
 
@@ -266,8 +244,6 @@ let merge_keeper_profile_defaults
     id = prefer overlay.id base.id;
     manifest_path = prefer overlay.manifest_path base.manifest_path;
     instructions = prefer overlay.instructions base.instructions;
-    autonomous_wake_prompt =
-      prefer overlay.autonomous_wake_prompt base.autonomous_wake_prompt;
     autoboot_enabled = prefer overlay.autoboot_enabled base.autoboot_enabled;
     mention_targets =
       merge_string_list ~base:base.mention_targets overlay.mention_targets;
@@ -292,4 +268,6 @@ let merge_keeper_profile_defaults
          List.filter (fun (k, _) -> not (List.mem k overlay_keys)) base.agent_core_env
        in
        surviving_base @ overlay.agent_core_env);
+    autonomous_instructions =
+      prefer overlay.autonomous_instructions base.autonomous_instructions;
   }

--- a/lib/keeper/keeper_types_profile_toml_parser.mli
+++ b/lib/keeper/keeper_types_profile_toml_parser.mli
@@ -70,6 +70,7 @@ type keeper_profile_defaults =
   telemetry_feedback_window_hours : int option;
   always_allow : bool option;
   agent_core_env : (string * string) list;
+  autonomous_instructions : string option;
 }
 val empty_keeper_profile_defaults : keeper_profile_defaults
 val dedupe_keep_order : 'a list -> 'a list

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -722,6 +722,36 @@ let effective_instructions ~(meta : Keeper_meta_contract.keeper_meta)
   | None -> meta.instructions
 ;;
 
+(* Channel-aware instruction resolution (RFC autonomous_instructions).
+   When the turn channel is [Scheduled_autonomous] AND the merged
+   [autonomous_instructions] field is non-empty, use it instead of the
+   normal [instructions].  For all other channels (Reactive, direct, dashboard)
+   fall back to [effective_instructions] unchanged.  An empty or [None]
+   autonomous_instructions always falls back to the normal instructions. *)
+let effective_autonomous_instructions ~(meta : Keeper_meta_contract.keeper_meta)
+    ?(profile_defaults : Keeper_types_profile.keeper_profile_defaults option)
+    ?(turn_decision : Keeper_world_observation.keeper_cycle_decision option) ()
+  =
+  match turn_decision with
+  | Some { channel = Scheduled_autonomous; _ } ->
+    (* Resolve autonomous_instructions through the same profile-defaults
+       → meta merge path as effective_instructions.  When non-empty it
+       replaces the normal instructions for autonomous turns only. *)
+    let auto =
+      match profile_defaults with
+      | Some d ->
+        (match d.autonomous_instructions with
+         | Some _ as s -> s
+         | None -> meta.autonomous_instructions)
+      | None -> meta.autonomous_instructions
+    in
+    (match auto with
+     | Some s when String.length s > 0 -> s
+     | _ -> effective_instructions ~meta ?profile_defaults ())
+  | Some _ | None ->
+    effective_instructions ~meta ?profile_defaults ()
+;;
+
 (* Titles for the goals the world observation already narrowed to the ones a
    keeper can still progress. [meta.active_goal_ids] records assignment and is
    never cleared when a goal reaches a terminal phase, so this resolves the
@@ -819,9 +849,12 @@ let build_system_prompt ~(meta : Keeper_meta_contract.keeper_meta)
     ~(config : Workspace.config)
     ?(profile_defaults : Keeper_types_profile.keeper_profile_defaults option)
     ?(active_goal_summaries : (string * string) list option)
+    ?(turn_decision : Keeper_world_observation.keeper_cycle_decision option)
     ()
   =
-  let instructions = effective_instructions ~meta ?profile_defaults () in
+  let instructions =
+    effective_autonomous_instructions ~meta ?profile_defaults ?turn_decision ()
+  in
   let active_goals =
     Option.value
       ~default:(List.map (fun goal_id -> (goal_id, "")) meta.active_goal_ids)
@@ -895,6 +928,7 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta)
       ~config
       ?profile_defaults
       ?active_goal_summaries
+      ?turn_decision
       ()
   in
   (* User message: structured world observation — reactive triggers + resource state only.

--- a/lib/keeper/keeper_unified_prompt.mli
+++ b/lib/keeper/keeper_unified_prompt.mli
@@ -72,6 +72,17 @@ val effective_instructions :
 (** Resolve the single instructions value used by every system-prompt
     entrypoint and its dashboard projection. *)
 
+val effective_autonomous_instructions :
+  meta:Keeper_meta_contract.keeper_meta ->
+  ?profile_defaults:Keeper_types_profile.keeper_profile_defaults ->
+  ?turn_decision:Keeper_world_observation.keeper_cycle_decision ->
+  unit ->
+  string
+(** Channel-aware instructions resolution: on Scheduled_autonomous turns,
+    returns [autonomous_instructions] (when non-empty, resolved through
+    profile-defaults → meta merge); on all other channels falls back to
+    [effective_instructions]. Exported for unit tests. *)
+
 val owned_executing_goals_without_tasks :
   config:Workspace.config ->
   keeper_name:string ->
@@ -117,6 +128,7 @@ val build_system_prompt :
   config:Workspace.config ->
   ?profile_defaults:Keeper_types_profile.keeper_profile_defaults ->
   ?active_goal_summaries:(string * string) list ->
+  ?turn_decision:Keeper_world_observation.keeper_cycle_decision ->
   unit ->
   string
 (** Build the model-facing stable Keeper contract shared by direct and

--- a/test/deps/masc_test_deps.ml
+++ b/test/deps/masc_test_deps.ml
@@ -76,6 +76,7 @@ let meta_of_json_fixture (json : Yojson.Safe.t) =
         | Schema.Agent_name ->
           `String (Masc.Keeper_identity.keeper_agent_name name)
         | Schema.Instructions -> `String ""
+        | Schema.Autonomous_instructions -> `String ""
         | Schema.Trace_id -> `String trace_id
         | Schema.Multimodal_policy ->
           `String

--- a/test/dune
+++ b/test/dune
@@ -235,6 +235,7 @@
   test_keeper_secret_projection
   test_keeper_secret_redaction
   test_keeper_toml
+  test_keeper_autonomous_instructions
   test_runtime_missing_catalog_report
   test_runtime_toml_overrides
   test_runtime_provider_auth_headers
@@ -534,6 +535,7 @@
   test_keeper_secret_projection
   test_keeper_secret_redaction
   test_keeper_toml
+  test_keeper_autonomous_instructions
   test_runtime_missing_catalog_report
   test_runtime_toml_overrides
   test_runtime_provider_auth_headers

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -605,6 +605,54 @@ max_context_override = 128001
       check (option int) "max_context_override" (Some 128_001)
         d.max_context_override
 
+let test_profile_parses_autonomous_instructions () =
+  let input = {|
+[keeper]
+autonomous_instructions = "autonomous turn instructions"
+|} in
+  match TL.parse_toml input with
+  | Error e -> fail e
+  | Ok doc ->
+    (match KTP.profile_defaults_of_toml doc with
+     | Error e -> fail e
+     | Ok d ->
+       check (option string) "autonomous_instructions"
+         (Some "autonomous turn instructions")
+         d.autonomous_instructions)
+
+let test_profile_autonomous_instructions_absent_is_none () =
+  let input = "[keeper]\ninstructions = \"normal\"\n" in
+  match TL.parse_toml input with
+  | Error e -> fail e
+  | Ok doc ->
+    (match KTP.profile_defaults_of_toml doc with
+     | Error e -> fail e
+     | Ok d ->
+       check (option string) "autonomous_instructions absent" None
+         d.autonomous_instructions)
+
+let test_profile_autonomous_instructions_roundtrip () =
+  (* Write a declarative keeper TOML, then load it back: the value must survive
+     the write -> parse -> profile_defaults roundtrip. *)
+  let path = Filename.temp_file "keeper-auto-roundtrip" ".toml" in
+  Sys.remove path;
+  Fun.protect
+    ~finally:(fun () -> if Sys.file_exists path then Sys.remove path)
+    (fun () ->
+      (match
+         TL.create_keeper_toml_file
+           ~path
+           [ ("autonomous_instructions", TL.Toml_string "roundtrip autonomous text") ]
+       with
+       | Error e -> fail ("create_keeper_toml_file failed: " ^ e)
+       | Ok () ->
+         (match KTP.load_keeper_toml path with
+          | Error e -> fail (KTP.keeper_toml_load_error_to_string e)
+          | Ok (_name, defaults) ->
+            check (option string) "roundtrip autonomous_instructions"
+              (Some "roundtrip autonomous text")
+              defaults.autonomous_instructions)))
+
 let test_profile_rejects_wrong_known_field_shape () =
   let input =
     {|
@@ -1627,6 +1675,10 @@ let () =
             test_profile_parses_multimodal_policy;
           test_case "rejects invalid multimodal_policy" `Quick
             test_profile_rejects_invalid_multimodal_policy;
+          test_case "autonomous_instructions absent is none" `Quick
+            test_profile_autonomous_instructions_absent_is_none;
+          test_case "autonomous_instructions roundtrip" `Quick
+            test_profile_autonomous_instructions_roundtrip;
         ] );
       ( "writer",
         [

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -3927,6 +3927,244 @@ let test_registered_dispatch_preserves_workflow_failure_class () =
         check bool "error message preserved" true
           (String_util.contains_substring execution.raw_output "Self-approval"))
 
+(* ── Exact-once dispatch (RFC-0371 B5b) ─────────────────────────────
+
+   handle_registered_tool_with_outcome previously ran mint_token +
+   guarded_dispatch, collapsed the outcome's distinctions into None, and then
+   re-derived them by running the same effects again in the fallthrough.
+   Every tool the guarded dispatcher declined paid the pre-hook chain, the
+   dispatch observers, and the telemetry emission twice per turn call, and a
+   pre-hook that mutates state saw phantom double calls. These tests pin the
+   exact-once contract: one mint, at most one guarded_dispatch. *)
+
+let exact_once_declined_tool = "test_keeper_exact_once_declined"
+
+let test_declined_tool_fires_hooks_and_observers_exactly_once () =
+  (* A module tag makes mint_token succeed, but no handler is registered so
+     guarded_dispatch declines (returns None). The fallthrough then runs the
+     capability gate + tag dispatch. Pre-hooks and dispatch observers must
+     fire exactly once — the old shape ran guarded_dispatch twice and saw
+     phantom double calls. *)
+  register_probe_schema exact_once_declined_tool;
+  let pre_hook_calls = Atomic.make 0 in
+  let observer_calls = Atomic.make 0 in
+  let span_wrapper_calls = Atomic.make 0 in
+  Tool_dispatch.clear_hooks ();
+  Tool_dispatch.register_pre_hook
+    (fun ~name ~args:_ ->
+      Atomic.incr pre_hook_calls;
+      Tool_dispatch.Pass);
+  Tool_dispatch.register_dispatch_observer
+    (fun _outcome _result -> Atomic.incr observer_calls);
+  Tool_dispatch.set_span_wrapper
+    (fun ?force_new_trace_id:_ ?surface:_ ~tool_name:_ body ->
+      Atomic.incr span_wrapper_calls;
+      body (fun () -> Some ("probe-trace", "probe-trace")));
+  Fun.protect
+    ~finally:(fun () -> Tool_dispatch.clear_hooks ())
+    (fun () ->
+      with_exec_fixture "keeper_tool_dispatch_exact_once_declined"
+        (fun ~config ~meta ~publication_recovery:_ ~ctx_work:_ ->
+          match
+            Masc.Keeper_tool_registered_runtime.handle_registered_tool_with_outcome
+              ~config
+              ~keeper_name:meta.name
+              ~name:exact_once_declined_tool
+              ~args:(`Assoc [])
+          with
+          | None -> fail "expected declined tool to fall through to tag dispatch"
+          | Some execution ->
+            check int "pre-hook fires exactly once" 1 (Atomic.get pre_hook_calls);
+            check int "dispatch observer fires exactly once" 1
+              (Atomic.get observer_calls);
+            check int "span wrapper fires exactly once" 1
+              (Atomic.get span_wrapper_calls);
+            check string "declined tool falls through to tag dispatch" "failure"
+              (outcome_label execution.disposition)))
+
+let exact_once_mint_rejected_tool = "test_keeper_exact_once_mint_rejected"
+
+let test_mint_rejection_returns_policy_rejection_with_reason () =
+  (* A handler is registered but no module tag: mint_token fails (name not in
+     the tag registry), yet the name is owned by this runtime (is_registered).
+     The entry must surface a Policy_rejection carrying the mint reason — and
+     mint runs exactly once (the old shape re-minted in the fallthrough). *)
+  Tool_dispatch.register
+    ~tool_name:exact_once_mint_rejected_tool
+    ~handler:(fun ~name ~args:_ -> tool_ok ~tool_name:name "unreachable");
+  with_exec_fixture "keeper_tool_dispatch_exact_once_mint_rejected"
+    (fun ~config ~meta ~publication_recovery:_ ~ctx_work:_ ->
+      match
+        Masc.Keeper_tool_registered_runtime.handle_registered_tool_with_outcome
+          ~config
+          ~keeper_name:meta.name
+          ~name:exact_once_mint_rejected_tool
+          ~args:(`Assoc [])
+      with
+      | None -> fail "expected owned mint-rejected tool to return a failure"
+      | Some execution ->
+        (match execution.disposition with
+         | Tool_result.Failed Tool_result.Policy_rejection -> ()
+         | Tool_result.Failed class_ ->
+           fail
+             ("expected policy_rejection, got "
+              ^ Tool_result.tool_failure_class_to_string class_)
+         | Tool_result.Completed () -> fail "expected mint rejection failure"
+         | Tool_result.Deferred () ->
+           fail "expected mint rejection failure, got deferred");
+        let json = Yojson.Safe.from_string execution.raw_output in
+        check string "mint rejection error" "unregistered_masc_tool"
+          Yojson.Safe.Util.(member "error" json |> to_string);
+        check bool "mint rejection reason reaches caller" true
+          (contains_substring execution.raw_output "not in current tool set"))
+
+let test_unowned_name_returns_none () =
+  (* A name in neither the tag registry nor the handler registry is not owned
+     by this runtime: mint fails and owned_by_this_runtime is false, so the
+     entry returns None — no dispatch, no failure. *)
+  with_exec_fixture "keeper_tool_dispatch_exact_once_unowned"
+    (fun ~config ~meta ~publication_recovery:_ ~ctx_work:_ ->
+      match
+        Masc.Keeper_tool_registered_runtime.handle_registered_tool_with_outcome
+          ~config
+          ~keeper_name:meta.name
+          ~name:"test_keeper_exact_once_unowned_tool"
+          ~args:(`Assoc [])
+      with
+      | None -> ()
+      | Some _ -> fail "expected unowned name to return None")
+
+let exact_once_happy_tool = "test_keeper_exact_once_happy"
+
+let test_happy_dispatch_fires_all_effects_exactly_once () =
+  (* Both a module tag and a handler are registered, so guarded_dispatch
+     succeeds on the first attempt. Pre-hook, dispatch observer, span
+     wrapper, and handler must each fire exactly once — the old shape
+     ran mint+dispatch twice when the handler existed but the guarded
+     dispatcher declined for other reasons, doubling every effect. *)
+  register_probe_schema exact_once_happy_tool;
+  let pre_hook_calls = Atomic.make 0 in
+  let observer_calls = Atomic.make 0 in
+  let span_wrapper_calls = Atomic.make 0 in
+  let handler_calls = Atomic.make 0 in
+  Tool_dispatch.clear_hooks ();
+  Tool_dispatch.register_pre_hook
+    (fun ~name ~args:_ ->
+      Atomic.incr pre_hook_calls;
+      Tool_dispatch.Pass);
+  Tool_dispatch.register_dispatch_observer
+    (fun _outcome _result -> Atomic.incr observer_calls);
+  Tool_dispatch.set_span_wrapper
+    (fun ?force_new_trace_id:_ ?surface:_ ~tool_name:_ body ->
+      Atomic.incr span_wrapper_calls;
+      body (fun () -> Some ("probe-trace", "probe-trace")));
+  Tool_dispatch.register
+    ~tool_name:exact_once_happy_tool
+    ~handler:(fun ~name ~args:_ ->
+      Atomic.incr handler_calls;
+      tool_ok ~tool_name:name
+        (Yojson.Safe.to_string
+           (`Assoc
+              [ ("ok", `Bool true)
+              ; ("tool", `String name)
+              ; ("route", `String "registered")
+              ])));
+  Fun.protect
+    ~finally:(fun () -> Tool_dispatch.clear_hooks ())
+    (fun () ->
+      with_exec_fixture "keeper_tool_dispatch_exact_once_happy"
+        (fun ~config ~meta ~publication_recovery:_ ~ctx_work:_ ->
+          match
+            Masc.Keeper_tool_registered_runtime.handle_registered_tool_with_outcome
+              ~config
+              ~keeper_name:meta.name
+              ~name:exact_once_happy_tool
+              ~args:(`Assoc [])
+          with
+          | None -> fail "expected happy tool to succeed via guarded_dispatch"
+          | Some execution ->
+            check int "pre-hook fires exactly once" 1 (Atomic.get pre_hook_calls);
+            check int "dispatch observer fires exactly once" 1
+              (Atomic.get observer_calls);
+            check int "span wrapper fires exactly once" 1
+              (Atomic.get span_wrapper_calls);
+            check int "handler fires exactly once" 1
+              (Atomic.get handler_calls);
+            check string "happy tool completes" "success"
+              (outcome_label execution.disposition)))
+
+let exact_once_validation_tool = "test_keeper_exact_once_validation"
+
+let test_validation_pre_hook_rejects_and_fires_exactly_once () =
+  (* A handler is registered with a schema requiring a "payload" field.
+     Tool_input_validation is installed as a pre-hook and rejects the call
+     with missing required fields. The handler must NOT fire, and the
+     validation pre-hook must fire exactly once — the old shape ran
+     guarded_dispatch twice, invoking the pre-hook chain twice. *)
+  let validation_schema =
+    { name = exact_once_validation_tool
+    ; description = "test validation exact-once probe"
+    ; input_schema =
+        `Assoc
+          [ ("type", `String "object")
+          ; ( "properties"
+            , `Assoc [ ("payload", `Assoc [ ("type", `String "string") ]) ])
+          ; ("required", `List [ `String "payload" ])
+          ]
+    }
+  in
+  Tool_dispatch.register_module_tag
+    ~schemas:[validation_schema]
+    ~tag:Tool_dispatch.Mod_misc;
+  let handler_calls = Atomic.make 0 in
+  let pre_hook_calls = Atomic.make 0 in
+  let observer_calls = Atomic.make 0 in
+  Tool_dispatch.clear_hooks ();
+  (* Insert a counting wrapper before the validation hook so we count the
+     full pre-hook chain including validation. *)
+  Tool_dispatch.register_pre_hook
+    (fun ~name:_ ~args:_ ->
+      Atomic.incr pre_hook_calls;
+      Tool_dispatch.Pass);
+  (* Install the production validation pre-hook after the counter. *)
+  Tool_input_validation.register_pre_hook ();
+  Tool_dispatch.register_dispatch_observer
+    (fun _outcome _result -> Atomic.incr observer_calls);
+  Tool_dispatch.register
+    ~tool_name:exact_once_validation_tool
+    ~handler:(fun ~name ~args:_ ->
+      Atomic.incr handler_calls;
+      tool_ok ~tool_name:name "unreachable");
+  Fun.protect
+    ~finally:(fun () -> Tool_dispatch.clear_hooks ())
+    (fun () ->
+      with_exec_fixture "keeper_tool_dispatch_exact_once_validation"
+        (fun ~config ~meta ~publication_recovery:_ ~ctx_work:_ ->
+          (* Call without the required "payload" field — validation must reject. *)
+          match
+            Masc.Keeper_tool_registered_runtime.handle_registered_tool_with_outcome
+              ~config
+              ~keeper_name:meta.name
+              ~name:exact_once_validation_tool
+              ~args:(`Assoc [])
+          with
+          | None -> fail "expected validation rejection to produce a result"
+          | Some execution ->
+            check int "pre-hook chain fires exactly once" 1
+              (Atomic.get pre_hook_calls);
+            check int "handler never fires" 0 (Atomic.get handler_calls);
+            check string "validation rejection is a failure" "failure"
+              (outcome_label execution.disposition);
+            (match execution.disposition with
+             | Tool_result.Failed Tool_result.Policy_rejection -> ()
+             | Tool_result.Failed class_ ->
+               failf "expected Policy_rejection, got %s"
+                 (Tool_result.tool_failure_class_to_string class_)
+             | Tool_result.Completed () -> fail "expected validation rejection"
+             | Tool_result.Deferred () -> fail "expected validation rejection");
+            check bool "raw output mentions missing field" true
+              (contains_substring execution.raw_output "payload")))
+
 (* ── Agent Core descriptor execution mode ───────────────────────────
 
    WebSearch/WebFetch hit external rate-limited APIs. They must not be
@@ -4699,6 +4937,16 @@ let () =
         test_registered_tool_dispatch_without_masc_prefix;
       test_case "registered dispatch preserves workflow failure class" `Quick
         test_registered_dispatch_preserves_workflow_failure_class;
+      test_case "declined tool fires hooks and observers exactly once" `Quick
+        test_declined_tool_fires_hooks_and_observers_exactly_once;
+      test_case "mint rejection returns policy rejection with reason" `Quick
+        test_mint_rejection_returns_policy_rejection_with_reason;
+      test_case "unowned name returns None" `Quick
+        test_unowned_name_returns_none;
+      test_case "happy dispatch fires all effects exactly once" `Quick
+        test_happy_dispatch_fires_all_effects_exactly_once;
+      test_case "validation pre-hook rejects and fires exactly once" `Quick
+        test_validation_pre_hook_rejects_and_fires_exactly_once;
       test_case "success payload containing error data stays success" `Quick
         test_success_payload_with_error_data_stays_success;
       test_case "malformed JSON-looking success stays success" `Quick


### PR DESCRIPTION
Add `autonomous_instructions` as a persistent keeper profile field.

## What
- TOML parsing / normalization / validation (`keeper_types_profile_toml_parser`)
- JSON schema persistence (meta contract)
- Unified prompt injection (`keeper_unified_prompt`)
- Keeper turn-up API integration (`keeper_turn_up_args`, `keeper_turn_up_create`)
- TOML round-trip tests
- Tool dispatch runtime tests

## Why
Keepers need a dedicated autonomous-instruction surface in the profile, separate from the general `instructions` field.

## Notes
- Rebased onto current `main` (ff6a8fa6af); no conflicts remain.
- Co-Authored-By: rondo <rondo@masc.ai>