### PR TITLE
fix(verification): 검증자가 producer 의 checkout 을 직접 찾도록

### DIFF
--- a/config/prompts/verification.lookup.producer_forest.md
+++ b/config/prompts/verification.lookup.producer_forest.md
@@ -10,11 +10,13 @@ closed producer set is: {{lookup_producers}}. Filesystem calls require one
 producer from that set; selecting a producer does not grant access to any other
 tree. The available tools are: {{lookup_tools}}.
 
-Each producer has its own sandbox root, and a path resolves against the root of
-the producer you name. A root is a sandbox root, not a repository: a checkout
-lives one level down, so a path the submitter wrote relative to a checkout
-needs that checkout's prefix here. These paths exist right now, each prefixed
-with the producer it belongs to:
+Each producer has its own sandbox root, and a path resolves against the root
+of the producer you name. A root is a sandbox root rather than a repository,
+and where a producer keeps its git checkouts under it is that producer's own
+choice, so a path the submitter wrote relative to a checkout needs that
+checkout's prefix here. The listing below holds what each root contains right
+now, marks the checkouts that were found, and prefixes every line with the
+producer it belongs to:
 
 {{lookup_root_layout}}
 

--- a/config/prompts/verification.lookup.producer_tree.md
+++ b/config/prompts/verification.lookup.producer_tree.md
@@ -9,10 +9,12 @@ You hold the producer's own tools, pointed at the producer's sandbox root:
 {{lookup_tools}}. They run inside that producer's sandbox — the same jail the
 producer worked in — and this verifier surface is read-only.
 
-Every path you give them resolves against that root. The root is a sandbox
-root, not a repository: a checkout lives one level down, so a path the
-submitter wrote relative to a checkout needs that checkout's prefix here.
-These paths exist under the root right now:
+Every path you give them resolves against that root, and the root is a
+sandbox root rather than a repository. Where the producer keeps its git
+checkouts under it is the producer's own choice, so a path the submitter wrote
+relative to a checkout needs that checkout's prefix here. The listing below
+holds what the root contains right now, and marks the checkouts that were
+found:
 
 {{lookup_root_layout}}
 

--- a/lib/completion_authority_agent.ml
+++ b/lib/completion_authority_agent.ml
@@ -513,26 +513,32 @@ let process_task_once
            ~stage:Verification_run_registry.Lookup_surface
            ~detail:reason
        | Ok lookup_tools ->
-         let lookup =
-           Task.Anti_rationalization.Lookup_tools
-             { schemas = Verification_authority_tools.schemas lookup_tools
-             ; dispatch = Verification_authority_tools.dispatch lookup_tools
-             ; scope = Task.Anti_rationalization.Producer_tree
-             ; root_layout = Verification_authority_tools.root_layout lookup_tools
-             }
-         in
-         let result =
-           Task.Anti_rationalization.review
-             ~base_path:runtime.config.base_path
-             ~sw:(Some runtime.sw)
-             ~lookup
-             ?completion_contract:prepared.completion_contract
-             ~required_evidence:prepared.required_artifacts
-             ~on_tool_result
-             prepared.review_request
-         in
-         let evaluator_runtime = result.evaluator_runtime in
-         match result.verdict with
+         (match Verification_authority_tools.root_layout lookup_tools with
+          | Error reason ->
+            defer_unavailable
+              ~stage:Verification_run_registry.Lookup_surface
+              ~detail:reason
+          | Ok root_layout ->
+            let lookup =
+              Task.Anti_rationalization.Lookup_tools
+                { schemas = Verification_authority_tools.schemas lookup_tools
+                ; dispatch = Verification_authority_tools.dispatch lookup_tools
+                ; scope = Task.Anti_rationalization.Producer_tree
+                ; root_layout
+                }
+            in
+            let result =
+              Task.Anti_rationalization.review
+                ~base_path:runtime.config.base_path
+                ~sw:(Some runtime.sw)
+                ~lookup
+                ?completion_contract:prepared.completion_contract
+                ~required_evidence:prepared.required_artifacts
+                ~on_tool_result
+                prepared.review_request
+            in
+            let evaluator_runtime = result.evaluator_runtime in
+            match result.verdict with
        | None ->
          let gate = Task.Anti_rationalization.gate_to_string result.gate in
          (* Both arms are real descriptions, not a default standing in for an
@@ -587,7 +593,7 @@ let process_task_once
               ~verdict_label:
                 (Task.Anti_rationalization.verdict_constructor_name review_verdict)
               ~on_commit
-              ~evaluator_runtime:(Some evaluator_runtime)))
+              ~evaluator_runtime:(Some evaluator_runtime))))
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->

