### PR TITLE
feat(harness): RW22 — 선언한 범위가 Goal·Task 검증을 거쳐 실제 동작으로 증명된다

### DIFF
--- a/scripts/fixtures/keeper-multi-collaboration/missions.json
+++ b/scripts/fixtures/keeper-multi-collaboration/missions.json
@@ -268,9 +268,9 @@
       "phase": "coverage_proof",
       "name": "declared_scope_full_coverage",
       "actors": ["researcher", "builder-a", "builder-b", "reviewer"],
-      "capabilities": ["Task", "Log", "Cross-Verification", "Sandbox", "Execute"],
-      "user_story": "선언한 대상 범위의 모든 케이스가 실행으로 증명된다. 구현자와 시험자가 나뉘고, 시험 실행이 케이스별 고유 토큰을 durable Execute row에 남기며, 검증자는 명세의 케이스 집합과 실행이 낸 토큰 집합을 대조한다. 부분 실행은 통과하지 못한다 — 한 케이스라도 빠지면 미션이 실패한다.",
-      "assertions": ["qa_coverage_execution_observed", "qa_coverage_review_matches_spec"],
+      "capabilities": ["Goal", "Task", "Verification", "Cross-Verification", "Sandbox", "Execute", "Log"],
+      "user_story": "선언한 대상 범위의 모든 케이스가 실제 동작으로 증명된다. 케이스는 서로 다른 변환이라 상수를 출력하는 스크립트는 아무것도 덮지 못한다. 구현자와 시험자가 각자 Task를 claim해 Goal에 연결하고 keeper_task_done으로 evidence를 제출하므로 완료는 자기 선언이 아니라 검증 제출이며, 검증자가 선언된 범위와 실행이 낸 결과를 대조한다. 부분 실행은 통과하지 못한다.",
+      "assertions": ["qa_coverage_execution_observed", "qa_coverage_enters_verification_flow", "qa_coverage_review_matches_spec"],
       "evidence": ["observations/board-post.json", "observations/tool-calls-builder-b.json"]
     }
   ]

--- a/scripts/fixtures/keeper-multi-collaboration/missions.json
+++ b/scripts/fixtures/keeper-multi-collaboration/missions.json
@@ -269,8 +269,8 @@
       "name": "declared_scope_full_coverage",
       "actors": ["researcher", "builder-a", "builder-b", "reviewer"],
       "capabilities": ["Goal", "Task", "Verification", "Cross-Verification", "Sandbox", "Execute", "Log"],
-      "user_story": "선언한 대상 범위의 모든 케이스가 실제 동작으로 증명된다. 케이스는 서로 다른 변환이라 상수를 출력하는 스크립트는 아무것도 덮지 못한다. 구현자와 시험자가 각자 Task를 claim해 Goal에 연결하고 keeper_task_done으로 evidence를 제출하므로 완료는 자기 선언이 아니라 검증 제출이며, 검증자가 선언된 범위와 실행이 낸 결과를 대조한다. 부분 실행은 통과하지 못한다.",
-      "assertions": ["qa_coverage_execution_observed", "qa_coverage_enters_verification_flow", "qa_coverage_review_matches_spec"],
+      "user_story": "선언한 대상 범위의 모든 케이스가 실제 동작으로 증명된다. 케이스는 서로 다른 변환이라 상수를 출력하는 스크립트는 아무것도 덮지 못한다. 구현자와 시험자가 각자 Task를 claim해 Goal에 연결하고 keeper_task_done으로 evidence를 제출하며, 독립 completion authority가 두 Task를 awaiting_verification에서 done으로 넘겨야 한다 — 제출은 완료가 아니다. 검증자는 선언된 범위와 실행이 낸 결과를 대조한다. 부분 실행은 통과하지 못한다.",
+      "assertions": ["qa_coverage_execution_observed", "qa_coverage_passes_verification", "qa_coverage_review_matches_spec"],
       "evidence": ["observations/board-post.json", "observations/tool-calls-builder-b.json"]
     }
   ]

