### PR TITLE
fix(test): 레인 기대값에서 cross_verifier 후보 제거 — main 깨짐 해소

### DIFF
--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=520
+UNWIRED_BASELINE=519
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -1853,7 +1853,6 @@ let test_keeper_dispatch_runtime_graph_enumeration () =
   let lanes =
     [ Runtime_lane.make ~id:"default-a" [ "lane-a"; "lane-b" ]
     ; Runtime_lane.make ~id:"dormant-lane" [ "lane-c"; "lane-b" ]
-    ; Runtime_lane.make ~id:"cross-e" [ "cross-a"; "lane-b" ]
     ]
   in
   let actual =
@@ -1872,7 +1871,6 @@ let test_keeper_dispatch_runtime_graph_enumeration () =
     ; "lane-b"
     ; "assigned-b"
     ; "media-c"
-    ; "cross-a"
     ; "verifier-a"
     ]
     actual


### PR DESCRIPTION
## main 이 red 입니다

`Build and Test` 가 실패합니다.

```
[FAIL] runtime TOML gate  54  keeper dispatch graph enumeration
ASSERT routed lane candidates, special routes, verifier_exact slots, and media failover
       are deduplicated without admitting a dormant lane

  Expected: ["lane-a"; "lane-b"; "assigned-b"; "media-c"; "cross-a"; "verifier-a"]
  Received: ["lane-a"; "lane-b"; "assigned-b"; "media-c"; "verifier-a"]
```

숙청이 `keeper_dispatch_runtime_ids` 에서 `[runtime].cross_verifier` 입력을 뺐는데, 그 route 의 lane 이 확장하던 후보 `"cross-a"` 가 **기대값 리터럴에 그대로** 남았습니다.

`cross-e` lane 도 fixture 에서 뺍니다. 가리키는 route 가 없어지면, 같은 테스트가 "제외되어야 한다" 고 이미 주장하는 `dormant-lane` 과 구별되지 않습니다.

## 타입체크로는 안 잡힙니다

리터럴 리스트는 내용이 낡아도 타입이 맞습니다. `dune build @check` 는 통과했고 CI 의 실제 스위트만 잡았습니다.

**이번엔 스위트를 돌렸습니다.**

| suite | |
|---|---|
| `test_runtime_config_validity` | 78 passed |
| `test_runtime_defaults_json` | 5 passed |
| `test_runtime_provider_auth_headers` | 2 passed |
| `test_eval_calibration` | 14 passed |
| `test_exact_output_catalog_precedence` | 53 passed |
| `test_verification` | 33 passed |
| `test_verification_run_registry` | 9 passed |
| `test_runtime_claude_code_config` | 48 passed |

## baseline 도 같이

main 은 `Meta Guards` 도 실패 중입니다 (`unwired 519 < baseline 520`). 한 번의 병합으로 두 게이트가 다 풀리도록 실측 기준선 조정을 같이 담았습니다. #29203 이 같은 한 줄을 들고 있으니, 이쪽이 먼저 들어가면 그건 닫겠습니다.

Refs #29197, #29200