### PR TITLE
fix(agent-core): correct ollama_cloud sibling rows to no-control-wire dialect

### DIFF
--- a/packages/agent_core/models.toml
+++ b/packages/agent_core/models.toml
@@ -515,8 +515,16 @@ supports_tools = true
 supports_tool_choice = false
 supports_reasoning = true
 supports_extended_thinking = true
-supports_reasoning_budget = true
-thinking_control_format = "ollama_think"
+# 2026-08-15: this row declared Ollama's native /api/chat think toggle
+# (ollama_think) even though it is served through ollama_cloud's OpenAI-compat
+# /v1/chat/completions, which cannot encode it — same defect as qwen3.5:397b
+# (PR #28748), already confirmed and corrected for this exact model in the live
+# overlay (~/me/.masc/config/oas-models-overlay.toml, oas#2716 2026-07-20 audit,
+# 2026-08-04 live probe: message keys ['role','content','reasoning']). This row
+# just carried the buggy default forward in the embedded catalog. Closes #28749.
+supports_reasoning_budget = false
+thinking_control_format = "none"
+reasoning_streaming_format = "delta:reasoning"
 supports_multimodal_inputs = false
 supports_image_input = false
 supports_native_streaming = true
@@ -530,8 +538,11 @@ supports_tools = true
 supports_tool_choice = false
 supports_reasoning = true
 supports_extended_thinking = true
-supports_reasoning_budget = true
-thinking_control_format = "ollama_think"
+# Same correction as deepseek-v4-flash above; see that row's comment. Confirmed
+# by the live overlay's deepseek-v4-pro row (2026-08-04 live probe).
+supports_reasoning_budget = false
+thinking_control_format = "none"
+reasoning_streaming_format = "delta:reasoning"
 supports_multimodal_inputs = false
 supports_image_input = false
 supports_native_streaming = true
@@ -794,8 +805,12 @@ supports_tools = true
 supports_tool_choice = false
 supports_reasoning = true
 supports_extended_thinking = true
-supports_reasoning_budget = true
-thinking_control_format = "ollama_think"
+# Same ollama_think/Enable_not_encodable defect as deepseek-v4-flash above
+# (2026-08-15, closes #28749); confirmed by the live overlay's kimi-k2.6 row
+# (2026-08-04 live probe: message keys ['role','content','reasoning']).
+supports_reasoning_budget = false
+thinking_control_format = "none"
+reasoning_streaming_format = "delta:reasoning"
 # Kimi K2 docs: reasoning content must be replayed (hard-required on tool turns,
 # recommended on all turns). Without this, the base replay policy is no_replay.
 reasoning_replay = "preserve_always"
@@ -816,8 +831,11 @@ supports_tools = true
 supports_tool_choice = false
 supports_reasoning = true
 supports_extended_thinking = true
-supports_reasoning_budget = true
-thinking_control_format = "ollama_think"
+# Same correction as kimi-k2.6 above; confirmed by the live overlay's
+# kimi-k2.7-code row (2026-08-04 live probe, same field shape).
+supports_reasoning_budget = false
+thinking_control_format = "none"
+reasoning_streaming_format = "delta:reasoning"
 # Kimi K2.7-code docs: Preserved Thinking is always-on (keep reasoning_content of
 # every historical assistant message) and thinking cannot be disabled.
 reasoning_replay = "preserve_always"
@@ -882,8 +900,12 @@ supports_tools = true
 supports_tool_choice = false
 supports_reasoning = true
 supports_extended_thinking = true
-supports_reasoning_budget = true
-thinking_control_format = "ollama_think"
+# Same ollama_think/Enable_not_encodable defect as deepseek-v4-flash above
+# (2026-08-15, closes #28749); confirmed by the live overlay's minimax-m3 row.
+# reasoning_streaming_format was already correct here — only the control-wire
+# axis and the coupled budget flag were wrong.
+supports_reasoning_budget = false
+thinking_control_format = "none"
 reasoning_streaming_format = "delta:reasoning"
 supports_multimodal_inputs = true
 supports_image_input = true

--- a/packages/agent_core/test/test_capabilities.ml
+++ b/packages/agent_core/test/test_capabilities.ml
@@ -446,10 +446,21 @@ let test_lookup_kimi_k2_native_cloud_suffix () =
          "provider-qualified Ollama Cloud Kimi context"
          (Some 262_144)
          cloud.max_context_tokens;