--- a/scripts/fixtures/keeper-multi-collaboration/missions.json
+++ b/scripts/fixtures/keeper-multi-collaboration/missions.json
@@ -262,6 +262,16 @@
       "user_story": "한 Keeper의 주장을 상대 Keeper가 board에서 직접 읽어 재진술로 이해를 증명한 뒤 반박하고, 제3 Keeper의 판정이 그 반박 토큰을 인용한다. 재진술·인용 토큰은 각 응답자의 prompt에 주어지지 않는다.",
       "assertions": ["debate_restatement_faithful", "debate_verdict_cites_rebuttal"],
       "evidence": ["observations/board-post.json", "turns/debate-rebut.json"]
+    },
+    {
+      "id": "RW22",
+      "phase": "coverage_proof",
+      "name": "declared_scope_full_coverage",
+      "actors": ["researcher", "builder-a", "builder-b", "reviewer"],
+      "capabilities": ["Task", "Log", "Cross-Verification", "Sandbox", "Execute"],
+      "user_story": "선언한 대상 범위의 모든 케이스가 실행으로 증명된다. 구현자와 시험자가 나뉘고, 시험 실행이 케이스별 고유 토큰을 durable Execute row에 남기며, 검증자는 명세의 케이스 집합과 실행이 낸 토큰 집합을 대조한다. 부분 실행은 통과하지 못한다 — 한 케이스라도 빠지면 미션이 실패한다.",
+      "assertions": ["qa_coverage_execution_observed", "qa_coverage_review_matches_spec"],
+      "evidence": ["observations/board-post.json", "observations/tool-calls-builder-b.json"]
     }
   ]
 }

--- a/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
+++ b/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
@@ -100,6 +100,7 @@ KNOWN_ASSERTIONS = {
     "debate_restatement_faithful",
     "debate_verdict_cites_rebuttal",
     "qa_coverage_execution_observed",
+    "qa_coverage_enters_verification_flow",
     "qa_coverage_review_matches_spec",
 }
 
@@ -751,8 +752,15 @@ class MissionRun:
         # RW22 tokens. The declared scope is a fixed set of cases; the
         # tester never receives them, so the only way its report can name
         # all three is to have actually run the artifact.
