### PR TITLE
fix(health): 죽은 examples root 제거 — Health job 전면 복구

### DIFF
--- a/.ci/health-baseline.json
+++ b/.ci/health-baseline.json
@@ -16,7 +16,6 @@
     "lib_ml_over_500": 222,
     "bin_ml_over_500": 5,
     "test_ml_over_500": 143,
-    "examples_ml_over_500": 0,
     "mli_open_base": 0,
     "ml_base_stdlib_shadow": 0,
     "bin_ml_base_stdlib_shadow": 0

--- a/scripts/health_snapshot.sh
+++ b/scripts/health_snapshot.sh
@@ -281,7 +281,6 @@ excepted_ml_over_500="$(extract_json_int "$ml_line_cap_json" "excepted_ml_over_5
 lib_ml_over_500="$(extract_json_int "$ml_line_cap_json" "lib_ml_over_500")"
 bin_ml_over_500="$(extract_json_int "$ml_line_cap_json" "bin_ml_over_500")"
 test_ml_over_500="$(extract_json_int "$ml_line_cap_json" "test_ml_over_500")"
-examples_ml_over_500="$(extract_json_int "$ml_line_cap_json" "examples_ml_over_500")"
 ml_line_cap_status="$(extract_json_field "$ml_line_cap_json" baseline status)"
 ml_line_cap_message="$(extract_json_field "$ml_line_cap_json" baseline message)"
 ml_line_cap_changed_status="$(extract_json_field "$ml_line_cap_json" changed status)"
@@ -362,7 +361,7 @@ echo "Anti-fake: status=${anti_fake_label} good=${anti_fake_good} suspect=${anti
 echo "Unsafe patterns (lib):  failwith=${lib_failwith} list_hd=${lib_list_hd} list_tl=${lib_list_tl} option_get=${lib_option_get} obj_magic=${lib_obj_magic}"
 echo "Unsafe patterns (test): failwith=${test_failwith} list_hd=${test_list_hd} list_tl=${test_list_tl} option_get=${test_option_get} obj_magic=${test_obj_magic}"
 echo "Base policy: mli_open_base=${mli_open_base} ml_base_stdlib_shadow=${ml_base_stdlib_shadow} bin_ml_base_stdlib_shadow=${bin_ml_base_stdlib_shadow}"
-echo "ML line cap: manual=${manual_ml_over_500} excepted=${excepted_ml_over_500} lib=${lib_ml_over_500} bin=${bin_ml_over_500} test=${test_ml_over_500} examples=${examples_ml_over_500}"
+echo "ML line cap: manual=${manual_ml_over_500} excepted=${excepted_ml_over_500} lib=${lib_ml_over_500} bin=${bin_ml_over_500} test=${test_ml_over_500}"
 echo "ML line cap changed: ${ml_line_cap_changed_status} (${ml_line_cap_changed_message})"
 echo "ML line cap aggregate: ${ml_line_cap_status} (${ml_line_cap_message})"
 echo "Ratchet: ${ratchet_status} (${ratchet_message})"
@@ -399,7 +398,6 @@ json_payload="$(cat <<EOF
     "lib_ml_over_500": ${lib_ml_over_500},
     "bin_ml_over_500": ${bin_ml_over_500},
     "test_ml_over_500": ${test_ml_over_500},
-    "examples_ml_over_500": ${examples_ml_over_500},
     "mli_open_base": ${mli_open_base},
     "ml_base_stdlib_shadow": ${ml_base_stdlib_shadow},
     "bin_ml_base_stdlib_shadow": ${bin_ml_base_stdlib_shadow}
@@ -462,7 +460,6 @@ if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
     echo "| lib | $lib_ml_over_500 | n/a |"
     echo "| bin | $bin_ml_over_500 | n/a |"
     echo "| test | $test_ml_over_500 | n/a |"
-    echo "| examples | $examples_ml_over_500 | n/a |"
     echo ""
     echo "- Anti-fake: \`$anti_fake_label\` (good=$anti_fake_good suspect=$anti_fake_suspect fake=$anti_fake_fake total=$anti_fake_total)"
     echo "- Base policy: mli_open_base=\`$mli_open_base\` ml_base_stdlib_shadow=\`$ml_base_stdlib_shadow\` bin_ml_base_stdlib_shadow=\`$bin_ml_base_stdlib_shadow\`"

