### PR TITLE
fix(board): write-ahead durable append for comment and post creation (#28952)

### DIFF
--- a/lib/board/board_core.ml
+++ b/lib/board/board_core.ml
@@ -11,32 +11,6 @@ include Board_core_persist
    indentation level. *)
 let ( let* ) = Result.bind
 
-let rollback_fresh_comment store ~(comment : comment) ~(previous_post : post) =
-  with_lock store (fun () ->
-    let post_key = Post_id.to_string comment.post_id in
-    let comment_key = Comment_id.to_string comment.id in
-    Hashtbl.remove store.comments comment_key;
-    (match Hashtbl.find_opt store.comments_by_post post_key with
-     | None -> ()
-     | Some ids ->
-       (match List.filter (fun id -> not (String.equal id comment_key)) ids with
-        | [] -> Hashtbl.remove store.comments_by_post post_key
-        | filtered -> Hashtbl.replace store.comments_by_post post_key filtered));
-    (match Hashtbl.find_opt store.posts post_key with
-     | None -> ()
-     | Some current ->
-       let updated_at =
-         if Stdlib.Float.equal current.updated_at comment.created_at
-         then previous_post.updated_at
-         else current.updated_at
-       in
-       Hashtbl.replace
-         store.posts
-         post_key
-         { current with reply_count = max 0 (current.reply_count - 1); updated_at });
-    invalidate_post_caches store;
-    invalidate_comment_caches store)
-;;
 
 let get_post store ~post_id : (post, board_error) Result.t =
   maybe_sweep store;
@@ -244,80 +218,87 @@ let add_comment_with_audience
   then Error (Validation_error "Content cannot be empty")
   else
     let* audience = Board_audience.audience_for_comment ~content in
