### PR TITLE
fix(goal): reserve verifier commits for typed authority

### DIFF
--- a/lib/completion_authority_agent.ml
+++ b/lib/completion_authority_agent.ml
@@ -10,7 +10,7 @@ open Result.Syntax
 (* RFC-0361 D7(b): fixed authority identity — every judgement carries the
    same actor string (the [verifier_exact] lane id) so verdicts aggregate by
    actor; run identity stays with the per-review [verification_id]. *)
-let authority_actor = Task.Anti_rationalization.verifier_exact_lane_id
+let authority_actor = Runtime.verifier_exact_lane_id
 
 type runtime =
   { config : Workspace_utils_backend_setup.config

--- a/lib/goal/goal_phase.ml
+++ b/lib/goal/goal_phase.ml
@@ -119,6 +119,46 @@ let action_of_string = function
 let parse_action s =
   String.trim s |> String.lowercase_ascii |> action_of_string
 
+module Public_action = struct
+  type t =
+    | Request_complete
+    | Pause
+    | Resume
+    | Block
+    | Unblock
+    | Drop
+    | Reopen
+
+  let to_action : t -> action = function
+    | Request_complete -> (Request_complete : action)
+    | Pause -> (Pause : action)
+    | Resume -> (Resume : action)
+    | Block -> (Block : action)
+    | Unblock -> (Unblock : action)
+    | Drop -> (Drop : action)
+    | Reopen -> (Reopen : action)
+  ;;
+
+  let to_string action = action_to_string (to_action action)
+
+  let of_string = function
+    | "request_complete" -> Some Request_complete
+    | "pause" -> Some Pause
+    | "resume" -> Some Resume
+    | "block" -> Some Block
+    | "unblock" -> Some Unblock
+    | "drop" -> Some Drop
+    | "reopen" -> Some Reopen
+    | _ -> None
+  ;;
+
+  let parse raw =
+    String.trim raw |> String.lowercase_ascii |> of_string
+  ;;
+
+  let all = [ Request_complete; Pause; Resume; Block; Unblock; Drop; Reopen ]
+end
+
 
 type outcome =
   | Move_to of t

--- a/lib/goal/goal_phase.mli
+++ b/lib/goal/goal_phase.mli
@@ -69,8 +69,28 @@ val action_of_string : string -> action option
 val parse_action : string -> action option
 
 val all_actions : action list
-(** Every action in declaration order. SSOT for the schema/validator action
-    enum via [List.map action_to_string all_actions]. *)
+(** Every internal action in declaration order. Includes verifier-only ledger
+    commits and is the SSOT for the exhaustive transition matrix. *)
+
+module Public_action : sig
+  (** Lifecycle requests exposed by [masc_goal_transition]. Verifier verdicts
+      are deliberately absent: they enter through the application-owned typed
+      authority boundary, never through an MCP caller. *)
+  type t =
+    | Request_complete
+    | Pause
+    | Resume
+    | Block
+    | Unblock
+    | Drop
+    | Reopen
+
+  val to_action : t -> action
+  val to_string : t -> string
+  val of_string : string -> t option
+  val parse : string -> t option
+  val all : t list
+end
 
 (** What a transition request resolves to.
 

--- a/lib/goal/goal_verification.ml
+++ b/lib/goal/goal_verification.ml
@@ -487,12 +487,29 @@ let ledger_error_to_yojson detail =
 
 let record_criterion_verdict config ~goal_id (verdict : verdict) =
   update_record config ~goal_id (fun current ->
-      let criterion =
-        match verdict.outcome with
-        | Proven -> Criterion_viable verdict
-        | Refuted _ -> Criterion_unreachable verdict
+      let committable =
+        match current.criterion, verdict.outcome with
+        | Criterion_pending _, _ -> true
+        | Criterion_viable _, Proven -> true
+        | Criterion_unreachable _, Refuted _ -> true
+        | ( Criterion_viable _, Refuted _ )
+        | ( Criterion_unreachable _, Proven )
+        | ( Criterion_unchecked, _ ) -> false
       in
-      Ok { current with criterion })
+      if not committable
+      then
+        Error
+          (Printf.sprintf
+             "goal_verification: criterion verdict for %s has no matching pending \
+              criterion request"
+             goal_id)
+      else
+        let criterion =
+          match verdict.outcome with
+          | Proven -> Criterion_viable verdict
+          | Refuted _ -> Criterion_unreachable verdict
+        in
+        Ok { current with criterion })
 
 (* {1 Stage-2 durable requests (RFC-0387 §3.2 / §4.1)}
 

--- a/lib/goal/goal_verification.mli
+++ b/lib/goal/goal_verification.mli
@@ -133,7 +133,10 @@ val record_criterion_verdict :
   verdict ->
   (record, string) result
 (** Commits the verifier's creation-time feasibility judgment (B2). [Proven]
-    lands as [Criterion_viable], [Refuted] as [Criterion_unreachable]. *)
+    lands as [Criterion_viable], [Refuted] as [Criterion_unreachable]. Requires
+    a durable [Criterion_pending] request, or the same criterion outcome already
+    committed for an idempotent retry. An unchecked or opposite stale verdict
+    is refused inside the locked record mutation. *)
 
 val record_proof_verdict :
   Workspace_utils.config ->

--- a/lib/goal_verification_agent.ml
+++ b/lib/goal_verification_agent.ml
@@ -293,36 +293,21 @@ let build_review_request config (goal : Goal_store.goal) kind
 
 (* {1 Verdict commit}
 
-   The commit rides the MCP handler itself — FSM decide, ledger commit, phase
-   write, event — with the lane's fixed identity as the session name. The
-   action strings come from {!Goal_phase.action_to_string}; nothing here
-   matches on them. *)
+   The application-owned worker crosses a typed internal boundary. Public MCP
+   callers can request lifecycle changes but cannot name verifier verdicts or
+   impersonate the fixed verifier authority. *)
 
-let commit_gate_verdict config ~goal_id ~action ~evidence ~note
+let commit_gate_verdict config ~goal_id ~decision ~evidence
   : (unit, string) result
   =
