### PR TITLE
feat(keeper): declare tool kind as a closed sum type (RFC-0386)

### DIFF
--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -232,6 +232,7 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0383 | 웹 아티팩트는 쌓이기만 한다 — 오프로드 파일을 재질의 가능한 코퍼스로 | Draft | - |
 | 0384 | In-process Telegram connector (long polling) | Proposed | - |
 | 0385 | 자율턴은 대화가 아니다 | Draft | - |
+| 0386 | 툴 종류(tool kind)는 닫힌 합타입으로 선언한다 | Draft | - |
 | RFC-async-log-sink-durable-append-offload | Offload the structured-log durable append off the emitting fiber | Draft | - |
 | RFC-checkpoint-pinned-root-containment | Immutable boot-pinned root capability for checkpoint containment | Draft | - |
 | RFC-claude-code-context-overflow-bounded-restart | Admit Claude Code bootstrap input without replaying rejected episodes | Draft | - |

--- a/docs/rfc/RFC-0386-tool-kind-closed-declaration.md
+++ b/docs/rfc/RFC-0386-tool-kind-closed-declaration.md
@@ -1,0 +1,94 @@
+---
+title: 툴 종류(tool kind)는 닫힌 합타입으로 선언한다
+rfc: "0386"
+status: Draft
+created: 2026-08-19
+author: vincent
+related: ["0378", "0179"]
+---
+
+# RFC-0386 — 툴 종류(tool kind)는 닫힌 합타입으로 선언한다
+
+## 1. 결정
+
+Keeper 툴 하나가 "단일 실행 단위인지, 합성/배치 실행 단위인지" 를 닫힌
+합타입으로 선언한다. 타입은 `Keeper_tool_descriptor.tool_kind` 다.
+
+```ocaml
+type tool_kind =
+  | Atomic_tool              (* 한 호출 = 한 capability 실행 *)
+  | Composition_tool         (* 카탈로그 고정 plan, inline 실행 *)
+  | Async_composition_tool   (* durable async 합성 + status/cancel 컨트롤 *)
+  | Batch_plan_tool          (* 모델 정의 plan을 하나의 DAG 로 실행 *)
+```
+
+실행 기계는 새로 만들지 않는다. 이미 존재하는 것들을 이 분류가 가리킬
+뿐이다:
+
+- `packages/agent_core/lib/agent/agent_tool_batch_plan.ml` — Serial /
+  Concurrent 배치 계획, `agent_tools.ml` 의 `execute_tools`
+- `lib/keeper/keeper_tool_plan.ml` — 닫힌 typed plan IR 과
+  `Keeper_tool_plan_executor`
+- `lib/keeper/keeper_tool_composition_catalog.ml` — TOML 카탈로그
+  (Inline / Async), `keeper_tool_composition_surface.ml` 의
+  `keeper_plan_execute`, `keeper_composition_status`, `keeper_composition_cancel`
+
+`execution` 필드(`Ordinary Serial/Concurrent | Terminal`) 와 직교하는
+축이다. `execution` 은 호출이 "어떻게" 실행되는지, `tool_kind` 는 호출이
+"무엇을" 담고 있는지를 분류한다.
+
+constitution feature_surface 용어와의 1:1 매핑:
+
+| feature_surface | tool_kind | 코드 대응물 |
+|---|---|---|
+| Multitools | `Composition_tool` | 카탈로그 `keeper_compose_*` (inline) |
+| AsyncTools | `Async_composition_tool` | async 카탈로그 엔트리 + `keeper_composition_status` / `keeper_composition_cancel` |
+| Batch Tools | `Batch_plan_tool` | `keeper_plan_execute` |
+| (기본) | `Atomic_tool` | 나머지 모든 descriptor-backed 툴 |
+
+## 2. 배경
+
+parity matrix B6("Batch/Multitool 실행 개념 부재")의 선행 조사 결론:
+실행 기계는 존재하지만, "이 툴이 합성/배치 실행 단위다" 를 선언하는 닫힌
+합타입이 descriptor/카탈로그 수준에 없었다. `keeper_tool_group` 은
+discovery 전용 분류라 실행 의미를 얹을 수 없다. 이 RFC 가 그 선언층을
+추가한다.
+
+## 3. 선언 위치
+
+- `Keeper_tool_descriptor.t.tool_kind` — descriptor-backed 툴은 전부
+  `Atomic_tool` 로 선언된다. 빌더(`descriptor`)의 기본값이며, 문자열
+  분류는 없다.
+- `Keeper_tool_composition_catalog.tool_kind` — 엔트리의
+  `execution : Inline | Async` 에서 타이프드하게 유도한다
+  (Inline → `Composition_tool`, Async → `Async_composition_tool`).
+  `status_tool_kind` / `cancel_tool_kind` 는 `Async_composition_tool` 다.
+- `Keeper_tool_composition_surface.plan_execute_tool_kind` —
+  `Batch_plan_tool`.
+
+parse 는 strict 하다. `tool_kind_of_string` 은 알 수 없는 문자열을
+`Error` 로 거부하며, 어떤 폴백 분류도 하지 않는다.
+
+## 4. 노출
+
+`route_evidence_json` 과 `discovery_fields` 가 `"tool_kind"` 필드를
+실는다. evidence 소비자는 키로 읽으므로 additive 변경이다.
+
+## 5. 범위 밖
+
+- 새 실행 엔진 — 금지. 기존 기계를 재사용한다.
+- keeper 툴의 `Concurrent` 선언 확대 — 별도 PR.
+- MCP 경로 배치 실행 — 이 RFC 의 대상이 아니다.
+- `keeper_tool_group` 의미 변경 — discovery 전용 분류를 유지한다.
+
+## 6. 검증
+
+`test/test_keeper_tool_kind.ml`:
+
+- 4개 생성자의 `tool_kind_to_string` / `tool_kind_of_string` 왕복과 문자열
+  유일성.
+- unknown 문자열 거부(fail-closed).
+- 전체 descriptor 가 `Atomic_tool` 을 선언하고 route/discovery evidence 에
+  `"tool_kind": "atomic"` 이 실리는지.
+- 카탈로그 inline/async 엔트리와 status/cancel 컨트롤,
+  `keeper_plan_execute` 의 kind 태깅.

