### PR TITLE
style(dashboard): keeper-v2 v3 스킨 델타 동기화 — PR-1 (craft·memory·문서)

### DIFF
--- a/dashboard/docs/V2-RESKIN-PROGRESS.md
+++ b/dashboard/docs/V2-RESKIN-PROGRESS.md
@@ -5,12 +5,13 @@ keeper-v2 design prototype (icons, fonts, colors, margins, padding, weight),
 SSOT CSS, production-grade, no stub/hardcode/silent-failure.
 
 ## Ground truth (prototype)
-- Source: keeper-v2 design prototype (jsx + `styles/`), provided out-of-repo by the
-  designer. Point `$KEEPER_V2_PROTO` at its local checkout; the vendored SSOT copy of
-  its CSS lives in `src/styles/keeper-v2/` (the in-repo source of truth for the skin).
-- Standalone (rendered target): the `Keeper Agent v2 (standalone)` HTML from that
-  prototype, served locally (`?surface=<id>` deep-links) — e.g.
-  `python3 -m http.server` inside `$KEEPER_V2_PROTO`.
+- Source: the keeper-v2 design prototype is now IN-REPO at
+  `dashboard/prototypes/keeper-v2/` (v3 export, #29046) — `$KEEPER_V2_PROTO`
+  indirection is no longer needed. The vendored SSOT copy of its CSS lives in
+  `src/styles/keeper-v2/` (the in-repo source of truth for the skin).
+- Standalone (rendered target): `Keeper Agent v3.html` from that directory,
+  served locally (`?surface=<id>` deep-links) — e.g.
+  `python3 -m http.server` inside `dashboard/prototypes/keeper-v2/`.
 - Maps (transient investigation output, regenerable, not committed):
   proto-data-contract, proto-keepers-dom, proto-css-tokens, live-store-mapping,
   current-shell-inventory.
@@ -39,18 +40,17 @@ DONE + verified in-browser (11 surfaces): overview, keepers (roster/rail/chat he
 approvals, board, connectors, logs, settings, workspace, schedule (shell+panel), code/IDE,
 fusion. Far-surface rebuilds (schedule-panel, ide, fusion) landed cleanly.
 
-REMAINING (reverted — rate-limited mid-rewrite, need careful redo):
-- monitoring/Monitor (agent-roster.ts): fl-* row retarget worked, but the rebuild left a
-  DUPLICATE "Keeper Fleet" header (shell SurfaceLead + a second header) + misplaced foot
-  ticker + skeleton stat bars. Note: monitoring is in dashboard-shell's "no own header"
-  list → SurfaceLead renders the title; a rebuild must NOT add a second top header.
-- runtime-editor (runtime-environment-editor.ts + runtime-toml-editor.ts): structure good
-  (.rt-nav sections switch, .rt-lane/.rt-card), but EMBEDDED in settings narrower than the
-  prototype full surface → .rt-lane flex (label-l flex:1 + wide .rt-select control) squeezes
-  the label to ~50px → vertical text wrap. Fix: full-width embed and/or cap .rt-select and/or
-  stack .rt-lane label-above-control when narrow.
-- mobile bottom tab bar (.v2-nav.is-mnav) in nav-rail-v2.ts (desktop-only so far).
-- keepers chat thread/composer (KeeperConversationPanel, board-shared) still .kw-*.
+REMAINING (re-audited 2026-08-19 against the tree — three of four were stale):
+- [x] monitoring duplicate header: RESOLVED in-tree. `status.ts:105-117` skips the
+  SurfaceHeader for `section === 'agents'`; `agent-roster.ts` `.fl-top` owns the header
+  alone, and `monitoring` sits in dashboard-shell's SURFACE_OWN_LEAD_IDS.
+- [x] runtime-editor embed squeeze: RESOLVED in-tree. `keeper-v2/runtime.css` carries the
+  local contract (`.rt-lane` flex-wrap + `.rt-select` max-width 320px), documented at
+  `runtime-environment-editor.ts:498`. Browser re-verify only.
+- [x] mobile bottom tab bar: SHIPPED. `.v2-nav.is-mnav` + more-sheet in
+  `nav-rail-v2.ts:124`, guarded by `mobile-bottom-reserve.test.ts`.
+- [ ] keepers chat thread/composer (KeeperConversationPanel, keeper-shared) still .kw-* —
+  the one real remaining rework (see Deferred polish; planned as v3-delta PR-6).
 
 ## Remaining deltas (adversarial, prioritized)
 - [ ] Keepers roster header: current = verbose stat grid (12/9/0/3) + chips;
@@ -63,9 +63,28 @@ REMAINING (reverted — rate-limited mid-rewrite, need careful redo):
 - [ ] Keepers chat header actions = FSM_ACTIONS glyphs (⏸◉⇄■⚙).
 - [ ] Per-surface audit: overview (도메인 현황 cards), board, schedule, runtime,
       monitor, approvals, work, logs, ide, connectors, settings.
-- [ ] Mobile bottom tab bar (.v2-nav.is-mnav) + more-sheet.
+- [x] Mobile bottom tab bar (.v2-nav.is-mnav) + more-sheet — shipped (see above).
 - [ ] Stray focus-mode toggle bottom-left on non-primary surfaces.
 - [ ] Final cleanup PR: remove legacy *-v2.css / v2-shell.css / app-shell-v2.css once surfaces migrated.
+
+## v3 delta sync (2026-08-19, prototype #29046)
+The in-repo prototype is the v3 export; the vendored CSS was v2-era plus local
+evolution. Per-file disposition of the v2→v3 delta (base `2782405bc3`):
+- craft.css: adopted the v3 desktop `--pad-surface` horizontal tightening
+  (42→30 / 26→18 / 18→14); the local ≤900px media-query tiers stay.
+- memory.css: adopted `.mem-ttl` (salience-bar replacement, RFC-0247) and
+  `.mem-retain*` (retention notice) — mirrored into memory-inspector-v2.css per
+  that file's SYNC CONTRACT. Everything else was already pre-applied.
+- colors_and_type.css: NO-OP — the whole v3 delta is the local-ttf @font-face
+  block, superseded by the dashboard font policy (fonts.css owns fonts).
+- schedule.css / logs.css: VERIFIED, kept as-is. logs has zero missing
+  selectors; schedule's 36 v3-only selectors (.sch-act/.sch-risk/.sch-decision/
+  .sch-reject/…) have zero DOM consumers — the surface renders real projection
+  data with shared ActionButton/StatusChip instead of the prototype's mock
+  operator actions (mark-don't-fake), so the dead selectors are not vendored.
+- Still queued (separate PRs): v2.css (PR-2), surfaces.css (PR-3),
+  fusion/runtime/keeper-config (PR-4), prompt-book (PR-4b), fleet + monitor.css
+  vendoring + agent-roster ctx column (PR-5), chat .kw-* retarget (PR-6).
 
 ## Notes
 - Live data gaps (mark, don't fake): schedule/cron (no signal), context window

--- a/dashboard/src/styles/keeper-v2/craft.css
+++ b/dashboard/src/styles/keeper-v2/craft.css
@@ -29,26 +29,26 @@
    them per density, then top up the spots that still carry literals.
    ══════════════════════════════════════════════════════════════ */
 .v2-app[data-density="spacious"] {
-  --pad-surface: 32px 42px 60px;
+  --pad-surface: 32px 30px 60px;
   --pad-card:    16px 18px;
   --gap-card:    18px;
   --gap-row:     11px;
 }
 .v2-app[data-density="regular"] {
-  --pad-surface: 22px 26px 40px;
+  --pad-surface: 22px 18px 40px;
   --pad-card:    12px 14px;
   --gap-card:    14px;
   --gap-row:     8px;
 }
 .v2-app[data-density="compact"] {
-  --pad-surface: 15px 18px 30px;
+  --pad-surface: 15px 14px 30px;
   --pad-card:    9px 11px;
   --gap-card:    10px;
   --gap-row:     6px;
 }
 
 /* Mobile (single-column shell, ≤900px — same breakpoint the bottom tab bar
-   uses): the desktop surface padding (up to 42px each side on spacious)
+   uses): the desktop surface padding (up to 30px each side on spacious)
    eats ~27% of a 406px viewport once the 12px shell pad is added. Compress
    the horizontal pad per density tier; keep the vertical rhythm. Only
    `--pad-surface` is touched, so every surface on `.ov-scroll`/`.surf-scroll`/

--- a/dashboard/src/styles/keeper-v2/memory.css
+++ b/dashboard/src/styles/keeper-v2/memory.css
@@ -79,7 +79,7 @@
 .mem-store-meta { display: flex; align-items: center; gap: 12px; margin-top: 6px; font-size: 10.5px; color: var(--text-dim); }
 .mem-src { color: var(--text-dim); }
 /* TTL / current badge — replaces the deleted salience bar (RFC-0247) */
-.mem-ttl { flex: none; font-size: 9.5px; letter-spacing: 0.04em; padding: 1px 7px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); }
+.mem-ttl { flex: none; font-size: var(--fs-9-5); letter-spacing: 0.04em; padding: 1px 7px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); }
 .mem-ttl.current { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 36%, transparent); }
 .mem-ttl.expired { color: var(--text-dim); border-style: dashed; }
 .mem-leg-tag { margin-left: 6px; font-size: 8.5px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--status-ok); border: 1px solid color-mix(in oklab, var(--status-ok) 32%, transparent); border-radius: var(--radius-xs); padding: 0 4px; }
