### PR TITLE
feat(keeper): canary 사다리 배관 — wall-clock 페이싱·Eio sleep·429 백오프 (M2 PR-A)

### DIFF
--- a/bin/keeper_canary_http.ml
+++ b/bin/keeper_canary_http.ml
@@ -58,7 +58,31 @@ let url_of ~host ~port ~path =
 
    Returns [Error detail] uniformly for connection failure, non-2xx status,
    and unparseable SSE — the caller does not need to distinguish those to
-   decide "this turn did not produce a usable reply." *)
+   decide "this turn did not produce a usable reply." The one exception is
+   HTTP 429: the loopback rate bucket is shared per IP and per admin token
+   (#28730), so a burst from a parallel session can throttle a turn that
+   would succeed seconds later. 429 retries with exponential backoff and
+   the same request_id — the server keys idempotent dedup on it, so a
+   retry can never double-send the turn. Every other non-2xx surfaces
+   immediately: a blind retry of a 500/409 would hide a real failure. *)
+let rate_limited_status = 429
+
+(* Five attempts spaced 2s/4s/8s/16s cover ~30s of sustained throttling —
+   the observed #28730 bursts (parallel session sweeps) drain within that;
+   anything longer is a real outage the run should surface. *)
+let max_rate_limit_attempts = 5
+let rate_limit_backoff_base_s = 2.0
+
+(* bin/keeper_canary_run.ml always publishes the Eio clock before any call
+   lands here; the Unix.sleepf arm only exists so this helper stays total
+   if that ever changes, and a blocking sleep is then the lesser harm. *)
+let sleep_s seconds =
+  if seconds > 0.0
+  then (
+    match Eio_context.get_clock_opt () with
+    | Some clock -> Eio.Time.sleep clock seconds
+    | None -> Unix.sleepf seconds)
+
 let send_turn ?(timeout_sec = default_timeout_sec) ~host ~port ~keeper_name
     ~request_id ~message () : (string, string) result
   =
