### PR TITLE
fix(keeper): persist a dead turn's reject round-trips into the replay checkpoint

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -814,6 +814,12 @@ let run_turn
                 ctx_work.checkpoint.Agent_core.Checkpoint.working_context
          in
          let last_persisted_checkpoint_ref = ref None in
+         (* masc#28885: typed pre_tool_use rejects recorded by the
+            official-client host during this turn. Flushed into the
+            replay checkpoint only when the turn dies, so the model can
+            repair the call next turn; a surviving turn already carries
+            the round-trip through its own history. *)
+         let pre_tool_rejects = ref [] in
          let checkpoint_sink (snapshot : Agent_core.Agent.checkpoint_snapshot) =
                 Option.iter (fun observe -> observe snapshot.stage) on_checkpoint_stage;
                 (* AGENT_CORE's per-turn pipeline builds checkpoints with an empty
@@ -854,6 +860,7 @@ let run_turn
                       ~runtime_id:runtime_id_string
                       ~base_path:config.base_path
                       ~keeper_name:meta.name
+                      ~pre_tool_rejects
                       ~goal:user_message
                       ?goal_blocks:user_blocks
                       ~session_id:
@@ -932,7 +939,28 @@ let run_turn
          (match
                  call_run_named ?raw_trace ~initial_messages:history_messages ()
                with
-               | Error e -> Error e
+               | Error e ->
+                 (match
+                    Keeper_official_client_host.persist_pre_tool_rejects
+                      ~session_dir:session.session_dir
+                      ~session_id:
+                        (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+                      !pre_tool_rejects
+                  with
+                  | Ok 0 -> ()
+                  | Ok persisted ->
+                    Log.Keeper.info
+                      "%s: persisted %d rejected tool round-trip(s) from the \
+                       failed turn into the replay checkpoint (masc#28885)"
+                      meta.name
+                      persisted
+                  | Error detail ->
+                    Log.Keeper.warn
+                      "%s: failed-turn reject round-trips could not be \
+                       persisted: %s"
+                      meta.name
+                      detail);
+                 Error e
                | Ok selected_run ->
                  let result = selected_run.Keeper_turn_driver.run_result in
                  let selected_runtime_id = selected_run.selected_runtime_id in

--- a/lib/keeper/keeper_antigravity_runtime.ml
+++ b/lib/keeper/keeper_antigravity_runtime.ml
@@ -314,7 +314,8 @@ let stream_projection ~turn_count on_event =
     }
 ;;
 
-let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
+let run_without_lifecycle ~runtime_id ~keeper_name
+    ~pre_tool_rejects ~base_path ~goal ~goal_blocks
     ~system_prompt ~tools ~initial_messages ~model_input_projection ~hooks
     ~context_injector ~context ~terminal_effect_state ~event_bus ~raw_trace ~on_event
     ~observe_effect_attempted
@@ -447,6 +448,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
         ~context
         ~terminal_effect_state
         ~terminal_error
+        ~pre_tool_rejects
         ~raw_trace_run:None
     in
     let runtime_root = Common.masc_dir_from_base_path ~base_path in
@@ -514,6 +516,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
         ~context
         ~terminal_effect_state
         ~terminal_error
+        ~pre_tool_rejects
         ~raw_trace_run
     in
     let dynamic_tools =
@@ -890,7 +893,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
                   recovery_detail))))
 ;;
 
-let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
+let run ~runtime_id ~keeper_name ~pre_tool_rejects ~base_path ~goal ~goal_blocks ~system_prompt
     ~tools ~initial_messages ~model_input_projection ~hooks ~context_injector
     ~context
     ?(terminal_effect_state = fun () -> Keeper_tools_agent_core.Terminal_effect_open)
@@ -906,6 +909,7 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
       run_without_lifecycle
         ~runtime_id
         ~keeper_name
+    ~pre_tool_rejects
         ~base_path
         ~goal
         ~goal_blocks

--- a/lib/keeper/keeper_antigravity_runtime.mli
+++ b/lib/keeper/keeper_antigravity_runtime.mli
@@ -12,6 +12,7 @@ type attempt_outcome =
 val run :
   runtime_id:string ->
   keeper_name:string ->
