### PR TITLE
fix(board): sub-board creation stops swallowing its durable append (#29004)

### DIFF
--- a/lib/board/board_core.ml
+++ b/lib/board/board_core.ml
@@ -690,9 +690,10 @@ let append_sub_board (sb : sub_board) =
   try
     ensure_masc_dir ();
     let path = sub_boards_path () in
-    Fs_compat.append_file path (Yojson.Safe.to_string (sub_board_to_yojson sb) ^ "\n")
+    Fs_compat.append_file path (Yojson.Safe.to_string (sub_board_to_yojson sb) ^ "\n");
+    Ok ()
   with
-  | Sys_error msg -> record_persist_error ~where:"append_sub_board" msg
+  | Sys_error msg -> persist_io_error ~where:"append_sub_board" msg
 ;;
 
 let valid_slug_pattern = Re.Pcre.re {|^[a-z0-9][a-z0-9_-]*$|} |> Re.compile
@@ -726,7 +727,14 @@ let create_sub_board
       (match parse_sub_board_members ~owner:owner_id members with
        | Error e -> Error e
        | Ok members ->
-         let result =
+         (* Write-ahead (#29004, same class as #28934/#28952): validate
+            under [with_lock] with no mutation, durably append outside
+            the store mutex, then commit under [with_lock] from a fresh
+            read. The previous shape mutated first and swallowed the
+            append error ([record_persist_error] + unit): a failed
+            append still returned [Ok sb] whose sub-board existed only
+            in memory and vanished on restart. *)
+         let staged =
            with_lock store (fun () ->
              if Hashtbl.mem store.sub_boards_by_slug slug
              then
@@ -734,7 +742,7 @@ let create_sub_board
                  (Already_exists (Printf.sprintf "Sub-board slug %S already exists" slug))
              else (
                  let id = Sub_board_id.generate () in
-                 let sb =
+                 Ok
                    { id
                    ; slug
                    ; name = String.trim name
@@ -744,17 +752,38 @@ let create_sub_board
                    ; access
                    ; created_at = Time_compat.now ()
                    ; post_count = 0
-                   }
-                 in
-                 Hashtbl.replace store.sub_boards (Sub_board_id.to_string id) sb;
-                 Hashtbl.replace store.sub_boards_by_slug slug (Sub_board_id.to_string id);
-                 Ok sb))
+                   }))
          in
-         (match result with
+         (match staged with
+          | Error _ as e -> e
           | Ok sb ->
-            with_persist_lock store (fun () -> append_sub_board sb);
-            Ok sb
-          | Error _ as e -> e)))
+            (match with_persist_lock store (fun () -> append_sub_board sb) with
+             | Error _ as e -> e
+             | Ok () ->
+               let committed =
+                 with_lock store (fun () ->
+                   if Hashtbl.mem store.sub_boards_by_slug slug
+                   then
+                     Error
+                       (Already_exists
+                          (Printf.sprintf "Sub-board slug %S already exists" slug))
+                   else (
+                     Hashtbl.replace store.sub_boards (Sub_board_id.to_string sb.id) sb;
+                     Hashtbl.replace
+                       store.sub_boards_by_slug
+                       slug
+                       (Sub_board_id.to_string sb.id);
+                     Ok sb))
+               in
+               (match committed with
+                | Ok _ as ok -> ok
+                | Error _ as e ->
+                  (* Lost a same-slug race after the append: the orphan
+                     row would shadow the winner on restart (the loader
+                     is last-row-wins per slug), so rewrite the snapshot
+                     from the committed store now. *)
+                  rewrite_sub_boards store;
+                  e)))))
 ;;
 
 

--- a/lib/board/board_core_persist.mli
+++ b/lib/board/board_core_persist.mli
@@ -27,6 +27,12 @@ val flusher_schedule_dropped_count : unit -> int
 val persist_error_count : unit -> int
 val record_persist_error : where:string -> string -> unit
 
