### PR TITLE
fix(agent_core): 프로바이더 거부 종류를 분류기 밖으로 전달

### DIFF
--- a/lib/keeper/keeper_exact_flow_detail.ml
+++ b/lib/keeper/keeper_exact_flow_detail.ml
@@ -8,8 +8,11 @@ let execution_cause_detail : Exact_output.execution_error_cause -> string = func
   | Clock_required_for_timeout -> "clock required for timeout"
   | Frozen_request_mismatch -> "frozen request mismatch"
   | Completion_failed -> "completion failed"
-  | Serialized_request_refused { http_status } ->
-    Printf.sprintf "serialized request refused (http_status=%d)" http_status
+  | Provider_response_refused { http_status; refusal } ->
+    Printf.sprintf
+      "provider refused (http_status=%d refusal=%s)"
+      http_status
+      (Exact_output.provider_refusal_to_string refusal)
   | Incomplete_output -> "incomplete output"
   | Missing_output -> "missing output"
   | Ambiguous_output count -> Printf.sprintf "ambiguous output (candidates=%d)" count

--- a/packages/agent_core/lib/llm_provider/exact_output.ml
+++ b/packages/agent_core/lib/llm_provider/exact_output.ml
@@ -88,12 +88,46 @@ type raw_response = Trace.raw_response =
   ; body_sha256 : string
   }
 
+type provider_refusal =
+  | Request_body_refused
+  | Rate_limited
+  | Overloaded
+  | Server_error
+  | Auth_failed
+  | Authorization_refused
+  | Payment_required
+  | Invalid_request
+  | Not_found
+  | Context_overflow
+  | Input_capacity
+  | Network_error
+  | Timeout
+
+let provider_refusal_to_string = function
+  | Request_body_refused -> "request_body_refused"
+  | Rate_limited -> "rate_limited"
+  | Overloaded -> "overloaded"
+  | Server_error -> "server_error"
+  | Auth_failed -> "auth_failed"
+  | Authorization_refused -> "authorization_refused"
+  | Payment_required -> "payment_required"
+  | Invalid_request -> "invalid_request"
+  | Not_found -> "not_found"
+  | Context_overflow -> "context_overflow"
+  | Input_capacity -> "input_capacity"
+  | Network_error -> "network_error"
+  | Timeout -> "timeout"
+;;
+
 type execution_error_cause =
   | Attempt_already_started
   | Clock_required_for_timeout
   | Frozen_request_mismatch
   | Completion_failed
-  | Serialized_request_refused of { http_status : int }
+  | Provider_response_refused of
+      { http_status : int
+      ; refusal : provider_refusal
+      }
   | Incomplete_output
   | Missing_output
   | Ambiguous_output of int
@@ -1070,10 +1104,19 @@ let evidence_transport_failure ~ordinal = function
   | Flow_advance_execution_failed { cause = Completion_failed; raw_response_sha256; _ } ->
     Ok (Validated_flow_evidence.Completion_failed_before_dispatch, raw_response_sha256)
   | Flow_advance_execution_failed
-      { cause = Serialized_request_refused { http_status }; raw_response_sha256; _ } ->
+      { cause = Provider_response_refused { http_status; refusal = Request_body_refused }
+      ; raw_response_sha256
+      ; _
+      } ->
     Ok
       ( Validated_flow_evidence.Serialized_request_refused { http_status }
       , raw_response_sha256 )
+  | Flow_advance_execution_failed
+      { cause = Provider_response_refused { http_status; refusal = Rate_limited }
+      ; raw_response_sha256
+      ; _
+      } ->
+    Ok (Validated_flow_evidence.Rate_limited { http_status }, raw_response_sha256)
   | Flow_advance_execution_failed { cause = Invalid_json_output; raw_response_sha256; _ }
     -> Ok (Validated_flow_evidence.Invalid_json_output, raw_response_sha256)
   | Flow_advance_execution_failed { cause; _ } ->
@@ -1083,7 +1126,11 @@ let evidence_transport_failure ~ordinal = function
       | Clock_required_for_timeout -> "clock_required_for_timeout"
       | Frozen_request_mismatch -> "frozen_request_mismatch"
       | Completion_failed -> "completion_failed"
