### PR TITLE
fix(operator): propagate heartbeat read errors in operator snapshot

### DIFF
--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -763,7 +763,7 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
         created_at: toIsoTimestamp(row.created_at) ?? asString(row.created_at),
         updated_at: toIsoTimestamp(row.updated_at) ?? asString(row.updated_at),
         last_heartbeat: asString(row.heartbeat_observation_error)
-          ? null
+          ? undefined
           : (asString(row.last_heartbeat) ?? asString(agentRaw?.last_seen)),
         heartbeat_observation_error: asString(row.heartbeat_observation_error) ?? null,
         last_autonomous_action_at: toIsoTimestamp(row.last_autonomous_action_at) ?? asString(row.last_autonomous_action_at) ?? null,

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -762,7 +762,10 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
           : null,
         created_at: toIsoTimestamp(row.created_at) ?? asString(row.created_at),
         updated_at: toIsoTimestamp(row.updated_at) ?? asString(row.updated_at),
-        last_heartbeat: asString(row.last_heartbeat) ?? asString(agentRaw?.last_seen),
+        last_heartbeat: asString(row.heartbeat_observation_error)
+          ? null
+          : (asString(row.last_heartbeat) ?? asString(agentRaw?.last_seen)),
+        heartbeat_observation_error: asString(row.heartbeat_observation_error) ?? null,
         last_autonomous_action_at: toIsoTimestamp(row.last_autonomous_action_at) ?? asString(row.last_autonomous_action_at) ?? null,
         generation: asNumber(row.generation),
         turn_count: asNumber(row.turn_count) ?? asNumber(row.total_turns),

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -1186,6 +1186,9 @@ export interface Keeper {
   created_at?: string
   updated_at?: string
   last_heartbeat?: string
+  /** Non-null when the heartbeat ledger could not be read — the operator
+      surface shows the error instead of substituting a stale timestamp. */
+  heartbeat_observation_error?: string | null
   keeper_age_s?: number
   last_turn_ago_s?: number
   last_handoff_ago_s?: number

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -105,20 +105,24 @@ let with_keeper_slot ~sem ~name f =
 
 let compact_keeper_runtime_trust_json = Operator_control_snapshot_trust.compact_keeper_runtime_trust_json
 
+(* Returns the persisted heartbeat timestamp JSON and, when the heartbeat
+   ledger could not be read, the typed unavailable reason.  The error is
+   surfaced separately from [last_heartbeat] so an unreadable ledger is not
+   relabeled as an absent/missing heartbeat by downstream consumers. *)
 let persisted_last_heartbeat_json config keeper_name =
   match
     Keeper_heartbeat_persisted_snapshot.latest
       ~config
       ~keeper_name
   with
-  | Ok (Some snapshot) -> `String snapshot.timestamp
-  | Ok None -> `Null
+  | Ok (Some snapshot) -> (`String snapshot.timestamp, None)
+  | Ok None -> (`Null, None)
   | Error error ->
     Log.Dashboard.warn
       "operator snapshot heartbeat read failed for keeper %s: %s"
       keeper_name
       error;
-    `Null
+    (`Null, Some error)
 ;;
 
 let keepers_json
@@ -210,7 +214,7 @@ let keepers_json
                   dt_meta := Time_compat.now () -. t0;
                   if lightweight && meta.paused
                   then (
-                    let last_heartbeat =
+                    let last_heartbeat, heartbeat_observation_error =
                       persisted_last_heartbeat_json config meta.name
                     in
                     let t_ph = Time_compat.now () in
@@ -258,6 +262,8 @@ let keepers_json
                              , `Float keeper_snapshot_interval_s )
                            ; "heartbeat_stale_after_s", `Float heartbeat_stale_after_s
                            ; "last_heartbeat", last_heartbeat
+                           ; ( "heartbeat_observation_error"
+                             , Json_util.string_opt_to_json heartbeat_observation_error )
                            ; "updated_at", `String meta.updated_at
                            ; "created_at", `String meta.created_at
                            ]

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -583,6 +583,74 @@ let test_lightweight_snapshot_surfaces_paused_keeper_runtime_trust () =
         heartbeat_timestamp
         (full_keeper |> member "last_heartbeat" |> to_string))
 
