### PR TITLE
feat(verification): 완료 판정 담당을 verifier_exact 로 고정 (RFC-0361 D7(b))

### DIFF
--- a/lib/completion_authority_agent.ml
+++ b/lib/completion_authority_agent.ml
@@ -7,6 +7,11 @@
 
 open Result.Syntax
 
+(* RFC-0361 D7(b): fixed authority identity — every judgement carries the
+   same actor string (the [verifier_exact] lane id) so verdicts aggregate by
+   actor; run identity stays with the per-review [verification_id]. *)
+let authority_actor = Task.Anti_rationalization.verifier_exact_lane_id
+
 type runtime =
   { config : Workspace_utils_backend_setup.config
   ; sw : Eio.Switch.t
@@ -458,8 +463,9 @@ let process_task_once
       ~assignee
       ~verification_id
   =
-  let agent_run_id = Random_id.prefixed ~prefix:"system-llm-agent-" ~bytes:16 in
-  let authority = Masc_domain.System_llm_agent { agent_run_id } in
+  (* RFC-0361 D7(b): fixed identity, not a per-judgement random mint — see
+     [authority_actor] above. *)
+  let authority = Masc_domain.System_llm_agent { agent_run_id = authority_actor } in
   (* Register before any work. Every exit below records through [complete],
      including paths that produce no semantic verdict. *)
   let registry = Verification_run_registry.global () in
@@ -747,6 +753,7 @@ let start ~sw ~clock ~(config : Workspace_utils_backend_setup.config) =
 ;;
 
 module For_testing = struct
+  let authority_actor = authority_actor
   let evidence_refs_of_output = evidence_refs_of_output
   let completion_verdict_of_review = completion_verdict_of_review
   let review_notes = review_notes

--- a/lib/completion_authority_agent.mli
+++ b/lib/completion_authority_agent.mli
@@ -12,6 +12,10 @@ val start :
   unit
 
 module For_testing : sig
+  val authority_actor : string
+  (** The fixed authority identity (RFC-0361 D7(b)): the [verifier_exact]
+      lane id, shared by every judgement so verdicts aggregate by actor. *)
+
   val evidence_refs_of_output :
     Yojson.Safe.t -> (string list, string) result
 

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -1199,10 +1199,11 @@ let test_rejected_verdict_audit_preserves_reason () =
         "system_llm_agent"
         (json |> member "authority_kind" |> to_string))
 
-(* The judging runtime is the only axis a verdict history can be grouped on:
-   [authority_actor] is minted fresh per review, so 74 verdicts carry 74 distinct
-   actors. The runtime was already computed and carried inside the review notes
-   blob, but every structured projection dropped it. *)
+(* The judging runtime is the axis a verdict history can be grouped on:
+   since RFC-0361 D7(b) [authority_actor] is the fixed [verifier_exact]
+   identity, so 74 verdicts carry one actor. The runtime was already computed
+   and carried inside the review notes blob, but every structured projection
+   dropped it. *)
 let test_verdict_audit_names_the_judging_runtime () =
   with_eio_temp_dir (fun base_path ->
     let config = W.default_config base_path in
@@ -1273,6 +1274,51 @@ let test_verdict_audit_names_the_judging_runtime () =
         "audit still carries the run-scoped actor"
         "system-runtime-agent"
         (json |> member "authority_actor" |> to_string))
+;;
+
+(* RFC-0361 D7(b): the completion authority no longer mints a random actor
+   per judgement. N judgements registered with the agent's authority identity
+   must all record the same fixed [authority_actor] — the [verifier_exact]
+   lane id — so verdicts aggregate by actor; run identity stays with
+   [verification_id]. *)
+let test_judgements_share_fixed_authority_actor () =
+  let module R = Masc.Verification_run_registry in
+  let registry = R.create () in
+  let authority =
+    Masc_domain.System_llm_agent
+      { agent_run_id = CA.For_testing.authority_actor }
+  in
+  for i = 1 to 3 do
+    let verification_id = Printf.sprintf "vrf-fixed-actor-%d" i in
+    R.register_running
+      registry
+      ~verification_id
+      ~task_id:(Printf.sprintf "task-fixed-actor-%d" i)
+      ~producer:"keeper-producer-agent"
+      ~authority_kind:(Masc_domain.completion_authority_kind authority)
+      ~authority_actor:(Masc_domain.completion_authority_actor authority)
+      ~started_at:(100.0 +. Float.of_int i);
+    R.mark_completed
+      registry
+      ~verification_id
+      ~outcome:R.Approved
+      ~tools:[]
+      ~elapsed_s:1.0
+      ()
+  done;
+  let actors =
+    R.list_runs registry
+    |> List.map (fun (run : R.run) -> run.authority_actor)
+    |> List.sort_uniq String.compare
+  in
+  Alcotest.(check int)
+    "all three judgements were recorded"
+    3
+    (List.length (R.list_runs registry));
+  Alcotest.(check (list string))
+    "every judgement records the same fixed authority actor"
+    [ "verifier_exact" ]
+    actors
 ;;
 
 let test_raw_workspace_submission_notifies_once () =
@@ -2381,6 +2427,8 @@ let () =
         test_rejected_verdict_audit_preserves_reason;
       Alcotest.test_case "verdict audit names the judging runtime" `Quick
         test_verdict_audit_names_the_judging_runtime;
+      Alcotest.test_case "judgements share the fixed authority actor" `Quick
+        test_judgements_share_fixed_authority_actor;
     ];
     "workspace_boundary", [
       Alcotest.test_case "raw submit notifies once" `Quick


### PR DESCRIPTION
## RFC-0361 D7(b) — 고정 authority identity

### Before
`lib/completion_authority_agent.ml` minted a random actor per judgement:
`Random_id.prefixed ~prefix:"system-llm-agent-" ~bytes:16` → every verdict carried a distinct `authority_actor`, so the observability axis (dashboard `authorityActor`, `dashboard-verification-runs.ts:227`) could never aggregate.

### After
The authority identity is fixed to `"verifier_exact"` — the same value as `Task.Anti_rationalization.verifier_exact_lane_id` (`lib/task/anti_rationalization.ml:301`), referenced directly so the two stay in sync. Run identity stays with the per-review `verification_id`; the actor becomes the aggregation/calibration/audit axis, per RFC-0361 D7(b).

- `Masc_domain.completion_authority_actor` type and serialization unchanged — only the value becomes fixed.
- New regression test `judgements share the fixed authority actor` (`test/test_verification.ml`): 3 judgements through the registry all record `authority_actor = "verifier_exact"`.
- Stale comment claiming "minted fresh per review" updated.

The goal-side verifier (RFC-0387 stage 2 PR-2) will use the same fixed identity when it records goal verdicts.

### Verification
- No local dune build/test per task rules — compile and tests verified by CI.
- `grep -rn "system-llm-agent" lib/ bin/ dashboard/src/` → only a fixture string in `dashboard/src/api/dashboard-verification-runs.test.ts` (arbitrary non-empty-string parser input; no prefix dependency).
- `scripts/audit-dead-surface.py --exports --ratchet`: 541 dead exports both with and without this change (origin/main is already 2 over the 539 baseline; this PR does not move the count).
- ocamlformat 0.29.0 applied to the three touched files.