### PR TITLE
feat(wire-capture): rotate the full day file instead of dropping new records

### DIFF
--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -8,6 +8,7 @@
       base_dir/
         2026-03/
           20.jsonl
+          21.001.jsonl   (completed size-rotation segment of day 21)
           21.jsonl
         2026-04/
           01.jsonl
@@ -238,10 +239,19 @@ let list_month_dirs base_dir =
     && d.[4] = '-'
     && Option.is_some (int_of_string_opt (String.sub d 0 4)))
 
-(** Day files matching [DD.jsonl], newest first. *)
+(** Day files matching [DD.jsonl] or [DD.NNN.jsonl], newest first. *)
 let list_day_files month_path =
   list_subdirs month_path
   |> List.filter (fun f -> Filename.check_suffix f ".jsonl")
+
+(* The day number is always the leading two characters — for both the
+   current [DD.jsonl] and rotated [DD.NNN.jsonl] segments.
+   [Filename.remove_extension] must not be used for this: it maps a
+   segment to ["DD.NNN"], which compares greater than its own day and
+   silently drops segments from range boundaries. *)
+let day_number_of_day_file_name name =
+  if String.length name >= 2 then String.sub name 0 2 else name
+;;
 
 type directory_presence =
   | Directory_present
@@ -312,14 +322,36 @@ let month_directory_name_is_valid name =
   Option.is_some (year_and_month_of_directory_name name)
 ;;
 
-let day_file_name_is_valid ~year ~month name =
-  String.length name = 8
-  && String.equal (String.sub name 2 6) ".jsonl"
-  && substring_is_ascii_digits name ~position:0 ~length:2
-  &&
-  match int_of_string_opt (String.sub name 0 2), days_in_month ~year month with
+(* [DD.jsonl] is the day's current append target; [DD.NNN.jsonl] is a
+   completed size-rotation segment of the same day (see
+   [append_rotating]). Lexicographic name order places a day's segments
+   after the previous day and before the day's current file, so the
+   newest-first listings, the oldest-first prune order, and range
+   selection all order them correctly with no special cases. *)
+let rotation_sequence_digits = 3
+let rotated_segment_name_length = 12 (* "DD." + NNN + ".jsonl" *)
+
+let day_number_is_valid ~year ~month day_text =
+  match int_of_string_opt day_text, days_in_month ~year month with
   | Some day, Some maximum -> day >= 1 && day <= maximum
   | None, _ | _, None -> false
+;;
+
+let day_file_name_is_valid ~year ~month name =
+  let is_current_shape =
+    String.length name = 8
+    && String.equal (String.sub name 2 6) ".jsonl"
+    && substring_is_ascii_digits name ~position:0 ~length:2
+  in
+  let is_rotated_segment_shape =
+    String.length name = rotated_segment_name_length
+    && Char.equal name.[2] '.'
+    && String.equal (String.sub name 6 6) ".jsonl"
+    && substring_is_ascii_digits name ~position:0 ~length:2
+    && substring_is_ascii_digits name ~position:3 ~length:rotation_sequence_digits
+  in
+  (is_current_shape || is_rotated_segment_shape)
+  && day_number_is_valid ~year ~month (String.sub name 0 2)
 ;;
 
 (* A name this layout can never produce is a foreign file, not a corrupted
@@ -786,7 +818,37 @@ let prune_to_max_bytes_unlocked t ~max_bytes ~keep_path =
 
 (* ── Public API ───────────────────────────────────────── *)
 
-let append_unlocked ?max_current_file_bytes t json =
+type append_outcome =
+  | Appended_to_current
+  | Appended_after_rotation of { segment : string }
+  | Skipped_rotation_exhausted of { sequence_limit : int }
+  | Skipped_by_append_guard
+
+(* Shared post-append maintenance for every append entry point:
+   opportunistic once-per-process-day retention prune, then best-effort
+   byte-budget prune that never touches the current day file. Divergence
+   between append paths here would give the same store two different
+   retention behaviours, so both call this one helper. *)
+let run_post_append_pruning_unlocked t ~(dated : Jsonl_writer.dated_path) =
+  (match t.retention_days with
+   | None -> ()
+   | Some days ->
+     let today = dated.month_dir ^ "/" ^ dated.day_file in
+     if
+       not
+         (Option.equal String.equal (Atomic.get t.last_prune_day) (Some today))
+     then begin
+       (* See retention pruning is opportunistic after append durability. *)
+       ignore (prune_unlocked t ~days : int);
+       Atomic.set t.last_prune_day (Some today)
+     end);
+  match t.max_bytes with
+  | None -> ()
+  | Some max_bytes ->
+    (* See byte-budget pruning is best-effort cleanup after append. *)
+    ignore (prune_to_max_bytes_unlocked t ~max_bytes ~keep_path:dated.path : int)
+
+let append_unlocked t json =
   let mutex = Atomic.get t.mutex in
   (* [use_ro] serializes file appends without poisoning the shared mutex on
      IO failure, so retry paths can keep using the same registry entry.
@@ -798,50 +860,91 @@ let append_unlocked ?max_current_file_bytes t json =
      was a pre-emptive duplicate of that guarantee — removed here. *)
   Eio.Mutex.use_ro mutex (fun () ->
     let dated = Jsonl_writer.dated_path_now ~base_dir:t.base_dir in
-    let fits_current_file =
-      match max_current_file_bytes with
-      | Some max_bytes when max_bytes > 0 ->
-        let row_bytes = String.length (Yojson.Safe.to_string json) + 1 in
-        file_size dated.path + row_bytes <= max_bytes
-      | _ -> true
-    in
-    if not fits_current_file
-    then false
-    else begin
-      Jsonl_writer.append_jsonl ~path:dated.path json;
-      (match t.retention_days with
-       | None -> ()
-       | Some days ->
-         let today = dated.month_dir ^ "/" ^ dated.day_file in
-         if
-           not
-             (Option.equal String.equal
-                (Atomic.get t.last_prune_day)
-                (Some today))
-         then begin
-           (* See retention pruning is opportunistic after append durability. *)
-           ignore (prune_unlocked t ~days : int);
-           Atomic.set t.last_prune_day (Some today)
-         end);
-      (match t.max_bytes with
-       | None -> ()
-       | Some max_bytes ->
-         (* See byte-budget pruning is best-effort cleanup after append. *)
-         ignore
-           (prune_to_max_bytes_unlocked t ~max_bytes ~keep_path:dated.path : int));
-      true
-    end)
+    Jsonl_writer.append_jsonl ~path:dated.path json;
+    run_post_append_pruning_unlocked t ~dated)
 
