### PR TITLE
feat(keeper): 워크스페이스 메시지를 Keeper 선형 이벤트 큐로 전달

### DIFF
--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -1389,12 +1389,12 @@ describe('parseKeeperEventQueuePendingSnapshot workspace message fields', () => 
       source_incarnation: '9',
       urgency: 'immediate',
       arrived_at_unix: 1786822060,
-      payload_kind: 'keeper_message',
+      payload_kind: 'workspace_message',
       ...extra,
     }],
   })
 
-  // Without these the operator row reads "wake reason keeper_message" and
+  // Without these the operator row reads "wake reason workspace_message" and
   // nothing else: no sender, and no way back to the transcript line.
   it('carries the sender and the request id through', () => {
     const parsed = parseKeeperEventQueuePendingSnapshot(snapshot({

--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -1373,3 +1373,45 @@ describe('parseKeeperEventQueuePendingSnapshot cancellation fields', () => {
     expect(row?.cancelledReason).toBeUndefined()
   })
 })
+
+describe('parseKeeperEventQueuePendingSnapshot workspace message fields', () => {
+  const snapshot = (extra: Record<string, unknown>) => ({
+    schema: 'keeper_event_queue.pending.v2',
+    ok: true,
+    keeper_name: 'sangsu',
+    revision: '9',
+    total_pending: 1,
+    next_after: null,
+    pending: [{
+      queue_index: 0,
+      post_id: 'workspace-message:wmsg-1234567890abcdef',
+      source_ref: 'b'.repeat(64),
+      source_incarnation: '9',
+      urgency: 'immediate',
+      arrived_at_unix: 1786822060,
+      payload_kind: 'keeper_message',
+      ...extra,
+    }],
+  })
+
+  // Without these the operator row reads "wake reason keeper_message" and
+  // nothing else: no sender, and no way back to the transcript line.
+  it('carries the sender and the request id through', () => {
+    const parsed = parseKeeperEventQueuePendingSnapshot(snapshot({
+      message_request_id: 'wmsg-1234567890abcdef',
+      message_from: 'keeper-rondo-agent',
+    }))
+    const row = parsed.pending[0]
+    expect(row).toBeDefined()
+    expect(row?.messageRequestId).toBe('wmsg-1234567890abcdef')
+    expect(row?.messageFrom).toBe('keeper-rondo-agent')
+  })
+
+  it('leaves both absent on a backend that predates the fields', () => {
+    const parsed = parseKeeperEventQueuePendingSnapshot(snapshot({}))
+    const row = parsed.pending[0]
+    expect(row).toBeDefined()
+    expect(row?.messageRequestId).toBeUndefined()
+    expect(row?.messageFrom).toBeUndefined()
+  })
+})

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -638,6 +638,12 @@ export interface KeeperEventQueuePendingItem {
   cancelledTaskId?: string
   cancelledBy?: string
   cancelledReason?: string
+  /** A workspace message that named this Keeper. `messageRequestId` is also
+      the transcript row's external message id, so an operator reading the
+      queue can find the line it refers to. Absent on a backend that predates
+      the fields. */
+  messageRequestId?: string
+  messageFrom?: string
 }
 
 export interface KeeperEventQueuePendingSnapshot {
@@ -733,6 +739,12 @@ export function parseKeeperEventQueuePendingSnapshot(
         : {}),
       ...(typeof raw.cancelled_reason === 'string' && raw.cancelled_reason.trim()
         ? { cancelledReason: raw.cancelled_reason.trim() }
+        : {}),
+      ...(typeof raw.message_request_id === 'string' && raw.message_request_id.trim()
+        ? { messageRequestId: raw.message_request_id.trim() }
+        : {}),
+      ...(typeof raw.message_from === 'string' && raw.message_from.trim()
+        ? { messageFrom: raw.message_from.trim() }
         : {}),
     }
   })

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -668,6 +668,9 @@ function KeeperQueueControlPanel({
               ${item.rejectionReason
                 ? html`<div class="whitespace-pre-wrap text-2xs text-[var(--color-fg-secondary)]">${item.rejectionTaskId ? `${item.rejectionTaskId}: ` : ''}${item.rejectionReason}</div>`
                 : null}
+              ${item.messageFrom
+                ? html`<div class="whitespace-pre-wrap text-2xs text-[var(--color-fg-secondary)]">${item.messageFrom} 님의 메시지${item.messageRequestId ? ` · ${item.messageRequestId}` : ''}</div>`
+                : null}
               <div class="break-all font-mono text-3xs text-[var(--color-fg-muted)]">
                 source ref ${item.sourceRef}
               </div>

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -164,7 +164,7 @@ let connector_attention_event_ids_of_stimuli stimuli =
       | Keeper_event_queue.Goal_reconciliation_ready _
       | Keeper_event_queue.Completion_authority_rejected _
       | Keeper_event_queue.Task_cancelled _
-      | Keeper_event_queue.Keeper_message _ ->
+      | Keeper_event_queue.Workspace_message _ ->
         None)
     stimuli
 ;;
@@ -186,7 +186,7 @@ let record_replay_owned_turn_started_reactions ~ctx ~keeper_name stimuli =
        | Keeper_event_queue.Goal_reconciliation_ready _
        | Keeper_event_queue.Completion_authority_rejected _
        | Keeper_event_queue.Task_cancelled _
-       | Keeper_event_queue.Keeper_message _ -> ())
+       | Keeper_event_queue.Workspace_message _ -> ())
     stimuli
 ;;
 

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -163,7 +163,8 @@ let connector_attention_event_ids_of_stimuli stimuli =
       | Keeper_event_queue.Goal_assigned _
       | Keeper_event_queue.Goal_reconciliation_ready _
       | Keeper_event_queue.Completion_authority_rejected _
-      | Keeper_event_queue.Task_cancelled _ ->
+      | Keeper_event_queue.Task_cancelled _
+      | Keeper_event_queue.Keeper_message _ ->
         None)
     stimuli
 ;;
@@ -184,7 +185,8 @@ let record_replay_owned_turn_started_reactions ~ctx ~keeper_name stimuli =
        | Keeper_event_queue.Goal_assigned _
        | Keeper_event_queue.Goal_reconciliation_ready _
        | Keeper_event_queue.Completion_authority_rejected _
-       | Keeper_event_queue.Task_cancelled _ -> ())
+       | Keeper_event_queue.Task_cancelled _
+       | Keeper_event_queue.Keeper_message _ -> ())
     stimuli
 ;;
 

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -67,7 +67,7 @@ let pending_board_event_of_stimulus ~meta_after_triage stim =
   | Keeper_event_queue.Goal_reconciliation_ready _
   | Keeper_event_queue.Completion_authority_rejected _
   | Keeper_event_queue.Task_cancelled _
-  | Keeper_event_queue.Keeper_message _ ->
+  | Keeper_event_queue.Workspace_message _ ->
     Keeper_world_observation.pending_board_event_of_stimulus
       ~meta:meta_after_triage
       stim
@@ -224,8 +224,8 @@ let event_queue_trigger_of_stimulus (stim : Keeper_event_queue.stimulus) =
   (* Dedicated turn_reason: the transcript scan reports the same message as
      [Mention_pending] only while the row is still ahead of the ack watermark.
      The queue entry is the durable delivery, so the turn names it as such. *)
-  | Keeper_event_queue.Keeper_message _ ->
-    Some Keeper_world_observation.Keeper_message_stimulus
+  | Keeper_event_queue.Workspace_message _ ->
+    Some Keeper_world_observation.Workspace_message_stimulus
 ;;
 
 let consume_single_heartbeat_stimulus
@@ -353,15 +353,15 @@ let consume_single_heartbeat_stimulus
         (Keeper_event_queue.hitl_resolution_decision_to_string r.decision)
         meta_after_triage.name;
       Stimulus_consumed []
-    | Keeper_event_queue.Keeper_message message ->
+    | Keeper_event_queue.Workspace_message message ->
       (* The transcript row committed at the delivery boundary carries the
          content and the message lane reads it, so there is no observation to
          fabricate here — injecting one would put the same message in front of
          the keeper twice. *)
       Log.Keeper.info
         "turn entry: keeper message delivered request_id=%s from=%s (keeper=%s)"
-        message.kmsg_request_id
-        message.kmsg_from
+        message.wmsg_request_id
+        message.wmsg_from
         meta_after_triage.name;
       Stimulus_consumed []
   in
