### PR TITLE
fix(ci): #29084가 추가한 test_channel_gate_slack_state를 CI에서 실제로 실행

### DIFF
--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -127,6 +127,7 @@ normal_targets=(
   @test/runtest-test_channel_gate_discord_state
   @test/runtest-test_channel_gate_imessage_state
   @test/runtest-test_channel_gate_metrics
+  @test/runtest-test_channel_gate_slack_state
   @test/runtest-test_client_registry_eio
   @test/runtest-test_code_navigation_eio
   @test/runtest-test_common


### PR DESCRIPTION
## 목표

main을 다시 green으로. #29084가 남긴 미배선 테스트 1건을 CI 매니페스트에 등록한다.

## 무슨 일이 있었나

#29084에서 `test/test_channel_gate_slack_state.ml`을 stanza와 함께 추가했는데, `scripts/ci-run-focused-tests.sh`의 CI 타깃 목록에는 넣지 않았다. 그래서 컴파일만 되고 한 번도 실행되지 않는 상태로 머지됐다.

Meta Guards가 main에서 잡았다.

```
[ci-test-targets] FAIL - 522 suites are declared but never run in CI (baseline 521)
```

정확히 1건 초과 — 그게 이 suite다. 머지 시점(06:49) 이후 main이 red다.

컴파일만 되는 테스트는 없느니만 못하다. 리뷰에서는 검증 근거로 읽히는데 실제로는 아무것도 확인하지 않고, 그 단언은 자기가 고정하려던 코드보다 오래 살아남는다.

## 변경

`scripts/ci-run-focused-tests.sh`에 한 줄 (알파벳 순 위치):

```
  @test/runtest-test_channel_gate_slack_state
```

## 로컬 검증

```
bash scripts/audit-ci-test-targets.sh
  [ci-test-targets] OK - 368 CI targets, all declared in Dune
  [ci-test-targets] OK - 521 suites unwired, at baseline

dune build --root . @test/runtest-test_channel_gate_slack_state
  Test Successful. 5 tests run.
```

## 참고

같은 실수를 #29089(아직 open)에서도 할 뻔했다 — `test_keeper_list_truncation`. 그쪽은 해당 브랜치에서 같이 등록한다. 그 alias를 여기서 미리 넣으면 main에 없는 suite를 참조하게 되므로 나누는 게 맞다.

Draft로 두지 않았다. main red 복구라 바로 봐야 한다.