### PR TITLE
fix(imessage): 런타임 상태 경로를 MASC_BASE_PATH 에 고정 — 봇이 아무도 안 읽는 곳에 쓰고 있었다

### DIFF
--- a/sidecars/imessage-bot/src/config.py
+++ b/sidecars/imessage-bot/src/config.py
@@ -21,7 +21,6 @@ from pydantic_settings import (
     TomlConfigSettingsSource,
 )
 
-DEFAULT_STATE_DIR: Final[str] = ".gate/runtime/imessage"
 DEFAULT_BINDING_STORE_PATH: Final[str] = ".gate/runtime/imessage/bindings.json"
 DEFAULT_BINDING_AUDIT_PATH: Final[str] = ".gate/runtime/imessage/binding_audit.jsonl"
 DEFAULT_STATUS_PATH: Final[str] = ".gate/runtime/imessage/status.json"
@@ -29,10 +28,23 @@ DEFAULT_CURSOR_PATH: Final[str] = ".gate/runtime/imessage/cursor.json"
 CHAT_DB_PATH: Final[str] = os.path.expanduser("~/Library/Messages/chat.db")
 
 
+def resolve_state_path(raw: str) -> Path:
+    """Anchor a runtime path to MASC_BASE_PATH.
+
+    run.sh exports MASC_BASE_PATH and then chdir's into the sidecar directory,
+    so a relative path left unresolved lands under sidecars/imessage-bot/
+    instead of the base path every reader looks at.
+    """
+    p = Path(raw).expanduser()
+    if p.is_absolute():
+        return p
+    raw_base = os.getenv("MASC_BASE_PATH", "").strip()
+    root = Path(raw_base).expanduser() if raw_base else Path.cwd()
+    return root / p
+
+
 def _runtime_toml_path() -> Path:
-    raw = os.getenv("MASC_BASE_PATH", "").strip()
-    root = Path(raw).expanduser() if raw else Path.cwd()
-    return root / ".gate/runtime/imessage/config.toml"
+    return resolve_state_path(".gate/runtime/imessage/config.toml")
 
 
 def _is_loopback_host(raw_host: str | None) -> bool:
@@ -112,13 +124,17 @@ class BotConfig(BaseSettings):
     keeper_cache_ttl_sec: int = Field(default=30)
 
     # State paths
-    state_dir: str = Field(default=DEFAULT_STATE_DIR)
     binding_store_path: str = Field(default=DEFAULT_BINDING_STORE_PATH)
     binding_audit_path: str = Field(default=DEFAULT_BINDING_AUDIT_PATH)
     status_path: str = Field(default=DEFAULT_STATUS_PATH)
     cursor_path: str = Field(default=DEFAULT_CURSOR_PATH)
     # chat.db
     chat_db_path: str = Field(default=CHAT_DB_PATH)
+
+    @field_validator("binding_store_path", "binding_audit_path", "status_path", "cursor_path")
+    @classmethod
+    def anchor_state_path(cls, v: str) -> str:
+        return str(resolve_state_path(v))
 
     @field_validator("gate_base_url")
     @classmethod

--- a/sidecars/imessage-bot/src/diagnostics.py
+++ b/sidecars/imessage-bot/src/diagnostics.py
@@ -360,14 +360,6 @@ async def check_gate_reachable() -> Check:
 # --- filesystem --------------------------------------------------------------
 
 
-def _resolve_state_path(raw: str) -> Path:
-    p = Path(raw).expanduser()
-    if p.is_absolute():
-        return p
-    base = os.getenv("MASC_BASE_PATH", "").strip()
-    return Path(base).expanduser() / p if base else Path.cwd() / p
-
-
 async def check_binding_paths_writable() -> Check:
     cfg = _config_or_none()
     if cfg is None:
@@ -377,10 +369,10 @@ async def check_binding_paths_writable() -> Check:
             message="config 로드 실패로 건너뜀",
         )
     candidates = [
-        ("binding store", _resolve_state_path(cfg.binding_store_path)),
-        ("binding audit", _resolve_state_path(cfg.binding_audit_path)),
-        ("status", _resolve_state_path(cfg.status_path)),
-        ("cursor", _resolve_state_path(cfg.cursor_path)),
+        ("binding store", Path(cfg.binding_store_path)),
+        ("binding audit", Path(cfg.binding_audit_path)),
+        ("status", Path(cfg.status_path)),
+        ("cursor", Path(cfg.cursor_path)),
     ]
     unwritable: list[str] = []
     auto_fix_targets: list[Path] = []

--- a/sidecars/imessage-bot/tests/test_config_runtime_path.py
+++ b/sidecars/imessage-bot/tests/test_config_runtime_path.py
@@ -17,3 +17,35 @@ def test_runtime_toml_path_returns_path_object() -> None:
     result = config._runtime_toml_path()
     assert isinstance(result, Path)
     assert str(result).endswith("/.gate/runtime/imessage/config.toml")
