### PR TITLE
feat(llm): OpenAI-compat SSE 스트림에서 llama-server timings(cache_n) 수집

### DIFF
--- a/packages/agent_core/lib/llm_provider/complete_stream.ml
+++ b/packages/agent_core/lib/llm_provider/complete_stream.ml
@@ -350,10 +350,13 @@ let complete_stream_http
          [ContentBlockDelta]). *)
       let first_token_at_ref : float option ref = ref None in
       let first_event_at_ref : float option ref = ref None in
-      (* Ollama-specific side channel: prompt_eval_count / eval_count and
-     the four duration fields only appear on the [done:true] line, so
-     stream_acc (which only sees content/tool deltas) cannot capture
-     them. We trap them here and patch the finalised response below. *)
+      (* Wire-timings side channel. Ollama carries prompt_eval_count /
+     eval_count and the four duration fields only on the [done:true]
+     line; llama-server (OpenAI-compat SSE) carries a [timings] object
+     (including [cache_n], the KV-cache-reused prompt tokens) only on
+     the final chunk. stream_acc (which only sees content/tool deltas)
+     cannot capture either, so we trap them here and patch the
+     finalised response below. *)
       let provider = Provider_config.string_of_provider_kind config.kind in
       let model = config.model_id in
       let active_wire_format =
@@ -376,7 +379,7 @@ let complete_stream_http
         | None -> ()
       in
       let ollama_usage = ref None in
-      let ollama_timings = ref None in
+      let stream_timings = ref None in
       (* Agent Core contract — stream-lifetime accumulators for the
          [Streaming_summary] variant that fires once at finalize.
          Hoisted out of [body_logic] so exception paths (timeout,
@@ -671,7 +674,7 @@ let complete_stream_http
                                ([ Types.NDJSONError { message; error_type; raw } ], None)
                            | Streaming.Ollama_chunk chunk ->
                              (match chunk.oll_timings with
-                              | Some _ as t -> ollama_timings := t
+                              | Some _ as t -> stream_timings := t
                               | None -> ());
                              (match chunk.oll_usage with
                               | Some _ as u -> ollama_usage := u
@@ -709,9 +712,19 @@ let complete_stream_http
                                  event_type
                                  data
                              | Provider_http_codec.Openai_chat ->
-                               Streaming.parse_openai_sse_chunk ~streaming_reasoning data
-                               |> Streaming.openai_sse_parse_result_to_events
-                                    (get_state ())
+                               let parsed =
+                                 Streaming.parse_openai_sse_chunk
+                                   ~streaming_reasoning
+                                   data
+                               in
+                               (match parsed with
+                                | Streaming.Openai_chunk
+                                    { chunk_timings = Some _ as t; _ } ->
+                                  stream_timings := t
+                                | _ -> ());
+                               Streaming.openai_sse_parse_result_to_events
+                                 (get_state ())
+                                 parsed
                              | Provider_http_codec.Gemini_generate_content ->
                                (match Streaming.parse_gemini_sse_chunk data with
                                 | Streaming.Gemini_chunk chunk ->
@@ -746,9 +759,19 @@ let complete_stream_http
                                     ]
                                   , None ))
                              | Provider_http_codec.Glm_chat ->
-                               Backend_glm.parse_stream_chunk ~streaming_reasoning data
-                               |> Streaming.openai_sse_parse_result_to_events
-                                    (get_state ())
+                               let parsed =
+                                 Backend_glm.parse_stream_chunk
+                                   ~streaming_reasoning
+                                   data
+                               in
+                               (match parsed with
+                                | Streaming.Openai_chunk
+                                    { chunk_timings = Some _ as t; _ } ->
+                                  stream_timings := t
+                                | _ -> ());
+                               Streaming.openai_sse_parse_result_to_events
+                                 (get_state ())
+                                 parsed
                              | Provider_http_codec.Ollama_chat ->
                                [], None (* unreachable: handled above *)
                            in
@@ -875,8 +898,7 @@ let complete_stream_http
       | Ok (Ok resp) ->
         let latency_ms = latency_ms_int latency_counter in
         (* Ollama injection: usage from the done chunk wins over the
-         zeroed accumulator, and timings populate the otherwise-None
-         telemetry slot before patch_telemetry layers in latency. *)
+         zeroed accumulator. *)
         let resp =
           match config.kind with
           | Provider_config.Ollama ->
