### PR TITLE
fix(agent-core): correct qwen3.5:397b embedded dialect to no-control-wire

### DIFF
--- a/packages/agent_core/models.toml
+++ b/packages/agent_core/models.toml
@@ -1078,8 +1078,37 @@ supports_tools = true
 supports_tool_choice = false
 supports_reasoning = true
 supports_extended_thinking = true
-supports_reasoning_budget = true
-thinking_control_format = "ollama_think"
+# 2026-08-15: "qwen3.5:397b" is the tag ollama.com actually serves; "qwen3.5:cloud"
+# above is an alias to the same backend (RFC-0370). This row previously declared
+# supports_reasoning_budget=true + thinking_control_format="ollama_think" —
+# Ollama's *native* /api/chat think:true/false toggle, which does not exist on
+# this OpenAI-compatible /v1/chat/completions request path (confirmed:
+# docs.ollama.com/api/openai-compatibility documents reasoning control only via
+# reasoning_effort/reasoning.effort; the native think field is /api/chat-only).
+# A live probe of the ":cloud" alias on this same backend returned reasoning
+# unconditionally (message keys ['content','reasoning','role'], 882 chars) even
+# without any request-side toggle, matching the confirmed sibling family (kimi-k2.6,
+# kimi-k2.7-code, minimax-m3, deepseek-v4-pro/flash; oas#2716 2026-07-20 audit) of
+# "inherent reasoning, no control wire on /v1". Sending enable_thinking=true against
+# ollama_think here fails fail-closed with Enable_not_encodable (masc keeper canary
+# canary-runtime-failover-20260814-0730, 2026-08-14 07:08); reasoning_effort was
+# tried too (PR #28680) and also failed, because nothing wires an effort value onto
+# this runtime — the reasoning_effort dialect needs both the format declaration and
+# a concrete effort level. supports_reasoning_budget follows the same correction
+# (no budget wire on /v1) already applied to the four confirmed siblings above.
+supports_reasoning_budget = false
+thinking_control_format = "none"
+# reasoning_streaming_format mirrors config/runtime.toml's ollama-cloud-qwen3-5-397b
+# fix (#28680, 2026-08-14), and matches the ollama_cloud fixture in
+# test_streaming.ml ("reasoning_content" delta on a qwen3.5:397b chunk).
+# Flagging one open discrepancy rather than silently resolving it: the
+# ":cloud" alias row above was live-probed and returned field name
+# "reasoning", not "reasoning_content" (oas-models-overlay.toml comment,
+# 2026-08-05). RFC-0370 says ":cloud" and ":397b" hit the same served backend,
+# so the two field names should match; they currently don't. Either value here
+# is strictly better than the prior No_streaming_reasoning default, but the
+# mismatch itself is unresolved — needs a live probe against ":397b" specifically.
+reasoning_streaming_format = "delta:reasoning_content"
 supports_multimodal_inputs = true
 supports_image_input = true
 modality_priority = "visual_first"
@@ -1456,8 +1485,13 @@ supports_tools = true
 supports_tool_choice = false
 supports_reasoning = true
 supports_extended_thinking = true
-supports_reasoning_budget = true
-thinking_control_format = "ollama_think"
+# Same correction as the provider-scoped row above (2026-08-15): this is the
+# bare-fallback twin of that entry and was carrying the identical
+# ollama_think/Enable_not_encodable defect. See that row's comment for the
+# full root-cause citation.
+supports_reasoning_budget = false
+thinking_control_format = "none"
+reasoning_streaming_format = "delta:reasoning_content"
 supports_multimodal_inputs = true
 supports_image_input = true
 modality_priority = "visual_first"

--- a/packages/agent_core/test/test_capabilities.ml
+++ b/packages/agent_core/test/test_capabilities.ml
@@ -888,10 +888,12 @@ let test_ollama_cloud_grouped_rows_have_required_axes () =
      production workflow: tool call -> tool_result replay -> final answer while
      reasoning may stream on a side channel. The catalog must not regress any
      one of these axes to a generic text-only profile. JSON response-format
-     support is an exact per-model contract rather than a provider-wide rule. *)
+     support is an exact per-model contract rather than a provider-wide rule.
+     "qwen3.5:397b" is deliberately absent: unlike the rows below it does not
+     use Ollama's native think toggle on this transport (see
+     test_ollama_cloud_qwen3_5_397b_has_no_control_wire). *)
   let cases =
