### PR TITLE
feat(goal): persist verifier run observations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1186,7 +1186,8 @@ jobs:
           opam exec -- dune build --root . \
             @test/runtest-test_goal_phase_all \
             @test/runtest-test_goal_verification_gate \
-            @test/runtest-test_goal_verification_agent
+            @test/runtest-test_goal_verification_agent \
+            @test/runtest-test_goal_verification_run_registry
 
       - name: Run metric zero-cell declaration suite
         # A counter emitted as a bare string still compiles and still counts;

--- a/lib/goal_verification_run_registry.ml
+++ b/lib/goal_verification_run_registry.ml
@@ -1,0 +1,288 @@
+type review_kind =
+  | Criterion
+  | Proof
+
+type outcome =
+  | Committed
+  | Deferred of
+      { retryable : bool
+      ; detail : string
+      }
+  | Raised of { detail : string }
+
+type run_status =
+  | Running
+  | Completed of
+      { outcome : outcome
+      ; evaluator_runtime : string option
+      ; elapsed_s : float
+      ; tools : Verification_run_registry.tool_observation list
+      }
+
+type run =
+  { run_id : string
+  ; goal_id : string
+  ; review_kind : review_kind
+  ; authority_actor : string
+  ; started_at : float
+  ; status : run_status
+  }
+
+let storage_filename = "goal-verification-runs.jsonl"
+
+let review_kind_label = function
+  | Criterion -> "criterion"
+  | Proof -> "proof"
+;;
+
+let review_kind_of_label = function
+  | "criterion" -> Ok Criterion
+  | "proof" -> Ok Proof
+  | label -> Error (Printf.sprintf "unknown Goal review kind %S" label)
+;;
+
+let outcome_label = function
+  | Committed -> "committed"
+  | Deferred _ -> "deferred"
+  | Raised _ -> "raised"
+;;
+
+module Payload = struct
+  type registration =
+    { goal_id : string
+    ; review_kind : review_kind
+    ; authority_actor : string
+    }
+
+  type completion =
+    { outcome : outcome
+    ; evaluator_runtime : string option
+    ; elapsed_s : float
+    ; tools : Verification_run_registry.tool_observation list
+    }
+
+  let name = "goal_verification_run_registry"
+  let running_noun = "Goal review(s)"
+  let restart_reason = "Goal review fibers do not survive server restart"
+  let completed_retention = `Latest 64
+
+  let registration_to_yojson registration =
+    `Assoc
+      [ "goal_id", `String registration.goal_id
+      ; "review_kind", `String (review_kind_label registration.review_kind)
+      ; "authority_actor", `String registration.authority_actor
+      ]
+  ;;
+
+  let registration_of_yojson json =
+    let open Result.Syntax in
+    let* fields = Run_registry_core.Json.object_fields json in
+    let* () =
+      Run_registry_core.Json.exact_fields
+        ~required:[ "goal_id"; "review_kind"; "authority_actor" ]
+        fields
+    in
+    let* goal_id = Run_registry_core.Json.string_field "goal_id" fields in
+    let* review_kind = Run_registry_core.Json.string_field "review_kind" fields in
+    let* review_kind = review_kind_of_label review_kind in
+    let* authority_actor =
+      Run_registry_core.Json.string_field "authority_actor" fields
+    in
+    Ok { goal_id; review_kind; authority_actor }
+  ;;
+
+  let completion_to_yojson completion =
+    let outcome_fields =
+      match completion.outcome with
+      | Committed -> []
+      | Deferred { retryable; detail } ->
+        [ "retryable", `Bool retryable; "detail", `String detail ]
+      | Raised { detail } -> [ "detail", `String detail ]
+    in
+    `Assoc
+      ([ "outcome", `String (outcome_label completion.outcome)
+       ; "elapsed_s", `Float completion.elapsed_s
+       ; ( "tools"
+         , `List
+             (List.map
+                Verification_run_registry.tool_observation_to_yojson
+                completion.tools) )
+       ]
+       @ outcome_fields
+       @
+       match completion.evaluator_runtime with
+       | None -> []
+       | Some runtime -> [ "evaluator_runtime", `String runtime ])
+  ;;
+
+  let completion_of_yojson json =
+    let open Result.Syntax in
+    let* fields = Run_registry_core.Json.object_fields json in
+    let* outcome_label = Run_registry_core.Json.string_field "outcome" fields in
+    let detail_fields =
+      match outcome_label with
+      | "committed" -> Ok []
+      | "deferred" -> Ok [ "retryable"; "detail" ]
+      | "raised" -> Ok [ "detail" ]
+      | label -> Error (Printf.sprintf "unknown Goal review outcome %S" label)
+    in
+    let* detail_fields = detail_fields in
+    let* () =
+      Run_registry_core.Json.exact_fields
+        ~required:([ "outcome"; "elapsed_s"; "tools" ] @ detail_fields)
+        ~optional:[ "evaluator_runtime" ]
+        fields
+    in
+    let* elapsed_s = Run_registry_core.Json.float_field "elapsed_s" fields in
+    let* evaluator_runtime =
+      Run_registry_core.Json.optional_string_field "evaluator_runtime" fields
+    in
+    let* tools_json =
+      match List.assoc_opt "tools" fields with
+      | Some (`List tools) -> Ok tools
+      | Some _ -> Error "field tools must be an array"
+      | None -> Error "missing field tools"
+    in
+    let rec parse_tools acc = function
+      | [] -> Ok (List.rev acc)
+      | tool :: rest ->
+        let* tool = Verification_run_registry.tool_observation_of_yojson tool in
+        parse_tools (tool :: acc) rest
+    in
+    let* tools = parse_tools [] tools_json in
+    let* outcome =
+      match outcome_label with
+      | "committed" -> Ok Committed
+      | "deferred" ->
+        let* retryable =
+          match List.assoc_opt "retryable" fields with
+          | Some (`Bool retryable) -> Ok retryable
+          | Some _ -> Error "field retryable must be a boolean"
+          | None -> Error "missing field retryable"
+        in
+        let* detail = Run_registry_core.Json.string_field "detail" fields in
+        Ok (Deferred { retryable; detail })
+      | "raised" ->
+        let* detail = Run_registry_core.Json.string_field "detail" fields in
+        Ok (Raised { detail })
+      | label -> Error (Printf.sprintf "unknown Goal review outcome %S" label)
+    in
+    Ok { outcome; evaluator_runtime; elapsed_s; tools }
+  ;;
+end
+
+module Store = Run_registry_core.Make (Payload)
+
+type t = Store.t
+
+let create = Store.create
+let replay = Store.replay
+let max_completed_retained = Store.max_completed_retained
+let change_observer_fn : (unit -> unit) Atomic.t = Atomic.make (fun () -> ())
+
+let notify_changed () =
+  try (Atomic.get change_observer_fn) () with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Log.Task.warn
+      "goal_verification_run_registry change observer failed: %s"
+      (Printexc.to_string exn)
+;;
+
+let register_running t ~run_id ~goal_id ~review_kind ~authority_actor ~started_at =
+  Store.register
+    t
+    ~id:run_id
+    ~started_at
+    ~registration:{ Payload.goal_id; review_kind; authority_actor };
+  notify_changed ()
+;;
+
+let mark_completed t ~run_id ~outcome ~tools ?evaluator_runtime ~elapsed_s () =
+  let completion = { Payload.outcome; evaluator_runtime; elapsed_s; tools } in
+  match Store.complete t ~id:run_id ~completion with
+  | `Completed -> notify_changed ()
+  | `Unknown -> ()
+  | `Persistence_failed failure -> raise (Sys_error failure.detail)
+;;
+
+let run_of_entry (entry : Store.entry) =
+  let status =
+    match entry.status with
+    | Store.Running -> Running
+    | Store.Completed completion ->
+      Completed
+        { outcome = completion.outcome
+        ; evaluator_runtime = completion.evaluator_runtime
+        ; elapsed_s = completion.elapsed_s
+        ; tools = completion.tools
+        }
+  in
+  { run_id = entry.id
+  ; goal_id = entry.registration.goal_id
+  ; review_kind = entry.registration.review_kind
+  ; authority_actor = entry.registration.authority_actor
+  ; started_at = entry.started_at
+  ; status
+  }
+;;
+
+let list_runs t = List.map run_of_entry (Store.list_entries t)
+let get t ~run_id = Option.map run_of_entry (Store.get t ~id:run_id)
+
+let status_label = function
+  | Running -> "running"
+  | Completed { outcome; _ } -> outcome_label outcome
+;;
+
+let run_to_yojson run =
+  let completion_fields =
+    match run.status with
+    | Running -> []
+    | Completed { outcome; evaluator_runtime; elapsed_s; tools } ->
+      let detail_fields =
+        match outcome with
+        | Committed -> []
+        | Deferred { retryable; detail } ->
+          [ "retryable", `Bool retryable; "detail", `String detail ]
+        | Raised { detail } -> [ "detail", `String detail ]
+      in
+      [ "elapsed_s", `Float elapsed_s
+      ; ( "tools"
+        , `List
+            (List.map
+               Verification_run_registry.tool_observation_to_yojson
+               tools) )
+      ]
+      @ detail_fields
+      @
+      match evaluator_runtime with
+      | None -> []
+      | Some runtime -> [ "evaluator_runtime", `String runtime ]
+  in
+  `Assoc
+    ([ "run_id", `String run.run_id
+     ; "goal_id", `String run.goal_id
+     ; "review_kind", `String (review_kind_label run.review_kind)
+     ; "authority_actor", `String run.authority_actor
+     ; "started_at", `Float run.started_at
+     ; "status", `String (status_label run.status)
+     ]
+     @ completion_fields)
+;;
+
+type global_install_error = Already_installed
+
+module Global = Run_registry_core.Global (struct
+    type nonrec t = t
+
+    let initial = create ()
+  end)
+
+let global = Global.current
+
+let install_global registry =
+  match Global.install registry with
+  | Ok () -> Ok ()
+  | Error Global.Already_installed -> Error Already_installed
+;;

--- a/lib/goal_verification_run_registry.mli
+++ b/lib/goal_verification_run_registry.mli
@@ -1,0 +1,73 @@
+(** Durable observation registry for standalone Goal-verifier reviews. The
+    Goal ledger remains completion authority; this registry records what the
+    independent reviewer did, including lookup tool calls, without becoming a
+    second lifecycle store. *)
+
+type review_kind =
+  | Criterion
+  | Proof
+
+type outcome =
+  | Committed
+  | Deferred of
+      { retryable : bool
+      ; detail : string
+      }
+  | Raised of { detail : string }
+
+type run_status =
+  | Running
+  | Completed of
+      { outcome : outcome
+      ; evaluator_runtime : string option
+      ; elapsed_s : float
+      ; tools : Verification_run_registry.tool_observation list
+      }
+
+type run =
+  { run_id : string
+  ; goal_id : string
+  ; review_kind : review_kind
+  ; authority_actor : string
+  ; started_at : float
+  ; status : run_status
+  }
+
+type t
+
+val storage_filename : string
+val create : ?path:string -> unit -> t
+val replay : string -> t
+
+val register_running :
+  t ->
+  run_id:string ->
+  goal_id:string ->
+  review_kind:review_kind ->
+  authority_actor:string ->
+  started_at:float ->
+  unit
+
+val mark_completed :
+  t ->
+  run_id:string ->
+  outcome:outcome ->
+  tools:Verification_run_registry.tool_observation list ->
+  ?evaluator_runtime:string ->
+  elapsed_s:float ->
+  unit ->
+  unit
+
+val list_runs : t -> run list
+val get : t -> run_id:string -> run option
+val review_kind_label : review_kind -> string
+val status_label : run_status -> string
+val run_to_yojson : run -> Yojson.Safe.t
+
+val change_observer_fn : (unit -> unit) Atomic.t
+
+type global_install_error = Already_installed
+
+val global : unit -> t
+val install_global : t -> (unit, global_install_error) result
+val max_completed_retained : int

--- a/lib/verification_run_registry.ml
+++ b/lib/verification_run_registry.ml
@@ -46,6 +46,66 @@ type run =
   ; status : run_status
   }
 
+let tool_observation_to_yojson tool =
+  `Assoc
+    [ "tool_name", `String tool.tool_name
+    ; "input", tool.input
+    ; "disposition", `String (Tool_result.string_of_disposition tool.disposition)
+    ; "output_excerpt", `String tool.output_excerpt
+    ; "output_truncated", `Bool tool.output_truncated
+    ; "duration_ms", `Float tool.duration_ms
+    ; "finished_at", `Float tool.finished_at
+    ]
+;;
+
+let tool_observation_of_yojson json =
+  let ( let* ) = Result.bind in
+  let* fields = Run_registry_core.Json.object_fields json in
+  let* () =
+    Run_registry_core.Json.exact_fields
+      ~required:
+        [ "tool_name"
+        ; "input"
+        ; "disposition"
+        ; "output_excerpt"
+        ; "output_truncated"
+        ; "duration_ms"
+        ; "finished_at"
+        ]
+      fields
+  in
+  let* tool_name = Run_registry_core.Json.string_field "tool_name" fields in
+  let* input =
+    match List.assoc_opt "input" fields with
+    | Some value -> Ok value
+    | None -> Error "missing field input"
+  in
+  let* disposition_wire =
+    Run_registry_core.Json.string_field "disposition" fields
+  in
+  let* disposition = Tool_result.unit_disposition_of_string disposition_wire in
+  let* output_excerpt =
+    Run_registry_core.Json.string_field "output_excerpt" fields
+  in
+  let* output_truncated =
+    match List.assoc_opt "output_truncated" fields with
+    | Some (`Bool value) -> Ok value
+    | Some _ -> Error "field output_truncated must be a boolean"
+    | None -> Error "missing field output_truncated"
+  in
+  let* duration_ms = Run_registry_core.Json.float_field "duration_ms" fields in
+  let* finished_at = Run_registry_core.Json.float_field "finished_at" fields in
+  Ok
+    { tool_name
+    ; input
+    ; disposition
+    ; output_excerpt
+    ; output_truncated
+    ; duration_ms
+    ; finished_at
+    }
+;;
+
 let outcome_label = function
   | Approved -> "approved"
   | Rejected _ -> "rejected"
@@ -128,21 +188,10 @@ module Payload = struct
   ;;
 
   let completion_to_yojson completion =
-    let tool_to_yojson tool =
-      `Assoc
-        [ "tool_name", `String tool.tool_name
-        ; "input", tool.input
-        ; "disposition", `String (Tool_result.string_of_disposition tool.disposition)
-        ; "output_excerpt", `String tool.output_excerpt
-        ; "output_truncated", `Bool tool.output_truncated
-        ; "duration_ms", `Float tool.duration_ms
-        ; "finished_at", `Float tool.finished_at
-        ]
-    in
     let fields =
       [ "outcome", `String (outcome_label completion.outcome)
       ; "elapsed_s", `Float completion.elapsed_s
-      ; "tools", `List (List.map tool_to_yojson completion.tools)
+      ; "tools", `List (List.map tool_observation_to_yojson completion.tools)
       ]
       @ outcome_fields completion.outcome
       @
@@ -183,56 +232,10 @@ module Payload = struct
       | Some _ -> Error "field tools must be an array"
       | None -> Error "missing field tools"
     in
-    let tool_of_yojson json =
-      let* fields = Run_registry_core.Json.object_fields json in
-      let* () =
-        Run_registry_core.Json.exact_fields
-          ~required:
-            [ "tool_name"
-            ; "input"
-            ; "disposition"
-            ; "output_excerpt"
-            ; "output_truncated"
-            ; "duration_ms"
-            ; "finished_at"
-            ]
-          fields
-      in
-      let* tool_name = Run_registry_core.Json.string_field "tool_name" fields in
-      let* input =
-        match List.assoc_opt "input" fields with
-        | Some value -> Ok value
-        | None -> Error "missing field input"
-      in
-      let* disposition_wire =
-        Run_registry_core.Json.string_field "disposition" fields
-      in
-      let* disposition = Tool_result.unit_disposition_of_string disposition_wire in
-      let* output_excerpt =
-        Run_registry_core.Json.string_field "output_excerpt" fields
-      in
-      let* output_truncated =
-        match List.assoc_opt "output_truncated" fields with
-        | Some (`Bool value) -> Ok value
-        | Some _ -> Error "field output_truncated must be a boolean"
-        | None -> Error "missing field output_truncated"
-      in
-      let* duration_ms = Run_registry_core.Json.float_field "duration_ms" fields in
-      let* finished_at = Run_registry_core.Json.float_field "finished_at" fields in
-      Ok
-        { tool_name
-        ; input
-        ; disposition
-        ; output_excerpt
-        ; output_truncated
-        ; duration_ms
-        ; finished_at
-        }
-    in
     let rec parse_tools acc = function
       | [] -> Ok (List.rev acc)
       | tool :: rest ->
-        let* tool = tool_of_yojson tool in
+        let* tool = tool_observation_of_yojson tool in
         parse_tools (tool :: acc) rest
     in
     let* tools = parse_tools [] tools_json in

--- a/lib/verification_run_registry.mli
+++ b/lib/verification_run_registry.mli
@@ -34,6 +34,11 @@ type tool_observation =
   ; finished_at : float
   }
 
+val tool_observation_to_yojson : tool_observation -> Yojson.Safe.t
+
+val tool_observation_of_yojson :
+  Yojson.Safe.t -> (tool_observation, string) result
+
 type run_status =
   | Running
   | Completed of

--- a/test/dune
+++ b/test/dune
@@ -1821,6 +1821,7 @@
 (include stanzas/test_goal_verification_gate.inc)
 
 (include stanzas/test_goal_verification_agent.inc)
+(include stanzas/test_goal_verification_run_registry.inc)
 
 
 

--- a/test/stanzas/test_goal_verification_run_registry.inc
+++ b/test/stanzas/test_goal_verification_run_registry.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_goal_verification_run_registry)
+ (modules test_goal_verification_run_registry)
+ (libraries masc_test_deps))

--- a/test/test_goal_verification_run_registry.ml
+++ b/test/test_goal_verification_run_registry.ml
@@ -29,7 +29,7 @@ let test_completed_run_replays_with_tool_evidence () =
   with_path
   @@ fun path ->
   let registry = R.create ~path () in
-  let run_id = Random_id.uuid_v7 () in
+  let run_id = "goal-run-completed" in
   R.register_running
     registry
     ~run_id
@@ -69,7 +69,7 @@ let test_running_attempt_is_not_claimed_after_restart () =
   let registry = R.create ~path () in
   R.register_running
     registry
-    ~run_id:(Random_id.uuid_v7 ())
+    ~run_id:"goal-run-interrupted"
     ~goal_id:"goal-interrupted"
     ~review_kind:R.Criterion
     ~authority_actor:"verifier_exact"

--- a/test/test_goal_verification_run_registry.ml
+++ b/test/test_goal_verification_run_registry.ml
@@ -1,0 +1,95 @@
+open Alcotest
+open Masc
+
+module R = Goal_verification_run_registry
+
+let with_path f =
+  let path = Filename.temp_file "goal_verification_runs_" ".jsonl" in
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove path with Sys_error _ -> ())
+    (fun () -> f path)
+;;
+
+let sample_tool () : Verification_run_registry.tool_observation =
+  { tool_name = "verification_read_file"
+  ; input =
+      `Assoc
+        [ "producer", `String "builder"
+        ; "file_path", `String "artifacts/proof.txt"
+        ]
+  ; disposition = Tool_result.Completed ()
+  ; output_excerpt = "proof bytes"
+  ; output_truncated = false
+  ; duration_ms = 3.0
+  ; finished_at = 12.5
+  }
+;;
+
+let test_completed_run_replays_with_tool_evidence () =
+  with_path
+  @@ fun path ->
+  let registry = R.create ~path () in
+  let run_id = Random_id.uuid_v7 () in
+  R.register_running
+    registry
+    ~run_id
+    ~goal_id:"goal-a"
+    ~review_kind:R.Proof
+    ~authority_actor:"verifier_exact"
+    ~started_at:10.0;
+  R.mark_completed
+    registry
+    ~run_id
+    ~outcome:R.Committed
+    ~tools:[ sample_tool () ]
+    ~evaluator_runtime:"runtime-a"
+    ~elapsed_s:2.5
+    ();
+  match R.get (R.replay path) ~run_id with
+  | Some
+      { goal_id = "goal-a"
+      ; review_kind = R.Proof
+      ; authority_actor = "verifier_exact"
+      ; status =
+          R.Completed
+            { outcome = R.Committed
+            ; evaluator_runtime = Some "runtime-a"
+            ; tools = [ tool ]
+            ; _
+            }
+      ; _
+      } ->
+    check string "replayed tool" "verification_read_file" tool.tool_name
+  | _ -> fail "completed Goal verification run did not replay"
+;;
+
+let test_running_attempt_is_not_claimed_after_restart () =
+  with_path
+  @@ fun path ->
+  let registry = R.create ~path () in
+  R.register_running
+    registry
+    ~run_id:(Random_id.uuid_v7 ())
+    ~goal_id:"goal-interrupted"
+    ~review_kind:R.Criterion
+    ~authority_actor:"verifier_exact"
+    ~started_at:20.0;
+  check int "replayed running attempts are dropped" 0
+    (List.length (R.list_runs (R.replay path)))
+;;
+
+let () =
+  run
+    "goal verification run registry"
+    [ ( "durability"
+      , [ test_case
+            "completed run replays with tool evidence"
+            `Quick
+            test_completed_run_replays_with_tool_evidence
+        ; test_case
+            "running attempt is not claimed after restart"
+            `Quick
+            test_running_attempt_is_not_claimed_after_restart
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary

Add a durable observation registry for standalone Goal-verifier attempts.

- Records Goal id, criterion/proof kind, fixed authority, start/completion, evaluator runtime, and redacted tool observations.
- Uses the shared append-only `Run_registry_core`; interrupted Running rows are dropped on replay rather than presented as completed.
- Reuses the existing verification tool-observation codec so Task and Goal panels cannot disagree about tool call envelopes.
- Does not become Goal completion authority; `goal_verifications.json` and the Goal FSM remain the only lifecycle gate.

## Evidence

- New restart/replay scenario retains a completed proof run and its `verification_read_file` observation.
- Interrupted Running attempt is not claimed after restart.
- `ocamlformat --check` — PASS.
- `ocamlc -stop-after parsing` — PASS.
- `git diff --check` — PASS.
- Local Dune intentionally not run; exact-head CI is authority.

Stacked on #29255. Worker/bootstrap/route wiring follows in the next child.