### PR TITLE
fix(goal): reconcile committed proofs after crash

### DIFF
--- a/dashboard/e2e/keeper-composition-real-backend.mjs
+++ b/dashboard/e2e/keeper-composition-real-backend.mjs
@@ -15,6 +15,8 @@ const tokenFile = required('MASC_COMPOSITION_DASHBOARD_TOKEN_FILE')
 const keeperName = required('MASC_COMPOSITION_KEEPER_NAME')
 const expectedBasePath = required('MASC_COMPOSITION_EXPECTED_BASE_PATH')
 const artifactDir = required('MASC_COMPOSITION_BROWSER_ARTIFACT_DIR')
+const goalVerificationGoalId = required('MASC_GOAL_VERIFICATION_GOAL_ID')
+const goalVerificationRunId = required('MASC_GOAL_VERIFICATION_RUN_ID')
 const token = readFileSync(tokenFile, 'utf8').trim()
 if (!token) throw new Error('dashboard token file is empty')
 
@@ -23,6 +25,8 @@ const screenshotPath = join(artifactDir, 'keeper-composition-inspector.png')
 const measurementPath = join(artifactDir, 'keeper-composition-inspector.json')
 const persistenceScreenshotPath = join(artifactDir, 'keeper-persistence-proof.png')
 const persistenceMeasurementPath = join(artifactDir, 'keeper-persistence-proof.json')
+const goalVerificationScreenshotPath = join(artifactDir, 'goal-verification-run-proof.png')
+const goalVerificationMeasurementPath = join(artifactDir, 'goal-verification-run-proof.json')
 const failureScreenshotPath = join(artifactDir, 'keeper-composition-failure.png')
 const failureStatePath = join(artifactDir, 'keeper-composition-failure.json')
 const viewport = { width: 1440, height: 1000 }
@@ -265,7 +269,69 @@ try {
     persistenceMeasurementPath,
     `${JSON.stringify(persistenceMeasurement, null, 2)}\n`,
   )
-  process.stdout.write(`${JSON.stringify({ composition: measurement, persistence: persistenceMeasurement })}\n`)
+
+  const goalRunsResponse = await fetch(
+    new URL('/api/v1/dashboard/goal-verification-runs', dashboardUrl),
+    { headers: { Authorization: `Bearer ${token}`, Accept: 'application/json' } },
+  )
+  if (!goalRunsResponse.ok) {
+    throw new Error(`Goal verification runs fetch failed: ${goalRunsResponse.status}`)
+  }
+  const goalRunsPayload = await goalRunsResponse.json()
+  const expectedRun = Array.isArray(goalRunsPayload?.runs)
+    ? goalRunsPayload.runs.find(run => run?.run_id === goalVerificationRunId)
+    : undefined
+  if (expectedRun?.goal_id !== goalVerificationGoalId
+    || expectedRun?.review_kind !== 'proof'
+    || expectedRun?.status !== 'committed'
+    || !Array.isArray(expectedRun?.tools)
+    || !expectedRun.tools.some(tool => tool?.tool_name === 'verification_read_file')) {
+    throw new Error(`exact Goal verification run is absent or incomplete: ${JSON.stringify(expectedRun)}`)
+  }
+
+  const goalPanel = page.getByTestId('goal-verification-runs-panel')
+  await goalPanel.waitFor()
+  const goalRunRow = goalPanel.locator(
+    `[data-goal-verification-run="${goalVerificationRunId}"]`,
+  )
+  await goalRunRow.waitFor()
+  if (await goalRunRow.getAttribute('data-goal-id') !== goalVerificationGoalId
+    || await goalRunRow.getAttribute('data-run-status') !== 'committed'
+    || await goalRunRow.getAttribute('data-review-kind') !== 'proof') {
+    throw new Error('rendered Goal verification row identity differs from backend payload')
+  }
+  const goalToolDetails = goalRunRow.locator(
+    `[data-goal-verification-tools="${goalVerificationRunId}"]`,
+  )
+  await goalToolDetails.locator('summary').click()
+  const artifactTool = goalToolDetails.getByText('verification_read_file', { exact: true })
+  await artifactTool.waitFor()
+  const goalVerificationScreenshot = await page.screenshot({
+    path: goalVerificationScreenshotPath,
+    fullPage: true,
+  })
+  const goalVerificationMeasurement = {
+    schema: 'masc.goal_verification_browser_evidence.v1',
+    goal_id: goalVerificationGoalId,
+    run_id: goalVerificationRunId,
+    status: await goalRunRow.getAttribute('data-run-status'),
+    review_kind: await goalRunRow.getAttribute('data-review-kind'),
+    artifact_tool_visible: await artifactTool.isVisible(),
+    backend_tool_names: expectedRun.tools.map(tool => tool.tool_name),
+    viewport,
+    screenshot_file: 'goal-verification-run-proof.png',
+    screenshot_bytes: goalVerificationScreenshot.byteLength,
+    screenshot_sha256: createHash('sha256').update(goalVerificationScreenshot).digest('hex'),
+  }
+  writeFileSync(
+    goalVerificationMeasurementPath,
+    `${JSON.stringify(goalVerificationMeasurement, null, 2)}\n`,
+  )
+  process.stdout.write(`${JSON.stringify({
+    composition: measurement,
+    persistence: persistenceMeasurement,
+    goal_verification: goalVerificationMeasurement,
+  })}\n`)
 } catch (error) {
   // The success path screenshots after every assertion has passed, so a locator
   // timeout produced only its own message: run 32434575143 aborted on

--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -344,6 +344,32 @@ let update_goal config ~goal_id f =
           let* () = write_state_result config next_state in
           Ok updated_goal)
 
+type conditional_update =
+  | Goal_updated of goal
+  | Goal_phase_mismatch of Goal_phase.t
+
+let update_goal_if_phase config ~goal_id ~expected_phase f =
+  let lock_path = goals_path config in
+  Workspace_utils.with_file_lock config lock_path (fun () ->
+      match load_state config with
+      | Undecodable detail -> Error (undecodable_store_error config detail)
+      | Loaded state ->
+        (match find_goal state.goals goal_id with
+         | None -> Error "goal not found"
+         | Some goal when goal.phase <> expected_phase ->
+           Ok (Goal_phase_mismatch goal.phase)
+         | Some goal ->
+           let now = Masc_domain.now_iso () in
+           let updated_goal = f { goal with updated_at = now } in
+           let next_state =
+             { version = state.version + 1
+             ; updated_at = now
+             ; goals = replace_goal state.goals updated_goal
+             }
+           in
+           let* () = write_state_result config next_state in
+           Ok (Goal_updated updated_goal)))
+
 type delete_goal_outcome =
   | Deleted
   | Deleted_with_orphaned_links of string
@@ -542,4 +568,3 @@ let compute_rollup goals =
     done_count = count (fun goal -> goal.phase = Goal_phase.Completed);
     dropped_count = count (fun goal -> goal.phase = Goal_phase.Dropped);
   }
-

--- a/lib/goal/goal_store.mli
+++ b/lib/goal/goal_store.mli
@@ -134,6 +134,20 @@ val update_goal :
     (with [updated_at] pre-stamped), normalises the result,
     and writes back.  Errors when the [goal_id] is unknown. *)
 
+type conditional_update =
+  | Goal_updated of goal
+  | Goal_phase_mismatch of Goal_phase.t
+
+val update_goal_if_phase :
+  Workspace_utils.config ->
+  goal_id:string ->
+  expected_phase:Goal_phase.t ->
+  (goal -> goal) ->
+  (conditional_update, string) result
+(** Atomic compare-and-update under the goals file lock. A phase mismatch is
+    returned without writing, so recovery cannot overwrite a concurrent
+    lifecycle transition. *)
+
 type delete_goal_outcome =
   | Deleted
   | Deleted_with_orphaned_links of string

