### PR TITLE
fix(masc_http_client): include the port in the HTTP/1.1 Host header

### DIFF
--- a/lib/masc_http_client/pool.ml
+++ b/lib/masc_http_client/pool.ml
@@ -329,6 +329,44 @@ let path_and_query uri =
   | [] -> p
   | _ -> p ^ "?" ^ Uri.encoded_of_query (Uri.query uri)
 
+let has_host_header headers =
+  List.exists
+    (fun (name, _) -> String.lowercase_ascii name = "host")
+    headers
+
+(* Piaf 0.2.0's own default HTTP/1.1 Host header (piaf/lib/headers.ml's
+   [canonicalize_headers], sourced from [Connection.Info.host]) carries the
+   bare hostname only — it never includes the port, even when the target
+   URI names one that differs from the scheme's default. Confirmed by
+   server-side capture (masc, 2026-08-16): a POST to a non-default local
+   port arrived at the server with [Host: 127.0.0.1] and no port; because
+   the server resolves a portless Host to the scheme's default port
+   (server_request_authority.ml's [effective_port_value]), it no longer
+   matches the port actually bound, and [admit_http1_authority] rejects the
+   request as [Untrusted] — this is what surfaced as
+   [request_authority_untrusted] on every non-default-port POST through
+   this client, including the keeper canary harness's live smoke test.
+
+   We supply an explicit, correct Host header ourselves so Piaf's
+   [add_unless_exists] keeps ours instead of its own truncated one. A
+   caller that already set a "host" header (any case) is left alone —
+   this only fills a gap Piaf leaves, it does not override a deliberate
+   caller choice. *)
+let ensure_host_header ~uri headers =
+  let headers = Option.value headers ~default:[] in
+  if has_host_header headers
+  then Some headers
+  else (
+    match Uri.host uri with
+    | None -> if headers = [] then None else Some headers
+    | Some host ->
+      let value =
+        match Uri.port uri with
+        | Some port -> Printf.sprintf "%s:%d" host port
+        | None -> host
+      in
+      Some (("host", value) :: headers))
+
 (* Wrap a single request: acquire-or-create client, send, release.
    Errors return [Error string]; the connection is dropped (close)
    on error, parked on success. *)
@@ -371,7 +409,8 @@ let do_request t ?headers ?body ~method_ uri : (response, string) result =
             ~finally:(fun () -> t.counters.inflight <- t.counters.inflight - 1)
             (fun () ->
                try
-                 Piaf.Client.request client ?headers ?body:body_piaf
+                 Piaf.Client.request client
+                   ?headers:(ensure_host_header ~uri headers) ?body:body_piaf
                    ~meth:(method_to_piaf method_) path
                with
                | Eio.Cancel.Cancelled _ as e -> raise e
@@ -535,7 +574,8 @@ let do_request_with_idle_timeout t
                t.counters.inflight <- t.counters.inflight - 1)
              (fun () ->
                 try
-                  Piaf.Client.request client ?headers ?body:body_piaf
+                  Piaf.Client.request client
+                    ?headers:(ensure_host_header ~uri headers) ?body:body_piaf
                     ~meth:(method_to_piaf method_) path
                 with
                 | Eio.Cancel.Cancelled _ as e -> raise e
@@ -620,4 +660,5 @@ module For_testing = struct
   module Host_key = Host_key
   let close_unreleased_client = close_unreleased_client
   let read_body_with_idle = read_body_with_idle
+  let ensure_host_header = ensure_host_header
 end

--- a/lib/masc_http_client/pool.ml
+++ b/lib/masc_http_client/pool.ml
@@ -329,6 +329,10 @@ let path_and_query uri =
   | [] -> p
   | _ -> p ^ "?" ^ Uri.encoded_of_query (Uri.query uri)
 
+(* STR-OK: HTTP boundary comparison. Header field names are untyped,
+   case-insensitive wire strings (RFC 7230 §3.2) — "host" is not a closed
+   domain enum this repo controls the shape of, so there is no variant to
+   parse it into. *)
 let has_host_header headers =
   List.exists
     (fun (name, _) -> String.lowercase_ascii name = "host")
@@ -353,6 +357,11 @@ let has_host_header headers =
    this only fills a gap Piaf leaves, it does not override a deliberate
    caller choice. *)
 let ensure_host_header ~uri headers =
