### PR TITLE
fix(keeper): terminalize board attention completions with a retired candidate

### DIFF
--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -2036,64 +2036,80 @@ let record_and_wake ~base_path candidate =
       }
 ;;
 
+type judgment_delivery_outcome =
+  | Delivered of candidate
+  | Candidate_absent
+      (** The candidate this partition's [Completed] item names is not in the
+          live ledger. A retire moves the whole candidate store aside as one
+          directory (scripts/check-runtime-deployment-preflight.sh); it never
+          leaves a tombstone the live ledger can read back, so this cannot
+          distinguish "retired" from any other cause a candidate is gone —
+          both mean the same thing for this delivery: it cannot succeed on a
+          retry of the identical request, because the row it would update no
+          longer exists. Every other failure below stays a typed [Error],
+          because those represent a live candidate in an unexpected state,
+          which is a bug this function must keep reporting loudly rather than
+          quietly resolve. *)
+
 let apply_judgment_and_deliver ~base_path ~keeper_name ~candidate_id ~judgment =
   let* candidates = load_candidates ~base_path ~keeper_name in
-  let* candidate =
-    match find_candidate candidates candidate_id with
-    | Some candidate -> Ok candidate
-    | None -> Error ("Board attention candidate not found: " ^ candidate_id)
-  in
-  let* judged_candidate =
-    match status_view candidate.status with
-    | Direct_resumable (Resumable_pending _)
-    | Requeued_resumable { resumable = Resumable_pending _; _ } ->
-      record_judgment ~base_path candidate judgment
-    | Direct_resumable (Resumable_judged judged)
-    | Requeued_resumable
-        { resumable = Resumable_judged judged; _ }
-      when same_judgment judged.judgment judgment ->
-      Ok candidate
-    | Direct_resumable (Resumable_consumed consumed)
-    | Requeued_resumable
-        { resumable = Resumable_consumed consumed; _ }
-      when same_judgment consumed.judgment judgment ->
-      Ok candidate
-    | Direct_resumable (Resumable_judged _ | Resumable_consumed _)
-    | Requeued_resumable
-        { resumable = (Resumable_judged _ | Resumable_consumed _); _ } ->
-      Error ("Board attention candidate judgment conflicts with worker result: " ^ candidate_id)
-    | Suspended_quarantine _ ->
-      Error
-        ("Quarantined or requeue-requested Board attention candidate cannot be settled: "
-         ^ candidate_id)
-  in
-  match status_view judged_candidate.status with
-  | Direct_resumable (Resumable_consumed _)
-  | Requeued_resumable { resumable = Resumable_consumed _; _ } ->
-    normalize_requeued_consumed ~base_path ~keeper_name ~candidate_id
-  | Direct_resumable (Resumable_pending _)
-  | Requeued_resumable { resumable = Resumable_pending _; _ } ->
-    Error ("Board attention candidate remained Pending after judgment commit: " ^ candidate_id)
-  | Direct_resumable (Resumable_judged judged)
-  | Requeued_resumable
-      { resumable = Resumable_judged judged; _ } ->
-    let* delivered = consume_judged ~base_path judged_candidate judged in
-    (match status_view delivered.status with
-     | Direct_resumable (Resumable_consumed _)
-     | Requeued_resumable { resumable = Resumable_consumed _; _ } ->
-       normalize_requeued_consumed ~base_path ~keeper_name ~candidate_id
-     | Direct_resumable (Resumable_pending _ | Resumable_judged _)
-     | Requeued_resumable
-         { resumable = (Resumable_pending _ | Resumable_judged _); _ } ->
-       Error
-         ("Board attention candidate delivery did not reach Consumed: "
-          ^ candidate_id)
-     | Suspended_quarantine _ ->
-       Error
-         ("Board attention candidate became quarantined during delivery: "
-          ^ candidate_id))
-  | Suspended_quarantine _ ->
-    Error
-      ("Quarantined or requeue-requested Board attention candidate cannot be settled: "
-       ^ candidate_id)
+  match find_candidate candidates candidate_id with
+  | None -> Ok Candidate_absent
+  | Some candidate ->
+    let* judged_candidate =
+      match status_view candidate.status with
+      | Direct_resumable (Resumable_pending _)
+      | Requeued_resumable { resumable = Resumable_pending _; _ } ->
+        record_judgment ~base_path candidate judgment
+      | Direct_resumable (Resumable_judged judged)
+      | Requeued_resumable
+          { resumable = Resumable_judged judged; _ }
+        when same_judgment judged.judgment judgment ->
+        Ok candidate
+      | Direct_resumable (Resumable_consumed consumed)
+      | Requeued_resumable
+          { resumable = Resumable_consumed consumed; _ }
+        when same_judgment consumed.judgment judgment ->
+        Ok candidate
+      | Direct_resumable (Resumable_judged _ | Resumable_consumed _)
+      | Requeued_resumable
+          { resumable = (Resumable_judged _ | Resumable_consumed _); _ } ->
+        Error ("Board attention candidate judgment conflicts with worker result: " ^ candidate_id)
+      | Suspended_quarantine _ ->
+        Error
+          ("Quarantined or requeue-requested Board attention candidate cannot be settled: "
+           ^ candidate_id)
+    in
+    let* delivered_candidate =
+      match status_view judged_candidate.status with
+      | Direct_resumable (Resumable_consumed _)
+      | Requeued_resumable { resumable = Resumable_consumed _; _ } ->
+        normalize_requeued_consumed ~base_path ~keeper_name ~candidate_id
+      | Direct_resumable (Resumable_pending _)
+      | Requeued_resumable { resumable = Resumable_pending _; _ } ->
+        Error ("Board attention candidate remained Pending after judgment commit: " ^ candidate_id)
+      | Direct_resumable (Resumable_judged judged)
+      | Requeued_resumable
+          { resumable = Resumable_judged judged; _ } ->
+        let* delivered = consume_judged ~base_path judged_candidate judged in
+        (match status_view delivered.status with
+         | Direct_resumable (Resumable_consumed _)
+         | Requeued_resumable { resumable = Resumable_consumed _; _ } ->
+           normalize_requeued_consumed ~base_path ~keeper_name ~candidate_id
+         | Direct_resumable (Resumable_pending _ | Resumable_judged _)
+         | Requeued_resumable
+             { resumable = (Resumable_pending _ | Resumable_judged _); _ } ->
+           Error
+             ("Board attention candidate delivery did not reach Consumed: "
+              ^ candidate_id)
+         | Suspended_quarantine _ ->
+           Error
+             ("Board attention candidate became quarantined during delivery: "
+              ^ candidate_id))
+      | Suspended_quarantine _ ->
+        Error
+          ("Quarantined or requeue-requested Board attention candidate cannot be settled: "
+           ^ candidate_id)
+    in
+    Ok (Delivered delivered_candidate)
 ;;

