### PR TITLE
docs(evidence): RFC-0383 재실측 기록 — #28818 실증 3건, acceptance 3 첫 라이브 PASS

### DIFF
--- a/docs/evidence/web-artifact-corpus-acceptance-2026-08-16.md
+++ b/docs/evidence/web-artifact-corpus-acceptance-2026-08-16.md
@@ -48,3 +48,35 @@ masc_broadcast '{"agent_name":"claude","message":"@rtprobe WebSearch 도구를 �
 rg 'gate replay approval|hitl resolution delivered' <base>/.masc/logs/system_log_2026-08-16.jsonl
 cat <base>/.masc/artifacts/web-fetch/index.jsonl
 ```
+
+## 4. 재실측 — #28818·#28826 병합 후 (05:39–06:16Z, :8949 scratch)
+
+환경: scratch 인스턴스가 05:39:05Z에 신 바이너리(#28818+#28826 포함)로 재기동. 프로덕션(:8935)도 05:55:53Z에 신 바이너리로 재기동 (`--base-path=/Users/dancer/me`).
+
+### #28818 야생 실증 3건 — 배달 기아 0초
+
+| 시각(Z) | approval | decision | projection | 큐 배달 |
+|---|---|---|---|---|
+| 05:45:26 | appr_5fed3255 | reject | **같은 초** (`hitl resolution projected from pending queue`) | 05:49:54 |
+| 05:56:10 | appr_eec08643 | reject | 같은 초 | 06:01:16 |
+| ≈06:13 | appr_11fef7f1 | reject | 같은 턴 (proj 카운트 3→4) | — |
+
+approve 경로는 프로덕션 04:25:41Z(appr_2361efbf, memory_write)에서 이미 실증 — 두 decision 모두 재기동 없이 배달된다. §3의 기아(재기동으로만 복구)와 대조.
+
+### acceptance 3 — keeper 레인 첫 라이브 PASS
+
+06:12:22Z, 활성 task-001 앵커 하에 `keeper_artifact_read(sha256=31d6b2b0…, offset=0, max_bytes=400)`:
+
+```
+tool_call tool=keeper_artifact_read input_shape=[max_bytes=int,offset=int,sha256=string:64] outcome=ok out_len=613
+```
+
+tool_error 누적 2건(§2, #28820 결함 증거)에서 증가 없음. §2의 FAIL(저장소 분리)이 #28826(put_durable 단일화)로 닫혔음을 keeper 레인에서 확인.
+
+### acceptance 1 (신 레인) — 라이브 미측정, 게이트 차단 기록
+
+auto-judge가 web_search 유예를 3회 reject (05:45:26 / 05:56:10 / ≈06:13). 3차는 judge가 요구한 활성 task 앵커(task-001, add 06:10:50 → claim/start 06:11, reject 시점에 in_progress; rtprobe 자율 release는 06:15:00)를 갖춘 상태였다. 3차 사유에는 검증 가능한 허위 포렌식("empty-string hash" — 실제 입력은 string:64, 빈 문자열 sha `e3b0c442…`와 불일치)이 포함 → #28842. 3회 시점에서 재시도 중단(게이트 판정 존중).
+
+신 레인 저장 경로의 대체 근거: (a) CI `test_tool_misc_web_fetch` — `put_durable` 후 reader와 같은 `Tool_blob_store.fetch`로 sha 동일성 핀, (b) 구 레인 라이브 PASS(§1, 메커니즘 동일·백엔드만 상이), (c) 프로덕션 유기 트래픽 후속 관측 — 신 바이너리 기동(05:55:53Z) 이후 첫 오프로드가 `tool_blobs/` blob + `full_text_sha256` 마커로 남는지 확인 (구 레인 마지막 오프로드는 04:33:12Z).
+
+부산물: 발신 주체(운영자 대리 발신 vs keeper 자율 발화 vs auto-judge)가 UI에서 구분되지 않는 문제를 #28841로 분리.

--- a/reports/web-tools-bench-2026-08-15.html
+++ b/reports/web-tools-bench-2026-08-15.html
@@ -278,13 +278,35 @@ hit@1 <strong>5/6</strong>, 옛 유일 경로(SearXNG)는 부분 회복 상태�
 수정은 PR #28818 — 턴 시작 시 ready resolution을 큐 소비 없이 투영 + grant 미소비 승인만
 post-tool boundary에서 소스 런을 선점.</p>
 
+<h2>재실측 — #28818·#28826 병합 후 (8/16 05:39–06:16Z, :8949)</h2>
+
+<p>위 "다음 반복"에 예고했던 두 항목을 신 바이너리 재기동(scratch 05:39:05Z, 프로덕션 05:55:53Z) 후 실측했다.</p>
+
+<table>
+<tr><th>항목</th><th>판정</th><th>근거</th></tr>
+<tr><td>#28818 배달 (유예→판정→배달, 재기동 없이)</td><td><strong>PASS ×3</strong></td>
+<td>reject 3건 모두 판정과 <strong>같은 초</strong>에 <code>hitl resolution projected from pending queue</code> 발화
+(05:45:26 / 05:56:10 / ≈06:13), 큐 배달 05:49:54·06:01:16. approve 경로는 프로덕션 04:25:41Z(appr_2361efbf)에서 실증.
+§부산물의 20분+ 기아와 대조 — 기아 0초.</td></tr>
+<tr><td>acceptance 3 (keeper 레인 blob 재적재)</td><td><strong>첫 라이브 PASS</strong></td>
+<td>06:12:22Z <code>keeper_artifact_read(sha256=31d6b2b0…, max_bytes=400)</code> →
+<code>outcome=ok out_len=613</code>, tool_error 증가 없음. #28820의 저장소 분리 FAIL이 #28826(put_durable 단일화)로 닫힘.</td></tr>
+<tr><td>acceptance 1 (신 레인 라이브 오프로드)</td><td>미측정 (게이트 차단)</td>
+<td>auto-judge가 web_search 유예를 3회 reject — 3차는 활성 task 앵커(task-001, reject 시점 in_progress)를 갖췄음에도,
+사유에 검증 가능한 허위 포렌식("empty-string hash" ≠ 실제 string:64 입력) 포함 → #28842.
+3회에서 재시도 중단. 대체 근거: CI <code>test_tool_misc_web_fetch</code>(같은 store fetch + sha 핀) +
+구 레인 라이브 PASS + 프로덕션 유기 트래픽 후속 관측(신 바이너리 이후 첫 오프로드 대기, 구 레인 마지막 04:33:12Z).</td></tr>
+</table>
+
+<p class="note">부산물 이슈 2건: 발신 주체(운영자 대리 vs keeper 자율 vs auto-judge)의 UI 구분 부재(#28841),
+auto-judge 사유의 허위 포렌식·계측 task 구조적 승인 불가(#28842).</p>
+
 <h2>다음 반복</h2>
 <ul>
 <li><strong>Iteration 6</strong> (선택): BRAVE_SEARCH_API_KEY 투입 시 grounded 경로 —
 <code>bench-web-quality.py</code>가 같은 쿼리셋으로 자동 A/B.</li>
-<li><strong>#28820 수정 후 재실측</strong>: 본문 저장 단일화가 병합되면 acceptance 3을
-같은 자극으로 다시 밟아 keeper 레인 PASS를 확인.</li>
-<li><strong>PR #28818 병합 후</strong>: 유예→승인→즉시 배달(재기동 없이)을 격리 인스턴스에서 재확인.</li>
+<li><strong>acceptance 1 신 레인 유기 관측</strong>: 프로덕션(:8935, base=<code>~/me/.masc</code>) 첫 web-fetch 오프로드가
+<code>tool_blobs/</code> blob + <code>full_text_sha256</code> 마커로 남는지 확인.</li>
 <li>품질은 <code>python3 scripts/bench-web-quality.py -o docs/evidence/web-quality-&lt;date&gt;-rN.json</code>,
 가용성·토큰은 <code>bench-web-tools.py</code> — 실행 후 이 문서에 섹션 추가.</li>
 </ul>


### PR DESCRIPTION
## 무엇

`docs/evidence/web-artifact-corpus-acceptance-2026-08-16.md`에 §4(재실측), `reports/web-tools-bench-2026-08-15.html`에 대응 섹션을 추가합니다. 문서만 변경합니다.

## 재실측 결과 (2026-08-16 05:39–06:16Z, :8949 scratch)

- **#28818 배달 실증 3건**: reject 판정과 같은 초에 `hitl resolution projected from pending queue` 발화, 큐 배달 05:49:54·06:01:16 — 기아 0초. approve 경로는 프로덕션 04:25:41Z에서 기실증.
- **acceptance 3 첫 라이브 PASS**: 06:12:22Z `keeper_artifact_read` → `outcome=ok out_len=613` (tool_error 증가 없음). #28820의 저장소 분리 FAIL이 #28826으로 닫힘을 keeper 레인에서 확인.
- **acceptance 1 (신 레인)**: auto-judge 3회 reject로 라이브 미측정 — 3차는 활성 task 앵커가 있었고 사유에 허위 포렌식 포함 (#28842). 대체 근거(CI 테스트 + 구 레인 PASS + 프로덕션 유기 관측 경로)를 명시.

## 검증

- 문서 전용 변경. 인용한 로그 라인은 scratch `system_log_2026-08-16.jsonl`에서 재확인 가능 (base path 보존 예정).
- 부산물 이슈: #28841 (발신 주체 UI 구분), #28842 (auto-judge 사유 품질).

🤖 Generated with [Claude Code](https://claude.com/claude-code)