### PR TITLE
feat(runtime): verifier_exact exact-output lane for completion-authority judgement (RFC-0361 D7(a))

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -11,10 +11,13 @@
 
 [runtime]
 default = "ollama_cloud.deepseek-v4-flash"
-# Anti-rationalization/cross-verifier work uses a typed verdict tool call.
+# Anti-rationalization/completion-authority work uses a typed verdict tool call.
 # Keep normal keeper turns on the fleet default flash runtime; reserve Pro for
-# this explicit smart lane.
-cross_verifier = "deepseek.deepseek-v4-pro"
+# this explicit smart lane. Since RFC-0361 D7(a) the judgement call no longer
+# reads a single-runtime binding here: it runs on the verifier_exact
+# exact-output lane below, whose first slot absorbs the retired
+# cross_verifier = "deepseek.deepseek-v4-pro" binding. The [runtime].cross_verifier
+# key still parses for preserved live configs but selects nothing.
 
 # Existing workspaces are not overwritten by this seed. Copy the required lane
 # declarations into the live runtime.toml before enabling their consumers.
@@ -33,6 +36,13 @@ slots = ["glm-coding.glm-5-turbo", "glm-coding.glm-4-7-coding"]
 
 [runtime.exact_output_lanes.board_attention_exact]
 slots = ["glm-coding.glm-5-turbo", "glm-coding.glm-4-7-coding"]
+
+# Verifier/completion-authority judgement lane (RFC-0361 D7(a)). Judgement
+# calls resolve only this lane and fail over in declared slot order, the same
+# frozen-order contract as the librarian/compaction lanes. Slot 1 is the
+# binding the retired [runtime].cross_verifier key used to carry.
+[runtime.exact_output_lanes.verifier_exact]
+slots = ["deepseek.deepseek-v4-pro", "glm-coding.glm-5-turbo"]
 
 [providers.ollama_cloud]
 display-name = "Ollama Cloud"

--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -1091,8 +1091,8 @@ let create_state_eio ~sw ~proc_mgr ~fs ~clock ~mono_clock ~net ~base_path =
         Workspace_metric_hooks.install ();
         Atomic.set Workspace_hooks.get_default_runtime_id_fn Runtime.get_default_runtime_id;
         Atomic.set
-          Workspace_hooks.get_cross_verifier_runtime_id_fn
-          Runtime.cross_verifier_runtime_id;
+          Workspace_hooks.get_verifier_exact_lane_slot_ids_fn
+          Runtime.verifier_exact_lane_slot_ids;
         Atomic.set Task.Handlers.push_event_to_sessions_fn Subscriptions.push_event_to_sessions;
         Board_dispatch.init_jsonl ())
       base_path

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -704,8 +704,30 @@ let keeper_dispatch_blocked (runtimes : t list) : (t * string) list =
     runtimes
 ;;
 
+(* [runtime.exact_output_lanes.verifier_exact] (RFC-0361 D7(a)) is the single
+   selector for completion-authority judgement calls: admitted slots in frozen
+   declaration order, fail over in that order. The retired
+   [runtime].cross_verifier single-runtime binding is absorbed into this lane's
+   first slot; the key still parses for preserved live configs but no judgement
+   path reads it. *)
+let verifier_exact_lane_id = "verifier_exact"
+
+let verifier_exact_slot_ids_of_lane_decls
+      (decls : Runtime_schema.exact_output_lane_decl list)
+  =
+  match
+    List.find_opt
+      (fun (lane : Runtime_schema.exact_output_lane_decl) ->
+         String.equal lane.id verifier_exact_lane_id)
+      decls
+  with
+  | None -> []
+  | Some lane -> lane.slot_ids
+;;
+
 (* Keeper provider attempts originate at the configured default, an explicit
-   keeper assignment, an explicit media-failover runtime, or cross verifier. A lane is
+   keeper assignment, an explicit media-failover runtime, the verifier_exact
+   exact-output lane's slots, or cross verifier. A lane is
    reachable only when its id shadows one of the configured routes; a merely
    declared lane is dormant until a routed root names it.
    Expand each lane-capable route with the same lane-over-runtime precedence as
@@ -718,6 +740,7 @@ let keeper_dispatch_runtime_ids
     ~(default_runtime_id : string)
     ~(assignments : (string * string) list)
     ~(cross_verifier_runtime_id : string option)
+    ~(verifier_exact_slot_ids : string list)
     ~(media_failover : string list)
     ~(lanes : Runtime_lane.t list)
   =
@@ -743,12 +766,14 @@ let keeper_dispatch_runtime_ids
     []
     ( routed_roots
       @ media_failover
-      @ (cross_verifier_runtime_id |> Option.to_list |> List.concat_map expand) )
+      @ (cross_verifier_runtime_id |> Option.to_list |> List.concat_map expand)
+      @ List.concat_map expand verifier_exact_slot_ids )
 ;;
 
 (* TEL-OK: pure fail-closed validation; the load boundary surfaces its error. *)
 let validate_keeper_dispatch_request_caps
     ~(config_path : string)
