### PR TITLE
docs(rfc): RFC-0382 라이브 fleet 검증 부록

### DIFF
--- a/docs/rfc/RFC-0382-runtime-kv-cache-reuse-and-reasoning-continuity.md
+++ b/docs/rfc/RFC-0382-runtime-kv-cache-reuse-and-reasoning-continuity.md
@@ -111,3 +111,19 @@
 - Blaizzy/mlx-vlm#999, ml-explore/mlx-lm#980 (mlx 캐시 결함)
 - NousResearch/hermes-agent#56004, earendil-works/pi#3325 (preserve_thinking 부재로 인한 multi-turn 결함 사례)
 - DeepSeek context caching 문서 (프리픽스 유닛 완전 일치 시에만 히트)
+
+## 7. 라이브 검증 (2026-08-16 04:10~04:25 KST, 추가)
+
+§4 계획의 PR-2(#28777)·PR-3(#28778)·PR-4(#28782)를 병합하고, llama_cpp 레인을 실제 fleet에 올려 keeper 턴으로 검증했다.
+
+절차: overlay + runtime.toml에 `llama_cpp.qwen3-8-27b-llama` 등록 → preview API 검증 → 핫리로드 → `/api/v1/runtime/resolved`에서 `keeper_dispatchable: true` 확인 → `canary-multiturn-localollama-20260814-0839`를 레인에 배정, thinking/preserve on.
+
+| 관측 | 값 | 근거 |
+|---|---|---|
+| 턴 15 (콜드) | 35K 프리픽스 프리필 중 first-event 120s 데드라인에 3회 취소, 취소마다 슬롯 KV 적립 12K→22K→32K, 4번째 시도 완주 | llama-server 로그 task 0/14/27/70 |
+| 턴 16 (웜) | LCP 유사도 0.949, **캐시 재사용 94.6%** — 신규 1,769tok만 19.3s 프리필, ttfrc 27.2s, `finish_reason: completed`, `enable_thinking: true` | turn-record absolute_turn=16, llama-server 로그 |
+| 대시보드 | 컨텍스트 미터 34.5k/65.5k(53%)가 provider 실측 입력 토큰으로 표시, 런타임 패널에 `chat-template-kwargs` 축 노출 | keeper 상세 화면 실측 |
+
+파생 수정: 콜드/딥 프리필의 first-event 침묵은 타임아웃 완화가 아니라 llama-server `return_progress`(prefill 중 `prompt_progress{total, cache, processed}` SSE 청크, b10180 검증)로 푼다 — PR-6 (#28791). `[turn] stream_idle_timeout_sec = 120`은 본래 역할(죽은 서버 감지)로 유지.
+
+병합 이력: #28774(본 RFC) → #28777(G1) → #28778(G5) → #28782(G2/G3 runbook) → #28785(G4, anthropic) → #28791(return_progress).

--- a/docs/rfc/RFC-0382-runtime-kv-cache-reuse-and-reasoning-continuity.md
+++ b/docs/rfc/RFC-0382-runtime-kv-cache-reuse-and-reasoning-continuity.md
@@ -8,10 +8,10 @@
 
 ## 0. 판정 요약
 
-1. MASC의 프롬프트 구조는 이미 캐시 인지형이다 — 안정 system 헤드, append-only 히스토리, window 양자화 컷, 변동 컨텍스트 꼬리 주입까지 설계 근거가 코드에 있다 (`agent_turn.ml:31`, `runtime_model_input_tail_window.mli`, `keeper_unified_prompt.mli`).
+1. MASC의 프롬프트 구조는 이미 캐시 인지형이다 — 안정 system 헤드, append-only 히스토리, window 양자화 컷, 변동 컨텍스트 꼬리 주입까지 설계 근거가 코드에 있다 (`agent_turn.ml:33-34`, `runtime_model_input_tail_window.mli`, `keeper_unified_prompt.mli`).
 2. llama-server(b10180) + Qwen3.8-27B 실측에서 preserve-thinking + append-only 정책은 턴당 prefill을 26~34 토큰(≈0.7s)으로 떨어뜨린다. 같은 대화를 시스템 헤드에 타임스탬프 한 줄만 넣고 돌리면 재처리 토큰이 314→863→1,892로 히스토리에 비례해 배증한다(턴4 14.4s). 같은 정보를 꼬리로 옮기면 61~69 토큰 상수로 돌아온다 — 턴4 기준 31배.
 3. 스트리밍 경로가 llama-server의 `timings`(cache_n = 캐시 재사용 토큰 수)를 버린다. 로컬 행은 전부 `streaming = true`이므로 정확히 관측이 필요한 지점에서 관측이 사라진다 (`complete_stream.ml:353` Ollama NDJSON 전용).
-4. 라이브 fleet(8/15, 760턴)의 캐시 히트는 provider가 결정했다: gemini 84.1%, GLM 40.6%, ollama_cloud(deepseek) 0% — 하루 2,340만 input 토큰이 전량 재프리필. 클라이언트 구조 문제가 아니라 캐시 없는 provider에 멀티턴 keeper를 태운 배치 문제다.
+4. 라이브 fleet(8/15, 762턴)의 캐시 히트는 provider가 결정했다: gemini 84.1%, GLM 68.5%, ollama_cloud(deepseek) 0% — 하루 2,340만 input 토큰이 전량 재프리필. 클라이언트 구조 문제가 아니라 캐시 없는 provider에 멀티턴 keeper를 태운 배치 문제다. (GLM 수치는 최초 게재분 40.6%의 정정 — §3.2)
 5. 로컬 8080은 현재 mlx_vlm.server이고 `apc_enabled: false`인 데다 upstream이 요청마다 Metal 캐시를 지운다(Blaizzy/mlx-vlm#999). llama-server b10180은 같은 모델에서 prefill 167 t/s / decode 17.6 t/s로 ollama 경로(3.2 t/s) 대비 5.5배, MLX+draft(19.1 t/s)와 대등하면서 KV 재사용·JSON schema·slot 저장을 전부 지원한다. 로컬 레인의 정답은 llama-server 복원이다.
 
 ## 1. 배경
@@ -34,7 +34,7 @@
 | 구조 | 위치 | 내용 |
 |---|---|---|
 | 3채널 프롬프트 | `lib/keeper/keeper_unified_prompt.mli` | system(세대 내 안정) / world_state(매턴 재조립, 비영속) / user_message(영속). #25193에서 world_state 영속화가 943/945 중복 프레임을 만든 사고 이후 분리됨 |
-| 변동 컨텍스트 꼬리 주입 | `packages/agent_core/lib/agent/agent_turn.ml:31` | extra_system_context를 히스토리 뒤에 append. 주석에 "critical for local LLM KV-cache reuse" 명시 |
+| 변동 컨텍스트 꼬리 주입 | `packages/agent_core/lib/agent/agent_turn.ml:33-34` | extra_system_context를 히스토리 뒤에 append. 주석에 "critical for local LLM KV-cache reuse" 명시 |
 | Window 양자화 컷 | `lib/runtime/runtime_model_input_tail_window.mli` | 슬라이딩 컷 대신 atoms_per_window 배수 점프로 프리픽스 바이트 동일 유지 (#26535 실측 기반) |
 | Reasoning replay 타입 계약 | `packages/agent_core/lib/llm_provider/reasoning_replay_contract.mli`, `reasoning_history_projection.mli` | replay_policy 5종 + provenance 검증 + rotation policy. provider 이름 비교 없음 |
 | preserve_thinking 인코딩 | `reasoning_dialect.ml:294,446` | `chat_template_kwargs: {enable_thinking, preserve_thinking}` 정확한 필드명. GLM `clear_thinking=false` 매핑도 존재 |
@@ -67,15 +67,17 @@
 
 턴4 기준 volatile-head 대 volatile-tail은 31배(1,892 vs 61 tok). 같은 정보를 넣는 위치만 바꿨다.
 
-핵심 기전 두 가지. (1) 생성된 thinking 토큰의 KV는 슬롯에 남아 있으므로, 다음 턴 히스토리에 같은 reasoning_content를 그대로 되돌려주면 재토큰화 비용 없이 프리픽스가 이어진다(preserve 턴2: 이전 턴 생성 419tok가 그대로 cache_n에 편입, 새 user 29tok만 처리). (2) 프리픽스 앞쪽 1바이트 변형은 그 뒤 전체를 무효화하며, hybrid(SSM) 모델은 임의 위치 롤백이 안 되므로 체크포인트(`--ctx-checkpoints`, b10180 기본 32/slot)가 있는 위치까지만 되감는다 — volatile-head 턴4에서 cache_n이 68로 무너진 것이 체크포인트 고갈의 실측이다. 원 수치는 `docs/evidence/kv-cache-harness-2026-08-16.jsonl`.
+핵심 기전 두 가지. (1) 생성된 thinking 토큰의 KV는 슬롯에 남아 있으므로, 다음 턴 히스토리에 같은 reasoning_content를 그대로 되돌려주면 재토큰화 비용 없이 프리픽스가 이어진다 — 전이 산술로 확인된다: 턴1이 생성한 295tok는 턴2의 cache_n에(68+516+295≈878), 턴2가 생성한 419tok는 턴3의 cache_n에(878+29+419≈1325) 그대로 편입되고, 각 턴의 신규 처리분은 새 user 메시지(29~34tok)뿐이다. (2) 프리픽스 앞쪽 1바이트 변형은 그 뒤 전체를 무효화하며, hybrid(SSM) 모델은 임의 위치 롤백이 안 되므로 체크포인트(`--ctx-checkpoints`, b10180 기본 32/slot)가 있는 위치까지만 되감는다 — volatile-head 턴4에서 cache_n이 68로 무너진 것이 체크포인트 고갈의 실측이다. 원 수치는 `docs/evidence/kv-cache-harness-2026-08-16.jsonl`. 측정 한계 두 가지(적대적 리뷰 지적): 시나리오 간 슬롯 캐시를 지우지 않아 각 시나리오의 턴1은 직전 시나리오 잔여 캐시에 오염될 수 있다(volatile 턴1 cache_n=559가 그 사례) — 표가 턴1을 제외하는 실제 이유다. 그리고 strip·volatile의 일부 턴은 thinking이 max_tokens를 소진해 content가 빈 퇴화 생성이었다(JSONL의 content_chars=0). 턴2~4의 정책 간 상대 비교에는 영향이 없지만, volatile의 재처리 증가에는 캐시 무효화 외에 프롬프트 변동으로 인한 생성 길이 변화가 혼입될 수 있다.
 
-### 3.2 라이브 fleet 캐시 히트 (8/15, `<MASC_BASE_PATH>/costs/2026-08/15.jsonl`, 760턴)
+### 3.2 라이브 fleet 캐시 히트 (8/15, `<MASC_BASE_PATH>/costs/2026-08/15.jsonl`, 762턴)
 
-| 모델 | 턴 | cache_read | input | 히트율 |
-|---|---|---|---|---|
-| gemini-3.6-flash-high | 127 | 145.5M | 27.6M | 84.1% |
-| GLM-5-Turbo | 364 | 13.1M | 19.2M | 40.6% |
-| deepseek-v4-flash:0731 (ollama_cloud) | 271 | 0 | 23.4M | 0% |
+| 모델 | 턴 | cache_read | input | 히트율 | input 의미론 |
+|---|---|---|---|---|---|
+| gemini-3.6-flash-high | 127 | 145.5M | 27.6M | 84.1% = r/(r+i) | cached 배제형 |
+| GLM-5-Turbo | 364 | 13.1M | 19.2M | **68.5% = r/i** | cached 포함형 (input = cache_read + cache_miss, 표본 불일치 0건) |
+| deepseek-v4-flash:0731 (ollama_cloud) | 271 | 0 | 23.4M | 0% | — |
+
+정정 기록 (2026-08-16 적대적 리뷰): 최초 게재분은 GLM에 40.6% = r/(r+i)를 썼으나, GLM의 `input_tokens`는 캐시 재사용분을 이미 포함하므로 분모에서 cache_read가 이중 계산된 오류였다. G6에서 지적한 "provider별 usage 의미론 차이"가 이 표 자체에 실현된 사례다. 히트율 공식은 provider의 input 의미론에 따라 행별로 다르다. 원본 로그는 라이브로 증가하는 파일이라 사후 재현이 불가하며, 위 수치는 8/15 자정 기준 스냅샷 합산이다.
 
 ### 3.3 로컬 서빙 경로 비교 (같은 Qwen3.8-27B)
 

--- a/reports/kv-cache-runtime-audit-2026-08-16.html
+++ b/reports/kv-cache-runtime-audit-2026-08-16.html
@@ -97,6 +97,16 @@
 <tr><td>G6</td><td>provider별 usage 의미론(input에 cached 포함 여부) 미감사</td><td>후속 감사</td></tr>
 </table>
 
+<h2>추가: 라이브 fleet 검증 (2026-08-16 04:10~04:25 KST)</h2>
+<p class="note">위 하네스 측정 이후, llama_cpp 레인을 실제 keeper fleet에 올려 검증했다. 절차와 수치는 RFC-0382 §7 참조.</p>
+<table>
+<tr><th>관측</th><th>값</th></tr>
+<tr><td>턴 15 (콜드, 35K 프리픽스)</td><td>first-event 120s 데드라인에 3회 취소 — 취소마다 슬롯 KV 적립(12K→22K→32K), 4번째 시도 완주. 재시도 사다리가 수렴하지만 수 분 낭비</td></tr>
+<tr><td>턴 16 (웜)</td><td class="good">LCP 유사도 0.949 · 캐시 재사용 94.6% — 신규 1,769tok/19.3s 프리필, ttfrc 27.2s, finish=completed, enable_thinking=true, input 34,468 / output 717</td></tr>
+<tr><td>대시보드</td><td>컨텍스트 미터 34.5k/65.5k(53%)가 provider 실측 토큰으로 표시, 런타임 패널에 chat-template-kwargs 축 노출</td></tr>
+<tr><td>파생 수정</td><td>콜드 프리필의 SSE 침묵 → <code>return_progress</code>(prefill 중 prompt_progress 청크, b10180 검증)로 근본 해결 — PR #28791. 타임아웃 값(120s)은 유지</td></tr>
+</table>
+
 <p class="note">이 리포트의 모든 수치는 위 명시된 환경에서의 단일 측정이다. mlx 서버와 동시 상주 상태라 decode 절대값에는 Metal 경합이 섞여 있고, 정책 간 <em>상대</em> 비교(같은 세션 내 연속 측정)가 이 리포트의 주장 범위다.</p>
 
 </body>

--- a/reports/kv-cache-runtime-audit-2026-08-16.html
+++ b/reports/kv-cache-runtime-audit-2026-08-16.html
@@ -36,16 +36,16 @@
 <div class="verdict">
 <p><strong>판정 5줄.</strong></p>
 <ol>
-<li>MASC의 프롬프트 조립은 이미 캐시 인지형이다 — 안정 system 헤드 / append-only 히스토리 / window 양자화 컷 / 변동 컨텍스트 꼬리 주입이 코드에 설계 주석과 함께 존재한다 (<code>agent_turn.ml:31</code> "critical for local LLM KV-cache reuse").</li>
+<li>MASC의 프롬프트 조립은 이미 캐시 인지형이다 — 안정 system 헤드 / append-only 히스토리 / window 양자화 컷 / 변동 컨텍스트 꼬리 주입이 코드에 설계 주석과 함께 존재한다 (<code>agent_turn.ml:33-34</code> "critical for local LLM KV-cache reuse").</li>
 <li>llama-server + Qwen3.8-27B에서 <strong>preserve-thinking + append-only</strong>는 턴당 prefill을 <span class="good">26~34 토큰(≈0.7s)</span>으로 만든다. 이전 턴에 생성된 thinking의 KV가 슬롯에 남아 있고, 같은 reasoning_content를 히스토리로 되돌려주면 재처리가 새 user 메시지 분량으로 수렴하기 때문이다.</li>
 <li>시스템 헤드에 타임스탬프 <em>한 줄</em>을 매턴 갱신하면 재처리 토큰이 <span class="dead">314 → 863 → 1,892(14.4s)</span>로 히스토리에 비례해 배증한다. 같은 정보를 대화 꼬리로 옮기면 61~69 토큰 상수 — <strong>턴4 기준 31배 차이</strong>. 변동 정보의 위치가 캐시의 전부다.</li>
 <li>llama-server는 스트리밍 최종 청크에 <code>timings.cache_n</code>(재사용 토큰 수)을 opt-in 없이 싣는데, agent-core 스트리밍 경로는 Ollama NDJSON에서만 timings를 읽어 <span class="dead">로컬 행(전부 streaming=true)의 캐시 관측이 유실</span>된다 (G1).</li>
-<li>라이브 fleet(8/15, 760턴)의 캐시 히트율은 클라이언트 구조가 아니라 provider가 결정했다: gemini 84.1% / GLM 40.6% / <span class="dead">ollama_cloud(deepseek) 0%</span> — 하루 2,340만 input 토큰 전량 재프리필. 멀티턴 keeper를 캐시 없는 provider에 태우는 배치가 지연·비용의 주범이다.</li>
+<li>라이브 fleet(8/15, 762턴)의 캐시 히트율은 클라이언트 구조가 아니라 provider가 결정했다: gemini 84.1% / GLM 68.5% / <span class="dead">ollama_cloud(deepseek) 0%</span> — 하루 2,340만 input 토큰 전량 재프리필 (GLM 수치는 최초 게재분 40.6%의 정정, 표 3 참조). 멀티턴 keeper를 캐시 없는 provider에 태우는 배치가 지연·비용의 주범이다.</li>
 </ol>
 </div>
 
 <h2>표 1. 히스토리 정책별 턴당 재처리 비용 (같은 대화, 같은 모델, 같은 서버)</h2>
-<p class="note">각 셀: <code>prompt_n</code>(이번 턴에 다시 처리한 토큰) / <code>prompt_ms</code>. cache_n·전체 원값은 evidence JSONL 참조. 턴1은 콜드 스타트라 제외.</p>
+<p class="note">각 셀: <code>prompt_n</code>(이번 턴에 다시 처리한 토큰) / <code>prompt_ms</code>. cache_n·전체 원값은 evidence JSONL 참조. 턴1 제외 사유: 하네스가 시나리오 간 슬롯 캐시를 지우지 않아 턴1은 직전 시나리오 잔여 캐시에 오염될 수 있다(volatile 턴1 cache_n=559). strip·volatile 일부 턴은 thinking이 max_tokens를 소진한 퇴화 생성(content_chars=0)으로, 턴2~4 상대 비교에는 영향 없으나 volatile의 절대 수치엔 생성 길이 변동이 혼입될 수 있다.</p>
 <table>
 <tr><th>히스토리 정책</th><th>턴2</th><th>턴3</th><th>턴4</th><th>경향</th></tr>
 <tr><td><strong>preserve</strong> — append-only + reasoning_content 재주입 (<code>chat_template_kwargs {"preserve_thinking": true}</code>)</td>
@@ -68,11 +68,12 @@
 </table>
 <p class="note">ollama의 3.2 t/s는 qwen35 아키텍처(Gated DeltaNet hybrid)의 SSM Metal 경로가 느린 빌드였고, brew b10180은 같은 GGUF에서 5.5배를 낸다. 로컬 레인이 "느려서 강등"된 2026-08-07~08의 근거가 더 이상 성립하지 않는다.</p>
 
-<h2>표 3. 라이브 fleet 캐시 히트 (2026-08-15, ~/.masc/costs, 760턴)</h2>
+<h2>표 3. 라이브 fleet 캐시 히트 (2026-08-15, 762턴)</h2>
+<p class="note">정정(2026-08-16 적대적 리뷰): GLM의 <code>input_tokens</code>는 캐시 재사용분 포함형(input = cache_read + cache_miss, 표본 불일치 0건)이라 히트율은 r/i. 최초 게재분의 40.6% = r/(r+i)는 분모 이중 계산 오류였다 — G6(provider별 usage 의미론)가 이 표에서 실현된 사례. gemini는 배제형이라 r/(r+i)가 맞다. 원본 로그는 라이브 증가 파일로 사후 재현 불가, 수치는 8/15 스냅샷.</p>
 <table>
 <tr><th>모델 (런타임)</th><th>턴</th><th>cache_read</th><th>input</th><th>히트율</th></tr>
-<tr><td>gemini-3.6-flash-high (antigravity)</td><td>127</td><td>145.5M</td><td>27.6M</td><td class="good">84.1%</td></tr>
-<tr><td>GLM-5-Turbo (glm-coding)</td><td>364</td><td>13.1M</td><td>19.2M</td><td>40.6%</td></tr>
+<tr><td>gemini-3.6-flash-high (antigravity)</td><td>127</td><td>145.5M</td><td>27.6M</td><td class="good">84.1% (r/(r+i), 배제형)</td></tr>
+<tr><td>GLM-5-Turbo (glm-coding)</td><td>364</td><td>13.1M</td><td>19.2M</td><td>68.5% (r/i, 포함형)</td></tr>
 <tr><td>deepseek-v4-flash:0731 (ollama_cloud)</td><td>271</td><td>0</td><td>23.4M</td><td class="dead">0%</td></tr>
 </table>
 

--- a/scripts/bench-kv-cache.py
+++ b/scripts/bench-kv-cache.py
@@ -46,6 +46,25 @@ USER_TURNS = [
 ]
 
 
+def erase_slots(base, slots=4):
+    """Best-effort slot-cache erase between scenarios so a scenario's turn 1
+    cannot silently reuse the previous scenario's residue (observed in the
+    2026-08-16 evidence run: volatile turn 1 matched strip's leftover system
+    prefix, cache_n=559). Requires the endpoint to be enabled server-side;
+    a refusal downgrades to a warning because relative turn-2..4 comparisons
+    do not depend on it."""
+    for slot in range(slots):
+        req = urllib.request.Request(
+            f"{base}/slots/{slot}?action=erase", data=b"", method="POST"
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=10):
+                pass
+        except Exception as exn:  # noqa: BLE001 - diagnostic path only
+            print(f"warn: slot {slot} erase unavailable: {exn}", file=sys.stderr)
+            return
+
+
 def call(base, body, timeout):
     req = urllib.request.Request(
         base + "/v1/chat/completions",
@@ -131,6 +150,7 @@ def main():
 
     with open(args.out, "a") as out:
         for scenario in args.scenarios.split(","):
+            erase_slots(args.base)
             print(f"### scenario={scenario}", file=sys.stderr, flush=True)
             run_scenario(args.base, scenario, args.turns, args.max_tokens,
                          args.model, args.timeout, out)


### PR DESCRIPTION
## 무엇

RFC-0382의 (1) 라이브 fleet 검증 부록 + (2) 적대적 리뷰(#28774 사후 리뷰) 지적 정정.

### 라이브 검증 (§7 신설)
- 턴 15 (콜드 35K): first-event 120s에 3회 취소 — 취소마다 슬롯 KV 적립(12K→22K→32K) → 4번째 완주
- 턴 16 (웜): **LCP 0.949 · 캐시 재사용 94.6%**, ttfrc 27.2s, `enable_thinking: true`
- 파생 수정 링크: #28791 (return_progress)

### 리뷰 정정 (같은 문서라 한 PR로 흡수)
- **Table 3 GLM 히트율 40.6% → 68.5%**: GLM `input_tokens`는 캐시 포함형(input = cache_read + cache_miss, 표본 불일치 0건)이라 r/i가 맞음. 최초 게재분 r/(r+i)는 분모 이중 계산 — G6가 이 표 자체에 실현된 사례로 정정 기록 명시
- §3.1 전이 산술 라벨 정정 (턴1 생성 295 → 턴2 cache_n, 턴2 생성 419 → 턴3 cache_n)
- `agent_turn.ml:31` → `:33-34`, 760턴 → 762턴
- 하네스: 시나리오 간 슬롯 erase(best-effort) 추가 + 턴1 오염 가능성·퇴화 생성(content_chars=0) 한계를 RFC/리포트 양쪽에 공시

🤖 Generated with [Claude Code](https://claude.com/claude-code)