### PR TITLE
feat(verification): 검증자가 직접 검사하는 typed pull-request 증거 (#28989)

### DIFF
--- a/lib/github_pull_request_evidence.ml
+++ b/lib/github_pull_request_evidence.ml
@@ -1,0 +1,120 @@
+module Store = Workspace_verification_store
+
+let github_api_prefix = "https://api.github.com/repos/"
+let fetch_timeout_sec = 15
+
+let api_url (locator : Store.pull_request_locator) =
+  Printf.sprintf
+    "%s%s/%s/pulls/%d"
+    github_api_prefix
+    locator.owner
+    locator.repo
+    locator.number
+
+let string_member json key =
+  match json with
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`String value) -> Some value
+     | Some _ | None -> None)
+  | _ -> None
+
+let bool_member json key =
+  match json with
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`Bool value) -> Some value
+     | Some _ | None -> None)
+  | _ -> None
+
+let get ~accept url =
+  Tool_local_runtime_http.http_get_text_with_status_with_headers
+    ~timeout_sec:fetch_timeout_sec
+    ~headers:
+      [ "Accept", accept
+      ; "X-GitHub-Api-Version", "2022-11-28"
+      ; "User-Agent", "masc-verification-evidence"
+      ]
+    ~follow_redirects:true
+    url
+
+let fetch_metadata locator =
+  match get ~accept:"application/vnd.github+json" (api_url locator) with
+  | Error detail -> Error (Store.Pull_request_transport detail)
+  | Ok (Some 200, body) ->
+    (match Yojson.Safe.from_string body with
+     | exception Yojson.Json_error detail ->
+       Error (Store.Pull_request_payload_invalid detail)
+     | json ->
+       let head_sha =
+         match json with
+         | `Assoc fields ->
+           (match List.assoc_opt "head" fields with
+            | Some head -> string_member head "sha"
+            | None -> None)
+         | _ -> None
+       in
+       (match
+          ( string_member json "state"
+          , bool_member json "merged"
+          , bool_member json "draft"
+          , head_sha
+          , string_member json "title" )
+        with
+        | Some state, Some merged, Some draft, Some head_sha, Some title ->
+          Ok (state, merged, draft, head_sha, title)
+        | _ ->
+          Error
+            (Store.Pull_request_payload_invalid
+               "pull-request object is missing state/merged/draft/head.sha/title")))
+  | Ok (Some status, _) -> Error (Store.Pull_request_http_status status)
+  | Ok (None, _) ->
+    Error (Store.Pull_request_transport "no HTTP status from GitHub")
+
+let fetch_diff locator =
+  (* One byte of headroom over the cap distinguishes "exactly cap" from
+     "curl stopped at the cap": a body longer than the cap is truncated
+     to it and flagged. *)
+  let cap = Store.verification_evidence_max_bytes in
+  match
+    Tool_local_runtime_http.http_get_text_with_status_with_headers
+      ~timeout_sec:fetch_timeout_sec
+      ~headers:
+        [ "Accept", "application/vnd.github.v3.diff"
+        ; "X-GitHub-Api-Version", "2022-11-28"
+        ; "User-Agent", "masc-verification-evidence"
+        ]
+      ~follow_redirects:true
+      ~max_response_bytes:(cap + 1)
+      (api_url locator)
+  with
+  | Error detail -> Error (Store.Pull_request_transport detail)
+  | Ok (Some 200, body) ->
+    let bytes = String.length body in
+    if bytes > cap
+    then Ok (String.sub body 0 cap, bytes, true)
+    else Ok (body, bytes, false)
+  | Ok (Some status, _) -> Error (Store.Pull_request_http_status status)
+  | Ok (None, _) ->
+    Error (Store.Pull_request_transport "no HTTP status from GitHub")
+
+let inspect locator =
+  match fetch_metadata locator with
+  | Error _ as error -> error
+  | Ok (state, merged, draft, head_sha, title) ->
+    (match fetch_diff locator with
+     | Error _ as error -> error
+     | Ok (diff, diff_bytes, diff_truncated) ->
+       Ok
+         { Store.url = Store.pull_request_locator_url locator
+         ; state
+         ; merged
+         ; draft
+         ; head_sha
+         ; title
+         ; diff
+         ; diff_bytes
+         ; diff_truncated
+         })
+
+let install () = Store.install_pull_request_inspector inspect

--- a/lib/github_pull_request_evidence.mli
+++ b/lib/github_pull_request_evidence.mli
@@ -1,0 +1,23 @@
+(** GitHub reader for [pull-request:] evidence references (masc#28989).
+
+    The verification store owns the evidence contract but stays free of
+    transport dependencies, so the composition root installs {!inspect}
+    into it at startup via
+    [Workspace_verification_store.install_pull_request_inspector].
+
+    Two GETs against api.github.com per snapshot: the pull-request object
+    (state, merged, draft, head sha, title) and the diff, the latter
+    bounded by the store's evidence byte cap. Unauthenticated — the
+    target repos are public; a non-200 comes back as a typed
+    [Pull_request_http_status] the verifier can reason about. *)
+
+val inspect :
+  Workspace_verification_store.pull_request_locator ->
+  ( Workspace_verification_store.pull_request_snapshot
+  , Workspace_verification_store.pull_request_fetch_failure )
+  result
+
+val install : unit -> unit
+(** [install ()] registers {!inspect} as the store's forge reader. Call once
+    from the server composition root, beside the other startup capability
+    installs. *)

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -456,6 +456,7 @@ let create_server_state ~sw ~base_path ?input_base_path ~clock ~mono_clock ~net
   let base_path = Env_config_core.normalize_masc_base_path_input base_path in
   Runtime_params.initialize ~base_path;
   Fs_compat.set_fs fs;
+  Github_pull_request_evidence.install ();
   Mcp_eio.set_net net;
   Mcp_eio.set_clock clock;
   Eio_context.set_switch sw;
@@ -755,6 +756,7 @@ let initialize_owner_state_blocking
       (Owner_initialization_failed
          (Startup_path_guard_rejected path_diagnostics));
   Fs_compat.set_fs fs;
+  Github_pull_request_evidence.install ();
   let masc_dir = Common.masc_dir_from_base_path ~base_path in
   let fusion_registry =
     Filename.concat masc_dir "fusion-runs.jsonl" |> Fusion_run_registry.replay

--- a/lib/task/tool_task_completion_review.ml
+++ b/lib/task/tool_task_completion_review.ml
@@ -26,7 +26,8 @@ let unresolvable_evidence_ref value =
   with
   | Workspace_verification_store.Unresolvable_reference -> true
   | Workspace_verification_store.Artifact_reference _
-  | Workspace_verification_store.Note_reference _ -> false
+  | Workspace_verification_store.Note_reference _
+  | Workspace_verification_store.Pull_request_reference _ -> false
 ;;
 
 let resolvable_evidence_ref_forms =

--- a/lib/task/tool_task_schemas.ml
+++ b/lib/task/tool_task_schemas.ml
@@ -11,13 +11,17 @@ let handoff_context_description =
   "Typed handoff payload. 'summary' is REQUIRED (non-empty) for exit-class \
      actions (submit_for_verification / done / release / cancel). On \
      action='submit_for_verification', every 'evidence_refs' entry must use \
-     'artifact:<producer-root-relative-path>' for a bounded file snapshot or \
-     'note:<text>' for narrative evidence. URLs, commits, and traces are not \
-     fetched by the system LLM lane; materialize their relevant contents as an \
-     artifact when they are required proof. Bare relative paths \
+     'artifact:<producer-root-relative-path>' for a bounded file snapshot, \
+     'note:<text>' for narrative evidence, or \
+     'pull-request:https://github.com/<owner>/<repo>/pull/<number>' for a \
+     GitHub PR — the system fetches the PR state, head sha, and a bounded \
+     diff itself, so the verifier inspects the forge directly. Other URLs, \
+     commits, and traces are not fetched; materialize their relevant contents \
+     as an artifact when they are required proof. Bare relative paths \
      and absolute host paths are persisted as typed invalid references. The \
-     list itself is optional. Example: {\"summary\": \"tests green, local proof saved\", \
-     \"evidence_refs\": [\"artifact:artifacts/proof.json\"]}."
+     list itself is optional. Example: {\"summary\": \"tests green, PR open\", \
+     \"evidence_refs\": [\"artifact:artifacts/proof.json\", \
+     \"pull-request:https://github.com/jeong-sik/masc/pull/28988\"]}."
 
 let schemas : Masc_domain.tool_schema list = [
   {
@@ -267,7 +271,7 @@ Tip: Look for status='todo' tasks to claim.";
             ("evidence_refs", `Assoc [
               ("type", `String "array");
               ("items", `Assoc [ ("type", `String "string"); ("minLength", `Int 1) ]);
-              ("description", `String "Typed verifier evidence. Use artifact:<producer-root-relative-path> for files or note:<text> for narrative, commit, trace, receipt, or URL evidence. Bare and absolute paths are invalid.");
+              ("description", `String "Typed verifier evidence. Use artifact:<producer-root-relative-path> for files, note:<text> for narrative/commit/trace/receipt evidence, or pull-request:https://github.com/<owner>/<repo>/pull/<number> for a GitHub PR the system fetches itself. Bare and absolute paths are invalid.");
             ]);
           ]);
           ("required", `List [`String "summary"]);

