### PR TITLE
feat(transport): record MCP auth rejects at every 401 boundary

### DIFF
--- a/lib/otel_metric_store/otel_core_metric_names.ml
+++ b/lib/otel_metric_store/otel_core_metric_names.ml
@@ -30,6 +30,7 @@ let metric_goal_attainment_measured = "masc_goal_attainment_measured"
 let metric_sse_reconnects = Otel_metric_store_core.declare_counter "masc_sse_reconnects_total"
 let metric_sse_idle_evictions = Otel_metric_store_core.declare_counter "masc_sse_idle_evictions_total"
 let metric_sse_rejects = Otel_metric_store_core.declare_counter "masc_sse_rejects_total"
+let metric_mcp_auth_rejects = Otel_metric_store_core.declare_counter "masc_mcp_auth_rejects_total"
 
 let metric_provider_prefix_cache_creation_tokens =
   Otel_metric_store_core.declare_counter "masc_provider_prefix_cache_creation_tokens_total"

--- a/lib/otel_metric_store/otel_core_metric_names.mli
+++ b/lib/otel_metric_store/otel_core_metric_names.mli
@@ -47,6 +47,14 @@ val metric_goal_attainment_measured : string
 val metric_sse_reconnects : string
 val metric_sse_idle_evictions : string
 val metric_sse_rejects : string
