### PR TITLE
fix(keeper): Goal 완료 알림 대상을 owner로 결정 — 51시간 반복되던 ambiguous 해소

### DIFF
--- a/lib/keeper/keeper_goal_reconciliation_wake.ml
+++ b/lib/keeper/keeper_goal_reconciliation_wake.ml
@@ -94,15 +94,55 @@ let exact_producer_keeper_name ~config ~completing_agent_name =
   | Keeper_identity_binding.Lookup_failed detail -> Error detail
 ;;
 
+(* RFC-0362 names [owner] as the keeper responsible for turning this Goal into
+   Tasks, which is exactly who a completion should wake. The reverse index of
+   keepers carrying the goal in [active_goal_ids] answers a different question —
+   who is working on it — and a collaboration mission legitimately has several. *)
+let goal_owner_keeper ~config goal_id =
+  match Goal_store.get_goal config ~goal_id with
+  | Some { Goal_store.owner = Some owner; _ } ->
+    (match String.trim owner with
+     | "" -> None
+     | owner -> Some owner)
+  | Some { Goal_store.owner = None; _ } | None -> None
+;;
+
+(* Several keepers carry this goal. The declared owner settles it when it is one
+   of them; an owner outside the set, or none at all, still fails rather than
+   picking a keeper this Goal never named. Pure so the decision is testable
+   without a workspace. *)
+let resolve_ambiguous_assignment ~goal_id ~owner ~keeper_names =
+  match owner with
+  | Some owner when List.mem owner keeper_names -> Ok owner
+  | Some owner ->
+    Error
+      (Printf.sprintf
+         "Goal owner is not among its active keepers goal_id=%s owner=%s \
+          keepers=%s"
+         goal_id
+         owner
+         (String.concat "," keeper_names))
+  | None ->
+    Error
+      (Printf.sprintf
+         "ambiguous active Goal assignment with no declared owner goal_id=%s \
+          keepers=%s"
+         goal_id
+         (String.concat "," keeper_names))
+;;
+
 let target_keeper_name ~config ~completing_agent_name ~goal_id =
   match assigned_keeper_resolution ~config goal_id with
   | Assigned_keeper keeper_name -> Ok (Some keeper_name)
   | Ambiguous_assigned_keepers keeper_names ->