@@ -885,17 +907,25 @@ let complete_stream_http
               | Some _ as u -> u
               | None -> resp.usage
             in
-            let telemetry =
-              match resp.telemetry, !ollama_timings with
-              | _, None -> resp.telemetry
-              | Some t, (Some _ as timings) -> Some { t with timings }
-              | None, (Some _ as timings) ->
-                Some { Types.default_inference_telemetry with timings }
-            in
-            { resp with usage; telemetry }
+            { resp with usage }
           | Anthropic | Kimi | OpenAI_compat | Gemini | Glm | DashScope -> resp
         in
-        (match !ollama_timings with
+        (* Wire timings (Ollama done line, llama-server final SSE chunk)
+         populate the otherwise-None telemetry slot before patch_telemetry
+         layers in latency. Provider-independent: whichever branch trapped
+         a timings payload above wins. *)
+        let resp =
+          match !stream_timings with
+          | None -> resp
+          | Some _ as timings ->
+            let telemetry =
+              match resp.telemetry with
+              | Some t -> Some { t with timings }
+              | None -> Some { Types.default_inference_telemetry with timings }
+            in
+            { resp with telemetry }
+        in
+        (match !stream_timings with
          | Some
              { Types.prompt_n = Some prompt_eval_tokens
              ; prompt_ms = Some prompt_eval_ms
@@ -911,7 +941,7 @@ let complete_stream_http
              (Telemetry_event.Prefill_complete
                 { provider; model; prompt_eval_tokens; prompt_eval_ms; cache_hit })
          | Some _ | None -> ());
-        let prefill_ms = Option.bind !ollama_timings (fun t -> t.prompt_ms) in
+        let prefill_ms = Option.bind !stream_timings (fun t -> t.prompt_ms) in
         Ok (patch_telemetry resp ~config ~ttfrc_ms:!ttfrc_ref ~prefill_ms latency_ms)
       | Ok (Error (Http_client.TimeoutError _ as err)) ->
         publish_summary ~terminal:(Telemetry_event.Terminal_error "timeout_error") ();

--- a/packages/agent_core/lib/llm_provider/streaming.ml
+++ b/packages/agent_core/lib/llm_provider/streaming.ml
@@ -357,6 +357,7 @@ type openai_chunk =
   ; delta_tool_calls : openai_tool_call_delta list
   ; finish_reason : string option
   ; chunk_usage : api_usage option
+  ; chunk_timings : inference_timings option
   }
 
 type openai_sse_parse_result =
@@ -613,6 +614,33 @@ let parse_openai_sse_chunk ?streaming_reasoning data_str : openai_sse_parse_resu
                      ; cost_usd = None
                      })
                in
+               (* llama-server attaches a top-level [timings] object to the
+                  final chunk (the one with [finish_reason]) without opt-in;
+                  [cache_n] is the prompt-token count reused from the slot KV
+                  cache. Cloud OpenAI-compatible providers do not send it. *)
+               let chunk_timings =
+                 let t = json |> member "timings" in
+                 if t = `Null
+                 then None
+                 else (
+                   let int_field name = t |> member name |> to_int_option in
+                   let float_field name =
+                     match t |> member name with
+                     | `Float f -> Some f
+                     | `Int i -> Some (float_of_int i)
+                     | `Intlit s -> float_of_string_opt s
+                     | _ -> None
+                   in
+                   Some
+                     { Types.prompt_n = int_field "prompt_n"
+                     ; prompt_ms = float_field "prompt_ms"
+                     ; prompt_per_second = float_field "prompt_per_second"
+                     ; predicted_n = int_field "predicted_n"
+                     ; predicted_ms = float_field "predicted_ms"
+                     ; predicted_per_second = float_field "predicted_per_second"
+                     ; cache_n = int_field "cache_n"
+                     })
+               in
                match assoc_field_opt "choices" json with
                | Some (`List []) ->
                  (match chunk_usage with
@@ -627,6 +655,7 @@ let parse_openai_sse_chunk ?streaming_reasoning data_str : openai_sse_parse_resu
                       ; delta_tool_calls = []
                       ; finish_reason = None
                       ; chunk_usage
+                      ; chunk_timings
                       })
                | Some (`List (choice :: _)) ->
                  let delta = choice |> member "delta" in
