### PR TITLE
feat(goal): B1 success-condition requirement + verification evidence ledger (RFC-0387 stage 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1170,9 +1170,15 @@ jobs:
         # exhaustive match proves every pair has an arm, not that the arm gives
         # the right answer -- so a matrix edit could change what the Goal FSM
         # admits without anything going red. The suite states all 35 pairs.
+        # test_goal_verification_gate pins the RFC-0387 stage-1 surface around
+        # the same lifecycle: B1 creation requires a declared success
+        # condition, the verification ledger is strict/fail-closed/fail-loud,
+        # and request_complete still completes a Goal directly (the gate is
+        # stage 2).
         run: |
           opam exec -- dune build --root . \
-            @test/runtest-test_goal_phase_all
+            @test/runtest-test_goal_phase_all \
+            @test/runtest-test_goal_verification_gate
 
       - name: Run metric zero-cell declaration suite
         # A counter emitted as a bare string still compiles and still counts;

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -233,6 +233,7 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0384 | In-process Telegram connector (long polling) | Proposed | - |
 | 0385 | 자율턴은 대화가 아니다 | Draft | - |
 | 0386 | 툴 종류(tool kind)는 닫힌 합타입으로 선언한다 | Draft | - |
+| 0387 | Goal verifier 게이트 — 성공조건 필수화, 생성 시 실재성 검증, 완료의 2단계 증명 | Draft | - |
 | RFC-async-log-sink-durable-append-offload | Offload the structured-log durable append off the emitting fiber | Draft | - |
 | RFC-checkpoint-pinned-root-containment | Immutable boot-pinned root capability for checkpoint containment | Draft | - |
 | RFC-claude-code-context-overflow-bounded-restart | Admit Claude Code bootstrap input without replaying rejected episodes | Draft | - |

--- a/docs/rfc/RFC-0387-goal-verifier-gate.md
+++ b/docs/rfc/RFC-0387-goal-verifier-gate.md
@@ -1,0 +1,267 @@
+---
+rfc: "0387"
+title: "Goal verifier 게이트 — 성공조건 필수화, 생성 시 실재성 검증, 완료의 2단계 증명"
+status: Draft
+created: 2026-08-19
+updated: 2026-08-20
+author: agent-16 + kimi
+supersedes: []
+superseded_by: null
+related: ["0362", "0089", "0337", "0361"]
+implementation_prs: ["29152"]
+---
+
+# RFC-0387: Goal verifier 게이트
+
+## 0. Summary
+
+constitution의 Goal 규칙 B1–B3는 문서만 있고 코드가 없었다. 이 RFC는 그 세 규칙을 기존 검증
+프로토콜 위에 얹는 최소 설계다.
+
+- **B1 (성공조건 필수)**: `Goal_store.upsert_goal`의 생성 경로가 `metric`과 `target_value`를
+  요구한다. 둘 다 blank이면 생성은 typed error로 거절된다. 갱신(기존 goal의 메타데이터 수정)은
+  게이트 대상이 아니다.
+- **B2 (생성 시 Verifier 실재성 체크)**: goal 생성과 함께 criterion 검증 요청이
+  `goal_verifications.json`에 durable하게 기록된다 (`Criterion_pending`). Verifier의 판정은
+  `record_criterion_viable` / `record_criterion_unreachable` action으로 커밋되며, 판정
+  결과는 goal record가 아니라 이 ledger에 보존된다. `Criterion_unreachable` 판정이 있는 goal은
+  `request_complete`이 typed conflict로 거절된다.
+- **B3 (완료 = Verifier 증명 + 사람 최종 확인)**: `Goal_phase`에 `Verifying`과
+  `Awaiting_confirmation` 두 phase와 네 action(`record_proof_proven`,
+  `record_proof_refuted`, `human_confirm`, `human_reject`)을 추가한다.
+  `request_complete`은 이제 `Executing -> Verifying`으로만 간다. `Completed`에 도달하는
+  유일한 경로는 `Verifying -(record_proof_proven)-> Awaiting_confirmation -(human_confirm)->
+  Completed`다.
+
+이 PR이 만드는 것은 게이트·상태기계·ledger·관측 표면이다. pending된 criterion/proof 요청을
+실제로 모델에 던지는 standalone verifier worker(Eio lane)은 **B7 후속**이다 — Task 도메인의
+`completion_authority_agent`(`lib/completion_authority_agent.ml`)가 하는 일의 Goal 판으로,
+기반은 이미 `Task.Anti_rationalization.review`(typed verdict, evaluator 미설정 시 typed
+non-verdict)로 존재한다. 본 PR은 그 모델 호출 **전에** durable 요청이 영속화되는 지점까지만
+만든다 (persist_before_model_call).
+
+## 0.5 Staging
+
+구현은 두 단계로 나뉜다 (adversarial review 지적 — 게이트에 caller 가 없으면 gate 에 들어선
+goal 은 keeper 의 시야에서 사라지고 영원히 `Completed` 에 도달할 수 없다 — 에 따라 분할).
+
+- **Stage 1 (PR #29152, 이 문서의 첫 구현)**: **B1 + ledger + 관측성만** 딴다.
+  - B1: `Goal_store.upsert_goal`의 생성 경로가 `metric`/`target_value`를 요구한다 (§2).
+  - `Goal_verification` ledger (`lib/goal/goal_verification.ml`) 는 **record-only 증거
+    저장소**로 도입된다 — 이 단계에서는 writer 가 하나도 없다. verdict 커밋 API
+    (`record_criterion_verdict` / `record_proof_verdict` / `record_human_confirmation`) 와
+    strict 디코더, fail-closed mutation, fail-loud read 만 갖춘다.
+  - 관측성: `masc_goal_list` 와 `/api/v1/dashboard/planning` 의 goal 항목에 ledger
+    `verification` 상태가 합류된다 (§6).
+  - **Stage 1은 lifecycle 을 전혀 바꾸지 않는다**: `request_complete`은 여전히
+    `Executing -> Completed` 로 곧장 완료된다. `Verifying` / `Awaiting_confirmation`
+    phase, gate action 들, criterion/proof 의 durable 요청 기록(`mark_*_pending`)은 전부
+    stage 2다.
+- **Stage 2 (후속 PR)**: §3.2/§3.3/§4/§5 의 FSM 게이트 — phase 2종 + action 6종,
+  `request_complete`의 `Verifying` 재라우팅, 생성 시 `Criterion_pending` durable 요청,
+  `Criterion_unreachable`의 `request_complete` 차단 — 와 그 게이트를 실제로 부르는
+  **verifier caller**(B7 standalone lane + 사람 확인 경로) 를 함께 딴다. 게이트는 caller
+  없이 머지하지 않는다.
+
+아래 §2–§6 은 최종 설계 전체를 기술한다. 각 절이 어느 stage 에 속하는지는 이 절의 분할을
+따른다.
+
+## 1. 원칙 → 설계 강제
+
+| 원칙 | 이 RFC에서의 강제 |
+|---|---|
+| 닫힌 합타입 | 새 상태는 전부 닫힌 variant다: phase 2종(`Goal_phase.t`), criterion 4종, completion 5종(`Goal_verification`). 문자열 상태 금지 |
+| strict parse | `goal_verifications.json` 디코더는 unknown 필드/unknown variant 문자열을 Error로 거절한다. 레거시 row(필드 부재)만 명시적 default(`Criterion_unchecked` / `Completion_idle`)로 읽힌다 |
+| 권위 저장소 fail-closed | `Goal_verification`의 쓰기 경로는 `Goal_store.update_state`와 같은 discipline을 따른다: 읽기가 decode 실패하면 mutation 불승인(`.last-good` mirror 포함) |
+| persist_before_model_call | `Criterion_pending`은 goal 생성 직후(모델 호출 전), `Proof_pending`은 `Verifying` phase 전이 전에 durable하게 쓴다. 영속화 실패 시 phase 전이/판정 커밋 모두 중단 |
+| wall-clock 만료 금지 | `Criterion_pending`/`Proof_pending`에는 만료가 없다. 재시도는 명시적이다: `Verifying`에서의 `request_complete` 재호출이 `Already`를 답하며 pending 상태를 그대로 보고한다 |
+| 실패 시 증거 보존 | `Refuted` 판정은 verdict(authority·evidence·recorded_at)째 ledger에 남는다. `human_reject`는 completion을 `Completion_idle`로 되돌리되 기각 사유는 `goal_events.jsonl`에 남는다 |
+| 매직 넘버/문자열 매칭 금지 | 게이트 판정은 전부 typed variant 매칭이다. 임계값·budget·문자열 substring 판정 없음 |
+| 재사용 우선 | verdict provenance는 `Masc_domain.completion_authority`(`Human_operator` / `System_llm_agent`)를 그대로 쓴다. judge 호출은 B7에서 `Task.Anti_rationalization.review` 위에 얹는다 |
+
+## 2. B1 — 생성 시 성공조건 필수 (stage 1)
+
+`Goal_store.upsert_goal`은 오늘 `title`만 필수다(`metric`/`target_value`는 `string option`).
+변경: 실제 생성(locked read 후 해당 id의 row가 없음)으로 확인되면 `metric`과 `target_value`
+모두 non-blank를 요구한다. 기존 row 갱신은 요구하지 않는다 — B1은 생성 시 선언 의무다.
+
+- 생성/갱신 판정은 **write lock 안**, 방금 decode된 state 위에서 이뤄진다. pre-lock
+  `read_state` 휴리스틱은 쓰지 않는다: decode 불가 저장소는 `update_state`의 fail-closed
+  거절이 먼저 잡으므로, B1 거절 메시지는 저장소를 실제로 읽고 row가 없음을 확인한 경우에만
+  나간다 (corruption을 "metric/target_value 누락"으로 오보하지 않는다).
+- 툴 스키마(`masc_goal_upsert`)는 create-or-update 겸용이라 JSON Schema `required`(무조건
+  적용)로는 B1을 표현할 수 없다 — `required`에 넣으면 기존 goal의 메타데이터 갱신이 전부
+  깨진다. 생성 경로 강제는 handler(`Goal_store.upsert_goal`)가 담당하며, 스키마는 두 필드의
+  description에 "생성 시 필수"를 명시한다.
+
+## 3. B2 — 생성 시 criterion 검증 (Verifier 실재성 체크)
+
+> **Stage 2.** 저장소(§3.1)는 stage 1이 싣지만, 이 절의 writer(§3.2 생성 훅, §3.3 판정
+> 커밋/게이트)는 verifier caller와 함께 stage 2에서 켜진다. Stage 1의 ledger는 writer 없는
+> record-only 저장소다.
+
+### 3.1 저장소: `Goal_verification` (lib/goal/goal_verification.ml)
+
+`Goal_store.goal` record는 외부 caller가 literal로 구성하므로(goal_store.mli:16-23) 필드 추가의
+파급이 크다. 따라서 `Workspace_goal_index`(goal-task link)와 같은 방식으로 **별도 ledger**
+`.masc/goal_verifications.json`에 둔다.
+
+```ocaml
+type verdict =
+  { outcome : Proven | Refuted of { reason : string }
+  ; authority : Masc_domain.completion_authority
+  ; evidence : string
+  ; recorded_at : string
+  }
+
+type criterion_state =
+  | Criterion_unchecked        (* RFC-0387 이전 row의 명시적 default *)
+  | Criterion_pending of { requested_at : string }   (* durable 요청 기록됨, 판정 전 *)
+  | Criterion_viable of verdict
+  | Criterion_unreachable of verdict
+```
+
+### 3.2 생성 훅
+
+`masc_goal_upsert`가 `created`를 답하면 곧바로 `mark_criterion_pending`으로 durable 요청을
+쓴다. 이 쓰기가 실패해도 goal은 이미 커밋됐으므로(delete_goal의 cross-file best-effort
+전례) 응답은 성공이지만 `criterion_check` 필드에 실패를 명시한다 — 모델 호출(B7)은 이
+영속화가 선행된 요청만 처리한다.
+
+### 3.3 판정 커밋과 게이트
+
+Verifier(B7 worker)는 `masc_goal_transition`의 `record_criterion_viable` /
+`record_criterion_unreachable` action으로 판정을 커밋한다. 이 action은 **phase-neutral**하다:
+`decide_transition`은 비종료 phase에 대해 `Already <같은 phase>`를 답하고(§5), 핸들러는
+phase 쓰기 없이 ledger만 갱신한다. `evidence` 인자는 필수(non-blank)다 — 근거 없는 판정은
+validation error.
+
+게이트: `request_complete` 시 criterion이 `Criterion_unreachable`이면 typed conflict로 거절.
+`Criterion_pending`(미판정)은 막지 않는다 — 완료 시점의 proof 검증(§4)이 더 강한 게이트이며,
+미판정 영구 차단은 wall-clock 없는 stall과 다름없기 때문이다.
+
+## 4. B3 — 완료의 2단계 증명
+
+> **Stage 2.** phase/action 추가와 `request_complete` 재라우팅은 게이트를 부를 verifier
+> caller(B7)와 같은 PR에서만 머지한다 — caller 없는 게이트는 진입한 goal을 keeper 시야에서
+> 지우고 완료 경로를 영구 차단한다 (adversarial review P0). Stage 1에서는
+> `request_complete`이 종전대로 `Executing -> Completed`다.
+
+### 4.1 상태기계 변경 (lib/goal/goal_phase.ml)
+
+phase 2종 추가: `Verifying`(완료 요청 접수, proof 대기), `Awaiting_confirmation`(proof
+증명됨, 사람 확인 대기). action 4종 추가:
+
+| action | from | to | 커밋 주체 |
+|---|---|---|---|
+| `record_proof_proven` | `Verifying` | `Awaiting_confirmation` | Verifier(`System_llm_agent`) |
+| `record_proof_refuted` | `Verifying` | `Executing` | Verifier — 반증 evidence 보존 |
+| `human_confirm` | `Awaiting_confirmation` | `Completed` | 사람 — `confirmed_by` 필수 |
+| `human_reject` | `Awaiting_confirmation` | `Executing` | 사람 — completion은 idle로 |
+
+`request_complete`의 유일한 이동은 이제 `Executing -> Verifying`이다. `Verifying` 진입 **전에**
+`mark_proof_pending`이 durable하게 쓰인다(persist_before_model_call); ledger 쓰기 실패 시
+phase는 움직이지 않는다.
+
+completion 상태 (같은 ledger):
+
+```ocaml
+type completion_state =
+  | Completion_idle
+  | Proof_pending of { requested_at : string }
+  | Proof_proven of verdict
+  | Proof_refuted of verdict
+  | Human_confirmed of { proof : verdict; confirmed_by : string; confirmed_at : string }
+```
+
+`Completed` phase에 있는 goal의 ledger row는 `Human_confirmed { proof; ... }`를 지니므로
+"완료 = verifier 증명 + 사람 확인"의 전체 사슬이 durable하게 읽힌다.
+
+`record_proof_verdict`는 ledger 쪽에서도 `Proof_pending`을 요구한다 — phase(FSM)와
+ledger(저장소) 양쪽이 같은 전이를 이중으로 검증해 stale verifier 커밋 경합을 막는다.
+
+### 4.2 직접 완료의 폐기
+
+기존 `Executing -(request_complete)-> Completed` 직행은 사라진다. `Paused`/`Blocked`에서의
+완료 요청은 종전대로 invalid다. `Completed`/`Dropped`에서 `reopen`/`drop` 동작은 불변이다.
+
+### 4.3 신분 바인딩의 한계 (명시)
+
+MCP 표면은 caller를 인증하지 않으므로, `record_proof_*`의 authority는 호출자 세션 이름을 담은
+`System_llm_agent { agent_run_id = ctx.agent_name }`이고, `human_confirm`의 `confirmed_by`는
+operator-asserted 문자열이다. Task 도메인이 `completion_authority` 생성을 인증된 operator /
+typed system-LLM 결과로 제한하는 것(types_core.mli:86-90 주석)과 같은 강도의 바인딩 — standalone
+verifier lane이 자기 run id로 커밋하고, 사람 확인이 operator 인증 경로(dashboard HITL)를
+타는 것 — 은 B7 후속이다. 이 PR은 그 바인딩이 꽂힐 typed 슬롯을 만든다.
+
+## 5. `Already` 의미론 확장
+
+> **Stage 2.** `decide_transition` 대각선 확장은 gate action들과 함께 들어온다.
+
+`decide_transition`의 대각선 규칙("목표 phase에 이미 있는 요청은 Already")을 두 방향으로
+확장한다:
+
+- `Verifying`/`Awaiting_confirmation`에서의 `request_complete` → `Already <현재 phase>`
+  (완료 요청은 파이프라인에 진입해 있다). 핸들러는 이 응답에 verification 상태를 실어
+  재시도 힌트로 쓴다 — wall-clock 만료 대신 명시적 재호출.
+- `record_criterion_*` → 비종료 phase에서 `Already <현재 phase>`: "phase 불변, ledger만
+  갱신"의 legality 판정. `Completed`/`Dropped`에서는 invalid — 종료된 goal의 생성 시점
+  선언은 확정된 역사다.
+
+proof/human action의 phase 밖 호출은 전부 invalid다(반증을 증거 없이 무시하는 Already를
+만들지 않기 위해).
+
+## 6. 관측성
+
+Stage 1 (이 PR):
+
+- `masc_goal_list` 응답의 goal 항목에 `verification`(criterion + completion 상태 JSON)을
+  합류한다 (goal items의 출력 스키마는 additionalProperties: true라 계약 변화 없음).
+- `/api/v1/dashboard/planning`의 goals 항목에도 동일한 `verification`을 합류한다.
+- 두 표면 모두 ledger를 **요청당 한 번만** 적재해 메모리에서 join한다 (goal당 재 decode
+  금지). Ledger가 decode되지 않으면 pre-verification default로 위장하지 않고 goal 항목에
+  명시적 `{"state": "ledger_error", "detail": …}` 마커를 렌더한다.
+
+Stage 2 (게이트와 함께):
+
+- `Goal_store.rollup`에 `verifying_count` / `awaiting_confirmation_count` 필드 추가 —
+  keeper 출력 계약(`keeper_tool_descriptor.ml`의 `goal_list_output_schema`, strict)에도 같은
+  두 필드를 추가한다.
+- goals-tree summary의 `phase_counts`에 `verifying` / `awaiting_confirmation`을 추가하고,
+  phase 색상을 배정한다.
+- 대시보드 프런트엔드(phase 색상 외의 렌더링)는 그 다음 PR로 미룬다.
+
+## 7. 범위 밖 (후속 PR)
+
+- **Stage 2 게이트 전체** — §3.2/§3.3/§4/§5: `Verifying`/`Awaiting_confirmation` phase,
+  gate action 6종, `request_complete` 재라우팅, `mark_*_pending` durable 요청,
+  `Criterion_unreachable` 차단. 반드시 아래 caller와 함께 머지한다.
+- **B7: standalone verifier lane** — `Criterion_pending`/`Proof_pending`을 drain해
+  `Task.Anti_rationalization.review`로 판정하고 §3.3/§4.1 action으로 커밋하는 Eio worker.
+  `completion_authority_agent.start`의 Goal 판.
+- `human_confirm`의 operator 인증 바인딩 (dashboard HITL 경로).
+- 대시보드 프런트엔드 렌더링(phase badge, verdict 카드).
+- `Verifying` 중 `pause` — 현재는 invalid; 필요해지면 별도 RFC.
+
+## 8. 수용 기준 (feature 수준)
+
+Stage 1 (이 PR):
+
+1. metric/target_value 없는(또는 blank인) 생성이 typed error로 거절되고, 기존 row 갱신은
+   거절되지 않는다. 생성/갱신 판정은 write lock 안에서 이뤄지므로, decode 불가 goal
+   저장소에서는 B1 메시지가 아니라 fail-closed persistence error가 나간다.
+2. Ledger verdict 커밋(`record_criterion_verdict`)이 파일 저장소를 왕복하고, refuted
+   판정의 reason이 보존된다.
+3. Ledger decode 실패(unknown 필드/variant 포함) 시 모든 mutation이 거절되고, 모든 read가
+   `Error`로 실패한다 — "미검증"으로 위장하지 않는다.
+4. `masc_goal_list`가 goal 항목에 `verification`을 합류하고, ledger가 없는 goal은 명시적
+   default(`unchecked`/`idle`), corrupt ledger는 `ledger_error`로 렌더된다.
+5. Lifecycle 불변: `request_complete`은 `Executing -> Completed`로 곧장 완료된다.
+
+Stage 2 (후속):
+
+1. criterion `unreachable` 판정 후 `request_complete`이 conflict로 거절된다.
+2. `request_complete → record_proof_proven → human_confirm` 왕복으로만 `Completed`에
+   도달하고, ledger가 `human_confirmed`(proof 사슬 포함)를 보인다.
+3. `record_proof_refuted`는 goal을 `Executing`으로 되돌리고 refuted verdict가 ledger에
+   남는다.

--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -455,6 +455,10 @@ let validate_parent_goal_id goals ~goal_id ~parent_goal_id =
       else
         Ok ()
 
+let blank_opt = function
+  | None -> true
+  | Some raw -> String.trim raw = ""
+
 let upsert_goal config ?id ?title ?metric ?target_value ?due_date
     ?priority ?phase ?parent_goal_id () =
   let is_new_goal = id = None in
@@ -495,6 +499,7 @@ let upsert_goal config ?id ?title ?metric ?target_value ?due_date
          | Error msg -> Error msg
          | Ok () ->
         let was_created = ref false in
+        let refusal = ref None in
         let state_result =
           update_state config (fun state ->
               match find_goal state.goals resolved_id with
@@ -532,6 +537,26 @@ let upsert_goal config ?id ?title ?metric ?target_value ?due_date
                     goals = replace_goal state.goals next_goal;
                   }
               | None ->
+                  (* RFC-0387 B1: a goal is created only with a declared
+                     measurable success condition — both [metric] and
+                     [target_value], non-blank. Updates (the arm above) are
+                     not gated: the obligation is declared at creation. The
+                     create/update split is decided HERE, inside the write
+                     lock on the freshly decoded state: an undecodable store
+                     is rejected by [update_state]'s fail-closed path before
+                     this closure runs, so the B1 refusal below can only ever
+                     fire against a store that was actually read and found
+                     not to hold the row. On refusal the closure returns the
+                     state unchanged and [update_state] rewrites the same
+                     bytes; the error is carried out via [refusal]. *)
+                  if blank_opt metric || blank_opt target_value then (
+                    refusal :=
+                      Some
+                        "metric and target_value are required for a new goal \
+                         (RFC-0387 B1: a goal must declare a measurable \
+                         success condition)";
+                    state)
+                  else (
                   let new_goal =
                       {
                         id = resolved_id;
@@ -554,16 +579,19 @@ let upsert_goal config ?id ?title ?metric ?target_value ?due_date
                     version = state.version + 1;
                     updated_at = now;
                     goals = state.goals @ [ new_goal ];
-                  })
+                  }))
         in
