### PR TITLE
fix(keeper): 되살리기 판정은 맞았는데 그 결과를 저장하지 않던 문제 (#29177 후속)

### DIFF
--- a/lib/keeper/keeper_paused_work_resume_transaction.ml
+++ b/lib/keeper/keeper_paused_work_resume_transaction.ml
@@ -174,18 +174,6 @@ type transcript_recovery =
   | Transcript_closed_open_tail of Agent_core.Types.message list
   | Transcript_unrecoverable
 
-(* Downgrade to Operator_paused instead of clearing outright: the keeper stays
-   paused and the generic resume path below still owns that transition. Only the
-   classification changes, from "cannot replay" to "an operator stopped this". *)
-let downgraded_transcript_latch (meta : Keeper_meta_contract.keeper_meta) =
-  { meta with
-    Keeper_meta_contract.latched_reason =
-      Some
-        (Keeper_latched_reason.Operator_paused
-           { operator_actor = Keeper_latched_reason.operator_actor_grpc_directive })
-  }
-;;
-
 (* The latch records that the transcript was broken when it was written, not
    that it is broken now. A keeper whose checkpoint has since become
    dispatchable is held by a stale record, so re-read the checkpoint and let its
@@ -210,7 +198,29 @@ let classify_transcript messages =
      | Ok closure -> Transcript_closed_open_tail closure.Keeper_compaction_unit.messages)
 ;;
 
-let recover_transcript_latch config (meta : Keeper_meta_contract.keeper_meta) =
+(* Commit the downgrade instead of returning a meta nobody stores. Pause with
+   an Operator_paused reason keeps [paused = true] and only replaces the
+   classification, so the existing resume path below sees an ordinary operator
+   pause and mark_resumed clears it. Reset_latch would drop the pause bit too,
+   and resume then refuses the keeper as Durable_owner_not_paused. *)
+let commit_transcript_latch_downgrade config ~keeper_name =
+  match
+    Keeper_owner_registry.apply_meta
+      ~base_path:config.Workspace.base_path
+      ~keeper_name
+      (Keeper_owner_reducer.Pause
+         { reason =
+             Keeper_latched_reason.Operator_paused
+               { operator_actor = Keeper_latched_reason.operator_actor_grpc_directive }
+         ; updated_at = Keeper_meta_contract.now_iso ()
+         })
+  with
+  | Ok (Some _) -> Ok ()
+  | Ok None | Error _ -> Error Durable_owner_transcript_reset_required
+;;
+
+let recover_transcript_latch config ~keeper_name (meta : Keeper_meta_contract.keeper_meta)
+  =
   let session_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
   let session_dir = Keeper_fs.keeper_session_dir config session_id in
   match Keeper_checkpoint_store.load_agent_core_with_ref ~session_dir ~session_id with
@@ -218,7 +228,8 @@ let recover_transcript_latch config (meta : Keeper_meta_contract.keeper_meta) =
   | Ok (checkpoint, source_ref) ->
     (match classify_transcript checkpoint.Agent_core.Checkpoint.messages with
      | Transcript_unrecoverable -> Error Durable_owner_transcript_reset_required
-     | Transcript_already_dispatchable -> Ok (downgraded_transcript_latch meta)
+     | Transcript_already_dispatchable ->
+       commit_transcript_latch_downgrade config ~keeper_name
      | Transcript_closed_open_tail messages ->
        (match
           Keeper_checkpoint_store.save_agent_core_if_source
@@ -228,10 +239,11 @@ let recover_transcript_latch config (meta : Keeper_meta_contract.keeper_meta) =
         with
         | Keeper_checkpoint_store.Not_installed _ ->
           Error Durable_owner_transcript_reset_required
-        | Keeper_checkpoint_store.Installed _ -> Ok (downgraded_transcript_latch meta)))
+        | Keeper_checkpoint_store.Installed _ ->
+          commit_transcript_latch_downgrade config ~keeper_name))
 ;;
 
-let paused_meta config receipt (meta : Keeper_meta_contract.keeper_meta) =
+let paused_meta receipt (meta : Keeper_meta_contract.keeper_meta) =
   match
     Keeper_lifecycle_admission.state
       ~paused:meta.paused
@@ -242,9 +254,7 @@ let paused_meta config receipt (meta : Keeper_meta_contract.keeper_meta) =
   | Keeper_lifecycle_admission.Paused
       (Keeper_lifecycle_admission.Classified
         Keeper_latched_reason.Transcript_corruption_reset_required) ->
-    let* recovered = recover_transcript_latch config meta in
-    let* () = validate_identity receipt recovered in
-    Ok recovered
+    Error Durable_owner_transcript_reset_required
   | Keeper_lifecycle_admission.Paused _ ->
     let* () = validate_identity receipt meta in
     Ok meta
