### PR TITLE
feat(keeper): first_event_timeout_s 배선 — idle이 prefill 구간을 지배하지 않게 (RFC-OAS-037)

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -556,6 +556,45 @@ module KeeperKeepalive = struct
                  detail)))
   ;;
 
+  let first_event_timeout_env_key = "MASC_KEEPER_FIRST_EVENT_TIMEOUT_SEC"
+
+  (* Fail-safe bound for the silent first-event (TTFT/prefill) wait; the
+     substitution rule lives in Keeper_runtime_resolved. Same magnitude as
+     [stream_idle_failsafe_floor_sec]: an order above real silent prefill
+     observed in production (152s mimo 1M-context 2026-07-20; ~200-525s local
+     MLX 20.7K-token keeper prompts 2026-08-16), not a per-provider tuning
+     (RFC-OAS-037 §3). *)
+  let first_event_failsafe_floor_sec = 600.0
+
+  (** Explicit first-event (TTFT/prefill) timeout for streaming AGENT_CORE
+      provider responses. Bounds only the wait for the FIRST provider event;
+      [stream_idle_timeout_sec] bounds the gaps after it. Providers that emit
+      no keepalives while prefilling are legitimately silent in this phase,
+      so this budget is distinct from — and typically longer than — the
+      inter-line idle gap (RFC-OAS-037). Unset means no explicit value; the
+      resolved layer substitutes {!first_event_failsafe_floor_sec}. A
+      configured value must be finite and strictly positive; malformed values
+      are operator configuration errors, never a fallback. Same value grammar
+      as the idle knob, hence the shared parser.
+
+      Env: [MASC_KEEPER_FIRST_EVENT_TIMEOUT_SEC]. Default: unset -> [None].
+      @category Timeouts @ops_class operator *)
+  let first_event_timeout_sec () =
+    match Env_config_core.raw_value_opt first_event_timeout_env_key with
+    | None -> None
+    | Some raw ->
+      (match parse_stream_idle_timeout_sec raw with
+       | Ok seconds -> Some seconds
+       | Error detail ->
+         raise
+           (Env_config_core.Config_error
+              (Printf.sprintf
+                 "invalid %s=%S (%s)"
+                 first_event_timeout_env_key
+                 raw
+                 detail)))
+  ;;
+
   (** Total HTTP body-consumption deadline for non-streaming AGENT_CORE completion
       calls. In agent_core this wraps [Complete.complete]'s synchronous HTTP
       body read; streaming calls deliberately ignore the knob so active

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -190,6 +190,19 @@ module KeeperKeepalive : sig
       value must be finite and strictly positive or configuration loading
       raises {!Env_config_core.Config_error}. *)
 
+  val first_event_failsafe_floor_sec : float
+  (** Resolved runtime fallback used only when the explicit first-event
+      timeout is absent. Kept beside {!stream_idle_failsafe_floor_sec} so
+      runtime execution and operator projection share one value. *)
+
+  val first_event_timeout_sec : unit -> float option
+  (** Explicit streaming-provider first-event (TTFT/prefill) timeout. Bounds
+      only the wait for the FIRST provider event; {!stream_idle_timeout_sec}
+      bounds inter-line gaps after it (RFC-OAS-037). [None] means no explicit
+      value (the resolved layer substitutes the fail-safe floor). A configured
+      value must be finite and strictly positive or configuration loading
+      raises {!Env_config_core.Config_error}. *)
+
   val body_timeout_sec_override : float option
   (** Total HTTP body-consumption deadline for non-streaming AGENT_CORE completion
       calls. [None] (env unset) leaves the runtime builder wire untouched.

--- a/lib/config/keeper_runtime_setting_registry.ml
+++ b/lib/config/keeper_runtime_setting_registry.ml
@@ -326,6 +326,15 @@ let all =
       ~category:"turn"
       "Streaming provider inter-line idle timeout"
   ; setting
+      ~range:(float_range ~min_exclusive:0.0 ())
+      ~env_name:"MASC_KEEPER_FIRST_EVENT_TIMEOUT_SEC"
+      ~exposure:(Toml_and_env "turn.first_event_timeout_sec")
+      ~value_kind:Float
+      ~default:"(failsafe 600)"
+      ~consumers:[ "Keeper_runtime_resolved"; "Runtime_agent_context" ]
+      ~category:"turn"
+      "Streaming provider first-event (TTFT/prefill) timeout"
+  ; setting
       ~range:(float_range ~min:30.0 ~max:3600.0 ())
       ~env_name:"MASC_KEEPER_PROVIDER_CALL_DEADLINE_SEC"
       ~exposure:(Toml_and_env "turn.provider_call_deadline_sec")

--- a/lib/keeper/keeper_runtime_resolved.ml
+++ b/lib/keeper/keeper_runtime_resolved.ml
@@ -11,6 +11,7 @@ type 'a field = {
 
 type t = {
   stream_idle_timeout_sec : float option field;
+  first_event_timeout_sec : float option field;
   body_timeout_override_sec : float option field;
   provider_call_deadline_sec : float option field;
 }
@@ -78,6 +79,20 @@ let stream_idle_failsafe_floor_sec =
   Env_config_keeper.KeeperKeepalive.stream_idle_failsafe_floor_sec
 ;;
 
+(* Fail-safe bound for the silent first-event (TTFT/prefill) wait (seconds).
+   When neither [MASC_KEEPER_FIRST_EVENT_TIMEOUT_SEC] nor runtime.toml
+   [turn.first_event_timeout_sec] is set, AGENT_CORE's first-event resolver
+   falls back to [body_timeout_s] (unset on streaming keeper paths) and then
+   to the inter-line idle value — a bound an order of magnitude below real
+   silent prefill (measured: 152s mimo 1M-context turn 2026-07-20; ~200-525s
+   local MLX 20.7K-token keeper prompts 2026-08-16, 9/9 canary failures at
+   the 120s idle cut). Same magnitude as the RFC-0345 idle floor: a single
+   universal liveness ceiling, NOT a per-provider tuned default
+   (RFC-OAS-037 §3). An explicit env/toml value overrides it verbatim. *)
+let first_event_failsafe_floor_sec =
+  Env_config_keeper.KeeperKeepalive.first_event_failsafe_floor_sec
+;;
+
 let freeze_from_current () =
   let stream_idle_timeout_sec =
     match Env_config_keeper.KeeperKeepalive.stream_idle_timeout_sec () with
@@ -97,6 +112,25 @@ let freeze_from_current () =
         source = Failsafe_floor;
       }
   in