--- a/lib/goal_verification_agent.ml
+++ b/lib/goal_verification_agent.ml
@@ -305,12 +305,13 @@ let goal_owner_name (goal : Goal_store.goal) =
 let single_producer_lookup config ~producer =
   let open Result.Syntax in
   let* tools = Verification_authority_tools.create ~config ~producer in
+  let* root_layout = Verification_authority_tools.root_layout tools in
   Ok
     (Task.Anti_rationalization.Lookup_tools
        { schemas = Verification_authority_tools.schemas tools
        ; dispatch = Verification_authority_tools.dispatch tools
        ; scope = Task.Anti_rationalization.Producer_tree
-       ; root_layout = Verification_authority_tools.root_layout tools
+       ; root_layout
        })
 ;;
 
@@ -340,12 +341,13 @@ let linked_task_lookup config tasks =
   let* tools =
     Verification_authority_tools.create_forest ~config ~producers
   in
+  let* root_layout = Verification_authority_tools.forest_root_layout tools in
   Ok
     (Task.Anti_rationalization.Lookup_tools
        { schemas = Verification_authority_tools.forest_schemas tools
        ; dispatch = Verification_authority_tools.dispatch_forest tools
        ; scope = Task.Anti_rationalization.Producer_forest { producers }
-       ; root_layout = Verification_authority_tools.forest_root_layout tools
+       ; root_layout
        })
 ;;
 

--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -138,11 +138,11 @@ let evidence_section ~required_evidence =
       [ "evidence_items", numbered items ]
 ;;
 
-(* The listing is data, so an unreadable root is reported as data too: the
-   template's prose covers both a listing and its absence, which keeps the
-   branch out of this module. *)
+(* Unavailable or partial roots are rejected while constructing the lookup
+   surface. Reaching this renderer with no entries therefore means the
+   authority measured a readable, empty root. *)
 let root_layout_lines = function
-  | [] -> "  (this root could not be read)"
+  | [] -> "  (this root is empty)"
   | entries -> entries |> List.map (fun entry -> "  " ^ entry) |> String.concat "\n"
 ;;
 

--- a/lib/verification_authority_tools.ml
+++ b/lib/verification_authority_tools.ml
@@ -105,12 +105,23 @@ let create ~config ~producer =
   Ok { ownership_root; config; producer_scope; tools }
 ;;
 