-        match state_result with
+        (match state_result with
         | Error msg -> Error msg
         | Ok state ->
-          match find_goal state.goals resolved_id with
+          (match !refusal with
+           | Some msg -> Error msg
+           | None ->
+          (match find_goal state.goals resolved_id with
           | Some goal ->
               Ok (goal, if !was_created then `created else `updated)
           | None ->
-              Error "failed to save goal")
+              Error "failed to save goal"))))
 
 let compute_rollup goals =
   let count predicate =

--- a/lib/goal/goal_store.mli
+++ b/lib/goal/goal_store.mli
@@ -184,4 +184,11 @@ val upsert_goal :
 
     Errors:
     - [title] required for new goals (omit / empty string
-      on a new goal id). *)
+      on a new goal id).
+    - RFC-0387 B1: [metric] and [target_value] are both required
+      (non-blank) whenever the upsert creates a new row —
+      including an explicit previously-unknown [id].  The
+      create/update split is decided inside the write lock on
+      the freshly decoded state, so an undecodable store hits
+      the fail-closed persistence error, never this one.
+      Updating an existing row is not gated. *)

--- a/lib/goal/goal_verification.ml
+++ b/lib/goal/goal_verification.ml
@@ -1,0 +1,554 @@
+(* Goal_verification — per-goal success-condition verification ledger
+   (RFC-0387).
+
+   Lives beside [Goal_store] rather than inside it: the goal record is
+   constructed by literal in external callers (goal_store.mli), so the
+   criterion/completion verification state gets its own store, the same way
+   [Workspace_goal_index] keeps goal-task links out of goals.json.
+
+   RFC-0387 stage 1 ships this as a RECORD-ONLY evidence store: no workflow
+   reads it for control and no caller writes it yet — the stage-2 verifier
+   gate adds the writers ([mark_*_pending] durable requests, verdict commits
+   from the verifier lane) and the readers that gate transitions.
+
+   Invariants carried here:
+
+   - No wall-clock expiry: pending states remain durable until a verdict is
+     committed.
+   - Failure keeps its evidence: a refuted verdict stays on the record until
+     the next request supersedes it.
+   - Fail-closed mutations: a store that does not decode refuses every
+     mutation, mirroring [Goal_store.update_state].
+   - Fail-loud reads: a store that does not decode is an [Error] for every
+     reader, never a silent "not verified yet". *)
+
+let ( let* ) = Result.bind
+
+type verdict_outcome =
+  | Proven
+  | Refuted of { reason : string }
+
+type verdict = {
+  outcome : verdict_outcome;
+  authority : Masc_domain.completion_authority;
+  evidence : string;
+  recorded_at : string;
+}
+
+type criterion_state =
+  | Criterion_unchecked
+  | Criterion_pending of { requested_at : string }
+  | Criterion_viable of verdict
+  | Criterion_unreachable of verdict
+
+type completion_state =
+  | Completion_idle
+  | Proof_pending of { requested_at : string }
+  | Proof_proven of verdict
+  | Proof_refuted of verdict
+  | Human_confirmed of {
+      proof : verdict;
+      confirmed_by : string;
+      confirmed_at : string;
+    }
+
+type record = {
+  goal_id : string;
+  criterion : criterion_state;
+  completion : completion_state;
+  updated_at : string;
+}
+
+type state = {
+  version : int;
+  updated_at : string;
+  records : record list;
+}
+
+let default_record ~goal_id =
+  { goal_id
+  ; criterion = Criterion_unchecked
+  ; completion = Completion_idle
+  ; updated_at = Masc_domain.now_iso ()
+  }
+
+(* {1 Codecs}
+
+   Strict, same discipline as [Goal_store.goal_of_yojson]: unknown fields and
+   unknown variant strings are decode errors, never a silent default. The only
+   lenient case is the absent record itself (a pre-RFC-0387 goal), which
+   [get_record] reports as [Ok None] and callers render through
+   {!default_record}. *)
+
+let authority_to_yojson authority =
+  `Assoc
+    [ "kind", `String (Masc_domain.completion_authority_kind authority)
+    ; "actor", `String (Masc_domain.completion_authority_actor authority)
+    ]
+
+let authority_of_yojson json =
+  match
+    Json_util.assoc_member_opt "kind" json, Json_util.assoc_member_opt "actor" json
+  with
+  | Some (`String "human_operator"), Some (`String actor) ->
+      Ok (Masc_domain.Human_operator { operator_id = actor })
+  | Some (`String "system_llm_agent"), Some (`String actor) ->
+      Ok (Masc_domain.System_llm_agent { agent_run_id = actor })
+  | _ ->
+      Error
+        ("goal_verification.authority_of_yojson: " ^ Yojson.Safe.to_string json)
+
+let verdict_to_yojson (v : verdict) =
+  let outcome_fields =
+    match v.outcome with
+    | Proven -> [ "outcome", `String "proven"; "reason", `Null ]
+    | Refuted { reason } ->
+        [ "outcome", `String "refuted"; "reason", `String reason ]
+  in
+  `Assoc
+    (outcome_fields
+     @ [ "authority", authority_to_yojson v.authority
+       ; "evidence", `String v.evidence
+       ; "recorded_at", `String v.recorded_at
+       ])
+
+let verdict_of_yojson = function
+  | `Assoc fields -> (
+      let unknown =
+        List.find_map
+          (fun (field, _) ->
+            (* strict wire-boundary decoder: rejects unknown fields. STR-OK *)
+            if List.mem field
+                 [ "outcome"; "reason"; "authority"; "evidence"; "recorded_at" ]
+            then None
+            else Some field)
+          fields
+      in
+      match unknown with
+      | Some field ->
+          Error
+            (Printf.sprintf
+               "goal_verification.verdict_of_yojson: unknown field %S" field)
+      | None -> (
+          let json = `Assoc fields in
+          match
+            ( Json_util.assoc_member_opt "outcome" json
+            , Json_util.get_string json "evidence"
+            , Json_util.assoc_member_opt "recorded_at" json )
+          with
+          | Some (`String outcome), Some evidence, Some (`String recorded_at) -> (
+              match authority_of_yojson (Yojson.Safe.Util.member "authority" json) with
+              | Error _ as error -> error
+              | Ok authority -> (
+                  match outcome with
+                  | "proven" ->
+                      Ok { outcome = Proven; authority; evidence; recorded_at }
+                  | "refuted" -> (
+                      match Json_util.get_string json "reason" with
+                      | Some reason ->
+                          Ok
+                            { outcome = Refuted { reason }
+                            ; authority
+                            ; evidence
+                            ; recorded_at
+                            }
+                      | None ->
+                          Error
+                            "goal_verification.verdict_of_yojson: refuted verdict \
+                             has no reason")
+                  | other ->
+                      Error
+                        ("goal_verification.verdict_of_yojson: unknown outcome "
+                         ^ other)))
+          | _ ->
+              Error
+                "goal_verification.verdict_of_yojson: outcome, evidence and \
+                 recorded_at are required"))
+  | json ->
+      Error ("goal_verification.verdict_of_yojson: " ^ Yojson.Safe.to_string json)
+
+let criterion_state_to_yojson = function
+  | Criterion_unchecked -> `Assoc [ "state", `String "unchecked" ]
+  | Criterion_pending { requested_at } ->
+      `Assoc
+        [ "state", `String "pending"; "requested_at", `String requested_at ]
+  | Criterion_viable verdict ->
+      `Assoc [ "state", `String "viable"; "verdict", verdict_to_yojson verdict ]
+  | Criterion_unreachable verdict ->
+      `Assoc
+        [ "state", `String "unreachable"; "verdict", verdict_to_yojson verdict ]
+
+let criterion_state_of_yojson json =
+  match Json_util.assoc_member_opt "state" json with
+  | Some (`String "unchecked") -> Ok Criterion_unchecked
+  | Some (`String "pending") -> (
+      match Json_util.assoc_member_opt "requested_at" json with
+      | Some (`String requested_at) -> Ok (Criterion_pending { requested_at })
+      | _ -> Error "goal_verification: criterion pending has no requested_at")
+  | Some (`String "viable") -> (
+      match verdict_of_yojson (Yojson.Safe.Util.member "verdict" json) with
+      | Ok verdict -> Ok (Criterion_viable verdict)
+      | Error _ as error -> error)
+  | Some (`String "unreachable") -> (
+      match verdict_of_yojson (Yojson.Safe.Util.member "verdict" json) with
+      | Ok verdict -> Ok (Criterion_unreachable verdict)
+      | Error _ as error -> error)
+  | Some (`String other) ->
+      Error ("goal_verification: unknown criterion state " ^ other)
+  | _ -> Error "goal_verification: criterion state missing"
+
+let completion_state_to_yojson = function
+  | Completion_idle -> `Assoc [ "state", `String "idle" ]
+  | Proof_pending { requested_at } ->
+      `Assoc
+        [ "state", `String "proof_pending"
+        ; "requested_at", `String requested_at
+        ]
+  | Proof_proven verdict ->
+      `Assoc
+        [ "state", `String "proof_proven"; "verdict", verdict_to_yojson verdict ]
+  | Proof_refuted verdict ->
+      `Assoc
+        [ "state", `String "proof_refuted"; "verdict", verdict_to_yojson verdict ]
+  | Human_confirmed { proof; confirmed_by; confirmed_at } ->
+      `Assoc
+        [ "state", `String "human_confirmed"
+        ; "proof", verdict_to_yojson proof
+        ; "confirmed_by", `String confirmed_by
+        ; "confirmed_at", `String confirmed_at
+        ]
+
+let completion_state_of_yojson json =
+  match Json_util.assoc_member_opt "state" json with
+  | Some (`String "idle") -> Ok Completion_idle
+  | Some (`String "proof_pending") -> (
+      match Json_util.assoc_member_opt "requested_at" json with
+      | Some (`String requested_at) -> Ok (Proof_pending { requested_at })
+      | _ -> Error "goal_verification: proof_pending has no requested_at")
+  | Some (`String "proof_proven") -> (
+      match verdict_of_yojson (Yojson.Safe.Util.member "verdict" json) with
+      | Ok verdict -> Ok (Proof_proven verdict)
+      | Error _ as error -> error)
+  | Some (`String "proof_refuted") -> (
+      match verdict_of_yojson (Yojson.Safe.Util.member "verdict" json) with
+      | Ok verdict -> Ok (Proof_refuted verdict)
+      | Error _ as error -> error)
+  | Some (`String "human_confirmed") -> (
+      match
+        ( verdict_of_yojson (Yojson.Safe.Util.member "proof" json)
+        , Json_util.get_string json "confirmed_by"
+        , Json_util.assoc_member_opt "confirmed_at" json )
+      with
+      | Ok proof, Some confirmed_by, Some (`String confirmed_at) ->
+          Ok (Human_confirmed { proof; confirmed_by; confirmed_at })
+      | Error _ as error, _, _ -> error
+      | _ ->
+          Error
+            "goal_verification: human_confirmed needs proof, confirmed_by and \
+             confirmed_at")
+  | Some (`String other) ->
+      Error ("goal_verification: unknown completion state " ^ other)
+  | _ -> Error "goal_verification: completion state missing"
+
+let record_to_yojson (record : record) =
+  `Assoc
+    [ "goal_id", `String record.goal_id
+    ; "criterion", criterion_state_to_yojson record.criterion
+    ; "completion", completion_state_to_yojson record.completion
+    ; "updated_at", `String record.updated_at
+    ]
+
+let record_of_yojson = function
+  | `Assoc fields -> (
+      let unknown =
+        List.find_map
+          (fun (field, _) ->
+            (* strict wire-boundary decoder: this membership test *rejects*
+               unknown record fields (constitution strict-parse). STR-OK *)
+            if List.mem field [ "goal_id"; "criterion"; "completion"; "updated_at" ]
+            then None
+            else Some field)
+          fields
+      in
+      match unknown with
+      | Some field ->
+          Error
+            (Printf.sprintf
+               "goal_verification.record_of_yojson: unknown field %S" field)
+      | None -> (
+          let json = `Assoc fields in
+          match
+            Json_util.assoc_member_opt "goal_id" json
+          , Json_util.assoc_member_opt "updated_at" json
+          with
+          | Some (`String goal_id), Some (`String updated_at) -> (
+              match
+                ( criterion_state_of_yojson (Yojson.Safe.Util.member "criterion" json)
+                , completion_state_of_yojson (Yojson.Safe.Util.member "completion" json)
+                )
+              with
+              | Ok criterion, Ok completion ->
+                  Ok { goal_id; criterion; completion; updated_at }
+              | Error _ as error, _ -> error
+              | _, (Error _ as error) -> error)
+          | _ ->
+              Error "goal_verification.record_of_yojson: goal_id and updated_at \
+                     are required"))
+  | json ->
+      Error ("goal_verification.record_of_yojson: " ^ Yojson.Safe.to_string json)
+
+let state_to_yojson (state : state) =
+  `Assoc
+    [ "version", `Int state.version
+    ; "updated_at", `String state.updated_at
+    ; "records", `List (List.map record_to_yojson state.records)
+    ]
+
+let state_of_yojson = function
+  | `Assoc _ as json -> (
+      match
+        ( Json_util.assoc_member_opt "version" json
+        , Json_util.assoc_member_opt "updated_at" json
+        , Json_util.assoc_member_opt "records" json )
+      with
+      | Some (`Int version), Some (`String updated_at), Some (`List records_json) ->
+          let rec collect acc = function
+            | [] -> Ok (List.rev acc)
+            | row :: rest -> (
+                match record_of_yojson row with
+                | Ok record -> collect (record :: acc) rest
+                | Error _ as error -> error)
+          in
+          Result.map
+            (fun records -> { version; updated_at; records })
+            (collect [] records_json)
+      | _ -> Error "goal_verification.state_of_yojson: invalid state")
+  | json ->
+      Error ("goal_verification.state_of_yojson: " ^ Yojson.Safe.to_string json)
+
+(* {1 Persistence} *)
+
+let verifications_path config =
+  Filename.concat (Workspace_utils.masc_dir config) "goal_verifications.json"
+
+let verifications_recovery_path config =
+  verifications_path config ^ ".last-good"
+
+let ensure_dirs config =
+  Workspace_utils.mkdir_p (Workspace_utils.masc_dir config)
+
+let default_state () =
+  { version = 1; updated_at = Masc_domain.now_iso (); records = [] }
+
+(* Same split as [Goal_store.load_state]: an absent store is legitimately
+   empty; a present-but-undecodable store must not license a write. *)
+type load_outcome =
+  | Loaded of state
+  | Undecodable of string
+
+let load_state config : load_outcome =
+  ensure_dirs config;
+  let path = verifications_path config in
+  if Workspace_utils.path_exists config path then
+    match Workspace_utils.read_json_result config path with
+    | Ok json -> (
+        match state_of_yojson json with
+        | Ok state -> Loaded state
+        | Error primary_msg ->
+            let recovery = verifications_recovery_path config in
+            if Workspace_utils.path_exists config recovery then
+              match Workspace_utils.read_json_result config recovery with
+              | Ok recovery_json -> (
+                  match state_of_yojson recovery_json with
+                  | Ok state ->
+                      Log.Misc.warn
+                        "goal_verification: primary store corrupt (%s), recovered \
+                         from %s"
+                        primary_msg recovery;
+                      Loaded state
+                  | Error recovery_msg ->
+                      Undecodable
+                        (Printf.sprintf "primary: %s; recovery: %s"
+                           primary_msg recovery_msg))
+              | Error recovery_read_msg ->
+                  Undecodable
+                    (Printf.sprintf "primary: %s; recovery unreadable: %s"
+                       primary_msg recovery_read_msg)
+            else Undecodable primary_msg)
+    | Error primary_msg ->
+        let recovery = verifications_recovery_path config in
+        if Workspace_utils.path_exists config recovery then
+          match Workspace_utils.read_json_result config recovery with
+          | Ok recovery_json -> (
+              match state_of_yojson recovery_json with
+              | Ok state ->
+                  Log.Misc.warn
+                    "goal_verification: primary store unreadable (%s), recovered \
+                     from %s"
+                    primary_msg recovery;
+                  Loaded state
+              | Error recovery_msg ->
+                  Undecodable
+                    (Printf.sprintf "primary unreadable: %s; recovery: %s"
+                       primary_msg recovery_msg))
+          | Error recovery_msg ->
+              Undecodable
+                (Printf.sprintf
+                   "primary unreadable: %s; recovery unreadable: %s"
+                   primary_msg recovery_msg)
+        else Undecodable primary_msg
+  else Loaded (default_state ())
+
+let undecodable_store_error config detail =
+  Printf.sprintf
+    "goal_verification: refusing to write over a store that did not decode (%s); \
+     reset or repair %s before writing"
+    detail
+    (verifications_path config)
+
+let undecodable_load_error config detail =
+  Printf.sprintf
+    "goal_verification: store did not decode (%s); repair or reset %s"
+    detail
+    (verifications_path config)
+
+let write_state_result config state =
+  ensure_dirs config;
+  let json = state_to_yojson state in
+  let* () = Workspace_utils.write_json_result config (verifications_path config) json in
+  (match Workspace_utils.write_json_result
+           config (verifications_recovery_path config) json
+   with
+   | Ok () -> ()
+   | Error msg ->
+     Log.Misc.warn
+       "goal_verification: primary committed; recovery mirror write failed for \
+        %s: %s"
+       (verifications_recovery_path config)
+       msg);
+  Ok ()
+
+(* {1 Record operations}
+
+   Every mutation is a locked read-modify-write that refuses an undecodable
+   store, mirroring [Goal_store.update_state]. *)
+
+let find_record records goal_id =
+  List.find_opt (fun (record : record) -> String.equal record.goal_id goal_id) records
+
+let replace_record records updated =
+  let rec loop acc = function
+    | [] -> List.rev (updated :: acc)
+    | (record : record) :: rest ->
+        if String.equal record.goal_id updated.goal_id
+        then List.rev_append acc (updated :: rest)
+        else loop (record :: acc) rest
+  in
+  loop [] records
+
+let update_record config ~goal_id f =
+  Workspace_utils.with_file_lock config (verifications_path config) (fun () ->
+      match load_state config with
+      | Undecodable detail -> Error (undecodable_store_error config detail)
+      | Loaded state ->
+          let current =
+            match find_record state.records goal_id with
+            | Some record -> record
+            | None -> default_record ~goal_id
+          in
+          let now = Masc_domain.now_iso () in
+          let* updated = f { current with updated_at = now } in
+          let next_state =
+            { version = state.version + 1
+            ; updated_at = now
+            ; records = replace_record state.records updated
+            }
+          in
+          let* () = write_state_result config next_state in
+          Ok updated)
+
+(* Read side: fail LOUD. An undecodable store is an [Error] for every
+   consumer — rendering it as "not verified yet" would let a corrupt ledger
+   masquerade as a clean one (P1-1). Consumers that show per-goal
+   verification state load once per request via {!load_records} and render
+   the error through {!ledger_error_to_yojson}. *)
+let load_records config : (record list, string) result =
+  match load_state config with
+  | Undecodable detail -> Error (undecodable_load_error config detail)
+  | Loaded state -> Ok state.records
+
+let get_record config ~goal_id : (record option, string) result =
+  match load_records config with
+  | Error _ as error -> error
+  | Ok records -> Ok (find_record records goal_id)
+
+let ledger_error_to_yojson detail =
+  `Assoc [ "state", `String "ledger_error"; "detail", `String detail ]
+
+let record_criterion_verdict config ~goal_id (verdict : verdict) =
+  update_record config ~goal_id (fun current ->
+      let criterion =
+        match verdict.outcome with
+        | Proven -> Criterion_viable verdict
+        | Refuted _ -> Criterion_unreachable verdict
+      in
+      Ok { current with criterion })
+
+(* A proof verdict is only committable against a pending proof — or against
+   the same outcome already committed. The latter is the crash-between-writes
+   case the stage-2 gate needs: the ledger write landed but the phase write
+   did not, and the retried transition must be able to re-commit the
+   identical outcome rather than wedge the goal. A commit in the OPPOSITE
+   direction of a standing verdict is a stale verifier answer and stays an
+   [Error]. The [Proof_pending] rows this matches against are written by the
+   stage-2 gate ([mark_proof_pending], persist-before-model-call); stage 1
+   has no writer, so until then this only ever answers the error. *)
+let record_proof_verdict config ~goal_id (verdict : verdict) =
+  update_record config ~goal_id (fun current ->
+      let committable =
+        match current.completion, verdict.outcome with
+        | Proof_pending _, _ -> true
+        | Proof_proven _, Proven -> true
+        | Proof_refuted _, Refuted _ -> true
+        | ( Proof_proven _, Refuted _ )
+        | ( Proof_refuted _, Proven )
+        | ( Completion_idle, _ )
+        | ( Human_confirmed _, _ ) -> false
+      in
+      if committable
+      then
+        let completion =
+          match verdict.outcome with
+          | Proven -> Proof_proven verdict
+          | Refuted _ -> Proof_refuted verdict
+        in
+        Ok { current with completion }
+      else
+        Error
+          (Printf.sprintf
+             "goal_verification: proof verdict for %s has no pending proof \
+              request"
+             goal_id))
+
+let record_human_confirmation config ~goal_id ~confirmed_by =
+  update_record config ~goal_id (fun current ->
+      (* [Human_confirmed] is accepted alongside [Proof_proven]: the same
+         crash-between-writes recovery as [record_proof_verdict] — the ledger
+         committed but the phase write did not, and the stage-2 retried
+         confirm must reconcile rather than wedge the goal. *)
+      match current.completion with
+      | Proof_proven proof | Human_confirmed { proof; _ } ->
+          Ok
+            { current with
+              completion =
+                Human_confirmed
+                  { proof
+                  ; confirmed_by
+                  ; confirmed_at = current.updated_at
+                  }
+            }
+      | Completion_idle | Proof_pending _ | Proof_refuted _ ->
+          Error
+            (Printf.sprintf
+               "goal_verification: human confirmation for %s needs a proven proof"
+               goal_id))

--- a/lib/goal/goal_verification.mli
+++ b/lib/goal/goal_verification.mli
@@ -1,0 +1,135 @@
+(** Goal_verification — per-goal success-condition verification ledger
+    (RFC-0387).
+
+    Persists under [<base>/.masc/goal_verifications.json], separate from
+    [goals.json] the way [Workspace_goal_index] keeps goal-task links separate:
+    the [Goal_store.goal] record is constructed by literal in external callers,
+    so verification state gets its own store.
+
+    RFC-0387 stage 1 ships this module as a RECORD-ONLY evidence store: the
+    dashboard read paths render it, but no workflow reads it for control and
+    no caller writes it yet. Stage 2 (the verifier gate) adds the writers —
+    the durable [*_pending] requests and the verifier-lane verdict commits.
+
+    Two state machines per goal, both closed sum types:
+
+    - [criterion_state] (B2) — the creation-time feasibility check of the
+      declared success condition. [Criterion_unchecked] is the explicit
+      default for pre-RFC-0387 goals, not a silent fallback.
+    - [completion_state] (B3) — the completion-time proof chain. A gated
+      [Completed] goal carries [Human_confirmed { proof; … }], so "verifier
+      proof plus human confirmation" reads back as one durable record.
+
+    Mutation discipline mirrors [Goal_store]: locked read-modify-write, strict
+    decode, and a store that does not decode refuses every mutation (the
+    [Undecodable] path), recovery mirror included. Pending states have no
+    wall-clock expiry; a refuted verdict stays on the record as preserved
+    evidence until the next request supersedes it. *)
+
+type verdict_outcome =
+  | Proven
+  | Refuted of { reason : string }
+
+type verdict = {
+  outcome : verdict_outcome;
+  authority : Masc_domain.completion_authority;
+      (** Typed provenance, reused from the Task completion protocol. The
+          stage-2 verifier lane commits with its own run identity
+          (RFC-0387 §4.3). *)
+  evidence : string;
+  recorded_at : string;
+}
+
+type criterion_state =
+  | Criterion_unchecked
+  | Criterion_pending of { requested_at : string }
+  | Criterion_viable of verdict
+  | Criterion_unreachable of verdict
+
+type completion_state =
+  | Completion_idle
+  | Proof_pending of { requested_at : string }
+  | Proof_proven of verdict
+  | Proof_refuted of verdict
+  | Human_confirmed of {
+      proof : verdict;
+      confirmed_by : string;
+      confirmed_at : string;
+    }
+
+type record = {
+  goal_id : string;
+  criterion : criterion_state;
+  completion : completion_state;
+  updated_at : string;
+}
+
+val default_record : goal_id:string -> record
+(** The explicit pre-verification state: [Criterion_unchecked] /
+    [Completion_idle]. Used to render goals that have no ledger row. *)
+
+(** {1 Codecs} *)
+
+val record_to_yojson : record -> Yojson.Safe.t
+
+(** {1 Persistence} *)
+
+val verifications_path : Workspace_utils.config -> string
+(** [{!Workspace_utils.masc_dir} / "goal_verifications.json"]. *)
+
+(** {1 Queries}
+
+    Reads fail LOUD: a store that does not decode is an [Error], never a
+    silent "not verified yet" — a corrupt ledger must be visible as a ledger
+    error to every consumer. *)
+
+val load_records :
+  Workspace_utils.config -> (record list, string) result
+(** Loads every ledger row once. Bulk consumers (dashboard endpoints, goal
+    listings) call this once per request and join in memory rather than
+    re-decoding the store per goal. *)
+
+val get_record :
+  Workspace_utils.config ->
+  goal_id:string ->
+  (record option, string) result
+(** Single-row read: [Ok None] only when the store decoded and holds no row
+    for [goal_id]. *)
+
+val ledger_error_to_yojson : string -> Yojson.Safe.t
+(** The explicit "ledger could not be read" marker consumers render in place
+    of a verification record: [{"state": "ledger_error", "detail": …}]. *)
+
+(** {1 Mutations}
+
+    All are locked read-modify-writes that refuse an undecodable store.
+    Stage 1 wires no caller; these are the surface the stage-2 verifier gate
+    commits through. *)
+
+val record_criterion_verdict :
+  Workspace_utils.config ->
+  goal_id:string ->
+  verdict ->
+  (record, string) result
+(** Commits the verifier's creation-time feasibility judgment (B2). [Proven]
+    lands as [Criterion_viable], [Refuted] as [Criterion_unreachable]. *)
+
+val record_proof_verdict :
+  Workspace_utils.config ->
+  goal_id:string ->
+  verdict ->
+  (record, string) result
+(** Commits the verifier's completion proof (B3). Requires [Proof_pending] —
+    the durable request the stage-2 gate persists before entering its
+    verifying phase — or the same outcome already committed (the
+    crash-between-writes retry); anything else is an [Error], not a silent
+    overwrite. *)
+
+val record_human_confirmation :
+  Workspace_utils.config ->
+  goal_id:string ->
+  confirmed_by:string ->
+  (record, string) result
+(** Commits the human's final confirmation (B3). Requires [Proof_proven]; the
+    proof is carried into [Human_confirmed] so the completed goal retains the
+    whole chain. *)

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1527,8 +1527,10 @@ let agent_timeline_output_schema =
 ;;
 
 (* Producer: Workspace_goals.handle_goal_list over Goal_store.goal_to_yojson
-   and rollup_to_yojson. Option-carrying goal fields serialize as
-   string-or-null and stay undeclared. *)
+   and rollup_to_yojson, with the RFC-0387 verification ledger
+   (Goal_verification.record_to_yojson) joined per goal as [verification].
+   Option-carrying goal fields serialize as string-or-null and stay
+   undeclared; [verification] rides the items' additionalProperties:true. *)
 let goal_list_output_schema =
   object_output_schema
     ~properties:

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -559,6 +559,33 @@ let dashboard_schedule_prune_http_json
 let dashboard_planning_http_json ~(config : Workspace.config) : Yojson.Safe.t =
   let goals = Goal_store.list_goals config () in
   let rollup = Goal_store.compute_rollup goals in
+  (* RFC-0387 (stage 1): the verification ledger joins each goal at the API
+     boundary (goal_to_yojson is the persistence codec and stays untouched).
+     The ledger is loaded ONCE per request and joined in memory; a store that
+     does not decode renders the explicit [ledger_error] marker per goal —
+     never the pre-verification default, which would disguise corruption as
+     "not verified yet". *)
+  let records = Goal_verification.load_records config in
+  let goal_json (goal : Goal_store.goal) =
+    let verification =
+      match records with
+      | Error detail -> Goal_verification.ledger_error_to_yojson detail
+      | Ok records ->
+        (match
+           List.find_opt
+             (fun (record : Goal_verification.record) ->
+               String.equal record.goal_id goal.id)
+             records
+         with
+         | Some record -> record
+         | None -> Goal_verification.default_record ~goal_id:goal.id)
+        |> Goal_verification.record_to_yojson
+    in
+    match Goal_store.goal_to_yojson goal with
+    | `Assoc fields ->
+      `Assoc (fields @ [ "verification", verification ])
+    | json -> json
+  in
   let task_rollup =
     dashboard_tasks_safe config
     |> List.fold_left
@@ -577,7 +604,7 @@ let dashboard_planning_http_json ~(config : Workspace.config) : Yojson.Safe.t =
   in
   `Assoc
     [ "generated_at", `String (Masc_domain.now_iso ())
-    ; "goals", `List (List.map Goal_store.goal_to_yojson goals)
+    ; "goals", `List (List.map goal_json goals)
     ; "rollup", Goal_store.rollup_to_yojson rollup
     ; ( "task_backlog"
       , `Assoc

--- a/lib/tool_schemas/tool_schemas_workspace_extra.ml
+++ b/lib/tool_schemas/tool_schemas_workspace_extra.ml
@@ -38,7 +38,9 @@ let schemas : tool_schema list =
     }
   ; { name = "masc_goal_upsert"
     ; description =
-        "Create or update Goal metadata and parent linkage. Use masc_goal_transition for lifecycle changes."
+        "Create or update Goal metadata and parent linkage. Creation requires a \
+         measurable success condition: metric and target_value (RFC-0387 B1). Use \
+         masc_goal_transition for lifecycle changes."
     ; input_schema =
         `Assoc
           [ "type", `String "object"
@@ -46,14 +48,35 @@ let schemas : tool_schema list =
             , `Assoc
                 [ "id", `Assoc [ "type", `String "string" ]
                 ; "title", `Assoc [ "type", `String "string" ]
-                ; "metric", `Assoc [ "type", `String "string" ]
-                ; "target_value", `Assoc [ "type", `String "string" ]
+                ; ( "metric"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "description"
+                        , `String
+                            "Required (non-blank) when the upsert creates a new \
+                             goal (RFC-0387 B1); optional on update." )
+                      ] )
+                ; ( "target_value"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "description"
+                        , `String
+                            "Required (non-blank) when the upsert creates a new \
+                             goal (RFC-0387 B1); optional on update." )
+                      ] )
                 ; "due_date", `Assoc [ "type", `String "string" ]
                 ; "priority", `Assoc [ "type", `String "integer" ]
                 ; "parent_goal_id", `Assoc [ "type", `String "string" ]
                 ] )
           ; "additionalProperties", `Bool false
           ]
+      (* B1 is NOT expressed in a schema-level [required] array on purpose:
+         this one tool serves both create and update, and JSON Schema
+         [required] is unconditional — listing metric/target_value there would
+         reject every metadata update of an existing goal. The create/update
+         split is only decidable against the store, so the handler enforces
+         the requirement on the creation branch (Goal_store.upsert_goal,
+         inside the write lock). *)
     }
   ; { name = "masc_goal_assign"
     ; description =

--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -199,12 +199,38 @@ let handle_goal_list ~tool_name ~start_time (ctx : context) args : Tool_result.r
   | Ok (), Ok phase ->
     let goals = Goal_store.list_goals ctx.config ?phase () in
     let rollup = Goal_store.compute_rollup goals in
+    (* RFC-0387 (stage 1): the verification ledger joins each goal here (not
+       in [Goal_store.goal_to_yojson], which is the persistence codec). The
+       ledger is loaded ONCE per request and joined in memory; a store that
+       does not decode renders the explicit [ledger_error] marker per goal —
+       never the pre-verification default, which would disguise corruption as
+       "not verified yet". *)
+    let records = Goal_verification.load_records ctx.config in
+    let goal_json (goal : Goal_store.goal) =
+      let verification =
+        match records with
+        | Error detail -> Goal_verification.ledger_error_to_yojson detail
+        | Ok records ->
+          (match
+             List.find_opt
+               (fun (record : Goal_verification.record) ->
+                 String.equal record.goal_id goal.id)
+               records
+           with
+           | Some record -> record
+           | None -> Goal_verification.default_record ~goal_id:goal.id)
+          |> Goal_verification.record_to_yojson
+      in
+      match Goal_store.goal_to_yojson goal with
+      | `Assoc fields -> `Assoc (fields @ [ "verification", verification ])
+      | json -> json
+    in
     ok_result
       ~tool_name
       ~start_time
       [ "generated_at", `String (Masc_domain.now_iso ())
       ; "count", `Int (List.length goals)
-      ; "goals", `List (List.map Goal_store.goal_to_yojson goals)
+      ; "goals", `List (List.map goal_json goals)
       ; "rollup", Goal_store.rollup_to_yojson rollup
       ]
 ;;

--- a/scripts/audit-dead-surface.py
+++ b/scripts/audit-dead-surface.py
@@ -557,7 +557,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 # 545 -> 541: tightened to the measured count. The four counts of slack
 # predate the Keeper_compact_audit purge (main already measured 541 against
 # the stale 545 baseline); the purge itself did not change the count.
-DEAD_EXPORT_BASELINE = 540
+# 540 -> 539: tightened to the measured count on the RFC-0387 stage-1 tree
+# (measured 2026-08-20: 539). The one count of slack predates this change;
+# goal_verification's exports all have callers (dashboard joins + tests), so
+# the ledger added none.
+DEAD_EXPORT_BASELINE = 539
 
 
 def run_ratchet(count: int) -> int:

--- a/scripts/harness/contract/golden_path_1_contract.sh
+++ b/scripts/harness/contract/golden_path_1_contract.sh
@@ -49,7 +49,7 @@ ensure_contract_goal() {
   local goal_payload
   local goal_json
 
-  goal_payload="$(call_tool 1000 "masc_goal_upsert" '{"title":"GP1 contract goal","priority":1}')"
+  goal_payload="$(call_tool 1000 "masc_goal_upsert" '{"title":"GP1 contract goal","metric":"contract steps pass","target_value":"all steps","priority":1}')"
   goal_json="$(printf '%s' "$goal_payload" | extract_result)"
   GOAL_ID="$(printf '%s' "$goal_json" | jq -r '.goal_id // empty')"
   if [ -z "$GOAL_ID" ]; then

--- a/scripts/harness/contract/public_tool_live_sweep.sh
+++ b/scripts/harness/contract/public_tool_live_sweep.sh
@@ -159,7 +159,7 @@ r_goal_list="$(call_tool 5008 "masc_goal_list" '{}')"
 expect_ok "masc_goal_list" "$r_goal_list"
 
 next_step "masc_goal_upsert"
-GOAL_SEED_PAYLOAD="$(call_tool 5009 "masc_goal_upsert" '{"title":"Public Tool Sweep Goal","priority":1}')"
+GOAL_SEED_PAYLOAD="$(call_tool 5009 "masc_goal_upsert" '{"title":"Public Tool Sweep Goal","metric":"sweep steps pass","target_value":"all steps","priority":1}')"
 GOAL_ID="$(printf '%s' "$GOAL_SEED_PAYLOAD" | extract_result | jq -r '.goal_id // empty')"
 if [ -z "$GOAL_ID" ]; then
   mcp_fail_with_context "could not create goal for public tool live sweep" "$GOAL_SEED_PAYLOAD"

--- a/test/dune
+++ b/test/dune
@@ -1818,6 +1818,8 @@
 
 (include stanzas/test_goal_phase_all.inc)
 
+(include stanzas/test_goal_verification_gate.inc)
+
 
 
 

--- a/test/stanzas/test_goal_verification_gate.inc
+++ b/test/stanzas/test_goal_verification_gate.inc
@@ -1,0 +1,9 @@
+; Per-file dune stanza for the RFC-0387 stage-1 surface: the B1 creation
+; requirement and the record-only verification ledger (+ its observability
+; join). Lives here per test/stanzas/README.md to avoid the conflict-runtime
+; hotspot in the legacy grouped (tests ...) stanza.
+
+(test
+ (name test_goal_verification_gate)
+ (modules test_goal_verification_gate)
+ (libraries masc_test_deps))

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -1783,7 +1783,7 @@ let test_dashboard_planning_http_json_keeps_utf8_valid_after_truncation () =
   ignore (Lib.Workspace.init config ~agent_name:(Some "dashboard"));
   let hangul_ga = "\234\176\128" in
   let title = String.concat "" (List.init 40 (fun _ -> hangul_ga)) in
-  (match Goal_store.upsert_goal config ~title () with
+  (match Goal_store.upsert_goal config ~title ~metric:"m" ~target_value:"1" () with
    | Ok _ -> ()
    | Error msg -> fail msg);
   let json = Server_dashboard_http.dashboard_planning_http_json ~config in

--- a/test/test_goal_scope_terminal_phase.ml
+++ b/test/test_goal_scope_terminal_phase.ml
@@ -51,7 +51,8 @@ let make_meta active_goal_ids =
 ;;
 
 let put_goal config ~id ~phase =
-  match Goal_store.upsert_goal config ~id ~title:("Goal " ^ id) ~phase () with
+  match Goal_store.upsert_goal config ~id ~title:("Goal " ^ id)
+          ~metric:"m" ~target_value:"1" ~phase () with
   | Ok _ -> ()
   | Error msg -> failf "upsert_goal %s failed: %s" id msg
 ;;

--- a/test/test_goal_store.ml
+++ b/test/test_goal_store.ml
@@ -203,7 +203,8 @@ let test_status_field_no_longer_decodes () =
      the next upsert would overwrite goals.json AND its .last-good mirror with the
      empty state, turning one undecodable row into permanent loss. *)
   (match
-     Goal_store.upsert_goal config ~title:"phase only" ~phase:Goal_phase.Paused ()
+     Goal_store.upsert_goal config ~title:"phase only" ~metric:"m"
+       ~target_value:"1" ~phase:Goal_phase.Paused ()
    with
    | Ok _ -> fail "upsert_goal wrote over an undecodable store"
    | Error msg ->
@@ -220,7 +221,8 @@ let test_status_field_no_longer_decodes () =
 let test_serializer_omits_status () =
   with_workspace @@ fun config ->
   match
-    Goal_store.upsert_goal config ~title:"phase only" ~phase:Goal_phase.Paused ()
+    Goal_store.upsert_goal config ~title:"phase only" ~metric:"m"
+      ~target_value:"1" ~phase:Goal_phase.Paused ()
   with
   | Error msg -> fail msg
   | Ok (goal, _) -> (
@@ -268,7 +270,7 @@ let test_blocked_phase_serializes_without_status () =
   with_workspace @@ fun config ->
   let goal, _kind =
     match Goal_store.upsert_goal config ~title:"Blocked goal"
-            ~phase:Goal_phase.Blocked ()
+            ~metric:"m" ~target_value:"1" ~phase:Goal_phase.Blocked ()
     with
     | Ok payload -> payload
     | Error msg -> fail msg
@@ -282,7 +284,8 @@ let test_blocked_phase_serializes_without_status () =
 let test_list_goals_filters_by_phase () =
   with_workspace @@ fun config ->
   let make title phase =
-    match Goal_store.upsert_goal config ~title ~phase () with
+    match Goal_store.upsert_goal config ~title ~metric:"m" ~target_value:"1"
+            ~phase () with
     | Ok _ -> ()
     | Error msg -> fail msg
   in

--- a/test/test_goal_task_assignment.ml
+++ b/test/test_goal_task_assignment.ml
@@ -40,7 +40,8 @@ let with_test_env f =
 ;;
 
 let make_goal config ~id =
-  match Goal_store.upsert_goal config ~id ~title:("Goal " ^ id) () with
+  match Goal_store.upsert_goal config ~id ~title:("Goal " ^ id)
+          ~metric:"m" ~target_value:"1" () with
   | Ok _ -> ()
   | Error msg -> failf "upsert_goal %s failed: %s" id msg
 ;;

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -77,6 +77,8 @@ let test_goal_upsert_and_list () =
       ~args:
         (`Assoc
             [ "title", `String "Ship Goal Surface"
+            ; "metric", `String "deploys shipped"
+            ; "target_value", `String "1"
             ; "priority", `Int 2
             ])
   in
