### PR TITLE
test(sidecar): 깨진 status 파일은 돌아가는 sidecar 가 아니다

### DIFF
--- a/test/test_sidecar_lifecycle_routes.ml
+++ b/test/test_sidecar_lifecycle_routes.ml
@@ -703,15 +703,10 @@ let reaped_pid () =
 
 let now_iso () = Masc_domain.iso8601_of_unix_seconds (Unix.time ())
 
-let observed_state_of_record ~updated_at ~pid =
+let observed_state_of_status_file contents =
   with_status_path_env (fun () ->
     with_temp_dir "sidecar-liveness" (fun base_path ->
-      write_file
-        (Routes.status_file ~base_path "discord")
-        (Printf.sprintf
-           {|{"connected":true,"pid":%d,"updated_at":"%s"}|}
-           pid
-           updated_at);
+      write_file (Routes.status_file ~base_path "discord") contents;
       (match
          Routes.write_desired_record
            ~base_path
@@ -725,6 +720,11 @@ let observed_state_of_record ~updated_at ~pid =
       |> Yojson.Safe.Util.member "sidecar_lifecycle"
       |> Yojson.Safe.Util.member "observed_state"
       |> Yojson.Safe.Util.to_string))
+;;
+
+let observed_state_of_record ~updated_at ~pid =
+  observed_state_of_status_file
+    (Printf.sprintf {|{"connected":true,"pid":%d,"updated_at":"%s"}|} pid updated_at)
 ;;
 
 let test_stopped_sidecar_parting_record_is_not_available () =
@@ -771,6 +771,18 @@ let test_unreadable_heartbeat_is_not_observed_available () =
     "a record with no readable heartbeat cannot claim liveness"
     "unavailable"
     (observed_state_of_record ~updated_at:"not-a-timestamp" ~pid:(Unix.getpid ()))
+;;
+
+let test_unparseable_status_file_is_not_observed_available () =
+  (* A status file the server cannot parse still reports [available: true]
+     with [status: null], because availability only means the file was found.
+     Liveness reads the record, and there is no record here — a half-written
+     or corrupt file must not be mistaken for a running sidecar. *)
+  check
+    string
+    "a corrupt status file is not a running sidecar"
+    "unavailable"
+    (observed_state_of_status_file {|{"connected": true, "pid":|})
 ;;
 
 let test_status_json_exposes_dashboard_provenance () =
@@ -1308,6 +1320,10 @@ let () =
             "unreadable heartbeat is not observed available"
             `Quick
             test_unreadable_heartbeat_is_not_observed_available
+        ; test_case
+            "corrupt status file is not observed available"
+            `Quick
+            test_unparseable_status_file_is_not_observed_available
         ] )
     ; ( "config_write_helpers"
       , [ test_case "escape: quotes + backslash" `Quick test_escape_quotes_and_backslash


### PR DESCRIPTION
#28855 후속. 그 PR 이 `check` (test coverage) 빨간 채로 병합돼서 테스트가 못 따라갔어요.

## 왜 필요한가

#28855 가 `"status"` 멤버가 없을 때 `` `Null `` 로 뭉개던 기본값을 제거했는데, **그 기본값이 있던 이유가 되는 입력이 스위트에 없었습니다.**

status 파일이 파싱 안 되면 라우트는 여전히 `available: true` 에 `status: null` 을 돌려줍니다 — `available` 은 "파일을 찾았다"는 뜻뿐이라 그 자체는 맞아요. 문제는 그 다음입니다. 반쯤 쓰이다 만 파일이나 깨진 파일을 **돌아가는 sidecar 로 착각하면 안 됩니다.**

```ocaml
(observed_state_of_status_file {|{"connected": true, "pid":|})
(* → "unavailable" *)
```

기존 픽스처가 레코드 필드를 조립하는 모양이라 파일 내용을 통째로 주는 헬퍼로 한 겹 벗겨내고, 기존 3케이스는 그 위에 얹었습니다. 동작 변화 없습니다.

## 검증

```
dune build @test/runtest-test_sidecar_lifecycle_routes   # 60 tests, 전부 통과
```

현재 main (`e8850a2b8b`) 기준입니다.

## 남은 것

#28848 은 `Meta Guards` 실패로, #28855 는 `check` 실패로 병합됐어요. 두 번 다 실패가 가리키던 것이 실제 결함이었고 후속 PR 로 따라잡는 중입니다. 필수 체크 실패가 병합을 막지 못하는 것 자체는 별건이고, 지금은 뒤따라가는 쪽으로만 대응했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)