### PR TITLE
fix(dashboard): tool_correction_lost attention 라벨 배선 — main CI 수리

### DIFF
--- a/dashboard/src/lib/keeper-attention-labels.ts
+++ b/dashboard/src/lib/keeper-attention-labels.ts
@@ -58,6 +58,7 @@ export const ATTENTION_REASONS = [
   'cancelled',
   'transcript_corruption',
   'provider_attempt_effect_fenced',
+  'tool_correction_lost',
   'unmapped_runtime_state',
 ] as const
 export type AttentionReason = typeof ATTENTION_REASONS[number]
@@ -80,6 +81,7 @@ const ATTENTION_REASON_LABELS: Record<AttentionReason, string> = {
   cancelled: '취소됨',
   transcript_corruption: '대화 기록 손상 - 초기화 필요',
   provider_attempt_effect_fenced: 'Provider 효과 결과 확인 필요',
+  tool_correction_lost: '도구 교정 유실 - 거절 응답이 전달되지 못함',
   unmapped_runtime_state: '매핑되지 않은 runtime 상태',
 }
 


### PR DESCRIPTION
## 무엇 (main 공통 블로커 수리)

#29038(13eee97757)이 `tool_correction_lost` attention_reason을 신설하며 backend 어휘 전체를 미러링했지만 dashboard TS union에는 arm이 없어, `keeper-attention-labels.drift.test.ts`의 build-time drift guard가 이후 **모든 main run의 Dashboard job을 막고 있다** (3연속 red 확인). `ATTENTION_REASONS` union과 한국어 라벨 맵에 fenced arm의 미러로 추가한다.

라벨: `도구 교정 유실 - 거절 응답이 전달되지 못함` (#29038 의미론: fence 턴에 typed pre_tool_use 거절이 있었던 케이스).

## 검증

- `npx vitest run src/lib/keeper-attention-labels.drift.test.ts` → 6/6 pass (수정 전에는 tool_correction_lost missing으로 fail)
- `npx vitest run src/lib/keeper-attention-labels.test.ts` → 4/4 pass
- 수정 선점 broadcast 게시함 (중복 수리 방지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)