### PR TITLE
fix(keeper): bound the turn budget by the smallest lane candidate window

### DIFF
--- a/lib/keeper/keeper_unified_turn_pre_dispatch.ml
+++ b/lib/keeper/keeper_unified_turn_pre_dispatch.ml
@@ -58,7 +58,61 @@ let build_runtime_execution
       (Agent_core.Error.Config
          (Agent_core.Error.InvalidConfig
             { field = "runtime.context_window"; detail }))
-  | Ok max_context_resolution ->
+  | Ok entry_resolution ->
+    (* #28765: the prompt is shaped once per turn, but sticky reordering
+       and in-turn failover mean any candidate in the entry point's lane
+       can end up serving that same prompt. The only single budget no
+       serving candidate can overflow is the minimum across the lane's
+       candidates — and a minimum is order-independent, so when the
+       sticky reorder runs stops mattering. A runtime outside any lane
+       keeps its own resolution. The lane is re-resolved here instead of
+       threaded from the driver: both read the same
+       [Runtime.resolve_assignment] SSOT, and a deferred lane hint's
+       entry point maps back to that same lane. A candidate without a
+       resolvable context window is excluded from the minimum with a
+       warning — it would serve a prompt shaped without its window
+       either way, which is exactly the pre-#28765 behavior. *)
+    let max_context_resolution =
+      match Runtime.resolve_assignment runtime_id with
+      | `Missing -> entry_resolution
+      | `Lane lane ->
+        List.fold_left
+          (fun (smallest : Keeper_context_runtime.max_context_resolution)
+            candidate_id ->
+            if String.equal candidate_id runtime_id
+            then smallest
+            else (
+              match
+                Keeper_context_runtime
+                .resolve_max_context_resolution_for_runtime_id
+                  ~requested_override:meta.max_context_override
+                  ~runtime_id:candidate_id
+              with
+              | Error error ->
+                Log.Keeper.warn
+                  "%s: pre_dispatch: lane candidate %s has no resolvable \
+                   context window (%s); it does not bound the turn budget"
+                  meta.name
+                  candidate_id
+                  (Keeper_context_runtime.max_context_resolution_error_to_string
+                     error);
+                smallest
+              | Ok resolution ->
+                if resolution.effective_budget < smallest.effective_budget
+                then resolution
+                else smallest))
+          entry_resolution
+          (Runtime_lane.ordered_candidates lane)
+    in
+    if max_context_resolution.effective_budget < entry_resolution.effective_budget
+    then
+      Log.Keeper.info
+        "%s: pre_dispatch: lane %s turn budget bound by a smaller sibling \
+         window: entry effective=%d lane-min effective=%d"
+        meta.name
+        runtime_id
+        entry_resolution.effective_budget
+        max_context_resolution.effective_budget;
     let max_context =
       Keeper_turn_runtime_budget.resolved_max_context_for_turn
         ~meta

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -3819,6 +3819,90 @@ let test_runtime_max_context_override_above_cap_is_clamped () =
                (Some 128000)
                execution.max_context_resolution.requested_override))
 
