### PR TITLE
feat(goal): Goal 완료를 바로 끝내지 않고 검증 단계를 거치게 (RFC-0387 2단계 첫 PR)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1168,15 +1168,16 @@ jobs:
             @test/runtest-test_claimable_task_summaries
 
       - name: Run goal phase suite
-        # decide_transition is a 5x7 matrix that had no behavioural test. Its
-        # exhaustive match proves every pair has an arm, not that the arm gives
-        # the right answer -- so a matrix edit could change what the Goal FSM
-        # admits without anything going red. The suite states all 35 pairs.
-        # test_goal_verification_gate pins the RFC-0387 stage-1 surface around
-        # the same lifecycle: B1 creation requires a declared success
-        # condition, the verification ledger is strict/fail-closed/fail-loud,
-        # and request_complete still completes a Goal directly (the gate is
-        # stage 2).
+        # decide_transition is a 6x11 matrix (RFC-0387 stage 2 added Verifying
+        # and the four gate actions). Its exhaustive match proves every pair
+        # has an arm, not that the arm gives the right answer -- so a matrix
+        # edit could change what the Goal FSM admits without anything going
+        # red. The suite states all 66 pairs.
+        # test_goal_verification_gate pins the RFC-0387 surface around the
+        # same lifecycle: B1 creation requires a declared success condition,
+        # the verification ledger is strict/fail-closed/fail-loud, and the
+        # stage-2 gate routes request_complete through Verifying with the
+        # durable proof request persisted before the phase write.
         run: |
           opam exec -- dune build --root . \
             @test/runtest-test_goal_phase_all \

--- a/lib/dashboard/dashboard_goals_types_attainment.ml
+++ b/lib/dashboard/dashboard_goals_types_attainment.ml
@@ -279,7 +279,8 @@ let goal_completion_to_json (goal : Goal_store.goal) (node : tree_node) ~attainm
   let ready_to_request_completion =
     match goal.phase with
     | Goal_phase.Executing -> true
-    | Goal_phase.Blocked | Goal_phase.Paused | Goal_phase.Completed | Goal_phase.Dropped ->
+    | Goal_phase.Blocked | Goal_phase.Paused | Goal_phase.Verifying
+    | Goal_phase.Completed | Goal_phase.Dropped ->
         false
   in
   let state =
@@ -288,12 +289,17 @@ let goal_completion_to_json (goal : Goal_store.goal) (node : tree_node) ~attainm
     | Goal_phase.Dropped -> "dropped"
     | Goal_phase.Blocked -> "blocked"
     | Goal_phase.Paused -> "paused"
+    (* RFC-0387 stage 2: completion was already requested; the proof verdict
+       is pending. Distinct from [ready_for_completion] so the dashboard does
+       not invite a second request. *)
+    | Goal_phase.Verifying -> "verifying"
     | Goal_phase.Executing -> "ready_for_completion"
   in
   let is_terminal =
     match goal.phase with
     | Goal_phase.Completed | Goal_phase.Dropped -> true
