### PR TITLE
docs(rfc): RFC-0382 — 런타임 KV 캐시 재사용·reasoning 연속성 실측 감사

### DIFF
--- a/docs/evidence/kv-cache-harness-2026-08-16.jsonl
+++ b/docs/evidence/kv-cache-harness-2026-08-16.jsonl
@@ -1,0 +1,16 @@
+{"scenario": "preserve", "turn": 1, "cache_n": 68, "prompt_n": 516, "prompt_ms": 5495.9, "predicted_n": 295, "predicted_ms": 34996.2, "wall_s": 40.58, "reasoning_chars": 968, "content_chars": 433}
+{"scenario": "preserve", "turn": 2, "cache_n": 878, "prompt_n": 29, "prompt_ms": 879.2, "predicted_n": 419, "predicted_ms": 39239.2, "wall_s": 40.14, "reasoning_chars": 1528, "content_chars": 390}
+{"scenario": "preserve", "turn": 3, "cache_n": 1325, "prompt_n": 34, "prompt_ms": 617.8, "predicted_n": 383, "predicted_ms": 38503.1, "wall_s": 39.14, "reasoning_chars": 1415, "content_chars": 418}
+{"scenario": "preserve", "turn": 4, "cache_n": 1741, "prompt_n": 26, "prompt_ms": 709.5, "predicted_n": 512, "predicted_ms": 54893.4, "wall_s": 55.62, "reasoning_chars": 2007, "content_chars": 342}
+{"scenario": "strip", "turn": 1, "cache_n": 68, "prompt_n": 516, "prompt_ms": 4307.8, "predicted_n": 469, "predicted_ms": 56790.9, "wall_s": 61.18, "reasoning_chars": 1445, "content_chars": 331}
+{"scenario": "strip", "turn": 2, "cache_n": 580, "prompt_n": 122, "prompt_ms": 1445.3, "predicted_n": 512, "predicted_ms": 66175.9, "wall_s": 68.43, "reasoning_chars": 1840, "content_chars": 191}
+{"scenario": "strip", "turn": 3, "cache_n": 698, "prompt_n": 86, "prompt_ms": 1199.5, "predicted_n": 512, "predicted_ms": 65593.5, "wall_s": 66.81, "reasoning_chars": 2098, "content_chars": 0}
+{"scenario": "strip", "turn": 4, "cache_n": 780, "prompt_n": 32, "prompt_ms": 1156.6, "predicted_n": 512, "predicted_ms": 76801.4, "wall_s": 77.99, "reasoning_chars": 2465, "content_chars": 0}
+{"scenario": "volatile", "turn": 1, "cache_n": 559, "prompt_n": 58, "prompt_ms": 1716.7, "predicted_n": 228, "predicted_ms": 50918.2, "wall_s": 52.71, "reasoning_chars": 707, "content_chars": 377}
+{"scenario": "volatile", "turn": 2, "cache_n": 559, "prompt_n": 314, "prompt_ms": 4032.4, "predicted_n": 512, "predicted_ms": 70754.3, "wall_s": 74.8, "reasoning_chars": 2166, "content_chars": 0}
+{"scenario": "volatile", "turn": 3, "cache_n": 559, "prompt_n": 863, "prompt_ms": 7091.8, "predicted_n": 512, "predicted_ms": 57940.1, "wall_s": 65.12, "reasoning_chars": 2019, "content_chars": 131}
+{"scenario": "volatile", "turn": 4, "cache_n": 68, "prompt_n": 1892, "prompt_ms": 14401.2, "predicted_n": 483, "predicted_ms": 57479.3, "wall_s": 72.02, "reasoning_chars": 2402, "content_chars": 0}
+{"scenario": "volatile_tail", "turn": 1, "cache_n": 68, "prompt_n": 551, "prompt_ms": 4869.7, "predicted_n": 187, "predicted_ms": 22377.1, "wall_s": 27.44, "reasoning_chars": 490, "content_chars": 380}
+{"scenario": "volatile_tail", "turn": 2, "cache_n": 805, "prompt_n": 64, "prompt_ms": 991.0, "predicted_n": 187, "predicted_ms": 22654.9, "wall_s": 23.68, "reasoning_chars": 508, "content_chars": 365}
+{"scenario": "volatile_tail", "turn": 3, "cache_n": 1055, "prompt_n": 69, "prompt_ms": 1117.4, "predicted_n": 253, "predicted_ms": 31391.5, "wall_s": 32.55, "reasoning_chars": 854, "content_chars": 349}
+{"scenario": "volatile_tail", "turn": 4, "cache_n": 1376, "prompt_n": 61, "prompt_ms": 1033.2, "predicted_n": 304, "predicted_ms": 38174.4, "wall_s": 39.25, "reasoning_chars": 1172, "content_chars": 325}

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -244,6 +244,7 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0379 | Keeper Monitor: 조건 전이가 Keeper 를 깨운다 (Event-Driven Wake) | Draft | - |
 | 0380 | 대기 나이는 홀더의 사이클을 알아야 한다 — work liveness 판정 축 정정 | Draft | - |
 | 0381 | 웹 검색은 폴백이 있는 척한다 — provider 계약 정정과 토큰 예산 도입 | Draft | - |
