### PR TITLE
feat(dashboard): runtime observables panel in the Monitor runtime lane

### DIFF
--- a/dashboard/src/api/runtime-observables.ts
+++ b/dashboard/src/api/runtime-observables.ts
@@ -1,0 +1,212 @@
+// MASC Dashboard — Runtime observables read surface.
+// Backend: lib/server/server_dashboard_http_runtime_observables.ml
+// Route:   GET /api/v1/dashboard/runtime-observables
+//
+// The store writer (Otel_runtime_observables, masc#29023) lands process
+// runtime health in Otel_metric_store every 30s; this endpoint re-groups
+// the cells into typed blocks. Numbers are null when the writer has not
+// landed the cell yet — absence stays distinguishable from a written zero.
+
+import { get } from './core'
+import { asNumber, isRecord } from '../components/common/normalize'
+
+export interface RuntimeObservablesConsoleSink {
+  queue_depth: number | null
+  dropped_total: number | null
+}
+
+export interface RuntimeObservablesTransitionAudit {
+  queue_depth: number | null
+}
+
+export interface RuntimeObservablesFdOperation {
+  kind: string
+  count: number
+}
+
+export interface RuntimeObservablesFdError {
+  kind: string
+  error: string
+  count: number
+}
+
+export interface RuntimeObservablesFd {
+  open: number | null
+  limit: number | null
+  active_operations: RuntimeObservablesFdOperation[]
+  resource_errors: RuntimeObservablesFdError[]
+}
+
+export interface RuntimeObservablesStoreEntry {
+  store: string
+  bytes: number
+  files: number | null
+}
+
+export interface RuntimeObservablesBusContract {
+  purpose: string
+  capacity: number | null
+  overflow: string
+  depth: number
+  dropped_total: number | null
+  capacity_total: number | null
+}
+
+export interface RuntimeObservablesBus {
+  bus: string
+  subscribers: number
+  contracts: RuntimeObservablesBusContract[]
+}
+
+export interface RuntimeObservablesPool {
+  idle: number | null
+  inflight: number | null
+  reuse_total: number | null
+  evict_total: number | null
+  evict_failure_total: number | null
+  create_total: number | null
+}
+
+export interface RuntimeObservablesSnapshot {
+  last_write_unixtime: number | null
+  age_seconds: number | null
+  console_sink: RuntimeObservablesConsoleSink
+  transition_audit: RuntimeObservablesTransitionAudit
+  fd: RuntimeObservablesFd
+  stores: RuntimeObservablesStoreEntry[]
+  event_bus: RuntimeObservablesBus[]
+  pool: RuntimeObservablesPool
+}
+
+function numberOrNull(value: unknown): number | null {
+  if (value === null || value === undefined) return null
+  return asNumber(value) ?? null
+}
+
+function requiredNumber(value: unknown): number | undefined {
+  return asNumber(value)
+}
+
+function requiredString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined
+}
+
+function decodeFdOperation(raw: unknown): RuntimeObservablesFdOperation | null {
+  if (!isRecord(raw)) return null
+  const kind = requiredString(raw.kind)
+  const count = requiredNumber(raw.count)
+  if (kind === undefined || count === undefined) return null
+  return { kind, count }
+}
+
+function decodeFdError(raw: unknown): RuntimeObservablesFdError | null {
+  if (!isRecord(raw)) return null
+  const kind = requiredString(raw.kind)
+  const error = requiredString(raw.error)
+  const count = requiredNumber(raw.count)
+  if (kind === undefined || error === undefined || count === undefined) return null
+  return { kind, error, count }
+}
+
+function decodeStoreEntry(raw: unknown): RuntimeObservablesStoreEntry | null {
+  if (!isRecord(raw)) return null
+  const store = requiredString(raw.store)
+  const bytes = requiredNumber(raw.bytes)
+  if (store === undefined || bytes === undefined) return null
+  return { store, bytes, files: numberOrNull(raw.files) }
+}
+
+function decodeBusContract(raw: unknown): RuntimeObservablesBusContract | null {
+  if (!isRecord(raw)) return null
+  const purpose = requiredString(raw.purpose)
+  const overflow = requiredString(raw.overflow)
+  const depth = requiredNumber(raw.depth)
+  if (purpose === undefined || overflow === undefined || depth === undefined) return null
+  return {
+    purpose,
+    overflow,
+    depth,
+    capacity: numberOrNull(raw.capacity),
+    dropped_total: numberOrNull(raw.dropped_total),
+    capacity_total: numberOrNull(raw.capacity_total),
+  }
+}
+
+function decodeBus(raw: unknown): RuntimeObservablesBus | null {
+  if (!isRecord(raw)) return null
+  const bus = requiredString(raw.bus)
+  const subscribers = requiredNumber(raw.subscribers)
+  if (bus === undefined || subscribers === undefined) return null
+  if (!Array.isArray(raw.contracts)) return null
+  const contracts: RuntimeObservablesBusContract[] = []
+  for (const entry of raw.contracts) {
+    const contract = decodeBusContract(entry)
+    if (contract === null) return null
+    contracts.push(contract)
+  }
+  return { bus, subscribers, contracts }
+}
+
+function decodeAll<T>(raw: unknown, decode: (entry: unknown) => T | null): T[] | null {
+  if (!Array.isArray(raw)) return null
+  const out: T[] = []
+  for (const entry of raw) {
+    const decoded = decode(entry)
+    if (decoded === null) return null
+    out.push(decoded)
+  }
+  return out
+}
+
+export function decodeRuntimeObservables(raw: unknown): RuntimeObservablesSnapshot | null {
+  if (!isRecord(raw)) return null
+  if (!isRecord(raw.console_sink)) return null
+  if (!isRecord(raw.transition_audit)) return null
+  if (!isRecord(raw.fd)) return null
+  if (!isRecord(raw.pool)) return null
+  const activeOperations = decodeAll(raw.fd.active_operations, decodeFdOperation)
+  const resourceErrors = decodeAll(raw.fd.resource_errors, decodeFdError)
+  const stores = decodeAll(raw.stores, decodeStoreEntry)
+  const eventBus = decodeAll(raw.event_bus, decodeBus)
+  if (
+    activeOperations === null
+    || resourceErrors === null
+    || stores === null
+    || eventBus === null
+  ) return null
+  return {
+    last_write_unixtime: numberOrNull(raw.last_write_unixtime),
+    age_seconds: numberOrNull(raw.age_seconds),
+    console_sink: {
+      queue_depth: numberOrNull(raw.console_sink.queue_depth),
+      dropped_total: numberOrNull(raw.console_sink.dropped_total),
+    },
+    transition_audit: {
+      queue_depth: numberOrNull(raw.transition_audit.queue_depth),
+    },
+    fd: {
+      open: numberOrNull(raw.fd.open),
+      limit: numberOrNull(raw.fd.limit),
+      active_operations: activeOperations,
+      resource_errors: resourceErrors,
+    },
+    stores,
+    event_bus: eventBus,
+    pool: {
+      idle: numberOrNull(raw.pool.idle),
+      inflight: numberOrNull(raw.pool.inflight),
+      reuse_total: numberOrNull(raw.pool.reuse_total),
+      evict_total: numberOrNull(raw.pool.evict_total),
+      evict_failure_total: numberOrNull(raw.pool.evict_failure_total),
+      create_total: numberOrNull(raw.pool.create_total),
+    },
+  }
+}
+
+export function fetchRuntimeObservables(): Promise<RuntimeObservablesSnapshot> {
+  return get<unknown>('/api/v1/dashboard/runtime-observables').then((raw) => {
+    const decoded = decodeRuntimeObservables(raw)
+    if (!decoded) throw new Error('유효하지 않은 runtime observables payload')
+    return decoded
+  })
+}

