### PR TITLE
style(dashboard): keeper-v2 v3 스킨 델타 — PR-3 (surfaces.css 표면 공통)

### DIFF
--- a/dashboard/src/styles/keeper-v2/surfaces.css
+++ b/dashboard/src/styles/keeper-v2/surfaces.css
@@ -14,6 +14,20 @@
 .surf-head .eyebrow { font-family: var(--font-mono); font-size: var(--fs-10); letter-spacing: 0.2em; text-transform: uppercase; color: var(--text-dim); margin-bottom: 5px; }
 .surf-sub { margin-top: 5px; font-size: var(--fs-12); color: var(--text-dim); }
 .surf-sub b { color: var(--volt-strong); font-weight: 600; }
+
+/* wiring-status badge — honest "how live is this surface" pill */
+.wire-badge {
+  display: inline-flex; align-items: center; gap: 6px; flex: none; white-space: nowrap;
+  font-family: var(--font-ui); font-size: var(--fs-10); letter-spacing: 0.08em; text-transform: uppercase;
+  padding: 3px 9px; border-radius: var(--radius-pill);
+  border: 1px solid var(--border-main); background: var(--bg-panel-alt); color: var(--text-mid);
+  cursor: help;
+}
+.wire-badge .wb-dot { font-size: 8px; line-height: 1; }
+.wire-live { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 34%, transparent); background: color-mix(in oklab, var(--status-ok) 8%, transparent); }
+.wire-partial { color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 34%, transparent); background: color-mix(in oklab, var(--status-warn) 8%, transparent); }
+.wire-demo { color: var(--text-dim); }
+.wire-experimental { color: var(--status-bad); border-color: color-mix(in oklab, var(--status-bad) 32%, transparent); background: color-mix(in oklab, var(--status-bad) 7%, transparent); }
 .surf-sub .mono { color: var(--text-mid); }
 
 /* ════ COLLAPSIBLE RAILS ════ */
@@ -79,6 +93,7 @@ body.rail-resizing .v2-body { transition: none; }
    the other surfaces (board/monitoring/command/lab/ide). Do not re-add
    max-width / margin:auto on a prototype re-sync. See .cp-inner below. */
 .ov-scroll { flex: 1; overflow-y: auto; padding: var(--pad-surface); width: 100%; }
+.ov-flush .ov-scroll { margin: 0; }
 .ov-head { display: flex; align-items: flex-end; justify-content: space-between; margin-bottom: 18px; }
 .ov-head h1 { font-family: var(--font-display); font-weight: 500; font-size: 22px; color: var(--text-bright); margin: 0; }
 .ov-sub { margin-top: 5px; font-size: var(--fs-12); color: var(--text-dim); }
@@ -354,11 +369,28 @@ body.rail-resizing .v2-body { transition: none; }
 .bd-detail-x { background: none; border: 0; color: var(--text-dim); cursor: pointer; font-size: var(--fs-13); padding: 3px 6px; border-radius: var(--radius-sm); }
 .bd-detail-x:hover { color: var(--text-bright); background: var(--bg-card); }
 .bd-detail-scroll { flex: 1; overflow-y: auto; padding: 14px; display: flex; flex-direction: column; gap: 11px; }
-.bd-th { display: grid; grid-template-columns: 26px 1fr; gap: 9px; }
+.bd-th { display: grid; grid-template-columns: 26px minmax(0, 1fr); gap: 9px; }
+.bd-th > div { min-width: 0; }
 .bd-th-hd { display: flex; align-items: baseline; gap: 7px; }
 .bd-th-hd .who { font-family: var(--font-display); font-weight: 600; font-size: var(--fs-12); color: var(--text-bright); }
 .bd-th-hd .ts { font-family: var(--font-mono); font-size: 9.5px; color: var(--text-dim); }
 .bd-th-body { font-size: 12.5px; color: var(--text-primary); line-height: 1.6; margin-top: 3px; }
