### PR TITLE
feat(canary): 측정 턴의 실서빙 runtime 검증 (--expect-runtime)

### DIFF
--- a/bin/keeper_canary_run.ml
+++ b/bin/keeper_canary_run.ml
@@ -31,7 +31,7 @@
        [--turn-timeout SECONDS] [--wall-clock-target SECONDS] \
        [--inject-restart-after N] [--inject-failover-after N \
        --failover-down-cmd CMD [--failover-up-cmd CMD]] \
-       [--judge-runtime ID] [--out PATH] *)
+       [--judge-runtime ID] [--expect-runtime ID] [--out PATH] *)
 
 let default_facts = 9
 let default_turn_interval_s = 0.0
@@ -42,7 +42,8 @@ let usage =
    [--turn-interval SECONDS] [--turn-timeout SECONDS] \
    [--wall-clock-target SECONDS] [--inject-restart-after N] \
    [--inject-failover-after N --failover-down-cmd CMD [--failover-up-cmd CMD]] \
-   [--judge-runtime ID] [--out PATH] [--allow-reused-keeper]"
+   [--judge-runtime ID] [--expect-runtime ID] [--out PATH] \
+   [--allow-reused-keeper]"
 
 type args = {
   keeper : string;
@@ -60,6 +61,7 @@ type args = {
   failover_down_cmd : string option;
   failover_up_cmd : string option;
   judge_runtime : string option;
+  expect_runtime : string option;
   out : string option;
   allow_reused_keeper : bool;
 }
@@ -80,6 +82,7 @@ let parse_args argv =
   let failover_down_cmd = ref None in
   let failover_up_cmd = ref None in
   let judge_runtime = ref None in
+  let expect_runtime = ref None in
   let out = ref None in
   let allow_reused_keeper = ref false in
   let rec parse = function
@@ -157,6 +160,10 @@ let parse_args argv =
       judge_runtime := Some v;
       parse rest
     | [ "--judge-runtime" ] -> Error "missing value for --judge-runtime"
+    | "--expect-runtime" :: v :: rest ->
+      expect_runtime := Some v;
+      parse rest
+    | [ "--expect-runtime" ] -> Error "missing value for --expect-runtime"
     | "--out" :: v :: rest ->
       out := Some v;
       parse rest
@@ -187,6 +194,12 @@ let parse_args argv =
        then Error "--inject-failover-after requires --failover-down-cmd"
        else if !failover_down_cmd <> None && !inject_failover_after = None
        then Error "--failover-down-cmd requires --inject-failover-after"
+       else if !expect_runtime <> None && !allow_reused_keeper
+       then
+         Error
+           "--expect-runtime and --allow-reused-keeper are mutually \
+            exclusive: the serving check matches harness turn indices \
+            against keeper_turn_id, which only line up on a fresh keeper"
        else
        Ok
          { keeper
@@ -204,6 +217,7 @@ let parse_args argv =
          ; failover_down_cmd = !failover_down_cmd
          ; failover_up_cmd = !failover_up_cmd
          ; judge_runtime = !judge_runtime
+         ; expect_runtime = !expect_runtime
          ; out = !out
          ; allow_reused_keeper = !allow_reused_keeper
          })
@@ -549,6 +563,28 @@ let start_failover ~down_cmd ~after_turn : (pending_failover, string) result =
     ; pf_down_cmd = down_cmd
     }
 