+(** [persist_io_error ~where msg] records the failure via
+    {!record_persist_error} and returns the typed
+    [Error (Io_error "<where>: <msg>")] the append paths surface to
+    their callers. *)
+val persist_io_error : where:string -> string -> ('a, board_error) result
+
 val create_store : unit -> store
 
 val invalidate_post_caches : store -> unit

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -328,6 +328,7 @@ normal_targets=(
   @test/runtest-test_board_vote_persistence
   @test/runtest-test_log_ring_bounds
   @test/runtest-test_board_comment_post_write_ahead
+  @test/runtest-test_board_sub_board_write_ahead
   @test/runtest-test_keeper_event_queue
   @test/runtest-test_keeper_event_queue_owner_lock
   @test/runtest-test_keeper_event_queue_persist_poison

--- a/test/dune
+++ b/test/dune
@@ -1066,6 +1066,7 @@
   test_board_sort
   test_board_vote_persistence
   test_board_comment_post_write_ahead
+  test_board_sub_board_write_ahead
   test_board_karma_ledger
   test_workspace_task_delete
   test_workspace_task_lifecycle
@@ -1206,6 +1207,7 @@
   test_board_sort
   test_board_vote_persistence
   test_board_comment_post_write_ahead
+  test_board_sub_board_write_ahead
   test_board_karma_ledger
   test_workspace_task_delete
   test_workspace_task_lifecycle

--- a/test/test_board_sub_board_write_ahead.ml
+++ b/test/test_board_sub_board_write_ahead.ml
@@ -1,0 +1,111 @@
+(** Write-ahead durability for sub-board creation (#29004).
+
+    create_sub_board previously mutated the in-memory store, then ran
+    a durable append whose failure was swallowed (persist-error
+    counter + unit): the caller got [Ok sb] for a sub-board that
+    existed only in memory and vanished on restart — the silent
+    persist failure class. These tests pin the converted contract:
+
+    - a failed durable append commits nothing and surfaces a typed
+      [Io_error];
+    - the same call succeeds once the disk is healthy again;
+    - a successful create is durable across a restart with no
+      snapshot flush in between. *)
+
+open Masc
+
+let () = Mirage_crypto_rng_unix.use_default ()
+let () = Random.self_init ()
+
+let fresh_test_base_path () =
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-test-subboard-wa-%06x" (Random.bits ()))
+  in
+  Unix.putenv "MASC_BASE_PATH" dir;
+  dir
+
+(* Replaces the board's [.masc] directory with a regular file so any
+   subsequent [Fs_compat.mkdir_p]/[append_file] under it raises
+   [Sys_error] (ENOTDIR). Same fixture as
+   [test_board_vote_persistence.ml], duplicated per that suite's
+   per-file fixture convention. *)
+let block_board_masc_dir_with_file () =
+  let base =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-test-subboard-wa-blocked-%06x" (Random.bits ()))
+  in
+  Unix.putenv "MASC_BASE_PATH" base;
+  let masc_dir = Filename.dirname (Board.persist_path ()) in
+  Fs_compat.mkdir_p (Filename.dirname masc_dir);
+  Fs_compat.save_file masc_dir "not a directory";
+  base
+
+let with_eio f () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  ignore (fresh_test_base_path ());
+  Board.reset_global_for_test ();
+  Board_dispatch.reset_for_test ();
+  Board_dispatch.init_jsonl ();
+  f ()
+
+let create ~slug =
+  Board_dispatch.create_sub_board ~slug ~name:"WA" ~description:"write-ahead"
+    ~owner:"subboard-wa-owner" ()
+
+let find_by_slug slug =
+  Board_dispatch.list_sub_boards ()
+  |> List.find_opt (fun (sb : Board.sub_board) -> String.equal sb.slug slug)
+
+let test_failed_append_commits_nothing () =
+  let working_base =
+    Sys.getenv_opt "MASC_BASE_PATH" |> Option.value ~default:""
+  in
+  ignore (block_board_masc_dir_with_file ());
+  let before_errors = Board.persist_error_count () in
+  (match create ~slug:"wa-blocked" with
+   | Ok _ -> Alcotest.fail "create must not succeed when the append fails"
+   | Error (Board.Io_error _) -> ()
+   | Error e ->
+     Alcotest.fail ("expected Io_error, got " ^ Board.show_board_error e));
+  Alcotest.(check bool)
+    "persist error counter incremented" true
+    (Board.persist_error_count () > before_errors);
+  Unix.putenv "MASC_BASE_PATH" working_base;
+  (* Nothing was committed: the same slug is free once the disk is
+     healthy again. *)
+  (match create ~slug:"wa-blocked" with
+   | Ok _ -> ()
+   | Error e ->
+     Alcotest.fail ("retry must succeed, got " ^ Board.show_board_error e));
+  match find_by_slug "wa-blocked" with
+  | Some _ -> ()
+  | None -> Alcotest.fail "retried sub-board missing from the store"
+
+let test_create_is_durable_across_restart () =
+  (match create ~slug:"wa-durable" with
+   | Ok _ -> ()
+   | Error e -> Alcotest.fail (Board.show_board_error e));
+  (* No snapshot flush: the append alone must carry the sub-board
+     across a restart. *)
+  Board.reset_global_for_test ();
+  Board_dispatch.reset_for_test ();
+  Board_dispatch.init_jsonl ();
+  match find_by_slug "wa-durable" with
+  | Some sb ->
+    Alcotest.(check string) "slug survives restart" "wa-durable" sb.Board.slug
+  | None -> Alcotest.fail "sub-board lost across restart"
+
+let () =
+  Alcotest.run "board_sub_board_write_ahead"
+    [
+      ( "durability",
+        [
+          Alcotest.test_case "failed append leaves nothing committed" `Quick
+            (with_eio test_failed_append_commits_nothing);
+          Alcotest.test_case "create is durable across restart" `Quick
+            (with_eio test_create_is_durable_across_restart);
+        ] );
+    ]


### PR DESCRIPTION
## As-Is
`append_sub_board`가 Sys_error를 `record_persist_error`로 삼키고 unit 반환 → `create_sub_board`는 append가 실패해도 `Ok sb`를 돌려주고, 그 sub-board는 메모리에만 존재하다 재시작 시 증발 (#29004, silent persist failure). vote(#28934)·comment/post(#29003) 전환 후 남은 마지막 생성 경로.

## To-Be
- `append_sub_board`가 typed Result 반환 (`persist_io_error` — 에러 카운터 동작 불변).
- `create_sub_board`를 동일한 3단계 write-ahead로 전환 (stage 무변이 검증 → durable append → fresh-read commit).
- append 후 same-slug 레이스에서 지면 즉시 `rewrite_sub_boards` — 로더가 slug별 last-row-wins라 고아 row가 재시작 시 승자를 가리는 걸 차단.

## 검증
- feature test 2케이스 (ENOTDIR 주입 픽스처 재사용): 실패 append는 아무것도 커밋 안 함(typed Io_error + 카운터 증가 + 재시도 성공), 성공 create는 flush 없이 재시작을 건너 지속.
- 로컬 dune build 미실행(repo 방침) — CI 판정. ocamlformat 파싱 2/2, git diff --check clean.

Refs #29004