### PR TITLE
fix(verification): stop retrying a review that cannot succeed on retry

### DIFF
--- a/dashboard/src/api/dashboard-verification-runs.test.ts
+++ b/dashboard/src/api/dashboard-verification-runs.test.ts
@@ -110,12 +110,39 @@ describe('parseVerificationRunsResponse', () => {
       generated_at: '2026-08-05T00:00:00Z',
       count: 1,
       runs: [
-        row({ status: 'not_reviewed', gate: 'evaluator_unavailable', detail: 'no runtime' }),
+        row({
+          status: 'not_reviewed',
+          gate: 'evaluator_unavailable',
+          detail: 'no runtime',
+          retryable: true,
+        }),
       ],
     })
     expect(onlyRun(parsed).status).toBe('not_reviewed')
     expect(onlyRun(parsed).cause).toBe('no runtime')
     expect(onlyRun(parsed).gate).toBe('evaluator_unavailable')
+    expect(onlyRun(parsed).retryable).toBe(true)
+  })
+
+  // The completion authority stops scheduling its own retry when the same
+  // review is known to keep failing the same way (a single-atom review whose
+  // seed message alone exceeds the target's whole budget, for example) —
+  // `retryable: false` is how an operator tells that apart from an ordinary
+  // in-flight `not_reviewed` row that will resolve itself on the next pulse.
+  it('surfaces a non-retryable not_reviewed row distinctly from a retryable one', () => {
+    const parsed = parseVerificationRunsResponse({
+      generated_at: '2026-08-05T00:00:00Z',
+      count: 1,
+      runs: [
+        row({
+          status: 'not_reviewed',
+          gate: 'evaluator_unavailable',
+          detail: 'newest conversation atom does not fit the model input budget',
+          retryable: false,
+        }),
+      ],
+    })
+    expect(onlyRun(parsed).retryable).toBe(false)
   })
 
   it('keeps the typed infrastructure stage without inventing a verdict', () => {

--- a/dashboard/src/api/dashboard-verification-runs.ts
+++ b/dashboard/src/api/dashboard-verification-runs.ts
@@ -63,6 +63,12 @@ export interface VerificationRunRecord {
   cause?: string
   /** Which gate declined to produce a verdict; `not_reviewed` rows only. */
   gate?: string
+  /** Whether the completion authority will schedule another automatic
+      attempt for this outcome; `not_reviewed` rows only. `false` means the
+      same review is expected to fail the same way — the task stays parked
+      until an operator acts (resubmission, evidence trim, config change),
+      not until the retry timer fires again. */
+  retryable?: boolean
   /** Which pre-review boundary was unavailable. */
   infrastructureStage?: 'review_preparation' | 'lookup_surface'
   tools?: VerificationToolObservation[]
@@ -108,6 +114,13 @@ function finiteNumber(value: unknown, context: string): number {
 
 function optionalNonEmptyString(value: unknown, context: string): string | undefined {
   return value === undefined ? undefined : nonEmptyString(value, context)
+}
+
+function strictBoolean(value: unknown, context: string): boolean {
+  if (typeof value !== 'boolean') {
+    protocolError(`${context} must be a boolean`)
+  }
+  return value
 }
 
 function verificationStatus(value: unknown, context: string): VerificationRunStatusLabel {
@@ -179,7 +192,7 @@ function parseRun(raw: unknown, index: number): VerificationRunRecord {
       optionalFields = ['evaluator_runtime']
       break
     case 'not_reviewed':
-      requiredOutcomeFields = ['elapsed_s', 'gate', 'detail', 'tools']
+      requiredOutcomeFields = ['elapsed_s', 'gate', 'detail', 'retryable', 'tools']
       optionalFields = ['evaluator_runtime']
       break
     case 'infrastructure_unavailable':
@@ -224,6 +237,9 @@ function parseRun(raw: unknown, index: number): VerificationRunRecord {
         : undefined,
     gate: status === 'not_reviewed'
       ? nonEmptyString(raw.gate, `${context}.gate`)
+      : undefined,
+    retryable: status === 'not_reviewed'
+      ? strictBoolean(raw.retryable, `${context}.retryable`)
       : undefined,
     infrastructureStage: status === 'infrastructure_unavailable'
       ? raw.stage === 'review_preparation' || raw.stage === 'lookup_surface'

--- a/dashboard/src/components/verification-runs-panel.ts
+++ b/dashboard/src/components/verification-runs-panel.ts
@@ -122,6 +122,12 @@ function VerificationRunRow({ row }: { row: VerificationRunRecord }) {
       <td class="py-2 text-[var(--color-fg-secondary)] break-words">
         ${row.gate ? html`<code class="mr-1">${row.gate}</code>` : null}
         ${row.infrastructureStage ? html`<code class="mr-1">${row.infrastructureStage}</code>` : null}
+        ${row.retryable === false
+          ? html`<span
+              class="mr-1 font-semibold text-destructive"
+              title="같은 이유로 계속 실패할 것으로 판단되어 자동 재시도가 멈췄습니다. 확인 후 조치가 필요합니다."
+            >[수동 확인 필요]</span>`
+          : null}
         ${row.cause ?? ''}
       </td>
     </tr>

--- a/lib/completion_authority_agent.ml
+++ b/lib/completion_authority_agent.ml
@@ -293,16 +293,30 @@ let prepare_review
 
 type process_outcome =
   | Committed
-  | Deferred
+  | Deferred of { retryable : bool }
 
-let defer ~task_id ~verification_id ~authority ~reason =
+(** [retryable] defaults [true]: every existing call site keeps scheduling
+    the maintenance-pulse retry unless it has positive evidence retrying
+    cannot succeed (currently only the review gate, via
+    {!Task.Anti_rationalization.review_result.retryable}). A [false] here
+    does not stop the task from ever being reviewed again — the next
+    unrelated verification submission still rescans the whole backlog — it
+    only stops this failure from keeping the maintenance-pulse timer
+    self-perpetuating on its own. *)
+let defer ?(retryable = true) ~task_id ~verification_id ~authority ~reason () =
   Log.Misc.warn
-    "system LLM completion authority deferred task_id=%s verification_id=%s authority=%s reason=%s"
+    "system LLM completion authority deferred task_id=%s verification_id=%s authority=%s retryable=%b reason=%s"
     task_id
     verification_id
     (Masc_domain.completion_authority_actor authority)
+    retryable
     reason;
-  Deferred
+  Deferred { retryable }
+;;
+
+let should_schedule_retry = function
+  | Committed -> false
+  | Deferred { retryable } -> retryable
 ;;
 
 let observe_rejection_wakeup
@@ -434,7 +448,7 @@ let commit_verdict
     Committed, on_commit
   | Error error ->
     let detail = Masc_domain.masc_error_to_string error in
-    ( defer ~task_id:task.id ~verification_id ~authority ~reason:detail
+    ( defer ~task_id:task.id ~verification_id ~authority ~reason:detail ()
     , Verification_run_registry.Commit_failed { detail } )
 ;;
 
@@ -480,7 +494,7 @@ let process_task_once
   in
   let defer_unavailable ~stage ~detail =
     complete
-      ( defer ~task_id:task.id ~verification_id ~authority ~reason:detail
+      ( defer ~task_id:task.id ~verification_id ~authority ~reason:detail ()
       , Verification_run_registry.Infrastructure_unavailable { stage; detail } )
   in
   try
@@ -539,8 +553,15 @@ let process_task_once
          in
          complete
            ~evaluator_runtime
-           ( defer ~task_id:task.id ~verification_id ~authority ~reason:detail
-           , Verification_run_registry.Not_reviewed { gate; detail } )
+           ( defer
+               ~retryable:result.retryable
+               ~task_id:task.id
+               ~verification_id
+               ~authority
+               ~reason:detail
+               ()
+           , Verification_run_registry.Not_reviewed
+               { gate; detail; retryable = result.retryable } )
        | Some review_verdict ->
          let verdict = completion_verdict_of_review review_verdict in
          let notes =
@@ -575,7 +596,7 @@ let process_task_once
   | exn ->
     let detail = Printexc.to_string exn in
     complete
-      ( defer ~task_id:task.id ~verification_id ~authority ~reason:detail
+      ( defer ~task_id:task.id ~verification_id ~authority ~reason:detail ()
       , Verification_run_registry.Raised { detail } )
 ;;
 
@@ -602,9 +623,7 @@ let process_task (runtime : runtime) (task : Masc_domain.task) ~assignee ~verifi
         ~finally:(fun () -> release_review runtime key)
         (fun () -> process_task_once runtime task ~assignee ~verification_id)
     in
-    match outcome with
-    | Committed -> ()
-    | Deferred -> schedule_retry runtime)
+    if should_schedule_retry outcome then schedule_retry runtime)
   else
     Log.Misc.debug
       "system LLM completion authority skipped duplicate in-flight review task_id=%s verification_id=%s"
@@ -720,4 +739,10 @@ module For_testing = struct
   let evidence_refs_of_output = evidence_refs_of_output
   let completion_verdict_of_review = completion_verdict_of_review
   let review_notes = review_notes
+
+  type nonrec process_outcome = process_outcome =
+    | Committed
+    | Deferred of { retryable : bool }
+
+  let should_schedule_retry = should_schedule_retry
 end

--- a/lib/completion_authority_agent.mli
+++ b/lib/completion_authority_agent.mli
@@ -24,4 +24,16 @@ module For_testing : sig
     result:Task.Anti_rationalization.review_result ->
     authority:Masc_domain.completion_authority ->
     string
+
+  (** How one review attempt ended, decoupled from the Eio scheduling loop so
+      the retry decision below is a pure function of it. *)
+  type process_outcome =
+    | Committed
+    | Deferred of { retryable : bool }
+
+  val should_schedule_retry : process_outcome -> bool
+  (** Whether [process_task] should arm the maintenance-pulse retry timer for
+      this outcome. [false] for [Committed] (nothing left to retry) and for
+      [Deferred { retryable = false }] (retrying is known not to change the
+      outcome) — [true] otherwise. *)
 end

--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -79,6 +79,7 @@ type review_result =
   ; generator_runtime : string option
   ; gate : gate
   ; fallback_reason : string option
+  ; retryable : bool
   }
 
 (* ================================================================ *)
@@ -377,6 +378,7 @@ let review
       ; generator_runtime
       ; gate = Evaluator_unavailable
       ; fallback_reason = Some reason
+      ; retryable = true
       }
   | Ok evaluator_runtime ->
     (match
@@ -402,6 +404,7 @@ let review
          ; generator_runtime
          ; gate = Evaluator_unavailable
          ; fallback_reason = Some detail
+         ; retryable = true
          }
      | Ok prompt ->
        (match generator_runtime with
@@ -448,6 +451,7 @@ let review
             ; generator_runtime
             ; gate = Structured_tool
             ; fallback_reason = None
+            ; retryable = true
             }
         | Ok None ->
           let detail =
@@ -463,15 +467,18 @@ let review
             ; generator_runtime
             ; gate = Invalid_verdict
             ; fallback_reason = Some detail
+            ; retryable = true
             }
         | Error error ->
           let detail = Agent_core.Error.to_string error in
+          let retryable = Agent_core.Error.is_retryable error in
           (Atomic.get outcome_observer_fn)
             ~outcome:"unavailable"
             ~runtime:evaluator_runtime;
           task_warn
-            "[task-completion-review] evaluator unavailable runtime=%s; task remains nonterminal: %s"
+            "[task-completion-review] evaluator unavailable runtime=%s retryable=%b; task remains nonterminal: %s"
             evaluator_runtime
+            retryable
             detail;
           emit
             { verdict = None
@@ -479,5 +486,6 @@ let review
             ; generator_runtime
             ; gate = Evaluator_unavailable
             ; fallback_reason = Some detail
+            ; retryable
             }))
 ;;

--- a/lib/task/anti_rationalization.mli
+++ b/lib/task/anti_rationalization.mli
@@ -48,6 +48,18 @@ type review_result =
   ; generator_runtime : string option
   ; gate : gate
   ; fallback_reason : string option
+  ; retryable : bool
+        (** Whether retrying this same review is expected to change the
+            outcome. [true] unless a typed evaluator error says otherwise:
+              only the [Error error] arm of [run_llm_reviewer_fn]'s result
+              carries an {!Agent_core.Error.t} to classify, so this is
+              [Agent_core.Error.is_retryable error] there and [true]
+              everywhere else (a produced verdict, a malformed tool call, or
+              a runtime/prompt resolution failure with no typed error to
+              consult). [false] means the same review_request will keep
+              failing the same way — a model-input-budget refusal on a
+              single-atom review being the case this exists for — and a
+              caller should not schedule another automatic attempt. *)
   }
 
 val review

--- a/lib/verification_run_registry.ml
+++ b/lib/verification_run_registry.ml
@@ -12,6 +12,7 @@ type outcome =
   | Not_reviewed of
       { gate : string
       ; detail : string
+      ; retryable : bool
       }
   | Commit_failed of { detail : string }
   | Raised of { detail : string }
@@ -122,8 +123,8 @@ module Payload = struct
       [ "stage", `String (infrastructure_stage_to_string stage)
       ; "detail", `String detail
       ]
-    | Not_reviewed { gate; detail } ->
-      [ "gate", `String gate; "detail", `String detail ]
+    | Not_reviewed { gate; detail; retryable } ->
+      [ "gate", `String gate; "detail", `String detail; "retryable", `Bool retryable ]
   ;;
 
   let completion_to_yojson completion =
@@ -162,7 +163,7 @@ module Payload = struct
       | "rejected" -> Ok [ "reason" ]
       | "infrastructure_unavailable" -> Ok [ "stage"; "detail" ]
       | "commit_failed" | "raised" -> Ok [ "detail" ]
-      | "not_reviewed" -> Ok [ "gate"; "detail" ]
+      | "not_reviewed" -> Ok [ "gate"; "detail"; "retryable" ]
       | other -> Error (Printf.sprintf "unknown verification outcome %S" other)
     in
     let* required_detail_fields = required_detail_fields in
@@ -249,7 +250,13 @@ module Payload = struct
       | "not_reviewed" ->
         let* gate = Run_registry_core.Json.string_field "gate" fields in
         let* detail = Run_registry_core.Json.string_field "detail" fields in
-        Ok (Not_reviewed { gate; detail })
+        let* retryable =
+          match List.assoc_opt "retryable" fields with
+          | Some (`Bool value) -> Ok value
+          | Some _ -> Error "field retryable must be a boolean"
+          | None -> Error "missing field retryable"
+        in
+        Ok (Not_reviewed { gate; detail; retryable })
       | "commit_failed" ->
         let* detail = Run_registry_core.Json.string_field "detail" fields in
         Ok (Commit_failed { detail })
@@ -371,8 +378,8 @@ let outcome_detail_fields = function
     [ "stage", `String (Payload.infrastructure_stage_to_string stage)
     ; "detail", `String detail
     ]
-  | Not_reviewed { gate; detail } ->
-    [ "gate", `String gate; "detail", `String detail ]
+  | Not_reviewed { gate; detail; retryable } ->
+    [ "gate", `String gate; "detail", `String detail; "retryable", `Bool retryable ]
 ;;
 
 let run_to_yojson run =

--- a/lib/verification_run_registry.mli
+++ b/lib/verification_run_registry.mli
@@ -14,6 +14,12 @@ type outcome =
   | Not_reviewed of
       { gate : string
       ; detail : string
+      ; retryable : bool
+            (** [false] means the completion authority will not schedule
+                another automatic attempt for this outcome — the same review
+                is expected to fail the same way. Operator intervention
+                (resubmission, evidence trim, config change) is what moves
+                this forward, not time. *)
       }
   | Commit_failed of { detail : string }
   | Raised of { detail : string }

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -107,6 +107,7 @@ normal_targets=(
   @test/runtest-test_subsystem_health_state
   @test/runtest-test_trailing_slash_rules
   @test/runtest-test_verification_run_registry
+  @test/runtest-test_completion_authority_retry_policy
   @test/runtest-test_slack_user_directory
   @test/runtest-test_cancel_safe
   @test/runtest-test_cancel_wall_bucket

--- a/test/dune
+++ b/test/dune
@@ -2548,6 +2548,8 @@
 
 (include stanzas/test_verification_run_registry.inc)
 
+(include stanzas/test_completion_authority_retry_policy.inc)
+
 (include stanzas/test_run_registry_concurrent_mutation.inc)
 (include stanzas/test_exact_lane_run_registry.inc)
 

--- a/test/stanzas/test_completion_authority_retry_policy.inc
+++ b/test/stanzas/test_completion_authority_retry_policy.inc
@@ -1,0 +1,8 @@
+; A Deferred review outcome that is known not to be retryable (e.g. a review
+; whose seed message alone exceeds the target's whole request budget) must
+; not keep arming the maintenance-pulse retry timer forever (masc, task-336).
+
+(test
+ (name test_completion_authority_retry_policy)
+ (modules test_completion_authority_retry_policy)
+ (libraries masc_test_deps))

--- a/test/test_anti_rationalization_empty_reject.ml
+++ b/test/test_anti_rationalization_empty_reject.ml
@@ -94,6 +94,54 @@ let test_evaluator_failure_is_unavailable_not_reject () =
        Alcotest.(check bool) "no fabricated reject" true (Option.is_none result.verdict))
 ;;
 
+(* The retry policy this exists for: a review whose single seed message
+   already exceeds the target's whole budget cannot be fixed by trying again
+   with the same request, so [Agent_core.Error.is_retryable] already reports
+   [false] for it (it is an [Agent (HookExecutionFailed _)]). [review] must
+   carry that through as [retryable = false] rather than default to the
+   always-retry [true] every other gate uses. *)
+let test_structural_budget_failure_is_not_retryable () =
+  with_reviewer
+    (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~lookup:_ ~on_tool_result:_ () ->
+       Error
+         (Agent_core.Error.Agent
+            (Agent_core.Error.HookExecutionFailed
+               { hook_name = "model_input_projection"
+               ; stage = "turn:parse"
+               ; tool_name = None
+               ; tool_use_id = None
+               ; detail =
+                   "newest conversation atom does not fit the model input budget: \
+                    available_bytes=233931 newest_atom_bytes=294670"
+               })))
+    (fun () ->
+       let result = review () in
+       Alcotest.(check string)
+         "gate"
+         "evaluator_unavailable"
+         (AR.gate_to_string result.gate);
+       Alcotest.(check bool) "not retryable" false result.retryable)
+;;
+
+(* Contrast case: a rate limit is exactly the kind of failure retrying is
+   supposed to absorb ([Agent_core.Error.is_retryable] reports [true] for
+   [Api (RateLimited _)]), so the always-retry default must survive here. *)
+let test_rate_limit_failure_stays_retryable () =
+  with_reviewer
+    (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~lookup:_ ~on_tool_result:_ () ->
+       Error
+         (Agent_core.Error.Api
+            (Agent_core.Error.Retry.RateLimited
+               { retry_after = None; message = "rate limited" })))
+    (fun () ->
+       let result = review () in
+       Alcotest.(check string)
+         "gate"
+         "evaluator_unavailable"
+         (AR.gate_to_string result.gate);
+       Alcotest.(check bool) "retryable" true result.retryable)
+;;
+
 let test_reject_without_reason_is_malformed () =
   let malformed =
     [ `Assoc [ "verdict", `String "REJECT" ]
@@ -154,6 +202,14 @@ let () =
             "provider failure unavailable"
             `Quick
             test_evaluator_failure_is_unavailable_not_reject
+        ; Alcotest.test_case
+            "structural budget failure is not retryable"
+            `Quick
+            test_structural_budget_failure_is_not_retryable
+        ; Alcotest.test_case
+            "rate limit failure stays retryable"
+            `Quick
+            test_rate_limit_failure_stays_retryable
         ; Alcotest.test_case
             "reject without reason is malformed"
             `Quick

--- a/test/test_completion_authority_retry_policy.ml
+++ b/test/test_completion_authority_retry_policy.ml
@@ -1,0 +1,56 @@
+(** Retry-scheduling decision for a completed completion-authority review.
+
+    [process_task] used to schedule the maintenance-pulse retry for every
+    [Deferred] outcome unconditionally, including a review whose seed message
+    alone already exceeds the target's whole request budget — a failure that
+    cannot change on a retry of the same request, so the retry kept firing
+    every [maintenance_pulse_interval_sec] forever (masc, task-336
+    diagnosis 2026-08-15/16: 20 identical failures in 20 minutes on a 294,670
+    byte single-atom review against a 262,144 byte lane).
+
+    [Task.Anti_rationalization.review_result.retryable] already carries
+    [Agent_core.Error.is_retryable] for that case; these pin that
+    [should_schedule_retry] — the pure decision [process_task] calls — reads
+    it correctly, on both sides. *)
+
+module CA = Masc.Completion_authority_agent
+
+let test_committed_never_retries () =
+  Alcotest.(check bool)
+    "committed"
+    false
+    (CA.For_testing.should_schedule_retry CA.For_testing.Committed)
+;;
+
+let test_retryable_defer_retries () =
+  Alcotest.(check bool)
+    "retryable defer"
+    true
+    (CA.For_testing.should_schedule_retry
+       (CA.For_testing.Deferred { retryable = true }))
+;;
+
+let test_non_retryable_defer_does_not_retry () =
+  Alcotest.(check bool)
+    "non-retryable defer"
+    false
+    (CA.For_testing.should_schedule_retry
+       (CA.For_testing.Deferred { retryable = false }))
+;;
+
+let () =
+  Alcotest.run
+    "completion_authority_retry_policy"
+    [ ( "should_schedule_retry"
+      , [ Alcotest.test_case "Committed never retries" `Quick test_committed_never_retries
+        ; Alcotest.test_case
+            "Deferred { retryable = true } retries"
+            `Quick
+            test_retryable_defer_retries
+        ; Alcotest.test_case
+            "Deferred { retryable = false } does not retry"
+            `Quick
+            test_non_retryable_defer_does_not_retry
+        ] )
+    ]
+;;

--- a/test/test_eval_calibration.ml
+++ b/test/test_eval_calibration.ml
@@ -40,7 +40,7 @@ let make_req ?(title = "Fix auth bug") ?(desc = "Fix the login issue")
 let make_result ?(verdict = AR.Approve) ?(runtime = "verifier")
     ?gen_runtime ?(gate = AR.Structured_tool) ?fallback_reason () : AR.review_result =
   { verdict = Some verdict; evaluator_runtime = runtime;
-    generator_runtime = gen_runtime; gate; fallback_reason }
+    generator_runtime = gen_runtime; gate; fallback_reason; retryable = true }
 
 (* ================================================================ *)
 (* Hashing tests                                                     *)

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -277,6 +277,7 @@ let test_system_llm_review_notes_are_metadata_only () =
     ; generator_runtime = None
     ; gate = Masc.Task.Anti_rationalization.Structured_tool
     ; fallback_reason = None
+    ; retryable = true
     }
   in
   let notes =

