### PR TITLE
feat(canary): --inject-failover with manifest-based attribution (M2 PR-C)

### DIFF
--- a/bin/keeper_canary_run.ml
+++ b/bin/keeper_canary_run.ml
@@ -29,7 +29,9 @@
        --keeper NAME --run-id ID [--runtime LABEL] [--base PATH] \
        [--host HOST] [--port N] [--facts N] [--turn-interval SECONDS] \
        [--turn-timeout SECONDS] [--wall-clock-target SECONDS] \
-       [--inject-restart-after N] [--judge-runtime ID] [--out PATH] *)
+       [--inject-restart-after N] [--inject-failover-after N \
+       --failover-down-cmd CMD [--failover-up-cmd CMD]] \
+       [--judge-runtime ID] [--out PATH] *)
 
 let default_facts = 9
 let default_turn_interval_s = 0.0
@@ -39,6 +41,7 @@ let usage =
    [--base PATH] [--host HOST] [--port N] [--facts N] \
    [--turn-interval SECONDS] [--turn-timeout SECONDS] \
    [--wall-clock-target SECONDS] [--inject-restart-after N] \
+   [--inject-failover-after N --failover-down-cmd CMD [--failover-up-cmd CMD]] \
    [--judge-runtime ID] [--out PATH]"
 
 type args = {
@@ -53,6 +56,9 @@ type args = {
   turn_timeout_s : float option;
   wall_clock_target_s : float option;
   inject_restart_after : int option;
+  inject_failover_after : int option;
+  failover_down_cmd : string option;
+  failover_up_cmd : string option;
   judge_runtime : string option;
   out : string option;
 }
@@ -69,6 +75,9 @@ let parse_args argv =
   let turn_timeout_s = ref None in
   let wall_clock_target_s = ref None in
   let inject_restart_after = ref None in
+  let inject_failover_after = ref None in
+  let failover_down_cmd = ref None in
+  let failover_up_cmd = ref None in
   let judge_runtime = ref None in
   let out = ref None in
   let rec parse = function
@@ -128,6 +137,20 @@ let parse_args argv =
        | Some n -> Error (Printf.sprintf "--inject-restart-after must be >= 1, got %d" n)
        | None -> Error ("--inject-restart-after must be an integer, got " ^ v))
     | [ "--inject-restart-after" ] -> Error "missing value for --inject-restart-after"
+    | "--inject-failover-after" :: v :: rest ->
+      (match int_of_string_opt v with
+       | Some n when n >= 1 -> inject_failover_after := Some n; parse rest
+       | Some n -> Error (Printf.sprintf "--inject-failover-after must be >= 1, got %d" n)
+       | None -> Error ("--inject-failover-after must be an integer, got " ^ v))
+    | [ "--inject-failover-after" ] -> Error "missing value for --inject-failover-after"
+    | "--failover-down-cmd" :: v :: rest ->
+      failover_down_cmd := Some v;
+      parse rest
+    | [ "--failover-down-cmd" ] -> Error "missing value for --failover-down-cmd"
+    | "--failover-up-cmd" :: v :: rest ->
+      failover_up_cmd := Some v;
+      parse rest
+    | [ "--failover-up-cmd" ] -> Error "missing value for --failover-up-cmd"
     | "--judge-runtime" :: v :: rest ->
       judge_runtime := Some v;
       parse rest
@@ -150,6 +173,15 @@ let parse_args argv =
          Error
            "--wall-clock-target and --turn-interval are mutually exclusive: \
             the target derives the interval"
+       else if !inject_restart_after <> None && !inject_failover_after <> None
+       then
+         Error
+           "--inject-restart-after and --inject-failover-after are mutually \
+            exclusive: one injection per run keeps the evidence attributable"
+       else if !inject_failover_after <> None && !failover_down_cmd = None
+       then Error "--inject-failover-after requires --failover-down-cmd"
+       else if !failover_down_cmd <> None && !inject_failover_after = None
+       then Error "--failover-down-cmd requires --inject-failover-after"
        else
        Ok
          { keeper
@@ -163,6 +195,9 @@ let parse_args argv =
          ; turn_timeout_s = !turn_timeout_s
          ; wall_clock_target_s = !wall_clock_target_s
          ; inject_restart_after = !inject_restart_after
+         ; inject_failover_after = !inject_failover_after
+         ; failover_down_cmd = !failover_down_cmd
+         ; failover_up_cmd = !failover_up_cmd
          ; judge_runtime = !judge_runtime
          ; out = !out
          })
@@ -321,7 +356,14 @@ let lifecycle_post ~host ~port ~keeper_name ~action ~body () :
    the resume directive 409 while it is still in flight (observed live
    2026-08-16: directive answered "Resume_owner requires a paused registry
    lane, actual phase=running" two HTTP round-trips after a 200 shutdown).
-   Poll the gate projection until the keeper leaves active before booting. *)
+
+   This poll is only a cheap pre-check, not a drain-completion guarantee:
+   the gate projection's surface status leaves "active" the moment the
+   registry phase leaves Running (Draining already reads as non-active —
+   adversarial review, 2026-08-16), and the gate row exposes no registry
+   phase to poll on. The 409 -> resume -> boot fallback below is the
+   actual correctness mechanism when the drain is still in flight; a
+   keeper with in-flight work will simply take that path every time. *)
 let wait_until_stopped ~host ~port ~keeper_name :
   (unit, string) result
   =
@@ -439,9 +481,8 @@ let inject_restart ~host ~port ~keeper_name ~run_id ~after_turn :
   let* trace_id_after, generation_after =
     trajectory_identity ~host ~port ~keeper_name
   in
