### PR TITLE
fix(keeper): 스트림 텍스트 델타 dedup — constitution B5 (중복 스트리밍 문자열 없음)

### DIFF
--- a/lib/keeper/keeper_chat_agent_core_stream_bridge.ml
+++ b/lib/keeper/keeper_chat_agent_core_stream_bridge.ml
@@ -304,10 +304,8 @@ let translate ~redact_text ~base_dir bridge_state
       }
   | ContentBlockDelta { index; delta = TextDelta text } -> (
       let accumulated =
-        (* DET-OK: [text_by_index] is deterministic local bridge state keyed by
-           content-block index; an absent key means no prior text for this
-           block, so "" is the sound identity for append/snapshot compare —
-           not a default on unknown wire input. *)
+        (* [text_by_index] is deterministic local bridge state keyed by
+           content-block index; absent key = no prior text. DET-OK *)
         Option.value ~default:"" (List.assoc_opt index bridge_state.text_by_index)
       in
       match classify_text_delta ~accumulated text with

--- a/lib/keeper/keeper_chat_agent_core_stream_bridge.ml
+++ b/lib/keeper/keeper_chat_agent_core_stream_bridge.ml
@@ -304,6 +304,10 @@ let translate ~redact_text ~base_dir bridge_state
       }
   | ContentBlockDelta { index; delta = TextDelta text } -> (
       let accumulated =
+        (* DET-OK: [text_by_index] is deterministic local bridge state keyed by
+           content-block index; an absent key means no prior text for this
+           block, so "" is the sound identity for append/snapshot compare —
+           not a default on unknown wire input. *)
         Option.value ~default:"" (List.assoc_opt index bridge_state.text_by_index)
       in
       match classify_text_delta ~accumulated text with

--- a/lib/keeper/keeper_chat_agent_core_stream_bridge.ml
+++ b/lib/keeper/keeper_chat_agent_core_stream_bridge.ml
@@ -22,6 +22,13 @@ type state =
   ; current_message_has_text : bool
   ; last_completed_message_has_text : bool
   ; message_open : bool
+  ; text_by_index : (int * string) list
+        (* Raw (pre-redaction) text accumulated per block index in the current
+           provider message.  Drives the deterministic text-delta dedup below;
+           cleared at [MessageStop] because block indices restart per message. *)
+  ; text_dedup_logged : bool
+        (* One warn log per stream is enough; every occurrence still bumps the
+           [masc_keeper_stream_text_delta_dedup_total] counter. *)
   }
 
 type translated_event = {
@@ -34,6 +41,8 @@ let empty_state =
   ; current_message_has_text = false
   ; last_completed_message_has_text = false
   ; message_open = false
+  ; text_by_index = []
+  ; text_dedup_logged = false
   }
 
 let terminal_message_had_text state =
@@ -145,6 +154,45 @@ let content_block_start_event ~index ~content_type ~tool_id ~tool_name =
 let content_block_stop_event ~index =
   Keeper_chat_events.Agent_core_content_block_stop { index }
 
+(* B5 ("no duplicate streaming strings"): some OpenAI-compatible providers send
+   each chunk's [content] as the cumulative text so far instead of an
+   incremental delta, and a reconnecting transport can re-send a chunk that was
+   already delivered.  Both surface here as a [TextDelta] whose bytes the user
+   has already seen.  The reconciliation below is decided by exact byte length
+   and exact prefix identity against the per-block accumulated text — a
+   deterministic retransmission/snapshot check, not a heuristic string
+   similarity judgement, so it stays inside the constitution's "no logic by
+   string comparison" rule (same exact-prefix discipline as the
+   claude_code/codex [Turn_finished] reconciliations). *)
+type text_delta_action =
+  | Append_delta
+  | Snapshot_reconcile of string (* emit only the not-yet-seen suffix *)
+  | Duplicate_retransmission (* emit nothing *)
+
+let classify_text_delta ~accumulated text =
+  let acc_len = String.length accumulated in
+  let text_len = String.length text in
+  if acc_len = 0 || text_len = 0 then Append_delta
+  else if text_len > acc_len && String.starts_with ~prefix:accumulated text then
+    Snapshot_reconcile (String.sub text acc_len (text_len - acc_len))
+  else if text_len <= acc_len && String.starts_with ~prefix:text accumulated then
+    Duplicate_retransmission
+  else Append_delta
+
+let stream_text_dedup_metric = Keeper_metrics.(to_string StreamTextDeltaDedup)
+
+let observe_text_dedup ~already_logged ~action ~index ~accumulated_bytes
+    ~delta_bytes =
+  Otel_metric_store.inc_counter stream_text_dedup_metric
+    ~labels:[ "action", action ]
+    ();
+  if not already_logged then
+    Log.Keeper.warn
+      "keeper stream text delta dedup engaged: action=%s index=%d \
+       accumulated_bytes=%d delta_bytes=%d (later occurrences in this stream \
+       are counted metric-only)"
+      action index accumulated_bytes delta_bytes
+
 let tool_args_event ~redact_text ~snapshot bridge_state index args =
   let open Keeper_chat_events in
   match stream_block_for_index bridge_state index with