@@ -402,7 +402,7 @@ let stimulus_ready_for_intake ~base_path (stimulus : Keeper_event_queue.stimulus
   | Keeper_event_queue.Goal_reconciliation_ready _
   | Keeper_event_queue.Completion_authority_rejected _
   | Keeper_event_queue.Task_cancelled _
-  | Keeper_event_queue.Keeper_message _ ->
+  | Keeper_event_queue.Workspace_message _ ->
     true
 ;;
 
@@ -482,7 +482,7 @@ let reconcile_spent_selection
   | Task_cancelled _
   (* A committed workspace message cannot be withdrawn, so the selection stays
      worth a turn. *)
-  | Keeper_message _ ->
+  | Workspace_message _ ->
     Ok Selection_actionable
 ;;
 
@@ -537,7 +537,7 @@ let heartbeat_event_intake
       | Keeper_event_queue.Goal_reconciliation_ready _
       | Keeper_event_queue.Completion_authority_rejected _
       | Keeper_event_queue.Task_cancelled _
-      | Keeper_event_queue.Keeper_message _ ->
+      | Keeper_event_queue.Workspace_message _ ->
         false
     in
     match select_pending_matching manual_compaction_ready with
@@ -608,7 +608,7 @@ let heartbeat_event_intake
     | Keeper_event_queue.Goal_reconciliation_ready _
     | Keeper_event_queue.Completion_authority_rejected _
     | Keeper_event_queue.Task_cancelled _
-    | Keeper_event_queue.Keeper_message _ ->
+    | Keeper_event_queue.Workspace_message _ ->
       None
   in
   (* RFC-0377 P1-1: preload every batch member's recorded attention item in

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -66,7 +66,8 @@ let pending_board_event_of_stimulus ~meta_after_triage stim =
   | Keeper_event_queue.Goal_assigned _
   | Keeper_event_queue.Goal_reconciliation_ready _
   | Keeper_event_queue.Completion_authority_rejected _
-  | Keeper_event_queue.Task_cancelled _ ->
+  | Keeper_event_queue.Task_cancelled _
+  | Keeper_event_queue.Keeper_message _ ->
     Keeper_world_observation.pending_board_event_of_stimulus
       ~meta:meta_after_triage
       stim
@@ -220,6 +221,11 @@ let event_queue_trigger_of_stimulus (stim : Keeper_event_queue.stimulus) =
      the 96%-of-turns scheduled channel and the cancellation reads as noise. *)
   | Keeper_event_queue.Task_cancelled _ ->
     Some Keeper_world_observation.Task_cancellation_stimulus
+  (* Dedicated turn_reason: the transcript scan reports the same message as
+     [Mention_pending] only while the row is still ahead of the ack watermark.
+     The queue entry is the durable delivery, so the turn names it as such. *)
+  | Keeper_event_queue.Keeper_message _ ->
+    Some Keeper_world_observation.Keeper_message_stimulus
 ;;
 
 let consume_single_heartbeat_stimulus
@@ -347,6 +353,17 @@ let consume_single_heartbeat_stimulus
         (Keeper_event_queue.hitl_resolution_decision_to_string r.decision)
         meta_after_triage.name;
       Stimulus_consumed []
+    | Keeper_event_queue.Keeper_message message ->
+      (* The transcript row committed at the delivery boundary carries the
+         content and the message lane reads it, so there is no observation to
+         fabricate here — injecting one would put the same message in front of
+         the keeper twice. *)
+      Log.Keeper.info
+        "turn entry: keeper message delivered request_id=%s from=%s (keeper=%s)"
+        message.kmsg_request_id
+        message.kmsg_from
+        meta_after_triage.name;
+      Stimulus_consumed []
   in
   match intake_result with
   | Stimulus_retry_later _ -> intake_result
@@ -384,7 +401,8 @@ let stimulus_ready_for_intake ~base_path (stimulus : Keeper_event_queue.stimulus
   | Keeper_event_queue.Goal_assigned _
   | Keeper_event_queue.Goal_reconciliation_ready _
   | Keeper_event_queue.Completion_authority_rejected _
-  | Keeper_event_queue.Task_cancelled _ ->
+  | Keeper_event_queue.Task_cancelled _
+  | Keeper_event_queue.Keeper_message _ ->
     true
 ;;
 
@@ -461,7 +479,10 @@ let reconcile_spent_selection
   | Completion_authority_rejected _
   (* A committed cancellation cannot be undone or settled elsewhere, so the
      selection is always still worth a turn. *)
-  | Task_cancelled _ ->
+  | Task_cancelled _
+  (* A committed workspace message cannot be withdrawn, so the selection stays
+     worth a turn. *)
+  | Keeper_message _ ->
     Ok Selection_actionable
 ;;
 
@@ -515,7 +536,8 @@ let heartbeat_event_intake
       | Keeper_event_queue.Goal_assigned _
       | Keeper_event_queue.Goal_reconciliation_ready _
       | Keeper_event_queue.Completion_authority_rejected _
-      | Keeper_event_queue.Task_cancelled _ ->
+      | Keeper_event_queue.Task_cancelled _
+      | Keeper_event_queue.Keeper_message _ ->
         false
     in
     match select_pending_matching manual_compaction_ready with
@@ -585,7 +607,8 @@ let heartbeat_event_intake
     | Keeper_event_queue.Goal_assigned _
     | Keeper_event_queue.Goal_reconciliation_ready _
     | Keeper_event_queue.Completion_authority_rejected _
-    | Keeper_event_queue.Task_cancelled _ ->
+    | Keeper_event_queue.Task_cancelled _
+    | Keeper_event_queue.Keeper_message _ ->
       None
   in
   (* RFC-0377 P1-1: preload every batch member's recorded attention item in

--- a/lib/keeper/keeper_paused_work_disposition_receipt.ml
+++ b/lib/keeper/keeper_paused_work_disposition_receipt.ml
@@ -64,7 +64,7 @@ let continuation_binding_of_source source =
   | Keeper_event_queue.Goal_reconciliation_ready _
   | Keeper_event_queue.Completion_authority_rejected _
   | Keeper_event_queue.Task_cancelled _
-  | Keeper_event_queue.Keeper_message _ ->
+  | Keeper_event_queue.Workspace_message _ ->
     No_channel
 ;;
 

--- a/lib/keeper/keeper_paused_work_disposition_receipt.ml
+++ b/lib/keeper/keeper_paused_work_disposition_receipt.ml
@@ -63,7 +63,8 @@ let continuation_binding_of_source source =
   | Keeper_event_queue.Goal_assigned _
   | Keeper_event_queue.Goal_reconciliation_ready _
   | Keeper_event_queue.Completion_authority_rejected _
-  | Keeper_event_queue.Task_cancelled _ ->
+  | Keeper_event_queue.Task_cancelled _
+  | Keeper_event_queue.Keeper_message _ ->
     No_channel
 ;;
 

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -12,6 +12,7 @@ type stimulus_kind =
   | Goal_reconciliation_ready
   | Completion_authority_rejected
   | Task_cancelled
+  | Keeper_message
 
 type reaction_kind =
   | Turn_started
@@ -39,6 +40,7 @@ let stimulus_kind_to_string = function
   | Goal_reconciliation_ready -> "goal_reconciliation_ready"
   | Completion_authority_rejected -> "completion_authority_rejected"
   | Task_cancelled -> "task_cancelled"
+  | Keeper_message -> "keeper_message"
 ;;
 
 (* stimulus_kind_to_string의 역. 닫힌 합에 없는 문자열(스키마 드리프트/손상 row)은
@@ -57,6 +59,7 @@ let stimulus_kind_of_string = function
   | "goal_reconciliation_ready" -> Some Goal_reconciliation_ready
   | "completion_authority_rejected" -> Some Completion_authority_rejected
   | "task_cancelled" -> Some Task_cancelled
+  | "keeper_message" -> Some Keeper_message
   | _ -> None
 ;;
 
@@ -94,6 +97,7 @@ let stimulus_kind_of_event_queue (stimulus : Keeper_event_queue.stimulus) =
   | Keeper_event_queue.Completion_authority_rejected _ ->
     Completion_authority_rejected
   | Keeper_event_queue.Task_cancelled _ -> Task_cancelled
+  | Keeper_event_queue.Keeper_message _ -> Keeper_message
 ;;
 
 let stimulus_id_of_event_queue (stimulus : Keeper_event_queue.stimulus) =
@@ -205,6 +209,11 @@ let stimulus_payload_preview (payload : Keeper_event_queue.stimulus_payload) =
       "task_cancelled task_id=%s cancelled_by=%s"
       cancellation.tc_task_id
       cancellation.tc_cancelled_by
+  | Keeper_event_queue.Keeper_message message ->
+    Printf.sprintf
+      "keeper_message request_id=%s from=%s"
+      message.kmsg_request_id
+      message.kmsg_from
 ;;
 
 let stimulus_json ~keeper_name (stimulus : Keeper_event_queue.stimulus) =
@@ -225,6 +234,7 @@ let stimulus_json ~keeper_name (stimulus : Keeper_event_queue.stimulus) =
     | Keeper_event_queue.Goal_reconciliation_ready _ -> None
     | Keeper_event_queue.Completion_authority_rejected _ -> None
     | Keeper_event_queue.Task_cancelled _ -> None
+    | Keeper_event_queue.Keeper_message _ -> None
   in
   `Assoc
     (base_fields
@@ -837,7 +847,8 @@ let decode_current_row ~keeper_name row =
         | Goal_assigned
         | Goal_reconciliation_ready
         | Completion_authority_rejected
-        | Task_cancelled ),
+        | Task_cancelled
+        | Keeper_message ),
         _ -> Ok ()
     in
     let expected_event_id = digest_id "krl" (stimulus_id ^ "|stimulus") in
@@ -1307,7 +1318,8 @@ let board_stimulus_token metadata stimulus_kind =
   | Goal_assigned
   | Goal_reconciliation_ready
   | Completion_authority_rejected
-  | Task_cancelled -> None
+  | Task_cancelled
+  | Keeper_message -> None
 ;;
 
 let summarize_rows ~keeper_name ~limit rows =

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -12,7 +12,7 @@ type stimulus_kind =
   | Goal_reconciliation_ready
   | Completion_authority_rejected
   | Task_cancelled
-  | Keeper_message
+  | Workspace_message
 
 type reaction_kind =
   | Turn_started
@@ -40,7 +40,7 @@ let stimulus_kind_to_string = function
   | Goal_reconciliation_ready -> "goal_reconciliation_ready"
   | Completion_authority_rejected -> "completion_authority_rejected"
   | Task_cancelled -> "task_cancelled"
-  | Keeper_message -> "keeper_message"
+  | Workspace_message -> "workspace_message"
 ;;
 
 (* stimulus_kind_to_string의 역. 닫힌 합에 없는 문자열(스키마 드리프트/손상 row)은
@@ -59,7 +59,7 @@ let stimulus_kind_of_string = function
   | "goal_reconciliation_ready" -> Some Goal_reconciliation_ready
   | "completion_authority_rejected" -> Some Completion_authority_rejected
   | "task_cancelled" -> Some Task_cancelled
-  | "keeper_message" -> Some Keeper_message
+  | "workspace_message" -> Some Workspace_message
   | _ -> None
 ;;
 
@@ -97,7 +97,7 @@ let stimulus_kind_of_event_queue (stimulus : Keeper_event_queue.stimulus) =
   | Keeper_event_queue.Completion_authority_rejected _ ->
     Completion_authority_rejected
   | Keeper_event_queue.Task_cancelled _ -> Task_cancelled
-  | Keeper_event_queue.Keeper_message _ -> Keeper_message
+  | Keeper_event_queue.Workspace_message _ -> Workspace_message
 ;;
 
 let stimulus_id_of_event_queue (stimulus : Keeper_event_queue.stimulus) =
@@ -209,11 +209,11 @@ let stimulus_payload_preview (payload : Keeper_event_queue.stimulus_payload) =
       "task_cancelled task_id=%s cancelled_by=%s"
       cancellation.tc_task_id
       cancellation.tc_cancelled_by
-  | Keeper_event_queue.Keeper_message message ->
+  | Keeper_event_queue.Workspace_message message ->
     Printf.sprintf
-      "keeper_message request_id=%s from=%s"
-      message.kmsg_request_id
-      message.kmsg_from
+      "workspace_message request_id=%s from=%s"
+      message.wmsg_request_id
+      message.wmsg_from
 ;;
 
 let stimulus_json ~keeper_name (stimulus : Keeper_event_queue.stimulus) =
@@ -234,7 +234,7 @@ let stimulus_json ~keeper_name (stimulus : Keeper_event_queue.stimulus) =
     | Keeper_event_queue.Goal_reconciliation_ready _ -> None
     | Keeper_event_queue.Completion_authority_rejected _ -> None
     | Keeper_event_queue.Task_cancelled _ -> None
-    | Keeper_event_queue.Keeper_message _ -> None
+    | Keeper_event_queue.Workspace_message _ -> None
   in
   `Assoc
     (base_fields
@@ -848,7 +848,7 @@ let decode_current_row ~keeper_name row =
         | Goal_reconciliation_ready
         | Completion_authority_rejected
         | Task_cancelled
-        | Keeper_message ),
+        | Workspace_message ),
         _ -> Ok ()
     in
     let expected_event_id = digest_id "krl" (stimulus_id ^ "|stimulus") in
@@ -1319,7 +1319,7 @@ let board_stimulus_token metadata stimulus_kind =
   | Goal_reconciliation_ready
   | Completion_authority_rejected
   | Task_cancelled
-  | Keeper_message -> None
+  | Workspace_message -> None
 ;;
 
 let summarize_rows ~keeper_name ~limit rows =

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -23,6 +23,8 @@ type stimulus_kind =
       (** System completion authority rejected Keeper evidence. *)
   | Task_cancelled
       (** Another Keeper cancelled a Task this Keeper authored. *)
+  | Keeper_message
+      (** A committed workspace message named this Keeper. *)
 
 type reaction_kind =
   | Turn_started

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -23,7 +23,7 @@ type stimulus_kind =
       (** System completion authority rejected Keeper evidence. *)
   | Task_cancelled
       (** Another Keeper cancelled a Task this Keeper authored. *)
-  | Keeper_message
+  | Workspace_message
       (** A committed workspace message named this Keeper. *)
 
 type reaction_kind =

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -359,7 +359,7 @@ let board_attention_event_id (stimulus : Keeper_event_queue.stimulus) =
   | Keeper_event_queue.Goal_reconciliation_ready _
   | Keeper_event_queue.Completion_authority_rejected _
   | Keeper_event_queue.Task_cancelled _
-  | Keeper_event_queue.Keeper_message _ ->
+  | Keeper_event_queue.Workspace_message _ ->
     None
 ;;
 

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -358,7 +358,8 @@ let board_attention_event_id (stimulus : Keeper_event_queue.stimulus) =
   | Keeper_event_queue.Goal_assigned _
   | Keeper_event_queue.Goal_reconciliation_ready _
   | Keeper_event_queue.Completion_authority_rejected _
-  | Keeper_event_queue.Task_cancelled _ ->
+  | Keeper_event_queue.Task_cancelled _
+  | Keeper_event_queue.Keeper_message _ ->
     None
 ;;
 

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -195,7 +195,7 @@ let is_manual_compaction_payload = function
   | Keeper_event_queue.Goal_reconciliation_ready _
   | Keeper_event_queue.Completion_authority_rejected _
   | Keeper_event_queue.Task_cancelled _
-  | Keeper_event_queue.Keeper_message _ ->
+  | Keeper_event_queue.Workspace_message _ ->
     false
 ;;
 

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -194,7 +194,8 @@ let is_manual_compaction_payload = function
   | Keeper_event_queue.Goal_assigned _
   | Keeper_event_queue.Goal_reconciliation_ready _
   | Keeper_event_queue.Completion_authority_rejected _
-  | Keeper_event_queue.Task_cancelled _ ->
+  | Keeper_event_queue.Task_cancelled _
+  | Keeper_event_queue.Keeper_message _ ->
     false
 ;;
 

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -167,7 +167,7 @@ type event_queue_trigger =
   | Completion_authority_rejection_stimulus
   | Task_cancellation_stimulus
   | Manual_compaction_stimulus
-  | Keeper_message_stimulus
+  | Workspace_message_stimulus
 
 type turn_reason = Keeper_world_observation_turn_types.turn_reason =
   | Mention_pending
@@ -179,7 +179,7 @@ type turn_reason = Keeper_world_observation_turn_types.turn_reason =
   | Completion_authority_rejection_pending
   | Task_cancellation_pending
   | Manual_compaction_pending
-  | Keeper_message_pending
+  | Workspace_message_pending
   | Scheduled_autonomous_turn
   | Scheduled_automation_due
   | Task_backlog of
@@ -815,11 +815,11 @@ let pending_board_event_of_stimulus
   | Keeper_event_queue.Connector_attention _
   | Keeper_event_queue.Hitl_resolved _
   | Keeper_event_queue.Manual_compaction_requested
-  | Keeper_event_queue.Keeper_message _ ->
+  | Keeper_event_queue.Workspace_message _ ->
     (* RFC-connector-ambient-attention-wake P1: not a board event. The wake
        fires via the trigger itself; [Hitl_resolved] carries no observation to
        inject — the keeper resumes on its own state once the approval is gone
-       from the queue. [Keeper_message] carries a pointer to a transcript row
+       from the queue. [Workspace_message] carries a pointer to a transcript row
        the message lane already reads, so injecting a board event here would
        show the operator the same message twice. *)
     Ok None
@@ -1356,7 +1356,7 @@ let keeper_cycle_decision
                  | Hitl_resolved_pending
                  | Task_cancellation_pending
                  | Manual_compaction_pending
-                 | Keeper_message_pending
+                 | Workspace_message_pending
                  | Scheduled_autonomous_turn
                  | Scheduled_automation_due
                  | Task_backlog _

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -167,6 +167,7 @@ type event_queue_trigger =
   | Completion_authority_rejection_stimulus
   | Task_cancellation_stimulus
   | Manual_compaction_stimulus
+  | Keeper_message_stimulus
 
 type turn_reason = Keeper_world_observation_turn_types.turn_reason =
   | Mention_pending
@@ -178,6 +179,7 @@ type turn_reason = Keeper_world_observation_turn_types.turn_reason =
   | Completion_authority_rejection_pending
   | Task_cancellation_pending
   | Manual_compaction_pending
+  | Keeper_message_pending
   | Scheduled_autonomous_turn
   | Scheduled_automation_due
   | Task_backlog of
@@ -812,11 +814,14 @@ let pending_board_event_of_stimulus
   | Keeper_event_queue.Bootstrap
   | Keeper_event_queue.Connector_attention _
   | Keeper_event_queue.Hitl_resolved _
-  | Keeper_event_queue.Manual_compaction_requested ->
+  | Keeper_event_queue.Manual_compaction_requested
+  | Keeper_event_queue.Keeper_message _ ->
     (* RFC-connector-ambient-attention-wake P1: not a board event. The wake
        fires via the trigger itself; [Hitl_resolved] carries no observation to
        inject — the keeper resumes on its own state once the approval is gone
-       from the queue. *)
+       from the queue. [Keeper_message] carries a pointer to a transcript row
+       the message lane already reads, so injecting a board event here would
+       show the operator the same message twice. *)
     Ok None
 ;;
 
@@ -1351,6 +1356,7 @@ let keeper_cycle_decision
                  | Hitl_resolved_pending
                  | Task_cancellation_pending
                  | Manual_compaction_pending
+                 | Keeper_message_pending
                  | Scheduled_autonomous_turn
                  | Scheduled_automation_due
                  | Task_backlog _

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -200,7 +200,7 @@ type event_queue_trigger =
   | Completion_authority_rejection_stimulus
   | Task_cancellation_stimulus
   | Manual_compaction_stimulus
-  | Keeper_message_stimulus
+  | Workspace_message_stimulus
 
 (** Typed reason for running a keeper cycle. Each variant corresponds to
     exactly one code path in {!keeper_cycle_decision}. *)
@@ -214,7 +214,7 @@ type turn_reason =
   | Completion_authority_rejection_pending
   | Task_cancellation_pending
   | Manual_compaction_pending
-  | Keeper_message_pending
+  | Workspace_message_pending
   | Scheduled_autonomous_turn
   | Scheduled_automation_due
   | Task_backlog of { unclaimed : int; failed : int }

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -200,6 +200,7 @@ type event_queue_trigger =
   | Completion_authority_rejection_stimulus
   | Task_cancellation_stimulus
   | Manual_compaction_stimulus
+  | Keeper_message_stimulus
 
 (** Typed reason for running a keeper cycle. Each variant corresponds to
     exactly one code path in {!keeper_cycle_decision}. *)
@@ -213,6 +214,7 @@ type turn_reason =
   | Completion_authority_rejection_pending
   | Task_cancellation_pending
   | Manual_compaction_pending
+  | Keeper_message_pending
   | Scheduled_autonomous_turn
   | Scheduled_automation_due
   | Task_backlog of { unclaimed : int; failed : int }

--- a/lib/keeper_contract/keeper_world_observation_turn_types.ml
+++ b/lib/keeper_contract/keeper_world_observation_turn_types.ml
@@ -49,6 +49,12 @@ type event_queue_trigger =
           reactive input: it is not Board activity (no post exists), not
           scheduled work, and not a completion-authority decision. *)
   | Manual_compaction_stimulus
+  | Keeper_message_stimulus
+      (** A committed workspace message named this Keeper and was delivered as
+          a durable queue entry. The transcript scan reports the same message
+          as [Mention_pending] when it can still see it; the queue entry is
+          what survives a restart, an ack watermark past the row, and a busy
+          cycle, so the drain reports it in its own right. *)
 
 type turn_reason =
   | Mention_pending
@@ -60,6 +66,7 @@ type turn_reason =
   | Completion_authority_rejection_pending
   | Task_cancellation_pending
   | Manual_compaction_pending
+  | Keeper_message_pending
   | Scheduled_autonomous_turn
   | Scheduled_automation_due
   | Task_backlog of
@@ -91,6 +98,7 @@ let turn_reason_to_string = function
     "completion_authority_rejection_pending"
   | Task_cancellation_pending -> "task_cancellation_pending"
   | Manual_compaction_pending -> "manual_compaction_pending"
+  | Keeper_message_pending -> "keeper_message_pending"
   | Scheduled_autonomous_turn -> "scheduled_autonomous_turn"
   | Scheduled_automation_due -> "scheduled_automation_due"
   | Task_backlog _ -> "task_backlog"
@@ -106,6 +114,7 @@ let turn_reason_of_event_queue_trigger = function
     Completion_authority_rejection_pending
   | Task_cancellation_stimulus -> Task_cancellation_pending
   | Manual_compaction_stimulus -> Manual_compaction_pending
+  | Keeper_message_stimulus -> Keeper_message_pending
 ;;
 
 let skip_reason_to_string = function

--- a/lib/keeper_contract/keeper_world_observation_turn_types.ml
+++ b/lib/keeper_contract/keeper_world_observation_turn_types.ml
@@ -49,7 +49,7 @@ type event_queue_trigger =
           reactive input: it is not Board activity (no post exists), not
           scheduled work, and not a completion-authority decision. *)
   | Manual_compaction_stimulus
