### PR TITLE
feat(dashboard): observability for the verifying goal phase (RFC-0387 stage 2 PR-3)

### DIFF
--- a/dashboard/src/components/goals/goal-helpers.test.ts
+++ b/dashboard/src/components/goals/goal-helpers.test.ts
@@ -5,6 +5,8 @@ import { describe, it, expect } from 'vitest'
 import {
   priorityStars,
   priorityLabel,
+  goalPhaseLabel,
+  goalPhaseStatus,
   phaseFilterLabel,
   matchesGoalPhaseFilter,
   sortByPriority,
@@ -75,6 +77,22 @@ describe('priorityLabel', () => {
 })
 
 // ================================================================
+// goalPhaseLabel / goalPhaseStatus
+// ================================================================
+
+describe('goalPhaseLabel', () => {
+  it('returns 검증 중 for verifying (RFC-0387 stage 2)', () => {
+    expect(goalPhaseLabel('verifying')).toBe('검증 중')
+  })
+})
+
+describe('goalPhaseStatus', () => {
+  it('maps verifying to the awaiting_verification info tone', () => {
+    expect(goalPhaseStatus('verifying')).toBe('awaiting_verification')
+  })
+})
+
+// ================================================================
 // phaseFilterLabel
 // ================================================================
 
@@ -93,6 +111,10 @@ describe('phaseFilterLabel', () => {
 
   it('returns 일시정지 for paused', () => {
     expect(phaseFilterLabel('paused')).toBe('일시정지')
+  })
+
+  it('returns 검증 중 for verifying', () => {
+    expect(phaseFilterLabel('verifying')).toBe('검증 중')
   })
 
   it('returns 완료 for completed', () => {
@@ -121,6 +143,12 @@ describe('matchesGoalPhaseFilter', () => {
   it('matches only the requested phase', () => {
     expect(matchesGoalPhaseFilter('blocked', 'blocked')).toBe(true)
     expect(matchesGoalPhaseFilter('executing', 'blocked')).toBe(false)
+  })
+
+  it('matches verifying goals against the verifying filter', () => {
+    expect(matchesGoalPhaseFilter('verifying', 'verifying')).toBe(true)
+    expect(matchesGoalPhaseFilter('executing', 'verifying')).toBe(false)
+    expect(matchesGoalPhaseFilter('verifying', 'all')).toBe(true)
   })
 })
 

--- a/dashboard/src/components/goals/goal-helpers.ts
+++ b/dashboard/src/components/goals/goal-helpers.ts
@@ -15,6 +15,7 @@ export type GoalPhaseFilter =
   | 'executing'
   | 'blocked'
   | 'paused'
+  | 'verifying'
   | 'completed'
   | 'dropped'
 
@@ -139,6 +140,7 @@ export function goalPhaseLabel(phase: string): string {
     case 'executing': return '실행 중'
     case 'blocked': return '차단됨'
     case 'paused': return '일시정지'
+    case 'verifying': return '검증 중'
     case 'completed': return '완료'
     case 'dropped': return '중단'
     default: return phase
@@ -150,6 +152,7 @@ export function goalPhaseStatus(phase: string): string {
     case 'completed': return 'completed'
     case 'blocked': return 'error'
     case 'paused': return 'paused'
+    case 'verifying': return 'awaiting_verification'
     case 'dropped': return 'offline'
     case 'executing':
     default:
@@ -178,6 +181,7 @@ export function phaseFilterLabel(value: GoalPhaseFilter): string {
     case 'executing':
     case 'blocked':
     case 'paused':
+    case 'verifying':
     case 'completed':
     case 'dropped':
       return goalPhaseLabel(value)

--- a/dashboard/src/components/goals/goal-tree.test.ts
+++ b/dashboard/src/components/goals/goal-tree.test.ts
@@ -294,6 +294,39 @@ describe('GoalTree', () => {
       .not.toBeNull()
   })
 
+  it('renders a verifying goal with phase label, filter chip, and summary count', async () => {
+    const goal = { ...makeGoal('goal-verifying', 'Verifying goal'), phase: 'verifying' }
+    const treePayload: DashboardGoalsTreeResponse = {
+      approval_queue_state: { state: 'ready' },
+      tree: [goal],
+      summary: {
+        ...emptySummary(),
+        total_goals: 1,
+        active_goals: 1,
+        phase_counts: { verifying: 1 },
+      },
+    }
+    const detailPayload: DashboardGoalDetailResponse = {
+      goal,
+      linked_tasks: [],
+      linked_keepers: [],
+      approvals: [],
+      execution_receipts: [],
+      timeline: [],
+    }
+    mocks.fetchDashboardGoalsTree.mockResolvedValue(treePayload)
+    mocks.fetchDashboardGoalDetail.mockResolvedValue(detailPayload)
+
+    render(html`<${GoalTree} />`)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('goal-detail-panel').getAttribute('data-selected-goal-id'))
+        .toBe('goal-verifying')
+    })
+    // Tree node badge and the phase filter chip both render the Korean label.
+    expect(screen.getAllByText('검증 중').length).toBeGreaterThanOrEqual(2)
+  })
+
   it('renders a loading indicator while the goal tree is refreshing', async () => {
     const goal = makeGoal('goal-loading', 'Loading goal')
     const treePayload: DashboardGoalsTreeResponse = {

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -389,6 +389,10 @@ function TreeSummary({
         <div class="mt-1 ${DECK_LABEL}">Blocked phase</div>
       </div>
       <div class="${CARD_BOX} text-center">
+        <div class="font-mono text-xl font-semibold text-[var(--color-fg-primary)] tabular-nums">${summary.phase_counts.verifying ?? 0}</div>
+        <div class="mt-1 ${DECK_LABEL}">검증 중</div>
+      </div>
+      <div class="${CARD_BOX} text-center">
         <div class="font-mono text-xl font-semibold text-[var(--color-fg-primary)] tabular-nums">${summary.pending_approvals}</div>
         <div class="mt-1 ${DECK_LABEL}">승인 대기</div>
       </div>
@@ -1240,6 +1244,7 @@ export function GoalTree() {
       executing: 0,
       blocked: 0,
       paused: 0,
+      verifying: 0,
       completed: 0,
       dropped: 0,
     }
@@ -1298,6 +1303,7 @@ export function GoalTree() {
                 'executing',
                 'blocked',
                 'paused',
+                'verifying',
                 'completed',
                 'dropped',
               ] as GoalPhaseFilter[]).map(filter => ({

--- a/lib/dashboard/dashboard_goals.ml
+++ b/lib/dashboard/dashboard_goals.ml
@@ -311,6 +311,7 @@ let dashboard_goals_tree_json_ready ~(config : Workspace.config)
                   ("executing", `Int (count_phase Goal_phase.Executing));
                   ("blocked", `Int (count_phase Goal_phase.Blocked));
                   ("paused", `Int (count_phase Goal_phase.Paused));
+                  ("verifying", `Int (count_phase Goal_phase.Verifying));
                   ("completed", `Int (count_phase Goal_phase.Completed));
                   ("dropped", `Int (count_phase Goal_phase.Dropped));
                 ] );

--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -157,6 +157,7 @@ and goal_of_yojson = function
 type rollup = {
   active_count : int;
   paused_count : int;
+  verifying_count : int;
   done_count : int;
   dropped_count : int;
 }
@@ -537,6 +538,7 @@ let compute_rollup goals =
           match goal.phase with
           | Goal_phase.Paused | Goal_phase.Blocked -> true
           | _ -> false);
+    verifying_count = count (fun goal -> goal.phase = Goal_phase.Verifying);
     done_count = count (fun goal -> goal.phase = Goal_phase.Completed);
     dropped_count = count (fun goal -> goal.phase = Goal_phase.Dropped);
   }

--- a/lib/goal/goal_store.mli
+++ b/lib/goal/goal_store.mli
@@ -72,6 +72,7 @@ type state = {
 type rollup = {
   active_count : int;
   paused_count : int;
+  verifying_count : int;
   done_count : int;
   dropped_count : int;
 }
@@ -84,7 +85,8 @@ val rollup_to_yojson : rollup -> Yojson.Safe.t
 val compute_rollup : goal list -> rollup
 (** Field-wise count of goals per lifecycle bucket
     ([Executing] → active, [Paused]/[Blocked] → paused,
-    [Completed] → done, [Dropped] → dropped).  Single
+    [Verifying] → verifying, [Completed] → done,
+    [Dropped] → dropped).  Single
     pass; no allocation beyond the result record. *)
 
 (** {1 Persistence paths} *)

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1571,11 +1571,13 @@ let goal_list_output_schema =
             ~properties:
               [ "active_count", `Assoc [ "type", `String "integer" ]
               ; "paused_count", `Assoc [ "type", `String "integer" ]
+              ; "verifying_count", `Assoc [ "type", `String "integer" ]
               ; "done_count", `Assoc [ "type", `String "integer" ]
               ; "dropped_count", `Assoc [ "type", `String "integer" ]
               ]
             ~required:
-              [ "active_count"; "paused_count"; "done_count"; "dropped_count" ] )
+              [ "active_count"; "paused_count"; "verifying_count"; "done_count"
+              ; "dropped_count" ] )
       ]
     ~required:[ "status"; "generated_at"; "count"; "goals"; "rollup" ]
 ;;

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -169,6 +169,10 @@ let test_goal_list_includes_rollup () =
            ~target_value:"1" () with
    | Ok _ -> ()
    | Error msg -> fail msg);
