### PR TITLE
fix(health): backlog 이유에 깊이를 싣는다 — 560건과 1건이 같은 줄로 보이던 문제

### DIFF
--- a/lib/server/server_routes_http_runtime_health_fleet.ml
+++ b/lib/server/server_routes_http_runtime_health_fleet.ml
@@ -299,6 +299,15 @@ let keeper_event_queue_health_dimensions ~stale_after_sec = function
         source_status
         (Health_status.max_string storage_status work_status)
     in
+    (* A backlog reason carries how deep the backlog is. Without it every size
+       reads the same on screen: thirty paused keepers holding 560 stimuli look
+       exactly like one keeper holding one. The dashboard joins these strings as
+       they arrive and already shows key=value entries beside them
+       (status=…, operator_action_required=…), so the count travels without a
+       schema change. *)
+    let backlog_reason name count reasons =
+      if count > 0 then Printf.sprintf "%s=%d" name count :: reasons else reasons
+    in
     let status_reasons =
       []
       |> (fun reasons ->
@@ -309,24 +318,11 @@ let keeper_event_queue_health_dimensions ~stale_after_sec = function
         if transition_outbox_count > 0
         then "transition_projection_pending" :: reasons
         else reasons)
-      |> (fun reasons ->
-        if runnable_backlog_count > 0 then "runnable_backlog" :: reasons else reasons)
-      |> (fun reasons ->
-        if recoverable_backlog_count > 0
-        then "recoverable_backlog" :: reasons
-        else reasons)
-      |> (fun reasons ->
-        if retained_disabled_backlog_count > 0
-        then "retained_disabled_backlog" :: reasons
-        else reasons)
-      |> (fun reasons ->
-        if paused_dead_backlog_count > 0
-        then "paused_dead_backlog" :: reasons
-        else reasons)
-      |> (fun reasons ->
-        if shutdown_fenced_backlog_count > 0
-        then "shutdown_fenced_backlog" :: reasons
-        else reasons)
+      |> backlog_reason "runnable_backlog" runnable_backlog_count
+      |> backlog_reason "recoverable_backlog" recoverable_backlog_count
+      |> backlog_reason "retained_disabled_backlog" retained_disabled_backlog_count
+      |> backlog_reason "paused_dead_backlog" paused_dead_backlog_count
+      |> backlog_reason "shutdown_fenced_backlog" shutdown_fenced_backlog_count
       |> (fun reasons ->
         if backlog_stale then "runnable_backlog_stale" :: reasons else reasons)
       |> List.rev

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -1287,7 +1287,9 @@ let () =
   check
     "non-runnable actionable backlog carries an explicit reason"
     (match member "status_reasons" recoverable with
-     | `List reasons -> List.mem (`String "recoverable_backlog") reasons
+     (* The fixture above sets recoverable_backlog_count to 2, and the reason
+        now carries it so an operator can tell two from two hundred. *)
+     | `List reasons -> List.mem (`String "recoverable_backlog=2") reasons
      | _ -> false);
   check
     "non-runnable actionable backlog is never backlog-clean"


### PR DESCRIPTION
## 증상

대시보드 "주의 필요" 카드에 이렇게 뜹니다.

```
status=degraded · operator_action_required=true
  · keeper_event_queue:paused_dead_backlog
```

지금 라이브에서 이 한 줄 뒤에는 **정지한 keeper 30개가 붙들고 있는 560건**이 있고, 최고령은 32시간입니다. 그런데 1건이 5분 기다리는 상태와 화면상 구분이 안 됩니다.

## 원인

건수를 **읽고 나서 버립니다.**

```ocaml
(* server_routes_http_runtime_health_fleet.ml:246 *)
let paused_dead_backlog_count = queue_assoc_int "paused_dead_backlog_count" fields

(* :323 *)
if paused_dead_backlog_count > 0 then "paused_dead_backlog" :: reasons
```

`fleet_summary_json`은 이미 깊이·최고령·keeper별 내역을 전부 만들고 있습니다(`keeper_event_queue_persistence.ml:1666-1674`). 변환 단계가 그중 아무것도 통과시키지 않을 뿐입니다.

## 변경

다섯 backlog 이유가 모두 같은 모양이라 헬퍼로 묶고 `name=count` 형태로 바꿉니다.

```ocaml
let backlog_reason name count reasons =
  if count > 0 then Printf.sprintf "%s=%d" name count :: reasons else reasons
in
...
|> backlog_reason "runnable_backlog" runnable_backlog_count
|> backlog_reason "recoverable_backlog" recoverable_backlog_count
|> backlog_reason "retained_disabled_backlog" retained_disabled_backlog_count
|> backlog_reason "paused_dead_backlog" paused_dead_backlog_count
|> backlog_reason "shutdown_fenced_backlog" shutdown_fenced_backlog_count
```

## 스키마를 안 건드리는 근거

**소비자가 없습니다.** `lib`·`test`·`dashboard/src`·`bin`을 절단 없이 훑으면 다섯 리터럴이 **생산 지점에만** 있습니다.

그리고 대시보드는 받은 문자열을 그대로 이어붙입니다.

```typescript
// dashboard-composite-health.ts:138,156
const reasons = health?.operator_action_reasons?.filter(r => r.trim() !== '') ?? []
detail: [`status=${status}`, `operator_action_required=${requiresAction}`, ...reasons, ...]
          .join(' · ')
```

빈 문자열만 걸러내고, **이미 옆에 `key=value` 항목이 놓여 있습니다.** 그래서 새 필드를 만들지 않아도 숫자가 화면까지 갑니다.

## 테스트

옛 형태를 고정한 단언이 하나 있어 함께 바꿨습니다.

```ocaml
- List.mem (`String "recoverable_backlog") reasons
+ List.mem (`String "recoverable_backlog=2") reasons
```

그 픽스처가 `recoverable_backlog_count`를 `Int 2`로 두므로, 이제 **이름만이 아니라 숫자까지** 검증합니다.

## 남는 것

최고령(`paused_dead_oldest_age_seconds`)과 keeper별 내역(`paused_dead_by_keeper`)은 여전히 화면에 안 옵니다. 이유 문자열에 밀어 넣기엔 길어서, 별도 표면이 맞아 보입니다. #29119에 남겨둡니다.

Refs #29119