### PR TITLE
refactor(keeper): make cache invariant identity-neutral

### DIFF
--- a/bin/gen_tool_descriptors.ml
+++ b/bin/gen_tool_descriptors.ml
@@ -335,6 +335,18 @@ let masc_broadcast_spec : tool_spec =
         ; p_description = "Broadcast body text (use @mention for specific agents)"
         ; p_required = true
         }
+      ; { p_name = "task_cache_subject_agent"
+        ; p_type = T_string { enum = None; default = None }
+        ; p_description =
+            "Optional typed cache signal: agent whose cached current task is being observed. Must be supplied together with task_cache_task_id."
+        ; p_required = false
+        }
+      ; { p_name = "task_cache_task_id"
+        ; p_type = T_string { enum = None; default = None }
+        ; p_description =
+            "Optional typed cache signal: task ID observed as active in the subject agent cache. Must be supplied together with task_cache_subject_agent."
+        ; p_required = false
+        }
       ]
   ; additional_properties = false
   ; behavior_contract =

--- a/lib/agent_core_tool_contract.ml
+++ b/lib/agent_core_tool_contract.ml
@@ -68,11 +68,19 @@ let agent_core_bindings : agent_core_tool_binding list =
         object_schema ~required:[ "content" ]
           [
             assoc_field "content" (string_prop "Broadcast body text");
+            assoc_field "task_cache_subject_agent"
+              (string_prop
+                 "Agent whose current-task cache was observed; supply together with task_cache_task_id");
+            assoc_field "task_cache_task_id"
+              (string_prop
+                 "Task ID observed in the subject agent cache; supply together with task_cache_subject_agent");
           ];
       arg_bindings =
         [
           ("agent_name", Agent_name);
           ("content", Input_field "content");
+          ("task_cache_subject_agent", Input_field "task_cache_subject_agent");
+          ("task_cache_task_id", Input_field "task_cache_task_id");
         ];
     };
     { name = "masc_heartbeat";

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -395,33 +395,19 @@ let handle_keeper_task_tool_with_outcome
             ]))
     | Broadcast ->
     let message = Safe_ops.json_string ~default:"" "content" args |> String.trim in
-    let task_cache_subject_agent =
-      Safe_ops.json_string_opt "task_cache_subject_agent" args
-      |> String_util.option_trim
-    in
-    let task_cache_task_id =
-      Safe_ops.json_string_opt "task_cache_task_id" args
-      |> String_util.option_trim
-    in
+    let task_cache_signal_result = Workspace_broadcast.task_cache_signal_of_args args in
     if message = ""
     then
       Keeper_tool_execution.failure
         ~class_:Tool_result.Policy_rejection
         (error_json "content is required. Good: content='Build complete, all tests pass.'.")
-    else if Option.is_some task_cache_subject_agent <> Option.is_some task_cache_task_id
-    then
-      Keeper_tool_execution.failure
-        ~class_:Tool_result.Policy_rejection
-        (error_json
-           "task_cache_subject_agent and task_cache_task_id must be supplied together")
     else (
-      let task_cache_signal =
-        match task_cache_subject_agent, task_cache_task_id with
-        | Some subject_agent, Some task_id ->
-          Some Workspace_broadcast.{ subject_agent; task_id }
-        | None, None -> None
-        | Some _, None | None, Some _ -> None
-      in
+      match task_cache_signal_result with
+      | Error detail ->
+        Keeper_tool_execution.failure
+          ~class_:Tool_result.Policy_rejection
+          (error_json detail)
+      | Ok task_cache_signal ->
       match
         (* A Keeper calling keeper_broadcast is speaking to the workspace,
            so this reaches every Keeper's conversation window. *)

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -395,21 +395,47 @@ let handle_keeper_task_tool_with_outcome
             ]))
     | Broadcast ->
     let message = Safe_ops.json_string ~default:"" "content" args |> String.trim in
+    let task_cache_subject_agent =
+      Safe_ops.json_string_opt "task_cache_subject_agent" args
+      |> String_util.option_trim
+    in
+    let task_cache_task_id =
+      Safe_ops.json_string_opt "task_cache_task_id" args
+      |> String_util.option_trim
+    in
     if message = ""
     then
       Keeper_tool_execution.failure
         ~class_:Tool_result.Policy_rejection
         (error_json "content is required. Good: content='Build complete, all tests pass.'.")
+    else if Option.is_some task_cache_subject_agent <> Option.is_some task_cache_task_id
+    then
+      Keeper_tool_execution.failure
+        ~class_:Tool_result.Policy_rejection
+        (error_json
+           "task_cache_subject_agent and task_cache_task_id must be supplied together")
     else (
+      let task_cache_signal =
+        match task_cache_subject_agent, task_cache_task_id with
+        | Some subject_agent, Some task_id ->
+          Some Workspace_broadcast.{ subject_agent; task_id }
+        | None, None -> None
+        | Some _, None | None, Some _ -> None
+      in
       match
         (* A Keeper calling keeper_broadcast is speaking to the workspace,
            so this reaches every Keeper's conversation window. *)
         Workspace.broadcast
+          ?task_cache_signal
           ~audience:Workspace_broadcast.Fleet_conversation
           config
           ~from_agent:(keeper_agent_sender ~meta)
           ~content:message
       with
+      | Error (Workspace_broadcast.Broadcast_policy_rejected detail) ->
+        Keeper_tool_execution.failure
+          ~class_:Tool_result.Policy_rejection
+          (error_json ("broadcast rejected: " ^ detail))
       | Error error ->
         Keeper_tool_execution.failure
           ~class_:Tool_result.Runtime_failure

--- a/lib/mcp_tool_runtime_comm.ml
+++ b/lib/mcp_tool_runtime_comm.ml
@@ -79,6 +79,13 @@ let handle_broadcast ~tool_name ~start_time (ctx : context) : tool_result option
         ~from_agent:agent_name ~content
     in
     match delivery with
+    | Error (Workspace_broadcast.Broadcast_policy_rejected detail) ->
+      Some
+        (Tool_result.error
+           ~failure_class:Tool_result.Workflow_rejection
+           ~tool_name
+           ~start_time
+           ("Broadcast rejected: " ^ detail))
     | Error error ->
       Some
         (Tool_result.error

--- a/lib/mcp_tool_runtime_comm.ml
+++ b/lib/mcp_tool_runtime_comm.ml
@@ -25,13 +25,8 @@ let handle_broadcast ~tool_name ~start_time (ctx : context) : tool_result option
   let state = ctx.state in
   let content = arg_get_string ctx "content" "" in
   let trimmed = String.trim content in
-  let task_cache_subject_agent =
-    Safe_ops.json_string_opt "task_cache_subject_agent" ctx.arguments
-    |> String_util.option_trim
-  in
-  let task_cache_task_id =
-    Safe_ops.json_string_opt "task_cache_task_id" ctx.arguments
-    |> String_util.option_trim
+  let task_cache_signal_result =
+    Workspace_broadcast.task_cache_signal_of_args ctx.arguments
   in
   if String.equal trimmed "" then
     (* RFC-0189: caller-input violation (empty broadcast content).
@@ -41,22 +36,16 @@ let handle_broadcast ~tool_name ~start_time (ctx : context) : tool_result option
             ~failure_class:Tool_result.Workflow_rejection
             ~tool_name ~start_time
             "Broadcast content cannot be empty")
-  else if Option.is_some task_cache_subject_agent <> Option.is_some task_cache_task_id
-  then
-    Some
-      (Tool_result.error
-         ~failure_class:Tool_result.Workflow_rejection
-         ~tool_name
-         ~start_time
-         "task_cache_subject_agent and task_cache_task_id must be supplied together")
   else
-  let task_cache_signal =
-    match task_cache_subject_agent, task_cache_task_id with
-    | Some subject_agent, Some task_id ->
-      Some Workspace_broadcast.{ subject_agent; task_id }
-    | None, None -> None
-    | Some _, None | None, Some _ -> None
-  in
+    match task_cache_signal_result with
+    | Error detail ->
+      Some
+        (Tool_result.error
+           ~failure_class:Tool_result.Workflow_rejection
+           ~tool_name
+           ~start_time
+           detail)
+    | Ok task_cache_signal ->
   let allowed, wait_secs = Session.check_rate_limit registry ~agent_name in
   if not allowed then
     (* RFC-0189: rate-limit hit — caller should retry after [wait_secs].

--- a/lib/mcp_tool_runtime_comm.ml
+++ b/lib/mcp_tool_runtime_comm.ml
@@ -25,6 +25,14 @@ let handle_broadcast ~tool_name ~start_time (ctx : context) : tool_result option
   let state = ctx.state in
   let content = arg_get_string ctx "content" "" in
   let trimmed = String.trim content in
+  let task_cache_subject_agent =
+    Safe_ops.json_string_opt "task_cache_subject_agent" ctx.arguments
+    |> String_util.option_trim
+  in
+  let task_cache_task_id =
+    Safe_ops.json_string_opt "task_cache_task_id" ctx.arguments
+    |> String_util.option_trim
+  in
   if String.equal trimmed "" then
     (* RFC-0189: caller-input violation (empty broadcast content).
        The producer supplies [Workflow_rejection] explicitly; body text
@@ -33,7 +41,22 @@ let handle_broadcast ~tool_name ~start_time (ctx : context) : tool_result option
             ~failure_class:Tool_result.Workflow_rejection
             ~tool_name ~start_time
             "Broadcast content cannot be empty")
+  else if Option.is_some task_cache_subject_agent <> Option.is_some task_cache_task_id
+  then
+    Some
+      (Tool_result.error
+         ~failure_class:Tool_result.Workflow_rejection
+         ~tool_name
+         ~start_time
+         "task_cache_subject_agent and task_cache_task_id must be supplied together")
   else
+  let task_cache_signal =
+    match task_cache_subject_agent, task_cache_task_id with
+    | Some subject_agent, Some task_id ->
+      Some Workspace_broadcast.{ subject_agent; task_id }
+    | None, None -> None
+    | Some _, None | None, Some _ -> None
+  in
   let allowed, wait_secs = Session.check_rate_limit registry ~agent_name in
   if not allowed then
     (* RFC-0189: rate-limit hit — caller should retry after [wait_secs].
@@ -51,6 +74,7 @@ let handle_broadcast ~tool_name ~start_time (ctx : context) : tool_result option
       (* A Keeper calling masc_broadcast is speaking to the workspace, so
          this reaches every Keeper's conversation window. *)
       Workspace.broadcast ?trace_context
+        ?task_cache_signal
         ~audience:Workspace_broadcast.Fleet_conversation config
         ~from_agent:agent_name ~content
     in

--- a/lib/tool_surface/tool_shard_types_schemas_taskboard.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_taskboard.ml
@@ -89,6 +89,22 @@ let taskboard_tools : Masc_domain.tool_schema list =
                       ; "description", `String "Broadcast body text"
                       ; "minLength", `Int 1
                       ] )
+                ; ( "task_cache_subject_agent"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "description"
+                        , `String
+                            "Agent whose current-task cache was observed; supply together with task_cache_task_id" )
+                      ; "minLength", `Int 1
+                      ] )
+                ; ( "task_cache_task_id"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "description"
+                        , `String
+                            "Task ID observed in the subject agent cache; supply together with task_cache_subject_agent" )
+                      ; "minLength", `Int 1
+                      ] )
                 ] )
           ; "required", `List [ `String "content" ]
           ]

--- a/lib/workspace/task_cache_invariant.ml
+++ b/lib/workspace/task_cache_invariant.ml
@@ -20,68 +20,124 @@
 open Masc_domain
 open Workspace_utils
 
+type fresh_task_lookup =
+  | Found of Masc_domain.task_status
+  | Absent
+  | Unavailable of string
+
 (** Read the current task status directly from the backlog (snapshot read,
-    no write lock).  Returns [None] when the task is absent or the backlog
-    cannot be read. *)
-let fresh_task_status config ~(task_id : string)
-    : Masc_domain.task_status option =
+    no write lock), preserving absence and read failure as distinct facts. *)
+let read_fresh_task_status config ~(task_id : string) : fresh_task_lookup =
   match Workspace_backlog.read_backlog_r config with
-  | Error _ -> None
+  | Error detail -> Unavailable detail
   | Ok backlog ->
-      List.find_opt
-        (fun (t : Masc_domain.task) -> String.equal t.id task_id)
-        backlog.tasks
-      |> Option.map (fun (t : Masc_domain.task) -> t.task_status)
+    (match
+       List.find_opt
+         (fun (t : Masc_domain.task) -> String.equal t.id task_id)
+         backlog.tasks
+     with
+     | Some task -> Found task.task_status
+     | None -> Absent)
+;;
+
+let fresh_task_status config ~task_id =
+  match read_fresh_task_status config ~task_id with
+  | Found status -> Some status
+  | Absent | Unavailable _ -> None
+;;
 
 (** [is_terminal status] returns [true] iff the status is [Done _] or
     [Cancelled _].  SSOT: [Masc_domain.task_status_is_terminal]. *)
 let is_terminal = Masc_domain.task_status_is_terminal
 