+  let first_event_timeout_sec =
+    match Env_config_keeper.KeeperKeepalive.first_event_timeout_sec () with
+    | Some seconds ->
+      (* Explicit env or runtime.toml value: honoured verbatim, no floor. *)
+      {
+        value = Some seconds;
+        source = source_of_env_name "MASC_KEEPER_FIRST_EVENT_TIMEOUT_SEC";
+      }
+    | None ->
+      (* Unset: substitute the silent-prefill liveness ceiling so the
+         first-event wait is never governed by the much shorter inter-line
+         idle knob (RFC-OAS-037; see [first_event_failsafe_floor_sec]).
+         Sourced as [Failsafe_floor] so telemetry and the boot log
+         distinguish it from an operator-supplied value. *)
+      {
+        value = Some first_event_failsafe_floor_sec;
+        source = Failsafe_floor;
+      }
+  in
   let body_timeout_override_sec =
     {
       value = body_timeout_override_sec_live ();
@@ -111,6 +145,7 @@ let freeze_from_current () =
   in
   {
     stream_idle_timeout_sec;
+    first_event_timeout_sec;
     body_timeout_override_sec;
     provider_call_deadline_sec;
   }
@@ -145,12 +180,16 @@ let to_yojson (runtime : t) =
   `Assoc
     [
       ("stream_idle_timeout_sec", field_to_yojson option_float_to_yojson runtime.stream_idle_timeout_sec);
+      ("first_event_timeout_sec", field_to_yojson option_float_to_yojson runtime.first_event_timeout_sec);
       ("body_timeout_override_sec", field_to_yojson option_float_to_yojson runtime.body_timeout_override_sec);
       ("provider_call_deadline_sec", field_to_yojson option_float_to_yojson runtime.provider_call_deadline_sec);
     ]
 
 let stream_idle_timeout_sec () =
   (current ()).stream_idle_timeout_sec.value
+
+let first_event_timeout_sec () =
+  (current ()).first_event_timeout_sec.value
 
 let body_timeout_override_sec () =
   (current ()).body_timeout_override_sec.value

--- a/lib/keeper/keeper_runtime_resolved.mli
+++ b/lib/keeper/keeper_runtime_resolved.mli
@@ -8,17 +8,18 @@
     late env drift cannot change keeper execution behaviour.
 
     [stream_idle_timeout_sec] additionally substitutes a fail-safe liveness floor
-    ({!stream_idle_failsafe_floor_sec}) when unset (RFC-0345, #25128); an explicit
-    value still overrides. *)
+    ({!stream_idle_failsafe_floor_sec}) when unset (RFC-0345, #25128), and
+    [first_event_timeout_sec] substitutes {!first_event_failsafe_floor_sec}
+    (RFC-OAS-037); an explicit value still overrides either. *)
 
 type source =
   | Env
   | Toml
   | Default
   | Failsafe_floor
-      (** The compiled default was [None] (unset) and the RFC-0345 fail-safe
-          liveness floor was substituted. Applies to [stream_idle_timeout_sec]
-          only. *)
+      (** The compiled default was [None] (unset) and a fail-safe liveness
+          floor was substituted. Applies to [stream_idle_timeout_sec]
+          (RFC-0345) and [first_event_timeout_sec] (RFC-OAS-037). *)
 
 type 'a field = {
   value : 'a;
@@ -27,6 +28,7 @@ type 'a field = {
 
 type t = {
   stream_idle_timeout_sec : float option field;
+  first_event_timeout_sec : float option field;
   body_timeout_override_sec : float option field;
   provider_call_deadline_sec : float option field;
 }
@@ -59,6 +61,28 @@ val stream_idle_timeout_sec : unit -> float option
 
     SSOT: {!Env_config_keeper.KeeperKeepalive.stream_idle_timeout_sec} (raw
     parse; [None] when unset) + {!stream_idle_failsafe_floor_sec} (floor). *)
+
+val first_event_failsafe_floor_sec : float
+(** Fail-safe bound for the silent first-event (TTFT/prefill) wait, in seconds
+    (600.0 = 10 min). Substituted for [first_event_timeout_sec] when no
+    explicit value is configured, so the first-event wait is never governed by
+    the much shorter inter-line idle knob through AGENT_CORE's fallback chain
+    (RFC-OAS-037; measured silent prefill: 152s mimo 1M-context, ~200-525s
+    local MLX 20.7K-token keeper prompts). A universal liveness ceiling, not a
+    per-provider tuned default; an explicit env/toml value overrides it. *)
+
+val first_event_timeout_sec : unit -> float option
+(** Streaming-provider first-event (TTFT/prefill) timeout, in seconds. Bounds
+    only the wait for the FIRST provider event; [stream_idle_timeout_sec] arms
+    the inter-line gaps after it (RFC-OAS-037). Always [Some] at runtime: an
+    explicit [MASC_KEEPER_FIRST_EVENT_TIMEOUT_SEC] (or runtime.toml
+    [turn.first_event_timeout_sec]) is honoured verbatim; when unset,
+    {!first_event_failsafe_floor_sec} is substituted. The [float option]
+    return type mirrors the transport wiring; the resolver never yields
+    [None].
+
+    SSOT: {!Env_config_keeper.KeeperKeepalive.first_event_timeout_sec} (raw
+    parse; [None] when unset) + {!first_event_failsafe_floor_sec} (floor). *)
 
 (** Non-streaming HTTP body-consumption deadline override.
     [None] (env unset) skips [Builder.with_body_timeout]. [Some s] is

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -1172,6 +1172,11 @@ let run_named
             ; initial_messages
             ; model_input_projection
             ; stream_idle_timeout_s
+            ; first_event_timeout_s =
+                (* Keeper policy knob, injected from the resolved layer like
+                   [provider_call_deadline_sec] below instead of threading
+                   one more optional through run_named (RFC-OAS-037). *)
+                Keeper_runtime_resolved.first_event_timeout_sec ()
             ; body_timeout_s
             ; provider_call_deadline_sec =
                 Keeper_runtime_resolved.provider_call_deadline_sec ()

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -62,6 +62,10 @@ type try_provider_ctx =
   ; initial_messages : Agent_core.Types.message list
   ; model_input_projection : Agent_core.Agent.model_input_projection option
   ; stream_idle_timeout_s : float option
+  ; first_event_timeout_s : float option
+    (* Bound on the silent wait for the FIRST streaming provider event
+       (TTFT/prefill), distinct from [stream_idle_timeout_s] which arms only
+       after that event (RFC-OAS-037). *)
   ; body_timeout_s : float option
   ; (* #27349, axis changed by #28417: the ceiling for THIS provider call
        attempt. Distinct from [stream_idle_timeout_s] (streaming inter-line
@@ -728,6 +732,7 @@ let run_try_provider
     Ok
       { base_config with
         stream_idle_timeout_s = ctx.stream_idle_timeout_s
+          ; first_event_timeout_s = ctx.first_event_timeout_s
           ; body_timeout_s = ctx.body_timeout_s
           ; temperature
           ; hooks = ctx.hooks

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -29,6 +29,7 @@ type try_provider_ctx =
   ; initial_messages : Agent_core.Types.message list
   ; model_input_projection : Agent_core.Agent.model_input_projection option
   ; stream_idle_timeout_s : float option
+  ; first_event_timeout_s : float option
   ; body_timeout_s : float option
   ; provider_call_deadline_sec : float option
         (** Seconds a provider attempt may go WITHOUT a progress signal

--- a/lib/keeper_runtime/keeper_runtime_config.ml
+++ b/lib/keeper_runtime/keeper_runtime_config.ml
@@ -507,6 +507,12 @@ let effective_setting_value (row : Keeper_runtime_setting_registry.setting) =
           | None ->
             display_float
               Env_config_keeper.KeeperKeepalive.stream_idle_failsafe_floor_sec)
+       | "MASC_KEEPER_FIRST_EVENT_TIMEOUT_SEC" ->
+         (match Env_config_keeper.KeeperKeepalive.first_event_timeout_sec () with
+          | Some value -> display_float value
+          | None ->
+            display_float
+              Env_config_keeper.KeeperKeepalive.first_event_failsafe_floor_sec)
        | "MASC_KEEPER_PROVIDER_CALL_DEADLINE_SEC" ->
          display_float_option
            Env_config_keeper.KeeperKeepalive.provider_call_deadline_sec_override

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -104,6 +104,7 @@ type config =
   system_prompt : string;
   tools : Agent_core.Tool.t list;
   stream_idle_timeout_s : float option;
+  first_event_timeout_s : float option;
   body_timeout_s : float option;
   max_tokens : int option;
   temperature : float option;
@@ -301,6 +302,7 @@ let runtime_observation_for_completed_config ~total_duration_ms config =
    sources so the failure path is testable without an Eio runtime. *)
 let decide_clock_for_idle
     ~(stream_idle_timeout_s : float option)
+    ~(first_event_timeout_s : float option)
     ~(process_clock : (float Eio.Time.clock_ty Eio.Resource.t, string) result)
     ~(ctx_clock : float Eio.Time.clock_ty Eio.Resource.t option)
   : (float Eio.Time.clock_ty Eio.Resource.t option, Agent_core.Error.t) result =
@@ -308,8 +310,8 @@ let decide_clock_for_idle
   | Ok c, _ -> Ok (Some c)
   | Error _, (Some _ as c) -> Ok c
   | Error e, None ->
-    (match stream_idle_timeout_s with
-     | Some idle ->
+    (match stream_idle_timeout_s, first_event_timeout_s with
+     | Some idle, _ ->
        Error
          (Agent_core.Error.Config
             (Agent_core.Error.InvalidConfig
@@ -322,12 +324,32 @@ let decide_clock_for_idle
                      idle
                      e
                }))
-     | None -> Ok None)
+     | None, Some first_event ->
+       (* The first-event (TTFT/prefill) bound has the same clock dependency
+          as the idle bound (RFC-OAS-037): AGENT_CORE arms it only when a
+          clock is present, so a missing clock would silently disarm it. *)
+       Error
+         (Agent_core.Error.Config
+            (Agent_core.Error.InvalidConfig
+               { field = "first_event_timeout_s"
+               ; detail =
+                   Printf.sprintf
+                     "runtime_agent: first_event_timeout_s configured (%.1fs) \
+                      but no clock resolvable (%s); refusing to run with a \
+                      silently disarmed first-event timeout"
+                     first_event
+                     e
+               }))
+     | None, None -> Ok None)
 ;;
 
-let resolve_clock_for_idle ~(stream_idle_timeout_s : float option) =
+let resolve_clock_for_idle
+    ~(stream_idle_timeout_s : float option)
+    ~(first_event_timeout_s : float option)
+  =
   decide_clock_for_idle
     ~stream_idle_timeout_s
+    ~first_event_timeout_s
     ~process_clock:(Process_eio.get_clock ())
     ~ctx_clock:(Eio_context.get_clock_opt ())
 ;;
@@ -849,7 +871,11 @@ let build
     ~(net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
     ~(config : config)
   : (Agent_core.Agent.t, Agent_core.Error.t) result =
-  match resolve_clock_for_idle ~stream_idle_timeout_s:config.stream_idle_timeout_s with
+  match
+    resolve_clock_for_idle
+      ~stream_idle_timeout_s:config.stream_idle_timeout_s
+      ~first_event_timeout_s:config.first_event_timeout_s
+  with
   | Error _ as e -> e
   | Ok clock ->
     (match
@@ -935,7 +961,11 @@ let resume_from_checkpoint
     ~(config : config)
     ~(checkpoint : Agent_core.Checkpoint.t)
   : (Agent_core.Agent.t, Agent_core.Error.t) result =
-  match resolve_clock_for_idle ~stream_idle_timeout_s:config.stream_idle_timeout_s with
+  match
+    resolve_clock_for_idle
+      ~stream_idle_timeout_s:config.stream_idle_timeout_s
+      ~first_event_timeout_s:config.first_event_timeout_s
+  with
   | Error _ as e -> e
   | Ok clock ->
     (match

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -95,6 +95,7 @@ type config = Runtime_agent_context.config = {
   system_prompt : string;
   tools : Agent_core.Tool.t list;
   stream_idle_timeout_s : float option;
+  first_event_timeout_s : float option;
   body_timeout_s : float option;
   max_tokens : int option;
   temperature : float option;
@@ -261,9 +262,11 @@ module For_testing : sig
   val stop_reason_of_cooperative_yield :
     turns_used:int -> cooperative_yield_reason -> stop_reason
 
-  (** Fail closed when an idle deadline is configured but no clock resolves. *)
+  (** Fail closed when a streaming deadline (inter-line idle or first-event,
+      RFC-OAS-037) is configured but no clock resolves. *)
   val decide_clock_for_idle :
     stream_idle_timeout_s:float option ->
+    first_event_timeout_s:float option ->
     process_clock:(float Eio.Time.clock_ty Eio.Resource.t, string) result ->
     ctx_clock:float Eio.Time.clock_ty Eio.Resource.t option ->
     (float Eio.Time.clock_ty Eio.Resource.t option, Agent_core.Error.t) result

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -46,6 +46,11 @@ type config =
   ; system_prompt : string
   ; tools : Agent_core.Tool.t list
   ; stream_idle_timeout_s : float option
+  ; first_event_timeout_s : float option
+    (** Bound on the silent wait for the FIRST streaming provider event
+        (TTFT/prefill). [stream_idle_timeout_s] arms only after that event;
+        when [None], AGENT_CORE's resolver falls back to [body_timeout_s],
+        then to [stream_idle_timeout_s] (RFC-OAS-037). *)
   ; body_timeout_s : float option
     (** Total HTTP body-consumption ceiling for non-streaming AGENT_CORE completion
         paths. Streaming paths deliberately ignore this knob so active long
@@ -132,6 +137,7 @@ let default_config
   ; system_prompt
   ; tools
   ; stream_idle_timeout_s = None
+  ; first_event_timeout_s = None
   ; body_timeout_s = None
   ; max_tokens = None
   ; temperature = provider_cfg.temperature
@@ -248,6 +254,11 @@ let builder
   let builder =
     match config.stream_idle_timeout_s with
     | Some timeout_s -> Agent_core.Builder.with_stream_idle_timeout timeout_s builder
+    | None -> builder
+  in
+  let builder =
+    match config.first_event_timeout_s with
+    | Some s -> Agent_core.Builder.with_first_event_timeout s builder
     | None -> builder
   in
   let builder =
@@ -393,6 +404,7 @@ let prepare_resume ~(config : config) ~(checkpoint : Agent_core.Checkpoint.t)
       hooks = (match config.hooks with Some hooks -> hooks | None -> Agent_core.Hooks.empty)
     ; provider_config = Some config.provider_cfg
     ; stream_idle_timeout_s = config.stream_idle_timeout_s
+    ; first_event_timeout_s = config.first_event_timeout_s
     ; body_timeout_s = config.body_timeout_s
     ; context_injector = config.context_injector
     ; event_bus = config.event_bus

--- a/lib/runtime/runtime_agent_context.mli
+++ b/lib/runtime/runtime_agent_context.mli
@@ -36,6 +36,13 @@ type config = {
   system_prompt : string;
   tools : Agent_core.Tool.t list;
   stream_idle_timeout_s : float option;
+  first_event_timeout_s : float option;
+      (** Bound on the silent wait for the FIRST streaming provider event
+          (TTFT/prefill), forwarded to AGENT_CORE
+          [Builder.with_first_event_timeout]. [stream_idle_timeout_s] arms
+          only after that event; when [None], AGENT_CORE's resolver falls
+          back to [body_timeout_s], then to [stream_idle_timeout_s]
+          (RFC-OAS-037). *)
   body_timeout_s : float option;
       (** Total HTTP body-consumption ceiling forwarded to AGENT_CORE
           [Builder.with_body_timeout] for non-streaming completion paths.

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -529,6 +529,22 @@ let create_server_state ~sw ~base_path ?input_base_path ~clock ~mono_clock ~net
       Log.Runtime.info
         ~category:Log.Boundary
         "keeper stream idle timeout resolved: disabled (no inter-line idle bound)");
+  (* RFC-OAS-037: same boot observability for the first-event (TTFT/prefill)
+     budget — configured-vs-effective must stay distinguishable at runtime,
+     the exact ambiguity #25128 hit for the idle knob. *)
+  Keeper_runtime_resolved.(
+    let first_event = (current ()).first_event_timeout_sec in
+    match first_event.value with
+    | Some seconds ->
+      Log.Runtime.info
+        ~category:Log.Boundary
+        "keeper first-event (TTFT/prefill) timeout resolved: %.1fs (source: %s)"
+        seconds
+        (source_to_string first_event.source)
+    | None ->
+      Log.Runtime.info
+        ~category:Log.Boundary
+        "keeper first-event timeout resolved: disabled (no first-event bound)");
   Keeper_task_owner_backend.install_hooks ();
   Server_dashboard_http_execution_surfaces.install_task_mutation_cache_invalidation ();
   let state =

--- a/test/test_keeper_runtime_resolved_observability.ml
+++ b/test/test_keeper_runtime_resolved_observability.ml
@@ -23,6 +23,12 @@ let test_resolved_config_exposes_timeout_knobs () =
     "resolved config exposes stream_idle_timeout_sec"
     true
     (List.mem "stream_idle_timeout_sec" names);
+  (* RFC-OAS-037: the first-event (TTFT/prefill) budget needs the same
+     configured-vs-effective disambiguation as the idle knob. *)
+  Alcotest.(check bool)
+    "resolved config exposes first_event_timeout_sec"
+    true
+    (List.mem "first_event_timeout_sec" names);
   Alcotest.(check bool)
     "resolved config exposes body_timeout_override_sec"
     true

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -1920,6 +1920,7 @@ let test_clock_failfast_returns_typed_error_when_idle_set_without_clock () =
   match
     Runtime_agent.For_testing.decide_clock_for_idle
       ~stream_idle_timeout_s:(Some 120.0)
+      ~first_event_timeout_s:None
       ~process_clock:(Error "process runtime not initialised")
       ~ctx_clock:None
   with
@@ -1940,10 +1941,11 @@ let test_clock_failfast_returns_typed_error_when_idle_set_without_clock () =
   | Ok _ -> fail "expected typed error when idle is configured but no clock resolves"
 
 let test_clock_failfast_opt_out_when_no_idle_no_clock () =
-  (* Legitimate opt-out: no idle deadline + no clock stays None, no raise. *)
+  (* Legitimate opt-out: no streaming deadline + no clock stays None, no raise. *)
   let clock =
     Runtime_agent.For_testing.decide_clock_for_idle
       ~stream_idle_timeout_s:None
+      ~first_event_timeout_s:None
       ~process_clock:(Error "no runtime")
       ~ctx_clock:None
   in
@@ -1951,6 +1953,51 @@ let test_clock_failfast_opt_out_when_no_idle_no_clock () =
     (match clock with
      | Ok None -> true
      | Ok (Some _) | Error _ -> false)
+
+(* RFC-OAS-037: the first-event (TTFT/prefill) bound has the same clock
+   dependency as the idle bound — configured without a resolvable clock it
+   must fail loudly, naming its own knob. *)
+let test_clock_failfast_returns_typed_error_when_first_event_set_without_clock () =
+  match
+    Runtime_agent.For_testing.decide_clock_for_idle
+      ~stream_idle_timeout_s:None
+      ~first_event_timeout_s:(Some 600.0)
+      ~process_clock:(Error "process runtime not initialised")
+      ~ctx_clock:None
+  with
+  | Error (Agent_core.Error.Config (Agent_core.Error.InvalidConfig { field; detail })) ->
+    check string "field" "first_event_timeout_s" field;
+    check
+      bool
+      "message identifies the configured first-event deadline with no clock"
+      true
+      (String.starts_with
+         ~prefix:"runtime_agent: first_event_timeout_s configured"
+         detail)
+  | Error err ->
+    fail
+      (Printf.sprintf
+         "expected InvalidConfig first_event_timeout_s, got %s"
+         (Agent_core.Error.to_string err))
+  | Ok _ ->
+    fail "expected typed error when first-event is configured but no clock resolves"
+
+let test_clock_failfast_names_idle_when_both_deadlines_set () =
+  (* Both knobs configured: the error names the idle knob (its arm is
+     checked first); the point pinned here is that SOME typed error fires,
+     not a silent disarm. *)
+  match
+    Runtime_agent.For_testing.decide_clock_for_idle
+      ~stream_idle_timeout_s:(Some 120.0)
+      ~first_event_timeout_s:(Some 600.0)
+      ~process_clock:(Error "no runtime")
+      ~ctx_clock:None
+  with
+  | Error (Agent_core.Error.Config (Agent_core.Error.InvalidConfig { field; _ })) ->
+    check string "field" "stream_idle_timeout_s" field
+  | Error err ->
+    fail (Printf.sprintf "expected InvalidConfig, got %s" (Agent_core.Error.to_string err))
+  | Ok _ -> fail "expected typed error when both deadlines set without clock"
 
 (* ── Runtime.decide_capability_gate (AGENT_CORE catalog binding gate) ── *)
 
@@ -2189,5 +2236,13 @@ let () =
             "clock fail-fast opt-out when no idle no clock"
             `Quick
             test_clock_failfast_opt_out_when_no_idle_no_clock
+        ; test_case
+            "clock fail-fast raises when first-event set without clock (RFC-OAS-037)"
+            `Quick
+            test_clock_failfast_returns_typed_error_when_first_event_set_without_clock
+        ; test_case
+            "clock fail-fast names idle when both deadlines set"
+            `Quick
+            test_clock_failfast_names_idle_when_both_deadlines_set
         ] )
     ]

