### PR TITLE
fix(server): keeper tool-failure 로그 레벨을 class helper로 정렬

### DIFF
--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -734,7 +734,10 @@ let execute_keeper_stream_tool_streaming
         ~error_msg:error_detail ();
       (match disposition with
        | Tool_result.Failed failure_class ->
-         Log.Keeper.emit Log.Error
+         (* SSOT: the failure class owns its log level (Runtime_failure ->
+            Error, the rest -> Warn). This site was the last Error hardcode;
+            the MCP twin already routes through the helper (#28878 review). *)
+         Log.Keeper.emit (Tool_result.log_level_of_failure_class failure_class)
            ~details:
              (keeper_tool_failure_log_details ~tool_name:"masc_keeper_msg"
                 ~agent_name ~duration_ms ~streaming:true ~error_body:body


### PR DESCRIPTION
#28878 리뷰가 두 번 기록한 non-blocking nit의 마감. `masc_keeper_msg` 실패 로그가 failure class와 무관하게 `Log.Error`를 하드코딩해, (1) `Tool_result.log_level_of_failure_class`의 선언된 계약(Runtime_failure만 Error, 나머지 Warn)과 이 사이트만 어긋났고, (2) 신설 `Operator_cancelled`의 Warn 레벨이 이 지점에서 무효였다. MCP dispatch 쪽 동일 로그는 이미 helper 경유(전수 확인: 이 사이트가 마지막 이탈).

1줄 수정: `Log.Keeper.emit (Tool_result.log_level_of_failure_class failure_class)`.

동작 변화: 이 사이트의 Transient/Policy/Workflow/Operator_cancelled 실패 로그가 Error → **Warn**으로 내려간다 — helper 계약이 의도한 그대로이며, Runtime_failure는 Error 유지.

검증: `@check` 0, chat_operation_http 4 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)