### PR TITLE
feat(keeper): 턴이 자기가 이미 한 일을 볼 수 있게 한다

### DIFF
--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -72,6 +72,19 @@ let keeper_fleet_messages_max_rp =
 let keeper_fleet_messages_max () : int =
   Runtime_params.get keeper_fleet_messages_max_rp
 
+(* How many of the keeper's own past turns are replayed as actions. The default
+   is the depth the product states a keeper must not lose ("10턴 전에 한 자신의
+   발화나 행동"), and it fits: measured on taskmaster 2026-08-16, a turn renders
+   at a median 1.6 KB, so ten turns add ~16 KB to a prompt that was assembling
+   5.8 KB against a 131 KB runtime cap. *)
+let keeper_own_recent_turns_max_rp =
+  _rp_int ~key:"keeper.own_actions.turns.max"
+    ~default:(fun () -> 10)
+    ~min_v:0 ~max_v:200
+    ~description:"Past turns of the keeper's own tool calls replayed into the world observation (0 = disable)" ()
+let keeper_own_recent_turns_max () : int =
+  Runtime_params.get keeper_own_recent_turns_max_rp
+
 let keeper_bootstrap_proactive_warmup_sec_rp =
   _rp_int ~key:"keeper.proactive.warmup_sec"
     ~default:(fun () -> int_of_env_default "MASC_KEEPER_BOOTSTRAP_PROACTIVE_WARMUP_SEC"

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -85,6 +85,12 @@ val keeper_board_own_recent_max : unit -> int
     the world observation carries per turn. Cursor-independent — no watermark. *)
 val keeper_fleet_messages_max : unit -> int
 
+val keeper_own_recent_turns_max : unit -> int
+(** Past turns of this keeper's own tool calls replayed into the world
+    observation. Autonomous turns carried no record of what the keeper had
+    already done, so it re-claimed finished tasks and repeated malformed
+    calls. *)
+
 val keeper_bootstrap_proactive_warmup_sec : unit -> int
 val keeper_bootstrap_stagger_step_sec : unit -> int
 val keeper_bootstrap_retry_interval_sec : unit -> int

--- a/lib/keeper/keeper_context_layers.ml
+++ b/lib/keeper/keeper_context_layers.ml
@@ -13,6 +13,7 @@ type layer_id =
   | Scope_messages
   | Own_board_posts
   | Board_activity
+  | Own_recent_actions
   | Fleet_messages
 
 (* Prefix-cache ordering: emit larger, more stable sections first so providers
@@ -21,8 +22,10 @@ type layer_id =
    after [Active_goals]: the claimed task is standing context that changes on
    claim/release, not per cycle. [Own_board_posts] changes only when the
    keeper itself publishes, so it sits just ahead of the per-cycle reactive
-   [Board_activity]. [Fleet_messages] carries any keeper's broadcast, so it
-   is the most fleet-volatile section and sits last. *)
+   [Board_activity]. [Own_recent_actions] is a window that slides every turn,
+   so it cannot hold a stable prefix and sits behind the sections that can.
+   [Fleet_messages] carries any keeper's broadcast, so it is the most
+   fleet-volatile section and sits last. *)
 let ordered =
   [ Active_goals
   ; Current_task
@@ -36,6 +39,7 @@ let ordered =
   ; Scope_messages
   ; Own_board_posts
   ; Board_activity
+  ; Own_recent_actions
   ; Fleet_messages
   ]
 ;;
@@ -56,7 +60,8 @@ let order_index = function
   | Scope_messages -> 9
   | Own_board_posts -> 10
   | Board_activity -> 11
-  | Fleet_messages -> 12
+  | Own_recent_actions -> 12
+  | Fleet_messages -> 13
 ;;
 
 let assemble ~content_of =

--- a/lib/keeper/keeper_context_layers.mli
+++ b/lib/keeper/keeper_context_layers.mli
@@ -25,6 +25,7 @@ type layer_id =
   | Scope_messages
   | Own_board_posts
   | Board_activity
+  | Own_recent_actions
   | Fleet_messages
 
 val ordered : layer_id list

--- a/lib/keeper/keeper_own_recent_actions.ml
+++ b/lib/keeper/keeper_own_recent_actions.ml
@@ -13,21 +13,12 @@ type turn =
   ; calls : call list
   }
 
-(* Bounds on what one call contributes to the prompt. The argument object is
-   what the keeper must see to recognise its own mistake (an empty object, a
-   finished task id), so it is kept wider than the failure text, which only has
-   to identify the refusal. *)
-let input_max_chars = 240
-let failure_max_chars = 200
-
-(* Rows to read per requested turn. Measured on taskmaster 2026-08-16: 818 calls
-   over 80 turns, median 8 per turn and p90 21. Reading 24 covers the 90th
-   percentile turn whole. *)
-let rows_per_turn = 24
-
-let clip max_chars s =
-  if String.length s <= max_chars then s else String.sub s 0 max_chars ^ "…"
-;;
+(* Sizing hint for the read window, not a bound on any row: how many calls a
+   turn typically makes. Measured on taskmaster 2026-08-16 over 932 calls --
+   median 8 per turn, p90 21. Reading short costs turns, never a partial turn:
+   only the oldest group can be clipped by the window edge, and
+   {!turns_of_rows} drops it. *)
+let typical_calls_per_turn = 24
 
 let string_field name json =
   match Json_util.assoc_member_opt name json with
