### PR TITLE
fix(dashboard): purge 거절이 chat lane의 진행 중 턴도 보게 한다

### DIFF
--- a/lib/keeper/keeper_dashboard_purge.ml
+++ b/lib/keeper/keeper_dashboard_purge.ml
@@ -40,15 +40,25 @@ type resolve_error =
   | Keeper_lane_executing of
       { keeper_name : string
       ; phase : string
+      ; live_turn_id : int option
       }
 
 let resolve_error_to_string = function
-  | Keeper_lane_executing { keeper_name; phase } ->
-    Printf.sprintf
-      "dashboard Keeper purge refused while the lane is executing: keeper=%s \
-       phase=%s. Stop or pause the Keeper first."
-      keeper_name
-      phase
+  | Keeper_lane_executing { keeper_name; phase; live_turn_id } ->
+    (match live_turn_id with
+     | None ->
+       Printf.sprintf
+         "dashboard Keeper purge refused while the lane is executing: \
+          keeper=%s phase=%s. Stop or pause the Keeper first."
+         keeper_name
+         phase
+     | Some turn_id ->
+       Printf.sprintf
+         "dashboard Keeper purge refused while a turn is in flight: keeper=%s \
+          phase=%s turn=%d. Let the turn finish, or stop the Keeper first."
+         keeper_name
+         phase
+         turn_id)
   | Empty_requested_name -> "dashboard Keeper purge requires a non-empty target name"
   | Invalid_requested_name { requested_name; detail } ->
     Printf.sprintf
@@ -121,14 +131,27 @@ let resolve (config : Workspace.config) requested_name =
        | Ok (Some meta) when String.equal meta.name keeper_name ->
          (match Workspace.validate_agent_name meta.agent_name with
           | Ok _ ->
-            (match
-               Keeper_registry.get_phase ~base_path:config.base_path keeper_name
-             with
-             | Some phase when Keeper_state_machine.can_execute_turn phase ->
+            (* Two signals, because the two lanes admit turns differently. The
+               autonomous cycle only enters through a phase [can_execute_turn]
+               admits, but the chat lane runs
+               [run_keeper_invocation_turn_admitted] and never changes phase —
+               [mark_turn_started] writes [current_turn_observation] and leaves
+               [phase] alone. A phase-only guard therefore reads a Paused
+               Keeper answering a chat message as purgeable. *)
+            (match Keeper_registry.get ~base_path:config.base_path keeper_name with
+             | Some entry when Keeper_state_machine.can_execute_turn entry.phase ->
+               Error
+                 (Keeper_lane_executing
+                    { keeper_name
+                    ; phase = Keeper_state_machine.phase_to_string entry.phase
+                    ; live_turn_id = None
+                    })
+             | Some { current_turn_observation = Some observation; phase; _ } ->
                Error
                  (Keeper_lane_executing
                     { keeper_name
                     ; phase = Keeper_state_machine.phase_to_string phase
+                    ; live_turn_id = Some observation.turn_id
                     })
              | Some _ | None -> Ok (Some { requested_name; keeper_name; meta }))
           | Error detail ->

--- a/lib/keeper/keeper_dashboard_purge.mli
+++ b/lib/keeper/keeper_dashboard_purge.mli
@@ -53,6 +53,10 @@ type resolve_error =
   | Keeper_lane_executing of
       { keeper_name : string
       ; phase : string
+      ; live_turn_id : int option
+            (** [Some turn_id] when the refusal came from a turn in flight
+                rather than from the phase. The chat lane admits turns without
+                changing phase, so phase alone does not see it. *)
       }
 
 val resolve_error_to_string : resolve_error -> string

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -2478,6 +2478,34 @@ let test_dashboard_purge_resolution_is_fail_closed () =
               ("executing lane produced the wrong refusal: "
                ^ Dashboard_purge.resolve_error_to_string other)
           | Ok _ -> fail "an executing Keeper must not be admitted for purge"));
