### PR TITLE
feat(otel): drive runtime-observable sampling from a store-writer fiber

### DIFF
--- a/lib/otel_runtime_observables.ml
+++ b/lib/otel_runtime_observables.ml
@@ -235,6 +235,25 @@ let samples ~masc_root () =
     ]
 ;;
 
+(* masc#29023: these samples used to reach the world only through the
+   OTLP export tick, and that tick fires only when a collector backend
+   is installed — with no collector every surface above computed
+   nothing. Sampling is now decoupled from export: the store writer
+   lands the values in Otel_metric_store cells (always readable by the
+   fleet HTTP and dashboard surfaces), and the store's own registered
+   OTLP source exports those cells when a collector exists — one
+   writer, one exporter, no duplicate series. Cumulative readings land
+   via [set_gauge] exactly like the GC sampler's
+   monotonic-by-construction gauges. *)
+let write_samples_to_store ~masc_root () =
+  let samples = samples ~masc_root () in
+  List.iter
+    (fun { Otel_metrics.name; value; labels; kind = _ } ->
+       Otel_metric_store_core.set_gauge name ~labels value)
+    samples;
+  List.length samples
+;;
+
 let registered = Atomic.make false
 let registration_mu = Stdlib.Mutex.create ()
 
@@ -244,8 +263,27 @@ let register_once ~masc_root () =
     Stdlib.Mutex.protect registration_mu (fun () ->
       if not (Atomic.get registered)
       then (
-        Otel_metrics.register_source (fun () -> samples ~masc_root ());
+        (* One synchronous write keeps the RFC-0217 property: every
+           sample is present from process start, absence never reads as
+           zero. *)
+        ignore (write_samples_to_store ~masc_root () : int);
         Atomic.set registered true))
+;;
+
+(* One refresh per half minute keeps queue-depth and byte-size surfaces
+   near-live while the directory walks stay amortized behind their own
+   60s cache. *)
+let store_writer_interval_s = 30.0
+
+let start_store_writer ~sw ~clock ~masc_root () =
+  register_once ~masc_root ();
+  Eio.Fiber.fork_daemon ~sw (fun () ->
+    let rec loop () =
+      Eio.Time.sleep clock store_writer_interval_s;
+      ignore (write_samples_to_store ~masc_root () : int);
+      loop ()
+    in
+    loop ())
 ;;
 
 module For_testing = struct

--- a/lib/otel_runtime_observables.ml
+++ b/lib/otel_runtime_observables.ml
@@ -266,6 +266,7 @@ let register_once ~masc_root () =
         (* One synchronous write keeps the RFC-0217 property: every
            sample is present from process start, absence never reads as
            zero. *)
+        (* fire-and-forget: the count only serves callers that log it *)
         ignore (write_samples_to_store ~masc_root () : int);
         Atomic.set registered true))
 ;;
@@ -280,6 +281,7 @@ let start_store_writer ~sw ~clock ~masc_root () =
   Eio.Fiber.fork_daemon ~sw (fun () ->
     let rec loop () =
       Eio.Time.sleep clock store_writer_interval_s;
+      (* fire-and-forget: the count only serves callers that log it *)
       ignore (write_samples_to_store ~masc_root () : int);
       loop ()
     in
@@ -288,5 +290,6 @@ let start_store_writer ~sw ~clock ~masc_root () =
 
 module For_testing = struct
   let samples = samples
+  let write_samples_to_store = write_samples_to_store
   let reset_store_cache () = Atomic.set store_cache (neg_infinity, [])
 end

--- a/lib/otel_runtime_observables.mli
+++ b/lib/otel_runtime_observables.mli
@@ -19,20 +19,8 @@
     from server bootstrap (next to
     [Otel_metric_store.register_otel_source_once]). [masc_root] anchors the
     watched store directories. *)
