### PR TITLE
fix(audit): 이벤트 개수 제한을 읽은 줄이 아니라 고른 줄 기준으로

### DIFF
--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -301,6 +301,29 @@ let read_entries ?(n = 10_000) (config : config) : audit_entry list =
     Some (entry_of_json_r json))
   |> collect_entries
 
+(* [n] counts entries that satisfy [keep]. {!read_entries} counts rows read, so
+   a caller that filters afterwards has to guess how wide a window its matches
+   need — the audit store carries every agent's actions, and one busy agent
+   fills any fixed guess. *)
+let read_entries_matching ?(n = 10_000) ~keep (config : config) : audit_entry list
+  =
+  let store = get_audit_store config in
+  (* Corrupt rows are collected but not counted: they are not entries the
+     caller asked for, and letting them consume the budget would make [n] mean
+     "matches, unless the store is damaged". They still reach
+     [collect_entries] so corruption keeps being reported. *)
+  let malformed = ref [] in
+  let matched =
+    Dated_jsonl.collect_matching store n ~f:(fun json ->
+      match entry_of_json_r json with
+      | Ok entry when keep entry -> Some (Ok entry)
+      | Ok _ -> None
+      | Error _ as corrupt ->
+        malformed := corrupt :: !malformed;
+        None)
+  in
+  collect_entries (List.rev !malformed @ matched)
+
 (** Append a single entry to the audit log (thread-safe via Dated_jsonl). *)
 let append_entry (config : config) (entry : audit_entry) =
   let store = get_audit_store config in
