### PR TITLE
fix(keeper): report the interrupt signal, not a cancellation that may not happen

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -113,9 +113,13 @@ export {
 // --- Types ---
 
 export interface KeeperTurnInterruptResult {
-  cancelled: boolean
+  /** The server failed the turn switch. Whether the signal reached the running
+   *  fiber, and whether that fiber then ended, are later events this response
+   *  cannot report. Read the turn state for the outcome. */
+  signalled: boolean
   turn_id?: number
   reason?: string
+  detail?: string
 }
 
 export async function interruptKeeperTurn(
@@ -137,9 +141,10 @@ export async function interruptKeeperTurn(
   }
   const data = (await resp.json()) as Record<string, unknown>
   return {
-    cancelled: data.cancelled === true,
+    signalled: data.signalled === true,
     turn_id: typeof data.turn_id === 'number' ? data.turn_id : undefined,
     reason: asString(data.reason),
+    detail: asString(data.detail),
   }
 }
 

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -212,7 +212,7 @@ export async function interruptKeeperTurn(keeperName: string): Promise<boolean> 
   try {
     const result = await apiInterruptKeeperTurn(name)
     setRecordValue(keeperActionErrors, name, null)
-    return result.cancelled
+    return result.signalled
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
     console.warn('[keeper] interrupt turn failed', { keeperName: name, message })

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -326,13 +326,6 @@ val set_turn_switch :
     keeper is not registered. *)
 val clear_turn_switch : base_path:string -> string -> unit
 
-(** Cancel the keeper's in-flight turn by failing its [Eio.Switch.t].
-    Returns [`Cancelled turn_id] when a live switch was held and
-    cancelled, or [`No_turn_in_flight] when there is no active turn or
-    no registered switch. *)
-val interrupt_current_turn :
-  base_path:string -> string -> [ `Cancelled of int | `No_turn_in_flight ]
-
 type exact_turn_interrupt_result =
   | Exact_turn_cancelled of int
   | Exact_no_turn_in_flight
@@ -341,10 +334,19 @@ type exact_turn_interrupt_result =
       ; detail : string
       }
 
-(** Cancel the turn switch retained by this exact registry entry. Unlike the
-    name-based compatibility API, failure is returned explicitly. *)
+(** Cancel the turn switch retained by this exact registry entry.
+
+    [Exact_turn_cancelled] states that the switch was failed, not that the
+    turn ended: the signal still has to reach the running fiber, and a fiber
+    parked in an uncancellable section never sees it. Callers must not report
+    it as a completed cancellation. *)
 val interrupt_current_turn_exact :
   registry_entry -> exact_turn_interrupt_result
+
+(** Same, resolved by name. Returns [Exact_turn_cancel_failed] when the entry
+    is absent, so a failure is never reported as an absent turn. *)
+val interrupt_current_turn :
+  base_path:string -> string -> exact_turn_interrupt_result
 
 (** Record the verdict reasons from a [keeper_cycle_decision] that
     chose to skip the next turn.  Stamps [last_skip_observation] with

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -1359,18 +1359,24 @@ let interrupt_current_turn_exact observed_entry =
            })
 ;;
 
