### PR TITLE
fix(test): let the ownerless admission predicate answer every cleanup reason

### DIFF
--- a/test/test_keeper_shutdown_ownerless_admission_release.ml
+++ b/test/test_keeper_shutdown_ownerless_admission_release.ml
@@ -399,14 +399,21 @@ let test_predicate_rejects_other_lookup_errors () =
 
 (* Owner absence plus missing metadata is only terminal removal evidence when
    the operation itself promised [Remove_meta]. Retain-meta operations must
-   keep surfacing the inconsistency. *)
-let test_predicate_rejects_retain_meta_intents () =
+   keep surfacing the inconsistency.
+
+   Every [cleanup_reason] is listed so that adding one forces a decision here
+   rather than inheriting whichever answer the new variant happens to fall
+   into. [Supervisor_cleanup] is the case that made this matter: it replaced
+   [Dead_tombstone_cleanup], whose disposition was retain, and moved to
+   [Remove_meta] at the same time. The rename carried the old expectation with
+   it and left main red. *)
+let test_predicate_answers_every_cleanup_reason () =
   with_workspace (fun ~config ->
     let owner_not_found name =
       Keeper_owner_registry.Command_lookup_failed
         (Keeper_owner_registry.Owner_not_found name)
     in
-    let check_reason label reason =
+    let check_reason label reason ~is_removal_evidence =
       let operation =
         make_operation
           ~keeper_name:label
@@ -415,15 +422,35 @@ let test_predicate_rejects_retain_meta_intents () =
       in
       check
         bool
-        (label ^ ": retain-meta intent is not removal evidence")
-        false
+        (label
+         ^ ": "
+         ^ (if is_removal_evidence then "removal" else "retain")
+         ^ " intent decides the admission release")
+        is_removal_evidence
         (Keeper_shutdown_finalize.admission_already_released_by_removal
            ~config
            operation
            (owner_not_found label))
     in
-    check_reason "ownerless-retain-operator" Operator_stop_retain_meta;
-    check_reason "ownerless-retain-tombstone" Supervisor_cleanup)
+    check_reason
+      "ownerless-retain-operator"
+      Operator_stop_retain_meta
+      ~is_removal_evidence:false;
+    check_reason
+      "ownerless-remove-operator"
+      Operator_stop_remove_meta
+      ~is_removal_evidence:true;
+    check_reason
+      "ownerless-supervisor-cleanup"
+      Supervisor_cleanup
+      ~is_removal_evidence:true;
+    check_reason
+      "ownerless-dashboard-purge"
+      (Dashboard_keeper_purge
+         { requested_name = "ownerless-dashboard-purge"
+         ; agent_name = "ownerless-dashboard-purge"
+         })
+      ~is_removal_evidence:true)
 ;;
 
 (* The cases above enter through [recover_operation_with_corrupt_owner_fence].
@@ -679,9 +706,9 @@ let () =
             `Quick
             test_predicate_rejects_other_lookup_errors
         ; Alcotest.test_case
-            "predicate rejects retain-meta intents"
+            "predicate answers every cleanup reason"
             `Quick
-            test_predicate_rejects_retain_meta_intents
+            test_predicate_answers_every_cleanup_reason
         ; Alcotest.test_case
             "corrupt sibling does not hide ownerless operator-retain"
             `Quick


### PR DESCRIPTION
## 현상

main이 빨갛습니다.

```
[FAIL] recovery 10  predicate rejects retain-meta intents.
FAIL ownerless-retain-tombstone: retain-meta intent is not removal evidence
```

## 원인

#29218이 `Dead_tombstone_cleanup`을 `Supervisor_cleanup`으로 바꾸면서 **처분도 같이 바꿨습니다.**

```ocaml
(* 전 *)  | Dead_tombstone_cleanup -> Retain_dead_tombstone
(* 후 *)  | Supervisor_cleanup     -> Remove_meta
```

테스트 쪽은 생성자 이름만 따라 바뀌었고 기대값은 그대로였습니다.

```ocaml
check_reason "ownerless-retain-tombstone" Supervisor_cleanup   (* false 를 기대 *)
```

이름이 맞으니 컴파일은 통과하고, 실행에서 갈립니다. `Remove_meta`는 주인이 없고 메타도 없으면 삭제 증거로 인정하므로 `true`가 나옵니다.

**이름 바꾸기는 기계가 했는데 의미 바꾸기는 사람 몫이었고, 둘을 맞추라고 강제하는 장치가 없었습니다.** 테스트가 "retain일 것들"만 나열하고 나머지는 언급하지 않는 형태여서, 새 변형이 어느 쪽인지 아무도 안 물었어요.

## 변경

`cleanup_reason`의 **모든 변형**을 답과 함께 나열합니다.

| reason | 삭제 증거인가 |
|---|---|
| `Operator_stop_retain_meta` | 아니오 |
| `Operator_stop_remove_meta` | 예 |
| `Supervisor_cleanup` | 예 |
| `Dashboard_keeper_purge` | 예 |

이제 변형을 추가하면 **어느 쪽인지 적을 때까지 여기서 실패합니다.** 빠뜨린 변형이 조용히 한쪽으로 흘러가지 않아요.

테스트 이름도 `predicate answers every cleanup reason`으로 바꿨습니다 — 하는 일이 달라졌으니까요.

## 검증

```
dune build @check                                        통과
test_keeper_shutdown_ownerless_admission_release   12 tests  Successful
```

Refs #29218
