### PR TITLE
fix(mcp): emit resultType on every JSON-RPC result (SEP-2322)

### DIFF
--- a/lib/mcp_transport_protocol/mcp_transport_protocol.ml
+++ b/lib/mcp_transport_protocol/mcp_transport_protocol.ml
@@ -136,7 +136,24 @@ let validate_initialize_params params =
 
 (* ── JSON-RPC response builders ──────────────────────────── *)
 
+(* SEP-2322 (protocol revision 2026-07-28): every result carries a
+   [resultType] -- ["complete"] for an ordinary result, ["input_required"]
+   for a Multi Round-Trip interim result.  Clients reject a result that
+   omits it when the negotiated revision is 2026-07-28 or later.
+
+   The field is added here rather than at each of the 22 call sites so a
+   new handler cannot forget it.  Handlers that already set [resultType]
+   (server/discover, and any future ["input_required"] responder) keep
+   their own value.  Adding the field unconditionally is safe for earlier
+   revisions: they treat an unknown result member as ignorable, and the
+   negotiated version is not threaded down to this builder. *)
 let make_response ~id result =
+  let result =
+    match result with
+    | `Assoc fields when not (List.mem_assoc "resultType" fields) ->
+      `Assoc (("resultType", `String "complete") :: fields)
+    | other -> other
+  in
   `Assoc [
     ("jsonrpc", `String "2.0");
     ("id", id);

--- a/lib/mcp_transport_protocol/mcp_transport_protocol.mli
+++ b/lib/mcp_transport_protocol/mcp_transport_protocol.mli
@@ -74,7 +74,12 @@ val validate_initialize_params : Yojson.Safe.t option -> (unit, string) result
 (** {1 JSON-RPC Response Builders} *)
 
 val make_response : id:Yojson.Safe.t -> Yojson.Safe.t -> Yojson.Safe.t
-(** [make_response ~id result] builds [{jsonrpc:"2.0", id, result}]. *)
+(** [make_response ~id result] builds [{jsonrpc:"2.0", id, result}].
+
+    When [result] is an object without a [resultType] member, ["complete"]
+    is inserted (SEP-2322, protocol revision 2026-07-28).  A [result] that
+    already carries [resultType] is passed through unchanged, so a handler
+    can answer ["input_required"] for a Multi Round-Trip turn. *)
 
 val make_error :
   ?data:Yojson.Safe.t ->

--- a/test/test_mcp_protocol_coverage.ml
+++ b/test/test_mcp_protocol_coverage.ml
@@ -242,6 +242,57 @@ let test_classify_wildcard_rejected () =
    Test Runners
    ============================================================ *)
 
+
+(* ============================================================
+   make_response resultType (SEP-2322, revision 2026-07-28)
+   ============================================================ *)
+
+let result_member resp =
+  match resp with
+  | `Assoc fields -> List.assoc_opt "result" fields
+  | _ -> None
+
+let result_type_of fields =
+  match List.assoc_opt "resultType" fields with
+  | Some (`String s) -> Some s
+  | _ -> None
+
+let test_make_response_adds_complete () =
+  let resp =
+    Mcp_transport_protocol.make_response ~id:(`Int 1) (`Assoc [ "ok", `Bool true ])
+  in
+  match result_member resp with
+  | Some (`Assoc fields) ->
+    check (option string) "resultType defaults to complete" (Some "complete")
+      (result_type_of fields);
+    check bool "original members preserved" true (List.mem_assoc "ok" fields)
+  | _ -> fail "result must remain an object"
+
+let test_make_response_preserves_existing_result_type () =
+  let resp =
+    Mcp_transport_protocol.make_response ~id:(`Int 2)
+      (`Assoc [ "resultType", `String "input_required" ])
+  in
+  match result_member resp with
+  | Some (`Assoc fields) ->
+    check (option string) "an explicit resultType is not overwritten"
+      (Some "input_required") (result_type_of fields);
+    check int "resultType appears once" 1
+      (List.length (List.filter (fun (k, _) -> String.equal k "resultType") fields))
+  | _ -> fail "result must remain an object"
+
+let test_make_response_envelope_intact () =
+  let resp = Mcp_transport_protocol.make_response ~id:(`Int 7) (`Assoc []) in
+  match resp with
+  | `Assoc fields ->
+    check (option string) "jsonrpc version" (Some "2.0")
+      (match List.assoc_opt "jsonrpc" fields with
+       | Some (`String v) -> Some v
+       | _ -> None);
+    check bool "id echoed" true
+      (match List.assoc_opt "id" fields with Some (`Int 7) -> true | _ -> false)
+  | _ -> fail "response must be an object"
+
 let () =
   run "Mcp_transport_protocol Coverage" [
     "constants", [
@@ -307,5 +358,10 @@ let () =
       test_case "rejected" `Quick test_classify_rejected;
       test_case "none rejected" `Quick test_classify_none_rejected;
       test_case "wildcard rejected" `Quick test_classify_wildcard_rejected;
+    ];
+    "make_response resultType", [
+      test_case "adds complete" `Quick test_make_response_adds_complete;
+      test_case "keeps input_required" `Quick test_make_response_preserves_existing_result_type;
+      test_case "envelope intact" `Quick test_make_response_envelope_intact;
     ];
   ]


### PR DESCRIPTION
## Problem

masc advertises protocol revision `2026-07-28` in `supported_protocol_versions` and
implements its stateless core (`is_stateless_protocol_version`), but the `resultType`
member that SEP-2322 makes **mandatory on every result** is set in exactly one place:

    $ rg -n '"resultType"' lib/ bin/ --glob '*.ml'
    lib/mcp_server_eio_protocol.ml:261:  [ "resultType", `String "complete"   # server/discover only

A client that negotiates `2026-07-28` therefore rejects every other result:

    masc: http://127.0.0.1:8935/mcp (HTTP) - ! Connected - tools fetch failed -
    Invalid result for tools/list: missing required resultType - servers implementing
    protocol revision 2026-07-28 MUST include it

Connection and auth both succeed; the whole tool surface is dropped at parse time.
`initialize` is affected too, so this is not specific to `tools/list`:

    {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2026-07-28","serverInfo":{...}}}

## Change

Insert `"complete"` in `make_response` -- the single builder in
`mcp_transport_protocol.ml` that the other 21 call sites alias -- so a new handler
cannot omit the field. A result that already carries `resultType` passes through
unchanged, which preserves `server/discover` and leaves room for `"input_required"`
(Multi Round-Trip).

No branching on the negotiated revision: earlier revisions ignore an unknown result
member, and threading the negotiated version into this builder would change the
signature of all 21 call sites for no behavioural gain. The rationale is in the
source comment so the next reader does not have to re-derive it.

| file | change |
|---|---|
| `lib/mcp_transport_protocol/mcp_transport_protocol.ml` | +17 (6 code, 11 comment) |
| `lib/mcp_transport_protocol/mcp_transport_protocol.mli` | +7 -1 (doc describes the insertion) |
| `test/test_mcp_protocol_coverage.ml` | +56 (3 cases) |

## Local verification

- `test_mcp_protocol_coverage.exe` -- **47 tests, exit 0**, including 3 new cases:
  default `complete` inserted, explicit `input_required` preserved without
  duplication, `jsonrpc`/`id` envelope intact.
- 7 suites that route through `make_response`, all exit 0:
  `test_mcp_h1_h2_admission_parity`, `test_response_model_empty_10083`,
  `test_keeper_owner`, `test_mcp_server_eio_call_tool`,
  `test_mcp_server_eio_coverage`, `test_http_negotiation`,
  `test_dashboard_agent_core_bridge`.

## Not verified

- **No live client has reconnected against a patched binary.** The running 8935
  instance is pre-patch, so this is proven to emit the field per spec, not yet proven
  to restore a specific client's tool listing. Needs a rebuild + restart.
- **Strict-validator clients.** SEP-2322 explicitly permits *omission* by
  pre-2026-07-28 servers but says nothing about *addition*. Unknown result members are
  ignorable by MCP/JSON-RPC convention, so the risk is judged low -- but a client that
  rejects unknown members would be affected.
- SEP-2549 (`ttlMs` / `cacheScope` on the list/read results) is out of scope;
  `cache_hint_fields` already exists but its coverage was not audited.
