### PR TITLE
feat(keeper): give a lost tool correction its own terminal label

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -45,6 +45,7 @@ let is_transient_internal_runner_error (err : Agent_core.Error.t) : bool =
       | Keeper_turn_driver.Incomplete_tool_transcript _
       | Keeper_turn_driver.Terminal_effect_failed _
       | Keeper_turn_driver.Provider_attempt_effect_fenced _
+      | Keeper_turn_driver.Tool_correction_lost _
       | Keeper_turn_driver.Receipt_persistence_failed _
       | Keeper_turn_driver.Gate_replay_repair_required _ )
   | None -> false
@@ -241,6 +242,7 @@ let is_auto_recoverable_runtime_exhausted_error (err : Agent_core.Error.t) : boo
   | Some (Keeper_turn_driver.Incomplete_tool_transcript _)
   | Some (Keeper_turn_driver.Terminal_effect_failed _)
   | Some (Keeper_turn_driver.Provider_attempt_effect_fenced _)
+  | Some (Keeper_turn_driver.Tool_correction_lost _)
   | Some (Keeper_turn_driver.Receipt_persistence_failed _)
   | Some (Keeper_turn_driver.Gate_replay_repair_required _)
   | None ->
@@ -264,6 +266,7 @@ let is_accept_no_usable_progress_error (err : Agent_core.Error.t) : bool =
       | Keeper_turn_driver.Incomplete_tool_transcript _
       | Keeper_turn_driver.Terminal_effect_failed _
       | Keeper_turn_driver.Provider_attempt_effect_fenced _
+      | Keeper_turn_driver.Tool_correction_lost _
       | Keeper_turn_driver.Receipt_persistence_failed _
       | Keeper_turn_driver.Gate_replay_repair_required _ )
   | None ->
@@ -387,6 +390,7 @@ let degraded_retry_after_recoverable_error
     | Some (Keeper_turn_driver.Incomplete_tool_transcript _)
     | Some (Keeper_turn_driver.Terminal_effect_failed _)
     | Some (Keeper_turn_driver.Provider_attempt_effect_fenced _)
+    | Some (Keeper_turn_driver.Tool_correction_lost _)
     | Some (Keeper_turn_driver.Receipt_persistence_failed _)
     | Some (Keeper_turn_driver.Gate_replay_repair_required _)
     | None ->
@@ -429,6 +433,7 @@ let recoverable_runtime_failure_reason (err : Agent_core.Error.t) =
     | Some (Keeper_turn_driver.Incomplete_tool_transcript _)
     | Some (Keeper_turn_driver.Terminal_effect_failed _)
     | Some (Keeper_turn_driver.Provider_attempt_effect_fenced _)
+    | Some (Keeper_turn_driver.Tool_correction_lost _)
     | Some (Keeper_turn_driver.Receipt_persistence_failed _)
     | Some (Keeper_turn_driver.Gate_replay_repair_required _) ->
         None
@@ -754,6 +759,7 @@ let should_warn_keeper_cycle_failed (err : Agent_core.Error.t) : bool =
   | Some (Keeper_turn_driver.Incomplete_tool_transcript _)
   | Some (Keeper_turn_driver.Terminal_effect_failed _)
   | Some (Keeper_turn_driver.Provider_attempt_effect_fenced _)
+  | Some (Keeper_turn_driver.Tool_correction_lost _)
   | Some (Keeper_turn_driver.Receipt_persistence_failed _)
   | Some (Keeper_turn_driver.Gate_replay_repair_required _)
   | None ->
@@ -810,6 +816,7 @@ let is_runtime_exhausted_error (err : Agent_core.Error.t) : bool =
   | Some (Keeper_turn_driver.Incomplete_tool_transcript _)
   | Some (Keeper_turn_driver.Terminal_effect_failed _)
   | Some (Keeper_turn_driver.Provider_attempt_effect_fenced _)
+  | Some (Keeper_turn_driver.Tool_correction_lost _)
   | Some (Keeper_turn_driver.Receipt_persistence_failed _)
   | Some (Keeper_turn_driver.Gate_replay_repair_required _) -> false
   | None -> false

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -96,6 +96,7 @@ type operator_disposition_reason =
   | Reason_phase_skipped
   | Reason_transcript_corruption
   | Reason_provider_attempt_effect_fenced
