### PR TITLE
feat(verification): bind lookup to producer forest

### DIFF
--- a/lib/completion_authority_agent.ml
+++ b/lib/completion_authority_agent.ml
@@ -531,6 +531,7 @@ let process_task_once
            Task.Anti_rationalization.Lookup_tools
              { schemas = Verification_authority_tools.schemas lookup_tools
              ; dispatch = Verification_authority_tools.dispatch lookup_tools
+             ; scope = Task.Anti_rationalization.Producer_tree
              }
          in
          let result =

--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -23,11 +23,16 @@ type review_request =
   ; evidence_refs : string list
   }
 
+type lookup_scope =
+  | Producer_tree
+  | Producer_forest of { producers : string list }
+
 type lookup_surface =
   | No_lookup_surface
   | Lookup_tools of
       { schemas : Types_core.tool_schema list
       ; dispatch : name:string -> args:Yojson.Safe.t -> (string, string) result
+      ; scope : lookup_scope
       }
 
 type verdict =
@@ -151,35 +156,51 @@ let lookup_section = function
      snapshot inside `completion_notes`. You have no tool that opens anything \
      else, so a reference you cannot read there is a reference you cannot \
      verify.\n"
-  | Lookup_tools { schemas; dispatch = _ } ->
+  | Lookup_tools { schemas; dispatch = _; scope = Producer_tree } ->
     sprintf
       "\n\
        <live_lookup>\n\
        You hold the producer's own tools, pointed at the producer's tree: %s. \
        They run inside that producer's sandbox — the same jail the producer \
-       worked in — and they are not restricted to reading.\n\n\
+       worked in — and this verifier surface is read-only.\n\n\
        The snapshot is what was true when the work was submitted. A lookup is what \
        is true now. Both are evidence, and disagreement between them is also \
        evidence: a file the snapshot shows and the tree no longer contains was \
        not durable.\n\n\
-       Present is not the same as durable. Work that exists only as an \
-       uncommitted change survives until the next task cleans that working tree, \
-       and reading the file cannot tell you which of the two you are looking at. \
-       Ask what differs from the last commit before treating a file's contents as \
-       the completed work.\n\n\
        A claim about behaviour is not settled by reading the code that makes it. \
-       If the submitter says a build succeeds or a test passes, run it. You are \
-       judging the work, not the description of the work.\n\n\
-       Because these tools can change the tree, one rule binds you: do not repair \
-       what you are judging. If a build fails, that is a finding, not a task. \
-       Fixing it and then approving produces work no one verified — yours. Every \
-       call you make is recorded against this review, so a verdict reached after \
-       you changed the tree is visible as exactly that.\n\n\
+       If the submitter says a build or test passed, require an inspectable run \
+       receipt or log. This surface cannot execute that claim, so source text \
+       alone must not be upgraded into execution evidence.\n\n\
        A note claiming a path, a commit, or a command result is still not proof by \
        itself. The difference is that you can now check the claims that name \
        something in the producer's tree, so approving without checking an \
        available one is your omission rather than the submitter's.\n\
        </live_lookup>\n"
+      (schemas
+       |> List.map (fun (schema : Types_core.tool_schema) -> schema.name)
+       |> String.concat ", ")
+  | Lookup_tools
+      { schemas
+      ; dispatch = _
+      ; scope = Producer_forest { producers }
+      } ->
+    sprintf
+      "\n\
+       <live_lookup>\n\
+       This Goal is backed by linked Tasks performed in different owned trees. \
+       The closed producer set is: %s. Filesystem calls require one producer \
+       from that set; selecting a producer does not grant access to any other \
+       tree. The available tools are: %s.\n\n\
+       Read the linked-task rollup first, then inspect the submitted artifact \
+       in the tree of the Task performer that supplied it. A reference, a Task \
+       completion state, or another verifier's verdict is not a substitute for \
+       this Goal verifier's own inspection. Snapshot/live disagreement is \
+       evidence that the claimed result is not durable.\n\n\
+       These tools are read-only. Do not reinterpret a failed or refused call \
+       as empty output. If an artifact cannot be inspected in its producer \
+       tree, reject or defer rather than approving from the submitter's prose.\n\
+       </live_lookup>\n"
+      (String.concat ", " producers)
       (schemas
        |> List.map (fun (schema : Types_core.tool_schema) -> schema.name)
        |> String.concat ", ")

