### PR TITLE
style(dashboard): keeper-v2 v3 델타 PR-4 — fusion·runtime·keeper-config 표면

### DIFF
--- a/dashboard/src/styles/keeper-v2/fusion.css
+++ b/dashboard/src/styles/keeper-v2/fusion.css
@@ -22,6 +22,25 @@
 .fus-list-scroll::-webkit-scrollbar { width: 8px; }
 .fus-list-scroll::-webkit-scrollbar-thumb { background: var(--border-main); border-radius: var(--radius-md); border: 2px solid transparent; background-clip: padding-box; }
 
+/* ── active [fusion] policy footer (live config, RFC-0252 §14.3 named gap) ── */
+.fus-policy { flex: none; border-top: 1px solid var(--border-main); background: color-mix(in oklab, var(--bg-panel) 60%, var(--bg-deep)); padding: 11px 13px 13px; }
+.fus-policy-h { display: flex; align-items: center; gap: 7px; font-family: var(--font-display); font-weight: 600; font-size: var(--fs-10); letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-mid); margin-bottom: 9px; }
+.fus-policy-src { font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0; text-transform: none; color: var(--text-dim); font-weight: 400; }
+.fus-policy-en { margin-left: auto; font-family: var(--font-mono); font-size: var(--fs-9); letter-spacing: 0.04em; padding: 2px 7px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); }
+.fus-policy-en.on { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 40%, transparent); background: color-mix(in oklab, var(--status-ok) 9%, transparent); }
+.fus-policy-en.off { color: var(--text-dim); }
+.fus-policy-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; background: var(--border-soft); border: 1px solid var(--border-soft); border-radius: var(--radius-sm); overflow: hidden; }
+.fus-pol { display: flex; align-items: center; justify-content: space-between; gap: 8px; background: var(--bg-card); padding: 6px 10px; }
+.fus-pol .k { font-size: var(--fs-10); color: var(--text-dim); }
+.fus-pol .v { font-size: var(--fs-11); color: var(--text-bright); font-variant-numeric: tabular-nums; }
+.fus-pol .v.dim { color: var(--text-dim); }
+
+/* phones: master-detail stacks — run list (with policy footer) on top */
+@media (max-width: 900px) {
+  .fus-body { grid-template-columns: 1fr; grid-template-rows: auto minmax(0, 1fr); }
+  .fus-list { border-right: 0; border-bottom: 1px solid var(--border-main); max-height: 44vh; }
+}
+
 .fus-row { text-align: left; background: var(--bg-card); border: 1px solid var(--border-soft); border-radius: var(--radius-md); padding: 10px 11px; cursor: pointer; transition: border-color 0.14s, background 0.14s; display: flex; flex-direction: column; gap: 7px; }
 .fus-row:hover { border-color: var(--border-highlight); }
 .fus-row.sel { border-color: var(--volt-dim); background: var(--bg-card-hover); box-shadow: inset 2px 0 0 var(--volt); }
@@ -206,6 +225,25 @@
 .fus-rec-action { font-size: var(--fs-12); color: var(--text-mid); }
 .fus-resolved-lbl { font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-dim); margin-bottom: 6px; }
 .fus-resolved-body { font-size: 14.5px; color: var(--text-bright); line-height: 1.62; margin: 0; text-wrap: pretty; }