@@ -134,7 +136,8 @@ let test_goal_list_filters_by_phase () =
       | Some phase -> phase
       | None -> fail ("invalid phase fixture: " ^ phase)
     in
-    match Goal_store.upsert_goal config ~title ~phase () with
+    match Goal_store.upsert_goal config ~title ~metric:"m" ~target_value:"1"
+            ~phase () with
     | Ok _ -> ()
     | Error msg -> fail msg
   in
@@ -162,7 +165,8 @@ let test_goal_list_filters_by_phase () =
 let test_goal_list_includes_rollup () =
   with_workspace
   @@ fun config ->
-  (match Goal_store.upsert_goal config ~title:"Executing goal" () with
+  (match Goal_store.upsert_goal config ~title:"Executing goal" ~metric:"m"
+           ~target_value:"1" () with
    | Ok _ -> ()
    | Error msg -> fail msg);
   let listed =
@@ -183,7 +187,8 @@ let test_goal_list_includes_rollup () =
 let test_goal_list_ignores_blank_optional_filters () =
   with_workspace
   @@ fun config ->
-  (match Goal_store.upsert_goal config ~title:"Blank filter goal" () with
+  (match Goal_store.upsert_goal config ~title:"Blank filter goal" ~metric:"m"
+           ~target_value:"1" () with
    | Ok _ -> ()
    | Error msg -> fail msg);
   let listed =
@@ -254,7 +259,8 @@ let test_goal_upsert_rejects_lifecycle_fields () =
     true
     (String_util.contains_substring (Yojson.Safe.to_string phase_error) "masc_goal_transition");
   let goal, _kind =
-    match Goal_store.upsert_goal config ~title:"Existing goal" () with
+    match Goal_store.upsert_goal config ~title:"Existing goal" ~metric:"m"
+            ~target_value:"1" () with
     | Ok payload -> payload
     | Error msg -> fail msg
   in
@@ -318,7 +324,10 @@ let test_goal_completion_accepts_goal_without_tasks () =
   with_workspace
   @@ fun config ->
   let goal, _ =
-    match Goal_store.upsert_goal config ~title:"Direct completion" () with
+    match
+      Goal_store.upsert_goal config ~title:"Direct completion" ~metric:"m"
+        ~target_value:"1" ()
+    with
     | Ok payload -> payload
     | Error msg -> fail msg
   in
@@ -330,7 +339,10 @@ let test_goal_completion_ignores_open_task_count () =
   with_workspace
   @@ fun config ->
   let goal, _ =
-    match Goal_store.upsert_goal config ~title:"Open task completion" () with
+    match
+      Goal_store.upsert_goal config ~title:"Open task completion" ~metric:"m"
+        ~target_value:"1" ()
+    with
     | Ok payload -> payload
     | Error msg -> fail msg
   in
@@ -367,7 +379,8 @@ let test_goal_block_and_unblock_have_no_operator_hierarchy () =
   with_workspace
   @@ fun config ->
   let goal, _ =
-    match Goal_store.upsert_goal config ~title:"Explicitly blocked Goal" () with
+    match Goal_store.upsert_goal config ~title:"Explicitly blocked Goal"
+            ~metric:"m" ~target_value:"1" () with
     | Ok payload -> payload
     | Error msg -> fail msg
   in

--- a/test/test_goal_upsert_fsm_bypass_10247.ml
+++ b/test/test_goal_upsert_fsm_bypass_10247.ml
@@ -97,7 +97,14 @@ let string_field json field =
 ;;
 
 let create_goal_id config ~title =
-  let body = dispatch_upsert_must_succeed (workspace_ctx config) [ "title", `String title ] in
+  let body =
+    dispatch_upsert_must_succeed
+      (workspace_ctx config)
+      [ "title", `String title
+      ; "metric", `String "m"
+      ; "target_value", `String "1"
+      ]
+  in
   string_field body "goal_id"
 ;;
 
@@ -178,7 +185,11 @@ let test_no_lifecycle_field_still_round_trips () =
   let body =
     dispatch_upsert_must_succeed
       (workspace_ctx config)
-      [ "title", `String "Default goal"; "priority", `Int 2 ]
+      [ "title", `String "Default goal"
+      ; "metric", `String "m"
+      ; "target_value", `String "1"
+      ; "priority", `Int 2
+      ]
   in
   check
     bool

--- a/test/test_goal_verification_gate.ml
+++ b/test/test_goal_verification_gate.ml
@@ -1,0 +1,517 @@
+(** RFC-0387 stage 1 — B1 creation requirement + verification ledger
+    (record-only evidence store) + its observability join.
+
+    B1: creation without a declared success condition ([metric] +
+    [target_value]) is a typed rejection; updates of an existing row are not
+    gated.
+
+    Ledger: verdict commits round-trip through the file store, the decoders
+    are strict (unknown fields / unknown variants are decode errors), a store
+    that does not decode refuses every mutation AND fails every read loudly —
+    never a silent "not verified yet".
+
+    Stage 1 has no lifecycle gate: [request_complete] still completes a Goal
+    directly, and no caller writes the ledger. The gate phases/actions and
+    the verifier caller are stage 2 (RFC-0387 §Staging). *)
+
+open Alcotest
+open Masc
+open Workspace_types
+
+let temp_dir () =
+  let path = Filename.temp_file "goal_verification_gate_" "" in
+  Sys.remove path;
+  Unix.mkdir path 0o755;
+  path
+;;
+
+let rm_rf dir =
+  let rec rm path =
+    if Sys.file_exists path
+    then
+      if Sys.is_directory path
+      then (
+        Sys.readdir path |> Array.iter (fun entry -> rm (Filename.concat path entry));
+        Unix.rmdir path)
+      else Sys.remove path
+  in
+  try rm dir with
+  | _ -> ()
+;;
+
+let with_workspace f =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+       let config = Workspace.default_config dir in
+       ignore (Workspace.init config ~agent_name:(Some "planner"));
+       f config)
+;;
+
+let workspace_ctx ?(agent_name = "planner") config : Tool_workspace.context =
+  { Tool_workspace.config; agent_name }
+;;
+
+let dispatch ctx ~name args =
+  match Tool_workspace.dispatch ctx ~name ~args:(`Assoc args) with
+  | Some result -> result
+  | None -> fail (name ^ " not handled")
+;;
+
+let body_of result = Yojson.Safe.from_string (Tool_result.message result)
+
+let must_succeed label result =
+  if Tool_result.is_success result
+  then body_of result
+  else fail (Printf.sprintf "%s: expected success, got %s" label
+               (Tool_result.message result))
+;;
+
+let must_fail label result =
+  if Tool_result.is_success result
+  then fail (Printf.sprintf "%s: expected rejection, got success" label)
+  else body_of result
+;;
+
+let json_state json path =
+  List.fold_left
+    (fun acc key -> Yojson.Safe.Util.member key acc)
+    json path
+  |> Yojson.Safe.Util.to_string
+;;
+
+let verdict ?(evidence = "observed by the verifier") outcome : Goal_verification.verdict =
+  { Goal_verification.outcome
+  ; authority = Masc_domain.System_llm_agent { agent_run_id = "test-verifier" }
+  ; evidence
+  ; recorded_at = Masc_domain.now_iso ()
+  }
+;;
+
+(* Poison the authoritative store AND its recovery mirror; the fail-closed
+   rule mirrors Goal_store: no mutation may proceed on a store that did not
+   decode. (Poisoning the primary alone recovers from the mirror — that is
+   what the mirror is for.) *)
+let poison_ledger config =
+  let poison path =
+    Out_channel.with_open_bin path (fun oc ->
+      Out_channel.output_string oc "not json")
+  in
+  let primary = Goal_verification.verifications_path config in
+  poison primary;
+  poison (primary ^ ".last-good")
+;;
+
+(* B1 *)
+
+let test_create_requires_a_success_condition () =
+  with_workspace
+  @@ fun config ->
+  let ctx = workspace_ctx config in
+  let rejected =
+    must_fail
+      "create without metric"
+      (dispatch ctx ~name:"masc_goal_upsert" [ "title", `String "No condition" ])
+  in
+  check string "typed validation error" "validation_error"
+    (json_state rejected [ "error_code" ]);
+  check bool "the message names the missing condition" true
+    (String_util.contains_substring
+       (Yojson.Safe.to_string rejected)
+       "metric and target_value");
+  (* A blank value rejects exactly like an absent one. *)
+  let blank =
+    must_fail
+      "create with blank target_value"
+      (dispatch
+         ctx
+         ~name:"masc_goal_upsert"
+         [ "title", `String "Blank condition"
+         ; "metric", `String "verified services"
+         ; "target_value", `String "   "
+         ])
+  in
+  check string "typed validation error" "validation_error"
+    (json_state blank [ "error_code" ])
+;;
+
+let test_create_with_a_success_condition_succeeds () =
+  with_workspace
+  @@ fun config ->
+  let ctx = workspace_ctx config in
+  let body =
+    must_succeed
+      "create with a success condition"
+      (dispatch
+         ctx
+         ~name:"masc_goal_upsert"
+         [ "title", `String "Verifiable goal"
+         ; "metric", `String "verified services"
+         ; "target_value", `String "3"
+         ])
+  in
+  check string "created" "created" (json_state body [ "action" ])
+;;
+
+let test_update_is_not_gated_by_b1 () =
+  with_workspace
+  @@ fun config ->
+  let goal, _ =
+    match
+      Goal_store.upsert_goal
+        config
+        ~title:"Created with a condition"
+        ~metric:"m"
+        ~target_value:"1"
+        ()
+    with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  (* B1 gates creation only: updating an existing row without re-stating the
+     success condition is metadata maintenance, not a new declaration. *)
+  match
+    Goal_store.upsert_goal config ~id:goal.id ~title:"Renamed" ()
+  with
+  | Ok (_, `updated) -> ()
+  | Ok (_, `created) -> fail "an existing id must update, not create"
+  | Error msg -> fail ("ungated update rejected: " ^ msg)
+;;
+
+let test_undecodable_goal_store_reports_corruption_not_b1 () =
+  with_workspace
+  @@ fun config ->
+  (* Poison the GOAL store: the create/update split is decided inside the
+     write lock on the decoded state, so a corrupt store must surface the
+     fail-closed persistence error — not "metric and target_value are
+     required", which would misreport corruption as a caller mistake. *)
+  let goals_path = Goal_store.goals_path config in
+  let poison path =
+    Out_channel.with_open_bin path (fun oc ->
+      Out_channel.output_string oc "not json")
+  in
+  poison goals_path;
+  poison (goals_path ^ ".last-good");
+  match Goal_store.upsert_goal config ~title:"x" ~metric:"m" ~target_value:"1" () with
+  | Ok _ -> fail "upsert_goal wrote over an undecodable store"
+  | Error msg ->
+    check bool "fail-closed persistence error, not the B1 message" true
+      (String_util.contains_substring msg "did not decode");
+    check bool "must not read as the B1 rejection" false
+      (String_util.contains_substring msg "metric and target_value")
+;;
+
+(* Ledger: record/read round-trip *)
+
+let test_criterion_verdict_round_trips () =
+  with_workspace
+  @@ fun config ->
+  let committed =
+    match
+      Goal_verification.record_criterion_verdict
+        config
+        ~goal_id:"goal-roundtrip"
+        (verdict Goal_verification.Proven)
+    with
+    | Ok record -> record
+    | Error msg -> fail msg
+  in
+  (match committed.criterion with
+   | Goal_verification.Criterion_viable _ -> ()
+   | _ -> fail "proven verdict must land as Criterion_viable");
+  (* A fresh read of the ledger agrees — the commit is durable. *)
+  (match Goal_verification.get_record config ~goal_id:"goal-roundtrip" with
+   | Ok (Some { criterion = Goal_verification.Criterion_viable _; _ }) -> ()
+   | Ok (Some _) -> fail "round-trip changed the criterion state"
+   | Ok None -> fail "committed record did not survive a fresh read"
+   | Error msg -> fail msg);
+  match Goal_verification.load_records config with
+  | Error msg -> fail msg
+  | Ok records ->
+    check int "one row in the ledger" 1 (List.length records)
+;;
+
+let test_refuted_criterion_keeps_its_reason () =
+  with_workspace
+  @@ fun config ->
+  match
+    Goal_verification.record_criterion_verdict
+      config
+      ~goal_id:"goal-refuted"
+      (verdict (Goal_verification.Refuted { reason = "no such API exists" }))
+  with
+  | Error msg -> fail msg
+  | Ok _ ->
+    (match Goal_verification.get_record config ~goal_id:"goal-refuted" with
+     | Ok
+         (Some
+           { criterion =
+               Goal_verification.Criterion_unreachable
+                 { outcome = Goal_verification.Refuted { reason }; _ }
+           ; _
+           }) ->
+       check string "the refutation reason is preserved" "no such API exists" reason
+     | Ok (Some _) -> fail "refuted verdict must land as Criterion_unreachable"
+     | Ok None -> fail "committed record did not survive a fresh read"
+     | Error msg -> fail msg)
+;;
+
+(* Ledger: record-only discipline (stage 1 pins the preconditions the stage-2
+   gate relies on) *)
+
+let test_proof_verdict_requires_a_pending_request () =
+  with_workspace
+  @@ fun config ->
+  match
+    Goal_verification.record_proof_verdict
+      config
+      ~goal_id:"goal-no-request"
+      (verdict Goal_verification.Proven)
+  with
+  | Ok _ -> fail "proof verdict committed without a pending request"
+  | Error msg ->
+    check bool "the refusal names the missing request" true
+      (String_util.contains_substring msg "no pending proof request")
+;;
+
+let test_human_confirmation_requires_a_proven_proof () =
+  with_workspace
+  @@ fun config ->
+  match
+    Goal_verification.record_human_confirmation
+      config
+      ~goal_id:"goal-unproven"
+      ~confirmed_by:"operator-test"
+  with
+  | Ok _ -> fail "human confirmation committed without a proven proof"
+  | Error msg ->
+    check bool "the refusal names the missing proof" true
+      (String_util.contains_substring msg "needs a proven proof")
+;;
+
+(* Ledger: strict decode, fail-closed mutations, fail-loud reads *)
+
+let test_undecodable_ledger_fails_closed_and_loud () =
+  with_workspace
+  @@ fun config ->
+  ignore
+    (match
+       Goal_verification.record_criterion_verdict
+         config
+         ~goal_id:"goal-corrupt"
+         (verdict Goal_verification.Proven)
+     with
+     | Ok _ -> ()
+     | Error msg -> fail msg);
+  poison_ledger config;
+  (* Mutations refuse. *)
+  (match
+     Goal_verification.record_criterion_verdict
+       config
+       ~goal_id:"goal-corrupt"
+       (verdict Goal_verification.Proven)
+   with
+   | Ok _ -> fail "mutation proceeded on an undecodable ledger"
+   | Error _ -> ());
+  (* Reads fail LOUD: an undecodable ledger is an Error, never [None] — a
+     corrupt store must not render as "not verified yet". *)
+  (match Goal_verification.get_record config ~goal_id:"goal-corrupt" with
+   | Ok _ -> fail "lenient read disguised a corrupt ledger as absence"
+   | Error msg ->
+     check bool "the decode failure is named" true
+       (String_util.contains_substring msg "did not decode"));
+  match Goal_verification.load_records config with
+  | Ok _ -> fail "bulk read disguised a corrupt ledger"
+  | Error msg ->
+    check bool "the decode failure is named" true
+      (String_util.contains_substring msg "did not decode")
+;;
+
+let test_unknown_ledger_field_is_a_decode_error () =
+  with_workspace
+  @@ fun config ->
+  ignore
+    (match
+       Goal_verification.record_criterion_verdict
+         config
+         ~goal_id:"goal-strict"
+         (verdict Goal_verification.Proven)
+     with
+     | Ok _ -> ()
+     | Error msg -> fail msg);
+  (* Hand-edit the committed store: add an unknown field to the one row. *)
+  let path = Goal_verification.verifications_path config in
+  let json = Yojson.Safe.from_file path in
+  let poisoned =
+    match json with
+    | `Assoc fields ->
+      `Assoc
+        (List.map
+           (fun (key, value) ->
+             match key, value with
+             | "records", `List [ `Assoc row ] ->
+               ( "records"
+               , `List [ `Assoc (("surprise_field", `Bool true) :: row) ] )
+             | _ -> key, value)
+           fields)
+    | _ -> fail "unexpected ledger shape"
+  in
+  Yojson.Safe.to_file path poisoned;
+  Yojson.Safe.to_file (path ^ ".last-good") poisoned;
+  match Goal_verification.get_record config ~goal_id:"goal-strict" with
+  | Ok _ -> fail "an unknown field decoded silently"
+  | Error msg ->
+    check bool "the unknown field is named" true
+      (String_util.contains_substring msg "surprise_field")
+;;
+
+(* Observability: the read surfaces join the ledger *)
+
+let test_goal_list_joins_the_ledger () =
+  with_workspace
+  @@ fun config ->
+  let ctx = workspace_ctx config in
+  let created =
+    must_succeed
+      "create goal"
+      (dispatch
+         ctx
+         ~name:"masc_goal_upsert"
+         [ "title", `String "Observable goal"
+         ; "metric", `String "verified services"
+         ; "target_value", `String "3"
+         ])
+  in
+  let goal_id = json_state created [ "goal_id" ] in
+  let listed = must_succeed "goal list" (dispatch ctx ~name:"masc_goal_list" []) in
+  let goals = Yojson.Safe.Util.member "goals" listed |> Yojson.Safe.Util.to_list in
+  (match goals with
+   | [ goal_json ] ->
+     (* No writer has run: the explicit pre-verification default renders. *)
+     check string "criterion renders unchecked" "unchecked"
+       (json_state goal_json [ "verification"; "criterion"; "state" ]);
+     check string "completion renders idle" "idle"
+       (json_state goal_json [ "verification"; "completion"; "state" ])
+   | _ -> fail "expected one listed goal");
+  (* A committed verdict shows up in the same join. *)
+  ignore
+    (match
+       Goal_verification.record_criterion_verdict
+         config
+         ~goal_id
+         (verdict Goal_verification.Proven)
+     with
+     | Ok _ -> ()
+     | Error msg -> fail msg);
+  let listed = must_succeed "goal list" (dispatch ctx ~name:"masc_goal_list" []) in
+  let goals = Yojson.Safe.Util.member "goals" listed |> Yojson.Safe.Util.to_list in
+  match goals with
+  | [ goal_json ] ->
+    check string "the verdict is observable" "viable"
+      (json_state goal_json [ "verification"; "criterion"; "state" ])
+  | _ -> fail "expected one listed goal"
+;;
+
+let test_goal_list_renders_a_ledger_error_state () =
+  with_workspace
+  @@ fun config ->
+  let ctx = workspace_ctx config in
+  ignore
+    (must_succeed
+       "create goal"
+       (dispatch
+          ctx
+          ~name:"masc_goal_upsert"
+          [ "title", `String "Goal beside a corrupt ledger"
+          ; "metric", `String "m"
+          ; "target_value", `String "1"
+          ]));
+  poison_ledger config;
+  let listed = must_succeed "goal list" (dispatch ctx ~name:"masc_goal_list" []) in
+  let goals = Yojson.Safe.Util.member "goals" listed |> Yojson.Safe.Util.to_list in
+  match goals with
+  | [ goal_json ] ->
+    check string "corruption renders as ledger_error, not as the default"
+      "ledger_error"
+      (json_state goal_json [ "verification"; "state" ])
+  | _ -> fail "expected one listed goal"
+;;
+
+(* Stage 1 changes no lifecycle semantics: request_complete still completes. *)
+
+let test_request_complete_still_completes_directly () =
+  with_workspace
+  @@ fun config ->
+  let ctx = workspace_ctx config in
+  let created =
+    must_succeed
+      "create goal"
+      (dispatch
+         ctx
+         ~name:"masc_goal_upsert"
+         [ "title", `String "Ungated completion"
+         ; "metric", `String "m"
+         ; "target_value", `String "1"
+         ])
+  in
+  let goal_id = json_state created [ "goal_id" ] in
+  let completed =
+    must_succeed
+      "request_complete"
+      (dispatch
+         ctx
+         ~name:"masc_goal_transition"
+         [ "goal_id", `String goal_id; "action", `String "request_complete" ])
+  in
+  check string "completed directly (stage 1 keeps main's lifecycle)"
+    "completed"
+    (json_state completed [ "goal"; "phase" ])
+;;
+
+let () =
+  run
+    "goal_verification_gate"
+    [ ( "b1 creation requirement"
+      , [ test_case "creation requires a success condition" `Quick
+            test_create_requires_a_success_condition
+        ; test_case "creation with a success condition succeeds" `Quick
+            test_create_with_a_success_condition_succeeds
+        ; test_case "update is not gated by B1" `Quick
+            test_update_is_not_gated_by_b1
+        ; test_case "undecodable goal store reports corruption, not B1" `Quick
+            test_undecodable_goal_store_reports_corruption_not_b1
+        ] )
+    ; ( "ledger round-trip"
+      , [ test_case "criterion verdict round-trips" `Quick
+            test_criterion_verdict_round_trips
+        ; test_case "refuted criterion keeps its reason" `Quick
+            test_refuted_criterion_keeps_its_reason
+        ] )
+    ; ( "ledger record-only discipline"
+      , [ test_case "proof verdict requires a pending request" `Quick
+            test_proof_verdict_requires_a_pending_request
+        ; test_case "human confirmation requires a proven proof" `Quick
+            test_human_confirmation_requires_a_proven_proof
+        ] )
+    ; ( "store discipline"
+      , [ test_case "undecodable ledger fails closed and loud" `Quick
+            test_undecodable_ledger_fails_closed_and_loud
+        ; test_case "unknown ledger field is a decode error" `Quick
+            test_unknown_ledger_field_is_a_decode_error
+        ] )
+    ; ( "observability"
+      , [ test_case "goal list joins the ledger" `Quick
+            test_goal_list_joins_the_ledger
+        ; test_case "goal list renders a ledger-error state" `Quick
+            test_goal_list_renders_a_ledger_error_state
+        ] )
+    ; ( "lifecycle unchanged"
+      , [ test_case "request_complete still completes directly" `Quick
+            test_request_complete_still_completes_directly
+        ] )
+    ]
+;;

--- a/test/test_keeper_registry_hardening.ml
+++ b/test/test_keeper_registry_hardening.ml
@@ -660,6 +660,8 @@ let test_goal_reconciliation_enqueues_once_after_last_terminal_task () =
              config
              ~id:"goal-reconciliation-test"
              ~title:"Reconcile after terminal tasks"
+             ~metric:"m"
+             ~target_value:"1"
              ()
          with
          | Ok result -> result
@@ -764,6 +766,8 @@ let test_goal_reconciliation_prefers_authoritative_assignment
              config
              ~id:"goal-reconciliation-assignment"
              ~title:"Use the assigned Keeper"
+             ~metric:"m"
+             ~target_value:"1"
              ()
          with
          | Ok result -> result
@@ -909,6 +913,8 @@ let test_goal_reconciliation_restart_scan_retries_missed_delivery () =
              config
              ~id:"goal-reconciliation-restart"
              ~title:"Recover a missed terminal hook"
+             ~metric:"m"
+             ~target_value:"1"
              ()
          with
          | Ok result -> result
@@ -995,7 +1001,8 @@ let test_goal_reconciliation_restart_scan_retries_missed_delivery () =
 
 let add_and_cancel_goal_task ~config ~goal_id ~title ~agent_name =
   let goal, _ =
-    match Goal_store.upsert_goal config ~id:goal_id ~title () with
+    match Goal_store.upsert_goal config ~id:goal_id ~title ~metric:"m"
+            ~target_value:"1" () with
     | Ok result -> result
     | Error detail -> fail detail
   in

--- a/test/test_keeper_task_create_typed_failure.ml
+++ b/test/test_keeper_task_create_typed_failure.ml
@@ -59,7 +59,8 @@ let meta_with_active_goals goal_ids =
 
 let test_task_create_goal_link_write_failure_returns_typed_failure () =
   with_test_env (fun config ->
-    (match Goal_store.upsert_goal config ~id:"goal-a" ~title:"Goal A" () with
+    (match Goal_store.upsert_goal config ~id:"goal-a" ~title:"Goal A"
+             ~metric:"m" ~target_value:"1" () with
      | Ok _ -> ()
      | Error msg -> fail ("upsert_goal failed: " ^ msg));
     make_path_unwritable (Workspace_goal_index.goal_task_links_path config);

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -388,7 +388,7 @@ let ensure_goal fixture =
       let goal =
         match
           Goal_store.upsert_goal (Mcp_server.workspace_config fixture.state)
-            ~title:"Tool Matrix Goal" ()
+            ~title:"Tool Matrix Goal" ~metric:"m" ~target_value:"1" ()
         with
         | Ok (goal, _status) -> goal
         | Error err -> failwith ("failed to seed tool matrix goal: " ^ err)

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -241,6 +241,8 @@ let create_executing_goal ctx ~goal_id =
       ctx.Task.Tool.config
       ~id:goal_id
       ~title:("Goal " ^ goal_id)
+      ~metric:"m"
+      ~target_value:"1"
       ~phase:Goal_phase.Executing
       ()
   with


### PR DESCRIPTION
## 요약

**재구성됨 (2026-08-20): FSM 게이트는 adversarial review의 P0 지적에 따라 이 PR에서 분리했다.**

> P0-1: the gate has NO caller — no keeper prompt, no verifier agent, no dashboard UI ever invokes record_proof_proven/human_confirm, so any Goal entering the gate vanishes from keeper sight and can never reach Completed.

이 PR은 이제 RFC-0387의 **stage 1**만 담는다: **B1 + verification ledger(record-only) + 관측성**. Lifecycle 변경은 없다 — `request_complete`은 여전히 `Executing → Completed`로 곧장 완료된다. FSM 게이트(`Verifying`/`Awaiting_confirmation` phase, gate action 6종, `request_complete` 재라우팅)와 그 게이트를 부르는 verifier caller(B7 standalone lane)는 **stage 2 후속 PR**에서 함께 딴다. 게이트는 caller 없이 머지하지 않는다.

## Stage 1 내용

- **B1 — 성공조건 필수** (`lib/goal/goal_store.ml:462`): `upsert_goal`의 생성 경로가 `metric` + `target_value`(둘 다 non-blank)를 요구한다. 갱신은 게이트하지 않는다 — B1은 생성 시 선언 의무다.
- **Verification ledger** (`lib/goal/goal_verification.ml`, `.masc/goal_verifications.json`): criterion/completion 검증 상태의 record-only 증거 저장소. 닫힌 합타입, strict decode(unknown 필드/variant 문자열은 decode error), locked read-modify-write + `.last-good` recovery mirror, undecodable store는 모든 mutation을 거절(fail-closed). **이 단계에서는 writer가 하나도 없다** — `record_criterion_verdict` / `record_proof_verdict` / `record_human_confirmation` API와 그 precondition(pending 없는 proof verdict 거절 등)만 갖추고, stage 2의 verifier gate가 커밋 경로로 쓴다.
- **관측성**: `masc_goal_list`(`lib/workspace_goals.ml:199`)와 `/api/v1/dashboard/planning`(`lib/server/server_dashboard_http.ml:559`)의 goal 항목에 ledger `verification` 상태를 합류한다. `goal_to_yojson`(persistence codec)은 건드리지 않고 boundary에서 join한다. keeper 출력 계약의 goal items는 `additionalProperties: true`라 계약 변화 없음(`lib/keeper/keeper_tool_descriptor.ml` 주석으로 producer 명시).
- **테스트** (`test/test_goal_verification_gate.ml`): B1 생성 거절/갱신 비게이트, ledger 쓰기-읽기 왕복, strict decode, fail-closed mutation, fail-loud read, 관측성 join, 그리고 "stage 1은 lifecycle을 바꾸지 않는다"(`request_complete` 직행 완료) pin.

## Review fixes 적용

- **P1-1 (corrupt ledger가 "미검증"으로 위장)**: `get_record`가 `Undecodable _ -> None`으로 삼키던 것을 fail-loud로 변경 — `load_records` / `get_record`가 `(…, string) result`를 반환하고(`lib/goal/goal_verification.ml:475`, `:480`), decode 실패 시 두 read 표면이 goal 항목에 명시적 `{"state": "ledger_error", …}` 마커를 렌더한다(`ledger_error_to_yojson`, `lib/goal/goal_verification.ml:485`). default_record로 위장하지 않는다.
- **P1-3 (B1 생성 판정의 pre-lock heuristic)**: 생성/갱신 판정을 write lock 안, 방금 decode된 state 위로 옮겼다(`lib/goal/goal_store.ml:540`). undecodable store는 `update_state`의 fail-closed 거절이 먼저 잡으므로, corruption이 "metric and target_value are required"로 오보되지 않는다. "pre-lock heuristic"을 인정하던 주석은 제거.
- **P2-1 (O(N²) ledger 재 decode)**: per-goal `get_record` 대신 `load_records`로 요청당 한 번만 적재해 메모리에서 join한다 (`lib/workspace_goals.ml:208`, `lib/server/server_dashboard_http.ml:568`).
- **P2-2 (schema-level required)**: `masc_goal_upsert`는 create-or-update 겸용 tool이고 JSON Schema `required`는 무조건 적용이라, `required` 배열에 넣으면 기존 goal의 모든 갱신이 깨진다. 생성/갱신 구분은 store를 봐야만 결정 가능하므로 handler-side 강제를 유지하되, 그 이유를 스키마 주석과 두 필드의 description("Required (non-blank) when the upsert creates a new goal")에 명시했다 (`lib/tool_schemas/tool_schemas_workspace_extra.ml:73`).

## Stage 2 (후속 PR)

- `Goal_phase`에 `Verifying` / `Awaiting_confirmation` phase와 gate action 6종 추가, `request_complete`의 `Executing → Verifying` 재라우팅, 생성 시 `Criterion_pending` durable 요청(`mark_*_pending`), `Criterion_unreachable`의 `request_complete` 차단.
- **B7: standalone verifier lane** — pending 요청을 drain해 `Task.Anti_rationalization.review`로 판정하고 verdict action으로 커밋하는 Eio worker + 사람 확인 경로(dashboard HITL). 게이트와 caller는 같은 PR에서만 머지한다.

설계 전체와 stage 분할은 `docs/rfc/RFC-0387-goal-verifier-gate.md` §0.5 (Staging) 참조.

## 검증

- `scripts/audit-dead-surface.py --exports --ratchet`: 539, at baseline (540 → 539로 하향 — 이 트리에서 실측; ledger export는 전부 caller가 있어 증가분 없음).
- `scripts/ci/check-enum-string-safety.sh` / `check-telemetry-coverage.sh`: STR/TEL gate PASS.
- 로컬 OCaml 빌드/테스트는 프로젝트 프로토콜상 돌리지 않았다 — 컴파일·테스트 검증은 CI에서 확인한다.