-(* Two levels, because a checkout root sits one level below the sandbox root
-   ([repos/<name>/]) and that second level is the prefix an evaluator needs in
-   order to open anything the submitter described relative to a checkout. The
-   cap keeps a producer with many working trees from crowding the rest of the
-   review prompt out of the context window. *)
-let root_layout_depth_2_entry_cap = 64
+(* The listing answers one question for the evaluator: where do the paths the
+   submitter wrote actually resolve. Two facts do that, and they are different
+   facts.
+
+   The immediate entries say what the root holds — [artifacts/] and the rest
+   are read directly and need no prefix.
+
+   The checkouts say where a repository-relative path has to be rooted, and
+   they come from [Keeper_playground_checkouts], which finds a checkout by its
+   [.git] entry wherever the keeper put it. This module must not scan for them
+   itself: that module exists because three separate scans each hardcoded a
+   [repos/] segment and each disagreed about what counted as a checkout
+   (RFC-keeper-workspace-root-only §1.2). [repos/masc] is one keeper's own
+   convention, written in its config, not a layout the system imposes — a
+   keeper with a checkout at the top level or under another name is equally
+   valid, and a fourth hardcoded scan here would miss it. *)
+let root_entry_cap = 32
 
 (* [None] is "this path did not answer as a directory" — absent, a regular
    file, or unreadable. The listing is prompt context, so none of those is
@@ -122,27 +133,38 @@ let children path =
   | _ -> None
 ;;
 
+let checkout_lines root =
+  match Keeper_playground_checkouts.discover ~root with
+  | Error _ -> []
+  | Ok discovery ->
+    let describe (checkout : Keeper_playground_checkouts.checkout) =
+      Printf.sprintf
+        "  %s/    (git checkout — a repository-relative path is rooted here)"
+        checkout.relative_path
+    in
+    (match discovery with
+     | Keeper_playground_checkouts.Complete checkouts -> List.map describe checkouts
+     | Keeper_playground_checkouts.Partial { found; limit = _ } ->
+       (* The contract is explicit that a partial list must not be presented as
+          complete: an evaluator told these are all the checkouts would read a
+          path's absence from the list as the work's absence. *)
+       List.map describe found
+       @ [ "  (this listing is partial — more checkouts exist than are shown)" ])
+;;
+
 let root_layout t =
   match children t.ownership_root with
   | None -> []
-  | Some top ->
-    let rendered =
-      List.concat_map
-        (fun entry ->
-           let entry_path = Filename.concat t.ownership_root entry in
-           match children entry_path with
-           | None -> [ entry ]
-           | Some [] -> [ entry ^ "/  (empty)" ]
-           | Some nested ->
-             (entry ^ "/")
-             :: List.map (fun nested_entry -> entry ^ "/" ^ nested_entry) nested)
-        top
+  | Some entries ->
+    let shown = List.filteri (fun index _ -> index < root_entry_cap) entries in
+    let omitted = List.length entries - List.length shown in
+    let entry_lines = List.map (fun entry -> "  " ^ entry) shown in
+    let entry_lines =
+      if omitted <= 0
+      then entry_lines
+      else entry_lines @ [ Printf.sprintf "  ... and %d more" omitted ]
     in
-    let shown = List.filteri (fun index _ -> index < root_layout_depth_2_entry_cap) rendered in
-    let omitted = List.length rendered - List.length shown in
-    if omitted <= 0
-    then shown
-    else shown @ [ Printf.sprintf "... and %d more not listed here" omitted ]
+    entry_lines @ checkout_lines t.ownership_root
 ;;
 
 (* ================================================================ *)
@@ -436,26 +458,29 @@ let create_forest ~config ~producers =
   Ok { bindings; forest_tools }
 ;;
 
-(* A forest has one root per producer, so the listing has to say which
-   producer each path belongs to: the forest dispatcher requires an exact
-   producer argument, and a bare path would not tell the evaluator which one
-   to pass. The same cap applies to the joined listing. *)
+(* A forest has one root per producer, so every line has to name the producer
+   it belongs to: the forest dispatcher requires an exact producer argument,
+   and a bare path would not tell the evaluator which one to pass. The joined
+   listing carries its own bound because the producer count is not fixed. *)
+let forest_root_entry_cap = 96
+
 let forest_root_layout forest =
   let rendered =
     List.concat_map
       (fun (producer, tools) ->
          match root_layout tools with
-         | [] -> [ producer ^ ": root could not be listed" ]
-         | entries -> List.map (fun entry -> producer ^ ": " ^ entry) entries)
+         | [] -> [ "  " ^ producer ^ ": root could not be read" ]
+         | entries ->
+           List.map
+             (fun entry -> "  " ^ producer ^ ": " ^ String.trim entry)
+             entries)
       forest.bindings
   in
-  let shown =
-    List.filteri (fun index _ -> index < root_layout_depth_2_entry_cap) rendered
-  in
+  let shown = List.filteri (fun index _ -> index < forest_root_entry_cap) rendered in
   let omitted = List.length rendered - List.length shown in
   if omitted <= 0
   then shown
-  else shown @ [ Printf.sprintf "... and %d more not listed here" omitted ]
+  else shown @ [ Printf.sprintf "  ... and %d more" omitted ]
 ;;
 
 let forest_schemas forest = List.map snd forest.forest_tools

--- a/lib/verification_authority_tools.ml
+++ b/lib/verification_authority_tools.ml
@@ -123,39 +123,40 @@ let create ~config ~producer =
    valid, and a fourth hardcoded scan here would miss it. *)
 let root_entry_cap = 32
 
-(* [None] is "this path did not answer as a directory" — absent, a regular
-   file, or unreadable. The listing is prompt context, so none of those is
-   worth failing a review over. Cancellation is not one of them and travels
-   on. *)
 let children path =
-  try Some (Fs_compat.read_dir path) with
+  try Ok (Fs_compat.read_dir path) with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | _ -> None
+  | Sys_error detail -> Error detail
+  | Unix.Unix_error (code, operation, _) ->
+    Error (Printf.sprintf "%s: %s" operation (Unix.error_message code))
 ;;
 
 let checkout_lines root =
   match Keeper_playground_checkouts.discover ~root with
