### PR TITLE
fix(keeper): queue-delivered scheduler wakes run on the scheduled channel

### DIFF
--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -1345,9 +1345,33 @@ let keeper_cycle_decision
   let proactive_gate_enabled =
     Keeper_lifecycle_gate_env.enabled Keeper_lifecycle_gate.Proactive meta
   in
-  let event_queue_reactive_triggers =
+  (* A scheduler wake delivered through the event queue is a scheduled
+     stimulus, not a reactive one. Routing it through the reactive trigger
+     list ran the turn with [channel = Reactive], which applied the
+     reactive prompt/sleep semantics and dropped the wake from every
+     [channel = Scheduled_autonomous] reader (proactive evidence, decision
+     log proof). The due signal joins the scheduled-autonomous decision
+     below instead; a wake that coincides with a real reactive trigger
+     still attributes to that trigger. *)
+  let scheduled_due_from_queue, event_queue_reactive_triggers =
     List.map turn_reason_of_event_queue_trigger event_queue_triggers
+    |> List.partition (function
+      | Scheduled_automation_due -> true
+      | Mention_pending
+      | Board_event_pending
+      | Scope_message_pending
+      | Bootstrap_stimulus_pending
+      | Connector_attention_pending
+      | Hitl_resolved_pending
+      | Completion_authority_rejection_pending
+      | Task_cancellation_pending
+      | Manual_compaction_pending
+      | Workspace_message_pending
+      | Scheduled_autonomous_turn
+      | Task_backlog _
+      | Never_started -> false)
   in
+  let scheduled_due_from_queue = scheduled_due_from_queue <> [] in
   let manual_compaction_control =
     List.mem Manual_compaction_stimulus event_queue_triggers
   in
@@ -1440,6 +1464,7 @@ let keeper_cycle_decision
         in
         let has_actionable_schedule =
           observation.scheduled_automation.due_ready_count > 0
+          || scheduled_due_from_queue
         in
         let is_bootstrap = since_last_scheduled_autonomous = max_int in
         let run_reasons =

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -334,6 +334,7 @@ normal_targets=(
   @test/runtest-test_keeper_event_queue_persist_poison
   @test/runtest-test_keeper_event_queue_state_v2
   @test/runtest-test_keeper_connector_attention_wake
+  @test/runtest-test_keeper_scheduled_stimulus_channel
   @test/runtest-test_keeper_external_attention
   @test/runtest-test_keeper_manual_compaction_preemption
   @test/runtest-test_keeper_compaction_unit

--- a/test/dune
+++ b/test/dune
@@ -1719,6 +1719,8 @@
 
 (include stanzas/test_otel_runtime_observables.inc)
 
+(include stanzas/test_keeper_scheduled_stimulus_channel.inc)
+
 (include stanzas/test_otel_port_ssot.inc)
 
 (include stanzas/test_otel_zero_fill.inc)

--- a/test/stanzas/test_keeper_scheduled_stimulus_channel.inc
+++ b/test/stanzas/test_keeper_scheduled_stimulus_channel.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_scheduled_stimulus_channel)
+ (modules test_keeper_scheduled_stimulus_channel)
+ (libraries masc masc_test_deps alcotest))

