### PR TITLE
fix(keeper): 비정규 열거형 meta 필드 자동 복구 + parse-failure WARN 상태 전이 dedupe (#28844)

### DIFF
--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -147,18 +147,44 @@ type enum_field_repair =
   ; repaired_value : string
   }
 
-(* Issue #28844: persisted enumerated fields whose non-canonical value has a
-   canonical default — the value the create path writes for a keeper that
-   never exercised the corresponding machinery, so resetting to it is
-   lossless.  A field belongs here only when its corruption has exactly one
-   sane fallback; anything else keeps failing loud. *)
+(* Issue #28844: repair target for one non-canonical enumerated value.
+   [None] means already canonical (no repair).  [Some repaired] is the
+   canonical spelling of the recognized value when the field's [of_string]
+   accepts [raw] — both parsers trim and lowercase, so a case/whitespace
+   misspelling keeps the operator's intent.  Only a value the parser does
+   not recognize at all falls back to the field's canonical default (the
+   value the create path writes for a keeper that never exercised the
+   corresponding machinery), which is the lossless reset. *)
+let proactive_outcome_repair_value raw =
+  match canonical_proactive_outcome_opt raw with
+  | Some _ -> None
+  | None ->
+    (* [proactive_cycle_outcome_of_string] is total: unrecognized garbage
+       lands on [Proactive_unknown], so a recognized misspelling is exactly
+       a parse to any other variant.  A misspelled ["unknown"] is
+       indistinguishable from garbage through the total parser and resets
+       with it. *)
+    (match proactive_cycle_outcome_of_string raw with
+     | Proactive_unknown ->
+       Some (proactive_cycle_outcome_to_string Proactive_never_started)
+     | outcome -> Some (proactive_cycle_outcome_to_string outcome))
+;;
+
+let multimodal_policy_repair_value raw =
+  match canonical_multimodal_policy_opt raw with
+  | Some _ -> None
+  | None ->
+    (match multimodal_policy_of_string raw with
+     | Some policy -> Some (multimodal_policy_to_string policy)
+     | None -> Some (multimodal_policy_to_string default_multimodal_policy))
+;;
+
+(* Persisted enumerated fields repairable in place.  A field belongs here
+   only when an unrecognized value has exactly one sane fallback; anything
+   else keeps failing loud. *)
 let repairable_enum_fields =
-  [ ( "last_proactive_outcome"
-    , (fun raw -> Option.is_some (canonical_proactive_outcome_opt raw))
-    , proactive_cycle_outcome_to_string Proactive_never_started )
-  ; ( "multimodal_policy"
-    , (fun raw -> Option.is_some (canonical_multimodal_policy_opt raw))
-    , multimodal_policy_to_string default_multimodal_policy )
+  [ "last_proactive_outcome", proactive_outcome_repair_value
+  ; "multimodal_policy", multimodal_policy_repair_value
   ]
 ;;
 
@@ -167,11 +193,13 @@ let repair_non_canonical_enum_fields json =
   | `Assoc fields ->
     let repairs =
       List.filter_map
-        (fun (field, is_canonical, canonical_default) ->
+        (fun (field, repair_value) ->
            match List.assoc_opt field fields with
-           | Some (`String raw) when not (is_canonical raw) ->
-             Some
-               { field; previous_value = raw; repaired_value = canonical_default }
+           | Some (`String raw) ->
+             (match repair_value raw with
+              | Some repaired_value ->
+                Some { field; previous_value = raw; repaired_value }
+              | None -> None)
            | Some _ | None -> None)
         repairable_enum_fields
     in

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -113,19 +113,85 @@ let parse_trace_history fields =
   | Some trace_id -> invalidf "trace_history contains invalid trace id %S" trace_id
 ;;
 
+let canonical_multimodal_policy_opt raw =
+  match multimodal_policy_of_string raw with
+  | Some policy when String.equal raw (multimodal_policy_to_string policy) ->
+    Some policy
+  | Some _ | None -> None
+;;
+
 let parse_multimodal_policy fields =
   let* raw = string_field fields "multimodal_policy" in
-  match multimodal_policy_of_string raw with
-  | Some policy when String.equal raw (multimodal_policy_to_string policy) -> Ok policy
-  | Some _ | None -> invalidf "multimodal_policy has non-canonical value %S" raw
+  match canonical_multimodal_policy_opt raw with
+  | Some policy -> Ok policy
+  | None -> invalidf "multimodal_policy has non-canonical value %S" raw
+;;
+
+let canonical_proactive_outcome_opt raw =
+  let outcome = proactive_cycle_outcome_of_string raw in
+  if String.equal raw (proactive_cycle_outcome_to_string outcome)
+  then Some outcome
+  else None
 ;;
 
 let parse_proactive_outcome fields =
   let* raw = string_field fields "last_proactive_outcome" in
-  let outcome = proactive_cycle_outcome_of_string raw in
-  if String.equal raw (proactive_cycle_outcome_to_string outcome)
-  then Ok outcome
-  else invalidf "last_proactive_outcome has non-canonical value %S" raw
+  match canonical_proactive_outcome_opt raw with
+  | Some outcome -> Ok outcome
+  | None -> invalidf "last_proactive_outcome has non-canonical value %S" raw
+;;
+
+type enum_field_repair =
+  { field : string
+  ; previous_value : string
+  ; repaired_value : string
+  }
+
+(* Issue #28844: persisted enumerated fields whose non-canonical value has a
+   canonical default — the value the create path writes for a keeper that
+   never exercised the corresponding machinery, so resetting to it is
+   lossless.  A field belongs here only when its corruption has exactly one
+   sane fallback; anything else keeps failing loud. *)
+let repairable_enum_fields =
+  [ ( "last_proactive_outcome"
+    , (fun raw -> Option.is_some (canonical_proactive_outcome_opt raw))
+    , proactive_cycle_outcome_to_string Proactive_never_started )
+  ; ( "multimodal_policy"
+    , (fun raw -> Option.is_some (canonical_multimodal_policy_opt raw))
+    , multimodal_policy_to_string default_multimodal_policy )
+  ]
+;;
+
+let repair_non_canonical_enum_fields json =
+  match json with
+  | `Assoc fields ->
+    let repairs =
+      List.filter_map
+        (fun (field, is_canonical, canonical_default) ->
+           match List.assoc_opt field fields with
+           | Some (`String raw) when not (is_canonical raw) ->
+             Some
+               { field; previous_value = raw; repaired_value = canonical_default }
+           | Some _ | None -> None)
+        repairable_enum_fields
+    in
+    (match repairs with
+     | [] -> None
+     | repairs ->
+       let repaired_fields =
+         List.map
+           (fun (key, value) ->
+              match
+                List.find_opt
+                  (fun repair -> String.equal repair.field key)
+                  repairs
+              with
+              | Some repair -> key, `String repair.repaired_value
+              | None -> key, value)
+           fields
+       in
+       Some (`Assoc repaired_fields, repairs))
+  | _ -> None
 ;;
 
 let parse_last_blocker fields =

--- a/lib/keeper/keeper_meta_json_parse.mli
+++ b/lib/keeper/keeper_meta_json_parse.mli
@@ -19,8 +19,11 @@ val repair_non_canonical_enum_fields :
   Yojson.Safe.t -> (Yojson.Safe.t * enum_field_repair list) option
 (** [Some (repaired, repairs)] when [json] is an object carrying at least one
     enumerated field whose value fails the canonical round-trip and whose
-    field has a canonical default (currently [last_proactive_outcome] and
+    field is repairable (currently [last_proactive_outcome] and
     [multimodal_policy]); [repairs] describes every field that was reset.
+    A recognized value repairs to its canonical spelling (the field parsers
+    trim and lowercase, so ["DELEGATE"] becomes ["delegate"]); only an
+    unrecognized value falls back to the field's canonical default.
     [None] when nothing repairable is present — the caller must keep failing
     loud with the original decode error.  Repair detection uses the same
     canonicality predicates as the decoder, never the error text. *)

--- a/lib/keeper/keeper_meta_json_parse.mli
+++ b/lib/keeper/keeper_meta_json_parse.mli
@@ -6,3 +6,21 @@ val meta_of_json :
     [Keeper_meta_json.meta_to_json]. Missing, wrong-typed, retired, duplicate,
     unknown, or malformed fields are explicit reset-required errors. Nullable
     domain fields still accept their current [`Null] representation. *)
+
+(** One enumerated-field repair: [field] held [previous_value], which is not a
+    canonical spelling of any variant, and is reset to [repaired_value]. *)
+type enum_field_repair =
+  { field : string
+  ; previous_value : string
+  ; repaired_value : string
+  }
+
+val repair_non_canonical_enum_fields :
+  Yojson.Safe.t -> (Yojson.Safe.t * enum_field_repair list) option
+(** [Some (repaired, repairs)] when [json] is an object carrying at least one
+    enumerated field whose value fails the canonical round-trip and whose
+    field has a canonical default (currently [last_proactive_outcome] and
+    [multimodal_policy]); [repairs] describes every field that was reset.
+    [None] when nothing repairable is present — the caller must keep failing
+    loud with the original decode error.  Repair detection uses the same
+    canonicality predicates as the decoder, never the error text. *)

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -45,10 +45,17 @@ let persist_snapshot ?ownership_root path meta =
     change in failure reason, or recovery — tracked as the last reported
     failure detail per (site, path).  The state is process-local on purpose:
     a restarted process reporting a still-bad file once is correct, and no
-    wall-clock interval is involved. *)
+    wall-clock interval is involved.
+
+    Growth bound: one entry per (site, path) that currently fails, plus stale
+    entries for keepers removed from config while failing — those linger for
+    the process lifetime.  Both populations are bounded by the configured
+    keeper count, so the table stays O(failing keepers). *)
 module Problem_report_state = struct
   type site =
     | Meta_read
