### PR TITLE
fix(keeper): 취소된 턴 settle 시 SSE terminal 이벤트 합성 (#28811)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1093,6 +1093,7 @@ jobs:
             @test/runtest-test_keeper_conditions_wire_parity \
             @test/runtest-test_keeper_fsm_guard_actions \
             @test/runtest-test_keeper_hitl_replay_delivery \
+            @test/runtest-test_keeper_wire_terminal \
             @test/runtest-test_keeper_invariant \
             @test/runtest-test_keeper_invocation_contract_hints \
             @test/runtest-test_keeper_path_ssot \

--- a/lib/keeper/keeper_owner.ml
+++ b/lib/keeper/keeper_owner.ml
@@ -92,6 +92,11 @@ type operation_executor =
 type operation_runner =
   { ready : keeper_name:string -> bool
   ; execute : operation_executor
+  ; on_execution_settled :
+      keeper_name:string ->
+      claimed_operation_id:Chat_operation.Operation_id.t option ->
+      execution:operation_execution ->
+      unit
   }
 
 type 'a autonomous_response =
@@ -607,6 +612,16 @@ let start
                   }
             in
             Atomic.set t.child_cancel None;
+            (try
+               runner.on_execution_settled
+                 ~keeper_name:t.keeper_name
+                 ~claimed_operation_id:!claimed_operation_id
+                 ~execution
+             with
+             | Eio.Cancel.Cancelled _ as exn -> raise exn
+             | exn ->
+               Log.Keeper.error "operation settle hook raised for %s: %s"
+                 t.keeper_name (Printexc.to_string exn));
             ignore
               (request
                  t

--- a/lib/keeper/keeper_owner.mli
+++ b/lib/keeper/keeper_owner.mli
@@ -122,11 +122,24 @@ type operation_executor =
 type operation_runner =
   { ready : keeper_name:string -> bool
   ; execute : operation_executor
+  ; on_execution_settled :
+      keeper_name:string ->
+      claimed_operation_id:Chat_operation.Operation_id.t option ->
+      execution:operation_execution ->
+      unit
   }
 (** Typed admission for the durable operation drain. [ready] must be a
     non-yielding in-memory read. When it returns [false], the FIFO head remains
     Queued and no child is started. The producer that makes the dependency
-    ready must call {!wake_operation_drain}; the Owner never polls. *)
+    ready must call {!wake_operation_drain}; the Owner never polls.
+
+    [on_execution_settled] runs on the Owner fiber after the child switch has
+    fully unwound — every executor fiber has finished or been cancelled — and
+    before the durable settle is applied. A cancelled child cannot publish its
+    own terminal event, so this is the only point that both survives the
+    cancellation and still knows the execution verdict. Implementations
+    project the verdict to live consumers (wire-terminal synthesis); they must
+    not mutate durable state. Exceptions are contained by the Owner. *)
 
 type t
 

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -95,6 +95,46 @@ type keeper_chat_stream_request = {
   direct_message : Keeper_invocation_contract.direct_message;
 }
 
