### PR TITLE
fix(scripts): binary-only 배포에서 dashboard stamp가 stale로 남는 계약 갭 수리

### DIFF
--- a/scripts/build-dashboard-if-needed.sh
+++ b/scripts/build-dashboard-if-needed.sh
@@ -119,5 +119,17 @@ if needs_rebuild; then
   touch "$STAMP"
   echo "[dashboard] Build complete." >&2
 else
-  echo "[dashboard] Up to date, skipping." >&2
+  # Binary-only deploys leave the stamp older than the freshly built server
+  # binary, and the server compares stamp mtime against its own executable
+  # (lib/web_dashboard.ml bundle_freshness) — so /health reported the bundle
+  # as stale even though it matches the sources (#28973). The stamp asserts
+  # source-bundle consistency; when that holds (needs_rebuild said no) and
+  # the server binary is newer, refresh the stamp instead of rebuilding.
+  server_bin="$REPO_ROOT/_build/default/bin/main_eio.exe"
+  if [ -f "$server_bin" ] && [ "$server_bin" -nt "$STAMP" ]; then
+    touch "$STAMP"
+    echo "[dashboard] Up to date; stamp refreshed past newer server binary (#28973)." >&2
+  else
+    echo "[dashboard] Up to date, skipping." >&2
+  fi
 fi


### PR DESCRIPTION
## 목표
#28973 수리 — 서버는 stamp mtime vs 자기 바이너리 mtime으로 stale을 판정하는데(lib/web_dashboard.ml bundle_freshness), wrapper는 소스 vs stamp만 봐서 binary-only 배포마다 /health가 dashboard stale을 보고했다. 오늘 5번의 배포 창 중 3번에서 수동 stamp 재빌드가 필요했던 마찰의 근본 수리.

## 접근
재빌드 강제가 아니라 **stamp 갱신**: needs_rebuild가 '번들이 소스와 일치'라고 판정한 상태에서 서버 바이너리가 stamp보다 새로우면 touch만 한다. stamp의 의미론(소스-번들 일치 증명)을 왜곡하지 않고, make build마다 10초 재빌드가 따라붙는 비용도 없다.

## 검증
- 시뮬레이션: stamp(소스보다 새로움, 바이너리보다 오래됨) 상태에서 1회차 실행 → stamp refreshed + mtime 역전 해소 확인, 2회차 실행 → skip (멱등)
- bash -n 문법 검사 통과

Closes #28973

🤖 Generated with [Claude Code](https://claude.com/claude-code)