--- a/lib/keeper/keeper_board_attention_candidate.mli
+++ b/lib/keeper/keeper_board_attention_candidate.mli
@@ -282,15 +282,28 @@ val normalize_requeued_consumed :
     consumed resumable state. Direct [Consumed] is idempotent; every other
     state is rejected. *)
 
+type judgment_delivery_outcome =
+  | Delivered of candidate
+  | Candidate_absent
+      (** The named candidate is not in the live ledger — a retire moves the
+          whole store aside as one directory and never leaves a tombstone, so
+          this is indistinguishable from any other cause of absence and is
+          treated the same: the delivery cannot succeed on a retry of the
+          identical request, because there is no row left to update. *)
+
 val apply_judgment_and_deliver :
   base_path:string ->
   keeper_name:string ->
   candidate_id:string ->
   judgment:judgment ->
-  (candidate, string) result
+  (judgment_delivery_outcome, string) result
 (** Idempotently apply one completed worker judgment and finish its durable
-    event delivery. Success means the candidate is [Consumed]. Conflicting
-    prior judgment or a non-terminal delivery result is explicit. *)
+    event delivery. [Delivered] means the candidate is [Consumed].
+    [Candidate_absent] is explicit rather than folded into [Error] so a caller
+    can settle the partition without delivery instead of retrying an update
+    that structurally cannot land. Conflicting prior judgment or a
+    non-terminal delivery result against a candidate that does exist remains
+    an [Error]. *)
 
 val record_and_wake :
   base_path:string -> candidate -> (record_acceptance, string) result

