### PR TITLE
fix(test): main 이 깨진 원인 — 레인 기대값에 없어진 cross-a 가 남아 있었음

### DIFF
--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -1868,11 +1868,15 @@ let test_keeper_dispatch_runtime_graph_enumeration () =
     (list string)
     "routed lane candidates, special routes, verifier_exact slots, and media \
      failover are deduplicated without admitting a dormant lane"
+    (* cross-a is absent on purpose. [cross-e] used to be a routed root via the
+       [runtime].cross_verifier key; #29197 purged that key, so nothing names
+       [cross-e] any more and it is dormant exactly like [dormant-lane]. A
+       dormant lane's candidates must not enter the dispatch set — which is what
+       this case is named for. *)
     [ "lane-a"
     ; "lane-b"
     ; "assigned-b"
     ; "media-c"
-    ; "cross-a"
     ; "verifier-a"
     ]
     actual


### PR DESCRIPTION
## 증상

`origin/main` 에서 `@test/runtest-test_runtime_config_validity` 가 실패한다.

```
Expected: ["lane-a"; "lane-b"; "assigned-b"; "media-c"; "cross-a"; "verifier-a"]
Received: ["lane-a"; "lane-b"; "assigned-b"; "media-c"; "verifier-a"]
```

브랜치 특유의 문제가 아니다. 순수 `origin/main` 을 체크아웃해 재현했다.

```
origin/main        1 failure! in 0.357s. 78 tests run.
이 PR 적용 후      Test Successful in 0.352s. 78 tests run.
```

## Received 가 맞다

테스트 데이터는 이렇다.

```ocaml
[ Runtime_lane.make ~id:"default-a"    [ "lane-a"; "lane-b" ]
; Runtime_lane.make ~id:"dormant-lane" [ "lane-c"; "lane-b" ]
; Runtime_lane.make ~id:"cross-e"      [ "cross-a"; "lane-b" ]
]
```

호출부에는 `cross-e` 를 routed root 로 지목하는 인자가 없다. 예전에는 `[runtime].cross_verifier` 키가 그 역할을 했고, #29197 이 그 키를 숙청했다. 이제 아무도 `cross-e` 를 가리키지 않으므로 `dormant-lane` 과 똑같이 dormant 다.

이 케이스의 이름이 "deduplicated **without admitting a dormant lane**" 이다. dormant lane 의 후보가 dispatch 집합에 들어가지 않는 것이 바로 이 테스트가 지키려는 성질이므로, `cross-a` 가 빠진 결과가 정확하다. 기대값이 숙청 이전 상태로 남아 있었을 뿐이다.

## 왜 #29200 이 못 잡았나

#29200 은 같은 숙청을 수리했지만 **타입 수준만** 손봤다. 테스트 파일 변경은 7 개 match arm 의 튜플 arity 를 6 → 5 로 줄인 것이 전부다.

```
-    | Ok (runtimes, _, _, _, _, _) ->
+    | Ok (runtimes, _, _, _, _) ->
```

제목 그대로 "main does not compile" 을 해소한 커밋이라, 동작이 바뀐 기대값은 검토 범위에 없었다.

## 영향

이 게이트는 `Build and Test` 안에서 돌고, main 을 병합하는 열린 PR 을 전부 막는다 (#29192, #29203, #29208). 세 PR 모두 각자의 변경과 무관하게 여기서 실패한다.