-    | Goal_phase.Executing | Goal_phase.Blocked | Goal_phase.Paused ->
+    | Goal_phase.Executing | Goal_phase.Blocked | Goal_phase.Paused
+    | Goal_phase.Verifying ->
         false
   in
   `Assoc

--- a/lib/dashboard/dashboard_goals_types_health.ml
+++ b/lib/dashboard/dashboard_goals_types_health.ml
@@ -33,6 +33,7 @@ let goal_fsm_state_kind = function
   | Goal_phase.Executing -> "executing"
   | Goal_phase.Blocked -> "blocked"
   | Goal_phase.Paused -> "paused"
+  | Goal_phase.Verifying -> "verifying"
   | Goal_phase.Completed -> "completed"
   | Goal_phase.Dropped -> "dropped"
 
@@ -45,6 +46,12 @@ let goal_fsm_next_actions ~goal_phase =
     Goal_phase.Unblock;
     Goal_phase.Drop;
     Goal_phase.Reopen;
+    (* RFC-0387 stage 2: the verifier's proof commits are the only moves out
+       of [Verifying]; on every other phase they are invalid and the filter
+       below drops them. Criterion verdicts are phase-neutral ([Already]), so
+       they never read as a next step. *)
+    Goal_phase.Record_proof_proven;
+    Goal_phase.Record_proof_refuted;
   ]
   |> List.filter (fun action ->
          match

--- a/lib/dashboard/dashboard_goals_types_timeline.ml
+++ b/lib/dashboard/dashboard_goals_types_timeline.ml
@@ -18,6 +18,9 @@ let goal_phase_color = function
   | Goal_phase.Executing -> "#4ade80"
   | Goal_phase.Blocked -> "#ef4444"
   | Goal_phase.Paused -> "#94a3b8"
+  (* RFC-0387 stage 2: the proof-pending hue matches the Task domain's
+     [AwaitingVerification] so the gate reads as the same shape of wait. *)
+  | Goal_phase.Verifying -> "#a78bfa"
   | Goal_phase.Completed -> "#60a5fa"
   | Goal_phase.Dropped -> "#6b7280"
 

--- a/lib/goal/goal_phase.ml
+++ b/lib/goal/goal_phase.ml
@@ -2,6 +2,7 @@ type t =
   | Executing
   | Blocked
   | Paused
+  | Verifying
   | Completed
   | Dropped
 
@@ -9,6 +10,7 @@ let to_string = function
   | Executing -> "executing"
   | Blocked -> "blocked"
   | Paused -> "paused"
+  | Verifying -> "verifying"
   | Completed -> "completed"
   | Dropped -> "dropped"
 
@@ -16,6 +18,7 @@ let of_string = function
   | "executing" -> Some Executing
   | "blocked" -> Some Blocked
   | "paused" -> Some Paused
+  | "verifying" -> Some Verifying
   | "completed" -> Some Completed
   | "dropped" -> Some Dropped
   | _ -> None
@@ -42,13 +45,19 @@ let all =
   [ Executing
   ; Blocked
   ; Paused
+  ; Verifying
   ; Completed
   ; Dropped
   ]
 
-(* Phases from which a keeper can make self-directed progress on the goal. *)
+(* Phases from which a keeper can make self-directed progress on the goal.
+   [Verifying] admits continued progress on the linked tasks while the
+   completion proof is judged out-of-band (RFC-0387 stage 2): the gate holds
+   the phase, not the work — a keeper whose goal entered [Verifying] must
+   still see it as its own (P0-1 of the stage-2 review). *)
 let admits_self_directed_progress = function
   | Executing -> true
+  | Verifying -> true
   | Blocked | Paused | Completed | Dropped -> false
 
 type action =
@@ -59,6 +68,10 @@ type action =
   | Unblock
   | Drop
   | Reopen
+  | Record_proof_proven
+  | Record_proof_refuted
+  | Record_criterion_viable
+  | Record_criterion_unreachable
 
 let action_to_string = function
   | Request_complete -> "request_complete"
@@ -68,6 +81,10 @@ let action_to_string = function
   | Unblock -> "unblock"
   | Drop -> "drop"
   | Reopen -> "reopen"
+  | Record_proof_proven -> "record_proof_proven"
+  | Record_proof_refuted -> "record_proof_refuted"
+  | Record_criterion_viable -> "record_criterion_viable"
+  | Record_criterion_unreachable -> "record_criterion_unreachable"
 
 (* Every action, declaration order. SSOT for the schema/validator action enum
    (see [all]). [action_to_string] is the exhaustive witness. *)
@@ -79,6 +96,10 @@ let all_actions =
   ; Unblock
   ; Drop
   ; Reopen
+  ; Record_proof_proven
+  ; Record_proof_refuted
+  ; Record_criterion_viable
+  ; Record_criterion_unreachable
   ]
 
 let action_of_string = function
@@ -89,6 +110,10 @@ let action_of_string = function
   | "unblock" -> Some Unblock
   | "drop" -> Some Drop
   | "reopen" -> Some Reopen
+  | "record_proof_proven" -> Some Record_proof_proven
+  | "record_proof_refuted" -> Some Record_proof_refuted
+  | "record_criterion_viable" -> Some Record_criterion_viable
+  | "record_criterion_unreachable" -> Some Record_criterion_unreachable
   | _ -> None
 
 let parse_action s =
@@ -104,7 +129,8 @@ type outcome =
    22 of the 35 pairs, so adding a phase or an action compiled cleanly and the
    new combinations silently became "invalid" — the same FSM sparse-match class
    that produced a runtime Assert_failure in keeper_registry. The compiler now
-   refuses a matrix with a hole in it. *)
+   refuses a matrix with a hole in it (6 phases x 11 actions since RFC-0387
+   stage 2 added [Verifying] and the four gate actions). *)
 (* The diagonal -- an action whose target phase the goal already occupies --
    answers [Already]. It used to answer "invalid goal transition", which is the
    opposite of what the Task FSM says for the same shape: there, Cancel on a
@@ -127,32 +153,66 @@ let decide_transition ~phase ~(action : action) =
          (to_string phase) (action_to_string action))
   in
   match phase, action with
-  (* Executing: the only phase that can request completion. Resume, Unblock and
-     Reopen all target Executing, which is where the goal already is. *)
-  | Executing, Request_complete -> Ok (Move_to Completed)
+  (* Executing: the only phase that can request completion. RFC-0387 stage 2:
+     the request no longer completes the goal — it enters [Verifying], and
+     only the verifier's [Record_proof_proven] reaches [Completed]. Resume,
+     Unblock and Reopen all target Executing, which is where the goal already
+     is. *)
+  | Executing, Request_complete -> Ok (Move_to Verifying)
   | Executing, Pause -> Ok (Move_to Paused)
   | Executing, Block -> Ok (Move_to Blocked)
   | Executing, Drop -> Ok (Move_to Dropped)
   | Executing, (Resume | Unblock | Reopen) -> Ok (Already Executing)
+  | Executing, (Record_proof_proven | Record_proof_refuted) -> invalid
+  | Executing, (Record_criterion_viable | Record_criterion_unreachable) ->
+      Ok (Already Executing)
   (* Paused: resumes or drops; it is not blocked and not finished. *)
   | Paused, Resume -> Ok (Move_to Executing)
   | Paused, Drop -> Ok (Move_to Dropped)
   | Paused, Pause -> Ok (Already Paused)
-  | Paused, (Request_complete | Block | Unblock | Reopen) -> invalid
+  | Paused, (Record_criterion_viable | Record_criterion_unreachable) ->
+      Ok (Already Paused)
+  | Paused,
+    ( Request_complete | Block | Unblock | Reopen
+    | Record_proof_proven | Record_proof_refuted ) -> invalid
   (* Blocked: unblocks or drops. Completing while blocked would skip the
      impediment rather than resolve it. *)
   | Blocked, Unblock -> Ok (Move_to Executing)
   | Blocked, Drop -> Ok (Move_to Dropped)
   | Blocked, Block -> Ok (Already Blocked)
-  | Blocked, (Request_complete | Pause | Resume | Reopen) -> invalid
+  | Blocked, (Record_criterion_viable | Record_criterion_unreachable) ->
+      Ok (Already Blocked)
+  | Blocked,
+    ( Request_complete | Pause | Resume | Reopen
+    | Record_proof_proven | Record_proof_refuted ) -> invalid
+  (* Verifying (RFC-0387 stage 2): the completion request is in the pipeline
+     and the proof is judged out-of-band. Only the verifier's proof actions
+     leave the phase; a repeated [Request_complete] is the explicit retry the
+     RFC substitutes for wall-clock expiry, so it answers [Already] and the
+     handler reports (and re-arms) the pending proof. Pausing mid-verdict is
+     out of scope (RFC-0387 §7). *)
+  | Verifying, Record_proof_proven -> Ok (Move_to Completed)
+  | Verifying, Record_proof_refuted -> Ok (Move_to Executing)
+  | Verifying, Request_complete -> Ok (Already Verifying)
+  | Verifying, (Record_criterion_viable | Record_criterion_unreachable) ->
+      Ok (Already Verifying)
+  | Verifying, (Pause | Resume | Block | Unblock | Drop | Reopen) -> invalid
   (* Completed and Dropped are terminal: only reopening leaves them.
      [Dropped, Request_complete] stays invalid -- completion is not the phase a
      dropped goal is in, so it is a real request for a state change, not a
-     restatement. Reopen first. *)
+     restatement. Reopen first. Criterion verdicts are invalid here too: the
+     creation-time declaration of a finished goal is settled history, not a
+     phase-neutral ledger update (RFC-0387 §5). *)
   | Completed, Reopen -> Ok (Move_to Executing)
   | Completed, Drop -> Ok (Move_to Dropped)
   | Completed, Request_complete -> Ok (Already Completed)
-  | Completed, (Pause | Resume | Block | Unblock) -> invalid
+  | Completed,
+    ( Pause | Resume | Block | Unblock
+    | Record_proof_proven | Record_proof_refuted
+    | Record_criterion_viable | Record_criterion_unreachable ) -> invalid
   | Dropped, Reopen -> Ok (Move_to Executing)
   | Dropped, Drop -> Ok (Already Dropped)
-  | Dropped, (Request_complete | Pause | Resume | Block | Unblock) -> invalid
+  | Dropped,
+    ( Request_complete | Pause | Resume | Block | Unblock
+    | Record_proof_proven | Record_proof_refuted
+    | Record_criterion_viable | Record_criterion_unreachable ) -> invalid

--- a/lib/goal/goal_phase.mli
+++ b/lib/goal/goal_phase.mli
@@ -1,15 +1,22 @@
 (** Goal_phase — state machine SSOT for goal lifecycle.
 
-    Encodes the five phases a goal can be in, the operator/system
+    Encodes the six phases a goal can be in, the operator/system
     actions that drive transitions, and the deterministic decision
     function {!decide_transition}. Used by the goal subsystem to keep
-    transition logic out of caller code. *)
+    transition logic out of caller code.
+
+    RFC-0387 stage 2: [Verifying] sits between [Executing] and
+    [Completed] — [Request_complete] enters it, and only the verifier's
+    [Record_proof_proven] leaves it for [Completed]. *)
 
 (** Goal lifecycle phases. *)
 type t =
   | Executing
   | Blocked
   | Paused
+  | Verifying
+      (** Completion requested; the proof verdict is pending out-of-band
+          (RFC-0387 B3). *)
   | Completed
   | Dropped
 
@@ -31,7 +38,9 @@ val all : t list
     string set (MCP schema enum, validator) via [List.map to_string all]. *)
 
 val admits_self_directed_progress : t -> bool
-(** Whether a keeper waking on this goal can make progress on it. *)
+(** Whether a keeper waking on this goal can make progress on it. [Verifying]
+    admits continued progress on the linked tasks while the completion proof
+    is judged out-of-band: the gate holds the phase, not the work. *)
 
 (** Operator / system actions that may drive a transition. *)
 type action =
@@ -42,6 +51,18 @@ type action =
   | Unblock
   | Drop
   | Reopen
+  | Record_proof_proven
+      (** Verifier commit: the completion proof held. [Verifying ->
+          Completed]. Requires non-blank evidence at the tool boundary. *)
+  | Record_proof_refuted
+      (** Verifier commit: the completion proof failed. [Verifying ->
+          Executing]; the refutation reason stays in the ledger and
+          goal_events. *)
+  | Record_criterion_viable
+  | Record_criterion_unreachable
+      (** Phase-neutral creation-time criterion verdicts (RFC-0387 B2): legal
+          in every non-terminal phase as [Already <same phase>] — the handler
+          commits the ledger and never writes the phase. *)
 
 val action_to_string : action -> string
 val action_of_string : string -> action option

--- a/lib/goal/goal_verification.ml
+++ b/lib/goal/goal_verification.ml
@@ -6,10 +6,10 @@
    criterion/completion verification state gets its own store, the same way
    [Workspace_goal_index] keeps goal-task links out of goals.json.
 
-   RFC-0387 stage 1 ships this as a RECORD-ONLY evidence store: no workflow
-   reads it for control and no caller writes it yet — the stage-2 verifier
-   gate adds the writers ([mark_*_pending] durable requests, verdict commits
-   from the verifier lane) and the readers that gate transitions.
+   RFC-0387 stage 1 shipped this as a RECORD-ONLY evidence store; stage 2
+   (the verifier gate) wires the writers: [mark_*_pending] durable requests
+   (creation hook, and before the phase enters [Verifying]) and verdict
+   commits from the verifier lane via [masc_goal_transition].
 
    Invariants carried here:
 
@@ -494,6 +494,57 @@ let record_criterion_verdict config ~goal_id (verdict : verdict) =
       in
       Ok { current with criterion })
 
+(* {1 Stage-2 durable requests (RFC-0387 §3.2 / §4.1)}
+
+   These are the writers the verifier gate persists BEFORE any model call:
+   [mark_criterion_pending] runs at goal creation, [mark_proof_pending] runs
+   before the phase enters [Verifying]. Both are locked read-modify-writes via
+   [update_record], idempotent on an already-pending state (a repeated
+   [request_complete] re-arms rather than failing), and refuse to overwrite a
+   committed verdict — except that a new proof request supersedes a standing
+   [Proof_refuted], per this module's header: a refuted verdict stays on the
+   record until the next request supersedes it, and the refuted goal returns
+   to [Executing] where re-requesting completion is the way forward. *)
+
+let mark_criterion_pending config ~goal_id =
+  update_record config ~goal_id (fun current ->
+      match current.criterion with
+      | Criterion_pending _ -> Ok current
+      | Criterion_unchecked ->
+          Ok
+            { current with
+              criterion = Criterion_pending { requested_at = current.updated_at }
+            }
+      | Criterion_viable _ | Criterion_unreachable _ ->
+          Error
+            (Printf.sprintf
+               "goal_verification: criterion verdict for %s is already \
+                committed; refusing to overwrite it with a pending request"
+               goal_id))
+
+let mark_proof_pending config ~goal_id =
+  update_record config ~goal_id (fun current ->
+      match current.completion with
+      | Proof_pending _ -> Ok current
+      | Completion_idle ->
+          Ok
+            { current with
+              completion = Proof_pending { requested_at = current.updated_at }
+            }
+      | Proof_refuted _ ->
+          (* The next request supersedes the standing refutation; the verdict
+             itself remains readable in the state history until this write. *)
+          Ok
+            { current with
+              completion = Proof_pending { requested_at = current.updated_at }
+            }
+      | Proof_proven _ | Human_confirmed _ ->
+          Error
+            (Printf.sprintf
+               "goal_verification: proof for %s is already proven; refusing \
+                to overwrite the verdict with a pending request"
+               goal_id))
+
 (* A proof verdict is only committable against a pending proof — or against
    the same outcome already committed. The latter is the crash-between-writes
    case the stage-2 gate needs: the ledger write landed but the phase write
@@ -501,8 +552,7 @@ let record_criterion_verdict config ~goal_id (verdict : verdict) =
    identical outcome rather than wedge the goal. A commit in the OPPOSITE
    direction of a standing verdict is a stale verifier answer and stays an
    [Error]. The [Proof_pending] rows this matches against are written by the
-   stage-2 gate ([mark_proof_pending], persist-before-model-call); stage 1
-   has no writer, so until then this only ever answers the error. *)
+   stage-2 gate ([mark_proof_pending], persist-before-model-call). *)
 let record_proof_verdict config ~goal_id (verdict : verdict) =
   update_record config ~goal_id (fun current ->
       let committable =

--- a/lib/goal/goal_verification.mli
+++ b/lib/goal/goal_verification.mli
@@ -6,10 +6,10 @@
     the [Goal_store.goal] record is constructed by literal in external callers,
     so verification state gets its own store.
 
-    RFC-0387 stage 1 ships this module as a RECORD-ONLY evidence store: the
-    dashboard read paths render it, but no workflow reads it for control and
-    no caller writes it yet. Stage 2 (the verifier gate) adds the writers —
-    the durable [*_pending] requests and the verifier-lane verdict commits.
+    RFC-0387 stage 1 shipped this module as a RECORD-ONLY evidence store;
+    stage 2 (the verifier gate) wires the writers — the durable
+    [mark_*_pending] requests and the verdict commits — and the reader that
+    gates [request_complete] on [Criterion_unreachable].
 
     Two state machines per goal, both closed sum types:
 
@@ -103,8 +103,29 @@ val ledger_error_to_yojson : string -> Yojson.Safe.t
 (** {1 Mutations}
 
     All are locked read-modify-writes that refuse an undecodable store.
-    Stage 1 wires no caller; these are the surface the stage-2 verifier gate
-    commits through. *)
+    Stage 2 wires them: [mark_*_pending] are the durable requests the gate
+    persists before any model call, and the verdict commits are what the
+    verifier lane (or a manual [masc_goal_transition] with evidence) writes. *)
+
+val mark_criterion_pending :
+  Workspace_utils.config ->
+  goal_id:string ->
+  (record, string) result
+(** Records the durable creation-time criterion check (RFC-0387 §3.2, B2):
+    [Criterion_unchecked -> Criterion_pending]. Idempotent when already
+    pending; refuses to overwrite a committed [Criterion_viable] /
+    [Criterion_unreachable] verdict. *)
+
+val mark_proof_pending :
+  Workspace_utils.config ->
+  goal_id:string ->
+  (record, string) result
+(** Records the durable completion-proof request (RFC-0387 §4.1, B3):
+    [Completion_idle -> Proof_pending], persisted BEFORE the phase enters
+    [Verifying] (persist-before-model-call). Idempotent when already pending —
+    a repeated [request_complete] re-arms the request. A standing
+    [Proof_refuted] is superseded by the new request; a committed
+    [Proof_proven] / [Human_confirmed] verdict is never overwritten. *)
 
 val record_criterion_verdict :
   Workspace_utils.config ->

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -41,7 +41,13 @@ let describe_pruned_goal = function
     "doesn't catch goal property changes (status, phase)", which is the residue
     this closes. Measured 2026-08-07: sangsu carried goal-request-menu-zero for
     5,362 tool calls across 2.5 days after it completed, stamped goal-bound the
-    whole time, with an empty Active goals section in every one of those turns. *)
+    whole time, with an empty Active goals section in every one of those turns.
+
+    RFC-0387 stage 2: [Verifying] deliberately SURVIVES this cross-check —
+    [Goal_phase.admits_self_directed_progress] admits it, because the gate
+    holds the phase while the proof is judged out-of-band and the keeper keeps
+    working the linked tasks. Pruning a Verifying goal here would erase it from
+    the keeper's scope at exactly the moment the gate took over (review P0-1). *)
 let validate_active_goal_ids ~(config : Workspace.config) ~(meta : keeper_meta) () =
   let valid_goal_ids, pruned =
     List.partition_map

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -106,26 +106,55 @@ let format_goals (goal_ids : string list) : string =
   String.concat "\n"
     (List.map (fun gid -> Printf.sprintf "- %s" gid) goal_ids)
 
+(* What the prompt knows about one active goal. [phase] is [None] only when the
+   id does not resolve in the store (a dangling assignment — kept visible, per
+   [active_goal_summaries]). RFC-0387 stage 2 carries the phase so a [Verifying]
+   goal is annotated rather than reading as ordinary open work — the gate must
+   not make the goal disappear from the keeper's view (review P0-1). *)
+type goal_summary =
+  { summary_goal_id : string
+  ; summary_title : string
+  ; summary_phase : Goal_phase.t option
+  }
+
 (** Format active goals with their titles (RFC-0315). Falls back to
-    [format_goals] at the call site when the caller did not resolve titles. *)
-let format_goal_summaries (summaries : (string * string) list) : string =
+    [format_goals] at the call site when the caller did not resolve titles.
+    A [Verifying] goal is annotated: completion is requested and the proof is
+    being judged out-of-band, so the keeper keeps working the linked tasks
+    instead of re-requesting completion. *)
+let format_goal_summaries (summaries : goal_summary list) : string =
   String.concat "\n"
     (List.map
-       (fun (gid, title) ->
-         if title = "" then Printf.sprintf "- %s" gid
-         else Printf.sprintf "- %s — %s" gid title)
+       (fun summary ->
+         let base =
+           if summary.summary_title = ""
+           then Printf.sprintf "- %s" summary.summary_goal_id
+           else
+             Printf.sprintf "- %s — %s" summary.summary_goal_id summary.summary_title
+         in
+         match summary.summary_phase with
+         | Some Goal_phase.Verifying ->
+           base ^ " [증명 대기 중 — verifier가 proof를 검토 중]"
+         | Some
+             ( Goal_phase.Executing | Goal_phase.Blocked | Goal_phase.Paused
+             | Goal_phase.Completed | Goal_phase.Dropped )
+         | None -> base)
        summaries)
 
 let format_goal_summaries_for_active_goals
     ~(active_goal_ids : string list)
-    (summaries : (string * string) list) : string =
-  let title_for goal_id =
-    match List.assoc_opt goal_id summaries with
-    | Some title -> title
-    | None -> ""
+    (summaries : goal_summary list) : string =
+  let summary_for goal_id =
+    match
+      List.find_opt
+        (fun (s : goal_summary) -> String.equal s.summary_goal_id goal_id)
+        summaries
+    with
+    | Some summary -> summary
+    | None ->
+      { summary_goal_id = goal_id; summary_title = ""; summary_phase = None }
   in
-  format_goal_summaries
-    (List.map (fun goal_id -> (goal_id, title_for goal_id)) active_goal_ids)
+  format_goal_summaries (List.map summary_for active_goal_ids)
 
 (** Render the keeper's own claimed task as standing context (RFC-0315).
     The scheduled cycle always runs when proactive lifecycle is enabled, and
@@ -777,11 +806,14 @@ let effective_instructions ~(meta : Keeper_meta_contract.keeper_meta)
   effective_autonomous_instructions ~meta ?profile_defaults ?channel ()
 ;;
 
-(* Titles for the goals the world observation already narrowed to the ones a
-   keeper can still progress. [meta.active_goal_ids] records assignment and is
-   never cleared when a goal reaches a terminal phase, so this resolves the
-   same phase question the observation does — a keeper must not be handed a
-   Completed goal under a heading that calls it available. *)
+(* Titles and phases for the goals the world observation already narrowed to
+   the ones a keeper can still progress. [meta.active_goal_ids] records
+   assignment and is never cleared when a goal reaches a terminal phase, so
+   this resolves the same phase question the observation does — a keeper must
+   not be handed a Completed goal under a heading that calls it available. The
+   phase rides along so the Active Goals block can annotate a [Verifying] goal
+   (RFC-0387 stage 2: the gate must not make the goal read as ordinary open
+   work, nor disappear — review P0-1). *)
 let active_goal_summaries
       ~(config : Workspace.config)
       ~(meta : Keeper_meta_contract.keeper_meta)
@@ -791,9 +823,19 @@ let active_goal_summaries
        match Goal_store.get_goal config ~goal_id with
        | Some { Goal_store.title; phase; _ } ->
          if Goal_phase.admits_self_directed_progress phase
-         then Some (goal_id, title)
+         then
+           Some
+             { summary_goal_id = goal_id
+             ; summary_title = title
+             ; summary_phase = Some phase
+             }
          else None
-       | None -> Some (goal_id, ""))
+       | None ->
+         Some
+           { summary_goal_id = goal_id
+           ; summary_title = ""
+           ; summary_phase = None
+           })
     meta.active_goal_ids
 ;;
 
@@ -823,7 +865,17 @@ let executing_goals_without_tasks ~(config : Workspace.config) ~owner_matches =
     let index = Workspace_goal_index.build_goal_task_index_for_config config tasks in
     List.filter
       (fun (g : Goal_store.goal) ->
-         Goal_phase.admits_self_directed_progress g.phase
+         (* Deliberately [Executing] only, not [admits_self_directed_progress]:
+            that predicate also admits [Verifying] (RFC-0387 stage 2), but a
+            goal awaiting its proof verdict is not "work with no Task yet" —
+            nudging the keeper to start new tasks on it would race the gate. *)
+         (match g.phase with
+          | Goal_phase.Executing -> true
+          | Goal_phase.Blocked
+          | Goal_phase.Paused
+          | Goal_phase.Verifying
+          | Goal_phase.Completed
+          | Goal_phase.Dropped -> false)
          &&
          match Hashtbl.find_opt index g.id with
          | Some (_ :: _) -> false
@@ -869,14 +921,25 @@ let build_system_prompt ~(meta : Keeper_meta_contract.keeper_meta)
     ~(config : Workspace.config)
     ?(profile_defaults : Keeper_types_profile.keeper_profile_defaults option)
     ?(channel : Keeper_world_observation.keeper_cycle_channel option)
-    ?(active_goal_summaries : (string * string) list option)
+    ?(active_goal_summaries : goal_summary list option)
     ()
   =
   let instructions = effective_instructions ~meta ?profile_defaults ?channel () in
+  (* [Keeper_prompt.build_keeper_system_prompt] renders id+title only; the
+     phase stays on the [goal_summary] for the Active Goals layer. *)
   let active_goals =
-    Option.value
-      ~default:(List.map (fun goal_id -> (goal_id, "")) meta.active_goal_ids)
-      active_goal_summaries
+    List.map
+      (fun (s : goal_summary) -> s.summary_goal_id, s.summary_title)
+      (Option.value
+         ~default:
+           (List.map
+              (fun goal_id ->
+                 { summary_goal_id = goal_id
+                 ; summary_title = ""
+                 ; summary_phase = None
+                 })
+              meta.active_goal_ids)
+         active_goal_summaries)
   in
   let base_system_prompt =
     Keeper_prompt.build_keeper_system_prompt
@@ -936,7 +999,7 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta)
     ?(profile_defaults : Keeper_types_profile.keeper_profile_defaults option)
     ~(turn_decision : Keeper_world_observation.keeper_cycle_decision option)
     ~(current_task : Keeper_world_observation_inputs.current_task_observation)
-    ?(active_goal_summaries : (string * string) list option)
+    ?(active_goal_summaries : goal_summary list option)
     ~(observation : Keeper_world_observation.world_observation)
     () : turn_prompt_parts
   =

--- a/lib/keeper/keeper_unified_prompt.mli
+++ b/lib/keeper/keeper_unified_prompt.mli
@@ -112,10 +112,21 @@ val unowned_executing_goals_without_tasks :
     store seven of the ten are children of the eighth, and as peers "take one"
     cannot distinguish taking the umbrella from taking one service under it. *)
 
+(** What the prompt knows about one active goal: id, title, and the stored
+    phase. [summary_phase] is [None] only for an id the store cannot resolve
+    (a dangling assignment, kept visible). RFC-0387 stage 2 carries the phase
+    so a [Verifying] goal renders annotated in the Active Goals layer — the
+    gate must not make the goal disappear from the keeper (review P0-1). *)
+type goal_summary = {
+  summary_goal_id : string;
+  summary_title : string;
+  summary_phase : Goal_phase.t option;
+}
+
 val active_goal_summaries :
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->
-  (string * string) list
+  goal_summary list
 (** Resolve the active goal ids a keeper can still progress, for the stable
     prompt contract. [meta.active_goal_ids] records assignment and is never
     cleared when a goal reaches a terminal phase, so ids whose stored phase
@@ -129,7 +140,7 @@ val build_system_prompt :
   config:Workspace.config ->
   ?profile_defaults:Keeper_types_profile.keeper_profile_defaults ->
   ?channel:Keeper_world_observation.keeper_cycle_channel ->
-  ?active_goal_summaries:(string * string) list ->
+  ?active_goal_summaries:goal_summary list ->
   unit ->
   string
 (** Build the model-facing stable Keeper contract shared by direct and
@@ -150,7 +161,7 @@ val build_prompt :
   ?profile_defaults:Keeper_types_profile.keeper_profile_defaults ->
   turn_decision:Keeper_world_observation.keeper_cycle_decision ->
   current_task:Keeper_world_observation_inputs.current_task_observation ->
-  ?active_goal_summaries:(string * string) list ->
+  ?active_goal_summaries:goal_summary list ->
   observation:Keeper_world_observation.world_observation ->
   unit ->
   turn_prompt_parts
@@ -164,14 +175,15 @@ val build_prompt :
     - [current_task] renders the held task or its explicit missing/unavailable
       state. [No_current_task] omits the layer.
     - [?active_goal_summaries]: renders goal titles next to ids in the Active
-      Goals layer. Omitted or empty: bare ids. *)
+      Goals layer, with a proof-pending annotation on [Verifying] goals
+      (RFC-0387 stage 2). Omitted or empty: bare ids. *)
 
 val build_prompt_preview :
   meta:Keeper_meta_contract.keeper_meta ->
   config:Workspace.config ->
   ?profile_defaults:Keeper_types_profile.keeper_profile_defaults ->
   current_task:Keeper_world_observation_inputs.current_task_observation ->
-  ?active_goal_summaries:(string * string) list ->
+  ?active_goal_summaries:goal_summary list ->
   observation:Keeper_world_observation.world_observation ->
   unit ->
   turn_prompt_parts

--- a/lib/tool_schemas/tool_schemas_workspace_extra.ml
+++ b/lib/tool_schemas/tool_schemas_workspace_extra.ml
@@ -106,7 +106,16 @@ let schemas : tool_schema list =
     }
   ; { name = "masc_goal_transition"
     ; description =
-        "Apply an explicit Goal lifecycle transition. request_complete completes the Goal directly."
+        "Apply an explicit Goal lifecycle transition (RFC-0387 stage 2 gate). \
+         request_complete no longer completes the Goal directly: it moves \
+         executing -> verifying and persists a durable proof request; only the \
+         verifier's record_proof_proven (with non-blank evidence) moves \
+         verifying -> completed, and record_proof_refuted returns the Goal to \
+         executing with the refutation preserved. record_criterion_viable / \
+         record_criterion_unreachable commit the creation-time criterion \
+         verdict without changing the phase. A Goal whose criterion was judged \
+         unreachable is refused on request_complete. All four record_* actions \
+         require non-blank evidence."
     ; input_schema =
         `Assoc
           [ "type", `String "object"
@@ -115,6 +124,17 @@ let schemas : tool_schema list =
                 [ "goal_id", `Assoc [ "type", `String "string" ]
                 ; "action", enum_schema goal_transition_action_enum
                 ; "note", `Assoc [ "type", `String "string" ]
+                ; ( "evidence"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "description"
+                        , `String
+                            "Required (non-blank) for the four record_* gate \
+                             actions: the observation the verdict stands on. \
+                             For record_proof_refuted and \
+                             record_criterion_unreachable, [note] carries the \
+                             refutation reason." )
+                      ] )
                 ] )
           ; "required", `List [ `String "goal_id"; `String "action" ]
           ; "additionalProperties", `Bool false