-  | Keeper_message_stimulus
+  | Workspace_message_stimulus
       (** A committed workspace message named this Keeper and was delivered as
           a durable queue entry. The transcript scan reports the same message
           as [Mention_pending] when it can still see it; the queue entry is
@@ -66,7 +66,7 @@ type turn_reason =
   | Completion_authority_rejection_pending
   | Task_cancellation_pending
   | Manual_compaction_pending
-  | Keeper_message_pending
+  | Workspace_message_pending
   | Scheduled_autonomous_turn
   | Scheduled_automation_due
   | Task_backlog of
@@ -98,7 +98,7 @@ let turn_reason_to_string = function
     "completion_authority_rejection_pending"
   | Task_cancellation_pending -> "task_cancellation_pending"
   | Manual_compaction_pending -> "manual_compaction_pending"
-  | Keeper_message_pending -> "keeper_message_pending"
+  | Workspace_message_pending -> "workspace_message_pending"
   | Scheduled_autonomous_turn -> "scheduled_autonomous_turn"
   | Scheduled_automation_due -> "scheduled_automation_due"
   | Task_backlog _ -> "task_backlog"
@@ -114,7 +114,7 @@ let turn_reason_of_event_queue_trigger = function
     Completion_authority_rejection_pending
   | Task_cancellation_stimulus -> Task_cancellation_pending
   | Manual_compaction_stimulus -> Manual_compaction_pending
-  | Keeper_message_stimulus -> Keeper_message_pending
+  | Workspace_message_stimulus -> Workspace_message_pending
 ;;
 
 let skip_reason_to_string = function

--- a/lib/keeper_contract/keeper_world_observation_turn_types.mli
+++ b/lib/keeper_contract/keeper_world_observation_turn_types.mli
@@ -24,7 +24,7 @@ type event_queue_trigger =
           reactive input: it is not Board activity (no post exists), not
           scheduled work, and not a completion-authority decision. *)
   | Manual_compaction_stimulus
