### PR TITLE
fix(task): task 이력 limit이 그 task의 이벤트를 세도록

### DIFF
--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -464,7 +464,17 @@ let handle_tasks ~tool_name ~start_time ctx args =
        ~include_cancelled
        ?status)
 
-let read_event_lines config ~limit =
+(* Walks newest-first and stops once [limit] events satisfy [keep], so [limit]
+   counts the events a caller asked for. Counting raw lines instead made the
+   caller filter afterwards, and no line budget expresses "this task's newest
+   N": the budget fills with whatever the workspace last did, and a task whose
+   events sit further back drops out of its own history entirely.
+
+   Parsing happens here because [keep] asks about fields, and deciding on the
+   raw line would mean matching an id as a substring of unparsed JSON —
+   a different event's payload can carry that text. Malformed lines are skipped
+   rather than counted: they are not events the caller asked for. *)
+let read_matching_events config ~limit ~keep =
   let events_dir = Filename.concat (Workspace.masc_dir config) "events" in
   if not (Sys.file_exists events_dir) then []
   else
@@ -485,8 +495,12 @@ let read_event_lines config ~limit =
           | [] -> ()
           | line :: rest ->
             if !remaining > 0 then begin
-              collected := line :: !collected;
-              decr remaining;
+              (match Yojson.Safe.from_string line with
+               | json when keep json ->
+                 collected := json :: !collected;
+                 decr remaining
+               | _ -> ()
+               | exception Yojson.Json_error _ -> ());
               take rest
             end
         in
@@ -513,11 +527,6 @@ let read_event_lines config ~limit =
     List.rev !collected
 
 let task_history_events_json (config : Workspace.config) ~task_id ~limit =
-  let scan_limit = min 500 (limit * 5) in
-  let lines = read_event_lines config ~limit:scan_limit in
-  let (parsed, _malformed) =
-    Fs_compat.parse_jsonl_lines ~source:"task_events" lines
-  in
   let matches_task json =
     let task = Json_util.get_string json "task" in
     let task_id_field = Json_util.get_string json "task_id" in
@@ -526,14 +535,7 @@ let task_history_events_json (config : Workspace.config) ~task_id ~limit =
     | _, Some t when String.equal t task_id -> true
     | _ -> false
   in
-  let rec take n xs =
-    match xs with
-    | [] -> []
-    | _ when n <= 0 -> []
-    | x :: rest -> x :: take (n - 1) rest
-  in
-  let events = parsed |> List.filter matches_task |> take limit in
-  `List events
+  `List (read_matching_events config ~limit ~keep:matches_task)
 
 let handle_task_history ~tool_name ~start_time ctx args =
   let task_id = get_string args "task_id" "" in

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -3120,6 +3120,58 @@ let () =
          ; Masc_domain.InProgress { assignee = "worker"; started_at = "t" }
          ])
 