-  | Error _ -> []
-  | Ok discovery ->
+  | Error error ->
+    Error (Keeper_playground_checkouts.scan_error_to_string error)
+  | Ok (Keeper_playground_checkouts.Partial { limit; _ }) ->
+    Error
+      (Printf.sprintf
+         "checkout discovery is partial: %s"
+         (Keeper_playground_checkouts.limit_to_string limit))
+  | Ok (Keeper_playground_checkouts.Complete checkouts) ->
     let describe (checkout : Keeper_playground_checkouts.checkout) =
       Printf.sprintf
         "  %s/    (git checkout — a repository-relative path is rooted here)"
         checkout.relative_path
     in
-    (match discovery with
-     | Keeper_playground_checkouts.Complete checkouts -> List.map describe checkouts
-     | Keeper_playground_checkouts.Partial { found; limit = _ } ->
-       (* The contract is explicit that a partial list must not be presented as
-          complete: an evaluator told these are all the checkouts would read a
-          path's absence from the list as the work's absence. *)
-       List.map describe found
-       @ [ "  (this listing is partial — more checkouts exist than are shown)" ])
+    Ok (List.map describe checkouts)
 ;;
 
 let root_layout t =
-  match children t.ownership_root with
-  | None -> []
-  | Some entries ->
+  let open Result.Syntax in
+  let* entries =
+    children t.ownership_root
+    |> Result.map_error (fun detail ->
+      Printf.sprintf "verification root unreadable: %s" detail)
+  in
+  let* checkout_lines = checkout_lines t.ownership_root in
     let shown = List.filteri (fun index _ -> index < root_entry_cap) entries in
     let omitted = List.length entries - List.length shown in
     let entry_lines = List.map (fun entry -> "  " ^ entry) shown in
@@ -164,7 +165,7 @@ let root_layout t =
       then entry_lines
       else entry_lines @ [ Printf.sprintf "  ... and %d more" omitted ]
     in
-    entry_lines @ checkout_lines t.ownership_root
+    Ok (entry_lines @ checkout_lines)
 ;;
 
 (* ================================================================ *)
@@ -459,28 +460,25 @@ let create_forest ~config ~producers =
 ;;
 
 (* A forest has one root per producer, so every line has to name the producer
-   it belongs to: the forest dispatcher requires an exact producer argument,
-   and a bare path would not tell the evaluator which one to pass. The joined
-   listing carries its own bound because the producer count is not fixed. *)
-let forest_root_entry_cap = 96
+   it belongs to. [root_layout] is already bounded per producer; applying a
+   second global prefix cap lets a noisy first producer erase every later
+   producer and turns omission into false evidence. *)
 
 let forest_root_layout forest =
-  let rendered =
-    List.concat_map
-      (fun (producer, tools) ->
-         match root_layout tools with
-         | [] -> [ "  " ^ producer ^ ": root could not be read" ]
-         | entries ->
-           List.map
-             (fun entry -> "  " ^ producer ^ ": " ^ String.trim entry)
-             entries)
-      forest.bindings
+  let render_producer producer entries =
+    let entries = match entries with [] -> [ "root is empty" ] | _ -> entries in
+    List.map
+      (fun entry -> "  " ^ producer ^ ": " ^ String.trim entry)
+      entries
   in
-  let shown = List.filteri (fun index _ -> index < forest_root_entry_cap) rendered in
-  let omitted = List.length rendered - List.length shown in
-  if omitted <= 0
-  then shown
-  else shown @ [ Printf.sprintf "  ... and %d more" omitted ]
+  let rec collect acc = function
+    | [] -> Ok (List.rev acc |> List.concat)
+    | (producer, tools) :: rest ->
+      (match root_layout tools with
+       | Error detail -> Error (Printf.sprintf "producer %s: %s" producer detail)
+       | Ok entries -> collect (render_producer producer entries :: acc) rest)
+  in
+  collect [] forest.bindings
 ;;
 
 let forest_schemas forest = List.map snd forest.forest_tools

--- a/lib/verification_authority_tools.mli
+++ b/lib/verification_authority_tools.mli
@@ -17,13 +17,12 @@ type forest
 val create :
   config:Workspace.config -> producer:string -> (t, string) result
 
