### PR TITLE
fix(auth): 프롬프트 오버라이드 저장 불가 수정 — masc_prompt_override 카탈로그 등록 + 라우트/카탈로그 대조 게이트

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -552,6 +552,13 @@ jobs:
       - name: Check CI test targets
         run: bash scripts/audit-ci-test-targets.sh
 
+      # A route that authorizes against a tool name the catalog never registered
+      # is closed to every credential, admin included, and the denial reads as a
+      # role problem. POST /api/v1/prompts shipped that way with a working
+      # dashboard editor in front of it (#29085).
+      - name: Check route tool catalog registration
+        run: bash scripts/audit-route-tool-catalog.sh
+
       - name: Check Keeper real-world secret boundary
         run: |
           python3 scripts/ci/check-keeper-realworld-secret-boundary.py

--- a/lib/tool/tool_catalog.ml
+++ b/lib/tool/tool_catalog.ml
@@ -343,6 +343,10 @@ let explicit_metadata : (string * metadata) list =
     ("masc_board_cleanup", admin_tool);
     ("masc_board_delete", admin_tool);
     ("masc_gc", admin_tool);
+    (* POST /api/v1/prompts. An override replaces a prompt for every keeper the
+       runtime serves, so it carries the same admin permission as the other
+       fleet-wide mutations here. *)
+    ("masc_prompt_override", admin_tool);
     ("masc_pause", broadcast_tool);
     ("masc_resume", broadcast_tool);
     ("masc_pause_status", read_state_tool);