--- a/lib/keeper/keeper_board_attention_worker.ml
+++ b/lib/keeper/keeper_board_attention_worker.ml
@@ -1641,17 +1641,42 @@ let settle_one_completed
     in
     match partition.Partition.state with
     | Partition.Completed { item; _ } ->
-      let* (_ : Candidate.candidate) =
+      let* delivery =
         Candidate.apply_judgment_and_deliver
           ~base_path
           ~keeper_name
           ~candidate_id:item.candidate_id
           ~judgment:item.judgment
       in
+      (* [Candidate_absent] means the candidate this item names is gone from
+         the live ledger for good (a retire moves the whole store aside as one
+         directory and leaves no tombstone to re-check later), so no delivery
+         can ever land for it. Settling the partition here without one is the
+         terminal outcome, not a fallback: the alternative is exactly what
+         this branch exists to stop — a settlement error that propagates and
+         leaves the same [Completed] item to be handed to this function again
+         next cycle, permanently, since the ledger it depends on cannot come
+         back (masc, board attention finalizer, 2026-08-16). Discarded rather
+         than [settles_without_admitting item]: no stimulus reached the
+         Keeper regardless of what the lost judgment's verdict was, so the
+         owner-turn batch must keep draining instead of stopping as if this
+         had been an admission. *)
+      let discarded_only =
+        match delivery with
+        | Candidate.Candidate_absent ->
+          Log.Keeper.error
+            "Board attention candidate permanently absent from the ledger; settling partition without delivery keeper=%s partition=%s candidate=%s"
+            keeper_name
+            partition.partition_id
+            item.candidate_id;
+          true
+        | Candidate.Delivered (_ : Candidate.candidate) ->
+          settles_without_admitting item
+      in
       let* settled =
         Partition.settle ~now:(Time_compat.now ()) ~base_path ~partition
       in
-      Ok (settled, settles_without_admitting item)
+      Ok (settled, discarded_only)
     | Partition.Ready
     | Partition.Running _
     | Partition.Settled _

--- a/test/test_keeper_board_attention_candidate.ml
+++ b/test/test_keeper_board_attention_candidate.ml
@@ -34,6 +34,17 @@ let ok label = function
   | Error detail -> Alcotest.failf "%s: %s" label detail
 ;;
 
+(* Every case in this file delivers against a candidate it just persisted, so
+   [Candidate_absent] here is a bug in the fixture, not the outcome under
+   test — see test_keeper_board_attention_worker.ml for the terminal-settlement
+   coverage of an actually-missing candidate. *)
+let delivered label = function
+  | Ok (A.Delivered candidate) -> candidate
+  | Ok A.Candidate_absent ->
+    Alcotest.failf "%s: candidate absent (fixture did not persist it)" label
+  | Error detail -> Alcotest.failf "%s: %s" label detail
+;;
+
 let signal ?(content = "Persisted Board evidence") ?(updated_at = 42.0) post_id :
   Masc.Board_dispatch.board_signal
   =
@@ -787,7 +798,7 @@ let test_not_relevant_delivery_is_idempotent () =
    | Error _ -> ()
    | Ok _ -> Alcotest.fail "conflicting durable judgment was accepted");
   let consumed =
-    ok
+    delivered
       "apply judgment"
       (A.apply_judgment_and_deliver
          ~base_path
@@ -800,7 +811,7 @@ let test_not_relevant_delivery_is_idempotent () =
    | A.Pending _ | A.Judged _ | A.Consumed _ | A.Quarantine _ ->
      Alcotest.fail "not-relevant judgment did not reach Consumed");
   let replayed =
