### PR TITLE
feat(tool-catalog): MCP operator 표면에 누락된 4종 도구 노출

### DIFF
--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -382,6 +382,26 @@ Clears stale data from previous sessions. Does not affect configuration, goals, 
   };
 
   {
+    name = "masc_keeper_msg";
+    description = "Send a direct message to a keeper. Submits the message as an async chat operation and returns operation_id immediately; poll masc_keeper_delegate_status with target {kind: \"keeper\", name} and this operation_id to observe the turn settle.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Keeper handle to message");
+        ]);
+        ("message", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Message text to send to the keeper");
+        ]);
+      ]);
+      ("required", `List [`String "name"; `String "message"]);
+      ("additionalProperties", `Bool false);
+    ];
+  };
+
+  {
     name = "masc_keeper_clear";
     description = "Last-resort context clear for a keeper. \
 Wipes user/assistant/tool messages from the checkpoint; keeps the system prompt \

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -2027,6 +2027,8 @@ let internal_descriptors : t list =
       ~readonly:false
   ; masc_keeper_descriptor ~keeper_model_projection:Operator_only "up" "masc_keeper_up"
       ~readonly:false
+  ; masc_keeper_descriptor ~keeper_model_projection:Operator_only "msg" "masc_keeper_msg"
+      ~readonly:false
   ]
   @ masc_board_descriptors
   @ masc_library_descriptors

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -470,6 +470,14 @@ let dispatch ?invocation_ref ctx ~name ~args : tool_result option =
               ~submitted_by:ctx.agent_name
               ctx
               args))
+  | "masc_keeper_msg" ->
+      Some
+        (tool_result_with_tool_name
+           ~tool_name:name
+           (Keeper_tool_surface_ops.handle_keeper_msg_from_args
+              ~submitted_by:ctx.agent_name
+              ctx
+              args))
   | "masc_keeper_delegate_status" ->
       Some
         (tool_result_with_tool_name ~tool_name:name
@@ -697,6 +705,15 @@ let () =
              ~submitted_by:agent_name
              ctx
              args))
+    | "masc_keeper_msg" ->
+      with_eio_context (fun ctx ->
+        Some
+          (tool_result_with_tool_name
+             ~tool_name:name
+             (Keeper_tool_surface_ops.handle_keeper_msg_from_args
+                ~submitted_by:agent_name
+                ctx
+                args)))
     | "masc_keeper_up" ->
       (match sw, clock with
        | Some sw, Some clock ->

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -660,6 +660,28 @@ let handle_keeper_delegate ?invocation_ref ~submitted_by ctx args =
   | Ok result -> result
   | Error error -> tool_result_of_handler_error error
 ;;
+
+(* Raw-args boundary for masc_keeper_msg, mirroring [handle_keeper_delegate]'s
+   args decode so both dispatch tables (Keeper_tool_surface.dispatch and
+   Keeper_dispatch_ref.dispatch) can register it the same way. Target
+   resolution, preflight, and submission stay inside [handle_keeper_msg]. *)
+let handle_keeper_msg_from_args ~submitted_by ctx args : tool_result =
+  match
+    Keeper_invocation_contract.direct_message
+      ~keeper_name:(get_string args "name" "")
+      ~prompt:(get_string args "message" "")
+      ~direct_reply:true
+      ~channel:""
+      ~user_blocks:[]
+      ~attachments:[]
+      ()
+    |> Result.map_error Keeper_invocation_contract.request_error_to_string
+    |> message_error
+  with
+  | Ok message -> handle_keeper_msg ~submitted_by ctx message
+  | Error error -> tool_result_of_handler_error error
+;;
+
 let operation_reference_arg args =
   let invalid detail =
     Error

--- a/lib/tool/tool_catalog.ml
+++ b/lib/tool/tool_catalog.ml
@@ -295,6 +295,10 @@ let explicit_metadata : (string * metadata) list =
     ("masc_keeper_sandbox_stop", mutating_tool);
     ("masc_keeper_delegate", broadcast_tool);
     ("masc_keeper_delegate_status", read_state_tool);
+    (* Submits an async chat operation (same submit_agent_operation path as
+       masc_keeper_delegate); poll masc_keeper_delegate_status for the
+       outcome. *)
+    ("masc_keeper_msg", broadcast_tool);
     ("masc_keeper_delegate_cancel", broadcast_tool);
     ("masc_keeper_delegate_list", read_state_tool);
     ("masc_keeper_audit", read_state_tool);

--- a/lib/tool_catalog_surfaces/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces/tool_catalog_surfaces.ml
@@ -66,16 +66,39 @@ let public_mcp_surface_tools =
        purpose: it wipes transcript messages, which is a different decision
        from asking a keeper to compact. *)
     "masc_keeper_compact"
