### PR TITLE
fix(keeper): keeper_list 행의 runtime_id 중복 제거

### DIFF
--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -321,7 +321,6 @@ let keeper_list_row_json ~runtime_class config name =
             ("status", `String status); ("keepalive_running", `Bool keepalive_running);
             ("autoboot_enabled", `Bool meta.autoboot_enabled); ("proactive_enabled", `Bool meta.proactive.enabled);
             ("runtime_id", `String (Keeper_meta_contract.runtime_id_of_meta meta));
-            ("runtime_id", `String (Keeper_meta_contract.runtime_id_of_meta meta));
             ("created_at", `String meta.created_at); ("updated_at", `String meta.updated_at);
           ]))
 let with_keeper_name args name =


### PR DESCRIPTION
## 무엇

`keeper_list_row_json`이 같은 항목을 두 번 넣고 있었습니다.

```ocaml
("runtime_id", `String (Keeper_meta_contract.runtime_id_of_meta meta));
("runtime_id", `String (Keeper_meta_contract.runtime_id_of_meta meta));
```

같은 키, 같은 함수, 같은 인자입니다. 그래서 모든 keeper_list 행이 `runtime_id`를 두 번 실어 보냈습니다.

## 출력은 안 바뀝니다

두 항목이 **같은 값**으로 풀리므로, 앞 쌍을 읽는 소비자와 뒤 쌍을 읽는 소비자가 이미 같은 답을 보고 있었습니다. 필드를 지우는 게 아니라 중복을 지웁니다. `runtime_id`는 dashboard 68파일·test 71파일이 읽는데 어느 쪽도 차이를 못 느낍니다.

## 전수 확인

`lib/` 전체에서 인접한 동일 Assoc 키를 훑었더니 **이 한 곳뿐**입니다.

```
인접 동일 키 줄: 1건
  lib/keeper/keeper_tool_surface_ops.ml 323
```

## 확인 못 한 것

`git log -L`은 이 줄의 마지막 변경으로 #19591(dashboard Cascade 필드 rename, 05-31)을 가리키는데, 그 커밋의 파일 목록에 이 파일이 없습니다. 그래서 **원래 두 개의 다른 키였다가 rename으로 합쳐진 것인지, 처음부터 복붙 실수였는지는 못 정했습니다.** 만약 전자라면 사라진 쪽 필드를 복원해야 하지만, 지금 트리만 봐서는 근거가 없어 중복 제거로만 두었습니다.
