### PR TITLE
fix(sidecar): 재시작 판단이 남은 파일 대신 pid 를 본다

### DIFF
--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -368,10 +368,68 @@ let write_attempt_record ~base_path ~id record =
   atomic_write_file ~path (Yojson.Safe.to_string (attempt_record_json record) ^ "\n")
 ;;
 
-let observed_state_of_status_json = function
+(* Does the pid the sidecar wrote still exist? Signal 0 performs the
+   permission and existence checks without delivering anything; EPERM means
+   the process is there and owned by somebody else, which is still alive. *)
+let pid_is_running pid =
+  pid > 0
+  &&
+  match Unix.kill pid 0 with
+  | () -> true
+  | exception Unix.Unix_error (Unix.EPERM, _, _) -> true
+  | exception Unix.Unix_error (_, _, _) -> false
+;;
+
+(* Total field access: a malformed record parses to something that is not an
+   object, and asking it for a member raises. *)
+let status_field key = function
+  | `Assoc fields -> List.assoc_opt key fields
+  | _ -> None
+;;
+
+let heartbeat_is_fresh ~now ~stale_after_sec status =
+  match status_field "updated_at" status with
+  | Some (`String updated_at) ->
+    (match Types_core.parse_iso8601_opt updated_at with
+     | Some stamped -> now -. stamped <= float_of_int stale_after_sec
+     | None -> false)
+  | Some _ | None -> false
+;;
+
+(* Whether a sidecar process is actually running. [available] next door only
+   says a status file was found, and a file is not a process: [run.sh stop]
+   sends SIGTERM and nothing — not the script, not the bot's StatusStore,
+   which has no delete path — ever removes the file. Reading presence as
+   liveness made the first stop permanent, because every later start
+   reconciled to "already_available" against the leftovers.
+
+   The stamp alone cannot replace it. A sidecar's shutdown path
+   (Bot.stop_status_heartbeat) writes one final record, and that record says
+   [connected: true] with the current time, so a just-stopped sidecar leaves
+   behind the freshest possible claim of liveness. The dashboard's restart is
+   stop → 800ms → start, which lands inside that window every time.
+
+   The pid in the record is the part that stops being true when the process
+   dies. Both are checked: the pid alone would be fooled by pid reuse, and the
+   stamp alone would be fooled by the shutdown write and by a bot whose
+   heartbeat thread died under a live process. Neither answer is a guess — a
+   record that cannot produce a readable stamp and a running pid does not
+   establish that a process is there, and restarting is the recoverable
+   direction. *)
+let observed_state_of_status_json ?(now = Unix.gettimeofday ()) ~id json =
+  match json with
   | `Assoc fields ->
+    let stale_after_sec = status_stale_sec id in
+    let status = Option.value (List.assoc_opt "status" fields) ~default:`Null in
+    let pid =
+      match status_field "pid" status with
+      | Some (`Int pid) -> pid
+      | Some _ | None -> 0
+    in
     (match List.assoc_opt "available" fields with
-     | Some (`Bool true) -> Observed_available
+     | Some (`Bool true)
+       when heartbeat_is_fresh ~now ~stale_after_sec status && pid_is_running pid ->
+       Observed_available
      | _ -> Observed_unavailable)
   | _ -> Observed_unavailable
 ;;
@@ -488,7 +546,7 @@ let attempt_fields = function
 ;;
 
 let lifecycle_json ~base_path id status_json =
-  let observed_state = observed_state_of_status_json status_json in
+  let observed_state = observed_state_of_status_json ~id status_json in
   let previous_attempt, attempt_error_fields =
     match read_attempt_record_result ~base_path id with
     | Ok previous_attempt -> previous_attempt, []
@@ -954,7 +1012,7 @@ let handle_start state request reqd =
              session and redirects stdio to [/dev/null], so the sidecar
              survives backend restart without retaining server FDs. *)
              let status_json = read_status_json ~base_path id in
-             let observed_state = observed_state_of_status_json status_json in
+             let observed_state = observed_state_of_status_json ~id status_json in
              let reconcile_result =
                reconcile_desired_once
                  ~current_generation:desired.generation

--- a/lib/server/server_routes_http_routes_sidecar.mli
+++ b/lib/server/server_routes_http_routes_sidecar.mli
@@ -1,11 +1,16 @@
 (** Server Routes — sidecar HTTP API.
 
-    Implements [/api/sidecar/<id>/...] for the Discord / cron / connector
-    sidecars: status, start/stop, log tail, GET/PUT TOML config, schema
-    introspection, and the desired-state reconciler that drives the
-    sidecar restart loop.  Mostly path-resolution + filesystem helpers
-    plus a small declarative-state pair (desired_record / attempt_record)
-    persisted as JSON under [.masc/sidecars]. *)
+    Implements [/api/sidecar/<id>/...] for the connector sidecars that run
+    as their own process — imessage and telegram; Discord and Slack moved
+    in-process (RFC-0203 Phase 3, RFC-0317) and the dashboard hides these
+    controls for them.  Serves status, start/stop, log tail, GET/PUT TOML
+    config, and schema introspection.
+
+    The desired-state pair (desired_record / attempt_record, persisted as
+    JSON under [.masc/sidecars]) is reconciled once per start request, in
+    [handle_start].  Nothing reconciles on a timer: [add_routes] takes no
+    switch or clock, so a sidecar that dies on its own stays down until an
+    operator asks for it again. *)
 
 module Http = Http_server_eio
 (** Local alias for the Eio HTTP server module. *)
@@ -82,12 +87,20 @@ val legacy_status_rel : string -> string
 type sidecar_status_config = {
   env_names : string list;
   toml_keys : string list;
+  stale_after_env_name : string;
 }
-(** Names to consult when resolving a sidecar's "is enabled" flag. *)
+(** Where a sidecar's status file may be configured, and the variable
+    naming the age at which its heartbeat stops counting as alive. *)
 
 val sidecar_status_config : string -> sidecar_status_config
-(** Per-sidecar [sidecar_status_config] (Discord checks
-    [DISCORD_BOT_TOKEN] etc.). *)
+(** Per-sidecar status config; raises on an id outside {!known_ids}. *)
+
+val default_status_stale_sec : int
+
+val status_stale_sec : string -> int
+(** Heartbeat age limit for this sidecar, from its
+    [MASC_*_STATUS_STALE_SEC] variable — the same window the gate state
+    modules apply when rendering "stale". *)
 
 val read_file : string -> string
 (** Read whole file; returns empty string when the file is missing. *)

--- a/lib/server/server_routes_http_sidecar_paths.ml
+++ b/lib/server/server_routes_http_sidecar_paths.ml
@@ -125,26 +125,47 @@ let legacy_status_rel id =
 type sidecar_status_config =
   { env_names : string list
   ; toml_keys : string list
+  ; stale_after_env_name : string
+      (** Age at which this sidecar's heartbeat stops counting as alive.
+          The same variable the connector registry reads to render
+          "stale" (lib/gate/channel_gate_*_state.ml) — an operator who
+          widens the window for a slow-heartbeating bot must widen it for
+          the restart decision too, or Start would fork a second process
+          onto the same token. *)
   }
 
 let sidecar_status_config = function
   | "discord" ->
     { env_names = [ "DISCORD_STATUS_PATH"; "discord_status_path" ]
     ; toml_keys = [ "discord_status_path"; "status_path" ]
+    ; stale_after_env_name = "MASC_DISCORD_STATUS_STALE_SEC"
     }
   | "imessage" ->
     { env_names = [ "IMESSAGE_STATUS_PATH"; "status_path" ]
     ; toml_keys = [ "status_path" ]
+    ; stale_after_env_name = "MASC_IMESSAGE_STATUS_STALE_SEC"
     }
   | "slack" ->
     { env_names = [ "SLACK_STATUS_PATH"; "MASC_SLACK_STATUS_PATH"; "status_path" ]
     ; toml_keys = [ "status_path" ]
+    ; stale_after_env_name = "MASC_SLACK_STATUS_STALE_SEC"
     }
   | "telegram" ->
     { env_names = [ "TELEGRAM_STATUS_PATH"; "MASC_TELEGRAM_STATUS_PATH"; "status_path" ]
     ; toml_keys = [ "status_path" ]
+    ; stale_after_env_name = "MASC_TELEGRAM_STATUS_STALE_SEC"
     }
   | id -> invalid_arg (Printf.sprintf "unknown sidecar id: %s" id)
+;;
+
+(** Fallback window when the connector's variable is unset, matching the
+    default the gate state modules apply to the same variable. *)
+let default_status_stale_sec = 30
+
+let status_stale_sec id =
+  Env_config_core.get_int
+    ~default:default_status_stale_sec
+    (sidecar_status_config id).stale_after_env_name
 ;;
 
 let read_file path = Fs_compat.load_file path

--- a/lib/server/server_routes_http_sidecar_paths.mli
+++ b/lib/server/server_routes_http_sidecar_paths.mli
@@ -34,9 +34,18 @@ val legacy_status_rel : string -> string
 type sidecar_status_config =
   { env_names : string list
   ; toml_keys : string list
+  ; stale_after_env_name : string
   }
 
 val sidecar_status_config : string -> sidecar_status_config
+
+val default_status_stale_sec : int
+
+val status_stale_sec : string -> int
+(** Age at which a sidecar's heartbeat stops counting as alive, read from
+    the connector's [MASC_*_STATUS_STALE_SEC] variable — the same window the
+    gate state modules apply when rendering "stale". Raises on an id outside
+    {!known_ids}, like {!sidecar_status_config}. *)
 val read_file : string -> string
 val strip_matching_quotes : string -> string
 val parse_env_assignment : string -> (string * string) option

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=549
+UNWIRED_BASELINE=548
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -112,6 +112,7 @@ normal_targets=(
   @test/runtest-test_keeper_canary_evidence
   @test/runtest-test_keeper_canary_judge
   @test/runtest-test_slack_user_directory
+  @test/runtest-test_sidecar_lifecycle_routes
   @test/runtest-test_cancel_safe
   @test/runtest-test_cancel_wall_bucket
   @test/runtest-test_cap_blocker_structured_error

--- a/test/test_sidecar_lifecycle_routes.ml
+++ b/test/test_sidecar_lifecycle_routes.ml
@@ -674,6 +674,105 @@ let test_status_json_includes_lifecycle_shape () =
       (lifecycle |> member "operator_next_action" |> to_string))
 ;;
 
+(* A status file is not a process. [run.sh stop] only sends SIGTERM; nothing
+   removes the file, and the sidecar's own shutdown path writes one last
+   record saying [connected: true] stamped at the current time. If observed
+   liveness were file presence — or even file freshness — the first stop would
+   make the connector unrestartable, because every later start would reconcile
+   to "already_available" against a dead process's parting claim.
+
+   These fixtures use real pids so the rule is exercised through the same
+   [Unix.kill pid 0] the route runs: this process for a live one, and a child
+   that has already been reaped for a dead one. *)
+let with_status_path_env f =
+  with_env "MASC_SIDECAR_ROOT" None (fun () ->
+    with_env "DISCORD_STATUS_PATH" None (fun () ->
+      with_env "discord_status_path" None f))
+;;
+
+let reaped_pid () =
+  let pid = Unix.create_process "/bin/sh" [| "/bin/sh"; "-c"; "exit 0" |] Unix.stdin Unix.stdout Unix.stderr in
+  let rec reap () =
+    match Unix.waitpid [] pid with
+    | _ -> ()
+    | exception Unix.Unix_error (Unix.EINTR, _, _) -> reap ()
+  in
+  reap ();
+  pid
+;;
+
+let now_iso () = Masc_domain.iso8601_of_unix_seconds (Unix.time ())
+
+let observed_state_of_record ~updated_at ~pid =
+  with_status_path_env (fun () ->
+    with_temp_dir "sidecar-liveness" (fun base_path ->
+      write_file
+        (Routes.status_file ~base_path "discord")
+        (Printf.sprintf
+           {|{"connected":true,"pid":%d,"updated_at":"%s"}|}
+           pid
+           updated_at);
+      (match
+         Routes.write_desired_record
+           ~base_path
+           ~id:"discord"
+           ~updated_by:"test"
+           Routes.Desired_running
+       with
+       | Ok _ -> ()
+       | Error msg -> failf "desired write failed: %s" msg);
+      Routes.read_status_json ~base_path "discord"
+      |> Yojson.Safe.Util.member "sidecar_lifecycle"
+      |> Yojson.Safe.Util.member "observed_state"
+      |> Yojson.Safe.Util.to_string))
+;;
+
+let test_stopped_sidecar_parting_record_is_not_available () =
+  (* The live failure: the dashboard restarts with stop → 800ms → start, which
+     always lands inside the stale window of the shutdown write. Only the dead
+     pid distinguishes that record from a running bot. *)
+  check
+    string
+    "a fresh record from a stopped process does not block its restart"
+    "unavailable"
+    (observed_state_of_record ~updated_at:(now_iso ()) ~pid:(reaped_pid ()))
+;;
+
+let test_running_sidecar_is_observed_available () =
+  (* The other side of the same rule: a live sidecar must keep suppressing the
+     start. [run.sh start] has no already-running guard, so a wrong answer here
+     forks a second bot onto the same token. *)
+  check
+    string
+    "a heartbeating process with a live pid is running"
+    "available"
+    (observed_state_of_record ~updated_at:(now_iso ()) ~pid:(Unix.getpid ()))
+;;
+
+let test_stale_heartbeat_is_not_observed_available () =
+  (* Pid alive, heartbeat aged out: the process exists but has stopped
+     reporting, which is the state an operator restarts out of. Also what pid
+     reuse looks like from here. *)
+  check
+    string
+    "a live pid that stopped heartbeating is not a working sidecar"
+    "unavailable"
+    (observed_state_of_record
+       ~updated_at:"2020-01-01T00:00:00Z"
+       ~pid:(Unix.getpid ()))
+;;
+
+let test_unreadable_heartbeat_is_not_observed_available () =
+  (* No parseable stamp means the record establishes nothing about the
+     process. Restarting a bot that writes garbage is the recoverable
+     direction. *)
+  check
+    string
+    "a record with no readable heartbeat cannot claim liveness"
+    "unavailable"
+    (observed_state_of_record ~updated_at:"not-a-timestamp" ~pid:(Unix.getpid ()))
+;;
+
 let test_status_json_exposes_dashboard_provenance () =
   with_temp_dir "sidecar-status-provenance" (fun base_path ->
     let json = Routes.read_status_json ~base_path "discord" in
@@ -1193,6 +1292,22 @@ let () =
             "status JSON exposes dashboard provenance"
             `Quick
             test_status_json_exposes_dashboard_provenance
+        ; test_case
+            "stopped sidecar's parting record does not block restart"
+            `Quick
+            test_stopped_sidecar_parting_record_is_not_available
+        ; test_case
+            "running sidecar is observed available"
+            `Quick
+            test_running_sidecar_is_observed_available
+        ; test_case
+            "stale heartbeat is not observed available"
+            `Quick
+            test_stale_heartbeat_is_not_observed_available
+        ; test_case
+            "unreadable heartbeat is not observed available"
+            `Quick
+            test_unreadable_heartbeat_is_not_observed_available
         ] )
     ; ( "config_write_helpers"
       , [ test_case "escape: quotes + backslash" `Quick test_escape_quotes_and_backslash


### PR DESCRIPTION
## 증상

sidecar 를 한 번 멈추면 다시 켤 수 없었어요. `POST /api/v1/sidecar/start` 는 `202 ok:true` 를 돌려주는데 프로세스는 뜨지 않습니다.

reconcile 이 관측 상태를 `status.json` 의 **존재 여부**로 판단했는데, `run.sh stop` 은 SIGTERM 만 보내고 그 파일을 지우는 코드가 어디에도 없습니다 (스크립트에도, 봇의 `StatusStore` 에도). 그래서 이후 모든 start 가 죽은 프로세스의 잔해를 보고 `Reconcile_noop "already_available"` 로 빠졌습니다.

## 신선도만으로는 안 고쳐집니다

각 sidecar 의 종료 경로가 `_write_status()` 를 한 번 더 호출하는데, 그 레코드는 `connected=True` 를 **현재 시각** 으로 박습니다 (`sidecars/{slack,telegram,imessage}-bot/src/bot.py`). 방금 멈춘 sidecar 가 가장 신선한 "살아있음" 주장을 남기는 셈이에요.

대시보드의 재시작은 `stop → 800ms → start` 라서 (`connector-config-form.ts:265`) 매번 그 창 안에 떨어집니다.

## 판단 기준

레코드에서 프로세스가 죽으면 같이 거짓이 되는 값은 `pid` 입니다. 그래서 살아있음 = **커넥터 자신의 `MASC_*_STATUS_STALE_SEC` 창 안의 읽히는 heartbeat** + **아직 존재하는 pid** 둘 다입니다.

둘 다 필요한 이유:
- pid 만 보면 pid 재사용에 속습니다
- stamp 만 보면 위의 종료 write, 그리고 heartbeat 스레드만 죽고 프로세스는 살아있는 경우에 속습니다

`run.sh start` 에는 이미 떠 있는지 확인하는 가드가 없어서, 살아있는 sidecar 를 "안 떴다" 고 답하면 같은 토큰으로 봇이 두 개 뜹니다. 그래서 반대 방향 오답도 테스트로 막았어요.

## 범위

아직 자기 프로세스로 도는 **imessage, telegram** 에 닿습니다. Discord/Slack 은 in-process 로 옮겨갔고 (RFC-0203 Phase 3, RFC-0317) 대시보드가 이 버튼들을 숨깁니다 (`IN_PROCESS_CONNECTOR_IDS`).

모듈 헤더가 이 reconciler 를 "restart loop 를 돌린다" 고 적어놨는데, `add_routes` 는 `~sw:_ ~clock:_` 라 루프가 없습니다. 헤더를 실제 동작으로 고쳤어요.

## 검증

```
dune build @check                                    # exit 0
./_build/default/test/test_sidecar_lifecycle_routes.exe test   # 59 tests, 전부 통과
bash scripts/ocaml-structure-ratchet.sh              # OK
```

수정 전 트리에서 새 케이스 3개가 실패하는 것을 확인했습니다 (lib/ 만 stash 하고 실행):

```
[FAIL] desired_state  8  stopped sidecar's parting record does not block restart
       Expected: "unavailable"   Received: "available"
[FAIL] desired_state 10  stale heartbeat is not observed available
[FAIL] desired_state 11  unreadable heartbeat is not observed available
```

9번 (`running sidecar is observed available`) 은 수정 전에도 통과합니다 — 새 테스트가 그냥 다 빨간 게 아니라는 뜻이에요.

테스트는 실제 pid 로 `Unix.kill` 경로를 그대로 탑니다. 살아있는 쪽은 이 프로세스, 죽은 쪽은 이미 reap 한 자식 프로세스를 씁니다.

## 미검증

- CI 는 named suite 만 돌리므로 `sidecar_lifecycle_routes` 가 CI 목록에 있는지는 checks 로 확인할 예정입니다.
- 실제 imessage/telegram sidecar 를 띄웠다 멈췄다 하는 라이브 재현은 안 했습니다. 봇 종료 경로 소스와 단위 테스트까지가 근거예요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)