### PR TITLE
chore(ci): unwired 기준선을 실측값 519로 조인다

### DIFF
--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=520
+UNWIRED_BASELINE=519
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then


### PR DESCRIPTION
## 무엇을

`scripts/audit-ci-test-targets.sh` 가 **현재 main 에서 실패합니다.**

```
[ci-test-targets] FAIL - 519 suites unwired, under the 520 baseline by 1
Set UNWIRED_BASELINE=519 in scripts/audit-ci-test-targets.sh. The gap is not slack to spend:
leaving it lets a later change add an unwired suite and still pass.
```

스크립트가 지시하는 대로 내립니다. main 을 그대로 체크아웃해서 돌린 **실측값**입니다.

## 어디서 온 드리프트인가

cross_verifier 숙청(#29197 / #29200)이 아닙니다. 그 브랜치를 main 위로 rebase 한 상태에서 숙청 커밋이 있든 없든 **둘 다 519** 였고, 그 PR 은 dune stanza 나 `.inc` 를 건드리지 않았습니다.

`#29175` · `#29176` · `#29195` 중 하나가 스위트를 배선하면서 기준선을 안 내렸고, 다음 PR 의 CI 에서 드러난 형태입니다.

## 세 번째 시도입니다

같은 한 줄이 두 번 유실됐습니다.

- #29199 — 별도 PR 로 냈다가, #29200 에 합치면서 닫음
- #29200 브랜치 — 합쳐 넣었으나 **push 전에 PR 이 병합**되어 커밋이 브랜치에 남음

둘 다 후속 push 가 병합보다 늦었습니다. 이번엔 main 에서 새로 갈라 단독으로 올립니다.

## 왜 그냥 두면 안 되나

스크립트가 스스로 적어둔 이유가 정확합니다 — 남은 1칸은 여유가 아니라 **다음 변경이 배선 안 된 스위트를 하나 더 추가하고도 통과하는 구멍**입니다.