### PR TITLE
fix(keeper): 압축 절감량을 owner projection까지 실어 보낸다

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -276,8 +276,11 @@ let manual_compaction_requested_of_stimuli = function
 
 
 let rec compaction_outcomes_of_cycle_outcome = function
-  | Cycle.Manual_compaction_applied { receipt; followup } ->
-    `Manual_committed receipt.commit_count
+  | Cycle.Manual_compaction_applied { receipt; evidence; followup } ->
+    `Manual_committed
+      ( receipt.commit_count
+      , evidence.Keeper_compaction_evidence.before_checkpoint_bytes
+      , evidence.Keeper_compaction_evidence.after_checkpoint_bytes )
     :: compaction_outcomes_of_cycle_outcome followup
   | Cycle.Manual_compaction_failed _ -> [ `Failed ]
   | Cycle.Failed { failure; _ } ->
@@ -981,7 +984,7 @@ let run_keepalive_unified_turn
              record_compaction_outcome_metric
                ~keeper_name:meta_after_triage.name
                `Failed
-           | `Manual_committed commit_count as outcome ->
+           | `Manual_committed (commit_count, before_bytes, after_bytes) as outcome ->
              record_compaction_outcome_metric
                ~keeper_name:meta_after_triage.name
                outcome;
@@ -994,6 +997,8 @@ let run_keepalive_unified_turn
                      ; generation = meta_after_triage.runtime.nonce
                      ; commit_count
                      ; at = Unix.gettimeofday () (* NDT-OK: stamps when this commit landed; no branch reads it *)
+                     ; before_bytes
+                     ; after_bytes
                      ; updated_at = Masc_domain.now_iso ()
                      })
               with

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -145,7 +145,10 @@ val record_crashed_cycle_failure :
 
 val compaction_outcomes_of_cycle_outcome :
   Keeper_heartbeat_loop_cycle.cycle_outcome ->
-  [ `Manual_committed of int | `Failed ] list
+  [ `Manual_committed of int * int * int | `Failed ] list
+(** [`Manual_committed (commit_count, before_checkpoint_bytes,
+    after_checkpoint_bytes)] — the sizes come from the preparation's evidence
+    so the owner projection can record what a commit saved (#29109). *)
 (** Pure mapping from one possibly nested cycle to every compaction
     commit/failure observation it contains. Only committed outcomes mutate
     durable compaction state. *)

--- a/lib/keeper/keeper_heartbeat_loop_cycle.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.ml
@@ -59,6 +59,11 @@ type cycle_outcome =
       }
   | Manual_compaction_applied of
       { receipt : Keeper_manual_compaction.applied_receipt
+      ; evidence : Keeper_compaction_evidence.t
+        (* The recovery this success carries measured the checkpoint on both
+           sides of the compaction. Dropping it here left the owner projection
+           able to say a compaction happened but not how much it saved
+           (#29109). *)
       ; followup : cycle_outcome
       }
 
@@ -266,7 +271,10 @@ let run_keeper_cycle_with
        Manual_compaction_not_applied { meta = meta_after_triage; no_compaction }
      | `Applied (success : Keeper_manual_compaction.success) ->
        Manual_compaction_applied
-         { receipt = success.receipt; followup = run_standard_cycle () })
+         { receipt = success.receipt
+         ; evidence = success.recovery.evidence
+         ; followup = run_standard_cycle ()
+         })
 ;;
 
 let run_keeper_cycle

--- a/lib/keeper/keeper_heartbeat_loop_cycle.mli
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.mli
@@ -24,6 +24,9 @@ type cycle_outcome =
       }
   | Manual_compaction_applied of
       { receipt : Keeper_manual_compaction.applied_receipt
+      ; evidence : Keeper_compaction_evidence.t
+        (** Checkpoint size on both sides of the compaction, carried so the
+            owner projection can record what a commit saved (#29109). *)
       ; followup : cycle_outcome
       }
 

--- a/lib/keeper/keeper_owner_reducer.ml
+++ b/lib/keeper/keeper_owner_reducer.ml
@@ -135,6 +135,8 @@ type meta_command =
       ; generation : int
       ; commit_count : int
       ; at : float
+      ; before_bytes : int
+      ; after_bytes : int
       ; updated_at : string
       }
   | Ack_message_scope of
@@ -703,7 +705,9 @@ let apply_existing (state : state) meta command =
   | Set_blocker { blocker; updated_at } ->
     let runtime = { meta.runtime with last_blocker = blocker } in
     Ok (with_meta state { meta with runtime; updated_at })
-  | Record_compaction_commit { trace_id; generation; commit_count; at; updated_at } ->
+  | Record_compaction_commit
+      { trace_id; generation; commit_count; at; before_bytes; after_bytes; updated_at }
+    ->
     if
       not (Keeper_id.Trace_id.equal meta.runtime.trace_id trace_id)
       || not (Int.equal meta.runtime.nonce generation)
@@ -712,15 +716,21 @@ let apply_existing (state : state) meta command =
     then Error (Invalid_delta "compaction commit count is negative")
     else if not (Float.is_finite at)
     then Error (Invalid_delta "compaction at must be finite")
+    else if before_bytes < 0 || after_bytes < 0
+    then Error (Invalid_delta "compaction checkpoint bytes must be non-negative")
     else
-      (* [count] alone said a compaction happened without saying when, so 136
-         commits left last_ts at zero and nothing could measure the interval
-         between them (#29109). The token pair stays unwritten here: this
-         commit path has no measurement of the context before or after. *)
+      (* [count] alone said a compaction happened without saying when or how
+         much it saved, so 136 commits left last_ts at zero and both token
+         fields at zero (#29109). The sizes come from the evidence the
+         preparation already measured on both sides of the checkpoint; the
+         cycle outcome now carries them this far instead of dropping them with
+         the recovery. *)
       let compaction_rt =
         { meta.runtime.compaction_rt with
           count = max meta.runtime.compaction_rt.count commit_count
         ; last_ts = at
+        ; last_before_tokens = before_bytes
+        ; last_after_tokens = after_bytes
         }
       in
       let meta = Keeper_meta_contract.map_compaction_rt (fun _ -> compaction_rt) meta in

--- a/lib/keeper/keeper_owner_reducer.mli
+++ b/lib/keeper/keeper_owner_reducer.mli
@@ -141,6 +141,8 @@ type meta_command =
       ; generation : int
       ; commit_count : int
       ; at : float
+      ; before_bytes : int
+      ; after_bytes : int
       ; updated_at : string
       }
   | Ack_message_scope of

--- a/test/test_keeper_compaction_outcome_counters.ml
+++ b/test/test_keeper_compaction_outcome_counters.ml
@@ -46,6 +46,8 @@ let persist_commit_projection config meta ~commit_count =
          ; generation = meta.runtime.nonce
          ; commit_count
          ; at = commit_at
+         ; before_bytes = 0
+         ; after_bytes = 0
          ; updated_at = Masc.Keeper_meta_contract.now_iso ()
          })
   with
