### PR TITLE
refactor(keeper): 레인 분류를 한 곳으로 — disjoint 를 우연이 아니게

### DIFF
--- a/lib/keeper/keeper_world_observation_message_scope.ml
+++ b/lib/keeper/keeper_world_observation_message_scope.ml
@@ -301,11 +301,17 @@ let is_owner_authored (m : Keeper_chat_store.chat_message) : bool =
   | None -> false
 ;;
 
-(* A row is addressed to this keeper when it mentions one of the keeper's ids
-   or the Owner wrote it. Both reactive lanes are built from this predicate and
-   the fleet layer excludes it, so the two cannot render the same row twice. *)
-let is_lane_addressed ~target_ids (m : Keeper_chat_store.chat_message) : bool =
-  Keeper_lane_mentions.ids_match ~target_ids m.mentions || is_owner_authored m
+(* Which reactive lane a row belongs to, or [None] when it is addressed to
+   nobody here. Both the reactive lanes and the fleet layer read this one
+   function — the lanes on [Some], the fleet layer on [None] — so a row cannot
+   reach both. Splitting the classification would leave disjointness as a
+   property of two expressions staying complements, which nothing checks. *)
+let lane_of ~target_ids (m : Keeper_chat_store.chat_message) : pending_kind option =
+  if Keeper_lane_mentions.ids_match ~target_ids m.mentions
+  then Some Mention
+  else if is_owner_authored m
+  then Some Scope
+  else None
 ;;
 
 let pending_messages_of_messages