--- a/dashboard/src/components/runtime-observables-panel.test.ts
+++ b/dashboard/src/components/runtime-observables-panel.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment happy-dom
+import { html } from 'htm/preact'
+import { cleanup, render, screen, waitFor } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { RuntimeObservablesSnapshot } from '../api/runtime-observables'
+
+const mockFetch = vi.fn<() => Promise<RuntimeObservablesSnapshot>>()
+
+vi.mock('../api/runtime-observables', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../api/runtime-observables')>()
+  return {
+    ...original,
+    fetchRuntimeObservables: () => mockFetch(),
+  }
+})
+
+import { decodeRuntimeObservables } from '../api/runtime-observables'
+import { RuntimeObservablesPanel } from './runtime-observables-panel'
+
+function makeSnapshot(
+  overrides: Partial<RuntimeObservablesSnapshot> = {},
+): RuntimeObservablesSnapshot {
+  return {
+    last_write_unixtime: 1_766_000_000,
+    age_seconds: 12,
+    console_sink: { queue_depth: 3, dropped_total: 0 },
+    transition_audit: { queue_depth: 1 },
+    fd: {
+      open: 210,
+      limit: 10_240,
+      active_operations: [{ kind: 'jsonl_append', count: 2 }],
+      resource_errors: [],
+    },
+    stores: [
+      { store: 'logs', bytes: 2048, files: 4 },
+      { store: 'tool_calls', bytes: 1_500_000, files: 12 },
+    ],
+    event_bus: [
+      {
+        bus: 'masc_domain',
+        subscribers: 2,
+        contracts: [
+          {
+            purpose: 'keeper_lifecycle',
+            capacity: 1024,
+            overflow: 'drop_oldest',
+            depth: 0,
+            dropped_total: 0,
+            capacity_total: 1024,
+          },
+        ],
+      },
+    ],
+    pool: {
+      idle: 1,
+      inflight: 0,
+      reuse_total: 42,
+      evict_total: 3,
+      evict_failure_total: 0,
+      create_total: 7,
+    },
+    ...overrides,
+  }
+}
+
+describe('RuntimeObservablesPanel', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders the written cells as stats, stores, and bus contracts', async () => {
+    mockFetch.mockResolvedValue(makeSnapshot())
+    render(html`<${RuntimeObservablesPanel} />`)
+
+    await waitFor(() => {
+      expect(screen.getByText('프로세스 관측')).toBeTruthy()
+    })
+    expect(screen.getByText('12초 전 샘플')).toBeTruthy()
+    expect(screen.getByText('콘솔 싱크 큐')).toBeTruthy()
+    expect(screen.getByText('logs')).toBeTruthy()
+    expect(screen.getByText('1.43 MB')).toBeTruthy()
+    expect(screen.getByText('masc_domain')).toBeTruthy()
+    expect(screen.getByText('keeper_lifecycle')).toBeTruthy()
+  })
+
+  it('renders absent cells as dashes, never as zero', async () => {
+    mockFetch.mockResolvedValue(
+      makeSnapshot({
+        age_seconds: null,
+        last_write_unixtime: null,
+        console_sink: { queue_depth: null, dropped_total: null },
+        pool: {
+          idle: null,
+          inflight: null,
+          reuse_total: null,
+          evict_total: null,
+          evict_failure_total: null,
+          create_total: null,
+        },
+      }),
+    )
+    render(html`<${RuntimeObservablesPanel} />`)
+
+    await waitFor(() => {
+      expect(screen.getByText('샘플 없음')).toBeTruthy()
+    })
+    const queueStat = document.querySelector('[data-observable-stat="콘솔 싱크 큐"]')
+    expect(queueStat?.textContent).toContain('—')
+    expect(queueStat?.textContent).not.toContain('0')
+  })
+
+  it('surfaces a fetch failure instead of an empty panel', async () => {
+    mockFetch.mockRejectedValue(new Error('연결 실패'))
+    render(html`<${RuntimeObservablesPanel} />`)
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('[data-observables-state="error"]')?.textContent,
+      ).toContain('연결 실패')
+    })
+  })
+})
+
+describe('decodeRuntimeObservables', () => {
+  it('round-trips a full server payload', () => {
+    const snapshot = makeSnapshot()
+    expect(decodeRuntimeObservables(JSON.parse(JSON.stringify(snapshot)))).toEqual(snapshot)
+  })
+
+  it('rejects structural drift instead of guessing', () => {
+    const broken = JSON.parse(JSON.stringify(makeSnapshot())) as Record<string, unknown>
+    delete broken.console_sink
+    expect(decodeRuntimeObservables(broken)).toBeNull()
+    expect(decodeRuntimeObservables({ stores: 'not-a-list' })).toBeNull()
+  })
+})

