### PR TITLE
feat(dashboard): 화면에서 keeper를 제거할 수 있게 하고, purge 연쇄에 대화 기록을 넣는다

### DIFF
--- a/dashboard/src/api/keeper-lifecycle.ts
+++ b/dashboard/src/api/keeper-lifecycle.ts
@@ -544,3 +544,52 @@ export async function bulkKeeperDirective(
     }
   }
 }
+
+// --- Keeper purge (permanent removal) ---
+
+// The purge endpoint admits a keeper from its persisted metadata rather than
+// from a live registry lane, so a keeper that has already stopped is a valid
+// target. `masc_keeper_down` cannot reach those: it refuses a keeper whose
+// metadata exists without a live lane.
+export interface KeeperPurgeResponse {
+  ok: true
+  accepted: boolean
+  target_kind: 'keeper'
+  agent_name: string
+  keeper_name: string
+  operation_id: string
+}
+
+// What the server's purge plan removes, in the order it removes it
+// (Keeper_shutdown_types.dashboard_purge_artifact_plan). The confirmation UI
+// shows this list, so it must stay in step with that plan.
+export const KEEPER_PURGE_ARTIFACTS: readonly string[] = [
+  '메트릭 저장소',
+  '결정 로그',
+  '피드백 로그',
+  '런타임 디렉터리',
+  'Memory OS 스냅샷과 저널',
+  'TOML 설정',
+  '대화 기록',
+  '에이전트 파일과 인증 토큰',
+]
+
+export async function purgeKeeper(name: string): Promise<KeeperPurgeResponse> {
+  const resp = await fetchControlPlane('/api/v1/dashboard/agents/purge', {
+    method: 'POST',
+    headers: jsonHeaders(),
+    body: JSON.stringify({ agent_name: name }),
+  })
+  if (!resp.ok) {
+    const payload = await safeJsonResponse<{ error?: string }>(
+      resp,
+      `${name} 제거 실패`,
+    )
+    throw new Error(
+      typeof payload.error === 'string' && payload.error.trim() !== ''
+        ? payload.error
+        : `${name} 제거 실패 (HTTP ${resp.status})`,
+    )
+  }
+  return resp.json() as Promise<KeeperPurgeResponse>
+}

--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -44,6 +44,7 @@ import {
   fetchKeeperCheckpoints as fetchKeeperCheckpointsFromLifecycle,
   pauseKeeper as pauseKeeperFromLifecycle,
   previewKeeperCheckpointPurge as previewKeeperCheckpointPurgeFromLifecycle,
+  purgeKeeper as purgeKeeperFromLifecycle,
   resetKeeper as resetKeeperFromLifecycle,
   resumeKeeper as resumeKeeperFromLifecycle,
   shutdownKeeper as shutdownKeeperFromLifecycle,
@@ -1413,5 +1414,64 @@ describe('parseKeeperEventQueuePendingSnapshot workspace message fields', () => 
     expect(row).toBeDefined()
     expect(row?.messageRequestId).toBeUndefined()
     expect(row?.messageFrom).toBeUndefined()
+  })
+})
+
+describe('purgeKeeper', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('posts the keeper name to the dashboard purge route and returns the accepted operation', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          accepted: true,
+          target_kind: 'keeper',
+          agent_name: 'keeper-canary-10t-agy3-agent',
+          keeper_name: 'canary-10t-agy3',
+          operation_id: 'op-1',
+        }),
+        { status: 202, headers: { 'Content-Type': 'application/json' } },
+      ),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await purgeKeeperFromLifecycle('canary-10t-agy3')
+
+    expect(result.accepted).toBe(true)
+    expect(result.keeper_name).toBe('canary-10t-agy3')
+    expect(result.operation_id).toBe('op-1')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]! as [string, RequestInit]
+    expect(url).toBe('/api/v1/dashboard/agents/purge')
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(String(init.body))).toEqual({ agent_name: 'canary-10t-agy3' })
+  })
+
+  it('surfaces the server error text instead of a bare status code', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: 'keeper metadata unreadable' }), {
+        status: 409,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(purgeKeeperFromLifecycle('canary-10t-agy3')).rejects.toThrow(
+      'keeper metadata unreadable',
+    )
+  })
+
+  it('falls back to a named error when the server body carries no error text', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('', { status: 500 }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(purgeKeeperFromLifecycle('canary-10t-agy3')).rejects.toThrow(
+      'canary-10t-agy3 제거 실패 (HTTP 500)',
+    )
   })
 })

