### PR TITLE
fix(web): 오프로드 전문을 Tool_blob_store에 저장해 keeper가 읽을 수 있게 한다 (#28820)

### DIFF
--- a/docs/ENV-CONTRACT.md
+++ b/docs/ENV-CONTRACT.md
@@ -158,13 +158,18 @@ Precedence:
 | `OLLAMA_API_KEY` | `(none)` | Env-only credential; presence admits the `ollama` provider. |
 
 Web artifact corpus (RFC-0383): every truncation offload stores the full
-extraction at `<base>/.masc/artifacts/web-fetch/<sha256>.md` and appends one
+extraction as a content-addressed blob in the `Tool_blob_store`
+(`<base>/.masc/tool_blobs/<sha[0..1]>/<sha256>`) — the exact store
+`keeper_artifact_read` resolves (#28820) — and appends one
 `masc.web_artifact.v1` fact row (`sha256`, `source_url`, optional `title`,
-`bytes`, `fetched_at`) to `index.jsonl` in the same directory. The index is a
-projection — deleting it changes no behavior — and keepers consume it with the
-existing pair: `Grep` the index for a topic, then
-`keeper_artifact_read(sha256, offset, max_bytes)` for the body. MASC never
-deletes artifacts or index rows; retention is operator-managed (#28759).
+`bytes`, `fetched_at`) to `<base>/.masc/artifacts/web-fetch/index.jsonl`.
+The index is a projection — deleting it changes no behavior. Lane note: a
+keeper re-reads a body with the sha carried by its `[TRUNCATED ...
+full_text_sha256=<sha>]` marker; discovering shas by `Grep`-ing the index is
+an agent/operator-lane path (keeper sandboxes do not expose `.masc` as a
+file surface — keeper-lane cross-session discovery is tracked in #28820).
+MASC never deletes blobs or index rows; retention is operator-managed
+(#28759).
 
 Equivalent `runtime.toml` keys:
 

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -257,8 +257,8 @@ Keeper WebSearch/WebFetch backend 메모:
 - `masc_web_search` / `masc_web_fetch`는 Keeper-internal backend 이름이며 MCP `tools/list` public surface에는 노출되지 않는다.
 - `web_search` / `web_fetch` are not agent core-owned capabilities; Keeper agents should call the MASC-owned public aliases shown in their tool list (`WebSearch` / `WebFetch`).
 - `WebSearch { includeContent: true }`는 가져온 본문을 keeper가 바로 읽는 `content_text` 렌더링 하나로만 싣는다. `WebFetch`는 선택한 단일 URL을 더 깊게 읽을 때 쓴다.
-- `maxChars`를 넘는 본문은 head/tail 창 + `[TRUNCATED ... full_text=<경로>]` 마커로 절단되고, 전문은 `<base>/.masc/artifacts/web-fetch/<sha256>.md`로 오프로드된다. 마크다운 헤딩이 있으면 마커 뒤 `[OUTLINE ...]` 블록이 헤딩별 바이트 오프셋을 주고, 그 오프셋이 곧 `keeper_artifact_read(sha256, offset, max_bytes)` 인자다.
-- 오프로드마다 같은 디렉터리의 `index.jsonl`에 `masc.web_artifact.v1` 행(sha256, source_url, title, bytes, fetched_at)이 append된다 (RFC-0383). 과거에 가져온 본문을 다시 쓰려면 index를 `Grep`으로 찾고 `keeper_artifact_read`로 읽는다 — 웹 왕복 없이. index는 projection이라 지워져도 다른 동작은 변하지 않는다.
+- `maxChars`를 넘는 본문은 head/tail 창 + `[TRUNCATED ... full_text_sha256=<sha>]` 마커로 절단되고, 전문은 content-addressed `Tool_blob_store`(`<base>/.masc/tool_blobs/`)에 저장된다 — `keeper_artifact_read`가 읽는 바로 그 저장소다 (#28820). 마크다운 헤딩이 있으면 마커 뒤 `[OUTLINE ...]` 블록이 헤딩별 바이트 오프셋을 주고, 마커의 sha와 그 오프셋이 곧 `keeper_artifact_read(sha256, offset, max_bytes)` 인자다.
+- 오프로드마다 `<base>/.masc/artifacts/web-fetch/index.jsonl`에 `masc.web_artifact.v1` 행(sha256, source_url, title, bytes, fetched_at)이 append된다 (RFC-0383). index는 projection이라 지워져도 다른 동작은 변하지 않는다. **레인 주의**: keeper는 컨텍스트/checkpoint의 마커 sha로 본문을 되읽는다. index를 `Grep`으로 뒤져 sha를 찾는 발견 경로는 임의 경로를 읽을 수 있는 agent/운영자 레인이다 — keeper sandbox는 `.masc`를 파일 표면으로 주지 않으므로 keeper 레인의 교차 세션 발견은 #28820에서 결정한다.
 - `[web_search].searxng_url` 또는 `MASC_SEARXNG_URL` 설정 시 self-hosted SearXNG가 최우선 provider로 작동한다.
 - 로컬 검색 품질이 필요하면 `scripts/searxng-local.sh start`로 Docker SearXNG를 올리고 active `runtime.toml`의 `[web_search].searxng_url = "http://localhost:8888"`만 설정한다. 별도 WebSearch MCP wrapper는 필요 없다.
 - `scripts/searxng-local.sh status|smoke|logs|stop`으로 로컬 provider를 점검한다. 기본 config는 `${MASC_BASE_PATH:-$HOME/me}/.local/share/masc-searxng/settings.yml`에 생성되며 MASC가 쓰는 JSON search format을 켠다.

--- a/docs/rfc/RFC-0383-web-artifact-corpus.md
+++ b/docs/rfc/RFC-0383-web-artifact-corpus.md
@@ -18,7 +18,10 @@ implementation_prs: [28794]
 RFC-0381이 만든 오프로드 경로는 검색·추출 전문을
 `<base>/.masc/artifacts/web-fetch/<sha256>.md`에 내용 주소로 저장한다. 첫 keeper 턴
 실측에서 검색 1회가 파일 3개(80KB)를 만들었고, keeper는
-`keeper_artifact_read(sha256, offset, max_bytes)`로 필요한 조각만 되읽었다.
+`keeper_artifact_read(sha256, offset, max_bytes)`로 필요한 조각만 되읽었다
+(→ §6 정정: 그때 되읽힌 것은 자동 blob화된 tool result였고, 이 경로의 파일
+자체는 keeper reader가 도달할 수 없는 저장소에 있었다. 본문 저장은 #28820에서
+`Tool_blob_store`로 단일화됐다).
 
 문제는 이 파일들이 **익명**이라는 것이다. sha256 파일명만 있고 — 어떤 URL에서 왔는지,
 언제 가져왔는지, 어떤 제목의 문서인지를 파일 시스템 어디에도 기록하지 않는다. 그 결과:
@@ -38,7 +41,7 @@ RFC-0381이 만든 오프로드 경로는 검색·추출 전문을
 | Ledger는 evidence authority | 인덱스는 **projection**이다. 진실은 아티팩트 파일 자체(내용 주소)이고, 인덱스 행은 "그 시각에 이렇게 저장했다"는 사실 기록. 인덱스가 유실·손상돼도 아티팩트 읽기는 그대로 동작한다 |
 | 행동을 유도·강제하는 장치 금지 | 신선도 필드(`fetched_at`)는 사실이다. 만료·TTL·재검증을 **강제하지 않는다** — 오래된 본문을 쓸지 다시 가져올지는 Keeper가 선택한다 |
 | Gate 0 | 어떤 경로에도 새 gate가 없다. 인덱스 append 실패는 오프로드 성공을 실패로 바꾸지 않는다(아래 §2.4) |
-| 도구 표면 최소 | **새 keeper 도구를 추가하지 않는다.** 인덱스는 JSONL 파일이고 keeper는 이미 Grep/Read를 가진다 — 파일 계약을 문서화하면 소비 표면은 이미 존재한다 |
+| 도구 표면 최소 | **새 keeper 도구를 추가하지 않는다.** 인덱스는 JSONL 파일이고 keeper는 이미 Grep/Read를 가진다 — 파일 계약을 문서화하면 소비 표면은 이미 존재한다 (→ §6 정정: keeper sandbox는 `.masc`를 파일 표면으로 주지 않아 이 전제는 agent/운영자 레인에서만 성립한다) |
 | 레거시 금지 | 인덱스 스키마는 v1 단일. reader/converter/migration 없음. 스키마가 바뀌면 hard cut |
 | SSOT | URL→내용 매핑의 진실은 웹이다. 인덱스는 "우리가 관측한 시점의 사실"만 기록하며, 같은 URL의 다른 시점 관측은 서로 다른 행(그리고 대개 다른 sha256)이다 |
 
@@ -56,7 +59,7 @@ RFC-0381이 만든 오프로드 경로는 검색·추출 전문을
 | 필드 | 의미 |
 |---|---|
 | `schema` | `masc.web_artifact.v1` 고정 |
-| `sha256` | 아티팩트 파일명과 동일한 내용 해시 — `keeper_artifact_read`의 첫 인자 |
+| `sha256` | 아티팩트의 내용 해시(= `Tool_blob_store` 주소, §6) — `keeper_artifact_read`의 첫 인자 |
 | `source_url` | 추출 원본의 최종 URL (리다이렉트 해소 후) |
 | `title` | 추출된 `<title>` (없으면 필드 자체 생략 — null 저장 금지) |
 | `bytes` | 오프로드된 전문 크기 |
@@ -120,4 +123,35 @@ dispatch 계층의 몫)이라는 기존 경계를 지킨다. 이것은 counter-a
    (Feature 테스트).
 2. 인덱스 파일을 지워도 fetch/read 경로의 동작이 변하지 않는다 (projection 증명).
 3. keeper가 Grep→`keeper_artifact_read` 2단으로 과거 본문에 도달한다 (턴 실측, RFC-0381
-   Iteration 5와 같은 방법).
+   Iteration 5와 같은 방법). (→ §6: 라이브 실측에서 keeper 레인은 두 단계 모두
+   실패했다 — 본문 읽기는 #28820 수정으로 열렸고, 발견 경로는 레인을 나눠 정정)
+
+## 6. 실측 정정 (2026-08-16, #28820)
+
+:8949 격리 인스턴스에서 acceptance를 keeper 레인으로 처음 끝까지 밟은 결과
+(근거: `docs/evidence/web-artifact-corpus-acceptance-2026-08-16.md`):
+
+- **acceptance 1은 라이브 PASS** — 절단 5건이 index 5행 + 본문 4파일을 만들었고,
+  서로 다른 URL 2개가 같은 내용 해시 한 파일로 dedup되는 것까지 관측했다.
+- **acceptance 3은 keeper 레인에서 양 단계 모두 불성립이었다.**
+  ① keeper sandbox는 `.masc`를 파일 표면으로 주지 않아 인덱스 `Grep`이 도달
+  불가(상대경로가 playground 기준으로 해석). ② 본문이
+  `artifacts/web-fetch/<sha>.md`에 있었는데 `keeper_artifact_read`는
+  `Tool_blob_store`(`tool_blobs/`)만 resolve한다. §0의 "되읽었다"는 관측은
+  web-fetch 파일이 아니라 같은 턴의 자동 blob화된 tool result를 읽은 것이었다.
+
+정정 내용:
+
+1. **본문 저장 단일화 (#28820)** — `offload_full_text`가 전문을
+   `Tool_blob_store.put_durable`로 저장한다. 마커는 경로 대신
+   `full_text_sha256=<sha>`를 싣고, 그 sha가 곧 `keeper_artifact_read`의 첫
+   인자다. `artifacts/web-fetch/`에는 `index.jsonl`만 남는다. 이전 위치의
+   `.md` 파일은 reader가 없던 표면이므로 hard cut(이관 코드 없음)하며, 남은
+   파일의 처분은 운영자 몫이다(#28759). 인덱스의 옛 행이 가리키는 sha가 blob
+   store에 없을 수 있음은 §2의 기존 계약("행이 가리키는 파일이 없을 수 있다")
+   그대로다.
+2. **소비 레인 구분** — 같은 턴/checkpoint 안의 재독은 마커 sha로 keeper
+   레인에서 성립한다. 인덱스를 뒤져 sha를 **발견**하는 교차 세션 경로는
+   agent/운영자 레인이다. keeper 레인의 교차 세션 발견 표면(도구 추가 여부
+   포함)은 #28820에서 별도 결정한다 — "새 도구 0" 원칙의 재검토가 필요한
+   지점이므로 이 RFC의 범위 밖으로 남긴다.

--- a/docs/rfc/RFC-0383-web-artifact-corpus.md
+++ b/docs/rfc/RFC-0383-web-artifact-corpus.md
@@ -8,7 +8,7 @@ author: vincent + claude
 supersedes: []
 superseded_by: null
 related: ["0381"]
-implementation_prs: [28794]
+implementation_prs: [28794, 28826]
 ---
 
 # RFC-0383: 웹 아티팩트는 쌓이기만 한다

--- a/lib/tool_misc_web_fetch.ml
+++ b/lib/tool_misc_web_fetch.ml
@@ -352,11 +352,19 @@ let offload_full_text ~source_url ~title ~fetched_at_unix text =
          let artifact =
            Tool_blob_store.put_durable store ~bytes:text ~mime:"text/markdown"
          in
-         Fs_compat.mkdir_p dir;
+         (* The blob is durable at this point, so an index-side directory or
+            append failure must surface as [index_unavailable], never as
+            [full_text_unavailable] — the marker would otherwise deny a blob
+            that exists. *)
          let index =
-           web_artifact_index_append ~dir
-             ~sha256:artifact.Tool_output.sha256 ~source_url ~title
-             ~bytes:(String.length text) ~fetched_at_unix
+           try
+             Fs_compat.mkdir_p dir;
+             web_artifact_index_append ~dir
+               ~sha256:artifact.Tool_output.sha256 ~source_url ~title
+               ~bytes:(String.length text) ~fetched_at_unix
+           with
+           | Unix.Unix_error (err, _, _) -> Error (Unix.error_message err)
+           | Sys_error message -> Error message
          in
          Ok (artifact.Tool_output.sha256, index)
        with

--- a/lib/tool_misc_web_fetch.ml
+++ b/lib/tool_misc_web_fetch.ml
@@ -339,20 +339,26 @@ let offload_full_text ~source_url ~title ~fetched_at_unix text =
           base
           [ Common.masc_dirname; "artifacts"; "web-fetch" ]
       in
-      let digest = Digestif.SHA256.(digest_string text |> to_hex) in
-      let path = Filename.concat dir (digest ^ ".md") in
-      (* Filesystem failures become typed reasons in the marker; anything
-         else propagates to the tool dispatch boundary rather than being
-         flattened into a string here. *)
+      (* #28820: the full text lives in the content-addressed
+         [Tool_blob_store], so the sha carried by the marker and the index
+         is directly the input of [keeper_artifact_read] — a keeper-lane
+         reader exists for it. This directory keeps only the discovery
+         projection ([index.jsonl]). Filesystem failures become typed
+         reasons in the marker; anything else propagates to the tool
+         dispatch boundary rather than being flattened into a string
+         here. *)
       (try
+         let store = Tool_blob_store.create ~base_path:base in
+         let artifact =
+           Tool_blob_store.put_durable store ~bytes:text ~mime:"text/markdown"
+         in
          Fs_compat.mkdir_p dir;
-         Fs_compat.save_file_atomic path text
-         |> Result.map (fun () ->
-                let index =
-                  web_artifact_index_append ~dir ~sha256:digest ~source_url
-                    ~title ~bytes:(String.length text) ~fetched_at_unix
-                in
-                path, index)
+         let index =
+           web_artifact_index_append ~dir
+             ~sha256:artifact.Tool_output.sha256 ~source_url ~title
+             ~bytes:(String.length text) ~fetched_at_unix
+         in
+         Ok (artifact.Tool_output.sha256, index)
        with
        | Unix.Unix_error (err, _, _) -> Error (Unix.error_message err)
        | Sys_error message -> Error message)
@@ -461,11 +467,11 @@ let truncate_text ~max_chars ~source_url ~title ~fetched_at_unix text =
     let offloaded = offload_full_text ~source_url ~title ~fetched_at_unix text in
     let marker =
       match offloaded with
-      | Ok (path, index) -> (
+      | Ok (sha256, index) -> (
           let base =
             Printf.sprintf
-              "[TRUNCATED total_chars=%d kept_head=%d kept_tail=%d full_text=%s]"
-              total (String.length head) (String.length tail) path
+              "[TRUNCATED total_chars=%d kept_head=%d kept_tail=%d full_text_sha256=%s]"
+              total (String.length head) (String.length tail) sha256
           in
           (* RFC-0383: a failed index append never demotes a successful
              offload — the artifact is the truth and the index only a
@@ -491,7 +497,7 @@ let truncate_text ~max_chars ~source_url ~title ~fetched_at_unix text =
     in
     ( String.concat "\n\n" [ head; marker; tail ]
     , true
-    , match offloaded with Ok (path, _) -> Some path | Error _ -> None )
+    , match offloaded with Ok (sha256, _) -> Some sha256 | Error _ -> None )
 
 (** Response cache. Authorization and admission belong to the Keeper Gate; this
     leaf does not maintain a second, process-local request limiter. *)
@@ -700,7 +706,7 @@ let fetch_impl ~url ~timeout_sec ~extract_mode ~max_chars ~fetched_at_unix =
               let rendered, extraction_source =
                 render_payload ~extract_mode ~content_kind response.body
               in
-              let text, truncated, full_text_path =
+              let text, truncated, full_text_sha256 =
                 truncate_text ~max_chars ~source_url:response.final_url ~title
                   ~fetched_at_unix rendered
               in
@@ -713,7 +719,7 @@ let fetch_impl ~url ~timeout_sec ~extract_mode ~max_chars ~fetched_at_unix =
                 , description
                 , text
                 , truncated
-                , full_text_path ))
+                , full_text_sha256 ))
       | Some status -> Error (Http_status status)
       | None -> Error No_http_status)
 
@@ -782,7 +788,7 @@ let handle ~tool_name ~start_time args : Tool_result.result =
                         , description
                         , text
                         , truncated
-                        , full_text_path ) ->
+                        , full_text_sha256 ) ->
                         let fields =
                           [
                             ("url", `String url);
@@ -798,8 +804,8 @@ let handle ~tool_name ~start_time args : Tool_result.result =
                             ("truncated", `Bool truncated);
                           ]
                           @
-                          (match full_text_path with
-                          | Some path -> [ ("full_text_path", `String path) ]
+                          (match full_text_sha256 with
+                          | Some sha256 -> [ ("full_text_sha256", `String sha256) ]
                           | None -> [])
                           @
                           (match response.content_type with

--- a/lib/tool_misc_web_fetch.mli
+++ b/lib/tool_misc_web_fetch.mli
@@ -40,29 +40,34 @@ val handle : tool_name:string -> start_time:float -> Yojson.Safe.t -> Tool_resul
 	    - [text]: readable extracted content. Over [maxChars] it becomes a
 	      deterministic head/tail window (three quarters of the budget from
 	      the start, one quarter from the end, cut on line boundaries) around
-	      a [\[TRUNCATED ...\]] marker that names the offloaded full text.
+	      a [\[TRUNCATED ... full_text_sha256=<sha256>\]] marker naming the
+	      offloaded full text by content address.
 	      When the extraction carries markdown ATX headings and the offload
 	      succeeded, the marker is followed by an [\[OUTLINE ...\]] block:
 	      up to 32 [<byte-offset> <heading-line>] rows addressing the
-	      offloaded file, so a reader fetches one section by offset instead
-	      of paging blindly. Fenced-code [#] lines are excluded;
+	      offloaded bytes, so a reader fetches one section via
+	      [keeper_artifact_read(sha256, offset, max_bytes)] instead of
+	      paging blindly. Fenced-code [#] lines are excluded;
 	      heading-free documents carry no outline
 	    - [content_chars]: length of [text]
 	    - [truncated]: whether output truncation was applied
-	    - [full_text_path]: present only when truncation offloaded the full
-	      extracted text under [<base>/.masc/artifacts/web-fetch/] (content
-	      addressed by sha256, so identical pages reuse one file); absent when
-	      no truncation happened or the offload failed — the marker then says
+	    - [full_text_sha256]: present only when truncation offloaded the
+	      full extracted text into the content-addressed [Tool_blob_store]
+	      ([<base>/.masc/tool_blobs/], #28820 — the store
+	      [keeper_artifact_read] resolves, so the keeper lane can re-read
+	      it; identical pages reuse one blob); absent when no truncation
+	      happened or the offload failed — the marker then says
 	      [full_text_unavailable=<reason>] instead of hiding it. MASC never
-	      deletes these files; retention is operator-managed. Cut points that
-	      fall away from a newline snap to UTF-8 codepoint starts, so a
-	      window never splits a multi-byte sequence. Each successful offload
-	      also appends one [masc.web_artifact.v1] fact row (sha256,
-	      source_url, optional title, bytes, fetched_at) to [index.jsonl] in
-	      the same directory — RFC-0383's requeryable corpus. The index is a
-	      projection: deleting it changes no behavior, and an append failure
-	      surfaces as an [\[index_unavailable=<reason>\]] marker line without
-	      demoting the offload
+	      deletes these blobs; retention is operator-managed. Cut points
+	      that fall away from a newline snap to UTF-8 codepoint starts, so
+	      a window never splits a multi-byte sequence. Each successful
+	      offload also appends one [masc.web_artifact.v1] fact row (sha256,
+	      source_url, optional title, bytes, fetched_at) to [index.jsonl]
+	      under [<base>/.masc/artifacts/web-fetch/] — RFC-0383's
+	      requeryable corpus. The index is a projection: deleting it
+	      changes no behavior, and an append failure surfaces as an
+	      [\[index_unavailable=<reason>\]] marker line without demoting the
+	      offload
 	    - [content_type]: optional upstream content type
 	    - [downloaded_bytes]: optional curl-reported download size
 	    - [title]: optional, extracted from [<title>] tag

--- a/test/test_tool_misc_web_fetch.ml
+++ b/test/test_tool_misc_web_fetch.ml
@@ -120,8 +120,9 @@ let with_base_path_env path f =
 
 (* Feature contract: past maxChars the text becomes a deterministic
    head/tail window around a [TRUNCATED ...] marker, and the complete
-   extraction is offloaded content-addressed under
-   <base>/.masc/artifacts/web-fetch/ with its path in full_text_path. *)
+   extraction is offloaded content-addressed into the Tool_blob_store —
+   the store keeper_artifact_read resolves (#28820) — with its sha256 in
+   full_text_sha256 and one fact row in the corpus index. *)
 let test_truncation_offloads_full_text () =
   let tmp_base =
     Filename.concat (Filename.get_temp_dir_name ())
@@ -160,20 +161,29 @@ let test_truncation_offloads_full_text () =
             (String_util.contains_substring text "[TRUNCATED total_chars=");
           check bool "no outline for heading-free text" false
             (String_util.contains_substring text "[OUTLINE");
-          let path = json |> member "full_text_path" |> to_string in
-          check bool "marker names the path" true
-            (String_util.contains_substring text ("full_text=" ^ path));
-          check bool "path under base" true
-            (String_util.contains_substring path
-               (Filename.concat tmp_base ".masc"));
-          let stored = In_channel.with_open_bin path In_channel.input_all in
-          check bool "offloaded file holds the full extraction" true
+          let sha256 = json |> member "full_text_sha256" |> to_string in
+          check bool "marker names the content address" true
+            (String_util.contains_substring text ("full_text_sha256=" ^ sha256));
+          (* The blob must resolve in the exact store keeper_artifact_read
+             reads (#28820): fetch it back through Tool_blob_store. *)
+          let store = Tool_blob_store.create ~base_path:tmp_base in
+          let stored =
+            match Tool_blob_store.fetch store ~sha256 with
+            | Ok (Some bytes) -> bytes
+            | Ok None -> Alcotest.fail "offloaded blob is absent from the store"
+            | Error error ->
+              Alcotest.fail (Tool_blob_store.fetch_error_to_string error)
+          in
+          check bool "offloaded blob holds the full extraction" true
             (String_util.contains_substring stored (line 200));
-          check int "offloaded file is complete" 400
+          check int "offloaded blob is complete" 400
             (List.length (String.split_on_char '\n' stored));
           (* RFC-0383: the same round trip appended one fact row to the
              corpus index, and the row agrees with the artifact. *)
-          let index_path = Filename.concat (Filename.dirname path) "index.jsonl" in
+          let index_path =
+            List.fold_left Filename.concat tmp_base
+              [ ".masc"; "artifacts"; "web-fetch"; "index.jsonl" ]
+          in
           let last_row =
             In_channel.with_open_bin index_path In_channel.input_all
             |> String.split_on_char '\n'
@@ -183,8 +193,7 @@ let test_truncation_offloads_full_text () =
           let row = Yojson.Safe.from_string last_row in
           check string "index schema" "masc.web_artifact.v1"
             (row |> member "schema" |> to_string);
-          check string "index sha256 matches the artifact name"
-            (Filename.basename path |> Filename.remove_extension)
+          check string "index sha256 matches the blob address" sha256
             (row |> member "sha256" |> to_string);
           check string "index source_url" "https://example.com/long"
             (row |> member "source_url" |> to_string);
@@ -243,7 +252,7 @@ let test_truncation_preserves_utf8_boundaries () =
 
 (* Feature contract: when the truncated extraction carries markdown
    headings, the marker is followed by an [OUTLINE ...] byte-offset map
-   addressing the offloaded file — reading the artifact at a listed
+   addressing the offloaded blob — reading the artifact at a listed
    offset lands exactly on that heading line. Fenced-code [#] lines stay
    out of the count, and collection caps at 32 rows while the header
    still reports the full heading total. *)
@@ -294,8 +303,15 @@ let test_truncation_outline_maps_headings () =
           let row = Printf.sprintf "\n%d ## section 10" expected_offset in
           check bool "outline row carries the constructed offset" true
             (String_util.contains_substring text row);
-          let path = json |> member "full_text_path" |> to_string in
-          let stored = In_channel.with_open_bin path In_channel.input_all in
+          let sha256 = json |> member "full_text_sha256" |> to_string in
+          let store = Tool_blob_store.create ~base_path:tmp_base in
+          let stored =
+            match Tool_blob_store.fetch store ~sha256 with
+            | Ok (Some bytes) -> bytes
+            | Ok None -> Alcotest.fail "offloaded blob is absent from the store"
+            | Error error ->
+              Alcotest.fail (Tool_blob_store.fetch_error_to_string error)
+          in
           let heading = "## section 10" in
           check string "offset addresses that heading in the artifact" heading
             (String.sub stored expected_offset (String.length heading))))


### PR DESCRIPTION
#28820의 본문 절반 수정입니다 (발견 경로 결정은 이슈에 남음).

## 문제
라이브 실측(:8949)에서 코퍼스가 keeper에게 write-only였습니다: 본문은 `artifacts/web-fetch/<sha>.md`, reader(`keeper_artifact_read`)는 `tool_blobs/`만 resolve — 문서화된 소비 2단이 keeper 레인에서 모두 불성립.

## 수정
- `offload_full_text` → `Tool_blob_store.put_durable`. 마커·tool result는 경로 대신 `full_text_sha256`을 싣습니다(= artifact_read의 첫 인자). `artifacts/web-fetch/`에는 `index.jsonl`만 남습니다.
- 옛 위치 `.md`는 동작하는 reader가 없던 표면이라 hard cut(이관 코드 없음, 처분은 운영자 #28759). 옛 index 행의 sha 미존재는 기존 missing-body 계약 그대로.
- 문서 3곳 + RFC-0383에 §6 실측 정정 추가(과거 '되읽었다' 주장의 실체 포함), 소비 레인 구분 명시.
- 테스트: blob이 **artifact_read가 읽는 바로 그 store**에서 resolve됨을 증명, 새 마커/필드 핀.

## 검증
- `test_tool_misc_web_fetch` 갱신 (CI에서 실행되는 스위트)
- 로컬 빌드는 세션 계약상 미실행 — CI가 검증
- 병합 후 :8949에서 acceptance 3 재실측 예정 (마커 sha → artifact_read)

🤖 Generated with [Claude Code](https://claude.com/claude-code)