@@ -696,6 +725,7 @@ let parse_openai_sse_chunk ?streaming_reasoning data_str : openai_sse_parse_resu
                          ; delta_tool_calls
                          ; finish_reason
                          ; chunk_usage
+                         ; chunk_timings
                          }))
                | None | Some `Null ->
                  openai_parse_failed
@@ -1369,6 +1399,7 @@ let%test
         ]
     ; finish_reason = None
     ; chunk_usage = None
+    ; chunk_timings = None
     }
   in
   let events, _ = openai_chunk_to_events state chunk in
@@ -1392,6 +1423,7 @@ let%test "openai_chunk_to_events: id-less continuation fragment stays in its cal
     ; delta_tool_calls = []
     ; finish_reason = None
     ; chunk_usage = None
+    ; chunk_timings = None
     }
   in
   let state = create_openai_stream_state () in
@@ -1443,6 +1475,7 @@ let%test
     ; delta_tool_calls = []
     ; finish_reason = None
     ; chunk_usage = None
+    ; chunk_timings = None
     }
   in
   let tc tc_index tc_id tc_name args =
@@ -1490,6 +1523,7 @@ let%test "openai_chunk_to_events: id-less continuation on ambiguous index fails 
     ; delta_tool_calls = []
     ; finish_reason = None
     ; chunk_usage = None
+    ; chunk_timings = None
     }
   in
   let tc tc_id args =

--- a/packages/agent_core/lib/llm_provider/streaming.mli
+++ b/packages/agent_core/lib/llm_provider/streaming.mli
@@ -78,6 +78,11 @@ type openai_chunk =
   ; delta_tool_calls : openai_tool_call_delta list
   ; finish_reason : string option
   ; chunk_usage : api_usage option
+  ; chunk_timings : inference_timings option
+    (** Top-level [timings] object llama-server attaches to the final SSE
+        chunk (the one carrying [finish_reason]) without opt-in. Includes
+        [cache_n], the prompt tokens reused from the slot KV cache. Cloud
+        OpenAI-compatible providers do not send it. *)
   }
 
 (** Closed classification of one OpenAI-compatible SSE data payload. Parsing

--- a/packages/agent_core/test/test_complete_http.ml
+++ b/packages/agent_core/test/test_complete_http.ml
@@ -289,6 +289,70 @@ let test_complete_stream_http_rejects_typed_empty_completion () =
     [ Types.EndTurn, "end_turn"; Types.MaxTokens, "max_tokens" ]
 ;;
 
+(* llama-server (OpenAI-compat SSE) attaches a [timings] object — including
+   [cache_n], the KV-cache-reused prompt tokens — to the final chunk without
+   opt-in. The stream path must land it in response telemetry and emit
+   [Prefill_complete], exactly like the Ollama NDJSON done line does. *)
+let openai_sse_with_llama_timings =
+  "data: \
+   {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"pong\"},\"finish_reason\":null}],\"id\":\"c-t\",\"model\":\"qwen3.8-27b\",\"object\":\"chat.completion.chunk\"}\n\n\
+   data: \
+   {\"choices\":[{\"finish_reason\":\"stop\",\"index\":0,\"delta\":{}}],\"id\":\"c-t\",\"model\":\"qwen3.8-27b\",\"object\":\"chat.completion.chunk\",\"timings\":{\"cache_n\":1741,\"prompt_n\":26,\"prompt_ms\":709.5,\"predicted_n\":2,\"predicted_ms\":122.7,\"predicted_per_second\":16.3}}\n\n\
+   data: [DONE]\n\n"
+;;
+
+let test_complete_stream_openai_captures_llama_server_timings () =
+  Eio_main.run
+  @@ fun env ->
+  try
+    Eio.Switch.run
+    @@ fun sw ->
+    let url = start_mock_server ~sw ~net:env#net openai_sse_with_llama_timings in
+    let prefill = ref None in
+    let result =
+      Complete.complete_stream
+        ~sw
+        ~net:env#net
+        ~config:(make_openai_config url)
+        ~messages
+        ~on_telemetry:(fun evt ->
+          match evt with
+          | Telemetry_event.Prefill_complete { prompt_eval_tokens; cache_hit; _ } ->
+            prefill := Some (prompt_eval_tokens, cache_hit)
+          | _ -> ())
+        ~on_event:(fun _ -> ())
+        ()
+    in
+    (match result with
+     | Ok resp ->
+       (match resp.telemetry with
+        | Some { timings = Some t; _ } ->
+          check (option int) "cache_n" (Some 1741) t.cache_n;
+          check (option int) "prompt_n" (Some 26) t.prompt_n;
+          check (option int) "predicted_n" (Some 2) t.predicted_n
+        | Some { timings = None; _ } | None ->
+          Alcotest.fail "expected stream timings in response telemetry");
+       (match !prefill with
+        | Some (prompt_eval_tokens, cache_hit) ->
+          check int "prefill tokens" 26 prompt_eval_tokens;
+          check bool "cache_hit" true cache_hit
+        | None -> Alcotest.fail "expected Prefill_complete telemetry")
+     | Error err ->
+       Alcotest.fail
+         (Printf.sprintf
+            "expected Ok, got %s"
+            (match err with
+             | Http_client.NetworkError { message; _ }
+             | Http_client.TimeoutError { message; _ } -> message
+             | Http_client.HttpError { code; _ } -> Printf.sprintf "HTTP %d" code
+             | Http_client.AcceptRejected { reason } -> reason
+             | Http_client.ProviderTerminal { message; _ } -> message
+             | Http_client.ProviderFailure { message; _ } -> message)));
+    Eio.Switch.fail sw Exit
+  with
+  | Exit -> ()
+;;
+
 (* ── complete: HTTP error ────────────────────────────── *)
 
 let test_complete_http_error () =
@@ -3672,6 +3736,10 @@ let () =
             `Quick
             test_complete_stream_idle_timeout_still_fires
         ; test_case "streaming metrics" `Quick test_complete_stream_metrics
+        ; test_case
+            "OpenAI-compat stream captures llama-server timings"
+            `Quick
+            test_complete_stream_openai_captures_llama_server_timings
         ; test_case
             "unknown stream latency stays unknown"
             `Quick

--- a/packages/agent_core/test/test_streaming_edge_cases.ml
+++ b/packages/agent_core/test/test_streaming_edge_cases.ml
@@ -29,6 +29,7 @@ let openai_chunk
   ; delta_tool_calls
   ; finish_reason
   ; chunk_usage
+  ; chunk_timings = None
   }
 ;;
 

--- a/packages/agent_core/test/test_streaming_openai.ml
+++ b/packages/agent_core/test/test_streaming_openai.ml
@@ -38,7 +38,44 @@ let test_parse_finish_reason () =
   match S.parse_openai_sse_chunk data with
   | S.Openai_chunk chunk ->
     Alcotest.(check (option string)) "finish" (Some "stop") chunk.finish_reason;
-    Alcotest.(check (option string)) "no content" None chunk.delta_content
+    Alcotest.(check (option string)) "no content" None chunk.delta_content;
+    Alcotest.(check bool) "no timings" true (chunk.chunk_timings = None)
+  | S.Openai_done | S.Openai_empty | S.Openai_provider_error _ | S.Openai_parse_failed _
+    -> Alcotest.fail "expected OpenAI chunk"
+;;
+
+(* Verbatim final chunk captured from llama-server b10180 (11b068d06) on
+   2026-08-16: the [timings] object rides the finish_reason chunk without
+   any opt-in, and [cache_n] is the KV-cache-reused prompt-token count. *)
+let test_parse_final_chunk_llama_server_timings () =
+  let data =
+    {|{"choices":[{"finish_reason":"stop","index":0,"delta":{}}],"created":1786817415,"id":"chatcmpl-csKoSC2O1Q4NOnFgmxNXcgXu8YZWWITo","model":"qwen3.8-27b","system_fingerprint":"b10180-11b068d06","object":"chat.completion.chunk","timings":{"cache_n":0,"prompt_n":14,"prompt_ms":572.696,"prompt_per_token_ms":40.90685714285714,"prompt_per_second":24.445779261597774,"predicted_n":2,"predicted_ms":122.729,"predicted_per_token_ms":61.3645,"predicted_per_second":16.296066944243005}}|}
+  in
+  match S.parse_openai_sse_chunk data with
+  | S.Openai_chunk chunk ->
+    Alcotest.(check (option string)) "finish" (Some "stop") chunk.finish_reason;
+    (match chunk.chunk_timings with
+     | None -> Alcotest.fail "expected chunk_timings"
+     | Some t ->
+       Alcotest.(check (option int)) "cache_n" (Some 0) t.cache_n;
+       Alcotest.(check (option int)) "prompt_n" (Some 14) t.prompt_n;
+       Alcotest.(check (option int)) "predicted_n" (Some 2) t.predicted_n;
+       (match t.prompt_ms with
+        | Some ms -> Alcotest.(check bool) "prompt_ms" true (abs_float (ms -. 572.696) < 0.001)
+        | None -> Alcotest.fail "expected prompt_ms"))
+  | S.Openai_done | S.Openai_empty | S.Openai_provider_error _ | S.Openai_parse_failed _
+    -> Alcotest.fail "expected OpenAI chunk"
+;;
+
+let test_parse_final_chunk_timings_cache_hit () =
+  let data =
+    {|{"choices":[{"finish_reason":"stop","index":0,"delta":{}}],"id":"c-9","model":"qwen3.8-27b","object":"chat.completion.chunk","timings":{"cache_n":1741,"prompt_n":26,"prompt_ms":709.5,"predicted_n":512,"predicted_ms":54893.4,"predicted_per_second":9.3}}|}
+  in
+  match S.parse_openai_sse_chunk data with
+  | S.Openai_chunk { chunk_timings = Some t; _ } ->
+    Alcotest.(check (option int)) "cache_n" (Some 1741) t.cache_n;
+    Alcotest.(check (option int)) "prompt_n" (Some 26) t.prompt_n
+  | S.Openai_chunk { chunk_timings = None; _ } -> Alcotest.fail "expected timings"
   | S.Openai_done | S.Openai_empty | S.Openai_provider_error _ | S.Openai_parse_failed _
     -> Alcotest.fail "expected OpenAI chunk"
 ;;
@@ -122,6 +159,7 @@ let test_events_text_first_chunk () =
     ; delta_tool_calls = []
     ; finish_reason = None
     ; chunk_usage = None
+    ; chunk_timings = None
     }
   in
   let events, _tel = S.openai_chunk_to_events state chunk in
@@ -150,6 +188,7 @@ let test_events_text_subsequent () =
       ; delta_tool_calls = []
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_timings = None
       }
   in
   (* Second chunk: no ContentBlockStart *)
@@ -164,6 +203,7 @@ let test_events_text_subsequent () =
       ; delta_tool_calls = []
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_timings = None
       }
   in
   Alcotest.(check int) "1 event" 1 (List.length events);
@@ -192,6 +232,7 @@ let test_events_tool_call () =
       ; delta_tool_calls = [ tc ]
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_timings = None
       }
   in
   Alcotest.(check int) "2 events" 2 (List.length events);
@@ -226,6 +267,7 @@ let idless_openai_tool_start () =
           ]
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_timings = None
       }
   in
   match events with
@@ -253,6 +295,7 @@ let test_events_idless_tool_identity_matches_final_response () =
       ; delta_tool_calls = []
       ; finish_reason = Some "tool_calls"
       ; chunk_usage = None
+      ; chunk_timings = None
       }
   in
   List.iter (Acc.accumulate_event acc) terminal;
@@ -289,6 +332,7 @@ let test_events_parallel_idless_tool_ids_are_distinct () =
       ; delta_tool_calls = [ call 0; call 1 ]
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_timings = None
       }
   in
   let ids =
@@ -323,6 +367,7 @@ let test_events_late_provider_tool_id_fails_closed () =
           ]
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_timings = None
       }
   in
   match events with
@@ -348,6 +393,7 @@ let test_events_finish_reason () =
       ; delta_reasoning_details = None
       ; finish_reason = Some "stop"
       ; chunk_usage = None
+      ; chunk_timings = None
       }
   in
   Alcotest.(check int) "1 event" 1 (List.length events);
@@ -369,6 +415,7 @@ let test_events_tool_calls_finish () =
       ; delta_reasoning_details = None
       ; finish_reason = Some "tool_calls"
       ; chunk_usage = None
+      ; chunk_timings = None
       }
   in
   match List.hd events with
@@ -402,6 +449,7 @@ let test_events_finish_closes_open_tool_block () =
       ; delta_tool_calls = [ tc ]
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_timings = None
       }
   in
   let events, _tel =
@@ -415,6 +463,7 @@ let test_events_finish_closes_open_tool_block () =
       ; delta_tool_calls = []
       ; finish_reason = Some "tool_calls"
       ; chunk_usage = None
+      ; chunk_timings = None
       }
   in
   Alcotest.(check int) "stop + message_delta" 2 (List.length events);
@@ -444,6 +493,7 @@ let test_events_length_finish () =
       ; delta_reasoning_details = None
       ; finish_reason = Some "length"
       ; chunk_usage = None
+      ; chunk_timings = None
       }
   in
   match List.hd events with
@@ -464,6 +514,7 @@ let test_events_empty_content_ignored () =
       ; delta_tool_calls = []
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_timings = None
       }
   in
   Alcotest.(check int) "0 events" 0 (List.length events)
@@ -630,6 +681,7 @@ let test_events_reasoning_then_text () =
       ; delta_tool_calls = []
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_timings = None
       }
   in
   Alcotest.(check int) "2 events (start+delta)" 2 (List.length r_events);
@@ -652,6 +704,7 @@ let test_events_reasoning_then_text () =
       ; delta_tool_calls = []
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_timings = None
       }
   in
   Alcotest.(check int) "2 events (start+delta)" 2 (List.length t_events);
@@ -681,6 +734,7 @@ let test_events_reasoning_delta_index_multi_chunk () =
       ; delta_tool_calls = []
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_timings = None
       }
   in
   Alcotest.(check int) "2 events (start+delta)" 2 (List.length r1);
@@ -705,6 +759,7 @@ let test_events_reasoning_delta_index_multi_chunk () =
       ; delta_tool_calls = []
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_timings = None
       }
   in
   Alcotest.(check int) "1 event (delta only)" 1 (List.length r2);
@@ -725,6 +780,7 @@ let test_events_reasoning_delta_index_multi_chunk () =
       ; delta_tool_calls = []
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_timings = None
       }
   in
   match List.nth t_events 1 with
@@ -756,6 +812,7 @@ let test_events_tool_first_then_text () =
       ; delta_tool_calls = [ tc ]
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_timings = None
       }
   in
   Alcotest.(check int) "2 tool events" 2 (List.length tool_events);
@@ -780,6 +837,7 @@ let test_events_tool_first_then_text () =
       ; delta_tool_calls = []
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_timings = None
       }
   in
   Alcotest.(check int) "2 text events" 2 (List.length text_events);
@@ -805,6 +863,7 @@ let test_events_tool_first_then_text () =
       ; delta_tool_calls = []
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_timings = None
       }
   in
   Alcotest.(check int) "1 event (delta only)" 1 (List.length text2_events);
@@ -844,6 +903,7 @@ let test_events_multi_tool_then_text () =
       ; delta_tool_calls = [ tc0; tc1 ]
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_timings = None
       }
   in
   (* Text must get index 2 *)
@@ -858,6 +918,7 @@ let test_events_multi_tool_then_text () =
       ; delta_tool_calls = []
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_timings = None
       }
   in
   (match List.nth text_events 0 with
@@ -885,6 +946,7 @@ let test_events_thinking_tool_text () =
       ; delta_tool_calls = []
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_timings = None
       }
   in
   (* Tool call: gets index 1 *)
@@ -906,6 +968,7 @@ let test_events_thinking_tool_text () =
       ; delta_tool_calls = [ tc ]
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_timings = None
       }
   in
   (* Text: must get index 2 *)
@@ -920,6 +983,7 @@ let test_events_thinking_tool_text () =
       ; delta_tool_calls = []
       ; finish_reason = None
       ; chunk_usage = None
+      ; chunk_timings = None
       }
   in
   (match List.nth text_events 0 with
@@ -1574,6 +1638,14 @@ let () =
       , [ test_case "text chunk" `Quick test_parse_text_chunk
         ; test_case "[DONE] sentinel" `Quick test_parse_done_sentinel
         ; test_case "finish_reason" `Quick test_parse_finish_reason
