### PR TITLE
docs(rfc): OAS 를 흡수된 agent_core 로 정정

### DIFF
--- a/docs/rfc/RFC-0029-dashboard-fiber-batched-aggregation.md
+++ b/docs/rfc/RFC-0029-dashboard-fiber-batched-aggregation.md
@@ -36,7 +36,7 @@ Two concrete defects to verify:
    without an Eio fiber group. Eio scheduling is single-threaded but
    non-blocking sub-ops (in-memory projection lookups) finish in
    sub-millisecond — so today's cost is dominated by the *blocking*
-   sub-ops (model adapter health probes, OAS roundtrips) which the
+   sub-ops (model adapter health probes, agent_core roundtrips) which the
    serial walk forces into a chain.
 
 2. **No per-site latency budget.** None of the four fan-out sites emits

--- a/docs/rfc/RFC-0043-metric-ownership-distribution.md
+++ b/docs/rfc/RFC-0043-metric-ownership-distribution.md
@@ -45,7 +45,7 @@ implementation_prs: []
 | #13990 | 2026-05-06 | +43 | 3059 (HEAD) |
 
 각 PR 은 자신의 telemetry 추가가 정당하나, *공통 file 에 누적* 되는 구조 자체가
-ratchet 을 만든다. 도메인 owner (keeper, sse, oas, ...) 가 자기 metric 을 자기
+ratchet 을 만든다. 도메인 owner (keeper, sse, agent_core, ...) 가 자기 metric 을 자기
 파일에 두면 ratchet 자체가 사라진다.
 
 ### 1.2 Why PR #14166 가 closed (user-rejected)
@@ -93,7 +93,7 @@ Owner 분산이 안 되어 있어 다음 두 비용이 영구 발생:
 
 | # | Goal |
 |---|------|
-| G1 | 도메인 모듈 (keeper / sse / oas / ws / runtime / ...) 이 자기 metric 을 자기 파일에 정의 |
+| G1 | 도메인 모듈 (keeper / sse / agent_core / ws / runtime / ...) 이 자기 metric 을 자기 파일에 정의 |
 | G2 | `legacy metrics backend module` 은 *runtime registry* + *wire format* (collect / expose) 만 |
 | G3 | godfile cap 위반 자연 해소 (3059 → 예상 ~600 LOC) |
 | G4 | 신규 telemetry 추가 시 도메인 모듈 single-file 변경으로 완료 |
@@ -117,7 +117,7 @@ Owner 분산이 안 되어 있어 다음 두 비용이 영구 발생:
 ```
 keeper:    187 metrics (50.3%)
 sse:        16
-oas:        15
+agent_core:        15
 llm:        15
 ws:         12
 runtime:     9
@@ -149,7 +149,7 @@ server:     24
 runtime:    16
 llm:        13
 tool:       12
-oas:        11
+agent_core:        11
 ... (lower)
 
 총 use site:  772 references across 140 files
@@ -249,7 +249,7 @@ let register_all_metrics () =
 |----|-------|-------|--------------------------|----------|
 | **PR-1** | introduce empty domain modules + `register_all` no-op | ~10 신규 (.ml/.mli pair × 5 도메인) | +200 (추정, 빈 모듈) | – |
 | **PR-2** | 187 `metric_keeper_*` 상수 → `Keeper_metrics`; `legacy metrics backend` 에 alias 유지 | 1 legacy metrics backend module (-) + 1 신규 (+) | legacy metrics backend module: 187 const × ~3 LOC 평균 = ~-560 *측정 base*; new module: ~600; alias: ~190 → net new module ~+800, legacy metrics backend net ~-560+190(alias)=−370 | ✅ **3059 → ~2700, cap 통과** |
-| **PR-3** | sse/oas/llm/ws/runtime (~70 metrics) → 5 도메인 모듈; alias 유지 | 5 신규 + 1 legacy metrics backend module | legacy metrics backend module: −210; new modules: +210; alias: +70 | – |
+| **PR-3** | sse/agent_core/llm/ws/runtime (~70 metrics) → 5 도메인 모듈; alias 유지 | 5 신규 + 1 legacy metrics backend module | legacy metrics backend module: −210; new modules: +210; alias: +70 | – |
 | **PR-4** | 나머지 (~115 metrics) | 10+ 신규 + 1 legacy metrics backend module | legacy metrics backend module: −345; new modules: +345; alias: +115 | – |
 | **PR-5** | call site 마이그 (`Otel_metric_store.metric_*` → `<Domain>_metrics.metric_*`) + alias 제거 | **140 caller files (use site 측정)** + 1 legacy metrics backend module | use site rename ~772; legacy metrics backend alias drop ~−372 | – |
 

--- a/docs/rfc/RFC-0052-boot-time-required-invariants.md
+++ b/docs/rfc/RFC-0052-boot-time-required-invariants.md
@@ -78,7 +78,7 @@ let start_probe ~sw ~base_path ~interval_sec =
 | `keeper_unified_turn.ml` | 402, 730, 886 | `Some -> sleep` / `None -> ()` |
 | `keeper_turn_runtime_budget.ml` | 754 | `Some -> sleep` / `None -> ()` |
 | `agent_tool_execute_runtime.ml` | 748 | conditional clock access |
-| `keeper_agent_run.ml` | 478 | optional arg to OAS callback |
+| `keeper_agent_run.ml` | 478 | optional arg to agent_core callback |
 
 **핵심**: 모든 keeper 모듈이 개별적으로 `match Some/None`을 처리. 중앙 집중식 enforcement 없음.
 

--- a/docs/rfc/RFC-0056-incremental-sublib-extraction.md
+++ b/docs/rfc/RFC-0056-incremental-sublib-extraction.md
@@ -175,7 +175,7 @@ Phase 0 PoC is included in this PR. RFC merges with Phase 0; Phase 1 RFC is a fo
 
 ## 7. Phase 2 — Tool surface leaf (LANE 6)
 
-Status: implemented (PR #20057, 2026-06-04). Design ledger: jeong-sik/masc-oas-docs#132 (boundary-decoupling §27 / LANE 6).
+Status: implemented (PR #20057, 2026-06-04). Design ledger: jeong-sik/masc-agent_core-docs#132 (boundary-decoupling §27 / LANE 6).
 
 Phase 0/1 defined and validated the extraction gate (G1–G5). Phase 2 applies that gate to the tool **surface** layer and folds in the previously unowned tool⊥keeper invariant.
 

--- a/docs/rfc/RFC-0077-write-side-silent-failure-typed.md
+++ b/docs/rfc/RFC-0077-write-side-silent-failure-typed.md
@@ -42,7 +42,7 @@ keeper_supervisor.ml:2061      auto-resume meta write failed             -> warn
 keeper_turn_runtime_budget.ml:675  overflow pause write_meta failed      -> warn + continue
 keeper_agent_memory_episode.ml:103 episode_create failed                 -> error log + None
 keeper_agent_memory_episode.ml:192 failed_turn_episode_create failed     -> error log + None
-keeper_checkpoint_store.ml:279     OAS snapshot archive write failed     -> warn + drop archive
+keeper_checkpoint_store.ml:279     agent_core snapshot archive write failed     -> warn + drop archive
 keeper_crash_persistence.ml:135    crash persistence write failed        -> warn + lose crash record
 keeper_approval_queue.ml:430       upsert_rule: save failed              -> warn + in-memory only
 keeper_alerting.ml:554             alert JSONL write failed              -> error + drop alert
@@ -164,7 +164,7 @@ This is *behavior change at migration boundaries only*. PR-1 alone is byte-compa
 
 - **Q1**: Should `Read_drop_reason.t` (RFC-0044) and `Write_failure_reason.t` (this RFC) unify into `Persistence_failure_reason.t` with read/write phantom-type discriminator? **Decision**: defer. Unification is mechanical once both RFCs reach `Active`. Premature unification couples migration cadence.
 - **Q2**: `Meta_cas_conflict` retry policy — caller-level retry vs cycle-level retry? RFC-0026 (Work-Conserving Admission) suggests cycle-level. **Decision**: per-migration in PR-2 sub-steps.
-- **Q3**: How to handle the cross-module case `keeper_agent_memory_episode.ml` calling into `Workspace` / OAS? Result must propagate through the boundary or be absorbed at the boundary with explicit `Episode_create_error` annotation. **Decision**: PR-3 surfaces this question in the sub-PR.
+- **Q3**: How to handle the cross-module case `keeper_agent_memory_episode.ml` calling into `Workspace` / agent_core? Result must propagate through the boundary or be absorbed at the boundary with explicit `Episode_create_error` annotation. **Decision**: PR-3 surfaces this question in the sub-PR.
 
 ## 8. Acceptance
 

--- a/docs/rfc/RFC-0081-telemetry-envelope-and-pivot-timeline.md
+++ b/docs/rfc/RFC-0081-telemetry-envelope-and-pivot-timeline.md
@@ -1,6 +1,6 @@
 ---
 rfc: "0081"
-title: "OAS Telemetry Envelope Context & Keeper/Goal Pivot Timeline"
+title: "agent_core Telemetry Envelope Context & Keeper/Goal Pivot Timeline"
 status: Implemented
 created: 2026-05-14
 updated: 2026-05-22
@@ -11,51 +11,51 @@ related: ["0046", "0049", "0063"]
 implementation_prs: [15137]
 ---
 
-# RFC-0081 — OAS Telemetry Envelope Context & Keeper/Goal Pivot Timeline
+# RFC-0081 — agent_core Telemetry Envelope Context & Keeper/Goal Pivot Timeline
 
 - **Status**: Implemented (PR #15137; synced to YAML frontmatter `status: Implemented` + `implementation_prs: [15137]`.)
 - **Author**: vincent (yousleepwhen)
 - **Created**: 2026-05-14
-- **Related**: RFC-0046 (keeper detail FSM Hub SSOT — same UI surface), RFC-0049 (surface telemetry foundation), RFC-0063 (telemetry feedback loop — same consumer fiber), **RFC-OAS-019** (upstream stream lifecycle aggregation in `agent_sdk`)
-- **Supersedes**: closed PR #15128 (RFC-0073) — same operator-facing goal but mis-located the emission source inside masc; RFC-0081 carves the work into the correct boundary (developer: `agent_sdk` for emission via RFC-OAS-019, masc for envelope context and pivot UI here)
+- **Related**: RFC-0046 (keeper detail FSM Hub SSOT — same UI surface), RFC-0049 (surface telemetry foundation), RFC-0063 (telemetry feedback loop — same consumer fiber), **RFC-OAS-019** (upstream stream lifecycle aggregation in `agent_core`)
+- **Supersedes**: closed PR #15128 (RFC-0073) — same operator-facing goal but mis-located the emission source inside masc; RFC-0081 carves the work into the correct boundary (developer: `agent_core` for emission via RFC-OAS-019, masc for envelope context and pivot UI here)
 
 ## 0. Summary
 
-Two operator-facing defects in masc's telemetry view of OAS streams are addressed here. Per-chunk noise — the third defect originally bundled in the closed RFC-0073 — is the upstream `agent_sdk` repo's emission surface and is now scoped under **RFC-OAS-019** in `~/me/workspace/yousleepwhen/oas`.
+Two operator-facing defects in masc's telemetry view of agent_core streams are addressed here. Per-chunk noise — the third defect originally bundled in the closed RFC-0073 — is the upstream `agent_core` repo's emission surface and is now scoped under **RFC-OAS-019** in `~/me/workspace/yousleepwhen/agent_core`.
 
-1. **Envelope context null** — every `oas:telemetry_event` record written to `.masc/oas-events/YYYY-MM/DD.jsonl` (the durable OAS-event store; see `lib/telemetry_unified.ml:105` and `lib/keeper/keeper_event_bridge.ml:710`) has `agent_name`, `task_id`, `turn` as `null`. Operators cannot answer "which keeper, which turn, which goal produced this record?" from the raw jsonl alone.
+1. **Envelope context null** — every `agent_core:telemetry_event` record written to `.masc/agent-core-events/YYYY-MM/DD.jsonl` (the durable agent_core-event store; see `lib/telemetry_unified.ml:105` and `lib/keeper/keeper_event_bridge.ml:710`) has `agent_name`, `task_id`, `turn` as `null`. Operators cannot answer "which keeper, which turn, which goal produced this record?" from the raw jsonl alone.
 
 2. **Pivot impossibility** — there is no `(keeper_name | goal_id) → ordered events` query path. `tool_agent_timeline` (6-source merger) is keyed on `agent_name` only; `telemetry_unified` exposes no keeper/goal filter; the dashboard `keeper-detail-state.ts` mounts a trajectory slot but the backend it talks to has no turn-grouped event endpoint. Goal detail has no timeline tab.
 
-This RFC fixes both at the **read boundary**, not the write boundary. The relay code in `keeper_event_bridge.ml` is unchanged. Three rounds of design (fiber-local binding → shared Hashtbl → read-time join) plus three rounds of grep verification settled on read-time as the structural fit: agent_sdk's `event_envelope` does not carry a turn-level identifier (per-event `fresh_id ()` defaults at `oas/lib/event_envelope.ml:55-57`), so any write-time stamping mechanism would race or fail. The fix instead extends `keeper_runtime_manifest` with three timestamp/id fields and lets `telemetry_unified` perform a time-overlap join at API read time. The user-visible artifacts (pivot UI, pivot API) deliver the same stamped events; only the inside of the system is simpler.
+This RFC fixes both at the **read boundary**, not the write boundary. The relay code in `keeper_event_bridge.ml` is unchanged. Three rounds of design (fiber-local binding → shared Hashtbl → read-time join) plus three rounds of grep verification settled on read-time as the structural fit: agent_core's `event_envelope` does not carry a turn-level identifier (per-event `fresh_id ()` defaults at `agent_core/lib/event_envelope.ml:55-57`), so any write-time stamping mechanism would race or fail. The fix instead extends `keeper_runtime_manifest` with three timestamp/id fields and lets `telemetry_unified` perform a time-overlap join at API read time. The user-visible artifacts (pivot UI, pivot API) deliver the same stamped events; only the inside of the system is simpler.
 
 The emission-side change (per-chunk noise) is RFC-OAS-019's responsibility.
 
 ## 1. Cross-repo boundary (why this RFC exists separately)
 
-`agent_sdk` is consumed via opam pin `git+https://github.com/jeong-sik/oas.git#<sha>` (`dune-project` line 44: `(agent_sdk (>= 0.193.10))`). The `Streaming_chunk_n` payload variant lives in `lib/llm_provider/telemetry_event.ml:20-24` of the `oas` repo, not in masc. masc receives `Event_bus.Custom("telemetry_event", json)` payloads via the upstream SDK, filters them in `keeper_telemetry_consumer.ml` (counter-only, no deserialization), and relays them to a dated JSONL store at `lib/keeper/keeper_event_bridge.ml:710` under `.masc/oas-events/<YYYY-MM>/<DD>.jsonl`. (Earlier drafts of this RFC referenced `lib/telemetry_eio.ml:114` for this surface; that path is the *agent_event* surface, `.masc/telemetry/`, with a different typed event set — corrected here after grep verification.)
+`agent_core` is consumed via opam pin `git+https://github.com/jeong-sik/agent_core.git#<sha>` (`dune-project` line 44: `(agent_core (>= 0.193.10))`). The `Streaming_chunk_n` payload variant lives in `lib/llm_provider/telemetry_event.ml:20-24` of the `agent_core` repo, not in masc. masc receives `Event_bus.Custom("telemetry_event", json)` payloads via the upstream SDK, filters them in `keeper_telemetry_consumer.ml` (counter-only, no deserialization), and relays them to a dated JSONL store at `lib/keeper/keeper_event_bridge.ml:710` under `.masc/agent-core-events/<YYYY-MM>/<DD>.jsonl`. (Earlier drafts of this RFC referenced `lib/telemetry_eio.ml:114` for this surface; that path is the *agent_event* surface, `.masc/telemetry/`, with a different typed event set — corrected here after grep verification.)
 
 | Concern | Owner repo | RFC |
 |---|---|---|
