### PR TITLE
test(keeper): msg_async 전역 테이블을 공용 eio 래퍼에서 정리 (#29024 가설)

### DIFF
--- a/test/test_keeper_mutex_coverage.ml
+++ b/test/test_keeper_mutex_coverage.ml
@@ -122,6 +122,13 @@ let with_eio_env f =
   Eio_guard.enable ();
   Fun.protect
     ~finally:(fun () ->
+      (* Keeper_msg_async keeps seven process-wide tables (pending,
+         transition_locks, active_switches, store_transition_locks,
+         reserved_request_ids, keeper_submission_locks,
+         keeper_persistence_locks). Only 10 of the 39 msg_async cases used to
+         clear them, so the other 29 handed their leftovers to whatever ran
+         next. Clearing here covers every case, including ones added later. *)
+      Keeper_msg_async.For_testing.clear ();
       Fs_compat.clear_fs ();
       Eio_guard.disable ())
     (fun () -> f env)


### PR DESCRIPTION
## 발견

`Keeper_msg_async`는 프로세스 전역 테이블을 **일곱 개** 들고 있습니다.

```ocaml
(* keeper_msg_async.ml:2858 *)
let clear () =
  with_lock (fun () ->
    Request_table.clear pending;
    Request_table.clear transition_locks;
    Request_table.clear active_switches;
    Store_transition_table.clear store_transition_locks;
    Store_transition_table.clear reserved_request_ids;
    Keeper_lane_table.clear keeper_submission_locks;
    Keeper_lane_table.clear keeper_persistence_locks)
```

그런데 이걸 정리하는 테스트는 일부뿐입니다.

```
test_keeper_msg_async_* 함수 정의 : 39개
For_testing.clear 호출            : 10개
```

**29개가 자기 항목을 남긴 채 끝납니다.**

## 왜 여기에 넣나

`with_eio_env`가 이미 42개 케이스를 감싸고 `Fs_compat`·`Eio_guard` 정리를 맡고 있습니다. 같은 자리에 두면 **나중에 추가되는 케이스도 자동으로 덮입니다** — 누가 기억해서 opt-in 할 필요가 없어집니다.

이미 자기 `Fun.protect`에서 clear를 부르는 10개는 그대로 둡니다. 빈 테이블을 지우는 건 no-op입니다.

## 확증하지 못한 것

**이게 #29024를 닫는다고 주장하지 않습니다.** 가설입니다.

근거는 이 정도입니다. 가장 자주 깨지는 두 케이스(16 live-cancel, 25 integrity-ambiguity — 08-19에 각각 3회)가 **둘 다 이 테이블들이 먹이는 공유 상태를 읽습니다.** 남은 항목이 순서·타이밍 의존 실패를 만들 수 있는 자리라는 뜻이지, 실제로 그랬다는 증거는 아닙니다.

판정은 CI 반복 실행으로만 가능합니다. 로컬에서 OCaml을 빌드하지 않으므로 여기서 재현해 보지는 못했습니다.

## 오늘의 비용

| 시각 | PR | 케이스 |
|---|---|---|
| 11:58Z | #29114 | 25 |
| 13:19Z | #29131 | 15 |
| 17:35Z | #29150 | 16, 24, 25 |
| 20:36Z | #29157 | 16, 25 |
| 21:57Z | #29162 | 16 |

최근 ci.yml 100건 중 실패 9건이고 그중 **최소 5건이 이 하나**입니다. 다섯 PR 모두 이 스위트와 무관한 변경이었고, 마지막은 JSON 중복 한 줄을 지우기만 했습니다.

Refs #29024
