### PR TITLE
fix(gate): iMessage 가 sidecar route 와 같은 환경변수를 읽게

### DIFF
--- a/lib/gate/channel_gate_imessage_state.ml
+++ b/lib/gate/channel_gate_imessage_state.ml
@@ -27,9 +27,17 @@ include
       let default_binding_audit_path =
         ".gate/runtime/imessage/binding_audit.jsonl"
 
-      let status_path_env_names = [ "MASC_IMESSAGE_STATUS_PATH" ]
-      let binding_store_path_env_names = [ "MASC_IMESSAGE_BINDING_STORE_PATH" ]
-      let binding_audit_path_env_names = [ "MASC_IMESSAGE_BINDING_AUDIT_PATH" ]
+      (* Both spellings, because Server_routes_http_sidecar_paths reads the
+         unprefixed one when it goes looking for the same file. Telegram
+         already accepts both. *)
+      let status_path_env_names =
+        [ "IMESSAGE_STATUS_PATH"; "MASC_IMESSAGE_STATUS_PATH" ]
+
+      let binding_store_path_env_names =
+        [ "IMESSAGE_BINDING_STORE_PATH"; "MASC_IMESSAGE_BINDING_STORE_PATH" ]
+
+      let binding_audit_path_env_names =
+        [ "IMESSAGE_BINDING_AUDIT_PATH"; "MASC_IMESSAGE_BINDING_AUDIT_PATH" ]
       let stale_after_env_name = "MASC_IMESSAGE_STATUS_STALE_SEC"
 
       (* iMessage has no guilds. *)