--- a/dashboard/src/components/runtime-observables-panel.ts
+++ b/dashboard/src/components/runtime-observables-panel.ts
@@ -1,0 +1,199 @@
+// RuntimeObservablesPanel — process runtime health from the observables
+// store cells (masc#29023): console sink, transition-audit queue, fd
+// accounting, on-disk store sizes, event-bus contracts, HTTP pool.
+//
+// Read-only diagnostic surface for Monitor > Runtime (collapsed by
+// default). Values come from GET /api/v1/dashboard/runtime-observables;
+// a null cell means the store writer has not landed it, rendered as "—"
+// so absence never reads as zero.
+
+import { html } from 'htm/preact'
+import { useEffect, useState } from 'preact/hooks'
+import {
+  fetchRuntimeObservables,
+  type RuntimeObservablesSnapshot,
+} from '../api/runtime-observables'
+import {
+  DEFAULT_PANEL_REFRESH_MS,
+  setupVisibleAutoRefresh,
+} from '../lib/auto-refresh'
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(2)} MB`
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`
+}
+
+function formatCount(value: number | null): string {
+  return value === null ? '—' : value.toLocaleString()
+}
+
+function formatAge(ageSeconds: number | null): string {
+  if (ageSeconds === null) return '샘플 없음'
+  if (ageSeconds < 60) return `${Math.round(ageSeconds)}초 전 샘플`
+  return `${Math.round(ageSeconds / 60)}분 전 샘플`
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return html`
+    <div
+      class="min-w-0 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-3 py-2"
+      data-observable-stat=${label}
+    >
+      <span class="block text-2xs text-[var(--color-fg-muted)]">${label}</span>
+      <span class="mt-1 block text-sm font-semibold tabular-nums text-[var(--color-fg-primary)]">${value}</span>
+    </div>
+  `
+}
+
+function StoresTable({ snapshot }: { snapshot: RuntimeObservablesSnapshot }) {
+  if (snapshot.stores.length === 0) {
+    return html`<div class="text-xs text-[var(--color-fg-muted)]">관측된 스토어 없음</div>`
+  }
+  return html`
+    <table class="w-full text-xs">
+      <thead>
+        <tr class="text-left text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">
+          <th class="py-1 pr-2">store</th>
+          <th class="py-1 pr-2">bytes</th>
+          <th class="py-1">files</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${snapshot.stores.map(entry => html`
+          <tr key=${entry.store} data-observable-store=${entry.store}>
+            <td class="py-1 pr-2 font-mono">${entry.store}</td>
+            <td class="py-1 pr-2 tabular-nums">${formatBytes(entry.bytes)}</td>
+            <td class="py-1 tabular-nums">${formatCount(entry.files)}</td>
+          </tr>
+        `)}
+      </tbody>
+    </table>
+  `
+}
+
+function BusList({ snapshot }: { snapshot: RuntimeObservablesSnapshot }) {
+  if (snapshot.event_bus.length === 0) {
+    return html`<div class="text-xs text-[var(--color-fg-muted)]">활성 이벤트 버스 없음</div>`
+  }
+  return html`
+    <div class="flex flex-col gap-2">
+      ${snapshot.event_bus.map(bus => html`
+        <div key=${bus.bus} data-observable-bus=${bus.bus}>
+          <div class="text-xs font-semibold text-[var(--color-fg-primary)]">
+            <span class="font-mono">${bus.bus}</span>
+            <span class="ml-2 font-normal text-[var(--color-fg-muted)]">구독자 ${bus.subscribers}</span>
+          </div>
+          ${bus.contracts.length === 0
+            ? null
+            : html`
+              <table class="mt-1 w-full text-xs">
+                <thead>
+                  <tr class="text-left text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">
+                    <th class="py-0.5 pr-2">purpose</th>
+                    <th class="py-0.5 pr-2">depth</th>
+                    <th class="py-0.5 pr-2">dropped</th>
+                    <th class="py-0.5">capacity</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  ${bus.contracts.map(contract => html`
+                    <tr key=${`${contract.purpose}-${contract.capacity ?? 'na'}-${contract.overflow}`}>
+                      <td class="py-0.5 pr-2 font-mono">${contract.purpose}</td>
+                      <td class="py-0.5 pr-2 tabular-nums">${contract.depth}</td>
+                      <td class="py-0.5 pr-2 tabular-nums">${formatCount(contract.dropped_total)}</td>
+                      <td class="py-0.5 tabular-nums">${formatCount(contract.capacity)} · ${contract.overflow}</td>
+                    </tr>
+                  `)}
+                </tbody>
+              </table>
+            `}
+        </div>
+      `)}
+    </div>
+  `
+}
+
+function Section({ title, children }: { title: string; children: unknown }) {
+  return html`
+    <div class="flex min-w-0 flex-col gap-2">
+      <div class="text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">${title}</div>
+      ${children}
+    </div>
+  `
+}
+
+export function RuntimeObservablesPanel() {
+  const [snapshot, setSnapshot] = useState<RuntimeObservablesSnapshot | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    // useEffect is appropriate here: external-system synchronization
+    // (periodic HTTP fetch from the MASC API), not derived state.
+    const controller = new AbortController()
+
+    const refresh = async () => {
+      try {
+        const result = await fetchRuntimeObservables()
+        if (controller.signal.aborted) return
+        setSnapshot(result)
+        setError(null)
+      } catch (err) {
+        if (controller.signal.aborted) return
+        setError(err instanceof Error ? err.message : 'runtime observables fetch failed')
+      } finally {
+        if (!controller.signal.aborted) setLoading(false)
+      }
+    }
+
+    setLoading(true)
+    void refresh()
+    const cleanup = setupVisibleAutoRefresh(() => { void refresh() }, DEFAULT_PANEL_REFRESH_MS)
+
+    return () => {
+      controller.abort()
+      cleanup()
+    }
+  }, [])
+
+  if (loading && snapshot === null) {
+    return html`<div class="text-xs text-[var(--color-fg-muted)]" data-observables-state="loading">프로세스 관측 로딩 중…</div>`
+  }
+  if (error !== null && snapshot === null) {
+    return html`<div class="text-xs text-[var(--color-danger-fg)]" data-observables-state="error">${error}</div>`
+  }
+  if (snapshot === null) return null
+
+  return html`
+    <section
+      class="flex flex-col gap-4 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3"
+      aria-label="Runtime observables"
+      data-observables-state="ready"
+    >
+      <div class="flex items-baseline justify-between gap-2">
+        <div class="text-sm font-semibold text-[var(--color-fg-primary)]">프로세스 관측</div>
+        <div class="text-2xs text-[var(--color-fg-muted)]" data-observables-age>${formatAge(snapshot.age_seconds)}</div>
+      </div>
+      <div class="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+        <${Stat} label="콘솔 싱크 큐" value=${formatCount(snapshot.console_sink.queue_depth)} />
+        <${Stat} label="콘솔 싱크 드랍 누계" value=${formatCount(snapshot.console_sink.dropped_total)} />
+        <${Stat} label="전이 감사 큐" value=${formatCount(snapshot.transition_audit.queue_depth)} />
+        <${Stat} label="FD 사용/한도" value=${`${formatCount(snapshot.fd.open)} / ${formatCount(snapshot.fd.limit)}`} />
+        <${Stat} label="HTTP 풀 유휴" value=${formatCount(snapshot.pool.idle)} />
+        <${Stat} label="HTTP 풀 사용 중" value=${formatCount(snapshot.pool.inflight)} />
+        <${Stat} label="풀 재사용 누계" value=${formatCount(snapshot.pool.reuse_total)} />
+        <${Stat} label="풀 방출 누계" value=${formatCount(snapshot.pool.evict_total)} />
+      </div>
+      <div class="grid gap-4 lg:grid-cols-2">
+        <${Section} title="온디스크 스토어">
+          <${StoresTable} snapshot=${snapshot} />
+        <//>
+        <${Section} title="이벤트 버스">
+          <${BusList} snapshot=${snapshot} />
+        <//>
+      </div>
+    </section>
+  `
+}

