### PR TITLE
fix(runtime): 모든 디스패치 대상에 갈 곳 있는 레인을 준다

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -633,7 +633,6 @@ let run_named
     | None ->
       (match Runtime.resolve_assignment runtime_id with
        | `Missing -> None, []
-       | `Single_runtime runtime -> None, [ runtime.Runtime.id ]
        | `Lane lane ->
          let lane_id = Runtime_lane.id lane in
          ( Some lane_id

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -339,8 +339,20 @@ let validate_lanes ~(config_path : string)
             ~runtime_count:(List.length runtimes) id))
 ;;
 
+(* [runtime].default is required, so every lane can end somewhere. Without this
+   a lane walk stops at its last declared candidate and the turn dies there —
+   failover would exist only where an operator remembered to type a second
+   candidate. Appended rather than substituted: declared order is the
+   operator's, this only says where the walk terminates. *)
+let with_terminal_default ~default_runtime_id candidates =
+  if List.exists (String.equal default_runtime_id) candidates
+  then candidates
+  else candidates @ [ default_runtime_id ]
+;;
+
 let lanes_of_decls ~(config_path : string)
-    ~(dropped_bindings : (string * drop_reason) list) (runtimes : t list)
+    ~(dropped_bindings : (string * drop_reason) list) ~(default_runtime_id : string)
+    (runtimes : t list)
     (lane_decls : Runtime_schema.lane_decl list)
   : (Runtime_lane.t list, string) result
   =
@@ -350,7 +362,8 @@ let lanes_of_decls ~(config_path : string)
        (fun ({ Runtime_schema.id; strategy; candidate_ids } : Runtime_schema.lane_decl) ->
           match strategy with
           | Runtime_schema.Ordered ->
-            Runtime_lane.make ~id ~strategy:Runtime_lane.Ordered candidate_ids)
+            Runtime_lane.make ~id ~strategy:Runtime_lane.Ordered
+              (with_terminal_default ~default_runtime_id candidate_ids))
        lane_decls)
 ;;
 
@@ -1113,7 +1126,8 @@ let materialize_config
      name a lane (#25394); candidate resolution is enforced by [validate_lanes]
      inside [lanes_of_decls]. *)
   let* lanes =
-    lanes_of_decls ~config_path ~dropped_bindings runtimes cfg.lane_decls
+    lanes_of_decls ~config_path ~dropped_bindings ~default_runtime_id:rt.id runtimes
+      cfg.lane_decls
   in
   (* One list in the order the errors surface: the route, then media_failover. *)
   let* () =
@@ -1400,16 +1414,26 @@ let max_context_of_runtime (rt : t) : int =
          rt.id)
 ;;
 
-(* Resolve a keeper assignment to either a lane or a single runtime. Lanes are
-   preferred so a lane id can shadow a runtime id (lanes are explicit operator
-   routing constructs). [Missing] means the assignment does not name a known
-   lane or runtime. *)
+(* Resolve a keeper assignment to a lane. Declared lanes are preferred so a lane
+   id can shadow a runtime id (lanes are explicit operator routing constructs).
+   An assignment naming a bare runtime gets a lane of its own rather than a
+   bare dispatch target: the lane id is what keys sticky preference and quota
+   demotion, so without one those mechanisms are simply off for that keeper.
+   [Missing] means the assignment does not name a known lane or runtime. *)
 let resolve_assignment (assigned_id : string) =
   match get_lane_by_id assigned_id with
   | Some lane -> `Lane lane
   | None ->
     (match get_runtime_by_id assigned_id with
-     | Some runtime -> `Single_runtime runtime
+     | Some runtime ->
+       let candidates =
+         match get_default_runtime () with
+         | Some default ->
+           with_terminal_default ~default_runtime_id:default.id [ runtime.id ]
+         | None -> [ runtime.id ]
+       in
+       `Lane
+         (Runtime_lane.make ~id:runtime.id ~strategy:Runtime_lane.Ordered candidates)
      | None -> `Missing)
 ;;
 

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -311,11 +311,12 @@ val lanes : unit -> Runtime_lane.t list
 val get_lane_by_id : string -> Runtime_lane.t option
 (** Lane with the given id, or [None] if no such lane is configured. *)
 
-val resolve_assignment :
-  string -> [ `Lane of Runtime_lane.t | `Single_runtime of t | `Missing ]
-(** Resolve a keeper assignment id to either a lane or a single runtime. Lanes
-    shadow runtimes. [Missing] means the id does not name a known lane or
-    runtime. *)
+val resolve_assignment : string -> [ `Lane of Runtime_lane.t | `Missing ]
+(** Resolve a keeper assignment id to a lane. Declared lanes shadow runtimes;
+    an id naming a bare runtime gets a lane of its own, because the lane id is
+    what keys sticky candidate preference and quota demotion. Every lane ends
+    at [\[runtime\].default], so a walk always has a next candidate.
+    [Missing] means the id does not name a known lane or runtime. *)
 
 val get_runtime_by_id : string -> t option
 (** [get_runtime_by_id id] is the materialized runtime whose binding-key id

--- a/lib/server/server_dashboard_runtime_resolved_json.ml
+++ b/lib/server/server_dashboard_runtime_resolved_json.ml
@@ -66,13 +66,11 @@ let lane_json (lane : Runtime_lane.t) : Yojson.Safe.t =
     ]
 ;;
 
-let resolved_assignment_json
-      (resolution : [ `Lane of Runtime_lane.t | `Single_runtime of Runtime.t | `Missing ])
+let resolved_assignment_json (resolution : [ `Lane of Runtime_lane.t | `Missing ])
   : Yojson.Safe.t
   =
   match resolution with
   | `Lane lane -> `Assoc [ "kind", `String "lane"; "id", `String (Runtime_lane.id lane) ]
-  | `Single_runtime rt -> `Assoc [ "kind", `String "single_runtime"; "id", `String rt.id ]
   | `Missing -> `Assoc [ "kind", `String "missing"; "id", `Null ]
 ;;
 
@@ -81,13 +79,16 @@ let resolved_assignment_json
    Duplicating that exact fallback here (rather than only reporting explicit
    assignments) is bug #14's fix — the resolved document must match what a
    turn actually dispatches to. *)
+let assignment_target (default : Runtime.t option) (keeper_name : string)
+  : string * string option
+  =
+  match Runtime.runtime_id_for_keeper keeper_name with
+  | Some id when String.trim id <> "" -> "explicit", Some (String.trim id)
+  | Some _ | None -> "default", Option.map (fun (rt : Runtime.t) -> rt.id) default
+;;
+
 let assignment_json (default : Runtime.t option) (keeper_name : string) : Yojson.Safe.t =
-  let explicit_id = Runtime.runtime_id_for_keeper keeper_name in
-  let assignment_source, runtime_id =
-    match explicit_id with
-    | Some id when String.trim id <> "" -> "explicit", Some (String.trim id)
-    | Some _ | None -> "default", Option.map (fun (rt : Runtime.t) -> rt.id) default
-  in
+  let assignment_source, runtime_id = assignment_target default keeper_name in
   let resolved =
     match runtime_id with
     | Some id -> resolved_assignment_json (Runtime.resolve_assignment id)
@@ -110,6 +111,29 @@ let all_keeper_names ~(config : Workspace.config) : string list =
   assigned @ registered |> List.sort_uniq String.compare
 ;;
 
+(* Declared lanes plus the lanes an assignment resolves to on its own. A keeper
+   assigned to a bare runtime id dispatches through a lane that no
+   [\[runtime.lanes\]] table declares, and reporting only declared lanes would
+   hide that lane's candidates from the document that is supposed to say what
+   dispatch will do. *)
+let dispatchable_lanes ~(config : Workspace.config) (default : Runtime.t option)
+  : Runtime_lane.t list
+  =
+  let declared = Runtime.lanes () in
+  let seen = List.map Runtime_lane.id declared in
+  let implicit =
+    all_keeper_names ~config
+    |> List.filter_map (fun keeper -> snd (assignment_target default keeper))
+    |> List.filter_map (fun id ->
+      match Runtime.resolve_assignment id with
+      | `Lane lane when not (List.mem (Runtime_lane.id lane) seen) -> Some lane
+      | `Lane _ | `Missing -> None)
+    |> List.sort_uniq (fun a b ->
+      String.compare (Runtime_lane.id a) (Runtime_lane.id b))
+  in
+  declared @ implicit
+;;
+
 let build ~generated_at_iso ~(config : Workspace.config) : Yojson.Safe.t =
   let default = Runtime.get_default_runtime () in
   `Assoc
@@ -121,7 +145,7 @@ let build ~generated_at_iso ~(config : Workspace.config) : Yojson.Safe.t =
         | Some rt -> runtime_resolution_json rt
         | None -> `Null )
     ; "runtimes", `List (List.map runtime_resolution_json (Runtime.get_runtimes ()))
-    ; "lanes", `List (List.map lane_json (Runtime.lanes ()))
+    ; "lanes", `List (List.map lane_json (dispatchable_lanes ~config default))
     ; ( "assignments"
       , `List (List.map (assignment_json default) (all_keeper_names ~config)) )
     ]

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -477,24 +477,43 @@ let test_resolve_assignment_prefers_lane_over_runtime () =
   with_runtime_config runtime_toml_lane_shadows_runtime (fun () ->
     match Runtime.resolve_assignment "primary.test_model" with
     | `Missing -> Alcotest.fail "expected assignment to resolve"
-    | `Single_runtime _ -> Alcotest.fail "expected lane to shadow runtime"
     | `Lane lane ->
       Alcotest.(check string)
         "lane id shadows runtime id"
         "primary.test_model"
         (Runtime_lane.id lane);
       Alcotest.(check (list string))
-        "lane candidates"
-        [ "fallback.test_model" ]
+        "declared candidates keep their order, then the default terminates"
+        [ "fallback.test_model"; "primary.test_model" ]
         (Runtime_lane.ordered_candidates lane))
 
-let test_resolve_assignment_to_single_runtime () =
+(* A keeper assigned to a bare runtime id used to dispatch without a lane, which
+   turned off failover, sticky candidate preference and quota demotion at once.
+   It now gets a lane of its own that ends at [runtime].default. *)
+let test_bare_runtime_assignment_gets_a_lane_with_somewhere_to_go () =
   with_runtime_config runtime_toml_with_lane (fun () ->
     match Runtime.resolve_assignment "fallback.test_model" with
     | `Missing -> Alcotest.fail "expected runtime to resolve"
-    | `Lane _ -> Alcotest.fail "expected single runtime, not lane"
-    | `Single_runtime rt ->
-      Alcotest.(check string) "runtime id" "fallback.test_model" rt.Runtime.id)
+    | `Lane lane ->
+      Alcotest.(check string)
+        "lane is named after the runtime it was assigned"
+        "fallback.test_model"
+        (Runtime_lane.id lane);
+      Alcotest.(check (list string))
+        "the assigned runtime is head, the default terminates the walk"
+        [ "fallback.test_model"; "primary.test_model" ]
+        (Runtime_lane.ordered_candidates lane))
+
+(* The default must not be appended twice when a lane already names it. *)
+let test_lane_already_naming_the_default_is_unchanged () =
+  with_runtime_config runtime_toml_with_lane (fun () ->
+    match Runtime.resolve_assignment "resilient" with
+    | `Missing -> Alcotest.fail "expected lane to resolve"
+    | `Lane lane ->
+      Alcotest.(check (list string))
+        "declared candidates already terminate at the default"
+        [ "primary.test_model"; "fallback.test_model" ]
+        (Runtime_lane.ordered_candidates lane))
 
 let test_attempt_inference_policy_uses_attempt_runtime () =
   with_model_catalog_content runtime_thinking_lane_model_catalog @@ fun () ->
@@ -547,8 +566,7 @@ let test_resolve_assignment_missing () =
   with_runtime_config runtime_toml_with_lane (fun () ->
     match Runtime.resolve_assignment "not.configured" with
     | `Missing -> ()