--- a/test/test_runtime_toml_overrides.ml
+++ b/test/test_runtime_toml_overrides.ml
@@ -341,6 +341,43 @@ let test_resolved_stream_idle_timeout_defaults_to_failsafe_floor () =
     "failsafe_floor"
     (Keeper_runtime_resolved.source_to_string runtime.stream_idle_timeout_sec.source)
 
+let test_resolved_first_event_timeout_defaults_to_failsafe_floor () =
+  (* RFC-OAS-037: with no explicit env/toml value the resolver substitutes the
+     silent-prefill liveness ceiling (not [None]). Without it AGENT_CORE's
+     first-event resolver falls through to the much shorter inter-line idle
+     value and any provider that prefills silently past it dies at
+     awaiting_first_event (canary-multiturn-localmlx, 9/9 on 2026-08-16). *)
+  with_clean_boot_overrides @@ fun () ->
+  Keeper_runtime_resolved.init ();
+  let runtime = Keeper_runtime_resolved.current () in
+  check (option (float 0.0001)) "first-event timeout defaults to fail-safe floor"
+    (Some Keeper_runtime_resolved.first_event_failsafe_floor_sec)
+    runtime.first_event_timeout_sec.value;
+  check (option (float 0.0001)) "accessor returns the floor when unset"
+    (Some Keeper_runtime_resolved.first_event_failsafe_floor_sec)
+    (Keeper_runtime_resolved.first_event_timeout_sec ());
+  check string "first-event timeout floor source"
+    "failsafe_floor"
+    (Keeper_runtime_resolved.source_to_string runtime.first_event_timeout_sec.source)
+
+let test_resolved_first_event_timeout_uses_toml () =
+  (* End-to-end pin for the registry-driven mapping: runtime.toml
+     [turn.first_event_timeout_sec] must reach the resolver as
+     MASC_KEEPER_FIRST_EVENT_TIMEOUT_SEC. *)
+  with_clean_boot_overrides @@ fun () ->
+  with_base_path @@ fun base_path ->
+  write_toml base_path "[turn]\nfirst_event_timeout_sec = 480\n";
+  (match Keeper_runtime_config.load_and_apply ~base_path with
+   | Error msg -> failf "unexpected error: %s" (Keeper_runtime_config.load_failure_to_string msg)
+   | Ok _ -> ());
+  Keeper_runtime_resolved.init ();
+  let runtime = Keeper_runtime_resolved.current () in
+  check (option (float 0.0001)) "first-event timeout from toml"
+    (Some 480.0) runtime.first_event_timeout_sec.value;
+  check string "first-event timeout source"
+    "toml"
+    (Keeper_runtime_resolved.source_to_string runtime.first_event_timeout_sec.source)
+
 let test_resolved_stream_idle_timeout_uses_toml () =
   with_clean_boot_overrides @@ fun () ->
   with_base_path @@ fun base_path ->
