### PR TITLE
feat(verification): 비-retryable 리뷰 정지를 Board로 승격

### DIFF
--- a/lib/completion_authority_agent.ml
+++ b/lib/completion_authority_agent.ml
@@ -551,6 +551,17 @@ let process_task_once
            | Some reason -> reason
            | None -> gate
          in
+         (* A non-retryable deferral never gets another automatic attempt, so
+            the registry row would be its only surface. Promote it to the
+            Board so the assignee/operator sees the forward path. *)
+         if not result.retryable
+         then
+           Verification_protocol.notify_stalled_verification
+             ~authority
+             ~task_id:task.id
+             ~verification_id
+             ~gate
+             ~detail;
          complete
            ~evaluator_runtime
            ( defer

--- a/lib/verification_protocol.ml
+++ b/lib/verification_protocol.ml
@@ -351,6 +351,63 @@ let notify_reject_verification
    authenticated operator or typed system-LLM judge commits a verdict. Long-waiting
    obligations are surfaced from the activity-event stream, not a poll-timer. *)
 
+let stalled_board_content ~task_id ~verification_id ~gate ~detail =
+  Printf.sprintf
+    "Stalled task %s (vrf:%s) — review will not retry. gate=%s: %s. Forward \
+     path: the assignee resubmits with submit_for_verification (supersedes \
+     this verification), or an operator commits a HITL verdict."
+    task_id
+    verification_id
+    gate
+    detail
+
+let stalled_metadata
+      ~(authority : Masc_domain.completion_authority)
+      ~task_id
+      ~verification_id
+      ~gate
+      ~detail
+  =
+  `Assoc
+    ([ ("type", `String "verification_stalled")
+     ; ("task_id", `String task_id)
+     ; ("verification_id", `String verification_id)
+     ]
+     @ completion_authority_fields authority
+     @ [ ("gate", `String gate)
+       ; ("detail", `String detail)
+       ; ("timestamp", `Float (Time_compat.now ()))
+       ])
+
+let notify_stalled_verification
+      ~(authority : Masc_domain.completion_authority)
+      ~task_id
+      ~verification_id
+      ~gate
+      ~detail
+  =
+  match
+    Board_dispatch.create_post
+      ~author:(Masc_domain.completion_authority_actor authority)
+      ~content:(stalled_board_content ~task_id ~verification_id ~gate ~detail)
+      ~post_kind:Board.System_post
+      ~meta_json:
+        (stalled_metadata ~authority ~task_id ~verification_id ~gate ~detail)
+      ~visibility:Board.Internal
+      ~hearth:"verification"
+      ()
+  with
+  | Ok _ -> ()
+  | Error e ->
+    Log.Task.error
+      ~keeper_name:task_id
+      "stalled-review board post failed (task=%s vrf=%s): %s"
+      task_id verification_id (Board_types.show_board_error e)
+
 module For_testing = struct
   let verdict_event_json = verdict_event_json
+  let stalled_board_content = stalled_board_content
+
+  let stalled_metadata ~authority ~task_id ~verification_id ~gate ~detail =
+    stalled_metadata ~authority ~task_id ~verification_id ~gate ~detail
 end

--- a/lib/verification_protocol.mli
+++ b/lib/verification_protocol.mli
@@ -75,6 +75,24 @@ val notify_reject_verification :
     carry typed provenance.
     State-free. *)
 
+val notify_stalled_verification :
+  authority:Masc_domain.completion_authority ->
+  task_id:string ->
+  verification_id:string ->
+  gate:string ->
+  detail:string ->
+  unit
+(** Board projection for a review that completed [Not_reviewed] with
+    [retryable = false]: the completion authority will not schedule another
+    automatic attempt, so without this post the only surface is the bounded
+    run registry and the task waits invisibly. The post names the task, the
+    verification id, the gate, and the two forward paths that exist today —
+    the assignee resubmitting through [submit_for_verification] (a legal
+    transition from [AwaitingVerification] that supersedes this
+    verification), or an operator HITL verdict. Visibility only: no
+    scheduling state, no retry obligation. A board write failure is logged
+    and does not affect the review outcome. *)
+
 module For_testing : sig
   val verdict_event_json :
     authority:Masc_domain.completion_authority ->
@@ -83,5 +101,16 @@ module For_testing : sig
     verdict:Masc_domain.completion_verdict ->
     notes:string ->
     timestamp:float ->
+    Yojson.Safe.t
+
+  val stalled_board_content :
+    task_id:string -> verification_id:string -> gate:string -> detail:string -> string
+
+  val stalled_metadata :
+    authority:Masc_domain.completion_authority ->
+    task_id:string ->
+    verification_id:string ->
+    gate:string ->
+    detail:string ->
     Yojson.Safe.t
 end

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -107,6 +107,70 @@ let test_verdict_event_preserves_typed_authority () =
      | `Assoc fields -> List.mem_assoc "verifier" fields
      | _ -> Alcotest.fail "verdict event must be an object")
 
+(* The stalled-review board projection is the only surface that tells the
+   assignee a non-retryable deferral happened and how to move forward.
+   Pin the content naming both forward paths and the typed metadata. *)
+let test_stalled_projection_names_forward_paths () =
+  let content =
+    VP.For_testing.stalled_board_content
+      ~task_id:"task-101"
+      ~verification_id:"vrf-101"
+      ~gate:"artifact_unreadable"
+      ~detail:"evidence path escapes the playground"
+  in
+  let contains needle =
+    let nl = String.length needle and hl = String.length content in
+    let rec loop i =
+      i + nl <= hl
+      && (String.equal (String.sub content i nl) needle || loop (i + 1))
+    in
+    nl = 0 || loop 0
+  in
+  List.iter
+    (fun needle ->
+       Alcotest.(check bool)
+         (Printf.sprintf "content names %S" needle)
+         true
+         (contains needle))
+    [ "task-101"
+    ; "vrf:vrf-101"
+    ; "artifact_unreadable"
+    ; "evidence path escapes the playground"
+    ; "submit_for_verification"
+    ; "HITL"
+    ]
+
+let test_stalled_metadata_preserves_typed_authority () =
+  let metadata =
+    VP.For_testing.stalled_metadata
+      ~authority:(Masc_domain.System_llm_agent { agent_run_id = "agent_core-agent-run-9" })
+      ~task_id:"task-102"
+      ~verification_id:"vrf-102"
+      ~gate:"review_preparation"
+      ~detail:"required artifact list is empty"
+  in
+  let open Yojson.Safe.Util in
+  Alcotest.(check string)
+    "metadata type"
+    "verification_stalled"
+    (metadata |> member "type" |> to_string);
+  Alcotest.(check string)
+    "task id"
+    "task-102"
+    (metadata |> member "task_id" |> to_string);
+  Alcotest.(check string)
+    "authority kind"
+    "system_llm_agent"
+    (metadata |> member "authority_kind" |> to_string);
+  Alcotest.(check string)
+    "gate"
+    "review_preparation"
+    (metadata |> member "gate" |> to_string);
+  Alcotest.(check string)
+    "detail"
+    "required artifact list is empty"
+    (metadata |> member "detail" |> to_string)
+
 let test_rejected_verdict_event_preserves_wire_type () =
   let event =
     VP.For_testing.verdict_event_json
@@ -2310,6 +2374,10 @@ let () =
         test_verdict_event_preserves_typed_authority;
       Alcotest.test_case "rejected verdict keeps wire type" `Quick
         test_rejected_verdict_event_preserves_wire_type;
+      Alcotest.test_case "stalled projection names forward paths" `Quick
+        test_stalled_projection_names_forward_paths;
+      Alcotest.test_case "stalled metadata keeps typed authority" `Quick
+        test_stalled_metadata_preserves_typed_authority;
     ];
     "storage", [
       Alcotest.test_case "create and load" `Quick test_create_and_load;


### PR DESCRIPTION
## 무엇 (캠페인 C3-2)

검증 리뷰가 `Not_reviewed { retryable = false }`로 끝나면 completion authority는 설계상 재시도를 잡지 않는다. 그동안 유일한 표면이 bounded run registry 행이라(`lib/verification_run_registry.mli`) task가 `AwaitingVerification`에서 보이지 않게 영구 대기했다. 이제 그 지점에서 Board `System_post`를 게시한다 — task·verification id·gate·detail과, **이미 존재하는** 두 forward path를 명시:

1. assignee가 `submit_for_verification` 재호출 — `AwaitingVerification`에서 합법 전이이며 정지된 verification을 supersede (`workspace_task_transitions.ml:449-460`)
2. 운영자 HITL verdict

## 경계 준수

- **가시성은 projection**: 스케줄링 상태·재시도 의무·Gate를 만들지 않는다 (projects.md Autonomy 원칙 그대로)
- **텔레메트리-as-fix 아님**: 이 outcome의 fix는 설계상 사람/assignee 개입이고, 그 개입 요청이 도달할 표면이 없던 것이 결함 — 도달 경로 자체가 기능
- 기존 `notify_approve/reject_verification`과 같은 `Board_dispatch.create_post` 경로 재사용, board 실패는 로그만 (리뷰 결과에 무영향)

## 변경

- `lib/verification_protocol.ml(i)`: `notify_stalled_verification` + content/metadata 빌더 (For_testing 노출)
- `lib/completion_authority_agent.ml`: `retryable=false` 팔에서만 호출
- `test/test_verification.ml`: content가 두 forward path를 모두 명시하는지, metadata가 typed authority를 보존하는지 2케이스

## 검증

- 빌드/스위트는 CI로. 로컬은 편집 후 참조 스윕만
- 병합 후 라이브에서 실제 retryable=false 케이스 발생 시 board 게시 실측 (기존 task-385 계열이 후보)

🤖 Generated with [Claude Code](https://claude.com/claude-code)