### PR TITLE
fix(e2e): capture console lines and failed requests with the failure page

### DIFF
--- a/dashboard/e2e/keeper-composition-real-backend.mjs
+++ b/dashboard/e2e/keeper-composition-real-backend.mjs
@@ -42,8 +42,34 @@ if (health?.dashboard_surface?.status !== 'ok') {
 }
 
 const browser = await chromium.launch({ headless: true })
+// Run 32444698841 timed out on the composer with the page showing
+// "Client WS · disconnected" and a registry stuck on "loading": auth had
+// passed and the route had selected the keeper, so the failure was the socket,
+// not the locator. The screenshot said which subsystem; it could not say why.
+// Console lines and failed requests name the cause, and both have to be
+// subscribed before the first navigation to catch anything.
+const consoleLines = []
+const failedRequests = []
+const CAPTURE_LIMIT = 400
 try {
   const page = await browser.newPage({ viewport })
+  page.on('console', message => {
+    if (consoleLines.length < CAPTURE_LIMIT) {
+      consoleLines.push(`[${message.type()}] ${message.text()}`)
+    }
+  })
+  page.on('pageerror', error => {
+    if (consoleLines.length < CAPTURE_LIMIT) {
+      consoleLines.push(`[pageerror] ${error.message}`)
+    }
+  })
+  page.on('requestfailed', request => {
+    if (failedRequests.length < CAPTURE_LIMIT) {
+      failedRequests.push(
+        `${request.method()} ${request.url()} — ${request.failure()?.errorText ?? 'unknown'}`,
+      )
+    }
+  })
   const route = new URL(dashboardUrl)
   route.searchParams.set('agent', 'dashboard')
   route.searchParams.set('token', token)
@@ -261,6 +287,8 @@ try {
             url: page.url(),
             title: await page.title(),
             body_text: (await page.locator('body').innerText()).slice(0, 20000),
+            console_lines: consoleLines,
+            failed_requests: failedRequests,
           },
           null,
           2,


### PR DESCRIPTION
## 배경

#29245 로 넣은 실패 캡처가 run `32444698841` 에서 처음 작동해 원인 subsystem 을 짚었습니다.

```
Reconnecting...
Client WS · disconnected
Verified @dashboard · admin        <- 인증은 통과
전체 0   실행 0   주의 0
키퍼 상세  RW-RW-32444698841-1-COORD   <- 주소도 정확히 골랐다
레지스트리 불러오는 중…
```

**인증도 라우팅도 정상이고 client WebSocket 만 안 붙었습니다.** 그래서 데이터가 안 와서 대화 패널이 그려지지 않고, 입력창이 없어서 30초 타임아웃이 났습니다.

여기까지가 스크린샷으로 알 수 있는 한계입니다. **왜 안 붙었는지는 안 나옵니다.**

## 변경

첫 navigation 전에 세 이벤트를 구독하고, 실패 기록에 같이 씁니다.

| 이벤트 | 담기는 것 |
|---|---|
| `console` | `[error] …`, `[warn] …` 등 타입과 본문 |
| `pageerror` | 잡히지 않은 예외 메시지 |
| `requestfailed` | 메서드, URL, `errorText` |

WS 핸드셰이크가 거부되거나 업그레이드가 막히면 이 둘 중 하나에 사유가 그대로 찍힙니다.

**구독 시점이 중요합니다.** `page.on(...)` 을 `page.goto()` 전에 걸어야 초기 로드에서 나는 것들을 놓치지 않습니다.

## 상한

두 목록 각각 **400개**로 자릅니다. 페이지가 루프로 로그를 뿜으면 evidence 아티팩트가 무한히 커질 수 있어서요.

## 검증

```
node --check dashboard/e2e/keeper-composition-real-backend.mjs   통과
```

`dashboard/package.json` 의 lint 는 `eslint src` 라 `e2e/` 는 대상이 아닙니다.

실제 캡처 내용은 acceptance 가 다시 실패할 때 확인됩니다 — 지금 재현 경로가 CI 환경 승인을 거쳐야 해서 로컬에서 못 돌렸습니다.

Refs #29183
