### PR TITLE
feat(observation): wire-capture 도구 스키마를 content address로 1회 저장

### DIFF
--- a/lib/keeper/keeper_wire_capture.ml
+++ b/lib/keeper/keeper_wire_capture.ml
@@ -187,6 +187,23 @@ let capture_request ~base_path ~masc_root ~keeper_name ~turn_id ~agent_core_turn
       let redacted_tools =
         List.map (redact_json_strings redaction) raw_tools
       in
+      (* The redacted schema array is stored once in the shared content-addressed
+         blob store and referenced from the row. The array is identical across
+         every request of the same tool surface (measured 2026-08-18 on a live
+         root: 2,702 rows carried 2 unique arrays of ~80KB each — 99.3% of all
+         capture bytes), so inlining it spent the day-file byte budget on
+         copies. [put_durable] is idempotent per content address, and blob
+         maintenance already lists wire-capture as a durable consumer, so the
+         blob lives exactly as long as a retained row references it. A blob
+         write failure raises out to [best_effort], which skips the whole
+         record: a marker is never emitted for bytes that were not persisted. *)
+      let tools_ref =
+        let blob_store = Tool_blob_store.create ~base_path in
+        Tool_blob_store.put_durable
+          blob_store
+          ~bytes:(Yojson.Safe.to_string (`List redacted_tools))
+          ~mime:"application/json"
+      in
       (* The replayed conversation is not copied into this record. It is
          already durable in the AGENT_CORE checkpoint and its [agent-core-snapshot-*]
          history, and [capture_request] fires once per agent-core turn, so
@@ -221,7 +238,7 @@ let capture_request ~base_path ~masc_root ~keeper_name ~turn_id ~agent_core_turn
               | None -> `Null )
           ; ("tool_count", `Int (List.length tools))
           ; ("tool_schema_bytes", `Int tool_schema_bytes)
-          ; ("tools", `List redacted_tools)
+          ; ("tools_ref", Tool_output.normalized_artifact_ref_to_json tools_ref)
           ; ("user_message", `String (redact redaction user_message))
           ; ("history_message_count", `Int (List.length history_messages))
           ; ("history_messages_digest", `String history_messages_digest)

--- a/lib/keeper/keeper_wire_capture.mli
+++ b/lib/keeper/keeper_wire_capture.mli
@@ -7,7 +7,13 @@
     durable store holds: the AGENT_CORE checkpoint keeps [system_prompt] and the
     replayed messages, but nothing else keeps the per-turn injected context.
     Tool schemas use the same {!Agent_core.Tool.schema_to_json} projection AGENT_CORE
-    prepares for the provider. String content is passed through
+    prepares for the provider; the redacted schema array is stored once in the
+    shared {!Tool_blob_store} under its content address and each request row
+    carries a [tools_ref] normalized artifact reference instead of the inline
+    array (measured 2026-08-18 on a live root: 2,702 rows held 2 unique
+    ~80KB arrays — 99.3% of all capture bytes were copies). Blob maintenance
+    already lists wire-capture as a durable consumer, so the blob expires with
+    the last retained row that references it. String content is passed through
     {!Llm_provider.Secret_redactor} and the exact {!Keeper_secret_redaction}
     projection snapshot before it is written.
 
@@ -91,8 +97,9 @@ val capture_request :
     correlation. [base_path] selects the exact Keeper secret projection
     snapshot; [masc_root] must already be the effective cluster-aware MASC
     root. [tool_schema_bytes] records the byte length of the exact unredacted
-    compact JSON schema array while [tools] stores its recursively redacted
-    content. [history_messages] is consumed for [history_message_count] and
+    compact JSON schema array while [tools_ref] points at its recursively
+    redacted content in the shared blob store (see the module header).
+    [history_messages] is consumed for [history_message_count] and
     [history_messages_digest] only; the messages themselves are not written
     (see the module header). *)
 

--- a/test/test_keeper_wire_capture.ml
+++ b/test/test_keeper_wire_capture.ml
@@ -110,15 +110,28 @@ let check_json_null label key json =
       (Yojson.Safe.to_string other)
 ;;
 
