### PR TITLE
test(dashboard): main red 수정 — 남은 로그 wire 픽스처에 ring 추가

### DIFF
--- a/dashboard/src/api/dashboard-logs.test.ts
+++ b/dashboard/src/api/dashboard-logs.test.ts
@@ -37,6 +37,7 @@ const currentWire = {
   latest_seq: null,
   oldest_seq: null,
   latest_ts_iso: null,
+  ring: { start_seq: 0, total: 0, dropped_before: false },
   total: 0,
   entries: [],
 } as const


### PR DESCRIPTION
## 무엇

**main red 수정**이에요. #29073이 `ring`을 로그 wire 스키마에 추가하면서 픽스처 3개를 갱신했는데, `src/api/dashboard-logs.test.ts`가 자체 `currentWire` 리터럴을 들고 있어서 빠졌습니다. 엄격 디코드라 필드가 없는 픽스처는 구조상 곧 drift고, 그 파일의 decode 케이스 2건이 main에서 실패합니다.

```
❯ src/api/dashboard-logs.test.ts (4 tests | 2 failed)
  × maps the product request to the current query wire and decodes once
  × omits negative cursors instead of emitting invalid query state
```

## 왜 놓쳤는지

#29073에서 타깃 테스트(`schemas/logs.test.ts`, `components/logs.test.ts`, `settings-surface.test.ts`)만 돌리고 전체 스위트가 끝나기 전에 머지됐어요. typecheck는 이 파일을 못 잡습니다 — 픽스처가 `LogsData`가 아니라 **wire 리터럴**이라 타입 계약 밖이거든요.

## 수정

보고된 2건만 고치지 않고 `masc_log_ring`을 언급하는 **5개 파일 전수**를 훑어 필드 누락이 남았는지 확인했습니다 (결과: 없음).

## 검증

- `pnpm vitest run src/api src/components/logs.test.ts src/components/settings-surface.test.ts` — 51파일 / 855개 통과
- 전체 스위트 실행 중, 결과는 코멘트로 남길게요