+| 0382 | 런타임별 KV/prompt cache 재사용과 reasoning 연속성 | Draft | - |
 | RFC-0034d-stale-agent-sync | d — release_stale_claims agent-side sync | Draft | - |
 | RFC-async-log-sink-durable-append-offload | Offload the structured-log durable append off the emitting fiber | Draft | - |
 | RFC-checkpoint-pinned-root-containment | Immutable boot-pinned root capability for checkpoint containment | Draft | - |

--- a/docs/rfc/RFC-0382-runtime-kv-cache-reuse-and-reasoning-continuity.md
+++ b/docs/rfc/RFC-0382-runtime-kv-cache-reuse-and-reasoning-continuity.md
@@ -69,7 +69,7 @@
 
 핵심 기전 두 가지. (1) 생성된 thinking 토큰의 KV는 슬롯에 남아 있으므로, 다음 턴 히스토리에 같은 reasoning_content를 그대로 되돌려주면 재토큰화 비용 없이 프리픽스가 이어진다(preserve 턴2: 이전 턴 생성 419tok가 그대로 cache_n에 편입, 새 user 29tok만 처리). (2) 프리픽스 앞쪽 1바이트 변형은 그 뒤 전체를 무효화하며, hybrid(SSM) 모델은 임의 위치 롤백이 안 되므로 체크포인트(`--ctx-checkpoints`, b10180 기본 32/slot)가 있는 위치까지만 되감는다 — volatile-head 턴4에서 cache_n이 68로 무너진 것이 체크포인트 고갈의 실측이다. 원 수치는 `docs/evidence/kv-cache-harness-2026-08-16.jsonl`.
 
-### 3.2 라이브 fleet 캐시 히트 (8/15, `~/.masc/costs/2026-08/15.jsonl`, 760턴)
+### 3.2 라이브 fleet 캐시 히트 (8/15, `<MASC_BASE_PATH>/costs/2026-08/15.jsonl`, 760턴)
 
 | 모델 | 턴 | cache_read | input | 히트율 |
 |---|---|---|---|---|
@@ -92,7 +92,7 @@
 | PR-1 (이 문서) | RFC + 리포트 + 하네스 + 증거 | — |
 | PR-2 | agent_core: OpenAI-compat SSE 최종 청크의 `timings` 파싱 → telemetry (Ollama 경로와 동형) | G1 |
 | PR-3 | keeper/dashboard: cache_n·prompt_n 원값 노출 (bool 축약 제거는 하지 않고 병기) | G5 |
-| PR-4 | llama-server 레인 복원 runbook + 캐파 행(preserve_thinking_control_format 선언) + `~/.masc` 설정 반영 (ops) | G2, G3 |
+| PR-4 | llama-server 레인 복원 runbook + 캐파 행(preserve_thinking_control_format 선언) + `<MASC_BASE_PATH>` 설정 반영 (ops) | G2, G3 |
 | PR-5 | backend_anthropic: top-level 자동 cache_control 옵트인 | G4 |
 | 후속 | usage 의미론 감사 (input_tokens에 cached 포함 여부 provider별 계약 명문화) | G6 |
 

