### PR TITLE
fix(harness): fence를 runtime surface에서 읽는다 — status 최상위가 아니다 (#29233 후속)

### DIFF
--- a/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
+++ b/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
@@ -1416,7 +1416,13 @@ class MissionRun:
         while time.monotonic() < down_deadline:
             status = self.read_status("coordinator", "down-poll")
             if isinstance(status, dict) and not status.get("keepalive_running", False):
-                if status.get("shutdown_admission_fence") is False:
+                runtime_surface = status.get("runtime")
+                fence = (
+                    runtime_surface.get("shutdown_admission_fence")
+                    if isinstance(runtime_surface, dict)
+                    else None
+                )
+                if fence is False:
                     break
             time.sleep(1.0)
         else:


### PR DESCRIPTION
## 증상

#29233이 **자기가 추가한 타임아웃 메시지**로 죽었습니다.

```
coordinator shutdown did not clear the admission fence within 90 seconds
```

그런데 evidence를 보면 그 시점에 조건이 **이미 충족**돼 있었습니다.

```
.data.keepalive_running                  false
.data.runtime.shutdown_admission_fence   false
.data.runtime.shutdown_operation_phase   "finalized"
```

## 원인

필드가 한 단계 아래에 있습니다. `keeper_status`는 runtime surface를 `"runtime"` 키로 감싸고, #29226이 projection을 `runtime_surface_json`에 넣었습니다.

runner의 `status`는 `.data`이므로 `status.get("shutdown_admission_fence")`는 **항상 `None`**이었고, `is False`가 성립할 수 없었습니다.

```python
runtime_surface = status.get("runtime")
fence = (
    runtime_surface.get("shutdown_admission_fence")
    if isinstance(runtime_surface, dict)
    else None
)
if fence is False:
    break
```

## `None`을 통과시키지 않는 건 그대로입니다

runtime surface가 없으면 상태를 못 읽은 것이고, 그걸 "fence 없음"으로 읽으면 #29233이 고친 오독을 반복합니다. 그래서 surface 자체가 dict인지 확인하고, 아니면 계속 기다립니다.

## 검증

`d9224405547b` 실행의 `evidence/raw/120-keeper-status-down-poll-coordinator.json`에서 경로를 직접 확인했습니다. `keepalive_running`은 `.data`에, 새 필드 둘은 `.data.runtime`에 있습니다.

Refs #29181, #29233
