### PR TITLE
fix(runtime): stop declaring a reasoning dialect the ollama endpoint cannot read

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -379,8 +379,8 @@ streaming = true
 [models.ollama-cloud-deepseek-v3-1-671b.capabilities]
 supports-tool-choice = false
 supports-extended-thinking = true
-supports-reasoning-budget = true
-thinking-control-format = "reasoning-effort"
+supports-reasoning-budget = false
+thinking-control-format = "none"
 supports-image-input = false
 supports-multimodal-inputs = false
 
@@ -396,8 +396,8 @@ streaming = true
 [models.ollama-cloud-deepseek-v3-2.capabilities]
 supports-tool-choice = false
 supports-extended-thinking = true
-supports-reasoning-budget = true
-thinking-control-format = "reasoning-effort"
+supports-reasoning-budget = false
+thinking-control-format = "none"
 supports-image-input = false
 supports-multimodal-inputs = false
 
@@ -413,8 +413,8 @@ streaming = true
 [models.ollama-cloud-deepseek-v4-flash.capabilities]
 supports-tool-choice = false
 supports-extended-thinking = true
-supports-reasoning-budget = true
-thinking-control-format = "reasoning-effort"
+supports-reasoning-budget = false
+thinking-control-format = "none"
 supports-image-input = false
 supports-multimodal-inputs = false
 
@@ -518,8 +518,8 @@ streaming = true
 [models.ollama-cloud-gemini-3-flash-preview.capabilities]
 supports-tool-choice = false
 supports-extended-thinking = true
-supports-reasoning-budget = true
-thinking-control-format = "reasoning-effort"
+supports-reasoning-budget = false
+thinking-control-format = "none"
 supports-image-input = true
 supports-multimodal-inputs = true
 
@@ -586,8 +586,8 @@ streaming = true
 [models.ollama-cloud-gemma4-31b.capabilities]
 supports-tool-choice = false
 supports-extended-thinking = true
-supports-reasoning-budget = true
-thinking-control-format = "reasoning-effort"
+supports-reasoning-budget = false
+thinking-control-format = "none"
 supports-image-input = true
 supports-multimodal-inputs = true
 
@@ -603,8 +603,8 @@ streaming = true
 [models.ollama-cloud-glm-4-7.capabilities]
 supports-tool-choice = false
 supports-extended-thinking = true
-supports-reasoning-budget = true
-thinking-control-format = "reasoning-effort"
+supports-reasoning-budget = false
+thinking-control-format = "none"
 supports-image-input = false
 supports-multimodal-inputs = false
 
@@ -620,8 +620,8 @@ streaming = true
 [models.ollama-cloud-glm-5.capabilities]
 supports-tool-choice = false
 supports-extended-thinking = true
-supports-reasoning-budget = true
-thinking-control-format = "reasoning-effort"
+supports-reasoning-budget = false
+thinking-control-format = "none"
 supports-image-input = false
 supports-multimodal-inputs = false
 
@@ -637,8 +637,8 @@ streaming = true
 [models.ollama-cloud-glm-5-1.capabilities]
 supports-tool-choice = false
 supports-extended-thinking = true
-supports-reasoning-budget = true
-thinking-control-format = "reasoning-effort"
+supports-reasoning-budget = false
+thinking-control-format = "none"
 supports-image-input = false
 supports-multimodal-inputs = false
 
@@ -654,8 +654,8 @@ streaming = true
 [models.ollama-cloud-glm-5-2.capabilities]
 supports-tool-choice = false
 supports-extended-thinking = true
-supports-reasoning-budget = true
-thinking-control-format = "reasoning-effort"
+supports-reasoning-budget = false
+thinking-control-format = "none"
 supports-image-input = false
 supports-multimodal-inputs = false
 
@@ -671,8 +671,8 @@ streaming = true
 [models.ollama-cloud-gpt-oss-20b.capabilities]
 supports-tool-choice = false
 supports-extended-thinking = true
-supports-reasoning-budget = true
-thinking-control-format = "reasoning-effort"
+supports-reasoning-budget = false
+thinking-control-format = "none"
 supports-image-input = false
 supports-multimodal-inputs = false
 
@@ -688,8 +688,8 @@ streaming = true
 [models.ollama-cloud-gpt-oss-120b.capabilities]
 supports-tool-choice = false
 supports-extended-thinking = true
-supports-reasoning-budget = true
-thinking-control-format = "reasoning-effort"
+supports-reasoning-budget = false
+thinking-control-format = "none"
 supports-image-input = false
 supports-multimodal-inputs = false
 
