### PR TITLE
feat(bench): 검색 품질 회귀 하네스 — 고정 쿼리셋 결정론 채점 (Q1 실측 포함)

### DIFF
--- a/docs/evidence/web-quality-2026-08-16-r1.json
+++ b/docs/evidence/web-quality-2026-08-16-r1.json
@@ -1,0 +1,267 @@
+{
+  "captured_at": "2026-08-16T03:44:45+0900",
+  "script": "scripts/bench-web-quality.py",
+  "top_k": 5,
+  "case_count": 8,
+  "providers": {
+    "ollama": {
+      "summary": {
+        "cases_scored": 8,
+        "cases_errored": 0,
+        "hit_at_1": "5/6",
+        "hit_at_5": "5/6",
+        "hangul_ok": "2/2",
+        "median_elapsed_ms": 1230.9
+      },
+      "cases": [
+        {
+          "query": "OCaml 5.5 effect handlers tutorial",
+          "category": "official-docs",
+          "http_status": 200,
+          "elapsed_ms": 1230.9,
+          "result_count": 5,
+          "top_hosts": [
+            "ocaml.org",
+            "github.com",
+            "lewinb.net",
+            "thomasnelson.me",
+            "xavierleroy.org"
+          ],
+          "hit_at_1": true,
+          "hit_at_5": true,
+          "first_match_rank": 1
+        },
+        {
+          "query": "python asyncio TaskGroup documentation",
+          "category": "official-docs",
+          "http_status": 200,
+          "elapsed_ms": 1112.5,
+          "result_count": 5,
+          "top_hosts": [
+            "docs.python.org",
+            "docs.python.org",
+            "github.com",
+            "github.com",
+            "github.com"
+          ],
+          "hit_at_1": true,
+          "hit_at_5": true,
+          "first_match_rank": 1
+        },
+        {
+          "query": "RFC 9110 HTTP semantics status codes",
+          "category": "reference",
+          "http_status": 200,
+          "elapsed_ms": 2564.4,
+          "result_count": 5,
+          "top_hosts": [
+            "www.rfc-editor.org",
+            "www.rfc-editor.org",
+            "www.iana.org",
+            "datatracker.ietf.org",
+            "www.ietf.org"
+          ],
+          "hit_at_1": true,
+          "hit_at_5": true,
+          "first_match_rank": 1
+        },
+        {
+          "query": "git rebase autostash pop conflict behavior",
+          "category": "technical-qa",
+          "http_status": 200,
+          "elapsed_ms": 1779.2,
+          "result_count": 5,
+          "top_hosts": [
+            "git-scm.dev",
+            "github.com",
+            "github.com",
+            "github.com",
+            "public-inbox.org"
+          ],
+          "hit_at_1": false,
+          "hit_at_5": false,
+          "first_match_rank": null
+        },
+        {
+          "query": "Eio Switch cancellation semantics OCaml",
+          "category": "niche",
+          "http_status": 200,
+          "elapsed_ms": 1588.5,
+          "result_count": 5,
+          "top_hosts": [
+            "ocaml.org",
+            "ocaml.github.io",
+            "ocaml.github.io",
+            "ocaml.github.io",
+            "discuss.ocaml.org"
+          ],
+          "hit_at_1": true,
+          "hit_at_5": true,
+          "first_match_rank": 1
+        },
+        {
+          "query": "Anthropic Claude latest model announcement",
+          "category": "recency",
+          "http_status": 200,
+          "elapsed_ms": 895.7,
+          "result_count": 5,
+          "top_hosts": [
+            "www.anthropic.com",
+            "www.anthropic.com",
+            "www.anthropic.com",
+            "www.anthropic.com",
+            "www.theverge.com"
+          ],
+          "hit_at_1": true,
+          "hit_at_5": true,
+          "first_match_rank": 1
+        },
+        {
+          "query": "장마철 제습기 원리",
+          "category": "korean",
+          "http_status": 200,
+          "elapsed_ms": 976.3,
+          "result_count": 5,
+          "top_hosts": [
+            "choicemon.com",
+            "www.ajd.co.kr",
+            "www.hvacrj.co.kr",
+            "ko.wikipedia.org",
+            "kotopranking.com"
+          ],
+          "hangul_ratio": 0.804,
+          "hangul_ok": true
+        },
+        {
+          "query": "전세 계약 갱신 청구권 조건",
+          "category": "korean",
+          "http_status": 200,
+          "elapsed_ms": 1069.7,
+          "result_count": 5,
+          "top_hosts": [
+            "www.mylawstory.com",
+            "aptcheck.kr",
+            "www.molit.go.kr",
+            "www.law.go.kr",
+            "angrywitch.co.kr"
+          ],
+          "hangul_ratio": 0.747,
+          "hangul_ok": true
+        }
+      ]
+    },
+    "brave_grounded": {
+      "skipped": "BRAVE_SEARCH_API_KEY absent"
+    },
+    "searxng": {
+      "summary": {
+        "cases_scored": 8,
+        "cases_errored": 0,
+        "hit_at_1": "2/6",
+        "hit_at_5": "2/6",
+        "hangul_ok": "0/2",
+        "median_elapsed_ms": 1920.5
+      },
+      "cases": [
+        {
+          "query": "OCaml 5.5 effect handlers tutorial",
+          "category": "official-docs",
+          "http_status": 200,
+          "elapsed_ms": 2214.2,
+          "result_count": 10,
+          "top_hosts": [
+            "ocaml.org",
+            "github.com",
+            "github.com",
+            "aj002.github.io",
+            "ocaml.org"
+          ],
+          "hit_at_1": true,
+          "hit_at_5": true,
+          "first_match_rank": 1
+        },
+        {
+          "query": "python asyncio TaskGroup documentation",
+          "category": "official-docs",
+          "http_status": 200,
+          "elapsed_ms": 2125.5,
+          "result_count": 10,
+          "top_hosts": [
+            "docs.python.org",
+            "docs.python.org",
+            "www.pyblog.in",
+            "www.geeksforgeeks.org",
+            "github.com"
+          ],
+          "hit_at_1": true,
+          "hit_at_5": true,
+          "first_match_rank": 1
+        },
+        {
+          "query": "RFC 9110 HTTP semantics status codes",
+          "category": "reference",
+          "http_status": 200,
+          "elapsed_ms": 1438.0,
+          "result_count": 0,
+          "top_hosts": [],
+          "hit_at_1": false,
+          "hit_at_5": false,
+          "first_match_rank": null
+        },
+        {
+          "query": "git rebase autostash pop conflict behavior",
+          "category": "technical-qa",
+          "http_status": 200,
+          "elapsed_ms": 608.2,
+          "result_count": 0,
+          "top_hosts": [],
+          "hit_at_1": false,
+          "hit_at_5": false,
+          "first_match_rank": null
+        },
+        {
+          "query": "Eio Switch cancellation semantics OCaml",
+          "category": "niche",
+          "http_status": 200,
+          "elapsed_ms": 2461.0,
+          "result_count": 0,
+          "top_hosts": [],
+          "hit_at_1": false,
+          "hit_at_5": false,
+          "first_match_rank": null
+        },
+        {
+          "query": "Anthropic Claude latest model announcement",
+          "category": "recency",
+          "http_status": 200,
+          "elapsed_ms": 1491.7,
+          "result_count": 0,
+          "top_hosts": [],
+          "hit_at_1": false,
+          "hit_at_5": false,
+          "first_match_rank": null
+        },
+        {
+          "query": "장마철 제습기 원리",
+          "category": "korean",
+          "http_status": 200,
+          "elapsed_ms": 1920.5,
+          "result_count": 0,
+          "top_hosts": [],
+          "hangul_ratio": 0.0,
+          "hangul_ok": false
+        },
+        {
+          "query": "전세 계약 갱신 청구권 조건",
+          "category": "korean",
+          "http_status": 200,
+          "elapsed_ms": 895.7,
+          "result_count": 0,
+          "top_hosts": [],
+          "hangul_ratio": 0.0,
+          "hangul_ok": false
+        }
+      ]
+    }
+  }
+}