-    | `Single_runtime _ | `Lane _ ->
-      Alcotest.fail "expected missing assignment")
+    | `Lane _ -> Alcotest.fail "expected missing assignment")
 
 let runtime_toml_assignment_to_lane =
   {|
@@ -761,7 +779,7 @@ let test_deferred_tail_rejects_transformed_uncapped_runtime () =
 let test_lane_media_degrade_uses_first_candidate_runtime_id () =
   with_runtime_config runtime_toml_with_lane (fun () ->
     match Runtime.resolve_assignment "resilient" with
-    | `Missing | `Single_runtime _ ->
+    | `Missing ->
       Alcotest.fail "expected resilient assignment to resolve to a lane"
     | `Lane lane ->
       let first_candidate_id =
@@ -984,7 +1002,7 @@ let test_text_official_client_history_stays_admissible () =
 let test_lane_media_reroute_stays_within_lane () =
   with_runtime_config runtime_toml_media_lane_with_global_outside (fun () ->
     match Runtime.resolve_assignment "resilient" with
-    | `Missing | `Single_runtime _ ->
+    | `Missing ->
       Alcotest.fail "expected resilient assignment to resolve to a lane"
     | `Lane lane ->
       let first_candidate_id, remaining_candidate_ids =
@@ -2167,9 +2185,13 @@ let () =
             `Quick
             test_resolve_assignment_prefers_lane_over_runtime;
           Alcotest.test_case
