### PR TITLE
fix(redaction): GitHub 토큰 redaction 3중 공백 수리 (#28925 감사)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -135,6 +135,7 @@
   dated_jsonl
   masc_http_client
   masc_log
+  masc_secret_patterns
   masc_types
   masc_core
   masc_gate

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -237,8 +237,19 @@ type chat_message = {
          reads as [None]; the row stays valid. *)
 }
 
+(* The GitHub CLI credential ([hosts.yml]) lives outside the generic keeper
+   secret projection roots (see [Keeper_github_identity]), so the plain
+   [snapshot] never captured it and a [gh] token could reach chat rows
+   unmasked (#28925 gap 2). The execute-output path already snapshots it
+   ([Keeper_tool_execute_runtime]); this brings the chat sink to parity. *)
 let redaction_for ~base_dir ~keeper_name =
-  Keeper_secret_redaction.snapshot ~base_path:base_dir ~keeper_name
+  Keeper_secret_redaction.snapshot_with_additional_secret_files
+    ~additional_secret_files:
+      (Keeper_github_identity.secret_files_of_base_path
+         ~base_path:base_dir
+         ~keeper_name)
+    ~base_path:base_dir
+    ~keeper_name
 
 let redact_attachment redaction att =
   { att with data = Keeper_secret_redaction.redact_text redaction att.data }

--- a/lib/keeper/keeper_github_identity.ml
+++ b/lib/keeper/keeper_github_identity.ml
@@ -23,16 +23,33 @@ type observation =
   ; checked_at_unix : float
   }
 
+let config_dir_name = "github-cli"
+
 let config_dir ~config ~keeper_name =
   Filename.concat
     (Filename.concat (Workspace.keepers_runtime_dir config) keeper_name)
-    "github-cli"
+    config_dir_name
+;;
+
+(* Base-path variant for callers that hold only [base_path] (e.g. the chat
+   store's redaction snapshot). Default-cluster on purpose, matching
+   [Common.keepers_runtime_dir_of_base]: the chat store's secret projection
+   roots are already base-path scoped, so this keeps both snapshot sources
+   on the same cluster resolution. *)
+let config_dir_of_base_path ~base_path ~keeper_name =
+  Filename.concat
+    (Filename.concat (Common.keepers_runtime_dir_of_base ~base_path) keeper_name)
+    config_dir_name
+;;
+
+let secret_files_of_base_path ~base_path ~keeper_name =
+  [ Filename.concat (config_dir_of_base_path ~base_path ~keeper_name) "hosts.yml" ]
 ;;
 
 let container_config_dir ~container_masc_dir ~keeper_name =
   Filename.concat
     (Filename.concat (Filename.concat container_masc_dir "keepers") keeper_name)
-    "github-cli"
+    config_dir_name
 ;;
 
 let file_kind_to_string = function

--- a/lib/keeper/keeper_github_identity.mli
+++ b/lib/keeper/keeper_github_identity.mli
@@ -22,6 +22,14 @@ type observation =
 
 val config_dir : config:Workspace.config -> keeper_name:string -> string
 val container_config_dir : container_masc_dir:string -> keeper_name:string -> string
+
+val secret_files_of_base_path : base_path:string -> keeper_name:string -> string list
+(** Paths of the GitHub CLI files that can hold credentials ([hosts.yml])
+    for callers that hold only [base_path] (default cluster). Intended as
+    [additional_secret_files] input for
+    {!Keeper_secret_redaction.snapshot_with_additional_secret_files};
+    missing files are ignored there, so the paths are safe to pass
+    unconditionally. *)
 val ensure_config_dir : config:Workspace.config -> keeper_name:string -> (string, string) result
 val overlay_config_env : config_dir:string -> string array -> string array
 val projected_config_dir : string array -> string option

--- a/lib/masc_log/console_sink.ml
+++ b/lib/masc_log/console_sink.ml
@@ -96,6 +96,11 @@ let queue_depth () =
   n
 
 let write line =
+  (* Sink-level structural secret masking (#28925 gap 3). The console mirror
+     is redirected to a file in production (nohup > masc-server.log), so it
+     is a recording path too and must mask independently of the ring —
+     [Log] hands it the raw pre-[Ring.push] line. *)
+  let line = Secret_patterns.redact_text line in
   if not (Atomic.get enqueue_active)
   then current_writer () line
   else begin

--- a/lib/masc_log/dune
+++ b/lib/masc_log/dune
@@ -8,4 +8,4 @@
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4) + unused-value ratchet (warning 32)
  (flags
   (:standard -w +4 -w +33 -w +37))
- (libraries unix threads.posix yojson time_compat eio fs_compat))
+ (libraries unix threads.posix yojson time_compat eio fs_compat masc_secret_patterns))