--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -283,12 +283,28 @@ let handle_goal_upsert ~tool_name ~start_time (ctx : context) args : Tool_result
             | `created -> "created"
             | `updated -> "updated"
           in
+          (* RFC-0387 §3.2 (B2): creation records the durable criterion-check
+             request BEFORE any verifier model call consumes it. The goal is
+             already committed, so a failed write does not fail the creation
+             (the cross-file best-effort precedent of [delete_goal]) — it is
+             reported in [criterion_check] instead. Updates carry no hook:
+             the declaration obligation is creation-time only. *)
+          let criterion_check =
+            match action with
+            | `updated -> `String "not_applicable_update"
+            | `created ->
+              (match Goal_verification.mark_criterion_pending ctx.config ~goal_id:goal.id with
+               | Ok _ -> `String "criterion_pending"
+               | Error msg -> `Assoc [ "state", `String "criterion_check_failed"
+                                     ; "detail", `String msg ])
+          in
           ok_result
             ~tool_name
             ~start_time
             [ "action", `String action_name
             ; "goal_id", `String goal.id
             ; "goal", Goal_store.goal_to_yojson goal
+            ; "criterion_check", criterion_check
             ; ( "task_goal_id_example"
               , `String
                   (Printf.sprintf
@@ -411,6 +427,159 @@ let handle_goal_assign ~tool_name ~start_time (ctx : context) args
              ]))
 ;;
 
