### PR TITLE
feat(mcp): answer an unsupported protocol version with -32022

### DIFF
--- a/lib/mcp_error_code.ml
+++ b/lib/mcp_error_code.ml
@@ -10,6 +10,7 @@ type t =
   | Tool_dispatch_failure
   | Backpressure_shed
   | Session_evicted
+  | Unsupported_protocol_version
   | Quiet of { reason : string ; recovered : bool }
 
 let to_wire_code = function
@@ -24,6 +25,9 @@ let to_wire_code = function
   | Tool_dispatch_failure -> -32004
   | Backpressure_shed -> -32005
   | Session_evicted -> -32006
+  (* Fixed by MCP revision 2026-07-28, not chosen by this server: clients pin
+     on -32022 to tell a modern server from a legacy one. *)
+  | Unsupported_protocol_version -> -32022
   | Quiet _ -> -32099
 
 let of_wire_code = function
@@ -38,6 +42,7 @@ let of_wire_code = function
   | -32004 -> Some Tool_dispatch_failure
   | -32005 -> Some Backpressure_shed
   | -32006 -> Some Session_evicted
+  | -32022 -> Some Unsupported_protocol_version
   | _ -> None
 
 let to_wire_message_default = function
@@ -52,6 +57,8 @@ let to_wire_message_default = function
   | Tool_dispatch_failure -> "Tool dispatch failed"
   | Backpressure_shed -> "Backpressure shed; resume via Last-Event-ID"
   | Session_evicted -> "Session evicted by server policy"
