### PR TITLE
docs(rfc): RFC-0387 에서 Goal 완료의 사람 확인 게이트를 철회한다

### DIFF
--- a/docs/rfc/RFC-0387-goal-verifier-gate.md
+++ b/docs/rfc/RFC-0387-goal-verifier-gate.md
@@ -26,12 +26,24 @@ constitution의 Goal 규칙 B1–B3는 문서만 있고 코드가 없었다. 이
   `record_criterion_viable` / `record_criterion_unreachable` action으로 커밋되며, 판정
   결과는 goal record가 아니라 이 ledger에 보존된다. `Criterion_unreachable` 판정이 있는 goal은
   `request_complete`이 typed conflict로 거절된다.
-- **B3 (완료 = Verifier 증명 + 사람 최종 확인)**: `Goal_phase`에 `Verifying`과
-  `Awaiting_confirmation` 두 phase와 네 action(`record_proof_proven`,
-  `record_proof_refuted`, `human_confirm`, `human_reject`)을 추가한다.
-  `request_complete`은 이제 `Executing -> Verifying`으로만 간다. `Completed`에 도달하는
-  유일한 경로는 `Verifying -(record_proof_proven)-> Awaiting_confirmation -(human_confirm)->
-  Completed`다.
+- **B3 (완료 = Verifier 가 동작으로 증명)**: `Goal_phase`에 `Verifying` phase 하나와
+  두 action(`record_proof_proven`, `record_proof_refuted`)을 추가한다.
+  `request_complete`은 `Executing -> Verifying`으로 가고, `Completed`에 도달하는 유일한
+  경로는 `Verifying -(record_proof_proven)-> Completed`다.
+
+  **사람 확인 축은 철회한다 (2026-08-20).** 초안은 `Awaiting_confirmation` phase 와
+  `human_confirm` / `human_reject` 를 두어 완료를 사람의 확인 뒤에 놓으려 했다. 실측이
+  그 전제를 반증한다: 완료된 Goal 18건의 종결 주체는 Keeper 자신 8건(rondo·sangsu·
+  kidsnote·analyst), admin 4건, operator·probe·mcp-client 6건이고 **"사람이 확인했다"는
+  사건은 `goal_events.jsonl` 어디에도 없다**. 확인할 표면도 이 RFC 범위 밖으로 빠져 있다.
+
+  게다가 action enum 은 `List.map action_to_string Goal_phase.all_actions` 로 생성되므로
+  새 action 은 그대로 `masc_goal_transition` 스키마에 실린다. 즉 **Keeper 가 자기 Goal 의
+  `human_confirm` 을 스스로 누를 수 있다.** 그러면 게이트는 이름만 남고 턴 수만 늘고,
+  누르지 못하게 막으면 Goal 이 `Awaiting_confirmation` 에서 나올 길을 잃는다. 어느 쪽이든
+  헌법의 게이트 조항("게이트로 얻는 실익이 크고 Feature 가 더 잘 돌아갈 때만")에 걸린다.
+
+  사람의 확인이 필요한 국면은 관측·통지로 제공한다. 상태를 잡아두는 방식이 아니다.
 
 이 PR이 만드는 것은 게이트·상태기계·ledger·관측 표면이다. pending된 criterion/proof 요청을
 실제로 모델에 던지는 standalone verifier worker(Eio lane)은 **B7 후속**이다 — Task 도메인의
@@ -49,15 +61,14 @@ goal 은 keeper 의 시야에서 사라지고 영원히 `Completed` 에 도달�
   - B1: `Goal_store.upsert_goal`의 생성 경로가 `metric`/`target_value`를 요구한다 (§2).
   - `Goal_verification` ledger (`lib/goal/goal_verification.ml`) 는 **record-only 증거
     저장소**로 도입된다 — 이 단계에서는 writer 가 하나도 없다. verdict 커밋 API
-    (`record_criterion_verdict` / `record_proof_verdict` / `record_human_confirmation`) 와
+    (`record_criterion_verdict` / `record_proof_verdict`) 와
     strict 디코더, fail-closed mutation, fail-loud read 만 갖춘다.
   - 관측성: `masc_goal_list` 와 `/api/v1/dashboard/planning` 의 goal 항목에 ledger
     `verification` 상태가 합류된다 (§6).
   - **Stage 1은 lifecycle 을 전혀 바꾸지 않는다**: `request_complete`은 여전히