--- a/test/test_verification_run_registry.ml
+++ b/test/test_verification_run_registry.ml
@@ -62,7 +62,8 @@ let all_outcomes : (string * E.outcome) list =
   ; ( "infrastructure_unavailable"
     , E.Infrastructure_unavailable
         { stage = E.Review_preparation; detail = "request store unavailable" } )
-  ; "not_reviewed", E.Not_reviewed { gate = "evaluator_unavailable"; detail = "no runtime" }
+  ; ( "not_reviewed"
+    , E.Not_reviewed { gate = "evaluator_unavailable"; detail = "no runtime"; retryable = true } )
   ; "commit_failed", E.Commit_failed { detail = "verification id mismatch" }
   ; "raised", E.Raised { detail = "Failure(\"boom\")" }
   ]
@@ -155,6 +156,57 @@ let test_outcomes_survive_replay () =
     all_outcomes
 ;;
 
+(* [Not_reviewed.retryable] is what tells an operator whether the completion
+   authority will keep polling this outcome or has already given up — it must
+   round-trip through the wire projection and through replay exactly like
+   [gate]/[detail] do, in both directions. *)
+let test_not_reviewed_retryable_survives_wire_and_replay () =
+  List.iter
+    (fun retryable ->
+       let label = if retryable then "retryable" else "non-retryable" in
+       let path = fresh_path (".not-reviewed-" ^ label ^ ".jsonl") in
+       let t = R.create ~path () in
+       let verification_id = "vrf-" ^ label in
+       register t ~verification_id ~started_at:5.0;
+       R.mark_completed
+         t
+         ~verification_id
+         ~outcome:
+           (E.Not_reviewed
+              { gate = "evaluator_unavailable"
+              ; detail = "newest conversation atom does not fit the model input budget"
+              ; retryable
+              })
+         ~tools:[]
+         ~elapsed_s:1.0
+         ();
+       (match R.get t ~verification_id with
+        | None -> fail (label ^ ": completed review should stay tracked")
+        | Some run ->
+          let json = R.run_to_yojson run in
+          check
+            (option bool)
+            (label ^ ": wire field")
+            (Some retryable)
+            (match field json "retryable" with
+             | Some (`Bool value) -> Some value
+             | _ -> None));
+       let replayed = R.replay path in
+       (match R.get replayed ~verification_id with
+        | None -> fail (label ^ ": lost on replay")
+        | Some run ->
+          let json = R.run_to_yojson run in
+          check
+            (option bool)
+            (label ^ ": replayed wire field")
+            (Some retryable)
+            (match field json "retryable" with
+             | Some (`Bool value) -> Some value
+             | _ -> None));
+       remove_if_exists path)
+    [ true; false ]
+;;
+
 let test_replay_drops_running_reviews () =
   let path = fresh_path ".running.jsonl" in
   let t = R.create ~path () in
