### PR TITLE
chore(transport): 죽은 bridge 집계 함수와 그것만 쓰던 PROVIDER 멤버 제거

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1629,45 +1629,24 @@ let run ~sw ~env ~host ~port ~base_path ?input_base_path ~make_routes ~make_requ
         let protocol = Transport.Sse
         let is_enabled () = true  (* SSE is always enabled *)
         let session_count () = Sse.client_count ()
-        let status_json () = `Assoc [
-          "clients", `Int (Sse.client_count ());
-          "external_subscribers", `Int (Sse.external_subscriber_count ());
-        ]
-        let reap_stale () = List.length (Sse.cleanup_stale ())
       end);
       Transport_bridge.register_provider (module struct
         let name = "ws"
         let protocol = Transport.Ws
         let is_enabled () = Server_ws_standalone.is_enabled ()
         let session_count () = Server_mcp_transport_ws.session_count ()
-        let status_json () = `Assoc [
-          "port", `Int (Server_ws_standalone.configured_port ());
-          "sessions", `Int (Server_mcp_transport_ws.session_count ());
-        ]
-        let reap_stale () = 0  (* WS sessions self-clean on disconnect *)
       end);
       Transport_bridge.register_provider (module struct
         let name = "grpc"
         let protocol = Transport.Grpc
         let is_enabled () = Masc_grpc_server.is_enabled ()
         let session_count () = 0  (* gRPC uses per-call, no persistent sessions *)
-        let status_json () = `Assoc [
-          "port", `Int (Masc_grpc_server.configured_port ());
-          "service", `String Masc_grpc_service.service_name;
-        ]
-        let reap_stale () = 0
       end);
       Transport_bridge.register_provider (module struct
         let name = "webrtc"
         let protocol = Transport.Webrtc
         let is_enabled () = Server_webrtc_transport.is_enabled ()
         let session_count () = Server_webrtc_transport.live_webrtc_count ()
-        let status_json () = `Assoc [
-          "active_peers", `Int (Server_webrtc_transport.active_peer_count ());
-          "live_connections", `Int (Server_webrtc_transport.live_webrtc_count ());
-          "connected_channels", `Int (Server_webrtc_transport.connected_channel_count ());
-        ]
-        let reap_stale () = 0  (* WebRTC has its own ICE timeout *)
       end);
       Transport_bridge.seal ();
       (* Cold-start warm-cache stagger is handled by warm_delay_s in each

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -1232,11 +1232,6 @@ let client_count_by_kind kind =
     (Atomic.get clients).entries
     0
 
-(** Return list of session_ids for all connected clients.
-    Used by transport metrics to report session count by kind. *)
-let all_session_ids () =
-  SMap.fold (fun sid _client acc -> sid :: acc) (Atomic.get clients).entries []
-
 (** Close all SSE clients - for graceful shutdown.
     Returns the number of clients that were closed. *)
 let close_all_clients () =

--- a/lib/sse.mli
+++ b/lib/sse.mli
@@ -131,7 +131,6 @@ val clear_disconnect_hook : string -> unit
 val exists : string -> bool
 val touch : string -> unit
 val update_last_event_id : string -> int -> unit
-val all_session_ids : unit -> string list
 val client_count : unit -> int
 val client_count_by_kind : session_kind -> int
 val close_all_clients : unit -> int

--- a/lib/transport_bridge.ml
+++ b/lib/transport_bridge.ml
@@ -8,8 +8,6 @@ module type PROVIDER = sig
   val protocol : Transport.protocol
   val is_enabled : unit -> bool
   val session_count : unit -> int
-  val status_json : unit -> Yojson.Safe.t
-  val reap_stale : unit -> int
 end
 
 (* ── Registry ─────────────────────────────────────────── *)
@@ -45,8 +43,6 @@ let register_provider (p : (module PROVIDER)) =
     update ()
   end
 
-let providers () = Atomic.get registry
-
 let provider_by_name name =
   List.find_opt
     (fun m ->
@@ -61,29 +57,6 @@ let total_session_count () =
     (fun acc m ->
        let module M = (val m : PROVIDER) in
        if M.is_enabled () then acc + M.session_count () else acc)
-    0
-    (Atomic.get registry)
-
-let status_all_json () =
-  `Assoc
-    (List.map
-       (fun m ->
-          let module M = (val m : PROVIDER) in
-          ( M.name,
-            `Assoc
-              [
-                "enabled", `Bool (M.is_enabled ());
-                "protocol", `String (Transport.protocol_to_string M.protocol);
-                "sessions", `Int (M.session_count ());
-                "detail", M.status_json ();
-              ] ))
-       (Atomic.get registry))
-
-let reap_all_stale () =
-  List.fold_left
-    (fun acc m ->
-       let module M = (val m : PROVIDER) in
-       if M.is_enabled () then acc + M.reap_stale () else acc)
     0
     (Atomic.get registry)
 

--- a/lib/transport_bridge.mli
+++ b/lib/transport_bridge.mli
@@ -3,8 +3,11 @@
     Each transport (SSE, WS, gRPC, WebRTC) implements {!PROVIDER}
     and registers at server bootstrap. The bridge centralizes:
     - Discovery: protocol enumeration, Agent Card generation
-    - Lifecycle: session reaping across all transports
     - Metrics: aggregate session/connection counts
+
+    Session reaping is not centralized here: SSE reaps via
+    {!Server_bootstrap_maintenance}, and the other transports clean up
+    on disconnect.
 
     Broadcast still flows through SSE's external_subscriber
     pattern. This module does not replace that mechanism. *)
@@ -22,12 +25,6 @@ module type PROVIDER = sig
 
   val session_count : unit -> int
   (** Number of active sessions/connections right now. *)
