### PR TITLE
test(dashboard): PR-6 — chat 헤더는 리타겟 대신 divergence를 가드로 고정

### DIFF
--- a/dashboard/docs/V2-RESKIN-PROGRESS.md
+++ b/dashboard/docs/V2-RESKIN-PROGRESS.md
@@ -49,8 +49,22 @@ REMAINING (re-audited 2026-08-19 against the tree — three of four were stale):
   `runtime-environment-editor.ts:498`. Browser re-verify only.
 - [x] mobile bottom tab bar: SHIPPED. `.v2-nav.is-mnav` + more-sheet in
   `nav-rail-v2.ts:124`, guarded by `mobile-bottom-reserve.test.ts`.
-- [ ] keepers chat thread/composer (KeeperConversationPanel, keeper-shared) still .kw-* —
-  the one real remaining rework (see Deferred polish; planned as v3-delta PR-6).
+- [x] keepers chat header: CLOSED as written — the audit found the item stale in four
+  places, so PR-6 pinned the divergences instead of executing it. Evidence:
+  - `chat-head` is already dual-emitted (`keeper-workspace-chat.ts:385`), so the vendored
+    skin already owns the header's shared properties.
+  - The `.sub` row it asked to retarget to is **deliberately absent**: the guard test
+    `keeps runtime scope/path out of the slim chat header`
+    (`keeper-workspace-chat.test.ts:322`) asserts `.chat-head .sub .sub-ns` is null.
+  - Adopting `.chat-id` would zero the desktop `min-width: 9rem` (prototype sets 0, and
+    keeper-v2 loads later), undoing the documented flex-wrap overflow fix. `.name-row`
+    is only defined as `.chat-id .name-row`, so it cannot be adopted independently.
+  - "drop search/archive/trash" describes buttons that do not exist: there is no trash
+    action, and Archive is the artifacts-panel *icon*. `search`/`turn`/`artifacts`/
+    `detail`/`config` are wired operator capability (`workspaceUtilityCommands`,
+    `keeper-workspace-chat.ts:98`); deleting them to match a static mock would be
+    capability loss, not a reskin.
+  Divergences now guarded by `styles/keeper-chat-header-divergence.test.ts`.
 
 ## Remaining deltas (adversarial, prioritized)
 - [ ] Keepers roster header: current = verbose stat grid (12/9/0/3) + chips;