--- a/scripts/ml_line_cap_audit.sh
+++ b/scripts/ml_line_cap_audit.sh
@@ -49,7 +49,7 @@ def parse_args(repo_root: Path) -> argparse.Namespace:
     parser.add_argument(
         "--roots",
         nargs="*",
-        default=["lib", "bin", "test", "examples"],
+        default=["lib", "bin", "test"],
         help="Repo-relative roots to scan.")
     args = parser.parse_args(sys.argv[2:])
     args.repo_root = repo_root
@@ -78,7 +78,6 @@ def scan_tree(base_dir: Path, roots: list[str], exceptions: set[str], max_lines:
         "lib_ml_over_500": 0,
         "bin_ml_over_500": 0,
         "test_ml_over_500": 0,
-        "examples_ml_over_500": 0,
     }
     skip_dirs = {".git", "_build", ".worktrees", "node_modules", "dist", "coverage", ".next"}
 
@@ -155,7 +154,6 @@ def baseline_from_file(args: argparse.Namespace) -> tuple[dict, str]:
         "lib_ml_over_500": int(counts.get("lib_ml_over_500", 0)),
         "bin_ml_over_500": int(counts.get("bin_ml_over_500", 0)),
         "test_ml_over_500": int(counts.get("test_ml_over_500", 0)),
-        "examples_ml_over_500": int(counts.get("examples_ml_over_500", 0)),
     }, f"file:{args.baseline_file}"
 
 
@@ -271,8 +269,7 @@ def main() -> int:
         f"excepted={current['counts']['excepted_ml_over_500']} "
         f"lib={current['counts']['lib_ml_over_500']} "
         f"bin={current['counts']['bin_ml_over_500']} "
-        f"test={current['counts']['test_ml_over_500']} "
-        f"examples={current['counts']['examples_ml_over_500']}"
+        f"test={current['counts']['test_ml_over_500']}"
     )
     print(f"Aggregate: {aggregate_status} ({aggregate_message})")
     print(f"Changed: {changed_status} ({changed_message})")


### PR DESCRIPTION
## 증상
오늘 12:34(#28784 병합) 이후, health_snapshot 표면을 트리거하는 **모든 PR의 Health job이 실패** (#28825, #28831에서 관측). 로그: \`git archive origin/main -- .ci bin examples lib test\` exit 128.

## 근본 원인 (단일)
#28784가 \`examples/\`의 마지막 파일을 지웠는데, ml_line_cap_audit의 root 목록 \`["lib","bin","test","examples"]\`이 하드코딩으로 남음. \`git archive\`는 매칭 없는 pathspec을 **fatal**로 처리합니다.

> 정정 기록: 초기 진단은 "shallow checkout에 origin/main ref 부재"를 공동 원인으로 지목했으나, **실패한 런의 실제 로그로 반증**됐습니다 — Health job에는 #12568부터 있던 "Fetch baseline for health ratchet" 스텝이 스냅샷 전에 origin/main을 항상 fetch합니다(\`[new branch] main -> origin/main\` 확인). 그 진단으로 넣었던 fetch-fallback 코드는 CI에서 한 번도 실행될 수 없는 죽은 방어라서 이 PR에서 제거했습니다(적대적 리뷰 지적 반영). shallow 클론 재현은 "같은 exit 128"을 재현한 것이지 이 사고를 재현한 게 아니었습니다.

## 수정
examples 축 전체 척살: roots·counters·snapshot JSON·표 출력·baseline key (9곳, 3파일). 그 외 변경 없음.

## 검증
- 실패 런(#28831 Health job 95111715910) 로그 재독으로 pathspec이 유일 원인임을 고정.
- 로컬(ref 해석 가능한 트리)에서 \`--baseline-ref origin/main\` 풀 스냅샷 **exit 0**, ref 비교 실행(\`manual_ml_over_500 439->439\`).
- \`bash -n\` 2파일, baseline JSON parse OK.
- 이 PR이 health_snapshot 표면을 트리거하므로 Health job이 runner에서 자가 검증합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)