@@ -96,7 +96,7 @@
 .mem-op.pin { color: var(--volt-strong); }
 .mem-op.summarize { color: var(--info); }
 /* 보존 정책 고지 — 주기 consolidation 제거(2026-08) */
-.mem-retain { display: flex; flex-direction: column; gap: 3px; margin: 0 0 10px; padding: 8px 10px; border: 1px dashed var(--border-main); border-radius: var(--radius-xs); font-size: 10px; letter-spacing: 0.04em; color: var(--text-dim); }
+.mem-retain { display: flex; flex-direction: column; gap: 3px; margin: 0 0 10px; padding: 8px 10px; border: 1px dashed var(--border-main); border-radius: var(--radius-xs); font-size: var(--fs-10); letter-spacing: 0.04em; color: var(--text-dim); }
 .mem-retain b { color: var(--text-mid); font-weight: 400; }
 .mem-retain-g { font-family: var(--font-ui); font-size: var(--fs-11); letter-spacing: 0; line-height: 1.5; color: var(--text-dim); text-wrap: pretty; }
 .mem-op.compact { color: var(--status-warn); }

--- a/dashboard/src/styles/keeper-v2/memory.css
+++ b/dashboard/src/styles/keeper-v2/memory.css
@@ -78,6 +78,10 @@
 .mem-store-text { font-size: 12.5px; line-height: 1.5; color: var(--text-primary); text-wrap: pretty; }
 .mem-store-meta { display: flex; align-items: center; gap: 12px; margin-top: 6px; font-size: 10.5px; color: var(--text-dim); }
 .mem-src { color: var(--text-dim); }
