### PR TITLE
fix(ci): test_keeper_meta_invalid_recovery 를 실제로 돌린다 — 모든 PR 의 Meta Guards 가 빨감

### DIFF
--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -112,6 +112,7 @@ normal_targets=(
   @test/runtest-test_keeper_canary_evidence
   @test/runtest-test_keeper_canary_judge
   @test/runtest-test_keeper_canary_failover
+  @test/runtest-test_keeper_meta_invalid_recovery
   @test/runtest-test_slack_user_directory
   @test/runtest-test_sidecar_lifecycle_routes
   @test/runtest-test_cancel_safe


### PR DESCRIPTION
## 증상

`Meta Guards` 의 `Check CI test targets` 스텝이 **열려 있는 모든 PR 에서** 실패합니다. 문서만 바꾼 PR([#28883](https://github.com/jeong-sik/masc/pull/28883))에서도 실패해서 알았습니다.

```
$ bash scripts/audit-ci-test-targets.sh
[ci-test-targets] FAIL - 549 suites are declared but never run in CI (baseline 548)
```

## 원인

`2ade75d901` (#28877) 이 `test_keeper_meta_invalid_recovery` 스위트와 dune stanza 를 넣었는데 **CI 타깃을 안 넣었습니다.**

```
$ rg 'test_keeper_meta_invalid_recovery' scripts/ci-run-focused-tests.sh .github/workflows/ci.yml
(없음)
```

같은 커밋 범위에 들어온 다른 두 스위트는 배선돼 있습니다 — `test_keeper_canary_failover` 는 `ci-run-focused-tests.sh:114`, `test_keeper_wire_terminal` 은 `ci.yml:1328`. 이것만 빠졌습니다.

컴파일은 되지만 실행되지 않으니, 그 4개 단언은 자기가 고정하려던 코드보다 오래 살아남습니다.

## 수정

`scripts/ci-run-focused-tests.sh` 에 타깃 한 줄 추가.

## 검증

**스위트 자체는 통과합니다 — 그냥 안 돌고 있었을 뿐입니다.**

```
$ dune build @test/runtest-test_keeper_meta_invalid_recovery
Test Successful in 0.078s. 4 tests run.

$ bash scripts/audit-ci-test-targets.sh; echo "exit=$?"
[ci-test-targets] OK - 330 CI targets, all declared in Dune
[ci-test-targets] OK - 548 suites unwired, at baseline
exit=0
```

**baseline 은 그대로 548 입니다.** 하나를 배선하면 카운트가 baseline 을 넘어가는 게 아니라 baseline 으로 되돌아옵니다 — 래칫을 느슨하게 하지 않았습니다.

## 참고

오늘 두 번째 공통 블로커입니다. 첫 번째는 [#28867](https://github.com/jeong-sik/masc/pull/28867) 의 SSOT 래칫이었고요. 둘 다 main 에 들어간 뒤에야 드러났는데, `2026-08-13T14:07:47Z` 이후 main CI 가 판정을 내지 못하고 있던 것과 무관하지 않습니다 ([#28864](https://github.com/jeong-sik/masc/pull/28864) 에서 수정).
