### PR TITLE
fix(canary): make recall scoring sound against transcript collisions

### DIFF
--- a/bin/keeper_canary_run.ml
+++ b/bin/keeper_canary_run.ml
@@ -42,7 +42,7 @@ let usage =
    [--turn-interval SECONDS] [--turn-timeout SECONDS] \
    [--wall-clock-target SECONDS] [--inject-restart-after N] \
    [--inject-failover-after N --failover-down-cmd CMD [--failover-up-cmd CMD]] \
-   [--judge-runtime ID] [--out PATH]"
+   [--judge-runtime ID] [--out PATH] [--allow-reused-keeper]"
 
 type args = {
   keeper : string;
@@ -61,6 +61,7 @@ type args = {
   failover_up_cmd : string option;
   judge_runtime : string option;
   out : string option;
+  allow_reused_keeper : bool;
 }
 
 let parse_args argv =
@@ -80,6 +81,7 @@ let parse_args argv =
   let failover_up_cmd = ref None in
   let judge_runtime = ref None in
   let out = ref None in
+  let allow_reused_keeper = ref false in
   let rec parse = function
     | [] -> Ok ()
     | "--keeper" :: v :: rest ->
@@ -159,6 +161,9 @@ let parse_args argv =
       out := Some v;
       parse rest
     | [ "--out" ] -> Error "missing value for --out"
+    | "--allow-reused-keeper" :: rest ->
+      allow_reused_keeper := true;
+      parse rest
     | x :: _ -> Error ("unknown option: " ^ x)
   in
   match parse argv with
@@ -200,6 +205,7 @@ let parse_args argv =
          ; failover_up_cmd = !failover_up_cmd
          ; judge_runtime = !judge_runtime
          ; out = !out
+         ; allow_reused_keeper = !allow_reused_keeper
          })
 
 let iso8601_now () =
@@ -653,6 +659,45 @@ type judge_fn =
   recall_reply:string ->
   (Keeper_canary_judge.judgment, string) result
 
+(* First-occurrence recall scoring is only sound on a transcript that
+   cannot already contain this run's fact values or another round's list
+   for the scorer to match first. A reused keeper broke exactly that on
+   the 2026-08-16 wave-1 sweep (an old round's enum value matched before
+   this run's facts and flipped order_matches). Fail loud before turn 1;
+   --allow-reused-keeper turns the refusal into a recorded measurement
+   condition instead. *)
+let require_fresh_transcript ~host ~port ~keeper_name ~allow_reused :
+  (string list, string) result
+  =
+  let ( let* ) = Result.bind in
+  let path = Printf.sprintf "/api/v1/keepers/%s/chat/history" keeper_name in
+  let* status, body = Keeper_canary_http.admin_get ~host ~port ~path () in
+  if status < 200 || status >= 300
+  then Error (Printf.sprintf "chat/history returned HTTP %d" status)
+  else (
+    match Yojson.Safe.from_string body with
+    | exception Yojson.Json_error msg -> Error ("chat/history: invalid JSON: " ^ msg)
+    | `List [] -> Ok []
+    | `List rows ->
+      if allow_reused
+      then
+        Ok
+          [ Printf.sprintf
+              "reused keeper: transcript already held %d messages before turn 1 \
+               (--allow-reused-keeper); first-occurrence order scoring may be \
+               polluted by earlier rounds"
+              (List.length rows)
+          ]
+      else
+        Error
+          (Printf.sprintf
+             "keeper %s already has %d transcript messages; recall scoring needs \
+              a fresh keeper (pass --allow-reused-keeper to record the condition \
+              and proceed)"
+             keeper_name
+             (List.length rows))
+    | _ -> Error "chat/history: expected a JSON array")
+
 let resolve_base_path (args : args) : (string, string) result =
   let resolved =
     match args.base_path with
@@ -761,6 +806,13 @@ let run ?(judge : judge_fn option) ~(base_path : string) (args : args) :
       match args.inject_restart_after with
       | None -> Ok ()
       | Some _ -> require_proactive_disabled ~host ~port ~keeper_name:args.keeper
+    in
+    let* transcript_notes =
+      require_fresh_transcript
+        ~host
+        ~port
+        ~keeper_name:args.keeper
+        ~allow_reused:args.allow_reused_keeper
     in
     let injections = ref [] in
     let pending_failover = ref None in
@@ -898,7 +950,9 @@ let run ?(judge : judge_fn option) ~(base_path : string) (args : args) :
       ; deterministic_signal
       ; judgment
       ; injections = List.rev !injections
-      ; notes = capped_note @ correlation_notes @ failover_notes @ judge_notes
+      ; notes =
+          transcript_notes @ capped_note @ correlation_notes @ failover_notes
+          @ judge_notes
       })
 
 (* Sized for the judge's small JSON verdict (at most nine per_fact rows and

--- a/lib/keeper_canary/keeper_canary_facts.ml
+++ b/lib/keeper_canary/keeper_canary_facts.ml
@@ -27,15 +27,18 @@ let category_names =
   ; "blocked_dependency"
   ; "fallback_runtime"
   ; "incident_number"
-  ; "reviewer_timezone"
+  ; "escalation_channel"
   ; "artifact_name"
   ; "rollback_switch"
   ]
 
