### PR TITLE
fix(keeper): transcript latch를 resume 시점에 재검증 — 출구 없는 걸쇠 해소

### DIFF
--- a/lib/keeper/keeper_paused_work_resume_transaction.ml
+++ b/lib/keeper/keeper_paused_work_resume_transaction.ml
@@ -169,7 +169,71 @@ let validate_identity (receipt : Keeper_paused_work_disposition_receipt.t)
   else Ok ()
 ;;
 
-let paused_meta receipt (meta : Keeper_meta_contract.keeper_meta) =
+type transcript_recovery =
+  | Transcript_already_dispatchable
+  | Transcript_closed_open_tail of Agent_core.Types.message list
+  | Transcript_unrecoverable
+
+(* Downgrade to Operator_paused instead of clearing outright: the keeper stays
+   paused and the generic resume path below still owns that transition. Only the
+   classification changes, from "cannot replay" to "an operator stopped this". *)
+let downgraded_transcript_latch (meta : Keeper_meta_contract.keeper_meta) =
+  { meta with
+    Keeper_meta_contract.latched_reason =
+      Some
+        (Keeper_latched_reason.Operator_paused
+           { Keeper_latched_reason.operator_actor =
+               Keeper_latched_reason.operator_actor_grpc_directive
+           })
+  }
+;;
+
+(* The latch records that the transcript was broken when it was written, not
+   that it is broken now. A keeper whose checkpoint has since become
+   dispatchable is held by a stale record, so re-read the checkpoint and let its
+   current structure decide.
+
+   Two shapes clear it. A transcript that already validates needs nothing. A
+   transcript whose only defect is the open ToolUse tail that checkpoint
+   persistence preserves on purpose is closed by [close_open_tail], which
+   appends one typed ToolResult per unresolved id recording that the call was
+   issued and no result was observed. Anything that fails to parse keeps
+   latching — that is the contract [close_open_tail] documents, and this does
+   not override it. *)
+(* The decision, with no I/O in it: read the current messages and say what the
+   latch is still worth. Kept separate so the three outcomes are testable
+   without seeding a checkpoint on disk. *)
+let classify_transcript messages =
+  match Keeper_compaction_unit.validate_provider_transcript messages with
+  | Ok () -> Transcript_already_dispatchable
+  | Error _ ->
+    (match Keeper_compaction_unit.close_open_tail messages with
+     | Error _ -> Transcript_unrecoverable
+     | Ok closure -> Transcript_closed_open_tail closure.Keeper_compaction_unit.messages)
+;;
+
+let recover_transcript_latch config (meta : Keeper_meta_contract.keeper_meta) =
+  let session_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
+  let session_dir = Keeper_fs.keeper_session_dir config session_id in
+  match Keeper_checkpoint_store.load_agent_core_with_ref ~session_dir ~session_id with
+  | Error _ -> Error Durable_owner_transcript_reset_required
+  | Ok (checkpoint, source_ref) ->
+    (match classify_transcript checkpoint.Agent_core.Checkpoint.messages with
+     | Transcript_unrecoverable -> Error Durable_owner_transcript_reset_required
+     | Transcript_already_dispatchable -> Ok (downgraded_transcript_latch meta)
+     | Transcript_closed_open_tail messages ->
+       (match
+          Keeper_checkpoint_store.save_agent_core_if_source
+            ~session_dir
+            ~expected_source_ref:source_ref
+            { checkpoint with Agent_core.Checkpoint.messages }
+        with
+        | Keeper_checkpoint_store.Not_installed _ ->
+          Error Durable_owner_transcript_reset_required
+        | Keeper_checkpoint_store.Installed _ -> Ok (downgraded_transcript_latch meta)))
+;;
+
+let paused_meta config receipt (meta : Keeper_meta_contract.keeper_meta) =
   match
     Keeper_lifecycle_admission.state
       ~paused:meta.paused
@@ -180,7 +244,9 @@ let paused_meta receipt (meta : Keeper_meta_contract.keeper_meta) =
   | Keeper_lifecycle_admission.Paused
       (Keeper_lifecycle_admission.Classified
         Keeper_latched_reason.Transcript_corruption_reset_required) ->
-    Error Durable_owner_transcript_reset_required
+    let* recovered = recover_transcript_latch config meta in
+    let* () = validate_identity receipt recovered in
+    Ok recovered
   | Keeper_lifecycle_admission.Paused _ ->
     let* () = validate_identity receipt meta in
     Ok meta