+/* TTL / current badge — replaces the deleted salience bar (RFC-0247) */
+.mem-ttl { flex: none; font-size: 9.5px; letter-spacing: 0.04em; padding: 1px 7px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); }
+.mem-ttl.current { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 36%, transparent); }
+.mem-ttl.expired { color: var(--text-dim); border-style: dashed; }
 .mem-leg-tag { margin-left: 6px; font-size: 8.5px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--status-ok); border: 1px solid color-mix(in oklab, var(--status-ok) 32%, transparent); border-radius: var(--radius-xs); padding: 0 4px; }
 .mem-tl-range { display: block; margin-top: 3px; font-size: 9.5px; color: var(--text-dim); }
 
@@ -91,6 +95,10 @@
 .mem-op.inject { color: var(--status-ok); }
 .mem-op.pin { color: var(--volt-strong); }
 .mem-op.summarize { color: var(--info); }
+/* 보존 정책 고지 — 주기 consolidation 제거(2026-08) */
+.mem-retain { display: flex; flex-direction: column; gap: 3px; margin: 0 0 10px; padding: 8px 10px; border: 1px dashed var(--border-main); border-radius: var(--radius-xs); font-size: 10px; letter-spacing: 0.04em; color: var(--text-dim); }
+.mem-retain b { color: var(--text-mid); font-weight: 400; }
+.mem-retain-g { font-family: var(--font-ui); font-size: var(--fs-11); letter-spacing: 0; line-height: 1.5; color: var(--text-dim); text-wrap: pretty; }
 .mem-op.compact { color: var(--status-warn); }
 .mem-op.evict { color: var(--text-dim); }
 .mem-tl-text { color: var(--text-mid); min-width: 0; line-height: 1.45; }

