### PR TITLE
fix(slack): trigger policy를 env 우선으로 읽고 잘못된 env 값은 fail-closed

### DIFF
--- a/lib/server/server_slack_in_process_gateway.ml
+++ b/lib/server/server_slack_in_process_gateway.ml
@@ -33,24 +33,6 @@ module Gw = Slack_gateway_state
    mention-triggered baseline, same stance as the Discord gateway. *)
 let default_trigger_policy : Gw.trigger_policy = Gw.Mention_or_thread
 
-(* Parse a configured trigger policy. Delegates to the single strict parser in
-   [Slack_gateway_state] so config and the (test-covered) canonical grammar
-   cannot drift. Empty ⇒ default (unset); a non-empty value that fails to parse
-   is logged and falls back to the default rather than being silently coerced
-   into a policy the operator did not write. *)
-let parse_trigger_policy raw : Gw.trigger_policy =
-  let s = String.trim raw in
-  if String.equal s "" then default_trigger_policy
-  else
-    match Gw.parse_trigger_policy s with
-    | Ok policy -> policy
-    | Error msg ->
-      Log.Server.warn
-        "slack trigger_policy %S rejected (%s); using default %s"
-        s msg
-        (Gw.trigger_policy_to_string default_trigger_policy);
-      default_trigger_policy
-
 type trigger_policy_toml_load =
   | Runtime_toml_missing
   | Trigger_policy_missing
@@ -60,6 +42,7 @@ type trigger_policy_load_error =
   | Runtime_toml_unreadable of { path : string; detail : string }
   | Runtime_toml_invalid of { path : string; detail : string }
   | Trigger_policy_invalid of { path : string; detail : string }
+  | Trigger_policy_env_invalid of { detail : string }
 
 let trigger_policy_load_error_to_string = function
   | Runtime_toml_unreadable { path; detail } ->
@@ -68,6 +51,8 @@ let trigger_policy_load_error_to_string = function
     Printf.sprintf "invalid TOML in %s: %s" path detail
   | Trigger_policy_invalid { path; detail } ->
     Printf.sprintf "invalid slack.trigger_policy in %s: %s" path detail
+  | Trigger_policy_env_invalid { detail } ->
+    Printf.sprintf "invalid MASC_SLACK_TRIGGER_POLICY: %s" detail
 ;;
 
 let load_trigger_policy_from_toml ~path =
@@ -106,20 +91,28 @@ let load_trigger_policy_from_toml ~path =
                   Error (Trigger_policy_invalid { path; detail })))))
 ;;
 
+(* Env > TOML > default — the precedence config/runtime.toml documents for this
+   key, and the one the Discord sibling already applies. An invalid env value is
+   a load error like an invalid TOML value; a blank/unset env falls through to
+   the TOML plane. [Env_config_slack.trigger_policy_opt] already reports blank
+   as unset, so there is no empty-string case to absorb here. *)
 let resolved_trigger_policy () =
-  let resolution = Config_dir_resolver.resolve () in
-  let toml_path =
-    Filename.concat resolution.Config_dir_resolver.config_root.path
-      Config_dir_resolver.runtime_toml_filename
-  in
-  match load_trigger_policy_from_toml ~path:toml_path with
-  | Error _ as error -> error
-  | Ok (Trigger_policy_loaded policy) -> Ok policy
-  | Ok (Runtime_toml_missing | Trigger_policy_missing) ->
-    Ok
-      (match Env_config_slack.trigger_policy_opt () with
-       | None -> default_trigger_policy
-       | Some raw -> parse_trigger_policy raw)
+  match Env_config_slack.trigger_policy_opt () with
+  | Some raw ->
+    (match Gw.parse_trigger_policy raw with
+     | Ok policy -> Ok policy
+     | Error detail -> Error (Trigger_policy_env_invalid { detail }))
+  | None ->
+    let resolution = Config_dir_resolver.resolve () in
+    let toml_path =
+      Filename.concat resolution.Config_dir_resolver.config_root.path
+        Config_dir_resolver.runtime_toml_filename
+    in
+    (match load_trigger_policy_from_toml ~path:toml_path with
+     | Error _ as error -> error
+     | Ok (Trigger_policy_loaded policy) -> Ok policy
+     | Ok (Runtime_toml_missing | Trigger_policy_missing) ->
+       Ok default_trigger_policy)
 ;;
 
 (* ---------------------------------------------------------------- *)