+(* Wire-terminal accounting for keeper chat operations. The Dashboard
+   projection publishes AG-UI events while the turn runs inside the child
+   switch; a cancelled turn kills the projection fiber before it can emit
+   RUN_ERROR, so the stream used to close with no terminal receipt (#28811).
+   Track which operations opened a live wire stream and whether a terminal
+   made it out; the Owner settle hook synthesizes the missing terminal from
+   the execution verdict after the child switch has unwound. *)
+type operation_wire_stream = Wire_started | Wire_terminal_sent
+
+let operation_wire_streams : (string, operation_wire_stream) Hashtbl.t =
+  Hashtbl.create 32
+
+let operation_wire_streams_mu = Stdlib.Mutex.create ()
+
+let ag_ui_terminal_event (event : Ag_ui.event) =
+  match event.Ag_ui.event_type with
+  | Ag_ui.Run_finished | Ag_ui.Run_error -> true
+  | Run_started | Step_started | Step_finished | Text_message_start
+  | Text_message_content | Text_message_end | Tool_call_start
+  | Tool_call_args | Tool_call_end | State_snapshot | State_delta
+  | Custom -> false
+
+let note_operation_wire_event ~operation_id event =
+  let terminal = ag_ui_terminal_event event in
+  Stdlib.Mutex.protect operation_wire_streams_mu (fun () ->
+    match Hashtbl.find_opt operation_wire_streams operation_id, terminal with
+    | Some Wire_terminal_sent, _ -> ()
+    | _, true ->
+      Hashtbl.replace operation_wire_streams operation_id Wire_terminal_sent
+    | None, false ->
+      Hashtbl.replace operation_wire_streams operation_id Wire_started
+    | Some Wire_started, false -> ())
+
+let take_operation_wire_stream ~operation_id =
+  Stdlib.Mutex.protect operation_wire_streams_mu (fun () ->
+    let state = Hashtbl.find_opt operation_wire_streams operation_id in
+    Hashtbl.remove operation_wire_streams operation_id;
+    state)
+
+
 let keeper_chat_stream_error_json message =
   `Assoc
     [
@@ -1960,6 +2000,7 @@ let operation_executor ~state ~clock : Keeper_owner.operation_executor =
                    in
                    Option.iter
                      (fun event ->
+                        note_operation_wire_event ~operation_id event;
                         Keeper_chat_broadcast.operation_event
                           ~keeper_name
                           ~operation_id
@@ -2071,6 +2112,30 @@ let operation_executor ~state ~clock : Keeper_owner.operation_executor =
   | execution -> execution
 ;;
 
+let synthesize_wire_terminal_on_settle ~keeper_name ~operation_id ~execution =
+  match take_operation_wire_stream ~operation_id, execution with
+  | None, _ ->
+    (* No live wire stream ever opened for this operation (connector
+       channels, pre-execution failures): nothing to close. *)
+    ()
+  | Some Wire_terminal_sent, _ -> ()
+  | Some Wire_started, Keeper_owner.Operation_failed { kind; detail; _ } ->
+    let event =
+      Ag_ui.run_error
+        ~thread_id:("keeper:" ^ keeper_name)
+        ~run_id:("keeper-operation-run-" ^ operation_id)
+        ~message:detail
+        ~code:(Keeper_chat_operation.failure_kind_to_string kind)
+        ()
+    in
+    note_operation_wire_event ~operation_id event;
+    Keeper_chat_broadcast.operation_event ~keeper_name ~operation_id ~event;
+    publish_operation_live_event ~operation_id event
+  | Some Wire_started, Keeper_owner.Operation_succeeded _ ->
+    Log.Misc.warn
+      "keeper chat operation %s succeeded without a wire terminal event"
+      operation_id
+
 let operation_runner ~state ~clock : Keeper_owner.operation_runner =
   let base_path = (Mcp_server.workspace_config state).base_path in
   { ready =
@@ -2080,6 +2145,16 @@ let operation_runner ~state ~clock : Keeper_owner.operation_runner =
          | Some (_, _)
          | None -> false)
   ; execute = operation_executor ~state ~clock
+  ; on_execution_settled =
+      (fun ~keeper_name ~claimed_operation_id ~execution ->
+         match claimed_operation_id with
+         | None -> ()
+         | Some operation_id ->
+           synthesize_wire_terminal_on_settle
+             ~keeper_name
+             ~operation_id:
+               (Keeper_owner.Chat_operation.Operation_id.to_string operation_id)
+             ~execution)
   }
 ;;
 
@@ -2276,4 +2351,8 @@ module For_testing = struct
   let surface_context_to_instructions = surface_context_to_instructions
   let keeper_tool_failure_log_details = keeper_tool_failure_log_details
   let keeper_chat_stream_headers = keeper_chat_stream_headers
+  let note_operation_wire_event = note_operation_wire_event
+  let take_operation_wire_stream = take_operation_wire_stream
+  let synthesize_wire_terminal_on_settle = synthesize_wire_terminal_on_settle
+  let register_operation_live_sink = register_operation_live_sink
 end

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -243,6 +243,12 @@ type translated_keeper_stream_event =
 }
 (** Result of translating one typed AGENT_CORE stream event into keeper chat events. *)
 
+type operation_wire_stream = Wire_started | Wire_terminal_sent
+(** Wire-terminal accounting for one keeper chat operation: whether a live
+    AG-UI stream opened and whether a terminal event (RUN_FINISHED/RUN_ERROR)
+    made it out. Consumed by the Owner settle hook to synthesize the missing
+    terminal after a cancelled child switch unwinds (#28811). *)
+
 module For_testing : sig
   val parse_request : string -> (keeper_chat_stream_request, string) result
   val has_connector_context : keeper_chat_stream_request -> bool
@@ -284,4 +290,15 @@ module For_testing : sig
     error_body:string ->
     failure_class:Tool_result.tool_failure_class ->
     Yojson.Safe.t
+
+  val note_operation_wire_event : operation_id:string -> Ag_ui.event -> unit
+  val take_operation_wire_stream :
+    operation_id:string -> operation_wire_stream option
+  val synthesize_wire_terminal_on_settle :
+    keeper_name:string ->
+    operation_id:string ->
+    execution:Keeper_owner.operation_execution ->
+    unit
+  val register_operation_live_sink :
+    operation_id:string -> (Ag_ui.event -> unit) -> unit -> unit
 end

--- a/test/dune
+++ b/test/dune
@@ -1601,6 +1601,7 @@
 ; add one (include stanzas/test_name.inc) line below,
 ; sorted alphabetically.
 
+(include stanzas/test_keeper_wire_terminal.inc)
 (include stanzas/test_agent_transport_vocabulary.inc)
 (include stanzas/test_agent_api_query_params.inc)
 

--- a/test/stanzas/test_keeper_wire_terminal.inc
+++ b/test/stanzas/test_keeper_wire_terminal.inc
@@ -1,0 +1,8 @@
+; Wire-terminal synthesis for keeper chat operations (#28811): registry
+; transitions plus the settle-hook decision table that closes cancelled
+; turn streams with RUN_ERROR.
+
+(test
+ (name test_keeper_wire_terminal)
+ (modules test_keeper_wire_terminal)
+ (libraries masc_test_deps))

--- a/test/test_keeper_owner.ml
+++ b/test/test_keeper_owner.ml
@@ -79,13 +79,19 @@ let owner_ok = function
   | Error error -> fail (Owner.error_to_string error)
 ;;
 
+let noop_execution_settled ~keeper_name:_ ~claimed_operation_id:_ ~execution:_ =
+  ()
+;;
+
 let start_owner_with_executor_ready
+      ?(on_execution_settled = noop_execution_settled)
       ~operation_ready
       ~sw
       ~store
       ~operation_executor
       ~keeper_name
       ~initial_meta
+      ()
   =
   let path = Filename.temp_file "keeper-owner-operations-" ".sqlite3" in
   Unix.unlink path;
@@ -98,21 +104,32 @@ let start_owner_with_executor_ready
     ~now:(fun () -> 42.0)
     ~operation_runner:
       (Option.map
-         (fun execute -> Owner.{ ready = operation_ready; execute })
+         (fun execute ->
+            Owner.{ ready = operation_ready; execute; on_execution_settled })
          operation_executor)
     ~on_turn_slot_released:None
     ~keeper_name
     ~initial_meta
 ;;
 
-let start_owner_with_executor ~sw ~store ~operation_executor ~keeper_name ~initial_meta =
+let start_owner_with_executor
+      ?on_execution_settled
+      ~sw
+      ~store
+      ~operation_executor
+      ~keeper_name
+      ~initial_meta
+      ()
+  =
   start_owner_with_executor_ready
+    ?on_execution_settled
     ~operation_ready:(fun ~keeper_name:_ -> true)
     ~sw
     ~store
     ~operation_executor
     ~keeper_name
     ~initial_meta
+    ()
 ;;
 
 let start_owner ~sw ~store ~keeper_name ~initial_meta =
@@ -122,6 +139,7 @@ let start_owner ~sw ~store ~keeper_name ~initial_meta =
     ~operation_executor:None
     ~keeper_name
     ~initial_meta
+    ()
 ;;
 
 let operation_id value =
@@ -735,7 +753,8 @@ let test_stopping_cancels_and_joins_active_child () =
          ~store:{ replace = (fun _ -> Ok ()); remove = (fun _ -> Ok ()) }
          ~operation_executor:(Some operation_executor)
          ~keeper_name:"stopping-active-child"
-         ~initial_meta:(Some (make_meta "stopping-active-child")))
+         ~initial_meta:(Some (make_meta "stopping-active-child"))
+         ())
   in
   let operation_id = operation_id "kmsg-stopping-active-child" in
   ignore
@@ -956,7 +975,8 @@ let test_chat_lane_holder_blocks_autonomous_admission () =
          ~store:{ replace = (fun _ -> Ok ()); remove = (fun _ -> Ok ()) }
          ~operation_executor:(Some execute)
          ~keeper_name:"cross-lane-exclusion"
-         ~initial_meta:(Some (make_meta "cross-lane-exclusion")))
+         ~initial_meta:(Some (make_meta "cross-lane-exclusion"))
+         ())
   in
   ignore
     (owner_ok
@@ -1104,7 +1124,8 @@ let test_operation_executor_claims_latest_input_and_drains_fifo () =
          ~store:{ replace = (fun _ -> Ok ()); remove = (fun _ -> Ok ()) }
          ~operation_executor:(Some operation_executor)
          ~keeper_name:"operation-executor"
-         ~initial_meta:(Some (make_meta "operation-executor")))
+         ~initial_meta:(Some (make_meta "operation-executor"))
+         ())
   in
   let first_id = operation_id "kmsg-operation-executor-first" in
   let second_id = operation_id "kmsg-operation-executor-second" in
@@ -1173,7 +1194,8 @@ let test_operation_executor_exception_is_terminal_and_next_runs () =
          ~store:{ replace = (fun _ -> Ok ()); remove = (fun _ -> Ok ()) }
          ~operation_executor:(Some operation_executor)
          ~keeper_name:"operation-exception"
-         ~initial_meta:(Some (make_meta "operation-exception")))
+         ~initial_meta:(Some (make_meta "operation-exception"))
+         ())
   in
   let first_id = operation_id "kmsg-operation-exception-first" in
   let second_id = operation_id "kmsg-operation-exception-second" in
@@ -1229,7 +1251,8 @@ let test_paused_owner_preserves_queue_until_resume () =
          ~store:{ replace = (fun _ -> Ok ()); remove = (fun _ -> Ok ()) }
          ~operation_executor:(Some operation_executor)
          ~keeper_name:"paused-operation"
-         ~initial_meta:(Some (make_meta "paused-operation")))
+         ~initial_meta:(Some (make_meta "paused-operation"))
+         ())
   in
   ignore
     (owner_ok
@@ -1311,7 +1334,8 @@ let test_pause_rechecks_pending_claim_admission () =
          ~store:{ replace = (fun _ -> Ok ()); remove = (fun _ -> Ok ()) }
          ~operation_executor:(Some operation_executor)
          ~keeper_name:"pause-pending-claim"
-         ~initial_meta:(Some (make_meta "pause-pending-claim")))
+         ~initial_meta:(Some (make_meta "pause-pending-claim"))
+         ())
   in
   let operation_id = operation_id "kmsg-pause-pending-claim" in
   ignore
@@ -1590,7 +1614,8 @@ let test_owner_linearizes_autonomous_and_chat_children () =
          ~store:{ replace = (fun _ -> Ok ()); remove = (fun _ -> Ok ()) }
          ~operation_executor:(Some operation_executor)
          ~keeper_name:"single-turn-owner"
-         ~initial_meta:(Some (make_meta "single-turn-owner")))
+         ~initial_meta:(Some (make_meta "single-turn-owner"))
+         ())
   in
   let autonomous_result = Eio.Stream.create 1 in
   Eio.Fiber.fork ~sw (fun () ->
@@ -1662,7 +1687,8 @@ let test_unready_chat_queue_does_not_block_autonomous () =
          ~store:{ replace = (fun _ -> Ok ()); remove = (fun _ -> Ok ()) }
          ~operation_executor:(Some operation_executor)
          ~keeper_name:"unready-chat-owner"
-         ~initial_meta:(Some (make_meta "unready-chat-owner")))
+         ~initial_meta:(Some (make_meta "unready-chat-owner"))
+         ())
   in
   let operation_id = operation_id "kmsg-unready-chat-owner" in
   ignore

--- a/test/test_keeper_owner.ml
+++ b/test/test_keeper_owner.ml
@@ -735,6 +735,10 @@ let test_stopping_cancels_and_joins_active_child () =
   let child_started, resolve_child_started = Eio.Promise.create () in
   let child_released, resolve_child_released = Eio.Promise.create () in
   let never, _resolve_never = Eio.Promise.create () in
+  let settled = ref None in
+  let record_settled ~keeper_name ~claimed_operation_id ~execution =
+    settled := Some (keeper_name, claimed_operation_id, execution)
+  in
   let operation_executor ~sw:child_sw ~keeper_name:_ ~claim =
     match claim () with
     | Error error -> fail (Owner.error_to_string error)
@@ -749,6 +753,7 @@ let test_stopping_cancels_and_joins_active_child () =
   let owner =
     owner_ok
       (start_owner_with_executor
+         ~on_execution_settled:record_settled
          ~sw
          ~store:{ replace = (fun _ -> Ok ()); remove = (fun _ -> Ok ()) }
          ~operation_executor:(Some operation_executor)
@@ -768,16 +773,38 @@ let test_stopping_cancels_and_joins_active_child () =
   ignore (owner_ok (Owner.begin_stopping owner));
   Eio.Promise.await child_released;
   let operation = Option.get (owner_ok (Owner.exact_operation owner operation_id)) in
-  match operation.state with
-  | Chat_operation.Failed { failure = { kind; _ }; _ } ->
-    check string
-      "stopped active child is terminal"
+  (match operation.state with
+   | Chat_operation.Failed { failure = { kind; _ }; _ } ->
+     check string
+       "stopped active child is terminal"
+       "Turn_cancelled"
+       (Chat_operation.failure_kind_to_string kind)
+   | state ->
+     fail
+       ("stopping returned before terminal persistence: "
+        ^ Chat_operation.state_to_string state));
+  match !settled with
+  | Some (settled_keeper, Some claimed_id, Owner.Operation_failed { kind; detail; _ })
+    ->
+    check string "settle hook keeper" "stopping-active-child" settled_keeper;
+    check
+      string
+      "settle hook operation id"
+      (Chat_operation.Operation_id.to_string operation_id)
+      (Chat_operation.Operation_id.to_string claimed_id);
+    check
+      string
+      "settle hook failure kind"
       "Turn_cancelled"
-      (Chat_operation.failure_kind_to_string kind)
-  | state ->
-    fail
-      ("stopping returned before terminal persistence: "
-       ^ Chat_operation.state_to_string state)
+      (Chat_operation.failure_kind_to_string kind);
+    check
+      string
+      "settle hook detail"
+      "Keeper owner stopped the active turn"
+      detail
+  | Some (_, None, _) -> fail "settle hook fired without a claimed operation id"
+  | Some (_, _, Owner.Operation_succeeded _) -> fail "cancelled turn settled as success"
+  | None -> fail "settle hook did not fire before stop completed"
 ;;
 
 let test_stopping_cancels_and_joins_autonomous_child () =
@@ -863,7 +890,12 @@ let test_turn_slot_release_signals_availability () =
          ~operation_store_path:path
          ~now:(fun () -> 42.0)
          ~operation_runner:
-           (Some Owner.{ ready = (fun ~keeper_name:_ -> true); execute })
+           (Some
+              Owner.
+                { ready = (fun ~keeper_name:_ -> true)
+                ; execute
+                ; on_execution_settled = noop_execution_settled
+                })
          ~on_turn_slot_released:(Some (fun () -> incr released))
          ~keeper_name:"slot-release"
          ~initial_meta:(Some (make_meta "slot-release")))
@@ -1472,7 +1504,12 @@ let test_startup_queued_waits_for_runner_readiness () =
               ~operation_store_path:path
               ~now:(fun () -> 20.0)
               ~operation_runner:
-                (Some Owner.{ ready = (fun ~keeper_name:_ -> !ready); execute })
+                (Some
+                   Owner.
+                     { ready = (fun ~keeper_name:_ -> !ready)
+                     ; execute
+                     ; on_execution_settled = noop_execution_settled
+                     })
               ~on_turn_slot_released:None
               ~keeper_name:"ready-after-registration"
               ~initial_meta:(Some (make_meta "ready-after-registration")))

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -1037,6 +1037,8 @@ let test_supervise_keepalive_wakes_ready_operation_drain () =
                   Eio.Promise.await release_executor;
                   Masc.Keeper_owner.Operation_succeeded
                     { outcome_ref = "supervisor-ready-wake" })
+         ; on_execution_settled =
+             (fun ~keeper_name:_ ~claimed_operation_id:_ ~execution:_ -> ())
          }
        in
        (match

--- a/test/test_keeper_wire_terminal.ml
+++ b/test/test_keeper_wire_terminal.ml
@@ -1,0 +1,140 @@
+(* Wire-terminal synthesis for keeper chat operations (#28811).
+
+   A cancelled turn kills the AG-UI projection fiber inside the child switch
+   before it can emit RUN_ERROR, so the SSE stream used to close with no
+   terminal receipt. The server tracks per-operation wire activity and the
+   Owner settle hook synthesizes the missing terminal from the execution
+   verdict. These tests pin the registry transitions and the synthesis
+   decision table. *)
+
+open Alcotest
+open Masc
+module Stream = Server_routes_http_keeper_stream
+
+let custom_event () =
+  Ag_ui.of_custom ~name:"TEST_EVENT" (`Assoc [ ("ok", `Bool true) ])
+
+let run_error_event () =
+  Ag_ui.run_error ~thread_id:"keeper:test" ~message:"boom" ()
+
+let failed_execution detail =
+  Keeper_owner.Operation_failed
+    { kind = Keeper_chat_operation.Turn_cancelled
+    ; detail
+    ; outcome_ref = None
+    }
+
+let test_note_marks_started_then_terminal () =
+  let operation_id = "op-wire-note" in
+  Stream.For_testing.note_operation_wire_event ~operation_id (custom_event ());
+  (match Stream.For_testing.take_operation_wire_stream ~operation_id with
+   | Some Stream.Wire_started -> ()
+   | Some Stream.Wire_terminal_sent -> fail "custom event marked terminal"
+   | None -> fail "custom event did not open a wire stream");
+  Stream.For_testing.note_operation_wire_event ~operation_id (custom_event ());
+  Stream.For_testing.note_operation_wire_event ~operation_id (run_error_event ());
+  (match Stream.For_testing.take_operation_wire_stream ~operation_id with
+   | Some Stream.Wire_terminal_sent -> ()
+   | Some Stream.Wire_started -> fail "terminal event left the stream open"
+   | None -> fail "terminal event dropped the stream record");
+  check bool "take consumes the record" true
+    (Option.is_none (Stream.For_testing.take_operation_wire_stream ~operation_id))
+
+let collect_sink () =
+  let events = ref [] in
+  let sink event = events := event :: !events in
+  (events, sink)
+
+let test_settle_synthesizes_run_error_for_open_stream () =
+  let operation_id = "op-wire-cancelled" in
+  let events, sink = collect_sink () in
+  let unregister =
+    Stream.For_testing.register_operation_live_sink ~operation_id sink
+  in
+  Fun.protect ~finally:unregister @@ fun () ->
+  Stream.For_testing.note_operation_wire_event ~operation_id (custom_event ());
+  Stream.For_testing.synthesize_wire_terminal_on_settle
+    ~keeper_name:"wire-test"
+    ~operation_id
+    ~execution:(failed_execution "Keeper owner stopped the active turn");
+  (match !events with
+   | [ event ] ->
+     (match event.Ag_ui.event_type with
+      | Ag_ui.Run_error -> ()
+      | _ -> fail "synthesized event is not RUN_ERROR");
+     let sse = Ag_ui.event_to_sse event in
+     check bool "reason travels on the wire" true
+       (Astring.String.is_infix
+          ~affix:"Keeper owner stopped the active turn" sse);
+     check bool "failure kind travels as code" true
+       (Astring.String.is_infix ~affix:"Turn_cancelled" sse)
+   | events ->
+     fail
+       (Printf.sprintf "expected exactly one synthesized event, got %d"
+          (List.length events)));
+  (* Settle consumed the record: a second settle stays silent. *)
+  Stream.For_testing.synthesize_wire_terminal_on_settle
+    ~keeper_name:"wire-test"
+    ~operation_id
+    ~execution:(failed_execution "second settle");
+  check int "second settle synthesizes nothing" 1 (List.length !events)
+
+let test_settle_is_silent_when_terminal_already_sent () =
+  let operation_id = "op-wire-terminal-sent" in
+  let events, sink = collect_sink () in
+  let unregister =
+    Stream.For_testing.register_operation_live_sink ~operation_id sink
+  in
+  Fun.protect ~finally:unregister @@ fun () ->
+  Stream.For_testing.note_operation_wire_event ~operation_id (custom_event ());
+  Stream.For_testing.note_operation_wire_event ~operation_id (run_error_event ());
+  Stream.For_testing.synthesize_wire_terminal_on_settle
+    ~keeper_name:"wire-test"
+    ~operation_id
+    ~execution:(failed_execution "already terminal");
+  check int "no duplicate terminal" 0 (List.length !events)
+
+let test_settle_is_silent_without_wire_activity () =
+  let operation_id = "op-wire-never-opened" in
+  let events, sink = collect_sink () in
+  let unregister =
+    Stream.For_testing.register_operation_live_sink ~operation_id sink
+  in
+  Fun.protect ~finally:unregister @@ fun () ->
+  Stream.For_testing.synthesize_wire_terminal_on_settle
+    ~keeper_name:"wire-test"
+    ~operation_id
+    ~execution:(failed_execution "no stream ever opened");
+  check int "no synthesis without wire activity" 0 (List.length !events)
+
+let test_settle_success_without_terminal_emits_nothing () =
+  let operation_id = "op-wire-success-anomaly" in
+  let events, sink = collect_sink () in
+  let unregister =
+    Stream.For_testing.register_operation_live_sink ~operation_id sink
+  in
+  Fun.protect ~finally:unregister @@ fun () ->
+  Stream.For_testing.note_operation_wire_event ~operation_id (custom_event ());
+  Stream.For_testing.synthesize_wire_terminal_on_settle
+    ~keeper_name:"wire-test"
+    ~operation_id
+    ~execution:(Keeper_owner.Operation_succeeded { outcome_ref = "ref" });
+  check int "success anomaly is logged, not synthesized" 0 (List.length !events);
+  check bool "success settle still consumes the record" true
+    (Option.is_none (Stream.For_testing.take_operation_wire_stream ~operation_id))
+
+let () =
+  Alcotest.run "keeper_wire_terminal"
+    [ ( "wire-terminal"
+      , [ test_case "note marks started then terminal" `Quick
+            test_note_marks_started_then_terminal
+        ; test_case "settle synthesizes RUN_ERROR for open stream" `Quick
+            test_settle_synthesizes_run_error_for_open_stream
+        ; test_case "settle silent when terminal already sent" `Quick
+            test_settle_is_silent_when_terminal_already_sent
+        ; test_case "settle silent without wire activity" `Quick
+            test_settle_is_silent_without_wire_activity
+        ; test_case "success without terminal emits nothing" `Quick
+            test_settle_success_without_terminal_emits_nothing
+        ] )
+    ]


