### PR TITLE
fix(agent-core): make the release profile build

### DIFF
--- a/packages/agent_core/lib/agent/agent_execution_runner.ml
+++ b/packages/agent_core/lib/agent/agent_execution_runner.ml
@@ -108,7 +108,8 @@ let reraise_after_abort_failure exn backtrace abort_detail =
     Printexc.raise_with_backtrace reserved backtrace
 ;;
 
-let capture_traceln_for_inline_test f =
+(* Inline-test-only; the release profile strips the tests that call it. *)
+let[@warning "-32"] capture_traceln_for_inline_test f =
   Eio_main.run
   @@ fun env ->
   let buffer = Buffer.create 256 in

--- a/packages/agent_core/lib/agent/agent_turn.ml
+++ b/packages/agent_core/lib/agent/agent_turn.ml
@@ -305,7 +305,8 @@ let make_tool_results results =
 
 (* === make_tool_results inline tests === *)
 
-let mock_result ?(is_error = false) ~id content : Agent_tools.tool_execution_result =
+(* Inline-test-only; the release profile strips the tests that call it. *)
+let[@warning "-32"] mock_result ?(is_error = false) ~id content : Agent_tools.tool_execution_result =
   let schedule : Tool_contract.schedule =
     { planned_index = 0
     ; batch_index = 0
@@ -333,7 +334,8 @@ let mock_result ?(is_error = false) ~id content : Agent_tools.tool_execution_res
   }
 ;;
 
-let single_tool_result = function
+(* Inline-test-only; the release profile strips the tests that call it. *)
+let[@warning "-32"] single_tool_result = function
   | [ ToolResult { tool_use_id; content; outcome; _ } ] ->
     Some (tool_use_id, content, Types.tool_result_outcome_is_error outcome)
   | []

--- a/packages/agent_core/lib/agent_tool.ml
+++ b/packages/agent_core/lib/agent_tool.ml
@@ -206,7 +206,8 @@ let create_simple ~name ~description runner =
 [@@@coverage off]
 (* === Inline tests === *)
 
-let mock_runner text _prompt =
+(* Inline-test-only; the release profile strips the tests that call it. *)
+let[@warning "-32"] mock_runner text _prompt =
   Ok
     { id = "m"
     ; model = "m"
@@ -217,7 +218,8 @@ let mock_runner text _prompt =
     }
 ;;
 
-let failing_runner _prompt = Error (Error.Internal "agent failed")
+(* Inline-test-only; the release profile strips the tests that call it. *)
+let[@warning "-32"] failing_runner _prompt = Error (Error.Internal "agent failed")
 
 let%test "create_simple produces valid tool" =
   let tool = create_simple ~name:"helper" ~description:"A helper" (mock_runner "hello") in

--- a/packages/agent_core/lib/llm_provider/backend_openai.ml
+++ b/packages/agent_core/lib/llm_provider/backend_openai.ml
@@ -28,7 +28,8 @@ let parse_openai_response_result = Backend_openai_parse.parse_openai_response_re
 (* ── Re-exports from request building ─────────────────── *)
 
 let warn_capability_drop = Backend_openai_request.warn_capability_drop
-let effective_tool_choice = Backend_openai_request.effective_tool_choice
+(* Inline-test-only; the release profile strips the tests that call it. *)
+let[@warning "-32"] effective_tool_choice = Backend_openai_request.effective_tool_choice
 let response_format_to_openai_json = Backend_openai_request.response_format_to_openai_json
 
 type request_artifact =
@@ -78,7 +79,8 @@ let deepseek_v4_capabilities =
   }
 ;;
 
-let declared_deepseek_config ?enable_thinking ?reasoning_effort model_id =
+(* Inline-test-only; the release profile strips the tests that call it. *)
+let[@warning "-32"] declared_deepseek_config ?enable_thinking ?reasoning_effort model_id =
   Provider_config.make
     ~kind:OpenAI_compat
     ~model_id
@@ -973,7 +975,8 @@ let%test "build_request includes tool_choice for model with supports_tool_choice
   json |> member "tool_choice" |> to_string = "required"
 ;;
 
-let json_object_missing_key key json =
+(* Inline-test-only; the release profile strips the tests that call it. *)
+let[@warning "-32"] json_object_missing_key key json =
   match Yojson.Safe.Util.to_assoc json with
   | fields -> not (List.exists (fun (k, _) -> k = key) fields)
   | exception Yojson.Safe.Util.Type_error _ -> false