-            let board_result =
-              with_lock store (fun () ->
-                (* Verify post exists *)
-                match Hashtbl.find_opt store.posts (Post_id.to_string pid) with
-                | None -> Error (Post_not_found post_id)
-                | Some post ->
-                  match
-                    validate_sub_board_post_policy_unlocked
-                      store
-                      ~author_id
-                      ~hearth:post.hearth
-                  with
-                      | Error e -> Error e
-                      | Ok () ->
-                    let now = Time_compat.now () in
-                    let comment =
-                      { id = Comment_id.generate ()
-                      ; post_id = pid
-                      ; parent_id = parent_cid
-                      ; author = author_id
-                      ; content
-                      ; created_at = now
-                      ; expires_at =
-                          (if ttl_hours = 0
-                           then 0.0
-                           else
-                             now
-                             +. (Stdlib.Float.of_int ttl_hours
-                                 *. Masc_time_constants.hour))
-                      ; votes_up = 0
-                      ; votes_down = 0
-                      }
-                    in
-                    Hashtbl.add store.comments (Comment_id.to_string comment.id) comment;
-                    (* Update comments_by_post index *)
-                    let post_key = Post_id.to_string pid in
-                    let existing =
-                      Hashtbl.find_opt store.comments_by_post post_key
-                      |> Option.value ~default:[]
-                    in
-                    Hashtbl.replace
-                      store.comments_by_post
-                      post_key
-                      (Comment_id.to_string comment.id :: existing);
-                    (* Update post reply count and updated_at *)
-                    Hashtbl.replace
-                      store.posts
-                      post_key
-                      { post with reply_count = post.reply_count + 1; updated_at = now };
-                    mark_dirty_post store post_key;
-                    mark_dirty_comment store (Comment_id.to_string comment.id);
-                    invalidate_post_caches store;
-                    invalidate_comment_caches store;
-                    Ok (comment, post, posts_jsonl_unlocked store))
-            in
-            match board_result with
-            | Ok (comment, previous_post, posts_jsonl) ->
-              (match
-                 with_persist_lock store (fun () ->
-                   match append_comment comment with
-                   | Error _ as e -> e
-                   | Ok () ->
-                     save_posts_jsonl posts_jsonl;
-                     Ok ())
-               with
-               | Ok () ->
-                 with_lock store (fun () ->
-                   mark_dirty_post store (Post_id.to_string comment.post_id);
-                   mark_dirty_comment store (Comment_id.to_string comment.id));
-                 Ok { comment; audience }
-               | Error e ->
-                 rollback_fresh_comment store ~comment ~previous_post;
-                 Error e)
-            | Error _ as e -> e
+    (* Write-ahead (PR #28934 class, #28952): validate under [with_lock]
+       with no mutation, durably append outside any lock, then commit
+       under [with_lock] from a fresh read. The previous shape mutated
+       first and appended second, so a racing [flush_dirty] could
+       snapshot-write a comment whose durable append was about to fail
+       and be rolled back — reviving it from the snapshot on restart.
+       If staging rejects or the append fails, nothing was mutated, so
+       there is nothing to roll back. *)
+    let staged =
+      with_lock store (fun () ->
+        match Hashtbl.find_opt store.posts (Post_id.to_string pid) with
+        | None -> Error (Post_not_found post_id)
+        | Some post ->
+          (match
+             validate_sub_board_post_policy_unlocked
+               store
+               ~author_id
+               ~hearth:post.hearth
+           with
+           | Error e -> Error e
+           | Ok () ->
+             let now = Time_compat.now () in
+             Ok
+               { id = Comment_id.generate ()
+               ; post_id = pid
+               ; parent_id = parent_cid
+               ; author = author_id
+               ; content
+               ; created_at = now
+               ; expires_at =
+                   (if ttl_hours = 0
+                    then 0.0
+                    else
+                      now
+                      +. (Stdlib.Float.of_int ttl_hours
+                          *. Masc_time_constants.hour))
+               ; votes_up = 0
+               ; votes_down = 0
+               }))
+    in
+    (match staged with
+     | Error _ as e -> e
+     | Ok comment ->
+       (match with_persist_lock store (fun () -> append_comment comment) with
+        | Error _ as e -> e
+        | Ok () ->
+          with_lock store (fun () ->
+            (* Commit from a fresh read: the post can change or vanish
+               while the append is in flight; bumping the stale staged
+               copy would clobber a concurrent unrelated mutation. *)
+            match Hashtbl.find_opt store.posts (Post_id.to_string pid) with
+            | None ->
+              (* Post deleted mid-append. The appended row is an orphan
+                 on disk; the next comments snapshot rewrite drops it,
+                 and after a crash the loader tolerates it (reply-count
+                 recalculation skips comments whose post is gone). *)
+              Error (Post_not_found post_id)
+            | Some post ->
+              let post_key = Post_id.to_string pid in
+              let comment_key = Comment_id.to_string comment.id in
+              Hashtbl.add store.comments comment_key comment;
+              let existing =
+                Hashtbl.find_opt store.comments_by_post post_key
+                |> Option.value ~default:[]
+              in
+              Hashtbl.replace
+                store.comments_by_post
+                post_key
+                (comment_key :: existing);
+              Hashtbl.replace
+                store.posts
+                post_key
+                { post with
+                  reply_count = post.reply_count + 1
+                ; updated_at = comment.created_at
+                };
+              mark_dirty_post store post_key;
+              mark_dirty_comment store comment_key;
+              invalidate_post_caches store;
+              invalidate_comment_caches store;
+              Ok { comment; audience })))
 ;;
 
 let add_comment store ~post_id ~author ~content ?parent_id ?ttl_hours () =

--- a/lib/board/board_core.ml
+++ b/lib/board/board_core.ml
@@ -264,41 +264,67 @@ let add_comment_with_audience
        (match with_persist_lock store (fun () -> append_comment comment) with
         | Error _ as e -> e
         | Ok () ->
-          with_lock store (fun () ->
-            (* Commit from a fresh read: the post can change or vanish
-               while the append is in flight; bumping the stale staged
-               copy would clobber a concurrent unrelated mutation. *)
-            match Hashtbl.find_opt store.posts (Post_id.to_string pid) with
-            | None ->
-              (* Post deleted mid-append. The appended row is an orphan
-                 on disk; the next comments snapshot rewrite drops it,
-                 and after a crash the loader tolerates it (reply-count
-                 recalculation skips comments whose post is gone). *)
-              Error (Post_not_found post_id)
-            | Some post ->
-              let post_key = Post_id.to_string pid in
-              let comment_key = Comment_id.to_string comment.id in
-              Hashtbl.add store.comments comment_key comment;
-              let existing =
-                Hashtbl.find_opt store.comments_by_post post_key
-                |> Option.value ~default:[]
-              in
-              Hashtbl.replace
-                store.comments_by_post
-                post_key
-                (comment_key :: existing);
-              Hashtbl.replace
-                store.posts
-                post_key
-                { post with
-                  reply_count = post.reply_count + 1
-                ; updated_at = comment.created_at
-                };
-              mark_dirty_post store post_key;
-              mark_dirty_comment store comment_key;
-              invalidate_post_caches store;
-              invalidate_comment_caches store;
-              Ok { comment; audience })))
+          let committed =
+            with_lock store (fun () ->
+              (* Commit from a fresh read: the post can change or vanish
+                 while the append is in flight; bumping the stale staged
+                 copy would clobber a concurrent unrelated mutation. The
+                 policy is re-checked for the same reason — it can flip
+                 while the append is in flight, and commit is the
+                 authoritative gate. *)
+              match Hashtbl.find_opt store.posts (Post_id.to_string pid) with
+              | None -> Error (Post_not_found post_id)
+              | Some post ->
+                (match
+                   validate_sub_board_post_policy_unlocked
+                     store
+                     ~author_id
+                     ~hearth:post.hearth
+                 with
+                 | Error _ as e -> e
+                 | Ok () ->
+                   let post_key = Post_id.to_string pid in
+                   let comment_key = Comment_id.to_string comment.id in
+                   Hashtbl.add store.comments comment_key comment;
+                   let existing =
+                     Hashtbl.find_opt store.comments_by_post post_key
+                     |> Option.value ~default:[]
+                   in
+                   Hashtbl.replace
+                     store.comments_by_post
+                     post_key
+                     (comment_key :: existing);
+                   Hashtbl.replace
+                     store.posts
+                     post_key
+                     { post with
+                       reply_count = post.reply_count + 1
+                     ; updated_at =
+                         (* Never move [updated_at] backwards: a
+                            concurrent mutation can land between staging
+                            and commit with a newer timestamp. *)
+                         Stdlib.Float.max post.updated_at comment.created_at
+                     };
+                   mark_dirty_post store post_key;
+                   mark_dirty_comment store comment_key;
+                   invalidate_post_caches store;
+                   invalidate_comment_caches store;
+                   Ok { comment; audience }))
+          in
+          (match committed with
+           | Ok _ as ok -> ok
+           | Error _ as e ->
+             (* The durable append won but the commit lost (post deleted
+                or policy flipped mid-append), so the appended row is an
+                orphan on disk. Rewrite the comments snapshot to dispose
+                of it — the snapshot cannot contain the orphan because
+                it never reached memory. If the rewrite itself fails,
+                the next successful snapshot rewrite disposes of the
+                row; until then reply-count recalculation on load skips
+                comments whose post is gone, so the orphan cannot
+                distort counts. *)
+             rewrite_comments store;
+             e)))
 ;;
 
 let add_comment store ~post_id ~author ~content ?parent_id ?ttl_hours () =

