### PR TITLE
feat(agent-core): diagnose fused and near-miss tool names in the reject message

### DIFF
--- a/packages/agent_core/lib/agent/agent_tools.ml
+++ b/packages/agent_core/lib/agent/agent_tools.ml
@@ -70,10 +70,98 @@ let render_tool_names names =
   | _ -> String.concat "," names
 ;;
 
+(* A registered tool name is a bare identifier, so lookup is exact and
+   stays exact. What follows only enriches the reject MESSAGE: when the
+   model fuses arguments into the name slot (masc#29008 live shape:
+   [Execute["argv"]]) or typos a name, echoing the string back gives it
+   nothing to repair with, and the same broken call comes back on the
+   next turn. *)
+let is_tool_name_char = function
+  | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '-' -> true
+  | _ -> false
+;;
+
+(* [Some prefix] when [requested] starts as an identifier but carries
+   trailing non-identifier characters; [None] when it already is a bare
+   identifier. *)
+let identifier_prefix requested =
+  let length = String.length requested in
+  let rec scan i =
+    if i < length && is_tool_name_char requested.[i] then scan (i + 1) else i
+  in
+  let stop = scan 0 in
+  if stop = length then None else Some (String.sub requested 0 stop)
+;;
+
+let levenshtein a b =
+  let la = String.length a
+  and lb = String.length b in
+  let prev = Array.init (lb + 1) Fun.id in
+  let curr = Array.make (lb + 1) 0 in
+  for i = 1 to la do
+    curr.(0) <- i;
+    for j = 1 to lb do
+      let cost = if Char.equal a.[i - 1] b.[j - 1] then 0 else 1 in
+      curr.(j) <- min (min (prev.(j) + 1) (curr.(j - 1) + 1)) (prev.(j - 1) + cost)
+    done;
+    Array.blit curr 0 prev 0 (lb + 1)
+  done;
+  prev.(lb)
+;;
+
+(* Two edits covers the observed miss shapes (transposed or dropped
+   letters) without ever suggesting an unrelated tool for a genuinely
+   unknown name. *)
+let max_suggestion_distance = 2
+
+let closest_registered ~requested ~available =
+  List.fold_left
+    (fun best name ->
+       let distance = levenshtein requested name in
+       if distance > max_suggestion_distance
+       then best
+       else (
+         match best with
+         | Some (best_distance, _) when best_distance <= distance -> best
+         | Some _ | None -> Some (distance, name)))
+    None
+    available
+  |> Option.map snd
+;;
+
 let unknown_tool_failure ~requested ~available =
   let available_preview = render_tool_names available in
-  ( Printf.sprintf "Tool not found: %s. Available tools: %s" requested available_preview
-  , Validation_error )
+  let base =
+    Printf.sprintf "Tool not found: %s. Available tools: %s" requested available_preview
+  in
+  let extras =
+    match identifier_prefix requested with
+    | None ->
+      (match closest_registered ~requested ~available with
+       | None -> []
+       | Some name -> [ Printf.sprintf "Closest registered name: %s." name ])
+    | Some prefix when List.exists (String.equal prefix) available ->
+      [ Printf.sprintf
+          "The name carries extra characters after %S; send the tool name alone and \
+           put arguments in the input object."
+          prefix
+      ]
+    | Some prefix ->
+      (match closest_registered ~requested:prefix ~available with
+       | Some name ->
+         [ Printf.sprintf
+             "The name is not a bare identifier (closest registered name: %s); send \
+              the registered tool name alone and put arguments in the input object."
+             name
+         ]
+       | None ->
+         [ "The name is not a bare identifier; send the registered tool name alone \
+            and put arguments in the input object."
+         ])
+  in
+  (* [base] carries no trailing period, so the sentence join supplies
+     it; with no extras the legacy message stays byte-identical. *)
+  String.concat ". " (base :: extras), Validation_error
 ;;
 
 let resolve_tool_call tool_index name input = name, input, find_in_index tool_index name

--- a/packages/agent_core/test/test_tool_execution.ml
+++ b/packages/agent_core/test/test_tool_execution.ml
@@ -778,6 +778,76 @@ let test_unknown_tool_is_uniform_validation_with_full_diagnostics () =
     with_registered_tools.content
 ;;
 