+    | Meta_read_changed
+    | Meta_repair
     | Keepalive_scan
     | Persistent_scan
 
@@ -128,47 +135,67 @@ let read_meta_file_path ?ownership_root path : (Keeper_meta_contract.keeper_meta
        | Ok meta ->
          if Problem_report_state.note_recovered ~site:Meta_read ~path
          then Log.Keeper.info "keeper meta parse recovered for %s" path;
+         Problem_report_state.clear ~site:Meta_repair ~path;
          Ok (Some meta)
        | Error e ->
          (* Issue #28844: a non-canonical enumerated field used to brick every
             reader until something external rewrote the file.  When the
             corruption is confined to fields with a canonical default, repair
-            in place through the normal serializer and proceed. *)
+            in place through the normal serializer and proceed.  A live
+            writer that keeps re-corrupting the file with the same content
+            re-triggers the (idempotent) repair write each cycle, but the
+            WARN is deduped on the repair detail via [Meta_repair], so the
+            log storm does not return; the residual cost is one atomic
+            rewrite of a small file per scan against an active corrupter. *)
          (match repair_non_canonical_enum_fields json with
           | Some (repaired_json, repairs) ->
+            let repair_detail =
+              repairs
+              |> List.map
+                   (fun (repair : enum_field_repair) ->
+                      Printf.sprintf
+                        "%s %S -> %S"
+                        repair.field
+                        repair.previous_value
+                        repair.repaired_value)
+              |> String.concat ", "
+            in
             (match meta_of_json repaired_json with
              | Ok repaired_meta ->
                (match
                   persist_snapshot ?ownership_root path repaired_meta
                 with
                 | Ok () ->
-                  Log.Keeper.warn
-                    "keeper meta auto-repaired %s: %s"
-                    path
-                    (repairs
-                     |> List.map
-                          (fun (repair : enum_field_repair) ->
-                             Printf.sprintf
-                               "%s %S -> %S"
-                               repair.field
-                               repair.previous_value
-                               repair.repaired_value)
-                     |> String.concat ", ");
+                  if Problem_report_state.should_report
+                       ~site:Meta_repair
+                       ~path
+                       ~detail:repair_detail
+                  then
+                    Log.Keeper.warn
+                      "keeper meta auto-repaired %s: %s"
+                      path
+                      repair_detail;
                   Ok (Some repaired_meta)
                 | Error write_detail ->
                   fail_parse
                     (Printf.sprintf
                        "%s; auto-repair of %s failed to persist: %s"
                        e
-                       (repairs
-                        |> List.map
-                             (fun (repair : enum_field_repair) -> repair.field)
-                        |> String.concat ", ")
+                       repair_detail
                        write_detail))
-             | Error _ ->
+             | Error redecode_detail ->
                (* Resetting the enumerated fields did not make the file
-                  decodable; the original failure stands. *)
-               fail_parse e)
+                  decodable; the original failure stands, with the new
+                  decode error attached when it differs. *)
+               fail_parse
+                 (if String.equal redecode_detail e
+                  then e
+                  else
+                    Printf.sprintf
+                      "%s; auto-repair of %s did not decode: %s"
+                      e
+                      repair_detail
+                      redecode_detail))
           | None -> fail_parse e)))
 ;;
 