+        ; test_case
+            "final chunk llama-server timings"
+            `Quick
+            test_parse_final_chunk_llama_server_timings
+        ; test_case
+            "final chunk timings cache hit"
+            `Quick
+            test_parse_final_chunk_timings_cache_hit
         ; test_case "tool_call start" `Quick test_parse_tool_call_start
         ; test_case "tool_call args" `Quick test_parse_tool_call_args
         ; test_case "usage" `Quick test_parse_usage

--- a/packages/agent_core/test/test_streaming_summary.ml
+++ b/packages/agent_core/test/test_streaming_summary.ml
@@ -130,6 +130,7 @@ let make_openai_chunk
   ; delta_tool_calls
   ; finish_reason = None
   ; chunk_usage = None
+  ; chunk_timings = None
   }
 ;;
 


### PR DESCRIPTION
## 무엇 (RFC-0382 G1)

llama-server는 최종 SSE 청크에 top-level `timings` 객체(`cache_n` = KV 캐시 재사용 프롬프트 토큰 수 포함)를 opt-in 없이 싣습니다 (2026-08-16 b10180 curl 실측). 그런데 스트리밍 경로는 Ollama NDJSON의 timings만 트랩해서, `streaming = true`인 로컬 행 전부가 캐시 관측을 잃고 있었습니다.

## 변경

- `parse_openai_sse_chunk`: top-level `timings` → 기존 `Types.inference_timings`로 디코드, `openai_chunk.chunk_timings`로 운반
- `complete_stream`: `Openai_chat`/`Glm_chat` 분기에서 트랩 → provider 독립 단계로 response telemetry에 설치. Ollama의 usage 주입은 그대로 Ollama 전용 유지
- `Prefill_complete` 텔레메트리(cache_hit 포함)가 OpenAI-compat 스트림에서도 Ollama와 동형으로 발화
- 후속 소비자는 기존 배선 그대로: keeper cost events(`cache_n`), dashboard bridge `cache_hit`

## 테스트

- `test_streaming_openai`: llama-server b10180에서 캡처한 **실제 최종 청크 원문**으로 파싱 검증 + cache-hit 케이스 + timings 부재 케이스
- `test_complete_http`: mock SSE 서버로 스트림 전체를 돌려 response telemetry의 `cache_n`/`prompt_n`과 `Prefill_complete` 발화까지 feature 검증

## 참조

- RFC-0382 (#28774) 격차 G1. 실측 증거: `docs/evidence/kv-cache-harness-2026-08-16.jsonl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)