### PR TITLE
fix(lint): residue 스캔이 공백 든 경로를 쪼개던 문제 (#29056)

### DIFF
--- a/scripts/lint/no-synthetic-tool-call-residue.sh
+++ b/scripts/lint/no-synthetic-tool-call-residue.sh
@@ -49,7 +49,8 @@ trap 'rm -f "$current_tmp"' EXIT
       -o -type f -print
   done
 } | sort -u \
-  | xargs rg --with-filename --no-heading --line-number --color=never \
+  | tr '\n' '\0' \
+  | xargs -0 rg --with-filename --no-heading --line-number --color=never \
       "$RESIDUE_PATTERN" \
   | while IFS=: read -r path line content; do
       [[ -n "${path:-}" && -n "${line:-}" ]] || continue


### PR DESCRIPTION
## 증상

Lint Suite 로그에 이런 줄이 남습니다.

```
rg: dashboard/prototypes/keeper-v2/Keeper: No such file or directory (os error 2)
rg: Agent: No such file or directory (os error 2)
rg: v3.html: No such file or directory (os error 2)
```

## 어디서

이슈는 `run-lint-suite.sh` 계열로 추정했는데, 실제로는 그것이 부르는 lint 하나입니다. 실패 그룹 이름(`Synthetic tool-call residue ratchet`)을 따라가면 나옵니다.

```bash
# scripts/lint/no-synthetic-tool-call-residue.sh:46-53
    find "$root" … -type f -print      # 개행으로 끊고
  done
} | sort -u \
  | xargs rg …                          # xargs는 공백도 구분자로 본다
```

`Keeper Agent v3.html`이 rg에 **세 인자**로 도착하고 셋 다 없는 파일입니다. 로그의 여섯 줄이 유일한 흔적이고, **정작 그 파일은 스캔되지 않은 채 래칫이 통과**합니다.

## 변경

저장소에 이미 같은 모양이 있어 그대로 따랐습니다.

```bash
# turn-path-provider-agnostic-gate.sh:78-80
printf '%s\n' "${list}" | tr '\n' '\0' | xargs -0 rg …
```

`sort`는 개행 상태로 두고 그 뒤에서 null로 바꿉니다. GNU `sort -z`가 필요 없고, `tr`은 POSIX이며 `xargs -0`은 BSD에도 있어서 **CI ubuntu와 macOS 체크아웃에서 같게 동작**합니다.

`xargs -d '\n'`이나 `mapfile`도 되지만 각각 GNU xargs와 bash 4+를 요구합니다. 저장소 관례(`xargs -0`이 네 스크립트에서 쓰임)와 호환성 둘 다 이쪽이 맞습니다.

## 검증

이 트리에 공백 든 파일이 둘 있습니다(`Keeper Agent v3.html`, `v4.html`).

| | `os error 2` | 결과 |
|---|---|---|
| 수정 전 | **6건** | 두 파일 미스캔, 래칫은 통과 |
| 수정 후 | **0건** | 래칫 OK |

## 남는 한계

파일명에 개행이 든 경우는 여전히 깨집니다 — `find -print`가 개행으로 끊으니까요. `-print0`까지 가면 `sort -z`가 필요해지고 macOS 호환이 깨집니다. 실제 사례가 없어 여기서 멈췄습니다.

Closes #29056
