### PR TITLE
feat(keeper): 감사 완료 read-only 서술자 26종 Concurrent 승격 (Stacked on #29012)

### DIFF
--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1211,6 +1211,7 @@ let cluster_policy ?(polling_read = false) ~readonly () =
 
 let cluster_descriptor_with_schema_source
       ?(polling_read = false)
+      ?ordinary_execution_mode
       ~capability_identity
       ~keeper_model_projection
       ~input_schema_source
@@ -1231,6 +1232,7 @@ let cluster_descriptor_with_schema_source
     ~name
     ~description
     ~input_schema
+    ?ordinary_execution_mode
     ~policy
     ~handler
     ()
@@ -1243,7 +1245,8 @@ let cluster_descriptor_with_schema_source
    in 57 — including every Goal tool and [masc_transition], whose canonical
    text is the only place [release] is named. Taking one field from the record
    and re-typing the other beside it is what allowed the drift. *)
-let cluster_descriptor ?(polling_read = false) ~capability_identity
+let cluster_descriptor ?(polling_read = false) ?ordinary_execution_mode
+      ~capability_identity
       ~keeper_model_projection ~id ~name
       ~handler ~readonly ()
   =
@@ -1254,6 +1257,7 @@ let cluster_descriptor ?(polling_read = false) ~capability_identity
   in
   cluster_descriptor_with_schema_source
     ~polling_read
+    ?ordinary_execution_mode
     ~capability_identity
     ~keeper_model_projection
     ~input_schema_source
@@ -1667,27 +1671,34 @@ let masc_board_descriptor board_name =
   let name = Tool_name.Board_name.to_string board_name in
   let operation_policy = Board_tool_registry.operation_policy board_name in
   let readonly = operation_policy.readonly in
+  (* Concurrent rows are the store-read operations: each resolves through
+     [Board_dispatch] into [Board_core] reads that snapshot under
+     [store.mutex] (an [Eio.Mutex]; board_core.mli "Locking + cache
+     invalidation"), or into the [Atomic]-held curation snapshot
+     ([Board_curation.latest_snapshot]). The [maybe_sweep] hook on reads
+     reserves timestamps under the same mutex and hands the work to the
+     flusher fiber. Write operations stay [Serial]. *)
   let ordinary_execution_mode =
     match board_name with
-    | Tool_name.Board_name.Board_stats -> Concurrent
+    | Tool_name.Board_name.Board_stats
+    | Board_curation_read
+    | Board_hearths
+    | Board_list
+    | Board_post_get
+    | Board_profile
+    | Board_search
+    | Board_sub_board_get
+    | Board_sub_board_list -> Concurrent
     | ( Board_cleanup
       | Board_comment
       | Board_comment_vote
-      | Board_curation_read
       | Board_curation_submit
       | Board_delete
-      | Board_hearths
-      | Board_list
       | Board_post
-      | Board_post_get
       | Board_post_update
-      | Board_profile
       | Board_reaction
-      | Board_search
       | Board_sub_board_create
       | Board_sub_board_delete
-      | Board_sub_board_get
-      | Board_sub_board_list
       | Board_sub_board_update
       | Board_vote ) -> Serial
   in
@@ -1762,8 +1773,9 @@ let voice_descriptor name ~readonly =
     ()
 ;;
 
-let task_descriptor ~capability_identity id name ~readonly =
+let task_descriptor ?ordinary_execution_mode ~capability_identity id name ~readonly =
   cluster_descriptor
+    ?ordinary_execution_mode
     ~capability_identity
     ~keeper_model_projection:Internal_name
     ~id:("keeper.task." ^ id)
@@ -1780,8 +1792,9 @@ let task_descriptor ~capability_identity id name ~readonly =
    (Task.Tool / Tool_plan / Tool_run / Tool_agent / Tool_workspace) are not
    schema-registry-backed. The handler routes by descriptor.internal_name
    through the existing typed dispatcher. *)