-    `Executing -> Completed` 로 곧장 완료된다. `Verifying` / `Awaiting_confirmation`
-    phase, gate action 들, criterion/proof 의 durable 요청 기록(`mark_*_pending`)은 전부
-    stage 2다.
-- **Stage 2 (후속 PR)**: §3.2/§3.3/§4/§5 의 FSM 게이트 — phase 2종 + action 6종,
+    `Executing -> Completed` 로 곧장 완료된다. `Verifying` phase, gate action 들,
+    criterion/proof 의 durable 요청 기록(`mark_*_pending`)은 전부 stage 2다.
+- **Stage 2 (후속 PR)**: §3.2/§3.3/§4/§5 의 FSM 게이트 — phase 1종 + action 4종,
   `request_complete`의 `Verifying` 재라우팅, 생성 시 `Criterion_pending` durable 요청,
   `Criterion_unreachable`의 `request_complete` 차단 — 와 그 게이트를 실제로 부르는
   **verifier caller**(B7 standalone lane + 사람 확인 경로) 를 함께 딴다. 게이트는 caller
@@ -75,7 +86,7 @@ goal 은 keeper 의 시야에서 사라지고 영원히 `Completed` 에 도달�
 | 권위 저장소 fail-closed | `Goal_verification`의 쓰기 경로는 `Goal_store.update_state`와 같은 discipline을 따른다: 읽기가 decode 실패하면 mutation 불승인(`.last-good` mirror 포함) |
 | persist_before_model_call | `Criterion_pending`은 goal 생성 직후(모델 호출 전), `Proof_pending`은 `Verifying` phase 전이 전에 durable하게 쓴다. 영속화 실패 시 phase 전이/판정 커밋 모두 중단 |
 | wall-clock 만료 금지 | `Criterion_pending`/`Proof_pending`에는 만료가 없다. 재시도는 명시적이다: `Verifying`에서의 `request_complete` 재호출이 `Already`를 답하며 pending 상태를 그대로 보고한다 |
-| 실패 시 증거 보존 | `Refuted` 판정은 verdict(authority·evidence·recorded_at)째 ledger에 남는다. `human_reject`는 completion을 `Completion_idle`로 되돌리되 기각 사유는 `goal_events.jsonl`에 남는다 |
+| 실패 시 증거 보존 | `Refuted` 판정은 verdict(authority·evidence·recorded_at)째 ledger에 남고 goal 은 `Executing` 으로 돌아간다. 기각 사유는 `goal_events.jsonl` 에 남는다 |
 | 매직 넘버/문자열 매칭 금지 | 게이트 판정은 전부 typed variant 매칭이다. 임계값·budget·문자열 substring 판정 없음 |
 | 재사용 우선 | verdict provenance는 `Masc_domain.completion_authority`(`Human_operator` / `System_llm_agent`)를 그대로 쓴다. judge 호출은 B7에서 `Task.Anti_rationalization.review` 위에 얹는다 |
 
@@ -149,15 +160,14 @@ validation error.
 
 ### 4.1 상태기계 변경 (lib/goal/goal_phase.ml)
 
-phase 2종 추가: `Verifying`(완료 요청 접수, proof 대기), `Awaiting_confirmation`(proof
-증명됨, 사람 확인 대기). action 4종 추가:
+phase 1종 추가: `Verifying`(완료 요청 접수, proof 대기). action 2종 추가:
 
 | action | from | to | 커밋 주체 |
 |---|---|---|---|
-| `record_proof_proven` | `Verifying` | `Awaiting_confirmation` | Verifier(`System_llm_agent`) |
+| `record_proof_proven` | `Verifying` | `Completed` | Verifier(`System_llm_agent`) |
 | `record_proof_refuted` | `Verifying` | `Executing` | Verifier — 반증 evidence 보존 |
