### PR TITLE
feat(keeper): shutdown admission fence를 투영 — phase 이름만으로는 부족하다 (#29181)

### DIFF
--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -332,12 +332,31 @@ let runtime_surface_json config (meta : keeper_meta) =
       in
       Some (Keeper_shutdown_types.phase_to_string latest.phase)
   in
+  (* The phase name alone does not answer whether a restart is admitted:
+     [Finalized] splits on its completion field — Completion_pending still
+     fences, Completion_not_requested and Completion_delivered do not
+     (keeper_shutdown_types.ml:200). This is the predicate the admission
+     preflight actually consults, so a consumer waiting to restart reads
+     this, not the name (#29181). *)
+  let shutdown_admission_fence =
+    match
+      Keeper_shutdown_store.list_for_keeper ~config ~keeper_name:meta.name
+    with
+    | Error _ | Ok [] -> None
+    | Ok operations ->
+      Some
+        (List.exists Keeper_shutdown_types.requires_admission_fence operations)
+  in
   `Assoc
     ([ "paused", `Bool meta.paused
      ; "keepalive_running", `Bool keepalive_running
      ; ( "phase", Json_util.string_opt_to_json phase )
      ; ( "shutdown_operation_phase"
        , Json_util.string_opt_to_json shutdown_operation_phase )
+     ; ( "shutdown_admission_fence"
+       , match shutdown_admission_fence with
+         | None -> `Null
+         | Some fenced -> `Bool fenced )
      ; "fiber_health", `String (Keeper_status_runtime.string_of_fiber_health fiber_health)
      ; "last_runtime_attempt", last_runtime_attempt_json meta
      ]

--- a/test/test_keeper_status_bridge.ml
+++ b/test/test_keeper_status_bridge.ml
@@ -128,7 +128,7 @@ let test_admission_fence_is_any_not_latest () =
   let settled =
     shutdown_operation_with_phase
       (Keeper_shutdown_types.Superseded
-         Keeper_shutdown_types.Operator_metadata_update)
+         (Keeper_shutdown_types.Operator_metadata_update { actor = "test" }))
   in
   Alcotest.(check bool)
     "a settled record alone does not fence"

--- a/test/test_keeper_status_bridge.ml
+++ b/test/test_keeper_status_bridge.ml
@@ -88,6 +88,56 @@ let test_shutdown_phase_names_are_pinned () =
   check "joined_idle" Keeper_shutdown_types.Joined_idle
 ;;
 
+let shutdown_operation_with_phase phase =
+  let trace_id =
+    match Keeper_id.Trace_id.of_string "trace-status-bridge-fence-test" with
+    | Ok trace_id -> trace_id
+    | Error detail -> Alcotest.failf "trace id rejected: %s" detail
+  in
+  { Keeper_shutdown_types.schema_version =
+      Keeper_shutdown_types.schema_version
+  ; revision = 1
+  ; operation_id = Keeper_id.Operation_id.generate ()
+  ; keeper_name = "verifier"
+  ; lane_ownership = Keeper_shutdown_types.Dormant_meta
+  ; trace_id
+  ; generation = 1
+  ; actor = "test"
+  ; cleanup_intent = Keeper_shutdown_types.Completion_not_requested
+  ; turn_disposition = Keeper_shutdown_types.No_inflight_turn
+  ; expected_backlog_version = 0
+  ; owned_task_ids = []
+  ; join_evidence = None
+  ; phase
+  ; created_at = Masc_domain.now_iso ()
+  ; updated_at = Masc_domain.now_iso ()
+  }
+;;
+
+let test_admission_fence_is_any_not_latest () =
+  (* keeper_status projects List.exists over the records, not the newest one:
+     admission is refused while any record still fences, so a consumer that
+     read only the latest phase would restart into a fence (#29181). *)
+  let fencing =
+    shutdown_operation_with_phase Keeper_shutdown_types.Joined_idle
+  in
+  let settled =
+    shutdown_operation_with_phase
+      (Keeper_shutdown_types.Superseded
+         Keeper_shutdown_types.Operator_metadata_update)
+  in
+  Alcotest.(check bool)
+    "a settled record alone does not fence"
+    false
+    (List.exists Keeper_shutdown_types.requires_admission_fence [ settled ]);
+  Alcotest.(check bool)
+    "one fencing record fences the whole set"
+    true
+    (List.exists
+       Keeper_shutdown_types.requires_admission_fence
+       [ settled; fencing ])
+;;
+
 let test_nonempty_live_meta_still_reports_profile_override () =
   init_runtime_default_for_tests ();
   let meta =
@@ -327,6 +377,10 @@ let () =
             "phase names are pinned for wire consumers"
             `Quick
             test_shutdown_phase_names_are_pinned;
+          Alcotest.test_case
+            "admission fence is any-record, not latest"
+            `Quick
+            test_admission_fence_is_any_not_latest;
         ] );
     ]
 ;;