--- a/packages/agent_core/lib/llm_provider/complete_stream_error.ml
+++ b/packages/agent_core/lib/llm_provider/complete_stream_error.ml
@@ -211,7 +211,8 @@ let%test "provider error diagnostic uses the active wire format" =
   | _ -> false
 ;;
 
-let maps_to_sse_wire_failure ~expected_kind stream_error =
+(* Inline-test-only; the release profile strips the tests that call it. *)
+let[@warning "-32"] maps_to_sse_wire_failure ~expected_kind stream_error =
   match http_error_of_stream_error stream_error with
   | Http_client.ProviderFailure
       { kind = Http_client.Provider_wire_error { format = Http_client.Sse; kind }; _ } ->

--- a/packages/agent_core/lib/llm_provider/complete_stream_state.ml
+++ b/packages/agent_core/lib/llm_provider/complete_stream_state.ml
@@ -443,10 +443,6 @@ let finalize state =
 
 [@@@coverage off]
 
-let finish state stop_reason =
-  transition state (Types.MessageDelta { stop_reason = Some stop_reason; usage = None })
-;;
-
 let%test "transition is deterministic for the same snapshot and event" =
   let event =
     Types.MessageStart { id = "message"; model = "model"; usage = None }
@@ -494,7 +490,12 @@ let%test "snapshot delta replaces an earlier complete tool input" =
       state
       (Types.ContentBlockDelta
          { index = 0; delta = Types.InputJsonSnapshot {|{"limit":10}|} })
-    |> fun state -> finish state Types.StopToolUse
+    |> fun state ->
+    (* Settling is a MessageDelta carrying the stop reason; naming the event
+       keeps the test honest about what "finishing" is. *)
+    transition
+      state
+      (Types.MessageDelta { stop_reason = Some Types.StopToolUse; usage = None })
   in
   match finalize state with
   | Completed { content = [ Types.ToolUse { input; _ } ]; _ } ->