+(* RFC-0387 stage 2 — the completion gate.
+
+   Ordering for every gated action: [Goal_phase.decide_transition] first (the
+   FSM is the ONLY transition decider), then the ledger commit, then the phase
+   write, then the event. The ledger never judges a transition — it records
+   durable requests ([mark_*_pending]) and verdicts, and its commit failure
+   vetoes the phase write (persist-before-model-call), which is what keeps a
+   crashed write reconcilable instead of wedged (stage-2 review P0-2). *)
+
+(* The four gate actions carry a verdict; a verdict without evidence is not a
+   judgment, so [evidence] is required non-blank (RFC-0387 §3.3/§4). *)
+let gate_action_requires_evidence = function
+  | Goal_phase.Record_proof_proven
+  | Goal_phase.Record_proof_refuted
+  | Goal_phase.Record_criterion_viable
+  | Goal_phase.Record_criterion_unreachable -> true
+  | Goal_phase.Request_complete
+  | Goal_phase.Pause
+  | Goal_phase.Resume
+  | Goal_phase.Block
+  | Goal_phase.Unblock
+  | Goal_phase.Drop
+  | Goal_phase.Reopen -> false
+;;
+
+let validate_gate_evidence args action =
+  if not (gate_action_requires_evidence action)
+  then Ok ""
+  else
+    match get_string_opt args "evidence" with
+    | Some evidence when String.trim evidence <> "" -> Ok evidence
+    | received ->
+      Error
+        [ { field = "evidence"
+          ; constraint_violated = Required
+          ; message =
+              Printf.sprintf
+                "%s requires non-blank evidence — a verdict without evidence \
+                 is not a judgment (RFC-0387)"
+                (Goal_phase.action_to_string action)
+          ; expected = Some "non-blank string"
+          ; received
+          }
+        ]
+;;
+
+(* The MCP surface does not authenticate the caller, so the commit authority is
+   the caller's session name in the system-agent slot (RFC-0387 §4.3); the
+   authenticated binding is the B7 follow-up this slot is typed for. *)
+let gate_verdict
+      (ctx : context)
+      (outcome : Goal_verification.verdict_outcome)
+      ~evidence
+    : Goal_verification.verdict
+  =
+  { Goal_verification.outcome
+  ; authority = Masc_domain.System_llm_agent { agent_run_id = ctx.agent_name }
+  ; evidence
+  ; recorded_at = Masc_domain.now_iso ()
+  }
+;;
+
+(* A refutation carries a reason; the caller's [note] is it, and the evidence
+   stands in when no note was given — a blank reason is never written. *)
+let refuted_outcome ~evidence ~note : Goal_verification.verdict_outcome =
+  match note with
+  | Some reason when String.trim reason <> "" ->
+    Goal_verification.Refuted { reason }
+  | _ -> Goal_verification.Refuted { reason = evidence }
+;;
+
+let gate_event_payload (ctx : context) ~phase (verdict : Goal_verification.verdict) =
+  let outcome_fields =
+    match verdict.outcome with
+    | Goal_verification.Proven -> [ "outcome", `String "proven" ]
+    | Goal_verification.Refuted { reason } ->
+      [ "outcome", `String "refuted"; "reason", `String reason ]
+  in
+  `Assoc
+    ([ "phase", Goal_phase.to_yojson phase
+     ; "actor", `String ctx.agent_name
+     ; "evidence", `String verdict.evidence
+     ]
+     @ outcome_fields)
+;;
+
+let already_goal_response ~tool_name ~start_time ~goal_id ~action ~phase goal verification =
+  ok_result
+    ~tool_name
+    ~start_time
+    ([ "goal_id", `String goal_id
+     ; "action", `String (Goal_phase.action_to_string action)
+     ; "noop", `Bool true
+     ; "phase", Goal_phase.to_yojson phase
+     ; "goal", Goal_store.goal_to_yojson goal
+     ]
+     @
+     match verification with
+     | Some (record : Goal_verification.record) ->
+       [ "verification", Goal_verification.record_to_yojson record ]
+     | None -> [])
+;;
+
+(* Phase-neutral criterion commit (RFC-0387 §3.3): the FSM answered [Already]
+   for a non-terminal phase, so there is no phase write and no phase event —
+   the ledger is the whole effect. *)
+let commit_criterion_verdict_response
+      ~tool_name ~start_time (ctx : context) ~goal_id ~action ~phase goal verdict
+  =
+  match Goal_verification.record_criterion_verdict ctx.config ~goal_id verdict with
+  | Error msg -> error_result_typed ~tool_name ~start_time ~code:Conflict msg
+  | Ok record ->
+    already_goal_response
+      ~tool_name ~start_time ~goal_id ~action ~phase goal (Some record)
+;;
+
+(* A repeated [request_complete] on [Verifying] is the explicit retry that
+   replaces wall-clock expiry (RFC-0387 §5). It answers [Already] carrying the
+   ledger state as the retry hint — and when the ledger lost the durable proof
+   request (the phase=Verifying + ledger=idle wedge of the rejected first
+   gate, P0-2), it RE-ARMS [mark_proof_pending] before answering, so the gate
+   always has a pending request for the verifier to drain. *)
+let answer_verifying_repeat ~tool_name ~start_time (ctx : context) ~goal_id ~action goal =
+  match Goal_verification.get_record ctx.config ~goal_id with
+  | Error msg -> error_result_typed ~tool_name ~start_time ~code:Internal_error msg
+  | Ok record ->
+    (match record with
+     | Some
+         { Goal_verification.completion =
+             ( Goal_verification.Proof_pending _
+             | Goal_verification.Proof_proven _
+             | Goal_verification.Human_confirmed _ )
+         ; _
+         } ->
+       (* The durable request stands, or the verdict committed but the phase
+          write did not (crash-between-writes) — nothing to re-arm; the
+          retried [record_proof_*] re-commits the identical outcome and moves
+          the phase. *)
+       already_goal_response
+         ~tool_name ~start_time ~goal_id ~action ~phase:Goal_phase.Verifying goal
+         record
+     | Some { Goal_verification.completion = Goal_verification.Completion_idle; _ }
+     | Some { Goal_verification.completion = Goal_verification.Proof_refuted _; _ }
+     | None ->
+       (match Goal_verification.mark_proof_pending ctx.config ~goal_id with
+        | Error msg ->
+          error_result_typed ~tool_name ~start_time ~code:Internal_error msg
+        | Ok record ->
+          already_goal_response
+            ~tool_name ~start_time ~goal_id ~action ~phase:Goal_phase.Verifying goal
+            (Some record)))
+;;
+
 let handle_goal_transition ~tool_name ~start_time (ctx : context) args
     : Tool_result.result =
   match
@@ -420,49 +589,183 @@ let handle_goal_transition ~tool_name ~start_time (ctx : context) args
   | Error err, _ | _, Error err ->
     validation_error_result ~tool_name ~start_time [ err ]
   | Ok goal_id, Ok (Some action) ->
-    let note = get_string_opt args "note" in
-    (match Goal_store.get_goal ctx.config ~goal_id with
-     | None ->
-       error_result_typed ~tool_name ~start_time ~code:Not_found "goal not found"
-     | Some goal ->
-       (match Goal_phase.decide_transition ~phase:goal.phase ~action with
-        | Error msg ->
-          error_result_typed ~tool_name ~start_time ~code:Conflict msg
-        (* The goal already occupies the phase this action targets. Writing it
-           and emitting a phase event would turn a repeated report — a duplicate
-           reconciliation, a stale racing event — into repeated history, so the
-           request is answered from the goal as it stands. *)
-        | Ok (Goal_phase.Already phase) ->
-          ok_result
-            ~tool_name
-            ~start_time
-            [ "goal_id", `String goal_id
-            ; "action", `String (Goal_phase.action_to_string action)
-            ; "noop", `Bool true
-            ; "phase", Goal_phase.to_yojson phase
-            ; "goal", Goal_store.goal_to_yojson goal
-            ]
-        | Ok (Goal_phase.Move_to phase) ->
-          (match update_goal_phase ctx goal ~phase ?note () with
+    (match validate_gate_evidence args action with
+     | Error errs -> validation_error_result ~tool_name ~start_time errs
+     | Ok evidence ->
+       let note = get_string_opt args "note" in
+       (match Goal_store.get_goal ctx.config ~goal_id with
+        | None ->
+          error_result_typed ~tool_name ~start_time ~code:Not_found "goal not found"
+        | Some goal ->
+          (match Goal_phase.decide_transition ~phase:goal.phase ~action with
            | Error msg ->
-             error_result_typed ~tool_name ~start_time ~code:Internal_error msg
-           | Ok updated_goal ->
-             emit_goal_event
-               ctx
-               ~goal_id
-               ~event_type:"goal_phase"
-               ~payload:
-                 (`Assoc
-                    [ "phase", Goal_phase.to_yojson updated_goal.phase
-                    ; "actor", `String ctx.agent_name
-                    ]);
-             ok_result
-               ~tool_name
-               ~start_time
-               [ "goal_id", `String goal_id
-               ; "action", `String (Goal_phase.action_to_string action)
-               ; "goal", Goal_store.goal_to_yojson updated_goal
-               ])))
+             error_result_typed ~tool_name ~start_time ~code:Conflict msg
+           (* The goal already occupies the phase this action targets. Writing it
+              and emitting a phase event would turn a repeated report — a duplicate
+              reconciliation, a stale racing event — into repeated history, so the
+              request is answered from the goal as it stands. The gate exceptions
+              that still work the ledger are the criterion commits and the
+              [Verifying] repeat; see the helpers above. *)
+           | Ok (Goal_phase.Already phase) ->
+             (match action with
+              | Goal_phase.Record_criterion_viable ->
+                commit_criterion_verdict_response
+                  ~tool_name ~start_time ctx ~goal_id ~action ~phase goal
+                  (gate_verdict ctx Goal_verification.Proven ~evidence)
+              | Goal_phase.Record_criterion_unreachable ->
+                commit_criterion_verdict_response
+                  ~tool_name ~start_time ctx ~goal_id ~action ~phase goal
+                  (gate_verdict ctx (refuted_outcome ~evidence ~note) ~evidence)
+              | Goal_phase.Request_complete ->
+                (match phase with
+                 | Goal_phase.Verifying ->
+                   answer_verifying_repeat
+                     ~tool_name ~start_time ctx ~goal_id ~action goal
+                 | Goal_phase.Executing
+                 | Goal_phase.Blocked
+                 | Goal_phase.Paused
+                 | Goal_phase.Completed
+                 | Goal_phase.Dropped ->
+                   already_goal_response
+                     ~tool_name ~start_time ~goal_id ~action ~phase goal None)
+              | Goal_phase.Record_proof_proven
+              | Goal_phase.Record_proof_refuted
+              | Goal_phase.Pause
+              | Goal_phase.Resume
+              | Goal_phase.Block
+              | Goal_phase.Unblock
+              | Goal_phase.Drop
+              | Goal_phase.Reopen ->
+                already_goal_response
+                  ~tool_name ~start_time ~goal_id ~action ~phase goal None)
+           | Ok (Goal_phase.Move_to phase) ->
+             (match action with
+              | Goal_phase.Request_complete ->
+                (* Executing -> Verifying (RFC-0387 §4): gate on the criterion
+                   verdict, then persist the proof request BEFORE the phase
+                   write — if the ledger write fails the phase does not move.
+                   A ledger that does not decode is a typed error, never read
+                   as "not unreachable" (P1-1). *)
+                (match Goal_verification.get_record ctx.config ~goal_id with
+                 | Error msg ->
+                   error_result_typed ~tool_name ~start_time ~code:Internal_error msg
+                 | Ok
+                     (Some
+                       { Goal_verification.criterion =
+                           Goal_verification.Criterion_unreachable _
+                       ; _
+                       }) ->
+                   error_result_typed
+                     ~tool_name
+                     ~start_time
+                     ~code:Conflict
+                     (Printf.sprintf
+                        "goal %s criterion was judged unreachable; \
+                         request_complete is refused (RFC-0387 B2)"
+                        goal_id)
+                 | Ok _ ->
+                   (match
+                      Goal_verification.mark_proof_pending ctx.config ~goal_id
+                    with
+                    | Error msg ->
+                      error_result_typed
+                        ~tool_name ~start_time ~code:Internal_error msg
+                    | Ok record ->
+                      (match update_goal_phase ctx goal ~phase ?note () with
+                       | Error msg ->
+                         error_result_typed
+                           ~tool_name ~start_time ~code:Internal_error msg
+                       | Ok updated_goal ->
+                         emit_goal_event
+                           ctx
+                           ~goal_id
+                           ~event_type:"goal_phase"
+                           ~payload:
+                             (`Assoc
+                                [ "phase", Goal_phase.to_yojson updated_goal.phase
+                                ; "actor", `String ctx.agent_name
+                                ]);
+                         ok_result
+                           ~tool_name
+                           ~start_time
+                           [ "goal_id", `String goal_id
+                           ; "action", `String (Goal_phase.action_to_string action)
+                           ; "goal", Goal_store.goal_to_yojson updated_goal
+                           ; ( "verification"
+                             , Goal_verification.record_to_yojson record )
+                           ])))
+              | Goal_phase.Record_proof_proven
+              | Goal_phase.Record_proof_refuted ->
+                (* Verifying -> Completed|Executing: the ledger commit is the
+                   verdict of record and runs BEFORE the phase write, so a
+                   stale verifier answer (no pending proof) vetoes the move. *)
+                let verdict =
+                  match action with
+                  | Goal_phase.Record_proof_proven ->
+                    gate_verdict ctx Goal_verification.Proven ~evidence
+                  | _ -> gate_verdict ctx (refuted_outcome ~evidence ~note) ~evidence
+                in
+                (match
+                   Goal_verification.record_proof_verdict
+                     ctx.config ~goal_id verdict
+                 with
+                 | Error msg ->
+                   error_result_typed ~tool_name ~start_time ~code:Conflict msg
+                 | Ok record ->
+                   (match update_goal_phase ctx goal ~phase ?note () with
+                    | Error msg ->
+                      error_result_typed
+                        ~tool_name ~start_time ~code:Internal_error msg
+                    | Ok updated_goal ->
+                      emit_goal_event
+                        ctx
+                        ~goal_id
+                        ~event_type:"goal_phase"
+                        ~payload:(gate_event_payload ctx ~phase verdict);
+                      ok_result
+                        ~tool_name
+                        ~start_time
+                        [ "goal_id", `String goal_id
+                        ; "action", `String (Goal_phase.action_to_string action)
+                        ; "goal", Goal_store.goal_to_yojson updated_goal
+                        ; "verification", Goal_verification.record_to_yojson record
+                        ]))
+              | Goal_phase.Record_criterion_viable
+              | Goal_phase.Record_criterion_unreachable ->
+                (* Criterion verdicts are phase-neutral: the FSM only answers
+                   [Already] for them, so [Move_to] here is unreachable. *)
+                error_result_typed
+                  ~tool_name
+                  ~start_time
+                  ~code:Internal_error
+                  "criterion verdicts are phase-neutral; decide_transition \
+                   never moves for them"
+              | Goal_phase.Pause
+              | Goal_phase.Resume
+              | Goal_phase.Block
+              | Goal_phase.Unblock
+              | Goal_phase.Drop
+              | Goal_phase.Reopen ->
+                (match update_goal_phase ctx goal ~phase ?note () with
+                 | Error msg ->
+                   error_result_typed ~tool_name ~start_time ~code:Internal_error msg
+                 | Ok updated_goal ->
+                   emit_goal_event
+                     ctx
+                     ~goal_id
+                     ~event_type:"goal_phase"
+                     ~payload:
+                       (`Assoc
+                          [ "phase", Goal_phase.to_yojson updated_goal.phase
+                          ; "actor", `String ctx.agent_name
+                          ]);
+                   ok_result
+                     ~tool_name
+                     ~start_time
+                     [ "goal_id", `String goal_id
+                     ; "action", `String (Goal_phase.action_to_string action)
+                     ; "goal", Goal_store.goal_to_yojson updated_goal
+                     ])))))
   | Ok _, Ok None ->
     validation_error_result
       ~tool_name