@@ -307,7 +317,7 @@ let project_receipt token config (receipt : Keeper_paused_work_disposition_recei
   let* committed =
     if current.paused
     then
-      let* _paused = paused_meta config receipt current in
+      let* _paused = paused_meta receipt current in
       let* committed =
         match
           Keeper_owner_registry.apply_meta
@@ -349,6 +359,22 @@ let create_receipt config ~keeper_name request =
     | None -> Error Durable_meta_missing
     | Some current -> Ok current
   in
+  (* A transcript latch is a record of the transcript that was written, not a
+     claim about the one on disk now. Re-read it before honouring the latch: if
+     the checkpoint dispatches today, downgrade the classification durably and
+     continue through the ordinary resume path. An unparseable checkpoint keeps
+     the latch and this returns the same error it always did. *)
+  let* current =
+    match current.latched_reason with
+    | Some Keeper_latched_reason.Transcript_corruption_reset_required ->
+      let* () = recover_transcript_latch config ~keeper_name current in
+      let* refreshed = read_meta config keeper_name in
+      (match refreshed with
+       | None -> Error Durable_meta_missing
+       | Some refreshed -> Ok refreshed)
+    | Some (Keeper_latched_reason.Operator_paused _ | Keeper_latched_reason.Dead_tombstone)
+    | None -> Ok current
+  in
   let receipt : Keeper_paused_work_disposition_receipt.t =
     { keeper_name
     ; expected_trace_id = current.runtime.trace_id
@@ -358,7 +384,7 @@ let create_receipt config ~keeper_name request =
     ; operation = Keeper_paused_work_disposition_receipt.Resume_owner
     }
   in
-  let* _ = paused_meta config receipt current in
+  let* _ = paused_meta receipt current in
   let* entry = registered_owner_opt config receipt in
   match entry with
   | None -> Ok receipt

--- a/test/test_keeper_paused_work_cancellation_transaction.ml
+++ b/test/test_keeper_paused_work_cancellation_transaction.ml
@@ -581,6 +581,79 @@ let test_resume_owner_rejects_dead_tombstone_without_receipt () =
        | Error detail -> Alcotest.fail detail)
 ;;
 
+
+(* Why the recovery commits Pause and not Reset_latch. Both clear the
+   transcript latch; only one leaves the keeper in a state resume accepts.
+   Reset_latch drops the pause bit too, and resume then refuses the keeper as
+   Durable_owner_not_paused, so the caller trades one refusal for another. *)
+let test_pause_downgrade_keeps_the_keeper_resumable () =
+  with_seeded_owner
+    ~registered:false
+    ~latched_reason:Keeper_latched_reason.Transcript_corruption_reset_required
+    ~paused:true
+    ~generation:31
+    (fun config keeper_name _source ->
+       match
+         Keeper_owner_registry.apply_meta
+           ~base_path:config.Workspace.base_path
+           ~keeper_name
+           (Keeper_owner_reducer.Pause
+              { reason =
+                  Keeper_latched_reason.Operator_paused
+                    { operator_actor =
+                        Keeper_latched_reason.operator_actor_grpc_directive
+                    }
+              ; updated_at = Keeper_meta_contract.now_iso ()
+              })
+       with
+       | Ok (Some meta) ->
+         Alcotest.(check bool) "still paused" true meta.Keeper_meta_contract.paused;
+         (match meta.Keeper_meta_contract.latched_reason with
+          | Some (Keeper_latched_reason.Operator_paused _) -> ()
+          | _ -> Alcotest.fail "latch must read as an operator pause after downgrade");
+         (match
+            Keeper_lifecycle_admission.state
+              ~paused:meta.Keeper_meta_contract.paused
+              ~latched_reason:meta.Keeper_meta_contract.latched_reason
+          with
+          | Keeper_lifecycle_admission.Paused
+              (Keeper_lifecycle_admission.Classified
+                Keeper_latched_reason.Transcript_corruption_reset_required) ->
+            Alcotest.fail "resume would still refuse this keeper"
+          | Keeper_lifecycle_admission.Paused _ -> ()
+          | _ -> Alcotest.fail "downgrade must leave the keeper paused")
+       | Ok None -> Alcotest.fail "owner metadata missing"
+       | Error _ -> Alcotest.fail "downgrade command rejected")
+
+let test_reset_latch_would_make_resume_refuse () =
+  with_seeded_owner
+    ~registered:false
+    ~latched_reason:Keeper_latched_reason.Transcript_corruption_reset_required
+    ~paused:true
+    ~generation:32
+    (fun config keeper_name _source ->
+       match
+         Keeper_owner_registry.apply_meta
+           ~base_path:config.Workspace.base_path
+           ~keeper_name
+           (Keeper_owner_reducer.Reset_latch
+              { updated_at = Keeper_meta_contract.now_iso () })
+       with
+       | Ok (Some meta) ->
+         Alcotest.(check bool)
+           "pause bit dropped"
+           false
+           meta.Keeper_meta_contract.paused;
+         (match
+            Keeper_lifecycle_admission.state
+              ~paused:meta.Keeper_meta_contract.paused
+              ~latched_reason:meta.Keeper_meta_contract.latched_reason
+          with
+          | Keeper_lifecycle_admission.Active -> ()
+          | _ -> Alcotest.fail "Reset_latch must leave the keeper active")
+       | Ok None -> Alcotest.fail "owner metadata missing"
+       | Error _ -> Alcotest.fail "reset command rejected")
+
 let test_resume_owner_rejects_transcript_reset_without_receipt () =
   with_seeded_owner
     ~registered:false
