### PR TITLE
fix(runtime): cross_verifier 숙청 수리 — main이 컴파일되지 않는다 (#29197)

### DIFF
--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -283,20 +283,6 @@ let assignment_references (assignments : (string * string) list) =
     assignments
 ;;
 
-let route_references (routes : (string * string option) list) =
-  List.filter_map
-    (fun (route_name, route_id) ->
-      Option.map
-        (fun id ->
-          { site = Printf.sprintf "[runtime].%s" route_name
-          ; shape = Scalar
-          ; id
-          ; domain = Lane_then_runtime
-          })
-        route_id)
-    routes
-;;
-
 let media_failover_references (media_failover : string list) =
   List.map
     (fun id ->
@@ -935,7 +921,6 @@ let degrade_loaded_for_missing_catalog
   : ( ( t list
         * t
         * (string * string) list
-        * string option
         * string list
         * Runtime_lane.t list )
       * startup_degradation
@@ -998,27 +983,6 @@ let degrade_loaded_for_missing_catalog
            , dropped_lanes ))
       lanes
       ([], [], [])
-  in
-  (* A route id may name a lane (#25394). A lane-targeted route stays live
-     while any candidate survives (the lane itself degrades), and drops only
-     when the whole lane dropped; a runtime-targeted route drops when that
-     runtime is missing. Mirrors [resolve_assignment]'s lane precedence. *)
-  let is_declared_lane id =
-    List.exists (fun lane -> String.equal (Runtime_lane.id lane) id) lanes
-  in
-  let lane_fully_dropped id =
-    List.exists
-      (fun (entry : dropped_runtime_lane) -> String.equal entry.lane_id id)
-      dropped_lanes
-  in
-  let route_unavailable id =
-    if is_declared_lane id then lane_fully_dropped id else is_missing id
-  in
-  let drop_route route_name = function
-    | None -> None, None
-    | Some runtime_id when route_unavailable runtime_id ->
-      None, Some { route_name; runtime_id }
-    | Some _ as value -> value, None
   in
   let dropped_routes =
     [ default_drop ]
@@ -1087,7 +1051,6 @@ let materialize_config
   : ( (t list
        * t
        * (string * string) list
-       * string option
        * string list
        * Runtime_lane.t list)
       * Runtime_schema.exact_output_lane_decl list
@@ -1164,7 +1127,6 @@ let load_list_internal ~(config_path : string) ~validate_max_context
   : ( (t list
        * t
        * (string * string) list
-       * string option
        * string list
        * Runtime_lane.t list)
       * Runtime_schema.exact_output_lane_decl list
@@ -1269,7 +1231,7 @@ let publish_exact_output_registry ?required_lane_ids ~lanes resolver_snapshot =
 let init_default_strict_report ~config_path =
   match load_list_internal ~config_path ~validate_max_context:true with
   | Error msg -> Error (Runtime_config_error msg)
-  | Ok (((runtimes, _, _, _, _, _) as loaded), exact_output_lane_decls) ->
+  | Ok (((runtimes, _, _, _, _) as loaded), exact_output_lane_decls) ->
     (match missing_runtime_model_capabilities ~config_path runtimes with
      | Some report -> Error (Missing_catalog_models report)
      | None ->
@@ -1292,7 +1254,7 @@ let init_default_strict ~config_path =
 let init_default_degraded_report ~config_path =
   match load_list_internal ~config_path ~validate_max_context:false with
   | Error msg -> Error (Runtime_config_error msg)
-  | Ok (((runtimes, _, _, _, _, _) as loaded), exact_output_lane_decls) ->
+  | Ok (((runtimes, _, _, _, _) as loaded), exact_output_lane_decls) ->
     let verifier_exact_slot_ids =
       verifier_exact_slot_ids_of_lane_decls exact_output_lane_decls
     in
@@ -1315,7 +1277,7 @@ let init_default_degraded_report ~config_path =
        (match degrade_loaded_for_missing_catalog loaded report with
         | Error msg -> Error (Runtime_config_error msg)
         | Ok
-            (((active_runtimes, _, _, _, _, _) as degraded_loaded), degradation)
+            (((active_runtimes, _, _, _, _) as degraded_loaded), degradation)
           ->
           (match validate_runtime_max_context ~config_path active_runtimes with
            | Error msg -> Error (Runtime_config_error msg)

--- a/lib/server/server_dashboard_runtime_defaults_json.ml
+++ b/lib/server/server_dashboard_runtime_defaults_json.ml
@@ -66,7 +66,7 @@ let build ~generated_at_iso (r : resolved) : Yojson.Safe.t =
     ; "runtimes", `List (List.map runtime_entry_json r.runtimes)
     ; ( "model_routing"
       , `Assoc
-          [           ; "media_failover", `List (List.map (fun s -> `String s) r.media_failover)
+          [ "media_failover", `List (List.map (fun s -> `String s) r.media_failover)
           ] )
     ]
 ;;

--- a/test/test_runtime_claude_code_config.ml
+++ b/test/test_runtime_claude_code_config.ml
@@ -37,7 +37,7 @@ let load content =
 let test_materializes_official_client_owner () =
   match load (runtime_toml ()) with
   | Error error -> failf "claude-code runtime should load: %s" error
-  | Ok (runtimes, default, _, _, _, _) ->
+  | Ok (runtimes, default, _, _, _) ->
     check int "one runtime" 1 (List.length runtimes);
     check string "default" "claude_code.claude-code-sonnet" default.id;
     (match default.execution with

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -2404,7 +2404,7 @@ let test_runtime_provider_disable_excludes_its_bindings () =
   with_temp_runtime_toml runtime_toml (fun path ->
     match Runtime.load_list ~config_path:path with
     | Error msg -> failf "disabled provider should not block active runtime: %s" msg
-    | Ok (runtimes, _, _, _, _, _) ->
+    | Ok (runtimes, _, _, _, _) ->
       check (list string) "materialized runtime ids" [ "active.sample" ]
         (List.map (fun (runtime : Runtime.t) -> runtime.id) runtimes))
 ;;
@@ -2433,7 +2433,7 @@ let test_runtime_binding_disable_excludes_only_that_binding () =
   with_temp_runtime_toml runtime_toml (fun path ->
     match Runtime.load_list ~config_path:path with
     | Error msg -> failf "disabled binding should not block active runtime: %s" msg
-    | Ok (runtimes, _, _, _, _, _) ->
+    | Ok (runtimes, _, _, _, _) ->
       check (list string) "materialized runtime ids" [ "local.good" ]
         (List.map (fun (runtime : Runtime.t) -> runtime.id) runtimes));
   let referenced_runtime_toml =
@@ -2485,7 +2485,7 @@ let test_declared_uncapped_runtime_reports_its_dispatch_blocker () =
     match Runtime.load_list ~config_path:path with
     | Error msg ->
       failf "an unassigned uncapped runtime must not fail the load: %s" msg
-    | Ok (runtimes, _, _, _, _, _) ->
+    | Ok (runtimes, _, _, _, _) ->
       check (list string) "both runtimes materialize"
         [ "local.sample"; "local.dormant" ]
         (List.map (fun (runtime : Runtime.t) -> runtime.id) runtimes);
@@ -2549,7 +2549,7 @@ let test_official_client_runtime_is_dispatchable_without_a_body_cap () =
   with_temp_runtime_toml runtime_toml (fun path ->
     match Runtime.load_list ~config_path:path with
     | Error msg -> failf "official-client runtime should load: %s" msg
-    | Ok (runtimes, _, _, _, _, _) ->
+    | Ok (runtimes, _, _, _, _) ->
       check (list string) "no runtime is reported blocked" []
         (List.map
            (fun ((runtime : Runtime.t), _) -> runtime.id)
@@ -2581,7 +2581,7 @@ let test_binding_naming_an_undeclared_model_fails_the_load () =
   in
   with_temp_runtime_toml runtime_toml (fun path ->
     match Runtime.load_list ~config_path:path with
-    | Ok (runtimes, _, _, _, _, _) ->
+    | Ok (runtimes, _, _, _, _) ->
       failf
         "binding naming an undeclared model must fail the load; got runtimes [%s]"
         (String.concat "; " (List.map (fun (r : Runtime.t) -> r.id) runtimes))
@@ -2624,7 +2624,7 @@ let test_non_provider_namespaces_are_not_bindings () =
   with_temp_runtime_toml runtime_toml (fun path ->
     match Runtime.load_list ~config_path:path with
     | Error msg -> failf "non-provider namespaces must not be bindings: %s" msg
-    | Ok (runtimes, _, _, _, _, _) ->
+    | Ok (runtimes, _, _, _, _) ->
       check (list string) "only the declared provider binds a runtime"
         [ "local.good" ]
         (List.map (fun (runtime : Runtime.t) -> runtime.id) runtimes))
@@ -2664,7 +2664,7 @@ let test_deliberate_disable_is_still_a_tolerated_drop () =
   with_temp_runtime_toml runtime_toml (fun path ->
     match Runtime.load_list ~config_path:path with
     | Error msg -> failf "deliberate disables must not fail the load: %s" msg
-    | Ok (runtimes, _, _, _, _, _) ->
+    | Ok (runtimes, _, _, _, _) ->
       check (list string) "disabled binding and disabled provider are excluded"
         [ "local.good" ]
         (List.map (fun (runtime : Runtime.t) -> runtime.id) runtimes))
@@ -2792,6 +2792,7 @@ let test_every_routing_field_names_itself_in_its_diagnostic () =
     (String_util.contains_substring media "[runtime].media_failover entry \"local.typo\"")
 
 let test_routing_reference_domains_stay_distinct () =
+  let lane = "\n[runtime.lanes.safe]\nstrategy = \"ordered\"\ncandidates = [\"local.good\"]\n" in
   (* An assignment resolves among runtimes only. runtime.mli documents the
      assignment snapshot as ids that resolve to a configured runtime, so admitting
      a lane here would load a config the assignment consumer cannot look up. *)
@@ -3763,7 +3764,7 @@ let test_codex_app_server_materializes_as_turn_runtime () =
   with_temp_runtime_toml (codex_app_server_runtime_toml ()) (fun path ->
     match Runtime.load_list ~config_path:path with
     | Error error -> failf "codex-app-server runtime should load: %s" error
-    | Ok (runtimes, default, _, _, _, _) ->
+    | Ok (runtimes, default, _, _, _) ->
       check int "one runtime" 1 (List.length runtimes);
       check string "default id" "codex.codex" default.id;
       (match default.execution with
@@ -3818,7 +3819,7 @@ let test_antigravity_cli_materializes_typed_process_options () =
     (fun path ->
        match Runtime.load_list ~config_path:path with
        | Error error -> failf "antigravity-cli runtime should load: %s" error
-       | Ok (runtimes, default, _, _, _, _) ->
+       | Ok (runtimes, default, _, _, _) ->
          check int "one runtime" 1 (List.length runtimes);
          check string "default id" "antigravity.gemini" default.id;
          (match default.execution with


### PR DESCRIPTION
## 급합니다 — main 이 red 입니다

#29197 이 **Build and Test 완주 전에 병합**됐고, 컴파일이 깨졌습니다. 이 PR 이 수리합니다.

## 무엇이 깨졌나

**1. 문법 오류** — `server_dashboard_runtime_defaults_json.ml:69`

숙청이 `model_routing` 리스트의 첫 항목만 지우고 구분자를 남겼습니다.
```ocaml
[           ; "media_failover", `List (...)
```

**2. 6요소 튜플 패턴** — 이름 검색으로는 보이지 않는 자리

`load_list` 가 5-tuple 이 됐는데, 사라진 자리를 `_` 로 적은 패턴들이 남았습니다.
```ocaml
Ok (runtimes, _, _, _, _, _)   (* cross_verifier 라는 단어가 없다 *)
```
`rg cross_verifier` 가 0건이어도 이것들은 남습니다. **삭제를 이름으로 하면 놓치는 자리**입니다.

- `runtime.ml` 3곳 + 타입 주석 3곳 (`degrade_loaded_for_missing_catalog` 반환형, `load_list` 내부 2곳)
- `test_runtime_claude_code_config.ml` 1곳 — 이 파일엔 `cross_verifier` 문자열이 아예 없었습니다
- `test_runtime_config_validity.ml` 9곳

**3. 소비자를 잃은 헬퍼** (warning 26/32 = error)

route 가 사라지면서 죽은 것들: `route_references`, `drop_route`, `route_unavailable`, `is_declared_lane`, `lane_fully_dropped`.

침묵시키지 않고 **제거**했습니다 — 이들이 섬기던 route 자체가 없습니다. `default_drop` 은 독립적으로 계산되므로 그대로 둡니다.

추가로 `test_routing_reference_domains_stay_distinct` 의 `lane` 바인딩을 복구했습니다. route 케이스와 함께 지웠는데 뒤의 두 케이스가 계속 쓰고 있었습니다.

## 이번엔 로컬에서 검증했습니다

CI 에 미루지 않았습니다.

```
dune build --root . lib/       → clean
dune build --root . @check     → lib/ · test/ 오류 0
```

(`packages/agent_core/test/` 의 module-alias 오류는 이 브랜치가 건드리지 않은 영역이고 main 에서도 동일합니다.)

## 배운 것

숙청은 **이름이 아니라 타입 모양**으로도 훑어야 합니다. `_` 로 채운 자리는 grep 에 안 걸리고, 컴파일러만 압니다. 그래서 삭제 PR 은 CI 완주를 기다려야 합니다 — #29197 은 그러지 못했습니다.

Refs #29197, #29173