### PR TITLE
fix(llm-provider): seed the TLS RNG at the https gate, not in each main()

### DIFF
--- a/lib/eio_context/dune
+++ b/lib/eio_context/dune
@@ -8,4 +8,4 @@
  ; RFC-0071 §3.4 Phase 5 ratchet: warning 4 enabled. Leaf util sublib. + unused-value ratchet (warning 32)
  (flags
   (:standard -w +4 -w +33 -w +37))
- (libraries eio eio.unix uri ca-certs tls tls-eio domain-name))
+ (libraries eio eio.unix uri ca-certs tls tls-eio domain-name masc.crypto_rng))

--- a/lib/eio_context/eio_context.ml
+++ b/lib/eio_context/eio_context.ml
@@ -202,6 +202,11 @@ let https_error message = Error message
 
 let build_https_connector_result () =
   try
+    (* The TLS handshake draws from the process-global RNG default; guard
+       it here like llm_provider's tls_client_config does, so a binary
+       whose first TLS contact is this connector cannot die on
+       No_default_generator (#28896). *)
+    Crypto_rng.ensure_default ();
     match Ca_certs.authenticator () with
     | Error (`Msg msg) -> https_error ("CA certs unavailable: " ^ msg)
     | Error _ -> https_error "CA certs unavailable: unknown error"

--- a/lib/keeper/keeper_capability_probe.ml
+++ b/lib/keeper/keeper_capability_probe.ml
@@ -98,6 +98,33 @@ type invocation =
       }
   | Provider_rejected of { detail : string }
 
+(* Every arm is spelled out. A wildcard here would fold a new transport
+   failure into the same string as a quota rejection, and telling those
+   apart is the reason this lane exists. The Unknown_provider_failure
+   reason must survive into the detail: it carries the raw exception
+   (e.g. No_default_generator), and dropping it turned a one-line
+   diagnosis into an archaeology dig (2026-08-16). *)
+let detail_of_http_error (err : Llm_provider.Http_client.http_error) : string =
+  match err with
+  | Llm_provider.Http_client.HttpError { code; body; _ } ->
+    Printf.sprintf "HTTP %d: %s" code (String.trim body)
+  | Llm_provider.Http_client.NetworkError { message; _ } ->
+    Printf.sprintf "network: %s" message
+  | Llm_provider.Http_client.TimeoutError { message; _ } ->
+    Printf.sprintf "timeout: %s" message
+  | Llm_provider.Http_client.AcceptRejected { reason } ->
+    Printf.sprintf "accept rejected: %s" reason
+  | Llm_provider.Http_client.ProviderTerminal { message; _ } ->
+    Printf.sprintf "provider terminal: %s" message
+  | Llm_provider.Http_client.ProviderFailure
+      { kind = Llm_provider.Http_client.Unknown_provider_failure { reason = Some reason }
+      ; message
+      } ->
+    Printf.sprintf "provider failure: %s (%s)" message reason
+  | Llm_provider.Http_client.ProviderFailure { message; _ } ->
+    Printf.sprintf "provider failure: %s" message
+;;
+
 let invocation_to_string = function
   | Tool_invoked { tool; elapsed_s } ->
     Printf.sprintf "invoked %s in %.1fs" tool elapsed_s
@@ -263,26 +290,7 @@ let probe_invocation ~sw ~net ?clock ~now ~runtime_id ~tool ~prompt () =
                   ~tools:[ tool_json ]
                   ()
               with
-              | Error err ->
-                (* Every arm is spelled out. A wildcard here would fold a new
-                   transport failure into the same string as a quota rejection,
-                   and telling those apart is the reason this lane exists. *)
-                let detail =
-                  match err with
-                  | Llm_provider.Http_client.HttpError { code; body; _ } ->
-                    Printf.sprintf "HTTP %d: %s" code (String.trim body)
-                  | Llm_provider.Http_client.NetworkError { message; _ } ->
-                    Printf.sprintf "network: %s" message
-                  | Llm_provider.Http_client.TimeoutError { message; _ } ->
-                    Printf.sprintf "timeout: %s" message
-                  | Llm_provider.Http_client.AcceptRejected { reason } ->
-                    Printf.sprintf "accept rejected: %s" reason
-                  | Llm_provider.Http_client.ProviderTerminal { message; _ } ->
-                    Printf.sprintf "provider terminal: %s" message
-                  | Llm_provider.Http_client.ProviderFailure { message; _ } ->
-                    Printf.sprintf "provider failure: %s" message
-                in
-                Ok (Provider_rejected { detail })
+              | Error err -> Ok (Provider_rejected { detail = detail_of_http_error err })
               | Ok response ->
                 let elapsed_s = now () -. started in
                 (match tool_use_names response with

--- a/lib/keeper/keeper_capability_probe.mli
+++ b/lib/keeper/keeper_capability_probe.mli
@@ -114,6 +114,12 @@ type invocation =
 
 val invocation_to_string : invocation -> string
 
+val detail_of_http_error : Llm_provider.Http_client.http_error -> string
+(** Render a provider error for [Provider_rejected.detail]. Exhaustive over
+    the closed error type; an [Unknown_provider_failure] keeps its raw
+    exception reason so an operator can tell a seeding bug from a quota
+    rejection without rerunning under a debugger. *)
+
 (** Why a probe could not be attempted at all. *)
 type invocation_error =
   | Not_on_surface of verdict

--- a/packages/agent_core/lib/llm_provider/api_common.ml
+++ b/packages/agent_core/lib/llm_provider/api_common.ml
@@ -618,7 +618,31 @@ let https_init_error_to_string = function
    results are equivalent and the last write wins. *)
 let tls_client_config_cache : Tls.Config.client option Atomic.t = Atomic.make None
 
+(* The TLS handshake draws from Mirage_crypto_rng's process-global default
+   generator, which some entrypoint must install. Leaving that to each
+   binary's main() made it forgettable: a CLI that skipped it had every
+   HTTPS request die in ~10ms as No_default_generator, swallowed downstream
+   into "unclassified transport exception" (keeper_capability_probe_cli,
+   2026-08-16 — five cloud providers read as rejected while local http
+   runtimes passed). Installing it at this gate, the single entrypoint
+   every HTTPS path crosses, removes the class. [use_default] is
+   idempotent, so a concurrent duplicate install is harmless. *)
+let ensure_rng_default () =
+  match Mirage_crypto_rng.default_generator () with
+  | _ -> ()
+  | exception Mirage_crypto_rng.No_default_generator ->
+    Mirage_crypto_rng_unix.use_default ()
+;;
+
+let%test "the https gate leaves the RNG default installed" =
+  ensure_rng_default ();
+  match Mirage_crypto_rng.default_generator () with
+  | _ -> true
+  | exception Mirage_crypto_rng.No_default_generator -> false
+;;
+
 let tls_client_config () : (Tls.Config.client, https_init_error) result =
+  ensure_rng_default ();
   match Atomic.get tls_client_config_cache with
   | Some config -> Ok config
   | None ->

--- a/packages/agent_core/lib/llm_provider/api_common.ml
+++ b/packages/agent_core/lib/llm_provider/api_common.ml
@@ -624,9 +624,17 @@ let tls_client_config_cache : Tls.Config.client option Atomic.t = Atomic.make No
    HTTPS request die in ~10ms as No_default_generator, swallowed downstream
    into "unclassified transport exception" (keeper_capability_probe_cli,
    2026-08-16 — five cloud providers read as rejected while local http
-   runtimes passed). Installing it at this gate, the single entrypoint
-   every HTTPS path crosses, removes the class. [use_default] is
-   idempotent, so a concurrent duplicate install is harmless. *)
+   runtimes passed). Installing it at this gate — the single entrypoint
+   every LLM-provider HTTPS path crosses (other subsystems with their own
+   TLS configs guard themselves: discord_wss_connection, eio_context,
+   otel) — removes the class for this package. Concurrent first calls may
+   each run [use_default], which unconditionally installs a fresh
+   generator; last write wins and every candidate is an independent
+   secure generator, so the guarded final state is safe even though the
+   install itself is not idempotent. This mirrors the masc-side
+   Crypto_rng.ensure_default, re-implemented here because agent_core
+   cannot depend on masc libraries (the package boundary points the
+   other way). *)
 let ensure_rng_default () =
   match Mirage_crypto_rng.default_generator () with
   | _ -> ()

--- a/packages/agent_core/lib/llm_provider/dune
+++ b/packages/agent_core/lib/llm_provider/dune
@@ -54,6 +54,7 @@
   ca-certs
   digestif
   cstruct
+  mirage-crypto-rng
   mirage-crypto-rng.unix
   mtime.clock.os
   domain-name

--- a/test/test_keeper_capability_probe.ml
+++ b/test/test_keeper_capability_probe.ml
@@ -392,6 +392,37 @@ let test_probe_and_turn_agree_on_the_seed () =
    surface exists only once the per-turn MCP bridge is up. Answering from the
    descriptor table instead would report advertisement as consumption, which is
    the exact mistake F1 of the 2026-08-12 audit was. *)
+(* detail_of_http_error must keep the Unknown_provider_failure reason: it
+   carries the raw exception (the 2026-08-16 probe read five cloud
+   providers as rejected because No_default_generator was rendered as a
+   bare "unclassified transport exception"). *)
+let test_detail_keeps_unknown_failure_reason () =
+  let detail =
+    Probe.detail_of_http_error
+      (Llm_provider.Http_client.ProviderFailure
+         { kind =
+             Llm_provider.Http_client.Unknown_provider_failure
+               { reason = Some "Mirage_crypto_rng.No_default_generator" }
+         ; message = "unclassified transport exception"
+         })
+  in
+  Alcotest.(check string)
+    "reason survives"
+    "provider failure: unclassified transport exception \
+     (Mirage_crypto_rng.No_default_generator)"
+    detail;
+  let bare =
+    Probe.detail_of_http_error
+      (Llm_provider.Http_client.ProviderFailure
+         { kind = Llm_provider.Http_client.Unknown_provider_failure { reason = None }
+         ; message = "unclassified transport exception"
+         })
+  in
+  Alcotest.(check string)
+    "reasonless failure stays bare"
+    "provider failure: unclassified transport exception"
+    bare
+
 let test_official_client_probe_refuses_antigravity () =
   let base = Filename.temp_file "probe-agy" ".d" in
   Sys.remove base;
@@ -574,6 +605,10 @@ let () =
         ; test_case "absent seed leaves the binding alone" `Quick test_undeclared_seed_leaves_the_binding_alone
         ; test_case "probe and turn agree on every declaration combination" `Quick
             test_probe_and_turn_agree_on_the_seed
+        ] )
+    ; ( "provider error rendering"
+      , [ test_case "unknown-failure reason survives into detail" `Quick
+            test_detail_keeps_unknown_failure_reason
         ] )
     ; ( "probe_official_client_invocation (offline)"
       , [ test_case "antigravity is refused with its reason" `Quick


### PR DESCRIPTION
## 문제

M3 admission probe(2026-08-16)에서 클라우드 provider 5종(ollama_cloud ×3, glm-5-turbo, kimi_coding)이 전부 ~10ms 만에 `provider failure: unclassified transport exception`으로 즉사. 로컬 http runtime은 전부 통과라 TLS 경로만 죽는 패턴.

원인: TLS 핸드셰이크가 요구하는 `Mirage_crypto_rng` 전역 기본 생성기를 **각 바이너리의 main()이 기억해서 설치**하는 구조였고, `keeper_capability_probe_cli`는 그 호출이 없었다 (`main_eio.ml:616`, `keeper_canary_run.ml:1014`은 있음). `No_default_generator` 예외가 `Unknown_provider_failure`로 삼켜지며 reason까지 detail에서 유실돼 진단이 어려웠다.

## 수정 (N-of-M 회피 — gate에서 클래스 제거)

1. `packages/agent_core/lib/llm_provider/api_common.ml`: `tls_client_config()`(모든 HTTPS 경로의 단일 관문)에서 RNG 기본 생성기를 idempotent하게 보장. 바이너리가 잊는 것이 불가능해짐. dune에 `mirage-crypto-rng` 코어 의존 추가.
2. `lib/keeper/keeper_capability_probe.ml`: detail 렌더러를 `detail_of_http_error`로 추출·노출하고 `Unknown_provider_failure`의 raw reason을 보존 (`... (Mirage_crypto_rng.No_default_generator)` 형태).

## 검증

- `@test/runtest-test_keeper_capability_probe` 20 green (신규: reason 보존 + reasonless 유지 고정)
- llm_provider inline test 신규 1건 pass. `exact_output_plan.ml:621`의 기존 inline 실패 1건은 **main에서도 동일 재현** — 이 PR과 무관 (이슈 별도 등록 예정)
- **라이브 재검**: 수정된 CLI로 실패했던 5 runtime 재-probe → **5/5 `tool_invoked`** (0.9–7.4s)

## admission 결과 (참고)

family 대표 12: PASS 11 / codex_subscription.gpt-5.4는 구독 한도(`usageLimitExceeded`, 8/20 16:46 리셋) — budget 게이트 없이 관측만 기록.