+
+
+def test_state_paths_anchor_to_base_path(monkeypatch, tmp_path) -> None:
+    """The bot must write where the readers look.
+
+    run.sh exports MASC_BASE_PATH and then chdir's into the sidecar directory.
+    Left relative, status.json landed under sidecars/imessage-bot/ while the
+    server, the gate state and run.sh all read <base>/.gate/runtime/imessage/,
+    so the connector reported "connector status file not found" while running.
+    """
+    monkeypatch.setenv("MASC_BASE_PATH", str(tmp_path))
+    # Stand somewhere other than the base path, the way run.sh does.
+    cwd = tmp_path / "sidecars" / "imessage-bot"
+    cwd.mkdir(parents=True)
+    monkeypatch.chdir(cwd)
+
+    cfg = config.BotConfig()
+
+    runtime = tmp_path / ".gate" / "runtime" / "imessage"
+    assert Path(cfg.status_path) == runtime / "status.json"
+    assert Path(cfg.cursor_path) == runtime / "cursor.json"
+    assert Path(cfg.binding_store_path) == runtime / "bindings.json"
+    assert Path(cfg.binding_audit_path) == runtime / "binding_audit.jsonl"
+
+
+def test_absolute_state_paths_are_left_alone(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("MASC_BASE_PATH", str(tmp_path))
+    pinned = tmp_path / "pinned" / "status.json"
+
+    cfg = config.BotConfig(status_path=str(pinned))
+
+    assert Path(cfg.status_path) == pinned


### PR DESCRIPTION
## 증상 (라이브)

```
$ curl -s localhost:8935/api/v1/gate/connectors
{"connector_id":"imessage","status":"offline","available":false,
 "connected":false,"error":"connector status file not found", ...}
```

봇이 돌고 있어도 imessage 커넥터는 available 로 뜨지 않습니다. 30초 뒤 자동 복구 같은 것도 없습니다.

## 원인

`run.sh` 가 `MASC_BASE_PATH` 를 export 한 뒤(`:32`) sidecar 디렉터리로 `cd` 합니다(`:42`). `config.py` 는 TOML 경로는 그 base 에 고정하면서(`_runtime_toml_path`) 상태 경로 4개는 맨 상대경로로 내보냈습니다. 그래서 sidecar 디렉터리 기준으로 풀립니다.

```
봇이 쓰는 곳    sidecars/imessage-bot/.gate/runtime/imessage/status.json
서버가 읽는 곳            <base>/.gate/runtime/imessage/status.json
gate 가 읽는 곳           <base>/...
run.sh 가 읽는 곳         <base>/...
```

서버 쪽 근거 — `server_routes_http_sidecar_paths.ml:256` 의 roots 는 `[sidecar_root; base_path; project_root]` 뿐입니다. `sidecar_dir` 파라미터가 있지만 그 안의 `.env` 를 읽는 데만 쓰이고, 거기서 나온 값도 다시 `roots` 기준으로 풀립니다.

**같은 프로세스가 자기 상태를 두 디렉터리로 쪼개고 있었습니다.** bindings 는 `load_bindings` 가 `gate_shared.resolve_runtime_path` 를 부르니 제대로 갔고, status 와 cursor 만 안 갔습니다.

`diagnostics.py` 는 자기 리졸버를 따로 갖고 있어서 **봇이 쓰지 않는 파일의 쓰기 권한을 점검**하고 있었습니다.

## 수정

경계에서 한 번 해석합니다. 그러면 어떤 소비자도 안 풀린 경로를 들 수 없습니다.

```python
@field_validator("binding_store_path", "binding_audit_path", "status_path", "cursor_path")
@classmethod
def anchor_state_path(cls, v: str) -> str:
    return str(resolve_state_path(v))
```

곁들여 정리한 것:

- `diagnostics._resolve_state_path` 삭제 — imessage 안의 세 번째 리졸버 사본이었습니다.
- `_runtime_toml_path` 가 같은 함수를 쓰도록 — 특수 케이스 제거.
- `state_dir` 필드 삭제 — sidecar 안팎 어디에도 읽는 곳이 없습니다.

## 검증

```
$ pytest tests/ -q
23 passed in 0.12s
```

**테스트가 공허하지 않은지 확인** — 수정 전 트리(`git checkout origin/main -- src/config.py`)에서 돌리면:

```
FAILED tests/test_config_runtime_path.py::test_state_paths_anchor_to_base_path
E  assert PosixPath('.gate/runtime/imessage/status.json') == .../test_state_paths_anchor_to_bas0/.gate/runtime/imessage/status.json
1 failed, 2 passed
```

정확히 그 결함을 잡습니다.

## 미검증

- **CI 는 sidecar 테스트를 돌리지 않습니다.** `ci.yml` 에 `sidecars` 언급이 0건이라, 위 결과는 로컬 venv(`pydantic-settings`, `httpx`, `pytest`) 실행뿐입니다. 이 결함이 살아남은 이유이기도 합니다 — 별도로 다룰 문제로 봅니다.
- 실제 봇을 띄워 `available:true` 로 바뀌는 것까지는 확인하지 못했습니다. macOS Full Disk Access 가 필요합니다.

## 손대지 않은 것

`sidecars/imessage-bot/src/status_store.py` 의 `StatusStore` 는 `gate_shared` 판본과 **`resolve_runtime_path` 한 줄만 다른** 복사본입니다. 이번 수정으로 유일한 생성 지점(`bot.py:59`)이 절대경로를 받으니 결함은 닫히지만, 사본 자체는 남습니다. 두 `ConnectorRuntimeStatus` dataclass 를 합치는 건 slack/telegram 의 status.json 모양까지 바꾸는 일이라 별도 판단이 필요해 보여서 이 PR 에는 넣지 않았습니다.
