### PR TITLE
fix(fs_compat): cwd "."가 ownership root 밖으로 거부되던 정규화 결함 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1066,6 +1066,7 @@ jobs:
             @test/runtest-test_event_bus_subscription_contract \
             @test/runtest-test_fs_compat_home_guard \
             @test/runtest-test_guarded_dispatch_telemetry \
+            @test/runtest-test_owned_read_cwd \
             @test/runtest-test_keeper_capability_probe \
             @test/runtest-test_keeper_checkpoint_stale_guard \
             @test/runtest-test_keeper_contract_classifier_pure \

--- a/lib/fs_compat/owned_directory_chain.ml
+++ b/lib/fs_compat/owned_directory_chain.ml
@@ -46,9 +46,14 @@ let relative_components ~ownership_root path =
         let component = Filename.basename current in
         if
           String.equal parent current
-          || String.equal component Filename.current_dir_name
           || String.equal component Filename.parent_dir_name
         then Error (Owned_path_outside_root { ownership_root; path })
+        else if String.equal component Filename.current_dir_name
+        then
+          (* "." is a path identity: /root/./x and /root/x name the same file,
+             so the segment is dropped. ".." stays rejected above because the
+             OS resolves it upward, which can leave the ownership root. *)
+          ascend components parent
         else ascend (component :: components) parent
     in
     ascend [] path

--- a/test/dune
+++ b/test/dune
@@ -630,6 +630,11 @@
  (modules test_repo_store)
  (libraries alcotest repo_manager unix masc.string_util))
 
+(test
+ (name test_owned_read_cwd)
+ (modules test_owned_read_cwd)
+ (libraries alcotest masc_test_deps))
+
 ; Request-authority admission uses Eio fiber-local bindings and therefore owns
 ; an explicit executable stanza instead of borrowing the pure synchronous test
 ; group above.