@@ -243,7 +309,7 @@ let project_receipt token config (receipt : Keeper_paused_work_disposition_recei
   let* committed =
     if current.paused
     then
-      let* _paused = paused_meta receipt current in
+      let* _paused = paused_meta config receipt current in
       let* committed =
         match
           Keeper_owner_registry.apply_meta
@@ -294,7 +360,7 @@ let create_receipt config ~keeper_name request =
     ; operation = Keeper_paused_work_disposition_receipt.Resume_owner
     }
   in
-  let* _ = paused_meta receipt current in
+  let* _ = paused_meta config receipt current in
   let* entry = registered_owner_opt config receipt in
   match entry with
   | None -> Ok receipt

--- a/lib/keeper/keeper_paused_work_resume_transaction.ml
+++ b/lib/keeper/keeper_paused_work_resume_transaction.ml
@@ -224,7 +224,7 @@ let recover_transcript_latch config (meta : Keeper_meta_contract.keeper_meta) =
           Keeper_checkpoint_store.save_agent_core_if_source
             ~session_dir
             ~expected_source_ref:source_ref
-            { checkpoint with Agent_core.Checkpoint.messages }
+            { checkpoint with Agent_core.Checkpoint.messages = messages }
         with
         | Keeper_checkpoint_store.Not_installed _ ->
           Error Durable_owner_transcript_reset_required

--- a/lib/keeper/keeper_paused_work_resume_transaction.ml
+++ b/lib/keeper/keeper_paused_work_resume_transaction.ml
@@ -182,9 +182,7 @@ let downgraded_transcript_latch (meta : Keeper_meta_contract.keeper_meta) =
     Keeper_meta_contract.latched_reason =
       Some
         (Keeper_latched_reason.Operator_paused
-           { Keeper_latched_reason.operator_actor =
-               Keeper_latched_reason.operator_actor_grpc_directive
-           })
+           { operator_actor = Keeper_latched_reason.operator_actor_grpc_directive })
   }
 ;;
 

--- a/lib/keeper/keeper_paused_work_resume_transaction.mli
+++ b/lib/keeper/keeper_paused_work_resume_transaction.mli
@@ -58,6 +58,19 @@ type success =
   ; reservation_release : Keeper_lifecycle_reservation.release_outcome
   }
 
+(** What a latched transcript is still worth, decided from its messages alone. *)
+type transcript_recovery =
+  | Transcript_already_dispatchable
+      (** Validates as-is; the latch outlived the defect it recorded. *)
+  | Transcript_closed_open_tail of Agent_core.Types.message list
+      (** Only the deliberately preserved open ToolUse tail was missing; these
+          messages carry the appended typed closers. *)
+  | Transcript_unrecoverable
+      (** Fails to parse. The latch stays, per the [close_open_tail] contract. *)
+
+val classify_transcript : Agent_core.Types.message list -> transcript_recovery
+(** Pure decision behind the resume-time latch re-check. Exposed for tests. *)
+
 val error_to_string : error -> string
 
 val resume :

--- a/test/test_keeper_compaction_unit.ml
+++ b/test/test_keeper_compaction_unit.ml
@@ -498,6 +498,36 @@ let test_provider_admission_quarantines_malformed_overlap () =
   | Ok () -> Alcotest.fail "poisoned transcript passed keeper admission"
 ;;
 
+
+(* Resume-time latch re-check. The latch says the transcript was broken when it
+   was written; these pin what it is still worth now. Same three outcomes the
+   close_open_tail contract already draws, read through the resume path. *)
+
+module R = Masc.Keeper_paused_work_resume_transaction
+
+let test_classify_keeps_latch_for_unparseable_history () =
+  let orphan = [ message T.Tool [ result "call-missing" ] ] in
+  match R.classify_transcript orphan with
+  | R.Transcript_unrecoverable -> ()
+  | _ -> Alcotest.fail "an orphan tool result must keep latching"
+
+let test_classify_clears_latch_for_dispatchable_history () =
+  let closed =
+    [ message T.Assistant [ use "call-a" ]; message T.Tool [ result "call-a" ] ]
+  in
+  match R.classify_transcript closed with
+  | R.Transcript_already_dispatchable -> ()
+  | _ -> Alcotest.fail "a closed history must clear the latch untouched"
+
+let test_classify_closes_open_tail_before_clearing () =
+  let open_tail = [ message T.Assistant [ use "call-a" ] ] in
+  match R.classify_transcript open_tail with
+  | R.Transcript_closed_open_tail messages ->
+    (match U.validate_provider_transcript messages with
+     | Ok () -> ()
+     | Error _ -> Alcotest.fail "returned messages must be dispatchable")
+  | _ -> Alcotest.fail "an open ToolUse tail is recoverable, not a dead latch"
+
 let () =
   Alcotest.run "keeper_compaction_unit"
     [ ( "partition"
@@ -558,5 +588,13 @@ let () =
             test_close_open_tail_preserves_structural_error
         ; Alcotest.test_case "close_open_tail never fabricates success" `Quick
             test_close_open_tail_never_fabricates_success
+        ] )
+    ; ( "resume_latch_recheck"
+      , [ Alcotest.test_case "unparseable history keeps latching" `Quick
+            test_classify_keeps_latch_for_unparseable_history
+        ; Alcotest.test_case "dispatchable history clears the latch" `Quick
+            test_classify_clears_latch_for_dispatchable_history
+        ; Alcotest.test_case "open tail is closed before clearing" `Quick
+            test_classify_closes_open_tail_before_clearing
         ] )
     ]