+  ; (* [masc_keeper_msg] is the operator's front door for sending a keeper a
+       direct message: submit -> operation_id, then poll
+       [masc_keeper_delegate_status]. It already had a real handler
+       (Keeper_tool_surface.handle_keeper_msg) reachable only from the HTTP
+       copilot chat route and the board-context-inference caller; this adds
+       the MCP tools/call path so an operator can reach the same handler
+       without going through either adapter. *)
+    "masc_keeper_msg"
+  ; (* [masc_keeper_delegate_status] is the read-side counterpart operators
+       need to poll the operation_id that masc_keeper_msg / masc_keeper_delegate
+       return; it was already catalog-owned as a read_state_tool but missing
+       from this surface, so an operator could submit a turn but never observe
+       it settle. *)
+    "masc_keeper_delegate_status"
   ; (* Board. [masc_board_reaction] is intentionally public: it is the
-       operator/client counterpart to existing board comment/vote actions. *)
+       operator/client counterpart to existing board comment/vote actions.
+       [masc_board_search] is the read counterpart operators need to locate a
+       post before calling masc_board_post_get/comment/vote on it. *)
     "masc_board_post"
   ; "masc_board_list"
   ; "masc_board_post_get"
+  ; "masc_board_search"
   ; "masc_board_comment"
   ; "masc_board_vote"
   ; "masc_board_curation_read"
   ; "masc_board_curation_submit"
   ; "masc_board_reaction"
+  ; (* Task workspace read-side: operators need the history of a task they
+       did not submit themselves (e.g. one another Keeper claimed). *)
+    "masc_task_history"
+  ; (* Fusion. Read-only status check for the fusion pipeline an operator
+       is coordinating multiple keepers through. *)
+    "masc_fusion_status"
   ]
   @ public_schedule_surface_tools
   @

--- a/lib/tool_catalog_surfaces/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces/tool_catalog_surfaces.ml
@@ -96,9 +96,14 @@ let public_mcp_surface_tools =
   ; (* Task workspace read-side: operators need the history of a task they
        did not submit themselves (e.g. one another Keeper claimed). *)
     "masc_task_history"
-  ; (* Fusion. Read-only status check for the fusion pipeline an operator
-       is coordinating multiple keepers through. *)
-    "masc_fusion_status"
+  (* [masc_fusion_status] deliberately stays off this surface: RFC-0266 §7
+     Phase 3 scopes it to the calling keeper's own fusion runs ("a run owned
+     by a different keeper is reported as not found" -- see
+     Keeper_tool_in_process_runtime.mli), and it has no external Tool_dispatch
+     tag registration, so an operator caller could only ever see an empty
+     result. Making it operator-visible would require a real scoping redesign
+     (target-keeper field + contract change), not a whitelist entry. See
+     masc#28963 / masc#28960. *)
   ]
   @ public_schedule_surface_tools
   @

--- a/scripts/fixtures/keeper-multi-collaboration/missions.json
+++ b/scripts/fixtures/keeper-multi-collaboration/missions.json
@@ -26,8 +26,7 @@
     "masc_board_search",
     "masc_board_post_get",
     "masc_schedule_create",
-    "masc_schedule_get",
-    "masc_fusion_status"
+    "masc_schedule_get"
   ],
   "keeper_required_tools": [
     "keeper_tasks_list",

--- a/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
+++ b/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
@@ -1150,20 +1150,24 @@ class MissionRun:
         return observation.data
 
     def wait_for_async_sources(self) -> None:
+        # masc_fusion_status is a keeper-internal tool (RFC-0266 §7 Phase 3
+        # keeper-scoped isolation; see masc#28963/#28960): the operator MCP
+        # session this runner authenticates as can never observe a researcher
+        # keeper's fusion runs through it, so gating on it here would spin the
+        # full deadline on every run. Fusion progress is observed instead via
+        # the researcher's own durable tool-call event (masc_agent_timeline),
+        # checked in evaluate_assertions.
         deadline = time.monotonic() + 180.0
         while time.monotonic() < deadline:
             schedule = self.call(
                 "schedule-poll", "masc_schedule_get", {"schedule_id": self.schedule_id}
             )
-            fusion = self.call("fusion-poll", "masc_fusion_status", {})
             self.observations["schedule"] = schedule
-            self.observations["fusion"] = fusion
             schedule_terminal = any(
                 text_contains(schedule.data, state)
                 for state in ("succeeded", "failed", "cancelled", "expired")
             )
-            fusion_seen = text_contains(fusion.data, self.roles["researcher"])
-            if schedule_terminal and fusion_seen:
+            if schedule_terminal:
                 data = self.read_status("coordinator", "after-schedule")
                 self.writer.write_json(
                     "keeper-status/coordinator-after-schedule.json", data
@@ -1223,7 +1227,6 @@ class MissionRun:
                 {"post_id": post_id, "comment_offset": 0, "comment_limit": 100},
             ),
             "schedule": ("masc_schedule_get", {"schedule_id": self.schedule_id}),
-            "fusion-status": ("masc_fusion_status", {}),
         }
         for label, (tool, arguments) in calls.items():
             observation = self.call(f"observe-{label}", tool, arguments)