+  pre_tool_rejects:Keeper_official_client_host.rejected_tool_call list ref ->
   base_path:string ->
   goal:string ->
   goal_blocks:Agent_core.Types.content_block list option ->

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -270,7 +270,8 @@ let recovery_failure_of_client_error = function
   | Runtime_claude_code.Stopped_by_host _ -> Session_store.Protocol_failed
 ;;
 
-let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
+let run_without_lifecycle ~runtime_id ~keeper_name
+    ~pre_tool_rejects ~base_path ~goal ~goal_blocks ~system_prompt
     ~tools ~initial_messages ~model_input_projection ~hooks ~context_injector
     ~context ~terminal_effect_state ~event_bus ~raw_trace ~on_event ~effect_disposition
     ~context_overflow_retry_safe
@@ -401,6 +402,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
         ~context
         ~terminal_effect_state
         ~terminal_error
+        ~pre_tool_rejects
         ~raw_trace_run:None
     in
     let dynamic_tools = host_dynamic_tools in
@@ -455,6 +457,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
         ~context
         ~terminal_effect_state
         ~terminal_error
+        ~pre_tool_rejects
         ~raw_trace_run
     in
     let dynamic_tools = host_dynamic_tools in
@@ -828,7 +831,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
                   recovery_detail))))
 ;;
 
-let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
+let run ~runtime_id ~keeper_name ~pre_tool_rejects ~base_path ~goal ~goal_blocks ~system_prompt
     ~tools ~initial_messages ~model_input_projection ~hooks ~context_injector
     ~context
     ?(terminal_effect_state = fun () -> Keeper_tools_agent_core.Terminal_effect_open)
@@ -877,6 +880,7 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks ~system_prompt
           run_without_lifecycle
             ~runtime_id
             ~keeper_name
+    ~pre_tool_rejects
             ~base_path
             ~goal
             ~goal_blocks

--- a/lib/keeper/keeper_claude_code_runtime.mli
+++ b/lib/keeper/keeper_claude_code_runtime.mli
@@ -25,6 +25,7 @@ end
 val run :
   runtime_id:string ->
   keeper_name:string ->
+  pre_tool_rejects:Keeper_official_client_host.rejected_tool_call list ref ->
   base_path:string ->
   goal:string ->
   goal_blocks:Agent_core.Types.content_block list option ->

--- a/lib/keeper/keeper_codex_runtime.ml
+++ b/lib/keeper/keeper_codex_runtime.ml
@@ -386,7 +386,8 @@ let recovery_failure_of_client_error = function
     Keeper_official_client_session_store.Protocol_failed
 ;;
 
-let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
+let run_without_lifecycle ~runtime_id ~keeper_name
+    ~pre_tool_rejects ~base_path ~goal ~goal_blocks
     ~system_prompt ~tools ~initial_messages ~model_input_projection ~hooks
     ~context_injector ~context ~terminal_effect_state ~event_bus ~raw_trace ~on_event
     ~observe_effect_attempted ~observe_successful_tool_completion
@@ -546,6 +547,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
         ~context
         ~terminal_effect_state
         ~terminal_error
+        ~pre_tool_rejects
         ~raw_trace_run:None
     in
     let dynamic_tools =
@@ -620,6 +622,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
         ~context
         ~terminal_effect_state
         ~terminal_error
+        ~pre_tool_rejects
         ~raw_trace_run
     in
     let dynamic_tools =
@@ -935,7 +938,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
                recovery_detail))))
 ;;
 
-let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
+let run ~runtime_id ~keeper_name ~pre_tool_rejects ~base_path ~goal ~goal_blocks
     ~system_prompt ~tools ~initial_messages ~model_input_projection ~hooks
     ~context_injector ~context
     ?(terminal_effect_state = fun () -> Keeper_tools_agent_core.Terminal_effect_open)
@@ -988,6 +991,7 @@ let run ~runtime_id ~keeper_name ~base_path ~goal ~goal_blocks
         run_without_lifecycle
           ~runtime_id
           ~keeper_name
