### PR TITLE
fix(runtime): antigravity 턴 완결을 EOF가 아니라 result 이벤트로 판정

### DIFF
--- a/lib/runtime/runtime_antigravity.ml
+++ b/lib/runtime/runtime_antigravity.ml
@@ -29,6 +29,15 @@ type config =
 let default_timeout_s = 300.0
 let process_termination_grace_s = 2.0
 
+(* How long a CLI that already delivered its result event may take to
+   exit before we reap it. A healthy CLI exits well under a second after
+   the result; the #28912 shutdown hang ("Waiting for migrations to
+   complete", a child language server holding stdout open) never exits at
+   all, so anything past this window is the hang, not slow work — the
+   turn itself is already complete and none of this wait is on the
+   critical path of a healthy turn. *)
+let result_exit_grace_s = 5.0
+
 (* [None] installs no deadline. The vendor client owns when its own turn ends;
    a declared bound is the operator's optional liveness guard over a silent
    client, not a limit on how long legitimate work may take. *)
@@ -689,7 +698,12 @@ let run_spawned ?home_dir ?on_spawned ~mgr ~clock ~cwd config ~conversation_mode
       if not !process_settled then signal_spawned_process proc stdin_w);
     let state = ref initial_protocol_state in
     (try
-       while true do
+       (* The result event completes the protocol — nothing after it is
+          attribution or content (apply_event rejects post-result events).
+          EOF cannot be the completion contract: the CLI's own shutdown can
+          hang while a child process keeps stdout open (#28912), which
+          turned already-served turns into idle timeouts. *)
+       while Option.is_none !state.result do
          let timeout_s =
            timeout_s_for_phase config ~turn_admitted:(Option.is_some !state.init)
          in
@@ -727,7 +741,19 @@ let run_spawned ?home_dir ?on_spawned ~mgr ~clock ~cwd config ~conversation_mode
        abort_with_runtime_error
          (Protocol_error
             { stage = "stdout read"; detail = Printexc.to_string exn }));
-    let status = Eio.Process.await proc in
+    let status =
+      (* Bounded: after a completed protocol (or EOF) a healthy CLI exits
+         almost immediately; a CLI stuck in its shutdown gets reaped. The
+         repeated await after terminate is safe — Eio.Process.await is
+         idempotent over the cached exit status. *)
+      try
+        Eio.Time.with_timeout_exn clock result_exit_grace_s (fun () ->
+          Eio.Process.await proc)
+      with
+      | Eio.Time.Timeout ->
+        Eio.Cancel.protect (fun () -> terminate_spawned_process ~clock proc stdin_w);
+        Eio.Process.await proc
+    in
     process_settled := true;
     status, !state, String.trim !stderr_tail)
 ;;
@@ -771,13 +797,17 @@ let run_turn ?(conversation_mode = Start) ?home_dir ?on_spawned ~mgr ~clock ~cwd
   let* status, state, stderr = run_result in
   let wall_duration_s = max 0.0 (Eio.Time.now clock -. started_at) in
   match status, state.init, state.result with
-  | `Exited 0, Some _, Some (Success, text, _, _, _)
+  (* A parsed Success result is the completion contract regardless of how
+     the process ended: the reply is already durable in the CLI's own
+     conversation store, and the exit status only describes the CLI's
+     shutdown (which can hang and get reaped, #28912). *)
+  | _, Some _, Some (Success, text, _, _, _)
     when not
            (Agent_core.Response_shape.has_deliverable_content
               (Agent_core.Response_shape.summarize_blocks
                  [ Agent_core.Types.Text text ])) ->
     Error (Turn_failed "successful result response has no deliverable content")
-  | `Exited 0, Some (conversation_id, model, permission_mode),
+  | _, Some (conversation_id, model, permission_mode),
     Some (Success, text, _, num_turns, usage) ->
     emit_stream_event on_stream_event (Turn_finished { text });
     Ok