--- a/lib/masc_log/log.ml
+++ b/lib/masc_log/log.ml
@@ -640,6 +640,15 @@ module Ring = struct
       ~module_name
       ~message
       () =
+    (* Sink-level structural secret masking (#28925 gap 3). The ring is the
+       single record source for both the dashboard log API and the JSONL
+       file sink ([entry_to_json] reads the stored entry), so masking here
+       covers every recording path regardless of which emit wrapper was
+       used. Exact keeper-secret values cannot be masked at this layer —
+       masc_log is a leaf and never sees keeper secret roots; those are
+       masked upstream by [Keeper_secret_redaction]. *)
+    let message = Secret_patterns.redact_text message in
+    let details = Secret_patterns.redact_json_strings details in
     let seq = Atomic.fetch_and_add total 1 in
     let idx = seq mod capacity in
     let entry = {

--- a/lib/observability_redact.ml
+++ b/lib/observability_redact.ml
@@ -2,135 +2,17 @@
 
     Truncation plus structural secret redaction. Every tool call remains
     observable; tool names never decide whether evidence exists.
-    Uses [Re] (thread-safe) instead of [Str]. *)
+
+    The pattern layer (secret-shaped prefixes, PEM blocks, sensitive JSON
+    keys) lives in [Secret_patterns] — a leaf library shared with the
+    [masc_log] sink — and is delegated to below so the pattern list has a
+    single source of truth. *)
 
 let default_max_len = 200
 
-let sensitive_keys =
-  [ "access_token"
-  ; "api_key"
-  ; "api_token"
-  ; "apikey"
-  ; "authorization"
-  ; "client_secret"
-  ; "credential"
-  ; "credentials"
-  ; "password"
-  ; "passwd"
-  ; "private_key"
-  ; "refresh_token"
-  ; "secret"
-  ; "token"
-  ]
+let is_sensitive_key = Secret_patterns.is_sensitive_key
 