--- a/lib/task/anti_rationalization.mli
+++ b/lib/task/anti_rationalization.mli
@@ -21,11 +21,21 @@ type review_request =
     that the submitted excerpt reads as real work. This module deliberately
     does not build the surface itself: the tools that read a producer's tree
     belong above the containment primitives, not inside the review protocol. *)
+type lookup_scope =
+  | Producer_tree
+      (** Every advertised filesystem tool is already bound to the one
+          producer named by the review request. *)
+  | Producer_forest of { producers : string list }
+      (** Filesystem calls must select one producer from this closed set. Used
+          by Goal proof review, where linked Tasks may have different
+          performers and therefore different owned trees. *)
+
 type lookup_surface =
   | No_lookup_surface
   | Lookup_tools of
       { schemas : Types_core.tool_schema list
       ; dispatch : name:string -> args:Yojson.Safe.t -> (string, string) result
+      ; scope : lookup_scope
       }
 
 type verdict =

--- a/lib/verification_authority_tools.ml
+++ b/lib/verification_authority_tools.ml
@@ -28,6 +28,16 @@ and producer_scope =
   | Keeper_producer of Keeper_meta_contract.keeper_meta
   | Workspace_producer
 
+type forest_tool =
+  | Forest_read_file
+  | Forest_search_files
+  | Forest_web_fetch
+
+type forest =
+  { bindings : (string * t) list
+  ; forest_tools : (forest_tool * Types_core.tool_schema) list
+  }
+
 let descriptor_of_tool tool =
   match Keeper_tool_descriptor.descriptors_for_internal (tool_name tool) with
   | [ descriptor ] -> Ok (tool, descriptor)
@@ -235,4 +245,221 @@ let dispatch t ~name ~args =
          ~argument
          ~outcome:(match result with Ok _ -> Resolved | Error _ -> Rejected);
        result)