--- a/lib/server/server_slack_in_process_gateway.mli
+++ b/lib/server/server_slack_in_process_gateway.mli
@@ -30,14 +30,6 @@ val default_trigger_policy : Slack_gateway_state.trigger_policy
 (** Policy used when none is configured (empty/unset): the quiet,
     mention-triggered baseline ([Mention_or_thread]). *)
 
-val parse_trigger_policy : string -> Slack_gateway_state.trigger_policy
-(** Resolve a configured trigger-policy string. Empty/whitespace is treated as
-    unset and returns {!default_trigger_policy}. A non-empty value is parsed by
-    the single canonical grammar ({!Slack_gateway_state.parse_trigger_policy});
-    a value that fails to parse is logged via [Log.Server] and falls back to the
-    default rather than being silently coerced. Exposed for unit testing the
-    config boundary. *)
-
 type trigger_policy_toml_load =
   | Runtime_toml_missing
   | Trigger_policy_missing
@@ -50,14 +42,25 @@ type trigger_policy_load_error =
   | Runtime_toml_unreadable of { path : string; detail : string }
   | Runtime_toml_invalid of { path : string; detail : string }
   | Trigger_policy_invalid of { path : string; detail : string }
+  | Trigger_policy_env_invalid of { detail : string }
 (** Fail-closed configuration errors. They are never converted to the env or
-    default policy. *)
+    default policy. Both configured planes fail the same way: an unparseable
+    [MASC_SLACK_TRIGGER_POLICY] is an error exactly like an unparseable
+    [slack.trigger_policy] in runtime.toml. *)
 
 val load_trigger_policy_from_toml :
   path:string -> (trigger_policy_toml_load, trigger_policy_load_error) result
 (** Read and validate the Slack trigger policy at [path]. *)
 
 val trigger_policy_load_error_to_string : trigger_policy_load_error -> string
+
+val resolved_trigger_policy :
+  unit -> (Slack_gateway_state.trigger_policy, trigger_policy_load_error) result
+(** Env > TOML > default, the same precedence the Discord sibling applies.
+    [MASC_SLACK_TRIGGER_POLICY] wins when set and valid; an invalid env value
+    is a load error (never a silent default); a blank/unset env falls through
+    to the [slack.trigger_policy] runtime.toml key, and a missing file/key
+    yields {!default_trigger_policy}. *)
 
 module For_testing : sig
   val submit_event :

--- a/test/test_server_slack_trigger_policy.ml
+++ b/test/test_server_slack_trigger_policy.ml
@@ -1,12 +1,14 @@
-(* RFC-0317 — the server's resolved-config trigger-policy parser for the Slack
-   gateway must delegate to the single canonical grammar in
-   [Slack_gateway_state], so production config and the (separately test-covered)
-   grammar cannot drift. Mirror of [test_server_discord_trigger_policy].
+(* RFC-0317 / masc#29078 — the Slack gateway's trigger-policy resolution must
+   delegate to the single canonical grammar in [Slack_gateway_state] and apply
+   the same precedence and failure posture as the Discord sibling
+   ([test_server_discord_trigger_policy]).
 
-   These assertions pin the wrapper's contract: an empty value is unset
-   (=> default), the four valid forms parse through to the same variant the
-   strict grammar yields, and an unparseable value (or empty user_only id)
-   falls back to the default rather than producing a half-formed policy. *)
+   These assertions pin the contract on both configured planes: env wins over
+   TOML, a blank/unset env falls through to TOML, a missing file/key yields the
+   default, and an unparseable value on *either* plane is a typed load error.
+   Neither plane may quietly resolve to a policy the operator did not write —
+   the default is [Mention_or_thread], which is wider than [Mention_only], so a
+   silent fallback would broaden the trigger surface on a typo. *)
 
 open Alcotest
 open Masc