-    Error
-      (Printf.sprintf
-         "ambiguous active Goal assignment goal_id=%s keepers=%s"
-         goal_id
-         (String.concat "," keeper_names))
+    (match
+       resolve_ambiguous_assignment
+         ~goal_id
+         ~owner:(goal_owner_keeper ~config goal_id)
+         ~keeper_names
+     with
+     | Ok owner -> Ok (Some owner)
+     | Error detail -> Error detail)
   | Assigned_keeper_lookup_failed detail -> Error detail
   | No_assigned_keeper ->
     (match exact_producer_keeper_name ~config ~completing_agent_name with

--- a/lib/keeper/keeper_goal_reconciliation_wake.mli
+++ b/lib/keeper/keeper_goal_reconciliation_wake.mli
@@ -15,6 +15,19 @@ type reconciliation_summary = {
   failed_count : int;
 }
 
+(** Decide which keeper a completion wakes when several carry the goal.
+
+    RFC-0362's [owner] names the keeper responsible for turning the Goal into
+    Tasks, so it settles a tie that the [active_goal_ids] reverse index cannot:
+    a collaboration mission legitimately puts several keepers on one goal. An
+    owner outside [keeper_names], or none at all, is an error rather than a
+    guess — the wake goes to a keeper the Goal named or to nobody. *)
+val resolve_ambiguous_assignment :
+  goal_id:string ->
+  owner:string option ->
+  keeper_names:string list ->
+  (string, string) result
+
 val enqueue_if_ready :
   config:Workspace.config ->
   completing_agent_name:string ->

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -231,6 +231,7 @@ normal_targets=(
   @test/runtest-test_keeper_tool_execute_exit_result
   @test/runtest-test_goal_store
   @test/runtest-test_keeper_goal_phase_projection
+  @test/runtest-test_keeper_goal_reconciliation_target
   @test/runtest-test_keeper_tool_descriptor_registry_integrity
   @test/runtest-test_schedule_runner
   @test/runtest-test_schedule_store

--- a/test/dune
+++ b/test/dune
@@ -1117,6 +1117,7 @@
   test_goal_upsert_fsm_bypass_10247
   test_goal_store
   test_keeper_goal_phase_projection
+  test_keeper_goal_reconciliation_target
   test_goal_metric_unevaluated
   test_string_util
   test_prompt_asset_sync
@@ -1258,6 +1259,7 @@
   test_goal_upsert_fsm_bypass_10247
   test_goal_store
   test_keeper_goal_phase_projection
+  test_keeper_goal_reconciliation_target
   test_goal_metric_unevaluated
   test_string_util
   test_prompt_asset_sync

--- a/test/test_keeper_goal_reconciliation_target.ml
+++ b/test/test_keeper_goal_reconciliation_target.ml
@@ -1,0 +1,59 @@
+(** Which keeper a Goal completion wakes when several carry the goal.
+
+    The resolver reads the reverse index of keepers holding the goal in
+    [active_goal_ids] and, before this change, failed outright whenever that
+    index held more than one name. A collaboration mission puts five keepers on
+    one goal, so every completion in the E0 campaign logged an ambiguity error.
+    The failure left goal and task state untouched, so the next scan found the
+    same goal ready and failed again — fifty-one hours of it in the live store.
+
+    RFC-0362's [owner] already names the keeper responsible for turning the Goal
+    into Tasks. These tests pin that it settles the tie, and that it never
+    invents a target: a Goal with no owner, or one naming somebody who is not
+    working under it, still fails. *)
+
+open Alcotest
+open Masc
+
+let resolve = Keeper_goal_reconciliation_wake.resolve_ambiguous_assignment
+
+let () =
+  run "keeper_goal_reconciliation_target"
+    [ ( "owner"
+      , [ test_case "declared owner settles a multi-keeper goal" `Quick (fun () ->
+            match
+              resolve ~goal_id:"goal-collab" ~owner:(Some "coord")
+                ~keeper_names:[ "build-a"; "build-b"; "coord"; "research"; "review" ]
+            with
+            | Ok name -> check string "wakes the owner" "coord" name
+            | Error detail -> fail ("expected the owner, got error: " ^ detail))
+        ; test_case "no declared owner stays an error" `Quick (fun () ->
+            match
+              resolve ~goal_id:"goal-ownerless" ~owner:None
+                ~keeper_names:[ "build-a"; "build-b" ]
+            with
+            | Error detail ->
+              check bool "names the missing owner" true
+                (String_util.contains_substring detail "no declared owner")
+            | Ok name ->
+              fail ("an ownerless goal must not pick a target, picked: " ^ name))
+        ; test_case "owner outside the working set stays an error" `Quick (fun () ->
+            match
+              resolve ~goal_id:"goal-stale-owner" ~owner:(Some "retired")
+                ~keeper_names:[ "build-a"; "build-b" ]
+            with
+            | Error detail ->
+              check bool "names the mismatch" true
+                (String_util.contains_substring detail "not among its active keepers")
+            | Ok name ->
+              fail ("an owner nobody works under must not be woken, picked: " ^ name))
+        ; test_case "single-keeper set still honours a matching owner" `Quick (fun () ->
+            match
+              resolve ~goal_id:"goal-solo" ~owner:(Some "solo")
+                ~keeper_names:[ "solo" ]
+            with
+            | Ok name -> check string "wakes the owner" "solo" name
+            | Error detail -> fail ("expected the owner, got error: " ^ detail))
+        ] )
+    ]
+;;


### PR DESCRIPTION
Goal 완료 알림이 대상을 못 정해서 51시간째 같은 에러를 반복하던 걸 고칩니다. #29083입니다.

## 무슨 일이었냐면

reconciliation은 알림 대상을 `active_goal_ids`에 그 goal을 담고 있는 keeper들에서 고르는데, **그 집합이 둘 이상이면 그냥 포기**했습니다.

```
| Ambiguous_assigned_keepers keeper_names -> Error "ambiguous active Goal assignment ..."
```

E0 협업 미션은 goal 하나에 keeper 5개(build-a/build-b/coord/research/review)를 붙입니다. 그러니 **항상** ambiguous였어요.

그리고 이 실패가 goal이나 task 상태를 아무것도 바꾸지 않아서, 다음 스캔이 같은 goal을 또 ready로 집어들고 또 실패합니다. 라이브 로그에 08-17부터 세 goal이 계속 이러고 있었습니다.

## 답은 이미 Goal 안에 있었습니다

RFC-0362가 `owner`를 "이 Goal을 Task로 바꿀 책임자"로 정의해 뒀어요. 완료 알림을 받아야 할 사람이 정확히 그 사람입니다.

`active_goal_ids` 역참조는 **다른 질문**에 답합니다 — "누가 이 goal을 작업 중인가". 협업 미션에서 여럿인 게 정상이고, 그걸 실패 사유로 쓴 게 문제였습니다.

그래서 후보가 여럿일 때 **owner가 그 안에 있으면 owner로 결정**합니다.

## 대신 대상을 지어내지는 않습니다

- owner가 없는 goal → 여전히 에러
- owner가 있는데 그 keeper가 작업 중이 아님 → 여전히 에러

에러 메시지도 둘을 구분합니다. 예전엔 뭐가 문제든 "ambiguous"라고만 나와서, 실제로는 owner 설정을 안 한 건지 owner가 낡은 건지 알 수 없었어요.

## 테스트

결정 로직을 순수 함수(`resolve_ambiguous_assignment`)로 뽑아서 워크스페이스 없이 네 경우를 검증합니다:

- owner가 후보 중에 있으면 owner를 깨운다
- owner가 없으면 에러이고 메시지에 "no declared owner"가 들어간다
- owner가 후보 밖이면 에러이고 메시지에 "not among its active keepers"가 들어간다
- 후보가 하나여도 owner 일치는 그대로 동작한다

## 검증

- `ocamlformat` 파싱 통과 (변경 파일 3종)
- `audit-ci-test-targets.sh` 통과 — 370 targets, baseline 521 유지
- 신규 스위트를 `test/dune` 2곳과 focused-tests에 등록

## 남은 것

이 수정은 대상 결정만 고칩니다. **죽은 keeper가 `active_goal_ids`를 놓지 않는 것**은 그대로예요 — 08-18에 끝난 keeper 5개가 아직 goal을 붙들고 있습니다. #29083 본문에 적어둔 대로, keeper 종료 시 정리하는 경로가 있어야 하는지는 별도 판단이 필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