-let append_inner t json = ignore (append_unlocked t json : bool)
+let append_inner t json = append_unlocked t json
 
 let append t json =
   (Atomic.get append_guard) (fun () -> append_inner t json)
 
-let append_if_current_file_fits t ~max_current_file_bytes json =
-  let appended = ref false in
+let max_rotation_sequence = 999 (* the [NNN] name space of [DD.NNN.jsonl] *)
+
+let rotated_segment_name ~day_prefix ~sequence =
+  Printf.sprintf "%s.%0*d.jsonl" day_prefix rotation_sequence_digits sequence
+
+(* Highest existing rotation sequence for [day_prefix] plus one. Scans
+   names structurally ([DD.NNN.jsonl] for this day) rather than keeping
+   a counter, so restarts and foreign writers cannot desynchronise it. *)
+let next_rotation_sequence ~month_path ~day_prefix =
+  let day_dot = day_prefix ^ "." in
+  list_subdirs month_path
+  |> List.fold_left
+       (fun highest name ->
+          if
+            String.length name = rotated_segment_name_length
+            && String.starts_with ~prefix:day_dot name
+            && substring_is_ascii_digits name ~position:3
+                 ~length:rotation_sequence_digits
+            && String.equal (String.sub name 6 6) ".jsonl"
+          then
+            match
+              int_of_string_opt (String.sub name 3 rotation_sequence_digits)
+            with
+            | Some sequence -> Stdlib.Int.max highest sequence
+            | None -> highest
+          else highest)
+       0
+  |> ( + ) 1
+
+let append_rotating_unlocked t ~max_current_file_bytes json =
+  let mutex = Atomic.get t.mutex in
+  Eio.Mutex.use_ro mutex (fun () ->
+    let dated = Jsonl_writer.dated_path_now ~base_dir:t.base_dir in
+    let row_bytes = String.length (Yojson.Safe.to_string json) + 1 in
+    let current_bytes = file_size dated.path in
+    let placement =
+      if
+        max_current_file_bytes <= 0
+        || current_bytes + row_bytes <= max_current_file_bytes
+      then Some Appended_to_current
+      else if current_bytes = 0
+      then
+        (* A single row larger than the cap: rotating an empty file out
+           would spin forever without ever accepting the row. The row
+           lands, the segment runs oversized once, and the next append
+           rotates it out. *)
+        Some Appended_to_current
+      else begin
+        let month_path = Filename.dirname dated.path in
+        let day_prefix = day_number_of_day_file_name dated.day_file in
+        let sequence = next_rotation_sequence ~month_path ~day_prefix in
+        if sequence > max_rotation_sequence
+        then None
+        else begin
+          let segment = rotated_segment_name ~day_prefix ~sequence in
+          (* Same pre-rename step as [prepare_for_directory_removal]:
+             drop any cached writer for the old identity before the
+             rename so the next append opens the fresh file. *)
+          Fs_compat.invalidate_cached_writer dated.path;
+          Sys.rename dated.path (Filename.concat month_path segment);
+          Some (Appended_after_rotation { segment })
+        end
+      end
+    in
+    match placement with
+    | None ->
+      Skipped_rotation_exhausted { sequence_limit = max_rotation_sequence }
+    | Some outcome ->
+      Jsonl_writer.append_jsonl ~path:dated.path json;
+      run_post_append_pruning_unlocked t ~dated;
+      outcome)
+
+let append_rotating t ~max_current_file_bytes json =
+  let outcome = ref Skipped_by_append_guard in
   (Atomic.get append_guard) (fun () ->
-    appended := append_unlocked ~max_current_file_bytes t json);
-  !appended
+    outcome := append_rotating_unlocked t ~max_current_file_bytes json);
+  !outcome
 
 let set_append_guard guard = Atomic.set append_guard guard
 
