### PR TITLE
fix(keeper): tool-failure 로그 레벨을 class로 파생 — 남은 2사이트 (#28895 리뷰 반영)

### DIFF
--- a/lib/keeper/keeper_tool_dispatch_runtime.ml
+++ b/lib/keeper/keeper_tool_dispatch_runtime.ml
@@ -67,8 +67,12 @@ let descriptor_route_invariant_error ~keeper_name ~tool_name descriptor =
       ; "runtime_handler", runtime_handler
       ]
     ();
+  (* The invariant break is a Runtime_failure by construction; deriving the
+     level from that same class keeps the log honest if the classification
+     ever changes (#28895 review). *)
+  let failure_class = Tool_result.Runtime_failure in
   Log.Keeper.emit
-    Log.Error
+    (Tool_result.log_level_of_failure_class failure_class)
     ~keeper_name
     ~category:Log.Tool
     ~details:
@@ -81,7 +85,7 @@ let descriptor_route_invariant_error ~keeper_name ~tool_name descriptor =
          ])
     "keeper descriptor route resolved but its typed runtime handler returned no result";
   Keeper_tool_execution.failure_data
-    ~class_:Tool_result.Runtime_failure
+    ~class_:failure_class
     ~message:(Yojson.Safe.to_string payload)
     payload
 ;;

--- a/lib/keeper/keeper_tools_agent_core_handler_exec.ml
+++ b/lib/keeper/keeper_tools_agent_core_handler_exec.ml
@@ -158,7 +158,12 @@ let execute_with_observers
         Keeper_metrics.(to_string ToolsAgent_coreFailures)
         ~labels:[ "tool", name; "site", "error_result" ]
         ();
-      Log.Keeper.error "tool %s returned error result: %s" name detail;
+      (* SSOT: the failure class owns its log level — a policy/workflow/
+         transient/operator-cancelled rejection is an expected outcome on
+         this path, not an Error-level event (#28895 review). *)
+      Log.Keeper.emit
+        (Tool_result.log_level_of_failure_class failure_class)
+        (Printf.sprintf "tool %s returned error result: %s" name detail);
       let projected_error = Tool_result.message dispatch_result in
       append_tool_exec_decision_log
         ~config


### PR DESCRIPTION
#28895가 리뷰 FAIL(완료 주장 반증) 대응 커밋 전에 병합되어(8번째, #28862 — 이번엔 push 중단 게이트가 작동해 커밋 고립은 없었음), 반증된 갭을 이 PR로 닫는다.

## 리뷰가 반증한 것

#28895 본문의 "이 사이트가 마지막 이탈"은 거짓이었다 — 내 스윕이 메시지 문자열 grep이어서 패턴(=`Failed failure_class` arm의 레벨 하드코딩)을 놓쳤다. 실제 잔존 2곳:

1. **`keeper_tools_agent_core_handler_exec.ml:161`** — keeper agent 턴의 **범용 tool-dispatch 경로**(#28895가 고친 스트리밍 사이트보다 넓은 표면)가 5개 class 전부를 무조건 `Log.Keeper.error`로 기록. → class 파생 레벨로 수정 (Runtime_failure만 Error, 나머지 Warn).
2. **`keeper_tool_dispatch_runtime.ml:70`** — descriptor route invariant가 `Runtime_failure`를 만들면서 레벨은 별도로 Error 하드코딩(우연히 일치). → class를 한 번 바인딩해 로그와 failure_data가 드리프트할 수 없게 정렬.

## 이번 스윕 방법 (지난번 실패의 교정)

`Tool_result.Failed`를 포함한 파일 전수 × error-레벨 로그 교차 후 **사이트별 판정**:

| 사이트 | 판정 |
|---|---|
| mcp:625, stream 감사 로그(#28895), 위 2곳 | class 파생 (helper 경유) |
| mcp:569·stream:721 (crash catch-all), stream:1456 (projection invariant), validation:866 (validation 예외), handler_exec:345 (예외 경로, 정적으로 Runtime_failure) | class-비구동 맥락 — 명시적 Error가 정당, 현행 유지 |

## 검증

`@check` 0, test_keeper_owner 42 pass. 로그 레벨 자체를 assert하는 기존 테스트 없음(리뷰 확인) — 회귀 없음.

adversarial 재검증 후 `review:adversarial-pass` 라벨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)