@@ -667,6 +740,14 @@ let () =
             "Resume_owner rejects transcript reset without receipt"
             `Quick
             test_resume_owner_rejects_transcript_reset_without_receipt
+        ; Alcotest.test_case
+            "Pause downgrade keeps the keeper resumable"
+            `Quick
+            test_pause_downgrade_keeps_the_keeper_resumable
+        ; Alcotest.test_case
+            "Reset_latch would make resume refuse"
+            `Quick
+            test_reset_latch_would_make_resume_refuse
         ] )
     ]
 ;;


### PR DESCRIPTION
## 현상

#29177 이 넣은 복구 경로가 판단은 제대로 하고서 그 결과를 그냥 버리고 있었어요.

`recover_transcript_latch` 가 사유를 낮춘 meta 를 **돌려주기만** 했고, `paused_meta` 가 그걸 위로 넘겼고, 받는 쪽은 전부 `_paused` 로 **버렸습니다.** 저장되는 곳이 한 군데도 없었어요.

배포 직후 실제로 눌러봤을 때:

```
resume → {"committed":true, ...,
  "error":"Resume_owner committed receipt but durable_meta projection failed:
           durable pause bit remained set after commit"}

taskmaster.json → latched_reason: {"kind":"transcript_corruption_reset_required"}
```

걸쇠 검사는 통과했어요(오류 문장이 바뀐 게 그 증거예요). 그런데 저장된 상태는 그대로였습니다. 결국 **아무 효과가 없는 코드** 였어요.

## 고친 것

낮춘 사유를 `Keeper_owner_registry.apply_meta` 로 실제 저장합니다. 이때 어떤 명령을 쓰느냐가 핵심이었어요.

| 명령 | 멈춤 표시 | 걸린 사유 | 되살리기 결과 |
|---|---|---|---|
| `Reset_latch` | **꺼짐** | 없음 | "이미 돌고 있다"며 거부 |
| `Pause { Operator_paused }` | 켜짐 유지 | 운영자 멈춤 | 통과 → `mark_resumed` 가 해제 |

`Reset_latch` 는 멈춤 표시까지 꺼버려서, 되살리기가 `Durable_owner_not_paused` 로 거절해요. `Pause` 는 분류만 바꾸기 때문에 기존 되살리기 경로가 그대로 이어받습니다.

## 위치를 옮겼어요

재검사를 `create_receipt` 로 옮겼습니다. 거기서 저장된 meta 를 이미 읽고 있어서 파일을 두 번 읽지 않아도 되고, `paused_meta` 는 `config` 인자가 없는 순수한 판정 함수로 되돌아갔어요.

`downgraded_transcript_latch` 는 지웠습니다. 아무도 저장하지 않는 값만 만들던 함수였어요.

## 그대로 둔 것

`classify_transcript` 와 테스트 3개는 손대지 않았습니다. 처음부터 제대로 동작하던 부분이에요.

```
읽을 수 없는 기록  → 걸쇠 유지
바로 쓸 수 있음    → 사유 낮추고 저장
도구 호출만 열려있음 → close_open_tail 로 닫고 저장한 뒤 사유 낮춤
```

## 확인한 것

- [x] `ocamlformat --check`
- [x] 기존 `test_resume_owner_rejects_transcript_reset_without_receipt` 유지 — 테스트 준비 과정이 checkpoint 를 만들지 않아서 읽기 실패로 거부가 그대로예요
- [ ] CI
- [ ] 배포 후 걸쇠에 걸린 Keeper 에 되살리기 실측

## 참고

지금은 `masc_keeper_reset` 이 같은 결과를 냅니다(설명이 잘못돼 있던 건 #29207 에서 고치는 중이에요). 차이는 이쪽이 **대화 기록을 다시 검사해서 안전할 때만** 푼다는 점입니다. `masc_keeper_reset` 은 조건 없이 지워요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EoKSDigFqnuo1EEH8hyri4
