### PR TITLE
fix(keeper): 실행 전에 거부된 도구 호출을 기록한다

### DIFF
--- a/lib/keeper/keeper_hooks_agent_core.ml
+++ b/lib/keeper/keeper_hooks_agent_core.ml
@@ -687,7 +687,8 @@ let make_hooks
       | _event -> Agent_core.Hooks.Continue);
 
     post_tool_use_failure = Some (function
-      | Agent_core.Hooks.PostToolUseFailure { tool_name; error; _ } ->
+      | Agent_core.Hooks.PostToolUseFailure
+          { invocation; tool_name; input; stage; duration_ms; error } ->
         let meta = !meta_ref in
         (* The richer counterpart
              "tool <name> returned error result (n/max): <detail>"
@@ -699,6 +700,50 @@ let make_hooks
           tool_name error;
         (* #9919: this path is a count event, not a heuristic decision. *)
         record_tool_use_failure ~keeper_name:meta.name ~tool_name;
+        (match stage with
+         | Agent_core.Hooks.Execution ->
+           (* [post_tool_use] fires for this same call and already wrote its
+              row. Writing again here would double every executed failure. *)
+           ()
+         | Agent_core.Hooks.Validation_before_execution ->
+           (* The handler never ran, so [post_tool_use] never fires and no
+              other site records the call. Until this row existed a rejected
+              call left only a counter: the keeper could not see the argument
+              object it got refused for, and repeated it. *)
+           let tctx : Keeper_tool_call_log_context.turn_context =
+             Keeper_tool_call_log_context.get_turn_context_record
+               ~cell:turn_ctx_cell ()
+           in
+           (try
+              Keeper_tool_call_log.log_call
+                ~keeper_name:meta.name
+                ~tool_name ~input ~output_text:error
+                ~success:false ~duration_ms
+                ~model:(current_keeper_model meta)
+                ?agent_name:tctx.agent_name
+                ?lane:tctx.lane
+                ~execution_id:(Ids.Execution_id.generate ())
+                ~tool_use_id:(Agent_core.Tool_contract.Invocation.tool_use_id invocation)
+                ~turn:(Agent_core.Tool_contract.Invocation.turn invocation)
+                ?trace_id:tctx.trace_id ?session_id:tctx.session_id
+                ?generation:tctx.generation
+                ?keeper_turn_id:tctx.keeper_turn_id
+                ?task_id:tctx.task_id ?goal_ids:tctx.goal_ids
+                ~result_bytes:(String.length error)
+                ()
+            with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | exn ->
+              Otel_metric_store.inc_counter
+                Keeper_metrics.(to_string LifecycleCallbackFailures)
+                ~labels:
+                  [ (label_keeper, meta.name)
+                  ; (label_callback, callback_label_post_tool_log_write)
+                  ]
+                ();
+              Log.Keeper.warn ~keeper_name:meta.name
+                "tool=%s rejected-call log_call write failed: %s"
+                tool_name (Printexc.to_string exn)));
         Agent_core.Hooks.Continue
       | _event -> Agent_core.Hooks.Continue);
   }

--- a/test/test_keeper_run_tools_hooks.ml
+++ b/test/test_keeper_run_tools_hooks.ml
@@ -680,6 +680,88 @@ let test_failed_tool_observer_releases_next_completion () =
   check bool "a reported observer failure does not poison later receipts" true !observed
 ;;
 
+
+(* A call refused before the handler runs used to leave only a counter. The
+   keeper's own history showed nothing, so it repeated the same malformed call
+   every turn. An executed failure must still be written once, not twice:
+   [post_tool_use] already records that one. *)
+let rejected_rows_for ~stage =
+  with_temp_base_path @@ fun base_path ->
+  Fun.protect
+    ~finally:(fun () -> Masc.Keeper_tool_call_log.reset_for_testing ())
+    (fun () ->
+       Eio_main.run @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       Masc.Keeper_tool_call_log.init ~base_path ();
+       let config = Masc.Workspace.default_config base_path in
+       let meta_ref = ref (make_meta "rejection-keeper") in
+       let turn_ctx_cell = Masc.Keeper_tool_call_log.create_turn_ctx_cell () in
+       let hooks =
+         Masc.Keeper_hooks_agent_core.make_hooks
+           ~config ~meta_ref ~turn_ctx_cell ~generation:0
+           ~trace_id:"rejection-trace" ~keeper_turn_id:1
+           ~on_after_turn_ordinal:ignore ()
+       in
+       let hook =
+         match hooks.Agent_core.Hooks.post_tool_use_failure with
+         | Some hook -> hook
+         | None -> fail "post_tool_use_failure hook is not installed"
+       in
+       let invocation =
+         Agent_core.Tool_contract.Invocation.create
+           ~tool_use_id:"call-1" ~turn:1
+           ~completion:Agent_core.Tool_contract.Continue_after_success
+           ~schedule:
+             { planned_index = 0
+             ; batch_index = 0
+             ; batch_size = 1
+             ; execution_mode = Agent_core.Tool_contract.Serial
+             }
+       in
+       let _ =
+         hook
+           (Agent_core.Hooks.PostToolUseFailure
+              { invocation
+              ; tool_name = "keeper_broadcast"
+              ; input = `Assoc []
+              ; stage
+              ; duration_ms = 1.0
+              ; error = {|"message": MISSING (required: string)|}
+              })
+       in
+       Masc.Keeper_tool_call_log.flush_now ();
+       Masc.Keeper_tool_call_log.read_recent ~keeper_name:"rejection-keeper" ())
+;;
+
+let test_a_rejected_call_leaves_a_row () =
+  let rows = rejected_rows_for ~stage:Agent_core.Hooks.Validation_before_execution in
+  check int "exactly one row" 1 (List.length rows);
+  match rows with
+  | [ row ] ->
+    let field name =
+      match Json_util.assoc_member_opt name row with
+      | Some (`String s) -> s
+      | Some (`Bool b) -> string_of_bool b
+      | Some other -> Yojson.Safe.to_string other
+      | None -> "<absent>"
+    in
+    check string "the tool that refused" "keeper_broadcast" (field "tool");
+    check string "recorded as a failure" "false" (field "success");
+    check bool "the argument object it was refused for" true
+      (String.length (field "input") > 0);
+    check bool "the refusal text" true
+      (let out = field "output" in
+       String.length out > 0
+       && (try ignore (Str.search_forward (Str.regexp_string "MISSING") out 0); true
+           with Not_found -> false))
+  | _ -> fail "expected exactly one row"
+;;
+
+let test_an_executed_failure_is_not_written_twice () =
+  let rows = rejected_rows_for ~stage:Agent_core.Hooks.Execution in
+  check int "post_tool_use owns that row, this hook adds none" 0 (List.length rows)
+;;
+
 let test_production_post_tool_hook_cancellation_releases_next_completion () =
   with_temp_base_path @@ fun base_path ->
   Fun.protect
@@ -890,6 +972,16 @@ let () =
             "production hook cancellation releases the next completion"
             `Quick
             test_production_post_tool_hook_cancellation_releases_next_completion
+        ] )
+    ; ( "rejected_tool_calls"
+      , [ test_case
+            "a call refused before execution leaves a row"
+            `Quick
+            test_a_rejected_call_leaves_a_row
+        ; test_case
+            "an executed failure is not written twice"
+            `Quick
+            test_an_executed_failure_is_not_written_twice
         ] )
     ]
 ;;


### PR DESCRIPTION
#28885 의 한 갈래. #28892 가 프롬프트에 되읽는 그 저장소를 채운다.

## 무엇이 비어 있었나

실행 전 검증에서 거부된 호출은 **디버그 로그 한 줄과 카운터만** 남긴다. 핸들러가 돌지 않으므로 `post_tool_use` 가 발화하지 않고, durable tool-call 로그에 행이 없다. 그 로그를 읽는 어떤 화면에도 나타나지 않는다.

## 실측

taskmaster, 2026-08-16:

| | |
|---|---|
| `keeper_broadcast` 를 `{}` 로 호출해 거부된 횟수 | ~36 |
| 저장소의 `keeper_broadcast` 행 | 46 |
| 그중 `success=false` | **0** |

거부 문구는 이렇게 생겼다:

```
Your call to "keeper_broadcast":
{}

Errors (fix these and call again):
  "message": MISSING (required: string)
```

"고쳐서 다시 부르라" 고 쓰여 있지만, antigravity CLI 가 도구 에러를 `turn_failed` 로 승격시켜 턴이 끝난다. 그리고 그 실수는 어디에도 안 남으므로 다음 턴이 같은 호출을 반복한다.

## 무엇을 했나

`post_tool_use_failure` 훅이 **검증 단계에 한해** 행을 쓴다.

실행 단계는 일부러 침묵한다. agent_core 는 실행 실패 시 `post_tool_use` 와 `post_tool_use_failure` 를 **둘 다** 발화하고(`agent_tools.ml:368,394`), 앞의 훅이 이미 그 행을 썼다. 여기서 또 쓰면 실행 실패가 전부 두 번 기록된다. 두 경우를 가르는 것은 `Hooks.tool_failure_stage` 변형이다 — 추론이 아니다.

## 검증

로컬, 워크트리 고정(`--root .`):

| | 결과 |
|---|---|
| `dune build @check` | exit 0 |
| `test_keeper_run_tools_hooks` | exit 0 — 33 tests |
| `check-determinism-contract.sh` | `DET/NDT gate: PASS` |

새 테스트 2건:
- 실행 전에 거부된 호출이 행 하나를 남기고, 그 행에 도구 이름·인자·거부 사유가 들어 있다
- 실행 단계 실패는 이 훅이 행을 추가하지 않는다

**공허하지 않음을 확인했다.** 두 단계의 처리를 서로 바꾸면 두 테스트가 모두 실패한다 (`3 FAIL`). 원래 배치로 되돌리면 33 tests 전부 통과.

## 이어지는 것

이 행들은 `keeper_turn_id` 를 달고 있으므로 #28892 의 `Your Recent Actions` 레이어가 렌더러 수정 없이 그대로 집는다.