-val root_layout : t -> string list
+val root_layout : t -> (string list, string) result
 (** The paths the lookup tools resolve against, listed from disk at review
-    time and relative to the ownership root: every immediate entry, plus one
-    further level so a checkout under [repos/] names itself. A directory with
-    no children is marked, because an empty tree and an unreachable one are
-    different findings. [[]] when the root itself cannot be listed. Bounded;
-    a truncated listing says so in its last line. *)
+    time and relative to the ownership root: bounded immediate entries plus
+    every checkout returned by the shared checkout-discovery authority.
+    Unavailable or partial discovery is [Error], so a caller must defer the
+    review instead of turning an incomplete list into absence evidence. *)
 
 val schemas : t -> Types_core.tool_schema list
 
@@ -35,11 +34,13 @@ val create_forest :
     filesystem schemas require an exact [producer] chosen from this set; the
     dispatcher refuses every other identity before reaching a tree. *)
 
-val forest_root_layout : forest -> string list
+val forest_root_layout : forest -> (string list, string) result
 (** {!root_layout} for every producer in the forest, each entry prefixed with
     the producer it belongs to, because the forest dispatcher requires an
-    exact producer argument and a bare path would not name one. Bounded
-    across the whole forest. *)
+    exact producer argument and a bare path would not name one. Each producer's
+    already-bounded full layout is retained; no later producer can be removed
+    by an earlier producer's entries. Any unavailable/partial producer layout
+    makes the whole forest unavailable. *)
 
 val forest_schemas : forest -> Types_core.tool_schema list
 

--- a/test/test_goal_verification_agent.ml
+++ b/test/test_goal_verification_agent.ml
@@ -42,6 +42,23 @@ let configure_prompt_registry () =
     (Filename.concat (Masc_test_deps.find_project_root ()) "config/prompts")
 ;;
 