-let json_list key json =
-  match json_member key json with
-  | `List items -> items
-  | other ->
-    Alcotest.failf "field %s must be list, got %s" key (Yojson.Safe.to_string other)
-;;
-
-let check_json_list_length label key expected json =
-  Alcotest.(check int) label expected (List.length (json_list key json))
+(* Decode the row's [tools_ref] and fetch the redacted schema array it points
+   at from the shared blob store, failing loudly on any malformed or missing
+   link so a broken reference chain cannot pass as an empty surface. *)
+let fetch_tools_blob ~base json =
+  match
+    Tool_output.normalized_artifact_ref_of_json (json_member "tools_ref" json)
+  with
+  | Tool_output.Not_normalized_artifact_ref ->
+    Alcotest.failf "tools_ref is not a normalized artifact reference: %s"
+      (Yojson.Safe.to_string (json_member "tools_ref" json))
+  | Tool_output.Invalid_normalized_artifact_ref { detail } ->
+    Alcotest.failf "tools_ref is malformed: %s" detail
+  | Tool_output.Decoded_normalized_artifact_ref reference ->
+    let store = Tool_blob_store.create ~base_path:base in
+    (match
+       Tool_blob_store.fetch store ~sha256:reference.Tool_output.sha256
+     with
+     | Ok (Some bytes) -> reference, bytes
+     | Ok None -> Alcotest.fail "tools blob missing from the store"
+     | Error error ->
+       Alcotest.failf "tools blob fetch failed: %s"
+         (Tool_blob_store.fetch_error_to_string error))
 ;;
 
 let metric_value name ~labels =
@@ -218,7 +231,9 @@ let enabled_writes_redacted () =
     check_json_int "empty tool count recorded" "tool_count" 0 json;
     check_json_int "empty tool schema bytes recorded" "tool_schema_bytes"
       (String.length "[]") json;
-    check_json_list_length "empty tool schemas recorded" "tools" 0 json;
+    let _reference, tools_bytes = fetch_tools_blob ~base json in
+    Alcotest.(check string) "empty tool schemas stored as [] blob" "[]"
+      tools_bytes;
     check_json_string "user message recorded" "user_message" "hello world" json;
     check_json_int "history_message_count recorded" "history_message_count" 2
       json;
@@ -288,15 +303,18 @@ let request_captures_exact_redacted_tool_schemas () =
     Alcotest.(check int) "exactly one jsonl written" 1 (List.length files);
     let content = read_file (List.hd files) in
     let json = parse_single_jsonl content in
-    Alcotest.(check bool) "tool schema secret is redacted" false
+    Alcotest.(check bool) "tool schema secret is redacted from the row" false
       (contains ~needle:projected_secret content);
     check_json_int "tool count recorded" "tool_count" 1 json;
     check_json_int "pre-redaction tool schema bytes recorded"
       "tool_schema_bytes"
       (Yojson.Safe.to_string raw_tools |> String.length)
       json;
-    match json_list "tools" json with
-    | [ tool_json ] ->
+    let _reference, tools_bytes = fetch_tools_blob ~base json in
+    Alcotest.(check bool) "tool schema secret is redacted from the blob" false
+      (contains ~needle:projected_secret tools_bytes);
+    match Yojson.Safe.from_string tools_bytes with
+    | `List [ tool_json ] ->
       check_json_string "tool name recorded" "name" "probe_tool" tool_json;
       Alcotest.(check bool) "tool description redaction marker present" true
         (contains ~needle:"[REDACTED]" (json_string "description" tool_json));
@@ -308,7 +326,52 @@ let request_captures_exact_redacted_tool_schemas () =
       Alcotest.(check bool) "parameter description is recursively redacted" true
         (contains ~needle:"[REDACTED]"
            (json_string "description" query_schema))