@@ -798,11 +828,11 @@ let run_turn ?(conversation_mode = Start) ?home_dir ?on_spawned ~mgr ~clock ~cwd
   | _, Some _, Some (Result_error, _, error, _, _) ->
     let detail = match error with Some detail -> detail | None -> "status=ERROR" in
     Error (Turn_failed detail)
+  | _, None, Some _ ->
+    Error (Protocol_error { stage = "process completion"; detail = "missing init event" })
   | `Exited 0, _, None ->
     Error (Protocol_error { stage = "process completion"; detail = "missing result event" })
-  | `Exited 0, None, Some _ ->
-    Error (Protocol_error { stage = "process completion"; detail = "missing init event" })
-  | (`Exited _ | `Signaled _), _, _ ->
+  | (`Exited _ | `Signaled _), _, None ->
     let exit = status_to_string status in
     Error (Process_exited (if stderr = "" then exit else exit ^ ": " ^ stderr))
 ;;

--- a/test/test_runtime_antigravity.ml
+++ b/test/test_runtime_antigravity.ml
@@ -61,6 +61,8 @@ let fixture_script
     ?(sleep_s = 0.0)
     ?line_delay_s
     ?after_first_line_delay_s
+    ?stdout_holder_s
+    ?exit_delay_s
     ?(exit_code = 0)
     lines
   =
@@ -107,6 +109,15 @@ let fixture_script
            after_first_line_delay_s;
        output_string output ("printf '%s\\n' " ^ shell_quote line ^ "\n"))
     lines;
+  (* The two #28912 shutdown shapes: a background child inheriting stdout
+     (so EOF never arrives even though the CLI exits), and the CLI itself
+     stalling before exit. *)
+  Option.iter
+    (fun seconds -> output_string output (Printf.sprintf "sleep %.3f &\n" seconds))
+    stdout_holder_s;
+  Option.iter
+    (fun seconds -> output_string output (Printf.sprintf "sleep %.3f\n" seconds))
+    exit_delay_s;
   output_string output (Printf.sprintf "exit %d\n" exit_code);
   close_out output;
   Unix.chmod path 0o700;
@@ -114,7 +125,7 @@ let fixture_script
 ;;
 
 let with_fixture ?require_resume ?required_home ?sleep_s ?line_delay_s
-    ?after_first_line_delay_s ?exit_code lines f =
+    ?after_first_line_delay_s ?stdout_holder_s ?exit_delay_s ?exit_code lines f =
   let path =
     fixture_script
       ?require_resume
@@ -122,6 +133,8 @@ let with_fixture ?require_resume ?required_home ?sleep_s ?line_delay_s
       ?sleep_s
       ?line_delay_s
       ?after_first_line_delay_s
+      ?stdout_holder_s
+      ?exit_delay_s
       ?exit_code
       lines
   in
@@ -575,6 +588,29 @@ let test_live_start_and_resume () =
   | _ -> Alcotest.skip ()
 ;;
 
+(* #28912 first shape: the CLI exits after the result but a background
+   child inherited stdout, so EOF never arrives. Completion must come from
+   the parsed result event, not from EOF. *)
+let test_result_completes_even_when_stdout_stays_open () =
+  with_fixture ~stdout_holder_s:10.0 [ init (); result () ] (fun path ->
+    match run_fixture ~timeout_s:2.0 path with
+    | Error error -> fail (Runtime_antigravity.error_to_string error)
+    | Ok turn ->
+      check string "reply" "MASC_ANTIGRAVITY_OK\n" turn.Runtime_antigravity.text)
+;;
+
+(* #28912 second shape: the CLI itself never exits after the result
+   ("Waiting for migrations to complete"). The bounded exit grace reaps it
+   and the already-served turn still succeeds even though the process ends
+   by signal. *)
+let test_result_completes_when_the_cli_hangs_in_shutdown () =
+  with_fixture ~exit_delay_s:15.0 [ init (); result () ] (fun path ->
+    match run_fixture ~timeout_s:2.0 path with
+    | Error error -> fail (Runtime_antigravity.error_to_string error)
+    | Ok turn ->
+      check string "reply" "MASC_ANTIGRAVITY_OK\n" turn.Runtime_antigravity.text)
+;;
+
 let () =
   run
     "runtime_antigravity"
