### PR TITLE
fix(agent-core): timeout 에러에 provider 라벨 전달 — 'unknown' 종식 (#28852)

### DIFF
--- a/packages/agent_core/lib/pipeline/pipeline_stage_route.ml
+++ b/packages/agent_core/lib/pipeline/pipeline_stage_route.ml
@@ -32,10 +32,10 @@ let input_capacity_error ~binding ~message ~constraint_ ~reason =
     (Error.Api (Llm_provider.Retry.InputCapacity { message; constraint_; reason }))
 ;;
 
-let measurement_error ~binding ~constraint_ = function
+let measurement_error ~binding ~constraint_ ~provider = function
   | Llm_provider.Count_tokens_sync.Input_count_failed
       (Llm_provider.Input_token_count.Transport http_error) ->
-    Provider_failure_attribution.of_http_error ~binding http_error
+    Provider_failure_attribution.of_http_error ~binding ~provider http_error
   | Llm_provider.Count_tokens_sync.Input_count_failed
       (Llm_provider.Input_token_count.Unsupported { protocol; model_id }) ->
     (match constraint_ with
@@ -196,6 +196,11 @@ let dispatch_sync
     |> Result.map_error (binding_identity_error ?on_provider_failure)
   in
   let* () = admit_provider_attempt before_provider_attempt binding in
+  (* Provider label for mapped transport errors: without it every timeout
+     reads "Provider 'unknown'" (#28852). *)
+  let provider =
+    Llm_provider.Provider_config.capability_provider_label provider_config
+  in
   let now_unix_s = int_of_float (Unix.gettimeofday ()) in
   let prepared =
     Llm_provider.Complete.prepare_request
@@ -217,7 +222,7 @@ let dispatch_sync
   let result =
     match
       Llm_provider.Complete.admit_request_body ~stream:false prepared
-      |> Result.map_error (Provider_failure_attribution.of_http_error ~binding)
+      |> Result.map_error (Provider_failure_attribution.of_http_error ~binding ~provider)
     with
     | Error error -> Error error
     | Ok serialized ->
@@ -233,7 +238,7 @@ let dispatch_sync
            ?body_timeout_s:agent.options.body_timeout_s
            ?request_wire_observer:agent.pre_dispatch_serialization_observer
            ()
-         |> Result.map_error (Provider_failure_attribution.of_http_error ~binding)
+         |> Result.map_error (Provider_failure_attribution.of_http_error ~binding ~provider)
        | Ok () ->
          (match Llm_provider.Complete.resolve_context_limit prepared with
           | Error error -> Error (fit_error ~binding error)
@@ -251,6 +256,7 @@ let dispatch_sync
                  (measurement_error
                     ~binding
                     ~constraint_:(Llm_provider.Complete.serving_constraint prepared)
+                    ~provider
                     error)
              | Ok measured ->
                (match
@@ -271,7 +277,7 @@ let dispatch_sync
                     ?request_wire_observer:agent.pre_dispatch_serialization_observer
                     ()
                   |> Result.map_error
-                       (Provider_failure_attribution.of_http_error ~binding)))))
+                       (Provider_failure_attribution.of_http_error ~binding ~provider)))))
   in
   finish_call ?on_provider_failure result
 ;;
@@ -297,6 +303,11 @@ let dispatch_stream
     |> Result.map_error (binding_identity_error ?on_provider_failure)
   in
   let* () = admit_provider_attempt before_provider_attempt binding in
+  (* Provider label for mapped transport errors: without it every timeout
+     reads "Provider 'unknown'" (#28852). *)
+  let provider =
+    Llm_provider.Provider_config.capability_provider_label provider_config
+  in
   let now_unix_s = int_of_float (Unix.gettimeofday ()) in
   let prepared =
     Llm_provider.Complete.prepare_request
@@ -318,7 +329,7 @@ let dispatch_stream
   let result =
     match
       Llm_provider.Complete.admit_request_body ~stream:true prepared
-      |> Result.map_error (Provider_failure_attribution.of_http_error ~binding)
+      |> Result.map_error (Provider_failure_attribution.of_http_error ~binding ~provider)
     with
     | Error error -> Error error
     | Ok serialized ->
@@ -335,7 +346,7 @@ let dispatch_stream
            ?on_telemetry
            ?request_wire_observer:agent.pre_dispatch_serialization_observer
            ()
-         |> Result.map_error (Provider_failure_attribution.of_http_error ~binding)
+         |> Result.map_error (Provider_failure_attribution.of_http_error ~binding ~provider)
        | Ok () ->
          (match Llm_provider.Complete.resolve_context_limit prepared with
           | Error error -> Error (fit_error ~binding error)
@@ -353,6 +364,7 @@ let dispatch_stream
                  (measurement_error
                     ~binding
                     ~constraint_:(Llm_provider.Complete.serving_constraint prepared)
+                    ~provider
                     error)
              | Ok measured ->
                (match
@@ -374,7 +386,7 @@ let dispatch_stream
                     ?request_wire_observer:agent.pre_dispatch_serialization_observer
                     ()
                   |> Result.map_error
-                       (Provider_failure_attribution.of_http_error ~binding)))))
+                       (Provider_failure_attribution.of_http_error ~binding ~provider)))))
   in
   finish_call ?on_provider_failure result
 ;;

