### PR TITLE
fix(ci): 스택 PR이 증거를 못 받던 배선 두 곳

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -879,13 +879,6 @@ jobs:
           set -euo pipefail
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             bash scripts/ci/git-fetch-retry.sh origin "${{ github.base_ref }}"
-            # The ratchet compares against the recorded base *SHA*, but the
-            # fetch above names the base *branch*. Those agree when the base is
-            # main; on a stacked PR the branch tip moves as the parent is
-            # restacked, so the recorded SHA can be absent locally and the
-            # ratchet exits with "base revision is unavailable" while its own
-            # suite passes 6/6. Fetch the exact revision the comparison needs.
-            bash scripts/ci/git-fetch-retry.sh origin "${OCAML_BOUNDARY_BASE_REF}"
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             bash scripts/ci/git-fetch-retry.sh \
               origin \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,14 @@ on:
   push:
     branches: [main, develop]
   pull_request:
-    branches: [main, develop]
+    # No base filter. The filter matches the *base* branch, so a stacked PR --
+    # one opened against another PR's branch rather than main -- did not start
+    # this workflow at all. Those PRs collected only the handful of checks other
+    # workflows contribute and reached review with no compile or test evidence;
+    # on 2026-08-14 five of them sat that way at once. A stack is how work over
+    # 20k tokens is supposed to arrive here, so the shape that needs evidence
+    # most was the one getting none.
+    #
     # Drafts stay cheap through pr-live-gate. ready_for_review starts the exact
     # source and real-world product gates once the author asks for a verdict.
     types: [opened, synchronize, reopened, ready_for_review]
@@ -872,6 +879,13 @@ jobs:
           set -euo pipefail
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             bash scripts/ci/git-fetch-retry.sh origin "${{ github.base_ref }}"
+            # The ratchet compares against the recorded base *SHA*, but the
+            # fetch above names the base *branch*. Those agree when the base is
+            # main; on a stacked PR the branch tip moves as the parent is
+            # restacked, so the recorded SHA can be absent locally and the
+            # ratchet exits with "base revision is unavailable" while its own
+            # suite passes 6/6. Fetch the exact revision the comparison needs.
+            bash scripts/ci/git-fetch-retry.sh origin "${OCAML_BOUNDARY_BASE_REF}"
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             bash scripts/ci/git-fetch-retry.sh \
               origin \

--- a/.github/workflows/fundamental-check.yml
+++ b/.github/workflows/fundamental-check.yml
@@ -22,7 +22,9 @@ name: Fundamental Check
 
 on:
   pull_request:
-    branches: [main]
+    # No base filter, for the reason ci.yml carries: the filter matches the
+    # base branch, so these guards skipped every stacked PR — the exact PRs
+    # that reach review with the least evidence.
   push:
     branches: [main]
 


### PR DESCRIPTION
## 왜

오늘 열린 PR 다섯 개(#28628 · #28641 · #28669 · #28737 · #28739)가 체크를 **2~4개**만 받았습니다. 코드가 아니라 배선 때문입니다.

### ① `pull_request.branches` 는 base 브랜치를 거릅니다

`ci.yml` 과 `fundamental-check.yml` 이 `branches: [main, develop]` 로 걸러요. 이 필터는 **base** 기준이라, 다른 PR 의 브랜치 위에 올린 PR — 20k 토큰을 넘는 작업이 도착하기로 되어 있는 바로 그 모양 — 은 어느 쪽에도 안 맞아서 **워크플로가 시작조차 안 했습니다.**

실측: #28628 은 base 를 main 으로 옮기기 전까지 **어떤 head 에서도 컴파일된 적이 없었습니다.** 옮기고 나서 첫 `Build and Test` 가 돌았고 통과했습니다.

패턴 목록(`agent/**` 등)으로 넓히지 않고 필터를 **제거**했습니다. 목록은 새 접두어가 생기는 순간 낡습니다.

### ② boundary ratchet 이 기준 커밋을 안 가져옵니다

기준은 `OCAML_BOUNDARY_BASE_REF`(base **SHA**)로 잡는데, fetch 는 base **브랜치 이름**으로 합니다. base 가 main 이면 같은 커밋이라 문제가 없습니다.

스택 PR 에서는 부모가 재기반될 때마다 브랜치 tip 이 움직여서, 기록된 SHA 가 로컬에 없을 수 있습니다. 그러면 이렇게 죽습니다:

```
[OK] typed path classification 0/1/2 …
[OK] ratchet 0/1/2 …
Test Successful in 0.001s. 6 tests run.

ocaml-boundary-ratchet: base revision is unavailable: f87228f752…
##[error]Process completed with exit code 1.
```

**감사는 6/6 통과하는데 실패로 보입니다.** 코드 결함으로 오독되는 자리라 오늘 두 PR 에서 실제로 오독됐습니다. 비교가 필요로 하는 그 리비전을 직접 fetch 하게 했습니다.

## 게이트를 푸는 변경이 아닙니다

- ①은 게이트가 **안 돌던 곳에서 돌게** 합니다
- ②는 ratchet 이 **이미 쓰라고 지정받은** 리비전과 비교하게 합니다

둘 다 검증 범위를 넓히는 방향이고, 좁히지 않습니다.

## 검증

- 두 파일 YAML 파싱 확인: `ci.yml` → `pull_request` 에 `types` 만 남음, `fundamental-check.yml` → `pull_request` null(전체 base). `push` 트리거는 둘 다 그대로.
- 이 PR 자체가 ①의 첫 시험대입니다 — base 가 main 이라 원래도 돌지만, 병합 뒤 스택 PR 에서 체크 수가 늘어나는지가 진짜 확인입니다.

## 남은 것 (이 PR 밖)

`keeper-realworld-acceptance` 환경이 승인자 1명을 요구해서, 승인 안 된 main 런이 concurrency 그룹을 점유합니다. 오늘 05:14 부터 main 푸시 런 6개가 그 뒤에 줄 서다 접혔습니다. 이건 워크플로 파일이 아니라 repo 설정이라 별도로 여쭙니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)