@@ -642,6 +678,14 @@ let () =
             "progress resets stream idle timeout"
             `Quick
             test_progress_resets_stream_idle_timeout
+        ; test_case
+            "result completes despite an open stdout holder"
+            `Quick
+            test_result_completes_even_when_stdout_stays_open
+        ; test_case
+            "result completes despite a shutdown hang"
+            `Quick
+            test_result_completes_when_the_cli_hangs_in_shutdown
         ; test_case
             "stream idle timeout is typed"
             `Quick


### PR DESCRIPTION
## 무엇 (#28912)
- \`lib/runtime/runtime_antigravity.ml\`:
  - 스트림 루프가 result 이벤트 파싱 시 탈출 (\`while Option.is_none !state.result\`) — EOF는 완결 계약이 될 수 없음 (자식 프로세스가 stdout을 상속한 채 CLI가 자기 종료에서 hang)
  - 프로세스 회수를 bounded로: 정상 CLI는 \`result_exit_grace_s\`(5s, 상수+근거 주석) 안에 스스로 exit, hang이면 기존 \`terminate_spawned_process\`(SIGTERM→2s→SIGKILL)로 reap
  - 성공 판정에서 \`Exited 0\` 요구 제거 — Success result가 파싱됐으면 exit status는 CLI 종료 방식일 뿐 (응답은 이미 CLI conversation store에 durable)
- 회귀 테스트 2종 (#28912의 두 hang 모양 그대로): stdout을 잡는 백그라운드 자식 + exit하지 않는 CLI — 리뷰어가 수정 전 트리에서 정확히 idle-timeout으로 FAIL함을 실측 확인

## RCA 근거 (#28912 코멘트의 4-probe 조사 + 단독 실행 확증 실험)
- 모든 실패에서 masc 에러 ts = CLI 마지막 stdout + **정확히 180.000s** (194s = ~14s 서빙 + 180s idle)
- fresh HOME 단독 실행 실측: result 17.71s 도착, EOF는 280s까지 없음

## latch에 대해 (리뷰 정정 반영)
recovery_required latch 메커니즘은 이 PR이 건드리지 않는다. latch는 \`Process_exited | Timeout → Transport_interrupted → Ambiguous → require_recovery\`로 여러 트리거를 갖고, **result-전 진짜 실패에서 latch를 찍는 것은 원래도 정당한 동작**이다. 이 PR이 닫는 것은 "result가 이미 파싱됐는데 EOF 부재로 Timeout이 나던" 오탐 경로 하나 — 그 오탐이 사라지므로 해당 시나리오의 부당한 latch도 함께 사라진다. antigravity에서 recovery_required는 병합 후에도 정당한 사유(#28918 포함)로 뜰 수 있다.

## 검증
- 신규 회귀 2건 포함 test_runtime_antigravity 23/24 OK — 유일 FAIL은 main에서도 동일 재현되는 기존 부하 flake(#28919), 별도 flake #28921도 등록
- test_keeper_antigravity_runtime 6/6, test_runtime_antigravity_home 9/9 green
- 리뷰어 검증: Eio.Process.await idempotency를 eio_posix 소스로 확인, 판정 매트릭스 exhaustiveness를 -warn-error로 확정, 수정 전 트리 FAIL 재현

## 후속 (별도)
- #28918: CLI를 아예 호출하지 않는 lane-resolution 결함 (이 수정과 무관)
- 병합 후 antigravity 재스윕은 --expect-runtime(#28914)으로 실서빙 검증하며 수행