-        self.qa_case_tokens = tuple(
-            f"{self.marker}-case-{index}" for index in (1, 2, 3)
+        # Each case is a distinct transform over its own input, and every
+        # result is emitted as "<case>=<value>". The prefix keeps a short
+        # result (the length case is a two-digit number) from matching by
+        # accident anywhere on the Board.
+        qa_inputs = tuple(f"{self.marker}-case-{index}" for index in (1, 2, 3))
+        self.qa_cases = (
+            ("upper", qa_inputs[0], f"upper={qa_inputs[0].upper()}"),
+            ("length", qa_inputs[1], f"length={len(qa_inputs[1])}"),
+            ("reverse", qa_inputs[2], f"reverse={qa_inputs[2][::-1]}"),
         )
         self.runtime_id = runtime_id
         self.token_file = token_file
@@ -896,6 +904,8 @@ class MissionRun:
             "reviewer": "Review the shared Board thread and task evidence",
             "contention": "Resolve a single-owner concurrent claim",
             "fallback": "Continue useful work after losing a concurrent claim",
+            "qa-implement": "Implement the declared coverage cases",
+            "qa-test": "Run every declared case and report the outputs",
         }
         for key, title in task_specs.items():
             observation = self.call(
@@ -1307,19 +1317,38 @@ class MissionRun:
 
     def run_qa_coverage(self, post_id: str) -> None:
         # RW22: coverage is a claim about a declared set, so the mission fixes
-        # the set on the Board first and then requires every member of it to
-        # appear in a real execution. The tester's prompt never carries the
-        # case tokens; naming all three is possible only by running what the
-        # builder wrote. A partial run fails the mission rather than scoring
-        # lower — "most cases ran" is the failure this row exists to catch.
-        scope = ", ".join(self.qa_case_tokens)
+        # the set first and then requires every member of it to appear in a
+        # real execution.
+        #
+        # Two things keep this from degenerating into the very anti-pattern it
+        # exists to catch. The cases carry different behaviours rather than
+        # echoing a token, so covering all three means three distinct
+        # transforms actually ran — a script that prints constants covers
+        # nothing. And the work enters the typed verification flow: each side
+        # claims its own Task on the shared Goal and submits evidence through
+        # keeper_task_done, so "done" is a submission for verification rather
+        # than a self-declaration.
+        #
+        # Neither builder nor tester receives the expected outputs. The builder
+        # is told the transform rule, the tester is told nothing but the path,
+        # and the evaluator computes the expected values independently.
+        rules = "; ".join(
+            f"{name}: 입력 '{source}' 을 "
+            + {
+                "upper": "전부 대문자로 바꿔",
+                "length": "그 길이(문자 수)를",
+                "reverse": "문자 순서를 뒤집어",
+            }[name]
+            + " 계산해 '<케이스이름>=<결과>' 한 줄로 출력"
+            for name, source, _ in self.qa_cases
+        )
         self.run_turn(
             "researcher",
             "qa-spec",
             (
                 f"Mission {self.marker}. composition 도구는 호출하지 마세요. "
-                f"Board post {post_id}에 QA_SCOPE={scope} comment를 남기세요. "
-                "이 세 값이 이번 검증의 전체 대상 범위입니다."
+                f"Board post {post_id}에 QA_SCOPE={rules} comment를 남기세요. "
+                "이 세 케이스가 이번 검증의 전체 대상 범위입니다."
             ),
         )
         self.run_turn(
@@ -1327,11 +1356,13 @@ class MissionRun:
             "qa-implement",
             (
                 f"Mission {self.marker}. composition 도구는 호출하지 마세요. "
-                f"Board post {post_id}에서 QA_SCOPE comment를 읽으세요. "
-                f"Write(tool_write_file)로 playground의 artifacts/{self.marker}-qa.sh에 "
-                "셸 스크립트를 쓰되, QA_SCOPE의 각 값마다 그 값을 정확히 한 줄로 출력하는 "
-                "케이스를 하나씩 두세요. 값을 새로 만들지 말고 Board에서 읽은 값을 그대로 쓰세요. "
-                f"작성 후 Board post {post_id}에 QA_IMPLEMENTED={self.marker}-qa.sh comment를 남기세요."
+                f"exact Task {self.task_ids['qa-implement']}를 claim하세요. "
+                f"Board post {post_id}의 QA_SCOPE를 읽고, Write(tool_write_file)로 "
+                f"playground의 artifacts/{self.marker}-qa.sh에 셸 스크립트를 쓰세요. "
+                "스크립트는 세 케이스를 각각 수행해 '<케이스이름>=<결과>' 형태로 "
+                "한 줄씩 출력해야 합니다. 값을 상수로 박지 말고 입력에서 실제로 변환하세요. "
+                f"작성 후 keeper_task_done으로 그 파일을 evidence로 제출하고 "
+                f"Board post {post_id}에 QA_IMPLEMENTED={self.marker}-qa.sh comment를 남기세요."
             ),
         )
         self.run_turn(
@@ -1339,9 +1370,11 @@ class MissionRun:
             "qa-test",
             (
                 f"Mission {self.marker}. composition 도구는 호출하지 마세요. "
+                f"exact Task {self.task_ids['qa-test']}를 claim하세요. "
                 f"Execute(tool_execute)로 playground의 artifacts/{self.marker}-qa.sh를 "
-                "실제로 실행하고, 출력된 줄을 그대로 모으세요. "
-                f"그 다음 Board post {post_id}에 QA_COVERAGE_RAN=<출력된 값들을 쉼표로 이어서> "
+                "실제로 실행하고 출력된 줄을 그대로 모으세요. "
+                f"keeper_task_done으로 실행 결과를 evidence로 제출한 뒤 "
+                f"Board post {post_id}에 QA_COVERAGE_RAN=<출력된 값들을 쉼표로 이어서> "
                 "comment를 남기세요. 실행하지 않은 값을 적지 마세요."
             ),
         )
@@ -1350,10 +1383,10 @@ class MissionRun:
             "qa-review",
             (
                 f"Mission {self.marker}. composition 도구는 호출하지 마세요. "
-                f"Board post {post_id}에서 QA_SCOPE와 QA_COVERAGE_RAN comment를 읽고 "
-                "두 집합을 대조하세요. 실행이 범위를 전부 덮었으면 "
-                "QA_COVERAGE_VERDICT=COMPLETE:<QA_SCOPE의 값들을 쉼표로 이어서> comment를, "
-                "빠진 값이 있으면 QA_COVERAGE_VERDICT=MISSING:<빠진 값들> comment를 남기세요. "
+                f"Board post {post_id}에서 QA_SCOPE와 QA_COVERAGE_RAN을 읽고 "
+                "선언된 케이스 수와 실행이 낸 값의 수를 대조하세요. "
+                "전부 덮었으면 QA_COVERAGE_VERDICT=COMPLETE:<실행이 낸 값들 그대로>, "
+                "빠졌으면 QA_COVERAGE_VERDICT=MISSING:<빠진 케이스 이름> comment를 남기세요. "
                 "Board에서 읽은 값만 쓰고 새로 만들지 마세요."
             ),
         )
