### PR TITLE
fix(ci): main-push concurrency 를 커밋 단위로 — 판정이 나오게

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,20 +23,27 @@ permissions:
   pull-requests: read
 
 concurrency:
-  # Branch/PR runs verify the current branch state: a newer push supersedes
-  # the older run, so the older one cancels. Main is excluded from that rule:
-  # merges land minutes apart while a build takes 30-50, so cancelling
-  # in-progress main runs left main with no completed verdict at all (72% of
-  # main-push runs cancelled; on 2026-08-14 five consecutive heads were killed
-  # inside 40 minutes with zero completions). With cancel-in-progress off,
-  # GitHub still keeps at most one pending run per group — intermediate queued
-  # runs collapse into the newest — so main completes one verdict per build
-  # duration and is never more than one build behind, without a backlog.
-  # TLA+ Main Verification remains independently SHA-scoped and preserves the
-  # per-commit formal verification contract.
+  # Branch/PR runs verify the current branch state: a newer push supersedes the
+  # older run, so the older one cancels.
+  #
+  # Main pushes are keyed by commit instead, because a shared main group cannot
+  # produce verdicts at this merge rate. Build and Test budgets 73 minutes of
+  # focused groups under a 90-minute timeout, while merges land every 5.5
+  # minutes on average and arrive 9 seconds apart in bursts. One slot for that
+  # stream means a run needs 90 quiet minutes to finish, and there are none:
+  # turning cancel-in-progress off does not help, because a main run sits
+  # pending and is collapsed by the next merge before it dispatches a single
+  # job. Measured 2026-08-16: main's last completed verdict of any kind was
+  # 2026-08-13T14:07:47Z, and the 150 runs after it produced 148 cancellations
+  # and zero verdicts; across 05:45-07:36 that day, 20 runs dispatched 0 jobs
+  # between them. Keying on github.sha gives each commit its own group, so
+  # nothing collapses. This is the scoping TLA+ Main Verification already uses.
   group: >-
     ${{ github.workflow }}-${{ github.event_name }}-${{
-      github.event.pull_request.number || github.ref_name || github.run_id
+      github.event.pull_request.number
+      || (github.ref == 'refs/heads/main' && github.sha)
+      || github.ref_name
+      || github.run_id
     }}
   cancel-in-progress: ${{ (github.event_name == 'push' && github.ref != 'refs/heads/main') || (github.event_name == 'pull_request' && contains(fromJSON('["opened","synchronize","reopened","ready_for_review"]'), github.event.action)) }}
 


### PR DESCRIPTION
## 무엇이 깨져 있었나

main CI 가 판정을 내놓지 못합니다. 실패하는 게 아니라 **아무 말도 안 합니다**.

| | |
|---|---|
| 마지막 성공한 main CI | `2026-08-12T01:54:13Z` |
| 마지막 판정(성공이든 실패든) | `2026-08-13T14:07:47Z` |
| 그 이후 main push 런 | **150건, 148건 취소, 판정 0건** |
| 2026-08-16 05:45–07:36 | 20건, **job dispatch 0개** |

취소 시각이 전부 다음 런의 생성 시각과 일치합니다. 런이 pending 에 머무는 동안 다음 병합이 접어버립니다.

```
$ gh api ".../actions/runs?branch=main&event=push" --jq '...'
07:34:25 → 07:35:59  cancelled   (jobs=0)
07:34:16 → 07:34:26  cancelled   (jobs=0)
07:33:53 → 07:34:17  cancelled   (jobs=0)
07:33:40 → 07:33:53  cancelled   (jobs=0)
07:22:58 → 07:33:41  cancelled   (jobs=0)
```

## 왜 기존 수정이 안 먹혔나

`ci.yml` 주석은 이 문제를 이미 알고 있었고 (`72% of main-push runs cancelled`, 2026-08-14), main 을 `cancel-in-progress` 에서 빼는 것으로 대응했습니다. 그 전제가 틀렸습니다:

> GitHub still keeps at most one pending run per group — intermediate queued runs collapse into the newest — so main completes one verdict per build duration

`cancel-in-progress: false` 는 **in-progress 런**을 보호합니다. main 런은 거기 도달하지 못합니다. 생성 → pending → 다음 병합에 접힘. job 이 하나도 뜨지 않습니다.

산수가 안 맞습니다:

- `Build and Test`: `timeout-minutes: 90`, focused group 예산 73분
- 병합 간격: 평균 5.5분, 버스트 구간은 45초에 4건 (07:33:40 → 07:34:25)
- 단일 슬롯이 완주하려면 **90분의 정적**이 필요 — 그런 구간이 없음

현장 증거 — 이 PR 을 쓰는 시점에 `31934284809` (a8622c23d5) 가 **7분 40초째 pending, job 0개**, 그룹 안에 도는 게 없었습니다.

## 수정

```diff
   group: >-
     ${{ github.workflow }}-${{ github.event_name }}-${{
-      github.event.pull_request.number || github.ref_name || github.run_id
+      github.event.pull_request.number
+      || (github.ref == 'refs/heads/main' && github.sha)
+      || github.ref_name
+      || github.run_id
     }}
```

커밋마다 자기 그룹을 가지니 접히지 않습니다. `TLA+ Main Verification` 이 이미 쓰고 있는 스코핑과 같습니다.

PR/branch 런의 supersede 규칙과 `cancel-in-progress` 식은 그대로입니다.

## 트레이드오프

main 동시 실행이 병합 속도에 비례해 늘어납니다 — 5.5분/90분 기준 최대 16개 정도. 러너 시간을 씁니다. 기존 그룹은 그 비용을 아끼는 대신 판정까지 같이 죽이고 있었습니다.

## 로컬 검증

```
$ python3 scripts/ci/check-yaml-syntax.py
37 YAML files validated successfully.

$ python3 -c "import yaml; ..."
group: "${{ github.workflow }}-${{ github.event_name }}-${{\n  github.event.pull_request.number\n  || (github.ref == 'refs/heads/main' && github.sha)\n  || github.ref_name\n  || github.run_id\n}}"
```

GitHub 식 평가: `github.ref == 'refs/heads/main' && github.sha` 는 참이면 `github.sha`, 거짓이면 `false` 를 돌려주고, `false || github.ref_name` 이 `ref_name` 으로 이어집니다. PR 이벤트는 `pull_request.number` 에서 단락됩니다.

## 미검증

- 실제 효과는 이 PR 이 병합돼 main push 가 발생해야 확인됩니다. 확인 방법: 병합 후 main 런이 pending 에 멈추지 않고 job 을 dispatch 하는지, 그리고 후속 병합이 그것을 취소하지 않는지.
- 동시 실행 증가가 계정 동시성 한도에 닿는지는 실측 필요.

## 곁가지

같은 창에서 병합된 #28848 / #28855 / #28857 은 셋 다 CI 판정 없이 들어갔습니다. PR 쪽은 별도 경로로 죽습니다 — `ci-cancel-closed-pr.yml` 이 PR 이 닫히면 in-flight 런을 취소하는데, #28857 은 `ready_for_review` 4초 뒤에 병합돼서 7분 돌던 `Build and Test` 가 병합 7초 뒤에 잘렸습니다. 그 동작 자체는 의도된 것이고, main 런이 살아나면 그 뒤를 받아줍니다. 이 PR 은 main 쪽만 고칩니다.
