### PR TITLE
fix(agent-core): api_usage.input_tokens를 포함형 prompt total로 통일 (RFC-0382 G6)

### DIFF
--- a/docs/evidence/usage-semantics-audit-2026-08-17.md
+++ b/docs/evidence/usage-semantics-audit-2026-08-17.md
@@ -15,6 +15,7 @@
 | ollama / ollama_cloud | `prompt_eval_count` | (없음) | 캐시 미보고 — backend가 캐시 필드 0 고정. 로컬 KV 재사용 시 `prompt_eval_count`는 처리분만 세는 것으로 알려져 있으나 캐시 필드가 없어 구분 불가 (G2 계열 한계) | backend_ollama.ml:366-367 |
 | llama-server (OpenAI-compat) | `usage.prompt_tokens` | usage에는 없음 (`timings.cache_n` 별도) | **포함형** (prompt 전체) — 캐시 관측은 timings 축(G5/PR-2) | RFC-0382 §3.1 |
 | Kimi (Anthropic-compat) | Anthropic 형식 동일 | 동일 | Anthropic 형식으로 파싱되므로 정규화가 동일 적용. Kimi 자체 문서로는 **확인 필요** — compat 표면이 의미론까지 미러링한다고 가정 | backend_anthropic 경유 (count-tokens 주석) |
+| Claude Code CLI (result frame) | `usage.input_tokens` | `cache_creation_input_tokens`, `cache_read_input_tokens` | **배제형** — CLI가 Anthropic Messages usage를 그대로 미러. 초판 감사가 masc lib/ 스윕을 누락해 keeper 매핑이 배제형을 직대입하던 것을 adversarial review가 적발(P1-1) → `Runtime_claude_code` 파서가 cache 필드를 실어 나르고 keeper 매핑이 `usage_of_wire_counts` 경유로 수정 | 테스트 픽스처의 실프레임 형태 + 리뷰 코멘트 |
 
 ## agent_core 코드 판정 (수정 전 → 후)
 
@@ -34,6 +35,19 @@ Anthropic 형식 + 캐시 활성(system/tools cache_control) 조합에서:
 
 1. **비용 과소**: regular input이 `max 0 (exclusive − creation − read)`로 클램프 — 캐시가 클수록 정규 입력 과금이 0으로 소멸.
 2. **점유율 과소**: `keeper_context_observation_projection`의 ratio 분자(RFC-0233 "provider-reported prompt total")가 배제형 값 — 캐시된 프리픽스가 클수록 창 점유가 실제보다 작게 보고.
+
+## Durable 표면의 구의미론 데이터 (adversarial review P1-2 판정)
+
+의미 변경 시점(배포 경계) 이전에 기록된 값을 들고 있는 durable 표면 4곳의 처분:
+
+| 표면 | 처분 | 근거 |
+|---|---|---|
+| `cache.ml` 응답 캐시 | **schema "2" 하드컷** (이 PR) | 유일하게 구 값이 *canonical 자리로 재유입*되는 코덱 — 버전 가드가 은퇴 |
+| turn_record (RFC-0233 점유율 원천) | 조치 불요 | 점유율 소비자는 `keeper_context_observation_projection.ml`의 trace_id 가드가 현재 턴 record만 통과시킴 — 배포(=재시작) 이후 구 record는 구조적으로 소비 불가. `last_turn_usage` 표시 표면은 첫 턴에 세척되는 1턴 잔상 |
+| checkpoint `usage_stats.total_*` 누적치 | 문서화(아래 epoch 주석) | 이 총합은 PR 이전부터 provider 혼합 의미론(배제형 Anthropic + 포함형 나머지)의 합이라 "순수한 v1 의미"가 애초에 없음. 전 소비자(codec 왕복, durable_event carry, tool_agent_timeline rollup, dashboard JSON ×3)가 관측 표면이고 게이트 0건. checkpoint 폐기는 transcript(durable truth) 파괴라 비례성 위반 |
+| `execution_provider_response_snapshot` 실행 저널 | 조치 불요 | 소비자는 `execution_event.ml` 단일 — 기록 시점 사실의 evidence 저널이며, 재해석/재작성은 ledger 원칙 위반 |
+
+**Epoch 주석**: checkpoint 누적 total_* 값은 2026-08-17 배포 경계 이전 기여분이 배제형 Anthropic 값(및 원래부터 포함형인 타 provider 값)의 혼합이다. 경계 이후 기여분은 전부 포함형. 이 총합에서 캐시 비중 등을 역산할 때는 경계 이전 구간을 신뢰하지 말 것.
 
 ## 잔여 결함 (이 PR 범위 밖, #28903으로 추적)
 

