### PR TITLE
refactor(keeper): clear remaining constitution forbidden patterns

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -132,6 +132,17 @@ let runtime_yield_reason request =
     Runtime_agent.Durable_stimulus_waiting
 ;;
 
+(* Constitution exception (named bound + rationale): loop detection is
+   inherently a repetition count, so no closed variant can replace the
+   number — what counts as "the same call" is already typed (tool name +
+   input/output fingerprints in [same_exact_tool_call]). The yield is a
+   cooperative turn boundary, not a keeper lifecycle gate: the keeper loop
+   stays active and decides the next cycle from the yielded outcome. 3 =
+   the first call plus two identical repeats: a single repeat (count 2) can
+   still be legitimate (an idempotent poll or a deliberate re-read while the
+   model waits for state to change); the second consecutive repeat with an
+   unchanged input AND output fingerprint means the world did not change
+   and the model made no progress — a deterministic loop. *)
 let repeated_tool_call_yield_threshold = 3
 
 let same_present_fingerprint left right =

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -164,7 +164,19 @@ let is_provider_wire_error (err : Agent_core.Error.t) : bool =
       message text is matched here — free-form provider bodies are not a
       classification source (see [is_provider_rejected_parse_error]).
     - ["Context overflow: empty completion"] — a context-overflow diagnostic,
-      already classified by [is_context_overflow] on the typed path. *)
+      already classified by [is_context_overflow] on the typed path.
+
+    Why a string prefix survives here (constitution exception, RFC-0371
+    §3.7): the typed [stop_reason] is deliberately flattened into [detail]
+    at the agent-core boundary (agent_core [Error.of_provider_failure],
+    [Empty_attributed] arm), so by the time the error reaches MASC the
+    prefix is the ONLY remaining discriminator between an empty-completion
+    [ProviderUnavailable] and the other [ProviderUnavailable] producers
+    (CLI startup failure, unknown provider failure). The marker is owned by
+    a single renderer ([error.ml]: ["empty completion (stop_reason=%s): %s"]),
+    not free-form provider prose. Re-typing requires a pinned Agent Core
+    error-variant change; that pin update — not this classifier — is where
+    the typed shape must be introduced. *)
 let is_empty_completion_error (err : Agent_core.Error.t) : bool =
   match err with
   | Agent_core.Error.Provider

--- a/lib/keeper/keeper_unified_metrics_support.ml
+++ b/lib/keeper/keeper_unified_metrics_support.ml
@@ -344,7 +344,6 @@ let turn_mode_of_result (result : Keeper_agent_run.run_result) : turn_mode =
   let text = String.trim result.response_text in
   if has_visible_tool_signal result then Tool_use
   else if text = "" then Noop
-  else if String.starts_with ~prefix:"SKIP:" text then Skip_text
   else Text_response
 
 let turn_mode_of_json = Turn_mode_codec.turn_mode_of_json

--- a/lib/keeper/keeper_unified_turn_failure.ml
+++ b/lib/keeper/keeper_unified_turn_failure.ml
@@ -10,7 +10,16 @@ module EC = Keeper_error_classify
    the 2026-07-21 provider-parse-rejection incident. The counter is
    process-local, which is where the unbounded loop lives; once the bound is
    exceeded the observation degrades to ordinary (durable) crash accounting,
-   so restarts cannot reset the bound either. *)
+   so restarts cannot reset the bound either.
+
+   Constitution exception (named bound + rationale): this number gates only
+   crash ACCOUNTING, never the keeper lifecycle — the keeper stays active
+   either way (see the "Keeper lifecycle remains active" log in
+   [record_failure_observation]). The failure class is deterministic
+   (identical request, identical 400), so the bound is not there to absorb
+   flakiness; 3 gives a poisoned checkpoint a few cycles in which an
+   intervening compaction or operator context clear can change the request
+   before durable accounting resumes. *)
 let max_consecutive_invalid_request_failures = 3
 
 let invalid_request_consecutive : (string, int) Hashtbl.t = Hashtbl.create 8
@@ -39,7 +48,15 @@ let reset_invalid_request_failures ~keeper_name =
     [empty_completion_exemption_budget] consecutive exempted empty-completion
     failures; the next one counts toward the crash threshold again.  A
     successful turn (or an operator context clear) resets the budget via