-      | Serialized_request_refused _ -> "serialized_request_refused"
+      | Provider_response_refused { http_status; refusal } ->
+        Printf.sprintf
+          "provider_response_refused:%s:%d"
+          (provider_refusal_to_string refusal)
+          http_status
       | Incomplete_output -> "incomplete_output"
       | Missing_output -> "missing_output"
       | Ambiguous_output _ -> "ambiguous_output"
@@ -1536,31 +1583,40 @@ let synchronize_receipt = Generation_receipt.synchronize
 let raw_response = Trace.raw_response
 let record_provider_trace = Generation_receipt.record_provider_trace
 
-let serialized_request_refusal_of_http_error ~code ~body ~retry_after_header =
-  match Retry.classify_error ~retry_after_header ~status:code ~body with
-  | Retry.InvalidRequest { reason = Retry.Request_body_refused_by_provider { status }; _ }
-    -> Some status
-  | Retry.RateLimited _
-  | Retry.Overloaded _
-  | Retry.ServerError _
-  | Retry.AuthError _
-  | Retry.AuthorizationError _
-  | Retry.PaymentRequired _
-  | Retry.InvalidRequest _
-  | Retry.NotFound _
-  | Retry.ContextOverflow _
-  | Retry.InputCapacity _
-  | Retry.NetworkError _
-  | Retry.Timeout _ -> None
+(* [Retry] already classifies a provider response; this projects that verdict
+   onto the flow's vocabulary WITHOUT collapsing it. The previous form answered
+   one question ("was this a body refusal?") and returned [None] for the other
+   twelve, and the caller read that [None] as "no status to report" — which is
+   how a 429 reached the keeper log as a bare "completion failed" with neither
+   its status nor its kind, and why the lane could not advance off it. *)
+let provider_refusal_of_api_error : Retry.api_error -> provider_refusal = function
+  | Retry.InvalidRequest { reason = Retry.Request_body_refused_by_provider _; _ } ->
+    Request_body_refused
+  | Retry.InvalidRequest _ -> Invalid_request
+  | Retry.RateLimited _ -> Rate_limited
+  | Retry.Overloaded _ -> Overloaded
+  | Retry.ServerError _ -> Server_error
+  | Retry.AuthError _ -> Auth_failed
+  | Retry.AuthorizationError _ -> Authorization_refused
+  | Retry.PaymentRequired _ -> Payment_required
+  | Retry.NotFound _ -> Not_found
+  | Retry.ContextOverflow _ -> Context_overflow
+  | Retry.InputCapacity _ -> Input_capacity
+  | Retry.NetworkError _ -> Network_error
+  | Retry.Timeout _ -> Timeout
 ;;
 
 let execution_error_cause = function
   | Exec.Clock_required_for_timeout -> Clock_required_for_timeout
   | Exec.Frozen_request_mismatch -> Frozen_request_mismatch
   | Exec.Provider_error (Http_client.HttpError { code; body; retry_after_header }) ->
-    (match serialized_request_refusal_of_http_error ~code ~body ~retry_after_header with
-     | Some http_status -> Serialized_request_refused { http_status }
-     | None -> Completion_failed)
+    Provider_response_refused
+      { http_status = code
+      ; refusal =
+          provider_refusal_of_api_error
+            (Retry.classify_error ~retry_after_header ~status:code ~body)
+      }
+  (* No HTTP status was produced, so there is no response to classify. *)
   | Exec.Provider_error _ -> Completion_failed
   | Exec.Output_normalization_failed (Exec.Incomplete_structured_response _) ->
     Incomplete_output
@@ -1661,15 +1717,43 @@ let execute_once_with_publication ~publish ~net ?clock (attempt : attempt) =
 let execution_failure_may_advance (error : execution_error) =
   match error.cause, receipt_phase error.receipt with
   | Completion_failed, Before_dispatch -> receipt_dispatch_count error.receipt = 0