@@ -55,6 +57,43 @@ let with_temp_toml content f =
        f path)
 ;;
 
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end
+    else Sys.remove path
+;;
+
+let with_temp_dir f =
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf
+         "masc-slack-trigger-policy-root-%d-%d"
+         (Unix.getpid ())
+         (Random.bits ()))
+  in
+  Unix.mkdir dir 0o700;
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+;;
+
+let write_file path content =
+  Out_channel.with_open_bin path (fun oc -> output_string oc content)
+;;
+
+(* Point the config resolver at a temp config root so the TOML plane is under
+   test control. MASC_CONFIG_DIR is the documented override the sandbox suites
+   already use. *)
+let with_config_root dir f =
+  with_env "MASC_CONFIG_DIR" dir @@ fun () ->
+  with_env "MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE" "1" @@ fun () ->
+  Config_dir_resolver.reset ();
+  Fun.protect ~finally:Config_dir_resolver.reset f
+;;
+
 let load_error_to_string error = G.trigger_policy_load_error_to_string error
 
 let test_with_env_restores_unset () =
@@ -65,16 +104,13 @@ let test_with_env_restores_unset () =
   check (option string) "restored unset" None (Sys.getenv_opt key)
 ;;
 
-let test_empty_is_default () =
-  check string "empty => default" default_str (ps (G.parse_trigger_policy ""))
+(* -- resolved_trigger_policy: env > TOML > default -- *)
 
-let test_whitespace_is_default () =
-  check string "whitespace => default" default_str
-    (ps (G.parse_trigger_policy "   "))
-
-let test_valid_values_parse_through () =
-  (* Each valid form yields exactly what the strict grammar yields,
-     proving the wrapper delegates rather than re-implementing. *)
+let test_env_valid_values_parse_through () =
+  (* Each valid form resolves to exactly what the strict grammar yields, so the
+     config boundary delegates rather than re-implementing the grammar. *)
+  with_temp_dir @@ fun dir ->
+  with_config_root dir @@ fun () ->
   List.iter
     (fun raw ->
       let expected =
@@ -82,21 +118,88 @@ let test_valid_values_parse_through () =
         | Ok p -> ps p
         | Error msg -> failf "strict grammar rejected %S: %s" raw msg
       in
-      check string (Printf.sprintf "%S parses through" raw) expected
-        (ps (G.parse_trigger_policy raw)))
+      with_env "MASC_SLACK_TRIGGER_POLICY" raw @@ fun () ->
+      match G.resolved_trigger_policy () with
+      | Ok p ->
+        check string (Printf.sprintf "%S resolves through" raw) expected (ps p)
+      | Error e ->
+        failf "expected %S to resolve, got error: %s" raw
+          (load_error_to_string e))
     [ "mention_only"; "mention_or_thread"; "all"; "user_only:U123" ]
+;;
 
-let test_unknown_falls_back_to_default () =
-  (* A typo must not produce a policy the operator did not write. The wrapper
-     logs (via Log.Server) and returns the default. *)
-  check string "typo => default" default_str
-    (ps (G.parse_trigger_policy "mention_ony"))
+let test_env_valid_wins_over_toml () =
+  with_temp_dir @@ fun dir ->
+  write_file (Filename.concat dir "runtime.toml")
+    "[slack]\ntrigger_policy = \"all\"\n";
+  with_config_root dir @@ fun () ->
+  with_env "MASC_SLACK_TRIGGER_POLICY" "mention_only" @@ fun () ->
+  match G.resolved_trigger_policy () with
+  | Ok p -> check string "env wins over TOML" "mention_only" (ps p)
+  | Error e ->
+    failf "expected env policy, got error: %s" (load_error_to_string e)
+;;
 
