### PR TITLE
fix(rw23): defer verifier task until refutation

### DIFF
--- a/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
+++ b/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
@@ -1173,25 +1173,10 @@ class MissionRun:
                 "owner": self.roles["coordinator"],
             },
         )
-        verifier_task = self.call(
-            "goal-verifier-task-create",
-            "masc_add_task",
-            {
-                "title": f"[{self.marker}] Produce exact Goal proof artifact",
-                "description": (
-                    f"Write {self.verifier_artifact} so its exact content is "
-                    f"{self.verifier_success_token}; submit that artifact as "
-                    "verification evidence."
-                ),
-                "priority": 1,
-                "goal_id": self.verifier_goal_id,
-            },
-        )
-        self.verifier_task_id = extract_identity(verifier_task.text, ["task-"])
         for role, keeper in self.roles.items():
             arguments: dict[str, Any] = {
                 "name": keeper,
-                "active_goal_ids": [self.goal_id, self.verifier_goal_id],
+                "active_goal_ids": [self.goal_id],
             }
             runtime_id = self.runtime_for_role(role)
             if runtime_id:
@@ -1705,6 +1690,21 @@ class MissionRun:
             criterion_state="viable",
             completion_state="idle",
         )
+        verifier_task = self.call(
+            "goal-verifier-task-create",
+            "masc_add_task",
+            {
+                "title": f"[{self.marker}] Produce exact Goal proof artifact",
+                "description": (
+                    f"Write {self.verifier_artifact} so its exact content is "
+                    f"{self.verifier_success_token}; submit that artifact as "
+                    "verification evidence."
+                ),
+                "priority": 1,
+                "goal_id": self.verifier_goal_id,
+            },
+        )
+        self.verifier_task_id = extract_identity(verifier_task.text, ["task-"])
         failure_token = f"GOAL_PROOF_FAIL={self.marker}"
         self.run_turn(
             "coordinator",

--- a/test/test_keeper_multi_collaboration_acceptance.py
+++ b/test/test_keeper_multi_collaboration_acceptance.py
@@ -1,5 +1,6 @@
 import hashlib
 import importlib.util
+import inspect
 import json
 import sys
 import tempfile
@@ -179,6 +180,28 @@ class KeeperMultiCollaborationAcceptanceTest(unittest.TestCase):
         self.assertEqual(
             [approach["id"] for approach in catalog["execution_approaches"]],
             ["A", "B", "C"],
+        )
+
+    def test_rw23_task_is_not_exposed_to_autonomous_work_before_refutation(self):
+        setup_source = inspect.getsource(acceptance.MissionRun.setup_product_state)
+        rw23_source = inspect.getsource(
+            acceptance.MissionRun.run_goal_verifier_refute_reenter_prove
+        )
+
+        # The success-token Task used to be created during fleet setup and the
+        # coordinator completed it autonomously before RW23 could write the
+        # failing artifact. Keep the Task creation inside the directed RW23
+        # phase and keep the verifier Goal out of the ordinary fleet scope.
+        self.assertNotIn("goal-verifier-task-create", setup_source)
+        self.assertIn('"active_goal_ids": [self.goal_id]', setup_source)
+        self.assertNotIn(
+            '"active_goal_ids": [self.goal_id, self.verifier_goal_id]',
+            setup_source,
+        )
+        self.assertIn("goal-verifier-task-create", rw23_source)
+        self.assertLess(
+            rw23_source.index("goal-verifier-task-create"),
+            rw23_source.index("goal-verifier-refute-artifact"),
         )
 
     def test_persistence_browser_validator_requires_exact_monotonic_fleet(self):


### PR DESCRIPTION
## Summary
- keep the Goal-verifier success-token Task out of initial fleet setup
- scope ordinary collaboration Keepers only to the main campaign Goal
- create the verifier Task inside the directed RW23 phase immediately before writing the failing artifact
- lock the lifecycle boundary with a regression test

## Real-world failure evidence
Protected-main run `32455741544`, exact source `c884017be761e1d614305b32e53aac7285f62470`, failed after the coordinator autonomously completed `task-001` with the success artifact before RW23 refutation. The Task verifier correctly approved it; the harness then waited for a rejection that could no longer occur. The later directed refutation turn also hit provider rate limiting, but retrying that turn would not repair the already-approved Task lifecycle.

Evidence artifact: `keeper-realworld-evidence-32455741544-1`

## Verification
- `python3 test/test_keeper_multi_collaboration_acceptance.py` (9/9)
- `python3 scripts/harness/workload/keeper_multi_collaboration_acceptance.py --validate-catalog` (23 missions / 47 assertions)
- `node --check dashboard/e2e/keeper-composition-real-backend.mjs`
- `git diff --check`
- no local Dune run; CI is compile/test authority