### PR TITLE
fix(ide): fold worktree-checkout writes to the main-tree Code_address (#28968)

### DIFF
--- a/lib/keeper/keeper_tool_filesystem_runtime.ml
+++ b/lib/keeper/keeper_tool_filesystem_runtime.ml
@@ -591,37 +591,66 @@ let apply_patch ~old_string ~new_string ~replace_all text =
    [(repo_id, rel)] pair first and the repository URL is looked up by
    id. This makes the sandbox/working-tree join work without forcing
    the operator to register every playground clone path. *)
-(* RFC-0378 §5.1: a write inside a git worktree checkout
-   ([<repo>/.worktrees/<dir>/...], this workspace's own convention)
-   must fold to the same [Code_address] as the main-tree write, with
-   the worktree directory riding along as the [checkout] projection
-   metadata. The worktree directory is proven by git's own marker (a
-   [.git] file at the worktree root), never guessed from path shape
-   alone: branch-named worktree directories can span several segments
-   ([.worktrees/feature/PK-123]), so the shortest marked prefix wins.
-   A [.worktrees/...] path with no marker anywhere is not a checkout
-   and keeps its literal address (#28968). *)
-let split_worktree_checkout ~fs_root rel =
-  match String.split_on_char '/' rel with
-  | ".worktrees" :: rest ->
-    let rec probe taken = function
-      | [] | [ _ ] ->
-        (* Nothing left that could be a file inside the checkout. *)
-        None
-      | seg :: remaining ->
-        let taken = taken @ [ seg ] in
-        let dir = String.concat "/" (".worktrees" :: taken) in
-        if safe_file_exists (Filename.concat (Filename.concat fs_root dir) ".git")
-        then Some (dir, String.concat "/" remaining)
-        else probe taken remaining
+(* RFC-0378 §5.1 / #28968: a write inside a linked git worktree must
+   fold to the same [Code_address] as the main-tree write, with the
+   checkout root carried as the [checkout] projection metadata
+   (RFC-0378 §9's proposed representation: the measured
+   [--show-toplevel] value).
+
+   RFC-keeper-workspace-root-only §3.2 owns the mechanism: git itself
+   answers "which checkout holds this file" — no path convention is
+   special-cased (that RFC's deletion list explicitly bans new
+   [.worktrees] literals), so worktrees outside the [.worktrees/]
+   convention fold too. The fold applies only when git's
+   [--git-common-dir] for the file equals the matched repo root's
+   [.git]: that is git's own statement that the checkout is a linked
+   worktree of THIS repository. A nested foreign clone (its own
+   [.git]), a submodule ([.git/modules/...]), or any git failure
+   (not a repo, timeout) leaves today's attribution untouched.
+   Repository identity always comes from the registered catalog URL,
+   never the measured origin — playground clones use local-path
+   origins that do not canonicalise. *)
+type worktree_fold_decision =
+  | Fold_to of string
+  | No_fold
+
+(* One bounded git subprocess per (file directory, matched root); the
+   resolver sits on the path-bearing tool post-hook, so per-call
+   subprocess cost would tax every file-touching turn. Checkout roots
+   do not move while a directory exists, so entries never expire; a
+   catalog change alters [matched_root] and thereby the key. *)
+let worktree_fold_memo : (string * string, worktree_fold_decision) Hashtbl.t =
+  Hashtbl.create 64
+
+let worktree_fold_memo_mutex = Stdlib.Mutex.create ()
+
+let measured_worktree_fold ~matched_root ~file_dir =
+  let key = (file_dir, matched_root) in
+  let cached =
+    Stdlib.Mutex.protect worktree_fold_memo_mutex (fun () ->
+        Hashtbl.find_opt worktree_fold_memo key)
+  in
+  match cached with
+  | Some decision -> decision
+  | None ->
+    let decision =
+      match Repo_git.checkout_identity ~local_path:file_dir with
+      | Error _ -> No_fold
+      | Ok { Repo_git.toplevel; git_common_dir } ->
+        if String.equal toplevel matched_root
+        then No_fold
+        else if String.equal git_common_dir (Filename.concat matched_root ".git")
+        then Fold_to toplevel
+        else No_fold
     in
-    probe [] rest
-  | _ -> None
+    Stdlib.Mutex.protect worktree_fold_memo_mutex (fun () ->
+        Hashtbl.replace worktree_fold_memo key decision);
+    decision
 
 (* The parsers hand back [rel] as the literal remainder of [abs], so
-   chopping that suffix recovers the repository's filesystem root for
-   the worktree-marker probe. A non-literal remainder (never produced
-   today) skips folding rather than guessing. *)
+   chopping that suffix recovers the matched repository's filesystem
+   root. A non-literal remainder (never produced today) skips folding
+   rather than guessing. *)
 let fs_root_of_rel ~abs ~rel =
   let suffix = "/" ^ rel in
   if String.length abs > String.length suffix
@@ -632,10 +661,20 @@ let fs_root_of_rel ~abs ~rel =
 let rel_and_checkout ~abs ~rel =
   match fs_root_of_rel ~abs ~rel with
   | None -> rel, None
-  | Some fs_root ->
-    (match split_worktree_checkout ~fs_root rel with
-     | Some (checkout_dir, inner_rel) -> inner_rel, Some checkout_dir
-     | None -> rel, None)
+  | Some matched_root ->
+    (match
+       measured_worktree_fold ~matched_root ~file_dir:(Filename.dirname abs)
+     with
+     | No_fold -> rel, None
+     | Fold_to checkout_root ->
+       let prefix = checkout_root ^ "/" in
+       if String.length abs > String.length prefix
+          && String.starts_with ~prefix abs
+       then
+         ( String.sub abs (String.length prefix)
+             (String.length abs - String.length prefix)
+         , Some checkout_root )
+       else rel, None)
 
 let resolve_write_attribution ~base_dir ~file_path =
   let abs =

--- a/lib/keeper/keeper_tool_filesystem_runtime.ml
+++ b/lib/keeper/keeper_tool_filesystem_runtime.ml
@@ -591,6 +591,52 @@ let apply_patch ~old_string ~new_string ~replace_all text =
    [(repo_id, rel)] pair first and the repository URL is looked up by
    id. This makes the sandbox/working-tree join work without forcing
    the operator to register every playground clone path. *)