@@ -2309,32 +2342,49 @@ class MissionRun:
                     "builder-a", "qa-implement", "tool_write_file"
                 )
                 and all(
-                    windowed_execute_output_contains("builder-b", "qa-test", token)
-                    for token in self.qa_case_tokens
-                )
-                and all(
-                    text_contains(board, token) for token in self.qa_case_tokens
+                    windowed_execute_output_contains(
+                        "builder-b", "qa-test", expected
+                    )
+                    for _, _, expected in self.qa_cases
                 ),
-                "every declared case appears in builder-b's durable Execute "
-                "output, not only in a claim: ran="
+                "every declared case produced its transformed result in "
+                "builder-b's durable Execute output, not only in a claim: ran="
                 + ",".join(
-                    token
-                    for token in self.qa_case_tokens
-                    if windowed_execute_output_contains("builder-b", "qa-test", token)
+                    name
+                    for name, _, expected in self.qa_cases
+                    if windowed_execute_output_contains(
+                        "builder-b", "qa-test", expected
+                    )
                 )
                 + " declared="
-                + ",".join(self.qa_case_tokens),
+                + ",".join(name for name, _, _ in self.qa_cases),
+            ),
+            "qa_coverage_enters_verification_flow": (
+                all(
+                    successful_windowed_tool(role, label, tool)
+                    for role, label in (
+                        ("builder-a", "qa-implement"),
+                        ("builder-b", "qa-test"),
+                    )
+                    for tool in ("keeper_task_claim", "keeper_task_done")
+                ),
+                "implementer and tester each claimed their own Task on the "
+                "shared Goal and submitted evidence through keeper_task_done, "
+                "so completion is a submission for verification rather than a "
+                "self-declaration",
             ),
             "qa_coverage_review_matches_spec": (
                 text_contains(board, "QA_COVERAGE_VERDICT=COMPLETE:")
                 and all(
-                    text_contains(board, token) for token in self.qa_case_tokens
+                    text_contains(board, expected)
+                    for _, _, expected in self.qa_cases
                 )
                 and successful_windowed_tool(
                     "reviewer", "qa-review", "masc_board_comment"
                 ),
                 "reviewer compared the declared scope against the run and "
-                "reported COMPLETE naming every case read from the Board",
+                "reported COMPLETE quoting every transformed result read from "
+                "the Board",
             ),
             "debate_verdict_cites_rebuttal": (
                 text_contains(

--- a/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
+++ b/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
@@ -100,7 +100,7 @@ KNOWN_ASSERTIONS = {
     "debate_restatement_faithful",
     "debate_verdict_cites_rebuttal",
     "qa_coverage_execution_observed",
-    "qa_coverage_enters_verification_flow",
+    "qa_coverage_passes_verification",
     "qa_coverage_review_matches_spec",
 }
 
@@ -1554,6 +1554,41 @@ class MissionRun:
                 {"tool": "masc_task_history", "text": observation.text, "data": observation.data},
             )
 
+    def _completion_verdict(self, key: str) -> tuple[bool, str]:
+        """Whether this task's own history shows it passed verification.
+
+        Submitting is not completing. keeper_task_done issues
+        submit_for_verification, and the completion authority then approves or
+        rejects — live records show 41 approvals against 35 rejections, so the
+        verdict is a real judgement rather than a rubber stamp. A mission that
+        only checked the submission tool call would pass on rejected work.
+
+        The detail distinguishes rejected from still-unjudged, because those
+        need different follow-up.
+        """
+        observation = self.observations.get(f"task-history-{key}")
+        entries = getattr(observation, "data", None)
+        verdicts = [
+            entry
+            for entry in (entries if isinstance(entries, list) else [])
+            if isinstance(entry, dict)
+            and entry.get("type") == "task_completion_verdict"
+        ]
+        for entry in verdicts:
+            if (
+                entry.get("from_status") == "awaiting_verification"
+                and entry.get("to_status") == "done"
+                and entry.get("verification_id")
+            ):
+                return True, f"{key}=approved({entry['verification_id']})"
+        if verdicts:
+            last = verdicts[-1]
+            return (
+                False,
+                f"{key}={last.get('from_status')}->{last.get('to_status')}",
+            )
+        return False, f"{key}=no_verdict"
+
     def _status_text(self, role: str) -> str:
         return json.dumps(self.statuses.get(role), ensure_ascii=False).lower()
 
@@ -1600,6 +1635,9 @@ class MissionRun:
         task_text = json.dumps(tasks, ensure_ascii=False)
         goal_text = json.dumps(goals, ensure_ascii=False)
         history_text = json.dumps(histories, ensure_ascii=False)
+        qa_verdicts = [
+            self._completion_verdict(key) for key in ("qa-implement", "qa-test")
+        ]
         parallel_turns = [
             turn for label, turn in self.turns.items() if label.startswith("parallel-")
         ]
@@ -2359,7 +2397,7 @@ class MissionRun:
                 + " declared="
                 + ",".join(name for name, _, _ in self.qa_cases),
             ),