+      (* The chat lane never changes phase: run_keeper_invocation_turn_admitted
+         calls mark_turn_started, which writes current_turn_observation and
+         leaves phase alone. A phase-only guard reads a Paused Keeper answering
+         a chat message as purgeable, so the refusal has to see the live turn
+         too. *)
+      (match
+         R.put_entry
+           ~base_path:config.base_path
+           persisted.name
+           { executing_entry with phase = Keeper_state_machine.Paused }
+       with
+       | Error _ -> fail "could not stage a paused lane for the chat-lane check"
+       | Ok () ->
+         R.mark_turn_started
+           ~base_path:config.base_path
+           ~wake:Masc.Keeper_registry_types.Chat_request
+           persisted.name;
+         (match Dashboard_purge.resolve config persisted.name with
+          | Error
+              (Dashboard_purge.Keeper_lane_executing
+                { keeper_name; live_turn_id = Some _; _ }) ->
+            check string "refused the Keeper mid chat turn" persisted.name keeper_name
+          | Error other ->
+            fail
+              ("a chat turn in flight produced the wrong refusal: "
+               ^ Dashboard_purge.resolve_error_to_string other)
+          | Ok _ ->
+            fail "a Keeper running a chat turn must not be admitted for purge"));
       (* Drop the staged lane so the assertions below still describe a Keeper
          that only has persisted metadata. *)
       ignore (R.unregister_exact executing_entry);


### PR DESCRIPTION
## 왜

#29178 이 실행 중인 Keeper의 purge를 거절하게 만들었지만, **레지스트리 phase만** 읽는다. autonomous 사이클은 단일 admission 지점이 같은 `can_execute_turn` 을 쓰므로 그건 덮인다. chat lane은 안 덮인다.

`run_keeper_invocation_turn_admitted` 는 `mark_turn_started` 를 부르는데, 그 함수는 `current_turn_observation` 을 쓰고 **`phase` 는 건드리지 않는다**(`keeper_registry_setup.ml:1104-1126`). 그래서 `Paused` 에 앉아 있는 Keeper — 시나리오 하네스가 자기 Keeper를 남겨두는 바로 그 상태 — 가 chat 메시지로 진짜 턴을 돌고 있어도 가드는 "지워도 된다"고 읽고, 턴 중에 저장소를 삭제한다. 앞 PR이 닫은 것과 같은 종류의 유실이 다른 문으로 재현된다.

적대적 리뷰가 5개 파일을 따라가 찾았고, 직접 재확인했다.

## 무엇

두 신호 중 **하나라도** 걸리면 거절한다. `can_execute_turn` 이 인정하는 phase이거나, `current_turn_observation` 이 살아 있거나. 두 lane 모두 이 필드를 세우고 지우므로 어느 쪽이 admit했든 턴이 보인다.

거절에 `live_turn_id` 를 실어 어느 쪽이 막았는지 문구로 구분한다. chat lane 거절에서 `phase=paused` 만 보여주면 운영자에게 말이 안 되기 때문이다.

## 검증

- `dune build --root . @check` — exit 0
- `dune exec --root . test/test_heartbeat_integration.exe` — 57 tests, **1 failure**. 그 1건(`direct_keepalive / fork rejection terminalize`)은 이 변경 이전부터 있던 것으로, #29178 에서 파일을 되돌려 기준선 대조로 확인했다.
- **가드가 실제로 잡는지 실행으로 증명**: 새 분기에 `when false` 를 달아 무력화하면 같은 스위트가 **2 failures** 가 되고, 되돌리면 1로 복귀한다.

## 남긴 것

리뷰가 확인해준 것들: `existing_operation` 선행 호출은 이미 승인된 operation의 멱등 재보고라 구멍이 아니고, `resolve` 의 순서는 맞고, `can_execute_turn=false` 인 7개 phase는 그대로 purge된다.

한계 하나. 이 가드는 레지스트리 엔트리가 있어야 발화한다. 엔트리 없이 턴을 도는 경로가 있다면 여전히 통과한다 — 이 서버에서 도는 턴은 엔트리를 갖지만, 원리상 그렇다.

Refs #29082, #29178

🤖 Generated with [Claude Code](https://claude.com/claude-code)