-  let ctx : Workspace_types.context =
-    { config
-    ; agent_name = Task.Anti_rationalization.verifier_exact_lane_id
-    }
-  in
-  let args =
-    `Assoc
-      ([ "goal_id", `String goal_id
-       ; "action", `String (Goal_phase.action_to_string action)
-       ; "evidence", `String evidence
-       ]
-       @
-       match note with
-       | Some note -> [ "note", `String note ]
-       | None -> [])
-  in
   let result =
-    Workspace_goals.handle_goal_transition
-      ~tool_name:"masc_goal_transition"
+    Workspace_goals.commit_verifier_decision
+      ~tool_name:"goal_verifier_commit"
       ~start_time:(Time_compat.now ())
-      ctx
-      args
+      config
+      ~goal_id
+      ~decision
+      ~evidence
   in
   if Tool_result.is_success result
   then Ok ()
@@ -437,24 +422,23 @@ let process_pending_work ?(sw : Eio.Switch.t option = None) config (work : pendi
              in
              (match evidence with
               | Some evidence when String.trim evidence <> "" ->
-                let action, note =
+                let decision =
                   match work.kind, review_verdict with
                   | Completion_proof, Task.Anti_rationalization.Approve ->
-                    Goal_phase.Record_proof_proven, None
+                    Workspace_goals.Proof_proven
                   | Completion_proof, Task.Anti_rationalization.Reject reason ->
-                    Goal_phase.Record_proof_refuted, Some reason
+                    Workspace_goals.Proof_refuted { reason }
                   | Criterion_check, Task.Anti_rationalization.Approve ->
-                    Goal_phase.Record_criterion_viable, None
+                    Workspace_goals.Criterion_viable
                   | Criterion_check, Task.Anti_rationalization.Reject reason ->
-                    Goal_phase.Record_criterion_unreachable, Some reason
+                    Workspace_goals.Criterion_unreachable { reason }
                 in
                 (match
                    commit_gate_verdict
                      config
                      ~goal_id:work.goal_id
-                     ~action
+                     ~decision
                      ~evidence
-                     ~note
                  with
                  | Ok () ->
                    Log.Misc.info

--- a/lib/goal_verification_agent.ml
+++ b/lib/goal_verification_agent.ml
@@ -8,10 +8,10 @@
     [Verifying] (B3) — judges each through
     {!Task.Anti_rationalization.review} (so provider selection is the
     [verifier_exact] exact-output lane with frozen-order failover), and
-    commits the verdict by riding the exact MCP commit path:
-    {!Workspace_goals.handle_goal_transition} with the gate action, so the
-    FSM decides, the ledger records, the phase writes, and the event emits —
-    none of that logic is duplicated here.
+    commits the verdict through the typed internal boundary
+    {!Workspace_goals.commit_verifier_decision}, so the FSM decides, the
+    ledger records, the phase writes, and the event emits — none of that
+    logic is duplicated here and no public MCP action can name a verdict.
 
     Authority is the fixed identity
     [System_llm_agent { agent_run_id = "verifier_exact" }] (RFC-0361 D7(b)):

--- a/lib/goal_verification_agent.mli
+++ b/lib/goal_verification_agent.mli
@@ -4,8 +4,8 @@
     verification ledger's durable pending requests — [Criterion_pending] (B2)
     and [Proof_pending] (B3) — judges each through
     {!Task.Anti_rationalization.review} on the [verifier_exact] lane, and
-    commits the verdict through {!Workspace_goals.handle_goal_transition}, the
-    same FSM+ledger+phase+event path the MCP surface uses, under the fixed
+    commits the verdict through {!Workspace_goals.commit_verifier_decision},
+    the typed internal FSM+ledger+phase+event boundary, under the fixed
     identity [System_llm_agent { agent_run_id = "verifier_exact" }]
     (RFC-0361 D7(b)).
 

--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -287,20 +287,6 @@ let parse_review_verdict_from_json (args : Yojson.Safe.t) : (verdict, string) re
   | exn -> Error (sprintf "review verdict JSON parse error: %s" (Printexc.to_string exn))
 ;;
 
-(* ================================================================ *)
-(* Cross-model runtime selection (#3067, RFC-0361 D7(a))             *)
-(* ================================================================ *)
-
-(** [\[runtime.exact_output_lanes.verifier_exact\]] — the dedicated exact-output
-    lane every completion-authority judgement call runs on. The lane's admitted
-    slots, in frozen declaration order, are the single provider-selection SSOT:
-    there is no second selector path and no [\[runtime\].default] fallback.
-
-    Cross-model evaluation is more effective than same-model different-role
-    because different model architectures have different blindspots.
-    See: Anthropic "Harness Design" blog analysis. *)
-let verifier_exact_lane_id = "verifier_exact"
-
 (** Ordered evaluator slot list for one review. An explicit
     [~evaluator_runtime] override is a single-slot lane (tests,
     [--evaluator-runtime]); without one the published [verifier_exact] lane

--- a/lib/task/anti_rationalization.mli
+++ b/lib/task/anti_rationalization.mli
@@ -92,11 +92,6 @@ val review
     review). The goal verification lane (RFC-0387) passes its own templates —
     provider selection, failover, and the verdict channel are unchanged. *)
 
-val verifier_exact_lane_id : string
-(** ["verifier_exact"] — the [\[runtime.exact_output_lanes.verifier_exact\]]
-    lane id every completion-authority judgement call resolves through
-    (RFC-0361 D7(a)). *)
-
 (** Render the single prompt-registry SSOT. There is no inline fallback prompt;
     an error keeps the Task nonterminal. [~prompt_name] defaults to
     {!Prompt_names.verification}; other callers (RFC-0387 goal verification)

--- a/lib/tool_schemas/tool_schemas_workspace_extra.ml
+++ b/lib/tool_schemas/tool_schemas_workspace_extra.ml
@@ -5,7 +5,7 @@ open Masc_domain
 let goal_phase_enum = List.map Goal_phase.to_string Goal_phase.all
 
 let goal_transition_action_enum =
-  List.map Goal_phase.action_to_string Goal_phase.all_actions
+  List.map Goal_phase.Public_action.to_string Goal_phase.Public_action.all
 ;;
 
 let enum_schema ?description values =
@@ -108,14 +108,10 @@ let schemas : tool_schema list =
     ; description =
         "Apply an explicit Goal lifecycle transition (RFC-0387 stage 2 gate). \
          request_complete no longer completes the Goal directly: it moves \
-         executing -> verifying and persists a durable proof request; only the \
-         verifier's record_proof_proven (with non-blank evidence) moves \
-         verifying -> completed, and record_proof_refuted returns the Goal to \
-         executing with the refutation preserved. record_criterion_viable / \
-         record_criterion_unreachable commit the creation-time criterion \
-         verdict without changing the phase. A Goal whose criterion was judged \
-         unreachable is refused on request_complete. All four record_* actions \
-         require non-blank evidence."
+         executing -> verifying and persists a durable proof request. Verifier \
+         verdicts are application-owned typed commits and are deliberately not \
+         accepted by this MCP tool. A Goal whose criterion was judged \
+         unreachable is refused on request_complete."
     ; input_schema =
         `Assoc
           [ "type", `String "object"
@@ -124,17 +120,6 @@ let schemas : tool_schema list =
                 [ "goal_id", `Assoc [ "type", `String "string" ]
                 ; "action", enum_schema goal_transition_action_enum
                 ; "note", `Assoc [ "type", `String "string" ]
-                ; ( "evidence"
-                  , `Assoc
-                      [ "type", `String "string"
-                      ; ( "description"
-                        , `String
-                            "Required (non-blank) for the four record_* gate \
-                             actions: the observation the verdict stands on. \
-                             For record_proof_refuted and \
-                             record_criterion_unreachable, [note] carries the \
-                             refutation reason." )
-                      ] )
                 ] )
           ; "required", `List [ `String "goal_id"; `String "action" ]
           ; "additionalProperties", `Bool false

