### PR TITLE
test(keeper): Thinking 행 typed 관측 파이프 feature test (CoT privacy 포함)

### DIFF
--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -347,6 +347,7 @@ normal_targets=(
   @test/fusion_core/runtest-test_fusion_harness
   @test/fusion_core/runtest-test_fusion_run_registry
   @test/fusion_core/runtest-test_fusion_config_json
+  @test/runtest-test_keeper_thinking_observation
   @test/runtest-test_keeper_external_attention
   @test/runtest-test_keeper_manual_compaction_preemption
   @test/runtest-test_keeper_compaction_unit

--- a/test/dune
+++ b/test/dune
@@ -1721,14 +1721,10 @@
 
 (include stanzas/test_keeper_scheduled_stimulus_channel.inc)
 
-<<<<<<< HEAD
 (include stanzas/test_server_dashboard_runtime_observables.inc)
 
-||||||| parent of a0845236a5 (test(keeper): feature-test the typed reasoning observation pipe)
-=======
 (include stanzas/test_keeper_thinking_observation.inc)
 
->>>>>>> a0845236a5 (test(keeper): feature-test the typed reasoning observation pipe)
 (include stanzas/test_otel_port_ssot.inc)
 
 (include stanzas/test_otel_zero_fill.inc)

--- a/test/dune
+++ b/test/dune
@@ -1721,8 +1721,14 @@
 
 (include stanzas/test_keeper_scheduled_stimulus_channel.inc)
 
+<<<<<<< HEAD
 (include stanzas/test_server_dashboard_runtime_observables.inc)
 
+||||||| parent of a0845236a5 (test(keeper): feature-test the typed reasoning observation pipe)
+=======
+(include stanzas/test_keeper_thinking_observation.inc)
+
+>>>>>>> a0845236a5 (test(keeper): feature-test the typed reasoning observation pipe)
 (include stanzas/test_otel_port_ssot.inc)
 
 (include stanzas/test_otel_zero_fill.inc)

--- a/test/stanzas/test_keeper_thinking_observation.inc
+++ b/test/stanzas/test_keeper_thinking_observation.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_thinking_observation)
+ (modules test_keeper_thinking_observation)
+ (libraries masc masc.trajectory masc.agent_core alcotest unix))