@@ -1274,7 +1277,6 @@ class MissionRun:
         tasks = self.observations["tasks"].data
         board = self.observations["board-post"].data
         schedule = self.observations["schedule"].data
-        fusion = self.observations["fusion-status"].data
         histories = {
             key: self.observations[f"task-history-{key}"].data for key in self.task_ids
         }
@@ -1636,8 +1638,11 @@ class MissionRun:
                 for role in ("builder-a", "builder-b")
             ),
             "Comment": len(comment_author_hits) >= 3,
-            "Fusion": self._successful_tool("researcher", "masc_fusion")
-            and text_contains(fusion, self.roles["researcher"]),
+            # masc_fusion_status is keeper-internal (RFC-0266 §7 Phase 3); the
+            # operator session cannot poll it (masc#28963/#28960), so Fusion
+            # progress is observed only through the researcher keeper's own
+            # durable masc_fusion tool-call event.
+            "Fusion": self._successful_tool("researcher", "masc_fusion"),
             "Memory": self._successful_tool("coordinator", "keeper_memory_write"),
             "Context": self.secret.lower() in board_text.lower(),
         }
@@ -1726,9 +1731,11 @@ class MissionRun:
                 "task history or current task state",
             ),
             "fusion_started": (
-                self._successful_tool("researcher", "masc_fusion")
-                and text_contains(fusion, self.roles["researcher"]),
-                "researcher durable tool event and fusion registry",
+                # keeper-side evidence only; masc_fusion_status is
+                # keeper-internal and unreachable from the operator session
+                # (masc#28963/#28960).
+                self._successful_tool("researcher", "masc_fusion"),
+                "researcher durable tool event",
             ),
             "peer_progress_during_fusion": (
                 text_contains(board, "BUILDER_A_DONE") and text_contains(board, "BUILDER_B_DONE"),
@@ -1812,8 +1819,8 @@ class MissionRun:
                     text_contains(value, self.marker)
                     for value in (goals, tasks, board, schedule)
                 )
