### PR TITLE
fix(agent-core): message_delta usage를 누적 계약대로 교체-fold (#28903)

### DIFF
--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -132,6 +132,41 @@ describe('Keeper operation stream projection', () => {
     )
   })
 
+  it('overlays partial delta usage onto the start snapshot instead of replacing it', () => {
+    assistantEntry()
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_STREAM_MESSAGE_START',
+      value: {
+        provider_message_id: 'msg-1',
+        model: 'claude-sonnet-5',
+        usage: {
+          input_tokens: 60_882,
+          output_tokens: 1,
+          total_tokens: 60_883,
+          cache_creation_input_tokens: 200,
+          cache_read_input_tokens: 50_000,
+        },
+      },
+    })
+    // The classic wire shape: the final delta reports only the cumulative
+    // output counter. It must not erase the start snapshot's counters.
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_STREAM_MESSAGE_DELTA',
+      value: { stop_reason: 'end_turn', usage: { output_tokens: 510 } },
+    })
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+    expect(entry?.details?.usage).toMatchObject({
+      inputTokens: 60_882,
+      outputTokens: 510,
+      totalTokens: 61_392,
+      cacheCreationInputTokens: 200,
+      cacheReadInputTokens: 50_000,
+    })
+  })
+
   it('routes server-pushed events by exact operation id', () => {
     for (const operationId of ['kmsg-operation-1', 'kmsg-operation-2']) {
       appendThreadEntry('sangsu', {

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -353,6 +353,33 @@ function normalizeStreamUsage(raw: unknown): NonNullable<KeeperConversationDetai
   return usage
 }
 
+// Delta usage carries cumulative counters for only the fields the wire
+// reported, and normalizeStreamUsage null-fills the base trio — so replacing
+// the whole usage object would erase the start snapshot with nulls. Overlay
+// the reported (non-null) counters onto what is already known, mirroring the
+// producer-side replace-fold, and rederive the total from its parts.
+function mergeStreamUsage(
+  previous: KeeperConversationDetails['usage'],
+  next: NonNullable<KeeperConversationDetails['usage']>,
+): NonNullable<KeeperConversationDetails['usage']> {
+  const merged: NonNullable<KeeperConversationDetails['usage']> = { ...(previous ?? {}) }
+  for (const key of [
+    'inputTokens',
+    'outputTokens',
+    'totalTokens',
+    'cacheCreationInputTokens',
+    'cacheReadInputTokens',
+    'costUsd',
+  ] as const) {
+    const value = next[key]
+    if (value !== null && value !== undefined) merged[key] = value
+  }
+  if (merged.inputTokens != null && merged.outputTokens != null) {
+    merged.totalTokens = merged.inputTokens + merged.outputTokens
+  }
+  return merged
+}
+
 function mergeAssistantStreamDetails(
   keeperName: string,
   assistantEntryId: string,
@@ -363,7 +390,9 @@ function mergeAssistantStreamDetails(
     details: {
       ...(entry.details ?? {}),
       ...patch,
-      usage: patch.usage ?? entry.details?.usage ?? null,
+      usage: patch.usage
+        ? mergeStreamUsage(entry.details?.usage, patch.usage)
+        : entry.details?.usage ?? null,
       rawPayload: entry.details?.rawPayload,
     },
   }))

--- a/dashboard/src/lib/keeper-chat-stream-contract.ts
+++ b/dashboard/src/lib/keeper-chat-stream-contract.ts
@@ -28,6 +28,15 @@ export type KeeperStreamUsage = {
   cost_usd?: number
 }
 
+// Cumulative mid-stream counters: only the fields the delta actually
+// reported appear, and the producer never emits a total or a cost here.
+export type KeeperStreamDeltaUsage = {
+  input_tokens?: number
+  output_tokens?: number
+  cache_creation_input_tokens?: number
+  cache_read_input_tokens?: number
+}
+
 export type KeeperStreamProtocolErrorKind =
   | 'tool_start_duplicate_index'
   | 'tool_start_missing_identity'
@@ -77,7 +86,7 @@ type KeeperChatCustomEvent =
   | {
       type: 'CUSTOM'
       name: 'KEEPER_STREAM_MESSAGE_DELTA'
-      value: { stop_reason?: string; usage?: KeeperStreamUsage }
+      value: { stop_reason?: string; usage?: KeeperStreamDeltaUsage }
     }
   | { type: 'CUSTOM'; name: 'KEEPER_STREAM_MESSAGE_STOP'; value: null }
   | { type: 'CUSTOM'; name: 'KEEPER_STREAM_PING'; value: null }

--- a/dashboard/src/schemas/sse.test.ts
+++ b/dashboard/src/schemas/sse.test.ts
@@ -266,6 +266,39 @@ describe('SSEMessageSchema', () => {
     expect(r.success).toBe(true)
   })
 
+  it('accepts a message_delta usage that reports only some cumulative counters', () => {
+    const event = (usage: unknown) => ({
+      type: 'keeper_chat_operation_event',
+      name: 'sangsu',
+      operation_id: 'kmsg-operation-1',
+      ag_ui_event: {
+        type: 'CUSTOM',
+        threadId: 'keeper-consumer:sangsu',
+        runId: 'run-1',
+        name: 'KEEPER_STREAM_MESSAGE_DELTA',
+        value: { stop_reason: 'end_turn', usage },
+        timestamp: 1_712_000_000,
+      },
+    })
+    // The classic wire shape: the final delta reports only the cumulative
+    // output counter. The producer omits unreported fields entirely.
+    expect(SSEMessageSchema.safeParse(event({ output_tokens: 42 })).success).toBe(true)
+    // The server-tool shape: every counter repeated as a cumulative total —
+    // still no total_tokens or cost on a delta.
+    expect(
+      SSEMessageSchema.safeParse(
+        event({
+          input_tokens: 60_882,
+          output_tokens: 510,
+          cache_creation_input_tokens: 200,
+          cache_read_input_tokens: 50_000,
+        }),
+      ).success,
+    ).toBe(true)
+    expect(SSEMessageSchema.safeParse(event({ output_tokens: 4.2 })).success).toBe(false)
+    expect(SSEMessageSchema.safeParse(event({ total_tokens: 9 })).success).toBe(false)
+  })
+
   it('accepts an operator-visible projection error for an operation', () => {
     const r = SSEMessageSchema.safeParse({
       type: 'keeper_chat_operation_event',

--- a/dashboard/src/schemas/sse.ts
+++ b/dashboard/src/schemas/sse.ts
@@ -333,6 +333,32 @@ function validateUsage(value: unknown): SafeParseResult<true> {
     : fail('ag_ui_event.value.usage.cost_usd', 'Expected finite cost_usd')
 }
 
+// KEEPER_STREAM_MESSAGE_DELTA usage carries cumulative counters and emits
+// only the ones the wire actually reported, so every field is optional and
+// there is no total_tokens or cost_usd. Requiring the full set here silently
+// dropped every classic (output-only) delta once the producer stopped
+// zero-filling unreported counters.
+function validateDeltaUsage(value: unknown): SafeParseResult<true> {
+  const result = exactCustomObject(value, 'usage', [
+    'input_tokens',
+    'output_tokens',
+    'cache_creation_input_tokens',
+    'cache_read_input_tokens',
+  ])
+  if (!result.success) return result
+  for (const field of [
+    'input_tokens',
+    'output_tokens',
+    'cache_creation_input_tokens',
+    'cache_read_input_tokens',
+  ]) {
+    if (result.data[field] === undefined) continue
+    const valid = requiredInteger(result.data, field)
+    if (!valid.success) return valid
+  }
+  return ok(true)
+}
+
 function validateKeeperCustomPayload(name: string, payload: unknown): SafeParseResult<true> {
   if ([
     'KEEPER_CONNECTED',
@@ -396,7 +422,7 @@ function validateKeeperCustomPayload(name: string, payload: unknown): SafeParseR
     case 'KEEPER_STREAM_MESSAGE_DELTA': {
       const stopReason = optionalString(value, 'stop_reason')
       if (!stopReason.success) return stopReason
-      return value.usage === undefined ? ok(true) : validateUsage(value.usage)
+      return value.usage === undefined ? ok(true) : validateDeltaUsage(value.usage)
     }
     case 'KEEPER_CONTENT_BLOCK_START': {
       const index = requiredInteger(value, 'index')

--- a/lib/keeper/keeper_chat_events.ml
+++ b/lib/keeper/keeper_chat_events.ml
@@ -58,7 +58,7 @@ type keeper_chat_event =
       }
   | Agent_core_stream_message_delta of
       { stop_reason : Agent_core.Types.stop_reason option
-      ; usage : Agent_core.Types.api_usage option
+      ; usage : Agent_core.Types.delta_usage option
       }
   | Agent_core_stream_message_stop
   | Agent_core_stream_ping
@@ -130,6 +130,17 @@ let api_usage_to_json (usage : Agent_core.Types.api_usage) =
      ]
      @ json_opt "cost_usd"
          (Option.map (fun value -> `Float value) usage.cost_usd))
+
+(* Cumulative mid-stream counters: only the fields the delta actually
+   reported appear, so a reader can tell "not reported" from 0. *)
+let delta_usage_to_json (usage : Agent_core.Types.delta_usage) =
+  `Assoc
+    (json_opt "input_tokens" (Option.map (fun v -> `Int v) usage.input_tokens)
+    @ json_opt "output_tokens" (Option.map (fun v -> `Int v) usage.output_tokens)
+    @ json_opt "cache_creation_input_tokens"
+        (Option.map (fun v -> `Int v) usage.cache_creation_input_tokens)
+    @ json_opt "cache_read_input_tokens"
+        (Option.map (fun v -> `Int v) usage.cache_read_input_tokens))
 
 let stream_protocol_error_kind_to_string = function
   | Tool_start_duplicate_index -> "tool_start_duplicate_index"

--- a/lib/keeper/keeper_chat_events.mli
+++ b/lib/keeper/keeper_chat_events.mli
@@ -72,7 +72,7 @@ type keeper_chat_event =
       }
   | Agent_core_stream_message_delta of
       { stop_reason : Agent_core.Types.stop_reason option
-      ; usage : Agent_core.Types.api_usage option
+      ; usage : Agent_core.Types.delta_usage option
       }
   | Agent_core_stream_message_stop
   | Agent_core_stream_ping
@@ -138,6 +138,10 @@ val publish : keeper_chat_event Eio.Stream.t -> keeper_chat_event -> unit
 val subscribe : keeper_chat_event Eio.Stream.t -> keeper_chat_event
 
 val api_usage_to_json : Agent_core.Types.api_usage -> Yojson.Safe.t
+
+(** JSON for cumulative mid-stream counters: only reported fields appear,
+    so "not reported" stays distinguishable from 0. *)
+val delta_usage_to_json : Agent_core.Types.delta_usage -> Yojson.Safe.t
 val stream_protocol_error_kind_to_string : stream_protocol_error_kind -> string
 val stream_protocol_error_summary : stream_protocol_error -> string
 val stream_protocol_error_to_json : stream_protocol_error -> Yojson.Safe.t

--- a/lib/server/server_keeper_chat_agui_projection.ml
+++ b/lib/server/server_keeper_chat_agui_projection.ml
@@ -133,7 +133,7 @@ let project ~timestamp ~redact_text ~redact_json state event =
                 (fun reason ->
                    `String (Agent_core.Types.stop_reason_to_string reason))
                 stop_reason)
-           @ json_opt "usage" (Option.map api_usage_to_json usage))
+           @ json_opt "usage" (Option.map delta_usage_to_json usage))
       in
       state, Some (custom ~timestamp ~redact_json state Stream_message_delta value)
   | Agent_core_stream_message_stop ->

--- a/packages/agent_core/lib/llm_provider/complete_stream_state.ml
+++ b/packages/agent_core/lib/llm_provider/complete_stream_state.ml
@@ -120,19 +120,25 @@ let update_block index f state =
   { state with blocks = Blocks.add index (f block) state.blocks }
 ;;
 
-let usage_from_message_start current (wire : Types.api_usage) =
-  { current with
-    input_tokens = wire.input_tokens
+let usage_from_message_start (wire : Types.api_usage) =
+  { input_tokens = wire.input_tokens
+  ; output_tokens = wire.output_tokens
   ; cache_creation = wire.cache_creation_input_tokens
   ; cache_read = wire.cache_read_input_tokens
   }
 ;;
 
-let add_usage current (wire : Types.api_usage) =
-  { input_tokens = current.input_tokens + wire.input_tokens
-  ; output_tokens = current.output_tokens + wire.output_tokens
-  ; cache_creation = current.cache_creation + wire.cache_creation_input_tokens
-  ; cache_read = current.cache_read + wire.cache_read_input_tokens
+(* Delta counters are wire-cumulative running totals (#28903): a reported
+   field replaces the seeded value, an unreported field keeps it. Nothing is
+   ever added — addition double-counts whenever the final delta repeats a
+   counter the start event already carried. *)
+let overlay_delta_usage current (delta : Types.delta_usage) =
+  { input_tokens = Option.value delta.input_tokens ~default:current.input_tokens
+  ; output_tokens = Option.value delta.output_tokens ~default:current.output_tokens
+  ; cache_creation =
+      Option.value delta.cache_creation_input_tokens ~default:current.cache_creation
+  ; cache_read =
+      Option.value delta.cache_read_input_tokens ~default:current.cache_read
   }
 ;;
 
@@ -147,7 +153,7 @@ let transition_open state = function
     let usage =
       match usage with
       | None -> state.usage
-      | Some wire -> usage_from_message_start state.usage wire
+      | Some wire -> usage_from_message_start wire
     in
     { state with id; model; usage }
   | Types.ContentBlockStart { index; content_type; tool_id; tool_name } ->
@@ -201,7 +207,7 @@ let transition_open state = function
     let usage =
       match usage with
       | None -> state.usage
-      | Some wire -> add_usage state.usage wire
+      | Some delta -> overlay_delta_usage state.usage delta
     in
     { state with completion; usage }
   | Types.SSEError { message; error_type; raw }

--- a/packages/agent_core/lib/llm_provider/streaming.ml
+++ b/packages/agent_core/lib/llm_provider/streaming.ml
@@ -51,12 +51,13 @@ let parse_sse_event event_type data_str =
                |> to_int_option
                |> Option.value ~default:0
              in
-             (* output_tokens stays 0: the start event owns input+cache and
-                the final message_delta owns output in the accumulator. *)
+             (* The start snapshot seeds every counter; a later cumulative
+                message_delta replaces the ones it reports (#28903). *)
              Some
                (Backend_anthropic.usage_of_wire_counts
                   ~input_tokens
-                  ~output_tokens:0
+                  ~output_tokens:
+                    (Cli_common_json.member_int "output_tokens" u)
                   ~cache_creation_input_tokens
                   ~cache_read_input_tokens))
          in
@@ -127,31 +128,38 @@ let parse_sse_event event_type data_str =
            if u = `Null
            then None
            else (
+             (* message_delta usage is wire-cumulative (official streaming
+                contract): every reported field is the message's running
+                total, so each is carried as present-or-absent for the
+                accumulator to replace, never add (#28903). The wire's
+                input_tokens is exclusive; when the delta reports it, the
+                same report carries the cache components it accounts
+                against, so the inclusive normalization uses those
+                (an unreported cache field in that report reads as 0, the
+                api_usage convention). *)
              let output_tokens = u |> member "output_tokens" |> to_int in
              let cache_creation_input_tokens =
-               u
-               |> member "cache_creation_input_tokens"
-               |> to_int_option
-               |> Option.value ~default:0
+               u |> member "cache_creation_input_tokens" |> to_int_option
              in
              let cache_read_input_tokens =
-               u
-               |> member "cache_read_input_tokens"
-               |> to_int_option
-               |> Option.value ~default:0
+               u |> member "cache_read_input_tokens" |> to_int_option
              in
-             (* Not built through [Backend_anthropic.usage_of_wire_counts]:
-                message_delta usage is wire-cumulative, and the accumulator
-                adds delta fields onto the start event's already-inclusive
-                totals — folding cache components into input here would count
-                them twice. input_tokens stays pinned to 0 for the same
-                reason. The add-vs-cumulative mismatch itself is #28903. *)
+             let input_tokens =
+               u
+               |> member "input_tokens"
+               |> to_int_option
+               |> Option.map (fun exclusive_input ->
+                 (* DET-OK: absent wire field is 0 by api_usage convention *)
+                 exclusive_input
+                 + Option.value cache_creation_input_tokens ~default:0
+                 (* DET-OK: absent wire field is 0 by api_usage convention *)
+                 + Option.value cache_read_input_tokens ~default:0)
+             in
              Some
-               { input_tokens = 0
-               ; output_tokens
+               { Types.input_tokens
+               ; output_tokens = Some output_tokens
                ; cache_creation_input_tokens
                ; cache_read_input_tokens
-               ; cost_usd = None
                })
          in
          Some (MessageDelta { stop_reason; usage })
@@ -285,8 +293,10 @@ let emit_synthetic_events (response : api_response) on_event =
         | RedactedThinking _ | ToolResult _ -> ());
        on_event (ContentBlockStop { index }))
     response.content;
-  on_event
-    (MessageDelta { stop_reason = Some response.stop_reason; usage = response.usage });
+  (* The start event already carried the complete usage; repeating it here
+     would make any replace-or-add accumulator double-count. The synthetic
+     delta only settles the stop reason. *)
+  on_event (MessageDelta { stop_reason = Some response.stop_reason; usage = None });
   on_event MessageStop
 ;;
 
@@ -1260,7 +1270,11 @@ let project_openai_chunk ?tx (state : openai_stream_state) (chunk : openai_chunk
           downstream per-message block-index consumer collides on the next
           message's reused index. *)
        List.iter emit (openai_open_block_stops state);
-       emit (MessageDelta { stop_reason = Some stop_reason; usage = chunk.chunk_usage })
+       emit
+         (MessageDelta
+            { stop_reason = Some stop_reason
+            ; usage = Option.map Types.delta_usage_of_api_usage chunk.chunk_usage
+            })
      | None ->
        (* With stream_options.include_usage the provider sends token totals in a
           separate final chunk that has no finish_reason and an empty choices
@@ -1269,7 +1283,12 @@ let project_openai_chunk ?tx (state : openai_stream_state) (chunk : openai_chunk
           already forwards usage when a stop arrives in the same chunk, so the two
           paths are mutually exclusive and usage is never emitted twice. *)
        (match chunk.chunk_usage with
-        | Some _ -> emit (MessageDelta { stop_reason = None; usage = chunk.chunk_usage })
+        | Some usage ->
+          emit
+            (MessageDelta
+               { stop_reason = None
+               ; usage = Some (Types.delta_usage_of_api_usage usage)
+               })
         | None -> ()));
     Ok (List.rev !events, !telemetry_event)
 ;;
@@ -1768,7 +1787,10 @@ let responses_sse_to_events (state : openai_stream_state) event_type data_str
         emit
           (MessageDelta
              { stop_reason = responses_stop_reason_of_response response
-             ; usage = responses_usage_of_response response
+             ; usage =
+                 Option.map
+                   Types.delta_usage_of_api_usage
+                   (responses_usage_of_response response)
              });
         emit MessageStop
       in
@@ -2853,9 +2875,17 @@ let gemini_chunk_to_events_impl (state : openai_stream_state) (chunk : gemini_ch
          ~has_tool_use:(Hashtbl.length state.tool_block_indices > 0)
          reason
      in
-     emit (MessageDelta { stop_reason = Some stop_reason; usage = chunk.gem_usage })
+     emit
+       (MessageDelta
+          { stop_reason = Some stop_reason
+          ; usage = Option.map Types.delta_usage_of_api_usage chunk.gem_usage
+          })
    | Some (Gemini_prompt_block_reason _) ->
-     emit (MessageDelta { stop_reason = Some Refusal; usage = chunk.gem_usage })
+     emit
+       (MessageDelta
+          { stop_reason = Some Refusal
+          ; usage = Option.map Types.delta_usage_of_api_usage chunk.gem_usage
+          })
    | None -> ());
   List.rev !events, !telemetry_event
 ;;
@@ -3209,7 +3239,11 @@ let ollama_chunk_to_events (state : openai_stream_state) (chunk : ollama_chunk)
              (Stop_reason_wire.wire_finish_of_string reason)
              ~has_tool_blocks:(chunk.oll_tool_calls <> []))
     in
-    emit (MessageDelta { stop_reason; usage = chunk.oll_usage }));
+    emit
+      (MessageDelta
+         { stop_reason
+         ; usage = Option.map Types.delta_usage_of_api_usage chunk.oll_usage
+         }));
   List.rev !events, !telemetry_event
 ;;
 
@@ -3404,7 +3438,7 @@ let%test "ollama_chunk_to_events: done with stop_reason emits MessageDelta" =
   let events, _tel = ollama_chunk_to_events state chunk in
   match events with
   | [ MessageDelta { stop_reason = Some EndTurn; usage = Some u } ] ->
-    u.input_tokens = 10 && u.output_tokens = 20
+    u.input_tokens = Some 10 && u.output_tokens = Some 20
   | unexpected_events ->
     let (_ : sse_event list) = unexpected_events in
     false

--- a/packages/agent_core/lib/llm_provider/types.ml
+++ b/packages/agent_core/lib/llm_provider/types.ml
@@ -1300,6 +1300,18 @@ let stop_reason_to_metric_label = function
 ;;
 
 (** API usage from a single response *)
+(* delta_usage is declared before api_usage on purpose: the two records
+   share field labels, and OCaml resolves an unqualified label to the most
+   recently defined record — the codebase's pervasive unannotated
+   [u.input_tokens] accesses must keep meaning api_usage. *)
+type delta_usage =
+  { input_tokens : int option
+  ; output_tokens : int option
+  ; cache_creation_input_tokens : int option
+  ; cache_read_input_tokens : int option
+  }
+[@@deriving show, yojson]
+
 type api_usage =
   { input_tokens : int
   ; output_tokens : int
@@ -1308,6 +1320,14 @@ type api_usage =
   ; cost_usd : float option
   }
 [@@deriving show, yojson]
+
+let delta_usage_of_api_usage (u : api_usage) : delta_usage =
+  { input_tokens = Some u.input_tokens
+  ; output_tokens = Some u.output_tokens
+  ; cache_creation_input_tokens = Some u.cache_creation_input_tokens
+  ; cache_read_input_tokens = Some u.cache_read_input_tokens
+  }
+;;
 
 (** Provider-reported inference timing from a single API call.
     llama-server populates all fields; cloud providers return [None]. *)
@@ -1527,7 +1547,7 @@ type sse_event =
   | ContentBlockStop of { index : int }
   | MessageDelta of
       { stop_reason : stop_reason option
-      ; usage : api_usage option
+      ; usage : delta_usage option
       }
   | MessageStop
   | Ping

--- a/packages/agent_core/lib/llm_provider/types.mli
+++ b/packages/agent_core/lib/llm_provider/types.mli
@@ -438,6 +438,22 @@ val stop_reason_to_string : stop_reason -> string
     {!stop_reason_to_string} except [Unknown _] collapses to ["unknown"]. *)
 val stop_reason_to_metric_label : stop_reason -> string
 
+(** Usage counts carried by a mid-stream event ([MessageDelta]). The wire
+    contract is cumulative — a reported value is the latest running total
+    for the whole message, never an increment — so accumulators replace the
+    fields a delta reports and keep the rest ([None] means the event did not
+    report that counter). Field semantics match {!api_usage}: [input_tokens]
+    is the inclusive prompt total, normalized by the producing parser.
+    Declared before {!api_usage} so the shared field labels keep resolving
+    unqualified to [api_usage] (the later definition wins). *)
+type delta_usage =
+  { input_tokens : int option
+  ; output_tokens : int option
+  ; cache_creation_input_tokens : int option
+  ; cache_read_input_tokens : int option
+  }
+[@@deriving show, yojson]
+
 (** API usage from a single provider response. Accumulated multi-call usage
     belongs in agent-level usage stats.
 
@@ -459,6 +475,10 @@ type api_usage =
   ; cost_usd : float option
   }
 [@@deriving show, yojson]
+
+(** All-fields-present projection for producers whose terminal usage report
+    is a complete {!api_usage} (OpenAI-format final usage chunk). *)
+val delta_usage_of_api_usage : api_usage -> delta_usage
 
 type inference_timings =
   { prompt_n : int option
@@ -661,7 +681,7 @@ type sse_event =
   | ContentBlockStop of { index : int }
   | MessageDelta of
       { stop_reason : stop_reason option
-      ; usage : api_usage option
+      ; usage : delta_usage option
       }
   | MessageStop
   | Ping

--- a/packages/agent_core/test/test_api.ml
+++ b/packages/agent_core/test/test_api.ml
@@ -653,7 +653,7 @@ let test_parse_sse_message_delta () =
      | Some Types.EndTurn -> ()
      | _ -> fail "expected EndTurn");
     (match usage with
-     | Some u -> check int "output" 42 u.Types.output_tokens
+     | Some u -> check (option int) "output" (Some 42) u.Types.output_tokens
      | None -> fail "expected usage")
   | _ -> fail "expected MessageDelta"
 ;;

--- a/packages/agent_core/test/test_cache.ml
+++ b/packages/agent_core/test/test_cache.ml
@@ -35,6 +35,34 @@ let test_parse_usage_with_cache_tokens () =
   | None -> Alcotest.fail "expected usage"
 ;;
 
+let test_streaming_message_delta_cumulative_input () =
+  (* The server-tool wire shape: the final delta repeats the full usage as
+     cumulative totals, input still exclusive on the wire. The parser
+     normalizes input inclusively against the cache counts of the same
+     report and carries every field as present. *)
+  let data_str =
+    {|{
+    "type": "message_delta",
+    "delta": {"stop_reason": "end_turn"},
+    "usage": {
+      "input_tokens": 10682,
+      "output_tokens": 510,
+      "cache_creation_input_tokens": 200,
+      "cache_read_input_tokens": 50000
+    }
+  }|}
+  in
+  match
+    Agent_core.Llm_provider.Streaming.parse_sse_event (Some "message_delta") data_str
+  with
+  | Some (MessageDelta { usage = Some u; _ }) ->
+    Alcotest.(check (option int)) "input inclusive" (Some 60882) u.input_tokens;
+    Alcotest.(check (option int)) "output" (Some 510) u.output_tokens;
+    Alcotest.(check (option int)) "cache_creation" (Some 200) u.cache_creation_input_tokens;
+    Alcotest.(check (option int)) "cache_read" (Some 50000) u.cache_read_input_tokens
+  | _ -> Alcotest.fail "expected MessageDelta with usage"
+;;
+
 let test_parse_usage_without_cache_tokens () =
   let json_str =
     {|{
@@ -182,9 +210,15 @@ let test_streaming_message_delta_with_cache () =
     Alcotest.(check bool) "has stop_reason" true (Option.is_some stop_reason);
     (match usage with
      | Some u ->
-       Alcotest.(check int) "output" 42 u.output_tokens;
-       Alcotest.(check int) "cache_creation" 1500 u.cache_creation_input_tokens;
-       Alcotest.(check int) "cache_read" 800 u.cache_read_input_tokens
+       (* Cumulative delta counters are per-field optional: reported ones
+          carry Some, the unreported input stays None (never a fabricated 0). *)
+       Alcotest.(check (option int)) "output" (Some 42) u.output_tokens;
+       Alcotest.(check (option int))
+         "cache_creation"
+         (Some 1500)
+         u.cache_creation_input_tokens;
+       Alcotest.(check (option int)) "cache_read" (Some 800) u.cache_read_input_tokens;
+       Alcotest.(check (option int)) "input not reported" None u.input_tokens
      | None -> Alcotest.fail "expected usage in message_delta")
   | _ -> Alcotest.fail "expected MessageDelta event"
 ;;
@@ -205,9 +239,12 @@ let test_streaming_message_delta_without_cache () =
   | Some (MessageDelta { usage; _ }) ->
     (match usage with
      | Some u ->
-       Alcotest.(check int) "output" 10 u.output_tokens;
-       Alcotest.(check int) "cache_creation defaults 0" 0 u.cache_creation_input_tokens;
-       Alcotest.(check int) "cache_read defaults 0" 0 u.cache_read_input_tokens
+       Alcotest.(check (option int)) "output" (Some 10) u.output_tokens;
+       Alcotest.(check (option int))
+         "cache_creation not reported"
+         None
+         u.cache_creation_input_tokens;
+       Alcotest.(check (option int)) "cache_read not reported" None u.cache_read_input_tokens
      | None -> Alcotest.fail "expected usage")
   | _ -> Alcotest.fail "expected MessageDelta event"
 ;;
@@ -246,6 +283,10 @@ let () =
             "message_delta without cache tokens"
             `Quick
             test_streaming_message_delta_without_cache
+        ; test_case
+            "message_delta cumulative input normalized"
+            `Quick
+            test_streaming_message_delta_cumulative_input
         ] )
     ]
 ;;

--- a/packages/agent_core/test/test_provider_complete.ml
+++ b/packages/agent_core/test/test_provider_complete.ml
@@ -1876,11 +1876,10 @@ let test_stream_acc_text () =
         { stop_reason = Some EndTurn
         ; usage =
             Some
-              { input_tokens = 0
-              ; output_tokens = 5
-              ; cache_creation_input_tokens = 0
-              ; cache_read_input_tokens = 0
-              ; cost_usd = None
+              { input_tokens = None
+              ; output_tokens = Some 5
+              ; cache_creation_input_tokens = None
+              ; cache_read_input_tokens = None
               }
         }
     ; MessageStop

--- a/packages/agent_core/test/test_stream_accumulator.ml
+++ b/packages/agent_core/test/test_stream_accumulator.ml
@@ -236,7 +236,18 @@ let test_accumulate_message_delta () =
   let acc = Streaming.create_stream_acc () in
   Streaming.accumulate_event
     acc
-    (MessageDelta { stop_reason = Some EndTurn; usage = Some (make_usage 0 75) });
+    (MessageDelta
+       { stop_reason = Some EndTurn
+       ; usage =
+           (* The classic wire shape: the final delta reports only the
+              cumulative output counter. *)
+           Some
+             { Types.input_tokens = None
+             ; output_tokens = Some 75
+             ; cache_creation_input_tokens = None
+             ; cache_read_input_tokens = None
+             }
+       });
   match Streaming.finalize_stream_acc acc with
   | Ok { stop_reason = EndTurn; usage = Some usage; _ } ->
     Alcotest.(check int) "output_tokens" 75 usage.output_tokens
@@ -262,11 +273,10 @@ let test_accumulate_message_delta_cache_update () =
        { stop_reason = Some EndTurn
        ; usage =
            Some
-             { input_tokens = 0
-             ; output_tokens = 50
-             ; cache_creation_input_tokens = 25
-             ; cache_read_input_tokens = 10
-             ; cost_usd = None
+             { Types.input_tokens = None
+             ; output_tokens = Some 50
+             ; cache_creation_input_tokens = Some 25
+             ; cache_read_input_tokens = Some 10
              }
        });
   match Streaming.finalize_stream_acc acc with
@@ -309,7 +319,16 @@ let test_finalize_text_response () =
     ; ContentBlockStart
         { index = 0; content_type = "text"; tool_id = None; tool_name = None }
     ; ContentBlockDelta { index = 0; delta = TextDelta "hello world" }
-    ; MessageDelta { stop_reason = Some EndTurn; usage = Some (make_usage 0 50) }
+    ; MessageDelta
+        { stop_reason = Some EndTurn
+        ; usage =
+            Some
+              { Types.input_tokens = None
+              ; output_tokens = Some 50
+              ; cache_creation_input_tokens = None
+              ; cache_read_input_tokens = None
+              }
+        }
     ];
   match Streaming.finalize_stream_acc acc with
   | Error err -> fail_unexpected_stream_error err

--- a/packages/agent_core/test/test_streaming.ml
+++ b/packages/agent_core/test/test_streaming.ml
@@ -232,7 +232,7 @@ let test_parse_message_delta_end_turn () =
      | Some EndTurn -> ()
      | _ -> Alcotest.fail "expected EndTurn stop_reason");
     (match usage with
-     | Some u -> Alcotest.(check int) "output_tokens" 57 u.output_tokens
+     | Some u -> Alcotest.(check (option int)) "output_tokens" (Some 57) u.output_tokens
      | None -> Alcotest.fail "expected Some usage")
   | Some _ -> Alcotest.fail "unexpected event type"
   | None -> Alcotest.fail "parse returned None"
@@ -315,8 +315,11 @@ let test_message_delta_with_cache_usage () =
      | _ -> Alcotest.fail "expected end_turn");
     (match usage with
      | Some u ->
-       Alcotest.(check int) "output" 150 u.output_tokens;
-       Alcotest.(check int) "cache_write zero" 0 u.cache_creation_input_tokens
+       Alcotest.(check (option int)) "output" (Some 150) u.output_tokens;
+       Alcotest.(check (option int))
+         "cache_write reported zero"
+         (Some 0)
+         u.cache_creation_input_tokens
      | None -> Alcotest.fail "expected usage in delta")
   | Some _ -> Alcotest.fail "unexpected event type"
   | None -> Alcotest.fail "parse returned None"
@@ -638,8 +641,12 @@ let test_synthetic_usage_propagation () =
    | MessageStart { usage = Some u; _ } -> Alcotest.(check int) "input" 100 u.input_tokens
    | _ -> Alcotest.fail "expected MessageStart with usage");
   match List.nth events 4 with
-  | MessageDelta { usage = Some u; _ } -> Alcotest.(check int) "output" 50 u.output_tokens
-  | _ -> Alcotest.fail "expected MessageDelta with usage"
+  | MessageDelta { usage = None; _ } ->
+    (* The synthetic replay carries the complete usage on the start event
+       only; repeating it on the delta would double-count in any
+       accumulator that folds both. *)
+    ()
+  | _ -> Alcotest.fail "expected MessageDelta without usage"
 ;;
 
 (* ------------------------------------------------------------------ *)

--- a/packages/agent_core/test/test_streaming_cov.ml
+++ b/packages/agent_core/test/test_streaming_cov.ml
@@ -213,7 +213,10 @@ let test_accumulate_message_delta () =
   in
   Streaming.accumulate_event
     acc
-    (Types.MessageDelta { stop_reason = Some Types.EndTurn; usage = Some usage });
+    (Types.MessageDelta
+       { stop_reason = Some Types.EndTurn
+       ; usage = Some (Types.delta_usage_of_api_usage usage)
+       });
   let response = finalize_ok acc in
   match response.usage with
   | Some usage ->
@@ -330,12 +333,13 @@ let test_finalize_with_usage () =
     (Types.MessageDelta
        { stop_reason = Some Types.EndTurn
        ; usage =
+           (* Classic wire shape: the final delta reports only the cumulative
+              output counter, so the start event's input survives the overlay. *)
            Some
-             { input_tokens = 0
-             ; output_tokens = 50
-             ; cache_creation_input_tokens = 0
-             ; cache_read_input_tokens = 0
-             ; cost_usd = None
+             { Types.input_tokens = None
+             ; output_tokens = Some 50
+             ; cache_creation_input_tokens = None
+             ; cache_read_input_tokens = None
              }
        });
   let resp = finalize_ok acc in

--- a/packages/agent_core/test/test_streaming_coverage.ml
+++ b/packages/agent_core/test/test_streaming_coverage.ml
@@ -242,11 +242,10 @@ let test_acc_message_delta_with_usage () =
   let acc = Streaming.create_stream_acc () in
   let usage =
     Some
-      { input_tokens = 0
-      ; output_tokens = 200
-      ; cache_creation_input_tokens = 30
-      ; cache_read_input_tokens = 15
-      ; cost_usd = None
+      { Types.input_tokens = Some 0
+      ; output_tokens = Some 200
+      ; cache_creation_input_tokens = Some 30
+      ; cache_read_input_tokens = Some 15
       }
   in
   Streaming.accumulate_event acc (MessageDelta { stop_reason = Some EndTurn; usage });
@@ -263,18 +262,18 @@ let test_acc_message_delta_with_zero_cache () =
   let acc = Streaming.create_stream_acc () in
   let usage =
     Some
-      { input_tokens = 0
-      ; output_tokens = 100
-      ; cache_creation_input_tokens = 0
-      ; cache_read_input_tokens = 0
-      ; cost_usd = None
+      { Types.input_tokens = Some 0
+      ; output_tokens = Some 100
+      ; cache_creation_input_tokens = Some 0
+      ; cache_read_input_tokens = Some 0
       }
   in
   Streaming.accumulate_event acc (MessageDelta { stop_reason = Some EndTurn; usage });
   let resp = finalize_ok acc in
   match resp.usage with
   | Some u ->
-    (* Zero cache values should not overwrite prior values *)
+    (* Reported counters are cumulative and authoritative — a reported 0
+       lands as 0 (here onto an empty seed). *)
     check_int "output" 100 u.output_tokens;
     check_int "cache_creation stays 0" 0 u.cache_creation_input_tokens;
     check_int "cache_read stays 0" 0 u.cache_read_input_tokens
@@ -594,11 +593,10 @@ let test_full_anthropic_sequence () =
         { stop_reason = Some EndTurn
         ; usage =
             Some
-              { input_tokens = 0
-              ; output_tokens = 30
-              ; cache_creation_input_tokens = 0
-              ; cache_read_input_tokens = 0
-              ; cost_usd = None
+              { Types.input_tokens = None
+              ; output_tokens = Some 30
+              ; cache_creation_input_tokens = None
+              ; cache_read_input_tokens = None
               }
         }
     ; MessageStop
@@ -656,11 +654,10 @@ let test_full_tool_use_sequence () =
         { stop_reason = Some StopToolUse
         ; usage =
             Some
-              { input_tokens = 0
-              ; output_tokens = 45
-              ; cache_creation_input_tokens = 0
-              ; cache_read_input_tokens = 0
-              ; cost_usd = None
+              { Types.input_tokens = None
+              ; output_tokens = Some 45
+              ; cache_creation_input_tokens = None
+              ; cache_read_input_tokens = None
               }
         }
     ; MessageStop
@@ -774,27 +771,29 @@ let test_acc_message_delta_cache_update_nonzero () =
              ; cost_usd = None
              }
        });
-  (* MessageDelta with nonzero cache values should update *)
+  (* A final delta repeating the cache counters carries cumulative totals:
+     they replace the start snapshot instead of adding onto it — the
+     addition fold double-counted exactly this wire shape (#28903). The
+     unreported input keeps the start value. *)
   Streaming.accumulate_event
     acc
     (MessageDelta
        { stop_reason = Some EndTurn
        ; usage =
            Some
-             { input_tokens = 0
-             ; output_tokens = 100
-             ; cache_creation_input_tokens = 20
-             ; cache_read_input_tokens = 15
-             ; cost_usd = None
+             { Types.input_tokens = None
+             ; output_tokens = Some 100
+             ; cache_creation_input_tokens = Some 20
+             ; cache_read_input_tokens = Some 15
              }
        });
   let resp = finalize_ok acc in
   match resp.usage with
   | Some u ->
-    check_int "input" 50 u.input_tokens;
+    check_int "input kept from start" 50 u.input_tokens;
     check_int "output" 100 u.output_tokens;
-    check_int "cache_creation added" 30 u.cache_creation_input_tokens;
-    check_int "cache_read added" 20 u.cache_read_input_tokens
+    check_int "cache_creation replaced, not added" 20 u.cache_creation_input_tokens;
+    check_int "cache_read replaced, not added" 15 u.cache_read_input_tokens
   | None -> Alcotest.fail "expected usage"
 ;;
 

--- a/packages/agent_core/test/test_streaming_openai.ml
+++ b/packages/agent_core/test/test_streaming_openai.ml
@@ -1166,9 +1166,9 @@ let test_responses_stream_reasoning_tool_and_terminal () =
       "encrypted reasoning"
       "enc_reasoning_1"
       (Yojson.Safe.Util.member "encrypted_content" reasoning |> Yojson.Safe.Util.to_string);
-    Alcotest.(check int) "input tokens" 12 usage.input_tokens;
-    Alcotest.(check int) "output tokens" 8 usage.output_tokens;
-    Alcotest.(check int) "cache read" 2 usage.cache_read_input_tokens
+    Alcotest.(check (option int)) "input tokens" (Some 12) usage.input_tokens;
+    Alcotest.(check (option int)) "output tokens" (Some 8) usage.output_tokens;
+    Alcotest.(check (option int)) "cache read" (Some 2) usage.cache_read_input_tokens
   | _ -> Alcotest.fail "expected redacted reasoning carrier and terminal StopToolUse"
 ;;
 
@@ -1302,8 +1302,8 @@ let test_responses_stream_hidden_reasoning_before_tool () =
       "encrypted reasoning"
       "enc_hidden_1"
       (Yojson.Safe.Util.member "encrypted_content" reasoning |> Yojson.Safe.Util.to_string);
-    Alcotest.(check int) "input tokens" 12 usage.input_tokens;
-    Alcotest.(check int) "output tokens" 8 usage.output_tokens
+    Alcotest.(check (option int)) "input tokens" (Some 12) usage.input_tokens;
+    Alcotest.(check (option int)) "output tokens" (Some 8) usage.output_tokens
   | _ -> Alcotest.fail "expected hidden reasoning carrier before terminal"
 ;;
 

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -1416,7 +1416,10 @@ let test_keeper_stream_bridge_surfaces_agent_core_message_metadata () =
       [
         MessageStart
           { id = "msg-agent_core-1"; model = "gpt-5.5"; usage = Some usage_start };
-        MessageDelta { stop_reason = Some EndTurn; usage = Some usage_delta };
+        MessageDelta
+          { stop_reason = Some EndTurn
+          ; usage = Some (Agent_core.Types.delta_usage_of_api_usage usage_delta)
+          };
         MessageStop;
         Ping;
       ]
@@ -1437,9 +1440,10 @@ let test_keeper_stream_bridge_surfaces_agent_core_message_metadata () =
         start_usage.cache_creation_input_tokens;
       check string "stop reason" "end_turn"
         (Agent_core.Types.stop_reason_to_string stop_reason);
-      check int "delta output tokens" 2 delta_usage.output_tokens;
-      check int "delta total tokens" 12
-        (Agent_core.Types.total_tokens delta_usage)
+      check (option int) "delta output tokens" (Some 2) delta_usage.output_tokens;
+      check (option int) "delta input tokens" (Some 10) delta_usage.input_tokens;
+      check (option int) "delta cache read tokens" (Some 4)
+        delta_usage.cache_read_input_tokens
   | _ -> fail "expected AGENT_CORE message lifecycle metadata events"
 
 let test_keeper_stream_bridge_terminal_text_state_is_message_scoped () =


### PR DESCRIPTION
## 무엇 (#28903 — G6 감사의 잔여 결함)

공식 스트리밍 문서는 명시한다: **"The token counts shown in the `usage` field of the `message_delta` event are *cumulative*"** — 그리고 공식 예시에는 최종 delta가 `input_tokens`/`cache_*`를 누적값으로 반복 보고하는 형태(server-tool)가 있다. 그러나 accumulator는 **가산**(`add_usage`)으로 접었다:

- wire가 최종 delta에 cache 카운터를 반복하면 start 스냅샷과 합산돼 **cache 2배**
- delta 파서가 input을 0으로 고정해 server-tool 스트림의 **input 갱신(서버측 루프 소비 반영)이 폐기**
- `emit_synthetic_events`는 같은 usage를 start와 delta 양쪽에 실어, fold와 조합되는 순간 input/cache 2배가 되는 잠재 조합 (프로덕션 호출자 0이라 실해는 없었음)

가산이 여태 맞아 보였던 건 "start가 input+cache, delta는 output만"이라는 고전 wire 형태에 파서 핀 2개(start output=0, delta input=0)로 끼워 맞춘 결과다. 계약이 "누적"인 이상 올바른 fold는 **보고된 필드 교체**다.

## 변경 (타입 수술)

| 층 | 내용 |
|---|---|
| `Types` | `MessageDelta` payload가 `delta_usage`(카운터별 `int option`) 운반 — "미보고"와 0을 타입으로 구분. 필드 라벨 공유 때문에 `api_usage`보다 **먼저** 선언(비한정 라벨 해석이 api_usage로 유지되도록, 주석 명시) |
| Anthropic SSE 파스 | delta의 보고 필드를 present로 운반, input 보고 시 같은 report의 cache 값으로 포함형 정규화. start의 output 핀 제거(가산 fold 보호용이었음 — 이제 start가 전 카운터 시드) |
| `complete_stream_state` | `add_usage` 삭제 → `overlay_delta_usage` (보고 필드 덮어쓰기, 미보고 유지) |
| OpenAI chat/Responses·Gemini·ollama 변환기 | 종단 usage 전체 보고를 `delta_usage_of_api_usage`로 투영. OpenAI·ollama는 최종 1회 누적 보고(공식 계약), Gemini는 usageMetadata의 누적 여부가 공식 문서에 명시돼 있지 않으나 변환기의 emit이 스트림당 1회뿐이라(finish_reason/block_reason arm 한정) fold 정합이 구조로 보장됨 — adversarial review 확인 |
| `emit_synthetic_events` | delta의 usage 반복 제거 — start 1회 운반 (G6-c 잠재 조합 구조적 종결) |
| masc chat events + AGUI projection | per-field 형태 운반, delta JSON은 보고된 카운터만 방출 |
| 테스트 | **add 의미론을 고정하던 테스트를 교체 계약 핀으로 반전** ("cache_creation added 30" → "replaced, not added" 20) + server-tool 누적 input 정규화 파스 테스트 신규 + shim delta-None 핀 |

## 검증 (로컬, worktree root)

```
opam exec -- dune build --root . @check                                  # 0
opam exec -- dune build --root . @packages/agent_core/test/runtest       # 0
opam exec -- dune exec --root . test/test_gate_keeper_backend.exe        # 0 (masc 브리지 경로)
bash scripts/ci/check-determinism-contract.sh                            # PASS
```

영향권 8개 스위트(test_cache/streaming/stream_accumulator/streaming_coverage/streaming_cov/api/streaming_openai/api_dispatch) 개별 exit 0.

## 관련

- #28904 (G6 포함형 정규화)의 stacked 후속 — 리뷰에서 고지한 "PR-5(Anthropic cache_control) 이전에 닫는 순서" 이행.
- 리뷰어 nit였던 "#28903 발화 시 스트리밍 pricing 클램프 재발 경로"가 이 수술의 수용 기준: delta의 input 교체값도 포함형으로 정규화되므로 클램프 재발 없음 (신규 파스 테스트가 고정).
- adversarial review 통과 시 `review:adversarial-pass` 라벨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