-
-  val status_json : unit -> Yojson.Safe.t
-  (** Protocol-specific status for diagnostic endpoints. *)
-
-  val reap_stale : unit -> int
-  (** Clean up dead/idle sessions. Returns number reaped. *)
 end
 
 (** {1 Provider Registry} *)
@@ -42,9 +39,6 @@ val seal : unit -> unit
     registered (end of bootstrap). Post-seal reads from multiple
     fibers are safe without synchronization. *)
 
-val providers : unit -> (module PROVIDER) list
-(** All registered providers, in registration order. *)
-
 val provider_by_name : string -> (module PROVIDER) option
 (** Lookup a provider by its [name] field. *)
 
@@ -52,12 +46,6 @@ val provider_by_name : string -> (module PROVIDER) option
 
 val total_session_count : unit -> int
 (** Sum of [session_count] across all enabled providers. *)
-
-val status_all_json : unit -> Yojson.Safe.t
-(** Assoc of provider name -> status_json for all providers. *)
-
-val reap_all_stale : unit -> int
-(** Reap stale sessions across all providers. Returns total reaped. *)
 
 val enabled_protocols : unit -> Transport.protocol list
 (** List of protocols with at least one enabled provider. *)

--- a/test/test_transport_bridge_seal.ml
+++ b/test/test_transport_bridge_seal.ml
@@ -7,8 +7,6 @@ module MockProvider : Masc.Transport_bridge.PROVIDER = struct
   let protocol = Masc.Transport.Sse
   let is_enabled () = false
   let session_count () = 0
-  let status_json () = `Null
-  let reap_stale () = 0
 end
 
 let test_seal_blocks_registration () =


### PR DESCRIPTION
프로토콜 감사 후속 **2번**입니다. PR #28766(문서 정리)과 파일이 겹치지 않아 독립적으로 착륙 가능합니다.

## 무엇을 지우나

`Transport_bridge`가 노출한 집계 3개에 `lib/`·`bin/`·`test/` 전체를 통틀어 호출자가 없습니다.

| 대상 | 위치 | 호출자 |
|---|---|---|
| `providers` | `transport_bridge.ml:48` | 0 |
| `status_all_json` | `:67` | 0 |
| `reap_all_stale` | `:82` | 0 |
| `Sse.all_session_ids` | `sse.ml:1237` / `sse.mli:134` | 0 |

`Transport_bridge` 모듈 자체는 살아 있습니다 — `provider_by_name`, `total_session_count`, `enabled_protocols`, `agent_card_transports_json`, `seal`, `register_provider` 전부 실사용 호출자가 있습니다.

## 연쇄를 끝까지 따라간 이유

집계 둘을 지우면 PROVIDER 시그니처 멤버 둘이 고아가 됩니다.

- `status_json` → 소비자는 `status_all_json` 하나뿐
- `reap_stale` → 소비자는 `reap_all_stale` 하나뿐

여기서 멈추면 provider 구현 4개가 **아무도 안 읽는 값을 계속 만들게** 됩니다. 부분 정리는 그 자체로 해로우니 체인을 함께 제거했습니다.

- `transport_bridge.{ml,mli}` — PROVIDER에서 두 멤버 제거
- `server_runtime_bootstrap.ml` — sse / ws / grpc / webrtc 4개 struct에서 제거
- `test_transport_bridge_seal.ml` — mock에서 제거

## 연쇄가 멈추는 지점 (확인함)

한 단계 더 내려가면 멈춥니다. 이걸 확인 안 하면 살아 있는 함수를 지울 뻔했습니다.

- `Sse.cleanup_stale` — sse provider의 `reap_stale`이 감싸던 함수인데, **janitor에 진짜 호출자**가 있습니다 (`server_bootstrap_maintenance.ml:631`). 유지.
- `Sse.external_subscriber_count` — sse provider의 `status_json`이 읽던 값인데, `test/test_sse_external_sub.ml`이 여러 곳에서 사용합니다. 유지.

## 파괴 위험 점검

bridge 밖에서 PROVIDER를 unpack하는 곳은 `transport_read_model.ml:170` 하나이고, `M.session_count ()`만 부릅니다 — 유지한 멤버입니다.

bridge 안의 나머지 unpack(`provider_by_name`, `total_session_count`, `enabled_protocols`, `agent_card_transports_json`)도 `name`/`protocol`/`is_enabled`/`session_count`만 씁니다.

## 곁다리로 고친 문서

- `transport_bridge.mli` 헤더가 "Lifecycle: session reaping across all transports"라고 주장하는데, 그 중앙집중 reaping이 바로 지금 지우는 죽은 코드였습니다. 실제 동작(SSE는 janitor가, 나머지는 disconnect 시 self-clean)으로 교체했습니다.
- `Sse.all_session_ids`의 주석은 "Used by transport metrics to report session count by kind"였는데 소비자가 0이었습니다.

## 검증

`dune build @default @check @install`로 시그니처 변경이 모든 구현부에 반영됐는지 확인됩니다. 런타임 동작 변화는 없습니다 — 지운 것 전부 아무도 부르지 않던 코드입니다.

## 후속 (이 PR 범위 아님)

`test/sse_event/test_sse_event.ml` 826줄이 삭제된 `lib/runtime/runtime_event_bridge.wrap_event`의 복제본을 유지하며 byte-identity를 검사합니다. CI의 sse 그룹은 `test_sse_coverage`·`test_ag_ui_coverage`·`test_sse_storm_e2e` 셋뿐이라 이 스위트는 실행되지 않습니다. 별도 PR로 다루겠습니다.