### PR DESCRIPTION
## 문제 (#28811)

취소되거나 실패한 keeper 턴이 `/keepers/:name/chat/stream` SSE를 **terminal 이벤트 없이** 닫는다. 클라이언트(대시보드·canary 하네스)는 delta 0개, terminal 0개인 채 스트림이 끊겨 사인을 알 수 없다.

## 근본 원인

`process_single_turn`은 모든 실패 분기에서 terminal 이벤트를 발행하지만 `Eio.Cancel.Cancelled`만 bare re-raise 한다. 턴 취소는 `Eio.Switch.fail child_sw`로 진행되는데, AG-UI projection fiber와 adapter fiber가 **같은 child switch 위에서 함께 죽는다**. 즉 취소 시점에는 wire에 RUN_ERROR를 쓸 수 있는 fiber가 이미 없다. 취소를 관찰하고도 살아남는 유일한 지점은 child switch 밖의 owner fiber다.

## 설계

**Owner settle hook + 서버 wire-stream 레지스트리.**

1. `Keeper_owner.operation_runner`에 `on_execution_settled` 추가 — child switch가 **완전히 해제된 뒤**(Eio switch 의미론상 모든 child fiber 종료 보장), durable settle **전에**, owner fiber에서 호출. projection 전용 계약: 예외는 격리(로그만), `Cancelled`는 재전파.
2. 서버(`server_routes_http_keeper_stream`)는 operation별 wire 활동을 추적: projection이 이벤트를 흘리면 `Wire_started`, terminal(RUN_FINISHED/RUN_ERROR)이 나가면 `Wire_terminal_sent`.
3. settle 시점 결정 테이블:
   - 기록 없음 → 침묵 (wire가 열린 적 없음)
   - `Wire_terminal_sent` → 침묵 (정상 경로가 이미 닫음)
   - `Wire_started` + `Operation_failed {kind; detail}` → **RUN_ERROR 합성** (code=failure kind, message=detail, run_id/thread_id는 기존 규약 그대로) → broadcast + live sink publish
   - `Wire_started` + `Operation_succeeded` → 발행하지 않고 anomaly WARN (성공을 wire에 위조하지 않는다)