+  (match Goal_store.upsert_goal config ~title:"Verifying goal" ~metric:"m"
+           ~target_value:"1" ~phase:Goal_phase.Verifying () with
+   | Ok _ -> ()
+   | Error msg -> fail msg);
   let listed =
     Tool_workspace.dispatch
       (workspace_ctx config)
@@ -182,7 +186,9 @@ let test_goal_list_includes_rollup () =
   in
   let rollup = Yojson.Safe.Util.member "rollup" listed_json in
   check int "active goal is counted" 1
-    (Yojson.Safe.Util.member "active_count" rollup |> Yojson.Safe.Util.to_int)
+    (Yojson.Safe.Util.member "active_count" rollup |> Yojson.Safe.Util.to_int);
+  check int "verifying goal is counted" 1
+    (Yojson.Safe.Util.member "verifying_count" rollup |> Yojson.Safe.Util.to_int)
 ;;
 let test_goal_list_ignores_blank_optional_filters () =
   with_workspace

--- a/test/test_keeper_tool_plan.ml
+++ b/test/test_keeper_tool_plan.ml
@@ -621,6 +621,7 @@ let test_new_declared_output_schemas_admit_producer_shapes () =
          , `Assoc
              [ "active_count", `Int 1
              ; "paused_count", `Int 0
+             ; "verifying_count", `Int 0
              ; "done_count", `Int 0
              ; "dropped_count", `Int 0
              ] )


