### PR TITLE
feat(verification): 검증자가 URL 증거를 스스로 dereference한다 (#28989)

### DIFF
--- a/lib/task/tool_task_schemas.ml
+++ b/lib/task/tool_task_schemas.ml
@@ -12,9 +12,10 @@ let handoff_context_description =
      actions (submit_for_verification / done / release / cancel). On \
      action='submit_for_verification', every 'evidence_refs' entry must use \
      'artifact:<producer-root-relative-path>' for a bounded file snapshot or \
-     'note:<text>' for narrative evidence. URLs, commits, and traces are not \
-     fetched by the system LLM lane; materialize their relevant contents as an \
-     artifact when they are required proof. Bare relative paths \
+     'note:<text>' for narrative evidence. A public URL inside a note (a PR, \
+     a CI run) can be fetched live by the verifier itself; materialize \
+     volatile contents as an artifact when they must be pinned at submit \
+     time. Commits and traces are not fetched. Bare relative paths \
      and absolute host paths are persisted as typed invalid references. The \
      list itself is optional. Example: {\"summary\": \"tests green, local proof saved\", \
      \"evidence_refs\": [\"artifact:artifacts/proof.json\"]}."

--- a/lib/verification_authority_tools.ml
+++ b/lib/verification_authority_tools.ml
@@ -7,13 +7,15 @@
 type tool =
   | Read_file
   | Search_files
+  | Web_fetch
 
 let tool_name = function
   | Read_file -> "tool_read_file"
   | Search_files -> "tool_search_files"
+  | Web_fetch -> "masc_web_fetch"
 ;;
 
-let all_tools = [ Read_file; Search_files ]
+let all_tools = [ Read_file; Search_files; Web_fetch ]
 
 type t =
   { ownership_root : string
@@ -64,7 +66,7 @@ let create ~config ~producer =
     resolve_tools
       (match producer_scope with
        | Keeper_producer _ -> all_tools
-       | Workspace_producer -> [ Read_file ])
+       | Workspace_producer -> [ Read_file; Web_fetch ])
   in
   let* ownership_root =
     match producer_scope with
@@ -184,6 +186,22 @@ let run t tool ~args =
     |> result_of_execution
   | Workspace_producer, Search_files ->
     Error "workspace producers do not expose tool_search_files"
+  (* Evidence notes carry URLs (a PR, a CI run) the judge must be able to
+     dereference itself — a producer's claim about a URL is not inspection
+     (masc#28989: three genuinely-completed submissions rejected because the
+     PR URL arrived as "a note, not proof"). The shared web-fetch tool owns
+     the boundary guards: http/https only, private-network and localhost
+     targets refused, validated redirects, bounded extraction. It reads the
+     public internet, not the producer tree, so it is producer-scope
+     independent; it dispatches directly because the judge has no turn
+     continuation for a Gate to resume. *)
+  | (Keeper_producer _ | Workspace_producer), Web_fetch ->
+    Tool_misc_web_fetch.handle
+      ~tool_name:(tool_name Web_fetch)
+      ~start_time:(Time_compat.now ())
+      args
+    |> Keeper_tool_execution.of_tool_result
+    |> result_of_execution
 ;;
 
 let dispatch t ~name ~args =

--- a/lib/verification_authority_tools.mli
+++ b/lib/verification_authority_tools.mli
@@ -1,7 +1,11 @@
 (** Completion-authority access to one producer's typed read-only filesystem
     descriptors. A Keeper producer receives its metadata-bound Read and Grep;
     a Workspace producer without Keeper runtime metadata receives an
-    ownership-root-bound Read. Descriptor registry drift and unreadable
+    ownership-root-bound Read. Both receive the shared web-fetch tool so a
+    URL left in note evidence (a PR, a CI run) is inspectable by the judge
+    itself instead of standing as the producer's claim (masc#28989); its
+    boundary guards — http/https only, private-network and localhost targets
+    refused, validated redirects, bounded extraction — live in the tool. Descriptor registry drift and unreadable
     producer state reject surface construction. Every dispatched call is
     validated and translated by the same descriptor that was advertised.
     Mutating execution is absent: a verifier has no turn continuation that

--- a/test/test_verification_authority_tools.ml
+++ b/test/test_verification_authority_tools.ml
@@ -86,7 +86,7 @@ let test_schemas_are_the_descriptor_schemas () =
     in
     Alcotest.(check (list string))
       "the surface is read-only"
-      [ "tool_read_file"; "tool_search_files" ]
+      [ "tool_read_file"; "tool_search_files"; "masc_web_fetch" ]
       names;
     List.iter
       (fun (schema : Masc_domain.tool_schema) ->
@@ -224,7 +224,7 @@ let test_workspace_producer_gets_owned_read_surface () =
   | Ok surface ->
     Alcotest.(check (list string))
       "workspace producer surface"
-      [ "tool_read_file" ]
+      [ "tool_read_file"; "masc_web_fetch" ]
       (VAT.schemas surface
        |> List.map (fun (schema : Masc_domain.tool_schema) -> schema.name));
     (match
@@ -301,6 +301,61 @@ let test_prompt_states_the_available_surface () =
       (Astring.String.is_infix ~affix:"do not repair what you are judging" with_tools))
 ;;
 
+
+(* masc#28989: a URL left in note evidence must be inspectable by the judge
+   itself. The fetch boundary is stubbed; what is pinned here is the surface —
+   the tool is offered on both producer scopes, a valid call dispatches through
+   the shared guards, and the typed envelope reaches the judge. *)
+let test_web_fetch_is_offered_and_dispatches () =
+  with_surface (fun _config surface ->
+    Alcotest.(check bool)
+      "keeper producer offers tool_web_fetch"
+      true
+      (List.exists
+         (fun (schema : Masc_domain.tool_schema) ->
+           String.equal schema.name "masc_web_fetch")
+         (VAT.schemas surface));
+    Masc.Tool_misc_web_fetch.with_http_fetch_for_test
+      (fun ~timeout_sec:_ ~headers:_ ~max_response_bytes:_ url ->
+        Ok
+          { Masc.Tool_misc_web_fetch.http_status = Some 200
+          ; final_url = url
+          ; redirect_count = 0
+          ; content_type = Some "text/plain"
+          ; downloaded_bytes = Some 20
+          ; body = "diff --git a/x b/x\n"
+          })
+      (fun () ->
+        match
+          VAT.dispatch
+            surface
+            ~name:"masc_web_fetch"
+            ~args:
+              (`Assoc
+                [ "url", `String "https://github.com/jeong-sik/masc/pull/28988"
+                ])
+        with
+        | Error reason -> Alcotest.failf "web fetch dispatch failed: %s" reason
+        | Ok output ->
+          Alcotest.(check bool)
+            "envelope carries the fetched text"
+            true
+            (Astring.String.is_infix ~affix:"diff --git" output)))
+;;
+
+let test_web_fetch_refuses_a_private_target () =
+  with_surface (fun _config surface ->
+    match
+      VAT.dispatch
+        surface
+        ~name:"masc_web_fetch"
+        ~args:(`Assoc [ "url", `String "http://127.0.0.1:8935/health" ])
+    with
+    | Ok output ->
+      Alcotest.failf "private-network fetch must be refused, got: %s" output
+    | Error _ -> ())
+;;
+
 let () =
   Random.self_init ();
   Alcotest.run
@@ -320,6 +375,10 @@ let () =
     ; ( "dispatch"
       , [ Alcotest.test_case "unknown tool name is an error" `Quick
             test_unknown_tool_name_is_an_error
+        ; Alcotest.test_case "web fetch is offered and dispatches" `Quick
+            test_web_fetch_is_offered_and_dispatches
+        ; Alcotest.test_case "web fetch refuses a private target" `Quick
+            test_web_fetch_refuses_a_private_target
         ] )
     ; ( "prompt"
       , [ Alcotest.test_case "prompt states the available surface" `Quick


### PR DESCRIPTION
## 배경

#28995의 재설계예요 — 운영자 반론(PR은 '추가 정보'인데 store에 GitHub 타입을 1급으로 박은 과결합)을 수용해 철회하고, 최소 결합으로 다시 구현했습니다.

## 설계

**기존 `masc_web_fetch`를 검증자 도구함(verification_authority_tools)에 노출** — 그게 전부예요.

- store/증거 계약 무변경: URL은 지금처럼 `note:`의 텍스트일 뿐이고, 검증자가 필요할 때 스스로 fetch해서 읽습니다
- 신규 fetch 코드 0줄: SSRF 가드(http/https만, 사설망·localhost 거부, 리다이렉트 검증)·바운디드 추출·truncation offload 전부 기존 도구 소유
- GitHub 지식 0: 어느 forge든, CI 로그든, 공개 URL이면 동일하게 동작
- Gate 미경유 직접 dispatch: 검증자는 Gate가 재개할 turn continuation이 없음 (모듈 주석에 근거 명시)
- evidence_refs 안내문 갱신: note 속 공개 URL은 검증자가 라이브로 읽을 수 있고, 휘발성 내용은 여전히 artifact로 고정

## 검증

기존 스위트 확장 8/8 green (이 스위트는 ci.yml에 이미 직접 배선돼 있음 — focused 스크립트 추가는 중복이라 안 함):
- 양 producer scope에서 도구 노출 pin
- 스텁 fetch로 dispatch → typed envelope 왕복
- **사설망 타겟(127.0.0.1:8935) end-to-end 거부**

diff: 4파일 +90 (#28995는 11파일 +646이었음)

## 후속

머지+6차 재배포 후 polisher의 task-385 재제출(note:PR-URL 그대로)이 라이브 검증이 됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)