@@ -471,28 +498,42 @@ let read_meta_if_changed config name ~(last_mtime : float) : (Keeper_meta_contra
   let read_candidate candidate =
     let path = keeper_meta_path config candidate in
     if not (Fs_compat.file_exists path)
-    then None
+    then (
+      Problem_report_state.clear ~site:Meta_read_changed ~path;
+      None)
     else (
       match Fs_compat.file_mtime path with
       | Some mtime when mtime > last_mtime ->
         (match
            read_meta_file_path ~ownership_root:config.Workspace.base_path path
          with
-         | Ok (Some meta) -> Some (meta, mtime)
-         | Ok None -> None
+         | Ok (Some meta) ->
+           Problem_report_state.clear ~site:Meta_read_changed ~path;
+           Some (meta, mtime)
+         | Ok None ->
+           Problem_report_state.clear ~site:Meta_read_changed ~path;
+           None
          | Error msg ->
            (* Issue #8377: was [_ -> None] which silently treated a
               read/parse failure as "no change". Now logs so an
-              operator can correlate stale UI with bad meta JSON. *)
+              operator can correlate stale UI with bad meta JSON.
+              Issue #28844: the mtime gate alone does not bound the WARN
+              when a live writer keeps touching a still-broken file, so the
+              WARN is deduped on the failure detail like the other sites. *)
            Otel_metric_store.inc_counter
              Keeper_metrics.(to_string MetaReadFailures)
              ~labels:[("keeper", "aggregate"); ("site", "changed_parse")]
              ();
-           Log.Keeper.warn
-             "read_meta_if_changed: parse failed for %s (mtime=%.0f): %s"
-             path
-             mtime
-             msg;
+           if Problem_report_state.should_report
+                ~site:Meta_read_changed
+                ~path
+                ~detail:msg
+           then
+             Log.Keeper.warn
+               "read_meta_if_changed: parse failed for %s (mtime=%.0f): %s"
+               path
+               mtime
+               msg;
            None)
       | _ -> None)
   in

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -8,32 +8,159 @@ open Keeper_types_profile
 open Keeper_meta_contract
 open Keeper_meta_json
 
-let read_meta_file_path path : (Keeper_meta_contract.keeper_meta option, string) result =
+let settle_durable_replace path = function
+  | Ok () -> Ok ()
+  | Error error ->
+    Error
+      (Printf.sprintf
+         "failed to durably write metadata %s: %s"
+         path
+         (Keeper_fs.durable_write_error_to_string error))
+;;
+
+let settle_durable_remove path = function
+  | Ok () -> Ok ()
+  | Error error ->
+    Error
+      (Printf.sprintf
+         "failed to durably remove metadata %s: %s"
+         path
+         (Keeper_fs.durable_remove_error_to_string error))
+;;
+
+(** The one durable snapshot write: normal serializer plus atomic durable
+    commit.  Both the Owner write path ([replace_snapshot]) and the
+    enumerated-field auto-repair in [read_meta_file_path] go through here, so
+    a repaired file is byte-identical in shape to any other persisted
+    snapshot. *)
+let persist_snapshot ?ownership_root path meta =
+  let payload = meta |> meta_to_json |> Yojson.Safe.pretty_to_string in
+  Keeper_fs.save_bytes_durable_atomic ?ownership_root path payload
+  |> settle_durable_replace path
+;;
+
+(** Issue #28844: one corrupt meta file used to produce an identical WARN on
+    every periodic scan iteration (422 in three minutes).  WARNs are now
+    emitted on state transitions only — a (site, path)'s first failure, a
+    change in failure reason, or recovery — tracked as the last reported
+    failure detail per (site, path).  The state is process-local on purpose:
+    a restarted process reporting a still-bad file once is correct, and no
+    wall-clock interval is involved. *)
+module Problem_report_state = struct
+  type site =
+    | Meta_read
+    | Keepalive_scan
+    | Persistent_scan
+
+  module Key = struct
+    type t = site * string
+
+    let equal (site_a, path_a) (site_b, path_b) =
+      site_a = site_b && String.equal path_a path_b
+    ;;
+
+    let hash = Hashtbl.hash
+  end
+
+  module Table = Hashtbl.Make (Key)
+
+  let reported : string Table.t = Table.create 16
+  let mutex = Stdlib.Mutex.create ()
+
+  (** [true] when (site, path, detail) is a new problem state and the caller
+      should log; [false] while the same failure keeps repeating. *)
+  let should_report ~site ~path ~detail =
+    Stdlib.Mutex.protect mutex (fun () ->
+      let key = site, path in
+      match Table.find_opt reported key with
+      | Some previous when String.equal previous detail -> false
+      | _ ->
+        Table.replace reported key detail;
+        true)
+  ;;
+
+  (** [true] when a previously reported problem cleared — the caller may log
+      the recovery transition once. *)
+  let note_recovered ~site ~path =
+    Stdlib.Mutex.protect mutex (fun () ->
+      let key = site, path in
+      match Table.find_opt reported key with
+      | None -> false
+      | Some _ ->
+        Table.remove reported key;
+        true)
+  ;;
+end
+
+let read_meta_file_path ?ownership_root path : (Keeper_meta_contract.keeper_meta option, string) result =
+  let fail_parse detail =
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string MetaReadFailures)
+      ~labels:[("keeper", "aggregate"); ("site", "meta_parse")]
+      ();
+    if Problem_report_state.should_report ~site:Meta_read ~path ~detail
+    then Log.Keeper.warn "keeper meta parse failed for %s: %s" path detail;
+    Error
+      (Printf.sprintf
+         "keeper meta invalid current schema at %s; runtime reset \
+          required: %s"
+         path
+         detail)
+  in
   if not (Fs_compat.file_exists path)