@@ -92,6 +94,8 @@ let test_missing_keeper_has_no_commit_state () =
            ; generation = 1
            ; commit_count = 1
            ; at = commit_at
+           ; before_bytes = 0
+           ; after_bytes = 0
            ; updated_at = Masc.Keeper_meta_contract.now_iso ()
            })
     with

--- a/test/test_keeper_owner.ml
+++ b/test/test_keeper_owner.ml
@@ -280,6 +280,8 @@ let test_reducer_rejects_invalid_compaction_numbers () =
       ; generation = meta.runtime.nonce
       ; commit_count = 1
       ; at = Float.nan
+      ; before_bytes = 0
+      ; after_bytes = 0
       ; updated_at = "invalid"
       }
   in
@@ -373,6 +375,8 @@ let test_turn_delta_preserves_concurrent_compaction_observation () =
             ; generation = before.runtime.nonce
             ; commit_count = 1
             ; at = 99.0
+            ; before_bytes = 4096
+            ; after_bytes = 1024
             ; updated_at = "compacted"
             }))
   in


### PR DESCRIPTION
## 남아 있던 절반

#29110이 커밋 경로에 시각을 넣으면서 이런 주석을 남겼습니다.

```ocaml
(* The token pair stays unwritten here: this commit path has no
   measurement of the context before or after. *)
```

측정값은 **있습니다.** 한 단계 앞에서 버려질 뿐입니다.

## 어디서 버려지나

`Keeper_manual_compaction.success`는 `receipt`와 `recovery`를 둘 다 들고 있고, 그 recovery에 준비 단계가 만든 evidence가 있습니다.

```ocaml
(* keeper_compaction_evidence.mli:11-12 *)
; before_checkpoint_bytes : int
; after_checkpoint_bytes : int
```

그런데 cycle outcome을 만들 때 receipt만 챙깁니다.

```ocaml
(* keeper_heartbeat_loop_cycle.ml:268 — 수정 전 *)
Manual_compaction_applied
  { receipt = success.receipt; followup = run_standard_cycle () }
```

그래서 heartbeat loop가 커밋을 기록할 때는 이미 크기가 사라진 뒤였고, 136번의 커밋 내내 `last_before_tokens`·`last_after_tokens`가 0이었습니다.

## 변경

evidence를 variant에 실어 끝까지 보냅니다.

| 지점 | 변경 |
|---|---|
| `Manual_compaction_applied` | `evidence : Keeper_compaction_evidence.t` 추가 |
| `compaction_outcomes_of_cycle_outcome` | `` `Manual_committed (count, before, after) `` |
| `Record_compaction_commit` | `before_bytes`·`after_bytes` 추가 |
| 리듀서 | `last_before_tokens`·`last_after_tokens` 기록 |

음수 크기는 음수 count와 같은 방식으로 거부합니다.

`Keeper_compaction_evidence`는 두 파일에서 이미 참조 중이라 dune 의존성은 그대로입니다.

## 테스트

`Record_compaction_commit`을 만드는 네 자리를 모두 고쳤습니다. 셋은 0으로 두고, `test_keeper_owner`의 커밋 성공 케이스만 **4096 → 1024**를 씁니다 — 0 두 개를 통과시키는 대신 실제 절감이 projection에 도달하는지 보게 했습니다.

## 확인 방법

착륙하고 재배포한 뒤 keeper meta를 읽으면 됩니다.

```bash
python3 -c "
import json,glob,os
for f in glob.glob('<base-path>/.masc/keepers/*.json'):
    nm=os.path.basename(f)[:-5]
    if '.' in nm: continue
    d=json.load(open(f))
    if d.get('compaction_count'):
        print(nm, d['compaction_count'], d['last_compaction_ts'],
              d['last_compaction_before_tokens'], d['last_compaction_after_tokens'])
"
```

지금은 여덟 keeper 전부 `0.0 0 0`입니다. 압축이 한 번 더 커밋되면 세 값이 함께 채워집니다.

Closes #29109