-let test_user_only_empty_id_falls_back () =
-  (* The strict grammar rejects an empty id; the wrapper falls back to the
-     default instead of constructing User_only "". *)
-  check string "user_only: empty id => default" default_str
-    (ps (G.parse_trigger_policy "user_only:"))
+let test_env_invalid_is_load_error () =
+  (* A typo must not resolve. Before masc#29078 this logged a WARN and returned
+     Mention_or_thread, quietly widening the trigger surface. *)
+  with_temp_dir @@ fun dir ->
+  with_config_root dir @@ fun () ->
+  with_env "MASC_SLACK_TRIGGER_POLICY" "mention_ony" @@ fun () ->
+  match G.resolved_trigger_policy () with
+  | Error (G.Trigger_policy_env_invalid _) -> ()
+  | Error e ->
+    failf "expected env_invalid, got: %s" (load_error_to_string e)
+  | Ok p -> failf "invalid env must not resolve, got %s" (ps p)
+;;
+
+let test_env_user_only_empty_id_is_load_error () =
+  (* The strict grammar rejects an empty id; the boundary must surface that
+     rather than constructing User_only "" or falling back. *)
+  with_temp_dir @@ fun dir ->
+  with_config_root dir @@ fun () ->
+  with_env "MASC_SLACK_TRIGGER_POLICY" "user_only:" @@ fun () ->
+  match G.resolved_trigger_policy () with
+  | Error (G.Trigger_policy_env_invalid _) -> ()
+  | Error e ->
+    failf "expected env_invalid, got: %s" (load_error_to_string e)
+  | Ok p -> failf "empty user_only id must not resolve, got %s" (ps p)
+;;
+
+let test_env_blank_falls_to_toml () =
+  with_temp_dir @@ fun dir ->
+  write_file (Filename.concat dir "runtime.toml")
+    "[slack]\ntrigger_policy = \"all\"\n";
+  with_config_root dir @@ fun () ->
+  with_env "MASC_SLACK_TRIGGER_POLICY" "   " @@ fun () ->
+  match G.resolved_trigger_policy () with
+  | Ok p -> check string "blank env is unset" "all" (ps p)
+  | Error e ->
+    failf "expected TOML policy, got error: %s" (load_error_to_string e)
+;;
+
+let test_env_unset_falls_to_toml () =
+  with_temp_dir @@ fun dir ->
+  write_file (Filename.concat dir "runtime.toml")
+    "[slack]\ntrigger_policy = \"all\"\n";
+  with_config_root dir @@ fun () ->
+  with_env "MASC_SLACK_TRIGGER_POLICY" "" @@ fun () ->
+  match G.resolved_trigger_policy () with
+  | Ok p -> check string "TOML applies when env unset" "all" (ps p)
+  | Error e ->
+    failf "expected TOML policy, got error: %s" (load_error_to_string e)
+;;
+
+let test_all_unset_is_default () =
+  with_temp_dir @@ fun dir ->
+  with_config_root dir @@ fun () ->
+  with_env "MASC_SLACK_TRIGGER_POLICY" "" @@ fun () ->
+  match G.resolved_trigger_policy () with
+  | Ok p -> check string "default when nothing configured" default_str (ps p)
+  | Error e -> failf "expected default, got error: %s" (load_error_to_string e)
+;;
+
+(* -- load_trigger_policy_from_toml: the TOML plane in isolation -- *)
 
 let test_missing_runtime_toml_is_typed_missing () =
   let path = Filename.temp_file "masc-slack-trigger-policy-missing-" ".toml" in
@@ -348,16 +451,20 @@ let test_binding_store_failure_does_not_enqueue () =
 
 let () =
   run "server_slack_trigger_policy"