-(** Clear the agent's [current_task] field on disk when it equals [task_id]
-    and log a [cache_desync.cleared] diagnostic event. *)
-let clear_stale_agent_task
+let emit_cache_desync_event config ~agent_name ~task_id ~status_label ~module_name =
+  try
+    log_event config
+      (`Assoc
+        [ "type", `String "cache_desync.cleared"
+        ; "module", `String module_name
+        ; "agent", `String agent_name
+        ; "task_id", `String task_id
+        ; "backlog_status", `String status_label
+        ; "ts", `String (now_iso ())
+        ])
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Log.Misc.warn
+      "task_cache_invariant: log_event failed (%s %s): %s"
+      module_name
+      task_id
+      (Printexc.to_string exn)
+;;
+
+let agent_file config agent_name =
+  Filename.concat (agents_dir config) (safe_filename agent_name ^ ".json")
+;;
+
+let agent_current_task_matches config ~agent_name ~task_id =
+  let path = agent_file config agent_name in
+  if not (path_exists config path)
+  then false
+  else
+    with_file_lock config path (fun () ->
+      match agent_of_yojson (read_json config path) with
+      | Ok agent -> agent.current_task = Some task_id
+      | Error detail ->
+        Log.Misc.warn
+          "task_cache_invariant: agent parse failed for %s: %s"
+          agent_name
+          detail;
+        false)
+;;
+
+let clear_stale_agent_task_if_matching
       config
       ~(agent_name : string)
       ~(task_id : string)
-      ~(status : Masc_domain.task_status)
+      ~(status_label : string)
       ~(module_name : string)
-    : unit =
-  (* 1. Clear agent state on disk *)
-  let agent_file =
-    Filename.concat (agents_dir config) (safe_filename agent_name ^ ".json")
+  =
+  let path =
+    agent_file config agent_name
   in
-  if path_exists config agent_file then
-    with_file_lock config agent_file (fun () ->
-      let json = read_json config agent_file in
-      match agent_of_yojson json with
-      | Ok agent when agent.current_task = Some task_id ->
+  let cleared =
+    if not (path_exists config path)
+    then false
+    else
+      with_file_lock config path (fun () ->
+        let json = read_json config path in
+        match agent_of_yojson json with
+        | Ok agent when agent.current_task = Some task_id ->
           let updated =
             { agent with status = Masc_domain.Active; current_task = None }
           in
-          write_json config agent_file (agent_to_yojson updated)
-      | Ok _ -> ()
-      | Error msg ->
+          write_json config path (agent_to_yojson updated);
+          true
+        | Ok _ -> false
+        | Error msg ->
           Log.Misc.warn
             "task_cache_invariant: agent parse failed for %s: %s"
-            agent_name msg);
-  (* 2. Log the desync event *)
-  (try
-     log_event config
-       (`Assoc
-           [ ("type", `String "cache_desync.cleared")
-           ; ("module", `String module_name)
-           ; ("agent", `String agent_name)
-           ; ("task_id", `String task_id)
-           ; ("backlog_status",
-              `String (Masc_domain.task_status_to_string status))
-           ; ("ts", `String (now_iso ()))
-           ])
-   with
-   | Eio.Cancel.Cancelled _ as e -> raise e
-   | exn ->
-       Log.Misc.warn
-         "task_cache_invariant: log_event failed (%s %s): %s"
-         module_name task_id (Printexc.to_string exn))
+            agent_name
+            msg;
+          false)
+  in
+  if cleared
+  then emit_cache_desync_event config ~agent_name ~task_id ~status_label ~module_name;
+  cleared
+;;
+
+(** Clear the agent's [current_task] field on disk when it equals [task_id]
+    and log a [cache_desync.cleared] diagnostic event. *)
+let clear_stale_agent_task config ~agent_name ~task_id ~status ~module_name =
+  ignore
+    (clear_stale_agent_task_if_matching
+       config
+       ~agent_name
+       ~task_id
+       ~status_label:(Masc_domain.task_status_to_string status)
+       ~module_name)
+;;
 
 (** Scan every on-disk agent record and clear [current_task] when it equals
     [task_id].  Use this when the backlog no longer references the task

--- a/lib/workspace/task_cache_invariant.ml
+++ b/lib/workspace/task_cache_invariant.ml
@@ -1,21 +1,18 @@
-(** Task_cache_invariant — Fleet-wide guard against stale task-cache emissions.
+(** Task_cache_invariant — reads canonical task state and the subject's own
+    record without collapsing absence, unreadability, and disagreement into
+    one another.
 
-    Any keeper module that maintains its own task-state cache MUST call
-    [with_fresh_task_status] before emitting broadcasts, mentions, or
-    transitions tied to a specific task ID.  Callers that need finer control
-    can compose [fresh_task_status] + [is_terminal] directly.
+    Two lookups, each keeping its failure modes apart:
+      - {!read_fresh_task_status} answers what the backlog says about a task.
+      - {!agent_current_task_match} answers what one agent record caches, and
+        says so when the record could not be read at all.
 
-    If the backlog reports the task as terminal (Done / Cancelled) while
-    the caller's cache is still active the guard:
-      1. Clears [current_task] on the agent record when it matches [task_id].
-      2. Logs a [cache_desync.cleared] event with module identity.
-      3. Returns [None] so callers skip the original emission.
+    {!clear_stale_agent_task_if_matching} clears [current_task] on a matching
+    record and logs a [cache_desync.cleared] event.  Whether the caller then
+    suppresses, rejects, or reports a dependency failure is the caller's
+    decision, made on the returned variant.
 
-    The caller is responsible for emitting a single [cache_invalidated]
-    broadcast in place of the original message (typically by passing the
-    replacement content directly to [Workspace_broadcast.broadcast]).
-
-    @since #13397 — fleet-wide invariant for broadcast / mention desync. *)
+    @since #13397 — broadcast / mention desync. *)
 
 open Masc_domain
 open Workspace_utils
@@ -40,11 +37,13 @@ let read_fresh_task_status config ~(task_id : string) : fresh_task_lookup =
      | None -> Absent)
 ;;
 
-let fresh_task_status config ~task_id =
-  match read_fresh_task_status config ~task_id with
-  | Found status -> Some status
-  | Absent | Unavailable _ -> None
-;;
+(** What one agent record says about a task, with the ways the answer can be
+    unavailable kept apart from the answer itself. *)
+type agent_task_match =
+  | Matches
+  | Mismatch
+  | Missing
+  | Unreadable of string
 
 (** [is_terminal status] returns [true] iff the status is [Done _] or
     [Cancelled _].  SSOT: [Masc_domain.task_status_is_terminal]. *)
@@ -75,20 +74,18 @@ let agent_file config agent_name =
   Filename.concat (agents_dir config) (safe_filename agent_name ^ ".json")
 ;;
 
-let agent_current_task_matches config ~agent_name ~task_id =
+let agent_current_task_match config ~agent_name ~task_id =
   let path = agent_file config agent_name in
   if not (path_exists config path)
-  then false
+  then Missing
   else
     with_file_lock config path (fun () ->
-      match agent_of_yojson (read_json config path) with
-      | Ok agent -> agent.current_task = Some task_id
-      | Error detail ->
-        Log.Misc.warn
-          "task_cache_invariant: agent parse failed for %s: %s"
-          agent_name
-          detail;
-        false)
+      match read_json_result config path with
+      | Error detail -> Unreadable detail
+      | Ok json ->
+        (match agent_of_yojson json with
+         | Ok agent -> if agent.current_task = Some task_id then Matches else Mismatch
+         | Error detail -> Unreadable detail))
 ;;
 
 let clear_stale_agent_task_if_matching
@@ -101,30 +98,29 @@ let clear_stale_agent_task_if_matching
   let path =
     agent_file config agent_name
   in
-  let cleared =
+  let outcome =
     if not (path_exists config path)
-    then false
+    then Missing
     else
       with_file_lock config path (fun () ->
-        let json = read_json config path in
-        match agent_of_yojson json with
-        | Ok agent when agent.current_task = Some task_id ->
-          let updated =
-            { agent with status = Masc_domain.Active; current_task = None }
-          in
-          write_json config path (agent_to_yojson updated);
-          true
-        | Ok _ -> false
-        | Error msg ->
-          Log.Misc.warn
-            "task_cache_invariant: agent parse failed for %s: %s"
-            agent_name
-            msg;
-          false)
+        match read_json_result config path with
+        | Error detail -> Unreadable detail
+        | Ok json ->
+          (match agent_of_yojson json with
+           | Ok agent when agent.current_task = Some task_id ->
+             let updated =
+               { agent with status = Masc_domain.Active; current_task = None }
+             in
+             write_json config path (agent_to_yojson updated);
+             Matches
+           | Ok _ -> Mismatch
+           | Error detail -> Unreadable detail))
   in
-  if cleared
-  then emit_cache_desync_event config ~agent_name ~task_id ~status_label ~module_name;
-  cleared
+  (match outcome with
+   | Matches ->
+     emit_cache_desync_event config ~agent_name ~task_id ~status_label ~module_name
+   | Mismatch | Missing | Unreadable _ -> ());
+  outcome
 ;;
 
 (** Clear the agent's [current_task] field on disk when it equals [task_id]
@@ -193,37 +189,3 @@ let clear_stale_agent_task_for_task
            "task_cache_invariant: unexpected scan error (%s): %s"
            module_name
            (Printexc.to_string exn))
