### PR TITLE
fix(runtime): ollama_cloud 5개 모델의 thinking dialect를 배포본과 맞춤

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -146,8 +146,8 @@ streaming = true
 max-output-tokens = 384000
 supports-tool-choice = false
 supports-extended-thinking = true
-supports-reasoning-budget = true
-thinking-control-format = "reasoning-effort"
+supports-reasoning-budget = false
+thinking-control-format = "none"
 supports-image-input = false
 supports-multimodal-inputs = false
 
@@ -294,8 +294,8 @@ streaming = true
 max-output-tokens = 131072
 supports-tool-choice = false
 supports-extended-thinking = true
-supports-reasoning-budget = true
-thinking-control-format = "reasoning-effort"
+supports-reasoning-budget = false
+thinking-control-format = "none"
 # SSOT = agent-core models.toml per official MiniMax Chat documentation; Chat
 # tool_choice, response_format, and structured output are not documented.
 supports-response-format-json = false
@@ -347,8 +347,8 @@ streaming = true
 max-output-tokens = 32768
 supports-tool-choice = false
 supports-extended-thinking = true
-supports-reasoning-budget = true
-thinking-control-format = "reasoning-effort"
+supports-reasoning-budget = false
+thinking-control-format = "none"
 # SSOT = AGENT_CORE models.toml; Ollama Cloud Kimi rows do not currently advertise a
 # native schema/response_format guarantee.
 supports-response-format-json = false
@@ -436,8 +436,8 @@ streaming = true
 [models.ollama-cloud-deepseek-v4-flash-0731.capabilities]
 supports-tool-choice = false
 supports-extended-thinking = true
-supports-reasoning-budget = true
-thinking-control-format = "reasoning-effort"
+supports-reasoning-budget = false
+thinking-control-format = "none"
 supports-image-input = false
 supports-multimodal-inputs = false
 
@@ -456,8 +456,8 @@ streaming = true
 [models.ollama-cloud-deepseek-v4-pro.capabilities]
 supports-tool-choice = false
 supports-extended-thinking = true
-supports-reasoning-budget = true
-thinking-control-format = "reasoning-effort"
+supports-reasoning-budget = false
+thinking-control-format = "none"
 supports-image-input = false
 supports-multimodal-inputs = false
 

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -1190,10 +1190,13 @@ List.iter
           check bool "Kimi K2.7 Code image input" true caps.supports_image_input;
           check bool "Kimi K2.7 Code multimodal input" true
             caps.supports_multimodal_inputs;
-          check bool "Kimi K2.7 Code reasoning effort" true
+          (* ollama.com /v1 reasons inherently and takes no control field, so
+             this model declares no thinking control. See the comment on
+             [inherent_reasoning_no_control] above for the measurement. *)
+          check bool "Kimi K2.7 Code thinking control" true
             (Runtime_schema.equal_thinking_control_format
                caps.thinking_control_format
-               Runtime_schema.Reasoning_effort)
+               Runtime_schema.No_thinking_control)
         | None -> fail "expected Kimi K2.7 Code capabilities"))
 
 (* The lane-resolution test below iterates the lanes a config declares, so it

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -322,11 +322,25 @@ let assert_ollama_cloud_seed_runtime runtimes case =
     (match runtime.model.capabilities with
      | None -> failf "expected capabilities for %s" case.runtime_id
      | Some caps ->
+       (* [thinking] says the model reasons; it does not say the endpoint takes a
+          control on the wire. ollama.com /v1 serves reasoning inherently and
+          accepts no control field, so [reasoning-effort] there declares a
+          dialect that can never be encoded: the format carries no effort value,
+          runtime.toml has no key that supplies one, and runtime_adapter never
+          sets reasoning_effort. Every enable_thinking=true turn is then rejected
+          as Enable_not_encodable — measured 25/25 on the acceptance harness
+          before this list, 0/25 after. Deployed config dropped the same five on
+          2026-08-04; the audit is oas#2716 (2026-07-20). *)
+       let inherent_reasoning_no_control =
+         [ "ollama_cloud.ollama-cloud-qwen3-5-397b"
+         ; "ollama_cloud.ollama-cloud-deepseek-v4-flash-0731"
+         ; "ollama_cloud.ollama-cloud-deepseek-v4-pro"
+         ]
+       in
        let expected_reasoning_budget, expected_thinking_format =
-         match case.runtime_id with
-         | "ollama_cloud.ollama-cloud-qwen3-5-397b" ->
-           false, Runtime_schema.No_thinking_control
-         | _ ->
+         if List.mem case.runtime_id inherent_reasoning_no_control
+         then false, Runtime_schema.No_thinking_control
+         else
            ( case.thinking
            , if case.thinking
              then Runtime_schema.Reasoning_effort


### PR DESCRIPTION
## 무엇

repo `config/runtime.toml`의 ollama_cloud 모델 5개가 아직 이렇게 선언돼 있습니다.

```toml
thinking-control-format = "reasoning-effort"
supports-reasoning-budget = true
```

배포된 config는 **2026-08-04에 둘 다 바꿨고**, 같은 블록에 이유를 남겨뒀습니다.

> reasoning-effort dialect 는 effort 값 없이는 wire 에 아무것도 싣지 못하는데, runtime.toml 에는 effort 값을 선언하는 키가 없고 runtime_adapter 도 reasoning_effort 를 설정하지 않는다. 결과적으로 keeper 의 enable_thinking=true 턴이 전량 AcceptRejected(Enable_not_encodable) 로 거부되어 17:43:23~17:50 사이 kidsnote keeper cycle 이 30초 주기로 실패했다.

같은 주석이 왜 이 블록만 따로 손봐야 했는지도 적고 있습니다. 태그된 api-name(`deepseek-v4-flash:0731`)은 provider-scoped capability 조회에서 exact 매칭이라 `id_prefix="deepseek-v4-flash"` 오버레이 행을 **상속하지 못하고**, 이 블록이 그대로 `Provider_config` override로 투영됩니다. 인용된 감사(oas#2716, 2026-07-20)는 다섯 모델 전부를 "control wire 없음 + inherent reasoning"으로 분류합니다.

## 실측

08-20에 라이브 바이너리로 격리 서버를 띄워 acceptance를 세 번 돌렸습니다.

| runtime-id | 결과 |
|---|---|
| 지정 없음 | turn 25건, **25 실패**, 전부 dialect |
| `ollama_cloud.…-0731` | agent 50회, **turn_completed 0**, agent_failed 50 |
| `glm-coding.glm-4-7-coding` | **23 성공 / 4 실패** |

가운데 줄이 이 PR의 핵심입니다. 모델을 **명시해도** 안 됩니다. 요청한 모델과 기본 모델이 **각자 자기 이름으로** 똑같이 거부됩니다.

```
[-0731] 50× model "deepseek-v4-flash:0731" declares thinking control…
[기본]  50× model "deepseek-v4-flash"      declares thinking control…
```

## 범위

다섯 모델을 바꿉니다. 넷은 배포본과 같은 값이 되고, `ollama-cloud-deepseek-v4-pro`는 배포본에 대응 항목이 없지만 인용된 감사가 형제로 묶고 있어 함께 맞췄습니다.

배포본에는 `reasoning-effort`가 **한 건도 남아 있지 않습니다.**

## 검증

이 세션에서는 OCaml을 로컬 빌드하지 않으므로 컴파일 판정은 CI에 맡깁니다. 다만 `keeper-realworld-acceptance` job이 실제로 이 변화를 재는 자리라, 그 결과가 이 PR의 진짜 검증입니다.

Refs #29159
