### PR TITLE
style(dashboard): keeper-v2 v3 델타 PR-5 — fleet·monitor vendoring·컨텍스트 관측 어휘

### DIFF
--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -835,6 +835,58 @@ describe('AgentRoster live-only cards', () => {
     expect(container.textContent).not.toContain('compact 임계 근접')
   })
 
+  it('annotates the observed context window next to the percentage (.fl-ctx-win)', async () => {
+    keepers.value = [
+      {
+        name: 'rondo',
+        agent_name: 'keeper-rondo-agent',
+        status: 'active',
+        phase: 'Running',
+        registered: true,
+        keepalive_running: true,
+        context_ratio: 0.62,
+        context_tokens: 79_360,
+        context_max: 128_000,
+      } as Keeper,
+    ]
+
+    await act(async () => {
+      render(html`<${AgentRoster} keeperFilter="keeper-only" />`, container)
+    })
+    await flushUi()
+
+    const val = container.querySelector('.fl-ctx-val')
+    expect(val?.textContent).toContain('62%')
+    // Window annotation renders only from an actually-received context_max —
+    // never derived (mark, don't fake).
+    expect(val?.querySelector('.fl-ctx-win')?.textContent).toBe('/ 128.0K')
+  })
+
+  it('omits the window annotation when context_max was not received', async () => {
+    keepers.value = [
+      {
+        name: 'rondo',
+        agent_name: 'keeper-rondo-agent',
+        status: 'active',
+        phase: 'Running',
+        registered: true,
+        keepalive_running: true,
+        context_ratio: 0.4,
+        context_tokens: null,
+        context_max: null,
+      } as Keeper,
+    ]
+
+    await act(async () => {
+      render(html`<${AgentRoster} keeperFilter="keeper-only" />`, container)
+    })
+    await flushUi()
+
+    const val = container.querySelector('.fl-ctx-val')
+    expect(val?.textContent).toContain('40%')
+    expect(val?.querySelector('.fl-ctx-win')).toBeNull()
+  })
+
   it('does not render the internal namespace-separation disclaimer strip', async () => {
     agents.value = [
       makeAgent({

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -126,7 +126,7 @@ function rosterContextMeta(
     context_tokens?: number | null
     context_max?: number | null
   } | null | undefined,
-): { pct: number; detail: string | null } | null {
+): { pct: number; detail: string | null; win: string | null } | null {
   const ratio = source?.context_ratio
   if (ratio == null || !Number.isFinite(ratio)) return null
 
@@ -140,7 +140,10 @@ function rosterContextMeta(
         ? formatTokens(tokens)
         : null
 
-  return { pct, detail }
+  // win = the observed context window size, rendered as the .fl-ctx-win
+  // annotation next to the percentage. Only present when context_max was
+  // actually received — never derived (mark, don't fake).
+  return { pct, detail, win: max != null ? formatTokens(max) : null }
 }
 
 /**
@@ -1217,13 +1220,19 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
             : null}
         </div>
 
-        <div class="fl-ctx" aria-label=${`컨텍스트 ${ctxPct != null ? `${ctxPct}%` : '없음'}`}>
+        <div class="fl-ctx" aria-label=${`컨텍스트 ${ctxPct != null ? `${ctxPct}%` : '미관측'}`}>
           ${ctxPct != null
             ? html`
                 <div class="fl-ctx-bar"><span class=${ctxHot ? 'hot' : ''} style="width:${ctxPct}%"></span></div>
-                <span class="fl-ctx-val ${ctxHot ? 'hot' : ctxPct === 0 ? 'zero' : ''}">${ctxPct}%</span>
+                <span class="fl-ctx-val ${ctxHot ? 'hot' : ctxPct === 0 ? 'zero' : ''}">${ctxPct}%${row.contextMeta?.win
+                  ? html` <i class="fl-ctx-win">/ ${row.contextMeta.win}</i>`
+                  : null}</span>
               `
-            : html`<span class="fl-ctx-val zero" data-stub="no context_ratio">—</span>`}
+            : html`<span
+                class="fl-ctx-val zero"
+                data-stub="no context_ratio"
+                title="현재 점유율 미관측 · 마지막 턴 usage와 분리"
+              >—</span>`}
         </div>
 
         <div
@@ -1480,9 +1489,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
             ${selectedCtxPct == null && selectedContextUnavailable?.kind === 'not_observed' ? html`
               <div class="fl-as-sec" data-testid="fleet-context-not-observed">
                 <h4>컨텍스트</h4>
-                <div class="text-xs text-[var(--color-fg-muted)]">
-                  현재 점유율 미관측 · usage와 분리
-                </div>
+                <div class="fl-notobs">현재 점유율 <b>미관측</b> · usage와 분리</div>
               </div>
             ` : null}
 

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -93,6 +93,9 @@ import './styles/keeper-v2/runtime.css'
 // the statchip pill shape. Loaded last so it wins on shape (see file header).
 import './styles/keeper-v2/ops-cluster.css'
 import './styles/keeper-v2/prompt-book.css'
+// v3 prototype link order places monitor.css after prompt-book.css (verify.css /
+// registry.css sit between in the prototype but are Phase B/C — not vendored).
+import './styles/keeper-v2/monitor.css'
 import './styles/mobile-operator-targets.css'
 
 // ── CSS SSOT removal scope (PR #22081 review P1) ──

--- a/dashboard/src/styles/keeper-v2/fleet.css
+++ b/dashboard/src/styles/keeper-v2/fleet.css
@@ -52,6 +52,16 @@
 .fl-hpill.bad { border-color: color-mix(in oklab, var(--status-bad) 38%, transparent); background: color-mix(in oklab, var(--status-bad) 10%, var(--bg-card)); color: var(--status-bad); }
 .fl-hpill.bad b { color: var(--status-bad); }
 .fl-spacer { flex: 1; }
+.fl-top-actions { display: flex; align-items: center; gap: 8px; flex: none; }
+.fl-top-btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--font-ui); font-size: var(--fs-12); color: var(--text-mid);
+  padding: 7px 13px; border-radius: var(--radius-sm);
+  border: 1px solid var(--border-main); background: var(--bg-card); cursor: pointer; transition: 0.16s; white-space: nowrap;
+}
+.fl-top-btn:hover { border-color: var(--volt-dim); color: var(--volt-strong); background: var(--volt-wash); }
+.fl-top-btn.primary { color: var(--volt-strong); border-color: color-mix(in oklab, var(--volt) 40%, var(--border-main)); background: var(--volt-wash); }
+.fl-top-btn.primary:hover { border-color: var(--volt); background: color-mix(in oklab, var(--volt) 15%, transparent); }
 .fl-meta { display: flex; align-items: center; gap: 14px; font-family: var(--font-mono); font-size: var(--fs-11); color: var(--text-dim); }
 .fl-meta .live { color: var(--status-ok); }
 
@@ -276,6 +286,65 @@
   .fl-body { grid-template-columns: 1fr; }
   .fl-aside { display: none; }
 }
+
+/* ── lane / admission queue band (fleet-wide WFQ) ─────────────── */
+.fl-lanes { border-bottom: 1px solid var(--border-main); background: var(--bg-deep); flex: none; }
+.fl-lanes-h { display: flex; align-items: center; gap: 12px; width: 100%; padding: 9px 22px; border: 0; background: none; color: var(--text-mid); cursor: pointer; font-size: var(--fs-12); text-align: left; }
+.fl-lanes-h:hover { color: var(--text-bright); }
+.fl-lanes-t { font-family: var(--font-ui); letter-spacing: 0.04em; color: var(--text-bright); }
+.fl-lanes-sum { font-size: 10.5px; color: var(--text-dim); }
+.fl-lanes-bp { font-size: var(--fs-10); color: var(--status-warn); border: 1px solid color-mix(in oklab, var(--status-warn) 40%, transparent); border-radius: var(--radius-pill); padding: 2px 8px; }
+.fl-lanes-spacer { margin-left: auto; }
+.fl-lanes-chev { color: var(--text-dim); font-size: var(--fs-10); }
+.fl-lanes-row { display: grid; grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)); gap: 10px; padding: 2px 22px 14px; }
+.fl-lane { border: 1px solid var(--border-main); border-radius: var(--radius-sm); background: var(--bg-card); padding: 10px 12px; }
+.fl-lane.bp { border-color: color-mix(in oklab, var(--status-warn) 38%, var(--border-main)); }
+.fl-lane-top { display: flex; align-items: baseline; gap: 8px; }
+.fl-lane-lbl { font-size: var(--fs-12); color: var(--text-bright); }
+.fl-lane-w { margin-left: auto; font-size: var(--fs-10); color: var(--text-dim); }
+.fl-lane-id { font-size: var(--fs-10); color: var(--text-dim); margin: 3px 0 8px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.fl-lane-bar { position: relative; height: 7px; border-radius: 4px; background: var(--bg-sunken); overflow: hidden; display: flex; }
+.fl-lane-active { background: var(--volt); height: 100%; }
+.fl-lane-wait { background: color-mix(in oklab, var(--status-warn) 60%, transparent); height: 100%; opacity: 0.6; }
+.fl-lane-foot { display: flex; align-items: center; gap: 10px; margin-top: 8px; font-size: var(--fs-10); color: var(--text-dim); }
+.fl-lane-waiting.on { color: var(--status-warn); }
+.fl-lane-bpf { margin-left: auto; color: var(--status-warn); }
+.fl-lane-okf { margin-left: auto; color: var(--status-ok); }
+
+/* ── aside: event queue + heartbeat ───────────────────────────── */
+.fl-q-acct { display: flex; gap: 12px; margin-bottom: 8px; }
+.fl-q-c { font-size: 10.5px; color: var(--text-dim); }
+.fl-q-c b { font-family: var(--font-mono); color: var(--text-mid); margin-right: 3px; }
+.fl-q-c.ok b { color: var(--status-ok); }
+.fl-q-list { display: flex; flex-direction: column; gap: 5px; margin-bottom: 8px; }
+.fl-q-item { display: flex; align-items: center; gap: 7px; font-size: var(--fs-11); padding: 5px 8px; border: 1px solid var(--border-soft); border-radius: var(--radius-sm); background: var(--bg-card); }
+.fl-q-item.drain { opacity: 0.6; text-decoration: line-through; text-decoration-color: var(--text-dim); }
+.fl-q-gl { color: var(--volt); flex: none; width: 12px; }
+.fl-q-kind { color: var(--text-dim); font-size: 9.5px; flex: none; }
+.fl-q-from { color: var(--text-mid); flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.fl-q-at { color: var(--text-dim); font-size: 9.5px; }
+.fl-q-hb { display: flex; align-items: center; gap: 7px; font-size: 10.5px; color: var(--text-dim); }
+.fl-q-hb.off { opacity: 0.7; }
+.fl-q-hb-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--status-ok); animation: fl-beat 2s ease-in-out infinite; }
+@keyframes fl-beat { 0%, 100% { opacity: 0.4; transform: scale(0.85); } 50% { opacity: 1; transform: scale(1.15); } }
+
+/* ── aside: runtime rotation ──────────────────────────────────── */
+.fl-rot-chain { display: flex; align-items: center; flex-wrap: wrap; gap: 5px; }
+.fl-rot-cand { font-size: var(--fs-10); padding: 3px 7px; border: 1px solid var(--border-main); border-radius: var(--radius-sm); color: var(--text-dim); background: var(--bg-card); }
+.fl-rot-cand.head { border-color: var(--volt-dim); color: var(--text-mid); }
+.fl-rot-cand.cur { color: var(--volt); border-color: var(--volt-dim); box-shadow: inset 0 0 0 1px var(--volt-dim); }
+.fl-rot-arr { color: var(--text-dim); font-size: var(--fs-10); }
+.fl-rot-note { font-size: 9.5px; color: var(--text-dim); margin-top: 7px; }
+.fl-rot-na { font-size: var(--fs-11); color: var(--text-dim); }
+.fl-rot-ev { display: flex; align-items: center; gap: 8px; margin-top: 7px; font-size: 10.5px; color: var(--text-mid); }
+.fl-rot-ev-out { flex: none; }
+.fl-rot-ev.recovered .fl-rot-ev-out { color: var(--status-ok); }
+.fl-rot-ev.paused .fl-rot-ev-out { color: var(--status-warn); }
+.fl-rot-ev.backpressure .fl-rot-ev-out { color: var(--status-warn); }
+.fl-as-tag { margin-left: 7px; font-size: var(--fs-9); font-family: var(--font-mono); letter-spacing: 0.04em; padding: 1px 6px; border-radius: var(--radius-xs); border: 1px solid var(--border-main); color: var(--text-dim); }
+.fl-as-tag.bad { color: var(--status-bad); border-color: color-mix(in oklab, var(--status-bad) 40%, transparent); background: color-mix(in oklab, var(--status-bad) 8%, transparent); }
+.fl-lanes-note { grid-column: 1 / -1; font-size: 9.5px; color: var(--text-dim); padding: 0 0 2px; }
+.fl-rot-ev-t { color: var(--text-dim); }
 
 @media (max-width: 900px) {
   .fl-top { height: auto; flex-wrap: wrap; padding: 12px 16px; gap: 10px 14px; }

--- a/dashboard/src/styles/keeper-v2/monitor.css
+++ b/dashboard/src/styles/keeper-v2/monitor.css
@@ -1,0 +1,188 @@
+/* Monitor 신규 섹션 — Internal Agents · 감사 무결성 (2026-08) */
+.fl-secs { display: flex; gap: 4px; padding: 0 var(--pad-x, 18px) 0; border-bottom: 1px solid var(--border-main); background: var(--bg-panel); }
+.fl-sec { appearance: none; background: none; border: 0; border-bottom: 2px solid transparent; padding: 9px 12px 8px; cursor: pointer; white-space: nowrap; font-family: var(--font-ui); font-size: var(--fs-12); color: var(--text-dim); transition: color 0.18s, border-color 0.18s; }
+.fl-sec:hover { color: var(--text-primary); }
+.fl-sec.on { color: var(--volt-strong); border-bottom-color: var(--volt-strong); }
+.fl-sec-new { margin-left: 6px; font-family: var(--font-mono); font-size: 8.5px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--volt-strong); border: 1px solid color-mix(in oklab, var(--volt-strong) 40%, var(--border-main)); border-radius: var(--radius-xs); padding: 0 4px; vertical-align: 1px; }
+
+/* context occupancy = not_observed (게이지·임계선 제거) */
+.ctx-usage { display: flex; align-items: baseline; gap: 6px; }
+.ctx-usage-k { font-family: var(--font-mono); font-size: var(--fs-9); letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-dim); margin-right: auto; }
+.ctx-usage-v { font-size: var(--fs-14); color: var(--volt-strong); }
+.ctx-notobs { display: flex; flex-direction: column; gap: 3px; margin-top: 9px; padding: 7px 9px; border: 1px dashed var(--border-main); border-radius: var(--radius-xs); font-size: var(--fs-10); letter-spacing: 0.04em; color: var(--text-dim); }
+.ctx-notobs b { color: var(--text-mid); font-weight: 400; }
+.ctx-notobs-g { font-family: var(--font-ui); font-size: 10.5px; letter-spacing: 0; line-height: 1.45; color: var(--text-dim); }
+.fl-ctx-win { font-style: normal; color: var(--text-dim); }
+.fl-notobs { margin-top: 7px; font-size: 9.5px; letter-spacing: 0.04em; line-height: 1.5; color: var(--text-dim); }
+.fl-notobs b { color: var(--text-mid); font-weight: 400; }
+
+.ia-wrap { overflow: auto; padding: 20px 22px 34px; display: flex; flex-direction: column; gap: 12px; min-height: 0; }
+.ia-head { display: flex; align-items: baseline; gap: 10px; }
+.ia-head h3 { margin: 0; font-family: var(--font-display); font-weight: 500; font-size: var(--fs-14); letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-bright); }
+.ia-count { font-size: 10.5px; color: var(--text-dim); }
+.ia-route { margin-left: auto; font-size: var(--fs-10); color: var(--text-dim); border: 1px dashed var(--border-main); border-radius: var(--radius-xs); padding: 2px 7px; }
+.ia-lede { margin: 0; font-size: var(--fs-12); line-height: 1.55; color: var(--text-mid); max-width: 78ch; text-wrap: pretty; }
+.ia-filters { display: flex; flex-wrap: wrap; gap: 6px; }
+.ia-filter { appearance: none; background: var(--bg-sunken); border: 1px solid var(--border-main); border-radius: var(--radius-xs); padding: 4px 10px; cursor: pointer; font-family: var(--font-ui); font-size: var(--fs-11); color: var(--text-dim); transition: color 0.18s, border-color 0.18s; }
+.ia-filter:hover { color: var(--text-primary); }
+.ia-filter.on { color: var(--volt-strong); border-color: color-mix(in oklab, var(--volt-strong) 45%, var(--border-main)); }
+.ia-empty { border: 1px dashed var(--border-main); border-radius: var(--radius-md); padding: 22px; text-align: center; font-size: var(--fs-12); color: var(--text-dim); }
+.ia-list { display: flex; flex-direction: column; gap: 8px; }
+.ia-card { border: 1px solid var(--border-main); border-radius: var(--radius-md); background: var(--bg-panel); overflow: hidden; }
+.ia-card.on { border-color: color-mix(in oklab, var(--volt) 32%, var(--border-main)); }
+.ia-row { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 14px; width: 100%; text-align: left; appearance: none; background: none; border: 0; padding: 11px 13px; cursor: pointer; }
+.ia-row:hover { background: var(--bg-panel-alt); }
+.ia-badge { display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-mono); font-size: var(--fs-10); letter-spacing: 0.06em; color: var(--text-dim); border: 1px solid var(--border-main); border-radius: var(--radius-xs); padding: 2px 7px; }
+.ia-badge i { width: 5px; height: 5px; border-radius: 50%; background: var(--text-dim); }
+.ia-badge[data-tone="ok"] { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 34%, var(--border-main)); }
+.ia-badge[data-tone="ok"] i { background: var(--status-ok); }
+.ia-badge[data-tone="warn"] { color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 34%, var(--border-main)); }
+.ia-badge[data-tone="warn"] i { background: var(--status-warn); }
+.ia-badge[data-tone="bad"] { color: var(--status-bad); border-color: color-mix(in oklab, var(--status-bad) 34%, var(--border-main)); }
+.ia-badge[data-tone="bad"] i { background: var(--status-bad); }
+.ia-badge[data-tone="info"] { color: var(--info); border-color: color-mix(in oklab, var(--info) 34%, var(--border-main)); }
+.ia-badge[data-tone="info"] i { background: var(--info); }
+.ia-sub { min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+.ia-sub b { font-size: var(--fs-12); color: var(--text-bright); font-weight: 500; }
+.ia-sub code { font-size: 10.5px; color: var(--text-dim); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ia-meta { display: flex; flex-direction: column; gap: 2px; text-align: right; font-size: var(--fs-10); color: var(--text-dim); }
+.ia-detail { border-top: 1px solid var(--border-main); background: var(--bg-sunken); padding: 12px 13px; display: grid; gap: 12px; }
+.ia-detail.two { grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
+.ia-k { font-family: var(--font-mono); font-size: var(--fs-9); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-dim); margin-bottom: 5px; }
+.ia-evi { min-width: 0; }
+.ia-evi code { font-size: var(--fs-11); color: var(--text-primary); }
+.ia-evi pre { margin: 0; overflow: auto; font-size: 10.5px; line-height: 1.5; color: var(--text-mid); white-space: pre-wrap; word-break: break-word; }
+.ia-tools { margin: 0; padding: 0 0 0 0; list-style: none; display: flex; flex-direction: column; gap: 8px; }
+.ia-tool { border: 1px solid var(--border-soft); border-radius: var(--radius-sm); padding: 8px 9px; }
+.ia-tool-h { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; font-size: 11.5px; color: var(--text-primary); }
+.ia-tool-h code { font-size: var(--fs-10); color: var(--status-ok); }
+.ia-ms { font-size: var(--fs-10); color: var(--text-dim); }
+.ia-tool-io { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 8px; margin-top: 7px; }
+.ia-note { margin: 0; font-size: var(--fs-11); color: var(--text-dim); line-height: 1.5; }
+.ia-note.span2 { grid-column: 1 / -1; }
+.ia-err { margin-top: 6px; font-size: 11.5px; color: var(--status-bad); }
+
+.ai-strip { display: flex; flex-wrap: wrap; gap: 8px; }
+.ai-stat { display: flex; flex-direction: column; gap: 3px; border: 1px solid var(--border-main); border-radius: var(--radius-sm); background: var(--bg-panel); padding: 8px 13px; min-width: 104px; }
+.ai-stat .k { font-family: var(--font-mono); font-size: var(--fs-9); letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-dim); }
+.ai-stat .v { font-size: 15px; color: var(--text-bright); }
+.ai-stat .v.ok { color: var(--status-ok); }
+.ai-stat .v.bad { color: var(--status-bad); }
+.ai-tablewrap { border: 1px solid var(--border-main); border-radius: var(--radius-md); overflow: auto; background: var(--bg-panel); }
+.ai-table { width: 100%; border-collapse: collapse; font-size: var(--fs-12); }
+.ai-table th { text-align: left; font-family: var(--font-mono); font-size: var(--fs-9); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-dim); font-weight: 400; padding: 9px 12px; border-bottom: 1px solid var(--border-main); }
+.ai-table td { padding: 9px 12px; border-bottom: 1px solid var(--border-soft); color: var(--text-primary); vertical-align: top; }
+.ai-table tr:last-child td { border-bottom: 0; }
+.ai-table tr.fail td { background: color-mix(in oklab, var(--status-bad) 6%, transparent); }
+.ai-b { display: inline-block; font-family: var(--font-mono); font-size: var(--fs-10); border: 1px solid var(--border-main); border-radius: var(--radius-xs); padding: 1px 6px; }
+.ai-b.ok { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 34%, var(--border-main)); }
+.ai-b.bad { color: var(--status-bad); border-color: color-mix(in oklab, var(--status-bad) 34%, var(--border-main)); }
+.ai-d { color: var(--text-mid); font-size: 11.5px; line-height: 1.5; }
+.cl-sub { font-size: 9.5px; color: var(--text-dim); }
+
+/* ── 2차 (Tool Monitor · Observatory · Lab · Command) ── */
+.ai-table .r, .ai-table th.r { text-align: right; }
+.ai-table .dim { color: var(--text-dim); }
+.ai-table .ok { color: var(--status-ok); }
+.ai-table .bad { color: var(--status-bad); }
+.ai-b.warn { color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 34%, var(--border-main)); }
+.tm-sub { margin-top: 3px; font-size: 9.5px; }
+.tm-board { display: flex; flex-direction: column; gap: 14px; }
+.tm-src { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; border: 1px solid var(--border-main); border-radius: var(--radius-sm); background: var(--bg-panel); padding: 8px 12px; font-size: 10.5px; color: var(--text-mid); }
+.tm-src .ok { color: var(--status-ok); }
+.tm-src .dim { color: var(--text-dim); }
+.tm-tiles { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 8px; }
+.tm-tile { display: flex; flex-direction: column; gap: 3px; border: 1px solid var(--border-main); border-left: 2px solid var(--border-main); border-radius: var(--radius-sm); background: var(--bg-panel); padding: 9px 12px; }
+.tm-tile[data-tone="ok"] { border-left-color: var(--status-ok); }
+.tm-tile[data-tone="warn"] { border-left-color: var(--status-warn); }
+.tm-tile .k { font-family: var(--font-mono); font-size: var(--fs-9); letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-dim); }
+.tm-tile .v { font-size: 17px; color: var(--text-bright); }
+.tm-tile .s { font-size: 9.5px; color: var(--text-dim); }
+.tm-sec { display: flex; flex-direction: column; gap: 8px; min-width: 0; }
+.tm-sec h4 { margin: 0; font-family: var(--font-mono); font-size: var(--fs-9); letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-dim); font-weight: 400; }
+.tm-split { display: grid; grid-template-columns: minmax(0, 1.45fr) minmax(250px, 0.8fr); gap: 14px; }
+@media (max-width: 1100px) { .tm-split { grid-template-columns: 1fr; } }
+.tm-side { display: flex; flex-direction: column; gap: 14px; }
+.tm-link { align-self: flex-start; appearance: none; background: none; border: 0; padding: 0; cursor: pointer; font-family: var(--font-ui); font-size: var(--fs-11); color: var(--text-dim); }
+.tm-link:hover { color: var(--volt-strong); }
+.tm-lanes { display: flex; flex-direction: column; gap: 6px; }
+.tm-lane { display: grid; grid-template-columns: minmax(0, 1fr) auto; grid-template-areas: "t o" "m o"; gap: 0 10px; align-items: center; text-align: left; appearance: none; background: var(--bg-panel); border: 1px solid var(--border-main); border-radius: var(--radius-sm); padding: 8px 11px; cursor: pointer; transition: border-color 0.18s; }
+.tm-lane:hover { border-color: color-mix(in oklab, var(--volt) 40%, var(--border-main)); }
+.tm-lane-t { grid-area: t; font-size: var(--fs-12); color: var(--text-bright); }
+.tm-lane-m { grid-area: m; font-size: 10.5px; color: var(--text-dim); }
+.tm-lane-o { grid-area: o; font-size: 9.5px; color: var(--text-dim); }
+.tm-cats { display: flex; flex-direction: column; gap: 5px; }
+.tm-cat { display: flex; justify-content: space-between; gap: 10px; font-size: 10.5px; color: var(--status-bad); }
+.tm-cat .dim { color: var(--text-dim); }
+.tm-pausedot { margin-left: 7px; font-size: 9.5px; color: var(--status-warn); }
+.tm-time { display: flex; flex-direction: column; border: 1px solid var(--border-main); border-radius: var(--radius-md); background: var(--bg-panel); overflow: hidden; }
+.tm-time-row { display: grid; grid-template-columns: 54px 132px auto minmax(0, 1fr); gap: 12px; align-items: center; padding: 9px 12px; border-bottom: 1px solid var(--border-soft); font-size: 11.5px; color: var(--text-primary); }
+.tm-time-row:last-child { border-bottom: 0; }
+.tm-time-row .dim { color: var(--text-dim); }
+.tm-tr b { font-weight: 500; color: var(--text-bright); }
+.tm-ok { border: 1px solid color-mix(in oklab, var(--status-ok) 30%, var(--border-main)); border-radius: var(--radius-sm); padding: 12px 14px; font-size: var(--fs-12); color: var(--status-ok); }
+.tm-paused-list { display: flex; flex-direction: column; gap: 6px; }
+.tm-paused-card { display: flex; flex-wrap: wrap; align-items: center; gap: 12px; border: 1px solid color-mix(in oklab, var(--status-warn) 28%, var(--border-main)); border-radius: var(--radius-sm); padding: 10px 13px; font-size: var(--fs-12); }
+.tm-paused-card .dim { color: var(--text-dim); }
+.tm-blk { font-size: 10.5px; color: var(--status-warn); }
+
+.ob-ranges { display: flex; gap: 6px; }
+.ob-panel { position: relative; display: flex; flex-direction: column; gap: 8px; border: 1px solid var(--border-main); border-radius: var(--radius-md); background: var(--bg-panel); padding: 12px 14px 14px; }
+.ob-axis { display: grid; grid-template-columns: repeat(7, 1fr); border-bottom: 1px solid var(--border-soft); padding-bottom: 5px; font-size: var(--fs-9); color: var(--text-dim); }
+.ob-axis span:first-child { text-align: left; }
+.ob-axis span:last-child { text-align: right; }
+.ob-axis span { text-align: center; }
+.ob-track { display: grid; grid-template-columns: 74px minmax(0, 1fr); align-items: center; gap: 10px; }
+.ob-track-k { font-size: var(--fs-9); letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-dim); }
+.ob-lane { position: relative; height: 34px; border-bottom: 1px solid var(--border-soft); }
+.ob-ev { position: absolute; bottom: 6px; width: 7px; height: 7px; margin-left: -3.5px; padding: 0; border: 0; border-radius: 50%; background: var(--text-dim); cursor: pointer; }
+.ob-ev.t-ok { background: var(--status-ok); }
+.ob-ev.t-warn { background: var(--status-warn); }
+.ob-ev.t-bad { background: var(--status-bad); }
+.ob-ev.t-info { background: var(--info); }
+.ob-ev:hover { transform: scale(1.6); }
+.ob-call { position: absolute; bottom: 0; width: 2px; margin-left: -1px; background: color-mix(in oklab, var(--volt) 55%, transparent); }
+.ob-call.bad { background: var(--status-bad); }
+.ob-svg { position: absolute; inset: 0; width: 100%; height: 100%; color: var(--volt-strong); }
+.ob-cursor { position: absolute; top: 34px; bottom: 14px; width: 1px; background: color-mix(in oklab, var(--volt-strong) 70%, transparent); pointer-events: none; }
+.ob-readout, .ob-detail { display: flex; flex-wrap: wrap; align-items: baseline; gap: 10px; border: 1px dashed var(--border-main); border-radius: var(--radius-sm); padding: 9px 12px; font-size: 11.5px; color: var(--text-primary); }
+.ob-readout .dim, .ob-detail .dim { color: var(--text-dim); }
+.ob-detail-body { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; }
+
+.lab-panel { display: flex; flex-direction: column; gap: 9px; border: 1px solid var(--border-main); border-radius: var(--radius-md); background: var(--bg-panel); padding: 13px 15px; }
+.lab-panel h4 { margin: 0; font-family: var(--font-display); font-size: var(--fs-12); letter-spacing: 0.08em; text-transform: uppercase; font-weight: 500; color: var(--text-bright); }
+.lab-kv { display: flex; flex-direction: column; }
+.lab-kv-row { display: grid; grid-template-columns: 168px minmax(0, 1fr) auto; gap: 12px; align-items: baseline; padding: 7px 0; border-bottom: 1px solid var(--border-soft); font-size: 11.5px; }
+.lab-kv-row:last-child { border-bottom: 0; }
+.lab-kv-row .k { color: var(--text-dim); }
+.lab-kv-row .v { color: var(--text-primary); }
+.lab-kv-row .s { font-size: 9.5px; color: var(--text-dim); }
+.lab-exec, .cmd-form { display: flex; flex-direction: column; gap: 9px; }
+.lab-f { display: flex; align-items: center; gap: 10px; font-size: var(--fs-11); color: var(--text-dim); }
+.lab-f span { min-width: 54px; font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.1em; text-transform: uppercase; }
+.lab-f input, .lab-f select, .lab-search, .cmd-text { flex: 1; min-width: 0; background: var(--bg-sunken); border: 1px solid var(--border-main); border-radius: var(--radius-xs); padding: 6px 9px; font-family: var(--font-mono); font-size: 11.5px; color: var(--text-primary); }
+.lab-f input[type="range"] { padding: 0; }
+.lab-search { align-self: flex-start; max-width: 260px; }
+.lab-run { align-self: flex-start; appearance: none; background: color-mix(in oklab, var(--volt) 16%, var(--bg-panel)); border: 1px solid color-mix(in oklab, var(--volt) 45%, var(--border-main)); border-radius: var(--radius-xs); padding: 6px 14px; cursor: pointer; font-family: var(--font-ui); font-size: 11.5px; color: var(--volt-strong); }
+.lab-run:disabled { opacity: 0.45; cursor: default; }
+.lab-srcline { display: flex; flex-wrap: wrap; gap: 10px; font-size: 10.5px; color: var(--text-mid); }
+.lab-srcline .ok { color: var(--status-ok); }
+.lab-srcline .dim { color: var(--text-dim); }
+.lab-x { margin-left: 6px; font-family: var(--font-mono); font-size: var(--fs-9); letter-spacing: 0.08em; text-transform: uppercase; color: var(--status-warn); }
+.lab-fb { margin-top: 3px; font-size: 9.5px; color: var(--status-bad); }
+.lab-perf-ctl { display: flex; align-items: center; gap: 12px; }
+
+.cmd-cols { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 14px; }
+.cmd-actions { display: flex; align-items: center; gap: 12px; }
+.cmd-actions .dim { font-size: 10.5px; color: var(--text-dim); }
+.cmd-log { display: flex; flex-direction: column; gap: 7px; }
+.cmd-log-row { border: 1px solid var(--border-main); border-radius: var(--radius-sm); background: var(--bg-sunken); padding: 9px 11px; }
+.cmd-log-h { display: flex; flex-wrap: wrap; align-items: center; gap: 9px; font-size: var(--fs-10); }
+.cmd-log-h .dim { color: var(--text-dim); }
+.cmd-log-b { margin-top: 6px; font-size: var(--fs-12); line-height: 1.5; color: var(--text-primary); }
+.cmd-banner { display: flex; flex-direction: column; gap: 6px; border: 1px solid color-mix(in oklab, var(--status-bad) 32%, var(--border-main)); border-radius: var(--radius-sm); background: color-mix(in oklab, var(--status-bad) 5%, transparent); padding: 11px 13px; font-size: var(--fs-12); color: var(--text-primary); }
+.cmd-banner b { font-weight: 500; color: var(--status-bad); }
+.cmd-banner ul { margin: 0; padding-left: 16px; display: grid; gap: 4px; }
+.cmd-banner .dim { font-size: 10.5px; color: var(--text-dim); }
+.cmd-gatelinks { display: flex; flex-direction: column; gap: 6px; }
+.cl-multi { font-family: var(--font-ui); font-size: var(--fs-11); color: var(--text-dim); }


