### PR TITLE
fix(keeper): last-resort demotion when the newest atom exceeds the input budget (#28845)

### DIFF
--- a/docs/rfc/RFC-0351-memory-first-context-management-compaction-sunset.md
+++ b/docs/rfc/RFC-0351-memory-first-context-management-compaction-sunset.md
@@ -63,6 +63,8 @@ L5 Budget  매턴 조립 예산: keeper + dynamic + Select 결과 + 최근 창(�
 | assistant/user text | 의미 콘텐츠 — L1/L2가 memory로 추출, 최근 창 밖에서는 조립에서 제외 | |
 | wake marker 등 무정보 자극 | **비영속** — §5 | analyst ×359 |
 
+tool_result 의 사이클 스코프에는 최후예외가 하나 있다 (#28845): tail-window cut 이 `Newest_atom_exceeds_available` 로 거부될 때 — 최신 원자가 분할 불가능한 채로 히스토리 예산 전체보다 클 때 — 조립은 경계를 최신 원자 너머로 옮겨 딱 한 번 재시도한다. 이번 턴이 막 생산한 결과도 마커로 강등되어 나간다. 턴을 실패시키는 것보다 주소로 남기는 쪽이 낫다는 판단이며, 그 외의 경로에서는 현재 턴 제외가 그대로 유지된다.
+
 Provider별 replay 정책이 `Preserve_always`로 선언된 모델(예: mimo 계열)은 공식 문서 재검증 후 turn-스코프 정책으로 교정한다(OAS capability 데이터 정정, 별도 검증 진행 중). 문서가 실제로 cross-turn replay를 요구하면 예외로 존중한다.
 
 ## 5. Persistence 정책 — 무정보 턴은 영구 transcript를 만들지 않는다 (#25462)

--- a/docs/rfc/RFC-0363-historical-tool-result-demotion.md
+++ b/docs/rfc/RFC-0363-historical-tool-result-demotion.md
@@ -75,7 +75,7 @@ RFC-0351 §4 타입 수명이 이미 이 줄을 적어놓았다:
 
 ```
 raw = project_with_drop ~measure_message_bytes ~capacity_bytes ~reserved_bytes messages
-demote ~demote_before:raw.dropped_atoms messages
+demote ~demote_before:(* §3.4.1: 현재 턴의 첫 원자 *) messages
   |> project_with_drop ~measure_message_bytes ~capacity_bytes ~reserved_bytes
 ```
 
@@ -87,7 +87,7 @@ demote ~demote_before:raw.dropped_atoms messages
    `api_common.ml:304-321` — `content_blocks = Some blocks` 이면 `content` 는 **직렬화되지 않는다**. 그런 메시지의 `content` 를 마커로 바꾸면 크기가 전혀 줄지 않는데 추정기는 감소를 계상한다. 즉 추정이 **하한**이 되어, window 가 과소평가로 cut 하고 물질화된 요청이 예산을 넘는다. `Some` 은 이미지·문서를 담으며 마커로 표현할 수도 없다.
 2. `Tool_output.decode_from_oas content = Not_marker`
    `Decoded` 는 이미 강등된 것이고, **`Invalid_marker` 는 강등하지 않는다** — 마커 모양인데 파싱에 실패한 payload 를 blob 으로 다시 저장하면 손상을 고착시킨다. 세 경우를 exhaustive match 로 다룬다.
-3. 원자 인덱스 < 원문 projection 의 `dropped_atoms`
+3. 원자 인덱스 < `demote_before` 경계 (§3.4.1: 현재 턴의 첫 원자. 최후예외 시에는 최신 원자 너머)
 4. `upper_bound_demoted_bytes msg < measure_message_bytes msg`
 
 판단은 (a) 타입, (b) 정수 비교, (c) 바이트 비교뿐이다. 중요도 점수·문자열 분류·휴리스틱 임계값 없음 (RFC-0351 §2 원칙 2).
@@ -136,6 +136,12 @@ where saturating_ref = make_artifact_ref
 3. 줄어든 메시지로 최종 cut을 다시 계산한다.
 
 따라서 demotion 경계는 원문 cut이 움직일 때만 움직인다. 양자화 cut이 60으로 유지되는 동안 새 turn을 붙여도 같은 60개만 마커이고, 60 → 120으로 뛰는 순간 새 60개가 바뀌지만 그 원자들은 원문 요청에서도 바로 그 jump에 탈락한다. demotion이 prompt-cache 변경 빈도를 늘리지 않는다. exact cut fallback에서도 동일하다. raw cut이 매 turn 움직이는 상황에서는 demotion도 움직이지만, 원문 prefix가 이미 같은 빈도로 움직인다.
+
+### 3.4.1 개정 — 경계는 현재 턴이다 (#28739), 최후예외 하나 (#28845)
+
+구현은 위 원문-cut 고정에서 **현재 턴의 첫 원자** 경계(RFC-0351 §4 사이클 스코프)로 옮겨졌다 (#28739). 이전 턴의 결과는 이미 receipt/보드 포스트로 보고됐으므로, 원문 cut 이 유지한 이전-턴 원자도 강등 대상이다 — 이것이 §1.1 "예산당 원자 수" 이득의 실제 원천이다. 경계는 턴당 한 번만 움직이므로 위 prompt-cache 논증은 그대로 성립한다.
+
+**최후예외 (#28845)**: 원문 cut 이 `Newest_atom_exceeds_available` 로 거부되는 경우 — 최신 원자가 분할 불가능한 채 히스토리 예산 전체보다 큰 경우 — 에는 고정할 원문 cut 이 존재하지 않는다. 이때 조립은 경계를 최신 원자 너머(`demote_before = atom_count`)로 옮겨 **딱 한 번** 재시도한다. 현재 턴 제외는 이 시도에서만 해제되고, 현재 턴의 tool 결과도 마커로 강등되어 나간다. 강등할 것이 없거나 강등 후에도 초과면 typed 거부가 그대로다 — 재시도 루프가 아니다.
 
 ### 3.5 물질화와 실패
 

--- a/lib/keeper/keeper_model_input_demotion.mli
+++ b/lib/keeper/keeper_model_input_demotion.mli
@@ -23,7 +23,8 @@
     transmitted list is rebuilt from durable state every turn, so demoting
     everything eagerly would re-store thousands of blobs per turn. Instead
     the unmodified history first chooses the authoritative window cut. {!plan}
-    substitutes a saturating placeholder only below that cut, the window cuts
+    substitutes a saturating placeholder below the caller's age boundary (the
+    keeper's assembly uses the current turn, see {!plan}), the window cuts
     again against the smaller messages, and {!materialize} stores only the
     messages that survived. The real marker is never larger than the
     placeholder, so a request that fit the plan still fits after
@@ -68,7 +69,11 @@ val plan
       cache, so callers pick one that moves at the rate the conversation
       itself does. The keeper's assembly uses the turn — results the current
       turn produced are what it is reasoning over, results from earlier turns
-      were already reported elsewhere — which moves once per turn.
+      were already reported elsewhere — which moves once per turn. One
+      exception: when the raw cut refuses because the newest atom alone
+      exceeds the budget, the assembly retries once with the boundary past
+      the newest atom, so the turn's own results leave as markers rather than
+      failing the turn (#28845).
     - the placeholder measures strictly smaller than the message does now.
       This replaces a size threshold: the encoded marker runs from about 125
       bytes to 1,154 depending on the preview's bytes, because

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -551,7 +551,17 @@ let plan_and_window_model_input
     let planned = plan ~demote_before:atom_count in
     (match planned.Keeper_model_input_demotion.pending with
      | [] -> Error first_error
-     | _ -> cut_planned planned atom_count)
+     | _ ->
+       (match cut_planned planned atom_count with
+        | Ok _ as ok -> ok
+        | Error
+            (Runtime_model_input_tail_window.Newest_atom_exceeds_available _) ->
+          (* The re-cut measured the placeholder-saturated atom, so its
+             [newest_atom_bytes] reports marker sizes and masks the true
+             magnitude. Re-raise the refusal measured against the real
+             bytes. *)
+          Error first_error
+        | Error _ as error -> error))
   | Error error -> Error error
   | Ok raw_projection ->
     let planned = plan ~demote_before in

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -488,6 +488,79 @@ let declared_request_reserve_bytes ~capacity_bytes ~system_prompt ~tools =
   + (capacity_bytes / unmeasured_request_reserve_divisor)
 ;;
 
+(* RFC-0363: the unmodified history chooses the authoritative cut first.
+   Demotion then rewrites the atoms older than the current turn — the
+   [demote_before] boundary the caller computes from [ctx.initial_messages]
+   (RFC-0351 §4) — and the window cuts again against the smaller messages.
+   Because that boundary moves once per turn, appending a message mid-turn
+   cannot rewrite the transmitted prefix. The [history_atom_count] result is
+   the atom count of that first cut — the only one taken against the whole
+   history; every later cut sees a list that has already been shortened — so
+   the reported share keeps that denominator.
+
+   #28845: with one exception. When the raw cut refuses with
+   [Newest_atom_exceeds_available], the newest atom is indivisible and larger
+   than the whole history budget, so no cut exists and there is no boundary to
+   anchor to. The composition is retried once with the demotion boundary moved
+   past the newest atom ([demote_before = atom_count]), lifting the RFC-0351
+   §4 current-turn exclusion for that attempt only: the turn's own tool
+   results are replaced by their externalized markers instead of failing the
+   turn. If the atom carries nothing demotable, or still does not fit once
+   demoted, the typed refusal stands — this is a single last-resort attempt,
+   not a retry loop. *)
+let plan_and_window_model_input
+      ~measure_message_bytes
+      ~capacity_bytes
+      ~reserved_bytes
+      ~base_path
+      ~demote_before
+      messages
+  =
+  let raw_cut candidate =
+    Runtime_model_input_tail_window.project_with_drop
+      ~measure_message_bytes
+      ~capacity_bytes
+      ~reserved_bytes
+      candidate
+  in
+  let plan ~demote_before =
+    if String.equal base_path "" || demote_before = 0
+    then { Keeper_model_input_demotion.messages; pending = [] }
+    else
+      Keeper_model_input_demotion.plan
+        ~measure_message_bytes
+        ~demote_before
+        messages
+  in
+  let cut_planned (planned : Keeper_model_input_demotion.plan_result) history_atom_count =
+    match raw_cut planned.Keeper_model_input_demotion.messages with
+    | Error _ as error -> error
+    | Ok windowed -> Ok (planned, windowed, history_atom_count)
+  in
+  match raw_cut messages with
+  | Error
+      (Runtime_model_input_tail_window.Newest_atom_exceeds_available _ as
+       first_error) ->
+    (* #28845: no cut exists, so there is no raw-cut boundary to anchor
+       demotion to. Retry the composition once with the boundary moved past
+       the newest atom — lifting the RFC-0351 §4 current-turn exclusion for
+       this attempt only — so the turn's own results leave as externalized
+       markers instead of failing the turn. Nothing demotable, or still
+       oversized once demoted, keeps the typed refusal. *)
+    let _, atom_count = Runtime_model_input_tail_window.annotate messages in
+    let planned = plan ~demote_before:atom_count in
+    (match planned.Keeper_model_input_demotion.pending with
+     | [] -> Error first_error
+     | _ -> cut_planned planned atom_count)
+  | Error error -> Error error
+  | Ok raw_projection ->
+    let planned = plan ~demote_before in
+    let history_atom_count = raw_projection.atom_count in
+    (match planned.Keeper_model_input_demotion.pending with
+     | [] -> Ok (planned, raw_projection, history_atom_count)
+     | _ -> cut_planned planned history_atom_count)
+;;
+
 (* The bounded transmission view runs here rather than in the caller because
    its budget is [ctx.model_input_capacity_bytes], which
    [Keeper_turn_driver.validate_provider_request_cap] resolves per runtime
@@ -579,57 +652,41 @@ let budgeted_model_input_projection
     in
     let planned_and_windowed =
       offload_model_input_cpu (fun () ->
-        let raw_cut candidate =
-          Runtime_model_input_tail_window.project_with_drop
+        (* RFC-0351 §4: a tool result is cycle-scoped. What the keeper is
+           reasoning over right now is what this turn produced, and
+           [ctx.initial_messages] is exactly the history the turn was seeded
+           with — so everything past it is this turn's own work and stays
+           verbatim, and everything before it was already reported through a
+           receipt or a board post and becomes a readable address.
+
+           This is a boundary rather than a count of recent results. It also
+           keeps the property the previous boundary was chosen for: appending
+           a message cannot rewrite the retained prefix, because it moves
+           once per turn rather than once per message.
+
+           One exception, exercised only when no cut exists at all: when the
+           raw cut refuses with [Newest_atom_exceeds_available],
+           [plan_and_window_model_input] retries once with the boundary moved
+           past the newest atom, demoting this turn's own results into their
+           externalized markers rather than failing the turn (#28845). *)
+        let demote_before =
+          Runtime_model_input_tail_window.first_atom_at_or_after
+            messages
+            ~message_index:(List.length ctx.initial_messages)
+        in
+        match
+          plan_and_window_model_input
             ~measure_message_bytes
             ~capacity_bytes:ctx.model_input_capacity_bytes
             ~reserved_bytes
-            candidate
-        in
-        (* RFC-0363: the unmodified history chooses the authoritative cut first.
-           Demotion rewrites only atoms omitted by that cut, so appending a turn
-           cannot move the rewrite boundary unless the raw cut itself moves. *)
-        match raw_cut messages with
+            ~base_path:ctx.base_path
+            ~demote_before
+            messages
+        with
         | Error error ->
           Error (Runtime_model_input_tail_window.budget_error_to_string error)
-        | Ok raw_projection ->
-          (* RFC-0351 §4: a tool result is cycle-scoped. What the keeper is
-             reasoning over right now is what this turn produced, and
-             [ctx.initial_messages] is exactly the history the turn was seeded
-             with — so everything past it is this turn's own work and stays
-             verbatim, and everything before it was already reported through a
-             receipt or a board post and becomes a readable address.
-
-             This is a boundary rather than a count of recent results. It also
-             keeps the property the previous boundary was chosen for: appending
-             a message cannot rewrite the retained prefix, because it moves
-             once per turn rather than once per message. *)
-          let demote_before =
-            Runtime_model_input_tail_window.first_atom_at_or_after
-              messages
-              ~message_index:(List.length ctx.initial_messages)
-          in
-          let planned =
-            if String.equal ctx.base_path "" || demote_before = 0
-            then { Keeper_model_input_demotion.messages; pending = [] }
-            else
-              Keeper_model_input_demotion.plan
-                ~measure_message_bytes
-                ~demote_before
-                messages
-          in
-          (* The first cut is the only one taken against the whole history;
-             every later cut sees a list that has already been shortened. Carry
-             its atom count so the reported share keeps that denominator. *)
-          let history_atom_count = raw_projection.atom_count in
-          (match planned.Keeper_model_input_demotion.pending with
-           | [] -> Ok (planned, raw_projection, history_atom_count)
-           | _ ->
-             (match raw_cut planned.Keeper_model_input_demotion.messages with
-              | Error error ->
-                Error
-                  (Runtime_model_input_tail_window.budget_error_to_string error)
-              | Ok windowed -> Ok (planned, windowed, history_atom_count))))
+        | Ok (planned, windowed, history_atom_count) ->
+          Ok (planned, windowed, history_atom_count))
     in
     let windowed =
       match planned_and_windowed with
@@ -1092,6 +1149,7 @@ module For_testing = struct
   let apply_accept = apply_accept
   let observe_request_wire_error = observe_request_wire_error
   let memoize_message_measurement = memoize_message_measurement
+  let plan_and_window_model_input = plan_and_window_model_input
   let offload_model_input_cpu = offload_model_input_cpu
   let context_overflow_shrink_max_attempts = context_overflow_shrink_max_attempts
   let context_overflow_shrink_divisor = context_overflow_shrink_divisor

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -208,6 +208,19 @@ module For_testing : sig
   val memoize_message_measurement :
     (Agent_core.Types.message -> int) -> Agent_core.Types.message -> int
 
+  val plan_and_window_model_input :
+    measure_message_bytes:(Agent_core.Types.message -> int) ->
+    capacity_bytes:int ->
+    reserved_bytes:int ->
+    base_path:string ->
+    demote_before:int ->
+    Agent_core.Types.message list ->
+    (Keeper_model_input_demotion.plan_result
+     * Runtime_model_input_tail_window.projection
+     * int,
+     Runtime_model_input_tail_window.budget_error)
+    result
+
   val offload_model_input_cpu : (unit -> 'a) -> 'a
 
   val context_overflow_shrink_max_attempts : int

--- a/test/test_keeper_model_input_demotion.ml
+++ b/test/test_keeper_model_input_demotion.ml
@@ -579,6 +579,50 @@ let last_resort_requires_a_blob_store () =
   | Error error -> Alcotest.fail (Window.budget_error_to_string error)
 ;;
 
+(* Demotion can shrink an atom only down to its non-demotable residue. When
+   that residue alone exceeds the budget, the last resort still refuses — and
+   the refusal must carry the atom's true bytes, not the placeholder-saturated
+   measurement the re-cut saw. *)
+let still_oversized_after_demotion_reports_true_magnitude () =
+  let earlier = history_with_tool_bodies [ "tick" ] in
+  let residue = assistant (String.make 50_000 'x') in
+  let newest =
+    residue
+    :: [ tool_message ~id:"big-0" (String.make 4_000 'a')
+       ; tool_message ~id:"big-1" (String.make 4_000 'b')
+       ]
+  in
+  let messages = earlier @ newest in
+  let _, atom_count = Window.annotate messages in
+  (* [plan] is pure, so this probe is exactly the plan the last-resort arm
+     computes: it proves the composition took the demotion branch and still
+     refused, rather than refusing for want of anything demotable. *)
+  let probe =
+    Demotion.plan ~measure_message_bytes ~demote_before:atom_count messages
+  in
+  Alcotest.(check int)
+    "the atom carries demotable results, so the last resort planned demotions"
+    2
+    (List.length probe.Demotion.pending);
+  (* [capacity] admits neither the raw atom nor its demoted residue: even the
+     assistant text alone overruns the budget once the preamble is charged. *)
+  let capacity_bytes = bytes_of [ residue ] in
+  match
+    compose
+      ~base_path:(Filename.temp_dir "demote" "")
+      ~capacity_bytes
+      ~demote_before:1
+      messages
+  with
+  | Ok _ -> Alcotest.fail "the residue alone exceeds the budget"
+  | Error (Window.Newest_atom_exceeds_available { newest_atom_bytes; _ }) ->
+    Alcotest.(check int)
+      "the refusal carries the atom's true bytes, not the demoted measurement"
+      (bytes_of newest)
+      newest_atom_bytes
+  | Error error -> Alcotest.fail (Window.budget_error_to_string error)
+;;
+
 let () =
   Alcotest.run
     "keeper_model_input_demotion"
@@ -642,6 +686,10 @@ let () =
             "last resort requires a blob store"
             `Quick
             last_resort_requires_a_blob_store
+        ; Alcotest.test_case
+            "still oversized after demotion reports the true magnitude"
+            `Quick
+            still_oversized_after_demotion_reports_true_magnitude
         ] )
     ]
 ;;

--- a/test/test_keeper_model_input_demotion.ml
+++ b/test/test_keeper_model_input_demotion.ml
@@ -438,6 +438,147 @@ let projection_reuses_candidate_measurements () =
     !raw_measurements
 ;;
 
+(* --- 7. Last resort: the newest atom does not fit (#28845) ------------- *)
+
+(* The sangsu incident shape: parallel WebSearch results joined the assistant
+   atom that called them, and that one atom (indivisible to the tail window)
+   outgrew the whole history budget. Ordinary demotion cannot help — its
+   boundary excludes the current turn (RFC-0351 §4) — so composition refused
+   the turn outright. The last-resort path retries the composition once with
+   the boundary moved past the newest atom, and the turn's own results leave
+   as externalized markers instead of the turn failing. *)
+module Try_provider = Masc.Keeper_turn_driver_try_provider
+
+let compose ~base_path ~capacity_bytes ~demote_before messages =
+  Try_provider.For_testing.plan_and_window_model_input
+    ~measure_message_bytes
+    ~capacity_bytes
+    ~reserved_bytes:0
+    ~base_path
+    ~demote_before
+    messages
+;;
+
+let bytes_of messages =
+  List.fold_left (fun acc m -> acc + measure_message_bytes m) 0 messages
+;;
+
+let newest_bodies = [ 24_000; 31_000; 47_000; 7_000 ]
+
+let oversized_newest_history () =
+  (* Earlier atoms carry tiny bodies, so nothing below the turn boundary is
+     demotable and every pending entry the composition produces belongs to the
+     newest atom. *)
+  let earlier = history_with_tool_bodies [ "tick"; "tock" ] in
+  let newest =
+    assistant "search batch"
+    :: List.mapi
+         (fun i size ->
+            tool_message
+              ~id:(Printf.sprintf "search-%d" i)
+              (String.make size (Char.chr (Char.code 'a' + i))))
+         newest_bodies
+  in
+  earlier, earlier @ newest, bytes_of newest
+;;
+
+let oversized_newest_atom_is_demoted_as_last_resort () =
+  let earlier, messages, newest_bytes = oversized_newest_history () in
+  (* [capacity] admits the newest atom only demoted: the raw history budget is
+     exactly the atom's own bytes, which the charged preamble pushes over. *)
+  let capacity_bytes = newest_bytes in
+  let demote_before =
+    Window.first_atom_at_or_after
+      messages
+      ~message_index:(List.length earlier)
+  in
+  let store = Tool_blob_store.create ~base_path:(Filename.temp_dir "demote" "") in
+  (match
+     Window.project_with_drop
+       ~measure_message_bytes
+       ~capacity_bytes
+       ~reserved_bytes:0
+       messages
+   with
+   | Error (Window.Newest_atom_exceeds_available _) -> ()
+   | Error error -> Alcotest.fail (Window.budget_error_to_string error)
+   | Ok _ -> Alcotest.fail "fixture must not fit without the last resort");
+  match
+    compose
+      ~base_path:(Filename.temp_dir "demote" "")
+      ~capacity_bytes
+      ~demote_before
+      messages
+  with
+  | Error error -> Alcotest.fail (Window.budget_error_to_string error)
+  | Ok (planned, windowed, history_atom_count) ->
+    Alcotest.(check int)
+      "each of the newest atom's results is demoted"
+      (List.length newest_bodies)
+      (List.length planned.Demotion.pending);
+    Alcotest.(check int)
+      "the denominator is still the whole history"
+      3
+      history_atom_count;
+    let outcome =
+      Demotion.materialize ~store ~pending:planned.Demotion.pending windowed.Window.messages
+    in
+    Alcotest.(check int) "a healthy store reverts nothing" 0 outcome.Demotion.reverted;
+    let transmitted = markers outcome.Demotion.messages in
+    List.iteri
+      (fun i size ->
+         let body = String.make size (Char.chr (Char.code 'a' + i)) in
+         Alcotest.(check bool)
+           (Printf.sprintf "body %d left as a reference, not its bytes" i)
+           false
+           (List.exists (String.equal body) transmitted))
+      newest_bodies;
+    Alcotest.(check int)
+      "the references are readable blob markers"
+      (List.length newest_bodies)
+      (List.length (List.filter Tool_output.is_marker transmitted))
+;;
+
+(* The last resort is not a blank cheque: an oversized atom with nothing
+   demotable in it keeps the typed refusal, with the original measured
+   values. *)
+let oversized_atom_without_demotable_body_still_refuses () =
+  let newest = [ assistant (String.make 50_000 'x') ] in
+  let messages = history_with_tool_bodies [ "tick" ] @ newest in
+  let capacity_bytes = bytes_of newest in
+  match
+    compose
+      ~base_path:(Filename.temp_dir "demote" "")
+      ~capacity_bytes
+      ~demote_before:1
+      messages
+  with
+  | Ok _ -> Alcotest.fail "an atom with no tool results cannot be demoted"
+  | Error (Window.Newest_atom_exceeds_available { newest_atom_bytes; _ }) ->
+    Alcotest.(check int)
+      "the refusal carries the atom's real bytes"
+      capacity_bytes
+      newest_atom_bytes
+  | Error error -> Alcotest.fail (Window.budget_error_to_string error)
+;;
+
+(* Without a blob store there is nothing a marker could reference, so the
+   refusal stands exactly as it did before #28845. *)
+let last_resort_requires_a_blob_store () =
+  let earlier, messages, newest_bytes = oversized_newest_history () in
+  let demote_before =
+    Window.first_atom_at_or_after
+      messages
+      ~message_index:(List.length earlier)
+  in
+  match
+    compose ~base_path:"" ~capacity_bytes:newest_bytes ~demote_before messages
+  with
+  | Ok _ -> Alcotest.fail "demotion without a store would dangle its markers"
+  | Error (Window.Newest_atom_exceeds_available _) -> ()
+  | Error error -> Alcotest.fail (Window.budget_error_to_string error)
+;;
+
 let () =
   Alcotest.run
     "keeper_model_input_demotion"
@@ -488,5 +629,19 @@ let () =
             `Quick
             projection_reuses_candidate_measurements
          ] )
+    ; ( "last_resort"
+      , [ Alcotest.test_case
+            "oversized newest atom is demoted as a last resort"
+            `Quick
+            oversized_newest_atom_is_demoted_as_last_resort
+        ; Alcotest.test_case
+            "oversized atom without a demotable body still refuses"
+            `Quick
+            oversized_atom_without_demotable_body_still_refuses
+        ; Alcotest.test_case
+            "last resort requires a blob store"
+            `Quick
+            last_resort_requires_a_blob_store
+        ] )
     ]
 ;;


### PR DESCRIPTION
Closes #28845

## Root cause

`model_input_projection` failed hard at turn:parse with `Newest_atom_exceeds_available` when one conversation atom outgrew the whole history budget. The tail window cannot split the newest atom (a tool result must stay with the call that produced it), and RFC-0363 demotion could never help: its boundary is the current turn's first atom (RFC-0351 §4), so the oversized newest atom — this turn's own tool results — was never demotable.

Observed 2026-08-15 (sangsu): 4 parallel WebSearch results (24/31/47/7KB) merged into one assistant atom = 148,330 bytes > 135,852 available. Three layered defenses all missed this shape: generation-time externalization (64KB threshold — none of the four bodies crossed it), demotion (boundary excludes the current turn), and tail-window truncation (cannot split the newest atom).

## Fix

`Keeper_turn_driver_try_provider.plan_and_window_model_input` (extracted from `budgeted_model_input_projection`; the normal path is behavior-identical) retries composition **once**, and only when the raw cut fails with `Newest_atom_exceeds_available`, with the demotion boundary moved past the newest atom (`demote_before = atom_count`). The current turn's tool results are replaced by their externalized blob markers through the existing RFC-0363 plan/materialize mechanism — referenced, not dropped. Principled bounds:

- Only on `Newest_atom_exceeds_available`, only after normal composition failed, exactly one attempt — no retry loop, no new byte threshold.
- Nothing demotable in the atom → the original typed refusal stands (verified by test).
- Still oversized after demotion → typed refusal stands.
- No blob store (`base_path = ""`) → refusal stands, unchanged from before.

## `content_blocks` precondition

Verified: demotion requires `ToolResult { content_blocks = None; _ }` because the provider encoder ignores `content` when blocks are present. WebSearch-style results satisfy it — both constructors that produce tool results set `content_blocks = None` (`Agent_turn.make_tool_results`, `agent_turn.ml:294`; `Types.tool_result_msg`, `types.ml:1671`), and the payloads are plain text. `content_blocks = Some` remains excluded by `demotable_body` and is covered by the existing `structured_results_are_not_demoted` test. No change to the precondition was needed.

## Tests (TDD, red → green)

New `last_resort` group in `test/test_keeper_model_input_demotion.ml`:

- `oversized newest atom is demoted as a last resort` — sangsu-shaped fixture (4 merged search results, atom > budget). **Red before the fix** with the exact production error (`available_bytes=109327 newest_atom_bytes=109629`); green after: composition succeeds, all 4 bodies materialize to readable blob markers, `history_atom_count` keeps the full-history denominator.
- `oversized atom without a demotable body still refuses` — pure assistant text keeps `Newest_atom_exceeds_available` with the original measured values.
- `last resort requires a blob store` — `base_path = ""` keeps the refusal.

```
scripts/dune-local.sh exec -- test/test_keeper_model_input_demotion.exe
# before: 1 failure! — ASSERT newest conversation atom does not fit the model input budget: ...
# after:  Test Successful — 14 tests run.
scripts/dune-local.sh exec -- test/test_runtime_model_input_tail_window.exe   # 26 tests OK
scripts/dune-local.sh exec -- test/test_keeper_context_overflow_shrink.exe    # 11 tests OK
scripts/dune-local.sh exec -- test/test_keeper_unified_context_overflow.exe   # 8 tests OK
scripts/dune-local.sh exec -- test/test_keeper_provider_call_deadline.exe     # 14 tests OK
```

## Docs

- `keeper_model_input_demotion.mli` and the RFC-0351 §4 comment at the boundary computation record the last-resort exception.
- RFC-0351 §4 gains a paragraph on the exception.
- RFC-0363 §3.4.1: notes the demotion boundary moved from the raw cut to the current turn in #28739 (the section still described the raw-cut anchor) and documents the #28845 exception.

## Out of scope (follow-up)

**Variant 2 from the same incident day is deliberately not fixed here.** The task-336 completion-review evaluator failed 1,144 times because its *initial prompt itself* was 294,670 bytes > 233,931 budget — there is no prior history to demote and no atom to drop. That variant needs payload caps at the review-composition site, not a windowing change. Filing as a separate follow-up.