+    ~pre_tool_rejects
           ~base_path
           ~goal
           ~goal_blocks

--- a/lib/keeper/keeper_codex_runtime.mli
+++ b/lib/keeper/keeper_codex_runtime.mli
@@ -18,6 +18,7 @@ type attempt_outcome =
 val run :
   runtime_id:string ->
   keeper_name:string ->
+  pre_tool_rejects:Keeper_official_client_host.rejected_tool_call list ref ->
   base_path:string ->
   goal:string ->
   goal_blocks:Agent_core.Types.content_block list option ->

--- a/lib/keeper/keeper_official_client_host.ml
+++ b/lib/keeper/keeper_official_client_host.ml
@@ -396,6 +396,17 @@ type dynamic_tool = Runtime_official_client_tool.dynamic_tool =
   ; call : call_id:string -> Yojson.Safe.t -> dynamic_tool_result
   }
 
+(* One pre_tool_use rejection the model must be able to repair from
+   (masc#28885). The official-client CLI owns the live conversation, so
+   when it escalates the reject to a dead turn, this record is the only
+   surviving typed copy of the round-trip masc produced. *)
+type rejected_tool_call =
+  { call_id : string
+  ; tool_name : string
+  ; input : Yojson.Safe.t
+  ; detail : string
+  }
+
 let tool_hook_error_to_string = function
   | Agent_core.Agent_tools.Hook_execution_failed
       { hook_name; stage; tool_name; detail; _ } ->
@@ -603,7 +614,7 @@ let apply_context_injection ~runtime_label ~terminal_error ~context
 
 let dynamic_tool_of_agent_core ~runtime_label ~keeper_name ~turn_count ~context ~tools
     ~(hooks : Agent_core.Hooks.hooks) ~event_bus ~context_injector
-    ~terminal_effect_state ~terminal_error ~raw_trace_run
+    ~terminal_effect_state ~terminal_error ~pre_tool_rejects ~raw_trace_run
     ~next_dynamic_invocation_index ~repeated_call_state
     (tool : Agent_core.Tool.t) =
   { name = tool.schema.name
@@ -656,7 +667,14 @@ let dynamic_tool_of_agent_core ~runtime_label ~keeper_name ~turn_count ~context 
                  })
           in
           match pre_tool_use with
-          | Block detail -> { success = false; content = detail; abort_turn = None }
+          | Block detail ->
+            (* The corrective error result goes back to the CLI, and the
+               same round-trip is kept here so a CLI that kills the turn
+               instead of retrying cannot erase it (masc#28885). *)
+            pre_tool_rejects
+            := { call_id; tool_name = tool.schema.name; input; detail }
+               :: !pre_tool_rejects;
+            { success = false; content = detail; abort_turn = None }
           | HookFailed { stage; detail } ->
             let detail =
               Printf.sprintf
@@ -830,7 +848,8 @@ let dynamic_tool_of_agent_core ~runtime_label ~keeper_name ~turn_count ~context 
 ;;
 
 let dynamic_tools ~runtime_label ~keeper_name ~turn_count ~tools ~hooks ~event_bus
-    ~context_injector ~context ~terminal_effect_state ~terminal_error ~raw_trace_run =
+    ~context_injector ~context ~terminal_effect_state ~terminal_error
+    ~pre_tool_rejects ~raw_trace_run =
   match tools, context with
   | [], _ -> Ok []
   | _ :: _, None ->
@@ -854,8 +873,78 @@ let dynamic_tools ~runtime_label ~keeper_name ~turn_count ~tools ~hooks ~event_b
             ~context_injector
             ~terminal_effect_state
             ~terminal_error
+            ~pre_tool_rejects
             ~raw_trace_run
             ~next_dynamic_invocation_index
             ~repeated_call_state)
          tools)
