### PR TITLE
feat(build): 빌드 타임 git 커밋 임베딩 — 대시보드 'binary unknown' 근본 수정

### DIFF
--- a/lib/build_identity.ml
+++ b/lib/build_identity.ml
@@ -249,13 +249,13 @@ let probe_commit_unix_ts commit_hash_opt =
     List.find_map probe_one repo_roots
 ;;
 
-let resolve_commit ~env_value ~probe =
-  match env_value with
-  | Some raw ->
-    (match String_util.trim_to_option raw with
+let resolve_commit ~embedded ~env_value ~probe =
+  match Option.bind embedded String_util.trim_to_option with
+  | Some commit -> Some commit
+  | None ->
+    (match Option.bind env_value String_util.trim_to_option with
      | Some commit -> Some commit
      | None -> probe ())
-  | None -> probe ()
 ;;
 
 type commit_resolution =
@@ -267,22 +267,35 @@ type commit_resolution =
   ; repo_head_commit_source : string option
   }
 
+let embedded_commit_source = "embedded"
 let build_env_commit_source = "env:MASC_BUILD_GIT_COMMIT"
 let runtime_repo_head_source = "runtime_repo_head"
 
-let resolve_commit_details ~env_value ~probe =
-  let binary_commit = Option.bind env_value String_util.trim_to_option in
+let resolve_commit_details ~embedded ~env_value ~probe =
+  (* The binary's own testimony wins: the embedded hash is stamped by the
+     build rule from the checkout being compiled, while the env var is a
+     launcher claim (historically set only by CI) and the repo-head probe
+     describes the source tree next to the process, which moves
+     independently of the binary. *)
+  let binary_commit, binary_commit_source =
+    match Option.bind embedded String_util.trim_to_option with
+    | Some commit -> Some commit, Some embedded_commit_source
+    | None ->
+      (match Option.bind env_value String_util.trim_to_option with
+       | Some commit -> Some commit, Some build_env_commit_source
+       | None -> None, None)
+  in
   let repo_head_commit = probe () in
   let commit, commit_source =
     match binary_commit, repo_head_commit with
-    | Some commit, _ -> Some commit, Some build_env_commit_source
+    | Some commit, _ -> Some commit, binary_commit_source
     | None, Some commit -> Some commit, Some runtime_repo_head_source
     | None, None -> None, None
   in
   { commit
   ; commit_source
   ; binary_commit
-  ; binary_commit_source = Option.map (fun _ -> build_env_commit_source) binary_commit
+  ; binary_commit_source
   ; repo_head_commit
   ; repo_head_commit_source = Option.map (fun _ -> runtime_repo_head_source) repo_head_commit
   }
@@ -306,6 +319,7 @@ let resolved_executable_dir = Filename.dirname resolved_executable_path
     Env var check + git probe are fast and side-effect-free. *)
 let commit_resolution =
   resolve_commit_details
+    ~embedded:Build_commit_generated.commit
     ~env_value:(Env_config_core.build_git_commit_opt ())
     ~probe:probe_git_commit
 ;;

--- a/lib/build_identity.mli
+++ b/lib/build_identity.mli
@@ -69,9 +69,12 @@ val repo_root : unit -> string option
     which may intentionally point at a different workspace such as [~/me]. *)
 
 val resolve_commit :
-  env_value:string option -> probe:(unit -> string option) -> string option
-(** Resolve commit hash from env var or probe function.
-    Exposed for testing. *)
+  embedded:string option ->
+  env_value:string option ->
+  probe:(unit -> string option) ->
+  string option
+(** Resolve commit hash: build-time embedded stamp first, then the
+    launcher env var, then the probe function. Exposed for testing. *)
 
 type commit_resolution = {
   commit : string option;
@@ -83,9 +86,15 @@ type commit_resolution = {
 }
 
 val resolve_commit_details :
-  env_value:string option -> probe:(unit -> string option) -> commit_resolution
-(** Resolve the compatibility [commit] plus the source-specific binary/env
-    and runtime repo-head fields.  Exposed for testing. *)
+  embedded:string option ->
+  env_value:string option ->
+  probe:(unit -> string option) ->
+  commit_resolution
+(** Resolve the compatibility [commit] plus the source-specific binary and
+    runtime repo-head fields. [binary_commit] prefers the build-time
+    embedded stamp (source ["embedded"]) over the launcher env var; the
+    repo-head probe never populates it because the source tree next to the
+    process moves independently of the binary. Exposed for testing. *)
 
 val pick_repo_candidates :
   exe_dir:string -> cwd:string -> string list

--- a/lib/dune
+++ b/lib/dune
@@ -341,3 +341,23 @@
   (pps ppx_deriving_yojson ppx_deriving.show ppx_deriving.eq ppx_let ppx_tla))
  (instrumentation
   (backend bisect_ppx)))
+
+; Embed the git commit the binary was built from (RFC-0382 follow-up,
+; "binary unknown" root fix). The launcher-supplied MASC_BUILD_GIT_COMMIT
+; env only ever worked in CI; a copied binary (e.g. the launchd deploy at
+; <base>/bin) could never testify to its own origin. (universe) re-runs
+; the probe every build; downstream recompiles only when the hash changes.
+; Sandboxing is disabled so git can ascend to the checkout being built —
+; in a worktree that is the worktree HEAD, which is the truth we want.
+(rule
+ (targets build_commit_generated.ml)
+ (deps
+  (sandbox none)
+  (universe))
+ (action
+  (with-stdout-to
+   %{targets}
+   (run
+    bash
+    -c
+    "c=$(git rev-parse HEAD 2>/dev/null || true); if [ -n \"$c\" ]; then printf 'let commit : string option = Some \"%s\"\\n' \"$c\"; else printf 'let commit : string option = None\\n'; fi"))))

