### PR TITLE
chore(ratchet): lib_dune_lines baseline 344→363 — main 상시 빨강 해소

### DIFF
--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -4,7 +4,7 @@
   "keeper_mli_missing": 13,
   "workspace_mli_missing": 2,
   "godsplit_count": 0,
-  "lib_dune_lines": 344,
+  "lib_dune_lines": 363,
   "inferred_dump_headers": 0,
   "lib_other_mli_missing": 0
 }


### PR DESCRIPTION
## 왜

#28806이 lib/dune에 build-time git commit 임베딩 `(rule)` 블록(~20줄)을 추가하면서 `lib_dune_lines`가 363이 됐는데 baseline은 344 그대로라, **main 자체가 OCaml Structure Ratchet에서 상시 실패** 상태입니다. #28806 이후 main의 게이트 런 2개는 모두 cancelled여서 무검증으로 착륙했고, 지금은 모든 열린 PR이 merge ref를 통해 이 실패를 상속받습니다 (#28797에서 발견).

## 판단

- 증가분은 `(rule)` 스탠자 — ratchet 힌트(sub-library 추출)로 해소할 수 있는 라이브러리 비대가 아닙니다.
- 다른 지표(keeper_mli_missing, godsplit_count 등)는 전부 baseline 이내.
- ratchet 계약대로 `--regenerate` + follow-up issue 페어링: lib_dune_lines 성장 추적은 #27205.

## 검증

- 이 브랜치에서 `bash scripts/ocaml-structure-ratchet.sh` → OK.
- diff는 baseline JSON의 `lib_dune_lines` 1줄.

🤖 Generated with [Claude Code](https://claude.com/claude-code)