-let reviewer_timezones =
-  [| "Asia/Seoul"; "America/New_York"; "Europe/London"; "Asia/Tokyo"
-   ; "Australia/Sydney"; "America/Los_Angeles"
-  |]
+(* No enum-valued categories: a value drawn from a small pool (the old
+   reviewer_timezones array) can also appear in a keeper transcript for
+   unrelated reasons — another run's round, or ordinary prose — and the
+   scorer attributes the first occurrence to this run's fact. Asia/Tokyo
+   did exactly that on a reused keeper (2026-08-16, wave-1 sweep): the
+   old round's list matched first and flipped order_matches to false.
+   Every category value carries digest entropy instead. *)
 
 (* No PRNG anywhere in this module: every value is read directly off a
    SHA-256 digest of [seed] and a [label] naming which draw it is
@@ -78,25 +81,23 @@ let value_of_category ~seed = function
   | "project_codename" -> "Codename-" ^ hex_suffix ~seed ~label:"project_codename"
   | "lead_reviewer" -> "Reviewer-" ^ hex_suffix ~seed ~label:"lead_reviewer"
   | "deadline" ->
-    (* A digest-derived near-future date, not tied to wall-clock "today"
-       so the same run id reproduces the same date regardless of when it
-       runs. Month and day are independent labels, not two draws from one
-       stream, so neither depends on the other's derivation order. *)
+    (* A digest-derived near-future timestamp, not tied to wall-clock
+       "today" so the same run id reproduces the same value regardless of
+       when it runs. Month, day, and time are independent labels, not
+       draws from one stream, so none depends on another's derivation
+       order. The minute-resolution time is what pushes the value out of
+       the ~336-date pool that could recur across rounds on one keeper. *)
     let month = 1 + int_in_range ~seed ~label:"deadline:month" ~modulus:12 in
     let day = 1 + int_in_range ~seed ~label:"deadline:day" ~modulus:28 in
-    Printf.sprintf "2026-%02d-%02d" month day
+    let hour = int_in_range ~seed ~label:"deadline:hour" ~modulus:24 in
+    let minute = int_in_range ~seed ~label:"deadline:minute" ~modulus:60 in
+    Printf.sprintf "2026-%02d-%02d %02d:%02d UTC" month day hour minute
   | "blocked_dependency" -> "dep-" ^ hex_suffix ~seed ~label:"blocked_dependency"
   | "fallback_runtime" -> "runtime-" ^ hex_suffix ~seed ~label:"fallback_runtime"
   | "incident_number" ->
-    string_of_int (1000 + int_in_range ~seed ~label:"incident_number" ~modulus:9000)
-  | "reviewer_timezone" ->
-    let index =
-      int_in_range
-        ~seed
-        ~label:"reviewer_timezone"
-        ~modulus:(Array.length reviewer_timezones)
-    in
-    reviewer_timezones.(index)
+    (* Nine digits: the old 1000..9999 pool recurred across rounds. *)
+    string_of_int (100_000_000 + int_in_range ~seed ~label:"incident_number" ~modulus:900_000_000)
+  | "escalation_channel" -> "#esc-" ^ hex_suffix ~seed ~label:"escalation_channel"
   | "artifact_name" -> "artifact-" ^ hex_suffix ~seed ~label:"artifact_name" ^ ".json"
   | "rollback_switch" -> "rollback-" ^ hex_suffix ~seed ~label:"rollback_switch"
   | other ->
@@ -111,8 +112,8 @@ let statement_of ~category ~value =
     Printf.sprintf "The blocked dependency is %s." value
   | "fallback_runtime" -> Printf.sprintf "The fallback runtime is %s." value
   | "incident_number" -> Printf.sprintf "The incident number is %s." value
-  | "reviewer_timezone" ->
-    Printf.sprintf "The reviewer timezone is %s." value
+  | "escalation_channel" ->
+    Printf.sprintf "The escalation channel is %s." value
   | "artifact_name" -> Printf.sprintf "The artifact name is %s." value
   | "rollback_switch" ->
     Printf.sprintf "The rollback switch is called %s." value

--- a/lib/keeper_canary/keeper_canary_facts.ml
+++ b/lib/keeper_canary/keeper_canary_facts.ml
@@ -85,8 +85,13 @@ let value_of_category ~seed = function
        "today" so the same run id reproduces the same value regardless of
        when it runs. Month, day, and time are independent labels, not
        draws from one stream, so none depends on another's derivation
-       order. The minute-resolution time is what pushes the value out of
-       the ~336-date pool that could recur across rounds on one keeper. *)
+       order. Minute resolution lifts the pool from ~336 dates to ~484k
+       combinations (~19 bits) — collision *resistance* across rounds on
+       one keeper, not a uniqueness guarantee like the 48-bit hex-suffix
+       categories; ~50 accumulated rounds still carry roughly a 0.2%
+       birthday collision chance on this field alone. The fresh-transcript
+       gate in bin/keeper_canary_run.ml is what actually removes the
+       reused-round scenario. *)
     let month = 1 + int_in_range ~seed ~label:"deadline:month" ~modulus:12 in
     let day = 1 + int_in_range ~seed ~label:"deadline:day" ~modulus:28 in
     let hour = int_in_range ~seed ~label:"deadline:hour" ~modulus:24 in

