### PR TITLE
fix(agent_timeline): stop per-source truncation from dropping early events below limit

### DIFF
--- a/lib/tool_agent_timeline.ml
+++ b/lib/tool_agent_timeline.ml
@@ -237,19 +237,6 @@ let message_events (config : Workspace.config) ~agent_name ~limit :
    exactly the recent events the tool contracts to surface (period.to = now)
    whenever a keeper exceeds the per-source cap. Mirrors [build_timeline]'s
    tail-keep on the merged list, and preserves the source's ascending order. *)
-let take_last n xs =
-  if n <= 0 then []
-  else
-    let len = List.length xs in
-    if len <= n then xs
-    else
-      let rec skip k = function
-        | [] -> []
-        | _ :: rest when k > 0 -> skip (k - 1) rest
-        | remaining -> remaining
-      in
-      skip (len - n) xs
-
 (* Collect tool call events from Activity Graph. Two producers feed this
    source: the external MCP dispatch path ([tool.called]) and the keeper
    in-turn execution hook ([keeper.tool_exec], #23540 — without it a keeper

--- a/lib/tool_agent_timeline.ml
+++ b/lib/tool_agent_timeline.ml
@@ -315,7 +315,6 @@ let tool_call_events (config : Workspace.config) ~agent_name ~limit :
                  ("typed_outcome", typed_outcome);
                ];
          })
-  |> take_last limit
 
 (* Collect turn-completed events from Activity Graph *)
 let turn_completed_events (config : Workspace.config) ~agent_name ~limit :
@@ -404,7 +403,6 @@ let turn_completed_events (config : Workspace.config) ~agent_name ~limit :
                  ("tools_used", `List (List.map (fun s -> `String s) tools_used));
                ] @ optional_fields);
          })
-  |> take_last limit
 
 (* Neutral projection of one keeper chat line for the timeline. The chat
    store (.masc/keeper_chat/<keeper>.jsonl) lives in the keeper subsystem,
@@ -463,7 +461,7 @@ let build_timeline ?(load_chat = fun ~agent_name:_ -> ([] : chat_line list))
       if include_tasks then task_events config ~agent_name
       else []
     in
-    let msg_evts = message_events config ~agent_name ~limit:200 in
+    let msg_evts = message_events config ~agent_name ~limit:2000 in
     let tool_evts =
       if include_tool_calls then tool_call_events config ~agent_name ~limit:200
       else []

--- a/test/test_tool_agent_timeline_build.ml
+++ b/test/test_tool_agent_timeline_build.ml
@@ -211,15 +211,19 @@ let test_self_scoped_chat_reader_blocks_cross_keeper () =
       check (list string) "other keeper chat is hidden" []
         (chat_field "content" (build_for "otherkeeper")))
 
-(* Regression for the per-source take-oldest bug (task-1647): each active
-   timeline collector fetches the source's newest window in seq-ascending order
-   (oldest first) and then front-truncates to the per-source cap. Once a keeper
-   produces more matching events than the cap, the front-take can discard the
-   NEWEST matches — the opposite of the tool contract (period.to = now) and of
-   build_timeline's own tail-keep on the merged list. These tests emit more than
-   the cap and assert the newest event survives while the oldest is dropped. *)
+(* Regression for the per-source truncation bugs (task-1647, task-386).
+   task-1647: each active timeline collector fetched the source's newest window
+   in seq-ascending order (oldest first) and then front-truncated to the
+   per-source cap, which could discard the NEWEST matches. task-386: the
+   per-source cap itself (message/tool/turn = 200) dropped this agent's EARLY
+   events before the merge, so even a final result below the requested limit was
+   missing its oldest events. The per-source truncations are now removed
+   entirely; build_timeline's single tail-keep on the merged list enforces the
+   user's requested limit. These tests emit more than the old cap and assert
+   that BOTH the newest and the oldest event survive when the limit is above
+   the count — i.e. no per-source cap drops early events. *)
 
-(* Per-source cap pinned in build_timeline (message/tool/turn = 200). *)
+(* Old per-source cap pinned in build_timeline (message/tool/turn = 200). *)
 let source_cap = 200
 let overflow = 60
 
@@ -265,24 +269,27 @@ let events_blob json =
 let newest_marker = marker (source_cap + overflow)
 let oldest_marker = marker 1
 
-let check_keeps_newest ~label config =
+(* With the per-source truncations removed (task-386), a limit above the
+   event count must surface BOTH the newest and the oldest event — the old
+   per-source cap would have dropped the oldest. *)
+let check_keeps_all ~label config =
   let blob = events_blob (build_all config ~agent_name:"testkeeper") in
   check bool (label ^ ": newest event present") true
     (contains ~needle:newest_marker blob);
-  check bool (label ^ ": oldest event dropped") false
+  check bool (label ^ ": oldest event present (no per-source cap)") true
     (contains ~needle:oldest_marker blob)
 
-let test_tool_call_keeps_newest () =
+let test_tool_call_keeps_all () =
   with_config (fun config ->
       emit_capacity_series config ~kind:"tool.called"
         ~payload_of:(fun s -> `Assoc [ ("tool_name", `String s) ]);
-      check_keeps_newest ~label:"tool_call" config)
+      check_keeps_all ~label:"tool_call" config)
 
-let test_turn_completed_keeps_newest () =
+let test_turn_completed_keeps_all () =
   with_config (fun config ->
       emit_capacity_series config ~kind:"keeper.turn_completed"
         ~payload_of:(fun s -> `Assoc [ ("model_used", `String s) ]);
-      check_keeps_newest ~label:"turn_completed" config)
+      check_keeps_all ~label:"turn_completed" config)
 
 (* keeper.tool_exec producer -> read model (#23540): keeper in-turn tool
    executions were invisible to the timeline because only the external MCP
@@ -387,11 +394,11 @@ let () =
           test_case "self-scoped reader blocks cross-keeper chat" `Quick
             test_self_scoped_chat_reader_blocks_cross_keeper;
         ] );
-      ( "per-source-cap-keeps-newest",
+      ( "per-source-cap-keeps-all",
         [
-          test_case "tool_call keeps newest" `Quick test_tool_call_keeps_newest;
-          test_case "turn_completed keeps newest" `Quick
-            test_turn_completed_keeps_newest;
+          test_case "tool_call keeps all (no per-source cap)" `Quick test_tool_call_keeps_all;
+          test_case "turn_completed keeps all (no per-source cap)" `Quick
+            test_turn_completed_keeps_all;
         ] );
       ( "keeper-tool-exec-source",
         [


### PR DESCRIPTION
## Summary

Closes task-386. `masc_agent_timeline` was losing early events even when the final result was below the requested `limit`.

## Root cause

`build_timeline` truncated each data source *before* merging:

1. `message_events` was called with `limit:200`, a global cap across ALL agents — in a busy workspace, other agents' broadcasts crowded out this agent's older messages before agent-name filtering.
2. `tool_call_events` and `turn_completed_events` each applied `|> take_last limit` per-source before the merge.

The final truncation in `build_timeline` already enforces the user's requested limit on the merged list, so the per-source truncations were redundant and destructive.

## Changes

- `lib/tool_agent_timeline.ml`: remove `|> take_last limit` from `tool_call_events` and `turn_completed_events`; raise the `message_events` scan limit from 200 to 2000.

## Verification

- `dune build lib/keeper` passes