### PR TITLE
feat(log): expose the ring's live-window bounds on the logs response

### DIFF
--- a/lib/masc_log/log.ml
+++ b/lib/masc_log/log.ml
@@ -221,6 +221,16 @@ module Ring = struct
     category : category option;
   }
 
+  (** Live-window bounds of the ring: sequences in
+      [[start_seq, total)] are answerable; anything below [start_seq]
+      has been evicted ([dropped_before]) and lives only in the daily
+      JSONL sink. *)
+  type bounds = {
+    start_seq : int;
+    total : int;
+    dropped_before : bool;
+  }
+
   (* Dashboard operators commonly inspect tool-call history over hours, not
      minutes.  5k entries was too small for high-volume keeper/MCP traffic and
      made recent MCP calls appear to disappear despite JSONL persistence. *)
@@ -763,6 +773,19 @@ module Ring = struct
               | Some turn_id -> `Int turn_id
               | None -> `Null) );
           ]
+
+  (* The live ring can only answer for the last [capacity] sequences.
+     A query that returns nothing (or thin results) is ambiguous
+     without these bounds: "it never happened" and "it happened before
+     the window" look identical (2026-08-17 source audit,
+     feature-matrix Log row). The bounds ride on every logs query
+     response so the operator sees the cut, not silence. *)
+  let bounds () =
+    let t = Atomic.get total in
+    { start_seq = max 0 (t - capacity)
+    ; total = t
+    ; dropped_before = t > capacity
+    }
 
   let summary_json () =
     let total_entries = Atomic.get total in

--- a/lib/masc_log/log.mli
+++ b/lib/masc_log/log.mli
@@ -134,6 +134,20 @@ module Ring : sig
   val capacity : int
   (** Maximum number of entries retained in the in-memory dashboard ring. *)
 
+  type bounds = {
+    start_seq : int;
+    total : int;
+    dropped_before : bool;
+  }
+  (** Live-window bounds: sequences in [[start_seq, total)] are
+      answerable from the ring; anything below [start_seq] has been
+      evicted ([dropped_before]) and lives only in the daily JSONL
+      sink. Rides on the dashboard logs response so "no results"
+      cannot be mistaken for "it never happened" when the cause
+      merely predates the window. *)
+
+  val bounds : unit -> bounds
+
   val source_of_string : string -> source
   (** Inverse of {!source_to_string}.  Raises {!Entry_decode_error} on
       unknown labels. *)

--- a/lib/server/server_dashboard_logs_json.ml
+++ b/lib/server/server_dashboard_logs_json.ml
@@ -28,6 +28,7 @@ let build
       ~before_seq
       ~category_filter
       ~exclude_category
+      ~(ring_bounds : Log.Ring.bounds)
       (entries : Log.Ring.entry list)
   : Yojson.Safe.t
   =
@@ -79,6 +80,16 @@ let build
        ; "latest_seq", Json_util.int_option_to_yojson (entry_seq_json newest)
        ; "oldest_seq", Json_util.int_option_to_yojson (entry_seq_json oldest)
        ; "latest_ts_iso", Json_util.string_option_to_yojson (entry_ts_json newest)
+         (* Live-window truth: with [dropped_before] true, an empty or
+            thin result below [start_seq] means "outside the ring
+            window" (consult [retention.durable_store]), not "did not
+            happen". *)
+       ; ( "ring"
+         , `Assoc
+             [ "start_seq", `Int ring_bounds.Log.Ring.start_seq
+             ; "total", `Int ring_bounds.Log.Ring.total
+             ; "dropped_before", `Bool ring_bounds.Log.Ring.dropped_before
+             ] )
        ]
        @ fields)
   | json -> json

--- a/lib/server/server_dashboard_logs_json.mli
+++ b/lib/server/server_dashboard_logs_json.mli
@@ -13,5 +13,6 @@ val build
   -> before_seq:int option
   -> category_filter:string option
   -> exclude_category:string list option