@@ -71,19 +95,32 @@ let send_turn ?(timeout_sec = default_timeout_sec) ~host ~port ~keeper_name
         ; ("message", `String message)
         ])
   in
-  match
-    Masc_http_client.post_sync
-      ?clock:(Eio_context.get_clock_opt ())
-      ~timeout_sec
-      ~url
-      ~headers:(json_headers ())
-      ~body
-      ()
-  with
-  | Error detail -> Error (Printf.sprintf "POST %s failed: %s" url detail)
-  | Ok (status, response_body) ->
-    if status < 200 || status >= 300
-    then
-      Error
-        (Printf.sprintf "POST %s returned HTTP %d: %s" url status response_body)
-    else Masc.Tui_decode.parse_keeper_chat_response response_body
+  let rec attempt n =
+    match
+      Masc_http_client.post_sync
+        ?clock:(Eio_context.get_clock_opt ())
+        ~timeout_sec
+        ~url
+        ~headers:(json_headers ())
+        ~body
+        ()
+    with
+    | Error detail -> Error (Printf.sprintf "POST %s failed: %s" url detail)
+    | Ok (status, response_body) ->
+      if status = rate_limited_status && n < max_rate_limit_attempts
+      then (
+        let delay = rate_limit_backoff_base_s *. Float.pow 2.0 (float_of_int (n - 1)) in
+        Printf.eprintf
+          "[keeper_canary_run] HTTP 429 (attempt %d/%d), retrying in %.0fs\n%!"
+          n
+          max_rate_limit_attempts
+          delay;
+        sleep_s delay;
+        attempt (n + 1))
+      else if status < 200 || status >= 300
+      then
+        Error
+          (Printf.sprintf "POST %s returned HTTP %d: %s" url status response_body)
+      else Masc.Tui_decode.parse_keeper_chat_response response_body
+  in
+  attempt 1

--- a/bin/keeper_canary_run.ml
+++ b/bin/keeper_canary_run.ml
@@ -28,7 +28,8 @@
      dune exec bin/keeper_canary_run.exe -- \
        --keeper NAME --run-id ID [--runtime LABEL] [--base PATH] \
        [--host HOST] [--port N] [--facts N] [--turn-interval SECONDS] \
-       [--turn-timeout SECONDS] [--judge-runtime ID] [--out PATH] *)
+       [--turn-timeout SECONDS] [--wall-clock-target SECONDS] \
+       [--judge-runtime ID] [--out PATH] *)
 
 let default_facts = 9
 let default_turn_interval_s = 0.0
@@ -36,8 +37,8 @@ let default_turn_interval_s = 0.0
 let usage =
   "usage: keeper_canary_run --keeper NAME --run-id ID [--runtime LABEL] \
    [--base PATH] [--host HOST] [--port N] [--facts N] \
-   [--turn-interval SECONDS] [--turn-timeout SECONDS] [--judge-runtime ID] \
-   [--out PATH]"
+   [--turn-interval SECONDS] [--turn-timeout SECONDS] \
+   [--wall-clock-target SECONDS] [--judge-runtime ID] [--out PATH]"
 
 type args = {
   keeper : string;
@@ -49,6 +50,7 @@ type args = {
   facts : int;
   turn_interval_s : float;
   turn_timeout_s : float option;
+  wall_clock_target_s : float option;
   judge_runtime : string option;
   out : string option;
 }
@@ -63,6 +65,7 @@ let parse_args argv =
   let facts = ref default_facts in
   let turn_interval_s = ref default_turn_interval_s in
   let turn_timeout_s = ref None in
+  let wall_clock_target_s = ref None in
   let judge_runtime = ref None in
   let out = ref None in
   let rec parse = function
@@ -110,6 +113,12 @@ let parse_args argv =
        | Some s -> Error (Printf.sprintf "--turn-timeout must be > 0, got %g" s)
        | None -> Error ("--turn-timeout must be a number, got " ^ v))
     | [ "--turn-timeout" ] -> Error "missing value for --turn-timeout"
+    | "--wall-clock-target" :: v :: rest ->
+      (match float_of_string_opt v with
+       | Some s when s > 0.0 -> wall_clock_target_s := Some s; parse rest
+       | Some s -> Error (Printf.sprintf "--wall-clock-target must be > 0, got %g" s)
+       | None -> Error ("--wall-clock-target must be a number, got " ^ v))
+    | [ "--wall-clock-target" ] -> Error "missing value for --wall-clock-target"
     | "--judge-runtime" :: v :: rest ->
       judge_runtime := Some v;
       parse rest
@@ -127,6 +136,12 @@ let parse_args argv =
      | None, _ -> Error "--keeper NAME is required"
      | _, None -> Error "--run-id ID is required"
      | Some keeper, Some run_id ->
+       if !wall_clock_target_s <> None && !turn_interval_s > 0.0
+       then
+         Error
+           "--wall-clock-target and --turn-interval are mutually exclusive: \
+            the target derives the interval"
+       else
        Ok
          { keeper
          ; run_id
@@ -137,6 +152,7 @@ let parse_args argv =
          ; facts = !facts
          ; turn_interval_s = !turn_interval_s
          ; turn_timeout_s = !turn_timeout_s
+         ; wall_clock_target_s = !wall_clock_target_s
          ; judge_runtime = !judge_runtime
          ; out = !out
          })
@@ -325,8 +341,23 @@ let run ?(judge : judge_fn option) ~(base_path : string) (args : args) :
         Printf.eprintf "[keeper_canary_run] %s FAILED: %s\n%!" turn_label detail;
         Error detail
     in
+    (* A wall-clock target spreads the whole plan evenly: N+1 turns have N
+       gaps, so interval = target / gaps. Mutual exclusion with
+       --turn-interval is enforced at parse time. *)
+    let effective_turn_interval_s =
+      match args.wall_clock_target_s with
+      | None -> args.turn_interval_s
+      | Some target_s ->
+        (* N fact turns + 1 recall = N gaps. *)
+        Keeper_canary_facts.interval_for_wall_clock
+          ~gaps:(List.length facts)
+          ~target_s
+    in
     let sleep_between_turns () =
-      if args.turn_interval_s > 0.0 then Unix.sleepf args.turn_interval_s
+      (* Eio sleep, not Unix.sleepf: a blocking sleep parks the whole Eio
+         domain, which is survivable at a few seconds but not at the
+         1h-to-24h gaps a wall-clock target produces. *)
+      Keeper_canary_http.sleep_s effective_turn_interval_s
     in
     (* The ordered turn sequence (N fact-injection turns, then one recall
        turn) is Keeper_canary_facts.plan's job, not inline bookkeeping here
@@ -394,7 +425,8 @@ let run ?(judge : judge_fn option) ~(base_path : string) (args : args) :
       ; runtime = args.runtime
       ; base_path
       ; endpoint = Keeper_canary_http.url_of ~host ~port ~path:"/api/v1/keepers/chat/stream"
-      ; turn_interval_s = args.turn_interval_s
+      ; turn_interval_s = effective_turn_interval_s
+      ; wall_clock_target_s = args.wall_clock_target_s
       ; facts
       ; turns
       ; recall =
@@ -575,12 +607,14 @@ let () =
          evidence.timing.min_s
          evidence.timing.median_s
          evidence.timing.max_s;
-       (* Masc_eio_env.init parks pool/keepalive fibers on this switch, so
-          returning normally leaves Switch.run waiting on them and the
-          process never exits (first live success run hung >7min after the
-          evidence write, 2026-08-16). Explicit exit is the sibling-harness
-          convention (keeper_capability_probe_cli.ml does the same); stdout
-          is flushed by exit's at_exit hooks. *)
+       (* Returning normally from the Switch.run body leaves the process
+          alive indefinitely — measured >7min after the evidence write on
+          the first live success run (2026-08-16). Exact owner of the
+          lingering fiber is unconfirmed (Masc_eio_env.init only captures
+          handles per its .mli; the HTTP connection pool or Process_eio.init
+          are the remaining suspects). Explicit exit is the sibling-harness
+          convention regardless (keeper_capability_probe_cli.ml does the
+          same); stdout is flushed by exit's at_exit hooks. *)
        (match args.judge_runtime, evidence.Keeper_canary_evidence.judgment with
         | Some _, None ->
           (* The judge was requested but produced no judgment — the receipt

--- a/lib/keeper_canary/keeper_canary_evidence.ml
+++ b/lib/keeper_canary/keeper_canary_evidence.ml
@@ -86,6 +86,7 @@ type run_evidence = {
   base_path : string;
   endpoint : string;
   turn_interval_s : float;
+  wall_clock_target_s : float option;
   facts : Keeper_canary_facts.fact list;
   turns : turn_evidence list;
   recall : recall_evidence;
@@ -162,6 +163,10 @@ let to_yojson (e : run_evidence) =
       , `Assoc
           [ ("endpoint", `String e.endpoint)
           ; ("turn_interval_s", `Float e.turn_interval_s)
+          ; ( "wall_clock_target_s"
+            , match e.wall_clock_target_s with
+              | Some s -> `Float s
+              | None -> `Null )
           ] )
     ; ("facts_established", `List (List.map fact_to_yojson e.facts))
     ; ("turns", `List (List.map turn_to_yojson e.turns))

