### PR TITLE
feat(dashboard): setupVisibleAutoRefresh가 server-push 피드를 받는다

### DIFF
--- a/dashboard/src/components/keeper-detail-hooks.ts
+++ b/dashboard/src/components/keeper-detail-hooks.ts
@@ -3,6 +3,7 @@ import { keeperRuntimeTraceRefreshNonce } from './keeper-runtime-trace-refresh'
 import { fetchKeeperComposite, fetchKeeperRuntimeTrace } from '../api/keeper'
 import type { KeeperCompositeSnapshot, KeeperRuntimeTraceResponse } from '../api/keeper'
 import { DEFAULT_PANEL_REFRESH_MS, setupVisibleAutoRefresh } from '../lib/auto-refresh'
+import { compositeTick } from '../composite-signals'
 import { errorMessageOr } from '../lib/format-string'
 import {
   applyFetchFailed,
@@ -51,7 +52,20 @@ export function useKeeperCompositeEvidence(keeperName: string): KeeperDetailEvid
       }
     }
     void refresh()
-    const cleanup = setupVisibleAutoRefresh(refresh, DEFAULT_PANEL_REFRESH_MS)
+    const cleanup = setupVisibleAutoRefresh(refresh, DEFAULT_PANEL_REFRESH_MS, {
+      // keeper_composite_changed is signal-only freshness transport: the
+      // registry broadcasts a {name, ts_unix} envelope and subscribers
+      // re-fetch the authoritative payload. See composite-signals.ts.
+      subscribeToPush: (onPush) => {
+        let seen = compositeTick.value.ts_unix
+        return compositeTick.subscribe((tick) => {
+          if (tick.name !== keeperName) return
+          if (tick.ts_unix === seen) return
+          seen = tick.ts_unix
+          onPush()
+        })
+      },
+    })
     return () => {
       cancelled = true
       controller.abort()

--- a/dashboard/src/lib/auto-refresh.test.ts
+++ b/dashboard/src/lib/auto-refresh.test.ts
@@ -112,4 +112,68 @@ describe('auto-refresh', () => {
     expect(refresh).toHaveBeenCalledTimes(1)
     dispose()
   })
+
+  it('refreshes when the push feed fires', async () => {
+    const refresh = vi.fn()
+    let emitPush = (): void => {}
+    const dispose = setupVisibleAutoRefresh(refresh, 30_000, {
+      subscribeToPush: (onPush) => {
+        emitPush = onPush
+        return () => {}
+      },
+    })
+
+    emitPush()
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(refresh).toHaveBeenCalledTimes(1)
+    dispose()
+  })
+
+  it('skips the interval tick when a push already refreshed within the interval', async () => {
+    const refresh = vi.fn()
+    let emitPush = (): void => {}
+    const dispose = setupVisibleAutoRefresh(refresh, 1_000, {
+      subscribeToPush: (onPush) => {
+        emitPush = onPush
+        return () => {}
+      },
+    })
+
+    // Push at t=600 covers the tick at t=1000.
+    await vi.advanceTimersByTimeAsync(600)
+    emitPush()
+    expect(refresh).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(400)
+    expect(refresh).toHaveBeenCalledTimes(1)
+
+    // Push stopped, so the timer takes over again on the next tick.
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(refresh).toHaveBeenCalledTimes(2)
+    dispose()
+  })
+
+  it('leaves timer behaviour untouched when no push feed is supplied', async () => {
+    const refresh = vi.fn()
+    const dispose = setupVisibleAutoRefresh(refresh, 200)
+
+    await vi.advanceTimersByTimeAsync(200)
+    await vi.advanceTimersByTimeAsync(200)
+
+    expect(refresh).toHaveBeenCalledTimes(2)
+    dispose()
+  })
+
+  it('unsubscribes from the push feed on cleanup', () => {
+    const refresh = vi.fn()
+    const unsubscribe = vi.fn()
+    const dispose = setupVisibleAutoRefresh(refresh, 30_000, {
+      subscribeToPush: () => unsubscribe,
+    })
+
+    expect(unsubscribe).not.toHaveBeenCalled()
+    dispose()
+    expect(unsubscribe).toHaveBeenCalledTimes(1)
+  })
 })

--- a/dashboard/src/lib/auto-refresh.ts
+++ b/dashboard/src/lib/auto-refresh.ts
@@ -19,33 +19,68 @@ export function formatAutoRefreshLabel(intervalMs: number): string {
   return `Auto-refresh ${seconds}s`
 }
 
