### PR TITLE
feat(keeper): 턴이 자기 이력을 얼마나 전송했는지 기록 (RFC-0351 계측)

### DIFF
--- a/dashboard/src/api/dashboard-turn-records.ts
+++ b/dashboard/src/api/dashboard-turn-records.ts
@@ -107,6 +107,14 @@ export type TurnRecordEntry = {
   // runtime is unknown or the operator left runtime.toml unset; the inspector
   // renders "미상" (unknown) rather than a fabricated 200K / Claude $3·$15.
   context_window?: number
+  // How much of the keeper's own history the dispatched request carried, in
+  // atoms (one user message, or one assistant message plus the tool messages
+  // answering it). Reported beside request_body_bytes, which counts the bytes
+  // the provider admitted — neither substitutes for the other. Absent when no
+  // model-input projection ran for the turn; that is not a zero-length
+  // history, so the inspector renders absence rather than 0.
+  transmitted_atoms?: number
+  total_atoms?: number
   price_input_per_million?: number
   price_output_per_million?: number
   // RFC-0233 §9 — wall-clock duration of the provider call (ms), sourced from
@@ -501,6 +509,8 @@ function decodeTurnRecordEntry(raw: unknown): TurnRecordEntry | null {
     'input_components',
     'request_runtime_profile',
     'request_body_bytes',
+    'transmitted_atoms',
+    'total_atoms',
     'runtime_profile',
     'selected_model',
     'finish_reason',
@@ -554,6 +564,9 @@ function decodeTurnRecordEntry(raw: unknown): TurnRecordEntry | null {
   const selected_model = decodeOptionalField(raw, 'selected_model', decodeExactNonEmptyString)
   const finish_reason = decodeOptionalField(raw, 'finish_reason', decodeExactNonEmptyString)
   const context_window = decodeOptionalField(raw, 'context_window', decodeNonNegativeSafeInteger)
+  const transmitted_atoms =
+    decodeOptionalField(raw, 'transmitted_atoms', decodeNonNegativeSafeInteger)
+  const total_atoms = decodeOptionalField(raw, 'total_atoms', decodeNonNegativeSafeInteger)
   const price_input_per_million =
     decodeOptionalField(raw, 'price_input_per_million', decodeFiniteNumber)
   const price_output_per_million =
@@ -644,6 +657,12 @@ function decodeTurnRecordEntry(raw: unknown): TurnRecordEntry | null {
     cache_creation_input_tokens,
     cache_read_input_tokens,
     context_window,
+    // A turn whose runtime assembles its own input emits these as null, which
+    // is an observation that no cut was selected — not a failed decode. Folding
+    // null into undefined keeps that turn's record instead of rejecting it, and
+    // reaches the inspector as absence rather than a fabricated 0.
+    transmitted_atoms: transmitted_atoms ?? undefined,
+    total_atoms: total_atoms ?? undefined,
     price_input_per_million,
     price_output_per_million,
     request_latency_ms,

--- a/dashboard/src/components/keeper-turn-inspector.test.ts
+++ b/dashboard/src/components/keeper-turn-inspector.test.ts
@@ -338,7 +338,9 @@ describe('KeeperTurnInspector v2 drawer', () => {
   // keeper_agent_run logs as "turn input composition unavailable".
   it('shows how much history a turn transmitted even without input components', async () => {
     const records = turnRecordsWithMemoryOs()
-    const latest = records.entries[records.entries.length - 1].record
+    const latestRow = records.entries.at(-1)
+    if (!latestRow) throw new Error('fixture must carry a latest turn')
+    const latest = latestRow.record
     latest.input_components = null
     latest.transmitted_atoms = 800
     latest.total_atoms = 5000

--- a/dashboard/src/components/keeper-turn-inspector.test.ts
+++ b/dashboard/src/components/keeper-turn-inspector.test.ts
@@ -332,6 +332,48 @@ describe('KeeperTurnInspector v2 drawer', () => {
     expect(text).toContain('wire 547.4KB')
   })
 
+  // The share is the answer to "can this keeper still see what it did 10 turns
+  // ago". It is carried by its own observation, so it has to survive a turn
+  // whose input-component attribution was unavailable — the shape
+  // keeper_agent_run logs as "turn input composition unavailable".
+  it('shows how much history a turn transmitted even without input components', async () => {
+    const records = turnRecordsWithMemoryOs()
+    const latest = records.entries[records.entries.length - 1].record
+    latest.input_components = null
+    latest.transmitted_atoms = 800
+    latest.total_atoms = 5000
+    fetchKeeperTurnRecordsMock.mockResolvedValue(records)
+
+    const { container } = render(html`<${KeeperTurnInspector} keeperName="albini" />`)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('T42')
+    })
+
+    expect(container.querySelector('[data-testid="turn-input-components"]')).toBeNull()
+    const atoms = container.querySelector('[data-testid="turn-transmitted-atoms"]')
+    expect(atoms).toBeTruthy()
+    const text = atoms?.textContent ?? ''
+    expect(text).toContain('800')
+    expect(text).toContain('5,000')
+    expect(text).toContain('16.0%')
+  })
+
+  // Absence has to read as absence: a turn on a runtime that assembles its own
+  // input carries no observation, and rendering 0 would say the keeper saw
+  // nothing.
+  it('renders nothing when the turn recorded no window observation', async () => {
+    fetchKeeperTurnRecordsMock.mockResolvedValue(turnRecordsWithMemoryOs())
+
+    const { container } = render(html`<${KeeperTurnInspector} keeperName="albini" />`)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('T42')
+    })
+
+    expect(container.querySelector('[data-testid="turn-transmitted-atoms"]')).toBeNull()
+  })
+
   it('matches an initial timestamp to the closest retained turn row', () => {
     const response = turnRecordsWithMemoryOs()
     const nearTurn42 = new Date((1_781_587_560 + 12) * 1000).toISOString()

--- a/dashboard/src/components/keeper-turn-inspector.ts
+++ b/dashboard/src/components/keeper-turn-inspector.ts
@@ -1231,6 +1231,20 @@ function TurnRow({
           ? (() => {
               const components = sortedInputComponents(record)
               const totalBytes = components.reduce((sum, c) => sum + c.bytes, 0)
+              // How much conversation those bytes were. Built here rather than
+              // inline so the template holds no nested literal.
+              const transmitted = record.transmitted_atoms
+              const total = record.total_atoms
+              const atomsLabel =
+                transmitted != null && total != null && total > 0
+                  ? '· 이력 '
+                    + transmitted.toLocaleString()
+                    + ' / '
+                    + total.toLocaleString()
+                    + ' atom ('
+                    + ((transmitted / total) * 100).toFixed(1)
+                    + '% 전송)'
+                  : null
               return html`
                 <div data-testid="turn-input-components">
                   <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-disabled)] mb-1">
@@ -1242,6 +1256,9 @@ function TurnRow({
                     <span class="text-[var(--color-fg-muted)]">합계 ${formatComponentBytes(totalBytes)}</span>
                     ${record.request_body_bytes != null
                       ? html`<span class="text-[var(--color-fg-disabled)]">· wire ${formatComponentBytes(record.request_body_bytes)} (방언 투영 후 실제 요청 본문)</span>`
+                      : null}
+                    ${atomsLabel != null
+                      ? html`<span data-testid="turn-transmitted-atoms" class="text-[var(--color-fg-disabled)]">${atomsLabel}</span>`
                       : null}
                   </div>
                 </div>

--- a/dashboard/src/components/keeper-turn-inspector.ts
+++ b/dashboard/src/components/keeper-turn-inspector.ts
@@ -1227,24 +1227,33 @@ function TurnRow({
             ? html`<div class="text-2xs text-[var(--color-fg-disabled)] v2-monitoring-row">기록된 블록 없음</div>`
             : record.blocks.map(block => html`<${BlockRow} block=${block} />`)}
         </div>
+        ${(() => {
+          // Rendered outside the composition panel: input_components can be
+          // absent on a turn whose window observation succeeded (they come from
+          // two independent observations), and nesting this inside it hid the
+          // number on exactly those turns.
+          const transmitted = record.transmitted_atoms
+          const total = record.total_atoms
+          if (transmitted == null || total == null || total <= 0) return null
+          // Built as concatenation so the html template holds no nested literal.
+          const label =
+            '이력 '
+            + transmitted.toLocaleString()
+            + ' / '
+            + total.toLocaleString()
+            + ' atom ('
+            + ((transmitted / total) * 100).toFixed(1)
+            + '% 전송)'
+          return html`
+            <div data-testid="turn-transmitted-atoms" class="flex items-center gap-2 text-2xs font-mono v2-monitoring-row">
+              <span class="text-[var(--color-fg-muted)]">${label}</span>
+            </div>
+          `
+        })()}
         ${record.input_components && record.input_components.length > 0
           ? (() => {
               const components = sortedInputComponents(record)
               const totalBytes = components.reduce((sum, c) => sum + c.bytes, 0)
-              // How much conversation those bytes were. Built here rather than
-              // inline so the template holds no nested literal.
-              const transmitted = record.transmitted_atoms
-              const total = record.total_atoms
-              const atomsLabel =
-                transmitted != null && total != null && total > 0
-                  ? '· 이력 '
-                    + transmitted.toLocaleString()
-                    + ' / '
-                    + total.toLocaleString()
-                    + ' atom ('
-                    + ((transmitted / total) * 100).toFixed(1)
-                    + '% 전송)'
-                  : null
               return html`
                 <div data-testid="turn-input-components">
                   <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-disabled)] mb-1">
@@ -1256,9 +1265,6 @@ function TurnRow({
                     <span class="text-[var(--color-fg-muted)]">합계 ${formatComponentBytes(totalBytes)}</span>
                     ${record.request_body_bytes != null
                       ? html`<span class="text-[var(--color-fg-disabled)]">· wire ${formatComponentBytes(record.request_body_bytes)} (방언 투영 후 실제 요청 본문)</span>`
-                      : null}
-                    ${atomsLabel != null
-                      ? html`<span data-testid="turn-transmitted-atoms" class="text-[var(--color-fg-disabled)]">${atomsLabel}</span>`
                       : null}
                   </div>
                 </div>

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -670,6 +670,11 @@ let run_turn
       s.Keeper_run_tools.receipt_response_text_present_ref
     in
     let request_evidence_ref = ref None in
+    (* Kept apart from [request_evidence_ref] rather than folded into it: the
+       window cut is observed before serialization, so a turn whose request was
+       refused at the wire has a real cut and no wire observation. Sharing one
+       cell would let the missing half erase the half that was measured. *)
+    let model_input_window_ref = ref None in
     let current_request_input_messages_ref = ref None in
     let source_model_input_projection =
       s.Keeper_run_tools.model_input_projection
@@ -889,6 +894,9 @@ let run_turn
                       ~on_runtime_observation:
                         (fun observation ->
                            receipt_runtime_observation_ref := Some observation)
+                      ~on_model_input_window_observation:
+                        (fun observation ->
+                           model_input_window_ref := Some observation)
                       ~on_request_wire_observation:
                         (fun
                           ~runtime_id
@@ -1301,6 +1309,19 @@ let run_turn
             (Option.map
                (fun evidence -> evidence.wire_observation)
                !request_evidence_ref)
+          ~model_input_window:
+            (Option.map
+               (fun
+                 (observation :
+                   Runtime_model_input_tail_window.window_observation)
+               ->
+                  { Turn_record.transmitted_atoms =
+                      observation
+                        .Runtime_model_input_tail_window.transmitted_atoms
+                  ; total_atoms =
+                      observation.Runtime_model_input_tail_window.total_atoms
+                  })
+               !model_input_window_ref)
           ~raw_trace_run_ref
           ~sampling:
             { temperature = Some temperature

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -539,6 +539,7 @@ let run_named
     ?event_bus
     ?on_runtime_observation
     ?on_request_wire_observation
+    ?on_model_input_window_observation
     ?runtime_manifest_context
     ?runtime_manifest_append
     ?deferred_runtime_lane
@@ -1205,6 +1206,7 @@ let run_named
             ; agent_ref
             ; on_runtime_observation
             ; on_request_wire_observation
+            ; on_model_input_window_observation
             ; event_bus
             ; runtime_manifest_context
             ; runtime_manifest_append

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -132,6 +132,8 @@ val run_named :
      max_request_body_bytes:int ->
      body_bytes:int ->
      unit) ->
+  ?on_model_input_window_observation:
+    (Runtime_model_input_tail_window.window_observation -> unit) ->
   ?runtime_manifest_context:Keeper_runtime_manifest.turn_context ->
   ?runtime_manifest_append:(Keeper_runtime_manifest.t -> unit) ->
   ?deferred_runtime_lane:deferred_runtime_lane ->

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -544,21 +544,26 @@ let budgeted_model_input_projection (ctx : try_provider_ctx)
                 ~demote_before:raw_projection.dropped_atoms
                 messages
           in
+          (* The first cut is the only one taken against the whole history;
+             every later cut sees a list that has already been shortened. Carry
+             its atom count so the reported share keeps that denominator. *)
+          let history_atom_count = raw_projection.atom_count in
           (match planned.Keeper_model_input_demotion.pending with
-           | [] -> Ok (planned, raw_projection)
+           | [] -> Ok (planned, raw_projection, history_atom_count)
            | _ ->
              (match raw_cut planned.Keeper_model_input_demotion.messages with
               | Error error ->
                 Error
                   (Runtime_model_input_tail_window.budget_error_to_string error)
-              | Ok windowed -> Ok (planned, windowed))))
+              | Ok windowed -> Ok (planned, windowed, history_atom_count))))
     in
     let windowed =
       match planned_and_windowed with
       | Error error -> Error error
-      | Ok (planned, windowed) ->
+      | Ok (planned, windowed, history_atom_count) ->
+        let keep projection = Ok (projection, history_atom_count) in
         (match planned.Keeper_model_input_demotion.pending with
-         | [] -> Ok windowed
+         | [] -> keep windowed
          | pending ->
            (* Blob materialization performs filesystem I/O and therefore stays
               on the owning Eio fiber rather than in the CPU domain pool. *)
@@ -572,7 +577,7 @@ let budgeted_model_input_projection (ctx : try_provider_ctx)
            then
              (* Materialization rewrites bodies inside the already-chosen cut;
                 it neither adds nor removes atoms, so the counts still hold. *)
-             Ok
+             keep
                { windowed with
                  Runtime_model_input_tail_window.messages =
                    outcome.Keeper_model_input_demotion.messages
@@ -589,16 +594,20 @@ let budgeted_model_input_projection (ctx : try_provider_ctx)
                     ~reserved_bytes
                     outcome.Keeper_model_input_demotion.messages)
               with
-              | Ok recut -> Ok recut
+              | Ok recut -> keep recut
               | Error error ->
                 Error
                   (Runtime_model_input_tail_window.budget_error_to_string error)))
     in
     match windowed with
     | Error error -> Error error
-    | Ok windowed ->
+    | Ok (windowed, history_atom_count) ->
       Option.iter
-        (fun observe -> observe (Runtime_model_input_tail_window.observe windowed))
+        (fun observe ->
+           observe
+             (Runtime_model_input_tail_window.observe
+                ~history_atom_count
+                windowed))
         ctx.on_model_input_window_observation;
       let windowed = windowed.Runtime_model_input_tail_window.messages in
       (match ctx.model_input_projection with

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -130,6 +130,8 @@ type try_provider_ctx =
        body_bytes:int ->
        unit)
         option
+  ; on_model_input_window_observation :
+      (Runtime_model_input_tail_window.window_observation -> unit) option
   ; (* Event bus *)
     event_bus : Agent_core.Event_bus.t option
   ; runtime_manifest_context : Keeper_runtime_manifest.turn_context option
@@ -526,12 +528,6 @@ let budgeted_model_input_projection (ctx : try_provider_ctx)
             ~reserved_bytes
             candidate
         in
-        let cut candidate =
-          Result.map
-            (fun projection ->
-               projection.Runtime_model_input_tail_window.messages)
-            (raw_cut candidate)
-        in
         (* RFC-0363: the unmodified history chooses the authoritative cut first.
            Demotion rewrites only atoms omitted by that cut, so appending a turn
            cannot move the rewrite boundary unless the raw cut itself moves. *)
@@ -549,9 +545,9 @@ let budgeted_model_input_projection (ctx : try_provider_ctx)
                 messages
           in
           (match planned.Keeper_model_input_demotion.pending with
-           | [] -> Ok (planned, raw_projection.messages)
+           | [] -> Ok (planned, raw_projection)
            | _ ->
-             (match cut planned.Keeper_model_input_demotion.messages with
+             (match raw_cut planned.Keeper_model_input_demotion.messages with
               | Error error ->
                 Error
                   (Runtime_model_input_tail_window.budget_error_to_string error)
@@ -559,7 +555,7 @@ let budgeted_model_input_projection (ctx : try_provider_ctx)
     in
     let windowed =
       match planned_and_windowed with
-      | Error _ as error -> error
+      | Error error -> Error error
       | Ok (planned, windowed) ->
         (match planned.Keeper_model_input_demotion.pending with
          | [] -> Ok windowed
@@ -570,16 +566,23 @@ let budgeted_model_input_projection (ctx : try_provider_ctx)
              Keeper_model_input_demotion.materialize
                ~store:(Tool_blob_store.create ~base_path:ctx.base_path)
                ~pending
-               windowed
+               windowed.Runtime_model_input_tail_window.messages
            in
            if outcome.Keeper_model_input_demotion.reverted = 0
-           then Ok outcome.Keeper_model_input_demotion.messages
+           then
+             (* Materialization rewrites bodies inside the already-chosen cut;
+                it neither adds nor removes atoms, so the counts still hold. *)
+             Ok
+               { windowed with
+                 Runtime_model_input_tail_window.messages =
+                   outcome.Keeper_model_input_demotion.messages
+               }
            else
              (* A restored body is larger than the measured placeholder, so the
                 final cut must be selected again against the actual payload. *)
              (match
                 offload_model_input_cpu (fun () ->
-                  Runtime_model_input_tail_window.project
+                  Runtime_model_input_tail_window.project_with_drop
                     ~measure_message_bytes:
                       (memoize_message_measurement measure_message_bytes)
                     ~capacity_bytes:ctx.model_input_capacity_bytes
@@ -592,8 +595,12 @@ let budgeted_model_input_projection (ctx : try_provider_ctx)
                   (Runtime_model_input_tail_window.budget_error_to_string error)))
     in
     match windowed with
-    | Error _ as error -> error
+    | Error error -> Error error
     | Ok windowed ->
+      Option.iter
+        (fun observe -> observe (Runtime_model_input_tail_window.observe windowed))
+        ctx.on_model_input_window_observation;
+      let windowed = windowed.Runtime_model_input_tail_window.messages in
       (match ctx.model_input_projection with
        | None -> Ok windowed
        | Some inner -> inner windowed)

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -69,6 +69,19 @@ type try_provider_ctx =
        body_bytes:int ->
        unit)
         option
+  ; on_model_input_window_observation :
+      (Runtime_model_input_tail_window.window_observation -> unit) option
+        (** Called with the cut the model-input projection selected, before the
+            request is serialized. Sits beside
+            {!on_request_wire_observation}: that one reports how many bytes the
+            provider admitted, this one reports how much of the keeper's own
+            history those bytes carried. A turn issues one provider request
+            (7,763 API calls over 7,646 turns on a live 2026-08-14 trace), so a
+            later call within one turn belongs to a failover attempt and
+            supersedes the earlier one. Never invoked when the projection
+            refuses — the turn carries a typed budget error instead, and
+            reporting a cut that was never dispatched would fabricate
+            evidence. *)
   ; event_bus : Agent_core.Event_bus.t option
   ; runtime_manifest_context : Keeper_runtime_manifest.turn_context option
   ; runtime_manifest_append : (Keeper_runtime_manifest.t -> unit) option

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -71,19 +71,23 @@ type try_provider_ctx =
         option
   ; on_model_input_window_observation :
       (Runtime_model_input_tail_window.window_observation -> unit) option
-        (** Called with the cut the model-input projection selected over the
-            keeper's conversation history.
+        (** Called with the cut the window stage selected over the keeper's
+            conversation history, as that stage saw it.
 
-            Counted in atoms, so it counts history and nothing else. Material
-            the per-turn assembler injects into the same request — pinned
-            extra-system context, the synthetic preamble, and any message
-            [model_input_projection] appends afterwards, such as a pending Gate
-            approval replay — is on the wire and is not history, so it appears
-            in neither count. That is the same exclusion {!annotate} already
-            makes, and it is why this is not a decomposition of
-            {!on_request_wire_observation}: that one measures the bytes the
-            provider admitted, and those bytes are a superset of what these
-            atoms describe.
+            Two kinds of material in the same request are outside these counts,
+            for two different reasons. Pinned extra-system context and the
+            synthetic preamble are excluded by rule: {!annotate} classifies
+            them [Pinned] every turn because they are re-assembled rather than
+            conversed. Anything [ctx.model_input_projection] appends afterwards
+            — a pending Gate approval replay, for instance — is excluded only
+            because it arrives after this stage has run. That one is ordinary
+            conversation, it is persisted, and from the next turn it is counted
+            like any other atom; the turn it is appended on undercounts by
+            exactly that message and then self-corrects.
+
+            So this is not a decomposition of {!on_request_wire_observation}:
+            that one measures the bytes the provider admitted, and those bytes
+            cover material these atoms do not.
 
             A turn issues one provider request (7,763 API calls over 7,646
             turns on a live 2026-08-14 trace), so a later call within one turn

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -71,17 +71,26 @@ type try_provider_ctx =
         option
   ; on_model_input_window_observation :
       (Runtime_model_input_tail_window.window_observation -> unit) option
-        (** Called with the cut the model-input projection selected, before the
-            request is serialized. Sits beside
-            {!on_request_wire_observation}: that one reports how many bytes the
-            provider admitted, this one reports how much of the keeper's own
-            history those bytes carried. A turn issues one provider request
-            (7,763 API calls over 7,646 turns on a live 2026-08-14 trace), so a
-            later call within one turn belongs to a failover attempt and
-            supersedes the earlier one. Never invoked when the projection
-            refuses — the turn carries a typed budget error instead, and
-            reporting a cut that was never dispatched would fabricate
-            evidence. *)
+        (** Called with the cut the model-input projection selected over the
+            keeper's conversation history.
+
+            Counted in atoms, so it counts history and nothing else. Material
+            the per-turn assembler injects into the same request — pinned
+            extra-system context, the synthetic preamble, and any message
+            [model_input_projection] appends afterwards, such as a pending Gate
+            approval replay — is on the wire and is not history, so it appears
+            in neither count. That is the same exclusion {!annotate} already
+            makes, and it is why this is not a decomposition of
+            {!on_request_wire_observation}: that one measures the bytes the
+            provider admitted, and those bytes are a superset of what these
+            atoms describe.
+
+            A turn issues one provider request (7,763 API calls over 7,646
+            turns on a live 2026-08-14 trace), so a later call within one turn
+            belongs to a failover attempt and supersedes the earlier one. Never
+            invoked when the projection refuses — the turn carries a typed
+            budget error instead, and reporting a cut that was never dispatched
+            would fabricate evidence. *)
   ; event_bus : Agent_core.Event_bus.t option
   ; runtime_manifest_context : Keeper_runtime_manifest.turn_context option
   ; runtime_manifest_append : (Keeper_runtime_manifest.t -> unit) option

--- a/lib/keeper/keeper_turn_record_writer.ml
+++ b/lib/keeper/keeper_turn_record_writer.ml
@@ -15,6 +15,7 @@ let write
       ~request_latency_ms
       ~ttfrc_ms
       ~request_wire_observation
+      ~model_input_window
       ~raw_trace_run_ref
       ~sampling
       ~usage
@@ -43,6 +44,7 @@ let write
     ; request_latency_ms
     ; ttfrc_ms
     ; request_wire_observation
+    ; model_input_window
     ; raw_trace_run_ref
     ; sampling
     ; usage

--- a/lib/keeper/keeper_turn_record_writer.mli
+++ b/lib/keeper/keeper_turn_record_writer.mli
@@ -25,6 +25,7 @@ val write :
   request_latency_ms:int option ->
   ttfrc_ms:float option ->
   request_wire_observation:Turn_record.request_wire_observation option ->
+  model_input_window:Turn_record.model_input_window option ->
   raw_trace_run_ref:Turn_record.raw_trace_run_ref option ->
   sampling:Turn_record.sampling ->
   usage:Turn_record.usage ->

--- a/lib/runtime/runtime_model_input_tail_window.ml
+++ b/lib/runtime/runtime_model_input_tail_window.ml
@@ -46,9 +46,9 @@ type window_observation =
   ; total_atoms : int
   }
 
-let observe (projection : projection) =
+let observe ~history_atom_count (projection : projection) =
   { transmitted_atoms = projection.atom_count - projection.dropped_atoms
-  ; total_atoms = projection.atom_count
+  ; total_atoms = history_atom_count
   }
 ;;
 

--- a/lib/runtime/runtime_model_input_tail_window.ml
+++ b/lib/runtime/runtime_model_input_tail_window.ml
@@ -38,7 +38,19 @@ type budget_error =
 type projection =
   { messages : Agent_core.Types.message list
   ; dropped_atoms : int
+  ; atom_count : int
   }
+
+type window_observation =
+  { transmitted_atoms : int
+  ; total_atoms : int
+  }
+
+let observe (projection : projection) =
+  { transmitted_atoms = projection.atom_count - projection.dropped_atoms
+  ; total_atoms = projection.atom_count
+  }
+;;
 
 let budget_error_to_string = function
   | Reservation_exceeds_capacity
@@ -319,7 +331,7 @@ let project_with_drop
       (Reservation_exceeds_capacity
          { capacity_bytes; reserved_bytes; undroppable_bytes })
   else if atom_count = 0
-  then Ok { messages; dropped_atoms = 0 }
+  then Ok { messages; dropped_atoms = 0; atom_count }
   else (
     let per_atom, suffix =
       atom_suffix_bytes ~measure_message_bytes ~atom_count labelled
@@ -330,6 +342,7 @@ let project_with_drop
         { messages =
             assemble ~allow_empty_history ~atom_count ~drop ~messages labelled
         ; dropped_atoms = drop
+        ; atom_count
         }
     | None ->
       let drop = exact_drop ~available_bytes ~atom_count suffix in
@@ -343,6 +356,7 @@ let project_with_drop
           { messages =
               assemble ~allow_empty_history ~atom_count ~drop ~messages labelled
           ; dropped_atoms = drop
+          ; atom_count
           })
 ;;
 

--- a/lib/runtime/runtime_model_input_tail_window.mli
+++ b/lib/runtime/runtime_model_input_tail_window.mli
@@ -157,9 +157,10 @@ val observe : history_atom_count:int -> projection -> window_observation
     pipeline cuts, materializes, and on a storage failure re-cuts the
     surviving sublist — and that last projection's own [atom_count] is the
     size of the sublist, not of the turn's history. Reading the denominator
-    from it would report a keeper that transmitted 800 of 5,000 atoms as
-    having transmitted 800 of 1,000. Supply the [atom_count] of the first cut,
-    which is the only one taken against the full history. *)
+    from it inflates the share by whatever the earlier cuts already removed:
+    a keeper that reached over 800 of 5,000 atoms would report 800 of 1,000
+    (illustrative shape, not a measured trace). Supply the [atom_count] of the
+    first cut, which is the only one taken against the full history. *)
 
 val budget_error_to_string : budget_error -> string
 (** Diagnostic rendering carrying the measured values. Suitable as the

--- a/lib/runtime/runtime_model_input_tail_window.mli
+++ b/lib/runtime/runtime_model_input_tail_window.mli
@@ -148,9 +148,18 @@ type window_observation =
 (** How much of a history one projection carried, kept without the messages so
     an observer can hold it for the length of a turn. *)
 
-val observe : projection -> window_observation
-(** Read the counts off a projection. The only arithmetic is [total_atoms -
-    dropped_atoms]; nothing here re-derives a cut. *)
+val observe : history_atom_count:int -> projection -> window_observation
+(** [observe ~history_atom_count projection] pairs what [projection]
+    transmitted with the history it was measured against.
+
+    [history_atom_count] is passed in rather than read off [projection]
+    because a projection only knows the list it was handed. The demotion
+    pipeline cuts, materializes, and on a storage failure re-cuts the
+    surviving sublist — and that last projection's own [atom_count] is the
+    size of the sublist, not of the turn's history. Reading the denominator
+    from it would report a keeper that transmitted 800 of 5,000 atoms as
+    having transmitted 800 of 1,000. Supply the [atom_count] of the first cut,
+    which is the only one taken against the full history. *)
 
 val budget_error_to_string : budget_error -> string
 (** Diagnostic rendering carrying the measured values. Suitable as the

--- a/lib/runtime/runtime_model_input_tail_window.mli
+++ b/lib/runtime/runtime_model_input_tail_window.mli
@@ -131,7 +131,26 @@ type projection =
         (** Exact raw-history cut chosen for [messages]. Projection stages that
             rewrite historical bytes use this as their cache-stable anchor: the
             rewrite boundary moves only when the authoritative cut moves. *)
+  ; atom_count : int
+        (** Atoms the input history contained, before the cut. [atom_count -
+            dropped_atoms] is what the provider receives. Both are reported
+            because a share is not recoverable from the transmitted list alone:
+            the dropped atoms leave no trace in [messages], so an observer
+            given only the result cannot tell a keeper that transmitted all of
+            a short history from one that transmitted the tail of a long one.
+            Pinned messages are not atoms and are counted in neither. *)
   }
+
+type window_observation =
+  { transmitted_atoms : int
+  ; total_atoms : int
+  }
+(** How much of a history one projection carried, kept without the messages so
+    an observer can hold it for the length of a turn. *)
+
+val observe : projection -> window_observation
+(** Read the counts off a projection. The only arithmetic is [total_atoms -
+    dropped_atoms]; nothing here re-derives a cut. *)
 
 val budget_error_to_string : budget_error -> string
 (** Diagnostic rendering carrying the measured values. Suitable as the

--- a/lib/types/turn_record.ml
+++ b/lib/types/turn_record.ml
@@ -43,6 +43,11 @@ type request_wire_observation =
   ; body_bytes : int
   }
 
+type model_input_window =
+  { transmitted_atoms : int
+  ; total_atoms : int
+  }
+
 type turn_kind =
   | Autonomous
   | Direct
@@ -76,6 +81,7 @@ type t =
   ; request_latency_ms : int option
   ; ttfrc_ms : float option
   ; request_wire_observation : request_wire_observation option
+  ; model_input_window : model_input_window option
   ; raw_trace_run_ref : raw_trace_run_ref option
   ; sampling : sampling
   ; usage : usage
@@ -141,6 +147,12 @@ let to_json (r : t) : Yojson.Safe.t =
       `String observation.runtime_profile, `Int observation.body_bytes
     | None -> `Null, `Null
   in
+  let transmitted_atoms, total_atoms =
+    match r.model_input_window with
+    | Some window ->
+      `Int window.transmitted_atoms, `Int window.total_atoms
+    | None -> `Null, `Null
+  in
   `Assoc
     ([ ( "execution_ids"
        , `List (List.map Ids.Execution_id.to_yojson r.execution_ids) )
@@ -160,6 +172,8 @@ let to_json (r : t) : Yojson.Safe.t =
      ; ("runtime_profile", `String r.runtime_profile)
      ; "request_runtime_profile", request_runtime_profile
      ; "request_body_bytes", request_body_bytes
+     ; "transmitted_atoms", transmitted_atoms
+     ; "total_atoms", total_atoms
      ; ( "raw_trace_run_ref"
        , match r.raw_trace_run_ref with
          | Some run_ref -> raw_trace_run_ref_to_json run_ref
@@ -425,6 +439,8 @@ let of_json (json : Yojson.Safe.t) : (t, string) result =
             ; "runtime_profile"
             ; "request_runtime_profile"
             ; "request_body_bytes"
+            ; "transmitted_atoms"
+            ; "total_atoms"
             ; "raw_trace_run_ref"
             ; "selected_model"
             ; "finish_reason"
@@ -519,6 +535,24 @@ let of_json (json : Yojson.Safe.t) : (t, string) result =
             "turn_record: request_runtime_profile and request_body_bytes must \
              both be present or both be null"
       in
+      let* transmitted_atoms =
+        nullable "transmitted_atoms" fields as_nonnegative_int
+      in
+      let* total_atoms = nullable "total_atoms" fields as_nonnegative_int in
+      let* model_input_window =
+        match transmitted_atoms, total_atoms with
+        | Some transmitted_atoms, Some total_atoms ->
+          if transmitted_atoms > total_atoms
+          then
+            Error
+              "turn_record: transmitted_atoms cannot exceed total_atoms"
+          else Ok (Some { transmitted_atoms; total_atoms })
+        | None, None -> Ok None
+        | Some _, None | None, Some _ ->
+          Error
+            "turn_record: transmitted_atoms and total_atoms must both be \
+             present or both be null"
+      in
       let* raw_trace_run_ref_json = require "raw_trace_run_ref" fields in
       let* raw_trace_run_ref =
         match raw_trace_run_ref_json with
@@ -574,6 +608,7 @@ let of_json (json : Yojson.Safe.t) : (t, string) result =
         ; request_latency_ms
         ; ttfrc_ms
         ; request_wire_observation
+        ; model_input_window
         ; raw_trace_run_ref
         ; sampling = { temperature; top_p; max_tokens; thinking_budget; enable_thinking }
         ; usage =

--- a/lib/types/turn_record.mli
+++ b/lib/types/turn_record.mli
@@ -74,9 +74,11 @@ type model_input_window =
 
     Reported beside {!request_wire_observation}, never in place of it: that one
     counts the bytes the provider admitted, this one counts how much
-    conversation those bytes were. Neither substitutes for the other, and
-    [input_components] answers a third question — which block kinds the bytes
-    went to.
+    conversation the turn reached back over. The two do not decompose into each
+    other — the admitted bytes also carry pinned context, the synthetic
+    preamble, and anything the per-turn assembler appends, none of which is
+    history and none of which is an atom. [input_components] answers a third
+    question: which block kinds the bytes went to.
 
     Both counts are recorded because a share cannot be recovered from the
     transmitted messages alone: dropped atoms leave no trace, so a reader given

--- a/lib/types/turn_record.mli
+++ b/lib/types/turn_record.mli
@@ -76,9 +76,10 @@ type model_input_window =
     counts the bytes the provider admitted, this one counts how much
     conversation the turn reached back over. The two do not decompose into each
     other — the admitted bytes also carry pinned context, the synthetic
-    preamble, and anything the per-turn assembler appends, none of which is
-    history and none of which is an atom. [input_components] answers a third
-    question: which block kinds the bytes went to.
+    preamble, and anything the per-turn assembler appends after the window
+    stage has run, none of which these atoms cover.
+    [input_components] answers a third question: which block kinds the bytes
+    went to.
 
     Both counts are recorded because a share cannot be recovered from the
     transmitted messages alone: dropped atoms leave no trace, so a reader given

--- a/lib/types/turn_record.mli
+++ b/lib/types/turn_record.mli
@@ -64,6 +64,26 @@ type request_wire_observation =
   ; body_bytes : int
   }
 
+type model_input_window =
+  { transmitted_atoms : int
+  ; total_atoms : int
+  }
+(** How much of the keeper's own history the dispatched request carried, in
+    atoms — one organic user message, or one assistant message together with
+    the tool messages answering it.
+
+    Reported beside {!request_wire_observation}, never in place of it: that one
+    counts the bytes the provider admitted, this one counts how much
+    conversation those bytes were. Neither substitutes for the other, and
+    [input_components] answers a third question — which block kinds the bytes
+    went to.
+
+    Both counts are recorded because a share cannot be recovered from the
+    transmitted messages alone: dropped atoms leave no trace, so a reader given
+    only the request cannot distinguish a keeper that sent all of a short
+    history from one that sent the tail of a long one. Pinned messages are not
+    atoms and appear in neither count. *)
+
 type turn_kind =
   | Autonomous
   | Direct
@@ -156,6 +176,10 @@ type t =
        indistinguishable from a measurement (§9.6), so decode stays
        not_recorded until a provider reports it natively. *)
   ; request_wire_observation : request_wire_observation option
+  ; model_input_window : model_input_window option
+    (* [None] is an explicit observation that no model-input projection ran for
+       this turn — a runtime that assembles its own input, or a turn that ended
+       before any cut was selected. It is not a zero-length history. *)
   ; raw_trace_run_ref : raw_trace_run_ref option
     (* Exact AGENT_CORE run selected by this turn's completed provider dispatch.
        [None] is an explicit observation that the raw-trace sink degraded or

--- a/test/test_keeper_autonomous_turn_source.ml
+++ b/test/test_keeper_autonomous_turn_source.ml
@@ -114,6 +114,7 @@ let run_ref ~path ~worker_run_id ~start_seq =
 
 let write_turn_record config ~absolute_turn ~generation ~turn_kind ~raw_trace_run_ref =
   Keeper_turn_record_writer.write
+    ~model_input_window:None
     ~config
     ~keeper_name
     ~agent_name

--- a/test/test_keeper_context_observation_projection.ml
+++ b/test/test_keeper_context_observation_projection.ml
@@ -53,6 +53,7 @@ let sample_record
   ; ttfrc_ms = None
   ; request_wire_observation =
       Some { runtime_profile = "glm-coding.glm-5-turbo"; body_bytes = 560_513 }
+  ; model_input_window = None
   ; raw_trace_run_ref = None
   ; sampling =
       { temperature = None

--- a/test/test_keeper_raw_trace_sink.ml
+++ b/test/test_keeper_raw_trace_sink.ml
@@ -117,6 +117,7 @@ let write_turn_record config ~(meta : Keeper_meta_contract.keeper_meta) ~turn
     }
   in
   Keeper_turn_record_writer.write
+    ~model_input_window:None
     ~config
     ~keeper_name:meta.name
     ~agent_name:meta.agent_name

--- a/test/test_runtime_model_input_tail_window.ml
+++ b/test/test_runtime_model_input_tail_window.ml
@@ -371,6 +371,66 @@ let test_exact_cut_when_no_quantized_cut_fits () =
   fits_budget ~capacity_bytes ~reserved_bytes:0 projected
 ;;
 
+(* The keeper's own history is the thing being reported on, so the assertion is
+   stated against the input the caller handed in — not against a number the
+   projection also produced. A share computed only from the transmitted list
+   would be vacuous: dropped atoms leave no trace there. *)
+let test_projection_reports_how_much_history_it_carried () =
+  let history = atoms (4 * k) in
+  let capacity_bytes = total_bytes history / 8 in
+  let projected =
+    match
+      Window.project_with_drop
+        ~measure_message_bytes
+        ~capacity_bytes
+        ~reserved_bytes:0
+        history
+    with
+    | Ok projection -> projection
+    | Error error ->
+      Alcotest.failf "reported cut: %s" (Window.budget_error_to_string error)
+  in
+  let observed = Window.observe projected in
+  Alcotest.(check int)
+    "total is the history the caller handed in"
+    (count_atoms history)
+    observed.Window.total_atoms;
+  Alcotest.(check int)
+    "transmitted is what came back"
+    (count_atoms projected.Window.messages)
+    observed.Window.transmitted_atoms;
+  Alcotest.(check bool)
+    "a cut history reports less than it held" true
+    (observed.Window.transmitted_atoms < observed.Window.total_atoms);
+  fits_budget ~capacity_bytes ~reserved_bytes:0 projected.Window.messages
+;;
+
+(* Absence of a cut has to be reportable as such. Without this the dashboard
+   cannot tell "sent everything" from "no observation", and both would render
+   as a full history. *)
+let test_uncut_history_reports_everything_carried () =
+  let history = atoms 3 in
+  let projected =
+    match
+      Window.project_with_drop
+        ~measure_message_bytes
+        ~capacity_bytes:unbounded_capacity
+        ~reserved_bytes:0
+        history
+    with
+    | Ok projection -> projection
+    | Error error ->
+      Alcotest.failf "uncut: %s" (Window.budget_error_to_string error)
+  in
+  let observed = Window.observe projected in
+  Alcotest.(check int)
+    "nothing was dropped" observed.Window.total_atoms observed.Window.transmitted_atoms;
+  Alcotest.(check int)
+    "and that total is the whole history"
+    (count_atoms history)
+    observed.Window.total_atoms
+;;
+
 let test_tool_results_stay_with_their_call () =
   let history = atoms (4 * k) in
   let projected =
@@ -591,6 +651,10 @@ let () =
             test_cut_point_is_stable_while_the_budget_holds
         ; Alcotest.test_case "exact cut when no quantized cut fits" `Quick
             test_exact_cut_when_no_quantized_cut_fits
+        ; Alcotest.test_case "projection reports how much history it carried"
+            `Quick test_projection_reports_how_much_history_it_carried
+        ; Alcotest.test_case "uncut history reports everything carried" `Quick
+            test_uncut_history_reports_everything_carried
         ; Alcotest.test_case "tool results stay with their call" `Quick
             test_tool_results_stay_with_their_call
         ; Alcotest.test_case "preamble on assistant head" `Quick

--- a/test/test_runtime_model_input_tail_window.ml
+++ b/test/test_runtime_model_input_tail_window.ml
@@ -390,7 +390,9 @@ let test_projection_reports_how_much_history_it_carried () =
     | Error error ->
       Alcotest.failf "reported cut: %s" (Window.budget_error_to_string error)
   in
-  let observed = Window.observe projected in
+  let observed =
+    Window.observe ~history_atom_count:projected.Window.atom_count projected
+  in
   Alcotest.(check int)
     "total is the history the caller handed in"
     (count_atoms history)
@@ -422,13 +424,56 @@ let test_uncut_history_reports_everything_carried () =
     | Error error ->
       Alcotest.failf "uncut: %s" (Window.budget_error_to_string error)
   in
-  let observed = Window.observe projected in
+  let observed =
+    Window.observe ~history_atom_count:projected.Window.atom_count projected
+  in
   Alcotest.(check int)
     "nothing was dropped" observed.Window.total_atoms observed.Window.transmitted_atoms;
   Alcotest.(check int)
     "and that total is the whole history"
     (count_atoms history)
     observed.Window.total_atoms
+;;
+
+(* The demotion pipeline cuts, materializes, and — when a blob fails to
+   persist — re-cuts the survivors. That last projection only ever saw the
+   survivors, so a denominator read off it would report a keeper that reached
+   back over a fraction of its history as having reached over nearly all of
+   it. *)
+let test_chained_cut_keeps_the_whole_history_as_denominator () =
+  let history = atoms (4 * k) in
+  let cut ~capacity_bytes messages =
+    match
+      Window.project_with_drop
+        ~measure_message_bytes
+        ~capacity_bytes
+        ~reserved_bytes:0
+        messages
+    with
+    | Ok projection -> projection
+    | Error error ->
+      Alcotest.failf "chained cut: %s" (Window.budget_error_to_string error)
+  in
+  let first = cut ~capacity_bytes:(total_bytes history / 4) history in
+  let second =
+    cut
+      ~capacity_bytes:(total_bytes first.Window.messages / 2)
+      first.Window.messages
+  in
+  let observed =
+    Window.observe ~history_atom_count:first.Window.atom_count second
+  in
+  Alcotest.(check int)
+    "denominator is the whole history, not the survivors"
+    (count_atoms history)
+    observed.Window.total_atoms;
+  Alcotest.(check bool)
+    "which the chained projection could not have supplied" true
+    (observed.Window.total_atoms > second.Window.atom_count);
+  Alcotest.(check int)
+    "numerator is what the last cut kept"
+    (count_atoms second.Window.messages)
+    observed.Window.transmitted_atoms
 ;;
 
 let test_tool_results_stay_with_their_call () =
@@ -655,6 +700,8 @@ let () =
             `Quick test_projection_reports_how_much_history_it_carried
         ; Alcotest.test_case "uncut history reports everything carried" `Quick
             test_uncut_history_reports_everything_carried
+        ; Alcotest.test_case "chained cut keeps the whole history as denominator"
+            `Quick test_chained_cut_keeps_the_whole_history_as_denominator
         ; Alcotest.test_case "tool results stay with their call" `Quick
             test_tool_results_stay_with_their_call
         ; Alcotest.test_case "preamble on assistant head" `Quick

--- a/test/test_turn_record.ml
+++ b/test/test_turn_record.ml
@@ -246,6 +246,7 @@ let test_codec_optional_fields_absent () =
     ; request_latency_ms = None
     ; ttfrc_ms = None
     ; request_wire_observation = None
+    ; model_input_window = None
     ; sampling =
         { temperature = None
         ; top_p = None
@@ -370,7 +371,66 @@ let test_codec_requires_current_observation_fields () =
     ; "input_components"
     ; "request_runtime_profile"
     ; "request_body_bytes"
+    ; "transmitted_atoms"
+    ; "total_atoms"
     ]
+
+(* The record has to carry how much of its own history the turn transmitted,
+   because nothing downstream can recover it: the request itself keeps no trace
+   of what was cut. *)
+let test_record_carries_transmitted_history_share () =
+  let record =
+    { (sample_record ()) with
+      Turn_record.model_input_window =
+        Some { Turn_record.transmitted_atoms = 7; total_atoms = 7_700 }
+    }
+  in
+  match Turn_record.of_json (Turn_record.to_json record) with
+  | Error message -> failf "roundtrip rejected the share: %s" message
+  | Ok decoded ->
+    (match decoded.Turn_record.model_input_window with
+     | None -> failf "roundtrip dropped the share"
+     | Some window ->
+       check int "transmitted survives" 7 window.Turn_record.transmitted_atoms;
+       check int "total survives" 7_700 window.Turn_record.total_atoms)
+
+(* A share above 1 is not a large number, it is a contradiction: the reader
+   would render a keeper transmitting more history than it holds. *)
+let test_codec_rejects_transmitting_more_than_held () =
+  let json =
+    match Turn_record.to_json (sample_record ()) with
+    | `Assoc fields ->
+      `Assoc
+        (("transmitted_atoms", `Int 9)
+         :: ("total_atoms", `Int 8)
+         :: List.remove_assoc "transmitted_atoms"
+              (List.remove_assoc "total_atoms" fields))
+    | other -> other
+  in
+  match Turn_record.of_json json with
+  | Ok _ -> failf "decoded a row transmitting more atoms than it held"
+  | Error message ->
+    check bool "error names the contradiction" true
+      (Astring.String.is_infix ~affix:"transmitted_atoms" message)
+
+(* Half an observation is not an observation. Accepting one side would let the
+   reader compute a share against a fabricated denominator. *)
+let test_codec_rejects_half_an_observation () =
+  let json =
+    match Turn_record.to_json (sample_record ()) with
+    | `Assoc fields ->
+      `Assoc
+        (("transmitted_atoms", `Int 7)
+         :: ("total_atoms", `Null)
+         :: List.remove_assoc "transmitted_atoms"
+              (List.remove_assoc "total_atoms" fields))
+    | other -> other
+  in
+  match Turn_record.of_json json with
+  | Ok _ -> failf "decoded a row with only one of the two counts"
+  | Error message ->
+    check bool "error says both or neither" true
+      (Astring.String.is_infix ~affix:"total_atoms" message)
 
 let test_codec_rejects_mismatched_turn_ref () =
   let json =
@@ -723,6 +783,12 @@ let () =
         ; test_case "rejects malformed rows" `Quick test_codec_rejects_malformed
         ; test_case "current observation fields required" `Quick
             test_codec_requires_current_observation_fields
+        ; test_case "record carries transmitted history share" `Quick
+            test_record_carries_transmitted_history_share
+        ; test_case "transmitting more than held rejected" `Quick
+            test_codec_rejects_transmitting_more_than_held
+        ; test_case "half an observation rejected" `Quick
+            test_codec_rejects_half_an_observation
         ; test_case "mismatched turn_ref rejected" `Quick
             test_codec_rejects_mismatched_turn_ref
         ; test_case "mismatched raw trace session rejected" `Quick

--- a/test/test_turn_record.ml
+++ b/test/test_turn_record.ml
@@ -83,6 +83,7 @@ let sample_record () : Turn_record.t =
         { runtime_profile = "ollama_cloud.deepseek-v4-flash"
         ; body_bytes = 560_513
         }
+  ; model_input_window = Some { transmitted_atoms = 15; total_atoms = 7_706 }
   ; raw_trace_run_ref =
       Some
         { worker_run_id = "worker-run-41"


### PR DESCRIPTION
## 왜

장기 Keeper가 자기 대화의 아주 일부만 전송하는데, 얼마나 적은지 남는 기록이 없었어요.

2026-08-14 라이브 체크포인트 실측 (`trace-1785189111911-00004`, glm-5-turbo, 7,650턴):

| 항목 | 값 |
|---|---|
| 저장된 메시지 | 15,413개 / 24 MB |
| 요청 body cap (`runtime.toml`) | 262,144 B |
| − 도구 스키마 96개 | 123,043 B (cap의 46.9%) |
| − system prompt / reserve | 1,762 / 26,214 B |
| = 이력 예산 | 111,125 B |
| **실제 전송** | **14 / 15,413 (0.10%) ≈ 7턴** |

turn record에는 이걸 답할 필드가 없었습니다. `input_components`는 블록 종류별 바이트를, `request_wire_observation`은 provider가 받은 바이트를 세는데, **그 바이트가 대화 몇 개였는지**는 어느 쪽도 말하지 않아요.

이 값은 나중에 되살릴 수가 없습니다. 잘려나간 atom은 전송 목록에 흔적을 안 남기니까, 요청만 받아본 쪽에서는 "짧은 이력을 전부 보낸 Keeper"와 "긴 이력의 꼬리만 보낸 Keeper"를 구분할 방법이 없어요. 그래서 두 수를 항상 같이 싣고, 한쪽만 있는 행은 거부합니다.

## 무엇을

- `Runtime_model_input_tail_window.projection`에 `atom_count` 추가, `observe`가 쌍을 읽어냄
- 강등(demotion) 경로가 메시지 목록 대신 projection을 들고 다니도록 변경 — 보고되는 cut이 materialize와 revert 재-cut을 거친 **실제 전송본**이 되도록
- `Turn_record.model_input_window` 추가. 디코더가 `transmitted > total`과 한쪽만 있는 관측을 거부
- Keeper 턴 인스펙터에 wire body 옆으로 표시

**동작 변경은 없습니다.** 전송되는 메시지는 이전과 같아요.

## 이 PR의 역할

이건 스택의 첫 PR이고, 뒤 작업의 전제를 **반증하기 위한** 것입니다. 다음 PR들은 "7턴만 보이는 이유는 창이 잘라내서"를 전제하는데, 만약 `model_input_projection` 상류에서 이미 잘려 있다면 회수한 바이트가 갈 곳이 없어요.

- `total_atoms ≈ 7,700`이면 창이 병목이고 조준이 맞습니다
- 이미 ~10이면 스택을 멈추고 상류 절단을 찾아야 해요

## 검증

- `test_runtime_model_input_tail_window`: 잘린 이력이 자기가 들고 있던 것보다 적게 보고하는지, 안 잘린 이력이 전량을 보고하는지 (부재와 전량 전송을 구분하기 위해)
- `test_turn_record`: 왕복 보존, 모순된 share 거부, 반쪽 관측 거부

로컬 빌드 없이 CI로 확인합니다.