--- a/lib/keeper_canary/keeper_canary_evidence.mli
+++ b/lib/keeper_canary/keeper_canary_evidence.mli
@@ -56,6 +56,10 @@ type run_evidence = {
   base_path : string;
   endpoint : string;
   turn_interval_s : float;
+      (** The effective per-gap interval the run used (derived from the
+          wall-clock target when one was given). *)
+  wall_clock_target_s : float option;
+      (** [None] renders as JSON null — no wall-clock target was set. *)
   facts : Keeper_canary_facts.fact list;
   turns : turn_evidence list;
   recall : recall_evidence;

--- a/lib/keeper_canary/keeper_canary_facts.ml
+++ b/lib/keeper_canary/keeper_canary_facts.ml
@@ -227,3 +227,6 @@ let score ~(facts : fact list) ~(reply : string) : score =
       |> List.map (fun r -> r.category)
   ; per_fact
   }
+
+let interval_for_wall_clock ~gaps ~target_s =
+  if gaps <= 0 then 0.0 else target_s /. float_of_int gaps

--- a/lib/keeper_canary/keeper_canary_facts.mli
+++ b/lib/keeper_canary/keeper_canary_facts.mli
@@ -63,3 +63,8 @@ val score : facts:fact list -> reply:string -> score
     plus an order check over the facts that were found. A raw deterministic
     signal, not the canary's pass/fail judgment — see
     {!Keeper_canary_evidence.run_evidence.judgment}. *)
+
+val interval_for_wall_clock : gaps:int -> target_s:float -> float
+(** Even spacing for a wall-clock target: [target_s /. gaps]. A plan of N
+    fact turns plus one recall has N gaps. [0.] when [gaps <= 0] — a plan
+    with nothing to space out has no interval, not an error. *)

--- a/test/test_keeper_canary_evidence.ml
+++ b/test/test_keeper_canary_evidence.ml
@@ -38,6 +38,7 @@ let sample_evidence : Keeper_canary_evidence.run_evidence =
   ; base_path = "/tmp/masc-base"
   ; endpoint = "http://127.0.0.1:8935/api/v1/keepers/chat/stream"
   ; turn_interval_s = 0.0
+  ; wall_clock_target_s = None
   ; facts = [ sample_fact ]
   ; turns = [ sample_turn; sample_recall_turn ]
   ; recall =
@@ -100,6 +101,22 @@ let test_top_level_keys_are_present () =
            (List.mem key actual))
       expected
   | _ -> Alcotest.fail "expected a JSON object"