-let is_sensitive_key key =
-  let lower = String.lowercase_ascii key in
-  List.exists (String.equal lower) sensitive_keys
-
-(** URL credential pattern — ://user:pass@ *)
-let url_credential_re =
-  Re.compile (Re.seq [Re.str "://"; Re.rep1 (Re.compl [Re.set "@ "]); Re.char '@'])
-
-(** Common secret-bearing value patterns — structural prefixes only.
-
-    Each pattern identifies a secret by its *structure* (a known prefix family
-    or the [://user:pass@] URL shape), not by a length heuristic. The former
-    generic "20+ alphanumeric run" matcher was removed: it classified ordinary
-    identifiers (keeper names, commit hashes, task ids) as secrets by length
-    alone, erasing them from observability fields, while every real prefix it
-    caught is already matched here in one shot (e.g. [sk-proj-...] via the
-    [sk-] body below). Known secret *values* loaded from the environment remain
-    redacted exactly by {!Keeper_secret_redaction}, which does not rely on this
-    heuristic.
-
-    Specific prefix regexes are hoisted to module level so they are compiled
-    once at init, not rebuilt on every [redact_text] call. [Re] is thread-safe
-    (see file header), so sharing compiled regexes across fibers/domains is
-    safe — [url_credential_re] already does this. *)
-let bearer_re =
-  Re.compile (Re.seq [Re.str "Bearer "; Re.rep1 (Re.compl [Re.set " \t\r\n"])])
-
-let sk_re =
-  Re.compile (Re.seq [Re.bow; Re.str "sk-"; Re.rep1 (Re.alt [Re.alnum; Re.char '-'])])
-
-let awsakia_re =
-  Re.compile (Re.seq [Re.bow; Re.str "AKIA"; Re.repn Re.alnum 16 (Some 16); Re.eow])
-
-let pem_marker_pairs =
-  [ "-----BEGIN PRIVATE KEY-----", "-----END PRIVATE KEY-----"
-  ; "-----BEGIN RSA PRIVATE KEY-----", "-----END RSA PRIVATE KEY-----"
-  ]
-
-let find_substring_from haystack needle start =
-  let needle_len = String.length needle in
-  if needle_len = 0
-  then Some start
-  else (
-    let haystack_len = String.length haystack in
-    let max_start = haystack_len - needle_len in
-    let rec loop idx =
-      if idx > max_start
-      then None
-      else if String.sub haystack idx needle_len = needle
-      then Some idx
-      else loop (idx + 1)
-    in
-    if start > max_start then None else loop start)
-
-let redact_between_markers ~begin_marker ~end_marker s =
-  let begin_len = String.length begin_marker in
-  let end_len = String.length end_marker in
-  let s_len = String.length s in
-  let buf = Buffer.create s_len in
-  let rec loop pos =
-    match find_substring_from s begin_marker pos with
-    | None ->
-        Buffer.add_substring buf s pos (s_len - pos);
-        Buffer.contents buf
-    | Some start ->
-        Buffer.add_substring buf s pos (start - pos);
-        Buffer.add_string buf "[REDACTED]";
-        let after_begin = start + begin_len in
-        (match find_substring_from s end_marker after_begin with
-         | None -> Buffer.contents buf
-         | Some stop -> loop (stop + end_len))
-  in
-  loop 0
-
-let redact_pem_blocks s =
-  List.fold_left
-    (fun acc (begin_marker, end_marker) ->
-       redact_between_markers ~begin_marker ~end_marker acc)
-    s
-    pem_marker_pairs
-
-(** Common secret-bearing value patterns. Specific prefixes are listed before
-    any generic matcher so short, well-known tokens are not missed when they
-    are embedded inside larger strings.
-
-    Each prefix literal is anchored at a word boundary ([Re.bow]) so a
-    word-internal substring is not mistaken for a key. Without the anchor, the
-    [sk-] pattern matched the substring [sk-1234] inside the task id
-    [task-1234] and redacted it to [ta\[REDACTED\]], destroying diagnostic
-    identifiers in error previews (and any other observability field carrying a
-    [task-XXXX] reference). [bow] rejects that match because [sk-] is preceded
-    by the identifier char 'a'. [Re.bow]/[eow] are zero-width assertions, so
-    [Re.replace_string] preserves the boundary character (=, space, quote)
-    automatically. The [sk-] body allows [-] so modern [sk-proj-...] keys are
-    matched in one shot instead of leaving a [-abc...] tail. [AKIA] is anchored
-    at both ends so a 17-char run is not truncated to its first 16 chars. *)
-let secret_res () =
-  [ url_credential_re
-  ; bearer_re
-  ; sk_re
-  ; awsakia_re
-  ]
-
-let redact_patterns (s : string) : string =
-  List.fold_left
-    (fun acc re -> Re.replace_string re ~by:"[REDACTED]" acc)
-    (redact_pem_blocks s)
-    (secret_res ())
+let redact_patterns = Secret_patterns.redact_text
 
 let redact_text (s : string) : string =
   redact_patterns s
@@ -181,17 +63,7 @@ let rec preview_json_strings ?(max_len = default_max_len) (json : Yojson.Safe.t)
   | `List items -> `List (List.map (preview_json_strings ~max_len) items)
   | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _) as j -> j
 
-let rec redact_json_strings = function
-  | `String s -> `String (redact_text s)
-  | `Assoc fields ->
-      `Assoc
-        (List.map
-           (fun (key, value) ->
-             if is_sensitive_key key then (key, `String "[REDACTED]")
-             else (key, redact_json_strings value))
-           fields)
-  | `List items -> `List (List.map redact_json_strings items)
-  | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _) as json -> json
+let redact_json_strings = Secret_patterns.redact_json_strings
 
 let rec redact_json_value = function
   | `Assoc fields ->

--- a/lib/secret_patterns/dune
+++ b/lib/secret_patterns/dune
@@ -1,0 +1,20 @@
+; Secret_patterns — structural secret masking shared by every sink.
+;
+; Extracted from Observability_redact so leaf sinks (masc_log) can mask
+; secret-shaped values without depending on the main masc library, which
+; itself depends on masc_log. Observability_redact delegates here, so the
+; pattern list stays a single source of truth.
+;
+; Keep this library's dependencies to re + yojson. A dependency added here
+; is inherited by masc_log and therefore by every module that logs.
+
+(include_subdirs no)
+
+(library
+ (name masc_secret_patterns)
+ (public_name masc.secret_patterns)
+ (wrapped false)
+ (modules secret_patterns)
+ (flags
+  (:standard -w +4 -w +33))
+ (libraries re yojson))

--- a/lib/secret_patterns/secret_patterns.ml
+++ b/lib/secret_patterns/secret_patterns.ml
@@ -1,0 +1,172 @@
+(** Secret_patterns — structural secret masking shared by every sink.
+
+    Moved verbatim from [Observability_redact] (which now delegates here)
+    so [masc_log] can mask without depending on the main masc library.
+    Uses [Re] (thread-safe) instead of [Str]. *)
+
+let sensitive_keys =
+  [ "access_token"
+  ; "api_key"
+  ; "api_token"
+  ; "apikey"
+  ; "authorization"
+  ; "client_secret"
+  ; "credential"
+  ; "credentials"
+  ; "password"
+  ; "passwd"
+  ; "private_key"
+  ; "refresh_token"
+  ; "secret"
+  ; "token"
+  ]
+
+let is_sensitive_key key =
+  let lower = String.lowercase_ascii key in
+  List.exists (String.equal lower) sensitive_keys
+
+(** URL credential pattern — ://user:pass@ *)
+let url_credential_re =
+  Re.compile (Re.seq [Re.str "://"; Re.rep1 (Re.compl [Re.set "@ "]); Re.char '@'])
+
+(** Common secret-bearing value patterns — structural prefixes only.
+
+    Each pattern identifies a secret by its *structure* (a known prefix family
+    or the [://user:pass@] URL shape), not by a length heuristic. The former
+    generic "20+ alphanumeric run" matcher was removed: it classified ordinary
+    identifiers (keeper names, commit hashes, task ids) as secrets by length
+    alone, erasing them from observability fields, while every real prefix it
+    caught is already matched here in one shot (e.g. [sk-proj-...] via the
+    [sk-] body below). Known secret *values* loaded from the environment remain
+    redacted exactly by {!Keeper_secret_redaction}, which does not rely on this
+    heuristic.
+
+    Specific prefix regexes are hoisted to module level so they are compiled
+    once at init, not rebuilt on every [redact_text] call. [Re] is thread-safe
+    (see file header), so sharing compiled regexes across fibers/domains is
+    safe — [url_credential_re] already does this. *)
+let bearer_re =
+  Re.compile (Re.seq [Re.str "Bearer "; Re.rep1 (Re.compl [Re.set " \t\r\n"])])
+
+let sk_re =
+  Re.compile (Re.seq [Re.bow; Re.str "sk-"; Re.rep1 (Re.alt [Re.alnum; Re.char '-'])])
+
+let awsakia_re =
+  Re.compile (Re.seq [Re.bow; Re.str "AKIA"; Re.repn Re.alnum 16 (Some 16); Re.eow])
+
+(* GitHub token prefixes, per the official token-format table
+   (docs.github.com "About authentication to GitHub", checked 2026-08-17):
+   [ghp_] classic PAT, [github_pat_] fine-grained PAT, [gho_] OAuth access
+   token, [ghu_] GitHub App user token, [ghs_] App installation token,
+   [ghr_] App refresh token.
+
+   The body includes [.] and [-] besides [alnum]/[_] because the stateless
+   installation-token format ([ghs_APPID_JWT], staged rollout from
+   2026-04-27) embeds a JWT: without [.] in the body the match would stop at
+   the first dot and leave the JWT payload and signature bytes visible.
+   Lengths are deliberately unconstrained — GitHub documents the 40-char
+   assumption as already broken by the stateless format, and a masking layer
+   must not leak a token because it is longer or shorter than expected. *)
+let github_token_re =
+  Re.compile
+    (Re.seq
+       [ Re.bow
+       ; Re.alt
+           [ Re.str "github_pat_"
+           ; Re.str "ghp_"
+           ; Re.str "gho_"
+           ; Re.str "ghu_"
+           ; Re.str "ghs_"
+           ; Re.str "ghr_"
+           ]
+       ; Re.rep1 (Re.alt [ Re.alnum; Re.set "_-." ])
+       ])
+
+let pem_marker_pairs =
+  [ "-----BEGIN PRIVATE KEY-----", "-----END PRIVATE KEY-----"
+  ; "-----BEGIN RSA PRIVATE KEY-----", "-----END RSA PRIVATE KEY-----"
+  ]
+
+let find_substring_from haystack needle start =
+  let needle_len = String.length needle in
+  if needle_len = 0
+  then Some start
+  else (
+    let haystack_len = String.length haystack in
+    let max_start = haystack_len - needle_len in
+    let rec loop idx =
+      if idx > max_start
+      then None
+      else if String.sub haystack idx needle_len = needle
+      then Some idx
+      else loop (idx + 1)
+    in
+    if start > max_start then None else loop start)
+
+let redact_between_markers ~begin_marker ~end_marker s =
+  let begin_len = String.length begin_marker in
+  let end_len = String.length end_marker in
+  let s_len = String.length s in
+  let buf = Buffer.create s_len in
+  let rec loop pos =
+    match find_substring_from s begin_marker pos with
+    | None ->
+        Buffer.add_substring buf s pos (s_len - pos);
+        Buffer.contents buf
+    | Some start ->
+        Buffer.add_substring buf s pos (start - pos);
+        Buffer.add_string buf "[REDACTED]";
+        let after_begin = start + begin_len in
+        (match find_substring_from s end_marker after_begin with
+         | None -> Buffer.contents buf
+         | Some stop -> loop (stop + end_len))
+  in
+  loop 0
+
+let redact_pem_blocks s =
+  List.fold_left
+    (fun acc (begin_marker, end_marker) ->
+       redact_between_markers ~begin_marker ~end_marker acc)
+    s
+    pem_marker_pairs
+
+(** Common secret-bearing value patterns. Specific prefixes are listed before
+    any generic matcher so short, well-known tokens are not missed when they
+    are embedded inside larger strings.
+
+    Each prefix literal is anchored at a word boundary ([Re.bow]) so a
+    word-internal substring is not mistaken for a key. Without the anchor, the
+    [sk-] pattern matched the substring [sk-1234] inside the task id
+    [task-1234] and redacted it to [ta\[REDACTED\]], destroying diagnostic
+    identifiers in error previews (and any other observability field carrying a
+    [task-XXXX] reference). [bow] rejects that match because [sk-] is preceded
+    by the identifier char 'a'. [Re.bow]/[eow] are zero-width assertions, so
+    [Re.replace_string] preserves the boundary character (=, space, quote)
+    automatically. The [sk-] body allows [-] so modern [sk-proj-...] keys are
+    matched in one shot instead of leaving a [-abc...] tail. [AKIA] is anchored
+    at both ends so a 17-char run is not truncated to its first 16 chars. *)
+let secret_res () =
+  [ url_credential_re
+  ; bearer_re
+  ; sk_re
+  ; awsakia_re
+  ; github_token_re
+  ]
+
+let redact_text (s : string) : string =
+  List.fold_left
+    (fun acc re -> Re.replace_string re ~by:"[REDACTED]" acc)
+    (redact_pem_blocks s)
+    (secret_res ())
+
+let rec redact_json_strings = function
+  | `String s -> `String (redact_text s)
+  | `Assoc fields ->
+      `Assoc
+        (List.map
+           (fun (key, value) ->
+             if is_sensitive_key key then (key, `String "[REDACTED]")
+             else (key, redact_json_strings value))
+           fields)
+  | `List items -> `List (List.map redact_json_strings items)
+  | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _) as json -> json

--- a/lib/secret_patterns/secret_patterns.mli
+++ b/lib/secret_patterns/secret_patterns.mli
@@ -1,0 +1,22 @@
+(** Secret_patterns — structural secret masking shared by every sink.
+
+    Pattern-based replacement of secret-shaped values with [\[REDACTED\]].
+    This is masking only: patterns never classify, route, or gate behavior.
+    Extracted from [Observability_redact] (which delegates here) so leaf
+    sinks such as [masc_log] can mask without a dependency cycle. Exact
+    secret *values* loaded from keeper secret roots are handled separately
+    by [Keeper_secret_redaction]. *)
+
+val redact_text : string -> string
+(** Replace known secret-shaped substrings (URL credentials, [Bearer]
+    values, [sk-]/[AKIA] keys, GitHub tokens, PEM private-key blocks)
+    with [\[REDACTED\]]. Never truncates or trims. *)
+
+val is_sensitive_key : string -> bool
+(** Case-insensitive exact match against the sensitive JSON key list
+    (token, api_key, password, ...). *)
+
+val redact_json_strings : Yojson.Safe.t -> Yojson.Safe.t
+(** Recursively apply {!redact_text} to string leaves and replace
+    sensitive-key fields with [\[REDACTED\]], preserving structure and
+    without truncation. *)

--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -4,7 +4,7 @@
   "keeper_mli_missing": 13,
   "workspace_mli_missing": 2,
   "godsplit_count": 0,
-  "lib_dune_lines": 190,
+  "lib_dune_lines": 191,
   "inferred_dump_headers": 0,
   "lib_other_mli_missing": 0
 }

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -458,6 +458,53 @@ let test_append_turn_redacts_projected_secrets () =
       Alcotest.(check bool) "redaction marker present" true
         (String_util.contains_substring rendered "[REDACTED]"))
 
+(* #28925 gap 2: the GitHub CLI credential lives in
+   [.masc/keepers/<name>/github-cli/hosts.yml], outside the generic secret
+   projection roots, so the plain [snapshot] never captured it. The token
+   value here is deliberately NOT GitHub-prefix shaped so the structural
+   pattern layer cannot mask it — only the exact-value hosts.yml snapshot
+   can, which is exactly what this test pins. *)
+let test_append_turn_redacts_github_hosts_token () =
+  let base_dir = temp_base_path "keeper-chat-store-gh-hosts" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      with_env "MASC_SECRET_DIR" "" @@ fun () ->
+      let keeper_name = "keeper-chat-gh-hosts" in
+      let gh_token = "hosts.yml-only.credential.42" in
+      let hosts_path =
+        match
+          Masc.Keeper_github_identity.secret_files_of_base_path
+            ~base_path:base_dir ~keeper_name
+        with
+        | [ path ] -> path
+        | paths ->
+          Alcotest.failf "expected one github secret file, got %d"
+            (List.length paths)
+      in
+      write_file hosts_path
+        (String.concat "\n"
+           [ "github.com:"
+           ; "    user: keeper-bot"
+           ; "    oauth_token: " ^ gh_token
+           ; "    git_protocol: https"
+           ; "" ]);
+      K.append_turn ~base_dir ~keeper_name
+        ~user_content:"show me the gh credential"
+        ~user_attachments:[]
+        ~tool_calls:[]
+        ~assistant_content:("the token is " ^ gh_token)
+        ();
+      let raw = read_file (chat_path ~base_dir ~keeper_name) in
+      Alcotest.(check bool) "hosts.yml token not persisted" false
+        (String_util.contains_substring raw gh_token);
+      let messages = K.load ~base_dir ~keeper_name in
+      let rendered = Yojson.Safe.to_string (K.to_json_array messages) in
+      Alcotest.(check bool) "loaded view stays redacted" false
+        (String_util.contains_substring rendered gh_token);
+      Alcotest.(check bool) "redaction marker present" true
+        (String_util.contains_substring rendered "[REDACTED]"))
+
 let test_load_redacts_raw_persisted_secret_rows () =
   let base_dir = temp_base_path "keeper-chat-store-read-redact" in
   Fun.protect
@@ -2312,6 +2359,8 @@ let () =
             test_direct_owner_context_excludes_connector_turns;
           Alcotest.test_case "append_turn redacts projected secrets" `Quick
             test_append_turn_redacts_projected_secrets;
+          Alcotest.test_case "append_turn redacts github hosts.yml token"
+            `Quick test_append_turn_redacts_github_hosts_token;
           Alcotest.test_case "load redacts raw persisted secret rows" `Quick
             test_load_redacts_raw_persisted_secret_rows;
           Alcotest.test_case "window counts primaries only" `Quick

--- a/test/test_masc_log.ml
+++ b/test/test_masc_log.ml
@@ -130,6 +130,51 @@ let test_entry_to_json_keeper_name_some_preserves () =
   in
   Alcotest.(check string) "keeper_name Some preserved" "my-keeper" keeper_name_val
 
+(* Local helper: this binary intentionally depends only on masc_log +
+   alcotest-adjacent modules, so no String_util import. *)
+let contains_substring haystack needle =
+  let h = String.length haystack and n = String.length needle in
+  let rec go i = i + n <= h && (String.sub haystack i n = needle || go (i + 1)) in
+  n = 0 || go 0
+
+let newest_entry ~module_name =
+  match Log.Ring.recent ~limit:1 ~module_filter:module_name () with
+  | entry :: _ -> entry
+  | [] -> Alcotest.fail "no ring entry recorded"
+
+(* #28925 gap 3: the recording path (ring + JSONL file sink render the same
+   stored entry) must mask secret-shaped values at the sink, regardless of
+   which emit wrapper produced the record. Token literals are concatenated
+   synthetic values, not live credentials. *)
+let test_push_masks_github_token_in_message () =
+  let module_name = "TestLogRedactMsg" in
+  let token = "ghp_" ^ "16C7e42F292c6912E7710c838347Ae178B4a" in
+  Log.info ~ctx:module_name "deploy used %s" token;
+  let entry = newest_entry ~module_name in
+  Alcotest.(check bool) "token body absent from ring" false
+    (contains_substring entry.message "16C7e42F292c6912");
+  Alcotest.(check bool) "redaction marker present" true
+    (contains_substring entry.message "[REDACTED]")
+
+let test_push_masks_secrets_in_details () =
+  let module_name = "TestLogRedactDetails" in
+  let token = "github_pat_" ^ "11ABCDEFG0abcdefghijkl" in
+  Log.emit Log.Info ~module_name
+    ~details:
+      (`Assoc
+         [ ("note", `String ("auth via " ^ token))
+         ; ("api_key", `String "plain-value-that-must-not-persist")
+         ])
+    "details redaction probe";
+  let entry = newest_entry ~module_name in
+  let rendered = Yojson.Safe.to_string entry.details in
+  Alcotest.(check bool) "token absent from details leaf" false
+    (contains_substring rendered "11ABCDEFG0abcdefghijkl");
+  Alcotest.(check bool) "sensitive key value replaced" false
+    (contains_substring rendered "plain-value-that-must-not-persist");
+  Alcotest.(check bool) "marker present" true
+    (contains_substring rendered "[REDACTED]")
+
 let () =
   Alcotest.run "Masc_log" [
     ( "ring",
@@ -146,5 +191,9 @@ let () =
         Alcotest.test_case
           "entry_to_json: keeper_name=Some preserves value"
           `Quick test_entry_to_json_keeper_name_some_preserves;
+        Alcotest.test_case "push masks github token in message" `Quick
+          test_push_masks_github_token_in_message;
+        Alcotest.test_case "push masks secrets in details" `Quick
+          test_push_masks_secrets_in_details;
       ] );
   ]

--- a/test/test_observability_redact.ml
+++ b/test/test_observability_redact.ml
@@ -289,6 +289,55 @@ let test_sk_modern_key_fully_redacted () =
   Alcotest.(check bool) "no partial sk- tail leak" true
     (not (String_util.contains_substring r "0123456789abcdef"))
 
+(* GitHub token prefixes per the official token-format table
+   (docs.github.com "About authentication to GitHub"): ghp_ classic PAT,
+   github_pat_ fine-grained PAT, gho_/ghu_/ghs_/ghr_ app-family tokens.
+   Token literals are concatenated so tooling does not mistake them for live
+   credentials; they are synthetic test values. *)
+let test_github_classic_tokens_redacted () =
+  List.iter
+    (fun prefix ->
+      let token = prefix ^ "16C7e42F292c6912E7710c838347Ae178B4a" in
+      let r = Observability_redact.redact_text ("pushed with " ^ token) in
+      Alcotest.(check bool) (prefix ^ " token body masked") true
+        (not (String_util.contains_substring r "16C7e42F292c6912"));
+      Alcotest.(check bool) (prefix ^ " marker present") true
+        (String_util.contains_substring r "[REDACTED]"))
+    [ "ghp_"; "gho_"; "ghu_"; "ghs_"; "ghr_" ]
+
+let test_github_fine_grained_token_redacted () =
+  let token =
+    "github_pat_" ^ "11ABCDEFG0abcdefghijkl_"
+    ^ "mnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456"
+  in
+  let r = Observability_redact.redact_text ("auth: " ^ token) in
+  Alcotest.(check bool) "fine-grained body masked" true
+    (not (String_util.contains_substring r "11ABCDEFG0abcdefghijkl"))
+
+(* Stateless installation tokens (ghs_APPID_JWT, staged rollout from
+   2026-04-27) embed a JWT: the body must swallow the '.' separators or the
+   payload and signature segments survive the mask. *)
+let test_github_stateless_installation_token_redacted () =
+  let token =
+    "ghs_" ^ "1234567_" ^ "eyJhbGciOiJSUzI1NiJ9" ^ "."
+    ^ "eyJpc3MiOiJnaXRodWIifQ" ^ "." ^ "c2lnbmF0dXJlLWJ5dGVz"
+  in
+  let r = Observability_redact.redact_text ("install token " ^ token) in
+  Alcotest.(check bool) "jwt payload masked" true
+    (not (String_util.contains_substring r "eyJpc3MiOiJnaXRodWIifQ"));
+  Alcotest.(check bool) "jwt signature masked" true
+    (not (String_util.contains_substring r "c2lnbmF0dXJlLWJ5dGVz"))
+
+let test_github_prefix_no_false_positive () =
+  (* Word-internal runs must not match ([Re.bow] anchor), mirroring the
+     sk-/task-id contract above. *)
+  let inputs = [ "github_pathway_notes"; "highslide_ghs"; "morphology" ] in
+  List.iter
+    (fun input ->
+      let r = Observability_redact.redact_text input in
+      Alcotest.(check string) (input ^ " preserved") input r)
+    inputs
+
 let () =
   Alcotest.run "observability_redact"
     [
@@ -322,6 +371,14 @@ let () =
             test_no_false_positive_on_keeper_identities;
           Alcotest.test_case "modern sk- key fully redacted" `Quick
             test_sk_modern_key_fully_redacted;
+          Alcotest.test_case "github classic tokens redacted" `Quick
+            test_github_classic_tokens_redacted;
+          Alcotest.test_case "github fine-grained token redacted" `Quick
+            test_github_fine_grained_token_redacted;
+          Alcotest.test_case "github stateless installation token redacted"
+            `Quick test_github_stateless_installation_token_redacted;
+          Alcotest.test_case "github prefixes no false positive" `Quick
+            test_github_prefix_no_false_positive;
         ] );
       ( "tool_observability",
         [


### PR DESCRIPTION
## 배경

#28925 소스 감사에서 GitHub 토큰 redaction 공백 3건이 확인되었어요. 셋이 겹치면 `gh` 자격 증명이 채팅 기록이나 로그에 그대로 실릴 수 있는 구조라, 세 층을 각각 막았습니다.

## 감사 주장 검증 (3건 모두 CONFIRMED)

| # | 주장 | 확인 위치 |
|---|------|----------|
| 1 | GitHub 토큰 접두사 패턴 미등록 | `observability_redact.ml`의 `secret_res` 목록에 `url_credential`/`Bearer`/`sk-`/`AKIA`/PEM만 존재 |
| 2 | 채팅 스냅샷이 `hosts.yml` 미포함 | `keeper_chat_store.ml:240`이 plain `snapshot`만 호출. `hosts.yml`은 secret projection root 밖(`.masc/keepers/<name>/github-cli/`)이라 exact-value 캡처에서 빠짐. execute-output 경로는 이미 포함(`keeper_tool_execute_runtime.ml:516`) |
| 3 | `masc_log` 기록 경로 redaction 부재 | `lib/masc_log/log.ml`의 `Ring.push`(ring + JSONL sink 공통 소스)와 console mirror 어디에도 redaction 없음 |

## 수정 내용

### 1. GitHub 토큰 패턴 등록
- 공식 문서(docs.github.com "About authentication to GitHub", 2026-08-17 확인) 기준 접두사 6종: `ghp_`, `github_pat_`, `gho_`, `ghu_`, `ghs_`, `ghr_`
- 본문 문자셋에 `.`/`-` 포함 — 2026-04-27부터 단계 도입된 stateless `ghs_APPID_JWT` 형식에서 첫 `.`에서 매칭이 끊기면 JWT payload/signature가 남는 문제를 막기 위해서예요
- 길이 제한 없음 — 공식 문서가 40자 가정을 이미 깨진 것으로 안내
- 패턴은 마스킹에만 쓰이고 분류/라우팅에는 쓰이지 않아요 (기존 `sk-`/`AKIA`와 같은 계약)

### 2. 채팅 스냅샷에 hosts.yml 포함
- `Keeper_github_identity.secret_files_of_base_path` 헬퍼 추가 (경로 SSOT는 identity 모듈이 소유)
- `keeper_chat_store.redaction_for`가 `snapshot_with_additional_secret_files`로 전환 — execute-output 경로와 동등해집니다
- `github-cli` 경로 리터럴은 `config_dir_name` 상수로 통일

### 3. masc_log sink 레벨 redaction
- 구조 패턴 레이어를 leaf 라이브러리 `lib/secret_patterns`(re + yojson만 의존)로 이동 — `masc_log`는 leaf라 `Observability_redact`(masc 본체)를 볼 수 없어서, 패턴 목록의 SSOT를 유지하면서 양쪽이 공유하는 구조예요. `Observability_redact`는 위임으로 전환되고 `.mli` 표면은 그대로입니다
- `Ring.push`에서 message/details 마스킹 (ring이 dashboard API와 JSONL sink의 단일 소스)
- `Console_sink.write`에서 mirror 라인 마스킹 (production에서 nohup으로 파일에 리다이렉트되는 기록 경로)
- 단, keeper별 exact secret 값은 이 층에서 볼 수 없어요 — 그건 상위의 `Keeper_secret_redaction` 담당이고, 이 층은 구조 패턴만 맡습니다

## 테스트

각 sink별 feature test를 추가했고, 수정 전 상태에서 실제로 실패하는 것을 확인했어요.

| Suite | 추가 케이스 | 수정 전 | 수정 후 |
|-------|------------|--------|--------|
| `test_observability_redact` | classic 5종 / fine-grained / stateless JWT / false-positive 부재 | FAIL 3건 | PASS |
| `test_keeper_chat_store` | 패턴 비매칭 hosts.yml 토큰이 chat 기록에서 마스킹 (exact-value 경로 고립 검증) | FAIL | PASS (59 tests) |
| `test_masc_log` | ring message / details 마스킹 + sensitive key 치환 | FAIL 2건 | PASS |

블라스트 반경 스위트 18종(console_sink, log_file_sink_self_heal, log_ring_encoder, system_log_atomicity, keeper_secret_redaction, keeper_secret_projection, boundary_redaction_runtime_lane, env_keeper_scrub, wire_capture ×2, exec_command_gate_log_sink, audit_log, keeper_tool_call_log, raw_trace_sink, error_logging_coverage 등) 전부 green, 전체 `dune build` green입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
