### PR TITLE
refactor(dashboard): remove retryability inference

### DIFF
--- a/dashboard/src/api/board-moderation.ts
+++ b/dashboard/src/api/board-moderation.ts
@@ -1,4 +1,4 @@
-import { get, post, withRetries } from './core'
+import { get, post, runRequest } from './core'
 import {
   asBoolean,
   asInt,
@@ -159,7 +159,7 @@ export function normalizeBoardModerationAuditEntry(raw: unknown): BoardModeratio
 export async function fetchBoardModerationQueue(
   options: { resolved?: boolean; signal?: AbortSignal } = {},
 ): Promise<BoardModerationQueue> {
-  return withRetries('fetchBoardModerationQueue', async () => {
+  return runRequest('fetchBoardModerationQueue', async () => {
     const params = new URLSearchParams()
     if (typeof options.resolved === 'boolean') {
       params.set('resolved', options.resolved ? 'true' : 'false')

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -1,4 +1,4 @@
-import { currentDashboardActor, get, post, del, put, withRetries, defaultBoardVoter } from './core'
+import { currentDashboardActor, get, post, del, put, runRequest, defaultBoardVoter } from './core'
 import { isRecord, asNullableString, asString, asNumber, asInt, asStringList } from '../components/common/normalize'
 import { normalizePendingConfirmation } from '../pending-confirm'
 import { timeBoardRequest } from '../board-metrics'
@@ -961,7 +961,7 @@ export async function fetchBoard(
     blindVotes?: boolean
   },
 ): Promise<{ posts: BoardPost[] }> {
-  return timeBoardRequest('list', () => withRetries('fetchBoard', async () => {
+  return timeBoardRequest('list', () => runRequest('fetchBoard', async () => {
     const params = new URLSearchParams()
     if (sortBy) params.set('sort_by', sortBy)
     if (options?.excludeSystem) params.set('exclude_system', 'true')
@@ -984,7 +984,7 @@ export async function fetchBoardHearths(options: {
   excludeSystem?: boolean
   excludeAutomation?: boolean
 } = {}): Promise<BoardHearth[]> {
-  return withRetries('fetchBoardHearths', async () => {
+  return runRequest('fetchBoardHearths', async () => {
     const params = new URLSearchParams()
     if (options.excludeSystem) params.set('exclude_system', 'true')
     if (options.excludeAutomation) params.set('exclude_automation', 'true')
@@ -997,7 +997,7 @@ export async function fetchBoardHearths(options: {
 }
 
 export async function fetchBoardFlairs(): Promise<BoardFlair[]> {
-  return withRetries('fetchBoardFlairs', async () => {
+  return runRequest('fetchBoardFlairs', async () => {
     const raw = await get<{ flairs?: unknown[] }>('/api/v1/board/flairs')
     return Array.isArray(raw.flairs)
       ? raw.flairs.map(normalizeBoardFlair).filter((row): row is BoardFlair => row !== null)
@@ -1006,14 +1006,14 @@ export async function fetchBoardFlairs(): Promise<BoardFlair[]> {
 }
 
 export async function fetchBoardCuration(): Promise<BoardCurationSnapshot | null> {
-  return withRetries('fetchBoardCuration', async () => {
+  return runRequest('fetchBoardCuration', async () => {
     const raw = await get<{ snapshot?: unknown }>('/api/v1/board/curation')
     return raw.snapshot != null ? normalizeBoardCurationSnapshot(raw.snapshot) : null
   })
 }
 
 export async function fetchBoardKarmaLedger(options: { agent?: string; limit?: number } = {}): Promise<BoardKarmaLedger> {
-  return withRetries('fetchBoardKarmaLedger', async () => {
+  return runRequest('fetchBoardKarmaLedger', async () => {
     const params = new URLSearchParams()
     const agent = options.agent?.trim()
     if (agent) params.set('agent', agent)
@@ -1030,7 +1030,7 @@ export async function fetchBoardReactionState(
   targetType: BoardReactionTargetType,
   targetId: string,
 ): Promise<BoardReactionState> {
-  return timeBoardRequest('reaction_summary', () => withRetries('fetchBoardReactionState', async () => {
+  return timeBoardRequest('reaction_summary', () => runRequest('fetchBoardReactionState', async () => {
     const params = new URLSearchParams({
       target_type: targetType,
       target_id: targetId,
@@ -1055,7 +1055,7 @@ export async function fetchBoardReactionState(
 }
 
 export async function fetchBoardPost(postId: string): Promise<BoardPost & { comments: BoardComment[] }> {
-  return timeBoardRequest('detail', () => withRetries('fetchBoardPost', async () => {
+  return timeBoardRequest('detail', () => runRequest('fetchBoardPost', async () => {
     const params = new URLSearchParams({
       format: 'flat',
       voter: currentDashboardActor(),
@@ -1200,7 +1200,7 @@ export function normalizeSubBoard(raw: unknown): SubBoard | null {
 }
 
 export async function fetchSubBoards(): Promise<SubBoard[]> {
-  const data = await withRetries('fetchSubBoards', () => get('/api/v1/board/sub-boards'))
+  const data = await runRequest('fetchSubBoards', () => get('/api/v1/board/sub-boards'))
   if (!isRecord(data)) return []
   const raw = Array.isArray(data.sub_boards) ? data.sub_boards : []
   return raw.flatMap((r: unknown) => {
@@ -1210,7 +1210,7 @@ export async function fetchSubBoards(): Promise<SubBoard[]> {
 }
 
 export async function fetchSubBoard(subBoardId: string): Promise<SubBoard | null> {
-  const data = await withRetries('fetchSubBoard', () => get(`/api/v1/board/sub-boards/${encodeURIComponent(subBoardId)}`))
+  const data = await runRequest('fetchSubBoard', () => get(`/api/v1/board/sub-boards/${encodeURIComponent(subBoardId)}`))
   return normalizeSubBoard(data)
 }
 

--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -226,7 +226,6 @@ export {
   DEFAULT_MCP_TIMEOUT_MS,
   NAMESPACE_TRUTH_GET_TIMEOUT_MS,
 } from '../config/constants'
-const RETRYABLE_STATUS_CODES = new Set([408, 425, 429, 500, 502, 503, 504])
 
 export class ApiRequestError extends Error {
   method: string
@@ -765,58 +764,8 @@ export async function getWithResponse<T>(
   return { data, headers: res.headers }
 }
 
-export function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms))
-}
-
-function parseStatusFromMessage(message: string): number | null {
-  const match = message.match(/\b(\d{3})\b/)
-  if (!match) return null
-  const statusToken = match[1]
-  if (!statusToken) return null
-  const status = Number.parseInt(statusToken, 10)
-  return Number.isFinite(status) ? status : null
-}
-
-function isRetryableError(err: unknown): boolean {
-  if (err instanceof ApiRequestError) {
-    if (err.errorCode === 'computation_timeout' || err.errorCode === 'timeout') {
-      return false
-    }
-    return err.timeout || (typeof err.status === 'number' && RETRYABLE_STATUS_CODES.has(err.status))
-  }
-
-  if (!(err instanceof Error)) return false
-  if (/timeout after \d+ms/i.test(err.message)) return true
-
-  // Network-level failures (server unreachable, connection reset, DNS failure).
-  // Browser fetch() throws TypeError on these — they are transient.
-  if (err instanceof TypeError && /failed to fetch|networkerror|load failed/i.test(err.message)) {
-    return true
-  }
-
-  const parsedStatus = parseStatusFromMessage(err.message)
-  return parsedStatus !== null && RETRYABLE_STATUS_CODES.has(parsedStatus)
-}
-
-export async function withRetries<T>(
-  operation: string,
-  run: () => Promise<T>,
-  retries = 2,
-): Promise<T> {
-  let attempt = 0
-
-  while (true) {
-    try {
-      return await run()
-    } catch (err) {
-      if (!isRetryableError(err) || attempt >= retries) throw err
-      const delayMs = 250 * (attempt + 1)
-      console.warn(`[dashboard/api] ${operation} failed (attempt ${attempt + 1}), retrying in ${delayMs}ms`, err)
-      await sleep(delayMs)
-      attempt += 1
-    }
-  }
+export function runRequest<T>(_operation: string, run: () => Promise<T>): Promise<T> {
+  return run()
 }
 
 export async function post<T>(

--- a/dashboard/src/api/dashboard-gate.ts
+++ b/dashboard/src/api/dashboard-gate.ts
@@ -1,7 +1,7 @@
 // MASC Dashboard — Gate / HITL transport and normalization boundary.
 // Public symbols are re-exported from dashboard.ts.
 
-import { ApiRequestError, get, post, withRetries } from './core'
+import { ApiRequestError, get, post, runRequest } from './core'
 import { isRecord, asBoolean, asInt, asNullableString, asString } from '../components/common/normalize'
 import {
   asNullableIsoTimestamp,
@@ -371,7 +371,7 @@ function normalizeKeeperResolvedApprovalState(raw: unknown): KeeperResolvedAppro
 export function fetchDashboardGate(
   opts?: FetchDashboardGateOptions,
 ): Promise<DashboardGateResponse> {
-  return withRetries('fetchDashboardGate', async () => {
+  return runRequest('fetchDashboardGate', async () => {
     const query = opts?.force ? '?force=1' : ''
     const raw = await get<Record<string, unknown>>(`/api/v1/dashboard/gate${query}`, {
       signal: opts?.signal,

--- a/dashboard/src/api/dev-token.test.ts
+++ b/dashboard/src/api/dev-token.test.ts
@@ -61,8 +61,7 @@ describe('ensureDevToken', () => {
     vi.useRealTimers()
   })
 
-  it('waits through the exact server warm-up payload and continues bootstrap', async () => {
-    vi.useFakeTimers()
+  it('requires an explicit bootstrap call after the server warm-up payload', async () => {
     fetchWithTimeout
       .mockResolvedValueOnce(jsonResponse({
         status: 'initializing',
@@ -74,9 +73,12 @@ describe('ensureDevToken', () => {
         role: 'admin',
       }))
 
-    const bootstrap = ensureDevToken()
-    await vi.advanceTimersByTimeAsync(1_000)
-    await bootstrap
+    await ensureDevToken()
+    expect(fetchWithTimeout).toHaveBeenCalledTimes(1)
+    expect(setStoredToken).not.toHaveBeenCalled()
+    expect(devTokenBootstrapStatus.value).toBe('warming')
+
+    await ensureDevToken()
 
     expect(fetchWithTimeout).toHaveBeenCalledTimes(2)
     expect(setStoredToken).toHaveBeenCalledWith('ready-dev-token', {
@@ -108,7 +110,7 @@ describe('ensureDevToken', () => {
     expect(token).toBe('operator-token')
   })
 
-  it('retries after a transient network bootstrap failure in the same page load', async () => {
+  it('allows a later explicit bootstrap after a network failure', async () => {
     fetchWithTimeout
       .mockRejectedValueOnce(new Error('server not ready'))
       .mockResolvedValueOnce(jsonResponse({

--- a/dashboard/src/api/dev-token.test.ts
+++ b/dashboard/src/api/dev-token.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   devTokenBootstrapStatus,
+  devTokenBootstrapNeedsReadinessProbe,
   ensureDevToken,
   refreshDevTokenAfterAuthError,
   resetDevTokenBootstrap,
@@ -89,6 +90,27 @@ describe('ensureDevToken', () => {
     expect(devTokenBootstrapStatus.value).toBe('ok')
   })
 
+  it.each([408, 425, 429, 500, 503])(
+    'exposes HTTP %s as a readiness state without pinning the in-flight promise',
+    async status => {
+      fetchWithTimeout
+        .mockResolvedValueOnce(new Response('not ready', { status }))
+        .mockResolvedValueOnce(jsonResponse({
+          token: 'ready-dev-token',
+          actor: 'dashboard',
+          role: 'admin',
+        }))
+
+      await ensureDevToken()
+      expect(devTokenBootstrapStatus.value).toBe('warming')
+      expect(devTokenBootstrapNeedsReadinessProbe()).toBe(true)
+
+      await ensureDevToken()
+      expect(fetchWithTimeout).toHaveBeenCalledTimes(2)
+      expect(devTokenBootstrapStatus.value).toBe('ok')
+    },
+  )
+
   it('does not overwrite a manual token entered while the server is warming', async () => {
     vi.useFakeTimers()
     let token: string | null = null
@@ -150,7 +172,7 @@ describe('ensureDevToken', () => {
     expect(devTokenBootstrapStatus.value).toBe('ok')
   })
 
-  it('does not keep retrying a disabled loopback dev-token endpoint', async () => {
+  it('memoizes a disabled loopback dev-token endpoint as terminal', async () => {
     fetchWithTimeout.mockResolvedValueOnce(new Response('not found', { status: 404 }))
 
     await ensureDevToken()

--- a/dashboard/src/api/dev-token.ts
+++ b/dashboard/src/api/dev-token.ts
@@ -11,7 +11,6 @@ import {
 } from './core'
 
 const DEV_TOKEN_FETCH_TIMEOUT_MS = 3000
-const DEV_TOKEN_WARMUP_RETRY_MS = 1_000
 
 let devTokenBootstrapPromise: Promise<void> | null = null
 let devTokenRefreshPromise: Promise<boolean> | null = null
@@ -46,10 +45,6 @@ interface DevTokenBootstrapPayload {
   status?: unknown
 }
 
-function waitForWarmupRetry(): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, DEV_TOKEN_WARMUP_RETRY_MS))
-}
-
 const REFRESHABLE_AUTH_CODES: ReadonlySet<DashboardAuthErrorCode> = new Set([
   'invalid_token',
   'token_expired',
@@ -61,10 +56,6 @@ export function isRefreshableDashboardAuthCode(
 ): value is DashboardAuthErrorCode {
   return typeof value === 'string'
     && REFRESHABLE_AUTH_CODES.has(value as DashboardAuthErrorCode)
-}
-
-function isRetryableDevTokenStatus(status: number): boolean {
-  return status === 408 || status === 425 || status === 429 || status >= 500
 }
 
 function shouldRefreshDevToken(): boolean {
@@ -94,9 +85,8 @@ export async function ensureDevToken(): Promise<void> {
   devTokenBootstrapPromise = (async () => {
     const storedMeta = getStoredTokenMeta()
     ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'fetching'
-    while (true) {
-      if (getStoredTokenMeta()?.source === 'manual' && getStoredToken()) return
-      try {
+    if (getStoredTokenMeta()?.source === 'manual' && getStoredToken()) return
+    try {
         const res = await fetchWithTimeout(
           '/api/v1/dashboard/dev-token',
           { method: 'GET', headers: { Accept: 'application/json' } },
@@ -107,21 +97,17 @@ export async function ensureDevToken(): Promise<void> {
             clearStoredToken()
           }
           ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'no_endpoint'
-          if (isRetryableDevTokenStatus(res.status)) {
-            devTokenBootstrapPromise = null
-          }
           return
         }
         const payload = (await res.json()) as DevTokenBootstrapPayload
         if (payload.status === 'initializing') {
           ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'warming'
-          await waitForWarmupRetry()
-          continue
+          devTokenBootstrapPromise = null
+          return
         }
         const token = typeof payload.token === 'string' ? payload.token.trim() : ''
         if (!token || payload.actor !== 'dashboard' || payload.role !== 'admin') {
           ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'invalid_response'
-          devTokenBootstrapPromise = null
           return
         }
         const currentMeta = getStoredTokenMeta()
@@ -145,11 +131,10 @@ export async function ensureDevToken(): Promise<void> {
         }
         ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'ok'
         return
-      } catch {
-        ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'network'
-        devTokenBootstrapPromise = null
-        return
-      }
+    } catch {
+      ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'network'
+      devTokenBootstrapPromise = null
+      return
     }
   })()
   return devTokenBootstrapPromise

--- a/dashboard/src/api/dev-token.ts
+++ b/dashboard/src/api/dev-token.ts
@@ -20,7 +20,7 @@ let devTokenRefreshPromise: Promise<boolean> | null = null
  * distinguish "auth required but no token" from "network error" etc.
  *   idle       — not yet attempted
  *   fetching   — in-flight
- *   warming    — server accepted HTTP but has not installed runtime state yet
+ *   warming    — server is initializing or explicitly reports temporary unavailability
  *   ok         — token stored
  *   no_endpoint — /dev-token returned 404 (loopback disabled or strict auth)
  *   invalid_response — endpoint response violated the exact token contract
@@ -37,6 +37,12 @@ export type DevTokenBootstrapStatus =
 
 export const devTokenBootstrapStatus: ReadonlySignal<DevTokenBootstrapStatus> =
   signal<DevTokenBootstrapStatus>('idle')
+
+export function devTokenBootstrapNeedsReadinessProbe(): boolean {
+  return shouldRefreshDevToken()
+    && (devTokenBootstrapStatus.value === 'warming'
+      || devTokenBootstrapStatus.value === 'network')
+}
 
 interface DevTokenBootstrapPayload {
   token?: unknown
@@ -96,7 +102,14 @@ export async function ensureDevToken(): Promise<void> {
           if (res.status === 404 && storedMeta?.source === 'dev') {
             clearStoredToken()
           }
-          ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'no_endpoint'
+          if (res.status === 408 || res.status === 425 || res.status === 429 || res.status >= 500) {
+            ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'warming'
+            devTokenBootstrapPromise = null
+          } else {
+            ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = res.status === 404
+              ? 'no_endpoint'
+              : 'invalid_response'
+          }
           return
         }
         const payload = (await res.json()) as DevTokenBootstrapPayload

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -21,7 +21,10 @@ import { cancelPendingServerPushRefreshes, registerGateRefresh, registerMissionR
 import { initNotificationDelivery } from './notifications'
 import { refreshShell } from './store'
 import { connectDashboardWS, disconnectDashboardWS, subscribeDashboardRoute } from './dashboard-ws'
-import { ensureDevToken } from './api/dev-token'
+import {
+  devTokenBootstrapNeedsReadinessProbe,
+  ensureDevToken,
+} from './api/dev-token'
 import { CONTEXT_RATIO_CRITICAL, CONTEXT_RATIO_WARN, CONTEXT_RATIO_COMPACTING } from './config/constants'
 import { setContextThresholds } from './config/context-thresholds'
 import { DashboardMain, DashboardHealthStrip, isKeeperDetailDashboardRoute } from './components/dashboard-shell'
@@ -158,6 +161,7 @@ export function App() {
 
   useEffect(() => {
     let cancelled = false
+    let devTokenReadinessTimer: number | null = null
 
     // Initialize hash router and compatible deep links
     initRouter()
@@ -167,9 +171,18 @@ export function App() {
         console.warn('[app] dashboard dev-token bootstrap failed', err instanceof Error ? err.message : err)
       })
 
+    const scheduleDevTokenReadinessProbe = () => {
+      if (cancelled || !devTokenBootstrapNeedsReadinessProbe()) return
+      devTokenReadinessTimer = window.setTimeout(() => {
+        devTokenReadinessTimer = null
+        void ensureLoopbackAuth().finally(scheduleDevTokenReadinessProbe)
+      }, 1_000)
+    }
+
     void ensureLoopbackAuth()
       .finally(() => {
         if (cancelled) return
+        scheduleDevTokenReadinessProbe()
         void refreshShell({ light: true })
         requestNamespaceTruthNow()
 
@@ -229,6 +242,10 @@ export function App() {
 
     return () => {
       cancelled = true
+      if (devTokenReadinessTimer !== null) {
+        window.clearTimeout(devTokenReadinessTimer)
+        devTokenReadinessTimer = null
+      }
       disconnectDashboardWS()
       unsubscribeServerPush()
       unsubNotify()

--- a/dashboard/src/components/common/agent-failure.a11y.test.ts
+++ b/dashboard/src/components/common/agent-failure.a11y.test.ts
@@ -16,23 +16,21 @@ describe('AgentFailure a11y', () => {
     document.body.removeChild(container)
   })
 
-  it('renders accessibly for retryable failure', async () => {
+  it('renders accessibly for blocked failure', async () => {
     render(
       html`<${AgentFailure}
-        type="retryable"
+        type="blocked"
         message="Connection timeout"
-        retryCount=${1}
-        maxRetries=${3}
       />`,
       container,
     )
     expect(await axe(container)).toHaveNoViolations()
   })
 
-  it('renders accessibly for non_retryable failure', async () => {
+  it('renders accessibly for non_blocked failure', async () => {
     render(
       html`<${AgentFailure}
-        type="non_retryable"
+        type="blocked"
         message="Invalid API key"
       />`,
       container,
@@ -65,7 +63,7 @@ describe('AgentFailure a11y', () => {
   it('renders accessibly without retry info', async () => {
     render(
       html`<${AgentFailure}
-        type="retryable"
+        type="blocked"
         message="Will retry automatically"
       />`,
       container,

--- a/dashboard/src/components/common/agent-failure.test.ts
+++ b/dashboard/src/components/common/agent-failure.test.ts
@@ -1,170 +1,37 @@
-import { describe, expect, it } from 'vitest'
-import { h } from 'preact'
-import { render } from 'preact'
+import { h, render } from 'preact'
+import { beforeEach, describe, expect, it } from 'vitest'
 import {
   AgentFailure,
   failureConfig,
   failureTypeFromDiagnostic,
   summarizeAgentFailure,
-  summarizeRetryBudget,
 } from './agent-failure'
 
-describe('failureConfig', () => {
-  it('returns config for retryable', () => {
-    const cfg = failureConfig('retryable')
-    expect(cfg.label).toBe('재시도 가능')
-    expect(cfg.action).toContain('재시도')
-    expect(cfg.colorVar).toBe('var(--color-status-warn)')
+describe('AgentFailure typed states', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
   })
 
-  it('returns config for non_retryable', () => {
-    const cfg = failureConfig('non_retryable')
-    expect(cfg.label).toBe('재시도 불가')
-    expect(cfg.colorVar).toBe('var(--color-status-err)')
+  it('uses blocked for an observed error without reading recoverability', () => {
+    expect(failureTypeFromDiagnostic('err')).toBe('blocked')
+    expect(failureTypeFromDiagnostic(null)).toBe('degraded')
   })
 
-  it('returns config for human_required', () => {
-    const cfg = failureConfig('human_required')
-    expect(cfg.label).toBe('승인 필요')
-    expect(cfg.colorVar).toBe('var(--color-accent-fg)')
-  })
-
-  it('returns config for degraded', () => {
-    const cfg = failureConfig('degraded')
-    expect(cfg.label).toBe('성능 저하')
-  })
-})
-
-describe('summarizeRetryBudget', () => {
-  it('summarizes retry budget', () => {
-    expect(summarizeRetryBudget(2, 5)).toEqual({
-      current: 2,
-      max: 5,
-      remaining: 3,
-      percent: 40,
-      exhausted: false,
-      visible: true,
-    })
-  })
-
-  it('hides invalid or empty retry budgets', () => {
-    expect(summarizeRetryBudget(undefined, 3).visible).toBe(false)
-    expect(summarizeRetryBudget(1, 0).visible).toBe(false)
-    expect(summarizeRetryBudget(1, Infinity)).toEqual({
-      current: 0,
-      max: 0,
-      remaining: 0,
-      percent: 0,
-      exhausted: false,
-      visible: false,
-    })
-    expect(summarizeRetryBudget(NaN, 3).visible).toBe(false)
-  })
-
-  it('detects exhausted retry budget', () => {
-    const budget = summarizeRetryBudget(7, 5)
-    expect(budget.current).toBe(7)
-    expect(budget.remaining).toBe(0)
-    expect(budget.percent).toBe(100)
-    expect(budget.exhausted).toBe(true)
-  })
-})
-
-describe('summarizeAgentFailure', () => {
-  it('reports retrying and exhausted retry statuses', () => {
-    expect(summarizeAgentFailure('retryable', 1, 3).status).toBe('retrying')
-    expect(summarizeAgentFailure('retryable', 3, 3).status).toBe('retry_exhausted')
-  })
-
-  it('reports non-retryable, human, and degraded statuses', () => {
-    expect(summarizeAgentFailure('non_retryable').status).toBe('blocked')
+  it('summarizes the three operator states', () => {
+    expect(summarizeAgentFailure('blocked').status).toBe('blocked')
     expect(summarizeAgentFailure('human_required').status).toBe('waiting_for_human')
     expect(summarizeAgentFailure('degraded').status).toBe('degraded')
-  })
-})
-
-describe('failureTypeFromDiagnostic', () => {
-  it('returns degraded when no error', () => {
-    expect(failureTypeFromDiagnostic(null, true)).toBe('degraded')
+    expect(failureConfig('blocked').label).toBe('진행 차단')
   })
 
-  it('returns retryable when recoverable', () => {
-    expect(failureTypeFromDiagnostic('err', true)).toBe('retryable')
-  })
-
-  it('returns non_retryable when not recoverable', () => {
-    expect(failureTypeFromDiagnostic('err', false)).toBe('non_retryable')
-  })
-
-  it('defaults to non_retryable when recoverable undefined', () => {
-    expect(failureTypeFromDiagnostic('err', undefined)).toBe('non_retryable')
-  })
-})
-
-describe('AgentFailure', () => {
-  it('renders role alert', () => {
-    const container = document.createElement('div')
-    render(h(AgentFailure, { type: 'retryable', message: 'oops' }), container)
-    expect(container.querySelector('[role="alert"]')).not.toBeNull()
-  })
-
-  it('renders message', () => {
-    const container = document.createElement('div')
-    render(h(AgentFailure, { type: 'non_retryable', message: 'failed' }), container)
-    expect(container.textContent).toContain('failed')
-  })
-
-  it('renders retry count', () => {
-    const container = document.createElement('div')
-    render(h(AgentFailure, { type: 'retryable', message: 'x', retryCount: 2, maxRetries: 5 }), container)
-    expect(container.textContent).toContain('2/5')
-  })
-
-  it('hides retry count when maxRetries is 0', () => {
-    const container = document.createElement('div')
-    render(h(AgentFailure, { type: 'retryable', message: 'x', retryCount: 1, maxRetries: 0 }), container)
-    expect(container.textContent).not.toContain('1/0')
-  })
-
-  it('sets data-failure-type', () => {
-    const container = document.createElement('div')
-    render(h(AgentFailure, { type: 'human_required', message: 'x' }), container)
-    const el = container.querySelector('[data-failure-type]')
-    expect(el?.getAttribute('data-failure-type')).toBe('human_required')
-  })
-
-  it('exposes summary data attributes', () => {
-    const container = document.createElement('div')
-    render(h(AgentFailure, { type: 'retryable', message: 'x', retryCount: 2, maxRetries: 5 }), container)
-    const root = container.querySelector('[data-agent-failure]') as HTMLElement
-    expect(root.dataset.agentFailureStatus).toBe('retrying')
-    expect(root.dataset.agentFailureLabel).toBe('재시도 가능')
-    expect(root.dataset.agentFailureAction).toBe('자동 재시도 중...')
-    expect(root.dataset.agentFailureRetryCurrent).toBe('2')
-    expect(root.dataset.agentFailureRetryMax).toBe('5')
-    expect(root.dataset.agentFailureRetryRemaining).toBe('3')
-    expect(root.dataset.agentFailureRetryPercent).toBe('40')
-    expect(root.dataset.agentFailureRetryExhausted).toBe('false')
-    expect(root.dataset.agentFailureRetryVisible).toBe('true')
-  })
-
-  it('exposes exhausted retry status', () => {
-    const container = document.createElement('div')
-    render(h(AgentFailure, { type: 'retryable', message: 'x', retryCount: 5, maxRetries: 5 }), container)
-    const root = container.querySelector('[data-agent-failure]') as HTMLElement
-    expect(root.dataset.agentFailureStatus).toBe('retry_exhausted')
-    expect(root.dataset.agentFailureRetryExhausted).toBe('true')
-  })
-
-  it('uses semantic aria label fallback for empty message', () => {
-    const container = document.createElement('div')
-    render(h(AgentFailure, { type: 'degraded', message: '' }), container)
-    expect(container.querySelector('[role="alert"]')?.getAttribute('aria-label')).toContain('상세 메시지 없음')
-  })
-
-  it('applies testId', () => {
-    const container = document.createElement('div')
-    render(h(AgentFailure, { type: 'degraded', message: 'x', testId: 'af-1' }), container)
-    expect(container.querySelector('[data-testid="af-1"]')).not.toBeNull()
+  it('renders typed data attributes and no local attempt budget', () => {
+    render(h(AgentFailure, { type: 'blocked', message: 'failed', testId: 'failure' }), container)
+    const element = container.querySelector('[data-testid="failure"]')
+    expect(element?.getAttribute('data-failure-type')).toBe('blocked')
+    expect(element?.getAttribute('data-agent-failure-status')).toBe('blocked')
+    expect(element?.getAttribute('data-agent-failure-retry-visible')).toBeNull()
   })
 })

--- a/dashboard/src/components/common/agent-failure.ts
+++ b/dashboard/src/components/common/agent-failure.ts
@@ -1,15 +1,13 @@
-// AgentFailure — AX atom that renders an error state with type-aware styling.
+// AgentFailure — AX atom that renders an observed failure state.
 //
-// MASC dashboard sec05 reference: icons + color-coded borders for retryable,
-// non-retryable, human-required and degraded failure types. The compact alert
-// card lets operators instantly grasp severity and required action.
-//
+// The dashboard displays typed operator state only. It does not infer a replay
+// policy from a generic `recoverable` boolean or maintain a local attempt budget.
 import { html } from 'htm/preact'
-import { AlertTriangle, RefreshCcw, UserRound, XCircle } from 'lucide-preact'
+import { AlertTriangle, UserRound, XCircle } from 'lucide-preact'
 import type { LucideIcon } from 'lucide-preact'
 
-export type FailureType = 'retryable' | 'non_retryable' | 'human_required' | 'degraded'
-export type AgentFailureStatus = 'retrying' | 'retry_exhausted' | 'blocked' | 'waiting_for_human' | 'degraded'
+export type FailureType = 'blocked' | 'human_required' | 'degraded'
+export type AgentFailureStatus = 'blocked' | 'waiting_for_human' | 'degraded'
 
 export interface FailureConfig {
   Icon: LucideIcon
@@ -18,34 +16,18 @@ export interface FailureConfig {
   action: string
 }
 
-export interface AgentFailureRetryBudget {
-  readonly current: number
-  readonly max: number
-  readonly remaining: number
-  readonly percent: number
-  readonly exhausted: boolean
-  readonly visible: boolean
-}
-
 export interface AgentFailureSummary {
   readonly type: FailureType
   readonly label: string
   readonly action: string
   readonly status: AgentFailureStatus
-  readonly retry: AgentFailureRetryBudget
 }
 
 const FAILURE_CONFIG: Record<FailureType, FailureConfig> = {
-  retryable: {
-    Icon: RefreshCcw,
-    colorVar: 'var(--color-status-warn)',
-    label: '재시도 가능',
-    action: '자동 재시도 중...',
-  },
-  non_retryable: {
+  blocked: {
     Icon: XCircle,
     colorVar: 'var(--color-status-err)',
-    label: '재시도 불가',
+    label: '진행 차단',
     action: '수동 개입 필요',
   },
   human_required: {
@@ -62,97 +44,33 @@ const FAILURE_CONFIG: Record<FailureType, FailureConfig> = {
   },
 }
 
-/** Pure: lookup a failure type's display config. */
 export function failureConfig(type: FailureType): FailureConfig {
   return FAILURE_CONFIG[type]
 }
 
-export function summarizeRetryBudget(
-  retryCount: number | undefined,
-  maxRetries: number | undefined,
-): AgentFailureRetryBudget {
-  const finiteRetryCount =
-    typeof retryCount === 'number' && Number.isFinite(retryCount) ? retryCount : undefined
-  const finiteMaxRetries =
-    typeof maxRetries === 'number' && Number.isFinite(maxRetries) ? maxRetries : undefined
-  if (finiteRetryCount === undefined || finiteMaxRetries === undefined || finiteMaxRetries <= 0) {
-    return {
-      current: 0,
-      max: 0,
-      remaining: 0,
-      percent: 0,
-      exhausted: false,
-      visible: false,
-    }
-  }
-  const current = Math.max(0, Math.floor(finiteRetryCount))
-  const max = Math.max(1, Math.floor(finiteMaxRetries))
-  const clampedCurrent = max > 0 ? Math.min(current, max) : 0
-  return {
-    current,
-    max,
-    remaining: Math.max(0, max - clampedCurrent),
-    percent: max > 0 ? Math.round((clampedCurrent / max) * 100) : 0,
-    exhausted: max > 0 && current >= max,
-    visible: true,
-  }
-}
-
-export function summarizeAgentFailure(
-  type: FailureType,
-  retryCount?: number,
-  maxRetries?: number,
-): AgentFailureSummary {
+export function summarizeAgentFailure(type: FailureType): AgentFailureSummary {
   const cfg = failureConfig(type)
-  const retry = summarizeRetryBudget(retryCount, maxRetries)
-  const status: AgentFailureStatus =
-    type === 'retryable'
-      ? retry.exhausted
-        ? 'retry_exhausted'
-        : 'retrying'
-      : type === 'human_required'
-        ? 'waiting_for_human'
-        : type === 'degraded'
-          ? 'degraded'
-          : 'blocked'
-  return {
-    type,
-    label: cfg.label,
-    action: cfg.action,
-    status,
-    retry,
-  }
+  const status: AgentFailureStatus = type === 'human_required'
+    ? 'waiting_for_human'
+    : type
+  return { type, label: cfg.label, action: cfg.action, status }
 }
 
-/** Pure: map a diagnostic error + recoverable flag to a failure type.
-    Defaults to degraded when no error is present, and non_retryable
-    when recoverable is false or undefined. */
 export function failureTypeFromDiagnostic(
   lastError: string | null | undefined,
-  recoverable: boolean | undefined,
 ): FailureType {
-  if (!lastError) return 'degraded'
-  if (recoverable === true) return 'retryable'
-  return 'non_retryable'
+  return lastError ? 'blocked' : 'degraded'
 }
 
 interface AgentFailureProps {
   type: FailureType
   message: string
-  retryCount?: number
-  maxRetries?: number
   testId?: string
 }
 
-export function AgentFailure({
-  type,
-  message,
-  retryCount,
-  maxRetries,
-  testId,
-}: AgentFailureProps) {
+export function AgentFailure({ type, message, testId }: AgentFailureProps) {
   const cfg = FAILURE_CONFIG[type]
-  const summary = summarizeAgentFailure(type, retryCount, maxRetries)
+  const summary = summarizeAgentFailure(type)
   const Icon = cfg.Icon
 
   return html`
@@ -166,12 +84,6 @@ export function AgentFailure({
       data-agent-failure-status=${summary.status}
       data-agent-failure-label=${summary.label}
       data-agent-failure-action=${summary.action}
-      data-agent-failure-retry-current=${summary.retry.current}
-      data-agent-failure-retry-max=${summary.retry.max}
-      data-agent-failure-retry-remaining=${summary.retry.remaining}
-      data-agent-failure-retry-percent=${summary.retry.percent}
-      data-agent-failure-retry-exhausted=${summary.retry.exhausted}
-      data-agent-failure-retry-visible=${summary.retry.visible}
       data-testid=${testId}
     >
       <span class="mt-0.5 shrink-0 leading-none" style="color: ${cfg.colorVar};" aria-hidden="true">
@@ -184,13 +96,6 @@ export function AgentFailure({
         <div class="break-words text-xs text-[var(--color-fg-muted)]">
           ${message}
         </div>
-        ${summary.retry.visible
-          ? html`
-              <div class="mt-1 text-xs text-[var(--color-fg-muted)]">
-                재시도: ${summary.retry.current}/${summary.retry.max}
-              </div>
-            `
-          : null}
       </div>
       <span class="col-start-2 text-xs text-[var(--color-fg-muted)] sm:col-start-auto sm:shrink-0 sm:text-right">
         ${cfg.action}

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -359,7 +359,7 @@ export function KeeperDiagnosticSummary({
       </div>
       ${diagnostic?.last_error
         ? html`<${AgentFailure}
-            type=${failureTypeFromDiagnostic(diagnostic.last_error, diagnostic.recoverable)}
+            type=${failureTypeFromDiagnostic(diagnostic.last_error)}
             message=${diagnostic.last_error}
           />`
         : null}


### PR DESCRIPTION
Split from #29271.

Scope:
- remove request-level retry loops from dashboard API clients
- remove presentation inference that labels failures as retryable
- keep failure reporting without inventing a recovery policy

Validation:
- Dashboard typecheck PASS
- focused Dashboard tests PASS (3 files / 18 tests)
- CI target audit PASS (380 declared / 516 unwired baseline)
- gRPC descriptor check PASS

This PR contains no schedule, Goal verifier, Task notification, Keeper-name, voice, or provider runtime changes.