-let masc_task_descriptor id name ~readonly =
+let masc_task_descriptor ?ordinary_execution_mode id name ~readonly =
   cluster_descriptor
+    ?ordinary_execution_mode
     ~capability_identity:Internal_name_identity
     ~keeper_model_projection:Internal_name
     ~id:("masc.task." ^ id)
@@ -1791,8 +1804,9 @@ let masc_task_descriptor id name ~readonly =
     ()
 ;;
 
-let masc_task_transport_descriptor id name ~readonly =
+let masc_task_transport_descriptor ?ordinary_execution_mode id name ~readonly =
   cluster_descriptor
+    ?ordinary_execution_mode
     ~capability_identity:Internal_name_identity
     ~keeper_model_projection:
       (Transport_alias { projected_by = "keeper_tasks_list" })
@@ -1803,8 +1817,9 @@ let masc_task_transport_descriptor id name ~readonly =
     ()
 ;;
 
-let masc_plan_descriptor id name ~readonly =
+let masc_plan_descriptor ?ordinary_execution_mode id name ~readonly =
   cluster_descriptor
+    ?ordinary_execution_mode
     ~capability_identity:Internal_name_identity
     ~keeper_model_projection:Internal_name
     ~id:("masc.plan." ^ id)
@@ -1814,8 +1829,9 @@ let masc_plan_descriptor id name ~readonly =
     ()
 ;;
 
-let masc_run_descriptor name ~readonly =
+let masc_run_descriptor ?ordinary_execution_mode name ~readonly =
   cluster_descriptor
