### PR TITLE
refactor(sidecar): liveness 판단에서 시계를 걷어내고 null 기본값을 없앤다

### DIFF
--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -415,20 +415,23 @@ let heartbeat_is_fresh ~now ~stale_after_sec status =
    heartbeat thread died under a live process. Neither answer is a guess — a
    record that cannot produce a readable stamp and a running pid does not
    establish that a process is there, and restarting is the recoverable
-   direction. *)
-let observed_state_of_status_json ?(now = Unix.gettimeofday ()) ~id json =
+   direction.
+
+   [now] is passed in rather than read here: the callers below already stand
+   at the filesystem boundary, and keeping the clock out of the decision makes
+   this a function of the record alone. *)
+let observed_state_of_status_json ~now ~id json =
   match json with
   | `Assoc fields ->
-    let stale_after_sec = status_stale_sec id in
-    let status = Option.value (List.assoc_opt "status" fields) ~default:`Null in
-    let pid =
+    let pid_of status =
       match status_field "pid" status with
       | Some (`Int pid) -> pid
       | Some _ | None -> 0
     in
-    (match List.assoc_opt "available" fields with
-     | Some (`Bool true)
-       when heartbeat_is_fresh ~now ~stale_after_sec status && pid_is_running pid ->
+    (match List.assoc_opt "available" fields, List.assoc_opt "status" fields with
+     | Some (`Bool true), Some status
+       when heartbeat_is_fresh ~now ~stale_after_sec:(status_stale_sec id) status
+            && pid_is_running (pid_of status) ->
        Observed_available
      | _ -> Observed_unavailable)
   | _ -> Observed_unavailable
@@ -546,7 +549,13 @@ let attempt_fields = function
 ;;
 
 let lifecycle_json ~base_path id status_json =
-  let observed_state = observed_state_of_status_json ~id status_json in
+  (* Heartbeat age can only be measured against wall-clock now, and this
+     function already reads the filesystem, so the clock belongs here rather
+     than inside the decision. *)
+  let observed_state =
+    (* DET-OK: boundary read; the decision takes [now] as an argument. *)
+    observed_state_of_status_json ~now:(Unix.gettimeofday ()) ~id status_json
+  in
   let previous_attempt, attempt_error_fields =
     match read_attempt_record_result ~base_path id with
     | Ok previous_attempt -> previous_attempt, []
@@ -1012,7 +1021,10 @@ let handle_start state request reqd =
              session and redirects stdio to [/dev/null], so the sidecar
              survives backend restart without retaining server FDs. *)
              let status_json = read_status_json ~base_path id in
-             let observed_state = observed_state_of_status_json ~id status_json in
+             let observed_state =
+               (* DET-OK: request boundary, same reading as [lifecycle_json]. *)
+               observed_state_of_status_json ~now:(Unix.gettimeofday ()) ~id status_json
+             in
              let reconcile_result =
                reconcile_desired_once
                  ~current_generation:desired.generation


### PR DESCRIPTION
#28848 후속입니다. 그 PR 이 `Meta Guards` 빨간 채로 병합돼서, 게이트가 지적한 두 줄이 main 에 남았어요.

## 무엇이 걸렸나

```
FAIL: new deterministic-boundary debt added:
  server_routes_http_routes_sidecar.ml:419: let observed_state_of_status_json ?(now = Unix.gettimeofday ()) ~id json =
  server_routes_http_routes_sidecar.ml:423: let status = Option.value (List.assoc_opt "status" fields) ~default:`Null in
```

둘 다 맞는 지적입니다.

- **시계**: liveness 판정 함수가 자기 안에서 `Unix.gettimeofday ()` 를 읽었어요. 판정은 레코드의 함수여야 하는데 시각이 섞였습니다.
- **null 기본값**: `"status"` 멤버가 없을 때 `` `Null `` 로 뭉갠 뒤 그걸 다시 물어봤습니다. 결과적으로는 보수적으로 떨어지지만, 없는 것을 있는 것처럼 만들어놓고 판정하는 모양이라 읽는 사람이 확인해야 알 수 있어요.

## 무엇을 했나

`observed_state_of_status_json` 이 `~now` 를 인자로 받고, `available` 과 `status` 두 멤버를 한 번에 매치합니다. 기본값이 사라지니 “없으면 판정 불가” 가 패턴 자체로 드러납니다.

```ocaml
match List.assoc_opt "available" fields, List.assoc_opt "status" fields with
| Some (`Bool true), Some status
  when heartbeat_is_fresh ~now ~stale_after_sec:(status_stale_sec id) status
       && pid_is_running (pid_of status) -> Observed_available
| _ -> Observed_unavailable
```

시계는 호출부 둘로 옮겼습니다. `lifecycle_json` 은 이미 파일을 읽고, `handle_start` 는 HTTP 핸들러라 둘 다 경계예요. 게이트는 `Unix.gettimeofday` 를 문법으로만 찾으므로 경계인지 아닌지 구분하지 못해서, 그 두 자리에는 `DET-OK` 를 사유와 함께 붙였습니다.

`Masc_domain.now_iso ()` 로 바꾸면 게이트 패턴에 안 걸리지만 그건 회피라서 하지 않았어요.

동작은 그대로입니다. 판정 결과가 달라지는 입력은 없습니다.

## 검증

```
bash scripts/ci/check-determinism-contract.sh   # exit 0, PASS: no new debt
dune build @check                                # exit 0
dune build @test/runtest-test_sidecar_lifecycle_routes   # 59 tests, 전부 통과
```

#28848 병합 후 main 기준으로 확인했습니다.

## 남은 것

`Meta Guards` 는 이 PR 로 초록이 되지만, #28848 이 그 실패를 안고 병합됐다는 사실 자체는 별개 문제예요. 필수 체크가 실패인데 병합이 가능했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)