### PR TITLE
feat(observability): runtime-observable store cells get a dashboard read surface

### DIFF
--- a/lib/otel_metric_store/otel_runtime_metric_names.ml
+++ b/lib/otel_metric_store/otel_runtime_metric_names.ml
@@ -35,3 +35,29 @@ let metric_memory_usage_bytes = "masc_memory_usage_bytes"
    non-yielding syscall or CPU hog -- the shared root cause of the
    2026-06 fleet freezes (#20677, #20684). *)
 let metric_eio_loop_lag_seconds = "masc_eio_loop_lag_seconds"
+
+(* Runtime-observable store cells: written by the Otel_runtime_observables
+   store writer (30s cadence plus one synchronous bootstrap write,
+   masc#29023) and read back by the dashboard runtime-observables endpoint.
+   Names lived as locals in otel_runtime_observables.ml while that module
+   was the only site; the endpoint made them two-site constants. *)
+let metric_console_sink_dropped = "masc_console_sink_dropped_total"
+let metric_console_sink_queue_depth = "masc_console_sink_queue_depth"
+let metric_transition_audit_queue_depth = "masc_keeper_transition_audit_queue_depth"
+let metric_fd_active_operations = "masc_fd_active_operations"
+let metric_fd_resource_errors = "masc_fd_resource_errors_total"
+let metric_store_bytes = "masc_store_bytes"
+let metric_store_files = "masc_store_files"
+let metric_bus_subscriber_dropped = "masc_event_bus_subscriber_dropped_total"
+let metric_bus_subscriber_depth = "masc_event_bus_subscriber_depth"
+let metric_bus_subscribers = "masc_event_bus_subscribers"
+(* The masc_pool_* series predate the observables module; the idle and
+   inflight gauges keep their historical *_total suffix. *)
+let metric_pool_idle = "masc_pool_idle_total"
+let metric_pool_inflight = "masc_pool_inflight_total"
+let metric_pool_reuse = "masc_pool_reuse_total"
+let metric_pool_evict = "masc_pool_evict_total"
+let metric_pool_evict_failure = "masc_pool_evict_failure_total"
+let metric_pool_create = "masc_pool_create_total"
+let metric_runtime_observables_last_write_unixtime =
+  "masc_runtime_observables_last_write_unixtime"

--- a/lib/otel_metric_store/otel_runtime_metric_names.mli
+++ b/lib/otel_metric_store/otel_runtime_metric_names.mli
@@ -58,3 +58,51 @@ val metric_memory_usage_bytes : string
     sampled by the bootstrap lag fiber.  Sustained values mean the single
     domain is blocked (2026-06 fleet-freeze root cause class). *)
 val metric_eio_loop_lag_seconds : string
+
+(** {1 Runtime-observable store cells}
+
+    Written by the [Otel_runtime_observables] store writer — every 30s and
+    once synchronously at bootstrap (masc#29023) — and read back by the
+    dashboard runtime-observables endpoint. Every cell lands as a gauge via
+    [set_gauge]; the cumulative [_total] readings are
+    monotonic-by-construction. *)
+
+(** Console-sink writer health. Unlabeled. *)
+val metric_console_sink_dropped : string
+
+val metric_console_sink_queue_depth : string
+
+(** Keeper transition-audit drain queue depth. Unlabeled. *)
+val metric_transition_audit_queue_depth : string
+
+(** Active fd-bearing operations. Labels: [kind]. *)
+val metric_fd_active_operations : string
+
+(** Cumulative fd/resource failures. Labels: [kind], [error]. *)
+val metric_fd_resource_errors : string
+
+(** On-disk telemetry store totals. Labels: [store] (directory name). *)
+val metric_store_bytes : string
+
+val metric_store_files : string
+
+(** Event-bus subscriber health. [metric_bus_subscribers] carries only a
+    [bus] label; the depth and dropped series add [purpose], [capacity],
+    and [overflow]. *)
+val metric_bus_subscriber_dropped : string
+
+val metric_bus_subscriber_depth : string
+val metric_bus_subscribers : string
+
+(** HTTP connection pool totals. Unlabeled, one series each. *)
+val metric_pool_idle : string
+
+val metric_pool_inflight : string
+val metric_pool_reuse : string
+val metric_pool_evict : string
+val metric_pool_evict_failure : string
+val metric_pool_create : string
+
+(** Unix time of the last completed store-writer pass. Absent until the
+    first write in processes that never start the writer. *)
+val metric_runtime_observables_last_write_unixtime : string

--- a/lib/otel_runtime_observables.ml
+++ b/lib/otel_runtime_observables.ml
@@ -230,9 +230,12 @@ let write_samples_to_store ~masc_root () =
     (fun { Otel_metrics.name; value; labels; kind = _ } ->
        Otel_metric_store_core.set_gauge name ~labels value)
     samples;
+  (* NDT-OK: the wall-clock read is the datum itself — a freshness stamp
+     cell for the read surface; no deterministic branch consumes it. *)
+  let stamped_at = Unix.gettimeofday () in
   Otel_metric_store_core.set_gauge
     Otel_metric_store.metric_runtime_observables_last_write_unixtime
-    (Unix.gettimeofday ());
+    stamped_at;
   List.length samples
 ;;
 

--- a/lib/otel_runtime_observables.ml
+++ b/lib/otel_runtime_observables.ml
@@ -6,33 +6,10 @@
     computed when the exporter ticks, so they are always fresh and present
     from process start (no absence-vs-zero ambiguity). *)
 
-(* Names with exactly one producer site (this module) stay local instead of
-   going through the otel_metric_store name modules: the name-module SSOT
-   exists to share a name between registration and scattered call sites,
-   which does not apply to computed samples. *)
-let metric_console_sink_dropped = "masc_console_sink_dropped_total"
-let metric_console_sink_queue_depth = "masc_console_sink_queue_depth"
-let metric_transition_audit_queue_depth = "masc_keeper_transition_audit_queue_depth"
-let metric_fd_active_operations = "masc_fd_active_operations"
-let metric_fd_resource_errors = "masc_fd_resource_errors_total"
-let metric_store_bytes = "masc_store_bytes"
-let metric_store_files = "masc_store_files"
-
-(* Event-bus health: each subscriber owns a non-blocking queue contract.
-   Labels identify the bus, purpose, capacity, and overflow behavior. *)
-let metric_bus_subscriber_dropped = "masc_event_bus_subscriber_dropped_total"
-let metric_bus_subscriber_depth = "masc_event_bus_subscriber_depth"
-let metric_bus_subscribers = "masc_event_bus_subscribers"
-
-(* HTTP connection pool: the export hook for Pool_metrics.current_snapshot.
-   The masc_pool_* names predate this module (see pool_metrics.ml); the
-   *_total gauges keep their historical names. *)
-let pool_gauge_idle = "masc_pool_idle_total"
-let pool_gauge_inflight = "masc_pool_inflight_total"
-let pool_counter_reuse = "masc_pool_reuse_total"
-let pool_counter_evict = "masc_pool_evict_total"
-let pool_counter_evict_failure = "masc_pool_evict_failure_total"
-let pool_counter_create = "masc_pool_create_total"
+(* Series names live in [Otel_runtime_metric_names] (via the
+   [Otel_metric_store] facade): the dashboard runtime-observables endpoint
+   reads the same cells this module writes, so producer and reader share
+   one constant per series. *)
 
 (* Stores implicated in the 2026-06 freeze incidents: unbounded JSONL growth
    in tool_calls / agent-core-events starved the telemetry readers (#20677), and
@@ -103,8 +80,8 @@ let rec store_samples ~masc_root () =
           if Sys.file_exists dir
           then (
             let bytes, files = walk_dir_totals dir in
-            [ gauge ~labels:[ "store", store ] metric_store_bytes bytes
-            ; gauge ~labels:[ "store", store ] metric_store_files (Float.of_int files)
+            [ gauge ~labels:[ "store", store ] Otel_metric_store.metric_store_bytes bytes
+            ; gauge ~labels:[ "store", store ] Otel_metric_store.metric_store_files (Float.of_int files)
             ])
           else [])
         watched_store_dirs
@@ -132,7 +109,7 @@ let fd_samples () =
       (fun (kind, n) ->
         gauge
           ~labels:[ "kind", Fd_accountant.kind_to_string kind ]
-          metric_fd_active_operations
+          Otel_metric_store.metric_fd_active_operations
           (Float.of_int n))
       snap.Fd_accountant.per_kind
   in
@@ -144,13 +121,15 @@ let fd_samples () =
             [ "kind", Fd_accountant.kind_to_string kind
             ; "error", Fd_accountant.resource_error_to_string error
             ]
-          metric_fd_resource_errors
+          Otel_metric_store.metric_fd_resource_errors
           (Float.of_int count))
       snap.Fd_accountant.resource_errors
   in
   open_limit @ per_kind @ resource_errors
 ;;
 
+(* Event-bus health: each subscriber owns a non-blocking queue contract.
+   Labels identify the bus, purpose, capacity, and overflow behavior. *)
 let bus_samples_of ~bus_label bus =
   let stats = Agent_core.Event_bus.stats bus in
   let by_contract =
@@ -174,7 +153,7 @@ let bus_samples_of ~bus_label bus =
       stats.subscriptions
   in
   let base = [ "bus", bus_label ] in
-  gauge ~labels:base metric_bus_subscribers (Float.of_int stats.subscriber_count)
+  gauge ~labels:base Otel_metric_store.metric_bus_subscribers (Float.of_int stats.subscriber_count)
   :: List.concat_map
        (fun ((purpose, capacity, overflow), (count, depth, dropped)) ->
          let labels =
@@ -188,8 +167,8 @@ let bus_samples_of ~bus_label bus =
              ~labels
              Otel_metric_store.metric_agent_core_bus_capacity
              (Float.of_int (count * capacity))
-         ; gauge ~labels metric_bus_subscriber_depth (Float.of_int depth)
-         ; counter_labeled ~labels metric_bus_subscriber_dropped (Float.of_int dropped)
+         ; gauge ~labels Otel_metric_store.metric_bus_subscriber_depth (Float.of_int depth)
+         ; counter_labeled ~labels Otel_metric_store.metric_bus_subscriber_dropped (Float.of_int dropped)
          ])
        by_contract
 ;;
@@ -209,23 +188,23 @@ let pool_samples () =
   match Pool_metrics.current_snapshot () with
   | None -> []
   | Some s ->
-    [ gauge pool_gauge_idle (Float.of_int s.Masc_http_client.Pool.total_idle)
-    ; gauge pool_gauge_inflight (Float.of_int s.Masc_http_client.Pool.total_inflight)
-    ; counter pool_counter_reuse (Float.of_int s.Masc_http_client.Pool.reuse_count_total)
-    ; counter pool_counter_evict (Float.of_int s.Masc_http_client.Pool.evict_count_total)
+    [ gauge Otel_metric_store.metric_pool_idle (Float.of_int s.Masc_http_client.Pool.total_idle)
+    ; gauge Otel_metric_store.metric_pool_inflight (Float.of_int s.Masc_http_client.Pool.total_inflight)
+    ; counter Otel_metric_store.metric_pool_reuse (Float.of_int s.Masc_http_client.Pool.reuse_count_total)
+    ; counter Otel_metric_store.metric_pool_evict (Float.of_int s.Masc_http_client.Pool.evict_count_total)
     ; counter
-        pool_counter_evict_failure
+        Otel_metric_store.metric_pool_evict_failure
         (Float.of_int s.Masc_http_client.Pool.evict_failure_count_total)
-    ; counter pool_counter_create (Float.of_int s.Masc_http_client.Pool.create_count_total)
+    ; counter Otel_metric_store.metric_pool_create (Float.of_int s.Masc_http_client.Pool.create_count_total)
     ]
 ;;
 
 let samples ~masc_root () =
   List.concat
-    [ [ counter metric_console_sink_dropped (Float.of_int (Console_sink.dropped_count ()))
-      ; gauge metric_console_sink_queue_depth (Float.of_int (Console_sink.queue_depth ()))
+    [ [ counter Otel_metric_store.metric_console_sink_dropped (Float.of_int (Console_sink.dropped_count ()))
+      ; gauge Otel_metric_store.metric_console_sink_queue_depth (Float.of_int (Console_sink.queue_depth ()))
       ; gauge
-          metric_transition_audit_queue_depth
+          Otel_metric_store.metric_transition_audit_queue_depth
           (Float.of_int (Keeper_transition_audit.queue_depth ()))
       ]
     ; fd_samples ()
@@ -239,8 +218,8 @@ let samples ~masc_root () =
    OTLP export tick, and that tick fires only when a collector backend
    is installed — with no collector every surface above computed
    nothing. Sampling is now decoupled from export: the store writer
-   lands the values in Otel_metric_store cells (always readable by the
-   fleet HTTP and dashboard surfaces), and the store's own registered
+   lands the values in Otel_metric_store cells (read back by the
+   dashboard runtime-observables endpoint), and the store's own registered
    OTLP source exports those cells when a collector exists — one
    writer, one exporter, no duplicate series. Cumulative readings land
    via [set_gauge] exactly like the GC sampler's
@@ -251,6 +230,9 @@ let write_samples_to_store ~masc_root () =
     (fun { Otel_metrics.name; value; labels; kind = _ } ->
        Otel_metric_store_core.set_gauge name ~labels value)
     samples;
+  Otel_metric_store_core.set_gauge
+    Otel_metric_store.metric_runtime_observables_last_write_unixtime
+    (Unix.gettimeofday ());
   List.length samples
 ;;
 

--- a/lib/server/server_dashboard_http_runtime_observables.ml
+++ b/lib/server/server_dashboard_http_runtime_observables.ml
@@ -1,0 +1,215 @@
+(** Read surface for the runtime-observable store cells written by
+    [Otel_runtime_observables]. masc#29023 decoupled sampling from OTLP
+    export so the cells are populated with or without a collector; this
+    module is the in-process consumer that makes them operator-visible.
+    Served at [/api/v1/dashboard/runtime-observables]. *)
+
+(* Every family below reads one detached [Otel_metric_store.snapshot]
+   pass; labeled families are re-grouped into typed JSON blocks instead of
+   a raw series dump so the frontend decodes a stable shape. *)
+
+let served_metric_names =
+  [ Otel_metric_store.metric_console_sink_dropped
+  ; Otel_metric_store.metric_console_sink_queue_depth
+  ; Otel_metric_store.metric_transition_audit_queue_depth
+  ; Otel_metric_store.metric_fd_open
+  ; Otel_metric_store.metric_fd_limit
+  ; Otel_metric_store.metric_fd_active_operations
+  ; Otel_metric_store.metric_fd_resource_errors
+  ; Otel_metric_store.metric_store_bytes
+  ; Otel_metric_store.metric_store_files
+  ; Otel_metric_store.metric_bus_subscribers
+  ; Otel_metric_store.metric_bus_subscriber_depth
+  ; Otel_metric_store.metric_bus_subscriber_dropped
+  ; Otel_metric_store.metric_agent_core_bus_capacity
+  ; Otel_metric_store.metric_pool_idle
+  ; Otel_metric_store.metric_pool_inflight
+  ; Otel_metric_store.metric_pool_reuse
+  ; Otel_metric_store.metric_pool_evict
+  ; Otel_metric_store.metric_pool_evict_failure
+  ; Otel_metric_store.metric_pool_create
+  ; Otel_metric_store.metric_runtime_observables_last_write_unixtime
+  ]
+;;
+
+let rows metrics name =
+  List.filter
+    (fun (m : Otel_metric_store.metric) -> String.equal m.name name)
+    metrics
+;;
+
+let label (m : Otel_metric_store.metric) key = List.assoc_opt key m.labels
+
+let unlabeled_value metrics name =
+  List.find_map
+    (fun (m : Otel_metric_store.metric) ->
+       if String.equal m.name name && m.labels = [] then Some m.value else None)
+    metrics
+;;
+
+(* Cells absent from the store (a process that never ran the writer) render
+   as [null]: absence must stay distinguishable from a written zero. *)
+let opt_int = function
+  | Some v -> `Int (int_of_float v)
+  | None -> `Null
+;;
+
+let console_sink_json metrics =
+  `Assoc
+    [ ( "queue_depth"
+      , opt_int
+          (unlabeled_value metrics Otel_metric_store.metric_console_sink_queue_depth) )
+    ; ( "dropped_total"
+      , opt_int (unlabeled_value metrics Otel_metric_store.metric_console_sink_dropped)
+      )
+    ]
+;;
+
+let transition_audit_json metrics =
+  `Assoc
+    [ ( "queue_depth"
+      , opt_int
+          (unlabeled_value
+             metrics
+             Otel_metric_store.metric_transition_audit_queue_depth) )
+    ]
+;;
+
+let fd_json metrics =
+  let active =
+    rows metrics Otel_metric_store.metric_fd_active_operations
+    |> List.filter_map (fun (m : Otel_metric_store.metric) ->
+      match label m "kind" with
+      | Some kind -> Some (kind, m.value)
+      | None -> None)
+    |> List.sort (fun (a, _) (b, _) -> String.compare a b)
+    |> List.map (fun (kind, count) ->
+      `Assoc [ "kind", `String kind; "count", `Int (int_of_float count) ])
+  in
+  let errors =
+    rows metrics Otel_metric_store.metric_fd_resource_errors
+    |> List.filter_map (fun (m : Otel_metric_store.metric) ->
+      match label m "kind", label m "error" with
+      | Some kind, Some error -> Some (kind, error, m.value)
+      | _ -> None)
+    |> List.sort (fun (ka, ea, _) (kb, eb, _) ->
+      match String.compare ka kb with
+      | 0 -> String.compare ea eb
+      | c -> c)
+    |> List.map (fun (kind, error, count) ->
+      `Assoc
+        [ "kind", `String kind
+        ; "error", `String error
+        ; "count", `Int (int_of_float count)
+        ])
+  in
+  `Assoc
+    [ "open", opt_int (unlabeled_value metrics Otel_metric_store.metric_fd_open)
+    ; "limit", opt_int (unlabeled_value metrics Otel_metric_store.metric_fd_limit)
+    ; "active_operations", `List active
+    ; "resource_errors", `List errors
+    ]
+;;
+
+let stores_json metrics =
+  let files_for store =
+    rows metrics Otel_metric_store.metric_store_files
+    |> List.find_map (fun (m : Otel_metric_store.metric) ->
+      if label m "store" = Some store then Some m.value else None)
+  in
+  rows metrics Otel_metric_store.metric_store_bytes
+  |> List.filter_map (fun (m : Otel_metric_store.metric) ->
+    match label m "store" with
+    | Some store -> Some (store, m.value)
+    | None -> None)
+  |> List.sort (fun (a, _) (b, _) -> String.compare a b)
+  |> List.map (fun (store, bytes) ->
+    `Assoc
+      [ "store", `String store
+      ; "bytes", `Int (int_of_float bytes)
+      ; "files", opt_int (files_for store)
+      ])
+  |> fun entries -> `List entries
+;;
+
+let event_bus_json metrics =
+  let canon (m : Otel_metric_store.metric) = List.sort compare m.labels in
+  let find_by_labels rows_ canon_labels =
+    List.find_map
+      (fun (m : Otel_metric_store.metric) ->
+         if canon m = canon_labels then Some m.value else None)
+      rows_
+  in
+  let depth_rows = rows metrics Otel_metric_store.metric_bus_subscriber_depth in
+  let dropped_rows = rows metrics Otel_metric_store.metric_bus_subscriber_dropped in
+  let capacity_rows = rows metrics Otel_metric_store.metric_agent_core_bus_capacity in
+  rows metrics Otel_metric_store.metric_bus_subscribers
+  |> List.filter_map (fun (m : Otel_metric_store.metric) ->
+    match label m "bus" with
+    | Some bus -> Some (bus, m.value)
+    | None -> None)
+  |> List.sort (fun (a, _) (b, _) -> String.compare a b)
+  |> List.map (fun (bus, subscribers) ->
+    let contracts =
+      depth_rows
+      |> List.filter (fun m -> label m "bus" = Some bus)
+      |> List.sort (fun a b -> compare (canon a) (canon b))
+      |> List.map (fun (m : Otel_metric_store.metric) ->
+        let canon_labels = canon m in
+        `Assoc
+          [ ( "purpose"
+            , `String (Option.value (label m "purpose") ~default:"unspecified") )
+          ; ( "capacity"
+            , match Option.bind (label m "capacity") int_of_string_opt with
+              | Some capacity -> `Int capacity
+              | None -> `Null )
+          ; ( "overflow"
+            , `String (Option.value (label m "overflow") ~default:"unspecified") )
+          ; "depth", `Int (int_of_float m.value)
+          ; "dropped_total", opt_int (find_by_labels dropped_rows canon_labels)
+          ; "capacity_total", opt_int (find_by_labels capacity_rows canon_labels)
+          ])
+    in
+    `Assoc
+      [ "bus", `String bus
+      ; "subscribers", `Int (int_of_float subscribers)
+      ; "contracts", `List contracts
+      ])
+  |> fun entries -> `List entries
+;;
+
+let pool_json metrics =
+  let v name = opt_int (unlabeled_value metrics name) in
+  `Assoc
+    [ "idle", v Otel_metric_store.metric_pool_idle
+    ; "inflight", v Otel_metric_store.metric_pool_inflight
+    ; "reuse_total", v Otel_metric_store.metric_pool_reuse
+    ; "evict_total", v Otel_metric_store.metric_pool_evict
+    ; "evict_failure_total", v Otel_metric_store.metric_pool_evict_failure
+    ; "create_total", v Otel_metric_store.metric_pool_create
+    ]
+;;
+
+let runtime_observables_http_json () =
+  let metrics = Otel_metric_store.snapshot () in
+  let last_write =
+    unlabeled_value
+      metrics
+      Otel_metric_store.metric_runtime_observables_last_write_unixtime
+  in
+  let last_write_json, age_json =
+    match last_write with
+    | Some t -> `Float t, `Float (Float.max 0.0 (Unix.gettimeofday () -. t))
+    | None -> `Null, `Null
+  in
+  `Assoc
+    [ "last_write_unixtime", last_write_json
+    ; "age_seconds", age_json
+    ; "console_sink", console_sink_json metrics
+    ; "transition_audit", transition_audit_json metrics
+    ; "fd", fd_json metrics
+    ; "stores", stores_json metrics
+    ; "event_bus", event_bus_json metrics
+    ; "pool", pool_json metrics
+    ]
+;;

--- a/lib/server/server_dashboard_http_runtime_observables.ml
+++ b/lib/server/server_dashboard_http_runtime_observables.ml
@@ -156,15 +156,19 @@ let event_bus_json metrics =
       |> List.sort (fun a b -> compare (canon a) (canon b))
       |> List.map (fun (m : Otel_metric_store.metric) ->
         let canon_labels = canon m in
+        (* The producer encodes an absent subscription purpose as
+           "unspecified" (bus_samples_of); mirroring that encoding is a
+           projection of the producer's own default, not a guess on
+           unknown input. sound-partial: allow *)
+        let purpose = Option.value (label m "purpose") ~default:"unspecified" in
+        let overflow = Option.value (label m "overflow") ~default:"unspecified" in
         `Assoc
-          [ ( "purpose"
-            , `String (Option.value (label m "purpose") ~default:"unspecified") )
+          [ "purpose", `String purpose
           ; ( "capacity"
             , match Option.bind (label m "capacity") int_of_string_opt with
               | Some capacity -> `Int capacity
               | None -> `Null )
-          ; ( "overflow"
-            , `String (Option.value (label m "overflow") ~default:"unspecified") )
+          ; "overflow", `String overflow
           ; "depth", `Int (int_of_float m.value)
           ; "dropped_total", opt_int (find_by_labels dropped_rows canon_labels)
           ; "capacity_total", opt_int (find_by_labels capacity_rows canon_labels)
@@ -198,8 +202,11 @@ let runtime_observables_http_json () =
       Otel_metric_store.metric_runtime_observables_last_write_unixtime
   in
   let last_write_json, age_json =
+    (* NDT-OK: wall-clock feeds only the presented age of the freshness
+       stamp; no deterministic branch depends on the value. *)
+    let now = Unix.gettimeofday () in
     match last_write with
-    | Some t -> `Float t, `Float (Float.max 0.0 (Unix.gettimeofday () -. t))
+    | Some t -> `Float t, `Float (Float.max 0.0 (now -. t))
     | None -> `Null, `Null
   in
   `Assoc

--- a/lib/server/server_dashboard_http_runtime_observables.mli
+++ b/lib/server/server_dashboard_http_runtime_observables.mli
@@ -1,0 +1,15 @@
+(** Read surface for the runtime-observable store cells written by
+    [Otel_runtime_observables] (masc#29023). Serves
+    [/api/v1/dashboard/runtime-observables]. *)
+
+(** Every store-cell name this endpoint serves. The coverage test asserts
+    that every sample the store writer lands appears here, so a new sample
+    family cannot ship invisible. *)
+val served_metric_names : string list
+
+(** One detached [Otel_metric_store.snapshot] pass re-grouped into typed
+    blocks: console sink, transition audit, fd accounting, on-disk store
+    sizes, event-bus contracts, HTTP pool, and the last-write freshness
+    stamp. Cells the writer has not landed render as [null] — absence stays
+    distinguishable from a written zero. *)
+val runtime_observables_http_json : unit -> Yojson.Safe.t

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -1499,6 +1499,13 @@ let add_routes ~sw ~clock router =
          in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
+  |> Http.Router.get "/api/v1/dashboard/runtime-observables" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         let json =
+           Server_dashboard_http_runtime_observables.runtime_observables_http_json ()
+         in
+         Http.Response.json_value ~compress:true ~request:req json reqd
+       ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/gate" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let base_path = (Mcp_server.workspace_config state).base_path in

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -161,6 +161,7 @@ normal_targets=(
   @test/runtest-test_dashboard_nav_event
   @test/runtest-test_dashboard_perf
   @test/runtest-test_dashboard_recent_terminal_tasks
+  @test/runtest-test_server_dashboard_runtime_observables
   @test/runtest-test_auth_ambiguous_lookup_9786
   @test/runtest-test_auth_credential_hash_collision
   @test/runtest-test_mcp_auth_reject_observability

--- a/test/dune
+++ b/test/dune
@@ -1721,6 +1721,8 @@
 
 (include stanzas/test_keeper_scheduled_stimulus_channel.inc)
 
+(include stanzas/test_server_dashboard_runtime_observables.inc)
+
 (include stanzas/test_otel_port_ssot.inc)
 
 (include stanzas/test_otel_zero_fill.inc)

--- a/test/stanzas/test_server_dashboard_runtime_observables.inc
+++ b/test/stanzas/test_server_dashboard_runtime_observables.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_server_dashboard_runtime_observables)
+ (modules test_server_dashboard_runtime_observables)
+ (libraries masc masc.server masc.otel_metrics unix alcotest))

--- a/test/test_server_dashboard_runtime_observables.ml
+++ b/test/test_server_dashboard_runtime_observables.ml
@@ -1,0 +1,111 @@
+(** Runtime-observables read surface (masc#29023 follow-up).
+
+    The store writer landing cells is only half the feature: the dashboard
+    endpoint must serve every family the writer lands, or a sample ships
+    invisible. Coverage is asserted structurally — every sample name the
+    writer produces must be in [served_metric_names] — and behaviorally:
+    after one writer pass the endpoint JSON carries the written values. *)
+
+open Alcotest
+module Obs = Masc.Otel_runtime_observables
+module Endpoint = Server_dashboard_http_runtime_observables
+
+let member key = function
+  | `Assoc fields -> List.assoc_opt key fields
+  | _ -> None
+;;
+
+let with_temp_masc_root f =
+  let root =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "runtime-obs-endpoint-%d" (Unix.getpid ()))
+  in
+  let store = Filename.concat root "logs" in
+  Unix.mkdir root 0o755;
+  Unix.mkdir store 0o755;
+  let oc = open_out (Filename.concat store "runtime.log") in
+  output_string oc "one line of log payload\n";
+  close_out oc;
+  Fun.protect
+    ~finally:(fun () ->
+      Sys.remove (Filename.concat store "runtime.log");
+      Unix.rmdir store;
+      Unix.rmdir root)
+    (fun () -> f root)
+;;
+
+(* Drift guard: a new sample family in the writer without a matching row in
+   the endpoint fails here, not silently in production. *)
+let test_every_sample_name_is_served () =
+  with_temp_masc_root (fun root ->
+    Obs.For_testing.reset_store_cache ();
+    let samples = Obs.For_testing.samples ~masc_root:root () in
+    List.iter
+      (fun (s : Otel_metrics.sample) ->
+         check
+           bool
+           (Printf.sprintf "sample %s has an endpoint row" s.name)
+           true
+           (List.exists (String.equal s.name) Endpoint.served_metric_names))
+      samples)
+;;
+
+let test_endpoint_serves_written_cells () =
+  with_temp_masc_root (fun root ->
+    Obs.For_testing.reset_store_cache ();
+    let written = Obs.For_testing.write_samples_to_store ~masc_root:root () in
+    check bool "writer landed at least the core samples" true (written >= 3);
+    let json = Endpoint.runtime_observables_http_json () in
+    (match member "console_sink" json with
+     | Some console ->
+       (match member "queue_depth" console with
+        | Some (`Int depth) -> check bool "console queue depth is an int" true (depth >= 0)
+        | _ -> fail "console_sink.queue_depth missing or null after a write")
+     | None -> fail "console_sink block missing");
+    (match member "transition_audit" json with
+     | Some audit ->
+       (match member "queue_depth" audit with
+        | Some (`Int depth) -> check bool "audit queue depth is an int" true (depth >= 0)
+        | _ -> fail "transition_audit.queue_depth missing or null after a write")
+     | None -> fail "transition_audit block missing");
+    (match member "stores" json with
+     | Some (`List entries) ->
+       let logs_entry =
+         List.find_opt
+           (fun entry ->
+              match member "store" entry with
+              | Some (`String store) -> String.equal store "logs"
+              | _ -> false)
+           entries
+       in
+       (match logs_entry with
+        | Some entry ->
+          (match member "bytes" entry with
+           | Some (`Int bytes) ->
+             check bool "walked store reports its payload bytes" true (bytes > 0)
+           | _ -> fail "stores.logs.bytes missing")
+        | None -> fail "written watched store missing from stores block")
+     | _ -> fail "stores block missing");
+    match member "last_write_unixtime" json, member "age_seconds" json with
+    | Some (`Float t), Some (`Float age) ->
+      check bool "last write stamp is a real unix time" true (t > 0.0);
+      check bool "age is non-negative" true (age >= 0.0)
+    | _ -> fail "freshness stamp missing after a write")
+;;
+
+let () =
+  run
+    "server_dashboard_runtime_observables"
+    [ ( "runtime-observables read surface"
+      , [ test_case
+            "every writer sample name is served"
+            `Quick
+            test_every_sample_name_is_served
+        ; test_case
+            "endpoint serves written cells"
+            `Quick
+            test_endpoint_serves_written_cells
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 무엇

#29040(store-writer)이 30초마다 `Otel_metric_store`에 착지시키는 런타임 관측 셀 — console sink, transition audit 큐, fd 계정, 스토어 크기, event-bus 계약, HTTP pool — 을 실제로 읽는 표면이 코드베이스에 하나도 없었습니다. #29023 본문의 "기존 즉시저장 소비자(transport_health_json, fleet HTTP)가 그대로 읽음" 주장을 전수 스윕으로 확인한 결과 해당 이름을 읽는 곳이 lib/ 어디에도 없습니다 (fd는 fleet이 store 경유가 아니라 라이브 계산으로 따로 서빙). 수집만 있고 가시성이 없는 반쪽 상태를 닫습니다.

## 어떻게

- **이름 승격**: `otel_runtime_observables.ml` 로컬 상수 16개를 `Otel_runtime_metric_names`(facade 경유 공유)로 이동. "producer 한 곳이라 로컬 유지"라는 기존 주석의 근거는 reader가 생기는 순간 소멸 — 그 주석이 명시한 원칙(2사이트+ = 이름 모듈) 그대로 따랐습니다.
- **읽기 표면**: `GET /api/v1/dashboard/runtime-observables` (`server_dashboard_http_runtime_observables.ml`). snapshot 1회를 typed 블록으로 재그룹:
  - `console_sink{queue_depth, dropped_total}` / `transition_audit{queue_depth}`
  - `fd{open, limit, active_operations[kind], resource_errors[kind,error]}`
  - `stores[{store, bytes, files}]` (디렉터리 정렬)
  - `event_bus[{bus, subscribers, contracts[{purpose, capacity, overflow, depth, dropped_total, capacity_total}]}]`
  - `pool{idle, inflight, reuse_total, evict_total, evict_failure_total, create_total}`
  - 안 써진 셀은 `null` — 부재와 기록된 0을 구분 (raw 시리즈 덤프가 아니라 기존 transport-health/memory-health와 같은 shaped JSON 관례)
- **신선도 스탬프**: writer pass 종료마다 `masc_runtime_observables_last_write_unixtime` gauge 기록, endpoint가 `last_write_unixtime` + `age_seconds` 서빙.
- **드리프트 가드 테스트**: writer가 생산하는 모든 샘플 이름이 `served_metric_names`에 포함되어야 함 — 새 샘플 계열이 보이지 않게 출시되면 테스트가 실패. 추가로 write 후 endpoint JSON이 기록값(콘솔 큐 depth, 스토어 bytes>0, 신선도 스탬프)을 서빙하는지 검증.

## 검증

- 로컬: `ocamlformat --enable-outside-detected-project` 7파일 파싱 OK, dead-surface ratchet 540 baseline 유지
- CI: Build and Test에서 신규 테스트 2케이스 실행
- 후속(별도 PR): dashboard runtime 섹션 패널이 이 endpoint를 소비 (browser 축)

## 매트릭스 연결

Operations/Observability 행의 live 축 — 이 endpoint가 착륙하면 `curl /api/v1/dashboard/runtime-observables`로 셀 실측 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 반증 근거 (#29023 주장 대조, 재조사용)

#29023 본문의 "기존 즉시저장 소비자(transport_health_json, fleet HTTP)가 그대로 읽음"에 대한 반증 스윕 — 이 PR 이전 main에서 producer(`otel_runtime_observables.ml`)와 이름 모듈을 제외하면 소비자 0:

```bash
rg --line-number "masc_console_sink|masc_store_bytes|masc_store_files|masc_event_bus_subscriber|masc_pool_idle" \
  lib --glob '*.ml' \
  --glob '!lib/otel_runtime_observables.ml' \
  --glob '!lib/otel_metric_store/*'
# (no output — 0 hits)
```

- `transport_health_json`(lib/transport_metrics.ml:460)이 읽는 것은 SSE/gRPC/WS 계열(`metric_sse_*`, `metric_grpc_*`)이며 위 이름들은 없음.
- fleet HTTP(`server_routes_http_runtime_health_fleet.ml:538`)의 fd는 `Fd_accountant.fd_snapshot()` 라이브 계산 — store 셀 경유가 아님.
- `Otel_metric_store.snapshot`의 유일한 기존 소비자는 `keeper_composite_observer.ml:131`로, `metric_fsm_guard_violation` 전용 필터.