+    ?ordinary_execution_mode
     ~capability_identity:Internal_name_identity
     ~keeper_model_projection:Internal_name
     ~id:("masc.run." ^ String.sub name (String.length "masc_run_")
@@ -1826,8 +1842,9 @@ let masc_run_descriptor name ~readonly =
     ()
 ;;
 
-let masc_agent_descriptor id name ~readonly =
+let masc_agent_descriptor ?ordinary_execution_mode id name ~readonly =
   cluster_descriptor
+    ?ordinary_execution_mode
     ~capability_identity:Internal_name_identity
     ~keeper_model_projection:Internal_name
     ~id:("masc.agent." ^ id)
@@ -1839,11 +1856,13 @@ let masc_agent_descriptor id name ~readonly =
 
 let masc_workspace_descriptor
     ?(keeper_model_projection = Internal_name)
+    ?ordinary_execution_mode
     id
     name
     ~readonly
   =
   cluster_descriptor
+    ?ordinary_execution_mode
     ~capability_identity:Internal_name_identity
     ~keeper_model_projection
     ~id:("masc.workspace." ^ id)
@@ -1855,8 +1874,9 @@ let masc_workspace_descriptor
 
 (* RFC-0182 §3.1 — additional cluster descriptor helpers (Phase 3:
    misc / control / agent_timeline / local_runtime). *)
-let masc_misc_descriptor id name ~readonly =
+let masc_misc_descriptor ?ordinary_execution_mode id name ~readonly =
   cluster_descriptor
+    ?ordinary_execution_mode
     ~capability_identity:Internal_name_identity
     ~keeper_model_projection:Internal_name
     ~id:("masc.misc." ^ id)
@@ -1881,8 +1901,9 @@ let masc_control_descriptor operation =
     ()
 ;;
 
-let masc_agent_timeline_descriptor name description ~readonly =
+let masc_agent_timeline_descriptor ?ordinary_execution_mode name description ~readonly =
   cluster_descriptor
+    ?ordinary_execution_mode
     ~capability_identity:Internal_name_identity
     ~keeper_model_projection:Internal_name
     ~id:"masc.agent_timeline"
@@ -2031,6 +2052,9 @@ let internal_descriptors : t list =
           keeper_surface_read only for current conversation context. \
           No arguments."
        ~input_schema:empty_object_schema
+       (* Concurrent: pure projection over the boot-time descriptor
+          registry and registered schemas; no shared mutable state. *)
+       ~ordinary_execution_mode:Concurrent
        ~policy:(read_only_in_process_policy ())
        ~handler:Tool_tools_list
        ()
@@ -2056,6 +2080,9 @@ let internal_descriptors : t list =
       ~name:Keeper_tool_runtime_schemas.artifact_read.name
       ~description:Keeper_tool_runtime_schemas.artifact_read.description
       ~input_schema:Keeper_tool_runtime_schemas.artifact_read.input_schema
+      (* Concurrent: content-addressed blob reads; the validated-file
+         cache in Tool_blob_store is an Atomic CAS over an immutable map. *)
+      ~ordinary_execution_mode:Concurrent
       ~policy:(read_only_in_process_policy ())
       ~handler:Tool_artifact_read
       ()
@@ -2091,6 +2118,9 @@ let internal_descriptors : t list =
       ~name:"keeper_library_search"
       ~description:"Search the keeper library catalog."
       ~input_schema:library_search_schema
+      (* Concurrent: directory listing + whole-file reads in
+         Tool_library; no shared mutable state on the search path. *)
+      ~ordinary_execution_mode:Concurrent
       ~policy:(read_only_in_process_policy ())
       ~handler:Tool_library_search
       ()
@@ -2100,6 +2130,7 @@ let internal_descriptors : t list =
       ~name:"keeper_library_read"
       ~description:"Read a library entry by id."
       ~input_schema:library_read_schema
+      ~ordinary_execution_mode:Concurrent
       ~policy:(read_only_in_process_policy ())
       ~handler:Tool_library_read
       ()
@@ -2176,6 +2207,10 @@ let internal_descriptors : t list =
       ~description:Keeper_tool_runtime_schemas.fusion_status.description
       ~input_schema:Keeper_tool_runtime_schemas.fusion_status.input_schema
       (* [Internal_name] is the model exposure authority. *)
+      (* Concurrent: projects an [Atomic.get] snapshot of the fusion run
+         registry (Run_registry_core); mutation goes through its own
+         cross-context mutex on the write side. *)
+      ~ordinary_execution_mode:Concurrent
       ~policy:(read_only_in_process_policy ())
       ~handler:Tool_masc_fusion_status
       ()
@@ -2213,12 +2248,17 @@ let internal_descriptors : t list =
       ~readonly:false
     (* ── task / broadcast cluster (RFC-0179 PR-3, 6 tools) ────── *)
   ; (task_descriptor
+       (* Concurrent: backlog reads go through the mtime/size-keyed cache in
+          Workspace_backlog, whose lookups and refreshes run under a
+          Stdlib.Mutex with no suspension inside the critical section. *)
+       ~ordinary_execution_mode:Concurrent
        ~capability_identity:(Named_capability "masc_tasks")
        "list"
        "keeper_tasks_list"
        ~readonly:true
      |> with_composable_output (Json_output { schema = tasks_list_output_schema }))
   ; task_descriptor
+      ~ordinary_execution_mode:Concurrent
       ~capability_identity:Internal_name_identity
       "audit"
       "keeper_tasks_audit"
@@ -2251,9 +2291,11 @@ let internal_descriptors : t list =
        ~readonly:false
   ; masc_task_descriptor "batch_add" "masc_batch_add_tasks"
        ~readonly:false
-  ; masc_task_descriptor "task_history" "masc_task_history"
+  ; masc_task_descriptor ~ordinary_execution_mode:Concurrent
+       "task_history" "masc_task_history"
        ~readonly:true
-  ; masc_task_transport_descriptor "tasks" "masc_tasks"
+  ; masc_task_transport_descriptor ~ordinary_execution_mode:Concurrent
+       "tasks" "masc_tasks"
        ~readonly:true
   ; masc_task_descriptor "transition" "masc_transition"
        ~readonly:false
@@ -2270,7 +2312,8 @@ let internal_descriptors : t list =
       ~readonly:false
   ; masc_plan_descriptor "set_task" "masc_plan_set_task"
        ~readonly:false
-  ; masc_plan_descriptor "get_task" "masc_plan_get_task"
+  ; masc_plan_descriptor ~ordinary_execution_mode:Concurrent
+       "get_task" "masc_plan_get_task"
        ~readonly:true
   ; masc_plan_descriptor "clear_task" "masc_plan_clear_task"
        ~readonly:false
@@ -2281,7 +2324,8 @@ let internal_descriptors : t list =
   (* ── RFC-0182 §3.1 — masc_run_* cluster (4 entries) ──────────── *)
   ; masc_run_descriptor "masc_run_init"
        ~readonly:false
-  ; (masc_run_descriptor "masc_run_list"
+  ; (masc_run_descriptor ~ordinary_execution_mode:Concurrent
+       "masc_run_list"
        ~readonly:true
      |> with_composable_output (Json_output { schema = run_list_output_schema }))
   ; masc_run_descriptor "masc_run_get"
@@ -2291,15 +2335,18 @@ let internal_descriptors : t list =
   (* ── RFC-0182 §3.1 — masc_agent_* cluster (3 entries; masc_agents +
        masc_agent_update removed 2026-06-09 with the dead agent-status
        surface) ────────── *)
-  ; (masc_agent_descriptor "card" "masc_agent_card"
+  ; (masc_agent_descriptor ~ordinary_execution_mode:Concurrent
+        "card" "masc_agent_card"
         ~readonly:true
      |> with_eval_tags [ "agent_profile_lookup" ]
      |> with_composable_output (Json_output { schema = agent_card_output_schema }))
-  ; (masc_agent_descriptor "fitness" "masc_agent_fitness"
+  ; (masc_agent_descriptor ~ordinary_execution_mode:Concurrent
+       "fitness" "masc_agent_fitness"
        ~readonly:true
      |> with_composable_output
           (Json_output { schema = agent_fitness_output_schema }))
-  ; (masc_agent_descriptor "get_metrics" "masc_get_metrics"
+  ; (masc_agent_descriptor ~ordinary_execution_mode:Concurrent
+       "get_metrics" "masc_get_metrics"
        ~readonly:true
      |> with_composable_output (Json_output { schema = get_metrics_output_schema }))
   (* ── RFC-0182 §3.1 — masc_workspace_* cluster (8 entries) ────────── *)
@@ -2332,7 +2379,8 @@ let internal_descriptors : t list =
        ~readonly:false
   ; masc_workspace_descriptor "check" "masc_check"
        ~readonly:true
-  ; (masc_workspace_descriptor "goal_list" "masc_goal_list"
+  ; (masc_workspace_descriptor ~ordinary_execution_mode:Concurrent
+       "goal_list" "masc_goal_list"
        ~readonly:true
      |> with_composable_output (Json_output { schema = goal_list_output_schema }))
   ; masc_workspace_descriptor "goal_upsert" "masc_goal_upsert"
@@ -2342,7 +2390,8 @@ let internal_descriptors : t list =
   ; masc_workspace_descriptor "goal_transition" "masc_goal_transition"
        ~readonly:false
   (* ── RFC-0182 §3.1 — masc_misc_* cluster (9 entries) ─────────── *)
-  ; masc_misc_descriptor "config" "masc_config"
+  ; masc_misc_descriptor ~ordinary_execution_mode:Concurrent
+       "config" "masc_config"
        ~readonly:true
   ; masc_misc_descriptor "dashboard" "masc_dashboard"
        ~readonly:true
@@ -2354,7 +2403,8 @@ let internal_descriptors : t list =
       ~handler:Tool_masc_misc_dispatch
       ~readonly:true
       ()
-  ; masc_misc_descriptor "tool_help" "masc_tool_help"
+  ; masc_misc_descriptor ~ordinary_execution_mode:Concurrent
+       "tool_help" "masc_tool_help"
        ~readonly:true
   ; masc_misc_descriptor "gc" "masc_gc"
       ~readonly:false
@@ -2366,7 +2416,8 @@ let internal_descriptors : t list =
   ; masc_control_descriptor Tool_schemas_misc.Pause
   ; masc_control_descriptor Tool_schemas_misc.Resume
   (* ── RFC-0182 §3.1 — masc_agent_timeline singleton (1 entry) ── *)
-  ; (masc_agent_timeline_descriptor "masc_agent_timeline"
+  ; (masc_agent_timeline_descriptor ~ordinary_execution_mode:Concurrent
+       "masc_agent_timeline"
        "Read agent timeline events." ~readonly:true
      |> with_composable_output
           (Json_output { schema = agent_timeline_output_schema }))

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -1236,7 +1236,35 @@ let test_concurrent_execution_opt_ins_are_exact () =
   in
   Alcotest.(check (list string))
     "only explicitly audited handlers opt into concurrent batches"
-    [ "keeper_time_now"; "masc_board_stats" ]
+    [ "keeper_artifact_read"
+    ; "keeper_library_read"
+    ; "keeper_library_search"
+    ; "keeper_tasks_audit"
+    ; "keeper_tasks_list"
+    ; "keeper_time_now"
+    ; "keeper_tools_list"
+    ; "masc_agent_card"
+    ; "masc_agent_fitness"
+    ; "masc_agent_timeline"
+    ; "masc_board_curation_read"
+    ; "masc_board_hearths"
+    ; "masc_board_list"
+    ; "masc_board_post_get"
+    ; "masc_board_profile"
+    ; "masc_board_search"
+    ; "masc_board_stats"
+    ; "masc_board_sub_board_get"
+    ; "masc_board_sub_board_list"
+    ; "masc_config"
+    ; "masc_fusion_status"
+    ; "masc_get_metrics"
+    ; "masc_goal_list"
+    ; "masc_plan_get_task"
+    ; "masc_run_list"
+    ; "masc_task_history"
+    ; "masc_tasks"
+    ; "masc_tool_help"
+    ]
     concurrent_internal_names
 
 let test_readonly_policy_is_descriptor_input_aware () =

--- a/test/test_keeper_tool_plan_executor.ml
+++ b/test/test_keeper_tool_plan_executor.ml
@@ -91,7 +91,7 @@ let test_schedule_and_parallel_dataflow () =
   (match batches with
    | [ Executor.Concurrent_batch [ producer ]
      ; Executor.Concurrent_batch [ left; right ]
-     ; Executor.Serial_batch final
+     ; Executor.Concurrent_batch [ final ]
      ] ->
      check int "producer batch index" 0 producer.schedule.batch_index;
      check int "parallel batch index" 1 left.schedule.batch_index;
@@ -101,7 +101,11 @@ let test_schedule_and_parallel_dataflow () =
      check bool
        "parallel execution mode"
        true
-       (left.schedule.execution_mode = Agent_core.Tool_contract.Concurrent)
+       (left.schedule.execution_mode = Agent_core.Tool_contract.Concurrent);
+     check bool
+       "final execution mode"
+       true
+       (final.schedule.execution_mode = Agent_core.Tool_contract.Concurrent)
    | _ -> fail "descriptor-aware schedule shape changed");
   let sibling_count = Atomic.make 0 in
   let observed = ref [] in


### PR DESCRIPTION
> **Stacked PR** — base는 `feat/composable-output-818` (#29012)입니다. 이 PR의 diff는 부모가 머지되기 전까지 부모 커밋을 포함해 보입니다. 부모 머지 후 base를 main으로 바꾸거나 auto-merge를 쓰면 자식 diff가 정화됩니다.

## 목표

동시성 안전이 확인된 read-only 서술자 26개를 기본 `Serial`에서 `Concurrent`로 승격합니다. 지금은 `keeper_time_now`, `masc_board_stats` 단 2개만 Concurrent라, 다중 호출 액션과 합성 fan-out 레이어의 조회 호출이 전부 직렬화됩니다 (`packages/agent_core/lib/agent/agent_tools.ml`의 `Eio.Fiber.List.map` — 같은 배치의 Concurrent 호출만 겹침).

## 변경 파일

- `lib/keeper/keeper_tool_descriptor.ml` — board 실행 모드 match 확장 + cluster helper 체인에 `?ordinary_execution_mode` 관통 + 승격 지점 26곳 명시
- `test/test_keeper_tool_descriptor_registry_integrity.ml` — `test_concurrent_execution_opt_ins_are_exact` 고정 목록 2 → 28

## 실행 모델 (감사의 전제)

- Concurrent 배치는 `Eio.Fiber.List.map` — **단일 도메인 협력형 fiber**입니다. 겹침은 Eio 중단 지점(IO)에서만 발생하고, 중단 없는 구간은 원자적입니다.
- 따라서 감사 기준은 (1) 핸들러 경로의 공유 가변 상태 쓰기, (2) 중단 지점을 걸치는 read-modify-write, (3) 외부 세션/프로세스 부수효과입니다.

## 승격 판정 표 (26개)

| 그룹 | 도구 | 근거 (file:line) |
|---|---|---|
| Board 조회 8종 | `masc_board_list` `masc_board_search` `masc_board_post_get` `masc_board_hearths` `masc_board_profile` `masc_board_curation_read` `masc_board_sub_board_get` `masc_board_sub_board_list` | 모든 읽기가 `store.mutex`(Eio.Mutex) 아래 스냅샷 — `lib/board/board_core.mli` "Locking + cache invalidation", `board_core.ml:41-84` (`get_post_and_comments`는 단일 임계구역으로 통합된 이력 있음). 읽기 훅 `maybe_sweep`은 같은 mutex 아래 타임스탬프만 예약하고 실제 작업은 flusher fiber로 위임 (`board_core_persist.ml:302-330`). curation은 `Atomic.get` 스냅샷 (`board_curation.ml:75-81`). 이미 Concurrent인 `masc_board_stats`와 동일 기계 |
| Backlog 조회 3종 | `keeper_tasks_list` `keeper_tasks_audit` `masc_tasks` | backlog 읽기는 mtime/size 키 캐시 경유 — 조회/갱신 모두 `Stdlib.Mutex.protect` 임계구역이고 내부에 중단 지점 없음 (`lib/workspace/workspace_backlog.ml:38-115`). audit의 `get_active_agents`/`list_tasks`도 읽기 전용 (`workspace_query.ml:175-235,410`) |
| 파일/디렉터리 읽기 10종 | `masc_task_history` `masc_plan_get_task` `masc_run_list` `masc_agent_card` `masc_agent_fitness` `masc_get_metrics` `masc_goal_list` `masc_agent_timeline` `keeper_library_search` `keeper_library_read` | 읽기 경로에 쓰기 없음: 이벤트 JSONL 읽기(`lib/task/tool_task.ml:468-536`), current-task 파일(`lib/task/planning_eio.ml:391`), runs 디렉터리(`lib/run_eio.ml:169`), agents/metrics 디렉터리(`lib/workspace/workspace_query.ml:175`, `lib/metrics_store_eio.ml:218`), goals.json(`lib/goal/goal_store.ml:195,270` — `ensure_dirs`의 mkdir는 멱등), timeline 멀티스토어 리더(`lib/tool_agent_timeline.ml:101-454` — 변조 지점 없음, `keeper_chat_timeline_source.ml`도 읽기 전용), library(`lib/tool_library.ml:171,289`) |
| 인메모리 투영 5종 | `keeper_tools_list` `masc_config` `masc_tool_help` `masc_fusion_status` `keeper_artifact_read` | 부팅 시 구성된 레지스트리 투영(`lib/keeper/keeper_tool_shared_runtime.ml:390`), env 조회(`lib/tool_misc_introspection.ml:113`), 스키마 목록 검색(`lib/tool_misc.ml:100`), fusion run 레지스트리 `Atomic.get` 스냅샷(`lib/run_registry_core.ml:109-157`, 쓰기는 별도 cross-context mutex), blob store의 검증 캐시는 불변 맵 위 Atomic CAS(`lib/tool_blob_store/tool_blob_store.ml:44-66,144`) — 내용주소(sha256) 읽기 |

## 보류 목록 (Serial 유지)

| 도구 | 사유 |
|---|---|
| `keeper_memory_search` | 읽기 도구지만 검색마다 decision-log에 JSONL append (`keeper_tool_memory_runtime.ml:281-300`). append 자체는 per-path mutex로 직렬화되지만 (`fs_compat.ml:199-205`), 로그 회전 검사 `maybe_rotate_file`이 그 mutex **밖**에서 check-then-rename을 수행 (`keeper_types_support.ml:172-190`) — 동시 실행 시 이중 회전 창 존재. 근본 해결은 회전을 append mutex 안으로 이동 |
| `keeper_context_status` | `Keeper_sandbox_control.live_status_json ~include_preflight:true`가 timeout 있는 sandbox 프로브를 실행 (`keeper_tool_memory_runtime.ml:333-340`) — 프로세스 부수효과 |
| `keeper_surface_read` | local lane은 읽기지만 discord 모드가 외부 Discord read API 호출 (`keeper_tool_in_process_runtime.ml:823-853`). 실행 모드는 입력별이 아니라 서술자 단위라 도구 전체 보류 |
| `masc_dashboard` | 핸들러가 부트스트랩 주입 ref(`tool_misc.ml:69-70`) 뒤에 있어 이번 라운드에서 실경로 미확증 |
| `masc_check` | 세션 바인딩 해석 경로(`tool_workspace.ml:462-477`)의 하위 호출까지 전수 확증 못함 |
| `masc_status` `masc_keeper_waiting_inventory` | `Operator_only` 투영 — 모델 주도 다중 호출 표면 대상이 아님 |
| `keeper_vision_analyze_image` `masc_web_search` `masc_web_fetch` | 외부 네트워크/게이트 경로 |

## 구현 방식

- 새 장치 없이 기존 `?ordinary_execution_mode` 파라미터(`in_process_descriptor*`에 이미 존재, `keeper_time_now`가 사용)를 cluster helper 체인(`cluster_descriptor_with_schema_source` → `cluster_descriptor` → 9개 helper)에 관통시키고, 승격 지점 26곳에 `~ordinary_execution_mode:Concurrent`를 명시했습니다.
- board는 helper가 아니라 기존 per-operation match를 확장 — catch-all 없이 전 연산 명시라 새 board 연산 추가 시 스케줄링 판단이 컴파일 타임에 강제됩니다.

## 검증

- 로컬 `dune build` 미수행 (CI 검증). `ocamlc -stop-after parsing` 구문 검사 통과, 참조 값(`?ordinary_execution_mode` 파라미터 존재, helper 시그니처)은 파일로 직접 확인.
- 기존 named suite `test_keeper_tool_descriptor_registry_integrity`의 ratchet 테스트가 승격 집합을 정확히 고정합니다 (감사 없는 추가 승격은 테스트가 거부).

## 미검증 항목

- 실제 동시 부하에서의 관측(예: board read 경합 시 mutex 대기 분포)은 측정하지 않았습니다. 문제가 보이면 이 PR은 서술자 선언만 되돌리면 됩니다(핸들러 무변경).
- `masc_dashboard`/`masc_check`는 감사 미완으로 보류했으며 후속에서 경로 확증 후 승격 가능합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
