### PR TITLE
chore(keeper): erase the dead-tombstone concept the rename left behind

### DIFF
--- a/lib/keeper/keeper_goal_assignment_wake.mli
+++ b/lib/keeper/keeper_goal_assignment_wake.mli
@@ -22,6 +22,6 @@ val enqueue_goal_assigned_wakes :
 (** Enqueue one [Goal_assigned] stimulus per added goal (title resolved from
     Goal_store at enqueue time; a goal deleted between validation and
     enqueue falls back to its id as the label). The durable queue append
-    precedes the Running-lane wake hint; inactive, paused, and dead-tombstone
-    lanes retain the queued entry without receiving the hint. Returns the added
+    precedes the Running-lane wake hint; inactive and paused lanes retain the
+    queued entry without receiving the hint. Returns the added
     goal ids. *)

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -1245,11 +1245,6 @@ let run_heartbeat_loop
           | Intake_lifecycle_blocked _ -> true
           | Intake_admitted -> false
         in
-        let terminal_lifecycle_blocked =
-          match intake_admission with
-          | Intake_lifecycle_blocked (Keeper_lifecycle_admission.Autonomous_paused _)
-          | Intake_admitted -> false
-        in
         (match intake_admission with
          | Intake_admitted -> ()
          | Intake_lifecycle_blocked denial ->
@@ -1272,15 +1267,12 @@ let run_heartbeat_loop
              "%s: heartbeat intake denied by lifecycle admission: %s"
              meta_current.name
              reason;
-           if terminal_lifecycle_blocked
-           then
-             (* A dead tombstone owns no runnable lane. Ordinary pause keeps
-                its lane parked so an explicit resume remains local. *)
-             Atomic.set stop true
-           else
-             Keeper_registry.touch_last_turn_ts
-               ~base_path:ctx.config.base_path
-               meta_current.name
+           (* [autonomous_denial] carries one variant, an ordinary pause, which
+              keeps the lane parked so an explicit resume stays local. The loop
+              therefore never stops itself here. *)
+           Keeper_registry.touch_last_turn_ts
+             ~base_path:ctx.config.base_path
+             meta_current.name
          );
         let pending_board_events, meta_after_triage =
           if admitted_turn

--- a/lib/keeper/keeper_invariant_check.mli
+++ b/lib/keeper/keeper_invariant_check.mli
@@ -39,7 +39,6 @@ val check_step_invariants :
     1. TypeOK
     6. RunningRequiresFiber
     7. StoppedRequiresDrain
-    8. DeadRequiresTombstone
     9. DerivePhaseAgreement
 
     Suitable for periodic sweep-time scans (e.g. keeper supervisor audit).

--- a/lib/keeper/keeper_keepalive_signal.mli
+++ b/lib/keeper/keeper_keepalive_signal.mli
@@ -123,8 +123,8 @@ val interruptible_sleep :
     When [?stimulus] is given, the stimulus is durably appended to the keeper's
     Event Layer queue ([Keeper_registry_event_queue.enqueue]) independently of
     lifecycle phase. The wake hint is sent only to a lifecycle-admitted Running
-    Keeper; inactive, paused, and dead-tombstone lanes retain the durable event
-    without a false delivery claim. If no live registry entry exists, callers
+    Keeper; inactive and paused lanes retain the durable event without a
+    false delivery claim. If no live registry entry exists, callers
     must supply [base_path] so the payload can be persisted for replay. Callers
     that only need to break the keeper out of [interruptible_sleep] may omit the
     stimulus. See RFC-0020 §3 (data channel vs hint signal). *)

--- a/lib/keeper/keeper_lifecycle_hooks.mli
+++ b/lib/keeper/keeper_lifecycle_hooks.mli
@@ -37,7 +37,7 @@ type event =
           phase changes after the registry write commits. Hooks observe an
           applied transition; they cannot veto. *)
   | Supervisor_cleaned
