### PR TITLE
fix(keeper): interrupt 분류를 원장까지 운반 + Eio 조합 shape 언랩 (#28868 리뷰 P0/P1)

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1364,17 +1364,13 @@ let run_turn
           ());
        receipt_result)
 with
-| Keeper_registry.Operator_interrupt as e ->
-  (* Bare form: [Switch.fail] on the turn switch re-raises the exception
-     itself at the [Switch.run] boundary; only fibers inside see the
-     [Cancelled]-wrapped form below (#28810). Same bookkeeping, same
-     re-raise. *)
+| exn when Keeper_registry_types.is_operator_interrupt exn ->
+  (* Every delivery shape — bare at the [Switch.run] boundary,
+     [Cancelled]-wrapped inside the switch, [Finally_raised]/[Multiple]
+     combinations — records the same failure reason and re-raises
+     unchanged (#28810, #28868 review). *)
   Keeper_registry.set_failure_reason
     ~base_path:config.base_path meta.name (Some Keeper_registry.Operator_interrupt);
-  raise e
-| Eio.Cancel.Cancelled Keeper_registry.Operator_interrupt as ce ->
-  Keeper_registry.set_failure_reason
-    ~base_path:config.base_path meta.name (Some Keeper_registry.Operator_interrupt);
-  raise ce
+  raise exn
 | Eio.Cancel.Cancelled _ as ce ->
   raise ce

--- a/lib/keeper/keeper_owner.ml
+++ b/lib/keeper/keeper_owner.ml
@@ -598,12 +598,12 @@ let start
                   ; detail = "Keeper owner stopped the active turn"
                   ; outcome_ref = None
                   }
-              | Keeper_registry_types.Operator_interrupt
-              | Eio.Cancel.Cancelled Keeper_registry_types.Operator_interrupt ->
+              | exn when Keeper_registry_types.is_operator_interrupt exn ->
                 (* Typed operator cancellation (#28810): the interrupt route
-                   fails the turn switch with this exception — bare at the
-                   switch boundary, [Cancelled]-wrapped inside it. Neither
-                   form is an internal error. *)
+                   fails the turn switch with this exception. The guard
+                   covers every delivery shape — bare, [Cancelled]-wrapped,
+                   and [Finally_raised]/[Multiple] combinations
+                   (#28868 review). None of them is an internal error. *)
                 Operation_failed
                   { kind = Chat_operation.Turn_cancelled
                   ; detail = Keeper_registry_types.operator_interrupt_detail

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -20,6 +20,24 @@ exception Operator_interrupt
    the human-facing detail. *)
 let operator_interrupt_detail = "operator interrupted the turn"
 
+(* Recursive classifier for every shape Eio can deliver the interrupt in:
+   bare at the [Switch.run] boundary, [Cancelled]-wrapped inside the switch,
+   [Fun.Finally_raised] when a cancellable finalizer trips a cancellation
+   point, and [Eio.Exn.Multiple] when the switch combines the interrupt with
+   what cancelled fibers raised. A [Multiple] counts only when every member
+   reduces to the interrupt — a real co-occurring error must keep its crash
+   classification. Mirrors [Shutdown.is_benign_termination] (#28868 review:
+   constructor-only arms missed the combined shapes). *)
+let rec is_operator_interrupt = function
+  | Operator_interrupt -> true
+  | Eio.Cancel.Cancelled inner -> is_operator_interrupt inner
+  | Stdlib.Fun.Finally_raised inner -> is_operator_interrupt inner
+  | Eio.Exn.Multiple [] -> false
+  | Eio.Exn.Multiple members ->
+    List.for_all (fun (member, _bt) -> is_operator_interrupt member) members
+  | _ -> false
+;;
+
 (* Turn_phase FSM types, witnesses, transitions, and resolver extracted to
    [Keeper_registry_types_turn_phase] (500-line decomp). *)
 include Keeper_registry_types_turn_phase

--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -64,6 +64,14 @@ val operator_interrupt_detail : string
     so ledger rows, queued outcomes, and tool responses classify as one
     incident class. *)
 
+val is_operator_interrupt : exn -> bool
+(** Whether [exn] reduces to {!Operator_interrupt} through every wrapper
+    shape Eio can deliver: bare, [Eio.Cancel.Cancelled],
+    [Fun.Finally_raised], and [Eio.Exn.Multiple] (only when every member
+    reduces). Classification ladders must use this rather than matching the
+    constructor directly (#28868 review: constructor-only arms missed the
+    combined shapes). *)
+
 val failure_reason_to_string : failure_reason -> string
 
 (** #10584: cohort key for grouping failures by variant (ignores

--- a/lib/keeper_runtime/keeper_runtime_failure_route.ml
+++ b/lib/keeper_runtime/keeper_runtime_failure_route.ml
@@ -139,7 +139,14 @@ let route_of_masc_internal ~err (internal : Keeper_internal_error.masc_internal_
         | Tool_result.Runtime_failure ->
           exhaust_failure Terminal_effect_runtime_failure
         | Tool_result.Workflow_rejection ->
-          exhaust_failure Terminal_effect_workflow_rejection))
+          exhaust_failure Terminal_effect_workflow_rejection
+        | Tool_result.Operator_cancelled ->
+          (* Operator interrupt observed as a terminal-effect failure class:
+             route like a transient outcome (it is not a crash and the
+             effect may be re-attempted by a later turn); the
+             operation-level classification already records the typed
+             cancel (#28810). *)
+          exhaust_failure Terminal_effect_transient_failure))
   | Keeper_internal_error.Provider_attempt_effect_fenced
       { effect_disposition; _ } ->
     (match effect_disposition with

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -551,14 +551,13 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
         ~failure_class:Tool_result.Runtime_failure
         ~tool_name:name ~start_time
         (Masc_domain.masc_error_to_string (Masc_domain.System Masc_domain.System_error.NotInitialized))
-    | Keeper_registry.Operator_interrupt ->
-      (* #28810: operator-requested turn interrupt is a cancellation, not a
-         crash. The failure-class vocabulary has no cancellation class;
-         Transient (retryable by the caller, WARN severity) is the honest
-         nearest fit. *)
+    | exn when Keeper_registry_types.is_operator_interrupt exn ->
+      (* #28810: operator-requested turn interrupt is a typed cancellation,
+         not a crash. The guard covers every Eio delivery shape
+         (#28868 review). *)
       Log.Mcp.info "tools/call interrupted by operator: %s" name;
       Tool_result.error
-        ~failure_class:Tool_result.Transient_error
+        ~failure_class:Tool_result.Operator_cancelled
         ~tool_name:name
         ~start_time
         Keeper_registry_types.operator_interrupt_detail

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -708,14 +708,14 @@ let execute_keeper_stream_tool_streaming
         ( Masc_domain.masc_error_to_string
             (Masc_domain.System Masc_domain.System_error.NotInitialized)
         , Tool_result.Failed Tool_result.Runtime_failure )
-    | Keeper_registry.Operator_interrupt ->
-        (* #28810: operator-requested turn interrupt is a cancellation, not a
-           crash. The failure-class vocabulary has no cancellation class;
-           Transient (retryable by the caller, WARN severity) is the honest
-           nearest fit. *)
+    | exn when Keeper_registry_types.is_operator_interrupt exn ->
+        (* #28810: operator-requested turn interrupt is a typed cancellation,
+           not a crash. The guard covers every Eio delivery shape — bare,
+           [Finally_raised], [Multiple] — while genuinely cancelled fibers
+           re-raise above (#28868 review). *)
         Log.Mcp.info "tools/call interrupted by operator (stream)";
         ( Keeper_registry_types.operator_interrupt_detail
-        , Tool_result.Failed Tool_result.Transient_error )
+        , Tool_result.Failed Tool_result.Operator_cancelled )
     | exn ->
         let err = Printexc.to_string exn in
         Log.Mcp.error "tools/call crashed (stream): %s" err;
@@ -772,7 +772,10 @@ let execute_keeper_stream_tool_streaming
         ~disposition
         ~duration_ms
         ();
-      `Ran (success, body)
+      (* Carry the full disposition, not a collapsed bool: the queued-outcome
+         consumer needs the failure class to keep an operator interrupt from
+         being written as a crash (#28868 review P0). *)
+      `Ran (disposition, body)
 
 type canonical_reply_payload_error =
   | Malformed_reply_json of { parser_detail : string }
@@ -1431,7 +1434,7 @@ let process_single_turn ~user_row_origin ~submission
               Error (Printexc.to_string exn))
         in
         match dispatch_result with
-        | Ok (`Ran (true, body)) ->
+        | Ok (`Ran ((Tool_result.Completed () | Tool_result.Deferred ()), body)) ->
           (match canonical_reply_payload_of_body ~redact_text body with
            | Error error ->
              let detail = canonical_reply_payload_error_to_string error in
@@ -1630,11 +1633,23 @@ let process_single_turn ~user_row_origin ~submission
                              ~tool_name:"masc_keeper_msg"
                              ~start_time
                              body)))))
-        | Ok (`Ran (false, err)) ->
+        | Ok (`Ran (Tool_result.Failed dispatch_failure_class, err)) ->
             let persisted = persist_failure_reply err in
             let queued_outcome =
               match persisted with
-              | Ok () -> Some (Failed { kind = Turn_failed; detail = err })
+              | Ok () ->
+                (* #28810 / #28868 review P0: the dispatch classifies an
+                   operator interrupt as [Operator_cancelled]; every other
+                   failure class stays a crash-shaped [Turn_failed]. *)
+                let kind =
+                  match dispatch_failure_class with
+                  | Tool_result.Operator_cancelled -> Turn_cancelled
+                  | Tool_result.Transient_error
+                  | Tool_result.Policy_rejection
+                  | Tool_result.Runtime_failure
+                  | Tool_result.Workflow_rejection -> Turn_failed
+                in
+                Some (Failed { kind; detail = err })
               | Error persist_error ->
                 Some
                   (Failed
@@ -1646,7 +1661,7 @@ let process_single_turn ~user_row_origin ~submission
               (Stream_terminal
                  { status = Stream_error; body = err; queued_outcome });
             Tool_result.error
-              ~failure_class:Tool_result.Runtime_failure
+              ~failure_class:dispatch_failure_class
               ~tool_name:"masc_keeper_msg"
               ~start_time
               err
@@ -1693,10 +1708,11 @@ let process_single_turn ~user_row_origin ~submission
            (match Eio.Switch.run (fun request_sw -> run_turn request_sw) with
             | _ -> publish_inline_completion ()
             | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
-            | exception Keeper_registry.Operator_interrupt ->
+            | exception exn when Keeper_registry_types.is_operator_interrupt exn ->
               (* Typed operator cancellation (#28810): the interrupt fails
-                 the turn switch and the [Switch.run] boundary re-raises the
-                 bare exception here. A cancelled turn, not a crash. *)
+                 the turn switch and the [Switch.run] boundary re-raises it
+                 here — bare or combined ([Multiple]/[Finally_raised],
+                 #28868 review). A cancelled turn, not a crash. *)
               let detail = Keeper_registry_types.operator_interrupt_detail in
               push_worker_event
                 (Stream_terminal

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -196,7 +196,10 @@ let externalization_tool_error ~recoverable error =
 let agent_core_error_class_of_tool_failure_class = function
   | Tool_result.Transient_error -> Agent_core.Types.Transient
   | Tool_result.Policy_rejection
-  | Tool_result.Workflow_rejection ->
+  | Tool_result.Workflow_rejection
+  (* Operator interrupt: final for the model — it must not re-attempt what
+     an operator explicitly stopped (#28810). *)
+  | Tool_result.Operator_cancelled ->
     Agent_core.Types.Deterministic
   | Tool_result.Runtime_failure -> Agent_core.Types.Unknown
 ;;

--- a/lib/tool_types/tool_result.ml
+++ b/lib/tool_types/tool_result.ml
@@ -7,6 +7,10 @@ type tool_failure_class =
           Covers caller-input/argument validation, not only auth/boundary. *)
   | Runtime_failure (** Internal error/bug — non-retryable *)
   | Workflow_rejection (** Business rule violation — non-retryable *)
+  | Operator_cancelled
+      (** An operator interrupted the work (#28810). Not retryable by the
+          system — resending is the operator's own decision — and not an
+          internal error: consumers must not classify it as a crash. *)
 [@@deriving yojson, show]
 
 type failure_effect_disposition =
@@ -32,6 +36,7 @@ let tool_failure_class_to_string = function
   | Policy_rejection -> "policy_rejection"
   | Runtime_failure -> "runtime_failure"
   | Workflow_rejection -> "workflow_rejection"
+  | Operator_cancelled -> "operator_cancelled"
 ;;
 
 let tool_failure_class_of_string = function
@@ -39,16 +44,19 @@ let tool_failure_class_of_string = function
   | "policy_rejection" -> Some Policy_rejection
   | "runtime_failure" -> Some Runtime_failure
   | "workflow_rejection" -> Some Workflow_rejection
+  | "operator_cancelled" -> Some Operator_cancelled
   | _ -> None
 ;;
 
 let is_retryable = function
   | Transient_error -> true
-  | Policy_rejection | Runtime_failure | Workflow_rejection -> false
+  | Policy_rejection | Runtime_failure | Workflow_rejection | Operator_cancelled ->
+    false
 ;;
 
 let log_level_of_failure_class = function
-  | Workflow_rejection | Policy_rejection | Transient_error -> Log.Warn
+  | Workflow_rejection | Policy_rejection | Transient_error | Operator_cancelled ->
+    Log.Warn
   | Runtime_failure -> Log.Error
 ;;
 

--- a/lib/tool_types/tool_result.mli
+++ b/lib/tool_types/tool_result.mli
@@ -19,6 +19,10 @@ type tool_failure_class =
   | Policy_rejection (** Auth/permission/boundary — permanent *)
   | Runtime_failure (** Internal error/bug — non-retryable *)
   | Workflow_rejection (** Business rule violation — non-retryable *)
+  | Operator_cancelled
+      (** An operator interrupted the work (#28810). Not retryable by the
+          system — resending is the operator's own decision — and not an
+          internal error: consumers must not classify it as a crash. *)
 
 type failure_effect_disposition =
   | Proven_pre_effect

--- a/test/test_keeper_owner.ml
+++ b/test/test_keeper_owner.ml
@@ -1311,6 +1311,82 @@ let test_operator_interrupt_settles_as_typed_cancel () =
   | _ -> fail "operator interrupt did not settle the operation as failed"
 ;;
 
+let test_is_operator_interrupt_unwraps_every_shape () =
+  let interrupt = Keeper_registry_types.Operator_interrupt in
+  let bt = Printexc.get_callstack 0 in
+  let is = Keeper_registry_types.is_operator_interrupt in
+  check bool "bare" true (is interrupt);
+  check bool "cancelled-wrapped" true (is (Eio.Cancel.Cancelled interrupt));
+  check bool "finally over cancelled" true
+    (is (Stdlib.Fun.Finally_raised (Eio.Cancel.Cancelled interrupt)));
+  check bool "multiple of interrupt shapes" true
+    (is
+       (Eio.Exn.Multiple
+          [ (interrupt, bt); (Eio.Cancel.Cancelled interrupt, bt) ]));
+  check bool "multiple with a real error keeps crash classification" false
+    (is (Eio.Exn.Multiple [ (interrupt, bt); (Failure "real crash", bt) ]));
+  check bool "empty multiple is not an interrupt" false
+    (is (Eio.Exn.Multiple []));
+  check bool "unrelated exception" false (is (Failure "boom"))
+;;
+
+let test_operator_interrupt_combined_shape_settles_as_typed_cancel () =
+  (* #28868 review P1: Eio combines the switch failure with what cancelled
+     fibers raise into [Multiple] (finalizers add [Finally_raised]). The
+     wrapper ladder must classify the combined shape too. *)
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let operation_executor ~sw:_ ~keeper_name:_ ~claim =
+    match claim () with
+    | Error error ->
+      Owner.Operation_failed
+        { kind = Chat_operation.Store_unavailable
+        ; detail = Owner.error_to_string error
+        ; outcome_ref = None
+        }
+    | Ok None -> failwith "missing FIFO head"
+    | Ok (Some (_ : Chat_operation.t)) ->
+      let bt = Printexc.get_callstack 0 in
+      raise
+        (Eio.Exn.Multiple
+           [ (Eio.Cancel.Cancelled Keeper_registry_types.Operator_interrupt, bt)
+           ; ( Stdlib.Fun.Finally_raised
+                 (Eio.Cancel.Cancelled Keeper_registry_types.Operator_interrupt)
+             , bt )
+           ])
+  in
+  let owner =
+    owner_ok
+      (start_owner_with_executor
+         ~sw
+         ~store:{ replace = (fun _ -> Ok ()); remove = (fun _ -> Ok ()) }
+         ~operation_executor:(Some operation_executor)
+         ~keeper_name:"operator-interrupt-combined"
+         ~initial_meta:(Some (make_meta "operator-interrupt-combined"))
+         ())
+  in
+  let operation_id = operation_id "kmsg-operator-interrupt-combined" in
+  ignore
+    (owner_ok
+       (Owner.submit_operation
+          owner
+          ~operation_id
+          ~source:operation_source
+          ~input:(operation_input "interrupt me, combined")));
+  let terminal = await_terminal owner operation_id 1_000 in
+  match terminal.state with
+  | Chat_operation.Failed { failure = { kind; detail; _ }; _ } ->
+    check string
+      "combined-shape failure kind"
+      "Turn_cancelled"
+      (Chat_operation.failure_kind_to_string kind);
+    check string
+      "combined-shape detail"
+      Keeper_registry_types.operator_interrupt_detail
+      detail
+  | _ -> fail "combined-shape interrupt did not settle the operation as failed"
+;;
+
 let test_paused_owner_preserves_queue_until_resume () =
   Eio_main.run @@ fun _env ->
   Eio.Switch.run @@ fun sw ->
@@ -2618,6 +2694,14 @@ let () =
             "operator interrupt settles as typed cancel"
             `Quick
             test_operator_interrupt_settles_as_typed_cancel
+        ; test_case
+            "is_operator_interrupt unwraps every shape"
+            `Quick
+            test_is_operator_interrupt_unwraps_every_shape
+        ; test_case
+            "combined-shape operator interrupt settles as typed cancel"
+            `Quick
+            test_operator_interrupt_combined_shape_settles_as_typed_cancel
         ; test_case
             "paused owner preserves queue until resume"
             `Quick


### PR DESCRIPTION
#28868의 사후 적대적 리뷰가 반증한 두 결함의 후속 수정.

## P0 — 분류가 dispatch 경계에서 소실 (실사용 경로에서 여전히 Turn_exception)

stream tool dispatch는 interrupt를 분류했지만 반환이 `` `Ran (success: bool, body) ``라 **class가 그 경계에서 죽고**, 소비자가 무조건 queued `Turn_failed`(→`Turn_exception`)를 썼다. 수정:

- `` `Ran``이 bool 대신 **Tool_result disposition 전체를 운반**.
- 소비자는 `Operator_cancelled → Turn_cancelled`를 exhaustive match로 결정 (wildcard 없음), 꼬리의 tool error도 하드코딩 `Runtime_failure` 대신 실제 class를 전달.
- 신규 class **`Operator_cancelled`**: 이전 커밋에서 "어휘에 취소 클래스 없음"이라고 주석으로 미뤘던 갭을 닫음. `is_retryable=false`(operator가 죽인 걸 시스템이 재시도하면 안 됨 — 기존 `Transient_error`는 retryable=true라 잘못된 선택이었음), log level Warn, agent-core bridge `Deterministic`, to_string/of_string 왕복. 컴파일러가 강제한 소진 match 확장 2곳(tool_bridge, terminal-effect route)은 주석과 함께.

## P1 — Eio 조합 shape 미처리

`Switch.fail`은 취소된 fiber들이 던진 것과 interrupt를 `Eio.Exn.Multiple`로 결합하고, 취소 가능한 finalizer는 `Fun.Finally_raised`를 만든다 — 생성자 직매치 arm은 이 조합을 놓친다 (repo가 이미 `Shutdown.is_benign_termination`으로 풀어둔 문제 클래스). 수정:

- `Keeper_registry_types.is_operator_interrupt : exn -> bool` — bare / `Cancelled` / `Finally_raised` / `Multiple`을 재귀 언랩. **`Multiple`은 모든 멤버가 interrupt로 환원될 때만 true** — 실제 에러가 동반되면 crash 분류 유지.
- 4개 분류 사이트(owner wrapper / agent_run / stream fork / tool dispatch 2곳) 전부 guard로 교체.

## 검증

```
opam exec -- dune build --root . @check                    # 0
opam exec -- dune exec --root . test/test_keeper_owner.exe # 42 pass
```

신규: 순수 언랩 테이블(혼합 Multiple 부정 케이스 포함) + **조합 shape(Multiple[Cancelled·Finally_raised])를 executor가 던져도 Turn_cancelled로 durable 종결**되는 통합 테스트. wire 8 / chat_operation_http 4 / supervisor 56 / completion_trust·dispatch_observer·gate 스위트 green.

## 리뷰 노트

- 1633 소비자의 kind 결정은 disposition 타입이 운반하므로 문자열 검사 없음 (detail 상수는 여전히 write-only).
- dispatch의 `Cancelled` 재발화 arm은 그대로 유지 — 진짜 취소 중인 fiber는 계속 unwind하고, guard arm은 그 아래에서 bare/조합 shape만 값으로 분류.

adversarial re-review 요청 예정. 통과 시 `review:adversarial-pass` 라벨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)