--- a/scripts/audit-route-tool-catalog.sh
+++ b/scripts/audit-route-tool-catalog.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Fail when an HTTP route demands a tool name that the tool catalog does not carry.
+#
+# Route handlers authorize through with_tool_auth ~tool_name:"...". Authorization
+# looks that name up in Tool_catalog and denies outright when the lookup misses:
+#
+#   lib/auth/auth.ml
+#     match Tool_catalog.registered_metadata tool_name with
+#     | Some metadata -> check_permission ... metadata.required_permission
+#     | None -> Error (Forbidden { action = "use unregistered tool: " ^ tool_name })
+#
+# So a route whose tool name was never registered is closed to every credential,
+# including admin ones. Nothing in the adding PR notices: the string is a literal,
+# the code compiles, and the route reads as protected rather than unreachable.
+#
+# That is how POST /api/v1/prompts sat unusable. The dashboard drew its prompt
+# editor with working Save and Clear buttons, the persistence layer was complete,
+# and masc_prompt_override was absent from the catalog, so both buttons returned
+# insufficient_role for two authenticated agents. The error names a role problem,
+# which sends the reader looking at permissions instead of at registration (#29085).
+#
+# This compares the two lists in a second.
+set -uo pipefail
+
+cd "$(git rev-parse --show-toplevel)" || exit
+
+demanded="$(mktemp)"
+trap 'rm -f "$demanded"' EXIT
+
+rg --only-matching --no-line-number 'with_tool_auth ~tool_name:"[a-z_]+"' lib/server \
+  | sed 's/.*"\(.*\)"/\1/' \
+  | sort -u > "$demanded"
+
+if [ ! -s "$demanded" ]; then
+  echo "[route-tool-catalog] no with_tool_auth call sites found - the scan pattern is stale"
+  exit 1
+fi
+
+missing=0
+while read -r tool; do
+  [ -n "$tool" ] || continue
+  if ! rg --quiet --no-line-number "\"$tool\"" \
+       lib/tool/tool_catalog.ml lib/tool_catalog_surfaces/*.ml 2>/dev/null; then
+    echo "[route-tool-catalog] FAIL - route demands \"$tool\" but no catalog entry declares it"
+    echo "                     every credential hits \"use unregistered tool\" on that route"
+    missing=$((missing + 1))
+  fi
+done < "$demanded"
+
+demanded_count="$(wc -l < "$demanded" | tr -d ' ')"
+
+if [ "$missing" -gt 0 ]; then
+  echo "[route-tool-catalog] $missing of $demanded_count route tool names are unregistered"
+  echo "                     register them in lib/tool/tool_catalog.ml with the permission the route needs"
+  exit 1
+fi
+
+echo "[route-tool-catalog] OK - $demanded_count route tool names, all registered in the catalog"


### PR DESCRIPTION
대시보드 Settings의 프롬프트 편집기가 저장이 안 되는 걸 발견해서 고칩니다. #29085입니다.

## 무슨 일이었냐면

`POST /api/v1/prompts`는 `masc_prompt_override`라는 이름으로 인증을 겁니다. 그런데 인증은 이렇게 동작해요:

```
match Tool_catalog.registered_metadata tool_name with
| Some metadata -> check_permission ... metadata.required_permission
| None -> Error (Forbidden { action = "use unregistered tool: " ^ tool_name })
```

그 이름이 카탈로그에 **한 번도 등록된 적이 없어서** `None` 분기로 떨어집니다. 결과적으로 **어떤 자격으로도 통과할 수 없었어요**. 실제로 정상 인증된 자격 둘(codex-mcp-client, dashboard-admin-deft-cobra)로 시도했는데 둘 다 같은 지점에서 막혔습니다.

에러 코드가 `insufficient_role`로 나오는 것도 진단을 흐립니다. 권한이 모자란 것처럼 읽히니까 자격을 바꿔가며 찾게 되는데, 실제 원인은 등록 누락이에요.

앞에는 멀쩡한 UI가 있었습니다. 프롬프트 목록도 뜨고, 편집창도 있고, "오버라이드 적용"·"오버라이드 제거" 버튼도 그려집니다. 저장소(`Prompt_override_persistence`)도 완성돼 있고요. 인증 한 겹만 막혀 있었습니다.

## 고친 것

**등록**: `masc_prompt_override`를 `admin_tool`로 카탈로그에 넣었습니다. 오버라이드는 이 런타임이 서빙하는 모든 keeper의 프롬프트를 바꾸니까, 옆에 있는 다른 fleet 전역 변경(`masc_board_cleanup`, `masc_gc`)과 같은 등급이 맞다고 봤어요.

**재발 방지**: `scripts/audit-route-tool-catalog.sh`를 추가했습니다. 라우트가 요구하는 도구 이름을 전부 뽑아서 카탈로그에 있는지 대조합니다.

이 검사가 필요한 이유는, 지금 구조에서 등록을 잊어도 **컴파일이 통과**하기 때문입니다. 도구 이름이 문자열 리터럴이라 타입 검사가 안 걸리고, 라우트 코드만 보면 보호되는 것처럼 읽혀요. 런타임 403으로만 드러납니다.

## 검증

```
# 수정 전
[route-tool-catalog] FAIL - route demands "masc_prompt_override" but no catalog entry declares it
[route-tool-catalog] 1 of 14 route tool names are unregistered

# 수정 후
[route-tool-catalog] OK - 14 route tool names, all registered in the catalog
```

- 게이트가 실제로 이 결함을 잡는 것과, 등록 후 통과하는 것을 둘 다 확인했습니다.
- `ocamlformat` 파싱 통과.
- CI YAML 파싱 확인(스텝 162개, 새 게이트 배선됨).

## 남은 이야기

librarian 프롬프트를 한국어로 바꾸려다 발견한 건이라, 번역본은 따로 준비돼 있습니다(플레이스홀더 5종·분류값 8종·스키마 필드 7종 무결성 검증 통과). 이 PR이 들어가면 API로 넣을 수 있게 됩니다.

그리고 현재 라이브에서 6개 프롬프트가 전부 `override=False`인데, 이게 "아무도 안 썼다"인지 "쓸 수 없었다"인지 지금은 구분이 안 됩니다. 아마 후자일 것 같아요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