--- a/dashboard/src/styles/memory-inspector-v2.css
+++ b/dashboard/src/styles/memory-inspector-v2.css
@@ -161,6 +161,10 @@
 .mem-store-text { font-size: 12.5px; line-height: 1.5; color: var(--text-primary); text-wrap: pretty; }
 .mem-store-meta { display: flex; align-items: center; flex-wrap: wrap; gap: 6px 12px; margin-top: 6px; font-size: 10.5px; color: var(--text-dim); }
 .mem-src { color: var(--text-dim); }
+/* TTL / current badge — replaces the deleted salience bar (RFC-0247) */
+.mem-ttl { flex: none; font-size: 9.5px; letter-spacing: 0.04em; padding: 1px 7px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); }
+.mem-ttl.current { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 36%, transparent); }
+.mem-ttl.expired { color: var(--text-dim); border-style: dashed; }
 .mem-store-why { margin-top: 5px; font-size: 10.5px; color: var(--text-dim); line-height: 1.4; }
 .mem-more { margin-top: 9px; width: 100%; border: 1px solid var(--border-main); border-radius: var(--radius-sm); background: var(--bg-sunken); color: var(--text-mid); font-family: var(--font-ui); font-size: var(--fs-11); padding: 7px 10px; cursor: pointer; transition: 0.14s; }
 .mem-more:hover { border-color: var(--volt-dim); color: var(--volt); }
@@ -177,6 +181,10 @@
 .mem-op.inject { color: var(--status-ok); }
 .mem-op.pin { color: var(--volt-strong); }
 .mem-op.summarize { color: var(--info); }
+/* 보존 정책 고지 — 주기 consolidation 제거(2026-08) */
+.mem-retain { display: flex; flex-direction: column; gap: 3px; margin: 0 0 10px; padding: 8px 10px; border: 1px dashed var(--border-main); border-radius: var(--radius-xs); font-size: 10px; letter-spacing: 0.04em; color: var(--text-dim); }
+.mem-retain b { color: var(--text-mid); font-weight: 400; }
+.mem-retain-g { font-family: var(--font-ui); font-size: var(--fs-11); letter-spacing: 0; line-height: 1.5; color: var(--text-dim); text-wrap: pretty; }
 .mem-op.compact { color: var(--status-warn); }
 .mem-op.evict { color: var(--text-dim); }
 .mem-tl-text { color: var(--text-mid); min-width: 0; line-height: 1.45; }

--- a/dashboard/src/styles/memory-inspector-v2.css
+++ b/dashboard/src/styles/memory-inspector-v2.css
@@ -162,7 +162,7 @@
 .mem-store-meta { display: flex; align-items: center; flex-wrap: wrap; gap: 6px 12px; margin-top: 6px; font-size: 10.5px; color: var(--text-dim); }
 .mem-src { color: var(--text-dim); }
 /* TTL / current badge — replaces the deleted salience bar (RFC-0247) */