+/* rich text inside post/comment detail bodies */
+.bd-th-body p { margin: 0 0 8px; }
+.bd-th-body p:last-child { margin-bottom: 0; }
+.bd-th-body ul, .bd-th-body ol { margin: 6px 0 10px; padding-left: 18px; display: flex; flex-direction: column; gap: 4px; }
+.bd-th-body li { font-size: 12.5px; color: var(--text-primary); }
+.bd-th-body a { color: var(--volt); text-decoration: none; border-bottom: 1px solid color-mix(in oklab, var(--volt) 40%, transparent); }
+.bd-th-body a:hover { color: var(--volt-strong); }
+.bd-th-body strong { color: var(--text-bright); font-weight: 600; }
+.bd-th-body em { color: var(--text-bright); font-style: italic; }
+.bd-th-body blockquote { margin: 8px 0; padding: 7px 12px; border-left: 2px solid var(--volt-dim); background: var(--bg-sunken); color: var(--text-mid); border-radius: 0 var(--radius-sm) var(--radius-sm) 0; font-size: var(--fs-12); }
+.bd-th-body pre { margin: 8px 0; background: var(--bg-deep); border: 1px solid var(--border-soft); border-radius: var(--radius-sm); padding: 10px 12px; overflow-x: auto; }
+.bd-th-body pre code { font-family: var(--font-mono); font-size: var(--fs-11); color: var(--text-primary); background: none; border: 0; padding: 0; white-space: pre; line-height: 1.5; }
+.bd-th-foot { display: flex; align-items: center; gap: 8px; margin-top: 8px; }
+.bd-th-react { font-family: var(--font-mono); font-size: var(--fs-10); color: var(--text-dim); border: 1px solid var(--border-soft); border-radius: var(--radius-pill); padding: 1px 8px; }
+.bd-th-karma { font-family: var(--font-mono); font-size: var(--fs-10); color: var(--text-dim); }
+.bd-th-karma b { color: var(--volt-strong); }
 .bd-mention-row { display: flex; align-items: flex-start; gap: 9px; padding: 9px 10px; border-radius: var(--radius-sm); background: var(--bg-card); border: 1px solid var(--border-soft); cursor: pointer; transition: 0.13s; }
 .bd-mention-row:hover { border-color: var(--border-highlight); }
 .bd-mention-row .txt { font-size: 11.5px; color: var(--text-mid); line-height: 1.5; min-width: 0; }
@@ -381,6 +413,7 @@ body.rail-resizing .v2-body { transition: none; }
 .cn-kv .v { font-family: var(--font-mono); font-size: 11.5px; color: var(--text-mid); margin-top: 3px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .cn-kv .v.hl { color: var(--volt-strong); }
 .cn-caps { display: flex; flex-wrap: wrap; gap: 5px; padding: 10px 15px; border-bottom: 1px solid var(--border-soft); }
+.cn-note { padding: 9px 15px; border-bottom: 1px solid var(--border-soft); font-size: 10.5px; line-height: 1.55; color: var(--text-dim); }
 .cn-cap { font-family: var(--font-mono); font-size: 9.5px; padding: 2px 8px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); color: var(--text-dim); background: var(--bg-deep); white-space: nowrap; }
 .cn-bind { padding: 10px 15px 13px; flex: 1; }
 .cn-bind h5 { font-size: var(--fs-10); letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-dim); margin: 0 0 9px; font-weight: 600; }
@@ -473,8 +506,32 @@ button.cn-bind-row:hover .cn-bind-go { color: var(--volt-strong); transform: tra
 .set-row-l { flex: 1; min-width: 0; }
 .set-label { font-size: var(--fs-13); color: var(--text-primary); }
 .set-hint { font-size: var(--fs-11); color: var(--text-dim); margin-top: 3px; }
+.set-legacy-note {
+  display: flex; align-items: flex-start; gap: 9px; margin: 0 0 14px;
+  padding: 9px 12px; border-radius: var(--radius-xs);
+  border: 1px dashed color-mix(in oklab, var(--text-dim) 55%, transparent);
+  background: color-mix(in oklab, var(--text-dim) 5%, transparent);
+  font-size: 11.5px; line-height: 1.55; color: var(--text-mid);
+}
+.set-legacy-tag {
+  flex: none; font-family: var(--font-ui); font-size: var(--fs-9); letter-spacing: 0.1em; text-transform: uppercase;
+  padding: 2px 7px; border-radius: var(--radius-pill); margin-top: 1px;
+  color: var(--text-dim); border: 1px solid var(--border-main); background: var(--bg-panel-alt);
+}
 .set-row-c { flex: none; }
 .set-sub-h { font-family: var(--font-ui); font-size: var(--fs-10); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-dim); margin: 18px 0 2px; }
