### PR TITLE
docs(rfc): RFC-0381 — 웹 검색은 폴백이 있는 척한다

### DIFF
--- a/docs/evidence/web-tools-bench-2026-08-15-r1.json
+++ b/docs/evidence/web-tools-bench-2026-08-15-r1.json
@@ -1,0 +1,59 @@
+{
+  "captured_at": "2026-08-15T21:54:52+0900",
+  "script": "scripts/bench-web-tools.py",
+  "server_health": {
+    "status": "ok",
+    "version": "0.22.0",
+    "commit": null,
+    "commit_source": null
+  },
+  "provider_direct": {
+    "searxng": [
+      {
+        "query": "OCaml 5.5 effect handlers tutorial",
+        "http_status": 200,
+        "elapsed_ms": 2398.4,
+        "bytes": 243,
+        "result_count": 0,
+        "engines": []
+      },
+      {
+        "query": "Claude Opus latest model context window",
+        "http_status": 200,
+        "elapsed_ms": 979.4,
+        "bytes": 9176,
+        "result_count": 10,
+        "engines": [
+          "duckduckgo"
+        ]
+      },
+      {
+        "query": "장마철 제습기 원리",
+        "http_status": 200,
+        "elapsed_ms": 1381.7,
+        "bytes": 21012,
+        "result_count": 10,
+        "engines": [
+          "duckduckgo"
+        ]
+      }
+    ],
+    "duckduckgo_html": {
+      "query": "OCaml 5.5 effect handlers tutorial",
+      "http_status": 202,
+      "elapsed_ms": 303.1,
+      "bytes": 14274,
+      "result_anchor_count": 0
+    },
+    "bing_rss": {
+      "query": "OCaml 5.5 effect handlers tutorial",
+      "http_status": 200,
+      "elapsed_ms": 215.3,
+      "bytes": 5285,
+      "item_count": 10
+    }
+  },
+  "mcp_tool": {
+    "error": "RuntimeError: HTTP 401: {\"jsonrpc\":\"2.0\",\"id\":null,\"error\":{\"code\":-32001,\"message\":\"[AuthError] Unauthorized: Authentication required. Use 'Authorization: Bearer <token>' header.\",\"data\":{\"auth_error_code\":\"missing_token\"}}}"
+  }
+}

--- a/docs/evidence/web-tools-bench-2026-08-15-r2.json
+++ b/docs/evidence/web-tools-bench-2026-08-15-r2.json
@@ -1,0 +1,56 @@
+{
+  "captured_at": "2026-08-15T21:57:07+0900",
+  "script": "scripts/bench-web-tools.py",
+  "server_health": {
+    "status": "ok",
+    "version": "0.22.0",
+    "commit": null,
+    "commit_source": null
+  },
+  "provider_direct": {
+    "searxng": [
+      {
+        "query": "OCaml 5.5 effect handlers tutorial",
+        "http_status": 200,
+        "elapsed_ms": 458.9,
+        "bytes": 265,
+        "result_count": 0,
+        "engines": []
+      },
+      {
+        "query": "Claude Opus latest model context window",
+        "http_status": 200,
+        "elapsed_ms": 202.7,
+        "bytes": 270,
+        "result_count": 0,
+        "engines": []
+      },
+      {
+        "query": "장마철 제습기 원리",
+        "http_status": 200,
+        "elapsed_ms": 152.9,
+        "bytes": 281,
+        "result_count": 0,
+        "engines": []
+      }
+    ],
+    "duckduckgo_html": {
+      "query": "OCaml 5.5 effect handlers tutorial",
+      "http_status": 202,
+      "elapsed_ms": 358.8,
+      "bytes": 14280,
+      "result_anchor_count": 0
+    },
+    "bing_rss": {
+      "query": "OCaml 5.5 effect handlers tutorial",
+      "http_status": 200,
+      "elapsed_ms": 265.3,
+      "bytes": 5790,
+      "item_count": 10
+    }
+  },
+  "mcp_auth_source": "env:MASC_MCP_TOKEN",
+  "mcp_tool": {
+    "error": "RuntimeError: HTTP 401: {\"jsonrpc\":\"2.0\",\"id\":null,\"error\":{\"code\":-32001,\"message\":\"[AuthError] Invalid token: Token mismatch\",\"data\":{\"auth_error_code\":\"invalid_token\"}}}"
+  }
+}

--- a/docs/evidence/web-tools-bench-2026-08-15-r3.json
+++ b/docs/evidence/web-tools-bench-2026-08-15-r3.json
@@ -1,0 +1,119 @@
+{
+  "captured_at": "2026-08-15T22:00:08+0900",
+  "script": "scripts/bench-web-tools.py",
+  "server_health": {
+    "status": "ok",
+    "version": "0.22.0",
+    "commit": null,
+    "commit_source": null
+  },
+  "provider_direct": {
+    "searxng": [
+      {
+        "query": "OCaml 5.5 effect handlers tutorial",
+        "http_status": 200,
+        "elapsed_ms": 430.9,
+        "bytes": 265,
+        "result_count": 0,
+        "engines": []
+      },
+      {
+        "query": "Claude Opus latest model context window",
+        "http_status": 200,
+        "elapsed_ms": 145.5,
+        "bytes": 270,
+        "result_count": 0,
+        "engines": []
+      },
+      {
+        "query": "장마철 제습기 원리",
+        "http_status": 200,
+        "elapsed_ms": 140.7,
+        "bytes": 281,
+        "result_count": 0,
+        "engines": []
+      }
+    ],
+    "duckduckgo_html": {
+      "query": "OCaml 5.5 effect handlers tutorial",
+      "http_status": 202,
+      "elapsed_ms": 381.1,
+      "bytes": 14292,
+      "result_anchor_count": 0
+    },
+    "bing_rss": {
+      "query": "OCaml 5.5 effect handlers tutorial",
+      "http_status": 200,
+      "elapsed_ms": 183.9,
+      "bytes": 5194,
+      "item_count": 10
+    }
+  },
+  "mcp_tool": {
+    "auth_source": "dashboard.token",
+    "auth_attempts_rejected": 1,
+    "initialize_ms": 3.7,
+    "server_info": {
+      "name": "masc",
+      "title": "MASC MCP Server",
+      "version": "0.22.0",
+      "description": "Multi-agent MCP server exposing MASC workspace state, tools, prompts, and resources.",
+      "websiteUrl": "https://github.com/yousleepwhen/masc",
+      "icons": [
+        {
+          "src": "data:image/svg+xml;utf8,%3Csvg%20xmlns='http:%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width='64'%20height='64'%20viewBox='0%200%2064%2064'%3E%3Crect%20width='64'%20height='64'%20rx='14'%20fill='%237C3AED'%2F%3E%3Ctext%20x='32'%20y='38'%20font-family='Arial,%20sans-serif'%20font-size='22'%20font-weight='700'%20text-anchor='middle'%20fill='%23F5F3FF'%3EMM%3C%2Ftext%3E%3C%2Fsvg%3E",
+          "mimeType": "image/svg+xml",
+          "sizes": [
+            "64x64"
+          ]
+        }
+      ]
+    },
+    "url": "http://localhost:8935/mcp",
+    "tool_count": 40,
+    "web_search_tool": null,
+    "web_fetch_tool": null,
+    "tool_names": [
+      "masc_add_task",
+      "masc_agent_card",
+      "masc_agent_timeline",
+      "masc_batch_add_tasks",
+      "masc_board_comment",
+      "masc_board_comment_vote",
+      "masc_board_curation_read",
+      "masc_board_curation_submit",
+      "masc_board_list",
+      "masc_board_post",
+      "masc_board_post_get",
+      "masc_board_reaction",
+      "masc_board_vote",
+      "masc_broadcast",
+      "masc_check",
+      "masc_goal_assign",
+      "masc_goal_list",
+      "masc_goal_transition",
+      "masc_goal_upsert",
+      "masc_heartbeat",
+      "masc_keeper_compact",
+      "masc_keeper_down",
+      "masc_keeper_list",
+      "masc_keeper_status",
+      "masc_keeper_up",
+      "masc_keeper_waiting_inventory",
+      "masc_messages",
+      "masc_plan_get",
+      "masc_plan_init",
+      "masc_plan_set_task",
+      "masc_plan_update",
+      "masc_schedule_cancel",
+      "masc_schedule_create",
+      "masc_schedule_get",
+      "masc_schedule_list",
+      "masc_start",
+      "masc_status",
+      "masc_tasks",
+      "masc_tool_help",
+      "masc_transition"
+    ]
+  }
+}

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -242,6 +242,7 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0377 | 같은 대화의 밀린 메시지는 한 턴이 함께 본다 (Conversation-Batched Stimulus Intake) | Draft | - |
 | 0378 | Code fact 는 태어날 때 주소를 받는다 — typed address, code-fact 전용 store, anchor 계약 통일 | Draft | - |
 | 0380 | 대기 나이는 홀더의 사이클을 알아야 한다 — work liveness 판정 축 정정 | Draft | - |
