### PR TITLE
refactor(build): commit-stamp rule을 lib/build_commit leaf로 추출 — lib_dune_lines 래칫 복원

### DIFF
--- a/lib/build_commit/dune
+++ b/lib/build_commit/dune
@@ -1,0 +1,26 @@
+(include_subdirs no)
+
+(library
+ (name masc_build_commit)
+ (public_name masc.build_commit)
+ (wrapped false))
+
+; Embed the git commit the binary was built from (RFC-0382 follow-up,
+; "binary unknown" root fix). The launcher-supplied MASC_BUILD_GIT_COMMIT
+; env only ever worked in CI; a copied binary (e.g. the launchd deploy at
+; <base>/bin) could never testify to its own origin. (universe) re-runs
+; the probe every build; downstream recompiles only when the hash changes.
+; Sandboxing is disabled so git can ascend to the checkout being built —
+; in a worktree that is the worktree HEAD, which is the truth we want.
+(rule
+ (targets build_commit_generated.ml)
+ (deps
+  (sandbox none)
+  (universe))
+ (action
+  (with-stdout-to
+   %{targets}
+   (run
+    bash
+    -c
+    "c=$(git rev-parse HEAD 2>/dev/null || true); if [ -n \"$c\" ]; then printf 'let commit : string option = Some \"%s\"\\n' \"$c\"; else printf 'let commit : string option = None\\n'; fi"))))

--- a/lib/dune
+++ b/lib/dune
@@ -25,6 +25,7 @@
   str
   re.pcre
   masc.markup_document
+  masc.build_commit
   mirage-crypto
   mirage-crypto-ec
   mirage-crypto-rng
@@ -341,23 +342,3 @@
   (pps ppx_deriving_yojson ppx_deriving.show ppx_deriving.eq ppx_let ppx_tla))
  (instrumentation
   (backend bisect_ppx)))
-
-; Embed the git commit the binary was built from (RFC-0382 follow-up,
-; "binary unknown" root fix). The launcher-supplied MASC_BUILD_GIT_COMMIT
-; env only ever worked in CI; a copied binary (e.g. the launchd deploy at
-; <base>/bin) could never testify to its own origin. (universe) re-runs
-; the probe every build; downstream recompiles only when the hash changes.
-; Sandboxing is disabled so git can ascend to the checkout being built —
-; in a worktree that is the worktree HEAD, which is the truth we want.
-(rule
- (targets build_commit_generated.ml)
- (deps
-  (sandbox none)
-  (universe))
- (action
-  (with-stdout-to
-   %{targets}
-   (run
-    bash
-    -c
-    "c=$(git rev-parse HEAD 2>/dev/null || true); if [ -n \"$c\" ]; then printf 'let commit : string option = Some \"%s\"\\n' \"$c\"; else printf 'let commit : string option = None\\n'; fi"))))


### PR DESCRIPTION
## 문제
#28806의 rule 20줄이 lib/dune을 363줄로 만들어 \`lib_dune_lines\` 래칫(baseline 344)을 처음으로 넘겼습니다. 이후 lib 표면을 건드리는 모든 PR에서 \`OCaml Structure Ratchet\`이 FAIL — main 상시 빨강의 원인입니다 (#28806 적대적 리뷰 finding #1, CI job 95105210489 로그 실측).

## 처방
래칫 에러 메시지가 처방하는 그대로: rule + 생성 모듈을 \`lib/build_commit/\` leaf sub-library로 추출.
- \`masc_build_commit\`은 repo 컨벤션대로 \`(wrapped false)\` — \`Build_identity\`의 기존 \`Build_commit_generated\` 참조가 무변경으로 해소됩니다.
- lib/dune 363 → **344줄** (baseline 복원). baseline.json 무변경 — bump PR #28812는 불필요해져 홀드 요청 코멘트를 남겼습니다.
- 리뷰 finding #4(private_modules 미등록)도 라이브러리 경계 명시로 자연 해소.

## 검증 (로컬 실행)
- \`bash scripts/ocaml-structure-ratchet.sh\` → \`OCaml structure ratchet: OK\`
- \`dune build lib/build_commit/build_commit_generated.ml\` → 산출 스탬프가 worktree HEAD(523db18d)와 정확히 일치
- \`dune exec test/test_build_identity.exe\` → 16/16 OK
- 이 PR은 lib_deps 표면을 건드리므로 래칫 job이 실제로 돌아 CI에서도 재검증됩니다.

## 남은 미검증 / 후속
- 리뷰 finding #3(env 경로 커버리지 공동화)·#5는 #28815로 분리 — env 경로 삭제 방향.

🤖 Generated with [Claude Code](https://claude.com/claude-code)