+.set-callout { font-size: 11.5px; line-height: 1.55; color: var(--text-mid); padding: 9px 12px; border-radius: var(--radius-xs); background: var(--bg-well); border: 1px solid var(--border-soft); border-left: 2px solid var(--border-main); text-wrap: pretty; }
+.set-callout b { color: var(--text-bright); font-weight: 600; }
+.set-callout.warn { border-left-color: var(--status-warn); background: color-mix(in oklab, var(--status-warn) 8%, var(--bg-well)); }
+
+.set-ro { font-size: var(--fs-12); color: var(--text-dim); }
+.set-dead { margin-top: 12px; border: 1px dashed color-mix(in oklab, var(--status-warn) 26%, var(--border-main)); border-radius: var(--radius-xs); background: color-mix(in oklab, var(--status-warn) 5%, transparent); padding: 9px 11px; font-size: 11.5px; line-height: 1.6; color: var(--text-mid); text-wrap: pretty; }
+.set-dead .mono { color: var(--text-bright); font-size: var(--fs-11); }
+.set-storemap { display: flex; flex-direction: column; gap: 6px; }
+.set-storerow { display: grid; grid-template-columns: minmax(200px, 280px) 1fr; gap: 14px; align-items: baseline; padding: 7px 11px; border: 1px solid var(--border-main); border-radius: var(--radius-xs); background: var(--bg-well); }
+.set-storerow .mono { font-size: 11.5px; color: var(--text-bright); }
+.set-storerow .d { font-size: 11.5px; color: var(--text-dim); line-height: 1.5; }
+
 .set-link { background: none; border: 0; color: var(--volt); cursor: pointer; font: inherit; padding: 0; text-decoration: underline; text-underline-offset: 2px; }
 .set-mcp-detail { margin: -4px 0 4px; padding: 8px 11px; background: var(--bg-well); border: 1px solid var(--border-soft); border-radius: var(--radius-xs); font-size: var(--fs-11); color: var(--text-dim); overflow-x: auto; white-space: nowrap; }
 .set-nav-note { margin: auto 12px 12px; font-size: var(--fs-10); line-height: 1.5; color: var(--text-dim); padding-top: 12px; border-top: 1px solid var(--border-soft); }
