### PR TITLE
refactor(keeper): work-as-hb max-silence 노브와 write-only freshness 시계 척살

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -471,13 +471,6 @@ module WorkAsHeartbeat = struct
       unified turn counts as presence proof, allowing the next cycle to skip
       the full ensure_keeper_workspace_presence call. *)
   let enabled = Feature_flag_registry.get_bool "MASC_KEEPER_WORK_AS_HEARTBEAT"
-
-  (** Maximum seconds since last successful workspace heartbeat before presence
-      sync is required again. Floor = keepalive interval (dynamic). *)
-  let max_silence_sec =
-    let floor = Float.of_int keepalive_interval_sec_ in
-    Float.max floor (get_float ~default:300.0 "MASC_KEEPER_MAX_SILENCE_SEC")
-  ;;
 end
 
 (** {1 Keeper health policy} *)

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -161,7 +161,6 @@ end
 
 module WorkAsHeartbeat : sig
   val enabled : bool
-  val max_silence_sec : float
 end
 
 (** {1 Keeper health policy} *)

--- a/lib/config/keeper_runtime_setting_registry.ml
+++ b/lib/config/keeper_runtime_setting_registry.ml
@@ -177,13 +177,16 @@ let all =
       "Keeper heartbeat cycle interval in seconds"
   ; setting
       ~range:(float_range ~min:0.0 ())
+      ~lifecycle:
+        (retired
+           "No runtime reader consumed this window; the freshness clock it was meant to bound had no reader either")
       ~env_name:"MASC_KEEPER_MAX_SILENCE_SEC"
       ~exposure:(Toml_and_env "heartbeat.max_silence_sec")
       ~value_kind:Float
-      ~default:"300.0"
-      ~consumers:[ "Env_config_keeper.WorkAsHeartbeat"; "Keeper_heartbeat_loop" ]
+      ~default:"(removed)"
+      ~consumers:[]
       ~category:"heartbeat"
-      "Maximum age of workspace presence proof"
+      "Removed workspace presence proof age overlay"
   ; setting
       ~range:(int_range ~min:15 ~max:3600 ())
       ~env_name:"MASC_KEEPER_SNAPSHOT_SEC"

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -1122,13 +1122,7 @@ let run_heartbeat_loop
   in
   let timing_cursor = ref 0 in
   let timing_filled = ref 0 in
-  (* Phase 1: work-as-heartbeat freshness tracking.
-     Updated ONLY on Workspace.heartbeat success after turn. *)
-  let last_successful_heartbeat_ts = ref (Time_compat.now ()) in
   let work_as_hb () = Runtime_params.get Runtime_settings.keeper_work_as_hb_enabled in
