### PR TITLE
docs(web): 코퍼스 소비 계약 문서화 (RFC-0383 PR-2)

### DIFF
--- a/docs/ENV-CONTRACT.md
+++ b/docs/ENV-CONTRACT.md
@@ -157,6 +157,15 @@ Precedence:
 | `AZURE_BING_SEARCH_API_KEY` | `(none)` | Azure-issued alias with the same admission as `BING_SEARCH_API_KEY`. |
 | `OLLAMA_API_KEY` | `(none)` | Env-only credential; presence admits the `ollama` provider. |
 
+Web artifact corpus (RFC-0383): every truncation offload stores the full
+extraction at `<base>/.masc/artifacts/web-fetch/<sha256>.md` and appends one
+`masc.web_artifact.v1` fact row (`sha256`, `source_url`, optional `title`,
+`bytes`, `fetched_at`) to `index.jsonl` in the same directory. The index is a
+projection — deleting it changes no behavior — and keepers consume it with the
+existing pair: `Grep` the index for a topic, then
+`keeper_artifact_read(sha256, offset, max_bytes)` for the body. MASC never
+deletes artifacts or index rows; retention is operator-managed (#28759).
+
 Equivalent `runtime.toml` keys:
 
 ```toml

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -257,6 +257,8 @@ Keeper WebSearch/WebFetch backend 메모:
 - `masc_web_search` / `masc_web_fetch`는 Keeper-internal backend 이름이며 MCP `tools/list` public surface에는 노출되지 않는다.
 - `web_search` / `web_fetch` are not agent core-owned capabilities; Keeper agents should call the MASC-owned public aliases shown in their tool list (`WebSearch` / `WebFetch`).
 - `WebSearch { includeContent: true }`는 가져온 본문을 keeper가 바로 읽는 `content_text` 렌더링 하나로만 싣는다. `WebFetch`는 선택한 단일 URL을 더 깊게 읽을 때 쓴다.
+- `maxChars`를 넘는 본문은 head/tail 창 + `[TRUNCATED ... full_text=<경로>]` 마커로 절단되고, 전문은 `<base>/.masc/artifacts/web-fetch/<sha256>.md`로 오프로드된다. 마크다운 헤딩이 있으면 마커 뒤 `[OUTLINE ...]` 블록이 헤딩별 바이트 오프셋을 주고, 그 오프셋이 곧 `keeper_artifact_read(sha256, offset, max_bytes)` 인자다.
+- 오프로드마다 같은 디렉터리의 `index.jsonl`에 `masc.web_artifact.v1` 행(sha256, source_url, title, bytes, fetched_at)이 append된다 (RFC-0383). 과거에 가져온 본문을 다시 쓰려면 index를 `Grep`으로 찾고 `keeper_artifact_read`로 읽는다 — 웹 왕복 없이. index는 projection이라 지워져도 다른 동작은 변하지 않는다.
 - `[web_search].searxng_url` 또는 `MASC_SEARXNG_URL` 설정 시 self-hosted SearXNG가 최우선 provider로 작동한다.
 - 로컬 검색 품질이 필요하면 `scripts/searxng-local.sh start`로 Docker SearXNG를 올리고 active `runtime.toml`의 `[web_search].searxng_url = "http://localhost:8888"`만 설정한다. 별도 WebSearch MCP wrapper는 필요 없다.
 - `scripts/searxng-local.sh status|smoke|logs|stop`으로 로컬 provider를 점검한다. 기본 config는 `${MASC_BASE_PATH:-$HOME/me}/.local/share/masc-searxng/settings.yml`에 생성되며 MASC가 쓰는 JSON search format을 켠다.

--- a/reports/web-tools-bench-2026-08-15.html
+++ b/reports/web-tools-bench-2026-08-15.html
@@ -238,10 +238,25 @@ hit@1 <strong>5/6</strong>, 옛 유일 경로(SearXNG)는 부분 회복 상태�
 </ol>
 </div>
 
+<h2>개선 라운드 2 — 하네스·아웃라인·코퍼스 (2026-08-16 병합분)</h2>
+
+<table>
+<tr><th>개선</th><th>내용</th><th>PR</th></tr>
+<tr><td>품질 회귀 하네스</td><td>고정 8쿼리 결정론 채점(hit@1/hit@5, 한글 비율). Brave grounded는 키 투입 즉시 같은 쿼리셋으로 A/B 활성</td><td>#28779</td></tr>
+<tr><td>내용 인식 절단</td><td>절단 마커 뒤 <code>[OUTLINE ...]</code> — 헤딩별 <strong>바이트 오프셋 지도</strong>(최대 32행, 펜스 제외). 각 행이 곧 <code>keeper_artifact_read(sha256, offset, max_bytes)</code> 인자라 keeper가 64KB 창을 맹목으로 넘기는 대신 섹션을 골라 읽는다. compile-only였던 web_fetch 스위트도 CI 배선</td><td>#28781</td></tr>
+<tr><td>코퍼스 인덱스</td><td>RFC-0383: 오프로드마다 <code>index.jsonl</code>에 사실 한 줄(sha256·source_url·title·bytes·fetched_at). 인덱스는 projection(삭제해도 무영향 — 테스트로 핀), 소비는 기존 Grep→artifact_read 2단으로 <strong>새 도구 0·게이트 0</strong>. keeper가 같은 주제를 웹 왕복 없이 재질의할 수 있는 기반</td><td>#28783 (RFC), #28794 (구현), PR-2 (소비 문서)</td></tr>
+</table>
+
+<p class="note">구현 중 determinism 게이트가 인덱스 행 생성부의 <code>Unix.gettimeofday</code>를
+정확히 FAIL로 잡았고, 마커 주석 대신 <strong>시각 주입</strong>(handle의 start_time을 체인으로 전달)으로
+수리했다 — 비결정 시계 읽기는 dispatch 경계에 남고 그 아래는 입력에 결정론적이다.</p>
+
 <h2>다음 반복</h2>
 <ul>
 <li><strong>Iteration 6</strong> (선택): BRAVE_SEARCH_API_KEY 투입 시 grounded 경로 —
 <code>bench-web-quality.py</code>가 같은 쿼리셋으로 자동 A/B.</li>
+<li><strong>코퍼스 재질의 실측</strong>: RFC-0383 acceptance 3 — keeper가 Grep→artifact_read
+2단으로 과거 본문에 도달하는 턴 실측 (Iteration 5와 같은 방법).</li>
 <li>품질은 <code>python3 scripts/bench-web-quality.py -o docs/evidence/web-quality-&lt;date&gt;-rN.json</code>,
 가용성·토큰은 <code>bench-web-tools.py</code> — 실행 후 이 문서에 섹션 추가.</li>
 </ul>


### PR DESCRIPTION
RFC-0383의 마지막 조각이에요. ENV-CONTRACT에 코퍼스 문단(인덱스 경로·v1 스키마·projection 의미·운영자 보존 #28759), QUICK-START에 keeper용 레시피(절단 마커의 OUTLINE 바이트 오프셋 → index Grep → keeper_artifact_read로 웹 왕복 없이 재사용)를 추가합니다. 문서만 변경해요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)