+;;
+
+(* ================================================================ *)
+(* Multi-producer Goal proof surface                                *)
+(* ================================================================ *)
+
+let forest_tool_name = function
+  | Forest_read_file -> "verification_read_file"
+  | Forest_search_files -> "verification_search_files"
+  | Forest_web_fetch -> tool_name Web_fetch
+;;
+
+let source_tool = function
+  | Forest_read_file -> Read_file
+  | Forest_search_files -> Search_files
+  | Forest_web_fetch -> Web_fetch
+;;
+
+let surface_has_tool surface tool =
+  List.exists (fun (candidate, _) -> candidate = tool) surface.tools
+;;
+
+let eligible_bindings bindings forest_tool =
+  let tool = source_tool forest_tool in
+  List.filter (fun (_, surface) -> surface_has_tool surface tool) bindings
+;;
+
+let replace_assoc key value fields =
+  (key, value) :: List.filter (fun (candidate, _) -> not (String.equal key candidate)) fields
+;;
+
+let producer_scoped_input_schema ~producers = function
+  | `Assoc fields ->
+    let open Result.Syntax in
+    let* properties =
+      match List.assoc_opt "properties" fields with
+      | Some (`Assoc properties) -> Ok properties
+      | Some other ->
+        Error
+          (Printf.sprintf
+             "verification tool descriptor properties must be an object, got %s"
+             (Json_util.excerpt other))
+      | None -> Error "verification tool descriptor has no properties"
+    in
+    let* required =
+      match List.assoc_opt "required" fields with
+      | Some (`List required) -> Ok required
+      | Some other ->
+        Error
+          (Printf.sprintf
+             "verification tool descriptor required must be an array, got %s"
+             (Json_util.excerpt other))
+      | None -> Ok []
+    in
+    let producer_schema =
+      `Assoc
+        [ "type", `String "string"
+        ; "enum", `List (List.map (fun producer -> `String producer) producers)
+        ; ( "description"
+          , `String
+              "Exact linked-Task producer whose owned tree this read targets" )
+        ]
+    in
+    let properties = replace_assoc "producer" producer_schema properties in
+    let required =
+      `String "producer"
+      :: List.filter
+           (function
+             | `String name -> not (String.equal name "producer")
+             | _ -> true)
+           required
+    in
+    Ok
+      (`Assoc
+         (fields
+          |> replace_assoc "properties" (`Assoc properties)
+          |> replace_assoc "required" (`List required)))
+  | other ->
+    Error
+      (Printf.sprintf
+         "verification tool descriptor input schema must be an object, got %s"
+         (Json_util.excerpt other))
+;;
+
+let forest_schema bindings forest_tool =
+  let open Result.Syntax in
+  let tool = source_tool forest_tool in
+  let* _, descriptor = descriptor_of_tool tool in
+  let eligible = eligible_bindings bindings forest_tool in
+  let producers = List.map fst eligible in
+  let* input_schema =
+    match forest_tool with
+    | Forest_web_fetch -> Ok descriptor.input_schema
+    | Forest_read_file | Forest_search_files ->
+      producer_scoped_input_schema ~producers descriptor.input_schema
+  in
+  Ok
+    { Types_core.name = forest_tool_name forest_tool
+    ; description =
+        (match forest_tool with
+         | Forest_read_file ->
+           "Read a file from one exact linked-Task producer tree. "
+           ^ descriptor.description
+         | Forest_search_files ->
+           "Search files in one exact linked-Task producer tree. "
+           ^ descriptor.description
+         | Forest_web_fetch -> descriptor.description)
+    ; input_schema
+    }
+;;
+
+let rec create_bindings ~config = function
+  | [] -> Ok []
+  | producer :: rest ->
+    let open Result.Syntax in
+    let* surface = create ~config ~producer in
+    let* bindings = create_bindings ~config rest in
+    Ok ((producer, surface) :: bindings)
+;;
+
+let create_forest ~config ~producers =
+  let open Result.Syntax in
+  let producers = List.sort_uniq String.compare producers in
+  let* () =
+    match List.find_opt (fun producer -> String.equal (String.trim producer) "") producers with
+    | Some _ -> Error "verification producer identity must not be blank"
+    | None -> Ok ()
+  in
+  let* bindings =
+    match producers with
+    | [] -> Error "verification producer forest must not be empty"
+    | _ -> create_bindings ~config producers
+  in
+  let forest_tool_kinds =
+    [ Forest_read_file ]
+    @ (match eligible_bindings bindings Forest_search_files with
+       | [] -> []
+       | _ -> [ Forest_search_files ])
+    @ [ Forest_web_fetch ]
+  in
+  let rec build = function
+    | [] -> Ok []
+    | forest_tool :: rest ->
+      let* schema = forest_schema bindings forest_tool in
+      let* schemas = build rest in
+      Ok ((forest_tool, schema) :: schemas)
+  in
+  let* forest_tools = build forest_tool_kinds in
+  Ok { bindings; forest_tools }
+;;
+
+let forest_schemas forest = List.map snd forest.forest_tools
+
+let forest_tool_of_name forest name =
+  forest.forest_tools
+  |> List.find_opt (fun (tool, _) -> String.equal (forest_tool_name tool) name)
+  |> Option.map fst
+;;
+
+let select_producer forest forest_tool args =
+  match args with
+  | `Assoc fields ->
+    (match List.assoc_opt "producer" fields with
+     | Some (`String producer) ->
+       let eligible = eligible_bindings forest.bindings forest_tool in
+       (match List.assoc_opt producer eligible with
+        | Some surface ->
+          Ok
+            ( surface
+            , `Assoc
+                (List.filter
+                   (fun (name, _) -> not (String.equal name "producer"))
+                   fields) )
+        | None ->
+          Error
+            (Printf.sprintf
+               "producer %s is not admitted for %s; admitted producers: %s"
+               producer
+               (forest_tool_name forest_tool)
+               (String.concat ", " (List.map fst eligible))))
+     | Some other ->
+       Error
+         (Printf.sprintf
+            "producer must be a string, got %s"
+            (Json_util.excerpt other))
+     | None -> Error "producer is required")
+  | other ->
+    Error
+      (Printf.sprintf
+         "%s input must be an object, got %s"
+         (forest_tool_name forest_tool)
+         (Json_util.excerpt other))
+;;
+
+let dispatch_forest forest ~name ~args =
+  match forest_tool_of_name forest name with
+  | None ->
+    Error
+      (Printf.sprintf
+         "unknown tool %s; this Goal review offers %s"
+         name
+         (forest.forest_tools
+          |> List.map (fun (tool, _) -> forest_tool_name tool)
+          |> String.concat ", "))
+  | Some Forest_web_fetch ->
+    (match forest.bindings with
+     | (_, surface) :: _ -> dispatch surface ~name:(tool_name Web_fetch) ~args
+     | [] -> Error "verification producer forest is empty")
+  | Some (Forest_read_file as forest_tool)
+  | Some (Forest_search_files as forest_tool) ->
+    (match select_producer forest forest_tool args with
+     | Error _ as error -> error
+     | Ok (surface, forwarded_args) ->
+       dispatch
+         surface
+         ~name:(tool_name (source_tool forest_tool))
+         ~args:forwarded_args)
 ;;

--- a/lib/verification_authority_tools.mli
+++ b/lib/verification_authority_tools.mli
@@ -12,6 +12,7 @@
     could resume an approved Gate effect. *)
 
 type t
