### PR TITLE
chore(build): MASC_BUILD_GIT_COMMIT env 경로 척살 — embedded 스탬프가 유일 경로

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1744,8 +1744,7 @@ jobs:
             esac
           done < <(awk 'NR > 1 { print $1 }' "$RUNNER_TEMP/masc-runtime-otool.txt")
           chmod +x scripts/release-binary-smoke.sh
-          MASC_BUILD_GIT_COMMIT="$EXPECTED_SOURCE_SHA" \
-            scripts/release-binary-smoke.sh "$binary"
+          scripts/release-binary-smoke.sh "$binary"
 
           identity_root="$(mktemp -d "$RUNNER_TEMP/masc-build-identity.XXXXXX")"
           identity_log="$identity_root/server.log"
@@ -1762,7 +1761,6 @@ jobs:
           trap cleanup_identity_probe EXIT
           mkdir -p "$identity_root/.masc/config"
           cp config/runtime.toml "$identity_root/.masc/config/runtime.toml"
-          MASC_BUILD_GIT_COMMIT="$EXPECTED_SOURCE_SHA" \
           MASC_BASE_PATH="$identity_root" \
           MASC_BASE_PATH_INPUT="$identity_root" \
           MASC_KEEPER_AUTONOMOUS_ENABLED=false \
@@ -1849,9 +1847,6 @@ jobs:
               target_arch: $target_arch,
               binary_format: $binary_format,
               binary_sha256: $binary_sha256,
-              required_launch_env: {
-                MASC_BUILD_GIT_COMMIT: $source_sha
-              },
               linked_dylibs: $linked_dylibs,
               supported_homebrew_prefixes: [
                 "/opt/homebrew/opt/gmp/",
@@ -1873,7 +1868,6 @@ jobs:
              .target_arch == "arm64" and
              .binary_format == "mach-o" and
              .binary_sha256 == $binary_sha256 and
-             .required_launch_env.MASC_BUILD_GIT_COMMIT == $source_sha and
              (.linked_dylibs | type == "array" and length > 0)' \
             "$runtime_dir/manifest.json" >/dev/null
 

--- a/dashboard/src/components/dashboard-shell-build-identity.test.ts
+++ b/dashboard/src/components/dashboard-shell-build-identity.test.ts
@@ -50,9 +50,9 @@ describe('BuildIdentityBadge executable identity', () => {
       build: {
         release_version: '0.22.0',
         commit: '0123456789abcdef',
-        commit_source: 'env:MASC_BUILD_GIT_COMMIT',
+        commit_source: 'embedded',
         binary_commit: '0123456789abcdef',
-        binary_commit_source: 'env:MASC_BUILD_GIT_COMMIT',
+        binary_commit_source: 'embedded',
         repo_head_commit: 'fedcba9876543210',
         repo_head_commit_source: 'runtime_repo_head',
         started_at: '2026-08-14T02:07:29Z',

--- a/lib/build_commit/dune
+++ b/lib/build_commit/dune
@@ -6,9 +6,8 @@
  (wrapped false))
 
 ; Embed the git commit the binary was built from (RFC-0382 follow-up,
-; "binary unknown" root fix). The launcher-supplied MASC_BUILD_GIT_COMMIT
-; env only ever worked in CI; a copied binary (e.g. the launchd deploy at
-; <base>/bin) could never testify to its own origin. (universe) re-runs
+; "binary unknown" root fix): a copied binary (e.g. the launchd deploy at
+; <base>/bin) must testify to its own origin. (universe) re-runs
 ; the probe every build; downstream recompiles only when the hash changes.
 ; Sandboxing is disabled so git can ascend to the checkout being built —
 ; in a worktree that is the worktree HEAD, which is the truth we want.

--- a/lib/build_identity.ml
+++ b/lib/build_identity.ml
@@ -249,13 +249,10 @@ let probe_commit_unix_ts commit_hash_opt =
     List.find_map probe_one repo_roots
 ;;
 
-let resolve_commit ~embedded ~env_value ~probe =
+let resolve_commit ~embedded ~probe =
   match Option.bind embedded String_util.trim_to_option with
   | Some commit -> Some commit
-  | None ->
-    (match Option.bind env_value String_util.trim_to_option with
-     | Some commit -> Some commit
-     | None -> probe ())
+  | None -> probe ()
 ;;
 
 type commit_resolution =
@@ -268,22 +265,17 @@ type commit_resolution =
   }
 
 let embedded_commit_source = "embedded"
-let build_env_commit_source = "env:MASC_BUILD_GIT_COMMIT"
 let runtime_repo_head_source = "runtime_repo_head"
 
-let resolve_commit_details ~embedded ~env_value ~probe =
+let resolve_commit_details ~embedded ~probe =
   (* The binary's own testimony wins: the embedded hash is stamped by the
-     build rule from the checkout being compiled, while the env var is a
-     launcher claim (historically set only by CI) and the repo-head probe
+     build rule from the checkout being compiled, while the repo-head probe
      describes the source tree next to the process, which moves
      independently of the binary. *)
   let binary_commit, binary_commit_source =
     match Option.bind embedded String_util.trim_to_option with
     | Some commit -> Some commit, Some embedded_commit_source
-    | None ->
-      (match Option.bind env_value String_util.trim_to_option with
-       | Some commit -> Some commit, Some build_env_commit_source
-       | None -> None, None)
+    | None -> None, None
   in
   let repo_head_commit = probe () in
   let commit, commit_source =
@@ -316,11 +308,10 @@ let resolved_executable_dir = Filename.dirname resolved_executable_path
 
 (** Commit hashes — eagerly resolved at startup.
     Not using [Eio.Lazy] because this is called from tests without Eio context.
-    Env var check + git probe are fast and side-effect-free. *)
+    Embedded stamp + git probe are fast and side-effect-free. *)
 let commit_resolution =
   resolve_commit_details
     ~embedded:Build_commit_generated.commit