-    [ "qwen3.5:397b", false
-    ; "gemma4:31b", true
+    [ "gemma4:31b", true
     ; "kimi-k2.7-code", false
     ; "minimax-m3", true
     ; "nemotron-3-ultra", false
@@ -926,6 +928,45 @@ let test_ollama_cloud_grouped_rows_have_required_axes () =
            Capabilities.Ollama_think
            c.thinking_control_format)
     cases
+;;
+
+let test_ollama_cloud_qwen3_5_397b_has_no_control_wire () =
+  (* "qwen3.5:397b" is the tag ollama.com actually serves; "qwen3.5:cloud"
+     above is an alias to the same backend (RFC-0370). A live probe of the
+     ":cloud" alias against ollama.com's OpenAI-compatible /v1/chat/completions
+     endpoint returned reasoning unconditionally (message keys
+     ['content','reasoning','role'], 882 chars) with no request-side toggle
+     accepted — matching the confirmed sibling family (kimi-k2.6,
+     kimi-k2.7-code, minimax-m3, deepseek-v4-pro/flash; oas#2716 2026-07-20
+     audit) of "inherent reasoning, no control wire on /v1". This row
+     previously declared Ollama's native think toggle (thinking_control_format
+     = "ollama_think"), which only exists on Ollama's native /api/chat, not
+     this OpenAI-compatible path; every enable_thinking=true keeper turn
+     failed closed with Enable_not_encodable (canary
+     canary-runtime-failover-20260814-0730, 2026-08-14 07:08). A later attempt
+     at thinking_control_format = "reasoning-effort" (#28680, since reverted)
+     failed the same way because nothing wires a concrete effort value onto
+     this runtime — the reasoning_effort dialect needs both the format
+     declaration and an effort level to encode anything. *)
+  match
+    Capabilities.for_provider_model_id
+      ~allow_bare_fallback:false
+      ~provider_label:"ollama_cloud"
+      ~model_id:"qwen3.5:397b"
+  with
+  | None -> fail "ollama_cloud/qwen3.5:397b should resolve"
+  | Some c ->
+    check bool "qwen3.5:397b reasoning" true c.supports_reasoning;
+    check bool "qwen3.5:397b extended thinking" true c.supports_extended_thinking;
+    check
+      bool
+      "qwen3.5:397b no reasoning budget control"
+      false
+      c.supports_reasoning_budget;
+    check_thinking_control
+      "qwen3.5:397b inherent thinking has no request control"
+      Capabilities.No_thinking_control
+      c.thinking_control_format
 ;;
 
 let test_ollama_cloud_grouped_rows_follow_exact_output_contract () =
@@ -1426,7 +1467,10 @@ let test_frontier_grouped_tool_thinking_provider_contracts () =
       , Extended_thinking
       , No_structured_output
       , Replay_not_required
-      , Delta_stream "thinking" )
+      (* 2026-08-15: no control wire on /v1 (see the catalog row's comment),
+         so the reasoning delta streams on the plain reasoning_content field
+         instead of Ollama's native "thinking" field. *)
+      , Delta_stream "reasoning_content" )
     ; ( "Ollama Cloud Gemma4"
       , Provider_qualified "ollama_cloud"
       , "gemma4:31b"
@@ -2833,6 +2877,10 @@ let () =
             "ollama cloud grouped rows keep required axes"
             `Quick
             test_ollama_cloud_grouped_rows_have_required_axes
+        ; test_case
+            "ollama cloud qwen3.5:397b has no control wire"
+            `Quick
+            test_ollama_cloud_qwen3_5_397b_has_no_control_wire
         ; test_case
             "ollama cloud grouped rows follow exact-output contract"
             `Quick


### PR DESCRIPTION
## 요약

`packages/agent_core/models.toml`의 임베디드 카탈로그에서 `id_prefix = "qwen3.5:397b"` 두 행이 `thinking_control_format = "ollama_think"`(Ollama 네이티브 `/api/chat` `think:true/false` 토글)와 `supports_reasoning_budget = true`를 선언하고 있었는데요, 이 행이 실제로 서비스되는 경로는 `ollama_cloud`의 OpenAI 호환 `/v1/chat/completions`라서 이 둘 다 wire에 실을 수 없는 상태였어요.

그 결과 `enable_thinking=true`로 나가는 keeper 턴이 전부 `Enable_not_encodable`로 fail-closed 거부됐습니다. 실측 근거는 canary 로그예요.

```
~/me/.masc/keeper_chat/canary-runtime-failover-20260814-0730.jsonl (2026-08-14 07:08:00)
"Keeper request failed: Invalid request (unknown): model \"qwen3.5:397b\" declares
thinking control, but the resolved typed dialect cannot encode enable_thinking=true
on this OpenAI-compatible request path. ..."
```

이 fail-closed 자체는 올바른 설계라, 조용히 무시하는 대신 명확하게 거절하고 있어요. 문제는 이 조합을 표현할 방법이 카탈로그에 잘못 선언돼 있었다는 쪽입니다.

## 근본 원인

같은 결함 패턴이 형제 4개 모델(kimi-k2.6, kimi-k2.7-code, minimax-m3, deepseek-v4-pro/flash)에서 이미 발견돼 `oas#2716`(2026-07-20 감사)으로 고쳐졌고, 바로 위에 있는 `"qwen3.5:cloud"` 별칭 행도 같은 이유로 이미 `"none"`을 쓰고 있었어요. 그런데 `"qwen3.5:397b"`(실제로 ollama.com이 서빙하는 태그, RFC-0370) 행은 그때 같이 안 고쳐진 채로 남아 있었습니다.

`":cloud"` 별칭 행의 라이브 프로브(`oas-models-overlay.toml` 주석, 2026-08-05)를 보면 ollama.com이 요청 방식과 무관하게 항상 reasoning을 반환했어요 (`message keys: ['content', 'reasoning', 'role']`). 즉 이 경로엔 진짜 제어 wire가 없고 reasoning은 상시 켜져 있는(inherent) 상태라는 거고요, `":397b"` 태그도 RFC-0370에 따르면 같은 백엔드를 가리키니 동일하게 봐야 한다는 판단입니다.

공식 문서 확인: [Ollama OpenAI compatibility docs](https://docs.ollama.com/api/openai-compatibility)는 `/v1/chat/completions`에서 reasoning 제어를 `reasoning_effort`/`reasoning.effort` 필드로만 지원한다고 명시하고 있고, 네이티브 `think` 필드는 `/api/chat` 전용이에요. 이 저장소에서 `thinking_control_format = "reasoning-effort"`를 실제로 시도했다가 되돌린 이력도 있는데요 (`config/runtime.toml`의 `masc#28680`, deepseek-v4-flash 관련 2026-08-04 주석), reasoning_effort dialect는 effort 값을 같이 안 실으면 wire에 아무것도 못 실어서 결국 같은 `Enable_not_encodable`로 돌아왔다고 기록돼 있었어요. 그래서 "control wire 없음"으로 선언하는 쪽이 맞다고 판단했습니다.

## 변경 내용

- `packages/agent_core/models.toml`: `qwen3.5:397b` 두 행(provider-scoped + provider-independent fallback) 모두 `thinking_control_format = "none"`, `supports_reasoning_budget = false`로 정정하고, `reasoning_streaming_format = "delta:reasoning_content"`를 추가했어요 (이전엔 이 키 자체가 없어서 `No_streaming_reasoning`으로 떨어져 reasoning content가 0건 캡처되고 있었습니다).
- `packages/agent_core/test/test_capabilities.ml`:
  - `test_ollama_cloud_grouped_rows_have_required_axes`에서 `qwen3.5:397b`를 뺐어요 (더 이상 `Ollama_think`가 아니라서요).
  - `test_ollama_cloud_qwen3_5_397b_has_no_control_wire` 신규 테스트로 정정된 dialect를 직접 검증했습니다.
  - `test_frontier_grouped_tool_thinking_provider_contracts`의 "Ollama Cloud Qwen3.5" 행 스트리밍 필드 기대값을 `"thinking"` → `"reasoning_content"`로 맞췄어요.

## 열어둔 채로 남긴 것

`reasoning_streaming_format`의 필드명이 `"reasoning_content"`인지 `"reasoning"`인지는 완전히 확정하지 못했어요. 근거가 갈립니다.

- `"reasoning_content"` 쪽 근거: `masc#28680`(2026-08-14, `config/runtime.toml`에 이미 병합됨)과 기존 `test_streaming.ml`의 `qwen3.5:397b` 픽스처.
- `"reasoning"` 쪽 근거: `":cloud"` 별칭의 실제 라이브 프로브.

RFC-0370상 두 태그가 같은 백엔드라 필드명이 같아야 하는데 다른 상태라, 추측으로 한쪽을 밀어붙이지 않고 기존에 이미 병합된 `#28680`의 선택(`"reasoning_content"`)을 따르되 이 불일치를 코드 주석과 PR에 명시적으로 남겼어요. 어느 쪽이든 기존 상태(`No_streaming_reasoning`, 캡처 0건)보다는 낫습니다. `":397b"` 태그를 직접 라이브 프로브하는 후속 작업을 권장드려요.

또한 같은 결함(embedded 카탈로그 미수정)이 kimi-k2.6 / minimax-m3 / deepseek-v4-pro에도 남아 있는 걸 확인했는데요, 이번 PR 범위는 qwen3.5로 한정했고 이 3개는 별도 이슈로 등록할 예정입니다.

## 로컬 검증

`.worktrees/fix-qwen-dialect`에서 (masc 저장소 nested worktree는 `--root .` 필요):

```bash
dune build --root . packages/agent_core/test/test_capabilities.exe
dune exec --root . packages/agent_core/test/test_capabilities.exe -- -e
# Test Successful in 0.099s. 102 tests run.
```

전체 빌드는 로컬에서 안 돌렸고 CI에 맡깁니다.

## 함께 반영한 live config

`~/me/.masc/config/runtime.toml`(git 비추적, 실제 운영 설정)의 `[models.qwen3-5-cloud.capabilities]`도 같은 이유로 `supports-reasoning-budget = false`, `reasoning-streaming-format = "delta:reasoning_content"`를 추가했고, "이 키는 runtime.toml 스키마에 없다"는 이제 stale인 주석(`masc#28680`이 실제로 그 키를 추가했어요)을 정정했어요. 이건 이 PR과 별개로 즉시 반영했습니다 (repo 코드 아님).

🤖 Generated with [Claude Code](https://claude.com/claude-code)