-  | Keeper_message_stimulus
+  | Workspace_message_stimulus
       (** A committed workspace message named this Keeper and was delivered as
           a durable queue entry, so the drain reports it in its own right. *)
 
@@ -38,7 +38,7 @@ type turn_reason =
   | Completion_authority_rejection_pending
   | Task_cancellation_pending
   | Manual_compaction_pending
-  | Keeper_message_pending
+  | Workspace_message_pending
   | Scheduled_autonomous_turn
   | Scheduled_automation_due
   | Task_backlog of

--- a/lib/keeper_contract/keeper_world_observation_turn_types.mli
+++ b/lib/keeper_contract/keeper_world_observation_turn_types.mli
@@ -24,6 +24,9 @@ type event_queue_trigger =
           reactive input: it is not Board activity (no post exists), not
           scheduled work, and not a completion-authority decision. *)
   | Manual_compaction_stimulus
+  | Keeper_message_stimulus
+      (** A committed workspace message named this Keeper and was delivered as
+          a durable queue entry, so the drain reports it in its own right. *)
 
 type turn_reason =
   | Mention_pending
@@ -35,6 +38,7 @@ type turn_reason =
   | Completion_authority_rejection_pending
   | Task_cancellation_pending
   | Manual_compaction_pending
+  | Keeper_message_pending
   | Scheduled_autonomous_turn
   | Scheduled_automation_due
   | Task_backlog of

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -77,6 +77,11 @@ type stimulus_payload =
      Goal_reconciliation_ready targets the Goal owner — a Task with no Goal
      link reaches no one. This carries the cancellation to the Task's author. *)
   | Task_cancelled of task_cancellation