-    ~env_value:(Env_config_core.build_git_commit_opt ())
     ~probe:probe_git_commit
 ;;
 

--- a/lib/build_identity.mli
+++ b/lib/build_identity.mli
@@ -15,13 +15,13 @@ type t = {
         when available.  This is runtime repo truth, not binary truth. *)
   commit : string option;
     (** Backwards-compatible identity field.  Uses [binary_commit] when
-        [MASC_BUILD_GIT_COMMIT] is set, otherwise falls back to
+        the build-time stamp is present, otherwise falls back to
         [repo_head_commit].  Inspect [commit_source] before using this as
         deploy proof. *)
   commit_source : string option;
-    (** [Some "env:MASC_BUILD_GIT_COMMIT"] when [commit] came from the
-        build env override, [Some "runtime_repo_head"] when it came from
-        probing the current checkout, [None] when unknown. *)
+    (** [Some "embedded"] when [commit] came from the build-time stamp,
+        [Some "runtime_repo_head"] when it came from probing the current
+        checkout, [None] when unknown. *)
   commit_unix_ts : float option;
     (** Unix timestamp of [commit].  Kept for compatibility; prefer the
         source-specific timestamp fields below. *)
@@ -29,8 +29,8 @@ type t = {
     (** Age of [commit_unix_ts].  Kept for compatibility; prefer
         [binary_commit_age_seconds] for binary freshness. *)
   binary_commit : string option;
-    (** Commit supplied by [MASC_BUILD_GIT_COMMIT], when available.  This is
-        the only commit field that operators should use as binary-build
+    (** Commit stamped into the binary at build time, when available.  This
+        is the only commit field that operators should use as binary-build
         identity in this module. *)
   binary_commit_source : string option;
   binary_commit_unix_ts : float option;
@@ -70,11 +70,10 @@ val repo_root : unit -> string option
 
 val resolve_commit :
   embedded:string option ->
-  env_value:string option ->
   probe:(unit -> string option) ->
   string option
-(** Resolve commit hash: build-time embedded stamp first, then the
-    launcher env var, then the probe function. Exposed for testing. *)
+(** Resolve commit hash: build-time embedded stamp first, then the probe
+    function. Exposed for testing. *)
 
 type commit_resolution = {
   commit : string option;
@@ -87,14 +86,13 @@ type commit_resolution = {
 
 val resolve_commit_details :
   embedded:string option ->
-  env_value:string option ->
   probe:(unit -> string option) ->
   commit_resolution
 (** Resolve the compatibility [commit] plus the source-specific binary and
-    runtime repo-head fields. [binary_commit] prefers the build-time
-    embedded stamp (source ["embedded"]) over the launcher env var; the
-    repo-head probe never populates it because the source tree next to the
-    process moves independently of the binary. Exposed for testing. *)
+    runtime repo-head fields. [binary_commit] carries the build-time
+    embedded stamp (source ["embedded"]); the repo-head probe never
+    populates it because the source tree next to the process moves
+    independently of the binary. Exposed for testing. *)
 
 val pick_repo_candidates :
   exe_dir:string -> cwd:string -> string list

--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -546,12 +546,6 @@ let telemetry_enabled () =
 (** Whether malformed env parses are escalated to a hard [Config_error]
     (fail-fast boot) instead of a warn + default. Controlled by
     [MASC_PARSE_WARN]. Default: false (warn + use default). *)
-(** {1 Build Identity} *)
-
-(** Git commit hash override for build identity. *)
-let build_git_commit_opt () =
-  raw_value_opt "MASC_BUILD_GIT_COMMIT" |> trim_opt
-
 (** PubSub max messages per read. Default: 1000. *)
 let pubsub_max_messages () =
   get_int ~default:1000 "MASC_PUBSUB_MAX_MESSAGES"

--- a/lib/config/env_config_core.mli
+++ b/lib/config/env_config_core.mli
@@ -218,9 +218,8 @@ val telemetry_enabled : unit -> bool
 
 (** Whether malformed env parses are escalated to {!Config_error} (fail-fast)
     instead of warn + default. Controlled by [MASC_PARSE_WARN]. Default: false. *)
-(** {1 Build identity / pubsub} *)
+(** {1 PubSub} *)
 
-val build_git_commit_opt : unit -> string option
 val pubsub_max_messages : unit -> int
 
 (** {1 Keeper defaults} *)

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -32,7 +32,6 @@ let server_entries =
       "MASC MCP endpoint URL (derived from base URL when unset)";
     entry ~default:"" "MASC_CLUSTER_NAME" "Cluster name for multi-instance";
     entry ~default:"(cwd)" Env_config_core.base_path_env_key "Base storage directory";
-    entry ~default:"(none)" "MASC_BUILD_GIT_COMMIT" "Build git commit hash";
     entry ~default:Masc_network_defaults.masc_http_default_host
       "MASC_HTTP_HOST" "HTTP server listen host";
     entry ~default:Masc_network_defaults.masc_http_default_max_connections_s

--- a/lib/env_config_introspect.ml
+++ b/lib/env_config_introspect.ml
@@ -6,13 +6,7 @@
     server library, which already depends on [masc.config] in [lib/dune]. *)
 
 let server_meta () =
-  let git_commit =
-    match Sys.getenv_opt "MASC_BUILD_GIT_COMMIT" with
-    | Some c ->
-        let trimmed = String.trim c in
-        if trimmed <> "" then Some trimmed else None
-    | None -> None
-  in
+  let git_commit = (Build_identity.current ()).Build_identity.binary_commit in
   `Assoc
     [
       ("version", `String Runtime_build_version.current);

--- a/lib/env_config_introspect.mli
+++ b/lib/env_config_introspect.mli
@@ -6,7 +6,8 @@
     [masc_config] sub-library. This wrapper adds root-runtime
     metadata that is only available from the main server library
     ([Runtime_build_version.current], [Server_startup_state.elapsed_since_start],
-    [Sys.ocaml_version], the live PID, and [MASC_BUILD_GIT_COMMIT]).
+    [Sys.ocaml_version], the live PID, and the build-time commit stamp
+    surfaced by [Build_identity]).
 
     Internal helper [server_meta] is hidden — callers consume only
     the two JSON entry points. *)