+  (* DET-OK: sound, not a permissive default on unknown input. [None] here
+     is [?headers] genuinely omitted by the caller ("no headers"), not
+     unparsed/malformed external data — [[]] is the only value that means
+     "no headers" for a [(string * string) list], so no information is
+     lost. *)
   let headers = Option.value headers ~default:[] in
   if has_host_header headers
   then Some headers

--- a/lib/masc_http_client/pool.ml
+++ b/lib/masc_http_client/pool.ml
@@ -329,13 +329,14 @@ let path_and_query uri =
   | [] -> p
   | _ -> p ^ "?" ^ Uri.encoded_of_query (Uri.query uri)
 
-(* STR-OK: HTTP boundary comparison. Header field names are untyped,
+(* HTTP boundary comparison. Header field names are untyped,
    case-insensitive wire strings (RFC 7230 §3.2) — "host" is not a closed
    domain enum this repo controls the shape of, so there is no variant to
    parse it into. *)
 let has_host_header headers =
   List.exists
-    (fun (name, _) -> String.lowercase_ascii name = "host")
+    (fun (name, _) ->
+       String.lowercase_ascii name = "host" (* STR-OK: see doc comment above *))
     headers
 
 (* Piaf 0.2.0's own default HTTP/1.1 Host header (piaf/lib/headers.ml's
@@ -356,13 +357,12 @@ let has_host_header headers =
    caller that already set a "host" header (any case) is left alone —
    this only fills a gap Piaf leaves, it does not override a deliberate
    caller choice. *)
+(* [None] here is [?headers] genuinely omitted by the caller ("no
+   headers"), not unparsed/malformed external data — [[]] is the only
+   value that means "no headers" for a [(string * string) list], so no
+   information is lost. *)
 let ensure_host_header ~uri headers =
-  (* DET-OK: sound, not a permissive default on unknown input. [None] here
-     is [?headers] genuinely omitted by the caller ("no headers"), not
-     unparsed/malformed external data — [[]] is the only value that means
-     "no headers" for a [(string * string) list], so no information is
-     lost. *)
-  let headers = Option.value headers ~default:[] in
+  let headers = Option.value headers ~default:[] (* DET-OK: sound default, see doc comment above *) in
   if has_host_header headers
   then Some headers
   else (

--- a/lib/masc_http_client/pool.mli
+++ b/lib/masc_http_client/pool.mli
@@ -196,4 +196,12 @@ module For_testing : sig
     idle_timeout_sec:float ->
     Piaf.Body.t ->
     (string * body_progress, string * body_progress) result
+
+  (** [ensure_host_header ~uri headers] fills in a correct
+      ["host"] header (including the port when [uri] names one) when
+      [headers] does not already carry one, case-insensitively. Exposed so
+      unit tests can pin the Host-header-port fix (masc, 2026-08-16)
+      without standing up a real HTTP server. *)
+  val ensure_host_header :
+    uri:Uri.t -> (string * string) list option -> (string * string) list option
 end

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=552
+UNWIRED_BASELINE=551
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -296,6 +296,7 @@ normal_targets=(
   @test/runtest-test_tool_type_label
   @test/runtest-test_telemetry_eio_pbt
   @test/runtest-test_process_eio_coverage
+  @test/runtest-test_pool
   @test/runtest-test_keeper_secret_redaction
   @test/runtest-test_keeper_sandbox_docker_route
   @test/runtest-test_dashboard_dev_token_host_gate

--- a/test/test_pool.ml
+++ b/test/test_pool.ml
@@ -133,6 +133,60 @@ let test_stats_zero_state_shape () =
   Alcotest.(check (list (pair string int))) "empty idle_per_host"
     [] zero.idle_per_host
 
+(* ── Host-header port fix (masc, 2026-08-16, task-11) ───────────
+   Piaf 0.2.0's own default HTTP/1.1 Host header carries the bare
+   hostname only, dropping any explicit non-default port — confirmed
+   live against server_request_authority.ml's admit_http1_authority,
+   which then rejects the request as Untrusted. See
+   ensure_host_header's doc comment in pool.ml for the full trace. *)
+
+let ensure_host_header = Masc_http_client.Pool.For_testing.ensure_host_header
+
+let test_ensure_host_header_adds_port_when_missing () =
+  let uri = Uri.of_string "http://127.0.0.1:18935/api/v1/keepers/chat/stream" in
+  match ensure_host_header ~uri (Some [ ("content-type", "application/json") ]) with
+  | Some headers ->
+    Alcotest.(check (option string)) "host header carries the port"
+      (Some "127.0.0.1:18935") (List.assoc_opt "host" headers);
+    Alcotest.(check int) "existing headers preserved" 2 (List.length headers)
+  | None -> Alcotest.fail "expected Some headers"
+
+let test_ensure_host_header_omits_port_when_uri_has_none () =
+  let uri = Uri.of_string "http://example.com/path" in
+  match ensure_host_header ~uri (Some []) with
+  | Some headers ->
+    Alcotest.(check (option string)) "host header has no port"
+      (Some "example.com") (List.assoc_opt "host" headers)
+  | None -> Alcotest.fail "expected Some headers"
+
+let test_ensure_host_header_leaves_caller_override_alone () =
+  let uri = Uri.of_string "http://127.0.0.1:18935/x" in
+  let caller_headers = [ ("Host", "override.example:9999") ] in
+  match ensure_host_header ~uri (Some caller_headers) with
+  | Some headers ->
+    Alcotest.(check (list (pair string string)))
+      "caller's Host header is untouched (case-insensitive match, no duplicate added)"
+      caller_headers headers
+  | None -> Alcotest.fail "expected Some headers"
+
+let test_ensure_host_header_on_none_headers_with_host () =
+  let uri = Uri.of_string "https://api.example.com:8443/v1" in
+  match ensure_host_header ~uri None with
+  | Some headers ->
+    Alcotest.(check (option string)) "host header added to an empty list"
+      (Some "api.example.com:8443") (List.assoc_opt "host" headers)
+  | None -> Alcotest.fail "expected Some headers"
+
+let test_ensure_host_header_on_none_headers_without_uri_host_stays_none () =
+  (* A URI with no host at all (malformed target) has nothing to add;
+     returning None here preserves ?headers's original "caller passed
+     nothing" shape instead of manufacturing a headers list from thin air. *)
+  let uri = Uri.of_string "not-a-uri" in
+  Alcotest.(check (option (list (pair string string))))
+    "no host to add, no headers supplied -> None"
+    None
+    (ensure_host_header ~uri None)
+
 (* ── RFC-0129 — read_body_with_idle ─────────────────────────── *)
 
 (* Build a mock [Piaf.Body.t] that the test fiber can feed chunks into
@@ -364,6 +418,19 @@ let () =
       ( "stats type shape",
         [
           Alcotest.test_case "zero state" `Quick test_stats_zero_state_shape;
+        ] );
+      ( "ensure_host_header (Host-header port fix, task-11)",
+        [
+          Alcotest.test_case "adds port when missing" `Quick
+            test_ensure_host_header_adds_port_when_missing;
+          Alcotest.test_case "omits port when uri has none" `Quick
+            test_ensure_host_header_omits_port_when_uri_has_none;
+          Alcotest.test_case "leaves caller override alone" `Quick
+            test_ensure_host_header_leaves_caller_override_alone;
+          Alcotest.test_case "adds header to None headers when uri has a host" `Quick
+            test_ensure_host_header_on_none_headers_with_host;
+          Alcotest.test_case "None headers stays None when uri has no host" `Quick
+            test_ensure_host_header_on_none_headers_without_uri_host_stays_none;
         ] );
       ( "RFC-0129 read_body_with_idle",
         [


### PR DESCRIPTION
## 요약

masc task-11(keeper canary 하네스) 작업 중 발견한 전송 버그의 근본 수정입니다. 발굴 경위와 실측 과정은 #28798에 정리해뒀습니다.

## 증상

`Masc_http_client`(Piaf 기반)로 masc 서버(비-기본 포트, 예: 8935)에 POST하면 매번 `HTTP 400 {"error_code":"request_authority_untrusted"}`가 났습니다. 같은 요청을 `curl`로 보내면 성공했고요.

## 처음 가설은 틀렸습니다

"h2-eio 서버가 h2c 연결에서 클라이언트가 주장하는 `:scheme` pseudo-header를 그대로 신뢰한다"는 가설로 시작했는데, 실측(임시 디버그 로그 + 격리된 throwaway 서버)해보니 완전히 다른 원인이었습니다.

- 요청은 h2 경로가 아니라 **HTTP/1.1 경로**로 들어오고 있었습니다. Piaf가 이 클라이언트에서는 h2c를 안 쓰고 있었어요.
- 서버가 받은 `Host` 헤더가 `127.0.0.1`뿐이고 **포트가 빠져있었습니다**. 서버의 `configured_bind`는 포트를 포함하니(`host=127.0.0.1 port=8935`), 포트 없는 Host는 scheme 기본 포트(80)로 해석되어 매치가 안 되고 `Untrusted`로 떨어졌던 거예요.
- Piaf 0.2.0 소스(`lib/headers.ml`, `lib/connection.ml`)를 봤더니, `Connection.Info.t.host : string`이 호스트명만 담고 있고 HTTP/1.1 기본 Host 헤더 생성 로직이 아예 포트를 안 넣더라고요. URL에 비-기본 포트가 명시돼 있어도요.
- `Host: 127.0.0.1:8935`를 직접 헤더로 넘기면(Piaf의 `add_unless_exists`가 caller 값을 우선하니까) 통과해서 404(경로 없음)로 바뀌는 것까지 실측으로 확인했습니다.

## 수정 방향

서버 쪽(`server_request_authority.ml`)은 안 건드렸습니다 — 포트 없는 Host를 scheme 기본 포트로 해석하는 건 RFC 7230 §5.4 기준으로 올바른 동작이라, 여기를 느슨하게 만드는 건 증상 억제일 뿐이라고 판단했습니다.

대신 masc 자체 라이브러리인 `lib/masc_http_client/pool.ml`에 `ensure_host_header ~uri headers`를 추가했습니다. URI에 포트가 있으면 포함해서 Host 헤더를 채우고, 없으면 그대로 두고, 호출자가 이미 Host를 넘겼으면 손대지 않습니다. Piaf(외부 의존성)나 서버 쪽 인증 로직은 건드리지 않았고, masc 자신의 HTTP 클라이언트 래퍼에 있던 빈틈만 메웠습니다.

## 변경 파일

- `lib/masc_http_client/pool.ml` / `.mli`: `ensure_host_header` 추가, 두 요청 경로(`do_request`, `do_request_with_idle_timeout`)에 배선, `For_testing`에 노출.
- `test/test_pool.ml`: 유닛테스트 5개 추가 (포트 채움/포트 없을 때 생략/caller override 존중/`None` headers 처리 양쪽).
- `scripts/ci-run-focused-tests.sh`: `test_pool`이 CI에서 컴파일만 되고 실제로 실행된 적이 없어서(`audit-ci-test-targets.sh` 기준 unwired) 이번에 같이 등록했습니다. 이 스위트가 이번에 잡은 버그의 회귀를 실제로 잡으려면 CI에서 돌아야 하니까요.
- `scripts/audit-ci-test-targets.sh`: 위 등록으로 unwired 개수가 552 → 551이 돼서 ratchet baseline도 같이 내렸습니다.

## 검증

- `dune build --root .` 클린.
- `test_pool` 전체 27개(신규 5개 포함) CI alias(`@test/runtest-test_pool`)로 직접 실행 통과.
- `scripts/audit-ci-test-targets.sh` OK (322 CI targets, 551 unwired at new baseline).
- **라이브 재현/수정 확인**: 격리된 throwaway masc 서버(외부 Discord/Slack 토큰은 빈 값으로 띄워 실봇 세션에 영향 없게 처리)에 대해, 수정 전 클라이언트로는 400 `request_authority_untrusted`, 수정 후 클라이언트로는(수동 헤더 개입 없이) 404(경로 없음)로 바뀌는 것을 직접 확인했습니다.

## 관련

- #28798 — 이 버그의 발굴 경위/실측 로그
- masc task-11 keeper canary 하네스(#28797)를 이 수정으로 라이브 검증할 예정입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