+    ~(verifier_exact_slot_ids : string list)
     ( runtimes
     , (default_runtime : t)
     , assignments
@@ -761,6 +786,7 @@ let validate_keeper_dispatch_request_caps
       ~default_runtime_id:default_runtime.id
       ~assignments
       ~cross_verifier_runtime_id
+      ~verifier_exact_slot_ids
       ~media_failover
       ~lanes
   in
@@ -1265,11 +1291,17 @@ let publish_exact_output_registry ?required_lane_ids ~lanes resolver_snapshot =
 let init_default_strict_report ~config_path =
   match load_list_internal ~config_path ~validate_max_context:true with
   | Error msg -> Error (Runtime_config_error msg)
-  | Ok (((runtimes, _, _, _, _, _) as loaded), _exact_output_lane_decls) ->
+  | Ok (((runtimes, _, _, _, _, _) as loaded), exact_output_lane_decls) ->
     (match missing_runtime_model_capabilities ~config_path runtimes with
      | Some report -> Error (Missing_catalog_models report)
      | None ->
-       (match validate_keeper_dispatch_request_caps ~config_path loaded with
+       (match
+          validate_keeper_dispatch_request_caps
+            ~config_path
+            ~verifier_exact_slot_ids:
+              (verifier_exact_slot_ids_of_lane_decls exact_output_lane_decls)
+            loaded
+        with
         | Error msg -> Error (Runtime_config_error msg)
         | Ok () ->
           set_loaded ~config_path loaded;
@@ -1282,13 +1314,21 @@ let init_default_strict ~config_path =
 let init_default_degraded_report ~config_path =
   match load_list_internal ~config_path ~validate_max_context:false with
   | Error msg -> Error (Runtime_config_error msg)
-  | Ok (((runtimes, _, _, _, _, _) as loaded), _exact_output_lane_decls) ->
+  | Ok (((runtimes, _, _, _, _, _) as loaded), exact_output_lane_decls) ->
+    let verifier_exact_slot_ids =
+      verifier_exact_slot_ids_of_lane_decls exact_output_lane_decls
+    in
     (match missing_runtime_model_capabilities ~config_path runtimes with
      | None ->
        (match validate_runtime_max_context ~config_path runtimes with
         | Error msg -> Error (Runtime_config_error msg)
         | Ok () ->
-          (match validate_keeper_dispatch_request_caps ~config_path loaded with
+          (match
+             validate_keeper_dispatch_request_caps
+               ~config_path
+               ~verifier_exact_slot_ids
+               loaded
+           with
            | Error msg -> Error (Runtime_config_error msg)
            | Ok () ->
              set_loaded ~config_path loaded;
@@ -1305,6 +1345,7 @@ let init_default_degraded_report ~config_path =
              (match
                 validate_keeper_dispatch_request_caps
                   ~config_path
+                  ~verifier_exact_slot_ids
                   degraded_loaded
               with
               | Error msg -> Error (Runtime_config_error msg)
@@ -1366,10 +1407,39 @@ let dashboard_runtime_defaults_snapshot () =
   }
 ;;
 
-(* [runtime].cross_verifier routing for the anti-rationalization evaluator.
-   [None] = the evaluator inherits [runtime].default. Reads the Atomic ref set by
-   [init_default]. *)
+(* [runtime].cross_verifier, kept parseable for preserved live configs. Since
+   RFC-0361 D7(a) no judgement path reads it — completion-authority provider
+   selection resolves the [verifier_exact] exact-output lane (see
+   {!verifier_exact_lane_slot_ids}); the lane's first slot absorbs the binding
+   this key used to carry. Remaining readers are config surfaces only: the
+   dashboard runtime-defaults display/route and the eval-calibration CLI's
+   evaluator default. *)
 let cross_verifier_runtime_id () = (runtime_state ()).cross_verifier_runtime_id
+
+(* Admitted [verifier_exact] slot ids in frozen declaration order from the
+   published exact-output registry — the single provider-selection SSOT for
+   completion-authority judgement calls (RFC-0361 D7(a)). [Error] names why the
+   lane cannot judge (registry not published, lane unconfigured, or no admitted
+   slots); there is no fallback to another route. *)
+let verifier_exact_lane_slot_ids () =
+  match Runtime_exact_output_registry.current () with
+  | Error error ->
+    Error (Runtime_exact_output_registry.publication_error_to_string error)
+  | Ok registry ->
+    (match
+       Runtime_exact_output_registry.resolve_lane
+         registry
+         ~lane_id:verifier_exact_lane_id
+     with
+     | Ok { selected_slots } ->
+       Ok
+         (List.map
+            (fun (slot : Runtime_exact_output_registry.selected_slot) ->
+               slot.slot_id)
+            selected_slots)
+     | Error error ->
+       Error (Runtime_exact_output_registry.lane_resolution_error_to_string error))
+;;
 
 (* [runtime].media_failover ordered runtime ids for RFC-0265 modality-gated
    reroute. [[]] = derive capable runtimes from declared capabilities. Reads the
@@ -1902,7 +1972,13 @@ let parse_and_validate_config_text ~config_path content =
     materialize_runtime_config_text ~config_path content
   in
   (* TEL-OK: validation is pure; config commit owns visible failure reporting. *)
-  let* () = validate_keeper_dispatch_request_caps ~config_path loaded in
+  let* () =
+    validate_keeper_dispatch_request_caps
+      ~config_path
+      ~verifier_exact_slot_ids:
+        (verifier_exact_slot_ids_of_lane_decls exact_output_lanes)
+      loaded
+  in
   Ok (loaded, exact_output_lanes)
 ;;
 

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -237,13 +237,16 @@ module For_testing : sig
     default_runtime_id:string ->
     assignments:(string * string) list ->
     cross_verifier_runtime_id:string option ->
+    verifier_exact_slot_ids:string list ->
     media_failover:string list ->
     lanes:Runtime_lane.t list ->
     string list
   (** Ordered, deduplicated runtime ids reachable by Keeper default/assignment
       roots (including a same-named lane's candidates), the explicit
-      cross-verifier runtime, and explicit
-      runtime-only media failover routing. Dormant declared lanes are excluded. *)
+      cross-verifier runtime, the [verifier_exact] exact-output lane's declared
+      slots (the completion-authority judgement route, RFC-0361 D7(a)), and
+      explicit runtime-only media failover routing. Dormant declared lanes are
+      excluded. *)
 
   val save_config_text_with_sync_parent :
     ?runtime_config_path:string ->
@@ -293,9 +296,25 @@ val dashboard_runtime_defaults_snapshot : unit -> dashboard_runtime_defaults_sna
     one immutable loaded-state snapshot. *)
 
 val cross_verifier_runtime_id : unit -> string option
-(** [\[runtime\].cross_verifier] runtime id for the anti-rationalization
-    evaluator, or [None] when unset (the evaluator uses [\[runtime\].default]).
-    Validated at load so a [Some] always resolves to a configured runtime. *)
+(** [\[runtime\].cross_verifier] runtime id, or [None] when unset. Since
+    RFC-0361 D7(a) no judgement path reads this: completion-authority provider
+    selection resolves the [verifier_exact] exact-output lane
+    ({!verifier_exact_lane_slot_ids}), whose first slot absorbs the binding this
+    key used to carry. The key stays parseable for preserved live configs;
+    remaining readers are config surfaces (dashboard runtime-defaults
+    display/route, eval-calibration CLI default). Validated at load so a [Some]
+    always resolves to a configured runtime. *)
+
+val verifier_exact_lane_id : string
+(** ["verifier_exact"] — the [\[runtime.exact_output_lanes.verifier_exact\]]
+    lane id (RFC-0361 D7(a)). *)
+
+val verifier_exact_lane_slot_ids : unit -> (string list, string) result
+(** Admitted [verifier_exact] slot ids in frozen declaration order from the
+    published exact-output registry — the single provider-selection SSOT for
+    completion-authority judgement calls. [Error] names why the lane cannot
+    judge (registry not published, lane unconfigured, or no admitted slots);
+    there is no fallback to another route. *)
 
 val media_failover : unit -> string list
 (** [\[runtime\].media_failover] (RFC-0265) — ordered runtime ids consulted when a

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -317,9 +317,11 @@ type config =
   ; bindings : binding list
   ; default_runtime_id : string option
   ; cross_verifier_runtime_id : string option
-    (** [\[runtime\].cross_verifier] — runtime id for the anti-rationalization
-        evaluator. [None] inherits [\[runtime\].default]. Unknown ids are
-        rejected at load. *)
+    (** [\[runtime\].cross_verifier] — legacy single-runtime binding for the
+        anti-rationalization evaluator. Since RFC-0361 D7(a) no judgement path
+        reads it; the [verifier_exact] exact-output lane is the selector.
+        Kept parseable for preserved live configs. Unknown ids are rejected at
+        load. *)
   ; keeper_assignments : (string * string) list
     (** [\[runtime.assignments\]] — keeper name → runtime id ["provider.model"].
         runtime.toml is the sole SSOT for keeper-to-runtime assignment; keeper

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -223,9 +223,13 @@ type config =
   ; bindings : binding list
   ; default_runtime_id : string option
   ; cross_verifier_runtime_id : string option
-    (** [\[runtime\].cross_verifier] — runtime id for the anti-rationalization
-        evaluator (cross-model task verification). [None] inherits
-        [\[runtime\].default]. Unknown ids are rejected at load. *)
+    (** [\[runtime\].cross_verifier] — legacy single-runtime binding for the
+        anti-rationalization evaluator. Since RFC-0361 D7(a) no judgement path
+        reads it: completion-authority provider selection resolves the
+        [verifier_exact] exact-output lane instead. Kept parseable for
+        preserved live configs; remaining readers are config surfaces
+        (dashboard runtime-defaults, eval-calibration CLI default). Unknown ids
+        are rejected at load. *)
   ; keeper_assignments : (string * string) list
     (** [\[runtime.assignments\]] — keeper name → runtime id ["provider.model"].
         Sole SSOT for keeper-to-runtime assignment. A

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -357,7 +357,11 @@ let configure_exact_output_registry ?config_root () =
        warn_optional_exact_output_lane
          registry
          ~lane_id:"librarian_exact"
-         ~feature:"librarian")
+         ~feature:"librarian";
+       warn_optional_exact_output_lane
+         registry
+         ~lane_id:Runtime.verifier_exact_lane_id
+         ~feature:"completion authority")
 ;;
 
 let install_domain_pool_references domain_pool =

--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -287,30 +287,45 @@ let parse_review_verdict_from_json (args : Yojson.Safe.t) : (verdict, string) re
 ;;
 
 (* ================================================================ *)
-(* Cross-model runtime selection (#3067)                             *)
+(* Cross-model runtime selection (#3067, RFC-0361 D7(a))             *)
 (* ================================================================ *)
 
-(** Default evaluator runtime name. Override via [~evaluator_runtime]
-    to force a specific evaluator profile. Without an override, the
-    concrete profile comes from [routes.cross_verifier].
+(** [\[runtime.exact_output_lanes.verifier_exact\]] — the dedicated exact-output
+    lane every completion-authority judgement call runs on. The lane's admitted
+    slots, in frozen declaration order, are the single provider-selection SSOT:
+    the retired [\[runtime\].cross_verifier] single-runtime binding is absorbed
+    into the lane's first slot, and there is no second selector path (no
+    cross_verifier read, no [\[runtime\].default] fallback).
 
     Cross-model evaluation is more effective than same-model different-role
     because different model architectures have different blindspots.
     See: Anthropic "Harness Design" blog analysis. *)
-(* Function, not a module-level value: [Runtime.get_default_runtime_id] fail-fasts
-   until [Runtime.init_default] runs at startup (RFC-0206 §2.1). A module-level
-   binding evaluates at load time and crashes boot; defer to call time.
+let verifier_exact_lane_id = "verifier_exact"
 
-   Prefer [\[runtime\].cross_verifier] when set: the verdict channel is the
-   [report_review_verdict] tool call, so the evaluator needs a tool-calling
-   model — no wire response format is requested
-   ([Keeper_structured_output_schema.anti_rationalization_reviewer_provider_config]).
-   Explicit routing restores cross-model separation from the generator.
-   [None] = inherit the global default (legacy). *)
-let default_evaluator_runtime () =
-  match (Atomic.get Workspace_hooks.get_cross_verifier_runtime_id_fn) () with
-  | Some id -> id
-  | None -> (Atomic.get Workspace_hooks.get_default_runtime_id_fn) ()
+(** Ordered evaluator slot list for one review. An explicit
+    [~evaluator_runtime] override is a single-slot lane (tests,
+    [--evaluator-runtime]); without one the published [verifier_exact] lane
+    supplies the frozen declaration order. The verdict channel is the
+    [report_review_verdict] tool call, so every slot needs a tool-calling
+    model — no wire response format is requested
+    ([Keeper_structured_output_schema.anti_rationalization_reviewer_provider_config]). *)
+let resolve_evaluator_slots = function
+  | Some runtime when String.trim runtime <> "" -> Ok [ runtime ]
+  | Some _ -> Error "task completion evaluator runtime is empty"
+  | None ->
+    (try
+       match (Atomic.get Workspace_hooks.get_verifier_exact_lane_slot_ids_fn) () with
+       | Ok [] ->
+         Error "verifier_exact exact-output lane resolved to no admitted slots"
+       | Ok slots -> Ok slots
+       | Error detail -> Error detail
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       Error
+         (Printf.sprintf
+            "verifier_exact exact-output lane resolution failed: %s"
+            (Printexc.to_string exn)))
 ;;
 
 (* ================================================================ *)
@@ -318,24 +333,6 @@ let default_evaluator_runtime () =
 (* ================================================================ *)
 
 let unresolved_evaluator_runtime = "unresolved"
-
-let resolve_evaluator_runtime = function
-  | Some runtime when String.trim runtime <> "" -> Ok runtime
-  | Some _ -> Error "task completion evaluator runtime is empty"
-  | None ->
-    (try
-       let runtime = default_evaluator_runtime () in
-       if String.trim runtime = ""
-       then Error "default task completion evaluator runtime is empty"
-       else Ok runtime
-     with
-     | Eio.Cancel.Cancelled _ as exn -> raise exn
-     | exn ->
-       Error
-         (Printf.sprintf
-            "task completion evaluator runtime resolution failed: %s"
-            (Printexc.to_string exn)))
-;;
 
 let review
       ?evaluator_runtime
@@ -366,7 +363,7 @@ let review
       (fun message -> Log.Task.warn "task_id=%s %s" req.task_id message)
       fmt
   in
-  match resolve_evaluator_runtime evaluator_runtime with
+  match resolve_evaluator_slots evaluator_runtime with
   | Error reason ->
     (Atomic.get outcome_observer_fn)
       ~outcome:"unavailable"
@@ -380,7 +377,23 @@ let review
       ; fallback_reason = Some reason
       ; retryable = true
       }
-  | Ok evaluator_runtime ->
+  | Ok [] ->
+    (* [resolve_evaluator_slots] never yields an empty list; this arm keeps the
+       match total without inventing a runtime. *)
+    (Atomic.get outcome_observer_fn)
+      ~outcome:"unavailable"
+      ~runtime:unresolved_evaluator_runtime;
+    let reason = "verifier_exact exact-output lane resolved to no admitted slots" in
+    task_warn "[task-completion-review] %s; task remains nonterminal" reason;
+    emit
+      { verdict = None
+      ; evaluator_runtime = unresolved_evaluator_runtime
+      ; generator_runtime
+      ; gate = Evaluator_unavailable
+      ; fallback_reason = Some reason
+      ; retryable = true
+      }
+  | Ok (first_slot :: _ as slots) ->
     (match
        build_prompt
          ~few_shot_block
@@ -393,14 +406,14 @@ let review
      | Error detail ->
        (Atomic.get outcome_observer_fn)
          ~outcome:"unavailable"
-         ~runtime:evaluator_runtime;
+         ~runtime:first_slot;
        task_warn
          "[task-completion-review] prompt unavailable runtime=%s: %s"
-         evaluator_runtime
+         first_slot
          detail;
        emit
          { verdict = None
-         ; evaluator_runtime
+         ; evaluator_runtime = first_slot
          ; generator_runtime
          ; gate = Evaluator_unavailable
          ; fallback_reason = Some detail
@@ -408,17 +421,23 @@ let review
          }
      | Ok prompt ->
        (match generator_runtime with
-        | Some generator when String.equal generator evaluator_runtime ->
+        | Some generator when List.exists (String.equal generator) slots ->
           task_warn
-            "[task-completion-review] generator and evaluator runtime are both %s"
-            evaluator_runtime
+            "[task-completion-review] generator runtime %s is one of the verifier_exact lane slots"
+            generator
         | None | Some _ -> ());
-       let reviewer_result =
+       (* Frozen-order slot failover, the same contract as the librarian /
+          compaction lanes: each slot is tried at most once, in declaration
+          order, and a slot that produces no usable verdict — provider error or
+          a reply without exactly one valid verdict tool call — yields to the
+          next slot. The terminal result describes the last attempt, so a
+          single-slot lane reports exactly what the pre-lane path reported. *)
+       let run_attempt slot =
          try
            (Atomic.get run_llm_reviewer_fn)
              ~base_path
              ?sw
-             ~evaluator_runtime
+             ~evaluator_runtime:slot
              ~prompt
              ~report_tool_schema:report_review_verdict_schema
              ~lookup
@@ -433,59 +452,81 @@ let review
                    "task completion evaluator raised unexpectedly: %s"
                    (Printexc.to_string exn)))
        in
-       (match reviewer_result with
-        | Ok (Some verdict) ->
-          (match verdict with
-           | Approve ->
-             task_info
-               "[task-completion-review] LLM approved runtime=%s"
-               evaluator_runtime
-           | Reject reason ->
-             task_info
-               "[task-completion-review] LLM rejected runtime=%s reason=%s"
-               evaluator_runtime
-               reason);
-          emit
-            { verdict = Some verdict
-            ; evaluator_runtime
-            ; generator_runtime
-            ; gate = Structured_tool
-            ; fallback_reason = None
-            ; retryable = true
-            }
-        | Ok None ->
-          let detail =
-            "task completion evaluator did not call report_review_verdict exactly once"
-          in
-          (Atomic.get outcome_observer_fn)
-            ~outcome:"invalid_verdict"
-            ~runtime:evaluator_runtime;
-          task_warn "[task-completion-review] %s" detail;
-          emit
-            { verdict = None
-            ; evaluator_runtime
-            ; generator_runtime
-            ; gate = Invalid_verdict
-            ; fallback_reason = Some detail
-            ; retryable = true
-            }
-        | Error error ->
-          let detail = Agent_core.Error.to_string error in
-          let retryable = Agent_core.Error.is_retryable error in
-          (Atomic.get outcome_observer_fn)
-            ~outcome:"unavailable"
-            ~runtime:evaluator_runtime;
-          task_warn
-            "[task-completion-review] evaluator unavailable runtime=%s retryable=%b; task remains nonterminal: %s"
-            evaluator_runtime
-            retryable
-            detail;
-          emit
-            { verdict = None
-            ; evaluator_runtime
-            ; generator_runtime
-            ; gate = Evaluator_unavailable
-            ; fallback_reason = Some detail
-            ; retryable
-            }))
+       let rec attempt slot remaining =
+         match run_attempt slot with
+         | Ok (Some verdict) ->
+           (match verdict with
+            | Approve ->
+              task_info
+                "[task-completion-review] LLM approved runtime=%s"
+                slot
+            | Reject reason ->
+              task_info
+                "[task-completion-review] LLM rejected runtime=%s reason=%s"
+                slot
+                reason);
+           emit
+             { verdict = Some verdict
+             ; evaluator_runtime = slot
+             ; generator_runtime
+             ; gate = Structured_tool
+             ; fallback_reason = None
+             ; retryable = true
+             }
+         | Ok None ->
+           let detail =
+             "task completion evaluator did not call report_review_verdict exactly once"
+           in
+           (Atomic.get outcome_observer_fn)
+             ~outcome:"invalid_verdict"
+             ~runtime:slot;
+           (match remaining with
+            | next :: rest ->
+              task_warn
+                "[task-completion-review] %s runtime=%s; failing over to next verifier_exact slot %s"
+                detail
+                slot
+                next;
+              attempt next rest
+            | [] ->
+              task_warn "[task-completion-review] %s" detail;
+              emit
+                { verdict = None
+                ; evaluator_runtime = slot
+                ; generator_runtime
+                ; gate = Invalid_verdict
+                ; fallback_reason = Some detail
+                ; retryable = true
+                })
+         | Error error ->
+           let detail = Agent_core.Error.to_string error in
+           let retryable = Agent_core.Error.is_retryable error in
+           (Atomic.get outcome_observer_fn)
+             ~outcome:"unavailable"
+             ~runtime:slot;
+           (match remaining with
+            | next :: rest ->
+              task_warn
+                "[task-completion-review] evaluator unavailable runtime=%s retryable=%b; failing over to next verifier_exact slot %s: %s"
+                slot
+                retryable
+                next
+                detail;
+              attempt next rest
+            | [] ->
+              task_warn
+                "[task-completion-review] evaluator unavailable runtime=%s retryable=%b; task remains nonterminal: %s"
+                slot
+                retryable
+                detail;
+              emit
+                { verdict = None
+                ; evaluator_runtime = slot
+                ; generator_runtime
+                ; gate = Evaluator_unavailable
+                ; fallback_reason = Some detail
+                ; retryable
+                }))
+       in
+       attempt first_slot (List.tl slots))
 ;;

--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -421,7 +421,7 @@ let review
          }
      | Ok prompt ->
        (match generator_runtime with
-        | Some generator when List.exists (String.equal generator) slots ->
+        | Some generator when List.exists (String.equal generator) (first_slot :: rest_slots) ->
           task_warn
             "[task-completion-review] generator runtime %s is one of the verifier_exact lane slots"
             generator
@@ -526,7 +526,7 @@ let review
                 ; gate = Evaluator_unavailable
                 ; fallback_reason = Some detail
                 ; retryable
-                }))
+                })
        in
        attempt first_slot rest_slots)
 ;;

--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -393,7 +393,7 @@ let review
       ; fallback_reason = Some reason
       ; retryable = true
       }
-  | Ok (first_slot :: _ as slots) ->
+  | Ok (first_slot :: rest_slots) ->
     (match
        build_prompt
          ~few_shot_block
@@ -528,5 +528,5 @@ let review
                 ; retryable
                 }))
        in