+;;
+
+(* Append the reject round-trips of a dead turn to the canonical
+   checkpoint so the next turn's replay carries the corrective text
+   (masc#28885: 14,466 persisted messages held exactly one reject
+   round-trip — the one from a turn that survived; every escalated turn
+   lost its correction and the model resent the same broken call).
+   Message shape mirrors what a surviving turn persists byte-for-byte:
+   an assistant [ToolUse] block answered by a tool-role [ToolResult]
+   whose outcome is the deterministic validation failure. A missing
+   checkpoint means no replay exists to correct — skipped, not an
+   error. Rejects are recorded newest-first; the append restores call
+   order. *)
+let persist_pre_tool_rejects ~session_dir ~session_id rejects =
+  match rejects with
+  | [] -> Ok 0
+  | rejects ->
+    (match Keeper_checkpoint_store.load_agent_core ~session_dir ~session_id with
+     | Error Keeper_checkpoint_store.Not_found -> Ok 0
+     | Error error ->
+       Error
+         (Printf.sprintf
+            "reject round-trip persistence could not load the checkpoint: %s"
+            (match error with
+             | Keeper_checkpoint_store.Not_found -> "not found"
+             | Keeper_checkpoint_store.Store_error detail
+             | Keeper_checkpoint_store.Parse_error detail
+             | Keeper_checkpoint_store.Io_error detail
+             | Keeper_checkpoint_store.Agent_core_error detail -> detail))
+     | Ok checkpoint ->
+       let roundtrip { call_id; tool_name; input; detail } =
+         [ { Agent_core.Types.role = Agent_core.Types.Assistant
+           ; content =
+               [ Agent_core.Types.ToolUse { id = call_id; name = tool_name; input } ]
+           ; name = None
+           ; tool_call_id = None
+           ; metadata = []
+           }
+         ; { Agent_core.Types.role = Agent_core.Types.Tool
+           ; content =
+               [ Agent_core.Types.ToolResult
+                   { tool_use_id = call_id
+                   ; content = detail
+                   ; outcome =
+                       Agent_core.Types.Tool_failed
+                         { failure_kind = Agent_core.Types.Validation_error
+                         ; error_class = Some Agent_core.Types.Deterministic
+                         }
+                   ; json = None
+                   ; content_blocks = None
+                   }
+               ]
+           ; name = None
+           ; tool_call_id = Some call_id
+           ; metadata = []
+           }
+         ]
+       in
+       let appended = List.concat_map roundtrip (List.rev rejects) in
+       let checkpoint =
+         { checkpoint with
+           Agent_core.Checkpoint.messages = checkpoint.messages @ appended
+         }
+       in
+       (match
+          Keeper_checkpoint_store.save_agent_core_classified ~session_dir checkpoint
+        with
+        | Ok _ -> Ok (List.length rejects)
+        | Error detail -> Error detail))
 ;;

--- a/lib/keeper/keeper_official_client_host.mli
+++ b/lib/keeper/keeper_official_client_host.mli
@@ -53,6 +53,17 @@ type dynamic_tool = Runtime_official_client_tool.dynamic_tool =
   ; call : call_id:string -> Yojson.Safe.t -> dynamic_tool_result
   }
 
