### PR TITLE
fix(gate): 효과 하나에 approval 하나 — turn을 요청 identity에서 제거, 미소비 grant에 재시도 접기 (#28866)

### DIFF
--- a/docs/evidence/web-artifact-corpus-acceptance-2026-08-16.md
+++ b/docs/evidence/web-artifact-corpus-acceptance-2026-08-16.md
@@ -83,7 +83,7 @@ auto-judge가 web_search 유예를 3회 reject (05:45:26 / 05:56:10 / ≈06:13).
 
 ## 5. acceptance 1 신 레인 — 유기적 라이브 PASS (07:30Z, 프로덕션)
 
-§4에서 예고한 (c) 유기 트래픽 관측이 닫혔다. 프로덕션(:8935, base=`~/me/.masc`, 신 바이너리 05:55:53Z 기동)에서 keeper 유기 트래픽의 web-fetch 오프로드 2건:
+§4에서 예고한 (c) 유기 트래픽 관측이 닫혔다. 프로덕션(:8935, base path `~/me` 아래 `.masc`, 신 바이너리 05:55:53Z 기동)에서 keeper 유기 트래픽의 web-fetch 오프로드 2건:
 
 | fetched_at(Z) | sha256(전위) | bytes | source |
 |---|---|---|---|

--- a/docs/evidence/web-artifact-corpus-acceptance-2026-08-16.md
+++ b/docs/evidence/web-artifact-corpus-acceptance-2026-08-16.md
@@ -83,7 +83,7 @@ auto-judge가 web_search 유예를 3회 reject (05:45:26 / 05:56:10 / ≈06:13).
 
 ## 5. acceptance 1 신 레인 — 유기적 라이브 PASS (07:30Z, 프로덕션)
 
-§4에서 예고한 (c) 유기 트래픽 관측이 닫혔다. 프로덕션(:8935, base path `~/me` 아래 `.masc`, 신 바이너리 05:55:53Z 기동)에서 keeper 유기 트래픽의 web-fetch 오프로드 2건:
+§4에서 예고한 (c) 유기 트래픽 관측이 닫혔다. 프로덕션(:8935, base=`~/me/.masc`, 신 바이너리 05:55:53Z 기동)에서 keeper 유기 트래픽의 web-fetch 오프로드 2건:
 
 | fetched_at(Z) | sha256(전위) | bytes | source |
 |---|---|---|---|

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -100,6 +100,7 @@ type grant_consumption =
 type pending_submission_disposition =
   | Pending_created of Keeper_approval.Audit.receipt
   | Pending_deduplicated
+  | Folded_onto_unconsumed_grant
 
 type pending_submission =
   { approval_id : string
@@ -2901,13 +2902,19 @@ let resolve_entry
   audit_receipt
 ;;
 
+(* The effect request's identity. [turn_id] is deliberately absent: it names
+   the turn that asked, not the effect being asked for. Keeping it in this
+   comparison made every next-turn retry of the same call a fresh approval —
+   measured 2026-08-16: one identical web_search deferred in turns
+   28959/28960/28961 produced three approvals, three auto-judge approvals,
+   and three replays of the same 17,712-byte output into the same context
+   (#28866). The turn that asked is still recorded on the entry for audit. *)
 let pending_entry_matches
       (entry : pending_approval)
       ~base_path
       ~keeper_name
       ~tool_name
       ~input_hash
-      ~turn_id
       ~task_id
       ~goal_id
       ~goal_ids
@@ -2917,7 +2924,6 @@ let pending_entry_matches
   && String.equal entry.keeper_name keeper_name
   && String.equal entry.tool_name tool_name
   && String.equal entry.input_hash input_hash
-  && entry.turn_id = turn_id
   && entry.task_id = task_id
   && entry.goal_id = goal_id
   && entry.goal_ids = goal_ids
@@ -2932,7 +2938,6 @@ let find_pending_id_in_map
       ~keeper_name
       ~tool_name
       ~input_hash
-      ~turn_id
       ~task_id
       ~goal_id
       ~goal_ids
@@ -2950,13 +2955,56 @@ let find_pending_id_in_map
              ~keeper_name
              ~tool_name
              ~input_hash
-             ~turn_id
              ~task_id
              ~goal_id
              ~goal_ids
              ~continuation_channel
          then Some id
          else None)
+    map
+    None
+;;
+
+(* An approved resolution whose one-shot grant is still unconsumed is the
+   same effect request one step further along: the host owes the Keeper a
+   replay of exactly this call. A resubmission folds onto it instead of
+   opening a second approval — "an approval owns its effect" (RFC-0356)
+   implies its dual, an effect has one approval. Rejected and
+   grant-consumed deliveries never match: a retry after rejection is a new
+   approval cycle, and a retry after the effect ran is a new effect. *)
+let find_unconsumed_grant_id_in_deliveries
+      (map : persisted_delivery SMap.t)
+      ~base_path
+      ~keeper_name
+      ~tool_name
+      ~input_hash
+      ~task_id
+      ~goal_id
+      ~goal_ids
+      ~continuation_channel
+  =
+  SMap.fold
+    (fun id (delivery : persisted_delivery) acc ->
+       match acc with
+       | Some _ -> acc
+       | None ->
+         (match delivery.decision with
+          | Decision.Reject _ -> None
+          | Decision.Approve ->
+            if
+              (not delivery.grant_consumed)
+              && pending_entry_matches
+                   delivery.entry
+                   ~base_path
+                   ~keeper_name
+                   ~tool_name
+                   ~input_hash
+                   ~task_id
+                   ~goal_id
+                   ~goal_ids
+                   ~continuation_channel
+            then Some id
+            else None))
     map
     None
 ;;
@@ -3000,7 +3048,6 @@ let submit_pending
              ~keeper_name
              ~tool_name
              ~input_hash
-             ~turn_id
              ~task_id
              ~goal_id
              ~goal_ids
@@ -3008,6 +3055,20 @@ let submit_pending
          with
          | Some id -> Ok (`Deduplicated id)
          | None ->
+           (match
+              find_unconsumed_grant_id_in_deliveries
+                (Atomic.get deliveries)
+                ~base_path
+                ~keeper_name
+                ~tool_name
+                ~input_hash
+                ~task_id
+                ~goal_id
+                ~goal_ids
+                ~continuation_channel
+            with
+            | Some id -> Ok (`Folded_onto_unconsumed_grant id)
+            | None ->
            let id = generate_id () in
            if sequence = max_int
            then
@@ -3047,12 +3108,14 @@ let submit_pending
              Atomic.set
                next_sequences
                (SMap.add base_path following_sequence (Atomic.get next_sequences));
-             Ok (`Created entry))))
+             Ok (`Created entry)))))
   in
   match stored with
   | Error _ as error -> error
   | Ok (`Deduplicated approval_id) ->
     Ok { approval_id; disposition = Pending_deduplicated }
+  | Ok (`Folded_onto_unconsumed_grant approval_id) ->
+    Ok { approval_id; disposition = Folded_onto_unconsumed_grant }
   | Ok (`Created entry) ->
     let audit_receipt = record_pending entry in
     Ok

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -120,6 +120,12 @@ type grant_consumption =
 type pending_submission_disposition =
   | Pending_created of Keeper_approval.Audit.receipt
   | Pending_deduplicated
+  | Folded_onto_unconsumed_grant
+      (** The same effect request is already approved and its one-shot grant
+          has not been consumed: the host owes the Keeper a replay of exactly
+          this call, so no second approval is opened. Rejected and
+          grant-consumed deliveries never fold — those retries are a new
+          approval cycle and a new effect respectively. *)
 
 type pending_submission =
   { approval_id : string
@@ -283,10 +289,14 @@ end
 (** {1 Nonblocking submission and explicit resolution} *)
 
 (** Durably enqueue an exact request without suspending the caller. Returns an
-    existing id only when the same Keeper, operation identity, canonical input,
-    turn/task/goal identity, and continuation channel are already pending. A
-    deduplicated request does not consume a durable queue sequence or emit a new
-    pending audit event. *)
+    existing id when the same Keeper, operation identity, canonical input,
+    task/goal identity, and continuation channel are already pending, or are
+    already approved with their one-shot grant unconsumed
+    ({!Folded_onto_unconsumed_grant}). The turn that asked is recorded on the
+    entry but is not part of the request's identity: a next-turn retry of the
+    same call folds onto the approval already in flight instead of opening a
+    second one (#28866). A deduplicated or folded request does not consume a
+    durable queue sequence or emit a new pending audit event. *)
 val submit_pending :
   keeper_name:string ->
   tool_name:string ->

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -1470,7 +1470,8 @@ let defer request reason =
     let audit_receipts =
       match submission.disposition with
       | Keeper_approval_queue.Pending_created receipt -> [ receipt ]
-      | Keeper_approval_queue.Pending_deduplicated -> []
+      | Keeper_approval_queue.Pending_deduplicated
+      | Keeper_approval_queue.Folded_onto_unconsumed_grant -> []
     in
     let reason =
       match reason with

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -270,7 +270,12 @@ let test_dedup_never_merges_distinct_origins () =
            ()
        in
        Alcotest.(check string) "same origin deduplicates" first same;
-       let another_turn =
+       (* The turn that asked is provenance, not origin: a next-turn retry
+          of the same call folds onto the approval already pending (#28866).
+          Before this change turn 2 here minted a second approval, and on
+          2026-08-16 that shape produced three approvals and three replays
+          of one identical web_search into the same context. *)
+       let retried_next_turn =
          submit_with_context
            ~turn_id:2
            ~goal_ids:[ "goal-a" ]
@@ -280,6 +285,10 @@ let test_dedup_never_merges_distinct_origins () =
            ~input
            ()
        in
+       Alcotest.(check string)
+         "next-turn retry folds onto the pending approval"
+         first
+         retried_next_turn;
        let another_channel =
          submit_with_context
            ~turn_id:1
@@ -304,9 +313,108 @@ let test_dedup_never_merges_distinct_origins () =
          (fun id ->
             Alcotest.(check bool) "distinct origin has its own request" true
               (not (String.equal first id)))
-         [ another_turn; another_channel; another_goal_context ];
+         [ another_channel; another_goal_context ];
        List.iter (reject_and_cleanup ~base_path)
-         [ first; another_turn; another_channel; another_goal_context ])
+         [ first; another_channel; another_goal_context ])
+;;
+
+(* The measured 2026-08-16 incident, end to end: the retry lands after the
+   approval resolved but before its grant was consumed. The resubmission must
+   fold onto that unconsumed grant; once the grant is consumed the same call
+   is a new effect and opens a fresh approval; a rejected approval never
+   absorbs a retry. *)
+let test_retry_folds_onto_unconsumed_grant_until_consumed () =
+  let base_path = temp_dir () in
+  let keeper_name = "queue-grant-fold" in
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_runtime_state ();
+      cleanup_dir base_path)
+    (fun () ->
+       ignore (install_exn ~base_path);
+       let input = `Assoc [ "target", `String "same-network-read" ] in
+       let first =
+         submit_submission_with_context
+           ~turn_id:11
+           ~base_path
+           ~keeper_name
+           ~input
+           ()
+       in
+       (match
+          AQ.resolve_with_policy
+            ~base_path
+            ~id:first.approval_id
+            ~decision:Rule_types.Decision.Approve
+            ()
+        with
+        | Ok _ -> ()
+        | Error error -> Alcotest.fail (AQ.resolve_error_to_string error));
+       let retried =
+         submit_submission_with_context
+           ~turn_id:12
+           ~base_path
+           ~keeper_name
+           ~input
+           ()
+       in
+       Alcotest.(check string)
+         "retry after approval reuses the approved id"
+         first.approval_id
+         retried.approval_id;
+       (match retried.disposition with
+        | AQ.Folded_onto_unconsumed_grant -> ()
+        | AQ.Pending_created _ ->
+          Alcotest.fail "retry opened a second approval over an unconsumed grant"
+        | AQ.Pending_deduplicated ->
+          Alcotest.fail "resolved approval was still reported as pending");
+       (match
+          AQ.consume_approved_resolution
+            ~base_path
+            ~id:first.approval_id
+            ~keeper_name
+            ~tool_name:"external-effect"
+            ~input
+        with
+        | Ok (AQ.Consumption_committed _) -> ()
+        | Ok (AQ.Consumption_already_committed | AQ.Consumption_not_matching) ->
+          Alcotest.fail "grant consumption did not commit"
+        | Error error -> Alcotest.fail (AQ.grant_error_to_string error));
+       let after_consumption =
+         submit_submission_with_context
+           ~turn_id:13
+           ~base_path
+           ~keeper_name
+           ~input
+           ()
+       in
+       Alcotest.(check bool)
+         "the same call after consumption is a new effect"
+         true
+         (not (String.equal first.approval_id after_consumption.approval_id));
+       (match after_consumption.disposition with
+        | AQ.Pending_created _ -> ()
+        | AQ.Pending_deduplicated | AQ.Folded_onto_unconsumed_grant ->
+          Alcotest.fail "consumed grant absorbed a new effect request");
+       reject_and_cleanup ~base_path after_consumption.approval_id;
+       let after_rejection =
+         submit_submission_with_context
+           ~turn_id:14
+           ~base_path
+           ~keeper_name
+           ~input
+           ()
+       in
+       Alcotest.(check bool)
+         "a rejected approval never absorbs a retry"
+         true
+         (not
+            (String.equal after_consumption.approval_id after_rejection.approval_id));
+       (match after_rejection.disposition with
+        | AQ.Pending_created _ -> ()
+        | AQ.Pending_deduplicated | AQ.Folded_onto_unconsumed_grant ->
+          Alcotest.fail "rejected delivery absorbed a retry");
+       reject_and_cleanup ~base_path after_rejection.approval_id)
 ;;
 
 let check_update label expected = function
@@ -650,7 +758,7 @@ let test_submit_is_nonblocking_and_exactly_deduplicated () =
         | AQ.Pending_created { write_result = Ok (); _ } -> ()
         | AQ.Pending_created { write_result = Error _; _ } ->
           Alcotest.fail "new pending request did not persist its audit"
-        | AQ.Pending_deduplicated ->
+        | AQ.Pending_deduplicated | AQ.Folded_onto_unconsumed_grant ->
           Alcotest.fail "new pending request was reported as deduplicated");
        let reordered =
          `Assoc
@@ -671,6 +779,8 @@ let test_submit_is_nonblocking_and_exactly_deduplicated () =
        Alcotest.(check string) "same exact request" first same;
        (match same_submission.disposition with
         | AQ.Pending_deduplicated -> ()
+        | AQ.Folded_onto_unconsumed_grant ->
+          Alcotest.fail "pending duplicate matched a delivery, not the pending entry"
         | AQ.Pending_created _ ->
           Alcotest.fail "exact duplicate reported a second pending commit");
        Alcotest.(check int)
@@ -4230,6 +4340,10 @@ let () =
             "dedup keeps distinct origins"
             `Quick
             test_dedup_never_merges_distinct_origins
+        ; Alcotest.test_case
+            "retry folds onto unconsumed grant until consumed"
+            `Quick
+            test_retry_folds_onto_unconsumed_grant_until_consumed
         ; Alcotest.test_case
             "resolution wakes only origin"
             `Quick


### PR DESCRIPTION
## 문제 (#28866 실측)

같은 web_search 호출이 턴 28959/28960/28961에서 각각 유예되어 **approval 3건 → auto-judge 승인 3건 → 같은 17,712B 출력이 같은 컨텍스트에 3회 주입**됐습니다. 07:30에는 사람 운영자가 같은 요청을 두 번 승인하는 형태로 재현(22,199B×2). 원인은 dedup 키의 `turn_id` — 턴을 넘긴 재시도는 구조적으로 절대 dedup되지 않았습니다.

## 수정

1. **`pending_entry_matches`에서 turn_id 제거** — turn은 "누가 물었나"(provenance)이지 효과의 identity가 아닙니다. `consume_approved_resolution`의 mli가 이미 같은 선언("Turn, Task, Goal, and channel fields remain provenance")을 하고 있어, 제출/소비의 비대칭을 정렬합니다. channel/task/goal은 identity에 유지(judge 심사 맥락 분리).
2. **미소비 grant에 접기** — pending 매치 실패 시, `decision=Approve && grant_consumed=false`인 delivery의 동일 identity에 매치되면 새 approval을 만들지 않고 기존 id를 `Folded_onto_unconsumed_grant`로 반환. "an approval owns its effect"(RFC-0356)의 쌍대인 **"an effect has one approval"**. rejected(새 승인 사이클)와 grant 소비 완료(새 효과)는 접지 않습니다.

## 계약 변경 명시

`test_dedup_never_merges_distinct_origins`가 "다른 turn → 별도 approval"을 핀하고 있었습니다(#24332). 이번 실측이 그 전제의 유해성을 보였으므로 **의도적으로 뒤집었습니다** — turn 재시도는 fold, channel/goal은 여전히 distinct origin. 새 테스트 `retry folds onto unconsumed grant until consumed`가 사고 시나리오를 끝까지 밟습니다(승인 후 fold → 소비 후 새 approval → 거부는 흡수 안 함).

## 검증

- `ocamlc -stop-after parsing` 3파일 통과 (괄호 균형).
- 컴파일·스위트는 CI로 검증합니다 (`runtest-test_keeper_approval_queue` 기존 배선).
- disposition 소비처 전수: `keeper_gate.ml` 1곳 + 자기 테스트 — 나머지 7개 테스트 파일의 "disposition"은 무관 타입 확인.

후속(별도 PR): (b) 승인 배달이 keepalive 틱당 1건인 처리량 문제, (a) deferred payload에 자동 배달 계약 사실 노출.

🤖 Generated with [Claude Code](https://claude.com/claude-code)