--- a/docs/evidence/usage-semantics-audit-2026-08-17.md
+++ b/docs/evidence/usage-semantics-audit-2026-08-17.md
@@ -43,7 +43,7 @@ Anthropic 형식 + 캐시 활성(system/tools cache_control) 조합에서:
 | 표면 | 처분 | 근거 |
 |---|---|---|
 | `cache.ml` 응답 캐시 | **schema "2" 하드컷** (이 PR) | 유일하게 구 값이 *canonical 자리로 재유입*되는 코덱 — 버전 가드가 은퇴 |
-| turn_record (RFC-0233 점유율 원천) | 조치 불요 | 점유율 소비자는 `keeper_context_observation_projection.ml`의 trace_id 가드가 현재 턴 record만 통과시킴 — 배포(=재시작) 이후 구 record는 구조적으로 소비 불가. `last_turn_usage` 표시 표면은 첫 턴에 세척되는 1턴 잔상 |
+| turn_record (RFC-0233 점유율 원천) | 조치 불요 — 단 잔류는 1턴 | **정정(재검증 반영)**: 재시작은 trace_id를 보존하므로(메타 로드가 그대로 파싱, 재발급은 Handoff뿐) trace_id 가드는 배포 경계를 거르지 못한다 — 초판의 "혼합 창이 빔" 주장은 오류. 올바른 근거: (1) record는 내부 일관 — tokens와 window가 같은 요청에서 나와 record 단위 교차-의미론 산술이 없음, 구 record의 과소 표시는 그 record가 기록될 당시 동작 그대로, (2) 다음 턴 완료가 포함형 record로 덮어써 keeper당 최대 1턴 잔류, (3) 소비자는 관측 표면(대시보드 점유율·last_turn_usage)이고 게이트 없음. 버전 필드 추가는 legacy-detection 필드라 부적격 |
 | checkpoint `usage_stats.total_*` 누적치 | 문서화(아래 epoch 주석) | 이 총합은 PR 이전부터 provider 혼합 의미론(배제형 Anthropic + 포함형 나머지)의 합이라 "순수한 v1 의미"가 애초에 없음. 전 소비자(codec 왕복, durable_event carry, tool_agent_timeline rollup, dashboard JSON ×3)가 관측 표면이고 게이트 0건. checkpoint 폐기는 transcript(durable truth) 파괴라 비례성 위반 |
 | `execution_provider_response_snapshot` 실행 저널 | 조치 불요 | 소비자는 `execution_event.ml` 단일 — 기록 시점 사실의 evidence 저널이며, 재해석/재작성은 ledger 원칙 위반 |
 