-    [ ( "parse_trigger_policy"
+    [ ( "resolved_trigger_policy (env > TOML > default)"
       , [ test_case "with_env restores unset" `Quick test_with_env_restores_unset
-        ; test_case "empty => default" `Quick test_empty_is_default
-        ; test_case "whitespace => default" `Quick test_whitespace_is_default
-        ; test_case "valid values parse through strict grammar" `Quick
-            test_valid_values_parse_through
-        ; test_case "unknown => default (no silent coercion)" `Quick
-            test_unknown_falls_back_to_default
-        ; test_case "user_only empty id => default" `Quick
-            test_user_only_empty_id_falls_back
+        ; test_case "valid values resolve through strict grammar" `Quick
+            test_env_valid_values_parse_through
+        ; test_case "valid env wins over TOML" `Quick
+            test_env_valid_wins_over_toml
+        ; test_case "invalid env => load error (no silent default)" `Quick
+            test_env_invalid_is_load_error
+        ; test_case "user_only empty id => load error" `Quick
+            test_env_user_only_empty_id_is_load_error
+        ; test_case "blank env falls to TOML" `Quick
+            test_env_blank_falls_to_toml
+        ; test_case "unset env falls to TOML" `Quick test_env_unset_falls_to_toml
+        ; test_case "all unset => default" `Quick test_all_unset_is_default
         ] )
     ; ( "runtime.toml loading"
       , [ test_case "missing file => typed missing" `Quick


### PR DESCRIPTION
## 목표

Slack 게이트웨이의 trigger policy 해석을 Discord와 같은 계약으로 맞춘다. #29078

두 가지가 달랐다.

**우선순위가 반대였다.** Slack은 `runtime.toml`의 `[slack].trigger_policy`를 먼저 보고, 값이 있으면 `MASC_SLACK_TRIGGER_POLICY`를 아예 읽지 않았다. Discord는 env를 먼저 본다 (`server_discord_in_process_gateway.ml:97-98` 주석: "Env > TOML > default — the precedence config/runtime.toml documents for this key"). 그래서 같은 방식으로 두 커넥터를 운영하면 env override가 Slack에서만 안 먹었다.

**env 값이 틀리면 조용히 넓어졌다.** `parse_trigger_policy`가 WARN 한 줄 남기고 `default_trigger_policy`를 돌려줬다. 그 기본값이 `Mention_or_thread`라 `mention_only`를 오타내면 트리거 범위가 넓어진다. TOML 평면은 이미 fail-closed였으므로, 한 모듈 안에서 두 설정 평면의 태도가 갈려 있었다.

## 변경 파일

- `lib/server/server_slack_in_process_gateway.ml` — `resolved_trigger_policy`를 env > TOML > default로 뒤집고, `Trigger_policy_env_invalid` 추가, permissive wrapper `parse_trigger_policy` 삭제
- `lib/server/server_slack_in_process_gateway.mli` — 삭제된 wrapper 제거, 새 오류 변형과 `resolved_trigger_policy` 노출 (Discord mli와 같은 모양)
- `test/test_server_slack_trigger_policy.ml` — 옛 fallback을 고정하던 케이스 2개를 typed error 단언으로 교체, Discord에만 있던 우선순위 케이스 4개 이식

`start`는 이미 `Error`를 fail-closed로 처리하고 있어서(`:725-731`) 손대지 않았다. env 평면의 오류가 그 경로에 도달하지 못하던 것이 문제였다.

wrapper를 지운 이유: `Env_config_slack.trigger_policy_opt`가 `trim_opt`를 거쳐 공백을 `None`으로 보고하므로(`env_config_core.ml:183-187`), wrapper가 흡수하던 빈 문자열 경우가 중복이었다. 남는 역할은 permissive fallback뿐이었다.

## 로컬 검증

```
test_server_slack_trigger_policy      19/19 green (기존 17개)
test_server_slack_gateway_attention   green
test_server_discord_trigger_policy    green
test_slack_gateway_state              green
dune build --root . @check            green
```

뮤테이션 확인: `Error detail -> Error (Trigger_policy_env_invalid { detail })`를 옛 형태인 `Error _ -> Ok default_trigger_policy`로 되돌리면 새 케이스 2개가 깨진다 (`FAIL invalid env must not resolve, got mention_or_thread`). 측정 후 즉시 복구했다.

## 남은 미검증

- 라이브 재현은 하지 않았다. 코드 경로와 단위 테스트까지다.
- 이 PR은 Slack만 다룬다. #29078 본문에 적어둔 나머지(Discord 기동 실패 이유가 status에 안 실리는 것, 사이드카 잔존, `CONNECTOR-CONFIG-SCHEMA.md` Slack 절 stale)는 건드리지 않았다.
- 운영 중인 서버에 `[slack].trigger_policy`와 `MASC_SLACK_TRIGGER_POLICY`가 동시에 설정돼 있다면 이 PR 이후 적용되는 정책이 바뀐다. 배포 전 두 평면 값을 확인하는 편이 좋다.