### PR TITLE
fix(keeper): wire open을 sink 등록 시점으로 — #28849 리뷰 P1 2건 재상륙

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1093,7 +1093,6 @@ jobs:
             @test/runtest-test_keeper_conditions_wire_parity \
             @test/runtest-test_keeper_fsm_guard_actions \
             @test/runtest-test_keeper_hitl_replay_delivery \
-            @test/runtest-test_keeper_wire_terminal \
             @test/runtest-test_keeper_invariant \
             @test/runtest-test_keeper_invocation_contract_hints \
             @test/runtest-test_keeper_path_ssot \
@@ -1318,7 +1317,8 @@ jobs:
         run: |
           opam exec -- dune build --root . \
             @test/runtest-test_keeper_owner \
-            @test/runtest-test_keeper_chat_operation_http
+            @test/runtest-test_keeper_chat_operation_http \
+            @test/runtest-test_keeper_wire_terminal
 
       - name: Run memory journal suite
         # The journal is the only disk record of a librarian pass that produced

--- a/lib/keeper/keeper_owner.ml
+++ b/lib/keeper/keeper_owner.ml
@@ -612,6 +612,13 @@ let start
                   }
             in
             Atomic.set t.child_cancel None;
+            (* Hook-before-durable-settle gives observers a happens-before: a
+               durably Failed/Succeeded operation implies its wire synthesis
+               already ran (the stopping test relies on this ordering).
+               Cancellation of the owner switch inside the hook skips the
+               Child_finished commit below exactly as it always could during
+               [request]; [settle_running_after_restart] clears that window
+               on the next boot. *)
             (try
                runner.on_execution_settled
                  ~keeper_name:t.keeper_name

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -12,6 +12,61 @@ let keeper_reply_chunk_hard_wrap_chars = 180
    blocks (backpressure) when the consumer lags. *)
 let worker_events_buffer_size = 512
 