--- a/reports/web-tools-bench-2026-08-15.html
+++ b/reports/web-tools-bench-2026-08-15.html
@@ -206,11 +206,44 @@ provider(Ollama)로 넘어가는 체인 순회를 코드와 결과 양쪽에서 
 </ol>
 </div>
 
+<h2>품질 하네스 Q1 — 고정 쿼리셋 첫 실측 (2026-08-16, web-quality r1)</h2>
+
+<p class="note">계측기: <code>scripts/bench-web-quality.py</code> (신규) ·
+원본 증거: <code>docs/evidence/web-quality-2026-08-16-r1.json</code>.
+고정 8쿼리(공식문서 2·레퍼런스 1·기술QA 1·니치 1·최신성 1·한국어 2)에 기대 도메인 포함 여부를
+순위로 채점(hit@1/hit@5), 한국어는 반환 본문의 한글 비율로 채점. 채점은 결정론,
+변하는 것은 provider 뒤의 웹뿐 — 그 drift를 시계열로 추적하는 것이 목적이다.
+임계값·게이트 없음: 측정기다.</p>
+
+<h2>표 6. 같은 8쿼리, provider 품질 (r1)</h2>
+<table>
+<tr><th>provider</th><th>hit@1</th><th>hit@5</th><th>한국어 본문</th><th>중앙값 지연</th><th>비고</th></tr>
+<tr><td>Ollama</td><td><strong>5/6</strong></td><td>5/6</td><td><strong>2/2</strong> (한글 비율 0.80·0.75)</td><td>1,231ms</td>
+<td>유일한 miss는 기술QA — <code>git-scm.dev</code>(비공식 미러)가 1위로 와서 기대 도메인 판정 밖</td></tr>
+<tr><td>SearXNG</td><td>2/6</td><td>2/6</td><td>0/2</td><td>1,921ms</td>
+<td>부분 회복 관측: 8쿼리 중 2개(공식문서 계열)만 10건, 나머지 6개는 0건 — 특정 상류 엔진만 생존한 상태</td></tr>
+<tr><td>Brave grounded</td><td colspan="4">skip</td><td>BRAVE_SEARCH_API_KEY 부재 — 키 투입 즉시 같은 쿼리셋으로 A/B 활성화</td></tr>
+</table>
+
+<div class="verdict">
+<p><strong>판정 3줄.</strong></p>
+<ol>
+<li>"품질이 늘었나"에 처음으로 수치로 답할 수 있다 — 같은 쿼리셋에서 새 기본 경로(Ollama)가
+hit@1 <strong>5/6</strong>, 옛 유일 경로(SearXNG)는 부분 회복 상태에서도 <strong>2/6</strong>.
+한국어 품질 격차는 더 크다(2/2 vs 0/2).</li>
+<li>SearXNG 붕괴의 해부가 정밀해졌다 — 전면 0건이 아니라 <strong>쿼리 계열별 선택적 생존</strong>
+(공식문서 계열만 10건). "컨테이너 생존 + 상류 부분 소진"의 세 번째 층위.</li>
+<li>Ollama의 유일한 miss는 오답이 아니라 채점 기준의 경계(비공식 미러 도메인이 1위) —
+기대 도메인 목록은 하네스 fixture로 버전 관리되므로 필요 시 근거와 함께 갱신한다.</li>
+</ol>
+</div>
+
 <h2>다음 반복</h2>
 <ul>