+(* One fetch shape for both consumers of the runtime-manifest attempts:
+   the failover verdict and the serving check (#28913). *)
+let fetch_manifest_attempts ~host ~port ~keeper_name :
+  (Keeper_canary_failover.attempt list, string) result
+  =
+  let ( let* ) = Result.bind in
+  let path =
+    Printf.sprintf "/api/v1/keepers/%s/runtime-trace?limit=500" keeper_name
+  in
+  let* status, body = Keeper_canary_http.admin_get ~host ~port ~path () in
+  let* () =
+    if status >= 200 && status < 300
+    then Ok ()
+    else Error (Printf.sprintf "runtime-trace returned HTTP %d" status)
+  in
+  let* json =
+    match Yojson.Safe.from_string body with
+    | j -> Ok j
+    | exception Yojson.Json_error msg -> Error ("runtime-trace: invalid JSON: " ^ msg)
+  in
+  Keeper_canary_failover.parse_manifest_rows json
+
 let finish_failover ~host ~port ~keeper_name ~up_cmd (pending : pending_failover) :
   (Keeper_canary_evidence.injection, string) result * string list
   =
@@ -566,21 +602,7 @@ let finish_failover ~host ~port ~keeper_name ~up_cmd (pending : pending_failover
   in
   let result =
     let ( let* ) = Result.bind in
-    let path =
-      Printf.sprintf "/api/v1/keepers/%s/runtime-trace?limit=500" keeper_name
-    in
-    let* status, body = Keeper_canary_http.admin_get ~host ~port ~path () in
-    let* () =
-      if status >= 200 && status < 300
-      then Ok ()
-      else Error (Printf.sprintf "runtime-trace returned HTTP %d" status)
-    in
-    let* json =
-      match Yojson.Safe.from_string body with
-      | j -> Ok j
-      | exception Yojson.Json_error msg -> Error ("runtime-trace: invalid JSON: " ^ msg)
-    in
-    let* attempts = Keeper_canary_failover.parse_manifest_rows json in
+    let* attempts = fetch_manifest_attempts ~host ~port ~keeper_name in
     let mode, windowed =
       Keeper_canary_failover.classify
         ~window_start:pending.pf_window_start
@@ -928,6 +950,41 @@ let run ?(judge : judge_fn option) ~(base_path : string) (args : args) :
          | Ok verdict -> (Some verdict, [])
          | Error detail -> (None, [ Printf.sprintf "judge failed: %s" detail ]))
     in
+    let serving, serving_notes =
+      match args.expect_runtime with
+      | None -> (None, [])
+      | Some expected_runtime ->
+        (match fetch_manifest_attempts ~host ~port ~keeper_name:args.keeper with
+         | Error detail ->
+           (* Attribution unreadable means the serving claim is unproven:
+              serving stays null and the exit path treats that as a failed
+              check rather than a silent pass. *)
+           (None, [ Printf.sprintf "serving: attribution read failed: %s" detail ])
+         | Ok attempts ->
+           (* [turns] already includes the recall turn: all_drafts ends
+              with it and every draft is correlated into a turn row. *)
+           let window_start =
+             match turns with
+             | first :: _ -> first.Keeper_canary_evidence.sent_at
+             | [] -> recall_draft.sent_at
+           in
+           let turn_ids =
+             List.map (fun (t : Keeper_canary_evidence.turn_evidence) -> t.index) turns
+           in
+           let c =
+             Keeper_canary_serving.check
+               ~expected_runtime
+               ~window_start
+               ~turn_ids
+               ~attempts
+           in
+           Printf.eprintf
+             "[keeper_canary_run] serving check expected=%s mismatched=%d unattributed=%d\n%!"
+             expected_runtime
+             (List.length c.Keeper_canary_serving.mismatched)
+             (List.length c.Keeper_canary_serving.unattributed);
+           (Some c, []))
+    in
     Ok
       { Keeper_canary_evidence.captured_at = iso8601_now ()
       ; harness_git_commit = git_commit_opt ()
@@ -950,9 +1007,10 @@ let run ?(judge : judge_fn option) ~(base_path : string) (args : args) :
       ; deterministic_signal
       ; judgment
       ; injections = List.rev !injections
+      ; serving
       ; notes =
           transcript_notes @ capped_note @ correlation_notes @ failover_notes
-          @ judge_notes
+          @ judge_notes @ serving_notes
       })
 
 (* Sized for the judge's small JSON verdict (at most nine per_fact rows and
@@ -1129,10 +1187,43 @@ let () =
           are the remaining suspects). Explicit exit is the sibling-harness
           convention regardless (keeper_capability_probe_cli.ml does the
           same); stdout is flushed by exit's at_exit hooks. *)
-       (match args.judge_runtime, evidence.Keeper_canary_evidence.judgment with
-        | Some _, None ->
-          (* The judge was requested but produced no judgment — the receipt
-             above still landed (with the failure note), and the exit code
-             tells automation the judging leg failed. *)
-          exit 1
-        | _ -> exit 0))
+       let serving_failed =
+         match args.expect_runtime, evidence.Keeper_canary_evidence.serving with
+         | None, _ -> false
+         | Some _, None ->
+           (* Requested but unreadable: the claim is unproven, which for
+              automation is the same as disproven. The note in the
+              evidence carries the read error. *)
+           true
+         | Some _, Some c ->
+           if Keeper_canary_serving.all_as_expected c
+           then false
+           else (
+             List.iter
+               (fun (turn, rid) ->
+                 Printf.eprintf
+                   "[keeper_canary_run] serving MISMATCH turn=%d served_by=%s\n"
+                   turn
+                   rid)
+               c.Keeper_canary_serving.mismatched;
+             List.iter
+               (fun turn ->
+                 Printf.eprintf
+                   "[keeper_canary_run] serving UNATTRIBUTED turn=%d\n"
+                   turn)
+               c.Keeper_canary_serving.unattributed;
+             true)
+       in
+       if serving_failed
+       then
+         (* Distinct from the judge-leg failure (1): the receipt landed but
+            it does not measure the runtime it was pointed at. *)
+         exit 3
+       else (
+         match args.judge_runtime, evidence.Keeper_canary_evidence.judgment with
+         | Some _, None ->
+           (* The judge was requested but produced no judgment — the receipt
+              above still landed (with the failure note), and the exit code
+              tells automation the judging leg failed. *)
+           exit 1
+         | _ -> exit 0))

