### PR TITLE
fix(keeper): 승인된 Gate resolution이 큐 순서에 굶지 않게 배달한다 (#28809)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1092,6 +1092,7 @@ jobs:
             @test/runtest-test_keeper_contract_classifier_pure \
             @test/runtest-test_keeper_conditions_wire_parity \
             @test/runtest-test_keeper_fsm_guard_actions \
+            @test/runtest-test_keeper_hitl_replay_delivery \
             @test/runtest-test_keeper_invariant \
             @test/runtest-test_keeper_invocation_contract_hints \
             @test/runtest-test_keeper_path_ssot \

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -719,12 +719,38 @@ let run_keepalive_unified_turn
           (* Preserve the typed resolution as input to the originating
              Keeper's external-effect Gate. It is not an AGENT_CORE approval. *)
           let hitl_resolution =
-            List.find_map
-              (fun (stim : Keeper_event_queue.stimulus) ->
-                match stim.Keeper_event_queue.payload with
-                | Keeper_event_queue.Hitl_resolved resolution -> Some resolution
-                | _ -> None)
-              !consumed_stimuli
+            match
+              List.find_map
+                (fun (stim : Keeper_event_queue.stimulus) ->
+                  match stim.Keeper_event_queue.payload with
+                  | Keeper_event_queue.Hitl_resolved resolution -> Some resolution
+                  | _ -> None)
+                !consumed_stimuli
+            with
+            | Some resolution -> Some resolution
+            | None ->
+              (* #28809: a ready resolution may be queued behind the stimulus
+                 that woke this turn (e.g. a redelivered workspace message
+                 whose own earlier turn deferred on this very approval).
+                 Project the durable resolution into this turn instead of
+                 waiting for its queue position; the untouched queue entry is
+                 retired as a spent grant by [reconcile_spent_selection]
+                 without costing a turn. *)
+              (match
+                 Stimulus_intake.ready_hitl_resolution_peek
+                   ~base_path:ctx.config.base_path
+                   ~keeper_name:meta_after_triage.name
+               with
+               | None -> None
+               | Some resolution ->
+                 Log.Keeper.info
+                   "hitl resolution projected from pending queue approval=%s \
+                    decision=%s (keeper=%s)"
+                   resolution.Keeper_event_queue.approval_id
+                   (Keeper_event_queue.hitl_resolution_decision_to_string
+                      resolution.Keeper_event_queue.decision)
+                   meta_after_triage.name;
+                 Some resolution)
           in
           (* The event intake is the exact turn input. Keep its attribution in
              the existing wake record even when the cadence, rather than a

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -406,6 +406,40 @@ let stimulus_ready_for_intake ~base_path (stimulus : Keeper_event_queue.stimulus
     true
 ;;
 
+(* #28809: a ready [Hitl_resolved] may sit behind the stimulus that woke this
+   turn — typically a redelivered workspace message whose own earlier turn
+   deferred on that very approval. The resolution is durable truth in the
+   approval journal, not queue-ordered content, so a turn may project it as
+   cycle context without admitting it (RFC-0020 §3 Rule 4 counts admitted
+   stimuli; the queue entry is untouched here). After the projected replay
+   spends the grant, [reconcile_spent_selection] retires the still-queued
+   entry without costing a turn. *)
+let ready_hitl_resolution_peek ~base_path ~keeper_name =
+  match Keeper_registry_event_queue.snapshot_result ~base_path keeper_name with
+  | Error _ -> None
+  | Ok pending ->
+    List.find_map
+      (fun (stimulus : Keeper_event_queue.stimulus) ->
+         match stimulus.payload with
+         | Keeper_event_queue.Hitl_resolved resolution ->
+           if stimulus_ready_for_intake ~base_path stimulus
+           then Some resolution
+           else None
+         | Keeper_event_queue.Board_signal _
+         | Keeper_event_queue.Board_attention _
+         | Keeper_event_queue.Bootstrap
+         | Keeper_event_queue.Fusion_completed _
+         | Keeper_event_queue.Schedule_due _
+         | Keeper_event_queue.Connector_attention _
+         | Keeper_event_queue.Manual_compaction_requested
+         | Keeper_event_queue.Goal_assigned _
+         | Keeper_event_queue.Goal_reconciliation_ready _
+         | Keeper_event_queue.Completion_authority_rejected _
+         | Keeper_event_queue.Task_cancelled _
+         | Keeper_event_queue.Workspace_message _ -> None)
+      (Keeper_event_queue.to_list pending)
+;;
+
 (* A selection can be ready to intake and still have nothing left for a turn to
    do, because the work it refers to settled elsewhere. Delivering one costs a
    full turn and leaves the entry at the queue head, so a turn that checkpoints

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.mli
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.mli
@@ -117,6 +117,17 @@ val consume_single_heartbeat_stimulus
   -> Keeper_event_queue.stimulus
   -> stimulus_intake_result
 
+(** [ready_hitl_resolution_peek ~base_path ~keeper_name] returns the first
+    queued [Hitl_resolved] whose approval has left the pending map, without
+    consuming the queue entry (#28809). A turn woken by a different stimulus
+    projects this durable resolution as cycle context so the RFC-0356 host
+    replay is not starved behind the queue position; the untouched entry is
+    later retired by [reconcile_spent_selection] once its grant is spent. *)
+val ready_hitl_resolution_peek
+  :  base_path:string
+  -> keeper_name:string
+  -> Keeper_event_queue.hitl_resolution option
+
 type spent_selection_reconciliation =
   | Selection_actionable
   | Spent_grant_replay_acknowledged

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -257,23 +257,125 @@ let manual_compaction_yield_request ~wake ~base_path ~keeper_name =
     Ok request
 ;;
 
+(* #28809: an approved Gate resolution whose one-shot grant is still unspent
+   is not an ordinary queued successor — it is the durable continuation of an
+   already-deferred external effect, and the in-flight source may itself be
+   the checkpoint that effect belongs to. Waiting for the source terminal can
+   therefore starve the replay behind an arbitrarily long run. Deliverability
+   is decided by the injected predicate; the wake payloads need no
+   self-exclusion here because a resolution threaded into the current turn
+   has its grant consumed at tool-bundle build, before this boundary probe
+   can run, so it already fails the unspent check. *)
+let hitl_replay_preemption_request ~resolution_deliverable ~now pending =
+  let stimuli = Keeper_event_queue.to_list pending in
+  match
+    List.find_opt
+      (fun (stimulus : Keeper_event_queue.stimulus) ->
+         match stimulus.payload with
+         | Keeper_event_queue.Hitl_resolved resolution ->
+           resolution_deliverable resolution
+         | Keeper_event_queue.Board_signal _
+         | Keeper_event_queue.Board_attention _
+         | Keeper_event_queue.Bootstrap
+         | Keeper_event_queue.Fusion_completed _
+         | Keeper_event_queue.Schedule_due _
+         | Keeper_event_queue.Connector_attention _
+         | Keeper_event_queue.Manual_compaction_requested
+         | Keeper_event_queue.Goal_assigned _
+         | Keeper_event_queue.Goal_reconciliation_ready _
+         | Keeper_event_queue.Completion_authority_rejected _
+         | Keeper_event_queue.Task_cancelled _
+         | Keeper_event_queue.Workspace_message _ -> false)
+      stimuli
+  with
+  | None -> None
+  | Some selected ->
+    let summary = Keeper_agent_run.durable_stimulus_summary ~now pending in
+    Some
+      Keeper_agent_run.
+        { reason =
+            Durable_stimulus_waiting
+              { summary with
+                head = Some selected
+              ; head_age_sec = Float.max 0. (now -. selected.arrived_at)
+              }
+        }
+;;
+
+(* Deliverable means the approval has left the pending map (the decision is
+   durable) and its grant is still unspent. A rejected resolution carries no
+   grant to starve: it reaches the model through ordinary selection or the
+   turn-start projection, so it never preempts a run. *)
+let approved_resolution_deliverable
+      ~base_path
+      (resolution : Keeper_event_queue.hitl_resolution)
+  =
+  match resolution.decision with
+  | Keeper_event_queue.Hitl_rejected _ -> false
+  | Keeper_event_queue.Hitl_approved ->
+    (match
+       Keeper_approval_queue.get_pending_entry_for_workspace
+         ~base_path
+         ~id:resolution.approval_id
+     with
+     | Ok (Some _) | Error _ -> false
+     | Ok None ->
+       (match
+          Keeper_approval_queue.approved_resolution_state
+            ~base_path
+            ~id:resolution.approval_id
+        with
+        | Ok Keeper_approval_queue.Resolution_unconsumed -> true
+        | Ok Keeper_approval_queue.Resolution_consumed | Error _ -> false))
+;;
+
+let hitl_replay_yield_request ~base_path ~keeper_name =
+  match Keeper_registry_event_queue.snapshot_result ~base_path keeper_name with
+  | Error _ as error -> error
+  | Ok pending ->
+    let request =
+      hitl_replay_preemption_request
+        ~resolution_deliverable:(approved_resolution_deliverable ~base_path)
+        ~now:(Time_compat.now ())
+        pending
+    in
+    Option.iter
+      (fun (request : Keeper_agent_run.autonomous_yield_request) ->
+         match request.reason with
+         | Keeper_agent_run.Operation_queued -> ()
+         | Keeper_agent_run.Durable_stimulus_waiting summary ->
+           Log.Keeper.info
+             ~keeper_name
+             "autonomous source turn yields to an approved Gate resolution: %s"
+             (Keeper_agent_run.durable_stimulus_summary_to_string summary))
+      request;
+    Ok request
+;;
+
 let autonomous_yield_request_for_wake ~wake ~base_path ~keeper_name =
   match wake with
   (* A nonempty [Woken] is the event queue input already selected for this
-     turn. It may yield for chat delivery. An explicit owner-lane manual
-     compaction is the sole successor allowed to preempt at a persisted
-     post-tool boundary; the selected source remains pending and resumes after
-     compaction. Other queued successors still wait for the source terminal. *)
+     turn. It may yield for chat delivery. Two successors may preempt at a
+     persisted post-tool boundary: an explicit owner-lane manual compaction,
+     and an approved Gate resolution whose grant is still unspent (#28809 —
+     the source may be the very checkpoint that resolution continues). The
+     selected source remains pending and resumes after the preemptor. Other
+     queued successors still wait for the source terminal. *)
   | Keeper_registry.Woken (_ :: _) ->
     fun () ->
       (match chat_yield_request ~base_path ~keeper_name with
        | Error _ as error -> error
        | Ok (Some _) as request -> request
        | Ok None ->
-         manual_compaction_yield_request
-           ~wake
-           ~base_path
-           ~keeper_name)
+         (match
+            manual_compaction_yield_request
+              ~wake
+              ~base_path
+              ~keeper_name
+          with
+          | Error _ as error -> error
+          | Ok (Some _) as request -> request
+          | Ok None -> hitl_replay_yield_request ~base_path ~keeper_name))
   | Keeper_registry.Proactive_tick | Keeper_registry.Woken [] ->
     fun () -> autonomous_yield_request ~base_path ~keeper_name
   (* Not reachable, same reason as in [manual_compaction_preemption_request]:

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -180,6 +180,25 @@ val manual_compaction_preemption_request
     pending. The summary names that exact runtime stimulus as the next
     source; a turn already consuming manual compaction never yields to itself. *)
 
+val hitl_replay_preemption_request
+  :  resolution_deliverable:(Keeper_event_queue.hitl_resolution -> bool)
+  -> now:float
+  -> Keeper_event_queue.t
+  -> Keeper_agent_run.autonomous_yield_request option
+(** Pure post-tool boundary decision (#28809): yield the in-flight source when
+    a queued [Hitl_resolved] passes [resolution_deliverable]. The runtime
+    predicate accepts only an approved resolution whose one-shot grant is
+    still unspent, so a resolution already threaded into the current turn
+    (grant consumed at tool-bundle build) never preempts its own run. *)
+
+val hitl_replay_yield_request
+  :  base_path:string
+  -> keeper_name:string
+  -> (Keeper_agent_run.autonomous_yield_request option, string) result
+(** [hitl_replay_preemption_request] over the keeper's durable queue snapshot
+    with the runtime deliverability predicate (approval left the pending map,
+    grant durably unspent). *)
+
 
 val run_keeper_cycle
   :  before_dispatch_authority:(unit -> (unit, string) result)

--- a/test/dune
+++ b/test/dune
@@ -799,6 +799,15 @@
  (modules test_keeper_manual_compaction_preemption)
  (libraries masc_test_deps))
 
+; #28809: an approved Gate resolution reaches a turn woken by a different
+; stimulus (turn-start projection) and preempts an in-flight source while
+; its one-shot grant is unspent (post-tool boundary yield).
+
+(test
+ (name test_keeper_hitl_replay_delivery)
+ (modules test_keeper_hitl_replay_delivery)
+ (libraries masc_test_deps))
+
 ; Fusion AGENT_CORE failure-detail tests need Fusion_types constructors from
 ; masc.fusion_core, which is intentionally not re-exported via masc.
 

--- a/test/test_keeper_hitl_replay_delivery.ml
+++ b/test/test_keeper_hitl_replay_delivery.ml
@@ -1,0 +1,326 @@
+(* #28809: an approved Gate resolution must reach a turn even when the turn
+   was woken by a different stimulus, and must be able to preempt an in-flight
+   source run while its one-shot grant is unspent. Covers the turn-start
+   projection ([ready_hitl_resolution_peek]) and the post-tool boundary
+   preemption ([hitl_replay_preemption_request] / [hitl_replay_yield_request]). *)
+open Alcotest
+open Masc
+module Q = Keeper_event_queue
+
+let () = Mirage_crypto_rng_unix.use_default ()
+
+let temp_dir () =
+  let path = Filename.temp_file "hitl_replay_delivery_test" "" in
+  Sys.remove path;
+  Unix.mkdir path 0o755;
+  path
+;;
+
+let rm_rf dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path |> Array.iter (fun entry -> rm (Filename.concat path entry));
+        Unix.rmdir path
+      end
+      else Sys.remove path
+  in
+  try rm dir with
+  | _ -> ()
+;;
+
+let with_workspace f =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = temp_dir () in
+  Eio.Switch.run
+  @@ fun sw ->
+  ignore
+    (Domain_pool.create ~sw ~domain_count:1 (Eio.Stdenv.domain_mgr env));
+  Eio.Switch.on_release sw (fun () -> rm_rf dir);
+  Unix.putenv "MASC_BASE_PATH" dir;
+  Board.reset_global_for_test ();
+  Board_dispatch.reset_for_test ();
+  Board_dispatch.init_jsonl ();
+  let config = Workspace.default_config dir in
+  ignore (Workspace.init config ~agent_name:(Some "test"));
+  (match
+     Keeper_owner_registry.install_from_store
+       ~sw
+       ~operation_runner:None
+       ~on_turn_slot_released:None
+       config
+   with
+   | Ok _ -> ()
+   | Error error -> fail (Keeper_owner_registry.install_error_to_string error));
+  f config
+;;
+
+let unrouted = Keeper_continuation_channel.Unrouted { reason = "test" }
+
+(* Submit + approve one grant. Resolving an approval for a keeper with no
+   live lane durably enqueues its [Hitl_resolved] wake, which is exactly the
+   queue state the projection and preemption read. *)
+let approved_grant_fixture ~base_path ~keeper_name ~input =
+  (match Keeper_approval_queue.install_persistence ~base_path with
+   | Ok _ -> ()
+   | Error error -> fail (Keeper_approval_queue.install_error_to_string error));
+  let approval_id =
+    match
+      Keeper_approval_queue.submit_pending
+        ~keeper_name
+        ~tool_name:"external-effect"
+        ~input
+        ~base_path
+        ()
+    with
+    | Ok submission -> submission.approval_id
+    | Error error -> fail (Keeper_approval_queue.storage_error_to_string error)
+  in
+  (match
+     Keeper_approval_queue.resolve_with_policy
+       ~base_path
+       ~id:approval_id
+       ~decision:Keeper_approval_queue_rules_types.Decision.Approve
+       ()
+   with
+   | Ok _ -> ()
+   | Error error -> fail (Keeper_approval_queue.resolve_error_to_string error));
+  approval_id
+;;
+
+let queue_length ~base_path ~keeper_name =
+  match Keeper_registry_event_queue.snapshot_result ~base_path keeper_name with
+  | Ok pending -> Q.length pending
+  | Error message -> fail message
+;;
+
+(* --- pure post-tool boundary decision --------------------------------- *)
+
+let stimulus ~post_id ~urgency ~arrived_at ~payload : Q.stimulus =
+  { post_id; urgency; arrived_at; payload }
+;;
+
+let queue_of stimuli = List.fold_left Q.enqueue Q.empty stimuli
+
+let hitl_stimulus ~arrived_at ~approval_id =
+  let resolution : Q.hitl_resolution =
+    { approval_id; decision = Q.Hitl_approved; channel = unrouted }
+  in
+  stimulus
+    ~post_id:(Q.hitl_resolution_post_id resolution)
+    ~urgency:Q.Immediate
+    ~arrived_at
+    ~payload:(Q.Hitl_resolved resolution)
+;;
+
+let test_deliverable_resolution_preempts_source () =
+  let source =
+    stimulus ~post_id:"source" ~urgency:Q.Normal ~arrived_at:900. ~payload:Q.Bootstrap
+  in
+  let hitl = hitl_stimulus ~arrived_at:990. ~approval_id:"appr-preempt" in
+  let request =
+    Keeper_unified_turn.hitl_replay_preemption_request
+      ~resolution_deliverable:(fun _ -> true)
+      ~now:1000.
+      (queue_of [ source; hitl ])
+  in
+  match request with
+  | Some
+      { Keeper_agent_run.reason = Keeper_agent_run.Durable_stimulus_waiting summary } ->
+    check int "both durable stimuli remain visible" 2 summary.pending_count;
+    (match summary.head with
+     | Some selected ->
+       check string
+         "yield names the resolved approval as the next source"
+         (Q.hitl_resolution_post_id
+            { approval_id = "appr-preempt"
+            ; decision = Q.Hitl_approved
+            ; channel = unrouted
+            })
+         selected.post_id
+     | None -> fail "hitl preemption lost its selected source");
+    check (float 0.001) "selected-source age is exact" 10. summary.head_age_sec
+  | Some { reason = Keeper_agent_run.Operation_queued } ->
+    fail "hitl preemption was mislabeled as chat"
+  | None -> fail "deliverable resolution did not preempt the in-flight source"
+;;
+
+let test_undeliverable_resolution_never_preempts () =
+  let hitl = hitl_stimulus ~arrived_at:990. ~approval_id:"appr-spent" in
+  check bool
+    "spent or unready resolution keeps the source running"
+    true
+    (Option.is_none
+       (Keeper_unified_turn.hitl_replay_preemption_request
+          ~resolution_deliverable:(fun _ -> false)
+          ~now:1000.
+          (queue_of [ hitl ])))
+;;
+
+let test_queue_without_resolution_never_preempts () =
+  let source =
+    stimulus ~post_id:"source" ~urgency:Q.Normal ~arrived_at:900. ~payload:Q.Bootstrap
+  in
+  check bool
+    "no queued resolution, no yield"
+    true
+    (Option.is_none
+       (Keeper_unified_turn.hitl_replay_preemption_request
+          ~resolution_deliverable:(fun _ -> true)
+          ~now:1000.
+          (queue_of [ source ])))
+;;
+
+(* --- durable deliverability -------------------------------------------- *)
+
+let test_yield_request_tracks_grant_consumption () =
+  with_workspace
+  @@ fun config ->
+  let base_path = config.Workspace_utils.base_path in
+  let keeper_name = "hitl-preempt-keeper" in
+  let input = `Assoc [ "target", `String "hitl-preempt" ] in
+  let approval_id = approved_grant_fixture ~base_path ~keeper_name ~input in
+  (match Keeper_unified_turn.hitl_replay_yield_request ~base_path ~keeper_name with
+   | Ok (Some { Keeper_agent_run.reason = Keeper_agent_run.Durable_stimulus_waiting _ })
+     -> ()
+   | Ok (Some { reason = Keeper_agent_run.Operation_queued }) ->
+     fail "unspent grant was mislabeled as chat"
+   | Ok None -> fail "unspent approved resolution did not request a yield"
+   | Error message -> fail message);
+  (match
+     Keeper_approval_queue.consume_approved_resolution
+       ~base_path
+       ~id:approval_id
+       ~keeper_name
+       ~tool_name:"external-effect"
+       ~input
+   with
+   | Ok (Keeper_approval_queue.Consumption_committed _) -> ()
+   | Ok Keeper_approval_queue.Consumption_already_committed ->
+     fail "grant was already consumed before the test consumed it"
+   | Ok Keeper_approval_queue.Consumption_not_matching ->
+     fail "exact grant did not match its own request"
+   | Error error -> fail (Keeper_approval_queue.grant_error_to_string error));
+  match Keeper_unified_turn.hitl_replay_yield_request ~base_path ~keeper_name with
+  | Ok None -> ()
+  | Ok (Some _) -> fail "spent grant preempted the source again"
+  | Error message -> fail message
+;;
+
+(* --- turn-start projection --------------------------------------------- *)
+
+let test_peek_projects_ready_resolution_without_consuming () =
+  with_workspace
+  @@ fun config ->
+  let base_path = config.Workspace_utils.base_path in
+  let keeper_name = "hitl-peek-keeper" in
+  let input = `Assoc [ "target", `String "hitl-peek" ] in
+  let approval_id = approved_grant_fixture ~base_path ~keeper_name ~input in
+  let before = queue_length ~base_path ~keeper_name in
+  check int "resolution queued exactly one replay" 1 before;
+  (match
+     Keeper_heartbeat_stimulus_intake.ready_hitl_resolution_peek
+       ~base_path
+       ~keeper_name
+   with
+   | Some (resolution : Q.hitl_resolution) ->
+     check string "peek returns the resolved approval" approval_id
+       resolution.approval_id
+   | None -> fail "ready resolution was not projected");
+  check int "peek admits nothing from the queue" before
+    (queue_length ~base_path ~keeper_name)
+;;
+
+let test_peek_skips_resolution_still_pending () =
+  with_workspace
+  @@ fun config ->
+  let base_path = config.Workspace_utils.base_path in
+  let keeper_name = "hitl-unready-keeper" in
+  (match Keeper_approval_queue.install_persistence ~base_path with
+   | Ok _ -> ()
+   | Error error -> fail (Keeper_approval_queue.install_error_to_string error));
+  let approval_id =
+    match
+      Keeper_approval_queue.submit_pending
+        ~keeper_name
+        ~tool_name:"external-effect"
+        ~input:(`Assoc [ "target", `String "hitl-unready" ])
+        ~base_path
+        ()
+    with
+    | Ok submission -> submission.approval_id
+    | Error error -> fail (Keeper_approval_queue.storage_error_to_string error)
+  in
+  (* The approval is still pending, so a queued resolution event for it is
+     not ready and must not be projected. *)
+  (match
+     Keeper_registry_event_queue.enqueue_hitl_resolution_durable_result
+       ~base_path
+       ~keeper_name
+       ~approval_id
+       ~decision:Q.Hitl_approved
+       ~channel:unrouted
+   with
+   | Ok () -> ()
+   | Error message -> fail message);
+  check bool
+    "pending approval is not projected"
+    true
+    (Option.is_none
+       (Keeper_heartbeat_stimulus_intake.ready_hitl_resolution_peek
+          ~base_path
+          ~keeper_name))
+;;
+
+let test_peek_none_on_empty_queue () =
+  with_workspace
+  @@ fun config ->
+  let base_path = config.Workspace_utils.base_path in
+  check bool
+    "empty queue projects nothing"
+    true
+    (Option.is_none
+       (Keeper_heartbeat_stimulus_intake.ready_hitl_resolution_peek
+          ~base_path
+          ~keeper_name:"hitl-empty-keeper"))
+;;
+
+let () =
+  run
+    "keeper hitl replay delivery"
+    [ ( "post-tool boundary preemption"
+      , [ test_case
+            "deliverable resolution preempts the in-flight source"
+            `Quick
+            test_deliverable_resolution_preempts_source
+        ; test_case
+            "undeliverable resolution never preempts"
+            `Quick
+            test_undeliverable_resolution_never_preempts
+        ; test_case
+            "queue without a resolution never preempts"
+            `Quick
+            test_queue_without_resolution_never_preempts
+        ; test_case
+            "yield request tracks durable grant consumption"
+            `Quick
+            test_yield_request_tracks_grant_consumption
+        ] )
+    ; ( "turn-start projection"
+      , [ test_case
+            "projects the ready resolution without consuming the queue"
+            `Quick
+            test_peek_projects_ready_resolution_without_consuming
+        ; test_case
+            "skips a resolution whose approval is still pending"
+            `Quick
+            test_peek_skips_resolution_still_pending
+        ; test_case
+            "projects nothing from an empty queue"
+            `Quick
+            test_peek_none_on_empty_queue
+        ] )
+    ]
+;;


### PR DESCRIPTION
Closes #28809.

## 문제

승인된 Gate resolution이 keeper에게 영영 배달되지 않을 수 있다. :8949 격리 인스턴스 실측(#28809)의 시퀀스:

1. mention 턴이 WebSearch에서 유예(deferred)되며 checkpoint 저장. 그 턴이 소비하던 workspace message 이벤트는 미커밋으로 남는다.
2. auto-judge approve가 커밋되는 같은 초에 keeper가 깨어나는데, 스케줄 사유는 재배달된 `workspace_message_pending`뿐이다.
3. `hitl_resolution`은 "이번 턴이 소비한 자극"에서만 추출되므로(`keeper_heartbeat_loop.ml`) None으로 checkpoint가 재개되고, RFC-0356 host replay(`keeper_tools_agent_core_bundle.ml`)는 발화 조건을 잃는다.
4. 재개된 런은 유예 통지만 보고 방황하며(`turn_limit=unlimited`), single-flight를 점유해 큐에 커밋된 `Hitl_resolved` 이벤트가 굶는다 — 실측 20분+, 인스턴스 재기동 후에야 배달·replay 성공 (`gate replay approval=… applied … output_bytes=31614`).

`Woken (_::_)` 런의 협조적 양보는 chat과 manual compaction만 허용했고, "다른 큐 후속은 소스 터미널까지 대기"가 설계였다. 그러나 승인 resolution은 일반 후속이 아니라 **소스 턴 자신이 checkpoint로 기다리는 continuation**일 수 있다.

## 수정 (배달 2경로, 큐 재정렬 없음·admission 불변)

1. **턴 시작 projection** — 소비 자극에 resolution이 없으면 pending 큐에서 ready 상태 `Hitl_resolved`를 **소비 없이** cycle context로 투영 (`ready_hitl_resolution_peek`). RFC-0020 §3 Rule 4는 admit 규칙이고 이 투영은 admit이 아니다. replay가 grant를 소비하면 남은 큐 엔트리는 기존 `reconcile_spent_selection`이 턴 없이 정리한다.
2. **post-tool boundary 선점** — grant가 durable하게 미소비인 **approved** resolution은 진행 중인 소스 런을 양보시킨다 (`hitl_replay_preemption_request`). 현재 턴에 투영된 resolution은 tool-bundle 빌드 시점에 grant가 소비되므로 자기 런을 선점하지 못한다. rejected는 grant가 없어 선점하지 않는다(일반 선택/투영으로 배달).

## 검증

- 신규 스위트 `test_keeper_hitl_replay_delivery` (CI 배선 완료):
  - 순수 선점 판정 3케이스 (deliverable/undeliverable/무-resolution)
  - durable 소비 게이팅: 같은 approval이 소비 전 Some → 소비 후 None (`hitl_replay_yield_request` 실저장소)
  - peek: ready resolution 투영 + **큐 길이 불변**(비소비 증명), pending 승인은 투영 안 함, 빈 큐 None
- `scripts/audit-ci-test-targets.sh` OK (선언+배선 동반이라 unwired 불변)
- 로컬 빌드는 세션 계약상 실행하지 않음 — CI가 컴파일·스위트를 검증

## 남은 미검증

- `keeper_heartbeat_loop.ml`의 fallback 배선 자체는 거대 클로저 내부라 단위 테스트가 없다. peek 함수와 배선 diff 리뷰로 커버.
- 라이브 재현(유예→approve→즉시 배달)은 격리 인스턴스에서 병합 후 재실측 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