+(* Wire-terminal accounting for keeper chat operations (#28811). The Dashboard
+   projection publishes AG-UI events while the turn runs inside the child
+   switch; a cancelled turn kills the projection fiber before it can emit
+   RUN_ERROR, so the stream used to close with no terminal receipt. Track
+   which operations have a live wire audience and whether a terminal made it
+   out; the Owner settle hook synthesizes the missing terminal from the
+   execution verdict after the child switch has unwound.
+
+   The stream counts as OPEN from sink registration, not from the first
+   projected event: a turn that fails after claim but before the projection
+   ever runs (missing input, payload parse failure) projects nothing, yet the
+   attached client is already waiting on a terminal (#28849 review). When the
+   last sink unregisters the record is dropped — with no audience there is
+   nothing to close, and the durable operation state stays the authority. *)
+type operation_wire_stream = Wire_started | Wire_terminal_sent
+
+let operation_wire_streams : (string, operation_wire_stream) Hashtbl.t =
+  Hashtbl.create 32
+
+let operation_wire_streams_mu = Stdlib.Mutex.create ()
+
+let ag_ui_terminal_event (event : Ag_ui.event) =
+  match event.Ag_ui.event_type with
+  | Ag_ui.Run_finished | Ag_ui.Run_error -> true
+  | Run_started | Step_started | Step_finished | Text_message_start
+  | Text_message_content | Text_message_end | Tool_call_start
+  | Tool_call_args | Tool_call_end | State_snapshot | State_delta
+  | Custom -> false
+
+let note_operation_wire_opened ~operation_id =
+  Stdlib.Mutex.protect operation_wire_streams_mu (fun () ->
+    if not (Hashtbl.mem operation_wire_streams operation_id)
+    then Hashtbl.replace operation_wire_streams operation_id Wire_started)
+
+let note_operation_wire_event ~operation_id event =
+  let terminal = ag_ui_terminal_event event in
+  Stdlib.Mutex.protect operation_wire_streams_mu (fun () ->
+    match Hashtbl.find_opt operation_wire_streams operation_id, terminal with
+    | Some Wire_terminal_sent, _ -> ()
+    | _, true ->
+      Hashtbl.replace operation_wire_streams operation_id Wire_terminal_sent
+    | None, false ->
+      Hashtbl.replace operation_wire_streams operation_id Wire_started
+    | Some Wire_started, false -> ())
+
+let drop_operation_wire_stream ~operation_id =
+  Stdlib.Mutex.protect operation_wire_streams_mu (fun () ->
+    Hashtbl.remove operation_wire_streams operation_id)
+
+let take_operation_wire_stream ~operation_id =
+  Stdlib.Mutex.protect operation_wire_streams_mu (fun () ->
+    let state = Hashtbl.find_opt operation_wire_streams operation_id in
+    Hashtbl.remove operation_wire_streams operation_id;
+    state)
+
 type operation_live_sink = Ag_ui.event -> unit
 
 let operation_live_sinks :
@@ -30,7 +85,12 @@ let register_operation_live_sink ~operation_id sink =
       | None -> []
       | Some sinks -> sinks
     in
-    Hashtbl.replace operation_live_sinks operation_id ((sink_id, sink) :: current));
+    Hashtbl.replace operation_live_sinks operation_id ((sink_id, sink) :: current);
+    (* An attached sink IS the open wire stream (#28849 review): mark it under
+       the sinks lock so registration and the last-sink drop below cannot
+       interleave into an attached-client/no-record state. Lock order is
+       always sinks_mu -> streams_mu; the streams lock never takes sinks_mu. *)
+    note_operation_wire_opened ~operation_id);
   fun () ->
     Stdlib.Mutex.protect operation_live_sinks_mu (fun () ->
       match Hashtbl.find_opt operation_live_sinks operation_id with
@@ -38,7 +98,11 @@ let register_operation_live_sink ~operation_id sink =
       | Some sinks ->
         let remaining = List.filter (fun (id, _) -> id <> sink_id) sinks in
         if remaining = []
-        then Hashtbl.remove operation_live_sinks operation_id
+        then (
+          Hashtbl.remove operation_live_sinks operation_id;
+          (* Last sink gone -> no audience: drop the wire record so settle
+             stays silent instead of synthesizing into the void. *)
+          drop_operation_wire_stream ~operation_id)
         else Hashtbl.replace operation_live_sinks operation_id remaining)
 ;;
 
@@ -94,46 +158,6 @@ type keeper_chat_stream_request = {
   attachments : Keeper_chat_store.attachment list;
   direct_message : Keeper_invocation_contract.direct_message;
 }
-
-(* Wire-terminal accounting for keeper chat operations. The Dashboard
-   projection publishes AG-UI events while the turn runs inside the child
-   switch; a cancelled turn kills the projection fiber before it can emit
-   RUN_ERROR, so the stream used to close with no terminal receipt (#28811).
-   Track which operations opened a live wire stream and whether a terminal
-   made it out; the Owner settle hook synthesizes the missing terminal from
-   the execution verdict after the child switch has unwound. *)
-type operation_wire_stream = Wire_started | Wire_terminal_sent
-
-let operation_wire_streams : (string, operation_wire_stream) Hashtbl.t =
-  Hashtbl.create 32
-
-let operation_wire_streams_mu = Stdlib.Mutex.create ()
-
-let ag_ui_terminal_event (event : Ag_ui.event) =
-  match event.Ag_ui.event_type with
-  | Ag_ui.Run_finished | Ag_ui.Run_error -> true
-  | Run_started | Step_started | Step_finished | Text_message_start
-  | Text_message_content | Text_message_end | Tool_call_start
-  | Tool_call_args | Tool_call_end | State_snapshot | State_delta
-  | Custom -> false
-
-let note_operation_wire_event ~operation_id event =
-  let terminal = ag_ui_terminal_event event in
-  Stdlib.Mutex.protect operation_wire_streams_mu (fun () ->
-    match Hashtbl.find_opt operation_wire_streams operation_id, terminal with
-    | Some Wire_terminal_sent, _ -> ()
-    | _, true ->
-      Hashtbl.replace operation_wire_streams operation_id Wire_terminal_sent
-    | None, false ->
-      Hashtbl.replace operation_wire_streams operation_id Wire_started
-    | Some Wire_started, false -> ())
-
-let take_operation_wire_stream ~operation_id =
-  Stdlib.Mutex.protect operation_wire_streams_mu (fun () ->
-    let state = Hashtbl.find_opt operation_wire_streams operation_id in
-    Hashtbl.remove operation_wire_streams operation_id;
-    state)
-
 
 let keeper_chat_stream_error_json message =
   `Assoc
@@ -2136,6 +2160,20 @@ let synthesize_wire_terminal_on_settle ~keeper_name ~operation_id ~execution =
       "keeper chat operation %s succeeded without a wire terminal event"
       operation_id
 
+(* The production settle glue between the Owner hook and the wire registry.
+   Named (and exposed via For_testing) so a test executes exactly what the
+   runner wires: both identifiers become plain strings at this boundary, so
+   a swapped argument would typecheck (#28849 review). *)
+let on_operation_execution_settled ~keeper_name ~claimed_operation_id ~execution =
+  match claimed_operation_id with
+  | None -> ()
+  | Some operation_id ->
+    synthesize_wire_terminal_on_settle
+      ~keeper_name
+      ~operation_id:(Keeper_owner.Chat_operation.Operation_id.to_string operation_id)
+      ~execution
+;;
+
 let operation_runner ~state ~clock : Keeper_owner.operation_runner =
   let base_path = (Mcp_server.workspace_config state).base_path in
   { ready =
@@ -2145,16 +2183,7 @@ let operation_runner ~state ~clock : Keeper_owner.operation_runner =
          | Some (_, _)
          | None -> false)
   ; execute = operation_executor ~state ~clock
-  ; on_execution_settled =
-      (fun ~keeper_name ~claimed_operation_id ~execution ->
-         match claimed_operation_id with
-         | None -> ()
-         | Some operation_id ->
-           synthesize_wire_terminal_on_settle
-             ~keeper_name
-             ~operation_id:
-               (Keeper_owner.Chat_operation.Operation_id.to_string operation_id)
-             ~execution)
+  ; on_execution_settled = on_operation_execution_settled
   }
 ;;
 
@@ -2354,5 +2383,6 @@ module For_testing = struct
   let note_operation_wire_event = note_operation_wire_event
   let take_operation_wire_stream = take_operation_wire_stream
   let synthesize_wire_terminal_on_settle = synthesize_wire_terminal_on_settle
+  let on_operation_execution_settled = on_operation_execution_settled
   let register_operation_live_sink = register_operation_live_sink
 end

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -245,9 +245,12 @@ type translated_keeper_stream_event =
 
 type operation_wire_stream = Wire_started | Wire_terminal_sent
 (** Wire-terminal accounting for one keeper chat operation: whether a live
-    AG-UI stream opened and whether a terminal event (RUN_FINISHED/RUN_ERROR)
-    made it out. Consumed by the Owner settle hook to synthesize the missing
-    terminal after a cancelled child switch unwinds (#28811). *)
+    AG-UI audience exists and whether a terminal event (RUN_FINISHED/
+    RUN_ERROR) made it out. The stream counts as open from sink registration
+    — not from the first projected event — so a turn that fails after claim
+    but before the projection runs still gets its synthesized terminal; the
+    record is dropped when the last sink unregisters. Consumed by the Owner
+    settle hook after the child switch unwinds (#28811). *)
 
 module For_testing : sig
   val parse_request : string -> (keeper_chat_stream_request, string) result
@@ -297,6 +300,11 @@ module For_testing : sig
   val synthesize_wire_terminal_on_settle :
     keeper_name:string ->
     operation_id:string ->
+    execution:Keeper_owner.operation_execution ->
+    unit
+  val on_operation_execution_settled :
+    keeper_name:string ->
+    claimed_operation_id:Keeper_owner.Chat_operation.Operation_id.t option ->
     execution:Keeper_owner.operation_execution ->
     unit
   val register_operation_live_sink :

--- a/test/test_keeper_wire_terminal.ml
+++ b/test/test_keeper_wire_terminal.ml
@@ -2,10 +2,11 @@
 
    A cancelled turn kills the AG-UI projection fiber inside the child switch
    before it can emit RUN_ERROR, so the SSE stream used to close with no
-   terminal receipt. The server tracks per-operation wire activity and the
-   Owner settle hook synthesizes the missing terminal from the execution
-   verdict. These tests pin the registry transitions and the synthesis
-   decision table. *)
+   terminal receipt. The server tracks per-operation wire audience — open
+   from sink registration, dropped when the last sink leaves — and the Owner
+   settle hook synthesizes the missing terminal from the execution verdict.
+   These tests pin the registry transitions, the synthesis decision table,
+   and the production glue the operation_runner wires. *)
 
 open Alcotest
 open Masc
@@ -94,8 +95,12 @@ let test_settle_is_silent_when_terminal_already_sent () =
     ~execution:(failed_execution "already terminal");
   check int "no duplicate terminal" 0 (List.length !events)
 
-let test_settle_is_silent_without_wire_activity () =
-  let operation_id = "op-wire-never-opened" in
+let test_settle_synthesizes_for_attached_client_with_no_events () =
+  (* A turn that fails after claim but before the projection ever runs
+     (missing input, payload parse failure) projects no events. The attached
+     client still needs a terminal: sink registration alone opens the wire
+     stream (#28849 review). *)
+  let operation_id = "op-wire-claimed-no-projection" in
   let events, sink = collect_sink () in
   let unregister =
     Stream.For_testing.register_operation_live_sink ~operation_id sink
@@ -104,8 +109,87 @@ let test_settle_is_silent_without_wire_activity () =
   Stream.For_testing.synthesize_wire_terminal_on_settle
     ~keeper_name:"wire-test"
     ~operation_id
-    ~execution:(failed_execution "no stream ever opened");
-  check int "no synthesis without wire activity" 0 (List.length !events)
+    ~execution:(failed_execution "operation input missing");
+  match !events with
+  | [ event ] ->
+    (match event.Ag_ui.event_type with
+     | Ag_ui.Run_error -> ()
+     | _ -> fail "synthesized event is not RUN_ERROR")
+  | events ->
+    fail
+      (Printf.sprintf "expected one synthesized event, got %d"
+         (List.length events))
+
+let test_settle_is_silent_without_audience () =
+  let operation_id = "op-wire-no-audience" in
+  check bool "no record before settle" true
+    (Option.is_none (Stream.For_testing.take_operation_wire_stream ~operation_id));
+  (* No sink was ever registered (connector channels): settle must not raise
+     and must stay silent — durable operation state is the authority. *)
+  Stream.For_testing.synthesize_wire_terminal_on_settle
+    ~keeper_name:"wire-test"
+    ~operation_id
+    ~execution:(failed_execution "no audience ever attached");
+  check bool "still no record after settle" true
+    (Option.is_none (Stream.For_testing.take_operation_wire_stream ~operation_id))
+
+let test_unregistering_last_sink_drops_the_record () =
+  let operation_id = "op-wire-audience-left" in
+  let events, sink = collect_sink () in
+  let unregister =
+    Stream.For_testing.register_operation_live_sink ~operation_id sink
+  in
+  unregister ();
+  Stream.For_testing.synthesize_wire_terminal_on_settle
+    ~keeper_name:"wire-test"
+    ~operation_id
+    ~execution:(failed_execution "client disconnected before settle");
+  check int "no synthesis after the audience left" 0 (List.length !events);
+  check bool "record dropped with the last sink" true
+    (Option.is_none (Stream.For_testing.take_operation_wire_stream ~operation_id))
+
+let test_production_glue_settles_claimed_operation () =
+  (* Executes the exact function the operation_runner wires. Both identifiers
+     are plain strings past this boundary, so a swapped argument would
+     typecheck — the content assertions below are the guard (#28849 review). *)
+  let operation_id_string = "op-wire-glue" in
+  let operation_id =
+    match
+      Keeper_owner.Chat_operation.Operation_id.of_string operation_id_string
+    with
+    | Ok id -> id
+    | Error detail -> fail detail
+  in
+  let events, sink = collect_sink () in
+  let unregister =
+    Stream.For_testing.register_operation_live_sink
+      ~operation_id:operation_id_string
+      sink
+  in
+  Fun.protect ~finally:unregister @@ fun () ->
+  Stream.For_testing.on_operation_execution_settled
+    ~keeper_name:"wire-glue"
+    ~claimed_operation_id:(Some operation_id)
+    ~execution:(failed_execution "glue path verdict");
+  (match !events with
+   | [ event ] ->
+     let sse = Ag_ui.event_to_sse event in
+     check bool "keeper name lands in thread_id position" true
+       (Astring.String.is_infix ~affix:"keeper:wire-glue" sse);
+     check bool "operation id lands in run_id position" true
+       (Astring.String.is_infix
+          ~affix:("keeper-operation-run-" ^ operation_id_string)
+          sse)
+   | events ->
+     fail
+       (Printf.sprintf "expected one glue-synthesized event, got %d"
+          (List.length events)));
+  (* Unclaimed settle is a no-op through the same glue. *)
+  Stream.For_testing.on_operation_execution_settled
+    ~keeper_name:"wire-glue"
+    ~claimed_operation_id:None
+    ~execution:(failed_execution "never claimed");
+  check int "unclaimed settle synthesizes nothing" 1 (List.length !events)
 
 let test_settle_success_without_terminal_emits_nothing () =
   let operation_id = "op-wire-success-anomaly" in
@@ -132,8 +216,14 @@ let () =
             test_settle_synthesizes_run_error_for_open_stream
         ; test_case "settle silent when terminal already sent" `Quick
             test_settle_is_silent_when_terminal_already_sent
-        ; test_case "settle silent without wire activity" `Quick
-            test_settle_is_silent_without_wire_activity
+        ; test_case "settle synthesizes for attached client with no events" `Quick
+            test_settle_synthesizes_for_attached_client_with_no_events
+        ; test_case "settle silent without audience" `Quick
+            test_settle_is_silent_without_audience
+        ; test_case "unregistering last sink drops the record" `Quick
+            test_unregistering_last_sink_drops_the_record
+        ; test_case "production glue settles claimed operation" `Quick
+            test_production_glue_settles_claimed_operation
         ; test_case "success without terminal emits nothing" `Quick
             test_settle_success_without_terminal_emits_nothing
         ] )


