### PR TITLE
test(keeper): assert observed effect disposition in Codex and Claude fence tests

### DIFF
--- a/test/test_keeper_claude_code_runtime.ml
+++ b/test/test_keeper_claude_code_runtime.ml
@@ -871,6 +871,11 @@ let test_post_effect_transport_enters_recovery () =
                    (Keeper_internal_error.Provider_attempt_effect_fenced
                       { effect_disposition; _ }) ->
                  check
+                   string
+                   "the fence observed the transport interruption (fail-closed Observation_unavailable)"
+                   "observation_unavailable"
+                   (Keeper_provider_attempt_effect.to_string effect_disposition);
+                 check
                    bool
                    "post-effect failure is fenced against same-turn retry"
                    false

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -1586,6 +1586,11 @@ let test_keeper_does_not_retry_context_error_after_tool_effect () =
               (Keeper_internal_error.Provider_attempt_effect_fenced
                  { effect_disposition; diagnostic; _ }) ->
             check
+              string
+              "the fence observed a tool effect (not Observation_unavailable)"
+              "effect_attempted"
+              (Keeper_provider_attempt_effect.to_string effect_disposition);
+            check
               bool
               "the fence forbids same-turn retry"
               false


### PR DESCRIPTION
## Summary

PR #28252 merged two typed-fence tests that only asserted `allows_same_turn_retry = false`, so both `Effect_attempted` and `Observation_unavailable` stayed green — an effect-observer regression would go undetected.

This pins the exact observed disposition so the tests fail closed:

- **test_runtime_codex_app_server.ml** (`test_keeper_does_not_retry_context_error_after_tool_effect`): the Codex fixture observes the tool effect, so it now asserts `effect_disposition = Effect_attempted` (`"effect_attempted"`).
- **test_keeper_claude_code_runtime.ml** (`test_post_effect_transport_enters_recovery`): the post-effect transport fixture interrupts the stream before the tool result is observed, so it pins the fail-closed `Observation_unavailable` disposition (`"observation_unavailable"`).

Both keep the same-turn-retry and recovery assertions intact.

## Verification

- `dune build test/test_runtime_codex_app_server.exe test/test_keeper_claude_code_runtime.exe` — OK
- `dune exec test/test_keeper_claude_code_runtime.exe` — 16/16 OK (incl. both fence tests)
- `dune exec test/test_runtime_codex_app_server.exe` — fence test 42 `[OK]` (4 unrelated pre-existing subscription-boundary timeout failures 21/24/25/26)

## Acceptance
- [x] `test_runtime_codex_app_server.ml` asserts `Effect_attempted` for the after-tool-effect fence scenario
- [x] `test_keeper_claude_code_runtime.ml` asserts `Effect_attempted` for the post-effect recovery scenario
- [x] The focused tests fail when the fixture emits `Observation_unavailable` instead of `Effect_attempted` (claude test pins `observation_unavailable` fail-closed)

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`rondo/task-281-effect-disposition` → `main` · 1 commit(s) · synced 2026-08-21T02:58:44Z

| sha | subject | date |
|---|---|---|
| `b052c43fa` | test(keeper): assert observed effect disposition in Codex and Claude … | 2026-08-21 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->