### PR DESCRIPTION
## 문제

`Keeper_latched_reason` 은 셋인데 **하나만 출구가 없습니다.**

| latch | 출구 |
|---|---|
| `Operator_paused` | `mark_resumed` 가 해제 |
| `Dead_tombstone` | "use the dead-revival transaction" |
| `Transcript_corruption_reset_required` | **없음** |

세 번째는 "reset the Keeper checkpoint first" 라고 지시하는데, reset이 어디에도 없습니다. directive API는 `pause`/`resume`/`wakeup` 뿐이고, CLI는 `init`/`keeper-github`/`login`/`runtime-default-set`/`runtime-wizard-catalog`/`schedule-prune`/`start` 뿐입니다. `lib/` 전체에서 `transcript_reset` 심볼 9개가 **전부 판정·거부 variant** 이고 수행 함수는 없습니다.

여기 걸린 keeper는 영구히 갇힙니다.

## 이미 만들어져 있던 해법

`close_open_tail` 이 정확히 이 실패를 위해 존재합니다. 자기 테스트가 이유를 적어놨습니다.

> "before `close_open_tail` nothing closed it, so provider admission rejected the history on every reload and **the lane latched permanently (2026-07-27: four keepers)**"

테스트 5개, **프로덕션 호출자 0개**. 이 PR이 그 배선입니다.

## 무엇을 바꾸나

latch는 "그때 깨졌다"는 기록이지 "지금도 깨졌다"는 증거가 아닙니다. 그래서 resume이 checkpoint를 다시 읽고 **현재 구조가 판정**하게 합니다.

```
validate_provider_transcript 통과   → 걸쇠만 남은 상태, 그대로 해제
열린 ToolUse 꼬리뿐               → close_open_tail 로 닫고 저장 후 해제
파싱 실패                          → 계속 latch (close_open_tail 계약 그대로)
```

해제는 `Operator_paused` 로 **강등**이지 제거가 아닙니다. keeper는 계속 paused고, 기존 resume 경로가 그 전이를 그대로 소유합니다.

판정은 I/O 없는 `classify_transcript` 로 분리해 `.mli` 에 노출했습니다. 세 결과를 checkpoint를 디스크에 만들지 않고 테스트합니다.

## 실측

라이브 런타임의 `taskmaster`:

- 2026-08-17부터 latch, **3일 정지**
- 누적 27,644턴, 대기열 **72건** (매시간 `schedule_due` 가 계속 쌓임)
- 현재 checkpoint: `tool_use 1617` : `tool_result 1617`, **닫히지 않은 id 0개**

즉 transcript는 이미 dispatchable이고 **오래된 실패 기록만 붙잡고 있습니다.** 이 PR 이후 첫 경로로 풀립니다.

대시보드 재개 버튼은 이 상태에서 `Cannot resume taskmaster: current owner generation is unavailable` 만 반복합니다.

## 검증

- [x] `ocamlformat --check` (수정 3파일)
- [x] 기존 `test_resume_owner_rejects_transcript_reset_without_receipt` 는 그대로 통과 — fixture가 checkpoint를 만들지 않아 로드 실패로 거부가 유지됩니다
- [x] 신규 테스트 3종: 파싱 실패는 latch 유지 / dispatchable은 해제 / 열린 꼬리는 닫은 뒤 해제
- [ ] CI
- [ ] 배포 후 taskmaster resume 실측

## 남은 것

3단 계층 중 1·2단만 넣었습니다. 3단(직전 스냅샷 복원)은 파싱 자체가 깨진 경우용이고, 지금 실측 대상에는 해당 사례가 없어 뒤로 미뤘습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EoKSDigFqnuo1EEH8hyri4