-      (** Fired by the durable dead-tombstone completion handler after exact
+      (** Fired by the durable supervisor cleanup completion handler after exact
           registry unregister and finalization persistence. The keeper is
           fully gone from in-process state at this point. *)
 

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -289,9 +289,8 @@ type keeper_meta = {
   active_goal_ids : string list;
   paused : bool;
   latched_reason : Keeper_latched_reason.t option;
-      (** Typed companion to [paused]. Explicit operator pause, terminal
-          dead-tombstone, and transcript-corruption reset-required paths may
-          write it. [None] while paused is a fail-closed unclassified state
+      (** Typed companion to [paused]. Explicit operator pause and
+          transcript-corruption reset-required paths may write it. [None] while paused is a fail-closed unclassified state
           requiring operator action. *)
   autoboot_enabled : bool;
   current_task_id : Keeper_id.Task_id.t option;

--- a/lib/keeper/keeper_supervisor_cleanup.ml
+++ b/lib/keeper/keeper_supervisor_cleanup.ml
@@ -14,17 +14,17 @@ let completion_meta_for_coverage config operation =
          && Int.equal meta.runtime.nonce operation.generation -> Some meta
   | Ok (Some _) ->
     Log.Keeper.warn
-      "%s: dead tombstone completion coverage meta identity changed"
+      "%s: supervisor cleanup completion coverage meta identity changed"
       operation.keeper_name;
     None
   | Ok None ->
     Log.Keeper.warn
-      "%s: dead tombstone completion coverage meta is absent"
+      "%s: supervisor cleanup completion coverage meta is absent"
       operation.keeper_name;
     None
   | Error detail ->
     Log.Keeper.warn
-      "%s: dead tombstone completion coverage meta read failed: %s"
+      "%s: supervisor cleanup completion coverage meta read failed: %s"
       operation.keeper_name
       detail;
     None
@@ -66,7 +66,7 @@ let handle_completion config operation = function
          ~keeper_id:operation.keeper_name
          Keeper_lifecycle_hooks.Supervisor_cleaned;
        Log.Keeper.info
-         "%s: dead tombstone finalization delivered operation=%s"
+         "%s: supervisor cleanup finalization delivered operation=%s"
          operation.keeper_name
        operation_id;
        Ok ())

--- a/lib/keeper/keeper_task_cancellation_wake.mli
+++ b/lib/keeper/keeper_task_cancellation_wake.mli
@@ -25,7 +25,7 @@ type outcome =
   | Author_not_a_keeper of { author : string }
       (** [created_by] resolves to no Keeper lane — an operator or a client id.
           Not an error: there is no lane to wake. A Keeper whose shutdown
-          finalized with a retained dead tombstone still presents a lane here
+          finalized while retaining its meta still presents a lane here
           and is not filtered out: that decision belongs to the durable intake
           gate in {!Keeper_registry_event_queue}, which admits every retention
           other than [Remove_meta] for all stimulus producers alike. *)

--- a/lib/keeper/keeper_turn_up_update.mli
+++ b/lib/keeper/keeper_turn_up_update.mli
@@ -17,9 +17,6 @@ val resolve_active_goal_ids :
 (** Update an existing keeper's meta record. Validates tool-access
     transitions, resolves active goals, applies parsed-arg overrides,
     persists the new meta, and broadcasts state-machine events.
-    A terminal dead tombstone is rejected before any mutation with the stable
-    [keeper_recreate_required] error; callers must delete it and create a fresh
-    Keeper identity.
     Returns structured {!Keeper_types_profile.tool_result}; failures carry their
     message on the typed error payload. *)
 val update_keeper :

--- a/lib/keeper_runtime/keeper_latched_reason.ml
+++ b/lib/keeper_runtime/keeper_latched_reason.ml
@@ -1,7 +1,7 @@
 (** Typed persisted lifecycle latch.
 
-    Explicit operator pauses, terminal dead tombstones, and structural
-    transcript corruption own the durable paused axis. Ordinary
+    Explicit operator pauses and structural transcript corruption own the
+    durable paused axis. Ordinary
     turn/provider/task failures remain observations and cannot manufacture a
     lifecycle state. *)
 

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -1018,7 +1018,7 @@ let test_keeper_shutdown_store_round_trip_and_identity_guard () =
            (Shutdown_store.Invalid_operation
              (Shutdown_types.Finalized_completion_mismatch _)) -> ()
        | Error error -> fail (Shutdown_store.error_to_string error)
-       | Ok () -> fail "store accepted completion outside dead-tombstone intent");
+       | Ok () -> fail "store accepted completion outside supervisor cleanup intent");
       (match
          operation
          |> unsupported_shutdown_schema_fixture

--- a/test/test_keeper_latched_reason_wiring.ml
+++ b/test/test_keeper_latched_reason_wiring.ml
@@ -304,7 +304,7 @@ let test_keeper_down_retain_records_reason () =
     (Some wire_keeper_down)
     (latched_reason_wire retained)
 
-(* ── Site 1: dead-tombstone cleanup ─────────────────────────── *)
+(* ── Site 1: supervisor cleanup ─────────────────────────────── *)
 
 
 let () =


### PR DESCRIPTION
## 현상

#29218이 Dead phase를 없애고 `Dead_tombstone_cleanup` → `Supervisor_cleanup` 으로 바꾸면서 처분도 retain → `Remove_meta` 로 옮겼습니다. **개념은 이름만 바뀌고 살아남았습니다.**

말투 문제가 아니라 세 가지 실질적 잔재가 있었습니다.

## 1. 도달 불가능한 코드

`keeper_heartbeat_loop.ml`

```ocaml
let terminal_lifecycle_blocked =
  match intake_admission with
  | Intake_lifecycle_blocked (Keeper_lifecycle_admission.Autonomous_paused _)
  | Intake_admitted -> false        (* 모든 갈래가 false *)
in
...
if terminal_lifecycle_blocked
then Atomic.set stop true           (* 절대 실행 안 됨 *)
else Keeper_registry.touch_last_turn_ts ...
```

`autonomous_denial` 은 변형이 하나(`Autonomous_paused`)라 이 값은 **항상 false** 입니다. 루프를 멈추던 분기가 도달 불가가 됐는데, 주석은 여전히 "죽은 tombstone은 돌릴 lane이 없다"고 설명하고 있었어요.

Dead phase가 그 분기를 참으로 만들던 유일한 조건이었습니다.

## 2. 없는 동작을 설명하는 문서

| 파일 | 적혀 있던 것 | 실제 |
|---|---|---|
| `keeper_turn_up_update.mli` | `keeper_recreate_required` 에러로 거부한다 | 그 식별자가 트리에 없음 |
| `keeper_invariant_check.mli` | `8. DeadRequiresTombstone` | 구현 없음, 이 줄이 유일한 등장 |
| `keeper_latched_reason.ml` | 래치를 쓰는 경로 셋 | 닫힌 합타입에 변형 둘 |
| `keeper_meta_contract.mli` | 같음 | 같음 |

`.mli` 를 읽고 `keeper_recreate_required` 를 찾으러 가면 아무것도 안 나옵니다.

## 3. 운영자에게 보이는 로그

`keeper_supervisor_cleanup.ml` — **rename이 만든 그 파일**이 이렇게 찍고 있었습니다.

```
"%s: dead tombstone completion coverage meta identity changed"
"%s: dead tombstone finalization delivered operation=%s"
```

타입은 `Supervisor_cleaned` 인데 로그는 dead tombstone 이라고 말합니다.

## 안 건드린 것

tombstone 을 **삭제 표식**이라는 일반적인 뜻으로 쓰는 자리는 그대로 뒀습니다. 살아있는 기능들이에요.

- `ide_annotations.ml` — 주석 삭제 키 `__tombstone`
- `keeper_tool_in_process_runtime.ml` — 빈 문자열로 note 지우기
- `board_tool_handlers.ml` — 은퇴한 `vote` 파라미터 거부 표식
- `dashboard_workspace.ml` — agent 목록의 삭제분
- `server_dashboard_http_core_operator.mli` — generation tombstone

## 검증

```
dune build @check                        통과
test_keeper_latched_reason_wiring   7/7  Successful
```

`test_heartbeat_integration` 은 fork 취소 케이스 1건이 실패하는데, **이 변경 전후로 똑같이 실패**합니다(53개 중 1건). 여기서 온 게 아니고, 이 스위트는 `scripts/ci-run-focused-tests.sh` allowlist 에 없어서 CI 에서 돌지 않습니다.

Refs #29218