--- a/test/test_build_identity.ml
+++ b/test/test_build_identity.ml
@@ -1,9 +1,23 @@
 open Masc
 
+let test_resolve_commit_prefers_embedded () =
+  let probe_called = ref false in
+  let commit =
+    Build_identity.resolve_commit
+      ~embedded:(Some " feed0123 ")
+      ~env_value:(Some "abc12345")
+      ~probe:(fun () ->
+        probe_called := true;
+        Some "deadbeef")
+  in
+  Alcotest.(check (option string)) "embedded wins" (Some "feed0123") commit;
+  Alcotest.(check bool) "probe not called" false !probe_called
+
 let test_resolve_commit_prefers_env () =
   let probe_called = ref false in
   let commit =
     Build_identity.resolve_commit
+      ~embedded:None
       ~env_value:(Some " abc12345 ")
       ~probe:(fun () ->
         probe_called := true;
@@ -15,14 +29,34 @@ let test_resolve_commit_prefers_env () =
 let test_resolve_commit_uses_probe_when_env_missing () =
   let commit =
     Build_identity.resolve_commit
+      ~embedded:None
       ~env_value:None
       ~probe:(fun () -> Some "deadbeef")
   in
   Alcotest.(check (option string)) "probe used" (Some "deadbeef") commit
 
+let test_resolve_commit_details_prefers_embedded_binary () =
+  let details =
+    Build_identity.resolve_commit_details
+      ~embedded:(Some " feed0123 ")
+      ~env_value:(Some "abc12345")
+      ~probe:(fun () -> Some "deadbeef")
+  in
+  Alcotest.(check (option string)) "binary commit is embedded"
+    (Some "feed0123") details.binary_commit;
+  Alcotest.(check (option string)) "binary source is embedded"
+    (Some "embedded") details.binary_commit_source;
+  Alcotest.(check (option string)) "compat commit uses embedded"
+    (Some "feed0123") details.commit;
+  Alcotest.(check (option string)) "commit source is embedded"
+    (Some "embedded") details.commit_source;
+  Alcotest.(check (option string)) "repo head still surfaced"
+    (Some "deadbeef") details.repo_head_commit
+
 let test_resolve_commit_details_splits_env_and_repo_head () =
   let details =
     Build_identity.resolve_commit_details
+      ~embedded:None
       ~env_value:(Some " abc12345 ")
       ~probe:(fun () -> Some "deadbeef")
   in
@@ -42,6 +76,7 @@ let test_resolve_commit_details_splits_env_and_repo_head () =
 let test_resolve_commit_details_marks_repo_head_fallback () =
   let details =
     Build_identity.resolve_commit_details
+      ~embedded:None
       ~env_value:None
       ~probe:(fun () -> Some "deadbeef")
   in
@@ -201,8 +236,12 @@ let () =
     [
       ( "identity",
         [
-          Alcotest.test_case "resolve commit prefers env" `Quick
+          Alcotest.test_case "resolve commit prefers embedded" `Quick
+            test_resolve_commit_prefers_embedded;
+          Alcotest.test_case "resolve commit prefers env over probe" `Quick
             test_resolve_commit_prefers_env;
+          Alcotest.test_case "resolve commit details prefers embedded binary"
+            `Quick test_resolve_commit_details_prefers_embedded_binary;
           Alcotest.test_case "resolve commit falls back to probe" `Quick
             test_resolve_commit_uses_probe_when_env_missing;
           Alcotest.test_case "resolve commit details splits env and repo head"


### PR DESCRIPTION
## 무엇

대시보드 헤더가 로컬 배포에서 항상 **"v0.22.0 · binary unknown"**인 원인과 근본 수정입니다.

## 원인 (실측)

- `binary_commit`은 기동 시 env `MASC_BUILD_GIT_COMMIT`로만 채워지는데, 이 env를 설정하는 곳은 **CI뿐**입니다 (`ci.yml`, realworld acceptance 스크립트). `start-masc.sh`도 launchd 래퍼(`masc-main-start.sh`)도 설정하지 않음
- `<base>/bin`으로 복사된 배포 바이너리는 자신의 출신 커밋을 증언할 방법 자체가 없음
- health의 `commit` 필드는 `runtime_repo_head` 폴백 — 프로세스 옆 소스 트리의 HEAD라 바이너리와 독립적으로 움직이는 값이고, 대시보드는 이를 바이너리 커밋으로 (정직하게) 인정하지 않음

## 수정

- dune rule이 컴파일되는 체크아웃에서 `build_commit_generated.ml`을 생성 (`(universe)`로 매 빌드 재프로브, 해시가 실제로 바뀔 때만 재컴파일; git이 워크트리를 보도록 sandbox off)
- `resolve_commit_details` 우선순위: **embedded("embedded") > env > repo-head 프로브**. repo-head는 `binary_commit`을 절대 채우지 않음 (바이너리와 독립적인 값이므로)
- git 없는 빌드(릴리즈 타르볼)는 None → 기존 폴백 유지. 대시보드 FE는 변경 불필요 (`binary_commit` 있으면 이미 렌더)

## 테스트

- `test_build_identity`: embedded > env > probe 우선순위 3단 + 기존 케이스 시그니처 갱신 (embedded가 이기면 probe 미호출 확인 포함)

## 참조

- RFC-0382 세션의 배포 검증 중 사용자 보고로 발견. 관련 메모리: "health commit은 repo HEAD 메타데이터" — 이 PR로 그 함정 자체가 소멸

🤖 Generated with [Claude Code](https://claude.com/claude-code)