### PR TITLE
ci(keeper): test_keeper_meta_invalid_recovery를 focused test target에 배선 (#28844)

### DIFF
--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -193,6 +193,7 @@ normal_targets=(
   @test/runtest-test_keeper_autonomous_turn_source
   @test/runtest-test_keeper_autoboot_single_owner
   @test/runtest-test_keeper_meta_current_schema
+  @test/runtest-test_keeper_meta_invalid_recovery
   @test/runtest-dashboard-http-behavior-contracts
   @test/runtest-test_dashboard_composite_claim_window
   @test/runtest-test_model_inference_metrics


### PR DESCRIPTION
## 무엇

#28877이 `eaf9239475` head로 머지되면서, 그 이후에 올라간 CI 배선 커밋(3cf236fc3e)이 main에 도달하지 못했다 — post-merge push 유실. 그 사이 원격 브랜치가 삭제되어 후속 push가 브랜치를 재생성했고, 이 PR은 그 커밋의 cherry-pick 재상륙이다 (#28860과 동일 패턴).

현재 main 상태: `test/dune`에는 `test_keeper_meta_invalid_recovery`가 선언되어 있으나(squash 머지로 포함) CI manifest에는 미배선 → `audit-ci-test-targets.sh` 기준 unwired 549 > baseline 548로 **main의 Meta Guards가 FAIL 상태**다.

## 변경

`scripts/ci-run-focused-tests.sh`에 `@test/runtest-test_keeper_meta_invalid_recovery` 1줄 추가 (형제 스위트 `test_keeper_meta_current_schema` 바로 아래).

## 검증

```
$ bash scripts/audit-ci-test-targets.sh
[ci-test-targets] OK - 330 CI targets, all declared in Dune
[ci-test-targets] OK - 548 suites unwired, at baseline
```

`scripts/dune-local.sh build @test/runtest-test_keeper_meta_invalid_recovery` — alias 해석 + 스위트 4/4 PASS (CI가 호출하는 것과 동일 경로).

Refs #28844

🤖 Generated with [Claude Code](https://claude.com/claude-code)