### PR TITLE
fix(slack): available에 SLACK_BOT_TOKEN 반영하고 connected 정의를 하나로

### DIFF
--- a/lib/gate/channel_gate_slack_state.ml
+++ b/lib/gate/channel_gate_slack_state.ml
@@ -57,6 +57,18 @@ let read_recent_audit ~limit = Store.read_recent_audit binding_store ~limit
 let stale_after_sec () =
   Env_config_core.get_int ~default:30 "MASC_SLACK_STATUS_STALE_SEC"
 
+(* The one definition of "the transport is live", used both by [status_json]
+   and by the [Channel_gate_connector.S] registry export [connected]. Keeping
+   them as one function is the point: they used to disagree, because
+   [status_json] folded startup and binding-store health into the same boolean
+   while the registry read the socket alone. Those two facts have their own
+   fields ([error], [binding_store_read_ok]) and their own effect on
+   [available]. *)
+let transport_connected () =
+  match Slack_socket_client.connection_state () with
+  | Slack_gateway_state.Connected -> true
+  | Disconnected | Awaiting_hello | Reconnect_pending _ | Failed _ -> false
+
 (* Trigger policy registry — set once at gateway startup, read for dashboard. *)
 let trigger_policy_ref : Slack_gateway_state.trigger_policy option ref =
   ref None
@@ -118,30 +130,43 @@ let status_json ?(audit_limit = 10) () =
     | Ok bindings -> bindings, ""
     | Error error -> [], Store.binding_store_error_to_string error
   in
-  let available = app_present && startup_ok && binding_store_read_ok in
-  let connected =
-    startup_ok
-    && binding_store_read_ok
-    && match gateway_state with
-       | Connected -> true
-       | Disconnected | Awaiting_hello | Reconnect_pending _ | Failed _ -> false
+  (* Slack needs both credentials to do its job, and they fail differently:
+     without SLACK_APP_TOKEN the Socket Mode gateway never starts, and without
+     SLACK_BOT_TOKEN it starts and receives but every reply fails
+     ([send_message] returns [Missing_token]). A connector that cannot answer
+     is not available, so both are part of the verdict. *)
+  let credential_error =
+    if not app_present then "SLACK_APP_TOKEN is unset or empty"
+    else if not bot_present then
+      "SLACK_BOT_TOKEN is unset or empty: inbound connects but every outbound \
+       chat.postMessage fails"
+    else ""
   in
+  let available =
+    app_present && bot_present && startup_ok && binding_store_read_ok
+  in
+  let connected = transport_connected () in
   let stale = false in
   (* NDT-OK: status_json is a dashboard observation boundary; this timestamp
      reports gateway freshness and is not used for control flow. *)
   let updated_at = Gate_time_util.iso8601_of_unix (Unix.gettimeofday ()) in
-  let transport_error =
+  (* A recorded startup error is why the gateway is not running; the rest is
+     downstream of it, so it stays the whole message. Otherwise report every
+     independent reason at once rather than letting one mask the others. *)
+  let error =
     match startup_error with
     | Some message -> message
     | None ->
-      (match gateway_state with
-       | Disconnected ->
-         if app_present then "" else "SLACK_APP_TOKEN is unset or empty"
-       | Failed msg -> msg
-       | Awaiting_hello | Connected | Reconnect_pending _ -> "")
-  in
-  let error =
-    if not binding_store_read_ok then binding_store_error else transport_error
+      [ (if binding_store_read_ok then None else Some binding_store_error)
+      ; (match gateway_state with
+         | Failed msg -> Some msg
+         | Disconnected | Awaiting_hello | Connected | Reconnect_pending _ ->
+           None)
+      ; (if String.equal credential_error "" then None
+         else Some credential_error)
+      ]
+      |> List.filter_map Fun.id
+      |> String.concat "; "
   in
   let recent_audit = read_recent_audit ~limit:audit_limit in
   let configured_binding_json = List.map binding_json configured_bindings in