@@ -317,23 +323,13 @@ let pending_messages_of_messages
   let target_ids = Keeper_lane_mentions.target_ids_of targets in
   pending_user_lines ?ack_id messages
   |> List.filter_map (fun (m : Keeper_chat_store.chat_message) ->
-    if Keeper_lane_mentions.ids_match ~target_ids m.mentions
-    then
-      Some
-        { message_id = m.id
-        ; speaker = speaker_display m
-        ; content = m.content
-        ; kind = Mention
-        }
-    else if is_owner_authored m
-    then
-      Some
-        { message_id = m.id
-        ; speaker = speaker_display m
-        ; content = m.content
-        ; kind = Scope
-        }
-    else None)
+    lane_of ~target_ids m
+    |> Option.map (fun kind ->
+      { message_id = m.id
+      ; speaker = speaker_display m
+      ; content = m.content
+      ; kind
+      }))
 ;;
 
 (* RFC-0230 P2 — scope messages: a keeper's lane is, in practice, an operator
@@ -385,7 +381,7 @@ let fleet_messages_of_messages
     |> List.filter (fun (m : Keeper_chat_store.chat_message) ->
       match m.role, m.surface with
       | Keeper_chat_store.Role.User, Some Surface_ref.Agent ->
-        not (is_lane_addressed ~target_ids m)
+        Option.is_none (lane_of ~target_ids m)
       | ( Keeper_chat_store.Role.User
         , Some
             ( Surface_ref.Dashboard _

--- a/lib/keeper/keeper_world_observation_message_scope.mli
+++ b/lib/keeper/keeper_world_observation_message_scope.mli
@@ -116,8 +116,9 @@ val pending_scope_of_messages
 (** [fleet_messages_of_messages ~limit ~targets messages] returns the newest
     [limit] keeper broadcasts projected into this transcript, in arrival order.
     A row qualifies when it is a user line on the [Surface_ref.Agent] surface
-    that is neither addressed to [targets] nor Owner-authored, so this layer
-    and the two reactive lanes cannot render the same row. [limit <= 0] returns
+    that the lane classifier places in no reactive lane — the lanes take its
+    [Some], this layer takes its [None], so the same row cannot reach both.
+    [limit <= 0] returns
     the empty list. No watermark: unlike the lanes this is standing context,
     and lane acknowledgement only advances on autonomous turns. Pure. *)
 val fleet_messages_of_messages

--- a/test/test_keeper_mention_scope.ml
+++ b/test/test_keeper_mention_scope.ml
@@ -206,6 +206,34 @@ let test_limit_keeps_the_newest_in_arrival_order () =
     (fleet_contents (fleet ~limit:2 messages))
 ;;
 
+(* The partition itself, which the per-case tests above do not check: one
+   message list, and every classifiable row lands in exactly one of the two
+   sections. This is what [lane_of] makes structural — the lanes take its
+   [Some], the fleet layer its [None]. *)
+let test_rows_partition_across_lanes_and_fleet () =
+  let messages =
+    [ msg ~role:Store.Role.User ~id:"m1" ~ts:(Some 10.0) ~surface:agent_surface
+        ~speaker:external_ "@alice take this"
+    ; msg ~role:Store.Role.User ~id:"m2" ~ts:(Some 11.0) ~surface:agent_surface
+        ~speaker:owner "status?"
+    ; msg ~role:Store.Role.User ~id:"m3" ~ts:(Some 12.0) ~surface:agent_surface
+        ~speaker:external_ "fleet note"
+    ]
+  in
+  let pending =
+    MS.pending_messages_of_messages ~targets messages
+    |> List.map (fun (m : MS.pending_message) -> m.content)
+  in
+  let fleet = fleet_contents (fleet ~limit:10 messages) in
+  check (list string) "lanes take the addressed rows"
+    [ "@alice take this"; "status?" ] pending;
+  check (list string) "fleet takes what no lane claimed" [ "fleet note" ] fleet;
+  check (list string) "no row is in both"
+    [] (List.filter (fun c -> List.mem c fleet) pending);
+  check int "every row is placed exactly once"
+    (List.length messages) (List.length pending + List.length fleet)
+;;
+
 let test_owner_unmentioned_line_is_scope () =
   let messages = [ msg ~role:Store.Role.User ~ts:(Some 10.0) ~speaker:owner "can you check the deploy" ] in
   check (list string) "operator without @ -> scope" [ "can you check the deploy" ]
@@ -467,6 +495,8 @@ let () =
         ; test_case "zero_limit_disables" `Quick test_zero_limit_disables_the_layer
         ; test_case "limit_keeps_newest_in_order" `Quick
             test_limit_keeps_the_newest_in_arrival_order
+        ; test_case "rows_partition_across_lanes_and_fleet" `Quick
+            test_rows_partition_across_lanes_and_fleet
         ] )
     ]
 ;;


### PR DESCRIPTION
0.23.0 CHANGELOG 사실 확인에서 나온 건입니다. 제가 이렇게 썼습니다.

> the lane predicate is shared with the reactive lanes so no row can render in both sections

**공유되고 있지 않았습니다.**

```
$ rg -n 'is_lane_addressed' lib/keeper/keeper_world_observation_message_scope.ml
307:let is_lane_addressed ~target_ids (m : Keeper_chat_store.chat_message) : bool =
388:        not (is_lane_addressed ~target_ids m)
```

호출부가 하나뿐이고 그게 fleet 필터입니다. `pending_messages_of_messages` 는 `Mention` 과 `Scope` 를 구분해야 해서 `ids_match` 와 `is_owner_authored` 를 따로 인라인합니다 (320, 328 행).

코드 주석도 같은 과장을 하고 있었습니다 — "Both reactive lanes are built from this predicate".

## 무엇이 문제인가

disjoint 는 지금 성립합니다. 다만 **두 식이 서로 여집합으로 남아 있다는 성질**로 성립하고, 그걸 검사하는 것이 아무것도 없습니다. 한쪽만 고치면 같은 행이 두 섹션에 조용히 렌더됩니다. 주석이 구조적 보장을 주장하지만 컴파일러는 모릅니다.

## 수정

```ocaml
let lane_of ~target_ids m : pending_kind option =
  if Keeper_lane_mentions.ids_match ~target_ids m.mentions then Some Mention
  else if is_owner_authored m then Some Scope
  else None
```

반응 레인은 `Some` 을, fleet 레이어는 `None` 을 가져갑니다. 분류 지점이 하나라 갈라질 수가 없습니다.

## 검증

동작은 그대로입니다.

```
dune build --root . @check                    exit 0
test_keeper_mention_scope.exe                 31 tests, exit 0
test_keeper_surface_presence_prompt.exe       20 tests, exit 0
```

`test_keeper_mention_scope` 의 `addressed_row_not_fleet` / `owner_row_not_fleet` 이 지목 행과 Owner 행이 fleet 에 들어가지 않는 것을, `test_keeper_surface_presence_prompt` 가 프롬프트 렌더를 각각 고정합니다.

## 관련

이게 병합되면 masc#28835 의 CHANGELOG 문장이 참이 됩니다. 그때까지 그 PR 은 대기시킵니다.