+
+let test_wall_clock_target_serializes_when_present () =
+  let json =
+    Keeper_canary_evidence.to_yojson
+      { sample_evidence with wall_clock_target_s = Some 3600.0 }
+  in
+  (match json |> member "transport" |> member "wall_clock_target_s" with
+   | `Float s -> Alcotest.(check (float 1e-9)) "target seconds" 3600.0 s
+   | _ -> Alcotest.fail "expected transport.wall_clock_target_s to serialize as a float");
+  match
+    Keeper_canary_evidence.to_yojson sample_evidence
+    |> member "transport"
+    |> member "wall_clock_target_s"
+  with
+  | `Null -> ()
+  | _ -> Alcotest.fail "expected transport.wall_clock_target_s to be null when unset"
 
 let test_judgment_is_null_without_a_judge () =
   let json = Keeper_canary_evidence.to_yojson sample_evidence in
@@ -198,6 +215,10 @@ let () =
             `Quick
             test_schema_field_matches_declared_version
         ; Alcotest.test_case "top-level keys are present" `Quick test_top_level_keys_are_present
+        ; Alcotest.test_case
+            "wall clock target serializes"
+            `Quick
+            test_wall_clock_target_serializes_when_present
         ; Alcotest.test_case
             "judgment is null without a judge"
             `Quick

--- a/test/test_keeper_canary_facts.ml
+++ b/test/test_keeper_canary_facts.ml
@@ -150,6 +150,20 @@ let test_score_empty_reply_recalls_nothing () =
   Alcotest.(check int) "facts_recalled" 0 score.facts_recalled;
   Alcotest.(check bool) "order_matches on empty recall" true score.order_matches
 
+let test_interval_for_wall_clock () =
+  Alcotest.(check (float 1e-9))
+    "9 gaps over 3600s"
+    400.0
+    (Keeper_canary_facts.interval_for_wall_clock ~gaps:9 ~target_s:3600.0);
+  Alcotest.(check (float 1e-9))
+    "zero gaps has no interval"
+    0.0
+    (Keeper_canary_facts.interval_for_wall_clock ~gaps:0 ~target_s:3600.0);
+  Alcotest.(check (float 1e-9))
+    "negative gaps has no interval"
+    0.0
+    (Keeper_canary_facts.interval_for_wall_clock ~gaps:(-1) ~target_s:3600.0)
+
 let () =
   Alcotest.run
     "keeper_canary_facts"
@@ -208,4 +222,6 @@ let () =
             `Quick
             test_score_empty_reply_recalls_nothing
         ] )
+    ; ( "ladder"
+      , [ Alcotest.test_case "interval for wall clock" `Quick test_interval_for_wall_clock ] )
     ]


### PR DESCRIPTION
## 요약

M2(duration 사다리) 3-PR 스택의 첫 번째 — injection 플래그(--inject-restart/--inject-failover, PR-B/C) 전에 있어야 하는 배관입니다. 정찰에서 나온 선행 결함 2건의 수리를 포함합니다.

## 뭘

1. **`--wall-clock-target SECONDS`**: 계획 전체(N 사실 + 회상 1 = N gaps)를 균등 분산. 파생은 순수 함수 `Keeper_canary_facts.interval_for_wall_clock`(테스트 포함), `--turn-interval`과 상호 배타(파스 타임 에러). 실효 간격과 target이 evidence `transport` 블록에 기록됩니다.
2. **`Unix.sleepf` → `Eio.Time.sleep`**: blocking sleep은 Eio 도메인 전체를 세웁니다 — 몇 초는 견디지만 1h~24h gap에선 치명적 (정찰 발견 a).
3. **429 지수 백오프**: send_turn이 429만 재시도(2s base × 5회, 같은 request_id — 서버 dedup이 멱등 보장), 다른 non-2xx는 즉시 표면화. 근거: #28730 (loopback rate bucket이 IP·토큰 공유, injection 시퀀스는 턴당 admin POST 4회로 증폭).
4. **exit 주석 정직화**: 성공 경로 hang의 원인 귀속을 "미확정"으로 정정 (Masc_eio_env.init은 .mli상 핸들 캡처만 — 정찰 발견 b). hang 실측과 `exit 0` 관례는 유지.

## 검증

- canary 3 스위트: facts 14 / evidence 15(신규: transport.wall_clock_target_s Some/Null 고정) / judge 18 — 전부 OK
- ignore lint exit 0, silent-failure ratchet OK
- **live**: `--facts 1 --wall-clock-target 16` → 24초 경과(=16s gap+턴 지연), interval 16.0 파생, recall 1/1, 자가 종료

## 다음 (스택)

- PR-B `--inject-restart`: shutdown → trajectory nonce → directive resume → boot 4단계 (08-14 drain-restart canary 실증 시퀀스), trace_id/generation 보존을 evidence로
- PR-C `--inject-failover`: 로컬 head 레인 + deferred_runtime_lane.failed_runtime_id 판정

🤖 Generated with [Claude Code](https://claude.com/claude-code)