+  (* A committed workspace message named this Keeper. The transcript row is the
+     content SSOT; this payload carries the workspace request identity so the
+     message is an entry in the linear drain rather than only a row a scan may
+     or may not reach. *)
+  | Keeper_message of keeper_message
 
 and board_attention = {
   candidate_id : string;
@@ -165,6 +170,14 @@ and task_cancellation = {
   tc_reason : string option;
 }
 
+and keeper_message = {
+  kmsg_request_id : string;
+  kmsg_from : string;
+}
+
+let keeper_message_post_id (message : keeper_message) =
+  "workspace-message:" ^ message.kmsg_request_id
+
 let fusion_completion_post_id (fc : fusion_completion) = "fusion-run:" ^ fc.run_id
 
 let hitl_resolution_post_id (r : hitl_resolution) = "hitl-approval:" ^ r.approval_id
@@ -233,7 +246,7 @@ let identity_payload = function
   | ( Board_signal _ | Board_attention _ | Bootstrap | Fusion_completed _
     | Schedule_due _ | Connector_attention _ | Hitl_resolved _
     | Manual_compaction_requested | Goal_reconciliation_ready _
-    | Completion_authority_rejected _
+    | Completion_authority_rejected _ | Keeper_message _
     ) as payload ->
     payload
 
@@ -352,6 +365,7 @@ let payload_kind_label = function
   | Goal_reconciliation_ready _ -> "goal_reconciliation_ready"
   | Completion_authority_rejected _ -> "completion_authority_rejected"
   | Task_cancelled _ -> "task_cancelled"
+  | Keeper_message _ -> "keeper_message"
 
 let is_board_signal = function
   | Board_signal _ | Board_attention _ -> true
@@ -359,7 +373,7 @@ let is_board_signal = function
   | Schedule_due _ | Connector_attention _ | Hitl_resolved _
   | Manual_compaction_requested | Goal_assigned _
   | Goal_reconciliation_ready _ | Completion_authority_rejected _
-  | Task_cancelled _ ->
+  | Task_cancelled _ | Keeper_message _ ->
     false
 
 (* RFC-0377: the batch-intake predicate needs the routed channel without
@@ -371,7 +385,7 @@ let connector_attention_channel = function
   | Board_signal _ | Board_attention _ | Bootstrap | Fusion_completed _
   | Schedule_due _ | Hitl_resolved _ | Manual_compaction_requested
   | Goal_assigned _ | Goal_reconciliation_ready _
-  | Completion_authority_rejected _ | Task_cancelled _ ->
+  | Completion_authority_rejected _ | Task_cancelled _ | Keeper_message _ ->
     None
 
 let drain_board_all (queue : t) : stimulus list * t =
@@ -606,6 +620,12 @@ let payload_to_yojson = function
         , match cancellation.tc_reason with
           | None -> `Null
           | Some reason -> `String reason )
+      ]
+  | Keeper_message message ->
+    `Assoc
+      [ "kind", `String "keeper_message"
+      ; "request_id", `String message.kmsg_request_id
+      ; "from", `String message.kmsg_from
       ]
 
 let continuation_channel_field fields =
@@ -882,6 +902,13 @@ let payload_of_yojson json =
     Ok
       (Task_cancelled
          { tc_task_id = task_id; tc_cancelled_by = cancelled_by; tc_reason = reason })
+  | "keeper_message" ->
+    let* () =
+      exact_fields ~context ~expected:[ "kind"; "request_id"; "from" ] fields
+    in
+    let* request_id = string_field ~context "request_id" fields in
+    let* from = string_field ~context "from" fields in
+    Ok (Keeper_message { kmsg_request_id = request_id; kmsg_from = from })
   | value -> Error (Printf.sprintf "unknown stimulus payload kind: %s" value)
 
 let stimulus_to_yojson (stimulus : stimulus) =
@@ -952,5 +979,6 @@ let continuation_channel_of_payload = function
   | Goal_assigned _
   | Goal_reconciliation_ready _
   | Completion_authority_rejected _
-  | Task_cancelled _ -> None
+  | Task_cancelled _
+  | Keeper_message _ -> None
 ;;

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -81,7 +81,7 @@ type stimulus_payload =
      content SSOT; this payload carries the workspace request identity so the
      message is an entry in the linear drain rather than only a row a scan may
      or may not reach. *)