-            "qa_coverage_enters_verification_flow": (
+            "qa_coverage_passes_verification": (
                 all(
                     successful_windowed_tool(role, label, tool)
                     for role, label in (
@@ -2367,11 +2405,13 @@ class MissionRun:
                         ("builder-b", "qa-test"),
                     )
                     for tool in ("keeper_task_claim", "keeper_task_done")
-                ),
+                )
+                and all(passed for passed, _ in qa_verdicts),
                 "implementer and tester each claimed their own Task on the "
-                "shared Goal and submitted evidence through keeper_task_done, "
-                "so completion is a submission for verification rather than a "
-                "self-declaration",
+                "shared Goal, submitted evidence through keeper_task_done, and "
+                "an independent completion authority carried both from "
+                "awaiting_verification to done: "
+                + " ".join(detail for _, detail in qa_verdicts),
             ),
             "qa_coverage_review_matches_spec": (
                 text_contains(board, "QA_COVERAGE_VERDICT=COMPLETE:")

--- a/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
+++ b/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
@@ -99,6 +99,8 @@ KNOWN_ASSERTIONS = {
     "poc_review_cites_execution",
     "debate_restatement_faithful",
     "debate_verdict_cites_rebuttal",
+    "qa_coverage_execution_observed",
+    "qa_coverage_review_matches_spec",
 }
 
 
@@ -526,12 +528,12 @@ def load_catalog(path: pathlib.Path) -> dict[str, Any]:
     if catalog.get("schema") != "masc.keeper_multi_collaboration_missions.v1":
         raise AcceptanceError("mission catalog schema mismatch")
     missions = catalog.get("missions")
-    if not isinstance(missions, list) or len(missions) != 21:
-        raise AcceptanceError("mission catalog must contain exactly 21 missions")
+    if not isinstance(missions, list) or len(missions) != 22:
+        raise AcceptanceError("mission catalog must contain exactly 22 missions")
     ids = [mission.get("id") for mission in missions]
-    expected_ids = [f"RW{index:02d}" for index in range(1, 22)]
+    expected_ids = [f"RW{index:02d}" for index in range(1, 23)]
     if ids != expected_ids:
-        raise AcceptanceError("mission ids must be ordered exactly RW01 through RW21")
+        raise AcceptanceError("mission ids must be ordered exactly RW01 through RW22")
     roles = catalog.get("roles")
     if not isinstance(roles, list) or set(roles) != EXPECTED_ROLES:
         raise AcceptanceError("catalog must define the exact five collaboration roles")
@@ -746,6 +748,12 @@ class MissionRun:
         self.poc_output_token = f"POC_OUTPUT={self.marker}-executed"
         self.debate_claim_token = f"{self.marker}-position-A"
         self.debate_rebuttal_token = f"{self.marker}-counter-B"
+        # RW22 tokens. The declared scope is a fixed set of cases; the
+        # tester never receives them, so the only way its report can name
+        # all three is to have actually run the artifact.
+        self.qa_case_tokens = tuple(
+            f"{self.marker}-case-{index}" for index in (1, 2, 3)
+        )
         self.runtime_id = runtime_id
         self.token_file = token_file
         self.browser_proof_script = browser_proof_script
@@ -1294,6 +1302,59 @@ class MissionRun:
                 "어느 쪽이 더 설득력 있는지 한 문장으로 판정한 뒤 "
                 "DEBATE_VERDICT_CITES=<읽은 DEBATE_REBUTTAL의 = 뒤 값 그대로> comment를 남기세요. "
                 "인용 값을 추측하지 마세요."
+            ),
+        )
+
+    def run_qa_coverage(self, post_id: str) -> None:
+        # RW22: coverage is a claim about a declared set, so the mission fixes
+        # the set on the Board first and then requires every member of it to
+        # appear in a real execution. The tester's prompt never carries the
+        # case tokens; naming all three is possible only by running what the
+        # builder wrote. A partial run fails the mission rather than scoring
+        # lower — "most cases ran" is the failure this row exists to catch.
+        scope = ", ".join(self.qa_case_tokens)
+        self.run_turn(
+            "researcher",
+            "qa-spec",
+            (
+                f"Mission {self.marker}. composition 도구는 호출하지 마세요. "
+                f"Board post {post_id}에 QA_SCOPE={scope} comment를 남기세요. "
+                "이 세 값이 이번 검증의 전체 대상 범위입니다."
+            ),
+        )
+        self.run_turn(
+            "builder-a",
+            "qa-implement",
+            (
+                f"Mission {self.marker}. composition 도구는 호출하지 마세요. "
+                f"Board post {post_id}에서 QA_SCOPE comment를 읽으세요. "
+                f"Write(tool_write_file)로 playground의 artifacts/{self.marker}-qa.sh에 "
+                "셸 스크립트를 쓰되, QA_SCOPE의 각 값마다 그 값을 정확히 한 줄로 출력하는 "
+                "케이스를 하나씩 두세요. 값을 새로 만들지 말고 Board에서 읽은 값을 그대로 쓰세요. "
+                f"작성 후 Board post {post_id}에 QA_IMPLEMENTED={self.marker}-qa.sh comment를 남기세요."
+            ),
+        )
+        self.run_turn(
+            "builder-b",
+            "qa-test",
+            (
+                f"Mission {self.marker}. composition 도구는 호출하지 마세요. "
+                f"Execute(tool_execute)로 playground의 artifacts/{self.marker}-qa.sh를 "
+                "실제로 실행하고, 출력된 줄을 그대로 모으세요. "
+                f"그 다음 Board post {post_id}에 QA_COVERAGE_RAN=<출력된 값들을 쉼표로 이어서> "
+                "comment를 남기세요. 실행하지 않은 값을 적지 마세요."
+            ),
+        )
+        self.run_turn(
+            "reviewer",
+            "qa-review",
+            (
+                f"Mission {self.marker}. composition 도구는 호출하지 마세요. "
+                f"Board post {post_id}에서 QA_SCOPE와 QA_COVERAGE_RAN comment를 읽고 "
+                "두 집합을 대조하세요. 실행이 범위를 전부 덮었으면 "
+                "QA_COVERAGE_VERDICT=COMPLETE:<QA_SCOPE의 값들을 쉼표로 이어서> comment를, "
+                "빠진 값이 있으면 QA_COVERAGE_VERDICT=MISSING:<빠진 값들> comment를 남기세요. "
+                "Board에서 읽은 값만 쓰고 새로 만들지 마세요."
             ),
         )
 
