### PR TITLE
docs(rfc): RFC-0385 Draft → Active

### DIFF
--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -231,7 +231,7 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0382 | 런타임별 KV/prompt cache 재사용과 reasoning 연속성 | Draft | - |
 | 0383 | 웹 아티팩트는 쌓이기만 한다 — 오프로드 파일을 재질의 가능한 코퍼스로 | Draft | - |
 | 0384 | In-process Telegram connector (long polling) | Proposed | - |
-| 0385 | 자율턴은 대화가 아니다 | Draft | - |
+| 0385 | 자율턴은 대화가 아니다 | Active | - |
 | 0386 | 툴 종류(tool kind)는 닫힌 합타입으로 선언한다 | Draft | - |
 | 0387 | Goal verifier 게이트 — 성공조건 필수화, 생성 시 실재성 검증, 완료의 2단계 증명 | Draft | - |
 | RFC-async-log-sink-durable-append-offload | Offload the structured-log durable append off the emitting fiber | Draft | - |

--- a/docs/rfc/RFC-0385-autonomous-turn-is-not-conversation.md
+++ b/docs/rfc/RFC-0385-autonomous-turn-is-not-conversation.md
@@ -1,10 +1,12 @@
 ---
 title: 자율턴은 대화가 아니다
 rfc: "0385"
-status: Draft
+status: Active
 created: 2026-08-19
+updated: 2026-08-20
 author: vincent
 related: ["0376", "0315"]
+implementation_prs: [29176]
 ---
 
 # RFC-0385 — 자율턴은 대화가 아니다


### PR DESCRIPTION
## 무엇을

RFC-0385 frontmatter 의 `status` 를 `Draft` → `Active` 로 올리고 `implementation_prs: [29176]` 을 기록한다. 생성 인덱스를 같은 커밋에서 재생성했다.

## 왜 Active 인가

`docs/rfc/README.md` §Status 기준:

- `Active` — spec 머지 완료, 구현이 진행 중. 일부 Phase 가 main 에 들어갔으나 전체 closeout 미완.
- `Implemented` — 모든 Phase 머지 완료 + closeout commit 또는 *Implementation summary* 필요.

§5.1 은 #29176 로 main 에 들어갔고 프로덕션에서 동작을 확인했다. 반면 §7(지침 이행 문구)과 §9 의 후속 3건은 열려 있다. 그래서 `Implemented` 가 아니라 `Active` 다.

## 동작 확인 (재배포 후 실측)

배포 SHA `cf13f22c99`, keeper `sangsu` 자율턴 4건(30055~30058) 관측:

| 체크포인트 지표 | 배포 직후 | 4턴 후 |
|---|---|---|
| `scheduled autonomous keepalive` 텍스트 | 1,019 | **1,019** |
| `무응답` 텍스트 | 6,079 | **6,079** |
| 전체 messages | 16,468 | 16,479 |

네 턴 모두 keepalive 독백을 생산했는데 체크포인트에는 0건 들어갔다. 늘어난 11개는 전부 tool_use/tool_result 쌍이며, 그중 한 턴은 `masc_board_list(if_revision)` 을 실제로 실행했다. 말한 것은 replay 에 들어가지 않고, 한 것은 남는다 — §5.2 의 계약 그대로다.

## 열린 항목

- §7 은 재검토가 필요하다. §2.6 실측에서 지침 변경만으로는 비율이 움직이지 않았으므로(65.5% → 67%), 지침 문구 작업의 값이 불분명하다.
- §9 의 세 건(외부 채널 라벨 공유, discord 비멘션 라우팅, `is_noop_cycle` 빈 문자열 판정)은 각각 독립 작업이다.
- 대조군 `lane-smith`(지침 유지) 검증은 baseline 만 고정한 상태다.

## 검증

```
python3 scripts/rfc-generate-index.py --check   # exit 0
python3 scripts/rfc_enforcer.py --check ...      # exit 0
```

인덱스 행: `| 0385 | 자율턴은 대화가 아니다 | Active | - |`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015YwBrqpAAUQEeGTB6yzuiB