--- a/lib/board/board_core_persist.ml
+++ b/lib/board/board_core_persist.ml
@@ -435,21 +435,6 @@ let append_comment (c : comment) =
   | Sys_error msg -> persist_io_error ~where:"append_comment" msg
 ;;
 
-let rollback_fresh_post store (post : post) =
-  with_lock store (fun () ->
-    let key = Post_id.to_string post.id in
-    match Hashtbl.find_opt store.posts key with
-    | None -> ()
-    | Some current
-      when Stdlib.Float.equal current.created_at post.created_at
-           && Stdlib.Float.equal current.updated_at post.updated_at ->
-      Hashtbl.remove store.posts key;
-      unindex_post_origin store post;
-      store.post_count := max 0 (!(store.post_count) - 1);
-      invalidate_post_caches store
-    | Some _ -> ())
-;;
-
 let sub_board_access_to_string = Board_sub_board_json.sub_board_access_to_string
 let sub_board_access_of_string_opt = Board_sub_board_json.sub_board_access_of_string_opt
 let sub_board_post_counts_unlocked store =
@@ -557,47 +542,52 @@ let create_post_with_audience
       with
       | Error _ as error -> error
       | Ok audience ->
-      let board_result =
+      (* Write-ahead (PR #28934 class, #28952): validate under
+         [with_lock] with no mutation, durably append outside any lock,
+         then commit under [with_lock]. The previous shape mutated
+         first and appended second, so a racing [flush_dirty] could
+         snapshot-write a post whose durable append was about to fail
+         and be rolled back — reviving it from the snapshot on restart.
+         If staging rejects or the append fails, nothing was mutated. *)
+      let staged =
         with_lock store (fun () ->
           match validate_sub_board_post_policy_unlocked store ~author_id ~hearth with
             | Error e -> Error e
             | Ok () ->
               let now = Time_compat.now () in
-              let post =
-                    { id = Post_id.generate ()
-                    ; author = author_id
-                    ; title = normalized_title
-                    ; body = normalized_body
-                    ; content = normalized_body
-                    ; post_kind = normalized_kind
-                    ; meta_json = normalized_meta
-                    ; visibility
-                    ; created_at = now
-                    ; updated_at = now
-                    ; expires_at
-                    ; votes_up = 0
-                    ; votes_down = 0
-                    ; reply_count = 0
-                    ; pinned = false
-                    ; hearth
-                    ; thread_id
-                    ; origin
-                    }
-                  in
-                  Hashtbl.add store.posts (Post_id.to_string post.id) post;
-                  index_post_origin store post;
-                  Stdlib.incr store.post_count;
-                  invalidate_post_caches store;
-              Ok post)
+              Ok
+                { id = Post_id.generate ()
+                ; author = author_id
+                ; title = normalized_title
+                ; body = normalized_body
+                ; content = normalized_body
+                ; post_kind = normalized_kind
+                ; meta_json = normalized_meta
+                ; visibility
+                ; created_at = now
+                ; updated_at = now
+                ; expires_at
+                ; votes_up = 0
+                ; votes_down = 0
+                ; reply_count = 0
+                ; pinned = false
+                ; hearth
+                ; thread_id
+                ; origin
+                })
       in