@@ -504,33 +527,31 @@ let audit_event_json (entry : audit_entry) =
   in
   `Assoc fields
 
+(* One predicate for the query filters, so the read and the projection cannot
+   disagree about what the caller asked for. A reader that counts matches needs
+   this decision before it pages; leaving it inside the projection is what made
+   the endpoint read a multiple of [limit] and hope. *)
+let audit_entry_matches ?actor ?kind ?severity ?since ?until (entry : audit_entry)
+  =
+  (match actor with
+   | None -> true
+   | Some value -> String.equal entry.agent_id (String.trim value))
+  && (match kind with
+      | None -> true
+      | Some value ->
+        String.starts_with ~prefix:(String.trim value)
+          (action_to_string entry.action))
+  && (match since with None -> true | Some value -> entry.timestamp >= value)
+  && (match until with None -> true | Some value -> entry.timestamp <= value)
+  && (match severity with
+      | None -> true
+      | Some value ->
+        String.equal (audit_event_severity entry) (String.trim value))
+
 let audit_events_response_json ?actor ?kind ?severity ?since ?until ~limit
     (entries : audit_entry list) =
   let filtered =
-    entries
-    |> (match actor with
-        | None -> Fun.id
-        | Some value ->
-            let actor = String.trim value in
-            List.filter (fun entry -> String.equal entry.agent_id actor))
-    |> (match kind with
-        | None -> Fun.id
-        | Some value ->
-            let kind = String.trim value in
-            List.filter (fun entry ->
-                String.starts_with ~prefix:kind (action_to_string entry.action)))
-    |> (match since with
-        | None -> Fun.id
-        | Some value -> List.filter (fun entry -> entry.timestamp >= value))
-    |> (match until with
-        | None -> Fun.id
-        | Some value -> List.filter (fun entry -> entry.timestamp <= value))
-    |> (match severity with
-        | None -> Fun.id
-        | Some value ->
-            let severity = String.trim value in
-            List.filter (fun entry ->
-                String.equal (audit_event_severity entry) severity))
+    List.filter (audit_entry_matches ?actor ?kind ?severity ?since ?until) entries
   in
   let total = List.length filtered in
   let drop_n = max 0 (total - limit) in

--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -301,11 +301,35 @@ let read_entries ?(n = 10_000) (config : config) : audit_entry list =
     Some (entry_of_json_r json))
   |> collect_entries
 
+let utc_date_of_timestamp timestamp =
+  match Unix.gmtime timestamp with
+  | tm ->
+    let year = tm.Unix.tm_year + 1900 in
+    if year < 0 || year > 9999
+    then None
+    else
+      Some
+        (Printf.sprintf
+           "%04d-%02d-%02d"
+           year
+           (tm.Unix.tm_mon + 1)
+           tm.Unix.tm_mday)
+  | exception Invalid_argument _
+  | exception Unix.Unix_error _ -> None
+;;
+
+let optional_date_bound = function
+  | None -> Some None
+  | Some timestamp ->
+    Option.map (fun date -> Some date) (utc_date_of_timestamp timestamp)
+;;
+
 (* [n] counts entries that satisfy [keep]. {!read_entries} counts rows read, so
    a caller that filters afterwards has to guess how wide a window its matches
    need — the audit store carries every agent's actions, and one busy agent
    fills any fixed guess. *)
-let read_entries_matching ?(n = 10_000) ~keep (config : config) : audit_entry list
+let read_entries_matching ?(n = 10_000) ?since ?until ~keep (config : config)
+  : audit_entry list
   =
   let store = get_audit_store config in
   (* Corrupt rows are collected but not counted: they are not entries the
@@ -313,14 +337,26 @@ let read_entries_matching ?(n = 10_000) ~keep (config : config) : audit_entry li
      "matches, unless the store is damaged". They still reach
      [collect_entries] so corruption keeps being reported. *)
   let malformed = ref [] in
-  let matched =
-    Dated_jsonl.collect_matching store n ~f:(fun json ->
+  let select json =
       match entry_of_json_r json with
       | Ok entry when keep entry -> Some (Ok entry)
       | Ok _ -> None
       | Error _ as corrupt ->
         malformed := corrupt :: !malformed;
-        None)
+        None
+  in
+  let matched =
+    match optional_date_bound since, optional_date_bound until with
+    | Some since_day, Some until_day
+      when Option.is_some since_day || Option.is_some until_day ->
+      Dated_jsonl.collect_matching_range
+        store
+        ~since:(Option.value ~default:"0000-01-01" since_day)
+        ~until:(Option.value ~default:"9999-12-31" until_day)
+        n
+        ~f:select
+    | Some _, Some _ | None, _ | _, None ->
+      Dated_jsonl.collect_matching store n ~f:select
   in
   collect_entries (List.rev !malformed @ matched)
 

--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -328,6 +328,13 @@ let optional_date_bound = function
    a caller that filters afterwards has to guess how wide a window its matches
    need — the audit store carries every agent's actions, and one busy agent
    fills any fixed guess. *)
+(* Day-file names sort lexicographically, so these two bound the range from
+   outside: no stored day can precede the first or follow the second. They mean
+   "this side is unbounded", which is why an absent [since]/[until] maps onto
+   them rather than onto a narrower guess. *)
+let earliest_day_bound = "0000-01-01"
+let latest_day_bound = "9999-12-31"
+
 let read_entries_matching ?(n = 10_000) ?since ?until ~keep (config : config)
   : audit_entry list
   =
@@ -349,10 +356,13 @@ let read_entries_matching ?(n = 10_000) ?since ?until ~keep (config : config)
     match optional_date_bound since, optional_date_bound until with
     | Some since_day, Some until_day
       when Option.is_some since_day || Option.is_some until_day ->
+      (* DET-OK: range identities, not a guess at a missing value. *)
+      let since_bound = Option.value ~default:earliest_day_bound since_day in
+      let until_bound = Option.value ~default:latest_day_bound until_day in
       Dated_jsonl.collect_matching_range
         store
-        ~since:(Option.value ~default:"0000-01-01" since_day)
-        ~until:(Option.value ~default:"9999-12-31" until_day)
+        ~since:since_bound
+        ~until:until_bound
         n
         ~f:select
     | Some _, Some _ | None, _ | _, None ->

--- a/lib/audit_log.mli
+++ b/lib/audit_log.mli
@@ -101,6 +101,25 @@ val entry_of_json : Yojson.Safe.t -> audit_entry option
 
 (** {1 Storage} *)
 
+val audit_entry_matches :
+  ?actor:string ->
+  ?kind:string ->
+  ?severity:string ->
+  ?since:float ->
+  ?until:float ->
+  audit_entry ->
+  bool
+(** The audit query filters as one predicate, so a reader and a
+    projection cannot disagree about what was asked for. *)
+
+val read_entries_matching :
+  ?n:int -> keep:(audit_entry -> bool) -> config -> audit_entry list
+(** Most-recent [n] entries satisfying [keep]. [n] counts matches,
+    where {!read_entries} counts rows read: the store holds every
+    agent's actions, so a caller that filters afterwards has no
+    window size that means "the newest [n] of mine". Corrupt rows are
+    reported but do not consume the budget. *)
+
 val read_entries : ?n:int -> config -> audit_entry list
 (** Most-recent [n] (default 10000) parsed entries from the
     date-split store. Malformed lines are logged (capped) and

--- a/lib/audit_log.mli
+++ b/lib/audit_log.mli
@@ -113,12 +113,18 @@ val audit_entry_matches :
     projection cannot disagree about what was asked for. *)
 
 val read_entries_matching :
-  ?n:int -> keep:(audit_entry -> bool) -> config -> audit_entry list
+  ?n:int ->
+  ?since:float ->
+  ?until:float ->
+  keep:(audit_entry -> bool) ->
+  config ->
+  audit_entry list
 (** Most-recent [n] entries satisfying [keep]. [n] counts matches,
     where {!read_entries} counts rows read: the store holds every
     agent's actions, so a caller that filters afterwards has no
     window size that means "the newest [n] of mine". Corrupt rows are
-    reported but do not consume the budget. *)
+    reported but do not consume the budget. [since]/[until] additionally bound
+    the day files opened; [keep] still decides exact timestamps on edge days. *)
 
 val read_entries : ?n:int -> config -> audit_entry list
 (** Most-recent [n] (default 10000) parsed entries from the

--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -953,6 +953,59 @@ let filter_map_recent ?(offset=0) t n ~f =
     !collected
   end
 
+(* [n] counts the values [f] produced, where [filter_map_recent]'s [n] counts
+   the rows it read. A caller that filters after that function cannot express
+   "the newest [n] rows that match": its budget fills with whatever was written
+   last, and the caller's filter thins the page to an unpredictable number —
+   zero once unrelated writes outpace the budget. Call sites compensated with a
+   multiplier over the row budget, and every multiplier is wrong at some write
+   rate.
+
+   Day files are walked newest-first and read whole, because how far back the
+   [n]-th match sits cannot be derived from [n]. The walk stops at the first
+   file that completes the count, so a caller whose matches are recent reads no
+   more than [filter_map_recent] would. *)
+let collect_matching ?(offset = 0) t n ~f =
+  if n <= 0 then []
+  else begin
+    let skip = ref offset in
+    let collected = ref [] in
+    let count = ref 0 in
+    let months = list_month_dirs t.base_dir in
+    let exception Done in
+    (try
+       List.iter (fun m ->
+         let month_path = Filename.concat t.base_dir m in
+         let days = list_day_files month_path in
+         List.iter (fun d ->
+           if !count >= n then raise_notrace Done;
+           let path = Filename.concat month_path d in
+           let lines = load_tail_lines path ~max_lines:max_int in
+           let rev_lines = List.rev lines in
+           List.iter (fun line ->
+             if !count >= n then raise_notrace Done;
+             let parsed =
+               try Some (Yojson.Safe.from_string line)
+               with Yojson.Json_error _ -> None
+             in
+             match parsed with
+             | None -> ()
+             | Some json ->
+               (match f json with
+                | None -> ()
+                | Some value ->
+                  if !skip > 0 then decr skip
+                  else begin
+                    collected := value :: !collected;
+                    incr count
+                  end)
+           ) rev_lines
+         ) days
+       ) months
+     with Done -> ());
+    !collected
+  end
+
 let read_recent ?offset t n =
   filter_map_recent ?offset t n ~f:(fun json -> Some json)
 

--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -1002,7 +1002,7 @@ let collect_matching_files ?(offset = 0) t n ~month_is_in_range
                                 collected := value :: !collected;
                                 incr count;
                                 if !count >= n then Some () else None
-                              end)))
+                              end))))
              end)
              days
          end

--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -954,18 +954,12 @@ let filter_map_recent ?(offset=0) t n ~f =
   end
 
 (* [n] counts the values [f] produced, where [filter_map_recent]'s [n] counts
-   the rows it read. A caller that filters after that function cannot express
-   "the newest [n] rows that match": its budget fills with whatever was written
-   last, and the caller's filter thins the page to an unpredictable number —
-   zero once unrelated writes outpace the budget. Call sites compensated with a
-   multiplier over the row budget, and every multiplier is wrong at some write
-   rate.
-
-   Day files are walked newest-first and read whole, because how far back the
-   [n]-th match sits cannot be derived from [n]. The walk stops at the first
-   file that completes the count, so a caller whose matches are recent reads no
-   more than [filter_map_recent] would. *)
-let collect_matching ?(offset = 0) t n ~f =
+   rows visited. Each day file is scanned backwards in 8 KB chunks through the
+   same primitive as [find_latest_entry_result], so a sparse/no-match query
+   never materialises a whole day file. Only the current chunk/line fragment
+   and the selected values remain live. *)
+let collect_matching_files ?(offset = 0) t n ~month_is_in_range
+      ~day_is_in_range ~f =
   if n <= 0 then []
   else begin
     let skip = ref offset in
@@ -975,36 +969,77 @@ let collect_matching ?(offset = 0) t n ~f =
     let exception Done in
     (try
        List.iter (fun m ->
-         let month_path = Filename.concat t.base_dir m in
-         let days = list_day_files month_path in
-         List.iter (fun d ->
-           if !count >= n then raise_notrace Done;
-           let path = Filename.concat month_path d in
-           let lines = load_tail_lines path ~max_lines:max_int in
-           let rev_lines = List.rev lines in
-           List.iter (fun line ->
+         if month_is_in_range m
+         then begin
+           let month_path = Filename.concat t.base_dir m in
+           let days = list_day_files month_path in
+           List.iter (fun d ->
              if !count >= n then raise_notrace Done;
-             let parsed =
-               try Some (Yojson.Safe.from_string line)
-               with Yojson.Json_error _ -> None
-             in
-             match parsed with
-             | None -> ()
-             | Some json ->
-               (match f json with
-                | None -> ()
-                | Some value ->
-                  if !skip > 0 then decr skip
-                  else begin
-                    collected := value :: !collected;
-                    incr count
-                  end)
-           ) rev_lines
-         ) days
+             if day_is_in_range m d
+             then begin
+               let path = Filename.concat month_path d in
+               let input = open_in_bin path in
+               Fun.protect
+                 ~finally:(fun () -> close_in_noerr input)
+                 (fun () ->
+                    ignore
+                      (find_latest_line_from_channel input (fun line ->
+                         let parsed =
+                           try Some (Yojson.Safe.from_string line)
+                           with Yojson.Json_error _ -> None
+                         in
+                         match parsed with
+                         | None -> None
+                         | Some json ->
+                           (match f json with
+                            | None -> None
+                            | Some value ->
+                              if !skip > 0
+                              then (
+                                decr skip;
+                                None)
+                              else begin
+                                collected := value :: !collected;
+                                incr count;
+                                if !count >= n then Some () else None
+                              end)))
+             end)
+             days
+         end
        ) months
      with Done -> ());
     !collected
   end
+
+let collect_matching ?offset t n ~f =
+  collect_matching_files
+    ?offset
+    t
+    n
+    ~month_is_in_range:(fun _ -> true)
+    ~day_is_in_range:(fun _ _ -> true)
+    ~f
+;;
+
+let collect_matching_range ?offset t ~since ~until n ~f =
+  match parse_date since, parse_date until with
+  | Some (since_month, since_day), Some (until_month, until_day)
+    when String.compare since until <= 0 ->
+    collect_matching_files
+      ?offset
+      t
+      n
+      ~month_is_in_range:(fun month ->
+        String.compare month since_month >= 0
+        && String.compare month until_month <= 0)
+      ~day_is_in_range:(fun month day_file ->
+        let day = day_number_of_day_file_name day_file in
+        not
+          ((String.equal month since_month && String.compare day since_day < 0)
+           || (String.equal month until_month && String.compare day until_day > 0)))
+      ~f
+  | Some _, Some _ | None, _ | _, None -> []
+;;
 
 let read_recent ?offset t n =
   filter_map_recent ?offset t n ~f:(fun json -> Some json)
@@ -1516,4 +1551,3 @@ module For_testing = struct
     Atomic.get cell
 
 end
-

--- a/lib/dated_jsonl/dated_jsonl.mli
+++ b/lib/dated_jsonl/dated_jsonl.mli
@@ -134,15 +134,27 @@ val collect_matching :
     Multiplying [n] to compensate only moves the write rate at which the answer
     goes empty.
 
-    The cost is the wider read that guarantee requires: day files are walked
-    newest-first and each is read whole, because how far back the [n]-th match
-    sits cannot be derived from [n]. The walk stops at the first file that
-    completes the count, so a caller whose matches are recent reads no more
-    than {!filter_map_recent} would.
+    Day files are walked newest-first and scanned backwards in fixed-size
+    chunks. The scan stops at the [n]-th match and never materialises a whole
+    day file; memory is bounded by the current chunk/line fragment plus the
+    selected values.
 
     [offset] skips selected values, not rows. Ordering and malformed-row
     skipping match {!filter_map_recent}, including that {b [f] is called
     newest-first}. *)
+
+val collect_matching_range :
+  ?offset:int ->
+  t ->
+  since:string ->
+  until:string ->
+  int ->
+  f:(Yojson.Safe.t -> 'a option) ->
+  'a list
+(** Range-bounded {!collect_matching}. Only day files in the inclusive
+    [[since, until]] UTC date range are opened. Invalid or reversed dates
+    return [[]], matching {!filter_map_range_recent}; row-level [f] remains
+    responsible for exact timestamp boundaries within the edge days. *)
 
 val filter_map_recent :
   ?offset:int -> t -> int -> f:(Yojson.Safe.t -> 'a option) -> 'a list

--- a/lib/dated_jsonl/dated_jsonl.mli
+++ b/lib/dated_jsonl/dated_jsonl.mli
@@ -122,6 +122,28 @@ val set_append_guard : ((unit -> unit) -> unit) -> unit
     runtimes can install resource accounting/backpressure without making this
     low-level storage library depend on those policy modules. *)
 
+val collect_matching :
+  ?offset:int -> t -> int -> f:(Yojson.Safe.t -> 'a option) -> 'a list
+(** [collect_matching ?offset t n ~f] returns the newest [n] values [f]
+    produced. Where {!filter_map_recent} counts rows read, this counts values
+    selected, so [n] means what a filtering caller intended by it.
+
+    Use it whenever [f] rejects rows. With {!filter_map_recent} such a caller
+    has no value of [n] that means "the newest [n] matches": the budget fills
+    with whatever was written last, and unrelated writes can consume all of it.
+    Multiplying [n] to compensate only moves the write rate at which the answer
+    goes empty.
+
+    The cost is the wider read that guarantee requires: day files are walked
+    newest-first and each is read whole, because how far back the [n]-th match
+    sits cannot be derived from [n]. The walk stops at the first file that
+    completes the count, so a caller whose matches are recent reads no more
+    than {!filter_map_recent} would.
+
+    [offset] skips selected values, not rows. Ordering and malformed-row
+    skipping match {!filter_map_recent}, including that {b [f] is called
+    newest-first}. *)
+
 val filter_map_recent :
   ?offset:int -> t -> int -> f:(Yojson.Safe.t -> 'a option) -> 'a list
 (** [filter_map_recent ?offset t n ~f] is [List.filter_map f (read_recent

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -700,15 +700,19 @@ let add_routes ~sw ~clock router =
            query_param req "until"
            |> Fun.flip Option.bind (fun s -> float_of_string_opt (String.trim s))
          in
-         let fetch_limit = match actor_filter, kind_filter, severity_filter with
-           | None, None, None -> limit
-           | _ -> min 5000 (limit * 20)
+         (* The filters decide the read, so [limit] counts entries the
+            caller asked for. Reading a multiple and filtering afterwards
+            only moved the write rate at which the answer came back short:
+            the store holds every agent's actions. *)
+         let matches =
+           Audit_log.audit_entry_matches ?actor:actor_filter ?kind:kind_filter
+             ?severity:severity_filter ?since:since_filter ?until:until_filter
          in
-         let all_entries = Audit_log.read_entries ~n:fetch_limit config in
+         let all_entries =
+           Audit_log.read_entries_matching ~n:limit ~keep:matches config
+         in
          let json =
-           Audit_log.audit_events_response_json ?actor:actor_filter
-             ?kind:kind_filter ?severity:severity_filter ?since:since_filter
-             ?until:until_filter ~limit all_entries
+           Audit_log.audit_events_response_json ~limit all_entries
          in
          Http.Response.json_value ~compress:true ~request:req
            json reqd

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -709,7 +709,12 @@ let add_routes ~sw ~clock router =
              ?severity:severity_filter ?since:since_filter ?until:until_filter
          in
          let all_entries =
-           Audit_log.read_entries_matching ~n:limit ~keep:matches config
+           Audit_log.read_entries_matching
+             ~n:limit
+             ?since:since_filter
+             ?until:until_filter
+             ~keep:matches
+             config
          in
          let json =
            Audit_log.audit_events_response_json ~limit all_entries

--- a/test/test_audit_log.ml
+++ b/test/test_audit_log.ml
@@ -415,6 +415,48 @@ let test_runtime_config_write_routing_list_projection () =
   check string "target" "/x/config/runtime.toml" (field "target");
   check string "severity" "warn" (field "severity")
 
+(* [read_entries ~n] counts rows, so a caller that filters afterwards cannot
+   ask for "the newest n of mine": the audit store holds every agent's actions
+   and one busy agent fills any window. The first check pins that; the rest pin
+   the filtered read that replaces it. *)
+let test_matching_read_counts_matches_not_rows () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Workspace.default_config base_dir in
+      let say agent_id tool =
+        Audit_log.log_non_public_tool_call config ~agent_id ~tool_name:tool
+          ~success:true ~error_msg:None ()
+      in
+      say "quiet" "masc_status";
+      say "quiet" "masc_tasks";
+      for i = 1 to 20 do
+        say "busy" (Printf.sprintf "masc_tool_%d" i)
+      done;
+      let is_quiet (e : Audit_log.audit_entry) = String.equal e.agent_id "quiet" in
+      let unfiltered = Audit_log.read_entries ~n:5 config in
+      check int "an unfiltered window of 5 holds none of the quiet agent's rows" 0
+        (List.length (List.filter is_quiet unfiltered));
+      let matched = Audit_log.read_entries_matching ~n:5 ~keep:is_quiet config in
+      check int "the filtered read returns every match under the limit" 2
+        (List.length matched);
+      let bounded =
+        Audit_log.read_entries_matching ~n:3
+          ~keep:(fun e -> not (is_quiet e))
+          config
+      in
+      check int "n bounds the matches" 3 (List.length bounded);
+      let by_actor =
+        Audit_log.read_entries_matching ~n:5
+          ~keep:(Audit_log.audit_entry_matches ~actor:"quiet")
+          config
+      in
+      check int "the shared predicate selects the same rows" 2
+        (List.length by_actor))
+
 let () =
   run "Audit_log"
     [
@@ -449,5 +491,7 @@ let () =
             test_runtime_config_write_assignment_projection;
           test_case "runtime_config_write routing list projection" `Quick
             test_runtime_config_write_routing_list_projection;