-       attempt first_slot (List.tl slots))
+       attempt first_slot rest_slots)
 ;;

--- a/lib/task/anti_rationalization.mli
+++ b/lib/task/anti_rationalization.mli
@@ -77,7 +77,19 @@ val review
   -> review_request
   -> review_result
 (** [base_path] is the workspace BasePath selected by the caller. The review
-    must not rediscover it from process-global environment state. *)
+    must not rediscover it from process-global environment state.
+
+    Without [~evaluator_runtime], the evaluator slots come from the published
+    [verifier_exact] exact-output lane (RFC-0361 D7(a)) and are tried in frozen
+    declaration order: a slot that fails or returns no valid verdict tool call
+    yields to the next slot, and the terminal result describes the last
+    attempt. An explicit [~evaluator_runtime] is a single-slot lane with no
+    failover. *)
+
+val verifier_exact_lane_id : string
+(** ["verifier_exact"] — the [\[runtime.exact_output_lanes.verifier_exact\]]
+    lane id every completion-authority judgement call resolves through
+    (RFC-0361 D7(a)). *)
 
 (** Render the single prompt-registry SSOT. There is no inline fallback prompt;
     an error keeps the Task nonterminal. *)

--- a/lib/workspace/workspace_hooks.ml
+++ b/lib/workspace/workspace_hooks.ml
@@ -253,12 +253,15 @@ let get_default_runtime_id_fn
   : (unit -> string) Atomic.t
   = Atomic.make (fun () -> failwith "Workspace_hooks: get_default_runtime_id_fn not connected")
 