+type forest
 
 val create :
   config:Workspace.config -> producer:string -> (t, string) result
@@ -19,3 +20,14 @@ val create :
 val schemas : t -> Types_core.tool_schema list
 
 val dispatch : t -> name:string -> args:Yojson.Safe.t -> (string, string) result
+
+val create_forest :
+  config:Workspace.config -> producers:string list -> (forest, string) result
+(** Bind a read-only verifier surface to a closed set of producer trees. The
+    filesystem schemas require an exact [producer] chosen from this set; the
+    dispatcher refuses every other identity before reaching a tree. *)
+
+val forest_schemas : forest -> Types_core.tool_schema list
+
+val dispatch_forest :
+  forest -> name:string -> args:Yojson.Safe.t -> (string, string) result

--- a/lib/workspace_metric_hooks.ml
+++ b/lib/workspace_metric_hooks.ml
@@ -309,7 +309,7 @@ let install () =
     let lookup_schemas, lookup_dispatch =
       match (lookup : Task.Anti_rationalization.lookup_surface) with
       | No_lookup_surface -> [], None
-      | Lookup_tools { schemas; dispatch } -> schemas, Some dispatch
+      | Lookup_tools { schemas; dispatch; scope = _ } -> schemas, Some dispatch
     in
     (* The verdict tool and the lookup tools share one dispatch entry point, so
        the name decides which surface answers. A name belonging to neither is an

--- a/test/test_verification_authority_tools.ml
+++ b/test/test_verification_authority_tools.ml
@@ -59,6 +59,22 @@ let with_surface f =
   | Ok surface -> f config surface
 ;;
 
+let with_forest producers f =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = temp_dir () in
+  Eio.Switch.run
+  @@ fun sw ->
+  Eio.Switch.on_release sw (fun () -> rm_rf dir);
+  let config = Workspace_core.default_config dir in
+  ignore (Workspace_core.init config ~agent_name:(Some "test"));
+  List.iter (ensure_producer config) producers;
+  match VAT.create_forest ~config ~producers with
+  | Error reason -> Alcotest.failf "forest creation failed: %s" reason
+  | Ok forest -> f config forest
+;;
+
 (* Create the producer playground used to resolve relative tool paths. *)
 let producer_playground (config : Workspace_core.config) producer_name =
   let path =
@@ -254,6 +270,60 @@ let test_workspace_producer_gets_owned_read_surface () =
          (Astring.String.is_infix ~affix:"this review offers tool_search_files" detail))
 ;;
 