--- a/lib/goal_verification_agent.ml
+++ b/lib/goal_verification_agent.ml
@@ -90,9 +90,9 @@ let group_pending_by_goal work =
    ledger row lost the durable proof request is re-armed via
    [mark_proof_pending] and joins the work set, the same recovery
    [answer_verifying_repeat] performs on the MCP surface. A [Verifying] goal
-   with a committed [Proof_proven] verdict is the
-   crash-between-writes case the keeper's repeated [request_complete]
-   reconciles; the lane must not overwrite that verdict. *)
+   with a committed proof verdict is the crash-between-writes case: the exact
+   stored verdict reconciles the missing phase/event effect without another
+   model call or ledger rewrite. *)
 
 let collect_pending config : (pending_work list, string) result =
   match Goal_verification.load_records config with
@@ -120,9 +120,9 @@ let collect_pending config : (pending_work list, string) result =
            criterion @ proof)
         records
     in
-    let rearmed =
-      Goal_store.list_goals config ~phase:Goal_phase.Verifying ()
-      |> List.filter_map (fun (goal : Goal_store.goal) ->
+    let rec reconcile_verifying acc = function
+      | [] -> Ok (List.rev acc)
+      | (goal : Goal_store.goal) :: rest ->
         if
           List.exists
             (fun work ->
@@ -131,7 +131,7 @@ let collect_pending config : (pending_work list, string) result =
                 | Criterion_check -> false)
                && String.equal work.goal_id goal.id)
             from_rows
-        then None
+        then reconcile_verifying acc rest
         else
           match
             List.find_opt
@@ -140,32 +140,67 @@ let collect_pending config : (pending_work list, string) result =
               records
           with
           | Some
-              { Goal_verification.completion =
-                  (Goal_verification.Proof_proven _ | Goal_verification.Proof_pending _)
-              ; _
-              } -> None
+              { Goal_verification.completion = Goal_verification.Proof_pending _; _ } ->
+            reconcile_verifying acc rest
           | Some
               { Goal_verification.completion =
-                  ( Goal_verification.Completion_idle
-                  | Goal_verification.Proof_refuted _ )
+                  (Goal_verification.Proof_proven _ | Goal_verification.Proof_refuted _)
               ; _
-              }
+              } ->
+            (match Workspace_goals.reconcile_committed_proof config ~goal_id:goal.id with
+             | Error detail ->
+               Error
+                 (Printf.sprintf
+                    "goal verifier could not reconcile committed proof goal_id=%s \
+                     detail=%s"
+                    goal.id
+                    detail)
+             | Ok Workspace_goals.No_committed_proof ->
+               Error
+                 (Printf.sprintf
+                    "goal verifier saw a committed proof but reconciliation \
+                     found none goal_id=%s"
+                    goal.id)
+             | Ok (Workspace_goals.Reconciled phase) ->
+               Log.Misc.info
+                 "goal verifier reconciled committed proof after restart \
+                  goal_id=%s phase=%s"
+                 goal.id
+                 (Goal_phase.to_string phase);
+               reconcile_verifying acc rest
+             | Ok (Workspace_goals.Reconciliation_not_needed phase) ->
+               Log.Misc.info
+                 "goal verifier skipped proof reconciliation after concurrent \
+                  phase change goal_id=%s phase=%s"
+                 goal.id
+                 (Goal_phase.to_string phase);
+               reconcile_verifying acc rest)
+          | Some
+              { Goal_verification.completion = Goal_verification.Completion_idle; _ }
           | None ->
             (match Goal_verification.mark_proof_pending config ~goal_id:goal.id with
              | Ok _ ->
                Log.Misc.info
                  "goal verifier re-armed a missing proof request (P0-2) goal_id=%s"
                  goal.id;
-               Some { goal_id = goal.id; kind = Completion_proof }
+               reconcile_verifying
+                 ({ goal_id = goal.id; kind = Completion_proof } :: acc)
+                 rest
              | Error msg ->
-               Log.Misc.error
-                 "goal verifier could not re-arm a missing proof request goal_id=%s \
-                  detail=%s"
-                 goal.id
-                 msg;
-               None))
+               Error
+                 (Printf.sprintf
+                    "goal verifier could not re-arm a missing proof request \
+                     goal_id=%s detail=%s"
+                    goal.id
+                    msg))
     in
-    Ok (from_rows @ rearmed)
+    (match
+       reconcile_verifying
+         []
+         (Goal_store.list_goals config ~phase:Goal_phase.Verifying ())
+     with
+     | Error _ as error -> error
+     | Ok rearmed -> Ok (from_rows @ rearmed))
 ;;
 
 (* {1 Review request construction}

--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -719,6 +719,13 @@ let reconcile_committed_proof config ~goal_id =
          | Goal_verification.Proof_refuted
              ({ outcome = Goal_verification.Refuted { reason }; _ } as verdict) ->
            Some (Goal_phase.Record_proof_refuted, verdict, Some reason)
+         | Goal_verification.Proof_proven
+             { outcome = Goal_verification.Refuted _; _ }
+         | Goal_verification.Proof_refuted
+             { outcome = Goal_verification.Proven; _ } ->
+           (* Rejected by the explicit malformed-ledger guards above. This
+              arm keeps the closed sum exhaustive at the use site. *)
+           None
          | Goal_verification.Completion_idle
          | Goal_verification.Proof_pending _ -> None
        in
@@ -730,7 +737,7 @@ let reconcile_committed_proof config ~goal_id =
           | Ok (Goal_phase.Already _) ->
             Error "committed proof reconciliation did not name a phase transition"
           | Ok (Goal_phase.Move_to phase) ->
-            let update current =
+            let update (current : Goal_store.goal) =
               let last_review_note, last_review_at =
                 match note with
                 | Some note -> Some note, Some (Masc_domain.now_iso ())

--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -499,6 +499,11 @@ type verifier_decision =
   | Proof_proven
   | Proof_refuted of { reason : string }
 
+type proof_reconciliation =
+  | No_committed_proof
+  | Reconciled of Goal_phase.t
+  | Reconciliation_not_needed of Goal_phase.t
+
 let validate_verification_run_id verification_run_id =
   if String.trim verification_run_id <> ""
   then Ok verification_run_id
@@ -678,31 +683,141 @@ let commit_verifier_decision
                      ])))))
 ;;
 