+(* masc#29008: the model can fuse arguments into the name slot
+   ([Execute["argv"]], live rondo shape) or typo a name. Lookup stays
+   exact; the reject message must name the received shape and the
+   nearest registered name so the model can repair the call instead of
+   resending the same broken string. A bare unknown identifier with no
+   near miss keeps the exact legacy message (pinned above). *)
+let run_unknown_name ~tools name =
+  match
+    run_execute_with_tools
+      ~tools
+      ~hooks:Hooks.empty
+      [ ToolUse { id = "shape"; name; input = `Assoc [] } ]
+  with
+  | [ result ] -> result
+  | _ -> fail "expected one unknown-tool result"
+;;
+
+let check_unknown_validation label result =
+  match result.Agent_tools.outcome with
+  | Tool_failed
+      { failure_kind = Agent_tools.Validation_error
+      ; error_class = Some Types.Deterministic
+      } -> ()
+  | _ -> fail (label ^ " must be a deterministic validation failure")
+;;
+
+let test_fused_name_reject_names_the_registered_prefix () =
+  let result =
+    run_unknown_name ~tools:[ make_echo_tool "Execute" ] {|Execute["argv"]|}
+  in
+  check_unknown_validation "fused name" result;
+  check
+    string
+    "fused name reject quotes the registered prefix and the repair"
+    ("Tool not found: Execute[\"argv\"]. Available tools: Execute. "
+     ^ "The name carries extra characters after \"Execute\"; send the tool name "
+     ^ "alone and put arguments in the input object.")
+    result.content
+;;
+
+let test_typo_name_reject_suggests_closest_registered () =
+  let result =
+    run_unknown_name
+      ~tools:[ make_echo_tool "keeper_broadcast"; make_echo_tool "keeper_tasks_list" ]
+      "keeper_broadcst"
+  in
+  check_unknown_validation "typo name" result;
+  check
+    string
+    "typo reject suggests the closest registered name"
+    ("Tool not found: keeper_broadcst. Available tools: "
+     ^ "keeper_broadcast,keeper_tasks_list. Closest registered name: "
+     ^ "keeper_broadcast.")
+    result.content
+;;
+
+let test_fused_typo_prefix_reject_suggests_closest_registered () =
+  let result =
+    run_unknown_name ~tools:[ make_echo_tool "Execute" ] {|Exceute["x"]|}
+  in
+  check_unknown_validation "fused typo prefix" result;
+  check
+    string
+    "fused typo reject pairs the shape note with the closest name"
+    ("Tool not found: Exceute[\"x\"]. Available tools: Execute. "
+     ^ "The name is not a bare identifier (closest registered name: Execute); "
+     ^ "send the registered tool name alone and put arguments in the input object.")
+    result.content
+;;
+
 let test_non_tool_use_blocks_filtered () =
   (* Non-ToolUse blocks (Text, Thinking) must be filtered out, not produce
      bogus ("", "", false) triples. Regression test for issue #327. *)
@@ -1487,6 +1557,18 @@ let () =
             "unknown tools are uniform validation failures with full diagnostics"
             `Quick
             test_unknown_tool_is_uniform_validation_with_full_diagnostics
+        ; test_case
+            "fused name reject names the registered prefix"
+            `Quick
+            test_fused_name_reject_names_the_registered_prefix
+        ; test_case
+            "typo name reject suggests the closest registered name"
+            `Quick
+            test_typo_name_reject_suggests_closest_registered
+        ; test_case
+            "fused typo prefix reject suggests the closest registered name"
+            `Quick
+            test_fused_typo_prefix_reject_suggests_closest_registered
         ; test_case
             "dispatch passes exact tool invocation"
             `Quick


### PR DESCRIPTION
## 무엇

#29008 수리. 모델이 tool name 자리에 이름+인자 결합(`Execute["argv"]` — rondo 라이브 관측)이나 오타를 보내면, 지금은 받은 문자열을 그대로 되돌려줘 모델이 고칠 실마리가 없습니다. 조회는 exact-match 그대로 두고 **거부 메시지에 typed 진단**을 싣습니다.

## 어떻게

`unknown_tool_failure`에서:
- 식별자 접두가 등록명과 일치하면 → "그 이름 뒤에 여분 문자가 붙어 있다, 이름만 보내고 인자는 input 객체로"를 접두 인용과 함께.
- 접두가 등록명의 근접 오타면 → 최근접 등록명을 함께.
- bare 오타면 → Levenshtein ≤2 이내에서만 최근접 제안 (전혀 다른 도구를 가리키는 일 없음).
- 해당 없는 bare unknown → **기존 메시지 byte-identical** (기존 routing 테스트가 핀, 무수정 생존).

라우팅/수용 로직 변화 없음 — 분류기 추가가 아니라 거부의 진단 품질만 올립니다. #28885 실측(검증거부 후 in-turn 교정은 antigravity 외 runtime에서 실제로 동작)에 따라, 이 메시지 개선은 glm/ollama/claude_code 경로에서 즉시 실효.

## 검증

- test_tool_execution routing 스위트에 3케이스 추가: 결합형(접두 인용), 오타(최근접 제안), 결합+접두오타(복합). 기존 bare-unknown exact-string 테스트는 무수정 통과가 곧 하위호환 증명.

🤖 Generated with [Claude Code](https://claude.com/claude-code)