### PR TITLE
fix(keeper): bare Operator_interrupt를 typed 취소로 분류 (#28810)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1364,6 +1364,14 @@ let run_turn
           ());
        receipt_result)
 with
+| Keeper_registry.Operator_interrupt as e ->
+  (* Bare form: [Switch.fail] on the turn switch re-raises the exception
+     itself at the [Switch.run] boundary; only fibers inside see the
+     [Cancelled]-wrapped form below (#28810). Same bookkeeping, same
+     re-raise. *)
+  Keeper_registry.set_failure_reason
+    ~base_path:config.base_path meta.name (Some Keeper_registry.Operator_interrupt);
+  raise e
 | Eio.Cancel.Cancelled Keeper_registry.Operator_interrupt as ce ->
   Keeper_registry.set_failure_reason
     ~base_path:config.base_path meta.name (Some Keeper_registry.Operator_interrupt);

--- a/lib/keeper/keeper_owner.ml
+++ b/lib/keeper/keeper_owner.ml
@@ -598,6 +598,17 @@ let start
                   ; detail = "Keeper owner stopped the active turn"
                   ; outcome_ref = None
                   }
+              | Keeper_registry_types.Operator_interrupt
+              | Eio.Cancel.Cancelled Keeper_registry_types.Operator_interrupt ->
+                (* Typed operator cancellation (#28810): the interrupt route
+                   fails the turn switch with this exception — bare at the
+                   switch boundary, [Cancelled]-wrapped inside it. Neither
+                   form is an internal error. *)
+                Operation_failed
+                  { kind = Chat_operation.Turn_cancelled
+                  ; detail = Keeper_registry_types.operator_interrupt_detail
+                  ; outcome_ref = None
+                  }
               | Eio.Cancel.Cancelled cause ->
                 Operation_failed
                   { kind = Chat_operation.Turn_cancelled

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -14,6 +14,12 @@ include Keeper_registry_types_failure
 
 exception Operator_interrupt
 
+(* One string for every [Operator_interrupt] terminal (ledger rows, queued
+   outcomes, tool responses) so the incident class stays greppable as one
+   thing. The classification itself is typed on the exception; this is only
+   the human-facing detail. *)
+let operator_interrupt_detail = "operator interrupted the turn"
+
 (* Turn_phase FSM types, witnesses, transitions, and resolver extracted to
    [Keeper_registry_types_turn_phase] (500-line decomp). *)
 include Keeper_registry_types_turn_phase

--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -54,8 +54,15 @@ type failure_reason =
 
 exception Operator_interrupt
 (** Raised by [interrupt_current_turn] to cancel the live turn switch.
-    The turn runtime may catch this via [Eio.Cancel.Cancelled] and record
-    [failure_reason.Operator_interrupt] for observability. *)
+    Fibers inside the turn switch observe it as
+    [Eio.Cancel.Cancelled Operator_interrupt]; the [Eio.Switch.run] boundary
+    re-raises it BARE. Classification ladders must handle both forms
+    (#28810: the bare form used to fall into generic internal-error arms). *)
+
+val operator_interrupt_detail : string
+(** Human-facing detail for [Operator_interrupt] terminals. One shared string
+    so ledger rows, queued outcomes, and tool responses classify as one
+    incident class. *)
 
 val failure_reason_to_string : failure_reason -> string
 

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -551,6 +551,17 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
         ~failure_class:Tool_result.Runtime_failure
         ~tool_name:name ~start_time
         (Masc_domain.masc_error_to_string (Masc_domain.System Masc_domain.System_error.NotInitialized))
+    | Keeper_registry.Operator_interrupt ->
+      (* #28810: operator-requested turn interrupt is a cancellation, not a
+         crash. The failure-class vocabulary has no cancellation class;
+         Transient (retryable by the caller, WARN severity) is the honest
+         nearest fit. *)
+      Log.Mcp.info "tools/call interrupted by operator: %s" name;
+      Tool_result.error
+        ~failure_class:Tool_result.Transient_error
+        ~tool_name:name
+        ~start_time
+        Keeper_registry_types.operator_interrupt_detail
     | exn ->
       (* Never let a tool exception crash the MCP server. *)
       let err = Printexc.to_string exn in

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -708,6 +708,14 @@ let execute_keeper_stream_tool_streaming
         ( Masc_domain.masc_error_to_string
             (Masc_domain.System Masc_domain.System_error.NotInitialized)
         , Tool_result.Failed Tool_result.Runtime_failure )
+    | Keeper_registry.Operator_interrupt ->
+        (* #28810: operator-requested turn interrupt is a cancellation, not a
+           crash. The failure-class vocabulary has no cancellation class;
+           Transient (retryable by the caller, WARN severity) is the honest
+           nearest fit. *)
+        Log.Mcp.info "tools/call interrupted by operator (stream)";
+        ( Keeper_registry_types.operator_interrupt_detail
+        , Tool_result.Failed Tool_result.Transient_error )
     | exn ->
         let err = Printexc.to_string exn in
         Log.Mcp.error "tools/call crashed (stream): %s" err;
@@ -1685,6 +1693,18 @@ let process_single_turn ~user_row_origin ~submission
            (match Eio.Switch.run (fun request_sw -> run_turn request_sw) with
             | _ -> publish_inline_completion ()
             | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
+            | exception Keeper_registry.Operator_interrupt ->
+              (* Typed operator cancellation (#28810): the interrupt fails
+                 the turn switch and the [Switch.run] boundary re-raises the
+                 bare exception here. A cancelled turn, not a crash. *)
+              let detail = Keeper_registry_types.operator_interrupt_detail in
+              push_worker_event
+                (Stream_terminal
+                   { status = Stream_error
+                   ; body = detail
+                   ; queued_outcome = Some (Failed { kind = Turn_cancelled; detail })
+                   });
+              publish_inline_completion ()
             | exception exn ->
               let detail = Printexc.to_string exn in
               push_worker_event

--- a/test/test_keeper_owner.ml
+++ b/test/test_keeper_owner.ml
@@ -1261,6 +1261,56 @@ let test_operation_executor_exception_is_terminal_and_next_runs () =
   check int "child exception does not stop the actor" 2 !execution_count
 ;;
 
+let test_operator_interrupt_settles_as_typed_cancel () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let operation_executor ~sw:_ ~keeper_name:_ ~claim =
+    match claim () with
+    | Error error ->
+      Owner.Operation_failed
+        { kind = Chat_operation.Store_unavailable
+        ; detail = Owner.error_to_string error
+        ; outcome_ref = None
+        }
+    | Ok None -> failwith "missing FIFO head"
+    | Ok (Some (_ : Chat_operation.t)) ->
+      (* The interrupt route fails the turn switch with this exception; at
+         the executor boundary it surfaces bare (#28810). It must settle as
+         a typed operator cancellation, never as Turn_exception. *)
+      raise Keeper_registry_types.Operator_interrupt
+  in
+  let owner =
+    owner_ok
+      (start_owner_with_executor
+         ~sw
+         ~store:{ replace = (fun _ -> Ok ()); remove = (fun _ -> Ok ()) }
+         ~operation_executor:(Some operation_executor)
+         ~keeper_name:"operator-interrupt"
+         ~initial_meta:(Some (make_meta "operator-interrupt"))
+         ())
+  in
+  let operation_id = operation_id "kmsg-operator-interrupt" in
+  ignore
+    (owner_ok
+       (Owner.submit_operation
+          owner
+          ~operation_id
+          ~source:operation_source
+          ~input:(operation_input "interrupt me")));
+  let terminal = await_terminal owner operation_id 1_000 in
+  match terminal.state with
+  | Chat_operation.Failed { failure = { kind; detail; _ }; _ } ->
+    check string
+      "operator interrupt failure kind"
+      "Turn_cancelled"
+      (Chat_operation.failure_kind_to_string kind);
+    check string
+      "operator interrupt detail"
+      Keeper_registry_types.operator_interrupt_detail
+      detail
+  | _ -> fail "operator interrupt did not settle the operation as failed"
+;;
+
 let test_paused_owner_preserves_queue_until_resume () =
   Eio_main.run @@ fun _env ->
   Eio.Switch.run @@ fun sw ->
@@ -2564,6 +2614,10 @@ let () =
             "operation executor exception is terminal and next runs"
             `Quick
             test_operation_executor_exception_is_terminal_and_next_runs
+        ; test_case
+            "operator interrupt settles as typed cancel"
+            `Quick
+            test_operator_interrupt_settles_as_typed_cancel
         ; test_case
             "paused owner preserves queue until resume"
             `Quick


### PR DESCRIPTION
## 정정된 진단 (#28810)

이슈의 "1회 소비형 latch" 추정은 **틀렸다**. 두 죽음의 사인은 별개다:

- **op 27 (표적 턴)**: `Eio.Switch.fail turn_sw Operator_interrupt`의 예외는 switch 안 fiber에는 `Cancelled Operator_interrupt`로, **`Switch.run` 경계에서는 bare로** 재발화한다. 모든 분류 사다리가 wrapped 형태만 처리해서 bare가 generic internal-error arm으로 떨어졌고, `Turn_exception / "Internal error: Masc.Keeper_registry_types.Operator_interrupt"`로 오분류됐다.
- **op 28 (68초 뒤 신규 턴)**: latch가 아니라 **서버 재시작 유탄**. 프로덕션에서 `begin_stopping`을 부르는 유일한 곳은 서버 종료 경로(`begin_stopping_all`, server_bootstrap_loops.ml:1640)이고, 서버 로그가 03:04:21Z 신규 부팅을 보여준다(main_eio-restart-20260816.log:102039 — op 28 사망 03:04:10Z의 11초 뒤). 피어 세션의 교차 증거(현 서빙 PID 시작 03:11:31Z, 그 시간대 재기동 사이클)와 정합. op 29가 정상 수용된 것도 새 인스턴스라서다.

## 수정 (typed classification)

| 지점 | 변경 |
|---|---|
| `keeper_registry_types` | `operator_interrupt_detail` 상수 SSOT + 예외에 bare-vs-wrapped 계약 문서화 |
| `keeper_owner` executor wrapper | bare·wrapped 양형 → `Turn_cancelled` + operator detail |
| `keeper_agent_run` | bare arm이 기존 wrapped arm과 동일한 `set_failure_reason` 기록 |
| server stream executor fork | bare → queued `Turn_cancelled` (기존: `Turn_failed` = "crash") |
| stream·MCP tool dispatch catch-all | typed arm이 "Internal error: …" 대신 operator detail + `Transient_error` 반환 (failure-class 어휘에 취소 클래스가 없음 — 인라인 주석으로 명시, 어휘 확장은 별도) |

4개 사이트는 같은 수정의 복붙이 아니라 **서로 다른 경계층**(owner 종결 / turn 기록 / queued outcome / tool 응답)의 각자 소비자를 위한 분류이며, 예외 타입과 detail 상수는 각각 1곳(SSOT)이다.

## 검증

```
opam exec -- dune build --root . @check                    # 0
opam exec -- dune exec --root . test/test_keeper_owner.exe # 40 pass (신규: operator interrupt settles as typed cancel)
opam exec -- dune exec --root . test/test_keeper_wire_terminal.exe        # 8 pass
opam exec -- dune exec --root . test/test_keeper_chat_operation_http.exe  # 4 pass
```

신규 테스트는 executor가 bare `Operator_interrupt`를 던질 때 operation이 `Turn_cancelled` + `operator_interrupt_detail`로 durable 종결됨을 고정한다.

## 남는 것 (범위 밖, 이슈로 추적)

- tool_failure_class에 취소 클래스 부재 → 어휘 확장은 exhaustive match 전수 영향이라 별도.
- op 28 계열(종료 중 서버에 도착한 턴의 수용-후-절단)은 graceful shutdown의 수용 차단 타이밍 문제 — 별도 관찰 후 필요시 이슈.

adversarial review 통과 시 `review:adversarial-pass` 라벨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)