-| Per-chunk emission → lifecycle summary | `oas` (`agent_sdk`) | **RFC-OAS-019** |
+| Per-chunk emission → lifecycle summary | `agent_core` (`agent_core`) | **RFC-OAS-019** |
 | Turn boundary index in `keeper_runtime_manifest` | `masc` | This RFC §4.2 |
-| Read-time join (oas-events ⨝ manifest) | `masc` | This RFC §4.1, §4.3 |
+| Read-time join (agent-core-events ⨝ manifest) | `masc` | This RFC §4.1, §4.3 |
 | Pivot API + UI | `masc` | This RFC §4.3–4.4 |
 
-Mixing the two would break the SDK Independence Gate that `oas` enforces on Ready (per `~/me/memory/reference_oas_pr_policy_vs_masc.md`). This RFC names no `oas` internal identifiers in `lib/`; it only consumes the public `Telemetry_event` variants as published by `agent_sdk` ≥ 0.194.0 (RFC-OAS-019's target version).
+Mixing the two would blur the emission/consumption boundary. This RFC names no `agent_core` internal identifiers in `lib/`; it only consumes the public `Telemetry_event` variants as published by `agent_core` ≥ 0.194.0 (RFC-OAS-019's target version).
 
 ## 2. Goal
 
 1. **Turn boundary index** — extend `keeper_runtime_manifest` rows with `turn_started_at`, `turn_ended_at`, and `correlation_id_first`. Forward-only; pre-deploy rows stay un-indexed.
-2. **Read-time join** — `telemetry_unified` joins `.masc/oas-events/` rows to manifest turns by time-overlap, with `correlation_id` prefix as a tie-breaker. The result is *stamped* records carrying `keeper_name`, `keeper_turn_id`, `agent_name`, `task_id`, `goal_id` — assembled at the API boundary rather than baked into jsonl.
+2. **Read-time join** — `telemetry_unified` joins `.masc/agent-core-events/` rows to manifest turns by time-overlap, with `correlation_id` prefix as a tie-breaker. The result is *stamped* records carrying `keeper_name`, `keeper_turn_id`, `agent_name`, `task_id`, `goal_id` — assembled at the API boundary rather than baked into jsonl.
 3. **Pivot API** — `GET /api/v1/keeper/:name/timeline` and `GET /api/v1/goal/:id/timeline` return events grouped by `keeper_turn_id`, reusing the existing `tool_agent_timeline` 6-source merger plus the new join.
 4. **Pivot UI** — single `keeper-timeline.ts` component renders the API output as either a vertical collapsible list (turn → events) or a horizontal `vis-timeline` swimlane, switched by a `layoutMode` signal.
 
 ## 3. Non-goals
 
 - Modify `keeper_event_bridge.ml` or anything else on the write side. The relay path remains unchanged.
-- Re-emit, throttle, or deduplicate any upstream `oas:telemetry_event` payload. The bus contents are RFC-OAS-019's responsibility. masc consumes whatever the SDK publishes.
-- Stamp envelope fields directly into `.masc/oas-events/` jsonl. Three rounds of grep verification showed write-time stamping does not fit OAS event-envelope semantics; the read-time join is the structural fix.
+- Re-emit, throttle, or deduplicate any upstream `agent_core:telemetry_event` payload. The bus contents are RFC-OAS-019's responsibility. masc consumes whatever the SDK publishes.
+- Stamp envelope fields directly into `.masc/agent-core-events/` jsonl. Three rounds of grep verification showed write-time stamping does not fit agent_core event-envelope semantics; the read-time join is the structural fix.
 - Rewrite the dashboard timeline framework. `vis-timeline` is already loaded by `fsm-hub-timeline-panels.ts` — reuse, don't replace.
 - Add a new aggregation engine. Extend `tool_agent_timeline` 6-source merger by adding key branches; do not duplicate the merger.
 
@@ -63,20 +63,20 @@ Mixing the two would break the SDK Independence Gate that `oas` enforces on Read
 
 ### 4.1 Envelope reconciliation at read time
 
-After three rounds of grep verification this RFC settled on a *read-time join* rather than write-time stamping. The earlier two drafts of §4.1 (closed PR #15128 RFC-0073: fiber-local binding; this PR's first revision: explicit shared map) both failed against OAS event-envelope semantics:
+After three rounds of grep verification this RFC settled on a *read-time join* rather than write-time stamping. The earlier two drafts of §4.1 (closed PR #15128 RFC-0073: fiber-local binding; this PR's first revision: explicit shared map) both failed against agent_core event-envelope semantics:
 
 | Round | Mechanism | Blocked because |
 |---|---|---|
 | 1 | `Eio.Fiber.with_binding` lookup in `wrap_event` | relay runs in a *background fiber* (`keeper_event_bridge.ml:772` `start_impl`), so keeper-turn-local bindings do not propagate to it |
-| 2 | Shared `Keeper_context` Hashtbl keyed on `oas_run_id`, registered at keeper turn start | OAS `event_envelope.ml:55-57` defaults `correlation_id` and `run_id` to `fresh_id ()` *per event*; agent_sdk does not guarantee a turn-level identifier in published envelopes. A keeper-side `register oas_run_id` has no stable id to register under |
-| 3 (chosen) | Read-time join — no write-side change | works without assuming a propagated id; relies only on data that already exists in `keeper_runtime_manifest` and the OAS-event `ts_unix` |
+| 2 | Shared `Keeper_context` Hashtbl keyed on `oas_run_id`, registered at keeper turn start | agent_core `event_envelope.ml:55-57` defaults `correlation_id` and `run_id` to `fresh_id ()` *per event*; agent_core does not guarantee a turn-level identifier in published envelopes. A keeper-side `register oas_run_id` has no stable id to register under |
+| 3 (chosen) | Read-time join — no write-side change | works without assuming a propagated id; relies only on data that already exists in `keeper_runtime_manifest` and the agent_core-event `ts_unix` |
 
-`lib/keeper/keeper_event_bridge.ml` is **unchanged**. `.masc/oas-events/<YYYY-MM>/<DD>.jsonl` continues to be written with `agent_name`/`task_id`/`turn` null when the OAS publisher did not supply them. Stamping happens at read time, not write time.
+`lib/keeper/keeper_event_bridge.ml` is **unchanged**. `.masc/agent-core-events/<YYYY-MM>/<DD>.jsonl` continues to be written with `agent_name`/`task_id`/`turn` null when the agent_core publisher did not supply them. Stamping happens at read time, not write time.
 
-At read time, `lib/telemetry_unified.ml` and `lib/tool_agent_timeline.ml` join each `.masc/oas-events/` row to the turn that owns it. The join is in two stages:
+At read time, `lib/telemetry_unified.ml` and `lib/tool_agent_timeline.ml` join each `.masc/agent-core-events/` row to the turn that owns it. The join is in two stages:
 
 1. **Time-overlap match** (primary). The row's `ts_unix` is checked against `keeper_runtime_manifest` (§4.2) turn windows `[turn_started_at, turn_ended_at]`. Each row belongs to the unique turn whose window contains its `ts_unix`. If no window contains the row (pre-deploy data, ungoverned bus events), the row is grouped under a marker `"unscoped"` bucket.
-2. **Id-prefix match** (fallback, optional). When multiple turns overlap the same wall-clock instant (concurrent keepers), the manifest also records `correlation_id_first` — the first OAS envelope id observed *during* the turn. Rows whose `correlation_id` shares the same provider-side prefix (an `evt-<pid>-<us_hex>-<n>` pattern, see `oas/lib/event_envelope.ml:24`) can be disambiguated by matching the prefix. This is a refinement; time-overlap alone resolves the common case.
+2. **Id-prefix match** (fallback, optional). When multiple turns overlap the same wall-clock instant (concurrent keepers), the manifest also records `correlation_id_first` — the first agent_core envelope id observed *during* the turn. Rows whose `correlation_id` shares the same provider-side prefix (an `evt-<pid>-<us_hex>-<n>` pattern, see `agent_core/lib/event_envelope.ml:24`) can be disambiguated by matching the prefix. This is a refinement; time-overlap alone resolves the common case.
 
 The result is the same envelope shape an in-jsonl stamp would produce, but assembled at the API boundary:
 
@@ -93,7 +93,7 @@ type stamped_event =
 
 `lib/keeper/keeper_telemetry_consumer.ml` keeps its current "deliberately do not deserialize" stance — it remains a counter-only path.
 
-**Why this works for the operator UX**: the user-visible artifact is the *pivot UI* (§4.4) and the *pivot API* (§4.3). A consumer reading either of those sees stamped events regardless of whether the stamp was baked into jsonl or assembled at the read boundary. Raw `.masc/oas-events/` inspection (`jq` on jsonl) loses keeper context, but that path is for debugging and a one-line `bash` helper can apply the same join when needed.
+**Why this works for the operator UX**: the user-visible artifact is the *pivot UI* (§4.4) and the *pivot API* (§4.3). A consumer reading either of those sees stamped events regardless of whether the stamp was baked into jsonl or assembled at the read boundary. Raw `.masc/agent-core-events/` inspection (`jq` on jsonl) loses keeper context, but that path is for debugging and a one-line `bash` helper can apply the same join when needed.
 
 ### 4.2 Turn index for read-time join
 
@@ -103,7 +103,7 @@ type stamped_event =
 |---|---|---|
 | `turn_started_at` (float, unix s) | `Time_compat.now ()` at turn entry | lower bound of the window |
 | `turn_ended_at` (float, unix s) | `Time_compat.now ()` at turn finalize | upper bound; written on success, abort, or timeout |
-| `correlation_id_first` (string option) | first OAS envelope `correlation_id` observed during the turn (recorded via `keeper_event_bridge` log hook or `Agent_sdk.Event_bus` callback) | disambiguator when multiple keepers overlap |
+| `correlation_id_first` (string option) | first agent_core envelope `correlation_id` observed during the turn (recorded via `keeper_event_bridge` log hook or `Agent_sdk.Event_bus` callback) | disambiguator when multiple keepers overlap |
 | `task_id` / `goal_id` / `agent_name` | already on the manifest row | join's output payload |
 
 No new file family is created — the manifest is the lookup table. This is a deliberate retraction from the second draft, which proposed a parallel `.masc/run-index/` file. The manifest already carries `keeper_name`, `keeper_turn_id`, and `task_id` (per `keeper_runtime_manifest.ml:204` `runtime_manifest_context`); adding two timestamps and one optional id is `~3 LoC` of struct extension plus a write-time `Time_compat.now ()` at the finalize site.
@@ -126,7 +126,7 @@ val read :
 
 `lib/tool_agent_timeline.ml` adds branches:
 
-- when `keeper_name` is set, scan `keeper_runtime_manifest` (§4.2) for matching turns, then merge the 6 sources keyed on those turn ids. `.masc/oas-events/` rows are joined to turns by the time-overlap algorithm in §4.1 (each row's `ts_unix` falls inside a `[turn_started_at, turn_ended_at]` window).
+- when `keeper_name` is set, scan `keeper_runtime_manifest` (§4.2) for matching turns, then merge the 6 sources keyed on those turn ids. `.masc/agent-core-events/` rows are joined to turns by the time-overlap algorithm in §4.1 (each row's `ts_unix` falls inside a `[turn_started_at, turn_ended_at]` window).
 - when `goal_id` is set, scan the manifest for turns with matching `goal_id`, then same merger + time-overlap join.
 - when `group_by = `Turn`, the merger output is post-grouped by `keeper_turn_id` with a chronological header per group. Rows that did not match any turn window go to a `"unscoped"` marker group at the tail.
 
@@ -170,7 +170,7 @@ If RFC-0081 ships and RFC-OAS-019 stalls, masc does *not* take on receive-side a
 
 | RFC | Interaction |
 |---|---|
-| RFC-OAS-019 (oas) | Upstream emission shape. Pivot UI gains clarity once `Streaming_summary` is emitted, but RFC-0081 does not block on RFC-OAS-019 merge. |
+| RFC-OAS-019 (agent_core) | Upstream emission shape. Pivot UI gains clarity once `Streaming_summary` is emitted, but RFC-0081 does not block on RFC-OAS-019 merge. |
 | RFC-0046 (masc) | Same `keeper-detail-state.ts` slot layout. Sync with RFC-0046 author before Phase 2 frontend merge: timeline above/below FsmHub. |
 | RFC-0063 (masc) | Same consumer fiber. RFC-0063's drain-yield contract is preserved without modification — read-time join is on the API path, not the consumer fiber. |
 | RFC-0049 (masc) | Surface telemetry foundation; the manifest-field extension is a foundation-layer additive change. |
@@ -187,8 +187,8 @@ If RFC-0081 ships and RFC-OAS-019 stalls, masc does *not* take on receive-side a
 
 1. `curl localhost:8935/api/v1/keeper/<name>/timeline?since=1h | jq -e '.groups | length > 0'`.
 2. `curl localhost:8935/api/v1/goal/<id>/timeline | jq '.groups[0].events[0].kind'` returns a known event kind.
-3. Time-overlap join: a synthetic `keeper_runtime_manifest` row with a known `[turn_started_at, turn_ended_at]` window plus 5 `.masc/oas-events/` rows whose `ts_unix` fall inside the window produce a `groups` array of length 1 with 5 events under the expected `keeper_turn_id`.
-4. Unscoped bucket: a `.masc/oas-events/` row outside any turn window is returned under the `"unscoped"` marker group, not silently dropped.
+3. Time-overlap join: a synthetic `keeper_runtime_manifest` row with a known `[turn_started_at, turn_ended_at]` window plus 5 `.masc/agent-core-events/` rows whose `ts_unix` fall inside the window produce a `groups` array of length 1 with 5 events under the expected `keeper_turn_id`.
+4. Unscoped bucket: a `.masc/agent-core-events/` row outside any turn window is returned under the `"unscoped"` marker group, not silently dropped.
 
 ### Gate 3 — Pivot UI (Phase 2 frontend)
 
@@ -217,7 +217,7 @@ Multiple keepers can have overlapping `[turn_started_at, turn_ended_at]` windows
 
 ### 8.2 Risk — unscoped bucket from pre-deploy data and ungoverned publishers
 
-Manifest rows written before Phase 1 deploy lack the three new fields and contribute every overlapping bus event to `"unscoped"`. OAS publishers outside any keeper turn (boot-time, background fibers, agent_sdk's own retries) emit bus events with no owning turn at all. Both feed the `"unscoped"` bucket. This is *visible*, not silent — the UI surfaces the bucket with a count.
+Manifest rows written before Phase 1 deploy lack the three new fields and contribute every overlapping bus event to `"unscoped"`. agent_core publishers outside any keeper turn (boot-time, background fibers, agent_core's own retries) emit bus events with no owning turn at all. Both feed the `"unscoped"` bucket. This is *visible*, not silent — the UI surfaces the bucket with a count.
 
 ### 8.3 Risk — manifest row size growth
 
@@ -225,11 +225,11 @@ Three additional fields per row: `turn_started_at: float`, `turn_ended_at: float
 
 ### 8.4 Alternative — fiber-local binding (rejected after grep)
 
-Tried first. The oas-events relay is a *background fiber* (`keeper_event_bridge.ml:783` `Eio.Fiber.fork ~sw` inside `start_impl`) subscribed to the OAS bus. `Eio.Fiber.with_binding` propagates only down the same fiber stack, so the relay never sees a binding installed in a keeper turn fiber.
+Tried first. The agent-core-events relay is a *background fiber* (`keeper_event_bridge.ml:783` `Eio.Fiber.fork ~sw` inside `start_impl`) subscribed to the agent_core bus. `Eio.Fiber.with_binding` propagates only down the same fiber stack, so the relay never sees a binding installed in a keeper turn fiber.
 
 ### 8.5 Alternative — explicit shared map keyed on `oas_run_id` (rejected after grep)
 
-Tried second. OAS `event_envelope.ml:55-57` defaults `correlation_id` and `run_id` to `fresh_id ()` *per event*. agent_sdk does not guarantee a turn-level identifier in published envelopes, so a keeper-side `register oas_run_id` has no stable id to register under. The keeper would have to scan published envelopes after emission to *learn* the id, which is exactly the read-time join — at which point the write-side machinery (Hashtbl + mutex + cleanup fiber) is pure overhead.
+Tried second. agent_core `event_envelope.ml:55-57` defaults `correlation_id` and `run_id` to `fresh_id ()` *per event*. agent_core does not guarantee a turn-level identifier in published envelopes, so a keeper-side `register oas_run_id` has no stable id to register under. The keeper would have to scan published envelopes after emission to *learn* the id, which is exactly the read-time join — at which point the write-side machinery (Hashtbl + mutex + cleanup fiber) is pure overhead.
 
 ### 8.6 Alternative — derive turn by scanning every read without an index
 
@@ -239,13 +239,13 @@ Rejected on cost. Every read query would walk `keeper_runtime_manifest` for the 
 
 Rejected. The current dashboard `useEffect`-free pattern relies on `useQuery` over typed API responses. Pushing grouping into the frontend forces every consumer (CLI, future scripts, ad-hoc queries) to re-implement the grouping logic. Backend grouping is the SSOT.
 
-### 8.8 Alternative — modify agent_sdk to carry a `keeper_owned_run_id` in the envelope
+### 8.8 Alternative — modify agent_core to carry a `keeper_owned_run_id` in the envelope
 
-Deferred. The OAS publishers do not currently surface an external `client_correlation_id` field on `event_envelope.t`. Adding it would let masc pass a stable turn id at `Agent.run` invocation and re-enable write-time stamping. That is a separate OAS-side RFC and a workspace collaboration problem; the read-time join works without it. If the manifest-field approach proves insufficient over time, this alternative is the upgrade path — not the entry path.
+Deferred. The agent_core publishers do not currently surface an external `client_correlation_id` field on `event_envelope.t`. Adding it would let masc pass a stable turn id at `Agent.run` invocation and re-enable write-time stamping. That is a separate agent_core-side RFC and a workspace collaboration problem; the read-time join works without it. If the manifest-field approach proves insufficient over time, this alternative is the upgrade path — not the entry path.
 
 ## 9. Open items
 
 - Sync with RFC-0046 author on `keeper-detail-state.ts` slot layout (timeline above/below FsmHub) before Phase 2b.
 - Decide whether `Timeline` tab in `goal-tree.ts` is the only mount or if a "fleet timeline" view is wanted later (defer).
-- Confirm the wiring point where `keeper_event_bridge` (or `keeper_telemetry_consumer`) can observe the first OAS envelope `correlation_id` per keeper turn so it can be persisted into `keeper_runtime_manifest` at finalize. If neither path can attribute "first correlation_id seen during turn X" without a back-channel from the relay to the keeper, the `correlation_id_first` field is dropped and §4.1 step 2 (id-prefix disambiguation) is dropped with it — time-overlap remains the sole join.
-- If `"unscoped"` bucket size becomes a real operator pain (visible from the pivot API's `unscoped_count`), evaluate §8.8 (agent_sdk envelope extension) as the upgrade path.
+- Confirm the wiring point where `keeper_event_bridge` (or `keeper_telemetry_consumer`) can observe the first agent_core envelope `correlation_id` per keeper turn so it can be persisted into `keeper_runtime_manifest` at finalize. If neither path can attribute "first correlation_id seen during turn X" without a back-channel from the relay to the keeper, the `correlation_id_first` field is dropped and §4.1 step 2 (id-prefix disambiguation) is dropped with it — time-overlap remains the sole join.
+- If `"unscoped"` bucket size becomes a real operator pain (visible from the pivot API's `unscoped_count`), evaluate §8.8 (agent_core envelope extension) as the upgrade path.

--- a/docs/rfc/RFC-0083-dashboard-system-actor-typed.md
+++ b/docs/rfc/RFC-0083-dashboard-system-actor-typed.md
@@ -15,7 +15,7 @@ related: ["RFC-0077"]
 src/types/core.ts:                  KeeperConversationRole = ... | 'system' | ...
 src/types/core.ts:                  KeeperConversationSource = ... | 'system' | ...
 src/types/core.ts:                  post_kind?: 'direct' | 'automation' | 'system'
-src/types/sse.ts:                   kind?: ... | 'system' | 'oas'
+src/types/sse.ts:                   kind?: ... | 'system' | 'agent_core'
 src/live-store.ts:                  LiveFilterKind = 'broadcast' | 'tasks' | 'keepers' | 'system'
 src/live-store.ts:                  new Set(['broadcast', 'tasks', 'keepers', 'system'])
 src/store.ts:                       new Set(['system'])  // boardHiddenCategories

--- a/docs/rfc/RFC-0087-tool-dispatch-path-unification-and-legacy-purge.md
+++ b/docs/rfc/RFC-0087-tool-dispatch-path-unification-and-legacy-purge.md
@@ -39,7 +39,7 @@ RFC-0084 sprint (24 PR) 완료 직후 정밀 audit이 3개 root gap을 식별:
 
 ## §3 비결정 영역 / Out of Scope
 
-- OAS `Agent_sdk.Tool.descriptor` audit — masc 외부 repo
+- agent_core `Agent_sdk.Tool.descriptor` audit — masc 외부 repo
 - `cdal_runtime` sub-library의 `Env_config_core` path caller migration — RFC-OAS-011 격리 보존
 - `auth_diagnostic` / `auth_login` / `config_diagnostic` `normalize_masc_base_path_input` — generic string utility, path SSOT 아님
 - `worker_runtime_docker` `Env_config_core.*_env_key` — string identifier (값 아님)

--- a/docs/rfc/RFC-0095-openai-compat-streaming-wire-up.md
+++ b/docs/rfc/RFC-0095-openai-compat-streaming-wire-up.md
@@ -16,7 +16,7 @@ implementation_prs: [15722,15725]
 ## 1. Summary
 
 masc 의 streaming infrastructure 는 4 layer (llama-server SSE,
-runtime transport `complete_stream`, OAS streaming hooks,
+runtime transport `complete_stream`, agent_core streaming hooks,
 `llm_metric_bridge` legacy metrics backend emission) 모두 코드 수준에 정착돼 있으나,
 **`Custom_openai_compat` runtime binding 을 사용하는 provider
 (예: 본 RFC 작성 시점의 `runpod_mtp`, `local_mtp`) 는 streaming chunk 를
@@ -138,7 +138,7 @@ Phase 0 PR 은 **production behavior 무변경**. trace 코드는 `-tags trace`
   `rg` grep 결과를 부록으로 첨부.
 - **H3 confirmed**: SDK 가 외부 opam dependency 라 직접 patch 불가
   → runtime transport layer 에 *openai_compat 전용 chunk parser shim*
-  을 추가하여 OAS hook chain 에 직접 연결. SDK upgrade path 와 충돌하지
+  을 추가하여 agent_core hook chain 에 직접 연결. SDK upgrade path 와 충돌하지
   않는 *layer-above* fix.
 
 Fix 자체는 **production-impacting**. 다음 안전망 적용:

--- a/docs/rfc/RFC-0097-keeper-sandbox-container-reuse.md
+++ b/docs/rfc/RFC-0097-keeper-sandbox-container-reuse.md
@@ -81,7 +81,7 @@ When the runtime-failure-storm at 2026-05-16 18:08-18:15 fired,
 12+ keepers retried tier rotations in lockstep, each retry spawning
 a fresh container. Host FD usage crossed `kern.maxfiles` (491_520),
 ENFILE returned for `fstatat`/`execve`/`fork`, and unrelated
-subsystems (cost emitter, OAS event bridge, keeper runtime manifest
+subsystems (cost emitter, agent_core event bridge, keeper runtime manifest
 appender, git worktree checks) all failed simultaneously. The system
 took ~10 minutes to drain.
 

--- a/docs/rfc/RFC-0098-typed-jsonrpc-error-envelope.md
+++ b/docs/rfc/RFC-0098-typed-jsonrpc-error-envelope.md
@@ -61,7 +61,7 @@ The two surfaces are coupled at the **boundary contract**: an internal silent fa
 
 - **Re-typing existing persistence writes.** [[RFC-0077]] owns that. This RFC will *consume* `Write_failure_reason.t` once it lands; it does not redefine it.
 - **Counter removal.** [[RFC-0088]] is the umbrella for telemetry-as-fix migration; this RFC adds a new emission shape (typed JSON-RPC error envelope) without removing existing legacy metrics backend counters.
-- **OAS / `agent_sdk` API change.** A separate RFC (forthcoming in the IMPROVE-series, see §9) covers `oas/lib/api_common.ml` `Error_type.t`. RFC-0098 stops at the masc boundary.
+- **agent_core / `agent_core` API change.** A separate RFC (forthcoming in the IMPROVE-series, see §9) covers `agent_core/lib/api_common.ml` `Error_type.t`. RFC-0098 stops at the masc boundary.
 - **`failure_envelope.ml` redesign.** That module is operator-visible **tool-host attachment** (severity / recoverability / operator action) and is orthogonal. The new envelope produced here may *embed* a `failure_envelope.t` in `data.evidence_ref`, but does not replace it.
 - **JSON-RPC error code spec change.** The set of well-known codes (`-32700`, `-32600`, `-32601`, `-32602`, `-32603`) is fixed by the spec. This RFC introduces **server-defined codes in `-32000` to `-32099`** per JSON-RPC 2.0 §5.1 ("reserved for implementation-defined server-errors").
 - **Replacing `with _ -> ()` everywhere.** Some of the 15 sites are legitimate (e.g., best-effort log writes during shutdown). Audit is per-cohort, not bulk rewrite.
@@ -207,7 +207,7 @@ PR-3 onward introduces *new* wire codes (`-32003`, `-32004`, …). Clients that 
 
 ## 7. Open questions
 
-- **Q1**: Should `Mcp_error_code` live in `lib/server/` (transport-only) or `lib/mcp/` (shared with consumer/SDK)? **Decision (default)**: `lib/server/` for PR-1 to bound the change; if/when OAS `Error_type.t` lands, consider promotion to `lib/mcp/` with phantom-type `server | client` discriminator.
+- **Q1**: Should `Mcp_error_code` live in `lib/server/` (transport-only) or `lib/mcp/` (shared with consumer/SDK)? **Decision (default)**: `lib/server/` for PR-1 to bound the change; if/when agent_core `Error_type.t` lands, consider promotion to `lib/mcp/` with phantom-type `server | client` discriminator.
 - **Q2**: Embed `failure_envelope.t` in `data` automatically, or always opt-in? **Decision**: opt-in via `?data:` argument. Auto-embed risks leaking operator-action hints to untrusted clients.
 - **Q3**: Should `Quiet` carry a *required* `surface : string` (which call site declared the skip) for grep traceability? **Open** — PR-1 introduces without `surface`, PR-2/3 considers based on real call sites.
 - **Q4**: `respond_sse_rate_limited` migration timing. **Open** — depends on whether WS-C RFC unifies SSE 429 into `Backpressure_shed`.

--- a/docs/rfc/RFC-0099-session-lifecycle-typed-events.md
+++ b/docs/rfc/RFC-0099-session-lifecycle-typed-events.md
@@ -21,7 +21,7 @@ Out of scope: execution-boundary ownership (defined by the typed source
 contracts in `lib/tool_types/tool_result.mli` and
 `lib/keeper/keeper_gate_replay.mli`), Streamable HTTP migration
 (IMPROVE-02, awaits in-flight #15722/#15725), FD accounting (IMPROVE-03)
-Series: **IMPROVE-05** of the masc + oas improvement series. Sibling RFCs: [[RFC-0098]] (typed envelope, IMPROVE-01).
+Series: **IMPROVE-05** of the masc + agent_core improvement series. Sibling RFCs: [[RFC-0098]] (typed envelope, IMPROVE-01).
 
 ## 1. Problem
 

--- a/docs/rfc/RFC-0100-streamable-http-as-default-transport.md
+++ b/docs/rfc/RFC-0100-streamable-http-as-default-transport.md
@@ -17,8 +17,8 @@ Status: Active (PR-3 merge promotes to Active; PR-5 removal flips to Implemented
 Author: jeong-sik (vincent)
 Date: 2026-05-17
 Scope: HTTP transport surface (`POST /mcp`) — chunked-first default, auto-upgrade to SSE on demand, `Mcp-Session-Id` header, legacy `GET /sse` deprecation window
-Out of scope: provider-side streaming wire-up ([[RFC-0095]], merged), error envelope shape ([[RFC-0098]]), session lifecycle events ([[RFC-0099]] — *consumed* by this RFC for resume/eviction), FD accounting (IMPROVE-03), TTFT measurement ([[RFC-OAS-020]] in oas)
-Series: **IMPROVE-02** of the masc + oas improvement series.
+Out of scope: provider-side streaming wire-up ([[RFC-0095]], merged), error envelope shape ([[RFC-0098]]), session lifecycle events ([[RFC-0099]] — *consumed* by this RFC for resume/eviction), FD accounting (IMPROVE-03), TTFT measurement ([[RFC-OAS-020]] in agent_core)
+Series: **IMPROVE-02** of the masc + agent_core improvement series.
 
 ## 1. Problem
 
@@ -149,7 +149,7 @@ PR-2 is **wire-shape-changing** (chunked framing replaces full-body); but the *b
 ## 7. Open questions
 
 - **Q1**: Should the 50 ms first-byte budget be configurable via env knob? **Decision (default)**: no — it's a spec/middlebox requirement, not a tunable. If a use case appears, revisit.
-- **Q2**: What's the exact upgrade dispatch signal? Tool catalog metadata (`streaming: true`)? Or runtime-decided (first chunk-emit from the OAS path)? **Decision (PR-3)**: tool catalog metadata, surfaced through `Server_mcp_streaming_tools.is_streaming_capable`. The registry is a hand-curated SSOT inside `lib/server/`; adding or removing a tool name flips its POST response between SSE framing and chunked JSON. The runtime-decided alternative was rejected because the first-chunk-emit signal arrives after the response shape is already framed, so it would require speculative framing or a second connection.
+- **Q2**: What's the exact upgrade dispatch signal? Tool catalog metadata (`streaming: true`)? Or runtime-decided (first chunk-emit from the agent_core path)? **Decision (PR-3)**: tool catalog metadata, surfaced through `Server_mcp_streaming_tools.is_streaming_capable`. The registry is a hand-curated SSOT inside `lib/server/`; adding or removing a tool name flips its POST response between SSE framing and chunked JSON. The runtime-decided alternative was rejected because the first-chunk-emit signal arrives after the response shape is already framed, so it would require speculative framing or a second connection.
 - **Q3**: Should server reject `POST /mcp` with `Mcp-Session-Id: <unknown>` (force re-open) or silently mint a new session? **Decision (PR-3)**: reject with `404 Not Found` + new `Mcp-Session-Id` header. Implemented as `validate_session_known` in `Server_mcp_transport_http_protocol`; the handshake set (`initialize` / `ping` / `notifications/initialized`) is exempt because those are the methods that legitimately establish a known session.
 
 ## 8. Acceptance
@@ -169,4 +169,4 @@ PR-2 is **wire-shape-changing** (chunked framing replaces full-body); but the *b
 - [[RFC-0098]] — Typed JSON-RPC error envelope (response edge, IMPROVE-01)
 - [[RFC-0099]] — Session lifecycle typed events (transport edge, IMPROVE-05)
 - [[RFC-0095]] — Provider-D-compat provider streaming wire-up (provider edge, in main)
-- [[RFC-OAS-020]] — TTFT instrumentation in oas (IMPROVE-04)
+- [[RFC-OAS-020]] — TTFT instrumentation in agent_core (IMPROVE-04)

--- a/docs/rfc/RFC-0107-outbound-http-stack-consolidation.md
+++ b/docs/rfc/RFC-0107-outbound-http-stack-consolidation.md
@@ -31,10 +31,10 @@ Prior Art 는 `~/me/knowledge/research/2026-05-17-piaf-ocsigen-eio-fd-prior-art.
 - **결과**: 매 호출 `connection: close` 강제 → keep-alive 0건 → runtime 마다 N socket burst.
 - **상위 issue**: [`ocaml-cohttp#85`](https://github.com/mirage/ocaml-cohttp/issues/85) "Support HTTP Keep-Alive" — 2014-01 개설, Closed (milestone "1.0 Stable API"), 결과적으로 abandoned/out-of-scope. masc 의 워크어라운드는 그 gap 의 lower bound.
 
-### 1.2 Connection pool 부재 — masc + oas 양쪽
+### 1.2 Connection pool 부재 — masc + agent_core 양쪽
 
 - **masc**: `lib/masc_http_client/masc_http_client.ml` 가 매 호출 fresh `Eio.Switch.run` → `Client.make` → 1 request → switch release → tracked socket close.
-- **oas**: `oas/lib/llm_provider/http_client.ml:380-410` 의 `get_sync` / `post_sync` 가 동일 패턴.
+- **agent_core**: `agent_core/lib/llm_provider/http_client.ml:380-410` 의 `get_sync` / `post_sync` 가 동일 패턴.
 - **RFC-0100 (Streamable HTTP)** 가 명시적으로 connection pooling 을 *out-of-scope* 로 명시 (line 20).
 - **Runtime 영향**: 12+ keeper 가 runtime 재시도 안에서 매 호출 새 TCP+TLS 를 염. runtime 1 turn 에 5~12 fd burst (provider probe + runtime attempt + tool call HTTP).
 
@@ -156,7 +156,7 @@ sandbox_exec
 
 ## 4. Implementation phases
 
-본 RFC 의 phase 구성은 plan `~/me/planning/claude-plans/me-workspace-yousleepwhen-masc-oas-vast-moonbeam.md` 와 동기화. 요약:
+본 RFC 의 phase 구성은 plan `~/me/planning/claude-plans/me-workspace-yousleepwhen-masc-agent_core-vast-moonbeam.md` 와 동기화. 요약:
 
 | Phase | Scope | Critical path? |
 |---|---|---|

--- a/docs/rfc/RFC-0107-phase-d-pool-design.md
+++ b/docs/rfc/RFC-0107-phase-d-pool-design.md
@@ -42,7 +42,7 @@ callsite 변경이 없도록 한다.
 | `lib/graphql_client.ml:181` | `post_sync` |
 | `lib/opentelemetry_client_cohttp_eio.ml:147` | `make_closing_client` |
 
-**합계: 13 callsites** in masc. (OAS 별도 repo 는 본 Phase 범위 외.)
+**합계: 13 callsites** in masc. (agent_core 는 본 Phase 범위 외.)
 
 ## 2. Current anti-pattern (per call, 모든 sync 호출자 동일)
 
@@ -239,7 +239,7 @@ Phase D step 2 가 그 결정 위에 구현.
 | per-host TLS context cache | piaf 가 이미 함 (Phase B 확인) — cohttp 직접 구현 시 우리가 더해야 함 |
 | HTTP/2 지원 | **out-of-scope** (RFC §2 non-goal). piaf 는 무료로 받지만 callsite 가 h1 가정 |
 | max_idle_per_host = 8 정당화 | RFC-0101 §2 nofile=10240 cap, 256 server slots × 8 idle = 2048, safe |
-| OAS repo 마이그레이션 | **out-of-scope of Phase D**. masc 13 callsites 만. OAS 는 동등 interface 후속 PR |
+| agent_core 마이그레이션 | **out-of-scope of Phase D**. masc 13 callsites 만. agent_core 는 동등 interface 후속 PR |
 
 ## 6. 검증
 

--- a/docs/rfc/RFC-0108-atomic-jsonl-append.md
+++ b/docs/rfc/RFC-0108-atomic-jsonl-append.md
@@ -29,7 +29,7 @@ implementation_prs: [15906, 15922, 15926, 15928, 15936, 15949]
 | 카테고리 | malformed 라인 | 손상 패턴 |
 |---|---|---|
 | `logs/system_log_YYYY-MM-DD.jsonl` | 2 | `}{` concat (두 JSON 이 newline 없이 한 라인에) |
-| `oas-events/YYYY-MM/DD.jsonl` | 38 | `}{` concat + 라인 중간에 다른 record 헤더 삽입 |
+| `agent_core-events/YYYY-MM/DD.jsonl` | 38 | `}{` concat + 라인 중간에 다른 record 헤더 삽입 |
 | `trajectories/<keeper>/trace-*.jsonl` | 89 | utf-8 multibyte 절단 — record 끝의 한글 byte가 다음 라인으로 흘러감 |
 | `keepers/<keeper>/reaction-ledger/YYYY-MM/DD.jsonl` | 114 | utf-8 multibyte 절단 — 같은 패턴, 2026-05-17 하루에 집중 |
 | (총) | **243** (live) + 136 (legacy _backups) | |
@@ -48,7 +48,7 @@ implementation_prs: [15906, 15922, 15926, 15928, 15936, 15949]
 |---|---|---|---|
 | 0 (없음) | `Ring.write_to_sink` (`lib/masc_log/log.ml:286-294`) | `output_string + output_char + flush` 3 syscall, mutex 0 | `}{` concat 직발 |
 | 1 (Stdlib) | `Fs_compat.append_file_unix` (`lib/fs_compat/fs_compat.ml:152-214`) → `trajectories` | `Stdlib.Mutex` + `Append_fd_cache` LRU | utf-8 절단 발생 |
-| 2 (Eio) | `Dated_jsonl.append` (`lib/dated_jsonl/dated_jsonl.ml:256-272`) → `oas-events` / `reaction-ledger` | `Eio.Mutex.use_ro` per base_dir + 내부 `Fs_compat.append_jsonl` | utf-8 절단 발생 |
+| 2 (Eio) | `Dated_jsonl.append` (`lib/dated_jsonl/dated_jsonl.ml:256-272`) → `agent_core-events` / `reaction-ledger` | `Eio.Mutex.use_ro` per base_dir + 내부 `Fs_compat.append_jsonl` | utf-8 절단 발생 |
 
 핵심 인사이트: **Tier-1 도 Tier-2 도 손상이 발생했다**. 이는 다음을 의미한다:
 
@@ -194,7 +194,7 @@ val close : t -> unit
 
 - PR-3 머지 후: `<base-path>/.masc/logs/system_log_*.jsonl`
 - PR-4 머지 후: `<base-path>/.masc/trajectories/`
-- PR-5 머지 후: `<base-path>/.masc/oas-events/` + `<base-path>/.masc/keepers/*/reaction-ledger/`
+- PR-5 머지 후: `<base-path>/.masc/agent_core-events/` + `<base-path>/.masc/keepers/*/reaction-ledger/`
 
 한 번이라도 malformed ≥ 1 재발견 시 즉시 §3.2 보장 모델 회귀.
 

--- a/docs/rfc/RFC-0111-goal-mint-atomicity-uniqueness-invariant.md
+++ b/docs/rfc/RFC-0111-goal-mint-atomicity-uniqueness-invariant.md
@@ -138,7 +138,7 @@ P3 가 핵심 — concurrent mint 의 race window 가 진짜 닫힘. P5 는 cap 
 ## §5 Non-goals
 
 - **외부 protocol** (예: MCP `masc_goal_upsert` 의 wire schema 변경) — 본 RFC 는 *내부 mint API* 만. wire schema 는 별도.
-- **Goal-Keeper relation lifecycle** (예: keeper down 시 goal 처리) — RFC-OAS 또는 별도.
+- **Goal-Keeper relation lifecycle** (예: keeper down 시 goal 처리) — RFC-agent_core 또는 별도.
 - **Janitor 의 *idle* sweep 정책 자체** — Cap 의 의미 분리만, 정책 변경 아님.
 
 ## §6 Risk & rollback

--- a/docs/rfc/RFC-0126-silent-fallback-discipline.md
+++ b/docs/rfc/RFC-0126-silent-fallback-discipline.md
@@ -49,13 +49,13 @@ introducing PR, treat as part of Phase 1 cluster).
   Phase 2b accuracy (AST surface more reliable than grep).
 - **Phase 4** — CI hard-fail. Final closure step.
 
-### Pending — Phase 1 OAS upstream
+### Pending — Phase 1 agent_core
 
-§6.1.b' notes that labels **C2 / C3 / V16** require an OAS upstream
+§6.1.b' notes that labels **C2 / C3 / V16** require an agent_core change
 PR before masc-side adaptation can land. RFC-0126 author flagged a
-sibling OAS RFC: `RFC-OAS-XYZ: Event_bus per-subscriber backpressure
+sibling agent_core RFC: `RFC-agent_core-XYZ: Event_bus per-subscriber backpressure
 override + Memory.long_term_backend Result.t boundary`. Not yet
-filed in OAS repo.
+filed against agent_core.
 
 ### Related RFC
 
@@ -212,23 +212,23 @@ audit doc `.tmp/memory-compacting-analysis.html` 가 작성 시점(01:22) 에 �
 | V | 위치 | 클러스터 매핑 | RFC §5 권고 |
 |---|---|---|---|
 | V15 (LOW) | `memory_jsonl.ml:69-95 parse_line` | A (wildcard parse drop) + E (warn 있고 counter 부재) | §5.1 OPTION A — closed-vocab `{empty_line / no_key / not_assoc / json_parse_error}` reason label, counter 추가. **iter 48 (PR pending) 흡수.** |
-| V16 (LOW) | `memory_jsonl.ml:120-219 long_term_backend` | B (Result.t asymmetry) | **OAS upstream 의존** — `Agent_sdk.Memory.long_term_backend` 타입이 OAS 정의. masc 단독 fix 불가. OAS-side sibling RFC 후보. |
+| V16 (LOW) | `memory_jsonl.ml:120-219 long_term_backend` | B (Result.t asymmetry) | **agent_core 의존** — `Agent_sdk.Memory.long_term_backend` 타입이 agent_core 정의. masc 단독 fix 불가. agent_core-side sibling RFC 후보. |
 | V09 (MED) | `keeper_compact_policy.ml compaction_decision` | H (type API drift) — *spiral 외* | RFC sub-issue: `Skipped_no_checkpoint` 를 wrapper variant 로 분리 또는 policy 내부 생성. invasive, 별도 RFC 후보. |
 
 V09 는 본 RFC scope 밖 (silent fallback 아니라 type API drift). 별도 RFC issue 후보.
 
 #### 6.1.b' Audit Phase 0/1 masc-side completeness (iter 49 closure)
 
-`oas-internal-audit.html` 의 C1-C3 label, 그리고 V16, 위 표의 OAS upstream 의존 항목들을 모두 묶으면:
+`agent_core-internal-audit.html` 의 C1-C3 label, 그리고 V16, 위 표의 agent_core 의존 항목들을 모두 묶으면:
 
 | label | 위치 | masc Phase 0/1 가능? | upstream block |
 |---|---|---|---|
 | C1 (pair-repair counter) | masc-side `keeper_compact_audit.ml` | 가능 — iter 24 PR #15792 머지 완료 | — |
 | C2 (Event_bus subscribe per-subscriber policy/buffer) | masc-side `runtime_event_bus.ml:58-59` | **불가** | `Agent_sdk.Event_bus.subscribe` 시그니처가 per-subscriber `?policy/?buffer_size` 미노출 |
-| C3 (retrieve contract typed) | masc-side `memory_jsonl.ml` 답습 | **불가** | `Agent_sdk.Memory.long_term_backend.retrieve : key → Yojson option` — `Result.t` 도입은 OAS 단에서 |
+| C3 (retrieve contract typed) | masc-side `memory_jsonl.ml` 답습 | **불가** | `Agent_sdk.Memory.long_term_backend.retrieve : key → Yojson option` — `Result.t` 도입은 agent_core 단에서 |
 | V16 (retrieve/query Result.t) | masc-side `memory_jsonl.ml` 답습 | **불가** | C3 와 동일 upstream contract |
 
-→ audit Phase 0/1 의 masc-side fix-able 라벨 (C1, V01-V15, V17) 은 **모두 처리 완료** (또는 §6.1.b 의 V09 같이 별도 RFC 후보). 남은 C2/C3/V16 은 OAS upstream PR + masc 후속 어댑테이션 2-step 시퀀스 필요. OAS-side sibling RFC 권고 (제목 예시: "RFC-OAS-XYZ: Event_bus per-subscriber backpressure override + Memory.long_term_backend Result.t boundary").
+→ audit Phase 0/1 의 masc-side fix-able 라벨 (C1, V01-V15, V17) 은 **모두 처리 완료** (또는 §6.1.b 의 V09 같이 별도 RFC 후보). 남은 C2/C3/V16 은 agent_core PR + masc 후속 어댑테이션 2-step 시퀀스 필요. agent_core-side sibling RFC 권고 (제목 예시: "RFC-agent_core-XYZ: Event_bus per-subscriber backpressure override + Memory.long_term_backend Result.t boundary").
 
 #### 6.1.c Non-spiral observability extension (cluster G)
 

--- a/docs/rfc/RFC-0129-http-idle-timeout-and-streaming-progress.md
+++ b/docs/rfc/RFC-0129-http-idle-timeout-and-streaming-progress.md
@@ -52,15 +52,15 @@ audit-sweep RFC to land directly at Implemented (after RFC-0132
 ## §0 Diagnosis reversal (2026-05-18)
 
 A first draft of this RFC framed the fix as a cross-repo change
-("OAS HTTP body lacks timeout, add idle-timeout to OAS"). Evidence
+("agent_core HTTP body lacks timeout, add idle-timeout to agent_core"). Evidence
 collected during PR-1 implementation contradicted that premise:
 
 | layer | claim in first draft | actual state on 2026-05-18 |
 |---|---|---|
-| `oas/lib/llm_provider/http_client.ml` `post_sync` body read | unbounded `take_all` | wrapped in `Eio.Time.with_timeout_exn` via `body_timeout_s` since OAS 0.195.0 (`complete.ml:656-686`) |
-| `oas/lib/llm_provider/http_client.ml` SSE / NDJSON | unbounded line read | per-line `idle_timeout` via `Eio.Time.with_timeout_exn` (`http_client.mli:204-243`) |
-| masc ↔ OAS cumulative per-attempt cap | not wired | no longer forwarded for active streaming: `per_provider_timeout_s` does not populate `Runtime_agent_context.max_execution_time_s`; streaming liveness is progress-based |
-| masc ↔ OAS per-line idle cap | not wired | wired: `Agent_sdk.Builder.with_stream_idle_timeout` (`runtime_agent_context.ml:174`), default `stream_idle_timeout_sec = 120s` (`keeper_runtime_config.mli:75`) |
+| `agent_core/lib/llm_provider/http_client.ml` `post_sync` body read | unbounded `take_all` | wrapped in `Eio.Time.with_timeout_exn` via `body_timeout_s` since agent_core 0.195.0 (`complete.ml:656-686`) |
+| `agent_core/lib/llm_provider/http_client.ml` SSE / NDJSON | unbounded line read | per-line `idle_timeout` via `Eio.Time.with_timeout_exn` (`http_client.mli:204-243`) |
+| masc ↔ agent_core cumulative per-attempt cap | not wired | no longer forwarded for active streaming: `per_provider_timeout_s` does not populate `Runtime_agent_context.max_execution_time_s`; streaming liveness is progress-based |
+| masc ↔ agent_core per-line idle cap | not wired | wired: `Agent_sdk.Builder.with_stream_idle_timeout` (`runtime_agent_context.ml:174`), default `stream_idle_timeout_sec = 120s` (`keeper_runtime_config.mli:75`) |
 
 The premise `keeper_turn_runtime_budget.ml:173-174` was written
 against is no longer true. Both caps the band-aid was protecting
@@ -102,7 +102,7 @@ and route through the same cap chain.
 self-incriminating comments:
 
 ```
-/* Root cause is OAS HTTP body lacking timeout
+/* Root cause is agent_core HTTP body lacking timeout
    (`http_client.ml take_all`); this is a band-aid until that lands. */
 
 /* Profiles with a declared fallback must not spend the whole turn on
@@ -112,10 +112,10 @@ self-incriminating comments:
 
 Both comments **predate**:
 
-1. **OAS 0.195.0** — added `body_timeout_s` on `post_sync`
+1. **agent_core 0.195.0** — added `body_timeout_s` on `post_sync`
    (`lib/llm_provider/complete.ml:656-686`). The non-streaming HTTP
    body read is now wall-clock-bounded.
-2. **OAS streaming `?idle_timeout`** — `read_sse`/`read_ndjson`
+2. **agent_core streaming `?idle_timeout`** — `read_sse`/`read_ndjson`
    raise `Eio.Time.Timeout` if no line arrives within
    `idle_timeout` seconds. The deadline resets on each line.
 3. **masc wiring**:
@@ -125,7 +125,7 @@ Both comments **predate**:
    from `per_provider_timeout_s`.
 
 Given these three pieces have all landed, the reserve_fraction is
-no longer protecting against "OAS can hang the body read". It is
+no longer protecting against "agent_core can hang the body read". It is
 only producing a smaller per-attempt budget than necessary, which
 deterministically truncates healthy slow streams at 307.5s.
 
@@ -134,7 +134,7 @@ Receipt-side scenarios in light of the corrected diagnosis:
 | scenario | what the system sees today | what is true |
 |---|---|---|
 | **A.** provider streaming for 280s, would have finished at 320s | timeout at 307.5s | output exists but is discarded; runtime rotates and pays double cost |
-| **B.** provider produces zero bytes after 280s (real hang) | also timeout at 307.5s | OAS `stream_idle_timeout_s=120s` would have caught this at 120s already, but `with_max_execution_time` fires first because reserve_fraction halved it down to 292.5s |
+| **B.** provider produces zero bytes after 280s (real hang) | also timeout at 307.5s | agent_core `stream_idle_timeout_s=120s` would have caught this at 120s already, but `with_max_execution_time` fires first because reserve_fraction halved it down to 292.5s |
 | **C.** provider finishes at 290s | success | the only path the band-aid does not corrupt |
 
 Across the 14-event sample on 2026-05-18 every observed case is **A**.
@@ -149,7 +149,7 @@ A single, narrow change scope:
 2. **Update** the stale comment block to reflect the cap chain that
    now exists end-to-end.
 3. **Keep** the streaming-progress wiring: `with_stream_idle_timeout`
-   continues to bound inter-line silence; OAS `body_timeout_s` is
+   continues to bound inter-line silence; agent_core `body_timeout_s` is
    sync-only and remains opt-in for explicit non-streaming body ceilings.
 
 Two related-but-non-gating tracks are explicitly separated below
@@ -181,15 +181,15 @@ No new flag, no new counter, no cooldown, no transitional baseline.
 
 Independent infrastructure work in `lib/masc_http_client/pool.ml`
 (piaf-based) to give the masc Pool the same idle-timeout +
-body-progress shape that OAS already has at its HTTP layer.
+body-progress shape that agent_core already has at its HTTP layer.
 
 Scope and rationale:
 
 - Pool callers today: `lib/server/server_dashboard_http_link_preview.ml`
-  and `lib/local/worker_container_types.ml`. Neither is an OAS LLM
+  and `lib/local/worker_container_types.ml`. Neither is an agent_core LLM
   call. Pool fixes do **not** affect runtime attempt timeouts.
 - Value of the PR: correct generic API at the Pool layer that
-  mirrors OAS's existing idle-timeout pattern, with unit tests for
+  mirrors agent_core's existing idle-timeout pattern, with unit tests for
   steady stream / silent-from-start / mid-stream silence.
 - Not gating the fleet fix. PR-2 lands independently of PR-1.
 
@@ -201,8 +201,8 @@ as part of the same RFC. It is now out of scope because:
 
 - The fleet 307.5s cluster does not require body-progress to fix —
   it requires the reserve to go away.
-- Sourcing body-progress from the OAS layer to masc receipt
-  schema requires an agent_sdk surface extension, which deserves
+- Sourcing body-progress from the agent_core layer to masc receipt
+  schema requires an agent_core surface extension, which deserves
   its own RFC (provider HTTP boundary cross-cut).
 - Deferring is consistent with the workaround-rejection bar's
   "make X visible" anti-pattern — if we made it visible without
@@ -252,7 +252,7 @@ Expected:
 - Streaming UI / token-by-token rendering.
 - Replacing `Piaf` in the Pool. PR-1's idle-timeout API fits inside
   Piaf's chunk-iteration; no library swap.
-- Modifying OAS. The 0.195.0+ caps are already correct.
+- Modifying agent_core. The 0.195.0+ caps are already correct.
 
 ## §8 Evidence
 
@@ -263,9 +263,9 @@ Expected:
 - Self-admitting comment at
   `lib/keeper/keeper_turn_runtime_budget.ml:173-174` (replaced by
   PR-2).
-- OAS `body_timeout_s` on the non-streaming `Complete.complete` path since
+- agent_core `body_timeout_s` on the non-streaming `Complete.complete` path since
   0.195.0, `complete.ml:656-686`.
-- OAS streaming `idle_timeout` at `http_client.mli:204-243`; streaming has
+- agent_core streaming `idle_timeout` at `http_client.mli:204-243`; streaming has
   no total body-duration cap.
 - masc `stream_idle_timeout_s` wiring at
   `runtime_agent_context.ml:174-180`.
@@ -282,5 +282,5 @@ Expected:
    happens; if §6 surfaces post-PR-2 fallback-starvation cases,
    revisit with a *separate* RFC rather than reintroducing reserve.
 3. Should `body_progress` follow up under a new RFC, or fold into
-   RFC-0132 (agent_sdk surface extensions)? Pending RFC backlog
+   RFC-0132 (agent_core surface extensions)? Pending RFC backlog
    triage.

--- a/docs/rfc/RFC-0132-redaction-ssot.md
+++ b/docs/rfc/RFC-0132-redaction-ssot.md
@@ -71,7 +71,7 @@ Related RFCs:
 
 ## 1. Problem statement
 
-The literal string `"runtime"` is used today as a **boundary redaction label** for aggregate surfaces (dashboard SSE, OAS bridge, keeper telemetry) where the *real* provider/model identity is intentionally suppressed. Exact per-turn evidence such as execution receipts and turn records is outside this label policy. The label is **scattered as inline literals or local module-level constants** across `lib/runtime/` and `lib/keeper/` with no compiler-enforced SSOT.
+The literal string `"runtime"` is used today as a **boundary redaction label** for aggregate surfaces (dashboard SSE, agent_core bridge, keeper telemetry) where the *real* provider/model identity is intentionally suppressed. Exact per-turn evidence such as execution receipts and turn records is outside this label policy. The label is **scattered as inline literals or local module-level constants** across `lib/runtime/` and `lib/keeper/` with no compiler-enforced SSOT.
 
 Direct measurement on `origin/main` (commit `aceefd562a`, 2026-05-19):
 
@@ -162,7 +162,7 @@ Introduce a private-type SSOT module that owns the redaction label vocabulary an
 ```ocaml
 (** Boundary redaction labels — SSOT for aggregate surface label vocabulary.
 
-    Aggregate surfaces (dashboard SSE, OAS bridge, keeper telemetry exposed to
+    Aggregate surfaces (dashboard SSE, agent_core bridge, keeper telemetry exposed to
     the operator UI) intentionally redact the real provider/model identity
     behind a fixed label. This module is the only place that holds the label
     string. Emit sites governed by that aggregate contract must route through
@@ -279,7 +279,7 @@ Once PR-3 is merged, any future PR that adds an inline `"runtime"` literal at an
 |---|---|
 | PR-1 | Alcotest: `runtime_provider_label \|> to_string = "runtime"` and `runtime_model_label \|> to_string = "runtime"`. Compile-time: attempting `let x : Boundary_redaction.public_label = "foo"` outside the module fails the build. |
 | 2026-07-06 extension | Alcotest: `unknown_model_label \|> to_string = "unknown_model"` and the value is distinct from `runtime_model_label`. Governance dashboard model classification and keeper status model labels route missing model evidence through this typed label instead of a local string. |
-| PR-2 | For each of the 23 sites: dashboard SSE / OAS bridge / keeper telemetry output byte-equality regression test. The boundary-emit byte stream must be identical to pre-codemod main. Regression count target: 0. |
+| PR-2 | For each of the 23 sites: dashboard SSE / agent_core bridge / keeper telemetry output byte-equality regression test. The boundary-emit byte stream must be identical to pre-codemod main. Regression count target: 0. |
 | PR-3 | Adding a test fixture that places `let _ = "runtime"` at `lib/runtime/foo.ml` causes a build failure with the lint rule error message. Removing the fixture restores the build. |
 | Overall | After PR-3 merge, `rg -n '"runtime"' lib/runtime/ lib/keeper/` should return only: (a) `boundary_redaction.ml` source, (b) `keeper_status_runtime.ml:219` allow-listed heuristic, (c) `.mli` doc comments. Total expected hits: ≤ 4. |
 

--- a/docs/rfc/RFC-0134-persistence-read-drop-root-fix.md
+++ b/docs/rfc/RFC-0134-persistence-read-drop-root-fix.md
@@ -16,7 +16,7 @@ Related: RFC-0044 (typed reason, partial fix), RFC-0088 (counter-as-fix
 umbrella), RFC-0097 (FD pressure / container reuse), RFC-0107
 (`Jsonl_atomic`, atomic-write SSOT)
 Plan SSOT: Error-Warn Reduction Goal §counter-as-fix
-(`memory/masc-oas-log-reduction-goal-2026-05-18.html` progress report)
+(`memory/masc-agent_core-log-reduction-goal-2026-05-18.html` progress report)
 
 ## 1. Problem
 

--- a/docs/rfc/RFC-0136-keeper-unified-turn-decomposition.md
+++ b/docs/rfc/RFC-0136-keeper-unified-turn-decomposition.md
@@ -21,7 +21,7 @@ implementation_prs: [16604, 16624, 16643]
 
 ### 1.1 현재 상태
 
-`lib/keeper/keeper_unified_turn.ml` 은 `OAS Agent.run()` 경유 keeper turn 의 *단일 진입점* (3-path dispatcher 통합 후 RFC-? 산물). Public entrypoint 는 `run_keeper_cycle` 이다.
+`lib/keeper/keeper_unified_turn.ml` 은 `agent_core Agent.run()` 경유 keeper turn 의 *단일 진입점* (3-path dispatcher 통합 후 RFC-? 산물). Public entrypoint 는 `run_keeper_cycle` 이다.
 
 interface (`.mli`, 319 LOC) 의 30+ surface 는 모두 *5 sub-module 가 정의* 하고 `keeper_unified_turn.ml` 이 `include` 로 re-export:
 
@@ -63,7 +63,7 @@ include Keeper_unified_turn_phase_plan   (*  84 LOC *)
 | Setup | L77-129 | 53 | nested let bindings |
 | **Phase Gate** | L130-242 | 113 | 3 typed outcomes (supervisor_stop / non_executable_phase / registry_missing → Ok meta or Error) |
 | Runtime resolution | L243-? | TBD | sets effective_runtime and timeout_budget |
-| Retry loop | ?-1900 | TBD | OAS Agent.run + runtime rotation + error classify |
+| Retry loop | ?-1900 | TBD | agent_core Agent.run + runtime rotation + error classify |
 | Success/Failure dispatch | L1904-1940 | 37 | already extracted to `Keeper_unified_turn_(success|failure)` |
 
 Phase Gate 의 3 outcome 은 *implicit early-exit* — caller (외부 모듈) 가 *outcome 별 처리* 를 *볼 수 없다*. *Alexis King — Parse, don't validate* 의 정확한 위반: validation 결과가 *타입에 표현되지 않음*.

--- a/docs/rfc/RFC-0145-permissive-silent-fallback-elimination.md
+++ b/docs/rfc/RFC-0145-permissive-silent-fallback-elimination.md
@@ -164,7 +164,7 @@ error is the operator-visible signal.
   audit findings).
 - Yojson protocol-level enforcement at the write side (RFC-0107 +
   RFC-0109 family).
-- Removing catch-all `_ ->` arms in non-parse code (RFC-OAS Cluster C
+- Removing catch-all `_ ->` arms in non-parse code (RFC-agent_core Cluster C
   candidate).
 
 ## 8a. Complementary wildcard-narrowing sweep (2026-05-22)

--- a/docs/rfc/RFC-0283-fusion-judge-of-judges.md
+++ b/docs/rfc/RFC-0283-fusion-judge-of-judges.md
@@ -10,7 +10,7 @@ status: Implemented
 - Created: 2026-06-23
 - Parent: RFC-0252 (fusion-panel-judge-deliberation) — §9(preset)를 개정. 위상 선택은 "Fusion as a Tool" 슬라이스 계열(refine/conditional)의 연장.
 - Scope: `lib/fusion_core/` (preset/config/types/policy), `lib/fusion/` (judge/orchestrator), `lib/keeper/keeper_tool_descriptor.ml` (스키마), `config/runtime.toml` (`[fusion.presets.*]`)
-- Boundary: OAS 0줄 변경. sink 계약 무변경. 기존 단일 `judge` 필드 **유지**(파괴 변경 없음). `simple`/`refine`/`conditional` 위상 동작 불변.
+- Boundary: agent_core 0줄 변경. sink 계약 무변경. 기존 단일 `judge` 필드 **유지**(파괴 변경 없음). `simple`/`refine`/`conditional` 위상 동작 불변.
 - Concurrency update (2026-07-17): retired `max_concurrent_judges` never
   controlled execution. Configured judge identities are the exact fan-out set;
   MASC-owned durable host draining is tracked separately in #25032.
@@ -142,7 +142,7 @@ val run_meta : (* run/run_refine과 동형, ~priors 추가 *) ...
 | preset에 `judges` 추가, Validated_preset 검증 | 기존 `judge`/`judge_system_prompt` |
 | `[fusion].staged_judge_group_size` config + staged grouping validation | panel preset grammar |
 | fusion_topology에 `Judge_of_judges`, `Staged_judge_of_judges` | simple/refine/conditional 동작 |
-| Fusion_judge: compose_meta_prompt/run_meta | sink 계약, OAS |
+| Fusion_judge: compose_meta_prompt/run_meta | sink 계약, agent_core |
 | orchestrator JOJ 분기 + 1차 병렬 fan-out | panel fan-out |
 
 ## 4. 테스트

--- a/docs/rfc/RFC-0315-wake-turn-self-description.md
+++ b/docs/rfc/RFC-0315-wake-turn-self-description.md
@@ -22,7 +22,7 @@ stimuli arrived without inventing a second state protocol.
 - Goal and Task APIs own objectives, assignment, priority, and status.
 - Board, connector, and reaction ledgers own incoming stimuli and delivery
   evidence.
-- OAS checkpoints own replayable typed message/tool/reasoning blocks.
+- agent_core checkpoints own replayable typed message/tool/reasoning blocks.
 - Memory APIs own durable notes. Transcript prose is context only.
 
 The complete boundary is
@@ -57,4 +57,4 @@ remain explicit lifecycle outcomes for genuine failure or operator action.
 - `test_keeper_event_queue.ml` and reaction-ledger tests pin assignment edges.
 - Keeper state-machine tests pin lane lifecycle transitions independently of
   transcript content.
-- Replay-checkpoint tests pin typed OAS message/tool/reasoning preservation.
+- Replay-checkpoint tests pin typed agent_core message/tool/reasoning preservation.

--- a/docs/rfc/RFC-0358-autonomous-turn-kind-on-turn-record.md
+++ b/docs/rfc/RFC-0358-autonomous-turn-kind-on-turn-record.md
@@ -17,13 +17,13 @@ related: ["0351", "0233"]
 | `turn_kind` | `Autonomous | Direct` | 자율/직접 진입점 |
 | `agent_name` | `string` | 실행에 사용한 keeper metadata |
 | `generation` | `int` | 실행 generation |
-| `raw_trace_run_ref` | exact OAS run ref option | 완료된 provider dispatch result |
+| `raw_trace_run_ref` | exact agent_core run ref option | 완료된 provider dispatch result |
 
 `raw_trace_run_ref`는 `worker_run_id`, `path`, `start_seq`, `end_seq`,
 `agent_name`, `session_id`를 보존한다. Record의 `agent_name`은 Keeper identity이고
-run ref의 `agent_name`은 OAS runtime identity이므로 서로 비교하지 않는다. Decoder는
+run ref의 `agent_name`은 agent_core runtime identity이므로 서로 비교하지 않는다. Decoder는
 run ref의 session identity가 record의 trace identity와 다르면 현재 record로
-인정하지 않는다. Reader는 선택된 raw row의 OAS runtime/session identity가 run ref와
+인정하지 않는다. Reader는 선택된 raw row의 agent_core runtime/session identity가 run ref와
 다르면 해당 turn을 투영하지 않는다.
 필드가 없는 과거 row를 읽는 migration이나 fallback은 없다.
 
@@ -79,6 +79,6 @@ projection이며 keeper prompt 입력이 아니다.
 - 한 trace file에 여러 provider run이 있어도 record가 지목한 run만 투영한다.
 - Public autonomous row의 activity trace에는 raw thinking, tool call id,
   arguments, result가 없다.
-- Raw row와 run ref의 OAS runtime/session identity mismatch 및 keeper trace
+- Raw row와 run ref의 agent_core runtime/session identity mismatch 및 keeper trace
   directory 밖 path를 거부한다.
 - Autonomous row volume은 200개의 direct conversation slot을 소비하지 않는다.

--- a/docs/rfc/RFC-0378-code-address-and-ide-observation-store.md
+++ b/docs/rfc/RFC-0378-code-address-and-ide-observation-store.md
@@ -43,7 +43,7 @@ Keeper 의 코드 작업이 IDE 에 보이려면 쓰기와 읽기가 같은 주�
 |---|---|
 | store 전체 | 389 MiB |
 | 그중 `_orphan/` | 380 MiB (**97.6%**) |
-| `by-url/` 파티션 15개 중 내용 있는 것 | 3개 (masc, oas, masc 8.5M 가 사실상 전부) |
+| `by-url/` 파티션 15개 중 내용 있는 것 | 3개 (masc, agent_core, masc 8.5M 가 사실상 전부) |
 | `by-url/wkbl·kirin·grpc-direct` | 0행 (라이브 API 확인) |
 | turn_events 가 by-url 에 존재 | **0건** — 146 MiB 전량 `_orphan` |
 | annotations 평생 총량 | **4행**, 전부 `_orphan` |
@@ -307,7 +307,7 @@ workspace-root-only 2a/2b 와의 결합: A 는 2a 의 `Unattributed` 타입을 �
 
 1. cursor_events — UI 는 wired(`keeper-cursor-overlay` → `fetchIdeCursors` → `list_cursors`, dashboard snapshot 도 호출)인데 producer 가 07-04 이후 침묵. "안 쓰는 기능"이 아니라 **"조용히 고장난 기능"**이다 — producer 수선 vs 기능 동반 삭제의 제품 결정 필요.
 2. checkout 판별자 표기 — `rev-parse --show-toplevel` 기반 실측값 제안 (workspace-root-only §5.2 인수). key 비참여는 본문 확정, 표기 형식만 미정.
-3. 한 tool call 이 **두 저장소의 파일을 만지는 경우** (예: Execute 가 masc 와 oas 를 함께 편집) — fact 는 주 경로 하나의 주소만 나른다. 현행과 동일한 한계이나 타입이 이를 명시하지 않는다. 부 경로들을 별도 Code fact 로 분리 방출할지, 단일 주소 한계를 계약으로 못박을지 결정 필요.
+3. 한 tool call 이 **두 저장소의 파일을 만지는 경우** (예: Execute 가 masc 와 agent_core 를 함께 편집) — fact 는 주 경로 하나의 주소만 나른다. 현행과 동일한 한계이나 타입이 이를 명시하지 않는다. 부 경로들을 별도 Code fact 로 분리 방출할지, 단일 주소 한계를 계약으로 못박을지 결정 필요.
 4. annotate 의 unaddressed tool-response — §5.3 의 typed reject 로 원칙은 닫혔으나, reject payload 의 정확한 필드(재시도 힌트 포함 여부)는 C 의 스키마 작업에서 확정.
 5. keeper 가 보내는 slug 는 self-asserted — 형식 검증(`Code_address.v`)만 있고 "이 keeper 가 실제로 그 저장소에서 작업 중인가"는 검증하지 않는다 (C 적대 리뷰 P1-3). co-view echo 계약의 의도된 신뢰이나, LLM 이 멀티턴에서 이전 저장소의 slug 를 재사용하면 orphan 매장보다 조용한 오귀속이 된다. 방어를 넣는다면 자리는 workspace-root-only 2b 의 실측 체크아웃 slug 집합 대조 — 게이트 신설이 아니라 관측 소비.
 6. slug drift — origin remote 가 바뀌면(조직 개명, host 이전, fork 승격) slug 가 갈라져 같은 저장소의 기록이 두 파티션으로 나뉜다. 일회성 전환이 아니라 **운영 중 반복 가능한 정상 이벤트**라 hard-cut 독트린의 범주 밖이다. 권고 기본값: drift 는 정상 동작으로 계약한다 — 새 파티션이 시작되고 둘 다 §5.4 모집합에 보인다. 자동 병합은 만들지 않는다 (병합은 identity 를 다시 추측하는 일이고, 그 추측이 이 RFC 가 죽이는 부류다). 운영에서 실제로 아프면 명시적 1회성 이관 도구로.

--- a/docs/rfc/RFC-keeper-memory-consolidation.md
+++ b/docs/rfc/RFC-keeper-memory-consolidation.md
@@ -44,7 +44,7 @@ durable 기억이 **두 개의 독립 시스템**으로 공존하며 **둘 다 b
    facts=명제형 claim)다. bank LT top-3 내용은 idle-echo("Acknowledged loop", "idle state confirmed")
    ·잡담이라 제거가 정당하나, "facts가 같은 정보를 커버하니 안전"이라는 단순 논리는 성립하지 않는다.
    bank LT는 *대체*가 아니라 *low-value 서사 제거*로 정당화된다.
-4. **continuity는 bank 비의존**: keeper runtime 복구는 `.memory.jsonl`이 아니라 OAS
+4. **continuity는 bank 비의존**: keeper runtime 복구는 `.memory.jsonl`이 아니라 agent_core
    checkpoint/context와 typed MASC metadata에서
    온다. → **bank를 꺼도 keeper continuity는 안 깨진다** (통합 리스크를 크게 낮추는 핵심 사실).
 


### PR DESCRIPTION
## 배경

OAS 는 masc 의 `packages/agent_core` 로 흡수됐다. 그런데 RFC 상당수가 여전히 OAS 를 **별도 repo / upstream SDK** 로 서술하고 있어, 읽는 사람이 지금도 두 시스템이 분리돼 있다고 오해한다.

코드 결합은 이미 0 이다. `masc.opam` 과 dune 어디에도 `agent_sdk` 가 없고, 실행 코드에 OAS 심볼도 없다. 남아 있던 것은 문서 어휘뿐이었다.

## 범위

**Active / Implemented 만 정정**한다. Draft 와 status 없는 RFC 는 당시 기록으로 남긴다 — RFC 본문은 그때의 결정 근거이고, 지금 기준으로 고치면 왜 그런 범위였는지 알 수 없게 된다.

28 파일 / 110 줄.

## 변경 세 갈래

**1. 명확한 이름 변경**

| 이전 | 이후 | 근거 |
|---|---|---|
| `.masc/oas-events/` | `.masc/agent-core-events/` | 흡수와 함께 저장소 이름이 바뀌었다. `keeper_event_bridge.ml` 이 현재 경로를 문서화하고 있고, 구 디렉토리는 2026-08-10 이후 쓰기가 없었다 |
| `agent_sdk` | `agent_core` | |

**2. 산문의 `OAS` / `oas` → `agent_core`**

`RFC-OAS-NNN` 식별자는 유지한다. 그 문서들은 `packages/agent_core/docs/rfc/` 에 실재하고 코드가 인용한다 — `RFC-OAS-037` 은 현재 first-event timeout 동작의 근거이며 `keeper_runtime_resolved.mli` 등 20 여 곳이 참조한다.

**3. 치환해도 거짓이 남는 문장 재작성**

이름만 바꾸면 `agent_core 별도 repo` 처럼 여전히 틀린 문장이 된다. 8 곳을 다시 썼다.

- `agent_core 별도 repo 는 본 Phase 범위 외` → `별도 repo` 삭제
- `require an agent_core upstream` → `require an agent_core change`
- `filed in agent_core repo` → `filed against agent_core`
- RFC-0081 의 SDK Independence Gate 문장은 agent_core 가 독립 SDK 로 배포되던 시절에만 성립한다. 그 장치가 실제로 지키려던 emission/consumption 경계를 진술하도록 바꿨다. 함께 인용하던 `~/me/memory/reference_oas_pr_policy_vs_masc.md` 는 **존재하지 않아** 인용을 제거했다.

## 유지한 것

`masc ↔ agent_core` 표기는 그대로 둔다. 흡수가 없앤 것은 repo 경계이지 레이어 경계가 아니다. masc 가 agent_core 를 호출하는 관계는 지금도 같다.
