### PR TITLE
fix(harness): 서버가 회수한 MCP 세션을 러너가 재핸드셰이크로 복구

### DIFF
--- a/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
+++ b/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
@@ -374,7 +374,13 @@ class McpClient:
                 return value
         raise AcceptanceError("MCP SSE response had no matching JSON-RPC payload")
 
-    def request(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+    def request(
+        self,
+        method: str,
+        params: dict[str, Any],
+        *,
+        _retry_on_stale_session: bool = True,
+    ) -> dict[str, Any]:
         request_id = self._next_id()
         payload = json.dumps(
             {
@@ -408,6 +414,28 @@ class McpClient:
                     self.protocol_version = protocol_version
         except urllib.error.HTTPError as error:
             detail = error.read().decode("utf-8", errors="replace")
+            if (
+                _retry_on_stale_session
+                and error.code == 404
+                and self.session_id is not None
+                and method != "initialize"
+            ):
+                # RFC-0100 Q3: the server answers a POST that echoes a
+                # session id it has no state for with 404 so the client
+                # re-handshakes — and it reaps sessions whose grace period
+                # (MASC_SESSION_SSE_GRACE_PERIOD_SEC, default 300s) elapses
+                # without activity. This runner's primary session sits idle
+                # while per-turn sub-clients drive keeper turns, so a long
+                # mission phase crosses that window (run
+                # e0-collab-20260818-1157 died exactly this way). The 404
+                # is raised by the session check before dispatch, so the
+                # rejected request never executed and one replay on a fresh
+                # session is safe for mutations too.
+                self.session_id = None
+                self.initialize()
+                return self.request(
+                    method, params, _retry_on_stale_session=False
+                )
             raise AcceptanceError(f"MCP HTTP {error.code}: {detail[:1000]}") from error
         except urllib.error.URLError as error:
             raise AcceptanceError(f"MCP transport failed: {error}") from error


### PR DESCRIPTION
## 무엇이 문제였나

E0 재시도(run e0-collab-20260818-1157)가 18턴을 완주하고 정확히 **세션 생성 +300초** 시점에 `404 Unknown Mcp-Session-Id`로 abort했어요.

타임라인 실측 (raw 교신 93건 mtime + 서버 로그):
- 러너 구조는 메인 세션(setup) + 턴별 서브 클라이언트 — 메인 세션의 마지막 POST가 11:55:27
- 서브 클라이언트들이 5분간 턴을 돌리는 동안 메인 세션은 유휴
- 서버 reaper가 11:55:27+300s(grace 기본값) 경과 후 12:00:34에 회수 ("reaped 3 stale sessions" 로그와 일치)
- continuity-9 완료 후 메인 세션으로 복귀한 다음 호출이 404

**서버는 설계대로 동작했어요** — RFC-0100 Q3가 미지의 세션 id에 404를 주고 재핸드셰이크를 처방하고, 404는 dispatch 전 세션 검사에서 나므로 거부된 요청은 실행되지 않았습니다.

## 수리

`McpClient.request`가 세션 id를 실은 POST에서 404를 받으면 1회 재초기화 후 같은 요청을 재전송해요 (재시도 후의 404는 그대로 raise, initialize 자신은 재시도 없음). dispatch 전 거부라 mutation 재전송도 이중 실행 위험이 없습니다.

## 검증 (라이브 실측)

initialize → session id를 phantom으로 교체(회수된 세션과 동일한 서버 상태) → `masc_status` 호출 → 투명 복구 확인. 순수 initialize 경로도 정상.

## 후속

SHA 계약(runner == binary commit)상 머지 후 3차 재배포가 필요해요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)