-  let _max_silence () =
-    Runtime_params.get Runtime_settings.keeper_work_as_hb_max_silence_sec
-  in
   (* Persistent AGENT_CORE Context.t — created once per keeper lifecycle.
      AGENT_CORE Context.t is a mutable cross-turn state container for values
      written directly into the shared context. This preserves shared
@@ -1192,7 +1186,6 @@ let run_heartbeat_loop
             ~ctx
             ~meta_current
             ~consecutive_failures
-            ~last_successful_heartbeat_ts
         in
         if !consecutive_failures > 0
         then
@@ -1380,10 +1373,9 @@ let run_heartbeat_loop
                  (Some (Keeper_registry.Turn_consecutive_failures turn_fail_count));
              (* Phase 1: work-as-heartbeat — renew point (b).
                 After turn, call Workspace.heartbeat to prove workspace I/O health.
-                On success: refresh freshness lease + reset consecutive_failures.
-                On failure: leave timestamp unchanged → presence sync resumes next cycle.
+                On success: reset consecutive_failures.
                 T6 audit: a crashed cycle proves nothing about health — do not
-                refresh the lease or reset consecutive_failures for it. *)
+                reset consecutive_failures for it. *)
              (match work_heartbeat_action with
               | Refresh_work_heartbeat ->
                refresh_work_as_heartbeat
@@ -1391,7 +1383,6 @@ let run_heartbeat_loop
                  ~meta_after_proactive
                  ~proactive_warmup_elapsed
                  ~work_as_hb
-                 ~last_successful_heartbeat_ts
                  ~consecutive_failures
               | Preserve_work_heartbeat ->
                Log.Keeper.info

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -20,7 +20,6 @@ val sync_keeper_presence :
   ctx:'a context ->
   meta_current:keeper_meta ->
   consecutive_failures:int ref ->
-  last_successful_heartbeat_ts:float ref ->
   keeper_meta
 
 val collect_keepalive_board_events :
@@ -219,7 +218,6 @@ val refresh_work_as_heartbeat :
   meta_after_proactive:keeper_meta ->
   proactive_warmup_elapsed:bool ->
   work_as_hb:(unit -> bool) ->
-  last_successful_heartbeat_ts:float ref ->
   consecutive_failures:int ref ->
   unit
 

--- a/lib/keeper/keeper_heartbeat_loop_presence.ml
+++ b/lib/keeper/keeper_heartbeat_loop_presence.ml
@@ -187,13 +187,11 @@ let sync_keeper_presence
       ~(ctx : _ context)
       ~(meta_current : keeper_meta)
       ~(consecutive_failures : int ref)
-      ~(last_successful_heartbeat_ts : float ref)
   : keeper_meta
   =
   try
     let synced = meta_current in
     consecutive_failures := 0;
-    last_successful_heartbeat_ts := Time_compat.now ();
     Keeper_registry.dispatch_event_unit
       ~base_path:ctx.config.base_path
       meta_current.name

--- a/lib/keeper/keeper_heartbeat_loop_presence.mli
+++ b/lib/keeper/keeper_heartbeat_loop_presence.mli
@@ -25,6 +25,5 @@ val sync_keeper_presence :
   ctx:'a Keeper_types_profile.context ->
   meta_current:Keeper_meta_contract.keeper_meta ->
   consecutive_failures:int ref ->
-  last_successful_heartbeat_ts:float ref ->
   Keeper_meta_contract.keeper_meta
 (** Publish keeper heartbeat presence and update failure counters. *)

--- a/lib/keeper/keeper_heartbeat_loop_refresh_work.ml
+++ b/lib/keeper/keeper_heartbeat_loop_refresh_work.ml
@@ -28,7 +28,6 @@ let refresh_work_as_heartbeat
       ~(meta_after_proactive : keeper_meta)
       ~(proactive_warmup_elapsed : bool)
       ~(work_as_hb : unit -> bool)
-      ~(last_successful_heartbeat_ts : float ref)
       ~(consecutive_failures : int ref)
   : unit
   =
@@ -57,8 +56,5 @@ let refresh_work_as_heartbeat
           (Printexc.to_string exn);
         false
     in
-    if hb_ok
-    then (
-      last_successful_heartbeat_ts := Time_compat.now ();
-      consecutive_failures := 0))
+    if hb_ok then consecutive_failures := 0)
 ;;

--- a/lib/keeper/keeper_heartbeat_loop_refresh_work.mli
+++ b/lib/keeper/keeper_heartbeat_loop_refresh_work.mli
@@ -5,7 +5,6 @@ val refresh_work_as_heartbeat :
   meta_after_proactive:Keeper_meta_contract.keeper_meta ->
   proactive_warmup_elapsed:bool ->
   work_as_hb:(unit -> bool) ->
-  last_successful_heartbeat_ts:float ref ->
   consecutive_failures:int ref ->
   unit
 (** Treat recent productive work as heartbeat evidence when a regular

--- a/lib/keeper_runtime/keeper_runtime_config.ml
+++ b/lib/keeper_runtime/keeper_runtime_config.ml
@@ -467,8 +467,6 @@ let effective_setting_value (row : Keeper_runtime_setting_registry.setting) =
          display_bool (Feature_flag_registry.get_bool row.env_name)
        | "MASC_KEEPER_HEARTBEAT_INTERVAL_SEC" ->
          display_int Env_config_keeper.KeeperKeepalive.interval_sec
-       | "MASC_KEEPER_MAX_SILENCE_SEC" ->
-         display_float Env_config_keeper.WorkAsHeartbeat.max_silence_sec
        | "MASC_KEEPER_SNAPSHOT_SEC" ->
          display_int Env_config_keeper.KeeperRuntime.snapshot_sec
        | "MASC_KEEPER_WORK_AS_HEARTBEAT" ->

--- a/lib/runtime_settings.ml
+++ b/lib/runtime_settings.ml
@@ -247,16 +247,6 @@ let keeper_work_as_hb_enabled =
             min_value = None; max_value = None }
     ()
 