--- a/test/stanzas/test_goal_verification_gate.inc
+++ b/test/stanzas/test_goal_verification_gate.inc
@@ -1,7 +1,8 @@
-; Per-file dune stanza for the RFC-0387 stage-1 surface: the B1 creation
-; requirement and the record-only verification ledger (+ its observability
-; join). Lives here per test/stanzas/README.md to avoid the conflict-runtime
-; hotspot in the legacy grouped (tests ...) stanza.
+; Per-file dune stanza for the RFC-0387 surface: the B1 creation
+; requirement, the verification ledger (+ its observability join), and the
+; stage-2 completion gate (Verifying phase, proof/criterion verdict actions,
+; re-arm). Lives here per test/stanzas/README.md to avoid the
+; conflict-runtime hotspot in the legacy grouped (tests ...) stanza.
 
 (test
  (name test_goal_verification_gate)

--- a/test/test_goal_phase_all.ml
+++ b/test/test_goal_phase_all.ml
@@ -20,7 +20,7 @@ let test_phase_roundtrip () =
 
 let test_phase_set () =
   let strs = List.map GP.to_string GP.all in
-  check int "phase count" 5 (List.length GP.all);
+  check int "phase count" 6 (List.length GP.all);
   check int "no duplicate phase strings"
     (List.length strs)
     (List.length (List.sort_uniq String.compare strs));
@@ -29,6 +29,7 @@ let test_phase_set () =
       "executing";
       "blocked";
       "paused";
+      "verifying";
       "completed";
       "dropped";
     ]
@@ -45,7 +46,7 @@ let test_action_roundtrip () =
 
 let test_action_set () =
   let strs = List.map GP.action_to_string GP.all_actions in
-  check int "action count" 7 (List.length GP.all_actions);
+  check int "action count" 11 (List.length GP.all_actions);
   check int "no duplicate action strings"
     (List.length strs)
     (List.length (List.sort_uniq String.compare strs));
@@ -58,10 +59,14 @@ let test_action_set () =
       "unblock";
       "drop";
       "reopen";
+      "record_proof_proven";
+      "record_proof_refuted";
+      "record_criterion_viable";
+      "record_criterion_unreachable";
     ]
     strs
 
-(* The 5x7 matrix in [decide_transition] had no behavioural test. Its comment
+(* The 6x11 matrix in [decide_transition] had no behavioural test. Its comment
    says the compiler "refuses a matrix with a hole in it", and that is true --
    but exhaustiveness proves each pair has an arm, not that the arm gives the
    right answer. Every pair is stated here as a literal, so a matrix edit shows
@@ -73,16 +78,23 @@ let outcome_label = function
   | Error _ -> "invalid"
 
 (* phase, action, expected outcome. Read down a column to see one action across
-   all phases; the diagonal (target phase = current phase) is "already:*". *)
+   all phases; the diagonal (target phase = current phase) is "already:*".
+   RFC-0387 stage 2: request_complete moves executing -> verifying; only
+   record_proof_proven reaches completed; the criterion actions are
+   phase-neutral (already:<same>) outside the terminal phases. *)
 let matrix =
   [
-    (GP.Executing, GP.Request_complete, "move_to:completed");
+    (GP.Executing, GP.Request_complete, "move_to:verifying");
     (GP.Executing, GP.Pause, "move_to:paused");
     (GP.Executing, GP.Resume, "already:executing");
     (GP.Executing, GP.Block, "move_to:blocked");
     (GP.Executing, GP.Unblock, "already:executing");
     (GP.Executing, GP.Drop, "move_to:dropped");
     (GP.Executing, GP.Reopen, "already:executing");
+    (GP.Executing, GP.Record_proof_proven, "invalid");
+    (GP.Executing, GP.Record_proof_refuted, "invalid");
+    (GP.Executing, GP.Record_criterion_viable, "already:executing");
+    (GP.Executing, GP.Record_criterion_unreachable, "already:executing");
     (GP.Blocked, GP.Request_complete, "invalid");
     (GP.Blocked, GP.Pause, "invalid");
     (GP.Blocked, GP.Resume, "invalid");
@@ -90,6 +102,10 @@ let matrix =
     (GP.Blocked, GP.Unblock, "move_to:executing");
     (GP.Blocked, GP.Drop, "move_to:dropped");
     (GP.Blocked, GP.Reopen, "invalid");
+    (GP.Blocked, GP.Record_proof_proven, "invalid");
+    (GP.Blocked, GP.Record_proof_refuted, "invalid");
+    (GP.Blocked, GP.Record_criterion_viable, "already:blocked");
+    (GP.Blocked, GP.Record_criterion_unreachable, "already:blocked");
     (GP.Paused, GP.Request_complete, "invalid");
     (GP.Paused, GP.Pause, "already:paused");
     (GP.Paused, GP.Resume, "move_to:executing");
@@ -97,6 +113,21 @@ let matrix =
     (GP.Paused, GP.Unblock, "invalid");
     (GP.Paused, GP.Drop, "move_to:dropped");
     (GP.Paused, GP.Reopen, "invalid");
+    (GP.Paused, GP.Record_proof_proven, "invalid");
+    (GP.Paused, GP.Record_proof_refuted, "invalid");
+    (GP.Paused, GP.Record_criterion_viable, "already:paused");
+    (GP.Paused, GP.Record_criterion_unreachable, "already:paused");
+    (GP.Verifying, GP.Request_complete, "already:verifying");
+    (GP.Verifying, GP.Pause, "invalid");
+    (GP.Verifying, GP.Resume, "invalid");
+    (GP.Verifying, GP.Block, "invalid");
+    (GP.Verifying, GP.Unblock, "invalid");
+    (GP.Verifying, GP.Drop, "invalid");
+    (GP.Verifying, GP.Reopen, "invalid");
+    (GP.Verifying, GP.Record_proof_proven, "move_to:completed");
+    (GP.Verifying, GP.Record_proof_refuted, "move_to:executing");
+    (GP.Verifying, GP.Record_criterion_viable, "already:verifying");
+    (GP.Verifying, GP.Record_criterion_unreachable, "already:verifying");
     (GP.Completed, GP.Request_complete, "already:completed");
     (GP.Completed, GP.Pause, "invalid");
     (GP.Completed, GP.Resume, "invalid");
@@ -104,6 +135,10 @@ let matrix =
     (GP.Completed, GP.Unblock, "invalid");
     (GP.Completed, GP.Drop, "move_to:dropped");
     (GP.Completed, GP.Reopen, "move_to:executing");
+    (GP.Completed, GP.Record_proof_proven, "invalid");
+    (GP.Completed, GP.Record_proof_refuted, "invalid");
+    (GP.Completed, GP.Record_criterion_viable, "invalid");
+    (GP.Completed, GP.Record_criterion_unreachable, "invalid");
     (GP.Dropped, GP.Request_complete, "invalid");
     (GP.Dropped, GP.Pause, "invalid");
     (GP.Dropped, GP.Resume, "invalid");
@@ -111,6 +146,10 @@ let matrix =
     (GP.Dropped, GP.Unblock, "invalid");
     (GP.Dropped, GP.Drop, "already:dropped");
     (GP.Dropped, GP.Reopen, "move_to:executing");
+    (GP.Dropped, GP.Record_proof_proven, "invalid");
+    (GP.Dropped, GP.Record_proof_refuted, "invalid");
+    (GP.Dropped, GP.Record_criterion_viable, "invalid");
+    (GP.Dropped, GP.Record_criterion_unreachable, "invalid");
   ]
 
 let test_matrix_is_total () =

--- a/test/test_goal_scope_terminal_phase.ml
+++ b/test/test_goal_scope_terminal_phase.ml
@@ -153,12 +153,31 @@ let test_surviving_ids_keep_declaration_order () =
         (surviving config [ "goal-first"; "goal-stale"; "goal-second" ]))
 ;;
 