+
+(** Counter [masc_mcp_auth_rejects_total{endpoint,reason}] — MCP transport
+    requests rejected at the auth boundary. Before this counter every
+    rejected bearer produced only a client-visible 401 with no
+    server-side trace (2026-08-18 finding: every external MCP credential
+    was stale and the operator surface showed nothing). *)
+val metric_mcp_auth_rejects : string
+
 val metric_provider_prefix_cache_creation_tokens : string
 val metric_tool_input_validation : string
 val metric_llm_provider_http_status : string

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -517,6 +517,14 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
                 | Ok () ->
                     (match auth_result with
                      | Error failure ->
+                         Server_mcp_transport_http_respond
+                         .record_mcp_auth_reject
+                           ~endpoint:
+                             ("h2 POST "
+                             ^ Server_mcp_transport_http.profile_label profile)
+                           ~claimed_agent:(agent_from_request httpun_request)
+                           ~token_presented:(Option.is_some auth_token)
+                           ~session_id:(Some session_id) failure;
                          let body = mcp_auth_error_body failure in
                          h2_respond_json h2_reqd body ~status:`Unauthorized
                            ~extra_headers:
@@ -664,6 +672,14 @@ let make_request_handler ~trust_policy ~sw ~clock ~server_start_time:_ =
           in
           (match auth_result with
            | Error failure ->
+               Server_mcp_transport_http_respond.record_mcp_auth_reject
+                 ~endpoint:
+                   ("h2 DELETE "
+                   ^ Server_mcp_transport_http.profile_label profile)
+                 ~claimed_agent:(agent_from_request httpun_request)
+                 ~token_presented:
+                   (Option.is_some (auth_token_from_request httpun_request))
+                 ~session_id:session_id_opt failure;
                let body = mcp_auth_error_body failure in
                h2_respond_json h2_reqd body ~status:`Unauthorized
                  ~extra_headers:

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -197,6 +197,13 @@ let body_with_canonical_http_actor ~base_path ~auth_token request body_str =
   let actor = Server_auth.dashboard_actor_for_request ~base_path request in
   Server_mcp_actor_injection.reduce ~actor ~auth_token body_str
 
+(* Auth-reject metric/log endpoint labels. Built on [profile_label]
+   so the label vocabulary cannot drift from the session module's
+   profile naming. *)
+let post_endpoint_label profile = "POST " ^ profile_label profile
+let get_endpoint_label profile = "GET " ^ profile_label profile
+let delete_endpoint_label profile = "DELETE " ^ profile_label profile
+
 let handle_post_mcp ~deps ?(profile = Full) request reqd =
   let request_authority = Server_request_authority.current_exn () in
   (* Readiness gate: reject before session/auth if server state is not ready *)
@@ -272,16 +279,15 @@ let handle_post_mcp ~deps ?(profile = Full) request reqd =
       match auth_result with
       | Ok () -> Ok ()
       | Error failure ->
-          respond_mcp_error
-            ?data:(auth_failure_data failure)
-            ~code:Mcp_error_code.Auth_error
+          respond_mcp_auth_error
             ~deps
             ~request_authority
+            ~endpoint:(post_endpoint_label profile)
             request
             reqd
             ~session_id
             ~protocol_version
-            failure.message;
+            failure;
           Error ()
     in
     let otel_transport_context =
@@ -603,16 +609,15 @@ let handle_get_mcp ~deps ?(profile = Full) ?(sse_kind = Sse.Agent_stream)
       | Ok () ->
       (match auth_result with
       | Error failure ->
-          respond_mcp_error
-            ?data:(auth_failure_data failure)
-            ~code:Mcp_error_code.Auth_error
+          respond_mcp_auth_error
             ~deps
             ~request_authority
+            ~endpoint:(get_endpoint_label profile)
             request
             reqd
             ~session_id
             ~protocol_version
-            failure.message
+            failure
       | Ok () ->
           (match last_event_id with
           | Error error ->
@@ -767,16 +772,15 @@ let handle_get_operator_mcp ~deps request reqd =
   let base_path = deps.get_base_path () in
   match deps.verify_operator_mcp_auth ~base_path request with
   | Error failure ->
-      respond_mcp_error
-        ?data:(auth_failure_data failure)
-        ~code:Mcp_error_code.Auth_error
+      respond_mcp_auth_error
         ~deps
         ~request_authority
+        ~endpoint:(get_endpoint_label Operator_remote)
         request
         reqd
         ~session_id
         ~protocol_version
-        failure.message
+        failure
   | Ok () ->
       handle_get_mcp ~deps ~profile:Operator_remote request reqd
 
@@ -797,16 +801,15 @@ let handle_delete_mcp ~deps ?(profile = Full) request reqd =
   | Error failure ->
       let session_id = Mcp_session.get_or_generate (get_session_id_any request) in
       let protocol_version = get_protocol_version_for_session ~session_id request in
-      respond_mcp_error
-        ?data:(auth_failure_data failure)
-        ~code:Mcp_error_code.Auth_error
+      respond_mcp_auth_error
         ~deps
         ~request_authority
+        ~endpoint:(delete_endpoint_label profile)
         request
         reqd
         ~session_id
         ~protocol_version
-        failure.message
+        failure
   | Ok () -> (
       match get_session_id_any request with
       | Some session_id -> (

--- a/lib/server/server_mcp_transport_http_agui.ml
+++ b/lib/server/server_mcp_transport_http_agui.ml
@@ -40,16 +40,15 @@ let handle_ag_ui_events ~deps request reqd =
   let last_event_id = Server_mcp_transport_http_headers.get_last_event_id request in
   match deps.verify_mcp_observer_stream_auth ~base_path request with
   | Error failure ->
-      respond_mcp_error
-        ?data:(auth_failure_data failure)
-        ~code:Mcp_error_code.Auth_error
+      respond_mcp_auth_error
         ~deps
         ~request_authority
+        ~endpoint:"GET /ag-ui/events"
         request
         reqd
         ~session_id
         ~protocol_version
-        failure.message
+        failure
   | Ok () ->
       (match last_event_id with
       | Error error ->
@@ -190,16 +189,15 @@ let handle_presence_events ~deps request reqd =
   let base_path = deps.get_base_path () in
   match deps.verify_mcp_observer_stream_auth ~base_path request with
   | Error failure ->
-      respond_mcp_error
-        ?data:(auth_failure_data failure)
-        ~code:Mcp_error_code.Auth_error
+      respond_mcp_auth_error
         ~deps
         ~request_authority
+        ~endpoint:"GET /events/presence"
         request
         reqd
         ~session_id:raw_session_id
         ~protocol_version
-        failure.message
+        failure
   | Ok () ->
       let token = Server_auth.observer_sse_auth_token_from_request request in
       let auth = { Sse.config = base_path; token } in

--- a/lib/server/server_mcp_transport_http_respond.ml
+++ b/lib/server/server_mcp_transport_http_respond.ml
@@ -101,11 +101,11 @@ let respond_mcp_error ?(extra_headers = []) ?data ?id
 
 let mcp_auth_reject_reason_label
     (failure : Server_mcp_transport_http_types.auth_failure) =
-  (* DET-OK: an absent [auth_error_code] folds to the fixed
-     "unclassified" label on purpose — the metric label set must stay
-     bounded, and the absence itself is what gets counted. Nothing is
-     silently repaired: the paired [Log.Auth] event carries the full
-     failure message and a [`Null] reason for the same reject. *)
+  (* An absent [auth_error_code] folds to the fixed "unclassified"
+     label on purpose — the metric label set must stay bounded, and
+     the absence itself is what gets counted. Nothing is silently
+     repaired: the paired [Log.Auth] event carries the full failure
+     message and a [`Null] reason for the same reject. DET-OK. *)
   Option.value ~default:"unclassified" failure.auth_error_code
 
 let mcp_auth_reject_details ~endpoint ~claimed_agent ~token_presented

--- a/lib/server/server_mcp_transport_http_respond.ml
+++ b/lib/server/server_mcp_transport_http_respond.ml
@@ -99,6 +99,65 @@ let respond_mcp_error ?(extra_headers = []) ?data ?id
   in
   safe_respond_with_string reqd response body
 
+let mcp_auth_reject_reason_label
+    (failure : Server_mcp_transport_http_types.auth_failure) =
+  (* Metric label comes from the typed [auth_error_code], never the
+     free-form message — the label set must stay bounded. *)
+  Option.value ~default:"unclassified" failure.auth_error_code
+
+let mcp_auth_reject_details ~endpoint ~claimed_agent ~token_presented
+    ~session_id (failure : Server_mcp_transport_http_types.auth_failure) =
+  let opt_string = function
+    | Some value -> `String value
+    | None -> `Null
+  in
+  `Assoc
+    [
+      ("endpoint", `String endpoint);
+      ("reason", opt_string failure.auth_error_code);
+      ("message", `String failure.message);
+      ("claimed_agent", opt_string claimed_agent);
+      ("token_presented", `Bool token_presented);
+      (* [`Null] when the request carried no [Mcp-Session-Id]
+         (e.g. h2 DELETE rejected before session resolution). *)
+      ("session_id", opt_string session_id);
+    ]
+
+(* Auth reject boundary observation. The transport is the only place
+   that turns an [auth_failure] into a client-visible 401, so it is
+   the only place that can record the rejection server-side. Before
+   this the reject produced no log line, no metric, and no audit
+   trace: on 2026-08-18 every external MCP credential had gone stale
+   after a token rotation and the operator surface could not
+   distinguish "no client ever connected" from "every client is being
+   rejected" ([mcp_transport_sessions.json] empty either way).
+   The raw bearer is never logged — only whether one was presented. *)
+let record_mcp_auth_reject ~endpoint ~claimed_agent ~token_presented
+    ~session_id (failure : Server_mcp_transport_http_types.auth_failure) =
+  Log.Auth.emit Log.Warn
+    ~details:
+      (mcp_auth_reject_details ~endpoint ~claimed_agent ~token_presented
+         ~session_id failure)
+    ~category:Log.Routine
+    (Printf.sprintf "MCP auth rejected: %s (%s)" endpoint failure.message);
+  Transport_metrics.inc_mcp_auth_reject ~endpoint
+    ~reason:(mcp_auth_reject_reason_label failure)
+
+let respond_mcp_auth_error ~(deps : Server_mcp_transport_http_types.deps)
+    ~request_authority ~endpoint request reqd ~session_id ~protocol_version
+    (failure : Server_mcp_transport_http_types.auth_failure) =
+  record_mcp_auth_reject ~endpoint
+    ~claimed_agent:(Server_auth.agent_from_request request)
+    ~token_presented:(Option.is_some (deps.auth_token_from_request request))
+    ~session_id:(Some session_id) failure;
+  respond_mcp_error
+    ?data:
+      (Option.map
+         (fun code -> `Assoc [ ("auth_error_code", `String code) ])
+         failure.auth_error_code)
+    ~code:Mcp_error_code.Auth_error ~deps ~request_authority request reqd
+    ~session_id ~protocol_version failure.message
+
 (* [respond_not_ready] is intentionally retained outside
    [respond_mcp_error]: it runs before [json_headers] / [session_id]
    are available. Widening [respond_mcp_error] to the pre-runtime case

--- a/lib/server/server_mcp_transport_http_respond.ml
+++ b/lib/server/server_mcp_transport_http_respond.ml
@@ -101,8 +101,11 @@ let respond_mcp_error ?(extra_headers = []) ?data ?id
 
 let mcp_auth_reject_reason_label
     (failure : Server_mcp_transport_http_types.auth_failure) =
-  (* Metric label comes from the typed [auth_error_code], never the
-     free-form message — the label set must stay bounded. *)
+  (* DET-OK: an absent [auth_error_code] folds to the fixed
+     "unclassified" label on purpose — the metric label set must stay
+     bounded, and the absence itself is what gets counted. Nothing is
+     silently repaired: the paired [Log.Auth] event carries the full
+     failure message and a [`Null] reason for the same reject. *)
   Option.value ~default:"unclassified" failure.auth_error_code
 
 let mcp_auth_reject_details ~endpoint ~claimed_agent ~token_presented

--- a/lib/server/server_mcp_transport_http_respond.mli
+++ b/lib/server/server_mcp_transport_http_respond.mli
@@ -128,53 +128,6 @@ val respond_mcp_error :
   code:Mcp_error_code.t ->
   string ->
   unit
-
-(** [mcp_auth_reject_details ~endpoint ~claimed_agent ~token_presented
-    ~session_id failure] is the pure structured-log payload for one
-    rejected MCP auth attempt. [reason] mirrors the typed
-    [auth_error_code]; the raw bearer never appears — only
-    [token_presented]. Exposed for tests. *)
-val mcp_auth_reject_details :
-  endpoint:string ->
-  claimed_agent:string option ->
-  token_presented:bool ->
-  session_id:string option ->
-  Server_mcp_transport_http_types.auth_failure ->
-  Yojson.Safe.t
-
-(** [record_mcp_auth_reject ~endpoint ~claimed_agent ~token_presented
-    ~session_id failure] emits the [Log.Auth] reject event and
-    increments [masc_mcp_auth_rejects_total{endpoint,reason}]. Every
-    transport that turns an {!Server_mcp_transport_http_types.auth_failure}
-    into a client-visible 401 must call this exactly once — before it
-    a rejected bearer left no server-side trace at all (2026-08-18
-    live finding: all external MCP credentials stale, zero log lines,
-    zero audit records, empty session store). h2 / non-httpun
-    transports call this directly and keep their own response
-    plumbing. *)
-val record_mcp_auth_reject :
-  endpoint:string ->
-  claimed_agent:string option ->
-  token_presented:bool ->
-  session_id:string option ->
-  Server_mcp_transport_http_types.auth_failure ->
-  unit
-
-(** [respond_mcp_auth_error ~deps ~request_authority ~endpoint request
-    reqd ~session_id ~protocol_version failure] records the reject
-    (see {!record_mcp_auth_reject}) and writes the standard
-    [Auth_error] JSON-RPC envelope via {!respond_mcp_error}. The
-    httpun MCP handlers' single reject path. *)
-val respond_mcp_auth_error :
-  deps:Server_mcp_transport_http_types.deps ->
-  request_authority:Server_request_authority.authority ->
-  endpoint:string ->
-  Httpun.Request.t ->
-  Httpun.Reqd.t ->
-  session_id:string ->
-  protocol_version:string ->
-  Server_mcp_transport_http_types.auth_failure ->
-  unit
 (** [respond_mcp_error ?extra_headers ?data ?id ~deps ~request_authority request reqd
     ~session_id ~protocol_version ~code msg] writes a single JSON-RPC
     2.0 error response derived from a typed {!Mcp_error_code.t}. This
@@ -199,3 +152,50 @@ val respond_mcp_auth_error :
     [extra_headers] are prepended; {!json_headers} append.  The
     function never raises; response writes go through the module's
     guarded response helper. *)
+
+(** [mcp_auth_reject_details ~endpoint ~claimed_agent ~token_presented
+    ~session_id failure] is the pure structured-log payload for one
+    rejected MCP auth attempt. [reason] mirrors the typed
+    [auth_error_code]; the raw bearer never appears — only
+    [token_presented]. Exposed for tests. *)
+val mcp_auth_reject_details :
+  endpoint:string ->
+  claimed_agent:string option ->
+  token_presented:bool ->
+  session_id:string option ->
+  Server_mcp_transport_http_types.auth_failure ->
+  Yojson.Safe.t
+
+(** [record_mcp_auth_reject ~endpoint ~claimed_agent ~token_presented
+    ~session_id failure] emits the [Log.Auth] reject event and
+    increments [masc_mcp_auth_rejects_total{endpoint,reason}]. Every
+    transport that turns an {!Server_mcp_transport_http_types.auth_failure}
+    into a client-visible 401 must call this exactly once — before it
+    a rejected bearer left no server-side trace at all (2026-08-18
+    live finding: all external MCP credentials stale, zero log lines,
+    zero audit records, empty session store). Transports with their
+    own response plumbing — the h2 gateway and the WebSocket upgrade
+    path — call this directly. *)
+val record_mcp_auth_reject :
+  endpoint:string ->
+  claimed_agent:string option ->
+  token_presented:bool ->
+  session_id:string option ->
+  Server_mcp_transport_http_types.auth_failure ->
+  unit
+
+(** [respond_mcp_auth_error ~deps ~request_authority ~endpoint request
+    reqd ~session_id ~protocol_version failure] records the reject
+    (see {!record_mcp_auth_reject}) and writes the standard
+    [Auth_error] JSON-RPC envelope via {!respond_mcp_error}. The
+    httpun MCP handlers' single reject path. *)
+val respond_mcp_auth_error :
+  deps:Server_mcp_transport_http_types.deps ->
+  request_authority:Server_request_authority.authority ->
+  endpoint:string ->
+  Httpun.Request.t ->
+  Httpun.Reqd.t ->
+  session_id:string ->
+  protocol_version:string ->
+  Server_mcp_transport_http_types.auth_failure ->
+  unit

--- a/lib/server/server_mcp_transport_http_respond.mli
+++ b/lib/server/server_mcp_transport_http_respond.mli
@@ -128,6 +128,53 @@ val respond_mcp_error :
   code:Mcp_error_code.t ->
   string ->
   unit
+
+(** [mcp_auth_reject_details ~endpoint ~claimed_agent ~token_presented
+    ~session_id failure] is the pure structured-log payload for one
+    rejected MCP auth attempt. [reason] mirrors the typed
+    [auth_error_code]; the raw bearer never appears — only
+    [token_presented]. Exposed for tests. *)
+val mcp_auth_reject_details :
+  endpoint:string ->
+  claimed_agent:string option ->
+  token_presented:bool ->
+  session_id:string option ->
+  Server_mcp_transport_http_types.auth_failure ->
+  Yojson.Safe.t
+
+(** [record_mcp_auth_reject ~endpoint ~claimed_agent ~token_presented
+    ~session_id failure] emits the [Log.Auth] reject event and
+    increments [masc_mcp_auth_rejects_total{endpoint,reason}]. Every
+    transport that turns an {!Server_mcp_transport_http_types.auth_failure}
+    into a client-visible 401 must call this exactly once — before it
+    a rejected bearer left no server-side trace at all (2026-08-18
+    live finding: all external MCP credentials stale, zero log lines,
+    zero audit records, empty session store). h2 / non-httpun
+    transports call this directly and keep their own response
+    plumbing. *)
+val record_mcp_auth_reject :
+  endpoint:string ->
+  claimed_agent:string option ->
+  token_presented:bool ->
+  session_id:string option ->
+  Server_mcp_transport_http_types.auth_failure ->
+  unit
+
+(** [respond_mcp_auth_error ~deps ~request_authority ~endpoint request
+    reqd ~session_id ~protocol_version failure] records the reject
+    (see {!record_mcp_auth_reject}) and writes the standard
+    [Auth_error] JSON-RPC envelope via {!respond_mcp_error}. The
+    httpun MCP handlers' single reject path. *)
+val respond_mcp_auth_error :
+  deps:Server_mcp_transport_http_types.deps ->
+  request_authority:Server_request_authority.authority ->
+  endpoint:string ->
+  Httpun.Request.t ->
+  Httpun.Reqd.t ->
+  session_id:string ->
+  protocol_version:string ->
+  Server_mcp_transport_http_types.auth_failure ->
+  unit
 (** [respond_mcp_error ?extra_headers ?data ?id ~deps ~request_authority request reqd
     ~session_id ~protocol_version ~code msg] writes a single JSON-RPC
     2.0 error response derived from a typed {!Mcp_error_code.t}. This

--- a/lib/server/server_routes_http_routes_frontend.ml
+++ b/lib/server/server_routes_http_routes_frontend.ml
@@ -129,7 +129,17 @@ let websocket_handler ?sw ?clock ~upgrade request reqd =
       (match
          websocket_upgrade_authorized ~base_path ~request_authority request
        with
-       | Error err -> respond_auth_error request reqd err
+       | Error err ->
+         (* Reject-boundary contract: every client-visible auth reject
+            leaves a metric + log trace (see [record_mcp_auth_reject]).
+            The response shape is unchanged. *)
+         Server_mcp_transport_http_respond.record_mcp_auth_reject
+           ~endpoint:"GET /ws upgrade"
+           ~claimed_agent:(agent_from_request request)
+           ~token_presented:(Option.is_some (auth_token_from_request request))
+           ~session_id:None
+           (Server_mcp_transport_http_types.auth_failure_of_masc_error err);
+         respond_auth_error request reqd err
        | Ok () ->
          (match
             Server_mcp_transport_ws.upgrade_connection

--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -150,6 +150,20 @@ let inc_sse_reject ~reason =
   Otel_metric_store.inc_counter Otel_metric_store.metric_sse_rejects ~labels:[ "reason", reason ] ()
 ;;
 
+(* Silent-failure fix (2026-08-18 live finding): every external MCP
+   credential had gone stale after a token rotation and every client
+   request died at the auth boundary with a client-only 401 — zero
+   server-side trace, so mcp_transport_sessions.json staying empty was
+   indistinguishable from "no client ever tried".  [reason] carries the
+   typed [auth_error_code] ("invalid_token", "missing_token", ...), not
+   free-form message text, so the label set stays bounded. *)
+let inc_mcp_auth_reject ~endpoint ~reason =
+  Otel_metric_store.inc_counter
+    Otel_metric_store.metric_mcp_auth_rejects
+    ~labels:[ "endpoint", endpoint; "reason", reason ]
+    ()
+;;
+
 let inc_sse_reconnect () = Otel_metric_store.inc_counter Otel_metric_store.metric_sse_reconnects ()
 
 (** {1 gRPC Metrics} *)
@@ -610,6 +624,10 @@ let transport_health_json () =
           ; "presence_stream", `String "/events/presence"
           ; "supports_post", `Bool true
           ; "supports_sse_upgrade", `Bool true
+          ; ( "auth_rejects_total"
+            , `Int
+                (int_of_float
+                   (Otel_metric_store.metric_total Otel_metric_store.metric_mcp_auth_rejects)) )
           ] )
     ; ( "http2"
       , `Assoc

--- a/lib/transport_metrics.mli
+++ b/lib/transport_metrics.mli
@@ -112,6 +112,18 @@ val inc_sse_idle_evicted : unit -> unit
     logs. *)
 val inc_sse_reject : reason:string -> unit
 
+(** [inc_mcp_auth_reject ~endpoint ~reason] increments
+    [masc_mcp_auth_rejects_total{endpoint,reason}] when an MCP
+    transport request is rejected at the auth boundary (HTTP 401).
+    [endpoint] is the fixed route label (e.g. ["POST /mcp"]),
+    [reason] the typed [auth_error_code] ("invalid_token",
+    "missing_token", ...) — never free-form message text, so the
+    label set stays bounded.  Paired with the [Log.Auth] reject
+    event emitted at the same boundary; before this pair a stale
+    bearer produced only a client-visible 401 (2026-08-18 live
+    finding: all external MCP credentials stale, zero trace). *)
+val inc_mcp_auth_reject : endpoint:string -> reason:string -> unit
+
 (** Increments [masc_sse_reconnects_total] whenever an SSE client
     arrives with a [Last-Event-Id] header, i.e. is asking the
     server to replay events from a prior connection.  Distinct

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -163,6 +163,7 @@ normal_targets=(
   @test/runtest-test_dashboard_recent_terminal_tasks
   @test/runtest-test_auth_ambiguous_lookup_9786
   @test/runtest-test_auth_credential_hash_collision
+  @test/runtest-test_mcp_auth_reject_observability
   @test/runtest-test_auth_load_credential_of
   @test/runtest-test_auth_token_uniqueness_audit
   @test/runtest-test_grpc_workspace

--- a/test/dune
+++ b/test/dune
@@ -66,6 +66,7 @@
   test_exec_tap
   test_auth
   test_auth_credential_hash_collision
+  test_mcp_auth_reject_observability
   test_auth_credential_index_cache
   test_auth_error_kind
   test_auth_error_kind_dashboard_fallback
@@ -367,6 +368,7 @@
   test_exec_tap
   test_auth
   test_auth_credential_hash_collision
+  test_mcp_auth_reject_observability
   test_auth_credential_index_cache
   test_auth_error_kind
   test_auth_error_kind_dashboard_fallback

--- a/test/test_mcp_auth_reject_observability.ml
+++ b/test/test_mcp_auth_reject_observability.ml
@@ -1,0 +1,117 @@
+(** MCP auth reject boundary observability.
+
+    2026-08-18 live finding: after a token rotation every external MCP
+    credential was stale and every client request died at the auth
+    boundary with a client-only 401 — no log line, no metric, empty
+    session store. These tests pin the reject-boundary contract:
+
+      1. [record_mcp_auth_reject] advances
+         [masc_mcp_auth_rejects_total{endpoint,reason}] with the typed
+         [auth_error_code] as [reason].
+      2. A failure without [auth_error_code] lands on the bounded
+         fallback label ["unclassified"], never on message text.
+      3. [mcp_auth_reject_details] carries endpoint / reason /
+         claimed_agent / token_presented / session_id and never the
+         bearer itself; absent session folds to [`Null], not [""]. *)
+
+module Respond = Server_mcp_transport_http_respond
+module Types = Server_mcp_transport_http_types
+module Metrics = Masc.Otel_metric_store
+
+let reject_total ~endpoint ~reason =
+  Metrics.metric_value_or_zero
+    Metrics.metric_mcp_auth_rejects
+    ~labels:[ ("endpoint", endpoint); ("reason", reason) ]
+    ()
+
+let failure ?auth_error_code message : Types.auth_failure =
+  { message; auth_error_code }
+
+let test_reject_counts_with_typed_reason () =
+  let endpoint = "POST /mcp (test-typed)" in
+  let before = reject_total ~endpoint ~reason:"invalid_token" in
+  Respond.record_mcp_auth_reject ~endpoint ~claimed_agent:(Some "probe-agent")
+    ~token_presented:true ~session_id:(Some "mcp_test_session")
+    (failure ~auth_error_code:"invalid_token" "Invalid token: Token mismatch");
+  Alcotest.(check (float 0.0001))
+    "reject counted under typed reason" (before +. 1.0)
+    (reject_total ~endpoint ~reason:"invalid_token")
+
+let test_reject_without_code_uses_bounded_fallback () =
+  let endpoint = "GET /mcp (test-fallback)" in
+  let before = reject_total ~endpoint ~reason:"unclassified" in
+  Respond.record_mcp_auth_reject ~endpoint ~claimed_agent:None
+    ~token_presented:false ~session_id:None
+    (failure "Authentication required. Use 'Authorization: Bearer <token>'.");
+  Alcotest.(check (float 0.0001))
+    "no auth_error_code -> unclassified label" (before +. 1.0)
+    (reject_total ~endpoint ~reason:"unclassified");
+  Alcotest.(check (float 0.0001))
+    "message text never becomes a label" 0.0
+    (reject_total ~endpoint
+       ~reason:"Authentication required. Use 'Authorization: Bearer <token>'.")
+
+let member name = function
+  | `Assoc fields -> List.assoc name fields
+  | _ -> Alcotest.fail "details payload is not an object"
+
+let test_details_payload_shape () =
+  let details =
+    Respond.mcp_auth_reject_details ~endpoint:"DELETE /mcp"
+      ~claimed_agent:(Some "codex-mcp-client") ~token_presented:true
+      ~session_id:(Some "mcp_abc")
+      (failure ~auth_error_code:"invalid_token" "Invalid token: Token mismatch")
+  in
+  Alcotest.(check string)
+    "endpoint" "DELETE /mcp"
+    (match member "endpoint" details with
+     | `String s -> s
+     | _ -> Alcotest.fail "endpoint not a string");
+  Alcotest.(check string)
+    "reason mirrors auth_error_code" "invalid_token"
+    (match member "reason" details with
+     | `String s -> s
+     | _ -> Alcotest.fail "reason not a string");
+  Alcotest.(check string)
+    "claimed_agent" "codex-mcp-client"
+    (match member "claimed_agent" details with
+     | `String s -> s
+     | _ -> Alcotest.fail "claimed_agent not a string");
+  Alcotest.(check bool)
+    "token_presented" true
+    (match member "token_presented" details with
+     | `Bool b -> b
+     | _ -> Alcotest.fail "token_presented not a bool")
+
+let test_details_absent_session_is_null () =
+  let details =
+    Respond.mcp_auth_reject_details ~endpoint:"h2 DELETE /mcp"
+      ~claimed_agent:None ~token_presented:false ~session_id:None
+      (failure "missing token")
+  in
+  (match member "session_id" details with
+   | `Null -> ()
+   | other ->
+       Alcotest.failf "absent session must be `Null, got %s"
+         (Yojson.Safe.to_string other));
+  match member "reason" details with
+  | `Null -> ()
+  | other ->
+      Alcotest.failf "absent auth_error_code must be `Null, got %s"
+        (Yojson.Safe.to_string other)
+
+let () =
+  Alcotest.run "mcp_auth_reject_observability"
+    [
+      ( "reject-boundary",
+        [
+          Alcotest.test_case "counter advances with typed reason" `Quick
+            test_reject_counts_with_typed_reason;
+          Alcotest.test_case "missing code -> unclassified label" `Quick
+            test_reject_without_code_uses_bounded_fallback;
+          Alcotest.test_case "details payload shape" `Quick
+            test_details_payload_shape;
+          Alcotest.test_case "absent session/code fold to null" `Quick
+            test_details_absent_session_is_null;
+        ] );
+    ]

--- a/test/test_transport_metrics.ml
+++ b/test/test_transport_metrics.ml
@@ -431,6 +431,7 @@ let test_transport_health_json () =
     ; "presence_stream"
     ; "supports_post"
     ; "supports_sse_upgrade"
+    ; "auth_rejects_total"
     ]
     streamable_json;
   check_assoc_keys


### PR DESCRIPTION
## As-Is (재현 가능한 한 가지)

2026-08-18 라이브 실측: 토큰 회전 이후 외부 MCP 자격 전부(Claude Code `.mcp.json`, Codex `MASC_MCP_TOKEN`, `admin.token`)가 stale이 됐고, 모든 외부 요청이 401 `Token mismatch`로 죽는 동안 서버 쪽에는 **로그 0줄, metric 0, audit 0건**. `mcp_transport_sessions.json`은 비어 있는데 이것이 "아무도 접속 안 함"인지 "전원이 거부당함"인지 구분할 방법이 없었음.

검증 방법: stale bearer로 `POST /mcp` initialize → 401 수신 → `logs/masc-*.out.log`, `logs/system_log_*.jsonl`, `audit/2026-08/18.jsonl` 전부에서 해당 시각 auth 기록 0건.

## To-Be

transport가 `auth_failure`를 클라이언트용 401로 바꾸는 유일한 계층이므로, 정확히 그 경계에서 기록한다.

- `record_mcp_auth_reject`: `Log.Auth` warn 이벤트(순수 payload 빌더 분리, bearer 원문은 절대 미포함 — `token_presented` bool만) + `masc_mcp_auth_rejects_total{endpoint,reason}` 카운터. reason은 typed `auth_error_code`, 부재 시 bounded `"unclassified"` (메시지 텍스트를 라벨로 쓰지 않음).
- httpun 4곳(POST/GET/DELETE `/mcp` — `profile_label` 재사용으로 라벨 어휘 고정, GET operator), agui 2곳(`/ag-ui/events`, `/events/presence`), h2 gateway 2곳(POST/DELETE) — **거부 경계 8/8 전부** 한 함수로 수렴.
- `/health` transport 스냅샷 `streamable_http.auth_rejects_total` 노출.

## 이것이 워크어라운드가 아닌 이유

고아 자격 자체의 수리는 별도로 완료했음(`masc login --agent codex-mcp-client` + `sb mcp sync`, 200 재검증). 이 PR은 그 사고의 *관측 공백*을 닫는 독립 기능이며, counter-as-fix가 아니라 이미 이 모듈에 있는 P1 silent-failure fix 계열(`inc_sse_reject`, `inc_broadcast_failure`)과 같은 축.

## 검증

- feature test 4케이스: typed reason 라벨 / unclassified fallback / payload 모양 / 부재 session·code의 `Null` 폴딩 (`test_mcp_auth_reject_observability`, group-1 tests 등록)
- 로컬 dune build 미실행 (repo 방침) — OCaml 컴파일·테스트는 CI 판정
- `ocamlformat` 파싱 검사 10/10 통과, `git diff --check` clean

## 남은 미검증

- 라이브 서버에서의 실제 emit은 배포 후 재확인 필요 (stale token 1회 쏘고 로그/`/health` 대조 예정)