-<li><strong>Iteration 6</strong> (선택): BRAVE_SEARCH_API_KEY 투입 시 grounded 경로
-(<code>maximum_number_of_tokens</code> 예산 준수) 실측.</li>
-<li>매 반복은 <code>python3 scripts/bench-web-tools.py -o docs/evidence/web-tools-bench-&lt;date&gt;-rN.json</code> 실행 후 이 문서에 섹션 추가.</li>
+<li><strong>Iteration 6</strong> (선택): BRAVE_SEARCH_API_KEY 투입 시 grounded 경로 —
+<code>bench-web-quality.py</code>가 같은 쿼리셋으로 자동 A/B.</li>
+<li>품질은 <code>python3 scripts/bench-web-quality.py -o docs/evidence/web-quality-&lt;date&gt;-rN.json</code>,
+가용성·토큰은 <code>bench-web-tools.py</code> — 실행 후 이 문서에 섹션 추가.</li>
 </ul>
 
 </body>

--- a/scripts/bench-web-quality.py
+++ b/scripts/bench-web-quality.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Search-quality regression bench: fixed queries, deterministic scoring.
+
+Answers "did search quality move?" with numbers instead of anecdotes.
+Each case pairs a fixed query with the evidence a good result must show:
+an expected domain in the top ranks, or (for Korean prose queries) a
+minimum hangul ratio in the returned content. Scoring is deterministic;
+only the web behind the providers varies between runs, which is exactly
+the drift this file exists to track over time.
+
+Providers measured per run:
+  - ollama          when OLLAMA_API_KEY is present (same endpoint, auth,
+                    and body shape as fetch_ollama in
+                    lib/tool_misc_web_search.ml)
+  - brave_grounded  when BRAVE_SEARCH_API_KEY is present (the Brave LLM
+                    Context endpoint fetch_brave_llm_context dispatches
+                    to); absent key records a skip, so the A/B side
+                    activates the moment the key lands
+  - searxng         always probed (no credential), as the availability
+                    time-series baseline
+
+Metrics per case: hit@1, hit@5 (expected-domain containment by rank),
+result_count, hangul_ratio where required, elapsed_ms. Aggregates per
+provider and per category. No thresholds and no exit-code gating: this
+is a measuring instrument, and the evidence JSON is the product.
+
+Usage:
+  python3 scripts/bench-web-quality.py -o docs/evidence/web-quality-<date>-rN.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import time
+import urllib.parse
+from pathlib import Path
+from typing import Any
+
+_spec = importlib.util.spec_from_file_location(
+    "bench_web_tools", Path(__file__).parent / "bench-web-tools.py"
+)
+assert _spec is not None and _spec.loader is not None
+_tools = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_tools)
+
+http = _tools.http
+probe = _tools.probe
+SEARXNG_URL = _tools.SEARXNG_URL
+
+# Each case: query, category, and the deterministic evidence of a good
+# answer. expected_domains matches against the registrable host suffix of
+# each result URL. min_hangul_ratio applies to concatenated result content.
+CASES: list[dict[str, Any]] = [
+    {
+        "query": "OCaml 5.5 effect handlers tutorial",
+        "category": "official-docs",
+        "expected_domains": ["ocaml.org"],
+    },
+    {
+        "query": "python asyncio TaskGroup documentation",
+        "category": "official-docs",
+        "expected_domains": ["docs.python.org"],
+    },
+    {
+        "query": "RFC 9110 HTTP semantics status codes",
+        "category": "reference",
+        "expected_domains": ["rfc-editor.org", "datatracker.ietf.org", "httpwg.org"],
+    },
+    {
+        "query": "git rebase autostash pop conflict behavior",
+        "category": "technical-qa",
+        "expected_domains": ["stackoverflow.com", "git-scm.com"],
+    },
+    {
+        "query": "Eio Switch cancellation semantics OCaml",
+        "category": "niche",
+        "expected_domains": ["ocaml.org", "github.com"],
+    },
+    {
+        "query": "Anthropic Claude latest model announcement",
+        "category": "recency",
+        "expected_domains": ["anthropic.com"],
+    },
+    {
+        "query": "장마철 제습기 원리",
+        "category": "korean",
+        "expected_domains": [],
+        "min_hangul_ratio": 0.2,
+    },
+    {
+        "query": "전세 계약 갱신 청구권 조건",
+        "category": "korean",
+        "expected_domains": [],
+        "min_hangul_ratio": 0.2,
+    },
+]
+
+TOP_K = 5
+
+
+def host_of(url: str) -> str:
+    try:
+        return (urllib.parse.urlsplit(url).hostname or "").lower()
+    except ValueError:
+        return ""
+
+
+def domain_matches(host: str, expected: str) -> bool:
+    return host == expected or host.endswith("." + expected)
+
+
+def hangul_ratio(text: str) -> float:
+    if not text:
+        return 0.0
+    hangul = sum(1 for ch in text if "가" <= ch <= "힣")
+    letters = sum(1 for ch in text if not ch.isspace())
+    return hangul / letters if letters else 0.0
+
+
+def score_case(case: dict[str, Any], ranked: list[dict[str, str]]) -> dict[str, Any]:
+    """ranked: [{url, content}] in provider rank order. Deterministic."""
+    expected = case["expected_domains"]
+    hosts = [host_of(r["url"]) for r in ranked[:TOP_K]]
+    first_match_rank = None
+    for rank, host in enumerate(hosts, start=1):
+        if any(domain_matches(host, e) for e in expected):
+            first_match_rank = rank
+            break
+    record: dict[str, Any] = {
+        "result_count": len(ranked),
+        "top_hosts": hosts,
+    }
+    if expected:
+        record["hit_at_1"] = first_match_rank == 1
+        record["hit_at_5"] = first_match_rank is not None
+        record["first_match_rank"] = first_match_rank
+    if "min_hangul_ratio" in case:
+        ratio = hangul_ratio("".join(r["content"] for r in ranked[:TOP_K]))
+        record["hangul_ratio"] = round(ratio, 3)
+        record["hangul_ok"] = ratio >= case["min_hangul_ratio"]
+    return record
+
+
+def run_ollama(api_key: str, case: dict[str, Any]) -> dict[str, Any]:
+    status, _, body, ms = http(
+        "https://ollama.com/api/web_search",
+        body=json.dumps({"query": case["query"], "max_results": TOP_K}).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+    )
+    parsed = json.loads(body)
+    results = parsed.get("results")
+    if results is None:
+        return {"http_status": status, "elapsed_ms": round(ms, 1), "error_payload": parsed}
+    ranked = [
+        {"url": r.get("url", ""), "content": r.get("content", "")} for r in results
+    ]
+    return {
+        "http_status": status,
+        "elapsed_ms": round(ms, 1),
+        **score_case(case, ranked),
+    }
+
+
+def run_brave_grounded(api_key: str, case: dict[str, Any]) -> dict[str, Any]:
+    query = urllib.parse.quote(case["query"])
+    status, _, body, ms = http(
+        f"https://api.search.brave.com/res/v1/llm/context?q={query}",
+        headers={"X-Subscription-Token": api_key, "Accept": "application/json"},
+    )
+    parsed = json.loads(body)
+    generic = (parsed.get("grounding") or {}).get("generic")
+    if generic is None:
+        return {"http_status": status, "elapsed_ms": round(ms, 1), "error_payload": parsed}
+    ranked = [
+        {
+            "url": entry.get("url", ""),
+            "content": "".join(entry.get("snippets") or []),
+        }
+        for entry in generic
+    ]
+    return {
+        "http_status": status,
+        "elapsed_ms": round(ms, 1),
+        **score_case(case, ranked),
+    }
+
+
+def run_searxng(case: dict[str, Any]) -> dict[str, Any]:
+    query = urllib.parse.quote(case["query"])
+    status, _, body, ms = http(f"{SEARXNG_URL}/search?q={query}&format=json")
+    parsed = json.loads(body)
+    results = parsed.get("results", [])
+    ranked = [
+        {"url": r.get("url", ""), "content": r.get("content", "")} for r in results
+    ]
+    return {
+        "http_status": status,
+        "elapsed_ms": round(ms, 1),
+        **score_case(case, ranked),
+    }
+
+
+def aggregate(rows: list[tuple[dict[str, Any], dict[str, Any]]]) -> dict[str, Any]:
+    scored = [r for _, r in rows if "error" not in r and "error_payload" not in r]
+    hit1 = [r["hit_at_1"] for r in scored if "hit_at_1" in r]
+    hit5 = [r["hit_at_5"] for r in scored if "hit_at_5" in r]
+    hangul = [r["hangul_ok"] for r in scored if "hangul_ok" in r]
+    ms = [r["elapsed_ms"] for r in scored if "elapsed_ms" in r]
+    return {
+        "cases_scored": len(scored),
+        "cases_errored": len(rows) - len(scored),
+        "hit_at_1": f"{sum(hit1)}/{len(hit1)}" if hit1 else None,
+        "hit_at_5": f"{sum(hit5)}/{len(hit5)}" if hit5 else None,
+        "hangul_ok": f"{sum(hangul)}/{len(hangul)}" if hangul else None,
+        "median_elapsed_ms": sorted(ms)[len(ms) // 2] if ms else None,
+    }
+
+
+def run_provider(runner) -> dict[str, Any]:
+    rows = [(case, probe(runner, case)) for case in CASES]
+    return {
+        "summary": aggregate(rows),
+        "cases": [
+            {"query": case["query"], "category": case["category"], **result}
+            for case, result in rows
+        ],
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-o", "--output", required=True, help="evidence JSON path")
+    args = parser.parse_args()
+
+    providers: dict[str, Any] = {}
+    ollama_key = os.environ.get("OLLAMA_API_KEY")
+    providers["ollama"] = (
+        run_provider(lambda case: run_ollama(ollama_key, case))
+        if ollama_key
+        else {"skipped": "OLLAMA_API_KEY absent"}
+    )
+    brave_key = os.environ.get("BRAVE_SEARCH_API_KEY")
+    providers["brave_grounded"] = (
+        run_provider(lambda case: run_brave_grounded(brave_key, case))
+        if brave_key
+        else {"skipped": "BRAVE_SEARCH_API_KEY absent"}
+    )
+    providers["searxng"] = run_provider(run_searxng)
+
+    evidence = {
+        "captured_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        "script": "scripts/bench-web-quality.py",
+        "top_k": TOP_K,
+        "case_count": len(CASES),
+        "providers": providers,
+    }
+    with open(args.output, "w", encoding="utf-8") as handle:
+        json.dump(evidence, handle, ensure_ascii=False, indent=2)
+        handle.write("\n")
+    for name, block in providers.items():
+        print(name, "->", json.dumps(block.get("summary", block), ensure_ascii=False))
+    print(f"wrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
"품질이 늘었나"에 수치로 답하기 위한 측정기예요.

- 고정 8쿼리 × 결정론 채점: 기대 도메인 순위 포함(hit@1/hit@5), 한국어는 본문 한글 비율
- provider: ollama(서버 `fetch_ollama`와 동일 계약) / brave_grounded(키 투입 즉시 A/B 활성) / searxng(가용성 베이스라인)
- 임계값·게이트 없음 — 측정기이며 evidence JSON이 산출물

**Q1 실측**: Ollama hit@1 **5/6**·한국어 **2/2** vs SearXNG **2/6**·0/2. SearXNG 붕괴의 3층위도 확정 — 전면 0건이 아니라 쿼리 계열별 선택 생존(8중 2계열만 10건).

🤖 Generated with [Claude Code](https://claude.com/claude-code)