--- a/docs/rfc/RFC-0386-tool-kind-closed-declaration.md
+++ b/docs/rfc/RFC-0386-tool-kind-closed-declaration.md
@@ -71,8 +71,24 @@ parse 는 strict 하다. `tool_kind_of_string` 은 알 수 없는 문자열을
 
 ## 4. 노출
 
-`route_evidence_json` 과 `discovery_fields` 가 `"tool_kind"` 필드를
-실는다. evidence 소비자는 키로 읽으므로 additive 변경이다.
+두 경로가 있다. 어느 쪽도 문자열 매칭으로 분류하지 않는다.
+
+1. **descriptor-backed 툴** — `route_evidence_json` 과
+   `discovery_fields` 가 `"tool_kind"` 필드를 실는다(현재 전부
+   `"atomic"`).
+2. **composition surface 툴** — `keeper_compose_*`,
+   `keeper_plan_execute`, `keeper_composition_status/cancel` 은 TOML
+   카탈로그에서 구체화되는 `Agent_core.Tool.t` 이며 Keeper descriptor
+   registry 에 속하지 않는다(`Keeper_tool_descriptor_resolution` 이
+   `None` 을 반환). 따라서 descriptor route evidence 경로는 이 툴들을
+   커버하지 않고, kind 는 이 툴들 자신의 관측 경로에 실린다:
+   - 실행/제출 결과 payload (`result_of_execution`, `failure_data`,
+     async submission, status/cancel 결과) 의 `"tool_kind"` 필드
+   - 노드별 tool-call log envelope 의 `"composition_tool_kind"` 필드
+     (typed `?composition_tool_kind` 파라미터로 전달)
+   - 호출 route evidence: `route_evidence_json_of_tool_io` 가 출력
+     payload 의 `"tool_kind"` 를 흡수한다. composition 툴 호출의
+     `route_evidence` 에 kind 가 나타난다.
 
 ## 5. 범위 밖
 
@@ -92,3 +108,7 @@ parse 는 strict 하다. `tool_kind_of_string` 은 알 수 없는 문자열을
   `"tool_kind": "atomic"` 이 실리는지.
 - 카탈로그 inline/async 엔트리와 status/cancel 컨트롤,
   `keeper_plan_execute` 의 kind 태깅.
+- composition surface 툴의 실제 관측 경로: status/cancel 결과 payload 에
+  `"tool_kind": "async_composition"` 이 실리고, composition/batch_plan 툴
+  호출의 route evidence 에 각각 `"composition"` / `"batch_plan"` 이
+  나타나는지.

--- a/lib/keeper/keeper_tool_composition_catalog.ml
+++ b/lib/keeper/keeper_tool_composition_catalog.ml
@@ -93,6 +93,15 @@ let execution_mode_to_string = function
   | Async -> "async"
 ;;
 
+let tool_kind (entry : entry) =
+  match entry.execution with
+  | Inline -> Keeper_tool_descriptor.Composition_tool
+  | Async -> Keeper_tool_descriptor.Async_composition_tool
+;;
+
+let status_tool_kind = Keeper_tool_descriptor.Async_composition_tool
+let cancel_tool_kind = Keeper_tool_descriptor.Async_composition_tool
+
 let path ~config_root = Filename.concat config_root "tool-compositions.toml"
 
 let entries catalog = catalog

--- a/lib/keeper/keeper_tool_composition_catalog.mli
+++ b/lib/keeper/keeper_tool_composition_catalog.mli
@@ -97,6 +97,16 @@ val tool_name : entry -> string
 
 val execution_mode_to_string : execution_mode -> string
 
+(** Execution-semantics kind (RFC-0386) declared by the entry's execution
+    mode: [Inline] entries are [Composition_tool], [Async] entries are
+    [Async_composition_tool]. *)
+val tool_kind : entry -> Keeper_tool_descriptor.tool_kind
+
+(** The shared async request controls operate on async composition runs, so
+    both are [Keeper_tool_descriptor.Async_composition_tool]. *)
+val status_tool_kind : Keeper_tool_descriptor.tool_kind
+val cancel_tool_kind : Keeper_tool_descriptor.tool_kind
+
 val model_tool_names : t -> string list
 (** Exact model-visible composition surface, including the shared status and
     cancel controls when at least one async composition is declared. *)

--- a/lib/keeper/keeper_tool_composition_surface.ml
+++ b/lib/keeper/keeper_tool_composition_surface.ml
@@ -15,6 +15,19 @@ let plan_execute_tool_name = "keeper_plan_execute"
 
 let plan_execute_tool_kind = Keeper_tool_descriptor.Batch_plan_tool
 
+(* Composition tools are materialized Agent_core tools outside the Keeper
+   descriptor registry, so their tool kind is observable through their own
+   result payloads and node telemetry — never through descriptor route
+   evidence. *)
+let tool_kind_field kind =
+  "tool_kind", `String (Keeper_tool_descriptor.tool_kind_to_string kind)
+;;
+
+let with_tool_kind_field kind = function
+  | `Assoc fields -> `Assoc (tool_kind_field kind :: fields)
+  | json -> json
+;;
+
 let plan_execute_input_schema =
   let node_schema =
     `Assoc
@@ -128,6 +141,7 @@ let node_result_to_json (result : Executor.node_result) =
 let observe_node_result
       ~composition_tool
       ~composition_execution
+      ~composition_tool_kind
       ~composition_run_id
       ~parent_invocation
       ~meta
@@ -167,6 +181,7 @@ let observe_node_result
         (Keeper_tool_plan.Composition_run_id.to_string composition_run_id)
       ~composition_node_id:(Keeper_tool_plan.Node_id.to_string result.node_id)
       ~composition_execution
+      ~composition_tool_kind
       ~parent_tool_use_id:
         (Agent_core.Tool_contract.Invocation.tool_use_id parent_invocation)
       ?trace_id:context.trace_id