+(* [limit] counts THIS task's events. Counting raw lines instead meant the
+   reader budgeted [min 500 (limit * 5)] lines and filtered afterwards, so a
+   task whose events sit behind a busier task's fell out of its own history:
+   at limit=5 the budget was 25 lines, and 30 later events from another task
+   consumed all of them. *)
+let () = test "task_history_counts_matches_not_lines" (fun () ->
+  let ctx = make_test_ctx () in
+  let rec mkdir_p path =
+    if path = "" || path = "." || path = "/" then ()
+    else if Sys.file_exists path then ()
+    else begin
+      mkdir_p (Filename.dirname path);
+      Unix.mkdir path 0o755
+    end
+  in
+  let open Unix in
+  let tm = gmtime (gettimeofday ()) in
+  let month = Printf.sprintf "%04d-%02d" (tm.tm_year + 1900) (tm.tm_mon + 1) in
+  let day = Printf.sprintf "%02d.jsonl" tm.tm_mday in
+  let events_dir = Filename.concat (Workspace.masc_dir ctx.config) "events" in
+  let month_dir = Filename.concat events_dir month in
+  let log_file = Filename.concat month_dir day in
+  mkdir_p month_dir;
+  let event task_id action =
+    Yojson.Safe.to_string
+      (`Assoc
+        [ ("task_id", `String task_id)
+        ; ("action", `String action)
+        ; ("ts", `Float (gettimeofday ()))
+        ])
+  in
+  Fs_compat.append_file log_file (event "quiet-task" "claim" ^ "\n");
+  Fs_compat.append_file log_file (event "quiet-task" "done" ^ "\n");
+  for i = 1 to 30 do
+    Fs_compat.append_file log_file
+      (event "busy-task" (Printf.sprintf "step-%d" i) ^ "\n")
+  done;
+  let rows json =
+    match json with
+    | `List rows -> rows
+    | _ -> failwith "task history payload must be a JSON list"
+  in
+  let quiet =
+    rows (Task.Tool.task_history_events_json ctx.config ~task_id:"quiet-task" ~limit:5)
+  in
+  assert (List.length quiet = 2);
+  let busy =
+    rows (Task.Tool.task_history_events_json ctx.config ~task_id:"busy-task" ~limit:5)
+  in
+  assert (List.length busy = 5)
+)
+
 let () =
   ensure_test_runtime ();
   Alcotest.run "Task.Tool"


### PR DESCRIPTION
## 무엇이 문제였나

`task_history_events_json`은 원시 줄 수로 예산을 잡았습니다.

```ocaml
let scan_limit = min 500 (limit * 5) in
let lines = read_event_lines config ~limit:scan_limit in
...
let events = parsed |> List.filter matches_task |> take limit in
```

모든 task의 최신 이벤트를 그만큼 읽은 뒤에 task_id로 거릅니다. 그런데 **줄 예산으로는 "이 task의 최신 N개"를 표현할 수 없어요.** 예산은 workspace가 마지막에 무슨 일을 했든 그걸로 채워지고, 조용한 task의 이력은 바쁜 task 뒤로 밀려 자기 이력에서 통째로 사라집니다.

`limit=5`면 예산이 25줄인데, 다른 task의 이벤트 30개면 그걸로 다 찹니다.

## 어떻게 고쳤나

리더가 `keep`을 받고, 조건을 만족하는 이벤트가 `limit`개 모이면 멈춥니다.

파싱을 안쪽으로 옮겼어요. 원시 줄에서 판정하면 id를 **파싱 안 된 JSON의 substring**으로 찾는 셈이라, 다른 이벤트의 payload가 그 문자열을 담고 있으면 오탐이 납니다.

malformed 줄은 세지 않고 건너뜁니다 — 호출자가 요청한 이벤트가 아니니까요. 기존 `parse_jsonl_lines`의 `_malformed`를 버리던 동작과 같습니다.

## 테스트가 등록되지 않던 문제

회귀 테스트를 파일 끝에 붙였더니 **실행되지 않았습니다.** 이 파일은 registry에 case를 모아 `Alcotest.run`으로 넘기는 구조라, runner 뒤에 추가한 `let () = test ...`는 프로세스가 이미 끝난 뒤에 등록돼요. 추가 전후 모두 `98 tests run`으로 나와서 조용히 지나갈 뻔했습니다.

runner 앞으로 옮긴 뒤:

| | |
|---|---|
| 수정 전 트리 | `[FAIL] task_history_counts_matches_not_lines`, exit 1 |
| 수정 후 | `[OK]`, 99 tests, exit 0 |

## 검증

| | |
|---|---|
| `test_tool_task_coverage` | 99 tests, exit 0 |
| DET/NDT gate | exit 0 |
| structure / stringly-boundary / silent-failure ratchet | exit 0 |
| ocamlformat | clean |

## 관련

`#29100`(메시지 스토어), `#29179`(Activity Graph)와 같은 처방입니다. 남은 같은 축은 `server_routes_http_routes_activity.ml`의 audit events API 하나예요 (`min 5000 (limit * 20)` 후 actor/kind/severity 필터).