-(* Optional: [None] means "use the global default runtime". Defaults to a
-   None-returning thunk (not a failwith) so unconnected test contexts fall back
-   to the default instead of crashing. *)
-let get_cross_verifier_runtime_id_fn
-  : (unit -> string option) Atomic.t
-  = Atomic.make (fun () -> None)
+(* The completion-authority evaluator's runtime comes only from the published
+   [verifier_exact] exact-output lane (RFC-0361 D7(a)): admitted slot ids in
+   frozen declaration order. The unconnected default is an explicit [Error] so
+   an unwired process leaves the review visibly deferred instead of silently
+   picking a runtime. *)
+let get_verifier_exact_lane_slot_ids_fn
+  : (unit -> (string list, string) result) Atomic.t
+  = Atomic.make (fun () ->
+      Error "Workspace_hooks: get_verifier_exact_lane_slot_ids_fn not connected")
 
 let record_task_metric_fn
   : (Workspace_utils_backend_setup.config ->

--- a/lib/workspace/workspace_hooks.mli
+++ b/lib/workspace/workspace_hooks.mli
@@ -121,12 +121,12 @@ val active_agents_change_fn : ([ `Inc | `Dec ] -> unit) Atomic.t
 val telemetry_observe_failure_fn : (string -> unit) Atomic.t
 val get_default_runtime_id_fn : (unit -> string) Atomic.t
 
-(** [\[runtime\].cross_verifier] runtime id for the anti-rationalization
-    evaluator, or [None] to use {!get_default_runtime_id_fn}. Wired to
-    [Runtime.cross_verifier_runtime_id] at startup; defaults to [fun () -> None]
-    (use the global default) when not connected, so callers in test contexts
-    fall back rather than crash. *)
-val get_cross_verifier_runtime_id_fn : (unit -> string option) Atomic.t
+(** Admitted [\[runtime.exact_output_lanes.verifier_exact\]] slot ids in frozen
+    declaration order for the completion-authority evaluator (RFC-0361 D7(a)).
+    Wired to [Runtime.verifier_exact_lane_slot_ids] at startup; the unconnected
+    default is an explicit [Error], so test contexts that drive a review must
+    install their own slot list rather than inherit a silent runtime default. *)
+val get_verifier_exact_lane_slot_ids_fn : (unit -> (string list, string) result) Atomic.t
 
 val record_task_metric_fn :
   (Workspace_utils_backend_setup.config ->

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -110,6 +110,7 @@ normal_targets=(
   @test/runtest-test_subsystem_health_state
   @test/runtest-test_trailing_slash_rules
   @test/runtest-test_verification_run_registry
+  @test/runtest-test_verifier_exact_lane
   @test/runtest-test_completion_authority_retry_policy
   @test/runtest-test_keeper_canary_facts
   @test/runtest-test_keeper_canary_evidence

--- a/test/dune
+++ b/test/dune
@@ -2582,6 +2582,8 @@
 
 (include stanzas/test_verification_run_registry.inc)
 
+(include stanzas/test_verifier_exact_lane.inc)
+
 (include stanzas/test_completion_authority_retry_policy.inc)
 
 (include stanzas/test_keeper_canary_facts.inc)

--- a/test/stanzas/test_verifier_exact_lane.inc
+++ b/test/stanzas/test_verifier_exact_lane.inc
@@ -1,0 +1,8 @@
+; RFC-0361 D7(a) — completion-authority judgement calls run on the dedicated
+; verifier_exact exact-output lane: frozen-order slot resolution through the
+; published registry, and failover in declared slot order inside review.
+
+(test
+ (name test_verifier_exact_lane)
+ (modules test_verifier_exact_lane)
+ (libraries masc_test_deps))

--- a/test/test_completion_trust_harness.ml
+++ b/test/test_completion_trust_harness.ml
@@ -544,6 +544,10 @@ let () =
   Masc.Keeper_task_owner_backend.install_hooks ();
   Masc_test_deps.init_unified_tool_registry ();
   Atomic.set Workspace_hooks.get_default_runtime_id_fn (fun () -> "test-evaluator-runtime");
+  (* RFC-0361 D7(a): completion review resolves only the verifier_exact lane. *)
+  Atomic.set
+    Workspace_hooks.get_verifier_exact_lane_slot_ids_fn
+    (fun () -> Ok [ "test-evaluator-runtime" ]);
   Atomic.set AR.run_llm_reviewer_fn reviewer;
   run "Completion_trust_harness"
     [ ( "completion_trust_dispatch_oracle"

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -22,7 +22,9 @@ let () =
   let (_operator_force_link : unit) = Operator_tool.force_link in
   let (_dashboard_ws_sessions : int) = Server_mcp_transport_ws.session_count () in
   Atomic.set Workspace_hooks.get_default_runtime_id_fn (fun () -> "test.local");
-  Atomic.set Workspace_hooks.get_cross_verifier_runtime_id_fn (fun () -> None)
+  Atomic.set
+    Workspace_hooks.get_verifier_exact_lane_slot_ids_fn
+    (fun () -> Ok [ "test.local" ])
 
 let () =
   (* These process-global registries are installed by module initializers in the

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -1053,14 +1053,8 @@ List.iter
         ~assignments
         ~cross_verifier_runtime_id:cross_verifier
         ~verifier_exact_slot_ids:
-          (match
-             List.find_opt
-               (fun (lane : Runtime_schema.exact_output_lane_decl) ->
-                  String.equal lane.id Runtime.verifier_exact_lane_id)
-               config.exact_output_lane_decls
-           with
-           | Some lane -> lane.slot_ids
-           | None -> [])
+          (* pinned to the seed by the verifier_exact lane check above *)
+          [ "deepseek.deepseek-v4-pro"; "glm-coding.glm-5-turbo" ]
         ~media_failover
         ~lanes
     in

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -1000,6 +1000,7 @@ check
   ; "compaction_exact"
   ; "hitl_auto_judge"
   ; "librarian_exact"
+  ; "verifier_exact"
   ]
   (List.map fst lane_signatures);
 check
@@ -1015,6 +1016,25 @@ check
        String.equal lane_id "board_attention_exact"
        || String.equal lane_id "hitl_auto_judge")
      lane_signatures);
+(* RFC-0361 D7(a): the completion-authority judgement lane is the single
+   provider-selection SSOT; slot 1 absorbs the retired [runtime].cross_verifier
+   binding and failover follows declaration order. *)
+check
+  (option (list string))
+  "verifier_exact absorbs cross_verifier as its first slot"
+  (Some [ "deepseek.deepseek-v4-pro"; "glm-coding.glm-5-turbo" ])
+  (match
+     List.find_opt
+       (fun (lane_id, _) -> String.equal lane_id "verifier_exact")
+       lane_signatures
+   with
+   | Some (_, slot_ids) -> Some slot_ids
+   | None -> None);
+check
+  (option string)
+  "cross_verifier is absorbed into the verifier_exact lane"
+  None
+  cross_verifier;
 List.iter
   (fun (lane : Runtime_schema.exact_output_lane_decl) ->
      check bool
@@ -1032,6 +1052,15 @@ List.iter
         ~default_runtime_id:default.id
         ~assignments
         ~cross_verifier_runtime_id:cross_verifier
+        ~verifier_exact_slot_ids:
+          (match
+             List.find_opt
+               (fun (lane : Runtime_schema.exact_output_lane_decl) ->
+                  String.equal lane.id Runtime.verifier_exact_lane_id)
+               config.exact_output_lane_decls
+           with
+           | Some lane -> lane.slot_ids
+           | None -> [])
         ~media_failover
         ~lanes
     in
@@ -1830,18 +1859,20 @@ let test_keeper_dispatch_runtime_graph_enumeration () =
       ~default_runtime_id:"default-a"
       ~assignments:[ "keeper-a", "assigned-b" ]
       ~cross_verifier_runtime_id:(Some "cross-e")
+      ~verifier_exact_slot_ids:[ "verifier-a"; "lane-b" ]
       ~media_failover:[ "media-c"; "lane-a" ]
       ~lanes
   in
   check
     (list string)
-    "routed lane candidates, special routes, and media failover are deduplicated \
-     without admitting a dormant lane"
+    "routed lane candidates, special routes, verifier_exact slots, and media \
+     failover are deduplicated without admitting a dormant lane"
     [ "lane-a"
     ; "lane-b"
     ; "assigned-b"
     ; "media-c"
     ; "cross-a"
+    ; "verifier-a"
     ]
     actual
 ;;

--- a/test/test_telemetry_task_transition_10358.ml
+++ b/test/test_telemetry_task_transition_10358.ml
@@ -49,12 +49,23 @@ let with_isolated_runtime_env f =
 
 let with_default_runtime_id_hook f =
   let previous = Atomic.get Workspace_hooks.get_default_runtime_id_fn in
+  let previous_lane_slots =
+    Atomic.get Workspace_hooks.get_verifier_exact_lane_slot_ids_fn
+  in
   Fun.protect
     ~finally:(fun () ->
-      Atomic.set Workspace_hooks.get_default_runtime_id_fn previous)
+      Atomic.set Workspace_hooks.get_default_runtime_id_fn previous;
+      Atomic.set
+        Workspace_hooks.get_verifier_exact_lane_slot_ids_fn
+        previous_lane_slots)
     (fun () ->
       Atomic.set Workspace_hooks.get_default_runtime_id_fn
         (fun () -> "test-evaluator-runtime");
+      (* RFC-0361 D7(a): completion review resolves only the verifier_exact
+         lane, so the review-driving tests below must supply its slots. *)
+      Atomic.set
+        Workspace_hooks.get_verifier_exact_lane_slot_ids_fn
+        (fun () -> Ok [ "test-evaluator-runtime" ]);
       f ())
 
 let make_ctx base_path =
@@ -105,6 +116,9 @@ let test_masc_transition_claim_done_emits_task_lifecycle () =
   let previous_default_runtime =
     Atomic.get Workspace_hooks.get_default_runtime_id_fn
   in
+  let previous_lane_slots =
+    Atomic.get Workspace_hooks.get_verifier_exact_lane_slot_ids_fn
+  in
   let previous_observe_task_transition =
     Atomic.get Workspace_hooks.observe_task_transition_fn
   in
@@ -119,6 +133,9 @@ let test_masc_transition_claim_done_emits_task_lifecycle () =
       Ok (Some Task.Anti_rationalization.Approve));
   Atomic.set Workspace_hooks.get_default_runtime_id_fn
     (fun () -> "test-evaluator-runtime");
+  Atomic.set
+    Workspace_hooks.get_verifier_exact_lane_slot_ids_fn
+    (fun () -> Ok [ "test-evaluator-runtime" ]);
   Atomic.set Workspace_hooks.observe_task_transition_fn
     (fun config ~agent_name ~task_id ~transition ~details:_ ->
       match transition with
@@ -132,6 +149,9 @@ let test_masc_transition_claim_done_emits_task_lifecycle () =
   Fun.protect
     ~finally:(fun () ->
       Atomic.set Workspace_hooks.get_default_runtime_id_fn previous_default_runtime;
+      Atomic.set
+        Workspace_hooks.get_verifier_exact_lane_slot_ids_fn
+        previous_lane_slots;
       Atomic.set Workspace_hooks.observe_task_transition_fn
         previous_observe_task_transition;
       Atomic.set Task.Anti_rationalization.run_llm_reviewer_fn previous_reviewer)

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -98,6 +98,10 @@ let install_test_hooks () =
   Prompt_registry.set_markdown_dir
     (Filename.concat (repo_root ()) "config/prompts");
   Atomic.set Workspace_hooks.get_default_runtime_id_fn Runtime.get_default_runtime_id;
+  (* RFC-0361 D7(a): completion review resolves only the verifier_exact lane. *)
+  Atomic.set
+    Workspace_hooks.get_verifier_exact_lane_slot_ids_fn
+    (fun () -> Ok [ "test-evaluator-runtime" ]);
   Atomic.set Task.Anti_rationalization.run_llm_reviewer_fn
     (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~lookup:_ ~on_tool_result:_ () ->
        Ok (Some Task.Anti_rationalization.Approve))

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -723,6 +723,9 @@ let test_system_llm_agent_commits_without_a_keeper_verifier () =
     Prompt_registry.set_markdown_dir prompt_dir;
     Masc.Prompt_defaults.init ();
     let previous_runtime = Atomic.get Workspace_hooks.get_default_runtime_id_fn in
+    let previous_lane_slots =
+      Atomic.get Workspace_hooks.get_verifier_exact_lane_slot_ids_fn
+    in
     let previous_reviewer =
       Atomic.get Masc.Task.Anti_rationalization.run_llm_reviewer_fn
     in
@@ -736,6 +739,9 @@ let test_system_llm_agent_commits_without_a_keeper_verifier () =
     Fun.protect
       ~finally:(fun () ->
         Atomic.set Workspace_hooks.get_default_runtime_id_fn previous_runtime;
+        Atomic.set
+          Workspace_hooks.get_verifier_exact_lane_slot_ids_fn
+          previous_lane_slots;
         Atomic.set Masc.Task.Anti_rationalization.run_llm_reviewer_fn previous_reviewer;
         Atomic.set Workspace_hooks.verification_notify_verdict_fn previous_notification;
         Atomic.set Workspace_hooks.verification_submitted_fn previous_submitted;
@@ -745,6 +751,12 @@ let test_system_llm_agent_commits_without_a_keeper_verifier () =
       (fun () ->
         Atomic.set Workspace_hooks.get_default_runtime_id_fn
           (fun () -> "test-system-evaluator");
+        (* RFC-0361 D7(a): the completion-authority review resolves only the
+           verifier_exact lane; the default runtime hook above no longer
+           reaches it. *)
+        Atomic.set
+          Workspace_hooks.get_verifier_exact_lane_slot_ids_fn
+          (fun () -> Ok [ "test-system-evaluator" ]);
         Eio.Switch.run (fun sw ->
           let reviewer_called, resolve_reviewer_called = Eio.Promise.create () in
           let verdict_committed, resolve_verdict_committed = Eio.Promise.create () in
@@ -970,6 +982,9 @@ let test_system_llm_agent_uses_persisted_request_contract_snapshot () =
     Prompt_registry.set_markdown_dir prompt_dir;
     Masc.Prompt_defaults.init ();
     let previous_runtime = Atomic.get Workspace_hooks.get_default_runtime_id_fn in
+    let previous_lane_slots =
+      Atomic.get Workspace_hooks.get_verifier_exact_lane_slot_ids_fn
+    in
     let previous_reviewer =
       Atomic.get Masc.Task.Anti_rationalization.run_llm_reviewer_fn
     in
@@ -980,12 +995,18 @@ let test_system_llm_agent_uses_persisted_request_contract_snapshot () =
     Fun.protect
       ~finally:(fun () ->
         Atomic.set Workspace_hooks.get_default_runtime_id_fn previous_runtime;
+        Atomic.set
+          Workspace_hooks.get_verifier_exact_lane_slot_ids_fn
+          previous_lane_slots;
         Atomic.set Masc.Task.Anti_rationalization.run_llm_reviewer_fn previous_reviewer;
         Atomic.set Workspace_hooks.verification_notify_verdict_fn previous_notification;
         Atomic.set Workspace_hooks.verification_submitted_fn previous_submitted)
       (fun () ->
         Atomic.set Workspace_hooks.get_default_runtime_id_fn
           (fun () -> "test-system-evaluator");
+        Atomic.set
+          Workspace_hooks.get_verifier_exact_lane_slot_ids_fn
+          (fun () -> Ok [ "test-system-evaluator" ]);
         Eio.Switch.run (fun sw ->
           let reviewer_called, resolve_reviewer_called = Eio.Promise.create () in
           let verdict_committed, resolve_verdict_committed = Eio.Promise.create () in

--- a/test/test_verifier_exact_lane.ml
+++ b/test/test_verifier_exact_lane.ml
@@ -1,0 +1,335 @@
+(* RFC-0361 D7(a) — the completion-authority judgement call runs on the
+   dedicated [verifier_exact] exact-output lane: lane resolution returns the
+   admitted slots in frozen declaration order, and [review] fails over in that
+   order when a slot produces no usable verdict. *)
+
+module AR = Masc.Task.Anti_rationalization
+module Exact_output = Agent_core.Exact_output
+
+let request : AR.review_request =
+  { agent_name = "test-keeper"
+  ; task_title = "finish concrete task"
+  ; task_description = "Implement and verify a concrete task."
+  ; completion_notes = "Implemented the change and ran the focused test."
+  ; task_id = "test-task"
+  ; evidence_refs = []
+  }
+;;
+
+let configure_prompt_registry () =
+  Prompt_registry.set_markdown_dir
+    (Filename.concat (Masc_test_deps.find_project_root ()) "config/prompts")
+;;
+
+let with_lane_and_reviewer ~slots ~reviewer f =
+  let saved_slots = Atomic.get Workspace_hooks.get_verifier_exact_lane_slot_ids_fn in
+  let saved_reviewer = Atomic.get AR.run_llm_reviewer_fn in
+  Fun.protect
+    ~finally:(fun () ->
+      Atomic.set Workspace_hooks.get_verifier_exact_lane_slot_ids_fn saved_slots;
+      Atomic.set AR.run_llm_reviewer_fn saved_reviewer)
+    (fun () ->
+       Atomic.set Workspace_hooks.get_verifier_exact_lane_slot_ids_fn slots;
+       Atomic.set AR.run_llm_reviewer_fn reviewer;
+       f ())
+;;
+
+let review () =
+  AR.review
+    ~lookup:AR.No_lookup_surface
+    ~base_path:(Filename.get_temp_dir_name ())
+    request
+;;
+
+(* A reviewer that answers per slot and records the attempt order. *)
+let recording_reviewer calls behaviors =
+  fun ~base_path:_ ?sw:_ ~evaluator_runtime ~prompt:_ ~report_tool_schema:_ ~lookup:_ ~on_tool_result:_ () ->
+    calls := !calls @ [ evaluator_runtime ];
+    match List.assoc_opt evaluator_runtime behaviors with
+    | Some behavior -> behavior
+    | None ->
+      Error
+        (Agent_core.Error.Internal
+           ("unexpected evaluator slot " ^ evaluator_runtime))
+;;
+
+let rate_limited =
+  Error
+    (Agent_core.Error.Api
+       (Agent_core.Error.Retry.RateLimited
+          { retry_after = None; message = "rate limited" }))
+;;
+
+let budget_refusal =
+  Error
+    (Agent_core.Error.Agent
+       (Agent_core.Error.HookExecutionFailed
+          { hook_name = "model_input_projection"
+          ; stage = "turn:parse"
+          ; tool_name = None
+          ; tool_use_id = None
+          ; detail = "newest conversation atom does not fit the model input budget"
+          }))
+;;
+
+let test_failover_follows_declared_slot_order () =
+  let calls = ref [] in
+  with_lane_and_reviewer
+    ~slots:(fun () -> Ok [ "slot-a"; "slot-b"; "slot-c" ])
+    ~reviewer:
+      (recording_reviewer
+         calls
+         [ "slot-a", rate_limited; "slot-b", Ok (Some AR.Approve) ])
+    (fun () ->
+       let result = review () in
+       Alcotest.(check (list string))
+         "attempts follow the declared slot order and stop at the first verdict"
+         [ "slot-a"; "slot-b" ]
+         !calls;
+       Alcotest.(check string)
+         "gate"
+         "structured_tool"
+         (AR.gate_to_string result.AR.gate);
+       Alcotest.(check string)
+         "the winning slot is the recorded evaluator runtime"
+         "slot-b"
+         result.evaluator_runtime;
+       match result.verdict with
+       | Some AR.Approve -> ()
+       | Some (AR.Reject reason) -> Alcotest.failf "unexpected reject: %s" reason
+       | None -> Alcotest.fail "failover lost the second slot's verdict")
+;;
+
+let test_first_slot_success_never_fails_over () =
+  let calls = ref [] in
+  with_lane_and_reviewer
+    ~slots:(fun () -> Ok [ "slot-a"; "slot-b" ])
+    ~reviewer:(recording_reviewer calls [ "slot-a", Ok (Some AR.Approve) ])
+    (fun () ->
+       let result = review () in
+       Alcotest.(check (list string)) "one attempt only" [ "slot-a" ] !calls;
+       Alcotest.(check string) "evaluator runtime" "slot-a" result.evaluator_runtime)
+;;
+
+let test_invalid_verdict_fails_over () =
+  let calls = ref [] in
+  with_lane_and_reviewer
+    ~slots:(fun () -> Ok [ "slot-a"; "slot-b" ])
+    ~reviewer:
+      (recording_reviewer
+         calls
+         [ "slot-a", Ok None; "slot-b", Ok (Some (AR.Reject "missing evidence")) ])
+    (fun () ->
+       let result = review () in
+       Alcotest.(check (list string))
+         "a reply without a verdict tool call yields to the next slot"
+         [ "slot-a"; "slot-b" ]
+         !calls;
+       Alcotest.(check string) "evaluator runtime" "slot-b" result.evaluator_runtime;
+       match result.verdict with
+       | Some (AR.Reject reason) ->
+         Alcotest.(check string) "reason" "missing evidence" reason
+       | Some AR.Approve -> Alcotest.fail "unexpected approve"
+       | None -> Alcotest.fail "failover lost the second slot's verdict")
+;;
+
+let test_exhaustion_reports_the_last_attempt () =
+  let calls = ref [] in
+  with_lane_and_reviewer
+    ~slots:(fun () -> Ok [ "slot-a"; "slot-b" ])
+    ~reviewer:
+      (recording_reviewer calls [ "slot-a", rate_limited; "slot-b", budget_refusal ])
+    (fun () ->
+       let result = review () in
+       Alcotest.(check (list string)) "both slots tried" [ "slot-a"; "slot-b" ] !calls;
+       Alcotest.(check string)
+         "gate"
+         "evaluator_unavailable"
+         (AR.gate_to_string result.AR.gate);
+       Alcotest.(check string)
+         "the last attempted slot is the reported evaluator runtime"
+         "slot-b"
+         result.evaluator_runtime;
+       Alcotest.(check bool)
+         "the last attempt's non-retryable classification wins"
+         false
+         result.retryable;
+       Alcotest.(check bool) "no fabricated verdict" true (Option.is_none result.verdict))
+;;
+
+let test_unconfigured_lane_is_unavailable_not_rerouted () =
+  with_lane_and_reviewer
+    ~slots:
+      (fun () ->
+         Error
+           "exact-output lane \"verifier_exact\" is not configured")
+    ~reviewer:(recording_reviewer (ref []) [])
+    (fun () ->
+       let result = review () in
+       Alcotest.(check string)
+         "gate"
+         "evaluator_unavailable"
+         (AR.gate_to_string result.AR.gate);
+       Alcotest.(check string)
+         "no runtime is invented for a missing lane"
+         "unresolved"
+         result.evaluator_runtime;
+       Alcotest.(check bool) "retryable" true result.retryable;
+       match result.fallback_reason with
+       | Some detail ->
+         Alcotest.(check bool)
+           "the deferral names the lane"
+           true
+           (String_util.contains_substring detail "verifier_exact")
+       | None -> Alcotest.fail "unconfigured lane must carry a reason")
+;;
+
+let test_explicit_override_never_consults_the_lane () =
+  let calls = ref [] in
+  with_lane_and_reviewer
+    ~slots:(fun () -> Error "lane must not be consulted")
+    ~reviewer:(recording_reviewer calls [ "explicit-runtime", Ok (Some AR.Approve) ])
+    (fun () ->
+       let result =
+         AR.review
+           ~evaluator_runtime:"explicit-runtime"
+           ~lookup:AR.No_lookup_surface
+           ~base_path:(Filename.get_temp_dir_name ())
+           request
+       in
+       Alcotest.(check (list string)) "single attempt" [ "explicit-runtime" ] !calls;
+       Alcotest.(check string)
+         "evaluator runtime"
+         "explicit-runtime"
+         result.evaluator_runtime)
+;;
+
+(* ------------------------------------------------------------ *)
+(* Lane resolution through the published exact-output registry  *)
+(* ------------------------------------------------------------ *)
+
+let verifier_catalog =
+  {|
+[[providers]]
+id = "verifier_provider"
+kind = "openai_compat"
+base_url = "http://127.0.0.1:1"
+request_path = "/v1/chat/completions"
+api_key_env = ""
+capabilities_base = "openai_chat_extended"
+
+[[models]]
+id_prefix = "verifier-model"
+provider_name = "verifier_provider"
+max_context_tokens = 8192
+max_output_tokens = 1024
+supports_response_format_json = true
+supports_structured_output = false
+input_per_million = 1.0
+
+[[targets]]
+id = "verifier-a"
+provider_ref = "verifier_provider"
+model_id = "verifier-model"
+
+[[targets]]
+id = "verifier-b"
+provider_ref = "verifier_provider"
+model_id = "verifier-model"
+|}
+;;
+
+let load_verifier_snapshot () =
+  let io : Exact_output.resolver_io = { getenv = (fun _ -> Ok None) } in
+  match
+    Exact_output.load_resolver_snapshot
+      ~io
+      ~target_binding_policy:Exact_output.Exclude_unbound_targets
+      ~catalog:
+        (Exact_output.Full_replacement
+           { source = "test-verifier-lane"; contents = verifier_catalog })
+      ()
+  with
+  | Ok snapshot -> snapshot
+  | Error _ -> Alcotest.fail "verifier lane test catalog should load"
+;;
+
+(* Runs before any publication below: with no registry the judgement path
+   defers loudly instead of inventing a runtime. *)
+let test_unpublished_registry_is_an_explicit_error () =
+  match Runtime.verifier_exact_lane_slot_ids () with
+  | Error detail ->
+    Alcotest.(check bool)
+      "error explains the registry is not published"
+      true
+      (String_util.contains_substring detail "not been published")
+  | Ok slots ->
+    Alcotest.failf "unexpected slots without a published registry: %s"
+      (String.concat ", " slots)
+;;
+
+let test_lane_resolution_preserves_frozen_order_and_drops_rejected_slots () =
+  let snapshot = load_verifier_snapshot () in
+  (match
+     Runtime.publish_exact_output_registry
+       ~lanes:
+         [ { Runtime_schema.id = "verifier_exact"
+           ; slot_ids = [ "verifier-b"; "verifier-missing"; "verifier-a" ]
+           }
+         ; { Runtime_schema.id = "compaction_exact"; slot_ids = [ "verifier-a" ] }
+         ]
+       snapshot
+   with
+   | Ok _ -> ()
+   | Error detail -> Alcotest.failf "lane publication failed: %s" detail);
+  match Runtime.verifier_exact_lane_slot_ids () with
+  | Error detail -> Alcotest.failf "verifier_exact lane should resolve: %s" detail
+  | Ok slots ->
+    Alcotest.(check (list string))
+      "admitted slots keep declaration order; the catalog-missing slot is dropped"
+      [ "verifier-b"; "verifier-a" ]
+      slots
+;;
+
+let () =
+  configure_prompt_registry ();
+  Alcotest.run
+    "verifier_exact_lane"
+    [ ( "frozen-order failover"
+      , [ Alcotest.test_case
+            "failover follows declared slot order"
+            `Quick
+            test_failover_follows_declared_slot_order
+        ; Alcotest.test_case
+            "first slot success never fails over"
+            `Quick
+            test_first_slot_success_never_fails_over
+        ; Alcotest.test_case
+            "invalid verdict fails over"
+            `Quick
+            test_invalid_verdict_fails_over
+        ; Alcotest.test_case
+            "exhaustion reports the last attempt"
+            `Quick
+            test_exhaustion_reports_the_last_attempt
+        ; Alcotest.test_case
+            "unconfigured lane is unavailable, not rerouted"
+            `Quick
+            test_unconfigured_lane_is_unavailable_not_rerouted
+        ; Alcotest.test_case
+            "explicit override never consults the lane"
+            `Quick
+            test_explicit_override_never_consults_the_lane
+        ] )
+    ; ( "lane resolution"
+      , [ Alcotest.test_case
+            "unpublished registry is an explicit error"
+            `Quick
+            test_unpublished_registry_is_an_explicit_error
+        ; Alcotest.test_case
+            "resolution preserves frozen order and drops rejected slots"
+            `Quick
+            test_lane_resolution_preserves_frozen_order_and_drops_rejected_slots
+        ] )
+    ]
+;;


### PR DESCRIPTION
## What / Why

RFC-0361 D7(a) 코드 1단계: Verifier/completion-authority judgement call(`Task.Anti_rationalization.review`)을 전용 exact-output lane `verifier_exact` 위에서 실행한다. judgement 경로의 provider 선택은 이제 published lane의 admitted slots(frozen declaration order) 하나뿐이며, slot failover는 librarian/compaction lane과 같은 계약을 따른다: 각 slot을 선언 순서대로 최대 1회 시도하고, provider `Error`(retryability 무관) 또는 유효 verdict tool call 없는 응답(`Ok None`)이면 다음 slot으로 넘어가며, terminal result는 마지막 시도를 기술한다(단일 slot = 기존 동작과 동일).

## SSOT choice: absorb (흡수)

- `[runtime].cross_verifier` 단일 runtime 바인딩을 제거하고, 그 값(`deepseek.deepseek-v4-pro`)을 `verifier_exact` lane의 **slot 1**으로 흡수. seed failover slot은 `glm-coding.glm-5-turbo` (`config/runtime.toml:40-46`).
- judgement 경로는 lane만 resolve한다 — cross_verifier 읽기도, `[runtime].default` fallback도 없다 (`lib/task/anti_rationalization.ml:289-330`).
- rationale: lane machinery가 이미 slot 검증/ admission(`resolve_lane`이 catalog-missing slot을 drop)을 수행하고, reload 경로가 TOML을 문자 그대로 재parse하므로 "참조형" lane을 합성하면 drift가 생긴다. absorb는 selector를 정확히 하나로 유지한다.
- `[runtime].cross_verifier`는 preserved live configs를 위해 parse 가능하게 유지하되 아무것도 선택하지 않는다 (`lib/runtime/runtime_schema.ml:320`, `lib/runtime/runtime.ml`의 `cross_verifier_runtime_id` doc).

## Evidence (file:line)

- Lane 상수/해결: `lib/runtime/runtime.ml:707-730` (`verifier_exact_lane_id`, `verifier_exact_slot_ids_of_lane_decls`), `runtime.ml` `verifier_exact_lane_slot_ids` — published registry(`Runtime_exact_output_registry.current` + `resolve_lane`)에서 frozen order로 slot id 반환, 실패 시 이유를 담은 `Error` (fallback 없음).
- Hook 교체: `Workspace_hooks.get_cross_verifier_runtime_id_fn` 삭제 → `get_verifier_exact_lane_slot_ids_fn : (unit -> (string list, string) result) Atomic.t`, unconnected default는 명시적 `Error` (`lib/workspace/workspace_hooks.ml:256-264`); `lib/mcp_server.ml:1093-1095`에서 `Runtime.verifier_exact_lane_slot_ids`로 wiring.
- Failover 구현: `lib/task/anti_rationalization.ml` `review` — `resolve_evaluator_slots`(override → 단일 slot lane) + `attempt` 재귀(`Ok (Some _)`에서 정지, `Error`/`Ok None`에서 다음 slot으로). `evaluator_runtime` in review_result = winning/last slot → 기존 D3 Verification_run_registry observability가 그대로 먹는다.
- Boot 시 optional lane 경고: `lib/server/server_runtime_bootstrap.ml` — `warn_optional_exact_output_lane ~lane_id:Runtime.verifier_exact_lane_id ~feature:"completion authority"` (librarian/compaction과 동일). 미구성 lane은 call time에 evaluator_unavailable deferral, silent reroute 없음.
- Request-body-cap validation 유지: `keeper_dispatch_runtime_ids`/`validate_keeper_dispatch_request_caps`에 `~verifier_exact_slot_ids` 추가 — cross_verifier 경로가 담당하던 verifier route의 startup cap 검증을 lane slots로 계승 (`lib/runtime/runtime.ml:739-770`, call sites 4곳).

## Tests / CI wiring

- 신규 `test/test_verifier_exact_lane.ml` (stanza `test/stanzas/test_verifier_exact_lane.inc`, `test/dune` include): failover 순서, 첫 slot 성공 시 failover 없음, invalid verdict failover, 소진 시 last-attempt `retryable=false`, 미구성 lane → unresolved/unavailable, override는 lane 미참조, unpublished registry → 명시적 Error, publish 후 frozen order + rejected slot drop (credential-free inline catalog).
- 기존 review-driving 테스트에 lane hook stub 추가: `test_verification.ml`(2곳, save/restore), `test_tool_task_coverage.ml`, `test_telemetry_task_transition_10358.ml`, `test_completion_trust_harness.ml`, `test_mcp_server_eio.ml`.
- `test/test_runtime_config_validity.ml`: seed lane-id pin에 `verifier_exact` 추가, slot-order pin(`Some ["deepseek.deepseek-v4-pro"; "glm-coding.glm-5-turbo"]`), `cross_verifier = None` pin, dispatch enumeration에 verifier slot 포함/중복 제거 검증.
- CI: `scripts/ci-run-focused-tests.sh`에 `@test/runtest-test_verifier_exact_lane` 추가.

## Caveats

- **로컬 빌드/테스트 미실행**(규칙상 CI가 검증). ocamlformat은 repo 전역 `disable = true`라 포맷 변경 없음.
- Dashboard의 runtime-defaults JSON/route(`set_runtime_cross_verifier`)와 `eval_calibration` CLI default는 여전히 legacy `cross_verifier` key를 읽는다 — config surface일 뿐 judgement에 영향 없음. 대시보드에서 cross_verifier를 편집해도 judgement routing은 바뀌지 않는다(후속 정리 대상).
- Lane은 optional: 라이브 config에 `[runtime.exact_output_lanes.verifier_exact]`가 없으면 judgement가 evaluator_unavailable로 defer된다(기존 default-runtime 상속과 달리 의도된 fail-loud). 배포 시 라이브 `runtime.toml`에 lane 선언 복사 필요 — seed 주석에 명시됨.
- Seed failover slot `glm-coding.glm-5-turbo`는 catalog상 `supports-tool-choice = false`라 forced tool choice는 slot 1에서만 쓰인다(기존 reviewer provider config 그대로).

Refs: RFC-0361 D7(a) (#29147 후속)