+let test_forest_requires_and_enforces_exact_producer () =
+  let producer_a = "producer-a" in
+  let producer_b = "producer-b" in
+  with_forest [ producer_a; producer_b ] (fun config forest ->
+    let file_name = "proof.txt" in
+    Out_channel.with_open_text
+      (Filename.concat (producer_playground config producer_a) file_name)
+      (fun channel -> output_string channel "proof from producer-a\n");
+    Out_channel.with_open_text
+      (Filename.concat (producer_playground config producer_b) file_name)
+      (fun channel -> output_string channel "proof from producer-b\n");
+    let schemas = VAT.forest_schemas forest in
+    Alcotest.(check (list string))
+      "forest surface"
+      [ "verification_read_file"; "verification_search_files"; "masc_web_fetch" ]
+      (List.map (fun (schema : Masc_domain.tool_schema) -> schema.name) schemas);
+    let read producer =
+      VAT.dispatch_forest
+        forest
+        ~name:"verification_read_file"
+        ~args:
+          (`Assoc
+            [ "producer", `String producer
+            ; "file_path", `String file_name
+            ])
+    in
+    (match read producer_b with
+     | Error detail -> Alcotest.failf "producer-b read failed: %s" detail
+     | Ok output ->
+       Alcotest.(check bool)
+         "the selected tree supplied the bytes"
+         true
+         (Astring.String.is_infix ~affix:"proof from producer-b" output));
+    (match read "producer-c" with
+     | Ok output -> Alcotest.failf "unadmitted producer read succeeded: %s" output
+     | Error detail ->
+       Alcotest.(check bool)
+         "refusal lists the closed set"
+         true
+         (Astring.String.is_infix ~affix:"producer-a, producer-b" detail));
+    match
+      VAT.dispatch_forest
+        forest
+        ~name:"verification_read_file"
+        ~args:(`Assoc [ "file_path", `String file_name ])
+    with
+    | Ok output -> Alcotest.failf "producer-free read succeeded: %s" output
+    | Error detail ->
+      Alcotest.(check bool)
+        "producer is mandatory"
+        true
+        (Astring.String.is_infix ~affix:"producer is required" detail))
+;;
+
 (* The prompt states the exact tools attached to the review request. *)
 let test_prompt_states_the_available_surface () =
   with_surface (fun _config surface ->
@@ -275,7 +345,10 @@ let test_prompt_states_the_available_surface () =
     let with_tools =
       render
         (AR.Lookup_tools
-           { schemas = VAT.schemas surface; dispatch = VAT.dispatch surface })
+           { schemas = VAT.schemas surface
+           ; dispatch = VAT.dispatch surface
+           ; scope = AR.Producer_tree
+           })
     in
     Alcotest.(check bool)
       "toolless prompt says the snapshot is the only proof"
@@ -296,9 +369,9 @@ let test_prompt_states_the_available_surface () =
          ~affix:"You have no tool that opens anything else"
          with_tools);
     Alcotest.(check bool)
-      "tool prompt forbids repairing the work under review"
+      "tool prompt states the read-only boundary"
       true
-      (Astring.String.is_infix ~affix:"do not repair what you are judging" with_tools))
+      (Astring.String.is_infix ~affix:"verifier surface is read-only" with_tools))
 ;;
 
 
@@ -371,6 +444,10 @@ let () =
             `Quick test_search_refuses_a_call_without_its_required_pattern
         ; Alcotest.test_case "workspace producer gets owned read surface" `Quick
             test_workspace_producer_gets_owned_read_surface
+        ; Alcotest.test_case
+            "forest requires and enforces exact producer"
+            `Quick
+            test_forest_requires_and_enforces_exact_producer
         ] )
     ; ( "dispatch"
       , [ Alcotest.test_case "unknown tool name is an error" `Quick


### PR DESCRIPTION
## Summary

Add a typed read-only verifier lookup scope for reviews backed by multiple producer trees.

- `Producer_tree` keeps the current single-producer Task verifier contract.
- `Producer_forest` advertises a closed producer enum on read/search schemas and refuses identities outside it before dispatch.
- Each filesystem call selects one admitted producer explicitly; web fetch stays shared and guarded.
- Correct the existing single-producer prompt: the surface is read-only and cannot execute build/test claims, so source text cannot be promoted into execution evidence.

This is the parent slice for Goal proof verification across linked Tasks with different performers. It does not wire the Goal worker yet.

## Evidence

- `ocamlformat --check` — PASS.
- `ocamlc -stop-after parsing` for changed implementations/tests — PASS.
- `git diff --check` — PASS.
- Local Dune intentionally not run; exact-head CI is build authority.

## Invariants

- no mutating tool is exposed;
- producer choice is schema-enumerated and dispatch-enforced;
- descriptor validation/translation remains the existing SSOT;
- unknown producer/tool/input fails closed.