-                and text_contains(fusion, self.roles["researcher"]),
-                "marker in Goal/Task/Board/Schedule and researcher in Fusion",
+                and self._successful_tool("researcher", "masc_fusion"),
+                "marker in Goal/Task/Board/Schedule and researcher's durable Fusion tool event",
             ),
             "artifact_bundle_complete": (
                 len(artifact_files) >= 20

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -662,9 +662,25 @@ let test_handle_request_tools_list () =
     false
     (List.mem "masc_voice_ping_pong" names);
   Alcotest.(check bool)
-    "board_search hidden from public surface"
-    false
+    "contains masc_board_search (public surface)"
+    true
     (List.mem "masc_board_search" names);
+  Alcotest.(check bool)
+    "contains masc_task_history (public surface)"
+    true
+    (List.mem "masc_task_history" names);
+  Alcotest.(check bool)
+    "contains masc_keeper_delegate_status (public surface)"
+    true
+    (List.mem "masc_keeper_delegate_status" names);
+  Alcotest.(check bool)
+    "contains masc_keeper_msg (public surface)"
+    true
+    (List.mem "masc_keeper_msg" names);
+  Alcotest.(check bool)
+    "omits masc_fusion_status (keeper-internal, RFC-0266)"
+    false
+    (List.mem "masc_fusion_status" names);
   Alcotest.(check bool)
     "removed experiment_start absent from list"
     false


### PR DESCRIPTION
## 배경

multi-keeper acceptance runner(`scripts/harness/workload/keeper_multi_collaboration_acceptance.py`, RW01~19)가 `--preflight`에서 실패한다: 배포된 MCP 표면(`tools/list`)에 러너가 오퍼레이터로서 호출하는 도구 중 여러 종이 빠져 있었다. Refs #28960 (동일 증상을 다른 세션이 tools/call 실측으로 분류한 이슈).

## 변경

1. **화이트리스트 4종 추가** (`tool_catalog_surfaces.ml`): `masc_board_search`, `masc_task_history`, `masc_keeper_delegate_status`, `masc_keeper_msg`. 각 항목에 근거 주석 포함.
2. **masc_keeper_msg 신규 배선** (masc_keeper_up/masc_keeper_delegate와 동일한 기존 패턴을 그대로 따름, 새 패턴 없음):
   - `keeper_schema.ml`: 스키마 추가 (`name`, `message` 필수)
   - `tool_catalog.ml`: catalog row 추가 (`broadcast_tool` 권한 — masc_keeper_delegate와 동일하게 `submit_agent_operation` 경로로 비동기 오퍼레이션 제출)
   - `keeper_tool_descriptor.ml`: `masc_keeper_descriptor` 항목 추가 (`Operator_only` projection — masc_keeper_up/compact와 동일, 키퍼 자신의 모델에는 노출하지 않음)
   - `keeper_tool_surface_ops.ml`: `handle_keeper_msg_from_args` 신설 — `handle_keeper_delegate`와 동일한 raw-args 디코드 경계. 대상 키퍼 해석/preflight/제출은 기존 `handle_keeper_msg` 내부 로직 그대로 재사용
   - `keeper_tool_surface.ml`: 두 dispatch 테이블 모두에 케이스 추가
     - `Keeper_tool_surface.dispatch` (ctx-based, `Keeper_tool_boundary`를 거쳐 외부 MCP 경계가 실제로 타는 경로)
     - `Keeper_dispatch_ref.dispatch` (ref-based, in-process keeper tool runtime이 타는 경로)
     - 둘 다 필요한 이유: `test_keeper_tool_descriptor_registry_integrity.ml`의 두 dispatch-gap 테스트가 각각 이 두 경로의 도달 가능성을 개별적으로 검증함.
3. **masc_fusion_status는 이 PR에서 다루지 않는다 — keeper-internal로 유지하는 결정** (masc-08 적대 리뷰 + team-lead 결정, 옵션 1 채택):
   - 이유는 아래 "masc_fusion_status: 화이트리스트에서 제외" 절 참고. 상세 근거는 masc#28963(결정 기록으로 갱신됨).
   - `missions.json`의 `operator_required_tools`에서 `masc_fusion_status` 제거 — preflight가 존재하지 않아야 할 오퍼레이터 도구를 요구하지 않게.
   - 러너의 fusion 관찰을 keeper-side 증거로 전환: `masc_fusion_status` tools/call은 `isError=true`일 때 `AcceptanceError`를 던져(`allow_tool_error` 미지정) 전체 런을 abort시키므로, `wait_for_async_sources`/`collect_product_observations`에서 두 호출 지점을 모두 제거하고, `fusion_started` / `observed_surfaces["Fusion"]` / `correlation_marker_complete` 판정을 researcher 키퍼 자신의 `masc_fusion` 자기-턴 tool-call 이벤트(`masc_agent_timeline` 기반, keeper-internal 실행이라 이번 결정과 무관하게 계속 동작)만으로 재구성. `wait_for_async_sources`는 이제 schedule terminal 상태만으로 게이트한다(기존 구조는 fusion-poll의 `isError`를 `allow_tool_error` 없이 받아 **첫 반복에서 즉시 크래시**하는 상태였음 — 리뷰 실측 정정, 제거 근거는 더 강함).

## masc_fusion_status: 화이트리스트에서 제외 (keeper-internal 유지)

추적 결과, 이건 "라우팅 등록 누락" 버그가 아니라 **아키텍처 차원의 결정이 필요한 사안**이었다:

- `masc_fusion_status`(그리고 `masc_fusion`/`analyze_image`/`artifact_read`)의 스키마는 `keeper_tool_runtime_schemas.ml`에 있고, `Config.raw_all_tool_schemas`에는 포함되지만(그래서 tools/list엔 뜬다) **외부 MCP 태그 레지스트리(`Tool_dispatch`)에는 등록되지 않는다** — `keeper_tool_surface.ml`의 `register_keeper_surface_schema`가 `Keeper_schema.schemas`(masc_keeper_up/msg 등)만 등록하고 `Keeper_tool_runtime_schemas.schemas`는 건드리지 않기 때문. 이 4종 전부가 동일한 상태다(개별 버그 아님).
- `handle_masc_fusion_status`의 `.mli` 문서(RFC-0266 §7 Phase 3)에 **명시적으로** 이렇게 적혀 있다: "projects the **calling keeper's** fusion runs... A run owned by a **different keeper is reported as not found**." 즉 키퍼별 격리가 설계 의도이지 실수가 아니다.
- PR #28961(같은 세션 masc-08)이 정확히 이 문제를 이미 인지하고 있었고, 동일 스키마 소스의 `analyze_image`를 "keeper-internal; not available on this MCP endpoint"라는 정직한 거부로 처리하기로 이미 결정했다 — `masc_fusion_status`만 예외로 강제 등록하면 형제 도구들과 아키텍처가 불일치한다.
- **결정**: 옵션 1(keeper-internal 유지) 채택, 옵션 2(대상 키퍼 필드 추가 + 계약 재설계)는 실수요 발생 시 별도 RFC로. 상세는 masc#28963(결정 기록으로 갱신).

## 검증

### 정적 검증
- `dune build --root . @check` exit 0
- `dune build --root .` (전체 빌드) exit 0
- `python3 -m py_compile scripts/harness/workload/keeper_multi_collaboration_acceptance.py` / `ruff check` 통과
- `ocamlformat` 변경 파일 전부 이미 정상 포맷 (로컬 `ocamlformat --enable-outside-detected-project` 확인)
- `test_keeper_tool_descriptor_registry_integrity` — **46/46 통과** (masc_fusion_status 제외 반영 후 재실행, `dispatch-gap`/`surface-projection` 게이트 포함)
- `test_streamable_http_upgrade` — 3/3 통과
- `test_tools_coverage` — 37/38 통과, 1건(`analyze_image uses a known namespace`)은 이 PR과 무관한 기존 실패임을 branch point pristine 빌드에서 동일 재현으로 확인

### scratch 서버 라이브 검증 (실서버 8935 미접촉, 별도 base-path/port/무봇토큰) — masc_fusion_status 제외 전 4종 대상
- 격리 base-path + `runtime.toml`/`agent-core-models-overlay.toml` 복사 + `env -i`로 Discord/Slack 토큰 등 shell env 완전 차단 + `MASC_ADMIN_TOKEN` 명시 지정 후 프로덕션 `main_eio.exe` 바이너리로 포트 18935에서 기동
- `tools/call` 판정표:

| tool | tools/call | 판정 |
|---|---|---|
| `masc_board_search` | 정상 응답 (`'scratch' 검색 결과 없음`) | 화이트리스트 추가만으로 완결 |
| `masc_task_history` | 정상 스키마 검증 (`task_id: MISSING`) | 화이트리스트 추가만으로 완결 |
| `masc_keeper_delegate_status` | 정상 dispatch (`Keeper owner not found: nope`) | 화이트리스트 추가만으로 완결 |
| `masc_keeper_msg` | 정상 동작 — 실제 키퍼 생성 후 호출 시 `{"operation_id":"kmsg-...","state":"queued"}` 반환, 이어서 `masc_keeper_delegate_status`로 동일 operation_id 폴링 성공 | 이번 PR에서 전체 배선 신설 |

- **acceptance runner `--preflight` 실행 결과** (masc_fusion_status 제외 전 측정, 4종 기준으로는 동일하게 통과 예상 — missing_operator_tools가 이미 빈 배열이었으므로 4종으로 줄여도 영향 없음):
  ```json
  {
    "status": "passed",
    "operator_required_tool_count": 18,
    "available_tool_count": 45,
    "missing_operator_tools": []
  }
  ```

### CI 오진 주의
현재 PR CI에 `check`(PR axis stale check)와 `ocamlformat-check` 2건이 빨간불로 뜰 수 있는데, 로그로 확인한 결과 둘 다 이 PR의 diff와 무관한 공통 인프라 문제다(#28962):
- `check`: "Check PR axis stale" 스텝이 `exit code 2`로 실패 — gh compare 404 계열.
- `ocamlformat-check`: `ocaml/setup-ocaml@v3`가 `ocaml-compiler: 5.5.0`을 provisioning하는 단계에서 실패 (opam 릴리즈 resolve 실패) — 실제 파일 포맷 검사 이전 단계.

## 건드리지 않은 것
- 화이트리스트 확장은 이 4종만. 다른 도구 추가 없음.
- masc_fusion_status의 dispatch-gap 자체는 고치지 않음 (keeper-internal 유지가 최종 결정, masc#28963 참고).
- `dune build @fmt`의 기존 dune 파일 포맷 드리프트(이 PR과 무관한 수십 개 파일)는 건드리지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

