### PR TITLE
feat(dashboard): add global autonomous-turn expand toggle

### DIFF
--- a/dashboard/src/components/chat/autonomous-turn-run.test.ts
+++ b/dashboard/src/components/chat/autonomous-turn-run.test.ts
@@ -62,7 +62,11 @@ describe('ChatTranscript — folded autonomous runs', () => {
 
   const draw = (
     entries: KeeperConversationEntry[],
-    opts: { unreadAfterTs?: number | null; showDayDividers?: boolean } = {},
+    opts: {
+      unreadAfterTs?: number | null
+      showDayDividers?: boolean
+      expandAutonomousRuns?: boolean
+    } = {},
   ) => {
     render(
       html`<${ChatTranscript}
@@ -71,6 +75,7 @@ describe('ChatTranscript — folded autonomous runs', () => {
         showDayDividers=${opts.showDayDividers ?? true}
         groupToolCalls=${true}
         unreadAfterTs=${opts.unreadAfterTs ?? null}
+        expandAutonomousRuns=${opts.expandAutonomousRuns ?? false}
       />`,
       container,
     )
@@ -86,6 +91,12 @@ describe('ChatTranscript — folded autonomous runs', () => {
     draw([said('u1', DAY_ONE), ...wakesFrom('a', minutesAfter(DAY_ONE, 1), 6)])
     // One chip, not six reading "1개".
     expect(headerCounts()).toEqual(['6개'])
+  })
+
+  it('leaves every autonomous turn unfolded when the global preference is enabled', () => {
+    draw(wakesFrom('a', DAY_ONE, 6), { expandAutonomousRuns: true })
+    expect(container.querySelectorAll('.chat-auto-run').length).toBe(0)
+    expect(headerCounts()).toEqual(['1개', '1개', '1개', '1개', '1개', '1개'])
   })
 
   it('holds every turn as its own row inside, so the run is a container and not a merge', () => {

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -4137,9 +4137,11 @@ function renderChatTranscriptBody(opts: {
   // Since-last-seen cursor (unix seconds) for the unread divider; null on every
   // non-keeper chat surface so those transcripts render unchanged.
   unreadAfterTs: number | null
+  // When true, skip folding autonomous groups into collapsed runs.
+  expandAutonomousRuns?: boolean
   action?: ChatTranscriptAction
 }): VNode[] {
-  const { entries, showDayDividers, groupToolCalls, showMetadata, variant, showSourceBadge, toolOutputsCoveredSinceMs, toolOutputsCoveredThroughMs, toolOutputHydrationContract, unreadAfterTs, action } = opts
+  const { entries, showDayDividers, groupToolCalls, showMetadata, variant, showSourceBadge, toolOutputsCoveredSinceMs, toolOutputsCoveredThroughMs, toolOutputHydrationContract, unreadAfterTs, expandAutonomousRuns, action } = opts
   const ungroupedUnits = buildChatRenderUnits(entries, groupToolCalls)
   // Anchored on the unfolded list: folding must not move the unread line, only
   // avoid hiding it. foldAutonomousRuns cuts a run open at this key so the unit
@@ -4148,7 +4150,9 @@ function renderChatTranscriptBody(opts: {
     ungroupedUnits.map(unit => ({ key: unitKey(unit), tsMs: unitTimestampMs(unit) })),
     unreadAfterTs,
   )
-  const units = foldAutonomousRuns(ungroupedUnits, {
+  const units = expandAutonomousRuns
+    ? ungroupedUnits
+    : foldAutonomousRuns(ungroupedUnits, {
     startsNewRun: (unit) => unreadAnchorKey !== null && unitKey(unit) === unreadAnchorKey,
     // Day dividers are emitted per unit below, so a run that spanned midnight
     // would show only its first day. Cutting on the day key keeps every day
@@ -4260,6 +4264,7 @@ export function ChatTranscript({
   toolOutputsCoveredThroughMs = null,
   toolOutputHydrationContract = null,
   unreadAfterTs = null,
+  expandAutonomousRuns = false,
   onSeenBottom,
   action,
 }: {
@@ -4281,6 +4286,8 @@ export function ChatTranscript({
   // Since-last-seen cursor (unix seconds) driving the unread divider. Null on
   // non-keeper surfaces -> no divider.
   unreadAfterTs?: number | null
+  // When true, skip folding autonomous groups into collapsed runs.
+  expandAutonomousRuns?: boolean
   // Called when the operator has demonstrably caught up (scrolled/pinned to the
   // bottom, or a new row arrived while pinned, or the tab regained visibility
   // while pinned). The keeper panel uses it to advance the last-seen cursor.
@@ -4401,6 +4408,7 @@ export function ChatTranscript({
               toolOutputsCoveredThroughMs,
               toolOutputHydrationContract,
               unreadAfterTs,
+              expandAutonomousRuns,
               action,
             })}
       </div>

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -68,7 +68,12 @@ import {
   subscribeKeeperWaitingInventory,
 } from '../keeper-waiting-inventory-store'
 import { registerKeeperWaitingInventoryRefresh } from '../sse-store'
-import { chatShowAutonomous, chatShowInternal, chatShowMetadata } from '../lib/chat-view-prefs'
+import {
+  chatExpandAutonomousRuns,
+  chatShowAutonomous,
+  chatShowInternal,
+  chatShowMetadata,
+} from '../lib/chat-view-prefs'
 import {
   cancelKeeperChatOperation,
   editQueuedKeeperChatOperation,
@@ -1045,6 +1050,7 @@ export function KeeperConversationPanel({
               toolOutputsCoveredThroughMs=${toolCallOutputsCoveredThroughMs(keeperName)}
               toolOutputHydrationContract=${toolCallOutputHydrationContract(keeperName)}
               unreadAfterTs=${unreadAfterTs}
+              expandAutonomousRuns=${chatExpandAutonomousRuns.value}
               onSeenBottom=${markTranscriptSeen}
               action=${inspectAction}
             />
@@ -1158,6 +1164,7 @@ export function KeeperConversationPanel({
           toolOutputsCoveredThroughMs=${toolCallOutputsCoveredThroughMs(keeperName)}
           toolOutputHydrationContract=${toolCallOutputHydrationContract(keeperName)}
           unreadAfterTs=${unreadAfterTs}
+          expandAutonomousRuns=${chatExpandAutonomousRuns.value}
           onSeenBottom=${markTranscriptSeen}
           action=${inspectAction}
         />
@@ -1263,6 +1270,7 @@ export function KeeperConversationPanel({
             toolOutputsCoveredThroughMs=${toolCallOutputsCoveredThroughMs(keeperName)}
             toolOutputHydrationContract=${toolCallOutputHydrationContract(keeperName)}
             unreadAfterTs=${unreadAfterTs}
+            expandAutonomousRuns=${chatExpandAutonomousRuns.value}
             onSeenBottom=${markTranscriptSeen}
             action=${inspectAction}
           />

--- a/dashboard/src/components/tweaks-panel.ts
+++ b/dashboard/src/components/tweaks-panel.ts
@@ -3,7 +3,12 @@ import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { useCallback, useEffect, useRef } from 'preact/hooks'
 import { persistentSignal } from '../lib/persistent-signal'
-import { chatShowAutonomous, chatShowInternal, chatShowMetadata } from '../lib/chat-view-prefs'
+import {
+  chatExpandAutonomousRuns,
+  chatShowAutonomous,
+  chatShowInternal,
+  chatShowMetadata,
+} from '../lib/chat-view-prefs'
 import { ringFocusClasses } from './common/ring'
 import { Settings2, X } from 'lucide-preact'
 
@@ -627,6 +632,11 @@ export function TweaksPanel() {
           label="자율턴"
           value=${chatShowAutonomous.value}
           onChange=${(v: boolean) => { chatShowAutonomous.value = v }}
+        />
+        <${TweakToggle}
+          label="자율턴 펼침"
+          value=${chatExpandAutonomousRuns.value}
+          onChange=${(v: boolean) => { chatExpandAutonomousRuns.value = v }}
         />
 
         <${TweakSection} label="타이포" />

--- a/dashboard/src/lib/chat-view-prefs.ts
+++ b/dashboard/src/lib/chat-view-prefs.ts
@@ -43,3 +43,9 @@ export const chatShowAutonomous = persistentSignal<boolean>({
   key: 'dashboard:chat:show-autonomous-v1',
   defaultValue: true,
 })
+
+/** When true, autonomous-turn groups are rendered unfolded (no folding into collapsed runs). */
+export const chatExpandAutonomousRuns = persistentSignal<boolean>({
+  key: 'dashboard:chat:expand-autonomous-runs-v1',
+  defaultValue: false,
+})


### PR DESCRIPTION
## Summary

Adds a persisted global toggle (chatExpandAutonomousRuns) that, when enabled, renders autonomous-turn groups unfolded instead of folding them into collapsed runs.

## Changes
- `chat-view-prefs.ts`: new `chatExpandAutonomousRuns` persistent signal (default off)
- `primitives.ts`: `renderChatTranscriptBody`/`ChatTranscript` accept `expandAutonomousRuns`; when true, skip `foldAutonomousRuns`
- `keeper-shared.ts`: wire the signal into all 3 ChatTranscript call sites
- `tweaks-panel.ts`: new "자율턴 펼침" toggle in the Tweaks panel

## Test
- `npx tsc --noEmit` passes in dashboard

Closes task-395

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`rondo/task-395-autonomous-expand-toggle` → `main` · 1 commit(s) · synced 2026-08-21T03:10:00Z

| sha | subject | date |
|---|---|---|
| `67b8a91f4` | feat(dashboard): add global autonomous-turn expand toggle | 2026-08-21 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->