### PR TITLE
fix(ci): #29084·#29089이 추가하고 배선하지 않은 테스트 2건을 실제로 실행

### DIFF
--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -127,6 +127,7 @@ normal_targets=(
   @test/runtest-test_channel_gate_discord_state
   @test/runtest-test_channel_gate_imessage_state
   @test/runtest-test_channel_gate_metrics
+  @test/runtest-test_channel_gate_slack_state
   @test/runtest-test_client_registry_eio
   @test/runtest-test_code_navigation_eio
   @test/runtest-test_common
@@ -197,6 +198,7 @@ normal_targets=(
   @test/runtest-test_keeper_playground_checkout_discovery
   @test/runtest-test_keeper_autonomous_turn_source
   @test/runtest-test_keeper_autoboot_single_owner
+  @test/runtest-test_keeper_list_truncation
   @test/runtest-test_keeper_meta_current_schema
   @test/runtest-test_keeper_meta_invalid_recovery
   @test/runtest-dashboard-http-behavior-contracts


### PR DESCRIPTION
## 목표

main 복구. 컴파일만 되고 실행되지 않는 테스트 2건을 CI 매니페스트에 등록한다.

## 무슨 일이 있었나

#29084와 #29089가 각각 테스트를 dune stanza와 함께 추가했는데, `scripts/ci-run-focused-tests.sh`의 CI 타깃 목록에는 넣지 않았다. stanza만으로는 컴파일까지만 되고 실행은 안 된다.

현재 main:

```
[ci-test-targets] FAIL - 523 suites are declared but never run in CI (baseline 521)
```

두 건 다 제 실수다. 첫 번째(#29084)를 Meta Guards가 잡은 시점에 두 번째(#29089)가 이미 같은 결함을 안고 머지된 뒤였다.

컴파일만 되는 테스트는 없느니만 못하다. 리뷰에서는 검증 근거로 읽히는데 실제로는 아무것도 확인하지 않고, 그 단언은 자기가 고정하려던 코드보다 오래 살아남는다.

## 변경

`scripts/ci-run-focused-tests.sh`에 두 줄:

```
  @test/runtest-test_channel_gate_slack_state   (#29084)
  @test/runtest-test_keeper_list_truncation     (#29089)
```

## 로컬 검증 (현재 main 1fc2f87c59 기준)

```
bash scripts/audit-ci-test-targets.sh
  [ci-test-targets] OK - 369 CI targets, all declared in Dune
  [ci-test-targets] OK - 521 suites unwired, at baseline

dune build --root . @test/runtest-test_channel_gate_slack_state \
                    @test/runtest-test_keeper_list_truncation
  Test Successful. 5 tests run.
  Test Successful. 5 tests run.
```

## 참고

#29092가 이 중 하나(slack_state)만 고친다. 그 PR은 main red를 처음 봤을 때 연 것이고, 그 사이 #29089가 머지되면서 두 번째가 생겼다. 반쪽짜리 두 개보다 이 PR 하나로 닫는 게 나아서 #29092는 닫는다.

Draft로 두지 않았다. main red 복구다.