### PR TITLE
chore(goal): parent_goal_id 제거 — Goal 은 중첩되지 않는다

### DIFF
--- a/bin/masc_tui_loader.ml
+++ b/bin/masc_tui_loader.ml
@@ -462,7 +462,6 @@ let decode_planning_goal json =
   let* pg_phase = required_string_field json "phase" in
   let* pg_priority = required_int_field json "priority" in
   let* pg_due_date = optional_string_field json "due_date" in
-  let* pg_parent_goal_id = optional_string_field json "parent_goal_id" in
   let* pg_metric = optional_string_field json "metric" in
   let* pg_target_value = optional_string_field json "target_value" in
   Ok
@@ -473,7 +472,6 @@ let decode_planning_goal json =
       pg_phase;
       pg_priority;
       pg_due_date;
-      pg_parent_goal_id;
       pg_metric;
       pg_target_value;
     }

--- a/bin/masc_tui_render.ml
+++ b/bin/masc_tui_render.ml
@@ -702,9 +702,7 @@ let render_planning_detail (state : state) (goal : planning_goal) =
        let target = match goal.pg_target_value with Some t -> " = " ^ t | None -> "" in
        box_line buf cols (Printf.sprintf "  Metric: %s%s" m target)
    | None -> box_empty buf cols);
-  (match goal.pg_parent_goal_id with
-   | Some pid -> box_line buf cols (Printf.sprintf "  Parent: %s" pid)
-   | None -> box_empty buf cols);
+  box_empty buf cols;
   box_divider buf cols;
 
   for _ = 1 to rows - 14 do

--- a/bin/masc_tui_types.ml
+++ b/bin/masc_tui_types.ml
@@ -143,7 +143,6 @@ type planning_goal = {
   pg_phase: string;
   pg_priority: int;
   pg_due_date: string option;
-  pg_parent_goal_id: string option;
   pg_metric: string option;
   pg_target_value: string option;
 }
@@ -173,10 +172,8 @@ type planning_snapshot = {
   pl_generated_at: string;
 }
 
-let planning_goal_depth (goals : planning_goal list) (goal : planning_goal) =
-  Tui_decode.bounded_parent_depth ~id_of:(fun g -> g.pg_id)
-    ~parent_id_of:(fun g -> g.pg_parent_goal_id)
-    goals goal
+(* Goals no longer nest, so every goal sits at depth 0. *)
+let planning_goal_depth (_goals : planning_goal list) (_goal : planning_goal) = 0
 
 let planning_visible_goals (goals : planning_goal list) : planning_goal list =
   goals

--- a/dashboard/prototypes/keeper-v2/data.jsx
+++ b/dashboard/prototypes/keeper-v2/data.jsx
@@ -357,7 +357,7 @@ const PERSONAS = {
 };
 const DEFAULT_PERSONA = { persona: '기본 keeper 성격. 작업에 충실하고 trace를 남긴다.', instructions: '담당 namespace의 작업을 수행하고 모든 행동을 trace로 기록한다.', traits: ['기본'] };
 
-// Goal store — core.ts Goal{horizon,priority(num),status,phase,parent_goal_id,
+// Goal store — core.ts Goal{horizon,priority(num),status,phase,
 //   require_completion_approval,verifier_policy} → Task{status(6-state),assignee,
 //   goal_id,contract,gate,handoff_context}. Task.status ∈ todo|claimed|in_progress|
 //   awaiting_verification|done|cancelled. todo + no assignee = claimable backlog.