+       (* 2026-08-15 (closes #28749): this row is served through ollama_cloud's
+          OpenAI-compat /v1/chat/completions, which cannot encode Ollama's
+          native think toggle — same defect class as qwen3.5:397b (#28748).
+          Live overlay probe (oas-models-overlay.toml, 2026-08-04): reasoning
+          is inherent, no request-side control wire. *)
        check_thinking_control
-         "provider-qualified Ollama Cloud Kimi uses native think"
-         Capabilities.Ollama_think
+         "provider-qualified Ollama Cloud Kimi has no request control"
+         Capabilities.No_thinking_control
          cloud.thinking_control_format;
+       let cloud_dialect = Reasoning_dialect.of_capabilities cloud in
+       (match cloud_dialect.streaming with
+        | Reasoning_dialect.Delta_field "reasoning" -> ()
+        | Reasoning_dialect.Delta_field field ->
+          fail ("provider-qualified Ollama Cloud Kimi reasoning delta field drifted: " ^ field)
+        | _ -> fail "provider-qualified Ollama Cloud Kimi should stream reasoning on a delta field");
        check_visual_first "provider-qualified Ollama Cloud Kimi" cloud
      | None -> fail "should match provider-qualified Ollama Cloud Kimi route")
   | None -> fail "should match kimi-k2 cloud route"
@@ -889,16 +900,14 @@ let test_ollama_cloud_grouped_rows_have_required_axes () =
      reasoning may stream on a side channel. The catalog must not regress any
      one of these axes to a generic text-only profile. JSON response-format
      support is an exact per-model contract rather than a provider-wide rule.
-     "qwen3.5:397b" is deliberately absent: unlike the rows below it does not
-     use Ollama's native think toggle on this transport (see
-     test_ollama_cloud_qwen3_5_397b_has_no_control_wire). *)
+     "qwen3.5:397b", "kimi-k2.6", "kimi-k2.7-code", "minimax-m3",
+     "deepseek-v4-flash", and "deepseek-v4-pro" are deliberately absent: unlike
+     the rows below, none of them use Ollama's native think toggle on this
+     transport (closes #28749; see test_ollama_cloud_qwen3_5_397b_has_no_control_wire
+     and test_ollama_cloud_kimi_deepseek_minimax_have_no_control_wire). *)
   let cases =
     [ "gemma4:31b", true
-    ; "kimi-k2.7-code", false
-    ; "minimax-m3", true
     ; "nemotron-3-ultra", false
-    ; "deepseek-v4-flash", false
-    ; "deepseek-v4-pro", false
     ; "glm-5.2", false
     ; "gpt-oss:20b", false
     ; "gpt-oss:120b", false
@@ -967,6 +976,48 @@ let test_ollama_cloud_qwen3_5_397b_has_no_control_wire () =
       "qwen3.5:397b inherent thinking has no request control"
       Capabilities.No_thinking_control
       c.thinking_control_format
+;;
+
+let test_ollama_cloud_kimi_deepseek_minimax_have_no_control_wire () =
+  (* 2026-08-15 (closes #28749): these four ollama_cloud-scoped rows carried
+     the same Ollama_think/Enable_not_encodable defect as qwen3.5:397b
+     (#28748) — declaring Ollama's native /api/chat think toggle on a model
+     served through the OpenAI-compat /v1/chat/completions path, which cannot
+     encode it. Each is independently confirmed by a live probe recorded in
+     the OAS overlay (~/me/.masc/config/oas-models-overlay.toml, oas#2716
+     2026-07-20 audit + 2026-08-04 per-model probes): reasoning is inherent
+     and unconditional, and the response streams it back on a plain "reasoning"
+     field (not Ollama's native "thinking" field). kimi-k2.6 is covered
+     separately by test_lookup_kimi_k2_native_cloud_suffix, which already
+     exercises its provider-qualified ollama_cloud lookup. *)
+  List.iter
+    (fun model_id ->
+       match
+         Capabilities.for_provider_model_id
+           ~allow_bare_fallback:false
+           ~provider_label:"ollama_cloud"
+           ~model_id
+       with
+       | None -> failf "ollama_cloud/%s should resolve" model_id
+       | Some c ->
+         check bool (model_id ^ " reasoning") true c.supports_reasoning;
+         check bool (model_id ^ " extended thinking") true c.supports_extended_thinking;
+         check
+           bool
+           (model_id ^ " no reasoning budget control")
+           false
+           c.supports_reasoning_budget;
+         check_thinking_control
+           (model_id ^ " inherent thinking has no request control")
+           Capabilities.No_thinking_control
+           c.thinking_control_format;
+         let dialect = Reasoning_dialect.of_capabilities c in
+         (match dialect.streaming with
+          | Reasoning_dialect.Delta_field "reasoning" -> ()
+          | Reasoning_dialect.Delta_field field ->
+            failf "%s reasoning delta field drifted: %s" model_id field
+          | _ -> failf "%s should stream reasoning on a delta field" model_id))
+    [ "kimi-k2.7-code"; "minimax-m3"; "deepseek-v4-flash"; "deepseek-v4-pro" ]
 ;;
 
 let test_ollama_cloud_grouped_rows_follow_exact_output_contract () =
@@ -1134,9 +1185,12 @@ let test_ollama_cloud_provider_qualified_preserves_shared_bare_family () =
     "bare latest Kimi always preserves reasoning"
     true
     (bare_kimi.preserve_thinking_control_format = Always_preserved_thinking);
+  (* 2026-08-15 (closes #28749): ollama_cloud serves this through the
+     OpenAI-compat /v1 path, which cannot encode Ollama's native think toggle
+     — same defect class as qwen3.5:397b (#28748). *)
   check_thinking_control
-    "cloud Kimi uses Ollama native think"
-    Ollama_think
+    "cloud Kimi has no request control on this transport"
+    No_thinking_control
     cloud_kimi.thinking_control_format;
   check
     (option int)
@@ -1484,7 +1538,9 @@ let test_frontier_grouped_tool_thinking_provider_contracts () =
       , Extended_thinking
       , No_structured_output
       , Replay_every_turn
-      , Delta_stream "thinking" )
+      (* 2026-08-15 (closes #28749): no control wire on /v1, same as the
+         qwen3.5:397b and MiniMax M3 rows above. *)
+      , Delta_stream "reasoning" )
     ; ( "Ollama Cloud MiniMax M3"
       , Provider_qualified "ollama_cloud"
       , "minimax-m3"
@@ -1505,14 +1561,16 @@ let test_frontier_grouped_tool_thinking_provider_contracts () =
       , Extended_thinking
       , No_structured_output
       , Replay_not_required
-      , Delta_stream "thinking" )
+      (* 2026-08-15 (closes #28749): no control wire on /v1. *)
+      , Delta_stream "reasoning" )
     ; ( "Ollama Cloud DeepSeek V4 Flash"
       , Provider_qualified "ollama_cloud"
       , "deepseek-v4-flash"
       , Extended_thinking
       , No_structured_output
       , Replay_not_required
-      , Delta_stream "thinking" )
+      (* 2026-08-15 (closes #28749): no control wire on /v1. *)
+      , Delta_stream "reasoning" )
     ; ( "Ollama Cloud GLM 5.2"
       , Provider_qualified "ollama_cloud"
       , "glm-5.2"
@@ -2881,6 +2939,10 @@ let () =
             "ollama cloud qwen3.5:397b has no control wire"
             `Quick
             test_ollama_cloud_qwen3_5_397b_has_no_control_wire
+        ; test_case
+            "ollama cloud kimi/deepseek/minimax have no control wire"
+            `Quick
+            test_ollama_cloud_kimi_deepseek_minimax_have_no_control_wire
         ; test_case
             "ollama cloud grouped rows follow exact-output contract"
             `Quick

--- a/packages/agent_core/test/test_provider_config.ml
+++ b/packages/agent_core/test/test_provider_config.ml
@@ -2139,10 +2139,17 @@ let test_capability_provider_label_ollama_cloud_requires_explicit_id () =
         "endpoint alone keeps the provider-independent MiniMax contract"
         true
         (native.thinking_control_format = Capabilities.Thinking_object_adaptive);
+      (* 2026-08-15 (closes #28749): minimax-m3 via ollama_cloud is served
+         through the OpenAI-compat /v1/chat/completions path, which cannot
+         encode Ollama's native think toggle — same defect class as
+         qwen3.5:397b (#28748), corrected in #28750 with a live-probe-backed
+         "none" declaration (oas#2716). This assertion is what checks that
+         the explicit ollama_cloud provider id actually picks up the
+         provider-scoped row's *own* contract rather than the bare/native one. *)
       check_bool
         "explicit Ollama Cloud/model tuple selects its exact contract"
         true
-        (cloud.thinking_control_format = Capabilities.Ollama_think)
+        (cloud.thinking_control_format = Capabilities.No_thinking_control)
     | _ -> Alcotest.fail "both bare and explicit Ollama Cloud rows must resolve")
 ;;
 


### PR DESCRIPTION
## 요약

Closes #28749.

#28748(`qwen3.5:397b`)에서 발견한 것과 같은 결함이 `packages/agent_core/models.toml`의 `provider_name = "ollama_cloud"` 행 5개에 그대로 남아 있었습니다: `kimi-k2.6`, `kimi-k2.7-code`, `minimax-m3`, `deepseek-v4-pro`, `deepseek-v4-flash`. 모두 `thinking_control_format = "ollama_think"`(Ollama 네이티브 `/api/chat` 전용 토글) + `supports_reasoning_budget = true`를 선언하고 있었는데, 이 행들이 실제로 서비스되는 경로는 `ollama_cloud`의 OpenAI 호환 `/v1/chat/completions`라서 이 둘 다 wire에 못 실었습니다.

#28749 리뷰에서 지적받은 대로, 처음엔 이 중 3개(kimi-k2.6/minimax-m3/deepseek-v4-pro)만 미수정으로 봤는데요, 다시 확인해보니 `kimi-k2.7-code`와 `deepseek-v4-flash`도 "이미 정정됨"이 아니라 **같은 모델명의 다른 provider 행(kimi native 1918줄대, deepseek native 383줄대)과 혼동**한 것이었습니다. `provider_name = "ollama_cloud"`인 행 기준으로는 5개 전부 미수정 상태였습니다.

## 근거

5개 전부 `~/me/.masc/config/oas-models-overlay.toml`(oas#2716 2026-07-20 감사 + 2026-08-04 모델별 라이브 프로브)에 이미 정정된 exact row가 있었습니다. reasoning은 이 경로에서 상시 켜져 있고(inherent, 요청과 무관), 응답은 `"reasoning"` 필드로 옵니다(Ollama 네이티브 `"thinking"` 필드가 아님). `qwen3.5:397b`(#28748)와 달리 이 5개는 필드명이 5개 전부 `"reasoning"`으로 일관돼 있어서 불일치나 후속 라이브 프로브가 필요 없었습니다.

## 변경 내용

- `packages/agent_core/models.toml`: 5개 행 모두 `thinking_control_format = "none"`, `supports_reasoning_budget = false`로 정정하고 `reasoning_streaming_format = "delta:reasoning"`을 보강했습니다 (minimax-m3는 이 필드가 이미 있었고, 나머지 4개는 없어서 reasoning이 아예 캡처 안 되고 있었습니다).
- `packages/agent_core/test/test_capabilities.ml`:
  - `test_lookup_kimi_k2_native_cloud_suffix`와 `test_ollama_cloud_provider_qualified_preserves_shared_bare_family`에서 `kimi-k2.7-code`의 ollama_cloud 행에 대해 `Ollama_think`를 기대하던 assertion 2곳을 `No_thinking_control`로 정정.
  - `test_ollama_cloud_grouped_rows_have_required_axes`에서 4개 모델(kimi-k2.7-code/minimax-m3/deepseek-v4-flash/deepseek-v4-pro)을 제거.
  - `test_ollama_cloud_kimi_deepseek_minimax_have_no_control_wire` 신규 회귀 테스트로 정정된 dialect + streaming field를 직접 검증.
  - `test_frontier_grouped_tool_thinking_provider_contracts`의 3개 행(Kimi K2.7 Code, DeepSeek V4 Pro, DeepSeek V4 Flash) 스트리밍 필드 기대값을 `"thinking"` → `"reasoning"`으로 정정 (MiniMax M3 행은 이미 `"reasoning"`이었어서 변경 없음).

## 범위에서 뺀 것

같은 조사 중 `deepseek-v3.2`, `minimax-m2.1`, `minimax-m2.5`, `minimax-m2.7`도 같은 `ollama_think` 패턴을 갖고 있는 걸 봤는데요, 이 넷은 오버레이에 대응하는 exact row가 없어서(라이브 프로브 근거 없음) 이번 PR에서 건드리지 않았습니다. 정정하려면 각각 별도 라이브 프로브가 먼저 필요합니다.

## 로컬 검증

`.worktrees/fix-ollama-cloud-thinking-dialect-siblings`에서 (masc 저장소 nested worktree는 `--root .` 필요):

```bash
dune build --root . packages/agent_core/test/test_capabilities.exe
dune exec --root . packages/agent_core/test/test_capabilities.exe -- -e
# Test Successful in 0.039s. 103 tests run.
```

전체 빌드는 로컬에서 안 돌렸고 CI에 맡깁니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)