--- a/lib/workspace/workspace_verification_store.ml
+++ b/lib/workspace/workspace_verification_store.ml
@@ -16,6 +16,30 @@ type evidence_read_failure =
   | Evidence_changed_during_read
   | Evidence_read_error of string
 
+type pull_request_locator =
+  { owner : string
+  ; repo : string
+  ; number : int
+  }
+
+type pull_request_snapshot =
+  { url : string
+  ; state : string
+  ; merged : bool
+  ; draft : bool
+  ; head_sha : string
+  ; title : string
+  ; diff : string
+  ; diff_bytes : int
+  ; diff_truncated : bool
+  }
+
+type pull_request_fetch_failure =
+  | Pull_request_inspector_uninstalled
+  | Pull_request_transport of string
+  | Pull_request_http_status of int
+  | Pull_request_payload_invalid of string
+
 type submitted_evidence_item =
   | Evidence_note of string
   | Evidence_artifact of
@@ -29,6 +53,33 @@ type submitted_evidence_item =
       { reference : string
       ; reason : evidence_read_failure
       }
+  | Evidence_pull_request of
+      { reference : string
+      ; snapshot : pull_request_snapshot
+      }
+  | Evidence_pull_request_unreadable of
+      { reference : string
+      ; reason : pull_request_fetch_failure
+      }
+
+(* The forge reader is installed by the composition root at startup; this
+   store stays free of transport dependencies (masc#28989). Stdlib mutex:
+   installation happens during bootstrap and reads are non-yielding. *)
+let pull_request_inspector :
+  (pull_request_locator ->
+   (pull_request_snapshot, pull_request_fetch_failure) result)
+    option
+    Atomic.t
+  =
+  Atomic.make None
+
+let install_pull_request_inspector inspector =
+  Atomic.set pull_request_inspector (Some inspector)
+
+let inspect_pull_request locator =
+  match Atomic.get pull_request_inspector with
+  | None -> Error Pull_request_inspector_uninstalled
+  | Some inspector -> inspector locator
 
 type evidence_access_failure =
   | Completion_authority_identity_missing
@@ -89,6 +140,52 @@ let evidence_read_failure_of_yojson = function
      | _ -> Error "submitted evidence snapshot has an invalid unreadable reason")
   | _ -> Error "submitted evidence snapshot unreadable reason must be an object"
 