+(* RFC-0387 stage 2: [Verifying] is NOT terminal and deliberately stays in
+   scope — the gate holds the phase while the proof is judged out-of-band, and
+   pruning it here would erase the goal from the keeper's view at exactly the
+   moment the gate took over (stage-2 review P0-1). *)
+let test_a_verifying_goal_stays_in_scope () =
+  let config = make_config () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_config config)
+    (fun () ->
+      put_goal config ~id:"goal-verifying" ~phase:Goal_phase.Verifying;
+      check
+        (list string)
+        "a goal under proof review stays in scope"
+        [ "goal-verifying" ]
+        (surviving config [ "goal-verifying" ]))
+;;
+
 let () =
   run
     "goal_scope_terminal_phase"
     [ ( "validate_active_goal_ids"
       , [ test_case "every terminal phase leaves scope" `Quick
             test_every_terminal_phase_leaves_scope
+        ; test_case "a verifying goal stays in scope" `Quick
+            test_a_verifying_goal_stays_in_scope
         ; test_case "a scope of only completed goals is empty" `Quick
             test_a_scope_of_only_completed_goals_is_empty
         ; test_case "reopening a goal returns it to scope" `Quick

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -320,6 +320,20 @@ let request_complete config goal_id =
          ])
 ;;
 
+(* RFC-0387 stage 2: [request_complete] enters [Verifying]; [Completed] is
+   reached only through the verifier's proof. *)
+let prove_complete config goal_id =
+  Tool_workspace.dispatch
+    (workspace_ctx config)
+    ~name:"masc_goal_transition"
+    ~args:
+      (`Assoc
+         [ "goal_id", `String goal_id
+         ; "action", `String "record_proof_proven"
+         ; "evidence", `String "observed by the test verifier"
+         ])
+;;
+
 let test_goal_completion_accepts_goal_without_tasks () =
   with_workspace
   @@ fun config ->
@@ -331,8 +345,10 @@ let test_goal_completion_accepts_goal_without_tasks () =
     | Ok payload -> payload
     | Error msg -> fail msg
   in
-  check string "completed directly" "completed"
-    (transition_phase (request_complete config goal.id))
+  check string "completion request enters verifying" "verifying"
+    (transition_phase (request_complete config goal.id));
+  check string "proof completes the goal" "completed"
+    (transition_phase (prove_complete config goal.id))
 ;;
 
 let test_goal_completion_ignores_open_task_count () =
@@ -353,8 +369,10 @@ let test_goal_completion_ignores_open_task_count () =
        ~title:"Still open"
        ~priority:3
        ~description:"open");
-  check string "open task does not gate Goal completion" "completed"
-    (transition_phase (request_complete config goal.id))
+  check string "open task does not gate the completion request" "verifying"
+    (transition_phase (request_complete config goal.id));
+  check string "proof completes the goal" "completed"
+    (transition_phase (prove_complete config goal.id))
 ;;
 
 let test_goal_completion_ignores_metric_text () =
@@ -372,8 +390,10 @@ let test_goal_completion_ignores_metric_text () =
     | Ok payload -> payload
     | Error msg -> fail msg
   in
-  check string "metric text does not gate Goal completion" "completed"
-    (transition_phase (request_complete config goal.id))
+  check string "metric text does not gate the completion request" "verifying"
+    (transition_phase (request_complete config goal.id));
+  check string "proof completes the goal" "completed"
+    (transition_phase (prove_complete config goal.id))
 ;;
 let test_goal_block_and_unblock_have_no_operator_hierarchy () =
   with_workspace

--- a/test/test_goal_verification_gate.ml
+++ b/test/test_goal_verification_gate.ml
@@ -1,5 +1,5 @@
-(** RFC-0387 stage 1 — B1 creation requirement + verification ledger
-    (record-only evidence store) + its observability join.
+(** RFC-0387 — B1 creation requirement + verification ledger + the stage-2
+    completion gate.
 
     B1: creation without a declared success condition ([metric] +
     [target_value]) is a typed rejection; updates of an existing row are not
@@ -10,9 +10,15 @@
     that does not decode refuses every mutation AND fails every read loudly —
     never a silent "not verified yet".
 
-    Stage 1 has no lifecycle gate: [request_complete] still completes a Goal
-    directly, and no caller writes the ledger. The gate phases/actions and
-    the verifier caller are stage 2 (RFC-0387 §Staging). *)
+    Stage 2 gate (this PR): [request_complete] moves Executing -> Verifying
+    and persists the durable proof request BEFORE the phase write; only
+    [record_proof_proven] (non-blank evidence mandatory) reaches Completed;
+    [record_proof_refuted] returns the goal to Executing with the refutation
+    preserved. A repeated [request_complete] on Verifying answers [Already]
+    and re-arms the proof request when the ledger lost it (the P0-2 wedge).
+    [record_criterion_*] verdicts are phase-neutral ledger commits, and a
+    [Criterion_unreachable] verdict blocks [request_complete] with a typed
+    conflict. The FSM is the only transition decider; the ledger records. *)
 
 open Alcotest
 open Masc