+| 0381 | 웹 검색은 폴백이 있는 척한다 — provider 계약 정정과 토큰 예산 도입 | Draft | - |
 | RFC-0034d-stale-agent-sync | d — release_stale_claims agent-side sync | Draft | - |
 | RFC-async-log-sink-durable-append-offload | Offload the structured-log durable append off the emitting fiber | Draft | - |
 | RFC-checkpoint-pinned-root-containment | Immutable boot-pinned root capability for checkpoint containment | Draft | - |

--- a/docs/rfc/RFC-0381-web-tool-provider-contract-and-token-budget.md
+++ b/docs/rfc/RFC-0381-web-tool-provider-contract-and-token-budget.md
@@ -1,0 +1,230 @@
+---
+rfc: "0381"
+title: "웹 검색은 폴백이 있는 척한다 — provider 계약 정정과 토큰 예산 도입"
+status: Draft
+created: 2026-08-15
+updated: 2026-08-15
+author: vincent + claude
+supersedes: []
+superseded_by: null
+related: ["0189", "21228", "5610"]
+implementation_prs: []
+---
+
+# RFC-0381: 웹 검색은 폴백이 있는 척한다
+
+## 0. Summary
+
+`masc_web_search`는 7개 provider의 폴백 체인을 광고한다. 실측하면 살아있는 provider는 **하나**다. 나머지는 자격 미달로 걸러지거나(API 키 없음), 응답은 200을 주는데 결과가 0~1건이다. 즉 폴백이 존재하는 게 아니라 **폴백의 외형**이 존재한다. 유일하게 동작하는 SearXNG는 Docker 컨테이너를 요구하므로, 컨테이너가 내려가면 검색 기능은 조용히 0건으로 수렴한다.
+
+같은 도구의 `includeContent` 경로는 본문을 **두 번** 싣는다. `results[].page_content`와 `content_text`가 같은 내용을 각각 담고, `Tool_result.message`는 payload 전체를 직렬화해 keeper에게 넘긴다.
+
+이 RFC는 세 가지를 한다.
+
+1. **죽은 provider를 척살한다.** 자격 없는 provider를 조용한 폴백으로 남기지 않고, 자격 미달은 `Config` 실패로 정직하게 드러낸다.
+2. **검색과 추출의 백엔드를 분리한다.** 무료 검색(SearXNG)과 유료·고품질 추출을 독립적으로 고를 수 있게 한다. Hermes가 쓰는 축과 같다.
+3. **토큰 예산을 도구 계약에 넣는다.** 절단을 휴리스틱이 아니라 결정론적 규칙으로 고정하고, 전문은 파일로 내보내 경로만 반환한다.
+
+Brave LLM Context API를 **옵션 provider**로 추가한다. 기본값으로 만들지 않는다 — 키가 없는 환경에서도 제품이 서야 한다.
+
+## 1. 원칙 → 설계 강제
+
+| 원칙 | 이 RFC에서의 강제 |
+|---|---|
+| 7. 게이트 | 신규 스케줄링 게이트 0. provider 자격 판정은 이미 있는 `provider_has_credentials`를 그대로 쓴다. 추가하는 것은 게이트가 아니라 **실패의 가시화**다 — 지금은 자격 미달이 조용한 폴백으로 흡수되어 keeper가 "검색했는데 결과가 없다"와 "검색 자체가 불가능하다"를 구분하지 못한다 |
+| 8. 레거시 | `Ddg`·`Bing_rss` variant를 코드에서 삭제한다. deprecated 주석·호환 reader·이중 경로를 남기지 않는다. `content_text`/`page_content` 중복도 hard cut이며 둘 중 하나만 남는다 |
+| 9. 매직넘버 | 현재 흩어진 리터럴(`4_000`, `20_000`, `50_000`, `2_000_000`, 캐시 30.0초, 타임아웃 15초)을 명명 상수로 올리고 설정 통로에 노출한다. 새 임계값은 만들지 않는다 |
+| 10. 휴리스틱 분류 | provider 판별은 이미 variant다. Brave LLM Context는 응답 구조가 `(title, url, snippet)`과 다르므로 **기존 hit 타입에 욱여넣지 않고** 별도 변형으로 받는다. 문자열로 형태를 추측하지 않는다 |
+| 19. 재사용 | 추출 파이프라인을 새로 쓰지 않는다. `select_readable_nodes`(article→main→body)와 `clean_search_text`가 이미 있다. 절단 규칙만 결정론적으로 고정한다 |
+| 20. 테스트 | acceptance는 Feature 왕복(§5)이다. provider 파서 단위 테스트를 늘리는 대신, keeper가 검색→추출→인용까지 한 바퀴 도는 경로를 검증한다 |
+| 23. 경로 | 오프로드 파일은 `<basepath>` 하위에 쓴다. 절대 경로를 코드에 박지 않는다 |
+| 24. 설정 통로 | 새 환경변수를 발명하지 않는다. `keeper_runtime_setting_registry`에 등록하고, 비밀이 아닌 값은 `Toml_and_env`, API 키는 `Env_only`로 노출한다. 키는 커밋되는 `config/runtime.toml`에 들어가지 않는다 |
+| 25. IDE plane | Hermes·OpenClaw 흡수 항목의 첫 실행이다. 두 제품이 공유하는 축(capability별 backend 분리, 결정론적 절단, 오프로드)을 채택하고 채택하지 않은 축은 §6에 남긴다 |
+
+## 2. 문제 — 실측 (2026-08-15)
+
+### 2.1 폴백은 외형만 있다
+
+`lib/tool_misc_web_search.ml:229`의 기본 순서는 자격 있는 provider만 남긴 뒤 무자격 두 개를 꼬리에 붙인다.
+
+```ocaml
+let default_provider_order () =
+  [ Searxng; Brave; Tavily; Exa; Bing_api ]
+  |> List.filter provider_has_credentials
+  |> fun official -> official @ [ Ddg; Bing_rss ]
+```
+
+현재 환경에 설정된 자격은 `MASC_SEARXNG_URL` 하나뿐이다. 따라서 실제 체인은 `[Searxng; Ddg; Bing_rss]` 3단이다. 세 provider를 같은 질의로 직접 호출한 결과:
+
+| Provider | HTTP | 결과 수 | 소요 | 판정 |
+|---|---|---|---|---|
+| SearXNG (`localhost:8888`) | 200 | 20건 | 1.81초 | 정상. 단 Docker 컨테이너 `masc-searxng` 필요 |
+| DuckDuckGo HTML (`html.duckduckgo.com`) | **202** | **0건** (`result__a` 매치 없음) | 0.31초 | 봇 차단 페이지. `<link rel=canonical href=https://duckduckgo.com/>`만 반환 |
+| Bing RSS (`bing.com/search?format=rss`) | 200 | **1건** (`<item>`) | — | 사실상 무응답 |
+
+SearXNG 응답의 `engine` 필드는 전부 `brave`였다. 지금도 Brave 인덱스를 쓰고 있으며, 그 앞에 Docker 한 겹이 끼어 있다.
+
+결과: 컨테이너가 내려간 순간 검색은 0건 또는 1건이 된다. 이때 도구는 실패하지 않고 **빈 성공**을 반환한다. keeper는 "웹에 정보가 없다"고 결론 내린다.
+
+### 2.2 같은 판단이 이미 한 번 있었고 main에 닿지 못했다
+
+`8a1bd382e9` (2026-06-10, `qa-king/task-718-websearch-backend-swap`):
+
+```
+task-718: remove Bing_rss from default provider fallback chain
+
+Bing RSS was the last-resort fallback in default_provider_order()
+tail (@ [Ddg; Bing_rss]). Brave/Tavily/Exa fetch functions already
+exist — they were just shadowed by the hardcoded Bing_rss tail.
+```
+
+`git merge-base --is-ancestor 8a1bd382e9 origin/main` → **false**. 진단은 정확했고 diff는 한 줄이었으나 main에 도달하지 않았다. 이 RFC는 그 판단의 두 번째 시도이며, 이번에는 `Ddg`까지 포함해 근본에서 자른다.
+
+### 2.3 본문이 두 번 실린다
+
+`lib/tool_misc_web_enrichment.ml:288-304`은 enrich된 hits를 `results`에 넣고, **같은 hits를 렌더링한 문자열**을 `content_text`로 또 넣는다.
+
+```ocaml
+[ "results", `List enriched_hits
+; ...
+; ( "content_text",
+    `String (render_content_text ... enriched_hits) )
+]
+```
+
+`lib/tool_types/tool_result.ml:128`에서 성공 결과의 message는 payload 전체 직렬화다.
+
+```ocaml
+let message : result -> string = function
+  | Completed { data; _ } | Deferred { data; _ } ->
+    (match data with
+     | `String s -> s
+     | other -> Yojson.Safe.to_string other)
+```
+
+따라서 keeper가 받는 문자열에는 본문이 정확히 2회 들어가며, JSON 이스케이프(`\n` 2자, `"` 2자)가 얹힌다. 기본값(`limit` 5 × `contentMaxChars` 4,000)으로 40,000자, 상한(20,000자)이면 200,000자가 한 턴에 투입된다.
+
+### 2.4 그 밖의 실측
+
+- **캐시가 캐시 역할을 못 한다.** `MASC_WEB_SEARCH_CACHE_TTL_SEC` 기본 30.0초(`lib/config/env_config_runtime.ml:291`). Hermes·OpenClaw는 15분이다. 30초는 같은 턴 안의 재호출조차 놓친다.
+- **API 키가 설정 SSOT 밖에 있다.** `BRAVE_SEARCH_API_KEY`·`TAVILY_API_KEY`·`EXA_API_KEY`·`BING_SEARCH_API_KEY`는 `env_present`로 raw env를 직접 읽으며 `keeper_runtime_setting_registry`에 등록되어 있지 않다. `web_search` 카테고리 등록 항목은 6개뿐이다.
+- **`web_fetch`에 목적지 제한이 없다.** `validate_redirect_target`(`lib/tool_misc_web_fetch.ml:348`)은 http/https 스킴만 검사한다. loopback·사설 대역·링크로컬(`169.254.0.0/16`) 차단이 없어, keeper가 읽은 페이지의 지시에 따라 `http://127.0.0.1:8935`(MASC 자신의 API)를 fetch할 수 있다.
+
+## 3. 설계
+
+### 3.1 provider 계약: 조용한 폴백 제거
+
+`Ddg`·`Bing_rss` variant를 타입에서 삭제한다. 파서(`parse_ddg_html`, `parse_bing_rss_items`, `looks_like_rss_payload`)와 그 테스트도 함께 삭제한다.
+
+자격 있는 provider가 하나도 없으면 빈 성공이 아니라 `Config` 실패를 반환한다. 이는 "unknown → permissive default" 안티패턴의 역방향 정정이다: 설정되지 않은 상태를 편리한 기본값으로 흡수하지 않는다.
+
+```ocaml
+(* 자격 필터 후 비었으면 빈 결과가 아니라 설정 실패 *)
+match provider_order () with
+| [] -> Error (Config "no web search provider is configured")
+| providers -> run_chain providers
+```
+
+### 3.2 capability별 backend 분리
+
+Hermes의 축을 그대로 채택한다. 검색과 추출은 서로 다른 provider가 잘한다.
+
+| 설정 키 | 노출 | 용도 |
+|---|---|---|
+| `web_search.provider_order` | `Toml_and_env` | 검색 체인 (기존 키 재사용) |
+| `web_fetch.extract_provider` | `Toml_and_env` | 추출 backend. 미설정 시 내장 Readability |
+| `web_search.brave_api_key` 외 키 | `Env_only` | 시크릿. TOML에 쓰지 않는다 |
+
+내장 추출(`select_readable_nodes`)은 기본값으로 남는다. 추출 backend는 그것이 실패했을 때가 아니라 **명시적으로 지정됐을 때** 쓴다 — 자동 폴백을 만들면 §3.1에서 제거한 조용한 흡수가 다시 생긴다.
+
+### 3.3 Brave LLM Context를 옵션 provider로
+
+`GET /v1/llm/context`는 URL+스니펫이 아니라 관련도 순위가 매겨진 추출 청크를 반환하며, **토큰 예산이 요청 파라미터**다.
+
+| 파라미터 | 기본 | 범위 |
+|---|---|---|
+| `maximum_number_of_tokens` | 8192 | 1024–32768 |
+| `maximum_number_of_tokens_per_url` | 4096 | 512–8192 |
+| `maximum_number_of_urls` | 20 | 1–50 |
+
+응답 형태가 `(title, url, snippet)`과 다르므로 기존 `normalized_hit`으로 다운캐스트하지 않는다. 다운캐스트하면 이 provider를 쓰는 이유(사전 추출된 청크)가 사라진다. 검색 결과를 두 변형으로 받는다.
+
+```ocaml
+type search_payload =
+  | Hits of normalized_hit list      (* 기존 provider *)
+  | Grounded of grounded_context     (* Brave LLM Context *)
+```
+
+키가 없으면 자격 필터에서 빠지므로 이 경로는 아예 열리지 않는다. 기본값이 아니다.
+
+### 3.4 결정론적 절단과 오프로드
+
+절단은 LLM 요약이 아니라 규칙이다. Hermes의 head/tail 분할을 채택한다.
+
+- 상한 초과 시 앞 75% + 뒤 25%를 마크다운 줄 경계에서 자른다.
+- 잘린 자리에 `[TRUNCATED]` 표시와 **전문 파일 경로**를 남긴다. 파일은 `<basepath>` 하위에 쓴다.
+- keeper는 필요할 때 그 경로를 읽는다. 전문을 컨텍스트에 밀어 넣지 않는다.
+
+`content_text`와 `page_content` 중 **`content_text`만 남긴다**. 이유: keeper가 실제로 읽는 것은 렌더링된 텍스트이고, `results[].page_content`는 같은 내용을 구조화된 형태로 중복 보관할 뿐 별도 소비자가 없다.
+
+### 3.5 목적지 제한 (`web_fetch`)
+
+`validate_redirect_target`을 스킴 검사에서 목적지 검사로 확장한다. 최초 요청과 각 리다이렉트 홉 모두에 적용한다.
+
+- 차단: loopback(`127.0.0.0/8`, `::1`), 사설(`10/8`, `172.16/12`, `192.168/16`), 링크로컬(`169.254/16`, `fe80::/10`), `0.0.0.0`
+- SearXNG는 `localhost:8888`이지만 `web_search`의 provider 경로이지 `web_fetch`의 사용자 입력 경로가 아니므로 영향이 없다
+
+원칙 #7("게이트는 목표 도달 이후")과의 관계를 명시한다. 이것은 스케줄링·admission 게이트가 아니라 **외부 입력이 내부 주소로 향하는 것을 막는 경계**다. keeper가 웹에서 읽은 내용이 곧 다음 도구 인자가 되는 구조에서, 이 경계가 없으면 외부 문서가 내부 API 호출을 지시할 수 있다.
+
+## 4. 구현 분할 (Stacked PR, 각 ≤ 20k token)
+
+| PR | 범위 | 새 기능 |
+|---|---|---|
+| PR-1 | 본문 중복 제거(`page_content` 삭제), 캐시 TTL 기본값 정정, 매직넘버 명명 | 없음 (순수 결함 수정) |
+| PR-2 | `Ddg`·`Bing_rss` 및 파서·테스트 삭제, 무자격 시 `Config` 실패 | 없음 (hard cut) |
+| PR-3 | API 키 4종 `Env_only` registry 등록, `web_fetch.extract_provider` 추가 | 설정 통로 |
+| PR-4 | Brave LLM Context provider + `search_payload` 변형 | 옵션 provider |
+| PR-5 | Ollama `web_search`/`web_fetch` provider | 옵션 provider |
+| PR-6 | 결정론적 절단 + `<basepath>` 오프로드 | 토큰 예산 |
+| PR-7 | `web_fetch` 목적지 제한 | 경계 |
+
+PR-1·PR-2가 먼저인 이유: 새 provider를 붙이기 전에 중복 전송과 가짜 폴백을 없애야 이후 PR의 효과를 측정할 수 있다.
+
+## 5. Acceptance — Feature 왕복
+
+함수 단위가 아니라 keeper가 도는 한 바퀴로 검증한다.
+
+1. **자격 없음이 드러난다.** 모든 provider 자격을 제거한 상태에서 `masc_web_search` 호출 → 빈 성공이 아니라 `Config` 실패. keeper 로그에 설정 부재가 남는다.
+2. **컨테이너가 내려가도 거짓 성공이 없다.** `masc-searxng` 중지 후 호출 → 0건 성공이 아니라 provider 실패로 종료.
+3. **본문이 한 번만 실린다.** `includeContent=true` 호출의 payload 직렬화 길이가 PR-1 전후로 비교된다. 같은 질의·같은 hit 수에서 감소분을 기록한다.
+4. **절단이 결정론적이다.** 상한을 넘는 페이지에서 head/tail 비율과 오프로드 경로가 재현된다. 같은 입력 → 같은 출력.
+5. **목적지 제한이 동작한다.** `http://127.0.0.1:8935/health` fetch → `Workflow_rejection`. 리다이렉트로 우회하는 경로도 각 홉에서 차단.
+
+증거는 로그·실측 수치로 저장소에 남긴다(원칙 #22).
+
+## 6. 채택하지 않은 것
+
+- **LLM 보조 모델로 추출 내용을 요약하는 경로.** 검색 스니펫 일부가 Hermes에 그런 기능이 있다고 기술하나, 공식 문서에는 없고 결정론적 절단만 기술되어 있다. 절단을 비결정론으로 바꾸면 같은 입력이 같은 출력을 내지 않는다. 채택하지 않는다.
+- **Firecrawl·Tavily·Exa를 기본 경로로 승격.** 키가 필요한 provider를 기본으로 두면 키 없는 환경에서 제품이 서지 않는다. 자격 기반 필터를 유지한다.
+- **추출 실패 시 자동 provider 폴백.** §3.1에서 제거한 조용한 흡수와 같은 구조다. 명시 설정만 쓴다.
+- **`web_crawl` 도구 추가.** Hermes에는 있으나 현재 MASC에 소비자가 없다. 소비자가 생기면 그때 만든다.
+
+## 7. 근거
+
+**코드 (2026-08-15, `origin/main` 80747590c9)**
+- `lib/tool_misc_web_search.ml:229` — `default_provider_order`
+- `lib/tool_misc_web_enrichment.ml:288-304` — 본문 이중 적재
+- `lib/tool_types/tool_result.ml:128` — payload 전체 직렬화
+- `lib/tool_misc_web_fetch.ml:348` — 스킴만 검사하는 리다이렉트 검증
+- `lib/config/env_config_runtime.ml:287-293` — 타임아웃 15초 / 캐시 30초
+- `lib/config/keeper_runtime_setting_registry.ml:569-597` — `web_search` 카테고리 6항목
+- `8a1bd382e9` — 미머지 선행 판단
+
+**외부 (2026-08-15 확인)**
+- Hermes Agent, Web Search & Extract — `web_search`/`web_extract`, capability별 backend 분리, `extract_char_limit` 기본 15,000자(2,000–500,000), head 75%/tail 25% 절단 + `[TRUNCATED]` + 파일 경로, 2MB 캡. <https://hermes-agent.nousresearch.com/docs/user-guide/features/web-search>
+- OpenClaw, Web Tools — Brave 기본 + Perplexity 옵션, Readability 우선 후 Firecrawl, 사설/내부 호스트 차단 + 리다이렉트 재검사, 캐시 15분. 로컬 사본 `~/me/workspace/yousleepwhen/openclaw/docs/tools/web.md`
+- Brave Search, LLM Context API — `GET /v1/llm/context`, `maximum_number_of_tokens` 기본 8192(1024–32768), `maximum_number_of_tokens_per_url` 기본 4096(512–8192), $5/1,000 요청. <https://api-dashboard.search.brave.com/api-reference/summarizer/llm_context/get>
+- Ollama — `POST /api/web_search`(`max_results` 기본 5, 최대 10), `POST /api/web_fetch`(title/content/links, 마크다운), 무료 계정 API 키. <https://docs.ollama.com/capabilities/web-search>
+- AIMultiple 벤치마크 — Agent Score(= 평균 관련 건수 × 품질 1–5): Brave 14.89 / Firecrawl 14.58 / Exa 14.39 / Parallel Pro 14.21 / Tavily 13.67 / Perplexity 12.96 / SerpAPI 12.28. 레이턴시 Brave 669ms ~ Parallel Pro 13.6초. **평가 시점은 페이지 내 표기가 엇갈려 확인 필요.** <https://aimultiple.com/agentic-search>
+
+Confidence: 코드·로컬 실측 High. 외부 API 파라미터 High(공식 문서). 벤치마크 순위 Medium(단일 출처, 시점 불명확).

--- a/docs/rfc/RFC-0381-web-tool-provider-contract-and-token-budget.md
+++ b/docs/rfc/RFC-0381-web-tool-provider-contract-and-token-budget.md
@@ -125,6 +125,13 @@ match provider_order () with
 | providers -> run_chain providers
 ```
 
+구현 주(PR-2 반영): `Config`는 per-provider 오류 변형이고 aggregate 경계는
+RFC-0189 관례대로 `Runtime_failure`를 유지한다 — `search_impl`의 반환
+시그니처가 이미 `(_, string) result`라 aggregate를 typed로 올리는 것은 이
+RFC 범위 밖의 리팩터다. 빈 체인은 해결 방법을 담은
+`no_provider_configured_message`로 `Runtime_failure`가 되며, 위 의사코드의
+의도(빈 성공 금지 + 안내 동봉)는 그대로다.
+
 ### 3.2 capability별 backend 분리
 
 Hermes의 축을 그대로 채택한다. 검색과 추출은 서로 다른 provider가 잘한다.

--- a/docs/rfc/RFC-0381-web-tool-provider-contract-and-token-budget.md
+++ b/docs/rfc/RFC-0381-web-tool-provider-contract-and-token-budget.md
@@ -8,7 +8,7 @@ author: vincent + claude
 supersedes: []
 superseded_by: null
 related: ["0189", "21228", "5610"]
-implementation_prs: []
+implementation_prs: ["28752", "28753", "28754", "28755", "28756", "28757", "28758"]
 ---
 
 # RFC-0381: 웹 검색은 폴백이 있는 척한다

--- a/reports/web-tools-bench-2026-08-15.html
+++ b/reports/web-tools-bench-2026-08-15.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>MASC Web Tools 벤치마크 — 반복 실측 보고서</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font-family: -apple-system, "Apple SD Gothic Neo", sans-serif; max-width: 60rem;
+         margin: 2rem auto; padding: 0 1rem; line-height: 1.6; }
+  h1 { font-size: 1.4rem; } h2 { font-size: 1.15rem; margin-top: 2rem; }
+  table { border-collapse: collapse; width: 100%; margin: .8rem 0; font-size: .92rem; }
+  th, td { border: 1px solid color-mix(in srgb, currentColor 25%, transparent);
+           padding: .35rem .6rem; text-align: left; vertical-align: top; }
+  th { background: color-mix(in srgb, currentColor 8%, transparent); }
+  code { font-family: ui-monospace, monospace; font-size: .88em;
+         background: color-mix(in srgb, currentColor 8%, transparent);
+         padding: .05rem .3rem; border-radius: 3px; }
+  .dead { color: #c0392b; font-weight: 600; }
+  .note { font-size: .88rem; opacity: .85; }
+  .verdict { border-left: 4px solid color-mix(in srgb, currentColor 40%, transparent);
+             padding: .2rem 1rem; margin: 1rem 0; }
+</style>
+</head>
+<body>
+
+<h1>MASC Web Tools 벤치마크 — 반복 실측 보고서</h1>
+<p class="note">
+측정 스크립트: <code>scripts/bench-web-tools.py</code> ·
+원본 증거: <code>docs/evidence/web-tools-bench-2026-08-15-r{1,2,3}.json</code> ·
+대상 서버: <code>localhost:8935</code> (masc 0.22.0, health commit <code>65d21caeee</code>) ·
+관련 설계: <code>docs/rfc/RFC-0381</code> (PR #28747)
+</p>
+
+<h2>Iteration 1 — Baseline (2026-08-15, 코드 변경 전)</h2>
+
+<div class="verdict">
+<p><strong>판정 4줄.</strong></p>
+<ol>
+<li>실제 폴백 체인 3단(SearXNG → DuckDuckGo → Bing RSS) 중 안정적으로 결과를 주는 provider는 <strong>0개</strong>다. 유일한 정식 provider인 SearXNG는 40분 사이 20건 → 10건 → <span class="dead">0건 전면 붕괴</span>로 퇴행했고, 그동안 HTTP는 계속 200이었다.</li>
+<li>SearXNG의 붕괴는 Docker와 무관했다 — 컨테이너는 <code>Up 2 hours</code> 상태에서 빈 결과를 반환했다(상류 엔진 소진). 즉 실패 층이 둘이다: 컨테이너 다운, 그리고 컨테이너 생존 중 상류 소진. 어느 쪽이든 도구는 <strong>빈 성공</strong>으로 보고한다.</li>
+<li>무자격 폴백 둘 중 DuckDuckGo HTML은 3회 전부 봇 차단(202, 결과 앵커 0), Bing RSS는 1건→10건→10건으로 쿼리·시점에 따라 요동한다. 폴백이 아니라 도박이다.</li>
+<li>외부 MCP surface(<code>:8935/mcp</code>)에는 web 도구가 <strong>노출되지 않는다</strong>(40개 전부 coordination 도구). WebSearch/WebFetch는 keeper 내부 전용이므로, 도구 레벨 검증은 외부 호출이 아니라 CI feature test + keeper 턴 경유로만 가능하다.</li>
+</ol>
+</div>
+
+<h2>표 1. SearXNG 시계열 붕괴 (같은 인스턴스, 40분)</h2>
+<table>
+<tr><th>시각</th><th>쿼리</th><th>HTTP</th><th>결과 수</th><th>engine</th><th>지연</th></tr>
+<tr><td>21:20경 (수동 프로브)</td><td>OCaml Eio release notes</td><td>200</td><td>20</td><td>brave</td><td>1,809ms</td></tr>
+<tr><td>21:54 (r1)</td><td>OCaml 5.5 effect handlers tutorial</td><td>200</td><td class="dead">0</td><td>—</td><td>2,398ms</td></tr>
+<tr><td>21:54 (r1)</td><td>Claude Opus latest model context window</td><td>200</td><td>10</td><td>duckduckgo</td><td>979ms</td></tr>
+<tr><td>21:54 (r1)</td><td>장마철 제습기 원리</td><td>200</td><td>10</td><td>duckduckgo</td><td>1,382ms</td></tr>
+<tr><td>21:57 (r2)</td><td>3개 쿼리 전부</td><td>200</td><td class="dead">0 / 0 / 0</td><td>—</td><td>153–459ms</td></tr>
+<tr><td>22:00 (r3)</td><td>3개 쿼리 전부</td><td>200</td><td class="dead">0 / 0 / 0</td><td>—</td><td>141–431ms</td></tr>
+</table>
+<p class="note">21:20 행은 bench 스크립트 도입 전 같은 엔드포인트에 대한 세션 수동 프로브. 이후 행은 전부
+<code>bench-web-tools.py</code> 산출 JSON. 빈 응답일수록 빨라지는 것(2.4s→0.14s)은 상류 엔진이
+즉시 거절하고 있다는 뜻이다. engine 필드가 brave→duckduckgo→없음으로 옮겨간 것은 SearXNG가
+상류를 순차 소진하는 과정.</p>
+
+<h2>표 2. 무자격 폴백 실측 (3회 반복)</h2>
+<table>
+<tr><th>Provider</th><th>회차</th><th>HTTP</th><th>결과</th><th>지연</th><th>판정</th></tr>
+<tr><td rowspan="3">DuckDuckGo HTML</td><td>수동</td><td>202</td><td class="dead">앵커 0</td><td>310ms</td><td rowspan="3" class="dead">3/3 봇 차단. 사망</td></tr>
+<tr><td>r1</td><td>202</td><td class="dead">앵커 0</td><td>303ms</td></tr>
+<tr><td>r3</td><td>202</td><td class="dead">앵커 0</td><td>381ms</td></tr>
+<tr><td rowspan="3">Bing RSS</td><td>수동</td><td>200</td><td>item 1</td><td>—</td><td rowspan="3">쿼리·시점 따라 1↔10건 요동. 신뢰 불가</td></tr>
+<tr><td>r1</td><td>200</td><td>item 10</td><td>215ms</td></tr>
+<tr><td>r3</td><td>200</td><td>item 10</td><td>184ms</td></tr>
+</table>
+<p class="note">이전 세션 실측에서 "Bing RSS 1건"으로 단정했던 것은 이번 3회 반복으로 정정한다 —
+죽어있는 게 아니라 <em>예측 불가능</em>하다. 제거 근거는 사망이 아니라 불안정성과,
+자격 있는 provider를 그림자에 가리는 구조다(미머지 선행 판단 <code>8a1bd382e9</code>와 동일 결론).</p>
+
+<h2>표 3. MCP 외부 surface 실측</h2>
+<table>
+<tr><th>항목</th><th>실측값</th></tr>
+<tr><td>인증</td><td>Bearer 필수. 세션의 낡은 <code>MASC_MCP_TOKEN</code> env는 mismatch로 거부(1회),
+<code>~/me/.masc/auth/dashboard.token</code>(최신 mtime)으로 성공 — 토큰 회전 실증</td></tr>
+<tr><td>initialize</td><td>3.7ms, 프로토콜 2025-06-18, 세션 ID 필수, <code>Accept</code>에 event-stream 누락 시 400</td></tr>
+<tr><td>tools/list</td><td>40개 — task/board/goal/keeper/schedule/broadcast 계열 전부.
+<strong>WebSearch/WebFetch 계열 이름 0개</strong> (전체 목록은 r3 JSON <code>tool_names</code>)</td></tr>
+</table>
+<p class="note">함의: web 도구의 토큰 소비(payload 크기·중복 계수)는 외부 MCP 호출로 측정할 수 없다.
+Iteration 2부터는 (a) CI feature test가 직렬화 길이를 핀으로 고정하고,
+(b) keeper 턴을 실제로 태워 대시보드에서 관측하는 두 경로로 잰다.</p>
+
+<h2>코드 레벨 확정 사실 (측정이 아니라 코드 판독, <code>origin/main</code> 80747590c9)</h2>
+<table>
+<tr><th>사실</th><th>위치</th></tr>
+<tr><td><code>includeContent=true</code> 시 본문이 <code>results[].page_content</code>와 <code>content_text</code>에 이중 적재</td>
+<td><code>lib/tool_misc_web_enrichment.ml:288-304</code></td></tr>
+<tr><td>keeper가 받는 문자열은 payload 전체 직렬화 — 이중 적재가 그대로 2배 토큰</td>
+<td><code>lib/tool_types/tool_result.ml:128</code></td></tr>
+<tr><td>검색 캐시 TTL 기본 30초 (Hermes·OpenClaw는 15분)</td>
+<td><code>lib/config/env_config_runtime.ml:291</code></td></tr>
+<tr><td>provider 자격 필터 후 무자격 2종을 꼬리에 상시 부착</td>
+<td><code>lib/tool_misc_web_search.ml:229</code></td></tr>
+</table>
+
+<h2>다음 반복</h2>
+<ul>
+<li><strong>Iteration 2</strong> (PR-1·PR-2 머지 후): 이중 적재 제거 전/후 payload 길이를 CI feature test 수치로 비교. SearXNG 회복 여부 재실측.</li>
+<li><strong>Iteration 3</strong> (PR-4·PR-5 후): Brave LLM Context / Ollama provider 경로 지연·결과 품질, keeper 턴 경유 실측.</li>
+<li>매 반복은 <code>python3 scripts/bench-web-tools.py -o docs/evidence/web-tools-bench-&lt;date&gt;-rN.json</code> 실행 후 이 문서에 섹션 추가.</li>
+</ul>
+
+</body>
+</html>

--- a/scripts/bench-web-tools.py
+++ b/scripts/bench-web-tools.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Measure the live web tool surface: provider endpoints and MCP tool calls.
+
+Captures, per run, into one JSON evidence file:
+  - provider_direct: SearXNG / DuckDuckGo HTML / Bing RSS reachability,
+    latency, and result counts measured against the real endpoints.
+  - mcp_tool: masc web search/fetch calls against the running MASC server
+    (default http://localhost:8935/mcp), with wall time, serialized payload
+    bytes, and the body-duplication factor of the includeContent path
+    (page_content chars vs content_text chars carried in one payload).
+
+Stdlib only. Every failure is recorded as data, never swallowed:
+each probe result carries either measurements or an "error" field.
+
+Usage:
+  python3 scripts/bench-web-tools.py -o docs/evidence/web-tools-bench.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import re
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+SEARXNG_URL = os.environ.get("MASC_SEARXNG_URL", "http://localhost:8888")
+MCP_URL = os.environ.get("MASC_MCP_URL", "http://localhost:8935/mcp")
+HEALTH_URL = os.environ.get("MASC_HEALTH_URL", "http://localhost:8935/health")
+BROWSER_UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
+)
+TIMEOUT_SEC = 25
+
+QUERIES = [
+    "OCaml 5.5 effect handlers tutorial",
+    "Claude Opus latest model context window",
+    "장마철 제습기 원리",
+]
+FETCH_URL = "https://ocaml.org/manual/5.4/index.html"
+
+
+def http(
+    url: str,
+    body: bytes | None = None,
+    headers: dict[str, str] | None = None,
+) -> tuple[int, dict[str, str], bytes, float]:
+    """One HTTP round trip. Returns (status, headers, body, elapsed_ms)."""
+    req = urllib.request.Request(url, data=body, headers=headers or {})
+    start = time.monotonic()
+    try:
+        with urllib.request.urlopen(req, timeout=TIMEOUT_SEC) as resp:
+            payload = resp.read()
+            elapsed = (time.monotonic() - start) * 1000.0
+            return resp.status, dict(resp.headers.items()), payload, elapsed
+    except urllib.error.HTTPError as err:
+        payload = err.read()
+        elapsed = (time.monotonic() - start) * 1000.0
+        return err.code, dict(err.headers.items()), payload, elapsed
+
+
+def probe(fn, *args) -> dict[str, Any]:
+    """Run one probe; transport-level failure becomes an error record."""
+    try:
+        return fn(*args)
+    except Exception as exn:  # record, never swallow
+        return {"error": f"{type(exn).__name__}: {exn}"}
+
+
+def probe_searxng(query: str) -> dict[str, Any]:
+    url = f"{SEARXNG_URL}/search?q={urllib.parse.quote(query)}&format=json"
+    status, _, body, ms = http(url)
+    record: dict[str, Any] = {
+        "query": query,
+        "http_status": status,
+        "elapsed_ms": round(ms, 1),
+        "bytes": len(body),
+    }
+    parsed = json.loads(body)
+    results = parsed.get("results", [])
+    engines = sorted({r.get("engine", "?") for r in results})
+    record.update({"result_count": len(results), "engines": engines})
+    return record
+
+
+def probe_ddg_html(query: str) -> dict[str, Any]:
+    url = f"https://html.duckduckgo.com/html/?q={urllib.parse.quote(query)}"
+    status, _, body, ms = http(url, headers={"User-Agent": BROWSER_UA})
+    text = body.decode("utf-8", errors="replace")
+    return {
+        "query": query,
+        "http_status": status,
+        "elapsed_ms": round(ms, 1),
+        "bytes": len(body),
+        "result_anchor_count": len(re.findall(r'class="result__a"', text)),
+    }
+
+
+def probe_bing_rss(query: str) -> dict[str, Any]:
+    url = f"https://www.bing.com/search?format=rss&q={urllib.parse.quote(query)}"
+    status, _, body, ms = http(url, headers={"User-Agent": BROWSER_UA})
+    text = body.decode("utf-8", errors="replace")
+    return {
+        "query": query,
+        "http_status": status,
+        "elapsed_ms": round(ms, 1),
+        "bytes": len(body),
+        "item_count": text.count("<item>"),
+    }
+
+
+def token_candidates() -> list[tuple[str, str]]:
+    """Bearer token candidates, most likely first: MASC_MCP_TOKEN env,
+    then every ``<base>/.masc/auth/*.token`` file newest-first (tokens
+    rotate, so a stale env value must not end the search). Returns
+    (label-for-evidence, token value) pairs; labels never carry the value."""
+    pairs: list[tuple[str, str]] = []
+    from_env = os.environ.get("MASC_MCP_TOKEN")
+    if from_env:
+        pairs.append(("env:MASC_MCP_TOKEN", from_env.strip()))
+    base = os.environ.get("MASC_BASE_PATH", os.path.expanduser("~/me"))
+    files = glob.glob(os.path.join(base, ".masc", "auth", "*.token"))
+    for path in sorted(files, key=os.path.getmtime, reverse=True):
+        with open(path, encoding="utf-8") as handle:
+            pairs.append((os.path.basename(path), handle.read().strip()))
+    return pairs
+
+
+class McpClient:
+    """Minimal JSON-RPC client for the MASC streamable-HTTP MCP endpoint."""
+
+    def __init__(self, url: str, token: str | None):
+        self.url = url
+        self.token = token
+        self.session_id: str | None = None
+        self.next_id = 0
+
+    def rpc(self, method: str, params: dict[str, Any]) -> tuple[dict[str, Any], float, int]:
+        """Returns (parsed JSON-RPC response, elapsed_ms, raw_body_bytes)."""
+        self.next_id += 1
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+        }
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        if self.session_id:
+            headers["Mcp-Session-Id"] = self.session_id
+        body = json.dumps(
+            {"jsonrpc": "2.0", "id": self.next_id, "method": method, "params": params}
+        ).encode()
+        status, resp_headers, payload, ms = http(self.url, body=body, headers=headers)
+        for key, value in resp_headers.items():
+            if key.lower() == "mcp-session-id":
+                self.session_id = value
+        text = payload.decode("utf-8", errors="replace")
+        content_type = next(
+            (v for k, v in resp_headers.items() if k.lower() == "content-type"), ""
+        )
+        if status >= 400:
+            raise RuntimeError(f"HTTP {status}: {text[:300]}")
+        if "text/event-stream" in content_type:
+            data_lines = [
+                line[len("data:"):].strip()
+                for line in text.splitlines()
+                if line.startswith("data:")
+            ]
+            if not data_lines:
+                raise RuntimeError(f"SSE response without data lines: {text[:300]}")
+            text = data_lines[-1]
+        try:
+            return json.loads(text), ms, len(payload)
+        except json.JSONDecodeError as err:
+            raise RuntimeError(
+                f"{method}: non-JSON body status={status} "
+                f"content_type={content_type!r} head={text[:160]!r}"
+            ) from err
+
+
+def tool_text_payload(rpc_result: dict[str, Any]) -> str:
+    """Concatenate the text content blocks the model would receive."""
+    content = rpc_result.get("result", {}).get("content", [])
+    return "".join(
+        block.get("text", "") for block in content if block.get("type") == "text"
+    )
+
+
+def content_duplication(payload_text: str) -> dict[str, Any]:
+    """Measure how many times the fetched bodies ride in one payload."""
+    try:
+        parsed = json.loads(payload_text)
+    except json.JSONDecodeError:
+        return {"parse": "non-json payload"}
+    result = parsed.get("result", parsed)
+    hits = result.get("results", [])
+    page_content_chars = sum(
+        len(hit.get("page_content", "")) for hit in hits if isinstance(hit, dict)
+    )
+    content_text_chars = len(result.get("content_text", ""))
+    return {
+        "hit_count": len(hits),
+        "page_content_chars_total": page_content_chars,
+        "content_text_chars": content_text_chars,
+        "both_fields_present": page_content_chars > 0 and content_text_chars > 0,
+    }
+
+
+def authenticated_client(url: str) -> tuple[McpClient, dict[str, Any]]:
+    """Try each token candidate until initialize succeeds. Auth failures
+    per candidate are recorded, not swallowed; exhausting all candidates
+    raises with the full attempt trail."""
+    attempts: list[str] = []
+    for label, token in token_candidates() or [("no-token", "")]:
+        client = McpClient(url, token or None)
+        try:
+            init, ms, _ = client.rpc(
+                "initialize",
+                {
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": {},
+                    "clientInfo": {"name": "bench-web-tools", "version": "0"},
+                },
+            )
+        except RuntimeError as err:
+            attempts.append(f"{label}: {err}")
+            continue
+        return client, {
+            "auth_source": label,
+            "auth_attempts_rejected": len(attempts),
+            "initialize_ms": round(ms, 1),
+            "server_info": init.get("result", {}).get("serverInfo", {}),
+        }
+    raise RuntimeError("no token candidate accepted: " + " | ".join(attempts))
+
+
+def probe_mcp(url: str) -> dict[str, Any]:
+    client, record = authenticated_client(url)
+    record["url"] = url
+
+    listing, _, _ = client.rpc("tools/list", {})
+    tool_names = [t.get("name", "") for t in listing.get("result", {}).get("tools", [])]
+    web_search = next((n for n in tool_names if re.fullmatch(r"(?i)(masc_)?web_?search", n)), None)
+    web_fetch = next((n for n in tool_names if re.fullmatch(r"(?i)(masc_)?web_?fetch", n)), None)
+    record["tool_count"] = len(tool_names)
+    record["web_search_tool"] = web_search
+    record["web_fetch_tool"] = web_fetch
+    if web_search is None or web_fetch is None:
+        # Absence claim needs the untrimmed listing: record every name so
+        # "no web tool on this surface" is verifiable from the evidence.
+        record["tool_names"] = sorted(tool_names)
+
+    if web_search:
+        args = {"query": QUERIES[0], "limit": 5}
+        plain, ms, raw = client.rpc("tools/call", {"name": web_search, "arguments": args})
+        text = tool_text_payload(plain)
+        record["web_search_plain"] = {
+            "elapsed_ms": round(ms, 1),
+            "raw_response_bytes": raw,
+            "payload_chars": len(text),
+            "is_error": plain.get("result", {}).get("isError", False),
+        }
+        enriched_args = {**args, "includeContent": True, "contentMaxChars": 2000}
+        enriched, ms, raw = client.rpc(
+            "tools/call", {"name": web_search, "arguments": enriched_args}
+        )
+        text = tool_text_payload(enriched)
+        record["web_search_enriched"] = {
+            "elapsed_ms": round(ms, 1),
+            "raw_response_bytes": raw,
+            "payload_chars": len(text),
+            "is_error": enriched.get("result", {}).get("isError", False),
+            "duplication": content_duplication(text),
+        }
+
+    if web_fetch:
+        fetched, ms, raw = client.rpc(
+            "tools/call", {"name": web_fetch, "arguments": {"url": FETCH_URL}}
+        )
+        text = tool_text_payload(fetched)
+        record["web_fetch"] = {
+            "url": FETCH_URL,
+            "elapsed_ms": round(ms, 1),
+            "raw_response_bytes": raw,
+            "payload_chars": len(text),
+            "is_error": fetched.get("result", {}).get("isError", False),
+        }
+    return record
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-o", "--output", required=True, help="evidence JSON path")
+    args = parser.parse_args()
+
+    health = probe(lambda: dict(json.loads(http(HEALTH_URL)[2])))
+    evidence = {
+        "captured_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        "script": "scripts/bench-web-tools.py",
+        "server_health": {
+            key: health.get(key)
+            for key in ("status", "version", "commit", "commit_source")
+        }
+        if "error" not in health
+        else health,
+        "provider_direct": {
+            "searxng": [probe(probe_searxng, q) for q in QUERIES],
+            "duckduckgo_html": probe(probe_ddg_html, QUERIES[0]),
+            "bing_rss": probe(probe_bing_rss, QUERIES[0]),
+        },
+        "mcp_tool": probe(probe_mcp, MCP_URL),
+    }
+    with open(args.output, "w", encoding="utf-8") as handle:
+        json.dump(evidence, handle, ensure_ascii=False, indent=2)
+        handle.write("\n")
+    print(f"wrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench-web-tools.py
+++ b/scripts/bench-web-tools.py
@@ -9,6 +9,10 @@ Captures, per run, into one JSON evidence file:
     bytes, and the body-duplication factor of the includeContent path
     (page_content chars vs content_text chars carried in one payload).
 
+The DuckDuckGo/Bing probes measure external endpoints masc no longer
+uses as providers — their run-to-run instability is the evidence the
+provider cut rests on, so the probes stay as time-series instruments.
+
 Stdlib only. Every failure is recorded as data, never swallowed:
 each probe result carries either measurements or an "error" field.
 


### PR DESCRIPTION
## 목표

`masc_web_search`/`masc_web_fetch`의 provider 계약을 정정하고 토큰 예산을 도구 계약에 넣기 위한 설계 문서. 구현 코드는 이 PR에 없다.

## 실측 (2026-08-15)

7-provider 폴백 체인 중 실제로 동작하는 것은 하나였다.

| Provider | HTTP | 결과 수 | 판정 |
|---|---|---|---|
| SearXNG (`localhost:8888`) | 200 | 20건 (1.81초) | 정상. Docker 컨테이너 필요 |
| DuckDuckGo HTML | 202 | 0건 | 봇 차단 페이지 |
| Bing RSS | 200 | 1건 | 사실상 무응답 |

자격 없는 provider가 조용한 폴백으로 남아 있어, **빈 결과**와 **미설정**이 구분되지 않는다. 컨테이너가 내려가면 검색은 실패가 아니라 0건 성공이 된다.

`includeContent` 경로는 본문을 두 번 싣는다 — `results[].page_content`와 `content_text`가 같은 내용을 담고, `Tool_result.message`(`lib/tool_types/tool_result.ml:128`)가 payload 전체를 직렬화한다.

## 제안

1. `Ddg`·`Bing_rss` hard cut. 자격 있는 provider가 없으면 `Config` 실패로 드러낸다
2. 검색/추출 backend를 capability별로 분리 (Hermes 축)
3. Brave LLM Context API를 **옵션** provider로 추가 — `maximum_number_of_tokens`가 요청 파라미터라 절단 휴리스틱이 필요 없다
4. 결정론적 절단(head 75% / tail 25%) + 전문은 `<basepath>`로 오프로드
5. `web_fetch` 목적지 제한 (loopback·사설·링크로컬)

구현은 7개 Stacked PR로 분할하며, 결함 수정(PR-1·2)이 새 provider(PR-4·5)보다 앞선다.

## 선행 이력

`8a1bd382e9`(2026-06-10)가 같은 결론에 도달했으나 main에 도달하지 못했다. `git merge-base --is-ancestor 8a1bd382e9 origin/main` → false.

## 검증

문서 전용 PR이며 코드 변경이 없다. 실측 수치는 RFC §2와 §7에 명령·파일:라인과 함께 기재했다. 외부 API 파라미터는 공식 문서로 확인했고, 인용한 벤치마크는 평가 시점 표기가 엇갈려 **확인 필요**로 표시했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