--- a/lib/keeper_canary/dune
+++ b/lib/keeper_canary/dune
@@ -10,7 +10,7 @@
  (name keeper_canary)
  (public_name masc.keeper_canary)
  (wrapped false)
- (modules keeper_canary_facts keeper_canary_evidence keeper_canary_judge keeper_canary_failover)
+ (modules keeper_canary_facts keeper_canary_evidence keeper_canary_judge keeper_canary_failover keeper_canary_serving)
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4) + unused-value ratchet (warning 32)
  (flags
   (:standard -w +4 -w +33 -w +37))

--- a/lib/keeper_canary/keeper_canary_evidence.ml
+++ b/lib/keeper_canary/keeper_canary_evidence.ml
@@ -153,6 +153,7 @@ type run_evidence = {
   deterministic_signal : Keeper_canary_facts.score;
   judgment : Keeper_canary_judge.judgment option;
   injections : injection list;
+  serving : Keeper_canary_serving.check option;
   notes : string list;
 }
 
@@ -249,6 +250,10 @@ let to_yojson (e : run_evidence) =
         | Some j -> Keeper_canary_judge.judgment_to_yojson j
         | None -> `Null )
     ; ("injections", `List (List.map injection_to_yojson e.injections))
+    ; ( "serving"
+      , match e.serving with
+        | None -> `Null
+        | Some c -> Keeper_canary_serving.to_yojson c )
     ; ("notes", `List (List.map (fun n -> `String n) e.notes))
     ]
 

--- a/lib/keeper_canary/keeper_canary_evidence.mli
+++ b/lib/keeper_canary/keeper_canary_evidence.mli
@@ -105,6 +105,11 @@ type run_evidence = {
       (** [None] renders as JSON null — no judge ran for this invocation. *)
   injections : injection list;
       (** Empty when the run injected nothing; order follows execution. *)
+  serving : Keeper_canary_serving.check option;
+      (** [None] renders as JSON null — no [--expect-runtime] was given, so
+          the run makes no claim about who served its turns. [runtime]
+          above stays a caller-supplied label; this field is the verified
+          counterpart (#28913). *)
   notes : string list;
 }
 

--- a/lib/keeper_canary/keeper_canary_serving.ml
+++ b/lib/keeper_canary/keeper_canary_serving.ml
@@ -1,0 +1,62 @@
+(* See keeper_canary_serving.mli. *)
+
+type check = {
+  expected_runtime : string;
+  served : (int * string) list;
+  mismatched : (int * string) list;
+  unattributed : int list;
+}
+
+let check ~expected_runtime ~window_start ~turn_ids
+    ~(attempts : Keeper_canary_failover.attempt list) : check
+  =
+  let served =
+    List.filter_map
+      (fun (a : Keeper_canary_failover.attempt) ->
+        match a.event with
+        | Keeper_canary_failover.Routed | Keeper_canary_failover.Failed -> None
+        | Keeper_canary_failover.Completed ->
+          (match a.keeper_turn_id with
+           | Some turn when String.compare a.ts window_start >= 0 ->
+             Some (turn, a.runtime_id)
+           | Some _ | None -> None))
+      attempts
+  in
+  (* Later Completed row wins for a turn: attempts arrive in row order and
+     the last completion is the one whose reply the transcript kept. *)
+  let completed_for turn =
+    List.fold_left
+      (fun acc (t, rid) -> if t = turn then Some rid else acc)
+      None
+      served
+  in
+  let mismatched, unattributed =
+    List.fold_left
+      (fun (mis, unat) turn ->
+        match completed_for turn with
+        | None -> (mis, turn :: unat)
+        | Some rid ->
+          if String.equal rid expected_runtime
+          then (mis, unat)
+          else ((turn, rid) :: mis, unat))
+      ([], [])
+      turn_ids
+  in
+  { expected_runtime
+  ; served
+  ; mismatched = List.rev mismatched
+  ; unattributed = List.rev unattributed
+  }
+
+let all_as_expected c = c.mismatched = [] && c.unattributed = []
+
+let to_yojson c =
+  let pair_to_json (turn, rid) =
+    `Assoc [ ("turn", `Int turn); ("runtime_id", `String rid) ]
+  in
+  `Assoc
+    [ ("expected_runtime", `String c.expected_runtime)
+    ; ("served", `List (List.map pair_to_json c.served))
+    ; ("mismatched", `List (List.map pair_to_json c.mismatched))
+    ; ("unattributed", `List (List.map (fun t -> `Int t) c.unattributed))
+    ]