-      match board_result with
+      match staged with
+      | Error _ as e -> e
       | Ok post ->
         (match with_persist_lock store (fun () -> append_post post) with
-         | Ok () -> Ok { post; audience }
-         | Error e ->
-           rollback_fresh_post store post;
-           Error e)
-      | Error _ as e -> e
+         | Error _ as e -> e
+         | Ok () ->
+           with_lock store (fun () ->
+             Hashtbl.add store.posts (Post_id.to_string post.id) post;
+             index_post_origin store post;
+             Stdlib.incr store.post_count;
+             invalidate_post_caches store);
+           Ok { post; audience })
 ;;
 
 let create_post store ~author ~content ?title ?body ~post_kind ?meta_json

--- a/lib/board/board_core_persist.ml
+++ b/lib/board/board_core_persist.ml
@@ -377,21 +377,31 @@ let rewrite_posts store =
   let content = with_lock store (fun () -> posts_jsonl_unlocked store) in
   with_persist_lock store (fun () -> save_posts_jsonl content)
 ;;
-let rewrite_comments store =
+let comments_jsonl_unlocked store =
+  let buf = Buffer.create 4096 in
+  Hashtbl.iter
+    (fun _ (cmt : comment) ->
+       Buffer.add_string buf (Yojson.Safe.to_string (comment_to_yojson cmt));
+       Buffer.add_char buf '\n')
+    store.comments;
+  Buffer.contents buf
+;;
+let save_comments_jsonl content =
   try
     ensure_masc_dir ();
-    let path = comments_path () in
-    let buf = Buffer.create 4096 in
-    Hashtbl.iter
-      (fun _ (cmt : comment) ->
-         Buffer.add_string buf (Yojson.Safe.to_string (comment_to_yojson cmt));
-         Buffer.add_char buf '\n')
-      store.comments;
-    match Fs_compat.save_file_atomic path (Buffer.contents buf) with
+    match Fs_compat.save_file_atomic (comments_path ()) content with
     | Ok () -> ()
     | Error msg -> record_persist_error ~where:"rewrite_comments" msg
   with
   | Sys_error msg -> record_persist_error ~where:"rewrite_comments" msg
+;;
+(* Mirrors [rewrite_posts]: snapshot under [store.mutex], disk I/O under
+   the persist lock after releasing the state lock. The previous body
+   iterated [store.comments] and wrote the file with no lock at all,
+   contradicting the interface doc; callers must not hold [store.mutex]. *)
+let rewrite_comments store =
+  let content = with_lock store (fun () -> comments_jsonl_unlocked store) in
+  with_persist_lock store (fun () -> save_comments_jsonl content)
 ;;
 let reactions_jsonl_unlocked store =
   let buf = Buffer.create 4096 in
@@ -582,12 +592,36 @@ let create_post_with_audience
         (match with_persist_lock store (fun () -> append_post post) with
          | Error _ as e -> e
          | Ok () ->
-           with_lock store (fun () ->
-             Hashtbl.add store.posts (Post_id.to_string post.id) post;
-             index_post_origin store post;
-             Stdlib.incr store.post_count;
-             invalidate_post_caches store);
-           Ok { post; audience })
+           let committed =
+             with_lock store (fun () ->
+               (* Commit re-checks the policy: staging validated it, but
+                  it can flip while the append is in flight, and commit
+                  is the authoritative gate — a durable row without a
+                  commit stays provisional. *)
+               match
+                 validate_sub_board_post_policy_unlocked store ~author_id ~hearth
+               with
+               | Error _ as e -> e
+               | Ok () ->
+                 Hashtbl.add store.posts (Post_id.to_string post.id) post;
+                 index_post_origin store post;
+                 Stdlib.incr store.post_count;
+                 invalidate_post_caches store;
+                 Ok ())
+           in
+           (match committed with
+            | Ok () -> Ok { post; audience }
+            | Error e ->
+              (* The appended row is an orphan on disk (the policy
+                 flipped mid-append; the post never reached memory).
+                 Rewrite the posts snapshot to dispose of it — the
+                 snapshot cannot contain the orphan. If the rewrite
+                 itself fails, the next successful snapshot rewrite
+                 disposes of the row; a restart before that would
+                 revive the post, because a post row is self-contained
+                 and the loader cannot tell it was never committed. *)
+              rewrite_posts store;
+              Error e))
 ;;
 
 let create_post store ~author ~content ?title ?body ~post_kind ?meta_json