--- a/test/test_keeper_canary_facts.ml
+++ b/test/test_keeper_canary_facts.ml
@@ -48,6 +48,44 @@ let test_generate_caps_at_category_count () =
     (List.length Keeper_canary_facts.category_names)
     (List.length facts)
 
+(* First-occurrence scoring needs values that cannot be matched by
+   anything except this run's own recall: no duplicates within a run, no
+   value that is a substring of another (its first occurrence would be
+   inside the longer value's statement), and no collision with another
+   run's values (an old round on a reused keeper matched "Asia/Tokyo"
+   first on 2026-08-16 and flipped order_matches). Two fixed seeds stand
+   in for "another run" deterministically. *)
+let test_values_are_unique_within_and_across_runs () =
+  let values seed =
+    Keeper_canary_facts.generate ~seed ~count:9
+    |> List.map (fun (f : Keeper_canary_facts.fact) -> f.value)
+  in
+  let a = values "run-fixed-A" in
+  let b = values "run-fixed-B" in
+  Alcotest.(check int)
+    "within-run values are pairwise distinct"
+    9
+    (List.length (List.sort_uniq compare a));
+  List.iter
+    (fun v ->
+      let contained_elsewhere =
+        List.exists
+          (fun w -> (not (String.equal v w)) && Astring.String.is_infix ~affix:v w)
+          a
+      in
+      Alcotest.(check bool)
+        (Printf.sprintf "%S is not a substring of another value" v)
+        false
+        contained_elsewhere)
+    a;
+  List.iter
+    (fun v ->
+      Alcotest.(check bool)
+        (Printf.sprintf "%S does not recur under another seed" v)
+        false
+        (List.mem v b))
+    a
+
 let test_statement_mentions_value () =
   let facts = Keeper_canary_facts.generate ~seed:"run-statement" ~count:9 in
   List.iter
@@ -185,6 +223,10 @@ let () =
             "statement mentions value"
             `Quick
             test_statement_mentions_value
+        ; Alcotest.test_case
+            "values are unique within and across runs"
+            `Quick
+            test_values_are_unique_within_and_across_runs
         ] )
     ; ( "plan"
       , [ Alcotest.test_case


### PR DESCRIPTION
## 문제 (wave-1 스윕 실측 2건)

first-occurrence 채점은 "값의 첫 등장 = 이 run의 recall"을 가정하는데, 재사용 keeper에서 두 방식으로 깨졌다:

1. `reviewer_timezone`이 6개 enum 풀에서 뽑혀 이전 라운드 목록의 `Asia/Tokyo`가 먼저 매치 → order_matches 거짓 반전 (llama_cpp run)
2. 이전 라운드 codename과의 모순 코멘터리가 새 codename의 첫 등장을 뒤로 밀어 순서 교란 (claude run)

## 수정 (양면)

**값 계약**: enum 카테고리 제거 — `reviewer_timezone` → `escalation_channel`(`#esc-<12hex>`, 48-bit), `deadline`에 digest 분 해상도 추가, `incident_number` 9자리로 확장. 신규 테스트가 run 내 중복 없음 + 값이 다른 값의 substring이 아님 + 다른 seed와 교집합 없음을 고정.

**프로토콜 강제**: 러너가 turn 1 전에 `chat/history`를 확인해 비어있지 않으면 거부. `--allow-reused-keeper`로 명시 해제 시 측정 조건 note가 evidence에 기록됨 (t1/t2 failover smoke처럼 의도적 재사용 경로 보존).

## 검증

- facts 15 / evidence 18 / failover 9 suites green
- 라이브: 38개 메시지 보유 keeper에 대해 turn 1 이전 거부 확인 (메시지에 해제 방법 안내)
- 재사용 오염 반례가 신선 keeper 재측정에서 소멸함은 오늘 wave-1 redo로 실증 (claude/llama_cpp 둘 다 9/9 + order true)

## 영향

기존 receipt 무효화 없음 (값 shape 변경은 새 run부터). category 명 변경은 hard-cut.