### PR TITLE
fix(keeper): report the dispatched runtime, not the lane hint, on cycle failure

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -956,13 +956,14 @@ let run_keeper_cycle
                      [attempt_runtime_candidates] actually dispatched —
                      [Runtime_lane_preference] sticky ordering can route a
                      lane keyed by one runtime id to a different candidate
-                     first (observed: a lane entered as
-                     "ollama_cloud...deepseek..." consistently dispatched
-                     "glm-coding.glm-5-turbo" first, and this log named the
-                     untried lane key instead of the runtime that actually
-                     errored). [keeper_cycle_failed_runtime_attribution]
-                     reports the dispatched candidate's own id when a
-                     same-turn deferral hint is available. *)
+                     first (observed 2026-08-15T11:49Z: the lane-entry
+                     runtime was consistently logged while a
+                     sticky-reordered sibling candidate actually dispatched,
+                     so this log named the untried lane key instead of the
+                     runtime that actually errored).
+                     [keeper_cycle_failed_runtime_attribution] reports the
+                     dispatched candidate's own id when a same-turn
+                     deferral hint is available. *)
                   let runtime_attribution =
                     keeper_cycle_failed_runtime_attribution
                       ~deferred_runtime_lane:turn_state.deferred_runtime_lane

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -950,13 +950,33 @@ let run_keeper_cycle
                     then Log.Keeper.warn
                     else Log.Keeper.error
                   in
+                  (* masc#28762: [final_execution.runtime_id] names the
+                     deferred-lane assignment this cycle was budgeted under,
+                     not necessarily the concrete candidate
+                     [attempt_runtime_candidates] actually dispatched —
+                     [Runtime_lane_preference] sticky ordering can route a
+                     lane keyed by one runtime id to a different candidate
+                     first (observed: a lane entered as
+                     "ollama_cloud...deepseek..." consistently dispatched
+                     "glm-coding.glm-5-turbo" first, and this log named the
+                     untried lane key instead of the runtime that actually
+                     errored). [keeper_cycle_failed_runtime_attribution]
+                     reports the dispatched candidate's own id when a
+                     same-turn deferral hint is available. *)
+                  let runtime_attribution =
+                    keeper_cycle_failed_runtime_attribution
+                      ~deferred_runtime_lane:turn_state.deferred_runtime_lane
+                      ~execution_runtime_id:final_execution.runtime_id
+                  in
                   log_keeper_cycle_failed
                     ~keeper_name:meta.name
-                    "%s: keeper cycle FAILED runtime=%s max_context=%d context_budget=%d \
+                    "%s: keeper cycle FAILED runtime=%s deferred_next_runtime=%s \
+                     max_context=%d context_budget=%d \
                      primary_budget=%d requested_override=%s system_and_user_bytes=%d \
                      latency=%dms%s error=%s"
                     meta.name
-                    final_execution.runtime_id
+                    runtime_attribution.reported_runtime_id
+                    runtime_attribution.deferred_next_runtime_id
                     final_execution.max_context
                     final_execution.max_context_resolution.effective_budget
                     final_execution.max_context_resolution.primary_budget

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -33,6 +33,21 @@ let require_last_execution_for_finalize ~keeper_name turn_state =
     Error err
 ;;
 
+type keeper_cycle_failed_runtime_attribution =
+  { reported_runtime_id : string
+  ; deferred_next_runtime_id : string
+  }
+
+let keeper_cycle_failed_runtime_attribution ~deferred_runtime_lane ~execution_runtime_id =
+  match deferred_runtime_lane with
+  | Some (hint : Keeper_turn_driver.deferred_runtime_lane) ->
+    { reported_runtime_id = hint.failed_runtime_id
+    ; deferred_next_runtime_id = hint.next_runtime_id
+    }
+  | None ->
+    { reported_runtime_id = execution_runtime_id; deferred_next_runtime_id = "none" }
+;;
+
 let turn_event_bus_manifest_decision
       (summary : Keeper_turn_runtime_budget.turn_event_bus_summary)
   =

--- a/lib/keeper/keeper_unified_turn_types.mli
+++ b/lib/keeper/keeper_unified_turn_types.mli
@@ -25,6 +25,35 @@ val require_last_execution_for_finalize :
   turn_state ->
   (Keeper_turn_runtime_budget.runtime_execution, Agent_core.Error.t) result
 