+          test_case "matching read counts matches not rows" `Quick
+            test_matching_read_counts_matches_not_rows;
         ] );
     ]

--- a/test/test_dated_jsonl.ml
+++ b/test/test_dated_jsonl.ml
@@ -180,6 +180,71 @@ let test_filter_map_recent_does_not_swallow_callback_failure () =
         (Dated_jsonl.filter_map_recent store 10 ~f:(fun _ ->
            raise (Yojson.Json_error "decoder rejected the row"))))
 
+let test_collect_matching_counts_selected_rows () =
+  let dir = tmpdir "dated_jsonl_collect_matching" in
+  write_dated_file
+    dir
+    "2026-01"
+    "01"
+    [ {|{"i":1}|}; {|{"i":2}|}; {|{"i":3}|}; {|{"i":4}|}; {|{"i":5}|} ];
+  let store = Dated_jsonl.create ~base_dir:dir () in
+  let values =
+    Dated_jsonl.collect_matching store 2 ~f:(fun json ->
+      let value = json_i json in
+      if value mod 2 = 0 then Some value else None)
+  in
+  check (list int) "newest two matches stay chronological" [ 2; 4 ] values
+;;
+
+let test_collect_matching_range_skips_out_of_range_files () =
+  let dir = tmpdir "dated_jsonl_collect_matching_range" in
+  write_dated_file dir "2026-01" "31" [ {|{"i":1}|} ];
+  write_dated_file dir "2026-02" "01" [ {|{"i":2}|} ];
+  write_dated_file dir "2026-02" "02" [ {|{"i":3}|} ];
+  let store = Dated_jsonl.create ~base_dir:dir () in
+  let visited = ref [] in
+  let values =
+    Dated_jsonl.collect_matching_range
+      store
+      ~since:"2026-02-01"
+      ~until:"2026-02-01"
+      10
+      ~f:(fun json ->
+        let value = json_i json in
+        visited := value :: !visited;
+        Some value)
+  in
+  check (list int) "only the requested day contributes" [ 2 ] values;
+  check (list int) "out-of-range files were never parsed" [ 2 ] !visited
+;;
+
+let test_collect_matching_stops_without_loading_the_day () =
+  let dir = tmpdir "dated_jsonl_collect_matching_bounded" in
+  let month_dir = Filename.concat dir "2026-01" in
+  Fs_compat.mkdir_p month_dir;
+  let path = Filename.concat month_dir "01.jsonl" in
+  let descriptor =
+    Unix.openfile path [ Unix.O_CREAT; Unix.O_TRUNC; Unix.O_WRONLY ] 0o600
+  in
+  Fun.protect
+    ~finally:(fun () -> Unix.close descriptor)
+    (fun () ->
+      let sparse_prefix_bytes = 64 * 1024 * 1024 in
+      Unix.ftruncate descriptor sparse_prefix_bytes;
+      ignore (Unix.lseek descriptor sparse_prefix_bytes Unix.SEEK_SET);
+      let suffix = "\n{\"i\":2}\n" in
+      ignore (Unix.write_substring descriptor suffix 0 (String.length suffix)));
+  let store = Dated_jsonl.create ~base_dir:dir () in
+  let allocated_before = Gc.allocated_bytes () in
+  let values =
+    Dated_jsonl.collect_matching store 1 ~f:(fun json -> Some (json_i json))
+  in
+  let allocated = Gc.allocated_bytes () -. allocated_before in
+  check (list int) "the newest match is returned" [ 2 ] values;
+  check bool "reverse scan allocation stays below one whole-day load" true
+    (allocated < Float.of_int (4 * 1024 * 1024))
+;;
+
 let test_read_recent_result_counts_malformed_physical_row () =
   let dir = tmpdir "dated_jsonl_recent_result_malformed" in
   write_dated_file
@@ -1155,6 +1220,14 @@ let () =
             test_filter_map_recent_calls_the_projection_newest_first;
           test_case "callback failure is not swallowed" `Quick
             test_filter_map_recent_does_not_swallow_callback_failure;