--- a/scripts/ci/run-keeper-realworld-acceptance.sh
+++ b/scripts/ci/run-keeper-realworld-acceptance.sh
@@ -131,7 +131,6 @@ trap cleanup EXIT INT TERM
 chmod +x "$BINARY"
 env \
   MASC_BASE_PATH="$base_path" \
-  MASC_BUILD_GIT_COMMIT="$EXPECTED_SHA" \
   MASC_ADMIN_TOKEN= \
   MASC_INTERNAL_MCP_TOKEN= \
   MASC_TOKEN= \

--- a/test/test_build_identity.ml
+++ b/test/test_build_identity.ml
@@ -5,7 +5,6 @@ let test_resolve_commit_prefers_embedded () =
   let commit =
     Build_identity.resolve_commit
       ~embedded:(Some " feed0123 ")
-      ~env_value:(Some "abc12345")
       ~probe:(fun () ->
         probe_called := true;
         Some "deadbeef")
@@ -13,24 +12,10 @@ let test_resolve_commit_prefers_embedded () =
   Alcotest.(check (option string)) "embedded wins" (Some "feed0123") commit;
   Alcotest.(check bool) "probe not called" false !probe_called
 
-let test_resolve_commit_prefers_env () =
-  let probe_called = ref false in
+let test_resolve_commit_uses_probe_when_embedded_missing () =
   let commit =
     Build_identity.resolve_commit
       ~embedded:None