+  | Reason_tool_correction_lost
   | Reason_unmapped_runtime_state
 
 let operator_disposition_reason_to_string = function
@@ -114,6 +115,7 @@ let operator_disposition_reason_to_string = function
   | Reason_transcript_corruption -> "transcript_corruption"
   | Reason_provider_attempt_effect_fenced ->
     Keeper_internal_error.provider_attempt_effect_fenced_kind
+  | Reason_tool_correction_lost -> Keeper_internal_error.tool_correction_lost_kind
   | Reason_unmapped_runtime_state -> "unmapped_runtime_state"
 ;;
 
@@ -165,6 +167,11 @@ let operator_disposition (receipt : t)
        classify the canonical typed failure instead of incrementing the
        unmapped-state regression metric. *)
     Disp_unknown, Reason_provider_attempt_effect_fenced
+  | Keeper_terminal_reason.Tool_correction_lost _ ->
+    (* Identical disposition to the fence above; only the label differs so a
+       lost correction (masc#28885) is countable apart from an ordinary
+       fenced provider failure. *)
+    Disp_unknown, Reason_tool_correction_lost
   | Keeper_terminal_reason.Runtime_exhausted _ ->
     Disp_fail_open_next_runtime, Reason_runtime_exhausted
   | Keeper_terminal_reason.Capacity_backpressure _ ->
@@ -236,6 +243,7 @@ let operator_disposition (receipt : t)
        | Provider_runtime_failure _
        | Transcript_corruption _
        | Provider_attempt_effect_fenced _
+       | Tool_correction_lost _
        | Internal_error _
        | Unknown _ -> false)
     then Disp_pass, Reason_healthy

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -216,6 +216,11 @@ type operator_disposition_reason =
   (** The provider attempt did not prove whether an effect occurred. Paired
       with [Disp_unknown] so operator attention remains required, while the
       receipt is no longer counted as an unmapped classifier regression. *)