-| `human_confirm` | `Awaiting_confirmation` | `Completed` | 사람 — `confirmed_by` 필수 |
-| `human_reject` | `Awaiting_confirmation` | `Executing` | 사람 — completion은 idle로 |
+
+`Awaiting_confirmation` / `human_confirm` / `human_reject` 는 §3 B3 의 근거로 철회했다.
 
 `request_complete`의 유일한 이동은 이제 `Executing -> Verifying`이다. `Verifying` 진입 **전에**
 `mark_proof_pending`이 durable하게 쓰인다(persist_before_model_call); ledger 쓰기 실패 시
@@ -171,11 +181,11 @@ type completion_state =
   | Proof_pending of { requested_at : string }
   | Proof_proven of verdict
   | Proof_refuted of verdict
-  | Human_confirmed of { proof : verdict; confirmed_by : string; confirmed_at : string }
 ```
 
-`Completed` phase에 있는 goal의 ledger row는 `Human_confirmed { proof; ... }`를 지니므로
-"완료 = verifier 증명 + 사람 확인"의 전체 사슬이 durable하게 읽힌다.
+`Completed` phase에 있는 goal의 ledger row는 `Proof_proven verdict`를 지니므로
+"완료 = verifier 가 동작으로 증명"의 사슬이 durable하게 읽힌다 — 판정 주체와 증거,
+기록 시각이 그 verdict 안에 있다.
 
 `record_proof_verdict`는 ledger 쪽에서도 `Proof_pending`을 요구한다 — phase(FSM)와
 ledger(저장소) 양쪽이 같은 전이를 이중으로 검증해 stale verifier 커밋 경합을 막는다.
@@ -188,8 +198,8 @@ ledger(저장소) 양쪽이 같은 전이를 이중으로 검증해 stale verifi
 ### 4.3 신분 바인딩의 한계 (명시)
 
 MCP 표면은 caller를 인증하지 않으므로, `record_proof_*`의 authority는 호출자 세션 이름을 담은
-`System_llm_agent { agent_run_id = ctx.agent_name }`이고, `human_confirm`의 `confirmed_by`는
-operator-asserted 문자열이다. Task 도메인이 `completion_authority` 생성을 인증된 operator /
+`System_llm_agent { agent_run_id = ctx.agent_name }`이다. Task 도메인이
+`completion_authority` 생성을 인증된 operator /
 typed system-LLM 결과로 제한하는 것(types_core.mli:86-90 주석)과 같은 강도의 바인딩 — standalone
 verifier lane이 자기 run id로 커밋하고, 사람 확인이 operator 인증 경로(dashboard HITL)를
 타는 것 — 은 B7 후속이다. 이 PR은 그 바인딩이 꽂힐 typed 슬롯을 만든다.
@@ -201,7 +211,7 @@ verifier lane이 자기 run id로 커밋하고, 사람 확인이 operator 인증
 `decide_transition`의 대각선 규칙("목표 phase에 이미 있는 요청은 Already")을 두 방향으로
 확장한다:
 
-- `Verifying`/`Awaiting_confirmation`에서의 `request_complete` → `Already <현재 phase>`
+- `Verifying`에서의 `request_complete` → `Already <현재 phase>`
   (완료 요청은 파이프라인에 진입해 있다). 핸들러는 이 응답에 verification 상태를 실어
   재시도 힌트로 쓴다 — wall-clock 만료 대신 명시적 재호출.
 - `record_criterion_*` → 비종료 phase에서 `Already <현재 phase>`: "phase 불변, ledger만
@@ -233,13 +243,12 @@ Stage 2 (게이트와 함께):
 
 ## 7. 범위 밖 (후속 PR)
 
-- **Stage 2 게이트 전체** — §3.2/§3.3/§4/§5: `Verifying`/`Awaiting_confirmation` phase,
-  gate action 6종, `request_complete` 재라우팅, `mark_*_pending` durable 요청,
+- **Stage 2 게이트 전체** — §3.2/§3.3/§4/§5: `Verifying` phase,
+  gate action 4종, `request_complete` 재라우팅, `mark_*_pending` durable 요청,
   `Criterion_unreachable` 차단. 반드시 아래 caller와 함께 머지한다.
 - **B7: standalone verifier lane** — `Criterion_pending`/`Proof_pending`을 drain해
   `Task.Anti_rationalization.review`로 판정하고 §3.3/§4.1 action으로 커밋하는 Eio worker.
   `completion_authority_agent.start`의 Goal 판.
-- `human_confirm`의 operator 인증 바인딩 (dashboard HITL 경로).
 - 대시보드 프런트엔드 렌더링(phase badge, verdict 카드).
 - `Verifying` 중 `pause` — 현재는 invalid; 필요해지면 별도 RFC.
 
@@ -261,7 +270,7 @@ Stage 1 (이 PR):
 Stage 2 (후속):
 
 1. criterion `unreachable` 판정 후 `request_complete`이 conflict로 거절된다.
-2. `request_complete → record_proof_proven → human_confirm` 왕복으로만 `Completed`에
-   도달하고, ledger가 `human_confirmed`(proof 사슬 포함)를 보인다.
+2. `request_complete → record_proof_proven` 으로만 `Completed`에 도달하고,
+   ledger가 그 proof verdict 를 보인다.
 3. `record_proof_refuted`는 goal을 `Executing`으로 되돌리고 refuted verdict가 ledger에
    남는다.


### PR DESCRIPTION
## 왜

초안은 `Completed` 를 사람 뒤에 두었습니다:

```
Verifying -(record_proof_proven)-> Awaiting_confirmation -(human_confirm)-> Completed
```

실측이 그 전제를 지지하지 않습니다.

## 실측 (2026-08-20, `goal_events.jsonl`)

`Completed` 에 도달한 Goal 18건의 종결 주체:

| 주체 | 건수 |
|---|---|
| **Keeper 자신** (rondo·sangsu·kidsnote·analyst) | **8** |
| admin | 4 |
| operator-reap · full-cycle-probe · codex-mcp-client | 6 |

**"사람이 보고 동의했다"는 사건이 없습니다.** 그 사람이 볼 표면조차 이 RFC 의 §7 범위 밖에 있습니다.

## 게이트가 성립하지 않는 이유

action enum 이 `List.map action_to_string Goal_phase.all_actions` 로 생성됩니다. 새 action 은 그대로 `masc_goal_transition` 스키마에 실리므로 **Keeper 가 자기 Goal 의 `human_confirm` 을 스스로 누를 수 있습니다.**

- 누를 수 있으면 → 게이트는 이름만 남고 턴 수만 2회 늘어납니다
- 못 누르게 막으면 → Goal 이 `Awaiting_confirmation` 에서 나올 길을 잃습니다

어느 쪽이든 헌법 게이트 조항("게이트로 얻는 실익이 크고 Feature 가 더 잘 돌아갈 때만")에 걸립니다. 방금 걷어낸 `active_goal_ids` 와 같은 모양입니다 — 게이트인 척하면서 상태를 가두는 것.

## 남는 것

측정을 하는 절반은 남깁니다: `record_proof_proven` / `record_proof_refuted`. 증거를 읽은 verifier 가 커밋하고, 그 verdict 하나가 완료를 결정합니다. **동작이 판정합니다.**

```
Verifying -(record_proof_proven)-> Completed
Verifying -(record_proof_refuted)-> Executing
```

사람의 확인은 관측 표면에 둡니다. 상태를 붙잡는 phase 가 아닙니다.

## 함께 바뀐 것

이 RFC 가 구현하려던 헌법 조항도 같이 고쳤습니다 (`~/me/instructions/masc-design.xml`):

> 완료 조건: 생성 시 지정한 성공조건을 Verifier 가 **동작으로** 증명한다.
> 사람의 확인은 관측 표면이지 상태 게이트가 아니다.

헌법을 안 고치면 다음 stage 에서 같은 설계가 다시 올라옵니다.

## 영향

Stage 1(#29152, merged)은 lifecycle 을 바꾸지 않았으므로 이 문서 변경만으로 코드 영향은 없습니다. Stage 2 를 구현할 때 phase 1종 + action 2종만 추가하게 됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6b6HtQuqvA9ptz4ExFNpH