### PR TITLE
fix(harness): E0 판정을 손실성 projection 대신 durable 스트림으로

### DIFF
--- a/scripts/fixtures/keeper-multi-collaboration/missions.json
+++ b/scripts/fixtures/keeper-multi-collaboration/missions.json
@@ -103,7 +103,7 @@
       "capabilities": ["Fusion", "Task", "Board"],
       "user_story": "Fusion이 비동기로 실행되는 동안 다른 Keeper들의 Task와 Board 진행이 완료된다.",
       "assertions": ["fusion_started", "peer_progress_during_fusion"],
-      "evidence": ["observations/fusion-status.json", "observations/timeline-researcher.json", "turns/parallel-*.json"]
+      "evidence": ["observations/tool-calls-researcher.json", "observations/timeline-researcher.json", "turns/parallel-*.json"]
     },
     {
       "id": "RW07",

--- a/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
+++ b/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
@@ -26,6 +26,7 @@ import subprocess
 import sys
 import threading
 import time
+import tomllib
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -41,6 +42,13 @@ DEFAULT_CATALOG = (
     / "fixtures"
     / "keeper-multi-collaboration"
     / "missions.json"
+)
+COMPOSITION_FIXTURE = (
+    REPO_ROOT
+    / "scripts"
+    / "fixtures"
+    / "keeper-multi-collaboration"
+    / "tool-compositions.toml"
 )
 SCHEMA = "masc.keeper_multi_collaboration_evidence.v1"
 EXPECTED_ROLES = {"coordinator", "builder-a", "builder-b", "reviewer", "researcher"}
@@ -588,6 +596,54 @@ def health_binary_commit(health: dict[str, Any]) -> str:
     return value.strip() if isinstance(value, str) else ""
 
 
+def composition_catalog_status(masc_root: str) -> dict[str, Any]:
+    """Compare the composition names this campaign's fixture requires against
+    the catalog installed at the deployed runtime's config root.
+
+    keeper_compose_* tools are a config-driven surface: Keeper_run_tools_setup
+    reads <config_root>/tool-compositions.toml on every turn, so a missing or
+    incomplete file makes every composition mission fail eight minutes in with
+    a downstream browser timeout instead of failing here (masc#28975, run
+    e0-r3-20260818). The runner and the runtime share a host by the
+    --expected-base-path contract, so reading the file the server reads is a
+    legitimate read-only preflight check."""
+    with open(COMPOSITION_FIXTURE, "rb") as handle:
+        fixture = tomllib.load(handle)
+    required = sorted(
+        entry["name"] for entry in fixture.get("compositions", [])
+    )
+    installed_path = pathlib.Path(masc_root) / "config" / "tool-compositions.toml"
+    report: dict[str, Any] = {
+        "required": required,
+        "installed_path": str(installed_path),
+        "fixture_path": str(COMPOSITION_FIXTURE),
+    }
+    if not installed_path.is_file():
+        report["status"] = "missing_file"
+        report["installed"] = []
+        report["missing"] = required
+        return report
+    try:
+        with open(installed_path, "rb") as handle:
+            installed_catalog = tomllib.load(handle)
+    except tomllib.TOMLDecodeError as error:
+        report["status"] = "unparseable"
+        report["error"] = str(error)
+        return report
+    installed = sorted(
+        name
+        for entry in installed_catalog.get("compositions", [])
+        if isinstance(entry, dict)
+        for name in [entry.get("name")]
+        if isinstance(name, str)
+    )
+    missing = sorted(set(required) - set(installed))
+    report["installed"] = installed
+    report["missing"] = missing
+    report["status"] = "ok" if not missing else "missing_names"
+    return report
+
+
 def preflight(
     *,
     catalog: dict[str, Any],
@@ -623,8 +679,11 @@ def preflight(
     available = client.list_tools()
     required = set(catalog["operator_required_tools"])
     missing = sorted(required - available)
+    compositions = composition_catalog_status(health_masc_root(health))
     result = {
-        "status": "passed" if not missing else "failed",
+        "status": (
+            "passed" if not missing and compositions["status"] == "ok" else "failed"
+        ),
         "checked_at": utc_now(),
         "mcp_url": mcp_url,
         "health_url": health_url,
@@ -636,9 +695,16 @@ def preflight(
         "available_tool_count": len(available),
         "missing_operator_tools": missing,
         "keeper_required_tools": catalog["keeper_required_tools"],
+        "composition_catalog": compositions,
     }
     if missing:
         raise AcceptanceError(f"deployed runtime is missing operator tools: {missing}")
+    if compositions["status"] != "ok":
+        raise AcceptanceError(
+            "composition catalog is not installed for this campaign: "
+            f"status={compositions['status']} missing={compositions.get('missing')} — "
+            f"install {compositions['fixture_path']} at {compositions['installed_path']}"
+        )
     return client, health, result
 
 
@@ -682,6 +748,7 @@ class MissionRun:
             "researcher": f"rw-{self.slug}-research",
         }
         self.task_ids: dict[str, str] = {}
+        self.task_create_receipts: dict[str, ToolObservation] = {}
         self.turns: dict[str, TurnObservation] = {}
         self.statuses: dict[str, Any] = {}
         self.observations: dict[str, ToolObservation] = {}
@@ -824,6 +891,13 @@ class MissionRun:
                 },
             )
             self.task_ids[key] = extract_identity(observation.text, ["task-"])
+            # The server's creation receipt echoes the persisted task with its
+            # goal_id — the durable evidence of goal linkage. The Quest Board
+            # text projection consumed at observation time does not render
+            # goal links at all, so judging linkage from it fails every run
+            # even though the linkage is real (masc#28976, run
+            # e0-r4-20260818).
+            self.task_create_receipts[key] = observation
 
         mentions = " ".join(f"@{keeper}" for keeper in self.roles.values())
         board = self.call(
@@ -1243,8 +1317,12 @@ class MissionRun:
                 },
             )
             encoded_keeper = urllib.parse.quote(self.roles[role], safe="")