-    | _ -> Alcotest.fail "tool schema list shape should have been checked above")
+    | other ->
+      Alcotest.failf "tools blob must hold a one-schema array, got %s"
+        (Yojson.Safe.to_string other))
+
+(* Two requests over the same tool surface must share one content address:
+   the blob store dedups by sha256, so the day file carries two small
+   references instead of two ~80KB schema copies. *)
+let tools_blob_is_shared_across_requests () =
+  with_flag "1" (fun () ->
+    let base = Filename.temp_dir "wirecap_dedup" "" in
+    let tool =
+      Agent_core.Tool.create
+        ~name:"probe_tool"
+        ~description:"stable schema"
+        ~parameters:
+          [ { Agent_core.Types.name = "query"
+            ; description = "query text"
+            ; param_type = Agent_core.Types.String
+            ; required = true
+            }
+          ]
+        (fun _input -> Ok { Agent_core.Types.content = "ok"; _meta = None })
+    in
+    let capture ~turn_id =
+      Wire.capture_request ~base_path:base ~masc_root:base
+        ~keeper_name:"sangsu" ~turn_id ~agent_core_turn:1 ~system_prompt:"sys"
+        ~extra_system_context:None ~user_message:"u" ~history_messages:[]
+        ~tools:[ tool ] ()
+    in
+    capture ~turn_id:1;
+    capture ~turn_id:2;
+    let files = find_jsonl base in
+    Alcotest.(check int) "one day file written" 1 (List.length files);
+    let rows =
+      read_file (List.hd files)
+      |> String.split_on_char '\n'
+      |> List.filter (fun line -> not (String.equal "" (String.trim line)))
+      |> List.map Yojson.Safe.from_string
+    in
+    match List.map (fetch_tools_blob ~base) rows with
+    | [ (first_ref, first_bytes); (second_ref, second_bytes) ] ->
+      Alcotest.(check string) "both rows share one content address"
+        first_ref.Tool_output.sha256 second_ref.Tool_output.sha256;
+      Alcotest.(check string) "both rows resolve the same bytes" first_bytes
+        second_bytes
+    | rows -> Alcotest.failf "expected two request rows, got %d" (List.length rows))
 
 let request_trace_id_emitted () =
   with_flag "1" (fun () ->
@@ -605,6 +668,8 @@ let () =
             enabled_writes_redacted;
           Alcotest.test_case "captures exact redacted tool schemas" `Quick
             request_captures_exact_redacted_tool_schemas;
+          Alcotest.test_case "tools blob is shared across requests" `Quick
+            tools_blob_is_shared_across_requests;
           Alcotest.test_case "write failure is best effort" `Quick
             request_capture_failure_is_best_effort;
           Alcotest.test_case "trace_id is emitted when provided" `Quick


### PR DESCRIPTION
## 무엇 (C2 수리)

wire-capture request 행마다 인라인되던 redacted 도구 스키마 배열(~80KB)을 공유 `Tool_blob_store`에 content address로 1회 저장하고, 행에는 `tools_ref`(normalized artifact reference)만 싣는다.

## 왜 (실측 근거)

analyst C2 실측 (2026-08-18, 라이브 루트): 2,702행 × ~80KB 배열, 고유 스키마 셋은 **2종** — 캡처 용량의 **99.3%가 동일 내용의 복사본**이었고 day-file 바이트 예산(64MiB)을 중복에 소모.

## 어떻게

- `put_durable`은 content-addressed 멱등이라 같은 표면이면 같은 sha256 1개만 저장 (`lib/keeper/keeper_gate_replay.ml:65`와 동일 패턴 재사용, 신규 저장 메커니즘 없음)
- **수명 관리 신설 없음**: `Tool_blob_maintenance`의 durable consumer 레지스트리에 wire-capture가 이미 등재돼 있어(`lib/tool_blob_store/tool_blob_maintenance.ml:254`), 참조하는 행이 retention에서 사라지면 2-스캔 GC가 블롭을 회수
- 블롭 쓰기 실패는 기존 `best_effort`로 전파되어 **행 전체를 스킵** — 저장되지 않은 바이트에 marker를 만들지 않음 (blob store 계약 그대로)
- row 필드는 `tools` → `tools_ref` hard cut (호환 reader 없음). `tool_count`/`tool_schema_bytes`는 유지

## 소비자 스윕

- dashboard/scripts에 `tools` 필드 소비자 없음 (`rg wire-capture dashboard/src scripts` — CI 스크립트 1건, 필드 무관)
- 테스트 3벌 갱신: 빈 표면 `[]` 블롭 확인, redaction이 row와 블롭 양쪽에서 성립, **동일 표면 2회 캡처가 같은 sha256 공유**(dedup 신규 테스트)

## 검증

- 로컬 dune 빌드 없이 CI로 검증 (원칙)
- 병합·배포 후 라이브 루트에서 day-file 용량 전/후 비교 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)