+type RefreshSource = 'push' | 'event' | 'interval'
+
+/**
+ * Sources that can arrive in bursts and therefore need dedupe. The
+ * interval cannot burst against itself, so two interval ticks never
+ * dedupe each other.
+ */
+const isBurstSource = (source: RefreshSource | null): boolean =>
+  source === 'event' || source === 'push'
+
+export interface VisibleAutoRefreshOptions {
+  /**
+   * Register a server-push notification for this panel's data. Called
+   * once at setup; must return an unsubscribe function.
+   *
+   * When supplied, the timer becomes a fallback: a tick is skipped if a
+   * push already refreshed within the last interval. If push stops, the
+   * timer resumes on the next tick, so a dead WS costs at most one
+   * interval of staleness rather than freezing the panel.
+   */
+  subscribeToPush?: (onPush: () => void) => () => void
+}
+
 export function setupVisibleAutoRefresh(
   refresh: () => void | Promise<void>,
   intervalMs: number,
+  options: VisibleAutoRefreshOptions = {},
 ): () => void {
   let lastRefreshAt = 0
-  let lastRefreshSource: 'event' | 'interval' | null = null
+  let lastRefreshSource: RefreshSource | null = null
+  let lastPushAt = 0
 
-  const runRefresh = (source: 'event' | 'interval') => {
+  const runRefresh = (source: RefreshSource) => {
     if (typeof document.visibilityState === 'string' && document.visibilityState !== 'visible') return
     const now = Date.now()
-    const dedupeRecentRefresh = source === 'event' || lastRefreshSource === 'event'
+    const dedupeRecentRefresh = isBurstSource(source) || isBurstSource(lastRefreshSource)
     if (dedupeRecentRefresh && now - lastRefreshAt < AUTO_REFRESH_EVENT_DEDUPE_MS) return
     lastRefreshAt = now
     lastRefreshSource = source
+    if (source === 'push') lastPushAt = now
     void refresh()
   }
 
-  const runIntervalRefresh = () => { runRefresh('interval') }
+  const runIntervalRefresh = () => {
+    // A push within the last interval already delivered what this tick
+    // would fetch. Without a push feed lastPushAt stays 0 and the timer
+    // behaves exactly as before.
+    if (lastPushAt !== 0 && Date.now() - lastPushAt < intervalMs) return
+    runRefresh('interval')
+  }
   const runEventRefresh = () => { runRefresh('event') }
+  const runPushRefresh = () => { runRefresh('push') }
 
   const interval = window.setInterval(runIntervalRefresh, intervalMs)
   window.addEventListener('focus', runEventRefresh)
   document.addEventListener('visibilitychange', runEventRefresh)
+  const unsubscribePush = options.subscribeToPush?.(runPushRefresh) ?? null
 
   return () => {
     window.clearInterval(interval)
     window.removeEventListener('focus', runEventRefresh)
     document.removeEventListener('visibilitychange', runEventRefresh)
+    unsubscribePush?.()
   }
 }


### PR DESCRIPTION
프로토콜 감사 후속 **4번**입니다. #28768(폴링 제거)과 파일이 겹치지 않아 독립 착륙 가능합니다.

## 문제

패널 9곳이 이 팩토리를 공유하는데, **서버가 이미 같은 데이터를 push하는 경우에도 전부 타이머로 폴링**합니다. 사이트마다 개별 구독으로 풀어헤치는 대신 팩토리에 push 피드를 추가하고 타이머를 폴백으로 강등했습니다.

```ts
setupVisibleAutoRefresh(refresh, intervalMs, {
  subscribeToPush: (onPush) => unsubscribe,
})
```

## 설계

interval 틱은 **직전 interval 안에 push가 왔으면 건너뜁니다.** push가 멈추면 다음 틱에서 타이머가 다시 인계받으므로, WS가 죽어도 최대 1 interval 만큼만 낡습니다 — 패널이 얼어붙지 않습니다.

`lib/`에 WS 스토어를 끌어들이지 않으려고 `dashboardWsReady` 같은 전역 의존 대신 **자기완결 방식**을 썼습니다. 팩토리는 자기가 받은 push의 시각만 알면 됩니다.

옵션을 안 주면 `lastPushAt`이 0으로 남아 타이머 동작이 이전과 **완전히 동일**합니다. 기존 호출부 4곳은 손대지 않았습니다.

dedupe 조건은 `source === 'event' || lastRefreshSource === 'event'`에서 `isBurstSource`(= `'event' | 'push'`)로 바뀝니다. interval끼리는 여전히 dedupe하지 않으므로 기존 타이머 테스트가 그대로 성립합니다.

## 첫 적용: `useKeeperCompositeEvidence`

`compositeTick`이 이미 정확히 이 용도로 설계돼 있습니다. `composite-signals.ts`가 `keeper_composite_changed`를 "signal-only freshness transport — 구독자는 authoritative payload를 재fetch한다"라고 명시합니다.

체인이 끝까지 살아 있는 것도 확인했습니다:

| 단계 | 위치 |
|---|---|
| 서버 발행 | `keeper_registry_broadcast.ml:16` |
| 클라이언트 수신 | `sse-store.ts:900` → `compositeTick.value = { name, ts_unix }` |

구독은 keeper 이름과 **변화한 `ts_unix`**로 필터링합니다. preact signal의 `subscribe`가 등록 즉시 현재 값으로 1회 발화하는데, 그게 훅 자신의 마운트 fetch와 겹쳐 중복 요청이 되는 걸 막기 위해서입니다.

## 이번에 안 붙인 것

`approvals-surface`. push 경로가 실재하긴 하는데 **전역**입니다 — approval 이벤트가 sse-store의 `_refreshGateFn`을 통해 `refreshGate`에 닿고, 컴포넌트를 거치지 않습니다. 그래서 팩토리 인스턴스가 push를 관측할 수 없고, gate-refresh 알림을 먼저 배선해야 합니다. 모양이 달라서 별도 변경으로 뺐습니다.

## 테스트

`auto-refresh.test.ts`에 4건 추가:

- push 피드가 발화하면 refresh 된다
- push가 살아 있는 동안 interval 틱이 건너뛰어진다
- push가 멈추면 다음 틱에서 타이머가 재개된다
- push 피드가 없으면 타이머 동작이 그대로다
- cleanup에서 unsubscribe 된다

기존 7건은 수정 없이 통과해야 합니다 (dedupe 확장이 interval-vs-interval 경로를 안 건드립니다).