@@ -705,8 +705,8 @@ streaming = true
 [models.ollama-cloud-kimi-k2-5.capabilities]
 supports-tool-choice = false
 supports-extended-thinking = true
-supports-reasoning-budget = true
-thinking-control-format = "reasoning-effort"
+supports-reasoning-budget = false
+thinking-control-format = "none"
 supports-image-input = true
 supports-multimodal-inputs = true
 
@@ -722,8 +722,8 @@ streaming = true
 [models.ollama-cloud-kimi-k2-6.capabilities]
 supports-tool-choice = false
 supports-extended-thinking = true
-supports-reasoning-budget = true
-thinking-control-format = "reasoning-effort"
+supports-reasoning-budget = false
+thinking-control-format = "none"
 supports-image-input = true
 supports-multimodal-inputs = true
 
@@ -739,8 +739,8 @@ streaming = true
 [models.ollama-cloud-kimi-k2-7-code.capabilities]
 supports-tool-choice = false
 supports-extended-thinking = true
-supports-reasoning-budget = true
-thinking-control-format = "reasoning-effort"
+supports-reasoning-budget = false
+thinking-control-format = "none"
 supports-image-input = true
 supports-multimodal-inputs = true
 
@@ -756,8 +756,8 @@ streaming = true
 [models.ollama-cloud-minimax-m2-1.capabilities]
 supports-tool-choice = false
 supports-extended-thinking = true
-supports-reasoning-budget = true
-thinking-control-format = "reasoning-effort"
+supports-reasoning-budget = false
+thinking-control-format = "none"
 supports-image-input = false
 supports-multimodal-inputs = false
 
@@ -773,8 +773,8 @@ streaming = true
 [models.ollama-cloud-minimax-m2-5.capabilities]
 supports-tool-choice = false
 supports-extended-thinking = true
-supports-reasoning-budget = true
-thinking-control-format = "reasoning-effort"
+supports-reasoning-budget = false
+thinking-control-format = "none"
 supports-image-input = false
 supports-multimodal-inputs = false
 
@@ -790,8 +790,8 @@ streaming = true
 [models.ollama-cloud-minimax-m2-7.capabilities]
 supports-tool-choice = false
 supports-extended-thinking = true
-supports-reasoning-budget = true
-thinking-control-format = "reasoning-effort"
+supports-reasoning-budget = false
+thinking-control-format = "none"
 supports-image-input = false
 supports-multimodal-inputs = false
 
@@ -807,8 +807,8 @@ streaming = true
 [models.ollama-cloud-minimax-m3.capabilities]
 supports-tool-choice = false
 supports-extended-thinking = true
-supports-reasoning-budget = true
-thinking-control-format = "reasoning-effort"
+supports-reasoning-budget = false
+thinking-control-format = "none"
 # SSOT = agent-core models.toml per official MiniMax Chat documentation.
 supports-response-format-json = false
 supports-structured-output = false
@@ -897,8 +897,8 @@ streaming = true
 [models.ollama-cloud-nemotron-3-nano-30b.capabilities]
 supports-tool-choice = false
 supports-extended-thinking = true
-supports-reasoning-budget = true
-thinking-control-format = "reasoning-effort"
+supports-reasoning-budget = false
+thinking-control-format = "none"
 supports-image-input = false
 supports-multimodal-inputs = false
 
@@ -914,8 +914,8 @@ streaming = true
 [models.ollama-cloud-nemotron-3-super.capabilities]
 supports-tool-choice = false
 supports-extended-thinking = true
-supports-reasoning-budget = true
-thinking-control-format = "reasoning-effort"
+supports-reasoning-budget = false
+thinking-control-format = "none"
 supports-image-input = false
 supports-multimodal-inputs = false
 
@@ -931,8 +931,8 @@ streaming = true
 [models.ollama-cloud-nemotron-3-ultra.capabilities]
 supports-tool-choice = false
 supports-extended-thinking = true
-supports-reasoning-budget = true
-thinking-control-format = "reasoning-effort"
+supports-reasoning-budget = false
+thinking-control-format = "none"
 supports-image-input = false
 supports-multimodal-inputs = false
 

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -328,24 +328,18 @@ let assert_ollama_cloud_seed_runtime runtimes case =
           dialect that can never be encoded: the format carries no effort value,
           runtime.toml has no key that supplies one, and runtime_adapter never
           sets reasoning_effort. Every enable_thinking=true turn is then rejected