+  -> ring_bounds:Log.Ring.bounds
   -> Log.Ring.entry list
   -> Yojson.Safe.t

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -1344,10 +1344,14 @@ let add_routes ~sw ~clock router =
              Log.Ring.recent ~limit ~min_level ~module_filter ?since_seq
                ?before_seq ?category_filter ?exclude_category ()
            in
+           (* Bounds read after the slice: seqs are monotonic, so the
+              window can only have grown — never claims more history
+              than the slice actually had available. *)
+           let ring_bounds = Log.Ring.bounds () in
            let json =
              dashboard_logs_json ~config:(Mcp_server.workspace_config state) ~limit
                ~level_filter ~applied_level ~min_level ~module_filter ~since_seq
-               ~before_seq ~category_filter ~exclude_category entries
+               ~before_seq ~category_filter ~exclude_category ~ring_bounds entries
            in
            Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)

--- a/lib/server/server_routes_http_routes_dashboard_setup.mli
+++ b/lib/server/server_routes_http_routes_dashboard_setup.mli
@@ -15,6 +15,7 @@ val dashboard_logs_json :
   before_seq:int option ->
   category_filter:string option ->
   exclude_category:string list option ->
+  ring_bounds:Log.Ring.bounds ->
   Log.Ring.entry list ->
   Yojson.Safe.t
 

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -325,6 +325,7 @@ normal_targets=(
   @test/runtest-test_keeper_mutex_coverage
   @test/runtest-test_board_karma_ledger
   @test/runtest-test_board_vote_persistence
+  @test/runtest-test_log_ring_bounds
   @test/runtest-test_keeper_event_queue
   @test/runtest-test_keeper_event_queue_owner_lock
   @test/runtest-test_keeper_event_queue_persist_poison

--- a/test/dune
+++ b/test/dune
@@ -71,6 +71,7 @@
   test_auth_error_kind_dashboard_fallback
   test_mcp_error_code
   test_error_body_wire_shape
+  test_log_ring_bounds
   test_session_lifecycle_event
   test_fd_accountant
   test_keeper_disk_pressure
@@ -372,6 +373,7 @@
   test_auth_error_kind_dashboard_fallback
   test_mcp_error_code
   test_error_body_wire_shape
+  test_log_ring_bounds
   test_session_lifecycle_event
   test_fd_accountant
   test_keeper_disk_pressure

--- a/test/test_log_ring_bounds.ml
+++ b/test/test_log_ring_bounds.ml
@@ -1,0 +1,97 @@
+(** Log.Ring live-window bounds (feature-matrix Log row, 08-17 audit).
+
+    The ring retains only the last [capacity] sequences, so a query
+    that comes back empty is ambiguous without bounds: "never
+    happened" and "evicted from the window" look identical. These
+    tests pin the [bounds] contract and its ride-along on the
+    dashboard logs response:
+
+      1. Below capacity: [start_seq = 0], [dropped_before = false].
+      2. Past capacity: [start_seq = total - capacity],
+         [dropped_before = true], and a [since_seq] query below
+         [start_seq] returning nothing coincides with bounds that
+         SAY the window is cut.
+      3. The dashboard logs JSON carries the [ring] object verbatim. *)
+
+open Masc
+
+let emit_n n =
+  for i = 1 to n do
+    Log.Misc.info "ring-bounds filler %d" i
+  done
+
+let test_bounds_below_capacity () =
+  let before = Log.Ring.bounds () in
+  emit_n 10;
+  let b = Log.Ring.bounds () in
+  Alcotest.(check int) "total grew by 10" (before.Log.Ring.total + 10) b.Log.Ring.total;
+  if b.Log.Ring.total <= Log.Ring.capacity then begin
+    Alcotest.(check int) "start_seq is 0 below capacity" 0 b.Log.Ring.start_seq;
+    Alcotest.(check bool) "nothing dropped below capacity" false
+      b.Log.Ring.dropped_before
+  end
+
+let test_bounds_past_capacity () =
+  emit_n (Log.Ring.capacity + 50);
+  let b = Log.Ring.bounds () in
+  Alcotest.(check bool) "past capacity: dropped_before" true
+    b.Log.Ring.dropped_before;
+  Alcotest.(check int) "start_seq = total - capacity"
+    (b.Log.Ring.total - Log.Ring.capacity)
+    b.Log.Ring.start_seq;
+  (* A query pinned entirely below the window returns nothing — and the
+     bounds are what tell the operator why. *)
+  let below = max 0 (b.Log.Ring.start_seq - 10) in
+  let entries =
+    Log.Ring.recent ~limit:5 ~since_seq:below
+      ~before_seq:(max 1 (b.Log.Ring.start_seq - 1)) ()
+  in
+  Alcotest.(check int) "window below start_seq is empty" 0 (List.length entries)
+
+let member name = function
+  | `Assoc fields -> List.assoc name fields
+  | _ -> Alcotest.fail "logs json is not an object"
+
+let test_dashboard_logs_json_carries_ring_bounds () =
+  let base_dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-test-ring-bounds-%06x" (Random.bits ()))
+  in
+  let config = Workspace.default_config base_dir in
+  let bounds = Log.Ring.bounds () in
+  let json =
+    Server_dashboard_logs_json.build ~config ~limit:5 ~level_filter:"all"
+      ~applied_level:Log.Info ~min_level:0 ~module_filter:"" ~since_seq:None
+      ~before_seq:None ~category_filter:None ~exclude_category:None
+      ~ring_bounds:bounds []
+  in
+  match member "ring" json with
+  | `Assoc ring ->
+    Alcotest.(check int) "ring.start_seq"
+      bounds.Log.Ring.start_seq
+      (match List.assoc "start_seq" ring with
+       | `Int i -> i
+       | _ -> Alcotest.fail "start_seq not an int");
+    Alcotest.(check int) "ring.total"
+      bounds.Log.Ring.total
+      (match List.assoc "total" ring with
+       | `Int i -> i
+       | _ -> Alcotest.fail "total not an int");
+    Alcotest.(check bool) "ring.dropped_before"
+      bounds.Log.Ring.dropped_before
+      (match List.assoc "dropped_before" ring with
+       | `Bool b -> b
+       | _ -> Alcotest.fail "dropped_before not a bool")
+  | _ -> Alcotest.fail "ring field missing or not an object"
+
+let () =
+  Alcotest.run "log_ring_bounds"
+    [
+      ( "bounds",
+        [
+          Alcotest.test_case "below capacity" `Quick test_bounds_below_capacity;
+          Alcotest.test_case "past capacity" `Quick test_bounds_past_capacity;
+          Alcotest.test_case "dashboard logs json carries ring bounds" `Quick
+            test_dashboard_logs_json_carries_ring_bounds;
+        ] );
+    ]


### PR DESCRIPTION
## As-Is
링 조회는 마지막 50k seq만 답할 수 있는데(부팅 하이드레이션도 어제·오늘 2파일), 빈 결과가 '없었던 일'인지 '창 밖으로 밀려난 일'인지 응답만 봐서는 구분 불가 — 08-17 소스 감사(매트릭스 Log 행)가 지목한 신호 없는 절단.

## To-Be
- `Log.Ring.bounds` typed 레코드(start_seq/total/dropped_before) 추가 — 링 상태의 관측이므로 쿼리 결과가 아니라 별도 상태 조회로 모델링(콜러 41곳 churn 없음).
- `/api/v1/dashboard/logs` 응답에 `ring` 객체로 동승(additive) — dropped_before=true + 빈 결과 = '창 밖, durable_store를 봐라'가 응답 안에서 읽힘. 빌더는 순수 유지(경계는 라우트가 읽어 전달).

## 검증
- feature test 3케이스: capacity 이하/초과의 경계 수식, 창 밖 쿼리 공집합과 dropped_before 동시성, JSON 동승 형태. CI 배선 포함.
- 로컬 dune build 미실행(repo 방침) — CI 판정. ocamlformat 파싱 6/6, git diff --check clean.