@@ -705,6 +742,8 @@ let () =
         ; test_case "float value round trip" `Quick test_float_value_round_trip
         ; test_case "resolved runtime freezes toml values after init" `Quick test_resolved_runtime_freezes_toml_values_after_init
         ; test_case "resolved stream idle timeout defaults to fail-safe floor" `Quick test_resolved_stream_idle_timeout_defaults_to_failsafe_floor
+        ; test_case "resolved first-event timeout defaults to fail-safe floor" `Quick test_resolved_first_event_timeout_defaults_to_failsafe_floor
+        ; test_case "resolved first-event timeout uses toml" `Quick test_resolved_first_event_timeout_uses_toml
         ; test_case "resolved stream idle timeout uses toml" `Quick test_resolved_stream_idle_timeout_uses_toml
         ; test_case "invalid stream idle TOML returns Error" `Quick test_stream_idle_timeout_invalid_toml_returns_error
         ; test_case "wrong-type stream idle TOML returns Error" `Quick test_stream_idle_timeout_toml_wrong_type_returns_error


### PR DESCRIPTION
## 문제

`agent_core-local_llama_server.qwen3-8-27b-mlx` 오늘 완료 9건 전부 실패:

```
Provider 'unknown' timeout phase=first_token: stream_idle_timeout_s deadline exceeded while awaiting_first_event
```

