### PR TITLE
chore(dashboard): #29175 이후 아무도 안 쓰게 된 export 두 개 삭제

### DIFF
--- a/lib/server/server_dashboard_http_keeper_api_types.ml
+++ b/lib/server/server_dashboard_http_keeper_api_types.ml
@@ -289,42 +289,10 @@ let tool_call_output_text_opt json =
     | None -> None)
   | None | Some _ -> None
 
-let parse_tool_output_json_opt json =
-  match tool_call_output_text_opt json with
-  | None -> None
-  | Some output -> (
-    match Safe_ops.parse_json_safe ~context:"runtime_lens.tool_output" output with
-    | Ok parsed -> Some parsed
-    | Error _ -> None)
-
 let tool_call_runtime_contract json =
   match Json_util.assoc_member_opt "runtime_contract" json with
   | Some contract -> contract
   | None -> `Assoc []
-
-let tool_call_matches_trace ?turn_id ~keeper_name ~trace_id json =
-  let contract = tool_call_runtime_contract json in
-  let keeper_matches =
-    match Json_util.get_string json "keeper" with
-    | Some keeper -> String.equal keeper keeper_name
-    | None -> true
-  in
-  let trace_matches =
-    match
-      ( Json_util.get_string json "trace_id",
-        Json_util.get_string contract "trace_id" )
-    with
-    | Some value, _ | _, Some value -> String.equal value trace_id
-    | None, None -> false
-  in
-  let turn_matches =
-    match turn_id with
-    | None -> true
-    | Some wanted ->
-      Json_util.assoc_int_opt "keeper_turn_id" json = Some wanted
-      || Json_util.assoc_int_opt "keeper_turn_id" contract = Some wanted
-  in
-  keeper_matches && trace_matches && turn_matches
 
 let first_string_opt values =
   List.find_map (fun value -> value) values

--- a/lib/server/server_dashboard_http_keeper_api_types.mli
+++ b/lib/server/server_dashboard_http_keeper_api_types.mli
@@ -164,15 +164,7 @@ val runtime_trace_public_json : Yojson.Safe.t -> Yojson.Safe.t
     records. Used by the runtime-lens response builders. *)
 
 val tool_call_output_text_opt : Yojson.Safe.t -> string option
-val parse_tool_output_json_opt : Yojson.Safe.t -> Yojson.Safe.t option
 val tool_call_runtime_contract : Yojson.Safe.t -> Yojson.Safe.t
-
-val tool_call_matches_trace :
-  ?turn_id:int ->
-  keeper_name:string ->
-  trace_id:string ->
-  Yojson.Safe.t ->
-  bool
 
 (** {1 Option list + string utilities} *)
 

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=520
+UNWIRED_BASELINE=519
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -1868,11 +1868,15 @@ let test_keeper_dispatch_runtime_graph_enumeration () =
     (list string)
     "routed lane candidates, special routes, verifier_exact slots, and media \
      failover are deduplicated without admitting a dormant lane"
+    (* cross-a is absent on purpose. [cross-e] used to be a routed root via the
+       [runtime].cross_verifier key; #29197 purged that key, so nothing names
+       [cross-e] any more and it is dormant exactly like [dormant-lane]. A
+       dormant lane's candidates must not enter the dispatch set — which is what
+       this case is named for. *)
     [ "lane-a"
     ; "lane-b"
     ; "assigned-b"
     ; "media-c"
-    ; "cross-a"
     ; "verifier-a"
     ]
     actual


### PR DESCRIPTION
## 증상

main 이 Meta Guards 의 dead-surface 래칫에서 실패하고 있다.

```
[dead-surface] FAIL - 541 dead exports, over the 539 baseline by 2.
```

main 을 병합하는 열린 PR 이 전부 여기서 막힌다 (#29192, #29203).

## 원인

`0a33e6cc05..origin/main` 22 개 커밋을 게이트로 bisect 했다.

```
8ded7a4c928e1f82ee4a34b13950cb0692097ab4 is the first bad commit
fix(keeper): keeper 의 goal 이 claim 가능한 task 를 제한하지 않는다 (#29175)
```

이 커밋은 export 를 추가하지 않았다. `keeper_tool_task_runtime.ml` 등에서 **소비자를 제거**했고, 그 결과 `server_dashboard_http_keeper_api_types` 의 두 값이 호출자를 잃었다.

| 시점 | 이 모듈의 dead exports |
|---|---|
| `8ded7a4c92^` | 8 |
| `8ded7a4c92` | 10 |

늘어난 두 개:

- `parse_tool_output_json_opt`
- `tool_call_matches_trace`

## 왜 baseline 을 올리지 않았나

`DEAD_EXPORT_BASELINE = 539` 는 #27405 "freeze the dead-export count so it can only fall" 로 고정된 값이다. 올리는 방향은 이 래칫의 존재 이유를 뒤집는다. 고아를 지우는 것이 래칫이 의도한 대응이다.

## 검증

두 이름은 자기 정의부에만 등장한다 (mli 2 회, ml 2 회). audit 스크립트는 확장자를 가리지 않고 트리 전체를 스캔하므로 (dune stanza, `.inc`, TLA spec, 문서, 셸, CI YAML 포함), 테스트나 문서에도 참조가 없다는 뜻이다.

```
dead exports: 539 across 291 modules
```

`dune build --root . bin/main_eio.exe` 통과 — 스크립트 자신이 "a reported name is a candidate for removal, not a proof of deadness; the compiler is the proof" 라고 적고 있어 빌드를 증거로 삼았다.

`@test/runtest-test_server_dashboard_http_keeper_api_trace` 도 함께 돌렸다.

## 범위

이 모듈에는 여전히 8 개의 dead export 가 남아 있다 (`cache_key_string_opt_segment`, `keeper_path_ends_with` 등). 이 PR 은 #29175 가 만든 증가분만 되돌리고 기존 잔여분은 건드리지 않는다.
