### PR TITLE
docs(ops): :8935 재배포 runbook 신설 + stamp 지우는 대시보드 빌드 권고 제거

### DIFF
--- a/docs/COMMON-PITFALLS.md
+++ b/docs/COMMON-PITFALLS.md
@@ -55,7 +55,7 @@ Dashboard is a Preact+HTM SPA compiled with Vite. Common issues:
 
 **Always after dashboard changes:**
 ```bash
-cd dashboard && pnpm run build  # catches TypeScript errors
+cd dashboard && pnpm run typecheck  # catches TypeScript errors (tsc --noEmit)
 ```
 
 ## 4. Test Breakage From Refactoring (6 occurrences)
@@ -306,8 +306,10 @@ dune build --root .  # ✅ OCaml 빌드 성공
 # 1. OCaml 빌드
 dune build --root .
 
-# 2. Dashboard 빌드 (별도)
-cd dashboard && pnpm run build
+# 2. Dashboard 빌드 (별도) — raw `pnpm run build` 금지: vite emptyOutDir가
+#    assets/dashboard/.build-stamp를 지우고 wrapper만 stamp를 다시 쓴다.
+#    stamp가 없으면 /health dashboard_surface가 "missing"으로 고착된다.
+scripts/build-dashboard-if-needed.sh
 
 # 또는 자동 빌드 script 사용
 ./start-masc.sh --http  # pnpm 있으면 자동 빌드
@@ -316,13 +318,13 @@ cd dashboard && pnpm run build
 **CI에서:**
 ```bash
 scripts/build-dashboard-if-needed.sh
-# checks if dashboard/dist/ exists and is up-to-date
+# assets/dashboard/.build-stamp 기준으로 필요할 때만 재빌드하고 stamp를 갱신한다
 ```
 
 **Dashboard 변경 후 반드시:**
 ```bash
-cd dashboard && pnpm run build
-# TypeScript 컴파일 에러, type 불일치 등을 사전에 감지
+cd dashboard && pnpm run typecheck   # 타입 에러 사전 감지 (비파괴)
+../scripts/build-dashboard-if-needed.sh   # 실제 빌드는 wrapper로
 ```
 
 **Dev Server와 Production Build 차이 주의:**
@@ -333,8 +335,8 @@ cd dashboard && MASC_DASHBOARD_PROXY_TARGET="http://127.0.0.1:8935" pnpm run dev
 # Vite port를 5173이 아닌 값으로 바꾸면 서버 쪽 allowlist도 같이 맞춘다.
 MASC_HTTP_DEV_MUTATION_ORIGINS="http://localhost:4173" ./start-masc.sh
 
-# Production build (static assets in dist/)
-cd dashboard && pnpm run build
+# Production build (static assets: assets/dashboard/)
+scripts/build-dashboard-if-needed.sh
 ```
 
 ## 12. Health Snapshot Ratcheting
@@ -403,7 +405,7 @@ scripts/check-feature-flag-consistency.sh
 dune build --root .  # fails on missing modules
 
 # Dashboard routes
-cd dashboard && pnpm run build  # TypeScript type check
+cd dashboard && pnpm run typecheck  # TypeScript type check
 ```
 
 **Files requiring semantic validation:**

