### PR TITLE
fix(dashboard): nested ternary 3건 수정 + pnpm lint를 CI에 배선 (#29054)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2260,6 +2260,12 @@ jobs:
         working-directory: dashboard
         run: pnpm run typecheck
 
+      # Nothing ran pnpm lint before this, which is how three
+      # no-nested-ternary errors reached main and stayed there (#29054).
+      - name: ESLint
+        working-directory: dashboard
+        run: pnpm lint
+
       - name: Run dashboard tests
         working-directory: dashboard
         run: pnpm test

--- a/dashboard/src/components/keeper-tool-call-inspector.test.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.test.ts
@@ -235,3 +235,27 @@ describe('deriveKeeperToolCallDossier outcome', () => {
     expect(dossier.tone).toBe('ok')
   })
 })
+
+describe('latest call tone', () => {
+  // The tone, the colour class and the glyph all read one resolver now.
+  // These pin the three outcomes it can return, plus the empty case, so a
+  // fourth outcome cannot land on one surface and miss the others.
+  const latestTone = (entries: Parameters<typeof deriveKeeperToolCallDossier>[0]) =>
+    deriveKeeperToolCallDossier(entries, null).cards.find(c => c.key === 'latest')?.tone
+
+  it('reads ok for a successful call', () => {
+    expect(latestTone([toolCall({ success: true })])).toBe('ok')
+  })
+
+  it('reads warn for a deferred call', () => {
+    expect(latestTone([toolCall({ success: false, disposition: 'deferred' })])).toBe('warn')
+  })
+
+  it('reads bad for a failed call', () => {
+    expect(latestTone([toolCall({ success: false })])).toBe('bad')
+  })
+
+  it('reads neutral when there is no call at all', () => {
+    expect(latestTone([])).toBe('neutral')
+  })
+})

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -361,6 +361,34 @@ function toolCallStatusLabel(entry: ToolCallEntry): string {
   return entry.disposition ?? (toolCallSucceeded(entry) ? 'completed' : 'failed')
 }
 