-
-(** Core invariant wrapper.
-
-    [with_fresh_task_status config ~agent_name ~task_id ~module_name f]
-    re-reads [task_id] from the backlog.  If the status is terminal:
-      - clears [current_task] on the agent record when it matches [task_id]
-      - logs a [cache_desync.cleared] event
-      - returns [None] — callers MUST skip the original emission and instead
-        emit a single [cache_invalidated] broadcast
-
-    If the task is still active, calls [f status] and returns [Some result].
-
-    Returns [None] when the task is not found (treat as unknown; caller decides).
-
-    @param module_name  Short ASCII label for the diagnostic log,
-    e.g. ["taskmaster.broadcast"] or ["mention_tracker.emit"]. *)
-let with_fresh_task_status
-      config
-      ~(agent_name : string)
-      ~(task_id : string)
-      ~(module_name : string)
-      (f : Masc_domain.task_status -> 'a)
-    : 'a option =
-  match fresh_task_status config ~task_id with
-  | Some status when is_terminal status ->
-      clear_stale_agent_task config ~agent_name ~task_id ~status ~module_name;
-      None
-  | Some status ->
-      Some (f status)
-  | None ->
-      (* Task not found in backlog — conservative: return None so the caller
-         treats it as though suppressed.  Callers that need to distinguish
-         "terminal" from "absent" should use [fresh_task_status] directly. *)
-      None

--- a/lib/workspace/task_cache_invariant.mli
+++ b/lib/workspace/task_cache_invariant.mli
@@ -8,8 +8,20 @@
     @since #13397 *)
 
 
-(** Read the current task status directly from the backlog.
-    Returns [None] when the task is absent or the backlog cannot be read. *)
+(** Result of reading one task from the canonical backlog. *)
+type fresh_task_lookup =
+  | Found of Masc_domain.task_status
+  | Absent
+  | Unavailable of string
+
+(** Read the current task status directly from the backlog without collapsing
+    an absent task and an unreadable canonical store. *)
+val read_fresh_task_status :
+  Workspace_utils_backend_setup.config -> task_id:string -> fresh_task_lookup
+
+(** Compatibility projection for callers that intentionally treat both
+    [Absent] and [Unavailable _] as [None]. New invariant code should use
+    {!read_fresh_task_status}. *)
 val fresh_task_status :
   Workspace_utils_backend_setup.config -> task_id:string -> Masc_domain.task_status option
 
@@ -29,6 +41,25 @@ val clear_stale_agent_task :
   status:Masc_domain.task_status ->
   module_name:string ->
   unit
+
+(** Atomically clear the subject only when its current task exactly matches
+    [task_id]. Returns [true] only after a matching record was rewritten and
+    the desynchronization event was emitted. *)
+val clear_stale_agent_task_if_matching :
+  Workspace_utils_backend_setup.config ->
+  agent_name:string ->
+  task_id:string ->
+  status_label:string ->
+  module_name:string ->
+  bool
+
+(** Check the subject's current task under its per-agent file lock. Missing,
+    malformed, or mismatched records return [false]. *)
+val agent_current_task_matches :
+  Workspace_utils_backend_setup.config ->
+  agent_name:string ->
+  task_id:string ->
+  bool
 
 (** Scan every on-disk agent record and clear [current_task] when it equals
     [task_id].  Use this when the backlog no longer references the task

--- a/lib/workspace/task_cache_invariant.mli
+++ b/lib/workspace/task_cache_invariant.mli
@@ -1,9 +1,8 @@
-(** Task_cache_invariant — Fleet-wide guard against stale task-cache emissions.
+(** Task_cache_invariant — reads canonical task state and the subject's own
+    record, keeping absence, unreadability, and disagreement apart.
 
-    Any keeper module that maintains its own task-state cache MUST use
-    [with_fresh_task_status] before emitting broadcasts, mentions, or
-    transitions tied to a specific task ID.  Callers that need finer control
-    can compose [fresh_task_status] and [is_terminal] directly.
+    Neither lookup decides what happens next: the caller reads the returned
+    variant and chooses to suppress, reject, or report a dependency failure.
 
     @since #13397 *)
 
@@ -19,11 +18,14 @@ type fresh_task_lookup =
 val read_fresh_task_status :
   Workspace_utils_backend_setup.config -> task_id:string -> fresh_task_lookup
 
-(** Compatibility projection for callers that intentionally treat both
-    [Absent] and [Unavailable _] as [None]. New invariant code should use
-    {!read_fresh_task_status}. *)
-val fresh_task_status :
-  Workspace_utils_backend_setup.config -> task_id:string -> Masc_domain.task_status option
+(** What one agent record says about a task.  [Unreadable] carries the read or
+    decode failure so a caller never reports a store it could not read as a
+    subject that disagrees. *)
+type agent_task_match =
+  | Matches
+  | Mismatch
+  | Missing
+  | Unreadable of string
 
 (** [is_terminal status] returns [true] iff [status] is [Done _] or
     [Cancelled _]. *)
@@ -43,23 +45,23 @@ val clear_stale_agent_task :
   unit
 
 (** Atomically clear the subject only when its current task exactly matches
-    [task_id]. Returns [true] only after a matching record was rewritten and
-    the desynchronization event was emitted. *)
+    [task_id]. [Matches] is returned only after the record was rewritten and
+    the desynchronization event was emitted; the other variants mean nothing
+    was written. *)
 val clear_stale_agent_task_if_matching :
   Workspace_utils_backend_setup.config ->
   agent_name:string ->
   task_id:string ->
   status_label:string ->
   module_name:string ->
-  bool
+  agent_task_match
 
-(** Check the subject's current task under its per-agent file lock. Missing,
-    malformed, or mismatched records return [false]. *)
-val agent_current_task_matches :
+(** Read the subject's current task under its per-agent file lock. *)
+val agent_current_task_match :
   Workspace_utils_backend_setup.config ->
   agent_name:string ->
   task_id:string ->
-  bool
+  agent_task_match
 
 (** Scan every on-disk agent record and clear [current_task] when it equals
     [task_id].  Use this when the backlog no longer references the task
@@ -74,21 +76,3 @@ val clear_stale_agent_task_for_task :
   status:Masc_domain.task_status ->
   module_name:string ->
   unit
-
-(** Core invariant wrapper.
-
-    [with_fresh_task_status config ~agent_name ~task_id ~module_name f]
-    verifies that [task_id] is non-terminal before calling [f].
-
-    - If the backlog shows [task_id] as terminal: clears agent state, logs the
-      desync, and returns [None].  Callers MUST skip the original emission.
-    - If the task is active: calls [f status] and returns [Some result].
-    - If the task is not found: returns [None] (conservative; callers that need
-      to distinguish terminal from absent should use [fresh_task_status] directly). *)
-val with_fresh_task_status :
-  Workspace_utils_backend_setup.config ->
-  agent_name:string ->
-  task_id:string ->
-  module_name:string ->
-  (Masc_domain.task_status -> 'a) ->
-  'a option

--- a/lib/workspace/workspace_broadcast.ml
+++ b/lib/workspace/workspace_broadcast.ml
@@ -45,6 +45,11 @@ type audience =
   | Fleet_conversation
   | System_record
 
+type task_cache_signal = Workspace_task_cache_invariant.signal =
+  { subject_agent : string
+  ; task_id : string
+  }
+
 type broadcast_delivery =
   { request_id : string
   ; seq : int
@@ -770,8 +775,8 @@ let reconcile_pending_mentions config =
   Cross_context_mutex.with_lock mention_delivery_mutex (fun () ->
     reconcile_pending_mentions_unlocked config)
 
-let broadcast_with_mention ?trace_context ~msg_type ~audience config ~from_agent
-    ~content ~pre_extract_mention ~deferred_by_predecessor =
+let broadcast_with_mention ?trace_context ~msg_type ~audience ~task_cache_signal
+    config ~from_agent ~content ~pre_extract_mention ~deferred_by_predecessor =
   let started_at = Time_compat.now () in
   let observe final_msg_type =
     let elapsed_s = Float.max 0.0 (Time_compat.now () -. started_at) in
@@ -781,34 +786,22 @@ let broadcast_with_mention ?trace_context ~msg_type ~audience config ~from_agent
   in
   ensure_initialized config;
 
-  (* Fleet-wide invariant (PR-B): if the broadcasting agent's typed
-     [current_task] is terminal in the canonical backlog, replace the original
-     broadcast and clear that stale state.  Message prose is deliberately not
-     inspected: arbitrary operator/agent text is not a cache signal. *)
+  (* Fleet-wide invariant (PR-B): only an explicitly typed producer signal can
+     identify a cache observation.  This supports observer -> assignee checks
+     without deriving authority from sender identity or message prose. *)
   let content, msg_type =
-    if String.equal msg_type "broadcast" then
-      let agent_file =
-        Filename.concat (agents_dir config) (safe_filename from_agent ^ ".json")
-      in
-      if path_exists config agent_file then
-        match agent_of_yojson (read_json config agent_file) with
-        | Ok agent -> (
-            match agent.current_task with
-            | Some task_id ->
-              (match
-                 Workspace_task_cache_invariant.rewrite_current_task
-                   ~config
-                   ~from_agent
-                   ~module_name:"workspace_broadcast"
-                   ~task_id
-                   ~content
-               with
-               | Unchanged content -> content, msg_type
-               | Invalidated content -> content, "cache_invalidated")
-            | None -> content, msg_type)
-        | Error _ -> content, msg_type
-      else content, msg_type
-    else (content, msg_type)
+    match task_cache_signal with
+    | Some signal when String.equal msg_type "broadcast" ->
+      (match
+         Workspace_task_cache_invariant.rewrite_signal
+           ~config
+           ~module_name:"workspace_broadcast"
+           ~signal
+           ~content
+       with
+       | Unchanged content -> content, msg_type
+       | Invalidated content -> content, "cache_invalidated")
+    | Some _ | None -> content, msg_type
   in
   let seq = Workspace_state.next_seq config in
   let request_id = Random_id.prefixed ~prefix:"wmsg-" ~bytes:16 in
@@ -905,8 +898,8 @@ let broadcast_with_mention ?trace_context ~msg_type ~audience config ~from_agent
      observe safe_msg_type;
      Ok { delivery with mention_delivery })
 
-let broadcast ?trace_context ?(msg_type = "broadcast") ~audience config
-      ~from_agent ~content =
+let broadcast ?trace_context ?(msg_type = "broadcast") ?task_cache_signal
+      ~audience config ~from_agent ~content =
   (* Preserve original content and extract mention tokens before any
      fleet-wide invariant rewrite. Explicit mentions share the recovery lock,
      so sequence assignment, commit, intake materialization, and wake request
@@ -918,6 +911,7 @@ let broadcast ?trace_context ?(msg_type = "broadcast") ~audience config
       ?trace_context
       ~msg_type
       ~audience
+      ~task_cache_signal
       config
       ~from_agent
       ~content

--- a/lib/workspace/workspace_broadcast.ml
+++ b/lib/workspace/workspace_broadcast.ml
@@ -781,10 +781,10 @@ let broadcast_with_mention ?trace_context ~msg_type ~audience config ~from_agent
   in
   ensure_initialized config;
 
-  (* Fleet-wide invariant (PR-B): if the broadcasting agent's current_task is
-     terminal in the backlog, replace the original broadcast with a single
-     cache_invalidated notice and clear the stale state (issue #13397).
-     Only applied to regular "broadcast" messages to avoid recursion. *)
+  (* Fleet-wide invariant (PR-B): if the broadcasting agent's typed
+     [current_task] is terminal in the canonical backlog, replace the original
+     broadcast and clear that stale state.  Message prose is deliberately not
+     inspected: arbitrary operator/agent text is not a cache signal. *)
   let content, msg_type =
     if String.equal msg_type "broadcast" then
       let agent_file =
@@ -794,37 +794,20 @@ let broadcast_with_mention ?trace_context ~msg_type ~audience config ~from_agent
         match agent_of_yojson (read_json config agent_file) with
         | Ok agent -> (
             match agent.current_task with
-            | Some task_id -> (
-                match Task_cache_invariant.fresh_task_status config ~task_id with
-                | Some status when Task_cache_invariant.is_terminal status ->
-                    Task_cache_invariant.clear_stale_agent_task config
-                      ~agent_name:from_agent ~task_id ~status
-                      ~module_name:"workspace_broadcast";
-                    let inv_content =
-                      Printf.sprintf
-                        "[cache_invalidated] workspace_broadcast: task %s is %s \
-                         — stale broadcast suppressed"
-                        task_id (Masc_domain.task_status_to_string status)
-                    in
-                    (inv_content, "cache_invalidated")
-                | _ ->
-                    ( Workspace_task_cache_invariant.rewrite_broadcast_content
-                        ~config ~from_agent ~module_name:"workspace_broadcast"
-                        ~content,
-                      msg_type ))
-            | None ->
-                ( Workspace_task_cache_invariant.rewrite_broadcast_content
-                    ~config ~from_agent ~module_name:"workspace_broadcast"
-                    ~content,
-                  msg_type ))
-        | Error _ ->
-            ( Workspace_task_cache_invariant.rewrite_broadcast_content
-                ~config ~from_agent ~module_name:"workspace_broadcast" ~content,
-              msg_type )
-      else
-        ( Workspace_task_cache_invariant.rewrite_broadcast_content
-            ~config ~from_agent ~module_name:"workspace_broadcast" ~content,
-          msg_type )
+            | Some task_id ->
+              (match
+                 Workspace_task_cache_invariant.rewrite_current_task
+                   ~config
+                   ~from_agent
+                   ~module_name:"workspace_broadcast"
+                   ~task_id
+                   ~content
+               with
+               | Unchanged content -> content, msg_type
+               | Invalidated content -> content, "cache_invalidated")
+            | None -> content, msg_type)
+        | Error _ -> content, msg_type
+      else content, msg_type
     else (content, msg_type)
   in
   let seq = Workspace_state.next_seq config in

--- a/lib/workspace/workspace_broadcast.ml
+++ b/lib/workspace/workspace_broadcast.ml
@@ -55,6 +55,18 @@ type task_cache_signal = Workspace_task_cache_invariant.signal =
   ; task_id : string
   }
 
+let task_cache_signal_partial_error =
+  "task_cache_subject_agent and task_cache_task_id must be supplied together"
+;;
+
+let task_cache_signal_of_args args =
+  let field name = Safe_ops.json_string_opt name args |> String_util.option_trim in
+  match field "task_cache_subject_agent", field "task_cache_task_id" with
+  | None, None -> Ok None
+  | Some subject_agent, Some task_id -> Ok (Some { subject_agent; task_id })
+  | Some _, None | None, Some _ -> Error task_cache_signal_partial_error
+;;
+
 type broadcast_delivery =
   { request_id : string
   ; seq : int
@@ -782,20 +794,30 @@ let reconcile_pending_mentions config =
 
 let rewrite_task_cache_signal config ~msg_type ~task_cache_signal ~content =
   match task_cache_signal with
-  | Some signal when String.equal msg_type "broadcast" ->
-    (match
-       Workspace_task_cache_invariant.rewrite_signal
-         ~config
-         ~module_name:"workspace_broadcast"
-         ~signal
-         ~content
-     with
-     | Unchanged content -> Ok (content, msg_type)
-     | Invalidated content -> Ok (content, "cache_invalidated")
-     | Rejected detail -> Error (Broadcast_policy_rejected detail)
-     | Dependency_unavailable detail ->
-       Error (Broadcast_dependency_unavailable detail))
-  | Some _ | None -> Ok (content, msg_type)
+  | None -> Ok (content, msg_type)
+  | Some signal ->
+    if not (String.equal msg_type "broadcast")
+    then
+      (* Only a broadcast carries the invalidation replacement, so accepting a
+         signal here would drop it after the caller was told it was applied. *)
+      Error
+        (Broadcast_policy_rejected
+           (Printf.sprintf
+              "task cache signal is carried by a broadcast, not by %s"
+              msg_type))
+    else (
+      match
+        Workspace_task_cache_invariant.rewrite_signal
+          ~config
+          ~module_name:"workspace_broadcast"
+          ~signal
+          ~content
+      with
+      | Unchanged content -> Ok (content, msg_type)
+      | Invalidated content -> Ok (content, "cache_invalidated")
+      | Rejected detail -> Error (Broadcast_policy_rejected detail)
+      | Dependency_unavailable detail ->
+        Error (Broadcast_dependency_unavailable detail))
 ;;
 
 let broadcast_with_mention ?trace_context ~msg_type ~audience

--- a/lib/workspace/workspace_broadcast.ml
+++ b/lib/workspace/workspace_broadcast.ml
@@ -6,10 +6,15 @@
 open Masc_domain
 open Workspace_utils
 
-type broadcast_error = Broadcast_not_persisted of string
+type broadcast_error =
+  | Broadcast_not_persisted of string
+  | Broadcast_policy_rejected of string
+  | Broadcast_dependency_unavailable of string
 
 let broadcast_error_to_string = function
-  | Broadcast_not_persisted detail -> detail
+  | Broadcast_not_persisted detail
+  | Broadcast_policy_rejected detail
+  | Broadcast_dependency_unavailable detail -> detail
 ;;
 
 type mention_delivery_deferred =
@@ -775,7 +780,25 @@ let reconcile_pending_mentions config =
   Cross_context_mutex.with_lock mention_delivery_mutex (fun () ->
     reconcile_pending_mentions_unlocked config)
 
-let broadcast_with_mention ?trace_context ~msg_type ~audience ~task_cache_signal
+let rewrite_task_cache_signal config ~msg_type ~task_cache_signal ~content =
+  match task_cache_signal with
+  | Some signal when String.equal msg_type "broadcast" ->
+    (match
+       Workspace_task_cache_invariant.rewrite_signal
+         ~config
+         ~module_name:"workspace_broadcast"
+         ~signal
+         ~content
+     with
+     | Unchanged content -> Ok (content, msg_type)
+     | Invalidated content -> Ok (content, "cache_invalidated")
+     | Rejected detail -> Error (Broadcast_policy_rejected detail)
+     | Dependency_unavailable detail ->
+       Error (Broadcast_dependency_unavailable detail))
+  | Some _ | None -> Ok (content, msg_type)
+;;
+
+let broadcast_with_mention ?trace_context ~msg_type ~audience
     config ~from_agent ~content ~pre_extract_mention ~deferred_by_predecessor =
   let started_at = Time_compat.now () in
   let observe final_msg_type =
@@ -786,23 +809,6 @@ let broadcast_with_mention ?trace_context ~msg_type ~audience ~task_cache_signal
   in
   ensure_initialized config;
 
-  (* Fleet-wide invariant (PR-B): only an explicitly typed producer signal can
-     identify a cache observation.  This supports observer -> assignee checks
-     without deriving authority from sender identity or message prose. *)
-  let content, msg_type =
-    match task_cache_signal with
-    | Some signal when String.equal msg_type "broadcast" ->
-      (match
-         Workspace_task_cache_invariant.rewrite_signal
-           ~config
-           ~module_name:"workspace_broadcast"
-           ~signal
-           ~content
-       with
-       | Unchanged content -> content, msg_type
-       | Invalidated content -> content, "cache_invalidated")
-    | Some _ | None -> content, msg_type
-  in
   let seq = Workspace_state.next_seq config in
   let request_id = Random_id.prefixed ~prefix:"wmsg-" ~bytes:16 in
   let mention = pre_extract_mention in
@@ -900,41 +906,45 @@ let broadcast_with_mention ?trace_context ~msg_type ~audience ~task_cache_signal
 
 let broadcast ?trace_context ?(msg_type = "broadcast") ?task_cache_signal
       ~audience config ~from_agent ~content =
+  ensure_initialized config;
   (* Preserve original content and extract mention tokens before any
      fleet-wide invariant rewrite. Explicit mentions share the recovery lock,
      so sequence assignment, commit, intake materialization, and wake request
      cannot overtake an older explicit mention. Passive fanout remains
      unsynchronized. *)
   let pre_extract_mention = Mention.extract content in
-  let run deferred_by_predecessor =
-    broadcast_with_mention
-      ?trace_context
-      ~msg_type
-      ~audience
-      ~task_cache_signal
-      config
-      ~from_agent
-      ~content
-      ~pre_extract_mention
-      ~deferred_by_predecessor
-  in
-  match pre_extract_mention with
-  | None -> run None
-  | Some target ->
-    Cross_context_mutex.with_lock mention_delivery_mutex (fun () ->
-      let deferred_by_predecessor =
-        match reconcile_pending_mentions_unlocked config with
-        | Error detail ->
-          Log.Misc.error
-            "workspace mention predecessor reconciliation unavailable target=%s: %s"
-            target detail;
-          Some Recovery_unavailable
-        | Ok report ->
-          if report.global_barrier || List.mem target report.blocked_targets
-          then Some Predecessor_pending
-          else None
-      in
-      run deferred_by_predecessor)
+  match rewrite_task_cache_signal config ~msg_type ~task_cache_signal ~content with
+  | Error _ as error -> error
+  | Ok (content, msg_type) ->
+    let run deferred_by_predecessor =
+      broadcast_with_mention
+        ?trace_context
+        ~msg_type
+        ~audience
+        config
+        ~from_agent
+        ~content
+        ~pre_extract_mention
+        ~deferred_by_predecessor
+    in
+    (match pre_extract_mention with
+     | None -> run None
+     | Some target ->
+       Cross_context_mutex.with_lock mention_delivery_mutex (fun () ->
+         let deferred_by_predecessor =
+           match reconcile_pending_mentions_unlocked config with
+           | Error detail ->
+             Log.Misc.error
+               "workspace mention predecessor reconciliation unavailable target=%s: %s"
+               target
+               detail;
+             Some Recovery_unavailable
+           | Ok report ->
+             if report.global_barrier || List.mem target report.blocked_targets
+             then Some Predecessor_pending
+             else None
+         in
+         run deferred_by_predecessor))
 
 module For_testing = struct
   let replace_on_broadcast_mention handler =

--- a/lib/workspace/workspace_broadcast.mli
+++ b/lib/workspace/workspace_broadcast.mli
@@ -2,7 +2,10 @@
     accompanying message-activity event. *)
 
 
-type broadcast_error = Broadcast_not_persisted of string
+type broadcast_error =
+  | Broadcast_not_persisted of string
+  | Broadcast_policy_rejected of string
+  | Broadcast_dependency_unavailable of string
 
 val broadcast_error_to_string : broadcast_error -> string
 

--- a/lib/workspace/workspace_broadcast.mli
+++ b/lib/workspace/workspace_broadcast.mli
@@ -37,6 +37,11 @@ type audience =
   | Fleet_conversation
   | System_record
 
+type task_cache_signal =
+  { subject_agent : string
+  ; task_id : string
+  }
+
 type broadcast_delivery =
   { request_id : string
   ; seq : int
@@ -131,6 +136,7 @@ val broadcast_delivery_to_yojson : broadcast_delivery -> Yojson.Safe.t
 
 val broadcast : ?trace_context:string ->
            ?msg_type:string ->
+           ?task_cache_signal:task_cache_signal ->
            audience:audience ->
            Workspace_utils_backend_setup.config ->
            from_agent:string -> content:string ->

--- a/lib/workspace/workspace_broadcast.mli
+++ b/lib/workspace/workspace_broadcast.mli
@@ -45,6 +45,13 @@ type task_cache_signal =
   ; task_id : string
   }
 
+val task_cache_signal_of_args :
+  Yojson.Safe.t -> (task_cache_signal option, string) result
+(** Read [task_cache_subject_agent] and [task_cache_task_id] out of a tool
+    call. Both blank or absent is [Ok None]; one without the other is an
+    [Error] carrying the message the caller reports, so every tool surface
+    rejects a half-given signal in the same words. *)
+
 type broadcast_delivery =
   { request_id : string
   ; seq : int

--- a/lib/workspace/workspace_core.ml
+++ b/lib/workspace/workspace_core.ml
@@ -161,15 +161,13 @@ let clear_agent_current_task_cache config ~task_id =
       agent_files)
 ;;
 
-(* #13460: cache desync invalidation counter. Workspace_broadcast emits this when
-   it replaces an active-claim/release message for a terminal backlog task with
-   a cache_invalidated broadcast.  Clear workspace-owned current_task caches so the
-   same stale claim does not re-emit every taskmaster cycle.  Keep labels
-   fleet-bounded; the task id stays in the replacement message/event, not the
-   Otel_metric_store series key. *)
-let record_cache_desync_cleared config ~module_name:_ ~task_id ~status =
-  if not (String.equal status "backlog_unavailable")
-  then clear_agent_current_task_cache config ~task_id
+(* #13460: fires only after a broadcast replaced a message about a task the
+   canonical backlog reports as terminal or absent. A backlog the reader could
+   not open never reaches here — it fails the broadcast instead — so every
+   call means the task really is over and the workspace-owned current_task
+   caches for it can go. *)
+let record_cache_desync_cleared config ~module_name:_ ~task_id ~status:_ =
+  clear_agent_current_task_cache config ~task_id
 ;;
 
 let () = Atomic.set Workspace_hooks.cache_desync_cleared_fn record_cache_desync_cleared

--- a/lib/workspace/workspace_task_cache_invariant.ml
+++ b/lib/workspace/workspace_task_cache_invariant.ml
@@ -1,29 +1,35 @@
-(** Guard an agent-owned task cache against canonical backlog state. *)
+(** Guard an explicitly declared task-cache signal against canonical backlog state. *)
+
+type signal =
+  { subject_agent : string
+  ; task_id : string
+  }
 
 type rewrite =
   | Unchanged of string
   | Invalidated of string
 
-let rewrite_current_task ~config ~from_agent ~module_name ~task_id ~content =
-  match Task_cache_invariant.fresh_task_status config ~task_id with
+let rewrite_signal ~config ~module_name ~signal ~content =
+  match Task_cache_invariant.fresh_task_status config ~task_id:signal.task_id with
   | Some status when Task_cache_invariant.is_terminal status ->
     Task_cache_invariant.clear_stale_agent_task
       config
-      ~agent_name:from_agent
-      ~task_id
+      ~agent_name:signal.subject_agent
+      ~task_id:signal.task_id
       ~status
       ~module_name;
     (Atomic.get Workspace_hooks.cache_desync_cleared_fn)
       config
       ~module_name
-      ~task_id
+      ~task_id:signal.task_id
       ~status:(Masc_domain.task_status_to_string status);
     Invalidated
       (Printf.sprintf
-         "[cache_invalidated] %s: task %s is %s \
+         "[cache_invalidated] %s: %s cached task %s as active, but it is %s \
           — stale broadcast suppressed"
          module_name
-         task_id
+         signal.subject_agent
+         signal.task_id
          (Masc_domain.task_status_to_string status))
   | Some _ | None -> Unchanged content
 ;;

--- a/lib/workspace/workspace_task_cache_invariant.ml
+++ b/lib/workspace/workspace_task_cache_invariant.ml
@@ -27,11 +27,6 @@ let string_contains = String_util.contains_substring
 
 let string_starts_with = String.starts_with
 
-let trusted_cache_signal_sender from_agent =
-  String.lowercase_ascii from_agent |> fun value ->
-  string_contains value "taskmaster"
-;;
-
 let extract_task_ids content =
   Re.all (Lazy.force task_ref_re) content
   |> List.map (fun group -> Re.Group.get group 0)
@@ -155,7 +150,6 @@ let record_backlog_unavailable ~config ~module_name task_ids =
 
 let rewrite_broadcast_content ~config ~from_agent ~module_name ~content =
   if string_starts_with ~prefix:"[cache_invalidated]" (String.trim content)
-     || not (trusted_cache_signal_sender from_agent)
   then content
   else
     match check_cache_signal ~config ~content with

--- a/lib/workspace/workspace_task_cache_invariant.ml
+++ b/lib/workspace/workspace_task_cache_invariant.ml
@@ -29,51 +29,67 @@ let reject_mismatch signal =
        signal.task_id)
 ;;
 
+let reject_missing_subject signal =
+  Rejected
+    (Printf.sprintf
+       "task cache signal rejected: subject %s has no agent record"
+       signal.subject_agent)
+;;
+
+let subject_unreadable signal detail =
+  Dependency_unavailable
+    (Printf.sprintf
+       "task cache signal subject record unreadable for %s: %s"
+       signal.subject_agent
+       detail)
+;;
+
+(* Clearing and reporting are the same decision on both terminal and absent
+   canonical state, so they read one match. An unreadable subject record is a
+   failure to look, never a subject that disagrees. *)
+let clear_and_report ~config ~module_name ~signal ~status_label =
+  match
+    Task_cache_invariant.clear_stale_agent_task_if_matching
+      config
+      ~agent_name:signal.subject_agent
+      ~task_id:signal.task_id
+      ~status_label
+      ~module_name
+  with
+  | Task_cache_invariant.Matches ->
+    (Atomic.get Workspace_hooks.cache_desync_cleared_fn)
+      config
+      ~module_name
+      ~task_id:signal.task_id
+      ~status:status_label;
+    Invalidated (invalidated_content ~module_name ~signal ~status_label)
+  | Task_cache_invariant.Mismatch -> reject_mismatch signal
+  | Task_cache_invariant.Missing -> reject_missing_subject signal
+  | Task_cache_invariant.Unreadable detail -> subject_unreadable signal detail
+;;
+
 let rewrite_signal ~config ~module_name ~signal ~content =
   match Task_cache_invariant.read_fresh_task_status config ~task_id:signal.task_id with
   | Task_cache_invariant.Unavailable detail ->
     Dependency_unavailable
       (Printf.sprintf "task cache signal canonical backlog unavailable: %s" detail)
   | Task_cache_invariant.Found status when Task_cache_invariant.is_terminal status ->
-    let status_label = Masc_domain.task_status_to_string status in
-    if
-      Task_cache_invariant.clear_stale_agent_task_if_matching
-        config
-        ~agent_name:signal.subject_agent
-        ~task_id:signal.task_id
-        ~status_label
-        ~module_name
-    then (
-      (Atomic.get Workspace_hooks.cache_desync_cleared_fn)
-        config
-        ~module_name
-        ~task_id:signal.task_id
-        ~status:status_label;
-      Invalidated (invalidated_content ~module_name ~signal ~status_label))
-    else reject_mismatch signal
+    clear_and_report
+      ~config
+      ~module_name
+      ~signal
+      ~status_label:(Masc_domain.task_status_to_string status)
   | Task_cache_invariant.Found _ ->
-    if
-      Task_cache_invariant.agent_current_task_matches
-        config
-        ~agent_name:signal.subject_agent
-        ~task_id:signal.task_id
-    then Unchanged content
-    else reject_mismatch signal
+    (match
+       Task_cache_invariant.agent_current_task_match
+         config
+         ~agent_name:signal.subject_agent
+         ~task_id:signal.task_id
+     with
+     | Task_cache_invariant.Matches -> Unchanged content
+     | Task_cache_invariant.Mismatch -> reject_mismatch signal
+     | Task_cache_invariant.Missing -> reject_missing_subject signal
+     | Task_cache_invariant.Unreadable detail -> subject_unreadable signal detail)
   | Task_cache_invariant.Absent ->
-    let status_label = "absent" in
-    if
-      Task_cache_invariant.clear_stale_agent_task_if_matching
-        config
-        ~agent_name:signal.subject_agent
-        ~task_id:signal.task_id
-        ~status_label
-        ~module_name
-    then (
-      (Atomic.get Workspace_hooks.cache_desync_cleared_fn)
-        config
-        ~module_name
-        ~task_id:signal.task_id
-        ~status:status_label;
-      Invalidated (invalidated_content ~module_name ~signal ~status_label))
-    else reject_mismatch signal
+    clear_and_report ~config ~module_name ~signal ~status_label:"absent"
 ;;

--- a/lib/workspace/workspace_task_cache_invariant.ml
+++ b/lib/workspace/workspace_task_cache_invariant.ml
@@ -1,163 +1,29 @@
-(** Guard task-state cache emissions against terminal backlog truth. *)
+(** Guard an agent-owned task cache against canonical backlog state. *)
 
-open Masc_domain
+type rewrite =
+  | Unchanged of string
+  | Invalidated of string
 
-type stale_terminal_task = {
-  task_id : string;
-  status : string;
-  actor : string;
-}
-
-type cache_signal_check =
-  | No_cache_signal
-  | No_terminal_task
-  | Backlog_unavailable of {
-      task_ids : string list;
-      error : string;
-    }
-  | Terminal_tasks of stale_terminal_task list
-
-let task_ref_re = lazy (Re.Pcre.re "\\btask-[0-9]+\\b" |> Re.compile)
-let invalidation_memory_ttl_s = Masc_time_constants.hour
-let invalidation_memory : (string, float) Hashtbl.t = Hashtbl.create 64
-let invalidation_memory_lock = Mutex.create ()
-
-let string_contains = String_util.contains_substring
-;;
-
-let string_starts_with = String.starts_with
-
-let extract_task_ids content =
-  Re.all (Lazy.force task_ref_re) content
-  |> List.map (fun group -> Re.Group.get group 0)
-  |> List.sort_uniq String.compare
-;;
-
-let active_cache_language_present content =
-  let lower = String.lowercase_ascii content in
-  List.exists
-    (string_contains lower)
-    [
-      "active-claim";
-      "cache desync";
-      "stale claim";
-      "current_task_id";
-      "still claimed";
-      "still lists";
-      "please release";
-      "task-state cache";
-    ]
-;;
-
-let check_cache_signal ~config ~content =
-  let task_ids = extract_task_ids content in
-  if task_ids = [] || not (active_cache_language_present content)
-  then No_cache_signal
-  else
-    match Workspace_backlog.read_backlog_r config with
-    | Error msg ->
-      Log.Misc.warn "task cache invariant: backlog read failed before broadcast: %s" msg;
-      Backlog_unavailable { task_ids; error = msg }
-    | Ok backlog ->
-      let task_by_id =
-        List.filter_map
-          (fun (task : task) ->
-             if List.mem task.id task_ids && task_status_is_terminal task.task_status
-             then
-               Some
-                 {
-                   task_id = task.id;
-                   status = task_status_to_string task.task_status;
-                   actor = task_display_assignee task.task_status;
-                 }
-             else None)
-          backlog.tasks
-      in
-      let stale_tasks =
-        List.sort
-          (fun left right -> String.compare left.task_id right.task_id)
-          task_by_id
-      in
-      if stale_tasks = [] then No_terminal_task else Terminal_tasks stale_tasks
-;;
-
-let invalidation_message ~from_agent stale_tasks =
-  let task_summary =
-    stale_tasks
-    |> List.map (fun task ->
-      Printf.sprintf "%s=%s by %s" task.task_id task.status task.actor)
-    |> String.concat ", "
-  in
-  Printf.sprintf
-    "[cache_invalidated] skipped stale task-state broadcast from %s: %s is \
-     terminal in backlog; original cached-claim message was not emitted."
-    from_agent
-    task_summary
-;;
-
-let backlog_unavailable_message ~from_agent task_ids =
-  Printf.sprintf
-    "[cache_invalidated] skipped unverifiable task-state broadcast from %s: \
-     backlog read failed while checking %s; original active-claim message was \
-     not emitted."
-    from_agent
-    (String.concat ", " task_ids)
-;;
-
-let remember_invalidation ~module_name ~task_id ~status =
-  let key = String.concat "\x00" [ module_name; task_id; status ] in
-  let now = Time_compat.now () in
-  Mutex.protect invalidation_memory_lock
-    (fun () ->
-       Hashtbl.filter_map_inplace
-         (fun _ ts ->
-            if now -. ts > invalidation_memory_ttl_s then None else Some ts)
-         invalidation_memory;
-       let first_seen = not (Hashtbl.mem invalidation_memory key) in
-       Hashtbl.replace invalidation_memory key now;
-       first_seen)
-;;
-
-let record_cache_desync_cleared ~config ~module_name stale_tasks =
-  List.iter
-    (fun task ->
-       if remember_invalidation ~module_name ~task_id:task.task_id ~status:task.status
-       then
-         (Atomic.get Workspace_hooks.cache_desync_cleared_fn)
-           config
-           ~module_name
-           ~task_id:task.task_id
-           ~status:task.status)
-    stale_tasks
-;;
-
-let record_backlog_unavailable ~config ~module_name task_ids =
-  List.iter
-    (fun task_id ->
-       if
-         remember_invalidation
-           ~module_name
-           ~task_id
-           ~status:"backlog_unavailable"
-       then
-         (Atomic.get Workspace_hooks.cache_desync_cleared_fn)
-           config
-           ~module_name
-           ~task_id
-           ~status:"backlog_unavailable")
-    task_ids
-;;
-
-let rewrite_broadcast_content ~config ~from_agent ~module_name ~content =
-  if string_starts_with ~prefix:"[cache_invalidated]" (String.trim content)
-  then content
-  else
-    match check_cache_signal ~config ~content with
-    | No_cache_signal | No_terminal_task -> content
-    | Backlog_unavailable { task_ids; error = _ } ->
-      record_backlog_unavailable ~config ~module_name task_ids;
-      backlog_unavailable_message ~from_agent task_ids
-    | Terminal_tasks stale_tasks ->
-      record_cache_desync_cleared ~config ~module_name stale_tasks;
-      invalidation_message ~from_agent stale_tasks
+let rewrite_current_task ~config ~from_agent ~module_name ~task_id ~content =
+  match Task_cache_invariant.fresh_task_status config ~task_id with
+  | Some status when Task_cache_invariant.is_terminal status ->
+    Task_cache_invariant.clear_stale_agent_task
+      config
+      ~agent_name:from_agent
+      ~task_id
+      ~status
+      ~module_name;
+    (Atomic.get Workspace_hooks.cache_desync_cleared_fn)
+      config
+      ~module_name
+      ~task_id
+      ~status:(Masc_domain.task_status_to_string status);
+    Invalidated
+      (Printf.sprintf
+         "[cache_invalidated] %s: task %s is %s \
+          — stale broadcast suppressed"
+         module_name
+         task_id
+         (Masc_domain.task_status_to_string status))
+  | Some _ | None -> Unchanged content
 ;;

--- a/lib/workspace/workspace_task_cache_invariant.ml
+++ b/lib/workspace/workspace_task_cache_invariant.ml
@@ -8,28 +8,72 @@ type signal =
 type rewrite =
   | Unchanged of string
   | Invalidated of string
+  | Rejected of string
+  | Dependency_unavailable of string
+
+let invalidated_content ~module_name ~signal ~status_label =
+  Printf.sprintf
+    "[cache_invalidated] %s: %s cached task %s as active, but canonical state is %s \
+     — stale broadcast suppressed"
+    module_name
+    signal.subject_agent
+    signal.task_id
+    status_label
+;;
+
+let reject_mismatch signal =
+  Rejected
+    (Printf.sprintf
+       "task cache signal rejected: subject %s does not currently cache task %s"
+       signal.subject_agent
+       signal.task_id)
+;;
 
 let rewrite_signal ~config ~module_name ~signal ~content =
-  match Task_cache_invariant.fresh_task_status config ~task_id:signal.task_id with
-  | Some status when Task_cache_invariant.is_terminal status ->
-    Task_cache_invariant.clear_stale_agent_task
-      config
-      ~agent_name:signal.subject_agent
-      ~task_id:signal.task_id
-      ~status
-      ~module_name;
-    (Atomic.get Workspace_hooks.cache_desync_cleared_fn)
-      config
-      ~module_name
-      ~task_id:signal.task_id
-      ~status:(Masc_domain.task_status_to_string status);
-    Invalidated
-      (Printf.sprintf
-         "[cache_invalidated] %s: %s cached task %s as active, but it is %s \
-          — stale broadcast suppressed"
-         module_name
-         signal.subject_agent
-         signal.task_id
-         (Masc_domain.task_status_to_string status))
-  | Some _ | None -> Unchanged content
+  match Task_cache_invariant.read_fresh_task_status config ~task_id:signal.task_id with
+  | Task_cache_invariant.Unavailable detail ->
+    Dependency_unavailable
+      (Printf.sprintf "task cache signal canonical backlog unavailable: %s" detail)
+  | Task_cache_invariant.Found status when Task_cache_invariant.is_terminal status ->
+    let status_label = Masc_domain.task_status_to_string status in
+    if
+      Task_cache_invariant.clear_stale_agent_task_if_matching
+        config
+        ~agent_name:signal.subject_agent
+        ~task_id:signal.task_id
+        ~status_label
+        ~module_name
+    then (
+      (Atomic.get Workspace_hooks.cache_desync_cleared_fn)
+        config
+        ~module_name
+        ~task_id:signal.task_id
+        ~status:status_label;
+      Invalidated (invalidated_content ~module_name ~signal ~status_label))
+    else reject_mismatch signal
+  | Task_cache_invariant.Found _ ->
+    if
+      Task_cache_invariant.agent_current_task_matches
+        config
+        ~agent_name:signal.subject_agent
+        ~task_id:signal.task_id
+    then Unchanged content
+    else reject_mismatch signal
+  | Task_cache_invariant.Absent ->
+    let status_label = "absent" in
+    if
+      Task_cache_invariant.clear_stale_agent_task_if_matching
+        config
+        ~agent_name:signal.subject_agent
+        ~task_id:signal.task_id
+        ~status_label
+        ~module_name
+    then (
+      (Atomic.get Workspace_hooks.cache_desync_cleared_fn)
+        config
+        ~module_name
+        ~task_id:signal.task_id
+        ~status:status_label;
+      Invalidated (invalidated_content ~module_name ~signal ~status_label))
+    else reject_mismatch signal
 ;;

--- a/lib/workspace/workspace_task_cache_invariant.mli
+++ b/lib/workspace/workspace_task_cache_invariant.mli
@@ -1,13 +1,17 @@
-(** Guard an agent-owned task cache against canonical backlog state. *)
+(** Guard an explicitly declared task-cache signal against canonical backlog state. *)
+
+type signal =
+  { subject_agent : string
+  ; task_id : string
+  }
 
 type rewrite =
   | Unchanged of string
   | Invalidated of string
 
-val rewrite_current_task :
+val rewrite_signal :
   config:Workspace_utils_backend_setup.config ->
-  from_agent:string ->
   module_name:string ->
-  task_id:string ->
+  signal:signal ->
   content:string ->
   rewrite

--- a/lib/workspace/workspace_task_cache_invariant.mli
+++ b/lib/workspace/workspace_task_cache_invariant.mli
@@ -8,6 +8,8 @@ type signal =
 type rewrite =
   | Unchanged of string
   | Invalidated of string
+  | Rejected of string
+  | Dependency_unavailable of string
 
 val rewrite_signal :
   config:Workspace_utils_backend_setup.config ->

--- a/lib/workspace/workspace_task_cache_invariant.mli
+++ b/lib/workspace/workspace_task_cache_invariant.mli
@@ -1,8 +1,13 @@
-(** Guard stale task-cache broadcasts against canonical backlog state. *)
+(** Guard an agent-owned task cache against canonical backlog state. *)
 
-val rewrite_broadcast_content :
+type rewrite =
+  | Unchanged of string
+  | Invalidated of string
+
+val rewrite_current_task :
   config:Workspace_utils_backend_setup.config ->
   from_agent:string ->
   module_name:string ->
+  task_id:string ->
   content:string ->
-  string
+  rewrite

--- a/scripts/fixtures/keeper-operation-real-e2e/AGENT.md
+++ b/scripts/fixtures/keeper-operation-real-e2e/AGENT.md
@@ -1,0 +1,2 @@
+You are the isolated Keeper fixture for the dashboard operations E2E harness.
+Follow only the operation requested by the harness and report its exact result.

--- a/scripts/fixtures/keeper-operation-real-e2e/keeper.toml
+++ b/scripts/fixtures/keeper-operation-real-e2e/keeper.toml
@@ -1,0 +1,4 @@
+[keeper]
+autoboot_enabled = true
+sandbox_profile = "docker"
+network_mode = "inherit"

--- a/scripts/harness_dashboard_keeper_operations_real_e2e.sh
+++ b/scripts/harness_dashboard_keeper_operations_real_e2e.sh
@@ -32,11 +32,12 @@ trap cleanup EXIT
 
 harness_seed_server_config "${ROOT_DIR}" "${BASE_PATH}"
 cp \
-  "${ROOT_DIR}/config/keepers/taskmaster.toml" \
+  "${ROOT_DIR}/scripts/fixtures/keeper-operation-real-e2e/keeper.toml" \
   "${BASE_PATH}/.masc/config/keepers/${KEEPER_NAME}.toml"
-cp -R \
-  "${ROOT_DIR}/config/keepers/taskmaster" \
-  "${BASE_PATH}/.masc/config/keepers/${KEEPER_NAME}"
+mkdir -p "${BASE_PATH}/.masc/config/keepers/${KEEPER_NAME}"
+cp \
+  "${ROOT_DIR}/scripts/fixtures/keeper-operation-real-e2e/AGENT.md" \
+  "${BASE_PATH}/.masc/config/keepers/${KEEPER_NAME}/AGENT.md"
 mkdir -p "${BASE_PATH}/.masc/keepers"
 cp \
   "${ROOT_DIR}/scripts/fixtures/keeper-operation-real-e2e/meta.json" \

--- a/test/test_keeper_task_outcomes.ml
+++ b/test/test_keeper_task_outcomes.ml
@@ -68,6 +68,132 @@ let test_task_create_without_goal_id_is_unscoped () =
        | tasks ->
            failf "expected exactly one persisted task, got %d" (List.length tasks))
 
+let test_keeper_broadcast_forwards_typed_cache_signal () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_path in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       let meta = keeper_meta () in
+       ignore
+         (Masc.Workspace.bind_session
+            config
+            ~agent_name:meta.agent_name
+            ~capabilities:[ "test" ]
+            ());
+       let subject = Masc.Workspace.resolve_agent_name config meta.agent_name in
+       ignore
+         (Masc.Workspace.add_task
+            config
+            ~title:"Terminal cache fixture"
+            ~priority:1
+            ~description:"");
+       ignore (Masc.Workspace.claim_task config ~agent_name:subject ~task_id:"task-001");
+       let backlog = Workspace_backlog.read_backlog_r config |> Result.get_ok in
+       let terminal_backlog =
+         { backlog with
+           tasks =
+             List.map
+               (fun (task : Masc_domain.task) ->
+                  if String.equal task.id "task-001"
+                  then
+                    { task with
+                      task_status =
+                        Masc_domain.Done
+                          { assignee = subject
+                          ; completed_at = "2026-08-22T00:00:00Z"
+                          ; notes = Some "keeper broadcast cache fixture"
+                          }
+                    }
+                  else task)
+               backlog.tasks
+         }
+       in
+       Workspace_backlog.write_backlog config terminal_backlog;
+       let agent_file =
+         Filename.concat
+           (Masc.Workspace.agents_dir config)
+           (Masc.Workspace.safe_filename subject ^ ".json")
+       in
+       let stale_agent =
+         match
+           Masc.Workspace.read_json config agent_file
+           |> Masc_domain.agent_of_yojson
+         with
+         | Ok agent ->
+           { agent with
+             status = Masc_domain.Busy
+           ; current_task = Some "task-001"
+           }
+         | Error detail -> fail ("fixture agent decode failed: " ^ detail)
+       in
+       Masc.Workspace.write_json
+         config
+         agent_file
+         (Masc_domain.agent_to_yojson stale_agent);
+       let execution =
+         Task.handle_keeper_task_tool_with_outcome
+           ~config
+           ~meta
+           ~name:"keeper_broadcast"
+           ~args:
+             (`Assoc
+               [ "content", `String "typed stale cache observation"
+               ; "task_cache_subject_agent", `String subject
+               ; "task_cache_task_id", `String "task-001"
+               ])
+       in
+       (match execution.disposition with
+        | Tool_result.Completed () -> ()
+        | Tool_result.Deferred () -> fail "keeper broadcast was deferred"
+        | Tool_result.Failed _ ->
+          fail ("keeper broadcast failed: " ^ execution.raw_output));
+       check bool
+         "keeper surface persists canonical cache invalidation"
+         true
+         (String_util.contains_substring
+            execution.raw_output
+            "[cache_invalidated]");
+       let current_task =
+         Option.bind
+           (Masc.Workspace.get_agents_raw config
+            |> List.find_opt (fun (agent : Masc_domain.agent) ->
+              String.equal agent.name subject))
+           (fun agent -> agent.current_task)
+       in
+       check (option string) "keeper surface clears exact stale cache" None current_task)
+
+let test_keeper_broadcast_rejects_partial_typed_cache_signal () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_path in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       let execution =
+         Task.handle_keeper_task_tool_with_outcome
+           ~config
+           ~meta:(keeper_meta ())
+           ~name:"keeper_broadcast"
+           ~args:
+             (`Assoc
+               [ "content", `String "partial typed signal"
+               ; "task_cache_subject_agent", `String "subject"
+               ])
+       in
+       (match execution.disposition with
+        | Tool_result.Failed Tool_result.Policy_rejection -> ()
+        | Tool_result.Failed _ -> fail "partial pair used the wrong failure class"
+        | Tool_result.Completed () | Tool_result.Deferred () ->
+          fail "partial typed cache pair was accepted");
+       check bool
+         "partial pair error names both fields"
+         true
+         (String_util.contains_substring
+            execution.raw_output
+            "task_cache_subject_agent and task_cache_task_id"))
+
 (* A page is not the backlog. The sort keys on priority alone and is stable, so
    within one priority the newest task sits last and falls off [limit] first.
    Eight tasks registered at priority 2 and 3 stayed invisible across nineteen
@@ -581,6 +707,10 @@ let () =
             "keeper_tasks_list reports a truncated page"
             `Quick
             test_tasks_list_reports_truncation
+        ; test_case "keeper_broadcast forwards typed cache signal" `Quick
+            test_keeper_broadcast_forwards_typed_cache_signal
+        ; test_case "keeper_broadcast rejects partial typed cache signal" `Quick
+            test_keeper_broadcast_rejects_partial_typed_cache_signal
         ; test_case
             "keeper_tasks_list returns snapshot and unchanged"
             `Quick

--- a/test/test_task_cache_invariant_13397.ml
+++ b/test/test_task_cache_invariant_13397.ml
@@ -1,10 +1,9 @@
-(** #13397: Pin the pure [Task_cache_invariant] classifier and verify the
-    core invariant logic.
+(** #13397: Pin the pure [Task_cache_invariant] classifier and the canonical
+    backlog lookup.
 
-    [is_terminal] must correctly classify all six task status variants.
-    [with_fresh_task_status] must return [None] for terminal tasks and
-    [Some _] for active tasks, while [fresh_task_status] must read the
-    backlog and return the live status. *)
+    [is_terminal] must correctly classify all six task status variants, and
+    [read_fresh_task_status] must keep an absent task apart from a backlog it
+    could not read. *)
 
 open Alcotest
 module T = Masc_domain
@@ -57,7 +56,7 @@ let test_is_terminal_awaiting () =
     (TCI.is_terminal status_awaiting)
 
 (* ============================================================ *)
-(* with_fresh_task_status — requires a live backlog             *)
+(* read_fresh_task_status — requires a live backlog             *)
 (* ============================================================ *)
 
 (** Minimal Eio + temp-dir test harness, borrowed from test_task_dispatch. *)
@@ -106,31 +105,6 @@ let seed_backlog config task =
   in
   Workspace_backlog.write_backlog config backlog
 
-let test_fresh_status_done () =
-  with_temp_config (fun config ->
-    let _ = Masc.Workspace.init config ~agent_name:(Some "tester") in
-    seed_backlog config (make_task ~id:"task-037" ~status:status_done);
-    let result = TCI.fresh_task_status config ~task_id:"task-037" in
-    check bool "done task status found" true (Option.is_some result);
-    check bool "done task is_terminal" true
-      (Option.value ~default:T.Todo result |> TCI.is_terminal))
-
-let test_fresh_status_active () =
-  with_temp_config (fun config ->
-    let _ = Masc.Workspace.init config ~agent_name:(Some "tester") in
-    seed_backlog config (make_task ~id:"task-038" ~status:status_claimed);
-    let result = TCI.fresh_task_status config ~task_id:"task-038" in
-    check bool "claimed task status found" true (Option.is_some result);
-    check bool "claimed task is not terminal" false
-      (Option.value ~default:T.Todo result |> TCI.is_terminal))
-
-let test_fresh_status_missing () =
-  with_temp_config (fun config ->
-    let _ = Masc.Workspace.init config ~agent_name:(Some "tester") in
-    seed_backlog config (make_task ~id:"task-001" ~status:T.Todo);
-    let result = TCI.fresh_task_status config ~task_id:"task-999" in
-    check bool "absent task returns None" true (Option.is_none result))
-
 let test_typed_fresh_status_missing () =
   with_temp_config (fun config ->
     let _ = Masc.Workspace.init config ~agent_name:(Some "tester") in
@@ -148,35 +122,6 @@ let test_typed_fresh_status_unavailable () =
     | TCI.Absent -> fail "missing backlog was collapsed into task absence"
     | TCI.Found _ -> fail "missing backlog unexpectedly returned a task")
 
-let test_with_fresh_terminal_returns_none () =
-  with_temp_config (fun config ->
-    let _ = Masc.Workspace.init config ~agent_name:(Some "tester") in
-    seed_backlog config (make_task ~id:"task-102" ~status:status_done);
-    let result =
-      TCI.with_fresh_task_status config
-        ~agent_name:"keeper-executor-agent"
-        ~task_id:"task-102"
-        ~module_name:"test.mention_tracker"
-        (fun _ -> `should_not_run)
-    in
-    check bool "terminal task → None (skip emission)" true
-      (Option.is_none result))
-
-let test_with_fresh_active_calls_continuation () =
-  with_temp_config (fun config ->
-    let _ = Masc.Workspace.init config ~agent_name:(Some "tester") in
-    seed_backlog config (make_task ~id:"task-050" ~status:status_claimed);
-    let called = ref false in
-    let result =
-      TCI.with_fresh_task_status config
-        ~agent_name:"keeper-bob-agent"
-        ~task_id:"task-050"
-        ~module_name:"test.broadcast"
-        (fun _status -> called := true; `proceed)
-    in
-    check bool "active task → continuation called" true !called;
-    check bool "active task → Some result" true (Option.is_some result))
-
 (* ============================================================ *)
 (* Test runner                                                  *)
 (* ============================================================ *)
@@ -193,22 +138,10 @@ let () =
         ; test_case "AwaitingVerification is not terminal" `Quick
             test_is_terminal_awaiting
         ] )
-    ; ( "fresh_task_status"
-      , [ test_case "done task found and terminal" `Quick
-            test_fresh_status_done
-        ; test_case "claimed task found and non-terminal" `Quick
-            test_fresh_status_active
-        ; test_case "absent task returns None" `Quick
-            test_fresh_status_missing
-        ; test_case "typed lookup preserves task absence" `Quick
+    ; ( "read_fresh_task_status"
+      , [ test_case "typed lookup preserves task absence" `Quick
             test_typed_fresh_status_missing
         ; test_case "typed lookup preserves backlog failure" `Quick
             test_typed_fresh_status_unavailable
-        ] )
-    ; ( "with_fresh_task_status"
-      , [ test_case "terminal task returns None (skip)" `Quick
-            test_with_fresh_terminal_returns_none
-        ; test_case "active task calls continuation" `Quick
-            test_with_fresh_active_calls_continuation
         ] )
     ]

--- a/test/test_task_cache_invariant_13397.ml
+++ b/test/test_task_cache_invariant_13397.ml
@@ -131,6 +131,23 @@ let test_fresh_status_missing () =
     let result = TCI.fresh_task_status config ~task_id:"task-999" in
     check bool "absent task returns None" true (Option.is_none result))
 
+let test_typed_fresh_status_missing () =
+  with_temp_config (fun config ->
+    let _ = Masc.Workspace.init config ~agent_name:(Some "tester") in
+    seed_backlog config (make_task ~id:"task-001" ~status:T.Todo);
+    match TCI.read_fresh_task_status config ~task_id:"task-999" with
+    | TCI.Absent -> ()
+    | TCI.Found _ -> fail "absent task was reported as found"
+    | TCI.Unavailable detail ->
+      failf "readable backlog was reported unavailable: %s" detail)
+
+let test_typed_fresh_status_unavailable () =
+  with_temp_config (fun config ->
+    match TCI.read_fresh_task_status config ~task_id:"task-999" with
+    | TCI.Unavailable _ -> ()
+    | TCI.Absent -> fail "missing backlog was collapsed into task absence"
+    | TCI.Found _ -> fail "missing backlog unexpectedly returned a task")
+
 let test_with_fresh_terminal_returns_none () =
   with_temp_config (fun config ->
     let _ = Masc.Workspace.init config ~agent_name:(Some "tester") in
@@ -183,6 +200,10 @@ let () =
             test_fresh_status_active
         ; test_case "absent task returns None" `Quick
             test_fresh_status_missing
+        ; test_case "typed lookup preserves task absence" `Quick
+            test_typed_fresh_status_missing
+        ; test_case "typed lookup preserves backlog failure" `Quick
+            test_typed_fresh_status_unavailable
         ] )
     ; ( "with_fresh_task_status"
       , [ test_case "terminal task returns None (skip)" `Quick

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -208,6 +208,25 @@ let test_masc_broadcast_schema () =
       | Some props ->
           Alcotest.(check bool) "has agent_name" true (List.mem_assoc "agent_name" props);
           Alcotest.(check bool) "has content" true (List.mem_assoc "content" props);
+          Alcotest.(check bool)
+            "has typed cache subject"
+            true
+            (List.mem_assoc "task_cache_subject_agent" props);
+          Alcotest.(check bool)
+            "has typed cache task"
+            true
+            (List.mem_assoc "task_cache_task_id" props);
+          (match get_json_list "required" schema.input_schema with
+           | Some required ->
+             Alcotest.(check bool)
+               "typed cache subject is optional"
+               false
+               (List.mem (`String "task_cache_subject_agent") required);
+             Alcotest.(check bool)
+               "typed cache task is optional"
+               false
+               (List.mem (`String "task_cache_task_id") required)
+           | None -> Alcotest.fail "masc_broadcast missing required field");
           (* The body is named "content" on every surface that carries it —
              board post, surface post, file write, and this tool's own result
              payload. A stray "message" here is the fork that cost a keeper

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -235,6 +235,64 @@ let test_masc_broadcast_schema () =
             (List.mem_assoc "message" props)
       | None -> Alcotest.fail "masc_broadcast missing properties"
 
+let test_broadcast_cache_signal_reaches_keeper_and_agent_core_surfaces () =
+  let assert_optional_pair label schema =
+    match get_json_assoc "properties" schema with
+    | None -> Alcotest.fail (label ^ " missing properties")
+    | Some props ->
+      Alcotest.(check bool)
+        (label ^ " has typed cache subject")
+        true
+        (List.mem_assoc "task_cache_subject_agent" props);
+      Alcotest.(check bool)
+        (label ^ " has typed cache task")
+        true
+        (List.mem_assoc "task_cache_task_id" props)
+  in
+  let keeper_schema =
+    Tool_shard_types.taskboard_tools
+    |> List.find_opt (fun (schema : Masc_domain.tool_schema) ->
+      String.equal schema.name "keeper_broadcast")
+  in
+  (match keeper_schema with
+   | None -> Alcotest.fail "keeper_broadcast schema missing"
+   | Some schema -> assert_optional_pair "keeper_broadcast" schema.input_schema);
+  let binding =
+    Masc.Agent_core_tool_contract.agent_core_binding_by_name "masc_broadcast"
+  in
+  (match binding with
+   | None -> Alcotest.fail "agent-core masc_broadcast binding missing"
+   | Some binding -> assert_optional_pair "agent-core masc_broadcast" binding.input_schema);
+  let arguments =
+    `Assoc
+      [ "content", `String "typed cache observation"
+      ; "task_cache_subject_agent", `String "subject"
+      ; "task_cache_task_id", `String "task-123"
+      ]
+  in
+  match
+    Masc.Agent_core_tool_contract.resolve_requested_tool_call
+      ~agent_name:"observer"
+      ~requested_name:"masc_broadcast"
+      ~arguments
+  with
+  | Error detail -> Alcotest.fail ("agent-core broadcast projection failed: " ^ detail)
+  | Ok (operation, `Assoc projected) ->
+    Alcotest.(check string) "canonical broadcast operation" "masc_broadcast" operation;
+    Alcotest.(check (option string))
+      "agent-core preserves typed cache subject"
+      (Some "subject")
+      (Option.bind
+         (List.assoc_opt "task_cache_subject_agent" projected)
+         (function `String value -> Some value | _ -> None));
+    Alcotest.(check (option string))
+      "agent-core preserves typed cache task"
+      (Some "task-123")
+      (Option.bind
+         (List.assoc_opt "task_cache_task_id" projected)
+         (function `String value -> Some value | _ -> None))
+  | Ok (_, _) -> Alcotest.fail "agent-core broadcast projection is not an object"
+
 let test_masc_transition_schema () =
   match find_registered_tool "masc_transition" with
   | None -> Alcotest.fail "masc_transition not found"
@@ -703,6 +761,8 @@ let () =
       Alcotest.test_case "masc_start" `Quick test_masc_start_schema;
       Alcotest.test_case "masc_status" `Quick test_masc_status_schema;
       Alcotest.test_case "masc_broadcast" `Quick test_masc_broadcast_schema;
+      Alcotest.test_case "broadcast cache signal surfaces" `Quick
+        test_broadcast_cache_signal_reaches_keeper_and_agent_core_surfaces;
       Alcotest.test_case "masc_transition" `Quick test_masc_transition_schema;
       Alcotest.test_case "masc_run schemas share SSOT" `Quick
         test_masc_run_schemas_share_ssot;

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -443,6 +443,27 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
     (Some "task-002")
     (current_task_for subject);
 
+  (* A subject record we cannot decode is a failure to look, not a subject
+     that disagrees. Rejecting it would tell a correct observer its report was
+     wrong and leave the stale cache in place. *)
+  let readable_subject_json = Workspace.read_json config agent_file in
+  Workspace.write_json config agent_file (`String "not an agent record");
+  let unreadable_result =
+    Workspace.broadcast
+      ~task_cache_signal:{ subject_agent = subject; task_id = "task-002" }
+      ~audience:Workspace_broadcast.System_record
+      config
+      ~from_agent:observer
+      ~content:"typed signal whose subject record cannot be decoded"
+  in
+  Alcotest.(check bool)
+    "an undecodable subject record reports a dependency failure"
+    true
+    (match unreadable_result with
+     | Error (Workspace_broadcast.Broadcast_dependency_unavailable _) -> true
+     | Error _ | Ok _ -> false);
+  Workspace.write_json config agent_file readable_subject_json;
+
   let normal_update =
     "Normal update: blocked by task-001 while I wait for review context."
   in

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -373,6 +373,76 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
     None
     (current_task_for observer);
 
+  let before_rejected =
+    Workspace.get_all_messages_raw config ~since_seq:0 |> List.length
+  in
+  let rejected =
+    Workspace.broadcast
+      ~task_cache_signal:{ subject_agent = subject; task_id = "task-001" }
+      ~audience:Workspace_broadcast.System_record
+      config
+      ~from_agent:observer
+      ~content:"typed signal without a matching subject cache"
+  in
+  Alcotest.(check bool)
+    "mismatched subject cache is rejected"
+    true
+    (match rejected with
+     | Error (Workspace_broadcast.Broadcast_policy_rejected _) -> true
+     | Error _ | Ok _ -> false);
+  Alcotest.(check int)
+    "rejected typed signal is not persisted"
+    before_rejected
+    (Workspace.get_all_messages_raw config ~since_seq:0 |> List.length);
+
+  let absent_agent =
+    match Workspace.read_json config agent_file |> Masc_domain.agent_of_yojson with
+    | Ok agent ->
+      { agent with status = Masc_domain.Busy; current_task = Some "task-ghost" }
+    | Error msg -> Alcotest.fail ("agent parse failed: " ^ msg)
+  in
+  Workspace.write_json config agent_file (Masc_domain.agent_to_yojson absent_agent);
+  let absent_result =
+    Workspace.broadcast
+      ~task_cache_signal:{ subject_agent = subject; task_id = "task-ghost" }
+      ~audience:Workspace_broadcast.System_record
+      config
+      ~from_agent:observer
+      ~content:"typed signal for a task absent from the canonical backlog"
+    |> Result.get_ok
+  in
+  Alcotest.(check bool)
+    "absent canonical task invalidates an exact subject cache"
+    true
+    (str_contains absent_result.content "[cache_invalidated]");
+  Alcotest.(check (option string))
+    "absent canonical task cache is cleared"
+    None
+    (current_task_for subject);
+
+  let _ =
+    Workspace.add_task config ~title:"Active task" ~priority:1 ~description:""
+  in
+  let _ = Workspace.claim_task config ~agent_name:subject ~task_id:"task-002" in
+  let active_content = "typed signal for a still-active canonical task" in
+  let active_result =
+    Workspace.broadcast
+      ~task_cache_signal:{ subject_agent = subject; task_id = "task-002" }
+      ~audience:Workspace_broadcast.System_record
+      config
+      ~from_agent:observer
+      ~content:active_content
+    |> Result.get_ok
+  in
+  Alcotest.(check string)
+    "active exact subject cache is preserved"
+    active_content
+    active_result.content;
+  Alcotest.(check (option string))
+    "active exact subject cache remains owned"
+    (Some "task-002")
+    (current_task_for subject);
+
   let normal_update =
     "Normal update: blocked by task-001 while I wait for review context."
   in

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -267,13 +267,18 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
     in
     Option.bind agent_opt (fun (agent : Masc_domain.agent) -> agent.current_task)
   in
-  let _ = Workspace.init config ~agent_name:(Some "fixture-keeper") in
+  let _ = Workspace.init config ~agent_name:(Some "fixture-agent") in
+  let broadcaster =
+    match Workspace.get_agents_raw config with
+    | [ agent ] -> agent.Masc_domain.name
+    | _ -> Alcotest.fail "expected exactly one bound broadcaster"
+  in
   let _ = Workspace.add_task config ~title:"Terminal task" ~priority:1 ~description:"" in
-  let _ = Workspace.claim_task config ~agent_name:"nick0cave" ~task_id:"task-001" in
+  let _ = Workspace.claim_task config ~agent_name:broadcaster ~task_id:"task-001" in
   (match
      transition_done_r
        config
-       ~agent_name:"nick0cave"
+       ~agent_name:broadcaster
        ~task_id:"task-001"
        ~notes:"terminal in backlog"
    with
@@ -288,7 +293,20 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
   Alcotest.(check (option string))
     "assignee current_task already cleared before invariant"
     None
-    (current_task_for "nick0cave");
+    (current_task_for broadcaster);
+
+  let agent_file =
+    Filename.concat
+      (Workspace.agents_dir config)
+      (Workspace.safe_filename broadcaster ^ ".json")
+  in
+  let stale_agent =
+    match Workspace.read_json config agent_file |> Masc_domain.agent_of_yojson with
+    | Ok agent ->
+      { agent with status = Masc_domain.Busy; current_task = Some "task-001" }
+    | Error msg -> Alcotest.fail ("agent parse failed: " ^ msg)
+  in
+  Workspace.write_json config agent_file (Masc_domain.agent_to_yojson stale_agent);
 
   let stale_message =
     "@nick0cave task-001 stale claim detected: current_task_id=null but \
@@ -299,7 +317,7 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
     |> List.fold_left (fun acc msg -> max acc msg.Masc_domain.seq) 0
   in
   let result =
-    Workspace.broadcast ~audience:Workspace_broadcast.System_record config ~from_agent:"fixture-keeper-jade-heron" ~content:stale_message
+    Workspace.broadcast ~audience:Workspace_broadcast.System_record config ~from_agent:broadcaster ~content:stale_message
     |> Result.get_ok
   in
   Alcotest.(check bool)
@@ -316,7 +334,7 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
     result.mention;
   Alcotest.(check string)
     "delivery exposes the canonical persisted sender"
-    "fixture-keeper-jade-heron"
+    broadcaster
     result.from_agent;
   let messages = Workspace.get_all_messages_raw config ~since_seq in
   (match messages with
@@ -328,19 +346,19 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
      Alcotest.(check bool)
        "replacement cites terminal task"
        true
-       (str_contains msg.content "task-001=done")
+       (str_contains msg.content "task task-001 is done")
    | msgs ->
      Alcotest.failf "expected one replacement message, got %d" (List.length msgs));
   Alcotest.(check (option string))
     "stale current_task cleared"
     None
-    (current_task_for "nick0cave");
+    (current_task_for broadcaster);
 
   let normal_update =
     "Normal update: blocked by task-001 while I wait for review context."
   in
   let normal_result =
-    Workspace.broadcast ~audience:Workspace_broadcast.System_record config ~from_agent:"fixture-keeper-jade-heron" ~content:normal_update
+    Workspace.broadcast ~audience:Workspace_broadcast.System_record config ~from_agent:broadcaster ~content:normal_update
     |> Result.get_ok
   in
   Alcotest.(check bool)
@@ -351,10 +369,10 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
     Workspace.broadcast ~audience:Workspace_broadcast.System_record config ~from_agent:"operator" ~content:stale_message
     |> Result.get_ok
   in
-  Alcotest.(check bool)
-    "sender identity does not bypass terminal-task truth"
-    true
-    (str_contains operator_result.rendered "[cache_invalidated]");
+  Alcotest.(check string)
+    "untyped operator prose is preserved"
+    stale_message
+    operator_result.content;
 
   let _ = Workspace.reset config in
   Unix.rmdir tmp_dir

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -267,18 +267,26 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
     in
     Option.bind agent_opt (fun (agent : Masc_domain.agent) -> agent.current_task)
   in
-  let _ = Workspace.init config ~agent_name:(Some "fixture-agent") in
-  let broadcaster =
+  let _ = Workspace.init config ~agent_name:(Some "fixture-observer") in
+  let observer =
     match Workspace.get_agents_raw config with
     | [ agent ] -> agent.Masc_domain.name
-    | _ -> Alcotest.fail "expected exactly one bound broadcaster"
+    | _ -> Alcotest.fail "expected exactly one bound observer"
   in
+  let _ =
+    Workspace.bind_session
+      config
+      ~agent_name:"fixture-subject"
+      ~capabilities:[ "test" ]
+      ()
+  in
+  let subject = Workspace.resolve_agent_name config "fixture-subject" in
   let _ = Workspace.add_task config ~title:"Terminal task" ~priority:1 ~description:"" in
-  let _ = Workspace.claim_task config ~agent_name:broadcaster ~task_id:"task-001" in
+  let _ = Workspace.claim_task config ~agent_name:subject ~task_id:"task-001" in
   (match
      transition_done_r
        config
-       ~agent_name:broadcaster
+       ~agent_name:subject
        ~task_id:"task-001"
        ~notes:"terminal in backlog"
    with
@@ -293,12 +301,12 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
   Alcotest.(check (option string))
     "assignee current_task already cleared before invariant"
     None
-    (current_task_for broadcaster);
+    (current_task_for subject);
 
   let agent_file =
     Filename.concat
       (Workspace.agents_dir config)
-      (Workspace.safe_filename broadcaster ^ ".json")
+      (Workspace.safe_filename subject ^ ".json")
   in
   let stale_agent =
     match Workspace.read_json config agent_file |> Masc_domain.agent_of_yojson with
@@ -309,15 +317,22 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
   Workspace.write_json config agent_file (Masc_domain.agent_to_yojson stale_agent);
 
   let stale_message =
-    "@nick0cave task-001 stale claim detected: current_task_id=null but \
-     MASC still lists task-001 as claimed by you. Please release it."
+    Printf.sprintf
+      "@%s task-001 stale claim detected: current_task_id=null but the cache \
+       still lists task-001 as active."
+      subject
   in
   let since_seq =
     Workspace.get_all_messages_raw config ~since_seq:0
     |> List.fold_left (fun acc msg -> max acc msg.Masc_domain.seq) 0
   in
   let result =
-    Workspace.broadcast ~audience:Workspace_broadcast.System_record config ~from_agent:broadcaster ~content:stale_message
+    Workspace.broadcast
+      ~task_cache_signal:{ subject_agent = subject; task_id = "task-001" }
+      ~audience:Workspace_broadcast.System_record
+      config
+      ~from_agent:observer
+      ~content:stale_message
     |> Result.get_ok
   in
   Alcotest.(check bool)
@@ -330,11 +345,11 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
     (str_contains result.content "[cache_invalidated]");
   Alcotest.(check (option string))
     "delivery preserves the original mention"
-    (Some "nick0cave")
+    (Some subject)
     result.mention;
   Alcotest.(check string)
     "delivery exposes the canonical persisted sender"
-    broadcaster
+    observer
     result.from_agent;
   let messages = Workspace.get_all_messages_raw config ~since_seq in
   (match messages with
@@ -342,37 +357,45 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
      Alcotest.(check bool)
        "original stale text omitted"
        false
-       (str_contains msg.content "Please release");
+       (str_contains msg.content "still lists task-001 as active");
      Alcotest.(check bool)
        "replacement cites terminal task"
        true
-       (str_contains msg.content "task task-001 is done")
+       (str_contains msg.content (subject ^ " cached task task-001 as active"))
    | msgs ->
      Alcotest.failf "expected one replacement message, got %d" (List.length msgs));
   Alcotest.(check (option string))
     "stale current_task cleared"
     None
-    (current_task_for broadcaster);
+    (current_task_for subject);
+  Alcotest.(check (option string))
+    "observer has no task cache ownership"
+    None
+    (current_task_for observer);
 
   let normal_update =
     "Normal update: blocked by task-001 while I wait for review context."
   in
   let normal_result =
-    Workspace.broadcast ~audience:Workspace_broadcast.System_record config ~from_agent:broadcaster ~content:normal_update
+    Workspace.broadcast ~audience:Workspace_broadcast.System_record config ~from_agent:observer ~content:normal_update
     |> Result.get_ok
   in
   Alcotest.(check bool)
     "normal task mention is not invalidated"
     false
     (str_contains normal_result.rendered "[cache_invalidated]");
-  let operator_result =
-    Workspace.broadcast ~audience:Workspace_broadcast.System_record config ~from_agent:"operator" ~content:stale_message
+  let untyped_result =
+    Workspace.broadcast
+      ~audience:Workspace_broadcast.System_record
+      config
+      ~from_agent:observer
+      ~content:stale_message
     |> Result.get_ok
   in
   Alcotest.(check string)
-    "untyped operator prose is preserved"
+    "same observer prose without a typed signal is preserved"
     stale_message
-    operator_result.content;
+    untyped_result.content;
 
   let _ = Workspace.reset config in
   Unix.rmdir tmp_dir

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -267,7 +267,7 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
     in
     Option.bind agent_opt (fun (agent : Masc_domain.agent) -> agent.current_task)
   in
-  let _ = Workspace.init config ~agent_name:(Some "taskmaster") in
+  let _ = Workspace.init config ~agent_name:(Some "fixture-keeper") in
   let _ = Workspace.add_task config ~title:"Terminal task" ~priority:1 ~description:"" in
   let _ = Workspace.claim_task config ~agent_name:"nick0cave" ~task_id:"task-001" in
   (match
@@ -299,7 +299,7 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
     |> List.fold_left (fun acc msg -> max acc msg.Masc_domain.seq) 0
   in
   let result =
-    Workspace.broadcast ~audience:Workspace_broadcast.System_record config ~from_agent:"taskmaster-jade-heron" ~content:stale_message
+    Workspace.broadcast ~audience:Workspace_broadcast.System_record config ~from_agent:"fixture-keeper-jade-heron" ~content:stale_message
     |> Result.get_ok
   in
   Alcotest.(check bool)
@@ -316,7 +316,7 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
     result.mention;
   Alcotest.(check string)
     "delivery exposes the canonical persisted sender"
-    "taskmaster-jade-heron"
+    "fixture-keeper-jade-heron"
     result.from_agent;
   let messages = Workspace.get_all_messages_raw config ~since_seq in
   (match messages with
@@ -340,7 +340,7 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
     "Normal update: blocked by task-001 while I wait for review context."
   in
   let normal_result =
-    Workspace.broadcast ~audience:Workspace_broadcast.System_record config ~from_agent:"taskmaster-jade-heron" ~content:normal_update
+    Workspace.broadcast ~audience:Workspace_broadcast.System_record config ~from_agent:"fixture-keeper-jade-heron" ~content:normal_update
     |> Result.get_ok
   in
   Alcotest.(check bool)
@@ -352,8 +352,8 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
     |> Result.get_ok
   in
   Alcotest.(check bool)
-    "non-taskmaster stale-looking prose is not invalidated"
-    false
+    "sender identity does not bypass terminal-task truth"
+    true
     (str_contains operator_result.rendered "[cache_invalidated]");
 
   let _ = Workspace.reset config in

--- a/test/test_workspace_messages_raw.ml
+++ b/test/test_workspace_messages_raw.ml
@@ -212,6 +212,10 @@ let test_failed_authoritative_write_suppresses_fanout () =
              "typed write failure"
              "injected authoritative failure"
              detail
+         | Error error ->
+           Alcotest.failf
+             "write failure used the wrong error variant: %s"
+             (Workspace.broadcast_error_to_string error)
          | Ok _ -> Alcotest.fail "failed write reported a committed broadcast");
         Alcotest.(check int) "backend publication suppressed" 0 !publications;
         Alcotest.(check int) "activity suppressed" 0 !activities;


### PR DESCRIPTION
Split from #29271.

Scope:
- remove the TaskMaster-name check from terminal task-cache invalidation
- apply the same persisted task truth to every sender
- make the dashboard Keeper operations E2E use an isolated fixture instead of operator-owned TaskMaster config

Validation:
- OCaml @check PASS
- Workspace focused test PASS
- CI target audit PASS (380 declared / 516 unwired baseline)
- harness shell syntax PASS

This PR intentionally excludes retry policy removal, concrete-name mass anonymization, and the rejected name blacklist gate.