@@ -45,13 +36,20 @@ let turn_id_field json =
   | _ -> None
 ;;
 
-(* A refusal the tool did not describe stays [None]. Substituting an empty
-   string here would render as a refusal with no reason, indistinguishable from
-   one the tool declined to explain. *)
+(* Only a refusal carries its output. What a successful call returned is not
+   what the keeper needs -- that the call landed is the fact -- and it is where
+   the bytes are: measured 2026-08-16, a success returns a median 1310 bytes
+   against a refusal's 417 (max 2116). Carrying both would put a 10-turn window
+   over 80 KB for no added recall, and would force a truncation rule over the
+   exact text the keeper has to read to recognise its mistake.
+
+   A refusal the tool did not describe stays [None]. Substituting an empty
+   string would render as a refusal with no reason, indistinguishable from one
+   the tool declined to explain. *)
 let outcome_of_row json =
   match Json_util.assoc_member_opt "success" json with
   | Some (`Bool true) -> Ok_call
-  | _ -> Failed_call (Option.map (clip failure_max_chars) (string_field "output" json))
+  | _ -> Failed_call (string_field "output" json)
 ;;
 
 let call_of_row json =
@@ -61,16 +59,27 @@ let call_of_row json =
     let input =
       match Json_util.assoc_member_opt "input" json with
       | None | Some `Null -> "{}"
-      | Some (`String s) -> clip input_max_chars s
-      | Some value -> clip input_max_chars (Yojson.Safe.to_string value)
+      | Some (`String s) -> s
+      | Some value -> Yojson.Safe.to_string value
     in
     Some { tool; input; outcome = outcome_of_row json }
 ;;
 
-let turns_of_rows ~keeper_name ~max_turns rows =
+(* A saturated tail read starts mid-turn, so its oldest group is missing that
+   turn's earliest calls. Rendering a turn with some calls silently absent is
+   worse than not rendering it: the keeper would read a complete-looking
+   history that omits the call it needs to see. *)
+let drop_clipped_leading_turn rows =
+  match List.find_map turn_id_field rows with
+  | None -> rows
+  | Some clipped -> List.filter (fun row -> turn_id_field row <> Some clipped) rows
+;;
+
+let turns_of_rows ~keeper_name ~max_turns ~window_saturated rows =
   if max_turns <= 0
   then []
   else (
+    let rows = if window_saturated then drop_clipped_leading_turn rows else rows in
     (* One pass in persisted order builds each turn's call list; the turn order
        is then the order the turns first appeared, so both stay source order
        without a sort. *)
@@ -98,10 +107,16 @@ let turns_of_rows ~keeper_name ~max_turns rows =
 let collect ~keeper_name ~max_turns =
   if max_turns <= 0
   then []
-  else
-    Keeper_tool_call_log.read_recent
-      ~keeper_name
-      ~n:(max_turns * rows_per_turn)
-      ()
-    |> turns_of_rows ~keeper_name ~max_turns
+  else begin
+    (* One turn's worth of slack, so discarding the clipped group still leaves
+       [max_turns] whole ones. *)
+    let n = (max_turns + 1) * typical_calls_per_turn in
+    let rows = Keeper_tool_call_log.read_recent ~keeper_name ~n () in
+    (* Short of the window means the store held nothing older, so nothing was
+       cut. *)
+    turns_of_rows
+      ~keeper_name ~max_turns
+      ~window_saturated:(List.length rows >= n)
+      rows
+  end
 ;;

--- a/lib/keeper/keeper_own_recent_actions.ml
+++ b/lib/keeper/keeper_own_recent_actions.ml
@@ -1,0 +1,106 @@
+type outcome =
+  | Ok_call
+  | Failed_call of string
+
+type call =
+  { tool : string
+  ; input : string
+  ; outcome : outcome
+  }
+
+type turn =
+  { turn_id : int
+  ; calls : call list
+  }
+
+(* Bounds on what one call contributes to the prompt. The argument object is
+   what the keeper must see to recognise its own mistake (an empty object, a
+   finished task id), so it is kept wider than the failure text, which only has
+   to identify the refusal. *)
+let input_max_chars = 240
+let failure_max_chars = 200
+
+(* Rows to read per requested turn. Measured on taskmaster 2026-08-16: 818 calls
+   over 80 turns, median 8 per turn and p90 21. Reading 24 covers the 90th
+   percentile turn whole. *)
+let rows_per_turn = 24
+
+let clip max_chars s =
+  if String.length s <= max_chars then s else String.sub s 0 max_chars ^ "…"
+;;
+
+let string_field name json =
+  match Json_util.assoc_member_opt name json with
+  | Some (`String s) -> Some s
+  | _ -> None
+;;
+
+(* [keeper_turn_id] is persisted as a string. A row whose id is not an integer
+   cannot be ordered against the others, so it is dropped with the unattributed
+   rows rather than folded into an adjacent turn. *)
+let turn_id_field json =
+  match Json_util.assoc_member_opt "keeper_turn_id" json with
+  | Some (`String s) -> int_of_string_opt (String.trim s)
+  | Some (`Int i) -> Some i
+  | _ -> None
+;;
+
+let outcome_of_row json =
+  match Json_util.assoc_member_opt "success" json with
+  | Some (`Bool true) -> Ok_call
+  | _ ->
+    Failed_call
+      (clip failure_max_chars (Option.value ~default:"" (string_field "output" json)))
+;;
+
+let call_of_row json =
+  match string_field "tool" json with
+  | None -> None
+  | Some tool ->
+    let input =
+      match Json_util.assoc_member_opt "input" json with
+      | None | Some `Null -> "{}"
+      | Some (`String s) -> clip input_max_chars s
+      | Some value -> clip input_max_chars (Yojson.Safe.to_string value)
+    in
+    Some { tool; input; outcome = outcome_of_row json }
+;;
+
+let turns_of_rows ~keeper_name ~max_turns rows =
+  if max_turns <= 0
+  then []
+  else (
+    (* One pass in persisted order builds each turn's call list; the turn order
+       is then the order the turns first appeared, so both stay source order
+       without a sort. *)
+    let order = ref [] in
+    let calls = Hashtbl.create 16 in
+    List.iter
+      (fun row ->
+         match string_field "keeper" row, turn_id_field row, call_of_row row with
+         | Some k, Some turn_id, Some call when String.equal k keeper_name ->
+           if not (Hashtbl.mem calls turn_id)
+           then (
+             Hashtbl.replace calls turn_id [];
+             order := turn_id :: !order);
+           Hashtbl.replace calls turn_id (call :: Hashtbl.find calls turn_id)
+         | _ -> ())
+      rows;
+    let ordered = List.rev !order in
+    let keep = max 0 (List.length ordered - max_turns) in
+    ordered
+    |> List.filteri (fun i _ -> i >= keep)
+    |> List.map (fun turn_id ->
+      { turn_id; calls = List.rev (Hashtbl.find calls turn_id) }))
+;;
+
+let collect ~keeper_name ~max_turns =
+  if max_turns <= 0
+  then []
+  else
+    Keeper_tool_call_log.read_recent
+      ~keeper_name
+      ~n:(max_turns * rows_per_turn)
+      ()
+    |> turns_of_rows ~keeper_name ~max_turns
+;;

--- a/lib/keeper/keeper_own_recent_actions.ml
+++ b/lib/keeper/keeper_own_recent_actions.ml
@@ -1,6 +1,6 @@
 type outcome =
   | Ok_call
-  | Failed_call of string
+  | Failed_call of string option
 
 type call =
   { tool : string
@@ -45,12 +45,13 @@ let turn_id_field json =
   | _ -> None
 ;;
 
+(* A refusal the tool did not describe stays [None]. Substituting an empty
+   string here would render as a refusal with no reason, indistinguishable from
+   one the tool declined to explain. *)
 let outcome_of_row json =
   match Json_util.assoc_member_opt "success" json with
   | Some (`Bool true) -> Ok_call
-  | _ ->
-    Failed_call
-      (clip failure_max_chars (Option.value ~default:"" (string_field "output" json)))
+  | _ -> Failed_call (Option.map (clip failure_max_chars) (string_field "output" json))
 ;;
 
 let call_of_row json =

--- a/lib/keeper/keeper_own_recent_actions.mli
+++ b/lib/keeper/keeper_own_recent_actions.mli
@@ -9,12 +9,15 @@
 type outcome =
   | Ok_call
   | Failed_call of string option
-      (** Bounded head of the failure text, [None] when the tool refused
-          without describing why. *)
+      (** The refusal text verbatim, [None] when the tool refused without
+          describing why. A successful call carries no output: that it landed
+          is the fact, and the returned body is where the bytes are. *)
 
 type call =
   { tool : string
-  ; input : string  (** Bounded rendering of the argument object. *)
+  ; input : string
+      (** The argument object verbatim. Not truncated: it is the thing the
+          keeper has to read to recognise the call it got refused for. *)
   ; outcome : outcome
   }
 
@@ -23,13 +26,23 @@ type turn =
   ; calls : call list  (** Persisted order: oldest call of the turn first. *)
   }
 
-val turns_of_rows : keeper_name:string -> max_turns:int -> Yojson.Safe.t list -> turn list
+val turns_of_rows
+  :  keeper_name:string
+  -> max_turns:int
+  -> window_saturated:bool
+  -> Yojson.Safe.t list
+  -> turn list
 (** Groups already-read log rows into the newest [max_turns] turns belonging to
     [keeper_name], oldest turn first. Rows without a turn id are dropped: they
-    cannot be attributed to a turn the keeper would recognise. [max_turns <= 0]
-    returns the empty list. Pure. *)
+    cannot be attributed to a turn the keeper would recognise.
+
+    [window_saturated] states that the caller's read filled its window, which
+    means it began mid-turn and the oldest group is missing that turn's
+    earliest calls; that group is then discarded rather than rendered
+    incomplete. [max_turns <= 0] returns the empty list. Pure. *)
 
 val collect : keeper_name:string -> max_turns:int -> turn list
-(** Reads the durable tool-call log and applies {!turns_of_rows}. The read
-    window is sized from [max_turns]; a turn that ran more calls than the
-    window covers is returned truncated rather than dropped. *)
+(** Reads the durable tool-call log and applies {!turns_of_rows}. Every turn
+    returned is whole: a saturated tail read begins mid-turn, so its oldest
+    group is discarded rather than rendered with calls silently missing. A
+    short read window therefore costs turns, never parts of one. *)

--- a/lib/keeper/keeper_own_recent_actions.mli
+++ b/lib/keeper/keeper_own_recent_actions.mli
@@ -8,8 +8,9 @@
 
 type outcome =
   | Ok_call
-  | Failed_call of string
-      (** Bounded head of the failure text the tool returned. *)
+  | Failed_call of string option
+      (** Bounded head of the failure text, [None] when the tool refused
+          without describing why. *)
 
 type call =
   { tool : string

--- a/lib/keeper/keeper_own_recent_actions.mli
+++ b/lib/keeper/keeper_own_recent_actions.mli
@@ -1,0 +1,34 @@
+(** The keeper's own tool calls from its recent turns.
+
+    An autonomous turn assembles a briefing of current world state and no
+    record of what this keeper already did. Nothing in that briefing says a
+    task was finished, or that the same call was rejected one turn ago, so the
+    keeper repeats both. This module reads back the durable tool-call log and
+    groups it into turns so the prompt can state it. *)
+
+type outcome =
+  | Ok_call
+  | Failed_call of string
+      (** Bounded head of the failure text the tool returned. *)
+
+type call =
+  { tool : string
+  ; input : string  (** Bounded rendering of the argument object. *)
+  ; outcome : outcome
+  }
+
+type turn =
+  { turn_id : int
+  ; calls : call list  (** Persisted order: oldest call of the turn first. *)
+  }
+
+val turns_of_rows : keeper_name:string -> max_turns:int -> Yojson.Safe.t list -> turn list
+(** Groups already-read log rows into the newest [max_turns] turns belonging to
+    [keeper_name], oldest turn first. Rows without a turn id are dropped: they
+    cannot be attributed to a turn the keeper would recognise. [max_turns <= 0]
+    returns the empty list. Pure. *)
+
+val collect : keeper_name:string -> max_turns:int -> turn list
+(** Reads the durable tool-call log and applies {!turns_of_rows}. The read
+    window is sized from [max_turns]; a turn that ran more calls than the
+    window covers is returned truncated rather than dropped. *)

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -80,6 +80,25 @@ let format_fleet_messages
       message.fleet_content)
   |> String.concat "\n"
 
+let format_own_recent_actions (turns : Keeper_own_recent_actions.turn list) : string =
+  turns
+  |> List.map (fun (turn : Keeper_own_recent_actions.turn) ->
+    turn.calls
+    |> List.map (fun (call : Keeper_own_recent_actions.call) ->
+      match call.outcome with
+      | Keeper_own_recent_actions.Ok_call ->
+        Printf.sprintf "- [turn %d] %s %s -> ok" turn.turn_id call.tool call.input
+      | Keeper_own_recent_actions.Failed_call detail ->
+        Printf.sprintf
+          "- [turn %d] %s %s -> REJECTED: %s"
+          turn.turn_id
+          call.tool
+          call.input
+          detail)
+    |> String.concat "\n")
+  |> String.concat "\n"
+;;
+
 (** Format active goals into a prompt section. *)
 let format_goals (goal_ids : string list) : string =
   String.concat "\n"
@@ -1271,6 +1290,24 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta)
        a fleet broadcast reaches the dashboard and never the prompt. Neutral
        rows, no advisory text; no watermark, so a keeper that never runs an
        autonomous turn accumulates nothing. *)
+    (* What this keeper already did. Without it an autonomous turn re-claims a
+       task it finished and repeats a call the tool just rejected, because the
+       briefing describes the world and never the keeper's own history. Both
+       outcomes are shown: the rejections are what the keeper must not repeat,
+       the successes are what it must not redo. *)
+    | Keeper_context_layers.Own_recent_actions ->
+      if observation.own_recent_actions <> [] then (
+        let ubuf = Buffer.create 1024 in
+        Buffer.add_string ubuf
+          (Printf.sprintf "### Your Recent Actions (%d turns)\n"
+             (List.length observation.own_recent_actions));
+        Buffer.add_string ubuf
+          "Tool calls you already made, oldest turn first — context, not instructions.\n";
+        Buffer.add_string ubuf
+          (format_own_recent_actions observation.own_recent_actions);
+        Buffer.add_string ubuf "\n\n";
+        Some (Buffer.contents ubuf))
+      else None
     | Keeper_context_layers.Fleet_messages ->
       if observation.fleet_messages <> [] then (
         let ubuf = Buffer.create 256 in

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -88,7 +88,9 @@ let format_own_recent_actions (turns : Keeper_own_recent_actions.turn list) : st
       match call.outcome with
       | Keeper_own_recent_actions.Ok_call ->
         Printf.sprintf "- [turn %d] %s %s -> ok" turn.turn_id call.tool call.input
-      | Keeper_own_recent_actions.Failed_call detail ->
+      | Keeper_own_recent_actions.Failed_call None ->
+        Printf.sprintf "- [turn %d] %s %s -> REJECTED" turn.turn_id call.tool call.input
+      | Keeper_own_recent_actions.Failed_call (Some detail) ->
         Printf.sprintf
           "- [turn %d] %s %s -> REJECTED: %s"
           turn.turn_id

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -152,6 +152,7 @@ type world_observation =
   ; connected_surface_failures : Gate_surface.presence_failure list
   ; own_recent_board_posts : Board.post list
   ; fleet_messages : Keeper_world_observation_message_scope.fleet_message list
+  ; own_recent_actions : Keeper_own_recent_actions.turn list
   }
 
 type keeper_cycle_channel =
@@ -1247,6 +1248,10 @@ let observe
   ; connected_surface_failures = surface_presence.failures
   ; own_recent_board_posts = collect_own_recent_board_posts ~meta
   ; fleet_messages
+  ; own_recent_actions =
+      Keeper_own_recent_actions.collect
+        ~keeper_name:meta.name
+        ~max_turns:(Keeper_config.keeper_own_recent_turns_max ())
   }
 ;;
 
@@ -1287,6 +1292,7 @@ let observe_direct_keeper_msg ~(config : Workspace.config) ~(meta : keeper_meta)
        performs no transcript I/O at all. The keeper sees fleet context on its
        next [observe] turn, where the same load already happens. *)
   ; fleet_messages = []
+  ; own_recent_actions = []
   }
 ;;
 

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -190,6 +190,13 @@ type world_observation = {
       rows addressed to this keeper, so a projected broadcast would otherwise
       reach the dashboard and never the prompt. Disjoint from
       [pending_messages] by construction. *)
+
+  own_recent_actions : Keeper_own_recent_actions.turn list;
+  (** This keeper's own tool calls from its newest
+      [Keeper_config.keeper_own_recent_turns_max] turns, oldest turn first,
+      each turn's calls in the order they ran. An autonomous turn otherwise
+      carries no record of what this keeper already did, so a finished task
+      gets claimed again and a rejected call gets repeated. *)
 }
 
 val claimable_task_count : world_observation -> int

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -280,6 +280,7 @@ let base_observation : WO.world_observation =
   ; connected_surface_failures = []
   ; own_recent_board_posts = []
   ; fleet_messages = []
+  ; own_recent_actions = []
   }
 
 (* ══════════════════════════════════════════════════════════

--- a/test/test_keeper_connector_attention_wake.ml
+++ b/test/test_keeper_connector_attention_wake.ml
@@ -143,6 +143,7 @@ let quiet_obs : WO.world_observation =
   ; connected_surface_failures = []
   ; own_recent_board_posts = []
   ; fleet_messages = []
+  ; own_recent_actions = []
   }
 
 let reasons_of_verdict = function

--- a/test/test_keeper_context_layers.ml
+++ b/test/test_keeper_context_layers.ml
@@ -23,6 +23,7 @@ let all_layers =
     L.Scope_messages;
     L.Own_board_posts;
     L.Board_activity;
+    L.Own_recent_actions;
     L.Fleet_messages;
   ]
 

--- a/test/test_keeper_lifecycle_global_gate.ml
+++ b/test/test_keeper_lifecycle_global_gate.ml
@@ -112,6 +112,7 @@ let base_obs : WO.world_observation =
   ; connected_surface_failures = []
   ; own_recent_board_posts = []
   ; fleet_messages = []
+  ; own_recent_actions = []
   }
 ;;
 

--- a/test/test_keeper_raw_task_signal_wake.ml
+++ b/test/test_keeper_raw_task_signal_wake.ml
@@ -18,6 +18,7 @@ let base_observation : WO.world_observation =
   ; connected_surface_failures = []
   ; own_recent_board_posts = []
   ; fleet_messages = []
+  ; own_recent_actions = []
   }
 ;;
 

--- a/test/test_keeper_surface_presence_prompt.ml
+++ b/test/test_keeper_surface_presence_prompt.ml
@@ -64,6 +64,7 @@ let base_observation : WO.world_observation =
     connected_surface_failures = [];
     own_recent_board_posts = [];
     fleet_messages = [];
+    own_recent_actions = [];
   }
 
 let meta : Masc.Keeper_meta_contract.keeper_meta =
@@ -187,6 +188,104 @@ let test_fleet_messages_reach_the_prompt () =
     (contains ~needle:"- fleet keeper-bob-agent: deploy is green" user);
   check bool "rows are marked as context" true
     (contains ~needle:"context, not instructions" user)
+;;
+
+(* The failure this closes: an autonomous turn described the world and never
+   the keeper's own history, so a finished task got claimed again and a
+   rejected call got repeated every turn. *)
+module Actions = Masc.Keeper_own_recent_actions
+
+let test_the_keeper_sees_the_call_it_got_rejected_for () =
+  let user =
+    user_message
+      { base_observation with
+        own_recent_actions =
+          [ { Actions.turn_id = 27486
+            ; calls =
+                [ { Actions.tool = "keeper_board_post"
+                  ; input = {|{"title":"status"}|}
+                  ; outcome = Actions.Ok_call
+                  }
+                ; { Actions.tool = "keeper_broadcast"
+                  ; input = "{}"
+                  ; outcome = Actions.Failed_call {|"message": MISSING|}
+                  }
+                ]
+            }
+          ]
+      }
+  in
+  check bool "section header states the depth" true
+    (contains ~needle:"### Your Recent Actions (1 turns)" user);
+  check bool "the work it already did is stated" true
+    (contains ~needle:{|- [turn 27486] keeper_board_post {"title":"status"} -> ok|} user);
+  check bool "the rejected call is stated with its arguments" true
+    (contains ~needle:{|keeper_broadcast {} -> REJECTED: "message": MISSING|} user);
+  check bool "rows are marked as context" true
+    (contains ~needle:"context, not instructions" user)
+;;
+
+(* Row shape as the durable tool-call log persists it: [keeper_turn_id] is a
+   string, [success] a bool, [input] an object. *)
+let log_row ~keeper ?turn ~tool ~success () =
+  `Assoc
+    ([ "keeper", `String keeper
+     ; "tool", `String tool
+     ; "input", `Assoc [ "arg", `String tool ]
+     ; "success", `Bool success
+     ; "output", `String (if success then "ok" else "Error: refused")
+     ]
+     @ match turn with None -> [] | Some t -> [ "keeper_turn_id", `String (string_of_int t) ])
+;;
+
+let test_only_the_newest_turns_of_this_keeper_are_replayed () =
+  let rows =
+    [ log_row ~keeper:"me" ~turn:1 ~tool:"a" ~success:true ()
+    ; log_row ~keeper:"me" ~turn:2 ~tool:"b" ~success:true ()
+    ; log_row ~keeper:"other" ~turn:2 ~tool:"not-mine" ~success:true ()
+    ; log_row ~keeper:"me" ~tool:"unattributed" ~success:true ()
+    ; log_row ~keeper:"me" ~turn:3 ~tool:"c" ~success:false ()
+    ]
+  in
+  let turns = Actions.turns_of_rows ~keeper_name:"me" ~max_turns:2 rows in
+  check (list int) "newest two turns, oldest first" [ 2; 3 ]
+    (List.map (fun (t : Actions.turn) -> t.turn_id) turns);
+  check (list string) "another keeper's row never appears" [ "b"; "c" ]
+    (List.concat_map
+       (fun (t : Actions.turn) ->
+          List.map (fun (c : Actions.call) -> c.tool) t.calls)
+       turns);
+  check bool "a row with no turn id is dropped, not folded into a neighbour" false
+    (List.exists
+       (fun (t : Actions.turn) ->
+          List.exists (fun (c : Actions.call) -> c.tool = "unattributed") t.calls)
+       turns)
+;;
+
+let test_calls_keep_the_order_they_ran_in () =
+  let rows =
+    [ log_row ~keeper:"me" ~turn:9 ~tool:"first" ~success:true ()
+    ; log_row ~keeper:"me" ~turn:9 ~tool:"second" ~success:false ()
+    ; log_row ~keeper:"me" ~turn:9 ~tool:"third" ~success:true ()
+    ]
+  in
+  match Actions.turns_of_rows ~keeper_name:"me" ~max_turns:5 rows with
+  | [ turn ] ->
+    check (list string) "persisted order" [ "first"; "second"; "third" ]
+      (List.map (fun (c : Actions.call) -> c.tool) turn.calls)
+  | other -> failf "expected exactly one turn, got %d" (List.length other)
+;;
+
+let test_disabling_the_depth_replays_nothing () =
+  let rows = [ log_row ~keeper:"me" ~turn:1 ~tool:"a" ~success:true () ] in
+  check int "zero turns means nothing is read back" 0
+    (List.length (Actions.turns_of_rows ~keeper_name:"me" ~max_turns:0 rows))
+;;
+
+let test_no_recent_actions_no_section () =
+  let user = user_message { base_observation with own_recent_actions = [] } in
+  check bool "absent when the keeper has done nothing" false
+    (contains ~needle:"### Your Recent Actions" user)
 ;;
 
 let test_no_fleet_messages_no_section () =
@@ -535,5 +634,18 @@ let () =
             test_no_fleet_messages_no_section;
           test_case "rows render in arrival order" `Quick
             test_fleet_rows_render_in_arrival_order;
+        ] );
+      ( "own recent actions",
+        [
+          test_case "the keeper sees the call it got rejected for" `Quick
+            test_the_keeper_sees_the_call_it_got_rejected_for;
+          test_case "no actions means no section" `Quick
+            test_no_recent_actions_no_section;
+          test_case "only the newest turns of this keeper are replayed" `Quick
+            test_only_the_newest_turns_of_this_keeper_are_replayed;
+          test_case "calls keep the order they ran in" `Quick
+            test_calls_keep_the_order_they_ran_in;
+          test_case "disabling the depth replays nothing" `Quick
+            test_disabling_the_depth_replays_nothing;
         ] );
     ]

--- a/test/test_keeper_surface_presence_prompt.ml
+++ b/test/test_keeper_surface_presence_prompt.ml
@@ -208,7 +208,7 @@ let test_the_keeper_sees_the_call_it_got_rejected_for () =
                   }
                 ; { Actions.tool = "keeper_broadcast"
                   ; input = "{}"
-                  ; outcome = Actions.Failed_call {|"message": MISSING|}
+                  ; outcome = Actions.Failed_call (Some {|"message": MISSING|})
                   }
                 ]
             }

--- a/test/test_keeper_surface_presence_prompt.ml
+++ b/test/test_keeper_surface_presence_prompt.ml
@@ -247,7 +247,7 @@ let test_only_the_newest_turns_of_this_keeper_are_replayed () =
     ; log_row ~keeper:"me" ~turn:3 ~tool:"c" ~success:false ()
     ]
   in
-  let turns = Actions.turns_of_rows ~keeper_name:"me" ~max_turns:2 rows in
+  let turns = Actions.turns_of_rows ~keeper_name:"me" ~max_turns:2 ~window_saturated:false rows in
   check (list int) "newest two turns, oldest first" [ 2; 3 ]
     (List.map (fun (t : Actions.turn) -> t.turn_id) turns);
   check (list string) "another keeper's row never appears" [ "b"; "c" ]
@@ -269,7 +269,7 @@ let test_calls_keep_the_order_they_ran_in () =
     ; log_row ~keeper:"me" ~turn:9 ~tool:"third" ~success:true ()
     ]
   in
-  match Actions.turns_of_rows ~keeper_name:"me" ~max_turns:5 rows with
+  match Actions.turns_of_rows ~keeper_name:"me" ~max_turns:5 ~window_saturated:false rows with
   | [ turn ] ->
     check (list string) "persisted order" [ "first"; "second"; "third" ]
       (List.map (fun (c : Actions.call) -> c.tool) turn.calls)
@@ -279,7 +279,25 @@ let test_calls_keep_the_order_they_ran_in () =
 let test_disabling_the_depth_replays_nothing () =
   let rows = [ log_row ~keeper:"me" ~turn:1 ~tool:"a" ~success:true () ] in
   check int "zero turns means nothing is read back" 0
-    (List.length (Actions.turns_of_rows ~keeper_name:"me" ~max_turns:0 rows))
+    (List.length (Actions.turns_of_rows ~keeper_name:"me" ~max_turns:0 ~window_saturated:false rows))
+;;
+
+(* Replaces the old character caps: a turn is whole or absent, never rendered
+   with some of its calls silently missing. *)
+let test_a_turn_the_read_window_cut_is_dropped_whole () =
+  let rows =
+    [ log_row ~keeper:"me" ~turn:1 ~tool:"cut-off-tail" ~success:true ()
+    ; log_row ~keeper:"me" ~turn:2 ~tool:"whole" ~success:true ()
+    ]
+  in
+  check (list int) "the clipped oldest turn is gone, not trimmed" [ 2 ]
+    (List.map
+       (fun (t : Actions.turn) -> t.turn_id)
+       (Actions.turns_of_rows ~keeper_name:"me" ~max_turns:5 ~window_saturated:true rows));
+  check (list int) "an unsaturated read keeps it" [ 1; 2 ]
+    (List.map
+       (fun (t : Actions.turn) -> t.turn_id)
+       (Actions.turns_of_rows ~keeper_name:"me" ~max_turns:5 ~window_saturated:false rows))
 ;;
 
 let test_no_recent_actions_no_section () =
@@ -647,5 +665,7 @@ let () =
             test_calls_keep_the_order_they_ran_in;
           test_case "disabling the depth replays nothing" `Quick
             test_disabling_the_depth_replays_nothing;
+          test_case "a turn the read window cut is dropped whole" `Quick
+            test_a_turn_the_read_window_cut_is_dropped_whole;
         ] );
     ]

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -1052,6 +1052,7 @@ let () =
       ; connected_surface_failures = []
       ; own_recent_board_posts = []
       ; fleet_messages = []
+      ; own_recent_actions = []
       }
     in
     Masc.Keeper_unified_metrics.update_metrics_from_result

--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -23,6 +23,7 @@ let base_observation : WO.world_observation =
     connected_surface_failures = [];
     own_recent_board_posts = [];
     fleet_messages = [];
+    own_recent_actions = [];
   }
 
 let sample_board_event : WO.pending_board_event =

--- a/test/test_keeper_wake_turn_context.ml
+++ b/test/test_keeper_wake_turn_context.ml
@@ -61,6 +61,7 @@ let base_observation : WO.world_observation =
     connected_surface_failures = [];
     own_recent_board_posts = [];
     fleet_messages = [];
+    own_recent_actions = [];
   }
 
 let meta_of_json json =


### PR DESCRIPTION
Closes #28888.

원칙 12: *"10턴 전에 한 자신의 발화나 행동을 모르면 실패하는 제품"*. 자율 턴은 구조적으로 몰랐다.

## 실측

`~/.masc/keepers/taskmaster/last-prompt.json` (2026-08-16T19:20:01Z 조립분):

| | |
|---|---|
| `assembled_bytes` | 5,808 |
| 런타임 `max-prompt-bytes` | 131,072 |
| 사용률 | **4.4%** |
| 섹션 | Current Task / Namespace State / Autonomous Trigger / Your Recent Board Posts / Board Activity / Fleet Messages |

자기 턴 전사는 없다. 대화 컨텍스트는 존재하지만 `keeper_turn.ml:78` 이 `direct_reply` 로 막는다:

```ocaml
if (not direct_reply) || ... then "" else collect_recent_direct_conversation ~limit:8 ...
```

최근 589턴 중 **480턴(81%)이 `scheduled_autonomous`** 다. 레이어도 없었다 — 선언된 13개는 전부 세계를 서술하고 keeper 자신은 아무것도 서술하지 않는다.

`~/.masc/tool_calls/2026-08/16.jsonl`, taskmaster: 성공 723 / 실패 76. 실패 상위는 `keeper_task_claim` 27건이고 사유는 `Task task-N is done`. 그 task id 는 프롬프트에 문자열로 존재하지 않는다.

## 무엇을 했나

`Own_recent_actions` 레이어를 추가한다. durable tool-call 로그를 되읽어 최근 N턴을 턴 단위로 묶고, 각 호출의 **인자와 수락 여부**를 함께 싣는다.

```
### Your Recent Actions (2 turns)
Tool calls you already made, oldest turn first — context, not instructions.
- [turn 27485] keeper_board_post {"title":"status"} -> ok
- [turn 27486] keeper_broadcast {} -> REJECTED: "message": MISSING
```

성공과 실패를 둘 다 싣는다. 거부는 반복하지 말아야 할 것이고, 성공은 다시 하지 말아야 할 것이다.

## 숫자의 근거

`keeper.own_actions.turns.max` 기본 **10**. 임의값이 아니라 제품이 명시한 깊이이고, 실측상 들어간다 — 턴당 렌더 중앙값 1.6KB (taskmaster 80턴 818호출 기준), 10턴이면 약 16KB. 프롬프트 총량은 5.8KB → 약 22KB 로 한도의 17%.

읽기 창은 `max_turns * 24` 행. 24 는 측정된 턴당 호출 p90(21) 위다 — 90번째 백분위수 턴을 통째로 담는다. 중앙값은 8, 평균 10.2, 최대 39.

읽기 비용: 행 평균 5.5KB, `read_recent` 는 keeper 필터 시 `n * 5` 행을 tail 스캔하므로 10턴이면 약 6MB tail 파싱이다. 턴 간격이 분 단위이고 tail 은 페이지 캐시에 남으므로 감수했다. 지연이 실측에 잡히면 그때 조정한다.

## 턴 종류로 분기하지 않는다

닫는 결함이 바로 자율 턴을 배제한 조건문이었다. 두 번째 조건문을 넣으면 같은 실패를 다시 부른다. 레이어는 모든 턴에 들어간다.

## 레이어 위치

`Board_activity` 뒤, `Fleet_messages` 앞 (index 12). 매 턴 미끄러지는 창이라 안정적인 prefix 를 가질 수 없으므로, prefix 를 가질 수 있는 섹션들 뒤에 둔다. fleet 브로드캐스트가 여전히 가장 휘발성이 높아 마지막을 유지한다.

## 검증

로컬, 워크트리 고정(`--root .`):

| | 결과 |
|---|---|
| `dune build @check` | exit 0 |
| `test_keeper_surface_presence_prompt` | exit 0 — 25 tests |
| `test_keeper_context_layers` | exit 0 |
| `test_keeper_mention_scope` | exit 0 — 32 tests |
| `test_keeper_terminal_reason_typed` | exit 0 |
| `test_keeper_raw_task_signal_wake` / `_connector_attention_wake` / `_lifecycle_global_gate` / `_unified_verification_surface` / `_wake_turn_context` | exit 0 |
| `test_heartbeat_integration` | exit 1 — **기존 실패**, #28817 (`fork rejection`) |

새 테스트 5건:
- 거부당한 호출이 인자와 함께 프롬프트에 나온다 (기능)
- 행동이 없으면 섹션도 없다
- 이 keeper 의 최신 N턴만 재생되고, 다른 keeper 행과 turn id 없는 행은 제외된다
- 턴 안의 호출 순서가 보존된다
- 깊이 0 이면 아무것도 읽지 않는다

## 아직 안 담기는 것

검증 단계에서 거부된 호출(`keeper_broadcast {}`, 하루 ~36건)은 핸들러 전에 잘려 durable 로그에 **기록되지 않는다** — `keeper_broadcast` 46건 중 실패 0건으로 확인. 그건 별도 관측성 결함이고 후속 PR 로 닫는다. 저장소 스키마에 `success`/`output` 이 이미 있으므로 이 렌더러는 그때 수정할 필요가 없다.