- keeper 프롬프트 ~21K tok(도구 96종). mlx_vlm.server 실측 prefill 40–65 t/s (`logs/mlx-vlm-qwen38.log`의 Prefill progress 타임스탬프 간격으로 산출) → 첫 토큰까지 5–8분.
- 서버 로그가 사인을 확정: `15:24:22 Prefill progress 10240/20816 (49.2%)` 직후 `Generation cancelled generated_tokens=0` — **행이 아니라 prefill 중**이었다. 같은 실패 계열: 2026-07-20 mimo 1M-context 턴 (RFC-OAS-037 §1 증거).

## 근본 원인

AGENT_CORE는 이미 TTFT/idle을 분리해 놓았다 (`resolve_first_event_bound`: explicit `first_event_timeout` → `body_timeout` → `idle_timeout` → Unarmed). **masc가 knob을 배선하지 않아서** (`rg first_event_timeout lib/ bin/` = 0건) fallback 체인이 `None, None, Some(idle)`로 떨어졌고, fleet의 inter-line idle 값(120s)이 무음 prefill 구간까지 지배했다.

이 화재에 대한 현장 대응으로 15:21에 runtime.toml `stream_idle_timeout_sec`가 120→360으로 올라갔는데, 이는 **모든 레인의 mid-stream stall 감지를 3배 무디게 하는 워크어라운드**다. 이 PR이 착륙·배포되면 idle을 120으로 되돌리고 두 지표를 각자의 knob으로 분리 운용할 수 있다.