-  | Keeper_message of keeper_message
+  | Workspace_message of workspace_message
 
 and board_attention = {
   candidate_id : string;
@@ -170,13 +170,13 @@ and task_cancellation = {
   tc_reason : string option;
 }
 
-and keeper_message = {
-  kmsg_request_id : string;
-  kmsg_from : string;
+and workspace_message = {
+  wmsg_request_id : string;
+  wmsg_from : string;
 }
 
-let keeper_message_post_id (message : keeper_message) =
-  "workspace-message:" ^ message.kmsg_request_id
+let workspace_message_post_id (message : workspace_message) =
+  "workspace-message:" ^ message.wmsg_request_id
 
 let fusion_completion_post_id (fc : fusion_completion) = "fusion-run:" ^ fc.run_id
 
@@ -246,7 +246,7 @@ let identity_payload = function
   | ( Board_signal _ | Board_attention _ | Bootstrap | Fusion_completed _
     | Schedule_due _ | Connector_attention _ | Hitl_resolved _
     | Manual_compaction_requested | Goal_reconciliation_ready _
-    | Completion_authority_rejected _ | Keeper_message _
+    | Completion_authority_rejected _ | Workspace_message _
     ) as payload ->
     payload
 
@@ -365,7 +365,7 @@ let payload_kind_label = function
   | Goal_reconciliation_ready _ -> "goal_reconciliation_ready"
   | Completion_authority_rejected _ -> "completion_authority_rejected"
   | Task_cancelled _ -> "task_cancelled"
-  | Keeper_message _ -> "keeper_message"
+  | Workspace_message _ -> "workspace_message"
 
 let is_board_signal = function
   | Board_signal _ | Board_attention _ -> true
@@ -373,7 +373,7 @@ let is_board_signal = function
   | Schedule_due _ | Connector_attention _ | Hitl_resolved _
   | Manual_compaction_requested | Goal_assigned _
   | Goal_reconciliation_ready _ | Completion_authority_rejected _
-  | Task_cancelled _ | Keeper_message _ ->
+  | Task_cancelled _ | Workspace_message _ ->
     false
 
 (* RFC-0377: the batch-intake predicate needs the routed channel without
@@ -385,7 +385,7 @@ let connector_attention_channel = function
   | Board_signal _ | Board_attention _ | Bootstrap | Fusion_completed _
   | Schedule_due _ | Hitl_resolved _ | Manual_compaction_requested
   | Goal_assigned _ | Goal_reconciliation_ready _
-  | Completion_authority_rejected _ | Task_cancelled _ | Keeper_message _ ->
+  | Completion_authority_rejected _ | Task_cancelled _ | Workspace_message _ ->
     None
 
 let drain_board_all (queue : t) : stimulus list * t =
@@ -621,11 +621,11 @@ let payload_to_yojson = function
           | None -> `Null
           | Some reason -> `String reason )
       ]
-  | Keeper_message message ->
+  | Workspace_message message ->
     `Assoc
-      [ "kind", `String "keeper_message"
-      ; "request_id", `String message.kmsg_request_id
-      ; "from", `String message.kmsg_from
+      [ "kind", `String "workspace_message"
+      ; "request_id", `String message.wmsg_request_id
+      ; "from", `String message.wmsg_from
       ]
 
 let continuation_channel_field fields =
@@ -902,13 +902,13 @@ let payload_of_yojson json =
     Ok
       (Task_cancelled
          { tc_task_id = task_id; tc_cancelled_by = cancelled_by; tc_reason = reason })
-  | "keeper_message" ->
+  | "workspace_message" ->
     let* () =
       exact_fields ~context ~expected:[ "kind"; "request_id"; "from" ] fields
     in
     let* request_id = string_field ~context "request_id" fields in
     let* from = string_field ~context "from" fields in
-    Ok (Keeper_message { kmsg_request_id = request_id; kmsg_from = from })
+    Ok (Workspace_message { wmsg_request_id = request_id; wmsg_from = from })
   | value -> Error (Printf.sprintf "unknown stimulus payload kind: %s" value)
 
 let stimulus_to_yojson (stimulus : stimulus) =
@@ -980,5 +980,5 @@ let continuation_channel_of_payload = function
   | Goal_reconciliation_ready _
   | Completion_authority_rejected _
   | Task_cancelled _
-  | Keeper_message _ -> None
+  | Workspace_message _ -> None
 ;;

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -108,6 +108,13 @@ type stimulus_payload =
           with no Goal link reaches no one. The cancelling Keeper's reason is
           carried here because it is the author's only account of why the work
           it asked for stopped. *)
+  | Keeper_message of keeper_message
+      (** A committed workspace message named this Keeper. The transcript row
+          the delivery boundary appends is the content SSOT; this payload
+          carries the durable workspace request identity so the message is
+          also an entry in the linear per-Keeper drain — ordered against every
+          other stimulus, deduplicated by request identity, and durable across
+          a restart. *)
 (** Closed set of stimulus kinds. Replaces the prior [payload : string] +
     [classify] JSON-prefix round-trip: producers hold the typed value and
     consumers match it exhaustively, so an unrecognised stimulus is
@@ -211,6 +218,21 @@ and task_cancellation = {
 (** Payload for [Task_cancelled]. [tc_reason] is [None] when the canceller gave
     none; it is not defaulted to a placeholder, so the author can tell "no
     reason was given" from "the reason was empty text". *)
+
+and keeper_message = {
+  kmsg_request_id : string;
+  kmsg_from : string;
+}
+(** Payload for [Keeper_message]. [kmsg_request_id] is the workspace message's
+    durable request id, which is also the [external_message_id] of the chat
+    row the delivery boundary committed — one identity, two stores, so the
+    content is never duplicated here. [kmsg_from] is the authoring agent, kept
+    because a drained stimulus has to name its sender without a second read. *)
+
+val keeper_message_post_id : keeper_message -> post_id
+(** Dedup/correlation id for [Keeper_message]:
+    ["workspace-message:<request_id>"]. Redelivery of the same committed
+    workspace message collapses onto the entry already queued. *)
 
 val fusion_completion_post_id : fusion_completion -> post_id
 (** Canonical dedup/correlation id for [Fusion_completed], always

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -108,7 +108,7 @@ type stimulus_payload =
           with no Goal link reaches no one. The cancelling Keeper's reason is
           carried here because it is the author's only account of why the work
           it asked for stopped. *)
-  | Keeper_message of keeper_message
+  | Workspace_message of workspace_message
       (** A committed workspace message named this Keeper. The transcript row
           the delivery boundary appends is the content SSOT; this payload
           carries the durable workspace request identity so the message is
@@ -219,18 +219,18 @@ and task_cancellation = {
     none; it is not defaulted to a placeholder, so the author can tell "no
     reason was given" from "the reason was empty text". *)
 
-and keeper_message = {
-  kmsg_request_id : string;
-  kmsg_from : string;
+and workspace_message = {
+  wmsg_request_id : string;
+  wmsg_from : string;
 }
-(** Payload for [Keeper_message]. [kmsg_request_id] is the workspace message's
+(** Payload for [Workspace_message]. [wmsg_request_id] is the workspace message's
     durable request id, which is also the [external_message_id] of the chat
     row the delivery boundary committed — one identity, two stores, so the
-    content is never duplicated here. [kmsg_from] is the authoring agent, kept
+    content is never duplicated here. [wmsg_from] is the authoring agent, kept
     because a drained stimulus has to name its sender without a second read. *)
 
-val keeper_message_post_id : keeper_message -> post_id
-(** Dedup/correlation id for [Keeper_message]:
+val workspace_message_post_id : workspace_message -> post_id
+(** Dedup/correlation id for [Workspace_message]:
     ["workspace-message:<request_id>"]. Redelivery of the same committed
     workspace message collapses onto the entry already queued. *)
 

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -454,7 +454,7 @@ let source_terminal_receipt_of_stimulus source =
   | Keeper_event_queue.Goal_reconciliation_ready _
   | Keeper_event_queue.Completion_authority_rejected _
   | Keeper_event_queue.Task_cancelled _
-  | Keeper_event_queue.Keeper_message _ ->
+  | Keeper_event_queue.Workspace_message _ ->
     Error "source event does not carry a typed terminal receipt"
 ;;
 

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -453,7 +453,8 @@ let source_terminal_receipt_of_stimulus source =
   | Keeper_event_queue.Goal_assigned _
   | Keeper_event_queue.Goal_reconciliation_ready _
   | Keeper_event_queue.Completion_authority_rejected _
-  | Keeper_event_queue.Task_cancelled _ ->
+  | Keeper_event_queue.Task_cancelled _
+  | Keeper_event_queue.Keeper_message _ ->
     Error "source event does not carry a typed terminal receipt"
 ;;
 

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -153,11 +153,11 @@ let board_sse_event_params event =
       ]
 ;;
 
-(* Origin label carried on the [keeper_chat_appended] SSE event, alongside
-   "slack" / "discord" / "dashboard" / "fusion". A workspace message reaches
-   the transcript from the shared message bus, whether another Keeper's
-   [masc_broadcast] or the operator's dashboard broadcast wrote it. *)
-let workspace_message_chat_source = "workspace"
+(* Origin label carried on the [keeper_chat_appended] SSE event. Derived from
+   the surface the row is written with rather than spelled out here:
+   [Surface_ref.lane_label] is the single derivation site for these labels, so
+   a writer that invents its own string drifts from the row it announces. *)
+let workspace_message_chat_source = Surface_ref.lane_label Surface_ref.Agent
 
 let broadcast_mention_wakeup_action = function
   | Some target when String.trim target <> "" -> `Wake_keeper target

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -153,6 +153,12 @@ let board_sse_event_params event =
       ]
 ;;
 
+(* Origin label carried on the [keeper_chat_appended] SSE event, alongside
+   "slack" / "discord" / "dashboard" / "fusion". A workspace message reaches
+   the transcript from the shared message bus, whether another Keeper's
+   [masc_broadcast] or the operator's dashboard broadcast wrote it. *)
+let workspace_message_chat_source = "workspace"
+
 let broadcast_mention_wakeup_action = function
   | Some target when String.trim target <> "" -> `Wake_keeper target
   | Some _ | None -> `Suppress_no_target
@@ -230,7 +236,57 @@ let deliver_broadcast_mention
             |> List.filter_map Keeper_identity.Keeper_id.of_string
             |> List.sort_uniq Keeper_identity.Keeper_id.compare
           in
+          (* The transcript row is committed but the dashboard is not told, so
+             the conversation window shows the message only after a reload —
+             every other intake (Slack, Discord, fusion, dashboard) announces
+             its row. *)
+          let announce_chat_row () =
+            Keeper_chat_broadcast.chat_appended
+              ~keeper_name:target
+              ~source:workspace_message_chat_source
+              ~content:delivery.content
+              ()
+          in
+          (* The message becomes an entry in the target's linear drain, so it
+             is ordered against every other stimulus, deduplicated by the
+             workspace request identity, and readable in the operator queue
+             view. The durable commit precedes the wake hint, so a keeper woken
+             by the hint always finds the entry. *)
+          let commit_queue_entry () =
+            let message =
+              { Keeper_event_queue.kmsg_request_id = delivery.request_id
+              ; kmsg_from = delivery.from_agent
+              }
+            in
+            let stimulus =
+              { Keeper_event_queue.post_id =
+                  Keeper_event_queue.keeper_message_post_id message
+              ; urgency = Keeper_event_queue.Immediate
+              ; arrived_at = Unix.gettimeofday ()
+                (* NDT-OK: stimulus receipt time, used only for ordering/age *)
+              ; payload = Keeper_event_queue.Keeper_message message
+              }
+            in
+            match
+              Keeper_registry_event_queue.enqueue_stimulus_durable_result
+                ~base_path
+                target
+                stimulus
+            with
+            | Keeper_registry_event_queue.Stimulus_enqueued
+            | Keeper_registry_event_queue.Stimulus_already_present -> ()
+            | Keeper_registry_event_queue.Stimulus_storage_error detail ->
+              Otel_metric_store.inc_counter
+                Keeper_metrics.(to_string KeepaliveSignalFailures)
+                ~labels:
+                  [ "keeper", target; "phase", "keeper_message_delivery" ]
+                ();
+              Log.Keeper.error
+                "keeper message durable delivery failed keeper=%s request_id=%s: %s"
+                target delivery.request_id detail
+          in
           let request_wake () =
+            commit_queue_entry ();
             if is_running target
             then (
               wakeup target;
@@ -255,6 +311,7 @@ let deliver_broadcast_mention
                ()
            with
            | Ok (Keeper_chat_store.Appended _) ->
+             announce_chat_row ();
              request_wake ();
              Workspace_broadcast.Accepted
            | Ok (Keeper_chat_store.Already_present { row_id }) ->

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -254,17 +254,17 @@ let deliver_broadcast_mention
              by the hint always finds the entry. *)
           let commit_queue_entry () =
             let message =
-              { Keeper_event_queue.kmsg_request_id = delivery.request_id
-              ; kmsg_from = delivery.from_agent
+              { Keeper_event_queue.wmsg_request_id = delivery.request_id
+              ; wmsg_from = delivery.from_agent
               }
             in
             let stimulus =
               { Keeper_event_queue.post_id =
-                  Keeper_event_queue.keeper_message_post_id message
+                  Keeper_event_queue.workspace_message_post_id message
               ; urgency = Keeper_event_queue.Immediate
               ; arrived_at = Unix.gettimeofday ()
                 (* NDT-OK: stimulus receipt time, used only for ordering/age *)
-              ; payload = Keeper_event_queue.Keeper_message message
+              ; payload = Keeper_event_queue.Workspace_message message
               }
             in
             match
@@ -279,7 +279,7 @@ let deliver_broadcast_mention
               Otel_metric_store.inc_counter
                 Keeper_metrics.(to_string KeepaliveSignalFailures)
                 ~labels:
-                  [ "keeper", target; "phase", "keeper_message_delivery" ]
+                  [ "keeper", target; "phase", "workspace_message_delivery" ]
                 ();
               Log.Keeper.error
                 "keeper message durable delivery failed keeper=%s request_id=%s: %s"

--- a/lib/server/server_dashboard_http_keeper_event_queue_operator.ml
+++ b/lib/server/server_dashboard_http_keeper_event_queue_operator.ml
@@ -110,11 +110,11 @@ let pending_page ~after ~limit pending =
                @ (match cancellation.tc_reason with
                   | None -> []
                   | Some reason -> [ "cancelled_reason", `String reason ])
-             | Keeper_event_queue.Keeper_message message ->
+             | Keeper_event_queue.Workspace_message message ->
                (* Who queued the message and under which workspace request, so
                   an operator reading the queue can find the transcript row. *)
-               [ "message_request_id", `String message.kmsg_request_id
-               ; "message_from", `String message.kmsg_from
+               [ "message_request_id", `String message.wmsg_request_id
+               ; "message_from", `String message.wmsg_from
                ]
              | Keeper_event_queue.Board_signal _
              | Keeper_event_queue.Board_attention _

--- a/lib/server/server_dashboard_http_keeper_event_queue_operator.ml
+++ b/lib/server/server_dashboard_http_keeper_event_queue_operator.ml
@@ -110,6 +110,12 @@ let pending_page ~after ~limit pending =
                @ (match cancellation.tc_reason with
                   | None -> []
                   | Some reason -> [ "cancelled_reason", `String reason ])
+             | Keeper_event_queue.Keeper_message message ->
+               (* Who queued the message and under which workspace request, so
+                  an operator reading the queue can find the transcript row. *)
+               [ "message_request_id", `String message.kmsg_request_id
+               ; "message_from", `String message.kmsg_from
+               ]
              | Keeper_event_queue.Board_signal _
              | Keeper_event_queue.Board_attention _
              | Keeper_event_queue.Bootstrap

--- a/lib/server_keeper_waiting_inventory.ml
+++ b/lib/server_keeper_waiting_inventory.ml
@@ -120,7 +120,7 @@ let wake_producer_of_payload : Keeper_event_queue.stimulus_payload -> wake_produ
   | Goal_reconciliation_ready _ -> Keeper_goal_reconciliation
   | Completion_authority_rejected _ -> Completion_authority
   | Task_cancelled _ -> Keeper_task_cancellation
-  | Keeper_message _ -> Keeper_workspace_message
+  | Workspace_message _ -> Keeper_workspace_message
 ;;
 
 let unix_iso_json = function

--- a/lib/server_keeper_waiting_inventory.ml
+++ b/lib/server_keeper_waiting_inventory.ml
@@ -33,6 +33,7 @@ type wake_producer =
   | Completion_authority
   | Keeper_task_cancellation
   | Keeper_compaction_request
+  | Keeper_workspace_message
   | Read_model_reader
 
 type waiting_row =
@@ -101,6 +102,7 @@ let wake_producer_to_string = function
   | Keeper_task_cancellation -> "keeper_task_cancellation"
   | Completion_authority -> "completion_authority"
   | Keeper_compaction_request -> "keeper_compaction_request"
+  | Keeper_workspace_message -> "keeper_workspace_message"
   | Read_model_reader -> "read_model_reader"
 ;;
 
@@ -118,6 +120,7 @@ let wake_producer_of_payload : Keeper_event_queue.stimulus_payload -> wake_produ
   | Goal_reconciliation_ready _ -> Keeper_goal_reconciliation
   | Completion_authority_rejected _ -> Completion_authority
   | Task_cancelled _ -> Keeper_task_cancellation
+  | Keeper_message _ -> Keeper_workspace_message
 ;;
 
 let unix_iso_json = function

--- a/test/test_broadcast_wakeup_policy.ml
+++ b/test/test_broadcast_wakeup_policy.ml
@@ -257,6 +257,84 @@ let test_canonical_delivery_stamps_configured_feed_target () =
       (List.mem alias mentions)
 ;;
 
+let queued_keeper_messages ~base_path ~keeper_name =
+  match Keeper_event_queue_persistence.load_result ~base_path ~keeper_name with
+  | Error detail -> failf "event queue load failed: %s" detail
+  | Ok queue ->
+    Keeper_event_queue.to_list queue
+    |> List.filter_map (fun (stimulus : Keeper_event_queue.stimulus) ->
+      match stimulus.payload with
+      | Keeper_event_queue.Keeper_message message ->
+        Some (stimulus.post_id, stimulus.urgency, message)
+      | Keeper_event_queue.Board_signal _
+      | Keeper_event_queue.Board_attention _
+      | Keeper_event_queue.Bootstrap
+      | Keeper_event_queue.Fusion_completed _
+      | Keeper_event_queue.Schedule_due _
+      | Keeper_event_queue.Connector_attention _
+      | Keeper_event_queue.Hitl_resolved _
+      | Keeper_event_queue.Manual_compaction_requested
+      | Keeper_event_queue.Goal_assigned _
+      | Keeper_event_queue.Goal_reconciliation_ready _
+      | Keeper_event_queue.Completion_authority_rejected _
+      | Keeper_event_queue.Task_cancelled _ -> None)
+;;
+
+(* A workspace message that names a Keeper has to reach the same linear drain
+   every other stimulus arrives on. Before this, the delivery boundary wrote a
+   transcript row and flipped a wake flag, so the message existed for the
+   transcript scan and for nothing else: it had no queue identity, no ordering
+   against other stimuli, and nothing for the operator queue view to show. *)
+let test_delivery_enqueues_linear_queue_entry () =
+  with_workspace @@ fun config ->
+  let target = "rondo" in
+  let request_id = "wmsg-1234567890abcdef" in
+  persist_meta config target;
+  let deliver () =
+    Broadcast_wakeup.deliver_broadcast_mention
+      ~config
+      ~base_path:config.base_path
+      ~is_running:(fun _ -> true)
+      ~wakeup:(fun _ -> ())
+      (delivery ~target ~request_id ~seq:6 ~content:"drain me")
+  in
+  ignore (deliver ());
+  (match queued_keeper_messages ~base_path:config.base_path ~keeper_name:target with
+   | [ (post_id, urgency, message) ] ->
+     check string "queue entry keys on the workspace request"
+       ("workspace-message:" ^ request_id) post_id;
+     check bool "an addressed message is immediate" true
+       (urgency = Keeper_event_queue.Immediate);
+     check string "queue entry names its sender" "external-agent"
+       message.Keeper_event_queue.kmsg_from
+   | entries ->
+     failf "expected one queued keeper message, got %d" (List.length entries));
+  (* Redelivery of the same committed message is the same durable event. *)
+  ignore (deliver ());
+  check int "redelivery does not duplicate the queue entry" 1
+    (List.length
+       (queued_keeper_messages ~base_path:config.base_path ~keeper_name:target))
+;;
+
+(* The wake is a hint; the delivery is durable. A Keeper that is not running
+   when the message commits still finds it in its queue on the next cycle. *)
+let test_stopped_keeper_keeps_queue_entry () =
+  with_workspace @@ fun config ->
+  let target = "stopped-drain-keeper" in
+  let request_id = "wmsg-fedcba0987654321" in
+  persist_meta config target;
+  ignore
+    (Broadcast_wakeup.deliver_broadcast_mention
+       ~config
+       ~base_path:config.base_path
+       ~is_running:(fun _ -> false)
+       ~wakeup:(fun _ -> fail "a stopped Keeper must not be woken")
+       (delivery ~target ~request_id ~seq:7 ~content:"queued while stopped"));
+  check int "stopped Keeper still holds the queue entry" 1
+    (List.length
+       (queued_keeper_messages ~base_path:config.base_path ~keeper_name:target))
+;;
+
 let () =
   run
     "broadcast_wakeup_policy"
@@ -276,5 +354,9 @@ let () =
             test_configured_mention_alias_resolves_and_stamps_feed_target
         ; test_case "canonical delivery stamps configured feed target" `Quick
             test_canonical_delivery_stamps_configured_feed_target
+        ; test_case "delivery enqueues a linear queue entry" `Quick
+            test_delivery_enqueues_linear_queue_entry
+        ; test_case "stopped Keeper keeps the queue entry" `Quick
+            test_stopped_keeper_keeps_queue_entry
         ] )
     ]

--- a/test/test_broadcast_wakeup_policy.ml
+++ b/test/test_broadcast_wakeup_policy.ml
@@ -257,14 +257,14 @@ let test_canonical_delivery_stamps_configured_feed_target () =
       (List.mem alias mentions)
 ;;
 
-let queued_keeper_messages ~base_path ~keeper_name =
+let queued_workspace_messages ~base_path ~keeper_name =
   match Keeper_event_queue_persistence.load_result ~base_path ~keeper_name with
   | Error detail -> failf "event queue load failed: %s" detail
   | Ok queue ->
     Keeper_event_queue.to_list queue
     |> List.filter_map (fun (stimulus : Keeper_event_queue.stimulus) ->
       match stimulus.payload with
-      | Keeper_event_queue.Keeper_message message ->
+      | Keeper_event_queue.Workspace_message message ->
         Some (stimulus.post_id, stimulus.urgency, message)
       | Keeper_event_queue.Board_signal _
       | Keeper_event_queue.Board_attention _
@@ -299,21 +299,21 @@ let test_delivery_enqueues_linear_queue_entry () =
       (delivery ~target ~request_id ~seq:6 ~content:"drain me")
   in
   ignore (deliver ());
-  (match queued_keeper_messages ~base_path:config.base_path ~keeper_name:target with
+  (match queued_workspace_messages ~base_path:config.base_path ~keeper_name:target with
    | [ (post_id, urgency, message) ] ->
      check string "queue entry keys on the workspace request"
        ("workspace-message:" ^ request_id) post_id;
      check bool "an addressed message is immediate" true
        (urgency = Keeper_event_queue.Immediate);
      check string "queue entry names its sender" "external-agent"
-       message.Keeper_event_queue.kmsg_from
+       message.Keeper_event_queue.wmsg_from
    | entries ->
      failf "expected one queued keeper message, got %d" (List.length entries));
   (* Redelivery of the same committed message is the same durable event. *)
   ignore (deliver ());
   check int "redelivery does not duplicate the queue entry" 1
     (List.length
-       (queued_keeper_messages ~base_path:config.base_path ~keeper_name:target))
+       (queued_workspace_messages ~base_path:config.base_path ~keeper_name:target))
 ;;
 
 (* The wake is a hint; the delivery is durable. A Keeper that is not running
@@ -332,7 +332,7 @@ let test_stopped_keeper_keeps_queue_entry () =
        (delivery ~target ~request_id ~seq:7 ~content:"queued while stopped"));
   check int "stopped Keeper still holds the queue entry" 1
     (List.length
-       (queued_keeper_messages ~base_path:config.base_path ~keeper_name:target))
+       (queued_workspace_messages ~base_path:config.base_path ~keeper_name:target))
 ;;
 
 let () =

--- a/test/test_keeper_board_attention_worker.ml
+++ b/test/test_keeper_board_attention_worker.ml
@@ -241,7 +241,8 @@ let relevant_delivery_count ~base_path ~candidate_id =
           | Event_queue.Goal_assigned _
           | Event_queue.Goal_reconciliation_ready _
           | Event_queue.Completion_authority_rejected _
-          | Event_queue.Task_cancelled _ -> count)
+          | Event_queue.Task_cancelled _
+          | Event_queue.Keeper_message _ -> count)
        0
 ;;
 

--- a/test/test_keeper_board_attention_worker.ml
+++ b/test/test_keeper_board_attention_worker.ml
@@ -242,7 +242,7 @@ let relevant_delivery_count ~base_path ~candidate_id =
           | Event_queue.Goal_reconciliation_ready _
           | Event_queue.Completion_authority_rejected _
           | Event_queue.Task_cancelled _
-          | Event_queue.Keeper_message _ -> count)
+          | Event_queue.Workspace_message _ -> count)
        0
 ;;
 

--- a/test/test_keeper_connector_attention_batch.ml
+++ b/test/test_keeper_connector_attention_batch.ml
@@ -210,7 +210,7 @@ let connector_event_ids_of_queue queue =
        | Q.Fusion_completed _ | Q.Schedule_due _ | Q.Hitl_resolved _
        | Q.Manual_compaction_requested | Q.Goal_assigned _
        | Q.Goal_reconciliation_ready _ | Q.Completion_authority_rejected _
-       | Q.Task_cancelled _ -> None)
+       | Q.Task_cancelled _ | Q.Keeper_message _ -> None)
   |> List.sort String.compare
 ;;
 

--- a/test/test_keeper_connector_attention_batch.ml
+++ b/test/test_keeper_connector_attention_batch.ml
@@ -210,7 +210,7 @@ let connector_event_ids_of_queue queue =
        | Q.Fusion_completed _ | Q.Schedule_due _ | Q.Hitl_resolved _
        | Q.Manual_compaction_requested | Q.Goal_assigned _
        | Q.Goal_reconciliation_ready _ | Q.Completion_authority_rejected _
-       | Q.Task_cancelled _ | Q.Keeper_message _ -> None)
+       | Q.Task_cancelled _ | Q.Workspace_message _ -> None)
   |> List.sort String.compare
 ;;
 

--- a/test/test_keeper_task_cancellation_wake.ml
+++ b/test/test_keeper_task_cancellation_wake.ml
@@ -108,7 +108,8 @@ let queued_cancellations ~base_path ~keeper_name =
     | Event_queue.Manual_compaction_requested
     | Event_queue.Goal_assigned _
     | Event_queue.Goal_reconciliation_ready _
-    | Event_queue.Completion_authority_rejected _ -> None)
+    | Event_queue.Completion_authority_rejected _
+    | Event_queue.Keeper_message _ -> None)
 ;;
 
 let test_cross_keeper_cancellation_is_delivered () =

--- a/test/test_keeper_task_cancellation_wake.ml
+++ b/test/test_keeper_task_cancellation_wake.ml
@@ -109,7 +109,7 @@ let queued_cancellations ~base_path ~keeper_name =
     | Event_queue.Goal_assigned _
     | Event_queue.Goal_reconciliation_ready _
     | Event_queue.Completion_authority_rejected _
-    | Event_queue.Keeper_message _ -> None)
+    | Event_queue.Workspace_message _ -> None)
 ;;
 
 let test_cross_keeper_cancellation_is_delivered () =


### PR DESCRIPTION
## 문제

Keeper를 지목한 워크스페이스 메시지(`masc_broadcast` 의 `@name`, 대시보드 브로드캐스트)는 대상 Keeper의 대화 기록 행을 쓰고 깨우기 플래그만 올렸습니다. 그래서 이 메시지는 대화 기록 스캔에만 존재하고 그 밖에는 아무 데도 없었습니다.

- 큐 신원 없음 → 다른 자극과 순서가 비교되지 않고, 중복 판정 대상도 아님
- 내구성 있는 큐 항목 없음 → 운영자 이벤트 큐 화면에 뜨지 않음
- `keeper_chat_appended` SSE 없음 → Slack·Discord·fusion·대시보드 인테이크는 모두 보내는데 이 경로만 빠져 있어서, 대화 창이 새로고침 전까지 메시지를 보여주지 않음

## 실측 기준선

현 저장소(`~/me/.masc/messages`)에 남아 있는 워크스페이스 메시지 18건 중 17건이 `Mention_passive`, 1건이 `Mention_accepted` 입니다. 지목이 붙은 유일한 1건도 사람(대시보드)이 보낸 것이고, Keeper가 보낸 17건은 전부 지목 없는 브로드캐스트입니다.

```
17 "Mention_passive"
 1 "Mention_accepted"   ← from: dashboard, mention: sangsu
```

이 PR은 그중 지목이 붙은 경로를 큐까지 잇습니다. 지목 없는 브로드캐스트 팬아웃은 후속 PR입니다.

## 변경

`Keeper_event_queue.Keeper_message` 를 추가합니다. 페이로드는 워크스페이스 request id 와 보낸 에이전트 이름입니다. request id 는 대화 기록 행의 `external_message_id` 와 같은 값이라, 하나의 신원이 두 저장소를 가리키고 본문을 큐에 복제하지 않습니다 (`Connector_attention` 이 `event_id` 포인터만 들고 다니는 것과 같은 방식).

전달 지점은 이제 커넥터 인테이크와 같은 순서로 동작합니다.

1. 대화 기록 행 커밋
2. `keeper_chat_appended` SSE 발행 (`connector = "workspace"`)
3. 내구성 있는 `Keeper_message` 항목 커밋
4. 깨우기 힌트

깨우기보다 커밋이 먼저이므로, 힌트로 깨어난 Keeper는 항상 항목을 찾습니다. 멈춰 있는 Keeper도 항목을 그대로 보관합니다.

턴 쪽은 `Keeper_message_stimulus` → `Keeper_message_pending` 으로 이름이 붙습니다. 관측 주입은 하지 않습니다. 본문은 이미 대화 기록 행에 있고 메시지 레인이 읽으므로, 여기서 관측을 하나 더 만들면 같은 메시지가 두 번 보입니다.

## 검증

```
$ dune build @check                     # exit 0
$ ./_build/default/test/test_broadcast_wakeup_policy.exe
Test Successful in 0.046s. 10 tests run.
```

새 케이스 2개:

- `delivery enqueues a linear queue entry` — 전달 후 대상 큐에 `workspace-message:<request_id>` 항목이 정확히 1개, urgency `Immediate`, 보낸이 기록. 같은 메시지 재전달 시 중복 없음
- `stopped Keeper keeps the queue entry` — 멈춘 Keeper는 깨우지 않지만 항목은 남음

`Keeper_message` 생산자는 이 PR의 전달 지점 한 곳뿐입니다 (`rg` 확인). 즉 위 테스트는 이 변경 없이는 큐 항목이 0개라 실패합니다.

## 남은 것

지목 없는 브로드캐스트는 아직 `Passive` 입니다. 대화 기록 스캔의 Scope 레인이 Owner 작성 행만 받기 때문에, External 로 쓰인 Keeper 브로드캐스트는 스캔으로는 전달할 수 없습니다. 이 PR이 깐 큐 경로가 그 팬아웃의 기반입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