--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -52,7 +52,7 @@ let validation_error_result
 let goal_phase_strings = List.map Goal_phase.to_string Goal_phase.all
 
 let goal_transition_action_strings =
-  List.map Goal_phase.action_to_string Goal_phase.all_actions
+  List.map Goal_phase.Public_action.to_string Goal_phase.Public_action.all
 ;;
 
 let make_enum_field_error ~field ~allowed ~received =
@@ -144,7 +144,7 @@ let parse_optional_transition_action args field =
   match Json_util.assoc_member_opt field args with
   | None | Some `Null -> Ok None
   | Some (`String raw) ->
-    (match Goal_phase.parse_action raw with
+    (match Goal_phase.Public_action.parse raw with
      | Some action -> Ok (Some action)
      | None ->
        Error
@@ -493,29 +493,25 @@ let validate_gate_evidence args action =
         ]
 ;;
 
-(* The MCP surface does not authenticate the caller, so the commit authority is
-   the caller's session name in the system-agent slot (RFC-0387 §4.3); the
-   authenticated binding is the B7 follow-up this slot is typed for. *)
-let gate_verdict
-      (ctx : context)
-      (outcome : Goal_verification.verdict_outcome)
-      ~evidence
+type verifier_decision =
+  | Criterion_viable
+  | Criterion_unreachable of { reason : string }
+  | Proof_proven
+  | Proof_refuted of { reason : string }
+
+(* The authority is constructed inside the application boundary. It is not a
+   field accepted from an MCP caller and cannot be replaced by a Keeper/session
+   name. [Runtime.verifier_exact_lane_id] is the runtime configuration SSOT. *)
+let gate_verdict (outcome : Goal_verification.verdict_outcome) ~evidence
     : Goal_verification.verdict
   =
   { Goal_verification.outcome
-  ; authority = Masc_domain.System_llm_agent { agent_run_id = ctx.agent_name }
+  ; authority =
+      Masc_domain.System_llm_agent
+        { agent_run_id = Runtime.verifier_exact_lane_id }
   ; evidence
   ; recorded_at = Masc_domain.now_iso ()
   }
-;;
-
-(* A refutation carries a reason; the caller's [note] is it, and the evidence
-   stands in when no note was given — a blank reason is never written. *)
-let refuted_outcome ~evidence ~note : Goal_verification.verdict_outcome =
-  match note with
-  | Some reason when String.trim reason <> "" ->
-    Goal_verification.Refuted { reason }
-  | _ -> Goal_verification.Refuted { reason = evidence }
 ;;
 
 let gate_event_payload (ctx : context) ~phase (verdict : Goal_verification.verdict) =
@@ -561,6 +557,98 @@ let commit_criterion_verdict_response
   | Ok record ->
     already_goal_response
       ~tool_name ~start_time ~goal_id ~action ~phase goal (Some record)
+;;
+
+let verifier_decision_parts = function
+  | Criterion_viable ->
+    Goal_phase.Record_criterion_viable, Goal_verification.Proven, None
+  | Criterion_unreachable { reason } ->
+    ( Goal_phase.Record_criterion_unreachable
+    , Goal_verification.Refuted { reason }
+    , Some reason )
+  | Proof_proven ->
+    Goal_phase.Record_proof_proven, Goal_verification.Proven, None
+  | Proof_refuted { reason } ->
+    ( Goal_phase.Record_proof_refuted
+    , Goal_verification.Refuted { reason }
+    , Some reason )
+;;
+
+let commit_verifier_decision
+      ~tool_name
+      ~start_time
+      config
+      ~goal_id
+      ~decision
+      ~evidence
+  =
+  let ctx : context =
+    { config; agent_name = Runtime.verifier_exact_lane_id }
+  in
+  let action, verdict_outcome, note = verifier_decision_parts decision in
+  match validate_gate_evidence (`Assoc [ "evidence", `String evidence ]) action with
+  | Error errors -> validation_error_result ~tool_name ~start_time errors
+  | Ok evidence ->
+    (match Goal_store.get_goal config ~goal_id with
+     | None ->
+       error_result_typed ~tool_name ~start_time ~code:Not_found "goal not found"
+     | Some goal ->
+       (match Goal_phase.decide_transition ~phase:goal.phase ~action with
+        | Error msg ->
+          error_result_typed ~tool_name ~start_time ~code:Conflict msg
+        | Ok (Goal_phase.Already phase) ->
+          (match decision with
+           | Criterion_viable | Criterion_unreachable _ ->
+             commit_criterion_verdict_response
+               ~tool_name
+               ~start_time
+               ctx
+               ~goal_id
+               ~action
+               ~phase
+               goal
+               (gate_verdict verdict_outcome ~evidence)
+           | Proof_proven | Proof_refuted _ ->
+             error_result_typed
+               ~tool_name
+               ~start_time
+               ~code:Conflict
+               "proof verdict did not name a phase transition")
+        | Ok (Goal_phase.Move_to phase) ->
+          (match decision with
+           | Criterion_viable | Criterion_unreachable _ ->
+             error_result_typed
+               ~tool_name
+               ~start_time
+               ~code:Internal_error
+               "criterion verdicts are phase-neutral; decide_transition never moves"
+           | Proof_proven | Proof_refuted _ ->
+             let verdict = gate_verdict verdict_outcome ~evidence in
+             (match Goal_verification.record_proof_verdict config ~goal_id verdict with
+              | Error msg ->
+                error_result_typed ~tool_name ~start_time ~code:Conflict msg
+              | Ok record ->
+                (match update_goal_phase ctx goal ~phase ?note () with
+                 | Error msg ->
+                   error_result_typed
+                     ~tool_name
+                     ~start_time
+                     ~code:Internal_error
+                     msg
+                 | Ok updated_goal ->
+                   emit_goal_event
+                     ctx
+                     ~goal_id
+                     ~event_type:"goal_phase"
+                     ~payload:(gate_event_payload ctx ~phase verdict);
+                   ok_result
+                     ~tool_name
+                     ~start_time
+                     [ "goal_id", `String goal_id
+                     ; "action", `String (Goal_phase.action_to_string action)
+                     ; "goal", Goal_store.goal_to_yojson updated_goal
+                     ; "verification", Goal_verification.record_to_yojson record
+                     ])))))
 ;;
 
 (* A repeated [request_complete] on [Verifying] is the explicit retry that
@@ -609,59 +697,44 @@ let handle_goal_transition ~tool_name ~start_time (ctx : context) args
   with
   | Error err, _ | _, Error err ->
     validation_error_result ~tool_name ~start_time [ err ]
-  | Ok goal_id, Ok (Some action) ->
-    (match validate_gate_evidence args action with
-     | Error errs -> validation_error_result ~tool_name ~start_time errs
-     | Ok evidence ->
-       let note = get_string_opt args "note" in
-       (match Goal_store.get_goal ctx.config ~goal_id with
-        | None ->
-          error_result_typed ~tool_name ~start_time ~code:Not_found "goal not found"
-        | Some goal ->
-          (match Goal_phase.decide_transition ~phase:goal.phase ~action with
-           | Error msg ->
-             error_result_typed ~tool_name ~start_time ~code:Conflict msg
-           (* The goal already occupies the phase this action targets. Writing it
-              and emitting a phase event would turn a repeated report — a duplicate
-              reconciliation, a stale racing event — into repeated history, so the
-              request is answered from the goal as it stands. The gate exceptions
-              that still work the ledger are the criterion commits and the
-              [Verifying] repeat; see the helpers above. *)
-           | Ok (Goal_phase.Already phase) ->
-             (match action with
-              | Goal_phase.Record_criterion_viable ->
-                commit_criterion_verdict_response
-                  ~tool_name ~start_time ctx ~goal_id ~action ~phase goal
-                  (gate_verdict ctx Goal_verification.Proven ~evidence)
-              | Goal_phase.Record_criterion_unreachable ->
-                commit_criterion_verdict_response
-                  ~tool_name ~start_time ctx ~goal_id ~action ~phase goal
-                  (gate_verdict ctx (refuted_outcome ~evidence ~note) ~evidence)
-              | Goal_phase.Request_complete ->
-                (match phase with
-                 | Goal_phase.Verifying ->
-                   answer_verifying_repeat
-                     ~tool_name ~start_time ctx ~goal_id ~action goal
-                 | Goal_phase.Executing
-                 | Goal_phase.Blocked
-                 | Goal_phase.Paused
-                 | Goal_phase.Completed
-                 | Goal_phase.Dropped ->
-                   already_goal_response
-                     ~tool_name ~start_time ~goal_id ~action ~phase goal None)
-              | Goal_phase.Record_proof_proven
-              | Goal_phase.Record_proof_refuted
-              | Goal_phase.Pause
-              | Goal_phase.Resume
-              | Goal_phase.Block
-              | Goal_phase.Unblock
-              | Goal_phase.Drop
-              | Goal_phase.Reopen ->
+  | Ok goal_id, Ok (Some public_action) ->
+    let action = Goal_phase.Public_action.to_action public_action in
+    let note = get_string_opt args "note" in
+    (match Goal_store.get_goal ctx.config ~goal_id with
+     | None ->
+       error_result_typed ~tool_name ~start_time ~code:Not_found "goal not found"
+     | Some goal ->
+       (match Goal_phase.decide_transition ~phase:goal.phase ~action with
+        | Error msg ->
+          error_result_typed ~tool_name ~start_time ~code:Conflict msg
+        (* The goal already occupies the phase this public lifecycle request
+           targets. Verifier verdicts cannot enter this branch because they
+           are absent from [Goal_phase.Public_action]. *)
+        | Ok (Goal_phase.Already phase) ->
+          (match public_action with
+           | Goal_phase.Public_action.Request_complete ->
+             (match phase with
+              | Goal_phase.Verifying ->
+                answer_verifying_repeat
+                  ~tool_name ~start_time ctx ~goal_id ~action goal
+              | Goal_phase.Executing
+              | Goal_phase.Blocked
+              | Goal_phase.Paused
+              | Goal_phase.Completed
+              | Goal_phase.Dropped ->
                 already_goal_response
                   ~tool_name ~start_time ~goal_id ~action ~phase goal None)
-           | Ok (Goal_phase.Move_to phase) ->
-             (match action with
-              | Goal_phase.Request_complete ->
+           | Goal_phase.Public_action.Pause
+           | Goal_phase.Public_action.Resume
+           | Goal_phase.Public_action.Block
+           | Goal_phase.Public_action.Unblock
+           | Goal_phase.Public_action.Drop
+           | Goal_phase.Public_action.Reopen ->
+             already_goal_response
+               ~tool_name ~start_time ~goal_id ~action ~phase goal None)
+        | Ok (Goal_phase.Move_to phase) ->
+          (match public_action with
+           | Goal_phase.Public_action.Request_complete ->
                 (* Executing -> Verifying (RFC-0387 §4): gate on the criterion
                    verdict, then persist the proof request BEFORE the phase
                    write — if the ledger write fails the phase does not move.
@@ -720,58 +793,12 @@ let handle_goal_transition ~tool_name ~start_time (ctx : context) args
                            ; ( "verification"
                              , Goal_verification.record_to_yojson record )
                            ])))
-              | Goal_phase.Record_proof_proven
-              | Goal_phase.Record_proof_refuted ->
-                (* Verifying -> Completed|Executing: the ledger commit is the
-                   verdict of record and runs BEFORE the phase write, so a
-                   stale verifier answer (no pending proof) vetoes the move. *)
-                let verdict =
-                  match action with
-                  | Goal_phase.Record_proof_proven ->
-                    gate_verdict ctx Goal_verification.Proven ~evidence
-                  | _ -> gate_verdict ctx (refuted_outcome ~evidence ~note) ~evidence
-                in
-                (match
-                   Goal_verification.record_proof_verdict
-                     ctx.config ~goal_id verdict
-                 with
-                 | Error msg ->
-                   error_result_typed ~tool_name ~start_time ~code:Conflict msg
-                 | Ok record ->
-                   (match update_goal_phase ctx goal ~phase ?note () with
-                    | Error msg ->
-                      error_result_typed
-                        ~tool_name ~start_time ~code:Internal_error msg
-                    | Ok updated_goal ->
-                      emit_goal_event
-                        ctx
-                        ~goal_id
-                        ~event_type:"goal_phase"
-                        ~payload:(gate_event_payload ctx ~phase verdict);
-                      ok_result
-                        ~tool_name
-                        ~start_time
-                        [ "goal_id", `String goal_id
-                        ; "action", `String (Goal_phase.action_to_string action)
-                        ; "goal", Goal_store.goal_to_yojson updated_goal
-                        ; "verification", Goal_verification.record_to_yojson record
-                        ]))
-              | Goal_phase.Record_criterion_viable
-              | Goal_phase.Record_criterion_unreachable ->
-                (* Criterion verdicts are phase-neutral: the FSM only answers
-                   [Already] for them, so [Move_to] here is unreachable. *)
-                error_result_typed
-                  ~tool_name
-                  ~start_time
-                  ~code:Internal_error
-                  "criterion verdicts are phase-neutral; decide_transition \
-                   never moves for them"
-              | Goal_phase.Pause
-              | Goal_phase.Resume
-              | Goal_phase.Block
-              | Goal_phase.Unblock
-              | Goal_phase.Drop
-              | Goal_phase.Reopen ->
+           | Goal_phase.Public_action.Pause
+           | Goal_phase.Public_action.Resume
+           | Goal_phase.Public_action.Block
+           | Goal_phase.Public_action.Unblock
+           | Goal_phase.Public_action.Drop
+           | Goal_phase.Public_action.Reopen ->
                 (match update_goal_phase ctx goal ~phase ?note () with
                  | Error msg ->
                    error_result_typed ~tool_name ~start_time ~code:Internal_error msg
@@ -791,7 +818,7 @@ let handle_goal_transition ~tool_name ~start_time (ctx : context) args
                      [ "goal_id", `String goal_id
                      ; "action", `String (Goal_phase.action_to_string action)
                      ; "goal", Goal_store.goal_to_yojson updated_goal
-                     ])))))
+                     ]))))
   | Ok _, Ok None ->
     validation_error_result
       ~tool_name

