### PR TITLE
fix(keeper): report Slack refusals as proven pre-effect

### DIFF
--- a/lib/keeper/keeper_chat_slack.ml
+++ b/lib/keeper/keeper_chat_slack.ml
@@ -14,6 +14,20 @@ let pp_error fmt = function
       Format.fprintf fmt "Slack API error: %s" error
   | Other msg -> Format.fprintf fmt "Other: %s" msg
 
+let effect_disposition = function
+  | Slack_api _ -> Tool_result.Proven_pre_effect
+  | Network _ | Http_status _ -> Tool_result.Effect_outcome_unknown
+  | Other _ ->
+    (* [Other] carries two facts the wire type does not separate: a
+       non-JSON response (nothing proven) and [ok=true] with no [ts]
+       (the message was posted). Reporting the weaker
+       [Effect_outcome_unknown] is sound for both — it only ever
+       withholds correction, never permits a retry of a committed send.
+       Separating them belongs with a split of the [Other] constructor in
+       {!Slack_rest_client}. *)
+    Tool_result.Effect_outcome_unknown
+;;
+
 let slack_message_limit = 4000
 let slack_max_blocks = 50
 let slack_block_text_limit = 3000

--- a/lib/keeper/keeper_chat_slack.mli
+++ b/lib/keeper/keeper_chat_slack.mli
@@ -16,6 +16,15 @@ type error =
 
 val pp_error : Format.formatter -> error -> unit
 
+val effect_disposition : error -> Tool_result.failure_effect_disposition
+(** [effect_disposition error] states what the Slack transport proves about
+    the requested send. Slack answers every Web API call with HTTP 200 and
+    [{ ok, error? }] (RFC-0317, {!Slack_rest_client}), so [Slack_api] is a
+    logical refusal of a request Slack fully received and declined to act on
+    — the message was not posted. Callers turn this into
+    {!Tool_result.Proven_pre_effect} so the refusal stays correctable inside
+    the provider turn instead of reaching the terminal effect boundary. *)
+
 val send_message :
   ?clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
   ?timeout_sec:float ->

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -1137,10 +1137,15 @@ let replay_connector_post_with_outcome
     Keeper_tool_execution.success
       (Keeper_surface_post.ok_json ~surface:connector ?message_id ())
   in
-  let fail connector detail =
+  (* [effect_disposition] decides whether the keeper may correct and retry
+     inside the same provider turn ({!Keeper_runtime_failure_route}: a proven
+     pre-effect rejection must never reach the terminal effect boundary), so
+     each connector supplies what its transport actually proves instead of
+     defaulting every failure to "outcome unknown". *)
+  let fail connector ~effect_disposition detail =
     Keeper_tool_execution.failure
       ~class_:Tool_result.Runtime_failure
-      ~effect_disposition:Tool_result.Effect_outcome_unknown
+      ~effect_disposition
       (Keeper_surface_post.error_json
          (Printf.sprintf "%s send failed: %s" connector detail))
   in
@@ -1166,8 +1171,14 @@ let replay_connector_post_with_outcome
          ~mention_user_ids ()
      with
      | Error send_error ->
+       (* Discord stays "outcome unknown": its refusals arrive as non-2xx and
+          {!Discord_rest_client.Discord_api} carries Discord's own error code
+          rather than the HTTP status, so this layer cannot tell a 4xx refusal
+          from a 5xx that may have committed. Claiming pre-effect here would
+          license a duplicate post. *)
        fail
          Keeper_surface_post.discord_label