-          as Enable_not_encodable — measured 25/25 on the acceptance harness
-          before this list, 0/25 after. Deployed config dropped the same five on
-          2026-08-04; the audit is oas#2716 (2026-07-20). *)
-       let inherent_reasoning_no_control =
-         [ "ollama_cloud.ollama-cloud-qwen3-5-397b"
-         ; "ollama_cloud.ollama-cloud-deepseek-v4-flash-0731"
-         ; "ollama_cloud.ollama-cloud-deepseek-v4-pro"
-         ]
-       in
-       let expected_reasoning_budget, expected_thinking_format =
-         if List.mem case.runtime_id inherent_reasoning_no_control
-         then false, Runtime_schema.No_thinking_control
-         else
-           ( case.thinking
-           , if case.thinking
-             then Runtime_schema.Reasoning_effort
-             else Runtime_schema.No_thinking_control )
-       in
+          as Enable_not_encodable — measured 25/25 on the acceptance harness,
+          0/25 after the first five models dropped the declaration. Deployed
+          config has carried none since 2026-08-04; the audit is oas#2716
+          (2026-07-20).
+
+          This is a property of the endpoint, not of individual models, and
+          every case in this list is an ollama.com /v1 model. Asserting it for
+          the whole list keeps a new model from declaring a dialect the
+          endpoint cannot read; a per-model exception set would admit one on
+          the next addition. *)
+       let expected_reasoning_budget = false
+       and expected_thinking_format = Runtime_schema.No_thinking_control in
        check bool (case.runtime_id ^ " forced tool_choice disabled") false
          caps.supports_tool_choice;
        check bool (case.runtime_id ^ " image input") case.vision
@@ -1206,7 +1200,7 @@ List.iter
             caps.supports_multimodal_inputs;
           (* ollama.com /v1 reasons inherently and takes no control field, so
              this model declares no thinking control. See the comment on
-             [inherent_reasoning_no_control] above for the measurement. *)
+             [expected_thinking_format] above for the measurement. *)
           check bool "Kimi K2.7 Code thinking control" true
             (Runtime_schema.equal_thinking_control_format
                caps.thinking_control_format


### PR DESCRIPTION
## 현상

ollama.com /v1 은 추론을 알아서 하고, 추론 조절 필드를 아예 받지 않습니다. 그런데 `runtime.toml` 의 ollama_cloud 모델 36개 중 21개가 `reasoning-effort` 를 쓴다고 선언하고 있었어요. 나머지 15개는 `none` 이었고요. **같은 endpoint 인데 절반씩 다른 방언을 주장**하던 상태입니다.

선언된 `reasoning-effort` 는 실제로는 아무것도 실어 보내지 못합니다. 그 형식 자체에 값이 없고, `runtime.toml` 에 값을 넣는 키도 없고, `runtime_adapter` 가 설정하지도 않아요. 그래서 `enable_thinking=true` 인 턴은 전부 `Enable_not_encodable` 로 거부됩니다.

## 왜 계속 남아 있었나

검증 테스트가 **반대 규칙**을 들고 있었습니다.

```ocaml
(* 기존 *)
if List.mem case.runtime_id inherent_reasoning_no_control
then false, No_thinking_control
else (case.thinking, if case.thinking then Reasoning_effort else No_thinking_control)
```

`thinking = true` 면 `reasoning-effort` 를 요구하고, 안 맞는 모델은 예외 목록에 하나씩 넣는 구조예요. 목록이 3개까지 자라 있었고, 모델이 깨질 때마다 한 줄씩 늘어나게 돼 있었습니다.

`thinking` 은 **모델이 추론한다**는 뜻이지 **endpoint 가 조절 필드를 받는다**는 뜻이 아닙니다. 이 둘을 같은 것으로 본 게 원인입니다.

## 변경

| 대상 | 내용 |
|---|---|
| `config/runtime.toml` | ollama_cloud 21개 → `thinking-control-format = "none"`, `supports-reasoning-budget = false` |
| `test/test_runtime_config_validity.ml` | 예외 목록 삭제, 목록 전체에 endpoint 성질을 단정 |

이 목록의 타입이 `ollama_cloud_case` 라 **전부 같은 endpoint 모델**입니다. 예외를 팔 자리가 아니라 목록 전체에 걸 규칙이었어요.

파서는 `reasoning-effort` 를 그대로 지원합니다. 실제로 읽는 provider 는 계속 씁니다 — deepseek 선언은 남겼습니다.

## 근거

- acceptance 하네스에서 거부 **25/25 → 0/25** (앞선 5개 모델을 내린 뒤)
- 배포 중인 config 는 2026-08-04 부터 선언 0개로 운영 중
- 감사: oas#2716 (2026-07-20)

## 로컬 검증

```
test_runtime_config_validity      78 tests  Successful
test_runtime_provider_auth_headers 53 tests  Successful
dune build @check                  통과
```

Refs #29174