### PR DESCRIPTION
#28849가 리뷰 수정 커밋(5e51bc4a6d)이 push되기 전 head(01e99f7635)로 admin-병합되어, 적대적 리뷰 PASS까지 받은 P1 수정 2건이 main에 도달하지 못했다 (masc#5303과 동일한 post-merge push 유실 패턴). 이 PR은 그 커밋의 cherry-pick 재상륙이다.

내용 (원 리뷰: #28849 코멘트 참조):
- **P1**: claim 후 projection 도달 전에 죽는 턴(입력 누락/파싱 실패)은 wire 이벤트가 없어 settle 합성이 침묵 → 붙어 있는 SSE 클라이언트 hang 잔존. wire open 신호를 **sink 등록 시점**(실제 청중 신호)으로 이동, 마지막 sink 이탈 시 기록 폐기. 등록 마킹은 sinks 락 안(락 순서 sinks_mu → streams_mu 단방향, 역방향 중첩 전수 부재 확인됨).
- **P1**: 프로덕션 settle glue를 `on_operation_execution_settled`로 추출해 runner가 동일 값을 참조, For_testing 노출 + 직접 실행 테스트 (thread_id/run_id 위치 검증으로 string 스왑 차단).
- **P2**: hook-before-durable 순서 근거 주석화 (durable 종결 ⇒ 합성 완료 happens-before).
- CI: 스위트를 keeper 동작 스텝으로 이동.

검증: adversarial 재검증 **PASS** (adv-review-28849, 5e51bc4a6d 기준 — cherry-pick 동일 diff). wire 스위트 8/8, owner 39, chat_operation_http 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)