+(** One pre_tool_use rejection (typed [Block]) recorded during a turn.
+    The official-client CLI owns the live conversation; when it
+    escalates the reject to a dead turn this record is the only
+    surviving copy of the corrective round-trip (masc#28885). *)
+type rejected_tool_call =
+  { call_id : string
+  ; tool_name : string
+  ; input : Yojson.Safe.t
+  ; detail : string
+  }
+
 type raw_trace_stage =
   | Run_start
   | Assistant_block
@@ -168,6 +179,7 @@ val dynamic_tools :
   context:Agent_core.Context.t option ->
   terminal_effect_state:(unit -> Keeper_tools_agent_core.terminal_effect_state) ->
   terminal_error:string option ref ->
+  pre_tool_rejects:rejected_tool_call list ref ->
   raw_trace_run:Agent_core.Raw_trace.active_run option ->
   (dynamic_tool list, Agent_core.Error.t) result
 (** Project Agent Core tools onto one official-client turn. Three consecutive
@@ -175,6 +187,23 @@ val dynamic_tools :
     [abort_turn]; this is the official-client equivalent of Agent Core's
     repeated exact tool boundary and prevents a vendor-owned loop from holding
     one Keeper and host resources indefinitely. *)
+
+val persist_pre_tool_rejects :
+  session_dir:string ->
+  session_id:string ->
+  rejected_tool_call list ->
+  (int, string) result
+(** Append a dead turn's reject round-trips to the canonical checkpoint
+    so the next turn's replay carries the corrective text (masc#28885:
+    every escalated turn lost its correction and the model resent the
+    same broken call). Each reject becomes the pair a surviving turn
+    already persists — an assistant [ToolUse] block answered by a
+    tool-role [ToolResult] with the deterministic validation failure —
+    appended in call order. Returns how many rejects were persisted; an
+    empty list and a missing checkpoint (no replay exists to correct)
+    are both [Ok 0]. Callers flush only on a failed turn: a surviving
+    turn's round-trips reach the checkpoint through the next turn's
+    history, and appending them here too would duplicate them. *)
 
 val with_run_lifecycle_events :
   event_bus:Agent_core.Event_bus.t option ->

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -522,6 +522,7 @@ let attempt_inference_policy
 let run_named
     ~runtime_id
     ?(keeper_name = "")
+    ?pre_tool_rejects
     ~base_path
     ~goal
     ?goal_blocks
@@ -621,6 +622,11 @@ let run_named
      selecting a fresh lane walk. A deferred suffix was already frozen before
      pre-dispatch shaping, so re-reading wall-clock quota state here could make
      the actual provider differ from the runtime used to shape the request. *)
+  let pre_tool_rejects =
+    match pre_tool_rejects with
+    | Some rejects -> rejects
+    | None -> ref []
+  in
   let demote_quota_exhausted candidates =
     quota_ordered_runtime_ids
       (* NDT-OK: scheduling intentionally compares the stored expiry with
@@ -874,6 +880,7 @@ let run_named
           Keeper_codex_runtime.run
             ~runtime_id:attempt_runtime_id
             ~keeper_name
+            ~pre_tool_rejects
             ~base_path
             ~goal
             ~goal_blocks
@@ -973,6 +980,7 @@ let run_named
           Keeper_antigravity_runtime.run
             ~runtime_id:attempt_runtime_id
             ~keeper_name
+            ~pre_tool_rejects
             ~base_path
             ~goal
             ~goal_blocks
@@ -1052,6 +1060,7 @@ let run_named
           Keeper_claude_code_runtime.run
             ~runtime_id:attempt_runtime_id
             ~keeper_name
+            ~pre_tool_rejects
             ~base_path
             ~goal
             ~goal_blocks

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -103,6 +103,7 @@ type named_run_result =
 val run_named :
   runtime_id:string ->
   ?keeper_name:string ->
+  ?pre_tool_rejects:Keeper_official_client_host.rejected_tool_call list ref ->
   base_path:string ->
   goal:string ->
   ?goal_blocks:Agent_core.Types.content_block list ->

--- a/test/test_keeper_antigravity_runtime.ml
+++ b/test/test_keeper_antigravity_runtime.ml
@@ -690,6 +690,7 @@ let test_spawn_failure_is_pre_dispatch () =
                   in
                   let attempt =
                     Keeper_antigravity_runtime.run
+                      ~pre_tool_rejects:(ref [])
                       ~runtime_id:"antigravity.gemini"
                       ~keeper_name:"antigravity-pre-dispatch"
                       ~base_path

--- a/test/test_keeper_claude_code_runtime.ml
+++ b/test/test_keeper_claude_code_runtime.ml
@@ -1105,6 +1105,7 @@ let run_direct_attempt ?hooks ~base_path ~cli_path ~goal ~tools () =
                     | Some _ | None -> fail "Claude runtime fixture did not resolve"
                   in
                   Keeper_claude_code_runtime.run
+                    ~pre_tool_rejects:(ref [])
                     ~runtime_id:"claude.claude"
                     ~keeper_name:"claude-pre-dispatch"
                     ~base_path

--- a/test/test_keeper_official_client_host.ml
+++ b/test/test_keeper_official_client_host.ml
@@ -92,6 +92,8 @@ let one_dynamic_tool
       ?descriptor
       ?(terminal_effect_state = fun () ->
         Masc.Keeper_tools_agent_core.Terminal_effect_open)
+      ?(hooks = Agent_core.Hooks.empty)
+      ?(pre_tool_rejects = ref [])
       ~active
       handler
   =
@@ -110,12 +112,13 @@ let one_dynamic_tool
       ~keeper_name:"keeper-raw-authority"
       ~turn_count:1
       ~tools:[ tool ]
-      ~hooks:Agent_core.Hooks.empty
+      ~hooks
       ~event_bus:None
       ~context_injector:None
       ~context:(Some (Agent_core.Context.create_sync ()))
       ~terminal_effect_state
       ~terminal_error
+      ~pre_tool_rejects
       ~raw_trace_run:(Some active)
   in
   match projected with
@@ -966,6 +969,165 @@ let test_seed_reaches_the_provider_whole () =
      | [] -> fail "the seed must not be emptied")
 ;;
 