+let pull_request_fetch_failure_code = function
+  | Pull_request_inspector_uninstalled -> "inspector_uninstalled"
+  | Pull_request_transport _ -> "transport"
+  | Pull_request_http_status _ -> "http_status"
+  | Pull_request_payload_invalid _ -> "payload_invalid"
+
+let pull_request_fetch_failure_to_yojson reason =
+  match reason with
+  | Pull_request_inspector_uninstalled ->
+    `Assoc [ "code", `String "inspector_uninstalled" ]
+  | Pull_request_transport detail ->
+    `Assoc [ "code", `String "transport"; "detail", `String detail ]
+  | Pull_request_http_status status ->
+    `Assoc [ "code", `String "http_status"; "status", `Int status ]
+  | Pull_request_payload_invalid detail ->
+    `Assoc [ "code", `String "payload_invalid"; "detail", `String detail ]
+
+let pull_request_fetch_failure_of_yojson = function
+  | `Assoc fields ->
+    (match List.sort (fun (left, _) (right, _) -> String.compare left right) fields with
+     | [ "code", `String "inspector_uninstalled" ] ->
+       Ok Pull_request_inspector_uninstalled
+     | [ "code", `String "transport"; "detail", `String detail ] ->
+       Ok (Pull_request_transport detail)
+     | [ "code", `String "http_status"; "status", `Int status ] ->
+       Ok (Pull_request_http_status status)
+     | [ "code", `String "payload_invalid"; "detail", `String detail ] ->
+       Ok (Pull_request_payload_invalid detail)
+     | _ ->
+       Error "submitted evidence snapshot has an invalid pull-request reason")
+  | _ ->
+    Error "submitted evidence snapshot pull-request reason must be an object"
+
+let pull_request_snapshot_to_yojson (snapshot : pull_request_snapshot) =
+  `Assoc
+    [ "url", `String snapshot.url
+    ; "state", `String snapshot.state
+    ; "merged", `Bool snapshot.merged
+    ; "draft", `Bool snapshot.draft
+    ; "head_sha", `String snapshot.head_sha
+    ; "title", `String snapshot.title
+    ; "diff", `String snapshot.diff
+    ; "diff_bytes", `Int snapshot.diff_bytes
+    ; "diff_truncated", `Bool snapshot.diff_truncated
+    ]
+
 let submitted_evidence_item_to_yojson = function
   | Evidence_note note ->
     `Assoc [ "kind", `String "note"; "content", `String note ]
@@ -110,6 +207,18 @@ let submitted_evidence_item_to_yojson = function
       [ "kind", `String "artifact_unreadable"
       ; "reference", `String reference
       ; "reason", evidence_read_failure_to_yojson reason
+      ]
+  | Evidence_pull_request { reference; snapshot } ->
+    `Assoc
+      [ "kind", `String "pull_request"
+      ; "reference", `String reference
+      ; "snapshot", pull_request_snapshot_to_yojson snapshot
+      ]
+  | Evidence_pull_request_unreadable { reference; reason } ->
+    `Assoc
+      [ "kind", `String "pull_request_unreadable"
+      ; "reference", `String reference
+      ; "reason", pull_request_fetch_failure_to_yojson reason
       ]
 
 let request_header_to_yojson request =
@@ -186,6 +295,22 @@ let submitted_evidence_item_metadata_to_yojson = function
       [ "kind", `String "artifact_unreadable"
       ; "reference", `String reference
       ; "reason", `String (evidence_read_failure_code reason)
+      ]
+  | Evidence_pull_request { reference; snapshot } ->
+    `Assoc
+      [ "kind", `String "pull_request"
+      ; "reference", `String reference
+      ; "state", `String snapshot.state
+      ; "merged", `Bool snapshot.merged
+      ; "head_sha", `String snapshot.head_sha
+      ; "diff_bytes", `Int snapshot.diff_bytes
+      ; "diff_truncated", `Bool snapshot.diff_truncated
+      ]
+  | Evidence_pull_request_unreadable { reference; reason } ->
+    `Assoc
+      [ "kind", `String "pull_request_unreadable"
+      ; "reference", `String reference
+      ; "reason", `String (pull_request_fetch_failure_code reason)
       ]
 ;;
 
@@ -294,6 +419,91 @@ let submitted_evidence_item_of_yojson = function
         | _, _, _ ->
           Error
             "submitted evidence unreadable item has unexpected fields")
+     | Some (`String "pull_request") ->
+       let open Result.Syntax in
+       let* () =
+         Json_util.reject_unknown_fields
+           ~surface:"submitted evidence pull request"
+           ~allowed:[ "kind"; "reference"; "snapshot" ]
+           fields
+       in
+       let* reference = string_field "reference" in
+       let* snapshot_fields =
+         match List.assoc_opt "snapshot" fields with
+         | Some (`Assoc snapshot_fields) -> Ok snapshot_fields
+         | Some value ->
+           Error
+             (Printf.sprintf
+                "submitted evidence pull-request snapshot must be an object, got %s"
+                (Json_util.excerpt value))
+         | None ->
+           Error "submitted evidence snapshot is missing pull-request snapshot"
+       in
+       let snapshot_string key =
+         match List.assoc_opt key snapshot_fields with
+         | Some (`String value) -> Ok value
+         | _ ->
+           Error
+             (Printf.sprintf
+                "submitted evidence pull-request snapshot needs string %s"
+                key)
+       in
+       let snapshot_bool key =
+         match List.assoc_opt key snapshot_fields with
+         | Some (`Bool value) -> Ok value
+         | _ ->
+           Error
+             (Printf.sprintf
+                "submitted evidence pull-request snapshot needs bool %s"
+                key)
+       in
+       let* () =
+         Json_util.reject_unknown_fields
+           ~surface:"submitted evidence pull request snapshot"
+           ~allowed:
+             [ "url"; "state"; "merged"; "draft"; "head_sha"; "title"
+             ; "diff"; "diff_bytes"; "diff_truncated" ]
+           snapshot_fields
+       in
+       let* url = snapshot_string "url" in
+       let* state = snapshot_string "state" in
+       let* merged = snapshot_bool "merged" in
+       let* draft = snapshot_bool "draft" in
+       let* head_sha = snapshot_string "head_sha" in
+       let* title = snapshot_string "title" in
+       let* diff = snapshot_string "diff" in
+       let* diff_bytes =
+         match List.assoc_opt "diff_bytes" snapshot_fields with
+         | Some (`Int value) when value >= 0 -> Ok value
+         | _ ->
+           Error
+             "submitted evidence pull-request snapshot needs non-negative diff_bytes"
+       in
+       let* diff_truncated = snapshot_bool "diff_truncated" in
+       Ok
+         (Evidence_pull_request
+            { reference
+            ; snapshot =
+                { url; state; merged; draft; head_sha; title
+                ; diff; diff_bytes; diff_truncated }
+            })
+     | Some (`String "pull_request_unreadable") ->
+       let open Result.Syntax in
+       let* () =
+         Json_util.reject_unknown_fields
+           ~surface:"submitted evidence pull request unreadable"
+           ~allowed:[ "kind"; "reference"; "reason" ]
+           fields
+       in
+       let* reference = string_field "reference" in
+       let* reason_json =
+         match List.assoc_opt "reason" fields with
+         | Some reason -> Ok reason
+         | None ->
+           Error "submitted evidence snapshot is missing pull-request reason"
+       in
+       let* reason = pull_request_fetch_failure_of_yojson reason_json in
+       Ok (Evidence_pull_request_unreadable { reference; reason })
      | Some (`String kind) ->
        Error (Printf.sprintf "unknown submitted evidence snapshot kind %S" kind)
      | Some value ->
@@ -503,6 +713,7 @@ let read_regular_file_prefix ~ownership_root path =
 
 let artifact_reference_prefix = "artifact:"
 let note_reference_prefix = "note:"
+let pull_request_reference_prefix = "pull-request:"
 
 let strip_prefix ~prefix value =
   if String.starts_with ~prefix value
@@ -514,6 +725,36 @@ let strip_prefix ~prefix value =
          (String.length value - String.length prefix))
   else None
 
+let pull_request_url_prefix = "https://github.com/"
+
+(* Parse, don't validate: the reference admits exactly
+   [https://github.com/<owner>/<repo>/pull/<number>] and yields the typed
+   locator. Anything else is Unresolvable at submit, so a malformed URL can
+   never reach the forge reader. *)
+let parse_pull_request_url url =
+  match strip_prefix ~prefix:pull_request_url_prefix url with
+  | None -> None
+  | Some rest ->
+    let segment_ok segment =
+      not (String.equal segment "")
+      && String.for_all
+           (fun ch ->
+             match ch with
+             | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '-' | '_' | '.' -> true
+             | _ -> false)
+           segment
+    in
+    (match String.split_on_char '/' rest with
+     | [ owner; repo; "pull"; number ]
+       when segment_ok owner && segment_ok repo ->
+       (match int_of_string_opt number with
+        | Some n when n > 0 -> Some { owner; repo; number = n }
+        | Some _ | None -> None)
+     | _ -> None)
+
+let pull_request_locator_url { owner; repo; number } =
+  Printf.sprintf "%s%s/%s/pull/%d" pull_request_url_prefix owner repo number
+
 (* The shape this store can read, decided without touching the filesystem.
    [snapshot_submitted_evidence_item] below is the only producer of evidence
    snapshots and answers [Evidence_invalid_reference] for anything else, so the
@@ -523,6 +764,7 @@ let strip_prefix ~prefix value =
 type reference_form =
   | Artifact_reference of string
   | Note_reference of string
+  | Pull_request_reference of pull_request_locator
   | Unresolvable_reference
 
 let classify_evidence_reference reference =
@@ -532,7 +774,14 @@ let classify_evidence_reference reference =
     (match strip_prefix ~prefix:note_reference_prefix reference with
      | Some note when not (String.equal (String.trim note) "") ->
        Note_reference note
-     | Some _ | None -> Unresolvable_reference)
+     | Some _ -> Unresolvable_reference
+     | None ->
+       (match strip_prefix ~prefix:pull_request_reference_prefix reference with
+        | Some url ->
+          (match parse_pull_request_url (String.trim url) with
+           | Some locator -> Pull_request_reference locator
+           | None -> Unresolvable_reference)
+        | None -> Unresolvable_reference))
 ;;
 
 let artifact_reference_form =
@@ -540,7 +789,14 @@ let artifact_reference_form =
 ;;
 
 let note_reference_form = note_reference_prefix ^ "<text>"
-let resolvable_reference_forms = [ artifact_reference_form; note_reference_form ]
+
+let pull_request_reference_form =
+  pull_request_reference_prefix
+  ^ pull_request_url_prefix
+  ^ "<owner>/<repo>/pull/<number>"
+
+let resolvable_reference_forms =
+  [ artifact_reference_form; note_reference_form; pull_request_reference_form ]
 
 let valid_producer_relative_path path =
   Filename.is_relative path
@@ -579,6 +835,10 @@ let snapshot_submitted_evidence_item ~base_path ~worker reference =
       ~reference
       relative_path
   | Note_reference note -> Evidence_note note
+  | Pull_request_reference locator ->
+    (match inspect_pull_request locator with
+     | Ok snapshot -> Evidence_pull_request { reference; snapshot }
+     | Error reason -> Evidence_pull_request_unreadable { reference; reason })
   | Unresolvable_reference -> Evidence_invalid_reference
 
 let snapshot_submitted_evidence_json ~base_path ~worker references =
@@ -610,6 +870,20 @@ let submitted_evidence_identity_line (item : Yojson.Safe.t) =
          "%s (unreadable: %s)"
          reference
          (evidence_read_failure_code reason))
+  | Ok (Evidence_pull_request { reference; snapshot }) ->
+    Ok
+      (Printf.sprintf
+         "%s (%s%s, head %s)"
+         reference
+         snapshot.state
+         (if snapshot.merged then ", merged" else "")
+         snapshot.head_sha)
+  | Ok (Evidence_pull_request_unreadable { reference; reason }) ->
+    Ok
+      (Printf.sprintf
+         "%s (unreadable: %s)"
+         reference
+         (pull_request_fetch_failure_code reason))
 ;;
 
 let submitted_evidence_identity_lines (json : Yojson.Safe.t) =

--- a/lib/workspace/workspace_verification_store.mli
+++ b/lib/workspace/workspace_verification_store.mli
@@ -153,10 +153,6 @@ val note_reference_form : string
     classifier. The artifact form has no such caller: a message that has to
     name both uses {!resolvable_reference_forms}. *)
 
-val pull_request_reference_form : string
-(** The accepted form for forge evidence:
-    [pull-request:https://github.com/<owner>/<repo>/pull/<number>]. *)
-
 val pull_request_locator_url : pull_request_locator -> string
 (** The canonical web URL a locator names — the inverse of the reference
     parser, so the fetcher and the snapshot spell the same URL. *)

--- a/lib/workspace/workspace_verification_store.mli
+++ b/lib/workspace/workspace_verification_store.mli
@@ -14,6 +14,34 @@ type evidence_read_failure =
   | Evidence_changed_during_read
   | Evidence_read_error of string
 
+type pull_request_locator =
+  { owner : string
+  ; repo : string
+  ; number : int
+  }
+
+type pull_request_snapshot =
+  { url : string
+  ; state : string
+  ; merged : bool
+  ; draft : bool
+  ; head_sha : string
+  ; title : string
+  ; diff : string
+  ; diff_bytes : int
+  ; diff_truncated : bool
+  }
+(** Facts this store fetched from the forge itself at the submit boundary —
+    independently inspected evidence, not the producer's narrative. [diff] is
+    bounded by the same cap as artifact content; [diff_bytes] reports the
+    fetched size before capping. *)
+
+type pull_request_fetch_failure =
+  | Pull_request_inspector_uninstalled
+  | Pull_request_transport of string
+  | Pull_request_http_status of int
+  | Pull_request_payload_invalid of string
+
 type submitted_evidence_item =
   | Evidence_note of string
   | Evidence_artifact of
@@ -27,6 +55,25 @@ type submitted_evidence_item =
       { reference : string
       ; reason : evidence_read_failure
       }
+  | Evidence_pull_request of
+      { reference : string
+      ; snapshot : pull_request_snapshot
+      }
+  | Evidence_pull_request_unreadable of
+      { reference : string
+      ; reason : pull_request_fetch_failure
+      }
+
+val install_pull_request_inspector :
+  (pull_request_locator ->
+   (pull_request_snapshot, pull_request_fetch_failure) result) ->
+  unit
+(** Install the forge reader once at process startup (the composition root
+    owns the HTTP client; this store stays free of transport dependencies).
+    Without an installed inspector a [pull-request:] reference snapshots as
+    [Evidence_pull_request_unreadable] with
+    [Pull_request_inspector_uninstalled] — typed absence, never a silent
+    pass (masc#28989). *)
 
 type evidence_access_failure =
   | Completion_authority_identity_missing
@@ -51,6 +98,12 @@ val request_header_of_yojson :
 
 val submitted_evidence_access_to_yojson :
   submitted_evidence_access -> Yojson.Safe.t
+
+val submitted_evidence_item_of_yojson :
+  Yojson.Safe.t -> (submitted_evidence_item, string) result
+(** Decode one persisted snapshot item. This module writes the snapshot and
+    owns the shape; exposed so tests and authority surfaces decode through
+    the same reader instead of re-deriving the JSON fields. *)
 
 val submitted_evidence_access_metadata_to_yojson :
   submitted_evidence_access -> Yojson.Safe.t
@@ -84,6 +137,7 @@ val read_regular_file_prefix :
 type reference_form =
   | Artifact_reference of string
   | Note_reference of string
+  | Pull_request_reference of pull_request_locator
   | Unresolvable_reference
 
 val classify_evidence_reference : string -> reference_form
@@ -98,6 +152,19 @@ val note_reference_form : string
     module matches on, so an error message naming it cannot drift from the
     classifier. The artifact form has no such caller: a message that has to
     name both uses {!resolvable_reference_forms}. *)
+
+val pull_request_reference_form : string
+(** The accepted form for forge evidence:
+    [pull-request:https://github.com/<owner>/<repo>/pull/<number>]. *)
+
+val pull_request_locator_url : pull_request_locator -> string
+(** The canonical web URL a locator names — the inverse of the reference
+    parser, so the fetcher and the snapshot spell the same URL. *)
+
+val verification_evidence_max_bytes : int
+(** One byte cap for every materialized evidence payload — artifact content
+    and pull-request diff alike — so no evidence form can smuggle a larger
+    snapshot than another. *)
 
 val resolvable_reference_forms : string list
 (** The accepted forms, spelled for an error message that has to tell a caller

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -224,6 +224,7 @@ normal_targets=(
   @test/runtest-test_mcp_session_task_lifecycle
   @test/runtest-test_mcp_server_eio
   @test/runtest-test_keeper_sandbox_docker_cwd_response
+  @test/runtest-test_workspace_pull_request_evidence
   @test/runtest-test_keeper_tool_execute_exit_result
   @test/runtest-test_goal_store
   @test/runtest-test_keeper_goal_phase_projection

--- a/test/dune
+++ b/test/dune
@@ -1914,6 +1914,7 @@
 (include stanzas/test_keeper_autonomous_turn_source.inc)
 
 (include stanzas/test_keeper_sandbox_docker_cwd_response.inc)
+(include stanzas/test_workspace_pull_request_evidence.inc)
 (include stanzas/test_keeper_tool_execute_exit_result.inc)
 
 (include stanzas/test_keeper_replay_checkpoint.inc)

--- a/test/stanzas/test_workspace_pull_request_evidence.inc
+++ b/test/stanzas/test_workspace_pull_request_evidence.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_workspace_pull_request_evidence)
+ (modules test_workspace_pull_request_evidence)
+ (libraries masc masc.masc_workspace masc.task_handlers masc_test_deps astring alcotest yojson))

--- a/test/test_workspace_pull_request_evidence.ml
+++ b/test/test_workspace_pull_request_evidence.ml
@@ -1,0 +1,139 @@
+(** Pin for the [pull-request:] evidence form (masc#28989).
+
+    The cross-verifier could only inspect local artifacts, so a keeper's
+    Draft PR — the natural deliverable of dev work — was "a note, not
+    proof" and three genuinely-completed submissions were rejected. The
+    store now parses [pull-request:<canonical GitHub URL>] into a typed
+    locator, fetches an independent snapshot through an inspector the
+    composition root installs, and persists it as typed evidence.
+
+    Pins: strict URL parsing (anything else is Unresolvable at submit),
+    typed absence when no inspector is installed, snapshot serialization
+    round-trip, and the completion-review boundary accepting the form. *)
+
+open Alcotest
+module Store = Workspace_verification_store
+
+let classify = Store.classify_evidence_reference
+
+let test_reference_parsing () =
+  (match classify "pull-request:https://github.com/jeong-sik/masc/pull/28988" with
+   | Store.Pull_request_reference { owner; repo; number } ->
+     check string "owner" "jeong-sik" owner;
+     check string "repo" "masc" repo;
+     check int "number" 28988 number
+   | _ -> fail "canonical pull-request reference must parse");
+  List.iter
+    (fun reference ->
+      match classify reference with
+      | Store.Unresolvable_reference -> ()
+      | _ -> failf "%S must be unresolvable" reference)
+    [ "pull-request:https://gitlab.com/o/r/pull/1"
+    ; "pull-request:http://github.com/o/r/pull/1"
+    ; "pull-request:https://github.com/o/r/pull/abc"
+    ; "pull-request:https://github.com/o/r/pull/0"
+    ; "pull-request:https://github.com/o/r/pull/1/files"
+    ; "pull-request:https://github.com/o/r/issues/1"
+    ; "pull-request:https://github.com/o/pull/1"
+    ; "pull-request:"
+    ]
+
+let fake_snapshot url : Store.pull_request_snapshot =
+  { url
+  ; state = "open"
+  ; merged = false
+  ; draft = true
+  ; head_sha = "abcdef1234"
+  ; title = "fix: example"
+  ; diff = "diff --git a/x b/x"
+  ; diff_bytes = 18
+  ; diff_truncated = false
+  }
+
+let snapshot_items references =
+  Store.snapshot_submitted_evidence_json
+    ~base_path:"/nonexistent-base-for-pull-request-items"
+    ~worker:"pin-worker"
+    references
+
+let decode_items json =
+  match Store.submitted_evidence_identity_lines json with
+  | Ok lines -> lines
+  | Error detail -> fail detail
+
+let test_snapshot_and_roundtrip () =
+  let reference = "pull-request:https://github.com/jeong-sik/masc/pull/28988" in
+  (* Before any inspector is installed the reference stays typed absence,
+     never a silent pass. This case must run before the install below. *)
+  (match snapshot_items [ reference ] with
+   | `List [ item ] ->
+     (match Store.submitted_evidence_item_of_yojson item with
+      | Ok
+          (Store.Evidence_pull_request_unreadable
+            { reason = Store.Pull_request_inspector_uninstalled; _ }) -> ()
+      | Ok _ -> fail "uninstalled inspector must yield typed absence"
+      | Error detail -> fail detail)
+   | _ -> fail "expected one snapshot item");
+  Store.install_pull_request_inspector (fun locator ->
+    Ok (fake_snapshot (Store.pull_request_locator_url locator)));
+  match snapshot_items [ reference; "note:done" ] with
+  | `List [ pr_item; _note_item ] as json ->
+    (match Store.submitted_evidence_item_of_yojson pr_item with
+     | Ok (Store.Evidence_pull_request { reference = persisted; snapshot }) ->
+       check string "reference survives" reference persisted;
+       check string "url spelled from the locator"
+         "https://github.com/jeong-sik/masc/pull/28988" snapshot.url;
+       check string "state" "open" snapshot.state;
+       check bool "draft" true snapshot.draft;
+       check int "diff bytes" 18 snapshot.diff_bytes
+     | Ok _ -> fail "expected a pull-request snapshot item"
+     | Error detail -> fail detail);
+    let lines = decode_items json in
+    check int "two identity lines" 2 (List.length lines);
+    (match lines with
+     | first :: _ ->
+       check bool "identity line names the reference and state" true
+         (Astring.String.is_infix ~affix:"(open, head abcdef1234)" first)
+     | [] -> fail "expected identity lines")
+  | _ -> fail "expected two snapshot items"
+
+let test_fetch_failure_roundtrip () =
+  Store.install_pull_request_inspector (fun _ ->
+    Error (Store.Pull_request_http_status 404));
+  match snapshot_items [ "pull-request:https://github.com/o/r/pull/9" ] with
+  | `List [ item ] ->
+    (match Store.submitted_evidence_item_of_yojson item with
+     | Ok
+         (Store.Evidence_pull_request_unreadable
+           { reason = Store.Pull_request_http_status 404; _ }) -> ()
+     | Ok _ -> fail "expected a typed 404 fetch failure"
+     | Error detail -> fail detail)
+  | _ -> fail "expected one snapshot item"
+
+let test_completion_review_accepts_the_form () =
+  check bool "valid pull-request reference is resolvable" false
+    (Masc_task_handlers.Tool_task_completion_review.unresolvable_evidence_ref
+       "pull-request:https://github.com/jeong-sik/masc/pull/28988");
+  check bool "malformed pull-request reference stays unresolvable" true
+    (Masc_task_handlers.Tool_task_completion_review.unresolvable_evidence_ref
+       "pull-request:https://example.com/pr/1")
+
+let () =
+  run
+    "workspace_pull_request_evidence"
+    [ ( "pull-request-evidence"
+      , [ test_case "reference parsing" `Quick test_reference_parsing
+        ; test_case
+            "snapshot and roundtrip"
+            `Quick
+            test_snapshot_and_roundtrip
+        ; test_case
+            "fetch failure roundtrip"
+            `Quick
+            test_fetch_failure_roundtrip
+        ; test_case
+            "completion review accepts the form"
+            `Quick
+            test_completion_review_accepts_the_form
+        ] )
+    ]


### PR DESCRIPTION
## 무엇이 문제였나 (#28989)

keeper 개발 작업의 자연스러운 산출물은 Draft PR인데, cross-verifier는 로컬 typed artifact만 독립 검사할 수 있어 PR URL이 "노트일 뿐 증명이 아니다"로 취급됐어요 — 실제로 완료된 task-385(PR #28988)가 3연속 반려됐습니다.

## 설계

- **세 번째 참조 형식**: `pull-request:https://github.com/<owner>/<repo>/pull/<number>` — 분류 시점에 typed locator로 **파싱**(그 외 전부 submit에서 Unresolvable, 잘못된 URL은 fetcher에 도달 불가). 거부 형태 7종 pin.
- **snapshot 경계에서 시스템이 직접 fetch**: PR state/merged/draft/head sha/title + artifact와 같은 바이트 캡의 diff → `Evidence_pull_request`로 영속화. producer의 서사가 아니라 시스템이 forge에서 가져온 사실.
- **실패도 typed**: inspector 미설치 포함 전 실패가 `Evidence_pull_request_unreadable`(uninstalled/transport/http_status/payload_invalid) — silent pass 없음.
- **레이어링**: masc_workspace는 transport 의존 없이 계약+주입점만 소유, 실제 reader(`Github_pull_request_evidence`)는 composition root(bootstrap의 Fs_compat.set_fs 옆 2곳)에서 install. 무인증 GET(대상 repo가 public), 비200은 typed status.
- keeper 대면 evidence_refs 스키마 서술 갱신(형식 교육), resolvable-forms 에러 문구는 store에서 자동 파생.

## 검증

- 신규 pin 스위트 4케이스 CI 배선 (unwired baseline 528 불변): 엄격 파싱(거부 7형), 미설치 시 typed 부재, 영속 JSON 리더 경유 roundtrip, completion-review 경계 수용
- GitHub 양 엔드포인트를 **PR #28988 자신**으로 라이브 실측 — 파싱하는 필드 그대로 응답 확인
- 전체 lib+test 빌드 green

## 후속

머지+재배포 후 polisher의 task-385 재제출이 이 기능의 end-to-end 라이브 검증이 됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)