### PR TITLE
feat(tool-surface): expose thread_ts and blocks on keeper_surface_post schema (task-327/328)

### DIFF
--- a/lib/tool_surface/tool_shard_types_schemas_surface.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_surface.ml
@@ -137,6 +137,13 @@ let surface_tools : Masc_domain.tool_schema list =
                         , `String
                             "Stable ids from keeper_surface_read participants to visibly mention. Slack requires U.../W... ids; Discord requires decimal user snowflakes. Display names such as @Vincent do not create API mentions." )
                       ] )
+                ; ( "thread_ts"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "description"
+                        , `String
+                            "Slack thread timestamp (ts) of an existing message to reply inside that thread. Slack surface only; ignored for dashboard/discord. Omit to post a new top-level message." )
+                      ] )
                 ] )
           ; "required", `List [ `String "surface"; `String "content" ]
           ]

--- a/lib/tool_surface/tool_shard_types_schemas_surface.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_surface.ml
@@ -144,6 +144,15 @@ let surface_tools : Masc_domain.tool_schema list =
                         , `String
                             "Slack thread timestamp (ts) of an existing message to reply inside that thread. Slack surface only; ignored for dashboard/discord. Omit to post a new top-level message." )
                       ] )
+                ; ( "blocks"
+                  , `Assoc
+                      [ "type", `String "array"
+                      ; "items", `Assoc [ "type", `String "object" ]
+                      ; "maxItems", `Int 50
+                      ; ( "description"
+                        , `String
+                            "Slack Block Kit blocks (chat.postMessage blocks parameter) for a structurally rich PR report: section/header/divider/context blocks, color banners, images. Slack surface only; ignored for dashboard/discord. Each block must be a JSON object carrying a non-empty string \"type\" member. When blocks is present it is sent alongside content (content remains the notification fallback text)." )
+                      ] )
                 ] )
           ; "required", `List [ `String "surface"; `String "content" ]
           ]


### PR DESCRIPTION
Split from PR #28992 (task-383 Quest Board goal links, merged).

This PR isolates the unrelated change that was mixed into #28992: exposing thread_ts and blocks (Slack Block Kit) parameters on the keeper_surface_post tool schema (task-327/328).

- lib/tool_surface/tool_shard_types_schemas_surface.ml (+16)

No other files changed. The main body of #28992 (Quest Board goal-link rendering) is untouched here.