@@ -1077,7 +1180,7 @@ let iter_range_entries_result t ~since ~until f =
       && String.compare month until_month <= 0
     in
     let day_in_range month day =
-      let day_number = Filename.remove_extension day in
+      let day_number = day_number_of_day_file_name day in
       not
         ((String.equal month since_month
           && String.compare day_number since_day < 0)
@@ -1137,7 +1240,7 @@ let iter_range t ~since ~until f =
         let month_path = Filename.concat t.base_dir m in
         let days = list_day_files month_path |> List.rev in
         List.iter (fun d ->
-          let day_num = Filename.remove_extension d in
+          let day_num = day_number_of_day_file_name d in
           let dominated =
             (m = since_month && String.compare day_num since_day < 0)
             || (m = until_month && String.compare day_num until_day > 0)
@@ -1293,7 +1396,7 @@ let filter_map_range_recent ?(offset = 0) t ~since ~until n ~f =
                 List.iter
                   (fun d ->
                      if !count >= n then raise_notrace Done;
-                     let day_num = Filename.remove_extension d in
+                     let day_num = day_number_of_day_file_name d in
                      let dominated =
                        (m = since_month && String.compare day_num since_day < 0)
                        || (m = until_month && String.compare day_num until_day > 0)

--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -897,54 +897,10 @@ let next_rotation_sequence ~month_path ~day_prefix =
        0
   |> ( + ) 1
 
-let append_rotating_unlocked t ~max_current_file_bytes json =
-  let mutex = Atomic.get t.mutex in
-  Eio.Mutex.use_ro mutex (fun () ->
-    let dated = Jsonl_writer.dated_path_now ~base_dir:t.base_dir in
-    let row_bytes = String.length (Yojson.Safe.to_string json) + 1 in
-    let current_bytes = file_size dated.path in
-    let placement =
-      if
-        max_current_file_bytes <= 0
-        || current_bytes + row_bytes <= max_current_file_bytes
-      then Some Appended_to_current
-      else if current_bytes = 0
-      then
-        (* A single row larger than the cap: rotating an empty file out
-           would spin forever without ever accepting the row. The row
-           lands, the segment runs oversized once, and the next append
-           rotates it out. *)
-        Some Appended_to_current
-      else begin
-        let month_path = Filename.dirname dated.path in
-        let day_prefix = day_number_of_day_file_name dated.day_file in
-        let sequence = next_rotation_sequence ~month_path ~day_prefix in
-        if sequence > max_rotation_sequence
-        then None
-        else begin
-          let segment = rotated_segment_name ~day_prefix ~sequence in
-          (* Same pre-rename step as [prepare_for_directory_removal]:
-             drop any cached writer for the old identity before the
-             rename so the next append opens the fresh file. *)
-          Fs_compat.invalidate_cached_writer dated.path;
-          Sys.rename dated.path (Filename.concat month_path segment);
-          Some (Appended_after_rotation { segment })
-        end
-      end
-    in
-    match placement with
-    | None ->
-      Skipped_rotation_exhausted { sequence_limit = max_rotation_sequence }
-    | Some outcome ->
-      Jsonl_writer.append_jsonl ~path:dated.path json;
-      run_post_append_pruning_unlocked t ~dated;
-      outcome)
-
-let append_rotating t ~max_current_file_bytes json =
-  let outcome = ref Skipped_by_append_guard in
-  (Atomic.get append_guard) (fun () ->
-    outcome := append_rotating_unlocked t ~max_current_file_bytes json);
-  !outcome
+(* [append_rotating] lives after the file-count cache below: rotation
+   must drop the current file's cache entry, and a fresh file that
+   happens to regrow to the cached byte boundary would otherwise return
+   the rotated-out file's count. *)
 
 let set_append_guard guard = Atomic.set append_guard guard
 
@@ -1353,6 +1309,60 @@ let count_entries = count_entries_incremental
 let reset_count_cache_for_testing () =
   Stdlib.Mutex.protect file_count_cache_mu (fun () -> Hashtbl.reset file_count_cache)
 ;;
+
+let append_rotating_unlocked t ~max_current_file_bytes json =
+  let mutex = Atomic.get t.mutex in
+  Eio.Mutex.use_ro mutex (fun () ->
+    let dated = Jsonl_writer.dated_path_now ~base_dir:t.base_dir in
+    let row_bytes = String.length (Yojson.Safe.to_string json) + 1 in
+    let current_bytes = file_size dated.path in
+    let placement =
+      if
+        max_current_file_bytes <= 0
+        || current_bytes + row_bytes <= max_current_file_bytes
+      then Some Appended_to_current
+      else if current_bytes = 0
+      then
+        (* A single row larger than the cap: rotating an empty file out
+           would spin forever without ever accepting the row. The row
+           lands, the segment runs oversized once, and the next append
+           rotates it out. *)
+        Some Appended_to_current
+      else begin
+        let month_path = Filename.dirname dated.path in
+        let day_prefix = day_number_of_day_file_name dated.day_file in
+        let sequence = next_rotation_sequence ~month_path ~day_prefix in
+        if sequence > max_rotation_sequence
+        then None
+        else begin
+          let segment = rotated_segment_name ~day_prefix ~sequence in
+          (* Same pre-rename steps as [prepare_for_directory_removal]:
+             drop the cached writer for the old identity, and drop the
+             file-count entry — a fresh file that regrows to exactly
+             the cached byte boundary would otherwise serve the
+             rotated-out file's count. *)
+          Fs_compat.invalidate_cached_writer dated.path;
+          Stdlib.Mutex.protect file_count_cache_mu (fun () ->
+            Hashtbl.remove file_count_cache dated.path);
+          Sys.rename dated.path (Filename.concat month_path segment);
+          Some (Appended_after_rotation { segment })
+        end
+      end
+    in
+    match placement with
+    | None ->
+      Skipped_rotation_exhausted { sequence_limit = max_rotation_sequence }
+    | Some outcome ->
+      Jsonl_writer.append_jsonl ~path:dated.path json;
+      run_post_append_pruning_unlocked t ~dated;
+      outcome)
+
+let append_rotating t ~max_current_file_bytes json =
+  let outcome = ref Skipped_by_append_guard in
+  (Atomic.get append_guard) (fun () ->
+    outcome := append_rotating_unlocked t ~max_current_file_bytes json);
+  !outcome
+
 let read_range t ~since ~until =
   let collected = ref [] in
   iter_range t ~since ~until (fun json -> collected := json :: !collected);

--- a/lib/dated_jsonl/dated_jsonl.mli
+++ b/lib/dated_jsonl/dated_jsonl.mli
@@ -85,13 +85,36 @@ val append : t -> Yojson.Safe.t -> unit
 (** Append [json] to today's [DD.jsonl] inside [YYYY-MM/].
     Creates directories as needed.  Thread-safe via internal mutex. *)
 
-val append_if_current_file_fits :
-  t -> max_current_file_bytes:int -> Yojson.Safe.t -> bool
-(** Append [json] only when today's current [DD.jsonl] would remain at or
-    below [max_current_file_bytes] after the row is added. Returns [true] when
-    appended and [false] when skipped. The size check and append share the
-    same internal mutex as {!append}. Retention and completed-file byte pruning
-    still run after a successful append. *)
+type append_outcome =
+  | Appended_to_current
+      (** The row landed in today's current [DD.jsonl]. *)
+  | Appended_after_rotation of { segment : string }
+      (** Today's file reached the cap and was renamed to the completed
+          segment [DD.NNN.jsonl] named here; the row landed in a fresh
+          current file. *)
+  | Skipped_rotation_exhausted of { sequence_limit : int }
+      (** The day already holds [sequence_limit] rotated segments — the
+          [NNN] name space is spent — so the row was dropped. *)
+  | Skipped_by_append_guard
+      (** The installed {!set_append_guard} declined to run the append. *)
+
+val append_rotating :
+  t -> max_current_file_bytes:int -> Yojson.Safe.t -> append_outcome
+(** Append [json] to today's current [DD.jsonl], rotating the file to a
+    completed [DD.NNN.jsonl] segment first when the row would push it
+    over [max_current_file_bytes] (a non-positive cap never rotates).
+    Rotated segments are ordinary completed files: readers include them
+    in day order, and the [?max_bytes] byte-budget prune from {!create}
+    removes the oldest of them first while the current file survives —
+    so a capped store keeps the newest records and sheds the oldest,
+    instead of dropping new rows for the rest of the day.
+
+    A single row larger than the cap lands in an empty current file
+    anyway (the segment runs oversized once) — rotating an empty file
+    out would spin without ever accepting the row. The size check,
+    rename, and append share the same internal mutex as {!append};
+    retention and byte-budget pruning still run after a successful
+    append. *)
 
 val set_append_guard : ((unit -> unit) -> unit) -> unit
 (** [set_append_guard guard] installs a process-wide wrapper around

--- a/lib/keeper/keeper_wire_capture.ml
+++ b/lib/keeper/keeper_wire_capture.ml
@@ -67,10 +67,13 @@ let prune_expired ~masc_root =
   | exn -> Error (Retention_prune_failed { path; detail = Printexc.to_string exn })
 ;;
 
-type record_skip_reason = Current_file_byte_cap
+type record_skip_reason =
+  | Rotation_sequence_exhausted
+  | Append_guard_refused
 
 let record_skip_reason_label = function
-  | Current_file_byte_cap -> "current_file_byte_cap"
+  | Rotation_sequence_exhausted -> "rotation_sequence_exhausted"
+  | Append_guard_refused -> "append_guard_refused"
 ;;
 
 type write_failure_site =
@@ -82,28 +85,55 @@ let write_failure_site_label = function
   | Response_capture -> "response"
 ;;
 
+let record_skip ~store ~keeper_name ~turn_id reason detail =
+  Otel_metric_store.inc_counter
+    Keeper_metrics.(to_string WireCaptureRecordSkipped)
+    ~labels:
+      [ ("keeper", keeper_name)
+      ; ("turn_id", string_of_int turn_id)
+      ; ("reason", record_skip_reason_label reason)
+      ]
+    ();
+  Log.Keeper.warn
+    "keeper_wire_capture: skipped record (%s) under %s"
+    detail
+    (Dated_jsonl.base_dir store)
+;;
+
+(* Segments are sized at a fraction of the store byte budget so the
+   budget-driven oldest-first prune keeps a ring of several completed
+   segments plus the current file. With segment size = budget, a freshly
+   rotated segment would already exceed the budget and be pruned at
+   once, collapsing the ring to a single file. *)
+let segments_per_byte_budget = 8
+
 let write_payload ~masc_root ~keeper_name ~turn_id (payload : Yojson.Safe.t) =
   let { store; max_bytes; _ } = store_for ~masc_root in
-  if
-    not
-      (Dated_jsonl.append_if_current_file_fits
-         store
-         ~max_current_file_bytes:max_bytes
-         payload)
-  then (
-    Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string WireCaptureRecordSkipped)
-      ~labels:
-        [ ("keeper", keeper_name)
-        ; ("turn_id", string_of_int turn_id)
-        ; ("reason", record_skip_reason_label Current_file_byte_cap)
-        ]
-      ();
-    Log.Keeper.warn
-      "keeper_wire_capture: skipped record because current day file would exceed %d \
-       bytes under %s"
-      max_bytes
-      (Dated_jsonl.base_dir store))
+  let segment_bytes = Stdlib.Int.max 1 (max_bytes / segments_per_byte_budget) in
+  match
+    Dated_jsonl.append_rotating
+      store
+      ~max_current_file_bytes:segment_bytes
+      payload
+  with
+  | Dated_jsonl.Appended_to_current -> ()
+  | Dated_jsonl.Appended_after_rotation { segment } ->
+    (* Rotation is the byte cap working, not a loss: the row landed in a
+       fresh current file and the completed segment stays readable until
+       the store byte budget prunes the oldest segments. *)
+    Log.Keeper.info
+      "keeper_wire_capture: rotated full day file to %s under %s"
+      segment
+      (Dated_jsonl.base_dir store)
+  | Dated_jsonl.Skipped_rotation_exhausted { sequence_limit } ->
+    record_skip ~store ~keeper_name ~turn_id Rotation_sequence_exhausted
+      (Printf.sprintf
+         "day already holds %d rotated segments of %d bytes"
+         sequence_limit
+         segment_bytes)
+  | Dated_jsonl.Skipped_by_append_guard ->
+    record_skip ~store ~keeper_name ~turn_id Append_guard_refused
+      "append guard declined the write"
 
 let best_effort ~site ~masc_root ~keeper_name ~turn_id f =
   let base_dir = wire_capture_dir masc_root in

--- a/lib/keeper/keeper_wire_capture.mli
+++ b/lib/keeper/keeper_wire_capture.mli
@@ -23,11 +23,15 @@
 
     Writes are best-effort and dated under
     [<masc_root>/wire-capture/YYYY-MM/DD.jsonl] (same [Dated_jsonl] per-day
-    store the cost ledger uses). The active day file and completed-file
-    retention are bounded by
-    [MASC_KEEPER_WIRE_CAPTURE_RETENTION_DAYS] and
-    [MASC_KEEPER_WIRE_CAPTURE_MAX_BYTES]. A write failure is logged and never
-    interrupts the turn.
+    store the cost ledger uses). [MASC_KEEPER_WIRE_CAPTURE_MAX_BYTES] is
+    the store byte budget: the current day file rotates to a completed
+    [DD.NNN.jsonl] segment at an eighth of the budget and capture
+    continues in a fresh file, while the budget prunes the oldest
+    completed files — so a busy day keeps a ring of its newest segments
+    and sheds its oldest instead of going dark after the cap
+    ([Dated_jsonl.append_rotating]). Retention is bounded by
+    [MASC_KEEPER_WIRE_CAPTURE_RETENTION_DAYS]. A write failure is
+    logged and never interrupts the turn.
 
     Motivation: the request boundary is the primary suspect for
     self-reinforcing repetition — the keeper's own prior visible text is

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -201,7 +201,7 @@ type t =
   | RawTraceRetentionUnlinkFailed (* counter: unreachable raw-trace files that could not be deleted *)
   | WireCaptureResponseSuppressed (* counter: keeper-visible response suppressed before wire capture *)
   | WireCaptureWriteFailures    (* counter: wire-capture write raised an exception *)
-  | WireCaptureRecordSkipped    (* counter: wire-capture record dropped by current-file byte cap *)
+  | WireCaptureRecordSkipped    (* counter: wire-capture record dropped — rotation name space exhausted or append guard refused *)
 [@@deriving enumerate]
 
 (** String conversion

--- a/test/test_dated_jsonl.ml
+++ b/test/test_dated_jsonl.ml
@@ -921,12 +921,172 @@ let test_empty_store () =
 
 (* ── Test Suite ───────────────────────────────────────── *)
 
+(* ── append_rotating: size-capped ring over intra-day segments ────
+   (#29009) The previous cap contract dropped every row for the rest of
+   the day once the current file was full. These pin the replacement:
+   the full file rotates to [DD.NNN.jsonl], new rows keep landing, the
+   store byte budget sheds the oldest segment first, and every reader
+   sees segments as ordinary day files. *)
+
+(* Fixed-size row: {"i":N} + newline = 8 bytes for single-digit N, so
+   the caps below are exact row multiples. *)
+let tiny_json i = `Assoc [ ("i", `Int i) ]
+let tiny_row_bytes = String.length (Yojson.Safe.to_string (tiny_json 1)) + 1
+
+let today_parts () =
+  let tm = Unix.gmtime (Unix.gettimeofday ()) in
+  let month = Printf.sprintf "%04d-%02d" (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) in
+  let day = Printf.sprintf "%02d" tm.Unix.tm_mday in
+  (month, day)
+
+let segment_path dir ~sequence =
+  let month, day = today_parts () in
+  Filename.concat (Filename.concat dir month)
+    (Printf.sprintf "%s.%03d.jsonl" day sequence)
+
+let current_path dir =
+  let month, day = today_parts () in
+  Filename.concat (Filename.concat dir month) (day ^ ".jsonl")
+
+let non_empty_lines file =
+  Fs_compat.load_file file
+  |> String.split_on_char '\n'
+  |> List.filter (fun l -> String.trim l <> "")
+
+let test_append_rotating_rotates_at_cap () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "dated_jsonl_rotate" in
+  let store = Dated_jsonl.create ~base_dir:dir () in
+  (match
+     Dated_jsonl.append_rotating store ~max_current_file_bytes:tiny_row_bytes
+       (tiny_json 1)
+   with
+   | Dated_jsonl.Appended_to_current -> ()
+   | _ -> fail "first row must land in the current file");
+  (match
+     Dated_jsonl.append_rotating store ~max_current_file_bytes:tiny_row_bytes
+       (tiny_json 2)
+   with
+   | Dated_jsonl.Appended_after_rotation { segment } ->
+     let _, day = today_parts () in
+     check string "segment name" (Printf.sprintf "%s.001.jsonl" day) segment
+   | _ -> fail "second row must rotate the full current file");
+  check int "segment holds the first row" 1
+    (List.length (non_empty_lines (segment_path dir ~sequence:1)));
+  check int "current holds the second row" 1
+    (List.length (non_empty_lines (current_path dir)));
+  let values = List.map json_i (Dated_jsonl.read_recent store 10) in
+  check (list int) "readers see both rows across the rotation" [ 1; 2 ] values
+
+let test_append_rotating_range_reads_cross_segments () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "dated_jsonl_rotate_range" in
+  let store = Dated_jsonl.create ~base_dir:dir () in
+  for i = 1 to 3 do
+    ignore
+      (Dated_jsonl.append_rotating store ~max_current_file_bytes:tiny_row_bytes
+         (tiny_json i)
+        : Dated_jsonl.append_outcome)
+  done;
+  let month, day = today_parts () in
+  let today = month ^ "-" ^ day in
+  let values =
+    Dated_jsonl.read_range store ~since:today ~until:today |> List.map json_i
+  in
+  check (list int) "range read includes rotated segments" [ 1; 2; 3 ] values
+
+let test_append_rotating_ring_prunes_oldest_segment () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "dated_jsonl_rotate_ring" in
+  let store =
+    Dated_jsonl.create ~base_dir:dir ~max_bytes:(2 * tiny_row_bytes) ()
+  in
+  for i = 1 to 3 do
+    ignore
+      (Dated_jsonl.append_rotating store ~max_current_file_bytes:tiny_row_bytes
+         (tiny_json i)
+        : Dated_jsonl.append_outcome)
+  done;
+  (* Three rows at a two-row budget: the oldest completed segment is
+     shed, the newest segment and the current file survive. *)
+  check bool "oldest segment pruned" false
+    (Sys.file_exists (segment_path dir ~sequence:1));
+  check bool "newest segment survives" true
+    (Sys.file_exists (segment_path dir ~sequence:2));
+  let values = List.map json_i (Dated_jsonl.read_recent store 10) in
+  check (list int) "ring keeps the newest rows" [ 2; 3 ] values
+
+let test_append_rotating_oversized_row_lands_in_empty_current () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "dated_jsonl_rotate_oversized" in
+  let store = Dated_jsonl.create ~base_dir:dir () in
+  let oversized = `Assoc [ ("i", `Int 1); ("pad", `String (String.make 64 'x')) ] in
+  (match
+     Dated_jsonl.append_rotating store ~max_current_file_bytes:tiny_row_bytes
+       oversized
+   with
+   | Dated_jsonl.Appended_to_current -> ()
+   | _ -> fail "an oversized row must land in an empty current file");
+  (match
+     Dated_jsonl.append_rotating store ~max_current_file_bytes:tiny_row_bytes
+       (tiny_json 2)
+   with
+   | Dated_jsonl.Appended_after_rotation { segment = _ } -> ()
+   | _ -> fail "the next row must rotate the oversized file out");
+  let values = List.map json_i (Dated_jsonl.read_recent store 10) in
+  check (list int) "both rows readable" [ 1; 2 ] values
+
+let test_append_rotating_sequence_survives_restart () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "dated_jsonl_rotate_restart" in
+  let store = Dated_jsonl.create ~base_dir:dir () in
+  ignore
+    (Dated_jsonl.append_rotating store ~max_current_file_bytes:tiny_row_bytes
+       (tiny_json 1)
+      : Dated_jsonl.append_outcome);
+  ignore
+    (Dated_jsonl.append_rotating store ~max_current_file_bytes:tiny_row_bytes
+       (tiny_json 2)
+      : Dated_jsonl.append_outcome);
+  (* A fresh handle over the same directory derives the next sequence
+     from the names on disk, not from in-process state. *)
+  let reopened = Dated_jsonl.create ~base_dir:dir () in
+  (match
+     Dated_jsonl.append_rotating reopened ~max_current_file_bytes:tiny_row_bytes
+       (tiny_json 3)
+   with
+   | Dated_jsonl.Appended_after_rotation { segment } ->
+     let _, day = today_parts () in
+     check string "sequence continues after reopen"
+       (Printf.sprintf "%s.002.jsonl" day) segment
+   | _ -> fail "reopened store must rotate with the next sequence");
+  check bool "first segment still present" true
+    (Sys.file_exists (segment_path dir ~sequence:1))
+
 let () =
   run "Dated_jsonl"
     [
       ( "append",
         [
           test_case "creates dated file" `Quick test_append_creates_dated_file;
+        ] );
+      ( "append_rotating",
+        [
+          test_case "rotates the full current file at the cap" `Quick
+            test_append_rotating_rotates_at_cap;
+          test_case "range reads cross rotated segments" `Quick
+            test_append_rotating_range_reads_cross_segments;
+          test_case "byte budget sheds the oldest segment first" `Quick
+            test_append_rotating_ring_prunes_oldest_segment;
+          test_case "oversized single row lands in an empty file" `Quick
+            test_append_rotating_oversized_row_lands_in_empty_current;
+          test_case "rotation sequence survives a reopen" `Quick
+            test_append_rotating_sequence_survives_restart;
         ] );
       ( "read_recent",
         [

--- a/test/test_keeper_wire_capture.ml
+++ b/test/test_keeper_wire_capture.ml
@@ -472,7 +472,13 @@ let capture_cache_reloads_when_retention_changes () =
    fires. *)
 let capture_rotates_when_current_file_cap_would_be_exceeded () =
   with_flag "1" (fun () ->
-    with_env "MASC_KEEPER_WIRE_CAPTURE_MAX_BYTES" "512" (fun () ->
+    (* The byte budget must hold the rotated segment plus the oversized
+       current record (~4.5KB here), or the budget prune sheds the
+       segment the moment it rotates — that shedding is the ring
+       working, but this case pins rotation itself. The segment cap is
+       an eighth of the budget (1KB), small enough that the second
+       record still triggers the rotation. *)
+    with_env "MASC_KEEPER_WIRE_CAPTURE_MAX_BYTES" "8192" (fun () ->
       let base = Filename.temp_dir "wirecap_cap" "" in
       let keeper_name = "wirecap_cap_metric" in
       Wire.capture_response ~base_path:base ~masc_root:base ~keeper_name ~turn_id:11

--- a/test/test_keeper_wire_capture.ml
+++ b/test/test_keeper_wire_capture.ml
@@ -465,7 +465,12 @@ let capture_cache_reloads_when_retention_changes () =
       Alcotest.(check bool) "old capture pruned after retention change" false
         (Sys.file_exists old_file)))
 
-let capture_skips_when_current_file_cap_would_be_exceeded () =
+(* #29009: the byte cap rotates the full current file to a completed
+   [DD.NNN.jsonl] segment instead of dropping every later record of the
+   day. Both records survive — the earlier one byte-identical in the
+   segment, the new one in the fresh current file — and no skip metric
+   fires. *)
+let capture_rotates_when_current_file_cap_would_be_exceeded () =
   with_flag "1" (fun () ->
     with_env "MASC_KEEPER_WIRE_CAPTURE_MAX_BYTES" "512" (fun () ->
       let base = Filename.temp_dir "wirecap_cap" "" in
@@ -474,31 +479,46 @@ let capture_skips_when_current_file_cap_would_be_exceeded () =
         ~agent_core_turn:1 ~response_text:"small" ();
       let files = find_jsonl base in
       Alcotest.(check int) "small record written" 1 (List.length files);
-      let before = read_file (List.hd files) in
-      let labels =
-        [ ("keeper", keeper_name)
-        ; ("turn_id", "12")
-        ; ("reason", "current_file_byte_cap")
-        ]
+      let current_file = List.hd files in
+      let first_record = read_file current_file in
+      let skip_value reason =
+        metric_value record_skipped_metric
+          ~labels:
+            [ ("keeper", keeper_name); ("turn_id", "12"); ("reason", reason) ]
       in
-      let legacy_labels =
-        [ ("keeper", keeper_name); ("turn_id", "12"); ("reason", "cap") ]
+      let exhausted_before = skip_value "rotation_sequence_exhausted" in
+      let guard_before = skip_value "append_guard_refused" in
+      Wire.capture_response ~base_path:base ~masc_root:base ~keeper_name
+        ~turn_id:12
+        ~agent_core_turn:1 ~response_text:(String.make 4096 'x') ();
+      let files_after = find_jsonl base in
+      Alcotest.(check int)
+        "cap rotates the full file into a segment: two jsonl files"
+        2
+        (List.length files_after);
+      let segment =
+        match List.filter (fun f -> f <> current_file) files_after with
+        | [ segment ] -> segment
+        | _ -> Alcotest.fail "expected exactly one rotated segment"
       in
-      let legacy_before = metric_value record_skipped_metric ~labels:legacy_labels in
-      check_metric_delta "current-file cap skip metric increments"
-        record_skipped_metric ~labels (fun () ->
-          Wire.capture_response ~base_path:base ~masc_root:base ~keeper_name
-            ~turn_id:12
-            ~agent_core_turn:1 ~response_text:(String.make 4096 'x') ());
-      let after = read_file (List.hd files) in
+      Alcotest.(check bool) "segment name carries a rotation sequence" true
+        (contains ~needle:".001.jsonl" segment);
       Alcotest.(check string)
-        "oversized record skipped without mutating current day file"
-        before
-        after;
+        "earlier record survives byte-identical in the segment"
+        first_record
+        (read_file segment);
+      Alcotest.(check bool)
+        "oversized record landed in the fresh current file"
+        true
+        (contains ~needle:(String.make 64 'x') (read_file current_file));
       Alcotest.(check (float 0.0001))
-        "legacy cap reason label is not incremented"
-        legacy_before
-        (metric_value record_skipped_metric ~labels:legacy_labels)))
+        "rotation is not counted as a skip (exhausted reason)"
+        exhausted_before
+        (skip_value "rotation_sequence_exhausted");
+      Alcotest.(check (float 0.0001))
+        "rotation is not counted as a skip (guard reason)"
+        guard_before
+        (skip_value "append_guard_refused")))
 
 let response_capture_matches_replayed_history_text () =
   with_flag "1" (fun () ->
@@ -600,8 +620,8 @@ let () =
             startup_prune_removes_old_files_without_new_capture;
           Alcotest.test_case "capture store reloads on retention change" `Quick
             capture_cache_reloads_when_retention_changes;
-          Alcotest.test_case "current file cap skips oversized record" `Quick
-            capture_skips_when_current_file_cap_would_be_exceeded;
+          Alcotest.test_case "current file cap rotates into a segment" `Quick
+            capture_rotates_when_current_file_cap_would_be_exceeded;
           Alcotest.test_case "trace_id is emitted when provided" `Quick
             response_trace_id_emitted;
           Alcotest.test_case "captured response matches replayed history text"


### PR DESCRIPTION
## 무엇

#29009 수리. wire-capture 일 파일이 바이트 상한에 도달하면 그날 나머지 기록을 전부 버리던 것을, 상한 도달 시 완결 세그먼트(`DD.NNN.jsonl`)로 회전하고 새 파일에 계속 기록하도록 바꿉니다. 스토어 바이트 예산이 가장 오래된 세그먼트부터 지우므로 디스크는 유계로 유지되고, 최신 기록은 항상 남습니다 (drop-newest → shed-oldest).

## 어떻게

- `Dated_jsonl.append_rotating`: 상한 도달 시 현재 파일을 세그먼트로 rename 후 신규 파일에 append. 세그먼트는 보통의 완결 파일 — 사전순 이름이 정렬/프루닝/범위 선택에 특례 없이 맞물립니다. outcome은 4-variant 닫힌 타입 (exhaustive match 강제).
- 범위 판독 3곳의 일자 추출을 `Filename.remove_extension`(세그먼트를 "DD.NNN"으로 만들어 경계에서 조용히 탈락)에서 앞 2자리로 교체.
- 상한보다 큰 단일 row는 빈 현재 파일에 그대로 착지 (빈 파일 회전 무한루프 방지, 세그먼트가 1회 과대).
- 세그먼트 크기 = 예산/8 (예산=세그먼트면 회전 즉시 프루닝돼 링이 1파일로 퇴화).
- 유일 호출자였던 `append_if_current_file_fits`와 `append_unlocked`의 죽은 cap 배관 제거.
- 회전 시퀀스는 디스크 이름에서 유도 (재시작/외부 기록자와 탈동기화 불가).

## 검증

- test_dated_jsonl에 rotation 섹션 5케이스: 상한 회전, 세그먼트 관통 범위 판독, 링 최고령 세그먼트 프루닝, 과대 row, 재오픈 후 시퀀스 연속.
- 소비자 전수 확인: tool_blob_maintenance는 디렉터리 재귀 스캔(파일명 무관), retention prune은 양쪽 이름 형태에 동일 판정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)