### PR TITLE
docs(web): RFC-0383 acceptance 라이브 실측 — 1 PASS / 3 keeper-lane FAIL 기록

### DIFF
--- a/docs/evidence/web-artifact-corpus-acceptance-2026-08-16.md
+++ b/docs/evidence/web-artifact-corpus-acceptance-2026-08-16.md
@@ -1,0 +1,50 @@
+# RFC-0383 코퍼스 acceptance 라이브 실측 (2026-08-16)
+
+- **Evidence**: :8949 격리 인스턴스 (`/private/tmp/.../scratchpad/mascroot`, masc-e8 세션 소유), 실측 전반부 commit `11401927ef` → 재기동 후 `523db18df2` (0.23.0). 로그 `<base>/.masc/logs/system_log_2026-08-16.jsonl`, trace `trace-1786546240916-00000`.
+- **Timestamp**: 2026-08-16T02:31Z ~ 03:32Z
+- **Confidence**: High (서버 로그 + 파일시스템 + keeper trace 3중 교차)
+- **Delta**: acceptance 1은 keeper 턴에서 라이브 검증 완료. acceptance 3은 keeper 레인에서 2단계 모두 해석 불가로 판명(#28820) — RFC-0383 문서의 소비 계약은 agent 레인만 성립. 부산물로 HITL resolution 배달 기아 결함 발견·수정(#28809 → PR #28818).
+
+## 1. acceptance 1 — 오프로드마다 index 행 (라이브 PASS)
+
+자극: `@rtprobe WebSearch("OCaml 5.5 effect handlers tutorial", includeContent=true, limit=5)` (02:41:13Z 발화, wmsg-bafc21e6).
+
+경로가 특이했다: 호출은 auto_judge 게이트에 유예 → 승인 → **배달 기아(#28809, 아래 §3)** → 인스턴스 재기동(마침 #28788 반영 재기동) 후 pending `Hitl_resolved`가 배달되며 RFC-0356 host replay가 실행:
+
+```
+03:12:52Z turn entry: hitl resolution delivered approval=appr_c055a52f-… decision=approve (keeper=rtprobe)
+03:13:01Z gate replay approval=appr_c055a52f-… applied operation=network_read journal=recorded output_bytes=31614 output_sha256=31d6b2b0…
+```
+
+그 network_read 안의 includeContent 절단 경로가 코퍼스를 만들었다 (03:12:54~13:01Z):
+
+- `<base>/.masc/artifacts/web-fetch/index.jsonl` — **5행**, 전부 `masc.web_artifact.v1`, sha256=파일명, title/bytes/fetched_at 채워짐.
+- 본문 4파일 (28,975 / 36,909 / 6,757 / 14,309 bytes).
+- **내용 주소 dedup 관측**: `github.com/ocaml-multicore/ocaml-effects-tutorial`와 그 `blob/master/README.md` 두 URL이 같은 sha `2dd3ef61…` 한 파일을 가리키는 index 2행 — 설계대로 파일은 진실, index는 projection.
+
+## 2. acceptance 3 — 웹 왕복 없는 재질의 (keeper 레인 FAIL → #28820)
+
+자극: `@rtprobe` (1) `Grep(pattern=ocaml.org, path=.masc/artifacts/web-fetch/index.jsonl)` (2) `keeper_artifact_read(sha256=f2c0826c…, offset=0, max_bytes=600)`.
+
+| 단계 | 결과 | 근거 |
+|---|---|---|
+| index Grep | **실패** — sandbox cwd 이중 결합 `<base>/.masc/playground/rtprobe/.masc/artifacts/...`, rg exit 2 | trace tool_result (`ok:false, via:host`) |
+| artifact_read | 지시한 web-fetch sha 대신 컨텍스트의 replay blob `31d6b2b0…`로 **대체 호출** (out_len=20775, ok). 지시 sha `f2c0826c…`는 `tool_blobs/`에 부재 (`f2` shard 없음) → 호출했다면 "artifact does not exist" | 로그 tool_call + `ls tool_blobs/` |
+
+정적 교차: `keeper_artifact_read.ml`은 `Tool_blob_store`(`.masc/tool_blobs/`)만 resolve, 오프로드는 `.masc/artifacts/web-fetch/`에 기록 — 저장소 분리. 상세와 수정 방향(본문 저장 단일화 + discovery 표면 결정)은 #28820.
+
+**agent 레인**은 두 단계 모두 성립한다(임의 경로 Grep 가능 + 운영자가 파일 직접 읽기) — RFC 문서의 계약 문구를 keeper/agent 레인으로 분리 정정해야 한다.
+
+## 3. 부산물 — HITL resolution 배달 기아 (#28809, PR #28818)
+
+02:41:51Z approve 커밋 직후 keeper가 깨어났으나 wake 사유는 재배달 workspace message뿐 → `hitl_resolution=None`으로 checkpoint 재개 → replay 미발화 → deepseek-v4-flash가 `keeper_surface_read` ~660회 루프로 20분+ 방황(turn_limit=unlimited, single-flight 점유) → 큐의 `Hitl_resolved` 기아. 재기동이 우연히 배달을 복구했고(§1), 그 배달-즉시-replay 성공이 "배달만이 결여였다"는 근본 원인 판정을 실증했다. 수정은 PR #28818 (턴 시작 projection + post-tool boundary 선점).
+
+## 재현 명령 (요지)
+
+```bash
+# 자극 (rtprobe 토큰으로)
+masc_broadcast '{"agent_name":"claude","message":"@rtprobe WebSearch 도구를 호출해 주세요. 인자: query=\"…\", includeContent=true, limit=5. …"}'
+# 관측
+rg 'gate replay approval|hitl resolution delivered' <base>/.masc/logs/system_log_2026-08-16.jsonl
+cat <base>/.masc/artifacts/web-fetch/index.jsonl
+```

--- a/reports/web-tools-bench-2026-08-15.html
+++ b/reports/web-tools-bench-2026-08-15.html
@@ -251,12 +251,40 @@ hit@1 <strong>5/6</strong>, 옛 유일 경로(SearXNG)는 부분 회복 상태�
 정확히 FAIL로 잡았고, 마커 주석 대신 <strong>시각 주입</strong>(handle의 start_time을 체인으로 전달)으로
 수리했다 — 비결정 시계 읽기는 dispatch 경계에 남고 그 아래는 입력에 결정론적이다.</p>
 
+<h2>코퍼스 acceptance 라이브 실측 (8/16, :8949 격리 인스턴스)</h2>
+
+<p>rtprobe keeper에게 mention 자극으로 <code>WebSearch(includeContent=true, limit=5)</code>를
+발화시켜 RFC-0383을 keeper 레인에서 처음으로 끝까지 밟았다.
+상세 로그·경로는 <code>docs/evidence/web-artifact-corpus-acceptance-2026-08-16.md</code>.</p>
+
+<table>
+<tr><th>acceptance</th><th>판정</th><th>실측</th></tr>
+<tr><td>1 — 오프로드마다 index 행</td><td><strong>라이브 PASS</strong></td>
+<td>절단 5건 → <code>index.jsonl</code> 5행(전부 <code>masc.web_artifact.v1</code>, sha256=파일명) + 본문 4파일.
+서로 다른 URL 2개(저장소 루트와 그 README)가 같은 내용 해시 <code>2dd3ef61…</code> 한 파일로 dedup되는 것까지 관측 —
+파일이 진실, 인덱스는 projection이라는 설계 그대로.</td></tr>
+<tr><td>3 — 웹 왕복 없는 재질의</td><td><strong>keeper 레인 FAIL → #28820</strong></td>
+<td>① index Grep: keeper sandbox가 상대경로를 playground 기준으로 이중 결합해 rg exit 2.
+② <code>keeper_artifact_read</code>: reader는 <code>tool_blobs/</code>만 resolve하는데 본문은
+<code>artifacts/web-fetch/</code>에 있어 도달 불가(rtprobe는 지시 sha 대신 컨텍스트의 replay blob으로 대체 호출).
+문서화된 2단 소비는 <strong>agent 레인만 성립</strong> — 본문 저장 단일화 + discovery 표면 결정이 수정 방향.</td></tr>
+</table>
+
+<p class="note">부산물로 배달 계층의 결함을 하나 잡았다: 승인된 Gate resolution이 재배달 stimulus 뒤에
+줄을 서면 <code>hitl_resolution=None</code>으로 checkpoint가 재개되어 RFC-0356 host replay가 영영 안 붙고,
+무제한 재개 런이 single-flight를 점유해 20분+ 기아를 실측했다 (#28809).
+인스턴스 재기동이 배달을 복구하자 replay가 즉시 실행된 것
+(<code>gate replay … applied output_bytes=31614</code>)이 "결여는 배달뿐"이라는 판정의 실증이다.
+수정은 PR #28818 — 턴 시작 시 ready resolution을 큐 소비 없이 투영 + grant 미소비 승인만
+post-tool boundary에서 소스 런을 선점.</p>
+
 <h2>다음 반복</h2>
 <ul>
 <li><strong>Iteration 6</strong> (선택): BRAVE_SEARCH_API_KEY 투입 시 grounded 경로 —
 <code>bench-web-quality.py</code>가 같은 쿼리셋으로 자동 A/B.</li>
-<li><strong>코퍼스 재질의 실측</strong>: RFC-0383 acceptance 3 — keeper가 Grep→artifact_read
-2단으로 과거 본문에 도달하는 턴 실측 (Iteration 5와 같은 방법).</li>
+<li><strong>#28820 수정 후 재실측</strong>: 본문 저장 단일화가 병합되면 acceptance 3을
+같은 자극으로 다시 밟아 keeper 레인 PASS를 확인.</li>
+<li><strong>PR #28818 병합 후</strong>: 유예→승인→즉시 배달(재기동 없이)을 격리 인스턴스에서 재확인.</li>
 <li>품질은 <code>python3 scripts/bench-web-quality.py -o docs/evidence/web-quality-&lt;date&gt;-rN.json</code>,
 가용성·토큰은 <code>bench-web-tools.py</code> — 실행 후 이 문서에 섹션 추가.</li>
 </ul>


### PR DESCRIPTION
reports/web-tools-bench-2026-08-15.html에 8/16 라이브 실측 섹션을 추가하고 evidence record를 동봉합니다.

- acceptance 1 (오프로드마다 index 행): **라이브 PASS** — :8949 rtprobe 턴에서 5행/4파일, 내용 해시 dedup까지 관측
- acceptance 3 (웹 왕복 없는 재질의): **keeper 레인 FAIL** — 근거와 수정 방향은 #28820
- 부산물 #28809 (HITL 배달 기아 → PR #28818) 서사 포함
- 근거 파일: docs/evidence/web-artifact-corpus-acceptance-2026-08-16.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)