### PR TITLE
fix(audit): dead-surface가 트리의 자기 복사본을 참조로 세던 문제 (#29113)

### DIFF
--- a/scripts/audit-dead-surface.py
+++ b/scripts/audit-dead-surface.py
@@ -117,7 +117,15 @@ ROOT = Path(__file__).resolve().parent.parent
 SOURCE_ROOTS = ("lib", "bin", "test")
 
 # Directories that never contain authored source.
-SKIP_PARTS = frozenset({"_build", "node_modules", ".git", "_opam", ".worktrees"})
+#
+# `.claude` holds tool state, and `.claude/worktrees` under it holds whole
+# copies of this tree. Those copies made every export look referenced by its
+# own duplicate: measured 2026-08-20 at the same commit, a checkout carrying
+# 14,298 files there reported 21 dead exports where a clean one reported 539.
+# `.worktrees` was already listed but does not match this path -- the name is
+# `worktrees`, without the leading dot -- so the audit walked 25,507 files
+# locally against CI's 9,491 and then advised lowering the baseline by 518.
+SKIP_PARTS = frozenset({"_build", "node_modules", ".git", "_opam", ".worktrees", ".claude"})
 
 # Short names collide with unrelated identifiers often enough that a token
 # scan says little about them, so `--exports` skips them by default.


### PR DESCRIPTION
## 증상 (#29113)

같은 커밋인데 dead-surface 감사가 로컬 21개, CI 539개를 냅니다. 그리고 **로컬에서는 baseline을 518 낮추라고 권합니다.** 따르면 CI가 즉시 깨집니다.

```
[dead-surface] OK - 21 dead exports, 540 baseline - lower DEAD_EXPORT_BASELINE to hold the 519 you removed
```

## 원인

`.claude/worktrees`입니다. **이 트리의 통째 복사본**이 들어 있어서, 모든 export가 자기 복제본에 의해 "참조됨"으로 판정됩니다. 이 체크아웃에는 그 아래 **14,298개 파일**이 있습니다.

`.worktrees`는 이미 `SKIP_PARTS`에 있지만 이 경로엔 안 걸립니다 — 디렉터리 이름이 점 없는 `worktrees`이고, `is_skipped_name`은 `".worktree"`로 시작하는 이름만 따로 봅니다.

```python
def is_skipped_name(name):
    return name in SKIP_PARTS or name.startswith(".worktree")
```

## 측정

같은 커밋(`de44d15a49`)에 워크트리를 만들어 대조군으로 삼았습니다. 변수는 디렉터리 유무 하나뿐입니다.

| 상태 | dead exports | 스캔 파일 |
|---|---|---|
| clean 체크아웃 (= CI) | **539** | 9,491 |
| + `reports/` 1,609개 | 538 | |
| + `.claude/` 14,311개 | **36** | |
| 이 체크아웃 (전부) | **21** | 25,507 |
| 이 체크아웃 + 이 수정 | **539** | |

`reports/`를 먼저 의심했는데 1,609개를 복사해도 539 → 538로 한 개만 움직였습니다. `.claude/`가 503개를 살리고 있었습니다.

## 변경

`SKIP_PARTS`에 `.claude`를 더합니다. 도구 상태이지 authored source가 아니라, 다른 결과는 바뀌지 않습니다.

수정 후 **본체에서도 539**가 나옵니다 — 로컬과 CI가 일치합니다.

## 남은 위험

이 수정은 두 답을 일치시키지만, "틀린 쪽이 baseline 조정을 권한다"는 구조 자체는 그대로입니다. 앞으로 다른 도구가 트리 복사본을 어딘가에 두면 같은 일이 반복됩니다. 권유 문구를 **스캔 파일 수가 예상 범위를 벗어나면 억제**하는 쪽이 근본에 가깝지만, 그 임계를 정할 근거가 없어 이 PR에서는 하지 않았습니다.

## 제 앞선 진단 정정

#29113 본문에 "`_build` 함정"이라고 적었다가, `SKIP_PARTS`와 `all_files`의 가지치기가 정상인 것을 보고 **원인 지목을 취소**했습니다. 이번 측정으로 확인하니 `_build`는 정말 무관했고, 취소는 옳았지만 대신 지목한 "브랜치 차이"도 틀렸습니다. 같은 커밋에서 518개가 갈립니다.

Refs #29113
