### PR TITLE
fix(health): stop a deliberately paused keeper from demanding operator action

### DIFF
--- a/lib/server/server_routes_http_runtime_health_fleet.ml
+++ b/lib/server/server_routes_http_runtime_health_fleet.ml
@@ -249,11 +249,28 @@ let keeper_event_queue_health_dimensions ~stale_after_sec = function
     let shutdown_fenced_backlog_count =
       queue_assoc_int "shutdown_fenced_backlog_count" fields
     in
+    (* Only part of the non-runnable backlog is something an operator can act
+       on.  [recoverable] clears once the owner fiber is restored and
+       [shutdown_fenced] clears once the shutdown completes, so both warrant a
+       prompt.  [retained_disabled] and [paused_dead] are the operator's own
+       standing decision -- a keeper deliberately paused, or autoboot /
+       proactive turned off.  Counting those as actionable pinned
+       [operator_action_required] to true for as long as the decision held, so
+       one deliberately paused keeper produced a permanent alarm that buried
+       the ones that do need an answer.  Both counts still travel in
+       [status_reasons], so the backlog stays visible without demanding
+       action. *)
+    let actionable_backlog_count =
+      recoverable_backlog_count + shutdown_fenced_backlog_count
+    in
+    (* [backlog_clean] answers a different question than [work_action_required]:
+       it reports whether the queue holds anything at all, so an operator-paused
+       entry does count against it. Keep the total separate from the actionable
+       subset. *)
     let non_runnable_backlog_count =
-      recoverable_backlog_count
+      actionable_backlog_count
       + retained_disabled_backlog_count
       + paused_dead_backlog_count
-      + shutdown_fenced_backlog_count
     in
     let runnable_oldest_age_seconds =
       queue_assoc_float_opt "runnable_oldest_age_seconds" fields
@@ -281,7 +298,7 @@ let keeper_event_queue_health_dimensions ~stale_after_sec = function
       then "degraded", "stalled"
       else if runnable_backlog_count > 0
       then "warning", "backlogged"
-      else if non_runnable_backlog_count > 0
+      else if actionable_backlog_count > 0
       then "warning", "blocked"
       else "ok", "idle"
     in
@@ -289,7 +306,7 @@ let keeper_event_queue_health_dimensions ~stale_after_sec = function
       queue_assoc_bool "operator_action_required" ~default:false fields
     in
     let work_action_required =
