### PR TITLE
fix(web): 본문 1회 적재 + 검색 캐시 TTL 정상화 (RFC-0381 PR-1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1047,7 +1047,8 @@ jobs:
             @test/runtest-test_tool_shard_coverage \
             @test/runtest-test_tool_board_coverage \
             @test/runtest-test_tool_task_coverage \
-            @test/runtest-test_tool_workspace_coverage
+            @test/runtest-test_tool_workspace_coverage \
+            @test/runtest-test_tool_misc_coverage
 
       - name: Run completion-authority lookup surface suite
         # The judge's lookup tools reach the filesystem and Git inside a

--- a/docs/ENV-CONTRACT.md
+++ b/docs/ENV-CONTRACT.md
@@ -149,7 +149,7 @@ Precedence:
 | `MASC_WEB_SEARCH_PROVIDER_ORDER` | built-in order | Overrides provider order for auto mode. |
 | `MASC_WEB_SEARCH_FALLBACKS` | built-in fallback order | Overrides fallback providers after the primary provider fails. |
 | `MASC_WEB_SEARCH_TIMEOUT_SEC` | `15` | Per-provider request timeout. |
-| `MASC_WEB_SEARCH_CACHE_TTL_SEC` | `30.0` | In-process WebSearch cache TTL. |
+| `MASC_WEB_SEARCH_CACHE_TTL_SEC` | `900.0` | In-process WebSearch cache TTL. |
 
 Equivalent `runtime.toml` keys:
 
@@ -160,7 +160,7 @@ provider = "auto"
 provider_order = "searxng,brave,tavily,exa,bing_api"
 fallbacks = "duckduckgo,bing_rss"
 timeout_sec = 15
-cache_ttl_sec = 30.0
+cache_ttl_sec = 900.0
 ```
 
 Representative code paths:

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -256,7 +256,7 @@ Keeper WebSearch/WebFetch backend 메모:
 
 - `masc_web_search` / `masc_web_fetch`는 Keeper-internal backend 이름이며 MCP `tools/list` public surface에는 노출되지 않는다.
 - `web_search` / `web_fetch` are not agent core-owned capabilities; Keeper agents should call the MASC-owned public aliases shown in their tool list (`WebSearch` / `WebFetch`).
-- `WebSearch { includeContent: true }`는 keeper가 바로 읽는 `content_text`와 결과별 raw `page_content`를 best-effort로 붙인다. `WebFetch`는 선택한 단일 URL을 더 깊게 읽을 때 쓴다.
+- `WebSearch { includeContent: true }`는 가져온 본문을 keeper가 바로 읽는 `content_text` 렌더링 하나로만 싣는다. `WebFetch`는 선택한 단일 URL을 더 깊게 읽을 때 쓴다.
 - `[web_search].searxng_url` 또는 `MASC_SEARXNG_URL` 설정 시 self-hosted SearXNG가 최우선 provider로 작동한다.
 - 로컬 검색 품질이 필요하면 `scripts/searxng-local.sh start`로 Docker SearXNG를 올리고 active `runtime.toml`의 `[web_search].searxng_url = "http://localhost:8888"`만 설정한다. 별도 WebSearch MCP wrapper는 필요 없다.
 - `scripts/searxng-local.sh status|smoke|logs|stop`으로 로컬 provider를 점검한다. 기본 config는 `${MASC_BASE_PATH:-$HOME/me}/.local/share/masc-searxng/settings.yml`에 생성되며 MASC가 쓰는 JSON search format을 켠다.

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -288,8 +288,17 @@ module Tools = struct
     let v = get_int ~default:15 "MASC_WEB_SEARCH_TIMEOUT_SEC" in
     max 1 (min 60 v)
 
+  (* 15 min, matching the Hermes/OpenClaw web-tool cache window. The
+     previous 30 s default expired before a keeper research loop could
+     even repeat a query inside one turn. *)
+  let web_search_cache_ttl_default_sec = 900.0
+
   let web_search_cache_ttl_sec () =
-    let v = get_float ~default:30.0 "MASC_WEB_SEARCH_CACHE_TTL_SEC" in
+    let v =
+      get_float
+        ~default:web_search_cache_ttl_default_sec
+        "MASC_WEB_SEARCH_CACHE_TTL_SEC"
+    in
     if v < 0.0 then 0.0 else v
 
 end

--- a/lib/tool_misc_web_enrichment.ml
+++ b/lib/tool_misc_web_enrichment.ml
@@ -285,10 +285,13 @@ let enrich_web_search_payload ~tool_name ~start_time ~content_max_chars
                     ~content_timeout
                     hits
                 in
+                (* Fetched bodies ride only in [content_text]. Mirroring
+                   them into [results.[].page_content] doubled every byte
+                   through [Tool_result.message]'s whole-payload
+                   serialization with no reader on the structured copy. *)
                 let result_fields =
                   append_assoc_fields result_fields
-                    [ "results", `List enriched_hits
-                    ; "content_enriched", `Bool true
+                    [ "content_enriched", `Bool true
                     ; "content_fetch_mode", `String "best_effort"
                     ; "content_max_chars", `Int content_max_chars
                     ; "content_timeout", `Int content_timeout

--- a/lib/tool_misc_web_search.mli
+++ b/lib/tool_misc_web_search.mli
@@ -140,9 +140,10 @@ val handle : tool_name:string -> start_time:float -> Yojson.Safe.t -> Tool_resul
 (** [handle ~tool_name ~start_time args] handles [masc_web_search] tool dispatch.
     Required: [query] (string).  Optional: [limit] (int,
     clamped to [\[1, 10\]], default 5).
-    The misc facade also accepts [includeContent=true] to best-effort enrich
-    each result with raw [page_content] via [WebFetch] and add a top-level
-    keeper-readable [content_text] rendering, plus optional [contentMaxChars]
+    The misc facade also accepts [includeContent=true] to best-effort fetch
+    each result page via [WebFetch] and add a top-level keeper-readable
+    [content_text] rendering (fetched bodies ride only there — the
+    [results] hits keep title/url/snippet), plus optional [contentMaxChars]
     and [contentTimeout] controls. This module remains the search-provider
     boundary to avoid depending on fetch.
 

--- a/lib/tool_schemas/tool_schemas_misc.ml
+++ b/lib/tool_schemas/tool_schemas_misc.ml
@@ -29,8 +29,8 @@ let web_search_schema : tool_schema =
       "Search the public web. Use exact tool name WebSearch. Example input: \
        {\"query\":\"OCaml 5.2 release date\",\"limit\":5,\"includeContent\":true}. \
        Returns result.results with title, url, snippet. With includeContent:true \
-       each result also has page_content and the response has a human-readable \
-       content_text summary. Do not use snake_case names like web_search."
+       the response gains a human-readable content_text rendering of every \
+       fetched page. Do not use snake_case names like web_search."
   ; input_schema =
       `Assoc
         [ "type", `String "object"
@@ -54,12 +54,12 @@ let web_search_schema : tool_schema =
                     [ "type", `String "boolean"
                     ; ( "description"
                       , `String
-                          "When true, also fetch each result page and add raw page_content plus a human-readable content_text summary. Recommended for research." )
+                          "When true, also fetch each result page and add a human-readable content_text rendering. Recommended for research." )
                     ] )
               ; ( "contentMaxChars"
                 , `Assoc
                     [ "type", `String "integer"
-                    ; "description", `String "Maximum raw page_content characters per result."
+                    ; "description", `String "Maximum fetched characters per result inside content_text."
                     ; "minimum", `Int 100
                     ; "maximum", `Int 20000
                     ; "default", `Int 4000

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=554
+UNWIRED_BASELINE=553
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -614,6 +614,15 @@ let () = test "dispatch_web_search_include_content_keeps_result_on_fetch_error" 
           | None -> failwith "dispatch returned None"))
 )
 
+(* Pins the named default (was inline 30.0): a keeper research loop must
+   be able to repeat a query inside one 15-minute window without paying
+   the provider again. *)
+let () = test "web_search_cache_ttl_default_is_fifteen_minutes" (fun () ->
+  with_boot_override "MASC_WEB_SEARCH_CACHE_TTL_SEC" None (fun () ->
+    with_env "MASC_WEB_SEARCH_CACHE_TTL_SEC" None (fun () ->
+      assert (Env_config.Tools.web_search_cache_ttl_sec () = 900.0)))
+)
+
 let () = test "parse_official_provider_json_payloads" (fun () ->
   let brave =
     Tool_misc.parse_brave_json

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -561,17 +561,11 @@ let () = test "dispatch_web_search_include_content_enriches_results" (fun () ->
               assert
                 (str_contains content_text
                    "[Standards ©](https://example.com/standards)");
-              assert (hit |> member "page_content_status" |> to_string = "ok");
-              assert (hit |> member "page_content_http_status" |> to_int = 200);
-              assert (hit |> member "page_content_truncated" |> to_bool = false);
-              assert
-                (str_contains
-                   (hit |> member "page_content" |> to_string)
-                   "# Result Page");
-              assert
-                (str_contains
-                   (hit |> member "page_content" |> to_string)
-                   "Readable page content & proof.")
+              (* Single-carriage contract: fetched bodies ride only in
+                 content_text, never mirrored into per-hit fields. *)
+              assert (hit |> member "page_content" = `Null);
+              assert (hit |> member "page_content_status" = `Null);
+              assert (hit |> member "page_content_http_status" = `Null)
           | None -> failwith "dispatch returned None"))
 )
 
@@ -613,15 +607,10 @@ let () = test "dispatch_web_search_include_content_keeps_result_on_fetch_error" 
               assert (str_contains content_text "Content status: error");
               assert (str_contains content_text "_Failed to retrieve page content:");
               assert (str_contains content_text ("Source: " ^ url));
-              assert (hit |> member "page_content_status" |> to_string = "error");
-              assert
-                (str_contains
-                   (hit |> member "page_content" |> to_string)
-                   "_Failed to retrieve page content:");
-              assert
-                (str_contains
-                   (hit |> member "page_content" |> to_string)
-                   ("Source: " ^ url))
+              (* Failure detail also rides only in content_text. *)
+              assert (hit |> member "page_content" = `Null);
+              assert (hit |> member "page_content_status" = `Null);
+              assert (hit |> member "page_content_error" = `Null)
           | None -> failwith "dispatch returned None"))
 )
 