@@ -199,6 +214,9 @@ let observe_node_result
         , `String
             (Keeper_tool_composition_catalog.execution_mode_to_string
                composition_execution) )
+      ; ( "composition_tool_kind"
+        , `String
+            (Keeper_tool_descriptor.tool_kind_to_string composition_tool_kind) )
       ; ( "parent_tool_use_id"
         , `String
             (Agent_core.Tool_contract.Invocation.tool_use_id parent_invocation) )
@@ -379,9 +397,10 @@ let cause_to_json = function
       ]
 ;;
 
-let failure_data ~tool_name (failure : Executor.failure) =
+let failure_data ~tool_name ~tool_kind (failure : Executor.failure) =
   `Assoc
     [ "composition_tool", `String tool_name
+    ; tool_kind_field tool_kind
     ; "settled", `List (List.map node_result_to_json failure.settled)
     ; "cause", cause_to_json failure.cause
     ; ( "effect_disposition"
@@ -403,7 +422,7 @@ let failure_class (failure : Executor.failure) =
     Tool_result.Runtime_failure
 ;;
 
-let result_of_execution ~tool_name ~start_time = function
+let result_of_execution ~tool_name ~tool_kind ~start_time = function
   | Ok settled ->
     Tool_result.make_ok
       ~tool_name
@@ -411,13 +430,14 @@ let result_of_execution ~tool_name ~start_time = function
       ~data:
         (`Assoc
             [ "composition_tool", `String tool_name
+            ; tool_kind_field tool_kind
             ; "actions", `List (List.map node_result_to_json settled)
             ])
       ()
   | Error
       ({ Executor.cause = Executor.Tool_did_not_complete result; _ } as failure :
         Executor.failure) ->
-    let data = failure_data ~tool_name failure in
+    let data = failure_data ~tool_name ~tool_kind failure in
     (match result.result with
      | Tool_result.Deferred payload ->
        Tool_result.make_deferred
@@ -442,7 +462,7 @@ let result_of_execution ~tool_name ~start_time = function
          ~data
          "composition executor reported a completed result as incomplete")
   | Error failure ->
-    let data = failure_data ~tool_name failure in
+    let data = failure_data ~tool_name ~tool_kind failure in
     Tool_result.make_err
       ~tool_name
       ~class_:Tool_result.Runtime_failure
@@ -498,6 +518,7 @@ let async_worker_result
             observe_node_result
               ~composition_tool:tool_name
               ~composition_execution:entry.execution
+              ~composition_tool_kind:(Catalog.tool_kind entry)
               ~composition_run_id
               ~parent_invocation:source_invocation
               ~meta
@@ -505,7 +526,7 @@ let async_worker_result
          turn_context)
     ?clock
     ()
-  |> result_of_execution ~tool_name ~start_time
+  |> result_of_execution ~tool_name ~tool_kind:(Catalog.tool_kind entry) ~start_time
 ;;
 
 let result_from_json ~tool_name ~start_time ~class_ ~ok data =
@@ -533,9 +554,12 @@ let async_submission_result
       ()
   =
   let start_time = Time_compat.now () in
+  let tool_kind = Catalog.tool_kind entry in
   match Keeper_msg_async.server_background_switch () with
   | Error error ->
-    let data = Keeper_msg_async.submit_error_to_json error in
+    let data =
+      with_tool_kind_field tool_kind (Keeper_msg_async.submit_error_to_json error)
+    in
     result_from_json
       ~tool_name
       ~start_time
@@ -566,7 +590,11 @@ let async_submission_result
          ()
      with
      | Error error ->
-       let data = Keeper_msg_async.submit_error_to_json error in
+       let data =
+         with_tool_kind_field
+           tool_kind
+           (Keeper_msg_async.submit_error_to_json error)
+       in
        result_from_json
          ~tool_name
          ~start_time
@@ -580,6 +608,7 @@ let async_submission_result
        let data =
          `Assoc
            [ "composition_tool", `String tool_name
+           ; tool_kind_field tool_kind
            ; "execution", `String "async"
            ; "request_id", `String request_id
            ; "submission", Keeper_msg_async.submit_outcome_to_json outcome
@@ -599,6 +628,7 @@ let async_submission_result
        let data =
          `Assoc
            [ "composition_tool", `String tool_name
+           ; tool_kind_field tool_kind
            ; "execution", `String "async"
            ; "submission", Keeper_msg_async.submit_outcome_to_json outcome
            ]
@@ -618,6 +648,7 @@ let status_result
   =
   let tool_name = Catalog.status_tool_name in
   let start_time = Time_compat.now () in
+  let with_kind = with_tool_kind_field Catalog.status_tool_kind in
   match
     Keeper_msg_async.poll
       ~base_path:config.base_path
@@ -631,7 +662,7 @@ let status_result
         ~start_time
         ~class_:Tool_result.Runtime_failure
         ~ok:true
-        (Keeper_msg_async.entry_to_json entry)
+        (with_kind (Keeper_msg_async.entry_to_json entry))
     in
     (match Tool_bridge.attach_artifact_manifest ~base_path:config.base_path result with
      | Ok result -> result
@@ -647,37 +678,36 @@ let status_result
       ~start_time
       ~class_:Tool_result.Workflow_rejection
       ~ok:false
-      (`Assoc
-          [ "error", `String "request_id_not_found"
-          ; "request_id", `String request_id
-          ])
+      (with_kind
+         (`Assoc
+             [ "error", `String "request_id_not_found"
+             ; "request_id", `String request_id
+             ]))
   | Keeper_msg_async.Unreadable reason ->
     result_from_json
       ~tool_name
       ~start_time
       ~class_:Tool_result.Runtime_failure
       ~ok:false
-      (`Assoc
-          [ "error", `String "request_record_unreadable"
-          ; "request_id", `String request_id
-          ; "reason", `String reason
-          ])
+      (with_kind
+         (`Assoc
+             [ "error", `String "request_record_unreadable"
+             ; "request_id", `String request_id
+             ; "reason", `String reason
+             ]))
   | Keeper_msg_async.Rejected rejection ->
     result_from_json
       ~tool_name
       ~start_time
       ~class_:Tool_result.Policy_rejection
       ~ok:false
-      (`Assoc
-          [ "error", `String "request_access_rejected"
-          ; "request_id", `String request_id
-          ; "reason", Keeper_msg_async.access_rejection_to_json rejection
-          ])
+      (with_kind
+         (`Assoc
+             [ "error", `String "request_access_rejected"
+             ; "request_id", `String request_id
+             ; "reason", Keeper_msg_async.access_rejection_to_json rejection
+             ]))
 ;;
-
-module For_testing = struct
-  let status_result = status_result
-end
 
 let cancel_result
       ~(config : Workspace.config)
@@ -692,7 +722,11 @@ let cancel_result
       ~caller:meta.name
       request_id
   in
-  let data = Keeper_msg_async.cancel_result_to_json ~request_id result in
+  let data =
+    with_tool_kind_field
+      Catalog.cancel_tool_kind
+      (Keeper_msg_async.cancel_result_to_json ~request_id result)
+  in
   match result with
   | Keeper_msg_async.Cancellation_requested _ ->
     result_from_json
@@ -728,6 +762,11 @@ let cancel_result
       ~ok:false
       data
 ;;
+
+module For_testing = struct
+  let status_result = status_result
+  let cancel_result = cancel_result
+end
 
 let make_request_control_tool
       ~(config : Workspace.config)
@@ -891,6 +930,7 @@ let make_tools
                          observe_node_result
                            ~composition_tool:tool_name
                            ~composition_execution:entry.execution
+                           ~composition_tool_kind:(Catalog.tool_kind entry)
                            ~composition_run_id
                            ~parent_invocation
                            ~meta
@@ -914,7 +954,11 @@ let make_tools
                 Option.iter
                   (fun mark_failed ->
                      let diagnostic =
-                       failure_data ~tool_name failure |> Yojson.Safe.to_string
+                       failure_data
+                         ~tool_name
+                         ~tool_kind:(Catalog.tool_kind entry)
+                         failure
+                       |> Yojson.Safe.to_string
                      in
                      mark_failed
                        { Keeper_tools_agent_core.failure_class =
@@ -930,7 +974,11 @@ let make_tools
                   } ->
                 ());
              let result =
-               result_of_execution ~tool_name ~start_time execution
+               result_of_execution
+                 ~tool_name
+                 ~tool_kind:(Catalog.tool_kind entry)
+                 ~start_time
+                 execution
              in
              (match
                 Tool_bridge.attach_artifact_manifest
@@ -992,6 +1040,7 @@ let make_tools
                 let data =
                   `Assoc
                     [ "composition_tool", `String tool_name
+                    ; tool_kind_field plan_execute_tool_kind
                     ; "error", Keeper_tool_plan_request.error_to_json error
                     ; ( "composable_tools"
                       , Json_util.json_string_list
@@ -1052,6 +1101,7 @@ let make_tools
                                observe_node_result
                                  ~composition_tool:tool_name
                                  ~composition_execution:Catalog.Inline
+                                 ~composition_tool_kind:plan_execute_tool_kind
                                  ~composition_run_id
                                  ~parent_invocation
                                  ~meta
@@ -1069,7 +1119,10 @@ let make_tools
                       Option.iter
                         (fun mark_failed ->
                            let diagnostic =
-                             failure_data ~tool_name failure
+                             failure_data
+                               ~tool_name
+                               ~tool_kind:plan_execute_tool_kind
+                               failure
                              |> Yojson.Safe.to_string
                            in
                            mark_failed
@@ -1087,7 +1140,11 @@ let make_tools
                         } ->
                       ());
                    let result =
-                     result_of_execution ~tool_name ~start_time execution
+                     result_of_execution
+                       ~tool_name
+                       ~tool_kind:plan_execute_tool_kind
+                       ~start_time
+                       execution
                    in
                    (match
                       Tool_bridge.attach_artifact_manifest

--- a/lib/keeper/keeper_tool_composition_surface.ml
+++ b/lib/keeper/keeper_tool_composition_surface.ml
@@ -13,6 +13,8 @@ let empty_input_schema =
 
 let plan_execute_tool_name = "keeper_plan_execute"
 
+let plan_execute_tool_kind = Keeper_tool_descriptor.Batch_plan_tool
+
 let plan_execute_input_schema =
   let node_schema =
     `Assoc

--- a/lib/keeper/keeper_tool_composition_surface.mli
+++ b/lib/keeper/keeper_tool_composition_surface.mli
@@ -39,4 +39,10 @@ module For_testing : sig
     meta:Keeper_meta_contract.keeper_meta ->
     request_id:string ->
     Tool_result.result
+
+  val cancel_result :
+    config:Workspace.config ->
+    meta:Keeper_meta_contract.keeper_meta ->
+    request_id:string ->
+    Tool_result.result
 end

--- a/lib/keeper/keeper_tool_composition_surface.mli
+++ b/lib/keeper/keeper_tool_composition_surface.mli
@@ -6,6 +6,10 @@
     composition catalog exists. *)
 val plan_execute_tool_name : string
 
+(** Execution-semantics kind (RFC-0386) of the model-defined plan tool:
+    [Keeper_tool_descriptor.Batch_plan_tool]. *)
+val plan_execute_tool_kind : Keeper_tool_descriptor.tool_kind
+
 val make_tools
   :  ?catalog:Keeper_tool_composition_catalog.t
   -> config:Workspace.config

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -56,6 +56,27 @@ let execution_to_string = function
   | Terminal -> "terminal"
 ;;
 
+type tool_kind =
+  | Atomic_tool
+  | Composition_tool
+  | Async_composition_tool
+  | Batch_plan_tool
+
+let tool_kind_to_string = function
+  | Atomic_tool -> "atomic"
+  | Composition_tool -> "composition"
+  | Async_composition_tool -> "async_composition"
+  | Batch_plan_tool -> "batch_plan"
+;;
+
+let tool_kind_of_string = function
+  | "atomic" -> Ok Atomic_tool
+  | "composition" -> Ok Composition_tool
+  | "async_composition" -> Ok Async_composition_tool
+  | "batch_plan" -> Ok Batch_plan_tool
+  | unknown -> Error ("unknown tool kind: " ^ unknown)
+;;
+
 type composable_output =
   | Opaque_output
   | Json_output of { schema : Yojson.Safe.t }
@@ -146,6 +167,7 @@ type t =
   ; model_output_projection : Tool_output.model_projection
   ; composable_output : composable_output
   ; execution : execution
+  ; tool_kind : tool_kind
   ; policy : policy
   ; executor : executor
   ; backend : backend
@@ -529,6 +551,7 @@ let descriptor
       ?(model_output_projection = Tool_output.default_model_projection)
       ?(composable_output = Opaque_output)
       ?(ordinary_execution_mode = Serial)
+      ?(tool_kind = Atomic_tool)
       ~policy
       ~executor
       ~backend
@@ -615,6 +638,7 @@ let descriptor
   ; model_output_projection
   ; composable_output
   ; execution
+  ; tool_kind
   ; policy
   ; executor
   ; backend
@@ -2607,6 +2631,7 @@ let route_evidence_json d =
      ; "sandbox", `String (sandbox_to_string d.sandbox)
      ; "runtime_handler", `String (runtime_handler_to_string d.runtime_handler)
      ; "execution", `String (execution_to_string d.execution)
+     ; "tool_kind", `String (tool_kind_to_string d.tool_kind)
      ; "composable_output", composable_output_to_json d.composable_output
      ; "receipt_labels", receipt_labels_json d
      ; "eval_tags", eval_tags_json d
@@ -2643,6 +2668,7 @@ let discovery_fields d =
    ; "sandbox", `String (sandbox_to_string d.sandbox)
    ; "runtime_handler", `String (runtime_handler_to_string d.runtime_handler)
    ; "execution", `String (execution_to_string d.execution)
+   ; "tool_kind", `String (tool_kind_to_string d.tool_kind)
    ; "composable_output", composable_output_to_json d.composable_output
    ; "policy", discovery_policy_json d.policy
    ; "schema_shape", Tool_input_validation.schema_shape_json d.input_schema

--- a/lib/keeper/keeper_tool_descriptor.mli
+++ b/lib/keeper/keeper_tool_descriptor.mli
@@ -68,6 +68,20 @@ type execution =
     imply concurrency safety, and terminal concurrent execution is not
     representable. *)
 
+(** Closed execution-semantics classification of one tool call: whether the
+    call is itself a multi-call execution unit (RFC-0386). [Atomic_tool] runs
+    one capability per call. [Composition_tool] runs one fixed, validated
+    catalog plan inline. [Async_composition_tool] covers durable async
+    composition submissions and their status/cancel controls.
+    [Batch_plan_tool] runs one model-defined plan as a dependency DAG. This
+    axis is orthogonal to {!execution}: kind classifies what a call contains,
+    execution classifies how that call runs. *)
+type tool_kind =
+  | Atomic_tool
+  | Composition_tool
+  | Async_composition_tool
+  | Batch_plan_tool
+
 (** Descriptor-owned output contract for typed composition. [Opaque_output]
     cannot be referenced by another plan node. [Json_output] carries a schema
     in the closed composable-output subset checked by [Keeper_tool_plan.create]:
@@ -157,6 +171,7 @@ type t =
   ; model_output_projection : Tool_output.model_projection
   ; composable_output : composable_output
   ; execution : execution
+  ; tool_kind : tool_kind
   ; policy : policy
   ; executor : executor
   ; backend : backend
@@ -177,6 +192,11 @@ val backend_to_string : backend -> string
 val sandbox_to_string : sandbox -> string
 val keeper_tool_group_to_string : keeper_tool_group -> string
 val runtime_handler_to_string : runtime_handler -> string
+val tool_kind_to_string : tool_kind -> string
+
+(** Strict parse of {!tool_kind_to_string} output. Unknown strings are an
+    error, never a fallback classification. *)
+val tool_kind_of_string : string -> (tool_kind, string) result
 
 (** [public_descriptors] is the LLM-native public surface. Each descriptor has
     exactly one [public_name]. *)

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -440,6 +440,7 @@ let log_call
       ?composition_run_id
       ?composition_node_id
       ?composition_execution
+      ?composition_tool_kind
       ?parent_tool_use_id
       ?trace_id
       ?session_id
@@ -606,6 +607,14 @@ let log_call
           ]
         | None -> []
       in
+      let composition_tool_kind_field =
+        match composition_tool_kind with
+        | Some value ->
+          [ ( "composition_tool_kind"
+            , `String (Keeper_tool_descriptor.tool_kind_to_string value) )
+          ]
+        | None -> []
+      in
       let session_id_field =
         match session_id with
         | Some value -> [ "session_id", `String value ]
@@ -717,6 +726,7 @@ let log_call
            @ typed_result_fields
            @ composition_fields
            @ composition_execution_field
+           @ composition_tool_kind_field
            @ trace_id_field
            @ session_id_field
            @ generation_field

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -101,6 +101,8 @@ val route_evidence_json_of_tool_io :
     [backend], [sandbox], evaluation-only [eval_tags], and policy labels.
     Runtime route/status fields such as [via], [sandbox_profile],
     [network_mode], [status], and redacted command/cwd/path are added when
+    present. Composition surface tools are not descriptor-backed; their
+    RFC-0386 [tool_kind] is picked up from the tool's own result payload when
     present. *)
 
 val init : ?cluster_name:string -> base_path:string -> unit -> unit
@@ -162,6 +164,7 @@ val log_call :
   ?composition_run_id:string ->
   ?composition_node_id:string ->
   ?composition_execution:Keeper_tool_composition_catalog.execution_mode ->
+  ?composition_tool_kind:Keeper_tool_descriptor.tool_kind ->
   ?parent_tool_use_id:string ->
   ?trace_id:string ->
   ?session_id:string ->

--- a/lib/keeper_tool_call_log_route_evidence.ml
+++ b/lib/keeper_tool_call_log_route_evidence.ml
@@ -18,6 +18,7 @@ let route_candidate_has_fields json =
            ; "sandbox_profile"
            ; "network_mode"
            ; "status"
+           ; "tool_kind"
            ])
       fields
 ;;
@@ -127,6 +128,7 @@ let route_evidence_json_of_tool_io ~max_output_len ~tool_name ~input ~output_tex
               (Json_util.assoc_member_opt "status" output_json))
       |> add_string "network_mode" (Json_util.assoc_string_opt "network_mode" output_json)
       |> add_string "sandbox_profile" (Json_util.assoc_string_opt "sandbox_profile" output_json)
+      |> add_string "tool_kind" (Json_util.assoc_string_opt "tool_kind" output_json)
       |> add_string "via" (Json_util.assoc_string_opt "via" output_json)
       |> add_string "path" (Option.map route_safe_path_string (Json_util.assoc_string_opt "path" input))
       |> add_string "cwd" (Option.map route_safe_path_string (Json_util.assoc_string_opt "cwd" input))

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -255,6 +255,7 @@ normal_targets=(
   @test/runtest-test_keeper_tool_call_log
   @test/runtest-test_keeper_tool_plan
   @test/runtest-test_keeper_tool_composition_catalog
+  @test/runtest-test_keeper_tool_kind
   @test/runtest-test_keeper_tool_plan_executor
   @test/runtest-test_keeper_external_resource_lease
   @test/runtest-test_keeper_wire_capture

--- a/test/dune
+++ b/test/dune
@@ -287,6 +287,7 @@
   test_keeper_tool_descriptor_registry_integrity
   test_keeper_tool_plan
   test_keeper_tool_composition_catalog
+  test_keeper_tool_kind
   test_voice_command_descriptor_parity
   test_disk_hygiene_script
   test_run_local_script
@@ -592,6 +593,7 @@
   test_keeper_tool_descriptor_registry_integrity
   test_keeper_tool_plan
   test_keeper_tool_composition_catalog
+  test_keeper_tool_kind
   test_voice_command_descriptor_parity
   test_disk_hygiene_script
   test_run_local_script

--- a/test/test_keeper_tool_kind.ml
+++ b/test/test_keeper_tool_kind.ml
@@ -232,6 +232,9 @@ let test_cancel_result_payload_carries_tool_kind () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
+       (* cancel goes through the async run registry, whose lock is an
+          Eio.Mutex — it needs an Eio runtime context. *)
+       Eio_main.run @@ fun _env ->
        let config = Workspace.default_config dir in
        let meta = make_meta () in
        let result =

--- a/test/test_keeper_tool_kind.ml
+++ b/test/test_keeper_tool_kind.ml
@@ -1,0 +1,202 @@
+(** RFC-0386: the closed tool-kind classification is declared, strict on
+    parse, and visible in route/discovery evidence. Composition and batch
+    kinds come from the catalog/surface declarations — never from matching on
+    tool-name strings. *)
+
+open Alcotest
+
+module Descriptor = Masc.Keeper_tool_descriptor
+module Catalog = Masc.Keeper_tool_composition_catalog
+module Surface = Masc.Keeper_tool_composition_surface
+
+let tool_kind_testable =
+  testable
+    (fun fmt kind ->
+       Format.pp_print_string fmt (Descriptor.tool_kind_to_string kind))
+    ( = )
+;;
+
+let all_tool_kinds =
+  [ Descriptor.Atomic_tool
+  ; Descriptor.Composition_tool
+  ; Descriptor.Async_composition_tool
+  ; Descriptor.Batch_plan_tool
+  ]
+;;
+
+let test_tool_kind_string_round_trip () =
+  List.iter
+    (fun kind ->
+       match
+         Descriptor.tool_kind_of_string (Descriptor.tool_kind_to_string kind)
+       with
+       | Ok parsed -> check tool_kind_testable "round trip" kind parsed
+       | Error detail -> fail detail)
+    all_tool_kinds
+;;
+
+let test_tool_kind_strings_are_distinct () =
+  let rendered = List.map Descriptor.tool_kind_to_string all_tool_kinds in
+  check
+    int
+    "kind strings do not collide"
+    (List.length all_tool_kinds)
+    (List.length (List.sort_uniq String.compare rendered))
+;;
+
+let test_tool_kind_of_string_rejects_unknown () =
+  match Descriptor.tool_kind_of_string "multitool" with
+  | Error _ -> ()
+  | Ok kind ->
+    failf
+      "unknown tool kind string was accepted as %s"
+      (Descriptor.tool_kind_to_string kind)
+;;
+
+let test_descriptors_declare_atomic_kind () =
+  let descriptors = Descriptor.all_descriptors () in
+  check bool "descriptor registry is not empty" true (descriptors <> []);
+  List.iter
+    (fun (d : Descriptor.t) ->
+       check
+         tool_kind_testable
+         (Printf.sprintf "descriptor %s declares atomic kind" d.Descriptor.id)
+         Descriptor.Atomic_tool
+         d.Descriptor.tool_kind)
+    descriptors
+;;
+
+let test_route_evidence_carries_tool_kind () =
+  Descriptor.all_descriptors ()
+  |> List.iter (fun (d : Descriptor.t) ->
+       match Descriptor.route_evidence_json d with
+       | `Assoc fields ->
+         (match List.assoc_opt "tool_kind" fields with
+          | Some (`String "atomic") -> ()
+          | Some other ->
+            failf
+              "route evidence for %s carries a non-atomic tool kind: %s"
+              d.Descriptor.id
+              (Yojson.Safe.to_string other)
+          | None ->
+            failf "route evidence for %s omits tool_kind" d.Descriptor.id)
+       | _ -> fail "route evidence is not a JSON object")
+;;
+
+let test_discovery_fields_carry_tool_kind () =
+  Descriptor.all_descriptors ()
+  |> List.iter (fun (d : Descriptor.t) ->
+       match List.assoc_opt "tool_kind" (Descriptor.discovery_fields d) with
+       | Some (`String "atomic") -> ()
+       | Some other ->
+         failf
+           "discovery fields for %s carry a non-atomic tool kind: %s"
+           d.Descriptor.id
+           (Yojson.Safe.to_string other)
+       | None ->
+         failf "discovery fields for %s omit tool_kind" d.Descriptor.id)
+;;
+
+let inline_and_async_catalog =
+  {|[[compositions]]
+name = "clock-inline"
+execution = "inline"
+[[compositions.nodes]]
+id = "time"
+tool = "keeper_time_now"
+[compositions.nodes.input]
+kind = "literal"
+value = {}
+
+[[compositions]]
+name = "clock-background"
+execution = "async"
+[[compositions.nodes]]
+id = "time"
+tool = "keeper_time_now"
+[compositions.nodes.input]
+kind = "literal"
+value = {}
+|}
+;;
+
+let test_catalog_entries_declare_tool_kind () =
+  let catalog =
+    match Catalog.parse inline_and_async_catalog with
+    | Ok catalog -> catalog
+    | Error error -> fail (Catalog.error_to_string error)
+  in
+  let entry name =
+    match Catalog.find catalog name with
+    | Some entry -> entry
+    | None -> failf "composition lookup missed exact name: %s" name
+  in
+  check
+    tool_kind_testable
+    "inline composition is a composition tool"
+    Descriptor.Composition_tool
+    (Catalog.tool_kind (entry "clock-inline"));
+  check
+    tool_kind_testable
+    "async composition is an async composition tool"
+    Descriptor.Async_composition_tool
+    (Catalog.tool_kind (entry "clock-background"))
+;;
+
+let test_async_controls_and_plan_execute_declare_kinds () =
+  check
+    tool_kind_testable
+    "status control is an async composition tool"
+    Descriptor.Async_composition_tool
+    Catalog.status_tool_kind;
+  check
+    tool_kind_testable
+    "cancel control is an async composition tool"
+    Descriptor.Async_composition_tool
+    Catalog.cancel_tool_kind;
+  check
+    tool_kind_testable
+    "plan execute is a batch plan tool"
+    Descriptor.Batch_plan_tool
+    Surface.plan_execute_tool_kind
+;;
+
+let () =
+  run
+    "keeper_tool_kind"
+    [ ( "tool_kind"
+      , [ test_case
+            "string round trip"
+            `Quick
+            test_tool_kind_string_round_trip
+        ; test_case
+            "kind strings are distinct"
+            `Quick
+            test_tool_kind_strings_are_distinct
+        ; test_case
+            "rejects unknown kind string"
+            `Quick
+            test_tool_kind_of_string_rejects_unknown
+        ; test_case
+            "descriptors declare atomic kind"
+            `Quick
+            test_descriptors_declare_atomic_kind
+        ; test_case
+            "route evidence carries tool kind"
+            `Quick
+            test_route_evidence_carries_tool_kind
+        ; test_case
+            "discovery fields carry tool kind"
+            `Quick
+            test_discovery_fields_carry_tool_kind
+        ; test_case
+            "catalog entries declare tool kind"
+            `Quick
+            test_catalog_entries_declare_tool_kind
+        ; test_case
+            "async controls and plan execute declare kinds"
+            `Quick
+            test_async_controls_and_plan_execute_declare_kinds
+        ] )
+    ]
+;;

--- a/test/test_keeper_tool_kind.ml
+++ b/test/test_keeper_tool_kind.ml
@@ -8,6 +8,56 @@ open Alcotest
 module Descriptor = Masc.Keeper_tool_descriptor
 module Catalog = Masc.Keeper_tool_composition_catalog
 module Surface = Masc.Keeper_tool_composition_surface
+module Call_log = Masc.Keeper_tool_call_log
+module Workspace = Masc.Workspace
+
+let temp_dir prefix =
+  let dir = Filename.temp_file prefix "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+;;
+
+let cleanup_dir path =
+  let rec rm target =
+    if Sys.file_exists target
+    then
+      if Sys.is_directory target
+      then (
+        Sys.readdir target
+        |> Array.iter (fun name -> rm (Filename.concat target name));
+        Unix.rmdir target)
+      else Unix.unlink target
+  in
+  try rm path with _ -> ()
+;;
+
+let make_meta () =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+          [ "name", `String "tool-kind-keeper"
+          ; ( "agent_name"
+            , `String
+                (Masc.Keeper_identity.keeper_agent_name "tool-kind-keeper") )
+          ; "trace_id", `String "tool-kind-trace"
+          ; "allowed_paths", `List [ `String "*" ]
+          ])
+  with
+  | Ok meta -> meta
+  | Error err -> failwith ("make_meta failed: " ^ err)
+;;
+
+let expect_tool_kind_field expected json =
+  match json with
+  | `Assoc fields ->
+    (match List.assoc_opt "tool_kind" fields with
+     | Some (`String actual) when String.equal actual expected -> ()
+     | Some other ->
+       failf "tool_kind is %s, expected %s" (Yojson.Safe.to_string other) expected
+     | None -> failf "tool_kind field missing, expected %s" expected)
+  | _ -> fail "expected a JSON object carrying tool_kind"
+;;
 
 let tool_kind_testable =
   testable
@@ -161,6 +211,73 @@ let test_async_controls_and_plan_execute_declare_kinds () =
     Surface.plan_execute_tool_kind
 ;;
 
+(* Composition surface tools are materialized Agent_core tools outside the
+   descriptor registry, so their kind must be observable on their own result
+   payloads and route evidence — not on descriptor evidence. *)
+let test_status_result_payload_carries_tool_kind () =
+  let dir = temp_dir "tool-kind-status" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+       let config = Workspace.default_config dir in
+       let meta = make_meta () in
+       let result =
+         Surface.For_testing.status_result ~config ~meta ~request_id:"no-such-request"
+       in
+       expect_tool_kind_field "async_composition" (Tool_result.data result))
+;;
+
+let test_cancel_result_payload_carries_tool_kind () =
+  let dir = temp_dir "tool-kind-cancel" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+       let config = Workspace.default_config dir in
+       let meta = make_meta () in
+       let result =
+         Surface.For_testing.cancel_result ~config ~meta ~request_id:"no-such-request"
+       in
+       expect_tool_kind_field "async_composition" (Tool_result.data result))
+;;
+
+let test_route_evidence_picks_composition_tool_kind () =
+  let output_text =
+    `Assoc
+      [ "composition_tool", `String "keeper_compose_clock-inline"
+      ; "tool_kind", `String "composition"
+      ; "actions", `List []
+      ]
+    |> Yojson.Safe.to_string
+  in
+  match
+    Call_log.route_evidence_json_of_tool_io
+      ~tool_name:"keeper_compose_clock-inline"
+      ~input:(`Assoc [])
+      ~output_text
+  with
+  | Some evidence -> expect_tool_kind_field "composition" evidence
+  | None -> fail "composition tool call produced no route evidence"
+;;
+
+let test_route_evidence_picks_batch_plan_tool_kind () =
+  let output_text =
+    `Assoc
+      [ "composition_tool", `String Surface.plan_execute_tool_name
+      ; "tool_kind", `String "batch_plan"
+      ; "actions", `List []
+      ]
+    |> Yojson.Safe.to_string
+  in
+  match
+    Call_log.route_evidence_json_of_tool_io
+      ~tool_name:Surface.plan_execute_tool_name
+      ~input:(`Assoc [])
+      ~output_text
+  with
+  | Some evidence -> expect_tool_kind_field "batch_plan" evidence
+  | None -> fail "batch plan tool call produced no route evidence"
+;;
+
 let () =
   run
     "keeper_tool_kind"
@@ -197,6 +314,22 @@ let () =
             "async controls and plan execute declare kinds"
             `Quick
             test_async_controls_and_plan_execute_declare_kinds
+        ; test_case
+            "status result payload carries tool kind"
+            `Quick
+            test_status_result_payload_carries_tool_kind
+        ; test_case
+            "cancel result payload carries tool kind"
+            `Quick
+            test_cancel_result_payload_carries_tool_kind
+        ; test_case
+            "route evidence picks composition tool kind"
+            `Quick
+            test_route_evidence_picks_composition_tool_kind
+        ; test_case
+            "route evidence picks batch plan tool kind"
+            `Quick
+            test_route_evidence_picks_batch_plan_tool_kind
         ] )
     ]
 ;;


### PR DESCRIPTION
## 배경

Parity matrix **B6("Batch/Multitool 실행 개념 부재")** 의 코드 대응물. 선행 조사 결론:

- 실행 기계는 이미 존재한다 — `agent_tool_batch_plan.ml`(Serial/Concurrent 배치 계획), `agent_tools.ml` `execute_tools`, `keeper_tool_plan.ml`(닫힌 typed plan IR) + `keeper_tool_plan_executor`, `keeper_tool_composition_catalog.ml`(TOML Inline/Async), `keeper_tool_composition_surface.ml`(`keeper_plan_execute`, `keeper_composition_status/cancel`).
- 없던 것은 "tool 타입으로서의 선언": constitution feature_surface 의 **Multitools / AsyncTools / Batch Tools** 에 대응하는 닫힌 합타입 분류가 descriptor/카탈로그 수준에 없었다.
- `keeper_tool_group` 은 discovery 전용 분류라 실행 의미를 얹지 않는다(유지).

## 변경

- **RFC-0386** (`docs/rfc/RFC-0386-tool-kind-closed-declaration.md`): tool kind 닫힌 합타입 도입, 기존 실행 기계 재사용 선언, feature_surface 용어와의 1:1 매핑.
- `Keeper_tool_descriptor.tool_kind` — `Atomic_tool | Composition_tool | Async_composition_tool | Batch_plan_tool`. `execution` 필드와 직교(무엇을 담는가 vs 어떻게 실행되는가). 모든 descriptor-backed 툴은 빌더 기본값 `Atomic_tool`. `tool_kind_of_string` 은 strict — unknown 문자열은 `Error`(폴백 분류 없음).
- 태깅은 문자열 매칭이 아니라 타입드 선언으로:
  - `Keeper_tool_composition_catalog.tool_kind` — 엔트리의 `execution : Inline | Async` 에서 유도 (Inline → `Composition_tool`, Async → `Async_composition_tool`).
  - `status_tool_kind` / `cancel_tool_kind` = `Async_composition_tool`.
  - `Keeper_tool_composition_surface.plan_execute_tool_kind` = `Batch_plan_tool`.

## evidence 노출 — 두 경로 (리뷰 반영)

composition surface 툴(`keeper_compose_*`, `keeper_plan_execute`, status/cancel)은 TOML 카탈로그에서 구체화되는 `Agent_core.Tool.t` 이며 **Keeper descriptor registry 에 속하지 않는다**(`Keeper_tool_descriptor_resolution.descriptor_for_tool_name` 이 `None`). 따라서 descriptor route evidence 경로는 이 툴들을 커버하지 않고, kind 는 이 툴들 자신의 관측 경로에 실린다:

1. **descriptor-backed 툴**: `route_evidence_json` / `discovery_fields` 에 `"tool_kind"` (현재 전부 `"atomic"`).
2. **composition surface 툴**:
   - 실행/제출/제어 결과 payload(`result_of_execution`, `failure_data`, async submission, status/cancel 결과, plan rejection)에 `"tool_kind"` — 타입드 접근자에서만 유래
   - 노드별 tool-call log envelope 에 typed `?composition_tool_kind` 파라미터 → `"composition_tool_kind"` 필드
   - `route_evidence_json_of_tool_io` 가 툴 출력 payload 의 `"tool_kind"` 를 흡수 → composition/batch 툴 호출의 `route_evidence` 에 kind 가 나타남

## 테스트

`test/test_keeper_tool_kind.ml` (fail-closed, `test_keeper_tool_dispatch_runtime.ml` 패턴):

- 4개 생성자의 to_string/of_string 왕복 + 문자열 유일성, unknown kind 문자열 거부
- 전체 descriptor 가 `Atomic_tool` 선언 + descriptor route/discovery evidence 에 `"tool_kind": "atomic"`
- 카탈로그 inline/async 엔트리, status/cancel 컨트롤, `keeper_plan_execute` 의 kind 태깅
- **실제 관측 경로 검증**: status/cancel 결과 payload 에 `"tool_kind": "async_composition"` (`For_testing.status_result/cancel_result`), `keeper_compose_*` / `keeper_plan_execute` 호출의 route evidence 에 `"composition"` / `"batch_plan"`

로컬 빌드/테스트는 실행하지 않았다 — CI 가 검증한다.

## 범위 밖 (이 PR 에서 하지 않는 것)

- 새 실행 엔진 금지 — 기존 기계 재사용만 선언
- keeper 툴 `Concurrent` 선언 확대 — 별도 PR
- MCP 경로 배치 실행 — 대상 아님
- `keeper_tool_group` 의미 변경 금지
- composition surface 툴의 descriptor registry 편입 — 설계상 registry 외부이며, evidence 는 위 2번 경로가 담당