-val register_once : masc_root:string -> unit -> unit
-
-(** Compute the samples once and land them in [Otel_metric_store]
-    cells via [set_gauge] (masc#29023). The store is the single
-    always-on read surface — fleet HTTP and the dashboard read it with
-    no collector required — and the store's own registered OTLP source
-    exports the same cells when a collector exists, so there is one
-    writer and one exporter with no duplicate series. Returns how many
-    samples were written. *)
-val write_samples_to_store : masc_root:string -> unit -> int
-
 (** Start the maintenance fiber that refreshes the store cells every
-    half minute (first write happens synchronously through
-    {!register_once}). Call once from server bootstrap next to the
+    half minute (the first write happens synchronously before the fiber starts). Call once from server bootstrap next to the
     other maintenance fibers. *)
 val start_store_writer :
   sw:Eio.Switch.t ->
@@ -43,5 +31,12 @@ val start_store_writer :
 
 module For_testing : sig
   val samples : masc_root:string -> unit -> Otel_metrics.sample list
+
+  (** Compute the samples once and land them in [Otel_metric_store]
+      cells via [set_gauge] (masc#29023) — the internal step the
+      {!start_store_writer} fiber repeats. Returns how many samples
+      were written. Exposed for tests; production callers go through
+      {!start_store_writer}. *)
+  val write_samples_to_store : masc_root:string -> unit -> int
   val reset_store_cache : unit -> unit
 end

--- a/lib/otel_runtime_observables.mli
+++ b/lib/otel_runtime_observables.mli
@@ -1,5 +1,7 @@
-(** Computed-at-export-tick OTel samples for runtime health surfaces with no
-    store cell: console-sink writer health (#20684: dropped mirror lines +
+(** Periodically sampled runtime health surfaces (masc#29023: sampling
+    is driven by the store-writer fiber, not the OTLP export tick, so
+    the values exist with or without a collector). Covers surfaces with
+    no at-source store cell: console-sink writer health (#20684: dropped mirror lines +
     queue depth), keeper transition-audit drain queue depth (#20677), fd
     accounting (open/limit/pressure/in-flight per kind), event-bus
     backpressure (#20676: masc_event_bus_* subscriber depth / drops /
@@ -18,6 +20,26 @@
     [Otel_metric_store.register_otel_source_once]). [masc_root] anchors the
     watched store directories. *)
 val register_once : masc_root:string -> unit -> unit
+
+(** Compute the samples once and land them in [Otel_metric_store]
+    cells via [set_gauge] (masc#29023). The store is the single
+    always-on read surface — fleet HTTP and the dashboard read it with
+    no collector required — and the store's own registered OTLP source
+    exports the same cells when a collector exists, so there is one
+    writer and one exporter with no duplicate series. Returns how many
+    samples were written. *)
+val write_samples_to_store : masc_root:string -> unit -> int
+
+(** Start the maintenance fiber that refreshes the store cells every
+    half minute (first write happens synchronously through
+    {!register_once}). Call once from server bootstrap next to the
+    other maintenance fibers. *)
+val start_store_writer :
+  sw:Eio.Switch.t ->
+  clock:_ Eio.Time.clock ->
+  masc_root:string ->
+  unit ->
+  unit
 
 module For_testing : sig
   val samples : masc_root:string -> unit -> Otel_metrics.sample list

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -508,7 +508,9 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
      span / no [tool_dispatch_total] metric). *)
   Tool_dispatch.set_span_wrapper Tool_telemetry.with_span;
   Otel_metric_store.register_otel_source_once ();
-  Otel_runtime_observables.register_once
+  Otel_runtime_observables.start_store_writer
+    ~sw
+    ~clock
     ~masc_root:(Workspace.masc_root_dir (Mcp_server.workspace_config state))
     ();
   Otel_spans.setup_exporter ~sw env;

--- a/test/test_otel_runtime_observables.ml
+++ b/test/test_otel_runtime_observables.ml
@@ -99,6 +99,44 @@ let test_fd_samples_present () =
     check bool "legacy pressure gauge absent" true
       (Option.is_none (find "masc_fd_pressure_active" samples)))
 
+(* masc#29023: the store writer lands every computed sample in an
+   Otel_metric_store cell, so fleet HTTP and the dashboard read them
+   with no collector installed. *)
+let test_store_writer_lands_samples_in_cells () =
+  with_temp_masc_root (fun root ->
+    Obs.For_testing.reset_store_cache ();
+    let written = Obs.write_samples_to_store ~masc_root:root () in
+    check bool "writer reports the sample count" true (written > 0);
+    let samples = Obs.For_testing.samples ~masc_root:root () in
+    let queue =
+      List.find
+        (fun (s : Otel_metrics.sample) ->
+          String.equal s.name "masc_console_sink_queue_depth")
+        samples
+    in
+    check (float 0.0)
+      "console queue depth readable from the store with no collector"
+      queue.value
+      (Masc.Otel_metric_store.metric_value_or_zero
+         "masc_console_sink_queue_depth"
+         ());
+    match
+      List.find_opt
+        (fun (s : Otel_metrics.sample) ->
+          String.equal s.name "masc_store_bytes"
+          && s.labels = [ "store", "tool_calls" ])
+        samples
+    with
+    | None -> fail "masc_store_bytes sample missing"
+    | Some bytes ->
+      check (float 0.0)
+        "store bytes readable from the labeled cell"
+        bytes.value
+        (Masc.Otel_metric_store.metric_value_or_zero
+           "masc_store_bytes"
+           ~labels:[ "store", "tool_calls" ]
+           ()))
+
 let () =
   run "otel_runtime_observables"
     [ ( "samples"
@@ -107,5 +145,7 @@ let () =
             test_bus_and_pool_absent_without_subsystems
         ; test_case "store bytes from walk + cache" `Quick test_store_bytes_from_walk
         ; test_case "fd samples present" `Quick test_fd_samples_present
+        ; test_case "store writer lands samples in cells (masc#29023)" `Quick
+            test_store_writer_lands_samples_in_cells
         ] )
     ]

--- a/test/test_otel_runtime_observables.ml
+++ b/test/test_otel_runtime_observables.ml
@@ -105,7 +105,7 @@ let test_fd_samples_present () =
 let test_store_writer_lands_samples_in_cells () =
   with_temp_masc_root (fun root ->
     Obs.For_testing.reset_store_cache ();
-    let written = Obs.write_samples_to_store ~masc_root:root () in
+    let written = Obs.For_testing.write_samples_to_store ~masc_root:root () in
     check bool "writer reports the sample count" true (written > 0);
     let samples = Obs.For_testing.samples ~masc_root:root () in
     let queue =


### PR DESCRIPTION
## 무엇

#29023 수리. 런타임 관측 샘플(console sink·audit 큐·fd·bus 백프레셔·pool·스토어 크기)이 **OTLP export tick 안에서만** 계산돼, collector가 없는 현 운영에선 전부 죽어 있던 결합(매트릭스 Observability blocked의 뿌리)을 끊습니다.

## 어떻게

- **수집과 수출의 분리**: bootstrap maintenance fiber가 30초마다 같은 샘플 계산을 돌려 `Otel_metric_store` 셀에 기록. 첫 기록은 동기(RFC-0217의 process-start 존재 성질 유지).
- **단일 기록자·단일 수출자**: fleet HTTP/대시보드는 셀을 collector 없이 상시 판독, collector가 있으면 store의 기존 등록 소스가 같은 셀을 수출 — 기존의 두 번째 OTLP 소스 등록은 제거(중복 시리즈 방지).
- 누적값의 `set_gauge` 기록은 GC 샘플러의 monotonic-by-construction gauge 선례를 그대로 따름. 디렉터리 walk 60s 캐시 유지.

## 검증

- 신규 테스트: writer가 계산 샘플을 판독 가능한 셀(무라벨 큐 깊이 + 라벨드 store bytes)로 착지시키는지 같은 샘플 계산과 대조 핀.
- register_once 호출자 전수 스윕(절단 없이): bootstrap 1곳뿐 — start_store_writer로 전환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)