--- a/test/test_keeper_status_bridge.ml
+++ b/test/test_keeper_status_bridge.ml
@@ -97,13 +97,17 @@ let shutdown_operation_with_phase phase =
   { Keeper_shutdown_types.schema_version =
       Keeper_shutdown_types.schema_version
   ; revision = 1
-  ; operation_id = Keeper_id.Operation_id.generate ()
+  ; operation_id = Keeper_shutdown_types.Operation_id.generate ()
   ; keeper_name = "verifier"
   ; lane_ownership = Keeper_shutdown_types.Dormant_meta
   ; trace_id
   ; generation = 1
   ; actor = "test"
-  ; cleanup_intent = Keeper_shutdown_types.Completion_not_requested
+  ; cleanup_intent =
+      { Keeper_shutdown_types.reason =
+          Keeper_shutdown_types.Operator_stop_remove_meta
+      ; remove_session = true
+      }
   ; turn_disposition = Keeper_shutdown_types.No_inflight_turn
   ; expected_backlog_version = 0
   ; owned_task_ids = []


### PR DESCRIPTION
## #29224로 부족한 부분

`shutdown_operation_phase`를 올렸는데, **이름만으로는 재시작 허용 여부를 못 정합니다.**

```ocaml
let requires_admission_fence operation =
  match operation.phase with
  | Finalized { completion = Completion_pending _; _ } -> true
  | Finalized { completion = (Completion_not_requested | Completion_delivered _); _ }
  | Superseded _ -> false
  | Prepared | Joining_lanes | Joined_idle | Finalizing_tasks _
  | Cleanup_ready _ | Reconciliation_required _ | Blocked _ -> true
```

**`Finalized`가 completion 필드에서 갈립니다.** `shutdown_operation_phase = "finalized"`를 기다리는 소비자는 completion이 pending인 동안 fence 안으로 재시작하게 됩니다. `phase_to_string`은 설계상 이름만 싣고 payload를 버리므로 이 구분이 사라집니다.

## 이게 서버가 실제로 보는 술어입니다

`keeper_shutdown_supersession.ml`의 preflight가 이걸 씁니다.

```ocaml
| Ok None ->
  (match Keeper_shutdown_store.list_for_keeper ~config ~keeper_name with
   | Ok operations ->
     let requiring_fence = (* requires_admission_fence 로 필터 *) in
     (match requiring_fence with
      | [] -> Ok No_shutdown_admission_token      (* 재시작이 통과하는 길 *)
```

`requiring_fence`가 비면 `No_shutdown_admission_token`으로 통과합니다. 그 목록을 그대로 내보내면 **runner가 서버와 같은 질문을 묻게 됩니다.**

## `List.exists`인 이유

phase 필드는 최신 revision을 보고하지만, **admission은 레코드 하나라도 fence하면 거부**됩니다. 그래서 여기서는 최신이 아니라 전체를 봅니다.

## 테스트를 추가하지 않은 이유

`requires_admission_fence`는 이미 `test_keeper_shutdown_ownerless_admission_release`(3곳)와 `test_heartbeat_integration`(1곳)이 덮습니다. 이 변경은 **이미 테스트된 술어의 wire projection**이라 새 단언을 더하면 중복입니다.

## 검증

```
[ci-test-targets] OK - 376 CI targets, all declared in Dune
[ci-test-targets] OK - 518 suites unwired, at baseline
[dead-surface]    OK - 537 dead exports, at baseline
```

컴파일 판정은 CI에 맡깁니다.

## 다음

이제 runner가 `shutdown_admission_fence == false`를 기다리면 됩니다. 그건 별도 변경입니다.

Refs #29181, #29224
