### PR TITLE
fix(rw23): trust typed verifier verdict

### DIFF
--- a/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
+++ b/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
@@ -1189,47 +1189,6 @@ class MissionRun:
             f"completion={completion_state}, last={json.dumps(last, ensure_ascii=False)}"
         )
 
-    def find_task(self, value: Any, task_id: str) -> dict[str, Any] | None:
-        if isinstance(value, dict):
-            if value.get("id") == task_id or value.get("task_id") == task_id:
-                if "task_status" in value or "status" in value:
-                    return value
-            for nested in value.values():
-                found = self.find_task(nested, task_id)
-                if found is not None:
-                    return found
-        elif isinstance(value, list):
-            for nested in value:
-                found = self.find_task(nested, task_id)
-                if found is not None:
-                    return found
-        return None
-
-    def wait_for_verifier_task_status(
-        self, expected_status: str, timeout: float = 300.0
-    ) -> dict[str, Any]:
-        deadline = time.monotonic() + timeout
-        attempt = 0
-        last: dict[str, Any] | None = None
-        while time.monotonic() < deadline:
-            attempt += 1
-            observation = self.call(
-                f"goal-verifier-task-poll-{expected_status}-{attempt}",
-                "masc_tasks",
-                {"include_done": True, "include_cancelled": True},
-            )
-            last = self.find_task(observation.data, self.verifier_task_id)
-            if isinstance(last, dict) and (
-                last.get("task_status") == expected_status
-                or last.get("status") == expected_status
-            ):
-                return last
-            time.sleep(2.0)
-        raise AcceptanceError(
-            f"verifier Task did not reach {expected_status}: "
-            f"last={json.dumps(last, ensure_ascii=False)}"
-        )
-
     def wait_for_verifier_task_verdict(
         self, to_status: str, timeout: float = 300.0
     ) -> dict[str, Any]:
@@ -1347,14 +1306,6 @@ class MissionRun:
                 ),
                 "target_value": self.verifier_success_token,
                 "priority": 1,
-            },
-        )
-        self.call(
-            "goal-verifier-assign",
-            "masc_goal_assign",
-            {
-                "goal_id": self.verifier_goal_id,
-                "owner": self.roles["coordinator"],
             },
         )
         for role, keeper in self.roles.items():
@@ -1903,10 +1854,17 @@ class MissionRun:
             ),
         )
         rejected_task_verdict = self.wait_for_verifier_task_verdict("in_progress")
-        self.wait_for_verifier_task_status("in_progress")
         self.writer.write_json(
             "observations/goal-verifier-task-refuted.json",
             rejected_task_verdict,
+        )
+        self.call(
+            "goal-verifier-assign",
+            "masc_goal_assign",
+            {
+                "goal_id": self.verifier_goal_id,
+                "owner": self.roles["coordinator"],
+            },
         )
         self.call(
             "goal-verifier-request-refute",
@@ -1941,7 +1899,6 @@ class MissionRun:
             ),
         )
         approved_task_verdict = self.wait_for_verifier_task_verdict("done")
-        self.wait_for_verifier_task_status("done")
         self.writer.write_json(
             "observations/goal-verifier-task-proven.json",
             approved_task_verdict,

--- a/test/test_keeper_multi_collaboration_acceptance.py
+++ b/test/test_keeper_multi_collaboration_acceptance.py
@@ -343,21 +343,40 @@ class KeeperMultiCollaborationAcceptanceTest(unittest.TestCase):
             acceptance.MissionRun.run_goal_verifier_refute_reenter_prove
         )
 
-        # The success-token Task used to be created during fleet setup and the
-        # coordinator completed it autonomously before RW23 could write the
-        # failing artifact. Keep the Task creation inside the directed RW23
-        # phase and keep the verifier Goal out of the ordinary fleet scope.
+        # The success-token Task and Goal assignment both used to be visible
+        # during fleet setup. A capable coordinator completed them autonomously
+        # before RW23 could write the failing artifact. Keep both inside the
+        # directed RW23 phase and the verifier Goal out of ordinary fleet scope.
         self.assertNotIn("goal-verifier-task-create", setup_source)
+        self.assertNotIn("goal-verifier-assign", setup_source)
         self.assertIn('"active_goal_ids": [self.goal_id]', setup_source)
         self.assertNotIn(
             '"active_goal_ids": [self.goal_id, self.verifier_goal_id]',
             setup_source,
         )
         self.assertIn("goal-verifier-task-create", rw23_source)
+        self.assertIn("goal-verifier-assign", rw23_source)
         self.assertLess(
             rw23_source.index("goal-verifier-task-create"),
             rw23_source.index("goal-verifier-refute-artifact"),
         )
+        self.assertLess(
+            rw23_source.index('wait_for_verifier_task_verdict("in_progress")'),
+            rw23_source.index("goal-verifier-assign"),
+        )
+
+    def test_rw23_uses_durable_verdict_without_parsing_board_text(self):
+        rw23_source = inspect.getsource(
+            acceptance.MissionRun.run_goal_verifier_refute_reenter_prove
+        )
+
+        # masc_tasks is a human-facing Board rendering in the live server. The
+        # verifier history event is the typed durable authority for both the
+        # rejected and approved transitions.
+        self.assertNotIn("wait_for_verifier_task_status", rw23_source)
+        self.assertEqual(rw23_source.count("wait_for_verifier_task_verdict"), 2)
+        self.assertIn('wait_for_verifier_task_verdict("in_progress")', rw23_source)
+        self.assertIn('wait_for_verifier_task_verdict("done")', rw23_source)
 
     def test_persistence_browser_validator_requires_exact_monotonic_fleet(self):
         expected = {"keeper-a", "keeper-b"}


### PR DESCRIPTION
## Summary
- remove the redundant `masc_tasks` Board-text status poll from RW23
- use durable `task_completion_verdict` events as the transition authority for rejection and approval
- defer verifier Goal ownership until the directed refutation has itself been Task-verified
- cover both autonomous-fleet race and verdict-only contracts in acceptance tests

## Evidence
- protected-main run 32464464661 emitted `task_completion_verdict` to `in_progress` with verification ID `vrf-f2f3c09c2b408db641c47c211172e62c`; `masc_tasks` returned a human-rendered Board string, so object lookup returned null
- exact-artifact heterogeneous run `hetero-386a517d01-20260821T091539Z`: early Goal assignment exposed the success path to the autonomous fleet; builder-a claimed/submitted task-009 under `vrf-63735ebee6ac45fed461c8fa69744c2d`, and the Goal reached proof_proven before directed RW23
- `python3 test/test_keeper_multi_collaboration_acceptance.py` (11/11)
- catalog validation: 23 missions / 48 assertions / A-B-C
- Python bytecode compile and `git diff --check`

Stacked on #29280.