### PR TITLE
docs+test(dashboard): pin autonomous-row id contract, banner count test

### DIFF
--- a/dashboard/docs/API_CONTRACT.md
+++ b/dashboard/docs/API_CONTRACT.md
@@ -114,6 +114,12 @@ rows written through idempotent operation paths. Plain append rows omit it.
 Consumers correlate accepted operations by exact `operation_id`; omission is
 a real domain case, not a value to backfill.
 
+Every history row — including autonomous-turn rows projected from typed turn
+records rather than the chat store — must carry a non-blank `id`. The schema
+(`keeper-chat-history.ts`) requires it and drops any row without one without
+an error surface. #29108 restored the autonomous projection's id after it was
+lost to a refactor that predated the required-id contract.
+
 ## Non-goals
 
 - OCaml-to-TypeScript schema code generation.

--- a/dashboard/src/api/schemas/keeper-chat-history.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.ts
@@ -269,7 +269,10 @@ const KeeperAutonomousTurnSchema = object({
 
 export const KeeperChatHistoryMessageSchema = object({
   // Current-record contract: keeper_chat_store mints a stable id on every
-  // append and rejects persisted rows whose id is absent or blank.
+  // append and rejects persisted rows whose id is absent or blank. Rows
+  // projected outside the chat store (autonomous turns via
+  // Keeper_autonomous_turn_source) must mint one too — safeParse drops any
+  // row without a non-blank id, with no error surface.
   id: string(),
   role: string(),
   // Autonomous turns can complete through tools without terminal prose. The

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -171,7 +171,7 @@ import {
   resetToolCallOutputs,
 } from '../tool-call-output-store'
 import { shellAuthSummary } from '../store'
-import { chatShowAutonomous } from '../lib/chat-view-prefs'
+import { chatShowAutonomous, chatShowInternal } from '../lib/chat-view-prefs'
 import type { KeeperConversationEntry } from '../types'
 import {
   KeeperConversationPanel,
@@ -248,6 +248,7 @@ describe('KeeperConversationPanel', () => {
     keeperThreads.value = {}
     keeperSending.value = {}
     chatShowAutonomous.value = true
+    chatShowInternal.value = true
     keeperHydrating.value = {}
     keeperStatusDetails.value = {}
     keeperActionErrors.value = {}
@@ -387,6 +388,66 @@ describe('KeeperConversationPanel', () => {
     await waitFor(() => {
       expect(container.textContent).not.toContain('자율턴')
     })
+    expect(container.textContent).toContain('직접 질문')
+  })
+
+  it('internal-message banner count excludes autonomously hidden turns', async () => {
+    keeperThreads.value = {
+      sangsu: [
+        {
+          id: 'world',
+          role: 'user',
+          source: 'world_state_prompt',
+          label: 'system',
+          text: '## Current World State',
+          rawText: '## Current World State',
+          timestamp: '2026-03-24T00:00:00.000Z',
+          delivery: 'history',
+          streamState: null,
+          details: null,
+          error: null,
+        },
+        {
+          id: 'direct-user',
+          role: 'user',
+          source: 'direct_user',
+          label: '사용자',
+          text: '직접 질문',
+          rawText: '직접 질문',
+          timestamp: '2026-03-24T00:01:00.000Z',
+          delivery: 'history',
+          streamState: null,
+          details: null,
+          error: null,
+        },
+        {
+          id: 'autonomous-1',
+          role: 'assistant',
+          source: 'autonomous_turn',
+          label: 'sangsu',
+          text: '자율 작업 결과',
+          rawText: '자율 작업 결과',
+          timestamp: '2026-03-24T00:02:00.000Z',
+          delivery: 'history',
+          streamState: null,
+          details: null,
+          error: null,
+        },
+      ],
+    }
+    chatShowInternal.value = false
+    chatShowAutonomous.value = false
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="메시지 입력..." />`,
+      container,
+    )
+    await Promise.resolve()
+
+    // Only the world-state prompt counts as a hidden internal message; the
+    // autonomous turn was hidden by its own toggle and must not inflate it.
+    expect(container.textContent).toContain('1개의 내부 메시지가 숨겨져 있습니다')
+    expect(container.textContent).not.toContain('자율턴')
     expect(container.textContent).toContain('직접 질문')
   })
 

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -1462,6 +1462,9 @@ function autonomousTurnEntry(
     ?.flatMap(block => block.t === 'trace' ? block.trace : [])
   const blocks = normalizedBlocks?.filter(block => block.t !== 'trace')
   return {
+    // Re-minted from turn_id, NOT the raw row's `autonomous:<turn_id>` id:
+    // that backend field exists only to satisfy the history schema's
+    // required-id check (keeper-chat-history.ts) and is never read here.
     id: `autonomous-${turnId}`,
     role: 'assistant',
     source: 'autonomous_turn',

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -1302,7 +1302,9 @@ let keeper_chat_history_freshness config name =
    typed turn identity only for stable dashboard grouping and exact raw-trace
    lookup; it is not the Keeper's semantic continuity mechanism. Final text
    and work trace come from the same exact AGENT_CORE run. The [id] is required:
-   the dashboard history schema drops any row without one. *)
+   the dashboard history schema drops any row without one. Its value is a pure
+   schema satisfier -- the dashboard re-mints its entry id from
+   [autonomous_turn.turn_id] and never reads this field. *)
 let autonomous_turn_json (turn : Keeper_autonomous_turn_source.turn) =
   let trace_fields =
     match turn.trace with


### PR DESCRIPTION
## #29108 적대적 리뷰 후속

머지된 #29108의 리뷰에서 나온 Minor 항목 중 실질적 가치가 있는 3건 처리:

1. **이중 id 어휘 문서화** — 백엔드 raw id `autonomous:<turn_id>`는 스키마 필수 id 충족용이고, 대시보드는 `autonomous_turn.turn_id`에서 entry id를 재합성해 raw id를 읽지 않음. 양쪽에 주석 추가 (미래 소비자가 두 id를 비교하다 조용히 miss하는 함정 방지)
2. **계약 불변식 기록** — "모든 history 행(채팅 스토어 밖에서 projection된 자율턴 행 포함)은 비어있지 않은 id가 필요, 없으면 무음 drop"을 `API_CONTRACT.md`와 스키마 주석에 명시. #7821dd3bc9가 이 불변식을 놓친 게 이번 회귀의 원인
3. **배너 카운트 테스트** — `showInternal=false + showAutonomous=false` 조합에서 "N개의 내부 메시지" 배너가 자율턴을 세지 않음을 고정

## 검증

- vitest 65/65 (keeper-shared / tweaks-panel / keeper-chat-history, 신규 배너 테스트 포함)
- `tsc --noEmit` 통과
- `ocamlformat --check` 통과 (ml 주석 변경)