### PR TITLE
fix(test): main 이 컴파일되지 않는다 — private 타입 variant 를 직접 적용

### DIFF
--- a/test/test_keeper_hitl_replay_delivery.ml
+++ b/test/test_keeper_hitl_replay_delivery.ml
@@ -57,7 +57,10 @@ let with_workspace f =
   f config
 ;;
 
-let unrouted = Keeper_continuation_channel.Unrouted { reason = "test" }
+(* [Keeper_continuation_channel.t] is private, so the variant cannot be
+   applied here; [unrouted] is the module's constructor for the fail-closed
+   value. *)
+let unrouted = Keeper_continuation_channel.unrouted "test"
 
 (* Submit + approve one grant. Resolving an approval for a keeper with no
    live lane durably enqueues its [Hitl_resolved] wake, which is exactly the


### PR DESCRIPTION
## main 이 깨져 있습니다

```
$ git log --oneline -1        # b372e3bc76
$ dune build @check
File "test/test_keeper_hitl_replay_delivery.ml", line 60, characters 52-71:
60 | let unrouted = Keeper_continuation_channel.Unrouted { reason = "test" }
                                                         ^^^^^^^^^^^^^^^^^^^
Error: Cannot create values of the private type Keeper_continuation_channel.t.Unrouted
```

`Keeper_continuation_channel.t` 는 `private` 선언이라 (`lib/keeper_runtime/keeper_continuation_channel.mli:17`) 바깥에서 variant 를 직접 적용할 수 없습니다. 같은 파일 63 행에 이 값 전용 생성자가 있습니다.

```
val unrouted : string -> t
```

## 범위

`@check` 가 실패하므로 **이 스위트만이 아니라 모든 PR 의 컴파일이 막힙니다.** Draft 로 두지 않고 바로 올립니다.

## 유입 경로

`bb21836a3d fix(keeper): deliver approved Gate resolutions past queue-ordered stimuli (#28809) (#28818)` 에서 들어왔습니다. 그 PR 의 CI 가 이 파일을 컴파일하는 job 을 실행했는지는 확인하지 않았습니다.

## 검증

```
dune build --root . @check                          exit 0
test_keeper_hitl_replay_delivery.exe                7 tests, exit 0
```