### PR TITLE
fix(keeper): nonzero exit을 실패한 effect가 아닌 관측된 결과로 취급

### DIFF
--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -772,32 +772,40 @@ let handle_tool_execute_typed
                     @ sandbox_extra_fields
                     @ dispatched_model_location_fields)
                in
+               (* A process that ran and exited nonzero (or died to a
+                  signal) is an observed tool result the model reads and
+                  reacts to — the payload carries ok:false, the exit
+                  status, and stderr. Routing it through the failure
+                  disposition marked the whole turn
+                  Terminal_effect_failed (sticky), so a keeper probing a
+                  missing path with `ls` died mid-mission — four turn
+                  deaths across the E0 campaign and the polisher pilot
+                  (masc#28983). Only infra failures — sandbox dispatch,
+                  secret projection, output/manifest persistence — keep
+                  the failure disposition. *)
                authorized
-                 (if succeeded
-                  then
-                    (match
-                       Tool_bridge.attach_artifact_manifest
-                         ~base_path:config.base_path
-                         (Tool_result.make_ok
-                            ~tool_name:"tool_execute"
-                            ~start_time:t0
-                            ~data:payload
-                            ())
-                     with
-                     | Ok result -> Keeper_tool_execution.of_tool_result result
-                     | Error _ ->
-                       Keeper_tool_execution.failure
-                         ~effect_disposition:Tool_result.Proven_post_effect
-                         (error_json
-                            ~fields:
-                              ([ "typed", `Bool true
-                               ; "code", `String "execute_result_manifest_failed"
-                               ; "status", status_json
-                               ; "execution_time_ms", `Int elapsed_ms
-                               ]
-                               @ dispatched_model_location_fields)
-                            "Execute completed, but its result manifest could not be persisted."))
-                  else Keeper_tool_execution.failure (Yojson.Safe.to_string payload)))
+                 (match
+                    Tool_bridge.attach_artifact_manifest
+                      ~base_path:config.base_path
+                      (Tool_result.make_ok
+                         ~tool_name:"tool_execute"
+                         ~start_time:t0
+                         ~data:payload
+                         ())
+                  with
+                  | Ok result -> Keeper_tool_execution.of_tool_result result
+                  | Error _ ->
+                    Keeper_tool_execution.failure
+                      ~effect_disposition:Tool_result.Proven_post_effect
+                      (error_json
+                         ~fields:
+                           ([ "typed", `Bool true
+                            ; "code", `String "execute_result_manifest_failed"
+                            ; "status", status_json
+                            ; "execution_time_ms", `Int elapsed_ms
+                            ]
+                            @ dispatched_model_location_fields)
+                         "Execute completed, but its result manifest could not be persisted.")))
         )))))
 
 let handle_tool_execute_with_outcome

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -224,6 +224,7 @@ normal_targets=(
   @test/runtest-test_mcp_session_task_lifecycle
   @test/runtest-test_mcp_server_eio
   @test/runtest-test_keeper_sandbox_docker_cwd_response
+  @test/runtest-test_keeper_tool_execute_exit_result
   @test/runtest-test_goal_store
   @test/runtest-test_keeper_goal_phase_projection
   @test/runtest-test_keeper_tool_descriptor_registry_integrity

--- a/test/dune
+++ b/test/dune
@@ -1914,6 +1914,7 @@
 (include stanzas/test_keeper_autonomous_turn_source.inc)
 
 (include stanzas/test_keeper_sandbox_docker_cwd_response.inc)
+(include stanzas/test_keeper_tool_execute_exit_result.inc)
 
 (include stanzas/test_keeper_replay_checkpoint.inc)
 

--- a/test/stanzas/test_keeper_tool_execute_exit_result.inc
+++ b/test/stanzas/test_keeper_tool_execute_exit_result.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_tool_execute_exit_result)
+ (modules test_keeper_tool_execute_exit_result)
+ (libraries masc masc_test_deps alcotest yojson unix))