+  | Reason_tool_correction_lost
+  (** The fenced turn also recorded typed pre_tool_use rejections
+      (masc#28885). Same [Disp_unknown] pairing as
+      [Reason_provider_attempt_effect_fenced]; the label separates a lost
+      correction from an ordinary fenced provider failure. *)
   | Reason_unmapped_runtime_state
 
 val operator_disposition_reason_to_string : operator_disposition_reason -> string

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -328,7 +328,9 @@ let failed_source_disposition
   | Keeper_unified_turn.Follow_failure_route ->
     (match failure.Keeper_unified_turn.route with
      | Keeper_runtime_failure_route.Exhausted_visible_alive
-         { terminal = Keeper_runtime_failure_route.Provider_attempt_effect_fenced
+         { terminal =
+             ( Keeper_runtime_failure_route.Provider_attempt_effect_fenced
+             | Keeper_runtime_failure_route.Tool_correction_lost )
          ; detail
          ; _
          } -> Quarantine_source { detail }

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -131,6 +131,9 @@ type blocker_class =
     (** A terminal tool effect failed after the turn's terminal outcome. *)
   | Provider_attempt_effect_fenced
     (** A provider failure cannot be retried without risking a duplicate effect. *)
+  | Tool_correction_lost
+    (** The fenced turn also carried typed pre_tool_use rejections: the
+        model's correction round-trip was the casualty (masc#28885). *)
   | Receipt_persistence_failed
     (** Execution receipt persistence failed. *)
   | Gate_replay_repair_required
@@ -152,6 +155,7 @@ let blocker_class_to_string = function
   | Incomplete_tool_transcript -> "incomplete_tool_transcript"
   | Terminal_effect_failed -> "terminal_effect_failed"
   | Provider_attempt_effect_fenced -> "provider_attempt_effect_fenced"
+  | Tool_correction_lost -> "tool_correction_lost"
   | Receipt_persistence_failed -> "receipt_persistence_failed"
   | Gate_replay_repair_required -> "gate_replay_repair_required"
 ;;
@@ -172,6 +176,7 @@ let blocker_class_of_serialized_string = function
   | "incomplete_tool_transcript" -> Some Incomplete_tool_transcript
   | "terminal_effect_failed" -> Some Terminal_effect_failed
   | "provider_attempt_effect_fenced" -> Some Provider_attempt_effect_fenced
+  | "tool_correction_lost" -> Some Tool_correction_lost
   | "receipt_persistence_failed" -> Some Receipt_persistence_failed
   | "gate_replay_repair_required" -> Some Gate_replay_repair_required
   | _ -> None

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -149,6 +149,7 @@ type blocker_class =
   | Incomplete_tool_transcript
   | Terminal_effect_failed
   | Provider_attempt_effect_fenced
+  | Tool_correction_lost
   | Receipt_persistence_failed
   | Gate_replay_repair_required
 

--- a/lib/keeper/keeper_provider_runtime_boundary.ml
+++ b/lib/keeper/keeper_provider_runtime_boundary.ml
@@ -233,6 +233,7 @@ let classify_masc_internal_error = function
       | Keeper_internal_error.Incomplete_tool_transcript _
       | Keeper_internal_error.Terminal_effect_failed _
       | Keeper_internal_error.Provider_attempt_effect_fenced _
+      | Keeper_internal_error.Tool_correction_lost _
       | Keeper_internal_error.Receipt_persistence_failed _
       | Keeper_internal_error.Gate_replay_repair_required _ )
   | None ->

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -106,6 +106,7 @@ let disposition_of_typed_runtime_blocker_class blocker_class =
   | Keeper_meta_contract.Incomplete_tool_transcript
   | Keeper_meta_contract.Terminal_effect_failed
   | Keeper_meta_contract.Provider_attempt_effect_fenced
+  | Keeper_meta_contract.Tool_correction_lost
   | Keeper_meta_contract.Receipt_persistence_failed
   | Keeper_meta_contract.Gate_replay_repair_required ->
     Keeper_turn_disposition.Provider_error

--- a/lib/keeper/keeper_status_bridge_blocker.ml
+++ b/lib/keeper/keeper_status_bridge_blocker.ml
@@ -52,6 +52,8 @@ let blocker_class_of_core_error (err : Agent_core.Error.t) : blocker_class optio
     Some Terminal_effect_failed
   | Some (Keeper_turn_driver.Provider_attempt_effect_fenced _) ->
     Some Provider_attempt_effect_fenced
+  | Some (Keeper_turn_driver.Tool_correction_lost _) ->
+    Some Tool_correction_lost
   | Some (Keeper_turn_driver.Receipt_persistence_failed _) ->
     Some Receipt_persistence_failed
   | Some (Keeper_turn_driver.Gate_replay_repair_required _) ->
@@ -145,6 +147,7 @@ let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
     | Incomplete_tool_transcript
     | Terminal_effect_failed
     | Provider_attempt_effect_fenced
+    | Tool_correction_lost
     | Receipt_persistence_failed
     | Gate_replay_repair_required -> if summary = "" then str else summary
   in

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -205,6 +205,7 @@ let lane_should_retry
     | None -> false
 
 let attempt_runtime_candidates
+    ?(pre_tool_rejects = ref [])
     ?(allow_retry = fun ~runtime_id:_ ~attempt:_ _error -> true)
     ?(allow_accept_no_progress_retry = fun ~runtime_id:_ ~attempt:_ _error ->
       true)
@@ -350,12 +351,26 @@ let attempt_runtime_candidates
            | Keeper_provider_attempt_effect.No_effect_observed -> error
            | Keeper_provider_attempt_effect.Effect_attempted
            | Keeper_provider_attempt_effect.Observation_unavailable ->
-             core_error_of_masc_internal_error
-               (Provider_attempt_effect_fenced
-                  { runtime_id = attempt_runtime_id
-                  ; effect_disposition
-                  ; diagnostic = Agent_core.Error.to_string error
-                  })
+             (* masc#28885: a fence on a turn that also recorded typed
+                pre_tool_use rejections gets its own terminal label — the
+                model's correction round-trip was the visible casualty.
+                Disposition is identical to the plain fence. *)
+             (match !pre_tool_rejects with
+              | [] ->
+                core_error_of_masc_internal_error
+                  (Provider_attempt_effect_fenced
+                     { runtime_id = attempt_runtime_id
+                     ; effect_disposition
+                     ; diagnostic = Agent_core.Error.to_string error
+                     })
+              | rejects ->
+                core_error_of_masc_internal_error
+                  (Tool_correction_lost
+                     { runtime_id = attempt_runtime_id
+                     ; effect_disposition
+                     ; reject_count = List.length rejects
+                     ; diagnostic = Agent_core.Error.to_string error
+                     }))
          in
          let allow_accept_no_progress_retry =
            if
@@ -824,6 +839,7 @@ let run_named
   (* Sequential candidate attempt loop. On failure we record a manifest row and
      move to the next candidate; on success we record completion and return. *)
   attempt_runtime_candidates
+    ~pre_tool_rejects
     ?lane_id:lane_id_opt
     ?on_retry_deferred:on_runtime_retry_deferred
     ~allow_retry:(fun ~runtime_id:attempt_runtime_id ~attempt error ->

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -254,6 +254,7 @@ module For_testing : sig
     attempt_inference_policy
 
   val attempt_runtime_candidates :
+    ?pre_tool_rejects:Keeper_official_client_host.rejected_tool_call list ref ->
     ?allow_retry:
       (runtime_id:string -> attempt:int -> Agent_core.Error.t -> bool) ->
     ?allow_accept_no_progress_retry:

--- a/lib/keeper/keeper_turn_terminal.ml
+++ b/lib/keeper/keeper_turn_terminal.ml
@@ -82,6 +82,7 @@ let of_failure ?(tool_call_count = 0) ~raw_error err =
         | Keeper_turn_driver.Incomplete_tool_transcript _
         | Keeper_turn_driver.Terminal_effect_failed _
         | Keeper_turn_driver.Provider_attempt_effect_fenced _
+        | Keeper_turn_driver.Tool_correction_lost _
         | Keeper_turn_driver.Receipt_persistence_failed _
         | Keeper_turn_driver.Gate_replay_repair_required _ ) ->
       of_disposition

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -87,6 +87,7 @@ let transcript_corruption error =
       | Keeper_internal_error.Internal_contract_rejected _
       | Keeper_internal_error.Terminal_effect_failed _
       | Keeper_internal_error.Provider_attempt_effect_fenced _
+      | Keeper_internal_error.Tool_correction_lost _
       | Keeper_internal_error.Receipt_persistence_failed _
       | Keeper_internal_error.Gate_replay_repair_required _ )
   | None ->
@@ -117,6 +118,7 @@ let execution_boundary_of_turn_failure ~transcript_corruption error =
       | Keeper_internal_error.Incomplete_tool_transcript _
       | Keeper_internal_error.Terminal_effect_failed _
       | Keeper_internal_error.Provider_attempt_effect_fenced _
+      | Keeper_internal_error.Tool_correction_lost _
       | Keeper_internal_error.Receipt_persistence_failed _ )
   | None, None ->
     Keeper_runtime_failure_route.Agent_core_execution

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -133,6 +133,7 @@ let runtime_exhausted_failure_reason_of_raw_error ~detail raw_error =
       | Keeper_internal_error.Incomplete_tool_transcript _
       | Keeper_internal_error.Terminal_effect_failed _
       | Keeper_internal_error.Provider_attempt_effect_fenced _
+      | Keeper_internal_error.Tool_correction_lost _
       | Keeper_internal_error.Receipt_persistence_failed _
       | Keeper_internal_error.Gate_replay_repair_required _ )
   | None -> None

--- a/lib/keeper_runtime/keeper_internal_error.ml
+++ b/lib/keeper_runtime/keeper_internal_error.ml
@@ -25,6 +25,7 @@ let runtime_id_to_string (s : string) = s
 let capacity_backpressure_kind = "capacity_backpressure"
 let incomplete_tool_transcript_kind = "incomplete_tool_transcript"
 let provider_attempt_effect_fenced_kind = "provider_attempt_effect_fenced"
+let tool_correction_lost_kind = "tool_correction_lost"
 
 type provider_rejection = {
   provider_label : string;
@@ -317,6 +318,12 @@ type masc_internal_error =
       effect_disposition : Keeper_provider_attempt_effect_core.t;
       diagnostic : string;
     }
+  | Tool_correction_lost of {
+      runtime_id : string;
+      effect_disposition : Keeper_provider_attempt_effect_core.t;
+      reject_count : int;
+      diagnostic : string;
+    }
   | Receipt_persistence_failed of {
       detail : string;
     }
@@ -523,6 +530,16 @@ let masc_internal_error_to_json = function
         , `String (Keeper_provider_attempt_effect_core.to_string effect_disposition) )
       ; "diagnostic", `String diagnostic
       ]
