### PR TITLE
fix(keeper): keeper_list에 total/truncated를 실어 짧은 응답이 전부로 읽히지 않게

### DIFF
--- a/dashboard/src/api/gate-keepers.test.ts
+++ b/dashboard/src/api/gate-keepers.test.ts
@@ -31,6 +31,9 @@ const currentWire = {
     created_at: '2026-08-12T00:00:00Z',
     updated_at: '2026-08-12T00:01:00Z',
   }],
+  total: 1,
+  limit: 200,
+  truncated: false,
 } as const
 
 function runWithHttp<A, E>(
@@ -44,18 +47,55 @@ describe('fetchGateKeepers', () => {
   it('fetches and decodes unknown data at the typed endpoint boundary', () => {
     const data = Effect.runSync(runWithHttp(fetchGateKeepers(), {
       getUnknown: path => {
-        expect(path).toBe('/api/v1/gate/keepers?limit=50&detailed=true')
+        expect(path).toBe('/api/v1/gate/keepers?detailed=true')
         return Effect.succeed(currentWire)
       },
     }))
 
     expect(data.keepers[0]?.name).toBe('planner')
+    expect(data.listing).toEqual({ total: 1, limit: 200, truncated: false })
+  })
+
+  it('does not pin a limit — the route bounds itself and reports the bound', () => {
+    // masc#29077: a limit hardcoded here was a second cap the UI had to keep in
+    // sync with the route, and it lost that race (50 vs a 200 clamp).
+    Effect.runSync(runWithHttp(fetchGateKeepers(), {
+      getUnknown: path => {
+        expect(path).not.toContain('limit=')
+        return Effect.succeed(currentWire)
+      },
+    }))
+  })
+
+  it('carries the truncation verdict through to the product value', () => {
+    const truncatedWire = { ...currentWire, total: 129, limit: 50, truncated: true }
+    const data = Effect.runSync(runWithHttp(fetchGateKeepers(), {
+      getUnknown: () => Effect.succeed(truncatedWire),
+    }))
+
+    expect(data.listing.truncated).toBe(true)
+    expect(data.listing.total).toBe(129)
+    // The rows are the page, not the directory. A consumer that reads
+    // keepers.length as the keeper count is the bug this field exists for.
+    expect(data.keepers.length).toBe(1)
+  })
+
+  it('rejects a response that omits the listing fields', () => {
+    // Strict decoding, so a server that stops sending them is drift rather
+    // than a silent downgrade to the old "count is all there is" shape.
+    const { total: _total, ...withoutTotal } = currentWire
+    const error = Effect.runSync(Effect.flip(runWithHttp(
+      fetchGateKeepers(),
+      { getUnknown: () => Effect.succeed(withoutTotal) },
+    )))
+
+    expect(error).toBeInstanceOf(GateKeepersSchemaDriftError)
   })
 
   it('preserves transport failures as typed values', () => {
     const transportError = new DashboardTransportError({
       method: 'GET',
-      path: '/api/v1/gate/keepers?limit=50&detailed=true',
+      path: '/api/v1/gate/keepers?detailed=true',
       message: 'offline',
       cause: new Error('offline'),
     })

--- a/dashboard/src/api/gate-keepers.ts
+++ b/dashboard/src/api/gate-keepers.ts
@@ -14,6 +14,7 @@ export type {
   GateKeeper,
   GateKeeperDirectoryIssue,
   GateKeepersData,
+  KeeperListing,
 } from './schemas/gate-keepers'
 export {
   decodeGateKeepers,
@@ -24,7 +25,11 @@ export type GateKeepersError =
   | DashboardTransportError
   | GateKeepersSchemaDriftError
 
-const GATE_KEEPERS_PATH = '/api/v1/gate/keepers?limit=50&detailed=true'
+// No limit parameter: the route clamps to its own bound and reports `total` /
+// `truncated`, so asking for a number here only re-introduces a second cap the
+// UI would have to keep in sync. masc#29077 — the hardcoded 50 hid 79 of 129
+// keepers, including every keeper that had a live channel binding.
+const GATE_KEEPERS_PATH = '/api/v1/gate/keepers?detailed=true'
 
 export function fetchGateKeepers(): Effect.Effect<
   GateKeepersData,

--- a/dashboard/src/api/schemas/gate-keepers.test.ts
+++ b/dashboard/src/api/schemas/gate-keepers.test.ts
@@ -55,11 +55,17 @@ function expectDrift(value: unknown): GateKeepersSchemaDriftError {
   return error
 }
 
+// The listing half of the envelope. Present on every valid fixture so a
+// drift assertion below fails for the reason it names, not for a missing
+// field. masc#29077.
+const listingWire = (total: number) => ({ total, limit: 200, truncated: false })
+
 describe('decodeGateKeepers', () => {
   it('decodes the current detailed wire shape into concrete product values', () => {
     const data = Effect.runSync(decodeGateKeepers({
       count: 1,
       keepers: [keeperWire()],
+      ...listingWire(1),
     }))
 
     expect(data).toEqual({
@@ -69,6 +75,7 @@ describe('decodeGateKeepers', () => {
         status: 'running',
       }],
       directoryIssues: [],
+      listing: { total: 1, limit: 200, truncated: false },
     })
   })
 
@@ -76,6 +83,7 @@ describe('decodeGateKeepers', () => {
     const data = Effect.runSync(decodeGateKeepers({
       count: 2,
       keepers: [keeperWire(), issueWire()],
+      ...listingWire(2),
     }))
 
     expect(data.keepers.map(keeper => keeper.name)).toEqual(['planner'])
@@ -99,6 +107,7 @@ describe('decodeGateKeepers', () => {
         autoboot_enabled: false,
         proactive_enabled: false,
       }],
+      ...listingWire(1),
     }))
 
     expect(data).toEqual({
@@ -107,6 +116,7 @@ describe('decodeGateKeepers', () => {
         keeperName: 'broken',
         message: 'invalid keeper config',
       }],
+      listing: { total: 1, limit: 200, truncated: false },
     })
   })
 
@@ -115,30 +125,47 @@ describe('decodeGateKeepers', () => {
     const data = Effect.runSync(decodeGateKeepers({
       count: 1,
       keepers: [{ ...row, agent_name: row.name }],
+      ...listingWire(1),
     }))
 
     expect(data.keepers[0]?.runtimeLabel).toBe('')
   })
 
   it('accepts an explicit empty directory', () => {
-    expect(Effect.runSync(decodeGateKeepers({ count: 0, keepers: [] })))
-      .toEqual({ keepers: [], directoryIssues: [] })
+    expect(Effect.runSync(decodeGateKeepers({
+      count: 0,
+      keepers: [],
+      ...listingWire(0),
+    }))).toEqual({
+      keepers: [],
+      directoryIssues: [],
+      listing: { total: 0, limit: 200, truncated: false },
+    })
   })
 
   it.each([
     ['missing outer fields', {}],
     ['non-object payload', null],
-    ['malformed row', { count: 1, keepers: [{ name: 'orphan' }] }],
+    ['malformed row', { count: 1, keepers: [{ name: 'orphan' }], ...listingWire(1) }],
     ['excess row property', {
       count: 1,
       keepers: [{ ...keeperWire(), unexpected: true }],
+      ...listingWire(1),
+    }],
+    ['a response without the listing fields', {
+      count: 1,
+      keepers: [keeperWire()],
     }],
   ])('rejects %s instead of defaulting or dropping data', (_name, value) => {
     expectDrift(value)
   })
 
   it('rejects a count that disagrees with the returned rows', () => {
-    const error = expectDrift({ count: 2, keepers: [keeperWire()] })
+    const error = expectDrift({
+      count: 2,
+      keepers: [keeperWire()],
+      ...listingWire(2),
+    })
     expect(error.message).toContain('count')
     expect(error.message).toContain('keepers.length')
   })
@@ -148,6 +175,7 @@ describe('decodeGateKeepers', () => {
     const error = expectDrift({
       count: 1,
       keepers: [{ ...row, meta: { ...row.meta, name: 'other' } }],
+      ...listingWire(1),
     })
     expect(error.message).toContain('keepers.0.meta.name')
   })
@@ -163,6 +191,7 @@ describe('decodeGateKeepers', () => {
           keeper: 'other',
         },
       }],
+      ...listingWire(1),
     })
     expect(error.message).toContain('effective_meta_error.keeper')
   })

