### PR TITLE
fix(harness): E0 러너 liveness 판정을 서버가 실제 방출하는 필드로 교체

### DIFF
--- a/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
+++ b/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
@@ -251,6 +251,26 @@ def source_sha() -> str:
         return "unknown"
 
 
+def keeper_is_live(data: Any) -> bool:
+    """A keeper can receive missions when its keepalive loop runs and the
+    registry reports a running fiber. These are the fields
+    ``masc_keeper_status`` actually emits (``runtime.phase`` /
+    ``runtime.fiber_health`` from the keeper registry FSM). The previous
+    predicate demanded ``agent.exists``, but ``parse_agent_status`` never
+    emits an ``exists`` key and keepers on this build never materialize an
+    agents-dir identity file, so no fleet could ever pass bootstrap."""
+    if not isinstance(data, dict):
+        return False
+    runtime = data.get("runtime")
+    if not isinstance(runtime, dict):
+        return False
+    return (
+        bool(data.get("keepalive_running"))
+        and runtime.get("phase") == "running"
+        and runtime.get("fiber_health") == "alive"
+    )
+
+
 def parse_json_maybe(text: str) -> Any:
     try:
         value = json.loads(text)
@@ -719,13 +739,7 @@ class MissionRun:
                 except AcceptanceError:
                     continue
                 data = status.data
-                if isinstance(data, dict):
-                    live = bool(data.get("keepalive_running")) and bool(
-                        (data.get("agent") or {}).get("exists")
-                    )
-                else:
-                    live = "keepalive" in status.text.lower() and "true" in status.text.lower()
-                if live:
+                if keeper_is_live(data):
                     self.statuses[role] = data
                     pending.remove(role)
             if pending:
@@ -1676,10 +1690,7 @@ class MissionRun:
             "all_keepers_live": (
                 len(self.statuses) == len(self.roles)
                 and all(
-                    isinstance(self.statuses.get(role), dict)
-                    and bool(self.statuses[role].get("agent", {}).get("exists"))
-                    and bool(self.statuses[role].get("keepalive_running"))
-                    for role in self.roles
+                    keeper_is_live(self.statuses.get(role)) for role in self.roles
                 ),
                 f"observed live keepalive status for {len(self.statuses)}/{len(self.roles)} roles",
             ),


### PR DESCRIPTION
## 무엇이 문제였나

첫 E0 라이브 캠페인(run e0-collab-20260818-1120)이 fleet bootstrap에서 전멸했어요 — `keepers did not become live: [5명 전원]`.

러너의 liveness 판정이 `agent.exists`를 요구하는데, 서버의 `parse_agent_status`(keeper_status_runtime.ml:122)는 어떤 브랜치에서도 `exists` 키를 방출하지 않아요. keeper가 agents-dir identity 파일을 만드는 개념 자체가 이 빌드에 없어서(기존 keeper analyst 등도 전부 `agent: {}`), 이 판정은 어떤 fleet도 통과할 수 없는 죽은 기대였습니다.

## 수리

- `keeper_is_live` helper 하나로 추출 (SSOT), 두 사용처(bootstrap wait, `all_keepers_live` 최종 assertion) 교체
- 판정 어휘를 registry FSM이 실제 방출하는 필드로: `keepalive_running` + `runtime.phase == running` + `runtime.fiber_health == alive`
- 텍스트 substring fallback 브랜치(`"keepalive" in text`)도 함께 삭제

## 검증 (라이브 실측)

캠페인이 남긴 keeper 5명 상대로 새 판정 실행 → 5/5 `True`, `None`/`str`/`{}` 가드 → `False`.

## 후속

러너는 `--run` 시 runner source SHA == 배포 binary commit을 강제하므로, 이 PR 머지 후 해당 SHA로 재배포해야 캠페인 재시도가 가능해요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)