+(* RFC-0378 §5.1: a write inside a git worktree checkout
+   ([<repo>/.worktrees/<dir>/...], this workspace's own convention)
+   must fold to the same [Code_address] as the main-tree write, with
+   the worktree directory riding along as the [checkout] projection
+   metadata. The worktree directory is proven by git's own marker (a
+   [.git] file at the worktree root), never guessed from path shape
+   alone: branch-named worktree directories can span several segments
+   ([.worktrees/feature/PK-123]), so the shortest marked prefix wins.
+   A [.worktrees/...] path with no marker anywhere is not a checkout
+   and keeps its literal address (#28968). *)
+let split_worktree_checkout ~fs_root rel =
+  match String.split_on_char '/' rel with
+  | ".worktrees" :: rest ->
+    let rec probe taken = function
+      | [] | [ _ ] ->
+        (* Nothing left that could be a file inside the checkout. *)
+        None
+      | seg :: remaining ->
+        let taken = taken @ [ seg ] in
+        let dir = String.concat "/" (".worktrees" :: taken) in
+        if safe_file_exists (Filename.concat (Filename.concat fs_root dir) ".git")
+        then Some (dir, String.concat "/" remaining)
+        else probe taken remaining
+    in
+    probe [] rest
+  | _ -> None
+
+(* The parsers hand back [rel] as the literal remainder of [abs], so
+   chopping that suffix recovers the repository's filesystem root for
+   the worktree-marker probe. A non-literal remainder (never produced
+   today) skips folding rather than guessing. *)
+let fs_root_of_rel ~abs ~rel =
+  let suffix = "/" ^ rel in
+  if String.length abs > String.length suffix
+     && String.ends_with ~suffix abs
+  then Some (String.sub abs 0 (String.length abs - String.length suffix))
+  else None
+
+let rel_and_checkout ~abs ~rel =
+  match fs_root_of_rel ~abs ~rel with
+  | None -> rel, None
+  | Some fs_root ->
+    (match split_worktree_checkout ~fs_root rel with
+     | Some (checkout_dir, inner_rel) -> inner_rel, Some checkout_dir
+     | None -> rel, None)
+
 let resolve_write_attribution ~base_dir ~file_path =
   let abs =
     if Filename.is_relative file_path
@@ -626,11 +672,12 @@ let resolve_write_attribution ~base_dir ~file_path =
       | None ->
         unaddressed (Agent_observation.Unattributed.Unparseable_remote_url url)
       | Some slug ->
+        let rel, checkout = rel_and_checkout ~abs ~rel in
         (match normalize_rel rel with
          | None -> unaddressed Agent_observation.Unattributed.Unregistered_path
          | Some rel ->
            (match Agent_observation.Code_address.v ~codebase:slug ~path:rel with
-            | Ok address -> Agent_observation.Addressed { address; checkout = None }
+            | Ok address -> Agent_observation.Addressed { address; checkout }
             | Error invalid ->
               unaddressed (Agent_observation.Unattributed.Unmintable invalid)))
   in

--- a/lib/keeper/keeper_tool_filesystem_runtime.mli
+++ b/lib/keeper/keeper_tool_filesystem_runtime.mli
@@ -18,10 +18,13 @@ val resolve_write_attribution
     prefix) whose [url] normalises via
     {!Agent_observation.canonical_url_of_remote}; the repo-relative
     path is lexically dot-collapsed before minting. A path inside a
-    git worktree checkout ([.worktrees/<dir>/...], proven by the
-    checkout's own [.git] marker file) folds to the {e same} address
-    as the main-tree path, with the worktree directory carried as the
-    [checkout] projection metadata (#28968, RFC-0378 §5.1).
+    linked git worktree of the matched repository folds to the {e same}
+    address as the main-tree path — decided by git itself
+    ({!Repo_git.checkout_identity}: the file's [--git-common-dir]
+    equals the matched root's [.git]), never by a path convention —
+    with the measured checkout root carried as the [checkout]
+    projection metadata (#28968, RFC-0378 §5.1/§9,
+    RFC-keeper-workspace-root-only §3.2).
     [Unaddressed] carries the typed reason and the path exactly as the
     resolver saw it. Total — never raises. *)
 

--- a/lib/keeper/keeper_tool_filesystem_runtime.mli
+++ b/lib/keeper/keeper_tool_filesystem_runtime.mli
@@ -17,9 +17,13 @@ val resolve_write_attribution
     registered repository (sandbox playground parse or [local_path]
     prefix) whose [url] normalises via
     {!Agent_observation.canonical_url_of_remote}; the repo-relative
-    path is lexically dot-collapsed before minting. [Unaddressed]
-    carries the typed reason and the path exactly as the resolver saw
-    it. Total — never raises. *)
+    path is lexically dot-collapsed before minting. A path inside a
+    git worktree checkout ([.worktrees/<dir>/...], proven by the
+    checkout's own [.git] marker file) folds to the {e same} address
+    as the main-tree path, with the worktree directory carried as the
+    [checkout] projection metadata (#28968, RFC-0378 §5.1).
+    [Unaddressed] carries the typed reason and the path exactly as the
+    resolver saw it. Total — never raises. *)
 
 val handle_read_file_with_outcome :
   turn_sandbox_factory:Keeper_sandbox_factory.t option ->

--- a/lib/repo_manager/repo_git.ml
+++ b/lib/repo_manager/repo_git.ml
@@ -280,6 +280,36 @@ let worktree_root ~local_path =
   | Ok [] -> Stdlib.Error "git rev-parse --show-toplevel returned no output"
   | Error msg -> Stdlib.Error msg
 
+type checkout_identity = {
+  toplevel : string;
+  git_common_dir : string;
+}
+
+let checkout_identity ~local_path =
+  (* Outputs arrive in argument order; [--path-format=absolute] pins
+     both lines to absolute paths regardless of the cwd (git >= 2.31,
+     far below any environment this runs in). *)
+  match
+    run_git
+      ~cwd:local_path
+      ~env:read_only_git_env
+      ~timeout_sec:inspection_timeout_sec
+      [ "rev-parse"
+      ; "--path-format=absolute"
+      ; "--show-toplevel"
+      ; "--git-common-dir"
+      ]
+  with
+  | Ok (toplevel :: git_common_dir :: _) ->
+    let toplevel = String.trim toplevel in
+    let git_common_dir = String.trim git_common_dir in
+    if String.equal toplevel "" || String.equal git_common_dir ""
+    then Stdlib.Error "git rev-parse checkout identity returned blank output"
+    else Stdlib.Ok { toplevel; git_common_dir }
+  | Ok _ ->
+    Stdlib.Error "git rev-parse checkout identity returned too few lines"
+  | Error msg -> Stdlib.Error msg
+
 let branch_of_origin_head_ref refname =
   let refname = String.trim refname in
   let prefix = "refs/remotes/origin/" in

--- a/lib/repo_manager/repo_git.mli
+++ b/lib/repo_manager/repo_git.mli
@@ -72,6 +72,26 @@ val worktree_root : local_path:string -> (string, string) result
     [local_path]. It is read-only and bounded; callers use it to avoid treating
     an arbitrary file's dirname as a repository root. *)
 
+type checkout_identity = {
+  toplevel : string;
+      (** Git's [--show-toplevel] for the queried path: the root of the
+          checkout (main tree or linked worktree) that holds it. *)
+  git_common_dir : string;
+      (** Git's [--git-common-dir]: the shared [.git] directory of the
+          repository the checkout belongs to. For a linked worktree
+          this is the {e main} checkout's [.git]; for a nested foreign
+          clone it is that clone's own [.git]. The pair lets a caller
+          decide "worktree of THIS repo" without any path convention
+          or remote-URL parsing. *)
+}
+
+val checkout_identity :
+  local_path:string -> (checkout_identity, string) result
+(** [checkout_identity ~local_path] answers both questions in one
+    read-only, bounded git invocation ([--path-format=absolute]).
+    Errors mirror {!worktree_root}: not a repository, timeout, or
+    unexpected output shape. *)
+
 val origin_head_branch : local_path:string -> (string, string) result
 (** [origin_head_branch ~local_path] returns the branch named by
     [refs/remotes/origin/HEAD]. It does not fall back to guessed branch names;

--- a/test/test_ide_canonical_url_join.ml
+++ b/test/test_ide_canonical_url_join.ml
@@ -307,9 +307,31 @@ let test_docker_playground_path_also_resolves () =
       (Agent_observation.Code_address.path address))
 ;;
 
-(* #28968 / RFC-0378 §5.1 — a write inside a git worktree checkout
-   must fold to the same Code_address as the main-tree write, with the
-   worktree directory carried as [checkout] projection metadata. *)
+(* #28968 / RFC-0378 §5.1 — a write inside a linked git worktree must
+   fold to the same Code_address as the main-tree write, with the
+   measured checkout root carried as [checkout] projection metadata.
+   The mechanism is git's own answer (toplevel + common dir), so the
+   fixtures build real repositories: [git init] + [git worktree add],
+   exactly like test_repo_git.ml. Temp paths are realpath-ed first —
+   git prints resolved paths and macOS tempdirs live behind
+   /var -> /private/var (the #28932 symlink trap). *)
+
+let run_or_fail ~cwd argv =
+  let cmd = String.concat " " (List.map Filename.quote argv) in
+  let full =
+    Printf.sprintf "cd %s && %s >/dev/null 2>&1" (Filename.quote cwd) cmd
+  in
+  if Sys.command full <> 0 then failf "fixture command failed: %s" cmd
+;;
+
+let init_git_repo path =
+  mkdir_p path;
+  run_or_fail ~cwd:path [ "git"; "init"; "-b"; "main" ];
+  run_or_fail ~cwd:path [ "git"; "config"; "user.email"; "test@example.com" ];
+  run_or_fail ~cwd:path [ "git"; "config"; "user.name"; "Test User" ];
+  run_or_fail ~cwd:path
+    [ "git"; "commit"; "--allow-empty"; "-m"; "initial" ]
+;;
 
 let register_repo ~base_dir ~id ~local_path =
   let repo =
@@ -338,22 +360,18 @@ let addressed_record_or_fail label = function
     failf "%s: expected Addressed, got %s" label (attribution_to_string got)
 ;;
 
-(* Mark [dir] as a git worktree checkout the way git does: a [.git]
-   marker file at the checkout root. *)
-let mark_worktree dir =
-  mkdir_p dir;
-  let oc = open_out (Filename.concat dir ".git") in
-  output_string oc "gitdir: elsewhere\n";
-  close_out oc
+let with_real_base_dir f =
+  with_temp_base_dir (fun base_dir -> f (Unix.realpath base_dir))
 ;;
 
 let test_worktree_checkout_folds_to_main_tree_address () =
-  with_temp_base_dir (fun base_dir ->
+  with_real_base_dir (fun base_dir ->
     let repo_root = Filename.concat base_dir "workspace/repo" in
-    mkdir_p repo_root;
+    init_git_repo repo_root;
     touch (Filename.concat repo_root "lib/foo.ml");
+    run_or_fail ~cwd:repo_root
+      [ "git"; "worktree"; "add"; ".worktrees/task-9" ];
     let worktree_dir = Filename.concat repo_root ".worktrees/task-9" in
-    mark_worktree worktree_dir;
     touch (Filename.concat worktree_dir "lib/foo.ml");
     register_repo ~base_dir ~id:"repo" ~local_path:repo_root;
     let main_record =
@@ -382,8 +400,8 @@ let test_worktree_checkout_folds_to_main_tree_address () =
       (Agent_observation.Code_address.codebase worktree_record.Agent_observation.address);
     check
       (option string)
-      "worktree write carries its checkout directory"
-      (Some ".worktrees/task-9")
+      "worktree write carries the measured checkout root"
+      (Some (Unix.realpath worktree_dir))
       worktree_record.Agent_observation.checkout;
     check
       (option string)
@@ -392,56 +410,91 @@ let test_worktree_checkout_folds_to_main_tree_address () =
       main_record.Agent_observation.checkout)
 ;;
 
-let test_multi_segment_worktree_dir_folds_via_git_marker () =
-  with_temp_base_dir (fun base_dir ->
+let test_out_of_convention_worktree_folds_too () =
+  with_real_base_dir (fun base_dir ->
     let repo_root = Filename.concat base_dir "workspace/repo" in
-    mkdir_p repo_root;
-    let worktree_dir = Filename.concat repo_root ".worktrees/feature/pk-1" in
-    mark_worktree worktree_dir;
+    init_git_repo repo_root;
+    (* No [.worktrees/] convention anywhere: git, not a path shape,
+       decides what is a checkout (RFC-keeper-workspace-root-only
+       §3.2). *)
+    run_or_fail ~cwd:repo_root [ "git"; "worktree"; "add"; "tmp/anywhere" ];
+    let worktree_dir = Filename.concat repo_root "tmp/anywhere" in
     touch (Filename.concat worktree_dir "lib/foo.ml");
     register_repo ~base_dir ~id:"repo" ~local_path:repo_root;
     let record =
       addressed_record_or_fail
-        "multi-segment worktree"
+        "out-of-convention worktree"
         (Masc.Keeper_tool_filesystem_runtime.resolve_write_attribution
            ~base_dir
            ~file_path:(Filename.concat worktree_dir "lib/foo.ml"))
     in
     check
       string
-      "branch-named worktree folds past every marked segment"
+      "convention-free worktree folds to the repo-relative path"
       "lib/foo.ml"
       (Agent_observation.Code_address.path record.Agent_observation.address);
     check
       (option string)
-      "checkout keeps the full worktree directory"
-      (Some ".worktrees/feature/pk-1")
+      "checkout carries the measured root"
+      (Some (Unix.realpath worktree_dir))
       record.Agent_observation.checkout)
 ;;
 
-let test_unmarked_worktrees_dir_stays_literal () =
-  with_temp_base_dir (fun base_dir ->
+let test_nested_foreign_clone_does_not_fold () =
+  with_real_base_dir (fun base_dir ->
     let repo_root = Filename.concat base_dir "workspace/repo" in
-    mkdir_p repo_root;
-    (* A .worktrees/ subtree with no .git marker anywhere is not a
-       checkout — the literal address is the correct one. *)
+    init_git_repo repo_root;
+    (* A different repository nested inside the matched tree: its
+       common dir is its own [.git], not the matched repo's, so the
+       fold must not fire and today's attribution stands. *)
+    let foreign = Filename.concat repo_root "vendor/other" in
+    init_git_repo foreign;
+    touch (Filename.concat foreign "lib/foo.ml");
+    register_repo ~base_dir ~id:"repo" ~local_path:repo_root;
+    let record =
+      addressed_record_or_fail
+        "nested foreign clone"
+        (Masc.Keeper_tool_filesystem_runtime.resolve_write_attribution
+           ~base_dir
+           ~file_path:(Filename.concat foreign "lib/foo.ml"))
+    in
+    check
+      string
+      "foreign clone keeps its literal path under the matched repo"
+      "vendor/other/lib/foo.ml"
+      (Agent_observation.Code_address.path record.Agent_observation.address);
+    check
+      (option string)
+      "foreign clone claims no checkout"
+      None
+      record.Agent_observation.checkout)
+;;
+
+let test_plain_subdir_stays_literal () =
+  with_real_base_dir (fun base_dir ->
+    let repo_root = Filename.concat base_dir "workspace/repo" in
+    init_git_repo repo_root;
+    (* A plain directory that merely LOOKS like the worktree
+       convention: git says it is part of the main checkout, so the
+       literal address is the correct one. *)
     touch (Filename.concat repo_root ".worktrees/notes/lib/foo.ml");
     register_repo ~base_dir ~id:"repo" ~local_path:repo_root;
     let record =
       addressed_record_or_fail
-        "unmarked .worktrees"
+        "plain subdir"
         (Masc.Keeper_tool_filesystem_runtime.resolve_write_attribution
            ~base_dir
-           ~file_path:(Filename.concat repo_root ".worktrees/notes/lib/foo.ml"))
+           ~file_path:
+             (Filename.concat repo_root ".worktrees/notes/lib/foo.ml"))
     in
     check
       string
-      "no marker: literal path is kept"
+      "plain subdir keeps its literal path"
       ".worktrees/notes/lib/foo.ml"
       (Agent_observation.Code_address.path record.Agent_observation.address);
     check
       (option string)
-      "no marker: no checkout claimed"
+      "plain subdir claims no checkout"
       None
       record.Agent_observation.checkout)
 ;;
@@ -475,13 +528,17 @@ let () =
             `Quick
             test_worktree_checkout_folds_to_main_tree_address
         ; test_case
-            "multi-segment worktree dir folds via git marker (#28968)"
+            "out-of-convention worktree folds too (#28968)"
             `Quick
-            test_multi_segment_worktree_dir_folds_via_git_marker
+            test_out_of_convention_worktree_folds_too
         ; test_case
-            "unmarked .worktrees dir keeps its literal address (#28968)"
+            "nested foreign clone does not fold (#28968)"
             `Quick
-            test_unmarked_worktrees_dir_stays_literal
+            test_nested_foreign_clone_does_not_fold
+        ; test_case
+            "plain look-alike subdir keeps its literal address (#28968)"
+            `Quick
+            test_plain_subdir_stays_literal
         ] )
     ]
 ;;

--- a/test/test_ide_canonical_url_join.ml
+++ b/test/test_ide_canonical_url_join.ml
@@ -307,6 +307,145 @@ let test_docker_playground_path_also_resolves () =
       (Agent_observation.Code_address.path address))
 ;;
 
+(* #28968 / RFC-0378 §5.1 — a write inside a git worktree checkout
+   must fold to the same Code_address as the main-tree write, with the
+   worktree directory carried as [checkout] projection metadata. *)
+
+let register_repo ~base_dir ~id ~local_path =
+  let repo =
+    { id
+    ; name = id
+    ; url = "https://github.com/owner/repo"
+    ; local_path
+    ; aliases = []
+    ; default_branch = "main"
+    ; keepers = []
+    ; status = Active
+    ; auto_sync = false
+    ; sync_interval = 0
+    ; created_at = Int64.zero
+    ; updated_at = Int64.zero
+    }
+  in
+  match Repo_store.save_all ~base_path:base_dir [ repo ] with
+  | Ok () -> ()
+  | Error msg -> failf "save_all: %s" msg
+;;
+
+let addressed_record_or_fail label = function
+  | Agent_observation.Addressed record -> record
+  | Agent_observation.Unaddressed _ as got ->
+    failf "%s: expected Addressed, got %s" label (attribution_to_string got)
+;;
+
+(* Mark [dir] as a git worktree checkout the way git does: a [.git]
+   marker file at the checkout root. *)
+let mark_worktree dir =
+  mkdir_p dir;
+  let oc = open_out (Filename.concat dir ".git") in
+  output_string oc "gitdir: elsewhere\n";
+  close_out oc
+;;
+
+let test_worktree_checkout_folds_to_main_tree_address () =
+  with_temp_base_dir (fun base_dir ->
+    let repo_root = Filename.concat base_dir "workspace/repo" in
+    mkdir_p repo_root;
+    touch (Filename.concat repo_root "lib/foo.ml");
+    let worktree_dir = Filename.concat repo_root ".worktrees/task-9" in
+    mark_worktree worktree_dir;
+    touch (Filename.concat worktree_dir "lib/foo.ml");
+    register_repo ~base_dir ~id:"repo" ~local_path:repo_root;
+    let main_record =
+      addressed_record_or_fail
+        "main tree"
+        (Masc.Keeper_tool_filesystem_runtime.resolve_write_attribution
+           ~base_dir
+           ~file_path:(Filename.concat repo_root "lib/foo.ml"))
+    in
+    let worktree_record =
+      addressed_record_or_fail
+        "worktree"
+        (Masc.Keeper_tool_filesystem_runtime.resolve_write_attribution
+           ~base_dir
+           ~file_path:(Filename.concat worktree_dir "lib/foo.ml"))
+    in
+    check
+      string
+      "worktree write folds to the main-tree path"
+      (Agent_observation.Code_address.path main_record.Agent_observation.address)
+      (Agent_observation.Code_address.path worktree_record.Agent_observation.address);
+    check
+      string
+      "same codebase slug"
+      (Agent_observation.Code_address.codebase main_record.Agent_observation.address)
+      (Agent_observation.Code_address.codebase worktree_record.Agent_observation.address);
+    check
+      (option string)
+      "worktree write carries its checkout directory"
+      (Some ".worktrees/task-9")
+      worktree_record.Agent_observation.checkout;
+    check
+      (option string)
+      "main-tree write carries no checkout"
+      None
+      main_record.Agent_observation.checkout)
+;;
+
+let test_multi_segment_worktree_dir_folds_via_git_marker () =
+  with_temp_base_dir (fun base_dir ->
+    let repo_root = Filename.concat base_dir "workspace/repo" in
+    mkdir_p repo_root;
+    let worktree_dir = Filename.concat repo_root ".worktrees/feature/pk-1" in
+    mark_worktree worktree_dir;
+    touch (Filename.concat worktree_dir "lib/foo.ml");
+    register_repo ~base_dir ~id:"repo" ~local_path:repo_root;
+    let record =
+      addressed_record_or_fail
+        "multi-segment worktree"
+        (Masc.Keeper_tool_filesystem_runtime.resolve_write_attribution
+           ~base_dir
+           ~file_path:(Filename.concat worktree_dir "lib/foo.ml"))
+    in
+    check
+      string
+      "branch-named worktree folds past every marked segment"
+      "lib/foo.ml"
+      (Agent_observation.Code_address.path record.Agent_observation.address);
+    check
+      (option string)
+      "checkout keeps the full worktree directory"
+      (Some ".worktrees/feature/pk-1")
+      record.Agent_observation.checkout)
+;;
+
+let test_unmarked_worktrees_dir_stays_literal () =
+  with_temp_base_dir (fun base_dir ->
+    let repo_root = Filename.concat base_dir "workspace/repo" in
+    mkdir_p repo_root;
+    (* A .worktrees/ subtree with no .git marker anywhere is not a
+       checkout — the literal address is the correct one. *)
+    touch (Filename.concat repo_root ".worktrees/notes/lib/foo.ml");
+    register_repo ~base_dir ~id:"repo" ~local_path:repo_root;
+    let record =
+      addressed_record_or_fail
+        "unmarked .worktrees"
+        (Masc.Keeper_tool_filesystem_runtime.resolve_write_attribution
+           ~base_dir
+           ~file_path:(Filename.concat repo_root ".worktrees/notes/lib/foo.ml"))
+    in
+    check
+      string
+      "no marker: literal path is kept"
+      ".worktrees/notes/lib/foo.ml"
+      (Agent_observation.Code_address.path record.Agent_observation.address);
+    check
+      (option string)
+      "no marker: no checkout claimed"
+      None
+      record.Agent_observation.checkout)
+;;
+
 let () =
   run
     "ide_canonical_url_join"
@@ -331,6 +470,18 @@ let () =
             "docker playground path resolves via repo_id (PR-6)"
             `Quick
             test_docker_playground_path_also_resolves
+        ; test_case
+            "worktree checkout folds to main-tree address (#28968)"
+            `Quick
+            test_worktree_checkout_folds_to_main_tree_address
+        ; test_case
+            "multi-segment worktree dir folds via git marker (#28968)"
+            `Quick
+            test_multi_segment_worktree_dir_folds_via_git_marker
+        ; test_case
+            "unmarked .worktrees dir keeps its literal address (#28968)"
+            `Quick
+            test_unmarked_worktrees_dir_stays_literal
         ] )
     ]
 ;;


### PR DESCRIPTION
## As-Is (재현 가능한 한 가지)

라이브 스토어 실측(#28968): `regions.jsonl`에 `file_path: ".worktrees/task-275-.../lib/workspace/task_cache_invariant.ml"` — worktree에서 작업한 keeper의 편집이 본 트리 주소와 **다른** Code_address로 접혀 IDE에서 보이지 않음. RFC-0378 §5.1 위반 + `checkout` 필드는 코드베이스 전체에서 채워진 적 없음.

## 기전 선택 (탐색 에이전트 조사 반영)

- 어휘적 `.worktrees` 접두 처리는 자매 RFC(keeper-workspace-root-only :146/:190)가 **철거 목록에 올린 패턴** — 새 리터럴 금지, "git이 답한다"가 확정 기전.
- origin URL 가드도 불가: playground 클론의 origin은 로컬 경로(`/Users/.../.masc/repos/masc`)라 canonical화가 None — 정확히 이 이슈의 라이브 행들이 거부됨(실측 확인).
- 채택: **`Repo_git.checkout_identity`** (read-only·bounded `git rev-parse --path-format=absolute --show-toplevel --git-common-dir` 1회). fold 조건 = **파일의 common dir == 매칭 repo 루트의 `.git`** — "이 checkout은 이 저장소의 linked worktree"라는 git 자신의 진술.

## To-Be

- 관례 밖 worktree도 접힘(경로 모양 특수취급 0). 중첩 외부 클론(자기 `.git`)·서브모듈(`.git/modules/…`)·git 실패는 기존 귀속 유지.
- 저장소 identity는 항상 카탈로그 URL(측정 origin 불사용).
- `checkout = Some <측정된 --show-toplevel>` — RFC-0378 §9의 제안 표기 채택.
- (file dir, matched root) 단위 메모이즈 — resolver가 경로 있는 도구 post-hook에 걸려 있어 호출당 subprocess는 비용.

## 검증

- feature test 4케이스, **실제 git 픽스처**(`git init`+`git worktree add`, macOS `/var→/private/var` 함정은 realpath로 고정): 관례 fold·관례 밖 fold·중첩 외부 클론 non-fold·look-alike 디렉토리 literal 유지.
- 로컬 dune build 미실행(repo 방침) — CI 판정. ocamlformat 파싱 5/5.

## 범위 밖 (후속)

- IDE sink(`ingest_tool_event`/region/annotation 레코드)에 `checkout` 필드가 없어 값이 sink에서 소실됨 — 주소 폴딩(본 버그)은 이 PR로 완결, checkout 지속화는 RFC-0378 §4 "세 파일 같은 자리" 층으로 분리(이슈로 기록).

Refs #28968