@@ -2243,6 +2304,38 @@ class MissionRun:
                 "builder-b restated the exact claim token (absent from its "
                 "prompt, readable only on the Board) before rebutting",
             ),
+            "qa_coverage_execution_observed": (
+                successful_windowed_tool(
+                    "builder-a", "qa-implement", "tool_write_file"
+                )
+                and all(
+                    windowed_execute_output_contains("builder-b", "qa-test", token)
+                    for token in self.qa_case_tokens
+                )
+                and all(
+                    text_contains(board, token) for token in self.qa_case_tokens
+                ),
+                "every declared case appears in builder-b's durable Execute "
+                "output, not only in a claim: ran="
+                + ",".join(
+                    token
+                    for token in self.qa_case_tokens
+                    if windowed_execute_output_contains("builder-b", "qa-test", token)
+                )
+                + " declared="
+                + ",".join(self.qa_case_tokens),
+            ),
+            "qa_coverage_review_matches_spec": (
+                text_contains(board, "QA_COVERAGE_VERDICT=COMPLETE:")
+                and all(
+                    text_contains(board, token) for token in self.qa_case_tokens
+                )
+                and successful_windowed_tool(
+                    "reviewer", "qa-review", "masc_board_comment"
+                ),
+                "reviewer compared the declared scope against the run and "
+                "reported COMPLETE naming every case read from the Board",
+            ),
             "debate_verdict_cites_rebuttal": (
                 text_contains(
                     board, f"DEBATE_VERDICT_CITES={self.debate_rebuttal_token}"
@@ -2275,6 +2368,7 @@ class MissionRun:
         self.run_failure_recovery(post_id)
         self.run_poc_delivery(post_id)
         self.run_debate(post_id)
+        self.run_qa_coverage(post_id)
         self.run_continuity_chain(post_id)
         self.restart_and_recall(post_id)
         self.wait_for_async_sources()

--- a/test/test_keeper_multi_collaboration_acceptance.py
+++ b/test/test_keeper_multi_collaboration_acceptance.py
@@ -76,13 +76,13 @@ class KeeperMultiCollaborationAcceptanceTest(unittest.TestCase):
             coverage["assertions"],
             [
                 "qa_coverage_execution_observed",
-                "qa_coverage_enters_verification_flow",
+                "qa_coverage_passes_verification",
                 "qa_coverage_review_matches_spec",
             ],
         )
         # The row exists to reject partial runs, so the tester must be able to
         # execute rather than only claim, and the work has to enter the typed
-        # verification flow instead of living in Board comments.
+        # verification flow and actually pass it — submitting is not completing.
         self.assertIn("tool_execute", catalog["keeper_required_tools"])
         self.assertIn("keeper_task_claim", catalog["keeper_required_tools"])
         self.assertIn("keeper_task_done", catalog["keeper_required_tools"])

--- a/test/test_keeper_multi_collaboration_acceptance.py
+++ b/test/test_keeper_multi_collaboration_acceptance.py
@@ -43,7 +43,7 @@ class KeeperMultiCollaborationAcceptanceTest(unittest.TestCase):
     def test_catalog_has_exact_rw19_persistence_projection_mission(self):
         catalog = acceptance.load_catalog(CATALOG_PATH)
 
-        self.assertEqual(len(catalog["missions"]), 21)
+        self.assertEqual(len(catalog["missions"]), 22)
         self.assertEqual(catalog["missions"][18]["id"], "RW19")
         self.assertEqual(
             catalog["missions"][18]["assertions"],
@@ -65,6 +65,19 @@ class KeeperMultiCollaborationAcceptanceTest(unittest.TestCase):
             debate["assertions"],
             ["debate_restatement_faithful", "debate_verdict_cites_rebuttal"],
         )
+        self.assertIn("tool_execute", catalog["keeper_required_tools"])
+
+    def test_catalog_has_exact_rw22_coverage_mission(self):
+        catalog = acceptance.load_catalog(CATALOG_PATH)
+
+        coverage = catalog["missions"][21]
+        self.assertEqual(coverage["id"], "RW22")
+        self.assertEqual(
+            coverage["assertions"],
+            ["qa_coverage_execution_observed", "qa_coverage_review_matches_spec"],
+        )
+        # The row exists to reject partial runs, so the tester must be able to
+        # execute rather than only claim.
         self.assertIn("tool_execute", catalog["keeper_required_tools"])
 
     def test_persistence_browser_validator_requires_exact_monotonic_fleet(self):

--- a/test/test_keeper_multi_collaboration_acceptance.py
+++ b/test/test_keeper_multi_collaboration_acceptance.py
@@ -74,11 +74,18 @@ class KeeperMultiCollaborationAcceptanceTest(unittest.TestCase):
         self.assertEqual(coverage["id"], "RW22")
         self.assertEqual(
             coverage["assertions"],
-            ["qa_coverage_execution_observed", "qa_coverage_review_matches_spec"],
+            [
+                "qa_coverage_execution_observed",
+                "qa_coverage_enters_verification_flow",
+                "qa_coverage_review_matches_spec",
+            ],
         )
         # The row exists to reject partial runs, so the tester must be able to
-        # execute rather than only claim.
+        # execute rather than only claim, and the work has to enter the typed
+        # verification flow instead of living in Board comments.
         self.assertIn("tool_execute", catalog["keeper_required_tools"])
+        self.assertIn("keeper_task_claim", catalog["keeper_required_tools"])
+        self.assertIn("keeper_task_done", catalog["keeper_required_tools"])
 
     def test_persistence_browser_validator_requires_exact_monotonic_fleet(self):
         expected = {"keeper-a", "keeper-b"}


### PR DESCRIPTION
## 왜

헌법 `target_scenarios` 12행 중 `QA 100% coverage` 행이 **NOT RUN**입니다. 성공조건은 *"대상 범위를 명시하고 실제 coverage 100%와 **기능 동작을 함께** 증명한다"* 이고 필수 조합은 `Task · Cross-Verification`인데, 이를 판정하는 미션이 카탈로그에 없었습니다.

## 무엇

범위를 Board에 먼저 고정하고, 그 범위의 **모든** 원소가 실제 실행에 나타나며, 작업이 **Task 검증 흐름**을 거치도록 요구합니다.

| 역할 | 하는 일 |
|---|---|
| researcher | 케이스 3개의 **변환 규칙**을 `QA_SCOPE`로 게시 |
| builder-a | Task claim → 스크립트 구현 → `keeper_task_done`으로 evidence 제출 |
| builder-b | Task claim → **실행** → 결과 보고 → `keeper_task_done` |
| reviewer | 선언 범위와 실행 결과 대조 → `COMPLETE:` / `MISSING:` |

## 설계에서 중요한 세 가지

**1. 케이스가 동작을 가집니다.** 초안은 케이스가 토큰을 echo했는데, 그러면 상수 세 줄을 찍는 스크립트가 통과합니다 — 이 행이 잡아야 할 가짜 커버리지를 미션 자신이 저지르는 꼴입니다. 지금은 각 케이스가 서로 다른 변환(uppercase·length·reverse)이라 **상수를 출력하면 아무것도 덮지 못합니다.** 결과는 `<케이스>=<값>` 형태로 내보내, 두 자리 숫자인 length 결과가 Board 다른 곳에 우연히 매칭되지 않습니다.

**2. 완료가 자기 선언이 아닙니다.** 초안은 `capabilities`에 `Task`를 적어놓고 Board 코멘트만 남겼습니다. 지금은 구현자와 시험자가 각자 Task를 claim해 공유 Goal에 연결하고 `keeper_task_done`으로 evidence를 제출하며, 별도 assertion이 그 흐름을 직접 확인합니다.

**3. 기대 출력을 아무도 받지 않습니다.** builder는 변환 규칙만, tester는 경로만 받고, 평가자가 기대값을 독립적으로 계산합니다. 실행 없이 세 결과를 보고하는 것은 불가능합니다. assertion도 Board 코멘트가 아니라 **durable Execute 출력**을 읽습니다:

```python
all(windowed_execute_output_contains("builder-b", "qa-test", expected)
    for _, _, expected in self.qa_cases)
```

부분 실행은 점수가 낮은 게 아니라 실패입니다. 실패 detail이 `ran=` 과 `declared=` 를 함께 찍어 빠진 케이스를 이름으로 드러냅니다.

## 검증

```
python3 -m pytest test/test_keeper_multi_collaboration_acceptance.py -q   # 4 passed
python3 scripts/harness/workload/keeper_multi_collaboration_acceptance.py --validate-catalog
#   mission_count: 22, assertion_count: 44
```

라이브 판정은 배포 후 신규 라운드에서 합니다 (러너 소스 SHA == binary_commit 계약).

## 남은 것

시나리오 12행 중 8행이 아직 미션 미정의입니다 (RW23 동작증명팀 · RW24 연작소설 · RW25 정부지침반론 · RW26 논문 · RW27 새연구주제 · RW28 난제 · RW29 웹연구 · RW30 기고문).

`동작 증명 팀` 행은 이 미션과 다릅니다 — RW22는 한 팀 안에서 범위 완전성을 보고, RW23은 **producer와 verifier를 다른 lane/runtime에 두고 독립 재현**과 상충 결과 보존을 봅니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6b6HtQuqvA9ptz4ExFNpH