-  | Serialized_request_refused _, Response_received ->
+  (* A refusal admits the successor only when the response proves the refusal
+     belongs to THIS binding and not to the input itself — otherwise the
+     successor replays a request that is already known to fail. *)
+  | Provider_response_refused { refusal = Request_body_refused; _ }, Response_received ->
     (* The response contract proves that the provider rejected this input before
        generation. Keep the honest one-dispatch receipt, but allow the frozen
        lane to try its predetermined successor. *)
     receipt_dispatch_count error.receipt = 1
+  | Provider_response_refused { refusal = Rate_limited; _ }, Response_received ->
+    (* Quota is a property of the binding, not of the request: the successor
+       carries its own. This is what an ordered lane of candidates is for, and
+       until the refusal kind survived classification the lane could not reach
+       it — a 429 arrived here as [Completion_failed] and ended the flow. *)
+    receipt_dispatch_count error.receipt = 1
   | Invalid_json_output, (Response_received | Terminal) ->
     receipt_dispatch_count error.receipt = 1
+  (* The remaining refusals do not advance, as before this classification
+     existed. Promoting any one of them needs its own argument about whether the
+     successor can serve the same input, which this change does not make. *)
+  | ( Provider_response_refused
+        { refusal =
+            ( Overloaded
+            | Server_error
+            | Auth_failed
+            | Authorization_refused
+            | Payment_required
+            | Invalid_request
+            | Not_found
+            | Context_overflow
+            | Input_capacity
+            | Network_error
+            | Timeout )
+        ; _
+        }
+    , (Not_started | Before_dispatch | Dispatch_started | Response_received | Terminal) )
   | Completion_failed, (Not_started | Dispatch_started | Response_received | Terminal)
