### PR TITLE
chore(keeper): 제거된 persona 시스템이 남긴 주석 표현 정리

### DIFF
--- a/lib/keeper/keeper_operator_note.ml
+++ b/lib/keeper/keeper_operator_note.ml
@@ -51,8 +51,8 @@ let path_for config keeper =
 
 (* A note is one instruction for one turn. The cap is a constant rather than a
    knob because nothing has asked to tune it, and an operator who needs more
-   than this is describing standing context, which belongs in the persona or in
-   memory rather than in a note that expires next turn. *)
+   than this is describing standing context, which belongs in the keeper's
+   instructions or in memory rather than in a note that expires next turn. *)
 let max_note_bytes = 4 * 1024
 let max_bytes () = max_note_bytes
 

--- a/lib/keeper/keeper_prompt_capture.mli
+++ b/lib/keeper/keeper_prompt_capture.mli
@@ -7,7 +7,7 @@
     {1 Why the last turn is the preview}
 
     The blocks are stable across turns — measured on a live fleet, the same
-    keeper renders identical persona, recall, and dynamic-context bytes turn
+    keeper renders identical system-prompt, recall, and dynamic-context bytes
     after turn while only the conversation grows. The assembled context of the
     turn that just ran is therefore what the next turn will assemble, minus the
     conversation. That is why this store needs no arming step: capturing every
@@ -21,8 +21,8 @@
 
     {1 What is not here}
 
-    The base system prompt (persona) is assembled on a different path and is not
-    part of this capture. This store holds the extra system context: the typed
+    The base system prompt is assembled on a different path and is not part of
+    this capture. This store holds the extra system context: the typed
     blocks appended to that base. *)
 
 type block =


### PR DESCRIPTION
persona 시스템은 제거됐는데 주석 세 곳이 아직 그 이름을 부르고 있었어요. 각 주석이 지금은 **없는 곳을 가리킵니다** — 고치려고 persona 를 찾으면 아무것도 없고, 아직 있다고 믿으면 base prompt 가 어디서 오는지를 잘못 읽게 돼요.

```
keeper_prompt_capture.mli:10   "identical persona, recall…"    → system-prompt
keeper_prompt_capture.mli:24   "base system prompt (persona)"  → 괄호 제거
keeper_operator_note.ml:54     "belongs in the persona"        → keeper's instructions
```

블록은 시스템 프롬프트이고, standing context 는 keeper instructions 에 들어갑니다.

`docs/research/2026-08-13-counterpart-relationship-memory.md` 의 세 줄은 그대로 뒀어요. LoCoMo 같은 외부 연구를 인용하는 자리라, 거기서는 그 논문들의 주제를 가리키지 이 시스템을 가리키지 않습니다.

주석만 바뀌어서 동작 변화는 없어요. 전체 빌드와 `@fmt` 확인했습니다.

참고로 런타임 쪽 잔재도 같이 걷어냈어요(이 PR 밖, `~/me/.masc`): 읽는 코드가 없어진 `config/personas/` 14개와 2026-08-07 persona strip 백업 디렉터리. keeper meta JSON 에는 persona 필드가 원래 없었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJ6nckZ5TPHncgEvUDmTAX
