### PR TITLE
fix(keeper): 멈춘 Keeper 를 되살리는 도구인데 설명은 통계 초기화라고 적혀 있던 문제

### DIFF
--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -357,8 +357,12 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_keeper_reset";
-    description = "Reset a keeper's runtime state (usage counters, last_model_used, token stats). \
-Clears stale data from previous sessions. Does not affect configuration, goals, or Keeper instructions.";
+    description = "Clear a keeper's lifecycle latch: drops the pause bit, the latched \
+reason, and runtime.last_blocker in one durable write. This is the operator recovery path \
+for a keeper the generic resume transform refuses to unpause — Keeper_meta_contract.mark_resumed \
+deliberately returns Transcript_corruption_reset_required and Dead_tombstone latches unchanged, \
+so resume alone cannot free them. Does not touch usage counters, token stats, configuration, \
+goals, or Keeper instructions.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [


### PR DESCRIPTION
## 현상

Keeper 가 멈췄을 때 되살릴 방법을 도구 목록에서 찾으면, `masc_keeper_reset` 이 있어도 그게 답인 줄 알 수 없어요. 설명이 이렇게 적혀 있거든요.

> 사용량 카운터, 마지막 사용 모델, 토큰 통계를 초기화합니다. 이전 세션의 오래된 데이터를 지웁니다.

그런데 실제로는 저 셋 중 아무것도 건드리지 않아요. 하는 일은 **멈춤 표시와 걸려 있는 사유를 지우는 것** 입니다.

```ocaml
(* keeper_tool_surface.ml:212 keeper_reset_body *)
Keeper_owner_reducer.Reset_latch { updated_at = ... }

(* keeper_owner_reducer.ml *)
| Reset_latch { updated_at } ->
  Ok (with_meta state { meta with paused = false; latched_reason = None; runtime; updated_at })
```

성공했을 때 돌려주는 문장도 스스로 그렇게 말해요 — `"Reset lifecycle latch for %s: pause and blocker state cleared."`

## 왜 문제가 되나

이게 **되살리기가 막힌 Keeper 를 풀어주는 유일한 운영자 수단** 이에요.

`Keeper_meta_contract.mark_resumed` 는 일부러 두 가지 사유를 그대로 남겨둡니다. 대화 기록이 깨졌다는 사유(`Transcript_corruption_reset_required`)와 완전히 죽었다는 사유(`Dead_tombstone`)예요. 이 둘에 걸린 Keeper 는 되살리기를 몇 번 눌러도 계속 멈춰 있습니다.

즉 도구 설명이 잘못돼 있으면 탈출구가 있는데도 없는 것처럼 보여요.

## 실제로 그런 일이 있었어요

`taskmaster` 가 8월 17일부터 20일까지 멈춰 있었고, 그동안 처리 못 한 일이 **72건** 쌓였습니다. 되살리는 도구는 **그 3일 내내 등록돼 있었어요.**

이번에 원인을 찾으면서 저도 같은 길을 걸었습니다. 지시 API(`pause`/`resume`/`wakeup`)와 CLI 를 다 뒤진 뒤 "되살릴 방법이 아예 없다"는 잘못된 결론을 내렸고, 그 전제로 PR #29177 까지 만들었어요. 도구 목록은 봤지만 설명이 "통계 초기화"라고 돼 있어서 지나쳤습니다.

## 고친 것

`lib/keeper/keeper_schema.ml` 한 곳입니다. `keeper_tool_descriptor.ml` 의 `masc_keeper_descriptor` 가 `Keeper_schema.schemas` 에서 스키마를 찾아 쓰기 때문에 여기가 원본이에요.

설명을 실제 하는 일로 바꿨습니다. 멈춤 표시와 걸린 사유, 그리고 마지막 blocker 를 한 번의 저장으로 지운다는 것, 되살리기가 거부하는 상태에서 빠져나오는 경로라는 것, 카운터나 설정이나 Goal 은 건드리지 않는다는 것까지요.

## 확인한 것

- [x] `ocamlformat --check`
- [x] 이 문구를 고정하는 테스트가 없다는 것 (`usage counters` / `last_model_used` 로 찾아봤어요)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EoKSDigFqnuo1EEH8hyri4
