### PR TITLE
fix(dashboard): 로그 화면 전체 장애 — 서버 ring 필드를 디코드하고 창 밖 표시

### DIFF
--- a/dashboard/src/api/schemas/logs.test.ts
+++ b/dashboard/src/api/schemas/logs.test.ts
@@ -51,6 +51,11 @@ function currentWire(entries: readonly Record<string, unknown>[] = []) {
     latest_seq: typeof newest?.seq === 'number' ? newest.seq : null,
     oldest_seq: typeof oldest?.seq === 'number' ? oldest.seq : null,
     latest_ts_iso: typeof newest?.ts === 'string' ? newest.ts : null,
+    ring: {
+      start_seq: typeof oldest?.seq === 'number' ? oldest.seq : 0,
+      total: entries.length,
+      dropped_before: false,
+    },
     total: entries.length,
     entries,
   }
@@ -144,5 +149,30 @@ describe('decodeLogsData', () => {
       latest_ts_iso: entries[0]?.ts,
     })
     expect(error.message).toContain('newest-seq-first')
+  })
+
+  // The ring bounds are the server's live-window truth (#29011). Decoding is
+  // strict (onExcessProperty: 'error'), so the server shipping this field
+  // without the schema took the whole logs surface down — the decode failed
+  // and the viewer rendered the drift message instead of any entries. These
+  // pin both directions of that contract.
+  it('carries the ring live-window bounds through to LogsData', () => {
+    const entries = [currentEntry({ seq: 81_225 })]
+    const data = Effect.runSync(decodeLogsData({
+      ...currentWire(entries),
+      ring: { start_seq: 31_225, total: 81_225, dropped_before: true },
+    }))
+    expect(data.ring).toEqual({
+      startSeq: 31_225,
+      total: 81_225,
+      droppedBefore: true,
+    })
+  })
+
+  it('rejects a response that omits the ring bounds', () => {
+    const wire = currentWire([currentEntry()]) as Record<string, unknown>
+    delete wire.ring
+    const error = expectDrift(wire)
+    expect(error.message).toContain('ring')
   })
 })

--- a/dashboard/src/api/schemas/logs.ts
+++ b/dashboard/src/api/schemas/logs.ts
@@ -63,6 +63,16 @@ const LogsQueryWireSchema = Schema.Struct({
   exclude_category: Schema.OptionFromNullOr(Schema.Array(LogCategorySchema)),
 })
 