--- a/test/test_keeper_scheduled_stimulus_channel.ml
+++ b/test/test_keeper_scheduled_stimulus_channel.ml
@@ -1,0 +1,136 @@
+(* test_keeper_scheduled_stimulus_channel.ml
+
+   A scheduler wake delivered through the event queue must run as
+   [channel = Scheduled_autonomous]. Before the fix the stimulus rode the
+   reactive trigger list, so the turn ran as [Reactive]: the reactive
+   prompt/sleep semantics applied and every channel=scheduled_autonomous
+   reader (proactive evidence, decision log proof) missed the wake — the
+   feature matrix documented the resulting undercount on the Proactive
+   row. A wake that coincides with a real reactive trigger still
+   attributes to that trigger. *)
+
+open Alcotest
+module WO = Masc.Keeper_world_observation
+module Scope = Masc.Keeper_world_observation_message_scope
+
+let make_meta name =
+  let json =
+    `Assoc
+      [ "name", `String name
+      ; "agent_name", `String (Masc.Keeper_identity.keeper_agent_name name)
+      ; "trace_id", `String ("trace-sched-" ^ name)
+      ]
+  in
+  match Masc_test_deps.meta_of_json_fixture json with
+  | Ok meta -> meta
+  | Error err -> fail ("make_meta failed: " ^ err)
+;;
+
+let quiet_obs : WO.world_observation =
+  { pending_messages = []
+  ; pending_board_events = []
+  ; idle_seconds = 0
+  ; active_goals = []
+  ; unclaimed_task_count = 0
+  ; claimable_tasks = []
+  ; failed_task_count = 0
+  ; scheduled_automation = WO.empty_scheduled_automation_observation
+  ; backlog_revision = Some 1
+  ; running_keeper_fiber_count = 1
+  ; connected_surfaces = []
+  ; connected_surface_failures = []
+  ; own_recent_board_posts = []
+  ; fleet_messages = []
+  ; own_recent_actions = []
+  }
+;;
+
+let reasons_of_verdict = function
+  | WO.Run { reasons = first, rest } -> first :: rest
+  | WO.Skip _ -> []
+;;
+
+let decide ?(event_queue_triggers = []) obs =
+  WO.keeper_cycle_decision ~event_queue_triggers ~meta:(make_meta "sched-keeper") obs
+;;
+
+let test_queue_scheduled_stimulus_runs_scheduled_channel () =
+  let d =
+    decide ~event_queue_triggers:[ WO.Scheduled_automation_stimulus ] quiet_obs
+  in
+  check bool "scheduled stimulus drives a turn" true d.should_run;
+  check
+    bool
+    "channel is Scheduled_autonomous, not Reactive"
+    true
+    (d.channel = WO.Scheduled_autonomous);
+  check
+    bool
+    "verdict carries Scheduled_automation_due"
+    true
+    (List.mem WO.Scheduled_automation_due (reasons_of_verdict d.verdict))
+;;
+
+let test_scheduled_stimulus_with_mention_stays_reactive () =
+  let obs =
+    { quiet_obs with
+      pending_messages =
+        [ { Scope.message_id = "msg-1"
+          ; speaker = "vincent"
+          ; content = "@sched-keeper ping"
+          ; kind = Scope.Mention
+          }
+        ]
+    }
+  in
+  let d = decide ~event_queue_triggers:[ WO.Scheduled_automation_stimulus ] obs in
+  check bool "coinciding mention still drives a turn" true d.should_run;
+  check
+    bool
+    "attribution goes to the reactive trigger"
+    true
+    (d.channel = WO.Reactive);
+  check
+    bool
+    "verdict carries Mention_pending"
+    true
+    (List.mem WO.Mention_pending (reasons_of_verdict d.verdict));
+  check
+    bool
+    "scheduled due no longer rides the reactive reason list"
+    false
+    (List.mem WO.Scheduled_automation_due (reasons_of_verdict d.verdict))
+;;
+
+let test_plain_reactive_stimulus_unchanged () =
+  let d =
+    decide ~event_queue_triggers:[ WO.Connector_attention_stimulus ] quiet_obs
+  in
+  check bool "connector stimulus drives a turn" true d.should_run;
+  check bool "channel stays Reactive" true (d.channel = WO.Reactive);
+  check
+    bool
+    "verdict carries Connector_attention_pending"
+    true
+    (List.mem WO.Connector_attention_pending (reasons_of_verdict d.verdict))
+;;
+
+let () =
+  run
+    "keeper_scheduled_stimulus_channel"
+    [ ( "queue-delivered scheduler wake attribution"
+      , [ test_case
+            "scheduled stimulus alone runs as Scheduled_autonomous"
+            `Quick
+            test_queue_scheduled_stimulus_runs_scheduled_channel
+        ; test_case
+            "scheduled stimulus with a mention attributes to the mention"
+            `Quick
+            test_scheduled_stimulus_with_mention_stays_reactive
+        ; test_case
+            "plain reactive stimulus keeps the Reactive channel"
+            `Quick
+            test_plain_reactive_stimulus_unchanged
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 무엇

매트릭스 Proactive 행이 08-17 소스 감사로 기록해둔 결함 — "스케줄러가 깨운 턴이 reactive로 떨어져 proactive 집계 밖" — 을 원천에서 수정합니다. 이번 회차 실측으로 결함이 현재 main에도 살아 있음을 확정했습니다:

- `keeper_world_observation.ml:1348` — 큐로 들어온 자극 전부(`Scheduled_automation_stimulus` 포함)를 `turn_reason_of_event_queue_trigger`로 변환해 **reactive 트리거 리스트에 합류**
- `match reactive_triggers with _ :: _ -> { channel = Reactive; ... }` — 스케줄러 깨움이 due 하나뿐이어도 Reactive 채널로 실행

결과: (1) reactive용 프롬프트/수면 의미가 잘못 적용되고, (2) `channel = scheduled_autonomous`만 세는 모든 리더(keeper 상세 proactive evidence, decision log proof)에서 그 깨움이 누락됩니다.

## 어떻게

큐 유래 트리거에서 `Scheduled_automation_due`만 분리(`List.partition`, 13개 variant 전수 나열 — catch-all 없음)해 scheduled-autonomous 결정의 `has_actionable_schedule`에 합류시킵니다.

- **due 단독 깨움** → `channel = Scheduled_autonomous`, run reason에 `Scheduled_automation_due` — 프롬프트·수면·집계 전부 원천에서 정렬
- **실제 reactive 트리거(멘션 등)와 동시** → 기존대로 그 트리거로 귀속 (사람-대면 자극 우선 유지)
- **reactive 게이트 off + due 단독** → 이전엔 `Reactive_disabled`로 relabel됐지만, 이제 scheduled 판정이 그대로 살아남음 (억눌린 reactive 신호가 아니므로 더 구체적인 이유가 생존 — RFC-0297 arm의 의도와 합치)

## 검증

- Feature 테스트 3케이스 신규 (`test_keeper_scheduled_stimulus_channel`): due 단독 → Scheduled_autonomous + due reason / due+멘션 → Reactive 귀속 + due가 reactive reason 리스트에 안 탐 / 순수 reactive 자극 → 채널 불변
- 로컬 게이트: DET/NDT PASS, ci-test-targets 358 targets OK·528 baseline 유지, ocamlformat 파싱 OK
- CI focused tests에 스위트 등록

## 매트릭스 연결

Proactive 행의 "지표 이름 어긋남" 결함 해소 — 착륙·배포 후 keeper 상세의 proactive evidence 카운트가 스케줄러 깨움을 포함하기 시작하는지가 라이브 판정 기준.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