@@ -614,10 +671,13 @@ button.cn-bind-row:hover .cn-bind-go { color: var(--volt-strong); transform: tra
 
 @media (max-width: 900px) {
   .set-shell { flex-direction: column; }
-  .set-nav { width: auto; flex-direction: row; overflow-x: auto; border-right: 0; border-bottom: 1px solid var(--border-main); padding: 0; }
+  .set-nav { width: auto; flex-direction: row; align-items: center; overflow-x: auto; border-right: 0; border-bottom: 1px solid var(--border-main); padding: 0; }
   .set-nav-h { display: none; }
   .set-nav-item { flex: none; margin: 6px 2px; }
   .set-nav-item .en { display: none; }
+  /* the prototype disclaimer wraps to many lines in a horizontal strip and
+     blows up the nav height — it belongs in the desktop sidebar only */
+  .set-nav-note { display: none; }
   .settings-surf .set-card-b { padding: 8px 16px 80px; max-width: 100%; }
   .set-content-h { padding: 16px; }
   .set-input { width: 100%; }
@@ -737,6 +797,31 @@ button.cn-bind-row:hover .cn-bind-go { color: var(--volt-strong); transform: tra
   .ide-rail { display: none; }
 }
 
+/* phones: board rail → horizontal channel strip; IDE → single column,
+   diff stacks, tree caps height so the editor stays reachable */
+@media (max-width: 900px) {
+  .bd-body {
+    grid-template-columns: 1fr; grid-template-rows: auto minmax(0, 1fr);
+  }
+  .bd-rail {
+    border-right: 0; border-bottom: 1px solid var(--border-main);
+    display: flex; gap: 6px; padding: 9px 12px; overflow-x: auto; overflow-y: hidden;
+  }
+  .bd-rail h4, .bd-rail .div { display: none; }
+  .bd-sub { width: auto; flex: none; white-space: nowrap; }
+  .bd-sub .n, .bd-sub .unread { margin-left: 6px; }
+  .bd-rail .col-resizer { display: none; }
+
+  .ide-body { grid-template-columns: 1fr !important; }
+  .ide-tree { max-height: 38vh; border-right: 0; border-bottom: 1px solid var(--border-main); }
+  .ide-tree .col-resizer { display: none; }
+  .ide-ed { min-height: 56vh; }
+  .ide-diff { grid-template-columns: 1fr; }
+  .ide-diff .pane { border-right: 0; border-bottom: 1px solid var(--border-soft); }
+  .ide-top { flex-wrap: wrap; height: auto; min-height: 42px; padding: 8px 12px; }
+  .ide-views { margin-left: auto; }
+}
+
 /* ══════════════════════════════════════════════════════════════
    TYPE LADDER — authoritative heading normalization
    One ladder for every surface. Loads last so it wins source order;
@@ -835,6 +920,11 @@ button.cn-bind-row:hover .cn-bind-go { color: var(--volt-strong); transform: tra
 .ap-req-goal { font-size: var(--fs-10); color: var(--text-dim); cursor: pointer; }
 .ap-req-goal:hover { color: var(--volt-strong); }
 .ap-req-quote { font-size: 12.5px; color: var(--text-primary); line-height: 1.5; font-style: italic; }
+.ap-origin { font-size: 9.5px; letter-spacing: 0.02em; color: var(--text-dim); border: 1px solid var(--border-main); border-radius: var(--radius-pill); padding: 2px 8px; }
+.ap-origin.remote { color: var(--info, var(--volt-strong)); border-color: color-mix(in oklab, var(--volt-strong) 34%, var(--border-main)); }
+.ap-cont { display: flex; align-items: center; gap: 6px; font-size: var(--fs-11); color: var(--text-mid); margin: 8px 0 2px; padding: 6px 10px; border-radius: var(--radius-sm); background: var(--volt-wash); border: 1px solid var(--volt-dim); }
+.ap-cont b { color: var(--text-bright); font-weight: 600; }
+.ap-cont .mono { margin-left: auto; font-size: 9.5px; color: var(--text-dim); }
 
 .ap-actions { display: flex; align-items: center; gap: 7px; }
 .ap-act { font-family: var(--font-ui); font-size: 11.5px; letter-spacing: 0.04em; padding: 7px 16px; border-radius: var(--radius-sm); border: 1px solid var(--border-main); background: var(--bg-card); color: var(--text-mid); cursor: pointer; transition: 0.14s; }
@@ -864,6 +954,15 @@ button.cn-bind-row:hover .cn-bind-go { color: var(--volt-strong); transform: tra
 .ap-spacer { flex: 1; }
 .ap-log-undo { font-family: var(--font-ui); font-size: 10.5px; color: var(--text-dim); background: none; border: 0; cursor: pointer; padding: 2px 4px; }
 .ap-log-undo:hover { color: var(--volt-strong); }
+
+/* ── 큐↔이력 뷰 전환 ── */
+
+/* ── HILT 이력 (감사 로그) ── */
+
+@media (max-width: 720px) {
+  .ap-hist-row { grid-template-columns: 44px 70px 1fr; }
+  .ap-hist-by { grid-column: 2 / 4; flex-direction: row; align-items: center; gap: 8px; }
+}
 
 /* nav badge (열린 승인 수) */
 .nav-item { position: relative; }


### PR DESCRIPTION
## 무엇

v3 델타 시리즈 **PR-3 — surfaces.css(표면 공통)** 병합이에요 (#29055 → #29059 후속, base `2782405bc3`, +101/−2).

- **채택한 v3 추가분**: settings의 legacy-note/callout/dead-config 어휘, store-map 행, `.ov-flush` 스크롤 변형, settings 섹션 폴리시. 유입 font-size 리터럴 27개는 유입 시점에 `--fs-*` 토큰으로 변환했어요
- **가드가 지킨 로컬 하드컷 3종** — 전부 스타일 테스트가 병합 중에 잡아서 유입분에서 제거했습니다:
  - `.ov-scroll` 전폭 유지 (decenter 가드 — 프로토의 max-width/margin:auto 재도입 차단, OVERRIDE 주석 보존)
  - `.ap-viewseg/.ap-viewbtn/.ap-hist*` 37룰 드랍 — 이 어휘는 `approvals-v2.css` 소유 (approvals-css-ownership 가드)
  - `.bd-body.no-detail` 재도입 차단 (collapse SSOT가 인라인 property로 이관됨 — 모바일 미디어쿼리 그룹에서 분리)
- repositories 섹션 블록(19줄)은 이미 선반영이라 중복 유입 제거

## 검증

- `pnpm test` 662 파일 / **9,018개 전부 통과** — 첫 실행이 `| tail` 파이프 탓에 실패 상세가 소실된 채 실패했는데, 파이프 없는 전체 출력 재실행은 완전 통과였어요. 실패 정체는 복구 불가(교훈으로 기록), 같은 코드 상태의 전체 재실행 green을 판정 근거로 삼습니다
- `pnpm vitest run src/styles` 27파일/170개, `no-raw-font-size-px` clean

## 다음

PR-4(fusion·runtime·keeper-config) / PR-4b(prompt-book) / PR-5(fleet+monitor.css) — 사전 3-way 조사 완료(충돌 9곳, 전부 기지 패턴)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