+(* #28765: the observed incident shape — a 1,048,576-window lane entry
+   point whose sticky-reordered sibling has a 203,000 window. The turn
+   budget must be the smallest candidate window, because the prompt is
+   shaped once and any candidate can serve it. *)
+let test_lane_budget_is_bound_by_smallest_candidate_window () =
+  let catalog =
+    "[[models]]\n\
+     id_prefix = \"lane-big\"\n\
+     provider_name = \"ollama_cloud\"\n\
+     base = \"ollama_cloud\"\n\
+     max_context_tokens = 1048576\n\
+     \n\
+     [[models]]\n\
+     id_prefix = \"lane-small\"\n\
+     provider_name = \"ollama_cloud\"\n\
+     base = \"ollama_cloud\"\n\
+     max_context_tokens = 203000\n"
+  in
+  let runtime_toml =
+    "[providers.ollama_cloud]\n\
+     protocol = \"openai-compatible-http\"\n\
+     endpoint = \"https://ollama.com/v1\"\n\
+     \n\
+     [models.bigwin]\n\
+     api-name = \"lane-big\"\n\
+     max-context = 1048576\n\
+     \n\
+     [models.smallwin]\n\
+     api-name = \"lane-small\"\n\
+     max-context = 203000\n\
+     \n\
+     [ollama_cloud.bigwin]\n\
+     [ollama_cloud.smallwin]\n\
+     \n\
+     [runtime.lanes.\"ollama_cloud.bigwin\"]\n\
+     strategy = \"ordered\"\n\
+     candidates = [\"ollama_cloud.bigwin\", \"ollama_cloud.smallwin\"]\n\
+     \n\
+     [runtime]\n\
+     default = \"ollama_cloud.bigwin\"\n"
+  in
+  let snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () -> Runtime.For_testing.restore snapshot)
+    (fun () ->
+       with_model_catalog_content catalog @@ fun () ->
+       with_temp_runtime_toml runtime_toml (fun path ->
+         match Runtime.init_default ~config_path:path with
+         | Error msg -> failf "lane fixture should load: %s" msg
+         | Ok () ->
+           let meta =
+             match
+               Masc_test_deps.meta_of_json_fixture
+                 (`Assoc
+                    [ "name", `String "lane-min-budget"
+                    ; "trace_id", `String "test-lane-min-budget"
+                    ])
+             with
+             | Ok meta -> meta
+             | Error detail -> failf "lane meta fixture failed: %s" detail
+           in
+           match
+             Keeper_unified_turn_pre_dispatch.build_runtime_execution
+               ~meta
+               ~runtime_id:"ollama_cloud.bigwin"
+           with
+           | Error error ->
+             failf
+               "lane execution should resolve: %s"
+               (Agent_core.Error.to_string error)
+           | Ok execution ->
+             check int
+               "turn budget is the smallest lane candidate window"
+               203000
+               execution.max_context;
+             check int
+               "stored resolution is the binding candidate's"
+               203000
+               execution.max_context_resolution.effective_budget;
+             check string
+               "execution keeps the entry-point runtime id"
+               "ollama_cloud.bigwin"
+               execution.runtime_id))
+
 let test_runtime_max_context_missing_both_sources_rejected_at_load () =
   let runtime_toml =
     "[providers.local]\n\
@@ -4256,6 +4340,9 @@ let () =
           test_case
             "max-context: override above the catalog cap is clamped"
             `Quick test_runtime_max_context_override_above_cap_is_clamped;
+          test_case
+            "max-context: lane budget is bound by the smallest candidate window"
+            `Quick test_lane_budget_is_bound_by_smallest_candidate_window;
           test_case
             "max-context: missing both sources is rejected at load"
             `Quick test_runtime_max_context_missing_both_sources_rejected_at_load;


### PR DESCRIPTION
## 무엇

#28765 수리. 프롬프트는 턴당 1회, lane 진입점의 창 기준으로 shaping되는데 sticky 재정렬·in-turn failover로 **어느 후보든** 그 프롬프트를 서빙할 수 있습니다. 실측 인시던트: 진입점 1,048,576 vs 실제 디스패치 후보 203,000. 어떤 서빙 후보도 넘치지 않는 유일한 단일 예산은 **후보 집합의 min**이고, min은 순서 무관이라 재정렬 시점 문제 자체가 소멸합니다.

## 어떻게

`build_runtime_execution`이 진입점 해석 후 같은 SSOT(`Runtime.resolve_assignment`)로 lane을 해석해 후보 각각의 resolution을 fold, 최소 effective_budget의 resolution을 채택:
- lane 미소속 runtime은 현행 유지 (기존 테스트가 그 경로를 무수정 핀).
- 저장되는 resolution은 binding 후보의 것 — 로그의 예산 수치가 shaping이 실제 쓴 값과 일치 (#28762 오귀속 부류가 오히려 개선). resolution 타입에는 runtime 식별 필드가 없어 identity 오귀속 리플 없음(소비자 4파일 전수 확인: dashboard/status_detail은 자체 해석이라 무관, event_publisher/unified_turn 로그는 정확해짐). execution.runtime_id는 진입점 유지.
- 창 해석 불가 후보는 WARN과 함께 min에서 제외 — 그 후보가 서빙하면 어차피 자기 창 모른 채 서빙하는 기존 동작 그대로.
- deferred hint 경로: hint 진입점이 같은 lane으로 역해석되고 hint 집합 ⊆ lane 집합이라 min은 같거나 더 보수적.

## 검증

- 신규 테스트: 인시던트 모양 그대로(1048576 진입점 + 203000 형제 lane) → max_context=203000, 저장 resolution=binding 후보, runtime_id=진입점 유지.
- 잠복 판정: 전 keeper trace + 서버 로그에서 provider context-length 거부 0건 (이슈 코멘트 실측).

🤖 Generated with [Claude Code](https://claude.com/claude-code)