+(* masc#28885: the reject round-trip of a dead turn. The host records
+   every typed pre_tool_use Block, and the persistence helper appends
+   those round-trips to the replay checkpoint in the same shape a
+   surviving turn already persists. *)
+
+let () = Random.self_init ()
+
+let reject_detail = "Your call to \"effect\": errors (fix these and call again)"
+
+let test_pre_tool_reject_is_recorded () =
+  with_active_raw_trace (fun ~path:_ ~active ->
+    let pre_tool_rejects = ref [] in
+    let hooks =
+      { Agent_core.Hooks.empty with
+        pre_tool_use = Some (fun _ -> Agent_core.Hooks.Block reject_detail)
+      }
+    in
+    let executions = ref 0 in
+    let tool, _terminal_error =
+      one_dynamic_tool ~hooks ~pre_tool_rejects ~active (fun _input ->
+        incr executions;
+        Ok { Agent_core.Types.content = "never"; _meta = None })
+    in
+    let result = tool.call ~call_id:"call-reject-1" (`Assoc [ "k", `String "v" ]) in
+    check bool "reject surfaces as a failed tool result" false result.success;
+    check string "corrective text goes back to the CLI" reject_detail result.content;
+    check int "the tool body never ran" 0 !executions;
+    match !pre_tool_rejects with
+    | [ reject ] ->
+      check string "call id" "call-reject-1" reject.Host.call_id;
+      check string "tool name" "effect" reject.Host.tool_name;
+      check string "detail" reject_detail reject.Host.detail;
+      check string "input" {|{"k":"v"}|} (Yojson.Safe.to_string reject.Host.input)
+    | rejects ->
+      fail (Printf.sprintf "expected one recorded reject, got %d" (List.length rejects)))
+;;
+
+let persistence_checkpoint ~session_id =
+  Agent_core.Checkpoint.
+    { version = checkpoint_version
+    ; session_id
+    ; agent_name = "reject-persistence"
+    ; model = "test-model"
+    ; system_prompt = None
+    ; messages = [ Agent_core.Types.text_message Agent_core.Types.User "seed" ]
+    ; usage = Agent_core.Types.empty_usage
+    ; turn_count = 3
+    ; created_at = 1_700_000_000.0
+    ; tools = []
+    ; tool_choice = None
+    ; disable_parallel_tool_use = false
+    ; temperature = None
+    ; top_p = None
+    ; top_k = None
+    ; min_p = None
+    ; enable_thinking = None
+    ; preserve_thinking = None
+    ; response_format = Agent_core.Types.Off
+    ; thinking_budget = None
+    ; reasoning_effort = None
+    ; cache_system_prompt = false
+    ; context = Agent_core.Context.create_sync ()
+    ; mcp_sessions = []
+    ; working_context = None
+    }
+;;
+
+let reject ~call_id ~detail =
+  { Host.call_id; tool_name = "keeper_broadcast"; input = `Assoc []; detail }
+;;
+
+let test_persist_appends_roundtrips_in_call_order () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let session_dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "reject-persist-%06x" (Random.bits ()))
+  in
+  Fs_compat.mkdir_p session_dir;
+  let session_id = "trace-reject-persist" in
+  (match
+     Keeper_checkpoint_store.save_agent_core_classified
+       ~session_dir
+       (persistence_checkpoint ~session_id)
+   with
+   | Ok _ -> ()
+   | Error detail -> fail ("seed checkpoint save failed: " ^ detail));
+  (* The host records rejects newest-first; this list is exactly the
+     ref shape a dead turn hands over. *)
+  let rejects =
+    [ reject ~call_id:"call-2" ~detail:"second correction"
+    ; reject ~call_id:"call-1" ~detail:"first correction"
+    ]
+  in
+  (match Host.persist_pre_tool_rejects ~session_dir ~session_id rejects with
+   | Ok persisted -> check int "two rejects persisted" 2 persisted
+   | Error detail -> fail ("persist failed: " ^ detail));
+  match Keeper_checkpoint_store.load_agent_core ~session_dir ~session_id with
+  | Error _ -> fail "checkpoint reload failed"
+  | Ok checkpoint ->
+    check int "seed + two round-trips" 5 (List.length checkpoint.messages);
+    (match List.filteri (fun i _ -> i >= 1) checkpoint.messages with
+     | [ use_1; result_1; use_2; result_2 ] ->
+       let tool_use label (message : Agent_core.Types.message) expected_id =
+         match message.content with
+         | [ Agent_core.Types.ToolUse { id; name; _ } ] ->
+           check string (label ^ " id") expected_id id;
+           check string (label ^ " name") "keeper_broadcast" name
+         | _ -> fail (label ^ " is not a single ToolUse block")
+       in
+       let tool_result
+             label
+             (message : Agent_core.Types.message)
+             expected_id
+             expected_detail
+         =
+         match message.content with
+         | [ Agent_core.Types.ToolResult { tool_use_id; content; outcome; _ } ] ->
+           check string (label ^ " tool_use_id") expected_id tool_use_id;
+           check string (label ^ " content") expected_detail content;
+           (match outcome with
+            | Agent_core.Types.Tool_failed
+                { failure_kind = Agent_core.Types.Validation_error
+                ; error_class = Some Agent_core.Types.Deterministic
+                } -> ()
+            | _ ->
+              fail (label ^ " outcome is not the deterministic validation failure"))
+         | _ -> fail (label ^ " is not a single ToolResult block")
+       in
+       tool_use "first round-trip use" use_1 "call-1";
+       tool_result "first round-trip result" result_1 "call-1" "first correction";
+       tool_use "second round-trip use" use_2 "call-2";
+       tool_result "second round-trip result" result_2 "call-2" "second correction"
+     | _ -> fail "appended message window has the wrong shape")
+;;
+
+let test_persist_skips_when_no_checkpoint_exists () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let session_dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "reject-persist-empty-%06x" (Random.bits ()))
+  in
+  Fs_compat.mkdir_p session_dir;
+  match
+    Host.persist_pre_tool_rejects
+      ~session_dir
+      ~session_id:"trace-absent"
+      [ reject ~call_id:"call-x" ~detail:"lost" ]
+  with
+  | Ok persisted ->
+    check int "no replay exists to correct, so nothing persists" 0 persisted
+  | Error detail -> fail ("missing checkpoint must not be an error: " ^ detail)
+;;
+
 let () =
   run
     "keeper official-client host"
@@ -1074,6 +1236,20 @@ let () =
             "seed reaches the provider whole"
             `Quick
             test_seed_reaches_the_provider_whole
+        ] )
+    ; ( "reject round-trip persistence (masc#28885)"
+      , [ test_case
+            "pre_tool_use Block is recorded with its call identity"
+            `Quick
+            test_pre_tool_reject_is_recorded
+        ; test_case
+            "dead-turn rejects append to the checkpoint in call order"
+            `Quick
+            test_persist_appends_roundtrips_in_call_order
+        ; test_case
+            "missing checkpoint skips persistence"
+            `Quick
+            test_persist_skips_when_no_checkpoint_exists
         ] )
     ]
 ;;

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -5240,6 +5240,7 @@ let test_direct_execute_post_effect_artifact_failure_closes_official_client_loop
             let projected =
               match
                 Masc.Keeper_official_client_host.dynamic_tools
+                  ~pre_tool_rejects:(ref [])
                   ~runtime_label:"test-official-client"
                   ~keeper_name:meta.name
                   ~turn_count:1
@@ -5326,6 +5327,7 @@ let test_direct_pre_effect_and_readonly_failures_remain_correction_capable () =
             let projected =
               match
                 Masc.Keeper_official_client_host.dynamic_tools
+                  ~pre_tool_rejects:(ref [])
                   ~runtime_label:"test-official-client"
                   ~keeper_name:meta.name
                   ~turn_count:1
@@ -5726,6 +5728,7 @@ let test_terminal_composition_post_effect_failure_closes_official_client_loop ()
             let projected =
               match
                 Masc.Keeper_official_client_host.dynamic_tools
+                  ~pre_tool_rejects:(ref [])
                   ~runtime_label:"test-official-client"
                   ~keeper_name:meta.name
                   ~turn_count:7
@@ -5838,6 +5841,7 @@ let test_terminal_composition_unknown_write_failure_closes_official_client_loop 
             let projected =
               match
                 Masc.Keeper_official_client_host.dynamic_tools
+                  ~pre_tool_rejects:(ref [])
                   ~runtime_label:"test-official-client"
                   ~keeper_name:meta.name
                   ~turn_count:8
@@ -5965,6 +5969,7 @@ let test_terminal_composition_post_effect_defer_closes_without_resume () =
             let projected =
               match
                 Masc.Keeper_official_client_host.dynamic_tools
+                  ~pre_tool_rejects:(ref [])
                   ~runtime_label:"test-official-client"
                   ~keeper_name:meta.name
                   ~turn_count:9


### PR DESCRIPTION
## 무엇

#28885 지속성 수리. 측정 3종(이슈 코멘트)으로 확정된 기전 — antigravity가 검증 거부를 turn_failed로 승격하면 그 턴의 교정 왕복이 checkpoint에 실리지 않아, 모델이 다음 턴에 같은 깨진 호출을 반복(하루 36건) — 을 닫습니다.

## 어떻게

- **기록**: official-client 호스트의 pre_tool_use `Block` 분기(typed Reject의 유일 지점)가 (call_id·tool_name·input·교정문)을 턴 스코프 ref에 기록 — `terminal_error`와 같은 스레딩 패턴. CLI로 가는 교정 error result는 불변.
- **flush는 죽은 턴에서만**: `keeper_agent_run`이 ref를 소유하고 run_named가 Error로 복귀할 때만 session lock 아래에서 checkpoint에 append. 각 왕복은 **살아남은 턴이 이미 지속하는 형태 그대로**(assistant ToolUse + tool-role ToolResult{Validation_error·Deterministic}) — 라이브 실물(messages[12886-12887])과 바이트 호환. 살아남은 턴은 다음 턴 history로 왕복이 흘러가므로 여기서도 쓰면 중복 — flush하지 않는 근거를 doc에 명시.
- **리플 제로 설계**: run_named의 인자는 optional — 기존 호출자(프로브·테스트) 무변경, in-process lane은 ref를 채우지 않음. 세 official-client 런타임(antigravity/codex/claude_code) 공통 적용.
- checkpoint 부재(교정할 replay가 없음)는 skip(Ok 0), append 실패는 WARN — 지속성 실패가 턴 에러를 가리지 않음.

## 검증

feature 테스트 3케이스 (기존 host 스위트에 합류 — 신규 등록 불요):
1. Block → ref에 call 정체성까지 기록 + 도구 본문 미실행 + CLI행 결과 불변
2. 죽은 턴 flush → checkpoint에 호출 순서대로 정확한 메시지 쌍 append (재로드 검증)
3. checkpoint 부재 → Ok 0

분류 분리(terminal code)는 후속 PR — 지속성 없는 분류는 counter-as-fix라 이 순서로만.

Closes 없음 (#28885는 분류 후속까지 열어둠).

🤖 Generated with [Claude Code](https://claude.com/claude-code)