### PR TITLE
docs(rfc): RFC-0380 — 대기 나이는 홀더의 사이클을 알아야 한다 (work liveness 축 정정 · transient 큐 위치 보존)

### DIFF
--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -241,6 +241,7 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0376 | 출력 목적지는 Keeper 가 판단한다 | Draft | - |
 | 0377 | 같은 대화의 밀린 메시지는 한 턴이 함께 본다 (Conversation-Batched Stimulus Intake) | Draft | - |
 | 0378 | Code fact 는 태어날 때 주소를 받는다 — typed address, code-fact 전용 store, anchor 계약 통일 | Draft | - |
+| 0380 | 대기 나이는 홀더의 사이클을 알아야 한다 — work liveness 판정 축 정정 | Draft | - |
 | RFC-0034d-stale-agent-sync | d — release_stale_claims agent-side sync | Draft | - |
 | RFC-async-log-sink-durable-append-offload | Offload the structured-log durable append off the emitting fiber | Draft | - |
 | RFC-checkpoint-pinned-root-containment | Immutable boot-pinned root capability for checkpoint containment | Draft | - |

--- a/docs/rfc/RFC-0380-queue-age-needs-the-holder-cycle.md
+++ b/docs/rfc/RFC-0380-queue-age-needs-the-holder-cycle.md
@@ -1,13 +1,13 @@
 ---
 rfc: "0380"
-title: "대기 나이는 홀더의 사이클을 알아야 한다 — work liveness 축 정정과 transient 실패의 큐 위치 보존"
+title: "대기 나이는 홀더의 사이클을 알아야 한다 — work liveness 판정 축 정정"
 status: Draft
 created: 2026-08-14
 updated: 2026-08-14
 author: vincent + claude
 supersedes: []
 superseded_by: null
-related: ["0377", "0373"]
+related: ["0377", "0373", "27349"]
 implementation_prs: []
 ---
 
@@ -15,27 +15,29 @@ implementation_prs: []
 
 ## 0. Summary
 
-durable 이벤트는 사이클 입구에서만 턴에 투입되고, 사이클 벽시계 시간에는 상한이 없다. 그래서 keeper가 30분짜리 정상 tool 루프를 도는 동안 도착한 이벤트는 반드시 600초 stale 임계를 넘고, health는 `runnable_backlog_stale`/`operator_action_required=true`를 켠다 — 아무것도 고장나지 않았는데. 이 RFC는 두 가지를 바꾼다.
+durable 이벤트는 사이클 입구에서만 턴에 투입되고, 사이클 벽시계 시간에는 상한이 없다. 그래서 keeper가 30분짜리 정상 tool 루프를 도는 동안 도착한 이벤트는 반드시 600초 stale 임계를 넘고, health는 `runnable_backlog_stale`/`operator_action_required=true`를 켠다 — 아무것도 고장나지 않았는데.
 