-            "resolve_assignment returns single runtime"
+            "a bare runtime assignment gets a lane with somewhere to go"
             `Quick
-            test_resolve_assignment_to_single_runtime;
+            test_bare_runtime_assignment_gets_a_lane_with_somewhere_to_go;
+          Alcotest.test_case
+            "a lane already naming the default is unchanged"
+            `Quick
+            test_lane_already_naming_the_default_is_unchanged;
           Alcotest.test_case
             "resolve_assignment reports missing id"
             `Quick


### PR DESCRIPTION
원칙 2 — "Runtime Failover 기능은 자연스러워야 하며" — 를 닫는다.

## 실측: failover 는 손으로 적어둔 곳에만 있었다

라이브 `GET /api/v1/runtime/resolved` 기준.

| 배정 | 인원 | failover |
|---|---|---|
| `claude_code.claude-sonnet-5` | 2 | **불가** (후보 1개) |
| `codex_subscription.gpt-5.4` | 1 | **불가** (레인 없음) |
| `local_llama_server.qwen3-8-27b-mlx` | 1 | **불가** (레인 없음) |
| 나머지 | 34 | 후보 2개 |

레인 12개 중 **5개가 후보 1개**.

## 기전

```ocaml
| `Single_runtime runtime -> None, [ runtime.Runtime.id ]
```

