### PR TITLE
fix(keeper): 은퇴한 candidate의 quarantine이 board attention worker를 죽인다 — settle로 전환

### DIFF
--- a/lib/keeper/keeper_board_attention_worker.ml
+++ b/lib/keeper/keeper_board_attention_worker.ml
@@ -1282,22 +1282,37 @@ let reconcile_quarantines ~now ~base_path ~keeper_name =
     | [] -> Ok ()
     | partition :: rest ->
       let* candidates = Candidate.load_candidates ~base_path ~keeper_name in
-      let* candidate =
-        match
-          List.find_opt
-            (fun candidate ->
-               String.equal
-                 candidate.Candidate.candidate_id
-                 partition.Partition.candidate_id)
-            candidates
-        with
-        | Some candidate -> Ok candidate
-        | None ->
-          Error
-            ("partition candidate is absent during quarantine reconciliation: "
-             ^ partition.candidate_id)
-      in
-      (match partition.state, Candidate.status_view candidate.status with
+      (match
+         List.find_opt
+           (fun candidate ->
+              String.equal
+                candidate.Candidate.candidate_id
+                partition.Partition.candidate_id)
+           candidates
+       with
+       | None ->
+         (* Mirror of the Completed finalizer's [Candidate_absent] outcome
+            (#28770): a retire moves the whole candidate store aside and
+            leaves no tombstone, so a quarantine naming a retired candidate
+            can never be acknowledged or requeued. Erroring here fataled the
+            whole worker at every process start (stage=process_recovery,
+            2026-08-16, three fleet keepers), which is exactly the permanent
+            re-encounter the finalizer branch exists to stop. Terminal
+            Blocked settles; every other state passes through the same way a
+            present candidate with a non-quarantine status does below. *)
+         (match partition.state with
+          | Partition.Blocked _ ->
+            Log.Keeper.error
+              "Board attention candidate permanently absent during quarantine reconciliation; settling blocked partition keeper=%s partition=%s candidate=%s"
+              keeper_name
+              partition.partition_id
+              partition.candidate_id;
+            let* (_ : Partition.t) = Partition.settle ~now ~base_path ~partition in
+            loop rest
+          | Partition.Ready | Partition.Running _ | Partition.Completed _
+          | Partition.Settled _ -> loop rest)
+       | Some candidate ->
+         (match partition.state, Candidate.status_view candidate.status with
        | ( Partition.Blocked _
          , (Candidate.Suspended_quarantine state
            | Candidate.Requeued_resumable { quarantine = state; _ }) )
@@ -1377,11 +1392,11 @@ let reconcile_quarantines ~now ~base_path ~keeper_name =
          Error
            ("Ready partition is not the quarantined generation successor: "
             ^ partition.partition_id)
-       | Partition.Ready, _
-       | Partition.Running _, _
-       | Partition.Completed _, _
-       | Partition.Settled _, _ ->
-         loop rest)
+          | Partition.Ready, _
+          | Partition.Running _, _
+          | Partition.Completed _, _
+          | Partition.Settled _, _ ->
+            loop rest))
   in
   loop partitions
 ;;
@@ -1937,6 +1952,7 @@ let run
 module For_testing = struct
   type nonrec rearm_scheduler = rearm_scheduler
 
+  let reconcile_quarantines = reconcile_quarantines
   let process_next = process_next
   let process_next_exact = process_next_exact
   let process_next_with_claim_ready_exact = process_next_with_claim_ready_exact

--- a/lib/keeper/keeper_board_attention_worker.mli
+++ b/lib/keeper/keeper_board_attention_worker.mli
@@ -102,6 +102,12 @@ val settle_one_completed :
 module For_testing : sig
   type rearm_scheduler
 
+  val reconcile_quarantines :
+    now:float -> base_path:string -> keeper_name:string -> (unit, string) result
+  (** The process-start quarantine reconciliation pass [run] performs.
+      Exposed so a test can drive the retired-candidate settlement without
+      standing up the full Eio worker lifecycle. *)
+
   val drain_outcome_label : drain_outcome -> string
   (** The drain verdict as one token, as logged. Retry_later keeps its reason
       so a worker stuck on a moved generation is distinguishable from one

--- a/test/test_keeper_board_attention_worker.ml
+++ b/test/test_keeper_board_attention_worker.ml
@@ -2328,6 +2328,50 @@ let test_undrained_outcomes_are_not_routine () =
    rondo 13x/25min the next, before both were data-cut by hand). This pins
    that the finalizer now settles such a partition once, terminally, and
    never revisits it. *)