--- a/docs/evidence/usage-semantics-audit-2026-08-17.md
+++ b/docs/evidence/usage-semantics-audit-2026-08-17.md
@@ -1,0 +1,41 @@
+# Provider usage 의미론 감사 — input_tokens의 캐시 포함 여부 (RFC-0382 G6)
+
+- 확인일: 2026-08-17 (공식 문서 fetch 기준)
+- 질문: 각 provider wire의 prompt/input 토큰 카운트가 캐시 성분(read/write)을 **포함**하는가 **배제**하는가, 그리고 agent_core `Types.api_usage`가 그 차이를 흡수하는가.
+- 결론: 배제형 wire는 Anthropic Messages 형식 하나. canonical 계약을 "inclusive prompt total"로 명문화하고(`types.mli`), Anthropic parse 경계에서 정규화한다(`Backend_anthropic.usage_of_wire_counts`).
+
+## Provider별 wire 의미론
+
+| Provider (wire) | prompt 카운트 필드 | 캐시 필드 | 의미론 | 근거 |
+|---|---|---|---|---|
+| Anthropic Messages | `usage.input_tokens` | `cache_creation_input_tokens`, `cache_read_input_tokens` | **배제형** — "Number of input tokens which were not read from or used to create a cache"; `total_input_tokens = cache_read + cache_creation + input_tokens` | platform.claude.com/docs prompt-caching, 2026-08-17 확인 |
+| OpenAI Chat/Responses | `usage.prompt_tokens` (`input_tokens`) | `prompt_tokens_details.cached_tokens` | **포함형** — "reused 1,920 **of its** 2,006 prompt tokens" (cached ⊂ prompt) | developers.openai.com prompt-caching, 2026-08-17 확인 |
+| Gemini generateContent | `usageMetadata.promptTokenCount` | `cachedContentTokenCount` | **포함형** — "this is still the total effective prompt size meaning this includes the number of tokens in the cached content" | ai.google.dev/api/generate-content, 2026-08-17 확인 |
+| GLM (OpenAI-compat) | `usage.prompt_tokens` | `prompt_tokens_details.cached_tokens` | **포함형** — RFC-0382 §3.2 정정 기록(라이브 데이터로 확정: input에 cache read 기포함) | RFC-0382 §3.2, 2026-08-16 |
+| ollama / ollama_cloud | `prompt_eval_count` | (없음) | 캐시 미보고 — backend가 캐시 필드 0 고정. 로컬 KV 재사용 시 `prompt_eval_count`는 처리분만 세는 것으로 알려져 있으나 캐시 필드가 없어 구분 불가 (G2 계열 한계) | backend_ollama.ml:366-367 |
+| llama-server (OpenAI-compat) | `usage.prompt_tokens` | usage에는 없음 (`timings.cache_n` 별도) | **포함형** (prompt 전체) — 캐시 관측은 timings 축(G5/PR-2) | RFC-0382 §3.1 |
+| Kimi (Anthropic-compat) | Anthropic 형식 동일 | 동일 | Anthropic 형식으로 파싱되므로 정규화가 동일 적용. Kimi 자체 문서로는 **확인 필요** — compat 표면이 의미론까지 미러링한다고 가정 | backend_anthropic 경유 (count-tokens 주석) |
+
+## agent_core 코드 판정 (수정 전 → 후)
+
+| 사이트 | 수정 전 | 수정 후 |
+|---|---|---|
+| `backend_anthropic.ml` parse_response | wire 값 그대로 복사 (**배제형 유입**) | `usage_of_wire_counts`로 inclusive 정규화 |
+| `streaming.ml` message_start | 동일 유입 | 동일 정규화 (output은 delta 소유라 0 유지) |
+| `streaming.ml` message_delta | input 0 고정, cache는 그대로 | 변경 없음 + 계약 주석 (아래 잔여 결함 참조) |
+| `backend_openai_parse.ml` / `_responses.ml` | prompt_tokens verbatim | 변경 불요 (wire가 이미 포함형) |
+| `backend_gemini.ml` | promptTokenCount verbatim | 변경 불요 (동일) |
+| `cache.ml` (저장 코덱) | schema "1" — 정규화 전 값 잔존 가능 | schema "2"로 하드컷 (구 항목은 버전 가드가 은퇴) |
+| `pricing.ml` estimate_cost | `regular = input − creation − read` — 포함형 가정이라 Anthropic 유입 시 이중 차감(`max 0`이 침묵 클램프) | 가정이 참이 되어 산식 그대로 정당화 |
+
+## 영향 (수정 전 결함의 실현 조건)
+
+Anthropic 형식 + 캐시 활성(system/tools cache_control) 조합에서:
+
+1. **비용 과소**: regular input이 `max 0 (exclusive − creation − read)`로 클램프 — 캐시가 클수록 정규 입력 과금이 0으로 소멸.
+2. **점유율 과소**: `keeper_context_observation_projection`의 ratio 분자(RFC-0233 "provider-reported prompt total")가 배제형 값 — 캐시된 프리픽스가 클수록 창 점유가 실제보다 작게 보고.
+
+## 잔여 결함 (이 PR 범위 밖, #28903으로 추적)
+
+- **누적 delta를 add로 접음**: 공식 계약 "The token counts shown in the usage field of the message_delta event are *cumulative*" vs `complete_stream_state.add_usage`(가산). wire가 최종 delta에 cache 필드를 반복하면 cache 이중 계산, server-tool 스트림의 input 갱신은 파서의 0 고정으로 폐기됨.
+- **`emit_synthetic_events` + fold 조합 위험**: 같은 usage를 MessageStart/MessageDelta 양쪽에 실어, fold 소비자가 생기면 input/cache 2배. 현재 프로덕션 호출자 0 (테스트 전용)이라 라이브 영향 없음.

--- a/docs/evidence/usage-semantics-audit-2026-08-17.md
+++ b/docs/evidence/usage-semantics-audit-2026-08-17.md
@@ -43,7 +43,7 @@ Anthropic 형식 + 캐시 활성(system/tools cache_control) 조합에서:
 | 표면 | 처분 | 근거 |
 |---|---|---|
 | `cache.ml` 응답 캐시 | **schema "2" 하드컷** (이 PR) | 유일하게 구 값이 *canonical 자리로 재유입*되는 코덱 — 버전 가드가 은퇴 |