@@ -333,10 +358,9 @@ let bound_channels ~keeper_name =
 
 let connected () =
   (* The in-process gateway (RFC-0317) is the only Slack transport; its run
-     loop publishes the typed connection state. *)
-  match Slack_socket_client.connection_state () with
-  | Slack_gateway_state.Connected -> true
-  | Disconnected | Awaiting_hello | Reconnect_pending _ | Failed _ -> false
+     loop publishes the typed connection state. Same definition [status_json]
+     reports — see [transport_connected]. *)
+  transport_connected ()
 
 (* ---- Outbound REST (delegates to Slack_rest_client with the bot token) ---- *)
 

--- a/test/dune
+++ b/test/dune
@@ -1660,6 +1660,7 @@
 (include stanzas/test_channel_gate.inc)
 
 (include stanzas/test_channel_gate_discord_state.inc)
+(include stanzas/test_channel_gate_slack_state.inc)
 
 (include stanzas/test_channel_gate_metrics.inc)
 

--- a/test/stanzas/test_channel_gate_slack_state.inc
+++ b/test/stanzas/test_channel_gate_slack_state.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_channel_gate_slack_state)
+ (modules test_channel_gate_slack_state)
+ (libraries masc_test_deps))

--- a/test/test_channel_gate_slack_state.ml
+++ b/test/test_channel_gate_slack_state.ml
@@ -1,0 +1,184 @@
+(* masc#29079 — the Slack connector's status must not read healthy while it is
+   structurally unable to answer, and "connected" must mean one thing.
+
+   Two defects are pinned here:
+
+   - [available] ignored SLACK_BOT_TOKEN. Slack has two credentials with
+     different failure modes: without SLACK_APP_TOKEN the Socket Mode gateway
+     never starts, without SLACK_BOT_TOKEN it starts and receives but every
+     reply fails ([Channel_gate_slack_state.send_message] returns
+     [Missing_token]). Only the first was part of the verdict, so an operator
+     saw a live card for a connector that could not reply.
+   - [connected] had two definitions in one module: [status_json] folded
+     startup and binding-store health into it, while the
+     [Channel_gate_connector.S] export read the socket alone. Routing and the
+     dashboard could disagree. *)
+
+open Alcotest
+open Masc
+module State = Channel_gate_slack_state
+module U = Yojson.Safe.Util
+
+external unsetenv : string -> unit = "masc_test_unsetenv"
+
+let with_env key value f =
+  let previous = Sys.getenv_opt key in
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some previous -> Unix.putenv key previous
+      | None -> unsetenv key)
+    (fun () ->
+      Unix.putenv key value;
+      f ())
+;;
+
+let without_env key f =
+  let previous = Sys.getenv_opt key in
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some previous -> Unix.putenv key previous
+      | None -> unsetenv key)
+    (fun () ->
+      unsetenv key;
+      f ())
+;;
+
+(* A private base path so the binding store reads cleanly and no test touches
+   an operator's real .gate/runtime/slack. *)
+let with_temp_base f =
+  let base_path =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf
+         "masc-slack-state-%d-%d"
+         (Unix.getpid ())
+         (Random.bits ()))
+  in
+  with_env Env_config_core.base_path_env_key base_path (fun () ->
+    with_env Env_config_core.base_path_input_env_key base_path f)
+;;
+
+let status_of f =
+  with_temp_base (fun () ->
+    State.clear_startup_error ();
+    Fun.protect ~finally:State.clear_startup_error (fun () -> f (State.status_json ())))
+;;
+
+let string_field status key = status |> U.member key |> U.to_string
+let bool_field status key = status |> U.member key |> U.to_bool
+
+let test_missing_bot_token_is_not_available () =
+  with_env "SLACK_APP_TOKEN" "xapp-test" (fun () ->
+    without_env "SLACK_BOT_TOKEN" (fun () ->
+      status_of (fun status ->
+        check bool "app token alone is not availability" false
+          (bool_field status "available");
+        check bool "app_token_present" true
+          (bool_field status "app_token_present");
+        check bool "bot_token_present" false
+          (bool_field status "bot_token_present");
+        check string "status uses connector vocabulary" "offline"
+          (string_field status "status");
+        (* The operator has to be able to read why. Before masc#29079 this
+           field was empty whenever the socket was not in Disconnected. *)
+        check bool "error names the missing credential" true
+          (let error = string_field status "error" in
+           let needle = "SLACK_BOT_TOKEN" in
+           let n = String.length needle in
+           let rec scan i =
+             i + n <= String.length error
+             && (String.equal (String.sub error i n) needle || scan (i + 1))
+           in
+           scan 0))))
+;;
+
+let test_missing_app_token_names_the_app_token () =
+  without_env "SLACK_APP_TOKEN" (fun () ->
+    without_env "SLACK_BOT_TOKEN" (fun () ->
+      status_of (fun status ->
+        check bool "not available" false (bool_field status "available");
+        (* App token first: without it the gateway never starts at all, so it
+           is the actionable one. *)
+        check string "error names the app token" "SLACK_APP_TOKEN is unset or empty"
+          (string_field status "error"))))
+;;
+
+let test_both_tokens_present_is_available () =
+  with_env "SLACK_APP_TOKEN" "xapp-test" (fun () ->
+    with_env "SLACK_BOT_TOKEN" "xoxb-test" (fun () ->
+      status_of (fun status ->
+        check bool "available with both credentials" true
+          (bool_field status "available");
+        (* No socket runs in this suite, so the transport is honestly down and
+           the card reads disconnected rather than offline. *)
+        check bool "not connected" false (bool_field status "connected");
+        check string "status" "disconnected" (string_field status "status");
+        check string "no error to report" "" (string_field status "error"))))
+;;
+
+(* Narrow on purpose, and named for what it can actually decide.
+
+   The interesting case for the unified definition is transport-up +
+   startup/binding-store-down, where the two old definitions disagreed. That
+   case is unreachable here: [Slack_socket_client]'s published state is a
+   module-private atomic written only by the run loop, so an in-process test
+   cannot report [Connected] without a socket. Adding a setter for the test
+   would be a backdoor into production state, so the divergence stays closed by
+   construction (one function, [transport_connected]) rather than by this
+   assertion. What this does catch is a status field that stops tracking the
+   registry export at all — a hardcoded value, or a fold that ignores the
+   transport. *)
+let test_connected_field_mirrors_registry_export_when_transport_is_down () =
+  with_env "SLACK_APP_TOKEN" "xapp-test" (fun () ->
+    with_env "SLACK_BOT_TOKEN" "xoxb-test" (fun () ->
+      with_temp_base (fun () ->
+        State.clear_startup_error ();
+        Fun.protect
+          ~finally:State.clear_startup_error
+          (fun () ->
+            check bool "agree when healthy" (State.connected ())
+              (bool_field (State.status_json ()) "connected");
+            State.record_startup_error "invalid Slack trigger policy";
+            check bool "agree under a startup error" (State.connected ())
+              (bool_field (State.status_json ()) "connected")))))
+;;
+
+let test_startup_error_still_offline_with_reason () =
+  (* Regression guard for the behaviour masc#29078's suite depends on: a
+     recorded startup error stays the whole message and keeps the card offline,
+     even though credentials are now part of [available]. *)
+  with_env "SLACK_APP_TOKEN" "xapp-test" (fun () ->
+    with_env "SLACK_BOT_TOKEN" "xoxb-test" (fun () ->
+      with_temp_base (fun () ->
+        State.record_startup_error "invalid Slack trigger policy";
+        Fun.protect
+          ~finally:State.clear_startup_error
+          (fun () ->
+            let status = State.status_json () in
+            check bool "not available" false (bool_field status "available");
+            check string "status" "offline" (string_field status "status");
+            check string "startup error is the whole message"
+              "invalid Slack trigger policy" (string_field status "error")))))
+;;
+
+let () =
+  run "channel_gate_slack_state"
+    [ ( "availability"
+      , [ test_case "missing bot token => offline with reason" `Quick
+            test_missing_bot_token_is_not_available
+        ; test_case "missing app token => named first" `Quick
+            test_missing_app_token_names_the_app_token
+        ; test_case "both credentials => available" `Quick
+            test_both_tokens_present_is_available
+        ; test_case "startup error => offline, error preserved" `Quick
+            test_startup_error_still_offline_with_reason
+        ] )
+    ; ( "connected field tracks the registry export"
+      , [ test_case
+            "status field mirrors the registry export (transport down)" `Quick
+            test_connected_field_mirrors_registry_export_when_transport_is_down
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 목표

Slack 커넥터 상태가 화면에서 거짓말하는 두 지점을 없앤다. #29079

**답할 수 없는 상태가 정상으로 보였다.** Slack은 자격이 둘이고 실패 방식이 다르다. `SLACK_APP_TOKEN`이 없으면 Socket Mode 게이트웨이가 아예 안 뜨고, `SLACK_BOT_TOKEN`이 없으면 뜨고 받기는 하는데 답이 전부 실패한다 (`channel_gate_slack_state.ml:355` — `send_message`가 `Error Missing_token`). `available`은 app token만 봤다. 게다가 없다는 사실이 `error`에도 안 실렸다. 기존 코드는 그 메시지를 `Disconnected` 갈래에서만 만들었기 때문에, 소켓이 붙어 있으면 `error`가 빈 문자열이었다.

**`connected` 정의가 한 모듈에 두 개였다.** `status_json`(122-128행)은 소켓 상태에 `startup_ok`와 `binding_store_read_ok`를 얹었고, `Channel_gate_connector.S`로 내보내는 `connected ()`(334행)는 소켓 상태만 봤다. 바인딩 스토어를 못 읽으면 대시보드는 끊김, 라우팅은 연결됨으로 갈렸다. 그 두 사실은 이미 각자의 필드(`error`, `binding_store_read_ok`)와 `available`에 대한 영향을 따로 갖고 있다.

## 변경 파일

- `lib/gate/channel_gate_slack_state.ml`
  - `available = app_present && bot_present && startup_ok && binding_store_read_ok`
  - 독립적인 이유를 한꺼번에 보고. 기존에는 바인딩 스토어 오류가 transport 오류를 가렸다. 단, 기록된 startup error는 나머지가 그것의 하위 결과이므로 여전히 메시지 전부를 차지한다
  - `transport_connected`를 뽑아 `status_json`과 `connected ()`가 같은 함수를 부르게 함
- `test/test_channel_gate_slack_state.ml` (신규) + stanza + `test/dune` include 한 줄

## 로컬 검증

```
test_channel_gate_slack_state         5/5 green (신규)
test_server_slack_trigger_policy      green (available=false 단언 유지)
test_server_slack_gateway_attention   green
test_keeper_chat_slack                green
dune build --root . @check            green
```

뮤테이션 확인: `available`에서 `bot_present`를 빼면 `missing bot token => offline with reason`이 깨진다 (`FAIL app token alone is not availability`). 측정 후 즉시 복구했다.

## 남은 미검증 — 읽어주세요

**`connected` 통합은 런타임 테스트로 못 덮었다.** 두 정의가 갈라지는 유일한 관측 지점은 "transport는 up인데 startup/binding-store가 down"인 경우인데, `Slack_socket_client`의 published state가 run loop만 쓰는 module-private atomic이라 in-process 테스트에서 `Connected`를 만들 수 없다. setter를 뚫는 건 production state로의 test backdoor라 하지 않았다. 그래서 이 부분은 테스트가 아니라 **구조로만** 닫혀 있다 — 함수가 하나뿐이라는 사실. 테스트 이름을 `..._when_transport_is_down`으로 두고 주석에 한계를 적어둬서, 통합을 증명한 것처럼 읽히지 않게 했다. 처음에 "두 surface가 일치한다"는 이름으로 썼다가 뮤테이션이 통과해버려서 (둘 다 false라 vacuous) 범위를 다시 잡았다.

**동작 변경 주의.** app token만 설정하고 운영 중인 Slack 커넥터가 있다면 이 PR 이후 카드가 `offline`로 바뀐다. 상태 vocabulary에 "받지만 못 보냄"에 해당하는 라벨이 없어서 `offline` + `error` 메시지 조합을 택했다. 받는 건 되는데 offline로 보이는 게 오해 소지가 있다고 보면 라벨 확장이 별건으로 필요하다.

라이브 재현은 하지 않았다. 코드 경로와 단위 테스트까지다.