+let test_reconcile_quarantines_settles_a_blocked_partition_whose_candidate_was_retired
+  ()
+  =
+  with_temp_base "board-attention-worker-quarantine-retired" @@ fun base_path ->
+  let persisted = record ~base_path (candidate ()) in
+  let attempt = provenance "quarantine-retired" in
+  let execute ~before_dispatch ~before_advance:_ _prepared =
+    ok "bind quarantine attempt" (before_dispatch attempt);
+    Error (E.Exact_execution_failed [ attempt ])
+  in
+  (match
+     ok
+       "fail to Blocked"
+       (process ~base_path ~prepare:(fun candidate -> Ok candidate) ~execute)
+   with
+   | W.Partition_blocked { candidate_id; _ }
+     when String.equal candidate_id persisted.candidate_id -> ()
+   | _ -> Alcotest.fail "fixture did not reach Blocked");
+  (* Same retire simulation as
+     test_settle_one_completed_terminalizes_a_partition_whose_candidate_was_retired:
+     move the whole per-keeper candidate ledger aside; the partition journal
+     still names the candidate. *)
+  let ledger_path =
+    Filename.concat
+      (Filename.concat
+         (Common.masc_dir_from_base_path ~base_path)
+         "board_attention_candidates")
+      "sangsu.jsonl"
+  in
+  Sys.remove ledger_path;
+  (* Before the fix this returned Error "partition candidate is absent during
+     quarantine reconciliation: ..." and fataled the worker at process start. *)
+  ok
+    "reconcile settles the orphaned quarantine instead of failing"
+    (W.For_testing.reconcile_quarantines ~now:10.0 ~base_path ~keeper_name:"sangsu");
+  (match (load_one_partition ~base_path).state with
+   | P.Settled _ -> ()
+   | _ ->
+     Alcotest.fail "blocked partition with a retired candidate did not reach Settled");
+  ok
+    "second reconciliation pass stays a no-op"
+    (W.For_testing.reconcile_quarantines ~now:11.0 ~base_path ~keeper_name:"sangsu")
+;;
+
 let test_settle_one_completed_terminalizes_a_partition_whose_candidate_was_retired
   ()
   =
@@ -2548,6 +2592,10 @@ let () =
             "settle_one_completed terminalizes a partition whose candidate was retired"
             `Quick
             test_settle_one_completed_terminalizes_a_partition_whose_candidate_was_retired
+        ; Alcotest.test_case
+            "reconcile_quarantines settles a blocked partition whose candidate was retired"
+            `Quick
+            test_reconcile_quarantines_settles_a_blocked_partition_whose_candidate_was_retired
         ] )
     ]
 ;;


### PR DESCRIPTION
## 증상

`reconcile_quarantines`가 모든 partition에 대해 candidate의 ledger 존재를 상태 무관하게 요구해서, 은퇴(retire)한 candidate를 가리키는 Blocked partition 하나가 **worker 전체를 process start마다 fatal**시켰습니다. 2026-08-16 관찰 창 실측: analyst/code-reviewer/kidsnote 3 keeper에서 `board attention worker stopped ... stage=process_recovery` — board attention 기능이 그 keeper들에서 죽어 있었습니다.

## 근본

#28770이 Completed finalizer 경로에 세운 계약과 같은 상황입니다 — retire는 store 전체를 옆으로 옮기고 tombstone을 남기지 않으므로 부재는 영구적이고, 그 quarantine은 영원히 acknowledge/requeue될 수 없습니다. 에러로 두면 매 process start마다 같은 partition을 다시 만나는 영구 재조우가 됩니다 (정확히 #28770이 finalizer에서 막은 패턴).

## 수리

부재 candidate + Blocked partition → #28770과 같은 error-level 영수증 로그 + `Partition.settle`(terminal Blocked → Settled). 그 외 상태는 candidate가 있되 quarantine 상태가 아닌 경우와 동일하게 통과(기존 skip 아암과 동형). catch-all 없음 — 상태 전부 명시.

## 검증

- feature test: 실제 retire 시뮬레이션(per-keeper candidate ledger를 옆으로 이동, 기존 #28770 테스트와 동일 기법)으로 Blocked+quarantine partition을 만들고 reconcile 호출 → Ok + Settled + 2회차 no-op. **수리 전 코드에서 이 테스트가 실제로 FAIL함을 확인**한 뒤 수리를 얹었습니다.
- `dune build --root .` 기존 worker suite 35개 + 신규 1개 = 36/36 OK.
- `reconcile_quarantines`는 `For_testing`으로만 노출 (이 모듈의 기존 관례 — process_next 등과 동일).

## 배포 노트

병합·배포 후 다음 process start에서 고아 quarantine들이 1회 settle되며 keeper당 error 영수증 로그 1줄씩 남는 게 정상입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)