-| turn_record (RFC-0233 점유율 원천) | 조치 불요 — 단 잔류는 1턴 | **정정(재검증 반영)**: 재시작은 trace_id를 보존하므로(메타 로드가 그대로 파싱, 재발급은 Handoff뿐) trace_id 가드는 배포 경계를 거르지 못한다 — 초판의 "혼합 창이 빔" 주장은 오류. 올바른 근거: (1) record는 내부 일관 — tokens와 window가 같은 요청에서 나와 record 단위 교차-의미론 산술이 없음, 구 record의 과소 표시는 그 record가 기록될 당시 동작 그대로, (2) 다음 턴 완료가 포함형 record로 덮어써 keeper당 최대 1턴 잔류, (3) 소비자는 관측 표면(대시보드 점유율·last_turn_usage)이고 게이트 없음. 버전 필드 추가는 legacy-detection 필드라 부적격 |
+| turn_record (RFC-0233 점유율 원천) | 조치 불요 — 단 잔류는 1턴 | **정정(재검증 반영)**: 재시작은 trace_id를 보존하므로(메타 로드가 그대로 파싱, 재발급은 Handoff뿐) trace_id 가드는 배포 경계를 거르지 못한다 — 초판의 "혼합 창이 빔" 주장은 오류. 올바른 근거: (1) record는 내부 일관 — tokens와 window가 같은 요청에서 나와 record 단위 교차-의미론 산술이 없음, 구 record의 과소 표시는 그 record가 기록될 당시 동작 그대로, (2) 다음 턴 완료가 포함형 record로 덮어써 정상 기록 경로 기준 keeper당 최대 1턴 잔류(writer의 append는 warn-only라 기록 실패 시 상한이 늘어질 수 있음 — 기존 writer 특성), (3) 소비자는 관측 표면(대시보드 점유율·last_turn_usage)이고 게이트 없음. 버전 필드 추가는 legacy-detection 필드라 부적격 |
 | checkpoint `usage_stats.total_*` 누적치 | 문서화(아래 epoch 주석) | 이 총합은 PR 이전부터 provider 혼합 의미론(배제형 Anthropic + 포함형 나머지)의 합이라 "순수한 v1 의미"가 애초에 없음. 전 소비자(codec 왕복, durable_event carry, tool_agent_timeline rollup, dashboard JSON ×3)가 관측 표면이고 게이트 0건. checkpoint 폐기는 transcript(durable truth) 파괴라 비례성 위반 |
 | `execution_provider_response_snapshot` 실행 저널 | 조치 불요 | 소비자는 `execution_event.ml` 단일 — 기록 시점 사실의 evidence 저널이며, 재해석/재작성은 ledger 원칙 위반 |
 

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -709,15 +709,17 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
              ; stop_reason = EndTurn
              ; content = [ Text turn.text ]
              ; usage =
+                 (* The CLI frame carries Anthropic exclusive counts; the
+                    shared constructor produces the canonical inclusive
+                    api_usage. *)
                  Option.map
-                   (fun (usage : Runtime_claude_code.turn_usage) :
-                        Agent_core.Types.api_usage ->
-                      { input_tokens = usage.input_tokens
-                      ; output_tokens = usage.output_tokens
-                      ; cache_creation_input_tokens = 0
-                      ; cache_read_input_tokens = 0
-                      ; cost_usd = None
-                      })
+                   (fun (usage : Runtime_claude_code.turn_usage) ->
+                      Agent_core.Llm_provider.Backend_anthropic.usage_of_wire_counts
+                        ~input_tokens:usage.input_tokens
+                        ~output_tokens:usage.output_tokens
+                        ~cache_creation_input_tokens:
+                          usage.cache_creation_input_tokens
+                        ~cache_read_input_tokens:usage.cache_read_input_tokens)
                    turn.usage
              ; telemetry =
                  Some

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -66,6 +66,8 @@ type rate_limit =
 type turn_usage =
   { input_tokens : int
   ; output_tokens : int
+  ; cache_creation_input_tokens : int
+  ; cache_read_input_tokens : int
   }
 
 type turn_result =
