### PR TITLE
fix(scripts): start-loopback가 bash 3.2에서 인자 없이 죽는 문제 수리

### DIFF
--- a/scripts/start-loopback.sh
+++ b/scripts/start-loopback.sh
@@ -33,4 +33,4 @@ done
 
 export MASC_KEEPER_BOOTSTRAP_ENABLED="$keeper_bootstrap_enabled"
 
-exec "$REPO_ROOT/start-masc.sh" --http --host 127.0.0.1 --port 8935 "${args[@]}"
+exec "$REPO_ROOT/start-masc.sh" --http --host 127.0.0.1 --port 8935 ${args[@]+"${args[@]}"}


### PR DESCRIPTION
## 증상

오늘 :8935 재배포 중 실제로 맞은 결함이에요. 문서화된 재기동 경로대로 `./scripts/start-loopback.sh --with-keeper-bootstrap`만 주고 실행하면:

```
./scripts/start-loopback.sh: line 36: args[@]: unbound variable
```

macOS `/bin/bash`(3.2)에서 `set -u` + 빈 배열 `"${args[@]}"" 확장이 에러가 나요. 패스스루 인자가 하나라도 있으면 통과하기 때문에 지금까지 안 드러났던 것 같아요.

## 수리

`${args[@]+"${args[@]}"}` 가드로 교체 — 빈 배열이면 아무것도 확장하지 않고, bash 4.4+에서는 동작 차이가 없어요.

## 검증

- bash 3.2 재현: `bash -uc 'args=(); echo "${args[@]}"'` → unbound variable
- 가드 검증: `bash -uc 'args=(); set -- ${args[@]+"${args[@]}"}; echo $#'` → 0
- `bash -n` 문법 통과, shellcheck 무경고
- 실전: 오늘 재배포에서 `-- --eio` 패스스루 우회로 기동했고, 이 수리가 우회를 제거해요

🤖 Generated with [Claude Code](https://claude.com/claude-code)