### PR DESCRIPTION
## 무엇

v3 델타 시리즈 **PR-5 — fleet + monitor.css vendoring + 컨텍스트 관측 어휘 채택**이에요 (#29065·#29066 형제, +327/−8).

### fleet.css 3-way (충돌 3곳)

- `.fl-top-actions`/`.fl-top-btn` 신규 채택, `.fl-meta`는 토큰화로 로컬과 수렴
- 반응형 shed 미디어는 **로컬 승** — 라이브 5트랙(1500px) 계약과 테스트로 가드된 720px 모바일 블록(터치 타깃·sr-only 헤더·모바일 인덴트)을 유지. v3의 구판(1320px 4트랙, 단순 720px)은 회귀라 드랍했어요
- v3 신규 어휘 채택: lane/admission queue 밴드(`.fl-lanes*`·`.fl-lane*`), aside 이벤트 큐+하트비트(`.fl-q-*`), runtime rotation(`.fl-rot-*`·`.fl-as-tag`)

### monitor.css vendoring (신규 188줄)

- 프로토 `<link>` 순서 위치(prompt-book 다음)에 main.ts import 1줄 — verify/registry는 그 사이지만 Phase B/C라 미벤더
- 정수 font-size 36개 토큰화, 폰트 블록 없음 확인

### agent-roster 컨텍스트 관측 어휘 (mark, don't fake)

- `.fl-ctx-win`: **`context_max`를 실제 수신했을 때만** `62% / 128.0K`처럼 창 크기 주석 — 파생·추정 없음
- 미관측 행 셀: aria-label을 `없음`→`미관측`으로 정정(없는 것과 모르는 것은 다르니까요) + title 추가, `—`와 `data-stub`은 기존 관례 유지
- aside 미관측 노트를 Tailwind 유틸에서 v3 `.fl-notobs` 어휘로 교체 (문구 계약 동일)

## 검증

- `agent-roster.test.ts` 58개 통과 — `.fl-ctx-win` 존재/부재 케이스 2개 신규
- `pnpm vitest run src/styles` 170개 / `no-raw-font-size-px` clean / `pnpm typecheck` clean
- `check-dashboard-nav-event-parity.sh` OK (main.ts 변경분)
- `pnpm test` 전체 스위트 실행 중 (파이프 없이) — 완료 결과를 코멘트로 남길게요

## 다음

PR-6 — chat `.kw-*` 리타겟 (마지막 잔여)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