+  (* Verbatim from the MCP 2026-07-28 example response. *)
+  | Unsupported_protocol_version -> "Unsupported protocol version"
   | Quiet { reason ; _ } -> reason
 
 (* JSON-RPC 2.0 §5: a response may carry a null id only when the request
@@ -70,6 +77,10 @@ let allows_null_request_id : t -> bool = function
   | Tool_dispatch_failure -> false
   | Backpressure_shed -> false
   | Session_evicted -> false
+  (* The version is read from the [MCP-Protocol-Version] header, so the
+     rejection happens before the JSON-RPC body — and the request id — has
+     been parsed. That is exactly the §5 case a null id is for. *)
+  | Unsupported_protocol_version -> true
   | Quiet _ -> false
 ;;
 
@@ -85,6 +96,9 @@ let to_http_status : t -> Httpun.Status.t = function
   | Tool_dispatch_failure -> `Internal_server_error
   | Backpressure_shed -> `Too_many_requests
   | Session_evicted -> `Gone
+  (* 4xx is what MCP 2026-07-28 Backward Compatibility has clients inspect;
+     the body, not the status, is what marks the server as modern. *)
+  | Unsupported_protocol_version -> `Bad_request
   | Quiet _ -> `OK
 
 let all =
@@ -100,6 +114,7 @@ let all =
     Tool_dispatch_failure;
     Backpressure_shed;
     Session_evicted;
+    Unsupported_protocol_version;
     Quiet { reason = "<exemplar>"; recovered = false };
   ]
 
@@ -108,6 +123,27 @@ let jsonrpc_error_body (t : t) ~(message : string) : string =
     {|{"jsonrpc":"2.0","error":{"code":%d,"message":"%s"},"id":null}|}
     (to_wire_code t)
     (String.escaped message)
+
+let unsupported_protocol_version_body ~(requested : string)
+    ~(supported : string list) : string =
+  Yojson.Safe.to_string
+    (`Assoc
+       [ ("jsonrpc", `String "2.0")
+       ; ( "error"
+         , `Assoc
+             [ ("code", `Int (to_wire_code Unsupported_protocol_version))
+             ; ( "message"
+               , `String
+                   (to_wire_message_default Unsupported_protocol_version) )
+             ; ( "data"
+               , `Assoc
+                   [ ( "supported"
+                     , `List (List.map (fun v -> `String v) supported) )
+                   ; ("requested", `String requested)
+                   ] )
+             ] )
+       ; ("id", `Null)
+       ])
 
 let pp fmt = function
   | Parse_error -> Format.pp_print_string fmt "Parse_error"
@@ -121,6 +157,8 @@ let pp fmt = function
   | Tool_dispatch_failure -> Format.pp_print_string fmt "Tool_dispatch_failure"
   | Backpressure_shed -> Format.pp_print_string fmt "Backpressure_shed"
   | Session_evicted -> Format.pp_print_string fmt "Session_evicted"
+  | Unsupported_protocol_version ->
+      Format.pp_print_string fmt "Unsupported_protocol_version"
   | Quiet { reason ; recovered } ->
       Format.fprintf fmt "Quiet { reason = %S ; recovered = %b }" reason
         recovered

--- a/lib/mcp_error_code.mli
+++ b/lib/mcp_error_code.mli
@@ -27,6 +27,20 @@ type t =
                               client SHOULD resume via Last-Event-ID. *)
   | Session_evicted       (** -32006 — session lifecycle terminated by server
                               policy (oldest-eviction at cap, idle timeout). *)
+  | Unsupported_protocol_version
+        (** -32022 — the request declared a protocol version this server does
+            not implement.
+
+            The code and the accompanying [data] shape are fixed by MCP
+            revision 2026-07-28 (Versioning and Compatibility, Protocol
+            Version Negotiation), which states the server MUST answer an
+            unsupported version with this error listing the versions it does
+            support. Build the body with
+            {!unsupported_protocol_version_body} rather than
+            {!jsonrpc_error_body} so the mandated [data.supported] and
+            [data.requested] fields are present: a 4xx whose body carries no
+            recognized modern error is what the same revision tells clients
+            to read as a legacy (initialize-handshake) server. *)
   | Quiet of { reason : string ; recovered : bool }
         (** -32099 — last-resort silent-skip annotation.
 
@@ -88,6 +102,24 @@ val jsonrpc_error_body : t -> message:string -> string
 (** [jsonrpc_error_body t ~message] returns a complete JSON-RPC 2.0 error
     response string with [id:null].  Replaces scattered [Printf.sprintf]
     templates that baked raw integer literals into JSON bodies. *)
+
+val unsupported_protocol_version_body :
+  requested:string -> supported:string list -> string
+(** [unsupported_protocol_version_body ~requested ~supported] returns the
+    complete JSON-RPC 2.0 error response mandated by MCP revision 2026-07-28
+    for a version the server does not implement: code [-32022], message
+    ["Unsupported protocol version"], and a [data] object carrying
+    [supported] (the versions this server accepts) and [requested] (the
+    version the client asked for).
+
+    [id] is null because the rejection happens at the transport header, before
+    the JSON-RPC body — and therefore the request id — has been read. That is
+    the JSON-RPC 2.0 §5 condition for a null id, and matches
+    {!allows_null_request_id} for this code.
+
+    [supported] is passed in rather than read here: this module sits below the
+    transport that owns the version list, and inverting that would point the
+    error vocabulary at the transport. *)
 
 val pp : Format.formatter -> t -> unit
 (** Pretty-printer for test failures and operator diagnostics. *)

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -507,8 +507,11 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
            | Ok () ->
                (match Server_mcp_transport_http.validate_protocol_version_continuity
                         ~session_id httpun_request with
-                | Error msg ->
-                    let body = json_rpc_error Mcp_error_code.Invalid_request msg in
+                | Error rejection ->
+                    let body =
+                      Server_mcp_transport_http
+                      .protocol_version_rejection_body rejection
+                    in
                     h2_respond_json h2_reqd body ~status:`Bad_request
                       ~extra_headers:(cors @ mcp_headers session_id protocol_version)
                 | Ok () ->
@@ -679,8 +682,11 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
                     | Ok () ->
                         (match Server_mcp_transport_http.validate_protocol_version_continuity
                                  ~session_id httpun_request with
-                         | Error msg ->
-                             let body = json_rpc_error Mcp_error_code.Invalid_request msg in
+                         | Error rejection ->
+                             let body =
+                               Server_mcp_transport_http
+                               .protocol_version_rejection_body rejection
+                             in
                              h2_respond_json h2_reqd body ~status:`Bad_request
                                ~extra_headers:(cors @ mcp_headers session_id (get_protocol_version httpun_request))
                          | Ok () ->

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -257,10 +257,8 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
     let* () =
       match validate_protocol_version_continuity ~session_id request with
       | Ok () -> Ok ()
-      | Error msg ->
-          let body =
-            Mcp_error_code.jsonrpc_error_body Invalid_request ~message:msg
-          in
+      | Error rejection ->
+          let body = protocol_version_rejection_body rejection in
           let headers =
             Httpun.Headers.of_list
               (("content-length", string_of_int (String.length body))
@@ -593,10 +591,8 @@ let handle_get_mcp ~deps ?(profile = Full) ?(sse_kind = Sse.Agent_stream)
       safe_respond_with_string reqd response msg
   | Ok () -> (
       match validate_protocol_version_continuity ~session_id request with
-      | Error msg ->
-          let body =
-            Mcp_error_code.jsonrpc_error_body Invalid_request ~message:msg
-          in
+      | Error rejection ->
+          let body = protocol_version_rejection_body rejection in
           let headers =
             Httpun.Headers.of_list
               (("content-length", string_of_int (String.length body))
@@ -824,10 +820,8 @@ let handle_delete_mcp ~deps ?(profile = Full) request reqd =
               safe_respond_with_string reqd response msg
           | Ok () -> (
               match validate_protocol_version_continuity ~session_id request with
-              | Error msg ->
-                  let body =
-                    Mcp_error_code.jsonrpc_error_body Invalid_request ~message:msg
-                  in
+              | Error rejection ->
+                  let body = protocol_version_rejection_body rejection in
                   let protocol_version =
                     get_protocol_version_for_session ~session_id request
                   in

--- a/lib/server/server_mcp_transport_http.mli
+++ b/lib/server/server_mcp_transport_http.mli
@@ -99,8 +99,24 @@ val get_header_any_case : Httpun.Headers.t -> string -> string option
 val get_cookie_value : Httpun.Request.t -> string -> string option
 val get_session_id_any : Httpun.Request.t -> string option
 val get_protocol_version : Httpun.Request.t -> string
+type protocol_version_rejection =
+  Server_mcp_transport_http_session.protocol_version_rejection =
+  | Unsupported_version of { requested : string }
+  | Session_version_mismatch of
+      { session_id : string
+      ; expected : string
+      ; got : string
+      }
+
+val protocol_version_rejection_body : protocol_version_rejection -> string
+val protocol_version_rejection_code :
+  protocol_version_rejection -> Mcp_error_code.t
+val protocol_version_rejection_message : protocol_version_rejection -> string
+
 val validate_protocol_version_continuity :
-  session_id:string -> Httpun.Request.t -> (unit, string) result
+  session_id:string ->
+  Httpun.Request.t ->
+  (unit, protocol_version_rejection) result
 val get_protocol_version_for_session :
   ?session_id:string -> Httpun.Request.t -> string
 val request_force_json_response : Httpun.Request.t -> bool

--- a/lib/server/server_mcp_transport_http_session.ml
+++ b/lib/server/server_mcp_transport_http_session.ml
@@ -495,12 +495,49 @@ let get_protocol_version (request : Httpun.Request.t) =
 let get_protocol_version_header_opt (request : Httpun.Request.t) =
   get_header_any_case request.headers "mcp-protocol-version"
 
+(* Two rejections that used to share one string. They answer different
+   questions — "this server does not speak that version" versus "this session
+   already settled on another version" — and MCP 2026-07-28 fixes the wire
+   shape of only the first (-32022 with data.supported/data.requested). A
+   caller handed a bare string cannot tell them apart, so the distinction
+   lives in the type. *)
+type protocol_version_rejection =
+  | Unsupported_version of { requested : string }
+  | Session_version_mismatch of
+      { session_id : string
+      ; expected : string
+      ; got : string
+      }
+
+let protocol_version_rejection_message = function
+  | Unsupported_version { requested } ->
+      Printf.sprintf "Unsupported MCP-Protocol-Version: %s" requested
+  | Session_version_mismatch { session_id; expected; got } ->
+      Printf.sprintf
+        "MCP-Protocol-Version mismatch for session %s: expected %s, got %s."
+        session_id expected got
+
+let protocol_version_rejection_code : protocol_version_rejection -> Mcp_error_code.t
+  = function
+  | Unsupported_version _ -> Mcp_error_code.Unsupported_protocol_version
+  | Session_version_mismatch _ -> Mcp_error_code.Invalid_request
+
+let protocol_version_rejection_body rejection =
+  match rejection with
+  | Unsupported_version { requested } ->
+      Mcp_error_code.unsupported_protocol_version_body ~requested
+        ~supported:Mcp_transport_protocol.supported_protocol_versions
+  | Session_version_mismatch _ ->
+      Mcp_error_code.jsonrpc_error_body
+        (protocol_version_rejection_code rejection)
+        ~message:(protocol_version_rejection_message rejection)
+
 let validate_protocol_version_continuity ~session_id request =
   let validate_supported version =
     if is_valid_protocol_version version then
       Ok ()
     else
-      Error (Printf.sprintf "Unsupported MCP-Protocol-Version: %s" version)
+      Error (Unsupported_version { requested = version })
   in
   let provided = get_protocol_version_header_opt request in
   match SMap.find_opt session_id (Atomic.get protocol_version_by_session) with
@@ -513,10 +550,8 @@ let validate_protocol_version_continuity ~session_id request =
             Ok ()
           else
             Error
-              (Printf.sprintf
-                 "MCP-Protocol-Version mismatch for session %s: expected %s, \
-                  got %s."
-                 session_id expected version))
+              (Session_version_mismatch
+                 { session_id; expected; got = version }))
   | None -> (
       match provided with
       | Some version -> validate_supported version

--- a/lib/server/server_mcp_transport_http_session.mli
+++ b/lib/server/server_mcp_transport_http_session.mli
@@ -194,19 +194,48 @@ val get_protocol_version : Httpun.Request.t -> string
 val get_protocol_version_header_opt :
   Httpun.Request.t -> string option
 
+type protocol_version_rejection =
+  | Unsupported_version of { requested : string }
+        (** The server does not implement the requested version. MCP
+            2026-07-28 fixes the answer: [-32022] carrying the supported
+            list. *)
+  | Session_version_mismatch of
+      { session_id : string
+      ; expected : string
+      ; got : string
+      }
+        (** The request contradicts the version this session already settled
+            on. A legacy-session concern with no wire shape in the modern
+            revision; answered as [Invalid_request]. *)
+
+val protocol_version_rejection_message : protocol_version_rejection -> string
+(** Operator-visible text. Strings pinned:
+    - [["Unsupported MCP-Protocol-Version: <v>"]]
+    - [["MCP-Protocol-Version mismatch for session <id>: expected <e>, got <g>."]] *)
+
+val protocol_version_rejection_code :
+  protocol_version_rejection -> Mcp_error_code.t
+(** Wire code per rejection. Callers deriving an HTTP status should pass this
+    through {!Mcp_error_code.to_http_status} rather than hardcoding one. *)
+
+val protocol_version_rejection_body : protocol_version_rejection -> string
+(** Complete JSON-RPC error body for the rejection. [Unsupported_version]
+    gets the mandated [data.supported]/[data.requested] payload built from
+    {!Mcp_transport_protocol.supported_protocol_versions}; every transport
+    answering a rejection MUST use this rather than assembling its own body,
+    or a client reading the 4xx will classify this server as legacy. *)
+
 val validate_protocol_version_continuity :
-  session_id:string -> Httpun.Request.t -> (unit, string) result
+  session_id:string ->
+  Httpun.Request.t ->
+  (unit, protocol_version_rejection) result
 (** [validate_protocol_version_continuity ~session_id request]
     enforces:
     - When the session has a remembered version: the request
       header (if present) must match.
     - When the session is unknown: the request header (if
       present) must be valid per {!is_valid_protocol_version}.
-    - Missing header is always [Ok ()].
-
-    Error messages pinned:
-    - [["Unsupported MCP-Protocol-Version: <v>"]]
-    - [["MCP-Protocol-Version mismatch for session <id>: expected <e>, got <g>."]] *)
+    - Missing header is always [Ok ()]. *)
 
 val get_protocol_version_for_session :
   ?session_id:string -> Httpun.Request.t -> string

--- a/test/test_http_negotiation.ml
+++ b/test/test_http_negotiation.ml
@@ -78,8 +78,9 @@ let test_protocol_continuity_allows_missing_header () =
     (fun () ->
       match Session.validate_protocol_version_continuity ~session_id request with
       | Ok () -> ()
-      | Error msg ->
-          failf "expected missing protocol header to use session continuity, got %s" msg)
+      | Error rejection ->
+          failf "expected missing protocol header to use session continuity, got %s"
+            (Session.protocol_version_rejection_message rejection))
 
 let test_protocol_version_for_session_falls_back_to_negotiated_version () =
   Eio_main.run @@ fun env ->
@@ -110,10 +111,56 @@ let test_protocol_continuity_rejects_mismatch () =
     (fun () ->
       match Session.validate_protocol_version_continuity ~session_id request with
       | Ok () -> fail "expected mismatched protocol version to be rejected"
-      | Error msg ->
-          check bool "mentions mismatch" true
-            (String.length msg > 0
-            && String.contains msg ':'))
+      | Error (Session.Session_version_mismatch { expected; got; _ }) ->
+          check string "remembered version" "2025-11-25" expected;
+          check string "requested version" "2025-03-26" got
+      | Error (Session.Unsupported_version { requested }) ->
+          failf
+            "expected a session mismatch, got an unsupported-version \
+             rejection for %s"
+            requested)
+
+(* The rejection a modern client reads to decide this server is modern. The
+   assertion runs through the transport rather than the error module so the
+   supported list the body advertises stays the list the transport actually
+   validates against. *)
+let test_unsupported_protocol_version_rejection () =
+  let module Session = Server_mcp_transport_http in
+  let session_id = "compat-session-unsupported-version" in
+  let headers =
+    Httpun.Headers.of_list [("mcp-protocol-version", "1900-01-01")]
+  in
+  let request = Httpun.Request.create ~headers `POST "/mcp" in
+  match Session.validate_protocol_version_continuity ~session_id request with
+  | Ok () -> fail "expected an unsupported protocol version to be rejected"
+  | Error (Session.Session_version_mismatch _) ->
+      fail "an unknown session cannot produce a continuity mismatch"
+  | Error (Session.Unsupported_version { requested } as rejection) ->
+      check string "requested version is echoed" "1900-01-01" requested;
+      let body = Session.protocol_version_rejection_body rejection in
+      let advertised =
+        match Yojson.Safe.from_string body with
+        | `Assoc fields -> (
+            match List.assoc_opt "error" fields with
+            | Some (`Assoc err) -> (
+                (match List.assoc_opt "code" err with
+                | Some (`Int code) ->
+                    check int "wire code fixed by MCP 2026-07-28" (-32022) code
+                | _ -> fail "error.code missing from the body");
+                match List.assoc_opt "data" err with
+                | Some (`Assoc data) -> (
+                    match List.assoc_opt "supported" data with
+                    | Some (`List vs) ->
+                        List.filter_map
+                          (function `String s -> Some s | _ -> None)
+                          vs
+                    | _ -> fail "data.supported missing from the body")
+                | _ -> fail "error.data missing from the body")
+            | _ -> fail "error object missing from the body")
+        | _ -> fail "rejection body is not a JSON object"
+      in
+      check (list string) "body advertises exactly what the transport accepts"
+        Mcp_transport_protocol.supported_protocol_versions advertised
 
 let test_notification_json_only_rejected () =
   let module Transport = Server_mcp_transport_http in
@@ -316,6 +363,8 @@ let () =
         test_case "missing header falls back to session" `Quick test_protocol_continuity_allows_missing_header;
         test_case "remembered session version is reused" `Quick test_protocol_version_for_session_falls_back_to_negotiated_version;
         test_case "mismatch still rejects" `Quick test_protocol_continuity_rejects_mismatch;
+        test_case "unsupported version answers -32022" `Quick
+          test_unsupported_protocol_version_rejection;
       ]);
       ("accept_contract", [
         test_case "notification json-only rejected" `Quick

--- a/test/test_mcp_error_code.ml
+++ b/test/test_mcp_error_code.ml
@@ -96,6 +96,65 @@ let test_wire_codes_in_range () =
           C.pp t code)
     C.all
 
+(* MCP revision 2026-07-28 pins this body, field for field: a client reading a
+   4xx decides from it whether it is talking to a modern server or a legacy
+   one. A missing [data.supported] does not degrade the error, it reclassifies
+   the whole server, so each field is asserted rather than the string as a
+   whole. *)
+let test_unsupported_protocol_version_body_shape () =
+  let body =
+    C.unsupported_protocol_version_body ~requested:"1900-01-01"
+      ~supported:[ "2026-07-28"; "2025-11-25" ]
+  in
+  let fields =
+    match Yojson.Safe.from_string body with
+    | `Assoc fields -> fields
+    | _ -> Alcotest.fail "body is not a JSON object"
+  in
+  (match List.assoc_opt "jsonrpc" fields with
+  | Some (`String v) -> Alcotest.(check string) "jsonrpc" "2.0" v
+  | _ -> Alcotest.fail "jsonrpc version missing");
+  (match List.assoc_opt "id" fields with
+  | Some `Null -> ()
+  | _ ->
+      Alcotest.fail
+        "id must be null: the header is rejected before the request id is read");
+  let err =
+    match List.assoc_opt "error" fields with
+    | Some (`Assoc err) -> err
+    | _ -> Alcotest.fail "error object missing"
+  in
+  (match List.assoc_opt "code" err with
+  | Some (`Int code) ->
+      Alcotest.(check int) "code fixed by the spec, not by this server" (-32022) code
+  | _ -> Alcotest.fail "error.code missing");
+  (match List.assoc_opt "message" err with
+  | Some (`String m) ->
+      Alcotest.(check string) "message" "Unsupported protocol version" m
+  | _ -> Alcotest.fail "error.message missing");
+  let data =
+    match List.assoc_opt "data" err with
+    | Some (`Assoc data) -> data
+    | _ ->
+        Alcotest.fail
+          "error.data missing — without it the response is not a recognized \
+           modern error and the client falls back to initialize"
+  in
+  (match List.assoc_opt "supported" data with
+  | Some (`List vs) ->
+      Alcotest.(check (list string))
+        "supported list is what the client retries from"
+        [ "2026-07-28"; "2025-11-25" ]
+        (List.map
+           (function
+             | `String s -> s
+             | _ -> Alcotest.fail "supported entry is not a string")
+           vs)
+  | _ -> Alcotest.fail "data.supported missing");
+  match List.assoc_opt "requested" data with
+  | Some (`String r) -> Alcotest.(check string) "requested echoed back" "1900-01-01" r
+  | _ -> Alcotest.fail "data.requested missing"
+
 let test_round_trip_well_known () =
   (* [of_wire_code] returns [None] for [Quiet] because the
      reason/recovered payload is not derivable from the integer alone.
@@ -202,16 +261,24 @@ let test_sse_get_registers_before_streaming_response () =
    match in the module. *)
 let test_allows_null_request_id_only_for_unreadable_id () =
   let allowed = List.filter C.allows_null_request_id C.all in
-  Alcotest.(check int) "exactly two codes allow a null id" 2 (List.length allowed);
+  Alcotest.(check int) "exactly three codes allow a null id" 3 (List.length allowed);
   Alcotest.(check bool) "Parse_error" true (C.allows_null_request_id C.Parse_error);
-  Alcotest.(check bool) "Invalid_request" true (C.allows_null_request_id C.Invalid_request)
+  Alcotest.(check bool) "Invalid_request" true (C.allows_null_request_id C.Invalid_request);
+  (* Third since the MCP 2026-07-28 version check: the declared version is
+     read from the [MCP-Protocol-Version] header and rejected there, so the
+     JSON-RPC body — and the id inside it — is never parsed. Same §5 condition
+     as the other two, reached by a different route. A future rejection driven
+     by the [_meta] key instead does parse the body, and would have to carry
+     the id. *)
+  Alcotest.(check bool) "Unsupported_protocol_version" true
+    (C.allows_null_request_id C.Unsupported_protocol_version)
 ;;
 
 let test_allows_null_request_id_rejects_answered_requests () =
   List.iter
     (fun code ->
       match code with
-      | C.Parse_error | C.Invalid_request -> ()
+      | C.Parse_error | C.Invalid_request | C.Unsupported_protocol_version -> ()
       | other ->
         Alcotest.(check bool)
           (Printf.sprintf "%s must carry the request id" (Format.asprintf "%a" C.pp other))
@@ -228,6 +295,8 @@ let () =
           test_case "unique" `Quick test_wire_codes_unique;
           test_case "in-range" `Quick test_wire_codes_in_range;
           test_case "round-trip (well-known)" `Quick test_round_trip_well_known;
+          test_case "unsupported protocol version body (MCP 2026-07-28)" `Quick
+            test_unsupported_protocol_version_body_shape;
           test_case "unknown returns None" `Quick
             test_of_wire_unknown_returns_none;
           test_case "Quiet round-trip drops payload" `Quick

--- a/test/test_mcp_h1_h2_admission_parity.ml
+++ b/test/test_mcp_h1_h2_admission_parity.ml
@@ -265,11 +265,14 @@ let test_shared_protocol_and_delete_matrix () =
     ~finally:(fun () -> Transport.forget_mcp_session session_id)
     (fun () ->
       Transport.remember_protocol_version session_id "2025-11-25";
+      let continuity ~session_id request =
+        Result.map_error Transport.protocol_version_rejection_message
+          (Transport.validate_protocol_version_continuity ~session_id request)
+      in
       assert_result_ok "missing protocol header preserves continuity"
-        (Transport.validate_protocol_version_continuity ~session_id
-           (request "/mcp"));
+        (continuity ~session_id (request "/mcp"));
       assert_result_error "mismatched protocol header is rejected"
-        (Transport.validate_protocol_version_continuity ~session_id
+        (continuity ~session_id
            (request
               ~headers:[ ("mcp-protocol-version", "2025-03-26") ]
               "/mcp")));


### PR DESCRIPTION
## Why

MCP revision 2026-07-28 ([Versioning and Compatibility](https://modelcontextprotocol.io/specification/2026-07-28/basic/versioning)) replaced the `initialize` handshake with per-request version declaration, and fixes what a server MUST answer when it does not implement the requested version:

```json
{"jsonrpc":"2.0","id":1,"error":{"code":-32022,"message":"Unsupported protocol version",
 "data":{"supported":["2026-07-28","2025-11-25"],"requested":"1900-01-01"}}}
```

masc already implements the rest of that revision — `server/discover` (`mcp_server_eio_protocol.ml:773`), the `io.modelcontextprotocol/protocolVersion` `_meta` key, the `MCP-Protocol-Version` header, the stateless request path, and 2026-07-28 in the supported list. The unsupported-version answer was the one piece missing: a bare `Invalid_request` (-32600) with a plain string.

That is not cosmetic. The same revision's Backward Compatibility section tells clients to read **a 4xx whose body carries no recognized modern error as a legacy server**. So today a modern client falls back to `initialize` instead of retrying from the `supported` list, and the stateless path already implemented here never gets exercised.

## What changed

`validate_protocol_version_continuity` could return two rejections through one string. They answer different questions — *this server does not speak that version* versus *this session already settled on another one* — and only the first has a wire shape fixed by the spec. A caller handed a bare string cannot tell them apart, so the distinction now lives in a variant:

```ocaml
type protocol_version_rejection =
  | Unsupported_version of { requested : string }
  | Session_version_mismatch of { session_id : string; expected : string; got : string }
```

All five call sites (3 in `server_mcp_transport_http.ml`, 2 in `server_h2_gateway.ml`) now build their body through `protocol_version_rejection_body` instead of assembling their own envelope, so h1 and h2 cannot drift from each other.

`Unsupported_protocol_version` is the third code allowed to answer with a null id — the version comes from the header and is rejected before the JSON-RPC body, and therefore the request id, is ever parsed. The existing "exactly two codes allow a null id" ratchet caught this and is updated with the reason rather than loosened silently.

`supported` is passed into `Mcp_error_code` rather than read there: that module sits below the transport that owns the version list.

## Verification

```
dune build --root .                          exit 0
dune exec test/test_mcp_error_code.exe                exit 0  (12 tests)
dune exec test/test_http_negotiation.exe              exit 0
dune exec test/test_mcp_h1_h2_admission_parity.exe    exit 0
```

Mutation-checked: with the code set to `-32023`, both `test_mcp_error_code` and `test_http_negotiation` fail (exit 1). The guards pin the value, not just the shape.

New tests assert the body field by field (`code`, `message`, `data.supported`, `data.requested`, null `id`) because a missing `data.supported` does not degrade the error — it reclassifies the whole server. The transport-level test asserts the advertised list equals `Mcp_transport_protocol.supported_protocol_versions`, so the body cannot drift from what the transport actually accepts.

## Not covered

- Rejection driven by the `_meta` key rather than the header. That path parses the body and so could carry the real request id; this PR does not add it.
- `default_protocol_version` resolves to `Mcp_protocol.Version.latest` from the opam `mcp_protocol` package. I could not locate that value in the installed package sources, so whether a request with no declared version defaults to a modern or legacy revision is unverified here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