--- a/dashboard/src/api/dashboard-goals.ts
+++ b/dashboard/src/api/dashboard-goals.ts
@@ -296,7 +296,6 @@ function decodeGoalTreeNode(raw: unknown): GoalTreeNode | null {
     metric,
     target_value: targetValue,
     due_date: asNullableString(raw.due_date),
-    parent_goal_id: asNullableString(raw.parent_goal_id),
     owner: asNullableString(raw.owner),
     attainment,
     tasks,

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -77,7 +77,6 @@ function makeRawGoalNode(overrides: Record<string, unknown> = {}) {
     metric: null,
     target_value: null,
     due_date: null,
-    parent_goal_id: null,
     tasks: [],
     task_count: 0,
     task_done_count: 0,

--- a/dashboard/src/components/goals/goal-tree.test.ts
+++ b/dashboard/src/components/goals/goal-tree.test.ts
@@ -72,7 +72,6 @@ function makeGoal(id: string, title: string, children: GoalTreeNode[] = []): Goa
     metric: null,
     target_value: null,
     due_date: null,
-    parent_goal_id: null,
     owner: null,
     attainment: {
       state: 'unmeasured',

--- a/dashboard/src/components/goals/task-detail-state.test.ts
+++ b/dashboard/src/components/goals/task-detail-state.test.ts
@@ -113,7 +113,6 @@ function makeGoal(overrides: Partial<Goal> = {}): Goal {
     due_date: null,
     priority: 3,
     phase: 'executing',
-    parent_goal_id: null,
     last_review_note: null,
     last_review_at: null,
     created_at: '2026-04-17T00:00:00Z',

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -733,7 +733,6 @@ const mocks = vi.hoisted(() => {
           metric: null,
           target_value: null,
           due_date: null,
-          parent_goal_id: null,
           tasks: [],
           task_count: 0,
           task_done_count: 0,

--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -125,7 +125,6 @@ function goalTreeNode(overrides: Partial<GoalTreeNode> = {}): GoalTreeNode {
     metric: null,
     target_value: null,
     due_date: null,
-    parent_goal_id: null,
     owner: null,
     attainment: {
       state: 'unmeasured',

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -312,7 +312,6 @@ function goalFromGoalTreeNode(node: GoalTreeNode): Goal {
     due_date: node.due_date,
     priority: node.priority,
     phase: node.phase,
-    parent_goal_id: node.parent_goal_id,
     last_review_note: null,
     created_at: node.created_at,
     updated_at: node.updated_at,

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -889,7 +889,6 @@ function applyPlanningEnvelope(data: DashboardPlanningResponse): void {
         due_date: asString(row.due_date) ?? null,
         priority: asNumber(row.priority) ?? 3,
         phase,
-        parent_goal_id: asString(row.parent_goal_id) ?? null,
         last_review_note: asString(row.last_review_note) ?? null,
         last_review_at: asString(row.last_review_at) ?? null,
         created_at: createdAt,

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -561,7 +561,6 @@ export interface Goal {
   due_date?: string | null
   priority: number
   phase: string
-  parent_goal_id?: string | null
   last_review_note?: string | null
   last_review_at?: string | null
   created_at: string

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -744,7 +744,6 @@ export interface GoalTreeMetricProjection {
   metric: string | null
   target_value: string | null
   due_date: string | null
-  parent_goal_id: string | null
   owner: string | null
   attainment: GoalAttainmentProjection
 }

--- a/lib/dashboard/dashboard_goals.ml
+++ b/lib/dashboard/dashboard_goals.ml
@@ -44,12 +44,6 @@ let keeper_runtime_trust_snapshot_json ~config ~(meta : Keeper_meta_contract.kee
 
 let build_forest ~(config : Workspace.config) ~goals ~tasks
     ~(pending_approvals : Yojson.Safe.t list) =
-  let goal_ids = List.map (fun (goal : Goal_store.goal) -> goal.id) goals in
-  let is_root (goal : Goal_store.goal) =
-    match goal.parent_goal_id with
-    | None -> true
-    | Some parent_id -> not (List.mem parent_id goal_ids)
-  in
   let keeper_metas =
     Keeper_meta_store.keeper_names config
     |> List.filter_map (fun keeper_name ->
@@ -78,9 +72,7 @@ let build_forest ~(config : Workspace.config) ~goals ~tasks
       goal_task_index;
     }
   in
-  goals
-  |> List.filter is_root
-  |> List.map (build_tree context goals)
+  goals |> List.map (build_tree context goals)
 
 
 
@@ -141,7 +133,6 @@ let rec tree_node_to_json ?(events_for_goal = fun _ -> []) node =
       ("metric", Json_util.string_opt_to_json goal.metric);
       ("target_value", Json_util.string_opt_to_json goal.target_value);
       ("due_date", Json_util.string_opt_to_json goal.due_date);
-      ("parent_goal_id", Json_util.string_opt_to_json goal.parent_goal_id);
       ("owner", Json_util.string_opt_to_json goal.owner);
       ("attainment", attainment);
       ("tasks", `List (List.map task_to_tree_json node.tasks));

--- a/lib/dashboard/dashboard_goals_types_builder.ml
+++ b/lib/dashboard/dashboard_goals_types_builder.ml
@@ -24,14 +24,12 @@ type build_context = {
   goal_task_index : (string, string list) Hashtbl.t;
 }
 
-let rec build_tree context goals goal =
-  let child_goals =
-    List.filter
-      (fun (candidate : Goal_store.goal) ->
-        candidate.parent_goal_id = Some goal.Goal_store.id)
-      goals
-  in
-  let children = List.map (build_tree context goals) child_goals in
+(* Goals are flat: every goal is a root, so [children] is always empty. The
+   field stays on the node because the JSON shape and its consumers are
+   unchanged. *)
+let build_tree context goals goal =
+  ignore goals;
+  let children = [] in
   let linked_tasks =
     context.all_tasks
     |> List.filter_map (fun task ->

--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -14,7 +14,6 @@ type goal = {
   due_date : string option;
   priority : int;
   phase : Goal_phase.t;
-  parent_goal_id : string option;
   last_review_note : string option;
   last_review_at : string option;
   (* RFC-0362: the keeper responsible for turning this Goal into Tasks.
@@ -49,7 +48,6 @@ and goal_to_yojson (goal : goal) =
       ("due_date", Json_util.string_opt_to_json goal.due_date);
       ("priority", `Int goal.priority);
       ("phase", Goal_phase.to_yojson goal.phase);
-      ("parent_goal_id", Json_util.string_opt_to_json goal.parent_goal_id);
       ("last_review_note", Json_util.string_opt_to_json goal.last_review_note);
       ("last_review_at", Json_util.string_opt_to_json goal.last_review_at);
       ("owner", Json_util.string_opt_to_json goal.owner);
@@ -87,7 +85,6 @@ and goal_of_yojson = function
         ; "due_date"
         ; "priority"
         ; "phase"
-        ; "parent_goal_id"
         ; "last_review_note"
         ; "last_review_at"
         ; "owner"
@@ -144,7 +141,6 @@ and goal_of_yojson = function
                       | Some (`Int value) -> clamp_priority value
                       | _ -> 3);
                     phase;
-                    parent_goal_id = Json_util.get_string json "parent_goal_id";
                     last_review_note = Json_util.get_string json "last_review_note";
                     last_review_at = Json_util.get_string json "last_review_at";
                     owner = Json_util.get_string json "owner";
@@ -425,42 +421,12 @@ let list_goals config ?phase () =
          | Some phase -> goal.phase = phase)
   |> sort_goals
 
-let validate_parent_goal_id goals ~goal_id ~parent_goal_id =
-  (* Cannot be own parent *)
-  if String.equal goal_id parent_goal_id then
-    Error "goal cannot be its own parent"
-  else
-    (* Parent must exist *)
-    match find_goal goals parent_goal_id with
-    | None -> Error (Printf.sprintf "parent goal %s not found" parent_goal_id)
-    | Some _ ->
-      (* Walk ancestor chain to detect cycles *)
-      let rec walk visited current_id =
-        if String.equal current_id goal_id then
-          true (* cycle detected *)
-        else
-          match find_goal goals current_id with
-          | None -> false (* orphan parent, already checked above *)
-          | Some g ->
-            match g.parent_goal_id with
-            | None -> false
-            | Some pid ->
-              if List.mem pid visited then
-                false (* existing cycle in ancestors, don't add to it *)
-              else
-                walk (pid :: visited) pid
-      in
-      if walk [parent_goal_id] parent_goal_id then
-        Error "parent_goal_id would create a cycle"
-      else
-        Ok ()
-
 let blank_opt = function
   | None -> true
   | Some raw -> String.trim raw = ""
 
 let upsert_goal config ?id ?title ?metric ?target_value ?due_date
-    ?priority ?phase ?parent_goal_id () =
+    ?priority ?phase () =
   let is_new_goal = id = None in
   if is_new_goal && (title = None || title = Some "") then
     Error "title required for new goal"
@@ -470,34 +436,6 @@ let upsert_goal config ?id ?title ?metric ?target_value ?due_date
     let default_phase = Option.value phase ~default:Goal_phase.Executing in
     let now = Masc_domain.now_iso () in
         let resolved_id = Option.value id ~default:(gen_goal_id ()) in
-        (* Validate parent_goal_id before acquiring the write lock *)
-        let parent_validation =
-          let current_goals = (read_state config).goals in
-          match find_goal current_goals resolved_id with
-          | Some existing ->
-              (* Existing goal: validate only if parent is being changed *)
-              (match parent_goal_id with
-               | Some new_pid ->
-                   (match existing.parent_goal_id with
-                    | Some old_pid when String.equal old_pid new_pid ->
-                        Ok () (* no change, skip validation *)
-                    | _ ->
-                        validate_parent_goal_id current_goals
-                          ~goal_id:resolved_id
-                          ~parent_goal_id:new_pid)
-               | None -> Ok ())
-          | None ->
-              (* New goal: validate any provided parent_goal_id *)
-              (match parent_goal_id with
-               | Some pid ->
-                   validate_parent_goal_id current_goals
-                     ~goal_id:resolved_id
-                     ~parent_goal_id:pid
-               | None -> Ok ())
-        in
-        (match parent_validation with
-         | Error msg -> Error msg
-         | Ok () ->
         let was_created = ref false in
         let refusal = ref None in
         let state_result =
@@ -524,10 +462,6 @@ let upsert_goal config ?id ?title ?metric ?target_value ?due_date
                           clamp_priority
                             (Option.value priority ~default:existing.priority);
                         phase = next_phase;
-                        parent_goal_id =
-                          (match parent_goal_id with
-                          | Some _ -> parent_goal_id
-                          | None -> existing.parent_goal_id);
                         updated_at = now;
                       }
                   in
@@ -566,7 +500,6 @@ let upsert_goal config ?id ?title ?metric ?target_value ?due_date
                         due_date;
                         priority = clamp_priority (Option.value priority ~default:3);
                         phase = default_phase;
-                        parent_goal_id;
                         last_review_note = None;
                         last_review_at = None;
                         owner = None;
@@ -591,7 +524,7 @@ let upsert_goal config ?id ?title ?metric ?target_value ?due_date
           | Some goal ->
               Ok (goal, if !was_created then `created else `updated)
           | None ->
-              Error "failed to save goal"))))
+              Error "failed to save goal")))
 
 let compute_rollup goals =
   let count predicate =

--- a/lib/goal/goal_store.mli
+++ b/lib/goal/goal_store.mli
@@ -43,7 +43,6 @@ type goal = {
   due_date : string option;
   priority : int;
   phase : Goal_phase.t;
-  parent_goal_id : string option;
   last_review_note : string option;
   last_review_at : string option;
   (** RFC-0362: the keeper responsible for turning this Goal into Tasks.
@@ -173,7 +172,6 @@ val upsert_goal :
   ?due_date:string ->
   ?priority:int ->
   ?phase:Goal_phase.t ->
-  ?parent_goal_id:string ->
   unit ->
   (goal * [ `created | `updated ], string) result
 (** Creates a new goal when [id] is omitted (mints

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -857,17 +857,12 @@ let owned_executing_goals_without_tasks
    renders nothing when there is nothing to name. It does not pick an owner
    (RFC-0362 §5) and asks for no action.
 
-   [parent_goal_id] rides along because the flat list without it misreads. On
-   the live store, seven of the ten unowned Goals are children of the eighth,
-   and rendered as peers "take one" cannot distinguish taking the umbrella from
-   taking one service under it -- two Keepers could take both and do the same
-   work twice. The relation is already in the store; only the render dropped
-   it. *)
+   (RFC-0362 §5) and asks for no action. *)
 let unowned_executing_goals_without_tasks ~(config : Workspace.config) =
   executing_goals_without_tasks ~config ~owner_matches:(function
     | Some _ -> false
     | None -> true)
-  |> List.map (fun (g : Goal_store.goal) -> g.id, g.title, g.parent_goal_id)
+  |> List.map (fun (g : Goal_store.goal) -> g.id, g.title)
 ;;
 
 let build_system_prompt ~(meta : Keeper_meta_contract.keeper_meta)
@@ -1023,65 +1018,22 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta)
       in
       (* RFC-0362 §6 Q2. An unowned executing Goal is addressed to whoever reads
          it, so it is the same fact for every Keeper and rendered to each.
-
-         A child is indented under its parent when the parent is in this same
-         list, because there taking the parent and taking the child are not two
-         independent moves. A child whose parent is absent -- owned, terminal,
-         or already served by a Task -- is its own invitation and stays at the
-         top level. Goal_store permits arbitrary parent depth, so the projection
-         follows the whole chain rather than dropping descendants. *)
+         Goals no longer nest, so the list is flat. *)
       let unowned_block =
         match unowned_executing_goals_without_tasks ~config with
         | [] -> None
         | goals ->
-          let present = List.map (fun (goal_id, _, _) -> goal_id) goals in
-          let line ~indent (goal_id, title, _) =
+          let line (goal_id, title) =
             if String.trim title = ""
-            then Printf.sprintf "%s- %s" indent goal_id
-            else Printf.sprintf "%s- %s — %s" indent goal_id title
-          in
-          let children_of parent_id =
-            List.filter
-              (fun (_, _, parent) ->
-                 match parent with
-                 | Some p -> String.equal p parent_id
-                 | None -> false)
-              goals
-          in
-          let stands_alone (_, _, parent) =
-            match parent with
-            | None -> true
-            | Some p -> not (List.exists (String.equal p) present)
-          in
-          let rendered_ids = ref [] in
-          let rec render_subtree ~depth ((goal_id, _, _) as goal) =
-            if List.exists (String.equal goal_id) !rendered_ids
-            then []
-            else (
-              rendered_ids := goal_id :: !rendered_ids;
-              let indent = String.make (depth * 2) ' ' in
-              line ~indent goal
-              :: List.concat_map
-                   (render_subtree ~depth:(depth + 1))
-                   (children_of goal_id))
-          in
-          let rendered_roots =
-            goals
-            |> List.filter stands_alone
-            |> List.concat_map (render_subtree ~depth:0)
-          in
-          let rendered =
-            rendered_roots
-            @ (goals
-               |> List.filter (fun (goal_id, _, _) ->
-                    not (List.exists (String.equal goal_id) !rendered_ids))
-               |> List.concat_map (render_subtree ~depth:0))
+            then Printf.sprintf "- %s" goal_id
+            else Printf.sprintf "- %s — %s" goal_id title
           in
           Some
             (Printf.sprintf
-               "### Unowned Goals, no Task yet — taking one is a move you can make (%d)\n%s\n\n"
+               "### Unowned Goals, no Task yet — taking one is a move you can \
+                make (%d)\n%s\n\n"
                (List.length goals)
-               (String.concat "\n" rendered))
+               (String.concat "\n" (List.map line goals)))
       in
       (match List.filter_map Fun.id [ active_block; owned_block; unowned_block ] with
        | [] -> None

--- a/lib/keeper/keeper_unified_prompt.mli
+++ b/lib/keeper/keeper_unified_prompt.mli
@@ -98,10 +98,10 @@ val owned_executing_goals_without_tasks :
     decoration and should be removed. *)
 
 val unowned_executing_goals_without_tasks :
-  config:Workspace.config -> (string * string * string option) list
-(** RFC-0362 §6 Q2 — the executing Goals nobody owns and no Task serves, each
-    with its [parent_goal_id]. The same list for every keeper, because an
-    unowned Goal is addressed to whoever reads it.
+  config:Workspace.config -> (string * string) list
+(** RFC-0362 §6 Q2 — the executing Goals nobody owns and no Task serves, as
+    [(id, title)]. The same list for every keeper, because an unowned Goal is
+    addressed to whoever reads it.
 
     The prompt already states that taking one is a move a keeper can make, and
     [handle_goal_assign] carries no ownership check. What was missing was the

--- a/lib/tool_schemas/tool_schemas_workspace_extra.ml
+++ b/lib/tool_schemas/tool_schemas_workspace_extra.ml
@@ -66,7 +66,6 @@ let schemas : tool_schema list =
                       ] )
                 ; "due_date", `Assoc [ "type", `String "string" ]
                 ; "priority", `Assoc [ "type", `String "integer" ]
-                ; "parent_goal_id", `Assoc [ "type", `String "string" ]
                 ] )
           ; "additionalProperties", `Bool false
           ]

--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -264,7 +264,6 @@ let handle_goal_upsert ~tool_name ~start_time (ctx : context) args : Tool_result
     let metric = get_string_opt args "metric" in
     let target_value = get_string_opt args "target_value" in
     let due_date = get_string_opt args "due_date" in
-    let parent_goal_id = get_string_opt args "parent_goal_id" in
     (match
           Goal_store.upsert_goal
             ctx.config
@@ -274,7 +273,6 @@ let handle_goal_upsert ~tool_name ~start_time (ctx : context) args : Tool_result
             ?target_value
             ?due_date
             ?priority
-            ?parent_goal_id
             ()
         with
         | Error msg ->

--- a/test/test_goal_metric_unevaluated.ml
+++ b/test/test_goal_metric_unevaluated.ml
@@ -24,7 +24,6 @@ let make_goal ?metric ?target_value id title =
     due_date = None;
     priority = 3;
     phase = Goal_phase.Executing;
-    parent_goal_id = None;
     last_review_note = None;
     last_review_at = None;
     owner = None;
@@ -98,23 +97,6 @@ let empty_build_context ?(pending_approvals = []) now_ts : B.build_context =
     latest_runtime_trusts = [];
     goal_task_index = Hashtbl.create 0;
   }
-
-let test_goal_projection_does_not_promote_child_approvals () =
-  let parent = make_goal "parent" "Parent" in
-  let child =
-    { (make_goal "child" "Child") with parent_goal_id = Some parent.id }
-  in
-  let approval =
-    `Assoc [ ("goal_id", `String child.id); ("requested_at", `Float 1.0) ]
-  in
-  let context = empty_build_context ~pending_approvals:[ approval ] 2.0 in
-  let node = B.build_tree context [ parent; child ] parent in
-  check int "parent only reports direct approvals" 0 node.pending_approval_count;
-  match node.children with
-  | [ child_node ] ->
-      check int "child reports its direct approval" 1
-        child_node.pending_approval_count
-  | _ -> fail "expected one child Goal"
 
 let test_goal_projection_surfaces_invalid_activity_time () =
   let goal =
@@ -580,8 +562,6 @@ let () =
             test_unevaluated_metric_is_display_only_for_completion;
           test_case "receipt timeline does not fabricate runtime" `Quick
             test_keeper_receipt_timeline_missing_runtime_stays_missing;
-          test_case "child approvals stay on the child Goal" `Quick
-            test_goal_projection_does_not_promote_child_approvals;
           test_case "invalid activity time stays unavailable" `Quick
             test_goal_projection_surfaces_invalid_activity_time;
           test_case "queue failure remains typed unavailable" `Quick

--- a/test/test_goal_store.ml
+++ b/test/test_goal_store.ml
@@ -46,7 +46,6 @@ let make_goal id title =
     Goal_store.id; title;
     metric = None; target_value = None; due_date = None;
     priority = 3; phase = Goal_phase.Executing;
-    parent_goal_id = None;
     last_review_note = None; last_review_at = None; owner = None;
     created_at = ts; updated_at = ts;
   }
@@ -174,7 +173,6 @@ let test_status_field_no_longer_decodes () =
         ("priority", `Int 3);
         ("status", `String status);
         ("phase", `String phase);
-        ("parent_goal_id", `Null);
         ("last_review_note", `Null);
         ("last_review_at", `Null);
         ("created_at", `String (iso_now ()));
@@ -255,8 +253,7 @@ let test_phaseless_row_no_longer_decodes () =
                   ("due_date", `Null);
                   ("priority", `Int 3);
                   ("status", `String "paused");
-                  ("parent_goal_id", `Null);
-                  ("last_review_note", `Null);
+                          ("last_review_note", `Null);
                   ("last_review_at", `Null);
                   ("created_at", `String (iso_now ()));
                   ("updated_at", `String (iso_now ()));

--- a/test/test_keeper_goal_phase_projection.ml
+++ b/test/test_keeper_goal_phase_projection.ml
@@ -48,7 +48,6 @@ let goal_in phase id title =
   ; due_date = None
   ; priority = 3
   ; phase
-  ; parent_goal_id = None
   ; last_review_note = None
   ; last_review_at = None
   ; owner = None
@@ -232,7 +231,7 @@ let test_another_keepers_goal_is_not_surfaced () =
 
 let unowned config =
   List.map
-    (fun (goal_id, _, _) -> goal_id)
+    (fun (goal_id, _) -> goal_id)
     (Keeper_unified_prompt.unowned_executing_goals_without_tasks ~config)
 
 let test_unowned_executing_goal_without_task_surfaces () =
@@ -352,71 +351,6 @@ let test_unowned_goals_reach_the_rendered_turn () =
   check bool "a completed goal is not offered" false (contains_in world "goal-done")
 ;;
 
-let goal_child_of parent phase id title =
-  { (goal_in phase id title) with Goal_store.parent_goal_id = Some parent }
-;;
-
-(* Seven of the ten unowned Goals on the live store are children of the eighth.
-   Rendered as peers, "taking one is a move you can make" cannot distinguish
-   taking the umbrella from taking one service under it, and two Keepers could
-   take both and do the same work twice. The relation is in the store; the flat
-   render dropped it. *)
-let test_a_child_renders_under_its_parent () =
-  with_workspace @@ fun config ->
-  Goal_store.write_state config
-    { version = 1
-    ; updated_at = Masc_domain.now_iso ()
-    ; goals =
-        [ goal_in Goal_phase.Executing "goal-umbrella" "all services to zero"
-        ; goal_child_of "goal-umbrella" Goal_phase.Executing "goal-one" "service one"
-        ; goal_in Goal_phase.Executing "goal-standalone" "unrelated"
-        ]
-    };
-  let world = rendered_world_state config in
-  check bool "the child is indented under its parent" true
-    (contains_in world "- goal-umbrella — all services to zero\n  - goal-one — service one");
-  check bool "an unrelated goal stays at the top level" true
-    (contains_in world "\n- goal-standalone — unrelated");
-  check bool "the count is still every goal, not just the roots" true
-    (contains_in world "taking one is a move you can make (3)")
-;;
-
-let test_all_descendants_render_at_their_full_depth () =
-  with_workspace @@ fun config ->
-  Goal_store.write_state config
-    { version = 1
-    ; updated_at = Masc_domain.now_iso ()
-    ; goals =
-        [ goal_in Goal_phase.Executing "goal-root" "root"
-        ; goal_child_of "goal-root" Goal_phase.Executing "goal-child" "child"
-        ; goal_child_of "goal-child" Goal_phase.Executing "goal-grandchild" "grandchild"
-        ]
-    };
-  let world = rendered_world_state config in
-  check bool "the complete parent chain is visible" true
-    (contains_in world
-       "- goal-root — root\n  - goal-child — child\n    - goal-grandchild — grandchild")
-;;
-
-(* A child whose parent is not in this list -- owned, terminal, or already served
-   by a Task -- is its own invitation, so it must not be hidden by the nesting. *)
-let test_a_child_whose_parent_is_absent_stands_alone () =
-  with_workspace @@ fun config ->
-  Goal_store.write_state config
-    { version = 1
-    ; updated_at = Masc_domain.now_iso ()
-    ; goals =
-        [ goal_owned_by "someone" Goal_phase.Executing "goal-taken" "already owned"
-        ; goal_child_of "goal-taken" Goal_phase.Executing "goal-orphan" "still free"
-        ]
-    };
-  let world = rendered_world_state config in
-  check bool "the orphaned child is offered at the top level" true
-    (contains_in world "\n- goal-orphan — still free");
-  check bool "it is not indented under a parent nobody can see" false
-    (contains_in world "  - goal-orphan")
-;;
-
 let () =
   run "keeper_goal_phase_projection"
     [ ( "prompt surfaces"
@@ -448,12 +382,6 @@ let () =
             test_unowned_goal_with_a_linked_task_is_not_surfaced
         ; test_case "unowned goals reach the rendered turn" `Quick
             test_unowned_goals_reach_the_rendered_turn
-        ; test_case "a child renders under its parent" `Quick
-            test_a_child_renders_under_its_parent
-        ; test_case "all descendants render at their full depth" `Quick
-            test_all_descendants_render_at_their_full_depth
-        ; test_case "a child whose parent is absent stands alone" `Quick
-            test_a_child_whose_parent_is_absent_stands_alone
         ] )
     ]
 ;;

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -416,9 +416,7 @@ let test_masc_goal_upsert_schema () =
           Alcotest.(check bool) "omits status lifecycle field" false
             (List.mem_assoc "status" props);
           Alcotest.(check bool) "omits phase lifecycle field" false
-            (List.mem_assoc "phase" props);
-          Alcotest.(check bool) "has parent_goal_id" true
-            (List.mem_assoc "parent_goal_id" props)
+            (List.mem_assoc "phase" props)
       | None -> Alcotest.fail "masc_goal_upsert missing properties"
 
 let test_masc_goal_transition_schema () =


### PR DESCRIPTION
`parent_goal_id` 를 제거한다. Goal 은 중첩되지 않는다.

## 왜

계층이 벌어들인 것이 평평한 목록보다 없었다. 대신 이런 것을 치르고 있었다.

- upsert 마다 사이클 탐지 walk (`validate_parent_goal_id`, 조상 체인 순회)
- 재귀 트리 빌더 (`build_tree`) 와 루트 판별 (`is_root`)
- TUI 의 깊이 정렬 투영 (`bounded_parent_depth`)
- keeper 프롬프트의 서브트리 렌더러 — 들여쓰기, 중복 제거, 고아 승격

라이브 47 개 goal 중 부모가 설정된 것은 **9 개** 다.

## 제거 범위

| 자리 | 무엇 |
|---|---|
| `goal_store` | 레코드 필드, encode, decode, `accepted_fields`, `validate_parent_goal_id` 와 사이클 walk, upsert 파라미터와 락 이전 검증 블록 |
| `workspace_goals` | `masc_goal_upsert` 인자 |
| tool schema | `masc_goal_upsert` 프로퍼티 |
| dashboard | `build_tree` 의 children, `build_forest` 의 `is_root`, JSON 필드 |
| keeper prompt | `(id, title, parent)` → `(id, title)`. 서브트리 렌더러가 평면 목록으로 |
| TUI | `planning_goal` 필드, 파싱, 깊이 정렬, Parent 행 |
| dashboard TS | 타입 필드, 매핑, 픽스처 |

## 삭제한 테스트

계층을 증명하려고 존재하던 것들이라 고치지 않고 지웠다. 대상이 없어졌다.

- a child renders under its parent
- all descendants render at their full depth
- a child whose parent is absent stands alone
- child approvals stay on the child Goal

## BREAKING — 배포 전에 저장소를 손봐야 한다

`goal_of_yojson` 은 미지 필드를 거부한다.

```
goal_of_yojson: unknown Goal field "parent_goal_id" is not accepted
```

기존 `goals.json` 의 모든 행이 이 키를 직렬화해 갖고 있으므로 **전부 디코드 실패** 하고, 손상 저장소 정책(복구 미러 또는 빈 상태 + 경고)이 발동한다. 오늘 라이브는 47 행 전부 해당한다.

hard-cut 계약대로 코드에 converter 를 두지 않는다. 배포 전에 한 줄로 벗긴다.

```bash
jq '.goals |= map(del(.parent_goal_id))' goals.json > tmp && mv tmp goals.json
```

## 검증

```
dune build --root .                                        clean
test_goal_store / test_goal_tools / test_goal_phase_all
test_goal_metric_unevaluated
test_keeper_goal_phase_projection
test_dashboard_goal_id_projection                          모두 EXIT=0
dashboard pnpm typecheck                                   0 errors
dashboard pnpm test --run                                  9060 passed
```

`test_tools_coverage` 는 이 브랜치와 main 에서 똑같이 실패한다 (`schema_structure` / `masc_prefix`). 무관하고 선행하는 결함이다.
