### PR TITLE
fix(dashboard): 개요 KPI 띠에서 마지막 칸 옆에 남던 빈 띠 제거

### DIFF
--- a/dashboard/src/styles/v2-overview.css
+++ b/dashboard/src/styles/v2-overview.css
@@ -99,6 +99,20 @@
   container-type: inline-size;
 }
 
+/* The vendored .ov-kpis strip (keeper-v2/surfaces.css) draws its cell dividers
+   with the 1px-gap technique: the container paints --border-soft and the cells
+   paint over it, so any grid track without a cell renders as a bare band.
+   The prototype fills its 6 columns exactly; the live overview renders 7 KPIs
+   (pinned by `renders exactly 7 cross-surface KPI cells`), so the trailing one
+   sat alone on a second row beside five empty tracks. Span it across the rest
+   of its row to close the strip. This holds at every configured column count
+   (6 desktop / 3 / 2 narrow) because 7 leaves exactly one trailing cell in
+   each; adding an 8th KPI trips the count test above, which is the signal to
+   revisit this rule rather than the place to bump a number. */
+.v2-overview-kpis > .ov-kpi:last-child {
+  grid-column: 1 / -1;
+}
+
 .v2-overview-attention,
 .v2-overview-telemetry,
 .v2-overview-fleet {

--- a/dashboard/src/styles/v2-overview.test.ts
+++ b/dashboard/src/styles/v2-overview.test.ts
@@ -23,4 +23,13 @@ describe('v2 overview CSS', () => {
     )
     expect(reasonText['overflow-wrap']).toBe('anywhere')
   })
+
+  it('closes the KPI strip when the last cell would sit alone on a row', () => {
+    // The vendored .ov-kpis grid paints --border-soft behind its 1px gaps, so a
+    // grid track with no cell shows as a bare band. The overview renders 7 KPIs
+    // into a 6-column strip; without this span the 7th sits beside five empty
+    // tracks. See the rule's comment in v2-overview.css.
+    const trailing = declarationsForSelector(css, '.v2-overview-kpis > .ov-kpi:last-child')
+    expect(trailing['grid-column']).toBe('1 / -1')
+  })
 })


### PR DESCRIPTION
## 무엇

개요(overview) 화면 상단 KPI 띠에서 **마지막 칸 옆에 빈 띠가 생기던 문제** 수정이에요. 칸반 수축(#29063)과 같은 계열 — 프로토가 전제한 자식 개수와 라이브 개수가 다른 경우입니다.

- **기전**: 벤더된 `.ov-kpis`는 1px 간격 기법으로 칸 구분선을 그려요. 컨테이너가 `--border-soft`를 칠하고 셀이 그 위를 덮는 구조라, **셀이 없는 트랙은 맨 배경이 그대로 보입니다**. 프로토는 6칸을 정확히 채우는데 라이브는 KPI를 7개 렌더링해서, 7번째가 2행에 홀로 앉고 옆의 빈 5칸이 통짜 띠로 보였어요
- **확인**: 로컬 8935에서 실측 — 자식 7개 / 컬럼 6개 / 행 top 2개(212, 295), 컨테이너 높이 166px. 스크린샷으로도 "진행 심의" 오른쪽에 빈 띠 확인
- **수정**: 마지막 셀이 남은 칸을 채우도록 `grid-column: 1 / -1`. 후보 두 개를 브라우저에서 직접 재봤고 `auto / -1`은 마지막 칸으로 밀려 왼쪽에 띠가 남아서 탈락시켰어요
- **모든 폭에서 유효**: 설정된 컬럼 수(데스크톱 6 / 좁은 화면 3 / 2) 전부에서 7은 정확히 하나가 남아요. KPI가 8개가 되면 기존 `renders exactly 7 cross-surface KPI cells` 테스트가 먼저 깨지는데, 그게 숫자를 올리라는 신호가 아니라 이 규칙을 다시 보라는 신호예요 — 주석에 그렇게 적어뒀습니다

## 형제 버그 스윕

칸반 버그의 본질(명시 template이 뒤의 auto-flow 재정의에도 살아남는 조합)로 대시보드 CSS 전체를 훑었는데, **그 조합은 칸반 한 곳뿐**이었어요. `work-v2.css`의 다른 auto-flow는 template을 제대로 지우고 있습니다.

## 검증

- `pnpm vitest run src/styles/v2-overview.test.ts src/components/overview` 4파일/134개 통과 (신규 가드 1개 포함)
- `pnpm typecheck` clean / `no-raw-font-size-px` clean
- `pnpm test` 전체 스위트 실행 중 — 결과는 코멘트로 남길게요

🤖 Generated with [Claude Code](https://claude.com/claude-code)
