### PR TITLE
docs(rfc): OAS 정정을 Draft/status 없는 RFC 로 확장

### DIFF
--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -73,7 +73,7 @@ implementation 머지가 아니므로 다수 RFC 가 `Draft` 로 남아있다.
 | 0077 | Write-side silent failure — typed propagation | Implemented | - |
 | 0079 | Log row typed encoder + silent-drop removal | Implemented | - |
 | 0080 | Registered descriptors are the tool-surface SSOT | Implemented | - |
-| 0081 | OAS Telemetry Envelope Context & Keeper/Goal Pivot Timeline | Implemented | - |
+| 0081 | agent_core Telemetry Envelope Context & Keeper/Goal Pivot Timeline | Implemented | - |
 | 0083 | Dashboard system-actor convention typed unification | Implemented | - |
 | 0084 | Tool dispatch handler and observation unification | Implemented | - |
 | 0086 | Keeper namespace bulk promotion to sub-library | Implemented | - |

--- a/docs/rfc/RFC-0009-runtime-trust-phase2.md
+++ b/docs/rfc/RFC-0009-runtime-trust-phase2.md
@@ -132,7 +132,7 @@ Recommendation: mtime threshold + a process-local flag (`Atomic.t` with timestam
 
 ## Out of scope
 
-- **Phase 3** (cost-aware boost via OAS `cost_tracker` token usage) — separate RFC.
+- **Phase 3** (cost-aware boost via agent_core `cost_tracker` token usage) — separate RFC.
 - **Cross-host trust sync** — every host has its own `<base_path>/.masc`; no fleet-level reputation in this RFC.
 - **Auto-disable of dead runtime** — operator decides; the recommendation only suggests.
 

--- a/docs/rfc/RFC-0012-mid-turn-progress-probe.md
+++ b/docs/rfc/RFC-0012-mid-turn-progress-probe.md
@@ -32,14 +32,14 @@ env-driven value to `[60, 600]`.
 `consecutive_noop_count` is updated only at turn end.
 
 Consequence: a turn that hangs in the middle — for example, an
-OAS HTTP single-bulk-read on a slow local LLM that never yields
+agent_core HTTP single-bulk-read on a slow local LLM that never yields
 intermediate progress — is invisible to the watchdog for up to one
 hour. The Apr 23 shutdown log confirms this is not theoretical:
 
 ```
-[Keeper] keeper_llm_bridge: OAS execution cancelled after 91.5s
-[Keeper] keeper_llm_bridge: OAS execution cancelled after 496.8s
-[Keeper] keeper_llm_bridge: OAS execution cancelled after 504.3s
+[Keeper] keeper_llm_bridge: agent_core execution cancelled after 91.5s
+[Keeper] keeper_llm_bridge: agent_core execution cancelled after 496.8s
+[Keeper] keeper_llm_bridge: agent_core execution cancelled after 504.3s
 ```
 
 These were 14 fibers all stuck mid-turn, only released by SIGTERM.
@@ -59,7 +59,7 @@ progress" from "hung turn that will never complete".
   but `lib/keeper/keeper_runtime_resolved.ml:73-79` currently
   clamps the env-driven value to `[60, 600]`. The desync is a code
   regression resolved separately by per-runtime override (Step 2 of
-  goal `oas-bridge-stabilization`). What remains rejected is
+  goal `agent_core-bridge-stabilization`). What remains rejected is
   **flat global reduction** that ignores the legitimate 27 B
   `900 s+` floor (`lib/keeper/keeper_stale_watchdog.ml:405-418`).
 - **Permitted (per-runtime override, added 2026-05-06)**: a runtime
@@ -73,7 +73,7 @@ progress" from "hung turn that will never complete".
   is gated behind a follow-up RFC after one week of legacy metrics backend data
   demonstrates a 900 s ceiling hit. Implementation: see
   `feature/runtime-tiered-turn-timeout`.
-- Changing OAS execution to use chunked reads. That is an OAS-level
+- Changing agent_core execution to use chunked reads. That is an agent_core-level
   change; the user explicitly noted in
   `feedback_oas_execution_uncancellable_mid_turn` that
   "masc 단독 fix 영역 zero".
@@ -83,7 +83,7 @@ progress" from "hung turn that will never complete".
 ## Proposal
 
 Add a `last_progress_at : float` field to `turn_observation` in
-`keeper_registry.ml`. Update it from every `oas:event` that proves
+`keeper_registry.ml`. Update it from every `agent_core:event` that proves
 forward motion (tool call started, tool call completed, agent text
 delta, substrate event). Use it as a third
 in-turn-stale criterion in `keeper_stale_watchdog.ml`:
@@ -113,7 +113,7 @@ Rationale:
 |---|---|
 | `lib/keeper/keeper_registry.ml` | Add `last_progress_at : float` to `turn_observation`; initialise in `start_turn`; expose `record_progress` |
 | `lib/keeper/keeper_registry.mli` | Surface `record_progress` |
-| `lib/keeper/keeper_hooks_oas.ml` | Call `Keeper_registry.record_progress` from each OAS event hook (`turn_ready`, `tool_started`, `tool_completed`, `agent_message_delta`) |
+| `lib/keeper/keeper_hooks_oas.ml` | Call `Keeper_registry.record_progress` from each agent_core event hook (`turn_ready`, `tool_started`, `tool_completed`, `agent_message_delta`) |
 | `lib/keeper/keeper_stale_watchdog.ml` | Use `last_progress_at` in `in_turn_stale` |
 | `lib/config/env_config_keeper.ml` | Add `progress_timeout_sec` (default 300, range \[60, 3600\]) |
 | `test/test_keeper_stale_watchdog.ml` (new or extended) | Cover three cases: progressing slow turn (no kill), hung mid-turn (kill after 300 s), legitimately long single-shot turn that never emits events (kill — desired behaviour) |
@@ -139,7 +139,7 @@ LOC estimate: 80–150 net additions.
 1. Stale watchdog terminates a fiber whose turn has been in
    progress for ≥ `progress_timeout_sec` with zero recorded events,
    even when total turn elapsed < `active_turn_timeout_sec`.
-2. A turn emitting at least one OAS event every 4 minutes is
+2. A turn emitting at least one agent_core event every 4 minutes is
    never killed by the new path, regardless of total duration.
 3. Test fixture verifies both, including the boundary at exactly
    `progress_timeout_sec`.
@@ -155,7 +155,7 @@ LOC estimate: 80–150 net additions.
   `progress_timeout_sec_override`.
 - Substrate events that are not progress (heartbeats, surface
   re-emissions) must be filtered out. The list of "real progress"
-  events is enumerable but needs review against `oas:event` taxonomy.
+  events is enumerable but needs review against `agent_core:event` taxonomy.
 - Should the watchdog distinguish "no event yet" (turn just
   started) from "no event for 5 min" (hang)? Yes — initialise
   `last_progress_at = obs.started_at`, then progress timeout has

--- a/docs/rfc/RFC-0032-env-knob-unification.md
+++ b/docs/rfc/RFC-0032-env-knob-unification.md
@@ -160,7 +160,7 @@ Order of migration (by impact, low → high):
 1. `lib/runtime/` — well-isolated, ~30 knobs.
 2. `lib/keeper/` — hot path; ~50 knobs. Migrate per-keeper-submodule.
 3. `lib/dashboard/` — ~20 knobs.
-4. `lib/server/`, `lib/oas*/`, `lib/workspace/` — remainder.
+4. `lib/server/`, `lib/agent_core*/`, `lib/workspace/` — remainder.
 
 Each module migration is one PR. Total PR count: ~10–15.
 

--- a/docs/rfc/RFC-0057-tool-descriptor-codegen.md
+++ b/docs/rfc/RFC-0057-tool-descriptor-codegen.md
@@ -39,7 +39,7 @@ progress_report.md §2.1에 기록된 8개 문제 중 미해결 4개:
 
 | # | 문제 | 현상 | 본 RFC 적용 범위 |
 |---|------|------|-----------------|
-| 1 | 과거 command/effect 분류 | generic executor/OAS에 제품 의미 유입 | **폐기** — descriptor codegen과 통합하지 않음 |
+| 1 | 과거 command/effect 분류 | generic executor/agent_core에 제품 의미 유입 | **폐기** — descriptor codegen과 통합하지 않음 |
 | 2 | `agent_tools` O(n) 선형 검색 | 도구 이름 문자열로 linear search | **Phase 2** — GADT dispatch로 대체 |
 | 3 | **61개 도구 수동 Yojson AST** | `{name="..."; description="..."; ...}` 하드코딩 | **핵심 범위** — codegen으로 자동화 |
 | 4 | 중복 도구 | `read_file` / `tool_read_file` 등 의미 중복 | **Phase 2** — alias/unification 계획 |
