### PR TITLE
fix(ci): test_keeper_meta_invalid_recovery 중복 호출 제거 — main 이 exit 2

### DIFF
--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -112,7 +112,6 @@ normal_targets=(
   @test/runtest-test_keeper_canary_evidence
   @test/runtest-test_keeper_canary_judge
   @test/runtest-test_keeper_canary_failover
-  @test/runtest-test_keeper_meta_invalid_recovery
   @test/runtest-test_slack_user_directory
   @test/runtest-test_sidecar_lifecycle_routes
   @test/runtest-test_cancel_safe


### PR DESCRIPTION
## 증상

main 이 깨져 있습니다. 모든 PR 의 `Meta Guards` 가 실패합니다.

```
$ bash scripts/audit-ci-test-targets.sh; echo "exit=$?"
[ci-test-targets] FAIL - CI executes the same Dune test target more than once

  - test_keeper_meta_invalid_recovery

Keep one authoritative invocation for each target; repeated runtest aliases
spend CI time without adding coverage.
exit=2
```

## 원인 — 제 잘못입니다

[#28887](https://github.com/jeong-sik/masc/pull/28887) 과 [#28884](https://github.com/jeong-sik/masc/pull/28884) 가 **같은 타깃을 1분 안에 각각 배선했고 둘 다 병합됐습니다.** `scripts/ci-run-focused-tests.sh` 에 같은 줄이 115행과 197행에 있습니다.

`masc-workflow.md` 는 모든 에이전트에게 보이는 실패를 고치기 전에 broadcast 로 선점을 선언하라고 요구합니다. 정확히 이런 경합을 막으려고요. #28887 을 그거 없이 냈습니다.

## 수정

#28887 쪽 사본을 뺍니다. #28884 것이 자매 스위트 `test_keeper_meta_current_schema` 바로 옆에 있어 배치가 낫습니다. 제 것은 그저 다른 신규 스위트가 있던 canary 타깃 옆에 붙여놨던 것뿐이고요.

## 검증

```
$ bash scripts/audit-ci-test-targets.sh; echo "exit=$?"
[ci-test-targets] OK - 330 CI targets, all declared in Dune
[ci-test-targets] OK - 548 suites unwired, at baseline
exit=0

$ rg -n 'test_keeper_meta_invalid_recovery' scripts/ci-run-focused-tests.sh
196:  @test/runtest-test_keeper_meta_invalid_recovery
```

스위트는 여전히 돕니다 — 한 번만 돕니다.
