### PR TITLE
feat(goal): inspect linked task artifacts before verdict

### DIFF
--- a/lib/goal_verification_agent.ml
+++ b/lib/goal_verification_agent.ml
@@ -196,6 +196,7 @@ let task_rollup_json (task : Masc_domain.task) =
   let verification_evidence =
     Task.Completion_review.concrete_verification_evidence task
   in
+  let producer = Masc_domain.task_performer_of_status task.task_status in
   let status_fields =
     match task.task_status with
     | Masc_domain.Done { assignee; completed_at; notes } ->
@@ -216,6 +217,10 @@ let task_rollup_json (task : Masc_domain.task) =
     ([ "task_id", `String task.id
      ; "title", `String task.title
      ; "status", `String (Masc_domain.task_status_to_string task.task_status)
+     ; ( "producer"
+       , match producer with
+         | Some producer -> `String producer
+         | None -> `Null )
      ; ( "verification_evidence"
        , Task.Completion_review.verification_evidence_to_yojson
            verification_evidence )
@@ -232,7 +237,9 @@ let task_submitted_evidence (task : Masc_domain.task) =
 
 (* A backlog that does not read is infrastructure failure: the proof review
    defers rather than judging a goal on an absent rollup. *)
-let linked_task_rollup config ~goal_id : (string * string list, string) result =
+let linked_task_rollup config ~goal_id
+  : (string * string list * Masc_domain.task list, string) result
+  =
   match Workspace_backlog.read_backlog_r config with
   | Error detail -> Error detail
   | Ok backlog ->
@@ -250,7 +257,8 @@ let linked_task_rollup config ~goal_id : (string * string list, string) result =
        in
        Ok
          ( Yojson.Safe.pretty_to_string (`List (List.map task_rollup_json tasks))
-         , evidence_refs ))
+         , evidence_refs
+         , tasks ))
 ;;
 
 let goal_owner_name (goal : Goal_store.goal) =
@@ -259,8 +267,57 @@ let goal_owner_name (goal : Goal_store.goal) =
   | Some _ | None -> "unassigned"
 ;;
 
+let single_producer_lookup config ~producer =
+  let open Result.Syntax in
+  let* tools = Verification_authority_tools.create ~config ~producer in
+  Ok
+    (Task.Anti_rationalization.Lookup_tools
+       { schemas = Verification_authority_tools.schemas tools
+       ; dispatch = Verification_authority_tools.dispatch tools
+       ; scope = Task.Anti_rationalization.Producer_tree
+       })
+;;
+
+let task_producer (task : Masc_domain.task) =
+  match Masc_domain.task_performer_of_status task.task_status with
+  | Some producer when not (String.equal (String.trim producer) "") -> Ok producer
+  | Some _ | None ->
+    Error
+      (Printf.sprintf
+         "linked task %s has no performer tree for Goal verification"
+         task.id)
+;;
+
+let rec task_producers = function
+  | [] -> Ok []
+  | task :: rest ->
+    let open Result.Syntax in
+    let* producer = task_producer task in
+    let* producers = task_producers rest in
+    Ok (producer :: producers)
+;;
+
+let linked_task_lookup config tasks =
+  let open Result.Syntax in
+  let* producers = task_producers tasks in
+  let producers = List.sort_uniq String.compare producers in
+  let* tools =
+    Verification_authority_tools.create_forest ~config ~producers
+  in
+  Ok
+    (Task.Anti_rationalization.Lookup_tools
+       { schemas = Verification_authority_tools.forest_schemas tools
+       ; dispatch = Verification_authority_tools.dispatch_forest tools
+       ; scope = Task.Anti_rationalization.Producer_forest { producers }
+       })
+;;
+
 let build_review_request config (goal : Goal_store.goal) kind