--- a/dashboard/src/components/keeper-action-panel.test.ts
+++ b/dashboard/src/components/keeper-action-panel.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 // Mock modules with lucide-preact icons that cause test-env errors
 vi.mock('./common/confirm-dialog', () => ({ requestConfirm: vi.fn(async () => false) }))
@@ -12,6 +12,17 @@ vi.mock('../api/keeper', () => ({
   shutdownKeeper: vi.fn(),
   wakeKeeper: vi.fn(),
 }))
+vi.mock('../api/keeper-lifecycle', () => ({
+  purgeKeeper: vi.fn(async () => ({
+    ok: true,
+    accepted: true,
+    target_kind: 'keeper',
+    agent_name: 'keeper-test-agent',
+    keeper_name: 'test',
+    operation_id: 'op-1',
+  })),
+  KEEPER_PURGE_ARTIFACTS: ['결정 로그', '대화 기록'],
+}))
 vi.mock('../store', () => ({
   keepers: { value: [] },
   applyOptimisticKeeperDirective: vi.fn(() => () => {}),
@@ -19,6 +30,9 @@ vi.mock('../store', () => ({
 }))
 
 import { pauseKeeper, resumeKeeper } from '../api/keeper'
+import { purgeKeeper } from '../api/keeper-lifecycle'
+import { requestConfirm } from './common/confirm-dialog'
+import { showToast } from './common/toast'
 import { keeperActionVisibility } from '../lib/keeper-predicates'
 import { applyOptimisticKeeperDirective, refreshKeeperRuntimeStatus } from '../store'
 import { runKeeperAction } from './keeper-action-panel'
@@ -181,5 +195,63 @@ describe('runKeeperAction', () => {
     await runKeeperAction('rondo', 'resume', 7)
 
     expect(resumeKeeper).toHaveBeenCalledWith('rondo', 7)
+  })
+})
+
+describe('purge action', () => {
+  beforeEach(() => {
+    // Mock call counts accumulate across this file, and the assertions below
+    // read the first recorded call.
+    vi.clearAllMocks()
+  })
+
+  // Purge is permanent, so the button must not appear while the lane is
+  // running — an operator has to shut the keeper down first.
+  it('is offered for offline and paused keepers but not for a running one', () => {
+    const running = makeKeeper({ status: 'active', phase: 'Running', paused: false })
+    const paused = makeKeeper({ status: 'active', phase: 'Paused', paused: true })
+    const offline = makeKeeper({
+      status: 'offline',
+      phase: 'Offline',
+      paused: false,
+      keepalive_running: false,
+    })
+
+    expect(keeperActionVisibility(running).canPurge).toBe(false)
+    expect(keeperActionVisibility(paused).canPurge).toBe(true)
+    expect(keeperActionVisibility(offline).canPurge).toBe(true)
+  })
+
+  it('does not call the endpoint when the confirmation is declined', async () => {
+    vi.mocked(requestConfirm).mockResolvedValueOnce(false)
+
+    await runKeeperAction('test', 'purge')
+
+    expect(purgeKeeper).not.toHaveBeenCalled()
+  })
+
+  it('names every deleted store in the confirmation before calling the endpoint', async () => {
+    vi.mocked(requestConfirm).mockResolvedValueOnce(true)
+
+    await runKeeperAction('test', 'purge')
+
+    expect(requestConfirm).toHaveBeenCalledTimes(1)
+    const options = vi.mocked(requestConfirm).mock.calls[0]![0]!
+    expect(options.tone).toBe('danger')
+    expect(options.message).toContain('되돌릴 수 없습니다')
+    expect(options.message).toContain('결정 로그')
+    expect(options.message).toContain('대화 기록')
+    expect(purgeKeeper).toHaveBeenCalledWith('test')
+    expect(refreshKeeperRuntimeStatus).toHaveBeenCalled()
+  })
+
+  it('surfaces the failure and does not refresh when the endpoint rejects', async () => {
+    vi.mocked(requestConfirm).mockResolvedValueOnce(true)
+    vi.mocked(purgeKeeper).mockRejectedValueOnce(new Error('keeper metadata unreadable'))
+
+    await runKeeperAction('test', 'purge')
+
+    expect(showToast).toHaveBeenCalledWith('keeper metadata unreadable', 'error')
+    expect(refreshKeeperRuntimeStatus).not.toHaveBeenCalled()
   })
 })

--- a/dashboard/src/components/keeper-action-panel.ts
+++ b/dashboard/src/components/keeper-action-panel.ts
@@ -11,10 +11,11 @@
 //   wakeup    → POST /api/v1/keepers/:name/directive  { action: "wakeup" }
 //   boot      → POST /api/v1/keepers/:name/boot
 //   shutdown  → POST /api/v1/keepers/:name/shutdown
+//   purge     → POST /api/v1/dashboard/agents/purge  { agent_name }
 
 import { html } from 'htm/preact'
 import { useSignal } from '@preact/signals'
-import { Pause, Play, Power, RotateCcw, Square } from 'lucide-preact'
+import { Pause, Play, Power, RotateCcw, Square, Trash2 } from 'lucide-preact'
 import { ActionButton } from './common/button'
 import { requestConfirm } from './common/confirm-dialog'
 import { showToast } from './common/toast'
@@ -25,6 +26,7 @@ import {
   shutdownKeeper,
   wakeKeeper,
 } from '../api/keeper'
+import { KEEPER_PURGE_ARTIFACTS, purgeKeeper } from '../api/keeper-lifecycle'
 import {
   applyOptimisticKeeperDirective,
   refreshKeeperRuntimeStatus,
@@ -46,7 +48,13 @@ function afterAction(): void {
   })
 }
 