-    ok
+    delivered
       "replay judgment"
       (A.apply_judgment_and_deliver
          ~base_path
@@ -824,7 +835,7 @@ let test_relevant_delivery_uses_exact_candidate_identity () =
   with_temp_base "board-attention-candidate-relevant" @@ fun base_path ->
   let persisted = record ~base_path (candidate (signal "post-relevant")) in
   let consumed =
-    ok
+    delivered
       "apply relevant judgment"
       (A.apply_judgment_and_deliver
          ~base_path

--- a/test/test_keeper_board_attention_worker.ml
+++ b/test/test_keeper_board_attention_worker.ml
@@ -62,6 +62,18 @@ let ok label = function
   | Error detail -> Alcotest.failf "%s: %s" label detail
 ;;
 
+(* Every direct A.apply_judgment_and_deliver call in this file targets a
+   candidate the test just persisted, so Candidate_absent here is a fixture
+   bug, not the case under test — test_settle_one_completed_terminalizes_a_
+   partition_whose_candidate_was_retired below drives the actually-missing
+   path through the finalizer it exists to cover. *)
+let delivered label = function
+  | Ok (A.Delivered candidate) -> candidate
+  | Ok A.Candidate_absent ->
+    Alcotest.failf "%s: candidate absent (fixture did not persist it)" label
+  | Error detail -> Alcotest.failf "%s: %s" label detail
+;;
+
 let signal post_id : Masc.Board_dispatch.board_signal =
   { kind = Masc.Board_dispatch.Board_post_created
   ; post_id
@@ -1451,7 +1463,7 @@ let test_existing_consumed_skips_exact_flow_and_settles () =
        (A.record_judgment ~base_path persisted (judgment exact J.Not_relevant))
       : A.candidate);
   ignore
-    (ok
+    (delivered
        "consume before worker"
        (A.apply_judgment_and_deliver
           ~base_path
@@ -1490,7 +1502,7 @@ let test_consumed_completed_crash_settles_without_duplicate_delivery () =
   let exact = provenance "consumed-completed-crash" in
   let completed_judgment = judgment exact J.Relevant in
   let consumed =
-    ok
+    delivered
       "consume Relevant candidate before crash"
       (A.apply_judgment_and_deliver
          ~base_path
@@ -2305,6 +2317,92 @@ let test_undrained_outcomes_are_not_routine () =
        (W.Retry_later { contention; reason = W.Selected_generation_changed }))
 ;;
 
+(* task-336 sibling defect (masc, 2026-08-16): before this fix,
+   settle_one_completed's Error propagated all the way up whenever the
+   candidate a Completed item named had been retired — the whole per-keeper
+   candidate store moved aside as one directory, per
+   scripts/check-runtime-deployment-preflight.sh, with no tombstone left for
+   a later re-check. The partition never advanced past Completed, so the
+   identical error repeated on every heartbeat forever (sangsu 170x one day,
+   rondo 13x/25min the next, before both were data-cut by hand). This pins
+   that the finalizer now settles such a partition once, terminally, and
+   never revisits it. *)
+let test_settle_one_completed_terminalizes_a_partition_whose_candidate_was_retired
+  ()
+  =
+  with_temp_base "board-attention-worker-candidate-retired" @@ fun base_path ->
+  let persisted = record ~base_path (candidate ()) in
+  ignore
+    (ok
+       "create Ready root"
+       (P.ensure_roots ~base_path ~keeper_name:"sangsu" [ persisted ])
+      : int);
+  let attempt = provenance "candidate-retired" in
+  let execute ~before_dispatch ~before_advance _prepared =
+    ok "bind" (before_dispatch attempt);
+    ignore before_advance;
+    (* Relevant, not Not_relevant: an ordinary Relevant completion is an
+       admission (settles_without_admitting returns false), which stops the
+       owner-turn settlement batch. If the retired candidate's lost verdict
+       leaked into that discard decision, a batch could incorrectly hold open
+       on a partition nothing was, or ever will be, delivered for. *)
+    Ok (judgment attempt J.Relevant)
+  in
+  (match
+     ok
+       "judge to Completed"
+       (process ~base_path ~prepare:(fun candidate -> Ok candidate) ~execute)
+   with
+   | W.Judgment_completed { candidate_id; _ }
+     when String.equal candidate_id persisted.candidate_id -> ()
+   | _ -> Alcotest.fail "fixture did not reach Completed");
+  (match (load_one_partition ~base_path).state with
+   | P.Completed _ -> ()
+   | _ -> Alcotest.fail "fixture partition is not Completed before the retire simulation");
+  (* Simulate the retire exactly as the preflight script instructs an
+     operator to run it: move the whole per-keeper candidate ledger aside.
+     The partition ledger is a separate append-only journal that a retire
+     never touches, so it still names this candidate_id afterward. *)
+  let ledger_path =
+    Filename.concat
+      (Filename.concat
+         (Common.masc_dir_from_base_path ~base_path)
+         "board_attention_candidates")
+      "sangsu.jsonl"
+  in
+  Sys.remove ledger_path;
+  Alcotest.(check int)
+    "candidate ledger is empty after the simulated retire"
+    0
+    (ok
+       "load after retire"
+       (A.load_candidates ~base_path ~keeper_name:"sangsu")
+     |> List.length);
+  (match
+     ok
+       "first settlement attempt"
+       (W.settle_one_completed ~base_path ~keeper_name:"sangsu")
+   with
+   | W.Partition_settled { candidate_id; _ }
+     when String.equal candidate_id persisted.candidate_id -> ()
+   | W.Partition_settled _ -> Alcotest.fail "a different candidate was settled"
+   | W.No_completed_partition ->
+     Alcotest.fail
+       "the Completed partition with the retired candidate was not settled");
+  (match (load_one_partition ~base_path).state with
+   | P.Settled _ -> ()
+   | _ -> Alcotest.fail "partition with a retired candidate did not reach Settled");
+  match
+    ok
+      "second settlement attempt"
+      (W.settle_one_completed ~base_path ~keeper_name:"sangsu")
+  with
+  | W.No_completed_partition -> ()
+  | W.Partition_settled _ ->
+    Alcotest.fail
+      "the terminalized partition was offered for settlement again (infinite retry)"
+;;
+
 let () =
   Alcotest.run
     "keeper_board_attention_worker"
@@ -2445,6 +2543,10 @@ let () =
             "drain outcome labels stay distinct"
             `Quick
             test_drain_outcome_labels_stay_distinct
+        ; Alcotest.test_case
+            "settle_one_completed terminalizes a partition whose candidate was retired"
+            `Quick
+            test_settle_one_completed_terminalizes_a_partition_whose_candidate_was_retired
         ] )
     ]
 ;;


### PR DESCRIPTION
## 배경 (실측 근거)

board attention 완결 finalizer(`settle_one_completed`)가 candidate가 retired store로 옮겨진 partition을 만나면 매 사이클 같은 에러를 영원히 반복하고 있었어요.

- sangsu: 어제 170건
- rondo: 오늘 13건/25분

둘 다 임시로 데이터 컷으로 소거했지만 근본 원인이 그대로라 재발 확실이었어요. task-336(#28763, 리뷰 중)이 "영원히 안 들어가는 요청을 영원히 재시도"한 것과 같은 모양의 결함이 두 번째로 나온 거라, 근본 수정 규칙("2번째 fix → 근본 수정 강제")에 따라 call site 패치가 아니라 근본을 고쳤어요.

## 메커니즘

- partition 저장소(`board_attention_partitions/<keeper>.jsonl`)는 append-only 저널이고, 최신 행이 현재 상태예요. candidate 저장소는 별도 파일(`board_attention_candidates/<keeper>.jsonl`)이에요.
- retire는 `scripts/check-runtime-deployment-preflight.sh`가 명시하는 대로 candidate 저장소 디렉터리 전체를 `mv`로 옮기는 배포 시점 작업이에요 — 미리보기 스키마 불일치를 hard-cut으로 처리하는 방식이고(레거시 호환 리더는 안 만듦), tombstone을 남기지 않아요. 그래서 partition은 여전히 (이제는 없는) candidate_id를 가리키는데, candidate 조회는 항상 `None`이에요.
- `Candidate.apply_judgment_and_deliver`가 이 `None`을 다른 모든 실패(judgment 충돌, quarantine 상태, delivery 미완료)와 똑같이 문자열 `Error`로 접어 넣고 있었어요. `settle_head`의 `let*`가 이 Error에서 바로 튕겨나가면서 `Partition.settle`을 아예 실행 못 하니, partition이 `Completed`에서 못 벗어나고 다음 스캔에 또 걸려요.

## 무엇을 고쳤나

`apply_judgment_and_deliver`의 반환 타입을 바꿨어요: `(candidate, string) result` → `(judgment_delivery_outcome, string) result`, `judgment_delivery_outcome = Delivered of candidate | Candidate_absent`.

- `Candidate_absent`는 candidate lookup이 `None`일 때만 나와요. **다른 실패는 전부 그대로 `Error`예요** — judgment 충돌이나 quarantine 상태는 살아있는 candidate가 예상 밖 상태에 있다는 뜻이라 계속 시끄럽게 에러로 보고돼야 하는 진짜 버그예요. `Candidate_absent`랑 같은 종결 경로로 조용히 흡수하면 안 돼요.
- 유일한 호출부인 `settle_head`(`keeper_board_attention_worker.ml`)는 `Candidate_absent`를 만나면: (1) candidate/partition id를 실어 ERROR 레벨로 1회 로그, (2) delivery 없이 곧바로 `Partition.settle`을 호출해 `Completed -> Settled`로 종결, (3) `discarded_only = true`로 처리해서 이 owner-turn의 settlement batch가 다음 completed partition으로 계속 진행하게 해요 — 잃어버린 judgment의 verdict가 뭐였든(Relevant든 Not_relevant든) 아무것도 Keeper에 admit되지 않았으니까요.

`Settled`가 왜 맞는 종결 상태인지: `Partition.block`은 구조적으로 `Running` 상태에서만 호출 가능해요(`transition_running_exact`가 강제). `Completed`는 state graph상 `Blocked`의 후행이 아니라 병렬 분기라서, `Completed` partition을 `Blocked`로 보내는 전이 자체가 없어요. `Partition.settle`은 이미 `Completed | Blocked` 양쪽을 다 받는 유일한 함수라, 새 전이 함수를 발명하지 않고 기존 계약을 그대로 썼어요.

## 테스트

새 케이스 `test_settle_one_completed_terminalizes_a_partition_whose_candidate_was_retired`:
1. candidate 하나를 정상적으로 exact-flow를 거쳐 `Completed`까지 진행시켜요 (verdict는 일부러 `Relevant`로 — `Not_relevant`를 썼으면 discarded_only가 우연히 true가 되는 경우와 구분이 안 돼요).
2. candidate ledger 파일을 통째로 지워서 retire를 재현해요 (partition 저널은 안 건드림 — 실제 retire와 동일).
3. `settle_one_completed` 1차 호출 → `Partition_settled` (Error 아님), partition이 `Settled`로 확인.
4. `settle_one_completed` 2차 호출 → `No_completed_partition` (재등장 없음 = 재시도 없음 증명).

**뮤테이션 테스트로 검증**: `Candidate_absent` 분기를 예전처럼 그냥 `Error`로 되돌려서(`worker.ml`만 임시 수정) 돌려보니 정확히 이 새 테스트만 "MUTATION_TEST: Board attention candidate not found: ..."로 실패하고 나머지 34개는 그대로 green이었어요. 수정을 되돌린 뒤 재확인해서 실제 코드가 이 테스트를 통과함도 확인했어요.

로컬 검증:
- `dune build --root .` 클린
- `test_keeper_board_attention_worker`(35/35, 새 테스트 포함), `test_keeper_board_attention_candidate`(13/13), `test_keeper_board_attention_partition`(13/13) 전부 통과
- `scripts/audit-ci-test-targets.sh` 통과 (기존에 이미 등록된 스위트라 CI 목록 변경 없음)
- `dune build @fmt`에서 내가 건드린 파일 관련 diff 없음

## 건드리지 않은 것

- retired store를 다시 읽는 호환 경로(#28728 처방 그대로 금지 유지)
- `Partition.block`/`quarantine_blocked_partition` 경로 (RUNNING/dispatch 실패 전용, 이번 결함과 무관)
- task-336(#28763)의 completion-authority 재시도 정책 — 같은 "구조적으로 성공 불가능한 요청을 영원히 재시도" 패턴이지만 다른 서브시스템이라 별도 PR로 남겨둠

🤖 Generated with [Claude Code](https://claude.com/claude-code)