--- a/packages/agent_core/lib/provider_failure_attribution.ml
+++ b/packages/agent_core/lib/provider_failure_attribution.ml
@@ -46,13 +46,13 @@ let invalid_request ?(reason_kind = Retry.Unknown_invalid_request) reason =
     (Retry.InvalidRequest { message = reason; reason = reason_kind })
 ;;
 
-let core_error_of_http_error ?(accept_rejected = Api_invalid_request) err =
+let core_error_of_http_error ?(accept_rejected = Api_invalid_request) ?provider err =
   match err with
   | Http.HttpError { code; body; retry_after_header } ->
     Error.Api (Retry.classify_error ~retry_after_header ~status:code ~body)
   | Http.NetworkError { message; kind } ->
     Error.Api (Retry.NetworkError { message; kind })
-  | Http.TimeoutError _ -> Error.Provider (Llm_provider.Error.of_http_error err)
+  | Http.TimeoutError _ -> Error.Provider (Llm_provider.Error.of_http_error ?provider err)
   | Http.AcceptRejected { reason } ->
     (match accept_rejected with
      | Api_invalid_request ->
@@ -94,7 +94,8 @@ let core_error_of_http_error ?(accept_rejected = Api_invalid_request) err =
        dedicated variant, scheduled with the next breaking API change. *)
     (match Retry.verdict_of_empty_completion ~stop_reason ~message with
      | Retry.Empty_overflow overflow -> Error.Api overflow
-     | Retry.Empty_attributed -> Error.Provider (Llm_provider.Error.of_http_error err)
+     | Retry.Empty_attributed ->
+       Error.Provider (Llm_provider.Error.of_http_error ?provider err)
      | Retry.Empty_unattributed { token } ->
        Error.Api
          (Retry.InvalidRequest
@@ -106,7 +107,7 @@ let core_error_of_http_error ?(accept_rejected = Api_invalid_request) err =
             ; reason = Retry.Unknown_invalid_request
             }))
   | Http.ProviderTerminal _ | Http.ProviderFailure _ ->
-    Error.Provider (Llm_provider.Error.of_http_error err)
+    Error.Provider (Llm_provider.Error.of_http_error ?provider err)
 ;;
 
 let of_core_error error =
@@ -276,8 +277,9 @@ let attribution_of_http_error ~binding = function
     }
 ;;
 