-      backlog_stale || non_runnable_backlog_count > 0
+      backlog_stale || actionable_backlog_count > 0
     in
     let operator_action_required =
       source_action_required || storage_degraded || work_action_required

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -82,6 +82,7 @@ paused_targets=(
   @test/runtest-test_keeper_paused_work_transfer_transaction
   @test/runtest-test_keeper_paused_work_source_terminal_transaction
   @test/runtest-test_keeper_paused_work_operator
+  @test/runtest-test_keeper_event_queue_health_actionable
 )
 
 normal_targets=(

--- a/test/dune
+++ b/test/dune
@@ -147,6 +147,7 @@
   test_sse_qw
   test_sse_stream
   test_health
+  test_keeper_event_queue_health_actionable
   test_keeper_hooks_agent_core_log_shape
   test_keeper_tool_duration_buckets
   test_keeper_catchup_digest
@@ -452,6 +453,7 @@
   test_sse_qw
   test_sse_stream
   test_health
+  test_keeper_event_queue_health_actionable
   test_keeper_hooks_agent_core_log_shape
   test_keeper_tool_duration_buckets
   test_keeper_catchup_digest

--- a/test/test_keeper_event_queue_health_actionable.ml
+++ b/test/test_keeper_event_queue_health_actionable.ml
@@ -1,0 +1,105 @@
+(** A deliberately paused keeper must not pin operator_action_required.
+
+    [keeper_event_queue_health_dimensions] splits the non-runnable backlog by
+    whether an operator can act on it.  [recoverable] and [shutdown_fenced]
+    clear on their own once the owner is restored or the shutdown finishes, so
+    they warrant a prompt.  [paused_dead] and [retained_disabled] encode a
+    decision the operator already made, so they must stay visible in
+    [status_reasons] without demanding action -- otherwise one paused keeper
+    raises a permanent alarm that buries the ones needing an answer. *)
+
+open Alcotest
+
+module Fleet = Server_routes_http_runtime_health_fleet
+
+let queue
+      ?(runnable = 0)
+      ?(recoverable = 0)
+      ?(retained_disabled = 0)
+      ?(paused_dead = 0)
+      ?(shutdown_fenced = 0)
+      ()
+  =
+  `Assoc
+    [ "status", `String "ok"
+    ; "counts_complete", `Bool true
+    ; "read_error_count", `Int 0
+    ; "transition_outbox_count", `Int 0
+    ; "operator_action_required", `Bool false
+    ; "runnable_backlog_count", `Int runnable
+    ; "recoverable_backlog_count", `Int recoverable
+    ; "retained_disabled_backlog_count", `Int retained_disabled
+    ; "paused_dead_backlog_count", `Int paused_dead
+    ; "shutdown_fenced_backlog_count", `Int shutdown_fenced
+    ]
+;;
+
+let dimensions input =
+  match Fleet.keeper_event_queue_health_dimensions ~stale_after_sec:600.0 input with
+  | `Assoc fields -> fields
+  | _ -> fail "expected an object"
+;;
+
+let bool_field name fields =
+  match List.assoc_opt name fields with
+  | Some (`Bool b) -> b
+  | _ -> fail (name ^ " missing or not a bool")
+;;
+
+let reasons fields =
+  match List.assoc_opt "status_reasons" fields with
+  | Some (`List items) ->
+    List.filter_map (function `String s -> Some s | _ -> None) items
+  | _ -> []
+;;
+
+let test_paused_dead_is_not_actionable () =
+  let fields = dimensions (queue ~paused_dead:74 ()) in
+  check bool "a paused keeper alone does not demand operator action" false
+    (bool_field "operator_action_required" fields)
+;;
+
+let test_retained_disabled_is_not_actionable () =
+  let fields = dimensions (queue ~retained_disabled:5 ()) in
+  check bool "autoboot/proactive off does not demand operator action" false
+    (bool_field "operator_action_required" fields)
+;;
+
+let test_recoverable_is_actionable () =
+  let fields = dimensions (queue ~recoverable:1 ()) in
+  check bool "a recoverable owner still demands action" true
+    (bool_field "operator_action_required" fields)
+;;
+
+let test_shutdown_fenced_is_actionable () =
+  let fields = dimensions (queue ~shutdown_fenced:28 ()) in
+  check bool "a fenced shutdown still demands action" true
+    (bool_field "operator_action_required" fields)
+;;
+
+let test_paused_dead_stays_visible () =
+  let fields = dimensions (queue ~paused_dead:74 ()) in
+  check bool "the paused backlog is still reported with its depth" true
+    (List.exists (String.equal "paused_dead_backlog=74") (reasons fields))
+;;
+
+let test_mixed_backlog_is_actionable () =
+  let fields = dimensions (queue ~paused_dead:74 ~recoverable:1 ()) in
+  check bool "a recoverable entry is not masked by paused ones" true
+    (bool_field "operator_action_required" fields)
+;;
+
+let () =
+  run "Keeper event queue health actionability"
+    [ ( "operator_intended"
+      , [ test_case "paused_dead" `Quick test_paused_dead_is_not_actionable
+        ; test_case "retained_disabled" `Quick test_retained_disabled_is_not_actionable
+        ; test_case "stays visible" `Quick test_paused_dead_stays_visible
+        ] )
+    ; ( "actionable"
+      , [ test_case "recoverable" `Quick test_recoverable_is_actionable
+        ; test_case "shutdown_fenced" `Quick test_shutdown_fenced_is_actionable
+        ; test_case "mixed" `Quick test_mixed_backlog_is_actionable
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Problem

`operator_action_required` counts a deliberately paused keeper as work needing
an operator:

    let non_runnable_backlog_count =
      recoverable_backlog_count
      + retained_disabled_backlog_count
      + paused_dead_backlog_count        <-- operator's own decision
      + shutdown_fenced_backlog_count
    in
    let work_action_required =
      backlog_stale || non_runnable_backlog_count > 0
    in

Live instance, with `taskmaster` paused on purpose:

    status_reasons: [runnable_backlog=4, paused_dead_backlog=74,
                     shutdown_fenced_backlog=28, runnable_backlog_stale]
    operator_action_required: true

Events keep being delivered to a paused keeper, so `paused_dead_backlog` only
grows. As long as the pause stands, `operator_action_required` cannot return to
false and the fleet reads `warning`/`blocked`. A standing alarm that no action
can clear is the kind that buries the alarms that do need an answer.

## Change

Split the non-runnable backlog by whether an operator can act on it.

- **actionable** — `recoverable` (clears when the owner fiber is restored) and
  `shutdown_fenced` (clears when the shutdown completes). These still drive
  `work_action_required` and the `warning`/`blocked` status.
- **operator-intended** — `paused_dead` and `retained_disabled` (a keeper
  deliberately paused; autoboot or proactive turned off). These no longer
  demand action.

Both still appear in `status_reasons` with their depth
(`paused_dead_backlog=74`), so nothing becomes invisible.

`backlog_clean` deliberately keeps using the **total**: it answers a different
question — whether the queue holds anything at all — and a paused entry does
count against that. Judgement (`operator_action_required`) and fact
(`backlog_clean`) are kept apart.

### Why not gate delivery instead

Blocking enqueue to a paused keeper would be a new scheduling gate. The MASC
implementation boundaries say not to add one when the feature is already
correct without it, and not to turn past evidence into a scheduling gate. The
delivery is fine; only the *classification of it as actionable* was wrong.

## Local verification

- New `test_keeper_event_queue_health_actionable` — **6 tests, exit 0**:
  `paused_dead` alone is not actionable, `retained_disabled` alone is not,
  the paused backlog still surfaces in `status_reasons` with its count,
  `recoverable` is actionable, `shutdown_fenced` is actionable, and a
  `recoverable` entry is not masked when paused entries are also present.

- Regression, all exit 0: `test_keeper_event_queue`,
  `test_keeper_terminal_reason_typed`, `test_keeper_fd_pressure_fleet`,
  `test_board_collect_pause_gate`, `test_health`.

## Not verified / scope

- **This does not clear the current live alarm.** The running instance also has
  `runnable_backlog_stale` and `shutdown_fenced_backlog=28`, both still
  actionable by design. This change removes a *permanent* source of
  `operator_action_required`, it does not silence today's degraded state.
- `test_server_runtime_bootstrap` was **not** verified locally: its `main_eio`
  cases need the executable path Dune injects, and running the .exe directly
  fails all 7 with "main_eio executable is unbound; run the test via Dune".
  The stated cause is unrelated to this change, but it is unverified here and
  left to CI.
- Why 4 runnable events sat for an hour, and why 28 shutdown-fenced entries
  remain after the fleet shrank, are separate questions not addressed here.