--- a/docs/REDEPLOY-8935-RUNBOOK.md
+++ b/docs/REDEPLOY-8935-RUNBOOK.md
@@ -1,0 +1,113 @@
+# :8935 재배포 Runbook
+
+`:8935`는 단일 운영 인스턴스이고 Cloudflare 터널(`masc.crying.pictures`, `masc-dev.crying.pictures`)이 직접 바라보는 대외 노출면이다 (`~/.cloudflared/config.yml`). `scripts/deploy.sh`는 별도 플레인(:8945, atomic lease handoff)용이며 이 문서의 대상이 아니다.
+
+## 0. 재배포 필요 판정
+
+```bash
+git -C <repo> ls-remote origin refs/heads/main
+curl -s http://127.0.0.1:8935/health | jq -r '.build.binary_commit, .build.binary_commit_source'
+```
+
+`binary_commit`은 빌드 타임에 임베드된다(`lib/build_commit/dune`의 `(universe)` rule → `lib/build_identity.ml`). `binary_commit_source`가 `embedded`이면 이 값이 곧 실행 중인 코드의 SHA다. 두 SHA가 같으면 재배포할 것이 없다.
+
+## 1. 기준선 스냅샷
+
+재기동 후 회귀 오판을 막기 위해 먼저 동결한다.
+
+```bash
+curl -s 'http://127.0.0.1:8935/health?full=1' > /tmp/health-before.json
+jq '{fibers:.keeper_fibers, fleet:.keeper_fleet_safety.status,
+     bootable:.keeper_fleet_safety.bootable_keeper_count,
+     blocker:.keeper_fleet_safety.blocker,
+     dash:.dashboard_surface.status}' /tmp/health-before.json
+```
+
+기존에 `degraded`였다면 재기동 후 `degraded`는 회귀가 아니다.
+
+## 2. main 동기화와 ancestry 확증
+
+```bash
+cd <repo> && git pull --rebase origin main
+git merge-base --is-ancestor <반드시-포함할-수리-SHA> HEAD && echo ANCESTOR_OK
+```
+
+ancestry 확증은 2026-08-16 운영 루프 2회차 사고(병합 파이프라인과 pull 경합으로 수리 커밋 미포함 checkout이 배포됨)의 재발 방지 단계다. 어떤 스크립트도 강제하지 않는 수동 단계이므로 생략하지 않는다.
+
+## 3. 빌드
+
+```bash
+./scripts/dune-local.sh build bin/main_eio.exe bin/deployment_preflight_helper.exe
+./scripts/build-dashboard-if-needed.sh
+```
+
+- 맨손 `dune build`는 금지 — wrapper가 `--root`를 고정하고 머신 전역 lock과 OCaml 버전 검증을 수행한다.
+- 대시보드는 raw `pnpm run build` 금지 — vite `emptyOutDir`가 `assets/dashboard/.build-stamp`를 지우고, stamp를 다시 쓰는 것은 wrapper뿐이다. stamp가 없으면 `/health`의 `dashboard_surface.status`가 `missing`으로 고착된다 (`lib/web_dashboard.ml`).
+
+## 4. keeper meta 스키마 정합 확인
+
+새 binary가 `Keeper_meta_json.current_field_names`에 필드를 추가했다면, 파서가 그 키를 필수로 요구하므로 기존 `<base>/.masc/keepers/*.json`이 전부 파싱 실패한다 (enum 자동 복구는 missing key를 못 고친다 — `lib/keeper/keeper_meta_store.ml`). 다운타임(6단계와 7단계 사이)에 store를 정합시킨다: 원본을 `<base>/.masc/_archive/`로 통째 보존한 뒤, 각 meta JSON에 새 키를 기본값(`null` 등 writer의 부재 표현)으로 주입한다.
+
+## 5. graceful shutdown
+
+HTTP로 프로세스를 내리는 경로는 없다. 유효한 경로는 SIGTERM/SIGINT뿐이다 (`bin/main_eio.ml`: NOTIFY → HOOKS → BOARD flush → CANCEL, 기본 예산 최대 10초).
+
+```bash
+kill -TERM $(lsof -ti tcp:8935 -sTCP:LISTEN)
+lsof -iTCP:8935 -sTCP:LISTEN   # 출력이 비면 내려간 것 — exit code로 판정하지 말 것
+```
+
+## 6. store preflight
+
+서버가 살아 있으면 writer lease 소유로 거부되므로 반드시 정지 후에 돌린다.
+
+```bash
+MASC_DEPLOYMENT_PREFLIGHT_HELPER=<repo>/_build/default/bin/deployment_preflight_helper.exe \
+  <repo>/scripts/check-runtime-deployment-preflight.sh --base-path <base>
+```
+
+성공 신호는 `[runtime-deployment-preflight] OK`. keeper 이벤트 큐/WAL 파싱, schedule ledger 계약, board attention candidate ledger `schema_version` 검사를 포함한다.
+
+## 7. 기동
+
+provider key가 로드된 interactive shell에서 실행한다. launchd 경로(`com.jeong-sik.masc-main`)는 `~/.zshenv`를 읽지 않아 provider 크리덴셜이 조용히 사라진다.
+
+```bash
+cd <repo>
+nohup ./scripts/start-loopback.sh --with-keeper-bootstrap \
+  > <base>/.masc/logs/masc-8935-$(date +%Y%m%d%H%M).out.log 2>&1 &
+```
+
+`--with-keeper-bootstrap`은 필수다 — `start-loopback.sh`는 상속된 `MASC_KEEPER_BOOTSTRAP_ENABLED`를 무시하고 기본 `false`로 덮으므로, 없이 올리면 autoboot keeper가 돌아오지 않는다.
+
+## 8. 검증
+
+```bash
+curl -s http://127.0.0.1:8935/health \
+  | jq '{v:.version, c:.build.binary_commit, src:.build.binary_commit_source,
+         dash:.dashboard_surface.status}'
+curl -s 'http://127.0.0.1:8935/health?full=1' \
+  | jq '{fibers:.keeper_fibers, fleet:.keeper_fleet_safety.status,
+         bootable:.keeper_fleet_safety.bootable_keeper_count}'
+```
+
+합격 기준:
+
+- `binary_commit` == 배포 의도 SHA, `binary_commit_source` == `embedded`
+- `dashboard_surface.status` == `ok`
+- `keeper_fibers`/`bootable_keeper_count`가 1단계 기준선으로 회복
+- 기동 로그에 keeper meta parse 실패가 없다 (`rg "meta parse" <로그>`)
+
+대시보드 TopBar는 같은 `/health` 필드를 읽는다. 브라우저 스크린샷은 보조 증거로 남긴다.
+
+## 함정 요약
+
+| 함정 | 결과 |
+|---|---|
+| `start-loopback.sh`에 `--with-keeper-bootstrap` 누락 | fleet이 빈 채로 기동 |
+| launchd로 재기동 | provider key 소실 (keeper.env는 2줄뿐) |
+| raw `pnpm run build` | `.build-stamp` 소실 → dashboard `missing` 고착 |
+| 맨손 `dune build` (worktree 안) | 상위 repo를 빌드하는 거짓 검증 |
+| ancestry 미확증 pull | 수리 커밋 없는 checkout 배포 (08-16 2회차 사고) |
+| meta 스키마 확장 후 store 미정합 | 전 keeper meta 파싱 실패 |
+| 포트 판정을 lsof exit code로 | 거짓 판정 — 출력 존재로 판정할 것 |


