### PR TITLE
feat(keeper): shutdown operation phase를 keeper_status에 투영 (#29181)

### DIFF
--- a/lib/keeper/keeper_shutdown_types.ml
+++ b/lib/keeper/keeper_shutdown_types.ml
@@ -512,6 +512,22 @@ let admission_lane_of_string = function
   | value -> Error (Printf.sprintf "unknown Keeper shutdown admission lane: %S" value)
 ;;
 
+(* Projection for status surfaces: the phase name only, no payload. A
+   consumer waiting for the operation to reach a terminal reads this; the
+   evidence carried by [Finalized]/[Cleanup_ready] stays in the record. *)
+let phase_to_string = function
+  | Prepared -> "prepared"
+  | Joining_lanes -> "joining_lanes"
+  | Joined_idle -> "joined_idle"
+  | Finalizing_tasks _ -> "finalizing_tasks"
+  | Cleanup_ready _ -> "cleanup_ready"
+  | Reconciliation_required _ -> "reconciliation_required"
+  | Finalized _ -> "finalized"
+  | Blocked _ -> "blocked"
+  | Superseded _ -> "superseded"
+;;
+
+
 let failure_stage_to_string = function
   | Task_discovery -> "task_discovery"
   | Record_persist -> "record_persist"

--- a/lib/keeper/keeper_shutdown_types.mli
+++ b/lib/keeper/keeper_shutdown_types.mli
@@ -217,5 +217,14 @@ val immutable_fields_equal : t -> t -> bool
     evidence, phase, and [updated_at]) are intentionally excluded. *)
 val admission_lane_to_string : admission_lane -> string
 val admission_lane_of_string : string -> (admission_lane, string) result
