### PR TITLE
fix(llm-provider): exact-output fingerprint 고정 테스트 수리 + agent_core inline suite CI 배선

### DIFF
--- a/packages/agent_core/lib/llm_provider/exact_output_plan.ml
+++ b/packages/agent_core/lib/llm_provider/exact_output_plan.ml
@@ -653,8 +653,15 @@ let%test "canonical fingerprint is sensitive to the frozen response codec" =
       ~admission_basis:(Measured_context_fit fit)
     |> fingerprint_to_string
   in
-  let v0_220_anthropic_fingerprint =
-    "d59eee4e9e01296bdea6b695c0e2d9ad1fcfd1ee5779777124a4379e4bc6d598"
+  (* Frozen over the [agent_core-exact-output-plan-v2] material domain. The
+     previous pin ([d59eee4e...], labeled v0.220) hashed the same material
+     under the [oas-exact-output-plan-v2] domain string; #27945 hard-cut the
+     oas name out of the fingerprint domain, which intentionally changed
+     every plan fingerprint. Any further mismatch here means the fingerprint
+     material drifted again — update this pin only for a deliberate,
+     commit-documented material change. *)
+  let agent_core_plan_v2_anthropic_fingerprint =
+    "a823aaf450989799c6af800e78fecb1fbc1a3a8f395315271776dd2225081b6f"
   in
   let anthropic_codec = Provider_http_codec.of_config config in
   let openai_codec =
@@ -665,5 +672,7 @@ let%test "canonical fingerprint is sensitive to the frozen response codec" =
       }
   in
   fingerprint anthropic_codec <> fingerprint openai_codec
-  && String.equal (fingerprint anthropic_codec) v0_220_anthropic_fingerprint
+  && String.equal
+       (fingerprint anthropic_codec)
+       agent_core_plan_v2_anthropic_fingerprint
 ;;

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -321,6 +321,11 @@ board_attention_targets=(
 
 agent_core_targets=(
   @packages/agent_core/test/runtest
+  # Recursive alias: runs the ppx_inline_test suites embedded in
+  # packages/agent_core/lib{,/base,/protocol,/llm_provider}. These were in no
+  # CI manifest, so the exact_output_plan fingerprint pin rotted silently
+  # after #27945 (masc#28897).
+  @packages/agent_core/lib/runtest
   @test/runtest-test_keeper_hooks_agent_core_introspection
   @test/runtest-test_keeper_execution_join
   @test/runtest-test_hitl_summary_worker


### PR DESCRIPTION
Closes #28897

## 재현
`dune runtest packages/agent_core/lib/llm_provider/ --root .` 실행 시 main에서 그대로 실패:

```
File "packages/agent_core/lib/llm_provider/exact_output_plan.ml", line 621:
canonical fingerprint is sensitive to the frozen response codec is false.
FAILED 1 / 3 tests
```

## 원인 커밋
**ea17e01c89 (#27945, `refactor(agent-core): hard-cut embedded execution ownership`, 2026-08-10)**

이 커밋이 fingerprint material의 domain-separation 문자열을
`oas-exact-output-plan-{v2,unmeasured-v1}` → `agent_core-exact-output-plan-*`로 일괄 개명하면서,
테스트가 고정해둔 기대값(`v0_220_anthropic_fingerprint = d59eee4e...`)은 옛 oas 도메인 값 그대로 남겨두었어요.

검증 방법: fingerprint material(길이-접두 인코딩)을 OCaml 밖에서 재구성해 sha256을 직접 계산했더니,

- 옛 문자열 `oas-exact-output-plan-v2`로 해시 → 고정값 `d59eee4e...`와 정확히 일치
- 현재 문자열 `agent_core-exact-output-plan-v2`로 해시 → 현재 테스트 출력 `a823aaf4...`와 바이트 단위 일치

즉 material의 다른 입력은 전부 그대로이고, 도메인 문자열 개명 하나가 원인이에요.

## 수리
- 개명은 hard-cut의 의도된 변경이라(oas 이름 부활 금지, fresh-state contract) 고정값을 새 도메인 기준 `a823aaf4...`로 재고정했어요. 상수 이름도 `agent_core_plan_v2_anthropic_fingerprint`로 바꾸고, 옛 pin의 유래와 "material이 또 바뀌면 커밋 근거와 함께 의도적으로만 갱신"이라는 주석을 남겼어요. 단언 자체(codec 민감도 + 정확한 pin)는 그대로 유지 — 완화 없음.
- 이 suite가 CI 어느 manifest에도 없어서 조용히 썩은 문제를 같이 닫았어요: `scripts/ci-run-focused-tests.sh`의 `agent_core_targets`에 재귀 alias `@packages/agent_core/lib/runtest`를 배선 (#28884/#28887의 named-target 방식과 동일 위치). 이 alias는 `lib{,/base,/protocol,/llm_provider}`의 ppx_inline_test suite를 전부 포함해요.

## 검증
- 수정 전 트리에서 `dune build --root . @packages/agent_core/lib/runtest` → exit 1 (이 실패 그대로) — 배선한 게이트가 실제로 잡는 것 확인
- 수정 후: 같은 타깃 exit 0, 원래 재현 명령 `dune runtest packages/agent_core/lib/llm_provider/ --root .` exit 0
- `scripts/audit-ci-test-targets.sh` → OK (331 CI targets, unwired baseline 변화 없음)
- `shellcheck scripts/ci-run-focused-tests.sh` → clean, `@fmt`에서 수정 파일 diff 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)