## 변경

`stream_idle_timeout_sec`(RFC-0345) 패턴을 그대로 미러링:

| 층 | 변경 |
|---|---|
| `Env_config_keeper` | `MASC_KEEPER_FIRST_EVENT_TIMEOUT_SEC` accessor + 600s fail-safe floor (idle floor와 같은 자리) |
| `Keeper_runtime_resolved` | unset → floor 대입(`Failsafe_floor` source), explicit은 verbatim; `to_yojson` 노출 |
| Setting registry | `turn.first_event_timeout_sec` (Toml_and_env) — registry-driven `key_to_env` 매핑이라 행 추가만으로 TOML 경로 개통 (end-to-end 테스트로 고정) |
| `Keeper_turn_driver` | resolved 값을 provider-attempt ctx에 주입 (`provider_call_deadline_sec`와 같은 방식, run_named 옵션 릴레이 회피) |
| `Runtime_agent_context` | config 필드 + `Builder.with_first_event_timeout` + Agent options 전달 |
| `Runtime_agent.decide_clock_for_idle` | first-event bound도 clock 의존 — clock 미해결 시 typed error (`field = "first_event_timeout_s"`), 조용한 disarm 금지 |
| `Server_runtime_bootstrap` | 부팅 시 resolved 값+source 로그 (#25128의 configured-vs-effective 모호성 방지) |

### floor 600s 근거
per-provider 튜닝이 아니라 단일 liveness ceiling (RFC-OAS-037 §3, RFC-0345 §3.1과 동일 원칙). 실측 무음 prefill: mimo 152s, mlx 21K tok ≈ 200–525s < 600. explicit env/toml 값이 있으면 그대로 존중.

## 검증 (로컬, worktree root)

```
opam exec -- dune build --root . @check                                   # 0
opam exec -- dune exec --root . test/test_runtime_toml_overrides.exe      # 38 pass (floor 대입 + toml 매핑 신규 2)
opam exec -- dune exec --root . test/test_runtime_provider_auth_headers.exe # 53 pass (first-event clock fail-fast 신규 2)
opam exec -- dune exec --root . test/test_keeper_runtime_resolved_observability.exe # 2 pass
opam exec -- dune exec --root . test/test_keeper_runtime_config_leaf.exe  # 6 pass
bash scripts/check-keeper-runtime-setting-registry.sh                     # PASS (41 inventoried)
```

## 배포 후 운영 노트

1. 재시작 시 부팅 로그에 `keeper first-event (TTFT/prefill) timeout resolved: 600.0s (source: failsafe_floor)` 확인.
2. runtime.toml `stream_idle_timeout_sec = 360` → 120 되돌리기 권장 (idle 본연의 stall 감지 회복). 이건 이 PR 범위 밖의 fleet 설정 변경이라 별도로.
3. mlx canary는 이 수정 후에도 턴당 5–8분(mlx는 cross-request KV 재사용 0)이라, 레인 유지 여부는 소유 세션 판단.

## 관련

- RFC-OAS-037 (TTFT/prefill vs inter-token idle 분리) — 이 PR은 masc측 배선 완성.
- 부수 결함 별도 추적: 에러 문구의 `Provider 'unknown'` (of_http_error ?provider 미전달) — 후속 소형 PR.
- adversarial review 통과 시 `review:adversarial-pass` 라벨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