--- a/lib/keeper_canary/keeper_canary_serving.ml
+++ b/lib/keeper_canary/keeper_canary_serving.ml
@@ -10,7 +10,7 @@ type check = {
 let check ~expected_runtime ~window_start ~turn_ids
     ~(attempts : Keeper_canary_failover.attempt list) : check
   =
-  let served =
+  let windowed =
     List.filter_map
       (fun (a : Keeper_canary_failover.attempt) ->
         match a.event with
@@ -18,17 +18,28 @@ let check ~expected_runtime ~window_start ~turn_ids
         | Keeper_canary_failover.Completed ->
           (match a.keeper_turn_id with
            | Some turn when String.compare a.ts window_start >= 0 ->
-             Some (turn, a.runtime_id)
+             Some (turn, a.ts, a.runtime_id)
            | Some _ | None -> None))
       attempts
   in
-  (* Later Completed row wins for a turn: attempts arrive in row order and
-     the last completion is the one whose reply the transcript kept. *)
+  let served = List.map (fun (turn, _, rid) -> (turn, rid)) windowed in
+  (* Chronologically last Completed row wins for a turn — its reply is the
+     one the transcript kept. Chronological order = list order is not
+     guaranteed by the wire (same lesson as classify in
+     keeper_canary_failover.ml), so compare timestamps directly; a ts tie
+     falls to the later row. *)
   let completed_for turn =
     List.fold_left
-      (fun acc (t, rid) -> if t = turn then Some rid else acc)
+      (fun acc (t, ts, rid) ->
+        if t <> turn
+        then acc
+        else (
+          match acc with
+          | Some (best_ts, _) when String.compare best_ts ts > 0 -> acc
+          | Some _ | None -> Some (ts, rid)))
       None
-      served
+      windowed
+    |> Option.map snd
   in
   let mismatched, unattributed =
     List.fold_left

--- a/lib/keeper_canary/keeper_canary_serving.mli
+++ b/lib/keeper_canary/keeper_canary_serving.mli
@@ -41,8 +41,10 @@ val check :
     [1..n]). Attempts before [window_start] are ignored (ISO8601 strings
     compare chronologically, same convention as
     {!Keeper_canary_failover.classify}). When one turn carries several
