### PR TITLE
fix(keeper): let runtime attempt attribution through the public projection

### DIFF
--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -396,6 +396,12 @@ let decision_public_allowlist =
     ; "operator_action_required"; "trace_id"; "generation"; "turn_count"
     ; "sha256"; "kind"; "detail"; "backtrace_present"; "completion_error"
     ; "failure_dispatch"; "failure_dispatch_error"
+    (* Runtime attempt attribution (#28871): the lane walk stores the
+       attempted candidate in decision.runtime_id/idx (error_kind on
+       failures) while the row's top-level runtime_id is the lane id.
+       Dropping these here made intra-lane failover unreadable on every
+       API consumer. *)
+    ; "idx"; "runtime_id"; "error_kind"
     ])
 
 let compaction_evidence_public_allowlist =

--- a/test/test_keeper_runtime_manifest_completeness.ml
+++ b/test/test_keeper_runtime_manifest_completeness.ml
@@ -181,6 +181,41 @@ let test_compaction_evidence_public_projection () =
     evidence
     (json |> member "decision" |> member "exact_evidence")
 
+(* Runtime attempt attribution (#28871): the driver's per-candidate walk
+   records the attempted candidate as decision.runtime_id (with idx, and
+   error_kind on failures) while the row's top-level runtime_id stays the
+   lane id. The public projection must let those three keys through, or
+   intra-lane failover becomes unreadable on every API consumer. *)
+let test_runtime_attempt_attribution_public_projection () =
+  let decision =
+    `Assoc
+      [ ("idx", `Int 1)
+      ; ("runtime_id", `String "glm-coding.glm-5-turbo")
+      ; ("error_kind", `String "api")
+      ; ("not_allowlisted_probe", `String "must-not-leak")
+      ; ( "clock_refs"
+        , `Assoc [ ("edge_id", `String "e1"); ("lane", `String "L1") ] )
+      ]
+  in
+  let json =
+    manifest ~event:M.Runtime_failed ~decision ~links:(links ())
+    |> M.public_to_json
+  in
+  let open Yojson.Safe.Util in
+  let projected = json |> member "decision" in
+  Alcotest.(check int)
+    "idx retained" 1 (projected |> member "idx" |> to_int);
+  Alcotest.(check string)
+    "attempted candidate retained"
+    "glm-coding.glm-5-turbo"
+    (projected |> member "runtime_id" |> to_string);
+  Alcotest.(check string)
+    "error_kind retained" "api" (projected |> member "error_kind" |> to_string);
+  Alcotest.(check bool)
+    "projection still redacts unknown keys"
+    true
+    (projected |> member "not_allowlisted_probe" = `Null)
+
 let test_current_compaction_evidence_read_boundary () =
   let evidence = canonical_compaction_evidence () in
   let row decision =
@@ -285,6 +320,8 @@ let () =
             test_is_complete_turn
         ; Alcotest.test_case "compaction evidence public projection" `Quick
             test_compaction_evidence_public_projection
+        ; Alcotest.test_case "runtime attempt attribution public projection" `Quick
+            test_runtime_attempt_attribution_public_projection
         ; Alcotest.test_case "current evidence read boundary" `Quick
             test_current_compaction_evidence_read_boundary
         ] )


### PR DESCRIPTION
## 목표

#28871 수리. lane walk는 시도한 후보를 `decision.runtime_id`(+`idx`, 실패 시 `error_kind`)로 durable store에 온전히 기록하는데, `decision_public_allowlist`에 이 3키가 없어 runtime-trace API 응답에서 벗겨졌다. 그 결과 lane 내부 failover가 모든 API 소비자에게 same-runtime retry로 보였다.

## 변경

- `lib/keeper/keeper_runtime_manifest.ml`: `decision_public_allowlist`에 `"idx"; "runtime_id"; "error_kind"` 추가 (+제약 주석)
- `test/test_keeper_runtime_manifest_completeness.ml`: attempt attribution 3키가 projection을 통과하고, allowlist 밖 키는 계속 redact되는 feature test. **수정 전 트리에서 FAIL 확인 후** 수정 적용 (8/8 green)

## 민감도 근거

- `runtime_id`는 이미 모든 행의 top-level에 노출되는 값 (새 노출면 아님)
- `error_kind`는 카테고리 라벨 (`"api"` 등). raw `error`·`exception_kind`는 이미 allowlist에 있으므로 기준상 더 민감하지 않음
- allowlist 위 주석의 선례(Request_body_over_capacity 정수 유실)와 동일한 실패 클래스

## 라이브 근거

turn 44 (2026-08-16 07:48:18Z) store 원본: `idx=0 llama failed(error_kind="api") → idx=1 glm completed` — 진짜 in-turn failover가 API에서는 lane id 4행으로만 보였다. 상세 포렌식: #28871.

## 후속

병합·배포 후 PR #28872의 `--inject-failover` 하네스를 재실행해 `in_turn` 라이브 receipt 수확 (M2 완료 기준). 하네스 분류기의 attribution 소스를 `decision.runtime_id` 우선으로 갱신하는 커밋은 #28872에 추가 예정.