-let keeper_work_as_hb_max_silence_sec =
-  register_float
-    ~key:"keeper.work_as_hb_max_silence_sec"
-    ~default:(fun () -> Env_config_keeper.WorkAsHeartbeat.max_silence_sec)
-    ~min:10.0 ~max:600.0
-    ~meta:{ description = "Work-as-heartbeat 최대 침묵 시간(초)";
-            value_type = "float";
-            min_value = Some (`Float 10.0); max_value = Some (`Float 600.0) }
-    ()
-
 let keeper_stage_timing_ring_size =
   register_int
     ~key:"keeper.stage_timing_ring_size"
@@ -292,7 +282,6 @@ let surfaces =
       param_keys = [
         "keeper.snapshot_sec";
         "keeper.work_as_hb_enabled";
-        "keeper.work_as_hb_max_silence_sec";
         "keeper.stage_timing_ring_size";
       ];
     };

--- a/lib/runtime_settings.mli
+++ b/lib/runtime_settings.mli
@@ -39,10 +39,6 @@ val keeper_snapshot_sec : int Runtime_params.param
 val keeper_work_as_hb_enabled : bool Runtime_params.param
 (** Enable work-as-heartbeat fallback. *)
 
-val keeper_work_as_hb_max_silence_sec : float Runtime_params.param
-(** Maximum silence allowed in work-as-heartbeat mode (seconds).
-    Range \[10.0, 600.0\]. *)
-
 val keeper_stage_timing_ring_size : int Runtime_params.param
 (** Stage-timing ring buffer size.  Applied on fiber restart only —
     runtime mutation requires keeper restart.  Range \[10, 1000\]. *)

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -596,8 +596,7 @@ let test_fresh_presence_preserves_turn_failures () =
         (Masc.Keeper_heartbeat_loop.sync_keeper_presence
            ~ctx
            ~meta_current:meta
-           ~consecutive_failures:(ref 0)
-           ~last_successful_heartbeat_ts:(ref 99.0));
+           ~consecutive_failures:(ref 0));
       check int
         "turn failures preserved"
         1

