### PR TITLE
fix(dashboard): agent 표면 배지가 다른 Keeper 의 행을 '자기 것'이라고 표시한다

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -514,6 +514,40 @@ describe('ChatTranscript', () => {
     expect(surfaceLink?.getAttribute('title')).toContain('thread_id=thread-1')
   })
 
+  it('names the agent surface without claiming the row is the viewer own', () => {
+    // A keeper broadcast projected into another keeper's transcript carries the
+    // agent surface, so the badge must not assert authorship — the speaker
+    // label is what identifies who spoke.
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({
+            id: 'projected-1',
+            role: 'user',
+            source: 'direct_user',
+            speakerName: 'keeper-code-reviewer-agent',
+            speakerAuthority: 'external',
+            text: 'fleet announcement',
+            rawText: 'fleet announcement',
+            surface: { kind: 'agent' },
+          }),
+        ]}
+        emptyText="empty"
+        variant="messenger"
+        showSourceBadge=${true}
+      />`,
+      container,
+    )
+
+    const bubble = container.querySelector('[data-chat-entry-id="projected-1"]') as HTMLElement
+    expect(bubble).not.toBeNull()
+    expect(bubble.getAttribute('data-chat-surface-kind')).toBe('agent')
+    expect(bubble.textContent).toContain('keeper-code-reviewer-agent')
+
+    expect(bubble.textContent).toContain('Agent')
+    expect(bubble.textContent).not.toContain('Self')
+  })
+
   it('renders connector speaker and route context for gate history rows', () => {
     render(
       html`<${ChatTranscript}

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -544,8 +544,12 @@ describe('ChatTranscript', () => {
     expect(bubble.getAttribute('data-chat-surface-kind')).toBe('agent')
     expect(bubble.textContent).toContain('keeper-code-reviewer-agent')
 
-    expect(bubble.textContent).toContain('Agent')
-    expect(bubble.textContent).not.toContain('Self')
+    // The badge is a span (ChatMetaChip renders an anchor only when url is a
+    // real link), so pin it by the chip attribute rather than bubble text:
+    // this fails when the badge disappears and cannot be perturbed by message
+    // content that happens to contain the same words.
+    const badge = bubble.querySelector('[title="surface=agent"]')
+    expect(badge?.getAttribute('data-chat-meta-chip')).toBe('Agent')
   })
 
   it('renders connector speaker and route context for gate history rows', () => {

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -279,9 +279,14 @@ function surfaceLink(surface?: SurfaceRef | null): ChatMetaInfo | null {
         ]),
       }
     case 'agent':
+      // Names the surface, not the author. The agent surface used to carry
+      // only the viewed keeper's own traffic, so '(Self)' held; keeper
+      // broadcasts are now projected into every other keeper's transcript
+      // with the same surface, and there '(Self)' names the wrong keeper.
+      // The speaker chip beside this badge already identifies the author.
       return {
         url: '#',
-        label: 'Agent (Self)',
+        label: 'Agent',
         icon: '🤖',
         title: 'surface=agent',
       }


### PR DESCRIPTION
## 증상

#28788 이 Keeper 브로드캐스트를 다른 모든 Keeper 의 대화 기록에 투영하면서, 그 행의 표면 배지가 `Agent (Self)` 로 찍힙니다. 다른 Keeper 가 보낸 행인데 "자기 것"이라고 말합니다.

격리 인스턴스(`:8949`, 0.23.0 / `523db18df2`) 실측 캡처 — rtprobe 창에 들어온 code-reviewer 발화:

```
🤖Agent (Self)  👤keeper-code-reviewer-agent   FANOUT-PROBE-... unmentioned fleet announcement
```

배지와 화자 칩이 서로 모순됩니다.

## 원인

```
dashboard/src/components/chat/primitives.ts:281-287
case 'agent':
  return { url: '#', label: 'Agent (Self)', icon: '🤖', title: 'surface=agent' }
```

이 라벨은 `Surface_ref.Agent` 행이 **그 Keeper 자신의** agent 트래픽뿐일 때 참이었습니다. #28788 이 같은 표면의 새 생산자(다른 Keeper 의 투영 발화)를 만들면서 소비자 쪽 전제가 깨졌습니다. 기존 타입 값에 새 생산자가 붙었는데 소비자가 옛 전제를 유지한 경우입니다.

## 수정

배지는 **표면**을 가리키고, 화자는 바로 옆 `👤` 칩이 이미 가리킵니다. 배지가 self/other 를 주장할 이유가 없으므로 주장을 뺍니다. 뷰에서 신원 비교를 다시 구현하지 않습니다.

다른 표면 라벨(`Dashboard`, `Discord Channel …`, `connector`)도 전부 표면 이름만 말합니다 — `(Self)` 만 예외였습니다.

## 검증

`dashboard/src/components/chat/primitives.test.ts` 에 테스트 1건 추가. 투영 행을 렌더하고 배지에 `Self` 가 없는지, 화자 칩이 작성자를 가리키는지 확인합니다.

수정 전 트리에서 실패하는지 되돌려 확인했습니다:

```
Expected: "Self"
Received: "사용사용자오전 09:00:00🤖Agent (Self)👤keeper-code-reviewer-agentfleet announcement"
```

파일 전체 143건 통과.

## 발견 경로

CI 가 아니라 #28788 병합 후 브라우저 실측에서 잡혔습니다. 이 라벨을 고정하는 테스트가 없었습니다.