-    {!note_turn_success}. *)
+    {!note_turn_success}.
+
+    Constitution exception (named bound + rationale): like the
+    [InvalidRequest] bound above, this gates crash ACCOUNTING only, not the
+    keeper lifecycle.  Unlike [InvalidRequest], an empty completion can be
+    transient provider flakiness (a degraded backend answering empty turns
+    while it recovers), so the budget deliberately leaves room — 5
+    consecutive exempted failures — for the provider to recover across
+    cycles before the failure class degrades to durable crash accounting. *)
 let empty_completion_exemption_budget = 5
 
 let empty_completion_exemptions : (string, int) Hashtbl.t = Hashtbl.create 8


### PR DESCRIPTION
## Summary

Cleans up the 4 remaining constitution forbidden-pattern sites (magic-number keeper flow control, string-matching logic decisions) identified by audit. Each site was re-verified by reading the source before acting.

## Per-item disposition

1. **`keeper_unified_metrics_support.ml` — `"SKIP:"` prefix match (removed)**
   `turn_mode_of_result` classified a trimmed response starting with `"SKIP:"` as `Skip_text`. Repo-wide grep confirms the `"SKIP:"` literal exists only here (the other hit is an unrelated shell lint script), and no prompt instructs this convention — the branch is dead. Removed the string-matching branch. The `Skip_text` **constructor is kept**: `Turn_mode_codec.turn_mode_of_string` still decodes historical `"skip_text"` payloads, so the variant stays live on the decode path. Only behavior change in this PR, and it is unreachable in practice.

2. **`keeper_error_classify.ml:184` — `ProviderUnavailable` detail prefix match (kept, justified)**
   The typed `stop_reason` is deliberately flattened into the free-text `detail` at the agent-core boundary (`Error.of_provider_failure`, `Empty_attributed` arm, `packages/agent_core/lib/llm_provider/error.ml`), so by the time the error reaches MASC the renderer-owned `"empty completion (stop_reason="` marker is the **only** discriminator between an empty-completion `ProviderUnavailable` and its other producers (CLI startup failure, unknown provider failure). Re-typing requires a pinned Agent Core error-variant change — out of minimal-change scope. Added an explicit constitution-exception note naming the boundary, the single renderer that owns the marker, and RFC-0371 §3.7 as the place a typed shape must be introduced.

3. **`keeper_unified_turn_failure.ml` — `max_consecutive_invalid_request_failures = 3`, `empty_completion_exemption_budget = 5` (exception, justified)**
   Judged a legitimate exception: these counters gate crash **accounting** only — the keeper lifecycle stays active either way (`record_failure_observation` logs "Keeper lifecycle remains active"). Without the bounds, both exempted failure classes would loop forever with the crash counter pinned at 0 (the 2026-07-21 incident shape). No typed replacement exists — the bound *is* a count. Added declaration-site rationale: why 3 for the deterministic `InvalidRequest` class (a few cycles for an intervening compaction/operator clear to change the request) and why 5 for empty completions (possibly transient provider flakiness, leave room to recover across cycles).

4. **`keeper_agent_run.ml` — `repeated_tool_call_yield_threshold = 3` (exception, justified)**
   Loop detection is inherently a repetition count, so no closed variant can replace the number. What counts as "the same call" is already typed (tool name + input/output fingerprints via `same_exact_tool_call`), and the yield is a cooperative turn boundary, not a keeper lifecycle gate. Rationale comment records why 3: one identical repeat can be legitimate (idempotent poll / re-read while waiting for state); the second consecutive repeat with unchanged input AND output fingerprints means no progress — a deterministic loop.

## Verification

- No local dune build/test run per project rule — CI validates.
- Grep-verified: no test references `Skip_text`/`skip_text` production or the `"SKIP:"` convention; the only producer of the empty-completion marker at the pinned Agent Core is the documented renderer.
- Net diff: +43/−4 across 4 files; comments plus one dead-branch deletion.

## Notes

`docs/NORTH-STAR-OCAML.md` quotes `turn_mode` in a 2026-04 historical analysis section; the variant itself is unchanged (`Skip_text` retained), so no doc update needed.