@@ -84,7 +98,8 @@ evolution. Per-file disposition of the v2→v3 delta (base `2782405bc3`):
   operator actions (mark-don't-fake), so the dead selectors are not vendored.
 - Still queued (separate PRs): v2.css (PR-2), surfaces.css (PR-3),
   fusion/runtime/keeper-config (PR-4), prompt-book (PR-4b), fleet + monitor.css
-  vendoring + agent-roster ctx column (PR-5), chat .kw-* retarget (PR-6).
+  vendoring + agent-roster ctx column (PR-5). PR-6 closed the chat-header item by
+  guarding its divergences rather than retargeting — the instruction was stale.
 
 ## Notes
 - Live data gaps (mark, don't fake): schedule/cron (no signal), context window
@@ -92,9 +107,9 @@ evolution. Per-file disposition of the v2→v3 delta (base `2782405bc3`):
 - KeeperPhase live enum == prototype FSM_STATES + Zombie.
 
 ## Deferred polish (after far surfaces)
-- Keepers chat (keeper-workspace-chat.ts) still uses .kw-chat-* classes (styled by
-  keeper-workspace.css mimic, not SSOT). Retarget header → .chat-head/.name-row/.sub/
-  .chat-actions + Pill, and reduce actions to prototype FSM glyphs + ⚙ (drop
-  search/archive/trash) — needs WorkspaceCommandButtons changes too. Visually ~95% already.
+- Keepers chat header: settled 2026-08-19 (see REMAINING above). keeper-workspace.css is
+  not a mimic here — the surviving `.kw-chat-*` rules are the desktop min-width/flex-wrap
+  overflow fix and the warn/bad/busy pill states the prototype does not have. The header
+  already emits `chat-head` and already uses the shared Pill.
 - Final cleanup PR: remove legacy keeper-workspace.css / *-v2.css / v2-shell.css once all
   surfaces emit prototype classes; run tsc/lint/tests.

--- a/dashboard/src/styles/keeper-chat-header-divergence.test.ts
+++ b/dashboard/src/styles/keeper-chat-header-divergence.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { parse } from 'postcss'
+
+// Regression guard for the chat header's deliberate divergences from the
+// keeper-v2 prototype.
+//
+// The live header already dual-emits the prototype's `chat-head` alongside
+// `kw-chat-head`, so the vendored skin owns the shared properties. The
+// remaining `kw-*` rules are NOT a stale mimic — each one carries a fix or a
+// state the prototype does not have. main.ts loads keeper-v2/v2.css after
+// keeper-workspace.css, so a same-specificity prototype rule wins; adopting
+// the prototype class on these nodes would therefore silently undo the fix.
+//
+// This pins the divergences so a later prototype re-sync has to argue with a
+// failing test instead of quietly regressing them.
+
+const read = (file: string): string => readFileSync(resolve(__dirname, file), 'utf-8')
+
+/** Declarations of the top-level (non-media) rules for one selector, merged in
+ *  source order. declarationsForSelector() is media-blind and would fold the
+ *  mobile overrides into the same object, which is what this guard must not
+ *  compare against. */
+function baseDeclarations(css: string, selector: string): Record<string, string> {
+  const declarations: Record<string, string> = {}
+  let found = false
+
+  parse(css).walkRules((rule) => {
+    if (rule.parent?.type !== 'root') return
+    if (!rule.selectors.includes(selector)) return
+    found = true
+    rule.walkDecls((decl) => {
+      declarations[decl.prop] = decl.value.trim()
+    })
+  })
+
+  if (!found) throw new Error(`Selector not found at top level: ${selector}`)
+  return declarations
+}
+
+const live = (): string => read('keeper-workspace.css')
+const proto = (): string => read('keeper-v2/v2.css')
+
+describe('chat header divergences from the keeper-v2 prototype', () => {
+  it('.kw-chat-id keeps a desktop min-width the prototype zeroes', () => {
+    // Paired with the header's flex-wrap: without a floor here the flex:none
+    // action row squeezes the identity to width:0 and the name overflows the
+    // buttons at 3-pane laptop widths (keeper-workspace.css:526-530). The
+    // mobile block deliberately relaxes it back to 0 — that is a narrow-screen
+    // decision, not the desktop contract this pins.
+    expect(baseDeclarations(live(), '.kw-chat-id')['min-width']).toBe('9rem')
+    expect(baseDeclarations(proto(), '.chat-id')['min-width']).toBe('0')
+  })
+
+  it('.kw-chat-head wraps where the prototype does not', () => {
+    expect(baseDeclarations(live(), '.kw-chat-head')['flex-wrap']).toBe('wrap')
+    // The prototype leaves flex-wrap unset, which is why dual-emitting
+    // `chat-head` is safe: the live rule supplies what the prototype omits.
+    expect(baseDeclarations(proto(), '.chat-head')['flex-wrap']).toBeUndefined()
+  })
+
+  it('.kw-state-pill carries runtime states the prototype pill lacks', () => {
+    // statePillTone() (keeper-workspace-shared.ts:153) is total over
+    // run|warn|bad|busy|off. The prototype only styles run|pause|off, so
+    // dropping the kw- variants would render warn/bad/busy as the base pill.
+    const liveCss = live()
+    const protoCss = proto()
+    for (const variant of ['warn', 'bad', 'busy']) {
+      expect(() => baseDeclarations(liveCss, `.kw-state-pill.${variant}`)).not.toThrow()
+      expect(() => baseDeclarations(protoCss, `.state-pill.${variant}`)).toThrow()
+    }
+  })
+})


### PR DESCRIPTION
## 무엇

v3 델타 시리즈 마지막 **PR-6**이에요. 원래 계획은 chat 헤더를 프로토 어휘로 리타겟하는 거였는데, 트리를 실제로 감사해보니 **지시가 네 군데에서 낡아 있어서** 실행 대신 divergence를 가드로 고정했습니다.

### 왜 리타겟을 안 했는지 (근거)

| 지시 | 실제 |
|---|---|
| `.chat-head`로 리타겟 | **이미 병기됨** (`keeper-workspace-chat.ts:385`) — 벤더 스킨이 이미 공유 속성을 소유 |
| `.sub`로 리타겟 | **의도적으로 없는 행** — 가드 테스트 `keeps runtime scope/path out of the slim chat header`가 `.chat-head .sub .sub-ns`를 null로 단언 |
| `.chat-id`/`.name-row` 채택 | 채택하면 데스크톱 `min-width: 9rem`이 0이 됨(프로토가 0, keeper-v2가 나중 로드) → 문서화된 flex-wrap 오버플로 수정이 조용히 무효. `.name-row`는 `.chat-id .name-row`로만 정의돼 단독 채택 불가 |
| search/archive/trash 제거 | **없는 버튼** — trash 액션 자체가 없고 Archive는 아티팩트 패널 아이콘이에요. search/turn/artifacts/detail/config는 전부 배선된 운영 기능(`workspaceUtilityCommands`)이라, 목업에 맞추려고 지우면 리스킨이 아니라 기능 삭제입니다 |
| "keeper-workspace.css는 mimic" | 남은 `.kw-chat-*`는 mimic이 아니라 **프로토에 없는 수정·상태**를 담고 있음 |

### 대신 넣은 것

`styles/keeper-chat-header-divergence.test.ts` — 프로토 재싱크가 다음을 되돌리면 의도적으로 실패해요:

1. 데스크톱 `.kw-chat-id { min-width: 9rem }` (프로토는 0)
2. `.kw-chat-head { flex-wrap: wrap }` (프로토는 미설정 — 그래서 `chat-head` 병기가 안전한 것)
3. `.kw-state-pill`의 `warn`/`bad`/`busy` — `statePillTone()`은 run|warn|bad|busy|off 전역이지만 프로토 pill은 run|pause|off만 있어요

헬퍼는 **최상위 룰만** 읽습니다. 공용 `declarationsForSelector`는 미디어쿼리를 구분하지 않아 모바일 오버라이드(`min-width: 0`)를 접어 넣거든요 — 처음 작성한 판이 실제로 이걸로 잘못 통과할 뻔했고, 그 함정도 주석에 남겼어요.

`V2-RESKIN-PROGRESS.md`의 원 지시문도 정정했습니다. 낡은 지시를 남겨두면 다음 세션이 같은 오지시를 재생산하니까요.

## 검증

- `pnpm vitest run src/styles` 28파일/173개 통과 (신규 가드 3개 포함)
- `pnpm typecheck` clean
- `pnpm test` 전체 스위트 실행 중 (파이프 없이) — 결과는 코멘트로 남길게요

🤖 Generated with [Claude Code](https://claude.com/claude-code)