### PR DESCRIPTION
## RFC-0387 stage 2 PR-3 — dashboard observability for `verifying`

Stacked on #29211 (`feat/goal-gate-stage2`, the `Verifying` goal phase). Closes the P3-1 gap: the dashboard frontend was unaware of the new phase — a goal parked in `verifying` fell through to raw-string labels, had no filter chip, and was invisible in rollup/counts.

### Backend (OCaml)
- `lib/goal/goal_store.ml{,.mli}`: `rollup` gains `verifying_count`; `compute_rollup` counts `Goal_phase.Verifying`.
- `lib/keeper/keeper_tool_descriptor.ml`: `goal_list_output_schema` rollup properties/required grow `verifying_count` in lockstep (strict schema).
- `lib/dashboard/dashboard_goals.ml`: goals-tree summary `phase_counts` gains `verifying`. (`phase_color` already handled on the base branch.)

### Frontend (dashboard/)
- `goal-helpers.ts`: `GoalPhaseFilter` += `'verifying'`; `goalPhaseLabel` → `검증 중`; `goalPhaseStatus` → `awaiting_verification` (info tone, same shape of wait as task verification); `phaseFilterLabel` rides the label.
- `goal-tree.ts`: phase-count record, filter chip list, and a `검증 중` summary card.
- `planning.ts` rides `goalPhaseLabel` — verified, no change needed.

### Tests
- `goal-helpers.test.ts`, `goal-tree.test.ts`: verifying label/status/filter/render cases. Ran locally: `vitest run` on both files — 53 passed; `tsc --noEmit` and `eslint` on changed files clean.
- OCaml: extended the existing rollup assertions only (`test_goal_tools.ml` rollup test now counts a verifying goal; `test_keeper_tool_plan.ml` `masc_goal_list` schema fixture gains `verifying_count`). No local dune build — deferred to CI.

No CI ratchet baselines touched. Human-confirmation phase does not exist (withdrawn from the RFC) — no `awaiting_confirmation` anywhere.