### PR DESCRIPTION
## 배경

재배포 준비 중 확인한 문서 결함 2건이에요.

1. **:8935 재배포 절차가 어느 문서에도 없음** — evidence JSON들과 매트릭스 서사에 흩어진 부족지식뿐이었어요. `docs/REDEPLOY-8935-RUNBOOK.md`로 명문화: embedded `binary_commit` 기반 필요 판정 → 기준선 스냅샷 → ancestry 확증(08-16 2회차 사고 재발 방지 단계) → `dune-local.sh`/`build-dashboard-if-needed.sh` 빌드 → keeper meta 스키마 정합 → SIGTERM drain → store preflight → `start-loopback.sh --with-keeper-bootstrap` 기동 → health 검증, 함정 7종 표.

2. **COMMON-PITFALLS가 파괴적 명령을 권고** — `cd dashboard && pnpm run build`를 5곳에서 권하는데, vite `emptyOutDir`가 `assets/dashboard/.build-stamp`를 지우고 stamp를 다시 쓰는 건 wrapper뿐이라 이 권고를 따르면 `/health`의 `dashboard_surface`가 `missing`으로 고착돼요. 타입 체크는 `pnpm run typecheck`(비파괴)로, 빌드는 wrapper로 교체하고, 존재하지 않는 `dashboard/dist/` 경로도 정정했어요.

## 검증

- 문서 전용. 패치는 anchor exactly-once assert 6건.
- runbook의 각 단계는 이번 세션에서 실측·파일 근거로 확인한 내용이에요 (lease 거부 실측, /health build 필드 실측, start-loopback 기본값·stamp wrapper 파일 확인).

🤖 Generated with [Claude Code](https://claude.com/claude-code)