### PR TITLE
fix(ci): main red 해소 — task outcome 스위트 배선 되돌리고 파일시스템 결함 하나 수정

### DIFF
--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,10 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=520
+# Back to 521 while test_keeper_task_outcomes is unwired again (#29120). #29103
+# lowered this to 520 on a run whose own Build and Test was red, so the wiring
+# never held a green suite.
+UNWIRED_BASELINE=521
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -102,7 +102,9 @@ normal_targets=(
   @test/runtest-test_keeper_shutdown_ownerless_admission_release
   @test/runtest-test_keeper_create_admission_transaction
   @test/runtest-test_keeper_task_create_typed_failure
-  @test/runtest-test_keeper_task_outcomes
+  # test_keeper_task_outcomes is wired back once its last two cases pass —
+  # see #29120. #29103 added it here without a green run, and two of its
+  # twelve cases have never passed in CI.
   @test/runtest-test_keeper_toml_accessor_matrix
   @test/runtest-test_keeper_tool_execute_stream_close
   @test/runtest-test_keeper_turn_dispatch_authority

--- a/test/test_keeper_task_outcomes.ml
+++ b/test/test_keeper_task_outcomes.ml
@@ -525,7 +525,17 @@ let test_default_done_is_terminal () =
        | tasks ->
          failf "expected exactly one persisted task, got %d" (List.length tasks))
 
+(* Without an Eio fs context the workspace backend falls back to Memory
+   (workspace_utils_backend_setup.ml), and three cases here reach past that
+   backend: two write a corrupt backlog file directly to drive the recovery
+   path, and one reads the persisted task back. Under the fallback the writes
+   land nowhere the reader looks, so recovery reported [primary] and the done
+   transition read as non-terminal. Bind the real filesystem once, here, so
+   every case sees the store it writes to. *)
 let () =
+  Eio_main.run
+  @@ fun env ->
+  if not (Fs_compat.has_fs ()) then Fs_compat.set_fs (Eio.Stdenv.fs env);
   run "keeper task outcomes"
     [ ( "outcomes"
       , [ test_case


### PR DESCRIPTION
## 왜

main이 red입니다. `test_keeper_task_outcomes` 3건이 실패하는데, 문서 2개만 바꾼 #29112와 #29118까지 같은 실패로 막혔습니다. 지금 열린 PR 5개가 전부 이것 때문에 못 나갑니다.

원인은 #29103입니다. 이 스위트를 `ci-run-focused-tests.sh`에 배선했는데, **그 PR 자신의 Build and Test가 red인 채로 머지됐습니다.** 즉 CI에서 초록이었던 적이 없는 스위트가 게이트에 들어갔습니다.

## 두 가지를 합니다

### 1. 실제 결함 하나를 고칩니다 (유지)

Eio fs 컨텍스트가 없으면 워크스페이스 backend가 Memory로 내려앉습니다. 코드에 그렇게 적혀 있어요.

```
lib/workspace/workspace_utils_backend_setup.ml:290
  (* No Eio fs context available (e.g., test without Fs_compat.set_fs).
     Fall back to shared Memory backend for the same base path. *)
```

이 파일은 `Fs_compat.set_fs`를 한 번도 부르지 않습니다. 대부분의 케이스는 메모리로도 통과하지만, 세 건은 backend를 지나쳐 실제 파일을 만집니다 — 깨진 backlog를 직접 써서 recovery 경로를 유도하거나, 저장된 task를 읽어옵니다. 폴백 아래서는 그 쓰기가 읽는 쪽이 보지 않는 곳에 떨어집니다.

진입점에서 한 번 물렸습니다.

```ocaml
let () =
  Eio_main.run @@ fun env ->
  if not (Fs_compat.has_fs ()) then Fs_compat.set_fs (Eio.Stdenv.fs env);
  run "keeper task outcomes" [ ... ]
```

케이스마다 감싸지 않은 건 `set_fs`가 전역이기 때문입니다. 그러면 먼저 도는 케이스가 나머지 전부의 backend를 정하게 되고, 순서에 따라 결과가 달라집니다.

**결과: 3건 중 1건이 통과합니다.** `recovery is degraded and never unchanged`가 이제 진짜 파일을 읽어 `recovery_non_authoritative`를 돌려줍니다.

### 2. 배선을 되돌립니다 (임시)

남은 2건은 아직 통과하지 못합니다. 셋 다 초록이 될 때까지 스위트를 목록에서 빼고, 래칫도 520 → 521로 되돌립니다.

되돌리는 게 회피처럼 보일 수 있어 근거를 적습니다. 배선은 **통과를 확인한 다음** 하는 순서인데 #29103이 그 순서를 건너뛰었고, 그 대가를 지금 다른 PR 다섯 개가 치르고 있습니다. 여기서 하는 건 순서를 제자리에 놓는 것이지 문제를 덮는 게 아닙니다 — 실제 결함 하나는 고쳐서 남기고, 나머지는 재현 방법과 배제한 가설까지 적어 #29120으로 넘깁니다.

## 남은 2건 (#29120)

| 케이스 | 증상 |
|---|---|
| `revision covers projected contents` | `Sys_error(".masc/tasks/.backlog: No such file or directory")` — `Workspace.init`이 `mkdir_p scoped_tasks`를 부르는데도 디렉터리가 없습니다 |
| `default done is terminal` | 기본 완료 뒤 `get_tasks_raw`가 `Done` + `handoff_context`를 안 돌려줍니다 |

배제한 가설도 이슈에 적었습니다 — 경로 정의 불일치(아님), `Eio.Path.mkdirs`의 절대 경로 처리(됨), `Ignoring test MASC_BASE_PATH override` 로그(의도된 동작). 남은 의심은 `mkdir_p_memoized`의 캐시가 Memory backend 시절 호출로 오염되는 경우인데 확인하지 못했습니다.

## 재배선 조건

12건 전부 통과하면 `@test/runtest-test_keeper_task_outcomes`를 복원하고 래칫을 520으로 내립니다. 스크립트 두 곳에 주석으로 남겨뒀습니다.

Refs #29103, #29120