--- a/test/test_keeper_tool_execute_exit_result.ml
+++ b/test/test_keeper_tool_execute_exit_result.ml
@@ -1,0 +1,160 @@
+(** Regression pin for masc#28983.
+
+    A process that runs and exits nonzero is an observed tool result the
+    model reads and reacts to — not a failed terminal effect. The previous
+    routing sent every nonzero exit through
+    [Keeper_tool_execution.failure], whose [Failed] disposition the tool
+    bundle promotes to a sticky [Terminal_effect_failed], killing the
+    whole turn: four keeper turn deaths across the E0 campaign and the
+    polisher pilot (2026-08-18) traced to probes like [ls] on a missing
+    path.
+
+    Pins: a nonzero exit produces a [Completed] execution whose payload
+    still reports [ok=false] and the exit status; an exit-0 run stays
+    [Completed] with [ok=true]. *)
+
+open Alcotest
+open Masc
+
+let temp_dir prefix =
+  let dir = Filename.temp_file prefix "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir path =
+  let rec rm p =
+    match Unix.lstat p with
+    | { Unix.st_kind = Unix.S_DIR; _ } ->
+      Array.iter (fun name -> rm (Filename.concat p name)) (Sys.readdir p);
+      Unix.rmdir p
+    | _ -> Unix.unlink p
+    | exception Unix.Unix_error _ -> ()
+  in
+  rm path
+
+let make_local_meta ~name : Keeper_meta_contract.keeper_meta =
+  let json =
+    `Assoc
+      [ ("name", `String name)
+      ; ("agent_name", `String ("keeper-" ^ name ^ "-agent"))
+      ; ("trace_id", `String ("trace-" ^ name))
+      ; ("allowed_paths", `List [ `String "*" ])
+      ]
+  in
+  match Masc_test_deps.meta_of_json_fixture json with
+  | Ok meta ->
+    { meta with sandbox_profile = Keeper_types_profile_sandbox.Local }
+  | Error e -> Alcotest.fail e
+
+let rec mkdir_p path =
+  if path = "" || path = Filename.dir_sep || Sys.file_exists path then ()
+  else begin
+    mkdir_p (Filename.dirname path);
+    Unix.mkdir path 0o755
+  end
+
+let playground_dir ~base ~name =
+  let dir =
+    List.fold_left Filename.concat base [ ".masc"; "playground"; name ]
+  in
+  mkdir_p dir;
+  dir
+
+(* The live workspace runs the Gate in always_allow mode (mode.json); the
+   test mirrors that so tool_execute is authorized instead of deferred. *)
+let install_always_allow_gate ~base =
+  let gate_dir = List.fold_left Filename.concat base [ ".masc"; "gate" ] in
+  mkdir_p gate_dir;
+  let oc = open_out (Filename.concat gate_dir "mode.json") in
+  output_string oc
+    {|{"mode":"always_allow","updated_by":"test","updated_at":"2026-08-18T00:00:00Z"}|};
+  close_out oc
+
+let run_execute ~config ~meta ~argv ~cwd =
+  Keeper_tool_execute_runtime.handle_tool_execute_with_outcome
+    ~turn_sandbox_factory:None
+    ~config
+    ~meta
+    ~args:
+      (`Assoc
+        [ "argv", `List (List.map (fun a -> `String a) argv)
+        ; "cwd", `String cwd
+        ])
+    ()
+
+let payload_of (execution : Keeper_tool_execution.t) =
+  Yojson.Safe.from_string execution.raw_output
+
+let test_nonzero_exit_is_a_completed_result () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base = temp_dir "exec_exit_result_" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base)
+    (fun () ->
+      let config = Workspace.default_config base in
+      (match Keeper_approval_queue.install_persistence ~base_path:base with
+       | Ok _ -> ()
+       | Error error ->
+         Alcotest.fail (Keeper_approval_queue.install_error_to_string error));
+      install_always_allow_gate ~base;
+      let meta = make_local_meta ~name:"exit-result-pin" in
+      (* Inside the keeper playground the effect is authorized via
+         workspace_always_allow, so the test needs no Gate store. *)
+      let cwd = playground_dir ~base ~name:"exit-result-pin" in
+      let execution =
+        run_execute ~config ~meta ~argv:[ "ls"; "definitely-missing-dir" ] ~cwd
+      in
+      (match execution.disposition with
+       | Tool_result.Completed () -> ()
+       | Tool_result.Failed _ ->
+         Alcotest.failf
+           "nonzero exit must stay a completed tool result, got failure: %s"
+           execution.raw_output
+       | Tool_result.Deferred () ->
+         Alcotest.fail "nonzero exit must not defer");
+      let open Yojson.Safe.Util in
+      let payload = payload_of execution in
+      check bool "payload reports ok=false" false
+        (payload |> member "ok" |> to_bool);
+      check string "payload reports the exit status" "exit"
+        (payload |> member "status" |> member "kind" |> to_string);
+      check bool "payload keeps a nonzero code" true
+        (payload |> member "status" |> member "code" |> to_int <> 0))
+
+let test_zero_exit_stays_ok () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base = temp_dir "exec_exit_ok_" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base)
+    (fun () ->
+      let config = Workspace.default_config base in
+      (match Keeper_approval_queue.install_persistence ~base_path:base with
+       | Ok _ -> ()
+       | Error error ->
+         Alcotest.fail (Keeper_approval_queue.install_error_to_string error));
+      install_always_allow_gate ~base;
+      let meta = make_local_meta ~name:"exit-ok-pin" in
+      let cwd = playground_dir ~base ~name:"exit-ok-pin" in
+      let execution = run_execute ~config ~meta ~argv:[ "true" ] ~cwd in
+      (match execution.disposition with
+       | Tool_result.Completed () -> ()
+       | Tool_result.Failed _ | Tool_result.Deferred () ->
+         Alcotest.failf "exit 0 must complete, got: %s" execution.raw_output);
+      let open Yojson.Safe.Util in
+      check bool "payload reports ok=true" true
+        (payload_of execution |> member "ok" |> to_bool))
+
+let () =
+  run
+    "keeper_tool_execute_exit_result"
+    [ ( "exit-status-is-a-result"
+      , [ test_case
+            "nonzero exit is a completed result"
+            `Quick
+            test_nonzero_exit_is_a_completed_result
+        ; test_case "zero exit stays ok" `Quick test_zero_exit_stays_ok
+        ] )
+    ]