--- a/docs/rfc/RFC-0382-runtime-kv-cache-reuse-and-reasoning-continuity.md
+++ b/docs/rfc/RFC-0382-runtime-kv-cache-reuse-and-reasoning-continuity.md
@@ -1,0 +1,113 @@
+# RFC-0382: 런타임별 KV/prompt cache 재사용과 reasoning 연속성
+
+- 상태: Draft
+- 날짜: 2026-08-16
+- 실측 리포트: `reports/kv-cache-runtime-audit-2026-08-16.html`
+- 원본 증거: `docs/evidence/kv-cache-harness-2026-08-16.jsonl`, `~/me/memory/procedural-memory/2026-08-16-llama-server-kv-preserve-thinking-evidence-record.md`
+- 측정 도구: `scripts/bench-kv-cache.py`
+
+## 0. 판정 요약
+
+1. MASC의 프롬프트 구조는 이미 캐시 인지형이다 — 안정 system 헤드, append-only 히스토리, window 양자화 컷, 변동 컨텍스트 꼬리 주입까지 설계 근거가 코드에 있다 (`agent_turn.ml:31`, `runtime_model_input_tail_window.mli`, `keeper_unified_prompt.mli`).
+2. llama-server(b10180) + Qwen3.8-27B 실측에서 preserve-thinking + append-only 정책은 턴당 prefill을 26~34 토큰(≈0.7s)으로 떨어뜨린다. 같은 대화를 시스템 헤드에 타임스탬프 한 줄만 넣고 돌리면 재처리 토큰이 314→863→1,892로 히스토리에 비례해 배증한다(턴4 14.4s). 같은 정보를 꼬리로 옮기면 61~69 토큰 상수로 돌아온다 — 턴4 기준 31배.
+3. 스트리밍 경로가 llama-server의 `timings`(cache_n = 캐시 재사용 토큰 수)를 버린다. 로컬 행은 전부 `streaming = true`이므로 정확히 관측이 필요한 지점에서 관측이 사라진다 (`complete_stream.ml:353` Ollama NDJSON 전용).
+4. 라이브 fleet(8/15, 760턴)의 캐시 히트는 provider가 결정했다: gemini 84.1%, GLM 40.6%, ollama_cloud(deepseek) 0% — 하루 2,340만 input 토큰이 전량 재프리필. 클라이언트 구조 문제가 아니라 캐시 없는 provider에 멀티턴 keeper를 태운 배치 문제다.
+5. 로컬 8080은 현재 mlx_vlm.server이고 `apc_enabled: false`인 데다 upstream이 요청마다 Metal 캐시를 지운다(Blaizzy/mlx-vlm#999). llama-server b10180은 같은 모델에서 prefill 167 t/s / decode 17.6 t/s로 ollama 경로(3.2 t/s) 대비 5.5배, MLX+draft(19.1 t/s)와 대등하면서 KV 재사용·JSON schema·slot 저장을 전부 지원한다. 로컬 레인의 정답은 llama-server 복원이다.
+
+## 1. 배경
+
+목표: 어떤 Runtime으로도 10턴+, 1~24시간 연속 동작하는 Keeper의 턴 연속성. 이전 턴의 기억(사고 과정 포함)이 다음 턴으로 이어지고, 그 연속성이 KV/prompt cache 재사용으로 비용·지연 이점까지 내는 구조가 맞는지 감사한다.
+
+"Preserve Thinking" 관련 외부 주장 검증 결과:
+
+| 주장 | 판정 | 근거 |
+|---|---|---|
+| llama-server `--reasoning-preserve` 플래그 존재 | 사실 (b10180) | `--help` 실측; "compatible with certain templates having 'supports_preserve_reasoning'" |
+| Qwen3.6+/3.8 `preserve_thinking` chat template kwarg | 사실 | Qwen3.8-27B GGUF 로드 로그 "chat template supports preserving reasoning"; NousResearch/hermes-agent#56004 |
+| thinking 보존 + prompt cache 결합 시 다음 턴 prefill ≈ 0 | 사실 (실측) | §3 표 — 턴당 prompt_n 29~38 |
+| `--prompt-cache` 플래그로 서버 캐시 제어 | 부정확 | llama-cli 전용. 서버는 `cache_prompt` 요청 필드(기본 true) + `--cache-reuse`/`--slot-save-path` |
+
+## 2. 현재 구조 감사
+
+### 2.1 이미 올바른 것
+
+| 구조 | 위치 | 내용 |
+|---|---|---|
+| 3채널 프롬프트 | `lib/keeper/keeper_unified_prompt.mli` | system(세대 내 안정) / world_state(매턴 재조립, 비영속) / user_message(영속). #25193에서 world_state 영속화가 943/945 중복 프레임을 만든 사고 이후 분리됨 |
+| 변동 컨텍스트 꼬리 주입 | `packages/agent_core/lib/agent/agent_turn.ml:31` | extra_system_context를 히스토리 뒤에 append. 주석에 "critical for local LLM KV-cache reuse" 명시 |
+| Window 양자화 컷 | `lib/runtime/runtime_model_input_tail_window.mli` | 슬라이딩 컷 대신 atoms_per_window 배수 점프로 프리픽스 바이트 동일 유지 (#26535 실측 기반) |
+| Reasoning replay 타입 계약 | `packages/agent_core/lib/llm_provider/reasoning_replay_contract.mli`, `reasoning_history_projection.mli` | replay_policy 5종 + provenance 검증 + rotation policy. provider 이름 비교 없음 |
+| preserve_thinking 인코딩 | `reasoning_dialect.ml:294,446` | `chat_template_kwargs: {enable_thinking, preserve_thinking}` 정확한 필드명. GLM `clear_thinking=false` 매핑도 존재 |
+| 캐시 관측 파싱(비스트리밍) | `backend_openai_parse.ml:240,286` | llama-server `timings.cache_n` 파싱 → keeper cost events(`keeper_hooks_agent_core_cost_events.ml:141`)까지 배선 |
+| Anthropic system+tools 캐시 | `backend_anthropic.ml:346,392` | `cache_system_prompt=true`(keeper 기본, `keeper_agent_run.ml:885`)면 system 블록 + 마지막 tool에 cache_control |
+
+### 2.2 격차
+
+| # | 격차 | 위치/근거 | 영향 |
+|---|---|---|---|
+| G1 | OpenAI-compat SSE 스트림이 `timings`를 파싱하지 않음 | `complete_stream.ml:353-379` (oll_timings는 Ollama NDJSON 전용). llama-server는 최종 청크(finish_reason 포함)에 top-level `timings`를 opt-in 없이 싣는다 — 2026-08-16 curl 실측, `system_fingerprint: b10180-11b068d06` | 로컬 행 전부 `streaming=true` → llama-server cache_n 관측 불가 |
+| G2 | llama-server 레인 부재 | runtime.toml 주석 2026-08-10 "127.0.0.1:8080 LISTEN 없음"; 현재 8080은 mlx(`apc_enabled:false`) | 로컬 멀티턴 KV 재사용 0 (mlx-vlm#999: 요청마다 Metal 캐시 소거) |
+| G3 | 로컬 행 `preserve-thinking = false` 일괄 | runtime.toml qwen3-8-27b 행 | reasoning 연속성 유실 + strip 재작성으로 캐시 경계 후퇴. 템플릿은 preserve 지원(로드 로그) |
+| G4 | Anthropic 대화 히스토리 캐시 breakpoint 없음 | `backend_anthropic.ml` (system+tools만) | 멀티턴 히스토리 매턴 전액 input 과금. 공식 권장은 top-level 자동 breakpoint (read 0.1x) |
+| G5 | 대시보드가 cache를 bool로 축약 | `dashboard_agent_core_bridge.ml:211` | 재사용 비율(cache_n / (cache_n+prompt_n)) 추이 관측 불가 |
+| G6 | provider별 usage 의미론(input에 cached 포함 여부) 미감사 | `pricing.ml:63`은 포함 가정, Anthropic wire는 배제형 | 비용 집계 이중 차감/과대 위험 — 후속 감사 |
+
+## 3. 실측
+
+### 3.1 llama-server KV 재사용 (Qwen3.8-27B UD-Q4_K_XL, b10180, M3 Max, -c 16384 -np 1, --reasoning-format deepseek)
+
+4개 히스토리 정책 × 4턴, 동일 대화 시드, max_tokens 512. `prompt_n`(재처리 토큰) / `prompt_ms`:
+
+| 정책 | 턴2 | 턴3 | 턴4 | 경향 |
+|---|---|---|---|---|
+| preserve (append-only + reasoning replay) | 29 tok / 0.9s | 34 / 0.6s | 26 / 0.7s | 상수 |
+| strip (Qwen 기본, reasoning 제거) | 122 / 1.4s | 86 / 1.2s | 32 / 1.2s | 마지막 교환 크기에 비례 |
+| volatile-head (system에 타임스탬프 1줄) | 314 / 4.0s | 863 / 7.1s | 1,892 / 14.4s | 히스토리 길이에 비례 — 턴마다 배증 |
+| volatile-tail (같은 정보를 꼬리에) | 64 / 1.0s | 69 / 1.1s | 61 / 1.0s | 상수 |
+
+턴4 기준 volatile-head 대 volatile-tail은 31배(1,892 vs 61 tok). 같은 정보를 넣는 위치만 바꿨다.
+
+핵심 기전 두 가지. (1) 생성된 thinking 토큰의 KV는 슬롯에 남아 있으므로, 다음 턴 히스토리에 같은 reasoning_content를 그대로 되돌려주면 재토큰화 비용 없이 프리픽스가 이어진다(preserve 턴2: 이전 턴 생성 419tok가 그대로 cache_n에 편입, 새 user 29tok만 처리). (2) 프리픽스 앞쪽 1바이트 변형은 그 뒤 전체를 무효화하며, hybrid(SSM) 모델은 임의 위치 롤백이 안 되므로 체크포인트(`--ctx-checkpoints`, b10180 기본 32/slot)가 있는 위치까지만 되감는다 — volatile-head 턴4에서 cache_n이 68로 무너진 것이 체크포인트 고갈의 실측이다. 원 수치는 `docs/evidence/kv-cache-harness-2026-08-16.jsonl`.
+
+### 3.2 라이브 fleet 캐시 히트 (8/15, `~/.masc/costs/2026-08/15.jsonl`, 760턴)
+
+| 모델 | 턴 | cache_read | input | 히트율 |
+|---|---|---|---|---|
+| gemini-3.6-flash-high | 127 | 145.5M | 27.6M | 84.1% |
+| GLM-5-Turbo | 364 | 13.1M | 19.2M | 40.6% |
+| deepseek-v4-flash:0731 (ollama_cloud) | 271 | 0 | 23.4M | 0% |
+
+### 3.3 로컬 서빙 경로 비교 (같은 Qwen3.8-27B)
+
+| 경로 | prefill | decode | KV 재사용 | 비고 |
+|---|---|---|---|---|
+| ollama 0.32.12 /api/chat | 12.3 t/s | 3.2 t/s | (미계측) | 2026-08-15 실측, runtime.toml 주석 |
+| mlx_vlm.server 0.6.13 + MTP draft | — | 19.1 t/s | 없음 (apc off + 요청별 캐시 소거) | response_format 미지원(draft) |
+| llama-server b10180 | 167 t/s | 17.6 t/s | cache_n 실측 재사용 | JSON schema·slot save·preserve 지원 |
+
+## 4. 계획 (stacked PR)
+
+| PR | 내용 | 격차 |
+|---|---|---|
+| PR-1 (이 문서) | RFC + 리포트 + 하네스 + 증거 | — |
+| PR-2 | agent_core: OpenAI-compat SSE 최종 청크의 `timings` 파싱 → telemetry (Ollama 경로와 동형) | G1 |
+| PR-3 | keeper/dashboard: cache_n·prompt_n 원값 노출 (bool 축약 제거는 하지 않고 병기) | G5 |
+| PR-4 | llama-server 레인 복원 runbook + 캐파 행(preserve_thinking_control_format 선언) + `~/.masc` 설정 반영 (ops) | G2, G3 |
+| PR-5 | backend_anthropic: top-level 자동 cache_control 옵트인 | G4 |
+| 후속 | usage 의미론 감사 (input_tokens에 cached 포함 여부 provider별 계약 명문화) | G6 |
+
+## 5. 하지 않는 것
+
+- 캐시 히트율 기반 게이트/차단/재시도 없음 — 관측만 한다. 히트율은 진단 신호이지 흐름 제어 입력이 아니다.
+- 토큰↔바이트 환산 상수 도입 없음 (기존 원칙 유지 — provider가 window fit의 oracle).
+- string 매칭 기반 provider 분기 없음 — 전부 기존 typed capability 축(`preserve_thinking_control_format`, `reasoning_streaming_format`)으로 선언.
+- 레거시 필드/마이그레이션 없음.
+
+## 6. 참고
+
+- llama.cpp server README (cache_prompt/cache_n/--cache-reuse/--slot-save-path/-sps/chat_template_kwargs/--reasoning-format)
+- llama.cpp PR #15293 (context checkpoints — hybrid/SWA 부분 재사용)
+- Anthropic prompt caching 문서 (top-level 자동 breakpoint, read 0.1x/write 1.25x, tools→system→messages 계층)
+- Blaizzy/mlx-vlm#999, ml-explore/mlx-lm#980 (mlx 캐시 결함)
+- NousResearch/hermes-agent#56004, earendil-works/pi#3325 (preserve_thinking 부재로 인한 multi-turn 결함 사례)
+- DeepSeek context caching 문서 (프리픽스 유닛 완전 일치 시에만 히트)

--- a/reports/kv-cache-runtime-audit-2026-08-16.html
+++ b/reports/kv-cache-runtime-audit-2026-08-16.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>런타임 KV 캐시 재사용 · reasoning 연속성 실측 감사</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font-family: -apple-system, "Apple SD Gothic Neo", sans-serif; max-width: 60rem;
+         margin: 2rem auto; padding: 0 1rem; line-height: 1.6; }
+  h1 { font-size: 1.4rem; } h2 { font-size: 1.15rem; margin-top: 2rem; }
+  table { border-collapse: collapse; width: 100%; margin: .8rem 0; font-size: .92rem; }
+  th, td { border: 1px solid color-mix(in srgb, currentColor 25%, transparent);
+           padding: .35rem .6rem; text-align: left; vertical-align: top; }
+  th { background: color-mix(in srgb, currentColor 8%, transparent); }
+  code { font-family: ui-monospace, monospace; font-size: .88em;
+         background: color-mix(in srgb, currentColor 8%, transparent);
+         padding: .05rem .3rem; border-radius: 3px; }
+  .dead { color: #c0392b; font-weight: 600; }
+  .good { color: #1e8e3e; font-weight: 600; }
+  .note { font-size: .88rem; opacity: .85; }
+  .verdict { border-left: 4px solid color-mix(in srgb, currentColor 40%, transparent);
+             padding: .2rem 1rem; margin: 1rem 0; }
+</style>
+</head>
+<body>
+
+<h1>런타임 KV 캐시 재사용 · reasoning 연속성 실측 감사</h1>
+<p class="note">
+2026-08-16 · 측정 스크립트: <code>scripts/bench-kv-cache.py</code> ·
+원본 증거: <code>docs/evidence/kv-cache-harness-2026-08-16.jsonl</code> ·
+설계 SSOT: <code>docs/rfc/RFC-0382</code> ·
+측정 환경: M3 Max 128GB, llama-server <code>b10180 (11b068d06)</code>, Qwen3.8-27B UD-Q4_K_XL(ollama blob 직접 로드), <code>-c 16384 -np 1 --jinja --reasoning-format deepseek</code>, 캐시 관련 서버 플래그는 전부 기본값
+</p>
+
+<div class="verdict">
+<p><strong>판정 5줄.</strong></p>
+<ol>
+<li>MASC의 프롬프트 조립은 이미 캐시 인지형이다 — 안정 system 헤드 / append-only 히스토리 / window 양자화 컷 / 변동 컨텍스트 꼬리 주입이 코드에 설계 주석과 함께 존재한다 (<code>agent_turn.ml:31</code> "critical for local LLM KV-cache reuse").</li>
+<li>llama-server + Qwen3.8-27B에서 <strong>preserve-thinking + append-only</strong>는 턴당 prefill을 <span class="good">26~34 토큰(≈0.7s)</span>으로 만든다. 이전 턴에 생성된 thinking의 KV가 슬롯에 남아 있고, 같은 reasoning_content를 히스토리로 되돌려주면 재처리가 새 user 메시지 분량으로 수렴하기 때문이다.</li>
+<li>시스템 헤드에 타임스탬프 <em>한 줄</em>을 매턴 갱신하면 재처리 토큰이 <span class="dead">314 → 863 → 1,892(14.4s)</span>로 히스토리에 비례해 배증한다. 같은 정보를 대화 꼬리로 옮기면 61~69 토큰 상수 — <strong>턴4 기준 31배 차이</strong>. 변동 정보의 위치가 캐시의 전부다.</li>
+<li>llama-server는 스트리밍 최종 청크에 <code>timings.cache_n</code>(재사용 토큰 수)을 opt-in 없이 싣는데, agent-core 스트리밍 경로는 Ollama NDJSON에서만 timings를 읽어 <span class="dead">로컬 행(전부 streaming=true)의 캐시 관측이 유실</span>된다 (G1).</li>
+<li>라이브 fleet(8/15, 760턴)의 캐시 히트율은 클라이언트 구조가 아니라 provider가 결정했다: gemini 84.1% / GLM 40.6% / <span class="dead">ollama_cloud(deepseek) 0%</span> — 하루 2,340만 input 토큰 전량 재프리필. 멀티턴 keeper를 캐시 없는 provider에 태우는 배치가 지연·비용의 주범이다.</li>
+</ol>
+</div>
+
+<h2>표 1. 히스토리 정책별 턴당 재처리 비용 (같은 대화, 같은 모델, 같은 서버)</h2>
+<p class="note">각 셀: <code>prompt_n</code>(이번 턴에 다시 처리한 토큰) / <code>prompt_ms</code>. cache_n·전체 원값은 evidence JSONL 참조. 턴1은 콜드 스타트라 제외.</p>
+<table>
+<tr><th>히스토리 정책</th><th>턴2</th><th>턴3</th><th>턴4</th><th>경향</th></tr>
+<tr><td><strong>preserve</strong> — append-only + reasoning_content 재주입 (<code>chat_template_kwargs {"preserve_thinking": true}</code>)</td>
+    <td class="good">29 / 0.9s</td><td class="good">34 / 0.6s</td><td class="good">26 / 0.7s</td><td>상수</td></tr>
+<tr><td><strong>strip</strong> — Qwen 기본 (이전 턴 reasoning 제거)</td>
+    <td>122 / 1.4s</td><td>86 / 1.2s</td><td>32 / 1.2s</td><td>마지막 교환 크기에 비례</td></tr>
+<tr><td><strong>volatile-head</strong> — system 프롬프트 끝에 타임스탬프 1줄 매턴 갱신</td>
+    <td class="dead">314 / 4.0s</td><td class="dead">863 / 7.1s</td><td class="dead">1,892 / 14.4s</td><td class="dead">히스토리 길이에 비례 (배증)</td></tr>
+<tr><td><strong>volatile-tail</strong> — 같은 타임스탬프를 새 user 메시지 머리에</td>
+    <td class="good">64 / 1.0s</td><td class="good">69 / 1.1s</td><td class="good">61 / 1.0s</td><td>상수</td></tr>
+</table>
+<p class="note">volatile-head 턴4에서 <code>cache_n</code>이 559→68로 무너졌다 — hybrid(SSM) 모델은 임의 위치 롤백이 불가능해 체크포인트(<code>--ctx-checkpoints</code>, 기본 32/slot, llama.cpp PR #15293) 위치까지만 되감는데, 매턴 헤드가 변형되면 체크포인트가 고갈된다. full-attention 모델보다 hybrid 모델이 프리픽스 오염에 더 취약하다는 실측.</p>
+
+<h2>표 2. 로컬 서빙 경로 비교 (같은 Qwen3.8-27B, 같은 박스)</h2>
+<table>
+<tr><th>경로</th><th>prefill</th><th>decode</th><th>턴간 KV 재사용</th><th>비고</th></tr>
+<tr><td>ollama 0.32.12 <code>/api/chat</code></td><td>12.3 t/s</td><td>3.2 t/s</td><td>미계측</td><td>2026-08-15 실측 (runtime.toml 주석)</td></tr>
+<tr><td>mlx_vlm.server 0.6.13 + MTP draft (현 8080)</td><td>—</td><td>19.1 t/s</td><td class="dead">없음</td><td><code>apc_enabled:false</code> 실측 + upstream이 요청마다 Metal 캐시 소거 (mlx-vlm#999). response_format 미지원(draft)</td></tr>
+<tr><td><strong>llama-server b10180</strong></td><td class="good">167 t/s</td><td class="good">17.6 t/s</td><td class="good">cache_n 실측 재사용</td><td>JSON schema · slot save/restore · <code>--reasoning-preserve</code> 지원. 로드 로그: "chat template supports preserving reasoning"</td></tr>
+</table>
+<p class="note">ollama의 3.2 t/s는 qwen35 아키텍처(Gated DeltaNet hybrid)의 SSM Metal 경로가 느린 빌드였고, brew b10180은 같은 GGUF에서 5.5배를 낸다. 로컬 레인이 "느려서 강등"된 2026-08-07~08의 근거가 더 이상 성립하지 않는다.</p>
+
+<h2>표 3. 라이브 fleet 캐시 히트 (2026-08-15, ~/.masc/costs, 760턴)</h2>
+<table>
+<tr><th>모델 (런타임)</th><th>턴</th><th>cache_read</th><th>input</th><th>히트율</th></tr>
+<tr><td>gemini-3.6-flash-high (antigravity)</td><td>127</td><td>145.5M</td><td>27.6M</td><td class="good">84.1%</td></tr>
+<tr><td>GLM-5-Turbo (glm-coding)</td><td>364</td><td>13.1M</td><td>19.2M</td><td>40.6%</td></tr>
+<tr><td>deepseek-v4-flash:0731 (ollama_cloud)</td><td>271</td><td>0</td><td>23.4M</td><td class="dead">0%</td></tr>
+</table>
+
+<h2>외부 주장 검증 (인용 프롬프트 대조)</h2>
+<table>
+<tr><th>주장</th><th>판정</th><th>근거</th></tr>
+<tr><td>llama-server <code>--reasoning-preserve</code> 플래그</td><td class="good">실재</td><td>b10180 <code>--help</code> 실측 (컷오프 이후 추가)</td></tr>
+<tr><td>Qwen3.6+/3.8 <code>preserve_thinking</code> template kwarg</td><td class="good">실재</td><td>GGUF 로드 로그 + hermes-agent#56004 (preserve 부재로 multi-turn thinking 유실 이슈)</td></tr>
+<tr><td>보존 + 캐시 결합 시 다음 턴 prefill ≈ 0</td><td class="good">실측 확인</td><td>표 1 preserve 행</td></tr>
+<tr><td><code>--prompt-cache ./cache.bin</code>으로 서버 캐시 제어</td><td class="dead">부정확</td><td>llama-cli 전용. 서버는 <code>cache_prompt</code> 요청 필드(기본 true) + <code>--slot-save-path</code>/<code>POST /slots/{id}?action=save</code></td></tr>
+<tr><td>Jinja 템플릿을 직접 수정해 reasoning_content 보존</td><td>불필요</td><td>템플릿이 <code>supports_preserve_reasoning</code>을 선언하면 kwarg/플래그로 제어 — 수정 없이 동작 (이번 측정이 그 경로)</td></tr>
+</table>
+
+<h2>격차와 다음 단계</h2>
+<table>
+<tr><th>#</th><th>격차</th><th>조치</th></tr>
+<tr><td>G1</td><td>OpenAI-compat SSE 스트림에서 <code>timings</code>(cache_n) 유실 — <code>complete_stream.ml</code>이 Ollama NDJSON만 읽음</td><td>PR-2: 최종 청크 timings 파싱 → telemetry 합류</td></tr>
+<tr><td>G2</td><td>llama-server 레인 부재 (8080은 mlx 점유, llama 레인 사망)</td><td>PR-4: b10180 기반 레인 복원 + runbook (<code>--cache-reuse 256 --slot-save-path</code> 권장)</td></tr>
+<tr><td>G3</td><td>로컬 행 <code>preserve-thinking=false</code> 일괄 — 템플릿은 지원, 실측 이득 확인</td><td>PR-4: keeper 대화 레인에서 preserve 활성 (exact JSON 레인은 think off 유지)</td></tr>
+<tr><td>G4</td><td>Anthropic 히스토리 캐시 breakpoint 없음 (system+tools만)</td><td>PR-5: top-level 자동 cache_control 옵트인 (read 0.1x)</td></tr>
+<tr><td>G5</td><td>대시보드가 캐시를 bool로 축약</td><td>PR-3: cache_n/prompt_n 원값 노출</td></tr>
+<tr><td>G6</td><td>provider별 usage 의미론(input에 cached 포함 여부) 미감사</td><td>후속 감사</td></tr>
+</table>
+
+<p class="note">이 리포트의 모든 수치는 위 명시된 환경에서의 단일 측정이다. mlx 서버와 동시 상주 상태라 decode 절대값에는 Metal 경합이 섞여 있고, 정책 간 <em>상대</em> 비교(같은 세션 내 연속 측정)가 이 리포트의 주장 범위다.</p>
+
+</body>
+</html>

--- a/scripts/bench-kv-cache.py
+++ b/scripts/bench-kv-cache.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""KV-cache reuse harness for llama-server (llama.cpp) OpenAI-compat endpoint.
+
+Measures per-turn timings.cache_n / prompt_n across four history policies:
+  preserve      — stable system prompt, assistant reasoning_content replayed
+  strip         — stable system prompt, reasoning_content dropped from history
+  volatile      — per-turn timestamp line appended to system prompt
+  volatile_tail — same timestamp carried in the new user message instead
+
+Server used for the 2026-08-16 evidence run (RFC-0382):
+  llama-server -m <gguf> --alias qwen3.8-27b -c 16384 -np 1 \
+    --port 9010 --host 127.0.0.1 --jinja --reasoning-format deepseek
+
+Output: one JSON line per turn on stdout and appended to --out.
+Evidence SSOT: docs/evidence/kv-cache-harness-2026-08-16.jsonl
+"""
+
+import argparse
+import json
+import sys
+import time
+import urllib.request
+
+SYSTEM_BASE = (
+    "You are keeper 'harness', a long-running autonomous agent in a multi-agent "
+    "coordination server. Your persona: terse, evidence-driven, skeptical. "
+    "You collaborate with sibling keepers on a shared board. Rules: "
+    "(1) never repeat a point you already made in a previous turn; "
+    "(2) reference your own earlier reasoning when extending it; "
+    "(3) answers stay under 80 words. "
+    "Project context: the team is auditing a distributed job scheduler written in OCaml. "
+    "Components: dispatcher (lease-based claim), worker pool (Eio fibers), ledger "
+    "(append-only JSONL), and a dashboard. Known symptoms: duplicate job execution "
+    "after lease expiry, a starving low-priority lane, and a slow drain queue. "
+    "Your job across turns: reason about root causes, propose one hypothesis per turn, "
+    "and refine earlier hypotheses instead of restating them. "
+) * 3  # ~600 tokens of stable system context
+
+USER_TURNS = [
+    "Turn 1: duplicate execution appears only when lease TTL < job runtime. First hypothesis?",
+    "Turn 2: extend your hypothesis — does the ledger see both executions or one?",
+    "Turn 3: the starving lane shares a mutex with the drain queue. Connect this to turn 1.",
+    "Turn 4: propose the single smallest fix that addresses both symptoms.",
+    "Turn 5: what measurement would falsify your turn-4 fix?",
+    "Turn 6: summarize all hypotheses so far WITHOUT repeating full sentences.",
+]
+
+
+def call(base, body, timeout):
+    req = urllib.request.Request(
+        base + "/v1/chat/completions",
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    t0 = time.time()
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        resp = json.load(r)
+    resp["_wall_s"] = round(time.time() - t0, 2)
+    return resp
+
+
+def run_scenario(base, scenario, turns, max_tokens, model, timeout, out):
+    history = []
+    rows = []
+    for i in range(turns):
+        if scenario == "volatile":
+            system = SYSTEM_BASE + f"\nCurrent time: 2026-08-16T{10+i:02d}:00:00+09:00 turn={i}"
+        else:
+            system = SYSTEM_BASE
+        user_text = USER_TURNS[i % len(USER_TURNS)]
+        if scenario == "volatile_tail":
+            user_text = (
+                f"[context update] time=2026-08-16T{10+i:02d}:00:00+09:00 turn={i}\n"
+                + user_text
+            )
+        messages = [{"role": "system", "content": system}] + history + [
+            {"role": "user", "content": user_text}
+        ]
+        body = {
+            "model": model,
+            "messages": messages,
+            "max_tokens": max_tokens,
+            "temperature": 0.7,
+            "stream": False,
+            "cache_prompt": True,
+            "chat_template_kwargs": {
+                "enable_thinking": True,
+                **({"preserve_thinking": True} if scenario != "strip" else {}),
+            },
+        }
+        resp = call(base, body, timeout)
+        msg = resp["choices"][0]["message"]
+        content = msg.get("content") or ""
+        reasoning = msg.get("reasoning_content") or ""
+        assistant = {"role": "assistant", "content": content}
+        if scenario != "strip" and reasoning:
+            assistant["reasoning_content"] = reasoning
+        history.append({"role": "user", "content": user_text})
+        history.append(assistant)
+        t = resp.get("timings") or {}
+        row = {
+            "scenario": scenario,
+            "turn": i + 1,
+            "cache_n": t.get("cache_n"),
+            "prompt_n": t.get("prompt_n"),
+            "prompt_ms": round(t.get("prompt_ms") or 0, 1),
+            "predicted_n": t.get("predicted_n"),
+            "predicted_ms": round(t.get("predicted_ms") or 0, 1),
+            "wall_s": resp["_wall_s"],
+            "reasoning_chars": len(reasoning),
+            "content_chars": len(content),
+        }
+        rows.append(row)
+        line = json.dumps(row, ensure_ascii=False)
+        print(line, flush=True)
+        out.write(line + "\n")
+        out.flush()
+    return rows
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", default="http://127.0.0.1:9010")
+    ap.add_argument("--scenarios", default="preserve,strip,volatile")
+    ap.add_argument("--turns", type=int, default=4)
+    ap.add_argument("--max-tokens", type=int, default=120)
+    ap.add_argument("--model", default="qwen3.8-27b")
+    ap.add_argument("--timeout", type=int, default=1800)
+    ap.add_argument("--out", default="kv_harness_results.jsonl")
+    args = ap.parse_args()
+
+    with open(args.out, "a") as out:
+        for scenario in args.scenarios.split(","):
+            print(f"### scenario={scenario}", file=sys.stderr, flush=True)
+            run_scenario(args.base, scenario, args.turns, args.max_tokens,
+                         args.model, args.timeout, out)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 무엇

런타임별 KV/prompt cache 재사용과 preserve-thinking(추론 연속성) 구현이 올바른지 실측으로 감사한 결과를 RFC-0382 + 리포트 + 하네스 + 증거 JSONL로 기록합니다. 코드 변경 없음 (docs/scripts only).

## 핵심 실측 (llama-server b10180, Qwen3.8-27B, M3 Max)

| 히스토리 정책 | 턴2 | 턴3 | 턴4 |
|---|---|---|---|
| preserve (append-only + reasoning 재주입) | 29 tok | 34 | 26 |
| strip (Qwen 기본) | 122 | 86 | 32 |
| volatile-head (system에 타임스탬프 1줄) | 314 | 863 | **1,892 (14.4s)** |
| volatile-tail (같은 정보를 꼬리에) | 64 | 69 | 61 |

- 변동 정보를 헤드에서 꼬리로 옮기는 것만으로 턴4 prefill **31배** 차이.
- 라이브 fleet(8/15, 760턴): gemini 84.1% / GLM 40.6% / ollama_cloud **0%** (하루 23.4M input 토큰 전량 재프리필).
- llama-server b10180이 같은 GGUF에서 ollama 대비 decode 5.5배 (17.6 vs 3.2 t/s) + 캐시 관측(`timings.cache_n`) 지원.
- 격차 G1~G6과 stacked PR 계획(PR-2 스트리밍 timings 파싱, PR-3 관측성, PR-4 llama-server 레인 복원, PR-5 Anthropic 자동 캐시)은 RFC 본문 참조.

## 검증

- `scripts/bench-kv-cache.py`로 재현 가능 (서버 커맨드 docstring 명시).
- 원 수치: `docs/evidence/kv-cache-harness-2026-08-16.jsonl` (16턴 전량).
- 코드 변경이 없어 로컬 lint/test 해당 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)