### PR TITLE
ci(release): linux-arm64 빌드 타깃 추가

### DIFF
--- a/.github/actions/setup-ocaml-toolchain/action.yml
+++ b/.github/actions/setup-ocaml-toolchain/action.yml
@@ -38,9 +38,14 @@ runs:
         path: |
           ~/.opam
           ~/.local/share/opam
-        key: opam-linux-${{ inputs.cache-prefix }}-${{ inputs.ocaml-compiler }}-${{ hashFiles('*.opam', 'dune-project', 'scripts/opam-pin-external-deps.sh') }}-v2
+        # runner.arch 가 키에 들어가야 한다. 없으면 arm64 러너가 x86_64 러너의
+        # ~/.opam 을 복원하고, opam switch list 는 switch 가 있다고 답하는데
+        # 그 안의 ocamlc 는 x86_64 ELF 라 실행되지 않는다. 그 결과
+        # `ocamlc -version` 이 빈 문자열이 되어 opam-pin-external-deps.sh 가
+        # "OCaml unknown detected" 로 거부한다 (run 32332266041).
+        key: opam-linux-${{ runner.arch }}-${{ inputs.cache-prefix }}-${{ inputs.ocaml-compiler }}-${{ hashFiles('*.opam', 'dune-project', 'scripts/opam-pin-external-deps.sh') }}-v2
         restore-keys: |
-          opam-linux-${{ inputs.cache-prefix }}-${{ inputs.ocaml-compiler }}-
+          opam-linux-${{ runner.arch }}-${{ inputs.cache-prefix }}-${{ inputs.ocaml-compiler }}-
 
     - name: Bootstrap local opam switch (Linux)
       if: runner.os == 'Linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,12 @@ jobs:
           - os: ubuntu-latest
             arch: linux-x64
             may-fail: false
+          # aarch64 Linux 타깃. Raspberry Pi 5 / arm64 SBC 에 바이너리를 그대로
+          # 내려받아 실행하기 위한 것으로, 기기에서 직접 빌드하지 않는다.
+          # ubuntu-24.04-arm 은 public repo 에서 4vCPU 로 제공된다.
+          - os: ubuntu-24.04-arm
+            arch: linux-arm64
+            may-fail: false
 
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.may-fail }}
@@ -143,7 +149,7 @@ jobs:
 
       - name: Verify advertised release assets
         run: |
-          for arch in macos-arm64 linux-x64; do
+          for arch in macos-arm64 linux-x64 linux-arm64; do
             for asset in \
               "masc-$arch" \
               "masc-deployment-preflight-helper-$arch" \

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -689,7 +689,7 @@ detect_asset() {
     Darwin/arm64)  echo "masc-macos-arm64" ;;
     Linux/x86_64)  echo "masc-linux-x64"   ;;
     Darwin/x86_64) die "macOS x86_64 release asset not built. Build from source per README." ;;
-    Linux/aarch64) die "Linux arm64 release asset not built yet. Track .github/workflows/release.yml." ;;
+    Linux/aarch64) echo "masc-linux-arm64" ;;
     *) die "unsupported platform: $os/$arch" ;;
   esac
 }


### PR DESCRIPTION
## 목표

`release.yml` 이 aarch64 Linux 자산을 만들지 않아서, Raspberry Pi 5 같은 arm64 기기에 바이너리를 내려받을 방법이 없었다. matrix 에 `linux-arm64` 를 추가한다.

masc 는 이미 aarch64 Linux 에서 돈다. 포팅이 아니라 배포 타깃이 비어 있던 것이다.

## 로컬 실측 (linux/arm64 컨테이너, CI 툴체인 경로 복제)

opam 2.5.0 + `ocaml-base-compiler.5.5.0` + `--disable-sandboxing` 으로 CI 의 Linux 경로를 그대로 재현했다.

| 항목 | 값 |
|---|---|
| `dune build bin/main_eio.exe` | real 1m2s |
| 산출물 | ELF 64-bit LSB, `e_machine=0xB7` (EM_AARCH64), 110MB |
| 서버 부팅 | `/health` → `{"status":"ok","version":"0.23.0"}` |
| keeper | 7개 `registry: phase transition → running` |
| RSS | keeper 0개 123MB / 7개 171MB |

`setup-ocaml-toolchain` 은 이미 `aarch64|arm64` 분기를 갖고 있어 손대지 않았다.

## 변경 파일

- `.github/workflows/release.yml` — matrix 에 `ubuntu-24.04-arm` / `linux-arm64` 추가, 자산 검증 루프에 반영
- `scripts/install.sh` — `Linux/aarch64` 가 `die()` 로 이 워크플로를 가리키고 있었다. 이제 `masc-linux-arm64` 로 해석된다

## 검증 방법

`release.yml` 은 tag push 와 `workflow_dispatch` 에서만 돈다. PR checks 로는 검증되지 않으므로 브랜치에서 수동 실행했다. 발행 job 은 `if: startsWith(github.ref, 'refs/tags/v')` 라 스킵된다.

- run: https://github.com/jeong-sik/masc/actions/runs/32332266041

## 미검증 / 확인 중

`libprotobuf-dev` 는 `conf-protoc` 가 요구하는데 이 워크플로가 설치하지 않는다. x64 러너 이미지에는 들어 있어서 지금까지 드러나지 않았다. arm64 러너 이미지는 Arm, LLC 가 관리하는 별도 이미지라 포함 여부를 추측할 수 없다. 위 run 이 그 답을 준다 — 실패하면 apt 설치 스텝을 추가한다.

README 의 지원 플랫폼 문구(116, 167행)는 arm64 빌드가 초록인 것을 확인한 뒤 갱신한다.