@@ -184,7 +236,7 @@ let test_retry_replaces_the_prior_attempt () =
   R.mark_completed
     t
     ~verification_id:"vrf-retry"
-    ~outcome:(E.Not_reviewed { gate = "invalid_verdict"; detail = "no tool call" })
+    ~outcome:(E.Not_reviewed { gate = "invalid_verdict"; detail = "no tool call"; retryable = true })
     ~tools:[]
     ~elapsed_s:1.0
     ();
@@ -358,6 +410,10 @@ let () =
             `Quick
             test_outcome_detail_reaches_the_surface
         ; test_case "every outcome survives replay" `Quick test_outcomes_survive_replay
+        ; test_case
+            "not_reviewed retryable survives the wire and replay, both values"
+            `Quick
+            test_not_reviewed_retryable_survives_wire_and_replay
         ; test_case
             "replay drops running reviews"
             `Quick

--- a/test/test_verification_run_registry.ml
+++ b/test/test_verification_run_registry.ml
@@ -291,6 +291,37 @@ let test_unknown_outcome_label_is_an_error () =
   remove_if_exists path
 ;;
 
+(* Deploy contract for the retryable field this PR adds to [Not_reviewed]
+   (masc, task-336 P1 review): [retryable] is required, not optional-with-a-
+   default, because a missing-field default would make this a legacy-shape
+   compat reader — exactly what the repo's hard-cut policy forbids (#28735's
+   turn_record precedent: required field + a store cut at deploy, never a
+   silent default). A pre-this-PR [not_reviewed] row therefore does not
+   survive replay: it is malformed, dropped, and left on disk untouched
+   (fold_replay_events reports it through [malformed], which also blocks
+   [compact_replay_log] from ever running again on this file — the intended
+   operator action is to cut the store at deploy, not to let old rows
+   accumulate forever behind a permanently malformed line). This pins that
+   behavior as the deliberate contract, not a regression to fix later. *)
+let test_pre_retryable_not_reviewed_row_is_malformed_on_replay () =
+  let path = fresh_path ".pre-retryable-not-reviewed.jsonl" in
+  let content =
+    String.concat
+      "\n"
+      [ {|{"event":"register","id":"vrf-pre-retryable","started_at":1.0,"registration":{"task_id":"task-336","producer":"keeper-rondo-agent","authority_kind":"system_llm_agent","authority_actor":"reviewer"}}|}
+      ; {|{"event":"complete","id":"vrf-pre-retryable","completion":{"outcome":"not_reviewed","elapsed_s":1.0,"gate":"evaluator_unavailable","detail":"no runtime"}}|}
+      ; ""
+      ]
+  in
+  Fs_compat.save_file path content;
+  let replayed = R.replay path in
+  check bool "pre-retryable not_reviewed row is not replayed" true
+    (Option.is_none (R.get replayed ~verification_id:"vrf-pre-retryable"));
+  check bool "the malformed row is left on disk, not silently compacted away" true
+    (String_util.contains_substring (Fs_compat.load_file path) "vrf-pre-retryable");
+  remove_if_exists path
+;;
+
 let test_missing_outcome_payload_is_an_error () =
   let path = fresh_path ".missing-outcome-detail.jsonl" in
   let content =