### PR DESCRIPTION
## 무엇이 문제였나 (#28983)

Execute의 프로세스가 nonzero exit(또는 시그널 사망)하면 `Keeper_tool_execution.failure`로 라우팅됐고, 번들이 Execute 실패를 sticky한 `Terminal_effect_failed`로 승격 → **`ls` 한 번이 keeper 턴 전체를 죽였습니다**. E0 캠페인·polisher 파일럿에서 턴 사망 4건이 이 경로였어요 (builders의 `ls artifacts`, polisher의 틸드 경로, 리뷰 대응 지시).

## 수리

payload가 이미 모든 것을 전달합니다(ok:false, exit status, stderr) — nonzero exit 분기를 exit 0과 같은 **완료된 도구 결과**로 반환해 모델이 읽고 대응하게 했어요(모든 코딩 에이전트의 shell 의미론). 인프라 실패(sandbox dispatch, secret projection, 출력/manifest 영속화, cwd 검증, Gate 거부)는 failure 유지.

## 관측성 노트

durable tool-call inspector row는 이제 nonzero-exit Execute를 dispatch 성공 + payload ok:false로 기록해요. exit 의미가 필요한 소비자는 payload status를 읽으면 됩니다.

## 검증

- 신규 pin 스위트 `test_keeper_tool_execute_exit_result` (CI 배선, unwired baseline 528 불변): nonzero exit → Completed + ok:false + exit status 보존, exit 0 → ok:true. 테스트 하네스는 라이브 환경 그대로 재현(fs capability, gate persistence, always_allow mode, playground cwd).
- **역검증**: lib 수정만 되돌린 트리에서 pin이 라이브 사망 payload 그대로 FAIL — 수리가 판정을 뒤집는 유일 변수임을 확증.
- analyst 생존 사례(exit 128 후 board_post 성공)와의 비대칭도 이 수리로 소멸 — 이제 어떤 순서든 nonzero exit은 결과입니다.

머지 후 재배포되면 polisher 파일럿과 E0 RW01/03/17 재판정이 이 수리의 라이브 검증이 됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)