### PR TITLE
fix(ci): axis check가 unreachable merge commit(404)에서 죽지 않게 — 모든 후속 PR check 차단 해소

### DIFF
--- a/scripts/pr_axis_check.py
+++ b/scripts/pr_axis_check.py
@@ -64,8 +64,12 @@ class RfcCollision:
         return f"RFC-{self.rfc_number}: claimed by {claimants}"
 
 
-def _run_gh(args: List[str]) -> Any:
-    """Run gh cli and return JSON output."""
+def _run_gh(args: List[str], *, allow_not_found: bool = False) -> Any:
+    """Run gh cli and return JSON output.
+
+    With ``allow_not_found`` an HTTP 404 returns ``None`` instead of exiting:
+    the caller owns the typed meaning of an unreachable object (e.g. a merge
+    commit orphaned when its stacked parent branch was auto-deleted)."""
     rendered_args = " ".join(args)
     for attempt in range(1, GH_RETRIES + 1):
         result = subprocess.run(
@@ -74,6 +78,8 @@ def _run_gh(args: List[str]) -> Any:
             text=True,
         )
         if result.returncode != 0:
+            if allow_not_found and "(HTTP 404)" in result.stderr:
+                return None
             if attempt < GH_RETRIES:
                 time.sleep(attempt)
                 continue
@@ -223,8 +229,19 @@ def merge_commit_already_in_base(
     # status == "ahead"   -> head is ahead of base (base is ancestor of head)
     # status == "identical" -> same
     resp = _run_gh(
-        [f"/repos/{owner}/{repo}/compare/{merge_commit_sha}...{pr_base_sha}"]
+        [f"/repos/{owner}/{repo}/compare/{merge_commit_sha}...{pr_base_sha}"],
+        allow_not_found=True,
     )
+    if resp is None:
+        # The merge commit is unreachable — typical for a stacked child whose
+        # parent branch was auto-deleted after folding. Containment cannot be
+        # proven, so do not skip: let the overlap analysis run.
+        print(
+            f"axis compare 404 for {merge_commit_sha[:12]}...{pr_base_sha[:12]}: "
+            "unreachable merge commit, treating as not-contained",
+            file=sys.stderr,
+        )
+        return False
     status = resp.get("status", "")
     return status in ("ahead", "identical")
 


### PR DESCRIPTION
## 증상 (#28965)

스택 PR(#28957)이 부모 브랜치로 접히고 부모가 자동 삭제되면 merge commit이 원격에서 unreachable이 돼요. axis check의 포함 여부 프로브가 그 SHA로 compare API를 부르면 404가 나는데, `_run_gh`가 이를 fatal(exit 2)로 올려서 **이후 모든 PR의 check job이 죽는** 상태였어요 (rerun 무효). 실측 실패 쌍: `936906b7f0...a1333e7d4d` (#28959 실패 job 로그).

## 수리

404에 typed 의미를 부여했어요: **"포함을 증명할 수 없음 → skip하지 않고 overlap 분석을 진행(False)"**. 결과는 fatal crash(전 PR 차단)에서 훨씬 좁고 얕아져요 — 다만 overlap 분석에서 dune/mli/type 겹침이 HIGH/MEDIUM confidence로 잡히면 `_block()` 경유 **exit 1 차단은 여전히 가능**합니다 (이건 axis check의 본래 기능이고, 겹침 없는 무관 PR은 통과). 다른 gh 에러는 기존 fatal 경로 유지, `allow_not_found`는 이 한 곳만 사용.

## 검증

- 수리 전 재현: #28959 실패 job 로그의 `936906b7f0...a1333e7d4d` 404 → exit 2 (리뷰 세션이 job API로 독립 확증)
- 수리 후: 이 PR 자신의 check job이 "No axis risks found"로 정상 종료
- 실존 조상 쌍(`1a8be94d61` → `d1c252282e`) → True (기존 skip 동작 보존)

## 정직한 기록 2건

- 초기 본문이 인용한 `313f4390...a1333e7d`는 실제로는 정상 조상 쌍이었어요 — 제 로컬 "재현"의 404는 당시 GitHub API 장애(전면 503/404)가 만든 가짜였고, 리뷰가 이를 적발했습니다. 부수 효과로: API 장애 중의 스퓨리어스 404도 이 수리에서는 같은 안전 방향(not-contained → 분석 진행)으로 강등되며, 이는 의도된 성질입니다.
- 이 PR check job의 별개 스텝(RFC collision)의 GH_TOKEN invalid 실패는 본 수리와 무관 — 별도 확인 대상.

Refs #28965, #28962(항목 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)