### PR TITLE
fix(ci): main 복구 2건 — 숙청된 examples/ 루트 + hitl 픽스처 private 생성자

### DIFF
--- a/.ci/health-baseline.json
+++ b/.ci/health-baseline.json
@@ -16,7 +16,6 @@
     "lib_ml_over_500": 222,
     "bin_ml_over_500": 5,
     "test_ml_over_500": 143,
-    "examples_ml_over_500": 0,
     "mli_open_base": 0,
     "ml_base_stdlib_shadow": 0,
     "bin_ml_base_stdlib_shadow": 0

--- a/scripts/health_snapshot.sh
+++ b/scripts/health_snapshot.sh
@@ -281,7 +281,6 @@ excepted_ml_over_500="$(extract_json_int "$ml_line_cap_json" "excepted_ml_over_5
 lib_ml_over_500="$(extract_json_int "$ml_line_cap_json" "lib_ml_over_500")"
 bin_ml_over_500="$(extract_json_int "$ml_line_cap_json" "bin_ml_over_500")"
 test_ml_over_500="$(extract_json_int "$ml_line_cap_json" "test_ml_over_500")"
-examples_ml_over_500="$(extract_json_int "$ml_line_cap_json" "examples_ml_over_500")"
 ml_line_cap_status="$(extract_json_field "$ml_line_cap_json" baseline status)"
 ml_line_cap_message="$(extract_json_field "$ml_line_cap_json" baseline message)"
 ml_line_cap_changed_status="$(extract_json_field "$ml_line_cap_json" changed status)"
@@ -362,7 +361,7 @@ echo "Anti-fake: status=${anti_fake_label} good=${anti_fake_good} suspect=${anti
 echo "Unsafe patterns (lib):  failwith=${lib_failwith} list_hd=${lib_list_hd} list_tl=${lib_list_tl} option_get=${lib_option_get} obj_magic=${lib_obj_magic}"
 echo "Unsafe patterns (test): failwith=${test_failwith} list_hd=${test_list_hd} list_tl=${test_list_tl} option_get=${test_option_get} obj_magic=${test_obj_magic}"
 echo "Base policy: mli_open_base=${mli_open_base} ml_base_stdlib_shadow=${ml_base_stdlib_shadow} bin_ml_base_stdlib_shadow=${bin_ml_base_stdlib_shadow}"
-echo "ML line cap: manual=${manual_ml_over_500} excepted=${excepted_ml_over_500} lib=${lib_ml_over_500} bin=${bin_ml_over_500} test=${test_ml_over_500} examples=${examples_ml_over_500}"
+echo "ML line cap: manual=${manual_ml_over_500} excepted=${excepted_ml_over_500} lib=${lib_ml_over_500} bin=${bin_ml_over_500} test=${test_ml_over_500}"
 echo "ML line cap changed: ${ml_line_cap_changed_status} (${ml_line_cap_changed_message})"
 echo "ML line cap aggregate: ${ml_line_cap_status} (${ml_line_cap_message})"
 echo "Ratchet: ${ratchet_status} (${ratchet_message})"
@@ -399,7 +398,6 @@ json_payload="$(cat <<EOF
     "lib_ml_over_500": ${lib_ml_over_500},
     "bin_ml_over_500": ${bin_ml_over_500},
     "test_ml_over_500": ${test_ml_over_500},
-    "examples_ml_over_500": ${examples_ml_over_500},
     "mli_open_base": ${mli_open_base},
     "ml_base_stdlib_shadow": ${ml_base_stdlib_shadow},
     "bin_ml_base_stdlib_shadow": ${bin_ml_base_stdlib_shadow}
@@ -462,7 +460,6 @@ if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
     echo "| lib | $lib_ml_over_500 | n/a |"
     echo "| bin | $bin_ml_over_500 | n/a |"
     echo "| test | $test_ml_over_500 | n/a |"