-  | ( Serialized_request_refused _
+  | ( Provider_response_refused { refusal = Request_body_refused | Rate_limited; _ }
     , (Not_started | Before_dispatch | Dispatch_started | Terminal) )
   | Invalid_json_output, (Not_started | Before_dispatch | Dispatch_started)
   | ( ( Attempt_already_started

--- a/packages/agent_core/lib/llm_provider/exact_output.mli
+++ b/packages/agent_core/lib/llm_provider/exact_output.mli
@@ -217,18 +217,55 @@ type raw_response =
   ; body_sha256 : string
   }
 
+(** The provider's own verdict on one dispatched request, projected from
+    {!Retry.api_error} onto the two facts an exact flow acts on: the status the
+    response carried, and which refusal it was. The full [api_error] is not
+    carried because its payloads (messages, serving constraints) would enter
+    flow evidence, which fingerprints and persists what it holds.
+
+    Every constructor of [Retry.api_error] maps to exactly one constructor here,
+    so a new provider failure kind cannot reach a flow as an unclassified one. *)
+type provider_refusal =
+  | Request_body_refused
+      (** The provider refused this request's size. A smaller input may succeed
+          and the frozen lane's successor may accept this one. *)
+  | Rate_limited
+      (** The provider's quota for this binding is spent. The request itself was
+          acceptable, so a successor binding with its own quota may serve it. *)
+  | Overloaded
+  | Server_error
+  | Auth_failed
+  | Authorization_refused
+  | Payment_required
+  | Invalid_request
+  | Not_found
+  | Context_overflow
+  | Input_capacity
+  | Network_error
+  | Timeout
+
 type execution_error_cause =
   | Attempt_already_started
   | Clock_required_for_timeout
   | Frozen_request_mismatch
   | Completion_failed
-  | Serialized_request_refused of { http_status : int }
+      (** No response was received: the failure landed before dispatch, or the
+          transport produced no HTTP status to classify. A failure that DID
+          carry a status is {!Provider_response_refused} — folding the two
+          together discards the status and the refusal kind. *)
+  | Provider_response_refused of
+      { http_status : int
+      ; refusal : provider_refusal
+      }
   | Incomplete_output
   | Missing_output
   | Ambiguous_output of int
   | Unexpected_output_content
   | Invalid_json_output
   | Internal_non_json_output
+
+(** Stable lowercase token for one refusal, for logs and evidence detail. *)
+val provider_refusal_to_string : provider_refusal -> string
 
 type execution_error =
   { call_id : call_id

--- a/packages/agent_core/lib/llm_provider/exact_output_validated_flow_evidence.mli
+++ b/packages/agent_core/lib/llm_provider/exact_output_validated_flow_evidence.mli
@@ -95,6 +95,7 @@ type transport_failure =
   | Candidate_rejected
   | Completion_failed_before_dispatch
   | Serialized_request_refused of { http_status : int }
+  | Rate_limited of { http_status : int }
   | Invalid_json_output
 
 type advance =

--- a/packages/agent_core/lib/llm_provider/exact_output_validated_flow_evidence_canonical_json.ml
+++ b/packages/agent_core/lib/llm_provider/exact_output_validated_flow_evidence_canonical_json.ml
@@ -186,6 +186,8 @@ let failure_json = function
   | Serialized_request_refused { http_status } ->
     `Assoc
       [ "kind", `String "serialized_request_refused"; "http_status", `Int http_status ]
+  | Rate_limited { http_status } ->
+    `Assoc [ "kind", `String "rate_limited"; "http_status", `Int http_status ]
   | Invalid_json_output -> `Assoc [ "kind", `String "invalid_json_output" ]
 ;;
 

--- a/packages/agent_core/lib/llm_provider/exact_output_validated_flow_evidence_codec.ml
+++ b/packages/agent_core/lib/llm_provider/exact_output_validated_flow_evidence_codec.ml
@@ -317,6 +317,10 @@ let parse_failure ~path json =
        let* fields = exact_assoc ~path [ "kind"; "http_status" ] json in
        let* http_status = int_field ~path fields "http_status" in
        Ok (Serialized_request_refused { http_status })
+     | Some (`String "rate_limited") ->
+       let* fields = exact_assoc ~path [ "kind"; "http_status" ] json in
+       let* http_status = int_field ~path fields "http_status" in
+       Ok (Rate_limited { http_status })
      | Some (`String "invalid_json_output") ->
        let* _ = exact_assoc ~path [ "kind" ] json in
        Ok Invalid_json_output

--- a/packages/agent_core/lib/llm_provider/exact_output_validated_flow_evidence_types.ml
+++ b/packages/agent_core/lib/llm_provider/exact_output_validated_flow_evidence_types.ml
@@ -86,6 +86,7 @@ type transport_failure =
   | Candidate_rejected
   | Completion_failed_before_dispatch
   | Serialized_request_refused of { http_status : int }
+  | Rate_limited of { http_status : int }
   | Invalid_json_output
 
 type advance =

--- a/packages/agent_core/lib/llm_provider/exact_output_validated_flow_evidence_validation_primitives.ml
+++ b/packages/agent_core/lib/llm_provider/exact_output_validated_flow_evidence_validation_primitives.ml
@@ -124,6 +124,15 @@ let attempt_advance_state_is_valid (attempt : attempt) (failure : transport_fail
     && attempt.http_status = Some http_status
     && Option.is_some attempt.provider_trace_sha256
     && Option.is_some attempt.raw_response_sha256
+  (* [Retry.classify_error] produces [RateLimited] from status 429 alone, so an
+     advance recorded as rate-limited must carry that status and the one
+     dispatch that received it. *)
+  | Rate_limited { http_status }, Response_received ->
+    http_status = 429
+    && attempt.dispatch_count = 1
+    && attempt.http_status = Some http_status
+    && Option.is_some attempt.provider_trace_sha256
+    && Option.is_some attempt.raw_response_sha256
   | Invalid_json_output, (Response_received | Terminal) ->
     attempt.dispatch_count = 1
     && successful_http_status attempt.http_status
@@ -132,6 +141,7 @@ let attempt_advance_state_is_valid (attempt : attempt) (failure : transport_fail
   | Candidate_rejected, _
   | Completion_failed_before_dispatch, (Response_received | Terminal)
   | Serialized_request_refused _, (Before_dispatch | Terminal)
+  | Rate_limited _, (Before_dispatch | Terminal)
   | Invalid_json_output, Before_dispatch -> false
 ;;
 

--- a/packages/agent_core/test/test_exact_output_flow.ml
+++ b/packages/agent_core/test/test_exact_output_flow.ml
@@ -3495,9 +3495,11 @@ let test_context_window_400_prose_remains_terminal () =
   | Error (EO.Flow_exact_execution_failed failure) ->
     check
       bool
-      "HTTP 400 prose remains unattributed completion failure"
+      "HTTP 400 prose stays terminal as a typed invalid request"
       true
-      (failure.cause.cause = EO.Completion_failed)
+      (failure.cause.cause
+       = EO.Provider_response_refused
+           { http_status = 400; refusal = EO.Invalid_request })
   | Ok _ | Error _ -> fail "HTTP 400 prose did not remain terminal"
 ;;
 
@@ -3507,8 +3509,25 @@ let test_serialized_request_413_refusal_advances_once_to_successor () =
     ~first_response:
       (Cohttp.Code.status_of_code 413, {|{"error":"request body too large"}|})
     ~assert_cause:(function
-      | EO.Serialized_request_refused { http_status = 413 } -> ()
+      | EO.Provider_response_refused
+          { http_status = 413; refusal = EO.Request_body_refused } -> ()
       | _ -> fail "HTTP 413 lost its typed serialized-request cause")
+;;
+
+(* A 429 says the binding's quota is spent, not that the request is bad. Before
+   the refusal kind survived classification it arrived as [Completion_failed],
+   which the advance table reads as terminal: the lane stopped on its first
+   candidate and the keeper reported "completion failed" with no status. *)
+let test_rate_limited_429_refusal_advances_once_to_successor () =
+  assert_typed_capacity_refusal_advances_once
+    ~label:"rate-limited"
+    ~first_response:
+      ( Cohttp.Code.status_of_code 429
+      , {|{"error":{"code":"1302","message":"Rate limit reached for requests"}}|} )
+    ~assert_cause:(function
+      | EO.Provider_response_refused { http_status = 429; refusal = EO.Rate_limited } ->
+        ()
+      | _ -> fail "HTTP 429 lost its typed rate-limit cause")
 ;;
 
 let test_generic_400_remains_terminal_without_advance () =
@@ -3541,9 +3560,17 @@ let test_generic_400_remains_terminal_without_advance () =
   match result with
   | Error
       (EO.Flow_exact_execution_failed
-         { candidate; cause = { cause = EO.Completion_failed; _ }; _ }) ->
+         { candidate
+         ; cause =
+             { cause =
+                 EO.Provider_response_refused
+                   { http_status = 400; refusal = EO.Invalid_request }
+             ; _
+             }
+         ; _
+         }) ->
     check string "generic 400 terminal candidate" "generic-400-a" (candidate_id candidate)
-  | Ok _ | Error _ -> fail "generic 400 did not remain a completion failure"
+  | Ok _ | Error _ -> fail "generic 400 did not remain a typed invalid request"
 ;;
 
 let test_postdispatch_and_structural_outcomes_never_advance () =
@@ -3594,7 +3621,11 @@ let test_postdispatch_and_structural_outcomes_never_advance () =
     | Ok _ | Error _ -> fail (label ^ " did not remain terminal")
   in
   run ~abort_completion:true "partial" "unused";
-  run ~status:`Too_many_requests "response" "rate limited";
+  (* A 429 used to sit here, pinning the behaviour of the era when every
+     unclassified HTTP failure became [Completion_failed]. It advances now and
+     is covered by its own case; 500 keeps a post-dispatch response failure
+     under this assertion. *)
+  run ~status:`Internal_server_error "response" "server error";
   run "tool" tool_response
 ;;
 
@@ -4179,6 +4210,10 @@ let () =
             "HTTP 413 serialized request advances with one dispatch per candidate"
             `Quick
             test_serialized_request_413_refusal_advances_once_to_successor
+        ; test_case
+            "HTTP 429 rate limit advances with one dispatch per candidate"
+            `Quick
+            test_rate_limited_429_refusal_advances_once_to_successor
         ; test_case
             "generic 400 remains terminal"
             `Quick

--- a/packages/agent_core/test/test_exact_output_single_surface.ml
+++ b/packages/agent_core/test/test_exact_output_single_surface.ml
@@ -1075,10 +1075,13 @@ let test_public_receipt_phase_matrix () =
     execute_once ~net (attempt (flow snapshot "rate-surface" EO.Json_syntax))
   in
   check int "429 observes one POST" 1 rate_posts;
+  (* The receipt always carried the status; the cause did not, and the cause is
+     what the keeper log and the advance table read. *)
   (match rate_result with
    | Error
        { EO.receipt
-       ; cause = EO.Completion_failed
+       ; cause =
+           EO.Provider_response_refused { http_status = 429; refusal = EO.Rate_limited }
        ; raw_response = Some { body = "rate limited"; _ }
        ; _
        } ->

--- a/packages/agent_core/test/test_exact_output_validated_flow_evidence.ml
+++ b/packages/agent_core/test/test_exact_output_validated_flow_evidence.ml
@@ -327,6 +327,102 @@ let test_projection_failure_is_typed_and_short_circuits_acceptance () =
      | Ok _ | Error _ -> fail "projection failure lost its typed ordinal and cause")
 ;;
 
+(* A quota refusal now advances the lane, so it also reaches durable evidence
+   as its own wire form. Folded into [completion_failed_before_dispatch] the
+   transcript would claim the request never left, while the receipt records one
+   dispatch and a 429 response — an internally inconsistent transcript that
+   validation rejects. *)
+let with_rate_limited_first_server f =
+  let posts = Atomic.make 0 in
+  let result =
+    Eio_main.run
+    @@ fun env ->
+    Eio.Switch.run
+    @@ fun sw ->
+    let net = Eio.Stdenv.net env in
+    let port = fresh_port () in
+    let handler _conn _request body =
+      ignore (Eio.Buf_read.(of_flow ~max_size:max_int body |> take_all) : string);
+      let index = Atomic.fetch_and_add posts 1 in
+      if index = 0
+      then
+        Cohttp_eio.Server.respond_string
+          ~status:(Cohttp.Code.status_of_code 429)
+          ~body:{|{"error":{"code":"1302","message":"Rate limit reached for requests"}}|}
+          ()
+      else
+        Cohttp_eio.Server.respond_string
+          ~status:`OK
+          ~body:(openai_response {|{"name":"accepted"}|})
+          ()
+    in
+    let socket =
+      Eio.Net.listen
+        net
+        ~sw
+        ~backlog:8
+        ~reuse_addr:true
+        (`Tcp (Eio.Net.Ipaddr.V4.loopback, port))
+    in
+    let server = Cohttp_eio.Server.make ~callback:handler () in
+    Eio.Fiber.fork_daemon ~sw (fun () ->
+      Cohttp_eio.Server.run socket server ~on_error:(fun _ -> ()));
+    f ~net ~base_url:(Printf.sprintf "http://127.0.0.1:%d" port)
+  in
+  result, Atomic.get posts
+;;
+
+let test_rate_limited_advance_survives_the_durable_round_trip () =
+  let result, posts =
+    with_rate_limited_first_server
+    @@ fun ~net ~base_url ->
+    with_catalog ~base_url
+    @@ fun snapshot ->
+    EO.execute_flow_once
+      ~net
+      ~before_measurement_dispatch:(fun _ -> Ok ())
+      ~on_measurement_terminal:(fun _ -> Ok ())
+      ~before_dispatch:(fun _ -> Ok ())
+      ~before_advance:(fun ~failed:_ ~next:_ -> Ok ())
+      ~validate:(fun success -> EO.Accept (candidate_id success))
+      (start_flow snapshot)
+  in
+  check int "the refused candidate and its successor each dispatch once" 2 posts;
+  match result with
+  | Error _ -> fail "the rate-limited candidate did not advance to its successor"
+  | Ok success ->
+    check string "successor accepted" "evidence-c" success.accepted;
+    let accepted_calls = ref 0 in
+    let rejection_calls = ref 0 in
+    let durable =
+      match snapshot success ~accepted_calls ~rejection_calls with
+      | Ok durable -> durable
+      | Error _ -> fail "a rate-limited advance did not produce durable evidence"
+    in
+    let encoded = EO.validated_flow_evidence_to_string durable in
+    let contains needle =
+      let n = String.length needle in
+      let rec scan i =
+        i + n <= String.length encoded
+        && (String.equal (String.sub encoded i n) needle || scan (i + 1))
+      in
+      scan 0
+    in
+    check bool "the advance names the refusal" true (contains {|"rate_limited"|});
+    check bool "the advance carries the status" true (contains {|"http_status":429|});
+    (match EO.validated_flow_evidence_of_string encoded with
+     | Ok decoded ->
+       check
+         string
+         "the rate-limited transcript decodes to the same digest"
+         (EO.validated_flow_evidence_sha256 durable)
+         (EO.validated_flow_evidence_sha256 decoded)
+     | Error error ->
+       failf
+         "a rate-limited transcript did not decode: %s"
+         (EO.validated_flow_evidence_decode_error_to_string error))
+;;
+
 let () =
   run
     "exact-output validated flow evidence"
@@ -335,6 +431,10 @@ let () =
             "mixed order round trip and projector cardinality"
             `Quick
             test_mixed_transcript_round_trip_and_projector_cardinality
+        ; test_case
+            "rate-limited advance round trip"
+            `Quick
+            test_rate_limited_advance_survives_the_durable_round_trip
         ; test_case
             "typed projection failure"
             `Quick

--- a/test/test_keeper_exact_flow_detail.ml
+++ b/test/test_keeper_exact_flow_detail.ml
@@ -6,9 +6,19 @@ module Exact_output = Agent_core.Exact_output
 let test_execution_cause_detail () =
   Alcotest.(check string)
     "refused"
-    "serialized request refused (http_status=413)"
+    "provider refused (http_status=413 refusal=request_body_refused)"
     (Detail.execution_cause_detail
-       (Exact_output.Serialized_request_refused { http_status = 413 }));
+       (Exact_output.Provider_response_refused
+          { http_status = 413; refusal = Exact_output.Request_body_refused }));
+  (* The line an operator reads when a lane dies on quota. It carried neither
+     the status nor the kind while a 429 was classified as a bare
+     [Completion_failed]. *)
+  Alcotest.(check string)
+    "rate limited"
+    "provider refused (http_status=429 refusal=rate_limited)"
+    (Detail.execution_cause_detail
+       (Exact_output.Provider_response_refused
+          { http_status = 429; refusal = Exact_output.Rate_limited }));
   Alcotest.(check string)
     "completion"
     "completion failed"
@@ -103,7 +113,19 @@ let test_every_execution_cause_renders_distinctly () =
     ; Clock_required_for_timeout
     ; Frozen_request_mismatch
     ; Completion_failed
-    ; Serialized_request_refused { http_status = 429 }
+    ; Provider_response_refused { http_status = 413; refusal = Request_body_refused }
+    ; Provider_response_refused { http_status = 429; refusal = Rate_limited }
+    ; Provider_response_refused { http_status = 529; refusal = Overloaded }
+    ; Provider_response_refused { http_status = 500; refusal = Server_error }
+    ; Provider_response_refused { http_status = 401; refusal = Auth_failed }
+    ; Provider_response_refused { http_status = 403; refusal = Authorization_refused }
+    ; Provider_response_refused { http_status = 402; refusal = Payment_required }
+    ; Provider_response_refused { http_status = 400; refusal = Invalid_request }
+    ; Provider_response_refused { http_status = 404; refusal = Not_found }
+    ; Provider_response_refused { http_status = 400; refusal = Context_overflow }
+    ; Provider_response_refused { http_status = 400; refusal = Input_capacity }
+    ; Provider_response_refused { http_status = 400; refusal = Network_error }
+    ; Provider_response_refused { http_status = 408; refusal = Timeout }
     ; Incomplete_output
     ; Missing_output
     ; Ambiguous_output 3


### PR DESCRIPTION
## 무엇이 문제였나

keeper 로그에 429가 이렇게 남고 있었어요.

```
cause=completion failed raw_response={"error":{"code":"1302","message":"Rate limit reached for requests"}}
```

HTTP status가 어디에도 없습니다. 429라는 숫자는 `http_client`의 4xx 진단 덤프 두 줄에만 남아 있었어요.

원인은 `exact_output.ml`의 이 함수입니다.

```ocaml
let serialized_request_refusal_of_http_error ~code ~body ~retry_after_header =
  match Retry.classify_error ~retry_after_header ~status:code ~body with
  | Retry.InvalidRequest { reason = Request_body_refused_by_provider { status }; _ } -> Some status
  | Retry.RateLimited _ | Retry.Overloaded _ | ... (나머지 12종)          -> None
```

`Retry`가 이미 429를 `RateLimited`로 정확히 분류하는데, 이 함수가 그걸 `None`으로 눌렀습니다. 호출부는 그 `None`을 "실을 status가 없다"로 읽어 `Completion_failed`를 만들었고요. status와 종류가 이 한 줄에서 같이 사라집니다.

## 그래서 failover까지 막혔습니다

`execution_failure_may_advance`의 판정표를 보면:

| cause | phase | advance |
|---|---|---|
| `Serialized_request_refused` | `Response_received` | 허용 |
| `Completion_failed` | `Response_received` | **차단** |

`librarian_exact` 레인은 후보가 둘(`glm-coding.glm-5-turbo`, `deepseek.deepseek-v4-pro`)인데, 429가 `Completion_failed`로 접히는 바람에 첫 후보에서 종료됐습니다. 후속 후보에 닿지 못했어요.

## 어떻게 고쳤나

- `serialized_request_refusal_of_http_error` 삭제 → `provider_refusal_of_api_error`로 대체. `Retry.api_error` 13종이 각각 `provider_refusal` 하나로 매핑되고, 컴파일러가 누락을 잡습니다.
- `Serialized_request_refused`를 `Provider_response_refused { http_status; refusal }`로 흡수. 축이 하나라 새 실패 종류가 "어느 쪽에도 안 맞아서 Completion_failed로 감"이 재발하지 않습니다.
- quota 거부는 advance하도록 열었습니다. quota는 request가 아니라 binding에 붙는 성질이고, 후보 목록을 순서대로 두는 이유가 그거라서요. **나머지 거부 종류는 현행 유지**입니다 — 각각 다른 근거가 필요한 판단이라 이번 범위 밖으로 뒀어요.
- evidence에 `rate_limited` wire 형식 추가 (413의 `serialized_request_refused`는 그대로). status 429 + dispatch 1회로 검증합니다.

로그는 이렇게 바뀝니다.

```
execution_failed cause=provider refused (http_status=429 refusal=rate_limited)
```

## 계약이 바뀌는 지점

`postdispatch and structural outcomes never advance` 테스트가 429를 "advance 안 함"의 예시로 박아두고 있었는데, `git log -S`로 보니 agent_core를 통째로 import한 #27619에서 그대로 넘어온 것이었어요. 429를 따로 논해서 정한 게 아니라, 분류가 없던 시절 동작을 그대로 굳힌 쪽에 가깝습니다. 그 자리는 500으로 채워서 테스트의 원래 의도(응답 받은 뒤 실패는 advance 안 함)는 유지했습니다.

## 검증

| 스위트 | 결과 |
|---|---|
| `dune runtest packages/agent_core` | exit 0 |
| `test_hitl_summary_worker` | exit 0 |
| `test_keeper_exact_flow_detail` | exit 0 |
| `test_keeper_librarian_retry` | exit 0 |
| `test_librarian_journal_failures` | exit 0 |

추가한 테스트:

- `HTTP 429 rate limit advances with one dispatch per candidate` — 429가 후속 후보로 정확히 한 번 넘어가고 그쪽이 성공
- `rate-limited advance round trip` — evidence에 `"rate_limited"`, `"http_status":429`가 실제로 실리고 디코딩 후 digest가 같음
- keeper 렌더러 테스트에 refusal 13종을 모두 넣어 서로 다른 문자열로 렌더링되는지 확인

## 남은 것 (이 PR 밖)

- `config/runtime.toml`의 exact lane 4개가 전부 `glm-coding.glm-5-turbo`를 1순위로 두고 있어서 한 키에 몰립니다. 429 발생 빈도 자체를 줄이려면 이쪽이 별건으로 필요해요.
- `http_client`의 4xx 진단 덤프는 `400 <= code < 500` 전체에 발화합니다. 원래 목적은 cloudflare edge의 opaque 400 진단인데 429에도 붙어요. 다만 지금까지 429를 말해주던 유일한 자리라서, 이 PR이 들어간 뒤에 정리하는 게 순서로 보입니다.
