### PR TITLE
refactor(agent-core): drop the unreachable thinking-token accessor chain

### DIFF
--- a/packages/agent_core/lib/llm_provider/capabilities.ml
+++ b/packages/agent_core/lib/llm_provider/capabilities.ml
@@ -1291,38 +1291,6 @@ let token_of_declared_format format =
   Option.bind format Capability_vocab.token_of_thinking_control_format
 ;;
 
-let thinking_control_token_for_model_id_catalog model_id =
-  match Model_catalog.global () with
-  | Some catalog ->
-    (match Model_catalog.lookup catalog model_id with
-     | Some entry -> token_of_declared_format entry.thinking_control_format
-     | None -> None)
-  | None -> None
-;;
-
-let thinking_control_token_for_model_id_with_manifest manifest model_id =
-  match Capability_manifest.lookup manifest model_id with
-  | Some entry -> token_of_declared_format entry.thinking_control_format
-  | None -> thinking_control_token_for_model_id_catalog model_id
-;;
-
-let[@warning "-32"] thinking_control_token_for_model_id model_id =
-  match Model_catalog.global () with
-  | Some catalog ->
-    (match Model_catalog.lookup catalog model_id with
-     | Some entry -> token_of_declared_format entry.thinking_control_format
-     | None ->
-       (match Capability_manifest.global () with
-        | Some manifest ->
-          thinking_control_token_for_model_id_with_manifest manifest model_id
-        | None -> thinking_control_token_for_model_id_catalog model_id))
-  | None ->
-    (match Capability_manifest.global () with
-     | Some manifest ->
-       thinking_control_token_for_model_id_with_manifest manifest model_id
-     | None -> thinking_control_token_for_model_id_catalog model_id)
-;;
-
 let thinking_control_token_for_provider_model_id
       ~(provider_label : string)
       ~(model_id : string)
@@ -1813,39 +1781,6 @@ let%test "Anthropic thinking policy falls back to manifest when catalog has no r
     (fun () ->
        anthropic_thinking_control_for_model_id "manifest-anthropic-model"
        = Some Anthropic_adaptive_only)
-;;
-
-let%test "thinking_control_token accessor reads the token from the catalog constructor" =
-  (* The token is the single source of truth carried by [Chat_template_token]; a
-     non-token format resolves to [None]. *)
-  Model_catalog.set_global
-    (Model_catalog.of_model_entries
-       [ { (test_catalog_entry "programmatic-catalog-token") with
-           thinking_control_format = Some (Chat_template_token "<|think|>")
-         }
-       ; { (test_catalog_entry "programmatic-catalog-no-token") with
-           thinking_control_format = Some Chat_template_kwargs
-         }
-       ]);
-  Fun.protect ~finally:Model_catalog.clear_global (fun () ->
-    thinking_control_token_for_model_id "programmatic-catalog-token" = Some "<|think|>"
-    && Option.is_none
-         (thinking_control_token_for_model_id "programmatic-catalog-no-token"))
-;;
-
-let%test "thinking_control_token accessor reads the token from the manifest constructor" =
-  Capability_manifest.set_global
-    [ { (test_manifest_entry "programmatic-manifest-token") with
-        thinking_control_format = Some (Chat_template_token "<|think|>")
-      }
-    ; { (test_manifest_entry "programmatic-manifest-no-token") with
-        thinking_control_format = Some Chat_template_kwargs
-      }
-    ];
-  Fun.protect ~finally:Capability_manifest.clear_global (fun () ->
-    thinking_control_token_for_model_id "programmatic-manifest-token" = Some "<|think|>"
-    && Option.is_none
-         (thinking_control_token_for_model_id "programmatic-manifest-no-token"))
 ;;
 
 (* --- emits_usage_tokens / capabilities_for_provider_label --- *)


### PR DESCRIPTION
## 무엇을

`thinking_control_token_for_model_id` 와 그 전용 헬퍼 둘(`_with_manifest`, `_catalog`), 그리고 그 셋만 부르던 인라인 테스트 2개를 제거합니다. 31줄 함수 + 32줄 테스트입니다.

## 왜

소비자가 없습니다.

- `capabilities.mli` 에 없습니다. export 되는 건 `thinking_control_token_for_provider_model_id` 입니다.
- 저장소 전체에서 정의부 외 참조는 인라인 테스트 4줄뿐이었습니다 (`capabilities.ml:1831, 1833, 1846, 1848`).
- `_with_manifest` 는 이 함수에서만, `_catalog` 는 그 둘에서만 불렸습니다. 사슬 전체가 자기 참조로 닫혀 있었습니다.

```
$ git log --oneline -S "thinking_control_token_for_model_id " --all -- packages/agent_core/lib/llm_provider/
eaddf336b6 refactor: import MASC agent core (#27619)
f76555ab9e refactor: import MASC agent core
```

agent_core 일괄 임포트 때 딸려 들어왔고 이 저장소에서 호출자를 가진 적이 없습니다. 끊긴 기능이 아니라 처음부터 도달 불가였습니다.

#28714 가 macOS arm64 release 레인을 돌리면서 warning 32 가 드러났고, 진행을 위해 `let[@warning "-32"]` 로 억제했습니다. 억제는 사실을 가릴 뿐이라 그 PR 리뷰에서 #28732 로 분리해 두었습니다. 이 PR 이 그걸 닫습니다.

## 동작 손실 없음

export 되는 `thinking_control_token_for_provider_model_id` 는 카탈로그만 조회합니다 (`Model_catalog.lookup_for_provider`). 이 사슬이 구현하던 manifest fallback 은 어떤 호출자에게도 도달 불가였으므로, 제거해도 실제로 동작하던 경로가 사라지지 않습니다.

manifest 기반 thinking-token 해석이 필요하다면 그건 별도 배선 작업이고, 도달 불가 구현을 남겨두는 것으로는 얻어지지 않습니다.

## 고아 확인

사슬을 지우면 헬퍼가 고아가 되는지 확인했습니다.

- `test_manifest_entry` — `capabilities.ml:1773` 에 실사용이 남습니다. 테스트 헬퍼 지위 유지, `[@warning "-32"]` 그대로 맞습니다.
- `with_test_catalog` (10회), `test_catalog_entry` (19회) — 영향 없습니다.

#28714 가 넣은 억제 3곳 중 이 PR 이 걷어내는 건 죽은 함수 것 하나뿐입니다. 나머지 둘은 이름 그대로 테스트 헬퍼라 대상이 아닙니다.

## 검증

- `dune build --root . @check` — exit 0
- `dune build --root . @packages/agent_core/runtest` — exit 1, 실패 1건
- 그 실패는 **main 에서도 동일합니다**: `exact_output_plan.ml:621 canonical fingerprint is sensitive to the frozen response codec is false` / `FAILED 1 / 3 tests`. 같은 커맨드를 main 워크트리에서 돌려 같은 줄·같은 메시지를 확인했습니다. 이 PR 과 무관한 기존 실패라 범위 밖으로 둡니다.