--- a/packages/agent_core/lib/llm_provider/discovery.ml
+++ b/packages/agent_core/lib/llm_provider/discovery.ml
@@ -469,9 +469,11 @@ let%test "default_endpoint is localhost:8085" =
 
 (* --- parse_llm_endpoints_env (SSOT helper, #1002) --- *)
 
-let no_env _ = None
+(* Inline-test-only; the release profile strips the tests that call it. *)
+let[@warning "-32"] no_env _ = None
 
-let getenv_with_llm_endpoints value name =
+(* Inline-test-only; the release profile strips the tests that call it. *)
+let[@warning "-32"] getenv_with_llm_endpoints value name =
   if name = llm_endpoints_env_var then Some value else None
 ;;
 

--- a/packages/agent_core/lib/llm_provider/http_client.ml
+++ b/packages/agent_core/lib/llm_provider/http_client.ml
@@ -1288,7 +1288,8 @@ let capture_response_header_evidence headers =
   Response_header_evidence fingerprint, retry_after_header
 ;;
 
-let header_evidence_fingerprint_for_test headers =
+(* Inline-test-only; the release profile strips the tests that call it. *)
+let[@warning "-32"] header_evidence_fingerprint_for_test headers =
   headers
   |> Http.Header.of_list
   |> capture_response_header_evidence
@@ -3187,7 +3188,8 @@ let%test "classify_network_exn: unknown backend printer text does not classify" 
   | None -> false
 ;;
 
-let multiple_io_exn errs =
+(* Inline-test-only; the release profile strips the tests that call it. *)
+let[@warning "-32"] multiple_io_exn errs =
   let combine acc err =
     let exn = eio_exn err in
     let bt = Printexc.get_callstack 0 in

--- a/packages/agent_core/lib/llm_provider/image_generation.ml
+++ b/packages/agent_core/lib/llm_provider/image_generation.ml
@@ -341,7 +341,8 @@ let generate
 
 let test_caps task = { Capabilities.default_capabilities with task }
 
-let test_config kind task =
+(* Inline-test-only; the release profile strips the tests that call it. *)
+let[@warning "-32"] test_config kind task =
   Provider_config.make
     ~kind
     ~provider_id:"test-image"
@@ -352,7 +353,8 @@ let test_config kind task =
     ()
 ;;
 
-let catalog_declares_image_task provider_label model_id =
+(* Inline-test-only; the release profile strips the tests that call it. *)
+let[@warning "-32"] catalog_declares_image_task provider_label model_id =
   match
     Capabilities.for_provider_model_id
       ~allow_bare_fallback:false

--- a/packages/agent_core/lib/llm_provider/speech_generation.ml
+++ b/packages/agent_core/lib/llm_provider/speech_generation.ml
@@ -305,7 +305,8 @@ let generate
 
 let test_caps task = { Capabilities.default_capabilities with task }
 
-let test_config ?(kind = Provider_config.OpenAI_compat) task =
+(* Inline-test-only; the release profile strips the tests that call it. *)
+let[@warning "-32"] test_config ?(kind = Provider_config.OpenAI_compat) task =
   Provider_config.make
     ~kind
     ~provider_id:"test-speech"

--- a/packages/agent_core/lib/llm_provider/streaming.ml
+++ b/packages/agent_core/lib/llm_provider/streaming.ml
@@ -1274,7 +1274,8 @@ let openai_sse_parse_result_to_events state = function
   | Openai_parse_failed { reason; raw } -> [ SSEParseFailed { reason; raw } ], None
 ;;
 
-let test_tool_use_start_with_name = function
+(* Inline-test-only; the release profile strips the tests that call it. *)
+let[@warning "-32"] test_tool_use_start_with_name = function
   | ContentBlockStart { index; content_type = "tool_use"; tool_name; _ } ->
     Some (index, tool_name)
   | MessageStart _
@@ -1296,7 +1297,8 @@ let test_tool_use_start_with_name = function
   | StreamIncomplete _ -> None
 ;;
 
-let test_tool_use_start = function
+(* Inline-test-only; the release profile strips the tests that call it. *)
+let[@warning "-32"] test_tool_use_start = function
   | ContentBlockStart { content_type = "tool_use"; _ } -> Some ()
   | MessageStart _
   | ContentBlockStart _
@@ -1317,7 +1319,8 @@ let test_tool_use_start = function
   | StreamIncomplete _ -> None
 ;;
 
-let test_input_json_delta = function
+(* Inline-test-only; the release profile strips the tests that call it. *)
+let[@warning "-32"] test_input_json_delta = function
   | ContentBlockDelta { index; delta = InputJsonDelta s } -> Some (index, s)
   | MessageStart _
   | ContentBlockStart _

--- a/packages/agent_core/lib/pipeline/pipeline.ml
+++ b/packages/agent_core/lib/pipeline/pipeline.ml
@@ -36,7 +36,6 @@ let stage_input = Pipeline_stage_prepare.stage_input
 
 (* ── Stage 2: Parse ──────────────────────────────────────── *)
 
-let last_tool_results_from = Pipeline_stage_prepare.last_tool_results_from
 
 (** Prepare the turn using current [agent.state.messages] and the given
     [turn_params].  Centralises the [Agent_turn.prepare_turn] parameter
@@ -703,7 +702,7 @@ let run_turn
 [@@@coverage off]
 (* === Inline tests === *)
 
-let%test "last_tool_results_from empty messages" = last_tool_results_from [] = []
+let%test "last_tool_results_from empty messages" = Agent_turn.last_tool_results_from [] = []
 
 let%test "last_tool_results_from no tool results" =
   let msgs =
@@ -715,7 +714,7 @@ let%test "last_tool_results_from no tool results" =
       }
     ]
   in
-  last_tool_results_from msgs = []
+  Agent_turn.last_tool_results_from msgs = []
 ;;
 
 let%test "last_tool_results_from finds tool results in last tool message" =
@@ -750,7 +749,7 @@ let%test "last_tool_results_from finds tool results in last tool message" =
       }
     ]
   in
-  match last_tool_results_from msgs with
+  match Agent_turn.last_tool_results_from msgs with
   | [ Ok { content = "result1"; _meta = _ }
     ; Error { message = "error msg"; recoverable = false; error_class = None }
     ] -> true
@@ -787,7 +786,7 @@ let%test "last_tool_results_from ignores tool results outside tool role" =
       }
     ]
   in
-  last_tool_results_from msgs = []
+  Agent_turn.last_tool_results_from msgs = []
 ;;
 
 let%test "tag_error passes through Ok" =
@@ -820,7 +819,7 @@ let%test "last_tool_results_from assistant-only messages" =
       }
     ]
   in