### 기각한 대안
- 죽어가는 switch 아래에서 events queue에 publish: 취소 경합으로 유실 가능 — 비결정.
- SSE 핸들러 쪽 폴링/타임아웃: 휴리스틱 추가일 뿐 사인 규명이 아님.
- projection fiber를 parent switch로 이동: 턴 취소가 projection을 정리한다는 기존 취소 의미론을 깨뜨림.

## 검증 (로컬, worktree root)

```
opam exec -- dune exec --root . test/test_keeper_wire_terminal.exe      # 5 pass
opam exec -- dune exec --root . test/test_keeper_owner.exe              # 39 pass (settle recorder assert 포함)
opam exec -- dune exec --root . test/test_keeper_supervisor.exe         # 56 pass
opam exec -- dune exec --root . test/test_keeper_chat_broadcast.exe     # 4 pass
opam exec -- dune exec --root . test/test_keeper_chat_operation_http.exe # 4 pass
```

- 신규 스위트 `test_keeper_wire_terminal`: 레지스트리 전이 + 합성 결정 테이블 5케이스 (RUN_ERROR에 detail·failure kind가 SSE로 실리는 것까지 assert).
- owner stopping 테스트: 실제 취소 경로에서 hook이 keeper 이름 / claimed operation id / `Turn_cancelled` / detail과 함께 정확히 1회 발화함을 assert.
- CI: `test/dune` include + `ci.yml` `@test/runtest-test_keeper_wire_terminal` 배선 (masc CI는 named suite만 실행).

## 후속

- #28810 (interrupt latch 누출) 이 PR 위에 스택 예정.
- adversarial review 통과 시 `review:adversarial-pass` 라벨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