--- a/test/test_owned_read_cwd.ml
+++ b/test/test_owned_read_cwd.ml
@@ -1,0 +1,104 @@
+(* Feature: a keeper reads files inside its sandbox through
+   [handle_owned_read_file_with_outcome] using the natural cwd spellings a
+   model produces. [cwd:"."] names the ownership root itself and must
+   resolve, not be rejected as an escape; [cwd:".."] genuinely leaves the
+   root and must stay rejected. Live failure: verification runs died on
+   {"error":"path <root>/. is outside ownership root <root>"} (issue
+   #28721). *)
+
+let rec rm_rf path =
+  match Unix.lstat path with
+  | { Unix.st_kind = Unix.S_DIR; _ } ->
+    Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+    Unix.rmdir path
+  | _ -> Sys.remove path
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> ()
+
+let with_ownership_root f =
+  let root = Filename.temp_file "owned_read_cwd" "" in
+  Sys.remove root;
+  Unix.mkdir root 0o755;
+  Fun.protect
+    ~finally:(fun () -> try rm_rf root with _ -> ())
+    (fun () -> f root)
+
+let write_file path content =
+  let oc = open_out_bin path in
+  output_string oc content;
+  close_out oc
+
+let read_via_tool ~ownership_root args =
+  Masc.Keeper_tool_filesystem_runtime.handle_owned_read_file_with_outcome
+    ~ownership_root
+    ~args
+
+let content_of_execution (execution : Masc.Keeper_tool_execution.t) =
+  match Yojson.Safe.from_string execution.raw_output with
+  | `Assoc fields ->
+    (match List.assoc_opt "content" fields with
+     | Some (`String content) -> Some content
+     | _ -> None)
+  | _ -> None
+  | exception _ -> None
+
+let expect_read_success ~what ~expected_content execution =
+  match execution.Masc.Keeper_tool_execution.disposition with
+  | Tool_result.Completed () ->
+    (match content_of_execution execution with
+     | Some content ->
+       Alcotest.(check string) (what ^ " content") expected_content content
+     | None ->
+       Alcotest.failf "%s: completed without a string content field: %s" what
+         execution.raw_output)
+  | Tool_result.Deferred () -> Alcotest.failf "%s: unexpectedly deferred" what
+  | Tool_result.Failed _ ->
+    Alcotest.failf "%s: read failed: %s" what execution.raw_output
+
+let expect_read_failure ~what execution =
+  match execution.Masc.Keeper_tool_execution.disposition with
+  | Tool_result.Failed _ -> ()
+  | Tool_result.Completed () | Tool_result.Deferred () ->
+    Alcotest.failf "%s: expected a failure, got: %s" what execution.raw_output
+
+let test_dot_cwd_reads_root_file () =
+  with_ownership_root (fun root ->
+    write_file (Filename.concat root "hello.txt") "hello from the root";
+    read_via_tool ~ownership_root:root
+      (`Assoc [ "path", `String "hello.txt"; "cwd", `String "." ])
+    |> expect_read_success ~what:"cwd:\".\"" ~expected_content:"hello from the root")
+
+let test_omitted_cwd_reads_root_file () =
+  with_ownership_root (fun root ->
+    write_file (Filename.concat root "hello.txt") "hello from the root";
+    read_via_tool ~ownership_root:root (`Assoc [ "path", `String "hello.txt" ])
+    |> expect_read_success ~what:"omitted cwd" ~expected_content:"hello from the root")
+
+let test_dot_slash_subdirectory_cwd () =
+  with_ownership_root (fun root ->
+    let sub = Filename.concat root "sub" in
+    Unix.mkdir sub 0o755;
+    write_file (Filename.concat sub "inner.txt") "inner payload";
+    read_via_tool ~ownership_root:root
+      (`Assoc [ "path", `String "inner.txt"; "cwd", `String "./sub" ])
+    |> expect_read_success ~what:"cwd:\"./sub\"" ~expected_content:"inner payload")
+
+let test_parent_cwd_stays_rejected () =
+  with_ownership_root (fun root ->
+    write_file (Filename.concat root "hello.txt") "hello from the root";
+    read_via_tool ~ownership_root:root
+      (`Assoc [ "path", `String "hello.txt"; "cwd", `String ".." ])
+    |> expect_read_failure ~what:"cwd:\"..\"")
+
+let () =
+  Alcotest.run "owned_read_cwd"
+    [ ( "cwd resolution"
+      , [ Alcotest.test_case "cwd \".\" reads a root file" `Quick
+            test_dot_cwd_reads_root_file
+        ; Alcotest.test_case "omitted cwd reads a root file" `Quick
+            test_omitted_cwd_reads_root_file
+        ; Alcotest.test_case "cwd \"./sub\" reads inside a subdirectory" `Quick
+            test_dot_slash_subdirectory_cwd
+        ; Alcotest.test_case "cwd \"..\" stays rejected" `Quick
+            test_parent_cwd_stays_rejected
+        ] )
+    ]


### PR DESCRIPTION
## 무엇을

`Owned_directory_chain.relative_components`가 `.` 세그먼트를 만나면 즉시 "outside ownership root"로 거부했습니다. keeper가 파일 읽기에 가장 자연스럽게 주는 `cwd: "."`(root 자기 자신)이 전부 실패했고, task-256 검증 런의 첫 read가 이걸로 죽었습니다 (#28721 실측 레코드).

`.`은 경로 항등이라 세그먼트를 소거하고 계속 올라가도록 바꿨습니다. `..`은 OS 해석에서 실제로 root를 벗어날 수 있으므로 거부를 유지합니다. ownership 판정의 단일 지점이라 읽기·쓰기 체인 전부가 같은 소거를 얻습니다.

## Feature 테스트

`test_owned_read_cwd` 신규 — `handle_owned_read_file_with_outcome` 레벨:
- `cwd:"."`로 root 파일 읽기 성공 (수정 전 FAIL)
- cwd 생략 성공 (회귀 가드)
- `cwd:"./sub"` 성공
- `cwd:".."` 거부 유지 (탈출 방어)

test_fs_compat 스위트가 CI 미배선이라 새 스위트를 ci.yml에 직접 배선했습니다.

## 검증

- 로컬 빌드 없이 CI로 판정합니다 (운영 원칙).
- 남은 미검증: 검증 런(taskmaster) 경로의 실제 재현은 서버 반영 후 verification-runs.jsonl에서 `cwd:"."` 실패 소멸로 확인 예정.

Closes #28721