-  last_tool_results_from msgs = []
+  Agent_turn.last_tool_results_from msgs = []
 ;;
 
 let%test "last_tool_results_from picks last tool-result message" =
@@ -861,7 +860,7 @@ let%test "last_tool_results_from picks last tool-result message" =
       }
     ]
   in
-  match last_tool_results_from msgs with
+  match Agent_turn.last_tool_results_from msgs with
   | [ Ok { content = "second"; _meta = _ } ] -> true
   | _ -> false
 ;;
@@ -886,7 +885,7 @@ let%test "last_tool_results_from ignores mixed content outside tool role" =
       }
     ]
   in
-  last_tool_results_from msgs = []
+  Agent_turn.last_tool_results_from msgs = []
 ;;
 
 let%test "last_tool_results_from error tool result" =
@@ -908,7 +907,7 @@ let%test "last_tool_results_from error tool result" =
       }
     ]
   in
-  match last_tool_results_from msgs with
+  match Agent_turn.last_tool_results_from msgs with
   | [ Error { message = "fail msg"; recoverable = false; error_class = None } ] -> true
   | _ -> false
 ;;
@@ -931,7 +930,7 @@ let%test "last_tool_results_from only non-result roles" =
       }
     ]
   in
-  last_tool_results_from msgs = []
+  Agent_turn.last_tool_results_from msgs = []
 ;;
 
 let%test "last_tool_results_from multiple tool results in one message" =
@@ -967,7 +966,7 @@ let%test "last_tool_results_from multiple tool results in one message" =
       }
     ]
   in
-  List.length (last_tool_results_from msgs) = 3
+  List.length (Agent_turn.last_tool_results_from msgs) = 3
 ;;
 
 let%test "last_tool_results_from user msg with only non-tool content" =
@@ -981,5 +980,5 @@ let%test "last_tool_results_from user msg with only non-tool content" =
       }
     ]
   in
-  last_tool_results_from msgs = []
+  Agent_turn.last_tool_results_from msgs = []
 ;;

--- a/packages/agent_core/lib/pipeline/pipeline_stage_prepare.ml
+++ b/packages/agent_core/lib/pipeline/pipeline_stage_prepare.ml
@@ -99,14 +99,19 @@ let stage_input ?raw_trace_run ?clock ~turn agent =
          ~decision:before_decision)
 ;;
 
-let last_tool_results_from = Agent_turn.last_tool_results_from
 
-(* Wiring coverage (Agent Core contract WP8 Inc1): the consumed [last_tool_results_from]
-   path routes [ToolResult] blocks through
-   [Canonical_tool.tool_result_of_block] and lowers the projection back to
-   [Types.tool_result]. A result carrying a [json] (WP4 structured) payload
-   must still lower to [Ok { content; _meta = None }] — the projection surfaces
-   [structured_content] without disturbing the existing string contract. *)
+(* Agent Core contract WP8 Inc1. [Agent_turn.last_tool_results_from] routes
+   [ToolResult] blocks through [Canonical_tool.tool_result_of_block] and lowers
+   the projection back to [Types.tool_result]. A result carrying a [json] (WP4
+   structured) payload must still lower to [Ok { content; _meta = None }] — the
+   projection surfaces [structured_content] without disturbing the existing
+   string contract.
+
+   This file used to re-export the function so the test below could name it
+   unqualified, and pipeline.ml re-exported that in turn. Neither rung had a
+   caller outside these tests, and the wording here ("the consumed path")
+   claimed a wiring this stage does not have: the consumer is Agent_turn
+   itself (agent_turn.ml:221). The test now names the function it pins. *)
 let%test "last_tool_results_from routes through canonical projection (with json)" =
   let msgs =
     [ { role = Tool
@@ -133,7 +138,7 @@ let%test "last_tool_results_from routes through canonical projection (with json)
       }
     ]
   in
-  match last_tool_results_from msgs with
+  match Agent_turn.last_tool_results_from msgs with
   | [ Ok { content = "ok payload"; _meta = _ }
     ; Error { message = "boom"; recoverable = false; error_class = None }
     ] -> true

--- a/packages/agent_core/lib/protocol/mcp.ml
+++ b/packages/agent_core/lib/protocol/mcp.ml
@@ -107,25 +107,6 @@ let list_tools t =
   | Ok tools -> Ok (List.map mcp_tool_of_agent_core_tool tools)
 ;;
 