--- a/test/test_keeper_thinking_observation.ml
+++ b/test/test_keeper_thinking_observation.ml
@@ -1,0 +1,216 @@
+(* test_keeper_thinking_observation.ml — Thinking 행 feature test.
+
+   The typed reasoning-observation pipe
+   ([Keeper_agent_run_thinking_trajectory.persist_response_content]) must
+   record one metadata-only entry per reasoning block — kind, turn,
+   block_index, char_count — and never the reasoning text itself. The
+   privacy half is the CoT-privacy contract: the persisted trajectory
+   bytes must not contain any hidden content, and a redacted block must
+   not even leak its length. *)
+
+open Alcotest
+module Obs = Masc.Keeper_agent_run_thinking_trajectory
+module T = Agent_core.Types
+
+let with_temp_masc_root f =
+  let root =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "thinking-obs-%d" (Unix.getpid ()))
+  in
+  Unix.mkdir root 0o755;
+  let rec rm_rf path =
+    if Sys.is_directory path
+    then (
+      Sys.readdir path |> Array.iter (fun n -> rm_rf (Filename.concat path n));
+      Unix.rmdir path)
+    else Sys.remove path
+  in
+  Fun.protect ~finally:(fun () -> rm_rf root) (fun () -> f root)
+;;
+
+let keeper_name = "thinker"
+let trace_id = "trace-think-1"
+
+let make_acc root =
+  Trajectory.create_accumulator
+    ~masc_root:root
+    ~keeper_name
+    ~trace_id
+    ~generation:1
+    ()
+;;
+
+let hidden_thinking = "secret chain of thought"
+let hidden_details = "hidden reasoning detail text"
+let hidden_redacted = "opaque-provider-signature-blob"
+
+let sample_content =
+  [ T.Text "visible answer"
+  ; T.Thinking { content = hidden_thinking; signature = None }
+  ; T.ReasoningDetails
+      { reasoning_content = Some hidden_details; details = [] }
+  ; T.RedactedThinking hidden_redacted
+  ; T.ReasoningDetails { reasoning_content = Some "   "; details = [] }
+  ]
+;;
+
+let thinking_lines root =
+  Trajectory.read_all_lines ~masc_root:root ~keeper_name ~trace_id
+  |> List.filter_map (function
+    | Trajectory.Withheld_thinking entry -> Some entry
+    | Trajectory.Tool_call _ -> None)
+;;
+
+let test_records_one_entry_per_reasoning_block () =
+  with_temp_masc_root (fun root ->
+    let acc = make_acc root in
+    Obs.persist_response_content
+      ~keeper_name
+      ~trajectory_acc:(Some acc)
+      ~turn:7
+      sample_content;
+    let entries = thinking_lines root in
+    check int "three reasoning blocks recorded" 3 (List.length entries);
+    let kinds =
+      List.map (fun (e : Trajectory.withheld_thinking_entry) -> e.reasoning_kind) entries
+    in
+    check
+      bool
+      "kinds cover thinking, details, redacted"
+      true
+      (kinds
+       = [ Trajectory.Thinking_block
+         ; Trajectory.Reasoning_details
+         ; Trajectory.Redacted_thinking
+         ]);
+    List.iter
+      (fun (e : Trajectory.withheld_thinking_entry) ->
+         check int "every entry carries the hook turn" 7 e.turn)
+      entries;
+    check
+      bool
+      "block_index preserves the position in the content list"
+      true
+      (List.map (fun (e : Trajectory.withheld_thinking_entry) -> e.block_index) entries
+       = [ 1; 2; 3 ]))
+;;
+
+let test_char_counts_are_metadata_only () =
+  with_temp_masc_root (fun root ->
+    let acc = make_acc root in
+    Obs.persist_response_content
+      ~keeper_name
+      ~trajectory_acc:(Some acc)
+      ~turn:1
+      sample_content;
+    match thinking_lines root with
+    | [ thinking; details; redacted ] ->
+      check
+        int
+        "thinking char_count matches the hidden text length"
+        (String.length hidden_thinking)
+        thinking.char_count;
+      check
+        int
+        "details char_count matches the joined detail text"
+        (String.length hidden_details)
+        details.char_count;
+      check
+        int
+        "redacted block does not leak its length"
+        0
+        redacted.char_count
+    | entries -> fail (Printf.sprintf "expected 3 entries, got %d" (List.length entries)))
+;;
+
+let test_whitespace_details_and_text_blocks_record_nothing () =
+  with_temp_masc_root (fun root ->
+    let acc = make_acc root in
+    Obs.persist_response_content
+      ~keeper_name
+      ~trajectory_acc:(Some acc)
+      ~turn:2
+      [ T.Text "plain"
+      ; T.ReasoningDetails { reasoning_content = Some " \n " ; details = [] }
+      ];
+    check int "nothing recorded" 0 (List.length (thinking_lines root)))
+;;
+
+let test_no_accumulator_is_a_noop () =
+  with_temp_masc_root (fun root ->
+    Obs.persist_response_content
+      ~keeper_name
+      ~trajectory_acc:None
+      ~turn:3
+      sample_content;
+    check int "no accumulator, no entries" 0 (List.length (thinking_lines root)))
+;;
+
+(* CoT privacy: walk every byte persisted under the masc root and prove the
+   hidden strings never reached disk. *)
+let test_persisted_bytes_never_contain_reasoning_text () =
+  with_temp_masc_root (fun root ->
+    let acc = make_acc root in
+    Obs.persist_response_content
+      ~keeper_name
+      ~trajectory_acc:(Some acc)
+      ~turn:4
+      sample_content;
+    let contains ~needle haystack =
+      let n = String.length needle
+      and h = String.length haystack in
+      let rec go i = i + n <= h && (String.sub haystack i n = needle || go (i + 1)) in
+      go 0
+    in
+    let rec files path =
+      if Sys.is_directory path
+      then
+        Sys.readdir path
+        |> Array.to_list
+        |> List.concat_map (fun n -> files (Filename.concat path n))
+      else [ path ]
+    in
+    let read_file path =
+      let ic = open_in_bin path in
+      Fun.protect
+        ~finally:(fun () -> close_in_noerr ic)
+        (fun () -> really_input_string ic (in_channel_length ic))
+    in
+    let all = files root in
+    check bool "at least one trajectory file persisted" true (all <> []);
+    List.iter
+      (fun path ->
+         let bytes = read_file path in
+         List.iter
+           (fun hidden ->
+              check
+                bool
+                (Printf.sprintf "%s never reaches disk (%s)" hidden (Filename.basename path))
+                false
+                (contains ~needle:hidden bytes))
+           [ hidden_thinking; hidden_details; hidden_redacted ])
+      all)
+;;
+
+let () =
+  run
+    "keeper_thinking_observation"
+    [ ( "typed reasoning observation pipe"
+      , [ test_case
+            "one metadata entry per reasoning block"
+            `Quick
+            test_records_one_entry_per_reasoning_block
+        ; test_case "char counts are metadata only" `Quick test_char_counts_are_metadata_only
+        ; test_case
+            "whitespace details and text blocks record nothing"
+            `Quick
+            test_whitespace_details_and_text_blocks_record_nothing
+        ; test_case "no accumulator is a no-op" `Quick test_no_accumulator_is_a_noop
+        ; test_case
+            "persisted bytes never contain reasoning text"
+            `Quick
+            test_persisted_bytes_never_contain_reasoning_text
+        ] )
+    ]
+;;

--- a/test/test_keeper_thinking_observation.ml
+++ b/test/test_keeper_thinking_observation.ml
@@ -12,11 +12,19 @@ open Alcotest
 module Obs = Masc.Keeper_agent_run_thinking_trajectory
 module T = Agent_core.Types
 
+(* Every case gets its own root AND its own trace id: Trajectory keeps
+   per-(keeper, trace) writer state cached in-process, so reusing a path
+   after rm_rf would leave a cached writer pointed at the unlinked file
+   and the re-created directory would stay empty on read-back. *)
+let case_counter = ref 0
+
 let with_temp_masc_root f =
+  incr case_counter;
+  let case = !case_counter in
   let root =
     Filename.concat
       (Filename.get_temp_dir_name ())
-      (Printf.sprintf "thinking-obs-%d" (Unix.getpid ()))
+      (Printf.sprintf "thinking-obs-%d-%d" (Unix.getpid ()) case)
   in
   Unix.mkdir root 0o755;
   let rec rm_rf path =
@@ -30,13 +38,13 @@ let with_temp_masc_root f =
 ;;
 
 let keeper_name = "thinker"
-let trace_id = "trace-think-1"
+let trace_id () = Printf.sprintf "trace-think-%d" !case_counter
 
 let make_acc root =
   Trajectory.create_accumulator
     ~masc_root:root
     ~keeper_name
-    ~trace_id
+    ~trace_id:(trace_id ())
     ~generation:1
     ()
 ;;
@@ -56,7 +64,7 @@ let sample_content =
 ;;
 
 let thinking_lines root =
-  Trajectory.read_all_lines ~masc_root:root ~keeper_name ~trace_id
+  Trajectory.read_all_lines ~masc_root:root ~keeper_name ~trace_id:(trace_id ())
   |> List.filter_map (function
     | Trajectory.Withheld_thinking entry -> Some entry
     | Trajectory.Tool_call _ -> None)


### PR DESCRIPTION
매트릭스 Thinking 행(ev: source live)의 test 축과 CoT privacy 행의 test 축을 겨냥한 feature test 5케이스입니다.

- reasoning 블록당 메타데이터 엔트리 1건(kind·hook turn·block_index) — Thinking/ReasoningDetails/RedactedThinking 3종
- char_count는 메타데이터만: redacted는 **길이조차 0으로** (길이 누설 차단 계약)
- 공백-only details·Text 블록은 무기록, accumulator 부재는 no-op
- **CoT privacy 직접 증명**: masc root 하위에 persist된 모든 파일의 바이트를 전수 스캔해 숨긴 문자열 3종이 디스크에 도달하지 않음을 단언

focused-tests 등록 포함(ci-test-targets baseline 유지). DET/NDT 해당 없음(테스트 전용).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
