### PR TITLE
fix(ci): fetch the boundary-ratchet base commit, not just the base branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -872,14 +872,16 @@ jobs:
           set -euo pipefail
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             bash scripts/ci/git-fetch-retry.sh origin "${{ github.base_ref }}"
-            # The ratchet compares against pull_request.base.sha, which is not
-            # always reachable from the base branch: a PR whose base was
-            # retargeted (its parent in a stack merged) keeps the SHA recorded
-            # at event time, and that commit lives on the old base. Fetching
-            # the branch alone leaves it absent and the ratchet hard-fails with
-            # "base revision is unavailable". Fetch the exact commit too.
+            # This job checks out shallow (no fetch-depth), so fetching the
+            # base branch brings its tip and nothing behind it. The ratchet
+            # wants pull_request.base.sha, which is an ancestor of that tip on
+            # a PR whose base branch has moved on, so it stays absent and the
+            # ratchet hard-fails with "base revision is unavailable". Fetch the
+            # exact commit; depth 1 is enough because the ratchet only reads
+            # two files at that revision, never its history.
             if ! git cat-file -e "${OCAML_BOUNDARY_BASE_REF}^{commit}" 2>/dev/null; then
-              bash scripts/ci/git-fetch-retry.sh origin "${OCAML_BOUNDARY_BASE_REF}"
+              bash scripts/ci/git-fetch-retry.sh \
+                origin "${OCAML_BOUNDARY_BASE_REF}" --depth=1
             fi
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             bash scripts/ci/git-fetch-retry.sh \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -872,6 +872,15 @@ jobs:
           set -euo pipefail
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             bash scripts/ci/git-fetch-retry.sh origin "${{ github.base_ref }}"
+            # The ratchet compares against pull_request.base.sha, which is not
+            # always reachable from the base branch: a PR whose base was
+            # retargeted (its parent in a stack merged) keeps the SHA recorded
+            # at event time, and that commit lives on the old base. Fetching
+            # the branch alone leaves it absent and the ratchet hard-fails with
+            # "base revision is unavailable". Fetch the exact commit too.
+            if ! git cat-file -e "${OCAML_BOUNDARY_BASE_REF}^{commit}" 2>/dev/null; then
+              bash scripts/ci/git-fetch-retry.sh origin "${OCAML_BOUNDARY_BASE_REF}"
+            fi
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             bash scripts/ci/git-fetch-retry.sh \
               origin \


### PR DESCRIPTION
## 증상

`#28641` 의 `Build and Test` 가 이 줄 하나로 실패합니다.

```
ocaml-boundary-ratchet: base revision is unavailable: 33be4b3b7e27f38ae4d4959f29533e439e980c11
##[error]Process completed with exit code 1
```

그 PR 이 바꾸는 파일은 `dashboard/src/components/overview/overview.ts` 와 그 테스트뿐입니다. OCaml 경계 감사가 볼 것이 없습니다.

## 원인

이 job 의 checkout 이 얕습니다 (`ci.yml:783-784`).

```yaml
- name: Checkout
  uses: actions/checkout@v7      # fetch-depth 없음 → depth 1
```

같은 파일의 다른 job 4곳은 `fetch-depth: 0` 을 명시합니다 (49 / 201 / 443 / 2055행). 이 job 만 빠져 있습니다.

얕은 클론에서는 base 브랜치를 fetch 해도 **팁 하나만** 들어옵니다. 그런데 ratchet 이 원하는 건 `pull_request.base.sha` 이고, 그건 팁보다 뒤에 있는 조상입니다. 그래서 브랜치를 가져와도 없습니다.

```bash
# ci.yml:868-879
env:
  OCAML_BOUNDARY_BASE_REF: ${{ ... github.event.pull_request.base.sha ... }}   # 커밋 SHA
run: |
  bash scripts/ci/git-fetch-retry.sh origin "${{ github.base_ref }}"           # 브랜치 이름
```

```bash
# scripts/ocaml-boundary-ratchet.sh:60-63
if ! git cat-file -e "${base_ref}^{commit}" 2>/dev/null; then
  echo "ocaml-boundary-ratchet: base revision is unavailable: ${base_ref}" >&2
```

## 변경

없을 때만 그 커밋을 직접, 깊이 1로 가져옵니다.

```bash
if ! git cat-file -e "${OCAML_BOUNDARY_BASE_REF}^{commit}" 2>/dev/null; then
  bash scripts/ci/git-fetch-retry.sh origin "${OCAML_BOUNDARY_BASE_REF}" --depth=1
fi
```

깊이 1로 충분한 이유는 ratchet 이 그 revision 에서 파일 두 개만 읽고 이력을 걷지 않기 때문입니다 (`ocaml-boundary-ratchet.sh:66-73`, `git show "${base_ref}:scripts/ocaml-boundary-baseline.tsv"` / `:scripts/ocaml-pure-modules.txt`).

`fetch-depth: 0` 으로 바꾸는 선택지도 있지만, 매 Build and Test 마다 전체 이력을 받는 비용을 이 한 가지 때문에 치르게 됩니다.

## 검증

- `python3 -c "yaml.safe_load(...)"` — 파싱 통과, jobs 16개 유지
- **bare SHA fetch 가 이 저장소에서 되는지 먼저 재현했습니다.** 서버가 거부하면 수정이 무의미하니까요.

```
$ git init -q shatest && cd shatest && git remote add origin https://github.com/jeong-sik/masc.git
$ git fetch --depth=1 origin 33be4b3b7e27f38ae4d4959f29533e439e980c11
 * branch  33be4b3b7e... -> FETCH_HEAD
$ git cat-file -t 33be4b3b7e27f38ae4d4959f29533e439e980c11
commit
```

## 정정 이력

첫 커밋(`8f4009cccc`)에 원인을 "base 가 재지정되어 SHA 가 옛 브랜치에 남았다"고 적었는데 **틀렸습니다**. 확인해 보니 그 SHA 는 base 브랜치의 조상이 맞습니다.

```
$ git merge-base --is-ancestor 33be4b3b7e... origin/agent/topbar-composite-health && echo YES
YES
```

두 번째 커밋(`c388dcafc8`)에서 원인을 checkout depth 로 바로잡고 fetch 를 `--depth=1` 로 묶었습니다. 수정 방향 자체는 첫 커밋부터 맞았지만, 근거가 틀린 채로 남으면 다음 사람이 잘못 배웁니다.