+  | Tool_correction_lost
+      { runtime_id; effect_disposition; reject_count; diagnostic } ->
+    `Assoc
+      [ "kind", `String tool_correction_lost_kind
+      ; "runtime_id", `String runtime_id
+      ; ( "effect_disposition"
+        , `String (Keeper_provider_attempt_effect_core.to_string effect_disposition) )
+      ; "reject_count", `Int reject_count
+      ; "diagnostic", `String diagnostic
+      ]
   | Receipt_persistence_failed { detail } ->
     `Assoc
       [
@@ -657,6 +674,7 @@ let summary_of_masc_internal_error = function
   | Incomplete_tool_transcript _
   | Terminal_effect_failed _
   | Provider_attempt_effect_fenced _
+  | Tool_correction_lost _
   | Receipt_persistence_failed _
   | Gate_replay_repair_required _ -> None
 
@@ -671,6 +689,7 @@ let kind_of_masc_internal_error = function
   | Incomplete_tool_transcript _ -> incomplete_tool_transcript_kind
   | Terminal_effect_failed _ -> "terminal_effect_failed"
   | Provider_attempt_effect_fenced _ -> provider_attempt_effect_fenced_kind
+  | Tool_correction_lost _ -> tool_correction_lost_kind
   | Receipt_persistence_failed _ -> "receipt_persistence_failed"
   | Gate_replay_repair_required _ -> "gate_replay_repair_required"
 
@@ -678,7 +697,8 @@ let runtime_id_of_masc_internal_error = function
   | Runtime_exhausted { runtime_id; _ }
   | Capacity_backpressure { runtime_id; _ }
   | Resumable_cli_session { runtime_id; _ }
-  | Provider_attempt_effect_fenced { runtime_id; _ } ->
+  | Provider_attempt_effect_fenced { runtime_id; _ }
+  | Tool_correction_lost { runtime_id; _ } ->
       let runtime_id = runtime_id_to_string runtime_id in
       if String.equal (String.trim runtime_id) "" then "unknown"
       else runtime_id
@@ -723,6 +743,7 @@ let accept_no_progress_retry_kind = function
   | Incomplete_tool_transcript _
   | Terminal_effect_failed _
   | Provider_attempt_effect_fenced _
+  | Tool_correction_lost _
   | Receipt_persistence_failed _
   | Gate_replay_repair_required _ ->
     None
@@ -947,6 +968,30 @@ let parse_masc_internal_error_json (json : Yojson.Safe.t) :
              (fun effect_disposition ->
                 Provider_attempt_effect_fenced
                   { runtime_id; effect_disposition; diagnostic })
+             (Keeper_provider_attempt_effect_core.of_string effect_disposition)
+         | _ -> None)
+      | Some (`String kind)
+        when String.equal kind tool_correction_lost_kind
+             && exact_fields
+                  [ "kind"
+                  ; "runtime_id"
+                  ; "effect_disposition"
+                  ; "reject_count"
+                  ; "diagnostic"
+                  ]
+                  fields ->
+        (match
+           string_opt_of_assoc "runtime_id" json,
+           string_opt_of_assoc "effect_disposition" json,
+           List.assoc_opt "reject_count" fields,
+           string_opt_of_assoc "diagnostic" json
+         with
+         | Some runtime_id, Some effect_disposition, Some (`Int reject_count),
+           Some diagnostic ->
+           Option.map
+             (fun effect_disposition ->
+                Tool_correction_lost
+                  { runtime_id; effect_disposition; reject_count; diagnostic })
              (Keeper_provider_attempt_effect_core.of_string effect_disposition)
          | _ -> None)
       | Some (`String "receipt_persistence_failed") -> (

--- a/lib/keeper_runtime/keeper_internal_error.mli
+++ b/lib/keeper_runtime/keeper_internal_error.mli
@@ -12,6 +12,12 @@ val incomplete_tool_transcript_kind : string
     forbids same-turn replay. *)
 val provider_attempt_effect_fenced_kind : string
 
+(** Canonical wire kind for a fenced provider-attempt failure whose turn also
+    carried typed pre_tool_use rejections: the model's correction round-trip
+    was the visible casualty (masc#28885). Fence semantics are identical to
+    {!provider_attempt_effect_fenced_kind}; only the label differs. *)
+val tool_correction_lost_kind : string
+
 type provider_rejection = {
   provider_label : string;
   reason : string;
@@ -166,6 +172,18 @@ type masc_internal_error =
       (** A provider attempt failed after an effect was attempted or after the
           runtime lost complete effect observation. The exact source must be
           terminalized as failed, never replayed automatically. *)
+  | Tool_correction_lost of {
+      runtime_id : string;
+      effect_disposition : Keeper_provider_attempt_effect_core.t;
+      reject_count : int;
+      diagnostic : string;
+    }
+      (** The same fence, on a turn that also recorded typed pre_tool_use
+          rejections: the runtime escalated a corrective tool error into the
+          turn's death (masc#28885). Disposition is identical to
+          {!Provider_attempt_effect_fenced} — never replayed in-turn — the
+          label exists so operators can tell a lost correction from an
+          ordinary fenced provider failure. *)
   | Receipt_persistence_failed of { detail : string }
   | Gate_replay_repair_required of {
       approval_id : string;

--- a/lib/keeper_runtime/keeper_runtime_failure_route.ml
+++ b/lib/keeper_runtime/keeper_runtime_failure_route.ml
@@ -29,6 +29,7 @@ type terminal_class =
   | Terminal_effect_runtime_failure
   | Terminal_effect_workflow_rejection
   | Provider_attempt_effect_fenced
+  | Tool_correction_lost
   | Internal_opaque
 
 type failure_provenance =
@@ -155,6 +156,13 @@ let route_of_masc_internal ~err (internal : Keeper_internal_error.masc_internal_
      | Keeper_provider_attempt_effect_core.Effect_attempted
      | Keeper_provider_attempt_effect_core.Observation_unavailable ->
        exhaust_failure Provider_attempt_effect_fenced)
+  | Keeper_internal_error.Tool_correction_lost { effect_disposition; _ } ->
+    (match effect_disposition with
+     | Keeper_provider_attempt_effect_core.No_effect_observed ->
+       exhaust_failure Contract_violation
+     | Keeper_provider_attempt_effect_core.Effect_attempted
+     | Keeper_provider_attempt_effect_core.Observation_unavailable ->
+       exhaust_failure Tool_correction_lost)
   | Keeper_internal_error.Internal_unhandled_exception _
   | Keeper_internal_error.Internal_bridge_exception _ ->
     exhaust_failure Internal_opaque
@@ -283,6 +291,7 @@ let terminal_class_label = function
   | Terminal_effect_runtime_failure -> "terminal_effect_runtime_failure"
   | Terminal_effect_workflow_rejection -> "terminal_effect_workflow_rejection"
   | Provider_attempt_effect_fenced -> "provider_attempt_effect_fenced"
+  | Tool_correction_lost -> "tool_correction_lost"
   | Internal_opaque -> "internal_opaque"
 
 let route_class_label = function

--- a/lib/keeper_runtime/keeper_runtime_failure_route.mli
+++ b/lib/keeper_runtime/keeper_runtime_failure_route.mli
@@ -69,6 +69,7 @@ type terminal_class =
   | Terminal_effect_runtime_failure
   | Terminal_effect_workflow_rejection
   | Provider_attempt_effect_fenced
+  | Tool_correction_lost
   | Internal_opaque
       (** unhandled internal exceptions, serialization/io/orchestration/agent
           family errors; the failure stays visible while the keeper remains

--- a/lib/keeper_runtime/keeper_terminal_reason.ml
+++ b/lib/keeper_runtime/keeper_terminal_reason.ml
@@ -30,6 +30,7 @@ type t =
   | Provider_runtime_failure of string
   | Transcript_corruption of string
   | Provider_attempt_effect_fenced of string
+  | Tool_correction_lost of string
   | Internal_error of string
   | Pre_dispatch_success of string
   | Unknown of string
@@ -73,6 +74,8 @@ let of_wire wire =
   else if
     String.equal wire Keeper_internal_error.provider_attempt_effect_fenced_kind
   then Provider_attempt_effect_fenced wire
+  else if String.equal wire Keeper_internal_error.tool_correction_lost_kind
+  then Tool_correction_lost wire
   else if String.equal wire "internal_error"
   then Internal_error wire
   else if String.equal wire "pre_dispatch_success"
@@ -91,6 +94,7 @@ let to_wire = function
   | Provider_runtime_failure wire -> wire
   | Transcript_corruption wire -> wire
   | Provider_attempt_effect_fenced wire -> wire
+  | Tool_correction_lost wire -> wire
   | Internal_error wire -> wire
   | Pre_dispatch_success wire -> wire
   | Unknown wire -> wire
@@ -120,6 +124,7 @@ let is_transient_provider_runtime_failure = function
   | Config_or_auth _
   | Transcript_corruption _
   | Provider_attempt_effect_fenced _
+  | Tool_correction_lost _
   | Internal_error _
   | Pre_dispatch_success _
   | Unknown _ -> false

--- a/lib/keeper_runtime/keeper_terminal_reason.mli
+++ b/lib/keeper_runtime/keeper_terminal_reason.mli
@@ -76,6 +76,13 @@ type t =
       attempt may have crossed an effect boundary, so same-turn replay is
       forbidden and the operator-facing receipt must retain an explicit alert
       rather than treating it as an unmapped internal state. *)
+  | Tool_correction_lost of string
+  (** Exact canonical wire
+      {!Keeper_internal_error.tool_correction_lost_kind}. The same fence, on a
+      turn that also recorded typed pre_tool_use rejections (masc#28885);
+      disposition matches {!Provider_attempt_effect_fenced}, only the label
+      differs so a lost correction is countable apart from ordinary fenced
+      provider failures. *)
   | Internal_error of string
   (** Exact wire ["internal_error"]. Payload is the original
           string, carried only for [to_wire] round-trip fidelity. *)

--- a/test/test_blocker_class_exhaustiveness.ml
+++ b/test/test_blocker_class_exhaustiveness.ml
@@ -39,6 +39,7 @@ let all_variants : blocker_class list =
   ; Incomplete_tool_transcript
   ; Terminal_effect_failed
   ; Provider_attempt_effect_fenced
+  ; Tool_correction_lost
   ; Receipt_persistence_failed
   ; Gate_replay_repair_required
   ]

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -90,6 +90,7 @@ let roundtrip_corpus =
   ; Keeper_internal_error.capacity_backpressure_kind
   ; Keeper_internal_error.incomplete_tool_transcript_kind
   ; Keeper_internal_error.provider_attempt_effect_fenced_kind
+  ; Keeper_internal_error.tool_correction_lost_kind
   ; "internal_error"
   ; "pre_dispatch_success"
   ; "provider_error"
@@ -184,6 +185,9 @@ let frozen_operator_disposition (receipt : R.t)
       terminal_reason
       Keeper_internal_error.provider_attempt_effect_fenced_kind
   then R.Disp_unknown, R.Reason_provider_attempt_effect_fenced
+  else if
+    String.equal terminal_reason Keeper_internal_error.tool_correction_lost_kind
+  then R.Disp_unknown, R.Reason_tool_correction_lost
   else if preflight_config_failure
   then R.Disp_fail_open_next_runtime, R.Reason_preflight_config_error
   else if
@@ -348,6 +352,49 @@ let () =
   check
     "provider-attempt fence terminal wire round-trips byte-identically"
     (String.equal (Tr.to_wire (Tr.of_wire fenced_wire)) fenced_wire);
+  let lost_error =
+    Keeper_internal_error.Tool_correction_lost
+      { runtime_id = "antigravity_subscription.gemini-3-6-flash-high"
+      ; effect_disposition = Keeper_provider_attempt_effect_core.Effect_attempted
+      ; reject_count = 2
+      ; diagnostic = "turn died after two corrective tool rejections"
+      }
+  in
+  let lost_json = Keeper_internal_error.masc_internal_error_to_json lost_error in
+  check
+    "tool-correction-lost codec emits the canonical kind"
+    (Json_util.get_string lost_json "kind"
+     = Some Keeper_internal_error.tool_correction_lost_kind);
+  check
+    "tool-correction-lost codec round-trips the typed evidence"
+    (Keeper_internal_error.parse_masc_internal_error_json lost_json
+     = Some lost_error);
+  let lost_wire = Keeper_internal_error.tool_correction_lost_kind in
+  check
+    "tool-correction-lost wire decodes to the closed terminal variant"
+    (match Tr.of_wire lost_wire with
+     | Tr.Tool_correction_lost wire -> String.equal wire lost_wire
+     | _ -> false);
+  check
+    "tool-correction-lost terminal wire round-trips byte-identically"
+    (String.equal (Tr.to_wire (Tr.of_wire lost_wire)) lost_wire);
+  let lost_disposition =
+    R.operator_disposition
+      { base_receipt with
+        terminal_reason_code = lost_wire
+      ; error_kind = Some (R.error_kind_of_string "internal")
+      ; outcome = `Error
+      ; runtime_outcome = R.Runtime_failed
+      }
+  in
+  check
+    "tool-correction-lost keeps operator attention with its own typed reason"
+    (lost_disposition = (R.Disp_unknown, R.Reason_tool_correction_lost));
+  check
+    "tool-correction-lost reason has the canonical dashboard wire"
+    (String.equal
+       (R.operator_disposition_reason_to_string (snd lost_disposition))
+       lost_wire);
   let unmapped_metric = Keeper_metrics.(to_string ReceiptUnmappedDisposition) in
   let unmapped_before = Masc.Otel_metric_store.metric_value_or_zero unmapped_metric () in
   let fenced_disposition =


### PR DESCRIPTION
## 무엇

#28885의 두 번째 반쪽(분류 분리). 지속성(#29035)에 이어, typed pre_tool_use 거부를 안고 죽은 fence 턴을 `tool_correction_lost`로 종결합니다 — 처분은 fence와 전 지점 동일(회전 금지·운영자 경보·격리), **라벨만 분리**해 라이브에서 45/80이던 교정 소실을 일반 fence와 구분 계수할 수 있게.

## 어떻게

이슈에 고정해둔 전수 지도 그대로 — 닫힌 어휘 5계열(internal_error·terminal_reason·failure_route·meta_contract·receipt Reason)과 브리지 8파일에 **fenced arm의 정확한 미러**를 추가(캐치올 0, 전 쌍 명시). 발급은 `attempt_runtime_candidates`가 턴의 pre_tool_rejects ref(optional, 기본 빈 ref — 프로브 호출자 무변경)를 받아 **typed 증거로만** 분기 — 문자열 판별 없음. No_effect_observed는 기존대로 Contract_violation 경로 유지.

## 검증

- blocker exhaustiveness 목록·terminal wire corpus에 신어휘 합류 (기존 왕복 테스트가 자동 커버)
- codec 왕복(reject_count 포함 exact_fields)·닫힌 변형 decode·operator disposition 쌍(Disp_unknown + 대시보드 wire) 신규 케이스
- 21파일 전체 파싱 검사 통과, 호출자 스윕은 절단 없이 수행 (지난 회차 교훈 적용)

Closes #28885.

🤖 Generated with [Claude Code](https://claude.com/claude-code)