### PR DESCRIPTION
## 목표 (RFC-0381 §4 PR-1 — 순수 결함 수정, 신규 기능 없음)

`includeContent=true` 경로가 가져온 본문을 한 payload에 두 번 실었다.

- `results[].page_content` — 구조화 사본. 소비자 없음 (`rg page_content` 전수: 스키마 설명·테스트뿐)
- `content_text` — keeper가 실제로 읽는 렌더링

`Tool_result.message`(`lib/tool_types/tool_result.ml:128`)가 payload 전체를 직렬화하므로 모든 바이트가 2배 + JSON 이스케이프로 전송됐다. 이제 enrichment는 렌더러에게만 본문을 공급하고, hits는 title/url/snippet을 유지한다.

캐시 TTL 기본 `30.0s → 900.0s` (named constant `web_search_cache_ttl_default_sec`). 30초는 keeper 리서치 루프가 한 턴 안에서 같은 쿼리를 반복하기도 전에 만료됐다. Hermes·OpenClaw 모두 15분. 오버라이드 키는 그대로.

## 변경 파일

- `lib/tool_misc_web_enrichment.ml` — enriched hits의 `results` 치환 제거 (본문 단일 적재)
- `test/test_tool_misc_coverage.ml` — ok/error 두 경로 모두 per-hit 필드 **부재**를 feature test로 핀
- `lib/tool_misc_web_search.mli`, `lib/tool_schemas/tool_schemas_misc.ml` — 계약 문구 동기화
- `lib/config/env_config_runtime.ml`, `docs/ENV-CONTRACT.md` — TTL 기본값

## 검증

- 로컬 빌드 없음(계약 #16) — CI가 판정. `page_content` 잔존 사본 전수: `rg -ln page_content lib/ bin/` → enrichment 내부(렌더러 전달용) 1파일만
- TTL 기본값을 핀하는 테스트 없음 확인 (`test_runtime_config_validity`는 45.5 오버라이드 왕복만 검사)
- Baseline 실측: `docs/evidence/web-tools-bench-2026-08-15-r{1,2,3}.json`, 보고서 `reports/web-tools-bench-2026-08-15.html`

Stacked on #28747 (RFC). 후속: PR-2 (죽은 provider hard cut).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