-      ~env_value:(Some " abc12345 ")
-      ~probe:(fun () ->
-        probe_called := true;
-        Some "deadbeef")
-  in
-  Alcotest.(check (option string)) "env wins" (Some "abc12345") commit;
-  Alcotest.(check bool) "probe not called" false !probe_called
-
-let test_resolve_commit_uses_probe_when_env_missing () =
-  let commit =
-    Build_identity.resolve_commit
-      ~embedded:None
-      ~env_value:None
       ~probe:(fun () -> Some "deadbeef")
   in
   Alcotest.(check (option string)) "probe used" (Some "deadbeef") commit
@@ -39,7 +24,6 @@ let test_resolve_commit_details_prefers_embedded_binary () =
   let details =
     Build_identity.resolve_commit_details
       ~embedded:(Some " feed0123 ")
-      ~env_value:(Some "abc12345")
       ~probe:(fun () -> Some "deadbeef")
   in
   Alcotest.(check (option string)) "binary commit is embedded"
@@ -53,31 +37,10 @@ let test_resolve_commit_details_prefers_embedded_binary () =
   Alcotest.(check (option string)) "repo head still surfaced"
     (Some "deadbeef") details.repo_head_commit
 
-let test_resolve_commit_details_splits_env_and_repo_head () =
-  let details =
-    Build_identity.resolve_commit_details
-      ~embedded:None
-      ~env_value:(Some " abc12345 ")
-      ~probe:(fun () -> Some "deadbeef")
-  in
-  Alcotest.(check (option string)) "compat commit uses env"
-    (Some "abc12345") details.commit;
-  Alcotest.(check (option string)) "commit source is env"
-    (Some "env:MASC_BUILD_GIT_COMMIT") details.commit_source;
-  Alcotest.(check (option string)) "binary commit uses env"
-    (Some "abc12345") details.binary_commit;
-  Alcotest.(check (option string)) "binary source is env"
-    (Some "env:MASC_BUILD_GIT_COMMIT") details.binary_commit_source;
-  Alcotest.(check (option string)) "repo head still surfaced"
-    (Some "deadbeef") details.repo_head_commit;
-  Alcotest.(check (option string)) "repo head source"
-    (Some "runtime_repo_head") details.repo_head_commit_source
-
 let test_resolve_commit_details_marks_repo_head_fallback () =
   let details =
     Build_identity.resolve_commit_details
       ~embedded:None
-      ~env_value:None
       ~probe:(fun () -> Some "deadbeef")
   in
   Alcotest.(check (option string)) "compat commit falls back to repo head"