+
+/* resolved_answer rich text — md→blocks rendered (p/h4/ul/code/callout/table) */
+.fus-rich { font-size: var(--fs-14); color: var(--text-primary); line-height: 1.64; }
+.fus-rich > *:first-child { margin-top: 0; }
+.fus-rich > *:last-child { margin-bottom: 0; }
+.fus-rich p { margin: 0 0 11px; color: var(--text-bright); text-wrap: pretty; }
+.fus-rich h4 { font-family: var(--font-ui); text-transform: none; letter-spacing: 0; font-size: 14.5px; font-weight: 600; color: var(--text-bright); margin: 16px 0 8px; }
+.fus-rich ul, .fus-rich ol { margin: 0 0 11px; padding-left: 19px; }
+.fus-rich li { margin: 4px 0; color: var(--text-primary); }
+.fus-rich li::marker { color: var(--volt); }
+.fus-rich strong { color: var(--text-bright); font-weight: 600; }
+.fus-rich em { color: var(--text-bright); }
+.fus-rich code { font-family: var(--font-mono); font-size: 12.5px; background: var(--bg-sunken); border: 1px solid var(--border-soft); padding: 1px 5px; border-radius: var(--radius-sm); color: var(--volt-strong); }
+.fus-rich a { color: var(--volt-strong); text-decoration: underline; text-underline-offset: 2px; text-decoration-color: color-mix(in oklab, var(--volt-strong) 45%, transparent); }
+.fus-rich a:hover { color: var(--volt); text-decoration-color: var(--volt); }
+/* long-document clamp + reveal */
+.fus-rich.clamp { max-height: 188px; overflow: hidden; -webkit-mask-image: linear-gradient(180deg, #000 64%, transparent); mask-image: linear-gradient(180deg, #000 64%, transparent); }
+.fus-rich-more { margin-top: 9px; background: none; border: 0; padding: 3px 0; font-family: var(--font-mono); font-size: var(--fs-10); letter-spacing: 0.1em; text-transform: uppercase; color: var(--volt-strong); cursor: pointer; transition: color 0.18s ease; }
+.fus-rich-more:hover { color: var(--volt); }
 .fus-rec-rationale { font-size: 12.5px; color: var(--text-mid); line-height: 1.55; margin: 11px 0 0; }
 .fus-rec-rationale .k, .fus-missing .k { font-size: var(--fs-9); letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-dim); margin-right: 8px; }
 .fus-missing { margin-top: 12px; }
@@ -262,35 +300,60 @@
 .msg-fusion-link { margin-left: auto; background: none; border: 0; padding: 0; cursor: pointer; font-family: var(--font-ui); font-size: var(--fs-11); color: var(--volt-strong); }
 .msg-fusion-link:hover { text-decoration: underline; }
 
-/* ════ JOJ pipeline (RFC-0283/0284 + design 2026-06-24) ════ */
+/* ════ TOPOLOGY · JOJ · PARAMS (RFC-0283/0284 + design 2026-06-24) ════ */
+/* topology chip in run header */
+.fus-topo { font-family: var(--font-mono); font-size: var(--fs-10); color: var(--volt-strong); border: 1px solid var(--volt-dim); background: var(--volt-wash); border-radius: var(--radius-sm); padding: 2px 8px; letter-spacing: 0.02em; }
+/* JoJ tag in list row */
+.fus-row-topo { font-family: var(--font-mono); font-size: 8.5px; font-weight: 600; letter-spacing: 0.06em; color: var(--volt-strong); border: 1px solid var(--volt-dim); border-radius: var(--radius-xs); padding: 1px 5px; }
 /* meta node in pipeline strip */
 .fus-pipe-node.meta { color: var(--accent-bone, var(--text-bright)); border-color: color-mix(in oklab, var(--volt) 32%, var(--border-main)); }
-/* isolation count in the pipeline strip judge node */
-.fus-pipe-iso { font-style: normal; font-size: var(--fs-9); color: var(--status-bad); letter-spacing: 0.02em; }
 
-/* meta reconcile drop notice — failed 1차 심판 격리 (RFC-0283 §2.3) */
-.fus-meta-drop { font-size: 11.5px; color: var(--status-warn); background: color-mix(in oklab, var(--status-warn) 9%, transparent); border: 1px solid color-mix(in oklab, var(--status-warn) 30%, transparent); border-radius: var(--radius-sm); padding: 7px 11px; margin-bottom: 9px; line-height: 1.5; }
+/* generation parameters */
+.fus-params { display: flex; flex-wrap: wrap; gap: 8px; }
+.fus-param { display: inline-flex; align-items: center; gap: 7px; border: 1px solid var(--border-main); border-radius: var(--radius-sm); background: var(--bg-sunken); padding: 5px 10px; }
+.fus-param .k { font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.04em; text-transform: uppercase; color: var(--text-dim); }
+.fus-param .v { font-size: var(--fs-12); color: var(--text-bright); font-variant-numeric: tabular-nums; }
 
 /* long-document clamp + reveal for resolved_answer (design 2026-06-24) */
 .fus-rich.clamp { max-height: 188px; overflow: hidden; -webkit-mask-image: linear-gradient(180deg, #000 64%, transparent); mask-image: linear-gradient(180deg, #000 64%, transparent); }
 .fus-rich-more { margin-top: 9px; background: none; border: 0; padding: 3px 0; font-family: var(--font-mono); font-size: var(--fs-10); letter-spacing: 0.1em; text-transform: uppercase; color: var(--volt-strong); cursor: pointer; transition: color 0.18s ease; }
 .fus-rich-more:hover { color: var(--volt); }
 
-/* JOJ 1차 심판 cards — N independent syntheses before meta reconcile (RFC-0283) */
+/* JOJ first-tier judge nodes */
 .fus-jnodes { display: grid; grid-template-columns: repeat(auto-fit, minmax(248px, 1fr)); gap: 10px; }
 .fus-jnode { background: var(--bg-panel); border: 1px solid var(--border-main); border-radius: var(--radius-md); border-left: 2px solid var(--volt-dim); padding: 11px 13px; display: flex; flex-direction: column; gap: 7px; min-width: 0; }
 .fus-jnode-h { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 .fus-jnode-id { font-family: var(--font-display); font-weight: 600; font-size: var(--fs-12); letter-spacing: 0.04em; text-transform: uppercase; color: var(--text-bright); }
+.fus-jnode-model { font-size: var(--fs-10); color: var(--text-dim); }
+.fus-jnode-lens { font-size: var(--fs-11); color: var(--text-mid); line-height: 1.45; }
 .fus-jnode-sum { margin: 0; font-size: 12.5px; color: var(--text-primary); line-height: 1.55; text-wrap: pretty; overflow-wrap: anywhere; }
 .fus-jnode-f { display: flex; align-items: center; gap: 10px; margin-top: auto; padding-top: 4px; }
 .fus-jnode-stat { font-size: 10.5px; color: var(--text-dim); }
 .fus-jnode-tok { margin-left: auto; font-size: var(--fs-10); color: var(--text-dim); }
 .fus-dec-badge.sm { font-size: var(--fs-9); padding: 1px 6px; }
+
 /* failed first-tier judge — isolated, excluded from meta (RFC-0283 §2.3) */
 .fus-jnode.failed { border-left-color: color-mix(in oklab, var(--status-bad) 50%, transparent); background: color-mix(in oklab, var(--status-bad) 6%, var(--bg-panel)); opacity: 0.92; }
 .fus-jnode-fail { margin-left: auto; font-family: var(--font-mono); font-size: 9.5px; color: var(--status-bad); border: 1px solid color-mix(in oklab, var(--status-bad) 40%, transparent); border-radius: var(--radius-xs); padding: 1px 6px; }
 .fus-jnode-isolated { margin: 0; font-size: 11.5px; color: var(--text-dim); font-style: italic; line-height: 1.5; }
+/* isolation count in the pipeline strip judge node */
+.fus-pipe-iso { font-style: normal; font-size: var(--fs-9); color: var(--status-bad); letter-spacing: 0.02em; }
+/* meta reconcile drop / degrade notice */
+.fus-meta-drop { font-size: 11.5px; color: var(--status-warn); background: color-mix(in oklab, var(--status-warn) 9%, transparent); border: 1px solid color-mix(in oklab, var(--status-warn) 30%, transparent); border-radius: var(--radius-sm); padding: 7px 11px; margin-bottom: 9px; line-height: 1.5; }
+.fus-meta-drop.degrade { color: var(--status-bad); background: color-mix(in oklab, var(--status-bad) 9%, transparent); border-color: color-mix(in oklab, var(--status-bad) 32%, transparent); }
+
+/* panel answer rich text — keep panel-card scale, not resolved scale */
+.fus-pans .fus-rich, .fus-pans .fus-rich p { font-size: var(--fs-12); color: var(--text-mid); line-height: 1.55; }
+.fus-pans .fus-rich p { margin: 0 0 6px; }
+.fus-pans .fus-rich > *:last-child { margin-bottom: 0; }
+
+/* word-break consistency (design 2026-06-24 §4) */
+.fus-prompt, .fus-resolved-body, .fus-pans, .fus-gap-miss, .fus-pos-s,
+.fus-claim p, .fus-insight p, .fus-blind li, .fus-missing li, .fus-jnode-sum {
+  overflow-wrap: anywhere; text-wrap: pretty;
+}
 
 @media (max-width: 760px) {
+  .fus-params { gap: 6px; }
   .fus-jnodes { grid-template-columns: 1fr; }
 }

--- a/dashboard/src/styles/keeper-v2/keeper-config.css
+++ b/dashboard/src/styles/keeper-v2/keeper-config.css
@@ -156,6 +156,16 @@ select.kcf-inline-control {
 .kcf-plan { display: inline-flex; align-items: center; gap: 2px; font-size: 9.5px; letter-spacing: 0.06em; font-weight: 400; color: var(--text-dim); background: color-mix(in oklab, var(--info) 12%, transparent); border: 1px solid color-mix(in oklab, var(--info) 30%, transparent); border-radius: var(--radius-xs); padding: 2px 7px; }
 .kcf-plan em { font-style: normal; color: var(--text-dim); font-size: var(--fs-11); letter-spacing: 0; margin-left: 4px; }
 .kcf-ro { font-family: var(--font-mono); font-size: var(--fs-12); color: var(--text-dim); }
+/* 소스에서 제거된 설정을 자리에 남겨 사실만 알림 (dead / 미와이어링) */
+.kcf-dead { margin-top: 10px; border: 1px dashed color-mix(in oklab, var(--status-warn) 26%, var(--border-main)); border-radius: var(--radius-xs); background: color-mix(in oklab, var(--status-warn) 5%, transparent); padding: 8px 10px; font-size: 11.5px; line-height: 1.55; color: var(--text-mid); text-wrap: pretty; }
+.kcf-dead .mono { color: var(--text-bright); font-size: var(--fs-11); }
+
+/* ── single-line editable identity field ── */
+.kcf-idrow { display: flex; flex-direction: column; gap: 14px; }
+.kcf-field { display: flex; flex-direction: column; gap: 6px; }
+.kcf-input { width: 100%; max-width: 320px; box-sizing: border-box; padding: 9px 12px; border: 1px solid var(--border-main); border-radius: var(--radius-sm); background: var(--bg-panel); color: var(--text-bright); font-family: var(--font-ui); font-size: var(--fs-13); transition: border-color .16s ease; }
+.kcf-input.mono { font-family: var(--font-mono); font-size: var(--fs-12); }
+.kcf-input:focus { outline: none; border-color: var(--volt-dim); }
 
 /* ── text fields ── */
 .kcf-textfield { display: flex; flex-direction: column; gap: 6px; margin-bottom: 12px; }
@@ -170,6 +180,26 @@ select.kcf-inline-control {
 }
 .kcf-text.mono { font-family: var(--font-mono); font-size: var(--fs-12); }
 .kcf-text:focus { outline: none; border-color: var(--volt-dim); }
+/* ── prompt assembly trace (cc-6): layered system-prompt lineage ── */
+.kasm { display: flex; flex-direction: column; gap: 12px; }
+.kasm-legend { display: flex; flex-wrap: wrap; gap: 6px 14px; }
+.kasm-leg { display: inline-flex; align-items: center; gap: 6px; font-size: 10.5px; letter-spacing: 0.04em; color: var(--text-dim); }
+.kasm-leg i { width: 9px; height: 9px; border-radius: 2px; background: var(--c); flex: none; }
+.kasm-stack { display: flex; flex-direction: column; gap: 7px; max-height: 460px; overflow-y: auto; padding-right: 4px; }
+.kasm-seg { border: 1px solid var(--border-soft); border-left: 3px solid var(--c); border-radius: var(--radius-sm); background: color-mix(in oklab, var(--c) 6%, var(--bg-card)); padding: 10px 13px; }
+.kasm-seg.win { box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--c) 32%, transparent); }
+.kasm-seg-h { display: flex; align-items: center; gap: 9px; flex-wrap: wrap; margin-bottom: 6px; }
+.kasm-seg-src { font-family: var(--font-display); font-size: var(--fs-10); letter-spacing: 0.12em; text-transform: uppercase; color: var(--c); font-weight: 600; }
+.kasm-seg-field { font-size: 10.5px; color: var(--text-mid); }
+.kasm-seg-win { font-size: 8.5px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--volt-ink); background: var(--volt); padding: 2px 7px; border-radius: var(--radius-pill); }
+.kasm-seg-path { margin-left: auto; font-size: 9.5px; color: var(--text-dim); }
+.kasm-seg-text { font-size: 12.5px; line-height: 1.55; color: var(--text-primary); white-space: pre-wrap; }
+.src-base { --c: var(--text-dim); }
+.src-manifest { --c: var(--info); }
+.src-override { --c: var(--volt-strong); }
+.src-goals { --c: var(--status-ok); }
+.src-world { --c: var(--status-warn); }
+
 /* ── runtime chain ── */
 .kcf-chain { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
 .kcf-chain-item { font-size: 11.5px; color: var(--text-mid); padding: 5px 11px; border: 1px solid var(--border-main); border-radius: var(--radius-pill); background: var(--bg-card); }
@@ -214,6 +244,48 @@ select.kcf-inline-control {
 .kcf-tool-toggle:hover { border-color: var(--volt-dim); }
 .kcf-tool.on .kcf-tool-toggle { background: var(--volt); color: var(--bg-deep); border-color: var(--volt); }
 
+/* ── avatar editor (cc): sigil / portrait / slot color / monogram ── */
+.kav { display: flex; flex-direction: column; gap: 20px; max-width: 640px; }
+.kav-preview { display: flex; align-items: center; gap: 16px; padding: 16px; border: 1px solid var(--border-main); border-radius: var(--radius-sm); background: var(--bg-card); }
+.kav-face { width: 76px; height: 76px; border-radius: var(--radius-sm); flex: none; box-shadow: inset 0 0 0 1px rgba(255,255,255,0.06); }
+.kav-face.is-img { object-fit: cover; }
+.kav-face.is-sigil { display: flex; align-items: center; justify-content: center; font-family: var(--font-mono); font-weight: 700; font-size: 30px; color: #0b0c10; }
+.kav-preview-meta { display: flex; flex-direction: column; gap: 5px; min-width: 0; }
+.kav-preview-name { font-family: var(--font-display); font-size: var(--fs-16); color: var(--text-bright); }
+.kav-preview-mode { font-size: var(--fs-11); color: var(--text-dim); }
+.kav-clear { margin-left: auto; align-self: flex-start; font-family: var(--font-ui); font-size: 11.5px; color: var(--text-mid); background: none; border: 1px solid var(--border-main); border-radius: var(--radius-pill); padding: 5px 12px; cursor: pointer; transition: .16s; }
+.kav-clear:hover { border-color: var(--volt-dim); color: var(--volt); }
+
+.kav-block { display: flex; flex-direction: column; gap: 9px; }
+.kav-block-row { flex-direction: row; align-items: flex-end; gap: 16px; }
+.kav-lbl { font-size: var(--fs-12); font-weight: 600; color: var(--text-mid); }
+.kav-lbl-hint { font-weight: 400; font-size: var(--fs-11); color: var(--text-dim); margin-left: 6px; }
+
+.kav-src { display: flex; gap: 4px; }
+.kav-src-b { flex: 1; font-family: var(--font-ui); font-size: var(--fs-13); color: var(--text-mid); background: var(--bg-panel); border: 1px solid var(--border-main); border-radius: var(--radius-sm); padding: 10px 14px; cursor: pointer; transition: .16s; }
+.kav-src-b:hover { border-color: var(--volt-dim); color: var(--text-bright); }
+.kav-src-b.on { color: var(--volt-strong, var(--volt)); border-color: var(--volt-dim); background: color-mix(in oklab, var(--volt) 10%, var(--bg-panel)); box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--volt) 32%, transparent); }
+
+.kav-portraits { display: grid; grid-template-columns: repeat(7, 1fr); gap: 6px; }
+.kav-por { position: relative; aspect-ratio: 1; padding: 0; border: 1px solid var(--border-main); border-radius: var(--radius-sm); background: var(--bg-panel); cursor: pointer; overflow: hidden; transition: border-color .16s ease, box-shadow .16s ease; }
+.kav-por img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.kav-por:hover { border-color: var(--volt-dim); }
+.kav-por.on { border-color: var(--volt); box-shadow: inset 0 0 0 2px var(--volt), 0 0 12px rgba(196,162,101,0.2); }
+.kav-upload { display: flex; align-items: center; justify-content: center; border-style: dashed; }
+.kav-upload-ic { display: flex; flex-direction: column; align-items: center; gap: 2px; font-size: 18px; color: var(--text-dim); }
+.kav-upload-ic em { font-style: normal; font-size: 8.5px; letter-spacing: 0.04em; }
+.kav-upload:hover .kav-upload-ic { color: var(--volt); }
+
+.kav-swatches { display: grid; grid-template-columns: repeat(12, 1fr); gap: 6px; }
+.kav-sw { position: relative; aspect-ratio: 1; border: 1px solid rgba(255,255,255,0.08); border-radius: var(--radius-xs); background: var(--sw); cursor: pointer; padding: 0; transition: transform .14s ease, box-shadow .14s ease; }
+.kav-sw:hover { transform: translateY(-1px); }
+.kav-sw.on { box-shadow: 0 0 0 2px var(--bg-deep), 0 0 0 3px var(--sw); }
+.kav-sw-tick { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; font-size: var(--fs-12); font-weight: 700; color: #0b0c10; }
+
+.kav-sigil-in { width: 84px; box-sizing: border-box; text-align: center; text-transform: uppercase; letter-spacing: 0.1em; font-size: var(--fs-16); padding: 9px 10px; border: 1px solid var(--border-main); border-radius: var(--radius-sm); background: var(--bg-panel); color: var(--text-bright); transition: border-color .16s ease; margin-top: 9px; }
+.kav-sigil-in:focus { outline: none; border-color: var(--volt-dim); }
+.kav-sigil-prev { width: 44px; height: 44px; display: flex; align-items: center; justify-content: center; border-radius: var(--radius-sm); font-weight: 700; font-size: 17px; color: #0b0c10; flex: none; }
+
 /* ── goals picker ── */
 .kcf-goals { display: flex; flex-direction: column; gap: 12px; }
 .kcf-goals-bar { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
@@ -237,6 +309,20 @@ select.kcf-inline-control {
 
 .kcf-goals-empty, .kcf-goals-empty { padding: 30px; text-align: center; color: var(--text-dim); font-size: var(--fs-13); background: var(--bg-card); }
 
+/* ── runtime picker (searchable list, single-select) ── */
+.kcf-rt-list { display: flex; flex-direction: column; gap: 1px; background: var(--border-soft); border: 1px solid var(--border-soft); border-radius: var(--radius-sm); overflow: hidden; max-height: 340px; overflow-y: auto; }
+.kcf-rt { display: grid; grid-template-columns: 18px 1fr auto; align-items: center; gap: 12px; padding: 11px 14px; background: var(--bg-card); border: 0; text-align: left; cursor: pointer; transition: .15s; }
+.kcf-rt:hover { background: color-mix(in oklab, var(--text-bright) 4%, var(--bg-card)); }
+.kcf-rt.on { background: color-mix(in oklab, var(--volt) 9%, var(--bg-card)); }
+.kcf-rt-radio { width: 14px; height: 14px; border-radius: 50%; border: 1px solid var(--border-main); position: relative; }
+.kcf-rt.on .kcf-rt-radio { border-color: var(--volt); }
+.kcf-rt.on .kcf-rt-radio::after { content: ""; position: absolute; inset: 3px; border-radius: 50%; background: var(--volt); }
+.kcf-rt-body { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+.kcf-rt-id { font-size: 12.5px; color: var(--text-bright); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.kcf-rt-meta { font-size: 10.5px; color: var(--text-dim); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.kcf-rt-badges { display: flex; gap: 5px; flex: none; }
+.kcf-rt-badge { font-size: var(--fs-9); letter-spacing: 0.04em; text-transform: uppercase; padding: 2px 7px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); color: var(--text-dim); white-space: nowrap; }
+
 /* ── hooks table ── */
 .kcf-hooks { display: flex; flex-direction: column; gap: 1px; background: var(--border-soft); border: 1px solid var(--border-soft); border-radius: var(--radius-sm); overflow: hidden; }
 .kcf-hook-hd, .kcf-hook { display: grid; grid-template-columns: 200px 200px 1fr; gap: 14px; align-items: center; padding: 9px 14px; background: var(--bg-card); }
@@ -247,6 +333,31 @@ select.kcf-inline-control {
 .kcf-hook-src { font-size: 11.5px; color: var(--text-mid); }
 .kcf-hook-src.na { color: var(--text-dim); font-style: italic; }
 .kcf-hook-gate { font-size: var(--fs-11); color: var(--text-dim); }
+
+/* ── guards + interventions (replaces hooks table) ── */
+.kcf-guards { display: flex; flex-direction: column; gap: 1px; background: var(--border-soft); border: 1px solid var(--border-soft); border-radius: var(--radius-sm); overflow: hidden; }
+.kcf-guard { display: grid; grid-template-columns: 10px 1fr auto; align-items: center; gap: 13px; padding: 12px 14px; background: var(--bg-card); }
+.kcf-guard-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--status-ok); box-shadow: 0 0 0 3px color-mix(in oklab, var(--status-ok) 16%, transparent); }
+.kcf-guard-main { min-width: 0; }
+.kcf-guard-lbl { display: flex; align-items: baseline; gap: 9px; font-size: var(--fs-13); color: var(--text-bright); }
+.kcf-guard-id { font-size: 10.5px; color: var(--text-dim); }
+.kcf-guard-desc { font-size: var(--fs-11); color: var(--text-dim); margin-top: 3px; text-wrap: pretty; }
+.kcf-guard-fires { font-size: var(--fs-14); color: var(--text-mid); flex: none; }
+.kcf-guard-fires em { font-size: var(--fs-10); color: var(--text-dim); font-style: normal; margin-left: 2px; }
+
+.kcf-ivs { display: flex; flex-direction: column; gap: 8px; }
+.kcf-iv { display: grid; grid-template-columns: 64px 1fr auto; align-items: start; gap: 12px; padding: 11px 13px; border: 1px solid var(--border-soft); border-radius: var(--radius-sm); background: var(--bg-card); }
+.kcf-iv-act { font-size: var(--fs-10); font-weight: 600; letter-spacing: 0.03em; text-align: center; padding: 3px 0; border-radius: var(--radius-xs); border: 1px solid var(--border-main); color: var(--text-mid); }
+.kcf-iv[data-act="escalated"] .kcf-iv-act { color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 40%, transparent); background: color-mix(in oklab, var(--status-warn) 10%, transparent); }
+.kcf-iv[data-act="blocked"] .kcf-iv-act { color: var(--status-bad); border-color: color-mix(in oklab, var(--status-bad) 40%, transparent); background: color-mix(in oklab, var(--status-bad) 11%, transparent); }
+.kcf-iv[data-act="passed"] .kcf-iv-act { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 38%, transparent); background: color-mix(in oklab, var(--status-ok) 10%, transparent); }
+.kcf-iv-main { min-width: 0; }
+.kcf-iv-top { display: flex; align-items: baseline; gap: 10px; }
+.kcf-iv-guard { font-size: 11.5px; color: var(--volt-strong); }
+.kcf-iv-at { font-size: var(--fs-10); color: var(--text-dim); }
+.kcf-iv-note { font-size: 11.5px; color: var(--text-mid); margin-top: 4px; line-height: 1.45; text-wrap: pretty; }
+.kcf-iv-ref { font-size: 10.5px; color: var(--text-dim); flex: none; }
+.kcf-ivs-empty { padding: 26px; text-align: center; color: var(--text-dim); font-size: 12.5px; border: 1px dashed var(--border-main); border-radius: var(--radius-sm); }
 
 /* ── footer ── */
 .kcf-foot { flex: none; display: flex; align-items: center; gap: 10px; padding: 13px 20px; border-top: 1px solid var(--border-main); background: var(--bg-panel); }

--- a/dashboard/src/styles/keeper-v2/runtime.css
+++ b/dashboard/src/styles/keeper-v2/runtime.css
@@ -68,6 +68,16 @@
 .rt-cap { font-family: var(--font-mono); font-size: var(--fs-10); padding: 2px 8px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); color: var(--text-dim); }
 .rt-cap.on { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 32%, transparent); }
 
+/* provider 호출 테스트 */
+.rt-test { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-top: 12px; padding-top: 11px; border-top: 1px solid var(--border-soft); }
+.rt-test-btn { flex: none; font-family: var(--font-ui); font-size: 11.5px; padding: 5px 12px; border-radius: var(--radius-sm); border: 1px solid var(--border-main); background: transparent; color: var(--text-mid); cursor: pointer; transition: 0.14s; }
+.rt-test-btn:hover { border-color: var(--volt-dim); color: var(--volt); }
+.rt-test-btn:disabled { opacity: 0.55; cursor: default; }
+.rt-test-r { font-size: 10.5px; line-height: 1.4; }
+.rt-test-r.pending { color: var(--text-dim); }
+.rt-test-r.ok { color: var(--status-ok); }
+.rt-test-r.fail { color: var(--status-bad); }
+
 /* models */
 .rt-search { width: 100%; box-sizing: border-box; background: var(--bg-sunken); border: 1px solid var(--border-main); border-radius: var(--radius-sm); padding: 9px 12px; color: var(--text-bright); font-size: var(--fs-12); margin-bottom: 12px; }
 .rt-search:focus { outline: none; border-color: var(--volt-dim); }
@@ -147,6 +157,13 @@
 
 /* settings launcher card + per-keeper runtime capability card */
 .rtc-card { border: 1px solid var(--border-main); border-radius: var(--radius-sm); background: var(--bg-card); padding: 10px 12px; }
+.rtc-head { display: flex; align-items: center; gap: 8px; width: 100%; background: none; border: 0; padding: 0; margin: 0; text-align: left; cursor: pointer; font: inherit; color: inherit; }
+.rtc-head .rtc-id { flex: 1; min-width: 0; }
+.rtc-chev { flex: none; font-size: 8px; color: var(--text-dim); transition: transform 0.18s; }
+.rtc-card.open .rtc-chev { transform: rotate(90deg); }
+.rtc-head:hover .rtc-id { color: var(--volt); }
+.rtc-head:hover .rtc-chev { color: var(--text-mid); }
+.rtc-detail { margin-top: 9px; padding-top: 9px; border-top: 1px solid var(--border-soft); }
 .rtc-id { font-size: 11.5px; color: var(--volt-strong); word-break: break-all; }
 /* Pending runtime assignment: the config editor saved a runtime the running
    keeper has not adopted yet (assigned ≠ live). Amber to read as "pending",
@@ -156,7 +173,7 @@
 .rtc-na { font-size: var(--fs-11); color: var(--text-dim); margin-top: 5px; }
 .rtc-model { font-size: 10.5px; color: var(--text-dim); margin-top: 4px; }
 .rtc-flags { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 9px; }
-.rtc-flag { font-family: var(--font-mono); font-size: var(--fs-10); padding: 1px 7px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); }
+.rtc-flag { font-family: var(--font-mono); font-size: var(--fs-10); padding: 1px 7px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); white-space: nowrap; }
 .rtc-flag.on { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 32%, transparent); }
 .rtc-flag.off { color: var(--text-dim); }
 /* Undeclared capability: distinct from a declared "off" — dashed border reads
@@ -200,6 +217,46 @@
 
 /* inline embedded mode — no double box-shadow */
 .set-card-b-wide .rt-shell { box-shadow: none; min-height: 36rem; }
+
+/* ── failover · rotation ─────────────────────────────────────── */
+.rt-fo { padding: 14px 0; border-top: 1px solid var(--border-soft); }
+.rt-fo:first-of-type { border-top: 0; }
+.rt-fo-h { display: flex; align-items: baseline; gap: 10px; }
+.rt-fo-lane { font-size: var(--fs-13); color: var(--text-primary); }
+.rt-fo-lane-id { font-size: 10.5px; color: var(--text-dim); }
+.rt-fo-note { font-size: var(--fs-11); line-height: 1.5; color: var(--text-dim); margin: 5px 0 10px; }
+.rt-fo-chain { display: flex; flex-direction: column; gap: 6px; }
+.rt-fo-cand { display: flex; align-items: center; gap: 10px; padding: 7px 10px; border: 1px solid var(--border-main); border-radius: var(--radius-sm); background: var(--bg-card); }
+.rt-fo-cand.head { border-color: var(--volt-dim); box-shadow: inset 0 0 0 1px var(--volt-dim); }
+.rt-fo-rank { flex: none; width: 30px; font-size: var(--fs-10); color: var(--text-dim); }
+.rt-fo-cand.head .rt-fo-rank { color: var(--volt); }
+.rt-fo-id { flex: 1; min-width: 0; font-size: var(--fs-12); color: var(--text-bright); }
+.rt-fo-cand-acts { display: flex; gap: 4px; }
+.rt-fo-mv { width: 22px; height: 22px; border: 1px solid var(--border-main); background: none; color: var(--text-dim); border-radius: var(--radius-sm); cursor: pointer; font-size: var(--fs-9); line-height: 1; transition: 0.14s; }
+.rt-fo-mv:hover:not(:disabled) { border-color: var(--volt-dim); color: var(--volt); }
+.rt-fo-mv.del:hover:not(:disabled) { border-color: color-mix(in oklab, var(--status-bad) 50%, transparent); color: var(--status-bad); }
+.rt-fo-mv:disabled { opacity: 0.3; cursor: default; }
+.rt-fo-foot { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; margin-top: 10px; }
+.rt-fo-add { min-width: 150px; }
+.rt-fo-toggle { display: flex; align-items: center; gap: 7px; font-size: 11.5px; color: var(--text-mid); cursor: pointer; }
+.rt-fo-toggle input { accent-color: var(--volt); }
+.rt-fo-cap { margin-left: auto; font-size: var(--fs-10); color: var(--text-dim); padding: 3px 9px; border: 1px solid var(--border-main); border-radius: var(--radius-pill); }
+
+.rt-fo-log { margin-top: 22px; border-top: 1px solid var(--border-soft); padding-top: 16px; }
+.rt-fo-log-h { display: flex; align-items: baseline; gap: 9px; font-size: var(--fs-12); color: var(--text-primary); margin-bottom: 10px; }
+.rt-fo-log-h .mono { font-size: var(--fs-10); color: var(--text-dim); }
+.rt-fo-ev { display: grid; grid-template-columns: 42px 62px 92px 108px 1fr; align-items: center; gap: 10px; padding: 7px 0; border-top: 1px solid var(--border-soft); font-size: 11.5px; }
+.rt-fo-ev:first-of-type { border-top: 0; }
+.rt-fo-ev-at { color: var(--text-dim); font-size: 10.5px; }
+.rt-fo-ev-out { font-size: var(--fs-10); letter-spacing: 0.02em; padding: 2px 7px; border-radius: var(--radius-pill); border: 1px solid transparent; text-align: center; }
+.rt-fo-ev-out.recovered { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 40%, transparent); }
+.rt-fo-ev-out.paused { color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 40%, transparent); }
+.rt-fo-ev-out.backpressure { color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 40%, transparent); }
+.rt-fo-ev-kp { color: var(--text-bright); }
+.rt-fo-ev-lane { color: var(--text-dim); font-size: 10.5px; }
+.rt-fo-ev-hop { color: var(--text-mid); font-size: 10.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.rt-fo-arr { color: var(--volt); }
+.rt-fo-ev-reason { color: var(--text-dim); font-size: 10.5px; text-align: right; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 
 @media (max-width: 720px) {
   .rt-shell { grid-template-columns: 1fr; }


### PR DESCRIPTION
## 무엇

v3 델타 시리즈 **PR-4 — 표면별 3종(fusion·runtime·keeper-config)** 병합이에요 (#29061 후속, base `2782405bc3`, +238/−7).

블록 단위 3-way(`git merge-file`) 충돌 5곳 판정:

- **fusion (1곳)**: v3의 확장판 채택 — topology 칩(`.fus-topo`/`.fus-row-topo`), 생성 파라미터(`.fus-params`), judge 카드의 model/lens 표시, `.fus-meta-drop.degrade` 변형, panel rich-text 스케일, word-break 일관성 블록. 로컬 전용이던 long-document clamp(`.fus-rich.clamp`/`.fus-rich-more`, design 2026-06-24)는 그대로 보존했어요
- **runtime (2곳)**: `.rtc-flag`는 로컬 토큰(`var(--fs-10)`) + v3 `white-space: nowrap` 합집합. 로컬 embed 규칙(`.set-card-b-wide .rt-shell`)을 유지하고 v3의 failover/rotation 섹션(`.rt-fo-*`, 45룰)을 추가
- **keeper-config (2곳)**: 로컬 토큰화 규칙 유지 + v3의 `.kcf-dead`(dead-config 알림)·identity 입력 필드·prompt assembly trace(`.kasm-*`, cc-6) 채택. **`.kcf-traits`/`.kcf-trait`는 재도입하지 않음** — #27048 Persona 하드컷의 의도적 삭제라서요
- 유입 정수 font-size 42개는 유입 시점에 `--fs-*` 토큰으로 변환 (fractional은 lint 면제 그대로)
- 유실 검증: src 대비 삭제 줄 전수 대조 — 전부 교체/이동(주석 개정, nowrap 추가, degrade 형제 추가)이고 셀렉터가 정의를 잃는 경우 0건

## 검증

- `pnpm test` 전체 스위트 663파일 / 9,018개 통과 (파이프 없이 실행, exit code 직접 판정)
- `pnpm vitest run src/styles` 170개 / `no-raw-font-size-px` clean / `pnpm typecheck` clean / `tokens:check` 통과
- `pnpm lint`의 no-nested-ternary 3건은 `keeper-tool-call-inspector.ts`의 main 기존 red (#29054 추적 중, 이 PR 무관)

## 다음

PR-4b(prompt-book v3 채택) → PR-5(fleet + monitor.css vendoring + agent-roster ctx 열) → PR-6(chat `.kw-*` 리타겟)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