@@ -391,8 +397,9 @@ let test_goal_list_joins_the_ledger () =
   let goals = Yojson.Safe.Util.member "goals" listed |> Yojson.Safe.Util.to_list in
   (match goals with
    | [ goal_json ] ->
-     (* No writer has run: the explicit pre-verification default renders. *)
-     check string "criterion renders unchecked" "unchecked"
+     (* The creation hook ran (stage 2): the durable criterion check request
+        renders, not the pre-verification default. *)
+     check string "criterion renders pending" "pending"
        (json_state goal_json [ "verification"; "criterion"; "state" ]);
      check string "completion renders idle" "idle"
        (json_state goal_json [ "verification"; "completion"; "state" ])
@@ -441,9 +448,255 @@ let test_goal_list_renders_a_ledger_error_state () =
   | _ -> fail "expected one listed goal"
 ;;
 
-(* Stage 1 changes no lifecycle semantics: request_complete still completes. *)
+(* {1 Stage 2 — the completion gate (RFC-0387 §3.2/§3.3/§4/§5)} *)
 
-let test_request_complete_still_completes_directly () =
+let create_goal ctx title =
+  let created =
+    must_succeed
+      "create goal"
+      (dispatch
+         ctx
+         ~name:"masc_goal_upsert"
+         [ "title", `String title
+         ; "metric", `String "m"
+         ; "target_value", `String "1"
+         ])
+  in
+  json_state created [ "goal_id" ]
+;;
+
+let transition ctx goal_id ?note ?evidence action =
+  let args =
+    [ "goal_id", `String goal_id; "action", `String action ]
+    @ (match note with
+       | Some note -> [ "note", `String note ]
+       | None -> [])
+    @ (match evidence with
+       | Some evidence -> [ "evidence", `String evidence ]
+       | None -> [])
+  in
+  dispatch ctx ~name:"masc_goal_transition" args
+;;
+
+let stored_phase config goal_id =
+  match Goal_store.get_goal config ~goal_id with
+  | Some goal -> Goal_phase.to_string goal.Goal_store.phase
+  | None -> fail ("goal not found: " ^ goal_id)
+;;
+
+let ledger_record config goal_id =
+  match Goal_verification.get_record config ~goal_id with
+  | Ok (Some record) -> record
+  | Ok None -> fail ("no ledger row for " ^ goal_id)
+  | Error msg -> fail msg
+;;
+
+let goal_events_text config =
+  let path =
+    Filename.concat
+      (Filename.dirname (Goal_verification.verifications_path config))
+      "goal_events.jsonl"
+  in
+  if Sys.file_exists path
+  then (
+    let ic = open_in_bin path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () ->
+         let b = Buffer.create 256 in
+         (try
+            while true do
+              Buffer.add_string b (input_line ic);
+              Buffer.add_char b '\n'
+            done
+          with
+          | End_of_file -> ());
+         Buffer.contents b))
+  else ""
+;;
+
+(* (a) The completion request enters the gate; the durable proof request is
+   visible in the response and in the ledger. *)
+let test_request_complete_enters_verifying_with_proof_pending () =
+  with_workspace
+  @@ fun config ->
+  let ctx = workspace_ctx config in
+  let goal_id = create_goal ctx "Gated completion" in
+  let entered =
+    must_succeed "request_complete" (transition ctx goal_id "request_complete")
+  in
+  check string "phase moved to verifying" "verifying"
+    (json_state entered [ "goal"; "phase" ]);
+  check string "the request is persisted before the phase" "proof_pending"
+    (json_state entered [ "verification"; "completion"; "state" ]);
+  check string "the store agrees" "verifying" (stored_phase config goal_id);
+  (match (ledger_record config goal_id).completion with
+   | Goal_verification.Proof_pending _ -> ()
+   | _ -> fail "ledger must hold the durable proof request")
+;;
+
+(* (b) Only the verifier's proven proof completes the goal, with mandatory
+   evidence; the verdict carries the typed authority. *)
+let test_proof_proven_completes_with_authority_and_evidence () =
+  with_workspace
+  @@ fun config ->
+  let ctx = workspace_ctx config in
+  let goal_id = create_goal ctx "Proof-gated goal" in
+  ignore (must_succeed "request_complete" (transition ctx goal_id "request_complete"));
+  (* Evidence is mandatory: absent and blank are the same validation error. *)
+  let missing =
+    must_fail "record_proof_proven without evidence"
+      (transition ctx goal_id "record_proof_proven")
+  in
+  check string "typed validation error" "validation_error"
+    (json_state missing [ "error_code" ]);
+  let blank =
+    must_fail "record_proof_proven with blank evidence"
+      (transition ctx goal_id ~evidence:"   " "record_proof_proven")
+  in
+  check string "typed validation error" "validation_error"
+    (json_state blank [ "error_code" ]);
+  check string "a refused verdict does not move the phase" "verifying"
+    (stored_phase config goal_id);
+  let completed =
+    must_succeed "record_proof_proven"
+      (transition
+         ctx
+         goal_id
+         ~evidence:"metric observed at target"
+         "record_proof_proven")
+  in
+  check string "completed via proof" "completed"
+    (json_state completed [ "goal"; "phase" ]);
+  check string "ledger shows the proven verdict" "proof_proven"
+    (json_state completed [ "verification"; "completion"; "state" ]);
+  check string "the evidence is on the verdict" "metric observed at target"
+    (json_state completed [ "verification"; "completion"; "verdict"; "evidence" ]);
+  check string "the caller session is the typed authority" "planner"
+    (json_state
+       completed
+       [ "verification"; "completion"; "verdict"; "authority"; "actor" ]);
+  check string "authority kind is the system-llm slot" "system_llm_agent"
+    (json_state
+       completed
+       [ "verification"; "completion"; "verdict"; "authority"; "kind" ])
+;;
+
+(* (c) A refuted proof returns the goal to Executing; the reason survives in
+   the ledger and in goal_events.jsonl. *)
+let test_proof_refuted_returns_to_executing_with_reason () =
+  with_workspace
+  @@ fun config ->
+  let ctx = workspace_ctx config in
+  let goal_id = create_goal ctx "Refutable goal" in
+  ignore (must_succeed "request_complete" (transition ctx goal_id "request_complete"));
+  let refuted =
+    must_succeed "record_proof_refuted"
+      (transition
+         ctx
+         goal_id
+         ~evidence:"coverage run attached"
+         ~note:"metric moved under the claim"
+         "record_proof_refuted")
+  in
+  check string "back to executing" "executing"
+    (json_state refuted [ "goal"; "phase" ]);
+  (match (ledger_record config goal_id).completion with
+   | Goal_verification.Proof_refuted
+       { outcome = Goal_verification.Refuted { reason }; _ } ->
+     check string "the refutation reason is preserved"
+       "metric moved under the claim" reason
+   | _ -> fail "ledger must hold the refuted verdict");
+  let events = goal_events_text config in
+  check bool "the refutation reason reaches goal_events.jsonl" true
+    (String_util.contains_substring events "metric moved under the claim");
+  check bool "the event names the outcome" true
+    (String_util.contains_substring events "refuted");
+  (* Failure keeps its evidence but does not wedge the goal: the next request
+     supersedes the refuted verdict and re-enters the gate. *)
+  let reentered =
+    must_succeed "request_complete again"
+      (transition ctx goal_id "request_complete")
+  in
+  check string "re-request re-enters verifying" "verifying"
+    (json_state reentered [ "goal"; "phase" ]);
+  check string "a fresh proof request supersedes the refutation"
+    "proof_pending"
+    (json_state reentered [ "verification"; "completion"; "state" ])
+;;
+
+(* (d) The P0-2 wedge — phase=Verifying with the ledger at Completion_idle —
+   is re-armed by the repeated request_complete: the FSM answers [Already]
+   and the handler re-writes the durable request before answering. *)
+let test_verifying_repeat_rearms_a_missing_proof_request () =
+  with_workspace
+  @@ fun config ->
+  let ctx = workspace_ctx config in
+  let goal_id = create_goal ctx "Wedged goal" in
+  (* Simulate the crash window: the phase is Verifying but the ledger never
+     recorded the proof request. *)
+  (match
+     Goal_store.upsert_goal config ~id:goal_id ~phase:Goal_phase.Verifying ()
+   with
+   | Ok _ -> ()
+   | Error msg -> fail msg);
+  (match (ledger_record config goal_id).completion with
+   | Goal_verification.Completion_idle -> ()
+   | _ -> fail "test setup: the wedge needs an idle ledger");
+  let answered =
+    must_succeed "repeated request_complete"
+      (transition ctx goal_id "request_complete")
+  in
+  check string "answered as Already (noop)" "true"
+    (json_state answered [ "noop" ]);
+  check string "still verifying" "verifying" (json_state answered [ "phase" ]);
+  check string "the proof request is re-armed" "proof_pending"
+    (json_state answered [ "verification"; "completion"; "state" ]);
+  (match (ledger_record config goal_id).completion with
+   | Goal_verification.Proof_pending _ -> ()
+   | _ -> fail "the re-arm must be durable, not just reported");
+  (* And the gate drains from there. *)
+  let completed =
+    must_succeed "record_proof_proven"
+      (transition ctx goal_id ~evidence:"verified after re-arm"
+         "record_proof_proven")
+  in
+  check string "the re-armed gate completes" "completed"
+    (json_state completed [ "goal"; "phase" ])
+;;
+
+(* (e) A criterion judged unreachable blocks the completion request with a
+   typed conflict; the criterion commit itself is phase-neutral. *)
+let test_unreachable_criterion_blocks_request_complete () =
+  with_workspace
+  @@ fun config ->
+  let ctx = workspace_ctx config in
+  let goal_id = create_goal ctx "Impossible goal" in
+  let committed =
+    must_succeed "record_criterion_unreachable"
+      (transition
+         ctx
+         goal_id
+         ~evidence:"the named API does not exist"
+         ~note:"no such API exists"
+         "record_criterion_unreachable")
+  in
+  check string "phase-neutral: still executing" "executing"
+    (json_state committed [ "phase" ]);
+  check string "the verdict is on the ledger" "unreachable"
+    (json_state committed [ "verification"; "criterion"; "state" ]);
+  let refused =
+    must_fail "request_complete against an unreachable criterion"
+      (transition ctx goal_id "request_complete")
+  in
+  check string "typed conflict" "conflict"
+    (json_state refused [ "error_code" ]);
+  check string "the phase did not move" "executing"
+    (stored_phase config goal_id)
+;;
+
+(* (f) Creation records the durable criterion-check request (B2 hook). *)
+let test_creation_writes_criterion_pending () =
   with_workspace
   @@ fun config ->
   let ctx = workspace_ctx config in
@@ -453,23 +706,88 @@ let test_request_complete_still_completes_directly () =
       (dispatch
          ctx
          ~name:"masc_goal_upsert"
-         [ "title", `String "Ungated completion"
+         [ "title", `String "Checked goal"
          ; "metric", `String "m"
          ; "target_value", `String "1"
          ])
   in
+  check string "the hook is reported in the response" "criterion_pending"
+    (json_state created [ "criterion_check" ]);
   let goal_id = json_state created [ "goal_id" ] in
-  let completed =
-    must_succeed
-      "request_complete"
-      (dispatch
-         ctx
-         ~name:"masc_goal_transition"
-         [ "goal_id", `String goal_id; "action", `String "request_complete" ])
+  match (ledger_record config goal_id).criterion with
+  | Goal_verification.Criterion_pending _ -> ()
+  | _ -> fail "creation must record the durable criterion request"
+;;
+
+(* (g) A keeper holding a Verifying goal keeps seeing it: the runtime-contract
+   cross-check keeps it, the world observation keeps it, and the prompt names
+   it with the proof-pending annotation (P0-1). *)
+let test_keeper_keeps_and_sees_a_verifying_goal () =
+  with_workspace
+  @@ fun config ->
+  let ctx = workspace_ctx config in
+  let goal_id = create_goal ctx "Goal under proof" in
+  ignore (must_succeed "request_complete" (transition ctx goal_id "request_complete"));
+  let meta =
+    match
+      Masc_test_deps.meta_of_json_fixture
+        (`Assoc
+           [ "name", `String "gate-keeper"
+           ; "trace_id", `String "gate-keeper-trace"
+           ; "active_goal_ids", `List [ `String goal_id ]
+           ])
+    with
+    | Ok meta -> meta
+    | Error e -> fail ("meta_of_json_fixture: " ^ e)
   in
-  check string "completed directly (stage 1 keeps main's lifecycle)"
-    "completed"
-    (json_state completed [ "goal"; "phase" ])
+  check
+    (list string)
+    "the cross-check keeps the verifying goal"
+    [ goal_id ]
+    (Keeper_runtime_contract.validate_active_goal_ids ~config ~meta ());
+  let observation =
+    Keeper_world_observation.observe ~pending_board_events:(Some []) ~config ~meta
+  in
+  check
+    (list string)
+    "the world observation keeps the verifying goal"
+    [ goal_id ]
+    observation.Keeper_world_observation.active_goals;
+  let summaries = Keeper_unified_prompt.active_goal_summaries ~config ~meta in
+  let { Keeper_unified_prompt.world_state; _ } =
+    Keeper_unified_prompt.build_prompt
+      ~meta
+      ~config
+      ~turn_decision:(Keeper_world_observation.keeper_cycle_decision ~meta observation)
+      ~current_task:Keeper_world_observation_inputs.No_current_task
+      ~active_goal_summaries:summaries
+      ~observation
+      ()
+  in
+  check bool "the Active Goals block names the goal" true
+    (String_util.contains_substring world_state goal_id);
+  check bool "with the proof-pending annotation" true
+    (String_util.contains_substring world_state "증명 대기 중")
+;;
+
+(* (h) A corrupt ledger during request_complete is a typed error, never a
+   silent pass — and the phase does not move. *)
+let test_corrupt_ledger_fails_request_complete_loudly () =
+  with_workspace
+  @@ fun config ->
+  let ctx = workspace_ctx config in
+  let goal_id = create_goal ctx "Goal beside a poisoned ledger" in
+  poison_ledger config;
+  let refused =
+    must_fail "request_complete over a corrupt ledger"
+      (transition ctx goal_id "request_complete")
+  in
+  check bool "the decode failure is named" true
+    (String_util.contains_substring
+       (Yojson.Safe.to_string refused)
+       "did not decode");
+  check string "the phase did not move" "executing"
+    (stored_phase config goal_id)
 ;;
 
 let () =
@@ -509,9 +827,23 @@ let () =
         ; test_case "goal list renders a ledger-error state" `Quick
             test_goal_list_renders_a_ledger_error_state
         ] )
-    ; ( "lifecycle unchanged"
-      , [ test_case "request_complete still completes directly" `Quick
-            test_request_complete_still_completes_directly
+    ; ( "stage 2 gate"
+      , [ test_case "request_complete enters verifying with proof pending" `Quick
+            test_request_complete_enters_verifying_with_proof_pending
+        ; test_case "proof proven completes with authority and evidence" `Quick
+            test_proof_proven_completes_with_authority_and_evidence
+        ; test_case "proof refuted returns to executing with reason" `Quick
+            test_proof_refuted_returns_to_executing_with_reason
+        ; test_case "verifying repeat re-arms a missing proof request" `Quick
+            test_verifying_repeat_rearms_a_missing_proof_request
+        ; test_case "unreachable criterion blocks request_complete" `Quick
+            test_unreachable_criterion_blocks_request_complete
+        ; test_case "creation writes criterion pending" `Quick
+            test_creation_writes_criterion_pending
+        ; test_case "keeper keeps and sees a verifying goal" `Quick
+            test_keeper_keeps_and_sees_a_verifying_goal
+        ; test_case "corrupt ledger fails request_complete loudly" `Quick
+            test_corrupt_ledger_fails_request_complete_loudly
         ] )
     ]
 ;;

--- a/test/test_goal_verification_gate.ml
+++ b/test/test_goal_verification_gate.ml
@@ -90,6 +90,13 @@ let json_state json path =
   |> Yojson.Safe.Util.to_string
 ;;
 
+let json_bool json path =
+  List.fold_left
+    (fun acc key -> Yojson.Safe.Util.member key acc)
+    json path
+  |> Yojson.Safe.Util.to_bool
+;;
+
 let verdict ?(evidence = "observed by the verifier") outcome : Goal_verification.verdict =
   { Goal_verification.outcome
   ; authority = Masc_domain.System_llm_agent { agent_run_id = "test-verifier" }
@@ -647,8 +654,8 @@ let test_verifying_repeat_rearms_a_missing_proof_request () =
     must_succeed "repeated request_complete"
       (transition ctx goal_id "request_complete")
   in
-  check string "answered as Already (noop)" "true"
-    (json_state answered [ "noop" ]);
+  check bool "answered as Already (noop)" true
+    (json_bool answered [ "noop" ]);
   check string "still verifying" "verifying" (json_state answered [ "phase" ]);
   check string "the proof request is re-armed" "proof_pending"
     (json_state answered [ "verification"; "completion"; "state" ]);

--- a/test/test_keeper_goal_phase_projection.ml
+++ b/test/test_keeper_goal_phase_projection.ml
@@ -57,13 +57,16 @@ let goal_in phase id title =
 ;;
 
 (* One goal per phase, so a future phase added to [Goal_phase.t] shows up here
-   as an unclassified id rather than silently inheriting a neighbour's verdict. *)
+   as an unclassified id rather than silently inheriting a neighbour's verdict.
+   [Verifying] (RFC-0387 stage 2) admits self-directed progress — the gate
+   holds the phase, not the work — so it survives alongside Executing. *)
 let seed_all_phases config =
   Goal_store.write_state config
     { version = 1
     ; updated_at = Masc_domain.now_iso ()
     ; goals =
         [ goal_in Goal_phase.Executing "goal-executing" "still work"
+        ; goal_in Goal_phase.Verifying "goal-verifying" "proof pending"
         ; goal_in Goal_phase.Blocked "goal-blocked" "waiting on someone"
         ; goal_in Goal_phase.Paused "goal-paused" "set aside"
         ; goal_in Goal_phase.Completed "goal-completed" "already achieved"
@@ -87,6 +90,7 @@ let meta_with_goals ids =
 
 let all_ids =
   [ "goal-executing"
+  ; "goal-verifying"
   ; "goal-blocked"
   ; "goal-paused"
   ; "goal-completed"
@@ -94,16 +98,33 @@ let all_ids =
   ]
 ;;
 
+let summary_ids summaries =
+  List.map
+    (fun (s : Keeper_unified_prompt.goal_summary) -> s.summary_goal_id)
+    summaries
+;;
+
+let summary_title_opt goal_id summaries =
+  match
+    List.find_opt
+      (fun (s : Keeper_unified_prompt.goal_summary) ->
+        String.equal s.summary_goal_id goal_id)
+      summaries
+  with
+  | Some s -> Some s.summary_title
+  | None -> None
+;;
+
 let test_system_prompt_surface_drops_terminal_goals () =
   with_workspace @@ fun config ->
   seed_all_phases config;
   let meta = meta_with_goals all_ids in
   let summaries = Keeper_unified_prompt.active_goal_summaries ~config ~meta in
-  let ids = List.map fst summaries in
-  check (list string) "only a progressable goal is offered" [ "goal-executing" ]
-    ids;
+  check (list string) "only progressable goals are offered"
+    [ "goal-executing"; "goal-verifying" ]
+    (summary_ids summaries);
   check (option string) "its title still resolves" (Some "still work")
-    (List.assoc_opt "goal-executing" summaries)
+    (summary_title_opt "goal-executing" summaries)
 ;;
 
 let test_world_observation_drops_terminal_goals () =
@@ -115,7 +136,8 @@ let test_world_observation_drops_terminal_goals () =
       ~meta
   in
   check (list string) "the per-turn frame agrees with the system prompt"
-    [ "goal-executing" ] observation.Keeper_world_observation.active_goals
+    [ "goal-executing"; "goal-verifying" ]
+    observation.Keeper_world_observation.active_goals
 ;;
 
 let test_unresolved_goal_id_stays_visible () =
@@ -127,9 +149,9 @@ let test_unresolved_goal_id_stays_visible () =
   let meta = meta_with_goals [ "goal-completed"; "goal-vanished" ] in
   let summaries = Keeper_unified_prompt.active_goal_summaries ~config ~meta in
   check (list string) "the terminal goal goes, the unknown id stays"
-    [ "goal-vanished" ] (List.map fst summaries);
+    [ "goal-vanished" ] (summary_ids summaries);
   check (option string) "unknown id renders with no title" (Some "")
-    (List.assoc_opt "goal-vanished" summaries)
+    (summary_title_opt "goal-vanished" summaries)
 ;;
 
 let test_no_goals_surface_when_all_are_terminal () =
@@ -137,7 +159,7 @@ let test_no_goals_surface_when_all_are_terminal () =
   seed_all_phases config;
   let meta = meta_with_goals [ "goal-completed"; "goal-dropped" ] in
   check (list string) "no goal block rather than an empty-looking one" []
-    (List.map fst (Keeper_unified_prompt.active_goal_summaries ~config ~meta));
+    (summary_ids (Keeper_unified_prompt.active_goal_summaries ~config ~meta));
   let observation =
     Keeper_world_observation.observe ~pending_board_events:(Some []) ~config
       ~meta

--- a/test/test_keeper_wake_turn_context.ml
+++ b/test/test_keeper_wake_turn_context.ml
@@ -574,7 +574,12 @@ let test_goal_summaries_render_titles () =
   let observation = { base_observation with active_goals = [ "goal-x" ] } in
   let with_titles =
     user_message
-      ~active_goal_summaries:[ ("goal-x", "Improve wake context") ]
+      ~active_goal_summaries:
+        [ { Prompt.summary_goal_id = "goal-x"
+          ; summary_title = "Improve wake context"
+          ; summary_phase = None
+          }
+        ]
       observation
   in
   check bool "id and title" true
@@ -590,7 +595,12 @@ let test_partial_goal_summaries_preserve_missing_ids () =
   in
   let user =
     user_message
-      ~active_goal_summaries:[ ("goal-a", "Improve wake context") ]
+      ~active_goal_summaries:
+        [ { Prompt.summary_goal_id = "goal-a"
+          ; summary_title = "Improve wake context"
+          ; summary_phase = None
+          }
+        ]
       observation
   in
   check bool "header keeps full active-goal count" true


### PR DESCRIPTION
## RFC-0387 stage 2 PR-1: the completion gate

`request_complete` no longer completes a Goal directly. The Goal FSM gains a `Verifying` phase and four gate actions; the ledger gains its durable-request writers; the keeper keeps seeing a gated goal.

### What changes

- **`Goal_phase`** (`lib/goal/goal_phase.ml`): new `Verifying` phase between `Executing` and `Completed`; new actions `record_proof_proven` / `record_proof_refuted` / `record_criterion_viable` / `record_criterion_unreachable`. `decide_transition` is now a fully explicit 6x11 matrix with no catch-all.
- **Gate semantics** (`lib/workspace_goals.ml`): `request_complete` moves `executing -> verifying` and persists the durable proof request (`Goal_verification.mark_proof_pending`) **before** the phase write — a failed ledger write vetoes the move (persist-before-model-call). Only `record_proof_proven` (non-blank `evidence` mandatory at the tool boundary) reaches `completed`; `record_proof_refuted` returns the goal to `executing` with the reason preserved in the ledger and `goal_events.jsonl`. `record_criterion_*` verdicts are phase-neutral ledger commits; a `Criterion_unreachable` verdict blocks `request_complete` with a typed `conflict`. Goal creation writes the durable criterion-check request (B2 hook, reported as `criterion_check`).
- **Ledger writers** (`lib/goal/goal_verification.ml`): `mark_criterion_pending` (creation hook) and `mark_proof_pending` (idempotent re-arm; supersedes a standing `Proof_refuted`, never overwrites a committed proof).
- **Keeper visibility** (`lib/keeper/keeper_unified_prompt.ml`): `admits_self_directed_progress` admits `Verifying`; `active_goal_summaries` carries the stored phase (new `goal_summary` record) so the Active Goals layer annotates a gated goal (`[증명 대기 중 …]`) instead of dropping it or letting it read as ordinary open work. `executing_goals_without_tasks` stays `Executing`-only so the no-task nudge cannot race the gate.
- **Schema** (`lib/tool_schemas/tool_schemas_workspace_extra.ml`): `masc_goal_transition` description documents the gate; new optional `evidence` property (required non-blank for the four `record_*` actions).

### Review defects closed

- **P0-1 (keeper visibility)**: a `Verifying` goal survives the runtime-contract cross-check, the world observation, and the prompt — with a proof-pending annotation. Pinned by `test_keeper_keeps_and_sees_a_verifying_goal` and the updated `test_keeper_goal_phase_projection` / `test_goal_scope_terminal_phase` suites.
- **P0-2 (single-authority FSM + re-arm)**: `decide_transition` is the only transition decider (explicit 66-pair matrix, no catch-all); the ledger records, never judges. A repeated `request_complete` on `Verifying` answers `Already` and **re-arms** `mark_proof_pending` when the ledger lost the durable request (the phase=Verifying + ledger=idle wedge) — pinned by `test_verifying_repeat_rearms_a_missing_proof_request`.

### Tests

- `test_goal_phase_all`: all 66 (phase, action) pairs stated as literals.
- `test_goal_verification_gate`: 8 new stage-2 feature tests — enter-gate + proof pending, proven-completes (authority/evidence/blank-evidence validation), refuted-returns (reason in ledger + goal_events, re-request supersedes), wedge re-arm, unreachable-criterion conflict, creation criterion hook, keeper visibility, corrupt-ledger typed error.
- `test_goal_tools`: completion tests updated to the gated flow (`request_complete` -> `verifying`, `record_proof_proven` -> `completed`).

### Ratchets

- `scripts/ci/check-enum-string-safety.sh`: **PASS**.
- `scripts/ci/check-telemetry-coverage.sh`: **PASS**.
- `scripts/audit-dead-surface.py --exports --ratchet`: reports 541 vs baseline 539, but the +2 is **pre-existing main drift** — the stashed tree (without this PR) reports the identical 541 set. This PR adds zero dead exports; the baseline bump belongs to the drift-repair PRs (#29196/#29201/#29203), not here.

### Not in this PR

Stage 2 PR-2 (the verifier caller) follows; until then the gate is manually operable via `masc_goal_transition` with `evidence`. PR-3 covers dashboard TS rendering of `verifying`. Compile and tests are verified by CI, not locally.
