### PR TITLE
docs(contributing): name the formatter CI actually runs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,21 @@ scripts/dune-local.sh exec test/test_keeper_meta_json_config_toml_only.exe
 - **Resource cleanup** — `Eio.Switch.on_release` over nested `Fun.protect`
 - **Pure functions** — extract testable logic from IO code when it keeps the change simpler
 
+#### Formatting
+
+CI checks `.ml` and `.mli` files with `ocamlformat` directly, on changed files
+only. Match it:
+
+```bash
+opam exec -- ocamlformat -i <changed .ml/.mli files>
+```
+
+Do **not** run `dune build @fmt --auto-promote`. It also rewrites `dune` files
+— 18 of them from a clean tree, including a blank line in `lib/dune` that puts
+the file one line over the `lib_dune_lines` baseline and fails the OCaml
+Structure Ratchet. CI never asks for those rewrites, so they are diff noise
+that costs a round trip. See #29253.
+
 ### Project Structure
 
 ```


### PR DESCRIPTION
## 문제

`CONTRIBUTING.md` 에 포맷 관련 항목이 없고 `docs/` · `AGENTS.md` 에도 `dune fmt` 언급이 0건입니다. 그러니 처음 보는 사람은 자연스럽게 이걸 씁니다.

```bash
dune build @fmt --auto-promote
```

**CI 가 하는 일과 다릅니다.** `.github/workflows/ocamlformat.yml:149` 는 바뀐 파일만 이렇게 검사합니다.

```bash
opam exec -- ocamlformat --check "$f"
```

`ocamlformat` 은 `.ml` / `.mli` 만 봅니다. dune 파일은 안 건드려요.

## 그래서 무슨 일이 생기나

깨끗한 트리에서 재현했습니다.

```
$ git reset --hard origin/main
$ wc -l < lib/dune
191

$ dune build @fmt --auto-promote
$ wc -l < lib/dune
192

$ git status --porcelain | grep 'dune$' | wc -l
18
```

`lib/dune` 에 들어가는 건 빈 줄 하나입니다.

```diff
 (include_subdirs unqualified)
+
 (library
```

그 한 줄이 `lib_dune_lines` baseline 191 을 넘겨 **OCaml Structure Ratchet 을 실패**시킵니다.

```
FAIL lib_dune_lines: 192 > baseline 191
     Fix: lib/dune is growing — consider extracting modules into a sub-library
```

메시지는 "모듈을 쪼개라" 인데 실제로 한 건 포맷터를 돌린 것뿐입니다. 나머지 17개 dune 파일 재포맷도 CI 가 요구하지 않은 diff 라 리뷰 노이즈가 됩니다.

## 변경

`### Code Style` 아래에 `#### Formatting` 을 추가해 **CI 가 쓰는 명령과 피할 명령**을 적었습니다. 5줄입니다.

## 이건 우회가 아닙니다

#29253 에 적은 세 방향 중 가장 작은 것만 했습니다. 나머지 둘은 그대로 남습니다.

- dune 파일 포맷을 관리할지 결정하고 `dune-project` 의 `(formatting)` 스탠자로 정리
- `lib_dune_lines` 가 줄 수 대신 stanza 수를 세게 (지금은 빈 줄 하나에 반응합니다)

문서 한 줄이 저 둘을 대신하지는 않고, 다만 그때까지 사람이 같은 데 걸리지 않게 합니다.

Refs #29253
