### PR TITLE
fix(systemd): masc.service 가 서버를 못 띄운다

### DIFF
--- a/infrastructure/systemd/masc.service
+++ b/infrastructure/systemd/masc.service
@@ -1,4 +1,4 @@
-# MASC MCP – Linux systemd unit, parity with infrastructure/launchd/com.jeong-sik.masc.plist.
+# MASC MCP – Linux systemd unit, parity with infrastructure/launchd/com.example.masc.plist.template.
 #
 # Why this exists:
 #   The launchd plist covers macOS dev/prod, but production Linux hosts
@@ -34,7 +34,21 @@ Environment=MASC_PORT=8080
 Environment=MASC_SHUTDOWN_CLEANUP_TIMEOUT=10
 Environment=MASC_SHUTDOWN_FORCE_TIMEOUT=60
 
-ExecStart=/opt/masc/bin/masc --http --port 8080 --base-path /var/lib/masc
+# 프로바이더 자격증명은 unit 파일에 넣지 않는다. 키가 없으면 서버는 뜨지만
+# keeper 턴이 프로바이더 호출에서 실패한다. 선행 '-' 는 파일이 없어도
+# 기동을 막지 않는다는 뜻이다.
+#   sudo install -d -m 0700 -o masc -g masc /etc/masc
+#   sudo install -m 0600 -o masc -g masc /dev/null /etc/masc/masc.env
+# 형식은 KEY=VALUE 한 줄씩이며 셸 확장은 일어나지 않는다.
+EnvironmentFile=-/etc/masc/masc.env
+
+# --http 는 바이너리 플래그가 아니라 start-masc.sh 래퍼의 플래그다
+# (start-masc.sh:733). launchd 는 그 래퍼를 거치지만 systemd 는 바이너리를
+# 직접 실행하므로, 래퍼 인자를 그대로 옮기면
+#   masc: unknown option '--http'
+# 로 즉시 종료하고 Restart=on-failure + RestartSec=30s 아래에서
+# 30 초 주기 재시작 루프가 된다. 서버 기동은 start 서브커맨드다.
+ExecStart=/opt/masc/bin/masc start --base-path=/var/lib/masc --host=0.0.0.0 --port=8080
 
 # Graceful shutdown contract — TimeoutStopSec is set a few seconds
 # larger than the server's force timeout (MASC_SHUTDOWN_FORCE_TIMEOUT=60)


### PR DESCRIPTION
## 증상

`infrastructure/systemd/masc.service` 를 그대로 설치하면 서비스가 뜨지 않는다.

```
masc: unknown option '--http'. Did you mean '--help'?
```

`Restart=on-failure` + `RestartSec=30s` 아래에서 30 초마다 재시작을 반복한다. 서버는 한 번도 리슨하지 않는다.

## 원인

`--http` 는 바이너리 플래그가 아니라 `start-masc.sh` 래퍼의 플래그다 (`start-masc.sh:733`).

launchd template 은 래퍼를 거친다.

```xml
<string>/bin/bash</string>
<string>__REPO_PATH__/start-masc.sh</string>
<string>--http</string>
```

systemd 는 바이너리를 직접 실행하므로 같은 인자를 쓸 수 없다. unit 이 launchd 와의 parity 를 목표로 작성되면서 래퍼 인자를 그대로 옮긴 것으로 보인다.

바이너리의 기동 경로는 `start` 서브커맨드다.

```
start [--base-path=PATH] [--host=HOST] [--port=PORT] [OPTION]…
    Start the MASC MCP server (HTTP/SSE).
```

## 검증

aarch64 Linux 컨테이너에서 수정된 `ExecStart` 를 그대로 실행했다.

```
[Server] [auto 0.0.0.0:8080] HTTP auto-detect mode: HTTP/1.1 + HTTP/2 h2c on same port
[startup] subsystems: keeper loops started
```

## 함께 담은 것

**`EnvironmentFile=-/etc/masc/masc.env`**

프로바이더 자격증명을 `Environment=` 로 인라인할 수 없다. 키가 없어도 서버는 뜨지만 keeper 턴이 프로바이더 호출에서 실패한다. masc 는 18 개 변수를 프로세스 환경에서 읽는다 (`ANTHROPIC_API_KEY`, `ZAI_API_KEY`, `DISCORD_BOT_TOKEN`, `SLACK_BOT_TOKEN` 등). 선행 `-` 는 파일이 없어도 기동을 막지 않는다.

**헤더 주석의 잘못된 경로**

`infrastructure/launchd/com.jeong-sik.masc.plist` 를 가리키고 있었으나 그런 파일은 없다. 실제 파일명은 `com.example.masc.plist.template` 이다.

## 범위 밖

같은 디렉토리의 `masc-worktree-cleanup.service` 와 `masc-docker-prune.service` 는 `ExecStart` 가 스크립트를 호출하므로 이 결함이 없다.
