### PR TITLE
fix(dashboard): 칸반 9열이 5열 explicit 트랙에 눌리던 스윔레인 수축 수정

### DIFF
--- a/dashboard/src/styles/keeper-v2/v2.css
+++ b/dashboard/src/styles/keeper-v2/v2.css
@@ -1120,7 +1120,14 @@
 .wk-viewtoggle button:hover { color: var(--text-bright); }
 .wk-viewtoggle button.on { background: var(--volt-wash); color: var(--volt-strong); }
 
-.wk-kanban { display: grid; grid-auto-flow: column; grid-auto-columns: minmax(244px, 1fr); gap: 12px; align-items: start; overflow-x: auto; padding-bottom: 14px; }
+/* OVERRIDE (intentional divergence from prototype): grid-template-columns must be
+   cleared here. The prototype renders exactly 5 kanban columns, so its earlier
+   repeat(5) base rule and this auto-flow override coexist without visible effect.
+   The live dashboard renders 9 protocol status columns (work.ts KANBAN_COLUMNS);
+   with repeat(5) still in effect the first five land in explicit minmax(0,1fr)
+   tracks and get squeezed to ~65px while implicit tracks hold 244px. `unset`
+   makes every column size via grid-auto-columns. Guarded by work-kanban.test.ts. */
+.wk-kanban { display: grid; grid-template-columns: unset; grid-auto-flow: column; grid-auto-columns: minmax(244px, 1fr); gap: 12px; align-items: start; overflow-x: auto; padding-bottom: 14px; }
 .wk-kcol { display: flex; flex-direction: column; min-width: 0; background: color-mix(in oklab, var(--bg-panel) 40%, var(--bg-deep)); border: 1px solid var(--border-soft); border-top: 2px solid var(--border-main); border-radius: var(--radius-sm); }
 .wk-kcol.st-todo { border-top-color: var(--status-warn); }
 .wk-kcol.st-claimed, .wk-kcol.st-verify { border-top-color: var(--info); }

--- a/dashboard/src/styles/work-kanban.test.ts
+++ b/dashboard/src/styles/work-kanban.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { declarationsForSelector } from './css-test-utils'
+
+// Regression guard: the kanban board must not keep an explicit column template
+// in its final cascade. The v3 prototype renders exactly 5 columns, so its
+// repeat(5) base rule survives alongside the later horizontal-scroll override
+// without visible damage. The live dashboard renders 9 protocol status columns
+// (work.ts KANBAN_COLUMNS); with repeat(5) still effective the first five
+// columns land in explicit minmax(0,1fr) tracks and get squeezed to ~65px while
+// the implicit tracks hold 244px. The intentional divergence in keeper-v2/v2.css
+// clears the template so every column sizes via grid-auto-columns. If a
+// prototype re-sync drops the `unset`, this test fails on purpose.
+//
+// declarationsForSelector merges same-selector rules in source order, so the
+// asserted values are the cascade-final ones (keeper-v2/v2.css loads after the
+// *-v2.css glob in main.ts and owns the final word on shared selectors).
+
+const read = (file: string): string => readFileSync(resolve(__dirname, file), 'utf-8')
+
+describe('kanban swimlanes size via grid-auto-columns, not an explicit template', () => {
+  it('.wk-kanban final cascade clears grid-template-columns', () => {
+    const d = declarationsForSelector(read('keeper-v2/v2.css'), '.wk-kanban')
+    expect(d['grid-template-columns']).toBe('unset')
+    expect(d['grid-auto-flow']).toBe('column')
+    expect(d['grid-auto-columns']).toBe('minmax(244px, 1fr)')
+    expect(d['overflow-x']).toBe('auto')
+  })
+})


### PR DESCRIPTION
## 무엇

`#workspace?section=work` 칸반 스윔레인이 짜부되는 문제 수정이에요 (PR-2 #29059 후속).

- **증상**: 앞쪽 5개 열이 ~65px로 눌리고 뒤 4개 열만 244px — 사용자 실측 보고
- **원인**: v3 프로토는 칸반이 정확히 5열이라 base의 `grid-template-columns: repeat(5, minmax(0,1fr))`과 뒤의 가로 스크롤 재정의(`grid-auto-flow: column`)가 공존해도 티가 안 났는데, 실제 대시보드는 **9개 프로토콜 상태 열**(work.ts `KANBAN_COLUMNS`)을 렌더링해요. repeat(5)가 살아남으면 앞 5열은 explicit `minmax(0,1fr)` 트랙에 들어가 0 근처까지 수축하고, 6열째부터만 implicit `minmax(244px,1fr)`을 받아요
- **수정**: 재정의 블록에 `grid-template-columns: unset` 1선언 추가 — 기존 work-v2.css의 모바일 재정의가 이미 쓰던 계약과 동일. 모든 열이 `grid-auto-columns`로 균일하게(≥244px) 잡히고 가로 스크롤
- **가드**: `work-kanban.test.ts` 신규 — 캐스케이드 최종값이 `unset`인지 단언, 프로토 재싱크가 이 선언을 떨어뜨리면 의도적으로 실패

## 검증

- `pnpm vitest run src/styles` 28파일/171개 통과 (신규 가드 포함)
- `pnpm typecheck` / `no-raw-font-size-px` clean
- `pnpm test` 전체 스위트 백그라운드 실행 중 — 완료 결과를 코멘트로 남길게요

🤖 Generated with [Claude Code](https://claude.com/claude-code)
