### PR TITLE
fix(harness): acceptance가 keepalive 대신 admission fence 해소를 기다린다 (#29181)

### DIFF
--- a/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
+++ b/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
@@ -1401,14 +1401,29 @@ class MissionRun:
             "masc_keeper_down",
             {"name": self.roles["coordinator"], "remove_meta": False, "remove_session": False},
         )
+        # keepalive_running answers whether the fiber is up. It does not
+        # answer whether the shutdown operation reached a phase that admits a
+        # restart: the operation can still sit in Finalizing_tasks or
+        # Cleanup_ready, and masc_keeper_up is then refused with
+        # "shutdown operation is not an operator-supersedable blocked
+        # operation" (#29181). shutdown_admission_fence is the predicate the
+        # server's admission preflight consults, so wait on that.
+        #
+        # Only False admits. None means the status carried no operation
+        # record — either none exists yet or the read failed — and treating
+        # that as "no fence" is the same misread this replaces.
         down_deadline = time.monotonic() + 90.0
         while time.monotonic() < down_deadline:
             status = self.read_status("coordinator", "down-poll")
             if isinstance(status, dict) and not status.get("keepalive_running", False):
-                break
+                if status.get("shutdown_admission_fence") is False:
+                    break
             time.sleep(1.0)
         else:
-            raise AcceptanceError("coordinator did not stop within 90 seconds")
+            raise AcceptanceError(
+                "coordinator shutdown did not clear the admission fence within "
+                "90 seconds"
+            )
         arguments: dict[str, Any] = {"name": self.roles["coordinator"]}
         if self.runtime_id:
             arguments["runtime_id"] = self.runtime_id


### PR DESCRIPTION
## 지금 무엇이 깨지나

runner의 coordinator 재시작 절차입니다.

```
masc_keeper_down
wait until keepalive_running == false
masc_keeper_up          ← 거부
```

`keepalive_running`은 **Keeper fiber가 떠 있나**를 답합니다. 서버는 재시작을 받아들이기 전에 **다른 질문**을 합니다 — shutdown operation 중 admission fence를 요구하는 게 남아 있나.

operation은 fiber가 사라진 뒤에도 `Finalizing_tasks`나 `Cleanup_ready`에 머물 수 있고, 그 phase들은 fence합니다. 그래서 이렇게 돌아옵니다.

```
keeper update refused before metadata commit:
shutdown operation is not an operator-supersedable blocked operation
```

CI acceptance 5건 중 1건을 죽였고, #29172가 앞단의 dialect 거부를 걷어낸 뒤로는 **종착 실패**가 됐습니다.

## 서버의 술어를 그대로 기다립니다

#29224가 `shutdown_operation_phase`를, #29226이 `shutdown_admission_fence`를 `keeper_status`에 올렸습니다. 후자는 admission preflight가 실제로 보는 `requires_admission_fence`의 투영입니다.

```python
if isinstance(status, dict) and not status.get("keepalive_running", False):
    if status.get("shutdown_admission_fence") is False:
        break
```

## `is False`인 이유

`None`은 상태에 operation 레코드가 없었다는 뜻이고, **아직 없는 것인지 읽기가 실패한 것인지 구분되지 않습니다.** 그걸 "fence 없음"으로 읽으면 지금 고치는 것과 똑같은 오독이 됩니다. 그래서 `False`만 통과시키고, 타임아웃 메시지도 어느 조건이 안 풀렸는지 말하도록 바꿨습니다.

## 왜 재시도가 아닌가

`masc_keeper_up`에 재시도를 감으면 세 줄로 끝나지만, 그건 **오판을 흡수**할 뿐입니다. 문제는 호출이 실패한 게 아니라 runner가 완료를 잘못 판정하고 너무 일찍 부른 것이고, 흡수하면 `keepalive_running`이 lifecycle 권위가 아니라는 사실 자체가 관측되지 않습니다. 이유는 #29181에 적어뒀습니다.

Refs #29181, #29224, #29226