--- a/test/test_channel_gate_imessage_state.ml
+++ b/test/test_channel_gate_imessage_state.ml
@@ -133,6 +133,41 @@ let test_audit_entries_omit_guild_id () =
       check bool "no guild_id on the entry" true
         (List.for_all (fun entry -> U.member "guild_id" entry = `Null) audit))
 
+(* Two OCaml readers go looking for this one file: the gate state below, and
+   Server_routes_http_sidecar_paths, which the dashboard's start/stop route
+   uses to decide whether the sidecar is running. They have to agree on which
+   env var relocates it, or an operator who sets one moves half the readers.
+   iMessage shared no name with the server until now; Telegram always did. *)
+let with_binding_paths dir f =
+  with_env "MASC_IMESSAGE_BINDING_STORE_PATH"
+    (Some (Filename.concat dir "bindings.json"))
+    (fun () ->
+      with_env "MASC_IMESSAGE_BINDING_AUDIT_PATH"
+        (Some (Filename.concat dir "audit.jsonl"))
+        f)
+
+let test_unprefixed_env_moves_both_readers () =
+  with_temp_dir @@ fun dir ->
+  with_binding_paths dir (fun () ->
+    let status_path = Filename.concat dir "relocated-status.json" in
+    with_env "MASC_IMESSAGE_STATUS_PATH" None (fun () ->
+      with_env "IMESSAGE_STATUS_PATH" (Some status_path) (fun () ->
+        Yojson.Safe.to_file status_path sample_status_json;
+        check string "gate state follows IMESSAGE_STATUS_PATH" status_path
+          (IMessage_state.status_json () |> U.member "status_path" |> U.to_string);
+        check string "the sidecar route resolves the same file" status_path
+          (Server_routes_http_sidecar_paths.status_file ~base_path:dir "imessage"))))
+
+let test_prefixed_env_still_moves_the_gate_state () =
+  with_temp_dir @@ fun dir ->
+  with_binding_paths dir (fun () ->
+    let status_path = Filename.concat dir "prefixed-status.json" in
+    with_env "IMESSAGE_STATUS_PATH" None (fun () ->
+      with_env "MASC_IMESSAGE_STATUS_PATH" (Some status_path) (fun () ->
+        Yojson.Safe.to_file status_path sample_status_json;
+        check string "MASC_-prefixed spelling keeps working" status_path
+          (IMessage_state.status_json () |> U.member "status_path" |> U.to_string))))
+
 let test_malformed_binding_store_is_explicit () =
   with_temp_dir @@ fun dir ->
   with_imessage_paths dir (fun () ->
@@ -165,6 +200,10 @@ let () =
             test_poll_interval_defaults_to_the_imessage_rate;
           test_case "audit entries omit guild_id" `Quick
             test_audit_entries_omit_guild_id;
+          test_case "unprefixed env moves both readers" `Quick
+            test_unprefixed_env_moves_both_readers;
+          test_case "prefixed env still moves the gate state" `Quick
+            test_prefixed_env_still_moves_the_gate_state;
           test_case "malformed binding store is explicit" `Quick
             test_malformed_binding_store_is_explicit;
         ] );


### PR DESCRIPTION
> Stacked on #28880. base 가 병합되면 자동으로 main 을 향합니다.

## 증상

iMessage 의 `status.json` 을 찾는 리더가 셋인데, OCaml 쪽 둘이 **공유하는 이름이 하나도 없었습니다.**

| 리더 | 읽는 환경변수 |
|---|---|
| Python 봇 (쓰는 쪽) | `status_path` (`config.py:129`, `env_prefix=""`) |
| sidecar route | `IMESSAGE_STATUS_PATH`, `status_path` (`server_routes_http_sidecar_paths.ml:144`) |
| `Channel_gate_imessage_state` | `MASC_IMESSAGE_STATUS_PATH` |

`IMESSAGE_STATUS_PATH` 를 세우면 route 만 옮겨가고 gate 는 안 옮겨갑니다. `MASC_IMESSAGE_STATUS_PATH` 를 세우면 반대고요. **어느 쪽을 세워도 리더가 갈라집니다.**

#28869 에서 Python 쪽에 고친 것과 같은 모양입니다 — 한 파일을 두고 두 리더가 다른 곳을 봅니다.

Telegram 은 이런 적이 없습니다. 두 리더가 `TELEGRAM_STATUS_PATH` 와 `MASC_TELEGRAM_STATUS_PATH` 를 모두 받습니다.

## 수정

iMessage 도 두 철자를 다 받게 했습니다. status 파일과 binding 경로 둘 다요.

```ocaml
let status_path_env_names =
  [ "IMESSAGE_STATUS_PATH"; "MASC_IMESSAGE_STATUS_PATH" ]
```

**추가입니다.** `MASC_` 접두 철자는 그대로 동작하고, 그걸 못 박는 테스트를 같이 넣었습니다.

## 테스트

```
[OK] status  5  unprefixed env moves both readers.
[OK] status  6  prefixed env still moves the gate state.
```

첫 번째는 `IMESSAGE_STATUS_PATH` 를 세운 뒤 gate state 와 `Server_routes_http_sidecar_paths.status_file` 이 **같은 파일**로 풀리는지 봅니다. 두 모듈을 한 테스트에서 부를 수 있는 건 둘이 `test/dune` 의 같은 stanza 에 있기 때문입니다.

**공허하지 않습니다** — 환경변수 목록을 예전처럼 `[ "MASC_IMESSAGE_STATUS_PATH" ]` 하나로 되돌리면:

```
> [FAIL]  status  5  unprefixed env moves both readers.
```

## 손대지 않은 것

봇 자신은 아직 맨 `status_path` 를 읽습니다. pydantic alias 를 건드려야 해서 여기 넣지 않았습니다. 지금은 route 의 목록에 `status_path` 가 있어 봇과 route 는 이미 겹칩니다 — 갈라져 있던 건 gate 쪽이고, 그게 이 PR 로 닫힙니다.

## 로컬 검증

```
test_channel_gate_imessage_state            8 passed
scripts/ci/check-determinism-contract.sh    PASS
ocamlformat --check                         clean
```