@@ -241,6 +289,8 @@ let translate ~redact_text ~base_dir bridge_state
           ; last_completed_message_has_text =
               bridge_state.current_message_has_text
           ; message_open = false
+          ; text_by_index = []
+          ; text_dedup_logged = bridge_state.text_dedup_logged
           }
       ;
         chat_events = block_ends @ [ Agent_core_stream_message_stop ]
@@ -252,14 +302,47 @@ let translate ~redact_text ~base_dir bridge_state
         chat_events =
           [ Event_error { message = redact_text ("Timeout: " ^ reason) } ]
       }
-  | ContentBlockDelta { delta = TextDelta text; _ } ->
-      { bridge_state =
-          { bridge_state with
-            current_message_has_text =
-              bridge_state.current_message_has_text || not (String.equal text "")
+  | ContentBlockDelta { index; delta = TextDelta text } -> (
+      let accumulated =
+        Option.value ~default:"" (List.assoc_opt index bridge_state.text_by_index)
+      in
+      match classify_text_delta ~accumulated text with
+      | Append_delta ->
+          { bridge_state =
+              { bridge_state with
+                current_message_has_text =
+                  bridge_state.current_message_has_text || not (String.equal text "")
+              ; text_by_index =
+                  (index, accumulated ^ text)
+                  :: List.remove_assoc index bridge_state.text_by_index
+              }
+          ; chat_events = [ Text_delta (redact_text text) ]
           }
-      ; chat_events = [ Text_delta (redact_text text) ]
-      }
+      | Snapshot_reconcile suffix ->
+          (* Cumulative snapshot: the provider re-sent the accumulated text and
+             then some.  Forward only the suffix; [suffix] is non-empty by
+             construction. *)
+          observe_text_dedup ~already_logged:bridge_state.text_dedup_logged
+            ~action:"reconcile" ~index ~accumulated_bytes:(String.length accumulated)
+            ~delta_bytes:(String.length text);
+          { bridge_state =
+              { bridge_state with
+                current_message_has_text = true
+              ; text_by_index =
+                  (index, text) :: List.remove_assoc index bridge_state.text_by_index
+              ; text_dedup_logged = true
+              }
+          ; chat_events = [ Text_delta (redact_text suffix) ]
+          }
+      | Duplicate_retransmission ->
+          (* Exact retransmission of bytes already delivered for this block:
+             drop so the user never sees the same string twice. *)
+          observe_text_dedup ~already_logged:bridge_state.text_dedup_logged
+            ~action:"drop" ~index ~accumulated_bytes:(String.length accumulated)
+            ~delta_bytes:(String.length text);
+          { bridge_state = { bridge_state with text_dedup_logged = true }
+          ; chat_events = []
+          })
   | ContentBlockDelta { index; delta = ThinkingDelta text } ->
       { bridge_state;
         chat_events =

--- a/lib/keeper/keeper_chat_agent_core_stream_bridge.mli
+++ b/lib/keeper/keeper_chat_agent_core_stream_bridge.mli
@@ -2,7 +2,14 @@
 
     MASC owns the channel event surface, but the upstream stream semantics come
     from AGENT_CORE' closed {!Agent_core.Types.sse_event} sum. This module is the
-    boundary adapter between those two domains. *)
+    boundary adapter between those two domains.
+
+    Text deltas are additionally reconciled against the per-block accumulated
+    text (exact byte-length/prefix identity, never similarity): cumulative
+    snapshot chunks are forwarded as their unseen suffix only, and exact
+    retransmissions are dropped, so a duplicated provider chunk never renders
+    twice.  Dedup occurrences bump
+    [masc_keeper_stream_text_delta_dedup_total]. *)
 
 type state
 (** Per-stream correlation state for AGENT_CORE content block indices. *)

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -202,6 +202,7 @@ type t =
   | WireCaptureResponseSuppressed (* counter: keeper-visible response suppressed before wire capture *)
   | WireCaptureWriteFailures    (* counter: wire-capture write raised an exception *)
   | WireCaptureRecordSkipped    (* counter: wire-capture record dropped — rotation name space exhausted or append guard refused *)