--- a/lib/board/board_core_persist.mli
+++ b/lib/board/board_core_persist.mli
@@ -54,10 +54,6 @@ val ensure_masc_dir : unit -> unit
 val max_jsonl_bytes : int
 val rotate_if_needed : string -> unit
 
-val posts_jsonl_unlocked : store -> string
-(* [save_posts_jsonl_result] is the result-returning inner form of
-   [save_posts_jsonl] below, which is the door callers use. *)
-val save_posts_jsonl : string -> unit
 val rewrite_posts : store -> unit
 val rewrite_comments : store -> unit
 val reactions_jsonl_unlocked : store -> string

--- a/lib/board/board_votes.ml
+++ b/lib/board/board_votes.ml
@@ -336,8 +336,11 @@ let comment_of_yojson = Board_votes_json.comment_of_yojson
 let load_persisted_posts = Board_votes_json.load_persisted_posts
 let load_persisted_comments = Board_votes_json.load_persisted_comments
 
-(** Recalculate reply_count for all posts based on actual comments.
-    This ensures data consistency after loading from disk. *)
+(** Recalculate reply_count for all posts based on actual comments, and
+    restore each post's [updated_at] high-water mark from its comments'
+    [created_at]. This ensures data consistency after loading from disk:
+    the posts snapshot can predate comment WAL rows appended after the
+    last flush, so both the count and the timestamp are re-derived. *)
 let recalculate_reply_counts store =
   (* First, reset all reply_counts to 0 *)
   Hashtbl.iter (fun key (p : post) ->
@@ -348,7 +351,10 @@ let recalculate_reply_counts store =
     let post_key = Post_id.to_string c.post_id in
     match Hashtbl.find_opt store.posts post_key with
     | Some p ->
-        Hashtbl.replace store.posts post_key { p with reply_count = p.reply_count + 1 }
+        Hashtbl.replace store.posts post_key
+          { p with
+            reply_count = p.reply_count + 1
+          ; updated_at = Stdlib.Float.max p.updated_at c.created_at }
     | None -> ()
   ) store.comments;
   let total = Hashtbl.fold (fun _ (p : post) acc -> acc + p.reply_count) store.posts 0 in

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -326,6 +326,7 @@ normal_targets=(
   @test/runtest-test_board_karma_ledger
   @test/runtest-test_board_vote_persistence
   @test/runtest-test_log_ring_bounds
+  @test/runtest-test_board_comment_post_write_ahead
   @test/runtest-test_keeper_event_queue
   @test/runtest-test_keeper_event_queue_owner_lock
   @test/runtest-test_keeper_event_queue_persist_poison

--- a/test/dune
+++ b/test/dune
@@ -1063,6 +1063,7 @@
   test_board_dispatch
   test_board_sort
   test_board_vote_persistence
+  test_board_comment_post_write_ahead
   test_board_karma_ledger
   test_workspace_task_delete
   test_workspace_task_lifecycle
@@ -1202,6 +1203,7 @@
   test_board_dispatch
   test_board_sort
   test_board_vote_persistence
+  test_board_comment_post_write_ahead
   test_board_karma_ledger
   test_workspace_task_delete
   test_workspace_task_lifecycle

--- a/test/test_board_comment_post_write_ahead.ml
+++ b/test/test_board_comment_post_write_ahead.ml
@@ -9,9 +9,9 @@
       memory, no reply-count drift, typed [Io_error]);
     - the same call succeeds once the disk is healthy again — the
       failure left no residual state to collide with;
-    - restart derives [reply_count] from the comment WAL, so dropping
-      the eager posts-snapshot save from the comment path loses
-      nothing across a crash. *)
+    - restart derives [reply_count] and the [updated_at] high-water
+      mark from the comment WAL, so dropping the eager posts-snapshot
+      save from the comment path loses nothing across a crash. *)
 
 open Masc
 
@@ -114,6 +114,9 @@ let test_comment_append_failure_commits_nothing () =
   | Error e -> Alcotest.fail (Board.show_board_error e)
 
 let test_post_append_failure_commits_nothing () =
+  let working_base =
+    Sys.getenv_opt "MASC_BASE_PATH" |> Option.value ~default:""
+  in
   ignore (block_board_masc_dir_with_file ());
   (match
      Board_dispatch.create_post ~author:"post-wa-author"
@@ -124,22 +127,26 @@ let test_post_append_failure_commits_nothing () =
    | Error (Board.Io_error _) -> ()
    | Error e ->
      Alcotest.fail ("expected Io_error, got " ^ Board.show_board_error e));