-    [Completed] rows the later row wins — it is the one whose reply the
-    transcript kept. *)
+    [Completed] rows the chronologically last one wins — its reply is the
+    one the transcript kept, and the wire does not guarantee list order
+    (same lesson classify already carries); a ts tie falls to the later
+    row. *)
 
 val all_as_expected : check -> bool
 (** True iff [mismatched] and [unattributed] are both empty. Derived, not

--- a/lib/keeper_canary/keeper_canary_serving.mli
+++ b/lib/keeper_canary/keeper_canary_serving.mli
@@ -1,0 +1,51 @@
+(** Serving-runtime attribution for the canary harness (#28913).
+
+    A canary receipt claims "runtime X served N turns with recall intact",
+    but the recall signal alone cannot see who served: when the lane walk
+    fails the head candidate, degraded retry serves every turn from another
+    runtime and the transcript still reads 9/9. The M3 sweep shipped eight
+    antigravity canaries whose every turn was actually served by
+    ollama_cloud this way (#28912) — the substitution was invisible in the
+    evidence. This module decides, from the same runtime-manifest attempts
+    the failover verdict uses, which candidate completed each measured
+    turn, so the receipt carries the X of its own claim.
+
+    Turn identity: the check matches harness turn indices against
+    [keeper_turn_id], which only lines up on a fresh keeper (turn 1 of the
+    run is turn 1 of the keeper). bin rejects [--expect-runtime] combined
+    with [--allow-reused-keeper] for exactly this reason. *)
+
+type check = {
+  expected_runtime : string;  (** The runtime id the run claims to measure. *)
+  served : (int * string) list;
+      (** Every windowed [Completed] attempt as (keeper_turn_id,
+          candidate runtime id), in row order — the full serving record
+          the verdict was computed from, including rows for turns the
+          harness did not send. *)
+  mismatched : (int * string) list;
+      (** Measured turns whose completing candidate differs from
+          [expected_runtime]. *)
+  unattributed : int list;
+      (** Measured turns with no windowed [Completed] row at all —
+          either the trace window missed them or the turn never
+          completed; both void the attribution claim. *)
+}
+
+val check :
+  expected_runtime:string ->
+  window_start:string ->
+  turn_ids:int list ->
+  attempts:Keeper_canary_failover.attempt list ->
+  check
+(** [turn_ids] are the keeper turn ids the harness measured (fresh keeper:
+    [1..n]). Attempts before [window_start] are ignored (ISO8601 strings
+    compare chronologically, same convention as
+    {!Keeper_canary_failover.classify}). When one turn carries several
+    [Completed] rows the later row wins — it is the one whose reply the
+    transcript kept. *)
+
+val all_as_expected : check -> bool
+(** True iff [mismatched] and [unattributed] are both empty. Derived, not
+    stored: the JSON carries the two lists and readers re-derive. *)
+
+val to_yojson : check -> Yojson.Safe.t

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -112,6 +112,7 @@ normal_targets=(
   @test/runtest-test_keeper_canary_evidence
   @test/runtest-test_keeper_canary_judge
   @test/runtest-test_keeper_canary_failover
+  @test/runtest-test_keeper_canary_serving
   @test/runtest-test_slack_user_directory
   @test/runtest-test_sidecar_lifecycle_routes
   @test/runtest-test_cancel_safe

--- a/test/dune
+++ b/test/dune
@@ -2565,6 +2565,7 @@
 (include stanzas/test_keeper_canary_evidence.inc)
 (include stanzas/test_keeper_canary_judge.inc)
 (include stanzas/test_keeper_canary_failover.inc)
+(include stanzas/test_keeper_canary_serving.inc)
 
 (include stanzas/test_run_registry_concurrent_mutation.inc)
 (include stanzas/test_exact_lane_run_registry.inc)

--- a/test/stanzas/test_keeper_canary_serving.inc
+++ b/test/stanzas/test_keeper_canary_serving.inc
@@ -1,0 +1,10 @@
+; Serving-runtime attribution verdicts for the canary harness
+; (lib/keeper_canary/keeper_canary_serving.ml, #28913): the check that a
+; receipt's turns were completed by the runtime the run claims to measure.
+; Born from the M3 sweep incident where degraded retry silently served
+; eight "antigravity" canaries from ollama_cloud (#28912).
+
+(test
+ (name test_keeper_canary_serving)
+ (modules test_keeper_canary_serving)
+ (libraries masc_test_deps))

--- a/test/test_keeper_canary_evidence.ml
+++ b/test/test_keeper_canary_evidence.ml
@@ -51,6 +51,7 @@ let sample_evidence : Keeper_canary_evidence.run_evidence =
   ; deterministic_signal = sample_score
   ; judgment = None
   ; injections = []
+  ; serving = None
   ; notes = []
   }
 
@@ -89,6 +90,7 @@ let test_top_level_keys_are_present () =
     ; "deterministic_signal"
     ; "judgment"
     ; "injections"
+    ; "serving"
     ; "notes"
     ]
   in

--- a/test/test_keeper_canary_serving.ml
+++ b/test/test_keeper_canary_serving.ml
@@ -116,10 +116,12 @@ let test_rows_before_window_are_ignored () =
     [ (1, "agy.x") ]
     c.S.served
 
-let test_later_completion_wins_for_a_turn () =
+(* Wire order is not chronological order (the classify lesson): the later
+   timestamp must win even when it arrives earlier in the list. *)
+let test_chronologically_later_completion_wins_for_a_turn () =
   let attempts =
-    [ completed ~turn:1 ~ts:"2026-08-17T01:00:00Z" ~runtime:"agy.x" ()
-    ; completed ~turn:1 ~ts:"2026-08-17T01:00:05Z" ~runtime:"oc.fallback" ()
+    [ completed ~turn:1 ~ts:"2026-08-17T01:00:05Z" ~runtime:"oc.fallback" ()
+    ; completed ~turn:1 ~ts:"2026-08-17T01:00:00Z" ~runtime:"agy.x" ()
     ]
   in
   let c =
@@ -129,9 +131,29 @@ let test_later_completion_wins_for_a_turn () =
       ~turn_ids:[ 1 ]
       ~attempts
   in
-  Alcotest.(check (list turn_pair)) "the later row decides"
+  Alcotest.(check (list turn_pair)) "the later timestamp decides"
     [ (1, "oc.fallback") ]
     c.S.mismatched
+
+(* [served] is the full windowed completion record: rows for turns the
+   harness never sent stay visible instead of silently vanishing. *)
+let test_served_keeps_rows_for_unmeasured_turns () =
+  let attempts =
+    [ completed ~turn:1 ~ts:"2026-08-17T01:00:00Z" ~runtime:"agy.x" ()
+    ; completed ~turn:99 ~ts:"2026-08-17T01:05:00Z" ~runtime:"oc.other" ()
+    ]
+  in
+  let c =
+    S.check
+      ~expected_runtime:"agy.x"
+      ~window_start:"2026-08-17T00:59:00Z"
+      ~turn_ids:[ 1 ]
+      ~attempts
+  in
+  Alcotest.(check bool) "measured turn is clean" true (S.all_as_expected c);
+  Alcotest.(check (list turn_pair)) "served keeps the unmeasured row"
+    [ (1, "agy.x"); (99, "oc.other") ]
+    c.S.served
 
 let test_json_carries_the_verdict_inputs () =
   let c =
@@ -171,8 +193,10 @@ let () =
             test_turn_without_completion_is_unattributed
         ; Alcotest.test_case "pre-window rows ignored" `Quick
             test_rows_before_window_are_ignored
-        ; Alcotest.test_case "later completion wins" `Quick
-            test_later_completion_wins_for_a_turn
+        ; Alcotest.test_case "chronologically later completion wins" `Quick
+            test_chronologically_later_completion_wins_for_a_turn
+        ; Alcotest.test_case "served keeps unmeasured turns" `Quick
+            test_served_keeps_rows_for_unmeasured_turns
         ; Alcotest.test_case "json carries verdict inputs" `Quick
             test_json_carries_the_verdict_inputs
         ] )

--- a/test/test_keeper_canary_serving.ml
+++ b/test/test_keeper_canary_serving.ml
@@ -1,0 +1,179 @@
+(* Serving-runtime attribution for the canary harness
+   (lib/keeper_canary/keeper_canary_serving.ml, #28913). The check exists
+   because the M3 sweep promoted eight antigravity receipts whose every
+   turn was silently served by the degraded-retry fallback (#28912); these
+   tests pin the verdict on exactly that shape. *)
+
+module F = Keeper_canary_failover
+module S = Keeper_canary_serving
+
+let attempt ?turn ~ts ~event ~runtime () : F.attempt =
+  match
+    F.parse_manifest_rows
+      (`Assoc
+        [ ( "manifest_rows"
+          , `List
+              [ `Assoc
+                  ([ ("ts", `String ts)
+                   ; ("event", `String event)
+                   ; ("runtime_id", `String "some-lane")
+                   ; ("decision", `Assoc [ ("runtime_id", `String runtime) ])
+                   ]
+                   @
+                   match turn with
+                   | Some n -> [ ("keeper_turn_id", `Int n) ]
+                   | None -> [])
+              ] )
+        ])
+  with
+  | Ok [ a ] -> a
+  | Ok l -> Alcotest.failf "expected one attempt, got %d" (List.length l)
+  | Error msg -> Alcotest.failf "attempt fixture: %s" msg
+
+let completed ~turn ~ts ~runtime () =
+  attempt ~turn ~ts ~event:"runtime_completed" ~runtime ()
+
+let turn_pair = Alcotest.(pair int string)
+
+let test_all_turns_served_by_expected () =
+  let attempts =
+    [ completed ~turn:1 ~ts:"2026-08-17T01:00:00Z" ~runtime:"agy.x" ()
+    ; completed ~turn:2 ~ts:"2026-08-17T01:10:00Z" ~runtime:"agy.x" ()
+    ]
+  in
+  let c =
+    S.check
+      ~expected_runtime:"agy.x"
+      ~window_start:"2026-08-17T00:59:00Z"
+      ~turn_ids:[ 1; 2 ]
+      ~attempts
+  in
+  Alcotest.(check bool) "all as expected" true (S.all_as_expected c);
+  Alcotest.(check (list turn_pair)) "served records both turns"
+    [ (1, "agy.x"); (2, "agy.x") ]
+    c.S.served
+
+(* The #28912 incident shape: the expected runtime never completes a turn,
+   the fallback completes every one, and the recall signal alone would
+   still read 9/9. The check must flag every measured turn. *)
+let test_silent_fallback_substitution_is_flagged () =
+  let attempts =
+    [ attempt ~turn:1 ~ts:"2026-08-17T01:00:00Z" ~event:"runtime_routed"
+        ~runtime:"agy.x" ()
+    ; attempt ~turn:1 ~ts:"2026-08-17T01:03:14Z" ~event:"runtime_failed"
+        ~runtime:"agy.x" ()
+    ; completed ~turn:1 ~ts:"2026-08-17T01:03:20Z" ~runtime:"oc.fallback" ()
+    ; completed ~turn:2 ~ts:"2026-08-17T01:10:00Z" ~runtime:"oc.fallback" ()
+    ]
+  in
+  let c =
+    S.check
+      ~expected_runtime:"agy.x"
+      ~window_start:"2026-08-17T00:59:00Z"
+      ~turn_ids:[ 1; 2 ]
+      ~attempts
+  in
+  Alcotest.(check bool) "substitution fails the check" false (S.all_as_expected c);
+  Alcotest.(check (list turn_pair)) "every turn is a mismatch"
+    [ (1, "oc.fallback"); (2, "oc.fallback") ]
+    c.S.mismatched;
+  Alcotest.(check (list int)) "no unattributed turns" [] c.S.unattributed
+
+let test_turn_without_completion_is_unattributed () =
+  let attempts =
+    [ completed ~turn:1 ~ts:"2026-08-17T01:00:00Z" ~runtime:"agy.x" () ]
+  in
+  let c =
+    S.check
+      ~expected_runtime:"agy.x"
+      ~window_start:"2026-08-17T00:59:00Z"
+      ~turn_ids:[ 1; 2 ]
+      ~attempts
+  in
+  Alcotest.(check bool) "missing completion fails the check" false
+    (S.all_as_expected c);
+  Alcotest.(check (list int)) "turn 2 is unattributed" [ 2 ] c.S.unattributed;
+  Alcotest.(check (list turn_pair)) "turn 1 is fine" [] c.S.mismatched
+
+(* Rows before the window come from earlier keeper traffic (a reused
+   keeper, an operator poke); counting them would attribute turns the run
+   never sent. *)
+let test_rows_before_window_are_ignored () =
+  let attempts =
+    [ completed ~turn:1 ~ts:"2026-08-16T23:00:00Z" ~runtime:"oc.fallback" ()
+    ; completed ~turn:1 ~ts:"2026-08-17T01:00:00Z" ~runtime:"agy.x" ()
+    ]
+  in
+  let c =
+    S.check
+      ~expected_runtime:"agy.x"
+      ~window_start:"2026-08-17T00:59:00Z"
+      ~turn_ids:[ 1 ]
+      ~attempts
+  in
+  Alcotest.(check bool) "stale row is invisible" true (S.all_as_expected c);
+  Alcotest.(check (list turn_pair)) "served has only the windowed row"
+    [ (1, "agy.x") ]
+    c.S.served
+
+let test_later_completion_wins_for_a_turn () =
+  let attempts =
+    [ completed ~turn:1 ~ts:"2026-08-17T01:00:00Z" ~runtime:"agy.x" ()
+    ; completed ~turn:1 ~ts:"2026-08-17T01:00:05Z" ~runtime:"oc.fallback" ()
+    ]
+  in
+  let c =
+    S.check
+      ~expected_runtime:"agy.x"
+      ~window_start:"2026-08-17T00:59:00Z"
+      ~turn_ids:[ 1 ]
+      ~attempts
+  in
+  Alcotest.(check (list turn_pair)) "the later row decides"
+    [ (1, "oc.fallback") ]
+    c.S.mismatched
+
+let test_json_carries_the_verdict_inputs () =
+  let c =
+    S.check
+      ~expected_runtime:"agy.x"
+      ~window_start:"2026-08-17T00:59:00Z"
+      ~turn_ids:[ 1 ]
+      ~attempts:
+        [ completed ~turn:1 ~ts:"2026-08-17T01:00:00Z" ~runtime:"oc.fallback" () ]
+  in
+  match S.to_yojson c with
+  | `Assoc kvs ->
+    Alcotest.(check (option string)) "expected_runtime"
+      (Some "agy.x")
+      (match List.assoc_opt "expected_runtime" kvs with
+       | Some (`String s) -> Some s
+       | _ -> None);
+    let count key =
+      match List.assoc_opt key kvs with
+      | Some (`List l) -> List.length l
+      | _ -> -1
+    in
+    Alcotest.(check int) "served rendered" 1 (count "served");
+    Alcotest.(check int) "mismatched rendered" 1 (count "mismatched");
+    Alcotest.(check int) "unattributed rendered" 0 (count "unattributed")
+  | _ -> Alcotest.fail "serving JSON must be an object"
+
+let () =
+  Alcotest.run
+    "keeper_canary_serving"
+    [ ( "check"
+      , [ Alcotest.test_case "all served by expected" `Quick
+            test_all_turns_served_by_expected
+        ; Alcotest.test_case "silent fallback substitution flagged" `Quick
+            test_silent_fallback_substitution_is_flagged
+        ; Alcotest.test_case "missing completion is unattributed" `Quick
+            test_turn_without_completion_is_unattributed
+        ; Alcotest.test_case "pre-window rows ignored" `Quick
+            test_rows_before_window_are_ignored
+        ; Alcotest.test_case "later completion wins" `Quick
+            test_later_completion_wins_for_a_turn
+        ; Alcotest.test_case "json carries verdict inputs" `Quick
+            test_json_carries_the_verdict_inputs
+        ] )
+    ]


### PR DESCRIPTION
## 무엇 (#28913)
- \`lib/keeper_canary/keeper_canary_serving.{ml,mli}\` 신규: runtime-manifest attempts에서 측정 턴별 완결 후보를 추출해 기대 runtime과 대조하는 순수 판정 모듈
- evidence schema에 \`serving\` 블록 추가 (expected_runtime / served / mismatched / unattributed; \`--expect-runtime\` 미지정 시 null)
- \`bin/keeper_canary_run.ml\`: \`--expect-runtime ID\` 플래그, 기존 failover fetch를 \`fetch_manifest_attempts\`로 추출·공용화, mismatch/unattributed 시 **exit 3** (자동화가 오염 receipt를 승격 못 하게)
- \`--allow-reused-keeper\`와 동시 지정은 파싱 단계에서 거부 (turn index ↔ keeper_turn_id 정렬은 fresh keeper에서만 성립)

## 왜
M3 스윕에서 antigravity canary 8건이 turn 1 api 실패 후 전 턴을 degraded_retry(ollama_cloud)가 서빙했는데 evidence는 9/9 PASS만 남았다 (#28912, 적대적 리뷰가 store 로그 대조로 적발). 이 PR은 receipt가 주장하는 명제의 주어(runtime X)를 receipt 자신이 증명하게 만든다.

## 설계 노트
- string 휴리스틱 아님: store가 typed로 주는 runtime_id 등식 비교
- all_as_expected는 파생 — JSON에 저장하지 않고 두 리스트로 재도출
- attribution 읽기 실패 시 serving=null + note + exit 3 (unproven = 실패, silent pass 금지)
- 같은 턴에 Completed 2행이면 나중 행 승리 (transcript가 남긴 응답의 행)

## 검증
- \`test/test_keeper_canary_serving.ml\` 6케이스: #28912 사고 모양(조용한 치환) 재현 케이스 포함, 창 밖 행 무시, 미완결 턴, 중복 완결, JSON 직렬화
- 기존 canary 4 suite + runner 빌드 green (evidence 스키마 확장 반영)
- CI: \`test/dune\` stanza + \`scripts/ci-run-focused-tests.sh\`에 suite 등록

## 사용 (M3 재스윕 계약)
\`\`\`
keeper_canary_run --keeper K --run-id R --expect-runtime antigravity_subscription.gemini-3-5-flash-high ...
# exit 0: 회상 + 실서빙 모두 증명 / exit 3: receipt는 남지만 측정 대상 아님
\`\`\`