### PR TITLE
feat(tool-surface): add thread_ts and blocks params to keeper_surface_post

### DIFF
--- a/lib/tool_surface/tool_shard_types_schemas_surface.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_surface.ml
@@ -137,6 +137,13 @@ let surface_tools : Masc_domain.tool_schema list =
                         , `String
                             "Stable ids from keeper_surface_read participants to visibly mention. Slack requires U.../W... ids; Discord requires decimal user snowflakes. Display names such as @Vincent do not create API mentions." )
                       ] )
+                ; ( "thread_ts"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "description"
+                        , `String
+                            "Slack thread timestamp (ts) of an existing message to reply inside that thread. Slack surface only; ignored for dashboard/discord. Omit to post a new top-level message." )
+                      ] )
                 ] )
           ; "required", `List [ `String "surface"; `String "content" ]
           ]

--- a/lib/tool_surface/tool_shard_types_schemas_surface.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_surface.ml
@@ -144,6 +144,15 @@ let surface_tools : Masc_domain.tool_schema list =
                         , `String
                             "Slack thread timestamp (ts) of an existing message to reply inside that thread. Slack surface only; ignored for dashboard/discord. Omit to post a new top-level message." )
                       ] )
+                ; ( "blocks"
+                  , `Assoc
+                      [ "type", `String "array"
+                      ; "items", `Assoc [ "type", `String "object" ]
+                      ; "maxItems", `Int 50
+                      ; ( "description"
+                        , `String
+                            "Slack Block Kit blocks (chat.postMessage blocks parameter) for a structurally rich PR report: section/header/divider/context blocks, color banners, images. Slack surface only; ignored for dashboard/discord. Each block must be a JSON object carrying a non-empty string \"type\" member. When blocks is present it is sent alongside content (content remains the notification fallback text)." )
+                      ] )
                 ] )
           ; "required", `List [ `String "surface"; `String "content" ]
           ]


### PR DESCRIPTION
## 요약

`keeper_surface_post` 스키마에 Slack thread reply(`thread_ts`) 및 Block Kit(`blocks`) 파라미터를 노출한다.

- `tool_shard_types_schemas_surface.ml`: `thread_ts` 필드(string, optional)와 `blocks` 필드(array of objects, optional, max 50)를 keeper_surface_post 파라미터에 추가.

## 배경

Slack 채널에서 기존 스레드에 reply를 달거나, Block Kit 블록을 렌더링하기 위한 파라미터입니다. 기존에는 표면에 노출되지 않아 사용이 제한적이었습니다.

## 변경 범위

- `lib/tool_shard_types_schemas/tool_shard_types_schemas_surface.ml` (+16)
- 2 커밋: thread_ts 추가(task-327), blocks 추가(task-328)

## 참고

원래 PR #28992(task-383)에 혼입되어 있던 변경입니다. 교차 리뷰 지시에 따라 Quest Board 본체와 분리하여 별도 PR로 발행합니다.