-  (* Fresh base: the failed create left nothing in memory to list. *)
-  ignore (fresh_test_base_path ());
-  Board.reset_global_for_test ();
-  Board_dispatch.reset_for_test ();
-  Board_dispatch.init_jsonl ();
+  Unix.putenv "MASC_BASE_PATH" working_base;
+  (* Same store, no reset: the failed create must have left nothing in
+     memory for the healthy-path retry to collide with. *)
   (match Board_dispatch.list_posts () with
    | [] -> ()
    | posts ->
      Alcotest.failf "failed create left %d post(s) behind" (List.length posts));
-  match
-    Board_dispatch.create_post ~author:"post-wa-author"
-      ~content:"retry lands durably" ~post_kind:Board.Human_post ()
-  with
-  | Ok _ -> ()
-  | Error e ->
-    Alcotest.fail ("retry must succeed, got " ^ Board.show_board_error e)
+  (match
+     Board_dispatch.create_post ~author:"post-wa-author"
+       ~content:"retry lands durably" ~post_kind:Board.Human_post ()
+   with
+   | Ok _ -> ()
+   | Error e ->
+     Alcotest.fail ("retry must succeed, got " ^ Board.show_board_error e));
+  Alcotest.(check int)
+    "exactly the retried post is listed" 1
+    (List.length (Board_dispatch.list_posts ()));
+  Alcotest.(check int)
+    "posts WAL has exactly the retried row, no ghost from the failure" 1
+    (List.length (Fs_compat.load_jsonl (Board.persist_path ())))
 
 let test_restart_recomputes_reply_count_from_comment_wal () =
   let post =
@@ -154,7 +161,8 @@ let test_restart_recomputes_reply_count_from_comment_wal () =
    | Ok _ -> ()
    | Error e -> Alcotest.fail (Board.show_board_error e));
   (* No snapshot flush: the posts snapshot on disk still carries
-     reply_count = 0. The comment WAL row alone must be enough. *)
+     reply_count = 0 and the post's creation-time [updated_at]. The
+     comment WAL row alone must restore both. *)
   Board.reset_global_for_test ();
   Board_dispatch.reset_for_test ();
   Board_dispatch.init_jsonl ();
@@ -162,7 +170,16 @@ let test_restart_recomputes_reply_count_from_comment_wal () =
   | Ok loaded ->
     Alcotest.(check int)
       "restart recomputes reply_count from the comment WAL" 1
-      loaded.reply_count
+      loaded.reply_count;
+    (match Board_dispatch.get_comments ~post_id with
+     | Ok [ c ] ->
+       Alcotest.(check (float 0.0))
+         "restart restores updated_at to the comment high-water mark"
+         c.created_at loaded.updated_at
+     | Ok comments ->
+       Alcotest.failf "expected exactly 1 comment, got %d"
+         (List.length comments)
+     | Error e -> Alcotest.fail (Board.show_board_error e))
   | Error e -> Alcotest.fail (Board.show_board_error e)
 
 let () =

