### PR TITLE
fix(e2e): capture the page when the composition proof times out

### DIFF
--- a/dashboard/e2e/keeper-composition-real-backend.mjs
+++ b/dashboard/e2e/keeper-composition-real-backend.mjs
@@ -23,6 +23,8 @@ const screenshotPath = join(artifactDir, 'keeper-composition-inspector.png')
 const measurementPath = join(artifactDir, 'keeper-composition-inspector.json')
 const persistenceScreenshotPath = join(artifactDir, 'keeper-persistence-proof.png')
 const persistenceMeasurementPath = join(artifactDir, 'keeper-persistence-proof.json')
+const failureScreenshotPath = join(artifactDir, 'keeper-composition-failure.png')
+const failureStatePath = join(artifactDir, 'keeper-composition-failure.json')
 const viewport = { width: 1440, height: 1000 }
 
 const healthResponse = await fetch(new URL('/health?full=1', dashboardUrl))
@@ -238,6 +240,37 @@ try {
     `${JSON.stringify(persistenceMeasurement, null, 2)}\n`,
   )
   process.stdout.write(`${JSON.stringify({ composition: measurement, persistence: persistenceMeasurement })}\n`)
+} catch (error) {
+  // The success path screenshots after every assertion has passed, so a locator
+  // timeout produced only its own message: run 32434575143 aborted on
+  // getByLabel('메시지 입력') with no record of what the page actually showed.
+  // The aria-label exists in the component, so the element was absent from the
+  // rendered state rather than mislocated, and separating "keeper missing from
+  // the list" from "route selected nothing" from "panel refused to draw" needs
+  // the page itself. Capture is best-effort: a browser that died takes its
+  // page with it, and the original error must still surface.
+  try {
+    const page = browser.contexts()[0]?.pages()[0]
+    if (page) {
+      await page.screenshot({ path: failureScreenshotPath, fullPage: true })
+      writeFileSync(
+        failureStatePath,
+        `${JSON.stringify(
+          {
+            error: String(error?.message ?? error),
+            url: page.url(),
+            title: await page.title(),
+            body_text: (await page.locator('body').innerText()).slice(0, 20000),
+          },
+          null,
+          2,
+        )}\n`,
+      )
+    }
+  } catch (captureError) {
+    process.stderr.write(`failure capture unavailable: ${captureError}\n`)
+  }
+  throw error
 } finally {
   await browser.close()
 }


### PR DESCRIPTION
## 현상

acceptance의 브라우저 증명이 타임아웃으로 죽는데, **화면에 뭐가 떠 있었는지 기록이 없습니다.**

```
locator.waitFor: Timeout 30000ms exceeded.
  - waiting for getByLabel('메시지 입력') to be visible
```

스크린샷을 찍는 코드는 있는데 **모든 단정을 통과한 뒤**에 있습니다. `waitFor`에서 던지면 거기까지 못 갑니다.

## 왜 화면이 필요한가

`aria-label="메시지 입력"`은 컴포넌트에 실제로 있습니다 (`dashboard/src/components/chat/primitives.ts:4911`). 그러니 locator가 틀린 게 아니라 **그 요소가 그려진 화면에 없었던** 겁니다.

여기까지는 알겠는데, 그 다음이 안 갈립니다.

| 후보 | 확인 방법 |
|---|---|
| 그 키퍼가 목록에 없음 | 화면에 키퍼 목록이 떴는지 |
| 주소 해시가 화면을 못 고름 | 어느 화면이 떴는지 |
| 턴이 실패한 키퍼라 패널이 안 그려짐 | 패널 자리에 뭐가 있는지 |

셋 다 화면을 보면 바로 갈리는데, 지금 evidence엔 타임아웃 문자열만 남습니다.

## 변경

실패 경로에서 다시 던지기 전에 남깁니다.

- `keeper-composition-failure.png` — 전체 화면
- `keeper-composition-failure.json` — 에러 메시지, 주소, 제목, 본문 텍스트 (20000자까지)

브라우저 evidence 디렉터리에 쓰므로 기존 아티팩트에 같이 올라갑니다 (업로드 단계가 `if: always()`).

## 안전장치

캡처 자체가 실패할 수 있습니다 (브라우저가 죽었으면 페이지도 같이 갑니다). 그 경우 캡처 실패를 stderr에 알리고 **원래 에러를 그대로 던집니다.** 진단을 남기려다 원인을 가리는 일은 없습니다.

## 검증

```
node --check dashboard/e2e/keeper-composition-real-backend.mjs   통과
```

`dashboard/package.json`의 lint는 `eslint src` 라 `e2e/`는 대상이 아닙니다.

실제 캡처 동작은 acceptance가 다시 실패할 때 확인됩니다 — 지금은 재현 경로가 CI 승인 필요라 로컬에서 못 돌렸습니다.

Refs #29183