-  then Ok None
+  then (
+    ignore (Problem_report_state.note_recovered ~site:Meta_read ~path);
+    Ok None)
   else (
     match Safe_ops.read_json_file_safe path with
     | Error e -> Error e
     | Ok json ->
-      (* The unknown-key pre-scan that used to run here is gone: [meta_of_json]
-         now decodes only the exact current shape, so an unknown top-level key
-         is already a decode error rather than something a separate scan has to
-         notice first. Keeping both would report the same drift twice under two
-         different messages. *)
       (match meta_of_json json with
-       | Ok meta -> Ok (Some meta)
+       | Ok meta ->
+         if Problem_report_state.note_recovered ~site:Meta_read ~path
+         then Log.Keeper.info "keeper meta parse recovered for %s" path;
+         Ok (Some meta)
        | Error e ->
-         Otel_metric_store.inc_counter
-           Keeper_metrics.(to_string MetaReadFailures)
-           ~labels:[("keeper", "aggregate"); ("site", "meta_parse")]
-           ();
-         Log.Keeper.warn "keeper meta parse failed for %s: %s" path e;
-         Error
-           (Printf.sprintf
-              "keeper meta invalid current schema at %s; runtime reset \
-               required: %s"
-              path
-              e)))
+         (* Issue #28844: a non-canonical enumerated field used to brick every
+            reader until something external rewrote the file.  When the
+            corruption is confined to fields with a canonical default, repair
+            in place through the normal serializer and proceed. *)
+         (match repair_non_canonical_enum_fields json with
+          | Some (repaired_json, repairs) ->
+            (match meta_of_json repaired_json with
+             | Ok repaired_meta ->
+               (match
+                  persist_snapshot ?ownership_root path repaired_meta
+                with
+                | Ok () ->
+                  Log.Keeper.warn
+                    "keeper meta auto-repaired %s: %s"
+                    path
+                    (repairs
+                     |> List.map
+                          (fun (repair : enum_field_repair) ->
+                             Printf.sprintf
+                               "%s %S -> %S"
+                               repair.field
+                               repair.previous_value
+                               repair.repaired_value)
+                     |> String.concat ", ");
+                  Ok (Some repaired_meta)
+                | Error write_detail ->
+                  fail_parse
+                    (Printf.sprintf
+                       "%s; auto-repair of %s failed to persist: %s"
+                       e
+                       (repairs
+                        |> List.map
+                             (fun (repair : enum_field_repair) -> repair.field)
+                        |> String.concat ", ")
+                       write_detail))
+             | Error _ ->
+               (* Resetting the enumerated fields did not make the file
+                  decodable; the original failure stands. *)
+               fail_parse e)
+          | None -> fail_parse e)))
 ;;
 
 let persisted_keeper_names_result config =
@@ -65,7 +192,11 @@ let persisted_keeper_name_for_agent_name config ~agent_name =
   let rec collect_matches matches = function
     | [] -> Ok (List.rev matches)
     | keeper_name :: rest ->
-      (match read_meta_file_path (keeper_meta_path config keeper_name) with
+      (match
+         read_meta_file_path
+           ~ownership_root:config.Workspace.base_path
+           (keeper_meta_path config keeper_name)
+       with
        | Error detail -> Error detail
        | Ok None -> collect_matches matches rest
        | Ok (Some meta) ->
@@ -91,7 +222,11 @@ let persisted_keeper_name_for_agent_name config ~agent_name =
 let persisted_keeper_for_mention_target config ~mention_target =
   let target = Keeper_identity.Keeper_id.of_string mention_target in
   let read_effective keeper_name =
-    match read_meta_file_path (keeper_meta_path config keeper_name) with
+    match
+      read_meta_file_path
+        ~ownership_root:config.Workspace.base_path
+        (keeper_meta_path config keeper_name)
+    with
     | Error _ as error -> error
     | Ok None -> Ok None
     | Ok (Some meta) ->
@@ -190,12 +325,19 @@ let effective_autoboot_enabled config name meta =
 let keepalive_keeper_names config =
   configured_keeper_names config
   |> List.filter_map (fun name ->
-    match read_meta_file_path (keeper_meta_path config name) with
+    let path = keeper_meta_path config name in
+    match
+      read_meta_file_path ~ownership_root:config.Workspace.base_path path
+    with
     | Ok (Some meta)
       when (not meta.paused) && effective_autoboot_enabled config name meta ->
+        ignore (Problem_report_state.note_recovered ~site:Keepalive_scan ~path);
         Some meta.name
-    | Ok (Some _) -> None
+    | Ok (Some _) ->
+      ignore (Problem_report_state.note_recovered ~site:Keepalive_scan ~path);
+      None
     | Ok None ->
+      ignore (Problem_report_state.note_recovered ~site:Keepalive_scan ~path);
       if declarative_autoboot_enabled_by_default config name then Some name
       else None
     | Error msg ->
@@ -203,15 +345,18 @@ let keepalive_keeper_names config =
          failures silently into "name disappeared". Discovery would
          treat a corrupt meta file as if the keeper was deleted,
          hiding the operational issue. Now logs and excludes so the
-         degraded state is operator-visible. *)
+         degraded state is operator-visible.  Issue #28844: the WARN
+         fires on failure-state transitions only, not per scan. *)
       Otel_metric_store.inc_counter
         Keeper_metrics.(to_string MetaReadFailures)
         ~labels:[("keeper", name); ("site", "keepalive_read")]
         ();
-      Log.Keeper.warn
-        "keepalive_keeper_names: meta read failed for %s, dropping from keepalive set: %s"
-        name
-        msg;
+      if Problem_report_state.should_report ~site:Keepalive_scan ~path ~detail:msg
+      then
+        Log.Keeper.warn
+          "keepalive_keeper_names: meta read failed for %s, dropping from keepalive set: %s"
+          name
+          msg;
       None)
 ;;
 
@@ -225,25 +370,36 @@ let keepalive_keeper_names config =
 let persistent_agent_names config =
   configured_keeper_names config
   |> List.filter_map (fun name ->
-    match read_meta_file_path (keeper_meta_path config name) with
+    let path = keeper_meta_path config name in
+    match
+      read_meta_file_path ~ownership_root:config.Workspace.base_path path
+    with
     | Ok (Some meta)
       when (not meta.paused) && effective_autoboot_enabled config name meta ->
+        ignore (Problem_report_state.note_recovered ~site:Persistent_scan ~path);
         Some meta.name
-    | Ok (Some _) -> None
-    | Ok None -> None
+    | Ok (Some _) ->
+      ignore (Problem_report_state.note_recovered ~site:Persistent_scan ~path);
+      None
+    | Ok None ->
+      ignore (Problem_report_state.note_recovered ~site:Persistent_scan ~path);
+      None
     | Error msg ->
       (* Issue #8377: same anti-pattern as keepalive_keeper_names:
          Error was silently collapsed into None. Operator can't
          distinguish "keeper intentionally not persistent" from
-         "meta file is corrupt and we couldn't read it". *)
+         "meta file is corrupt and we couldn't read it".  Issue #28844:
+         the WARN fires on failure-state transitions only. *)
       Otel_metric_store.inc_counter
         Keeper_metrics.(to_string MetaReadFailures)
         ~labels:[("keeper", name); ("site", "persistent_read")]
         ();
