### PR TITLE
docs(changelog): fleet 메시지 반복분을 미출시 0.23.0 에 기록

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,9 @@
   `Pending Messages` and the two broadcasts once under `Fleet Messages`.
 - **The direct-keeper-message path reads no transcript**: an earlier cut of the
   fleet layer called the uncapped `Keeper_chat_store.load_all` there, on a path
-  that performs no transcript I/O otherwise, costing a full read and parse of a
-  1,829,467 byte / 2,915 row store per direct message in production. That path
+  that performs no transcript I/O otherwise, costing a full read and parse of
+  the whole store per direct message — the largest in production was about
+  1.8 MB over roughly 2,900 rows, and it is append-only. That path
   empties the reactive lanes because the triggering message is the point; the
   Keeper sees fleet context on its next observation turn, where the load
   already happens.
@@ -38,7 +39,9 @@
 - **Build**: the commit-stamp rule moved to a `lib/build_commit` leaf, dead
   dune descriptions were removed, and the health snapshot no longer archives
   the purged `examples/` root — that pathspec made `git archive` exit 128 and
-  failed the required `CI Gate` on every PR.
+  failed the required `CI Gate` on every PR. The same change restored
+  `dune build @check`, which a test applying a `private` variant directly had
+  broken; both landed inside this window, so no release carried either.
 
 - **Workspace messages reach the linear event queue**: a workspace message
   that names a Keeper is committed as a typed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@
 
 ## [0.23.0] - 2026-08-16
 
+- **Keeper broadcasts reach the other Keepers' prompts**: projecting a fleet
+  broadcast into every other Keeper's transcript got the row to the dashboard
+  and no further. The prompt's `Pending Messages` section renders only rows that
+  mention this Keeper or that the Owner authored, and nothing else read the
+  transcript into context. A `Fleet Messages` layer now carries the newest
+  `keeper.fleet.messages.max` projected rows (default 10, `0` disables) as
+  standing context. Selection reads the typed `Surface_ref.Agent` surface, and
+  the lane predicate is shared with the reactive lanes so no row can render in
+  both sections. No acknowledgement cursor: lane ack advances only on
+  autonomous turn success, so a Keeper with `proactive_enabled = false` would
+  otherwise accumulate rows forever. Measured on an isolated instance: the
+  probe string appeared once in the transcript and not at all in the rendered
+  prompt before, and once in both after, with the mention rendered once under
+  `Pending Messages` and the two broadcasts once under `Fleet Messages`.
+- **The direct-keeper-message path reads no transcript**: an earlier cut of the
+  fleet layer called the uncapped `Keeper_chat_store.load_all` there, on a path
+  that performs no transcript I/O otherwise, costing a full read and parse of a
+  1,829,467 byte / 2,915 row store per direct message in production. That path
+  empties the reactive lanes because the triggering message is the point; the
+  Keeper sees fleet context on its next observation turn, where the load
+  already happens.
+- **Approved Gate resolutions are delivered past queue-ordered stimuli**: a
+  turn suspended at an approval gate resumed on a redelivered workspace message
+  rather than the approval, so `hitl_resolution` was absent and the host replay
+  never fired.
+- **The agent surface badge no longer claims a row is the viewer's own**: it
+  read `Agent (Self)`, which held while that surface carried only the viewed
+  Keeper's traffic. Projected broadcasts share the surface, so the badge named
+  the wrong Keeper; the speaker chip beside it already identifies the author.
+- **`LspCall` rpc and the inline LSP dispatcher are removed** from the gRPC
+  surface.
+- **Build**: the commit-stamp rule moved to a `lib/build_commit` leaf, dead
+  dune descriptions were removed, and the health snapshot no longer archives
+  the purged `examples/` root — that pathspec made `git archive` exit 128 and
+  failed the required `CI Gate` on every PR.
+
 - **Workspace messages reach the linear event queue**: a workspace message
   that names a Keeper is committed as a typed
   `Keeper_event_queue.Workspace_message` entry in that Keeper's per-Keeper


### PR DESCRIPTION
0.23.0 이후 병합된 11 커밋 중 사용자에게 보이는 변경을 CHANGELOG 에 기록합니다.

## 처음엔 0.24.0 bump 로 썼고, 가드가 거절했습니다

```
release train guard failed: base ref origin/main advertises unreleased package
version 0.23.0 while latest tag is v0.22.0 (package version 0.22.0), and head
changes package version to 0.24.0; publish/tag v0.23.0 before widening the
release train
```

이 repo 는 **최신 태그보다 앞선 미출시 버전을 하나만** 허용합니다. 0.23.0 은 오늘 올라갔고 태그가 없어서, 0.24.0 은 두 칸 앞이 됩니다.

v0.23.0 태그를 미는 것은 릴리스 행위지 CHANGELOG 편집의 부수효과가 아니라고 봐서, 태그는 만들지 않고 **아직 미출시인 0.23.0 항목에 흡수**시켰습니다. 패키지 버전 파일은 main 과 동일합니다 (diff 는 `CHANGELOG.md` 하나).

> 반복마다 version bump 를 원하신다면 v0.23.0 태그부터 필요합니다. 그건 별도 판단이라 여기서 하지 않았습니다.

## 담긴 것

| PR | 내용 |
|---|---|
| #28819 + #28830 | fleet 브로드캐스트가 다른 Keeper 의 **프롬프트**까지 도달 |
| #28813 | agent 표면 배지가 남의 행을 "자기 것" 이라 표시하던 것 수정 |
| #28818 | 승인된 Gate resolution 이 큐 순서 자극을 앞질러 전달 |
| #28773 | `LspCall` rpc + 인라인 LSP 디스패처 제거 |
| #28828 | health snapshot 이 숙청된 `examples/` 루트를 archive 하던 것 제거 |

## 수치 근거

전부 격리 인스턴스 실측입니다.

- 프롬프트 도달: 프로브 문자열이 대화 기록 1 / 프롬프트 0 (before) → 1 / 1 (after)
- 레인 disjoint: 지목은 `Pending Messages` 에 한 번, 브로드캐스트 2 건은 `Fleet Messages` 에만
- 직접 메시지 경로 읽기 비용: `sangsu.jsonl` 1,829,467 B / 2,915 행

## 가드

```
check-version-truth        exit 0   package=0.23.0 changelog_entry=0.23.0
check-doc-truth            exit 0
check-release-train-guard  exit 0   base=0.23.0 head=0.23.0
```

`check-doc-truth` 는 `ROADMAP.md` 와 `docs/PRODUCT-OPERATING-PLAN.md`, `docs/spec/SPEC-INDEX.md` 가 서로 맞아야 통과합니다. 이번엔 버전을 안 올렸으니 셋 다 그대로입니다.