+(** Which runtime a "keeper cycle FAILED" report should name, and what the
+    (possibly different) next-attempt hint is. See
+    [keeper_cycle_failed_runtime_attribution] (masc#28762). *)
+type keeper_cycle_failed_runtime_attribution =
+  { reported_runtime_id : string
+    (** The runtime that actually dispatched and failed this cycle. *)
+  ; deferred_next_runtime_id : string
+    (** The runtime a same-turn deferral queued for the *next* cycle, or
+        ["none"] when no deferral occurred. Distinct fact from
+        [reported_runtime_id]; never conflate the two into one field. *)
+  }
+
+(** [keeper_cycle_failed_runtime_attribution ~deferred_runtime_lane
+    ~execution_runtime_id] resolves the runtime a failure report should
+    name. [execution_runtime_id] (typically [execution.runtime_id]) names
+    the deferred-lane assignment this cycle was budgeted under, not
+    necessarily the concrete candidate [attempt_runtime_candidates] actually
+    dispatched: [Runtime_lane_preference] sticky ordering can route a lane
+    keyed by one runtime id to a different candidate first. When
+    [deferred_runtime_lane] is [Some hint] (a same-turn deferral was
+    recorded), [hint.failed_runtime_id] is the dispatched candidate's own id
+    and is reported as [reported_runtime_id]; otherwise
+    [execution_runtime_id] is used as-is (no rotation occurred, so it is
+    already the dispatched candidate). *)
+val keeper_cycle_failed_runtime_attribution :
+  deferred_runtime_lane:Keeper_turn_driver.deferred_runtime_lane option ->
+  execution_runtime_id:string ->
+  keeper_cycle_failed_runtime_attribution
+
 val turn_event_bus_manifest_decision :
   Keeper_turn_runtime_budget.turn_event_bus_summary -> Yojson.Safe.t
 

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -271,6 +271,7 @@ normal_targets=(
   @test/runtest-test_dashboard_workspace
   @test/runtest-test_host_fd_pressure_poller
   @test/runtest-test_keeper_turn_driver_failover
+  @test/runtest-test_keeper_cycle_failed_runtime_attribution
   @test/runtest-test_keeper_turn_driver_accept
   @test/runtest-test_keeper_vision_tool
   @test/runtest-test_runtime_modality_reroute

--- a/test/dune
+++ b/test/dune
@@ -220,6 +220,7 @@
   test_keeper_context_overflow_shrink
   test_keeper_provider_call_deadline
   test_keeper_failed_selection_disposition
+  test_keeper_cycle_failed_runtime_attribution
   test_keeper_invalid_request_auto_recover
   test_keeper_surface_post
   test_keeper_person_notes
@@ -521,6 +522,7 @@
   test_keeper_context_overflow_shrink
   test_keeper_provider_call_deadline
   test_keeper_failed_selection_disposition
+  test_keeper_cycle_failed_runtime_attribution
   test_keeper_invalid_request_auto_recover
   test_keeper_surface_post
   test_keeper_person_notes

--- a/test/test_keeper_cycle_failed_runtime_attribution.ml
+++ b/test/test_keeper_cycle_failed_runtime_attribution.ml
@@ -1,0 +1,90 @@
+(** [keeper_cycle_failed_runtime_attribution] tests (masc#28762).
+
+    Reproduces the observed defect: a keeper cycle budgeted under a
+    deferred-lane assignment (e.g. "ollama_cloud...deepseek...") whose
+    [Runtime_lane_preference] sticky ordering actually dispatches a
+    different candidate first (e.g. "glm-coding.glm-5-turbo"). Before the
+    fix, the "keeper cycle FAILED" log named the untried lane assignment
+    instead of the runtime that actually errored — misattributing every
+    provider-wire failure on that lane to a provider that was never
+    contacted. *)
+
+open Alcotest
+
+module Types = Masc.Keeper_unified_turn_types
+module Driver = Masc.Keeper_turn_driver
+
+let malformed_payload_error =
+  Agent_core.Error.Provider
+    (Llm_provider.Error.ProviderWireError
+       { provider = "unknown"
+       ; format = Llm_provider.Http_client.Sse
+       ; kind = Llm_provider.Http_client.Malformed_payload
+       ; detail = "SSE parse failed: json_error: unexpected token"
+       })
+;;
+
+(** Mirrors the real incident (masc#28761/#28762, 2026-08-15T11:49:38Z,
+    keeper=sangsu, turn=6595): the cycle's [execution.runtime_id] is the
+    lane assignment "ollama_cloud.ollama-cloud-deepseek-v4-flash-0731",
+    but the candidate that was actually dispatched and failed is
+    "glm-coding.glm-5-turbo". *)
+let real_incident_lane =
+  Driver.For_testing.make_deferred_runtime_lane
+    ~assignment_id:"ollama_cloud.ollama-cloud-deepseek-v4-flash-0731"
+    ~failed_runtime_id:"glm-coding.glm-5-turbo"
+    ~next_runtime_id:"ollama_cloud.ollama-cloud-deepseek-v4-flash-0731"
+    ~later_runtime_ids:[]
+    ~failure:malformed_payload_error
+;;
+
+let test_deferred_lane_reports_the_dispatched_candidate () =
+  let attribution =
+    Types.keeper_cycle_failed_runtime_attribution
+      ~deferred_runtime_lane:(Some real_incident_lane)
+      ~execution_runtime_id:"ollama_cloud.ollama-cloud-deepseek-v4-flash-0731"
+  in
+  check string
+    "runtime= names the candidate that actually dispatched and failed, \
+     not the lane entry point"
+    "glm-coding.glm-5-turbo"
+    attribution.Types.reported_runtime_id;
+  check string
+    "deferred_next_runtime= is a separate field for what the next cycle \
+     will try"
+    "ollama_cloud.ollama-cloud-deepseek-v4-flash-0731"
+    attribution.Types.deferred_next_runtime_id
+;;
+
+let test_no_deferral_reports_the_execution_runtime_unchanged () =
+  let attribution =
+    Types.keeper_cycle_failed_runtime_attribution
+      ~deferred_runtime_lane:None
+      ~execution_runtime_id:"glm-coding.glm-5-turbo"
+  in
+  check string
+    "with no same-turn deferral, [execution_runtime_id] is already the \
+     dispatched candidate"
+    "glm-coding.glm-5-turbo"
+    attribution.Types.reported_runtime_id;
+  check string
+    "no deferral occurred, so there is no next-runtime hint to report"
+    "none"
+    attribution.Types.deferred_next_runtime_id
+;;
+
+let () =
+  run "keeper_cycle_failed_runtime_attribution"
+    [ ( "attribution"
+      , [ test_case
+            "same-turn deferral reports the dispatched candidate, not the \
+             lane assignment"
+            `Quick
+            test_deferred_lane_reports_the_dispatched_candidate
+        ; test_case
+            "no deferral reports the execution runtime unchanged"
+            `Quick
+            test_no_deferral_reports_the_execution_runtime_unchanged
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 요약

masc#28762 수리입니다. `keeper cycle FAILED runtime=%s` 로그가 실제로 실패한 runtime이 아니라, 이번 사이클이 예산을 계산한 deferred-lane 진입점(예: `ollama_cloud.ollama-cloud-deepseek-v4-flash-0731`)을 찍고 있었어요.

`Runtime_lane_preference`의 sticky ordering이 한 runtime id로 진입한 lane을 다른 candidate로 먼저 라우팅할 수 있어서(`attempt_runtime_candidates`가 실제로 시도한 건 `glm-coding.glm-5-turbo`), 로그만 보면 마치 `ollama_cloud`가 실패한 것처럼 보였습니다. masc#28761(SSE malformed_payload 조사) 과정에서, "GLM과 ollama_cloud 두 provider에서 동일 증상"이라고 잘못 판단하게 만든 원인이 바로 이 오귀속이었어요.

## 변경 내용

- `lib/keeper/keeper_unified_turn_types.ml`/`.mli`: `keeper_cycle_failed_runtime_attribution` 순수 함수를 추가했습니다. `deferred_runtime_lane` 힌트가 있으면 `failed_runtime_id`(실제 디스패치된 candidate)를 `reported_runtime_id`로, `next_runtime_id`를 별도 `deferred_next_runtime_id` 필드로 분리해서 돌려줍니다. 힌트가 없으면 기존처럼 `execution_runtime_id`를 그대로 씁니다.
- `lib/keeper/keeper_unified_turn.ml`: "keeper cycle FAILED" 로그가 이 함수를 호출하도록 바꾸고, 로그 포맷에 `deferred_next_runtime=%s` 필드를 추가했습니다 (문자열 재구성이 아니라 typed 필드 두 개를 각자 이름으로 찍습니다).
- `test/test_keeper_cycle_failed_runtime_attribution.ml`: 2026-08-15T11:49:38Z 실제 인시던트를 그대로 재현하는 회귀 테스트입니다. `Driver.For_testing.make_deferred_runtime_lane`로 `failed_runtime_id="glm-coding.glm-5-turbo"`, `next_runtime_id="ollama_cloud..."`인 힌트를 만들고, `execution_runtime_id`엔 lane 진입점("ollama_cloud...")을 넣어서, 결과가 실제 실패 candidate(glm-coding)를 가리키는지 확인합니다. 힌트가 없는 경우(회귀 없음)도 같이 검증합니다.

## 로컬 검증

```
dune build --root . test/test_keeper_cycle_failed_runtime_attribution.exe lib/.masc.objs/byte/masc__Keeper_unified_turn.cmo
dune exec --root . test/test_keeper_cycle_failed_runtime_attribution.exe   # 2 tests run, 전부 OK
dune exec --root . test/test_keeper_failed_selection_disposition.exe      # 기존 8 tests, 회귀 없음
dune exec --root . test/test_keeper_turn_driver_failover.exe              # 기존 45 tests, 회귀 없음
```

`.ocamlformat` 기준으로 수정한 4개 파일(`.ml`/`.mli`/test) 모두 `ocamlformat <file> | diff - <file>`로 확인, diff 없음 (레포 전체 `@fmt --auto-promote`는 무관한 dune 파일들까지 재포맷해서 되돌리고 파일 단위로만 확인했습니다).

전체 빌드/전체 테스트는 CI에 맡깁니다.

## 스코프 밖

`max_context`/`context_budget`가 lane 진입점(예: ollama_cloud의 1048576) 기준으로 계산되는데 실제로는 다른 candidate(GLM, max-context 203000)가 디스패치되는 경우가 있다는 것도 확인했는데, 이건 로그 라벨링이 아니라 예산 산정 자체의 문제라 이번 PR 스코프 밖입니다. 별도로 다뤄야 할 것 같아요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)