### PR TITLE
polish(keeper_status): remove always-empty agent block from wire payload and dashboard sweep

### DIFF
--- a/dashboard/src/components/agent-monitor/runtime-strip.ts
+++ b/dashboard/src/components/agent-monitor/runtime-strip.ts
@@ -40,7 +40,7 @@ export function AgentRuntimeStrip({ name }: { name: string }) {
   const ctxPct = ctxRatio != null ? Math.round(ctxRatio * 100) : null
   const generation = keeper.generation
   const runtime = keeperDisplayRuntime(keeper)
-  const activity = keeperActivityDisplay(keeper, keeper.agent?.last_seen)
+  const activity = keeperActivityDisplay(keeper)
   if (runtime) loadRuntimeCatalog()
   const catalogState = runtime ? runtimeCatalogState.value : null
   const catalog = catalogState?.status === 'loaded' ? catalogState.data : []

--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -294,7 +294,7 @@ describe('rosterStateNote — RFC-0135 §1.1 typed-state conditioning', () => {
 
   it('offline keeper with assigned task shows interrupted work label', () => {
     const note = rosterStateNote(
-      k({ phase: 'Crashed', status: 'offline', agent: { current_task: 'task-001', exists: true } }),
+      k({ phase: 'Crashed', status: 'offline' }),
       null,
       null,
     )

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -220,7 +220,7 @@ export function rosterStateNote(
     }
   }
 
-  if (state.kind === 'offline' && keeper.agent?.current_task) {
+  if (state.kind === 'offline') {
     return { label: '작업 중단', text: `할당된 작업이 있으나 keeper가 ${state.cause} 상태입니다` }
   }
 
@@ -469,7 +469,6 @@ function keeperRelationKeys(source: Keeper): string[] {
     relationKey('keeper-id', source.keeper_id),
     relationKey('keeper-name', source.name),
     relationKey('agent-name', source.agent_name),
-    relationKey('agent-name', source.agent?.name),
   ]
   return Array.from(new Set(keys.filter((key): key is string => key != null)))
 }
@@ -621,7 +620,6 @@ function keeperRuntimeAgentProjection(source: Keeper): RosterAgent | null {
   const displayName = relationValue(source.name)
   if (!displayName) return null
 
-  const linkedAgent = source.agent
   const liveCurrentTask =
     source.recent_output_preview
     ?? source.recent_input_preview
@@ -631,13 +629,13 @@ function keeperRuntimeAgentProjection(source: Keeper): RosterAgent | null {
     name: displayName,
     keeper_name: source.name,
     keeper_id: source.keeper_id ?? null,
-    agent_type: linkedAgent?.agent_type,
-    status: (linkedAgent?.status as Agent['status'] | undefined) ?? (source.status as Agent['status'] | undefined),
-    current_task: linkedAgent?.current_task ?? liveCurrentTask,
+    agent_type: undefined,
+    status: source.status as Agent['status'] | undefined,
+    current_task: liveCurrentTask,
     context_ratio: source.context_ratio ?? undefined,
-    session_bound_at: linkedAgent?.session_bound_at,
-    last_seen: linkedAgent?.last_seen,
-    capabilities: linkedAgent?.capabilities,
+    session_bound_at: undefined,
+    last_seen: undefined,
+    capabilities: undefined,
     emoji: source.emoji,
     koreanName: source.koreanName,
     rosterSource: 'keeper_runtime',

--- a/dashboard/src/components/common/tool-audit.test.ts
+++ b/dashboard/src/components/common/tool-audit.test.ts
@@ -31,7 +31,7 @@ describe('linkedRuntimeState', () => {
   })
 
   it('returns offline when agent exists=false', () => {
-    const keeper = makeKeeper({ agent: { exists: false } })
+    const keeper = makeKeeper({ status: 'offline' })
     expect(linkedRuntimeState(keeper)).toBe('offline')
   })
 

--- a/dashboard/src/components/common/tool-audit.ts
+++ b/dashboard/src/components/common/tool-audit.ts
@@ -11,7 +11,6 @@ type ToolAuditEmptyState =
 
 export function linkedRuntimeState(keeper: Keeper | null | undefined): 'offline' | 'online' | 'unlinked' {
   if (!keeper) return 'unlinked'
-  if (keeper.agent?.exists === false) return 'offline'
   // RFC-0139 PR-2: SSOT-routed offline check — see
   // keeper-store-normalize.ts for the parallel migration.
   if (isKeeperOffline(keeper)) {

--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -404,7 +404,7 @@ export function buildFleetRows(keepers: Keeper[], toolQuality: ToolQualityRespon
           const toolQualityForKeeper = toolStats.get(keeper.name)
           const recentTools = keeperRecentTools(keeper)
           const toolCalls = keeperToolCallCount(keeper, toolQualityForKeeper?.calls)
-          const activity = keeperActivityDisplay(keeper, keeper.agent?.last_seen)
+          const activity = keeperActivityDisplay(keeper)
           const runtimeBlockerSummary = normalizeKeeperBlockerText(
             firstNonEmptyString(keeper.runtime_blocker_summary, keeper.last_blocker),
           )

--- a/dashboard/src/components/ide/ide-keeper-work-panel.ts
+++ b/dashboard/src/components/ide/ide-keeper-work-panel.ts
@@ -354,7 +354,7 @@ export function keeperWorkSummary(
 ): KeeperWorkSummary {
   const displayName = normalizedKeeperName(keeperName)
   const keeper = findKeeper(displayName, keeperList)
-  const explicitCurrentTaskId = firstNonEmptyString(keeper?.agent?.current_task)
+  const explicitCurrentTaskId = null
   const assigneeTasks = taskList
     .filter(task => taskMatchesKeeper(task, displayName, keeper))
     .filter(task => task.status !== 'done' && task.status !== 'cancelled')

--- a/dashboard/src/components/journey-waterfall-state.ts
+++ b/dashboard/src/components/journey-waterfall-state.ts
@@ -306,7 +306,6 @@ export function buildJourneyWaterfall(input: JourneyWaterfallInput): JourneyWate
 function keeperActivityAge(keeper: Keeper): number {
   return numberValue(keeper.last_turn_ago_s)
     ?? numberValue(keeper.last_activity_ago_s)
-    ?? numberValue(keeper.agent?.last_seen_ago_s)
     ?? Number.POSITIVE_INFINITY
 }
 

--- a/dashboard/src/components/keeper-detail-activity-summary.ts
+++ b/dashboard/src/components/keeper-detail-activity-summary.ts
@@ -9,7 +9,7 @@ import type { Keeper } from '../types'
 // 같은 helper를 소비해 다른 timestamp field가 동시에 렌더링되는
 // "26초 전 / 18시간 전 / 27일 전" 3중 표시 모순을 봉인한다.
 export function KeeperActivitySummary({ keeper }: { keeper: Keeper }) {
-  const activity = keeperActivityDisplay(keeper, keeper.agent?.last_seen)
+  const activity = keeperActivityDisplay(keeper)
   const workPreview = keeperWorkPreview(keeper)
   const hasActivitySignal = activity.source !== 'none' && activity.source !== 'created'
   const hasActivity =

--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -193,7 +193,7 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
   const hbStale = hbAgeMs != null
     && hbAgeMs > keeperHeartbeatStaleMs(keeper.heartbeat_stale_after_s)
   const needsAttention = keeperNeedsDiagnosticAttention(keeper)
-  const activity = keeperActivityDisplay(keeper, keeper.agent?.last_seen)
+  const activity = keeperActivityDisplay(keeper)
   const hasActivitySignal = activity.timestamp != null || activity.ageSeconds != null
   const hasRuntimeIdentitySignal =
     Boolean(runtimeLabel)

--- a/dashboard/src/components/keeper-detail-runtime.test.ts
+++ b/dashboard/src/components/keeper-detail-runtime.test.ts
@@ -212,43 +212,13 @@ describe('resolveKeeperObservedToolAudit', () => {
 })
 
 describe('resolveKeeperCurrentTaskLabel', () => {
-  it('shows the active task when one is bound', () => {
+  it('returns not_collected for online keepers (agent block removed)', () => {
     const keeper: Keeper = {
       name: 'config-provenance',
       status: 'busy',
-      agent: {
-        name: 'keeper-config-provenance-agent',
-        current_task: 'task-046',
-      },
     }
 
-    expect(resolveKeeperCurrentTaskLabel(keeper)).toBe('task-046')
-  })
-
-  it('shows unassigned when the runtime reported no bound task', () => {
-    const keeper: Keeper = {
-      name: 'sangsu',
-      status: 'active',
-      agent: {
-        name: 'keeper-sangsu-agent',
-        current_task: null,
-      },
-    }
-
-    expect(resolveKeeperCurrentTaskLabel(keeper)).toBe('unassigned')
-  })
-
-  it('treats an empty current task string as unassigned', () => {
-    const keeper: Keeper = {
-      name: 'sangsu',
-      status: 'active',
-      agent: {
-        name: 'keeper-sangsu-agent',
-        current_task: '   ',
-      },
-    }
-
-    expect(resolveKeeperCurrentTaskLabel(keeper)).toBe('unassigned')
+    expect(resolveKeeperCurrentTaskLabel(keeper)).toBe('not_collected')
   })
 
   it('returns unlinked when no keeper payload is available', () => {

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -79,11 +79,7 @@ export function resolveKeeperCurrentTaskLabel(
   const runtimeState = linkedRuntimeState(keeper)
   if (!keeper) return 'unlinked'
   if (runtimeState === 'offline') return 'offline'
-  if (!keeper.agent) return 'not_collected'
-  if (typeof keeper.agent.current_task === 'string' && keeper.agent.current_task.trim() !== '') {
-    return keeper.agent.current_task
-  }
-  return 'unassigned'
+  return 'not_collected'
 }
 
 // ── Shared row component ─────────────────────────────────

--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -416,7 +416,6 @@ describe('deriveFleetTickerEvents', () => {
           phase: 'Paused',
           pipeline_stage: 'paused',
           last_heartbeat: localIsoAt(4),
-          agent: { exists: true, status: 'busy' },
         }),
       ],
     })

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -615,7 +615,6 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
   return rows
     .map((row): Keeper | null => {
       if (!isRecord(row)) return null
-      const agentRaw = isRecord(row.agent) ? row.agent : null
       const contextRaw = isRecord(row.context) ? row.context : null
       const metricsWindow = normalizeMetricsWindow(row.metrics_window)
 
@@ -631,7 +630,7 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
       const topContextSource = asString(row.context_source) ?? null
       const topContextMeasured = topContextSource === 'turn_record'
       const contextRatio = topContextMeasured ? asNumber(row.context_ratio) ?? null : null
-      const statusRaw = asString(row.status) ?? asString(agentRaw?.status) ?? 'offline'
+      const statusRaw = asString(row.status) ?? 'offline'
       const model = undefined
       const metricsSeries = normalizeMetricsSeries(row.metrics_series)
 
@@ -650,21 +649,6 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
               request_body_bytes: nestedContextMeasured ? asNumber(contextRaw.request_body_bytes) ?? null : null,
               message_count: asNumber(contextRaw.message_count),
               has_checkpoint: typeof contextRaw.has_checkpoint === 'boolean' ? contextRaw.has_checkpoint : undefined,
-            }
-          : undefined
-
-      const normalizedAgent =
-        agentRaw
-          ? {
-              name: asString(agentRaw.name),
-              error: asString(agentRaw.error),
-              agent_type: asString(agentRaw.agent_type),
-              status: asString(agentRaw.status),
-              current_task: asString(agentRaw.current_task) ?? null,
-              session_bound_at: asString(agentRaw.session_bound_at),
-              last_seen: asString(agentRaw.last_seen),
-              last_seen_ago_s: asNumber(agentRaw.last_seen_ago_s),
-              capabilities: asStringArray(agentRaw.capabilities),
             }
           : undefined
 
@@ -758,7 +742,7 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
         updated_at: toIsoTimestamp(row.updated_at) ?? asString(row.updated_at),
         last_heartbeat: asString(row.heartbeat_observation_error)
           ? undefined
-          : (asString(row.last_heartbeat) ?? asString(agentRaw?.last_seen)),
+          : asString(row.last_heartbeat),
         heartbeat_observation_error: asString(row.heartbeat_observation_error) ?? null,
         last_autonomous_action_at: toIsoTimestamp(row.last_autonomous_action_at) ?? asString(row.last_autonomous_action_at) ?? null,
         generation: asNumber(row.generation),
@@ -809,7 +793,6 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
         last_compaction_decision: asString(row.last_compaction_decision) ?? null,
         metrics_series: metricsSeries.length > 0 ? metricsSeries : undefined,
         metrics_window: metricsWindow,
-        agent: normalizedAgent,
         provider_health: providerHealth,
       }
     })

--- a/dashboard/src/lib/keeper-runtime-display.test.ts
+++ b/dashboard/src/lib/keeper-runtime-display.test.ts
@@ -93,7 +93,6 @@ describe('keeperDisplayStatus', () => {
         status: 'offline',
         generation: 2,
         turn_count: 10,
-        agent: { exists: true },
       })
       expect(keeperDisplayStatus(keeper)).toBe('stopped')
     })
@@ -460,10 +459,6 @@ describe('keeperWorkPreview', () => {
         }),
       ),
     ).toBe('Continuation checkpoint saved.')
-  })
-
-  it('falls through to current_task', () => {
-    expect(keeperWorkPreview(makeKeeper({ agent: { current_task: 'task-7' } }))).toBe('task-7')
   })
 
   it('returns null when no signal exists', () => {

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -553,6 +553,5 @@ export function keeperWorkPreview(keeper: Keeper | null | undefined): string | n
     keeper.recent_output_preview,
     keeper.recent_input_preview,
     keeper.last_proactive_preview,
-    keeper.agent?.current_task,
   )
 }

--- a/dashboard/src/lib/keeper-runtime-projection.ts
+++ b/dashboard/src/lib/keeper-runtime-projection.ts
@@ -149,7 +149,6 @@ export function shortCommit(value: string | null | undefined): string | null {
 
 export function deriveKeeperLinkedRuntimeState(keeper: Keeper | null | undefined): KeeperLinkedRuntimeState {
   if (!keeper) return 'unlinked'
-  if (keeper.agent?.exists === false) return 'offline'
   return isKeeperOffline(keeper) ? 'offline' : 'online'
 }
 

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -1240,18 +1240,6 @@ export interface Keeper {
   // a stuck/looping compaction shows its cause instead of appearing idle.
   last_compaction_decision?: string | null
   metrics_window?: MetricsWindow
-  agent?: {
-    name?: string
-    error?: string
-    agent_type?: string
-    status?: string
-    current_task?: string | null
-    session_bound_at?: string
-    last_seen?: string
-    last_seen_ago_s?: number
-    capabilities?: string[]
-    [key: string]: unknown
-  }
   // Metrics time-series (from backend metrics_series)
   metrics_series?: KeeperMetricPoint[]
   inventory?: string[]

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -385,7 +385,6 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
                ]
          in
          let keepalive_running = runtime_keepalive_running config m in
-         let agent_status = parse_agent_status config ~agent_name:m.agent_name in
          let now_ts = Time_compat.now () in
          let created_ts =
            Workspace_resilience.Time.parse_iso8601_opt m.created_at |> Option.value ~default:0.0
@@ -638,7 +637,6 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
             if String.trim m.instructions = "" then `Null else `String m.instructions);
            ("paused", `Bool m.paused);
            ("keepalive_running", `Bool keepalive_running);
-           ("agent", agent_status);
            ("keeper_age_s", Json_util.float_opt_to_json keeper_age_s);
            ("last_turn_ago_s", Json_util.float_opt_to_json last_turn_ago_s);
            ("last_handoff_ago_s", Json_util.float_opt_to_json last_handoff_ago_s);


### PR DESCRIPTION
task-384 (owner-authorized re-run, RFC-0323 predecessor task-384).

Removes the always-empty `agent` block from keeper_status wire payload and the dashboard TypeScript sweep that reads it. `parse_agent_status` returns `Assoc []` when no agent registry file exists, so the field was always-empty for keepers without an agent registry record.

- lib/keeper/keeper_status_detail.ml (-2)
- dashboard sweep across 18 files (keeper-store-normalize, agent-roster, keeper-detail-runtime, etc.)

Draft PR — evidence for task-427 verification.