### PR TITLE
feat(dashboard): 기록된 tool-call 실행 증거 디코드 복원 + 합성 트리 렌더

### DIFF
--- a/dashboard/src/api/dashboard-keeper-tool-calls.ts
+++ b/dashboard/src/api/dashboard-keeper-tool-calls.ts
@@ -20,6 +20,54 @@ export type ToolCallOutputBlob = {
 export type ToolCallDisposition = 'completed' | 'deferred' | 'failed'
 export type ToolCallCompositionExecution = 'inline' | 'async'
 
+// Recorded execution evidence — written per row by lib/keeper_tool_call_log.ml.
+// The jsonl row is the wire truth: nested nullable fields persist as explicit
+// nulls (e.g. runtime_contract.task_id), optional top-level fields as absent.
+
+export type ToolCallPathResolution = {
+  read_implicit_cwd?: boolean
+  read_explicit_cwd_supported?: boolean
+  read_basis?: string
+  discover_before_read?: string
+  execute_path_basis?: string
+  masc_state_basis?: string
+}
+
+// Sandbox/runtime contract the call executed under. Identity fields that
+// duplicate the top-level row (keeper_name, trace_id, session_id, task_id,
+// goal_ids, keeper_turn_id, sandbox_profile) are not repeated here.
+export type ToolCallRuntimeContract = {
+  agent_name?: string
+  generation?: number
+  sandbox_root?: string
+  allowed_paths?: string[]
+  path_resolution?: ToolCallPathResolution
+  network_mode?: string
+  runtime_profile?: string
+}
+
+// What the call touched, as observed by the executor. tool_name / success /
+// duration_ms duplicate the top-level row and are not repeated here.
+export type ToolCallActionRadius = {
+  action_key?: string
+  target_kind?: string
+  target_path?: string
+  observed_paths?: string[]
+  error?: string
+}
+
+// How the call was routed: descriptor identity plus executor/backend receipt.
+export type ToolCallRouteEvidence = {
+  descriptor_id?: string
+  capability_id?: string
+  executor?: string
+  backend?: string
+  runtime_handler?: string
+  readonly?: boolean
+  retryable?: boolean
+  receipt_labels?: Record<string, string>
+}
+
 export type ToolCallEntry = {
   ts: number
   keeper: string
@@ -62,6 +110,16 @@ export type ToolCallEntry = {
   // Goal id(s) this call was attributed to (conditional on the row carrying
   // them), for goal-scoped drill-down alongside task_id/turn.
   goal_ids?: string[]
+  // Recorded execution evidence. runtime_contract and action_radius are
+  // written on every row; route_evidence only when the descriptor resolved.
+  runtime_contract?: ToolCallRuntimeContract
+  action_radius?: ToolCallActionRadius
+  route_evidence?: ToolCallRouteEvidence
+  // Model invocation parameters for this call's turn.
+  thinking_enabled?: boolean
+  thinking_budget?: number
+  tool_choice?: string
+  prompt_fingerprint?: string
 }
 
 export type ToolCallsResponse = TelemetryFreshnessMetadata & {
@@ -90,6 +148,67 @@ function decodeToolCallOutput(raw: unknown): string | ToolCallOutputBlob {
     }
   }
   return ''
+}
+
+// receipt_labels is a flat string→string projection on the wire; non-string
+// values are dropped rather than coerced.
+function asStringRecord(value: unknown): Record<string, string> | undefined {
+  if (!isRecord(value)) return undefined
+  const out: Record<string, string> = {}
+  for (const [key, entryValue] of Object.entries(value)) {
+    if (typeof entryValue === 'string') out[key] = entryValue
+  }
+  return out
+}
+
+function decodePathResolution(raw: unknown): ToolCallPathResolution | undefined {
+  if (!isRecord(raw)) return undefined
+  return {
+    read_implicit_cwd: asBoolean(raw.read_implicit_cwd),
+    read_explicit_cwd_supported: asBoolean(raw.read_explicit_cwd_supported),
+    read_basis: asString(raw.read_basis),
+    discover_before_read: asString(raw.discover_before_read),
+    execute_path_basis: asString(raw.execute_path_basis),
+    masc_state_basis: asString(raw.masc_state_basis),
+  }
+}
+
+function decodeRuntimeContract(raw: unknown): ToolCallRuntimeContract | undefined {
+  if (!isRecord(raw)) return undefined
+  return {
+    agent_name: asString(raw.agent_name),
+    generation: asNumber(raw.generation),
+    sandbox_root: asString(raw.sandbox_root),
+    allowed_paths: asStringArray(raw.allowed_paths),
+    path_resolution: decodePathResolution(raw.path_resolution),
+    network_mode: asString(raw.network_mode),
+    runtime_profile: asString(raw.runtime_profile),
+  }
+}
+
+function decodeActionRadius(raw: unknown): ToolCallActionRadius | undefined {
+  if (!isRecord(raw)) return undefined
+  return {
+    action_key: asString(raw.action_key),
+    target_kind: asString(raw.target_kind),
+    target_path: asString(raw.target_path),
+    observed_paths: asStringArray(raw.observed_paths),
+    error: asString(raw.error),
+  }
+}
+
+function decodeRouteEvidence(raw: unknown): ToolCallRouteEvidence | undefined {
+  if (!isRecord(raw)) return undefined
+  return {
+    descriptor_id: asString(raw.descriptor_id),
+    capability_id: asString(raw.capability_id),
+    executor: asString(raw.executor),
+    backend: asString(raw.backend),
+    runtime_handler: asString(raw.runtime_handler),
+    readonly: asBoolean(raw.readonly),
+    retryable: asBoolean(raw.retryable),
+    receipt_labels: asStringRecord(raw.receipt_labels),
+  }
 }
 
 function decodeToolCallEntry(raw: unknown): ToolCallEntry | null {
@@ -139,6 +258,13 @@ function decodeToolCallEntry(raw: unknown): ToolCallEntry | null {
     parent_tool_use_id:
       typeof raw.parent_tool_use_id === 'string' ? raw.parent_tool_use_id : undefined,
     goal_ids: asStringArray(raw.goal_ids),
+    runtime_contract: decodeRuntimeContract(raw.runtime_contract),
+    action_radius: decodeActionRadius(raw.action_radius),
+    route_evidence: decodeRouteEvidence(raw.route_evidence),
+    thinking_enabled: asBoolean(raw.thinking_enabled),
+    thinking_budget: asNumber(raw.thinking_budget),
+    tool_choice: asString(raw.tool_choice),
+    prompt_fingerprint: asString(raw.prompt_fingerprint),
   }
 }
 

--- a/dashboard/src/api/dashboard-keeper-tool-calls.ts
+++ b/dashboard/src/api/dashboard-keeper-tool-calls.ts
@@ -46,8 +46,12 @@ export type ToolCallRuntimeContract = {
   runtime_profile?: string
 }
 
-// What the call touched, as observed by the executor. tool_name / success /
-// duration_ms duplicate the top-level row and are not repeated here.
+// What the call targeted. The server derives this once at record time by
+// parsing the redacted input (lib/keeper/keeper_runtime_contract.ml
+// action_radius_json), so every consumer reads the same value. Note that
+// Execute rows record their cwd here (masc#29013): target_kind "path" does
+// not guarantee a file target. tool_name / success / duration_ms duplicate
+// the top-level row and are not repeated here.
 export type ToolCallActionRadius = {
   action_key?: string
   target_kind?: string
@@ -57,6 +61,8 @@ export type ToolCallActionRadius = {
 }
 
 // How the call was routed: descriptor identity plus executor/backend receipt.
+// status is projected to a string from either wire shape (bare "ok" or a
+// record like {kind:"exit",code:0}).
 export type ToolCallRouteEvidence = {
   descriptor_id?: string
   capability_id?: string
@@ -66,6 +72,7 @@ export type ToolCallRouteEvidence = {
   readonly?: boolean
   retryable?: boolean
   receipt_labels?: Record<string, string>
+  status?: string
 }
 
 export type ToolCallEntry = {
@@ -111,7 +118,10 @@ export type ToolCallEntry = {
   // them), for goal-scoped drill-down alongside task_id/turn.
   goal_ids?: string[]
   // Recorded execution evidence. runtime_contract and action_radius are
-  // written on every row; route_evidence only when the descriptor resolved.
+  // written on every row. route_evidence is omitted only when the writer had
+  // neither descriptor fields nor route-shaped output — an unresolved
+  // descriptor can still yield a row carrying just status/tool_name (see
+  // lib/keeper_tool_call_log_route_evidence.ml).
   runtime_contract?: ToolCallRuntimeContract
   action_radius?: ToolCallActionRadius
   route_evidence?: ToolCallRouteEvidence
@@ -197,6 +207,15 @@ function decodeActionRadius(raw: unknown): ToolCallActionRadius | undefined {
   }
 }
 
+function decodeRouteStatus(raw: unknown): string | undefined {
+  if (typeof raw === 'string') return asString(raw)
+  if (!isRecord(raw)) return undefined
+  const kind = asString(raw.kind)
+  if (kind === undefined) return undefined
+  const code = asNumber(raw.code)
+  return code !== undefined ? `${kind} ${code}` : kind
+}
+
 function decodeRouteEvidence(raw: unknown): ToolCallRouteEvidence | undefined {
   if (!isRecord(raw)) return undefined
   return {
@@ -208,6 +227,7 @@ function decodeRouteEvidence(raw: unknown): ToolCallRouteEvidence | undefined {
     readonly: asBoolean(raw.readonly),
     retryable: asBoolean(raw.retryable),
     receipt_labels: asStringRecord(raw.receipt_labels),
+    status: decodeRouteStatus(raw.status),
   }
 }
 

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -452,6 +452,163 @@ describe('keeper tool telemetry fetchers', () => {
     expect(entry?.parent_tool_use_id).toBe('outer-7')
   })
 
+  it('decodes recorded execution evidence (runtime contract, action radius, route evidence)', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(
+      new Response(JSON.stringify({
+        keeper: 'keeper-alpha',
+        count: 1,
+        source: 'tool_call_io',
+        entries: [
+          {
+            // Field shapes mirror a recorded .masc/tool_calls row (2026-08-18),
+            // anonymized. Nested nullable fields arrive as explicit nulls.
+            ts: 1787024860.1,
+            keeper: 'keeper-alpha',
+            tool: 'keeper_time_now',
+            input: {},
+            output: '{"now_iso":"2026-08-18T05:00:00Z"}',
+            success: true,
+            duration_ms: 0.5,
+            thinking_enabled: true,
+            prompt_fingerprint: '464ce7b3280c24fe1cbdcd990a70db87',
+            runtime_contract: {
+              keeper_name: 'keeper-alpha',
+              agent_name: 'keeper-alpha-agent',
+              trace_id: 'trace-1',
+              session_id: 'trace-1',
+              generation: 1,
+              keeper_turn_id: 29567,
+              task_id: null,
+              goal_ids: [],
+              sandbox_profile: 'local',
+              sandbox_root: '/sandbox/keeper-alpha/',
+              allowed_paths: ['.masc/playground/keeper-alpha/'],
+              path_resolution: {
+                read_implicit_cwd: false,
+                read_explicit_cwd_supported: true,
+                read_basis: 'Read file_path resolves against explicit cwd when cwd is provided.',
+                discover_before_read: 'Inspect visible paths before Read.',
+                execute_path_basis: 'Execute path arguments resolve against cwd.',
+                masc_state_basis: '.masc runtime state is not a sandbox filesystem target.',
+              },
+              network_mode: 'inherit',
+              runtime_profile: 'ollama_cloud.example-model',
+            },
+            action_radius: {
+              tool_name: 'keeper_time_now',
+              action_key: 'keeper_time_now',
+              target_kind: 'tool',
+              target_path: null,
+              sandbox_target: 'local',
+              observed_paths: [],
+              success: true,
+              duration_ms: 0.5,
+              error: null,
+            },
+            route_evidence: {
+              descriptor_id: 'keeper.time.now',
+              capability_id: 'keeper_time_now',
+              keeper_model_projection: 'internal_name',
+              public_name: 'keeper_time_now',
+              canonical_name: 'keeper_time_now',
+              executor: 'in_process',
+              backend: 'ocaml_runtime',
+              sandbox: 'none',
+              runtime_handler: 'tool_time_now',
+              execution: 'concurrent',
+              composable_output: { kind: 'json' },
+              receipt_labels: {
+                descriptor_id: 'keeper.time.now',
+                executor: 'in_process',
+                keeper_tool_group: 'meta',
+                input_schema_source: 'descriptor_owned',
+              },
+              eval_tags: [],
+              readonly: true,
+              retryable: true,
+              cwd_scope: null,
+              polling_read: false,
+              tool_name: 'keeper_time_now',
+            },
+          },
+        ],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    ))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchKeeperToolCalls('keeper-alpha')
+    const entry = result.entries[0]
+    expect(entry?.thinking_enabled).toBe(true)
+    expect(entry?.thinking_budget).toBeUndefined()
+    expect(entry?.tool_choice).toBeUndefined()
+    expect(entry?.prompt_fingerprint).toBe('464ce7b3280c24fe1cbdcd990a70db87')
+    expect(entry?.runtime_contract).toMatchObject({
+      agent_name: 'keeper-alpha-agent',
+      generation: 1,
+      sandbox_root: '/sandbox/keeper-alpha/',
+      allowed_paths: ['.masc/playground/keeper-alpha/'],
+      network_mode: 'inherit',
+      runtime_profile: 'ollama_cloud.example-model',
+    })
+    expect(entry?.runtime_contract?.path_resolution).toMatchObject({
+      read_implicit_cwd: false,
+      read_explicit_cwd_supported: true,
+    })
+    expect(entry?.action_radius).toMatchObject({
+      action_key: 'keeper_time_now',
+      target_kind: 'tool',
+      observed_paths: [],
+    })
+    // Explicit wire nulls decode to absent, not to empty strings.
+    expect(entry?.action_radius?.target_path).toBeUndefined()
+    expect(entry?.action_radius?.error).toBeUndefined()
+    expect(entry?.route_evidence).toMatchObject({
+      descriptor_id: 'keeper.time.now',
+      capability_id: 'keeper_time_now',
+      executor: 'in_process',
+      backend: 'ocaml_runtime',
+      runtime_handler: 'tool_time_now',
+      readonly: true,
+      retryable: true,
+    })
+    expect(entry?.route_evidence?.receipt_labels).toEqual({
+      descriptor_id: 'keeper.time.now',
+      executor: 'in_process',
+      keeper_tool_group: 'meta',
+      input_schema_source: 'descriptor_owned',
+    })
+  })
+
+  it('leaves execution evidence absent on rows recorded before it was written', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(
+      new Response(JSON.stringify({
+        keeper: 'keeper-alpha',
+        count: 1,
+        source: 'tool_call_io',
+        entries: [
+          {
+            ts: 1,
+            keeper: 'keeper-alpha',
+            tool: 'keeper_context_status',
+            input: {},
+            output: 'ok',
+            success: true,
+            duration_ms: 5,
+          },
+        ],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    ))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchKeeperToolCalls('keeper-alpha')
+    const entry = result.entries[0]
+    expect(entry?.runtime_contract).toBeUndefined()
+    expect(entry?.action_radius).toBeUndefined()
+    expect(entry?.route_evidence).toBeUndefined()
+    expect(entry?.thinking_enabled).toBeUndefined()
+    expect(entry?.prompt_fingerprint).toBeUndefined()
+  })
+
   it('keeps missing or malformed tool-call duration unmeasured', async () => {
     const fetchMock = vi.fn(() => Promise.resolve(
       new Response(JSON.stringify({

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -579,6 +579,44 @@ describe('keeper tool telemetry fetchers', () => {
     })
   })
 
+  it('projects route_evidence.status from both wire shapes', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(
+      new Response(JSON.stringify({
+        keeper: 'keeper-alpha',
+        count: 2,
+        source: 'tool_call_io',
+        entries: [
+          {
+            ts: 1,
+            keeper: 'keeper-alpha',
+            tool: 'WebSearch',
+            input: {},
+            output: 'ok',
+            success: true,
+            duration_ms: 5,
+            route_evidence: { descriptor_id: 'agent.search_web', status: 'ok' },
+          },
+          {
+            ts: 2,
+            keeper: 'keeper-alpha',
+            tool: 'Execute',
+            input: {},
+            output: 'done',
+            success: true,
+            duration_ms: 5,
+            route_evidence: { descriptor_id: 'agent.execute', status: { kind: 'exit', code: 0 } },
+          },
+        ],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    ))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchKeeperToolCalls('keeper-alpha')
+
+    expect(result.entries[0]?.route_evidence?.status).toBe('ok')
+    expect(result.entries[1]?.route_evidence?.status).toBe('exit 0')
+  })
+
   it('leaves execution evidence absent on rows recorded before it was written', async () => {
     const fetchMock = vi.fn(() => Promise.resolve(
       new Response(JSON.stringify({

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -337,7 +337,15 @@ export type { ToolStat, HourlyBucket, ToolStatsResponse } from './dashboard-keep
 export { fetchKeeperToolStats } from './dashboard-keeper-tool-stats'
 
 // ── Keeper tool call log (full I/O) ──────────────────────
-export type { ToolCallOutputBlob, ToolCallEntry, ToolCallsResponse } from './dashboard-keeper-tool-calls'
+export type {
+  ToolCallOutputBlob,
+  ToolCallEntry,
+  ToolCallsResponse,
+  ToolCallPathResolution,
+  ToolCallRuntimeContract,
+  ToolCallActionRadius,
+  ToolCallRouteEvidence,
+} from './dashboard-keeper-tool-calls'
 export { fetchKeeperToolCalls } from './dashboard-keeper-tool-calls'
 
 // ── Keeper turn records (RFC-0233 PR-4) ─────────────────

--- a/dashboard/src/components/keeper-tool-call-inspector-render.test.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector-render.test.ts
@@ -84,7 +84,7 @@ describe('KeeperToolCallInspector render', () => {
     expect(outputCopy?.getAttribute('title')).toBe('도구 호출 출력 복사')
   })
 
-  it('links recorded path targets back to the Code IDE route, ignoring tool input', async () => {
+  it('links recorded path targets back to the Code IDE route', async () => {
     const fetchKeeperToolCalls = vi.fn().mockResolvedValue({
       keeper: 'analyst',
       count: 1,
@@ -95,9 +95,11 @@ describe('KeeperToolCallInspector render', () => {
           ts: 1_777_100_000,
           keeper: 'analyst',
           tool: 'keeper_fs_read',
-          // The input names a different file on purpose: route links must come
-          // from the recorded action_radius, never from re-parsing the input.
-          input: { file_path: 'lib/other.ml', line: 12 },
+          // The recorded action_radius mirrors the input's path (the server
+          // derives it from the input at record time). The client reads only
+          // the recorded value: the input's line number is not re-parsed, so
+          // the link carries no line.
+          input: { file_path: 'lib/runtime.ml', line: 12 },
           output: 'file contents',
           success: true,
           duration_ms: 42,
@@ -335,6 +337,54 @@ describe('KeeperToolCallInspector render', () => {
     expect(dossier?.textContent).toContain('no failed calls in this window')
     expect(container.querySelector('[title="deferred"]')?.textContent).toBe('D')
     expect(container.querySelector('[data-composition-node="wait_for_board"]')).not.toBeNull()
+  })
+
+  it('does not promote Execute cwd targets to Code links', async () => {
+    const fetchKeeperToolCalls = vi.fn().mockResolvedValue({
+      keeper: 'analyst',
+      count: 1,
+      source: 'tool_call_io',
+      health: 'ok',
+      entries: [
+        {
+          ts: 1_777_100_000,
+          keeper: 'analyst',
+          tool: 'Execute',
+          input: { argv: ['git', 'status'], cwd: 'repos/masc' },
+          output: 'clean',
+          success: true,
+          duration_ms: 42,
+          // Recorded shape for Execute rows: the writer stores the cwd as
+          // target_path (masc#29013) — a directory, not a file.
+          action_radius: {
+            action_key: 'Execute',
+            target_kind: 'path',
+            target_path: 'repos/masc',
+            observed_paths: ['repos/masc'],
+            error: null,
+          },
+          route_evidence: {
+            descriptor_id: 'agent.execute',
+          },
+        },
+      ],
+    })
+
+    const { KeeperToolCallInspector } = await loadInspector(fetchKeeperToolCalls)
+    await act(async () => {
+      render(html`<${KeeperToolCallInspector} keeperName="analyst" />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    const rowToggle = container.querySelector('button[aria-expanded="false"]') as HTMLButtonElement | null
+    await act(async () => {
+      rowToggle?.click()
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    expect(container.querySelector('[data-testid="keeper-tool-code-link"]')).toBeNull()
   })
 
   it('does not render Code links for unsafe absolute recorded target paths', async () => {

--- a/dashboard/src/components/keeper-tool-call-inspector-render.test.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector-render.test.ts
@@ -84,7 +84,7 @@ describe('KeeperToolCallInspector render', () => {
     expect(outputCopy?.getAttribute('title')).toBe('도구 호출 출력 복사')
   })
 
-  it('links safe tool-call file inputs back to the Code IDE route', async () => {
+  it('links recorded path targets back to the Code IDE route, ignoring tool input', async () => {
     const fetchKeeperToolCalls = vi.fn().mockResolvedValue({
       keeper: 'analyst',
       count: 1,
@@ -95,10 +95,19 @@ describe('KeeperToolCallInspector render', () => {
           ts: 1_777_100_000,
           keeper: 'analyst',
           tool: 'keeper_fs_read',
-          input: { file_path: 'lib/runtime.ml', line: 12 },
+          // The input names a different file on purpose: route links must come
+          // from the recorded action_radius, never from re-parsing the input.
+          input: { file_path: 'lib/other.ml', line: 12 },
           output: 'file contents',
           success: true,
           duration_ms: 42,
+          action_radius: {
+            action_key: 'keeper_fs_read',
+            target_kind: 'path',
+            target_path: 'lib/runtime.ml',
+            observed_paths: ['lib/runtime.ml'],
+            error: null,
+          },
         },
       ],
     })
@@ -120,16 +129,16 @@ describe('KeeperToolCallInspector render', () => {
     const codeLink = container.querySelector('[data-testid="keeper-tool-code-link"]') as HTMLButtonElement | null
     expect(codeLink).not.toBeNull()
     expect(codeLink?.textContent).toBe('Code')
-    expect(codeLink?.getAttribute('title')).toBe('Code lib/runtime.ml:12')
+    expect(codeLink?.getAttribute('title')).toBe('Code lib/runtime.ml')
 
     await act(async () => {
       codeLink?.click()
       await Promise.resolve()
     })
-    expect(window.location.hash).toBe('#code?section=ide-shell&view=source&file=lib%2Fruntime.ml&line=12&surface=Tool&label=keeper_fs_read&source_id=tool%3Aanalyst%3A1777100000%3Akeeper_fs_read&keeper=analyst')
+    expect(window.location.hash).toBe('#code?section=ide-shell&view=source&file=lib%2Fruntime.ml&surface=Tool&label=keeper_fs_read&source_id=tool%3Aanalyst%3A1777100000%3Akeeper_fs_read&keeper=analyst')
   })
 
-  it('routes nested tool-call evidence to operational IDE surfaces', async () => {
+  it('routes recorded identity fields to operational IDE surfaces', async () => {
     const fetchKeeperToolCalls = vi.fn().mockResolvedValue({
       keeper: 'analyst',
       count: 1,
@@ -140,29 +149,20 @@ describe('KeeperToolCallInspector render', () => {
           ts: 1_777_100_000,
           keeper: 'analyst',
           tool: 'keeper_apply_patch',
-          input: {
-            context: {
-              goal_id: 'goal-runtime',
-              task_id: 'task-runtime',
-              board_post_id: 'post-1',
-              comment_id: 'comment-1',
-            },
-            failure_envelope: {
-              evidence_ref: {
-                file_path: 'lib/runtime.ml',
-                line_start: '8',
-                pr_number: 15125,
-                branch: 'fix/runtime',
-                log_id: 'turn-8',
-                session_id: 'sess-nested',
-                operation_id: 'op-nested',
-                worker_run_id: 'wr-nested',
-              },
-            },
-          },
+          input: { patch: '...' },
           output: 'patched',
           success: true,
           duration_ms: 42,
+          task_id: 'task-runtime',
+          goal_ids: ['goal-runtime'],
+          session_id: 'sess-nested',
+          action_radius: {
+            action_key: 'keeper_apply_patch',
+            target_kind: 'path',
+            target_path: 'lib/runtime.ml',
+            observed_paths: ['lib/runtime.ml'],
+            error: null,
+          },
         },
       ],
     })
@@ -186,11 +186,6 @@ describe('KeeperToolCallInspector render', () => {
       'Code',
       'Goal',
       'Task',
-      'Board',
-      'Comment',
-      'PR',
-      'Git',
-      'Log',
       'Telemetry',
       'Keeper',
     ])
@@ -199,13 +194,13 @@ describe('KeeperToolCallInspector render', () => {
       routeLinks.find(link => link.textContent?.trim() === 'Code')?.click()
       await Promise.resolve()
     })
-    expect(window.location.hash).toBe('#code?section=ide-shell&view=source&file=lib%2Fruntime.ml&line=8&surface=Tool&label=keeper_apply_patch&source_id=tool%3Aanalyst%3A1777100000%3Akeeper_apply_patch&keeper=analyst')
+    expect(window.location.hash).toBe('#code?section=ide-shell&view=source&file=lib%2Fruntime.ml&surface=Tool&label=keeper_apply_patch&source_id=tool%3Aanalyst%3A1777100000%3Akeeper_apply_patch&keeper=analyst')
 
     await act(async () => {
       routeLinks.find(link => link.textContent?.trim() === 'Telemetry')?.click()
       await Promise.resolve()
     })
-    expect(window.location.hash).toBe('#monitoring?section=fleet-health&view=event-log&session_id=sess-nested&operation_id=op-nested&worker_run_id=wr-nested&q=turn-8')
+    expect(window.location.hash).toBe('#monitoring?section=fleet-health&view=event-log&session_id=sess-nested')
   })
 
   it('renders an activity dossier for recent tool-call evidence', async () => {
@@ -233,15 +228,23 @@ describe('KeeperToolCallInspector render', () => {
           output: 'file contents',
           success: true,
           duration_ms: 42,
+          action_radius: {
+            action_key: 'keeper_fs_read',
+            target_kind: 'path',
+            target_path: 'lib/runtime.ml',
+            observed_paths: ['lib/runtime.ml'],
+            error: null,
+          },
         },
         {
           ts: 1_777_100_010,
           keeper: 'analyst',
           tool: 'Execute',
-          input: { cmd: 'false', context: { task_id: 'task-runtime' } },
+          input: { cmd: 'false' },
           output: 'exit 1',
           success: false,
           duration_ms: 2_600,
+          task_id: 'task-runtime',
           trace_id: 'trace-runtime',
           tool_use_id: '',
           turn: 9,
@@ -334,7 +337,7 @@ describe('KeeperToolCallInspector render', () => {
     expect(container.querySelector('[data-composition-node="wait_for_board"]')).not.toBeNull()
   })
 
-  it('does not render Code links for unsafe absolute tool-call file inputs', async () => {
+  it('does not render Code links for unsafe absolute recorded target paths', async () => {
     const fetchKeeperToolCalls = vi.fn().mockResolvedValue({
       keeper: 'analyst',
       count: 1,
@@ -349,6 +352,13 @@ describe('KeeperToolCallInspector render', () => {
           output: 'file contents',
           success: true,
           duration_ms: 42,
+          action_radius: {
+            action_key: 'keeper_fs_read',
+            target_kind: 'path',
+            target_path: '/tmp/runtime.ml',
+            observed_paths: ['/tmp/runtime.ml'],
+            error: null,
+          },
         },
       ],
     })
@@ -368,6 +378,156 @@ describe('KeeperToolCallInspector render', () => {
     await flushUi()
 
     expect(container.querySelector('[data-testid="keeper-tool-code-link"]')).toBeNull()
+  })
+
+  it('renders recorded execution evidence blocks in the expanded row', async () => {
+    const fetchKeeperToolCalls = vi.fn().mockResolvedValue({
+      keeper: 'analyst',
+      count: 1,
+      source: 'tool_call_io',
+      health: 'ok',
+      entries: [
+        {
+          ts: 1_777_100_000,
+          keeper: 'analyst',
+          tool: 'keeper_time_now',
+          input: {},
+          output: '{"now_iso":"2026-08-18T05:00:00Z"}',
+          success: true,
+          duration_ms: 1,
+          thinking_enabled: true,
+          prompt_fingerprint: '464ce7b3280c24fe1cbdcd990a70db87',
+          runtime_contract: {
+            agent_name: 'keeper-analyst-agent',
+            generation: 1,
+            sandbox_root: '/sandbox/analyst/',
+            allowed_paths: ['.masc/playground/analyst/'],
+            network_mode: 'inherit',
+            runtime_profile: 'ollama_cloud.example-model',
+            path_resolution: { read_implicit_cwd: false, read_explicit_cwd_supported: true },
+          },
+          action_radius: {
+            action_key: 'keeper_time_now',
+            target_kind: 'tool',
+            target_path: null,
+            observed_paths: [],
+            error: null,
+          },
+          route_evidence: {
+            descriptor_id: 'keeper.time.now',
+            capability_id: 'keeper_time_now',
+            executor: 'in_process',
+            backend: 'ocaml_runtime',
+            runtime_handler: 'tool_time_now',
+            readonly: true,
+            retryable: true,
+            receipt_labels: { keeper_tool_group: 'meta' },
+          },
+        },
+      ],
+    })
+
+    const { KeeperToolCallInspector } = await loadInspector(fetchKeeperToolCalls)
+    await act(async () => {
+      render(html`<${KeeperToolCallInspector} keeperName="analyst" />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    const rowToggle = container.querySelector('button[aria-expanded="false"]') as HTMLButtonElement | null
+    await act(async () => {
+      rowToggle?.click()
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    const evidence = container.querySelector('[data-testid="tool-call-evidence"]')
+    expect(evidence).not.toBeNull()
+    const text = evidence?.textContent ?? ''
+    expect(text).toContain('route evidence')
+    expect(text).toContain('keeper.time.now')
+    expect(text).toContain('in_process')
+    expect(text).toContain('ocaml_runtime')
+    expect(text).toContain('tool_time_now')
+    expect(text).toContain('keeper_tool_group=meta')
+    expect(text).toContain('runtime contract')
+    expect(text).toContain('/sandbox/analyst/')
+    expect(text).toContain('.masc/playground/analyst/')
+    expect(text).toContain('inherit')
+    expect(text).toContain('read_implicit_cwd=false read_explicit_cwd_supported=true')
+    expect(text).toContain('action radius')
+    expect(text).toContain('target kind')
+
+    expect(container.textContent).toContain('invocation:')
+    expect(container.textContent).toContain('thinking on')
+    expect(container.textContent).toContain('prompt 464ce7b3280c')
+  })
+
+  it('nests composition children under the composite parent row', async () => {
+    const fetchKeeperToolCalls = vi.fn().mockResolvedValue({
+      keeper: 'analyst',
+      count: 3,
+      source: 'tool_call_io',
+      health: 'ok',
+      entries: [
+        {
+          ts: 1_777_100_000,
+          keeper: 'analyst',
+          tool: 'keeper_time_now',
+          input: {},
+          output: 'now',
+          success: true,
+          duration_ms: 1,
+          composition_tool: 'keeper_compose_mission-snapshot',
+          composition_run_id: 'run-1',
+          composition_node_id: 'clock',
+          composition_execution: 'inline',
+          parent_tool_use_id: 'call_parent',
+          disposition: 'completed',
+        },
+        {
+          ts: 1_777_100_005,
+          keeper: 'analyst',
+          tool: 'masc_board_stats',
+          input: {},
+          output: 'stats',
+          success: true,
+          duration_ms: 2,
+          composition_tool: 'keeper_compose_mission-snapshot',
+          composition_run_id: 'run-1',
+          composition_node_id: 'board',
+          composition_execution: 'inline',
+          parent_tool_use_id: 'call_parent',
+          disposition: 'completed',
+        },
+        {
+          ts: 1_777_100_010,
+          keeper: 'analyst',
+          tool: 'keeper_compose_mission-snapshot',
+          input: {},
+          output: 'snapshot',
+          success: true,
+          duration_ms: 12,
+          tool_use_id: 'call_parent',
+        },
+      ],
+    })
+
+    const { KeeperToolCallInspector } = await loadInspector(fetchKeeperToolCalls)
+    await act(async () => {
+      render(html`<${KeeperToolCallInspector} keeperName="analyst" />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    const childGroup = container.querySelector('[data-composition-children="call_parent"]')
+    expect(childGroup).not.toBeNull()
+    expect(childGroup?.querySelector('[data-composition-node="clock"]')).not.toBeNull()
+    expect(childGroup?.querySelector('[data-composition-node="board"]')).not.toBeNull()
+    // The children render only inside the parent's group, not as top-level rows.
+    expect(container.querySelectorAll('[data-composition-node="clock"]')).toHaveLength(1)
+    const parentRow = childGroup?.parentElement
+    expect(parentRow?.textContent).toContain('keeper_compose_mission-snapshot')
   })
 
   it('surfaces coverage gap provenance when tool-call IO is stale', async () => {

--- a/dashboard/src/components/keeper-tool-call-inspector.test.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { blobMarkerOfOutput, deriveKeeperToolCallDossier, formatInput } from './keeper-tool-call-inspector'
+import {
+  blobMarkerOfOutput,
+  deriveKeeperToolCallDossier,
+  formatInput,
+  groupToolCallTree,
+} from './keeper-tool-call-inspector'
 import type { ToolCallEntry } from '../api/dashboard'
 
 function toolCall(overrides: Partial<ToolCallEntry> = {}): ToolCallEntry {
@@ -86,6 +91,77 @@ describe('blobMarkerOfOutput', () => {
   it('returns null for inline string outputs', () => {
     expect(blobMarkerOfOutput('{"ok":true}')).toBeNull()
     expect(blobMarkerOfOutput('')).toBeNull()
+  })
+})
+
+describe('groupToolCallTree', () => {
+  const compositionChild = (overrides: Partial<ToolCallEntry> = {}): ToolCallEntry =>
+    toolCall({
+      composition_tool: 'keeper_compose_mission-snapshot',
+      composition_run_id: 'run-1',
+      composition_execution: 'inline',
+      parent_tool_use_id: 'call_parent',
+      ...overrides,
+    })
+
+  it('nests composition children under their composite parent', () => {
+    const parent = toolCall({
+      ts: 100,
+      tool: 'keeper_compose_mission-snapshot',
+      tool_use_id: 'call_parent',
+    })
+    const childBoard = compositionChild({ ts: 95, tool: 'masc_board_stats', composition_node_id: 'board' })
+    const childClock = compositionChild({ ts: 90, tool: 'keeper_time_now', composition_node_id: 'clock' })
+
+    // Newest-first display order, as the inspector passes it.
+    const nodes = groupToolCallTree([parent, childBoard, childClock])
+
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0]?.entry).toBe(parent)
+    expect(nodes[0]?.children).toEqual([childBoard, childClock])
+  })
+
+  it('keeps children top-level when the parent row is outside the window', () => {
+    const childBoard = compositionChild({ ts: 95, tool: 'masc_board_stats', composition_node_id: 'board' })
+    const childClock = compositionChild({ ts: 90, tool: 'keeper_time_now', composition_node_id: 'clock' })
+
+    const nodes = groupToolCallTree([childBoard, childClock])
+
+    expect(nodes.map(node => node.entry)).toEqual([childBoard, childClock])
+    expect(nodes.every(node => node.children.length === 0)).toBe(true)
+  })
+
+  it('attaches a run to the nearest parent at or after its newest child when provider ids repeat', () => {
+    const lateParent = toolCall({ ts: 200, tool: 'keeper_compose_mission-snapshot', tool_use_id: 'call_dup' })
+    const nearParent = toolCall({ ts: 100, tool: 'keeper_compose_mission-snapshot', tool_use_id: 'call_dup' })
+    const staleParent = toolCall({ ts: 50, tool: 'keeper_compose_mission-snapshot', tool_use_id: 'call_dup' })
+    const child = compositionChild({ ts: 90, tool: 'keeper_time_now', composition_node_id: 'clock', parent_tool_use_id: 'call_dup' })
+
+    const nodes = groupToolCallTree([lateParent, nearParent, child, staleParent])
+
+    expect(nodes.find(node => node.entry === nearParent)?.children).toEqual([child])
+    expect(nodes.find(node => node.entry === lateParent)?.children).toEqual([])
+    expect(nodes.find(node => node.entry === staleParent)?.children).toEqual([])
+  })
+
+  it('never joins on blank provider ids', () => {
+    const parent = toolCall({ ts: 100, tool: 'keeper_compose_mission-snapshot', tool_use_id: '' })
+    const child = compositionChild({ ts: 90, tool: 'keeper_time_now', parent_tool_use_id: '' })
+
+    const nodes = groupToolCallTree([parent, child])
+
+    expect(nodes.map(node => node.entry)).toEqual([parent, child])
+    expect(nodes.every(node => node.children.length === 0)).toBe(true)
+  })
+
+  it('keeps plain rows as leaf nodes in display order', () => {
+    const first = toolCall({ ts: 3, tool: 'Execute' })
+    const second = toolCall({ ts: 2, tool: 'keeper_context_status' })
+
+    const nodes = groupToolCallTree([first, second])
+
+    expect(nodes.map(node => node.entry)).toEqual([first, second])
+    expect(nodes.map(node => node.children)).toEqual([[], []])
   })
 })
 

--- a/dashboard/src/components/keeper-tool-call-inspector.test.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.test.ts
@@ -144,6 +144,66 @@ describe('groupToolCallTree', () => {
     expect(nodes.find(node => node.entry === staleParent)?.children).toEqual([])
   })
 
+  it('attaches an async run to the parent recorded at dispatch, before its children', () => {
+    // Recorded async shape (.masc/tool_calls 2026-08-18): the composite
+    // parent row is written at dispatch, so its ts precedes every child ts.
+    const parent = toolCall({
+      ts: 1_787_025_233.044336,
+      tool: 'keeper_compose_mission-snapshot',
+      tool_use_id: 'call_async',
+    })
+    const childClock = compositionChild({
+      ts: 1_787_025_233.045521,
+      tool: 'keeper_time_now',
+      composition_node_id: 'clock',
+      composition_execution: 'async',
+      parent_tool_use_id: 'call_async',
+    })
+    const childBoard = compositionChild({
+      ts: 1_787_025_233.045685,
+      tool: 'masc_board_stats',
+      composition_node_id: 'board',
+      composition_execution: 'async',
+      parent_tool_use_id: 'call_async',
+    })
+
+    const nodes = groupToolCallTree([childBoard, childClock, parent])
+
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0]?.entry).toBe(parent)
+    expect(nodes[0]?.children).toEqual([childBoard, childClock])
+  })
+
+  it('attaches an async run to its dispatch parent, not a later reuse of the provider id', () => {
+    const dispatchParent = toolCall({ ts: 80, tool: 'keeper_compose_mission-snapshot', tool_use_id: 'call_dup' })
+    const laterReuse = toolCall({ ts: 200, tool: 'keeper_compose_mission-snapshot', tool_use_id: 'call_dup' })
+    const child = compositionChild({
+      ts: 90,
+      tool: 'keeper_time_now',
+      composition_node_id: 'clock',
+      composition_execution: 'async',
+      parent_tool_use_id: 'call_dup',
+    })
+
+    const nodes = groupToolCallTree([laterReuse, child, dispatchParent])
+
+    expect(nodes.find(node => node.entry === dispatchParent)?.children).toEqual([child])
+    expect(nodes.find(node => node.entry === laterReuse)?.children).toEqual([])
+  })
+
+  it('leaves a run unattributed when every candidate sits strictly inside the child ts window', () => {
+    // Neither recorded shape: the candidate is after the oldest child and
+    // before the newest child, so attaching would be a guess.
+    const interiorCandidate = toolCall({ ts: 95, tool: 'keeper_compose_mission-snapshot', tool_use_id: 'call_mid' })
+    const childEarly = compositionChild({ ts: 90, tool: 'keeper_time_now', composition_node_id: 'clock', parent_tool_use_id: 'call_mid' })
+    const childLate = compositionChild({ ts: 100, tool: 'masc_board_stats', composition_node_id: 'board', parent_tool_use_id: 'call_mid' })
+
+    const nodes = groupToolCallTree([childLate, interiorCandidate, childEarly])
+
+    expect(nodes.map(node => node.entry)).toEqual([childLate, interiorCandidate, childEarly])
+    expect(nodes.every(node => node.children.length === 0)).toBe(true)
+  })
+
   it('never joins on blank provider ids', () => {
     const parent = toolCall({ ts: 100, tool: 'keeper_compose_mission-snapshot', tool_use_id: '' })
     const child = compositionChild({ ts: 90, tool: 'keeper_time_now', parent_tool_use_id: '' })

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -10,7 +10,6 @@ import { lastEvent } from '../sse'
 import { formatTimeHms } from '../lib/format-time'
 import { formatMsCompact } from '../lib/format-number'
 import { LoadingState } from './common/feedback-state'
-import { asRecord, mergeRouteRecord, hasRouteContext, type MutableRouteContext } from './common/normalize'
 import { SectionCap } from './common/section-cap'
 import { toolCategory, durationColor, prettyJson } from './tool-call-shared'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
@@ -73,51 +72,116 @@ function tryPrettyJson(s: string): string | null {
   return prettyJson(s)
 }
 
-function parseInputRecord(input: string): Record<string, unknown> | null {
-  try {
-    return asRecord(JSON.parse(input))
-  } catch {
-    return null
-  }
-}
-
-function mergeToolInputContext(
-  context: MutableRouteContext,
-  input: unknown,
-  depth = 0,
-): void {
-  if (depth > 4) return
-  if (typeof input === 'string') {
-    mergeToolInputContext(context, parseInputRecord(input), depth + 1)
-    return
-  }
-  const record = asRecord(input)
-  if (!record) return
-  const failureEnvelope = asRecord(record.failure_envelope)
-  mergeRouteRecord(context, asRecord(record.context))
-  mergeRouteRecord(context, asRecord(record.evidence_ref))
-  mergeRouteRecord(context, asRecord(failureEnvelope?.evidence_ref))
-  mergeRouteRecord(context, asRecord(record.tool_args))
-  mergeToolInputContext(context, record.input, depth + 1)
-  mergeRouteRecord(context, record, true)
-}
-
+// Route links derive from the recorded row (action_radius target plus the
+// identity fields the writer persisted), never from re-parsing the tool
+// input: the log is the authority for what the call actually touched.
 function toolCallRouteLinks(entry: ToolCallEntry): ReadonlyArray<IdeContextRouteLink> {
-  const context: MutableRouteContext = {}
-  mergeToolInputContext(context, entry.input)
-  if (!hasRouteContext(context)) return []
+  const radius = entry.action_radius
+  const filePath = radius?.target_kind === 'path'
+    ? radius.target_path ?? radius.observed_paths?.[0]
+    : undefined
+  const goalId = entry.goal_ids?.[0]
+  const taskId = entry.task_id
+  const sessionId = entry.session_id
+  if (filePath === undefined && goalId === undefined && taskId === undefined && sessionId === undefined) {
+    return []
+  }
   const links = routeLinksForContext({
-    ...context,
+    filePath,
+    goalId,
+    taskId,
+    sessionId,
     surface: 'Tool',
     label: entry.tool,
     sourceId: `tool:${entry.keeper}:${entry.ts}:${entry.tool}`,
     keeperId: entry.keeper,
-    telemetry: context.logId !== undefined
-      || context.sessionId !== undefined
-      || context.operationId !== undefined
-      || context.workerRunId !== undefined,
+    telemetry: sessionId !== undefined,
   })
   return links.some(link => link.label !== 'Keeper') ? links : []
+}
+
+// ── Composition tree grouping ───────────────────────────
+
+export type ToolCallTreeNode = {
+  entry: ToolCallEntry
+  children: ToolCallEntry[]
+}
+
+// Nest composition children (rows carrying a composition_run_id) under the
+// composite parent row they were dispatched from. The join is typed-field
+// equality on recorded identity: parent.tool === child.composition_tool and
+// parent.tool_use_id === child.parent_tool_use_id, both non-blank (provider
+// ids may be blank or repeated). When several parent rows share that key,
+// each run attaches to the candidate nearest at-or-after its newest child —
+// the parent row is written when the composite completes. Children whose
+// parent row is outside the given list stay top-level, so a filtered window
+// never hides recorded calls.
+export function groupToolCallTree(entries: readonly ToolCallEntry[]): ToolCallTreeNode[] {
+  const parentKey = (tool: string, toolUseId: string): string => `${tool}\u0000${toolUseId}`
+  const parentsByKey = new Map<string, ToolCallEntry[]>()
+  for (const entry of entries) {
+    if (entry.composition_run_id !== undefined) continue
+    if (entry.tool_use_id === undefined || entry.tool_use_id === '') continue
+    const key = parentKey(entry.tool, entry.tool_use_id)
+    const bucket = parentsByKey.get(key)
+    if (bucket === undefined) {
+      parentsByKey.set(key, [entry])
+    } else {
+      bucket.push(entry)
+    }
+  }
+
+  type RunGroup = { key: string; children: ToolCallEntry[]; newestChildTs: number }
+  const groupsByRun = new Map<string, RunGroup>()
+  for (const entry of entries) {
+    if (entry.composition_run_id === undefined) continue
+    if (entry.composition_tool === undefined) continue
+    if (entry.parent_tool_use_id === undefined || entry.parent_tool_use_id === '') continue
+    const key = parentKey(entry.composition_tool, entry.parent_tool_use_id)
+    const group = groupsByRun.get(entry.composition_run_id)
+    if (group === undefined) {
+      groupsByRun.set(entry.composition_run_id, {
+        key,
+        children: [entry],
+        newestChildTs: entry.ts,
+      })
+    } else {
+      group.children.push(entry)
+      group.newestChildTs = Math.max(group.newestChildTs, entry.ts)
+    }
+  }
+
+  const childrenByParent = new Map<ToolCallEntry, ToolCallEntry[]>()
+  const nestedChildren = new Set<ToolCallEntry>()
+  for (const group of groupsByRun.values()) {
+    const candidates = parentsByKey.get(group.key)
+    if (candidates === undefined) continue
+    let parent: ToolCallEntry | null = null
+    for (const candidate of candidates) {
+      if (candidate.ts < group.newestChildTs) continue
+      if (parent === null || candidate.ts < parent.ts) parent = candidate
+    }
+    if (parent === null) {
+      for (const candidate of candidates) {
+        if (parent === null || candidate.ts > parent.ts) parent = candidate
+      }
+    }
+    if (parent === null) continue
+    const existing = childrenByParent.get(parent)
+    if (existing === undefined) {
+      childrenByParent.set(parent, [...group.children])
+    } else {
+      existing.push(...group.children)
+    }
+    for (const child of group.children) nestedChildren.add(child)
+  }
+
+  const nodes: ToolCallTreeNode[] = []
+  for (const entry of entries) {
+    if (nestedChildren.has(entry)) continue
+    nodes.push({ entry, children: childrenByParent.get(entry) ?? [] })
+  }
+  return nodes
 }
 
 type ToolCallDossierCard = {
@@ -500,6 +564,108 @@ function ToolCallOutputBlock({ entry }: { entry: ToolCallEntry }) {
   `
 }
 
+// ── Recorded execution evidence (route / contract / radius) ──
+
+type EvidencePair = readonly [string, string | undefined]
+
+function EvidenceBlock({ title, pairs }: { title: string; pairs: ReadonlyArray<EvidencePair> }) {
+  const rows = pairs.filter((pair): pair is readonly [string, string] => pair[1] !== undefined)
+  if (rows.length === 0) return null
+  return html`
+    <details class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2.5 py-1.5">
+      <summary class="cursor-pointer text-3xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">${title}</summary>
+      <div class="mt-1 space-y-0.5">
+        ${rows.map(([label, value]) => html`
+          <div key=${label} class="flex gap-2 text-3xs">
+            <span class="w-28 flex-shrink-0 text-[var(--color-fg-muted)]">${label}</span>
+            <span class="min-w-0 break-all font-mono text-[var(--color-fg-secondary)]">${value}</span>
+          </div>
+        `)}
+      </div>
+    </details>
+  `
+}
+
+function formatFlag(value: boolean | undefined): string | undefined {
+  if (value === undefined) return undefined
+  return value ? 'true' : 'false'
+}
+
+function joinedOrAbsent(values: readonly string[] | undefined): string | undefined {
+  return values !== undefined && values.length > 0 ? values.join(' · ') : undefined
+}
+
+function ToolCallEvidenceSection({ entry }: { entry: ToolCallEntry }) {
+  const route = entry.route_evidence
+  const contract = entry.runtime_contract
+  const radius = entry.action_radius
+  if (route === undefined && contract === undefined && radius === undefined) return null
+  const receiptEntries = route?.receipt_labels !== undefined ? Object.entries(route.receipt_labels) : []
+  const receiptLabels = receiptEntries.length > 0
+    ? receiptEntries.map(([key, value]) => `${key}=${value}`).join(' ')
+    : undefined
+  const pathResolution = contract?.path_resolution
+  const pathResolutionFlags = pathResolution === undefined
+    ? undefined
+    : [
+        pathResolution.read_implicit_cwd !== undefined
+          ? `read_implicit_cwd=${pathResolution.read_implicit_cwd}`
+          : null,
+        pathResolution.read_explicit_cwd_supported !== undefined
+          ? `read_explicit_cwd_supported=${pathResolution.read_explicit_cwd_supported}`
+          : null,
+      ].filter((part): part is string => part !== null).join(' ') || undefined
+  return html`
+    <div class="space-y-1 v2-monitoring-panel" data-testid="tool-call-evidence">
+      <${EvidenceBlock}
+        title="route evidence"
+        pairs=${[
+          ['descriptor', route?.descriptor_id],
+          ['capability', route?.capability_id],
+          ['executor', route?.executor],
+          ['backend', route?.backend],
+          ['runtime handler', route?.runtime_handler],
+          ['readonly', formatFlag(route?.readonly)],
+          ['retryable', formatFlag(route?.retryable)],
+          ['receipt labels', receiptLabels],
+        ]}
+      />
+      <${EvidenceBlock}
+        title="runtime contract"
+        pairs=${[
+          ['agent', contract?.agent_name],
+          ['generation', contract?.generation !== undefined ? String(contract.generation) : undefined],
+          ['sandbox root', contract?.sandbox_root],
+          ['allowed paths', joinedOrAbsent(contract?.allowed_paths)],
+          ['network mode', contract?.network_mode],
+          ['runtime profile', contract?.runtime_profile],
+          ['path resolution', pathResolutionFlags],
+        ]}
+      />
+      <${EvidenceBlock}
+        title="action radius"
+        pairs=${[
+          ['action key', radius?.action_key],
+          ['target kind', radius?.target_kind],
+          ['target path', radius?.target_path],
+          ['observed paths', joinedOrAbsent(radius?.observed_paths)],
+          ['error', radius?.error],
+        ]}
+      />
+    </div>
+  `
+}
+
+function invocationLabel(entry: ToolCallEntry): string | null {
+  const parts = [
+    entry.thinking_enabled !== undefined ? `thinking ${entry.thinking_enabled ? 'on' : 'off'}` : null,
+    entry.thinking_budget !== undefined ? `budget ${entry.thinking_budget}` : null,
+    entry.tool_choice !== undefined ? `tool_choice ${entry.tool_choice}` : null,
+    entry.prompt_fingerprint !== undefined ? `prompt ${entry.prompt_fingerprint.slice(0, 12)}` : null,
+  ].filter((part): part is string => part !== null)
+  return parts.length > 0 ? parts.join(' · ') : null
+}
+
 function ToolCallRow({ entry }: { entry: ToolCallEntry }) {
   const expanded = useSignal(false)
   const cat = toolCategory(entry.tool)
@@ -552,6 +718,11 @@ function ToolCallRow({ entry }: { entry: ToolCallEntry }) {
           ${entry.model ? html`
             <div class="text-3xs text-[var(--color-fg-muted)]">model: <span class="text-[var(--color-fg-secondary)] font-mono">${entry.model}</span></div>
           ` : null}
+          ${invocationLabel(entry) !== null ? html`
+            <div class="text-3xs text-[var(--color-fg-muted)]">
+              invocation: <span class="text-[var(--color-fg-secondary)] font-mono" title=${entry.prompt_fingerprint}>${invocationLabel(entry)}</span>
+            </div>
+          ` : null}
           <div class="text-3xs text-[var(--color-fg-muted)]">
             occurrence: <span class="text-[var(--color-fg-secondary)] font-mono">${entryScopeLabel(entry)}</span>
           </div>
@@ -577,6 +748,7 @@ function ToolCallRow({ entry }: { entry: ToolCallEntry }) {
               </div>
             </div>
           ` : null}
+          <${ToolCallEvidenceSection} entry=${entry} />
           <${CopyableToolCallBlock}
             title="입력"
             value=${formattedInput}
@@ -742,7 +914,21 @@ export function KeeperToolCallInspector({ keeperName }: { keeperName: string }) 
           <span class="w-5 text-center">OK</span>
           <span class="w-4"></span>
         </div>
-        ${sorted.map((entry: ToolCallEntry) => html`<${ToolCallRow} key=${`${entry.ts}-${entry.keeper}-${entry.tool}`} entry=${entry} />`)}
+        ${groupToolCallTree(sorted).map((node: ToolCallTreeNode) => html`
+          <div key=${`${node.entry.ts}-${node.entry.keeper}-${node.entry.tool}`}>
+            <${ToolCallRow} entry=${node.entry} />
+            ${node.children.length > 0 ? html`
+              <div
+                class="ml-4 border-l border-[var(--color-accent-border)] v2-monitoring-panel"
+                data-composition-children=${node.entry.tool_use_id}
+              >
+                ${node.children.map((child: ToolCallEntry) => html`
+                  <${ToolCallRow} key=${`${child.ts}-${child.keeper}-${child.tool}-${child.composition_node_id ?? ''}`} entry=${child} />
+                `)}
+              </div>
+            ` : null}
+          </div>
+        `)}
       </div>
     </div>
   `

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -73,11 +73,27 @@ function tryPrettyJson(s: string): string | null {
 }
 
 // Route links derive from the recorded row (action_radius target plus the
-// identity fields the writer persisted), never from re-parsing the tool
-// input: the log is the authority for what the call actually touched.
+// identity fields the writer persisted) instead of re-deriving them from the
+// tool input here: the server parses the redacted input once at record time
+// (keeper_runtime_contract.action_radius_json), so every consumer reads the
+// same recorded value.
+//
+// Execute rows record their cwd as target_path with target_kind "path"
+// (masc#29013) — a directory, not a file — so they are held back from Code
+// link promotion by exact identity (recorded descriptor id, with the tool
+// name covering rows that carry no route_evidence) until the writer records
+// a typed file/cwd distinction.
+const EXECUTE_DESCRIPTOR_ID = 'agent.execute'
+const EXECUTE_TOOL_NAME = 'Execute'
+
+function recordsCwdAsTarget(entry: ToolCallEntry): boolean {
+  return entry.route_evidence?.descriptor_id === EXECUTE_DESCRIPTOR_ID
+    || entry.tool === EXECUTE_TOOL_NAME
+}
+
 function toolCallRouteLinks(entry: ToolCallEntry): ReadonlyArray<IdeContextRouteLink> {
   const radius = entry.action_radius
-  const filePath = radius?.target_kind === 'path'
+  const filePath = radius?.target_kind === 'path' && !recordsCwdAsTarget(entry)
     ? radius.target_path ?? radius.observed_paths?.[0]
     : undefined
   const goalId = entry.goal_ids?.[0]
@@ -111,11 +127,20 @@ export type ToolCallTreeNode = {
 // composite parent row they were dispatched from. The join is typed-field
 // equality on recorded identity: parent.tool === child.composition_tool and
 // parent.tool_use_id === child.parent_tool_use_id, both non-blank (provider
-// ids may be blank or repeated). When several parent rows share that key,
-// each run attaches to the candidate nearest at-or-after its newest child —
-// the parent row is written when the composite completes. Children whose
-// parent row is outside the given list stay top-level, so a filtered window
-// never hides recorded calls.
+// ids may be blank or repeated).
+//
+// Recorded write order differs by execution mode: inline composites write
+// the parent row after the children complete (parent ts >= every child ts),
+// async composites write it at dispatch (parent ts < every child ts) — both
+// observed in .masc/tool_calls 2026-08-18. When several parent rows share
+// the join key, the recorded composition_execution of the children picks the
+// shape to try first: an all-async run attaches to the candidate nearest
+// at-or-before its oldest child, any other run to the candidate nearest
+// at-or-after its newest child, with the other shape as fallback. A
+// candidate set strictly inside the child ts window matches neither
+// recorded shape and is left unattributed rather than guessed. Children
+// whose parent row is outside the given list stay top-level, so a filtered
+// window never hides recorded calls.
 export function groupToolCallTree(entries: readonly ToolCallEntry[]): ToolCallTreeNode[] {
   const parentKey = (tool: string, toolUseId: string): string => `${tool}\u0000${toolUseId}`
   const parentsByKey = new Map<string, ToolCallEntry[]>()
@@ -131,7 +156,12 @@ export function groupToolCallTree(entries: readonly ToolCallEntry[]): ToolCallTr
     }
   }
 
-  type RunGroup = { key: string; children: ToolCallEntry[]; newestChildTs: number }
+  type RunGroup = {
+    key: string
+    children: ToolCallEntry[]
+    newestChildTs: number
+    oldestChildTs: number
+  }
   const groupsByRun = new Map<string, RunGroup>()
   for (const entry of entries) {
     if (entry.composition_run_id === undefined) continue
@@ -144,10 +174,12 @@ export function groupToolCallTree(entries: readonly ToolCallEntry[]): ToolCallTr
         key,
         children: [entry],
         newestChildTs: entry.ts,
+        oldestChildTs: entry.ts,
       })
     } else {
       group.children.push(entry)
       group.newestChildTs = Math.max(group.newestChildTs, entry.ts)
+      group.oldestChildTs = Math.min(group.oldestChildTs, entry.ts)
     }
   }
 
@@ -156,16 +188,28 @@ export function groupToolCallTree(entries: readonly ToolCallEntry[]): ToolCallTr
   for (const group of groupsByRun.values()) {
     const candidates = parentsByKey.get(group.key)
     if (candidates === undefined) continue
-    let parent: ToolCallEntry | null = null
-    for (const candidate of candidates) {
-      if (candidate.ts < group.newestChildTs) continue
-      if (parent === null || candidate.ts < parent.ts) parent = candidate
-    }
-    if (parent === null) {
+    // Inline shape: parent written after the children completed.
+    const completionParent = (): ToolCallEntry | null => {
+      let found: ToolCallEntry | null = null
       for (const candidate of candidates) {
-        if (parent === null || candidate.ts > parent.ts) parent = candidate
+        if (candidate.ts < group.newestChildTs) continue
+        if (found === null || candidate.ts < found.ts) found = candidate
       }
+      return found
     }
+    // Async shape: parent written at dispatch, before every child.
+    const dispatchParent = (): ToolCallEntry | null => {
+      let found: ToolCallEntry | null = null
+      for (const candidate of candidates) {
+        if (candidate.ts > group.oldestChildTs) continue
+        if (found === null || candidate.ts > found.ts) found = candidate
+      }
+      return found
+    }
+    const allAsync = group.children.every(child => child.composition_execution === 'async')
+    const parent = allAsync
+      ? dispatchParent() ?? completionParent()
+      : completionParent() ?? dispatchParent()
     if (parent === null) continue
     const existing = childrenByParent.get(parent)
     if (existing === undefined) {
@@ -627,6 +671,7 @@ function ToolCallEvidenceSection({ entry }: { entry: ToolCallEntry }) {
           ['runtime handler', route?.runtime_handler],
           ['readonly', formatFlag(route?.readonly)],
           ['retryable', formatFlag(route?.retryable)],
+          ['status', route?.status],
           ['receipt labels', receiptLabels],
         ]}
       />


### PR DESCRIPTION
## 목표

서버는 tool-call 행을 필드 스트립 없이 그대로 내려주는데(`lib/server/server_dashboard_http_keeper_api.ml`은 행 필터만 수행), 클라이언트 `decodeToolCallEntry`가 기록된 실행 증거를 대량 폐기하고 있었어요. 이 PR은 폐기되던 필드를 typed로 복원하고, 인스펙터가 그 증거를 실제로 보여주게 합니다. OCaml 서버 코드는 변경하지 않았습니다 (순수 클라이언트 복원).

## 변경 파일

- `dashboard/src/api/dashboard-keeper-tool-calls.ts` — 타입 4종 추가 + 디코더 복원 (+ route_evidence.status 투영)
- `dashboard/src/api/dashboard.ts` — 새 타입 re-export
- `dashboard/src/components/keeper-tool-call-inspector.ts` — 증거 섹션, route link 교체, 합성 트리
- `dashboard/src/api/dashboard.test.ts` — 디코더 테스트 (실물 행 익명화 fixture, status 양쪽 wire 모양)
- `dashboard/src/components/keeper-tool-call-inspector.test.ts` — `groupToolCallTree` 테스트 8건 (inline/async/id 재사용/미귀속)
- `dashboard/src/components/keeper-tool-call-inspector-render.test.ts` — route link 테스트 재작성 + 렌더 테스트 추가 (증거 블록, 트리, Execute 제외)

## 복원한 필드 (wire 계약은 `~/.masc/tool_calls/2026-08/18.jsonl` 실물 행 + `lib/keeper_tool_call_log.ml` writer로 확정)

- `runtime_contract`: `agent_name`, `generation`, `sandbox_root`, `allowed_paths`, `path_resolution`(불리언 2종 + 안내문 4종), `network_mode`, `runtime_profile`
- `action_radius`: `action_key`, `target_kind`, `target_path`, `observed_paths`, `error`
- `route_evidence`: `descriptor_id`, `capability_id`, `executor`, `backend`, `runtime_handler`, `readonly`, `retryable`, `receipt_labels`, `status`(문자열/`{kind,code}` 양쪽 wire 모양을 문자열로 투영)
- top-level: `thinking_enabled`, `thinking_budget`, `tool_choice`, `prompt_fingerprint`

top-level에 이미 있는 중복 정체성 필드(`keeper_name`, `trace_id`, `session_id`, `task_id` 등)는 중첩 객체에서 다시 디코드하지 않았어요. wire의 명시적 `null`(예: `action_radius.target_path`)은 absent로 디코드됩니다.

## 렌더 변경 (구조 설명 — 스크린샷 대체)

1. **실행 증거 섹션**: 확장 행에 `data-testid="tool-call-evidence"` 블록. `<details>` 접이식 3개 — route evidence(디스크립터/실행자/backend/readonly/retryable/status/receipt labels), runtime contract(sandbox root/허용 경로/네트워크/프로파일/path resolution 불리언), action radius(대상 종류/경로/관측 경로/에러). 값이 없는 행은 렌더하지 않아요.
2. **invocation 라인**: `model:` 라인 아래에 `thinking on/off · budget · tool_choice · prompt <fp 앞 12자>`.
3. **route link 교체**: `toolCallRouteLinks`가 input 재파싱(`mergeToolInputContext`/`parseInputRecord` — 삭제) 대신 기록된 `action_radius` 대상 경로 + 저장된 정체성 필드(`task_id`/`goal_ids`/`session_id`)로 IDE 링크를 만들어요. 서버가 기록 시점에 한 번 유도한 값을 모든 소비자가 같이 읽는 구조입니다. input 안에서만 유도되던 Board/Comment/PR/Git/Log 링크는 tool-call 행에서 더 이상 생성되지 않고(기록되지 않은 정보였음), Code 링크의 줄 번호도 기록에 없으므로 빠져요.
   - **Execute 제외 (리뷰 F1)**: Execute 행은 writer가 cwd(디렉터리)를 `target_path`로 기록하므로(#29013), descriptor `agent.execute`/tool `Execute` 정확 일치로 Code 링크 승격을 보류했어요. writer가 file/cwd typed 구분을 기록하면 이 예외는 제거 대상입니다.
4. **합성 트리**: `composition_run_id`가 같은 자식 행들이 composite 부모 행 아래 들여쓰기 컨테이너(`data-composition-children`)로 중첩. join은 typed 필드 등식(`parent.tool_use_id == child.parent_tool_use_id` && `parent.tool == child.composition_tool`, blank 제외). 기록 순서는 실행 모드마다 달라서(inline은 부모가 자식 완료 후, async는 dispatch 시점 — 둘 다 실물 확인) 자식들의 `composition_execution` 기록값으로 우선 모양을 고르고, 후보가 자식 ts 창 내부에만 있으면 추측하지 않고 미귀속으로 둡니다. 부모가 창 밖이면 자식은 기존처럼 top-level에 남아요 (행 소실 없음).

## 리뷰 대응 (적대적 리뷰 F1-F4, 커밋 44d06ef85f)

- **F1**: Execute cwd→Code 링크 회귀 — 위 3항 제외 조치 + 근본 수정(writer typed target 구분)은 #29013으로 기록.
- **F2**: async 부모 선기록 실물 반영 — 주석/join 정리 + async 모양·id 재사용·창 내부 미귀속 테스트 3건 추가.
- **F3**: "executor 관측" 서사 정정(기록 시점 input 파싱의 서버측 SSOT화) + writer가 만들 수 없던 fixture 교체.
- **F4**: route_evidence 존재 조건 주석 정정 + `status` 디코드/표시 추가.

## 검증

- `npx vitest run --no-file-parallelism --maxWorkers=1 src/api/dashboard.test.ts src/components/keeper-tool-call-inspector.test.ts src/components/keeper-tool-call-inspector-render.test.ts` → 3 files, **180 passed** (전체 스위트는 부하 시 무작위 실패 실측이 있어 지정 실행만 했어요)
- `npx tsc --noEmit` exit 0
- `npx eslint` — 새 오류 0건 (main에 이미 있던 `no-nested-ternary` 3건만 그대로)
- OCaml 서버 코드 미변경 (`lib/` diff 없음)

## 미검증 항목

- 브라우저 실측(라이브 keeper 데이터로 증거 블록/트리 시각 확인)은 후속으로 남겨요.
- 합성 부모 귀속 규칙은 실물 관측 2모양(inline 후기록/async 선기록) 기반 단위 테스트로 검증했고, 한 run에 inline·async 노드가 혼재하는 케이스는 실물 표본이 없어 inline 규칙 우선으로 처리돼요.
- Execute 외에 cwd를 `target_path`로 기록하는 도구가 더 있는지는 전수 확인하지 않았어요 (#29013에서 writer 쪽을 고치면 일괄 해소).

🤖 Generated with [Claude Code](https://claude.com/claude-code)