### PR TITLE
docs(keeper): purge 가드가 쓰는 live-turn 신호의 한계를 타입 옆에 적는다

### DIFF
--- a/lib/keeper/keeper_dashboard_purge.mli
+++ b/lib/keeper/keeper_dashboard_purge.mli
@@ -56,7 +56,21 @@ type resolve_error =
       ; live_turn_id : int option
             (** [Some turn_id] when the refusal came from a turn in flight
                 rather than from the phase. The chat lane admits turns without
-                changing phase, so phase alone does not see it. *)
+                changing phase, so phase alone does not see it.
+
+                The phase arm is checked first, and an autonomous turn sets
+                both signals at once, so [None] here means "the phase refused
+                it", not "no turn is running".
+
+                [current_turn_observation] is in-memory only and is cleared by
+                [mark_turn_finished]. The chat lane swallows
+                [Eio.Cancel.Cancelled] around that call
+                ([keeper_turn.ml:861-865]), so a cancelled chat turn can leave
+                the marker set and keep refusing purges. Recovery is a server
+                restart, which re-registers every Keeper with the field unset,
+                or the supervisor sweep that unregisters an exited lane. There
+                is no per-Keeper reset: [register_restarting] would do it but
+                has no production caller. *)
       }
 
 val resolve_error_to_string : resolve_error -> string


### PR DESCRIPTION
## 왜 별도 PR인가

이 커밋은 원래 #29185 브랜치에 올렸는데, 그 PR이 커밋 직전에 병합돼서 **main에 도달하지 못했다.** squash merge 뒤 브랜치에 얹은 커밋은 main에 가지 않는다(masc#5303 선례). 건져서 다시 올린다.

## 무엇

#29185 가 purge 승인 가드에 `current_turn_observation` 을 추가했다. 적대적 리뷰가 "그 신호가 새면 어떻게 되냐"고 물었고, 답 세 가지는 리뷰 스레드가 아니라 타입 옆에 있어야 한다.

- **`live_turn_id = None` 은 "턴이 없다"가 아니다.** phase arm이 먼저 검사되고 autonomous 턴은 두 신호를 동시에 세우므로, `None` 은 "phase가 막았다"는 뜻이다.
- **취소된 chat 턴이 마커를 남길 수 있다.** `keeper_turn.ml:861-865` 가 `mark_turn_finished` 주변에서 `Eio.Cancel.Cancelled` 를 로그도 없이 삼킨다. 근본 수정은 <a href="https://github.com/jeong-sik/masc/issues/29189">#29189</a>.
- **복구는 서버 재시작이나 supervisor sweep 뿐이다.** per-Keeper 리셋은 없다 — `register_restarting` 이 그 일을 하지만 프로덕션 호출자가 0이다(유닛테스트 1건뿐).

마지막 항목은 제가 확인 전에 "키퍼 재부팅하면 된다"고 말했다가 틀린 부분이다. 함수가 존재하는 것과 도달 가능한 것을 구분하지 않았다. 그 오류가 반복되지 않게 이유까지 적었다.

## 측정 불가

오늘 몇 개의 Keeper가 이 상태인지는 **어떤 정적 검사로도 볼 수 없다.** `current_turn_observation` 은 in-memory 전용이고 `keeper_meta_contract` 직렬화 대상이 아니라 디스크에 없다. 살아있는 서버에 per-keeper 질의를 해야만 보인다. 추측하지 않고 미측정으로 남긴다.

## 검증

`dune build --root . lib/keeper` — exit 0. 주석만 바뀌므로 동작 변화는 없다.

Refs #29185, #29189

🤖 Generated with [Claude Code](https://claude.com/claude-code)