--- a/test/test_keeper_runtime_config_leaf.ml
+++ b/test/test_keeper_runtime_config_leaf.ml
@@ -43,6 +43,7 @@ let test_resolve_overrides_keeps_env_precedence () =
 let retired_toml_keys =
   [ "autonomous.fairness_cooldown_sec"
   ; "heartbeat.board_wakeup_max"
+  ; "heartbeat.max_silence_sec"
   ; "turn.cli_subprocess_idle_sec"
   ; "turn.capacity_limit"
   ; "turn.max_output_tokens"

--- a/test/test_runtime_params.ml
+++ b/test/test_runtime_params.ml
@@ -452,13 +452,11 @@ let () =
     match diag_surface with
     | None -> Alcotest.fail "keeper_diagnostics surface not found"
     | Some s ->
-        Alcotest.(check int) "param count" 4 (List.length s.param_keys);
+        Alcotest.(check int) "param count" 3 (List.length s.param_keys);
         Alcotest.(check bool) "has snapshot_sec"
           true (List.mem "keeper.snapshot_sec" s.param_keys);
         Alcotest.(check bool) "has work_as_hb_enabled"
           true (List.mem "keeper.work_as_hb_enabled" s.param_keys);
-        Alcotest.(check bool) "has work_as_hb_max_silence_sec"
-          true (List.mem "keeper.work_as_hb_max_silence_sec" s.param_keys);
         Alcotest.(check bool) "has stage_timing_ring_size"
           true (List.mem "keeper.stage_timing_ring_size" s.param_keys)
   in

--- a/test/test_work_as_heartbeat.ml
+++ b/test/test_work_as_heartbeat.ml
@@ -1,5 +1,5 @@
 (** Test suite for Phase 1: Work-as-heartbeat config defaults,
-    freshness decision logic, and Phase 0 percentile function.
+    keepalive cycle actions, and Phase 0 percentile function.
 
     Note: env_config values are top-level let bindings, evaluated once at
     program start. Runtime putenv does NOT affect them. Tests verify defaults
@@ -18,19 +18,6 @@ let test_wah_enabled_default () =
   check bool "work-as-heartbeat enabled by default"
     true Cfg.WorkAsHeartbeat.enabled
 
-let test_wah_max_silence_default () =
-  (* MASC_KEEPER_MAX_SILENCE_SEC not set in test env → default 300.0 *)
-  let v = Cfg.WorkAsHeartbeat.max_silence_sec in
-  check (float 0.1) "default max silence 300s" 300.0 v
-
-let test_wah_max_silence_floor_logic () =
-  (* The floor clamp uses keepalive interval dynamically.
-     We verify: max_silence_sec >= keepalive_interval_sec always. *)
-  let v = Cfg.WorkAsHeartbeat.max_silence_sec in
-  let interval = Float.of_int Cfg.KeeperKeepalive.interval_sec in
-  check bool "max_silence >= keepalive interval"
-    true (v >= interval)
-
 let keeper_setting env_name =
   match
     List.find_opt
@@ -46,11 +33,7 @@ let test_keepalive_registry_defaults_match_runtime () =
   let interval = keeper_setting "MASC_KEEPER_HEARTBEAT_INTERVAL_SEC" in
   check string "interval registry default matches runtime"
     (string_of_int Cfg.KeeperKeepalive.interval_sec)
-    interval.default_display;
-  let max_silence = keeper_setting "MASC_KEEPER_MAX_SILENCE_SEC" in
-  check (float 0.1) "max-silence registry default matches runtime"
-    Cfg.WorkAsHeartbeat.max_silence_sec
-    (float_of_string max_silence.default_display)
+    interval.default_display
 ;;
 
 (* ── KeeperKeepalive config defaults ───────────────────── *)
@@ -153,58 +136,10 @@ let test_timing_ring_size_range () =
 
 (* ── Config invariant properties ───────────────────────── *)
 
-let test_config_invariant_silence_ge_interval () =
-  let silence = Cfg.WorkAsHeartbeat.max_silence_sec in
-  let interval = Float.of_int Cfg.KeeperKeepalive.interval_sec in
-  check bool "max_silence >= interval (invariant)" true (silence >= interval)
-
 let test_config_invariant_sweep_independent () =
   let sweep = Cfg.KeeperSupervisor.sweep_interval_sec in
   check bool "sweep > 0" true (sweep > 0.0)
 
-
-(* ── Freshness decision pure logic ──────────────────────── *)
-
-let test_freshness_fresh () =
-  let now = 100.0 in
-  let last_hb = 50.0 in
-  let max_silence = 120.0 in
-  let fresh = now -. last_hb < max_silence in
-  check bool "50s ago < 120s window → fresh" true fresh
-
-let test_freshness_stale () =
-  let now = 200.0 in
-  let last_hb = 50.0 in
-  let max_silence = 120.0 in
-  let fresh = now -. last_hb < max_silence in
-  check bool "150s ago >= 120s window → stale" false fresh
-
-let test_freshness_exact_boundary () =
-  let now = 170.0 in
-  let last_hb = 50.0 in
-  let max_silence = 120.0 in
-  let fresh = now -. last_hb < max_silence in
-  check bool "exactly 120s → NOT fresh (< is strict)" false fresh
-
-let test_freshness_never_heartbeated () =
-  (* Initial last_hb = 0.0. At unix epoch + 200s:
-     200.0 - 0.0 = 200.0 >= 120.0 → stale.
-     This correctly forces initial presence sync. *)
-  let now = 200.0 in
-  let last_hb = 0.0 in
-  let max_silence = 120.0 in
-  let fresh = now -. last_hb < max_silence in
-  check bool "never heartbeated (0.0) → stale → forces presence sync"
-    false fresh
-
-let test_freshness_disabled_flag () =
-  (* When work_as_hb = false, presence_fresh is always false regardless of timestamp *)
-  let work_as_hb = false in
-  let now = 100.0 in
-  let last_hb = 99.0 in
-  let max_silence = 120.0 in
-  let fresh = work_as_hb && (now -. last_hb < max_silence) in
-  check bool "feature disabled → always stale" false fresh
 
 let test_completed_cycle_records_and_refreshes () =
   match
@@ -279,8 +214,6 @@ let () =
   run "work_as_heartbeat" [
     "config", [
       test_case "enabled default" `Quick test_wah_enabled_default;
-      test_case "max_silence default" `Quick test_wah_max_silence_default;
-      test_case "max_silence floor invariant" `Quick test_wah_max_silence_floor_logic;
       test_case "registry defaults match runtime" `Quick
         test_keepalive_registry_defaults_match_runtime;
     ];
@@ -307,13 +240,6 @@ let () =
       test_case "timing_ring default" `Quick test_timing_ring_size_default;
       test_case "timing_ring range" `Quick test_timing_ring_size_range;
     ];
-    "freshness_logic", [
-      test_case "within window → fresh" `Quick test_freshness_fresh;
-      test_case "beyond window → stale" `Quick test_freshness_stale;
-      test_case "exact boundary → stale (strict <)" `Quick test_freshness_exact_boundary;
-      test_case "never heartbeated → stale" `Quick test_freshness_never_heartbeated;
-      test_case "feature disabled → always stale" `Quick test_freshness_disabled_flag;
-    ];
     "cycle_action", [
       test_case
         "completed records and refreshes work-heartbeat"
@@ -329,7 +255,6 @@ let () =
         test_busy_cycle_defers_typed_block;
     ];
     "config_invariants", [
-      test_case "max_silence >= interval" `Quick test_config_invariant_silence_ge_interval;
       test_case "sweep interval positive" `Quick test_config_invariant_sweep_independent;
     ];
     "percentile", [

--- a/test/test_workspace_heartbeat_outcome.ml
+++ b/test/test_workspace_heartbeat_outcome.ml
@@ -11,8 +11,8 @@
 
     The keeper's work-as-heartbeat refresher treated any call that did not
     raise as proof that a session-bound workspace was writable, and a missing
-    agent file returns without raising. That is the value it stamps into
-    [last_successful_heartbeat_ts] and uses to reset [consecutive_failures].
+    agent file returns without raising. That is the evidence it uses to reset
+    [consecutive_failures].
 
     These cases pin the outcome an unwritten heartbeat now reports, and that
     the rendered message is unchanged. *)


### PR DESCRIPTION
## 판정
**척살** (#28925 소스 감사 항목 2)

## 근거
- `keeper_work_as_hb_max_silence_sec`의 유일한 참조는 heartbeat 루프의 `let _max_silence () = ...` — 언더스코어 바인딩이고 호출자가 없어요.
- 이 창이 감시하기로 한 freshness 시계 `last_successful_heartbeat_ts`는 reader 0의 write-only ref예요 (`!last_successful_heartbeat_ts` 전수 grep 0건). presence sync와 work-as-hb refresher가 쓰기만 하고 아무도 읽지 않아요.
- 즉 "작업을 heartbeat로 간주할 때 최대 침묵 시간" 기능은 애초에 구현된 적이 없고, 지금 배선하려면 없는 스케줄링 gate를 새로 발명해야 해요. 파생/장식 값으로 gate를 만들지 않는다는 keeper autonomy 원칙상 배선이 아니라 척살이 맞다고 판단했어요.
- 라이브 영향 없음: 운영 runtime.toml/env 어디에도 `heartbeat.max_silence_sec`/`MASC_KEEPER_MAX_SILENCE_SEC` 설정 없음 확인.

## 처리
- `Runtime_settings` param 등록 + surface param_keys 행 제거, `Env_config_keeper.WorkAsHeartbeat.max_silence_sec` 파생 제거, operator display case 제거
- write-only `last_successful_heartbeat_ts` ref를 `sync_keeper_presence`/`refresh_work_as_heartbeat` 시그니처에서 제거 (consecutive_failures 리셋 동작은 그대로)
- 설정 registry의 `MASC_KEEPER_MAX_SILENCE_SEC` 행은 삭제 대신 기존 컨벤션대로 **Retired** 전환 — 남아 있을지 모를 stale TOML 키가 unknown-key가 아니라 사유 있는 검증 에러를 받도록 (선례: `autonomous.fairness_cooldown_sec`, `heartbeat.board_wakeup_max`)
- 테스트: config 배관·미배선 freshness 공식만 검증하던 케이스 삭제, retired-key 가드 목록에 `heartbeat.max_silence_sec` 추가, param count 4→3 반영
- `keeper_work_as_hb_enabled`(라이브 소비 있음)는 건드리지 않았어요.

## 검증
- `dune build --root . @check` green
- `test_work_as_heartbeat` 24, `test_runtime_params` 22, `test_keeper_runtime_config_leaf` 6, `test_runtime_toml_overrides` 38, `test_workspace_heartbeat_outcome` 4 — 전부 green (실행)
- `test_heartbeat_integration` 57 중 1 실패는 base SHA(fae4081300)에서도 동일하게 실패하는 선재 결함이에요 (`test_direct_start_terminalizes_fork_rejection_under_launch_reservation`, #28625에서 추가). 이 PR 변경과 무관함을 base 재실행으로 확인했어요.
- `audit-ci-test-targets.sh` OK (548 at baseline), dead-surface/structure/stringly/silent 래칫 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)