@@ -721,11 +723,24 @@ let parse_result ~expected_session_id ~rate_limit ~tool_effect_attempted
           | Some (`Int value) when value >= 0 -> Some value
           | _ -> None
         in
-        (* Only the two counts this reads are carried. A cache-read field would
-           need a value when the block omits it, and defaulting a count nobody
-           reported to zero states something the stream did not say. *)
+        (* The CLI mirrors Anthropic Messages usage: input_tokens is the
+           exclusive count (tokens after the last cache breakpoint) and the
+           cache components arrive as their own fields. Both are carried so
+           the keeper can build the canonical inclusive api_usage
+           (Backend_anthropic.usage_of_wire_counts); an absent cache field
+           reads as 0, the same convention every Anthropic-format parse in
+           agent_core uses. Presence of a usage block still requires both
+           base counts. *)
         (match int_field "input_tokens", int_field "output_tokens" with
-         | Some input_tokens, Some output_tokens -> Some { input_tokens; output_tokens }
+         | Some input_tokens, Some output_tokens ->
+           Some
+             { input_tokens
+             ; output_tokens
+             ; cache_creation_input_tokens =
+                 Option.value (int_field "cache_creation_input_tokens") ~default:0
+             ; cache_read_input_tokens =
+                 Option.value (int_field "cache_read_input_tokens") ~default:0
+             }
          | Some _, None | None, Some _ | None, None -> None)
       | Some _ -> None
     in

--- a/lib/runtime/runtime_claude_code.ml
+++ b/lib/runtime/runtime_claude_code.ml
@@ -737,8 +737,10 @@ let parse_result ~expected_session_id ~rate_limit ~tool_effect_attempted
              { input_tokens
              ; output_tokens
              ; cache_creation_input_tokens =
+                 (* DET-OK: absent wire field is 0 by api_usage convention *)
                  Option.value (int_field "cache_creation_input_tokens") ~default:0
              ; cache_read_input_tokens =
+                 (* DET-OK: absent wire field is 0 by api_usage convention *)
                  Option.value (int_field "cache_read_input_tokens") ~default:0
              }
          | Some _, None | None, Some _ | None, None -> None)

--- a/lib/runtime/runtime_claude_code.mli
+++ b/lib/runtime/runtime_claude_code.mli
@@ -49,9 +49,17 @@ type rate_limit =
   ; overage_disabled_reason : string option
   }
 
+(** Usage counts from the CLI result frame. The CLI mirrors Anthropic
+    Messages semantics: [input_tokens] is the exclusive wire count (tokens
+    after the last cache breakpoint); absent cache fields read as 0. The
+    keeper mapping builds the canonical inclusive
+    {!Agent_core.Types.api_usage} from these via
+    [Backend_anthropic.usage_of_wire_counts]. *)
 type turn_usage =
   { input_tokens : int
   ; output_tokens : int
+  ; cache_creation_input_tokens : int
+  ; cache_read_input_tokens : int
   }
 
 type turn_result =

--- a/packages/agent_core/lib/llm_provider/backend_anthropic.ml
+++ b/packages/agent_core/lib/llm_provider/backend_anthropic.ml
@@ -11,6 +11,29 @@ type request_artifact = string Request_artifact_internal.t
 let request_payload = Request_artifact_internal.payload
 let request_output_token_receipt = Request_artifact_internal.output_token_receipt
 
+(* The Messages wire reports exclusive input: "input_tokens: Number of input
+   tokens which were not read from or used to create a cache", with
+   total_input_tokens = cache_read_input_tokens + cache_creation_input_tokens
+   + input_tokens (platform.claude.com/docs prompt-caching, checked
+   2026-08-17). {!Types.api_usage.input_tokens} is the canonical inclusive
+   prompt total, so every parse of this wire shape must build through this
+   constructor. *)
+let usage_of_wire_counts
+      ~input_tokens
+      ~output_tokens
+      ~cache_creation_input_tokens
+      ~cache_read_input_tokens
+  : api_usage
+  =
+  { input_tokens =
+      input_tokens + cache_creation_input_tokens + cache_read_input_tokens
+  ; output_tokens
+  ; cache_creation_input_tokens
+  ; cache_read_input_tokens
+  ; cost_usd = None
+  }
+;;
+
 (** Parse Anthropic API response JSON into {!api_response}. *)
 let parse_response json =
   let open Yojson.Safe.Util in
@@ -45,12 +68,11 @@ let parse_response json =
         Cli_common_json.member_int "cache_read_input_tokens" u
       in
       Some
-        { input_tokens
-        ; output_tokens
-        ; cache_creation_input_tokens
-        ; cache_read_input_tokens
-        ; cost_usd = None
-        })
+        (usage_of_wire_counts
+           ~input_tokens
+           ~output_tokens
+           ~cache_creation_input_tokens
+           ~cache_read_input_tokens))
   in
   let has_tool_blocks =
     List.exists

--- a/packages/agent_core/lib/llm_provider/backend_anthropic.mli
+++ b/packages/agent_core/lib/llm_provider/backend_anthropic.mli
@@ -19,6 +19,22 @@ val project_history
 
 val parse_response : Yojson.Safe.t -> Types.api_response
 
+(** Build the canonical {!Types.api_usage} from Anthropic Messages wire
+    counts. The wire's [input_tokens] is exclusive — it counts only tokens
+    after the last cache breakpoint (official contract: total input =
+    cache_read + cache_creation + input_tokens) — while
+    {!Types.api_usage.input_tokens} is the inclusive prompt total, so this
+    constructor adds the cache components in. Every parse of this wire shape
+    (sync response, SSE [message_start]) must build through it; bypassing it
+    reintroduces the exclusive/inclusive mix that under-prices regular input
+    and under-reports context occupancy. *)
+val usage_of_wire_counts
+  :  input_tokens:int
+  -> output_tokens:int
+  -> cache_creation_input_tokens:int
+  -> cache_read_input_tokens:int
+  -> Types.api_usage
+
 type request_artifact
 
 val request_payload : request_artifact -> string

--- a/packages/agent_core/lib/llm_provider/cache.ml
+++ b/packages/agent_core/lib/llm_provider/cache.ml
@@ -33,11 +33,14 @@ let request_fingerprint
 
 (* ── Serialization ──────────────────────────────────── *)
 
-let schema_version = "1"
+let schema_version = "2"
 
 (* stop_reason wire serialization is the SSOT [Types.stop_reason_to_string]
-   (this module's former local copy was byte-identical). Cache schema_version
-   "1" is preserved because the emitted strings are unchanged. *)
+   (this module's former local copy was byte-identical). schema_version "2":
+   [api_usage.input_tokens] became the inclusive prompt total (Anthropic wire
+   normalization) — entries written under "1" hold exclusive input for
+   Anthropic responses, so the version guard retires them instead of
+   replaying mixed semantics. *)
 
 (* Cache replay routes through [Types.stop_reason_of_string] so that a cached
    response parses identically to a live one. A local copy here previously

--- a/packages/agent_core/lib/llm_provider/streaming.ml
+++ b/packages/agent_core/lib/llm_provider/streaming.ml
@@ -51,13 +51,14 @@ let parse_sse_event event_type data_str =
                |> to_int_option
                |> Option.value ~default:0
              in
+             (* output_tokens stays 0: the start event owns input+cache and
+                the final message_delta owns output in the accumulator. *)
              Some
-               { input_tokens
-               ; output_tokens = 0
-               ; cache_creation_input_tokens
-               ; cache_read_input_tokens
-               ; cost_usd = None
-               })
+               (Backend_anthropic.usage_of_wire_counts
+                  ~input_tokens
+                  ~output_tokens:0
+                  ~cache_creation_input_tokens
+                  ~cache_read_input_tokens))
          in
          Some (MessageStart { id; model; usage })
        | "content_block_start" ->
@@ -139,6 +140,12 @@ let parse_sse_event event_type data_str =
                |> to_int_option
                |> Option.value ~default:0
              in
+             (* Not built through [Backend_anthropic.usage_of_wire_counts]:
+                message_delta usage is wire-cumulative, and the accumulator
+                adds delta fields onto the start event's already-inclusive
+                totals — folding cache components into input here would count
+                them twice. input_tokens stays pinned to 0 for the same
+                reason. The add-vs-cumulative mismatch itself is #28903. *)
              Some
                { input_tokens = 0
                ; output_tokens

--- a/packages/agent_core/lib/llm_provider/types.mli
+++ b/packages/agent_core/lib/llm_provider/types.mli
@@ -439,7 +439,18 @@ val stop_reason_to_string : stop_reason -> string
 val stop_reason_to_metric_label : stop_reason -> string
 
 (** API usage from a single provider response. Accumulated multi-call usage
-    belongs in agent-level usage stats. *)
+    belongs in agent-level usage stats.
+
+    [input_tokens] is the canonical inclusive prompt total: it counts every
+    prompt token the provider processed for the request, including the
+    [cache_creation_input_tokens] and [cache_read_input_tokens] components.
+    Consumers subtract the cache components to price the regular remainder
+    (see [Pricing.estimate_cost]) and divide by the context window for
+    occupancy. Wire formats that already report an inclusive prompt total
+    (OpenAI [prompt_tokens], Gemini [promptTokenCount], GLM) map verbatim;
+    the Anthropic Messages wire reports exclusive input and is normalized at
+    its parse boundary ([Backend_anthropic.usage_of_wire_counts]). A parser
+    that copies an exclusive wire count into [input_tokens] is a defect. *)
 type api_usage =
   { input_tokens : int
   ; output_tokens : int

--- a/packages/agent_core/test/test_api.ml
+++ b/packages/agent_core/test/test_api.ml
@@ -563,7 +563,9 @@ let test_parse_response_with_cache_tokens () =
   let resp = Llm_provider.Backend_anthropic.parse_response json in
   match resp.usage with
   | Some u ->
-    check int "input" 50 u.Types.input_tokens;
+    (* The wire's 50 is exclusive (tokens after the last cache breakpoint);
+       api_usage.input_tokens is the inclusive prompt total 50+1000+800. *)
+    check int "input" 1850 u.Types.input_tokens;
     check int "output" 25 u.output_tokens;
     check int "cache_creation" 1000 u.cache_creation_input_tokens;
     check int "cache_read" 800 u.cache_read_input_tokens
@@ -586,6 +588,21 @@ let test_parse_sse_message_start () =
      | Some u -> check int "input" 10 u.Types.input_tokens
      | None -> fail "expected usage")
   | _ -> fail "expected MessageStart"
+;;
+
+let test_parse_sse_message_start_cache_tokens () =
+  let data =
+    {|{"message":{"id":"msg_2","model":"claude-sonnet-4-6","usage":{"input_tokens":50,"cache_creation_input_tokens":1000,"cache_read_input_tokens":800}}}|}
+  in
+  match Llm_provider.Streaming.parse_sse_event (Some "message_start") data with
+  | Some (Types.MessageStart { usage = Some u; _ }) ->
+    (* Same inclusive normalization as the sync parse: wire input is
+       exclusive, api_usage.input_tokens carries the prompt total. *)
+    check int "input" 1850 u.Types.input_tokens;
+    check int "output pinned to the delta event" 0 u.output_tokens;
+    check int "cache_creation" 1000 u.cache_creation_input_tokens;
+    check int "cache_read" 800 u.cache_read_input_tokens
+  | _ -> fail "expected MessageStart with usage"
 ;;
 
 let test_parse_sse_content_block_delta_text () =
@@ -901,6 +918,10 @@ let () =
         ] )
     ; ( "parse_sse_event"
       , [ test_case "message_start" `Quick test_parse_sse_message_start
+        ; test_case
+            "message_start cache tokens"
+            `Quick
+            test_parse_sse_message_start_cache_tokens
         ; test_case
             "content_block_delta text"
             `Quick

--- a/packages/agent_core/test/test_api_dispatch.ml
+++ b/packages/agent_core/test/test_api_dispatch.ml
@@ -181,7 +181,8 @@ let test_anthropic_cache_usage_parsing () =
   match resp.usage with
   | None -> fail "expected usage"
   | Some u ->
-    check int "input" 1000 u.input_tokens;
+    (* Inclusive prompt total: exclusive wire 1000 + creation 500 + read 300. *)
+    check int "input" 1800 u.input_tokens;
     check int "output" 200 u.output_tokens;
     check int "cache write" 500 u.cache_creation_input_tokens;
     check int "cache read" 300 u.cache_read_input_tokens

--- a/packages/agent_core/test/test_cache.ml
+++ b/packages/agent_core/test/test_cache.ml
@@ -26,7 +26,9 @@ let test_parse_usage_with_cache_tokens () =
   let resp = Agent_core.Llm_provider.Backend_anthropic.parse_response json in
   match resp.usage with
   | Some u ->
-    Alcotest.(check int) "input_tokens" 100 u.input_tokens;
+    (* Wire input 100 is exclusive of the cache components; the canonical
+       api_usage carries the inclusive prompt total 100+2000+1500. *)
+    Alcotest.(check int) "input_tokens" 3600 u.input_tokens;
     Alcotest.(check int) "output_tokens" 50 u.output_tokens;
     Alcotest.(check int) "cache_creation" 2000 u.cache_creation_input_tokens;
     Alcotest.(check int) "cache_read" 1500 u.cache_read_input_tokens

--- a/packages/agent_core/test/test_streaming.ml
+++ b/packages/agent_core/test/test_streaming.ml
@@ -294,7 +294,8 @@ let test_parse_message_start_with_cache () =
     Alcotest.(check string) "id" "msg_cache" id;
     (match usage with
      | Some u ->
-       Alcotest.(check int) "input_tokens" 100 u.input_tokens;
+       (* Inclusive prompt total: exclusive wire 100 + creation 50 + read 30. *)
+       Alcotest.(check int) "input_tokens" 180 u.input_tokens;
        Alcotest.(check int) "cache_creation" 50 u.cache_creation_input_tokens;
        Alcotest.(check int) "cache_read" 30 u.cache_read_input_tokens
      | None -> Alcotest.fail "expected Some usage")

--- a/test/test_runtime_claude_code.ml
+++ b/test/test_runtime_claude_code.ml
@@ -340,8 +340,14 @@ let test_result_usage_is_carried () =
       (match turn.usage with
        | None -> fail "usage block was dropped"
        | Some usage ->
+         (* turn_usage keeps the CLI's exclusive wire counts as-is; the
+            inclusive normalization happens in the keeper's api_usage
+            mapping. The frame's cache_read 42 must survive the parse and
+            its absent cache_creation reads as 0. *)
          check int "input tokens" 123456 usage.input_tokens;
-         check int "output tokens" 789 usage.output_tokens))
+         check int "output tokens" 789 usage.output_tokens;
+         check int "cache read carried" 42 usage.cache_read_input_tokens;
+         check int "absent cache creation is 0" 0 usage.cache_creation_input_tokens))
 ;;
 
 (* A usage block the CLI shapes differently must not fail the turn: the text is


### PR DESCRIPTION
## 무엇 (RFC-0382 G6 후속 감사 + 수정)

`Types.api_usage.input_tokens`의 의미가 provider마다 달랐다. Anthropic Messages wire는 **배제형**(공식 정의: "Number of input tokens which were not read from or used to create a cache", `total_input = cache_read + cache_creation + input_tokens`)인데 그대로 복사해 유입했고, OpenAI/Gemini/GLM/llama-server는 **포함형** prompt total을 유입했다. 소비자는 포함형을 가정한다:

- `Pricing.estimate_cost`: `regular = max 0 (input − creation − read)` → Anthropic 유입 시 **이중 차감을 `max 0`이 침묵 클램프**, 캐시가 클수록 정규 입력 과금 소멸
- `keeper_context_observation_projection` (RFC-0233 "provider-reported prompt total"): 점유율 분자가 배제형 → **캐시된 프리픽스만큼 창 점유 과소 보고**

RFC-0382 §3.2의 GLM 히트율 정정이 이 격차의 실현 사례였고, PR-5(Anthropic top-level cache_control)가 착지하면 상시 결함이 되므로 그 전에 닫는다.

## 변경

| 층 | 내용 |
|---|---|
| `types.mli` | canonical 계약 명문화: `input_tokens` = inclusive prompt total (G6가 처방한 "계약 명문화" 본체) |
| `backend_anthropic.ml/.mli` | `usage_of_wire_counts` 공유 생성자 — 배제형 wire를 경계에서 정규화, 공식 산식 인용 주석 |
| `streaming.ml` | SSE `message_start`도 같은 생성자 경유. `message_delta`는 핀 유지 + 왜 정규화하면 안 되는지 계약 주석 (가산 fold와 조합 시 이중 계산 — #28903) |
| `cache.ml` | 저장 코덱 schema "1"→"2" 하드컷 — 배제형으로 직렬화된 구 항목을 버전 가드가 은퇴 (compat reader 없음) |
| 테스트 | 배제형 값을 고정하던 4건 갱신(test_api, test_cache, test_streaming, test_api_dispatch) + cache 성분 포함 message_start 신규 1건 |

포함형 wire 경로(openai_parse/responses, gemini, ollama, llama-server)는 무변경 — 감사표로 정당화.

## 감사 산출물

`docs/evidence/usage-semantics-audit-2026-08-17.md` — provider별 wire 의미론 표(공식 문서 인용 3건: Anthropic prompt-caching / OpenAI prompt-caching / Gemini generate-content, 전부 2026-08-17 확인) + 사이트별 수정 전후 판정 + 잔여 결함.

발견된 인접 결함은 범위 밖으로 분리: **#28903** — 공식 계약상 message_delta usage는 *cumulative*인데 fold가 가산(add_usage)이라, wire가 최종 delta에 cache 필드를 반복하면 이중 계산되고 server-tool 스트림의 input 갱신은 폐기됨. `MessageDelta` payload 타입 수술이 필요해 별도 PR 크기.

## 검증 (로컬, worktree root)

```
opam exec -- dune build --root . @check                                    # 0
opam exec -- dune build --root . @packages/agent_core/test/runtest         # 0 (test_api 46, streaming_edge 22, cache 7 등 전부 green)
# masc측 usage 소비 스위트: test_response_model_empty_10083 / test_cost_usd_source_attribution_10318 / test_cost_token_decouple / test_turn_record 각 EXIT=0
```

pre-existing 주의: `test_provider_complete.exe`를 repo root에서 직접 exec하면 main에서도 동일하게 `models.toml not found`로 실패한다 (cwd 의존 하네스 전제, 본 PR 무관 — runtest alias 경유는 green).

## 운영 노트

- Anthropic/Kimi 레인의 대시보드·알림 input 합계가 정규화 후 커진다(정확해진 것). 히트율은 `cache_read / input_tokens`로 provider 무관 동일 산식이 된다 (G5 표면의 행별 산식 각주 불요).
- adversarial review 통과 시 `review:adversarial-pass` 라벨.

Closes: RFC-0382 G6 후속 행
🤖 Generated with [Claude Code](https://claude.com/claude-code)