-  let injection =
-    { Keeper_canary_evidence.injection_kind = Keeper_canary_evidence.Restart
-    ; after_turn
+  let restart =
+    { Keeper_canary_evidence.after_turn
     ; started_at
     ; duration_s = Unix.gettimeofday () -. started
     ; trace_id_before
@@ -452,11 +493,110 @@ let inject_restart ~host ~port ~keeper_name ~run_id ~after_turn :
   in
   Printf.eprintf
     "[keeper_canary_run] restart done in %.1fs continuation=%b (trace=%s gen=%d)\n%!"
-    injection.duration_s
-    (Keeper_canary_evidence.injection_is_continuation injection)
+    restart.duration_s
+    (Keeper_canary_evidence.restart_is_continuation restart)
     trace_id_after
     generation_after;
-  Ok injection
+  Ok (Keeper_canary_evidence.Restart restart)
+
+(* --inject-failover-after: the harness owns no knowledge of how to
+   break a runtime, so the operator supplies the two commands (take the
+   lane's head candidate down, bring it back). The verdict never comes
+   from the commands' exit codes — it is read back from the keeper's own
+   runtime-manifest rows, the durable per-candidate attribution the turn
+   driver writes (see Keeper_canary_failover). *)
+let run_shell_command cmd : (unit, string) result =
+  match
+    With_process.with_process_args_in
+      "/bin/sh"
+      [| "/bin/sh"; "-c"; cmd |]
+      With_process.drain_lines
+  with
+  | _, Unix.WEXITED 0 -> Ok ()
+  | _, Unix.WEXITED code -> Error (Printf.sprintf "%S exited %d" cmd code)
+  | _, Unix.WSIGNALED signal -> Error (Printf.sprintf "%S killed by signal %d" cmd signal)
+  | _, Unix.WSTOPPED signal -> Error (Printf.sprintf "%S stopped by signal %d" cmd signal)
+  | exception e -> Error (Printf.sprintf "%S failed to spawn: %s" cmd (Printexc.to_string e))
+
+type pending_failover = {
+  pf_after_turn : int;
+  pf_started_at : string;
+  pf_duration_s : float;
+  pf_window_start : string;
+  pf_down_cmd : string;
+}
+
+let start_failover ~down_cmd ~after_turn : (pending_failover, string) result =
+  let ( let* ) = Result.bind in
+  let window_start = iso8601_now () in
+  let started = Unix.gettimeofday () in
+  Printf.eprintf
+    "[keeper_canary_run] inject failover after turn %d: %s\n%!"
+    after_turn
+    down_cmd;
+  let* () = run_shell_command down_cmd in
+  Ok
+    { pf_after_turn = after_turn
+    ; pf_started_at = window_start
+    ; pf_duration_s = Unix.gettimeofday () -. started
+    ; pf_window_start = window_start
+    ; pf_down_cmd = down_cmd
+    }
+
+let finish_failover ~host ~port ~keeper_name ~up_cmd (pending : pending_failover) :
+  (Keeper_canary_evidence.injection, string) result * string list
+  =
+  let up_notes =
+    match up_cmd with
+    | None -> [ "failover: no --failover-up-cmd given; the head candidate stays down" ]
+    | Some cmd ->
+      (match run_shell_command cmd with
+       | Ok () -> []
+       | Error detail ->
+         (* The run itself already measured what it needed; a failed
+            restore is the operator's cleanup problem, surfaced loudly
+            in the evidence rather than aborting the receipt. *)
+         [ Printf.sprintf "failover: up command failed: %s" detail ])
+  in
+  let result =
+    let ( let* ) = Result.bind in
+    let path =
+      Printf.sprintf "/api/v1/keepers/%s/runtime-trace?limit=500" keeper_name
+    in
+    let* status, body = Keeper_canary_http.admin_get ~host ~port ~path () in
+    let* () =
+      if status >= 200 && status < 300
+      then Ok ()
+      else Error (Printf.sprintf "runtime-trace returned HTTP %d" status)
+    in
+    let* json =
+      match Yojson.Safe.from_string body with
+      | j -> Ok j
+      | exception Yojson.Json_error msg -> Error ("runtime-trace: invalid JSON: " ^ msg)
+    in
+    let* attempts = Keeper_canary_failover.parse_manifest_rows json in
+    let mode, windowed =
+      Keeper_canary_failover.classify
+        ~window_start:pending.pf_window_start
+        ~attempts
+    in
+    Printf.eprintf
+      "[keeper_canary_run] failover verdict mode=%s attempts=%d\n%!"
+      (Keeper_canary_failover.mode_to_string mode)
+      (List.length windowed);
+    Ok
+      (Keeper_canary_evidence.Failover
+         { after_turn = pending.pf_after_turn
+         ; started_at = pending.pf_started_at
+         ; duration_s = pending.pf_duration_s
+         ; down_cmd = pending.pf_down_cmd
+         ; up_cmd
+         ; window_start = pending.pf_window_start
+         ; mode
+         ; attempts = windowed
+         })
+  in
+  result, up_notes
 
 (* A restart mid-run only measures continuity if the keeper cannot slip
    unattended turns into the transcript while the harness is not looking:
@@ -601,38 +741,63 @@ let run ?(judge : judge_fn option) ~(base_path : string) (args : args) :
        turn) is Keeper_canary_facts.plan's job, not inline bookkeeping here
        — see that module for the (unit-tested) construction. *)
     let plan = Keeper_canary_facts.plan ~facts in
-    let* () =
-      match args.inject_restart_after with
+    let bounds_check ~flag = function
       | None -> Ok ()
       | Some n ->
         if n >= List.length plan
         then
           Error
             (Printf.sprintf
-               "--inject-restart-after %d is at or past the recall turn (plan \
-                has %d turns); the restart must land between turns"
+               "%s %d is at or past the recall turn (plan has %d turns); the \
+                injection must land between turns"
+               flag
                n
                (List.length plan))
-        else require_proactive_disabled ~host ~port ~keeper_name:args.keeper
+        else Ok ()
+    in
+    let* () = bounds_check ~flag:"--inject-restart-after" args.inject_restart_after in
+    let* () = bounds_check ~flag:"--inject-failover-after" args.inject_failover_after in
+    let* () =
+      match args.inject_restart_after with
+      | None -> Ok ()
+      | Some _ -> require_proactive_disabled ~host ~port ~keeper_name:args.keeper
     in
     let injections = ref [] in
+    let pending_failover = ref None in
     let inject_between ~completed_index =
-      match args.inject_restart_after with
-      | Some n when n = completed_index ->
-        (match
-           inject_restart
-             ~host
-             ~port
-             ~keeper_name:args.keeper
-             ~run_id:args.run_id
-             ~after_turn:n
-         with
-         | Ok injection ->
-           injections := injection :: !injections;
-           Ok ()
-         | Error detail ->
-           Error (Printf.sprintf "restart injection after turn %d failed: %s" n detail))
-      | Some _ | None -> Ok ()
+      let restart () =
+        match args.inject_restart_after with
+        | Some n when n = completed_index ->
+          (match
+             inject_restart
+               ~host
+               ~port
+               ~keeper_name:args.keeper
+               ~run_id:args.run_id
+               ~after_turn:n
+           with
+           | Ok injection ->
+             injections := injection :: !injections;
+             Ok ()
+           | Error detail ->
+             Error (Printf.sprintf "restart injection after turn %d failed: %s" n detail))
+        | Some _ | None -> Ok ()
+      in
+      let failover () =
+        match args.inject_failover_after, args.failover_down_cmd with
+        | Some n, Some down_cmd when n = completed_index ->
+          (match start_failover ~down_cmd ~after_turn:n with
+           | Ok pending ->
+             pending_failover := Some pending;
+             Ok ()
+           | Error detail ->
+             Error
+               (Printf.sprintf "failover injection after turn %d failed: %s" n detail))
+        | _ -> Ok ()
+      in
+      let ( let* ) = Result.bind in
+      let* () = restart () in
+      failover ()
     in
     let rec send_all acc = function
       | [] -> Ok (List.rev acc)
@@ -681,6 +846,28 @@ let run ?(judge : judge_fn option) ~(base_path : string) (args : args) :
     (* A requested judge that fails does not erase the run's receipt: the
        evidence still lands with [judgment = None] plus an explicit note,
        and main exits non-zero so automation sees the judging failed. *)
+    let failover_notes =
+      match !pending_failover with
+      | None -> []
+      | Some pending ->
+        let result, up_notes =
+          finish_failover
+            ~host
+            ~port
+            ~keeper_name:args.keeper
+            ~up_cmd:args.failover_up_cmd
+            pending
+        in
+        (match result with
+         | Ok injection ->
+           injections := injection :: !injections;
+           up_notes
+         | Error detail ->
+           (* The attribution read failing does not erase the run: the note
+              records it and the missing Failover entry in [injections] is
+              the loud signal. *)
+           (Printf.sprintf "failover: attribution read failed: %s" detail) :: up_notes)
+    in
     let judgment, judge_notes =
       match judge with
       | None -> (None, [])
@@ -711,7 +898,7 @@ let run ?(judge : judge_fn option) ~(base_path : string) (args : args) :
       ; deterministic_signal
       ; judgment
       ; injections = List.rev !injections
-      ; notes = capped_note @ correlation_notes @ judge_notes
+      ; notes = capped_note @ correlation_notes @ failover_notes @ judge_notes
       })
 
 (* Sized for the judge's small JSON verdict (at most nine per_fact rows and

--- a/docs/evidence/keeper-canary-failover-sigkill-2026-08-16.json
+++ b/docs/evidence/keeper-canary-failover-sigkill-2026-08-16.json
@@ -1,0 +1,135 @@
+{
+  "schema": "masc.keeper_canary_run.v1",
+  "captured_at": "2026-08-16T07:50:50Z",
+  "harness": { "git_commit": "a8622c23d56bbb59a1679d1bc6f429188a49588d" },
+  "run_id": "canary-failover-smoke-20260816-t2",
+  "keeper": {
+    "name": "canary-multiturn-localollama-20260814-0839",
+    "runtime": null,
+    "base_path": "/Users/dancer/me"
+  },
+  "transport": {
+    "endpoint": "http://127.0.0.1:8935/api/v1/keepers/chat/stream",
+    "turn_interval_s": 0.0,
+    "wall_clock_target_s": null
+  },
+  "facts_established": [
+    {
+      "category": "project_codename",
+      "statement": "The project codename is Codename-b6b2d5060f4e.",
+      "value": "Codename-b6b2d5060f4e"
+    },
+    {
+      "category": "lead_reviewer",
+      "statement": "The lead reviewer is Reviewer-12fd71764a3b.",
+      "value": "Reviewer-12fd71764a3b"
+    }
+  ],
+  "turns": [
+    {
+      "index": 1,
+      "category": "project_codename",
+      "delivery_key": {
+        "kind": "operation",
+        "operation_id": "canary-7294411b27599fc5"
+      },
+      "turn_ref": "trace-1786696748903-0000b#45",
+      "sent_at": "2026-08-16T07:50:31Z",
+      "round_trip_s": 5.762689113616943,
+      "reply_digest": "5688565b38df605f481bdcdd0698b16b0e8937142a12bb52eb56c9099b476e43"
+    },
+    {
+      "index": 2,
+      "category": "lead_reviewer",
+      "delivery_key": {
+        "kind": "operation",
+        "operation_id": "canary-bdb01b6f6ae36aad"
+      },
+      "turn_ref": "trace-1786696748903-0000b#46",
+      "sent_at": "2026-08-16T07:50:37Z",
+      "round_trip_s": 3.3456671237945557,
+      "reply_digest": "5743a077b6da333367d52f2bfb443bfdb5c39f4ffe56348f98553894046c7f2e"
+    },
+    {
+      "index": 3,
+      "category": null,
+      "delivery_key": {
+        "kind": "operation",
+        "operation_id": "canary-67cc273281889fc5"
+      },
+      "turn_ref": "trace-1786696748903-0000b#47",
+      "sent_at": "2026-08-16T07:50:40Z",
+      "round_trip_s": 9.349783897399902,
+      "reply_digest": "820445fc15e9a6b52590e339c27490dffdd4eab2a9aeeb865db1d0c8df7d0557"
+    }
+  ],
+  "recall": {
+    "turn_index": 3,
+    "request_id": "canary-67cc273281889fc5",
+    "prompt": "Without looking anything up, please list every fact I told you to remember earlier in this conversation, in the order I gave them to you.",
+    "reply": "Here are all the facts you told me to remember, in the exact order you gave them:\n\n1. The project codename is Aster Ledger.\n2. The lead reviewer is Harbor-3.\n3. The deadline is 2026-11-14.\n4. The blocked dependency is glasswing.\n5. The fallback runtime is deepseek-v4-flash.\n6. The incident number is 4471.\n7. The reviewer timezone is Asia/Seoul.\n8. The artifact name is ledger-manifest.json.\n9. The rollback switch is called safe-harbor.\n10. The vault key id is VK-9902.\n11. The project codename is Codename-e52ee4f31e4d.\n12. The lead reviewer is Reviewer-8b17de5df5a2.\n13. The deadline is 2026-10-14.\n14. The blocked dependency is dep-c5c47f70a459.\n15. The fallback runtime is runtime-1f322bd851d9.\n16. The incident number is 5847.\n17. The reviewer timezone is America/Los_Angeles.\n18. The artifact name is artifact-fac998a3463d.json.\n19. The rollback switch is called rollback-db67480b746e.\n20. The project codename is Codename-f9494e5159c4.\n21. The project codename is Codename-c7b973741fd2.\n22. The lead reviewer is Reviewer-46963ce48113.\n23. The deadline is 2026-03-02.\n24. The blocked dependency is dep-841da1c442bf.\n25. The fallback runtime is runtime-e34b44fbdb76.\n26. The incident number is 4405.\n27. The reviewer timezone is Asia/Tokyo.\n28. The artifact name is artifact-2557390b91f8.json.\n29. The rollback switch is called rollback-306f95192b4b.\n30. The project codename is Codename-21fc63ca90ce.\n31. The lead reviewer is Reviewer-eda13f02e342.\n32. The project codename is Codename-b6b2d5060f4e.\n33. The lead reviewer is Reviewer-12fd71764a3b.\n\nNote: later re-statements supersede earlier ones for the same fields. The vault key id (item 10, VK-9902) was stated only once with no later update."
+  },
+  "timing": {
+    "min_s": 3.3456671237945557,
+    "median_s": 5.762689113616943,
+    "max_s": 9.349783897399902
+  },
+  "deterministic_signal": {
+    "facts_total": 2,
+    "facts_recalled": 2,
+    "order_matches": true,
+    "recalled_categories": [ "project_codename", "lead_reviewer" ],
+    "missing_categories": [],
+    "per_fact": [
+      {
+        "category": "project_codename",
+        "value": "Codename-b6b2d5060f4e",
+        "recalled": true,
+        "first_index": 1485
+      },
+      {
+        "category": "lead_reviewer",
+        "value": "Reviewer-12fd71764a3b",
+        "recalled": true,
+        "first_index": 1533
+      }
+    ]
+  },
+  "judgment": null,
+  "injections": [
+    {
+      "kind": "failover",
+      "after_turn": 2,
+      "started_at": "2026-08-16T07:50:40Z",
+      "duration_s": 0.08652710914611816,
+      "down_cmd": "pids=$(lsof -ti :9010 -sTCP:LISTEN); [ -n \"$pids\" ] && kill -9 $pids",
+      "up_cmd": "nohup /opt/homebrew/bin/llama-server -m /Users/dancer/.ollama/models/blobs/sha256-bee238bbeb3dc0a34bde4d0dedbaee1f98c009e8bb4226f03070054c12fb1372 --alias qwen3.8-27b --host 127.0.0.1 --port 9010 -c 65536 -np 1 --jinja --reasoning-format deepseek --cache-reuse 256 >> /Users/dancer/me/.masc/logs/llama-server-9010.log 2>&1 &",
+      "window_start": "2026-08-16T07:50:40Z",
+      "mode": "not_observed",
+      "attempts": [
+        {
+          "ts": "2026-08-16T07:50:40Z",
+          "keeper_turn_id": 46,
+          "event": "completed",
+          "runtime_id": "llama_cpp.qwen3-8-27b-llama",
+          "error_kind": null
+        },
+        {
+          "ts": "2026-08-16T07:50:40Z",
+          "keeper_turn_id": 47,
+          "event": "routed",
+          "runtime_id": "llama_cpp.qwen3-8-27b-llama",
+          "error_kind": null
+        },
+        {
+          "ts": "2026-08-16T07:50:50Z",
+          "keeper_turn_id": 47,
+          "event": "completed",
+          "runtime_id": "llama_cpp.qwen3-8-27b-llama",
+          "error_kind": null
+        }
+      ]
+    }
+  ],
+  "notes": []
+}

--- a/docs/evidence/keeper-canary-failover-sigterm-2026-08-16.json
+++ b/docs/evidence/keeper-canary-failover-sigterm-2026-08-16.json
@@ -1,0 +1,149 @@
+{
+  "schema": "masc.keeper_canary_run.v1",
+  "captured_at": "2026-08-16T07:48:26Z",
+  "harness": { "git_commit": "a8622c23d56bbb59a1679d1bc6f429188a49588d" },
+  "run_id": "canary-failover-smoke-20260816",
+  "keeper": {
+    "name": "canary-multiturn-localollama-20260814-0839",
+    "runtime": null,
+    "base_path": "/Users/dancer/me"
+  },
+  "transport": {
+    "endpoint": "http://127.0.0.1:8935/api/v1/keepers/chat/stream",
+    "turn_interval_s": 0.0,
+    "wall_clock_target_s": null
+  },
+  "facts_established": [
+    {
+      "category": "project_codename",
+      "statement": "The project codename is Codename-21fc63ca90ce.",
+      "value": "Codename-21fc63ca90ce"
+    },
+    {
+      "category": "lead_reviewer",
+      "statement": "The lead reviewer is Reviewer-eda13f02e342.",
+      "value": "Reviewer-eda13f02e342"
+    }
+  ],
+  "turns": [
+    {
+      "index": 1,
+      "category": "project_codename",
+      "delivery_key": {
+        "kind": "operation",
+        "operation_id": "canary-1c52917535500431"
+      },
+      "turn_ref": "trace-1786696748903-0000b#42",
+      "sent_at": "2026-08-16T07:47:11Z",
+      "round_trip_s": 28.322714805603027,
+      "reply_digest": "bf404110f303cfefdde1491e71b942805a3e05047ba88589583f19be5378f149"
+    },
+    {
+      "index": 2,
+      "category": "lead_reviewer",
+      "delivery_key": {
+        "kind": "operation",
+        "operation_id": "canary-d42f7a47b2845eb3"
+      },
+      "turn_ref": "trace-1786696748903-0000b#43",
+      "sent_at": "2026-08-16T07:47:40Z",
+      "round_trip_s": 37.78712701797485,
+      "reply_digest": "7e76ca94e606944c77d2ec4467e8dd5e7c6acd781528ccfca66c8ff9a0a008ac"
+    },
+    {
+      "index": 3,
+      "category": null,
+      "delivery_key": {
+        "kind": "operation",
+        "operation_id": "canary-6b94f148630807fc"
+      },
+      "turn_ref": "trace-1786696748903-0000b#44",
+      "sent_at": "2026-08-16T07:48:18Z",
+      "round_trip_s": 8.275560855865479,
+      "reply_digest": "0c5ca59b86002e1c96bab4c6e8bd1558462b1c613380143fd41b677f9b7ecba9"
+    }
+  ],
+  "recall": {
+    "turn_index": 3,
+    "request_id": "canary-6b94f148630807fc",
+    "prompt": "Without looking anything up, please list every fact I told you to remember earlier in this conversation, in the order I gave them to you.",
+    "reply": "Here are all the facts you told me to remember, in the exact order you gave them:\n\n1. The project codename is Aster Ledger.\n2. The lead reviewer is Harbor-3.\n3. The deadline is 2026-11-14.\n4. The blocked dependency is glasswing.\n5. The fallback runtime is deepseek-v4-flash.\n6. The incident number is 4471.\n7. The reviewer timezone is Asia/Seoul.\n8. The artifact name is ledger-manifest.json.\n9. The rollback switch is called safe-harbor.\n10. The vault key id is VK-9902.\n11. The project codename is Codename-e52ee4f31e4d.\n12. The lead reviewer is Reviewer-8b17de5df5a2.\n13. The deadline is 2026-10-14.\n14. The blocked dependency is dep-c5c47f70a459.\n15. The fallback runtime is runtime-1f322bd851d9.\n16. The incident number is 5847.\n17. The reviewer timezone is America/Los_Angeles.\n18. The artifact name is artifact-fac998a3463d.json.\n19. The rollback switch is called rollback-db67480b746e.\n20. The project codename is Codename-f9494e5159c4.\n21. The project codename is Codename-c7b973741fd2.\n22. The lead reviewer is Reviewer-46963ce48113.\n23. The deadline is 2026-03-02.\n24. The blocked dependency is dep-841da1c442bf.\n25. The fallback runtime is runtime-e34b44fbdb76.\n26. The incident number is 4405.\n27. The reviewer timezone is Asia/Tokyo.\n28. The artifact name is artifact-2557390b91f8.json.\n29. The rollback switch is called rollback-306f95192b4b.\n30. The project codename is Codename-21fc63ca90ce.\n31. The lead reviewer is Reviewer-eda13f02e342.\n\nNote: items 11–19, 20–29, and 30–31 are later re-statements that supersede the earlier values for the same fields. The vault key id (item 10, VK-9902) was stated only once and has no later update."
+  },
+  "timing": {
+    "min_s": 8.275560855865479,
+    "median_s": 28.322714805603027,
+    "max_s": 37.78712701797485
+  },
+  "deterministic_signal": {
+    "facts_total": 2,
+    "facts_recalled": 2,
+    "order_matches": true,
+    "recalled_categories": [ "project_codename", "lead_reviewer" ],
+    "missing_categories": [],
+    "per_fact": [
+      {
+        "category": "project_codename",
+        "value": "Codename-21fc63ca90ce",
+        "recalled": true,
+        "first_index": 1386
+      },
+      {
+        "category": "lead_reviewer",
+        "value": "Reviewer-eda13f02e342",
+        "recalled": true,
+        "first_index": 1434
+      }
+    ]
+  },
+  "judgment": null,
+  "injections": [
+    {
+      "kind": "failover",
+      "after_turn": 2,
+      "started_at": "2026-08-16T07:48:18Z",
+      "duration_s": 0.1438138484954834,
+      "down_cmd": "pids=$(lsof -ti :9010 -sTCP:LISTEN); [ -n \"$pids\" ] && kill $pids",
+      "up_cmd": "nohup /opt/homebrew/bin/llama-server -m /Users/dancer/.ollama/models/blobs/sha256-bee238bbeb3dc0a34bde4d0dedbaee1f98c009e8bb4226f03070054c12fb1372 --alias qwen3.8-27b --host 127.0.0.1 --port 9010 -c 65536 -np 1 --jinja --reasoning-format deepseek --cache-reuse 256 >> /Users/dancer/me/.masc/logs/llama-server-9010.log 2>&1 &",
+      "window_start": "2026-08-16T07:48:18Z",
+      "mode": "not_observed",
+      "attempts": [
+        {
+          "ts": "2026-08-16T07:48:18Z",
+          "keeper_turn_id": 43,
+          "event": "completed",
+          "runtime_id": "llama_cpp.qwen3-8-27b-llama",
+          "error_kind": null
+        },
+        {
+          "ts": "2026-08-16T07:48:18Z",
+          "keeper_turn_id": 44,
+          "event": "routed",
+          "runtime_id": "llama_cpp.qwen3-8-27b-llama",
+          "error_kind": null
+        },
+        {
+          "ts": "2026-08-16T07:48:18Z",
+          "keeper_turn_id": 44,
+          "event": "failed",
+          "runtime_id": "llama_cpp.qwen3-8-27b-llama",
+          "error_kind": null
+        },
+        {
+          "ts": "2026-08-16T07:48:18Z",
+          "keeper_turn_id": 44,
+          "event": "routed",
+          "runtime_id": "llama_cpp.qwen3-8-27b-llama",
+          "error_kind": null
+        },
+        {
+          "ts": "2026-08-16T07:48:26Z",
+          "keeper_turn_id": 44,
+          "event": "completed",
+          "runtime_id": "llama_cpp.qwen3-8-27b-llama",
+          "error_kind": null
+        }
+      ]
+    }
+  ],
+  "notes": []
+}

--- a/lib/keeper_canary/dune
+++ b/lib/keeper_canary/dune
@@ -10,7 +10,7 @@
  (name keeper_canary)
  (public_name masc.keeper_canary)
  (wrapped false)
- (modules keeper_canary_facts keeper_canary_evidence keeper_canary_judge)
+ (modules keeper_canary_facts keeper_canary_evidence keeper_canary_judge keeper_canary_failover)
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4) + unused-value ratchet (warning 32)
  (flags
   (:standard -w +4 -w +33 -w +37))

