### PR TITLE
feat(keeper): parallel tool use — 감사된 read-only 툴 4종 Concurrent 배치 승격 + fail-closed admission

### DIFF
--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -580,6 +580,23 @@ let descriptor
       | Tool_masc_local_runtime_dispatch
       | Tool_analyze_image ) -> Ordinary ordinary_execution_mode
   in
+  (* Fail-closed admission rule for parallel tool use: a descriptor may opt
+     into [Concurrent] batches only when its policy carries a static
+     read-only hint. The batch planner (Agent_core Agent_tool_batch_plan)
+     fans an ordinary [Concurrent] run out onto sibling Eio fibers, so an
+     effectful tool admitted by mistake would execute its side effect
+     concurrently with no ordering guarantee. The hint is the same typed
+     declaration the composition catalog uses for its Async admission
+     check (Async_tool_not_statically_read_only); no string heuristics. *)
+  (match execution, policy.readonly_hint with
+   | Ordinary Concurrent, Some true -> ()
+   | Ordinary Concurrent, (Some false | None) ->
+     invalid_arg
+       (Printf.sprintf
+          "descriptor %S declares Concurrent execution without a static \
+           read-only policy hint"
+          internal_name)
+   | Ordinary Serial, _ | Terminal, _ -> ());
   let receipt_labels =
     [ "descriptor_id", id
     ; "capability_id", capability_id
@@ -755,6 +772,10 @@ let public_descriptors =
          literal newline in `pattern` is rejected. To match across lines, run \
          `rg -U` through the Execute tool."
       ~input_schema:search_files_schema
+      (* Concurrent: each call spawns its own rg process through the sandbox
+         backend; the only shared write is the bash-history audit line, a
+         single O_APPEND write with no fiber yield inside it. *)
+      ~ordinary_execution_mode:Concurrent
       ~policy:
         (policy
            ~readonly:true
@@ -785,6 +806,10 @@ let public_descriptors =
          Execute tool with ls. Pass cwd explicitly for repo-relative reads. Read \
          never inherits Execute cwd."
       ~input_schema:read_file_schema
+      (* Concurrent: a pure read — containment check plus either a host
+         file read (Safe_ops.read_file_result) or a per-call backend read
+         runner process; no shared mutable state on the path. *)
+      ~ordinary_execution_mode:Concurrent
       ~policy:
         (policy
            ~readonly:true
@@ -866,6 +891,10 @@ let public_descriptors =
       ~internal_name:Tool_schemas_misc.web_search_schema.name
       ~description:Tool_schemas_misc.web_search_schema.description
       ~input_schema:Tool_schemas_misc.web_search_schema.input_schema
+      (* Concurrent: every call runs its own curl subprocess via
+         Tool_local_runtime_http; provider selection reads env only, so
+         there is no shared mutable state between sibling calls. *)
+      ~ordinary_execution_mode:Concurrent
       ~policy:
         (policy
            ~readonly:true
@@ -886,6 +915,12 @@ let public_descriptors =
       ~internal_name:Tool_schemas_misc.web_fetch_schema.name
       ~description:Tool_schemas_misc.web_fetch_schema.description
       ~input_schema:Tool_schemas_misc.web_fetch_schema.input_schema
+      (* Concurrent: per-call curl subprocess; the full-text offload writes
+         into the content-addressed Tool_blob_store (Atomic CAS cache, the
+         same store keeper_artifact_read already reads concurrently) and
+         appends the index row through Fs_compat.append_jsonl's per-path
+         mutex. *)
+      ~ordinary_execution_mode:Concurrent
       ~policy:
         (policy
            ~readonly:true

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -1264,8 +1264,27 @@ let test_concurrent_execution_opt_ins_are_exact () =
     ; "masc_task_history"
     ; "masc_tasks"
     ; "masc_tool_help"
+    ; "masc_web_fetch"
+    ; "masc_web_search"
+    ; "tool_read_file"
+    ; "tool_search_files"
     ]
     concurrent_internal_names
+
+let test_concurrent_opt_ins_are_statically_read_only () =
+  (* Property mirror of the fail-closed admission rule enforced by the
+     [Descriptor.descriptor] constructor: a Concurrent descriptor without a
+     static read-only hint cannot be constructed, so the registry must never
+     contain one. *)
+  all_descriptors ()
+  |> List.iter (fun (descriptor : Descriptor.t) ->
+    match descriptor.execution, Descriptor.readonly_static_hint descriptor with
+    | Descriptor.Ordinary Descriptor.Concurrent, Some true -> ()
+    | Descriptor.Ordinary Descriptor.Concurrent, (Some false | None) ->
+      Alcotest.fail
+        (descriptor.internal_name
+         ^ " opts into concurrent batches without a static read-only hint")
+    | Descriptor.Ordinary Descriptor.Serial, _ | Descriptor.Terminal, _ -> ())
 
 let test_readonly_policy_is_descriptor_input_aware () =
   let public_input =
@@ -1724,6 +1743,10 @@ let () =
             "concurrent execution opt-ins are exact"
             `Quick
             test_concurrent_execution_opt_ins_are_exact
+        ; test_case
+            "concurrent execution opt-ins are statically read-only"
+            `Quick
+            test_concurrent_opt_ins_are_statically_read_only
         ; test_case
             "descriptor owns the read-only metadata projection"
             `Quick


### PR DESCRIPTION
## 조사 결과 (현재 상태)

**직렬 실행 경로**: Keeper 턴의 tool call은 `Keeper_tools_agent_core_bundle.make_tool_bundle_for_descriptors`(lib/keeper/keeper_tools_agent_core_bundle.ml:242-257)가 각 keeper descriptor의 `execution` 필드를 `Agent_core.Tool` descriptor로 사상하고, agent_core 런 루프가 `Agent_tools.execute_tools`(packages/agent_core/lib/agent/agent_tools.ml:953)로 디스패치한다. 여기서 `Agent_tool_batch_plan.create`가 `Tool_contract.Concurrent` 선언 툴의 연속 run을 `Concurrent_batch`로 묶어 `Eio.Fiber.List.map`으로 fan-out한다(agent_tools.ml:1041-1047). 즉 **병렬 실행 엔진 자체는 이미 존재**하며, per-call 결과 variant(실패가 형제 결과를 조용히 죽이지 않음)도 `test_concurrent_journal_failure_retains_sibling_results` 등으로 검증돼 있다.

**`disable_parallel_tool_use` 소비부**: 억제 플래그는 wire 수준에서 이미 소비된다 — `Capabilities.effective_disable_parallel_tool_use`가 Anthropic(`tool_choice.disable_parallel_tool_use`)·OpenAI(`parallel_tool_calls=false`)·Ollama 요청 빌더에 배선돼 있다(packages/agent_core/lib/llm_provider/backend_anthropic.ml:292, backend_openai_request.ml:414, backend_ollama.ml:158). 감사가 지적한 것은 실행 측이다.

**Wire 지원 여부**: 지원된다. Anthropic content block은 한 턴에 복수 `tool_use`를 자연스럽게 담고, provider capability에 `supports_parallel_tool_calls`가 있다. 라이브 증거도 있다: 2026-08-19 실측에서 `execution_mode=concurrent` 118콜·batch_size 2~4 배치 52건이 복수 keeper(rondo 104·sangsu 11·analyst 5)에서 관측됐다(docs/evidence/keeper-parallel-batch-live-2026-08-19.json, docs/design/keeper-feature-state-matrix-2026-08-13.html "Parallel Tool" 행). 단 그 배치는 `masc_task_history`·`keeper_tasks_list` 등 **내부 클러스터 읽기 툴 7종**에 한정됐다 — 모델이 실제로 가장 많이 묶어 부르는 공개 read 툴(Read/Grep/WebSearch/WebFetch)이 `Serial` 기본값에 갇혀 있었기 때문이다(08-17 소스 감사: "Concurrent 선언 descriptor가 2개뿐" → 이후 클러스터 툴 중심으로 부분 승격됐으나 공개 read 툴은 미승격).

## 설계

캠페인 플랜 A3-1(docs/design/composition-campaign-plan-2026-08-18.md:97)의 "readonly 서술자 일괄 승격 — 핸들러 동시성 안전성 감사 후 `ordinary_execution_mode:Concurrent`"를 공개 read 툴에 적용한다. 판정은 기존 typed 선언(`policy.readonly_hint`, composition catalog의 `Async_tool_not_statically_read_only` admission이 쓰는 것과 동일, keeper_tool_composition_catalog.ml:445)을 재사용한다. 문자열 휴리스틱 없음.

1. **4개 공개 read 툴 승격** — 각각 핸들러 감사 근거를 descriptor에 주석으로 기록:
   - `tool_read_file` (Read): containment 체크 + 호스트 파일 읽기 또는 호출당 backend read-runner 프로세스. 공유 가변 상태 없음.
   - `tool_search_files` (Grep): 호출당 rg 프로세스 spawn. 유일한 공유 쓰기인 bash-history 감사 행은 O_APPEND 단일 write로 fiber yield 지점이 없다(lib/exec/bash_history.ml:56).
   - `masc_web_search` (WebSearch): 호출당 curl 서브프로세스(Tool_local_runtime_http), provider 선택은 env 읽기뿐.
   - `masc_web_fetch` (WebFetch): 호출당 curl; full-text offload는 content-addressed `Tool_blob_store`(Atomic CAS — 이미 Concurrent인 `keeper_artifact_read`가 읽는 같은 스토어) + `Fs_compat.append_jsonl`의 경로별 mutex.

2. **Fail-closed admission 규칙** (keeper_tool_descriptor.ml `descriptor` 생성자): `Ordinary Concurrent`인데 `readonly_static_hint <> Some true`이면 `invalid_arg`로 레지스트리 빌드(=서버 부팅) 시점에 실패. 부작용 툴이 실수로 병렬 배치에 admission되는 것을 타입 수준 닫힌 판정으로 차단한다.

3. **관측성**: 기존 자산으로 충분 — 각 디스패치의 `schedule`이 `execution_mode`/`batch_index`/`batch_size`/`planned_index`를 agent-core-events와 raw trace에 기록한다(keeper_tools_agent_core_handler_telemetry.ml:71, keeper_event_bridge.ml:194). 위 라이브 증거 JSON이 이 관측 경로의 산출물이다.

## 테스트

- `test_concurrent_execution_opt_ins_are_exact`: opt-in 정확 목록 핀에 4개 이름 추가.
- `test_concurrent_opt_ins_are_statically_read_only` (신규): 생성자 규칙의 프로퍼티 미러 — 레지스트리 전수 순회하며 Concurrent ⇒ 정적 read-only 불변식 검증.

로컬 dune 빌드/테스트는 실행하지 않았다(작업 지침). CI가 검증한다.

## 범위 밖 (후속 감사 후보)

- `keeper_context_status` (`Keeper_sandbox_control.live_status_json ~include_preflight:true`가 샌드박스 프로브를 spawn — 병렬 격상은 샌드박스 제어 경로 감사가 선행), `keeper_surface_read` (Discord 라이브 읽기 레인의 공유 클라이언트 상태 미감사), `keeper_memory_search` (decision-log append는 mutex 보호되나 검색 경로 감사 미완), `keeper_voice_agent`/`keeper_voice_sessions` (voice 런타임 상태), `masc_run_plan`·`masc_dashboard`·`masc_check`·`keeper_vision_analyze_image` — 전부 `readonly:true`이나 Serial 유지.
- official client host 경로(keeper_official_client_host.ml:629)는 호출당 `batch_size=1`로 디스패치 — 외부 하네스가 순차 호출하므로 서버 측 병렬화 대상이 아니다.