--- a/test/test_board_comment_post_write_ahead.ml
+++ b/test/test_board_comment_post_write_ahead.ml
@@ -1,0 +1,183 @@
+(** Write-ahead durability for comment and post creation (#28952).
+
+    PR #28934 converted votes to write-ahead (validate, durably append,
+    then commit from a fresh read) and documented comments as the same
+    known race class; posts shared the shape too. These tests pin the
+    converted contract for both creation paths:
+
+    - a failed durable append commits nothing (no comment/post in
+      memory, no reply-count drift, typed [Io_error]);
+    - the same call succeeds once the disk is healthy again — the
+      failure left no residual state to collide with;
+    - restart derives [reply_count] from the comment WAL, so dropping
+      the eager posts-snapshot save from the comment path loses
+      nothing across a crash. *)
+
+open Masc
+
+let () = Mirage_crypto_rng_unix.use_default ()
+let () = Random.self_init ()
+
+let fresh_test_base_path () =
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-test-comment-wa-%06x" (Random.bits ()))
+  in
+  Unix.putenv "MASC_BASE_PATH" dir;
+  dir
+
+(* Replaces the board's [.masc] directory with a regular file so any
+   subsequent [Fs_compat.mkdir_p]/[append_file] under it raises
+   [Sys_error] (ENOTDIR). Same fixture as
+   [test_board_vote_persistence.ml]; duplicated locally per that
+   suite's per-file fixture convention. *)
+let block_board_masc_dir_with_file () =
+  let base =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-test-comment-wa-blocked-%06x" (Random.bits ()))
+  in
+  Unix.putenv "MASC_BASE_PATH" base;
+  let masc_dir = Filename.dirname (Board.persist_path ()) in
+  Fs_compat.mkdir_p (Filename.dirname masc_dir);
+  Fs_compat.save_file masc_dir "not a directory";
+  base
+
+let with_eio f () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  ignore (fresh_test_base_path ());
+  Board.reset_global_for_test ();
+  Board_dispatch.reset_for_test ();
+  Board_dispatch.init_jsonl ();
+  f ()
+
+let create_post_exn ~author ~content =
+  match
+    Board_dispatch.create_post ~author ~content ~post_kind:Board.Human_post ()
+  with
+  | Ok post -> post
+  | Error e -> Alcotest.fail (Board.show_board_error e)
+
+let flush () =
+  match Board_dispatch.backend () with
+  | Board_dispatch.Jsonl store -> Board.flush_dirty store
+
+let comment_rows () = Fs_compat.load_jsonl (Board.comments_path ())
+
+let test_comment_append_failure_commits_nothing () =
+  let post =
+    create_post_exn ~author:"comment-wa-author"
+      ~content:"comment write-ahead under test"
+  in
+  let post_id = Board.Post_id.to_string post.id in
+  let working_base =
+    Sys.getenv_opt "MASC_BASE_PATH" |> Option.value ~default:""
+  in
+  ignore (block_board_masc_dir_with_file ());
+  (match
+     Board_dispatch.add_comment ~post_id ~author:"comment-wa-commenter"
+       ~content:"must not survive a failed append" ()
+   with
+   | Ok _ -> Alcotest.fail "comment must not succeed when the append fails"
+   | Error (Board.Io_error _) -> ()
+   | Error e ->
+     Alcotest.fail ("expected Io_error, got " ^ Board.show_board_error e));
+  Unix.putenv "MASC_BASE_PATH" working_base;
+  (match Board_dispatch.get_comments ~post_id with
+   | Ok [] -> ()
+   | Ok comments ->
+     Alcotest.failf "failed append left %d comment(s) in memory"
+       (List.length comments)
+   | Error e -> Alcotest.fail (Board.show_board_error e));
+  (match Board_dispatch.get_post ~post_id with
+   | Ok loaded ->
+     Alcotest.(check int)
+       "failed append leaves reply_count untouched" 0 loaded.reply_count
+   | Error e -> Alcotest.fail (Board.show_board_error e));
+  (* Nothing was committed, so the retry starts clean once the disk is
+     healthy again. *)
+  (match
+     Board_dispatch.add_comment ~post_id ~author:"comment-wa-commenter"
+       ~content:"retry lands durably" ()
+   with
+   | Ok _ -> ()
+   | Error e ->
+     Alcotest.fail ("retry must succeed, got " ^ Board.show_board_error e));
+  flush ();
+  Alcotest.(check int)
+    "comment WAL has exactly the retried row, no ghost from the failure" 1
+    (List.length (comment_rows ()));
+  match Board_dispatch.get_post ~post_id with
+  | Ok loaded ->
+    Alcotest.(check int) "retry bumped reply_count" 1 loaded.reply_count
+  | Error e -> Alcotest.fail (Board.show_board_error e)
+
+let test_post_append_failure_commits_nothing () =
+  ignore (block_board_masc_dir_with_file ());
+  (match
+     Board_dispatch.create_post ~author:"post-wa-author"
+       ~content:"must not survive a failed append"
+       ~post_kind:Board.Human_post ()
+   with
+   | Ok _ -> Alcotest.fail "post must not succeed when the append fails"
+   | Error (Board.Io_error _) -> ()
+   | Error e ->
+     Alcotest.fail ("expected Io_error, got " ^ Board.show_board_error e));
+  (* Fresh base: the failed create left nothing in memory to list. *)
+  ignore (fresh_test_base_path ());
+  Board.reset_global_for_test ();
+  Board_dispatch.reset_for_test ();
+  Board_dispatch.init_jsonl ();
+  (match Board_dispatch.list_posts () with
+   | [] -> ()
+   | posts ->
+     Alcotest.failf "failed create left %d post(s) behind" (List.length posts));
+  match
+    Board_dispatch.create_post ~author:"post-wa-author"
+      ~content:"retry lands durably" ~post_kind:Board.Human_post ()
+  with
+  | Ok _ -> ()
+  | Error e ->
+    Alcotest.fail ("retry must succeed, got " ^ Board.show_board_error e)
+
+let test_restart_recomputes_reply_count_from_comment_wal () =
+  let post =
+    create_post_exn ~author:"restart-wa-author"
+      ~content:"reply_count is derived on load"
+  in
+  let post_id = Board.Post_id.to_string post.id in
+  (match
+     Board_dispatch.add_comment ~post_id ~author:"restart-wa-commenter"
+       ~content:"counted after restart" ()
+   with
+   | Ok _ -> ()
+   | Error e -> Alcotest.fail (Board.show_board_error e));
+  (* No snapshot flush: the posts snapshot on disk still carries
+     reply_count = 0. The comment WAL row alone must be enough. *)
+  Board.reset_global_for_test ();
+  Board_dispatch.reset_for_test ();
+  Board_dispatch.init_jsonl ();
+  match Board_dispatch.get_post ~post_id with
+  | Ok loaded ->
+    Alcotest.(check int)
+      "restart recomputes reply_count from the comment WAL" 1
+      loaded.reply_count
+  | Error e -> Alcotest.fail (Board.show_board_error e)
+
+let () =
+  Alcotest.run "board_comment_post_write_ahead"
+    [
+      ( "durability",
+        [
+          Alcotest.test_case
+            "comment: failed append leaves nothing committed" `Quick
+            (with_eio test_comment_append_failure_commits_nothing);
+          Alcotest.test_case "post: failed append leaves nothing committed"
+            `Quick
+            (with_eio test_post_append_failure_commits_nothing);
+          Alcotest.test_case "restart derives reply_count from comment WAL"
+            `Quick
+            (with_eio test_restart_recomputes_reply_count_from_comment_wal);
+        ] );
+    ]

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -876,6 +876,11 @@ let test_comment_persists_post_reply_count () =
    with
    | Error e -> Alcotest.fail (Board.show_board_error e)
    | Ok _ -> ());
+  (* Write-ahead (#28952): the comment append is the durable WAL row;
+     the posts snapshot picks up the bumped reply_count on the next
+     flush, exactly like vote counts — not inline with the comment. *)
+  (match Board_dispatch.backend () with
+   | Board_dispatch.Jsonl store -> Board.flush_dirty store);
   let persisted_reply_count =
     Board.persist_path ()
     |> Fs_compat.load_jsonl
@@ -886,7 +891,7 @@ let test_comment_persists_post_reply_count () =
       | _ -> None)
   in
   Alcotest.(check (option int))
-    "post snapshot reply_count updated with comment append"
+    "post snapshot reply_count updated by the flush after a comment"
     (Some 1)
     persisted_reply_count;
   Board.reset_global_for_test ();


### PR DESCRIPTION
## As-Is (재현 가능한 한 가지)

`add_comment_with_audience`(board_core.ml)와 `create_post_with_audience`(board_core_persist.ml)는 **in-memory 반영 → durable append → 실패 시 rollback** 순서였음. append 실패와 rollback 사이에 `flush_dirty`가 끼어들면, durable하지 못한 항목이 스냅샷에 실려 재시작 시 부활함 — #28934(vote)가 리뷰에서 확정한 것과 동일한 클래스, comment는 #28952로 추적되고 있었고 post는 이번 조사에서 같은 형태로 확인.

## To-Be

vote에 이미 검증된 3단계 write-ahead로 전환:

1. **stage**: `with_lock` 안에서 검증만 (post 존재, sub-board 정책), 무변이. comment/post 값 구성.
2. **durable append**: store mutex 밖에서 `with_persist_lock` append.
3. **commit**: `with_lock` 안에서 **fresh read**로 재판정 후 반영 — staged 사본으로 덮지 않아 동시 무관 변이를 보존. append 중 post가 지워졌으면 `Post_not_found`, 디스크의 append row는 다음 comments 스냅샷 rewrite가 삭제(로더도 죽은 post의 comment를 `recalculate_reply_counts`에서 스킵).

부수 정리:
- comment마다 전체 posts 스냅샷을 다시 쓰던 `save_posts_jsonl` 제거 — reply_count는 vote 카운트와 동일하게 `mark_dirty_post`/flusher + 재시작 시 WAL 재계산으로 지속.
- `rollback_fresh_comment` / `rollback_fresh_post` 삭제 (write-ahead에선 되돌릴 게 없음).

## 검증

- feature test 3케이스 (`test_board_comment_post_write_ahead`, vote 스위트의 ENOTDIR 주입 픽스처 재사용):
  1. comment append 실패 → 아무것도 커밋 안 됨 + 회복 후 재시도는 WAL row 정확히 1개
  2. post append 실패 → 아무것도 커밋 안 됨 + 재시도 성공
  3. 스냅샷 flush 없이 재시작 → comment WAL만으로 reply_count=1 재계산 (save_posts_jsonl 제거의 안전성 근거)
- 로컬 dune build 미실행 (repo 방침) — 컴파일/테스트는 CI 판정. `ocamlformat` 파싱 3/3, `git diff --check` clean.

## 같은 클래스의 잔여 (별도 기록)

`create_sub_board`는 append 실패를 `record_persist_error`로 삼키고 Ok를 반환하는 **다른** 결함(silent persist failure)이라 이 PR 범위 밖 — 이슈로 분리 기록 예정.

Refs #28952