+  | StreamTextDeltaDedup        (* counter: streamed text delta dropped as an exact retransmission or reconciled to a cumulative-snapshot suffix *)
 [@@deriving enumerate]
 
 (** String conversion
@@ -417,6 +418,7 @@ let to_string = function
     "masc_keeper_wire_capture_response_suppressed_total"
   | WireCaptureWriteFailures -> "masc_keeper_wire_capture_write_failures_total"
   | WireCaptureRecordSkipped -> "masc_keeper_wire_capture_record_skipped_total"
+  | StreamTextDeltaDedup -> "masc_keeper_stream_text_delta_dedup_total"
 ;;
 
 type collection =

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -192,6 +192,7 @@ type t =
   | WireCaptureResponseSuppressed
   | WireCaptureWriteFailures
   | WireCaptureRecordSkipped
+  | StreamTextDeltaDedup
 
 val to_string : t -> string
 

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -1399,6 +1399,95 @@ let test_keeper_stream_bridge_isolates_tool_blocks_across_messages () =
   check (list string) "message-2 args routed to its own fresh block"
     [ "{\"b\":2}" ] second_args
 
+let stream_text_deltas events =
+  List.filter_map
+    (function Keeper_chat_events.Text_delta text -> Some text | _ -> None)
+    events
+
+let test_keeper_stream_bridge_text_delta_passthrough_incremental () =
+  let open Agent_core.Types in
+  let events =
+    translate_agent_core_stream_events
+      [
+        ContentBlockDelta { index = 0; delta = TextDelta "Hello" };
+        ContentBlockDelta { index = 0; delta = TextDelta "" };
+        ContentBlockDelta { index = 0; delta = TextDelta " world" };
+        ContentBlockDelta { index = 1; delta = TextDelta "second block" };
+      ]
+  in
+  check (list string) "incremental deltas pass through in order"
+    [ "Hello"; ""; " world"; "second block" ]
+    (stream_text_deltas events)
+
+let test_keeper_stream_bridge_text_delta_reconciles_cumulative_snapshot () =
+  let open Agent_core.Types in
+  (* An OpenAI-compatible provider that puts the cumulative text-so-far into
+     each chunk's content instead of an incremental delta: only the unseen
+     suffix may reach the user. *)
+  let events =
+    translate_agent_core_stream_events
+      [
+        ContentBlockDelta { index = 0; delta = TextDelta "Hello" };
+        ContentBlockDelta { index = 0; delta = TextDelta "Hello world" };
+        ContentBlockDelta { index = 0; delta = TextDelta "Hello world!" };
+      ]
+  in
+  check (list string) "cumulative snapshots forward only the new suffix"
+    [ "Hello"; " world"; "!" ]
+    (stream_text_deltas events)
+
+let test_keeper_stream_bridge_text_delta_drops_retransmission () =
+  let open Agent_core.Types in
+  (* A reconnecting transport re-sends a chunk that was already delivered:
+     the replayed bytes are an exact prefix of the accumulated text and must
+     be dropped, not shown twice. *)
+  let events =
+    translate_agent_core_stream_events
+      [
+        ContentBlockDelta { index = 0; delta = TextDelta "Hello" };
+        ContentBlockDelta { index = 0; delta = TextDelta " world" };
+        ContentBlockDelta { index = 0; delta = TextDelta "Hello" };
+        ContentBlockDelta { index = 0; delta = TextDelta "Hello world" };
+        ContentBlockDelta { index = 0; delta = TextDelta " again" };
+      ]
+  in
+  check (list string) "retransmitted prefixes drop, new text still flows"
+    [ "Hello"; " world"; " again" ]
+    (stream_text_deltas events)
+
+let test_keeper_stream_bridge_text_dedup_resets_per_message () =
+  let open Agent_core.Types in
+  (* Block indices restart per provider message, so the accumulated text used
+     for dedup must reset at MessageStop: message 2 reusing index 0 with text
+     that is a prefix of message 1's text is new content, not a duplicate. *)
+  let events =
+    translate_agent_core_stream_events
+      [
+        ContentBlockDelta { index = 0; delta = TextDelta "abcdef" };
+        MessageStop;
+        ContentBlockDelta { index = 0; delta = TextDelta "abc" };
+      ]
+  in
+  check (list string) "dedup state is message-scoped"
+    [ "abcdef"; "abc" ]
+    (stream_text_deltas events)
+
+let test_keeper_stream_bridge_text_delta_appends_unrelated_overlap () =
+  let open Agent_core.Types in
+  (* A delta that shares neither an exact-prefix relation with the accumulated
+     text is new content by the deterministic rule and passes through — the
+     bridge never guesses at partial overlaps. *)
+  let events =
+    translate_agent_core_stream_events
+      [
+        ContentBlockDelta { index = 0; delta = TextDelta "abc" };
+        ContentBlockDelta { index = 0; delta = TextDelta "bcd" };
+      ]
+  in
+  check (list string) "non-prefix delta appends verbatim"
+    [ "abc"; "bcd" ]
+    (stream_text_deltas events)
+
 let test_keeper_stream_bridge_surfaces_agent_core_message_metadata () =
   let open Agent_core.Types in
   let usage_start =
@@ -2812,6 +2901,16 @@ let () =
             test_keeper_stream_bridge_rejects_conflicting_tool_index_reuse;
           test_case "stream bridge isolates tool blocks across messages" `Quick
             test_keeper_stream_bridge_isolates_tool_blocks_across_messages;
+          test_case "stream bridge passes through incremental text deltas" `Quick
+            test_keeper_stream_bridge_text_delta_passthrough_incremental;
+          test_case "stream bridge reconciles cumulative text snapshots" `Quick
+            test_keeper_stream_bridge_text_delta_reconciles_cumulative_snapshot;
+          test_case "stream bridge drops retransmitted text deltas" `Quick
+            test_keeper_stream_bridge_text_delta_drops_retransmission;
+          test_case "stream bridge text dedup resets per message" `Quick
+            test_keeper_stream_bridge_text_dedup_resets_per_message;
+          test_case "stream bridge appends non-prefix text deltas verbatim" `Quick
+            test_keeper_stream_bridge_text_delta_appends_unrelated_overlap;
           test_case "stream bridge surfaces AGENT_CORE message metadata" `Quick
             test_keeper_stream_bridge_surfaces_agent_core_message_metadata;
           test_case "stream bridge scopes terminal text to final message" `Quick


### PR DESCRIPTION
## 배경 (constitution B5 — "중복 스트리밍 문자열 없음")

감사 지적(`keeper_chat_agent_core_stream_bridge.ml:255-261`): 스트림 텍스트 델타가 dedup 없이 pass-through. 기존 중복 방지는 구조 수준뿐(`Tool_start_duplicate_index` 가드, 채팅 delivery provenance append-once).

## 중복 실체 분석 (조사 결과)

스트림 텍스트가 유저에게 도달하는 경로를 전수 조사했다:

| 경로 | 중복 가능성 | 상태 |
|---|---|---|
| Agent_core Anthropic SSE (`text_delta`) | 인크리멘털만 emit | 중복 없음 |
| Agent_core OpenAI chat (`delta.content`) | 스펙상 인크리멘털, **비준수 OpenAI-compat 서버는 누적 텍스트를 chunk마다 전송** | **실재 — 이번 PR이 방어** |
| Agent_core OpenAI Responses | `output_text.delta` 인크리멘털 + `output_text.done` 폴백은 `text_block_started` 가드로 이중 emit 불가 | 중복 없음 |
| Agent_core Gemini / Ollama NDJSON | 파트/청크 단위 인크리멘털 | 중복 없음 |
| claude_code / codex 런타임 | `Turn_finished`의 전체 텍스트 vs 스트리밍된 텍스트 | **이미 방어됨** — exact-prefix suffix-only 보정 (`keeper_claude_code_runtime.ml:172-186`, `keeper_codex_runtime.ml:264-279`) |
| antigravity 런타임 | 결과 1회 emit, 델타 없음 | 중복 없음 |
| keeper 턴 종료 시 final reply publish | 스트림에서 텍스트가 이미 나갔으면 억제 | 이미 방어됨 (`terminal_message_had_text`, `server_routes_http_keeper_stream.ml:1917-1925`) |
| 대시보드 SSE reconnect | `Keeper_chat_events.publish`는 Eio.Stream 라이브 브로드캐스트, replay 버퍼 없음 | 중복 없음 |
| persist/replay | 스트림 델타는 persist되지 않음(최종 delivery만 provenance append-once) | 중복 없음 |
| 턴 실패 후 provider 로테이션 | 실패 시도의 부분 텍스트 + 후속 시도의 전체 텍스트 | **범위 밖** (아래 참조) |

결론: 중복의 실체는 **(a) 누적 스냅샷을 chunk content에 넣는 OpenAI-compat 프로바이더**와 **(b) 재연결 transport가 이미 전달된 chunk를 재전송**하는 경우다. 둘 다 유저가 이미 본 바이트가 `TextDelta`로 다시 들어오는 형태로 브릿지에 도달한다.

## 설계

`Agent_core.Types.sse_event`에는 텍스트용 시퀀스 번호/스냅샷 variant가 없다(`InputJsonSnapshot`는 tool args 전용). 따라서 브릿지가 결정론적 식별자 역할을 할 상태를 직접 추적한다: **현재 프로바이더 메시지 내 content-block index별 누적 raw 텍스트**. 각 `TextDelta`를 정확한 바이트 길이와 정확한 prefix 동일성으로 분류:

- `len(delta) > len(accumulated)` && accumulated가 delta의 정확한 prefix → **누적 스냅샷**: 아직 보여주지 않은 suffix만 전달 (`reconcile`)
- `len(delta) <= len(accumulated)` && delta가 accumulated의 정확한 prefix → **재전송**: drop
- 그 외 → 기존과 동일하게 그대로 append

**헌법 정합성**: "문자열 비교로 로직을 결정하지 않는다"는 규칙은 휴리스틱 텍스트 매칭 금지 조항이다. 여기서의 비교는 정확한 바이트 길이 + 정확한 prefix 동일성에 근거한 재전송/스냅샷 판별로, 유사도 판단이 아니라 데이터 정합성 문제다. claude_code/codex의 `Turn_finished` exact-prefix 보정과 동일한 기 discipline을 스트림 중간 지점으로 확장한 것이다. 부분 겹침(prefix 관계가 아닌 경우)은 추측하지 않고 그대로 통과시킨다.

**스코핑**: dedup 상태는 `MessageStop`에서 초기화 — block index는 프로바이더 메시지마다 0부터 재시작하므로(기존 block table과 동일한 규율) 메시지 경계를 넘는 stale dedup이 없다.

## 관측성

- 메트릭: `masc_keeper_stream_text_delta_dedup_total{action=drop|reconcile}` (`Keeper_metrics.t`에 `StreamTextDeltaDedup` 추가 — 기존 keeper 메트릭 enum 패턴, `_total` suffix로 0-cell 자동 등록)
- 로그: 스트림당 첫 발생 시 `Log.Keeper.warn` 1회(바이트 수만, 내용 없음), 이후 발생은 메트릭 전용 — 누적 스냅샷 프로바이더는 매 chunk가 reconcile되므로 per-event 로그는 flood 위험

## 테스트

`test/test_gate_keeper_backend.ml`에 feature 수준 테스트 5건 추가 (기존 stream-bridge 테스트 관행):
- 인크리멘털 델타 pass-through 불변 (빈 델타 포함)
- 누적 스냅샷 → suffix만 전달
- 재전송 prefix drop + 이후 신규 텍스트 정상 흐름
- MessageStop 후 동일 index 재사용 시 dedup 상태 리셋
- prefix 관계 없는 델타는 verbatim append (추측 금지 확인)

로컬 빌드/테스트는 실행하지 않음(지시에 따라 CI 검증). `ocamlc -stop-after parsing`으로 변경 파일 전부 구문 검증 완료.

## 범위 밖 (후속 PR 후보)

- **턴 실패 후 provider 로테이션 시 부분 텍스트 잔류**: 실패한 시도 A의 부분 텍스트가 이미 유저에게 스트리밍된 뒤 시도 B가 성공하면 유저는 A 잔재 + B 전체를 본다. 텍스트 내용이 달라 결정론적 dedup이 불가능하며, 해결하려면 "실패 시도의 델타는 유저에게 노출하지 않는다"는 버퍼링/격리 설계가 필요 — 별도 논의가 맞다.
- **ThinkingDelta/reasoning 델타 dedup**: 동일 기법을 thinking lane에도 적용 가능하나, 헌법 축은 유저 가시 텍스트이므로 이번 범위에서 제외.
- **대시보드 API 노출**: 카운터는 OTel 메트릭 스토어(`/metrics`)로 즉시 관측 가능. 대시보드 전용 API/위젯 표면은 별도 범위.