--- a/lib/workspace_goals.mli
+++ b/lib/workspace_goals.mli
@@ -42,11 +42,30 @@ val handle_goal_assign
 
 (** [handle_goal_transition ctx args] handles
     [masc_goal_transition].  Required arg: [action] (one of
-    {!goal_transition_action_strings}). [request_complete] moves an executing
-    Goal directly to [Completed]. *)
+    {!Goal_phase.Public_action.all}). [request_complete] moves an executing
+    Goal to [Verifying]; verifier verdicts are not public actions. *)
 val handle_goal_transition
   :  tool_name:string
   -> start_time:float
   -> Workspace_types.context
   -> Yojson.Safe.t
+  -> Tool_result.result
+
+type verifier_decision =
+  | Criterion_viable
+  | Criterion_unreachable of { reason : string }
+  | Proof_proven
+  | Proof_refuted of { reason : string }
+
+(** Commit one verdict from the application-owned Goal verifier. The fixed
+    [verifier_exact] authority is constructed inside this boundary; callers
+    cannot supply or impersonate it. The ledger commit precedes any phase
+    write, and a stale/non-pending verdict is refused. *)
+val commit_verifier_decision
+  :  tool_name:string
+  -> start_time:float
+  -> Workspace_utils_backend_setup.config
+  -> goal_id:string
+  -> decision:verifier_decision
+  -> evidence:string
   -> Tool_result.result