@@ -434,6 +465,10 @@ let () =
             "rejected without a reason is an error"
             `Quick
             test_missing_outcome_payload_is_an_error
+        ; test_case
+            "a pre-retryable not_reviewed row is malformed on replay (deploy contract)"
+            `Quick
+            test_pre_retryable_not_reviewed_row_is_malformed_on_replay
         ; test_case "completed runs are pruned" `Quick test_completed_runs_are_pruned
         ; test_case
             "tool evidence keeps input and typed disposition"


### PR DESCRIPTION
## 배경

task-336(masc)이 2026-08-15 15:30Z부터 20분 동안 같은 `evaluator unavailable` defer를 60초 간격으로 20회 반복했어요. 조사해보니 이 task의 evidence 번들이 만드는 seed 메시지가 294,670바이트였고, cross_verifier_lane의 가용 예산은 233,931바이트라 `Runtime_model_input_tail_window`의 `Newest_atom_exceeds_available`이 매번 정확히 같은 이유로 거부하고 있었어요.

이 거부 자체는 맞는 동작이에요 (atom이 1개뿐이라 이력을 떨궈서 줄일 방법이 구조적으로 없음). 문제는 그 다음이었어요 — `completion_authority_agent.defer`가 실패 원인과 무관하게 무조건 60초 뒤 재시도를 예약하고 있어서, 같은 요청을 다시 보내도 절대 성공할 수 없는 상황인데도 영원히 반복되고 있었어요.

라이브 config의 cross_verifier_lane 바이트 캡(262144→524288)은 팀장님이 이미 별도로 적용하셨어요. 이 PR은 그거랑은 다른 문제를 다뤄요 — 캡을 아무리 올려도 언젠가 그보다 큰 evidence 번들이 오면 똑같은 무한 재시도가 재현될 수 있으니, 그 재발 자체를 막는 거예요.

## 무엇을 고쳤나

다행히 새 메커니즘을 만들 필요는 없었어요. `Agent_core.Error.is_retryable`이 이미 존재하는 타입 분류기라, 이 예산 초과 에러(`HookExecutionFailed`로 래핑됨)를 이미 재시도 불가로 판정하고 있었거든요. 문제는 `anti_rationalization.ml`이 에러를 로그용 문자열로 즉시 변환하면서 이 정보를 버리고 있었던 거예요.

- `Task.Anti_rationalization.review_result`에 `retryable` 필드를 추가했어요. 기본값은 `true`(기존 동작 유지)이고, 타입이 있는 에러를 만나는 유일한 분기(`Error error`)에서만 `Agent_core.Error.is_retryable error`로 채워요.
- `Completion_authority_agent`의 `process_outcome`이 `Deferred`에 `retryable`을 실어 나르고, `should_schedule_retry`라는 순수 함수가 그 값으로 재시도 여부를 결정해요. `process_task`는 이제 이 함수 하나만 봐요.
- `Verification_run_registry.Not_reviewed`도 같은 `retryable` 비트를 durable하게 남겨요 — 그래야 대시보드에서 "곧 재시도될 행"과 "이미 포기하고 멈춘 행"을 구분할 수 있어요.
- 대시보드는 `not_reviewed` row의 필수 필드로 `retryable`을 검증하고, `retryable=false`인 행에는 `[수동 확인 필요]` 표시를 붙였어요.

## 테스트

- `test_anti_rationalization_empty_reject.ml`에 두 케이스 추가: budget-overflow(`HookExecutionFailed`) 에러는 `retryable=false`, rate-limit(`RateLimited`) 에러는 `retryable=true`로 나오는지.
- 새 파일 `test_completion_authority_retry_policy.ml`: `should_schedule_retry`가 `Committed`/`Deferred{retryable=true}`/`Deferred{retryable=false}` 세 경우를 정확히 구분하는지 (팀장님이 요청하신 "재시도 안 됨 + 기존대로 재시도됨" 양방향 커버).
- `test_verification_run_registry.ml`에 `retryable` 값이 JSON 직렬화와 replay를 양쪽 값 모두 왕복하는지 추가.
- 대시보드 쪽 `dashboard-verification-runs.test.ts`에 `retryable: true`/`false` 케이스 추가.

로컬 검증:
- `dune build --root .` 클린
- `test_anti_rationalization_empty_reject`(9/9), `test_completion_authority_retry_policy`(3/3), `test_verification_run_registry`(14/14), `test_verification`(46/46), `test_eval_calibration`(39/39), `test_completion_trust_harness`(7/7, CI 미등록이지만 회귀 확인용으로 같이 돌림) 전부 통과
- 대시보드 `pnpm typecheck` 클린, `dashboard-verification-runs.test.ts`(13/13) 통과, 관련 파일 `eslint` 클린
- `scripts/audit-ci-test-targets.sh` 통과 (새 suite가 CI 목록에 정확히 등록됨)

## 건드리지 않은 것

- 라이브 config 값(팀장님이 이미 적용)
- evidence 총 바이트를 lane 용량에 연동하는 처방 C(별도 판단 필요, 이번 PR 범위 아님)
- `resolve_evaluator_runtime`/`build_prompt` 실패, commit 실패, 미처리 예외 — 이 넷은 타입 있는 에러가 없어서 여전히 기존 방식대로 무조건 재시도해요(현재 동작 그대로 보존)

## 리뷰 대응: P1 — retryable 필수화가 기존 registry 행을 깨뜨리는 문제

리뷰에서 나온 지적: `Not_reviewed.retryable`을 필수 필드로 만들면 (a) 이 PR 이전에 쓰인 `not_reviewed` 행이 replay마다 malformed로 분류되어 조용히 유실되고, (b) `run_registry_core.ml`의 `replay`는 `malformed = []`일 때만 `compact_replay_log`를 실행하므로(`lib/run_registry_core/run_registry_core.ml:498`), malformed 행이 하나라도 남아있으면 그 이후 **재기동마다 영원히 컴팩션이 안 돌아** 온디스크 `verification-runs.jsonl`이 무한 성장해요.

리뷰어가 제안한 "결측 시 `Ok true` 기본값"은 채택하지 않았어요. 그건 optional 필드 모양을 한 legacy compat reader라서, 이 repo가 이미 #28735(turn_record)에서 정한 hard-cut 계약("필수 필드 + 배포 시 store 컷, 조용한 기본값 금지")과 정면으로 어긋나요.

대신:
1. **디코더는 strict 유지** — 결측 `retryable`은 여전히 malformed로 분류되고 replay에서 드롭돼요.
2. **계약을 테스트로 명시**: `test_pre_retryable_not_reviewed_row_is_malformed_on_replay` (`test/test_verification_run_registry.ml`)를 추가해서, 이 PR 이전 코드가 쓴 모양의 `not_reviewed` 행(`gate`+`detail`만 있고 `retryable` 없음)이 replay에서 드롭되고 원본 파일에는 손대지 않은 채 남는다는 걸 명시적으로 고정했어요. 이게 "의도된 fresh-state 계약"이라는 걸 테스트가 문서화해요.
3. **배포 계약**: 이 PR을 배포할 때는 **라이브 verification run registry store를 컷(아카이브)해야 해요.**
   - 파일 경로: `/Users/dancer/me/.masc/verification-runs.jsonl` (일반형: `<masc_dir>/verification-runs.jsonl`, `server_runtime_bootstrap.ml:759-761`)
   - 컷 안 하면: 기존 행 유실(이미 malformed 취급되어 replay에서 드롭됨) + 그 시점부터 컴팩션 영구 정지(온디스크 파일 무한 성장)가 같이 발생해요.
   - task-336 사고 기록 자체는 이 PR과 별도로 이슈/로그/메모리에 이미 보존돼 있으니, registry store 유실이 사고 기록 자체를 지우진 않아요.

배포 시 컷은 팀장님이 진행하신다고 하셔서 이 PR에서 스크립트는 별도로 추가하지 않았어요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
