### PR TITLE
fix(ci): apt 인덱스 갱신에 90초 상한 — Meta Guards 15분 타임아웃 소진 차단

### DIFF
--- a/scripts/ci/apt-refresh.sh
+++ b/scripts/ci/apt-refresh.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if sudo apt-get update -qq; then
+# A hung mirror must become a finite failure, not eat the whole job
+# timeout: Meta Guards died at its 15-minute cap three times on 2026-08-19
+# with apt-get update stuck ~15m. The existing fail-open branch below
+# already handles failure; timeout(1) extends it to the hang case.
+if sudo timeout 90 apt-get update -qq; then
   echo "Refreshed apt package index."
 else
-  echo "::warning::apt package index refresh failed; using existing package index" >&2
+  echo "::warning::apt package index refresh failed or timed out; using existing package index" >&2
 fi


### PR DESCRIPTION
오늘 Meta Guards가 3회(15m15s·15m16s·cancelled) 정확히 잡 타임아웃(15분)에서 죽었습니다. 검시: apt-refresh.sh의 apt-get update가 미러 행에서 무한 대기 — 스크립트의 fail-open 분기(캐시 인덱스로 진행)는 exit 실패만 다루고 행은 못 다룹니다. timeout(1) 90초로 행을 유한 실패로 변환해 기존 분기가 의도대로 작동하게 합니다. 정상 실행은 수 초라 여유 충분. 매 취소가 CI Gate rollup 실패 + auto-merge 트레인 정체로 번지던 것도 함께 멎습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)