-      Log.Keeper.warn
-        "persistent_agent_names: meta read failed for %s, treating as non-persistent: %s"
-        name
-        msg;
+      if Problem_report_state.should_report ~site:Persistent_scan ~path ~detail:msg
+      then
+        Log.Keeper.warn
+          "persistent_agent_names: meta read failed for %s, treating as non-persistent: %s"
+          name
+          msg;
       None)
 ;;
 
@@ -252,7 +408,9 @@ let read_meta_resolved config name : ((string * Keeper_meta_contract.keeper_meta
   if requested_name = ""
   then Ok None
   else
-    read_meta_file_path (keeper_meta_path config requested_name)
+    read_meta_file_path
+      ~ownership_root:config.Workspace.base_path
+      (keeper_meta_path config requested_name)
     |> Result.map (Option.map (fun meta -> requested_name, meta))
 ;;
 
@@ -308,7 +466,9 @@ let read_meta_if_changed config name ~(last_mtime : float) : (Keeper_meta_contra
     else (
       match Fs_compat.file_mtime path with
       | Some mtime when mtime > last_mtime ->
-        (match read_meta_file_path path with
+        (match
+           read_meta_file_path ~ownership_root:config.Workspace.base_path path
+         with
          | Ok (Some meta) -> Some (meta, mtime)
          | Ok None -> None
          | Error msg ->
@@ -330,37 +490,12 @@ let read_meta_if_changed config name ~(last_mtime : float) : (Keeper_meta_contra
   read_candidate requested_name
 ;;
 
-let settle_durable_replace path = function
-  | Ok () -> Ok ()
-  | Error error ->
-    Error
-      (Printf.sprintf
-         "failed to durably write metadata %s: %s"
-         path
-         (Keeper_fs.durable_write_error_to_string error))
-;;
-
-let settle_durable_remove path = function
-  | Ok () -> Ok ()
-  | Error error ->
-    Error
-      (Printf.sprintf
-         "failed to durably remove metadata %s: %s"
-         path
-         (Keeper_fs.durable_remove_error_to_string error))
-;;
-
 let replace_snapshot config (persisted : Keeper_meta_contract.keeper_meta) =
   let path = keeper_meta_path config persisted.name in
   match Keeper_meta_contract.terminal_latch_pause_violation persisted with
   | Some detail -> Error ("Keeper metadata invariant violation: " ^ detail)
   | None ->
-    let payload = persisted |> meta_to_json |> Yojson.Safe.pretty_to_string in
-    Keeper_fs.save_bytes_durable_atomic
-      ~ownership_root:config.Workspace.base_path
-      path
-      payload
-    |> settle_durable_replace path
+    persist_snapshot ~ownership_root:config.Workspace.base_path path persisted
 ;;
 
 let remove_snapshot config ~name =

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -90,6 +90,15 @@ module Problem_report_state = struct
         Table.remove reported key;
         true)
   ;;
+
+  (** Drop any reported problem state for (site, path) without observing
+      whether one existed.  For outcomes whose recovery transition is not
+      logged — the file disappeared, or the scan site whose recovery the
+      [Meta_read] site already reports — the clear itself is the whole
+      operation. *)
+  let clear ~site ~path =
+    Stdlib.Mutex.protect mutex (fun () -> Table.remove reported (site, path))
+  ;;
 end
 
 let read_meta_file_path ?ownership_root path : (Keeper_meta_contract.keeper_meta option, string) result =
@@ -109,7 +118,7 @@ let read_meta_file_path ?ownership_root path : (Keeper_meta_contract.keeper_meta
   in
   if not (Fs_compat.file_exists path)
   then (
-    ignore (Problem_report_state.note_recovered ~site:Meta_read ~path);
+    Problem_report_state.clear ~site:Meta_read ~path;
     Ok None)
   else (
     match Safe_ops.read_json_file_safe path with
@@ -331,13 +340,13 @@ let keepalive_keeper_names config =
     with
     | Ok (Some meta)
       when (not meta.paused) && effective_autoboot_enabled config name meta ->
-        ignore (Problem_report_state.note_recovered ~site:Keepalive_scan ~path);
+        Problem_report_state.clear ~site:Keepalive_scan ~path;
         Some meta.name
     | Ok (Some _) ->
-      ignore (Problem_report_state.note_recovered ~site:Keepalive_scan ~path);
+      Problem_report_state.clear ~site:Keepalive_scan ~path;
       None
     | Ok None ->
-      ignore (Problem_report_state.note_recovered ~site:Keepalive_scan ~path);
+      Problem_report_state.clear ~site:Keepalive_scan ~path;
       if declarative_autoboot_enabled_by_default config name then Some name
       else None
     | Error msg ->
@@ -376,13 +385,13 @@ let persistent_agent_names config =
     with
     | Ok (Some meta)
       when (not meta.paused) && effective_autoboot_enabled config name meta ->
-        ignore (Problem_report_state.note_recovered ~site:Persistent_scan ~path);
+        Problem_report_state.clear ~site:Persistent_scan ~path;
         Some meta.name
     | Ok (Some _) ->
-      ignore (Problem_report_state.note_recovered ~site:Persistent_scan ~path);
+      Problem_report_state.clear ~site:Persistent_scan ~path;
       None
     | Ok None ->
-      ignore (Problem_report_state.note_recovered ~site:Persistent_scan ~path);
+      Problem_report_state.clear ~site:Persistent_scan ~path;
       None
     | Error msg ->
       (* Issue #8377: same anti-pattern as keepalive_keeper_names:

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -6,9 +6,22 @@
 
 (** Read a keeper meta JSON file at [path]. Returns [Ok None] when
     the file does not exist. Unknown top-level keys are rejected with a
-    reset-required error; the persisted file is never rewritten. *)
+    reset-required error.
+
+    Issue #28844: a non-canonical value in an enumerated field with a
+    canonical default (e.g. [last_proactive_outcome]) is auto-repaired in
+    place through the normal serializer and the read proceeds; all other
+    corruption keeps failing loud and the file is left untouched.
+    [ownership_root] scopes the durable directory-chain fsync of the repair
+    write when the caller knows the workspace root.
+
+    The parse-failure WARN is emitted on state transitions (new failure,
+    changed failure reason, recovery) per (site, path), not on every
+    repeated read of the same broken file. *)
 val read_meta_file_path :
-  string -> (Keeper_meta_contract.keeper_meta option, string) result
+  ?ownership_root:string ->
+  string ->
+  (Keeper_meta_contract.keeper_meta option, string) result
 
 (** [true] when [f] has an exact canonical Keeper-metadata interpretation. *)
 (** List keeper names with persisted JSON in [.masc/keepers/].
@@ -48,7 +61,8 @@ val effective_autoboot_enabled :
 
 (** Names of keepers eligible for the keepalive fiber set —
     autoboot enabled, not paused. Logs and excludes on read failure
-    (issue #8377). *)
+    (issue #8377); the WARN fires on failure-state transitions only
+    (issue #28844). *)
 val keepalive_keeper_names : Workspace.config -> string list
 
 (** Names of keepers expected to persist across sessions. Mirrors

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -136,7 +136,11 @@ type autoboot_exclusion = {
 }
 
 let autoboot_exclusion_reason config name =
-  match read_meta_file_path (keeper_meta_path config name) with
+  match
+    read_meta_file_path
+      ~ownership_root:config.Workspace.base_path
+      (keeper_meta_path config name)
+  with
   | Ok (Some meta) ->
     if meta.paused then Some Paused
     else

--- a/lib/keeper_catchup_digest.ml
+++ b/lib/keeper_catchup_digest.ml
@@ -581,7 +581,9 @@ let build ~base_path ~keeper_name ~since_unix ~now_unix =
   in
   let paused_now =
     let meta_path = Filename.concat keepers_dir (keeper_name ^ ".json") in
-    match Keeper_meta_store.read_meta_file_path meta_path with
+    match
+      Keeper_meta_store.read_meta_file_path ~ownership_root:base_path meta_path
+    with
     | Ok (Some m) -> m.Keeper_meta_contract.paused
     | Ok None -> false
     | Error e ->

--- a/test/dune
+++ b/test/dune
@@ -2470,6 +2470,8 @@
 
 (include stanzas/test_keeper_meta_current_schema.inc)
 
+(include stanzas/test_keeper_meta_invalid_recovery.inc)
+
 (include stanzas/test_keeper_compact_recovery_tool_surface.inc)
 
 (test

--- a/test/stanzas/test_keeper_meta_invalid_recovery.inc
+++ b/test/stanzas/test_keeper_meta_invalid_recovery.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_meta_invalid_recovery)
+ (modules test_keeper_meta_invalid_recovery)
+ (libraries masc alcotest masc_test_deps))

--- a/test/test_keeper_meta_invalid_recovery.ml
+++ b/test/test_keeper_meta_invalid_recovery.ml
@@ -1,0 +1,271 @@
+(** Issue #28844: keeper meta invalid-value recovery.
+
+    Feature tests for the 2026-08-16 incident where one non-canonical
+    [last_proactive_outcome] value (["\"\"​"]) bricked a keeper: the strict
+    parser demanded "runtime reset required", the keepalive scan re-logged the
+    same WARN every iteration, and the keeper dropped out of the keepalive
+    set until an external rewrite fixed the file.
+
+    Two behaviors are pinned here at the scan/store level:
+    1. A non-canonical enumerated field with a canonical default is
+       auto-repaired in place through the normal serializer, so the keeper
+       rejoins the keepalive set without operator intervention.
+    2. The parse-failure WARN is emitted on state transitions (new failure,
+       changed reason, recovery) — not on every periodic iteration. *)
+
+open Alcotest
+open Masc
+
+let rec rm_rf path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path)
+    else Sys.remove path
+;;
+
+let rec mkdir_p path =
+  if not (Sys.file_exists path)
+  then (
+    let parent = Filename.dirname path in
+    if not (String.equal parent path) then mkdir_p parent;
+    Unix.mkdir path 0o755)
+;;
+
+let write_file path content =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+;;
+
+let with_temp_workspace f =
+  let base_path = Filename.temp_dir "keeper-meta-invalid-recovery" "" in
+  let config = Workspace.default_config base_path in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_path)
+    (fun () ->
+      ignore (Workspace.init config ~agent_name:None);
+      f config)
+;;
+
+let write_keeper_toml config name =
+  let keepers_dir =
+    Config_dir_resolver.keepers_dir_for_base_path
+      ~base_path:config.Workspace.base_path
+  in
+  mkdir_p keepers_dir;
+  write_file
+    (Filename.concat keepers_dir (name ^ ".toml"))
+    "[keeper]\ninstructions = \"test keeper\"\nsandbox_profile = \"local\"\n"
+;;
+
+let keeper_meta_path config name =
+  Keeper_types_profile.keeper_meta_path config name
+;;
+
+let replace_field field value json =
+  match json with
+  | `Assoc fields -> `Assoc ((field, value) :: List.remove_assoc field fields)
+  | _ -> fail "keeper meta fixture must be a JSON object"
+;;
+
+let write_corrupted_meta config name ~field ~value =
+  let json =
+    Masc_test_deps.current_meta_json_fixture ~name () |> replace_field field value
+  in
+  let path = keeper_meta_path config name in
+  write_file path (Yojson.Safe.pretty_to_string json);
+  path
+;;
+
+(* [Log.Ring] is the typed in-process log sink; filtering on the unique
+   keeper name keeps assertions exact without scraping stderr. *)
+let latest_seq () =
+  match Log.Ring.recent ~limit:1 () with
+  | entry :: _ -> entry.Log.Ring.seq
+  | [] -> 0
+;;
+
+let keeper_entries_since seq =
+  Log.Ring.recent ~limit:1000 ~since_seq:seq ~module_filter:"Keeper" ~order:`Oldest_first ()
+;;
+
+let entries_about needle entries =
+  List.filter
+    (fun (entry : Log.Ring.entry) ->
+       Astring.String.is_infix ~affix:needle entry.message)
+    entries
+;;
+
+let warns entries =
+  List.filter (fun (entry : Log.Ring.entry) -> entry.level = Log.Warn) entries
+;;
+
+let infos entries =
+  List.filter (fun (entry : Log.Ring.entry) -> entry.level = Log.Info) entries
+;;
+
+let test_auto_repair_unbricks_keepalive () =
+  with_temp_workspace @@ fun config ->
+  let name = "meta-repair-canary" in
+  write_keeper_toml config name;
+  let path =
+    write_corrupted_meta config name ~field:"last_proactive_outcome" ~value:(`String "")
+  in
+  (* Sentinel values prove the repair rewrites only the offending field. *)
+  let corrupted =
+    Yojson.Safe.from_string (Masc_test_deps.read_file path)
+    |> replace_field "instructions" (`String "keep me")
+    |> replace_field "total_turns" (`Int 41)
+  in
+  write_file path (Yojson.Safe.pretty_to_string corrupted);
+  let base_seq = latest_seq () in
+  (* The keepalive scan is the path that dropped the keeper in the incident. *)
+  let names = Keeper_meta_store.keepalive_keeper_names config in
+  check
+    (list string)
+    "keeper rejoins keepalive set after auto-repair"
+    [ name ]
+    names;
+  (* The file was rewritten through the normal serializer: the offending
+     field carries its canonical default, every other field survives. *)
+  (match Yojson.Safe.from_string (Masc_test_deps.read_file path) with
+   | `Assoc fields ->
+     check
+       string
+       "last_proactive_outcome reset to canonical default"
+       "never_started"
+       (match List.assoc "last_proactive_outcome" fields with
+        | `String value -> value
+        | other -> Yojson.Safe.to_string other);
+     check
+       string
+       "instructions preserved"
+       "keep me"
+       (match List.assoc "instructions" fields with
+        | `String value -> value
+        | other -> Yojson.Safe.to_string other);
+     check
+       int
+       "total_turns preserved"
+       41
+       (match List.assoc "total_turns" fields with
+        | `Int value -> value
+        | _ -> -1)
+   | _ -> fail "repaired meta file is not a JSON object");
+  (* The read path serves the repaired meta. *)
+  (match Keeper_meta_store.read_meta config name with
+   | Ok (Some meta) ->
+     check
+       int
+       "read_meta returns repaired snapshot"
+       41
+       meta.Keeper_meta_contract.runtime.usage.total_turns
+   | Ok None -> fail "read_meta lost the keeper after repair"
+   | Error detail -> failf "read_meta still rejects repaired meta: %s" detail);
+  (* Exactly one repair WARN; a second scan of the now-healthy file is
+     silent. *)
+  let first_scan_entries = entries_about name (keeper_entries_since base_seq) in
+  check
+    int
+    "one auto-repair WARN per repair"
+    1
+    (List.length
+       (warns first_scan_entries
+        |> List.filter (fun (entry : Log.Ring.entry) ->
+             Astring.String.is_infix ~affix:"auto-repaired" entry.message)));
+  let second_seq = latest_seq () in
+  let names = Keeper_meta_store.keepalive_keeper_names config in
+  check (list string) "keeper stays in keepalive set" [ name ] names;
+  check
+    int
+    "second scan of repaired file logs nothing"
+    0
+    (List.length (entries_about name (keeper_entries_since second_seq)))
+;;
+
+let test_scan_warns_on_state_transitions_only () =
+  with_temp_workspace @@ fun config ->
+  let name = "meta-dedupe-canary" in
+  write_keeper_toml config name;
+  (* A zero generation is non-enumerated corruption: no canonical default
+     exists, so the file stays unreadable and the WARN state persists. *)
+  let path = write_corrupted_meta config name ~field:"generation" ~value:(`Int 0) in
+  let base_seq = latest_seq () in
+  ignore (Keeper_meta_store.keepalive_keeper_names config);
+  let first_episode =
+    warns (entries_about name (keeper_entries_since base_seq))
+  in
+  check int "first failure is logged" 2 (List.length first_episode);
+  (* Repeated scans of the same (path, failure-reason) state are silent. *)
+  let repeat_seq = latest_seq () in
+  ignore (Keeper_meta_store.keepalive_keeper_names config);
+  ignore (Keeper_meta_store.keepalive_keeper_names config);
+  check
+    int
+    "repeated scans of an unchanged failure log nothing"
+    0
+    (List.length (entries_about name (keeper_entries_since repeat_seq)));
+  (* Recovery is a transition: the keeper rejoins the set and the recovery
+     is logged once. *)
+  let valid = Masc_test_deps.current_meta_json_fixture ~name () in
+  write_file path (Yojson.Safe.pretty_to_string valid);
+  let recovery_seq = latest_seq () in
+  let names = Keeper_meta_store.keepalive_keeper_names config in
+  check (list string) "keeper rejoins keepalive set after external fix" [ name ] names;
+  let recovery_entries = entries_about name (keeper_entries_since recovery_seq) in
+  check int "recovery emits no WARN" 0 (List.length (warns recovery_entries));
+  check int "recovery is logged once" 1 (List.length (infos recovery_entries));
+  (* A later identical failure is a new state (the previous one cleared), so
+     it is logged again — dedupe is state-based, not a time-based rate
+     limiter that would still be suppressing it. *)
+  ignore (write_corrupted_meta config name ~field:"generation" ~value:(`Int 0));
+  let relapse_seq = latest_seq () in
+  ignore (Keeper_meta_store.keepalive_keeper_names config);
+  check
+    int
+    "identical failure after recovery logs again"
+    2
+    (List.length (warns (entries_about name (keeper_entries_since relapse_seq))))
+;;
+
+let test_non_enumerated_corruption_fails_loud () =
+  with_temp_workspace @@ fun config ->
+  let name = "meta-fail-loud-canary" in
+  write_keeper_toml config name;
+  let path = write_corrupted_meta config name ~field:"generation" ~value:(`Int 0) in
+  let before = Masc_test_deps.read_file path in
+  (match Keeper_meta_store.read_meta config name with
+   | Error detail ->
+     check
+       bool
+       "non-enumerated corruption still requires reset"
+       true
+       (Astring.String.is_infix ~affix:"runtime reset required" detail)
+   | Ok _ -> fail "non-enumerated corruption was silently accepted");
+  check string "corrupt file is not rewritten" before (Masc_test_deps.read_file path)
+;;
+
+let () =
+  run
+    "keeper_meta_invalid_recovery"
+    [ ( "issue-28844"
+      , [ test_case
+            "non-canonical enumerated field is auto-repaired and keeper rejoins keepalive"
+            `Quick
+            test_auto_repair_unbricks_keepalive
+        ; test_case
+            "scan WARN is emitted on state transitions only"
+            `Quick
+            test_scan_warns_on_state_transitions_only
+        ; test_case
+            "non-enumerated corruption still fails loud"
+            `Quick
+            test_non_enumerated_corruption_fails_loud
+        ] )
+    ]
+;;

--- a/test/test_keeper_meta_invalid_recovery.ml
+++ b/test/test_keeper_meta_invalid_recovery.ml
@@ -250,6 +250,56 @@ let test_non_enumerated_corruption_fails_loud () =
   check string "corrupt file is not rewritten" before (Masc_test_deps.read_file path)
 ;;
 
+let test_recognized_misspelling_repairs_to_canonical_spelling () =
+  with_temp_workspace @@ fun config ->
+  let name = "meta-spelling-canary" in
+  write_keeper_toml config name;
+  (* Both of_string parsers trim and lowercase, so these are recognized
+     values with a spelling defect — the operator intent is unambiguous and
+     repair must keep it, not reset to the field default. *)
+  let path =
+    write_corrupted_meta config name ~field:"multimodal_policy" ~value:(`String "DELEGATE")
+  in
+  let corrupted =
+    Yojson.Safe.from_string (Masc_test_deps.read_file path)
+    |> replace_field "last_proactive_outcome" (`String "SILENT")
+  in
+  write_file path (Yojson.Safe.pretty_to_string corrupted);
+  (match Keeper_meta_store.read_meta config name with
+   | Ok (Some meta) ->
+     check
+       string
+       "multimodal_policy keeps recognized intent"
+       "delegate"
+       (Keeper_types_profile.multimodal_policy_to_string
+          meta.Keeper_meta_contract.multimodal_policy);
+     check
+       string
+       "last_proactive_outcome keeps recognized intent"
+       "silent"
+       (Keeper_meta_contract.proactive_cycle_outcome_to_string
+          meta.runtime.proactive_rt.last_outcome)
+   | Ok None -> fail "read_meta lost the keeper"
+   | Error detail -> failf "recognized misspelling was rejected: %s" detail);
+  (match Yojson.Safe.from_string (Masc_test_deps.read_file path) with
+   | `Assoc fields ->
+     check
+       string
+       "persisted policy is the canonical spelling"
+       "delegate"
+       (match List.assoc "multimodal_policy" fields with
+        | `String value -> value
+        | other -> Yojson.Safe.to_string other);
+     check
+       string
+       "persisted outcome is the canonical spelling"
+       "silent"
+       (match List.assoc "last_proactive_outcome" fields with
+        | `String value -> value
+        | other -> Yojson.Safe.to_string other)
+   | _ -> fail "repaired meta file is not a JSON object")
+;;
+
 let () =
   run
     "keeper_meta_invalid_recovery"
@@ -258,6 +308,10 @@ let () =
             "non-canonical enumerated field is auto-repaired and keeper rejoins keepalive"
             `Quick
             test_auto_repair_unbricks_keepalive
+        ; test_case
+            "recognized misspelling repairs to its canonical spelling"
+            `Quick
+            test_recognized_misspelling_repairs_to_canonical_spelling
         ; test_case
             "scan WARN is emitted on state transitions only"
             `Quick


### PR DESCRIPTION
## 무엇

2026-08-16 06:00–06:03Z 인시던트(task-339): keeper meta 파일의 `last_proactive_outcome`이 비정규 값(`""`) 하나만으로 해당 keeper의 수명주기 전체가 마비됐다.

- strict parser가 "runtime reset required"로 거부 (`keeper_meta_json_parse.ml`)
- 주기 스캔이 반복될 때마다 동일 WARN 재출력 — 3분에 422건
- `keepalive_keeper_names`가 keeper를 keepalive 집합에서 제외, `create_keeper` 부팅도 거부 — 외부가 파일을 정규 값으로 다시 써줄 때까지 brick

## 변경

1. **자동 복구** — `read_meta_file_path`가 디코드 실패 시, 정규 기본값이 존재하는 열거형 필드(`last_proactive_outcome` → `never_started`, `multimodal_policy` → `inherit`)의 비정규 값을 typed predicate(디코더와 동일한 canonicality 검사, 에러 문자열 매칭 아님)로 감지해 기본값으로 되돌린 뒤 **기존 serializer/durable-write 경로**(`replace_snapshot`와 공유하는 `persist_snapshot`)로 파일을 다시 쓰고 진행한다. 나머지 필드는 전부 보존. 복구 불가(비열거형 손상, 재디코드 실패, 쓰기 실패)는 기존처럼 loud하게 실패하고 파일을 건드리지 않는다.
2. **WARN dedupe (시간이 아니라 상태 기준)** — parse-failure WARN과 keepalive/persistent 스캔 WARN을 (site, path)별 마지막 실패 사유와 비교해 **상태 전이 시에만** 출력: 신규 실패, 실패 사유 변경, 복구(1회 info). magic interval 기반 rate limiter 아님. 메트릭 카운터는 매 발생 시 증가 유지.

## 검증

신규 feature 테스트 `test/test_keeper_meta_invalid_recovery.ml` (TDD: 구현 전 red 확인 — 인시던트 그대로 keeper가 keepalive 집합에서 탈락하는 것 재현):

- 비정규 `last_proactive_outcome` → 자동 복구 + keeper가 keepalive 집합에 복귀 + 다른 필드(instructions/total_turns) 보존 + 두 번째 스캔 무로그
- 비열거형 손상(generation=0) → 첫 실패만 WARN, 반복 스캔 무로그, 외부 수정 후 복구 1회 로그 + 재합류, 동일 실패 재발 시 다시 로그(시간 기반 억제가 아님을 증명)
- 비열거형 손상은 여전히 "runtime reset required"로 실패 + 파일 미변경

```
scripts/dune-local.sh build test/test_keeper_meta_invalid_recovery.exe
_build/default/test/test_keeper_meta_invalid_recovery.exe  → 3/3 OK
```

인접 회귀 스위트: keeper_meta_current_schema 8, current_keyset 3, cwd_resilience 1, effective_meta_overlay 25, status_bridge 8, warn_root_causes 10, transition_audit 21, schedule_consumer_dispatch 28, schedule_tool_wiring 16, keeper_owner 39, paused_work_operator 4 — 전부 PASS. `bin/main_eio.exe` 빌드 OK. (`test_keeper_keepalive_helpers`의 `current_task_reconciliation` 1건 실패는 base a8622c23d5에서도 동일하게 실패하는 기존 결함 — 본 변경 무관.)

Closes #28844

🤖 Generated with [Claude Code](https://claude.com/claude-code)