### PR TITLE
fix(dashboard): restore autonomous turn rows in keeper chat, add view toggle

### DIFF
--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -114,6 +114,7 @@ vi.mock('../keeper-state', async () => {
           && entry.source !== 'tool_result'
           && entry.source !== 'system'),
     ),
+    isAutonomousTurnEntry: (entry: { source?: string }) => entry.source === 'autonomous_turn',
   }
 })
 
@@ -170,6 +171,7 @@ import {
   resetToolCallOutputs,
 } from '../tool-call-output-store'
 import { shellAuthSummary } from '../store'
+import { chatShowAutonomous } from '../lib/chat-view-prefs'
 import type { KeeperConversationEntry } from '../types'
 import {
   KeeperConversationPanel,
@@ -245,6 +247,7 @@ describe('KeeperConversationPanel', () => {
     })
     keeperThreads.value = {}
     keeperSending.value = {}
+    chatShowAutonomous.value = true
     keeperHydrating.value = {}
     keeperStatusDetails.value = {}
     keeperActionErrors.value = {}
@@ -339,6 +342,52 @@ describe('KeeperConversationPanel', () => {
     expect(container.querySelector('[data-chat-variant="messenger"]')).not.toBeNull()
     expect(container.querySelector('textarea')?.getAttribute('placeholder')).toBe('메시지 입력...')
     expect(hydrateKeeperStatus).not.toHaveBeenCalled()
+  })
+
+  it('hides autonomous turns when the autonomous view pref is off', async () => {
+    keeperThreads.value = {
+      sangsu: [
+        {
+          id: 'direct-user',
+          role: 'user',
+          source: 'direct_user',
+          label: '사용자',
+          text: '직접 질문',
+          rawText: '직접 질문',
+          timestamp: '2026-03-24T00:01:00.000Z',
+          delivery: 'history',
+          streamState: null,
+          details: null,
+          error: null,
+        },
+        {
+          id: 'autonomous-1',
+          role: 'assistant',
+          source: 'autonomous_turn',
+          label: 'sangsu',
+          text: '자율 작업 결과',
+          rawText: '자율 작업 결과',
+          timestamp: '2026-03-24T00:02:00.000Z',
+          delivery: 'history',
+          streamState: null,
+          details: null,
+          error: null,
+        },
+      ],
+    }
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="메시지 입력..." />`,
+      container,
+    )
+    await Promise.resolve()
+    expect(container.textContent).toContain('자율턴')
+
+    chatShowAutonomous.value = false
+    await waitFor(() => {
+      expect(container.textContent).not.toContain('자율턴')
+    })
+    expect(container.textContent).toContain('직접 질문')
   })
 
   it('renders the primary conversation layout as an airy canvas', async () => {

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -40,7 +40,7 @@ import {
   keeperThreads,
   setRecordValue,
 } from '../keeper-state'
-import { isDefaultVisibleConversationEntry } from '../keeper-state'
+import { isAutonomousTurnEntry, isDefaultVisibleConversationEntry } from '../keeper-state'
 import {
   getKeeperLastSeen,
   advanceKeeperLastSeen,
@@ -68,7 +68,7 @@ import {
   subscribeKeeperWaitingInventory,
 } from '../keeper-waiting-inventory-store'
 import { registerKeeperWaitingInventoryRefresh } from '../sse-store'
-import { chatShowInternal, chatShowMetadata } from '../lib/chat-view-prefs'
+import { chatShowAutonomous, chatShowInternal, chatShowMetadata } from '../lib/chat-view-prefs'
 import {
   cancelKeeperChatOperation,
   editQueuedKeeperChatOperation,
@@ -751,6 +751,7 @@ export function KeeperConversationPanel({
   // subscribes this component, so a Tweaks flip re-renders every mounted panel.
   const showMetadata = chatShowMetadata.value
   const showInternal = chatShowInternal.value
+  const showAutonomous = chatShowAutonomous.value
 
   const [historyExpanded, setHistoryExpanded] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
@@ -794,15 +795,23 @@ export function KeeperConversationPanel({
 
   const rawThread = keeperThreads.value[keeperName] ?? []
   // thread / visibleThread / transcriptEntries form a derivation chain over
-  // rawThread + UI state (showInternal toggle, sending flag, searchQuery
-  // keystrokes). The parent re-renders on every search keystroke and other
-  // unrelated signals; memoizing each stage on its stable upstream skips the
-  // refilter when rawThread and the relevant UI flag are unchanged.
-  const thread = useMemo(
+  // rawThread + UI state (showInternal/showAutonomous toggles, sending flag,
+  // searchQuery keystrokes). The parent re-renders on every search keystroke
+  // and other unrelated signals; memoizing each stage on its stable upstream
+  // skips the refilter when rawThread and the relevant UI flag are unchanged.
+  // hiddenCount stays internal-only: the "숨겨진 내부 메시지" banner must not
+  // count autonomous entries the operator chose to hide with their own toggle.
+  const internalFilteredThread = useMemo(
     () => showInternal ? rawThread : rawThread.filter(isDefaultVisibleConversationEntry),
     [rawThread, showInternal],
   )
-  const hiddenCount = rawThread.length - thread.length
+  const hiddenCount = rawThread.length - internalFilteredThread.length
+  const thread = useMemo(
+    () => showAutonomous
+      ? internalFilteredThread
+      : internalFilteredThread.filter(entry => !isAutonomousTurnEntry(entry)),
+    [internalFilteredThread, showAutonomous],
+  )
   const sending = keeperSending.value[keeperName] ?? false
   const serverBusy = inventoryEntry?.state === 'busy'
   const isKeeperBusy = Boolean(serverBusy && !sending)

--- a/dashboard/src/components/tweaks-panel.test.ts
+++ b/dashboard/src/components/tweaks-panel.test.ts
@@ -12,6 +12,7 @@ import {
   tweaksMotion,
   tweaksOpen,
 } from './tweaks-panel'
+import { chatShowAutonomous } from '../lib/chat-view-prefs'
 
 describe('TweaksPanel', () => {
   let container: HTMLDivElement
@@ -24,6 +25,7 @@ describe('TweaksPanel', () => {
     tweaksMotion.value = 'subtle'
     tweaksBubble.value = 'card'
     tweaksFontScale.value = 100
+    chatShowAutonomous.value = true
   })
 
   afterEach(() => {
@@ -124,6 +126,22 @@ describe('TweaksPanel', () => {
     await fireEvent.click(close)
 
     expect(tweaksOpen.value).toBe(false)
+  })
+
+  it('autonomous-turn toggle updates the chat view pref', async () => {
+    tweaksOpen.value = true
+    chatShowAutonomous.value = true
+    render(html`<${TweaksPanel} />`, container)
+
+    const row = Array.from(container.querySelectorAll('.twk-row')).find(
+      el => el.textContent?.includes('자율턴'),
+    ) as HTMLElement
+    expect(row).not.toBeUndefined()
+    const toggle = row.querySelector('button[role="switch"]') as HTMLButtonElement
+    expect(toggle.getAttribute('aria-checked')).toBe('true')
+
+    await fireEvent.click(toggle)
+    expect(chatShowAutonomous.value).toBe(false)
   })
 })
 // Keeper Agent v2 sync: coverage ratchet trigger

--- a/dashboard/src/components/tweaks-panel.ts
+++ b/dashboard/src/components/tweaks-panel.ts
@@ -3,7 +3,7 @@ import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { useCallback, useEffect, useRef } from 'preact/hooks'
 import { persistentSignal } from '../lib/persistent-signal'
-import { chatShowInternal, chatShowMetadata } from '../lib/chat-view-prefs'
+import { chatShowAutonomous, chatShowInternal, chatShowMetadata } from '../lib/chat-view-prefs'
 import { ringFocusClasses } from './common/ring'
 import { Settings2, X } from 'lucide-preact'
 
@@ -622,6 +622,11 @@ export function TweaksPanel() {
           label="내부 메시지"
           value=${chatShowInternal.value}
           onChange=${(v: boolean) => { chatShowInternal.value = v }}
+        />
+        <${TweakToggle}
+          label="자율턴"
+          value=${chatShowAutonomous.value}
+          onChange=${(v: boolean) => { chatShowAutonomous.value = v }}
         />
 
         <${TweakSection} label="타이포" />

--- a/dashboard/src/lib/chat-view-prefs.ts
+++ b/dashboard/src/lib/chat-view-prefs.ts
@@ -35,3 +35,11 @@ export const chatShowInternal = persistentSignal<boolean>({
   key: 'dashboard:chat:show-internal-v1',
   defaultValue: legacyBool(LEGACY_INTERNAL_KEY) ?? true,
 })
+
+/** Show autonomous-turn entries in transcripts. They are visible by default
+ *  but not part of the direct conversation, so they get their own switch
+ *  rather than riding the internal-message toggle. */
+export const chatShowAutonomous = persistentSignal<boolean>({
+  key: 'dashboard:chat:show-autonomous-v1',
+  defaultValue: true,
+})

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -1301,7 +1301,8 @@ let keeper_chat_history_freshness config name =
    AGENT_CORE checkpoint, not as duplicate chat-store rows. This read projection uses
    typed turn identity only for stable dashboard grouping and exact raw-trace
    lookup; it is not the Keeper's semantic continuity mechanism. Final text
-   and work trace come from the same exact AGENT_CORE run. *)
+   and work trace come from the same exact AGENT_CORE run. The [id] is required:
+   the dashboard history schema drops any row without one. *)
 let autonomous_turn_json (turn : Keeper_autonomous_turn_source.turn) =
   let trace_fields =
     match turn.trace with
@@ -1312,7 +1313,8 @@ let autonomous_turn_json (turn : Keeper_autonomous_turn_source.turn) =
             [ Keeper_chat_blocks.Trace { trace; omitted = 0 } ] ) ]
   in
   `Assoc
-    ([ "role", `String "assistant"
+    ([ "id", `String ("autonomous:" ^ turn.turn_id)
+     ; "role", `String "assistant"
      ; "ts", `Float turn.started_at
      ; ( "content"
        , match turn.final_text with

--- a/lib/server/server_dashboard_http_keeper_api.mli
+++ b/lib/server/server_dashboard_http_keeper_api.mli
@@ -65,6 +65,11 @@ include module type of Server_dashboard_http_keeper_api_types
 
 (** {1 Chat history paging} *)
 
+val keeper_chat_history_json : Workspace.config -> string -> Yojson.Safe.t
+(** Body for [GET /chat/history]: the chat-store tail window plus every
+    autonomous turn retention still holds. Every row carries a stable [id] —
+    the dashboard history schema silently drops rows without one. *)
+
 val keeper_chat_history_page_json :
   Workspace.config -> string -> before:float option -> Yojson.Safe.t
 (** Body for [GET /chat/history/page]: direct-conversation rows older than

--- a/test/test_keeper_autonomous_turn_source.ml
+++ b/test/test_keeper_autonomous_turn_source.ml
@@ -484,6 +484,41 @@ let test_wake_prompt_resolution_order () =
     (fun () -> ignore (resolve ()))
 ;;
 
+(* The dashboard history schema (keeper-chat-history.ts) requires [id] on every
+   row and silently drops any row without one. A projected autonomous turn
+   without [id] would therefore never reach the transcript. *)
+let test_dashboard_history_autonomous_rows_carry_id () =
+  with_workspace @@ fun config ->
+  let path = trace_path config "history-id" in
+  let worker_run_id = "run-history-id" in
+  write_lines path
+    (run_lines ~worker_run_id ~start_seq:1 ~base_ts:7000.
+       ~prompt:Keeper_unified_prompt.autonomous_wake_marker
+       ~final_text:"visible in history");
+  write_turn_record config ~absolute_turn:48 ~generation:9
+    ~turn_kind:Turn_record.Autonomous
+    ~raw_trace_run_ref:(Some (run_ref ~path ~worker_run_id ~start_seq:1));
+  match
+    Server_dashboard_http_keeper_api.keeper_chat_history_json config keeper_name
+  with
+  | `List rows ->
+    Alcotest.(check int) "one autonomous row in history" 1 (List.length rows);
+    List.iter
+      (fun row ->
+        match row with
+        | `Assoc fields ->
+          (match List.assoc_opt "id" fields with
+           | Some (`String id) when String.length id > 0 ->
+             Alcotest.(check string) "id is namespaced off the turn ref"
+               "autonomous:trace-test-0000#48" id
+           | _ ->
+             Alcotest.fail
+               "autonomous history row without id is dropped by the dashboard schema")
+        | _ -> Alcotest.fail "history row is not an object")
+      rows
+  | _ -> Alcotest.fail "history body is not a list"
+;;
+
 let () =
   Alcotest.run "keeper_autonomous_turn_source"
     [ ( "load_recent"
@@ -513,6 +548,10 @@ let () =
             test_session_identity_mismatch_is_rejected
         ; Alcotest.test_case "rejects an absent session identity" `Quick
             test_absent_session_identity_is_rejected
+        ] )
+    ; ( "dashboard_history"
+      , [ Alcotest.test_case "autonomous rows carry a schema-required id" `Quick
+            test_dashboard_history_autonomous_rows_carry_id
         ] )
     ; ( "wake_prompt"
       , [ Alcotest.test_case "rejects blank and over-bound values" `Quick


### PR DESCRIPTION
## 문제

개별 keeper 채팅에 자율턴이 표시되지 않던 버그.

- `autonomous_turn_json`이 `d5f7d70ce3`(#26804) 리팩터링에서 `id` 필드를 잃음
- 대시보드 `KeeperChatHistoryMessageSchema`는 `id`를 필수로 요구하고 파싱 실패 행을 무음 drop (`keeper-chat-history.ts:273,353`)
- 결과: 자율턴 행 전체가 스키마 경계에서 소실. UI 토글/fold 문제가 아니라 데이터 자체가 도달하지 않았음

## 수정

- **백엔드**: `id: "autonomous:<turn_id>"` 복원 (`server_dashboard_http_keeper_api.ml`)
- **회귀 테스트**: `test_keeper_autonomous_turn_source.ml`에 history 행 id 계약 테스트 추가 — id 제거 시 FAIL, 복원 시 PASS 양방향 확인. 이를 위해 `keeper_chat_history_json`을 mli에 노출
- **뷰 토글**: Tweaks 패널 > 대화 > "자율턴" (`chatShowAutonomous`, 기본 ON, localStorage 영속). off 시 개별 채팅에서 자율턴 카드 숨김. "숨겨진 내부 메시지" 배너 카운트는 내부 메시지 토글 전용으로 유지

## 검증

- OCaml: `test_keeper_autonomous_turn_source` 15/15 통과 (신규 테스트 포함)
- 대시보드: vitest 64/64 (keeper-shared / tweaks-panel / keeper-chat-history, 신규 2개), `tsc --noEmit` 통과
- 라이브 검증: 8935 서버 재배포 후 `/api/v1/keepers/sangsu/chat/history`에서 자율턴 행 197개 전부 id 포함 확인