--- a/dashboard/src/components/runtime-panel.ts
+++ b/dashboard/src/components/runtime-panel.ts
@@ -32,6 +32,7 @@ import { AgentCoreHealthChip } from './agent-core-health-chip'
 import { RuntimeHealthSnapshot } from './runtime-health-snapshot'
 import { RuntimeMonitor } from './runtime-monitor'
 import { RuntimeTomlEditor } from './runtime-toml-editor'
+import { RuntimeObservablesPanel } from './runtime-observables-panel'
 import { VerificationSpecsPanel } from './verification-specs-panel'
 import { TelemetryPanel, isTelemetryView, TELEMETRY_VIEW_CHIPS } from './telemetry-panel'
 import { RouteLink } from './common/route-link'
@@ -174,6 +175,9 @@ export function RuntimePanel() {
             <${AgentCoreHealthChip} />
             <${RuntimeMonitor} />
             <${HiddenDiagnosticsLinks} />
+            <${CollapsibleSection} id="runtime-details-observables" title="프로세스 관측">
+              <${RuntimeObservablesPanel} />
+            <//>
             <${CollapsibleSection} id="runtime-details-verification" title="형식검증">
               <${VerificationSpecsPanel} />
             <//>


### PR DESCRIPTION
## 무엇

#29047(runtime observables read surface)의 프론트 짝 — `GET /api/v1/dashboard/runtime-observables`를 소비하는 "프로세스 관측" 패널을 Monitor > Runtime 기본 뷰의 접힌 섹션으로 추가합니다. store-writer(masc#29023)가 30초마다 착지시키는 셀 전 계열이 처음으로 운영자 눈에 보입니다:

- 콘솔 싱크 큐/드랍 누계, 전이 감사 큐, FD 사용/한도, HTTP 풀 4종 — 스탯 그리드
- 온디스크 스토어(store/bytes/files) 표, 이벤트 버스 구독 계약(purpose/depth/dropped/capacity) 표
- writer 마지막 pass 기준 신선도(`N초 전 샘플`)

## 계약 유지

- **부재 ≠ 0**: 서버가 `null`로 주는 미기록 셀은 `—`로 렌더 (테스트로 고정: null 셀에서 `0`이 나오면 실패)
- **드리프트는 조용히 넘기지 않음**: 수동 decode가 구조 불일치 시 `null` → 패널이 에러 상태를 표시 (형제 keeper-memory-health와 같은 관례)
- 폴링은 `setupVisibleAutoRefresh` 표준 주기, useEffect는 외부 시스템 동기화 용도로만

## 검증

- `pnpm typecheck` clean, `pnpm eslint <touched 4 files>` clean
- vitest 14/14 (신규 5케이스: 렌더/부재 대시/에러 표면/decode 왕복/drift 거부 + nav reachability 기존 9)
- 런타임 값은 #29047 착륙 후 라이브 브라우저 실측으로 확인 예정 (매트릭스 browser 축)

## 의존

- #29047 (endpoint) — 파일 겹침 없음, 런타임에서만 의존. 순서 무관하게 머지 가능하나 패널이 데이터를 받으려면 #29047이 먼저 배포되어야 합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
