### PR TITLE
fix(test): hitl replay 픽스처를 스마트 생성자로 만든다 (main 빌드 복구)

### DIFF
--- a/test/test_keeper_hitl_replay_delivery.ml
+++ b/test/test_keeper_hitl_replay_delivery.ml
@@ -57,7 +57,7 @@ let with_workspace f =
   f config
 ;;
 
-let unrouted = Keeper_continuation_channel.Unrouted { reason = "test" }
+let unrouted = Keeper_continuation_channel.unrouted "test"
 
 (* Submit + approve one grant. Resolving an approval for a keeper with no
    live lane durably enqueues its [Hitl_resolved] wake, which is exactly the


### PR DESCRIPTION
## 증상

`main` 에서 `dune build` 가 깨집니다.

```
File "test/test_keeper_hitl_replay_delivery.ml", line 60, characters 52-71:
Error: Cannot create values of the private type
       Keeper_continuation_channel.t.Unrouted
```

## 원인

`Keeper_continuation_channel.t` 는 **#25020 (2026-07-17)** 부터 `private` 입니다. 밖에서 생성자를 직접 적용할 수 없습니다.

`test_keeper_hitl_replay_delivery.ml` 은 어제(#28818) 들어왔는데 `Unrouted { reason = "test" }` 를 직접 씁니다. 즉 이 파일은 **한 번도 컴파일된 적이 없습니다.**

CI 가 못 잡은 게 아닙니다. 이 스위트는 `.github/workflows/ci.yml:1095` 에 `@test/runtest-test_keeper_hitl_replay_delivery` 로 등록돼 있고, #28818 은 `Build and Test` **fail 상태로 병합**됐습니다.

## 수정

```diff
-let unrouted = Keeper_continuation_channel.Unrouted { reason = "test" }
+let unrouted = Keeper_continuation_channel.unrouted "test"
```

`unrouted` 가 그 케이스의 공개 생성자입니다. 빈 진단 문자열을 거부하는데, 직접 생성을 막아둔 이유가 그거예요 — 허용되는 값이 전부 `of_yojson` 으로 재현 가능하도록 강제합니다. 바인딩 이름을 그대로 둬서 이 파일의 나머지 사용처는 안 건드립니다.

## 같은 오류 전수

`Keeper_continuation_channel.{Dashboard,Discord,Slack,Unrouted}` 참조 37곳을 전부 열어봤습니다. **생성은 이 한 곳뿐**이고 나머지는 패턴 매칭이라 private 타입에서 합법입니다.

헷갈릴 만한 3곳도 직접 확인했습니다 — `test_server_slack_trigger_policy.ml:266`, `test_server_discord_trigger_policy.ml:254`, `keeper_surface_post.ml:248` 전부 `match ... with | Some { ... }` 안쪽입니다.

## 로컬 검증

```
dune build --root . test/test_keeper_hitl_replay_delivery.exe   exit 0
./_build/default/test/test_keeper_hitl_replay_delivery.exe      exit 0
  Test Successful in 0.173s. 7 tests run.
```