-let decode_items field decode result_json =
-  let open Yojson.Safe.Util in
-  match result_json |> member field with
-  | `List items ->
-    let rec loop acc = function
-      | [] -> Ok (List.rev acc)
-      | item :: rest ->
-        (match decode item with
-         | Ok value -> loop (value :: acc) rest
-         | Error detail ->
-           Error
-             (Error.Serialization
-                (JsonParseError
-                   { detail = Printf.sprintf "MCP %s decode failed: %s" field detail })))
-    in
-    loop [] items
-  | _ -> Ok []
-;;
-
 let list_resources t =
   match Sdk_client.list_resources_all t.client with
   | Error detail -> Error (Error.Mcp (ToolListFailed { detail }))
@@ -444,7 +425,8 @@ let connect_all_best_effort ~sw ~mgr specs =
 [@@@coverage off]
 (* === Inline tests === *)
 
-let test_tool_result ?is_error ?structured_content content =
+(* Inline-test-only; the release profile strips the tests that call it. *)
+let[@warning "-32"] test_tool_result ?is_error ?structured_content content =
   let fields = [ "content", Sdk_types.tool_content_list_to_yojson content ] in
   let fields =
     match is_error with
@@ -558,38 +540,6 @@ let%test "merge_env overrides existing keys" =
   | _ -> false
 ;;
 
-let%test "decode_items empty list returns Ok []" =
-  let json = `Assoc [ "items", `List [] ] in
-  decode_items "items" (fun _ -> Ok "x") json = Ok []
-;;
-
-let%test "decode_items missing field returns Ok []" =
-  let json = `Assoc [] in
-  decode_items "items" (fun _ -> Ok "x") json = Ok []
-;;
-
-let%test "decode_items decodes successfully" =
-  let json = `Assoc [ "items", `List [ `String "a"; `String "b" ] ] in
-  match
-    decode_items
-      "items"
-      (fun j ->
-         match j with
-         | `String s -> Ok s
-         | _ -> Error "bad")
-      json
-  with
-  | Ok [ "a"; "b" ] -> true
-  | _ -> false
-;;
-
-let%test "decode_items propagates decode error" =
-  let json = `Assoc [ "items", `List [ `Int 42 ] ] in
-  match decode_items "items" (fun _ -> Error "decode failed") json with
-  | Error _ -> true
-  | Ok _ -> false
-;;
-
 let%test "text_of_tool_result skips non-text content" =
   let r : Sdk_types.tool_result =
     test_tool_result
@@ -606,26 +556,6 @@ let%test "mcp_tool_of_json description not a string defaults to empty" =
   match mcp_tool_of_json json with
   | Some tool -> tool.description = ""
   | None -> false
-;;
-
-let%test "decode_items with single successful item" =
-  let json = `Assoc [ "items", `List [ `String "only" ] ] in
-  match
-    decode_items
-      "items"
-      (fun j ->
-         match j with
-         | `String s -> Ok s
-         | _ -> Error "bad")
-      json
-  with
-  | Ok [ "only" ] -> true
-  | _ -> false
-;;
-
-let%test "decode_items field is not a list returns Ok []" =
-  let json = `Assoc [ "items", `String "not a list" ] in
-  decode_items "items" (fun _ -> Ok "x") json = Ok []
 ;;
 
 let%test "merge_env multiple overrides" =


### PR DESCRIPTION
main 의 `Trusted macOS arm64 Runtime` 잡이 실패하는 것을 고칩니다. 분석은 #28742 에 있습니다.

## 왜 병합 전에 안 걸렸나

그 잡은 protected main 의 push/dispatch 에서만 돕니다 (`ci.yml:1575-1584`). 그래서 #28714 의 PR CI 는 이 잡을 실행할 수 없었고, 체크가 전부 초록인 채로 병합됐습니다. main 에서 처음 돌아 실패했습니다.

## 원인

회귀가 아니라 구조입니다. 루트 `dune:19-25` 가 dev 와 release 양쪽에 같은 플래그를 겁니다.

```
(env (dev (flags (:standard -w +32 -warn-error +a)))
     (release (flags (:standard -w +32 -warn-error +a))))
```

dev 는 인라인 테스트를 함께 컴파일하므로 테스트만 부르는 값도 호출자가 있습니다. release 는 `ppx_inline_test` 가 테스트를 제거하므로 그 값이 마지막 호출자를 잃습니다. `dune:14-18` 이 원하는 신호가 바로 이것입니다.

