### PR TITLE
feat(keeper): read-only 핵심 서술자 9종에 composable Json_output 스키마 선언

### DIFF
--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1297,6 +1297,371 @@ let time_now_output_schema =
     ~required:[ "now_iso"; "now_unix" ]
 ;;
 
+(* Producer: Snapshot_protocol.to_yojson via dispatch_board_list
+   (keeper_tool_board_runtime.ml). [snapshot] carries the formatted post
+   listing as one string and is absent on the [unchanged] variant. *)
+let board_list_output_schema =
+  object_output_schema
+    ~properties:
+      [ "kind", `Assoc [ "type", `String "string" ]
+      ; "revision", `Assoc [ "type", `String "string" ]
+      ; "snapshot", `Assoc [ "type", `String "string" ]
+      ]
+    ~required:[ "kind"; "revision" ]
+;;
+
+(* Producer: Masc_domain.task_to_yojson (lib/types/types_core.ml). Only the
+   unconditionally emitted fields are declared; status-variant and
+   presence-conditional fields pass through [additionalProperties]. *)
+let tasks_list_task_item_schema =
+  `Assoc
+    [ "type", `String "object"
+    ; ( "properties"
+      , `Assoc
+          [ "id", `Assoc [ "type", `String "string" ]
+          ; "title", `Assoc [ "type", `String "string" ]
+          ; "description", `Assoc [ "type", `String "string" ]
+          ; "priority", `Assoc [ "type", `String "integer" ]
+          ; ( "files"
+            , `Assoc
+                [ "type", `String "array"
+                ; "items", `Assoc [ "type", `String "string" ]
+                ] )
+          ; "created_at", `Assoc [ "type", `String "string" ]
+          ; "status", `Assoc [ "type", `String "string" ]
+          ] )
+    ; ( "required"
+      , `List
+          (List.map
+             (fun name -> `String name)
+             [ "id"
+             ; "title"
+             ; "description"
+             ; "priority"
+             ; "files"
+             ; "created_at"
+             ; "status"
+             ]) )
+    ; "additionalProperties", `Bool true
+    ]
+;;
+
+(* Producer: Tasks_list Ok branch (keeper_tool_task_runtime.ml) — the
+   Snapshot_protocol envelope prefixed with backlog provenance. [snapshot]
+   is absent on the [unchanged] variant. *)
+let tasks_list_output_schema =
+  object_output_schema
+    ~properties:
+      [ "backlog_authority", `Assoc [ "type", `String "string" ]
+      ; "degraded", `Assoc [ "type", `String "boolean" ]
+      ; "kind", `Assoc [ "type", `String "string" ]
+      ; "revision", `Assoc [ "type", `String "string" ]
+      ; ( "snapshot"
+        , `Assoc
+            [ "type", `String "array"; "items", tasks_list_task_item_schema ] )
+      ]
+    ~required:[ "backlog_authority"; "degraded"; "kind"; "revision" ]
+;;
+
+(* Producer: Keeper_artifact_read.page_to_json — the single success path. *)
+let artifact_read_output_schema =
+  object_output_schema
+    ~properties:
+      [ "ok", `Assoc [ "type", `String "boolean" ]
+      ; "sha256", `Assoc [ "type", `String "string" ]
+      ; "offset", `Assoc [ "type", `String "integer" ]
+      ; "next_offset", `Assoc [ "type", `String "integer" ]
+      ; "total_bytes", `Assoc [ "type", `String "integer" ]
+      ; "eof", `Assoc [ "type", `String "boolean" ]
+      ; "encoding", `Assoc [ "type", `String "string" ]
+      ; "content", `Assoc [ "type", `String "string" ]
+      ]
+    ~required:
+      [ "ok"
+      ; "sha256"
+      ; "offset"
+      ; "next_offset"
+      ; "total_bytes"
+      ; "eof"
+      ; "encoding"
+      ; "content"
+      ]
+;;
+
+(* Producer: Tool_agent_timeline.build_timeline. [detail] on an event and
+   the [retention] body are heterogeneous and stay undeclared. *)
+let agent_timeline_output_schema =
+  object_output_schema
+    ~properties:
+      [ "dashboard_surface", `Assoc [ "type", `String "string" ]
+      ; "source", `Assoc [ "type", `String "string" ]
+      ; "retention", `Assoc [ "type", `String "object" ]
+      ; "generated_at_iso", `Assoc [ "type", `String "string" ]
+      ; "agent", `Assoc [ "type", `String "string" ]
+      ; ( "period"
+        , object_output_schema
+            ~properties:
+              [ "from", `Assoc [ "type", `String "string" ]
+              ; "to", `Assoc [ "type", `String "string" ]
+              ]
+            ~required:[ "from"; "to" ] )
+      ; ( "events"
+        , `Assoc
+            [ "type", `String "array"
+            ; ( "items"
+              , `Assoc
+                  [ "type", `String "object"
+                  ; ( "properties"
+                    , `Assoc
+                        [ "ts", `Assoc [ "type", `String "string" ]
+                        ; "type", `Assoc [ "type", `String "string" ]
+                        ] )
+                  ; ( "required"
+                    , `List [ `String "ts"; `String "type" ] )
+                  ; "additionalProperties", `Bool true
+                  ] )
+            ] )
+      ; ( "summary"
+        , object_output_schema
+            ~properties:
+              [ "tasks_completed", `Assoc [ "type", `String "integer" ]
+              ; "tasks_claimed", `Assoc [ "type", `String "integer" ]
+              ; "messages_sent", `Assoc [ "type", `String "integer" ]
+              ; "tool_calls", `Assoc [ "type", `String "integer" ]
+              ; "chat_messages", `Assoc [ "type", `String "integer" ]
+              ; "turns_completed", `Assoc [ "type", `String "integer" ]
+              ; "total_input_tokens", `Assoc [ "type", `String "integer" ]
+              ; "total_output_tokens", `Assoc [ "type", `String "integer" ]
+              ; "total_cost_usd", `Assoc [ "type", `String "number" ]
+              ; ( "active_duration_minutes"
+                , `Assoc [ "type", `String "number" ] )
+              ; "total_events", `Assoc [ "type", `String "integer" ]
+              ]
+            ~required:
+              [ "tasks_completed"
+              ; "tasks_claimed"
+              ; "messages_sent"
+              ; "tool_calls"
+              ; "chat_messages"
+              ; "turns_completed"
+              ; "total_input_tokens"
+              ; "total_output_tokens"
+              ; "total_cost_usd"
+              ; "active_duration_minutes"
+              ; "total_events"
+              ] )
+      ]
+    ~required:
+      [ "dashboard_surface"
+      ; "source"
+      ; "retention"
+      ; "generated_at_iso"
+      ; "agent"
+      ; "period"
+      ; "events"
+      ; "summary"
+      ]
+;;
+
+(* Producer: Workspace_goals.handle_goal_list over Goal_store.goal_to_yojson
+   and rollup_to_yojson. Option-carrying goal fields serialize as
+   string-or-null and stay undeclared. *)
+let goal_list_output_schema =
+  object_output_schema
+    ~properties:
+      [ "status", `Assoc [ "type", `String "string" ]
+      ; "generated_at", `Assoc [ "type", `String "string" ]
+      ; "count", `Assoc [ "type", `String "integer" ]
+      ; ( "goals"
+        , `Assoc
+            [ "type", `String "array"
+            ; ( "items"
+              , `Assoc
+                  [ "type", `String "object"
+                  ; ( "properties"
+                    , `Assoc
+                        [ "id", `Assoc [ "type", `String "string" ]
+                        ; "title", `Assoc [ "type", `String "string" ]
+                        ; "priority", `Assoc [ "type", `String "integer" ]
+                        ; "phase", `Assoc [ "type", `String "string" ]
+                        ; "created_at", `Assoc [ "type", `String "string" ]
+                        ; "updated_at", `Assoc [ "type", `String "string" ]
+                        ] )
+                  ; ( "required"
+                    , `List
+                        (List.map
+                           (fun name -> `String name)
+                           [ "id"
+                           ; "title"
+                           ; "priority"
+                           ; "phase"
+                           ; "created_at"
+                           ; "updated_at"
+                           ]) )
+                  ; "additionalProperties", `Bool true
+                  ] )
+            ] )
+      ; ( "rollup"
+        , object_output_schema
+            ~properties:
+              [ "active_count", `Assoc [ "type", `String "integer" ]
+              ; "paused_count", `Assoc [ "type", `String "integer" ]
+              ; "done_count", `Assoc [ "type", `String "integer" ]
+              ; "dropped_count", `Assoc [ "type", `String "integer" ]
+              ]
+            ~required:
+              [ "active_count"; "paused_count"; "done_count"; "dropped_count" ] )
+      ]
+    ~required:[ "status"; "generated_at"; "count"; "goals"; "rollup" ]
+;;
+
+(* Producer: Run_eio.list over run_record_to_json. [agent_name] serializes
+   as string-or-null and stays undeclared. *)
+let run_list_output_schema =
+  object_output_schema
+    ~properties:
+      [ "count", `Assoc [ "type", `String "integer" ]
+      ; ( "runs"
+        , `Assoc
+            [ "type", `String "array"
+            ; ( "items"
+              , `Assoc
+                  [ "type", `String "object"
+                  ; ( "properties"
+                    , `Assoc
+                        [ "task_id", `Assoc [ "type", `String "string" ]
+                        ; "plan", `Assoc [ "type", `String "string" ]
+                        ; "created_at", `Assoc [ "type", `String "string" ]
+                        ; "updated_at", `Assoc [ "type", `String "string" ]
+                        ] )
+                  ; ( "required"
+                    , `List
+                        (List.map
+                           (fun name -> `String name)
+                           [ "task_id"; "plan"; "created_at"; "updated_at" ]) )
+                  ; "additionalProperties", `Bool true
+                  ] )
+            ] )
+      ]
+    ~required:[ "count"; "runs" ]
+;;
+
+(* Producer: Metrics_store_eio.agent_metrics_to_yojson (ppx-derived over the
+   11-field record in metrics_store_eio.mli). *)
+let agent_metrics_output_properties =
+  [ "agent_id", `Assoc [ "type", `String "string" ]
+  ; "period_start", `Assoc [ "type", `String "number" ]
+  ; "period_end", `Assoc [ "type", `String "number" ]
+  ; "total_tasks", `Assoc [ "type", `String "integer" ]
+  ; "completed_tasks", `Assoc [ "type", `String "integer" ]
+  ; "failed_tasks", `Assoc [ "type", `String "integer" ]
+  ; "avg_completion_time_s", `Assoc [ "type", `String "number" ]
+  ; "task_completion_rate", `Assoc [ "type", `String "number" ]
+  ; "error_rate", `Assoc [ "type", `String "number" ]
+  ; "handoff_success_rate", `Assoc [ "type", `String "number" ]
+  ; ( "unique_collaborators"
+    , `Assoc
+        [ "type", `String "array"; "items", `Assoc [ "type", `String "string" ] ]
+    )
+  ]
+;;
+
+let agent_metrics_output_required =
+  [ "agent_id"
+  ; "period_start"
+  ; "period_end"
+  ; "total_tasks"
+  ; "completed_tasks"
+  ; "failed_tasks"
+  ; "avg_completion_time_s"
+  ; "task_completion_rate"
+  ; "error_rate"
+  ; "handoff_success_rate"
+  ; "unique_collaborators"
+  ]
+;;
+
+(* Producer: Tool_agent.handle_get_metrics. The two resolution fields are
+   appended by metrics_json_with_resolution only when the requested name
+   resolved to a different metric id. *)
+let get_metrics_output_schema =
+  object_output_schema
+    ~properties:
+      (agent_metrics_output_properties
+       @ [ "requested_agent_name", `Assoc [ "type", `String "string" ]
+         ; "resolved_agent_name", `Assoc [ "type", `String "string" ]
+         ])
+    ~required:agent_metrics_output_required
+;;
+
+(* Producer: Tool_agent.handle_agent_fitness — both the empty-pool and the
+   populated envelope. *)
+let agent_fitness_output_schema =
+  object_output_schema
+    ~properties:
+      [ "count", `Assoc [ "type", `String "integer" ]
+      ; ( "agents"
+        , `Assoc
+            [ "type", `String "array"
+            ; ( "items"
+              , object_output_schema
+                  ~properties:
+                    [ "agent_id", `Assoc [ "type", `String "string" ]
+                    ; ( "components"
+                      , object_output_schema
+                          ~properties:
+                            [ "completion", `Assoc [ "type", `String "number" ]
+                            ; "reliability", `Assoc [ "type", `String "number" ]
+                            ; "speed", `Assoc [ "type", `String "number" ]
+                            ; "handoff", `Assoc [ "type", `String "number" ]
+                            ]
+                          ~required:
+                            [ "completion"; "reliability"; "speed"; "handoff" ]
+                      )
+                    ; ( "metrics"
+                      , object_output_schema
+                          ~properties:agent_metrics_output_properties
+                          ~required:agent_metrics_output_required )
+                    ]
+                  ~required:[ "agent_id"; "components"; "metrics" ] )
+            ] )
+      ]
+    ~required:[ "count"; "agents" ]
+;;
+
+(* Producer: Tool_agent.handle_agent_card. [agent] is object-or-null and
+   stays undeclared, so the object keeps [additionalProperties] open. *)
+let agent_card_output_schema =
+  `Assoc
+    [ "type", `String "object"
+    ; ( "properties"
+      , `Assoc
+          [ "schema", `Assoc [ "type", `String "string" ]
+          ; "name", `Assoc [ "type", `String "string" ]
+          ; "description", `Assoc [ "type", `String "string" ]
+          ; "action", `Assoc [ "type", `String "string" ]
+          ; "requested_by", `Assoc [ "type", `String "string" ]
+          ; "base_path", `Assoc [ "type", `String "string" ]
+          ; "workspace_path", `Assoc [ "type", `String "string" ]
+          ; "agent_count", `Assoc [ "type", `String "integer" ]
+          ] )
+    ; ( "required"
+      , `List
+          (List.map
+             (fun name -> `String name)
+             [ "schema"
+             ; "name"
+             ; "description"
+             ; "action"
+             ; "requested_by"
+             ; "base_path"
+             ; "workspace_path"
+             ; "agent_count"
+             ]) )
+    ; "additionalProperties", `Bool true
+    ]
+;;
+
 let masc_board_descriptor board_name =
   let canonical_schema = Board_tool_registry.schema_for_board_name board_name in
   let name = Tool_name.Board_name.to_string board_name in
@@ -1357,6 +1722,9 @@ let masc_board_descriptor board_name =
   | Tool_name.Board_name.Board_stats ->
     descriptor
     |> with_composable_output (Json_output { schema = board_stats_output_schema })
+  | Tool_name.Board_name.Board_list ->
+    descriptor
+    |> with_composable_output (Json_output { schema = board_list_output_schema })
   | ( Board_cleanup
     | Board_comment
     | Board_comment_vote
@@ -1364,7 +1732,6 @@ let masc_board_descriptor board_name =
     | Board_curation_submit
     | Board_delete
     | Board_hearths
-    | Board_list
     | Board_post
     | Board_post_get
     | Board_post_update
@@ -1692,7 +2059,8 @@ let internal_descriptors : t list =
       ~policy:(read_only_in_process_policy ())
       ~handler:Tool_artifact_read
       ()
-    |> with_model_output_projection Tool_output.bounded_inline_model_projection)
+    |> with_model_output_projection Tool_output.bounded_inline_model_projection
+    |> with_composable_output (Json_output { schema = artifact_read_output_schema }))
   ; in_process_descriptor_with_schema_source
       ~capability_identity:Internal_name_identity
       ~keeper_model_projection:Internal_name
@@ -1844,11 +2212,12 @@ let internal_descriptors : t list =
       "keeper_voice_session_end"
       ~readonly:false
     (* ── task / broadcast cluster (RFC-0179 PR-3, 6 tools) ────── *)
-  ; task_descriptor
-      ~capability_identity:(Named_capability "masc_tasks")
-      "list"
-      "keeper_tasks_list"
-      ~readonly:true
+  ; (task_descriptor
+       ~capability_identity:(Named_capability "masc_tasks")
+       "list"
+       "keeper_tasks_list"
+       ~readonly:true
+     |> with_composable_output (Json_output { schema = tasks_list_output_schema }))
   ; task_descriptor
       ~capability_identity:Internal_name_identity
       "audit"
@@ -1912,8 +2281,9 @@ let internal_descriptors : t list =
   (* ── RFC-0182 §3.1 — masc_run_* cluster (4 entries) ──────────── *)
   ; masc_run_descriptor "masc_run_init"
        ~readonly:false
-  ; masc_run_descriptor "masc_run_list"
+  ; (masc_run_descriptor "masc_run_list"
        ~readonly:true
+     |> with_composable_output (Json_output { schema = run_list_output_schema }))
   ; masc_run_descriptor "masc_run_get"
       ~readonly:false
   ; masc_run_descriptor "masc_run_plan"
@@ -1923,11 +2293,15 @@ let internal_descriptors : t list =
        surface) ────────── *)
   ; (masc_agent_descriptor "card" "masc_agent_card"
         ~readonly:true
-     |> with_eval_tags [ "agent_profile_lookup" ])
-  ; masc_agent_descriptor "fitness" "masc_agent_fitness"
+     |> with_eval_tags [ "agent_profile_lookup" ]
+     |> with_composable_output (Json_output { schema = agent_card_output_schema }))
+  ; (masc_agent_descriptor "fitness" "masc_agent_fitness"
        ~readonly:true
-  ; masc_agent_descriptor "get_metrics" "masc_get_metrics"
+     |> with_composable_output
+          (Json_output { schema = agent_fitness_output_schema }))
+  ; (masc_agent_descriptor "get_metrics" "masc_get_metrics"
        ~readonly:true
+     |> with_composable_output (Json_output { schema = get_metrics_output_schema }))
   (* ── RFC-0182 §3.1 — masc_workspace_* cluster (8 entries) ────────── *)
   (* Operator-only: [masc_status] answers with the operator's status *screen*.
      Workspace_status renders it for a terminal — emoji, a box-drawing rule, a
@@ -1958,8 +2332,9 @@ let internal_descriptors : t list =
        ~readonly:false
   ; masc_workspace_descriptor "check" "masc_check"
        ~readonly:true
-  ; masc_workspace_descriptor "goal_list" "masc_goal_list"
+  ; (masc_workspace_descriptor "goal_list" "masc_goal_list"
        ~readonly:true
+     |> with_composable_output (Json_output { schema = goal_list_output_schema }))
   ; masc_workspace_descriptor "goal_upsert" "masc_goal_upsert"
        ~readonly:false
   ; masc_workspace_descriptor "goal_assign" "masc_goal_assign"
@@ -1991,8 +2366,10 @@ let internal_descriptors : t list =
   ; masc_control_descriptor Tool_schemas_misc.Pause
   ; masc_control_descriptor Tool_schemas_misc.Resume
   (* ── RFC-0182 §3.1 — masc_agent_timeline singleton (1 entry) ── *)
-  ; masc_agent_timeline_descriptor "masc_agent_timeline"
-      "Read agent timeline events." ~readonly:true
+  ; (masc_agent_timeline_descriptor "masc_agent_timeline"
+       "Read agent timeline events." ~readonly:true
+     |> with_composable_output
+          (Json_output { schema = agent_timeline_output_schema }))
   (* ── RFC-0234 — scheduled internal automation (6 entries) ─────── *)
   ]
   @ List.map masc_schedule_descriptor Tool_schemas_schedule.definitions

--- a/test/test_keeper_tool_plan.ml
+++ b/test/test_keeper_tool_plan.ml
@@ -425,8 +425,272 @@ let test_composable_output_registry_is_closed () =
   check
     (list string)
     "explicit JSON-producing tools"
-    [ "Execute"; "keeper_time_now"; "masc_board_stats" ]
+    [ "Execute"
+    ; "keeper_artifact_read"
+    ; "keeper_tasks_list"
+    ; "keeper_time_now"
+    ; "masc_agent_card"
+    ; "masc_agent_fitness"
+    ; "masc_agent_timeline"
+    ; "masc_board_list"
+    ; "masc_board_stats"
+    ; "masc_get_metrics"
+    ; "masc_goal_list"
+    ; "masc_run_list"
+    ]
     json_names
+;;
+
+let test_declared_output_schemas_satisfy_the_contract () =
+  Descriptor.all_descriptors ()
+  |> List.iter (fun descriptor ->
+    match descriptor.Descriptor.composable_output with
+    | Descriptor.Opaque_output -> ()
+    | Descriptor.Json_output { schema } ->
+      (match Plan.validate_composable_schema schema with
+       | Ok () -> ()
+       | Error _ ->
+         failf
+           "declared composable schema violates the schema contract: %s"
+           descriptor.Descriptor.id))
+;;
+
+(* Producer-shaped samples mirror the single JSON construction site of each
+   tool; the file:line for each lives in the schema comments in
+   keeper_tool_descriptor.ml. *)
+let test_new_declared_output_schemas_admit_producer_shapes () =
+  let validate tool_name value =
+    let single = node ~id:"n" ~tool_name literal_object in
+    match Plan.create ~descriptors:(descriptors ()) [ single ] with
+    | Error _ -> failf "single-node plan was rejected for %s" tool_name
+    | Ok plan ->
+      Plan.validate_output plan ~run_id:(Plan.Run_id.fresh ()) ~node_id:(node_id "n") value
+  in
+  let accepts tool_name value =
+    match validate tool_name value with
+    | Ok _ -> ()
+    | Error _ -> failf "producer-shaped output was rejected for %s" tool_name
+  in
+  let rejects tool_name value =
+    match validate tool_name value with
+    | Error (Plan.Output_validation_failed _) -> ()
+    | Error _ | Ok _ -> failf "malformed output was accepted for %s" tool_name
+  in
+  let metrics_value =
+    Masc.Metrics_store_eio.agent_metrics_to_yojson
+      { Masc.Metrics_store_eio.agent_id = "albini"
+      ; period_start = 1755400000.0
+      ; period_end = 1755500000.0
+      ; total_tasks = 3
+      ; completed_tasks = 2
+      ; failed_tasks = 1
+      ; avg_completion_time_s = 42.5
+      ; task_completion_rate = 0.66
+      ; error_rate = 0.33
+      ; handoff_success_rate = 1.0
+      ; unique_collaborators = [ "gemini" ]
+      }
+  in
+  accepts
+    "masc_board_list"
+    (Masc.Snapshot_protocol.to_yojson
+       (Masc.Snapshot_protocol.Snapshot
+          { revision = "board:r1"; value = `String "posts" }));
+  accepts
+    "masc_board_list"
+    (Masc.Snapshot_protocol.to_yojson
+       (Masc.Snapshot_protocol.Unchanged { revision = "board:r1" }));
+  let task_item =
+    `Assoc
+      [ "id", `String "task-1"
+      ; "title", `String "t"
+      ; "description", `String "d"
+      ; "priority", `Int 3
+      ; "files", `List [ `String "lib/a.ml" ]
+      ; "created_at", `String "2026-08-18T00:00:00Z"
+      ; "status", `String "claimed"
+      ; "assignee", `String "albini"
+      ; "claimed_at", `String "2026-08-18T00:00:01Z"
+      ]
+  in
+  accepts
+    "keeper_tasks_list"
+    (`Assoc
+       [ "backlog_authority", `String "primary"
+       ; "degraded", `Bool false
+       ; "kind", `String "snapshot"
+       ; "revision", `String "tasks:r1"
+       ; "snapshot", `List [ task_item ]
+       ]);
+  accepts
+    "keeper_tasks_list"
+    (`Assoc
+       [ "backlog_authority", `String "primary"
+       ; "degraded", `Bool false
+       ; "kind", `String "unchanged"
+       ; "revision", `String "tasks:r1"
+       ]);
+  rejects
+    "keeper_tasks_list"
+    (`Assoc
+       [ "backlog_authority", `String "primary"
+       ; "degraded", `Bool false
+       ; "kind", `String "snapshot"
+       ]);
+  accepts
+    "keeper_artifact_read"
+    (`Assoc
+       [ "ok", `Bool true
+       ; "sha256", `String (String.make 64 'a')
+       ; "offset", `Int 0
+       ; "next_offset", `Int 512
+       ; "total_bytes", `Int 1024
+       ; "eof", `Bool false
+       ; "encoding", `String "utf-8"
+       ; "content", `String "chunk"
+       ]);
+  rejects
+    "keeper_artifact_read"
+    (`Assoc
+       [ "ok", `Bool true
+       ; "sha256", `String (String.make 64 'a')
+       ; "offset", `Int 0
+       ; "next_offset", `Int 512
+       ; "total_bytes", `Int 1024
+       ; "eof", `Bool false
+       ; "encoding", `String "utf-8"
+       ; "content", `String "chunk"
+       ; "_unexpected", `Bool true
+       ]);
+  accepts
+    "masc_agent_timeline"
+    (`Assoc
+       [ "dashboard_surface", `String "/api/v1/agent-timeline"
+       ; "source", `String "agent_timeline_read_model"
+       ; "retention", `Assoc [ "scope", `String "multi_source_tail" ]
+       ; "generated_at_iso", `String "2026-08-18T00:00:00Z"
+       ; "agent", `String "albini"
+       ; ( "period"
+         , `Assoc
+             [ "from", `String "2026-08-17T00:00:00Z"
+             ; "to", `String "2026-08-18T00:00:00Z"
+             ] )
+       ; ( "events"
+         , `List
+             [ `Assoc
+                 [ "ts", `String "2026-08-17T01:00:00Z"
+                 ; "type", `String "tool_call"
+                 ; "detail", `Assoc [ "tool", `String "masc_board_stats" ]
+                 ]
+             ] )
+       ; ( "summary"
+         , `Assoc
+             [ "tasks_completed", `Int 1
+             ; "tasks_claimed", `Int 1
+             ; "messages_sent", `Int 0
+             ; "tool_calls", `Int 1
+             ; "chat_messages", `Int 0
+             ; "turns_completed", `Int 2
+             ; "total_input_tokens", `Int 100
+             ; "total_output_tokens", `Int 50
+             ; "total_cost_usd", `Float 0.01
+             ; "active_duration_minutes", `Float 60.0
+             ; "total_events", `Int 1
+             ] )
+       ]);
+  accepts
+    "masc_goal_list"
+    (`Assoc
+       [ "status", `String "ok"
+       ; "generated_at", `String "2026-08-18T00:00:00Z"
+       ; "count", `Int 1
+       ; ( "goals"
+         , `List
+             [ `Assoc
+                 [ "id", `String "goal-1"
+                 ; "title", `String "g"
+                 ; "metric", `Null
+                 ; "priority", `Int 2
+                 ; "phase", `String "executing"
+                 ; "owner", `Null
+                 ; "created_at", `String "2026-08-01T00:00:00Z"
+                 ; "updated_at", `String "2026-08-18T00:00:00Z"
+                 ]
+             ] )
+       ; ( "rollup"
+         , `Assoc
+             [ "active_count", `Int 1
+             ; "paused_count", `Int 0
+             ; "done_count", `Int 0
+             ; "dropped_count", `Int 0
+             ] )
+       ]);
+  accepts
+    "masc_run_list"
+    (`Assoc
+       [ "count", `Int 1
+       ; ( "runs"
+         , `List
+             [ Masc.Run_eio.run_record_to_json
+                 { Masc.Run_eio.task_id = "task-1"
+                 ; agent_name = None
+                 ; plan = "plan body"
+                 ; created_at = "2026-08-18T00:00:00Z"
+                 ; updated_at = "2026-08-18T00:00:00Z"
+                 }
+             ] )
+       ]);
+  accepts "masc_get_metrics" metrics_value;
+  accepts
+    "masc_get_metrics"
+    (match metrics_value with
+     | `Assoc fields ->
+       `Assoc
+         (fields
+          @ [ "requested_agent_name", `String "albini"
+            ; "resolved_agent_name", `String "keeper-albini-agent"
+            ])
+     | other -> other);
+  rejects
+    "masc_get_metrics"
+    (match metrics_value with
+     | `Assoc fields -> `Assoc (("_unexpected", `Bool true) :: fields)
+     | other -> other);
+  accepts
+    "masc_agent_fitness"
+    (`Assoc [ "count", `Int 0; "agents", `List [] ]);
+  accepts
+    "masc_agent_fitness"
+    (`Assoc
+       [ "count", `Int 1
+       ; ( "agents"
+         , `List
+             [ `Assoc
+                 [ "agent_id", `String "albini"
+                 ; ( "components"
+                   , `Assoc
+                       [ "completion", `Float 0.66
+                       ; "reliability", `Float 0.67
+                       ; "speed", `Float 1.0
+                       ; "handoff", `Float 1.0
+                       ] )
+                 ; "metrics", metrics_value
+                 ]
+             ] )
+       ]);
+  accepts
+    "masc_agent_card"
+    (`Assoc
+       [ "schema", `String "masc.agent_card.v1"
+       ; "name", `String "MASC"
+       ; "description", `String "MASC multi-agent workspace MCP server"
+       ; "action", `String "get"
+       ; "requested_by", `String "albini"
+       ; "base_path", `String "/tmp/masc"
+       ; "workspace_path", `String "/tmp/masc/ws"
+       ; "agent_count", `Int 2
+       ; "agent", `Null
+       ])
 ;;
 
 let test_composition_run_id_is_uuid_v7_identity () =
@@ -468,6 +732,14 @@ let () =
             "closed composable output registry"
             `Quick
             test_composable_output_registry_is_closed
+        ; test_case
+            "declared schemas satisfy the contract"
+            `Quick
+            test_declared_output_schemas_satisfy_the_contract
+        ; test_case
+            "declared schemas admit producer shapes"
+            `Quick
+            test_new_declared_output_schemas_admit_producer_shapes
         ; test_case
             "unsupported output schema keywords"
             `Quick


### PR DESCRIPTION
## 목표

read-only 핵심 서술자 9개에 composable `Json_output` 스키마를 선언합니다. 지금까지 composable 선언은 3곳(`Execute`, `masc_board_stats`, `keeper_time_now`)뿐이라, 나머지 도구는 합성 플랜에서 다운스트림 노드가 출력을 참조할 수 없었습니다 (`keeper_tool_plan.mli`의 `Opaque_output_reference` 거부). 이 PR로 조회 계열 결과를 다음 노드 입력으로 먹일 수 있게 됩니다.

## 선언 방식 (수기 스키마가 1차 경로)

스키마를 기계 유도할 typed encoder 층은 코드베이스에 없습니다 (설계 문서 적대적 리뷰 #29007 확정). 기존 composable 3개도 전부 수기 스키마입니다. 따라서 이 PR도 **실제 출력 구성 코드를 대조한 수기 선언**을 1차 경로로 택했고, producer 계약화(A2-3, 출력 타입을 코드에서 스키마로 유도)는 후속 작업입니다. 스키마마다 producer 위치를 주석으로 남겨 두 표면의 동기화 지점을 명시했습니다.

top-level `{"type":"string"}` 선언은 closed subset 계약상 유효함을 확인했지만 (`keeper_tool_plan.ml` `validate_schema_contract`가 scalar 루트 허용), (1) 닫힌 레지스트리 테스트가 object 루트를 강제하고 있고 (2) prose 출력을 계약으로 굳히는 방향이라, 이번 라운드에서는 구조화 출력 도구에 집중하고 문자열 스키마는 채택하지 않았습니다 (아래 제외 표 참조).

## 변경 파일

- `lib/keeper/keeper_tool_descriptor.ml` — 스키마 정의 9종 + 서술자 배선
- `test/test_keeper_tool_plan.ml` — 닫힌 레지스트리 목록 갱신 + 계약/값 검증 테스트 2건 추가

## 도구별 스키마 근거 (출력 구성 코드 위치)

| 도구 | 출력 구성 코드 | 스키마 요약 |
|---|---|---|
| `masc_board_list` | `lib/keeper/keeper_tool_board_runtime.ml` `dispatch_board_list` → `lib/snapshot_protocol.ml` `to_yojson` | `{kind, revision, snapshot?}`, snapshot은 string. `unchanged` 변형은 snapshot 없음 → required는 kind/revision만. additionalProperties false |
| `keeper_tasks_list` | `lib/keeper/keeper_tool_task_runtime.ml` `Tasks_list` Ok 분기 (envelope에 `backlog_authority`/`degraded` 선행 삽입) | `{backlog_authority, degraded, kind, revision, snapshot?}`. snapshot 항목은 `lib/types/types_core.ml` `task_to_yojson`의 무조건 방출 7필드(id/title/description/priority/files/created_at/status)만 required, 조건부 필드는 additionalProperties true로 통과 |
| `keeper_artifact_read` | `lib/keeper/keeper_artifact_read.ml` `page_to_json` (성공 경로 단일) | 8키 고정 객체, 전부 required, additionalProperties false |
| `masc_agent_timeline` | `lib/tool_agent_timeline.ml` `build_timeline` (make_ok 단일) | 8키 envelope. `events[].detail`·`retention` 본문은 이종 JSON이라 미선언. summary는 integer 9 + number 2 고정 |
| `masc_goal_list` | `lib/workspace_goals.ml` `handle_goal_list` → `lib/goal/goal_store.ml` `goal_to_yojson`/`rollup_to_yojson` | `{status, generated_at, count, goals, rollup}` 고정. goal 항목의 option 필드(string-or-null)는 미선언 |
| `masc_run_list` | `lib/run_eio.ml` `list` + `run_record_to_json` | `{count, runs}`. run 항목의 `agent_name`은 string-or-null이라 미선언 |
| `masc_get_metrics` | `lib/tool_agent.ml` `handle_get_metrics` → `metrics_store_eio.mli`의 ppx 파생 11필드 + `metrics_json_with_resolution` | 11필드 required + `requested_agent_name`/`resolved_agent_name` optional(이름 재해석 시에만 추가), additionalProperties false |
| `masc_agent_fitness` | `lib/tool_agent.ml` `handle_agent_fitness` (빈 풀/일반 두 성공 경로) | `{count, agents[]}`; 항목은 `agent_id` + `components`(number 4) + `metrics`(11필드) 고정 |
| `masc_agent_card` | `lib/tool_agent.ml` `handle_agent_card` (성공 경로 단일) | 안정 8필드 required. `agent`가 object-or-null 유니언이라 미선언 + additionalProperties true |

공통 판단 기준:

- 런타임 재검증(`keeper_tool_plan_executor.ml`의 `Plan.validate_output`)이 **모든 Completed 결과**에 적용되므로, required에는 모든 성공 경로에서 반드시 존재하는 필드만 넣었습니다. 각 도구의 Completed 경로를 전수 추적했고, 오류 경로는 `make_err`(Failed)라 검증 대상이 아님을 확인했습니다.
- closed subset 언어(type/properties/required/additionalProperties/items)에 유니언이 없으므로, string-or-null·object-or-null·상태 변형 필드는 선언하지 않고 additionalProperties true로 열어 두었습니다. 키 집합이 닫힌 envelope만 additionalProperties false입니다.
- 타입 매핑: `` `Float`` → `number`, `` `Int`` → `integer`(validator에서 number는 Int도 수용, integer는 Float 거부 — `keeper_tool_plan.ml` `json_type`/`validate_schema_value`).

## 제외 목록과 사유

| 도구 | 사유 |
|---|---|
| `masc_tasks` | `Tool_result.ok`가 사람용 포맷 문자열을 그대로 data에 실음 (`lib/task/tool_task.ml` `handle_tasks`). typed envelope은 `keeper_tasks_list`가 담당 |
| `keeper_memory_search`, `keeper_context_status`, `keeper_tools_list`, `keeper_surface_read`, `masc_fusion_status` | 핸들러가 `Keeper_tool_execution.success`(텍스트)라 data가 `` `String raw``로 투영됨 (`keeper_tools_agent_core_handler_exec.ml` `producer_payload`). object 스키마는 런타임 검증에서 즉시 깨지고, `{"type":"string"}` 선언은 stringly 출력 자체를 계약으로 굳히는 워크어라운드라 배제. 근본 해결은 핸들러의 `success_data` 전환(후속 작업) |
| `keeper_library_search`, `keeper_library_read` | `text_ok` prose 출력 (`lib/tool_library.ml`) |
| `masc_board_search`, `masc_board_post_get`, `masc_board_hearths`, `masc_board_profile` | data가 prose `` `String`` (`lib/board_tool_adapter/*.ml`) |
| `masc_task_history` | data가 JSONL 파싱 라인의 `` `List``인데 `parse_jsonl_lines`가 라인당 임의 JSON을 허용해 항목 타입 보장이 없고, 루트가 object가 아니라 닫힌 레지스트리 테스트의 object-root 불변식과 충돌. 배열 루트 허용은 별도 논의로 |
| `masc_plan_get_task` | 출력이 `{current_task: string-or-null}` 단일 유니언 필드라 closed subset으로 유의미한 포인터를 만들 수 없음 |
| `masc_run_plan` | readonly 플래그와 달리 핸들러가 `Run_eio.update_plan`으로 쓰기 수행 — read-only 묶음에서 제외 |
| `keeper_vision_analyze_image`, `masc_web_search`, `masc_web_fetch` | 출력 구조가 외부 모델/네트워크 응답에 의존해 비결정적 |
| `masc_status`, `masc_keeper_waiting_inventory` | `Operator_only` 투영이라 keeper 합성 표면 대상이 아님 |
| `masc_config`, `masc_dashboard`, `masc_tool_help`, `masc_check`, `keeper_tasks_audit` | 출력 구성 경로를 이번 라운드에서 전수 확증하지 못해 보수적으로 보류 |

## 검증

- 로컬 `dune build`는 수행하지 않았습니다 (CI가 컴파일/테스트 검증). 대신:
  - `ocamlc -stop-after parsing`으로 두 파일 구문 검사 통과
  - 참조한 값/타입(`validate_composable_schema`, `Output_validation_failed`, `Snapshot_protocol` variant, `Run_eio.run_record`, `Metrics_store_eio.agent_metrics`)의 `.mli` 공개 여부를 파일로 직접 확인
- 테스트 (기존 named suite `test_keeper_tool_plan` 확장 — 새 파일/새 배선 없음):
  - `test_composable_output_registry_is_closed` 기대 목록 3 → 12
  - `test_declared_output_schemas_satisfy_the_contract` — 모든 선언 스키마가 `validate_composable_schema` 통과
  - `test_new_declared_output_schemas_admit_producer_shapes` — 도구별 producer 모양 값 수용(snapshot/unchanged 변형, resolution 필드 유무, 빈 fitness 풀 포함) + 닫힌 envelope의 필수 누락/여분 키 거부. `Snapshot_protocol.to_yojson`, `run_record_to_json`, `agent_metrics_to_yojson`은 실제 프로듀서 함수를 직접 호출

## 라이브 기록 대조 (`me/.masc/tool_calls/2026-08/*.jsonl`, 읽기 전용)

실제 기록 행의 output과 스키마를 대조했습니다:

- `keeper_tasks_list` — snapshot 변형(빈 배열/태스크 포함) 실측 일치. 태스크 항목의 조건부 필드(created_by/contract/execution_links/assignee/started_at)가 실제로 붙는 것 확인 → required 7필드 + additionalProperties true 판단과 부합
- `masc_board_list`, `masc_goal_list`, `masc_run_list`, `masc_get_metrics`, `masc_agent_fitness`, `keeper_artifact_read` — 실측 키 집합 일치
- `masc_agent_card` — 08-07 기록에 현재 코드에 없는 `capabilities` 필드가 존재(그 뒤 제거된 것으로 보임). additionalProperties true라 구버전 출력도 통과
- `masc_agent_timeline` — envelope 앞부분(8키 중 retention까지)은 실측 일치. 기록이 약 4KB에서 잘려 summary 꼬리는 라이브로 확인 불가 — summary 11키는 `build_timeline` 단일 구성부 정독 근거

## 미검증 항목

- 컴파일과 스위트 실행은 CI 결과로 확인해야 합니다.
- `masc_agent_timeline` summary와 `keeper_tasks_list` unchanged 변형은 라이브 기록 대신 구성 코드 정독이 근거입니다 (로그 4KB 절단/미발생). 런타임 `validate_output`이 최종 강제선입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