@@ -88,7 +88,7 @@ progress_report.md §2.1에 기록된 8개 문제 중 미해결 4개:
 
 1. **PPX 사용** (RFC-0054 §3 Non-goals #1과 동일한 근거)
 2. **런타임 코드 생성** — 동적 `ocamlc` 호출이나 `Metaocaml` 사용 금지
-3. **`mode_enforcer.ml` 마이그레이션** — OAS subsystem 별도 작업
+3. **`mode_enforcer.ml` 마이그레이션** — agent_core subsystem 별도 작업
 4. **다국어 description 자동 번역** — 영문 description 기준, 번역은 별도 파이프라인
 
 ---
@@ -299,7 +299,7 @@ python3 -c "import json; tools=json.load(open('tool_descriptors_golden.json')); 
 ## §10 Open Questions
 
 1. **Parameter record의 GADT화 수준**: `param`을 GADT로 만들면 type-safe tool calling이 가능하지만, 61개 도구의 parameter 정의가 복잡해집니다. Phase 0에서는 value-level record로 시작할까요, 아니면 바로 GADT로 갈까요?
-2. **Authorization boundary (resolved 2026-07-13)**: OAS 또는 descriptor
+2. **Authorization boundary (resolved 2026-07-13)**: agent_core 또는 descriptor
    codegen과 command/effect 분류를 통합하지 않는다. 실제 외부 효과는
    MASC의 product-neutral Keeper Gate가 concrete input으로 판단한다.
 3. **Git 관리**: `tool_descriptors_gen.ml`을 `.gitignore`할지, 아니면 golden test용으로 커밋할지?

--- a/docs/rfc/RFC-0063-telemetry-feedback-loop.md
+++ b/docs/rfc/RFC-0063-telemetry-feedback-loop.md
@@ -8,7 +8,7 @@
 
 ## 1. Problem
 
-PR #14491 (`feat(keeper): wire OAS telemetry into provider health, livelock gate, and supervisor`, merged 2026-05-10 14:34Z) introduced the OAS-side telemetry feedback loop without a tracking RFC. The PR body cited `RFC-WAIVED: telemetry feedback loop is new cross-repo concern, no prior RFC exists.` and pointed to `docs/design/telemetry-feedback-loop-architecture.md` as the design substitute.
+PR #14491 (`feat(keeper): wire agent_core telemetry into provider health, livelock gate, and supervisor`, merged 2026-05-10 14:34Z) introduced the agent_core-side telemetry feedback loop without a tracking RFC. The PR body cited `RFC-WAIVED: telemetry feedback loop is new cross-repo concern, no prior RFC exists.` and pointed to `docs/design/telemetry-feedback-loop-architecture.md` as the design substitute.
 
 Two retroactive findings from origin/main on 2026-05-11:
 
@@ -49,7 +49,7 @@ Diagnostic decisive moment: `sample 22289 2 -mayDie` showed the hot stack as `Ke
 ## 5. Telemetry feedback loop architecture (as shipped by #14491)
 
 ```
-OAS turn execution
+agent_core turn execution
    │
    ▼
 Agent_sdk.Event_bus  (bounded Eio.Stream, default depth 256)

--- a/docs/rfc/RFC-0103-log-retention-opt-in-and-volume-root.md
+++ b/docs/rfc/RFC-0103-log-retention-opt-in-and-volume-root.md
@@ -15,12 +15,12 @@ related:
 
 ## 1. Summary
 
-JSONL log retention (tool_calls, tool_usage, oas-events, runtime-manifests)
+JSONL log retention (tool_calls, tool_usage, agent-core-events, runtime-manifests)
 는 PR-5 (#PENDING) 에서 *opt-in* (env-gated) 으로 wiring. **default disabled**.
 
 이 RFC 는:
 1. *왜 default disabled 인가* — retention 이 root fix 가 아니라 symptom 억제
-2. *진짜 root* — JSONL volume reduction (특히 `oas-events` 의
+2. *진짜 root* — JSONL volume reduction (특히 `agent-core-events` 의
    `Context_window_usage` telemetry-as-fix anti-pattern)
 3. *Phase 별 step* — RFC-0089 (string→typed) 와 정렬
 
@@ -30,12 +30,12 @@ JSONL log retention (tool_calls, tool_usage, oas-events, runtime-manifests)
 
 | Path | Size | 24-hour growth |
 |---|---|---|
-| `.masc/oas-events` | 226M | ~38M/day (5/05, 5/06 측정) |
+| `.masc/agent-core-events` | 226M | ~38M/day (5/05, 5/06 측정) |
 | `.masc/keepers/*/runtime-manifests/` | (~per-keeper) | append-only, no archive |
 | `.masc/tool_calls` | 115M | 16 keeper burst proxy |
 | `.masc/tool_usage` | 128K | rolling stable |
 
-`oas-events` 가 가장 큰 hotspot. 분석:
+`agent-core-events` 가 가장 큰 hotspot. 분석:
 - 14 emits/min sustained
 - **84% noise** = `Context_window_usage` event (RFC-0089 anti-pattern target)
 - event format = `[name_string, props_dict]` (string-classifier 의 변종 —
@@ -51,7 +51,7 @@ JSONL log retention (tool_calls, tool_usage, oas-events, runtime-manifests)
 
 ### 3.2 Retention 은 symptom 억제, root 아님
 
-- `oas-events` 226M 의 84% 가 `Context_window_usage` telemetry-as-fix —
+- `agent-core-events` 226M 의 84% 가 `Context_window_usage` telemetry-as-fix —
   retention 으로 *지운다 해서 emit rate 가 줄지 않음*
 - 30일 후 다시 226M 가 누적, 60일 후 같음 — *volume 자체 reduction* 이 root
 - `Workaround Rejection Bar` §Symptom 억제 패턴 ④ "Log Dedup/Demote" 변종
@@ -75,7 +75,7 @@ default disabled 면:
 - 4 모듈의 `retention_days ()` default → `None`
   - `lib/keeper_tool_call_log.ml`
   - `lib/tool_usage_log.ml`
-  - `lib/runtime/runtime_event_bridge.ml` (oas-events)
+  - `lib/runtime/runtime_event_bridge.ml` (agent-core-events)
   - `lib/keeper/keeper_runtime_manifest.ml`
 - env vars 유지: `MASC_*_RETENTION_DAYS` (positive int 일 때만 enable)
 - invalid env 값 (non-positive 또는 non-int) = disabled (안전한 default)

--- a/docs/rfc/RFC-0107-eio-context-switch-audit.md
+++ b/docs/rfc/RFC-0107-eio-context-switch-audit.md
@@ -39,7 +39,7 @@ supplement_of: RFC-0107
 
 | 파일 | 라인 | 의도 |
 |---|---|---|
-| `lib/runtime/runtime_oas_runner.ml` | 23 | OAS runner sw fallback |
+| `lib/runtime/runtime_oas_runner.ml` | 23 | agent_core runner sw fallback |
 | `lib/runtime/runtime_runtime.ml` | 177 | runtime fiber attachment |
 | `lib/runtime/runtime_catalog_runtime.ml` | 619 | catalog runtime fork |
 | `lib/keeper/keeper_run_tools.ml` | 781 | tool execution sw |

--- a/docs/rfc/RFC-0159-reason-internal-error-typed-split.md
+++ b/docs/rfc/RFC-0159-reason-internal-error-typed-split.md
@@ -238,7 +238,7 @@ truth for the catch-all removal).
   boundary unit test must include an FFI-raised case.
 - **Phase 3 breaking change**: removing `Reason_internal_error` is a
   closed-sum API break. Mitigation: phase 1 keeps both; downstream JSON
-  consumers (dashboard, OAS exporters) must ship readers for the four
+  consumers (dashboard, agent_core exporters) must ship readers for the four
   new forms in phase 1 PR (not deferred).
 - **Producer-side typo**: a site that previously wrote
   `terminal_reason := "internal_error"` and now must pick a sub-variant

--- a/docs/rfc/RFC-0162-jsonl-write-path-fd-pressure.md
+++ b/docs/rfc/RFC-0162-jsonl-write-path-fd-pressure.md
@@ -274,7 +274,7 @@ let append_jsonl path json =
 **fd budget 분석**:
 
 - macOS default `RLIMIT_NOFILE` = 256 (soft) / unlimited (hard). masc 가 256 root 안에서 운영.
-- 4 writer (system_log / trajectory / oas-events / reaction-ledger) × 평균 1 active path = 4 fd baseline.
+- 4 writer (system_log / trajectory / agent-core-events / reaction-ledger) × 평균 1 active path = 4 fd baseline.
 - Day rollover 시 어제 path 도 evict 전까지 남음 → 최대 8 fd.
 - Dashboard read-side, network connection 등 합쳐 ~30 fd. fd_cache_max=32 는 safe margin.
 - RFC-0108 §3.3 의 "N≤64" budget 안 *충분히 들어옴*.

--- a/docs/rfc/RFC-0178-types-sublib-intf-mli-only.md
+++ b/docs/rfc/RFC-0178-types-sublib-intf-mli-only.md
@@ -39,7 +39,7 @@ Measured 2026-05-26:
 
 ### 1.2 Coupling hypothesis
 
-`types_core.ml` aggregates types across at least 5 domains observed in source: keeper-side, runtime-side, OAS-side, shell-side, dashboard-side. Today every caller imports the entire 1,067-LoC module to use a single domain's types. This:
+`types_core.ml` aggregates types across at least 5 domains observed in source: keeper-side, runtime-side, agent_core-side, shell-side, dashboard-side. Today every caller imports the entire 1,067-LoC module to use a single domain's types. This:
 
 1. Inflates compile fan-out for unrelated changes (touching one keeper type recompiles runtime callers).
 2. Defeats the cycle-avoidance property `_intf.ml` would provide — when two sub-libraries each need the same type, only direct embedding works (or duplication).

--- a/docs/rfc/RFC-0182-masc-descriptor-projection.md
+++ b/docs/rfc/RFC-0182-masc-descriptor-projection.md
@@ -96,7 +96,7 @@ After the body merged (PR #18726 → renumber #18731), a 5-prong dead/live audit
 | Verdict | Tools | Decision |
 |---|---|---|
 | **dead** (no handler, no live caller) | `masc_execute`, `masc_execute_dry_run`, `masc_admin_cleanup`, `masc_admin_reset`, `masc_gc_force`, `masc_workspace_delete`, `masc_force_unbind` | delete tool_catalog metadata; do not migrate |
-| **dead** (after ambiguous decision) | `masc_spawn` (dispatch explicitly removed with comment `"masc_spawn removed: vendor-specific agent spawning belongs to OAS domain"` at `mcp_tool_runtime.ml:287`; metadata and test fixture left behind) | delete metadata + test fixture (completes the in-progress cleanup) |
+| **dead** (after ambiguous decision) | `masc_spawn` (dispatch explicitly removed with comment `"masc_spawn removed: vendor-specific agent spawning belongs to agent_core domain"` at `mcp_tool_runtime.ml:287`; metadata and test fixture left behind) | delete metadata + test fixture (completes the in-progress cleanup) |
 | **live at audit time** | `masc_bind`, `masc_unbind`, `masc_broadcast`, `masc_messages`, `channel_gate`, `masc_set_param` plus one subsequently retired membership mutation entry | migrate surviving entries to `Tool_spec.register`; descriptor projection added |
 | **deferred** (separate RFC) | `masc_portal_open`, `masc_portal_close`, `masc_portal_send` | live, but dispatch is at `mcp_server_eio_protocol.ml` protocol level — not in-process. This RFC's cluster-variant pattern does not fit. Tracked for a separate RFC (RFC-0183 candidate). Excluded from this RFC's scope. |
 
@@ -170,7 +170,7 @@ masc_workspace_delete        — no handler, no dispatch, no live caller
 masc_force_unbind        — no handler, no dispatch, no live caller
 masc_spawn              — dispatch explicitly removed (mcp_tool_runtime.ml:287
                           comment `"masc_spawn removed: vendor-specific agent
-                          spawning belongs to OAS domain"`), metadata+test left
+                          spawning belongs to agent_core domain"`), metadata+test left
                           behind. This RFC completes the cleanup.
 ```
 

--- a/docs/rfc/RFC-0206-runtime-concept-runtime-rebirth.md
+++ b/docs/rfc/RFC-0206-runtime-concept-runtime-rebirth.md
@@ -3,7 +3,7 @@
 - Status: Draft
 - Date: 2026-05-30
 - Supersedes 라우팅 레이어: RFC-0038(routing-intent), RFC-0041(group-item-hierarchy), RFC-0058 §Layer-4/5(routes/aliases), RFC-0181(routes+phonebook dual-SSOT)
-- Superseded (partial): binding-key id 형식(`id = "provider.model"`, §2)은 runtime assignment contract이 supersede — id는 masc에 opaque, OAS만 parser. single-binding 모델/fail-fast load/§2.1은 유지.
+- Superseded (partial): binding-key id 형식(`id = "provider.model"`, §2)은 runtime assignment contract이 supersede — id는 masc에 opaque, agent_core만 parser. single-binding 모델/fail-fast load/§2.1은 유지.
 - Builds on: RFC-0058(provider/model/binding 선언 스키마, Layers 1-3), keeper_meta_contract(HEAD; exhaustion 분류)
 - Context: PR #19536이 `lib/runtime*`(170+파일) 전면 삭제 + 빌드 의도적 broken. 본 RFC는 그 후속 "Runtime 구현 채우기"의 설계 SSOT.
 
@@ -37,7 +37,7 @@ Runtime은 하나의 완전히 materialize된 (Provider × Model × Binding) tri
 | `api_format` | `Messages_api \| Chat_completions_api \| Ollama_api` | `runtime_api_format` |
 | `transport` | `Http of string \| Cli of string` | `runtime_transport` |
 | `credential` | `Env of string \| File of string \| Inline of string` | `runtime_credential` |
-| `thinking_control_format` | OAS `Llm_provider.Capabilities.thinking_control_format` re-export (`No_thinking_control`, `Thinking_object`, `Thinking_object_adaptive`, `Thinking_object_only`, `Chat_template_kwargs`, `Chat_template_token of string`, `Ollama_think`, `Reasoning_effort`, `Enable_thinking`) | `runtime_thinking_control_format` |
+| `thinking_control_format` | agent_core `Llm_provider.Capabilities.thinking_control_format` re-export (`No_thinking_control`, `Thinking_object`, `Thinking_object_adaptive`, `Thinking_object_only`, `Chat_template_kwargs`, `Chat_template_token of string`, `Ollama_think`, `Reasoning_effort`, `Enable_thinking`) | `runtime_thinking_control_format` |
 | `capabilities` | 10-field provider 행동 record + `capabilities_default` | `runtime_capabilities` |
 | `model_capabilities` | 24-field record (`Llm_provider.Capabilities` 미러) + default | `runtime_model_capabilities` |
 | `provider` | Layer 1 record (id/display_name/protocol/api_format/transport/is_non_interactive/credentials/capabilities/headers). log·healthcheck sub-record는 v1에서 parse-and-ignore | `runtime_provider` |
@@ -62,7 +62,7 @@ runtime 5-state(`Idle/Selecting/Trying/Done/Exhausted`)는 다중후보 selectio
 
 **계승(INHERIT):**
 - `keeper_meta_contract`의 exhaustion_reason + blocker_class (frozen, 재사용)
-- `Llm_provider.Provider_config.t`를 `Runtime.t.provider_config` hot-path 대상으로 (외부 OAS lib, 생존)
+- `Llm_provider.Provider_config.t`를 `Runtime.t.provider_config` hot-path 대상으로 (외부 agent_core lib, 생존)
 - RFC-0058 절대 원칙: 코드는 provider/model 이름을 모른다 — provider 추가 = TOML 항목만, 재컴파일 없음
 - RFC-0058 §4.1 load-time validation = `Runtime.load_list`의 fail-fast gate
 - `binding.max_concurrent` is optional metadata for explicit operator overrides; missing means no static per-binding cap. It does not replace URL/probe-based capacity by default.

--- a/docs/rfc/RFC-0214-otel-genai-dual-emission.md
+++ b/docs/rfc/RFC-0214-otel-genai-dual-emission.md
@@ -137,7 +137,7 @@ Why OTel-backed migration:
 
 ```
                     ┌─────────────────┐
-                    │  OAS Callbacks   │
+                    │  agent_core Callbacks   │
                     │  (on_token_usage, │
                     │   on_error, etc)  │
                     └────────┬─────────┘

--- a/docs/rfc/RFC-0223-typed-connector-surfaces-presence-pull-speaker.md
+++ b/docs/rfc/RFC-0223-typed-connector-surfaces-presence-pull-speaker.md
@@ -109,7 +109,7 @@ old push-scoped message feed.
    classifier branches (CLAUDE.md workaround signature #2).
 4. **read/act split.** The read tool is side-effect-free and always allowed;
    the post tool is an action and goes through tool policy.
-5. **OAS untouched.** Surfaces are a MASC concept. OAS continues to receive a
+5. **agent_core untouched.** Surfaces are a MASC concept. agent_core continues to receive a
    host-assembled message list; nothing here crosses the boundary.
 6. **No standing machinery (owner constraint).** Presence is recomputed from
    bindings + registry on every observation — no cached presence state. The

--- a/docs/rfc/RFC-0225-per-keeper-turn-single-flight.md
+++ b/docs/rfc/RFC-0225-per-keeper-turn-single-flight.md
@@ -30,8 +30,8 @@ Measured on 2026-06-10 (sangsu, session `trace-1780648779957-00000`): a
 - **Checkpoint clobber** — both lanes share one trace_id-keyed checkpoint
   file (`keeper_run_context.ml:101-112`); finalize is last-writer-wins
   (`keeper_agent_run_finalize_response.ml:112-127`). The autonomous lane's
-  07:11:50Z save (oas turn_count=1355) overwrote the chat lane's 07:10:38Z
-  save (oas=1324) which contained the entire voice conversation — user-visible
+  07:11:50Z save (agent_core turn_count=1355) overwrote the chat lane's 07:10:38Z
+  save (agent_core=1324) which contained the entire voice conversation — user-visible
   as "the keeper forgot what it just said".
 - **Meta regression** — `update_direct_turn_meta` writes a stale
   snapshot+1 (`keeper_turn.ml:57-80`), regressing `total_turns` 385→370 and
@@ -79,7 +79,7 @@ Admission is the primary fix; the writes are corrected so a future bypass
 cannot corrupt state silently:
 
 - Checkpoint save becomes versioned CAS: refuse (and log at Error) when the
-  on-disk oas `turn_count` is **newer** than the snapshot being saved
+  on-disk agent_core `turn_count` is **newer** than the snapshot being saved
   (`keeper_agent_run_finalize_response.ml`).
 - `update_direct_turn_meta` becomes monotonic: read-modify-write under the
   meta CAS with `max` instead of stale-snapshot+1 (`keeper_turn.ml:57-80`).

--- a/docs/rfc/RFC-0233-turn-observability-execution-identity.md
+++ b/docs/rfc/RFC-0233-turn-observability-execution-identity.md
@@ -35,7 +35,7 @@ same second:
 |---|---|---|
 | `trajectories/<keeper>/<trace>.jsonl` | `{"turn":0,"round":4,"tool_name":...,"args":...}` **(verified)** | turn-relative `turn`/`round` |
 | `tool_calls/<YYYY-MM>/<DD>.jsonl` | full input/output + `runtime_contract.keeper_turn_id:718`, `trace_id`, `session_id` **(verified)** | absolute keeper turn + session |
-| `logs/system_log_<date>.jsonl` | `oas:tool_called` / `oas:tool_completed` pair, `correlation_id`, `run_id`, `turn:null` **(verified)** | OAS correlation ids |
+| `logs/system_log_<date>.jsonl` | `agent_core:tool_called` / `agent_core:tool_completed` pair, `correlation_id`, `run_id`, `turn:null` **(verified)** | agent_core correlation ids |
 
 No field is shared across all three. The dashboard session-trace
 interleaves at least two of these sources and renders the same physical
@@ -96,10 +96,10 @@ Propagation:
 - `tool_calls` store: new `execution_id` field.
 - trajectory writer: same field; `turn`/`round` stay as display
   attributes.
-- OAS event bridge: masc already owns the consumer that turns OAS
-  stream events into `oas:tool_called`/`oas:tool_completed` log rows;
+- agent_core event bridge: masc already owns the consumer that turns agent_core
+  stream events into `agent_core:tool_called`/`agent_core:tool_completed` log rows;
   that consumer joins on the in-flight execution (it is masc-side, so
-  no OAS API change — OAS stays masc-agnostic per the boundary rule).
+  no agent_core API change — agent_core stays masc-agnostic per the boundary rule).
 - dashboard: one row per `execution_id`; turn-relative and absolute
   labels become attributes of that row, not separate rows.
 
@@ -160,8 +160,8 @@ record; digests join against the existing prompt/receipt stores.
 
 - No new telemetry pipeline or transport — TurnRecord is one JSONL
   store next to the existing receipt store; views read it.
-- No OAS API change. The execution-id join happens in masc's own event
-  consumer. OAS continues to know nothing about MASC.
+- No agent_core API change. The execution-id join happens in masc's own event
+  consumer. agent_core continues to know nothing about MASC.
 - No backfill of historical stores; old rows render as today.
 - No prompt-text duplication into TurnRecord (digests only).
 
@@ -169,7 +169,7 @@ record; digests join against the existing prompt/receipt stores.
 
 1. PR-1: `Execution_id` + stamp at dispatch + `tool_calls` and
    trajectory fields (additive, old readers unaffected).
-2. PR-2: OAS event consumer join + dashboard single-row render keyed by
+2. PR-2: agent_core event consumer join + dashboard single-row render keyed by
    `execution_id` (closes the #20910 double-row symptom at the root).
 3. PR-3: `Prompt_block_id` + TurnRecord writer at receipt site.
 4. PR-4: dashboard turn inspector (block diff) + OTel span attributes.
@@ -183,7 +183,7 @@ cap/dedup — if the id is missing, writers fail loudly in dev builds.
   TurnRecord codec.
 - Behavioral: drive one fake tool execution through dispatch → assert
   exactly one `execution_id` appears in tool_calls + trajectory + the
-  oas-event rows for that call (no orphan, no dup).
+  agent_core-event rows for that call (no orphan, no dup).
 - Dashboard: session-trace fixture with all three sources for one
   execution → exactly one rendered row.
 - Block-diff: two synthetic TurnRecords → diff yields the exact
@@ -321,11 +321,11 @@ collapsed into `turn_ref`.
 
 ### §7.3 Boundary invariant (unchanged from §3)
 
-OAS owns the run/turn lifecycle and stays MASC-agnostic. OAS exposes no
+agent_core owns the run/turn lifecycle and stays MASC-agnostic. agent_core exposes no
 first-class per-turn id — only `(worker_run_id : string, turn : int)` on the
 event bus / `last_raw_trace_run` (**verified 2026-06-19**: `run()` does not
 return the run id). MASC joins that pair MASC-side and mints `Turn_ref`. No
-MASC concept (`turn_ref`, channel) crosses into OAS. The channel axis is
+MASC concept (`turn_ref`, channel) crosses into agent_core. The channel axis is
 `Surface_ref.t` (`lib/keeper/surface_ref.ml`: `Dashboard | Discord | Slack |
 Github | Webhook | Agent | Gate`). The keeper-v2 prototype's `imessage`
 source has no first-class variant today — it rides `Gate { label =
@@ -335,7 +335,7 @@ deferred** to whoever wires the iMessage gate.
 
 ### §7.4 Non-goals
 
-- No OAS API change (per §3).
+- No agent_core API change (per §3).
 - No backfill: legacy chat rows / posts decode `turn_ref = None`; the FE
   30-min window survives only as an explicit, commented, removal-targeted
   fallback for `None` rows.
@@ -447,9 +447,9 @@ view-side-repair violation of §2.3.
 
 ### §8.3 Boundary invariant (unchanged from §3)
 
-No OAS change. MASC reads the runtime binding it already materialized at
-boot (`Runtime.t.binding`); OAS's `Provider_runtime_binding` catalog — which
-deliberately omits price ("OAS owns identity/capability, not pricing") — is
+No agent_core change. MASC reads the runtime binding it already materialized at
+boot (`Runtime.t.binding`); agent_core's `Provider_runtime_binding` catalog — which
+deliberately omits price ("agent_core owns identity/capability, not pricing") — is
 untouched. Price is MASC's operator-config concern, sourced from
 runtime.toml.
 
@@ -459,14 +459,14 @@ runtime.toml.
   "미상" for them.
 - `context_window` is the **keeper compaction budget**, not the provider's
   per-request `num_ctx` cap. `num_ctx` is an Ollama-only transport detail
-  (`oas/lib/llm_provider/backend_ollama.ml`: honored by Ollama only); the
+  (`agent_core/lib/llm_provider/backend_ollama.ml`: honored by Ollama only); the
   keeper resolver does not consult it, and conflating the two would mis-state
   the window for any Ollama binding where the operator set `num-ctx` below
   the model ceiling. For the current fleet (glm/deepseek/claude, none
   Ollama-bound) `max_context` is the effective window. A future wave that
   needs the provider-enforced cap should add a separate
   `provider_context_window` field rather than overload this one.
-- No OAS `request_latency_ms` (phase duration) — that is a separate
+- No agent_core `request_latency_ms` (phase duration) — that is a separate
   amendment (Wave 2b); this amendment is context window + pricing only.
 
 ### §8.5 Migration
@@ -538,12 +538,12 @@ context assembly (`ctx`), thinking (`reason`), tool calls (`tool`), and
 response generation (`gen`). Only the `tool` phase carried a measured
 `duration_ms` (from `/api/v1/keepers/:name/tool-calls`). The other three
 were hardcoded `durationMs: null, durationSource: 'not_recorded'`, and the
-`gen` phase's own `meta` string declared *"provider/OAS duration is not
+`gen` phase's own `meta` string declared *"provider/agent_core duration is not
 recorded in turn-records"*. So every keeper turn's response-generation bar
 read "측정 없음" even though the provider call wall-clock was already
 measured — it just never reached the record.
 
-The measurement already exists in-process: the OAS `api_response.telemetry`
+The measurement already exists in-process: the agent_core `api_response.telemetry`
 field carries `inference_telemetry.request_latency_ms`, and the transport
 layer (`complete_common.patch_telemetry` non-streaming, `complete_stream`
 streaming) synthesizes it for every provider, so it is populated whenever a
@@ -555,7 +555,7 @@ hooks already consume (`keeper_hooks_oas.ml:417` reads
 stored it, forcing the `gen` phase to render "측정 없음" — a view-side-repair
 violation of §2.3.
 
-### §9.2 Design — one option field, populated from OAS transport telemetry
+### §9.2 Design — one option field, populated from agent_core transport telemetry
 
 ```ocaml
 ; request_latency_ms : int option
@@ -564,8 +564,8 @@ violation of §2.3.
 
 - Sourced at the write site (`lib/keeper/keeper_agent_run.ml`, next to the
   `usage` binding) via `Option.bind result.inference_telemetry (fun t ->
-  t.request_latency_ms)`. `request_latency_ms` is itself `int option` in OAS
-  (`oas/lib/llm_provider/types.mli:197`), and `inference_telemetry` is an
+  t.request_latency_ms)`. `request_latency_ms` is itself `int option` in agent_core
+  (`agent_core/lib/llm_provider/types.mli:197`), and `inference_telemetry` is an
   outer `option`; `Option.bind` flattens the two layers rather than nesting
   option-of-option. On the error path (or before a response existed) the
   value is `None`.
@@ -574,23 +574,23 @@ violation of §2.3.
   `TurnPhase.durationSource` union, distinct from `'tool_call_log'` so the
   tooltip names the real source). Absent → the existing `'not_recorded'` /
   "측정 없음" render is preserved. No fabrication.
-- `ctx` and `reason` phases stay `'not_recorded'`: OAS `inference_telemetry`
+- `ctx` and `reason` phases stay `'not_recorded'`: agent_core `inference_telemetry`
   has no isolated measurement for context assembly or thinking, so mapping
   `request_latency_ms` onto them would mislabel the whole-call wall-clock.
   This is an honest limit, not a gap to paper over.
 
 ### §9.3 Boundary invariant (unchanged from §3)
 
-No OAS change. MASC reads `inference_telemetry` it already receives in the
+No agent_core change. MASC reads `inference_telemetry` it already receives in the
 keeper turn result — the same consumption pattern as
 `keeper_hooks_oas.ml:287/326/417`, `lib/runtime/dashboard_oas_bridge.ml`,
-and `keeper_unified_turn_success.ml:253`. The telemetry record is an OAS
+and `keeper_unified_turn_success.ml:253`. The telemetry record is an agent_core
 generic asset (`types.mli:325` docstring: *"Parsed from the raw API
 response; never computed by downstream"*); `rg "MASC|masc|keeper"` in
-`oas/lib/api.ml` / `types.ml` returns 0 hits, so `patch_telemetry` is OAS's
+`agent_core/lib/api.ml` / `types.ml` returns 0 hits, so `patch_telemetry` is agent_core's
 own transport pipeline, not MASC-requested code. Per
-`docs/OAS-MASC-BOUNDARY.md:16,50,52`, MASC consuming a public OAS response
-field is permitted; only adding MASC-specific code to OAS would not be.
+`docs/agent_core-MASC-BOUNDARY.md:16,50,52`, MASC consuming a public agent_core response
+field is permitted; only adding MASC-specific code to agent_core would not be.
 
 ### §9.4 Non-goals
 
@@ -604,7 +604,7 @@ field is permitted; only adding MASC-specific code to OAS would not be.
   every provider reports.
 - No derivation of `ctx`/`reason` durations by differencing
   `request_latency_ms` against tool durations — that would fabricate a
-  measurement OAS does not provide (see §9.6).
+  measurement agent_core does not provide (see §9.6).
 - No backfill: legacy rows decode `request_latency_ms` as `None`; the `gen`
   phase renders "측정 없음" exactly as before.
 
@@ -624,7 +624,7 @@ case).
 ### §9.6 Workaround guards (rejected per CLAUDE.md §워크어라운드)
 
 1. Deriving a `ctx` or `reason` duration as
-   `request_latency_ms − Σ tool durations` — constructs a measurement OAS
+   `request_latency_ms − Σ tool durations` — constructs a measurement agent_core
    never made; silent on multi-SDK-turn keeper turns where multiple provider
    calls occur. → leave those phases `'not_recorded'`.
 2. Defaulting `request_latency_ms` to 0 (the `keeper_hooks_oas.ml:417`
@@ -659,7 +659,7 @@ the full generation duration. This is the half of latency users perceive
 
 ### §10.2 Design
 
-Add `ttfrc_ms : float option` to `Turn_record.t`, sourced from OAS
+Add `ttfrc_ms : float option` to `Turn_record.t`, sourced from agent_core
 `inference_telemetry.ttfrc_ms` (Time-To-First-Response-Chunk, wall-clock).
 Unlike `request_latency_ms`, this isolates the wait for the first SSE chunk.
 The inspector renders it alongside the `gen` phase's end-to-end duration
@@ -668,7 +668,7 @@ The inspector renders it alongside the `gen` phase's end-to-end duration
 ### §10.3 Provider fill matrix (grounding)
 
 `ttfrc_ms` is the one phase-level signal populated across the keeper fleet:
-the OAS streaming transport (`complete_stream.ml:573-574`) sets it as a
+the agent_core streaming transport (`complete_stream.ml:573-574`) sets it as a
 provider-agnostic wall-clock measurement as soon as the first SSE chunk
 arrives. The keeper default fleet (deepseek-v4-flash / deepseek-v4-pro /
 glm-4-7-coding / minimax-m3, all `openai-compatible-http` + `streaming`)

--- a/docs/rfc/RFC-0235-voice-output-browser-transport-device-routing.md
+++ b/docs/rfc/RFC-0235-voice-output-browser-transport-device-routing.md
@@ -128,7 +128,7 @@ broadcast.
    The only `Sys.remove` sites (`:384` dedup, `:451` synthesis failure)
    produce unservable files and stay as-is. (Correction of an earlier
    draft that claimed immediate deletion on every exit path.)
-5. **OAS boundary respected.** Voice output is a MASC concept. OAS continues
+5. **agent_core boundary respected.** Voice output is a MASC concept. agent_core continues
    to receive a host-assembled message list and is unaware of audio delivery
    (mirrors RFC-0223 §2.5). All transport code lives under MASC
    (`lib/voice*`, `lib/keeper*`, `lib/server*`, `dashboard/`).

--- a/docs/rfc/RFC-0240-tool-pair-write-time-enforcement.md
+++ b/docs/rfc/RFC-0240-tool-pair-write-time-enforcement.md
@@ -159,9 +159,9 @@ can prevent: **the process dies between committing a `ToolUse` and
 committing its `ToolResult`.** The write that would have closed the pair
 never runs, so "reject at write" has nothing to reject.
 
-**The producer is exact and reachable today.** OAS persists a durable
+**The producer is exact and reachable today.** agent_core persists a durable
 checkpoint at stage `After_assistant_collected`
-(`oas/lib/pipeline/pipeline.ml:213-220` **(verified 07-28)**), whose
+(`agent_core/lib/pipeline/pipeline.ml:213-220` **(verified 07-28)**), whose
 state is `messages = snoc agent.state.messages assistant_message` — the
 assistant message carrying the `ToolUse` blocks appended, no `ToolResult`
 in existence yet. masc's sink saves **every** snapshot with no stage
@@ -546,14 +546,14 @@ unresolved ids from the 2026-07-27 incident are absent from their
 keepers' `decisions.jsonl` while completed ids from the same turns are
 present. Absence therefore cannot be read as "did not run".
 
-OAS does have the authority: `Pipeline_execution_resume`
-(`oas/lib/pipeline/pipeline_execution_resume.ml`) classifies a crashed
+agent_core does have the authority: `Pipeline_execution_resume`
+(`agent_core/lib/pipeline/pipeline_execution_resume.ml`) classifies a crashed
 tool turn against the execution journal and replays settled results
 rather than re-executing. masc does not use it — `rg` for
 `Execution_journal|Pipeline_execution_resume|durable_execution` over
 masc `lib/` and `bin/` returns **zero hits**, and receipts record
 `oas_dispatch_mode: single_provider_agent_run` with
-`oas_internal_runtime_disabled: true`. Adopting OAS durable execution
+`oas_internal_runtime_disabled: true`. Adopting agent_core durable execution
 for keeper turns is the principled successor to §2.4 and would replace
 "may or may not have taken effect" with a journal-backed answer. It is a
 separate project; until then, stating the uncertainty is the accurate
@@ -788,7 +788,7 @@ New anchors introduced by this amendment, all **(verified 07-28)**:
 - Recovery phases: `lib/server/server_bootstrap_loops.ml:490,558`.
 - Removal of repair: `f5f45f97c3` (#25046, 2026-07-18). Hard reject:
   `4a1880624b` (#25335, 2026-07-23).
-- Producer: `oas/lib/pipeline/pipeline.ml:213-220`
+- Producer: `agent_core/lib/pipeline/pipeline.ml:213-220`
   (`persist_turn_checkpoint_for_state … After_assistant_collected` over
   `snoc messages assistant_message`); unfiltered sink `checkpoint_sink`
   in `lib/keeper/keeper_agent_run.ml` (passes `snapshot.stage` to an

--- a/docs/rfc/RFC-0252-fusion-panel-judge-deliberation.md
+++ b/docs/rfc/RFC-0252-fusion-panel-judge-deliberation.md
@@ -4,7 +4,7 @@
 - Author: Vincent (yousleepwhen) + Claude
 - Created: 2026-06-16
 - Scope: `lib/fusion/` (신규), `lib/runtime/` (config 확장), `.masc/config/runtime.toml` (`[fusion]` 테이블)
-- Boundary: OAS(`~/me/workspace/yousleepwhen/oas`)는 **0줄 변경**. 본 루프는 OAS의 범용 프리미티브만 소비한다.
+- Boundary: agent_core(`~/me/workspace/yousleepwhen/agent_core`)는 **0줄 변경**. 본 루프는 agent_core의 범용 프리미티브만 소비한다.
 - 참조: OpenRouter Fusion API — [plugin](https://openrouter.ai/docs/guides/features/plugins/fusion), [router](https://openrouter.ai/docs/guides/routing/routers/fusion-router)
 - Concurrency update (2026-07-17): the retired
   `max_concurrent_panels`/`max_concurrent_judges` settings never controlled
@@ -39,7 +39,7 @@ MASC는 이미 멀티 fiber로 N개 키퍼를 상시 병렬 구동한다. 같은
 
 ## 2. Non-goals / 경계
 
-- **OAS 변경 금지.** OAS는 single-provider completion + 범용 fan-out(`Async_agent.all`) + 구조화 출력(`Structured.extract`)만 제공한다. 멀티모델 오케스트레이션·심판 프롬프트·게이트·가시성은 전부 MASC.
+- **agent_core 변경 금지.** agent_core는 single-provider completion + 범용 fan-out(`Async_agent.all`) + 구조화 출력(`Structured.extract`)만 제공한다. 멀티모델 오케스트레이션·심판 프롬프트·게이트·가시성은 전부 MASC.
 - **죽은 합의 코드에 의존 금지.** MAGI 삼두정치·walph·cascade·board curation은 작동/사용된 적 없음(사용자 확인). 본 루프는 그 위에 쌓지 않고 새로 만든다. (죽은 3종의 *삭제*는 본 RFC 범위 밖, 별도 정리.)
 - **v1은 advisory만.** 패널/심판은 분석·종합을 산출하는 read-only. tool-call을 패널이 제안하고 심판이 골라 *실행*하는 action 모드는 side-effect atomicity가 필요 → v2(§14).
 - **재귀 금지.** 패널·심판은 fusion을 다시 못 부른다(§10). OpenRouter의 `x-openrouter-fusion-depth`에 대응하는 타입드 depth guard.
@@ -197,11 +197,11 @@ val decide
 
 ---
 
-## 7. 패널 + 심판 (OAS 프리미티브 소비)
+## 7. 패널 + 심판 (agent_core 프리미티브 소비)
 
 ### 7.1 패널 — `Async_agent.all`
 
-`oas/lib/async_agent.mli:78`:
+`agent_core/lib/async_agent.mli:78`:
 ```ocaml
 val all : sw:Eio.Switch.t -> ?clock:_ -> ?max_fibers:int
        -> (Agent.t * string) list
@@ -228,7 +228,7 @@ val all : sw:Eio.Switch.t -> ?clock:_ -> ?max_fibers:int
 > 이 절은 `lib/fusion/fusion_judge.mli` 헤더가 "RFC가 요구하는지 확인하지 않았다"로 남겨둔
 > 미해결 항목이었다. 요구는 실재했고, 맞추는 쪽이 RFC다.
 
-`oas/lib/structured.mli:38` (provider-native JSON schema 강제, 미지원 provider fail-fast):
+`agent_core/lib/structured.mli:38` (provider-native JSON schema 강제, 미지원 provider fail-fast):
 ```ocaml
 val extract : sw:_ -> net:_ -> ?provider:Provider.config -> config:agent_config
            -> schema:'a schema -> string -> ('a, Error.sdk_error) result

--- a/docs/rfc/RFC-0257-per-keeper-memory-execution-lane.md
+++ b/docs/rfc/RFC-0257-per-keeper-memory-execution-lane.md
@@ -2,7 +2,7 @@
 
 - Status: Draft
 - Updated: 2026-07-13
-- Boundary: Memory work is lane-local; provider calls are OAS calls.
+- Boundary: Memory work is lane-local; provider calls are agent_core calls.
 
 ## Contract
 
@@ -12,7 +12,7 @@ acquire a fleet-wide permit and never block Keeper B.
 
 Submissions are durable FIFO work, not a bounded best-effort queue. Saturation,
 provider latency, token use, and queue depth are observations only: work is not
-dropped because a fixed count or timeout was reached. An OAS provider result is
+dropped because a fixed count or timeout was reached. An agent_core provider result is
 recorded explicitly. A completed or failed long-running memory job wakes only
 its originating Keeper lane.
 

--- a/docs/rfc/RFC-0266-fusion-async-completion-wake-and-visibility.md
+++ b/docs/rfc/RFC-0266-fusion-async-completion-wake-and-visibility.md
@@ -26,7 +26,7 @@ RFC-0252 §4(line 71)는 "키퍼가 다음 턴에 observation으로 resolved_ans
 
 - **panel/judge/orchestrator 로직 무변경.** 이 RFC는 *완료 후 전달*만 다룬다.
 - **self-author board_signal 게이트 무변경.** board post가 작성자 키퍼를 깨우지 않는 것(self-author score 0)은 board 도배 방지를 위한 *의도된* 게이트다. 우회·약화하지 않는다. wake는 별도 typed stimulus로 구현한다.
-- **OAS 경계 무변경.** fusion 개념은 OAS에 노출하지 않는다(RFC-0252 §2 유지).
+- **agent_core 경계 무변경.** fusion 개념은 agent_core에 노출하지 않는다(RFC-0252 §2 유지).
 - **키퍼 턴 루프 단일 모델 유지.** wake는 평범한 단일-모델 턴을 시작시킬 뿐이다(심의는 이미 out-of-band로 끝났다).
 - **휴면 `Keeper_chat_queue` 경로 미사용.** `keeper_chat_consumer.ml`(1초 폴링 → turn)은 production enqueue 호출처가 0이라 휴면 상태다. 이를 깨워 쓰는 대신, 타입 안전한 닫힌 합타입 stimulus를 택한다(아래 §5 근거).
 

--- a/docs/rfc/RFC-0269-process-critic-loop.md
+++ b/docs/rfc/RFC-0269-process-critic-loop.md
@@ -92,7 +92,7 @@ It does not hide the raw trace rows; raw evidence remains the source of truth.
 
 The turn inspector can later reuse the same projection for a per-turn view, but
 the first slice attaches to the session trace because that surface already
-merges timeline, trajectory, tool-call, and live OAS events.
+merges timeline, trajectory, tool-call, and live agent_core events.
 
 ### 3.4 Later Evaluator Loop
 

--- a/docs/rfc/RFC-0277-fusion-heterogeneous-panels.md
+++ b/docs/rfc/RFC-0277-fusion-heterogeneous-panels.md
@@ -5,7 +5,7 @@
 - Created: 2026-06-22
 - Parent: RFC-0252 (fusion-panel-judge-deliberation) — 본 RFC는 §6(게이트/예산)·§9(preset)을 개정한다.
 - Scope: `lib/fusion_core/` (preset/config/types), `lib/fusion/` (panel/orchestrator/tool), `bin/fusion_run.ml`, `config/runtime.toml` (`[fusion]`)
-- Boundary: OAS는 0줄 변경. judge/sink 계약 무변경. 심판은 preset당 1개 유지.
+- Boundary: agent_core는 0줄 변경. judge/sink 계약 무변경. 심판은 preset당 1개 유지.
 
 ---
 

--- a/docs/rfc/RFC-0278-fusion-same-model-panels.md
+++ b/docs/rfc/RFC-0278-fusion-same-model-panels.md
@@ -4,7 +4,7 @@
 - Author: Vincent (yousleepwhen) + Claude
 - Created: 2026-06-22
 - Parent: RFC-0252 (fusion-panel-judge-deliberation) §7 — 본 RFC는 패널 정체성(panel identity)을 개정한다. RFC-0277(이종 패널 그룹)의 후속 슬라이스.
-- Scope: `lib/fusion_core/` (policy/config/types), `lib/fusion/` (panel/oas/sink). judge/dashboard 무변경.
+- Scope: `lib/fusion_core/` (policy/config/types), `lib/fusion/` (panel/agent_core/sink). judge/dashboard 무변경.
 - Boundary: provider 라우팅 무변경(언제나 raw model). judge 계약 무변경. sink는 패널 실패 렌더를 정체성 대신 raw-model attribution으로 분리(`panel_failure_text`, §2.5) — label 없는 config에는 byte-identical(§3).
 
 ---

--- a/docs/rfc/RFC-0287-ws-direct-masc-owned-websocket-stack.md
+++ b/docs/rfc/RFC-0287-ws-direct-masc-owned-websocket-stack.md
@@ -200,7 +200,7 @@ unrelated merged RFC (fusion-judge-of-judges); ws-direct uses RFC-0287.
 
 - `httpun` / `httpun-eio` / `gluten` — only the WS protocol is replaced; the HTTP
   server and the gluten upgrade boundary stay.
-- `cohttp` / `cohttp-eio` — used by OAS/GraphQL/telemetry; the Discord client
+- `cohttp` / `cohttp-eio` — used by agent_core/GraphQL/telemetry; the Discord client
   stops using `Cohttp_eio.Private.IO`, but the dep remains for other users.
 - TLS setup (`tls-eio` / `ca-certs`) — reused for the Discord connection.
 - The [[RFC-0281]] driving SSOT and session protocol.

--- a/docs/rfc/RFC-0289-keeper-progress-lib-split.md
+++ b/docs/rfc/RFC-0289-keeper-progress-lib-split.md
@@ -109,7 +109,7 @@ one-liners in sync.
 ## Open questions
 
 - Exact module closure for `Keeper_tool_name`/`Keeper_tool_resolution` (do they
-  pull in OAS/registry state that should stay in `masc`?).
+  pull in agent_core/registry state that should stay in `masc`?).
 - Whether `turn_effect` / `empty_queue_reason` travel with the classification
   layer or stay in `masc` (they are detector-FSM concerns, not classification).
 

--- a/docs/rfc/RFC-0290-keeper-background-wait-tool.md
+++ b/docs/rfc/RFC-0290-keeper-background-wait-tool.md
@@ -47,8 +47,8 @@ The generalization is sound only with the §5 isolation and resource design.
 
 - **Inline blocking await as the default path.** A keeper turn must not `Eio.Promise.await` a background job as its primary way to get the result. (An optional short-budget inline mode may be added later behind a hard single-digit-second clamp; not in v1.)
 - **A `task_wait`-style blocking re-await tool.** Re-awaiting a handle from a later turn requires a durable result store that survives registry pruning. The fusion registry prunes completed entries at `max_completed_retained=64` (`fusion_run_registry.ml:35,47-53`); a `wait` tool over it would silently lose results. Deferred until a durable store is specified.
-- **Routing LLM/agent sub-jobs through OAS `async_agent`.** The research could not read the OAS `async_agent`/`approval` API (reader failed twice on transport errors). Any "LLM sub-jobs reuse OAS async_agent" claim is unverified and out of scope; v1 covers the subprocess job kind only.
-- **Touching the OAS boundary.** OAS must not learn about `wakeup_keeper`, the keeper registry, the board, or the event queue. The result→wake bridge lives only in the MASC tool fiber's terminal callback (§5.4).
+- **Routing LLM/agent sub-jobs through agent_core `async_agent`.** The research could not read the agent_core `async_agent`/`approval` API (reader failed twice on transport errors). Any "LLM sub-jobs reuse agent_core async_agent" claim is unverified and out of scope; v1 covers the subprocess job kind only.
+- **Touching the agent_core boundary.** agent_core must not learn about `wakeup_keeper`, the keeper registry, the board, or the event queue. The result→wake bridge lives only in the MASC tool fiber's terminal callback (§5.4).
 
 ## 4. Surface inventory
 
@@ -116,7 +116,7 @@ Because results are reachable by both wake (stimulus) and poll (`masc_bg_status`
 - **P0② unbounded concurrency / scheduler starvation.** No cap means ~15 keepers × unbounded spawns × `Eio_unix.run_in_systhread` waitpid (`autonomy_exec.ml:310`) saturate the systhread pool. Mitigation: §5.3 cap with rejection. Note: adding more domains is not a fix (keepers are scheduler-bound, not core-bound).
 - **R3 not-Running orphan window.** If the keeper is paused, in succession, or dead when a job completes, the `Bg_completed` stimulus drops. v1 treats this as intended (the keeper rereads state on resume); a durable result store is deferred with the `task_wait` non-goal. Documented so it is not mistaken for a delivery bug.
 - **R4 behavior/observability gap.** No eval asserts on background-job outcomes yet. v1 ships the mechanism and the unit/FD/cap tests above; outcome-quality measurement is a separate harness concern.
-- **R5 OAS boundary, checkpoint write contention.** Unverified: whether a root-switch task fiber and the turn fiber can race on checkpoint read/write. v1's subprocess jobs do not touch keeper checkpoints, sidestepping this; revisit before any in-process LLM job kind is added.
+- **R5 agent_core boundary, checkpoint write contention.** Unverified: whether a root-switch task fiber and the turn fiber can race on checkpoint read/write. v1's subprocess jobs do not touch keeper checkpoints, sidestepping this; revisit before any in-process LLM job kind is added.
 
 ## 8. Rollout
 

--- a/docs/rfc/RFC-0299-typed-boundary-sweep.md
+++ b/docs/rfc/RFC-0299-typed-boundary-sweep.md
@@ -9,9 +9,9 @@ updated: 2026-07-13
 | Field | Value |
 |---|---|
 | Status | Draft |
-| Repo | `jeong-sik/masc` (refs `jeong-sik/oas`) |
+| Repo | `jeong-sik/masc` (refs `jeong-sik/agent_core`) |
 | Supersedes / absorbs | masc #22071, #18840, #20674, #22042, #22246, #22639, #15257, #22177 (workaround-rejection signature #2/#3 cluster) |
-| Relates | oas #2051 (capability ingestion 4 paths), manifesto "NO string-match / NO SSOT violations", CLAUDE.md workaround-rejection §2 |
+| Relates | agent_core #2051 (capability ingestion 4 paths), manifesto "NO string-match / NO SSOT violations", CLAUDE.md workaround-rejection §2 |
 | Audit | 2026-06-29 8-lens manifesto audit — the single most repeated structural anti-pattern (7+ sites). |
 
 ## 0. Summary
@@ -47,7 +47,7 @@ The 2026-06-29 audit found the pattern compounds: `string catch-all` → `silent
 | Config category enum | #15257 | `config_category_enum_strings` duplicated 5 files (regrew after RFC-0057) | `config_category` variant + single SSOT |
 | masc_run_* tool schemas | #22177 | 4 tool JSON schemas defined twice (`tool_schemas_run.ml` vs `tool_run.ml:115-184`) with divergent fields (`additionalProperties:false` vs descriptions) | single schema SSOT, both consumers import |
 
-oas #2051 (capability ingestion 4 paths) is the same shape in the sibling repo; referenced for cross-repo coordination, not migrated here.
+agent_core #2051 (capability ingestion 4 paths) is the same shape in the sibling repo; referenced for cross-repo coordination, not migrated here.
 
 ## 3. Goal — the typed boundary
 
@@ -89,7 +89,7 @@ The 2026-06-29 audit noted every issue here *reports* a violation and proposes a
 ## 7. Non-goals
 
 - Per-issue behavioral fixes beyond the type boundary (e.g. #22042's anti-thrash semantics are the issue's scope; this RFC only fixes the classification type).
-- oas #2051 capability ingestion (sibling repo; coordinated, not migrated).
+- agent_core #2051 capability ingestion (sibling repo; coordinated, not migrated).
 - The silent-failure sink cluster (#21990 `write_json` `Result.t`) — separate axis; covered by its own issue, not this RFC.
 
 ## 8. Open questions

--- a/docs/rfc/RFC-0301-keeper-generated-media-exposure.md
+++ b/docs/rfc/RFC-0301-keeper-generated-media-exposure.md
@@ -12,17 +12,17 @@
 
 ### 1.1 경계 분석 — 데이터는 어디까지 오는가
 
-OAS는 미디어 데이터를 **완전히 surface한다** (MASC는 OAS를 소비; OAS는 MASC를 모름):
+agent_core는 미디어 데이터를 **완전히 surface한다** (MASC는 agent_core를 소비; agent_core는 MASC를 모름):
 
-- 스트리밍 델타: `oas/lib/llm_provider/types.ml:462-471` `MediaDelta { media_type; source_type; data : string }` — 주석: "Carries the block-level media_type and source_type alongside the data payload ... the accumulator records the metadata (idempotent across chunks) and concatenates data."
+- 스트리밍 델타: `agent_core/lib/llm_provider/types.ml:462-471` `MediaDelta { media_type; source_type; data : string }` — 주석: "Carries the block-level media_type and source_type alongside the data payload ... the accumulator records the metadata (idempotent across chunks) and concatenates data."
 - 최종 content block: 동 `types.ml:278-292` `Image / Document / Audio of { media_type; data : string; source_type }`.
 - `media_source_kind = Base64 | Url | File_id` (`types.ml:225-228`).
 
-즉 **OAS는 실제 페이로드(base64/url/file_id)를 전달**한다. OAS 측 변경은 필요 없다.
+즉 **agent_core는 실제 페이로드(base64/url/file_id)를 전달**한다. agent_core 측 변경은 필요 없다.
 
 ### 1.2 근본 원인 — pre-RFC MASC 브릿지가 데이터를 카운트로 축소
 
-pre-RFC MASC가 OAS 스트림을 키퍼 채팅 이벤트로 변환하는 브릿지에서
+pre-RFC MASC가 agent_core 스트림을 키퍼 채팅 이벤트로 변환하는 브릿지에서
 **데이터를 byte-count로 축소**했다. 이 RFC의 구현은 byte-count emit을
 제거하고, block별 누적 후 `ContentBlockStop`/`MessageStop`에서 persist한
 `media_ref` URL emit으로 교체한다:
@@ -42,7 +42,7 @@ lib/keeper/keeper_chat_events.ml (current)
 - turn persist path가 같은 stream에서 생성 미디어를 `Image`/`Voice`/`Attach` block으로 저장해 reload-visible하게 만든다.
 - `dashboard/src/types/core.ts:837,835`의 `ChatImageBlock`/`ChatVoiceBlock`는 reload path에서 저장된 block을 렌더하는 재사용 대상이다.
 
-이는 **"telemetry-as-fix" 안티패턴이 프로토콜 shape에 박힌 형태**다 — 데이터 채널이어야 할 자리에 카운트(관측치)를 넣었다. 데이터는 OAS에서 가용했으나 경계에서 의도적으로 버려졌다.
+이는 **"telemetry-as-fix" 안티패턴이 프로토콜 shape에 박힌 형태**다 — 데이터 채널이어야 할 자리에 카운트(관측치)를 넣었다. 데이터는 agent_core에서 가용했으나 경계에서 의도적으로 버려졌다.
 
 ### 1.3 영향 범위
 
@@ -53,7 +53,7 @@ lib/keeper/keeper_chat_events.ml (current)
 
 목표:
 1. 모델 생성 미디어를 키퍼 채팅에 라이브 + reload 양쪽에서 노출.
-2. 경계 규칙 준수: OAS 변경 없이 MASC 소비 측에서 해결.
+2. 경계 규칙 준수: agent_core 변경 없이 MASC 소비 측에서 해결.
 3. count-only 안티패턴 제거 (augment가 아니라 replace).
 
 비목표:
@@ -103,9 +103,9 @@ lib/keeper/keeper_chat_events.ml (current)
 
 ## 5. 의존성 / 경계
 
-- OAS: 변경 없음 (데이터 이미 surface). pin bump 불요.
+- agent_core: 변경 없음 (데이터 이미 surface). pin bump 불요.
 - RFC-0235/0236 voice transport 인프라 재사용/일반화. RFC-0164 voice tool 추상화와 토큰/route 정합 유지.
-- 경계: MASC↔OAS 브릿지(`keeper_chat_oas_stream_bridge`)가 유일한 변경 진입점. lane-per-keeper 격리 불변.
+- 경계: MASC↔agent_core 브릿지(`keeper_chat_oas_stream_bridge`)가 유일한 변경 진입점. lane-per-keeper 격리 불변.
 
 ## 6. 검증 방법
 

--- a/docs/rfc/RFC-0302-keeper-memory-io-offmain-offload.md
+++ b/docs/rfc/RFC-0302-keeper-memory-io-offmain-offload.md
@@ -39,7 +39,7 @@ Eio는 **단일 도메인 cooperative 스케줄러**다. main 도메인에서 �
 
 ## 2. 경계 분석
 
-이건 **MASC-internal**이다. OAS 무관(OAS는 single-provider completion만; 파일 저장/메모리는 MASC 소유). MASC↔OAS 경계 변경 없음. 대상은 `lib/keeper/keeper_memory_os_io.ml`(781줄) 및 동일 패턴의 `Skill_candidate_store`/`Keeper_memory_recall`(후속).
+이건 **MASC-internal**이다. agent_core 무관(agent_core는 single-provider completion만; 파일 저장/메모리는 MASC 소유). MASC↔agent_core 경계 변경 없음. 대상은 `lib/keeper/keeper_memory_os_io.ml`(781줄) 및 동일 패턴의 `Skill_candidate_store`/`Keeper_memory_recall`(후속).
 
 ## 3. 근본 원인
 

--- a/docs/rfc/RFC-0303-stimulus-gated-keeper-wake.md
+++ b/docs/rfc/RFC-0303-stimulus-gated-keeper-wake.md
@@ -14,7 +14,7 @@ are assessed by the configured LLM.
 There is no tool-class `made_progress` score, consecutive no-progress counter,
 automatic pause, or wake tombstone. A completed turn is observed as a turn; it
 does not become a lifecycle verdict. Empty or malformed provider output is an
-explicit OAS/runtime result, and semantic Task completion is an asynchronous
+explicit agent_core/runtime result, and semantic Task completion is an asynchronous
 configured-LLM judgment.
 
 One pending or failed wake never blocks another Keeper lane.

--- a/docs/rfc/RFC-0306-fusion-settings-typed-editor.md
+++ b/docs/rfc/RFC-0306-fusion-settings-typed-editor.md
@@ -90,9 +90,9 @@ in Phase 0. This RFC covers the remaining editability work.
    (`GET /api/v1/providers` → `fetchRuntimeProviders` → `runtimeSelectOptionsFromCatalog`),
    the same source the default-runtime select already uses. `runtime_id` is
    `provider.model`.
-5. **MASC → OAS stays one-way.** Model resolution uses the existing MASC→OAS
-   catalog path (OAS embedded catalog plus deployment overlay; `Runtime_oas_runner`,
-   `Fusion_oas`). No new coupling; OAS remains unaware of fusion.
+5. **MASC → agent_core stays one-way.** Model resolution uses the existing MASC→agent_core
+   catalog path (agent_core embedded catalog plus deployment overlay; `Runtime_oas_runner`,
+   `Fusion_oas`). No new coupling; agent_core remains unaware of fusion.
 6. **No silent failure.** Every write step returns `result`; failures produce a
    JSON error body plus an audit `Failure` record, mirroring
    `save_config_text` (`server_routes_http_routes_dashboard.ml:562`).
@@ -222,8 +222,8 @@ Each phase is independently mergeable and keeps main deployable.
   file unchanged (atomic write not reached).
 - **Frontend (vitest)**: populate form from a JSON fixture; produce the patch;
   render a server error payload to field-level messages.
-- **Boundary**: no new `masc → oas` reference beyond the existing catalog path;
-  OAS has no fusion reference.
+- **Boundary**: no new `masc → agent_core` reference beyond the existing catalog path;
+  agent_core has no fusion reference.
 
 ## 7. Resolved questions
 
@@ -246,6 +246,6 @@ Each phase is independently mergeable and keeps main deployable.
 
 Per the product boundary rule, this surface is entirely **deterministic /
 declarative**: typed config in, validated TOML out, no heuristic and no LLM
-judgment. The only external boundary is the MASC→OAS model catalog read, which is
+judgment. The only external boundary is the MASC→agent_core model catalog read, which is
 unchanged. Observability (audit records, reload confirmation) is retained from the
 existing raw path.

--- a/docs/rfc/RFC-0307-midturn-advisor-consult.md
+++ b/docs/rfc/RFC-0307-midturn-advisor-consult.md
@@ -35,7 +35,7 @@ A second, higher-capability model already participates in keeper workflows — b
 *after* the producing turn, as a verifier/judge, never *inside* it:
 
 - **Exact-output judgment lanes**: Keeper board attention and HITL judgment
-  resolve immutable OAS target slots through `Runtime_exact_output_registry`
+  resolve immutable agent_core target slots through `Runtime_exact_output_registry`
   (`board_attention_exact` and `hitl_auto_judge`).
 - **Fusion judge**: `lib/fusion/fusion_judge.ml:188` `run_composed
   ~judge_model …` (and `run` / `run_refine` wrappers) — a distinct judge model
@@ -58,7 +58,7 @@ paired with an Anthropic-family advisor (the tool's `model` field), a valid
 executor≤advisor performance pair, and is **API/AWS-only** (not Bedrock, GCP,
 Foundry). (Source: platform.claude.com advisor-tool docs, confirmed 2026-07-04.)
 
-MASC keepers are predominantly routed to **non-Anthropic** providers via OAS
+MASC keepers are predominantly routed to **non-Anthropic** providers via agent_core
 (GLM, kimi, deepseek, ollama, runpod). For those keepers the native advisor tool
 **cannot be attached at all** — there is no Anthropic executor to carry it.
 
@@ -139,8 +139,8 @@ value. Avoid Option B until C (or a T1 benchmark) justifies the blast radius.
 
 Derived from an adversarial mapping of Anthropic's agents-and-tools surface
 (advisor / tool-search / strict / code-execution / computer / text-editor) onto
-MASC/OAS (2026-07-04). Of the six ideas, five were already covered by existing
-MASC/OAS mechanisms or unfit at the boundary; **mid-turn advisor was the only
+MASC/agent_core (2026-07-04). Of the six ideas, five were already covered by existing
+MASC/agent_core mechanisms or unfit at the boundary; **mid-turn advisor was the only
 genuinely novel axis MASC lacks**, and this RFC resolves its disposition.
 Companion analysis:
-`reports/masc-oas-anthropic-tools-orthogonal-blastradius-2026-07-04.html`.
+`reports/masc-agent_core-anthropic-tools-orthogonal-blastradius-2026-07-04.html`.

--- a/docs/rfc/RFC-0320-keeper-connector-aware-continuation.md
+++ b/docs/rfc/RFC-0320-keeper-connector-aware-continuation.md
@@ -143,7 +143,7 @@ and connector_attention =
 
 ## 8. 경계
 
-- **MASC 전용** — OAS 무관.
+- **MASC 전용** — agent_core 무관.
 - **LLM 경계** = 재개 턴에서 무엇을 말할지. 라우팅(어디로)은 typed channel로 결정론적. 커넥터를 LLM/문자열로 추론하지 않음.
 - **No fabrication** — 커넥터 미상은 `Unrouted`. 편의 기본값(예: 항상 Dashboard) 금지.
 - **Keeper Gate와 직교** — continuation은 Channel provenance이고 Gate는 외부 효과 결정을 소유한다. 둘을 합친 permission envelope를 만들지 않는다.

--- a/docs/rfc/RFC-0324-keeper-filesystem-repo-truth.md
+++ b/docs/rfc/RFC-0324-keeper-filesystem-repo-truth.md
@@ -7,14 +7,14 @@ Draft
 
 keeper들이 매 턴 `cwd_not_directory` 에러로 자기 repo 경로를 못 찾는 현상이 상시 발생한다.
 
-- garnet keeper → `repos/masc` 시도 (실제 clone은 `masc-mcp`, `oas`)
+- garnet keeper → `repos/masc` 시도 (실제 clone은 `masc-mcp`, `agent_core`)
 - nick0cave keeper → `repos/jeong-sic-masc` 시도 (실제 clone은 `masc`)
 
 ### 근본 원인
 
 keeper prompt assembly(`lib/keeper/keeper_prompt.ml`의 `registered_repositories_block`)가 `repositories.toml` catalog의 **globally registered repo ID**를 "유효한 `repos/<name>` 세그먼트"로 keeper에게 주입한다. 하지만 catalog ID와 keeper playground에 **실제로 clone된 디렉토리 이름** 사이에 invariant가 없다:
 
-- provisioning은 clone을 basename/별칭(`masc`, `masc-mcp`, `oas`)으로 깐다.
+- provisioning은 clone을 basename/별칭(`masc`, `masc-mcp`, `agent_core`)으로 깐다.
 - catalog/합성은 다른 이름(`masc`, `jeong-sik-masc`)을 쓴다.
 - keeper는 catalog를 진실로 믿고 → 디스크에 없는 경로를 Execute cwd로 시도 → `cwd_not_directory`.
 
@@ -75,7 +75,7 @@ dune runtest test_exec_policy
 ```
 
 - keeper 새 턴에서 prompt에 `<registered_repositories>` 블록이 더 이상 렌더링되지 않는지.
-- garnet/nick0cave keeper가 tool로 playground를 조회한 뒤 정확한 clone 경로(`masc-mcp`, `oas`, `masc`)를 사용하는지 로그 모니터링.
+- garnet/nick0cave keeper가 tool로 playground를 조회한 뒤 정확한 clone 경로(`masc-mcp`, `agent_core`, `masc`)를 사용하는지 로그 모니터링.
 - keeper Execute가 filesystem 실존 디렉토리에 대해 catalog 무관하게 허용되는지.
 - `cwd_not_directory` 에러 빈도 감소 확인.
 

--- a/docs/rfc/RFC-0342-capability-catalog-overlay-and-boot-posture.md
+++ b/docs/rfc/RFC-0342-capability-catalog-overlay-and-boot-posture.md
@@ -2,45 +2,45 @@
 
 - Status: Draft
 - Date: 2026-07-15
-- Related: masc#24528 (provider_id stamping fix, merged), oas RFC-OAS-036 / oas#2604
-  (D1 overlay + alias-canonicalized lookup, implemented), oas RFC-OAS-034
+- Related: masc#24528 (provider_id stamping fix, merged), agent_core RFC-OAS-036 / agent_core#2604
+  (D1 overlay + alias-canonicalized lookup, implemented), agent_core RFC-OAS-034
   (endpoint/capability boundary), masc `codex/catalog-ssot-purge-20260714`
   (`6921f46c98`, vendored-catalog purge, unlanded), RFC-0206 §2.1 (no silent
   fallback)
 
-> 2026-07-15 update: D1 is implemented on the OAS side as RFC-OAS-036
-> (`Model_catalog.merge` / `set_global_overlay`, oas#2604). That PR also
+> 2026-07-15 update: D1 is implemented on the agent_core side as RFC-OAS-036
+> (`Model_catalog.merge` / `set_global_overlay`, agent_core#2604). That PR also
 > canonicalizes `lookup_for_provider` through the catalog's own `[[providers]]`
 > alias data, which makes **D3 optional**: a deployment alias can be declared
 > as pure overlay data (a provider entry `id = "vllm-qwen3-mtp"` with
 > `aliases = ["runpod_mtp"]`) instead of a masc-side `capability-namespace`
 > key. The masc key remains the better ergonomics when the declaration should
 > live next to the endpoint in runtime.toml; decide at D3 implementation time.
-> MASC D1 now resolves and seeds only `oas-models-overlay.toml`; automatic
+> MASC D1 now resolves and seeds only `agent_core-models-overlay.toml`; automatic
 > config-root/parent full-catalog discovery and the repo full fork are retired.
 > Remaining masc-side work: D2 and D4.
 
 ## 1. Problem
 
 2026-07-15, the server refused to boot: every routed runtime was reported
-absent from the OAS capability catalog and startup declined BasePath
+absent from the agent_core capability catalog and startup declined BasePath
 ownership. Two defects compounded:
 
 1. **Integration defect (fixed by masc#24528).** The runtime adapter never
    stamped `Provider_config.provider_id`, so `capability_provider_label`
    collapsed every OpenAI-compatible provider into the wire-kind label
-   `"openai_compat"`, which no catalog row carries. Under the OAS 0.212
+   `"openai_compat"`, which no catalog row carries. Under the agent_core 0.212
    contract (a declared provider only accepts an exact provider-scoped row;
    bare-row fallback is disabled), no catalog content could satisfy the gate.
 
 2. **Structural defect (this RFC).** Capability truth for a deployment has no
    designed home. The observed consequences, all live in this deployment on
    2026-07-15:
-   - Four divergent catalog copies: oas embedded (`models.toml`, build-time),
-     `~/.config/oas/models.toml` (symlink to a checkout), the deployment
-     config-root `oas-models.toml` (hand-forked, 103 rows / 0 providers,
+   - Four divergent catalog copies: agent_core embedded (`models.toml`, build-time),
+     `~/.config/agent_core/models.toml` (symlink to a checkout), the deployment
+     config-root `agent_core-models.toml` (hand-forked, 103 rows / 0 providers,
      three generations of row encodings), and the masc repo-root
-     `oas-models.toml` (stale, read by env-coupled tests).
+     `agent_core-models.toml` (stale, read by env-coupled tests).
    - Override semantics are replace-not-merge (`Model_catalog.set_global`):
      adding one deployment row requires forking the entire catalog, and the
      fork silently masks every subsequent upstream update. Resolution order
@@ -51,7 +51,7 @@ ownership. Two defects compounded:
      leaked upstream (`provider_name = "runpod_rtxa6000"`) — the boundary
      violated in the opposite direction.
    - masc's own `[models.X.capabilities]` blocks are parsed and used by
-     masc-side validators, but never reach the OAS capability lookup: the
+     masc-side validators, but never reach the agent_core capability lookup: the
      carrier was deleted during the 0.212 diet ("v1 drops
      runtime_capabilities_override … never consumed",
      `runtime_adapter.ml`). Only `supports_tool_choice` survives. The
@@ -63,18 +63,18 @@ ownership. Two defects compounded:
      radius is not.
 
 Interim state after the incident: masc#24528 restores boot, with a
-deployment-local full fork (`<base-path>/.masc/config/oas-models.toml` = upstream copy +
+deployment-local full fork (`<base-path>/.masc/config/agent_core-models.toml` = upstream copy +
 five alias rows, labeled `WORKAROUND … removal target: overlay RFC merge`).
 That fork is the debt this RFC removes.
 
 ## 2. Design
 
-### D1. Overlay merge in `Model_catalog` (oas)
+### D1. Overlay merge in `Model_catalog` (agent_core)
 
 `Model_catalog.global ()` becomes `embedded ⊕ overlay`:
 
-- Overlay source: `oas-models-overlay.toml` in the deployment config root
-  (same resolution chain as today, minus the full-file `oas-models.toml`
+- Overlay source: `agent_core-models-overlay.toml` in the deployment config root
+  (same resolution chain as today, minus the full-file `agent_core-models.toml`
   step). It contains only delta rows and, when needed, delta provider
   entries.
 - Merge key: `(provider_name option, id_prefix)` per model row; provider `id`
@@ -89,7 +89,7 @@ That fork is the debt this RFC removes.
 Consequence: upstream updates ride along with the pin bump; deployment files
 shrink from a 173-row fork to a handful of rows; staleness class disappears.
 
-### D2. Wire `[models.X.capabilities]` into the OAS override (masc)
+### D2. Wire `[models.X.capabilities]` into the agent_core override (masc)
 
 `Provider_config.model_capabilities_override` exists and is consulted before
 any catalog lookup. Restore the carrier: materialization converts a declared
@@ -134,11 +134,11 @@ capabilities) is unchanged; only the blast radius shrinks.
 
 1. masc#24528 (landed first) — gate resolves provider-scoped rows.
 2. D3 alias mapping + D2 wiring (masc, independent PRs).
-3. D1 overlay (oas PR + release + masc pin bump).
+3. D1 overlay (agent_core PR + release + masc pin bump).
 4. Convert the deployment fork: five alias rows → either D3 mappings
    (`runpod_mtp`, `kimi_code`) or overlay delta rows (`glm-coding`
    coding-plan row, local ollama hf.co builds); delete
-   `oas-models.toml` fork and the masc repo-root copy; rewrite the eight
+   `agent_core-models.toml` fork and the masc repo-root copy; rewrite the eight
    env-coupled `test_runtime_config_validity` cases that still assert
    pre-0.212 prefix-encoded rows (red on main today).
 5. D4 boot posture last — it changes operator-visible failure semantics and
@@ -150,7 +150,7 @@ capabilities) is unchanged; only the blast radius shrinks.
   upstream change re-rots the fork; three row-encoding generations in the
   previous fork show how this ends.
 - **Add alias rows upstream**: violates RFC-OAS-034 §2 rule 1 and reverts
-  oas#2432; pollutes a shared catalog with per-deployment hosting names
+  agent_core#2432; pollutes a shared catalog with per-deployment hosting names
   (`runpod_rtxa6000` is already there and should migrate out via D1/D3).
 - **Re-enable bare-row fallback for declared providers**: reintroduces the
   exact corruption the gate exists to prevent (native Kimi vs Ollama-Cloud
@@ -163,7 +163,7 @@ capabilities) is unchanged; only the blast radius shrinks.
 - Overlay: unit tests for merge precedence (embedded row vs overlay row,
   provider-scoped vs bare), empty overlay, provider-entry overlay.
 - D2: total-conversion property — every declarable masc capability field maps
-  to the OAS field; a schema field with no OAS counterpart fails load.
+  to the agent_core field; a schema field with no agent_core counterpart fails load.
 - D3: binding with `capability-namespace` resolves upstream serving-contract
   rows; without it, table-name behavior is unchanged (masc#24528 tests).
 - D4: boot with a catalog-missing routed binding → control plane healthy,

--- a/docs/rfc/RFC-0345-stream-idle-failsafe.md
+++ b/docs/rfc/RFC-0345-stream-idle-failsafe.md
@@ -6,23 +6,23 @@
 
 ## 0. Summary
 
-A hung provider stream (bytes stop arriving mid-response, connection never closes) freezes a keeper's chat lane indefinitely. masc already threads an inter-line idle timeout (`stream_idle_timeout_s`) to OAS, but it defaults to `None` by explicit design ("neither MASC nor OAS may infer a provider/model default"), so an operator who does not set `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` gets no bound at all. Measured freeze: 30+ minutes (#25128).
+A hung provider stream (bytes stop arriving mid-response, connection never closes) freezes a keeper's chat lane indefinitely. masc already threads an inter-line idle timeout (`stream_idle_timeout_s`) to agent_core, but it defaults to `None` by explicit design ("neither MASC nor agent_core may infer a provider/model default"), so an operator who does not set `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` gets no bound at all. Measured freeze: 30+ minutes (#25128).
 
 This RFC separates two conflated concepts — a **tuned per-provider timeout** (which the current principle rightly forbids inferring) versus a **liveness fail-safe floor** (a single generous absolute ceiling that only fires on genuine hangs). It proposes adding the latter without violating the former.
 
 ## 1. Problem (evidence)
 
-- `keeper_agent_run.ml:498-509`: comment states OAS `stream_idle_timeout_s` "bounds inter-line idle on HTTP streams", and "`[None]` is carried unchanged: neither MASC nor OAS may infer a provider/model default." The value is `Keeper_runtime_resolved.stream_idle_timeout_sec () : float option` (`:503-504`), passed at `:597` as `?stream_idle_timeout_s`.
+- `keeper_agent_run.ml:498-509`: comment states agent_core `stream_idle_timeout_s` "bounds inter-line idle on HTTP streams", and "`[None]` is carried unchanged: neither MASC nor agent_core may infer a provider/model default." The value is `Keeper_runtime_resolved.stream_idle_timeout_sec () : float option` (`:503-504`), passed at `:597` as `?stream_idle_timeout_s`.
 - `env_config_keeper.ml:559-570`: `stream_idle_timeout_sec ()` reads `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC`; absent → `None`.
 - Consequence: with the env var unset (the default deployment posture), a provider stream that stalls after emitting partial output is never cancelled. The keeper's turn fiber blocks on the stream read; the chat lane makes no further progress until an external restart. `body_timeout_s` (`body_timeout_override_sec`) is likewise opt-in and does not bound *inter-chunk* idle.
 - #25128 (created 2026-07-18, label `triage-required`) records the 30+ minute freeze. The team treats it as a bug, not intended behavior.
 
-The tension: the "no inferred default" rule exists so masc/OAS never silently truncate a **slow-but-alive** stream (a provider legitimately pausing between tokens) by guessing a provider-tuned value. That rationale is sound. But it currently also permits the **degenerate** case (never-progressing stream) to hang forever.
+The tension: the "no inferred default" rule exists so masc/agent_core never silently truncate a **slow-but-alive** stream (a provider legitimately pausing between tokens) by guessing a provider-tuned value. That rationale is sound. But it currently also permits the **degenerate** case (never-progressing stream) to hang forever.
 
 ## 2. Non-goals
 
 - Per-provider or per-model tuned idle values (that is the thing the "no inferred default" rule forbids, and this RFC preserves that).
-- Changing OAS enforcement semantics. OAS already enforces whatever `stream_idle_timeout_s` it receives; this RFC only changes what masc *resolves* when the operator supplies nothing.
+- Changing agent_core enforcement semantics. agent_core already enforces whatever `stream_idle_timeout_s` it receives; this RFC only changes what masc *resolves* when the operator supplies nothing.
 - Bounding total response latency (that is `body_timeout_s`, a separate knob).
 - Retry/failover policy after a timeout fires (existing keeper error handling owns that).
 
@@ -36,7 +36,7 @@ The tension: the "no inferred default" rule exists so masc/OAS never silently tr
 ### 3.2 Options
 
 **Option A — fail-safe floor (recommended).**
-`Keeper_runtime_resolved.stream_idle_timeout_sec ()` resolves `None → Some FLOOR` where `FLOOR` is a named constant (proposed `600.0` s = 10 min, justified below). An explicit `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` still overrides. The resolved value flows through the existing `?stream_idle_timeout_s` wiring unchanged — OAS enforcement is untouched.
+`Keeper_runtime_resolved.stream_idle_timeout_sec ()` resolves `None → Some FLOOR` where `FLOOR` is a named constant (proposed `600.0` s = 10 min, justified below). An explicit `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` still overrides. The resolved value flows through the existing `?stream_idle_timeout_s` wiring unchanged — agent_core enforcement is untouched.
 - Pro: closes the indefinite-freeze hole for the default deployment posture; the value is a liveness floor, not a tuned default, so the principle holds; bounded code change at one resolution site + a constant.
 - Con: a provider that legitimately idles >10 min mid-stream would be cut. This is judged non-existent in practice (no known provider pauses 10 min between bytes of a single response); if one exists, the operator sets the env var higher (explicit override path already exists).
 
@@ -67,7 +67,7 @@ Leave the default `None`; emit a loud WARN when unset and document the knob.
 
 ## 5. Blast radius
 
-- Single resolution site (`Keeper_runtime_resolved.stream_idle_timeout_sec`) changes `None → Some FLOOR`; every consumer already handles `Some`. OAS enforcement path unchanged (it already received `float option` and acted on `Some`).
+- Single resolution site (`Keeper_runtime_resolved.stream_idle_timeout_sec`) changes `None → Some FLOOR`; every consumer already handles `Some`. agent_core enforcement path unchanged (it already received `float option` and acted on `Some`).
 - Behavioral change: deployments that previously ran with no idle bound now get a 10-min ceiling. This is the intended fix; call it out in CHANGELOG.
 - No schema change, no wire-format change, no cross-repo coordination (masc-local resolution).
 
@@ -80,4 +80,4 @@ Leave the default `None`; emit a loud WARN when unset and document the knob.
 
 ## 7. Implementation note (post-approval)
 
-Bounded: (a) name the floor constant + resolve `None → Some floor` in `Keeper_runtime_resolved`; (b) add the boot log line with source attribution; (c) test the hang-cancels / slow-survives / env-overrides matrix with a fake clock. No OAS change. Sequenced after this RFC is accepted.
+Bounded: (a) name the floor constant + resolve `None → Some floor` in `Keeper_runtime_resolved`; (b) add the boot log line with source attribution; (c) test the hang-cancels / slow-survives / env-overrides matrix with a fake clock. No agent_core change. Sequenced after this RFC is accepted.

--- a/docs/rfc/RFC-0350-unbounded-request-fiber-admission.md
+++ b/docs/rfc/RFC-0350-unbounded-request-fiber-admission.md
@@ -7,7 +7,7 @@
 
 ## 0. Summary
 
-07-17 인시던트 총평(레인 보고서)이 지목한 무제한 fork 4개 레인 중 board attention judge는 durable candidate + lifecycle-sibling 직렬 worker + candidate당 singleton exact flow로 수리됐다. MASC는 입력과 durable callback만 소유하고, target admission·provider-attempt dispatch·advance는 OAS가 소유한다. provider max-concurrent dead knob도 OAS `Provider_admission.with_admission` 배선으로 수리됐다. **나머지 3개 — fusion run fork, keeper_msg 요청 fork, HTTP/MCP accept/request fiber — 는 2026-07-18 fresh grep 기준 여전히 무제한이다.**
+07-17 인시던트 총평(레인 보고서)이 지목한 무제한 fork 4개 레인 중 board attention judge는 durable candidate + lifecycle-sibling 직렬 worker + candidate당 singleton exact flow로 수리됐다. MASC는 입력과 durable callback만 소유하고, target admission·provider-attempt dispatch·advance는 agent_core가 소유한다. provider max-concurrent dead knob도 agent_core `Provider_admission.with_admission` 배선으로 수리됐다. **나머지 3개 — fusion run fork, keeper_msg 요청 fork, HTTP/MCP accept/request fiber — 는 2026-07-18 fresh grep 기준 여전히 무제한이다.**
 
 본 RFC는 이 3개 갭에 같은 구조적 경계를 적용한다: **(1) backlog는 살아있는 fiber가 아니라 durable store에, (2) 실행은 owner lane의 직렬(또는 고정 소수 워커) drain이 독점, (3) 포화는 생산자에게 typed signal로 되돌린다.** RFC-0277이 문서화한 `cap ≠ backpressure` 교훈에 따라 임의 숫자 rate cap은 재도입하지 않는다. 숫자 상한이 불가피한 지점(HTTP 동시 연결)은 typed saturation signal + 명시적 거부 응답(503/Retry-After)으로 처리하고 silent drop을 금지한다.
 
@@ -43,8 +43,8 @@ board attention은 이 모드의 **첫 번째** 발현이었고 durable candidat
 
 ### 1.5 repo가 이미 받아들인 경계 패턴 (선례)
 
-1. **board attention judge** (#25045 계열): 생산자는 durable candidate 기록 + typed wake 요청만 하고, Keeper lifecycle의 sibling worker가 candidate를 하나씩 직렬 drain한다. 각 candidate는 singleton exact flow이며 MASC는 immutable 입력과 before-dispatch/before-advance durable callback만 소유한다. target admission·provider-attempt dispatch·advance는 OAS가 소유하고, MASC에는 batch/TTL 또는 provider 재시도 정책이 없다. record 경로는 모델 호출을 fork하지 않는다.
-2. **provider max-concurrent**: dead knob을 OAS `Provider_admission.with_admission` (`oas/lib/llm_provider/provider_admission.mli:26-33`)에 배선 — 초과분은 drop이 아니라 slot 대기.
+1. **board attention judge** (#25045 계열): 생산자는 durable candidate 기록 + typed wake 요청만 하고, Keeper lifecycle의 sibling worker가 candidate를 하나씩 직렬 drain한다. 각 candidate는 singleton exact flow이며 MASC는 immutable 입력과 before-dispatch/before-advance durable callback만 소유한다. target admission·provider-attempt dispatch·advance는 agent_core가 소유하고, MASC에는 batch/TTL 또는 provider 재시도 정책이 없다. record 경로는 모델 호출을 fork하지 않는다.
+2. **provider max-concurrent**: dead knob을 agent_core `Provider_admission.with_admission` (`agent_core/lib/llm_provider/provider_admission.mli:26-33`)에 배선 — 초과분은 drop이 아니라 slot 대기.
 3. **HITL Gate Auto Judge**: atomic claim-set + durable queue + chained drain (`keeper_gate.ml:304` `claim_auto_judge`, claim-set 타입 :283-294) — 보고서가 "구조적으로 올바르게 bounded된 유일한 LLM 레인"으로 확인한 exemplar.
 
 본 RFC는 새 패턴을 발명하지 않고 이 세 선례를 3개 갭에 이식한다.
@@ -53,7 +53,7 @@ board attention은 이 모드의 **첫 번째** 발현이었고 durable candidat
 
 - `per_hour_budget` 또는 어떤 시간당/분당 숫자 rate cap의 재도입 (RFC-0277 문서화 결정, §1.2).
 - RFC-0192가 retire한 MASC 소유 **provider-attempt** admission queue의 부활 — 레이어가 다르다 (§6).
-- OAS 강제 의미론 변경. provider-attempt 동시성은 OAS 소유로 유지 (RFC-0000 §2 Boundary Law).
+- agent_core 강제 의미론 변경. provider-attempt 동시성은 agent_core 소유로 유지 (RFC-0000 §2 Boundary Law).
 - 단일 Eio 도메인 수렴 자체의 해소 (별도 프로그램; 본 RFC는 무제한 fiber **생성**이 그 수렴을 증폭시키는 것만 차단한다).
 - SSE/세션 플레인 한도 (이미 bounded: max_clients 200, per-client 256 버퍼 등).
 - board attention·librarian·supervisor backoff 등 보고서의 다른 갭 — 각자의 RFC/PR이 소유.
@@ -123,8 +123,8 @@ board attention은 이 모드의 **첫 번째** 발현이었고 durable candidat
 
 - **RFC-0000 §1.2 (Four Laws)**: §3이 정합성 근거. 특히 LAW 4 "Fiber ≠ Durable job"이 이 3개 갭의 공통 위반 지점이다.
 - **RFC-0277 / RFC-0000 §3.7 (Fusion 경계 계약) (#22051)**: `per_hour_budget` 삭제 결정을 유지한다. 본 RFC는 rate cap을 재도입하지 않는다 — fusion의 경계는 "허용 run 수"가 아니라 "실행 소유권(단일 drain)"이다. §4.A의 Saturated 신호는 cap이 아니라 대기 상태의 typed 표면화다.
-- **RFC-0153 (Withdrawn)**: MASC↔OAS **runtime-attempt** 레이어를 다뤘다 (saturation은 측정·표시하되 provider call의 pre-dispatch 거부는 안 함). 본 RFC는 그 한 층 위 — 요청 진입 경계(도구 호출, keeper_msg submit, TCP accept) — 에서 동작하며 OAS 측 attempt 의미론은 건드리지 않는다. dead scaffold `OllamaSaturationSkip` (`lib/keeper_metrics/keeper_metrics.ml:104,322`)는 현상 유지; 배선/삭제는 본 RFC 범위 밖.
-- **RFC-0192 (Retired)**: MASC 소유 **provider-attempt** admission queue + 누적 대기 예산을 retire했다. 본 RFC는 이를 되살리지 않는다 — keeper와 provider 사이에 어떤 큐도 삽입하지 않고, provider 용량 소유는 OAS에 남는다. 여기서의 큐는 masc 자신의 요청 경계에 대한 것으로, RFC-0192가 규정한 계약("provider-attempt timeout/progress는 provider/runtime 경계 소유")과 충돌하지 않는다.
+- **RFC-0153 (Withdrawn)**: MASC↔agent_core **runtime-attempt** 레이어를 다뤘다 (saturation은 측정·표시하되 provider call의 pre-dispatch 거부는 안 함). 본 RFC는 그 한 층 위 — 요청 진입 경계(도구 호출, keeper_msg submit, TCP accept) — 에서 동작하며 agent_core 측 attempt 의미론은 건드리지 않는다. dead scaffold `OllamaSaturationSkip` (`lib/keeper_metrics/keeper_metrics.ml:104,322`)는 현상 유지; 배선/삭제는 본 RFC 범위 밖.
+- **RFC-0192 (Retired)**: MASC 소유 **provider-attempt** admission queue + 누적 대기 예산을 retire했다. 본 RFC는 이를 되살리지 않는다 — keeper와 provider 사이에 어떤 큐도 삽입하지 않고, provider 용량 소유는 agent_core에 남는다. 여기서의 큐는 masc 자신의 요청 경계에 대한 것으로, RFC-0192가 규정한 계약("provider-attempt timeout/progress는 provider/runtime 경계 소유")과 충돌하지 않는다.
 - **레인 보고서 (2026-07-17)**: 갭 인벤토리와 일반 실패 모드의 출처. 보고서 정오표가 확인한 2개 후속 RFC(masc#25055 Draft)와의 중첩 여부는 리뷰 시점에 대조한다 — 본 RFC는 보고서의 무제한 fork 3개 레인만을 스코프로 하며, 다른 후속 RFC가 같은 레인을 다루면 본 RFC가 그쪽에 양보하거나 병합한다.
 
 ## 7. NEEDS_DECISION (본 RFC는 값을 결정하지 않는다)

--- a/docs/rfc/RFC-0351-memory-first-context-management-compaction-sunset.md
+++ b/docs/rfc/RFC-0351-memory-first-context-management-compaction-sunset.md
@@ -35,7 +35,7 @@ evidence: knowledge/research/2026-07-20-memory-first-context-management-adversar
 2. **결정론 층에 남는 것은 판단이 아니다**: (a) 타입 수명(thinking=턴 스코프, tool_result=사이클 스코프), (b) 예산 산술(정수 비교), (c) 프로토콜 경계(tool_use/tool_result 쌍, provider replay 계약). 어디에도 중요도 점수·문자열 분류·휴리스틱 임계값이 없다.
 3. **어떤 단일 계층도 유일한 context manager가 되지 않는다.** fleet-freeze의 교훈은 "overflow 시점에 모든 축소 리스크가 몰린 단일 LLM 서브콜"이었다.
 4. **죽일 대상에 투자하지 않는다.** 컴팩션 파이프라인은 수리 최소화(무한루프 종결 등 안전만) 후 동결한다. 결정론적 floor(#25281 계열)도 신규 투자하지 않는다 — assembly가 floor를 대체한다.
-5. **경계 유지**: OAS는 MASC를 모른다. 필요한 OAS 표면(typed overflow, replay 계약, caller-assembled messages)은 이미 존재하며, provider별 replay 정책 교정은 capability 데이터 정정이다.
+5. **경계 유지**: agent_core는 MASC를 모른다. 필요한 agent_core 표면(typed overflow, replay 계약, caller-assembled messages)은 이미 존재하며, provider별 replay 정책 교정은 capability 데이터 정정이다.
 
 ## 3. 목표 아키텍처 (5층 ordering)
 
@@ -58,14 +58,14 @@ L5 Budget  매턴 조립 예산: keeper + dynamic + Select 결과 + 최근 창(�
 
 | 타입 | 수명 | 근거 |
 |---|---|---|
-| assistant thinking | **턴 스코프** — 진행 중 tool 루프 안에서만 유지 (provider replay 계약 준수: OAS `reasoning_dialect.replay_policy`) | reasoning 모델 일반 계약("reasoning을 다음 턴에 되돌려 보내지 마라"); rondo 47.4% 실측 |
+| assistant thinking | **턴 스코프** — 진행 중 tool 루프 안에서만 유지 (provider replay 계약 준수: agent_core `reasoning_dialect.replay_policy`) | reasoning 모델 일반 계약("reasoning을 다음 턴에 되돌려 보내지 마라"); rondo 47.4% 실측 |
 | tool_result | **사이클 스코프** — 닫힌 사이클은 조립 시 축약/스필 대상 (Anthropic "microcompact/tool-result clearing = safest touch") | rondo 23.3% |
 | assistant/user text | 의미 콘텐츠 — L1/L2가 memory로 추출, 최근 창 밖에서는 조립에서 제외 | |
 | wake marker 등 무정보 자극 | **비영속** — §5 | analyst ×359 |
 
 tool_result 의 사이클 스코프에는 최후예외가 하나 있다 (#28845): tail-window cut 이 `Newest_atom_exceeds_available` 로 거부될 때 — 최신 원자가 분할 불가능한 채로 히스토리 예산 전체보다 클 때 — 조립은 경계를 최신 원자 너머로 옮겨 딱 한 번 재시도한다. 이번 턴이 막 생산한 결과도 마커로 강등되어 나간다. 턴을 실패시키는 것보다 주소로 남기는 쪽이 낫다는 판단이며, 그 외의 경로에서는 현재 턴 제외가 그대로 유지된다.
 
-Provider별 replay 정책이 `Preserve_always`로 선언된 모델(예: mimo 계열)은 공식 문서 재검증 후 turn-스코프 정책으로 교정한다(OAS capability 데이터 정정, 별도 검증 진행 중). 문서가 실제로 cross-turn replay를 요구하면 예외로 존중한다.
+Provider별 replay 정책이 `Preserve_always`로 선언된 모델(예: mimo 계열)은 공식 문서 재검증 후 turn-스코프 정책으로 교정한다(agent_core capability 데이터 정정, 별도 검증 진행 중). 문서가 실제로 cross-turn replay를 요구하면 예외로 존중한다.
 
 ## 5. Persistence 정책 — 무정보 턴은 영구 transcript를 만들지 않는다 (#25462)
 
@@ -98,7 +98,7 @@ S4 전까지 typed trigger(`Provider_overflow | Manual`)와 partition/evidence/C
 - 결정론적 floor(#25281)의 신규 완성 (assembly가 대체; 열린 PR 처분은 S3 시점 재평가)
 - write-side jaccard/문자열 dedup (RFC-0332 기각 유지)
 - **memory lane 의 delivery accounting / due-backlog 인프라** — L1이 모델 tool call 주도로 바뀌면서 불필요해진다. 배달 보증 계층을 만드는 대신 드롭이 발생할 수 있는 구조 자체를 없앤다. `Keeper_memory_lane`은 librarian 보조 추출 전용으로 축소 유지하되, 그 경로의 유실은 계측(counter)만 하고 인프라 투자는 하지 않는다.
-- OAS에 MASC 개념 유입 (replay 교정은 provider capability 데이터 정정일 뿐)
+- agent_core에 MASC 개념 유입 (replay 교정은 provider capability 데이터 정정일 뿐)
 
 ## 9. 리스크
 

--- a/docs/rfc/RFC-0352-legacy-goal-contradiction-resolution.md
+++ b/docs/rfc/RFC-0352-legacy-goal-contradiction-resolution.md
@@ -3,7 +3,7 @@
 - Status: **Accepted — Path B (오너 결정 2026-07-21)**
 - Decision: §4의 1문항에 오너가 **(a) Goal은 1급 엔티티** 로 답함 → Path B 채택. RFC-0000 §3.2 카드 재작성·§11 D10 DECIDED 처리는 본 RFC와 같은 PR에서 집행됨.
 - Date: 2026-07-21
-- Evidence: 2026-07-21 dead-surface 적대적 감사 (`~/me/reports/masc-oas-dead-surface-adversarial-audit-2026-07-21.md`, 판정 4건: `retired/legacy-goal-*` 전부 **ALIVE**, `spec-map/goal-loop-spec-self-conflict` **ALIVE**)
+- Evidence: 2026-07-21 dead-surface 적대적 감사 (`~/me/reports/masc-agent_core-dead-surface-adversarial-audit-2026-07-21.md`, 판정 4건: `retired/legacy-goal-*` 전부 **ALIVE**, `spec-map/goal-loop-spec-self-conflict` **ALIVE**)
 - Blocks: goal 일가족 정리 (감사 Tier B 최대 항목, 합계 ~13k LoC 규모)
 - Non-blocking: goal_loop 스크립트 10개+Python 테스트 8개(4,844 LoC)는 **어느 결정과도 양립하는 삭제**라 본 RFC와 무관하게 진행 가능 (RFC-0000:781 KILL 행, 자동 호출자 0 확인)
 

--- a/docs/rfc/RFC-0353-failure-classification-boundary.md
+++ b/docs/rfc/RFC-0353-failure-classification-boundary.md
@@ -1,7 +1,7 @@
 # RFC-0353 — 실패 분류가 모듈 경계에서 소실되는 결함 (결정 요청)
 
 **Status**: Draft — 결정 요청
-**연관**: #25489 (수집 이슈), #25482, #25488, #25443, #24838, oas#2736, #25052
+**연관**: #25489 (수집 이슈), #25482, #25488, #25443, #24838, agent_core#2736, #25052
 **제약**: RFC-0000 §1.2 LAW 1 (No dead-end) · LAW 2 (연속 횟수는 결정 권한 없음) · §9 Anti-patterns
 
 ---
@@ -28,7 +28,7 @@
 
 | # | 위치 | 소실 방식 | 실측 |
 |---|---|---|---|
-| oas#2736 | `reasoning_history_projection` | 인과가 다른 두 모집단이 단일 집계 | `No_replay` 217k + replay-all 112k/일이 한 필드에 합산. 이후 #2721 로 Warn→Info |
+| agent_core#2736 | `reasoning_history_projection` | 인과가 다른 두 모집단이 단일 집계 | `No_replay` 217k + replay-all 112k/일이 한 필드에 합산. 이후 #2721 로 Warn→Info |
 | #25052 | `keeper_memory_lane:242` | drop 시 unit 미식별 + `let (_ : outcome) =` | 343건/일. analyst 24.2% |
 | #24838 | `http_client_4xx_request_header_profile` | 배제된 가설만 측정 | `max_single_header=81` vs `limit=8192`. body 크기는 ollama 경로에서 미기록(glm 81건 / ollama 0건) |
 
@@ -36,7 +36,7 @@
 
 ### 1.3 이 목록이 어떻게 만들어졌는가
 
-운영 워크스페이스의 `<base-path>/logs/system_log_*.jsonl` ERROR/WARN 을 36회 반복 스윕하며 수집했다. 각 항목은 시간대별 버킷팅으로 라이브 여부를 확인했고, 같은 방식으로 **이미 해소된 2건은 목록에서 제외**했다(oas#2734, #25487 — 각각 03Z·08Z 경계로 소멸, 이슈 종료). 코드 주장은 `.mli`/모듈 doc 대조로 검증했다.
+운영 워크스페이스의 `<base-path>/logs/system_log_*.jsonl` ERROR/WARN 을 36회 반복 스윕하며 수집했다. 각 항목은 시간대별 버킷팅으로 라이브 여부를 확인했고, 같은 방식으로 **이미 해소된 2건은 목록에서 제외**했다(agent_core#2734, #25487 — 각각 03Z·08Z 경계로 소멸, 이슈 종료). 코드 주장은 `.mli`/모듈 doc 대조로 검증했다.
 
 ---
 
@@ -46,7 +46,7 @@
 2. **타입 시스템이 막지 못한다.** 여섯 건 모두 컴파일되는 형태다 — catch-all `| Error _ ->`, nullary variant, match 순서 의존, `let (_ : t) =`. 한 사이트를 고쳐도 다음 사이트가 같은 코드를 다시 쓴다.
 3. **AI 에이전트가 선례로 학습한다.** CLAUDE.md 가 명시한 누적 메커니즘이며, 현재 코드베이스 통계상 "실패를 catch-all 로 requeue" 는 합리적 패턴으로 보인다.
 4. **비용이 직접 발생한다.** 형태 A 는 성공 확률 0 인 provider 호출을 소비한다.
-5. **은폐 수단이 관습화되어 있다.** oas#2721 은 분해 불가능한 신호를 통째로 Info 로 낮췄다. 형태 B 는 고치지 않으면 *보이지 않게* 된다.
+5. **은폐 수단이 관습화되어 있다.** agent_core#2721 은 분해 불가능한 신호를 통째로 Info 로 낮췄다. 형태 B 는 고치지 않으면 *보이지 않게* 된다.
 
 ---
 
@@ -72,7 +72,7 @@
 
 - **작업**: 실패 타입에 두 축을 필수화한다 — (1) 재시도 가능성, (2) 사유 payload. nullary 실패 variant 금지. 경계 통과 시 재시도 가능성을 뒤집는 변환을 타입으로 차단하거나 명시적 근거를 요구. 재시도/회전 자격을 분리(현재 `InvalidRequest` 하나가 둘을 동시에 차단).
 - **장점**: 재발이 구조적으로 막힌다. 새 실패 경로가 컴파일 시점에 결정을 강제받는다.
-- **단점/리스크**: 실패 타입이 공개 경계(oas ↔ masc)에 걸쳐 있어 변경 범위가 크다. oas 는 별도 repo 이므로 pin 조율 필요. RFC-OAS-035 가 "source compatibility 를 위해 `ProviderUnavailable` 로 투영" 을 명시했으므로 그 결정의 재검토가 선행된다.
+- **단점/리스크**: 실패 타입이 공개 경계(agent_core ↔ masc)에 걸쳐 있어 변경 범위가 크다. agent_core 와 masc 는 함께 움직인다. RFC-OAS-035 가 "source compatibility 를 위해 `ProviderUnavailable` 로 투영" 을 명시했으므로 그 결정의 재검토가 선행된다.
 
 ### Path B — 소비 지점 규율 (lint + 명시 match)
 
@@ -91,7 +91,7 @@
 ## 5. 결정 요청
 
 1. **Path A / B / C 중 어느 것인가.** (제안: C → A. 관측을 먼저 세우고 타입 강제로 수렴. B 의 lint 는 A 착지 전 회귀 방지로 병행 가능.)
-2. **oas 경계 처리.** RFC-OAS-035 의 `ProviderUnavailable` 투영 결정을 재검토 대상으로 열 것인가, masc 쪽에서만 흡수할 것인가.
+2. **agent_core 경계 처리.** RFC-OAS-035 의 `ProviderUnavailable` 투영 결정을 재검토 대상으로 열 것인가, masc 쪽에서만 흡수할 것인가.
 3. **재시도 이탈 시의 목적지 상태.** LAW 1 이 허용하는 `Awaiting` / `Recovering` 중 어느 쪽인가, 아니면 새 typed 상태가 필요한가.
 4. **선행 조사 승인.** 현재 코드베이스의 실패 소비 지점 catch-all 규모 전수 조사(§4 Path B 의 미지수). 규모를 모른 채 lint 를 세우면 대량 위반으로 CI 가 막힌다.
 

--- a/docs/rfc/RFC-async-log-sink-durable-append-offload.md
+++ b/docs/rfc/RFC-async-log-sink-durable-append-offload.md
@@ -29,7 +29,7 @@ latent throughput bottleneck for **all 644+ `Log.{Runtime,Keeper,Mcp}.{warn,erro
 call sites**, not any one subsystem.
 
 It became load-bearing when #25162 (`Oas_diag_sink`) added a new high-rate
-producer: OAS `Llm_provider.Diag.warn/error` now route into `Log.Runtime`, so a
+producer: agent_core `Llm_provider.Diag.warn/error` now route into `Log.Runtime`, so a
 provider 4xx/429 storm (observed: deepseek-v4-flash ~78% 4xx) fires one
 synchronous durable flush per rejected request, serializing provider fibers on
 the log mutex + disk flush precisely during the storm. #25162 merged with this
@@ -115,7 +115,7 @@ rewrite would break boot/shutdown logging.
 
 ## 6. Alternative rejected: bound at `Oas_diag_sink`
 
-Dedupe/sample/rate-bound the `oas:*` warns at `oas_diag_sink.ml:24-48`. Rejected
+Dedupe/sample/rate-bound the `agent_core:*` warns at `oas_diag_sink.ml:24-48`. Rejected
 as a standalone fix: (a) it quiets only the one new producer while the other
 644+ warn/error sites keep hitting the same synchronous flush; (b) cap / cooldown
 / dedup / sample is an explicit manifest workaround-rejection signature requiring
@@ -133,7 +133,7 @@ P1 is latent, not production-blocking now).
    path, line lands immediately; then start consumer → subsequent lines defer.
 4. Shutdown-drain: enqueue, cancel the switch, assert residue synchronously
    flushed via `on_release` (models safety invariant #1).
-5. Storm/harness: simulate the deepseek 429 pattern (hundreds of `oas:*`
+5. Storm/harness: simulate the deepseek 429 pattern (hundreds of `agent_core:*`
    `Diag.warn`/s); assert producer emit latency stays bounded (no per-record
    flush syscall on the emitting fiber).
 6. Interleave (RFC-0108 regression): concurrent producers never emit `}{`-concat

--- a/docs/rfc/RFC-compaction-deterministic-floor.md
+++ b/docs/rfc/RFC-compaction-deterministic-floor.md
@@ -115,7 +115,7 @@ but the reactive path — the one that matters for the spiral — does not persi
 
 PR #25232 tried to reduce *how much* accumulates by stamping/superseding
 world-state user messages; it was a no-op because masc metadata cannot cross the
-OAS conversation boundary (see the world-state-channel-split RFC). That work is
+agent_core conversation boundary (see the world-state-channel-split RFC). That work is
 upstream (reduce accumulation); **this** RFC is downstream (guarantee reduction
 when the window is already exceeded). They are complementary, not alternatives.
 
@@ -177,7 +177,7 @@ floor would therefore drop the foundational setup. Two protections cover this:
 - a positional **head window** (`floor_protected_head_units`) for the leading
   setup, and
 - **explicit protection of the first User unit** (`first_user_goal_index`) — the
-  OAS goal. A fixed head window alone does not suffice: if System/setup units
+  agent_core goal. A fixed head window alone does not suffice: if System/setup units
   precede the goal, it can sit just past the window and be dropped (review
   #25281 P1.2). Protecting its exact index guarantees the goal survives wherever
   it is.
@@ -207,7 +207,7 @@ one. Be precise about the two residuals:
   1. a **byte-heuristic** token estimate — which the codebase explicitly rejects
      as a capacity guess (#25092: "not a tokenizer estimate, byte heuristic";
      #25130: "does not infer capacity from bytes"; CLAUDE.md workaround bar), or
-  2. the **actual-wire typed fit authority** — OAS #2667, which is unresolved and
+  2. the **actual-wire typed fit authority** — agent_core #2667, which is unresolved and
      is the same dependency the attention-worker capacity split waits on.
 
   So the adaptive tail is **not merely a follow-up: it is blocked on #2667.**

--- a/docs/rfc/RFC-keeper-runtime-context-observation-phase0.md
+++ b/docs/rfc/RFC-keeper-runtime-context-observation-phase0.md
@@ -103,7 +103,7 @@ This RFC authorizes one hard-cut implementation slice:
    decision-log guessing, and zero-call fabrication.
 6. Remove producer-less metrics context, model, drift, compaction, fallback,
    event, and history surfaces instead of filling them with defaults.
-7. Delete the dormant context-bearing OAS keeper snapshot publisher and its
+7. Delete the dormant context-bearing agent_core keeper snapshot publisher and its
    Dashboard decoder/state.
 8. Make the direct `keeper_context_status` tool output and both of its
    descriptors state checkpoint/session facts without promising unobserved
@@ -112,7 +112,7 @@ This RFC authorizes one hard-cut implementation slice:
 
 The implementation changes observation writers and read models. It does not
 change Keeper turn scheduling, heartbeat cadence, compaction admission,
-provider routing, checkpoints, or the OAS runtime contract.
+provider routing, checkpoints, or the agent_core runtime contract.
 
 ## 4. Typed contract
 
@@ -271,14 +271,14 @@ Implementation blast radius:
   harness, and operator tool audit;
 - shared missing-context projection and operator/status call sites;
 - direct `keeper_context_status` output, model schema, and internal descriptor;
-- Dashboard Keeper/OAS types, normalizers, telemetry panels, and focused tests;
+- Dashboard Keeper/agent_core types, normalizers, telemetry panels, and focused tests;
 - deletion of the private context snapshot decoder, producer-less compaction
-  history options, tool-alias facade, dormant OAS snapshot publisher/decoder,
+  history options, tool-alias facade, dormant agent_core snapshot publisher/decoder,
   and their tests;
 - `docs/KEEPER-USER-MANUAL.md` and
   `docs/SYSTEM-EVENT-AND-SNAPSHOT-INVENTORY.md`.
 
-Compaction policy, provider routing, and OAS request/response serialization
+Compaction policy, provider routing, and agent_core request/response serialization
 remain outside this RFC.
 
 ## 8. Rejected alternatives

--- a/docs/rfc/RFC-keeper-workspace-root-only.md
+++ b/docs/rfc/RFC-keeper-workspace-root-only.md
@@ -166,8 +166,8 @@ RFC-0312 (**Accepted**, PR #23359) 가 "keeper repo 매핑은 advisory default s
       so no repos/<repo> cwd exists yet
 변경: no git checkout found under your workspace root
 
-현재: available repo cwds: repos/masc, repos/oas
-변경: git checkouts under your workspace root: masc, work/oas, .tmp/task-12
+현재: available repo cwds: repos/masc, repos/agent_core
+변경: git checkouts under your workspace root: masc, work/agent_core, .tmp/task-12
 ```
 
 앞의 것은 **어디에 있어야 하는지를 주장**하고 뒤의 것은 **어디에 있는지를 보고**한다. 앞은 틀릴 수 있고(379건/24h 틀렸다) 뒤는 틀릴 수 없다.

--- a/docs/rfc/RFC-memory-os-bounded-context-and-librarian-curator.md
+++ b/docs/rfc/RFC-memory-os-bounded-context-and-librarian-curator.md
@@ -118,7 +118,7 @@ working set이 "구성상 유계"이려면 모든 항이 유계여야 한다. K�
 2. **PR-B** keeper 변수 주입 (§3.4) — 계약 불변, 템플릿+변수.
 3. **PR-C** exact 실패 타이핑 + compaction terminal phase (§3.6 이행기, #26533과 정합).
 4. curator ops 계약 교체 (§3.3) — 스키마·파서·검증·템플릿. 하네스로 준수율 측정 동반.
-5. 전송 계약 (§3.1) — K/M 결정(선행 측정: OAS checkpoint JSON에서 tool result 비중 실측), elision, archive 조회 도구.
+5. 전송 계약 (§3.1) — K/M 결정(선행 측정: agent_core checkpoint JSON에서 tool result 비중 실측), elision, archive 조회 도구.
 6. 숙청 — compaction_exact lane, 화석 템플릿 2종(`memory_consolidation`, `episode_extraction`), request-body cap 재평가(§3.1이 상한을 구성으로 보장하면 거절 cap은 중복 gate).
 
 ## 5. 비제안

--- a/docs/rfc/RFC-runtime-note-field-and-dashboard-surfacing.md
+++ b/docs/rfc/RFC-runtime-note-field-and-dashboard-surfacing.md
@@ -31,7 +31,7 @@ Two structural causes, grounded:
 | Cause | Evidence |
 |---|---|
 | No typed rationale field exists | `dashboard/src/lib/runtime-toml-config.ts` parses `RuntimeTomlProvider`/`Model`/`Binding`; `rg note` → 0 hits. The only optional string is `displayName` (parsed by the same helper in `runtime-toml-config.ts` at anchor commit `6c9029bcbf`). |
-| Dashboard runtime detail surfaces no rationale | `RuntimePanel` (`런타임` tab) = "OAS health chip + runtime monitor only" (operational); the `runtime.toml` tab = a **raw textarea** in `RuntimeTomlEditor`. The rationale exists only as raw-text comments visible in that textarea — there is no structured per-runtime rationale surface in the `런타임`/`전체` views, so an operator scanning the structured runtime list cannot see "why this default" without dropping into raw text. |
+| Dashboard runtime detail surfaces no rationale | `RuntimePanel` (`런타임` tab) = "agent_core health chip + runtime monitor only" (operational); the `runtime.toml` tab = a **raw textarea** in `RuntimeTomlEditor`. The rationale exists only as raw-text comments visible in that textarea — there is no structured per-runtime rationale surface in the `런타임`/`전체` views, so an operator scanning the structured runtime list cannot see "why this default" without dropping into raw text. |
 
 ## 2. Boundary & invariants
 
@@ -50,9 +50,9 @@ Two structural causes, grounded:
 
 Spec §7.3.1 (`masc-mcp/docs/spec/14-configuration.md`) already defines `keeper-assignable` — a typed `bool` metadata field on `tier`/`runtime` consumed by the dashboard/runtime manager, ignored by the dispatch parser. `note` follows the identical pattern: typed, optional, dashboard-consumed, dispatch-ignored. We are extending an established metadata lane, not inventing one.
 
-### 2.3 OAS boundary
+### 2.3 agent_core boundary
 
-Untouched. OAS owns provider/model/transport/turn-lifecycle. `note` never crosses into OAS — it is not in `Runtime_schema.config`.
+Untouched. agent_core owns provider/model/transport/turn-lifecycle. `note` never crosses into agent_core — it is not in `Runtime_schema.config`.
 
 ### 2.4 No second SSOT
 

--- a/docs/rfc/auth-bootstrap-grace-token-proof.md
+++ b/docs/rfc/auth-bootstrap-grace-token-proof.md
@@ -4,7 +4,7 @@
 - Author: Claude (Sonnet 5), on behalf of jeong-sik (vincent)
 - Date: 2026-07-01
 - Related: RFC-0292 (Complete lib/auth de-duplication — out of scope: auth behavior; this RFC is exactly that behavior)
-- Tracking: masc-oas keeper-fleet audit 2026-07-01, item 12 (auth/dashboard token)
+- Tracking: masc-agent_core keeper-fleet audit 2026-07-01, item 12 (auth/dashboard token)
 
 ## 1. Problem
 

--- a/docs/rfc/mcp-dual-bearer-oauth.md
+++ b/docs/rfc/mcp-dual-bearer-oauth.md
@@ -241,7 +241,7 @@ redaction.
 - Existing static bearer files and their JSON schema are unchanged.
 - `bearer_token_env_var` remains supported.
 - OAuth is off unless explicitly enabled.
-- No OAS dependency or protocol change is introduced.
+- No agent_core dependency or protocol change is introduced.
 - No dashboard session or cookie becomes an ambient OAuth login authority.
 - MCP authorization changes only token resolution and the 401 challenge header;
   the existing permission matrix remains authoritative.


### PR DESCRIPTION
## 배경

#29241 이 Active/Implemented RFC 28 개를 정정했다. 이 PR 은 남은 50 개(Draft + status 없음)에 같은 정정을 적용한다.

50 파일 / 185 줄.

## 첫 패스가 놓친 것 — 한글 조사

`\bOAS\b` 는 `OAS는` / `OAS에` 를 매치하지 않는다. 뒤따르는 문자가 한글이라 단어 경계가 성립하지 않기 때문이다. 그래서 첫 패스는 **잔여 0 건이라고 보고하면서 17 건을 남겼다**. `OAS(?=[가-힣])` 로 다시 훑었다.

같은 이유로 이번 검증은 조사별 패턴이 아니라 `RFC-OAS-NNN` 만 제외한 전수 스캔으로 했다.

## 유지한 것

**코드 식별자.** 이름을 바꾸면 인용이 맞아지는 게 아니라 틀려진다.

| 식별자 | 근거 |
|---|---|
| `OAS_DISCOVERY_PORTS`, `OAS_OLLAMA_THINK_DEFAULT`, `OAS_VOCAB_PHASE` | 런타임이 지금 읽는 환경변수 |
| `keeper_hooks_oas` | 심볼 존재 |
| `RFC-OAS-NNN` | `packages/agent_core/docs/rfc/` 에 실재, 코드가 인용 |

**RFC-0233 의 "agent_core owns the run/turn lifecycle and stays MASC-agnostic".** 흡수 후에도 참이다. `packages/agent_core/lib` 는 masc 심볼을 참조하지 않는다 (`Masc_domain` / `Workspace.` / `Keeper_runtime` 0 건). 흡수가 없앤 것은 repo 경계이고 의존성 방향은 그대로다.

**`masc ↔ agent_core` 표기.** 레이어 경계는 살아있다.

## 재작성한 것

RFC-0353 의 `agent_core 는 별도 repo 이므로 pin 조율 필요` → `agent_core 와 masc 는 함께 움직인다`. pin 조율은 별도 repo 의 결과였고 그 repo 가 없어졌다.

## 절차 문제 하나

이 커밋은 원래 #29241 브랜치에 올렸는데 그 PR 이 이미 머지된 뒤였다. squash merge 이후의 push 는 main 에 도달하지 않으므로 새 브랜치로 옮겼다. `gh pr view --json state` 로 확인은 했으나 결과에 따라 멈추는 분기를 걸지 않은 것이 원인이다.
