### PR TITLE
fix(dashboard): Observatory가 tool-quality의 시각 형식을 못 읽어 트랙이 영구히 비어 있다

### DIFF
--- a/dashboard/src/components/observatory/observatory-utils.test.ts
+++ b/dashboard/src/components/observatory/observatory-utils.test.ts
@@ -1,6 +1,24 @@
 import { describe, expect, it } from 'vitest'
 import type { TelemetryEntry } from '../../api/dashboard'
-import { bucketTelemetryEntries, isToolCall } from './observatory-utils'
+import { bucketTelemetryEntries, hourToMs, isToolCall } from './observatory-utils'
+
+describe('hourToMs', () => {
+  it('parses the hour-precision bucket the tool-quality API sends', () => {
+    // The exact shape of hourly_trend[].hour on /api/v1/dashboard/tool-quality.
+    // Left unparsed it returns null, every point is filtered out, and the
+    // success-rate track reads "hourly_trend 데이터 부족" against a store
+    // holding 122k tool calls.
+    expect(hourToMs('2026-08-18T07')).toBe(Date.parse('2026-08-18T07:00:00Z'))
+  })
+
+  it('passes a complete timestamp through unchanged', () => {
+    expect(hourToMs('2026-08-18T07:00:00Z')).toBe(Date.parse('2026-08-18T07:00:00Z'))
+  })
+
+  it('returns null for a string it cannot read', () => {
+    expect(hourToMs('not-a-time')).toBeNull()
+  })
+})
 
 describe('bucketTelemetryEntries', () => {
   it('keeps the latest entry as the representative inside each bucket', () => {

--- a/dashboard/src/components/observatory/observatory-utils.ts
+++ b/dashboard/src/components/observatory/observatory-utils.ts
@@ -15,8 +15,12 @@ export function entryTimestampMs(entry: TelemetryEntry): number | null {
   return null
 }
 
+/** tool-quality's hourly_trend buckets arrive as "2026-08-18T07" — hour precision,
+    no minutes. The shortest date-time ECMAScript parses is YYYY-MM-DDTHH:mm, so
+    that string yields NaN and every point is dropped downstream. Fill the missing
+    minutes and seconds; anything already complete is passed through. */
 export function hourToMs(hour: string): number | null {
-  const parsed = Date.parse(hour.includes('T') ? hour : `${hour}:00:00Z`)
+  const parsed = Date.parse(/T\d{2}$/.test(hour) ? `${hour}:00:00Z` : hour)
   return Number.isNaN(parsed) ? null : parsed
 }
 


### PR DESCRIPTION
## 증상

Observatory의 **도구 성공률** 트랙이 항상 `hourly_trend 데이터 부족`입니다. 범위를 24h로 넓혀도 같아요.

데이터가 없어서가 아닙니다. 대시보드가 **실제로 부르는 그 요청**이 이렇게 답합니다.

```
GET /api/v1/dashboard/tool-quality?n=2000

{ "total": 2000, "success_rate": 98.3,
  "hourly_trend": [ … 29개 … ],
  "by_tool": [ … 32개 … ], "by_keeper": [ … 8개 … ] }
```

스토어에는 `entry_count: 122429`가 있습니다.

## 원인 — 조건이 뒤집혀 있습니다

```typescript
const parsed = Date.parse(hour.includes('T') ? hour : `${hour}:00:00Z`)
```

포인트의 `hour`는 `"2026-08-18T07"`입니다. **시(hour)까지만 있고 분이 없어요.** ECMAScript가 파싱하는 최단 date-time은 `YYYY-MM-DDTHH:mm`이라 이 문자열은 `NaN`입니다.

```js
Date.parse("2026-08-18T07")         // NaN
Date.parse("2026-08-18T07:00:00Z")  // 1787036400000
```

붙이려던 `:00:00Z`는 **정확히 `"…T07"`에 맞는 모양**입니다. 그런데 그 경로가 `T`가 **없을 때**로 걸려 있어요. `T` 없는 값(`"2026-08-18"`)에 붙이면 `"2026-08-18:00:00Z"`가 되어 이것도 실패합니다. **두 분기 모두 실제 payload를 못 다루고, 동작하는 조합은 도달하지 못했습니다.**

`null`이 되면 소비하는 쪽이 전부 버립니다.

```typescript
// metric-track.ts:25-30
.filter(m => m.ts !== null && m.ts >= windowStart && m.ts <= windowEnd)
```

29개가 0개가 되고 `windowed.length === 0`이 "부족" 문구를 그립니다.

## 수정

끝이 `T` + 두 자리인 값에만 분·초를 채웁니다.

```typescript
const parsed = Date.parse(/T\d{2}$/.test(hour) ? `${hour}:00:00Z` : hour)
```

완전한 형태(`"…T07:00:00Z"`)는 `Z`로 끝나 정규식에 안 걸리고 그대로 지나갑니다.

## 검증 — 라이브 응답으로 대조

브라우저에서 실제 29개 포인트에 두 구현을 나란히 돌렸습니다.

| | 파싱 성공 |
|---|---|
| 기존 | **0 / 29** |
| 수정 | **29 / 29** |

완전한 타임스탬프는 여전히 통과하고, 읽을 수 없는 문자열은 여전히 `null`입니다.

## 테스트가 없어서 살아남았습니다

`hourToMs`에는 테스트가 하나도 없었습니다. 그래서 트랙이 영구히 비어 있는 동안에도 CI는 계속 초록이었어요. 세 개를 추가했고, 첫 번째는 API가 보내는 **문자 그대로의 형식**을 씁니다.

```typescript
expect(hourToMs('2026-08-18T07')).toBe(Date.parse('2026-08-18T07:00:00Z'))
```

## 남은 것

같은 패널의 **도구 호출** 트랙도 비어 있습니다. `total: 2000`이 응답에 있으니 같은 뿌리인지 확인이 필요한데, 이 PR 범위 밖이라 #29132에 적어뒀습니다.

Refs #29132