### PR TITLE
chore(ci): unwired 스위트 기준선을 실측값 519로 조인다

### DIFF
--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=520
+UNWIRED_BASELINE=519
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then


### PR DESCRIPTION
## 무엇을

`scripts/audit-ci-test-targets.sh` 가 **현재 main 에서 실패합니다.**

```
[ci-test-targets] FAIL - 519 suites unwired, under the 520 baseline by 1
Set UNWIRED_BASELINE=519 in scripts/audit-ci-test-targets.sh. The gap is not slack to spend:
leaving it lets a later change add an unwired suite and still pass.
```

스크립트가 지시하는 대로 기준선을 실측값으로 내립니다. **계산이 아니라 측정입니다** — 위 명령을 main 체크아웃에서 그대로 돌려 나온 숫자입니다.

## 어디서 온 드리프트인가

#29197(cross_verifier 숙청) 때문이 아닙니다. 그 브랜치를 main 위로 rebase 한 상태에서 숙청 커밋이 있든 없든 **둘 다 519** 였습니다. 그 PR 은 dune stanza 나 `.inc` 를 건드리지 않았습니다.

`#29175` · `#29176` · `#29195` 중 하나가 스위트를 배선하면서 기준선을 안 내렸고, 그 다음 PR 의 CI 에서 드러난 형태입니다.

## 왜 그냥 두면 안 되나

스크립트가 스스로 적어둔 이유가 정확합니다 — 남은 1칸은 여유가 아니라 **다음 변경이 배선 안 된 스위트를 하나 추가하고도 통과할 수 있는 구멍**입니다.

Refs #29197