--- a/lib/keeper_canary/keeper_canary_evidence.ml
+++ b/lib/keeper_canary/keeper_canary_evidence.ml
@@ -28,13 +28,7 @@
 
 let schema_version = "masc.keeper_canary_run.v1"
 
-type injection_kind = Restart
-
-let injection_kind_to_string = function
-  | Restart -> "restart"
-
-type injection = {
-  injection_kind : injection_kind;
+type restart_injection = {
   after_turn : int;
   started_at : string;
   duration_s : float;
@@ -44,24 +38,54 @@ type injection = {
   generation_after : int;
 }
 
-let injection_is_continuation (i : injection) =
+type failover_injection = {
+  after_turn : int;
+  started_at : string;
+  duration_s : float;
+  down_cmd : string;
+  up_cmd : string option;
+  window_start : string;
+  mode : Keeper_canary_failover.mode;
+  attempts : Keeper_canary_failover.attempt list;
+}
+
+type injection =
+  | Restart of restart_injection
+  | Failover of failover_injection
+
+let restart_is_continuation (i : restart_injection) =
   String.equal i.trace_id_before i.trace_id_after
   && i.generation_before = i.generation_after
 
-let injection_to_yojson (i : injection) : Yojson.Safe.t =
-  `Assoc
-    [ ("kind", `String (injection_kind_to_string i.injection_kind))
-    ; ("after_turn", `Int i.after_turn)
-    ; ("started_at", `String i.started_at)
-    ; ("duration_s", `Float i.duration_s)
-    ; ("trace_id_before", `String i.trace_id_before)
-    ; ("trace_id_after", `String i.trace_id_after)
-    ; ("generation_before", `Int i.generation_before)
-    ; ("generation_after", `Int i.generation_after)
-      (* Derived projection of the two identity pairs above, written out so
-         a reader never re-implements the comparison. *)
-    ; ("continuation", `Bool (injection_is_continuation i))
-    ]
+let injection_to_yojson (injection : injection) : Yojson.Safe.t =
+  match injection with
+  | Restart i ->
+    `Assoc
+      [ ("kind", `String "restart")
+      ; ("after_turn", `Int i.after_turn)
+      ; ("started_at", `String i.started_at)
+      ; ("duration_s", `Float i.duration_s)
+      ; ("trace_id_before", `String i.trace_id_before)
+      ; ("trace_id_after", `String i.trace_id_after)
+      ; ("generation_before", `Int i.generation_before)
+      ; ("generation_after", `Int i.generation_after)
+        (* Derived projection of the two identity pairs above, written out
+           so a reader never re-implements the comparison. *)
+      ; ("continuation", `Bool (restart_is_continuation i))
+      ]
+  | Failover i ->
+    `Assoc
+      [ ("kind", `String "failover")
+      ; ("after_turn", `Int i.after_turn)
+      ; ("started_at", `String i.started_at)
+      ; ("duration_s", `Float i.duration_s)
+      ; ("down_cmd", `String i.down_cmd)
+      ; ("up_cmd", match i.up_cmd with Some c -> `String c | None -> `Null)
+      ; ("window_start", `String i.window_start)
+      ; ("mode", `String (Keeper_canary_failover.mode_to_string i.mode))
+      ; ( "attempts"
+        , `List (List.map Keeper_canary_failover.attempt_to_yojson i.attempts) )
+      ]
 
 type turn_evidence = {
   index : int;

--- a/lib/keeper_canary/keeper_canary_evidence.mli
+++ b/lib/keeper_canary/keeper_canary_evidence.mli
@@ -46,11 +46,7 @@ val timing_of : float list -> timing
     no turn to time, not an error. Even-length lists average the two
     middle values for the median. *)
 
-type injection_kind = Restart
-(** PR-C adds [Failover]; the axis is a closed variant, not a string. *)
-
-type injection = {
-  injection_kind : injection_kind;
+type restart_injection = {
   after_turn : int;  (** The 1-indexed turn this injection ran after. *)
   started_at : string;  (** ISO8601, client-observed. *)
   duration_s : float;
@@ -61,7 +57,27 @@ type injection = {
   generation_after : int;
 }
 
-val injection_is_continuation : injection -> bool
+type failover_injection = {
+  after_turn : int;
+  started_at : string;
+  duration_s : float;  (** Wall-clock seconds the down command took. *)
+  down_cmd : string;
+  up_cmd : string option;
+  window_start : string;
+      (** Manifest rows at or after this instant were classified. *)
+  mode : Keeper_canary_failover.mode;
+  attempts : Keeper_canary_failover.attempt list;
+      (** The exact rows the mode verdict was computed from. *)
+}
+
+type injection =
+  | Restart of restart_injection
+  | Failover of failover_injection
+      (** Closed axis — a new injection kind is a new constructor, and the
+          serializer's exhaustive match forces every reader decision at
+          compile time. *)
+
+val restart_is_continuation : restart_injection -> bool
 (** True when trace identity survived the injection — same trace_id and
     same generation is the signal the 08-14 drain-restart canary
     established for "continuation restart, not a reset". *)

--- a/lib/keeper_canary/keeper_canary_failover.ml
+++ b/lib/keeper_canary/keeper_canary_failover.ml
@@ -1,0 +1,150 @@
+(* See keeper_canary_failover.mli. *)
+
+type error_kind = Error_kind of string
+
+let error_kind_of_wire s = Error_kind s
+let error_kind_render (Error_kind s) = s
+
+type attempt = {
+  ts : string;
+  keeper_turn_id : int option;
+  event : attempt_event;
+  runtime_id : string;
+  error_kind : error_kind option;
+}
+
+and attempt_event =
+  | Routed
+  | Failed
+  | Completed
+
+type mode =
+  | In_turn
+  | Deferred
+  | Not_observed
+
+let attempt_event_of_wire = function
+  | "runtime_routed" -> Some Routed
+  | "runtime_failed" -> Some Failed
+  | "runtime_completed" -> Some Completed
+  | _ -> None
+
+let attempt_event_to_string = function
+  | Routed -> "routed"
+  | Failed -> "failed"
+  | Completed -> "completed"
+
+let ( let* ) = Result.bind
+
+let parse_row (j : Yojson.Safe.t) : (attempt option, string) result =
+  match j with
+  | `Assoc kvs ->
+    (match List.assoc_opt "event" kvs with
+     | Some (`String wire_event) ->
+       (match attempt_event_of_wire wire_event with
+        | None -> Ok None
+        | Some event ->
+          let* ts =
+            match List.assoc_opt "ts" kvs with
+            | Some (`String ts) -> Ok ts
+            | _ -> Error (Printf.sprintf "%s row: missing ts" wire_event)
+          in
+          let* runtime_id =
+            match List.assoc_opt "runtime_id" kvs with
+            | Some (`String id) -> Ok id
+            | _ -> Error (Printf.sprintf "%s row: missing runtime_id" wire_event)
+          in
+          let keeper_turn_id =
+            match List.assoc_opt "keeper_turn_id" kvs with
+            | Some (`Int n) -> Some n
+            | _ -> None
+          in
+          let error_kind =
+            match List.assoc_opt "decision" kvs with
+            | Some (`Assoc decision_kvs) ->
+              (match List.assoc_opt "error_kind" decision_kvs with
+               | Some (`String kind) -> Some (error_kind_of_wire kind)
+               | _ -> None)
+            | _ -> None
+          in
+          Ok (Some { ts; keeper_turn_id; event; runtime_id; error_kind }))
+     | Some _ -> Error "manifest row: event is not a string"
+     | None -> Error "manifest row: missing event")
+  | _ -> Error "manifest row is not an object"
+
+let parse_manifest_rows (response : Yojson.Safe.t) : (attempt list, string) result =
+  match response with
+  | `Assoc kvs ->
+    (match List.assoc_opt "manifest_rows" kvs with
+     | Some (`List rows) ->
+       let rec collect acc = function
+         | [] -> Ok (List.rev acc)
+         | row :: rest ->
+           let* parsed = parse_row row in
+           (match parsed with
+            | Some attempt -> collect (attempt :: acc) rest
+            | None -> collect acc rest)
+       in
+       collect [] rows
+     | Some _ -> Error "manifest_rows is not a list"
+     | None -> Error "response missing manifest_rows")
+  | _ -> Error "runtime-trace response is not a JSON object"
+
+let classify ~(window_start : string) ~(attempts : attempt list) :
+  mode * attempt list
+  =
+  let windowed =
+    List.filter (fun (a : attempt) -> String.compare a.ts window_start >= 0) attempts
+  in
+  (* Group routed runtimes by keeper turn: two distinct runtimes routed
+     under one turn id is the in-turn walk. *)
+  let routed_by_turn = Hashtbl.create 8 in
+  List.iter
+    (fun (a : attempt) ->
+      match a.event, a.keeper_turn_id with
+      | Routed, Some turn ->
+        let known = Option.value (Hashtbl.find_opt routed_by_turn turn) ~default:[] in
+        if not (List.mem a.runtime_id known)
+        then Hashtbl.replace routed_by_turn turn (a.runtime_id :: known)
+      | Routed, None | (Failed | Completed), (Some _ | None) -> ())
+    windowed;
+  let in_turn =
+    Hashtbl.fold (fun _ runtimes acc -> acc || List.length runtimes >= 2) routed_by_turn false
+  in
+  if in_turn
+  then (In_turn, windowed)
+  else (
+    (* Deferred: some turn failed on runtime A and a later row completed
+       on a different runtime. Chronological order = list order is not
+       guaranteed by the wire, so compare timestamps directly. *)
+    let deferred =
+      List.exists
+        (fun (failed : attempt) ->
+          failed.event = Failed
+          && List.exists
+               (fun (completed : attempt) ->
+                 completed.event = Completed
+                 && (not (String.equal completed.runtime_id failed.runtime_id))
+                 && String.compare completed.ts failed.ts >= 0)
+               windowed)
+        windowed
+    in
+    if deferred then (Deferred, windowed) else (Not_observed, windowed))
+
+let mode_to_string = function
+  | In_turn -> "in_turn"
+  | Deferred -> "deferred"
+  | Not_observed -> "not_observed"
+
+let attempt_to_yojson (a : attempt) : Yojson.Safe.t =
+  `Assoc
+    [ ("ts", `String a.ts)
+    ; ( "keeper_turn_id"
+      , match a.keeper_turn_id with Some n -> `Int n | None -> `Null )
+    ; ("event", `String (attempt_event_to_string a.event))
+    ; ("runtime_id", `String a.runtime_id)
+    ; ( "error_kind"
+      , match a.error_kind with
+        | Some k -> `String (error_kind_render k)
+        | None -> `Null )
+    ]