+// Live-window bounds of the log ring (server #29011). `dropped_before` true
+// means entries below `start_seq` have already left the ring, so a thin or
+// empty result there is "outside the window — consult retention.durable_store",
+// not "did not happen".
+const LogsRingWireSchema = Schema.Struct({
+  start_seq: Schema.NonNegativeInt,
+  total: Schema.NonNegativeInt,
+  dropped_before: Schema.Boolean,
+})
+
 const LogsWireSchema = Schema.Struct({
   generated_at_iso: Schema.NonEmptyString,
   dashboard_surface: Schema.Literal('/api/v1/dashboard/logs'),
@@ -70,6 +80,7 @@ const LogsWireSchema = Schema.Struct({
   retention: LogsRetentionWireSchema,
   query: LogsQueryWireSchema,
   returned: Schema.NonNegativeInt,
+  ring: LogsRingWireSchema,
   latest_seq: Schema.OptionFromNullOr(Schema.NonNegativeInt),
   oldest_seq: Schema.OptionFromNullOr(Schema.NonNegativeInt),
   latest_ts_iso: Schema.OptionFromNullOr(Schema.NonEmptyString),
@@ -169,6 +180,11 @@ export interface LogsData {
     readonly scope: 'dashboard_logs'
     readonly durableStore: string
   }
+  readonly ring: {
+    readonly startSeq: number
+    readonly total: number
+    readonly droppedBefore: boolean
+  }
   readonly total: number
   readonly entries: readonly LogEntry[]
 }
@@ -221,6 +237,11 @@ function toLogsData(wire: LogsWire): LogsData {
     retention: {
       scope: wire.retention.scope,
       durableStore: wire.retention.durable_store,
+    },
+    ring: {
+      startSeq: wire.ring.start_seq,
+      total: wire.ring.total,
+      droppedBefore: wire.ring.dropped_before,
     },
     total: wire.total,
     entries: wire.entries.map(toLogEntry),

--- a/dashboard/src/components/logs.test.ts
+++ b/dashboard/src/components/logs.test.ts
@@ -40,6 +40,7 @@ function logData(
       scope: 'dashboard_logs',
       durableStore: '/Users/dancer/me/.masc/logs/system_log_2026-05-15.jsonl',
     },
+    ring: { startSeq: 0, total: entries.length, droppedBefore: false },
     total: entries.length,
     entries,
     ...overrides,

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -869,6 +869,14 @@ function renderLogProvenance(data: LogData | undefined) {
         >store ${store}</${StatusChip}>
       ` : null}
       ${renderSummaryChip('at', generatedAt)}
+      ${data.ring.droppedBefore ? html`
+        <${StatusChip}
+          tone="warn"
+          uppercase=${false}
+          title=${`링 시작 seq ${data.ring.startSeq} · 이전 기록은 ${data.retention.durableStore}에 있습니다`}
+          data-testid="logs-ring-dropped"
+        >seq ${data.ring.startSeq} 이전은 창 밖</${StatusChip}>
+      ` : null}
     </div>
   `
 }

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -156,6 +156,7 @@ function makeLogsData(entries: readonly LogEntry[]): LogsData {
       scope: 'dashboard_logs',
       durableStore: '/workspace/.masc/logs/system_log_2026-06-21.jsonl',
     },
+    ring: { startSeq: 0, total: entries.length, droppedBefore: false },
     total: entries.length,
     entries,
   }


### PR DESCRIPTION
## 증상

이벤트 로그 화면에 로그 대신 이 문구가 떠 있었어요:

```
logs schema drift: ring: is unexpected, expected: "generated_at_iso" | "dashboard_surface" | ...
```

설정 › 관측·시스템 로그도 같은 엔드포인트라 함께 죽어 있었습니다.

## 원인

**#29011**(오늘 00:13 머지)이 `/api/v1/dashboard/logs` 응답에 `ring` 객체를 추가했고, PR 본문은 이를 `additive(동승)`으로 설명했어요. 그런데 대시보드는 이 응답을 **`onExcessProperty: 'error'`로 엄격 디코드**합니다 — 이 소비자에게 additive는 안전하지 않아요. 모르는 최상위 키 하나가 곧 디코드 실패고, `logResource`가 그 에러를 그대로 화면에 띄웁니다. 즉 **필드 하나 추가가 표면 전체를 내리는 fail-closed**였습니다.

서버는 지금도 매 응답에 실어 보내고 있어요: `{"start_seq": 31548, "total": 81548, "dropped_before": true}`

## 수정

서버가 내보내는 그대로 타입을 만들었습니다 (`start_seq`/`total`/`dropped_before`, 셋 다 필수 — 서버 코드가 항상 채웁니다). 그리고 **화면에 노출**했어요. #29011의 목적 자체가 "빈 결과가 '없었던 일'인지 '창 밖으로 밀려난 일'인지 응답에서 읽히게" 하는 거였으니, 받아만 두고 안 쓰면 그 목적이 사라집니다.

`dropped_before`가 true면 출처 칩 줄에 `seq 31548 이전은 창 밖` 경고 칩이 붙고, title에 durable_store 경로를 담았습니다. 이제 그 아래가 얇거나 비어도 "안 일어난 일"이 아니라 "링 밖 — durable_store를 보라"로 읽혀요.

## 검증

- **라이브 응답 디코드**: 돌고 있는 서버에서 실제 응답을 받아 새 스키마로 디코드 성공 (`ring = {start_seq: 31548, total: 81548, dropped_before: true}`). 픽스처가 아니라 진짜 페이로드로 확인한 게 이번 검증의 핵심이에요
- 테스트 2개 추가로 양방향 고정: 바운드가 `LogsData`까지 도달하는지, `ring` 없는 응답은 여전히 drift로 잡는지
- `pnpm vitest run src/api/schemas/logs.test.ts src/components/logs.test.ts src/components/settings-surface.test.ts` 79개 통과
- `pnpm typecheck` clean — 타입이 소비처 픽스처 2곳을 정확히 잡아줘서 같이 채웠습니다
- `pnpm test` 전체 실행 중, 결과는 코멘트로 남길게요
- `pnpm lint`의 no-nested-ternary 3건은 `keeper-tool-call-inspector.ts`의 main 기존 red(#29054)로 이 변경과 무관합니다 (파일 한정 확인)

## 남는 질문

서버 필드 추가가 대시보드를 조용히 내릴 수 있는 구조 자체는 그대로예요. 지금은 사람이 화면을 봐야 알 수 있고, 이번에도 사용자가 발견했습니다. producer/consumer 계약을 CI에서 맞물리게 하는 건 별도로 논의가 필요해 보여요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
