### PR TITLE
fix(dashboard): 실행 중인 keeper의 purge를 서버에서 거절한다 (409)

### DIFF
--- a/lib/keeper/keeper_dashboard_purge.ml
+++ b/lib/keeper/keeper_dashboard_purge.ml
@@ -37,8 +37,18 @@ type resolve_error =
       ; operation_id : Keeper_shutdown_types.Operation_id.t
       ; detail : string
       }
+  | Keeper_lane_executing of
+      { keeper_name : string
+      ; phase : string
+      }
 
 let resolve_error_to_string = function
+  | Keeper_lane_executing { keeper_name; phase } ->
+    Printf.sprintf
+      "dashboard Keeper purge refused while the lane is executing: keeper=%s \
+       phase=%s. Stop or pause the Keeper first."
+      keeper_name
+      phase
   | Empty_requested_name -> "dashboard Keeper purge requires a non-empty target name"
   | Invalid_requested_name { requested_name; detail } ->
     Printf.sprintf
@@ -110,7 +120,17 @@ let resolve (config : Workspace.config) requested_name =
            (Keeper_metadata_unreadable { keeper_name; metadata_path; detail })
        | Ok (Some meta) when String.equal meta.name keeper_name ->
          (match Workspace.validate_agent_name meta.agent_name with
-          | Ok _ -> Ok (Some { requested_name; keeper_name; meta })
+          | Ok _ ->
+            (match
+               Keeper_registry.get_phase ~base_path:config.base_path keeper_name
+             with
+             | Some phase when Keeper_state_machine.can_execute_turn phase ->
+               Error
+                 (Keeper_lane_executing
+                    { keeper_name
+                    ; phase = Keeper_state_machine.phase_to_string phase
+                    })
+             | Some _ | None -> Ok (Some { requested_name; keeper_name; meta }))
           | Error detail ->
             Error
               (Keeper_agent_name_invalid

--- a/lib/keeper/keeper_dashboard_purge.mli
+++ b/lib/keeper/keeper_dashboard_purge.mli
@@ -45,6 +45,15 @@ type resolve_error =
       ; operation_id : Keeper_shutdown_types.Operation_id.t
       ; detail : string
       }
+      (** The lane is still taking turns. Purge deletes the Keeper and every
+          store it owns, so a Keeper that can still execute is refused here
+          rather than raced: stop or pause it first. The dashboard hides the
+          control in the same states, but that is a rendering choice — this is
+          the rule. *)
+  | Keeper_lane_executing of
+      { keeper_name : string
+      ; phase : string
+      }
 
 val resolve_error_to_string : resolve_error -> string
 

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -531,6 +531,7 @@ let keeper_purge_resolve_status = function
   | Keeper_metadata_required _
   | Keeper_metadata_name_mismatch _
   | Keeper_agent_name_invalid _ -> `Conflict
+  | Keeper_lane_executing _ -> `Conflict
   | Keeper_owner_unavailable _ -> `Service_unavailable
   | Keeper_operation_unreadable _ -> `Internal_server_error
 ;;

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -2450,6 +2450,37 @@ let test_dashboard_purge_resolution_is_fail_closed () =
         | Error error -> fail (Dashboard_purge.resolve_error_to_string error)
       in
       check string "resolved exact Keeper name" persisted.name target.keeper_name;
+      (* A Keeper that can still execute a turn is refused here, not raced.
+         The dashboard hides the control in the same states, but a caller
+         reaching the endpoint directly bypassed that entirely — which is how a
+         live campaign Keeper was purged mid-run on 2026-08-20. *)
+      let executing_entry =
+        R.register_offline ~base_path:config.base_path persisted.name persisted
+      in
+      (match
+         R.put_entry
+           ~base_path:config.base_path
+           persisted.name
+           { executing_entry with phase = Keeper_state_machine.Running }
+       with
+       | Error _ -> fail "could not stage an executing lane for purge admission"
+       | Ok () ->
+         (match Dashboard_purge.resolve config persisted.name with
+          | Error (Dashboard_purge.Keeper_lane_executing { keeper_name; phase }) ->
+            check string "refused the executing Keeper" persisted.name keeper_name;
+            check
+              string
+              "reported the phase that refused it"
+              "running"
+              (String.lowercase_ascii phase)
+          | Error other ->
+            fail
+              ("executing lane produced the wrong refusal: "
+               ^ Dashboard_purge.resolve_error_to_string other)
+          | Ok _ -> fail "an executing Keeper must not be admitted for purge"));
+      (* Drop the staged lane so the assertions below still describe a Keeper
+         that only has persisted metadata. *)
+      ignore (R.unregister_exact executing_entry);
       check bool
         "resolved exact metadata trace"
         true


### PR DESCRIPTION
## 왜

Purge는 Keeper와 그가 소유한 저장소 전부를 지운다. 대시보드는 아직 턴을 돌 수 있는 Keeper에는 제거 버튼을 숨기지만, **그 규칙이 거기에만 있었다.** `POST /api/v1/dashboard/agents/purge` 는 메타데이터만 읽히면 무엇이든 받아줬으므로, 엔드포인트를 직접 부르는 호출자는 그 방어를 통째로 지나쳤다.

가정이 아니다. 2026-08-20 잔재 일괄 정리에서 이름 접두어로 대상을 골랐고, 진행 중이던 E0 캠페인 Keeper 8개가 삭제됐다 — 그중 `rw-e0-r8-20260820-*` 5개는 팀 전체다. 서버는 전부 실행 중인 채로 받아들였다.

## 무엇

규칙을 승인 경계로 옮긴다. `Keeper_dashboard_purge.resolve` 가 레지스트리 phase를 보고 `can_execute_turn` 이 인정하는 상태(Running · Failing · Overflowed · Compacting · HandingOff)면 typed `Keeper_lane_executing` 으로 거절하고, 엔드포인트는 409를 답한다. Offline · Paused · Stopped · Crashed · Restarting · Dead 는 그대로 지울 수 있다 — 끝난 작업을 정리하려는 운영자가 실제로 원하는 집합이다.

**새 술어도, override 플래그도 만들지 않았다.** `can_execute_turn` 이 턴 승인에서 이미 이 선을 긋고 있으므로 재사용하면 "아직 돌고 있다"의 정의가 하나로 유지된다. override를 두면 이번 사고가 통과한 구멍을 그대로 되살린다. 살아있는 Keeper를 지우려면 먼저 멈추면 된다 — 대시보드가 이미 요구하는 절차다.

## 검증

- `dune build --root . @check` — exit 0. variant 추가로 컴파일러가 매치 지점을 강제했다.
- `dune exec --root . test/test_heartbeat_integration.exe` — 57 tests, 새 assertion 통과.
- **기준선 대조**: 남는 실패 1건(`direct_keepalive / fork rejection terminalize` — "cancelled parent did not return a launch outcome")은 이 변경과 무관하다. 변경 4파일을 되돌리고 같은 스위트를 돌려 동일하게 1 failure / 57 tests를 확인했다.

기존 purge-resolution 시나리오에 executing lane을 세워 거절을 확인하고, 이후 assertion들이 계속 "메타데이터만 있는 Keeper"를 설명하도록 그 lane을 다시 내린다.

## 남긴 것

이번 사고로 드러난 다른 결함 두 개는 이 PR 범위가 아니다. purge 연쇄 목록이 손으로 유지돼 keeper 소유 경로 8종이 고아로 남는 것과, 접수된 뒤 `Blocked` 로 막힌 purge가 화면에 안 보이는 것. 둘 다 #29082 에 기록돼 있다.

Refs #29082

🤖 Generated with [Claude Code](https://claude.com/claude-code)
