### PR TITLE
fix(dashboard): WS가 이미 push하는 표면 2곳의 폴링 제거

### DIFF
--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -359,17 +359,16 @@ export function TransportHealthPanel() {
       { cooldownMs: 0, debounceMs: 1200 },
     )
 
-    const interval = setInterval(() => {
-      void refreshTransportHealth()
-    }, 30_000)
-
+    // No periodic poll: the server recomputes this surface on a 30s
+    // Proactive_refresh and pushes `transport_health_snapshot`, which
+    // sse-store hydrates into this same resource. A client timer could
+    // only re-read the same 30s cache entry the push already delivered.
     const unsubscribe = lastEvent.subscribe((event) => {
       if (!event || !shouldRefreshFromEvent(event)) return
       sseRefreshScheduler.request()
     })
 
     return () => {
-      clearInterval(interval)
       unsubscribe()
       sseRefreshScheduler.dispose()
       transportHealthResource.cancel()

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -996,9 +996,12 @@ let _periodicId: ReturnType<typeof setInterval> | null = null
 export function startPeriodicRefresh(): void {
   if (_periodicId) return
   _periodicId = setInterval(() => {
-    if (!dashboardWsReady.value) {
-      invalidateDashboardCache()
-    }
+    // Fallback only. While the WS is delivering, every route surface this
+    // would refetch is already hydrated by push, so firing anyway just
+    // duplicates the traffic. Previously only invalidateDashboardCache()
+    // was gated and the two refresh calls ran unconditionally.
+    if (dashboardWsReady.value) return
+    invalidateDashboardCache()
     requestNamespaceTruth()
     void refreshActiveRoute().catch(err =>
       console.warn('[periodic] route refresh failed', err instanceof Error ? err.message : err),


### PR DESCRIPTION
프로토콜 감사 후속 **3번**입니다. FE 전용이고 서버 변경이 없어 #28766·#28767과 파일이 겹치지 않습니다.

## 왜 중복인가

두 타이머 모두 **서버 push가 이미 배달한 데이터를 다시 가져옵니다.**

### 1. transport-health 패널 (30초)

서버가 `Proactive_refresh`로 30초마다 재계산하고 `transport_health_snapshot`을 브로드캐스트합니다 (`server_dashboard_http_execution_surfaces.ml:1099`, `interval_s = 30.0`). 그 이벤트를 `sse-store.ts:854`가 받아서 패널이 읽는 **바로 그 resource**에 넣습니다.

즉 클라이언트 타이머는 같은 30초 캐시 엔트리를 다시 읽을 뿐입니다. 라이브 서버에서 확인했습니다 — 20초 간격으로 두 번 GET 했더니 `generated_at`이 동일했습니다:

```
1st: "generated_at": "2026-08-15T16:12:02Z"
2nd: "generated_at": "2026-08-15T16:12:02Z"   ← 20초 뒤, 같은 값
```

재계산 사이에 낀 폴은 구조적으로 새 정보를 볼 수 없습니다.

유지한 것: 마운트 시 fetch(첫 페인트 + WS 다운 복구), 그리고 이벤트 구동 refresh(`shouldRefreshFromEvent`).

### 2. sse-store 주기 refresh (prod 120초 / dev 180초)

`!dashboardWsReady` 가드가 `invalidateDashboardCache()`에만 걸려 있었고, `requestNamespaceTruth()`와 `refreshActiveRoute()`는 **WS가 정상 push 중일 때도 무조건** 실행됐습니다.

본문 전체를 가드 아래로 옮겨 폴백 전용으로 만들었습니다. WS가 죽었을 때 동작은 그대로입니다.

## 뺀 것과 이유

감사 원안은 5곳이었는데, 확인해 보니 셋은 이 PR에 맞지 않습니다.

| 사이트 | 왜 뺐나 |
|---|---|
| `fsm-hub.ts:584` | 30초 틱이 폴링만 하는 게 아니라, store에 keeper가 없을 때 **gate-keeper fallback을 재시도**합니다. 제거하면 첫 fallback fetch가 실패했을 때 복구 경로가 사라집니다. "위험 0" PR에 넣을 변경이 아닙니다. |
| `keeper-detail-hooks.ts:54` | raw interval이 아니라 `setupVisibleAutoRefresh` 팩토리 뒤에 있습니다. |
| `approvals-surface.ts:769` | 위와 동일. |

팩토리 뒤 사이트는 개별 우회 대신 팩토리 시그니처를 고쳐 9곳이 함께 움직이는 게 맞아서, 다음 PR로 넘깁니다.

## 검증

- 두 파일 모두 기존 동작을 고정하는 테스트가 없습니다 (`transport-health.test.ts`에 interval/마운트 assertion 0건, `startPeriodicRefresh`는 테스트 파일 없음).
- CI의 Dashboard job이 타입체크와 vitest를 돌립니다. (worktree에 node_modules가 없어 로컬 vitest는 생략했습니다.)
- 라이브 확인 방법: 대시보드를 열고 네트워크 패널을 2분 관찰. WS가 살아 있는 동안 `/api/v1/dashboard/transport-health` GET이 0이고 패널은 계속 갱신되면 통과. WS를 끊으면 폴백 폴이 다시 도는지도 같이 확인.