+         ~effect_disposition:Tool_result.Effect_outcome_unknown
          (Format.asprintf
             "%a"
             Channel_gate_discord_state.pp_send_error
@@ -1228,6 +1239,7 @@ let replay_connector_post_with_outcome
         | Error send_error ->
           fail
             Keeper_surface_post.slack_label
+            ~effect_disposition:(Keeper_chat_slack.effect_disposition send_error)
             (Format.asprintf "%a" Keeper_chat_slack.pp_error send_error)
         | Ok () ->
           (match

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=555
+UNWIRED_BASELINE=554
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -92,6 +92,7 @@ normal_targets=(
   @test/runtest-test_file_kind_vocabulary
   @test/runtest-test_http_auth_strict_flag
   @test/runtest-test_keeper_chat_broadcast
+  @test/runtest-test_keeper_chat_slack
   @test/runtest-test_keeper_memory_lane
   @test/runtest-test_server_dashboard_http_keeper_chat_page
   @test/runtest-test_keeper_codex_effort_clamp

--- a/test/test_keeper_chat_slack.ml
+++ b/test/test_keeper_chat_slack.ml
@@ -543,10 +543,49 @@ let test_native_activity_failure_does_not_affect_delivery () =
     (List.rev !sends);
   check bool "delivery still succeeds" true (outcomes = [ Ok () ])
 
+let disposition_testable =
+  testable
+    (fun fmt disposition ->
+      Format.pp_print_string fmt
+        (Tool_result.failure_effect_disposition_to_string disposition))
+    ( = )
+
+(* Slack answers logical refusals with HTTP 200 and [{ok:false,error}]
+   (Slack_rest_client, RFC-0317), so a refused post never happened.
+   Keeper_tools_agent_core_handler skips mark_terminal_effect_failed on
+   Proven_pre_effect, so this mapping is what keeps an invalid_blocks refusal
+   correctable inside the provider turn instead of ending it. *)
+let test_slack_api_refusal_is_proven_pre_effect () =
+  check disposition_testable "invalid_blocks"
+    Tool_result.Proven_pre_effect
+    (Masc.Keeper_chat_slack.effect_disposition
+       (Masc.Keeper_chat_slack.Slack_api { error = "invalid_blocks" }))
+
+let test_unproven_slack_failures_stay_unknown () =
+  let unknown = Tool_result.Effect_outcome_unknown in
+  check disposition_testable "network"
+    unknown
+    (Masc.Keeper_chat_slack.effect_disposition
+       (Masc.Keeper_chat_slack.Network "connection reset"));
+  check disposition_testable "http status"
+    unknown
+    (Masc.Keeper_chat_slack.effect_disposition
+       (Masc.Keeper_chat_slack.Http_status { code = 503; body = "" }));
+  check disposition_testable "other"
+    unknown
+    (Masc.Keeper_chat_slack.effect_disposition
+       (Masc.Keeper_chat_slack.Other "ok=true but missing 'ts'"))
+
 let () =
   run "keeper_chat_slack"
     [
-      ( "audio-url"
+      ( "effect-disposition"
+      , [ test_case "Slack refusal proves no post" `Quick
+            test_slack_api_refusal_is_proven_pre_effect
+        ; test_case "unproven failures stay unknown" `Quick
+            test_unproven_slack_failures_stay_unknown
+        ] )
+    ; ( "audio-url"
       , [ test_case "uses base URL" `Quick test_public_voice_audio_url_uses_base_url
         ; test_case "strips trailing slash" `Quick
             test_public_voice_audio_url_strips_trailing_slash


### PR DESCRIPTION
## 문제

라이브 keeper 턴이 이 오류로 죽었습니다 (2026-08-14, 사용자 보고):

```
Terminal tool use call_d0168b08c9d04c45b50ceb80 failed at an unknown effect boundary:
{"error":"slack send failed: Slack API error: invalid_blocks"}
```

`invalid_blocks`는 Slack이 블록을 검증하고 거절한 것이라 메시지는 올라가지 않았습니다. 모델이 에러를 받아 블록을 고쳐 다시 보낼 수 있어야 하는데, 턴이 통째로 끝나서 교정 기회가 없습니다.

## 원인

`keeper_tool_in_process_runtime.ml`의 connector replay 경로가 전송 실패를 문자열로 평탄화한 뒤 **전부** `Effect_outcome_unknown`으로 찍었습니다.

```ocaml
let fail connector detail =
  Keeper_tool_execution.failure
    ~class_:Tool_result.Runtime_failure
    ~effect_disposition:Tool_result.Effect_outcome_unknown   (* 모든 실패가 여기로 *)
    ...
| Error send_error ->
  fail Keeper_surface_post.slack_label
    (Format.asprintf "%a" Keeper_chat_slack.pp_error send_error)   (* 타입을 버림 *)
```

`Keeper_chat_slack.error`는 이미 `Network` / `Http_status` / `Slack_api` / `Other`를 구분합니다. disposition을 정하는 바로 그 지점에서 그 구분이 사라졌습니다.

결과적으로 `keeper_tools_agent_core_handler.ml:69-79`의 분기를 `Effect_outcome_unknown` 쪽으로 타서 `mark_terminal_effect_failed`가 호출되고, `Keeper_tool_terminal_boundary.decision`이 `Error`를 반환해 턴이 종료됩니다.

`Keeper_runtime_failure_route`는 의도를 이미 명시하고 있습니다 (`keeper_runtime_failure_route.ml:129-132`):

```ocaml
| Tool_result.Proven_pre_effect ->
  (* A proven pre-effect rejection must remain correction-capable inside
     the provider turn and must never reach this terminal boundary. *)
```

## 변경

`Keeper_chat_slack.effect_disposition`을 추가해 기존 variant에서 disposition을 파생시키고, `fail`이 이를 인자로 받게 했습니다. 문자열 매칭은 도입하지 않았습니다.

| 생성자 | disposition | 근거 |
|---|---|---|
| `Slack_api _` | `Proven_pre_effect` | Slack Web API는 논리 실패도 HTTP 200 + `{ok:false,error}`로 답한다 (`slack_rest_client.ml:8-11`, RFC-0317). 접수 후 거절이므로 게시 없음 |
| `Network _` | `Effect_outcome_unknown` | 응답 없음 |
| `Http_status _` | `Effect_outcome_unknown` | non-2xx가 커밋 이후인지 이 층에서 증명 불가 |
| `Other _` | `Effect_outcome_unknown` | 두 사실(비 JSON 응답 / `ok=true`인데 `ts` 없음)이 한 생성자에 섞여 있음. 약한 쪽 보고는 교정을 보류할 뿐 커밋된 전송의 재시도를 허용하지 않음 |

`Proven_pre_effect`는 `keeper_tools_agent_core_handler.ml:70`에서 terminal 상태를 찍지 않고 넘어가므로, 거절이 일반 tool error로 모델에 돌아가고 턴은 유지됩니다.

**Discord는 바꾸지 않았습니다.** `Discord_rest_client.Discord_api`가 HTTP 상태가 아니라 Discord 자체 에러 코드를 싣고 있어서, 이 층에서 4xx 거절과 커밋 이후 5xx를 가릴 수 없습니다. 여기서 pre-effect를 주장하면 중복 게시를 허용하게 됩니다. 호출부에 근거를 주석으로 남겼습니다.

## 검증

- `dune build --root . @check` — exit 0
- `dune build --root . @test/runtest-test_keeper_chat_slack` — 35 tests, 전부 통과
- **역방향 확인**: `Slack_api _ -> Effect_outcome_unknown`으로 되돌리면 새 테스트가 실패합니다 (`FAIL invalid_blocks`, 1 failure / 35). 테스트가 실제로 이 결함을 잡습니다.
- `test_keeper_chat_slack`은 `scripts/ci-run-focused-tests.sh`에 없어서 CI가 돌리지 않고 있었습니다. 목록에 추가했습니다. 스위트 전체가 로컬에서 통과합니다.

## 남는 것

- `Slack_rest_client.Other`가 두 사실을 한 생성자에 담고 있는 문제는 그대로입니다. 분리하려면 그 생성자를 쪼개야 하고, 이 PR 범위 밖입니다.
- Discord의 disposition은 `Discord_rest_client`가 HTTP 상태를 타입에 보존해야 풀립니다.
