### PR TITLE
docs(rfc): RFC-0384 — Telegram 커넥터를 서버 프로세스 안으로 (long polling)

### DIFF
--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -231,6 +231,7 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0381 | 웹 검색은 폴백이 있는 척한다 — provider 계약 정정과 토큰 예산 도입 | Draft | - |
 | 0382 | 런타임별 KV/prompt cache 재사용과 reasoning 연속성 | Draft | - |
 | 0383 | 웹 아티팩트는 쌓이기만 한다 — 오프로드 파일을 재질의 가능한 코퍼스로 | Draft | - |
+| 0384 | In-process Telegram connector (long polling) | Proposed | - |
 | RFC-async-log-sink-durable-append-offload | Offload the structured-log durable append off the emitting fiber | Draft | - |
 | RFC-checkpoint-pinned-root-containment | Immutable boot-pinned root capability for checkpoint containment | Draft | - |
 | RFC-claude-code-context-overflow-bounded-restart | Admit Claude Code bootstrap input without replaying rejected episodes | Draft | - |

--- a/docs/rfc/RFC-0384-telegram-builtin-gateway.md
+++ b/docs/rfc/RFC-0384-telegram-builtin-gateway.md
@@ -1,0 +1,173 @@
+---
+title: In-process Telegram connector (long polling)
+rfc: "0384"
+status: Proposed
+created: 2026-08-16
+author: vincent
+related: ["0203", "0317"]
+---
+
+# RFC-0384 — In-process Telegram connector (long polling)
+
+An OCaml `getUpdates` loop replaces `sidecars/telegram-bot/` (Python
+python-telegram-bot). The third and simplest instance of the move
+[[RFC-0203]] made for Discord and [[RFC-0317]] made for Slack.
+
+> **Status.** Proposed. Two PRs, not four — see §PR split.
+
+## Why
+
+The out-of-process shape is not a neutral packaging choice. It generates a
+specific, recurring class of defect, and this repo paid for it four times on
+2026-08-16 alone:
+
+| PR | Defect |
+|---|---|
+| #28848 | A stopped sidecar could not be restarted. Liveness read a heartbeat file that the bot's shutdown path rewrote with `connected=true` |
+| #28855 | The liveness decision took the clock inside itself |
+| #28869 | The bot wrote `status.json` to a path no reader looked at |
+| #28882 | The two OCaml readers of that file accepted no env var in common |
+
+Every one of those is a consequence of liveness being a *file* rather than a
+value the process owns. Discord and Slack have none of them: their
+`connected ()` reads an `Atomic` published by the run loop
+(`channel_gate_discord_state.ml:469`, `channel_gate_slack_state.ml:336`), and
+a value in memory cannot be stale, cannot be at the wrong path, and cannot
+outlive the process that wrote it.
+
+Telegram is the cheapest remaining connector to move, and it is cheaper than
+Slack was.
+
+## Shape
+
+```
+api.telegram.org  ←  getUpdates(offset, timeout=N)   [Eio fiber, Masc_http_client]
+        ↓ decode update
+  Channel_gate.handle_inbound ~dispatch
+        ↓
+  keeper turn
+
+keeper → Channel_gate_telegram_state.send → Masc_http_client.post_sync sendMessage
+```
+
+There is no third box. That is the whole point of this RFC.
+
+### Reuse, not re-implementation
+
+`Masc_http_client` (`post_sync`, `get_sync`, `get_response_sync`) already
+carries Slack's and Discord's REST traffic. Telegram's Bot API is ordinary
+HTTPS JSON against `api.telegram.org`. **Zero new opam deps**, same as
+RFC-0317.
+
+`Channel_gate.handle_inbound` (`channel_gate.mli:83`) is the existing inbound
+boundary; Slack reaches it at
+`server_slack_in_process_gateway.ml:315`. Telegram uses the same call.
+
+### Unlike Slack: there is no gateway FSM
+
+This is the material difference from RFC-0317, and it is what makes this the
+smallest of the three migrations.
+
+| Layer | Discord | Slack | Telegram |
+|---|---|---|---|
+| Transport | `discord_wss_connection` (WSS + TLS) | reused | **none** — plain HTTPS |
+| Gateway FSM | `discord_gateway_state.ml` (1,285 lines) | `slack_gateway_state.ml` (376) | **none** |
+| I/O driver | `discord_gateway_client.ml` (431) | `slack_socket_client.ml` (293) | poll loop |
+| Handshake | HELLO → IDENTIFY | HELLO envelope | **none** |
+| Liveness | client heartbeat + ACK | TCP/TLS layer | **the poll itself** |
+| Resume | RESUME with session_id + sequence | fresh `apps.connections.open` | **`offset`, an integer** |
+| Per-message ack | none | required per envelope | **implicit**: advancing `offset` |
+
+Long polling has no connection state machine because it has no connection to
+keep. Every `getUpdates` is a fresh request; the only carried state is one
+integer. The 1,285-line box and the 376-line box are both empty here.
+
+### What is genuinely new
+
+Three things, and they are where the bugs will be:
+
+1. **The offset ledger.** `getUpdates(offset=N)` acknowledges everything below
+   `N`. Advance it before the turn is durably accepted and an update is lost;
+   advance it after and a crash redelivers. python-telegram-bot hid this
+   choice. We have to make it, and it must be the same choice
+   `Channel_gate.handle_inbound` already encodes for the other two.
+2. **429 / `retry_after`.** Telegram answers flood with a `retry_after`
+   seconds field. Honour it or the bot is throttled into silence.
+3. **Structured-block rendering.** `formatters.py` is 255 lines projecting
+   keeper chat blocks into Telegram HTML. That has to be ported, not
+   redesigned.
+
+## Validation
+
+- **Unit**: offset advances exactly once per accepted update and never past an
+  unaccepted one; `retry_after` honoured; update decode
+  (`message` / `edited_message` / unknown → ignored); HTML renderer matches
+  `formatters.py` output for each block kind.
+- **Integration**: server boot with `TELEGRAM_BOT_TOKEN` → send a message →
+  keeper turn → reply arrives.
+- **Regression**: `/api/v1/sidecar/status?name=telegram` 404 after PR-2;
+  Discord and Slack unaffected (separate module trees).
+- **Security**: token redaction snapshot; no token in logs or argv.
+
+All of it runs on Linux CI. This is not true of iMessage — see §Out of scope.
+
+## PR split
+
+Two, not four.
+
+1. **PR-1**: `telegram_rest_client` (`getUpdates` / `sendMessage` /
+   `editMessageText`), the poll fiber, the offset ledger, the HTML renderer,
+   unit tests. Not wired into bootstrap; the sidecar still runs.
+2. **PR-2**: `channel_gate_telegram_state` rewritten from the sidecar functor
+   instance to the in-process shape, bootstrap wiring, env, observability,
+   dashboard `IN_PROCESS_CONNECTOR_IDS` + `IN_PROCESS_CONFIG_GUIDES`, and
+   deletion of `sidecars/telegram-bot/`.
+
+RFC-0317 split the same work four ways and PR-4 — the deletion — has not
+landed in five weeks. `sidecars/slack-bot/` is still on disk while
+`channel_gate_slack_state.ml:7` says it was removed. A migration whose last
+step is optional does not finish; the deletion belongs in the PR that makes
+it correct.
+
+## Costs
+
+Stated plainly, because the Why section only lists gains.
+
+- **Crash blast radius.** A sidecar that dies takes Telegram with it. An
+  exception escaping an Eio switch takes the server. Discord and Slack already
+  accepted this for network I/O; Telegram adds no new kind of risk, but it
+  does add another fiber that can raise.
+- **A proven library is lost.** python-telegram-bot handles offset, dedup and
+  flood control. Hand-writing them is where this will break. Mitigation is
+  only that Discord and Slack hand-wrote harder protocols and hold.
+- **Dashboard config surface.** Small and measured: the in-process guide
+  entries for Discord and Slack are four lines each
+  (`dashboard/src/components/connector-config-form.ts:82`).
+
+## Out of scope
+
+- **iMessage.** It reads `~/Library/Messages/chat.db` and sends through
+  `osascript`, so in-processing it moves macOS Full Disk Access and Automation
+  grants onto the masc binary. Whether a TCC grant survives a rebuild of an
+  unsigned dune-built executable is unverified, and if it does not, the failure
+  mode is precisely the one #28869 just fixed — configured, silent, reading
+  nothing. Separately, CI cannot see it: of the `runs-on` declarations in
+  `ci.yml`, fifteen are `ubuntu-latest` and one is `macos-14`
+  (`ci.yml:1601`), and that one is gated on
+  `github.ref == 'refs/heads/main' && github.ref_protected == true`
+  (`ci.yml:1611-1612`), so it never runs on a PR. Needs its own RFC, and a
+  measurement of whether the TCC grant survives a rebuild, before anything
+  else.
+- Telegram inline keyboards, callback queries, slash commands. This round is
+  `message` and `edited_message`.
+- Webhook mode. Long polling only; no public endpoint, no secret token.
+- Ambient recording and idle-keeper wake on non-triggering messages —
+  deferred in RFC-0317 too.
+
+## Alternatives rejected
+
+- **Keep the sidecar, fix the file protocol.** Four PRs on 2026-08-16 did
+  exactly that. The class does not close while liveness lives in a file.
+- **Move all remaining sidecars at once.** [[RFC-0203]] already rejected this:
+  *"All-sidecars-at-once rejected: per-sidecar RFCs"* (RFC-0203:120). Telegram
+  and iMessage have nothing in common beyond both being out of process.