-export type KeeperActionKey = 'pause' | 'resume' | 'wakeup' | 'boot' | 'shutdown'
+export type KeeperActionKey =
+  | 'pause'
+  | 'resume'
+  | 'wakeup'
+  | 'boot'
+  | 'shutdown'
+  | 'purge'
 
 /**
  * Single source of truth for keeper-action 한국어 라벨.
@@ -109,6 +117,13 @@ export const KEEPER_ACTION_LABELS: Record<KeeperActionKey, KeeperActionLabel> = 
     icon: Square,
     danger: true,
   },
+  purge: {
+    noun: '제거', verb: '제거하기', compact: '제거', label: '제거',
+    title:
+      '제거: keeper 와 그 저장소를 영구 삭제합니다 (되돌릴 수 없음). 실행 중이 아닌 keeper 에만 보입니다.',
+    icon: Trash2,
+    danger: true,
+  },
 }
 
 /** Execute a lifecycle action for a single keeper with toast feedback.
@@ -130,6 +145,32 @@ export async function runKeeperAction(
     if (!confirmed) return
   }
   const noun = KEEPER_ACTION_LABELS[action].noun
+
+  // Purge is not a lifecycle directive: it deletes the keeper and every store
+  // it owns, and the endpoint answers 202 with an operation id rather than the
+  // { ok, error } shape the directive calls share. It is handled here, ahead of
+  // the directive switch, so the confirmation naming the deleted stores cannot
+  // be bypassed by a caller surface.
+  if (action === 'purge') {
+    const confirmed = await requestConfirm({
+      title: '키퍼 영구 제거',
+      message:
+        `${name} 키퍼를 영구 제거합니다. 되돌릴 수 없습니다.\n\n`
+        + `함께 삭제되는 항목:\n`
+        + KEEPER_PURGE_ARTIFACTS.map(item => `  · ${item}`).join('\n'),
+      confirmText: '영구 제거',
+      tone: 'danger',
+    })
+    if (!confirmed) return
+    try {
+      const result = await purgeKeeper(name)
+      showToast(`${name} ${noun} 요청됨 (operation ${result.operation_id})`, 'success')
+      afterAction()
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : `${noun} 실패`, 'error')
+    }
+    return
+  }
 
   // Optimistic UI: pause/resume/wakeup mutate `paused` + phase locally
   // before the POST returns so the row's button set flips instantly. On
@@ -259,6 +300,16 @@ export function KeeperActionButtons({
             onClick=${(e: Event) => handle(e, 'shutdown')}
             title=${KEEPER_ACTION_LABELS.shutdown.title}
           >${text('shutdown')}<//>`
+        : null}
+      ${vis.canPurge
+        ? html`<${ActionButton}
+            variant="danger"
+            size=${size}
+            disabled=${busy.value}
+            onClick=${(e: Event) => handle(e, 'purge')}
+            title=${KEEPER_ACTION_LABELS.purge.title}
+            testId="keeper-action-purge"
+          >${text('purge')}<//>`
         : null}
     </div>
   `

--- a/dashboard/src/lib/keeper-predicates.ts
+++ b/dashboard/src/lib/keeper-predicates.ts
@@ -164,6 +164,7 @@ export interface KeeperActionVisibility {
   canWake: boolean
   canBoot: boolean
   canShutdown: boolean
+  canPurge: boolean
 }
 
 /** Determine which lifecycle actions are relevant for a keeper's
@@ -183,6 +184,12 @@ export function keeperActionVisibility(keeper: Keeper): KeeperActionVisibility {
     canWake:     keeperCanWakeup(keeper),
     canBoot:     isOffline && !isPaused,
     canShutdown: isRunning || isPaused,
+    // Purge deletes the keeper and every store it owns, permanently, so it
+    // is offered only for a keeper that is not taking turns: paused (the
+    // scenario harnesses leave their keepers here) or offline (finished
+    // canaries). A healthy running keeper must be paused or shut down first,
+    // so the button can never be a one-click loss of working state.
+    canPurge:    isPaused || isOffline,
   }
 }
 

--- a/lib/keeper/keeper_shutdown_types.ml
+++ b/lib/keeper/keeper_shutdown_types.ml
@@ -56,6 +56,7 @@ type dashboard_purge_artifact =
   | Keeper_memory_current_artifact
   | Keeper_memory_journal_artifact
   | Keeper_configuration_artifact
+  | Keeper_chat_store_artifact
   | Agent_artifact_bundle of string list
 
 type completion_receipt =
@@ -463,6 +464,12 @@ let dashboard_purge_artifact_plan ~keeper_name context =
   ; Keeper_memory_current_artifact
   ; Keeper_memory_journal_artifact
   ; Keeper_configuration_artifact
+    (* The chat store is a top-level per-keeper file
+       (.masc/keeper_chat/<name>.jsonl), so it sits outside the runtime
+       directory removed above. Without an explicit entry a purged keeper
+       leaves its conversation behind and a later keeper with the same name
+       reads it as its own history. *)
+  ; Keeper_chat_store_artifact
   ; Agent_artifact_bundle agent_aliases
   ]
 ;;

--- a/lib/keeper/keeper_shutdown_types.mli
+++ b/lib/keeper/keeper_shutdown_types.mli
@@ -39,6 +39,7 @@ type dashboard_purge_artifact =
   | Keeper_memory_current_artifact
   | Keeper_memory_journal_artifact
   | Keeper_configuration_artifact
+  | Keeper_chat_store_artifact
   | Agent_artifact_bundle of string list
 
 type completion_receipt =

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -395,6 +395,11 @@ let keeper_artifact_path config keeper_name artifact =
          (Config_dir_resolver.keepers_dir_for_base_path
             ~base_path:config.Workspace.base_path)
          (keeper_name ^ ".toml"))
+  | Keeper_chat_store_artifact ->
+    Some
+      (Keeper_chat_store.chat_path
+         ~base_dir:config.Workspace.base_path
+         ~keeper_name)
   | Agent_artifact_bundle _ -> None
 ;;
 
@@ -438,6 +443,7 @@ let purge_dashboard_keeper_artifacts config operation =
             | Keeper_runtime_directory_artifact
             | Keeper_memory_current_artifact
             | Keeper_configuration_artifact
+            | Keeper_chat_store_artifact
             | Agent_artifact_bundle _ -> ());
            (match remove_path_strict path with
             | Error _ as error -> error
@@ -451,6 +457,7 @@ let purge_dashboard_keeper_artifacts config operation =
                | Keeper_memory_current_artifact
                | Keeper_memory_journal_artifact
                | Keeper_configuration_artifact
+               | Keeper_chat_store_artifact
                | Agent_artifact_bundle _ -> ());
               Log.Keeper.debug
                 "dashboard Keeper purge artifact: keeper=%s path=%s outcome=%s"

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -2252,6 +2252,23 @@ let test_transcript_absent_returns_empty () =
       Alcotest.(check bool) "found=false when no rows match" true
         (String_util.contains_substring (Yojson.Safe.to_string json) "\"found\":false"))
 
+(* The chat store is a top-level per-keeper file, outside the runtime
+   directory the purge plan removes, so it needs its own entry. Without one a
+   purged keeper leaves its conversation on disk and a later keeper with the
+   same name reads it back as its own history — the same failure the memory
+   sidecars already hit. *)
+let test_purge_plan_removes_chat_store () =
+  let module Shutdown = Masc.Keeper_shutdown_types in
+  let context =
+    { Shutdown.requested_name = "keeper"; agent_name = "keeper" }
+  in
+  let plan = Shutdown.dashboard_purge_artifact_plan ~keeper_name:"keeper" context in
+  Alcotest.(check bool)
+    "plan removes the chat store"
+    true
+    (List.exists (fun entry -> entry = Shutdown.Keeper_chat_store_artifact) plan)
+;;
+
 let () =
   Alcotest.run "keeper_chat_store"
     [
@@ -2396,5 +2413,7 @@ let () =
           Alcotest.test_case
             "transcript absent returns empty + found=false (RFC-0233 §7)"
             `Quick test_transcript_absent_returns_empty;
+          Alcotest.test_case "purge plan removes the chat store" `Quick
+            test_purge_plan_removes_chat_store;
         ] );
     ]


### PR DESCRIPTION
## 왜

`POST /api/v1/dashboard/agents/purge` 는 이미 있었다. 영속 메타데이터로 대상을 승인하므로 정지된 keeper도 지울 수 있고, 메트릭·결정 로그·피드백 로그·런타임 디렉터리·Memory OS 스냅샷/저널·TOML 설정·에이전트 파일과 인증 토큰까지 연쇄 삭제한다. 그런데 **대시보드에서 이걸 부르는 곳이 없었다.**

운영자에게 노출된 유일한 제거 수단은 `masc_keeper_down --remove_meta` 인데, 이건 live lane이 없는 keeper를 `"Keeper metadata exists without a live lane; refusing untracked cleanup"` 으로 거부한다 (`lib/keeper/keeper_turn_lifecycle.ml:34-79`). 정리하고 싶은 대상이 정확히 그 부류다. 결과적으로 기준 store의 keeper 129개 중 **120개가 종료된 실험의 잔재**다.

관련: #29082

## 무엇

**화면에서 제거.** `KeeperActionButtons` 에 `제거` 액션을 추가했다. 이 버튼 묶음은 fleet 행과 KEEPER OPERATIONS 인라인 행이 함께 쓰므로 한 곳만 고치면 두 표면에 다 나온다.

- 확인 창이 **삭제되는 항목을 모두 나열한다**. 영구 삭제라서 "정말 지울까요?" 만으로는 부족하다고 봤다.
- 실행 중인 keeper에는 버튼이 나오지 않는다 (`canPurge: isPaused || isOffline`). 서버가 live lane을 fence하기도 하고, 동작 중인 keeper를 한 번의 클릭으로 잃을 여지를 두지 않으려는 것이다.
- purge는 lifecycle directive가 아니다. 202와 operation id를 돌려주고 실패는 예외로 던지므로, `{ ok, error }` 를 공유하는 directive switch 앞에서 따로 처리한다. 그래야 어떤 호출 표면도 확인 창을 건너뛸 수 없다.

**연쇄 누락 수정.** purge plan에 `Keeper_chat_store_artifact` 를 추가했다. 대화 기록은 `.masc/keeper_chat/<name>.jsonl` 로 최상위에 있어서 plan이 지우는 런타임 디렉터리 바깥이다. 그래서 purge된 keeper가 대화를 남겼고, 같은 이름의 새 keeper가 그걸 자기 이력으로 읽었다. Memory OS sidecar가 겪고 고친 것과 같은 실패다 (`keeper_shutdown_types.ml:458-462` 주석).

chat store는 fd 캐시가 아니라 `append_private_jsonl_durable_locked_*` 로 append하므로 memory journal과 달리 `invalidate_cached_writer` 가 필요 없다. `Fd_cache.with_writer` 사용처는 `append_file_unix` / `append_jsonl` / `append_jsonl_batch` 뿐이다 (`lib/fs_compat/fs_compat.ml`).

## 검증

로컬 실행 결과다.

- `dune build --root . @check` — exit 0. artifact variant 추가로 컴파일러가 match 지점 3곳을 강제했다.
- `dune exec --root . test/test_keeper_chat_store.exe` — 60 tests, Test Successful.
- `npx vitest run src/components/keeper-action-panel.test.ts src/lib/keeper-predicates.test.ts` — 94 passed.
- `npx vitest run src/api/keeper.test.ts -t purgeKeeper` — 3 passed.
- `npx tsc --noEmit` — exit 0.

**새 OCaml 테스트가 계약을 실제로 고정하는지 확인했다.** plan에서 `Keeper_chat_store_artifact` 한 줄만 빼고 돌리면 exit 1 로 `FAIL plan removes the chat store` 가 난다. 타입만 보는 게 아니라 plan 내용을 고정한다.

## 남긴 것

`KEEPER_PURGE_ARTIFACTS` (확인 창이 보여주는 목록) 와 서버의 `dashboard_purge_artifact_plan` 을 묶는 가드는 없다. 한쪽은 TS, 한쪽은 OCaml이라 지금 구조로는 컴파일러가 못 잡는다. 더 근본적으로 plan 자체가 손으로 유지하는 목록이라, keeper 소유 저장소가 새로 생길 때마다 고아를 만든다 — 이번 대화 기록이 그 두 번째 사례다. keeper 소유 산출물을 타입으로 등록하고 plan을 거기서 유도하는 것이 근본 수정이고, #29082 에 P2로 적어뒀다.

일괄 제거(잔재 120개를 한 번에)도 이 PR에는 없다. 하네스 teardown이 purge를 부르게 되면 애초에 쌓이지 않으므로 그쪽이 먼저다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 삭제 경계 — 무엇을 지우고 무엇을 남기는가

purge는 **그 keeper가 소유한 것만** 지운다. 다른 keeper에 남은 기록과 공유 기록은 건드리지 않는다.

지우는 쪽(소유):
- `.masc/keeper_chat/<name>.jsonl` — 이 keeper 자신의 대화 파일 하나. 모든 append API가 `~keeper_name` 으로 키를 잡으므로 (`keeper_chat_store.mli:239-328`), A를 지워도 B의 파일에는 아무 영향이 없다. keeper 간 교차 읽기도 이미 막혀 있다 (`test_tool_agent_timeline_build.ml:187` "Keeper-runtime dispatch must not let a keeper read another keeper's ...").
- 메트릭 저장소, 결정 로그, 피드백 로그, 런타임 디렉터리, Memory OS 스냅샷/저널, TOML 설정, 에이전트 파일과 인증 토큰.

남기는 쪽(공유·타인 소유):
- `board_posts.jsonl`, `board_comments.jsonl`, `board_votes.jsonl`, `messages/` 는 plan에 없고 이 PR도 추가하지 않는다. A가 Board에 남긴 글은 B의 맥락이기도 하므로, A를 지운다고 B의 과거가 다시 쓰이면 안 된다.
- 다른 keeper의 chat 파일.

이건 "ledger는 사실을 기록하고 행동을 통제하지 않는다"는 제품 원칙과 같은 선이다. 삭제는 소유 경계까지만 간다.
