### PR TITLE
fix(keeper): 도구호출 행에 턴 성격을 실어 합성 실행 귀속을 판정 가능하게

### DIFF
--- a/dashboard/src/api/dashboard-keeper-tool-calls.ts
+++ b/dashboard/src/api/dashboard-keeper-tool-calls.ts
@@ -90,6 +90,12 @@ export type ToolCallEntry = {
   keeper_turn_id?: number
   task_id?: string
   lane?: string
+  // Which turn made the call: a submitted operation's turn ('direct') or the
+  // keeper's own autonomous cycle. Both carry the same trace_id, so without
+  // this an operator reading the inspector cannot tell a submission's calls
+  // from work the keeper started on its own. Absent on rows written outside
+  // a keeper turn (runtime MCP) and on pre-#28977 logs.
+  turn_kind?: string
   // RFC-0233: canonical execution identity minted at dispatch (absent on pre-PR-1 rows)
   execution_id?: string
   result_bytes?: number
@@ -251,6 +257,7 @@ function decodeToolCallEntry(raw: unknown): ToolCallEntry | null {
     keeper_turn_id: asNumber(raw.keeper_turn_id),
     task_id: asString(raw.task_id),
     lane: asString(raw.lane),
+    turn_kind: asString(raw.turn_kind),
     execution_id: asString(raw.execution_id),
     result_bytes: asNumber(raw.result_bytes),
     truncated_to: asNumber(raw.truncated_to),

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -334,6 +334,7 @@ function entryScopeLabel(entry: ToolCallEntry): string {
       ? `tool_use_id ${entry.tool_use_id === '' ? '(blank)' : entry.tool_use_id}`
       : null,
     typeof entry.keeper_turn_id === 'number' ? `keeper ${entry.keeper_turn_id}` : null,
+    entry.turn_kind ? `turn ${entry.turn_kind}` : null,
     entry.lane ? `lane ${entry.lane}` : null,
     entry.task_id ? `task ${entry.task_id}` : null,
     goalIds.length > 0 ? `goal ${goalIds.join(',')}` : null,

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -575,6 +575,7 @@ let run_turn
       ~start_turn_count
       ~generation
       ~keeper_turn_id:manifest_keeper_turn_id
+      ~turn_kind
       ~runtime_id
       ~is_retry
       ~config_root

--- a/lib/keeper/keeper_hooks_agent_core.ml
+++ b/lib/keeper/keeper_hooks_agent_core.ml
@@ -520,6 +520,7 @@ let make_hooks
              ~success:(outcome = Tool_result.Ok) ~duration_ms
              ~model:(current_keeper_model !meta_ref)
              ?agent_name:tctx.agent_name
+             ?turn_kind:tctx.turn_kind
              ?lane:tctx.lane ?tool_choice:tctx.tool_choice
              ?thinking_enabled:tctx.thinking_enabled
              ?thinking_budget:tctx.thinking_budget
@@ -721,6 +722,7 @@ let make_hooks
                 ~success:false ~duration_ms
                 ~model:(current_keeper_model meta)
                 ?agent_name:tctx.agent_name
+                ?turn_kind:tctx.turn_kind
                 ?lane:tctx.lane
                 ~execution_id:(Ids.Execution_id.generate ())
                 ~tool_use_id:(Agent_core.Tool_contract.Invocation.tool_use_id invocation)

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -92,6 +92,7 @@ val prepare_agent_setup
   -> start_turn_count:int
   -> generation:int
   -> keeper_turn_id:int
+  -> turn_kind:Turn_record.turn_kind
   -> runtime_id:string
   -> is_retry:bool
   -> config_root:string

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -60,6 +60,7 @@ type ctx =
   ; keeper_tools_cleanup : unit -> unit
   ; terminal_effect_state : unit -> Keeper_tools_agent_core.terminal_effect_state
   ; keeper_turn_id : int
+  ; turn_kind : Turn_record.turn_kind
   ; meta : Keeper_meta_contract.keeper_meta
   ; turn_ctx_cell : Keeper_tool_call_log.turn_ctx_cell
     (* RFC-0225 §3.3: per-run carrier; written by the pre-request hook
@@ -227,6 +228,7 @@ let assemble_hooks
   let keeper_tools_cleanup = ctx.keeper_tools_cleanup in
   let terminal_effect_state = ctx.terminal_effect_state in
   let keeper_turn_id = ctx.keeper_turn_id in
+  let turn_kind = ctx.turn_kind in
   let meta = ctx.meta in
   let turn_ctx_cell = ctx.turn_ctx_cell in
   let final_agent_core_turn_ordinal_ref = ctx.final_agent_core_turn_ordinal_ref in
@@ -522,6 +524,7 @@ let assemble_hooks
                 Keeper_tool_call_log.set_turn_context
                   ~cell:turn_ctx_cell
                   ~agent_name:meta.agent_name
+                  ~turn_kind
                   ~lane:
                     (Keeper_agent_tool_surface.turn_lane_to_string lane)
                   ?tool_choice:

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -176,6 +176,7 @@ let prepare_agent_setup
       ~(start_turn_count : int)
       ~(generation : int)
       ~(keeper_turn_id : int)
+      ~(turn_kind : Turn_record.turn_kind)
       ~(runtime_id : string)
       ~(is_retry : bool)
       ~(config_root : string)
@@ -453,6 +454,7 @@ let prepare_agent_setup
     ; keeper_tools_cleanup
     ; terminal_effect_state
     ; keeper_turn_id
+    ; turn_kind
     ; meta
     ; turn_ctx_cell
     ; final_agent_core_turn_ordinal_ref

--- a/lib/keeper/keeper_tool_composition_surface.ml
+++ b/lib/keeper/keeper_tool_composition_surface.ml
@@ -94,6 +94,7 @@ let observe_node_result
       ~duration_ms:(Tool_result.duration_ms result.result)
       ~model:(Keeper_hooks_agent_core_types.current_keeper_model meta)
       ?agent_name:context.agent_name
+      ?turn_kind:context.turn_kind
       ?lane:context.lane
       ?tool_choice:context.tool_choice
       ?thinking_enabled:context.thinking_enabled

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -423,6 +423,7 @@ let log_call
       ~(duration_ms : float)
       ?(model : string = "")
       ?agent_name
+      ?turn_kind
       ?lane
       ?tool_choice
       ?thinking_enabled
@@ -501,6 +502,16 @@ let log_call
       let lane_field =
         match lane with
         | Some value -> [ "lane", `String value ]
+        | None -> []
+      in
+      (* Names the turn that made the call: a submitted operation's turn or
+         the keeper's own autonomous cycle. Both produce identical rows
+         otherwise, so a reader joining calls to a submission had to guess
+         from timestamps (#28977). *)
+      let turn_kind_field =
+        match turn_kind with
+        | Some value ->
+          [ "turn_kind", `String (Turn_record.turn_kind_to_string value) ]
         | None -> []
       in
       let tool_choice_field =
@@ -691,6 +702,7 @@ let log_call
            @ route_evidence_field
            @ model_field
            @ runtime_profile_field
+           @ turn_kind_field
            @ lane_field
            @ tool_choice_field
            @ thinking_enabled_field

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -38,6 +38,7 @@ val create_turn_ctx_cell : unit -> turn_ctx_cell
 val set_turn_context :
   cell:turn_ctx_cell ->
   ?agent_name:string ->
+  ?turn_kind:Turn_record.turn_kind ->
   ?lane:string ->
   ?tool_choice:string ->
   ?thinking_enabled:bool ->
@@ -144,6 +145,7 @@ val log_call :
   duration_ms:float ->
   ?model:string ->
   ?agent_name:string ->
+  ?turn_kind:Turn_record.turn_kind ->
   ?lane:string ->
   ?tool_choice:string ->
   ?thinking_enabled:bool ->
@@ -200,7 +202,11 @@ val log_call :
     [on_committed], when supplied, forces this row through the synchronous
     append boundary and runs only after that append succeeds. It is intended
     for exact completion notifications whose readers must not race the
-    asynchronous log queue. Output is truncated to 4000 bytes. [model] is a compatibility input only;
+    asynchronous log queue. [turn_kind] names which turn made the call —
+    a submitted operation's turn or the keeper's own autonomous cycle —
+    so a reader can join calls to a submission instead of inferring the
+    boundary from timestamps that a concurrent autonomous turn overlaps.
+    Output is truncated to 4000 bytes. [model] is a compatibility input only;
     non-empty values are redacted to the neutral runtime lane. [runtime_profile]
     is persisted separately as the operator-facing runtime selector. Turn-policy fields ([lane], [tool_choice],
     [thinking_enabled], [thinking_budget]) capture the effective tool

--- a/lib/keeper_tool_call_log_context.ml
+++ b/lib/keeper_tool_call_log_context.ml
@@ -7,6 +7,7 @@
 
 type turn_context =
   { agent_name : string option
+  ; turn_kind : Turn_record.turn_kind option
   ; lane : string option
   ; tool_choice : string option
   ; thinking_enabled : bool option
@@ -28,6 +29,7 @@ type turn_context =
 
 let empty_turn_context =
   { agent_name = None
+  ; turn_kind = None
   ; lane = None
   ; tool_choice = None
   ; thinking_enabled = None
@@ -55,6 +57,7 @@ let create_cell () : cell = ref empty_turn_context
 let set_turn_context
       ~(cell : cell)
       ?agent_name
+      ?turn_kind
       ?lane
       ?tool_choice
       ?thinking_enabled
@@ -76,6 +79,7 @@ let set_turn_context
   =
   cell
   := { agent_name
+     ; turn_kind
      ; lane
      ; tool_choice
      ; thinking_enabled

--- a/lib/keeper_tool_call_log_context.mli
+++ b/lib/keeper_tool_call_log_context.mli
@@ -10,6 +10,13 @@
 
 type turn_context =
   { agent_name : string option
+  ; turn_kind : Turn_record.turn_kind option
+    (* Whether this run is an operator/agent submission or the keeper's own
+       autonomous cycle. Both kinds call the same tools with the same
+       trace_id, so without this field a reader asking which calls belong to
+       a submitted operation has only wall-clock overlap to go on, and a
+       concurrent autonomous turn's calls are indistinguishable from the
+       submission's (#28977). *)
   ; lane : string option
   ; tool_choice : string option
   ; thinking_enabled : bool option
@@ -38,6 +45,7 @@ val create_cell : unit -> cell
 val set_turn_context :
   cell:cell ->
   ?agent_name:string ->
+  ?turn_kind:Turn_record.turn_kind ->
   ?lane:string ->
   ?tool_choice:string ->
   ?thinking_enabled:bool ->

--- a/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
+++ b/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
@@ -1436,7 +1436,34 @@ class MissionRun:
                 if isinstance(row.get("ts"), (int, float))
                 and turn.started_epoch_seconds <= float(row["ts"])
                 <= turn.finished_epoch_seconds
+                and is_submitted_turn_row(row)
             ]
+
+        def is_submitted_turn_row(row: dict[str, Any]) -> bool:
+            # The mission prompt reaches a keeper only through a submitted
+            # turn. Its autonomous cycle receives "Continue." and calls the
+            # same tools with the same trace_id, so before rows carried
+            # turn_kind (masc#28977) the only available boundary was the
+            # submission's wall clock — and a keeper that started an
+            # autonomous turn while the harness was submitting had its own
+            # compose runs land outside every window, counted as an
+            # exactly-once violation it never committed. Rows without the
+            # field fail closed: no run is attributable, and the assertion
+            # says so rather than passing on an empty universe.
+            return row.get("turn_kind") == "direct"
+
+        def autonomous_composition_runs(composition_tool: str) -> set[tuple[str, str]]:
+            runs: set[tuple[str, str]] = set()
+            for role, rows in self.tool_call_rows.items():
+                for row in rows:
+                    if row.get("composition_tool") != composition_tool:
+                        continue
+                    if is_submitted_turn_row(row):
+                        continue
+                    run_id = row.get("composition_run_id")
+                    if isinstance(run_id, str) and run_id:
+                        runs.add((role, run_id))
+            return runs
 
         def composition_runs(
             composition_tool: str,
@@ -1445,6 +1472,8 @@ class MissionRun:
             for role, rows in self.tool_call_rows.items():
                 for row in rows:
                     if row.get("composition_tool") != composition_tool:
+                        continue
+                    if not is_submitted_turn_row(row):
                         continue
                     run_id = row.get("composition_run_id")
                     if isinstance(run_id, str) and run_id:
@@ -1480,6 +1509,9 @@ class MissionRun:
 
         inline_runs = composition_runs("keeper_compose_mission-snapshot")
         async_runs = composition_runs("keeper_compose_background-snapshot")
+        autonomous_inline_runs = autonomous_composition_runs(
+            "keeper_compose_mission-snapshot"
+        )
         composition_rows = [row for rows in inline_runs.values() for row in rows]
         inline_turn_runs: dict[str, tuple[str, list[dict[str, Any]]]] = {}
         inline_turn_errors: list[str] = []
@@ -1995,7 +2027,8 @@ class MissionRun:
                 and inline_row_universe_exact
                 and inline_action_identities_globally_unique,
                 f"exact completed inline runs={len(inline_turn_runs)}/14 "
-                f"errors={inline_turn_errors} unattributed={sorted(unattributed_inline_runs)}",
+                f"errors={inline_turn_errors} unattributed={sorted(unattributed_inline_runs)} "
+                f"autonomous={sorted(autonomous_inline_runs)}",
             ),
             "composition_parallel_schedule_observed": (
                 parallel_schedule_observed,

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -341,6 +341,100 @@ let test_composition_action_context_persisted () =
         ]
     | _ -> Alcotest.fail "expected exactly one composition action entry")
 
+(* One keeper, one trace: a submitted turn and the keeper's own autonomous
+   cycle each run the same composition tool. Rows of both carry the same
+   keeper, trace_id and composition tool, so a reader asking which run
+   belongs to the submission had nothing to separate them and fell back to
+   the submission's wall clock — which the autonomous run overlaps
+   (masc#28977 RW17: builder-b's autonomous compose runs were read as
+   exactly-once violations of the submitted mission).
+
+   The rows are written the way both production writers do it: context into
+   a per-run cell, read back as a record, passed explicitly to log_call. *)
+let test_composition_rows_separate_submitted_from_autonomous_turn () =
+  with_tmp_log (fun () ->
+    let node_ids = [ "clock"; "board"; "board-peer"; "memory" ] in
+    let log_composition_run ~turn_kind ~keeper_turn_id ~run_id =
+      let cell = Keeper_tool_call_log.create_turn_ctx_cell () in
+      Keeper_tool_call_log.set_turn_context
+        ~cell
+        ~agent_name:"keeper-build-b-agent"
+        ~turn_kind
+        ~lane:"tool_optional"
+        ~trace_id:"trace-shared"
+        ~session_id:"trace-shared"
+        ~keeper_turn_id
+        ();
+      let context : Keeper_tool_call_log_context.turn_context =
+        Keeper_tool_call_log_context.get_turn_context_record ~cell ()
+      in
+      List.iter
+        (fun node_id ->
+           Keeper_tool_call_log.log_call
+             ~keeper_name:"build-b"
+             ~tool_name:"masc_board_stats"
+             ~input:(`Assoc [])
+             ~output_text:"ok"
+             ~success:true
+             ~duration_ms:1.0
+             ?agent_name:context.agent_name
+             ?turn_kind:context.turn_kind
+             ?lane:context.lane
+             ?trace_id:context.trace_id
+             ?session_id:context.session_id
+             ?keeper_turn_id:context.keeper_turn_id
+             ~composition_tool:"keeper_compose_mission-snapshot"
+             ~composition_run_id:run_id
+             ~composition_node_id:node_id
+             ~composition_execution:Keeper_tool_composition_catalog.Inline
+             ~parent_tool_use_id:("call-" ^ run_id)
+             ())
+        node_ids
+    in
+    log_composition_run
+      ~turn_kind:Turn_record.Direct
+      ~keeper_turn_id:2
+      ~run_id:"run-submitted";
+    log_composition_run
+      ~turn_kind:Turn_record.Autonomous
+      ~keeper_turn_id:3
+      ~run_id:"run-autonomous";
+    let entries = Keeper_tool_call_log.read_recent ~n:16 () in
+    Alcotest.(check int) "every node row of both runs persisted" 8
+      (List.length entries);
+    let run_ids_for kind =
+      List.filter_map
+        (fun entry ->
+           match Safe_ops.json_string_opt "turn_kind" entry with
+           | Some value when String.equal value kind ->
+             Safe_ops.json_string_opt "composition_run_id" entry
+           | Some _ | None -> None)
+        entries
+      |> List.sort_uniq String.compare
+    in
+    Alcotest.(check (list string)) "submitted turn owns exactly its run"
+      [ "run-submitted" ]
+      (run_ids_for "direct");
+    Alcotest.(check (list string)) "autonomous cycle owns exactly its run"
+      [ "run-autonomous" ]
+      (run_ids_for "autonomous");
+    let submitted_node_rows =
+      List.filter
+        (fun entry ->
+           match Safe_ops.json_string_opt "turn_kind" entry with
+           | Some value -> String.equal value "direct"
+           | None -> false)
+        entries
+    in
+    Alcotest.(check int) "submitted run keeps all four node rows" 4
+      (List.length submitted_node_rows);
+    Alcotest.(check (list string)) "every node of the submitted run is named"
+      (List.sort String.compare node_ids)
+      (List.filter_map
+         (Safe_ops.json_string_opt "composition_node_id")
+         submitted_node_rows
+       |> List.sort String.compare))
+
 (* ── Redaction: tool names do not suppress evidence ────────────── *)
 
 let test_sensitive_named_tool_logged_with_redaction () =
@@ -1548,6 +1642,8 @@ let () =
         ; eio_test "exact AGENT_CORE occurrence" test_exact_agent_core_occurrence_persisted
         ; eio_test "composition action context"
             test_composition_action_context_persisted
+        ; eio_test "composition rows separate submitted from autonomous turn"
+            test_composition_rows_separate_submitted_from_autonomous_turn
         ] )
     ; ( "redaction",
         [ eio_test "sensitive-named tool logged with redaction"


### PR DESCRIPTION
## 문제

E0 캠페인 미션 RW17(`typed_inline_and_async_tool_composition`)이 r6·r7 두 라운드 연속 실패했습니다. r7은 요구된 14개 턴이 모두 정상(14/14)인데도 builder-b의 합성 실행 2건이 **무귀속(unattributed)** 으로 남아 exactly-once 위반으로 판정됐습니다.

```
composition_inline_observed: passed=false
  exact completed inline runs=14/14 errors=[]
  unattributed=[('builder-b', '01a013a6-5ac4-...'), ('builder-b', '01a013a6-eee9-...')]
```

## 원인 체인

**1. 증거: 무귀속 행은 자율 턴이 만든 것이었습니다.**

`~/.masc/tool_calls/2026-08/18.jsonl`의 두 run(각 4개 노드 행)은 모두 `rw-e0-r7-20260818-build-b`의 `keeper_turn_id: 3`에 찍혀 있습니다. 이 키퍼의 원본 트레이스를 보면 턴 성격이 갈립니다.

| raw trace | 시각(UTC) | 프롬프트 | compose 호출 |
|---|---|---|---|
| `turn-1787035962948-…` | 06:52:42 | `먼저 keeper_compose_mission-snapshot을 정확히 한 번 호출하고…` | **1회** |
| `turn-1787036024311-…` | 06:53:44 | `Continue.` | 2회 |

미션 지시를 받은 턴은 지시대로 정확히 한 번 호출했습니다. 나머지 2회는 그런 지시가 없는 자율 턴에서 나왔습니다. r6도 같은 모양입니다 — 무귀속 8건 중 6건이 autonomous 턴(`turn-records`의 `turn_kind`로 대조 확인), 나머지 2건만 coordinator가 한 direct 턴 안에서 실제로 두 번 부른 진짜 위반(#28977의 원래 관찰)입니다.

**2. 코드: 턴 성격이 행까지 도달하지 않습니다.**

- `Keeper_agent_run.run_turn`은 `~turn_kind:Turn_record.turn_kind`를 이미 받습니다(`lib/keeper/keeper_agent_run.ml:391`). 즉 사실은 턴 생성 시점에 존재합니다.
- 그런데 이 값은 turn-record writer(`keeper_agent_run.ml:1302`)까지만 가고 `prepare_agent_setup`으로 넘어가지 않았습니다. 그래서 `Keeper_run_tools_hooks.ctx`에 필드가 없고, 턴 컨텍스트를 찍는 지점(`keeper_run_tools_hooks.ml:522`의 `set_turn_context`)이 이 값을 알 수 없었습니다.
- 결과적으로 `Keeper_tool_call_log_context.turn_context`에도, 두 writer(`keeper_hooks_agent_core.ml:517`, `keeper_tool_composition_surface.ml:88`)가 쓰는 행에도 턴 성격이 남지 않았습니다.

**3. 그래서 판정이 시계에 의존합니다.**

행에는 `trace_id`, `keeper_turn_id`, `turn`, `lane`이 있지만 "이 호출이 제출된 작업의 턴에서 났는지, 키퍼 자율 턴에서 났는지"를 말해주는 값이 없습니다. 러너는 제출 작업의 벽시계 구간(`operation_started_at`~`completed_at`)으로 행을 묶을 수밖에 없고, 제출 도중에 자율 턴이 돌던 키퍼는 자기 합성 실행이 어느 구간에도 안 들어가 무귀속으로 떨어집니다.

**검토했다가 반증된 가설**: run_id를 성공 시점에 발급한다는 가설(d)은 사실이 아닙니다. `Keeper_tool_plan.Run_id.fresh ()`는 인라인 실행 시작 시점에 발급되고(`keeper_tool_composition_surface.ml:810`), 모든 노드 행이 그 값을 공유합니다. async 경로도 같은 스냅샷을 씁니다(`:788`). 태그 누락이나 disposition별 누락도 없었습니다 — 무귀속 행 10개 전부 `composition_run_id`/`node_id`/`execution` 태그가 온전했습니다.

## 수정

턴 생성 시점에 이미 아는 사실을 행까지 나릅니다.

- `run_turn` → `prepare_agent_setup` → `Keeper_run_tools_hooks.ctx` → `set_turn_context`로 `turn_kind`를 전달합니다. 타입은 문자열이 아니라 기존 `Turn_record.turn_kind` variant을 그대로 씁니다.
- `Keeper_tool_call_log.log_call`이 `turn_kind`를 받아 행에 씁니다. 두 writer(일반 도구 호출, 합성 노드 행) 모두 전달하므로 합성 노드 행도 같은 값을 갖습니다.
- 키퍼 턴 밖에서 쓰이는 runtime MCP 경로(`mcp_server_eio_call_tool.ml`)는 턴이 없으므로 이 필드를 남기지 않습니다. 없는 턴을 지어내지 않습니다.
- 대시보드 도구호출 인스펙터가 이미 `keeper N · lane …` 스코프 줄을 그리므로 거기에 `turn direct|autonomous`를 함께 보여줍니다.

판정부(`keeper_multi_collaboration_acceptance.py`)는 exactly-once 계약을 **제출된 턴으로 한정**하고, 자율 턴의 합성 실행은 `autonomous=[...]`로 따로 보고합니다. 완화가 아닙니다 — 필드가 없는 행은 하나도 귀속되지 않아 assertion이 그대로 실패합니다(fail closed). coordinator가 한 direct 턴 안에서 두 번 부른 r6 케이스는 여전히 실패로 남습니다.

## 변경 파일

| 파일 | 내용 |
|---|---|
| `lib/keeper_tool_call_log_context.{ml,mli}` | `turn_context`에 `turn_kind` 추가, setter 인자 |
| `lib/keeper_tool_call_log.{ml,mli}` | `log_call ?turn_kind`, 행 JSON `turn_kind` 필드 |
| `lib/keeper/keeper_run_tools_hooks.ml` | `ctx.turn_kind`, `set_turn_context`에 전달 |
| `lib/keeper/keeper_run_tools_setup.ml`, `keeper_run_tools.mli` | `~turn_kind` 인자 |
| `lib/keeper/keeper_agent_run.ml` | 이미 받고 있던 `turn_kind`를 setup으로 전달 |
| `lib/keeper/keeper_hooks_agent_core.ml` | 실행/거부 두 log_call 사이트에 전달 |
| `lib/keeper/keeper_tool_composition_surface.ml` | 합성 노드 행에 전달 |
| `test/test_keeper_tool_call_log.ml` | 귀속 불변식 테스트 추가 |
| `scripts/harness/workload/keeper_multi_collaboration_acceptance.py` | 제출 턴 한정 판정 + 자율 실행 별도 보고 |
| `dashboard/src/api/dashboard-keeper-tool-calls.ts`, `components/keeper-tool-call-inspector.ts` | 인스펙터 노출 |

## 검증

수행한 것:

- `dashboard`: `npx tsc --noEmit` 통과, 인스펙터 테스트 2파일 20건 통과.
- `python3 -m py_compile scripts/harness/workload/keeper_multi_collaboration_acceptance.py` 통과.
- 증거 재확인: r7 raw trace에서 direct 턴의 compose 1회 / autonomous 턴의 2회를 직접 대조, r6 무귀속 8건을 `turn-records`의 `turn_kind`와 전수 대조.

추가한 OCaml 테스트 (`test_keeper_tool_call_log`, 기존 named suite): 한 키퍼·한 trace에서 direct 턴과 autonomous 턴이 각각 4노드 합성 실행을 남길 때, 행이 `turn_kind`로 정확히 갈리고 제출 턴이 자기 run 하나만 소유하는지 확인합니다.

수행하지 않은 것:

- 로컬 `dune build` / OCaml 테스트 실행 (요청에 따라 CI 검증에 맡깁니다). OCaml 변경분은 컴파일 미검증입니다.
- RW17 재판정: 이번 수정 이후 캠페인 라운드에서 `composition_inline_observed`가 실제로 통과하는지 확인이 필요합니다. 판정은 새 필드가 실린 바이너리가 배포된 뒤에 쌓인 행에만 적용됩니다.

Refs #28977

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W86EUm9YkoA3zRU4o4TvtR