+(* A cancellation that failed used to collapse into [`No_turn_in_flight], which
+   reads as "there was nothing to cancel" — the opposite of what happened. The
+   metric and the warn line stay; the outcome now reaches the caller so an
+   operator surface can say which of the two it was. *)
 let interrupt_current_turn ~base_path name =
   match StringMap.find_opt (registry_key ~base_path name) (Atomic.get registry) with
-  | None -> `No_turn_in_flight
+  | None ->
+    Exact_turn_cancel_failed
+      { turn_id = None; detail = "no registry entry for this Keeper name" }
   | Some entry ->
     (match interrupt_current_turn_exact entry with
-     | Exact_turn_cancelled turn_id -> `Cancelled turn_id
-     | Exact_no_turn_in_flight -> `No_turn_in_flight
-     | Exact_turn_cancel_failed { detail; _ } ->
+     | Exact_turn_cancelled _ as cancelled -> cancelled
+     | Exact_no_turn_in_flight -> Exact_no_turn_in_flight
+     | Exact_turn_cancel_failed { detail; _ } as failed ->
        Otel_metric_store.inc_counter
          Keeper_metrics.(to_string LifecycleDispatchRejections)
          ~labels:[ "keeper", name; "event", "turn_cancel_failed" ]
          ();
        Log.Keeper.warn "%s: turn cancellation failed: %s" name detail;
-       `No_turn_in_flight)
+       failed)
 ;;

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -267,17 +267,35 @@ let handle_keeper_turn_interrupt state request reqd =
         respond_json_value_with_cors ~status:`Not_found request reqd
           (keeper_chat_stream_error_json "keeper not registered")
       else (
+        (* The server fails the turn switch and learns nothing more within this
+           request: whether the signal reaches the running fiber, and whether
+           that fiber then terminates, are later events. [signalled] reports
+           what happened here. A turn parked in an uncancellable section keeps
+           running after a [signalled: true] response, so an operator has to
+           read the turn state to know the outcome. The former [cancelled:
+           true] read as that outcome and hid a 63-minute hang (#29229). *)
         match Keeper_registry.interrupt_current_turn ~base_path keeper_name with
-        | `Cancelled turn_id ->
+        | Keeper_registry.Exact_turn_cancelled turn_id ->
           Log.Keeper.info "keeper_turn_interrupt: keeper=%s turn_id=%d" keeper_name turn_id;
           respond_json_value_with_cors ~status:`OK request reqd
-            (`Assoc [ ("cancelled", `Bool true); ("turn_id", `Int turn_id) ])
-        | `No_turn_in_flight ->
+            (`Assoc [ ("signalled", `Bool true); ("turn_id", `Int turn_id) ])
+        | Keeper_registry.Exact_no_turn_in_flight ->
           respond_json_value_with_cors ~status:`OK request reqd
             (`Assoc
-               [ ("cancelled", `Bool false)
+               [ ("signalled", `Bool false)
                ; ("reason", `String "no_in_flight_turn")
-               ])))
+               ])
+        | Keeper_registry.Exact_turn_cancel_failed { turn_id; detail } ->
+          respond_json_value_with_cors ~status:`OK request reqd
+            (`Assoc
+               ([ ("signalled", `Bool false)
+                ; ("reason", `String "cancel_failed")
+                ; ("detail", `String detail)
+                ]
+                @
+                match turn_id with
+                | Some turn_id -> [ ("turn_id", `Int turn_id) ]
+                | None -> []))))
 ;;
 
 (* No cumulative timeout or work budget for keeper_msg. Keeper calls AGENT_CORE with

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -116,10 +116,16 @@ val handle_keeper_turn_interrupt :
   Mcp_server.server_state -> Httpun.Request.t -> Httpun.Reqd.t -> unit
 (** Drives [POST /api/v1/keepers/turn/interrupt].
     Reads [{"name": "<keeper>"}], validates the keeper is registered, and
-    asks {!Keeper_registry.interrupt_current_turn} to cancel the in-flight
-    turn's switch. Returns [{cancelled, turn_id}] on success or
-    [{cancelled:false, reason:"no_in_flight_turn"}] when there is nothing
-    to interrupt. *)
+    asks {!Keeper_registry.interrupt_current_turn} to fail the in-flight
+    turn's switch. Returns [{signalled:true, turn_id}] when the switch was
+    failed, [{signalled:false, reason:"no_in_flight_turn"}] when there was
+    no turn, and [{signalled:false, reason:"cancel_failed", detail}] when
+    the attempt itself failed.
+
+    [signalled] is not a completed cancellation: the signal still has to
+    reach the running fiber, and a fiber parked in an uncancellable section
+    keeps running. The turn state, not this response, says whether the turn
+    ended. *)
 
 (** {1 SSE handler} *)
 

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=517
+UNWIRED_BASELINE=516
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -108,6 +108,7 @@ normal_targets=(
   @test/runtest-test_keeper_toml_accessor_matrix
   @test/runtest-test_keeper_tool_execute_stream_close
   @test/runtest-test_keeper_turn_dispatch_authority
+  @test/runtest-test_keeper_turn_interrupt
   @test/runtest-test_runtime_quota_window
   @test/runtest-test_subsystem_health_state
   @test/runtest-test_trailing_slash_rules

--- a/test/test_keeper_turn_interrupt.ml
+++ b/test/test_keeper_turn_interrupt.ml
@@ -29,7 +29,10 @@ let make_meta name =
       (`Assoc
         [
           ("name", `String name);
-          ("agent_name", `String ("agent-" ^ name));
+          (* The canonical form is the identity module's, not a literal
+             prefix: this fixture drifted and the suite has been failing at
+             construction, unnoticed because it is not in the CI list. *)
+          ("agent_name", `String (Keeper_identity.keeper_agent_name name));
           ("trace_id", `String ("trace-" ^ name));
           ("allowed_paths", `List [ `String "*" ]);
         ])
@@ -99,10 +102,14 @@ let test_interrupt_cancels_turn () =
      | Eio.Cancel.Cancelled _ -> ()));
   Eio.Promise.await registered;
   (match Keeper_registry.interrupt_current_turn ~base_path:base name with
-   | `Cancelled turn_id ->
+   | Keeper_registry.Exact_turn_cancelled turn_id ->
      check "turn_id is 1" (turn_id = 1);
      check "turn fibre cancelled" (Eio.Promise.await cancelled)
-   | `No_turn_in_flight -> check "expected an in-flight turn" false);
+   | Keeper_registry.Exact_no_turn_in_flight ->
+     check "expected an in-flight turn" false
+   | Keeper_registry.Exact_turn_cancel_failed { detail; _ } ->
+     Printf.printf "  cancel failed: %s\n%!" detail;
+     check "cancellation must not fail here" false);
   let entry = Option.get (Keeper_registry.get ~base_path:base name) in
   check "switch cleared" (Atomic.get entry.current_turn_switch = None)
 ;;
@@ -119,13 +126,36 @@ let test_interrupt_no_turn_is_noop () =
   check
     "no in-flight turn"
     (match Keeper_registry.interrupt_current_turn ~base_path:base name with
-     | `Cancelled _ -> false
-     | `No_turn_in_flight -> true)
+     | Keeper_registry.Exact_no_turn_in_flight -> true
+     | Keeper_registry.Exact_turn_cancelled _
+     | Keeper_registry.Exact_turn_cancel_failed _ -> false)
+;;
+
+(* An unregistered name is a failed cancellation, not an idle Keeper. Reporting
+   it as [Exact_no_turn_in_flight] told an operator the turn was already gone
+   when the registry never held it. *)
+let test_unknown_keeper_is_a_failure_not_idle () =
+  Printf.printf "Test: interrupting an unregistered Keeper reports failure\n%!";
+  with_env
+  @@ fun ~base ->
+  Eio_main.run
+  @@ fun env ->
+  Masc_test_deps.init_eio_clock env;
+  check
+    "unregistered name reports cancel_failed"
+    (match
+       Keeper_registry.interrupt_current_turn ~base_path:base "never-registered"
+     with
+     | Keeper_registry.Exact_turn_cancel_failed { turn_id = None; _ } -> true
+     | Keeper_registry.Exact_turn_cancel_failed _
+     | Keeper_registry.Exact_no_turn_in_flight
+     | Keeper_registry.Exact_turn_cancelled _ -> false)
 ;;
 
 let () =
   test_interrupt_cancels_turn ();
   test_interrupt_no_turn_is_noop ();
+  test_unknown_keeper_is_a_failure_not_idle ();
   if !failures > 0
   then (
     Printf.printf "FAILED: %d check(s)\n%!" !failures;


### PR DESCRIPTION
## 현상

`POST /api/v1/keepers/turn/interrupt` 가 `cancelled: true` 를 돌려주는데, 이건 **턴이 끝났다는 뜻이 아닙니다.** 스위치를 실패시켰다는 뜻이에요. 그 신호가 실행 중인 fiber 에 닿아야 하고, 취소가 안 되는 구간에 들어가 있는 fiber 는 신호를 못 봅니다.

#29229 의 실측입니다.

```
01:38:15  keeper_turn_interrupt: keeper=taskmaster turn_id=27647
          -> {"cancelled":true,"turn_id":27647}

01:38:26 ~ 01:40:07   pending 87 고정
taskmaster FSM 마지막 전이: 00:35:22 streaming -> awaiting_tool   (이후 0건)
```

운영자는 개입이 성공했다고 읽었고, 턴은 63분째 그대로였습니다.

## 두 번째 결함 — 실패가 "취소할 게 없었다" 로 뭉개집니다

```ocaml
| Exact_turn_cancel_failed { detail; _ } ->
   ...
   Log.Keeper.warn "%s: turn cancellation failed: %s" name detail;
   `No_turn_in_flight)                              (* <- 실패가 여기서 사라짐 *)
```

응답은 `{"cancelled": false, "reason": "no_in_flight_turn"}` 이 됩니다. **취소가 실패했는데 "취소할 턴이 없었다" 로 나갑니다.**

타입 있는 형제는 이미 실패를 반환하고 있었어요.

```ocaml
type exact_turn_interrupt_result =
  | Exact_turn_cancelled of int
  | Exact_no_turn_in_flight
  | Exact_turn_cancel_failed of { turn_id : int option; detail : string }
```

`.mli` 주석도 *"이름 기반 호환 API와 달리 실패를 명시적으로 반환한다"* 고 적어뒀습니다. 이름 기반 쪽만 그걸 버리고 있었습니다.

## 변경

이름 기반 API 도 같은 타입을 반환하고, 응답은 **아는 것만** 말합니다.

| 결과 | 응답 |
|---|---|
| 스위치를 실패시킴 | `{"signalled": true, "turn_id": N}` |
| 돌던 턴 없음 | `{"signalled": false, "reason": "no_in_flight_turn"}` |
| 취소 시도 자체가 실패 | `{"signalled": false, "reason": "cancel_failed", "detail": "…"}` |

등록되지 않은 이름도 이제 **실패**입니다. 전에는 "쉬고 있는 keeper" 로 답했어요.

`signalled` 는 완료된 취소가 아닙니다. 턴이 끝났는지는 **턴 상태를 봐야** 알고, 그 문장을 `.mli` 와 대시보드 타입 주석에 적었습니다.

### 계약 변경

응답 필드 `cancelled` → `signalled`, 실패 시 `detail` 추가. 대시보드 클라이언트(`api/keeper.ts`, `keeper-actions.ts`)를 같이 고쳤습니다.

## 테스트가 아예 못 돌고 있었습니다

`test_keeper_turn_interrupt` 는 **모든 케이스가 생성 단계에서 죽고 있었습니다.**

```
Fatal error: make_meta failed: invalid current keeper meta:
  agent_name does not match canonical keeper identity
```

픽스처가 `"agent-" ^ name` 을 쓰는데 정본은 `Keeper_identity.keeper_agent_name` 입니다. 그리고 이 스위트는 `scripts/ci-run-focused-tests.sh` 에 없어서 **CI 에서 돌지 않습니다.** 그래서 이 어긋남이 안 보였어요.

`origin/main` 에서도 똑같이 실패하는 걸 확인했습니다(제 변경 탓 아님).

- 픽스처를 정본 함수로 고침
- 등록 안 된 이름이 실패로 나오는지 보는 케이스 추가
- 스위트를 allowlist 에 배선 (`UNWIRED_BASELINE` 517 → 516)

## 검증

```
dune build @check                    통과
test_keeper_turn_interrupt           전부 통과 (신규 케이스 포함)
dashboard  npx tsc --noEmit          통과
audit-ci-test-targets.sh             516 unwired, at baseline
```

Refs #29229
