### PR TITLE
fix(goal): remove redundant reconciliation arm

### DIFF
--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -719,12 +719,10 @@ let reconcile_committed_proof config ~goal_id =
          | Goal_verification.Proof_refuted
              ({ outcome = Goal_verification.Refuted { reason }; _ } as verdict) ->
            Some (Goal_phase.Record_proof_refuted, verdict, Some reason)
-         | Goal_verification.Proof_proven
-             { outcome = Goal_verification.Refuted _; _ }
          | Goal_verification.Proof_refuted
              { outcome = Goal_verification.Proven; _ } ->
-           (* Rejected by the explicit malformed-ledger guards above. This
-              arm keeps the closed sum exhaustive at the use site. *)
+           (* Rejected by the explicit malformed-ledger guard above. This arm
+              keeps the closed sum exhaustive at the use site. *)
            None
          | Goal_verification.Completion_idle
          | Goal_verification.Proof_pending _ -> None


### PR DESCRIPTION
## Summary
- remove the `Proof_proven + Refuted` inner match arm already excluded by the outer malformed-ledger guard
- preserve the remaining closed-sum exhaustiveness arm for `Proof_refuted + Proven`
- unblock the protected-main warning-as-error build at `827bfd7143e8e72e278bf0a1701873f837865863`

## Verification
- `git diff --check`
- `ocamlformat --check lib/workspace_goals.ml`
- no local Dune run; CI is the compile/test authority

## Failure evidence
- main CI run `32453678211`, job `96686856259`
- `warning 12 [redundant-subpat]` at `lib/workspace_goals.ml:722-723`