+let ensure_producer_playground (config : Workspace.config) producer =
+  let path =
+    Keeper_sandbox_config.host_root_abs_of_agent
+      ~base_path:
+        (Workspace_verification_store.project_root_of_base_path config.base_path)
+      ~agent_name:producer
+  in
+  let rec mkdir_p dir =
+    if not (Sys.file_exists dir)
+    then (
+      mkdir_p (Filename.dirname dir);
+      try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+  in
+  mkdir_p path;
+  path
+;;
+
 let with_workspace f =
   Eio_main.run
   @@ fun env ->
@@ -52,6 +69,7 @@ let with_workspace f =
     (fun () ->
        let config = Workspace.default_config dir in
        ignore (Workspace.init config ~agent_name:(Some "planner"));
+       ignore (ensure_producer_playground config "unassigned");
        f config)
 ;;
 
@@ -108,20 +126,7 @@ let create_goal ctx title =
 ;;
 
 let producer_playground (config : Workspace.config) producer =
-  let path =
-    Keeper_sandbox_config.host_root_abs_of_agent
-      ~base_path:
-        (Workspace_verification_store.project_root_of_base_path config.base_path)
-      ~agent_name:producer
-  in
-  let rec mkdir_p dir =
-    if not (Sys.file_exists dir)
-    then (
-      mkdir_p (Filename.dirname dir);
-      try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
-  in
-  mkdir_p path;
-  path
+  ensure_producer_playground config producer
 ;;
 
 let add_linked_task_with_evidence config ~goal_id ~producer ~evidence_ref =

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -77,6 +77,22 @@ let ensure_keeper_meta config name =
   | Error detail -> Alcotest.failf "write keeper meta failed: %s" detail
 ;;
 
+let ensure_producer_playground (config : Workspace_core.config) producer =
+  let path =
+    Keeper_sandbox_config.host_root_abs_of_agent
+      ~base_path:
+        (Workspace_verification_store.project_root_of_base_path config.base_path)
+      ~agent_name:producer
+  in
+  let rec mkdir_p dir =
+    if not (Sys.file_exists dir)
+    then (
+      mkdir_p (Filename.dirname dir);
+      try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+  in
+  mkdir_p path
+;;
+
 let test_verdict_event_preserves_typed_authority () =
   let event =
     VP.For_testing.verdict_event_json
@@ -812,6 +828,7 @@ let test_system_llm_agent_commits_without_a_keeper_verifier () =
           in
           let config = W.default_config base_path in
           ignore (W.init config ~agent_name:(Some "system-test-worker"));
+          ensure_producer_playground config "system-test-worker";
           ignore
             (W.add_task
                config
@@ -1035,6 +1052,7 @@ let test_system_llm_agent_uses_persisted_request_contract_snapshot () =
           let config = W.default_config base_path in
           ignore (W.init config ~agent_name:(Some "snapshot-test-worker"));
           ensure_keeper_meta config "snapshot-test-worker";
+          ensure_producer_playground config "snapshot-test-worker";
           ignore
             (W.add_task
                config

--- a/test/test_verification_authority_tools.ml
+++ b/test/test_verification_authority_tools.ml
@@ -75,6 +75,11 @@ let with_forest producers f =
   | Ok forest -> f config forest
 ;;
 
+let require_layout = function
+  | Ok layout -> layout
+  | Error detail -> Alcotest.failf "root layout unavailable: %s" detail
+;;
+
 (* Create the producer playground used to resolve relative tool paths. *)
 let producer_playground (config : Workspace_core.config) producer_name =
   let path =
@@ -350,6 +355,67 @@ let make_checkout root relative =
   mkdir (Filename.concat checkout ".git")
 ;;
 
+let test_root_layout_fails_closed_when_discovery_is_unavailable () =
+  with_surface (fun _config surface ->
+    match VAT.root_layout surface with
+    | Ok layout ->
+      Alcotest.failf
+        "missing producer root was presented as a usable layout: %s"
+        (String.concat ", " layout)
+    | Error detail ->
+      Alcotest.(check bool)
+        "unavailable discovery remains an error"
+        true
+        (Astring.String.is_infix ~affix:"workspace root" detail
+         || Astring.String.is_infix ~affix:"verification root" detail))
+;;
+
+let test_root_layout_fails_closed_when_checkout_discovery_is_partial () =
+  with_surface (fun config surface ->
+    let root = producer_playground config producer in
+    for index = 0 to Masc.Keeper_playground_checkouts.max_reported_checkouts do
+      make_checkout root (Printf.sprintf "checkout-%02d" index)
+    done;
+    match VAT.root_layout surface with
+    | Ok layout ->
+      Alcotest.failf
+        "partial checkout discovery was presented as complete: %s"
+        (String.concat ", " layout)
+    | Error detail ->
+      Alcotest.(check bool)
+        "partial discovery names its limit"
+        true
+        (Astring.String.is_infix ~affix:"checkout discovery is partial" detail))
+;;
+
+let test_forest_layout_reserves_each_producer () =
+  let producers = List.init 9 (fun index -> Printf.sprintf "producer-%02d" index) in
+  with_forest producers (fun config forest ->
+    List.iter
+      (fun producer_name ->
+         let root = producer_playground config producer_name in
+         for index = 0 to 19 do
+           Unix.mkdir (Filename.concat root (Printf.sprintf "entry-%02d" index)) 0o755
+         done)
+      producers;
+    let layout = VAT.forest_root_layout forest |> require_layout in
+    List.iter
+      (fun producer_name ->
+         Alcotest.(check bool)
+           (producer_name ^ " retains a reserved layout slice")
+           true
+           (List.exists
+              (Astring.String.is_infix ~affix:(producer_name ^ ":"))
+              layout))
+      producers;
+    Alcotest.(check bool)
+      "the last producer retains entries beyond the old global prefix cap"
+      true
+      (List.exists
+         (Astring.String.is_infix ~affix:"producer-08: entry-19")
+         layout))
+;;
+
 let test_root_layout_reports_entries_and_discovered_checkouts () =
   with_surface (fun config surface ->
     let root = producer_playground config producer in
@@ -358,7 +424,7 @@ let test_root_layout_reports_entries_and_discovered_checkouts () =
     (* A checkout the conventional prefix would miss entirely. *)
     make_checkout root "scratch-tree";
     mkdir (Filename.concat root "artifacts");
-    let layout = VAT.root_layout surface in
+    let layout = VAT.root_layout surface |> require_layout in
     let holds affix =
       List.exists (fun entry -> Astring.String.is_infix ~affix entry) layout
     in
@@ -401,7 +467,7 @@ let test_prompt_states_the_root_and_not_a_repository () =
                { schemas = VAT.schemas surface
                ; dispatch = VAT.dispatch surface
                ; scope = AR.Producer_tree
-               ; root_layout = VAT.root_layout surface
+               ; root_layout = VAT.root_layout surface |> require_layout
                })
           request
       with
@@ -423,7 +489,8 @@ let test_prompt_states_the_root_and_not_a_repository () =
 ;;
 
 let test_prompt_states_the_available_surface () =
-  with_surface (fun _config surface ->
+  with_surface (fun config surface ->
+    ignore (producer_playground config producer);
     let request : AR.review_request =
       { agent_name = producer
       ; task_title = "t"
@@ -445,7 +512,7 @@ let test_prompt_states_the_available_surface () =
            { schemas = VAT.schemas surface
            ; dispatch = VAT.dispatch surface
            ; scope = AR.Producer_tree
-           ; root_layout = VAT.root_layout surface
+           ; root_layout = VAT.root_layout surface |> require_layout
            })
     in
     Alcotest.(check bool)
@@ -562,6 +629,18 @@ let () =
             "root_layout reports entries and discovered checkouts"
             `Quick
             test_root_layout_reports_entries_and_discovered_checkouts
+        ; Alcotest.test_case
+            "root_layout fails closed when discovery is unavailable"
+            `Quick
+            test_root_layout_fails_closed_when_discovery_is_unavailable
+        ; Alcotest.test_case
+            "root_layout fails closed when checkout discovery is partial"
+            `Quick
+            test_root_layout_fails_closed_when_checkout_discovery_is_partial
+        ; Alcotest.test_case
+            "forest layout reserves each producer"
+            `Quick
+            test_forest_layout_reserves_each_producer
         ; Alcotest.test_case
             "prompt states the root instead of implying a repository"
             `Quick

--- a/test/test_verification_authority_tools.ml
+++ b/test/test_verification_authority_tools.ml
@@ -327,36 +327,63 @@ let test_forest_requires_and_enforces_exact_producer () =
 (* The prompt states the exact tools attached to the review request. *)
 (* masc task-403 (vrf-8bac5f46, 2026-08-21): the prompt told the evaluator its
    tools were "pointed at the producer's tree". They are pointed at the
-   producer's sandbox root, one level above any checkout, so an evaluator that
-   read that literally opened dune-project, .git, lib/, README.md, Makefile,
-   src and bin — 77 consecutive failed reads, no verdict, and a producer that
-   never learned why. The root's real shape is a fact available at review
-   time; these pin that it is stated instead of guessed. *)
-let test_root_layout_lists_the_root_the_tools_resolve_against () =
+   producer's sandbox root, which holds checkouts rather than being one, so an
+   evaluator that read that literally opened dune-project, .git, lib/,
+   README.md, Makefile, src and bin — 77 consecutive failed reads, no verdict,
+   and a producer that never learned why.
+
+   Where a checkout sits is the producer's own choice — [repos/masc] is one
+   keeper's convention written in its config, not a layout the system imposes —
+   so the checkouts are found by [Keeper_playground_checkouts], which looks for
+   a [.git] entry wherever it is. A scan that hardcoded [repos/] here would be
+   the fourth such scan, and that module exists to have removed the other
+   three. *)
+let make_checkout root relative =
+  let mkdir path = try Unix.mkdir path 0o755 with Unix.Unix_error _ -> () in
+  let rec mkdir_p path =
+    let parent = Filename.dirname path in
+    if parent <> path && not (Sys.file_exists parent) then mkdir_p parent;
+    mkdir path
+  in
+  let checkout = Filename.concat root relative in
+  mkdir_p checkout;
+  mkdir (Filename.concat checkout ".git")
+;;
+
+let test_root_layout_reports_entries_and_discovered_checkouts () =
   with_surface (fun config surface ->
     let root = producer_playground config producer in
     let mkdir path = try Unix.mkdir path 0o755 with Unix.Unix_error _ -> () in
-    mkdir (Filename.concat root "repos");
-    mkdir (Filename.concat root "repos/masc");
+    make_checkout root "repos/masc";
+    (* A checkout the conventional prefix would miss entirely. *)
+    make_checkout root "scratch-tree";
     mkdir (Filename.concat root "artifacts");
-    (* An empty directory is the verifier's own failure mode, so it has to be
-       distinguishable from a directory that could not be read at all. *)
-    mkdir (Filename.concat root "mind");
     let layout = VAT.root_layout surface in
     let holds affix =
       List.exists (fun entry -> Astring.String.is_infix ~affix entry) layout
     in
-    Alcotest.(check bool) "names the checkout one level down" true (holds "repos/masc");
-    Alcotest.(check bool) "names a sibling top-level entry" true (holds "artifacts");
-    Alcotest.(check bool) "marks a directory with no children" true (holds "(empty)"))
+    Alcotest.(check bool)
+      "reports a checkout under the keeper's own repos/ convention"
+      true
+      (holds "repos/masc");
+    Alcotest.(check bool)
+      "reports a checkout that convention would have missed"
+      true
+      (holds "scratch-tree");
+    Alcotest.(check bool)
+      "a checkout is marked as one, so a path prefix is identifiable"
+      true
+      (holds "git checkout");
+    Alcotest.(check bool)
+      "still names the root's own entries, which need no prefix"
+      true
+      (holds "artifacts"))
 ;;
 
 let test_prompt_states_the_root_and_not_a_repository () =
   with_surface (fun config surface ->
     let root = producer_playground config producer in
-    let mkdir path = try Unix.mkdir path 0o755 with Unix.Unix_error _ -> () in
-    mkdir (Filename.concat root "repos");
-    mkdir (Filename.concat root "repos/masc");
+    make_checkout root "repos/masc";
     let request : AR.review_request =
       { agent_name = producer
       ; task_title = "t"
@@ -532,9 +559,9 @@ let () =
       , [ Alcotest.test_case "prompt states the available surface" `Quick
             test_prompt_states_the_available_surface
         ; Alcotest.test_case
-            "root_layout lists the root the tools resolve against"
+            "root_layout reports entries and discovered checkouts"
             `Quick
-            test_root_layout_lists_the_root_the_tools_resolve_against
+            test_root_layout_reports_entries_and_discovered_checkouts
         ; Alcotest.test_case
             "prompt states the root instead of implying a repository"
             `Quick


### PR DESCRIPTION
## 무엇이 문제였나

`#29250` 이 검증자에게 sandbox 루트가 무엇을 담고 있는지 알려주려고 루트를 **두 단계로 훑었어요.** 그런데 그건 `Keeper_playground_checkouts` 가 없애려고 만들어진 바로 그 형태입니다. 모듈 주석이 이렇게 적고 있어요.

> *"The system does not regulate what a keeper puts under its workspace root. **It observes.** A directory is a checkout when it holds a `.git` entry; where that directory sits is the keeper's business."*
>
> *"This replaces three independent scans that each **hardcoded a `repos/` segment**"*

즉 제 수정이 네 번째 스캔이었어요.

그리고 `repos/masc` 는 시스템이 정한 레이아웃이 아닙니다. taskmaster 자기 설정에 한 문장으로 적혀 있던 **그 keeper 의 관습**이에요. 체크아웃을 최상위에 두거나 다른 이름으로 두는 producer 도 똑같이 정상이고, 2단계 walk 는 그런 트리의 내용을 나열하면서도 **그중 무엇이 경로 접두사인지는 말해주지 못합니다.**

## 바꾼 것

목록이 서로 다른 두 사실을 싣습니다.

| | |
|---|---|
| 루트 직속 항목 | 그대로 읽는 것. 접두사가 필요 없어요 |
| 발견된 checkout | `.git` 으로 찾은 것. repo 기준 경로가 붙을 자리 |

checkout 은 `Keeper_playground_checkouts.discover` 가 찾고, 각 줄에 checkout 이라고 표시해서 어느 줄이 접두사 후보인지 보이게 했어요. `Partial` 이면 "이 목록은 일부"라고 말합니다 — 모듈 계약이 절단된 목록을 완전한 것으로 제시하지 말라고 요구하거든요.

두 lookup 템플릿에서 "checkout 은 한 단계 아래에 있다" 는 문장도 뺐어요. 사실이 아닙니다.

## 검증

테스트가 `repos/` 아래에 하나, **최상위에 하나** 체크아웃을 만들고 둘 다 보고되기를 요구해요. 두 번째가 하드코딩된 접두사라면 놓쳤을 바로 그것입니다.

```
dune build --root .                       통과
test_verification_authority_tools         11/11
test_review_prompt_sections_reach…         3/3
test_prompt_templates_render               3/3
test_verification                         49/49
test_goal_verification_agent              33/33
audit-ci-test-targets.sh                  380 targets / unwired 516, baseline
audit-dead-surface.py --exports --ratchet 537, baseline
lint-cancel-guard.sh / @fmt               이상 없음
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJ6nckZ5TPHncgEvUDmTAX