+/** succeeded / deferred / neither, resolved once so the three places that
+    branch on it (tone, colour, glyph) cannot drift apart. */
+type ToolCallOutcome = 'ok' | 'deferred' | 'failed'
+
+function toolCallOutcome(entry: ToolCallEntry): ToolCallOutcome {
+  if (toolCallSucceeded(entry)) return 'ok'
+  if (toolCallDeferred(entry)) return 'deferred'
+  return 'failed'
+}
+
+const TOOL_CALL_OUTCOME_TONE: Record<ToolCallOutcome, StatusChipTone> = {
+  ok: 'ok',
+  deferred: 'warn',
+  failed: 'bad',
+}
+
+const TOOL_CALL_OUTCOME_COLOR: Record<ToolCallOutcome, string> = {
+  ok: 'text-[var(--color-status-ok)]',
+  deferred: 'text-[var(--color-status-warn)]',
+  failed: 'text-[var(--color-status-err)]',
+}
+
+const TOOL_CALL_OUTCOME_GLYPH: Record<ToolCallOutcome, string> = {
+  ok: 'O',
+  deferred: 'D',
+  failed: 'X',
+}
+
 export function deriveKeeperToolCallDossier(
   entries: readonly ToolCallEntry[],
   response: TelemetryFreshnessMetadata | null | undefined,
@@ -378,10 +406,8 @@ export function deriveKeeperToolCallDossier(
   const totalCalls = entries.length
   const failedCount = failed.length
   const deferredCount = deferred.length
-  let latestTone: StatusChipTone = 'neutral'
-  if (latest !== null) {
-    latestTone = toolCallSucceeded(latest) ? 'ok' : toolCallDeferred(latest) ? 'warn' : 'bad'
-  }
+  const latestTone: StatusChipTone =
+    latest === null ? 'neutral' : TOOL_CALL_OUTCOME_TONE[toolCallOutcome(latest)]
 
   let headline = 'no calls'
   if (totalCalls > 0 && failedCount > 0) {
@@ -745,14 +771,10 @@ function ToolCallRow({ entry }: { entry: ToolCallEntry }) {
           ${entry.duration_ms != null ? formatMsCompact(entry.duration_ms) : NO_DURATION_LABEL}
         </span>
         <span
-          class=${`flex-shrink-0 w-5 text-center ${toolCallSucceeded(entry)
-            ? 'text-[var(--color-status-ok)]'
-            : toolCallDeferred(entry)
-              ? 'text-[var(--color-status-warn)]'
-              : 'text-[var(--color-status-err)]'}`}
+          class=${`flex-shrink-0 w-5 text-center ${TOOL_CALL_OUTCOME_COLOR[toolCallOutcome(entry)]}`}
           title=${toolCallStatusLabel(entry)}
         >
-          ${toolCallSucceeded(entry) ? 'O' : toolCallDeferred(entry) ? 'D' : 'X'}
+          ${TOOL_CALL_OUTCOME_GLYPH[toolCallOutcome(entry)]}
         </span>
         <span class="flex-shrink-0 w-4 text-[var(--color-fg-muted)] text-center">
           ${expanded.value ? '-' : '+'}


### PR DESCRIPTION
## 증상

`main`에서 `cd dashboard && pnpm lint`가 **3 errors**입니다.

```
383:18  error  Do not nest ternary expressions  no-nested-ternary
748:52  error  Do not nest ternary expressions  no-nested-ternary
755:13  error  Do not nest ternary expressions  no-nested-ternary
```

제가 직접 돌려 이슈와 같은 위치를 확인했습니다. #29015가 들어오며 유입됐고, **어떤 워크플로도 `pnpm lint`를 돌리지 않아서** 지금까지 남아 있었습니다(dashboard job은 typecheck·test·e2e 2종만).

## 세 곳이 같은 사다리를 반복하고 있었습니다

succeeded → deferred → 나머지, 이 순서를 세 번 씁니다. 각각 chip tone, 색상 클래스, 글리프로요.

각각을 중첩 if/else로 풀면 lint는 통과하지만 **사다리 사본이 셋 그대로** 남습니다. 결과를 한 번만 판정하고 매핑을 나누는 쪽으로 바꿨습니다.

```typescript
type ToolCallOutcome = 'ok' | 'deferred' | 'failed'

function toolCallOutcome(entry: ToolCallEntry): ToolCallOutcome {
  if (toolCallSucceeded(entry)) return 'ok'
  if (toolCallDeferred(entry)) return 'deferred'
  return 'failed'
}

const TOOL_CALL_OUTCOME_TONE:  Record<ToolCallOutcome, StatusChipTone> = { … }
const TOOL_CALL_OUTCOME_COLOR: Record<ToolCallOutcome, string> = { … }
const TOOL_CALL_OUTCOME_GLYPH: Record<ToolCallOutcome, string> = { … }
```

`Record<ToolCallOutcome, …>`라 네 번째 결과가 생기면 **세 매핑 모두** 컴파일 에러가 납니다. 한 곳만 고치고 나머지를 놓치는 일이 안 생깁니다.

## 게이트

dashboard job의 typecheck 다음에 `pnpm lint`를 넣었습니다.

**순서를 지켰습니다** — 고치기 전에 배선하면 main이 다른 체크로 붉어집니다. 오늘 #29103이 그 순서를 뒤집어 main red를 만들었고(통과 확인 없이 CI에 스위트를 배선), 그걸 푸는 데 세 회차가 들었습니다. 같은 실수를 반복하지 않으려고 고침 → 검증 → 배선 순으로 했습니다.

## 검증

`dashboard/node_modules`를 빌려 로컬에서 셋 다 돌렸습니다.

| | |
|---|---|
| `pnpm lint` | exit **0** |
| `pnpm typecheck` | exit **0** |
| `pnpm test` | exit **0** |

`ci.yml`은 YAML 파싱으로 확인했습니다.

Closes #29054