@@ -87,7 +50,9 @@ let test_resolve_commit_details_marks_repo_head_fallback () =
   Alcotest.(check (option string)) "binary commit absent" None
     details.binary_commit;
   Alcotest.(check (option string)) "repo head commit present"
-    (Some "deadbeef") details.repo_head_commit
+    (Some "deadbeef") details.repo_head_commit;
+  Alcotest.(check (option string)) "repo head source"
+    (Some "runtime_repo_head") details.repo_head_commit_source
 
 let test_current_started_at_is_stable () =
   let first = Build_identity.current () in
@@ -238,14 +203,10 @@ let () =
         [
           Alcotest.test_case "resolve commit prefers embedded" `Quick
             test_resolve_commit_prefers_embedded;
-          Alcotest.test_case "resolve commit prefers env over probe" `Quick
-            test_resolve_commit_prefers_env;
           Alcotest.test_case "resolve commit details prefers embedded binary"
             `Quick test_resolve_commit_details_prefers_embedded_binary;
           Alcotest.test_case "resolve commit falls back to probe" `Quick
-            test_resolve_commit_uses_probe_when_env_missing;
-          Alcotest.test_case "resolve commit details splits env and repo head"
-            `Quick test_resolve_commit_details_splits_env_and_repo_head;
+            test_resolve_commit_uses_probe_when_embedded_missing;
           Alcotest.test_case
             "resolve commit details marks repo head fallback" `Quick
             test_resolve_commit_details_marks_repo_head_fallback;


### PR DESCRIPTION
## 왜 삭제인가
#28806 이후 바이너리가 빌드 시점에 커밋을 자체 스탬프합니다. 이 env를 설정하는 CI job 2곳은 빌드 직전 \`git rev-parse HEAD == github.sha\`를 하드 검증하므로 **env 값이 embedded와 달라질 수 있는 경로가 구조적으로 없습니다**. 남겨두면 env 배선이 썩어도 CI가 못 잡는 검증 불능 중복 축이 됩니다 (#28815, #28806 적대적 리뷰 finding #3 실측).

## 변경 (+32/−103, 12파일)
- \`Build_identity.resolve_commit{,_details}\`: \`env_value\` 파라미터 제거 (embedded → repo-head probe 2단). \`env:MASC_BUILD_GIT_COMMIT\` source 문자열 소멸.
- \`Env_config_core.build_git_commit_opt\` 삭제 (유일 호출자가 build_identity였음), snapshot 목록에서 변수 제거.
- \`Env_config_introspect.server_meta\`: env 직독 → \`Build_identity\`의 \`binary_commit\`(embedded) 사용. introspection의 \`git_commit\`이 계속 의미를 가짐.
- ci.yml: smoke/identity-probe launch env 2곳 제거. identity probe의 \`binary_commit == source_sha\` assert는 유지 — **이제 유일 경로인 embedded를 진짜로 검증**합니다. trusted-runtime manifest의 \`required_launch_env\` 필드+jq assert 제거 (레포 내 소비자 없음 rg 확인, 바이너리 기동에 identity env 불요).
- \`scripts/ci/run-keeper-realworld-acceptance.sh\`: launch env 제거 (이 스크립트는 binary_commit을 assert하지 않고, checkout SHA 검증은 자체 보유).
- 테스트: env 케이스 2개 삭제, \`repo_head_commit_source\` 고유 assert는 fallback 테스트로 이관. dashboard 픽스처 \`'env:...'\` → \`'embedded'\`.
- 의도적 보존: \`docs/evidence/*2026-08-13*.json\` (역사 스냅샷).

## 검증 (로컬 실행)
- \`dune build lib test\` exit 0, \`test_build_identity\` **14/14 OK** (16−삭제 2)
- dashboard \`dashboard-shell-build-identity.test.ts\` **3/3 OK**
- ci.yml \`yaml.safe_load\` OK, acceptance 스크립트 \`bash -n\` OK

## 미검증 항목 (main-only)
trusted-macos-arm64-runtime / keeper-realworld-acceptance는 main push 전용 job이라 PR에서 실행 불가. 삭제 라인이 launch env 주입뿐이고 assert는 그대로라 병합 후 main run에서 확인 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)