`lane_id = None` 이면 **셋이 한꺼번에 꺼진다**:

- `Runtime_lane_preference.prefer_order` — sticky 후보 기억 없음
- `demote_quota_exhausted` — 소진된 계정 강등 없음
- `rest = []` — 레인 워크가 갈 곳 없음

셋 다 조용히 꺼지고, 어느 화면에도 안 나온다.

## 무엇을 했나

`` `Single_runtime `` 갈래를 삭제한다. 런타임 id 배정은 그 이름의 레인으로 해석되고, 선언 레인이든 암묵 레인이든 **`[runtime].default` 에서 끝난다.** 파서가 이미 `[runtime].default is required` 를 강제하므로 종착지는 항상 존재한다.

선언 순서는 안 건드린다. 워크가 어디서 끝나는지만 정한다.

```ocaml
let with_terminal_default ~default_runtime_id candidates =
  if List.exists (String.equal default_runtime_id) candidates
  then candidates
  else candidates @ [ default_runtime_id ]
```

resolved 문서는 선언 레인 + 배정이 스스로 만드는 레인을 함께 보고한다. `[runtime.lanes]` 에 없는 레인도 후보까지 보인다 (원칙 11).

## 설계 판단

기본값을 **모든** 레인 끝에 붙이므로, opus 에 붙은 keeper 가 타임아웃 시 deepseek 으로 답할 수 있다. 원칙 12 의 "턴이 이어지지 않으면 실패" 를 "함대가 한 런타임으로 수렴할 위험" 보다 위에 둔 선택이다. exact-output 은 `[runtime.exact_output_lanes]` 라는 별도 decl 목록과 별도 레지스트리(`Runtime_exact_output_registry.publish ~lanes:exact_output_lane_decl list`)를 쓰므로 이 변경의 영향을 받지 않는다.

핀 고정이 필요해지면 그때 넣는다 (원칙 7).

## 검증

로컬, 워크트리 고정(`--root .`):

| | 결과 |
|---|---|
| `dune build @check` | exit 0 |
| `test_keeper_turn_driver_failover` | exit 0 — 46 tests |
| `test_keeper_runtime_resolved_observability` | exit 0 |
| `test_runtime_toml_overrides` | exit 0 |
| `test_runtime_config_validity` | exit 0 |

테스트 변경:
- `resolve_assignment returns single runtime` 삭제 — 없어진 동작의 회귀 테스트다 (원칙 20).
- `a bare runtime assignment gets a lane with somewhere to go` 추가.
- `a lane already naming the default is unchanged` 추가 — 기본값 중복 append 방지.

## 병합 후 실측 예정

배포 후 `GET /api/v1/runtime/resolved` 에서 위 표의 4명이 후보 2개가 되는지 확인하고, 대시보드 스크린샷을 붙인다.

그리고 어제 손으로 넣은 `runtime.toml` 의 antigravity 두 번째 후보를 **되돌린다.** 그게 이 PR 의 진짜 증명이다 — 코드가 같은 결과를 만들면 손으로 적을 이유가 없다.
