### PR TITLE
ci(test): audit-confirmed 18개 스위트를 CI focused-tests allowlist에 등록

### DIFF
--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=548
+UNWIRED_BASELINE=530
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -314,6 +314,27 @@ normal_targets=(
   @test/runtest-test_dated_jsonl
   @test/runtest-test_audit_log
   @test/keeper_github_identity/runtest
+  # Declared in Dune, compiled every run, never executed before this batch
+  # (masc#28925 audit). Each target below was run individually against this
+  # worktree and confirmed green before being added here.
+  @test/runtest-test_keeper_memory_os_current
+  @test/runtest-test_keeper_msg_async_path_traversal
+  @test/runtest-test_keeper_msg_async_durable_active_inventory
+  @test/runtest-test_keeper_mutex_coverage
+  @test/runtest-test_board_karma_ledger
+  @test/runtest-test_board_vote_persistence
+  @test/runtest-test_keeper_event_queue
+  @test/runtest-test_keeper_event_queue_owner_lock
+  @test/runtest-test_keeper_event_queue_persist_poison
+  @test/runtest-test_keeper_event_queue_state_v2
+  @test/runtest-test_keeper_connector_attention_wake
+  @test/runtest-test_keeper_external_attention
+  @test/runtest-test_keeper_manual_compaction_preemption
+  @test/runtest-test_keeper_compaction_unit
+  @test/runtest-test_keeper_compaction_persist_gate
+  @test/runtest-test_keeper_overflow_recovery
+  @test/runtest-test_keeper_post_turn_wirein_order
+  @test/runtest-test_keeper_checkpoint_purge
 )
 
 board_attention_targets=(


### PR DESCRIPTION
## 배경

masc CI는 catch-all `dune test`가 없고 `scripts/ci-run-focused-tests.sh`의 이름 지정 스위트만 실행한다. #28925 감사에서 확인된, 결함 표면을 실제로 덮지만 컴파일만 되고 한 번도 실행되지 않던 스위트들을 등록한다.

## 추가한 스위트 (18개, 각각 개별 `dune build --root . @test/runtest-<name>`로 로컬 PASS 확인)

| 스위트 | 결과 | 비고 |
|---|---|---|
| test_keeper_memory_os_current | PASS (22 tests, 16s) | Memory OS CAS 회귀 |
| test_keeper_msg_async_path_traversal | PASS (3 tests, 4s) | async durable |
| test_keeper_msg_async_durable_active_inventory | PASS (4 tests, 3s) | async durable |
| test_keeper_mutex_coverage | PASS (45 tests, 5s) | async recovery 단언 보유 |
| test_board_karma_ledger | PASS (19 tests, 5s) | karma 영속성 |
| test_board_vote_persistence | PASS (6 tests, 4s) | 투표 영속성 |
| test_keeper_event_queue | PASS (78 ASSERT, exit 0, 4s) | 커스텀 러너, drain queue |
| test_keeper_event_queue_owner_lock | PASS (12 ASSERT, exit 0, 3s) | drain queue |
| test_keeper_event_queue_persist_poison | PASS (exit 0, 4s) | drain queue |
| test_keeper_event_queue_state_v2 | PASS (17 tests, 3s) | drain queue |
| test_keeper_connector_attention_wake | PASS (5 tests, 3s) | counterpart |
| test_keeper_external_attention | PASS (4 tests, 4s) | counterpart |
| test_keeper_manual_compaction_preemption | PASS (4 tests, 4s) | 압축 |
| test_keeper_compaction_unit | PASS (30 tests, 4s) | 압축 |
| test_keeper_compaction_persist_gate | PASS (4 tests, 4s) | 압축 (`stanzas/*.inc` 경유) |
| test_keeper_overflow_recovery | PASS (4 tests, 3s) | 압축 |
| test_keeper_post_turn_wirein_order | PASS (12 tests, 6s) | 압축 (`stanzas/*.inc` 경유) |
| test_keeper_checkpoint_purge | PASS (16 tests, 4s) | 압축 |

`test_keeper_event_queue*` 세 개는 Alcotest가 아니라 커스텀 러너(`all tests passed` / `OK` 출력)라 테스트 개수 대신 ASSERT 라인 수와 exit code로 표기했다.

전부 `normal_targets` 배열 끝에 새 블록으로 추가했다(paused/board-attention/agent-core/operator/sse 그룹과는 무관한 표준 `masc_test_deps` 스위트라서).

## 스킵한 스위트 (2개)

- **test_keeper_msg_async_terminal_event**: 로컬 실행 시 FAIL. `settlement carries BasePath identity` assertion이 `/var/folders/...`를 기대하는데 실제로는 `/private/var/folders/...`를 받음 — macOS에서 `/tmp`가 `/private/tmp`로 symlink되는 것과 같은 종류의 경로 정규화 문제로 보인다. 수정은 이 PR 범위 밖이라 등록하지 않았다.
- **test_keeper_compact_audit**: 지시에 따라 제외 (척살 예정 모듈이 대상).

## CI 배선 확인

`scripts/ci-run-focused-tests.sh`는 `.github/workflows/ci.yml:1376`에서 인자 없이 직접 호출되는 구조라, 스크립트에 타겟을 추가하는 것만으로 CI가 실행한다. `ci.yml` 자체는 건드리지 않았다.

## 래칫 갱신

`scripts/audit-ci-test-targets.sh`의 `UNWIRED_BASELINE`을 548에서 530으로 낮췄다. 스크립트를 실제로 두 번 실행해 측정한 값이다 (편집 전 548 at baseline, 편집 후 350 CI targets / 530 unwired, 정확히 18 감소로 이번에 추가한 개수와 일치).

```
# 편집 전
[ci-test-targets] OK - 332 CI targets, all declared in Dune
[ci-test-targets] OK - 548 suites unwired, at baseline

# 편집 후 (baseline 갱신 전)
[ci-test-targets] OK - 350 CI targets, all declared in Dune
[ci-test-targets] FAIL - 530 suites unwired, under the 548 baseline by 18

# baseline=530으로 갱신 후
[ci-test-targets] OK - 350 CI targets, all declared in Dune
[ci-test-targets] OK - 530 suites unwired, at baseline
```

## 건드리지 않은 것

- 테스트 코드 자체 (`test/*.ml`, `test/stanzas/*.inc`)는 수정하지 않았다.
- `.github/workflows/ci.yml`은 수정하지 않았다 (스크립트 등록만으로 실행되는 구조 확인됨).
- 실패한 `test_keeper_msg_async_terminal_event`는 고치지 않고 스킵만 했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
