### PR TITLE
fix(dashboard): 프롬프트 편집 화면 — 안내 블록 접기, 99줄 문서에 맞는 편집기 크기

### DIFF
--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -584,6 +584,12 @@ describe('SettingsSurface', () => {
     expect(container.querySelector('.set-card-b')?.getAttribute('data-settings-mode')).toBe('local')
     expect(container.querySelector('[data-testid="settings-control-ledger"]')?.textContent)
       .toContain('browser shell only')
+    // The ledger reads and never writes, so it ships collapsed: open above the
+    // real controls it looked like one of them that refused to work.
+    const ledger = container.querySelector('[data-testid="settings-control-ledger"]')
+    expect(ledger?.tagName.toLowerCase()).toBe('details')
+    expect((ledger as HTMLDetailsElement | null)?.open).toBe(false)
+    expect(ledger?.querySelector('summary')?.textContent).toContain('읽기 전용')
     expect(container.querySelector('[data-control-id="settings-theme-density"]')?.getAttribute('data-control-kind'))
       .toBe('browser-local')
     expect(container.querySelector('[data-control-id="settings-display-locale"]')?.getAttribute('data-control-kind'))

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -408,11 +408,10 @@ function SettingsControlLedger({ section }: { section: SectionId }) {
   const items = settingsControlInventory(section)
   if (items.length === 0) return null
   return html`
-    <section class="set-control-ledger" data-testid="settings-control-ledger">
-      <div class="set-control-ledger-h">
-        <span>Control backing</span>
-        <span class="mono" data-testid="settings-control-ledger-count">${items.length}</span>
-      </div>
+    <details class="set-control-ledger" data-testid="settings-control-ledger">
+      <summary class="set-control-ledger-h">
+        <span>이 화면을 뒷받침하는 것 ${items.length}건 — 읽기 전용 안내</span>
+      </summary>
       <div class="set-control-ledger-grid">
         ${items.map(item => html`
           <div
@@ -429,7 +428,7 @@ function SettingsControlLedger({ section }: { section: SectionId }) {
           </div>
         `)}
       </div>
-    </section>
+    </details>
   `
 }
 

--- a/dashboard/src/components/tools/prompt-registry-panel.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.ts
@@ -520,7 +520,7 @@ export function PromptRegistryPanel({ embedded = false }: { embedded?: boolean }
 
             <div class="mb-4">
               <div class="mb-2 text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">파일 기준값</div>
-              <div class="max-h-55 overflow-auto rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] custom-scrollbar"><${Markdown} text=${'```markdown\n' + (selectedPrompt.file_value ?? '없음') + '\n```'} /></div>
+              <div class="max-h-[38vh] overflow-auto rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] custom-scrollbar"><${Markdown} text=${'```markdown\n' + (selectedPrompt.file_value ?? '없음') + '\n```'} /></div>
             </div>
 
             <div class="mb-2 flex items-center justify-between gap-2">
@@ -528,9 +528,9 @@ export function PromptRegistryPanel({ embedded = false }: { embedded?: boolean }
               <div class="text-2xs text-[var(--color-fg-muted)]">저장 후 effective 미리보기가 오버라이드를 반영합니다</div>
             </div>
             <${TextArea}
-              rows=${18}
+              rows=${28}
               value=${draft}
-              class="min-h-80 font-mono text-xs"
+              class="min-h-[46vh] font-mono text-sm leading-relaxed"
               onInput=${(event: Event) => {
                 setDraft((event.target as HTMLTextAreaElement).value)
                 setStatus(null)

--- a/dashboard/src/styles/settings-surface.css
+++ b/dashboard/src/styles/settings-surface.css
@@ -255,16 +255,28 @@
   overflow: hidden;
 }
 
+/* Collapsed by default: this block explains what backs the section and edits
+   nothing, so it sat above the real controls looking like one that refused to
+   work. The marker and pointer say it opens; the caption says it only reads. */
 .set-control-ledger-h {
   align-items: center;
-  border-bottom: 1px solid var(--border-soft);
   color: var(--text-mid);
+  cursor: pointer;
   display: flex;
   font-family: var(--font-ui);
-  font-size: var(--fs-10);
-  justify-content: space-between;
+  font-size: var(--fs-11);
+  gap: 6px;
+  justify-content: flex-start;
   padding: 8px 10px;
-  text-transform: uppercase;
+  user-select: none;
+}
+
+.set-control-ledger[open] .set-control-ledger-h {
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.set-control-ledger-h:hover {
+  color: var(--text-high);
 }
 
 .set-control-ledger-grid {


### PR DESCRIPTION
Settings의 프롬프트 화면에서 나온 문제 두 가지를 고칩니다. 저장이 아예 안 되던 건은 #29087로 따로 갔고, 이건 남은 화면 쪽입니다.

## 1. 위쪽에 "수정 안 되는 설정"처럼 보이던 것

모든 Settings 섹션 맨 위에 control-backing ledger가 붙습니다. 이 섹션이 무엇에 의해 뒷받침되는지 설명하는 블록이고 **아무것도 편집하지 않아요**. 그런데 표 형태로 진짜 컨트롤 위에 놓여 있어서, 화면에서는 "위에 있는 설정은 왜 수정이 안 되지?"로 읽힙니다.

게다가 prompts 섹션에서 마지막 칸에 이렇게 나옵니다:

> PromptRegistryPanel owned writer

개발자 메모지 사용자가 읽을 문장이 아니에요.

**접힌 상태로 바꿨습니다.** `<details>`로 감싸고 요약줄에 "이 화면을 뒷받침하는 것 N건 — 읽기 전용 안내"라고 적었습니다. 필요하면 펼쳐서 볼 수 있고, 기본은 안 보입니다. 접힘이 유지되도록 테스트도 넣었어요.

## 2. 99줄 문서를 18줄 창에서 편집하던 것

`librarian.md`는 99줄입니다. 그런데 편집기가 이랬습니다:

- 편집창 `rows=18`, 폰트 `text-xs`
- 원본("파일 기준값")은 `max-h-55`(약 220px) 박스에 갇혀 스크롤
- 둘이 세로로 쌓여 있어서 원본 찾고 → 내려가서 고치고 → 다시 올라가서 대조

**짧은 프롬프트를 가끔 손보는 화면으로 설계됐는데 실물은 규정집**이었던 셈입니다.

편집창을 `min-h-[46vh]`(rows 28), 원본을 `max-h-[38vh]`로 올리고 편집 폰트를 `text-sm`으로 한 단계 키웠습니다. 화면 높이에 비례하니 큰 모니터에서 더 넓게 잡힙니다.

좌우 분할까지는 이번에 안 했습니다. 레이아웃 변경이 커져서 따로 보는 게 나을 것 같아요.

## 검증

- `tsc --noEmit` 통과
- `settings-surface.test.ts` 46개, `prompt-registry-panel.test.ts` 포함 53개 통과
- ledger가 `<details>`이고 기본 접힘이며 요약에 "읽기 전용"이 들어가는지 확인하는 테스트 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)