+(* PR #28216 regression: an unreadable heartbeat ledger must not be relabeled
+   as an absent/missing heartbeat.  Corrupt the metrics ledger with an invalid
+   month directory so [Keeper_heartbeat_persisted_snapshot.latest] fails, then
+   assert the operator row surfaces [heartbeat_observation_error] and keeps
+   [last_heartbeat] null instead of substituting a fallback. *)
+let test_lightweight_snapshot_surfaces_heartbeat_read_error () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let keeper_name = "heartbeat-read-error" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_keepalive.stop_keepalive keeper_name;
+      Keeper_registry.For_testing.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Workspace.default_config base_dir in
+      init_runtime_default_for_snapshot base_dir;
+      ignore (Workspace.init config ~agent_name:(Some "operator"));
+      let meta =
+        match
+          Masc_test_deps.meta_of_json_fixture
+            (`Assoc
+              [ ("name", `String keeper_name)
+              ; ( "agent_name"
+                , `String (Keeper_identity.keeper_agent_name keeper_name) )
+              ; ("trace_id", `String "trace-heartbeat-read-error")
+              ])
+        with
+        | Ok meta -> { meta with paused = true }
+        | Error err -> Alcotest.fail ("keeper meta fixture failed: " ^ err)
+      in
+      (match Keeper_meta_store.replace_snapshot config meta with
+       | Ok () -> ()
+       | Error err -> Alcotest.fail err);
+      (* Corrupt the heartbeat metrics ledger: an invalid month directory is a
+         layout violation, so the persisted-snapshot read returns an error. *)
+      let metrics_dir =
+        Keeper_types_support.keeper_metrics_dir config keeper_name
+      in
+      let rec mkdir_p path =
+        if not (Sys.file_exists path)
+        then (
+          mkdir_p (Filename.dirname path);
+          Unix.mkdir path 0o755)
+      in
+      mkdir_p (Filename.concat metrics_dir "2026-13");
+      Operator_control.invalidate_snapshot_cache ();
+      let snapshot =
+        Operator_control.snapshot_json ~view:"summary" ~include_messages:false
+          ~include_keepers:true ~include_summary_fields:false
+          ~lightweight_summary:true
+          (operator_ctx env sw config "operator")
+      in
+      let open Yojson.Safe.Util in
+      let keeper =
+        snapshot |> member "keepers" |> member "items" |> to_list
+        |> List.find_opt (fun row -> row |> member "name" |> to_string = keeper_name)
+        |> Option.value ~default:`Null
+      in
+      Alcotest.(check bool) "keeper present" true (keeper <> `Null);
+      Alcotest.(check bool) "last_heartbeat is not relabeled" true
+        (keeper |> member "last_heartbeat" = `Null);
+      Alcotest.(check bool) "heartbeat observation error surfaced" true
+        (keeper |> member "heartbeat_observation_error" <> `Null))
+
 let test_diagnostic_uses_persisted_heartbeat_freshness () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
@@ -1546,6 +1614,10 @@ let () =
             "diagnostic uses persisted heartbeat freshness"
             `Quick
             test_diagnostic_uses_persisted_heartbeat_freshness;
+          Alcotest.test_case
+            "lightweight snapshot surfaces heartbeat read error"
+            `Quick
+            test_lightweight_snapshot_surfaces_heartbeat_read_error;
         ] );
       ( "context metrics ledger"
       , [ Alcotest.test_case


### PR DESCRIPTION
Propagate heartbeat read errors in the operator snapshot.

- `persisted_last_heartbeat_json` now returns `(json, error_opt)`; the operator row exposes `heartbeat_observation_error` instead of collapsing an unreadable ledger into a null `last_heartbeat`.
- dashboard `keeper-store-normalize.ts` stops substituting `agent.last_seen` when `heartbeat_observation_error` is present.
- Adds regression coverage `test_lightweight_snapshot_surfaces_heartbeat_read_error`.

Build green; operator_control_snapshot suite passes including the new test.