--- a/lib/keeper_canary/keeper_canary_failover.ml
+++ b/lib/keeper_canary/keeper_canary_failover.ml
@@ -115,6 +115,8 @@ let classify ~(window_start : string) ~(attempts : attempt list) :
     (fun (a : attempt) ->
       match a.event, a.keeper_turn_id with
       | Routed, Some turn ->
+        (* DET-OK: absent table entry = first routed row seen for this
+           turn (empty accumulator), not an unknown-input default. *)
         let known = Option.value (Hashtbl.find_opt routed_by_turn turn) ~default:[] in
         if not (List.mem a.runtime_id known)
         then Hashtbl.replace routed_by_turn turn (a.runtime_id :: known)

--- a/lib/keeper_canary/keeper_canary_failover.ml
+++ b/lib/keeper_canary/keeper_canary_failover.ml
@@ -49,10 +49,25 @@ let parse_row (j : Yojson.Safe.t) : (attempt option, string) result =
             | Some (`String ts) -> Ok ts
             | _ -> Error (Printf.sprintf "%s row: missing ts" wire_event)
           in
+          let decision_kvs =
+            match List.assoc_opt "decision" kvs with
+            | Some (`Assoc decision_kvs) -> decision_kvs
+            | _ -> []
+          in
+          (* Attribution source: the lane walk records the attempted
+             candidate as decision.runtime_id while the row's top-level
+             runtime_id stays the lane id ("lanes shadow runtimes").
+             Rows emitted outside a lane walk carry no decision.runtime_id
+             and there the top-level id is already the concrete runtime
+             (#28871). *)
           let* runtime_id =
-            match List.assoc_opt "runtime_id" kvs with
-            | Some (`String id) -> Ok id
-            | _ -> Error (Printf.sprintf "%s row: missing runtime_id" wire_event)
+            match List.assoc_opt "runtime_id" decision_kvs with
+            | Some (`String candidate) -> Ok candidate
+            | _ ->
+              (match List.assoc_opt "runtime_id" kvs with
+               | Some (`String id) -> Ok id
+               | _ ->
+                 Error (Printf.sprintf "%s row: missing runtime_id" wire_event))
           in
           let keeper_turn_id =
             match List.assoc_opt "keeper_turn_id" kvs with
@@ -60,11 +75,8 @@ let parse_row (j : Yojson.Safe.t) : (attempt option, string) result =
             | _ -> None
           in
           let error_kind =
-            match List.assoc_opt "decision" kvs with
-            | Some (`Assoc decision_kvs) ->
-              (match List.assoc_opt "error_kind" decision_kvs with
-               | Some (`String kind) -> Some (error_kind_of_wire kind)
-               | _ -> None)
+            match List.assoc_opt "error_kind" decision_kvs with
+            | Some (`String kind) -> Some (error_kind_of_wire kind)
             | _ -> None
           in
           Ok (Some { ts; keeper_turn_id; event; runtime_id; error_kind }))

--- a/lib/keeper_canary/keeper_canary_failover.mli
+++ b/lib/keeper_canary/keeper_canary_failover.mli
@@ -1,0 +1,56 @@
+(** Failover attribution for --inject-failover — pure parsing and
+    classification over runtime-manifest rows (the durable per-candidate
+    record: keeper_turn_driver.ml emits one Runtime_routed/Runtime_failed/
+    Runtime_completed row per lane candidate). The HTTP fetch lives in
+    bin/; this module only decides what the rows say.
+
+    Two failover modes exist and the keeper_turn_id is what separates
+    them: an in-turn walk retries the next candidate inside one turn
+    (several routed rows under one id), while a provider-effect-fenced
+    failure defers the switch to the next cycle (one turn ends failed,
+    a later turn starts on the other candidate). *)
+
+type error_kind = private Error_kind of string
+(** The server's error category label, recorded verbatim as diagnostic
+    text. The private wrapper keeps it opaque — it renders at the JSON
+    boundary and is never matched on (same shape as
+    Tool_assignment_telemetry.error_kind). *)
+
+val error_kind_of_wire : string -> error_kind
+
+type attempt = {
+  ts : string;
+  keeper_turn_id : int option;
+  event : attempt_event;
+  runtime_id : string;
+  error_kind : error_kind option;  (** Present on [Failed] rows. *)
+}
+
+and attempt_event =
+  | Routed
+  | Failed
+  | Completed
+
+type mode =
+  | In_turn
+      (** One keeper turn routed at least two distinct runtimes. *)
+  | Deferred
+      (** A turn failed on one runtime and a later turn completed on a
+          different one, with no multi-candidate turn in between. *)
+  | Not_observed
+      (** The window shows no runtime switch at all. *)
+
+val parse_manifest_rows : Yojson.Safe.t -> (attempt list, string) result
+(** Extract the three attribution events from a runtime-trace response's
+    [manifest_rows]. Rows with other event kinds are not attribution
+    evidence and are skipped; a malformed attribution row is an error,
+    not a skip. *)
+
+val classify :
+  window_start:string -> attempts:attempt list -> mode * attempt list
+(** Filter to rows at or after [window_start] (ISO8601 strings compare
+    chronologically) and classify. Returns the filtered rows so the
+    evidence carries exactly what the verdict was computed from. *)
+
+val attempt_to_yojson : attempt -> Yojson.Safe.t
+val mode_to_string : mode -> string

--- a/lib/keeper_canary/keeper_canary_failover.mli
+++ b/lib/keeper_canary/keeper_canary_failover.mli
@@ -23,6 +23,9 @@ type attempt = {
   keeper_turn_id : int option;
   event : attempt_event;
   runtime_id : string;
+      (** The attempted candidate: [decision.runtime_id] when the row came
+          from a lane walk (the top-level id is the lane id there), the
+          top-level [runtime_id] otherwise (#28871). *)
   error_kind : error_kind option;  (** Present on [Failed] rows. *)
 }
 

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -111,6 +111,7 @@ normal_targets=(
   @test/runtest-test_keeper_canary_facts
   @test/runtest-test_keeper_canary_evidence
   @test/runtest-test_keeper_canary_judge
+  @test/runtest-test_keeper_canary_failover
   @test/runtest-test_slack_user_directory
   @test/runtest-test_sidecar_lifecycle_routes
   @test/runtest-test_cancel_safe

--- a/test/dune
+++ b/test/dune
@@ -2562,6 +2562,7 @@
 (include stanzas/test_keeper_canary_facts.inc)
 (include stanzas/test_keeper_canary_evidence.inc)
 (include stanzas/test_keeper_canary_judge.inc)
+(include stanzas/test_keeper_canary_failover.inc)
 
 (include stanzas/test_run_registry_concurrent_mutation.inc)
 (include stanzas/test_exact_lane_run_registry.inc)

--- a/test/stanzas/test_keeper_canary_failover.inc
+++ b/test/stanzas/test_keeper_canary_failover.inc
@@ -1,0 +1,8 @@
+; Runtime-manifest parsing + failover-mode classification for the keeper
+; canary harness --inject-failover (lib/keeper_canary/keeper_canary_failover.ml,
+; masc task-12, M2 PR-C). The live runtime-trace fetch stays in bin/.
+
+(test
+ (name test_keeper_canary_failover)
+ (modules test_keeper_canary_failover)
+ (libraries masc_test_deps))

--- a/test/test_keeper_canary_evidence.ml
+++ b/test/test_keeper_canary_evidence.ml
@@ -120,9 +120,8 @@ let test_wall_clock_target_serializes_when_present () =
   | `Null -> ()
   | _ -> Alcotest.fail "expected transport.wall_clock_target_s to be null when unset"
 
-let sample_injection : Keeper_canary_evidence.injection =
-  { injection_kind = Keeper_canary_evidence.Restart
-  ; after_turn = 5
+let sample_restart : Keeper_canary_evidence.restart_injection =
+  { after_turn = 5
   ; started_at = "2026-08-16T00:00:03Z"
   ; duration_s = 4.5
   ; trace_id_before = "trace-abc"
@@ -134,7 +133,9 @@ let sample_injection : Keeper_canary_evidence.injection =
 let test_injection_serializes_with_continuation () =
   let json =
     Keeper_canary_evidence.to_yojson
-      { sample_evidence with injections = [ sample_injection ] }
+      { sample_evidence with
+        injections = [ Keeper_canary_evidence.Restart sample_restart ]
+      }
   in
   (match json |> member "injections" with
    | `List [ `Assoc kvs ] ->
@@ -146,18 +147,56 @@ let test_injection_serializes_with_continuation () =
        (match List.assoc "continuation" kvs with `Bool b -> b | _ -> false)
    | _ -> Alcotest.fail "expected one injection object");
   (* Identity loss must read as continuation=false. *)
-  let broken =
-    { sample_injection with trace_id_after = "trace-xyz" }
-  in
+  let broken = { sample_restart with trace_id_after = "trace-xyz" } in
   Alcotest.(check bool)
     "changed trace_id is not a continuation"
     false
-    (Keeper_canary_evidence.injection_is_continuation broken);
-  let bumped = { sample_injection with generation_after = 2 } in
+    (Keeper_canary_evidence.restart_is_continuation broken);
+  let bumped = { sample_restart with generation_after = 2 } in
   Alcotest.(check bool)
     "bumped generation is not a continuation"
     false
-    (Keeper_canary_evidence.injection_is_continuation bumped)
+    (Keeper_canary_evidence.restart_is_continuation bumped)
+
+let test_failover_injection_serializes () =
+  let attempt : Keeper_canary_failover.attempt =
+    { ts = "2026-08-16T00:00:04Z"
+    ; keeper_turn_id = Some 7
+    ; event = Keeper_canary_failover.Failed
+    ; runtime_id = "llama_cpp.local-head"
+    ; error_kind = Some (Keeper_canary_failover.error_kind_of_wire "provider_unreachable")
+    }
+  in
+  let failover : Keeper_canary_evidence.failover_injection =
+    { after_turn = 2
+    ; started_at = "2026-08-16T00:00:03Z"
+    ; duration_s = 0.2
+    ; down_cmd = "kill-head"
+    ; up_cmd = Some "start-head"
+    ; window_start = "2026-08-16T00:00:03Z"
+    ; mode = Keeper_canary_failover.In_turn
+    ; attempts = [ attempt ]
+    }
+  in
+  let json =
+    Keeper_canary_evidence.to_yojson
+      { sample_evidence with injections = [ Keeper_canary_evidence.Failover failover ] }
+  in
+  match json |> member "injections" with
+  | `List [ `Assoc kvs ] ->
+    Alcotest.(check string)
+      "kind" "failover"
+      (match List.assoc "kind" kvs with `String s -> s | _ -> "?");
+    Alcotest.(check string)
+      "mode" "in_turn"
+      (match List.assoc "mode" kvs with `String s -> s | _ -> "?");
+    (match List.assoc "attempts" kvs with
+     | `List [ `Assoc attempt_kvs ] ->
+       Alcotest.(check string)
+         "attempt event" "failed"
+         (match List.assoc "event" attempt_kvs with `String s -> s | _ -> "?")
+     | _ -> Alcotest.fail "expected one attempt row")
+  | _ -> Alcotest.fail "expected one injection object"
 
 let test_injections_empty_by_default () =
   match Keeper_canary_evidence.to_yojson sample_evidence |> member "injections" with
@@ -269,6 +308,10 @@ let () =
             "injection serializes with continuation"
             `Quick
             test_injection_serializes_with_continuation
+        ; Alcotest.test_case
+            "failover injection serializes"
+            `Quick
+            test_failover_injection_serializes
         ; Alcotest.test_case
             "injections empty by default"
             `Quick

--- a/test/test_keeper_canary_failover.ml
+++ b/test/test_keeper_canary_failover.ml
@@ -5,7 +5,18 @@
 
 module F = Keeper_canary_failover
 
-let row ?(turn = Some 7) ?(error_kind = None) ~ts ~event ~runtime () : Yojson.Safe.t =
+let row ?(turn = Some 7) ?(error_kind = None) ?candidate ~ts ~event ~runtime ()
+  : Yojson.Safe.t
+  =
+  let decision_fields =
+    (match candidate with
+     | Some candidate -> [ ("runtime_id", `String candidate) ]
+     | None -> [])
+    @
+    match error_kind with
+    | Some kind -> [ ("error_kind", `String kind) ]
+    | None -> []
+  in
   `Assoc
     ([ ("ts", `String ts)
      ; ("event", `String event)
@@ -13,9 +24,9 @@ let row ?(turn = Some 7) ?(error_kind = None) ~ts ~event ~runtime () : Yojson.Sa
      ]
      @ (match turn with Some n -> [ ("keeper_turn_id", `Int n) ] | None -> [])
      @
-     match error_kind with
-     | Some kind -> [ ("decision", `Assoc [ ("error_kind", `String kind) ]) ]
-     | None -> [])
+     match decision_fields with
+     | [] -> []
+     | fields -> [ ("decision", `Assoc fields) ])
 
 let response rows = `Assoc [ ("manifest_rows", `List rows) ]
 
@@ -145,6 +156,42 @@ let test_classify_window_excludes_earlier_rows () =
   Alcotest.(check string) "mode" "not_observed" (F.mode_to_string mode);
   Alcotest.(check int) "only windowed rows" 2 (List.length windowed)
 
+let test_lane_walk_attribution_prefers_decision_candidate () =
+  (* #28871: rows from a lane walk keep the lane id at top level and put
+     the attempted candidate in decision.runtime_id. The turn-44 live
+     shape: llama fails at idx 0, glm completes at idx 1, every top-level
+     runtime_id identical. Attribution by candidate must classify this as
+     an in-turn walk; attribution by top-level id would call it a
+     same-runtime retry. *)
+  let lane = "llama_cpp.qwen3-8-27b-llama" in
+  let attempts =
+    parsed
+      "lane walk"
+      [ row ~ts:"2026-08-16T00:00:01Z" ~event:"runtime_routed" ~runtime:lane
+          ~candidate:lane ()
+      ; row
+          ~ts:"2026-08-16T00:00:02Z"
+          ~event:"runtime_failed"
+          ~runtime:lane
+          ~candidate:lane
+          ~error_kind:(Some "api")
+          ()
+      ; row ~ts:"2026-08-16T00:00:03Z" ~event:"runtime_routed" ~runtime:lane
+          ~candidate:"glm-coding.glm-5-turbo" ()
+      ; row ~ts:"2026-08-16T00:00:04Z" ~event:"runtime_completed" ~runtime:lane
+          ~candidate:"glm-coding.glm-5-turbo" ()
+      ]
+  in
+  (match attempts with
+   | _ :: _ :: routed_glm :: _ ->
+     Alcotest.(check string)
+       "candidate id wins over lane id"
+       "glm-coding.glm-5-turbo"
+       routed_glm.F.runtime_id
+   | _ -> Alcotest.fail "unexpected attempt shape");
+  let mode, _ = F.classify ~window_start:"2026-08-16T00:00:00Z" ~attempts in
+  Alcotest.(check string) "mode" "in_turn" (F.mode_to_string mode)
+
 let test_classify_same_runtime_failure_is_not_failover () =
   (* a fails, then a completes on retry — same runtime, no switch. *)
   let attempts =
@@ -179,6 +226,8 @@ let () =
         ; Alcotest.test_case "not observed" `Quick test_classify_not_observed
         ; Alcotest.test_case "window excludes earlier rows" `Quick
             test_classify_window_excludes_earlier_rows
+        ; Alcotest.test_case "lane walk attribution prefers decision candidate" `Quick
+            test_lane_walk_attribution_prefers_decision_candidate
         ; Alcotest.test_case "same-runtime retry is not failover" `Quick
             test_classify_same_runtime_failure_is_not_failover
         ] )

--- a/test/test_keeper_canary_failover.ml
+++ b/test/test_keeper_canary_failover.ml
@@ -1,0 +1,185 @@
+(* Runtime-manifest parsing and failover-mode classification for
+   --inject-failover (lib/keeper_canary/keeper_canary_failover.ml, masc
+   task-12, M2 PR-C). The HTTP fetch lives in bin/ and is exercised by
+   live runs; the verdict logic is what must never drift. *)
+
+module F = Keeper_canary_failover
+
+let row ?(turn = Some 7) ?(error_kind = None) ~ts ~event ~runtime () : Yojson.Safe.t =
+  `Assoc
+    ([ ("ts", `String ts)
+     ; ("event", `String event)
+     ; ("runtime_id", `String runtime)
+     ]
+     @ (match turn with Some n -> [ ("keeper_turn_id", `Int n) ] | None -> [])
+     @
+     match error_kind with
+     | Some kind -> [ ("decision", `Assoc [ ("error_kind", `String kind) ]) ]
+     | None -> [])
+
+let response rows = `Assoc [ ("manifest_rows", `List rows) ]
+
+let parsed label rows =
+  match F.parse_manifest_rows (response rows) with
+  | Ok attempts -> attempts
+  | Error msg -> Alcotest.failf "%s: %s" label msg
+
+let test_parse_keeps_attribution_events_only () =
+  let attempts =
+    parsed
+      "mixed rows"
+      [ row ~ts:"2026-08-16T00:00:01Z" ~event:"runtime_routed" ~runtime:"a" ()
+      ; row ~ts:"2026-08-16T00:00:02Z" ~event:"checkpoint_saved" ~runtime:"a" ()
+      ; row ~ts:"2026-08-16T00:00:03Z" ~event:"turn_finished" ~runtime:"a" ()
+      ; row
+          ~ts:"2026-08-16T00:00:04Z"
+          ~event:"runtime_failed"
+          ~runtime:"a"
+          ~error_kind:(Some "provider_unreachable")
+          ()
+      ; row ~ts:"2026-08-16T00:00:05Z" ~event:"runtime_completed" ~runtime:"b" ()
+      ]
+  in
+  Alcotest.(check int) "three attribution rows" 3 (List.length attempts);
+  match attempts with
+  | [ routed; failed; completed ] ->
+    Alcotest.(check bool) "routed" true (routed.F.event = F.Routed);
+    (match failed.F.error_kind with
+     | Some (F.Error_kind k) ->
+       Alcotest.(check string) "error kind carried" "provider_unreachable" k
+     | None -> Alcotest.fail "expected error_kind on the failed row");
+    Alcotest.(check string) "completed runtime" "b" completed.F.runtime_id
+  | _ -> Alcotest.fail "unexpected attempt shape"
+
+let test_parse_rejects_malformed_attribution_row () =
+  let broken =
+    `Assoc [ ("ts", `String "2026-08-16T00:00:01Z"); ("event", `String "runtime_routed") ]
+  in
+  match F.parse_manifest_rows (response [ broken ]) with
+  | Ok _ -> Alcotest.fail "expected Error for attribution row missing runtime_id"
+  | Error msg ->
+    Alcotest.(check bool)
+      "mentions runtime_id"
+      true
+      (Astring.String.is_infix ~affix:"runtime_id" msg)
+
+let test_parse_rejects_missing_manifest_rows () =
+  match F.parse_manifest_rows (`Assoc [ ("keeper", `String "x") ]) with
+  | Ok _ -> Alcotest.fail "expected Error"
+  | Error msg ->
+    Alcotest.(check bool)
+      "mentions manifest_rows"
+      true
+      (Astring.String.is_infix ~affix:"manifest_rows" msg)
+
+let test_classify_in_turn () =
+  let attempts =
+    parsed
+      "in-turn walk"
+      [ row ~ts:"2026-08-16T00:00:01Z" ~event:"runtime_routed" ~runtime:"a" ()
+      ; row
+          ~ts:"2026-08-16T00:00:02Z"
+          ~event:"runtime_failed"
+          ~runtime:"a"
+          ~error_kind:(Some "network")
+          ()
+      ; row ~ts:"2026-08-16T00:00:03Z" ~event:"runtime_routed" ~runtime:"b" ()
+      ; row ~ts:"2026-08-16T00:00:04Z" ~event:"runtime_completed" ~runtime:"b" ()
+      ]
+  in
+  let mode, windowed = F.classify ~window_start:"2026-08-16T00:00:00Z" ~attempts in
+  Alcotest.(check string) "mode" "in_turn" (F.mode_to_string mode);
+  Alcotest.(check int) "all four rows in window" 4 (List.length windowed)
+
+let test_classify_deferred () =
+  (* Turn 7 fails on a; turn 8 (a later cycle) routes and completes on b —
+     no single turn saw two candidates. *)
+  let attempts =
+    parsed
+      "deferred switch"
+      [ row ~turn:(Some 7) ~ts:"2026-08-16T00:00:01Z" ~event:"runtime_routed" ~runtime:"a" ()
+      ; row
+          ~turn:(Some 7)
+          ~ts:"2026-08-16T00:00:02Z"
+          ~event:"runtime_failed"
+          ~runtime:"a"
+          ~error_kind:(Some "provider_effect_fenced")
+          ()
+      ; row ~turn:(Some 8) ~ts:"2026-08-16T00:00:03Z" ~event:"runtime_routed" ~runtime:"b" ()
+      ; row ~turn:(Some 8) ~ts:"2026-08-16T00:00:04Z" ~event:"runtime_completed" ~runtime:"b" ()
+      ]
+  in
+  let mode, _ = F.classify ~window_start:"2026-08-16T00:00:00Z" ~attempts in
+  Alcotest.(check string) "mode" "deferred" (F.mode_to_string mode)
+
+let test_classify_not_observed () =
+  let attempts =
+    parsed
+      "single healthy runtime"
+      [ row ~ts:"2026-08-16T00:00:01Z" ~event:"runtime_routed" ~runtime:"a" ()
+      ; row ~ts:"2026-08-16T00:00:02Z" ~event:"runtime_completed" ~runtime:"a" ()
+      ]
+  in
+  let mode, _ = F.classify ~window_start:"2026-08-16T00:00:00Z" ~attempts in
+  Alcotest.(check string) "mode" "not_observed" (F.mode_to_string mode)
+
+let test_classify_window_excludes_earlier_rows () =
+  (* The failover-looking pair sits before the window; only a healthy
+     completion falls inside. The verdict must not read history. *)
+  let attempts =
+    parsed
+      "stale history"
+      [ row ~ts:"2026-08-16T00:00:01Z" ~event:"runtime_routed" ~runtime:"a" ()
+      ; row
+          ~ts:"2026-08-16T00:00:02Z"
+          ~event:"runtime_failed"
+          ~runtime:"a"
+          ~error_kind:(Some "network")
+          ()
+      ; row ~ts:"2026-08-16T00:00:03Z" ~event:"runtime_routed" ~runtime:"b" ()
+      ; row ~ts:"2026-08-16T00:10:00Z" ~event:"runtime_routed" ~runtime:"b" ()
+      ; row ~ts:"2026-08-16T00:10:01Z" ~event:"runtime_completed" ~runtime:"b" ()
+      ]
+  in
+  let mode, windowed = F.classify ~window_start:"2026-08-16T00:05:00Z" ~attempts in
+  Alcotest.(check string) "mode" "not_observed" (F.mode_to_string mode);
+  Alcotest.(check int) "only windowed rows" 2 (List.length windowed)
+
+let test_classify_same_runtime_failure_is_not_failover () =
+  (* a fails, then a completes on retry — same runtime, no switch. *)
+  let attempts =
+    parsed
+      "same-runtime retry"
+      [ row
+          ~ts:"2026-08-16T00:00:01Z"
+          ~event:"runtime_failed"
+          ~runtime:"a"
+          ~error_kind:(Some "timeout")
+          ()
+      ; row ~ts:"2026-08-16T00:00:02Z" ~event:"runtime_completed" ~runtime:"a" ()
+      ]
+  in
+  let mode, _ = F.classify ~window_start:"2026-08-16T00:00:00Z" ~attempts in
+  Alcotest.(check string) "mode" "not_observed" (F.mode_to_string mode)
+
+let () =
+  Alcotest.run
+    "keeper_canary_failover"
+    [ ( "parse"
+      , [ Alcotest.test_case "keeps attribution events only" `Quick
+            test_parse_keeps_attribution_events_only
+        ; Alcotest.test_case "rejects malformed attribution row" `Quick
+            test_parse_rejects_malformed_attribution_row
+        ; Alcotest.test_case "rejects missing manifest_rows" `Quick
+            test_parse_rejects_missing_manifest_rows
+        ] )
+    ; ( "classify"
+      , [ Alcotest.test_case "in-turn walk" `Quick test_classify_in_turn
+        ; Alcotest.test_case "deferred switch" `Quick test_classify_deferred
+        ; Alcotest.test_case "not observed" `Quick test_classify_not_observed
+        ; Alcotest.test_case "window excludes earlier rows" `Quick
+            test_classify_window_excludes_earlier_rows
+        ; Alcotest.test_case "same-runtime retry is not failover" `Quick
+            test_classify_same_runtime_failure_is_not_failover
+        ] )
+    ]


### PR DESCRIPTION
## 목표

M2의 세 번째 조각: `keeper_canary_run`에 failover 주입을 추가한다. turn N 이후 1차 runtime을 down-cmd로 죽이고, 다음 턴이 디스패치된 뒤 keeper의 runtime-manifest 행으로 무엇이 일어났는지 분류(`in_turn` / `deferred` / `not_observed`)해 evidence에 싣는다.

## 변경

| 파일 | 내용 |
|---|---|
| `lib/keeper_canary/keeper_canary_failover.{ml,mli}` (신규) | runtime-trace `manifest_rows` 파싱 + 분류. 순수 모듈 (HTTP는 bin). attribution은 `decision.runtime_id`(lane walk의 시도 후보) 우선, 없으면 top-level `runtime_id` (#28871). `error_kind`는 `private Error_kind of string` opaque wrapper. 손상된 attribution 행은 skip이 아니라 Error |
| `lib/keeper_canary/keeper_canary_evidence.{ml,mli}` | injections를 closed variant로 재구성 (`Restart \| Failover`), serializer exhaustive match |
| `bin/keeper_canary_run.ml` | `--inject-failover-after N` / `--failover-down-cmd` / `--failover-up-cmd`. restart 주입과 상호 배타 검증. up-cmd 실패는 note (측정은 이미 끝난 뒤이므로 abort 아님) |
| `test/test_keeper_canary_failover.ml` (신규) | 9 tests — parse 3, classify 6 (in_turn, deferred, not_observed, window 필터, same-runtime retry ≠ failover, turn-44 실측 모양의 lane-walk attribution) |
| `test/test_keeper_canary_evidence.ml` | variant 재구성 반영 + failover serialize 테스트 (18 tests) |

## 로컬 검증

- `dune build --root . @test/runtest-test_keeper_canary_failover @test/runtest-test_keeper_canary_evidence` green (9 + 18)
- stringly-boundary-ratchet / ignore-lint / focused-suite alias 등록 확인

## 라이브 receipt (정직한 not_observed 2건)

- `docs/evidence/keeper-canary-failover-sigterm-2026-08-16.json` — SIGTERM smoke
- `docs/evidence/keeper-canary-failover-sigkill-2026-08-16.json` — SIGKILL smoke. :9010 리스너가 없는 구간에 llama_cpp "completed"가 기록됨

두 판정 모두 당시 API wire를 정확히 읽은 결과다. 후속 포렌식으로 확인한 사실: **store에는 attempt 진실(idx·후보 id·error_kind)이 온전히 기록되지만, runtime-trace API의 `decision_public_allowlist`가 그 3키를 벗겨내** failover가 API에서 안 보였다 → #28871 (수리 PR #28875). 실제로 turn 44에서 llama→glm in-turn failover가 일어났고 store 원본이 이를 증명한다. 이 PR의 분류기는 #28875가 배포되면 같은 코드로 `in_turn`을 읽는다 (turn-44 모양 테스트로 고정).

## 미검증 / 후속

- `in_turn` 라이브 receipt: #28875 병합·배포 후 SIGKILL smoke 재실행으로 수확 (M2 완료 기준). 재기동이 sticky lane preference도 초기화하므로 1회차와 같은 조건에서 측정된다