+            # 500, not 200: the durable inspector is now the assertion
+            # evidence stream, and r4 roles already reached 139 rows in a
+            # single campaign — headroom keeps a longer mission ladder from
+            # clipping the early turns the assertions need.
             tool_calls = self.dashboard_get(
-                f"/api/v1/keepers/{encoded_keeper}/tool-calls?limit=200"
+                f"/api/v1/keepers/{encoded_keeper}/tool-calls?limit=500"
             )
             entries = tool_calls.get("entries")
             if not isinstance(entries, list) or not all(
@@ -1293,19 +1371,28 @@ class MissionRun:
         return json.dumps(self.statuses.get(role), ensure_ascii=False).lower()
 
     def _tool_events(self, role: str, tool_name: str) -> list[dict[str, Any]]:
-        observation = self.observations.get(f"timeline-{role}")
-        data = observation.data if observation else None
-        if not isinstance(data, dict):
-            return []
-        events = data.get("events") or []
+        # Judged from the durable tool-call inspector rows, not from
+        # masc_agent_timeline: the timeline is a lossy window that dropped
+        # early-turn events (masc_fusion, keeper_memory_write) even under its
+        # limit, flipping real successes to FAIL in run e0-r4-20260818
+        # (masc#28976). Rows nested inside a composition run are excluded —
+        # a composition node executing masc_board_stats is not the keeper
+        # calling it. Normalized to the {"detail": {...}} event shape the
+        # assertion sites consume, ordered by timestamp so
+        # rejected-then-recovered sequences stay judgeable.
         accepted_names = TOOL_ALIASES.get(tool_name, {tool_name})
+        rows = self.tool_call_rows.get(role) or []
         return [
-            event
-            for event in events
-            if isinstance(event, dict)
-            and event.get("type") == "tool_call"
-            and isinstance(event.get("detail"), dict)
-            and event["detail"].get("tool_name") in accepted_names
+            {
+                "detail": {
+                    "tool_name": row.get("tool"),
+                    "success": row.get("success"),
+                },
+                "ts": row.get("ts"),
+            }
+            for row in sorted(rows, key=lambda row: float(row.get("ts") or 0.0))
+            if row.get("tool") in accepted_names
+            and not row.get("composition_tool")
         ]
 
     def _successful_tool(self, role: str, tool_name: str) -> bool:
@@ -1534,15 +1621,22 @@ class MissionRun:
         all_composition_run_ids = {
             run_id for _, run_id in set(inline_runs) | set(async_runs)
         }
+        # Uniqueness is judged as uniqueness, not as a fixed count: pinning
+        # these to 14/15/58 made one duplicate compose call (already rejected
+        # by composition_inline_observed's exactly-once contract) cascade into
+        # three unrelated structure assertions in run e0-r4-20260818
+        # (masc#28976). Each failure mode stays owned by exactly one check.
         composition_run_ids_globally_unique = (
-            len(inline_runs) == 14
-            and len(async_runs) == 1
-            and len(all_composition_run_ids) == 15
+            len(inline_runs) > 0
+            and len(async_runs) > 0
+            and len(all_composition_run_ids) == len(inline_runs) + len(async_runs)
         )
         all_nested_action_identities_globally_unique = (
-            len(all_nested_action_rows) == 58
-            and len({row.get("execution_id") for row in all_nested_action_rows}) == 58
-            and len({row.get("tool_use_id") for row in all_nested_action_rows}) == 58
+            len(all_nested_action_rows) > 0
+            and len({row.get("execution_id") for row in all_nested_action_rows})
+            == len(all_nested_action_rows)
+            and len({row.get("tool_use_id") for row in all_nested_action_rows})
+            == len(all_nested_action_rows)
         )
 
         coordinator_runtime_turn_ids: dict[str, int] = {}
@@ -1564,7 +1658,10 @@ class MissionRun:
                 continue
             coordinator_runtime_turn_ids[label] = next(iter(keeper_turn_ids))
         required_inline_rows = [rows for _, rows in inline_turn_runs.values()]
-        parallel_schedule_observed = len(required_inline_rows) == 14 and all(
+        # Structure is judged over every attributed run; the 14-turn
+        # exactly-once count contract is composition_inline_observed's job
+        # alone (see the uniqueness comment above).
+        parallel_schedule_observed = len(required_inline_rows) > 0 and all(
             all(
                 any(
                     row.get("composition_node_id") == node
@@ -1577,7 +1674,7 @@ class MissionRun:
             )
             for rows in required_inline_rows
         )
-        sequential_dataflow_observed = len(required_inline_rows) == 14 and all(
+        sequential_dataflow_observed = len(required_inline_rows) > 0 and all(
             any(
                 isinstance(row.get("input"), dict)
                 and row["input"].get("query") == clock_output.get("now_iso")
@@ -1732,9 +1829,22 @@ class MissionRun:
                 self.roles["coordinator"],
             ),
             "tasks_linked_to_goal": (
+                # Goal linkage is judged from the creation receipts (the
+                # server echoes the persisted task, goal_id included); the
+                # Quest Board text projection never renders goal links, so
+                # searching it for the goal id fails even when linkage is
+                # real (masc#28976). The projection still proves the tasks
+                # are alive on the board at observation time.
                 all(task_id.lower() in task_text.lower() for task_id in self.task_ids.values())
-                and self.goal_id.lower() in task_text.lower(),
-                f"{len(self.task_ids)} task ids plus goal id",
+                and len(self.task_create_receipts) == len(self.task_ids)
+                and all(
+                    isinstance(receipt.data, dict)
+                    and receipt.data.get("ok") is True
+                    and receipt.data.get("goal_id") == self.goal_id
+                    for receipt in self.task_create_receipts.values()
+                ),
+                f"{len(self.task_ids)} task ids on the board; "
+                f"{len(self.task_create_receipts)} creation receipts carry goal_id",
             ),
             "parallel_wave_completed": (
                 len(parallel_turns) == 5 and all(turn.status == "passed" for turn in parallel_turns),


### PR DESCRIPTION
## 무엇이 문제였나 (#28976, #28975)

r4 첫 완주에서 37개 assertion 중 15개 FAIL — 다수가 **실제 성공의 오판**이었어요:

1. `_tool_events`가 masc_agent_timeline(손실성 창 — limit 미만에서도 초반 턴 이벤트 유실)만 읽어 fusion/memory_write/annotate 성공이 전부 FAIL로 뒤집힘. durable inspector rows에는 전부 기록돼 있었습니다.
2. `tasks_linked_to_goal`이 goal 링크를 렌더링하지 않는 Quest Board 텍스트에서 goal id를 검색.
3. composition 전역 유일성 절이 개수(14/15/58)에 고정돼, exactly-once 위반 1건(inline_observed가 이미 잡음)이 무관한 구조 판정 3종을 연쇄로 죽임.
4. preflight가 composition 카탈로그 설치를 검증 안 해 r3가 8분 뒤 하류 증상으로 죽음.
5. RW06 evidence 경로가 RFC-0266 이전 stale.

## 수리

- `_tool_events` → durable tool-call inspector rows (기존 수집 재사용, 동일 이벤트 shape 정규화, ts 정렬, composition-nested 제외)
- `tasks_linked_to_goal` → 생성 영수증(서버 echo의 goal_id) + board 생존 확인
- 유일성은 유일성으로 판정 (magic count 해체), 구조 판정은 attributed runs 전수 위에서
- inspector 수집 limit 200→500
- preflight에 composition catalog 검증 추가 (fixture SSOT 대조, missing_file/missing_names/unparseable 리포트)
- missions.json RW06 evidence를 durable 경로로

## 검증 (r4 실증거 오프라인 재판정)

- 뒤집혀야 할 판정 7종 전부 PASS 전환: fusion/memory_write/schedule_get/builder-b annotate/양 builder write + tasks_linked_to_goal 영수증 6/6
- **뒤집히면 안 되는 것 보존**: builder-a의 실제 annotate 거부는 여전히 FAIL(#28977), 거부→복구 순서 판정, masc_task_update 부재 검사 무결
- 유일성: 16 runs / 62 nested rows 전 축 unique. 구조+dataflow(clock→memory): 15/15 inline runs
- preflight: live root=ok, 빈 root=missing_file

## 후속

러너 SHA 계약상 머지 후 재배포 필요. r5 캠페인은 SHA 고정 worktree에서 실행 예정(공유 checkout pull 레이스 방지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)