### PR TITLE
fix(gate): deferred payload에 host replay 계약 명시 (#28866 마지막 층)

### DIFF
--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -335,6 +335,15 @@ let decision_to_yojson = function
       ([ "decision", `String "deferred"
        ; "approval_id", `String approval_id
        ; "reason", `String (deferred_reason_to_string reason)
+       (* RFC-0356 host replay, stated where the model reads it: without
+          this line the payload reads as a plain block and the model
+          resubmits the same call while the approval is in flight —
+          measured as three duplicate approvals in #28866. *)
+       ; ( "on_approve"
+         , `String
+             "The host replays this exact call and delivers its output to \
+              you automatically. Do not resubmit it; a resubmission folds \
+              onto this same approval." )
        ; "audit_receipts", audit_receipts_to_yojson audit_receipts
        ]
        @ detail)

--- a/test/test_keeper_gate_replay.ml
+++ b/test/test_keeper_gate_replay.ml
@@ -874,6 +874,39 @@ let test_connector_post_rejects_heuristic_or_truncated_input () =
     ]
 ;;
 
+(* The deferred payload is what the model reads when the Gate holds a call.
+   Without the replay contract stated there, the model resubmits the same
+   call while the approval is in flight (#28866: three duplicate approvals
+   of one web_search). This pins the stated fact, not its wording. *)
+let test_deferred_payload_states_the_replay_contract () =
+  let payload =
+    Masc.Keeper_gate.decision_to_yojson
+      (Masc.Keeper_gate.Deferred
+         { approval_id = "appr_test"
+         ; reason = Masc.Keeper_gate.Judge_requested
+         ; audit_receipts = []
+         })
+  in
+  let open Yojson.Safe.Util in
+  Alcotest.(check string)
+    "deferred decision"
+    "deferred"
+    (payload |> member "decision" |> to_string);
+  let on_approve =
+    match payload |> member "on_approve" with
+    | `String text -> text
+    | _ -> Alcotest.fail "deferred payload has no on_approve string"
+  in
+  Alcotest.(check bool)
+    "on_approve states host replay delivery"
+    true
+    (Astring.String.is_infix ~affix:"delivers its output" on_approve);
+  Alcotest.(check bool)
+    "on_approve tells the model not to resubmit"
+    true
+    (Astring.String.is_infix ~affix:"Do not resubmit" on_approve)
+;;
+
 let () =
   Alcotest.run
     "keeper_gate_replay"
@@ -983,6 +1016,10 @@ let () =
             "memory write replay rejects invalid input"
             `Quick
             test_memory_write_replay_rejects_invalid_input
+        ; Alcotest.test_case
+            "deferred payload states the replay contract"
+            `Quick
+            test_deferred_payload_states_the_replay_contract
         ] )
     ]
 ;;


### PR DESCRIPTION
## 무엇

#28866의 3층 중 (a): 유예 시 모델이 받는 payload가 `{decision, approval_id, reason}`뿐이라 거부로 읽고 같은 호출을 재발사했습니다 (중복 체인의 첫 고리). `on_approve` 필드로 이미 존재하는 계약 사실(RFC-0356 host replay + #28870 fold)을 모델이 읽는 자리에 명시합니다.

- 새 게이트/상태 없음 — 기존 계약의 사실 전달만.
- 테스트는 문구가 아니라 진술된 사실 2가지(자동 배달, 재제출 불필요)를 infix로 핀.

## 검증

- `ocamlc -stop-after parsing` 통과. 컴파일·스위트는 CI (`runtest-test_keeper_gate_replay` 기존 배선, astring은 masc_test_deps re_export 확인).

이로써 #28866 3층이 모두 처리됩니다: (c) identity fold #28870 병합, (b) 별도 수정 불요 판정(이슈 코멘트), (a) 본 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)