### PR DESCRIPTION
RFC-0203(Discord), RFC-0317(Slack) 이 한 이동의 세 번째 인스턴스입니다. 그리고 셋 중 제일 쌉니다.

## 왜

사이드카가 프로세스 밖에 있는 건 포장 방식의 문제가 아니라, 특정 결함군을 계속 만들어냅니다. **2026-08-16 하루에 네 번 값을 치렀습니다:**

| PR | 결함 |
|---|---|
| #28848 | 멈춘 사이드카가 재시작되지 않음. 봇의 종료 경로가 heartbeat 파일에 `connected=true` 를 다시 씀 |
| #28855 | 생존 판정이 시계를 자기 안에 들고 있었음 |
| #28869 | 봇이 `status.json` 을 아무도 안 읽는 경로에 씀 |
| #28882 | 그 파일을 읽는 OCaml 리더 둘이 공유하는 환경변수가 없었음 |

전부 **생존이 프로세스가 소유한 값이 아니라 파일**이라서 생깁니다. Discord 와 Slack 은 하나도 없어요 — `connected ()` 가 run loop 가 발행한 `Atomic` 을 읽습니다 (`channel_gate_discord_state.ml:469`, `channel_gate_slack_state.ml:336`). 메모리 안의 값은 낡을 수도, 엉뚱한 경로에 있을 수도, 자기를 쓴 프로세스보다 오래 살 수도 없습니다.