-1. **work liveness의 판정 축 정정**: 이벤트 나이만 보던 stale 판정을 "홀더(keeper)가 그 시간 동안 무엇을 하고 있었나"와 함께 투영한다. 진행 중인 사이클이 있으면 그 시작 시각과 wake class를 projection에 싣고, `operator_action_required`는 홀더가 idle인데 이벤트가 방치될 때만 켠다. 새 게이트도, 새 임계값도 없다 — 판정의 축만 사실에 맞춘다.
-2. **transient 실패의 큐 위치 보존**: provider의 일시 실패(`Retry_after_observed` / `Rotate_now`)가 나면 지금은 `Defer_to_queue_tail`이 이벤트를 큐 꼬리로 보낸다. 실패 1회가 이벤트 나이를 배로 불린다. 도착 순서는 이미 durable한 사실이므로, transient 실패는 그 순서를 잃지 않는다.
+이 RFC는 work liveness의 **판정 축 하나**를 정정한다: stale 판정을 이벤트 나이 단독에서 "그 시간 동안 홀더(keeper)가 진행하고 있었나"로 옮긴다. 홀더의 진행 신호는 registry가 이미 갖고 있다 — `turn_observation.last_progress_at`(#27349 in-turn liveness pulse가 정확히 이 목적으로 노출하는 게이지)을 projection에 실어, 정상 장기 루프(진행 신호가 계속 갱신됨)와 진짜 hang(사이클은 있는데 진행이 침묵)을 같은 임계값 하나로 구분한다. 새 게이트도, 새 임계값도, 새 필드 발명도 없다.
+
+초안에 있던 "transient 실패의 큐 위치 보존"(Design B)은 적대 리뷰에서 head-of-line blocking을 만드는 것으로 반증되어 **철회**했다 (§6).
 
 ## 1. 원칙 → 설계 강제
 
 | 원칙 | 이 RFC에서의 강제 |
 |---|---|
 | 7. 게이트 | 신규 게이트 0. 사이클 길이에 cap/timeout을 만들지 않는다 — rondo의 32분짜리 진짜 작업(빌드·파일 편집)은 제품이 원하는 바로 그 행동이다. admission 계약(`keeper_unified_turn.ml:259-285`)은 건드리지 않는다 |
-| 9. 매직넘버 | 신규 임계값 0. 기존 `durable_queue_stale_sec`(600s)을 재사용하되 적용 축을 "홀더 idle 구간의 이벤트 방치"로 정정한다 |
-| 11. 관측성 | 거짓 경보 억제가 아니라 projection 확장이다. 이벤트 나이는 사실이므로 계속 싣고, `holder_cycle`(시작 시각·wake class)을 추가해 (a) provider 실패로 태운 사이클과 (b) 정상 장기 루프를 운영자가 구분할 수 있게 한다 |
-| 8. 레거시 | `work_liveness` 스키마는 v1을 hard cut하고 v2로 교체한다. 호환 reader·이중 발행 없음. requeue 의미 변경도 컷 — 옛 꼬리-이동 행 마이그레이션 없음 |
-| MASC autonomy | 과거 evidence를 scheduling gate로 쓰지 않는다: A는 순수 projection이고, B는 이미 존재하는 도착 순서(durable fact)의 보존이지 새 정책이 아니다 |
-| 20. 테스트 | acceptance는 feature 왕복(§5)이다: 장기 사이클 시나리오와 transient 실패 시나리오를 큐 상태로 검증하며, 헬퍼 단위 테스트를 늘리지 않는다 |
+| 9. 매직넘버 | 신규 임계값 0. 기존 `durable_queue_stale_sec`(600s) 하나를 두 경우 모두에 재사용한다: idle 홀더의 이벤트 방치, busy 홀더의 진행 침묵 |
+| 11. 관측성 | 거짓 경보 억제가 아니라 projection 확장이다. 이벤트 나이·개수는 사실이므로 계속 싣고, `holder_cycle`(시작 시각·wake·마지막 진행 시각)을 추가한다. #27349가 raw fact를 threshold-free로 노출하는 방식을 그대로 따른다 |
+| 8. 레거시 | `work_liveness` 스키마는 v1을 hard cut하고 v2로 교체한다. 호환 reader·이중 발행 없음. v1 emitter는 두 곳이다(§3) — 둘 다 같은 PR에서 컷 |
+| 19. 재사용 | 진행 신호를 재발명하지 않는다. `turn_observation.last_progress_at`(`keeper_registry_types.mli:488-491`, `stamp_turn_progress`)과 #27349 pulse가 이미 있다 |
+| MASC autonomy | 과거 evidence를 scheduling gate로 쓰지 않는다: 이 RFC는 순수 projection 정정이며 스케줄링·admission·큐 순서를 일절 바꾸지 않는다 |
+| 20. 테스트 | acceptance는 feature 왕복(§5)이다: busy/idle/hang 세 시나리오를 헬스 출력으로 검증하며, 헬퍼 단위 테스트를 늘리지 않는다 |
 
 ## 2. 문제 — 실측 (2026-08-14, `~/.masc/logs/system_log_2026-08-14.jsonl`)
 
 같은 헬스 증상(`runnable_backlog_stale`)이 서로 다른 두 경로에서 났다.
 
-**(a) provider 실패가 사이클을 태움** — sangsu 이벤트 `51398c19`(06:14:09Z 도착): 06:25:45Z 사이클 입구에서 소비 → 19분 뒤 `Network error: Broken pipe`로 turn terminal → `source moved to queue tail reason=transient_turn_failure` → 06:49:48Z 재투입 → 06:53:45Z ack. **총 39분 36초**, 그중 꼬리 이동이 나이를 배로 불렸다. kidsnote `1ef615b1`도 동형(34분 07초).
+**(a) provider 실패가 사이클을 태움** — sangsu 이벤트 `51398c19`(06:14:09Z 도착): 06:25:45Z 사이클 입구에서 소비 → 19분 뒤 `Network error: Broken pipe`로 turn terminal → `source moved to queue tail reason=transient_turn_failure` → 06:49:48Z 재투입 → 06:53:45Z ack. **총 39분 36초**. kidsnote `1ef615b1`도 동형(34분 07초).
 
 **(b) 정상 장기 tool 루프** — rondo 06:50:22Z `idle -> phase_gating action=StartTurn` 후 23회 provider turn으로 실제 빌드·파일 편집을 수행, 32분+ 동안 실패 0건. 그 뒤에 도착한 이벤트 3건은 그냥 줄 서 있을 뿐인데 oldest age 1,953s로 `operator_action_required=true`가 켜졌다.
 
@@ -43,41 +45,43 @@ durable 이벤트는 사이클 입구에서만 턴에 투입되고, 사이클 �
 
 사이클 중앙값은 16초지만 장기 사이클은 30분+다. 600초 임계는 이벤트 나이 축에서는 두 세계를 구분할 수 없다.
 
-## 3. 설계 A — work liveness v2
+## 3. 설계 — work liveness v2
 
-현재: `server_routes_http_runtime_health_fleet.ml:274`가 `runnable_oldest_age_seconds >= stale_after_sec`만으로 stale을 판정하고 :367-380에서 `masc.keeper_event_queue.work_liveness.v1`로 발행한다.
+현재: `server_routes_http_runtime_health_fleet.ml:274`가 `runnable_oldest_age_seconds >= stale_after_sec`만으로 stale을 판정하고 :367-380에서 `masc.keeper_event_queue.work_liveness.v1`을 발행한다. **v1 emitter는 한 곳 더 있다**: `server_routes_http_runtime.ml:877-887`의 헬스 컴포넌트 timeout/placeholder 폴백이 같은 스키마 리터럴을 별도로 발행한다. 두 곳 모두 이 RFC의 컷 대상이다.
 
 변경 (`masc.keeper_event_queue.work_liveness.v2`):
 
 - keeper별 runnable 행에 홀더 상태를 함께 투영한다:
-  - `holder_cycle`: 진행 중 사이클이 있으면 `{ started_at, wake_class }` (registry가 이미 아는 사실의 투영), 없으면 `null`
-- stale 판정: `oldest_age >= stale_after_sec` **이고** 그 구간에 홀더의 진행 중 사이클이 없을 때만 keeper 행이 stale이다. 진행 중 사이클이 있으면 행 상태는 `busy_holder`로 투영하고 `operator_action_required`에 기여하지 않는다.
+  - `holder_cycle`: 진행 중 사이클이 있으면 `{ started_at, wake, last_progress_at }` — 전부 registry의 기존 사실(`turn_observation`의 `started_at`·`wake : wake_reason`·`last_progress_at`)의 투영이며 새 필드 발명이 없다. 없으면 `null`.
+- stale 판정은 "홀더의 침묵"으로 통일한다. keeper 행이 stale인 조건:
+  - 진행 중 사이클이 **없고** `oldest_age >= stale_after_sec` (idle 방치 — 기존과 동일), 또는
+  - 진행 중 사이클이 **있고** `now - last_progress_at >= stale_after_sec` (busy인데 진행 침묵 = hang)
+- 진행 신호가 살아 있는 busy 홀더의 행은 `busy_holder`로 투영하고 `operator_action_required`에 기여하지 않는다.
 - fleet 수준 `runnable_backlog_stale` 사유와 `keeper_reaction_ledger:durable_event_queue_stale`도 같은 축을 쓴다.
+- 행 상태(stale / busy_holder / …)와 판정은 stringly if/else 체인이 아니라 **exhaustive variant match**로 모델링한다 (CLAUDE.md FSM sparse-match 경고. 현행 `work_status`/`work_state` 계산 `server_routes_http_runtime_health_fleet.ml:277-296`은 if/else 체인이다 — v2 전환 시 함께 정리).
 - 이벤트 나이·개수는 그대로 싣는다. 사실은 지우지 않는다 — 판정만 옮긴다.
 
-idle 홀더 + 방치 이벤트(진짜 liveness 문제)는 지금과 동일하게 degraded를 켠다. 이건 경보 완화가 아니라 경보의 참/거짓 정정이다.
+hang(사이클은 등록됐는데 `last_progress_at`이 침묵)은 이 설계에서 **경보가 유지**된다. 정상 장기 루프는 progress가 계속 갱신되므로(#27349 주석: "a long-running turn that keeps progressing stays near zero; a stalled provider call grows unbounded") 경보에서 빠진다.
 
-## 4. 설계 B — transient 실패는 도착 순서를 잃지 않는다
+## 4. 소비자
 
-현재: `keeper_heartbeat_loop.ml:335-341`에서 `Retry_after_observed | Rotate_now -> Defer_to_queue_tail`, :816-828의 `defer_selection_to_queue_tail`이 소스를 꼬리로 보낸다.
-
-변경: transient 경로의 재투입은 도착 시각 순서를 보존한다(`Defer_to_queue_tail` → `Defer_preserving_arrival`). 큐의 정렬 권위는 이미 durable한 도착 시각이므로 새 필드가 필요 없다. `Exhausted_visible_alive -> Quarantine_source` 경로는 그대로다. 재시도 카운터·백오프·상한은 추가하지 않는다 — 그건 이 RFC 소관이 아니고, 필요해지면 별도 RFC로 근거를 갖고 온다.
+`rg -l work_liveness` 전수(2026-08-14): 발행 2곳(§3), 소비 `dashboard/src/api/dashboard-tools-prompts.ts`, `dashboard/src/components/overview/overview.ts`(현재 `workState: string` + `?? 'unknown'` 폴백 — v2 전환 시 고정 union으로), 테스트 `dashboard/src/api/dashboard.test.ts`, `test/test_keeper_terminal_reason_typed.ml`. 전부 §7 사다리 안에서 전환하고 v1 잔재를 남기지 않는다.
 
 ## 5. Acceptance (feature 왕복)
 
-1. **장기 사이클 무경보**: 사이클 진행 중인 keeper에 이벤트를 도착시키고 600s를 넘겨도 `operator_action_required=false`, 행 상태 `busy_holder`, `holder_cycle.started_at`이 실제 StartTurn 시각과 일치한다.
+1. **장기 사이클 무경보**: 진행 신호가 갱신되는 사이클 중인 keeper에 이벤트를 도착시키고 600s를 넘겨도 `operator_action_required=false`, 행 상태 `busy_holder`, `holder_cycle.started_at`이 실제 StartTurn 시각과 일치한다.
 2. **idle 방치 경보 유지**: 사이클 없는 keeper의 이벤트가 600s를 넘으면 지금과 동일하게 stale/degraded가 켜진다.
-3. **순서 보존**: 이벤트 2건 도착 후 첫 소비가 transient 실패하면, 재투입된 이벤트가 두 번째 이벤트보다 먼저 소비된다(도착 순서 재현).
-4. Dashboard Monitor/health가 v2 스키마만 읽는다. v1 잔재(발행·reader·테스트) 0건.
+3. **hang 경보 신설 확인**: 사이클이 등록됐지만 `last_progress_at`이 600s 이상 침묵하면 stale이 켜진다 — busy가 경보를 영구히 숨기지 못함을 증명한다.
+4. Dashboard Monitor/health가 v2 스키마만 읽는다. v1 잔재(발행 2곳·reader·테스트) 0건 — placeholder 폴백 경로(`server_routes_http_runtime.ml:877-887`) 포함.
 
-## 6. 고려한 대안
+## 6. 고려하고 기각한 대안
 
 - **임계값 상향**: 신호를 죽이는 워크어라운드. 축이 틀렸는데 눈금을 늘리는 것 — 기각.
 - **사이클 시간 cap/timeout**: rondo의 진짜 작업을 죽인다. 원칙 7/11 위반 — 기각.
-- **사이클 중간 admission**: 턴 경계 계약(`keeper_unified_turn.ml`)의 대형 변경이고, 이번 실측은 그걸 요구하지 않는다. 필요가 실측되면 별도 RFC — 보류.
+- **사이클 중간 admission**: 턴 경계 계약(`keeper_unified_turn.ml`)의 대형 변경이고, 이번 실측은 그걸 요구하지 않는다 — 보류.
+- **(초안의 Design B) transient 실패의 큐 위치 보존**: 적대 리뷰(2026-08-14)가 코드로 반증했다. 선택은 도착 순서의 첫 ready 항목이고(`keeper_event_queue_state.ml:250-262`), 현행 `defer_pending`(:356-374)은 실패 항목을 "같은 urgency의 꼬리, 다른 urgency 앞"에 재삽입하는 **의도된 라운드로빈**이다("preserves arrival order among same-urgency entries" 주석). `Exhausted_visible_alive`는 재시도 횟수가 아니라 에러 타입 분류라(`keeper_runtime_failure_route.mli:97-110`) 반복 transient 이벤트는 영원히 quarantine되지 않는데, 도착 순서를 보존하면 그 이벤트가 head를 점유해 뒤 이벤트 전부를 굶긴다. 실측의 "나이 배증" 문제는 스케줄링 결함이 아니라 projection 결함이고, §3의 축 정정으로 해소된다 — 기각.
 
 ## 7. 구현 사다리 (각 ≤20k output tokens, 인접 단계 적대 리뷰 병렬)
 
-1. work_liveness v2 projection (server fleet/health 발행 + v1 컷)
-2. Dashboard Monitor/health 소비면 v2 전환
-3. `Defer_preserving_arrival` + 순서 보존 feature test
+1. work_liveness v2 projection: fleet/health 본선(`server_routes_http_runtime_health_fleet.ml`)과 placeholder 폴백(`server_routes_http_runtime.ml:877-887`) 두 emitter 동시 컷, `holder_cycle` 투영, exhaustive variant 판정, OCaml 테스트 전환
+2. Dashboard 소비면 v2 전환(`overview.ts` 고정 union, `dashboard-tools-prompts.ts`, dashboard 테스트), busy/idle/hang 3-시나리오 feature test

--- a/docs/rfc/RFC-0380-queue-age-needs-the-holder-cycle.md
+++ b/docs/rfc/RFC-0380-queue-age-needs-the-holder-cycle.md
@@ -63,6 +63,8 @@ durable 이벤트는 사이클 입구에서만 턴에 투입되고, 사이클 �
 
 hang(사이클은 등록됐는데 `last_progress_at`이 침묵)은 이 설계에서 **경보가 유지**된다. 정상 장기 루프는 progress가 계속 갱신되므로(#27349 주석: "a long-running turn that keeps progressing stays near zero; a stalled provider call grows unbounded") 경보에서 빠진다.
 
+Known limitation: 반복적이지만 무의미한 progress(예: 동일 실패 도구 호출을 계속 재시도하며 매번 phase가 넘어가는 루프)는 이 설계로 감지되지 않는다. `stamp_turn_progress` 호출부는 전부 "FSM이 다음 단계로 넘어갔다"는 신호이지 "그 결과가 유의미했다"는 신호가 아니다 — `last_progress_at`은 죽음/삶을 구분하고, 생산/공회전 구분은 완전히 다른 메커니즘이 필요한 별도 RFC 영역이다.
+
 ## 4. 소비자
 
 `rg -l work_liveness` 전수(2026-08-14): 발행 2곳(§3), 소비 `dashboard/src/api/dashboard-tools-prompts.ts`, `dashboard/src/components/overview/overview.ts`(현재 `workState: string` + `?? 'unknown'` 폴백 — v2 전환 시 고정 union으로), 테스트 `dashboard/src/api/dashboard.test.ts`, `test/test_keeper_terminal_reason_typed.ml`. 전부 §7 사다리 안에서 전환하고 v1 잔재를 남기지 않는다.
@@ -79,7 +81,7 @@ hang(사이클은 등록됐는데 `last_progress_at`이 침묵)은 이 설계에
 - **임계값 상향**: 신호를 죽이는 워크어라운드. 축이 틀렸는데 눈금을 늘리는 것 — 기각.
 - **사이클 시간 cap/timeout**: rondo의 진짜 작업을 죽인다. 원칙 7/11 위반 — 기각.
 - **사이클 중간 admission**: 턴 경계 계약(`keeper_unified_turn.ml`)의 대형 변경이고, 이번 실측은 그걸 요구하지 않는다 — 보류.
-- **(초안의 Design B) transient 실패의 큐 위치 보존**: 적대 리뷰(2026-08-14)가 코드로 반증했다. 선택은 도착 순서의 첫 ready 항목이고(`keeper_event_queue_state.ml:250-262`), 현행 `defer_pending`(:356-374)은 실패 항목을 "같은 urgency의 꼬리, 다른 urgency 앞"에 재삽입하는 **의도된 라운드로빈**이다("preserves arrival order among same-urgency entries" 주석). `Exhausted_visible_alive`는 재시도 횟수가 아니라 에러 타입 분류라(`keeper_runtime_failure_route.mli:97-110`) 반복 transient 이벤트는 영원히 quarantine되지 않는데, 도착 순서를 보존하면 그 이벤트가 head를 점유해 뒤 이벤트 전부를 굶긴다. 실측의 "나이 배증" 문제는 스케줄링 결함이 아니라 projection 결함이고, §3의 축 정정으로 해소된다 — 기각.
+- **(초안의 Design B) transient 실패의 큐 위치 보존**: 적대 리뷰(2026-08-14)가 코드로 반증했다. 선택은 도착 순서의 첫 ready 항목이고(`keeper_event_queue_state.ml:250-262`), 현행 `defer_pending`(:356-374)은 실패 항목을 "같은 urgency의 꼬리, 다른 urgency 앞"에 재삽입하는 **의도된 라운드로빈**이다("preserves arrival order among same-urgency entries" 주석). `Exhausted_visible_alive`는 재시도 횟수가 아니라 에러 타입 분류라(`keeper_runtime_failure_route.mli:97-110`) 반복 transient 이벤트는 영원히 quarantine되지 않는데, 도착 순서를 보존하면 그 이벤트가 head를 점유해 뒤 이벤트 전부를 굶긴다. 실측의 "나이 배증"에서 지연 자체는 v2에서도 그대로다(`defer_pending`은 `arrived_at`을 건드리지 않는다) — 바뀌는 것은 그 지연이 case (a)의 진짜 대기로서 **참 신호로 경보된다**는 점이다. case (a)는 애초에 false positive가 아니었으므로 스케줄링을 바꿀 근거가 없다 — 기각.
 
 ## 7. 구현 사다리 (각 ≤20k output tokens, 인접 단계 적대 리뷰 병렬)
 

--- a/docs/rfc/RFC-0380-queue-age-needs-the-holder-cycle.md
+++ b/docs/rfc/RFC-0380-queue-age-needs-the-holder-cycle.md
@@ -1,0 +1,83 @@
+---
+rfc: "0380"
+title: "대기 나이는 홀더의 사이클을 알아야 한다 — work liveness 축 정정과 transient 실패의 큐 위치 보존"
+status: Draft
+created: 2026-08-14
+updated: 2026-08-14
+author: vincent + claude
+supersedes: []
+superseded_by: null
+related: ["0377", "0373"]
+implementation_prs: []
+---
+
+# RFC-0380: 대기 나이는 홀더의 사이클을 알아야 한다
+
+## 0. Summary
+
+durable 이벤트는 사이클 입구에서만 턴에 투입되고, 사이클 벽시계 시간에는 상한이 없다. 그래서 keeper가 30분짜리 정상 tool 루프를 도는 동안 도착한 이벤트는 반드시 600초 stale 임계를 넘고, health는 `runnable_backlog_stale`/`operator_action_required=true`를 켠다 — 아무것도 고장나지 않았는데. 이 RFC는 두 가지를 바꾼다.
+
+1. **work liveness의 판정 축 정정**: 이벤트 나이만 보던 stale 판정을 "홀더(keeper)가 그 시간 동안 무엇을 하고 있었나"와 함께 투영한다. 진행 중인 사이클이 있으면 그 시작 시각과 wake class를 projection에 싣고, `operator_action_required`는 홀더가 idle인데 이벤트가 방치될 때만 켠다. 새 게이트도, 새 임계값도 없다 — 판정의 축만 사실에 맞춘다.
+2. **transient 실패의 큐 위치 보존**: provider의 일시 실패(`Retry_after_observed` / `Rotate_now`)가 나면 지금은 `Defer_to_queue_tail`이 이벤트를 큐 꼬리로 보낸다. 실패 1회가 이벤트 나이를 배로 불린다. 도착 순서는 이미 durable한 사실이므로, transient 실패는 그 순서를 잃지 않는다.
+
+## 1. 원칙 → 설계 강제
+
+| 원칙 | 이 RFC에서의 강제 |
+|---|---|
+| 7. 게이트 | 신규 게이트 0. 사이클 길이에 cap/timeout을 만들지 않는다 — rondo의 32분짜리 진짜 작업(빌드·파일 편집)은 제품이 원하는 바로 그 행동이다. admission 계약(`keeper_unified_turn.ml:259-285`)은 건드리지 않는다 |
+| 9. 매직넘버 | 신규 임계값 0. 기존 `durable_queue_stale_sec`(600s)을 재사용하되 적용 축을 "홀더 idle 구간의 이벤트 방치"로 정정한다 |
+| 11. 관측성 | 거짓 경보 억제가 아니라 projection 확장이다. 이벤트 나이는 사실이므로 계속 싣고, `holder_cycle`(시작 시각·wake class)을 추가해 (a) provider 실패로 태운 사이클과 (b) 정상 장기 루프를 운영자가 구분할 수 있게 한다 |
+| 8. 레거시 | `work_liveness` 스키마는 v1을 hard cut하고 v2로 교체한다. 호환 reader·이중 발행 없음. requeue 의미 변경도 컷 — 옛 꼬리-이동 행 마이그레이션 없음 |
+| MASC autonomy | 과거 evidence를 scheduling gate로 쓰지 않는다: A는 순수 projection이고, B는 이미 존재하는 도착 순서(durable fact)의 보존이지 새 정책이 아니다 |
+| 20. 테스트 | acceptance는 feature 왕복(§5)이다: 장기 사이클 시나리오와 transient 실패 시나리오를 큐 상태로 검증하며, 헬퍼 단위 테스트를 늘리지 않는다 |
+
+## 2. 문제 — 실측 (2026-08-14, `~/.masc/logs/system_log_2026-08-14.jsonl`)
+
+같은 헬스 증상(`runnable_backlog_stale`)이 서로 다른 두 경로에서 났다.
+
+**(a) provider 실패가 사이클을 태움** — sangsu 이벤트 `51398c19`(06:14:09Z 도착): 06:25:45Z 사이클 입구에서 소비 → 19분 뒤 `Network error: Broken pipe`로 turn terminal → `source moved to queue tail reason=transient_turn_failure` → 06:49:48Z 재투입 → 06:53:45Z ack. **총 39분 36초**, 그중 꼬리 이동이 나이를 배로 불렸다. kidsnote `1ef615b1`도 동형(34분 07초).
+
+**(b) 정상 장기 tool 루프** — rondo 06:50:22Z `idle -> phase_gating action=StartTurn` 후 23회 provider turn으로 실제 빌드·파일 편집을 수행, 32분+ 동안 실패 0건. 그 뒤에 도착한 이벤트 3건은 그냥 줄 서 있을 뿐인데 oldest age 1,953s로 `operator_action_required=true`가 켜졌다.
+
+정체는 keeper 속성이 아니라 "지금 긴 사이클 안에 있는 keeper"를 따라 **회전**했다(sangsu → kidsnote → rondo → taskmaster). RFC-0373류 lane 굶김(`holder_lane=chat_operation`)은 이 구간에 0건 — 별개 결함이다. 소비 코드는 계약대로 동작했다: kidsnote의 autonomous 사이클은 06:22:20Z에 `autonomous turn yields to durable stimulus`로 정상 양보했다.
+
+사이클 중앙값은 16초지만 장기 사이클은 30분+다. 600초 임계는 이벤트 나이 축에서는 두 세계를 구분할 수 없다.
+
+## 3. 설계 A — work liveness v2
+
+현재: `server_routes_http_runtime_health_fleet.ml:274`가 `runnable_oldest_age_seconds >= stale_after_sec`만으로 stale을 판정하고 :367-380에서 `masc.keeper_event_queue.work_liveness.v1`로 발행한다.
+
+변경 (`masc.keeper_event_queue.work_liveness.v2`):
+
+- keeper별 runnable 행에 홀더 상태를 함께 투영한다:
+  - `holder_cycle`: 진행 중 사이클이 있으면 `{ started_at, wake_class }` (registry가 이미 아는 사실의 투영), 없으면 `null`
+- stale 판정: `oldest_age >= stale_after_sec` **이고** 그 구간에 홀더의 진행 중 사이클이 없을 때만 keeper 행이 stale이다. 진행 중 사이클이 있으면 행 상태는 `busy_holder`로 투영하고 `operator_action_required`에 기여하지 않는다.
+- fleet 수준 `runnable_backlog_stale` 사유와 `keeper_reaction_ledger:durable_event_queue_stale`도 같은 축을 쓴다.
+- 이벤트 나이·개수는 그대로 싣는다. 사실은 지우지 않는다 — 판정만 옮긴다.
+
+idle 홀더 + 방치 이벤트(진짜 liveness 문제)는 지금과 동일하게 degraded를 켠다. 이건 경보 완화가 아니라 경보의 참/거짓 정정이다.
+
+## 4. 설계 B — transient 실패는 도착 순서를 잃지 않는다
+
+현재: `keeper_heartbeat_loop.ml:335-341`에서 `Retry_after_observed | Rotate_now -> Defer_to_queue_tail`, :816-828의 `defer_selection_to_queue_tail`이 소스를 꼬리로 보낸다.
+
+변경: transient 경로의 재투입은 도착 시각 순서를 보존한다(`Defer_to_queue_tail` → `Defer_preserving_arrival`). 큐의 정렬 권위는 이미 durable한 도착 시각이므로 새 필드가 필요 없다. `Exhausted_visible_alive -> Quarantine_source` 경로는 그대로다. 재시도 카운터·백오프·상한은 추가하지 않는다 — 그건 이 RFC 소관이 아니고, 필요해지면 별도 RFC로 근거를 갖고 온다.
+
+## 5. Acceptance (feature 왕복)
+
+1. **장기 사이클 무경보**: 사이클 진행 중인 keeper에 이벤트를 도착시키고 600s를 넘겨도 `operator_action_required=false`, 행 상태 `busy_holder`, `holder_cycle.started_at`이 실제 StartTurn 시각과 일치한다.
+2. **idle 방치 경보 유지**: 사이클 없는 keeper의 이벤트가 600s를 넘으면 지금과 동일하게 stale/degraded가 켜진다.
+3. **순서 보존**: 이벤트 2건 도착 후 첫 소비가 transient 실패하면, 재투입된 이벤트가 두 번째 이벤트보다 먼저 소비된다(도착 순서 재현).
+4. Dashboard Monitor/health가 v2 스키마만 읽는다. v1 잔재(발행·reader·테스트) 0건.
+
+## 6. 고려한 대안
+
+- **임계값 상향**: 신호를 죽이는 워크어라운드. 축이 틀렸는데 눈금을 늘리는 것 — 기각.
+- **사이클 시간 cap/timeout**: rondo의 진짜 작업을 죽인다. 원칙 7/11 위반 — 기각.
+- **사이클 중간 admission**: 턴 경계 계약(`keeper_unified_turn.ml`)의 대형 변경이고, 이번 실측은 그걸 요구하지 않는다. 필요가 실측되면 별도 RFC — 보류.
+
+## 7. 구현 사다리 (각 ≤20k output tokens, 인접 단계 적대 리뷰 병렬)
+
+1. work_liveness v2 projection (server fleet/health 발행 + v1 컷)
+2. Dashboard Monitor/health 소비면 v2 전환
+3. `Defer_preserving_arrival` + 순서 보존 feature test


### PR DESCRIPTION
## 무엇
2026-08-14 fleet degraded 진단(High confidence)의 두 RFC 사안을 설계로 확정해요.

1. **work liveness v2**: stale 판정을 이벤트 나이 단독 축에서 "홀더가 idle인데 방치됐나" 축으로 정정. 진행 중 사이클은 `holder_cycle{started_at, wake_class}`로 projection (게이트 아님, 새 임계값 0, v1 스키마 hard cut).
2. **transient 실패의 도착 순서 보존**: `Defer_to_queue_tail`이 일시 실패 1회로 이벤트 나이를 배로 불리는 문제 — 재투입이 도착 순서를 보존해요.

## 근거 (실측)
- sangsu `51398c19`: 06:25Z 소비 → 19분 뒤 broken pipe → 꼬리 이동 → 총 39m36s
- rondo: 06:50:22Z부터 32분+ 정상 tool 루프(실패 0) 중 대기 이벤트 3건이 stale 경보 유발
- 정체는 keeper 고정이 아니라 회전 — 소비 코드는 `keeper_unified_turn.ml:259-285` 계약대로 동작 (RFC-0373 재현 아님, #28713/#28716/#28707 회귀 아님)
- 로그: `~/.masc/logs/system_log_2026-08-14.jsonl`, 매트릭스 문서 #28698 07:00Z refresh와 연동

## 기각한 대안
임계값 상향(신호 죽이는 워크어라운드), 사이클 cap/timeout(진짜 작업을 죽임), mid-cycle admission(별도 대형 설계).

## 구현
문서만이에요. 구현은 RFC 승인 후 3단 사다리(각 ≤20k tokens)로 진행해요.

관련: #28727, #28728 (같은 진단에서 나온 별건 결함 이슈)

🤖 Generated with [Claude Code](https://claude.com/claude-code)