### PR TITLE
fix(keeper): fence 가 원인 타입을 문자열로 눌러 다음 턴이 아무것도 배우지 못한다

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -352,6 +352,7 @@ let attempt_runtime_candidates
                (Provider_attempt_effect_fenced
                   { runtime_id = attempt_runtime_id
                   ; effect_disposition
+                  ; cause = fenced_attempt_cause_of_core_error error
                   ; diagnostic = Agent_core.Error.to_string error
                   })
          in

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -34,6 +34,7 @@ include
       Keeper_internal_error.transcript_quarantine_reason
      and type gate_replay_repair_stage =
       Keeper_internal_error.gate_replay_repair_stage
+     and type fenced_attempt_cause = Keeper_internal_error.fenced_attempt_cause
      and type masc_internal_error = Keeper_internal_error.masc_internal_error
 
 (** {1 Turn pipeline records} *)

--- a/lib/keeper_runtime/keeper_internal_error.ml
+++ b/lib/keeper_runtime/keeper_internal_error.ml
@@ -256,6 +256,45 @@ let gate_replay_repair_stage_of_string = function
   | _ -> None
 ;;
 
+type fenced_attempt_cause =
+  | Attempt_timed_out
+  | Attempt_failed
+
+let fenced_attempt_cause_to_string = function
+  | Attempt_timed_out -> "attempt_timed_out"
+  | Attempt_failed -> "attempt_failed"
+;;
+
+let fenced_attempt_cause_of_string = function
+  | "attempt_timed_out" -> Some Attempt_timed_out
+  | "attempt_failed" -> Some Attempt_failed
+  | _ -> None
+;;
+
+let fenced_attempt_cause_of_core_error : Agent_core.Error.t -> fenced_attempt_cause
+  = function
+  | Agent_core.Error.Api (Agent_core.Retry.Timeout _)
+  | Agent_core.Error.Provider (Llm_provider.Error.Timeout _)
+  | Agent_core.Error.Provider
+      (Llm_provider.Error.NetworkError { timeout_phase = Some _; _ })
+  | Agent_core.Error.Provider
+      (Llm_provider.Error.NetworkError
+         { kind = Llm_provider.Http_client.Timeout; _ }) -> Attempt_timed_out
+  (* Every remaining top-level constructor is named rather than swept by a
+     wildcard: a new agent-core error family must be classified here on
+     purpose, not inherit "the runtime answered" by default. *)
+  | Agent_core.Error.Provider _
+  | Agent_core.Error.Api _
+  | Agent_core.Error.Agent _
+  | Agent_core.Error.Mcp _
+  | Agent_core.Error.Config _
+  | Agent_core.Error.Serialization _
+  | Agent_core.Error.Io _
+  | Agent_core.Error.Orchestration _
+  | Agent_core.Error.Internal _
+  | Agent_core.Error.Internal_carried _ -> Attempt_failed
+;;
+
 type masc_internal_error =
   | Runtime_exhausted of {
       runtime_id : string;
@@ -315,6 +354,7 @@ type masc_internal_error =
   | Provider_attempt_effect_fenced of {
       runtime_id : string;
       effect_disposition : Keeper_provider_attempt_effect_core.t;
+      cause : fenced_attempt_cause;
       diagnostic : string;
     }
   | Receipt_persistence_failed of {
@@ -515,12 +555,13 @@ let masc_internal_error_to_json = function
         ("diagnostic", `String diagnostic);
       ]
   | Provider_attempt_effect_fenced
-      { runtime_id; effect_disposition; diagnostic } ->
+      { runtime_id; effect_disposition; cause; diagnostic } ->
     `Assoc
       [ "kind", `String provider_attempt_effect_fenced_kind
       ; "runtime_id", `String runtime_id
       ; ( "effect_disposition"
         , `String (Keeper_provider_attempt_effect_core.to_string effect_disposition) )
+      ; "cause", `String (fenced_attempt_cause_to_string cause)
       ; "diagnostic", `String diagnostic
       ]
   | Receipt_persistence_failed { detail } ->
@@ -935,19 +976,24 @@ let parse_masc_internal_error_json (json : Yojson.Safe.t) :
       | Some (`String kind)
         when String.equal kind provider_attempt_effect_fenced_kind
              && exact_fields
-                  [ "kind"; "runtime_id"; "effect_disposition"; "diagnostic" ]
+                  [ "kind"; "runtime_id"; "effect_disposition"; "cause"; "diagnostic" ]
                   fields ->
         (match
            string_opt_of_assoc "runtime_id" json,
            string_opt_of_assoc "effect_disposition" json,
+           string_opt_of_assoc "cause" json,
            string_opt_of_assoc "diagnostic" json
          with
-         | Some runtime_id, Some effect_disposition, Some diagnostic ->
-           Option.map
-             (fun effect_disposition ->
-                Provider_attempt_effect_fenced
-                  { runtime_id; effect_disposition; diagnostic })
-             (Keeper_provider_attempt_effect_core.of_string effect_disposition)
+         | Some runtime_id, Some effect_disposition, Some cause, Some diagnostic ->
+           (match
+              Keeper_provider_attempt_effect_core.of_string effect_disposition,
+              fenced_attempt_cause_of_string cause
+            with
+            | Some effect_disposition, Some cause ->
+              Some
+                (Provider_attempt_effect_fenced
+                   { runtime_id; effect_disposition; cause; diagnostic })
+            | _ -> None)
          | _ -> None)
       | Some (`String "receipt_persistence_failed") -> (
           match string_opt_of_assoc "detail" json with

--- a/lib/keeper_runtime/keeper_internal_error.mli
+++ b/lib/keeper_runtime/keeper_internal_error.mli
@@ -107,6 +107,26 @@ type gate_replay_repair_stage =
   | Replay_stale_grant_retirement
   | Replay_invalid_resolution_state
 
+type fenced_attempt_cause =
+  | Attempt_timed_out
+  (** The runtime stopped producing output. No failure response arrived, so
+          the attempt's outcome is unknown to the provider as well as to us. *)
+  | Attempt_failed
+  (** The runtime answered and the answer was a failure. *)
+(** Why a fenced attempt ended, kept as the one distinction a later turn's
+    runtime ordering can act on: a runtime that stops responding is a
+    different kind of candidate from one that rejects requests. Deliberately
+    coarser than the attempt's own error — every finer typed fact stays in
+    that error at the point of fencing, and the display rendering of it stays
+    in [diagnostic]. *)
+
+val fenced_attempt_cause_to_string : fenced_attempt_cause -> string
+val fenced_attempt_cause_of_string : string -> fenced_attempt_cause option
+
+val fenced_attempt_cause_of_core_error : Agent_core.Error.t -> fenced_attempt_cause
+(** Matches the typed timeout constructors only — no message inspection.
+    Everything else is [Attempt_failed]. *)
+
 type masc_internal_error =
   | Runtime_exhausted of {
       runtime_id : string;
@@ -161,11 +181,17 @@ type masc_internal_error =
   | Provider_attempt_effect_fenced of {
       runtime_id : string;
       effect_disposition : Keeper_provider_attempt_effect_core.t;
+      cause : fenced_attempt_cause;
       diagnostic : string;
     }
       (** A provider attempt failed after an effect was attempted or after the
           runtime lost complete effect observation. The exact source must be
-          terminalized as failed, never replayed automatically. *)
+          terminalized as failed, never replayed automatically.
+
+          Wrapping replaces the attempt's own typed error, so [cause] carries
+          forward the distinction a later turn can still act on. [diagnostic]
+          is the display rendering of the replaced error and is never
+          matched. *)
   | Receipt_persistence_failed of { detail : string }
   | Gate_replay_repair_required of {
       approval_id : string;

--- a/test/test_keeper_failed_selection_disposition.ml
+++ b/test/test_keeper_failed_selection_disposition.ml
@@ -80,6 +80,7 @@ let test_effect_fenced_failure_terminalizes_exact_source () =
          { runtime_id = "effect-owner"
          ; effect_disposition =
              Masc.Keeper_provider_attempt_effect.Observation_unavailable
+         ; cause = Masc.Keeper_turn_driver.Attempt_failed
          ; diagnostic = "provider failed after dispatch"
          })
   in

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -319,6 +319,7 @@ let () =
     Keeper_internal_error.Provider_attempt_effect_fenced
       { runtime_id = "antigravity_subscription.gemini-3-6-flash-high"
       ; effect_disposition = Keeper_provider_attempt_effect_core.Effect_attempted
+      ; cause = Keeper_internal_error.Attempt_failed
       ; diagnostic = "provider response did not prove whether the tool effect settled"
       }
   in
@@ -331,6 +332,42 @@ let () =
     "provider-attempt fence codec round-trips the typed evidence"
     (Keeper_internal_error.parse_masc_internal_error_json fenced_json
      = Some fenced_error);
+  (* A fence replaces the attempt's own error, so the record is the only place
+     left that can say the runtime stopped responding rather than answered with
+     a failure. Both directions of the wire must keep that. *)
+  let timed_out_error =
+    Keeper_internal_error.Provider_attempt_effect_fenced
+      { runtime_id = "antigravity_subscription.gemini-3-6-flash-high"
+      ; effect_disposition = Keeper_provider_attempt_effect_core.Effect_attempted
+      ; cause = Keeper_internal_error.Attempt_timed_out
+      ; diagnostic = "Timeout: Antigravity turn timed out after 600.000s"
+      }
+  in
+  let timed_out_json =
+    Keeper_internal_error.masc_internal_error_to_json timed_out_error
+  in
+  check
+    "a timed-out fence is distinguishable on the wire from a failed one"
+    (Json_util.get_string timed_out_json "cause"
+     = Some
+         (Keeper_internal_error.fenced_attempt_cause_to_string
+            Keeper_internal_error.Attempt_timed_out)
+     && Json_util.get_string fenced_json "cause"
+        <> Json_util.get_string timed_out_json "cause");
+  check
+    "a timed-out fence round-trips its cause"
+    (Keeper_internal_error.parse_masc_internal_error_json timed_out_json
+     = Some timed_out_error);
+  check
+    "a provider timeout classifies as a non-answering attempt"
+    (Keeper_internal_error.fenced_attempt_cause_of_core_error
+       (Agent_core.Error.Provider
+          (Llm_provider.Error.Timeout
+             { provider = "antigravity"
+             ; timeout_phase = Some Llm_provider.Http_client.Wall_clock
+             ; detail = "turn timed out after 600.000s"
+             }))
+     = Keeper_internal_error.Attempt_timed_out);
   let fenced_wire = Keeper_internal_error.provider_attempt_effect_fenced_kind in
   let producer_wire =
     fenced_error

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -1274,6 +1274,7 @@ let check_effect_disposition_blocks_same_turn_retry label effect_disposition =
              { runtime_id = "primary.test_model"
              ; effect_disposition = observed
              ; diagnostic
+             ; _
              }) ->
         Alcotest.(check bool)
           (label ^ " keeps the exact effect disposition")


### PR DESCRIPTION
Closes #28856.

## 무엇이 문제였나

부수효과가 나간 프로바이더 실패는 `Provider_attempt_effect_fenced` 로 감싸이면서 **원래의 타입 오류가 표시용 문자열로 대체된다.** 그 뒤로는 "런타임이 응답을 안 했다" 와 "런타임이 실패를 응답했다" 를 구분할 방법이 없다. fence 레코드가 남는 유일한 흔적인데, 거기에 타입화된 원인이 없었다.

`lib/keeper/keeper_turn_driver.ml`

```ocaml
| Effect_attempted | Observation_unavailable ->
  core_error_of_masc_internal_error
    (Provider_attempt_effect_fenced
       { runtime_id; effect_disposition
       ; diagnostic = Agent_core.Error.to_string error })   (* 타입 → string *)
```

## 실측

`logs/masc-8935-restart-20260814.log`

| | 건수 |
|---|---|
| `antigravity ... timed out after 600.000s` | 86 |
| 그중 fence (`effect_attempted`) | 6 |
| fence `diagnostic` 고유값 | 1종 |

## 무엇을 했나

`fenced_attempt_cause` 를 variant 와 wire 양쪽에 싣는다.

```ocaml
type fenced_attempt_cause =
  | Attempt_timed_out   (* 런타임이 출력을 멈춤. 실패 응답조차 안 옴 *)
  | Attempt_failed      (* 런타임이 답했고, 그 답이 실패 *)
```

### 왜 phase 를 안 싣는가

처음에는 `{ phase : timeout_phase option }` 를 실으려 했고 되돌렸다. `timeout_phase` 에는 `Stream_idle of stream_idle_state` 가 있고 라벨이 `"stream_idle:<state>"` 로 인코딩된다. 역함수를 만들면 그 접두사를 문자열로 파싱해야 하는데, 그건 이 저장소가 금지하는 분류기다. 왕복 안 되는 값을 durable 레코드에 넣으면 디코딩 쪽에서 **틀린 데이터**(phase 가 있었는데 없었다고 말함)가 나온다.

다음 턴이 실제로 쓸 수 있는 구분은 phase 가 아니라 "응답을 했는가" 다. 더 세밀한 사실은 fence 시점의 error 와 표시용 `diagnostic` 에 그대로 남는다.

### 와일드카드를 안 쓴다

`fenced_attempt_cause_of_core_error` 는 `Agent_core.Error.t` 의 최상위 생성자를 **전부 명시**한다. 새 에러 계열이 생기면 컴파일이 막힌다 — `_ ->` 로 "런타임이 답했다" 를 기본값으로 물려받지 않는다. 선례: `Keeper_agent_error.core_termination_semantics`.

## Breaking

wire hard cut. `"cause"` 가 `exact_fields` 집합에 들어가므로 **이 커밋 이전에 기록된 fence receipt 는 더 이상 디코딩되지 않는다.** 호환 리더를 만들지 않는다.

## 검증

로컬, 워크트리 고정(`--root .`):

| | 결과 |
|---|---|
| `dune build @check` | exit 0 |
| `test_keeper_terminal_reason_typed` | exit 0 (matrix cases=118400 mismatches=0) |
| `test_keeper_failed_selection_disposition` | exit 0 |
| `test_blocker_class_exhaustiveness` | exit 0 |
| `test_keeper_turn_driver_failover` | exit 0 |
| `test_keeper_claude_code_runtime` | exit 0 |
| `test_runtime_codex_app_server` | exit 1 — **기존 실패**, #28360 |

#28360 은 `subscription boundary` 의 no-deadline 4건이고 2026-08-12 부터 열려 있다. 단독 재실행에서도 같은 4건이라 부하 영향이 아니며, 이 PR 의 diff 는 deadline 경로를 건드리지 않는다.

새 테스트 3건 (`test_keeper_terminal_reason_typed`):
- 타임아웃 fence 와 실패 fence 가 wire 에서 구분된다
- 타임아웃 fence 가 cause 를 왕복한다
- 프로바이더 타임아웃이 `Attempt_timed_out` 으로 분류된다

## 소비자는 아직 없다

이 PR 은 사실을 보존만 한다. 그 위에서 무엇을 할지(실패한 런타임을 다음 턴에 뒤로 미룰지)는 별개 판단이고, 같은 파일에 이미 반대 입장이 있다 — 프로바이더가 복구 시각을 말하지 않은 실패에 쿨다운을 합성하지 않는다. 같은 모듈의 `Accept_rejected.stop_reason` 이 동일한 순서를 밟은 선례다.