+let reconcile_committed_proof config ~goal_id =
+  let ctx : context =
+    { config; agent_name = Runtime.verifier_exact_lane_id }
+  in
+  match Goal_store.get_goal config ~goal_id with
+  | None -> Error (Printf.sprintf "goal not found: %s" goal_id)
+  | Some goal when goal.phase <> Goal_phase.Verifying ->
+    Ok (Reconciliation_not_needed goal.phase)
+  | Some goal ->
+    (match Goal_verification.get_record config ~goal_id with
+     | Error _ as error -> error
+     | Ok None -> Ok No_committed_proof
+     | Ok
+         (Some
+           { Goal_verification.completion =
+               Goal_verification.Proof_proven
+                 { outcome = Goal_verification.Refuted _; _ }
+           ; _
+           }) ->
+       Error "proof_proven ledger state carries a refuted verdict"
+     | Ok
+         (Some
+           { Goal_verification.completion =
+               Goal_verification.Proof_refuted
+                 { outcome = Goal_verification.Proven; _ }
+           ; _
+           }) ->
+       Error "proof_refuted ledger state carries a proven verdict"
+     | Ok (Some record) ->
+       let transition =
+         match record.completion with
+         | Goal_verification.Proof_proven verdict ->
+           Some (Goal_phase.Record_proof_proven, verdict, None)
+         | Goal_verification.Proof_refuted
+             ({ outcome = Goal_verification.Refuted { reason }; _ } as verdict) ->
+           Some (Goal_phase.Record_proof_refuted, verdict, Some reason)
+         | Goal_verification.Completion_idle
+         | Goal_verification.Proof_pending _ -> None
+       in
+       match transition with
+       | None -> Ok No_committed_proof
+       | Some (action, verdict, note) ->
+         (match Goal_phase.decide_transition ~phase:goal.phase ~action with
+          | Error msg -> Error msg
+          | Ok (Goal_phase.Already _) ->
+            Error "committed proof reconciliation did not name a phase transition"
+          | Ok (Goal_phase.Move_to phase) ->
+            let update current =
+              let last_review_note, last_review_at =
+                match note with
+                | Some note -> Some note, Some (Masc_domain.now_iso ())
+                | None -> current.last_review_note, current.last_review_at
+              in
+              { current with phase; last_review_note; last_review_at }
+            in
+            (match
+               Goal_store.update_goal_if_phase
+                 config
+                 ~goal_id
+                 ~expected_phase:Goal_phase.Verifying
+                 update
+             with
+             | Error _ as error -> error
+             | Ok (Goal_store.Goal_phase_mismatch current_phase) ->
+               Ok (Reconciliation_not_needed current_phase)
+             | Ok (Goal_store.Goal_updated _) ->
+               emit_goal_event
+                 ctx
+                 ~goal_id
+                 ~event_type:"goal_phase"
+                 ~payload:(gate_event_payload ctx ~phase verdict);
+               Ok (Reconciled phase))))
+;;
+
 (* A repeated [request_complete] on [Verifying] is the explicit retry that
-   replaces wall-clock expiry (RFC-0387 §5). It answers [Already] carrying the
-   ledger state as the retry hint — and when the ledger lost the durable proof
-   request (the phase=Verifying + ledger=idle wedge of the rejected first
-   gate, P0-2), it RE-ARMS [mark_proof_pending] before answering, so the gate
-   always has a pending request for the verifier to drain. *)
+   replaces wall-clock expiry (RFC-0387 §5). A missing durable request is
+   re-armed; a committed verdict whose phase/event write was interrupted is
+   reconciled from that exact ledger row without another model call. *)
 let answer_verifying_repeat ~tool_name ~start_time (ctx : context) ~goal_id ~action goal =
   match Goal_verification.get_record ctx.config ~goal_id with
   | Error msg -> error_result_typed ~tool_name ~start_time ~code:Internal_error msg
   | Ok record ->
     (match record with
      | Some
-         { Goal_verification.completion =
-             (Goal_verification.Proof_pending _ | Goal_verification.Proof_proven _)
-         ; _
-         } ->
-       (* The durable request stands, or the verdict committed but the phase
-          write did not (crash-between-writes) — nothing to re-arm; the
-          retried [record_proof_*] re-commits the identical outcome and moves
-          the phase. *)
+         { Goal_verification.completion = Goal_verification.Proof_pending _; _ } ->
        already_goal_response
          ~tool_name ~start_time ~goal_id ~action ~phase:Goal_phase.Verifying goal
          record
+     | Some
+         ({ Goal_verification.completion =
+              (Goal_verification.Proof_proven _ | Goal_verification.Proof_refuted _)
+          ; _
+          } as committed_record) ->
+       (match reconcile_committed_proof ctx.config ~goal_id with
+        | Error msg ->
+          error_result_typed ~tool_name ~start_time ~code:Internal_error msg
+        | Ok No_committed_proof ->
+          error_result_typed
+            ~tool_name
+            ~start_time
+            ~code:Internal_error
+            "committed proof disappeared during phase reconciliation"
+        | Ok (Reconciliation_not_needed phase) ->
+          (match Goal_store.get_goal ctx.config ~goal_id with
+           | None ->
+             error_result_typed
+               ~tool_name ~start_time ~code:Internal_error "goal disappeared"
+           | Some current_goal ->
+             already_goal_response
+               ~tool_name
+               ~start_time
+               ~goal_id
+               ~action
+               ~phase
+               current_goal
+               (Some committed_record))
+        | Ok (Reconciled phase) ->
+          (match Goal_store.get_goal ctx.config ~goal_id with
+           | None ->
+             error_result_typed
+               ~tool_name ~start_time ~code:Internal_error "goal disappeared"
+           | Some updated_goal ->
+             ok_result
+               ~tool_name
+               ~start_time
+               [ "goal_id", `String goal_id
+               ; "action", `String (Goal_phase.action_to_string action)
+               ; "noop", `Bool false
+               ; "reconciled", `Bool true
+               ; "phase", Goal_phase.to_yojson phase
+               ; "goal", Goal_store.goal_to_yojson updated_goal
+               ; ( "verification"
+                 , Goal_verification.record_to_yojson committed_record )
+               ]))
      | Some { Goal_verification.completion = Goal_verification.Completion_idle; _ }
-     | Some { Goal_verification.completion = Goal_verification.Proof_refuted _; _ }
      | None ->
        (match Goal_verification.mark_proof_pending ctx.config ~goal_id with
         | Error msg ->

--- a/lib/workspace_goals.mli
+++ b/lib/workspace_goals.mli
@@ -57,6 +57,11 @@ type verifier_decision =
   | Proof_proven
   | Proof_refuted of { reason : string }
 
+type proof_reconciliation =
+  | No_committed_proof
+  | Reconciled of Goal_phase.t
+  | Reconciliation_not_needed of Goal_phase.t
+
 (** Commit one verdict from the application-owned Goal verifier. The fixed
     [verifier_exact] authority is constructed inside this boundary; callers
     cannot supply or impersonate it. The ledger commit precedes any phase
@@ -70,3 +75,11 @@ val commit_verifier_decision
   -> decision:verifier_decision
   -> evidence:string
   -> Tool_result.result
+
+val reconcile_committed_proof :
+  Workspace_utils_backend_setup.config ->
+  goal_id:string ->
+  (proof_reconciliation, string) result
+(** Converges the Goal phase after a crash between the durable proof verdict
+    write and the phase/event write. The existing verdict is reused without a
+    model call or ledger rewrite. *)

--- a/scripts/fixtures/keeper-multi-collaboration/missions.json
+++ b/scripts/fixtures/keeper-multi-collaboration/missions.json
@@ -2,6 +2,27 @@
   "schema": "masc.keeper_multi_collaboration_missions.v1",
   "acceptance_authority": "real_world_product_outcomes",
   "minimum_keeper_count": 5,
+  "approaches_apply_to_each_mission": true,
+  "execution_approaches": [
+    {
+      "id": "A",
+      "name": "hermetic_typed_contract",
+      "method": "Typed unit/integration tests plus deterministic fault injection verify the state machine, persistence ordering, strict codecs, and recovery invariants.",
+      "required_evidence": ["exact source SHA", "CI test target", "typed assertion or injected fault receipt"]
+    },
+    {
+      "id": "B",
+      "name": "isolated_exact_revision_realworld",
+      "method": "An isolated exact-revision server drives real providers, five roles, durable product state, and a real-backend browser without API interception.",
+      "required_evidence": ["binary/source digest", "raw tool and state receipts", "Dashboard screenshot"]
+    },
+    {
+      "id": "C",
+      "name": "shared_shadow_duration_canary",
+      "method": "A shared or shadow canary repeats the mission across 10 turns and 1h, 2h, 4h, and 24h tiers with restart/failover and per-occurrence receipts.",
+      "required_evidence": ["served_by attribution", "duration and restart receipts", "queue and Dashboard cross-check"]
+    }
+  ],
   "roles": [
     "coordinator",
     "builder-a",
@@ -19,6 +40,7 @@
     "masc_goal_upsert",
     "masc_goal_assign",
     "masc_goal_list",
+    "masc_goal_transition",
     "masc_add_task",
     "masc_tasks",
     "masc_task_history",
@@ -272,6 +294,16 @@
       "user_story": "선언한 대상 범위의 모든 케이스가 실제 동작으로 증명된다. 케이스는 서로 다른 변환이라 상수를 출력하는 스크립트는 아무것도 덮지 못한다. 구현자와 시험자가 각자 Task를 claim해 Goal에 연결하고 keeper_task_done으로 evidence를 제출하며, 독립 completion authority가 두 Task를 awaiting_verification에서 done으로 넘겨야 한다 — 제출은 완료가 아니다. 검증자는 선언된 범위와 실행이 낸 결과를 대조한다. 부분 실행은 통과하지 못한다.",
       "assertions": ["qa_coverage_execution_observed", "qa_coverage_passes_verification", "qa_coverage_review_matches_spec"],
       "evidence": ["observations/board-post.json", "observations/tool-calls-builder-b.json"]
+    },
+    {
+      "id": "RW23",
+      "phase": "goal_verification",
+      "name": "goal_verifier_refute_reenter_prove",
+      "actors": ["coordinator", "reviewer"],
+      "capabilities": ["Goal", "Verification", "Cross-Verification", "Sandbox", "Dashboard", "Browser", "Restart"],
+      "user_story": "Goal 완료는 독립 verifier가 owner playground의 실제 artifact를 읽은 판정으로만 일어난다. 실패 artifact는 Proof_refuted와 Executing 복귀를 만들고, 같은 Goal의 수정 artifact는 새 run으로 재진입해 Proof_proven과 Completed를 만든다. 최종 ledger run ID, durable evaluator/tool run, 실제 backend Dashboard의 펼친 verification_read_file 행과 screenshot이 같은 Goal/run을 가리켜야 한다.",
+      "assertions": ["goal_verifier_refutation_observed", "goal_verifier_reentry_proven", "goal_verifier_dashboard_browser_observed"],
+      "evidence": ["observations/goal-verifier-task-refuted.json", "observations/goal-verifier-task-proven.json", "observations/goal-verifier-refuted.json", "observations/goal-verifier-proven.json", "observations/goal-verification-runs.json", "browser/goal-verification-run-proof.json", "browser/goal-verification-run-proof.png"]
     }
   ]
 }

--- a/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
+++ b/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
@@ -102,6 +102,9 @@ KNOWN_ASSERTIONS = {
     "qa_coverage_execution_observed",
     "qa_coverage_passes_verification",
     "qa_coverage_review_matches_spec",
+    "goal_verifier_refutation_observed",
+    "goal_verifier_reentry_proven",
+    "goal_verifier_dashboard_browser_observed",
 }
 
 
@@ -529,17 +532,37 @@ def load_catalog(path: pathlib.Path) -> dict[str, Any]:
     if catalog.get("schema") != "masc.keeper_multi_collaboration_missions.v1":
         raise AcceptanceError("mission catalog schema mismatch")
     missions = catalog.get("missions")
-    if not isinstance(missions, list) or len(missions) != 22:
-        raise AcceptanceError("mission catalog must contain exactly 22 missions")
+    if not isinstance(missions, list) or len(missions) != 23:
+        raise AcceptanceError("mission catalog must contain exactly 23 missions")
     ids = [mission.get("id") for mission in missions]
-    expected_ids = [f"RW{index:02d}" for index in range(1, 23)]
+    expected_ids = [f"RW{index:02d}" for index in range(1, 24)]
     if ids != expected_ids:
-        raise AcceptanceError("mission ids must be ordered exactly RW01 through RW22")
+        raise AcceptanceError("mission ids must be ordered exactly RW01 through RW23")
     roles = catalog.get("roles")
     if not isinstance(roles, list) or set(roles) != EXPECTED_ROLES:
         raise AcceptanceError("catalog must define the exact five collaboration roles")
     if catalog.get("minimum_keeper_count") != len(roles):
         raise AcceptanceError("minimum_keeper_count must equal the five-role fleet")
+    approaches = catalog.get("execution_approaches")
+    if (
+        catalog.get("approaches_apply_to_each_mission") is not True
+        or not isinstance(approaches, list)
+        or [approach.get("id") for approach in approaches] != ["A", "B", "C"]
+    ):
+        raise AcceptanceError(
+            "catalog must apply the exact A/B/C execution approaches to every mission"
+        )
+    for approach in approaches:
+        for field in ("name", "method"):
+            if not isinstance(approach.get(field), str) or not approach[field].strip():
+                raise AcceptanceError(f"approach {approach.get('id')} is missing {field}")
+        evidence = approach.get("required_evidence")
+        if not isinstance(evidence, list) or not evidence or not all(
+            isinstance(item, str) and item.strip() for item in evidence
+        ):
+            raise AcceptanceError(
+                f"approach {approach.get('id')} has invalid required_evidence"
+            )
     for mission in missions:
         actors = mission.get("actors")
         if not isinstance(actors, list) or not actors or not set(actors) <= EXPECTED_ROLES:
@@ -852,6 +875,9 @@ class MissionRun:
         self.expected_base_path = expected_base_path
         self.secret = f"memory-{uuid.uuid4().hex[:12]}"
         self.goal_id = f"goal-{self.marker}"
+        self.verifier_goal_id = f"goal-{self.marker}-verifier"
+        self.verifier_artifact = f"artifacts/{self.marker}-goal-proof.txt"
+        self.verifier_success_token = f"GOAL_PROOF_PASS={self.marker}"
         self.schedule_id = f"schedule-{self.marker}"
         self.roles = {
             "coordinator": f"rw-{self.slug}-coord",
@@ -861,6 +887,7 @@ class MissionRun:
             "researcher": f"rw-{self.slug}-research",
         }
         self.task_ids: dict[str, str] = {}
+        self.verifier_task_id = ""
         self.task_create_receipts: dict[str, ToolObservation] = {}
         self.turns: dict[str, TurnObservation] = {}
         self.statuses: dict[str, Any] = {}
@@ -868,6 +895,8 @@ class MissionRun:
         self.tool_call_rows: dict[str, list[dict[str, Any]]] = {}
         self.browser_proof: dict[str, Any] = {}
         self.persistence_browser_proof: dict[str, Any] = {}
+        self.goal_verifier_browser_proof: dict[str, Any] = {}
+        self.goal_verifier_evidence: dict[str, Any] = {}
 
     def runtime_for_role(self, role: str) -> str | None:
         return self.runtime_by_role.get(role, self.runtime_id)
@@ -899,6 +928,152 @@ class MissionRun:
         if not isinstance(value, dict):
             raise AcceptanceError(f"Dashboard GET {path} returned a non-object payload")
         return value
+
+    def find_goal(self, value: Any, goal_id: str) -> dict[str, Any] | None:
+        if isinstance(value, dict):
+            if value.get("id") == goal_id or value.get("goal_id") == goal_id:
+                if "phase" in value and "verification" in value:
+                    return value
+            for nested in value.values():
+                found = self.find_goal(nested, goal_id)
+                if found is not None:
+                    return found
+        elif isinstance(value, list):
+            for nested in value:
+                found = self.find_goal(nested, goal_id)
+                if found is not None:
+                    return found
+        return None
+
+    def read_goal(self, goal_id: str, label: str) -> dict[str, Any]:
+        observation = self.call(label, "masc_goal_list", {})
+        goal = self.find_goal(observation.data, goal_id)
+        if goal is None:
+            raise AcceptanceError(f"goal list did not contain {goal_id}")
+        return goal
+
+    def wait_for_goal_state(
+        self,
+        *,
+        phase: str,
+        completion_state: str | None = None,
+        criterion_state: str | None = None,
+        timeout: float = 300.0,
+    ) -> dict[str, Any]:
+        deadline = time.monotonic() + timeout
+        attempt = 0
+        last: dict[str, Any] | None = None
+        while time.monotonic() < deadline:
+            attempt += 1
+            last = self.read_goal(
+                self.verifier_goal_id,
+                f"goal-verifier-poll-{phase}-{attempt}",
+            )
+            verification = last.get("verification")
+            criterion = (
+                verification.get("criterion")
+                if isinstance(verification, dict)
+                else None
+            )
+            completion = (
+                verification.get("completion")
+                if isinstance(verification, dict)
+                else None
+            )
+            if (
+                last.get("phase") == phase
+                and (
+                    criterion_state is None
+                    or (
+                        isinstance(criterion, dict)
+                        and criterion.get("state") == criterion_state
+                    )
+                )
+                and (
+                    completion_state is None
+                    or (
+                        isinstance(completion, dict)
+                        and completion.get("state") == completion_state
+                    )
+                )
+            ):
+                return last
+            time.sleep(2.0)
+        raise AcceptanceError(
+            "Goal verifier state did not converge: "
+            f"expected phase={phase} criterion={criterion_state} "
+            f"completion={completion_state}, last={json.dumps(last, ensure_ascii=False)}"
+        )
+
+    def find_task(self, value: Any, task_id: str) -> dict[str, Any] | None:
+        if isinstance(value, dict):
+            if value.get("id") == task_id or value.get("task_id") == task_id:
+                if "task_status" in value or "status" in value:
+                    return value
+            for nested in value.values():
+                found = self.find_task(nested, task_id)
+                if found is not None:
+                    return found
+        elif isinstance(value, list):
+            for nested in value:
+                found = self.find_task(nested, task_id)
+                if found is not None:
+                    return found
+        return None
+
+    def wait_for_verifier_task_status(
+        self, expected_status: str, timeout: float = 300.0
+    ) -> dict[str, Any]:
+        deadline = time.monotonic() + timeout
+        attempt = 0
+        last: dict[str, Any] | None = None
+        while time.monotonic() < deadline:
+            attempt += 1
+            observation = self.call(
+                f"goal-verifier-task-poll-{expected_status}-{attempt}",
+                "masc_tasks",
+                {"include_done": True, "include_cancelled": True},
+            )
+            last = self.find_task(observation.data, self.verifier_task_id)
+            if isinstance(last, dict) and (
+                last.get("task_status") == expected_status
+                or last.get("status") == expected_status
+            ):
+                return last
+            time.sleep(2.0)
+        raise AcceptanceError(
+            f"verifier Task did not reach {expected_status}: "
+            f"last={json.dumps(last, ensure_ascii=False)}"
+        )
+
+    def wait_for_verifier_task_verdict(
+        self, to_status: str, timeout: float = 300.0
+    ) -> dict[str, Any]:
+        deadline = time.monotonic() + timeout
+        attempt = 0
+        last: Any = None
+        while time.monotonic() < deadline:
+            attempt += 1
+            history = self.call(
+                f"goal-verifier-task-history-{to_status}-{attempt}",
+                "masc_task_history",
+                {"task_id": self.verifier_task_id, "limit": 100},
+            )
+            last = history.data
+            entries = last if isinstance(last, list) else []
+            for entry in entries:
+                if (
+                    isinstance(entry, dict)
+                    and entry.get("type") == "task_completion_verdict"
+                    and entry.get("to_status") == to_status
+                    and entry.get("verification_id")
+                ):
+                    return entry
+            time.sleep(2.0)
+        raise AcceptanceError(
+            f"verifier Task has no completion verdict to {to_status}: "
+            f"last={json.dumps(last, ensure_ascii=False)}"
+        )
 
     def role_instructions(self, role: str) -> str:
         shared = (
@@ -976,10 +1151,47 @@ class MissionRun:
             "masc_goal_assign",
             {"goal_id": self.goal_id, "owner": self.roles["coordinator"]},
         )
+        self.call(
+            "goal-verifier-upsert",
+            "masc_goal_upsert",
+            {
+                "id": self.verifier_goal_id,
+                "title": f"Artifact-gated Goal verifier mission {self.marker}",
+                "metric": (
+                    f"owner artifact {self.verifier_artifact} contains the exact "
+                    f"token {self.verifier_success_token}"
+                ),
+                "target_value": self.verifier_success_token,
+                "priority": 1,
+            },
+        )
+        self.call(
+            "goal-verifier-assign",
+            "masc_goal_assign",
+            {
+                "goal_id": self.verifier_goal_id,
+                "owner": self.roles["coordinator"],
+            },
+        )
+        verifier_task = self.call(
+            "goal-verifier-task-create",
+            "masc_add_task",
+            {
+                "title": f"[{self.marker}] Produce exact Goal proof artifact",
+                "description": (
+                    f"Write {self.verifier_artifact} so its exact content is "
+                    f"{self.verifier_success_token}; submit that artifact as "
+                    "verification evidence."
+                ),
+                "priority": 1,
+                "goal_id": self.verifier_goal_id,
+            },
+        )
+        self.verifier_task_id = extract_identity(verifier_task.text, ["task-"])
         for role, keeper in self.roles.items():
             arguments: dict[str, Any] = {
                 "name": keeper,
-                "active_goal_ids": [self.goal_id],
+                "active_goal_ids": [self.goal_id, self.verifier_goal_id],
             }
             runtime_id = self.runtime_for_role(role)
             if runtime_id:
@@ -1242,6 +1454,10 @@ class MissionRun:
                 "MASC_COMPOSITION_KEEPER_NAME": self.roles["coordinator"],
                 "MASC_COMPOSITION_EXPECTED_BASE_PATH": self.expected_base_path,
                 "MASC_COMPOSITION_BROWSER_ARTIFACT_DIR": str(browser_dir),
+                "MASC_GOAL_VERIFICATION_GOAL_ID": self.verifier_goal_id,
+                "MASC_GOAL_VERIFICATION_RUN_ID": str(
+                    self.goal_verifier_evidence.get("proven_run_id", "")
+                ),
             }
         )
         completed = subprocess.run(
@@ -1276,6 +1492,9 @@ class MissionRun:
         self.browser_proof = read_measurement("keeper-composition-inspector.json")
         self.persistence_browser_proof = read_measurement(
             "keeper-persistence-proof.json"
+        )
+        self.goal_verifier_browser_proof = read_measurement(
+            "goal-verification-run-proof.json"
         )
 
     def run_contention(self, post_id: str) -> None:
@@ -1478,6 +1697,141 @@ class MissionRun:
                 "빠졌으면 QA_COVERAGE_VERDICT=MISSING:<빠진 케이스 이름> comment를 남기세요. "
                 "Board에서 읽은 값만 쓰고 새로 만들지 마세요."
             ),