## Slack 보다 쉽습니다 — 게이트웨이 FSM 이 없어서

RFC-0317 과의 결정적 차이입니다.

| 레이어 | Discord | Slack | Telegram |
|---|---|---|---|
| 트랜스포트 | `discord_wss_connection` | 재사용 | **없음** — 평범한 HTTPS |
| 게이트웨이 FSM | `discord_gateway_state.ml` (1,285줄) | `slack_gateway_state.ml` (376줄) | **없음** |
| I/O 드라이버 | `discord_gateway_client.ml` (431줄) | `slack_socket_client.ml` (293줄) | 폴 루프 |
| 핸드셰이크 | HELLO → IDENTIFY | HELLO 엔벌로프 | **없음** |
| 생존 확인 | 클라이언트 heartbeat + ACK | TCP/TLS 계층 | **폴 자체** |
| Resume | session_id + sequence | 새 `apps.connections.open` | **`offset`, 정수 하나** |
| 메시지별 ack | 없음 | 엔벌로프마다 필수 | **암묵적**: `offset` 전진 |

long polling 은 유지할 연결이 없어서 연결 상태 머신도 없습니다. Discord 의 1,285줄 상자와 Slack 의 376줄 상자가 **둘 다 비어 있습니다.**

새 opam 의존성 0 — `Masc_http_client` 가 이미 두 커넥터의 REST 를 나릅니다.

## 진짜 새로 짜야 하는 것

세 가지고, 버그는 여기서 납니다.

1. **offset 장부.** `getUpdates(offset=N)` 은 N 미만을 전부 승인합니다. 턴이 durable 하게 수락되기 전에 전진시키면 유실, 후에 전진시키면 재배달. python-telegram-bot 이 이 선택을 숨기고 있었습니다.
2. **429 / `retry_after`.** 지키지 않으면 봇이 조용해집니다.
3. **구조화 블록 렌더링.** `formatters.py` 255줄을 재설계가 아니라 이식.

## PR 는 넷이 아니라 둘

RFC-0317 은 같은 일을 넷으로 쪼갰고, 삭제였던 PR-4 가 **5주째 안 들어왔습니다.** `channel_gate_slack_state.ml:7` 은 사이드카가 제거됐다고 적어놨는데 `sidecars/slack-bot/` 는 디스크에 그대로 있습니다.

마지막 단계가 선택 사항인 마이그레이션은 끝나지 않습니다. 삭제는 그걸 옳게 만드는 PR 안에 있어야 합니다.

## iMessage 는 범위 밖 — 이유를 적었습니다

in-process 로 옮기면 macOS Full Disk Access 와 Automation 승인이 masc 바이너리로 옮겨갑니다. **서명 없는 dune 산출물을 재빌드했을 때 TCC 승인이 살아남는지 확인되지 않았고**, 안 살아남는다면 그 실패 모양이 #28869 에서 방금 고친 것과 정확히 같습니다 — 설정된 것처럼 보이는데 아무것도 안 읽는 상태.

게다가 CI 가 못 봅니다. `ci.yml` 의 `runs-on` 이 ubuntu 15개, macOS 1개(`:1601`)이고 그 하나가 `github.ref == 'refs/heads/main' && github.ref_protected == true` (`:1611-1612`) 조건이라 PR 에서는 절대 안 돕니다.

별도 RFC 와, 재빌드 후 TCC 실측이 먼저입니다.

## 검증

`scripts/check-ssot.sh` exit 0. RFC 번호 충돌 없음 (`rg RFC-0384 docs/` 확인).

문서만 있는 PR 이라 코드 변경은 없습니다.