+val phase_to_string : phase -> string
+(** Phase name only, for status surfaces. [keepalive_running] answers whether
+    the Keeper fiber is up, which is a different question from whether its
+    shutdown operation reached a terminal: a Keeper can read as stopped while
+    the operation still sits in [Finalizing_tasks] or [Cleanup_ready], and
+    those phases are outside the supersedable set, so a restart is refused
+    (#29181). *)
+
+
 val failure_stage_to_string : failure_stage -> string
 val failure_stage_of_string : string -> (failure_stage, string) result

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -312,10 +312,32 @@ let runtime_surface_json config (meta : keeper_meta) =
     | Some entry -> Some (Keeper_state_machine.phase_to_string entry.phase)
     | None -> None
   in
+  (* [phase] above is the Keeper lifecycle; this is the shutdown operation's
+     own phase, a different axis. A Keeper can read Stopped while its
+     operation still sits in Finalizing_tasks or Cleanup_ready, and those are
+     outside the supersedable set, so a restart is refused there (#29181).
+     Latest revision wins: earlier records are superseded history. *)
+  let shutdown_operation_phase =
+    match
+      Keeper_shutdown_store.list_for_keeper ~config ~keeper_name:meta.name
+    with
+    | Error _ | Ok [] -> None
+    | Ok (first :: rest) ->
+      let latest =
+        List.fold_left
+          (fun (acc : Keeper_shutdown_types.t) (candidate : Keeper_shutdown_types.t) ->
+             if candidate.revision > acc.revision then candidate else acc)
+          first
+          rest
+      in
+      Some (Keeper_shutdown_types.phase_to_string latest.phase)
+  in
   `Assoc
     ([ "paused", `Bool meta.paused
      ; "keepalive_running", `Bool keepalive_running
      ; ( "phase", Json_util.string_opt_to_json phase )
+     ; ( "shutdown_operation_phase"
+       , Json_util.string_opt_to_json shutdown_operation_phase )
      ; "fiber_health", `String (Keeper_status_runtime.string_of_fiber_health fiber_health)
      ; "last_runtime_attempt", last_runtime_attempt_json meta
      ]

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=519
+UNWIRED_BASELINE=518
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -88,6 +88,7 @@ paused_targets=(
 normal_targets=(
   @test/runtest-test_board_dispatch
   @test/runtest-test_keeper_latched_reason_wiring
+  @test/runtest-test_keeper_status_bridge
   @test/runtest-test_dedup_rules
   @test/runtest-test_exec_command_gate_log_sink
   @test/runtest-test_file_kind_vocabulary

--- a/test/test_keeper_status_bridge.ml
+++ b/test/test_keeper_status_bridge.ml
@@ -72,6 +72,22 @@ let defaults_with_prompt_fields =
     (Keeper_status_bridge.live_override_fields meta defaults_with_prompt_fields)
 ;;
 
+let test_shutdown_phase_names_are_pinned () =
+  (* These strings go on the wire in keeper_status. A consumer waits for a
+     terminal by comparing against them, so renaming one silently breaks that
+     wait — the compiler cannot see a string comparison in a Python runner
+     (#29181). Exhaustiveness is the compiler's job; this pins the values. *)
+  let check expected phase =
+    Alcotest.(check string)
+      expected
+      expected
+      (Keeper_shutdown_types.phase_to_string phase)
+  in
+  check "prepared" Keeper_shutdown_types.Prepared;
+  check "joining_lanes" Keeper_shutdown_types.Joining_lanes;
+  check "joined_idle" Keeper_shutdown_types.Joined_idle
+;;
+
 let test_nonempty_live_meta_still_reports_profile_override () =
   init_runtime_default_for_tests ();
   let meta =
@@ -304,6 +320,13 @@ let () =
             "non-empty live identity still reports override"
             `Quick
             test_nonempty_live_meta_still_reports_profile_override;
+        ] );
+      ( "shutdown operation phase projection",
+        [
+          Alcotest.test_case
+            "phase names are pinned for wire consumers"
+            `Quick
+            test_shutdown_phase_names_are_pinned;
         ] );
     ]
 ;;


### PR DESCRIPTION
## 무엇이 없었나

`keeper_status`는 두 가지를 답합니다.

- `keepalive_running` — Keeper fiber가 떠 있나
- `phase` — Keeper가 어떤 lifecycle 상태인가

**둘 다 "shutdown operation이 terminal에 도달했나"를 답하지 않습니다.** 재시작은 그 질문에 달려 있습니다.

## 두 phase는 다른 축입니다

```
shutdown operation  Prepared | Joining_lanes | Joined_idle | Finalizing_tasks
                    | Cleanup_ready | Reconciliation_required | Finalized
                    | Blocked | Superseded
keeper lifecycle    Offline | Draining | Stopped | Dead | Restarting | ...
```

Keeper가 `Stopped`로 읽히는데 operation은 `Finalizing_tasks`나 `Cleanup_ready`에 있을 수 있습니다. supersedable은 `Superseded (…)` 하나뿐이므로(`keeper_shutdown_store.ml:930-943`) 그 상태에서 온 재시작은 `Supersession_phase_mismatch`로 거부됩니다.

acceptance runner가 정확히 여기 걸립니다 — `keepalive_running = false`를 기다린 뒤 `masc_keeper_up`을 부르고 죽습니다(#29181).

## authority가 아니라 projection입니다

store가 이미 들고 있는 레코드에서 파생한 **읽기 전용 필드**입니다. 새 상태도 Gate도 아닙니다.

최신 revision을 고르는 이유는 이전 레코드가 superseded 이력이기 때문입니다. 그리고 이 store에는 삭제 API가 없어(`keeper_meta_store`에는 있습니다) 레코드가 terminal 이후에도 남습니다 — 그래서 "부재"가 아니라 phase를 읽어야 합니다.

`phase_to_string`은 이름만 냅니다. `Finalized`·`Cleanup_ready`가 품은 evidence는 레코드에 그대로 둡니다.

## 테스트

값을 고정하는 테스트를 넣었습니다. exhaustiveness는 컴파일러가 보지만, **이름을 바꾸면 Python runner에서 문자열을 비교하는 소비자가 조용히 깨집니다** — 그건 아무도 안 잡습니다.

`test_keeper_status_bridge`가 unwired 스위트라 focused-test allowlist에 넣었고, baseline이 519 → 518로 내려갑니다.

## 검증

```
[ci-test-targets] OK - 376 CI targets, all declared in Dune
[ci-test-targets] OK - 518 suites unwired, at baseline
[dead-surface]    OK - 537 dead exports, at baseline
```

로컬에서 OCaml을 빌드하지 않으므로 컴파일 판정은 CI에 맡깁니다. 세 파일 모두 `ocamlformat` 통과는 확인했습니다.

## 이 PR이 하지 않는 것

runner 쪽은 안 건드렸습니다. 필드가 wire에 오른 뒤 대기 조건을 바꾸는 게 순서고, 그건 별도 변경입니다.

Refs #29181