+        ] );
+      ( "collect_matching",
+        [ test_case "n counts selected rows" `Quick
+            test_collect_matching_counts_selected_rows;
+          test_case "range skips out-of-range files" `Quick
+            test_collect_matching_range_skips_out_of_range_files;
+          test_case "reverse scan keeps day-file allocation bounded" `Quick
+            test_collect_matching_stops_without_loading_the_day;
         ] );
       ( "read_recent_lines",
         [


### PR DESCRIPTION
## 근본 원인

`Dated_jsonl.filter_map_recent`는 `f`가 행을 골랐든 아니든 카운터를 올립니다.

```ocaml
(match f json with
 | Some value -> collected := value :: !collected
 | None -> ());
incr count        (* ← f 결과와 무관 *)
```

즉 `n`은 **읽은 행 수**예요. mli에도 그렇게 적혀 있습니다 — "n and offset count parsed rows, not selected ones".

그래서 필터하는 호출자는 "내 최신 n개"를 표현할 방법이 없습니다. 예산이 마지막에 쓰인 것들로 차고, audit 스토어는 모든 에이전트의 행동을 담으니까요.

audit events 엔드포인트는 이렇게 대응했어요.

```ocaml
let fetch_limit = match actor_filter, kind_filter, severity_filter with
  | None, None, None -> limit
  | _ -> min 5000 (limit * 20)
```

**필터가 있을 때만** 20배로 부풀립니다. 그냥 limit으로는 부족하다는 걸 코드가 알고 있었다는 뜻이에요. 배율은 답이 비는 시점을 뒤로 미룰 뿐 없애지 못합니다.

## 어떻게 고쳤나

`Dated_jsonl.collect_matching`을 추가했습니다. `n`이 **선택된 값**을 셉니다.

일자 파일을 최신순으로 훑고 각 파일은 통째로 읽어요 — n번째 매치가 얼마나 뒤에 있는지는 `n`으로 알 수 없으니까요. 카운트가 채워지는 첫 파일에서 멈추므로, 매치가 최근이면 기존과 같은 양만 읽습니다.

`filter_map_recent`는 **건드리지 않았습니다.** 나머지 6개 호출자는 모든 행을 projection하고 행 수 기반 상한에 의존해요.

그 위에:
- `Audit_log.read_entries_matching` — 매치 기준 읽기
- `Audit_log.audit_entry_matches` — 쿼리 필터 5개를 하나의 술어로 추출. 읽기와 projection이 "무엇을 요청했는지"에 대해 어긋날 수 없게 됩니다

손상된 행은 여전히 보고되지만 예산을 소비하지 않습니다. 소비하게 두면 `n`이 "매치 개수, 단 스토어가 멀쩡할 때"라는 뜻이 되니까요.

## 검증

| | |
|---|---|
| `test_audit_log` | 14 tests, exit 0 |
| DET/NDT gate | exit 0 |
| structure / stringly-boundary / silent-failure ratchet | exit 0 |
| ocamlformat | clean |

회귀 테스트가 결함을 고정합니다 — 조용한 에이전트 2건 위에 바쁜 쪽이 20건 쌓인 상태에서 `read_entries ~n:5`를 부르면 **조용한 쪽이 0건**입니다. `read_entries_matching ~n:5`는 2건을 돌려줘요. 추출한 술어(`~actor:"quiet"`)로도 같은 2건이 나오는지 함께 확인합니다.

## 남은 것

같은 축에 3곳이 남아 있어요. 각자 소비자를 전환해야 합니다.

- `keeper_transition_audit.ml:343` (`max limit 1 * 8`)
- `keeper_transition_audit.ml:410` (`max limit 1 * 8`)
- `server_dashboard_http_keeper_api.ml:2438` (`max 500 (min 5000 (limit * multiplier))`)

## 관련

`#29100`(메시지 스토어), `#29179`(Activity Graph), `#29187`(task 이력)과 같은 축입니다.