-let of_http_error ?(accept_rejected = Api_invalid_request) ~binding http_error =
-  { error = core_error_of_http_error ~accept_rejected http_error
+let of_http_error ?(accept_rejected = Api_invalid_request) ?provider ~binding http_error
+  =
+  { error = core_error_of_http_error ~accept_rejected ?provider http_error
   ; provider_failure = Some (attribution_of_http_error ~binding http_error)
   }
 ;;

--- a/packages/agent_core/lib/provider_failure_attribution.mli
+++ b/packages/agent_core/lib/provider_failure_attribution.mli
@@ -72,16 +72,21 @@ val of_response_parse_error
 
 (** Coarse projection for call sites that do not consume attribution.
     Provider call paths use {!of_http_error} so attribution is retained through
-    the detailed boundary. *)
+    the detailed boundary. [provider] labels the mapped provider errors
+    (timeout/terminal/failure) so operators see which provider the failure
+    belongs to; omitted, the error keeps the typed 'unknown' label (#28852). *)
 val core_error_of_http_error
   :  ?accept_rejected:accept_rejected
+  -> ?provider:string
   -> Llm_provider.Http_client.http_error
   -> Error.t
 
 (** Central transport-error mapping. Ownership is derived only from closed or
-    status evidence and the agent-core binding identity. *)
+    status evidence and the agent-core binding identity. [provider] labels the
+    mapped provider errors as in {!core_error_of_http_error}. *)
 val of_http_error
   :  ?accept_rejected:accept_rejected
+  -> ?provider:string
   -> binding:Binding_identity.t
   -> Llm_provider.Http_client.http_error
   -> detailed_error

--- a/packages/agent_core/test/test_pipeline_metrics.ml
+++ b/packages/agent_core/test/test_pipeline_metrics.ml
@@ -239,6 +239,40 @@ let test_core_error_of_http_error_classifies () =
   ()
 ;;
 
+let string_contains ~needle haystack =
+  let nl = String.length needle
+  and hl = String.length haystack in
+  let rec go i = i + nl <= hl && (String.sub haystack i nl = needle || go (i + 1)) in
+  nl = 0 || go 0
+;;
+
+let test_core_error_of_http_error_labels_provider () =
+  (* #28852: a first-token timeout must name its provider; without the label
+     every provider timeout in the fleet read "Provider 'unknown'". *)
+  let timeout_error =
+    Llm_provider.Http_client.TimeoutError
+      { message = "first_event_timeout_s deadline exceeded while awaiting_first_event"
+      ; phase = Llm_provider.Http_client.First_token
+      }
+  in
+  (match
+     Provider_failure_attribution.core_error_of_http_error
+       ~provider:"local_llama_server"
+       timeout_error
+   with
+   | Error.Provider provider_error ->
+     let rendered = Llm_provider.Error.to_string provider_error in
+     if not (string_contains ~needle:"Provider 'local_llama_server' timeout" rendered)
+     then Alcotest.failf "provider label missing from: %s" rendered
+   | _ -> Alcotest.fail "expected a Provider error for the timeout");
+  match Provider_failure_attribution.core_error_of_http_error timeout_error with
+  | Error.Provider provider_error ->
+    let rendered = Llm_provider.Error.to_string provider_error in
+    if not (string_contains ~needle:"Provider 'unknown' timeout" rendered)
+    then Alcotest.failf "unlabelled error must keep the typed unknown: %s" rendered
+  | _ -> Alcotest.fail "expected a Provider error for the timeout"
+;;
+
 let test_core_error_preserves_streaming_timeout_phase () =
   Eio_main.run
   @@ fun env ->
@@ -311,6 +345,10 @@ let () =
             "core_error_of_http_error compiles"
             `Quick
             test_core_error_of_http_error_classifies
+        ; Alcotest.test_case
+            "core_error_of_http_error labels the provider"
+            `Quick
+            test_core_error_of_http_error_labels_provider
         ; Alcotest.test_case
             "core_error preserves streaming timeout phase"
             `Quick


### PR DESCRIPTION
Closes #28852.

## 문제

fleet의 모든 provider timeout이 `Provider 'unknown' timeout phase=...`로 표기됐다 — 오늘 mlx canary 실패 9건 전부, 그리고 RFC-OAS-037 §1의 mimo 인용문(2026-07-20)까지 같은 문자열. 원인: `Provider_failure_attribution.core_error_of_http_error`가 provider 라벨을 받을 수단 자체가 없어, 내부의 `Llm_provider.Error.of_http_error` 매핑 3곳(timeout / empty-attributed / terminal·failure)이 항상 typed 'unknown' 기본값으로 떨어졌다.

## 수정

- `core_error_of_http_error` / `of_http_error`에 `?provider` 추가, 매핑 3곳에 관통.
- `pipeline_stage_route`는 dispatch당 1회 라벨을 파생해 attribution 7개 사이트(measurement_error 포함) 전부에 전달. 파생은 **기존** `Provider_config.capability_provider_label` 재사용 (provider_id 있으면 그 값, 없으면 provider kind — 새 파생 규칙 발명 없음, SSOT).
- 라벨 미전달 시 typed 'unknown' 유지 (정체성 발명 금지).

## 검증

```
opam exec -- dune build --root . @check                                    # 0
opam exec -- dune exec --root . packages/agent_core/test/test_pipeline_metrics.exe  # 7 pass
```

신규 테스트가 양방향을 고정: 라벨 있는 first-token timeout은 `Provider 'local_llama_server' timeout`으로, 라벨 없는 경우는 `Provider 'unknown' timeout` 유지.

adversarial review 통과 시 `review:adversarial-pass` 라벨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)