--- a/test/stanzas/test_goal_verification_agent.inc
+++ b/test/stanzas/test_goal_verification_agent.inc
@@ -1,7 +1,7 @@
 ; Per-file dune stanza for the RFC-0387 stage-2 PR-2 surface: the goal
 ; verifier caller (lib/goal_verification_agent.ml) that drains the ledger's
 ; durable pending requests through the verifier_exact lane and commits
-; verdicts via the masc_goal_transition commit path.
+; verdicts via the application-owned typed commit boundary.
 
 (test
  (name test_goal_verification_agent)

--- a/test/test_goal_phase_all.ml
+++ b/test/test_goal_phase_all.ml
@@ -1,6 +1,6 @@
-(* RFC-0089 — Goal_phase.all / all_actions are the SSOT for the MCP goal schema
-   enums and the workspace_goals validator, both built as
-   [List.map to_string all]. This guards those lists: every entry round-trips
+(* RFC-0089 — Goal_phase.all / Public_action.all are the SSOT for the MCP goal
+   schema enums and the workspace_goals validator. Internal [all_actions]
+   additionally covers verifier commits. This guards those lists: every entry round-trips
    through of_string, the derived string set has no duplicates, and it matches
    the expected set AND order (so deriving does not silently change the
    advertised enum order). to_string / action_to_string are the exhaustive
@@ -65,6 +65,26 @@ let test_action_set () =
       "record_criterion_unreachable";
     ]
     strs
+
+let test_public_action_set () =
+  let module PA = GP.Public_action in
+  let strs = List.map PA.to_string PA.all in
+  check int "public action count" 7 (List.length PA.all);
+  check int "no duplicate public action strings"
+    (List.length strs)
+    (List.length (List.sort_uniq String.compare strs));
+  check (list string) "public action set and order"
+    [ "request_complete"; "pause"; "resume"; "block"; "unblock"; "drop"; "reopen" ]
+    strs;
+  List.iter
+    (fun action ->
+      check bool
+        (Printf.sprintf "public action %s round-trips" (PA.to_string action))
+        true
+        (PA.of_string (PA.to_string action) = Some action))
+    PA.all;
+  check bool "verifier action is not public" true
+    (Option.is_none (PA.parse "record_proof_proven"))
 
 (* The 6x11 matrix in [decide_transition] had no behavioural test. Its comment
    says the compiler "refuses a matrix with a hole in it", and that is true --
@@ -217,6 +237,8 @@ let () =
         [
           test_case "round-trip" `Quick test_action_roundtrip;
           test_case "set and order" `Quick test_action_set;
+          test_case "public set excludes verifier commits" `Quick
+            test_public_action_set;
         ] );
       ( "transition matrix",
         [

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -329,15 +329,14 @@ let request_complete config goal_id =
 (* RFC-0387 stage 2: [request_complete] enters [Verifying]; [Completed] is
    reached only through the verifier's proof. *)
 let prove_complete config goal_id =
-  Tool_workspace.dispatch
-    (workspace_ctx config)
-    ~name:"masc_goal_transition"
-    ~args:
-      (`Assoc
-         [ "goal_id", `String goal_id
-         ; "action", `String "record_proof_proven"
-         ; "evidence", `String "observed by the test verifier"
-         ])
+  Some
+    (Workspace_goals.commit_verifier_decision
+       ~tool_name:"goal_verifier_commit"
+       ~start_time:0.
+       config
+       ~goal_id
+       ~decision:Workspace_goals.Proof_proven
+       ~evidence:"observed by the test verifier")
 ;;
 
 let test_goal_completion_accepts_goal_without_tasks () =

--- a/test/test_goal_verification_agent.ml
+++ b/test/test_goal_verification_agent.ml
@@ -3,8 +3,8 @@
     The lane drains the ledger's durable pending requests
     ([Criterion_pending] / [Proof_pending]) through
     [Task.Anti_rationalization.review] on the stubbed verifier_exact lane and
-    commits verdicts via the [masc_goal_transition] handler path, under the
-    fixed identity [verifier_exact]. Typed non-verdicts (evaluator
+    commits verdicts via the application-owned typed boundary, under the fixed
+    identity [verifier_exact]. Typed non-verdicts (evaluator
     unavailable, malformed replies after all slots failed, a verdict without
     a stated reason) leave the pending row durable and schedule a retry —
     failure never consumes a pending row. *)

--- a/test/test_goal_verification_gate.ml
+++ b/test/test_goal_verification_gate.ml
@@ -10,15 +10,14 @@
     that does not decode refuses every mutation AND fails every read loudly —
     never a silent "not verified yet".
 
-    Stage 2 gate (this PR): [request_complete] moves Executing -> Verifying
-    and persists the durable proof request BEFORE the phase write; only
-    [record_proof_proven] (non-blank evidence mandatory) reaches Completed;
-    [record_proof_refuted] returns the goal to Executing with the refutation
-    preserved. A repeated [request_complete] on Verifying answers [Already]
-    and re-arms the proof request when the ledger lost it (the P0-2 wedge).
-    [record_criterion_*] verdicts are phase-neutral ledger commits, and a
-    [Criterion_unreachable] verdict blocks [request_complete] with a typed
-    conflict. The FSM is the only transition decider; the ledger records. *)
+    Stage 2 gate: [request_complete] moves Executing -> Verifying and persists
+    the durable proof request BEFORE the phase write. Public MCP callers cannot
+    name verifier commits. Only the application-owned typed verifier boundary
+    can prove/refute completion or criterion viability, with non-blank
+    evidence and fixed [verifier_exact] authority. A repeated
+    [request_complete] on Verifying answers [Already] and re-arms the proof
+    request when the ledger lost it (the P0-2 wedge). The FSM is the only
+    transition decider; the ledger records. *)
 
 open Alcotest
 open Masc
@@ -515,15 +514,25 @@ let transition ctx goal_id ?note ?evidence action =
   dispatch ctx ~name:"masc_goal_transition" args
 ;;
 
+let verifier_transition config goal_id decision evidence =
+  Workspace_goals.commit_verifier_decision
+    ~tool_name:"goal_verifier_commit"
+    ~start_time:0.
+    config
+    ~goal_id
+    ~decision
+    ~evidence
+;;
+
 let mark_criterion_viable ctx goal_id =
   ignore
     (must_succeed
-       "record_criterion_viable"
-       (transition
-          ctx
+       "typed criterion viable"
+       (verifier_transition
+          ctx.config
           goal_id
-          ~evidence:"criterion is measurable"
-          "record_criterion_viable"))
+          Workspace_goals.Criterion_viable
+          "criterion is measurable"))
 ;;
 
 let stored_phase config goal_id =
@@ -583,8 +592,8 @@ let test_request_complete_enters_verifying_with_proof_pending () =
    | _ -> fail "ledger must hold the durable proof request")
 ;;
 
-(* (b) Only the verifier's proven proof completes the goal, with mandatory
-   evidence; the verdict carries the typed authority. *)
+(* (b) Public callers cannot self-verify. Only the typed verifier boundary can
+   complete the goal, with mandatory evidence and fixed authority. *)
 let test_proof_proven_completes_with_authority_and_evidence () =
   with_workspace
   @@ fun config ->
@@ -592,28 +601,31 @@ let test_proof_proven_completes_with_authority_and_evidence () =
   let goal_id = create_goal ctx "Proof-gated goal" in
   mark_criterion_viable ctx goal_id;
   ignore (must_succeed "request_complete" (transition ctx goal_id "request_complete"));
-  (* Evidence is mandatory: absent and blank are the same validation error. *)
-  let missing =
-    must_fail "record_proof_proven without evidence"
-      (transition ctx goal_id "record_proof_proven")
+  let public_refusal =
+    must_fail "public record_proof_proven"
+      (transition
+         ctx
+         goal_id
+         ~evidence:"caller-provided evidence"
+         "record_proof_proven")
   in
-  check string "typed validation error" "validation_error"
-    (json_state missing [ "error_code" ]);
+  check string "verifier action is not in the public enum" "validation_error"
+    (json_state public_refusal [ "error_code" ]);
   let blank =
-    must_fail "record_proof_proven with blank evidence"
-      (transition ctx goal_id ~evidence:"   " "record_proof_proven")
+    must_fail "typed proof verdict with blank evidence"
+      (verifier_transition config goal_id Workspace_goals.Proof_proven "   ")
   in
   check string "typed validation error" "validation_error"
     (json_state blank [ "error_code" ]);
   check string "a refused verdict does not move the phase" "verifying"
     (stored_phase config goal_id);
   let completed =
-    must_succeed "record_proof_proven"
-      (transition
-         ctx
+    must_succeed "typed proof proven"
+      (verifier_transition
+         config
          goal_id
-         ~evidence:"metric observed at target"
-         "record_proof_proven")
+         Workspace_goals.Proof_proven
+         "metric observed at target")
   in
   check string "completed via proof" "completed"
     (json_state completed [ "goal"; "phase" ]);
@@ -621,7 +633,7 @@ let test_proof_proven_completes_with_authority_and_evidence () =
     (json_state completed [ "verification"; "completion"; "state" ]);
   check string "the evidence is on the verdict" "metric observed at target"
     (json_state completed [ "verification"; "completion"; "verdict"; "evidence" ]);
-  check string "the caller session is the typed authority" "planner"
+  check string "the caller cannot impersonate the typed authority" "verifier_exact"
     (json_state
        completed
        [ "verification"; "completion"; "verdict"; "authority"; "actor" ]);
@@ -641,13 +653,12 @@ let test_proof_refuted_returns_to_executing_with_reason () =
   mark_criterion_viable ctx goal_id;
   ignore (must_succeed "request_complete" (transition ctx goal_id "request_complete"));
   let refuted =
-    must_succeed "record_proof_refuted"
-      (transition
-         ctx
+    must_succeed "typed proof refuted"
+      (verifier_transition
+         config
          goal_id
-         ~evidence:"coverage run attached"
-         ~note:"metric moved under the claim"
-         "record_proof_refuted")
+         (Workspace_goals.Proof_refuted { reason = "metric moved under the claim" })
+         "coverage run attached")
   in
   check string "back to executing" "executing"
     (json_state refuted [ "goal"; "phase" ]);
@@ -708,9 +719,12 @@ let test_verifying_repeat_rearms_a_missing_proof_request () =
    | _ -> fail "the re-arm must be durable, not just reported");
   (* And the gate drains from there. *)
   let completed =
-    must_succeed "record_proof_proven"
-      (transition ctx goal_id ~evidence:"verified after re-arm"
-         "record_proof_proven")
+    must_succeed "typed proof proven"
+      (verifier_transition
+         config
+         goal_id
+         Workspace_goals.Proof_proven
+         "verified after re-arm")
   in
   check string "the re-armed gate completes" "completed"
     (json_state completed [ "goal"; "phase" ])
@@ -724,13 +738,12 @@ let test_unreachable_criterion_blocks_request_complete () =
   let ctx = workspace_ctx config in
   let goal_id = create_goal ctx "Impossible goal" in
   let committed =
-    must_succeed "record_criterion_unreachable"
-      (transition
-         ctx
+    must_succeed "typed criterion unreachable"
+      (verifier_transition
+         config
          goal_id
-         ~evidence:"the named API does not exist"
-         ~note:"no such API exists"
-         "record_criterion_unreachable")
+         (Workspace_goals.Criterion_unreachable { reason = "no such API exists" })
+         "the named API does not exist")
   in
   check string "phase-neutral: still executing" "executing"
     (json_state committed [ "phase" ]);

--- a/test/test_goal_verification_gate.ml
+++ b/test/test_goal_verification_gate.ml
@@ -104,6 +104,12 @@ let verdict ?(evidence = "observed by the verifier") outcome : Goal_verification
   }
 ;;
 
+let mark_criterion_pending config goal_id =
+  match Goal_verification.mark_criterion_pending config ~goal_id with
+  | Ok _ -> ()
+  | Error msg -> fail msg
+;;
+
 (* Poison the authoritative store AND its recovery mirror; the fail-closed
    rule mirrors Goal_store: no mutation may proceed on a store that did not
    decode. (Poisoning the primary alone recovers from the mirror — that is
@@ -222,6 +228,7 @@ let test_undecodable_goal_store_reports_corruption_not_b1 () =
 let test_criterion_verdict_round_trips () =
   with_workspace
   @@ fun config ->
+  mark_criterion_pending config "goal-roundtrip";
   let committed =
     match
       Goal_verification.record_criterion_verdict
@@ -250,6 +257,7 @@ let test_criterion_verdict_round_trips () =
 let test_refuted_criterion_keeps_its_reason () =
   with_workspace
   @@ fun config ->
+  mark_criterion_pending config "goal-refuted";
   match
     Goal_verification.record_criterion_verdict
       config
@@ -270,6 +278,52 @@ let test_refuted_criterion_keeps_its_reason () =
      | Ok (Some _) -> fail "refuted verdict must land as Criterion_unreachable"
      | Ok None -> fail "committed record did not survive a fresh read"
      | Error msg -> fail msg)
+;;
+
+let test_criterion_verdict_requires_pending_or_same_outcome () =
+  with_workspace
+  @@ fun config ->
+  let goal_id = "goal-criterion-discipline" in
+  (match
+     Goal_verification.record_criterion_verdict
+       config
+       ~goal_id
+       (verdict Goal_verification.Proven)
+   with
+   | Ok _ -> fail "criterion verdict committed without a pending request"
+   | Error msg ->
+     check bool "the refusal names the missing request" true
+       (String_util.contains_substring msg "no matching pending"));
+  mark_criterion_pending config goal_id;
+  (match
+     Goal_verification.record_criterion_verdict
+       config
+       ~goal_id
+       (verdict Goal_verification.Proven)
+   with
+   | Ok _ -> ()
+   | Error msg -> fail msg);
+  (match
+     Goal_verification.record_criterion_verdict
+       config
+       ~goal_id
+       (verdict Goal_verification.Proven)
+   with
+   | Ok _ -> ()
+   | Error msg -> fail ("same-outcome retry was refused: " ^ msg));
+  (match
+     Goal_verification.record_criterion_verdict
+       config
+       ~goal_id
+       (verdict (Goal_verification.Refuted { reason = "stale result" }))
+   with
+   | Ok _ -> fail "opposite stale criterion verdict overwrote the committed outcome"
+   | Error _ -> ());
+  match Goal_verification.get_record config ~goal_id with
+  | Ok (Some { criterion = Goal_verification.Criterion_viable _; _ }) -> ()
+  | Ok (Some _) -> fail "opposite stale verdict changed the committed criterion"
+  | Ok None -> fail "criterion row disappeared"
+  | Error msg -> fail msg
 ;;
 
 (* Ledger: record-only discipline (stage 1 pins the preconditions the stage-2
@@ -340,6 +394,7 @@ let test_human_confirmation_requires_a_proven_proof () =
 let test_undecodable_ledger_fails_closed_and_loud () =
   with_workspace
   @@ fun config ->
+  mark_criterion_pending config "goal-corrupt";
   ignore
     (match
        Goal_verification.record_criterion_verdict
@@ -376,6 +431,7 @@ let test_undecodable_ledger_fails_closed_and_loud () =
 let test_unknown_ledger_field_is_a_decode_error () =
   with_workspace
   @@ fun config ->
+  mark_criterion_pending config "goal-strict";
   ignore
     (match
        Goal_verification.record_criterion_verdict
@@ -874,7 +930,9 @@ let () =
             test_refuted_criterion_keeps_its_reason
         ] )
     ; ( "ledger record-only discipline"
-      , [ test_case "proof verdict requires a pending request" `Quick
+      , [ test_case "criterion verdict requires pending or same outcome" `Quick
+            test_criterion_verdict_requires_pending_or_same_outcome
+        ; test_case "proof verdict requires a pending request" `Quick
             test_proof_verdict_requires_a_pending_request
         ; test_case "proof verdict requires a viable criterion" `Quick
             test_proof_verdict_requires_a_viable_criterion

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -432,7 +432,23 @@ let test_masc_goal_transition_schema () =
           Alcotest.(check bool) "actor is authenticated context, not input" false
             (List.mem_assoc "actor" props);
           Alcotest.(check bool) "has note" true
-            (List.mem_assoc "note" props)
+            (List.mem_assoc "note" props);
+          Alcotest.(check bool) "verifier evidence is not public input" false
+            (List.mem_assoc "evidence" props);
+          (match List.assoc_opt "action" props with
+           | Some action_schema ->
+             Alcotest.(check (list string))
+               "only lifecycle actions are public"
+               [ "request_complete"; "pause"; "resume"; "block"; "unblock"; "drop"; "reopen" ]
+               (match get_json_list "enum" action_schema with
+                | Some values ->
+                  List.map
+                    (function
+                      | `String value -> value
+                      | json -> Alcotest.fail ("non-string action enum: " ^ Yojson.Safe.to_string json))
+                    values
+                | None -> Alcotest.fail "masc_goal_transition action enum missing")
+           | None -> Alcotest.fail "masc_goal_transition action missing")
       | None -> Alcotest.fail "masc_goal_transition missing properties");
       match get_json_list "required" schema.input_schema with
       | Some reqs ->


### PR DESCRIPTION
## Summary

- Remove verifier verdict actions from the public `masc_goal_transition` schema and parser.
- Add a typed application-owned Goal verifier commit boundary with fixed `verifier_exact` authority.
- Route the standalone Goal verifier worker through that boundary and remove the duplicate lane-id constant.

## Product impact

- User-visible change: a Keeper or ordinary MCP caller can request Goal completion, but cannot approve its own proof or criterion. Completion remains pending until the standalone verifier commits a typed verdict.

## Evidence

- `git diff --check` — PASS at `ff2394ede7`.
- `ocamlformat --check` for all 15 changed OCaml/test files — PASS at `ff2394ede7`.
- Regression coverage now asserts the seven-action public enum, rejection of `record_proof_proven` through MCP, mandatory evidence at the typed boundary, and fixed `verifier_exact` authority.
- Whole-repo build/test is intentionally delegated to CI on the exact PR head; no local Dune result is claimed.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 2/2
provenance: direct
stages:
  - command: git diff --check
    result: pass
  - command: ocamlformat --check
    result: pass
```

## GOAL LOOP ACT checklist

- [x] Observe — current public schema admitted `record_proof_*` and bound authority to the caller session name.
- [x] Orient — RFC-0387 standalone worker exists in the base PR, but its public commit path still allowed self-verification.
- [x] Decide — close the public authority hole before adding live Goal-verifier scenarios and dashboard projection.
- [x] Act — public/internal action types are separated; the worker uses a typed internal commit.
- [ ] Verify — exact-head CI is pending.
- [x] Loop — live scenario and matrix evidence remain follow-up stacked slices.

## Review evidence

- Independent read-only verifier audit confirmed that the lifecycle gate existed but ordinary callers could still self-complete by naming `record_proof_proven`; this patch implements its typed-authority recommendation.

## Linked issue

- Relates #29221
- Relates RFC-0387

## Variant addition checklist

- [x] **OCaml** — `Public_action.t` and `verifier_decision` are declared in `.ml`/`.mli`; exhaustive matches and matrix tests are updated.
- [ ] **TypeScript** — N/A: no dashboard union changes in this slice.
- [x] **TLA+ spec** — N/A: internal/public authority surface split, no lifecycle phase/domain literal change.
- [x] **Event / JSON schema** — public MCP enum is derived from `Public_action.all` and pinned by schema tests.
- [ ] **`make check-variants` passes** — delegated to exact-head CI; no local Dune/build claim.

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/goal-transition-schema-drift` → `feat/goal-verifier-caller` · 1 commit(s) · synced 2026-08-21T00:46:25Z

| sha | subject | date |
|---|---|---|
| `ff2394ede` | fix(goal): reserve verifier commits for typed authority | 2026-08-21 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->