-    echo "| examples | $examples_ml_over_500 | n/a |"
     echo ""
     echo "- Anti-fake: \`$anti_fake_label\` (good=$anti_fake_good suspect=$anti_fake_suspect fake=$anti_fake_fake total=$anti_fake_total)"
     echo "- Base policy: mli_open_base=\`$mli_open_base\` ml_base_stdlib_shadow=\`$ml_base_stdlib_shadow\` bin_ml_base_stdlib_shadow=\`$bin_ml_base_stdlib_shadow\`"

--- a/scripts/ml_line_cap_audit.sh
+++ b/scripts/ml_line_cap_audit.sh
@@ -49,7 +49,7 @@ def parse_args(repo_root: Path) -> argparse.Namespace:
     parser.add_argument(
         "--roots",
         nargs="*",
-        default=["lib", "bin", "test", "examples"],
+        default=["lib", "bin", "test"],
         help="Repo-relative roots to scan.")
     args = parser.parse_args(sys.argv[2:])
     args.repo_root = repo_root
@@ -78,7 +78,6 @@ def scan_tree(base_dir: Path, roots: list[str], exceptions: set[str], max_lines:
         "lib_ml_over_500": 0,
         "bin_ml_over_500": 0,
         "test_ml_over_500": 0,
-        "examples_ml_over_500": 0,
     }
     skip_dirs = {".git", "_build", ".worktrees", "node_modules", "dist", "coverage", ".next"}
 
@@ -155,7 +154,6 @@ def baseline_from_file(args: argparse.Namespace) -> tuple[dict, str]:
         "lib_ml_over_500": int(counts.get("lib_ml_over_500", 0)),
         "bin_ml_over_500": int(counts.get("bin_ml_over_500", 0)),
         "test_ml_over_500": int(counts.get("test_ml_over_500", 0)),
-        "examples_ml_over_500": int(counts.get("examples_ml_over_500", 0)),
     }, f"file:{args.baseline_file}"
 
 
@@ -271,8 +269,7 @@ def main() -> int:
         f"excepted={current['counts']['excepted_ml_over_500']} "
         f"lib={current['counts']['lib_ml_over_500']} "
         f"bin={current['counts']['bin_ml_over_500']} "
-        f"test={current['counts']['test_ml_over_500']} "
-        f"examples={current['counts']['examples_ml_over_500']}"
+        f"test={current['counts']['test_ml_over_500']}"
     )
     print(f"Aggregate: {aggregate_status} ({aggregate_message})")
     print(f"Changed: {changed_status} ({changed_message})")

--- a/test/test_keeper_hitl_replay_delivery.ml
+++ b/test/test_keeper_hitl_replay_delivery.ml
@@ -57,7 +57,7 @@ let with_workspace f =
   f config
 ;;
 
-let unrouted = Keeper_continuation_channel.Unrouted { reason = "test" }
+let unrouted = Keeper_continuation_channel.unrouted "test"
 
 (* Submit + approve one grant. Resolving an approval for a keeper with no
    live lane durably enqueues its [Hitl_resolved] wake, which is exactly the


### PR DESCRIPTION
## 왜

#28784가 examples/를 트리에서 숙청했는데 `scripts/ml_line_cap_audit.sh`의 기본 roots에 `examples`가 남아 있어, Health job의 baseline 단계(`git archive origin/main -- .ci bin examples lib test`)가 pathspec 불일치 exit 128로 **모든 PR에서 죽습니다** (#28797에서 발견, traceback 캡처됨).

## 뭘

죽은 개념의 잔재를 한 번에 컷:
- `ml_line_cap_audit.sh`: 기본 roots에서 `examples` 제거 + `examples_ml_over_500` 카운터 3곳 제거
- `health_snapshot.sh`: 해당 카운터 추출/echo/JSON 필드/markdown 행 제거
- `.ci/health-baseline.json`: 키 제거

## 검증

- 이 트리에서 CI와 동일 인자 실행: `bash scripts/health_snapshot.sh --skip-build --json-out .health/health-snapshot.json --baseline-ref origin/main --fail-on-lib-regression` → exit 0, baseline 비교(439→439) 정상 계산
- `rg -c examples` 3개 파일 전부 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)