> the build stops the moment a value loses its last caller

## 센서스

빌드 → 보고된 값 억제 → 재빌드를 반복해 세었습니다. **13 파일 24 값에서 수렴**하고, 그 뒤 release 빌드는 통과합니다. 다른 release 전용 결함은 없습니다.

## 값마다 판정했습니다

이름이 아니라 **딸린 테스트가 무엇을 지키는가**로 갈랐습니다.

**① 자기 자신만 검증하는 테스트를 가진 값 → 삭제**

`protocol/mcp.ml decode_items`. 딸린 테스트 6 개가 전부 `"decode_items empty list returns Ok []"` 식으로 그 함수만 봅니다. `git log -S` 결과도 agent_core 임포트 커밋 2 개뿐이라 이 저장소에서 호출자를 가진 적이 없습니다. 함수와 테스트를 함께 제거했습니다.

**② 살아 있는 함수 위의 래퍼 → 삭제하고 테스트가 실체를 부르게**

- `pipeline.ml` · `pipeline_stage_prepare.ml` 의 `last_tool_results_from` — 실체는 `agent_turn.ml:185` 이고 프로덕션 소비자는 같은 파일 221 행입니다. 두 파일이 이름만 재노출했고 소비자는 인라인 테스트뿐이라, 사다리 2 단을 걷고 테스트 5 개가 `Agent_turn.last_tool_results_from` 을 직접 부르게 했습니다. 고정되는 계약은 동일합니다.
- `complete_stream_state.ml finish` — `transition state (MessageDelta { stop_reason = Some _; usage = None })` 한 줄이었습니다. 테스트에 인라인해서 "끝낸다" 가 실제로 무슨 이벤트인지 보이게 했습니다.

**③ 다른 프로덕션 함수를 검증하는 테스트의 도구 → 남기고 억제 (20 건)**

fixture 생성기 · `~getenv` stub · 단언 술어입니다. 프로덕션이 안 부르는 게 정상입니다. `[@warning "-32"]` 와 이유 한 줄을 붙였습니다. #28714 이 `capabilities.ml` 에서 한 처리와 같습니다.

## 판정을 한 번 틀렸고 실행하다 잡았습니다

`single_tool_result` · `multiple_io_exn` · `catalog_declares_image_task` 를 처음엔 ① 로 분류해 삭제했습니다. 그런데 함께 사라지는 테스트가 이것들이었습니다.

```
- let%test "make_tool_results: small result passes through unchanged"
- let%test "classify_network_exn: Multiple_io prefers non-retryable kind"
- let%test "embedded catalog declares exact image providers"
```

`make_tool_results` · `classify_network_exn` · 임베디드 카탈로그를 검증하는 테스트였고, 셋은 그 안에서 도구로 쓰일 뿐이었습니다. ③ 이 맞아서 되돌렸습니다. 이름 모양만 보고 판정한 오류였고, 삭제를 실제로 해 보지 않았으면 그대로 남았을 겁니다.

## 주석 하나를 정정했습니다

`pipeline_stage_prepare.ml` 이 "the consumed `last_tool_results_from` path" 라고 적고 있었는데, 이 stage 는 그 값을 소비하지 않습니다. 소비자는 `Agent_turn` 자신입니다. 실제 소비자를 가리키도록 고쳤습니다.

## 검증

워크트리 루트 기준입니다.

```
release          exit=0  unused=0
dev @check       exit=0
agent_core tests exit=1  FAILED 1 / 3
```

테스트 실패 1 건은 `exact_output_plan.ml:621 canonical fingerprint is sensitive to the frozen response codec` 이고, **main 에서 같은 명령이 같은 줄로 실패합니다.** 이 PR 과 무관한 기존 실패라 범위 밖으로 둡니다.

주의: `dune --release` 는 `--root .` 를 함의합니다. `--root . --release` 로 부르면 `option '--root' cannot be repeated` 로 거부되니, 워크트리에서 재현하실 때 참고하세요.

## 남는 것

억제한 20 건은 "테스트가 쓰는 도구" 라는 판정이지 "영원히 있어야 한다" 는 뜻이 아닙니다. 그 테스트가 사라지면 값도 같이 사라져야 하는데, 그때는 이 신호가 다시 잡아 줍니다 — 억제는 값 단위라 파일 전체를 막지 않습니다.