+        )
+
+    def run_goal_verifier_refute_reenter_prove(self) -> None:
+        self.wait_for_goal_state(
+            phase="executing",
+            criterion_state="viable",
+            completion_state="idle",
+        )
+        failure_token = f"GOAL_PROOF_FAIL={self.marker}"
+        self.run_turn(
+            "coordinator",
+            "goal-verifier-refute-artifact",
+            (
+                f"Mission {self.marker}. composition 도구는 호출하지 마세요. "
+                f"exact Task {self.verifier_task_id}를 claim하세요. "
+                f"Write(tool_write_file)로 playground의 {self.verifier_artifact}에 "
+                f"정확히 '{failure_token}' 한 줄만 쓰세요. 다른 토큰을 추가하지 마세요. "
+                f"keeper_task_done으로 artifact:{self.verifier_artifact}를 evidence로 "
+                "제출하세요. 실패 내용이어도 완료를 가장하지 말고 실제 파일을 그대로 제출하세요."
+            ),
+        )
+        rejected_task_verdict = self.wait_for_verifier_task_verdict("in_progress")
+        self.wait_for_verifier_task_status("in_progress")
+        self.writer.write_json(
+            "observations/goal-verifier-task-refuted.json",
+            rejected_task_verdict,
+        )
+        self.call(
+            "goal-verifier-request-refute",
+            "masc_goal_transition",
+            {"goal_id": self.verifier_goal_id, "action": "request_complete"},
+        )
+        refuted = self.wait_for_goal_state(
+            phase="executing",
+            criterion_state="viable",
+            completion_state="proof_refuted",
+        )
+        refuted_verdict = (
+            refuted.get("verification", {})
+            .get("completion", {})
+            .get("verdict", {})
+        )
+        refuted_run_id = refuted_verdict.get("verification_run_id")
+        if not isinstance(refuted_run_id, str) or not refuted_run_id.strip():
+            raise AcceptanceError("refuted Goal verdict has no verification_run_id")
+        self.writer.write_json("observations/goal-verifier-refuted.json", refuted)
+
+        self.run_turn(
+            "coordinator",
+            "goal-verifier-proven-artifact",
+            (
+                f"Mission {self.marker}. composition 도구는 호출하지 마세요. "
+                f"Write(tool_write_file)로 playground의 {self.verifier_artifact}를 "
+                f"정확히 '{self.verifier_success_token}' 한 줄로 교체하세요. "
+                "쓴 뒤 파일의 exact content를 다시 읽어 확인하고, "
+                f"keeper_task_done으로 artifact:{self.verifier_artifact}를 evidence로 "
+                "다시 제출하세요."
+            ),
+        )
+        approved_task_verdict = self.wait_for_verifier_task_verdict("done")
+        self.wait_for_verifier_task_status("done")
+        self.writer.write_json(
+            "observations/goal-verifier-task-proven.json",
+            approved_task_verdict,
+        )
+        self.call(
+            "goal-verifier-request-prove",
+            "masc_goal_transition",
+            {"goal_id": self.verifier_goal_id, "action": "request_complete"},
+        )
+        proven = self.wait_for_goal_state(
+            phase="completed",
+            criterion_state="viable",
+            completion_state="proof_proven",
+        )
+        proven_verdict = (
+            proven.get("verification", {})
+            .get("completion", {})
+            .get("verdict", {})
+        )
+        proven_run_id = proven_verdict.get("verification_run_id")
+        if not isinstance(proven_run_id, str) or not proven_run_id.strip():
+            raise AcceptanceError("proven Goal verdict has no verification_run_id")
+        if proven_run_id == refuted_run_id:
+            raise AcceptanceError("refutation and proof reused one verification run ID")
+        self.writer.write_json("observations/goal-verifier-proven.json", proven)
+
+        runs_payload = self.dashboard_get(
+            "/api/v1/dashboard/goal-verification-runs"
+        )
+        runs = runs_payload.get("runs")
+        if not isinstance(runs, list):
+            raise AcceptanceError("Goal verification runs route has no runs array")
+        proof_runs = [
+            run
+            for run in runs
+            if isinstance(run, dict)
+            and run.get("goal_id") == self.verifier_goal_id
+            and run.get("review_kind") == "proof"
+        ]
+        by_id = {
+            run.get("run_id"): run
+            for run in proof_runs
+            if isinstance(run.get("run_id"), str)
+        }
+        for expected_run_id in (refuted_run_id, proven_run_id):
+            run = by_id.get(expected_run_id)
+            if not isinstance(run, dict) or run.get("status") != "committed":
+                raise AcceptanceError(
+                    f"Goal proof run {expected_run_id} is not durably committed"
+                )
+            tools = run.get("tools")
+            if not isinstance(tools, list) or not any(
+                isinstance(tool, dict)
+                and tool.get("tool_name") == "verification_read_file"
+                for tool in tools
+            ):
+                raise AcceptanceError(
+                    f"Goal proof run {expected_run_id} has no artifact read"
+                )
+        self.goal_verifier_evidence = {
+            "goal_id": self.verifier_goal_id,
+            "artifact": self.verifier_artifact,
+            "task_id": self.verifier_task_id,
+            "task_refuted_verdict": rejected_task_verdict,
+            "task_proven_verdict": approved_task_verdict,
+            "refuted_run_id": refuted_run_id,
+            "proven_run_id": proven_run_id,
+            "refuted_goal": refuted,
+            "proven_goal": proven,
+            "runs": proof_runs,
+        }
+        self.writer.write_json(
+            "observations/goal-verification-runs.json",
+            {"payload": runs_payload, "evidence": self.goal_verifier_evidence},
         )
 
     def restart_and_recall(self, post_id: str) -> None:
@@ -1749,6 +2103,22 @@ class MissionRun:
         qa_verdicts = [
             self._completion_verdict(key) for key in ("qa-implement", "qa-test")
         ]
+        goal_verifier_refuted = self.goal_verifier_evidence.get("refuted_goal")
+        goal_verifier_proven = self.goal_verifier_evidence.get("proven_goal")
+        goal_verifier_refuted_run = self.goal_verifier_evidence.get(
+            "refuted_run_id"
+        )
+        goal_verifier_proven_run = self.goal_verifier_evidence.get(
+            "proven_run_id"
+        )
+        goal_verifier_runs = self.goal_verifier_evidence.get("runs")
+        goal_verifier_runs_by_id = {
+            run.get("run_id"): run
+            for run in (
+                goal_verifier_runs if isinstance(goal_verifier_runs, list) else []
+            )
+            if isinstance(run, dict) and isinstance(run.get("run_id"), str)
+        }
         parallel_turns = [
             turn for label, turn in self.turns.items() if label.startswith("parallel-")
         ]
@@ -2547,6 +2917,61 @@ class MissionRun:
                 "reviewer's verdict quotes the rebuttal token (absent from its "
                 "prompt, readable only on the Board)",
             ),
+            "goal_verifier_refutation_observed": (
+                isinstance(goal_verifier_refuted, dict)
+                and goal_verifier_refuted.get("phase") == "executing"
+                and isinstance(goal_verifier_refuted_run, str)
+                and text_contains(goal_verifier_refuted, "proof_refuted")
+                and text_contains(
+                    goal_verifier_runs_by_id.get(goal_verifier_refuted_run),
+                    self.verifier_artifact,
+                ),
+                f"goal={self.verifier_goal_id} refuted_run={goal_verifier_refuted_run}",
+            ),
+            "goal_verifier_reentry_proven": (
+                isinstance(goal_verifier_proven, dict)
+                and goal_verifier_proven.get("phase") == "completed"
+                and isinstance(goal_verifier_proven_run, str)
+                and goal_verifier_proven_run != goal_verifier_refuted_run
+                and text_contains(goal_verifier_proven, "proof_proven")
+                and text_contains(goal_verifier_proven, self.verifier_success_token)
+                and text_contains(
+                    goal_verifier_runs_by_id.get(goal_verifier_proven_run),
+                    self.verifier_artifact,
+                ),
+                f"goal={self.verifier_goal_id} proven_run={goal_verifier_proven_run}",
+            ),
+            "goal_verifier_dashboard_browser_observed": (
+                self.goal_verifier_browser_proof.get("schema")
+                == "masc.goal_verification_browser_evidence.v1"
+                and self.goal_verifier_browser_proof.get("goal_id")
+                == self.verifier_goal_id
+                and self.goal_verifier_browser_proof.get("run_id")
+                == goal_verifier_proven_run
+                and self.goal_verifier_browser_proof.get("status") == "committed"
+                and self.goal_verifier_browser_proof.get("review_kind") == "proof"
+                and self.goal_verifier_browser_proof.get("artifact_tool_visible")
+                is True
+                and isinstance(
+                    self.goal_verifier_browser_proof.get("screenshot_sha256"),
+                    str,
+                )
+                and len(self.goal_verifier_browser_proof["screenshot_sha256"])
+                == 64
+                and (
+                    self.writer.output_dir
+                    / "browser"
+                    / "goal-verification-run-proof.png"
+                ).is_file()
+                and sha256_file(
+                    self.writer.output_dir
+                    / "browser"
+                    / "goal-verification-run-proof.png"
+                )
+                == self.goal_verifier_browser_proof["screenshot_sha256"],
+                "real-backend browser expanded the exact proven Goal run and "
+                "rendered verification_read_file evidence",
+            ),
         }
         malformed = [
             name
@@ -2570,6 +2995,7 @@ class MissionRun:
         self.run_poc_delivery(post_id)
         self.run_debate(post_id)
         self.run_qa_coverage(post_id)
+        self.run_goal_verifier_refute_reenter_prove()
         self.run_continuity_chain(post_id)
         self.restart_and_recall(post_id)
         self.wait_for_async_sources()
@@ -2588,6 +3014,15 @@ def bundle_markdown(bundle: dict[str, Any]) -> str:
         f"- Effective base path: `{bundle['effective_base_path']}`",
         f"- Status: **{bundle['status']}** ({bundle['passed_count']}/{bundle['scenario_count']})",
         f"- Bundle ID: `{bundle['bundle_id']}`",
+        "- Approach A: **not executed by this runner** (hermetic CI remains separate)",
+        "- Approach B: **"
+        + next(
+            row["status"]
+            for row in bundle["approach_results"]
+            if row["id"] == "B"
+        )
+        + "** (this isolated real-world run)",
+        "- Approach C: **not executed by this runner** (duration canary remains separate)",
         "",
         "| ID | Real-world mission | Status | Failed assertions |",
         "|---|---|---|---|",
@@ -2640,6 +3075,19 @@ def build_bundle(
             {"name": name, **assertions[name]} for name in mission["assertions"]
         ]
         passed = all(row["passed"] for row in routed)
+        approach_results = [
+            {
+                "id": approach["id"],
+                "name": approach["name"],
+                "status": (
+                    ("passed" if passed else "failed")
+                    if approach["id"] == "B"
+                    else "not_executed_by_this_runner"
+                ),
+                "required_evidence": approach["required_evidence"],
+            }
+            for approach in catalog["execution_approaches"]
+        ]
         missions.append(
             {
                 "id": mission["id"],
@@ -2651,6 +3099,7 @@ def build_bundle(
                 "status": "passed" if passed else "failed",
                 "assertions": routed,
                 "evidence": mission["evidence"],
+                "approaches": approach_results,
             }
         )
     passed_count = sum(mission["status"] == "passed" for mission in missions)
@@ -2683,6 +3132,24 @@ def build_bundle(
         "status": "passed" if passed_count == len(missions) else "failed",
         "scenario_count": len(missions),
         "passed_count": passed_count,
+        "approach_results": [
+            {
+                "id": approach["id"],
+                "name": approach["name"],
+                "status": (
+                    (
+                        "passed"
+                        if passed_count == len(missions)
+                        else "failed"
+                    )
+                    if approach["id"] == "B"
+                    else "not_executed_by_this_runner"
+                ),
+                "method": approach["method"],
+                "required_evidence": approach["required_evidence"],
+            }
+            for approach in catalog["execution_approaches"]
+        ],
         "effective_base_path": health_base_path(health),
         "effective_masc_root": health_masc_root(health),
         "preflight": preflight_result,
@@ -2695,6 +3162,8 @@ def build_bundle(
                 roles=set(run.roles),
             ),
             "goal_id": run.goal_id,
+            "goal_verifier_goal_id": run.verifier_goal_id,
+            "goal_verifier_task_id": run.verifier_task_id,
             "task_ids": run.task_ids,
             "board_post_id": post_id,
             "schedule_id": run.schedule_id,
@@ -2731,6 +3200,30 @@ def verify_bundle(
         errors.append(f"mission ids mismatch: {actual_ids!r}")
     if bundle.get("scenario_count") != len(expected_ids):
         errors.append("scenario count mismatch")
+    expected_approach_ids = ["A", "B", "C"]
+    approach_results = bundle.get("approach_results")
+    if (
+        not isinstance(approach_results, list)
+        or [row.get("id") for row in approach_results] != expected_approach_ids
+        or [row.get("status") for row in approach_results]
+        != ["not_executed_by_this_runner", "passed", "not_executed_by_this_runner"]
+    ):
+        errors.append("bundle A/B/C approach results are missing or conflated")
+    for mission in missions:
+        approaches = mission.get("approaches")
+        if (
+            not isinstance(approaches, list)
+            or [row.get("id") for row in approaches] != expected_approach_ids
+            or [row.get("status") for row in approaches]
+            != [
+                "not_executed_by_this_runner",
+                mission.get("status"),
+                "not_executed_by_this_runner",
+            ]
+        ):
+            errors.append(
+                f"mission {mission.get('id')} A/B/C results are missing or conflated"
+            )
     passed_count = sum(mission.get("status") == "passed" for mission in missions)
     if bundle.get("passed_count") != passed_count:
         errors.append("passed count mismatch")
@@ -2848,6 +3341,54 @@ def verify_bundle(
         )
         if not persistence_valid:
             errors.append(f"persistence browser proof is invalid: {persistence_detail}")
+    goal_proof_path = output_dir / "browser" / "goal-verification-run-proof.json"
+    goal_screenshot_path = output_dir / "browser" / "goal-verification-run-proof.png"
+    proven_goal_path = output_dir / "observations" / "goal-verifier-proven.json"
+    try:
+        goal_proof = json.loads(goal_proof_path.read_text(encoding="utf-8"))
+        proven_goal = json.loads(proven_goal_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        errors.append(f"Goal verifier browser/ledger proof is unreadable: {error}")
+    else:
+        resources = bundle.get("resources")
+        expected_goal_id = (
+            resources.get("goal_verifier_goal_id")
+            if isinstance(resources, dict)
+            else None
+        )
+        verification = (
+            proven_goal.get("verification")
+            if isinstance(proven_goal, dict)
+            else None
+        )
+        completion = (
+            verification.get("completion")
+            if isinstance(verification, dict)
+            else None
+        )
+        verdict = (
+            completion.get("verdict") if isinstance(completion, dict) else None
+        )
+        expected_run_id = (
+            verdict.get("verification_run_id")
+            if isinstance(verdict, dict)
+            else None
+        )
+        if (
+            goal_proof.get("schema")
+            != "masc.goal_verification_browser_evidence.v1"
+            or not isinstance(expected_goal_id, str)
+            or goal_proof.get("goal_id") != expected_goal_id
+            or not isinstance(expected_run_id, str)
+            or goal_proof.get("run_id") != expected_run_id
+            or goal_proof.get("status") != "committed"
+            or goal_proof.get("review_kind") != "proof"
+            or goal_proof.get("artifact_tool_visible") is not True
+            or not goal_screenshot_path.is_file()
+            or goal_proof.get("screenshot_sha256")
+            != sha256_file(goal_screenshot_path)
+        ):
+            errors.append("Goal verifier browser proof does not match ledger run identity")
     seed = {
         "source_sha": bundle.get("source_sha"),
         "runner_source_sha": bundle.get("runner_source_sha"),
@@ -2927,6 +3468,10 @@ def main() -> int:
                         "catalog": str(pathlib.Path(args.catalog)),
                         "mission_count": len(catalog["missions"]),
                         "assertion_count": len(KNOWN_ASSERTIONS),
+                        "approach_ids": [
+                            approach["id"]
+                            for approach in catalog["execution_approaches"]
+                        ],
                         "acceptance_authority": catalog["acceptance_authority"],
                     },
                     ensure_ascii=False,

--- a/test/test_goal_verification_agent.ml
+++ b/test/test_goal_verification_agent.ml
@@ -682,6 +682,91 @@ let test_verifying_goal_with_a_missing_request_is_rearmed_and_drained () =
   | _ -> fail "ledger must hold the proven verdict"
 ;;
 
+let set_up_committed_proof_crash config ~outcome ~evidence =
+  let ctx = workspace_ctx config in
+  let goal_id = create_goal ctx "Crash-between-writes goal" in
+  with_lane_and_reviewer
+    ~slots:(fun () -> Ok [ "verifier-a" ])
+    ~reviewer:
+      (recording_reviewer (ref []) [ "verifier-a", Stub_approve "criterion viable" ])
+    (fun () -> drain config);
+  ignore
+    (must_succeed "request_complete" (transition ctx goal_id "request_complete"));
+  let verdict : Goal_verification.verdict =
+    { outcome
+    ; verification_run_id = "goal-run-before-crash"
+    ; authority =
+        Masc_domain.System_llm_agent { agent_run_id = "verifier_exact" }
+    ; evidence
+    ; recorded_at = Masc_domain.now_iso ()
+    }
+  in
+  (match Goal_verification.record_proof_verdict config ~goal_id verdict with
+   | Ok _ -> ()
+   | Error msg -> fail msg);
+  check string "test setup leaves the phase write missing" "verifying"
+    (stored_phase config goal_id);
+  goal_id
+;;
+
+let has_completion_work goal_id work =
+  List.exists
+    (fun item ->
+       String.equal item.Agent.goal_id goal_id
+       && item.kind = Agent.Completion_proof)
+    work
+;;
+
+let test_committed_proven_proof_reconciles_without_review () =
+  with_workspace
+  @@ fun config ->
+  let goal_id =
+    set_up_committed_proof_crash
+      config
+      ~outcome:Goal_verification.Proven
+      ~evidence:"artifact was inspected before the crash"
+  in
+  let work =
+    match Agent.collect_pending config with
+    | Ok work -> work
+    | Error msg -> fail msg
+  in
+  check bool "reconciliation does not call the model again" false
+    (has_completion_work goal_id work);
+  check string "proven verdict converges to completed" "completed"
+    (stored_phase config goal_id);
+  match (ledger_record config goal_id).completion with
+  | Goal_verification.Proof_proven verdict ->
+    check string "the exact run survives reconciliation" "goal-run-before-crash"
+      verdict.Goal_verification.verification_run_id
+  | _ -> fail "reconciliation rewrote the proven ledger state"
+;;
+
+let test_committed_refuted_proof_reconciles_without_rearm () =
+  with_workspace
+  @@ fun config ->
+  let goal_id =
+    set_up_committed_proof_crash
+      config
+      ~outcome:(Goal_verification.Refuted { reason = "artifact contradicts claim" })
+      ~evidence:"artifact contradicts claim"
+  in
+  let work =
+    match Agent.collect_pending config with
+    | Ok work -> work
+    | Error msg -> fail msg
+  in
+  check bool "refutation is not overwritten by a re-armed request" false
+    (has_completion_work goal_id work);
+  check string "refuted verdict converges to executing" "executing"
+    (stored_phase config goal_id);
+  match (ledger_record config goal_id).completion with
+  | Goal_verification.Proof_refuted verdict ->
+    check string "the exact refutation run survives" "goal-run-before-crash"
+      verdict.Goal_verification.verification_run_id
+  | _ -> fail "reconciliation overwrote the refuted ledger state"
+;;
+
 let () =
   configure_prompt_registry ();
   run
@@ -715,7 +800,15 @@ let () =
             test_group_pending_orders_criterion_before_proof
         ] )
     ; ( "re-arm"
-      , [ test_case "verifying goal with a missing request is rearmed and drained"
+      , [ test_case
+            "committed proven proof reconciles without review"
+            `Quick
+            test_committed_proven_proof_reconciles_without_review
+        ; test_case
+            "committed refuted proof reconciles without re-arm"
+            `Quick
+            test_committed_refuted_proof_reconciles_without_rearm
+        ; test_case "verifying goal with a missing request is rearmed and drained"
             `Quick
             test_verifying_goal_with_a_missing_request_is_rearmed_and_drained
         ] )

--- a/test/test_goal_verification_gate.ml
+++ b/test/test_goal_verification_gate.ml
@@ -829,6 +829,39 @@ let test_verifying_repeat_rearms_a_missing_proof_request () =
     (json_state completed [ "goal"; "phase" ])
 ;;
 
+let test_verifying_repeat_reconciles_a_committed_proof () =
+  with_workspace
+  @@ fun config ->
+  let ctx = workspace_ctx config in
+  let goal_id = create_goal ctx "Proof committed before crash" in
+  mark_criterion_viable ctx goal_id;
+  ignore
+    (must_succeed "request_complete" (transition ctx goal_id "request_complete"));
+  (match
+     Goal_verification.record_proof_verdict
+       config
+       ~goal_id
+       (verdict ~evidence:"artifact inspected before crash" Goal_verification.Proven)
+   with
+   | Ok _ -> ()
+   | Error msg -> fail msg);
+  check string "phase write is the simulated missing effect" "verifying"
+    (stored_phase config goal_id);
+  let answered =
+    must_succeed "repeated request reconciles proof"
+      (transition ctx goal_id "request_complete")
+  in
+  check bool "response exposes recovery" true
+    (json_bool answered [ "reconciled" ]);
+  check string "the committed proof converges to completed" "completed"
+    (json_state answered [ "goal"; "phase" ]);
+  match (ledger_record config goal_id).completion with
+  | Goal_verification.Proof_proven proof ->
+    check string "recovery preserves the original proof run"
+      "goal-verifier-test-run" proof.verification_run_id
+  | _ -> fail "recovery rewrote the committed proof"
+;;
+
 (* (e) A criterion judged unreachable blocks the completion request with a
    typed conflict; the criterion commit itself is phase-neutral. *)
 let test_unreachable_criterion_blocks_request_complete () =
@@ -1003,6 +1036,8 @@ let () =
             test_proof_refuted_returns_to_executing_with_reason
         ; test_case "verifying repeat re-arms a missing proof request" `Quick
             test_verifying_repeat_rearms_a_missing_proof_request
+        ; test_case "verifying repeat reconciles a committed proof" `Quick
+            test_verifying_repeat_reconciles_a_committed_proof
         ; test_case "unreachable criterion blocks request_complete" `Quick
             test_unreachable_criterion_blocks_request_complete
         ; test_case "creation writes criterion pending" `Quick

--- a/test/test_keeper_multi_collaboration_acceptance.py
+++ b/test/test_keeper_multi_collaboration_acceptance.py
@@ -115,7 +115,7 @@ class KeeperMultiCollaborationAcceptanceTest(unittest.TestCase):
     def test_catalog_has_exact_rw19_persistence_projection_mission(self):
         catalog = acceptance.load_catalog(CATALOG_PATH)
 
-        self.assertEqual(len(catalog["missions"]), 22)
+        self.assertEqual(len(catalog["missions"]), 23)
         self.assertEqual(catalog["missions"][18]["id"], "RW19")
         self.assertEqual(
             catalog["missions"][18]["assertions"],
@@ -158,6 +158,28 @@ class KeeperMultiCollaborationAcceptanceTest(unittest.TestCase):
         self.assertIn("tool_execute", catalog["keeper_required_tools"])
         self.assertIn("keeper_task_claim", catalog["keeper_required_tools"])
         self.assertIn("keeper_task_done", catalog["keeper_required_tools"])
+
+    def test_catalog_has_exact_rw23_goal_verifier_mission(self):
+        catalog = acceptance.load_catalog(CATALOG_PATH)
+
+        goal_verifier = catalog["missions"][22]
+        self.assertEqual(goal_verifier["id"], "RW23")
+        self.assertEqual(
+            goal_verifier["assertions"],
+            [
+                "goal_verifier_refutation_observed",
+                "goal_verifier_reentry_proven",
+                "goal_verifier_dashboard_browser_observed",
+            ],
+        )
+        self.assertIn("Goal", goal_verifier["capabilities"])
+        self.assertIn("Browser", goal_verifier["capabilities"])
+        self.assertIn("masc_goal_transition", catalog["operator_required_tools"])
+        self.assertTrue(catalog["approaches_apply_to_each_mission"])
+        self.assertEqual(
+            [approach["id"] for approach in catalog["execution_approaches"]],
+            ["A", "B", "C"],
+        )
 
     def test_persistence_browser_validator_requires_exact_monotonic_fleet(self):
         expected = {"keeper-a", "keeper-b"}


### PR DESCRIPTION
## Summary
- add an atomic phase-guarded Goal update so recovery cannot overwrite a concurrent lifecycle transition
- reconcile durable `Proof_proven`/`Proof_refuted` rows left in `Verifying` after a crash, preserving the exact run ID and evidence
- converge both the autonomous worker scan and repeated `request_complete` without another model review
- stop treating a committed refutation as a missing request and overwriting it with `Proof_pending`

## Validation
- `ocamlformat --check` on all changed OCaml files
- `ocamlc -stop-after parsing` on all changed implementations/tests
- `git diff --check`
- feature tests cover proven→Completed, refuted→Executing, no second model work, no refutation re-arm, and public retry recovery

No local Dune build was run; CI remains the OCaml build/test authority.