### PR TITLE
fix(memory): Memory OS 스냅샷 lock 경로 이중 접미사 제거

### DIFF
--- a/lib/keeper/keeper_memory_os_current.ml
+++ b/lib/keeper/keeper_memory_os_current.ml
@@ -536,8 +536,6 @@ let read_journal_tail ~keepers_dir ~keeper_id ~limit =
           Error (Printf.sprintf "journal line is not valid JSON: %s" message)))
 ;;
 
-let lock_path snapshot_path = snapshot_path ^ ".lock"
-
 let update_locked
       ?clock
       ?dropped_statements
@@ -547,7 +545,9 @@ let update_locked
   =
   Fs_compat.mkdir_p keepers_dir;
   let snapshot_path = path_for_keepers_dir ~keepers_dir ~keeper_id in
-  File_lock_eio.with_lock ?clock (lock_path snapshot_path) (fun () ->
+  (* File_lock_eio.with_lock appends ".lock" itself; a pre-suffixed path
+     locked "<snapshot>.lock.lock" and left a stray file per keeper. *)
+  File_lock_eio.with_lock ?clock snapshot_path (fun () ->
     let* previous =
       match Fs_compat.load_file_opt snapshot_path with
       | None -> Ok None


### PR DESCRIPTION
## 무엇 (캠페인 C3-3, lock_path 일원화)

`File_lock_eio.with_lock`은 받은 경로에 스스로 `.lock`을 붙인다 (`lib/process/file_lock_eio.mli:101`). `keeper_memory_os_current.ml`의 `update_locked`가 미리 `.lock`을 붙인 경로를 넘겨 실제 flock 파일이 `<snapshot>.lock.lock`이 됐고, keeper마다 잔여 파일이 하나씩 남았다. 로컬 `lock_path` wrapper를 삭제하고 snapshot 경로를 그대로 넘긴다.

## 안전성 (전수 확인)

- `update_locked`가 이 스냅샷의 **유일한** locker (`rg File_lock_eio.with_lock lib/`) — 경로 변경으로 경합 상대가 바뀌지 않음
- 테스트/코드 어디에도 `.lock.lock` 파일명 고정 없음
- 기존 잔여 `*.lock.lock` 파일은 빈 flock 파일이라 무해 — 운영자가 원하면 keepers 디렉터리에서 1회 정리
- 배포 겹침 창(구 바이너리 `.lock.lock` ↔ 신 바이너리 `.lock`)은 REDEPLOY runbook이 서버를 정지 후 교체하므로 발생하지 않음

## 검증

- `rg lock_path lib/keeper/keeper_memory_os_current.ml` → 잔존 참조 0
- 빌드/스위트는 CI로 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)