-.mem-ttl { flex: none; font-size: 9.5px; letter-spacing: 0.04em; padding: 1px 7px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); }
+.mem-ttl { flex: none; font-size: var(--fs-9-5); letter-spacing: 0.04em; padding: 1px 7px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); }
 .mem-ttl.current { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 36%, transparent); }
 .mem-ttl.expired { color: var(--text-dim); border-style: dashed; }
 .mem-store-why { margin-top: 5px; font-size: 10.5px; color: var(--text-dim); line-height: 1.4; }
@@ -182,7 +182,7 @@
 .mem-op.pin { color: var(--volt-strong); }
 .mem-op.summarize { color: var(--info); }
 /* 보존 정책 고지 — 주기 consolidation 제거(2026-08) */
-.mem-retain { display: flex; flex-direction: column; gap: 3px; margin: 0 0 10px; padding: 8px 10px; border: 1px dashed var(--border-main); border-radius: var(--radius-xs); font-size: 10px; letter-spacing: 0.04em; color: var(--text-dim); }
+.mem-retain { display: flex; flex-direction: column; gap: 3px; margin: 0 0 10px; padding: 8px 10px; border: 1px dashed var(--border-main); border-radius: var(--radius-xs); font-size: var(--fs-10); letter-spacing: 0.04em; color: var(--text-dim); }
 .mem-retain b { color: var(--text-mid); font-weight: 400; }
 .mem-retain-g { font-family: var(--font-ui); font-size: var(--fs-11); letter-spacing: 0; line-height: 1.5; color: var(--text-dim); text-wrap: pretty; }
 .mem-op.compact { color: var(--status-warn); }


### PR DESCRIPTION
## 무엇

keeper-v2 **v3 프로토타입 델타**(#29046, base `2782405bc3`)의 첫 슬라이스예요 — 계획된 6개 PR 중 저위험 묶음(PR-1)입니다.

- `craft.css`: v3의 데스크톱 `--pad-surface` 좌우 패딩 축소(42→30 / 26→18 / 18→14) 채택. 로컬 ≤900px 미디어쿼리 단계는 유지했어요 (주석의 42px 참조도 정정)
- `memory.css`: `.mem-ttl`(salience bar 대체 배지, RFC-0247) + `.mem-retain*`(보존 정책 고지) 채택 — 파일 헤더의 SYNC CONTRACT대로 `memory-inspector-v2.css`에도 미러. font-size는 로컬 토큰화 컨벤션(`var(--fs-11)`)을 따랐습니다
- `V2-RESKIN-PROGRESS.md`: stale했던 REMAINING 4항목 재감사(3개는 이미 트리에서 해소돼 있었어요) + 파일별 v3 처분 기록

## 판정만 하고 코드 변경 없는 것

- `colors_and_type.css`: **무처분** — v3 델타 전체가 로컬 ttf `@font-face` 블록인데, 대시보드 폰트 정책(`fonts.css` 단독 소유, `fonts.test.ts` 가드)이 이미 대체
- `schedule.css` / `logs.css`: **검증 후 유지** — logs는 개별 셀렉터 기준 누락 0. schedule의 v3-전용 셀렉터 36개(`.sch-act/.sch-risk/.sch-decision/…`)는 DOM 소비자 0 — 실제 표면은 projection 실데이터 + 공용 ActionButton/StatusChip으로 렌더하고 프로토의 목 operator 액션은 의도적 미채택(mark-don't-fake)이라 dead 셀렉터를 벤더링하지 않았어요

## 검증

- `pnpm test` **9,018개 전부 통과** (662 파일, 직렬)
- `pnpm typecheck` / `pnpm vitest run src/styles` (170개) / `pnpm tokens:check` green
- `pnpm lint`는 main에서 이미 red(이 변경과 무관한 `keeper-tool-call-inspector.ts` no-nested-ternary 3건) — lint가 CI에 미배선인 근본 원인 포함해 #29054로 분리 기록했어요

## 다음 슬라이스

PR-2 v2.css(최대) → PR-3 surfaces → PR-4/4b fusion·runtime·keeper-config / prompt-book → PR-5 fleet+monitor.css → PR-6 chat `.kw-*` 리타겟

🤖 Generated with [Claude Code](https://claude.com/claude-code)