--- a/dashboard/src/api/schemas/gate-keepers.ts
+++ b/dashboard/src/api/schemas/gate-keepers.ts
@@ -69,6 +69,13 @@ const GateKeeperEntryWireSchema = Schema.Union(
 const GateKeepersWireSchema = Schema.Struct({
   count: Schema.NonNegativeInt,
   keepers: Schema.Array(GateKeeperEntryWireSchema),
+  // Listing truth: `total` counts keepers known before `limit` was applied, so
+  // a short page is distinguishable from a complete one. Decoding is strict
+  // (`onExcessProperty: 'error'`), so these are required, not optional —
+  // a server that stops sending them is drift, not a silent downgrade.
+  total: Schema.NonNegativeInt,
+  limit: Schema.NonNegativeInt,
+  truncated: Schema.Boolean,
 })
 
 type GateKeeperEntryWire = Schema.Schema.Type<
@@ -138,9 +145,22 @@ export interface GateKeeperDirectoryIssue {
   readonly message: string
 }
 
+/** What the server actually answered, as opposed to what it knows.
+    Kept as its own record so a consumer that renders a keeper count has to
+    reach for the page size and the total together. */
+export interface KeeperListing {
+  /** Keepers known to the server, counted before `limit` was applied. */
+  readonly total: number
+  /** The limit the server applied to this response. */
+  readonly limit: number
+  /** True when `limit` dropped keepers from the answer. */
+  readonly truncated: boolean
+}
+
 export interface GateKeepersData {
   readonly keepers: readonly GateKeeper[]
   readonly directoryIssues: readonly GateKeeperDirectoryIssue[]
+  readonly listing: KeeperListing
 }
 
 export class GateKeepersSchemaDriftError extends Data.TaggedError(
@@ -196,6 +216,11 @@ function toGateKeepersData(wire: GateKeepersWire): GateKeepersData {
   return {
     keepers,
     directoryIssues,
+    listing: {
+      total: wire.total,
+      limit: wire.limit,
+      truncated: wire.truncated,
+    },
   }
 }
 

--- a/dashboard/src/components/connector-keeper-matrix.test.ts
+++ b/dashboard/src/components/connector-keeper-matrix.test.ts
@@ -11,7 +11,7 @@ import {
   type MatrixRow,
 } from './connector-keeper-matrix'
 import type { GateConnectorInfo } from '../api/gate'
-import type { GateKeeper } from '../api/gate-keepers'
+import type { GateKeeper, KeeperListing } from '../api/gate-keepers'
 
 const mkConnector = (id: string, overrides: Partial<GateConnectorInfo> = {}): GateConnectorInfo => ({
   connector_id: id,
@@ -30,16 +30,24 @@ const mkKeeper = (name: string): GateKeeper => ({
   status: 'idle',
 })
 
+// The server answered with everything it knows. Tests that care about
+// truncation pass their own listing.
+const whole = (keepers: readonly GateKeeper[]): KeeperListing => ({
+  total: keepers.length,
+  limit: 200,
+  truncated: false,
+})
+
 describe('deriveMatrix', () => {
   it('returns 4 columns in known order', () => {
-    const m = deriveMatrix([], [])
+    const m = deriveMatrix([], [], whole([]))
     expect(m.columns).toEqual(['discord', 'imessage', 'slack', 'telegram'])
   })
 
   it('cell is na when keeper exists but connector is offline', () => {
     const connectors = [mkConnector('discord', { available: false })]
     const keepers = [mkKeeper('alpha')]
-    const m = deriveMatrix(connectors, keepers)
+    const m = deriveMatrix(connectors, keepers, whole(keepers))
     const alphaRow = m.rows.find(r => r.keeperName === 'alpha')!
     const discordCell = alphaRow.cells.find(c => c.connectorId === 'discord')!
     expect(discordCell.state).toBe('na')
@@ -48,7 +56,7 @@ describe('deriveMatrix', () => {
   it('cell is unbound when connector is up but no binding exists', () => {
     const connectors = [mkConnector('discord', { available: true })]
     const keepers = [mkKeeper('alpha')]
-    const m = deriveMatrix(connectors, keepers)
+    const m = deriveMatrix(connectors, keepers, whole(keepers))
     const alphaRow = m.rows.find(r => r.keeperName === 'alpha')!
     const discordCell = alphaRow.cells.find(c => c.connectorId === 'discord')!
     expect(discordCell.state).toBe('unbound')
@@ -62,7 +70,7 @@ describe('deriveMatrix', () => {
         { channel_id: 'c2', keeper_name: 'alpha' },
       ] as never,
     })]
-    const m = deriveMatrix(connectors, [mkKeeper('alpha')])
+    const m = deriveMatrix(connectors, [mkKeeper('alpha')], whole([mkKeeper('alpha')]))
     const firstRow = m.rows[0]!
     const cell = firstRow.cells.find(c => c.connectorId === 'discord')!
     expect(cell.state).toBe('bound')
@@ -74,7 +82,7 @@ describe('deriveMatrix', () => {
       available: true,
       configured_bindings: [{ channel_id: 'c1', keeper_name: 'ghost' }] as never,
     })]
-    const m = deriveMatrix(connectors, [mkKeeper('alpha')])
+    const m = deriveMatrix(connectors, [mkKeeper('alpha')], whole([mkKeeper('alpha')]))
     expect(m.rows.some(r => r.keeperName === 'ghost' && !r.known)).toBe(true)
     const ghostRow = m.rows.find(r => r.keeperName === 'ghost')!
     const slackCell = ghostRow.cells.find(c => c.connectorId === 'slack')!
@@ -89,7 +97,7 @@ describe('deriveMatrix', () => {
       }),
       mkConnector('slack', { available: false }),
     ]
-    const m = deriveMatrix(connectors, [mkKeeper('alpha'), mkKeeper('beta')])
+    const m = deriveMatrix(connectors, [mkKeeper('alpha'), mkKeeper('beta')], whole([mkKeeper('alpha'), mkKeeper('beta')]))
     expect(m.totals.knownKeepers).toBe(2)
     expect(m.totals.liveConnectors).toBe(1)
     expect(m.totals.totalBindings).toBe(1)
@@ -108,7 +116,7 @@ describe('ConnectorKeeperMatrix', () => {
   })
 
   it('renders empty-state copy when no keepers exist', () => {
-    const matrix: MatrixData = deriveMatrix([], [])
+    const matrix: MatrixData = deriveMatrix([], [], whole([]))
     render(html`<${ConnectorKeeperMatrix} matrix=${matrix} />`, container)
     expect(container.textContent).toContain('No keepers yet')
   })
@@ -118,7 +126,7 @@ describe('ConnectorKeeperMatrix', () => {
       mkConnector('discord', { available: true, configured_bindings: [{ channel_id: 'c1', keeper_name: 'alpha' }] as never }),
     ]
     const keepers = [mkKeeper('alpha'), mkKeeper('beta')]
-    const matrix = deriveMatrix(connectors, keepers)
+    const matrix = deriveMatrix(connectors, keepers, whole(keepers))
     render(html`<${ConnectorKeeperMatrix} matrix=${matrix} />`, container)
     expect(container.querySelector('.v2-connector-keeper-matrix')).not.toBeNull()
     const cells = container.querySelectorAll('[data-matrix-cell]')
@@ -130,7 +138,7 @@ describe('ConnectorKeeperMatrix', () => {
   })
 
   it('renders a Coverage header in the trailing column', () => {
-    const matrix = deriveMatrix([mkConnector('discord', { available: true })], [mkKeeper('alpha')])
+    const matrix = deriveMatrix([mkConnector('discord', { available: true })], [mkKeeper('alpha')], whole([mkKeeper('alpha')]))
     render(html`<${ConnectorKeeperMatrix} matrix=${matrix} />`, container)
     expect(container.querySelector('[data-matrix-coverage-header]')).toBeTruthy()
   })
@@ -141,7 +149,7 @@ describe('ConnectorKeeperMatrix', () => {
       mkConnector('slack', { available: true }),
     ]
     const keepers = [mkKeeper('alpha'), mkKeeper('beta')]
-    const matrix = deriveMatrix(connectors, keepers)
+    const matrix = deriveMatrix(connectors, keepers, whole(keepers))
     render(html`<${ConnectorKeeperMatrix} matrix=${matrix} />`, container)
     const chips = container.querySelectorAll('[data-matrix-row-coverage]')
     // One chip per keeper row.
@@ -168,7 +176,7 @@ describe('ConnectorKeeperMatrix', () => {
       ] as never }),
     ]
     const keepers = [mkKeeper('alpha'), mkKeeper('beta')]
-    const matrix = deriveMatrix(connectors, keepers)
+    const matrix = deriveMatrix(connectors, keepers, whole(keepers))
     render(html`<${ConnectorKeeperMatrix} matrix=${matrix} />`, container)
     // Footer label ("Totals →") is visible.
     expect(container.querySelector('[data-matrix-column-totals-label]')).toBeTruthy()
@@ -195,7 +203,7 @@ describe('ConnectorKeeperMatrix', () => {
       ] as never }),
     ]
     const keepers = [mkKeeper('alpha')]
-    const matrix = deriveMatrix(connectors, keepers)
+    const matrix = deriveMatrix(connectors, keepers, whole(keepers))
     render(html`<${ConnectorKeeperMatrix} matrix=${matrix} />`, container)
     const cells = container.querySelectorAll('[data-matrix-column-total-bound]')
     const discordCell = cells[0] as HTMLElement
@@ -206,7 +214,7 @@ describe('ConnectorKeeperMatrix', () => {
   it('column totals footer dashes empty columns (no bound, no unbound, no unknown)', () => {
     // imessage + telegram have 0 bindings and are offline → na cells only.
     // The totals cell for those columns shows "—" not "0".
-    const matrix = deriveMatrix([mkConnector('discord', { available: true })], [mkKeeper('alpha')])
+    const matrix = deriveMatrix([mkConnector('discord', { available: true })], [mkKeeper('alpha')], whole([mkKeeper('alpha')]))
     render(html`<${ConnectorKeeperMatrix} matrix=${matrix} />`, container)
     const cells = container.querySelectorAll('[data-matrix-column-total-bound]')
     // imessage is col 1 — offline, no bindings → all na → dashed.
@@ -256,7 +264,7 @@ describe('summarizeMatrixColumn (pure)', () => {
       mkConnector('slack', { available: true }),
     ]
     const keepers = [mkKeeper('alpha'), mkKeeper('beta')]
-    const matrix = deriveMatrix(connectors, keepers)
+    const matrix = deriveMatrix(connectors, keepers, whole(keepers))
     // Discord column (idx 0): alpha=bound, beta=unbound, gamma=unknown
     const discordCounts = summarizeMatrixColumn(matrix, 0)
     expect(discordCounts.bound).toBe(1)
@@ -266,8 +274,51 @@ describe('summarizeMatrixColumn (pure)', () => {
   })
 
   it('handles an out-of-range column index (returns all-zero, no crash)', () => {
-    const matrix = deriveMatrix([mkConnector('discord', { available: true })], [mkKeeper('alpha')])
+    const matrix = deriveMatrix([mkConnector('discord', { available: true })], [mkKeeper('alpha')], whole([mkKeeper('alpha')]))
     // columnIdx 99 → no cell at that index in any row
     expect(summarizeMatrixColumn(matrix, 99)).toEqual({ bound: 0, unbound: 0, na: 0, unknown: 0 })
+  })
+})
+
+describe('ConnectorKeeperMatrix — truncated directory', () => {
+  let host: HTMLDivElement
+
+  beforeEach(() => {
+    host = document.createElement('div')
+    document.body.appendChild(host)
+  })
+
+  afterEach(() => {
+    render(null, host)
+    host.remove()
+  })
+
+  it('says so when the grid is drawn from a partial keeper list', () => {
+    // masc#29077: the grid used to render 50 of 129 keepers with no sign that
+    // 79 were missing, and the bindings pointing at those 79 showed up as
+    // "unknown" keepers instead.
+    const matrix = deriveMatrix(
+      [mkConnector('discord', { available: true })],
+      [mkKeeper('alpha')],
+      { total: 129, limit: 50, truncated: true },
+    )
+    render(html`<${ConnectorKeeperMatrix} matrix=${matrix} />`, host)
+
+    const notice = host.querySelector('[data-testid="keeper-matrix-truncated"]')
+    expect(notice).not.toBeNull()
+    expect(notice?.textContent).toContain('129')
+    expect(notice?.textContent).toContain('50')
+  })
+
+  it('stays quiet when the list is complete', () => {
+    const keepers = [mkKeeper('alpha')]
+    const matrix = deriveMatrix(
+      [mkConnector('discord', { available: true })],
+      keepers,
+      whole(keepers),
+    )
+    render(html`<${ConnectorKeeperMatrix} matrix=${matrix} />`, host)
+
+    expect(host.querySelector('[data-testid="keeper-matrix-truncated"]')).toBeNull()
   })
 })

--- a/dashboard/src/components/connector-keeper-matrix.ts
+++ b/dashboard/src/components/connector-keeper-matrix.ts
@@ -18,7 +18,7 @@
 
 import { html } from 'htm/preact'
 import type { GateConnectorInfo } from '../api/gate'
-import type { GateKeeper } from '../api/gate-keepers'
+import type { GateKeeper, KeeperListing } from '../api/gate-keepers'
 import {
   CONNECTOR_DISPLAY_NAMES,
   KNOWN_CONNECTOR_IDS,
@@ -54,6 +54,10 @@ export interface MatrixData {
     totalBindings: number
     liveConnectors: number
   }
+  /** How much of the keeper directory this grid is drawn from. Required, not
+      optional: a grid rendered from a truncated list must say so, and an
+      optional field would let a caller drop it and keep the old silence. */
+  listing: KeeperListing
 }
 
 /** Per-row or per-column state breakdown. Airflow / GitHub Actions
@@ -95,6 +99,7 @@ function findConnector(connectors: GateConnectorInfo[], id: string): GateConnect
 export function deriveMatrix(
   connectors: GateConnectorInfo[],
   keepers: readonly GateKeeper[],
+  listing: KeeperListing,
 ): MatrixData {
   const columns: KnownConnectorId[] = [...KNOWN_CONNECTOR_IDS]
   const knownKeeperNames = new Set(keepers.map(k => k.name))
@@ -143,6 +148,7 @@ export function deriveMatrix(
   return {
     columns,
     rows,
+    listing,
     totals: {
       knownKeepers: keepers.length,
       unknownKeepers: unknownKeeperNames.size,
@@ -244,6 +250,18 @@ export function ConnectorKeeperMatrix({ matrix }: { matrix: MatrixData }) {
               ? html`· <span class="text-[var(--color-status-warn)]">${matrix.totals.unknownKeepers} unknown</span>`
               : null}
           </p>
+          ${matrix.listing.truncated
+            ? html`
+                <p
+                  class="mt-1 text-3xs text-[var(--color-status-warn)]"
+                  data-testid="keeper-matrix-truncated"
+                >
+                  ${matrix.listing.total}개 중 ${matrix.listing.limit}개만
+                  받았어요 — 나머지 ${matrix.listing.total - matrix.listing.limit}개는
+                  이 표에 없고, 그 키퍼에 걸린 바인딩은 unknown으로 보여요.
+                </p>
+              `
+            : null}
         </div>
         <div class="text-3xs text-[var(--color-fg-disabled)]">
           <span class="mr-2"><span class="mr-1 inline-block h-1.5 w-1.5 rounded-full bg-[var(--ok-10)]" aria-hidden="true"></span>bound</span>

--- a/dashboard/src/components/connector-quick-bind.test.ts
+++ b/dashboard/src/components/connector-quick-bind.test.ts
@@ -7,13 +7,16 @@ import {
   resetQuickBindState,
   channelIdPlaceholder,
 } from './connector-quick-bind'
-import type { GateKeeper } from '../api/gate-keepers'
+import type { GateKeeper, KeeperListing } from '../api/gate-keepers'
 
 const mkKeeper = (name: string): GateKeeper => ({
   name,
   runtimeLabel: '',
   status: 'idle',
 })
+
+// Default: the server served the whole directory.
+const WHOLE: KeeperListing = { total: 2, limit: 200, truncated: false }
 
 const flushUi = async () => {
   for (let i = 0; i < 4; i++) await Promise.resolve()
@@ -32,12 +35,12 @@ describe('QuickBindForm', () => {
   })
 
   it('renders nothing when there are no keepers', () => {
-    render(html`<${QuickBindForm} connectorId="discord" keepers=${[]} />`, container)
+    render(html`<${QuickBindForm} connectorId="discord" keepers=${[]} listing=${WHOLE} />`, container)
     expect(container.querySelector('[data-quick-bind]')).toBeNull()
   })
 
   it('renders a channel input + keeper select + Bind button', () => {
-    render(html`<${QuickBindForm} connectorId="discord" keepers=${[mkKeeper('kpr-a'), mkKeeper('kpr-b')]} />`, container)
+    render(html`<${QuickBindForm} connectorId="discord" keepers=${[mkKeeper('kpr-a'), mkKeeper('kpr-b')]} listing=${WHOLE} />`, container)
     expect(container.querySelector('.v2-connector-quick-bind')).not.toBeNull()
     const form = container.querySelector('[data-quick-bind="discord"]')!
     expect(form.querySelector('input[placeholder*="1234567890"]')).toBeTruthy()
@@ -50,7 +53,7 @@ describe('QuickBindForm', () => {
   })
 
   it('Bind button disabled while channel ID is empty', () => {
-    render(html`<${QuickBindForm} connectorId="discord" keepers=${[mkKeeper('kpr-a')]} />`, container)
+    render(html`<${QuickBindForm} connectorId="discord" keepers=${[mkKeeper('kpr-a')]} listing=${WHOLE} />`, container)
     const form = container.querySelector('[data-quick-bind="discord"]')!
     const submit = Array.from(form.querySelectorAll('button')).find(b => b.textContent?.includes('Bind')) as HTMLButtonElement
     expect(submit.disabled).toBe(true)
@@ -60,7 +63,7 @@ describe('QuickBindForm', () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(JSON.stringify({ ok: true }), { status: 200 }),
     )
-    render(html`<${QuickBindForm} connectorId="discord" keepers=${[mkKeeper('kpr-a')]} />`, container)
+    render(html`<${QuickBindForm} connectorId="discord" keepers=${[mkKeeper('kpr-a')]} listing=${WHOLE} />`, container)
     const form = container.querySelector('[data-quick-bind="discord"]')!
     const input = form.querySelector('input') as HTMLInputElement
     input.value = '1234567890'
@@ -85,7 +88,7 @@ describe('QuickBindForm', () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(JSON.stringify({ ok: true }), { status: 200 }),
     )
-    render(html`<${QuickBindForm} connectorId="slack" keepers=${[mkKeeper('kpr-a')]} />`, container)
+    render(html`<${QuickBindForm} connectorId="slack" keepers=${[mkKeeper('kpr-a')]} listing=${WHOLE} />`, container)
     const form = container.querySelector('[data-quick-bind="slack"]')!
     const input = form.querySelector('input') as HTMLInputElement
     input.value = 'C09TK9L4DV4'
@@ -113,7 +116,7 @@ describe('QuickBindForm', () => {
       if (String(url).includes('/api/v1/gate/connector/bind')) bindRequested = true
       return Promise.resolve(new Response(JSON.stringify({ error: 'unknown keeper' }), { status: 404 }))
     })
-    render(html`<${QuickBindForm} connectorId="discord" keepers=${[mkKeeper('kpr-a')]} />`, container)
+    render(html`<${QuickBindForm} connectorId="discord" keepers=${[mkKeeper('kpr-a')]} listing=${WHOLE} />`, container)
     const form = container.querySelector('[data-quick-bind="discord"]')!
     const input = form.querySelector('input') as HTMLInputElement
     input.value = '1234567890123456789'
@@ -141,7 +144,7 @@ describe('QuickBindForm', () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(JSON.stringify({ ok: true }), { status: 200 }),
     )
-    render(html`<${QuickBindForm} connectorId="discord" keepers=${[mkKeeper('kpr-a')]} />`, container)
+    render(html`<${QuickBindForm} connectorId="discord" keepers=${[mkKeeper('kpr-a')]} listing=${WHOLE} />`, container)
     const form = container.querySelector('[data-quick-bind="discord"]')!
     const input = form.querySelector('input') as HTMLInputElement
     input.value = '1234567890123456789'
@@ -162,7 +165,7 @@ describe('QuickBindForm', () => {
       if (String(url).includes('/api/v1/gate/connector/bind')) bindPosts += 1
       return new Promise<Response>(resolve => { deferred.push(resolve) })
     })
-    render(html`<${QuickBindForm} connectorId="discord" keepers=${[mkKeeper('kpr-a')]} />`, container)
+    render(html`<${QuickBindForm} connectorId="discord" keepers=${[mkKeeper('kpr-a')]} listing=${WHOLE} />`, container)
     const form = container.querySelector('[data-quick-bind="discord"]')!
     const input = form.querySelector('input') as HTMLInputElement
     input.value = '1234567890123456789'
@@ -182,7 +185,7 @@ describe('QuickBindForm', () => {
   })
 
   it('renders the connector-specific placeholder (Slack shows C-prefix example, not Discord snowflake)', () => {
-    render(html`<${QuickBindForm} connectorId="slack" keepers=${[mkKeeper('kpr-a')]} />`, container)
+    render(html`<${QuickBindForm} connectorId="slack" keepers=${[mkKeeper('kpr-a')]} listing=${WHOLE} />`, container)
     const input = container.querySelector('[data-quick-bind="slack"] input') as HTMLInputElement
     const placeholder = input.getAttribute('placeholder') ?? ''
     expect(placeholder).toContain('C0123ABCD')
@@ -217,5 +220,50 @@ describe('channelIdPlaceholder', () => {
 
   it('unknown connector falls through to a neutral example', () => {
     expect(channelIdPlaceholder('xyz-unknown')).toContain('1234567890')
+  })
+})
+
+describe('QuickBindForm — truncated keeper directory', () => {
+  let container: HTMLElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    resetQuickBindState()
+  })
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+  })
+
+  it('warns that the dropdown is not the whole directory', () => {
+    // masc#29077: with 129 keepers the dropdown listed the alphabetically
+    // first 50 — almost all throwaway benchmark keepers — so the operational
+    // ones could not be selected at all, and nothing on screen said why.
+    render(
+      html`<${QuickBindForm}
+        connectorId="discord"
+        keepers=${[mkKeeper('kpr-a')]}
+        listing=${{ total: 129, limit: 50, truncated: true }}
+      />`,
+      container,
+    )
+
+    const notice = container.querySelector('[data-testid="quick-bind-truncated"]')
+    expect(notice).not.toBeNull()
+    expect(notice?.textContent).toContain('129')
+    expect(notice?.textContent).toContain('50')
+  })
+
+  it('stays quiet when every keeper is selectable', () => {
+    render(
+      html`<${QuickBindForm}
+        connectorId="discord"
+        keepers=${[mkKeeper('kpr-a')]}
+        listing=${WHOLE}
+      />`,
+      container,
+    )
+
+    expect(container.querySelector('[data-testid="quick-bind-truncated"]')).toBeNull()
   })
 })

--- a/dashboard/src/components/connector-quick-bind.ts
+++ b/dashboard/src/components/connector-quick-bind.ts
@@ -11,7 +11,7 @@
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
-import type { GateKeeper } from '../api/gate-keepers'
+import type { GateKeeper, KeeperListing } from '../api/gate-keepers'
 import { ActionButton } from './common/button'
 import { TextInput } from './common/input'
 import { Select } from './common/select'
@@ -85,9 +85,10 @@ async function submit(connectorId: string, entry: FormEntry) {
   setEntry(connectorId, ok ? { channelId: '', submitting: false } : { submitting: false })
 }
 
-export function QuickBindForm({ connectorId, keepers }: {
+export function QuickBindForm({ connectorId, keepers, listing }: {
   connectorId: string
   keepers: readonly GateKeeper[]
+  listing: KeeperListing
 }) {
   if (keepers.length === 0) return null
   const entry = getEntry(connectorId, keepers)
@@ -148,6 +149,18 @@ export function QuickBindForm({ connectorId, keepers }: {
       >
         ${entry.submitting ? '연결 중...' : '🔗 Bind'}
       <//>
+      ${listing.truncated
+        ? html`
+            <p
+              class="w-full text-3xs text-[var(--color-status-warn)]"
+              data-testid="quick-bind-truncated"
+            >
+              키퍼 ${listing.total}개 중 ${listing.limit}개만 목록에 있어요 —
+              이름순으로 뒤쪽 ${listing.total - listing.limit}개는 여기서 고를
+              수 없어요.
+            </p>
+          `
+        : null}
     </div>
   `
 }

--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -176,6 +176,9 @@ function sampleKeepersResponse(overrides?: Partial<Record<string, unknown>>) {
       },
     ],
     directoryIssues: [],
+    // The panel reads this to decide whether to warn that the keeper list is
+    // a page rather than the directory. masc#29077.
+    listing: { total: 2, limit: 200, truncated: false },
     ...overrides,
   }
 }
@@ -966,6 +969,7 @@ describe('ConnectorStatusPanel', () => {
     const fetchGateKeepers = vi.fn<() => Promise<unknown>>().mockResolvedValue({
       keepers: [],
       directoryIssues: [],
+      listing: { total: 0, limit: 200, truncated: false },
     })
 
     const { ConnectorStatusPanel } = await loadComponentWithApi({

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -22,6 +22,7 @@ import {
 import {
   fetchGateKeepers,
   type GateKeeper,
+  type KeeperListing,
 } from '../api/gate-keepers'
 import { dashboardRuntime } from '../api/effect-http'
 import {
@@ -189,15 +190,24 @@ type ConnectorStatusSnapshot = {
   gate: GateStatusData | null
   connectors: GateConnectorsData | null
   keepers: readonly GateKeeper[]
+  // How much of the directory `keepers` is. Carried next to the rows so the
+  // surfaces that render a keeper count cannot report the page size as the
+  // whole set — masc#29077.
+  keeperListing: KeeperListing
   gateError: string | null
   connectorError: string | null
   keeperError: string | null
 }
 
+// Nothing fetched yet: zero known, zero served, nothing dropped. `truncated`
+// false here is honest — an empty answer is not a cut-off one.
+const EMPTY_KEEPER_LISTING: KeeperListing = { total: 0, limit: 0, truncated: false }
+
 const EMPTY_SNAPSHOT: ConnectorStatusSnapshot = {
   gate: null,
   connectors: null,
   keepers: [],
+  keeperListing: EMPTY_KEEPER_LISTING,
   gateError: null,
   connectorError: null,
   keeperError: null,
@@ -211,6 +221,7 @@ async function refresh() {
       gate: previous?.gate ?? null,
       connectors: previous?.connectors ?? null,
       keepers: previous?.keepers ?? [],
+      keeperListing: previous?.keeperListing ?? EMPTY_KEEPER_LISTING,
       gateError: null,
       connectorError: null,
       keeperError: null,
@@ -236,6 +247,7 @@ async function refresh() {
 
     if (keeperResult.status === 'fulfilled') {
       next.keepers = keeperResult.value.keepers
+      next.keeperListing = keeperResult.value.listing
       next.keeperError = keeperResult.value.directoryIssues.length === 0
         ? null
         : keeperResult.value.directoryIssues
@@ -243,6 +255,7 @@ async function refresh() {
             .join('; ')
     } else {
       next.keepers = []
+      next.keeperListing = EMPTY_KEEPER_LISTING
       next.keeperError = keeperResult.reason instanceof Error ? keeperResult.reason.message : 'fetch failed'
     }
 
@@ -582,6 +595,7 @@ function ConnectorLivePanel({
   connector,
   gate,
   keepers,
+  keeperListing,
   connectorError,
   keeperDirectoryError,
   loading,
@@ -589,6 +603,7 @@ function ConnectorLivePanel({
   connector: GateConnectorInfo | null
   gate: GateStatusData | null
   keepers: readonly GateKeeper[]
+  keeperListing: KeeperListing
   connectorError: string | null
   keeperDirectoryError: string | null
   loading: boolean
@@ -828,7 +843,7 @@ function ConnectorLivePanel({
       <${StartupCheckBanner} connectorId=${connectorId} sidecarUp=${connector?.available === true} />
 
       ${connector?.available === true && keepers.length > 0
-        ? html`<${QuickBindForm} connectorId=${connectorId} keepers=${keepers} />`
+        ? html`<${QuickBindForm} connectorId=${connectorId} keepers=${keepers} listing=${keeperListing} />`
         : null}
 
       <${ConnectorFlowSection} connector=${connector} gate=${gate} />
@@ -2234,6 +2249,7 @@ export function ConnectorStatusPanel() {
                     connector=${focusedConnector}
                     gate=${d}
                     keepers=${snapshot.keepers}
+                    keeperListing=${snapshot.keeperListing}
                     connectorError=${snapshot.connectorError}
                     keeperDirectoryError=${snapshot.keeperError}
                     loading=${loading}
@@ -2241,10 +2257,10 @@ export function ConnectorStatusPanel() {
                 </${SurfaceCard}>
                 <${DisclosurePanel}
                   title="키퍼 매트릭스"
-                  badge=${html`<span>키퍼 ${snapshot.keepers.length}</span>`}
+                  badge=${html`<span>키퍼 ${snapshot.keepers.length}${snapshot.keeperListing.truncated ? ` / ${snapshot.keeperListing.total}` : ''}</span>`}
                   testId="connector-matrix-disclosure"
                 >
-                  <${ConnectorKeeperMatrix} matrix=${deriveMatrix(allConnectors, snapshot.keepers)} />
+                  <${ConnectorKeeperMatrix} matrix=${deriveMatrix(allConnectors, snapshot.keepers, snapshot.keeperListing)} />
                 <//>
                 <${ConnectorPathsStrip} />
                 <${GateAnalyticsSection} gate=${d} gateError=${snapshot.gateError} />
@@ -2259,6 +2275,7 @@ export function ConnectorStatusPanel() {
               connector=${focusedConnector}
               gate=${d}
               keepers=${snapshot.keepers}
+              keeperListing=${snapshot.keeperListing}
               connectorError=${snapshot.connectorError}
               keeperDirectoryError=${snapshot.keeperError}
               loading=${loading}

--- a/dashboard/src/components/fsm-hub.integration.test.ts
+++ b/dashboard/src/components/fsm-hub.integration.test.ts
@@ -110,6 +110,7 @@ const REAL_GATE_KEEPERS_SHAPE: GateKeepersData = {
     { name: 'masc-improver', runtimeLabel: 'keeper-masc-improver-agent', status: 'active' },
   ],
   directoryIssues: [],
+  listing: { total: 5, limit: 200, truncated: false },
 }
 
 describe('FSM Hub integration — API response shape', () => {

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -331,13 +331,20 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_keeper_list";
-    description = "List known keepers from persisted keeper metadata.";
+    description =
+      "List known keepers from persisted keeper metadata. The response carries \
+       total (keepers known before limit), limit (the value applied) and \
+       truncated, so a short answer is distinguishable from a complete one.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("limit", `Assoc [
           ("type", `String "integer");
-          ("description", `String "Max keepers to return (default: 50).");
+          ("description",
+           `String
+             "Max keepers to return (default: 50). Names are sorted and cut \
+              from the end, so a low limit hides whatever sorts last; check \
+              truncated in the response.");
         ]);
         ("detailed", `Assoc [
           ("type", `String "boolean");

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -26,32 +26,53 @@ let keeper_list_body ~(config : Workspace.config) args : tool_result =
           Keeper_registry.all ~base_path:config.base_path ()
           |> List.map (fun (entry : Keeper_registry.registry_entry) -> entry.name)
         in
-        let names =
+        let all_names =
           registry_names @ keeper_names config
           |> List.map String.trim
           |> List.filter (fun name -> not (String.equal name ""))
           |> List.sort_uniq String.compare
-          |> take limit
         in
+        (* [total] is measured before [limit] is applied, so a caller can tell
+           a short answer from a complete one. Without it [count] reports the
+           post-truncation size and reads as "that is all of them" — the shape
+           behind masc#29077, where a 129-keeper workspace answered 50 and the
+           operational keepers, sorting after ~90 benchmark ones, all fell off
+           the end. *)
+        let total = List.length all_names in
+        let names = take limit all_names in
+        let truncated = List.length names < total in
         let rows =
           names
           |> List.filter_map (fun name ->
                keeper_list_row_json ~runtime_class:"keeper" config name)
         in
+        (* [truncated] answers "did [limit] drop names", nothing else. [count]
+           can still be below [min total limit] in the detailed shape when a
+           listed name has no readable metadata and [keeper_list_row_json]
+           yields no row. *)
+        let listing =
+          [
+            ("total", `Int total);
+            ("limit", `Int limit);
+            ("truncated", `Bool truncated);
+          ]
+        in
         let json =
           if not detailed then
             `Assoc
-              [
-                ("count", `Int (List.length names));
-                ("keepers", `List (List.map (fun name -> `String name) names));
-                ("items", `List rows);
-              ]
+              ([
+                 ("count", `Int (List.length names));
+                 ("keepers", `List (List.map (fun name -> `String name) names));
+                 ("items", `List rows);
+               ]
+              @ listing)
           else
             `Assoc
-              [
-                ("count", `Int (List.length rows));
-                ("keepers", `List rows);
-              ]
+              ([
+                 ("count", `Int (List.length rows));
+                 ("keepers", `List rows);
+               ]
+              @ listing)
         in
         json)
   in

--- a/lib/server/server_routes_http_routes_channel_gate.ml
+++ b/lib/server/server_routes_http_routes_channel_gate.ml
@@ -322,13 +322,23 @@ let respond_keeper_tool_json ~sw ~clock state request reqd ~tool_name ~args =
       respond_json_value_with_cors ~status:`Service_unavailable request reqd
         (Channel_gate.error_json "keeper dispatch unavailable")
 
-(** GET /api/v1/gate/keepers?limit=100&detailed=true
+(* Upper bound on rows in one keeper-list response, and the default. One
+   constant so the two cannot drift: before masc#29077 the default was 100
+   while the clamp was 200, so an unparameterised caller was capped below what
+   the route was willing to serve, and neither number appeared in the answer.
+   The response carries [total] and [truncated], so a workspace that outgrows
+   this bound says so instead of returning a short list that looks complete. *)
+let keeper_list_max_limit = 200
 
-    Authenticated keeper discovery for channel-side connectors. *)
+(** GET /api/v1/gate/keepers?limit=200&detailed=true
+
+    Authenticated keeper discovery for channel-side connectors. [limit] only
+    narrows: it is clamped to [1, keeper_list_max_limit] and defaults to the
+    bound. *)
 let handle_gate_keepers ~sw ~clock state request reqd =
   let limit =
-    int_query_param request "limit" ~default:100
-    |> fun value -> max 1 (min 200 value)
+    int_query_param request "limit" ~default:keeper_list_max_limit
+    |> fun value -> max 1 (min keeper_list_max_limit value)
   in
   let detailed = bool_query_param request "detailed" ~default:true in
   let args =

--- a/test/dune
+++ b/test/dune
@@ -1609,6 +1609,7 @@
 ; add one (include stanzas/test_name.inc) line below,
 ; sorted alphabetically.
 
+(include stanzas/test_keeper_list_truncation.inc)
 (include stanzas/test_keeper_wire_terminal.inc)
 (include stanzas/test_agent_transport_vocabulary.inc)
 (include stanzas/test_agent_api_query_params.inc)

--- a/test/stanzas/test_keeper_list_truncation.inc
+++ b/test/stanzas/test_keeper_list_truncation.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_list_truncation)
+ (modules test_keeper_list_truncation)
+ (libraries masc_test_deps))

--- a/test/test_keeper_list_truncation.ml
+++ b/test/test_keeper_list_truncation.ml
@@ -1,0 +1,221 @@
+(* masc#29077 — masc_keeper_list must say how much of the directory it answered
+   with.
+
+   The list is sorted by name and cut at [limit], and the response reported only
+   the post-truncation [count]. A caller could not tell a short answer from a
+   complete one, so a 129-keeper workspace answering 50 read as "there are 50
+   keepers" — and because throwaway benchmark keepers sort first, the ones with
+   live channel bindings were the ones that fell off the end.
+
+   These assertions pin [total] (before the cut), [limit] (what was applied) and
+   [truncated] on both response shapes, through the public tool dispatch. *)
+
+open Alcotest
+open Masc
+
+let with_temp_dir prefix f =
+  let path = Filename.temp_dir prefix ".workspace" in
+  Fun.protect ~finally:(fun () -> Fs_compat.remove_tree path) (fun () -> f path)
+;;
+
+(* keeper_list_row_json resolves the default runtime id per row, which fails
+   closed when no runtime is loaded (RFC-0206 §2.1). Minimal catalog, loaded
+   once for the executable. *)
+let test_runtime_toml =
+  {|
+[runtime]
+default = "test_provider.test_model"
+
+[providers.test_provider]
+display-name = "Test Provider"
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:1"
+
+[models.test_model]
+api-name = "test-model"
+max-context = 8192
+tools-support = true
+streaming = true
+
+[test_provider.test_model]
+is-default = true
+max-concurrent = 1
+|}
+;;
+
+let runtime_initialized = ref false
+
+let ensure_runtime () =
+  if not !runtime_initialized
+  then (
+    let path = Filename.temp_file "keeper-list-truncation-runtime-" ".toml" in
+    Fun.protect
+      ~finally:(fun () -> try Sys.remove path with Sys_error _ -> ())
+      (fun () ->
+        Out_channel.with_open_bin path (fun oc ->
+          output_string oc test_runtime_toml);
+        match Runtime.init_default ~config_path:path with
+        | Ok () -> runtime_initialized := true
+        | Error error -> failf "Runtime.init_default failed: %s" error))
+;;
+
+let make_meta name =
+  let json =
+    `Assoc
+      [ "name", `String name
+      ; "agent_name", `String (Keeper_identity.keeper_agent_name name)
+      ; "trace_id", `String ("trace-" ^ name)
+      ]
+  in
+  match Masc_test_deps.meta_of_json_fixture json with
+  | Ok meta -> meta
+  | Error error -> fail ("meta_of_json failed: " ^ error)
+;;
+
+let seed_keepers config names =
+  List.iter
+    (fun name ->
+      match Keeper_meta_store.replace_snapshot config (make_meta name) with
+      | Ok () -> ()
+      | Error error -> failf "replace_snapshot %s failed: %s" name error)
+    names
+;;
+
+let int_field json key =
+  match json |> Yojson.Safe.Util.member key with
+  | `Int value -> value
+  | other ->
+    failf "expected int at %S, got %s" key (Yojson.Safe.to_string other)
+;;
+
+let bool_field json key =
+  match json |> Yojson.Safe.Util.member key with
+  | `Bool value -> value
+  | other ->
+    failf "expected bool at %S, got %s" key (Yojson.Safe.to_string other)
+;;
+
+let list_length json key =
+  match json |> Yojson.Safe.Util.member key with
+  | `List items -> List.length items
+  | other ->
+    failf "expected list at %S, got %s" key (Yojson.Safe.to_string other)
+;;
+
+(* Run masc_keeper_list against a workspace seeded with [names], through the
+   same dispatch an MCP client and the HTTP route use. *)
+let keeper_list ~names ~args f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  ensure_runtime ();
+  with_temp_dir "masc-keeper-list-truncation-" @@ fun base_path ->
+  let config = Workspace.default_config base_path in
+  ignore (Workspace.init config ~agent_name:None);
+  Fun.protect
+    ~finally:(fun () ->
+      ignore (Workspace.reset config);
+      Keeper_registry.For_testing.clear ();
+      Keeper_tool_surface.For_testing.reset_keeper_list_cache ();
+      Keeper_runtime.reset_test_state base_path)
+    (fun () ->
+      seed_keepers config names;
+      Keeper_tool_surface.For_testing.reset_keeper_list_cache ();
+      Eio.Switch.run @@ fun sw ->
+      let ctx : _ Keeper_types_profile.context =
+        { config
+        ; agent_name = "test-caller"
+        ; sw
+        ; clock = Eio.Stdenv.clock env
+        ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
+        ; net = Some (Eio.Stdenv.net env)
+        ; publication_recovery_provider =
+            Masc_test_deps.non_runtime_publication_recovery_provider
+        }
+      in
+      match Keeper_tool_surface.dispatch ctx ~name:"masc_keeper_list" ~args with
+      | None -> fail "masc_keeper_list did not dispatch"
+      | Some result ->
+        let body = Tool_result.message result in
+        (match Yojson.Safe.from_string body with
+         | exception Yojson.Json_error error ->
+           failf "masc_keeper_list returned invalid JSON: %s" error
+         | json -> f json))
+;;
+
+(* Ten names, sorted, so a limit of 4 keeps k00..k03 and drops the rest —
+   the same "the tail disappears" shape the live workspace hit. *)
+let ten_names = List.init 10 (fun i -> Printf.sprintf "k%02d" i)
+
+let test_truncated_reports_the_whole_directory () =
+  keeper_list
+    ~names:ten_names
+    ~args:(`Assoc [ "limit", `Int 4; "detailed", `Bool true ])
+    (fun json ->
+      check int "total counts every keeper, not the page" 10 (int_field json "total");
+      check int "limit is what was applied" 4 (int_field json "limit");
+      check bool "truncated" true (bool_field json "truncated");
+      check int "count is the page" 4 (int_field json "count");
+      check int "rows match count" 4 (list_length json "keepers"))
+;;
+
+let test_complete_answer_is_not_marked_truncated () =
+  keeper_list
+    ~names:ten_names
+    ~args:(`Assoc [ "limit", `Int 50; "detailed", `Bool true ])
+    (fun json ->
+      check int "total" 10 (int_field json "total");
+      check bool "not truncated when the limit is not reached" false
+        (bool_field json "truncated");
+      check int "count" 10 (int_field json "count"))
+;;
+
+let test_limit_equal_to_total_is_not_truncated () =
+  (* Boundary: cutting at exactly the directory size drops nothing. *)
+  keeper_list
+    ~names:ten_names
+    ~args:(`Assoc [ "limit", `Int 10; "detailed", `Bool true ])
+    (fun json ->
+      check bool "limit = total is complete" false (bool_field json "truncated");
+      check int "count" 10 (int_field json "count"))
+;;
+
+let test_name_only_shape_carries_the_same_verdict () =
+  (* The non-detailed shape is a different branch and had the same silence. *)
+  keeper_list
+    ~names:ten_names
+    ~args:(`Assoc [ "limit", `Int 3; "detailed", `Bool false ])
+    (fun json ->
+      check int "total" 10 (int_field json "total");
+      check int "limit" 3 (int_field json "limit");
+      check bool "truncated" true (bool_field json "truncated");
+      check int "names returned" 3 (list_length json "keepers"))
+;;
+
+let test_default_limit_is_reported_not_assumed () =
+  (* A caller that passes no limit still learns which one applied — the tool
+     default is 50, and nothing in the old response said so. *)
+  keeper_list
+    ~names:ten_names
+    ~args:(`Assoc [ "detailed", `Bool true ])
+    (fun json ->
+      check int "default limit is stated" 50 (int_field json "limit");
+      check int "total" 10 (int_field json "total");
+      check bool "not truncated" false (bool_field json "truncated"))
+;;
+
+let () =
+  run "keeper_list_truncation"
+    [ ( "listing truth"
+      , [ test_case "truncated answer reports the whole directory" `Quick
+            test_truncated_reports_the_whole_directory
+        ; test_case "complete answer is not marked truncated" `Quick
+            test_complete_answer_is_not_marked_truncated
+        ; test_case "limit = total is not truncated" `Quick
+            test_limit_equal_to_total_is_not_truncated
+        ; test_case "name-only shape carries the same verdict" `Quick
+            test_name_only_shape_carries_the_same_verdict
+        ; test_case "default limit is reported" `Quick
+            test_default_limit_is_reported_not_assumed
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 목표

keeper 목록이 잘렸다는 사실이 응답 어디에도 없던 것을 없앤다. #29077

`masc_keeper_list`는 이름을 정렬해서 `limit`에서 자르는데, 응답은 자른 뒤의 `count`만 실었다. 호출자가 페이지와 디렉터리를 구분할 방법이 없었다.

라이브(129개 keeper)에서 이게 어떻게 나타났는지:

- 대시보드는 50개를 요청하고 "50 keepers"를 렌더했다
- 그 50개는 `canary-*` 43개 + `adm-race-*` 6개 + `analyst` 1개였다. 일회성 벤치마크 keeper가 이름순으로 앞을 다 차지한다
- 채널 바인딩이 걸린 keeper(`sangsu`, `kidsnote`)는 전부 잘린 쪽에 있었다. 그래서 매트릭스에 `unknown`(경고색)으로 찍혔다
- 같은 목록으로 만들어지는 bind 드롭다운에서는 아예 고를 수가 없었다. 기본 선택값은 `keepers[0]` = `adm-race-cf-000`

상한 자체도 세 군데로 갈라져 있었다. 라우트는 기본 100인데 clamp는 200, 도구 기본값은 50, 대시보드는 URL에 50을 박아뒀다.

## 변경

**OCaml**
- `keeper_tool_surface.ml` — `take limit` 전에 `total`을 재고, 두 응답 shape 모두에 `total` / `limit` / `truncated`를 실는다. `count`는 뜻을 유지(반환된 행 수)해서 대시보드의 `count === keepers.length` 불변식을 건드리지 않는다
- `server_routes_http_routes_channel_gate.ml` — 상한을 `keeper_list_max_limit` 하나로 이름 붙이고 기본값을 거기에 맞춘다. `limit`은 이제 좁히는 용도로만 쓰인다
- `keeper_schema.ml` — 도구 설명에 새 필드와 "이름순으로 뒤가 잘린다"는 사실을 적는다

**대시보드**
- URL에서 `limit`을 뺀다. 라우트가 스스로 상한을 걸고 그 값을 응답에 실으므로, 여기에 숫자를 박으면 동기화해야 할 두 번째 cap이 생긴다 (그리고 실제로 어긋났었다)
- 디코더는 새 필드를 **필수**로 받는다. `onExcessProperty: 'error'`인 strict 디코딩이라, 서버가 안 보내면 조용한 downgrade가 아니라 drift로 잡힌다
- 화면에 표시: 매트릭스 헤더 경고줄, bind 폼 경고줄, disclosure 배지 `키퍼 50 / 129`

## 범위 밖 — 읽어주세요

**벤치마크 keeper와 운영 keeper는 여전히 한 이름공간에 있다.** 129개 중 94개가 `canary-*`(58) + `rw-e*`(30) + `adm-race-*`(6)다. 그래서 워크스페이스가 커지면 상한에 또 닿는다. 달라지는 건 **그때 조용하지 않다는 것**뿐이다. 분리는 #29077에 남겨뒀다. 숫자만 올리는 것으로 닫지 않은 이유이기도 하다.

**`truncated`는 "`limit`이 이름을 떨어뜨렸는가"만 답한다.** detailed shape에서 `count`는 `min(total, limit)`보다 더 작을 수 있다 — 목록에 있는 이름의 메타데이터를 못 읽으면 `keeper_list_row_json`이 행을 안 만든다(`Ok None`). 이건 별개의 조용한 드랍이라 여기 섞지 않고 #29077에 적어뒀다.

## 로컬 검증

```
test_keeper_list_truncation                       5/5 green (신규)
dashboard pnpm test                               664 files / 9035 tests green
dashboard pnpm typecheck                          green
eslint (변경 파일 11개)                            clean
dune build --root . @check                        green
test_tool_contract_truth                          green
test_keeper_tool_descriptor_registry_integrity    green
test_keeper_tool_policy_masc_surface              green
test_gate_surface                                 green
```

뮤테이션 확인: `total`을 페이지 크기(`List.length names`)로 되돌리면 2개 케이스가 깨진다 (`FAIL total counts every keeper, not the page`). 측정 후 즉시 복구했다.

**`pnpm lint` 전체는 red인데 이 PR과 무관하다.** `src/components/keeper-tool-call-inspector.ts`의 `no-nested-ternary` 3건이고, 그 파일은 main과 동일하다(이 브랜치에서 수정 안 함). 변경한 11개 파일만 eslint 돌리면 clean이다. 별도로 기록하겠다.

라이브 재현은 못 했다 — `/api/v1/gate/keepers`가 401(`missing_token`)이라 응답 본문 대조는 안 했고, 파일 개수(129)와 코드 경로로 확인했다.