-  : (Task.Anti_rationalization.review_request * string, string) result
+  : ( Task.Anti_rationalization.review_request
+      * string
+      * Task.Anti_rationalization.lookup_surface
+    , string )
+      result
   =
   let base =
     { Task.Anti_rationalization.task_title = goal.title
@@ -273,22 +330,38 @@ let build_review_request config (goal : Goal_store.goal) kind
   in
   match kind with
   | Criterion_check ->
+    let open Result.Syntax in
+    let* lookup = single_producer_lookup config ~producer:(goal_owner_name goal) in
     Ok
       ( { base with
           Task.Anti_rationalization.completion_notes =
             Yojson.Safe.pretty_to_string (Goal_store.goal_to_yojson goal)
         }
-      , Prompt_names.goal_verification_criterion )
+      , Prompt_names.goal_verification_criterion
+      , lookup )
   | Completion_proof ->
     (match linked_task_rollup config ~goal_id:goal.id with
      | Error _ as error -> error
-     | Ok (rollup, evidence_refs) ->
+     | Ok (rollup, evidence_refs, []) ->
+       let open Result.Syntax in
+       let* lookup = single_producer_lookup config ~producer:(goal_owner_name goal) in
        Ok
          ( { base with
              Task.Anti_rationalization.completion_notes = rollup
            ; evidence_refs
            }
-         , Prompt_names.goal_verification_proof ))
+         , Prompt_names.goal_verification_proof
+         , lookup )
+     | Ok (rollup, evidence_refs, tasks) ->
+       let open Result.Syntax in
+       let* lookup = linked_task_lookup config tasks in
+       Ok
+         ( { base with
+             Task.Anti_rationalization.completion_notes = rollup
+           ; evidence_refs
+           }
+         , Prompt_names.goal_verification_proof
+         , lookup ))
 ;;
 
 (* {1 Verdict commit}
@@ -374,7 +447,7 @@ let process_pending_work ?(sw : Eio.Switch.t option = None) config (work : pendi
        (match build_review_request config goal work.kind with
         | Error detail ->
           defer ~goal_id:work.goal_id ~kind:work.kind ~retryable:true ~reason:detail
-        | Ok (review_request, prompt_name) ->
+        | Ok (review_request, prompt_name, lookup) ->
           (* The verdict channel drops the reason for [Approve]; capture the
              stated reason from the successful verdict tool call — exactly one
              such call exists per review, and it belongs to the winning slot
@@ -398,7 +471,7 @@ let process_pending_work ?(sw : Eio.Switch.t option = None) config (work : pendi
               ~base_path:config.base_path
               ~sw
               ~prompt_name
-              ~lookup:Task.Anti_rationalization.No_lookup_surface
+              ~lookup
               ~on_tool_result
               review_request
           in

--- a/test/test_goal_verification_agent.ml
+++ b/test/test_goal_verification_agent.ml
@@ -55,6 +55,17 @@ let with_workspace f =
        f config)
 ;;
 
+let with_verification_persistence f =
+  let previous = Atomic.get Workspace_hooks.verification_submit_request_fn in
+  Atomic.set
+    Workspace_hooks.verification_submit_request_fn
+    (fun _config ~task:_ ~assignee:_ ~verification_id:_ ~evidence_refs:_ -> Ok ());
+  Fun.protect
+    ~finally:(fun () ->
+      Atomic.set Workspace_hooks.verification_submit_request_fn previous)
+    f
+;;
+
 let workspace_ctx ?(agent_name = "planner") config : Tool_workspace.context =
   { Tool_workspace.config; agent_name }
 ;;
@@ -382,11 +393,12 @@ let test_goal_proof_reads_linked_task_producer_artifact () =
   Out_channel.with_open_text artifact_path (fun channel ->
     output_string channel "three services verified by isolated run\n");
   ignore
-    (add_linked_task_with_evidence
-       config
-       ~goal_id
-       ~producer
-       ~evidence_ref:("artifact:" ^ file_name));
+    (with_verification_persistence (fun () ->
+       add_linked_task_with_evidence
+         config
+         ~goal_id
+         ~producer
+         ~evidence_ref:("artifact:" ^ file_name)));
   ignore
     (must_succeed "request_complete" (transition ctx goal_id "request_complete"));
   let forest_reads = ref 0 in

--- a/test/test_goal_verification_agent.ml
+++ b/test/test_goal_verification_agent.ml
@@ -96,6 +96,78 @@ let create_goal ctx title =
   json_state created [ "goal_id" ]
 ;;
 
+let producer_playground (config : Workspace.config) producer =
+  let path =
+    Keeper_sandbox_config.host_root_abs_of_agent
+      ~base_path:
+        (Workspace_verification_store.project_root_of_base_path config.base_path)
+      ~agent_name:producer
+  in
+  let rec mkdir_p dir =
+    if not (Sys.file_exists dir)
+    then (
+      mkdir_p (Filename.dirname dir);
+      try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+  in
+  mkdir_p path;
+  path
+;;
+
+let add_linked_task_with_evidence config ~goal_id ~producer ~evidence_ref =
+  let created =
+    match
+      Workspace.add_task_with_result
+        config
+        ~goal_id
+        ~created_by:producer
+        ~title:"Linked proof task"
+        ~priority:1
+        ~description:"Produce the Goal proof artifact"
+    with
+    | Ok created -> created
+    | Error error ->
+      fail
+        ("add linked task: " ^ Workspace.add_task_error_to_string error)
+  in
+  (match Workspace.claim_task_r config ~agent_name:producer ~task_id:created.task_id () with
+   | Ok _ -> ()
+   | Error error -> fail (Masc_domain.masc_error_to_string error));
+  let handoff_context : Masc_domain.task_handoff_context =
+    { summary = "proof artifact is ready"
+    ; reason = None
+    ; next_step = None
+    ; failure_mode = None
+    ; reclaim_policy = None
+    ; evidence_refs = [ evidence_ref ]
+    ; updated_at = None
+    ; updated_by = Some producer
+    }
+  in
+  (match
+     Workspace.transition_task_r
+       config
+       ~agent_name:producer
+       ~task_id:created.task_id
+       ~action:Masc_domain.Start
+       ()
+   with
+   | Ok _ -> ()
+   | Error error -> fail (Masc_domain.masc_error_to_string error));
+  (match
+     Workspace.transition_task_r
+       config
+       ~agent_name:producer
+       ~task_id:created.task_id
+       ~action:Masc_domain.Submit_for_verification
+       ~notes:"artifact ready for Goal verification"
+       ~handoff_context
+       ()
+   with
+   | Ok _ -> ()
+   | Error error -> fail (Masc_domain.masc_error_to_string error));
+  created.task_id
+;;
+
 let transition ctx goal_id ?note ?evidence action =
   let args =
     [ "goal_id", `String goal_id; "action", `String action ]
@@ -191,6 +263,61 @@ let recording_reviewer calls behaviors =
       Error (Agent_core.Error.Internal ("unexpected evaluator slot " ^ evaluator_runtime))
 ;;
 
+let inspecting_goal_reviewer ~producer ~file_name ~expected ~forest_reads =
+  fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt ~report_tool_schema:_
+      ~lookup ~on_tool_result () ->
+    let report reason =
+      let input =
+        `Assoc [ "verdict", `String "APPROVE"; "reason", `String reason ]
+      in
+      on_tool_result
+        ~input
+        (Tool_result.ok
+           ~tool_name:"report_review_verdict"
+           ~start_time:0.0
+           "recorded");
+      Ok (Some AR.Approve)
+    in
+    match lookup with
+    | AR.No_lookup_surface -> fail "Goal verifier received no lookup surface"
+    | AR.Lookup_tools { scope = AR.Producer_tree; _ } ->
+      report "criterion is measurable"
+    | AR.Lookup_tools
+        { schemas
+        ; dispatch
+        ; scope = AR.Producer_forest { producers }
+        } ->
+      check (list string) "closed producer set" [ producer ] producers;
+      check bool "rollup identifies the evidence producer" true
+        (String_util.contains_substring
+           prompt
+           (Printf.sprintf "\"producer\": \"%s\"" producer));
+      check bool "forest read tool is advertised" true
+        (List.exists
+           (fun (schema : Masc_domain.tool_schema) ->
+              String.equal schema.name "verification_read_file")
+           schemas);
+      let input =
+        `Assoc
+          [ "producer", `String producer
+          ; "file_path", `String file_name
+          ]
+      in
+      (match dispatch ~name:"verification_read_file" ~args:input with
+       | Error detail -> fail ("Goal proof lookup failed: " ^ detail)
+       | Ok output ->
+         check bool "Goal verifier read the linked producer artifact" true
+           (String_util.contains_substring output expected);
+         forest_reads := !forest_reads + 1;
+         on_tool_result
+           ~input
+           (Tool_result.ok
+              ~tool_name:"verification_read_file"
+              ~start_time:0.0
+              output));
+      report "linked producer artifact was inspected"
+;;
+
 let with_lane_and_reviewer ~slots ~reviewer f =
   let saved_slots = Atomic.get Workspace_hooks.get_verifier_exact_lane_slot_ids_fn in
   let saved_reviewer = Atomic.get AR.run_llm_reviewer_fn in
@@ -239,6 +366,42 @@ let test_proof_pending_drains_to_completed () =
     check string "authority kind is the system-llm slot" "system_llm_agent"
       (Masc_domain.completion_authority_kind verdict.Goal_verification.authority)
   | _ -> fail "ledger must hold the proven verdict"
+;;
+
+let test_goal_proof_reads_linked_task_producer_artifact () =
+  with_workspace
+  @@ fun config ->
+  let ctx = workspace_ctx config in
+  let goal_id = create_goal ctx "Artifact-inspected goal" in
+  let producer = "builder" in
+  let file_name = "artifacts/goal-proof.txt" in
+  let playground = producer_playground config producer in
+  let artifact_path = Filename.concat playground file_name in
+  let artifact_dir = Filename.dirname artifact_path in
+  if not (Sys.file_exists artifact_dir) then Unix.mkdir artifact_dir 0o755;
+  Out_channel.with_open_text artifact_path (fun channel ->
+    output_string channel "three services verified by isolated run\n");
+  ignore
+    (add_linked_task_with_evidence
+       config
+       ~goal_id
+       ~producer
+       ~evidence_ref:("artifact:" ^ file_name));
+  ignore
+    (must_succeed "request_complete" (transition ctx goal_id "request_complete"));
+  let forest_reads = ref 0 in
+  with_lane_and_reviewer
+    ~slots:(fun () -> Ok [ "verifier-a" ])
+    ~reviewer:
+      (inspecting_goal_reviewer
+         ~producer
+         ~file_name
+         ~expected:"three services verified"
+         ~forest_reads)
+    (fun () -> drain config);
+  check int "the proof review performed one linked-tree read" 1 !forest_reads;
+  check string "inspected proof completed the Goal" "completed"
+    (stored_phase config goal_id)
 ;;
 
 (* (b) A refuted proof returns the goal to Executing; the reason is preserved
@@ -486,6 +649,10 @@ let () =
     [ ( "drain"
       , [ test_case "proof pending drains to completed" `Quick
             test_proof_pending_drains_to_completed
+        ; test_case
+            "Goal proof reads linked Task producer artifact"
+            `Quick
+            test_goal_proof_reads_linked_task_producer_artifact
         ; test_case "refuted proof returns to executing with reason" `Quick
             test_refuted_proof_returns_to_executing
         ; test_case "criterion pending drains to viable" `Quick


### PR DESCRIPTION
## Summary

Wire the standalone Goal verifier to an actual read-only lookup surface.

- Criterion review receives the Goal owner tree.
- Completion proof resolves every linked Task performer and builds a closed producer forest.
- The rollup carries the exact evidence producer next to each Task and its submitted evidence refs.
- A linked Task without a performer tree defers the Goal review instead of approving from prose.
- The Goal worker no longer calls `Anti_rationalization.review` with `No_lookup_surface`.

## Feature evidence

The new Goal-verifier scenario creates a Goal, links a Task with `artifact:artifacts/goal-proof.txt`, submits that Task, requests Goal completion, then drives the real review seam. The verifier must dispatch `verification_read_file` against the Task producer tree and observe the artifact bytes before its typed proof verdict can complete the Goal.

## Validation

- `ocamlformat --check` — PASS.
- `ocamlc -stop-after parsing` for both changed files — PASS.
- `git diff --check` — PASS.
- Local Dune intentionally not run; exact-head CI is build/test authority.

Stacked on #29254.