### PR TITLE
refactor(keeper): anonymize concrete Keeper names in OCaml

### DIFF
--- a/bin/masc_trace.ml
+++ b/bin/masc_trace.ml
@@ -6,7 +6,7 @@
     fields; presentation strings do not participate in routing.
 
     Usage:  masc-trace <base-path> <keeper> <turn_id>
-    Example: masc-trace ~/me nick0cave 5
+    Example: masc-trace ~/me example-keeper 5
 *)
 
 let usage_and_exit () =

--- a/lib/auth/auth.mli
+++ b/lib/auth/auth.mli
@@ -70,8 +70,8 @@ val load_credential : string -> string -> agent_credential option
     dispatcher-validated [ctx_agent_name]".  The second case is the
     {b dual identity} mode where {!load_credential} silently returned a
     credential whose [agent_name] differs from the caller's claimed
-    identity (e.g. requested [sangsu] resolves to bare-nickname cred
-    while [ctx_agent_name] is [keeper-sangsu-agent]).
+    identity (e.g. requested [example-keeper] resolves to bare-nickname cred
+    while [ctx_agent_name] is [keeper-example-keeper-agent]).
     [load_credential_of] surfaces the mismatch instead of
     perpetuating it. *)
 type load_credential_error =
@@ -113,8 +113,8 @@ val load_credential_of :
     simple exact-match lookup with explicit error variants.
 
     This replaces the removed silent alias fallback
-    where a stem of [sangsu] against a [ctx_agent_name] of
-    [keeper-sangsu-agent] would return the bare-nickname credential and
+    where a stem of [example-keeper] against a [ctx_agent_name] of
+    [keeper-example-keeper-agent] would return the bare-nickname credential and
     perpetuate dual identity. *)
 
 val save_credential : string -> agent_credential -> unit

--- a/lib/auth/auth_credential_base.ml
+++ b/lib/auth/auth_credential_base.ml
@@ -231,9 +231,9 @@ let raw_token_file config agent_name =
     Tries an exact filename match first. If that misses and [agent_name]
     looks like a generated nickname ({agent_type}-{adj}-{animal}[...]),
     retry with just the agent_type prefix — shared-token aliases
-    provisioned for stable keeper names (e.g. [adversary.json]) then
+    provisioned for stable keeper names (e.g. [example-keeper.json]) then
     cover every dynamically generated nickname in that family
-    (e.g. [adversary-fair-tapir]).
+    (e.g. [example-keeper-fair-tapir]).
 
     Without this fallback, Workspace.bind_session's nickname output caused a
     chronic "No credential found for <type>-<adj>-<animal>" noise band
@@ -633,8 +633,8 @@ let () =
 (** #9786: detect credentials sharing the same bearer token.
 
     The 2026-04-23 audit found [external MCP clients] and [admin]
-    tokens being presented for [keeper-sangsu-agent] /
-    [nick0cave-sage-heron] requests — symptom of multiple
+    tokens being presented for [keeper-example-keeper-agent] /
+    [example-keeper-sage-heron] requests — symptom of multiple
     credentials hashing to the same token, or a single MCP
     client connection being reused across agent identities.
 

--- a/lib/board_tool_adapter/board_tool_format.ml
+++ b/lib/board_tool_adapter/board_tool_format.ml
@@ -17,7 +17,7 @@ let author_raw_agent_name_meta_key = raw_agent_name_meta_key ~field:"author"
    [Time_compat.now ()] inside functions whose signatures promised a pure
    [float -> string]: the clock was a hidden second input. A re-listed post
    therefore drifted "7m ago" -> "8m ago" while nothing about the post changed.
-   Measured on one rondo turn: 42 [masc_board_list] calls returning the same
+   Measured on one live Keeper turn: 42 [masc_board_list] calls returning the same
    878B of board state split across three distinct byte sequences, purely
    because the minute counter advanced.
 
@@ -447,7 +447,7 @@ let provenance_arg args =
     Convert a stray [Yojson.Safe.Util.Type_error] from a board-tool
     handler into a structured [Tool_result.error] so the MCP transport
     sees a typed message rather than an opaque exception payload (cf.
-    task-213 board post p-1efba4b2311478dff37fff9fdbfea483, sangsu
+    task-213 board post p-1efba4b2311478dff37fff9fdbfea483, example-keeper
     broadcast 2026-05-15T10:51:20Z). Diagnostic, not a workaround: the
     offending value field points the next triager at the failing
     field. *)

--- a/lib/config/playground_paths.ml
+++ b/lib/config/playground_paths.ml
@@ -21,7 +21,7 @@ let all_playgrounds_prefix : string =
 
 (** Strip the [keeper-...-agent] canonical wrapper when present,
     returning the inner short name.  E.g.
-    ["keeper-masc-improver-agent"] -> ["masc-improver"].
+    ["keeper-example-keeper-agent"] -> ["example-keeper"].
 
     The MCP session resolver generates canonical names via
     [keeper_agent_name] in [keeper_types_profile.ml], but playground

--- a/lib/dashboard/dashboard_execution_helpers.ml
+++ b/lib/dashboard/dashboard_execution_helpers.ml
@@ -76,14 +76,14 @@ type agent_profile = {
 }
 
 (** Extract the Keeper name from a MASC agent name.
-    "keeper-sangsu-agent" -> "sangsu", "claude-agent-abc" -> "claude-agent-abc"
+    "keeper-example-agent" -> "example", "claude-agent-abc" -> "claude-agent-abc"
 
     [Keeper_identity] owns this parse. It enumerates the four accepted
     spellings — keeper-/-agent, keeper_/_agent, and the two mixed forms — and
     its own comment records what happens when a spelling is known in one place
     and not another. This function used to hand-roll the first pair with
     [String.sub s 7] and [String.sub s (len - 6) 6], so an agent named
-    keeper_sangsu_agent kept its affixes and the profile lookup below searched
+    keeper_example_agent kept its affixes and the profile lookup below searched
     for a directory of that name. *)
 let extract_keeper_name (agent_name : string) : string =
   match Keeper_identity.keeper_name_of_agent_alias agent_name with

--- a/lib/dashboard/dashboard_keeper_decision_log_proof.ml
+++ b/lib/dashboard/dashboard_keeper_decision_log_proof.ml
@@ -54,7 +54,7 @@ let decision_tail_max_lines = 5000
 
 (* Head budget for locating the earliest turn row in one segment. Measured
    2026-08-09 over the 8-keeper fleet: the first turn row sat within 7.6 KB of
-   every segment head (worst case [sangsu], row 4), so this clears the observed
+   every segment head (worst case a live Keeper at row 4), so this clears the observed
    worst case by ~67x while keeping the read O(1) in file size. *)
 let decision_head_max_bytes = 512 * 1024
 

--- a/lib/fusion/fusion_judge.mli
+++ b/lib/fusion/fusion_judge.mli
@@ -17,7 +17,7 @@
     벗기므로(fusion_judge_parse.ml:177-190), 응답 전체가 펜스 블록 하나면 파싱은
     통과한다. 벗겨지지 않는 경우는 둘뿐이다 — 펜스 앞에 산문이 붙어 첫 3바이트가
     ``` 이 아니거나, 펜스 뒤에 개행이 없어 [String.index_opt s '\n'] 이 [None]
-    이라 원문이 그대로 나가는 경우. 라이브 관측(keeper rondo, event-queue-v12.json
+    이라 원문이 그대로 나가는 경우. 라이브 Keeper 관측(event-queue-v12.json
     last_settlement, 2026-07-25T10:44Z, ``Invalid token '```json``)은 Yojson 이
     펜스를 봤다는 뜻이므로 이 둘 중 하나이며, 어느 쪽인지는 tier 기록이 없어
     settlement 만으로는 가려지지 않는다.

--- a/lib/keeper/keeper_checkpoint_purge.ml
+++ b/lib/keeper/keeper_checkpoint_purge.ml
@@ -71,7 +71,7 @@ let is_assistant (message : Agent_core.Types.message) =
    (#25537). That outer guard had no rationale of its own: the commit message
    justified it with "providers replay [signed thinking] byte-exact", which the
    [signature = None] pattern already enforces per block. On an agentic keeper
-   the guard swallows nearly everything — measured on the sangsu checkpoint
+   the guard swallows nearly everything — measured on a live Keeper checkpoint
    after a full purge, 418 of 422 surviving unsigned Thinking blocks (490,370 B,
    41.0% of the 1,196,574 B file) sat in messages that also carried a ToolUse.
    Unsigned thinking additionally cannot be replayed to Anthropic in that
@@ -209,7 +209,7 @@ let purge_messages ~config messages =
          distinct assistant messages byte-identical, and only the stripped
          form participates in duplicate grouping. This ordering is what makes
          a single pass a fixpoint (verified by the idempotence test; measured
-         on the sangsu checkpoint, R1-first left 229 duplicates for a second
+         on the same checkpoint, R1-first left 229 duplicates for a second
          pass to find). *)
       let dedup_key_of message =
         if is_text_only message

--- a/lib/keeper/keeper_checkpoint_purge.mli
+++ b/lib/keeper/keeper_checkpoint_purge.mli
@@ -51,7 +51,7 @@ type config =
 
 val default_config : config
 (** [{ dup_threshold = 3; keep_recent_messages = 20; strip_thinking = true;
-      clear_tool_results = true }] — the rule set measured on the analyst
+      clear_tool_results = true }] — the rule set measured on a live Keeper
     checkpoint (1,315 -> 579 messages, -28.0% bytes, next-turn input
     -26.0%). *)
 

--- a/lib/keeper/keeper_claude_code_runtime.ml
+++ b/lib/keeper/keeper_claude_code_runtime.ml
@@ -536,7 +536,7 @@ let run_without_lifecycle ~runtime_id ~keeper_name
        conversation is not held here and cannot be measured from this process.
        What this process does send every turn - the prompt, the system prompt
        and the tool declarations - is measurable, and a live refusal says that
-       part alone is the problem: analyst was told the request is ~2,226,104
+       part alone is the problem: a live Keeper was told the request is ~2,226,104
        tokens against a 1,000,000 limit while "this conversation is only
        ~1,094,432 tokens - the rest is system prompt, tool definitions, and
        attachment content" (#27427). Recording the half this process controls

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -74,7 +74,7 @@ let keeper_fleet_messages_max () : int =
 
 (* How many of the keeper's own past turns are replayed as actions. The default
    is the depth the product states a keeper must not lose ("10턴 전에 한 자신의
-   발화나 행동"), and it fits: measured on taskmaster 2026-08-16, a turn renders
+   발화나 행동"), and it fits the measured fleet distribution: a turn renders
    at a median 1.6 KB, so ten turns add ~16 KB to a prompt that was assembling
    5.8 KB against a 131 KB runtime cap. *)
 let keeper_own_recent_turns_max_rp =

--- a/lib/keeper/keeper_config_text.ml
+++ b/lib/keeper/keeper_config_text.ml
@@ -88,7 +88,7 @@ let utf8_repair_string (s : string) : string =
 (* #10552: trim BOTH before and after [String_util.utf8_prefix].  The
    pre-fix sequence was [trim → prefix], but [String_util.utf8_prefix]
    can cut at a position that leaves trailing ASCII whitespace
-   (e.g. nick0cave's 322-byte desires field ends with [...는 것.] —
+   (e.g. a 322-byte live desires field ends with [...는 것.] —
    the prefix at max_bytes=320 backs up to byte 318, ending at the
    space before [것]). That made the previous normalizer
    non-idempotent: applying it once produces a 318-byte string ending

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -597,7 +597,7 @@ let run_keepalive_unified_turn
       then (
         (* #10008 fm3: emit per-reason skip counter so operators can
            see why proactive scheduler never fires for a given keeper.
-           scholar/executor stayed at [proactive_count_total=0,
+           two Keepers stayed at [proactive_count_total=0,
            last_proactive_ts=0.0] for 45+ min despite
            proactive_enabled=true — the info log alone buried the
            reason across many lines.  Labelled counter lets Grafana

--- a/lib/keeper/keeper_invocation_contract.ml
+++ b/lib/keeper/keeper_invocation_contract.ml
@@ -49,7 +49,7 @@ let exact_fields ~field ~allowed fields =
     | None -> Ok ()
     | Some key ->
       (* [allowed] is the answer the caller is looking for, and dropping it
-         made the rejection unactionable: live logs carry taskmaster trying
+         made the rejection unactionable: live logs carry a Keeper trying
          target.agent, then target.keeper_name, then target.keeper, one per
          call, against an allowed list of kind and name. Naming the accepted
          fields turns three round trips into one. *)

--- a/lib/keeper/keeper_own_recent_actions.ml
+++ b/lib/keeper/keeper_own_recent_actions.ml
@@ -14,7 +14,7 @@ type turn =
   }
 
 (* Sizing hint for the read window, not a bound on any row: how many calls a
-   turn typically makes. Measured on taskmaster 2026-08-16 over 932 calls --
+   turn typically makes. Measured on a live Keeper over 932 calls --
    median 8 per turn, p90 21. Reading short costs turns, never a partial turn:
    only the oldest group can be clipped by the window edge, and
    {!turns_of_rows} drops it. *)

--- a/lib/keeper/keeper_raw_trace_reader.ml
+++ b/lib/keeper/keeper_raw_trace_reader.ml
@@ -103,7 +103,7 @@ let trace_id_of_line ~file ~line_number line =
    for a page of at most [limit] entries. Measured 2026-08-12 over the 1,229
    retained traces on this host: p50 3.7 KB, p90 60 KB, p95 218 KB — and one
    runaway turn of 372.5 MB (16,801 tool executions in a single turn) holding
-   84% of the corpus. That one file made the listing take 3.35 s for [sangsu]
+   84% of the corpus. That one file made the listing take 3.35 s for one Keeper
    while another keeper with *more* files but less data answered in 0.039 s.
 
    With a per-file budget the listing costs O(entries x budget) no matter what

--- a/lib/keeper/keeper_runtime_contract.ml
+++ b/lib/keeper/keeper_runtime_contract.ml
@@ -39,7 +39,7 @@ let describe_pruned_goal = function
     succeeds ... but the task is now irrelevant") and closed the seconds-wide
     observe/claim race; its §8 comparison records that the chosen approach
     "doesn't catch goal property changes (status, phase)", which is the residue
-    this closes. Measured 2026-08-07: sangsu carried goal-request-menu-zero for
+    this closes. Measured 2026-08-07: one Keeper carried goal-request-menu-zero for
     5,362 tool calls across 2.5 days after it completed, stamped goal-bound the
     whole time, with an empty Active goals section in every one of those turns.
 

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -158,7 +158,7 @@ let schemas : tool_schema list = [
         ("mention_targets", `Assoc [
           ("type", `String "array");
           ("items", `Assoc [("type", `String "string")]);
-          ("description", `String "Exact direct-mention tokens that can wake the keeper in workspace traffic (for example ['sangsu']).");
+          ("description", `String "Exact direct-mention tokens that can wake the keeper in workspace traffic (for example ['example-keeper']).");
         ]);
         ("active_goal_ids", `Assoc [
           ("type", `String "array");

--- a/lib/keeper/keeper_task_cancellation_wake.ml
+++ b/lib/keeper/keeper_task_cancellation_wake.ml
@@ -36,8 +36,8 @@ let outcome_label = function
 
 (* Both actor fields are resolved to a canonical Keeper name before they are
    compared, because they are recorded in different vocabularies:
-   [created_by] holds a canonical Keeper name ("sangsu", "lane-smith") while
-   [cancelled_by] holds an agent name ("keeper-sangsu-agent"). Comparing the raw
+   [created_by] holds a canonical Keeper name ("keeper-a", "keeper-b") while
+   [cancelled_by] holds an agent name ("keeper-keeper-a-agent"). Comparing the raw
    strings reads a self-cancellation as a cross-Keeper one and wakes a Keeper
    about a decision it just made itself; resolving only by agent name finds no
    author at all.
@@ -86,8 +86,8 @@ let keeper_of_author ~config ~author =
    stores the acting [agent_name] verbatim — so the agent binding answers it
    completely. There is deliberately no lane-name fallback: no caller writes a
    lane name here, and accepting one resolved a non-Keeper actor whose id
-   happens to match a lane (an operator called "sangsu" against Keeper lane
-   "sangsu") to that Keeper, which then read as a self-cancellation and
+   happens to match a lane (an operator called "keeper-a" against Keeper lane
+   "keeper-a") to that Keeper, which then read as a self-cancellation and
    swallowed a wake the author was owed. *)
 let keeper_of_canceller ~config ~agent_name =
   keeper_of_agent_binding ~config ~actor:agent_name

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -779,7 +779,7 @@ let handle_tool_execute_typed
                   disposition marked the whole turn
                   Terminal_effect_failed (sticky), so a keeper probing a
                   missing path with `ls` died mid-mission — four turn
-                  deaths across the E0 campaign and the polisher pilot
+                  deaths across the E0 campaign and a pilot Keeper
                   (masc#28983). Only infra failures — sandbox dispatch,
                   secret projection, output/manifest persistence — keep
                   the failure disposition. *)

--- a/lib/keeper/keeper_tool_filesystem_runtime.ml
+++ b/lib/keeper/keeper_tool_filesystem_runtime.ml
@@ -197,7 +197,7 @@ let string_opt_nonempty name json =
    A keeper that guesses the host layout ("workspace/<org>/<repo>") gets the
    same "directory does not exist" as one that asked for a repo nobody
    materialized, and the two need opposite responses: retry with the right
-   path, or stop asking. Live taskmaster hit the first and kept retrying
+   path, or stop asking. A live Keeper hit the first and kept retrying
    (#23442). The set is measured, not prescribed: whatever git checkouts sit
    under the keeper's workspace root, wherever the keeper put them. An empty
    set is reported as empty rather than omitted, because "no repository is

--- a/lib/keeper/keeper_tool_voice_runtime.ml
+++ b/lib/keeper/keeper_tool_voice_runtime.ml
@@ -86,7 +86,7 @@ let handle_speak_with_outcome
          playback finishes". The former fire-and-forget queue returned
          status="queued" immediately, so the model never saw playback
          complete and re-spoke the same content every sub-turn
-         (2026-06-10 sangsu voice repeat incident). *)
+         (2026-06-10 live voice-repeat incident). *)
       authorize_external_effect
         ~operation:(command_to_string Speak)
         ~input:args

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -77,8 +77,8 @@ type try_provider_ctx =
        #27349 measured this against total elapsed wall-clock. Elapsed cannot
        separate "a turn that stopped" from "a turn that is taking a while",
        and on 2026-08-12 the same 900s value did both at once: it correctly
-       rotated 4 wedged sangsu attempts (65 minutes with zero trajectory
-       events) and killed a healthy rondo attempt 6 seconds after a
+       rotated 4 wedged attempts (65 minutes with zero trajectory
+       events) and killed a healthy Keeper attempt 6 seconds after a
        successful tool call (30+ tool calls inside the window, longest
        progress gap 120s). #28417 moves the measurement onto the progress
        signal, which is the distinction #27355's own observation side always
@@ -296,7 +296,7 @@ let attempt_stalled ~now ~threshold_sec ~attempt_started_at ~sample =
   | Some { last_progress_at; active_tool_count } ->
     (* A tool call that runs for minutes refreshes no progress signal while
        it runs, so tools in flight are work, not a stall. The 2026-08-12
-       rondo attempt spent 120s inside one [Execute] and was healthy. *)
+       live attempt spent 120s inside one [Execute] and was healthy. *)
     active_tool_count = 0 && now -. last_progress_at > threshold_sec
   | None ->
     (* Probe absent, or the keeper has no live turn observation to read.

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -129,7 +129,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
                   (* Ensure full session dir tree, not just base_dir (issue #3019) *)
                   ignore (Keeper_fs.ensure_dir (Filename.concat base_dir trace_id));
                   let bundle_paths =
-                    (* Surface masc-improver/sangsu sandbox boot
+                    (* Surface per-Keeper sandbox boot
                        silent-failure (2026-05-05).  Keeper_fs.ensure_dir
                        raises on filesystem error; the previous [ignore]
                        discarded it.  Now we log + emit a Otel_metric_store

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -1193,7 +1193,7 @@ let build_prompt_internal ~(meta : Keeper_meta_contract.keeper_meta)
            is the set the last turn described. A keeper that concluded "nothing
            actionable" reads "3 unclaimed" the same way whether those are the
            same three tasks or three different ones, so the conclusion outlives
-           whatever made it true. [taskmaster] -- whose instructions are to take
+           whatever made it true. A Keeper instructed to take
            unclaimed work on sight -- repeated one verbatim across every turn of
            a day while its stated reason, that the three were blocked, appeared
            nowhere in the backlog (#27629).

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -1304,8 +1304,8 @@ let failed_drives_wake failed_task_count = failed_task_count > 0
 (* An AwaitingVerification obligation is NOT a Keeper wake signal: the
    application-owned system LLM completion authority or authenticated HITL
    operator decides it out of band. Neither authority is a Keeper. Surfacing
-   it here would hand Keepers work that is not theirs — which is how a Keeper
-   named "verifier" came to hold approval authority in the first place. *)
+   it here would hand Keepers work that is not theirs — a concrete Keeper name
+   must never confer approval authority. *)
 let actionable_signal_present (observation : world_observation) =
   observation.pending_messages <> []
   || observation.pending_board_events <> []

--- a/lib/keeper/keeper_world_observation_inputs.ml
+++ b/lib/keeper/keeper_world_observation_inputs.ml
@@ -50,7 +50,7 @@ let rec tasks_with_identities = function
    Without this, a Keeper whose response to "an unclaimed task exists" is to
    create a routing/report task produces a closed positive feedback loop: the
    new task is itself an unclaimed Todo authored by the same keeper, so it
-   re-satisfies the trigger on the next observation. Live evidence: taskmaster
+   re-satisfies the trigger on the next observation. In the live incident, one Keeper
    authored 367 of the active tasks, 272 of them the same four "Route g0700 #N"
    templates re-emitted once per iteration (#28..#90), none ever claimed.
 

--- a/lib/mcp_tool_runtime_board.ml
+++ b/lib/mcp_tool_runtime_board.ml
@@ -145,7 +145,7 @@ let record_identity_raw_surface field raw canonical fields =
     1. Empty / "anonymous" -> fill from [agent_name].
     2. Caller's canonical equals ctx canonical -> keep the caller's
        canonicalisation (same keeper, possibly different surface form
-       like [keeper-velvet-hammer-agent] vs [velvet-hammer]).
+       like [keeper-example-keeper-agent] vs [example-keeper]).
     3. Caller's canonical disagrees -> rewrite the field to ctx
        canonical, preserve the caller's claim in
        [meta.<field>_caller_claim] for forensics, and increment

--- a/lib/otel_metric_store/otel_metric_names.ml
+++ b/lib/otel_metric_store/otel_metric_names.ml
@@ -232,8 +232,8 @@ let metric_tool_keeper_cache_ttl_parse_failures =
    view of allowed sandbox roots (for example [(roots=[<list>])]
    and [(sandbox roots: [<list>])]) to the LLM.  Combined with
    the keeper identity drift documented in the issue (turn 433:
-   contract emitted [masc-improver/Docker] while the resolver
-   enumerated [analyst]'s sandbox), the error became a
+   contract emitted a stale Keeper/sandbox pair while the resolver
+   enumerated another Keeper's sandbox), the error became a
    side-channel oracle for sibling sandboxes.
 
    The leak lives strictly in the user-visible string; the

--- a/lib/otel_metric_store/otel_metric_names.ml
+++ b/lib/otel_metric_store/otel_metric_names.ml
@@ -59,7 +59,7 @@
      rate(masc_keeper_turn_latency_bucket_total{bucket="600-1200s"}[5m])
    directly surfaces slow-turn keepers without needing the JSONL
    ledger.  20-minute turns from provider_timeout exhaustion
-   (#9933, observed 1,204,542 ms = 20 min on taskmaster
+   (#9933, observed 1,204,542 ms = 20 min on a live Keeper
    2026-04-24) appear in the [over_1200s] bucket and operators can
    alert on its rate.  Existing [masc_llm_inference_duration_seconds]
    histogram is labelled by [model] only (per-LLM-call latency); this

--- a/lib/runtime/runtime_antigravity.ml
+++ b/lib/runtime/runtime_antigravity.ml
@@ -88,8 +88,8 @@ type usage =
 
 (* Nothing in this tree branches on [permission_mode]: the only read of the
    field is its own parse site. It was closed, and the one member the CLI added
-   ended a turn, parked the official-client session, and stopped the keeper --
-   taskmaster, 110 turns in one hour (#28008). Adding that member leaves the
+   ended a turn, parked the official-client session, and stopped a live Keeper
+   after 110 turns in one hour (#28008). Adding that member leaves the
    next one to do it again, so an unseen mode is carried rather than rejected.
    [step_type] took the same route in #28027. *)
 type permission_mode =
@@ -277,7 +277,7 @@ let parse_step_state stage value =
    we have not seen carries no decision we could get wrong -- but rejecting it
    ends the turn and parks the session, which blocks every later turn for that
    Keeper. Live 2026-08-10: Antigravity began emitting "system_message" and
-   taskmaster stopped (#28027).
+   the affected Keeper stopped (#28027).
 
    #28029 opened this with [Unrecognized]; #28037 closed it again and named
    [System_message] instead. Naming the member that stalled a keeper leaves the

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -619,7 +619,7 @@ let terminal_result ~thread_id ~turn_id ~seen_final ~seen_fallback
    official-client session into Recovery_required and made every later turn for
    that keeper fail closed on `official_client_session.claim` until an operator
    resolved it by hand. Three such chunks accounted for 3,236 rejected turns
-   across sangsu, kidsnote and taskmaster in one retained log window (#27967). *)
+   across three Keepers in one retained log window (#27967). *)
 let item_delta_notification ~method_ ~thread_id ~turn_id params =
   let* fields = assoc_at method_ params in
   let* notification_thread_id = required_string method_ "threadId" fields in

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1692,7 +1692,7 @@ let start_keeper_loops_owned
       (* A keeper filtered out here is config-bootable but its admission is
          still owned by a durable shutdown operation from the boot scan.
          Stamp it into the excluded list instead of dropping it silently —
-         the 2026-07-21 wedge left rondo absent from both the boot set and
+         the 2026-07-21 wedge left one Keeper absent from both the boot set and
          the excluded list, so the outage was invisible in the autoboot
          report. Boot recovery settles recoverable operations in this same
          bootstrap, after which the supervisor's periodic pass registers the
@@ -1802,7 +1802,7 @@ let start_keeper_loops_owned
                  fiber flips the registry to running asynchronously on the
                  next Eio tick, so querying is_running here is a race that
                  keepers with a larger proactive-warmup idx lose
-                 deterministically (verdict=165s / sojin=150s / sangsu=135s
+                 deterministically (keeper-a=165s / keeper-b=150s / keeper-c=135s
                  produced the bulk of the false-positive "not in registry"
                  WARNs).  Check the synchronous is_registered predicate
                  instead — the running transition is observed later by the

--- a/lib/server/server_dashboard_http_composite_claims.ml
+++ b/lib/server/server_dashboard_http_composite_claims.ml
@@ -114,7 +114,7 @@ let row_is_task_claim json =
    [filter_rows_for_keeper] rings a busy keeper down to its last
    [claim_rows_per_keeper] rows, which usually trims the older claim away and
    leaves the newer one to be found by accident; a quiet keeper keeps both and
-   reports the superseded task. Measured live: keeper [analyst] (46 rows in
+   reports the superseded task. Measured on one live Keeper (46 rows in
    window, nothing trimmed) reported task-305 while it had claimed task-306.
    See #28437.
 

--- a/lib/task/tool_task_args.ml
+++ b/lib/task/tool_task_args.ml
@@ -88,7 +88,7 @@ let synthesize_summary_from_siblings args =
    outcome of work it did. Pure ownership transitions (Claim, Start)
    have no outcome to summarize yet, so requiring a summary just makes
    the LLM either invent one (degrading audit signal) or fail the call
-   entirely (the 2026-05-17 nick0cave production case).
+   entirely (the 2026-05-17 production case).
 
    Exit-class actions:
      Cancel / Release / Submit_for_verification

--- a/lib/task/tool_task_handlers.ml
+++ b/lib/task/tool_task_handlers.ml
@@ -409,7 +409,7 @@ let handle_claim ~tool_name ~start_time ctx args =
 
    This is consumed only by [format_no_eligible] below, to give the LLM
    the *current* goal phase instead of letting it infer "completed goal"
-   from the bare excluded_count. See PR body for the velvet-hammer
+   from the bare excluded_count. See PR body for the live Keeper
    misdiagnosis that motivated this surface. *)
 let active_goal_phases_for_agent ctx =
   (current_task_owner_hooks ()).active_goal_phases_for_agent

--- a/lib/tool_surface/tool_shard_types_board_keeper_projection.ml
+++ b/lib/tool_surface/tool_shard_types_board_keeper_projection.ml
@@ -146,7 +146,7 @@ let schemas : Masc_domain.tool_schema list =
                      (board_tool_post.ml handle_post_list) already
                      reads [compact] (default true), but the keeper surface
                      omitted it, so a keeper could never request full output
-                     and qa-king's [compact] arg was rejected as an
+                     and a live Keeper's [compact] arg was rejected as an
                      unsupported field. additionalProperties stays false —
                      unknown fields remain fail-closed. *)
                   ( "compact"

--- a/lib/workspace/nickname.ml
+++ b/lib/workspace/nickname.ml
@@ -79,7 +79,7 @@ let is_dictionary_generated_nickname name =
 
 (** Extract the stable agent prefix from a generated nickname.
     "<prefix>-<adj>-<animal>" -> Some "<prefix>"
-    "qa-king-warm-heron" -> Some "qa-king"
+    "example-keeper-warm-heron" -> Some "example-keeper"
     "<prefix>" -> Some "<prefix>" (legacy bare-prefix form) *)
 let extract_agent_type name =
   let parts = String.split_on_char '-' name in

--- a/lib/workspace/task_cache_invariant.ml
+++ b/lib/workspace/task_cache_invariant.ml
@@ -152,7 +152,7 @@ let clear_stale_agent_task_for_task
     Returns [None] when the task is not found (treat as unknown; caller decides).
 
     @param module_name  Short ASCII label for the diagnostic log,
-    e.g. ["taskmaster.broadcast"] or ["mention_tracker.emit"]. *)
+    e.g. ["workspace.broadcast"] or ["mention_tracker.emit"]. *)
 let with_fresh_task_status
       config
       ~(agent_name : string)

--- a/lib/workspace/workspace_core.ml
+++ b/lib/workspace/workspace_core.ml
@@ -164,7 +164,7 @@ let clear_agent_current_task_cache config ~task_id =
 (* #13460: cache desync invalidation counter. Workspace_broadcast emits this when
    it replaces an active-claim/release message for a terminal backlog task with
    a cache_invalidated broadcast.  Clear workspace-owned current_task caches so the
-   same stale claim does not re-emit every taskmaster cycle.  Keep labels
+   same stale claim does not re-emit every Keeper cycle. Keep labels
    fleet-bounded; the task id stays in the replacement message/event, not the
    Otel_metric_store series key. *)
 let record_cache_desync_cleared config ~module_name:_ ~task_id ~status =
@@ -220,7 +220,6 @@ let () =
                   ()))
          active_agents)
 ;;
-
 
 
 

--- a/packages/agent_core/test/test_tool_execution.ml
+++ b/packages/agent_core/test/test_tool_execution.ml
@@ -779,7 +779,7 @@ let test_unknown_tool_is_uniform_validation_with_full_diagnostics () =
 ;;
 
 (* masc#29008: the model can fuse arguments into the name slot
-   ([Execute["argv"]], live rondo shape) or typo a name. Lookup stays
+   ([Execute["argv"]], live Keeper shape) or typo a name. Lookup stays
    exact; the reject message must name the received shape and the
    nearest registered name so the model can repair the call instead of
    resending the same broken string. A bare unknown identifier with no

--- a/test/board_addressing/test_board_addressing.ml
+++ b/test/board_addressing/test_board_addressing.ml
@@ -23,8 +23,8 @@ let test_trim_token_edges () =
   check string "wrapping parens" "@alice" (Board_addressing.trim_token_edges "(@alice)");
   check string "email keeps internal dot" "email@alice.com"
     (Board_addressing.trim_token_edges "email@alice.com");
-  check string "possessive apostrophe kept" "@sangsu's"
-    (Board_addressing.trim_token_edges "@sangsu's");
+  check string "possessive apostrophe kept" "@alpha's"
+    (Board_addressing.trim_token_edges "@alpha's");
   check string "all non-word" "" (Board_addressing.trim_token_edges "...")
 
 let test_tokens_of_text () =
@@ -60,22 +60,22 @@ let test_parse_targets () =
   check_parse "mid-token at is not a target" "none" "mid@alice token";
   check_parse "bare at is the empty candidate" "targets:" "@ bare at";
   check_parse "trailing punctuation trimmed" "targets:alice" "ok @alice, thanks";
-  check_parse "possessive stays distinct" "targets:sangsu's" "@sangsu's note"
+  check_parse "possessive stays distinct" "targets:alpha's" "@alpha's note"
 
 let test_parse_broadcast () =
   check_parse "exact broadcast" "broadcast" "release note @@all";
   check_parse "broadcast selector compare is case-insensitive" "broadcast"
     "release note @@ALL";
-  check_parse "unsupported selector" "unsupported:analyst" "release note @@analyst";
-  check_parse "unsupported selectors lowercased" "unsupported:analyst"
-    "release note @@Analyst";
+  check_parse "unsupported selector" "unsupported:delta" "release note @@delta";
+  check_parse "unsupported selectors lowercased" "unsupported:delta"
+    "release note @@Delta";
   check_parse "empty broadcast selector fails closed" "unsupported:" "release @@";
-  check_parse "mixed all and unsupported fails closed" "unsupported:all,analyst"
-    "@@all @@analyst";
+  check_parse "mixed all and unsupported fails closed" "unsupported:all,delta"
+    "@@all @@delta";
   check_parse "broadcast precedence over direct targets" "broadcast"
     "@@all and @alpha";
-  check_parse "unsupported broadcast hides direct targets" "unsupported:analyst"
-    "@@analyst and @alpha"
+  check_parse "unsupported broadcast hides direct targets" "unsupported:delta"
+    "@@delta and @alpha"
 
 (* Code spans are not address text. Every one of these strings appeared in a
    live Board comment that was rejected whole: @internals/libs/datadogRum

--- a/test/keeper_recording_error_state/test_keeper_recording_error_state.ml
+++ b/test/keeper_recording_error_state/test_keeper_recording_error_state.ml
@@ -6,9 +6,9 @@ let reset () = S.reset_for_test ()
 let test_record_first_then_repeated () =
   reset ();
   let error = "opaque diagnostic text" in
-  check bool "first" true (S.record ~keeper:"verifier" ~error = `First);
-  check bool "second" true (S.record ~keeper:"verifier" ~error = `Repeated 2);
-  check bool "third" true (S.record ~keeper:"verifier" ~error = `Repeated 3)
+  check bool "first" true (S.record ~keeper:"fixture-reviewer" ~error = `First);
+  check bool "second" true (S.record ~keeper:"fixture-reviewer" ~error = `Repeated 2);
+  check bool "third" true (S.record ~keeper:"fixture-reviewer" ~error = `Repeated 3)
 ;;
 
 let test_distinct_keepers_are_independent () =

--- a/test/multimodal/test_artifact.ml
+++ b/test/multimodal/test_artifact.ml
@@ -80,7 +80,7 @@ let test_provenance_with_origins_round_trip () =
   let pr =
     {
       Pr.origin_artifact_ids = [ id1; id2 ];
-      created_by = "executor";
+      created_by = "omega";
       created_at = 9999.0;
     }
   in
@@ -100,7 +100,7 @@ let make_image_artifact () : A.image A.t =
     kind = A.Image;
     payload = P.Blob_ref "img-blob-1";
     metadata = `Assoc [ ("width", `Int 800); ("height", `Int 600) ];
-    provenance = Pr.provenance_empty ~created_by:"executor" ~created_at:1.0;
+    provenance = Pr.provenance_empty ~created_by:"omega" ~created_at:1.0;
   }
 [@@warning "-37"]
 
@@ -136,7 +136,7 @@ let test_homogeneous_list_of_any () =
       kind = A.Code;
       payload = P.Streaming 0;
       metadata = `Null;
-      provenance = Pr.provenance_empty ~created_by:"executor" ~created_at:2.0;
+      provenance = Pr.provenance_empty ~created_by:"omega" ~created_at:2.0;
     }
   in
   let xs = [ A.Any a_img; A.Any a_code ] in

--- a/test/multimodal/test_multimodal_hydrator.ml
+++ b/test/multimodal/test_multimodal_hydrator.ml
@@ -115,7 +115,7 @@ let make_doc_artifact id : A.doc A.t =
     kind = A.Doc;
     payload = P.Blob_ref (Aid.to_string id ^ "-blob");
     metadata = `Null;
-    provenance = Pr.provenance_empty ~created_by:"executor" ~created_at:1.0;
+    provenance = Pr.provenance_empty ~created_by:"omega" ~created_at:1.0;
   }
 [@@warning "-37"]
 

--- a/test/multimodal/test_multimodal_keeper_bridge.ml
+++ b/test/multimodal/test_multimodal_keeper_bridge.ml
@@ -84,7 +84,7 @@ let test_hydrate_one_provenance () =
   let parent = Aid.generate () in
   let raw = make_raw "image" in
   match
-    B.hydrate_one raw ~now:5.0 ~created_by:"executor"
+    B.hydrate_one raw ~now:5.0 ~created_by:"omega"
       ~origin_artifact_ids:[ parent ]
   with
   | None -> failwith "expected hydrate"
@@ -92,7 +92,7 @@ let test_hydrate_one_provenance () =
       check_bool "1 origin"
         (List.length art.provenance.origin_artifact_ids = 1);
       check_bool "created_by carries through"
-        (String.equal art.provenance.created_by "executor");
+        (String.equal art.provenance.created_by "omega");
       check_bool "created_at = 5.0"
         (Float.equal art.provenance.created_at 5.0)
 

--- a/test/multimodal/test_workspace.ml
+++ b/test/multimodal/test_workspace.ml
@@ -10,7 +10,7 @@ let make_artifact ~id ~kind ~payload ~metadata ts =
   ; kind
   ; payload
   ; metadata
-  ; provenance = A.provenance_empty ~created_by:"executor" ~created_at:ts
+  ; provenance = A.provenance_empty ~created_by:"omega" ~created_at:ts
   }
 
 let make_doc id ts =

--- a/test/test_activity_graph.ml
+++ b/test/test_activity_graph.ml
@@ -102,7 +102,7 @@ let test_events_json_derives_ide_context () =
   with_config (fun config ->
       ignore
         (Activity_graph.emit config ~kind:"keeper.turn_completed"
-           ~actor:(Activity_graph.entity ~kind:"keeper" "sangsu")
+           ~actor:(Activity_graph.entity ~kind:"keeper" "alpha")
            ~subject:(Activity_graph.entity ~kind:"log" "turn-9")
            ~tags:[
              "file:lib/keeper/keeper_tool_ide_runtime.ml:27";
@@ -151,7 +151,7 @@ let test_events_json_normalizes_ide_context_file_paths () =
   with_config (fun config ->
       ignore
         (Activity_graph.emit config ~kind:"keeper.turn_completed"
-           ~actor:(Activity_graph.entity ~kind:"keeper" "sangsu")
+           ~actor:(Activity_graph.entity ~kind:"keeper" "alpha")
            ~subject:(Activity_graph.entity ~kind:"log" "turn-payload")
            ~tags:[]
            ~payload:
@@ -163,7 +163,7 @@ let test_events_json_normalizes_ide_context_file_paths () =
            ());
       ignore
         (Activity_graph.emit config ~kind:"keeper.turn_completed"
-           ~actor:(Activity_graph.entity ~kind:"keeper" "sangsu")
+           ~actor:(Activity_graph.entity ~kind:"keeper" "alpha")
            ~subject:(Activity_graph.entity ~kind:"log" "turn-tag")
            ~tags:[ "file: lib\\tag.ml:27" ]
            ~payload:(`Assoc [])
@@ -186,7 +186,7 @@ let test_events_json_omits_unsafe_ide_context_file_paths () =
   with_config (fun config ->
       ignore
         (Activity_graph.emit config ~kind:"keeper.turn_completed"
-           ~actor:(Activity_graph.entity ~kind:"keeper" "sangsu")
+           ~actor:(Activity_graph.entity ~kind:"keeper" "alpha")
            ~subject:(Activity_graph.entity ~kind:"log" "turn-absolute")
            ~tags:[]
            ~payload:
@@ -198,21 +198,21 @@ let test_events_json_omits_unsafe_ide_context_file_paths () =
            ());
       ignore
         (Activity_graph.emit config ~kind:"keeper.turn_completed"
-           ~actor:(Activity_graph.entity ~kind:"keeper" "sangsu")
+           ~actor:(Activity_graph.entity ~kind:"keeper" "alpha")
            ~subject:(Activity_graph.entity ~kind:"log" "turn-drive")
            ~tags:[ "file:C:\\workspace\\lib\\tag.ml:27" ]
            ~payload:(`Assoc [])
            ());
       ignore
         (Activity_graph.emit config ~kind:"keeper.turn_completed"
-           ~actor:(Activity_graph.entity ~kind:"keeper" "sangsu")
+           ~actor:(Activity_graph.entity ~kind:"keeper" "alpha")
            ~subject:(Activity_graph.entity ~kind:"log" "turn-traversal")
            ~tags:[ "file:lib/../tag.ml:31" ]
            ~payload:(`Assoc [])
            ());
       ignore
         (Activity_graph.emit config ~kind:"keeper.turn_completed"
-           ~actor:(Activity_graph.entity ~kind:"keeper" "sangsu")
+           ~actor:(Activity_graph.entity ~kind:"keeper" "alpha")
            ~subject:(Activity_graph.entity ~kind:"log" "turn-mismatch")
            ~tags:[ "file:/workspace/lib/tag.ml:99" ]
            ~payload:
@@ -252,7 +252,7 @@ let test_events_json_ignores_invalid_derived_pr_number () =
   with_config (fun config ->
       ignore
         (Activity_graph.emit config ~kind:"keeper.turn_completed"
-           ~actor:(Activity_graph.entity ~kind:"keeper" "sangsu")
+           ~actor:(Activity_graph.entity ~kind:"keeper" "alpha")
            ~subject:(Activity_graph.entity ~kind:"log" "turn-10")
            ~tags:[]
            ~payload:(`Assoc [ ("pr_number", `Int 0) ])

--- a/test/test_audit_log.ml
+++ b/test/test_audit_log.ml
@@ -349,7 +349,7 @@ let test_runtime_config_write_assignment_projection () =
           [
             ("path", `String "/x/config/runtime.toml");
             ("operation", `String "assignment");
-            ("keeper_name", `String "verifier");
+            ("keeper_name", `String "fixture-reviewer");
             ("runtime_id", `String "ollama_cloud.deepseek-v4-flash");
             ("cleared", `Bool false);
             ("bytes", `Int 18783);
@@ -371,7 +371,7 @@ let test_runtime_config_write_assignment_projection () =
     | _ -> failf "audit_event_json is not an object"
   in
   check string "summary"
-    "runtime.toml assignment updated: verifier -> ollama_cloud.deepseek-v4-flash"
+    "runtime.toml assignment updated: fixture-reviewer -> ollama_cloud.deepseek-v4-flash"
     (field "summary");
   check string "target" "/x/config/runtime.toml" (field "target");
   check string "severity" "warn" (field "severity")

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -466,17 +466,17 @@ let test_verify_token_reports_token_owner_on_agent_mismatch () =
 
 let test_verify_token_allows_generated_alias_for_token_owner_prefix () =
   let dir = setup_test_workspace () in
-  let create_result = Auth.create_token dir ~agent_name:"qa-king" ~role:Masc_domain.Worker in
+  let create_result = Auth.create_token dir ~agent_name:"mu-king" ~role:Masc_domain.Worker in
   let verify_result =
     match create_result with
     | Ok (raw_token, _) ->
-        Auth.verify_token dir ~agent_name:"qa-king-warm-heron" ~token:raw_token
+        Auth.verify_token dir ~agent_name:"mu-king-warm-heron" ~token:raw_token
     | Error e -> Error e
   in
   cleanup_test_workspace dir;
   match create_result, verify_result with
   | Ok _, Ok cred ->
-      check string "token owner credential returned" "qa-king" cred.agent_name;
+      check string "token owner credential returned" "mu-king" cred.agent_name;
       check bool "role preserved" true (cred.role = Masc_domain.Worker)
   | Ok _, Error e ->
       fail
@@ -524,7 +524,7 @@ let test_load_credential_redirect_stub () =
     {
       id = Some id;
       agent_id = None;
-      agent_name = "adversary";
+      agent_name = "lambda";
       token = "hashed-token";
       role = Masc_domain.Worker;
       created_at = "2026-01-01T00:00:00Z";
@@ -532,14 +532,14 @@ let test_load_credential_redirect_stub () =
     }
   in
   Auth.save_credential dir cred;
-  let stub_hit = Auth.load_credential dir "adversary" in
+  let stub_hit = Auth.load_credential dir "lambda" in
   let uuid_hit = Auth.load_credential dir (Masc_domain.Credential_id.to_string id) in
   cleanup_test_workspace dir;
   (match stub_hit with
-   | Some loaded when loaded.agent_name = "adversary" -> ()
+   | Some loaded when loaded.agent_name = "lambda" -> ()
    | _ -> fail "redirect stub should resolve to UUID-backed credential");
   (match uuid_hit with
-   | Some loaded when loaded.agent_name = "adversary" -> ()
+   | Some loaded when loaded.agent_name = "lambda" -> ()
    | _ -> fail "direct UUID lookup should resolve")
 
 let test_delete_uuid_backed_credential_removes_redirect_target () =
@@ -553,7 +553,7 @@ let test_delete_uuid_backed_credential_removes_redirect_target () =
         {
           id = Some id;
           agent_id = None;
-          agent_name = "adversary";
+          agent_name = "lambda";
           token = Auth.sha256_hash raw_token;
           role = Masc_domain.Worker;
           created_at = "2026-01-01T00:00:00Z";
@@ -561,16 +561,16 @@ let test_delete_uuid_backed_credential_removes_redirect_target () =
         }
       in
       Auth.save_credential dir cred;
-      (match Auth.verify_token dir ~agent_name:"adversary" ~token:raw_token with
+      (match Auth.verify_token dir ~agent_name:"lambda" ~token:raw_token with
        | Ok _ -> ()
        | Error e ->
            fail
              (Printf.sprintf
                 "uuid-backed credential should verify before delete: %s"
                 (Masc_domain.masc_error_to_string e)));
-      Auth.delete_credential dir "adversary";
+      Auth.delete_credential dir "lambda";
       check bool "agent stub removed" true
-        (Option.is_none (Auth.load_credential dir "adversary"));
+        (Option.is_none (Auth.load_credential dir "lambda"));
       check bool "uuid target removed" true
         (Option.is_none
            (Auth.load_credential dir (Masc_domain.Credential_id.to_string id)));
@@ -590,47 +590,47 @@ let test_load_credential_exact_wins_over_fallback () =
   (* If both the nickname file and the prefix file exist, the exact
      match wins so a per-nickname override remains possible. *)
   let dir = setup_test_workspace () in
-  let _ = Auth.create_token dir ~agent_name:"adversary" ~role:Masc_domain.Worker in
-  let _ = Auth.create_token dir ~agent_name:"adversary-fair-tapir" ~role:Masc_domain.Admin in
-  let resolved = Auth.load_credential dir "adversary-fair-tapir" in
+  let _ = Auth.create_token dir ~agent_name:"lambda" ~role:Masc_domain.Worker in
+  let _ = Auth.create_token dir ~agent_name:"lambda-fair-tapir" ~role:Masc_domain.Admin in
+  let resolved = Auth.load_credential dir "lambda-fair-tapir" in
   cleanup_test_workspace dir;
   match resolved with
-  | Some cred when cred.agent_name = "adversary-fair-tapir" && cred.role = Masc_domain.Admin -> ()
+  | Some cred when cred.agent_name = "lambda-fair-tapir" && cred.role = Masc_domain.Admin -> ()
   | Some cred ->
       fail (Printf.sprintf "unexpected resolution: %s/%s" cred.agent_name
               (match cred.role with Worker -> "Worker" | Admin -> "Admin"))
   | None -> fail "exact match should resolve"
 
 let test_extract_agent_type_prefix_keeper_aliases () =
-  check (option string) "keeper simple alias" (Some "sangsu")
-    (Auth.extract_agent_type_prefix "keeper-sangsu-agent");
-  check (option string) "keeper hyphenated alias" (Some "masc-improver")
-    (Auth.extract_agent_type_prefix "keeper-masc-improver-agent");
-  check (option string) "generated nickname" (Some "adversary")
-    (Auth.extract_agent_type_prefix "adversary-fair-tapir");
-  check (option string) "hyphenated generated nickname" (Some "qa-king")
-    (Auth.extract_agent_type_prefix "qa-king-warm-heron");
-  check (option string) "hyphenated generated nickname unique" (Some "qa-king")
-    (Auth.extract_agent_type_prefix "qa-king-warm-heron-a3b2");
-  check (option string) "plain name stays plain" (Some "sangsu")
-    (Auth.extract_agent_type_prefix "sangsu");
+  check (option string) "keeper simple alias" (Some "alpha")
+    (Auth.extract_agent_type_prefix "keeper-alpha-agent");
+  check (option string) "keeper hyphenated alias" (Some "omicron-improver")
+    (Auth.extract_agent_type_prefix "keeper-omicron-improver-agent");
+  check (option string) "generated nickname" (Some "lambda")
+    (Auth.extract_agent_type_prefix "lambda-fair-tapir");
+  check (option string) "hyphenated generated nickname" (Some "mu-king")
+    (Auth.extract_agent_type_prefix "mu-king-warm-heron");
+  check (option string) "hyphenated generated nickname unique" (Some "mu-king")
+    (Auth.extract_agent_type_prefix "mu-king-warm-heron-a3b2");
+  check (option string) "plain name stays plain" (Some "alpha")
+    (Auth.extract_agent_type_prefix "alpha");
   check (option string) "two segment keeper fallback unchanged" (Some "keeper")
-    (Auth.extract_agent_type_prefix "keeper-sangsu")
+    (Auth.extract_agent_type_prefix "keeper-alpha")
 
 let test_verify_token_keeper_exact_match () =
   (* UUID-based storage removes nickname-prefix collapse.  Keeper
      credentials must be looked up by their exact agent_name. *)
   let dir = setup_test_workspace () in
   let result =
-    match Auth.ensure_keeper_credential dir ~agent_name:"keeper-sangsu-agent" with
+    match Auth.ensure_keeper_credential dir ~agent_name:"keeper-alpha-agent" with
     | Ok (raw_token, _) ->
-        Auth.verify_token dir ~agent_name:"keeper-sangsu-agent" ~token:raw_token
+        Auth.verify_token dir ~agent_name:"keeper-alpha-agent" ~token:raw_token
     | Error e -> Error e
   in
   cleanup_test_workspace dir;
   match result with
   | Ok cred ->
-      check string "keeper credential exact match" "keeper-sangsu-agent" cred.agent_name
+      check string "keeper credential exact match" "keeper-alpha-agent" cred.agent_name
   | Error e ->
       fail
         (Printf.sprintf
@@ -638,8 +638,8 @@ let test_verify_token_keeper_exact_match () =
            (Masc_domain.masc_error_to_string e))
 
 (* Was: this test validated a legacy fallback where a bare-form
-   credential ("sangsu") was accepted as a verification source for a
-   canonical lookup ("keeper-sangsu-agent"). That fallback was the
+   credential ("alpha") was accepted as a verification source for a
+   canonical lookup ("keeper-alpha-agent"). That fallback was the
    mechanism by which dual-identity credentials silently coexisted --
    any path that minted a bare credential created a second valid
    identity for the same keeper.
@@ -654,7 +654,7 @@ let test_verify_token_keeper_alias_archives_dual_identity_bare () =
   Fun.protect
     ~finally:(fun () -> cleanup_test_workspace dir)
     (fun () ->
-      match Auth.create_token dir ~agent_name:"sangsu" ~role:Masc_domain.Worker with
+      match Auth.create_token dir ~agent_name:"alpha" ~role:Masc_domain.Worker with
       | Error e ->
           fail
             (Printf.sprintf "stable keeper token creation failed: %s"
@@ -662,7 +662,7 @@ let test_verify_token_keeper_alias_archives_dual_identity_bare () =
       | Ok (stale_bare_token, _) -> (
           match
             Auth.ensure_keeper_credential dir
-              ~agent_name:"keeper-sangsu-agent"
+              ~agent_name:"keeper-alpha-agent"
           with
           | Error e ->
               fail
@@ -671,11 +671,11 @@ let test_verify_token_keeper_alias_archives_dual_identity_bare () =
           | Ok _ -> (
               check bool "canonical credential exists" true
                 (Option.is_some
-                   (Auth.load_credential dir "keeper-sangsu-agent"));
+                   (Auth.load_credential dir "keeper-alpha-agent"));
               (* PR-3a behavior: bare credential is archived, the bare
                  token is now stale and must not authenticate. *)
               match
-                Auth.verify_token dir ~agent_name:"keeper-sangsu-agent"
+                Auth.verify_token dir ~agent_name:"keeper-alpha-agent"
                   ~token:stale_bare_token
               with
               | Ok cred ->
@@ -695,7 +695,7 @@ let test_load_credential_missing_keeper_alias_stays_quiet () =
         let resolved = ref None in
         let stderr_output =
           capture_stderr (fun () ->
-            resolved := Auth.load_credential dir "keeper-sangsu-agent")
+            resolved := Auth.load_credential dir "keeper-alpha-agent")
         in
         (!resolved, stderr_output))
   in
@@ -787,15 +787,15 @@ let test_ensure_keeper_credential_uses_per_keeper_token () =
     (fun () ->
       let ensure_result =
         with_env "MASC_TOKEN" "" (fun () ->
-          Auth.ensure_keeper_credential dir ~agent_name:"keeper-masc-improver-agent")
+          Auth.ensure_keeper_credential dir ~agent_name:"keeper-omicron-improver-agent")
       in
       match ensure_result with
       | Ok (raw_token, cred) ->
           let raw_token_path =
             Filename.concat (Auth.auth_dir dir)
-              "keeper-masc-improver-agent.token"
+              "keeper-omicron-improver-agent.token"
           in
-          check string "keeper credential exact name" "keeper-masc-improver-agent" cred.agent_name;
+          check string "keeper credential exact name" "keeper-omicron-improver-agent" cred.agent_name;
           check bool "keeper credential has uuid id" true (Option.is_some cred.id);
           check bool "keeper credential is worker" true (cred.role = Masc_domain.Worker);
           check bool "keeper bearer is not the shared internal token" false
@@ -807,16 +807,16 @@ let test_ensure_keeper_credential_uses_per_keeper_token () =
           check string "raw token hashes to keeper credential"
             cred.token (Auth.sha256_hash raw_token);
           check bool "keeper credential persisted by exact name" true
-            (Option.is_some (Auth.load_credential dir "keeper-masc-improver-agent"));
+            (Option.is_some (Auth.load_credential dir "keeper-omicron-improver-agent"));
           check bool "no normalized keeper credential persisted" true
-            (Option.is_none (Auth.load_credential dir "masc-improver"));
+            (Option.is_none (Auth.load_credential dir "omicron-improver"));
           (match
-             Auth.verify_token dir ~agent_name:"keeper-masc-improver-agent"
+             Auth.verify_token dir ~agent_name:"keeper-omicron-improver-agent"
                ~token:raw_token
            with
            | Ok verified ->
                check string "keeper bearer verifies exact agent"
-                 "keeper-masc-improver-agent" verified.agent_name
+                 "keeper-omicron-improver-agent" verified.agent_name
            | Error e ->
                fail
                  (Printf.sprintf
@@ -835,10 +835,10 @@ let test_ensure_keeper_credential_reuses_persisted_raw_token_when_env_mismatched
     (fun () ->
       let first_result =
         with_env "MASC_TOKEN" "" (fun () ->
-          Auth.ensure_keeper_credential dir ~agent_name:"keeper-masc-improver-agent")
+          Auth.ensure_keeper_credential dir ~agent_name:"keeper-omicron-improver-agent")
       in
       let raw_token_path =
-        Filename.concat (Auth.auth_dir dir) "keeper-masc-improver-agent.token"
+        Filename.concat (Auth.auth_dir dir) "keeper-omicron-improver-agent.token"
       in
       let shared_raw_token = "shared-codex-token" in
       let _ =
@@ -847,7 +847,7 @@ let test_ensure_keeper_credential_reuses_persisted_raw_token_when_env_mismatched
       in
       let reused_result =
         with_env "MASC_TOKEN" shared_raw_token (fun () ->
-          Auth.ensure_keeper_credential dir ~agent_name:"keeper-masc-improver-agent")
+          Auth.ensure_keeper_credential dir ~agent_name:"keeper-omicron-improver-agent")
       in
       match first_result, reused_result with
       | Ok (first_raw_token, first_cred), Ok (reused_raw_token, reused_cred) ->
@@ -855,9 +855,9 @@ let test_ensure_keeper_credential_reuses_persisted_raw_token_when_env_mismatched
             (Sys.file_exists raw_token_path);
           check int "persisted raw token file mode 0600" 0o600
             (permission_bits raw_token_path);
-          check string "first credential uses exact keeper name" "keeper-masc-improver-agent"
+          check string "first credential uses exact keeper name" "keeper-omicron-improver-agent"
             first_cred.agent_name;
-          check string "reused credential keeps exact keeper name" "keeper-masc-improver-agent"
+          check string "reused credential keeps exact keeper name" "keeper-omicron-improver-agent"
             reused_cred.agent_name;
           check string "persisted keeper raw token reused" first_raw_token
             reused_raw_token
@@ -875,13 +875,13 @@ let test_ensure_keeper_credential_reuses_uuid () =
       let result =
         with_env "MASC_INTERNAL_MCP_TOKEN" "shared-keeper-token" (fun () ->
           match
-            Auth.ensure_keeper_credential dir ~agent_name:"keeper-masc-improver-agent"
+            Auth.ensure_keeper_credential dir ~agent_name:"keeper-omicron-improver-agent"
           with
           | Error e -> Error e
           | Ok (_, first_cred) -> (
               match
                 Auth.ensure_keeper_credential dir
-                  ~agent_name:"keeper-masc-improver-agent"
+                  ~agent_name:"keeper-omicron-improver-agent"
               with
               | Error e -> Error e
               | Ok (_, second_cred) -> Ok (first_cred, second_cred)))
@@ -1130,7 +1130,7 @@ let test_authorize_known_keeper_tool_strict_worker_allowed () =
   let dir = setup_test_workspace () in
   let _ = Auth.enable_auth dir ~require_token:true ~agent_name:"test-admin" in
   let create_result =
-    Auth.create_token dir ~agent_name:"keeper-analyst-agent" ~role:Masc_domain.Worker
+    Auth.create_token dir ~agent_name:"keeper-delta-agent" ~role:Masc_domain.Worker
   in
   let result =
     match create_result with
@@ -1140,7 +1140,7 @@ let test_authorize_known_keeper_tool_strict_worker_allowed () =
              match acc with
              | Error _ as e -> e
              | Ok () ->
-                 Auth.authorize_tool dir ~agent_name:"keeper-analyst-agent"
+                 Auth.authorize_tool dir ~agent_name:"keeper-delta-agent"
                    ~token:(Some raw_token) ~tool_name)
           (Ok ()) keeper_strict_auth_regression_tools
     | Error e -> Error e
@@ -1157,7 +1157,7 @@ let test_authorize_tool_v2_known_keeper_tool_strict_worker_allowed () =
          match acc with
          | Error _ as e -> e
          | Ok () ->
-             Auth.authorize_tool_for_role ~agent_name:"keeper-analyst-agent"
+             Auth.authorize_tool_for_role ~agent_name:"keeper-delta-agent"
                ~role:Masc_domain.Worker ~tool_name)
       (Ok ()) keeper_strict_auth_regression_tools
   in
@@ -1200,7 +1200,7 @@ let test_authorize_tool_v2_enforces_catalog_permission () =
 
 let test_authorize_tool_v2_unknown_keeper_prefix_strict_denied () =
   let result =
-    Auth.authorize_tool_for_role ~agent_name:"keeper-analyst-agent"
+    Auth.authorize_tool_for_role ~agent_name:"keeper-delta-agent"
       ~role:Masc_domain.Worker ~tool_name:"keeper_totally_fake"
   in
   match result with

--- a/test/test_auth_load_credential_of.ml
+++ b/test/test_auth_load_credential_of.ml
@@ -52,15 +52,15 @@ let write_cred ~base ~agent_name ~token_hash =
 
 let test_exact_match_load_ok () =
   with_temp_base (fun base ->
-    write_cred ~base ~agent_name:"keeper-sangsu-agent"
+    write_cred ~base ~agent_name:"keeper-alpha-agent"
       ~token_hash:"abc123";
     match
       Auth.load_credential_of base
-        ~ctx_agent_name:"keeper-sangsu-agent"
-        ~resolved_credential_stem:"keeper-sangsu-agent"
+        ~ctx_agent_name:"keeper-alpha-agent"
+        ~resolved_credential_stem:"keeper-alpha-agent"
     with
     | Ok cred ->
-        assert (cred.agent_name = "keeper-sangsu-agent");
+        assert (cred.agent_name = "keeper-alpha-agent");
         print_endline "PASS: exact match -> Ok cred"
     | Error e ->
         Printf.printf "FAIL: expected Ok, got Error %s\n"
@@ -89,13 +89,13 @@ let test_mismatch_rejects_even_when_resolved_stem_exists () =
   (* Dual-identity scenario: bare nickname cred exists on disk, but ctx
      is canonical. load_credential_of must reject rather than fall back. *)
   with_temp_base (fun base ->
-    write_cred ~base ~agent_name:"sangsu" ~token_hash:"bare-token";
-    write_cred ~base ~agent_name:"keeper-sangsu-agent"
+    write_cred ~base ~agent_name:"alpha" ~token_hash:"bare-token";
+    write_cred ~base ~agent_name:"keeper-alpha-agent"
       ~token_hash:"canonical-token";
     match
       Auth.load_credential_of base
-        ~ctx_agent_name:"keeper-sangsu-agent"
-        ~resolved_credential_stem:"sangsu"
+        ~ctx_agent_name:"keeper-alpha-agent"
+        ~resolved_credential_stem:"alpha"
     with
     | Ok _ ->
         print_endline "FAIL: expected Credential_mismatch, got Ok (silent fallback)";
@@ -106,8 +106,8 @@ let test_mismatch_rejects_even_when_resolved_stem_exists () =
     | Error
         (Auth.Credential_mismatch
            { ctx_agent_name; resolved_credential_stem }) ->
-        assert (ctx_agent_name = "keeper-sangsu-agent");
-        assert (resolved_credential_stem = "sangsu");
+        assert (ctx_agent_name = "keeper-alpha-agent");
+        assert (resolved_credential_stem = "alpha");
         print_endline
           "PASS: ctx<>stem -> Credential_mismatch (no silent fallback)")
 

--- a/test/test_auth_token_uniqueness_audit.ml
+++ b/test/test_auth_token_uniqueness_audit.ml
@@ -59,15 +59,15 @@ let test_unique_tokens_return_empty () =
 let test_shared_token_surfaces_pair () =
   with_temp_base (fun base ->
     let shared = "shared_token_hash_value_with_enough_length" in
-    write_cred ~base ~agent_name:"keeper-sangsu-agent" ~token_hash:shared;
-    write_cred ~base ~agent_name:"nick0cave-sage-heron" ~token_hash:shared;
+    write_cred ~base ~agent_name:"keeper-alpha-agent" ~token_hash:shared;
+    write_cred ~base ~agent_name:"theta0-sage-heron" ~token_hash:shared;
     let groups = Auth.audit_token_uniqueness base in
     match groups with
     | [ (prefix, agents) ] ->
         Alcotest.(check int) "exactly 2 agents in group"
           2 (List.length agents);
         Alcotest.(check (list string)) "agents sorted"
-          [ "keeper-sangsu-agent"; "nick0cave-sage-heron" ]
+          [ "keeper-alpha-agent"; "theta0-sage-heron" ]
           agents;
         Alcotest.(check int) "prefix is 12 chars"
           12 (String.length prefix);

--- a/test/test_board_author_identity_10297.ml
+++ b/test/test_board_author_identity_10297.ml
@@ -6,7 +6,7 @@
     contract's [agent_name] when the caller's [author] argument was
     blank.  Any non-blank caller-supplied [author] passed through
     canonicalisation without comparison, so an LLM running as
-    keeper [velvet-hammer] could write [author = "analyst"] and
+    keeper [xi-hammer] could write [author = "delta"] and
     impersonate a different principal on the public board.
     Board comment/vote paths also lacked an [agent_name] comparison
     point, so they could not have caught spoofing either.
@@ -19,8 +19,8 @@
     2. Caller's canonical equals ctx canonical → preserve canonical
        form, optionally stash raw surface in
        [meta.<field>_raw_agent_name] when the caller passed a
-       different surface form (e.g. [keeper-velvet-hammer-agent]
-       vs [velvet-hammer]).
+       different surface form (e.g. [keeper-xi-hammer-agent]
+       vs [xi-hammer]).
     3. Caller's canonical disagrees with ctx canonical → REWRITE to
        ctx canonical, preserve the caller's claim under
        [meta.<field>_caller_claim] for forensics, and increment
@@ -65,12 +65,12 @@ let assoc fields = `Assoc fields
 let test_blank_field_fills_from_ctx () =
   let result =
     D.enforce_caller_identity ~tool:"masc_board_post" ~field:"author"
-      ~agent_name:"keeper-velvet-hammer-agent"
+      ~agent_name:"keeper-xi-hammer-agent"
       (assoc [ ("body", `String "hi") ])
   in
   check (option string)
     "blank author rewritten to ctx canonical"
-    (Some "velvet-hammer")
+    (Some "xi-hammer")
     (json_string_field "author" result);
   check (option string)
     "no caller_claim recorded for blank source"
@@ -80,12 +80,12 @@ let test_blank_field_fills_from_ctx () =
 let test_anonymous_field_fills_from_ctx () =
   let result =
     D.enforce_caller_identity ~tool:"masc_board_post" ~field:"author"
-      ~agent_name:"keeper-velvet-hammer-agent"
+      ~agent_name:"keeper-xi-hammer-agent"
       (assoc [ ("author", `String "anonymous"); ("body", `String "hi") ])
   in
   check (option string)
     "anonymous author rewritten to ctx canonical"
-    (Some "velvet-hammer")
+    (Some "xi-hammer")
     (json_string_field "author" result);
   check (option string)
     "no caller_claim recorded for anonymous source"
@@ -97,12 +97,12 @@ let test_anonymous_field_fills_from_ctx () =
 let test_caller_short_name_matches_ctx () =
   let result =
     D.enforce_caller_identity ~tool:"masc_board_post" ~field:"author"
-      ~agent_name:"keeper-velvet-hammer-agent"
-      (assoc [ ("author", `String "velvet-hammer") ])
+      ~agent_name:"keeper-xi-hammer-agent"
+      (assoc [ ("author", `String "xi-hammer") ])
   in
   check (option string)
     "matching short-name preserved"
-    (Some "velvet-hammer")
+    (Some "xi-hammer")
     (json_string_field "author" result);
   check (option string)
     "no caller_claim because no spoof"
@@ -116,16 +116,16 @@ let test_caller_passes_full_agent_name_form () =
      [meta.author_raw_agent_name] — legacy semantic preserved. *)
   let result =
     D.enforce_caller_identity ~tool:"masc_board_post" ~field:"author"
-      ~agent_name:"velvet-hammer"
-      (assoc [ ("author", `String "keeper-velvet-hammer-agent") ])
+      ~agent_name:"xi-hammer"
+      (assoc [ ("author", `String "keeper-xi-hammer-agent") ])
   in
   check (option string)
     "canonical short-name in author"
-    (Some "velvet-hammer")
+    (Some "xi-hammer")
     (json_string_field "author" result);
   check (option string)
     "raw surface preserved in meta.author_raw_agent_name"
-    (Some "keeper-velvet-hammer-agent")
+    (Some "keeper-xi-hammer-agent")
     (meta_string_field "author_raw_agent_name" result);
   check (option string)
     "no caller_claim because canonicals match"
@@ -134,25 +134,25 @@ let test_caller_passes_full_agent_name_form () =
 
 (* --- 3. caller canonical disagrees with ctx canonical ----------- *)
 
-let test_velvet_hammer_cannot_post_as_analyst () =
-  (* The exact #10297 reproducer: velvet-hammer keeper attempts to
-     write a board post under analyst's name.  Dispatcher must
-     rewrite the author to velvet-hammer, preserve the analyst
+let test_velvet_hammer_cannot_post_as_delta () =
+  (* The exact #10297 reproducer: xi-hammer keeper attempts to
+     write a board post under delta's name.  Dispatcher must
+     rewrite the author to xi-hammer, preserve the delta
      claim in meta, and increment the spoof counter. *)
   let before = counter_for ~tool:"masc_board_post" ~field:"author" in
   let result =
     D.enforce_caller_identity ~tool:"masc_board_post" ~field:"author"
-      ~agent_name:"keeper-velvet-hammer-agent"
+      ~agent_name:"keeper-xi-hammer-agent"
       (assoc
-         [ ("author", `String "analyst"); ("body", `String "spoof attempt") ])
+         [ ("author", `String "delta"); ("body", `String "spoof attempt") ])
   in
   check (option string)
     "author rewritten to ctx canonical"
-    (Some "velvet-hammer")
+    (Some "xi-hammer")
     (json_string_field "author" result);
   check (option string)
     "caller claim preserved in meta.author_caller_claim"
-    (Some "analyst")
+    (Some "delta")
     (meta_string_field "author_caller_claim" result);
   check (float 0.0001)
     "spoof counter +1"
@@ -166,16 +166,16 @@ let test_voter_field_spoof_also_rewritten () =
   let before = counter_for ~tool:"masc_board_vote" ~field:"voter" in
   let result =
     D.enforce_caller_identity ~tool:"masc_board_vote" ~field:"voter"
-      ~agent_name:"keeper-velvet-hammer-agent"
-      (assoc [ ("voter", `String "analyst"); ("post_id", `String "p1") ])
+      ~agent_name:"keeper-xi-hammer-agent"
+      (assoc [ ("voter", `String "delta"); ("post_id", `String "p1") ])
   in
   check (option string)
     "voter rewritten to ctx canonical"
-    (Some "velvet-hammer")
+    (Some "xi-hammer")
     (json_string_field "voter" result);
   check (option string)
     "voter claim preserved in meta.voter_caller_claim"
-    (Some "analyst")
+    (Some "delta")
     (meta_string_field "voter_caller_claim" result);
   check (float 0.0001)
     "voter spoof counter +1"
@@ -190,8 +190,8 @@ let test_counter_separates_by_tool_and_field () =
   let other_before = counter_for ~tool:"masc_board_vote" ~field:"voter" in
   let _ =
     D.enforce_caller_identity ~tool:"masc_board_post" ~field:"author"
-      ~agent_name:"keeper-velvet-hammer-agent"
-      (assoc [ ("author", `String "analyst") ])
+      ~agent_name:"keeper-xi-hammer-agent"
+      (assoc [ ("author", `String "delta") ])
   in
   check (float 0.0001)
     "vote/voter unchanged when post/author bumps"
@@ -209,11 +209,11 @@ let test_empty_ctx_preserves_legacy_canonicalisation () =
   let result =
     D.enforce_caller_identity ~tool:"masc_board_post" ~field:"author"
       ~agent_name:""
-      (assoc [ ("author", `String "keeper-velvet-hammer-agent") ])
+      (assoc [ ("author", `String "keeper-xi-hammer-agent") ])
   in
   check (option string)
     "canonical short-name even without ctx"
-    (Some "velvet-hammer")
+    (Some "xi-hammer")
     (json_string_field "author" result)
 
 let () =
@@ -235,8 +235,8 @@ let () =
         ] );
       ( "spoof-rewrite",
         [
-          test_case "velvet-hammer cannot post as analyst" `Quick
-            test_velvet_hammer_cannot_post_as_analyst;
+          test_case "xi-hammer cannot post as delta" `Quick
+            test_velvet_hammer_cannot_post_as_delta;
           test_case "voter spoof also rewritten" `Quick
             test_voter_field_spoof_also_rewritten;
         ] );

--- a/test/test_board_context_inference_resolution.ml
+++ b/test/test_board_context_inference_resolution.ml
@@ -28,7 +28,7 @@ let with_workspace f =
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
       let config = Workspace.default_config dir in
-      ignore (Workspace.init config ~agent_name:(Some "keeper-sangsu-agent"));
+      ignore (Workspace.init config ~agent_name:(Some "keeper-alpha-agent"));
       f config)
 
 let make_meta name : Keeper_meta_contract.keeper_meta =
@@ -84,15 +84,15 @@ let check_bad_request label expected = function
 
 let test_parse_request () =
   (* 1. Valid payload *)
-  let json = `Assoc [("post_id", `String "post-123"); ("target_keeper", `String "sangsu")] in
+  let json = `Assoc [("post_id", `String "post-123"); ("target_keeper", `String "alpha")] in
   (match Server_routes_http_routes_activity.parse_board_context_inference_request json with
    | Ok req ->
      check string "post_id parsed" "post-123" req.post_id;
-     check (option string) "target_keeper parsed" (Some "sangsu") req.target_keeper
+     check (option string) "target_keeper parsed" (Some "alpha") req.target_keeper
    | Error err -> fail ("parse failed: " ^ err));
 
   (* 2. Missing post_id *)
-  let json = `Assoc [("target_keeper", `String "sangsu")] in
+  let json = `Assoc [("target_keeper", `String "alpha")] in
   (match Server_routes_http_routes_activity.parse_board_context_inference_request json with
    | Error err -> check string "error on missing post_id" "post_id is required" err
    | Ok _ -> fail "expected parsing error");
@@ -107,15 +107,15 @@ let test_parse_request () =
 
 let test_target_resolution_explicit_registered () =
   with_workspace (fun config ->
-    (* Register keeper "sangsu" *)
-    (match Keeper_meta_store.replace_snapshot config (make_meta "sangsu") with
+    (* Register keeper "alpha" *)
+    (match Keeper_meta_store.replace_snapshot config (make_meta "alpha") with
      | Ok _ -> ()
      | Error msg -> fail ("write_meta failed: " ^ msg));
 
     let post = make_post ~id:"post-1" ~author:"operator" in
-    match Server_routes_http_routes_activity.resolve_board_context_inference_target ~config post (Some "sangsu") with
+    match Server_routes_http_routes_activity.resolve_board_context_inference_target ~config post (Some "alpha") with
     | Ok (resolved_name, source) ->
-      check string "resolved name" "sangsu" resolved_name;
+      check string "resolved name" "alpha" resolved_name;
       check bool "source is Explicit_target" true (source = Server_routes_http_routes_activity.Explicit_target)
     | Error _ -> fail "expected resolution to succeed")
 
@@ -130,16 +130,16 @@ let test_target_resolution_explicit_unregistered () =
 
 let test_target_resolution_implicit_registered_author () =
   with_workspace (fun config ->
-    (* Register keeper "sangsu" *)
-    (match Keeper_meta_store.replace_snapshot config (make_meta "sangsu") with
+    (* Register keeper "alpha" *)
+    (match Keeper_meta_store.replace_snapshot config (make_meta "alpha") with
      | Ok _ -> ()
      | Error msg -> fail ("write_meta failed: " ^ msg));
 
     (* Post author matches a registered keeper (either by short name or full agent name) *)
-    let post = make_post ~id:"post-1" ~author:"sangsu" in
+    let post = make_post ~id:"post-1" ~author:"alpha" in
     match Server_routes_http_routes_activity.resolve_board_context_inference_target ~config post None with
     | Ok (resolved_name, source) ->
-      check string "resolved name" "sangsu" resolved_name;
+      check string "resolved name" "alpha" resolved_name;
       check bool "source is Post_author" true (source = Server_routes_http_routes_activity.Post_author)
     | Error _ -> fail "expected resolution to succeed")
 

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -420,7 +420,7 @@ let test_create_post_persistence_failure_returns_error_without_fanout () =
 
 let test_structured_post_roundtrip () =
   let meta = `Assoc [("source", `String "keeper_autonomy")] in
-  match Board_dispatch.create_post ~author:"sangsu"
+  match Board_dispatch.create_post ~author:"alpha"
           ~title:"Explicit title"
           ~content:"Visible line\n\nSupporting detail"
           ~post_kind:Board.Automation_post

--- a/test/test_broadcast_wakeup_policy.ml
+++ b/test/test_broadcast_wakeup_policy.ml
@@ -4,8 +4,8 @@ open Masc
 module Broadcast_wakeup = Server_bootstrap_loops.For_testing
 
 let test_mention_wakes_target () =
-  match Broadcast_wakeup.broadcast_mention_wakeup_action (Some "rondo") with
-  | `Wake_keeper "rondo" -> ()
+  match Broadcast_wakeup.broadcast_mention_wakeup_action (Some "beta") with
+  | `Wake_keeper "beta" -> ()
   | `Wake_keeper other -> failf "unexpected wake target: %s" other
   | `Suppress_no_target -> fail "expected explicit mention to wake target"
 
@@ -119,7 +119,7 @@ let count_delivery_rows ~base_path ~keeper_name ~request_id =
 
 let test_delivery_appends_once_before_wake () =
   with_workspace @@ fun config ->
-  let target = "rondo" in
+  let target = "beta" in
   let request_id = "wmsg-0011223344556677" in
   persist_meta config target;
   let wakes = ref 0 in
@@ -167,7 +167,7 @@ let test_stopped_keeper_persists_without_wake () =
 
 let test_runtime_agent_alias_resolves_before_delivery () =
   with_workspace @@ fun config ->
-  let keeper_name = "rondo" in
+  let keeper_name = "beta" in
   let target = Keeper_identity.keeper_agent_name keeper_name in
   let request_id = "wmsg-aabbccddeeff0011" in
   persist_meta config keeper_name;
@@ -201,9 +201,9 @@ let delivery_message ~base_path ~keeper_name ~request_id =
 
 let test_configured_mention_alias_resolves_and_stamps_feed_target () =
   with_workspace @@ fun config ->
-  let keeper_name = "rondo" in
-  let configured_alias = "Sangsu" in
-  let delivery_target = "sangsu" in
+  let keeper_name = "beta" in
+  let configured_alias = "Alpha" in
+  let delivery_target = "alpha" in
   let request_id = "wmsg-1122334455667788" in
   persist_meta config keeper_name;
   configure_mention_targets config keeper_name [ configured_alias ];
@@ -235,8 +235,8 @@ let test_configured_mention_alias_resolves_and_stamps_feed_target () =
 
 let test_canonical_delivery_stamps_configured_feed_target () =
   with_workspace @@ fun config ->
-  let keeper_name = "rondo" in
-  let alias = "sangsu" in
+  let keeper_name = "beta" in
+  let alias = "alpha" in
   let request_id = "wmsg-8877665544332211" in
   persist_meta config keeper_name;
   configure_mention_targets config keeper_name [ alias ];
@@ -288,7 +288,7 @@ let queued_workspace_messages ~base_path ~keeper_name =
    against other stimuli, and nothing for the operator queue view to show. *)
 let test_delivery_enqueues_linear_queue_entry () =
   with_workspace @@ fun config ->
-  let target = "rondo" in
+  let target = "beta" in
   let request_id = "wmsg-1234567890abcdef" in
   persist_meta config target;
   let deliver () =
@@ -359,23 +359,23 @@ let fleet_delivery ~request_id ~from_agent ~content
 let test_fleet_projection_reaches_other_keepers () =
   with_workspace @@ fun config ->
   let request_id = "wmsg-00fleet0000000001" in
-  List.iter (persist_meta config) [ "rondo"; "sangsu"; "taskmaster" ];
+  List.iter (persist_meta config) [ "beta"; "alpha"; "fixture-keeper" ];
   Broadcast_wakeup.project_workspace_message_to_fleet
     ~base_path:config.base_path
     ~registered_keepers:(fun () ->
-       [ "rondo", Keeper_identity.keeper_agent_name "rondo"; "sangsu", Keeper_identity.keeper_agent_name "sangsu"; "taskmaster", Keeper_identity.keeper_agent_name "taskmaster" ])
+       [ "beta", Keeper_identity.keeper_agent_name "beta"; "alpha", Keeper_identity.keeper_agent_name "alpha"; "fixture-keeper", Keeper_identity.keeper_agent_name "fixture-keeper" ])
     (fleet_delivery
        ~request_id
-       ~from_agent:(Keeper_identity.keeper_agent_name "rondo")
+       ~from_agent:(Keeper_identity.keeper_agent_name "beta")
        ~content:"task-209 is mine, do not claim it");
   let rows keeper_name =
     count_delivery_rows ~base_path:config.base_path ~keeper_name ~request_id
   in
-  check int "listener sees the broadcast" 1 (rows "sangsu");
-  check int "second listener sees the broadcast" 1 (rows "taskmaster");
+  check int "listener sees the broadcast" 1 (rows "alpha");
+  check int "second listener sees the broadcast" 1 (rows "fixture-keeper");
   (* The author already knows what it said; echoing it back would put the
      Keeper's own speech in front of it as someone else's line. *)
-  check int "author does not receive its own broadcast" 0 (rows "rondo")
+  check int "author does not receive its own broadcast" 0 (rows "beta")
 ;;
 
 (* Visibility, not a request: the fanout must not put an entry in anyone's
@@ -383,20 +383,20 @@ let test_fleet_projection_reaches_other_keepers () =
 let test_fleet_projection_adds_no_queue_entry () =
   with_workspace @@ fun config ->
   let request_id = "wmsg-00fleet0000000002" in
-  List.iter (persist_meta config) [ "rondo"; "sangsu" ];
+  List.iter (persist_meta config) [ "beta"; "alpha" ];
   Broadcast_wakeup.project_workspace_message_to_fleet
     ~base_path:config.base_path
     ~registered_keepers:(fun () ->
-       [ "rondo", Keeper_identity.keeper_agent_name "rondo"; "sangsu", Keeper_identity.keeper_agent_name "sangsu" ])
+       [ "beta", Keeper_identity.keeper_agent_name "beta"; "alpha", Keeper_identity.keeper_agent_name "alpha" ])
     (fleet_delivery
        ~request_id
-       ~from_agent:(Keeper_identity.keeper_agent_name "rondo")
+       ~from_agent:(Keeper_identity.keeper_agent_name "beta")
        ~content:"status ping");
   check int "listener row is visibility only" 1
-    (count_delivery_rows ~base_path:config.base_path ~keeper_name:"sangsu" ~request_id);
+    (count_delivery_rows ~base_path:config.base_path ~keeper_name:"alpha" ~request_id);
   check int "no queue entry for a fleet broadcast" 0
     (List.length
-       (queued_workspace_messages ~base_path:config.base_path ~keeper_name:"sangsu"))
+       (queued_workspace_messages ~base_path:config.base_path ~keeper_name:"alpha"))
 ;;
 
 (* The named target's row is written by the mention path with its mention ids.
@@ -405,32 +405,32 @@ let test_fleet_projection_adds_no_queue_entry () =
    unmentioned copy or append a second row. *)
 let test_fleet_projection_preserves_the_mention_row () =
   with_workspace @@ fun config ->
-  let target = "sangsu" in
+  let target = "alpha" in
   let request_id = "wmsg-00fleet0000000003" in
-  List.iter (persist_meta config) [ "rondo"; target ];
+  List.iter (persist_meta config) [ "beta"; target ];
   ignore
     (Broadcast_wakeup.deliver_broadcast_mention
        ~config
        ~base_path:config.base_path
        ~is_running:(fun _ -> true)
        ~wakeup:(fun _ -> ())
-       (delivery ~target ~request_id ~seq:41 ~content:"@sangsu please review"));
+       (delivery ~target ~request_id ~seq:41 ~content:"@alpha please review"));
   Broadcast_wakeup.project_workspace_message_to_fleet
     ~base_path:config.base_path
     ~registered_keepers:(fun () ->
-       [ "rondo", Keeper_identity.keeper_agent_name "rondo"
+       [ "beta", Keeper_identity.keeper_agent_name "beta"
        ; target, Keeper_identity.keeper_agent_name target
        ])
     (fleet_delivery
        ~request_id
        ~from_agent:"external-agent"
-       ~content:"@sangsu please review");
+       ~content:"@alpha please review");
   check int "target keeps exactly one row" 1
     (count_delivery_rows ~base_path:config.base_path ~keeper_name:target ~request_id);
   (* Without this the case passes with no fanout at all: both assertions above
      read only the row the mention path already wrote. *)
   check int "the bystander received the fanout row" 1
-    (count_delivery_rows ~base_path:config.base_path ~keeper_name:"rondo" ~request_id);
+    (count_delivery_rows ~base_path:config.base_path ~keeper_name:"beta" ~request_id);
   match delivery_message ~base_path:config.base_path ~keeper_name:target ~request_id with
   | None -> fail "mention row disappeared after the fleet pass"
   | Some message ->
@@ -445,11 +445,11 @@ let test_fleet_projection_preserves_the_mention_row () =
 let test_system_record_is_not_projected () =
   with_workspace @@ fun config ->
   let request_id = "wmsg-00fleet0000000004" in
-  List.iter (persist_meta config) [ "rondo"; "sangsu" ];
+  List.iter (persist_meta config) [ "beta"; "alpha" ];
   let record =
     { (fleet_delivery
          ~request_id
-         ~from_agent:(Keeper_identity.keeper_agent_name "rondo")
+         ~from_agent:(Keeper_identity.keeper_agent_name "beta")
          ~content:"Claimed task-209")
       with Workspace_broadcast.audience = Workspace_broadcast.System_record
     }
@@ -457,10 +457,10 @@ let test_system_record_is_not_projected () =
   Broadcast_wakeup.project_workspace_message_to_fleet
     ~base_path:config.base_path
     ~registered_keepers:(fun () ->
-       [ "rondo", Keeper_identity.keeper_agent_name "rondo"; "sangsu", Keeper_identity.keeper_agent_name "sangsu" ])
+       [ "beta", Keeper_identity.keeper_agent_name "beta"; "alpha", Keeper_identity.keeper_agent_name "alpha" ])
     record;
   check int "a system record reaches no conversation window" 0
-    (count_delivery_rows ~base_path:config.base_path ~keeper_name:"sangsu" ~request_id)
+    (count_delivery_rows ~base_path:config.base_path ~keeper_name:"alpha" ~request_id)
 ;;
 
 (* The default is the record, so a producer added later cannot silently fan a

--- a/test/test_caller_identity_credential_binding.ml
+++ b/test/test_caller_identity_credential_binding.ml
@@ -34,8 +34,8 @@ let test_credential_owned_name_is_not_rewritable () =
     false
     (may_rewrite ~credential_owner:(Some "dashboard") ~agent_name:"dashboard")
 
-(* Keeper transport aliases keep working: the caller names "rondo" while the
-   credential belongs to "keeper-rondo-agent", so the alias is still the only
+(* Keeper transport aliases keep working: the caller names "beta" while the
+   credential belongs to "keeper-beta-agent", so the alias is still the only
    thing that can connect the two. *)
 let test_unowned_name_stays_rewritable () =
   check
@@ -43,8 +43,8 @@ let test_unowned_name_stays_rewritable () =
     "an alias may still rewrite a name the credential does not own"
     true
     (may_rewrite
-       ~credential_owner:(Some "keeper-rondo-agent")
-       ~agent_name:"rondo")
+       ~credential_owner:(Some "keeper-beta-agent")
+       ~agent_name:"beta")
 
 let test_unauthenticated_request_stays_rewritable () =
   check
@@ -63,7 +63,7 @@ let test_prefix_sharing_owner_is_not_rewritable () =
         (Printf.sprintf "%S is credential-bound, so no alias rewrite" name)
         false
         (may_rewrite ~credential_owner:(Some name) ~agent_name:name))
-    [ "dashboard"; "dashboard-admin"; "keeper-rondo-agent"; "analyst" ]
+    [ "dashboard"; "dashboard-admin"; "keeper-beta-agent"; "delta" ]
 
 (* The live workspace lookup, as a stub: no [dashboard.json] record exists,
    so the prefix scan returns the first record sharing the "dashboard-"
@@ -71,7 +71,7 @@ let test_prefix_sharing_owner_is_not_rewritable () =
    which is the part that decides what reaches [Auth.authorize_tool_v2]. *)
 let live_alias_scan = function
   | "dashboard" | "dashboard-admin" -> "dashboard-admin-deft-cobra"
-  | "rondo" -> "keeper-rondo-agent"
+  | "beta" -> "keeper-beta-agent"
   | name -> name
 
 let subject_for ~credential_owner agent_name =
@@ -91,8 +91,8 @@ let test_authorization_subject_keeps_transport_alias () =
   check
     string
     "a keeper transport alias still resolves to its bound record"
-    "keeper-rondo-agent"
-    (subject_for ~credential_owner:(Some "keeper-rondo-agent") "rondo")
+    "keeper-beta-agent"
+    (subject_for ~credential_owner:(Some "keeper-beta-agent") "beta")
 
 let test_authorization_subject_without_credential () =
   check

--- a/test/test_channel_gate_binding_store.ml
+++ b/test/test_channel_gate_binding_store.ml
@@ -88,7 +88,7 @@ let test_rejects_malformed_binding_rows () =
   expect_error "duplicate channel id was accepted"
     (`Assoc
       [ "channel-1", `String "luna"
-      ; "channel-1", `String "sangsu"
+      ; "channel-1", `String "alpha"
       ])
 
 let test_read_bindings_result_missing_store_is_empty () =
@@ -131,7 +131,7 @@ let test_audit_failure_rolls_back_binding_mutation () =
   let result =
     Store.mutate_bindings store ~decide:(fun _ ->
       Ok
-        ( [ ({ channel_id = "channel-2"; keeper_name = "sangsu" }
+        ( [ ({ channel_id = "channel-2"; keeper_name = "alpha" }
             : Store.binding) ]
         , sample_event ~action:"bind" ()
         , () ))
@@ -195,7 +195,7 @@ let test_failed_mutation_cannot_erase_concurrent_success () =
       in
       Ok (updated, sample_event ~action:"bind" (), ()))
   in
-  let failed = Domain.spawn (fun () -> bind "failed" "sangsu") in
+  let failed = Domain.spawn (fun () -> bind "failed" "alpha") in
   Stdlib.Mutex.lock coordination_mu;
   while not !first_audit_waiting do
     Stdlib.Condition.wait coordination coordination_mu

--- a/test/test_channel_gate_connector_routes.ml
+++ b/test/test_channel_gate_connector_routes.ml
@@ -259,9 +259,9 @@ let test_error_json_wire_shape () =
     (json |> U.member "error" |> U.to_string)
 
 let test_error_json_unknown_keeper_includes_name () =
-  let json = Channel_gate.error_json "unknown keeper: rondo" in
+  let json = Channel_gate.error_json "unknown keeper: beta" in
   check bool "ok is false" false (json |> U.member "ok" |> U.to_bool);
-  check string "error contains keeper name" "unknown keeper: rondo"
+  check string "error contains keeper name" "unknown keeper: beta"
     (json |> U.member "error" |> U.to_string)
 
 let () =

--- a/test/test_channel_gate_discord_state.ml
+++ b/test/test_channel_gate_discord_state.ml
@@ -329,14 +329,14 @@ let test_resolve_keeper_exact_binding_wins_over_parent () =
       (Discord_state.bind ~channel_id:"parent-1" ~keeper_name:"luna"
          ~actor_name:"dashboard");
     ignore
-      (Discord_state.bind ~channel_id:"thread-1" ~keeper_name:"sangsu"
+      (Discord_state.bind ~channel_id:"thread-1" ~keeper_name:"alpha"
          ~actor_name:"dashboard");
     match
       Discord_state.resolve_keeper_for_channel_result ~channel_id:"thread-1"
     with
     | Error _ | Ok None -> fail "expected exact binding to resolve"
     | Ok (Some resolution) ->
-        check string "keeper" "sangsu" resolution.keeper_name;
+        check string "keeper" "alpha" resolution.keeper_name;
         check string "incoming" "thread-1" resolution.incoming_channel_id;
         check string "bound" "thread-1" resolution.bound_channel_id;
         check bool "not via parent" false resolution.via_parent)

--- a/test/test_channel_gate_metrics.ml
+++ b/test/test_channel_gate_metrics.ml
@@ -57,7 +57,7 @@ let test_record_internal_error_exn_tracks_internal_failures () =
       Metrics.record_internal_error_exn
         ~channel
         ~workspace_id:"workspace-z"
-        ~keeper:"  sangsu  "
+        ~keeper:"  alpha  "
         ~duration_ms:42
         (Failure "boom");
       let stats =
@@ -68,7 +68,7 @@ let test_record_internal_error_exn_tracks_internal_failures () =
       check int "message_count" 1 stats.message_count;
       check int "error_count" 1 stats.error_count;
       check int "internal_error_count" 1 stats.internal_error_count;
-      check string "last_keeper trimmed" "sangsu" stats.last_keeper;
+      check string "last_keeper trimmed" "alpha" stats.last_keeper;
       check string "last_error redacted" "internal error" stats.last_error;
       check_error_kind "last_error_kind" "internal" stats.last_error_kind;
       check string "last_outcome" "internal_error" stats.last_outcome)
@@ -124,9 +124,9 @@ let test_record_validation_error_metric_falls_back_for_invalid_json () =
 let test_snapshot_json_reports_health_and_latency () =
   with_eio (fun () ->
       let channel = unique_channel "discord-json" in
-      Metrics.record_attempt ~channel ~workspace_id:"workspace-1" ~keeper:"sangsu"
+      Metrics.record_attempt ~channel ~workspace_id:"workspace-1" ~keeper:"alpha"
         ~duration_ms:10_500 Metrics.Success;
-      Metrics.record_attempt ~channel ~workspace_id:"workspace-1" ~keeper:"sangsu"
+      Metrics.record_attempt ~channel ~workspace_id:"workspace-1" ~keeper:"alpha"
         ~duration_ms:11_500
         (Metrics.Keeper_error "upstream timeout");
       let json = Metrics.snapshot_json () in
@@ -151,7 +151,7 @@ let test_snapshot_json_includes_workspace_bindings () =
       let channel = unique_channel "discord-bindings" in
       Metrics.record_attempt ~channel ~workspace_id:"workspace-alpha" ~keeper:"luna"
         ~duration_ms:120 Metrics.Success;
-      Metrics.record_attempt ~channel ~workspace_id:"workspace-beta" ~keeper:"sangsu"
+      Metrics.record_attempt ~channel ~workspace_id:"workspace-beta" ~keeper:"alpha"
         ~duration_ms:0
         (Metrics.Keeper_error "keeper offline");
       let json = Metrics.snapshot_json () in
@@ -187,7 +187,7 @@ let test_events_json_filters_newest_first () =
       Metrics.record_attempt ~channel ~workspace_id:"workspace-a" ~keeper:"luna"
         ~duration_ms:0
         (Metrics.Keeper_error "upstream timeout");
-      Metrics.record_attempt ~channel ~workspace_id:"workspace-b" ~keeper:"sangsu"
+      Metrics.record_attempt ~channel ~workspace_id:"workspace-b" ~keeper:"alpha"
         ~duration_ms:0
         (Metrics.Validation_error "content is required");
       let json = Metrics.events_json ~channel ~keeper:"luna" ~limit:5 () in

--- a/test/test_claimable_task_summaries.ml
+++ b/test/test_claimable_task_summaries.ml
@@ -169,7 +169,7 @@ let test_invalid_stored_task_id_makes_snapshot_non_authoritative () =
 
 
 (* A count and a set of ids describe the backlog; they do not say whether it is
-   the backlog the last turn described. [taskmaster], whose instructions are to
+   the backlog the last turn described. [fixture-keeper], whose instructions are to
    take unclaimed work on sight, repeated one "nothing actionable" verbatim
    across a day of turns -- and the reason it gave, that the three tasks were
    blocked, appears nowhere in their records (#27629). Nothing in its frame

--- a/test/test_compression.ml
+++ b/test/test_compression.ml
@@ -173,7 +173,7 @@ let gunzip payload =
 let sample_json =
   "[" ^ String.concat ","
     (List.init 400 (fun i ->
-       Printf.sprintf {|{"i":%d,"keeper":"sangsu","ts":1786500000.0}|} i))
+       Printf.sprintf {|{"i":%d,"keeper":"alpha","ts":1786500000.0}|} i))
   ^ "]"
 
 let test_gzip_round_trips () =

--- a/test/test_dashboard_composite_claim_window.ml
+++ b/test/test_dashboard_composite_claim_window.ml
@@ -108,15 +108,15 @@ let claim_present ~claim_window ~keeper =
 
    Rows come back oldest-first, so taking the first matching row reported
    task-a — the claim the keeper had already superseded. Measured live before
-   the fix: keeper [analyst] reported task-305 while it had claimed task-306. *)
+   the fix: keeper [delta] reported task-305 while it had claimed task-306. *)
 let test_reports_the_latest_claim () =
-  log_claim ~keeper:"analyst" ~task_id:"task-a" ~goal_id:"goal-a";
-  log_claim ~keeper:"analyst" ~task_id:"task-b" ~goal_id:"goal-b";
+  log_claim ~keeper:"delta" ~task_id:"task-a" ~goal_id:"goal-a";
+  log_claim ~keeper:"delta" ~task_id:"task-b" ~goal_id:"goal-b";
   let claim_window = Server_dashboard_http_composite_claims.read_claim_window () in
   Alcotest.(check (option string))
     "the superseding claim is the one reported"
     (Some "task-b")
-    (claimed_task_id ~claim_window ~keeper:"analyst")
+    (claimed_task_id ~claim_window ~keeper:"delta")
 ;;
 
 (* Why the defect stayed invisible on a busy keeper.
@@ -131,14 +131,14 @@ let test_ring_trim_hides_the_older_claim () =
   let rows_per_keeper =
     Server_dashboard_http_composite_claims.claim_rows_per_keeper
   in
-  log_claim ~keeper:"rondo" ~task_id:"task-old" ~goal_id:"goal-old";
-  log_noise ~keeper:"rondo" ~n:rows_per_keeper;
-  log_claim ~keeper:"rondo" ~task_id:"task-new" ~goal_id:"goal-new";
+  log_claim ~keeper:"beta" ~task_id:"task-old" ~goal_id:"goal-old";
+  log_noise ~keeper:"beta" ~n:rows_per_keeper;
+  log_claim ~keeper:"beta" ~task_id:"task-new" ~goal_id:"goal-new";
   let claim_window = Server_dashboard_http_composite_claims.read_claim_window () in
   Alcotest.(check (option string))
     "a trimmed older claim cannot be reported"
     (Some "task-new")
-    (claimed_task_id ~claim_window ~keeper:"rondo")
+    (claimed_task_id ~claim_window ~keeper:"beta")
 ;;
 
 (* The N+1 property: the window is fleet-wide, so one read answers for every

--- a/test/test_dashboard_continuity_briefs.ml
+++ b/test/test_dashboard_continuity_briefs.ml
@@ -8,8 +8,8 @@ let keeper ?(status = "offline") ?(last_autonomous_action_at = "")
     ?(autonomous_turn_count = 0) ?(paused = false) () =
   `Assoc
     [
-      ("name", `String "executor");
-      ("agent_name", `String "executor");
+      ("name", `String "omega");
+      ("agent_name", `String "omega");
       ("keeper_id", `String "k-executor");
       ("status", `String status);
       ("paused", `Bool paused);

--- a/test/test_dashboard_execute_output.ml
+++ b/test/test_dashboard_execute_output.ml
@@ -10,31 +10,31 @@ let with_fresh f () =
   f ()
 
 let test_no_task_event () =
-  let json = EO.event_json ~keeper_name:"sangsu" in
+  let json = EO.event_json ~keeper_name:"alpha" in
   let open Yojson.Safe.Util in
   check string "type" "no_task" (json |> member "type" |> to_string);
-  check string "keeper" "sangsu" (json |> member "keeper" |> to_string);
+  check string "keeper" "alpha" (json |> member "keeper" |> to_string);
   check bool "closed" true (json |> member "closed" |> to_bool)
 
 let test_snapshot_merges_completed_output () =
   EO.inject_for_testing
-    ~keeper_name:"Sangsu"
+    ~keeper_name:"Alpha"
     ~task_id:"task-1"
     ~stdout:"first\n"
     ~stderr:""
     ~status:status_ok
     ();
   EO.inject_for_testing
-    ~keeper_name:"sangsu"
+    ~keeper_name:"alpha"
     ~task_id:"task-2"
     ~stdout:"second\n"
     ~stderr:"err\n"
     ~status:status_ok
     ();
-  match EO.snapshot ~keeper_name:"sangsu" with
+  match EO.snapshot ~keeper_name:"alpha" with
   | None -> fail "expected snapshot"
   | Some snapshot ->
-    check string "keeper normalized" "sangsu" snapshot.keeper;
+    check string "keeper normalized" "alpha" snapshot.keeper;
     check (option string) "latest task" (Some "task-2") snapshot.task_id;
     check int "task count" 2 snapshot.task_count;
     check string "stdout" "first\nsecond\n" snapshot.stdout_since;
@@ -45,14 +45,14 @@ let test_snapshot_merges_completed_output () =
 
 let test_snapshot_json_shape () =
   EO.inject_for_testing
-    ~keeper_name:"sangsu"
+    ~keeper_name:"alpha"
     ~task_id:"task-123"
     ~generated_at:1000.0
     ~stdout:"ok\n"
     ~stderr:""
     ~status:status_ok
     ();
-  let json = EO.event_json ~keeper_name:"sangsu" in
+  let json = EO.event_json ~keeper_name:"alpha" in
   let open Yojson.Safe.Util in
   check string "type" "snapshot" (json |> member "type" |> to_string);
   check string "task" "task-123" (json |> member "task_id" |> to_string);
@@ -62,18 +62,18 @@ let test_snapshot_json_shape () =
 
 let test_snapshot_line_ring_shape () =
   EO.inject_for_testing
-    ~keeper_name:"sangsu"
+    ~keeper_name:"alpha"
     ~task_id:"task-123"
     ~generated_at:1000.0
     ~stdout:"ok\nsecond"
     ~stderr:"warn\n"
     ~status:status_ok
     ();
-  let lines = EO.output_lines_for_testing ~keeper_name:"sangsu" in
+  let lines = EO.output_lines_for_testing ~keeper_name:"alpha" in
   check int "line count" 3 (List.length lines);
   check string "first stream" "stdout" (List.hd lines).stream;
   check string "first text" "ok" (List.hd lines).text;
-  let json = EO.event_json ~keeper_name:"sangsu" in
+  let json = EO.event_json ~keeper_name:"alpha" in
   let open Yojson.Safe.Util in
   let json_lines = json |> member "lines" |> to_list in
   check int "json line count" 3 (List.length json_lines);
@@ -82,14 +82,14 @@ let test_snapshot_line_ring_shape () =
 
 let test_live_tail_subscriber_receives_line_and_close () =
   Eio_main.run (fun env ->
-    match EO.subscribe ~keeper_name:"sangsu" with
+    match EO.subscribe ~keeper_name:"alpha" with
     | None -> fail "expected subscriber"
     | Some subscriber ->
       Fun.protect
         ~finally:(fun () -> EO.unsubscribe subscriber)
         (fun () ->
            EO.inject_for_testing
-             ~keeper_name:"sangsu"
+             ~keeper_name:"alpha"
              ~task_id:"task-123"
              ~generated_at:1000.0
              ~stdout:"ok\n"
@@ -121,13 +121,13 @@ let test_live_tail_subscriber_receives_line_and_close () =
 
 let test_stream_start_emits_task_opened () =
   Eio_main.run (fun env ->
-    match EO.subscribe ~keeper_name:"sangsu" with
+    match EO.subscribe ~keeper_name:"alpha" with
     | None -> fail "expected subscriber"
     | Some subscriber ->
       Fun.protect
         ~finally:(fun () -> EO.unsubscribe subscriber)
         (fun () ->
-           EO.record_stream_start ~keeper_name:"sangsu" ~task_id:(Some "task-stream");
+           EO.record_stream_start ~keeper_name:"alpha" ~task_id:(Some "task-stream");
            let json =
              Eio.Time.with_timeout_exn
                (Eio.Stdenv.clock env)
@@ -141,13 +141,13 @@ let test_stream_start_emits_task_opened () =
 
 let test_stream_chunk_emits_line () =
   Eio_main.run (fun env ->
-    match EO.subscribe ~keeper_name:"sangsu" with
+    match EO.subscribe ~keeper_name:"alpha" with
     | None -> fail "expected subscriber"
     | Some subscriber ->
       Fun.protect
         ~finally:(fun () -> EO.unsubscribe subscriber)
         (fun () ->
-           EO.record_stream_start ~keeper_name:"sangsu" ~task_id:(Some "task-stream");
+           EO.record_stream_start ~keeper_name:"alpha" ~task_id:(Some "task-stream");
            (* drain task_opened *)
            let _ =
              Eio.Time.with_timeout_exn
@@ -155,7 +155,7 @@ let test_stream_chunk_emits_line () =
                1.0
                (fun () -> EO.take_event subscriber |> EO.stream_event_json)
            in
-           EO.append_stream_chunk ~keeper_name:"sangsu" ~stream:`Stdout "hello\nworld";
+           EO.append_stream_chunk ~keeper_name:"alpha" ~stream:`Stdout "hello\nworld";
            let line1 =
              Eio.Time.with_timeout_exn
                (Eio.Stdenv.clock env)
@@ -185,13 +185,13 @@ let test_stream_chunk_emits_line () =
 
 let test_stream_end_emits_task_closed () =
   Eio_main.run (fun env ->
-    match EO.subscribe ~keeper_name:"sangsu" with
+    match EO.subscribe ~keeper_name:"alpha" with
     | None -> fail "expected subscriber"
     | Some subscriber ->
       Fun.protect
         ~finally:(fun () -> EO.unsubscribe subscriber)
         (fun () ->
-           EO.record_stream_start ~keeper_name:"sangsu" ~task_id:(Some "task-stream");
+           EO.record_stream_start ~keeper_name:"alpha" ~task_id:(Some "task-stream");
            let _ =
              Eio.Time.with_timeout_exn
                (Eio.Stdenv.clock env)
@@ -199,7 +199,7 @@ let test_stream_end_emits_task_closed () =
                (fun () -> EO.take_event subscriber |> EO.stream_event_json)
            in
            EO.record_stream_end
-             ~keeper_name:"sangsu"
+             ~keeper_name:"alpha"
              ~task_id:(Some "task-stream")
              ~status:status_ok;
            let closed_json =
@@ -219,13 +219,13 @@ let test_stream_end_emits_task_closed () =
 
 let test_stream_completed_does_not_duplicate_events () =
   Eio_main.run (fun env ->
-    match EO.subscribe ~keeper_name:"sangsu" with
+    match EO.subscribe ~keeper_name:"alpha" with
     | None -> fail "expected subscriber"
     | Some subscriber ->
       Fun.protect
         ~finally:(fun () -> EO.unsubscribe subscriber)
         (fun () ->
-           EO.record_stream_start ~keeper_name:"sangsu" ~task_id:(Some "task-stream");
+           EO.record_stream_start ~keeper_name:"alpha" ~task_id:(Some "task-stream");
            (* task_opened *)
            let _ =
              Eio.Time.with_timeout_exn
@@ -233,7 +233,7 @@ let test_stream_completed_does_not_duplicate_events () =
                1.0
                (fun () -> EO.take_event subscriber)
            in
-           EO.append_stream_chunk ~keeper_name:"sangsu" ~stream:`Stdout " streamed line\n";
+           EO.append_stream_chunk ~keeper_name:"alpha" ~stream:`Stdout " streamed line\n";
            (* line event from chunk *)
            let _ =
              Eio.Time.with_timeout_exn
@@ -242,11 +242,11 @@ let test_stream_completed_does_not_duplicate_events () =
                (fun () -> EO.take_event subscriber)
            in
            EO.record_stream_end
-             ~keeper_name:"sangsu"
+             ~keeper_name:"alpha"
              ~task_id:(Some "task-stream")
              ~status:status_ok;
            EO.record_completed
-             ~keeper_name:"sangsu"
+             ~keeper_name:"alpha"
              ~task_id:(Some "task-stream")
              ~stdout:" streamed line\n"
              ~stderr:""
@@ -302,11 +302,11 @@ let test_dashboard_routes_match_keeper_path () =
       in
       check_route
         "legacy route"
-        "/api/dashboard/execute-output/sangsu"
+        "/api/dashboard/execute-output/alpha"
         "/api/dashboard/execute-output/";
       check_route
         "v1 route"
-        "/api/v1/dashboard/execute-output/sangsu"
+        "/api/v1/dashboard/execute-output/alpha"
         "/api/v1/dashboard/execute-output/"))
 
 let () =

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -3498,7 +3498,7 @@ let test_tool_call_fleet_cache_tracks_durable_revision () =
          (Dashboard_cache.get_or_compute key ~ttl:30.0 (fun () -> `List []));
        check bool "fleet cache is seeded" true (Option.is_some (Dashboard_cache.peek key));
        Masc.Keeper_tool_call_log.log_call
-         ~keeper_name:"analyst"
+         ~keeper_name:"delta"
          ~tool_name:"keeper_time_now"
          ~input:(`Assoc [])
          ~output_text:"ok"

--- a/test/test_dashboard_keeper_metrics_10286.ml
+++ b/test/test_dashboard_keeper_metrics_10286.ml
@@ -228,14 +228,14 @@ let test_history_summary_decodes_content_blocks () =
     String.concat
       "\n"
       [ {|{"role":"assistant","content_blocks":[{"type":"text","text":"hello from albini"}],"ts_unix":1.0}|}
-      ; {|{"role":"user","content_blocks":[{"type":"text","text":"ping @taskmaster please"}],"ts_unix":2.0}|}
+      ; {|{"role":"user","content_blocks":[{"type":"text","text":"ping @fixture-keeper please"}],"ts_unix":2.0}|}
       ]
     ^ "\n"
   in
   with_temp_history rows (fun path ->
       let conversation, _k2k_recent, _k2k_mentions, raw_count, _frag, _filtered =
         Metrics.keeper_history_summary_json
-          ~all_keeper_names:[ "albini"; "taskmaster" ]
+          ~all_keeper_names:[ "albini"; "fixture-keeper" ]
           ~keeper_name:"albini"
           ~history_path:path
           ~filter_fragments:false

--- a/test/test_dashboard_keeper_name.ml
+++ b/test/test_dashboard_keeper_name.ml
@@ -15,15 +15,15 @@ module Codec = Keeper_name_codec
 open Alcotest
 
 let spellings =
-  [ "keeper-sangsu-agent"; "keeper_sangsu_agent"; "keeper-sangsu_agent"
-  ; "keeper_sangsu-agent"
+  [ "keeper-alpha-agent"; "keeper_alpha_agent"; "keeper-alpha_agent"
+  ; "keeper_alpha-agent"
   ]
 ;;
 
 let test_every_spelling_reaches_the_same_keeper () =
   List.iter
     (fun agent_name ->
-      check string agent_name "sangsu" (Helpers.extract_keeper_name agent_name))
+      check string agent_name "alpha" (Helpers.extract_keeper_name agent_name))
     spellings
 ;;
 
@@ -47,7 +47,7 @@ let test_mixed_spellings_are_not_left_with_affixes () =
 let test_non_alias_passes_through () =
   List.iter
     (fun name -> check string name name (Helpers.extract_keeper_name name))
-    [ "claude-agent-abc"; "claude-swift-fox"; "sangsu"; "" ]
+    [ "claude-agent-abc"; "claude-swift-fox"; "alpha"; "" ]
 ;;
 
 let test_agrees_with_the_canonical_parser () =
@@ -68,9 +68,9 @@ let test_codec_normalizes_all_spellings_round_trip () =
       match Codec.keeper_name_of_agent_alias alias with
       | None -> failf "codec rejected accepted alias %S" alias
       | Some keeper_name ->
-        check string (alias ^ ": parsed keeper") "sangsu" keeper_name;
+        check string (alias ^ ": parsed keeper") "alpha" keeper_name;
         let canonical_alias = Codec.keeper_agent_name keeper_name in
-        check string (alias ^ ": canonical render") "keeper-sangsu-agent" canonical_alias;
+        check string (alias ^ ": canonical render") "keeper-alpha-agent" canonical_alias;
         check
           (option string)
           (alias ^ ": render parses to the same keeper")

--- a/test/test_dashboard_namespace_truth.ml
+++ b/test/test_dashboard_namespace_truth.ml
@@ -277,7 +277,7 @@ let test_dashboard_namespace_truth_keeper_only_workspace_not_reported_empty () =
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
       with_config_dir dir @@ fun ~config_dir:_ ~keepers_dir ->
-      write_keeper_toml ~keepers_dir ~name:"sangsu";
+      write_keeper_toml ~keepers_dir ~name:"alpha";
       with_runtime_default_for_tests dir @@ fun () ->
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -298,15 +298,15 @@ let test_dashboard_namespace_truth_keeper_only_workspace_not_reported_empty () =
         ignore (Lib.Workspace.init config ~agent_name:None);
         ignore
           (Lib.Workspace.bind_session config
-             ~agent_name:"keeper-sangsu-agent"
+             ~agent_name:"keeper-alpha-agent"
              ~agent_type_override:(Some "keeper")
              ~capabilities:["keeper"]
              ());
         Fun.protect
           ~finally:(fun () ->
-            Lib.Keeper_keepalive.stop_keepalive "sangsu")
+            Lib.Keeper_keepalive.stop_keepalive "alpha")
           (fun () ->
-            create_keeper env sw state "sangsu";
+            create_keeper env sw state "alpha";
             warm_execution_cache ();
             let json =
               Server_dashboard_http.dashboard_namespace_truth_http_json
@@ -332,7 +332,7 @@ let test_dashboard_namespace_truth_mixed_runtime_counts () =
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
       with_config_dir dir @@ fun ~config_dir:_ ~keepers_dir ->
-      write_keeper_toml ~keepers_dir ~name:"sangsu";
+      write_keeper_toml ~keepers_dir ~name:"alpha";
       with_runtime_default_for_tests dir @@ fun () ->
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -359,15 +359,15 @@ let test_dashboard_namespace_truth_mixed_runtime_counts () =
              ());
         ignore
           (Lib.Workspace.bind_session config
-             ~agent_name:"keeper-sangsu-agent"
+             ~agent_name:"keeper-alpha-agent"
              ~agent_type_override:(Some "keeper")
              ~capabilities:["keeper"]
              ());
         Fun.protect
           ~finally:(fun () ->
-            Lib.Keeper_keepalive.stop_keepalive "sangsu")
+            Lib.Keeper_keepalive.stop_keepalive "alpha")
           (fun () ->
-            create_keeper env sw state "sangsu";
+            create_keeper env sw state "alpha";
             warm_execution_cache ();
             let json =
               Server_dashboard_http.dashboard_namespace_truth_http_json

--- a/test/test_dashboard_workspace.ml
+++ b/test/test_dashboard_workspace.ml
@@ -41,15 +41,15 @@ let string_list_field key json =
 let test_workspace_projection_includes_messages_and_mentions () =
   with_workspace
   @@ fun config ->
-  ignore (Workspace.bind_session config ~agent_name:"sangsu" ~capabilities:[] ());
-  ignore (Workspace.broadcast ~audience:Workspace_broadcast.System_record config ~from_agent:"operator" ~content:"hello @sangsu");
+  ignore (Workspace.bind_session config ~agent_name:"alpha" ~capabilities:[] ());
+  ignore (Workspace.broadcast ~audience:Workspace_broadcast.System_record config ~from_agent:"operator" ~content:"hello @alpha");
   ignore
     (Workspace.broadcast ~audience:Workspace_broadcast.System_record
        config
-       ~from_agent:"sangsu"
+       ~from_agent:"alpha"
        ~msg_type:"status"
        ~content:"work remains in progress");
-  let json = Dashboard_workspace.json ~config ~me:"sangsu" ~limit:10 () in
+  let json = Dashboard_workspace.json ~config ~me:"alpha" ~limit:10 () in
   let workspace = Yojson.Safe.Util.(json |> member "workspace") in
   let messages = list_field "messages" json in
   let inbox = list_field "mentions_inbox" json in
@@ -57,9 +57,9 @@ let test_workspace_projection_includes_messages_and_mentions () =
   Alcotest.(check int) "one mention" 1 (List.length inbox);
   Alcotest.(check string) "workspace id" "workspace" (string_field "id" workspace);
   Alcotest.(check bool)
-    "participants include sangsu"
+    "participants include alpha"
     true
-    (List.mem "sangsu" (string_list_field "participants" workspace));
+    (List.mem "alpha" (string_list_field "participants" workspace));
   let first = List.hd messages in
   Alcotest.(check string) "first sender" "operator" (string_field "sender" first);
   Alcotest.(check string) "first type" "broadcast" (string_field "type" first);
@@ -69,7 +69,7 @@ let test_workspace_projection_includes_messages_and_mentions () =
     Yojson.Safe.Util.(first |> member "expires_at" = `Null);
   Alcotest.(check (list string))
     "mentions"
-    [ "sangsu" ]
+    [ "alpha" ]
     (string_list_field "mentions" first);
   let second = List.nth messages 1 in
   Alcotest.(check string) "second type" "status" (string_field "type" second);

--- a/test/test_discord_presence_bridge.ml
+++ b/test/test_discord_presence_bridge.ml
@@ -17,7 +17,7 @@ let check_status label expected actual =
 ;;
 
 let test_disconnected_gateway_is_noop () =
-  let keepers = [ keeper ~running:true ~bound_channels:[ "C123" ] "verifier" ] in
+  let keepers = [ keeper ~running:true ~bound_channels:[ "C123" ] "fixture-reviewer" ] in
   check_status
     "disconnected gateway"
     None

--- a/test/test_env_config_keeper_bootstrap_intervals.ml
+++ b/test/test_env_config_keeper_bootstrap_intervals.ml
@@ -58,20 +58,20 @@ let test_polling_floor () =
 let test_autoboot_warmup_jitter_is_bounded_not_linear () =
   let names =
     [
-      "analyst";
-      "executor";
-      "issue_king";
+      "delta";
+      "omega";
+      "kappa_keeper";
       "janitor";
-      "masc-improver";
-      "nick0cave";
-      "qa-king";
-      "ramarama";
-      "sangsu";
-      "scholar";
-      "taskmaster";
-      "tech_glutton";
-      "velvet-hammer";
-      "verifier";
+      "omicron-improver";
+      "theta0";
+      "mu-king";
+      "nu";
+      "alpha";
+      "iota";
+      "fixture-keeper";
+      "pi_glutton";
+      "xi-hammer";
+      "fixture-reviewer";
     ]
   in
   let warmups =
@@ -103,10 +103,10 @@ let test_warmup_hash_pinned_cross_platform () =
     Boot.autoboot_proactive_warmup_sec ~base_warmup:0
       ~stagger_window_sec:99 ~keeper_name:name
   in
-  check int "verifier hash mod 100 (Int32 djb2)" 25 (warmup "verifier");
+  check int "fixture-reviewer hash mod 100 (Int32 djb2)" 90 (warmup "fixture-reviewer");
   check int "designer hash mod 100 (Int32 djb2)" 74 (warmup "designer");
   check int "developer hash mod 100 (Int32 djb2)" 15 (warmup "developer");
-  check int "analyst hash mod 100 (Int32 djb2)" 73 (warmup "analyst");
+  check int "delta hash mod 100 (Int32 djb2)" 3 (warmup "delta");
   check int "janitor hash mod 100 (Int32 djb2)" 4 (warmup "janitor")
 
 let test_autoboot_warmup_is_order_independent () =
@@ -114,14 +114,14 @@ let test_autoboot_warmup_is_order_independent () =
     Boot.autoboot_proactive_warmup_sec ~base_warmup:60 ~stagger_window_sec:15
       ~keeper_name:name
   in
-  (* PR #13119 review: previously this test called [warmup "verifier"]
+  (* PR #13119 review: previously this test called [warmup "fixture-reviewer"]
      twice with identical inputs, which would still pass even if the
      implementation depended on list position.  The actual invariant
      is "permuting the keeper boot list does not change any individual
      keeper's warmup".  Compute warmups for an ordered name list and
      for its reverse, then assert per-name equality. *)
   let names = [
-    "verifier"; "designer"; "developer"; "operator"; "supervisor";
+    "fixture-reviewer"; "designer"; "developer"; "operator"; "supervisor";
     "tester"; "auditor"; "researcher"; "writer"; "scheduler";
   ] in
   let warmups_forward = List.map (fun n -> (n, warmup n)) names in
@@ -135,10 +135,10 @@ let test_autoboot_warmup_is_order_independent () =
         w_fwd w_rev)
     warmups_forward;
   check int "same keeper gets same warmup independent of boot order"
-    (warmup "verifier") (warmup "verifier");
+    (warmup "fixture-reviewer") (warmup "fixture-reviewer");
   check int "zero jitter keeps exact base warmup" 60
     (Boot.autoboot_proactive_warmup_sec ~base_warmup:60
-       ~stagger_window_sec:0 ~keeper_name:"verifier");
+       ~stagger_window_sec:0 ~keeper_name:"fixture-reviewer");
   (* Coverage smoke: the test assumes the hash actually distributes
      names across the stagger window — if every name collapsed to
      a single offset the previous "no list-position dependency"

--- a/test/test_fs_atomic_orphan_sweep_10130.ml
+++ b/test/test_fs_atomic_orphan_sweep_10130.ml
@@ -77,7 +77,7 @@ let test_name_matcher () =
   no "atomic_abc.tmp";
   no ".atomic_abc";
   no "normal.json";
-  no "sangsu.json";
+  no "alpha.json";
   no ".atomic_prefix_only";
   no "prefix_.atomic_abc.tmp" (* prefix not at start *)
 
@@ -101,7 +101,7 @@ let test_zero_byte_orphan_at_base_deleted () =
 let test_nonzero_orphan_preserved_in_recovered () =
   with_temp_base @@ fun base_path ->
   let orphan = Filename.concat base_path ".atomic_data42.tmp" in
-  let payload = "{\"name\":\"sangsu\",\"goal\":\"…\"}" in
+  let payload = "{\"name\":\"alpha\",\"goal\":\"…\"}" in
   write_file ~path:orphan ~content:payload;
   let report = cleanup base_path in
   check_no_failures report;
@@ -131,7 +131,7 @@ let test_orphans_in_subdirs_found () =
   Unix.mkdir subdir 0o755;
   touch (Filename.concat subdir ".atomic_zeroKeeper.tmp");
   write_file ~path:(Filename.concat subdir ".atomic_dataKeeper.tmp")
-    ~content:"sangsu data";
+    ~content:"alpha data";
   let report =
     cleanup
       ~scope:Fs_compat.Directory_and_immediate_subdirectories
@@ -150,13 +150,13 @@ let test_orphans_in_subdirs_found () =
    [is_atomic_orphan_name] predicate strictly. *)
 let test_non_orphan_files_untouched () =
   with_temp_base @@ fun base_path ->
-  let normal = Filename.concat base_path "sangsu.json" in
+  let normal = Filename.concat base_path "alpha.json" in
   write_file ~path:normal ~content:"{\"real\":\"data\"}";
   let atomic_no_suffix = Filename.concat base_path ".atomic_abc" in
   write_file ~path:atomic_no_suffix ~content:"not an orphan";
   let report = cleanup base_path in
   check_no_failures report;
-  Alcotest.(check bool) "sangsu.json survived" true
+  Alcotest.(check bool) "alpha.json survived" true
     (Sys.file_exists normal);
   Alcotest.(check bool) ".atomic_abc (no .tmp) survived" true
     (Sys.file_exists atomic_no_suffix)

--- a/test/test_fusion_delivery_obligation.ml
+++ b/test/test_fusion_delivery_obligation.ml
@@ -79,8 +79,8 @@ let channel =
 ;;
 
 let payload ?(prompt = "compare implementations") () : Obligation.accepted_payload =
-  { keeper_name = "analyst"
-  ; submitted_by = "analyst"
+  { keeper_name = "delta"
+  ; submitted_by = "delta"
   ; prompt
   ; preset = "council"
   ; web_tools = false
@@ -184,7 +184,7 @@ let test_startup_recovery_projects_canonical_terminal () =
           Keeper_msg_async.submit_with_request_id ~on_accepted
             ~on_worker_settled:(fun settlement ->
               Eio.Promise.resolve resolve_settled settlement)
-            ~background_sw ~base_path ~caller:"analyst" ~keeper_name:"analyst"
+            ~background_sw ~base_path ~caller:"delta" ~keeper_name:"delta"
             ~f:(fun ~request_id:_ _request_sw ->
               Keeper_types_profile.tool_result_ok_data
                 (Fusion_types.deliberation_evidence_to_yojson evidence))
@@ -232,7 +232,7 @@ let test_startup_recovery_projects_canonical_terminal () =
          | Error error -> fail (Obligation.error_to_string error)
          | Ok _ -> fail "projected obligation was not removed");
         match
-          Keeper_event_queue_persistence.load ~base_path ~keeper_name:"analyst"
+          Keeper_event_queue_persistence.load ~base_path ~keeper_name:"delta"
           |> Keeper_event_queue.dequeue
         with
         | Some ({ payload = Keeper_event_queue.Fusion_completed completion; _ }, _) ->
@@ -295,7 +295,7 @@ let test_startup_recovery_remediates_missing_evidence () =
           Keeper_msg_async.submit_with_request_id ~on_accepted
             ~on_worker_settled:(fun settlement ->
               Eio.Promise.resolve resolve_settled settlement)
-            ~background_sw ~base_path ~caller:"analyst" ~keeper_name:"analyst"
+            ~background_sw ~base_path ~caller:"delta" ~keeper_name:"delta"
             ~f:(fun ~request_id:_ _request_sw ->
               (* A plain string body settles [Done{ok=true; data=None}]. *)
               Keeper_types_profile.tool_result_ok "done without evidence")
@@ -340,7 +340,7 @@ let test_startup_recovery_remediates_missing_evidence () =
          | Error error -> fail (Obligation.error_to_string error)
          | Ok _ -> fail "remediated obligation was not removed");
         match
-          Keeper_event_queue_persistence.load ~base_path ~keeper_name:"analyst"
+          Keeper_event_queue_persistence.load ~base_path ~keeper_name:"delta"
           |> Keeper_event_queue.dequeue
         with
         | Some ({ payload = Keeper_event_queue.Fusion_completed completion; _ }, _) ->

--- a/test/test_goal_metric_unevaluated.ml
+++ b/test/test_goal_metric_unevaluated.ml
@@ -297,7 +297,7 @@ let cancelled_task id ~reason : MD.task =
   { (make_done_task id) with
     task_status =
       MD.Cancelled
-        { cancelled_by = "keeper-rondo-agent"; cancelled_at = iso_now (); reason }
+        { cancelled_by = "keeper-beta-agent"; cancelled_at = iso_now (); reason }
   }
 
 let tree_field name json =
@@ -313,7 +313,7 @@ let cancelled_with_handoff id ~handoff_reason ~summary : MD.task =
   { (make_done_task id) with
     task_status =
       MD.Cancelled
-        { cancelled_by = "keeper-rondo-agent"; cancelled_at = iso_now (); reason = None }
+        { cancelled_by = "keeper-beta-agent"; cancelled_at = iso_now (); reason = None }
   ; handoff_context =
       Some
         { MD.summary
@@ -350,7 +350,7 @@ let test_tree_task_falls_through_to_the_handoff_summary () =
 
 let test_tree_task_carries_the_cancellation_actor_and_reason () =
   let json = Timeline.task_to_tree_json (cancelled_task "task-aged" ~reason:(Some "superseded by G-2")) in
-  check (option string) "the canceller is projected" (Some "keeper-rondo-agent")
+  check (option string) "the canceller is projected" (Some "keeper-beta-agent")
     (match tree_field "cancelled_by" json with Some (`String v) -> Some v | _ -> None);
   check (option string) "the reason is projected" (Some "superseded by G-2")
     (match tree_field "reason" json with Some (`String v) -> Some v | _ -> None)
@@ -422,20 +422,20 @@ let goal_owner_event ~previous_owner ~owner ~actor =
 let test_goal_owner_timeline_names_the_transition () =
   let json =
     Timeline.goal_event_timeline_json
-      (goal_owner_event ~previous_owner:(Some "dancer") ~owner:(Some "sangsu")
+      (goal_owner_event ~previous_owner:(Some "dancer") ~owner:(Some "alpha")
          ~actor:"operator")
   in
-  check string "the transition names both owners" "owner: dancer -> sangsu by operator"
+  check string "the transition names both owners" "owner: dancer -> alpha by operator"
     (json_str json "summary");
   check string "kind stays the event type" "goal_owner" (json_str json "kind")
 
 let test_goal_owner_timeline_names_unassigned_sides () =
   let assigned =
     Timeline.goal_event_timeline_json
-      (goal_owner_event ~previous_owner:None ~owner:(Some "sangsu") ~actor:"operator")
+      (goal_owner_event ~previous_owner:None ~owner:(Some "alpha") ~actor:"operator")
   in
   check string "an unassigned previous owner is explicit"
-    "owner: <unassigned> -> sangsu by operator"
+    "owner: <unassigned> -> alpha by operator"
     (json_str assigned "summary");
   let cleared =
     Timeline.goal_event_timeline_json

--- a/test/test_goal_scope_terminal_phase.ml
+++ b/test/test_goal_scope_terminal_phase.ml
@@ -87,7 +87,7 @@ let test_every_terminal_phase_leaves_scope () =
         (surviving config ("goal-executing" :: List.map fst terminal)))
 ;;
 
-(* The live shape this closes, measured 2026-08-07: sangsu's only configured
+(* The live shape this closes, measured 2026-08-07: alpha's only configured
    goal completed 2h12m after it entered scope and stayed there. Over the next
    2.5 days the runtime contract stamped goal_ids from the raw list for 5,362
    tool calls while the prompt, applying the phase predicate, showed no goal in

--- a/test/test_graphql_api.ml
+++ b/test/test_graphql_api.ml
@@ -72,7 +72,7 @@ let test_messages_temporal_decay_fields () =
   let config = Workspace_utils.default_config base_path in
   let _ = Workspace.init config ~agent_name:None in
   let _ =
-    Workspace.broadcast ~audience:Workspace_broadcast.System_record config ~from_agent:"operator" ~content:"hello @sangsu"
+    Workspace.broadcast ~audience:Workspace_broadcast.System_record config ~from_agent:"operator" ~content:"hello @alpha"
   in
   let json =
     graphql_query config
@@ -90,9 +90,9 @@ let test_messages_temporal_decay_fields () =
   Alcotest.(check string) "from" "operator" (node |> member "from" |> to_string);
   Alcotest.(check string) "messageType" "broadcast"
     (node |> member "messageType" |> to_string);
-  Alcotest.(check string) "content" "hello @sangsu"
+  Alcotest.(check string) "content" "hello @alpha"
     (node |> member "content" |> to_string);
-  Alcotest.(check string) "mention" "sangsu"
+  Alcotest.(check string) "mention" "alpha"
     (node |> member "mention" |> to_string);
   Alcotest.(check bool) "expiresAt null" true
     (node |> member "expiresAt" = `Null);

--- a/test/test_grpc_client.ml
+++ b/test/test_grpc_client.ml
@@ -54,7 +54,7 @@ let test_tool_call_error_response_roundtrip () =
 
 let test_heartbeat_ping_roundtrip () =
   let ping = T.HeartbeatPing.{
-    agent_name = "keeper-sangsu";
+    agent_name = "keeper-alpha";
     session_id = "sess-42";
     timestamp_ms = 1700000000000L;
     current_task_id = "T-99";

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -1895,7 +1895,7 @@ let test_keeper_up_shared_boundary_outlives_calling_turn () =
     (fun () ->
       ensure_default_runtime ();
       let config = Masc.Workspace.default_config base_dir in
-      ignore (Masc.Workspace.init config ~agent_name:(Some "rondo"));
+      ignore (Masc.Workspace.init config ~agent_name:(Some "beta"));
       seed_keeper_sandbox_profile ~base_dir target_name;
       ignore Masc.Keeper_tool_surface.schemas;
       Masc.Server_startup_state.reset ();
@@ -1937,7 +1937,7 @@ let test_keeper_up_shared_boundary_outlives_calling_turn () =
                    Eio_context.with_turn_switch turn_sw @@ fun () ->
                    let ctx : _ Masc.Keeper_tool_surface.context =
                      { config
-                     ; agent_name = "rondo"
+                     ; agent_name = "beta"
                      ; sw = turn_sw
                      ; clock
                      ; proc_mgr = None

--- a/test/test_ide_annotations.ml
+++ b/test/test_ide_annotations.ml
@@ -25,7 +25,7 @@ let route_annotation : Types.annotation =
   ; file_path = "lib/keeper/keeper_tool_ide_runtime.ml"
   ; line_start = 12
   ; line_end = 14
-  ; keeper_id = "sangsu"
+  ; keeper_id = "alpha"
   ; kind = Types.Comment
   ; content = "Connect this line to the active review context."
   ; goal_id = Some "goal-ide"
@@ -132,7 +132,7 @@ let test_create_lists_route_context () =
       Store.create
         ~base_dir
         ~codebase:"github.com_other_repo"
-        ~keeper_id:"sangsu"
+        ~keeper_id:"alpha"
         ~file_path:"lib/keeper/keeper_tool_ide_runtime.ml"
         ~line_start:12
         ~line_end:14
@@ -169,7 +169,7 @@ let test_lsp_overlay_exposes_route_context () =
       Store.create
         ~base_dir
         ~codebase:"github.com_other_repo"
-        ~keeper_id:"sangsu"
+        ~keeper_id:"alpha"
         ~file_path:"lib/keeper/keeper_tool_ide_runtime.ml"
         ~line_start:12
         ~line_end:14
@@ -225,7 +225,7 @@ let test_region_tracker_writes_fixed_regions_file () =
     Region.ingest_tool_call
       ~base_dir
       ~codebase:"github.com_other_repo"
-      ~keeper_id:"sangsu"
+      ~keeper_id:"alpha"
       ~turn:7
       (`Assoc
         [ "name", `String "write_file"
@@ -241,7 +241,7 @@ let test_region_tracker_writes_fixed_regions_file () =
       check string "file path" "lib/a.ml" region.Types.file_path;
       check int "line start" 1 region.line_start;
       check int "line end" 1 region.line_end;
-      check string "keeper" "sangsu" region.keeper_id;
+      check string "keeper" "alpha" region.keeper_id;
       (match region.source with
        | Types.Tool_call { tool_name; turn } ->
          check string "tool name" "write_file" tool_name;
@@ -264,7 +264,7 @@ let create_in_codebase ~base_dir ~codebase ~kind ~content () =
   Store.create
     ~base_dir
     ~codebase
-    ~keeper_id:"sangsu"
+    ~keeper_id:"alpha"
     ~file_path:"lib/foo.ml"
     ~line_start:1
     ~line_end:3
@@ -357,7 +357,7 @@ let test_explicit_codebase_store () =
       Store.create
         ~base_dir
         ~codebase:"github.com_other_repo"
-        ~keeper_id:"sangsu"
+        ~keeper_id:"alpha"
         ~file_path:"lib/foo.ml"
         ~line_start:1
         ~line_end:3
@@ -394,7 +394,7 @@ let test_delete_is_codebase_scoped () =
         ~base_dir
         ~codebase:"github.com_other_repo"
         ~id:by_url.id
-        ~keeper_id:"sangsu"
+        ~keeper_id:"alpha"
         ()
     in
     (match in_other with
@@ -405,7 +405,7 @@ let test_delete_is_codebase_scoped () =
         ~base_dir
         ~codebase:(slug)
         ~id:by_url.id
-        ~keeper_id:"sangsu"
+        ~keeper_id:"alpha"
         ()
     in
     (match in_by_url with
@@ -417,7 +417,7 @@ let test_region_append_isolates_codebases () =
   with_temp_dir (fun base_dir ->
     let slug = "github.com_owner_repo" in
     let region : Types.code_region =
-      { keeper_id = "sangsu"
+      { keeper_id = "alpha"
       ; file_path = "lib/foo.ml"
       ; line_start = 1
       ; line_end = 5
@@ -480,7 +480,7 @@ let test_ingest_edit_file_content_fallback () =
     Region.ingest_tool_call
       ~base_dir
       ~codebase:(slug)
-      ~keeper_id:"sangsu"
+      ~keeper_id:"alpha"
       ~turn:1
       json;
     let by_url_path =
@@ -516,7 +516,7 @@ let test_ingest_no_double_write () =
     Region.ingest_tool_call
       ~base_dir
       ~codebase:(slug)
-      ~keeper_id:"sangsu"
+      ~keeper_id:"alpha"
       ~turn:0
       json;
     let by_url_path =
@@ -592,7 +592,7 @@ let test_compact_preserves_annotations () =
         Store.create
           ~base_dir
           ~codebase:"github.com_other_repo"
-          ~keeper_id:"sangsu"
+          ~keeper_id:"alpha"
           ~file_path:"lib/x.ml"
           ~line_start:1
           ~line_end:2

--- a/test/test_ide_bridge.ml
+++ b/test/test_ide_bridge.ml
@@ -271,7 +271,7 @@ let test_list_events_merges_kinds_newest_first () =
 let test_hook_row_carries_the_resolved_path_not_the_raw_argument () =
   with_temp_dir (fun base_dir ->
     let raw_argument =
-      "/base/.masc/playground/analyst/repos/masc/lib/keeper/keeper_approval_queue.ml"
+      "/base/.masc/playground/delta/repos/masc/lib/keeper/keeper_approval_queue.ml"
     in
     let resolved = "lib/keeper/keeper_approval_queue.ml" in
     let input =
@@ -285,7 +285,7 @@ let test_hook_row_carries_the_resolved_path_not_the_raw_argument () =
       ~base_path:base_dir
       ~attribution:(addressed_file ~codebase:"github.com_x_y" ~path:resolved)
       ~tool_name:"edit_file"
-      ~keeper_id:"analyst"
+      ~keeper_id:"delta"
       ~turn_id:"turn-3"
       ~outcome:"ok"
       ~typed_outcome_str:"progress"
@@ -321,7 +321,7 @@ let test_pathless_hook_stores_no_document () =
       ~base_path:base_dir
       ~attribution:Agent_observation.Pathless
       ~tool_name:"masc_broadcast"
-      ~keeper_id:"analyst"
+      ~keeper_id:"delta"
       ~turn_id:"turn-4"
       ~outcome:"ok"
       ~typed_outcome_str:"progress"

--- a/test/test_ide_canonical_url_join.ml
+++ b/test/test_ide_canonical_url_join.ml
@@ -232,7 +232,7 @@ let test_sandbox_playground_path_joins_with_worktree () =
     let sandbox_file =
       Filename.concat
         base_dir
-        ".masc/playground/sangsu/repos/masc/lib/foo.ml"
+        ".masc/playground/alpha/repos/masc/lib/foo.ml"
     in
     let worktree_file = Filename.concat worktree "lib/foo.ml" in
     let sandbox_address =
@@ -291,7 +291,7 @@ let test_docker_playground_path_also_resolves () =
     let docker_file =
       Filename.concat
         base_dir
-        ".masc/playground/docker/tech_glutton/repos/masc/lib/foo.ml"
+        ".masc/playground/docker/pi_glutton/repos/masc/lib/foo.ml"
     in
     let address =
       addressed_or_fail

--- a/test/test_ide_diagnostics.ml
+++ b/test/test_ide_diagnostics.ml
@@ -51,7 +51,7 @@ let make_test_annotation () =
   ; file_path = "lib/test.ml"
   ; line_start = 10
   ; line_end = 15
-  ; keeper_id = "rondo"
+  ; keeper_id = "beta"
   ; kind = Ide_annotation_types.Comment
   ; content = "test annotation"
   ; goal_id = Some "goal-1"
@@ -154,7 +154,7 @@ let test_region_json_round_trip_tool_call () =
     { Ide_annotation_types.file_path = "lib/server.ml"
     ; line_start = 7
     ; line_end = 9
-    ; keeper_id = "rondo"
+    ; keeper_id = "beta"
     ; source = Ide_annotation_types.Tool_call { tool_name = "masc_status"; turn = 42 }
     ; timestamp_ms = 1700000000123L
     }

--- a/test/test_ide_lsp_join_key.ml
+++ b/test/test_ide_lsp_join_key.ml
@@ -70,7 +70,7 @@ let test_write_is_read_under_its_codebase () =
       (create_annotation
          ~base_dir
          ~codebase:slug
-         ~keeper_id:"analyst"
+         ~keeper_id:"delta"
          ~content:"picked Eio.Mutex over Lazy here"
          ~line:12);
     check
@@ -96,7 +96,7 @@ let test_unaddressed_store_reads_empty () =
       (create_annotation
          ~base_dir
          ~codebase:"github.com_other_repo"
-         ~keeper_id:"analyst"
+         ~keeper_id:"delta"
          ~content:"orphan lane row"
          ~line:3);
     check
@@ -117,14 +117,14 @@ let test_codebases_do_not_share_cache_entries () =
       (create_annotation
          ~base_dir
          ~codebase:slug
-         ~keeper_id:"analyst"
+         ~keeper_id:"delta"
          ~content:"by-url row"
          ~line:5);
     ignore
       (create_annotation
          ~base_dir
          ~codebase:"github.com_other_repo"
-         ~keeper_id:"sangsu"
+         ~keeper_id:"alpha"
          ~content:"orphan row"
          ~line:5);
     (* Read the by-URL codebase first so its rows are the cached ones. *)
@@ -156,7 +156,7 @@ let test_write_after_first_read_becomes_visible () =
       (create_annotation
          ~base_dir
          ~codebase:slug
-         ~keeper_id:"analyst"
+         ~keeper_id:"delta"
          ~content:"written after the reader cached the empty store"
          ~line:9);
     check

--- a/test/test_keeper_approval_audit_timeline.ml
+++ b/test/test_keeper_approval_audit_timeline.ml
@@ -43,7 +43,7 @@ let audit_record ?decision_kind event =
     ([ ("ts", `Float 1_700_000_000.0)
      ; ("event", `String (Audit.event_to_string event))
      ; ("id", `String "appr-1")
-     ; ("keeper", `String "sangsu")
+     ; ("keeper", `String "alpha")
      ; ("tool", `String "bash")
      ]
     @
@@ -158,7 +158,7 @@ let test_approval_mentioning_rejection_is_not_bad () =
       [ ("ts", `Float 1_700_000_000.0)
       ; ("event", `String (Audit.event_to_string Audit.Resolved))
       ; ("id", `String "appr-2")
-      ; ("keeper", `String "sangsu")
+      ; ("keeper", `String "alpha")
       ; ("tool", `String "bash")
       ; ("decision", `String "approve: proceed after the earlier reject")
       ; ("decision_kind", `String (Audit.decision_kind_to_string Audit.Decision_approve))
@@ -177,7 +177,7 @@ let test_unknown_spelling_says_so () =
       [ ("ts", `Float 1_700_000_000.0)
       ; ("event", `String "auto_approved_always")
       ; ("id", `String "appr-3")
-      ; ("keeper", `String "sangsu")
+      ; ("keeper", `String "alpha")
       ; ("tool", `String "bash")
       ]
   in

--- a/test/test_keeper_approval_resolved_history.ml
+++ b/test/test_keeper_approval_resolved_history.ml
@@ -69,7 +69,7 @@ let append_row ~base_path ~ts (row : Yojson.Safe.t) =
     (fun () -> output_string oc (Yojson.Safe.to_string row ^ "\n"))
 ;;
 
-let seed_resolved ~base_path ~ts ~id ?(keeper = "rondo") ?(tool = "tool_execute")
+let seed_resolved ~base_path ~ts ~id ?(keeper = "beta") ?(tool = "tool_execute")
       ?(decision = "approve") ?(source = "auto_judge") ()
   =
   let decision_kind, decision_reason =
@@ -118,7 +118,7 @@ let seed_noise ~base_path ~ts ~count =
             [ "event", `String "summary_updated"
             ; "id", `String (Printf.sprintf "noise_%d" i)
             ; "ts", `Float ts
-            ; "keeper", `String "rondo"
+            ; "keeper", `String "beta"
             ]
         in
         output_string oc (Yojson.Safe.to_string row ^ "\n")
@@ -284,7 +284,7 @@ let test_nullable_string_projection_is_literal base_path =
         [ "event", `String "resolved"
         ; "id", `String "approve-nullable"
         ; "ts", `Float approve_ts
-        ; "keeper", `String "rondo"
+        ; "keeper", `String "beta"
         ; "tool", `String "tool_execute"
         ; "decision", `String "approve"
         ; "turn_id", `Null
@@ -309,7 +309,7 @@ let test_nullable_string_projection_is_literal base_path =
         [ "event", `String "resolved"
         ; "id", `String "reject-present"
         ; "ts", `Float reject_ts
-        ; "keeper", `String "rondo"
+        ; "keeper", `String "beta"
         ; "tool", `String "tool_execute"
         ; "decision", `String "reject"
         ; "turn_id", `Null
@@ -334,7 +334,7 @@ let test_nullable_string_projection_is_literal base_path =
     [ `Assoc
         [ "id", `String "reject-present"
         ; "event", `String "resolved"
-        ; "keeper_name", `String "rondo"
+        ; "keeper_name", `String "beta"
         ; "tool_name", `String "tool_execute"
         ; "decision", `String "reject"
         ; "decision_kind", `String "reject"
@@ -352,7 +352,7 @@ let test_nullable_string_projection_is_literal base_path =
     ; `Assoc
         [ "id", `String "approve-nullable"
         ; "event", `String "resolved"
-        ; "keeper_name", `String "rondo"
+        ; "keeper_name", `String "beta"
         ; "tool_name", `String "tool_execute"
         ; "decision", `String "approve"
         ; "decision_kind", `String "approve"
@@ -383,7 +383,7 @@ let test_judge_evidence_passes_through base_path =
         [ "event", `String "resolved"
         ; "id", `String "with-judge"
         ; "ts", `Float (now -. minutes 5)
-        ; "keeper", `String "rondo"
+        ; "keeper", `String "beta"
         ; "tool", `String "tool_execute"
         ; "decision", `String "approve"
         ; "turn_id", `Null

--- a/test/test_keeper_artifact_read_request.ml
+++ b/test/test_keeper_artifact_read_request.ml
@@ -1,6 +1,6 @@
 (** Per-field diagnostics for [keeper_artifact_read] request parsing.
 
-    Live failure 2026-08-05 20:06:36 (keeper kidsnote):
+    Live failure 2026-08-05 20:06:36 (keeper gamma):
     [{"max_bytes": 565244, "offset": 0, "sha256": "8ee32b2a…740c"}] was
     answered with ["expected sha256, non-negative offset, and max_bytes
     1..65536"]. The sha256 was correct; [max_bytes] was over the maximum.

--- a/test/test_keeper_board_attention_candidate.ml
+++ b/test/test_keeper_board_attention_candidate.ml
@@ -116,14 +116,14 @@ let comment_of_signal
 
 let keeper_context ?(active_goal_ids = []) () =
   `Assoc
-    [ "lane_keeper_name", `String "sangsu"
-    ; "agent_name", `String "sangsu-agent"
+    [ "lane_keeper_name", `String "alpha"
+    ; "agent_name", `String "alpha-agent"
     ; "keeper_record_id", `Null
     ; "keeper_runtime_uid", `Null
     ; "instructions", `String "continue"
     ; "active_goal_ids", `List (List.map (fun id -> `String id) active_goal_ids)
     ; "current_task_id", `Null
-    ; "mention_keeper_ids", `List [ `String "sangsu" ]
+    ; "mention_keeper_ids", `List [ `String "alpha" ]
     ]
 ;;
 
@@ -149,7 +149,7 @@ let render_row_with_non_finite ~field ~literal json =
 let candidate ?(context = keeper_context ()) signal :
   A.candidate
   =
-  let keeper_name = "sangsu" in
+  let keeper_name = "alpha" in
   let candidate_id = A.candidate_id_of_signal ~keeper_name signal in
   { candidate_id
   ; keeper_name
@@ -245,7 +245,7 @@ let record ~base_path candidate =
 ;;
 
 let load_one ~base_path =
-  match ok "load candidate" (A.load_candidates ~base_path ~keeper_name:"sangsu") with
+  match ok "load candidate" (A.load_candidates ~base_path ~keeper_name:"alpha") with
   | [ candidate ] -> candidate
   | candidates -> Alcotest.failf "expected one candidate, got %d" (List.length candidates)
 ;;
@@ -554,7 +554,7 @@ let test_non_finite_lifecycle_times_are_rejected () =
       (Filename.concat
          (Common.masc_dir_from_base_path ~base_path)
          "board_attention_candidates")
-      "sangsu.jsonl"
+      "alpha.jsonl"
   in
   let non_finite_row =
     render_row_with_non_finite
@@ -756,7 +756,7 @@ let test_record_requests_worker_without_invoking_judgment () =
   Eio.Switch.run @@ fun sw ->
   with_temp_base "board-attention-candidate-wake" @@ fun base_path ->
   let registration =
-    ok "register worker" (Wake.register ~sw ~base_path ~keeper_name:"sangsu")
+    ok "register worker" (Wake.register ~sw ~base_path ~keeper_name:"alpha")
   in
   let original = candidate (signal "post-wake") in
   let accepted =

--- a/test/test_keeper_board_attention_exact_flow.ml
+++ b/test/test_keeper_board_attention_exact_flow.ml
@@ -156,7 +156,7 @@ let comment_of_signal (signal : Board_dispatch.board_signal) : Board.comment =
 
 let candidate post_id : Candidate.candidate =
   let signal = signal post_id in
-  let keeper_name = "sangsu" in
+  let keeper_name = "alpha" in
   let candidate_id = Candidate.candidate_id_of_signal ~keeper_name signal in
   { candidate_id
   ; keeper_name
@@ -170,7 +170,7 @@ let candidate post_id : Candidate.candidate =
         ; ( "keeper_context"
           , `Assoc
               [ "lane_keeper_name", `String keeper_name
-              ; "agent_name", `String "sangsu-agent"
+              ; "agent_name", `String "alpha-agent"
               ; "keeper_record_id", `Null
               ; "keeper_runtime_uid", `Null
               ; "instructions", `String "continue"

--- a/test/test_keeper_board_attention_partition.ml
+++ b/test/test_keeper_board_attention_partition.ml
@@ -52,7 +52,7 @@ let context name =
     ]
 ;;
 
-let candidate ?(keeper_name = "sangsu") ?(context = context "primary") ~id ~recorded_at () :
+let candidate ?(keeper_name = "alpha") ?(context = context "primary") ~id ~recorded_at () :
   A.candidate
   =
   { candidate_id = id
@@ -106,13 +106,13 @@ let judgment ?(judged_at = 101.0) (proof : P.exact_provenance) : A.judgment =
 
 let roots ~base_path candidates =
   ignore
-    (ok "ensure roots" (P.ensure_roots ~base_path ~keeper_name:"sangsu" candidates) : int);
-  ok "load roots" (P.load ~base_path ~keeper_name:"sangsu")
+    (ok "ensure roots" (P.ensure_roots ~base_path ~keeper_name:"alpha" candidates) : int);
+  ok "load roots" (P.load ~base_path ~keeper_name:"alpha")
 ;;
 
 let claim ~base_path ~worker_epoch ~now =
   let target =
-    ok "load claim target" (P.load ~base_path ~keeper_name:"sangsu")
+    ok "load claim target" (P.load ~base_path ~keeper_name:"alpha")
     |> List.find_opt (fun (partition : P.t) ->
       match partition.state with
       | P.Ready -> true
@@ -130,7 +130,7 @@ let claim ~base_path ~worker_epoch ~now =
          ~now
          ~worker_epoch
          ~base_path
-         ~keeper_name:"sangsu"
+         ~keeper_name:"alpha"
          ~partition_id:target.partition_id
          ~generation:target.generation)
   with
@@ -175,15 +175,15 @@ let test_roots_are_singleton_deterministic_and_context_exact () =
        "repeat ensure"
        (P.ensure_roots
           ~base_path
-          ~keeper_name:"sangsu"
+          ~keeper_name:"alpha"
           [ first; second; isolated ]));
-  let repeated = ok "load repeated roots" (P.load ~base_path ~keeper_name:"sangsu") in
+  let repeated = ok "load repeated roots" (P.load ~base_path ~keeper_name:"alpha") in
   Alcotest.(check bool) "root creation is idempotent" true (created = repeated);
   expect_error
     "same candidate identity with changed context"
     (P.ensure_roots
        ~base_path
-       ~keeper_name:"sangsu"
+       ~keeper_name:"alpha"
        [ { first with judgment_request = `Assoc [ "keeper_context", context "changed" ] } ]);
   let primary_key = (List.hd created).P.context_key in
   let isolated_key = (List.hd (List.rev created)).P.context_key in
@@ -218,7 +218,7 @@ let test_exact_claim_never_claims_a_ready_sibling () =
           ~now:10.0
           ~worker_epoch:competitor
           ~base_path
-          ~keeper_name:"sangsu"
+          ~keeper_name:"alpha"
           ~partition_id:first_partition.partition_id
           ~generation:first_partition.generation)
      : P.t option);
@@ -233,11 +233,11 @@ let test_exact_claim_never_claims_a_ready_sibling () =
              ~now:11.0
              ~worker_epoch:stale_worker
              ~base_path
-             ~keeper_name:"sangsu"
+             ~keeper_name:"alpha"
              ~partition_id:first_partition.partition_id
              ~generation:first_partition.generation)));
   (match
-     ok "load after stale target conflict" (P.load ~base_path ~keeper_name:"sangsu")
+     ok "load after stale target conflict" (P.load ~base_path ~keeper_name:"alpha")
      |> List.find_opt (fun (partition : P.t) ->
        String.equal partition.partition_id second_partition.partition_id)
    with
@@ -250,7 +250,7 @@ let test_exact_claim_never_claims_a_ready_sibling () =
          ~now:12.0
          ~worker_epoch:stale_worker
          ~base_path
-         ~keeper_name:"sangsu"
+         ~keeper_name:"alpha"
          ~partition_id:second_partition.partition_id
          ~generation:second_partition.generation)
   with
@@ -279,7 +279,7 @@ let test_generation_advances_only_for_state_transition () =
            ~now:2.0
            ~worker_epoch:owner
            ~base_path
-           ~keeper_name:"sangsu"
+           ~keeper_name:"alpha"
            ~partition_id:ready.partition_id
            ~generation:ready.generation)
     with
@@ -516,16 +516,16 @@ let test_existing_judgment_completion_is_atomic_and_restart_safe () =
   in
   require_projected
     "durable roundtrip"
-    (ok "load projected judgment" (P.load ~base_path ~keeper_name:"sangsu"));
+    (ok "load projected judgment" (P.load ~base_path ~keeper_name:"alpha"));
   Alcotest.(check int)
     "restart does not recover completed existing judgment"
     0
     (ok
        "restart after existing judgment completion"
-       (P.recover_for_process_start ~now:12.0 ~base_path ~keeper_name:"sangsu"));
+       (P.recover_for_process_start ~now:12.0 ~base_path ~keeper_name:"alpha"));
   require_projected
     "restart"
-    (ok "load after restart" (P.load ~base_path ~keeper_name:"sangsu"));
+    (ok "load after restart" (P.load ~base_path ~keeper_name:"alpha"));
   let bound_claim = claim ~base_path ~worker_epoch:owner ~now:13.0 in
   let bound_proof =
     provenance ~slot_id:"bound-existing-slot" ~call_id:"bound-existing-call" ()
@@ -672,7 +672,7 @@ let test_runtime_transitions_append_then_startup_compacts () =
   with_temp_base "board-attention-partition-append-index" @@ fun base_path ->
   let pending = candidate ~id:"candidate-append" ~recorded_at:1.0 () in
   ignore (roots ~base_path [ pending ] : P.t list);
-  let ledger_path = P.For_testing.path ~base_path ~keeper_name:"sangsu" in
+  let ledger_path = P.For_testing.path ~base_path ~keeper_name:"alpha" in
   let owner = P.Worker_epoch.generate () in
   let claimed = claim ~base_path ~worker_epoch:owner ~now:10.0 in
   let proof = provenance () in
@@ -711,12 +711,12 @@ let test_runtime_transitions_append_then_startup_compacts () =
     0
     (ok
        "startup compaction"
-       (P.recover_for_process_start ~now:20.0 ~base_path ~keeper_name:"sangsu"));
+       (P.recover_for_process_start ~now:20.0 ~base_path ~keeper_name:"alpha"));
   Alcotest.(check int)
     "startup compacts to one latest row"
     1
     (List.length (ledger_lines ledger_path));
-  match ok "load compacted ledger" (P.load ~base_path ~keeper_name:"sangsu") with
+  match ok "load compacted ledger" (P.load ~base_path ~keeper_name:"alpha") with
   | [ { P.state = P.Settled _; _ } ] -> ()
   | _ -> Alcotest.fail "startup ledger rewrite lost the Settled receipt"
 ;;
@@ -745,8 +745,8 @@ let test_restart_releases_only_unbound_and_quarantines_dispatchable () =
     2
     (ok
        "process-start recovery"
-       (P.recover_for_process_start ~now:20.0 ~base_path ~keeper_name:"sangsu"));
-  let recovered = ok "load recovered partitions" (P.load ~base_path ~keeper_name:"sangsu") in
+       (P.recover_for_process_start ~now:20.0 ~base_path ~keeper_name:"alpha"));
+  let recovered = ok "load recovered partitions" (P.load ~base_path ~keeper_name:"alpha") in
   (match recovered with
    | [ first; second ] ->
      (match first.state with
@@ -776,7 +776,7 @@ let test_restart_releases_only_unbound_and_quarantines_dispatchable () =
   Alcotest.(check (list string))
     "quarantined executions are never redispatched"
     []
-    (ok "load terminalized roots" (P.load ~base_path ~keeper_name:"sangsu")
+    (ok "load terminalized roots" (P.load ~base_path ~keeper_name:"alpha")
      |> List.filter_map (fun (partition : P.t) ->
        match partition.state with
        | P.Ready -> Some partition.candidate_id
@@ -833,7 +833,7 @@ let test_provider_neutral_blocked_reason_codec () =
        ~base_path
        ~partition:claimed
        (P.Exact_setup_unavailable ""));
-  match ok "load after rejected reason" (P.load ~base_path ~keeper_name:"sangsu") with
+  match ok "load after rejected reason" (P.load ~base_path ~keeper_name:"alpha") with
   | [ { P.state = P.Running { progress = P.Unbound; _ }; _ } ] -> ()
   | _ -> Alcotest.fail "invalid blocked reason mutated the partition"
 ;;
@@ -887,11 +887,11 @@ let test_strict_current_schema_rejects_old_json () =
     "retired judgment failure JSON is rejected"
     (P.of_yojson (replace_field "state" retired_blocked encoded));
   let malformed = replace_field "partition_id" (`String "forged-root") encoded in
-  let ledger_path = P.For_testing.path ~base_path ~keeper_name:"sangsu" in
+  let ledger_path = P.For_testing.path ~base_path ~keeper_name:"alpha" in
   ok
     "inject malformed durable row"
     (Fs_compat.save_file_atomic ledger_path (Yojson.Safe.to_string malformed ^ "\n"));
-  expect_error "forged deterministic root identity" (P.load ~base_path ~keeper_name:"sangsu")
+  expect_error "forged deterministic root identity" (P.load ~base_path ~keeper_name:"alpha")
 ;;
 
 let inject_torn_tail ledger_path =
@@ -904,18 +904,18 @@ let test_torn_tail_recovery_preserves_current_hard_cut () =
   with_temp_base "board-attention-partition-torn-tail" @@ fun base_path ->
   let pending = candidate ~id:"candidate-torn" ~recorded_at:1.0 () in
   ignore (roots ~base_path [ pending ] : P.t list);
-  let ledger_path = P.For_testing.path ~base_path ~keeper_name:"sangsu" in
+  let ledger_path = P.For_testing.path ~base_path ~keeper_name:"alpha" in
   let durable = Fs_compat.load_file ledger_path in
   inject_torn_tail ledger_path;
   expect_error
     "torn tail still hard-fails general reads"
-    (P.load ~base_path ~keeper_name:"sangsu");
+    (P.load ~base_path ~keeper_name:"alpha");
   Alcotest.(check int)
     "torn tail without Running recovers nothing"
     0
     (ok
        "torn-tail process-start recovery"
-       (P.recover_for_process_start ~now:10.0 ~base_path ~keeper_name:"sangsu"));
+       (P.recover_for_process_start ~now:10.0 ~base_path ~keeper_name:"alpha"));
   Alcotest.(check string)
     "torn tail truncated to last complete row"
     durable
@@ -928,8 +928,8 @@ let test_torn_tail_recovery_preserves_current_hard_cut () =
     1
     (ok
        "torn Unbound recovery"
-       (P.recover_for_process_start ~now:12.0 ~base_path ~keeper_name:"sangsu"));
-  match ok "load after torn recovery" (P.load ~base_path ~keeper_name:"sangsu") with
+       (P.recover_for_process_start ~now:12.0 ~base_path ~keeper_name:"alpha"));
+  match ok "load after torn recovery" (P.load ~base_path ~keeper_name:"alpha") with
   | [ { P.state = P.Ready; candidate_id; _ } ] ->
     Alcotest.(check string) "candidate remains recoverable" pending.candidate_id candidate_id
   | _ -> Alcotest.fail "torn-tail recovery lost the current partition"
@@ -941,7 +941,7 @@ let test_invalid_or_mismatched_provenance_never_rewrites () =
     "non-finite candidate time"
     (P.ensure_roots
        ~base_path
-       ~keeper_name:"sangsu"
+       ~keeper_name:"alpha"
        [ candidate ~id:"candidate-invalid" ~recorded_at:Float.nan () ]);
   let valid = candidate ~id:"candidate-valid" ~recorded_at:1.0 () in
   ignore (roots ~base_path [ valid ] : P.t list);
@@ -983,7 +983,7 @@ let test_invalid_or_mismatched_provenance_never_rewrites () =
          { candidate_id = valid.candidate_id
          ; judgment = judgment (provenance ~request_body_sha256:"other-body" ())
          });
-  match ok "load Bound after rejected completion" (P.load ~base_path ~keeper_name:"sangsu") with
+  match ok "load Bound after rejected completion" (P.load ~base_path ~keeper_name:"alpha") with
   | [ { P.state = P.Running { progress = P.Bound durable; _ }; _ } ] ->
     Alcotest.(check bool) "durable binding remains intact" true (durable = proof)
   | _ -> Alcotest.fail "rejected completion mutated the durable binding"

--- a/test/test_keeper_board_attention_worker.ml
+++ b/test/test_keeper_board_attention_worker.ml
@@ -53,7 +53,7 @@ let register_owner ~base_path keeper_name =
 
 let with_temp_base name f =
   let base_path = Filename.temp_dir name "" in
-  register_owner ~base_path "sangsu";
+  register_owner ~base_path "alpha";
   Fun.protect ~finally:(fun () -> remove_tree base_path) (fun () -> f base_path)
 ;;
 
@@ -120,7 +120,7 @@ let post_of_signal (signal : Masc.Board_dispatch.board_signal) : Masc.Board.post
 ;;
 
 let candidate ?(id = "candidate-worker") ?(recorded_at = 1.0) () : A.candidate =
-  let keeper_name = "sangsu" in
+  let keeper_name = "alpha" in
   let signal = signal id in
   let candidate_id = A.candidate_id_of_signal ~keeper_name signal in
   { candidate_id
@@ -135,7 +135,7 @@ let candidate ?(id = "candidate-worker") ?(recorded_at = 1.0) () : A.candidate =
         ; ( "keeper_context"
           , `Assoc
               [ "lane_keeper_name", `String keeper_name
-              ; "agent_name", `String "sangsu-agent"
+              ; "agent_name", `String "alpha-agent"
               ; "keeper_record_id", `Null
               ; "keeper_runtime_uid", `Null
               ; "instructions", `String "continue"
@@ -211,19 +211,19 @@ let record ~base_path candidate =
 ;;
 
 let load_one_candidate ~base_path =
-  match ok "load candidate" (A.load_candidates ~base_path ~keeper_name:"sangsu") with
+  match ok "load candidate" (A.load_candidates ~base_path ~keeper_name:"alpha") with
   | [ candidate ] -> candidate
   | candidates -> Alcotest.failf "expected one candidate, got %d" (List.length candidates)
 ;;
 
 let load_one_partition ~base_path =
-  match ok "load partition" (P.load ~base_path ~keeper_name:"sangsu") with
+  match ok "load partition" (P.load ~base_path ~keeper_name:"alpha") with
   | [ partition ] -> partition
   | partitions -> Alcotest.failf "expected one partition, got %d" (List.length partitions)
 ;;
 
 let relevant_delivery_count ~base_path ~candidate_id =
-  Event_queue_persistence.load ~base_path ~keeper_name:"sangsu"
+  Event_queue_persistence.load ~base_path ~keeper_name:"alpha"
   |> Event_queue.to_list
   |> List.fold_left
        (fun count (stimulus : Event_queue.stimulus) ->
@@ -251,7 +251,7 @@ let process_at ~now ~base_path ~prepare ~execute =
     ~now
     ~worker_epoch:(P.Worker_epoch.generate ())
     ~base_path
-    ~keeper_name:"sangsu"
+    ~keeper_name:"alpha"
     ~prepare
     ~execute
 ;;
@@ -365,7 +365,7 @@ let test_worker_exact_callback_integration_and_owner_settlement () =
      Alcotest.(check string) "selected opaque slot" third.slot_id observed.slot_id;
      Alcotest.(check (float 0.0)) "completion observes post-execution time" 9.0 completed_at
    | _ -> Alcotest.fail "callback chain did not persist Completed");
-  (match ok "owner settlement" (W.settle_one_completed ~base_path ~keeper_name:"sangsu") with
+  (match ok "owner settlement" (W.settle_one_completed ~base_path ~keeper_name:"alpha") with
    | W.Partition_settled { candidate_id; _ }
      when String.equal candidate_id persisted.candidate_id -> ()
    | W.Partition_settled _ -> Alcotest.fail "a different candidate was settled"
@@ -418,7 +418,7 @@ let test_discards_do_not_hold_the_owner_delivery_slot () =
     admitted.candidate_id
     second;
   (match
-     ok "owner settlement" (W.settle_one_completed ~base_path ~keeper_name:"sangsu")
+     ok "owner settlement" (W.settle_one_completed ~base_path ~keeper_name:"alpha")
    with
    | W.Partition_settled { candidate_id; _ } ->
      Alcotest.(check string)
@@ -436,7 +436,7 @@ let test_discards_do_not_hold_the_owner_delivery_slot () =
          List.find_opt
            (fun (c : A.candidate) ->
               String.equal c.candidate_id candidate.candidate_id)
-           (ok "load" (A.load_candidates ~base_path ~keeper_name:"sangsu"))
+           (ok "load" (A.load_candidates ~base_path ~keeper_name:"alpha"))
        with
        | Some { status = A.Consumed _; _ } -> ()
        | Some _ | None ->
@@ -492,7 +492,7 @@ let test_discard_settlement_is_bounded_and_continues () =
   (match
      ok
        "bounded owner settlement"
-       (W.settle_one_completed ~base_path ~keeper_name:"sangsu")
+       (W.settle_one_completed ~base_path ~keeper_name:"alpha")
    with
    | W.Partition_settled { candidate_id; continuation_wake = Some _ } ->
      (* Candidate ids are content hashes derived by [candidate], not the
@@ -515,7 +515,7 @@ let test_discard_settlement_is_bounded_and_continues () =
   (match
      ok
        "continued owner settlement"
-       (W.settle_one_completed ~base_path ~keeper_name:"sangsu")
+       (W.settle_one_completed ~base_path ~keeper_name:"alpha")
    with
    | W.Partition_settled { candidate_id; continuation_wake = None } ->
      Alcotest.(check string)
@@ -546,7 +546,7 @@ let test_setup_error_stops_before_claim_without_hot_retry () =
        ~now:(fun () -> 3.0)
        ~worker_epoch:(P.Worker_epoch.generate ())
        ~base_path
-       ~keeper_name:"sangsu"
+       ~keeper_name:"alpha"
        ~prepare
        ~execute:(fun ~before_dispatch:_ ~before_advance:_ _ ->
          Alcotest.fail "setup error reached execution")
@@ -588,7 +588,7 @@ let test_claim_generation_change_discards_without_sibling_selection () =
   let prepare candidate =
     incr prepare_calls;
     let partition =
-      ok "load prepared claim target" (P.load ~base_path ~keeper_name:"sangsu")
+      ok "load prepared claim target" (P.load ~base_path ~keeper_name:"alpha")
       |> List.find_opt (fun (partition : P.t) ->
         String.equal partition.candidate_id candidate.A.candidate_id)
     in
@@ -604,7 +604,7 @@ let test_claim_generation_change_discards_without_sibling_selection () =
             ~now:10.0
             ~worker_epoch:competitor
             ~base_path
-            ~keeper_name:"sangsu"
+            ~keeper_name:"alpha"
             ~partition_id:partition.partition_id
             ~generation:partition.generation)
      with
@@ -624,7 +624,7 @@ let test_claim_generation_change_discards_without_sibling_selection () =
           ~now:(fun () -> 10.0)
           ~worker_epoch:(P.Worker_epoch.generate ())
           ~base_path
-          ~keeper_name:"sangsu"
+          ~keeper_name:"alpha"
           ~prepare
           ~execute)
    with
@@ -639,7 +639,7 @@ let test_claim_generation_change_discards_without_sibling_selection () =
   Alcotest.(check int) "selected target is prepared once" 1 !prepare_calls;
   Alcotest.(check int) "no prepared attempt was dispatched" 0 !execute_calls;
   let running, ready =
-    ok "classify roots after retry exhaustion" (P.load ~base_path ~keeper_name:"sangsu")
+    ok "classify roots after retry exhaustion" (P.load ~base_path ~keeper_name:"alpha")
     |> List.fold_left
          (fun (running, ready) (partition : P.t) ->
             match partition.state with
@@ -672,7 +672,7 @@ let test_exact_claim_retry_exhaustion_has_no_self_wake () =
           : A.candidate))
     [ 0; 1 ];
   let registration =
-    ok "register exact claim wake" (Wake.register ~sw ~base_path ~keeper_name:"sangsu")
+    ok "register exact claim wake" (Wake.register ~sw ~base_path ~keeper_name:"alpha")
   in
   let prepare_calls = ref 0 in
   let claim_calls = ref 0 in
@@ -713,7 +713,7 @@ let test_exact_claim_retry_exhaustion_has_no_self_wake () =
           ~now:(fun () -> 10.0)
           ~worker_epoch:(P.Worker_epoch.generate ())
           ~base_path
-          ~keeper_name:"sangsu"
+          ~keeper_name:"alpha"
           ~prepare
           ~execute)
    with
@@ -722,7 +722,7 @@ let test_exact_claim_retry_exhaustion_has_no_self_wake () =
       | Some (partition_id, generation) ->
         Alcotest.(check string)
           "contention retains Keeper"
-          "sangsu"
+          "alpha"
           contention.keeper_name;
         Alcotest.(check string)
           "contention retains partition"
@@ -743,7 +743,7 @@ let test_exact_claim_retry_exhaustion_has_no_self_wake () =
   Alcotest.(check int) "initial claim plus two retries" 3 !claim_calls;
   Alcotest.(check int) "no exact dispatch" 0 !execute_calls;
   let ready =
-    ok "load roots after exact claim exhaustion" (P.load ~base_path ~keeper_name:"sangsu")
+    ok "load roots after exact claim exhaustion" (P.load ~base_path ~keeper_name:"alpha")
     |> List.fold_left
          (fun count (partition : P.t) ->
             match partition.state with
@@ -755,7 +755,7 @@ let test_exact_claim_retry_exhaustion_has_no_self_wake () =
          0
   in
   Alcotest.(check int) "no sibling was claimed" 2 ready;
-  (match ok "probe pending self wake" (Wake.request ~base_path ~keeper_name:"sangsu") with
+  (match ok "probe pending self wake" (Wake.request ~base_path ~keeper_name:"alpha") with
    | Wake.Signaled -> ()
    | Wake.Coalesced ->
      Alcotest.fail "claim exhaustion enqueued an immediate self wake"
@@ -769,11 +769,11 @@ let test_contention_rearm_is_delayed_and_deduplicated () =
   ignore
     (ok
        "create contention root"
-       (P.ensure_roots ~base_path ~keeper_name:"sangsu" [ persisted ])
+       (P.ensure_roots ~base_path ~keeper_name:"alpha" [ persisted ])
      : int);
   let partition = load_one_partition ~base_path in
   let contention : W.contention =
-    { keeper_name = "sangsu"
+    { keeper_name = "alpha"
     ; partition_id = partition.partition_id
     ; generation = partition.generation
     }
@@ -868,7 +868,7 @@ let test_contention_rearm_is_delayed_and_deduplicated () =
 
 let test_rescan_later_reaches_delayed_run_rearm () =
   let contention : W.contention =
-    { keeper_name = "sangsu"
+    { keeper_name = "alpha"
     ; partition_id = "partition-old-selection"
     ; generation = P.Generation.initial
     }
@@ -923,7 +923,7 @@ let test_rescan_later_reaches_delayed_run_rearm () =
 
 let test_contention_wake_error_schedules_next_backoff () =
   let contention : W.contention =
-    { keeper_name = "sangsu"
+    { keeper_name = "alpha"
     ; partition_id = "partition-wake-error"
     ; generation = P.Generation.initial
     }
@@ -964,7 +964,7 @@ let test_contention_wake_error_schedules_next_backoff () =
 
 let test_contention_wake_callback_is_outside_scheduler_lock () =
   let contention : W.contention =
-    { keeper_name = "sangsu"
+    { keeper_name = "alpha"
     ; partition_id = "partition-reentrant-wake"
     ; generation = P.Generation.initial
     }
@@ -1015,7 +1015,7 @@ let test_contention_wake_callback_is_outside_scheduler_lock () =
 
 let test_reset_during_wake_error_suppresses_old_generation_rearm () =
   let contention : W.contention =
-    { keeper_name = "sangsu"
+    { keeper_name = "alpha"
     ; partition_id = "partition-reset-during-wake"
     ; generation = P.Generation.initial
     }
@@ -1217,7 +1217,7 @@ let test_bound_cancellation_is_prompt_and_process_recoverable () =
        (P.recover_for_process_start
           ~now:4.0
           ~base_path
-          ~keeper_name:"sangsu"));
+          ~keeper_name:"alpha"));
   match load_one_partition ~base_path with
   | { state = P.Blocked { reason = P.Exact_execution_quarantined (P.Bound durable); _ }
     ; _
@@ -1286,7 +1286,7 @@ let test_released_cancellation_is_prompt_and_process_recoverable () =
        (P.recover_for_process_start
           ~now:4.0
           ~base_path
-          ~keeper_name:"sangsu"));
+          ~keeper_name:"alpha"));
   match load_one_partition ~base_path with
   | { state =
         P.Blocked
@@ -1338,7 +1338,7 @@ let test_unbound_cancellation_waits_for_process_start_recovery () =
        (P.recover_for_process_start
           ~now:4.0
           ~base_path
-          ~keeper_name:"sangsu"));
+          ~keeper_name:"alpha"));
   match (load_one_partition ~base_path).state with
   | P.Ready -> ()
   | _ -> Alcotest.fail "process-start recovery did not return Unbound to Ready"
@@ -1358,7 +1358,7 @@ let test_terminal_root_does_not_strand_ready_sibling () =
        ~now:(fun () -> 3.0)
        ~worker_epoch:(P.Worker_epoch.generate ())
        ~base_path
-       ~keeper_name:"sangsu"
+       ~keeper_name:"alpha"
        ~prepare:(fun candidate -> Ok candidate)
        ~execute:(fun ~before_dispatch ~before_advance:_ observed ->
          calls := !calls @ [ observed.A.candidate_id ];
@@ -1372,7 +1372,7 @@ let test_terminal_root_does_not_strand_ready_sibling () =
     "terminal root and sibling were each visited once"
     [ first.candidate_id; sibling.candidate_id ]
     !calls;
-  let partitions = ok "load sibling partitions" (P.load ~base_path ~keeper_name:"sangsu") in
+  let partitions = ok "load sibling partitions" (P.load ~base_path ~keeper_name:"alpha") in
   let state_for candidate_id =
     List.find_opt
       (fun (partition : P.t) -> String.equal partition.candidate_id candidate_id)
@@ -1411,7 +1411,7 @@ let test_completed_startup_replays_owner_wake () =
        "replay completed wake"
        (W.For_testing.replay_completed_owner_wake
           ~base_path
-          ~keeper_name:"sangsu"
+          ~keeper_name:"alpha"
           ~wake_owner)
    with
    | Some Masc.Keeper_registry.Signaled -> ()
@@ -1454,7 +1454,7 @@ let test_existing_consumed_skips_exact_flow_and_settles () =
        "create Ready root"
        (P.ensure_roots
           ~base_path
-          ~keeper_name:"sangsu"
+          ~keeper_name:"alpha"
           [ persisted ])
       : int);
   let exact = provenance "existing-consumed" in
@@ -1468,7 +1468,7 @@ let test_existing_consumed_skips_exact_flow_and_settles () =
        "consume before worker"
        (A.apply_judgment_and_deliver
           ~base_path
-          ~keeper_name:"sangsu"
+          ~keeper_name:"alpha"
           ~candidate_id:persisted.candidate_id
           ~judgment:(judgment exact J.Not_relevant))
       : A.candidate);
@@ -1497,7 +1497,7 @@ let test_consumed_completed_crash_settles_without_duplicate_delivery () =
        "create root before consumption"
        (P.ensure_roots
           ~base_path
-          ~keeper_name:"sangsu"
+          ~keeper_name:"alpha"
           [ persisted ])
       : int);
   let exact = provenance "consumed-completed-crash" in
@@ -1507,7 +1507,7 @@ let test_consumed_completed_crash_settles_without_duplicate_delivery () =
       "consume Relevant candidate before crash"
       (A.apply_judgment_and_deliver
          ~base_path
-         ~keeper_name:"sangsu"
+         ~keeper_name:"alpha"
          ~candidate_id:persisted.candidate_id
          ~judgment:completed_judgment)
   in
@@ -1529,7 +1529,7 @@ let test_consumed_completed_crash_settles_without_duplicate_delivery () =
            ~now:3.0
            ~worker_epoch
            ~base_path
-           ~keeper_name:"sangsu"
+           ~keeper_name:"alpha"
            ~partition_id:claim_target.partition_id
            ~generation:claim_target.generation)
     with
@@ -1556,7 +1556,7 @@ let test_consumed_completed_crash_settles_without_duplicate_delivery () =
   (match (load_one_partition ~base_path).state with
    | P.Completed _ -> ()
    | _ -> Alcotest.fail "crash fixture did not retain Completed partition");
-  (match ok "settle crash-replayed completion" (W.settle_one_completed ~base_path ~keeper_name:"sangsu") with
+  (match ok "settle crash-replayed completion" (W.settle_one_completed ~base_path ~keeper_name:"alpha") with
    | W.Partition_settled { candidate_id; continuation_wake = None }
      when String.equal candidate_id persisted.candidate_id -> ()
    | W.Partition_settled _ ->
@@ -1578,7 +1578,7 @@ let test_process_recovery_claim_is_released_after_cancellation () =
     try
       W.For_testing.with_process_recovery_claim
         ~base_path
-        ~keeper_name:"sangsu"
+        ~keeper_name:"alpha"
       (fun claimed ->
          Alcotest.(check bool) "first lifecycle acquired recovery" true claimed;
          raise (Eio.Cancel.Cancelled (Failure "injected lifecycle cancellation")))
@@ -1589,7 +1589,7 @@ let test_process_recovery_claim_is_released_after_cancellation () =
   let restarted_claim =
     W.For_testing.with_process_recovery_claim
       ~base_path
-      ~keeper_name:"sangsu"
+      ~keeper_name:"alpha"
       (fun claimed -> claimed)
   in
   Alcotest.(check bool)
@@ -1667,7 +1667,7 @@ let test_requested_blocked_recovery_and_sequential_cas_converge () =
   let command =
     match
       Q.make
-        ~keeper_name:"sangsu"
+        ~keeper_name:"alpha"
         ~raw_partition_id:partition.partition_id
         request
     with
@@ -1767,7 +1767,7 @@ let test_manual_quarantine_requeue_is_unclaimable_until_authorized_and_settles (
   (match requeued.status, (load_one_partition ~base_path).state with
    | A.Quarantine { phase = A.Requeued _; _ }, P.Blocked _ -> ()
    | _ -> Alcotest.fail "authorization was not durable before the Ready commit");
-  let inventory = Q.inventory ~base_path ~keeper_names:[ "sangsu" ] in
+  let inventory = Q.inventory ~base_path ~keeper_names:[ "alpha" ] in
   let inventory_item =
     match inventory.items with
     | [ item ] -> item
@@ -1775,7 +1775,7 @@ let test_manual_quarantine_requeue_is_unclaimable_until_authorized_and_settles (
   in
   Alcotest.(check string)
     "inventory keeper CAS"
-    "sangsu"
+    "alpha"
     inventory_item.keeper_name;
   Alcotest.(check string)
     "inventory partition CAS"
@@ -1812,7 +1812,7 @@ let test_manual_quarantine_requeue_is_unclaimable_until_authorized_and_settles (
        |> Yojson.Safe.Util.member field
        |> Yojson.Safe.Util.to_string)
   in
-  check_json_string "keeper_name" "sangsu";
+  check_json_string "keeper_name" "alpha";
   check_json_string "partition_id" blocked.partition_id;
   check_json_string "candidate_id" persisted.candidate_id;
   check_json_string "quarantine_id" quarantine.quarantine_id;
@@ -1826,7 +1826,7 @@ let test_manual_quarantine_requeue_is_unclaimable_until_authorized_and_settles (
   let command =
     match
       Q.make
-        ~keeper_name:"sangsu"
+        ~keeper_name:"alpha"
         ~raw_partition_id:blocked.partition_id
         request
     with
@@ -1870,7 +1870,7 @@ let test_manual_quarantine_requeue_is_unclaimable_until_authorized_and_settles (
   (match
      ok
        "owner settlement"
-       (W.settle_one_completed ~base_path ~keeper_name:"sangsu")
+       (W.settle_one_completed ~base_path ~keeper_name:"alpha")
    with
    | W.Partition_settled { candidate_id; _ }
      when String.equal candidate_id persisted.candidate_id -> ()
@@ -1879,7 +1879,7 @@ let test_manual_quarantine_requeue_is_unclaimable_until_authorized_and_settles (
   (match (load_one_candidate ~base_path).status, (load_one_partition ~base_path).state with
    | A.Consumed { delivery = A.Not_relevant; _ }, P.Settled _ -> ()
    | _ -> Alcotest.fail "manual requeue did not normalize, consume, and settle");
-  (match (Q.inventory ~base_path ~keeper_names:[ "sangsu" ]).items with
+  (match (Q.inventory ~base_path ~keeper_names:[ "alpha" ]).items with
    | [] -> ()
    | _ -> Alcotest.fail "settled candidate remained in quarantine inventory")
 ;;
@@ -1937,7 +1937,7 @@ let test_ready_requested_recovery_fails_closed () =
   let command =
     match
       Q.make
-        ~keeper_name:"sangsu"
+        ~keeper_name:"alpha"
         ~raw_partition_id:blocked.partition_id
         request
     with
@@ -1984,7 +1984,7 @@ let test_stale_quarantine_generation_is_rejected () =
   let command =
     match
       Q.make
-        ~keeper_name:"sangsu"
+        ~keeper_name:"alpha"
         ~raw_partition_id:blocked.partition_id
         request
     with
@@ -2037,7 +2037,7 @@ let test_same_quarantine_command_cas_loser_converges () =
   let command =
     match
       Q.make
-        ~keeper_name:"sangsu"
+        ~keeper_name:"alpha"
         ~raw_partition_id:partition.partition_id
         request
     with
@@ -2106,7 +2106,7 @@ let test_stale_blocked_snapshot_cannot_requeue_new_generation () =
   let command =
     match
       Q.make
-        ~keeper_name:"sangsu"
+        ~keeper_name:"alpha"
         ~raw_partition_id:partition.partition_id
         request
     with
@@ -2149,7 +2149,7 @@ let test_stale_blocked_snapshot_cannot_requeue_new_generation () =
                   ~now:20.0
                   ~worker_epoch:owner
                   ~base_path
-                  ~keeper_name:"sangsu"
+                  ~keeper_name:"alpha"
                   ~partition_id:first_ready.partition.partition_id
                   ~generation:first_ready.partition.generation)
            with
@@ -2209,11 +2209,11 @@ let test_cross_domain_wake_is_coalesced_and_rearmed () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
   with_temp_base "board-attention-worker-wake" @@ fun base_path ->
-  (match ok "unregistered request" (Wake.request ~base_path ~keeper_name:"sangsu") with
+  (match ok "unregistered request" (Wake.request ~base_path ~keeper_name:"alpha") with
    | Wake.Not_registered -> ()
    | Wake.Signaled | Wake.Coalesced -> Alcotest.fail "unregistered wake was accepted");
   let registration =
-    ok "register worker wake" (Wake.register ~sw ~base_path ~keeper_name:"sangsu")
+    ok "register worker wake" (Wake.register ~sw ~base_path ~keeper_name:"alpha")
   in
   (match
      W.run
@@ -2221,7 +2221,7 @@ let test_cross_domain_wake_is_coalesced_and_rearmed () =
        ~clock:(Eio.Stdenv.clock env)
        ~net:None
        ~base_path
-       ~keeper_name:"sangsu"
+       ~keeper_name:"alpha"
    with
    | Error { stage = W.Registration; _ } -> ()
    | Error fatal ->
@@ -2230,25 +2230,25 @@ let test_cross_domain_wake_is_coalesced_and_rearmed () =
        (W.fatal_error_to_string fatal)
    | Ok () -> Alcotest.fail "duplicate registration returned normally");
   let first =
-    Domain.spawn (fun () -> Wake.request ~base_path ~keeper_name:"sangsu")
+    Domain.spawn (fun () -> Wake.request ~base_path ~keeper_name:"alpha")
     |> Domain.join
     |> ok "cross-domain wake"
   in
   (match first with
    | Wake.Signaled -> ()
    | Wake.Coalesced | Wake.Not_registered -> Alcotest.fail "first wake was not signaled");
-  (match ok "coalesced wake" (Wake.request ~base_path ~keeper_name:"sangsu") with
+  (match ok "coalesced wake" (Wake.request ~base_path ~keeper_name:"alpha") with
    | Wake.Coalesced -> ()
    | Wake.Signaled | Wake.Not_registered -> Alcotest.fail "pending wake did not coalesce");
   (match Wake.await registration with
    | Wake.Wake -> ()
    | Wake.Registration_closed -> Alcotest.fail "live registration closed");
-  (match ok "rearmed wake" (Wake.request ~base_path ~keeper_name:"sangsu") with
+  (match ok "rearmed wake" (Wake.request ~base_path ~keeper_name:"alpha") with
    | Wake.Signaled -> ()
    | Wake.Coalesced | Wake.Not_registered ->
      Alcotest.fail "consumed wake did not rearm");
   Wake.unregister registration;
-  match ok "explicit unregister" (Wake.request ~base_path ~keeper_name:"sangsu") with
+  match ok "explicit unregister" (Wake.request ~base_path ~keeper_name:"alpha") with
   | Wake.Not_registered -> ()
   | Wake.Signaled | Wake.Coalesced ->
     Alcotest.fail "worker lifetime left a stale wake registration"
@@ -2324,8 +2324,8 @@ let test_undrained_outcomes_are_not_routine () =
    candidate store moved aside as one directory, per
    scripts/check-runtime-deployment-preflight.sh, with no tombstone left for
    a later re-check. The partition never advanced past Completed, so the
-   identical error repeated on every heartbeat forever (sangsu 170x one day,
-   rondo 13x/25min the next, before both were data-cut by hand). This pins
+   identical error repeated on every heartbeat forever (alpha 170x one day,
+   beta 13x/25min the next, before both were data-cut by hand). This pins
    that the finalizer now settles such a partition once, terminally, and
    never revisits it. *)
 let test_reconcile_quarantines_settles_a_blocked_partition_whose_candidate_was_retired
@@ -2355,21 +2355,21 @@ let test_reconcile_quarantines_settles_a_blocked_partition_whose_candidate_was_r
       (Filename.concat
          (Common.masc_dir_from_base_path ~base_path)
          "board_attention_candidates")
-      "sangsu.jsonl"
+      "alpha.jsonl"
   in
   Sys.remove ledger_path;
   (* Before the fix this returned Error "partition candidate is absent during
      quarantine reconciliation: ..." and fataled the worker at process start. *)
   ok
     "reconcile settles the orphaned quarantine instead of failing"
-    (W.For_testing.reconcile_quarantines ~now:10.0 ~base_path ~keeper_name:"sangsu");
+    (W.For_testing.reconcile_quarantines ~now:10.0 ~base_path ~keeper_name:"alpha");
   (match (load_one_partition ~base_path).state with
    | P.Settled _ -> ()
    | _ ->
      Alcotest.fail "blocked partition with a retired candidate did not reach Settled");
   ok
     "second reconciliation pass stays a no-op"
-    (W.For_testing.reconcile_quarantines ~now:11.0 ~base_path ~keeper_name:"sangsu")
+    (W.For_testing.reconcile_quarantines ~now:11.0 ~base_path ~keeper_name:"alpha")
 ;;
 
 let test_settle_one_completed_terminalizes_a_partition_whose_candidate_was_retired
@@ -2380,7 +2380,7 @@ let test_settle_one_completed_terminalizes_a_partition_whose_candidate_was_retir
   ignore
     (ok
        "create Ready root"
-       (P.ensure_roots ~base_path ~keeper_name:"sangsu" [ persisted ])
+       (P.ensure_roots ~base_path ~keeper_name:"alpha" [ persisted ])
       : int);
   let attempt = provenance "candidate-retired" in
   let execute ~before_dispatch ~before_advance _prepared =
@@ -2413,7 +2413,7 @@ let test_settle_one_completed_terminalizes_a_partition_whose_candidate_was_retir
       (Filename.concat
          (Common.masc_dir_from_base_path ~base_path)
          "board_attention_candidates")
-      "sangsu.jsonl"
+      "alpha.jsonl"
   in
   Sys.remove ledger_path;
   Alcotest.(check int)
@@ -2421,12 +2421,12 @@ let test_settle_one_completed_terminalizes_a_partition_whose_candidate_was_retir
     0
     (ok
        "load after retire"
-       (A.load_candidates ~base_path ~keeper_name:"sangsu")
+       (A.load_candidates ~base_path ~keeper_name:"alpha")
      |> List.length);
   (match
      ok
        "first settlement attempt"
-       (W.settle_one_completed ~base_path ~keeper_name:"sangsu")
+       (W.settle_one_completed ~base_path ~keeper_name:"alpha")
    with
    | W.Partition_settled { candidate_id; _ }
      when String.equal candidate_id persisted.candidate_id -> ()
@@ -2440,7 +2440,7 @@ let test_settle_one_completed_terminalizes_a_partition_whose_candidate_was_retir
   match
     ok
       "second settlement attempt"
-      (W.settle_one_completed ~base_path ~keeper_name:"sangsu")
+      (W.settle_one_completed ~base_path ~keeper_name:"alpha")
   with
   | W.No_completed_partition -> ()
   | W.Partition_settled _ ->

--- a/test/test_keeper_chat_broadcast.ml
+++ b/test/test_keeper_chat_broadcast.ml
@@ -20,13 +20,13 @@ let test_operation_event_has_singular_identity () =
   let event =
     Ag_ui.make_event
       ~timestamp:13.0
-      ~thread_id:"keeper:taskmaster"
+      ~thread_id:"keeper:fixture-keeper"
       ~delta:(Some "live")
       Ag_ui.Text_message_content
   in
   let fields =
     B.operation_event_to_json
-      ~keeper_name:"taskmaster"
+      ~keeper_name:"fixture-keeper"
       ~operation_id:"kmsg-operation-1"
       ~event
     |> fields_without_ts_unix
@@ -52,7 +52,7 @@ let test_projection_preserves_stream_identity () =
   let state, started =
     project P.initial
       (E.Run_started
-         { run_id = "run-1"; thread_id = "keeper-consumer:taskmaster" })
+         { run_id = "run-1"; thread_id = "keeper-consumer:fixture-keeper" })
   in
   ignore (projected_exn (state, started));
   let state, message_started =
@@ -77,7 +77,7 @@ let test_projection_covers_thinking_and_tool_args () =
   let state, _ =
     project P.initial
       (E.Run_started
-         { run_id = "run-2"; thread_id = "keeper-consumer:taskmaster" })
+         { run_id = "run-2"; thread_id = "keeper-consumer:fixture-keeper" })
   in
   let _, thinking =
     project state
@@ -101,7 +101,7 @@ let test_tool_result_ready_projection_has_exact_identity () =
   let state, _ =
     project P.initial
       (E.Run_started
-         { run_id = "run-3"; thread_id = "keeper-consumer:taskmaster" })
+         { run_id = "run-3"; thread_id = "keeper-consumer:fixture-keeper" })
   in
   let _, ready =
     project state (E.Tool_result_ready { tool_call_id = "tool-use-7" })

--- a/test/test_keeper_chat_operation_http.ml
+++ b/test/test_keeper_chat_operation_http.ml
@@ -15,20 +15,20 @@ let test_dashboard_worker_permissions () =
 ;;
 
 let test_exact_routes () =
-  (match Api.get_route "/api/v1/keepers/sangsu/chat/operations" with
+  (match Api.get_route "/api/v1/keepers/alpha/chat/operations" with
    | Some (Api.Operation_list { keeper_name }) ->
-     check string "list keeper" "sangsu" keeper_name
+     check string "list keeper" "alpha" keeper_name
    | Some _ | None -> fail "operation list route did not match");
-  (match Api.get_route "/api/v1/keepers/sangsu/chat/operations/kmsg-1" with
+  (match Api.get_route "/api/v1/keepers/alpha/chat/operations/kmsg-1" with
    | Some (Api.Operation_exact { keeper_name; raw_operation_id }) ->
-     check string "exact keeper" "sangsu" keeper_name;
+     check string "exact keeper" "alpha" keeper_name;
      check string "exact operation" "kmsg-1" raw_operation_id
    | Some _ | None -> fail "exact operation route did not match");
   List.iter
     (fun (action, expected) ->
        match
          Api.mutation_route
-           ("/api/v1/keepers/sangsu/chat/operations/kmsg-1/" ^ action)
+           ("/api/v1/keepers/alpha/chat/operations/kmsg-1/" ^ action)
        with
        | Some { Api.mutation; _ } ->
          check bool "mutation kind" true (mutation = expected)
@@ -44,8 +44,8 @@ let test_unknown_routes_do_not_match () =
          true
          (Option.is_none (Api.get_route path)
           && Option.is_none (Api.mutation_route path)))
-    [ "/api/v1/keepers/sangsu/chat/operations/kmsg-1/retry"
-    ; "/api/v1/keepers/sangsu/chat/tasks/kmsg-1"
+    [ "/api/v1/keepers/alpha/chat/operations/kmsg-1/retry"
+    ; "/api/v1/keepers/alpha/chat/tasks/kmsg-1"
     ]
 ;;
 

--- a/test/test_keeper_checkpoint_purge.ml
+++ b/test/test_keeper_checkpoint_purge.ml
@@ -1,5 +1,5 @@
 (* RFC-0351 S1: deterministic offline checkpoint purge. The rules were
-   measured live on the analyst checkpoint (1,315 -> 579 messages, -28.0%
+   measured live on the delta checkpoint (1,315 -> 579 messages, -28.0%
    bytes); these tests pin the rule contract so the checked-in tool cannot
    drift from what was validated. *)
 
@@ -130,7 +130,7 @@ let test_reasoning_strip_scope () =
 (* Contract change: R2 used to skip any message carrying a ToolUse, so the
    assistant message that opens a tool cycle kept its unsigned reasoning. On an
    agentic keeper that is almost every assistant message — measured on the
-   sangsu checkpoint, 418 of 422 surviving unsigned Thinking blocks (490,370 B,
+   alpha checkpoint, 418 of 422 surviving unsigned Thinking blocks (490,370 B,
    41.0% of the file) were held by this rule. Unsigned reasoning carries no
    signature to replay, so the exemption bought nothing. *)
 let test_unsigned_reasoning_inside_tool_cycle_is_stripped () =
@@ -266,7 +266,7 @@ let test_cycle_overlapping_protected_tail_is_untouched () =
 let test_strip_revealed_duplicates_collapse_in_one_pass () =
   (* Three assistant replies that differ only in their reasoning become
      byte-identical once R2 strips them; R1 must see the stripped form in the
-     same pass (measured on the sangsu checkpoint: the reverse ordering left
+     same pass (measured on the alpha checkpoint: the reverse ordering left
      229 duplicates for a second run to find). *)
   let reply thinking =
     block_message Types.Assistant [ unsigned_thinking thinking; Types.Text "same answer" ]

--- a/test/test_keeper_compaction_persist_gate.ml
+++ b/test/test_keeper_compaction_persist_gate.ml
@@ -46,7 +46,7 @@ let result id =
 
 (* One complete tool cycle, then an assistant turn that opens a cycle and a
    second assistant turn that opens another before the first is answered. That
-   overlap is the shape observed live on analyst and idealist:
+   overlap is the shape observed live on delta and idealist:
 
      compaction_rejected reason=invalid_structure:
        Keeper_compaction_unit.Overlapping_tool_cycle

--- a/test/test_keeper_connector_attention_batch.ml
+++ b/test/test_keeper_connector_attention_batch.ml
@@ -1,7 +1,7 @@
 (* test_keeper_connector_attention_batch.ml — RFC-0377: conversation-batched
    stimulus intake.
 
-   sangsu live data (2026-08-08..08-13) showed every delivered continuation
+   alpha live data (2026-08-08..08-13) showed every delivered continuation
    obligation (48/48) bound 1:1 to a single distinct inbound message: a turn
    admitted exactly one Connector_attention stimulus (RFC-0020 Rule 4), so a
    backlog of N pending messages in the same conversation took N turns to

--- a/test/test_keeper_context_observation_projection.ml
+++ b/test/test_keeper_context_observation_projection.ml
@@ -29,8 +29,8 @@ let sample_record
   : Turn_record.t
   =
   { execution_ids = []
-  ; keeper = "rondo"
-  ; agent_name = "rondo-agent"
+  ; keeper = "beta"
+  ; agent_name = "beta-agent"
   ; generation = 7
   ; turn_kind = Turn_record.Direct
   ; trace_id = sample_trace
@@ -123,7 +123,7 @@ let test_measured_record_projects () =
   with_temp_workspace (fun config ->
     let record = sample_record () in
     append_record config record;
-    let fields = Projection.context_fields ~config ~keeper_name:"rondo" ~current_trace_id:sample_trace in
+    let fields = Projection.context_fields ~config ~keeper_name:"beta" ~current_trace_id:sample_trace in
     (match field fields "context_tokens" with
      | `Int tokens -> check int "tokens" 18_000 tokens
      | _ -> fail "context_tokens is not an int");
@@ -160,7 +160,7 @@ let test_newest_record_wins () =
   with_temp_workspace (fun config ->
     append_record config (sample_record ~absolute_turn:1 ~input_tokens:(Some 100) ());
     append_record config (sample_record ~absolute_turn:2 ~input_tokens:(Some 200) ());
-    let fields = Projection.context_fields ~config ~keeper_name:"rondo" ~current_trace_id:sample_trace in
+    let fields = Projection.context_fields ~config ~keeper_name:"beta" ~current_trace_id:sample_trace in
     match field fields "context_tokens" with
     | `Int tokens -> check int "newest tokens" 200 tokens
     | _ -> fail "context_tokens is not an int")
@@ -169,14 +169,14 @@ let test_newest_record_wins () =
 let test_record_without_usage_is_typed () =
   with_temp_workspace (fun config ->
     append_record config (sample_record ~input_tokens:None ());
-    let fields = Projection.context_fields ~config ~keeper_name:"rondo" ~current_trace_id:sample_trace in
+    let fields = Projection.context_fields ~config ~keeper_name:"beta" ~current_trace_id:sample_trace in
     check_not_observed fields ~reason:"turn_record_without_usage")
 ;;
 
 let test_undecodable_newest_line_is_typed () =
   with_temp_workspace (fun config ->
-    append_raw config ~keeper_name:"rondo" (`Assoc [ "schema", `String "future" ]);
-    let fields = Projection.context_fields ~config ~keeper_name:"rondo" ~current_trace_id:sample_trace in
+    append_raw config ~keeper_name:"beta" (`Assoc [ "schema", `String "future" ]);
+    let fields = Projection.context_fields ~config ~keeper_name:"beta" ~current_trace_id:sample_trace in
     check_not_observed fields ~reason:"turn_record_undecodable")
 ;;
 
@@ -186,7 +186,7 @@ let test_undecodable_newest_line_is_typed () =
 let test_malformed_raw_tail_is_undecodable_not_previous_row () =
   with_temp_workspace (fun config ->
     append_record config (sample_record ());
-    let store = Masc.Keeper_types_support.keeper_turn_record_store config "rondo" in
+    let store = Masc.Keeper_types_support.keeper_turn_record_store config "beta" in
     let base_dir = Dated_jsonl.base_dir store in
     let day_files =
       Sys.readdir base_dir
@@ -205,7 +205,7 @@ let test_malformed_raw_tail_is_undecodable_not_previous_row () =
        output_string channel "not a json line\n";
        close_out channel
      | files -> failf "expected exactly one day file, found %d" (List.length files));
-    let fields = Projection.context_fields ~config ~keeper_name:"rondo" ~current_trace_id:sample_trace in
+    let fields = Projection.context_fields ~config ~keeper_name:"beta" ~current_trace_id:sample_trace in
     check_not_observed fields ~reason:"turn_record_undecodable")
 ;;
 
@@ -215,7 +215,7 @@ let test_previous_trace_row_is_typed_absent () =
     let fields =
       Projection.context_fields
         ~config
-        ~keeper_name:"rondo"
+        ~keeper_name:"beta"
         ~current_trace_id:"trace-1780648779957-99999"
     in
     check_not_observed fields ~reason:"turn_record_trace_mismatch")
@@ -224,7 +224,7 @@ let test_previous_trace_row_is_typed_absent () =
 let test_missing_window_keeps_tokens_without_ratio () =
   with_temp_workspace (fun config ->
     append_record config (sample_record ~context_window:None ());
-    let fields = Projection.context_fields ~config ~keeper_name:"rondo" ~current_trace_id:sample_trace in
+    let fields = Projection.context_fields ~config ~keeper_name:"beta" ~current_trace_id:sample_trace in
     (match field fields "context_tokens" with
      | `Int tokens -> check int "tokens survive" 18_000 tokens
      | _ -> fail "context_tokens is not an int");

--- a/test/test_keeper_context_overflow_shrink.ml
+++ b/test/test_keeper_context_overflow_shrink.ml
@@ -249,7 +249,7 @@ let test_state_defaults_to_max_capacity_when_unseen () =
   Shrink_state.For_testing.reset ();
   check int "no memory yet: falls back to the declared cap" 1_048_576
     (Shrink_state.starting_capacity_bytes
-       ~keeper_name:"sangsu" ~runtime_id:"agent_core-primary" ~max_capacity_bytes:1_048_576)
+       ~keeper_name:"alpha" ~runtime_id:"agent_core-primary" ~max_capacity_bytes:1_048_576)
 ;;
 
 let test_state_remembers_last_success () =
@@ -257,10 +257,10 @@ let test_state_remembers_last_success () =
   @@ fun _env ->
   Shrink_state.For_testing.reset ();
   Shrink_state.record_success
-    ~keeper_name:"sangsu" ~runtime_id:"agent_core-primary" ~capacity_bytes:131_072;
+    ~keeper_name:"alpha" ~runtime_id:"agent_core-primary" ~capacity_bytes:131_072;
   check int "next turn starts from the remembered capacity" 131_072
     (Shrink_state.starting_capacity_bytes
-       ~keeper_name:"sangsu" ~runtime_id:"agent_core-primary" ~max_capacity_bytes:1_048_576)
+       ~keeper_name:"alpha" ~runtime_id:"agent_core-primary" ~max_capacity_bytes:1_048_576)
 ;;
 
 let test_state_clamps_a_remembered_value_above_the_current_cap () =
@@ -268,11 +268,11 @@ let test_state_clamps_a_remembered_value_above_the_current_cap () =
   @@ fun _env ->
   Shrink_state.For_testing.reset ();
   Shrink_state.record_success
-    ~keeper_name:"sangsu" ~runtime_id:"agent_core-primary" ~capacity_bytes:2_097_152;
+    ~keeper_name:"alpha" ~runtime_id:"agent_core-primary" ~capacity_bytes:2_097_152;
   check int "a stale remembered value never exceeds the current declared cap"
     1_048_576
     (Shrink_state.starting_capacity_bytes
-       ~keeper_name:"sangsu" ~runtime_id:"agent_core-primary" ~max_capacity_bytes:1_048_576)
+       ~keeper_name:"alpha" ~runtime_id:"agent_core-primary" ~max_capacity_bytes:1_048_576)
 ;;
 
 let test_state_is_keyed_per_keeper_and_runtime () =
@@ -280,13 +280,13 @@ let test_state_is_keyed_per_keeper_and_runtime () =
   @@ fun _env ->
   Shrink_state.For_testing.reset ();
   Shrink_state.record_success
-    ~keeper_name:"sangsu" ~runtime_id:"agent_core-primary" ~capacity_bytes:131_072;
+    ~keeper_name:"alpha" ~runtime_id:"agent_core-primary" ~capacity_bytes:131_072;
   check int "a different runtime on the same keeper is unaffected" 1_048_576
     (Shrink_state.starting_capacity_bytes
-       ~keeper_name:"sangsu" ~runtime_id:"agent_core-fallback" ~max_capacity_bytes:1_048_576);
+       ~keeper_name:"alpha" ~runtime_id:"agent_core-fallback" ~max_capacity_bytes:1_048_576);
   check int "the same runtime id on a different keeper is unaffected" 1_048_576
     (Shrink_state.starting_capacity_bytes
-       ~keeper_name:"analyst" ~runtime_id:"agent_core-primary" ~max_capacity_bytes:1_048_576)
+       ~keeper_name:"beta" ~runtime_id:"agent_core-primary" ~max_capacity_bytes:1_048_576)
 ;;
 
 let () =

--- a/test/test_keeper_cycle_failed_runtime_attribution.ml
+++ b/test/test_keeper_cycle_failed_runtime_attribution.ml
@@ -25,7 +25,7 @@ let malformed_payload_error =
 ;;
 
 (** Mirrors the real incident (masc#28761/#28762, 2026-08-15T11:49:38Z,
-    keeper=sangsu, turn=6595): the cycle's [execution.runtime_id] is the
+    keeper=alpha, turn=6595): the cycle's [execution.runtime_id] is the
     lane assignment "ollama_cloud.ollama-cloud-deepseek-v4-flash-0731",
     but the candidate that was actually dispatched and failed is
     "glm-coding.glm-5-turbo". *)

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -605,7 +605,7 @@ sandbox_profile = "docker"
 
 let test_keepalive_meta_selection_overlays_disk_meta () =
   with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
-  let name = "taskmaster" in
+  let name = "fixture-keeper" in
   write_keeper_agent ~keepers_dir ~name "Coordinate the work.";
   write_file
     (Filename.concat keepers_dir (name ^ ".toml"))

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -295,7 +295,7 @@ let test_keeper_surface_resolves_alias_names () =
 
 let test_toml_overlay_reaches_effective_meta () =
   with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
-  let name = "analyst" in
+  let name = "delta" in
   write_keeper_agent ~keepers_dir ~name "Analyze carefully.";
   write_file
     (Filename.concat keepers_dir (name ^ ".toml"))
@@ -419,7 +419,7 @@ multimodal_policy = "delegate"
 
 let test_ensure_keeper_meta_persists_toml_identity_snapshot () =
   with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
-  let name = "masc-improver" in
+  let name = "omicron-improver" in
   let agent_dir = Filename.concat keepers_dir name in
   mkdir_p agent_dir;
   write_file
@@ -431,7 +431,7 @@ let test_ensure_keeper_meta_persists_toml_identity_snapshot () =
 sandbox_profile = "docker"
 proactive_enabled = true
 allowed_paths = ["workspace/yousleepwhen/masc"]
-active_goal_ids = ["goal-masc-improver"]
+active_goal_ids = ["goal-omicron-improver"]
 |};
   let config = Workspace.default_config base in
   ignore (seed_runtime_meta config name : Masc.Keeper_meta_contract.keeper_meta);
@@ -492,7 +492,7 @@ active_goal_ids = ["goal-masc-improver"]
     returned.allowed_paths;
   Alcotest.(check (list string))
     "returned active_goal_ids is TOML canonical"
-    [ "goal-masc-improver" ]
+    [ "goal-omicron-improver" ]
     returned.active_goal_ids
 
 let test_ensure_keeper_meta_preserves_live_usage_during_reconcile () =

--- a/test/test_keeper_external_attention.ml
+++ b/test/test_keeper_external_attention.ml
@@ -28,10 +28,10 @@ let conversation ?(surface = discord_surface "chan-1") id =
 let external_message ?(surface = discord_surface "chan-1") message_id =
   { A.surface = surface; message_id; reply_to_message_id = None }
 
-let item ?(dedupe_key = "discord:chan-1:msg-1") ?(keeper_name = "sangsu")
+let item ?(dedupe_key = "discord:chan-1:msg-1") ?(keeper_name = "alpha")
     ?(conversation = conversation "discord:guild-1:chan-1")
     ?external_message ?(urgency = A.Mention) ?(received_at = 10.0)
-    ?(preview = "@sangsu check this") () =
+    ?(preview = "@alpha check this") () =
   {
     A.event_id = A.event_id_of_dedupe_key dedupe_key;
     dedupe_key;

--- a/test/test_keeper_ide_annotate_contract.ml
+++ b/test/test_keeper_ide_annotate_contract.ml
@@ -5,7 +5,7 @@
    path, line)]; the keeper hands it back verbatim; the annotation must
    land in that codebase's store at that line — retrievable by the
    same repo-scoped read the IDE uses — and never in the orphan store.
-   The probe's actual burial (analyst's annotation filed under its
+   The probe's actual burial (delta's annotation filed under its
    sandbox root, id 528e6fd6-…) is the regression this suite pins shut.
 
    The failure half: a missing codebase and an out-of-tree path are
@@ -60,7 +60,7 @@ let test_owner_probe_round_trip () =
     Agent_observation.reset_for_testing ();
     Ide_bridge.install_agent_observation_sinks ();
     let config = Masc.Workspace.default_config (Filename.concat base_path ".masc") in
-    let meta = make_meta "analyst" in
+    let meta = make_meta "delta" in
     let raw =
       annotate
         ~config
@@ -78,7 +78,7 @@ let test_owner_probe_round_trip () =
      | _ -> failf "expected ok:true, got %s" raw);
     (* The IDE reads with the same repo-scoped vocabulary it handed out. *)
     let filter : Ide_annotation_types.annotation_filter =
-      { file_path = Some probe_path; keeper_id = Some "analyst"; goal_id = None; task_id = None }
+      { file_path = Some probe_path; keeper_id = Some "delta"; goal_id = None; task_id = None }
     in
     (match
        Ide_annotations.list
@@ -126,7 +126,7 @@ let expect_reject ~needle raw =
 let test_missing_codebase_is_a_typed_reject () =
   with_temp_base_path (fun base_path ->
     let config = Masc.Workspace.default_config (Filename.concat base_path ".masc") in
-    let meta = make_meta "analyst" in
+    let meta = make_meta "delta" in
     annotate
       ~config
       ~meta
@@ -141,7 +141,7 @@ let test_missing_codebase_is_a_typed_reject () =
 let test_out_of_tree_path_is_a_typed_reject () =
   with_temp_base_path (fun base_path ->
     let config = Masc.Workspace.default_config (Filename.concat base_path ".masc") in
-    let meta = make_meta "analyst" in
+    let meta = make_meta "delta" in
     annotate
       ~config
       ~meta

--- a/test/test_keeper_identity_id.ml
+++ b/test/test_keeper_identity_id.ml
@@ -114,8 +114,8 @@ let test_of_string_idempotent_on_goldens () =
 
 let keeper_identities =
   [ ("alice", "keeper-alice-agent")
-  ; ("sangsu", "keeper_sangsu_agent")
-  ; ("analyst", "keeper-analyst-agent")
+  ; ("alpha", "keeper_alpha_agent")
+  ; ("delta", "keeper-delta-agent")
   ]
 
 let author_forms name =

--- a/test/test_keeper_identity_normalize.ml
+++ b/test/test_keeper_identity_normalize.ml
@@ -41,26 +41,26 @@ let check_bundle ~label ~input ~keeper ~agent =
   check string (label ^ ": agent_name") agent b.agent_name
 
 let test_bare_canonical () =
-  check_bundle ~label:"bare canonical" ~input:"sangsu"
-    ~keeper:"sangsu" ~agent:"sangsu"
+  check_bundle ~label:"bare canonical" ~input:"alpha"
+    ~keeper:"alpha" ~agent:"alpha"
 
 let test_keeper_dash_agent_wrapper () =
-  check_bundle ~label:"keeper-X-agent wrapper" ~input:"keeper-sangsu-agent"
-    ~keeper:"sangsu" ~agent:"keeper-sangsu-agent"
+  check_bundle ~label:"keeper-X-agent wrapper" ~input:"keeper-alpha-agent"
+    ~keeper:"alpha" ~agent:"keeper-alpha-agent"
 
 let test_keeper_underscore_agent_wrapper () =
-  check_bundle ~label:"keeper_X_agent wrapper" ~input:"keeper_sangsu_agent"
-    ~keeper:"sangsu" ~agent:"keeper_sangsu_agent"
+  check_bundle ~label:"keeper_X_agent wrapper" ~input:"keeper_alpha_agent"
+    ~keeper:"alpha" ~agent:"keeper_alpha_agent"
 
 let test_ephemeral_suffix_only () =
-  check_bundle ~label:"ephemeral suffix" ~input:"issue_king-pale-llama"
-    ~keeper:"issue_king"
-    ~agent:"issue_king-pale-llama"
+  check_bundle ~label:"ephemeral suffix" ~input:"kappa_keeper-pale-llama"
+    ~keeper:"kappa_keeper"
+    ~agent:"kappa_keeper-pale-llama"
 
 let test_wrapper_plus_ephemeral () =
   check_bundle ~label:"wrapper + suffix"
-    ~input:"keeper-executor-warm-raven-agent"
-    ~keeper:"executor" ~agent:"keeper-executor-warm-raven-agent"
+    ~input:"keeper-omega-warm-raven-agent"
+    ~keeper:"omega" ~agent:"keeper-omega-warm-raven-agent"
 
 let test_empty_input () =
   match normalize "" with
@@ -134,12 +134,12 @@ let () =
         ] );
       ( "round_trip",
         [
-          test_case "round-trip sangsu" `Quick (test_round_trip_for_name "sangsu");
+          test_case "round-trip alpha" `Quick (test_round_trip_for_name "alpha");
           test_case "round-trip executor" `Quick
-            (test_round_trip_for_name "executor");
-          test_case "round-trip qa-king" `Quick
-            (test_round_trip_for_name "qa-king");
-          test_case "round-trip masc-improver" `Quick
-            (test_round_trip_for_name "masc-improver");
+            (test_round_trip_for_name "omega");
+          test_case "round-trip mu-king" `Quick
+            (test_round_trip_for_name "mu-king");
+          test_case "round-trip omicron-improver" `Quick
+            (test_round_trip_for_name "omicron-improver");
         ] );
     ]

--- a/test/test_keeper_invocation_contract_hints.ml
+++ b/test/test_keeper_invocation_contract_hints.ml
@@ -19,8 +19,8 @@ let contains ~needle haystack =
   nl = 0 || go 0
 
 let test_undeclared_field_names_the_accepted_set () =
-  (* The exact shape taskmaster sent. *)
-  let json = `Assoc [ "agent", `String "analyst" ] in
+  (* The exact shape fixture-keeper sent. *)
+  let json = `Assoc [ "agent", `String "delta" ] in
   match message_of_target_json json with
   | None -> Alcotest.fail "expected target.agent to be rejected"
   | Some msg ->
@@ -32,7 +32,7 @@ let test_undeclared_field_names_the_accepted_set () =
 let test_other_guessed_names_get_the_same_hint () =
   List.iter
     (fun field ->
-      let json = `Assoc [ field, `String "analyst" ] in
+      let json = `Assoc [ field, `String "delta" ] in
       match message_of_target_json json with
       | None -> Alcotest.failf "expected target.%s to be rejected" field
       | Some msg ->
@@ -43,7 +43,7 @@ let test_other_guessed_names_get_the_same_hint () =
     [ "keeper_name"; "keeper" ]
 
 let test_valid_target_still_parses () =
-  let json = `Assoc [ "kind", `String "keeper"; "name", `String "analyst" ] in
+  let json = `Assoc [ "kind", `String "keeper"; "name", `String "delta" ] in
   match C.target_of_json json with
   | Ok _ -> ()
   | Error err ->
@@ -61,7 +61,7 @@ let request_json ?capability () =
     ((match capability with
       | None -> []
       | Some value -> [ "capability", `String value ])
-     @ [ "target", `Assoc [ "kind", `String "keeper"; "name", `String "analyst" ]
+     @ [ "target", `Assoc [ "kind", `String "keeper"; "name", `String "delta" ]
        ; "prompt", `String "Claim and work on task-154."
        ])
 

--- a/test/test_keeper_keepalive_helpers.ml
+++ b/test/test_keeper_keepalive_helpers.ml
@@ -457,7 +457,7 @@ let test_closed_board_audience_routes_only_its_authority () =
     (match classified inherited_reaction with
      | KBA.Thread_participants -> true
      | _ -> false);
-  let unsupported = audience_signal ~author:"external-author" "@@analyst inspect" in
+  let unsupported = audience_signal ~author:"external-author" "@@delta inspect" in
   check bool "unsupported broadcast fails closed" true
     (match KBA.classify ~visibility:Board.Internal unsupported with
      | Error (KBA.Invalid_board_audience (Board.Validation_error _)) -> true
@@ -466,7 +466,7 @@ let test_closed_board_audience_routes_only_its_authority () =
     (match KBA.classify ~visibility:Board.Direct discoverable with
      | Error (KBA.Invalid_board_audience (Board.Validation_error _)) -> true
      | Error _ | Ok _ -> false);
-  let mixed = audience_signal ~author:"external-author" "@alpha @@analyst inspect" in
+  let mixed = audience_signal ~author:"external-author" "@alpha @@delta inspect" in
   check bool "mixed direct target and unsupported selector fails closed" true
     (match KBA.classify ~visibility:Board.Internal mixed with
      | Error (KBA.Invalid_board_audience (Board.Validation_error _)) -> true
@@ -603,7 +603,7 @@ let test_mixed_address_signal_is_dropped_at_routing () =
        (match
           Board_dispatch.create_post
             ~author:"external-author"
-            ~content:"@alpha @@analyst inspect"
+            ~content:"@alpha @@delta inspect"
             ~title:"mixed address"
             ~post_kind:Board.Human_post
             ~visibility:Board.Internal

--- a/test/test_keeper_lane_mentions.ml
+++ b/test/test_keeper_lane_mentions.ml
@@ -41,14 +41,14 @@ let test_parser_goldens () =
   check ids "newline separated" [ "alice" ] (parse "line one\n@alice two");
   check ids "deduplicated" [ "alice" ] (parse "@alice and @alice again");
   check ids "two distinct"
-    [ "alice"; "sangsu" ]
-    (parse "@sangsu and @alice please");
+    [ "alice"; "alpha" ]
+    (parse "@alpha and @alice please");
   check ids "keeper-shaped form canonicalizes (documented widening)"
     [ "alice" ]
     (parse "cc @keeper-alice");
-  (* Apostrophe is an internal (kept) character — "@sangsu's" is its own
-     token and never reaches "sangsu"; same as the legacy tokenizer. *)
-  check ids "possessive stays distinct" [ "sangsu's" ] (parse "@sangsu's note")
+  (* Apostrophe is an internal (kept) character — "@alpha's" is its own
+     token and never reaches "alpha"; same as the legacy tokenizer. *)
+  check ids "possessive stays distinct" [ "alpha's" ] (parse "@alpha's note")
 
 let test_explicit_address_is_closed () =
   let check_address label expected content =
@@ -68,13 +68,13 @@ let test_explicit_address_is_closed () =
   check_address "exact broadcast" "broadcast" "release note @@all";
   check_address
     "generic agent-type broadcast is not Keeper authority"
-    "unsupported:analyst"
-    "release note @@analyst";
+    "unsupported:delta"
+    "release note @@delta";
   check_address "empty broadcast selector fails closed" "unsupported:" "release @@";
   check_address
     "mixed valid and unsupported broadcast fails closed"
-    "unsupported:all,analyst"
-    "@@all @@analyst";
+    "unsupported:all,delta"
+    "@@all @@delta";
   check_address
     "broadcast precedence"
     "broadcast"
@@ -130,8 +130,8 @@ let corpus_contents =
   ; "PING @DREAMER NOW"
   ; "ok @alice, thanks"
   ; "just chatting here"
-  ; "@sangsu and @alice please"
-  ; "@analyst: status?"
+  ; "@alpha and @alice please"
+  ; "@delta: status?"
   ; "tab\t@alice\tseparated"
   ; "(@alice)"
   ; "@@alice double at"
@@ -141,14 +141,14 @@ let corpus_contents =
   ; "@vincent are you there"
   ; "mid@alice token"
   ; "@alice."
-  ; "...@sangsu..."
+  ; "...@alpha..."
   ]
 
 let corpus_target_sets =
   [ [ "alice" ]
-  ; [ "sangsu" ]
-  ; [ "alice"; "sangsu" ]
-  ; [ "analyst" ]
+  ; [ "alpha" ]
+  ; [ "alice"; "alpha" ]
+  ; [ "delta" ]
   ; [ "vincent" ]
   ; []
   ; [ "" ]
@@ -200,16 +200,16 @@ let message_mentions (m : Store.chat_message) =
 let test_append_persists_mentions () =
   with_base "lane-mentions-append" (fun base ->
       Store.append_user_message ~base_dir:base ~keeper_name:"alice"
-        ~content:"@alice please look at @sangsu note" ();
+        ~content:"@alice please look at @alpha note" ();
       Store.append_turn ~base_dir:base ~keeper_name:"alice"
-        ~user_content:"thanks @analyst" ~user_attachments:[]
+        ~user_content:"thanks @delta" ~user_attachments:[]
         ~assistant_content:"done" ();
       match Store.load ~base_dir:base ~keeper_name:"alice" with
       | [ first; second; third ] ->
           check ids "user message mentions"
-            [ "alice"; "sangsu" ]
+            [ "alice"; "alpha" ]
             (message_mentions first);
-          check ids "turn user line mentions" [ "analyst" ]
+          check ids "turn user line mentions" [ "delta" ]
             (message_mentions second);
           check ids "assistant line has none" [] (message_mentions third)
       | other ->

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -715,7 +715,7 @@ let test_prompt_omits_tool_result_payload_and_has_one_message () =
    applies. Measured on the live workspace 2026-08-05: excluding taskmaster,
    12 of 25 stored facts were category constraint, and five of those were the
    agent's own scope decisions -- "unclaimed implementation tasks are outside
-   the code-reviewer's scope and should be ignored", "only intervening when
+   the epsilon-reviewer's scope and should be ignored", "only intervening when
    directly mentioned", "does not autonomously claim backlog tasks". None was
    set by an operator; each was a turn's operating judgment promoted to a
    permanent boundary, and the same backlog held 56 cancelled tasks that no
@@ -755,7 +755,7 @@ let test_constraint_category_excludes_self_imposed_scope () =
       (String_util.contains_substring user_text
          "does not earn retention by already being there");
     (* Scoping the omit rule to the constraint bullet left the category itself
-       as the escape hatch. Observed live 2026-08-05 within one hour: kidsnote's
+       as the escape hatch. Observed live 2026-08-05 within one hour: gamma's
        store went from revision 129 carrying [constraint] "standing-by policy,
        only intervening ... when directly mentioned" to revision 131 carrying
        [preference] "Skip polling on non-scheduled wakes, acting only when the
@@ -776,10 +776,10 @@ let test_constraint_category_excludes_self_imposed_scope () =
       (String_util.contains_substring user_text
          "drop a stored memory that no external rule enforces but that still \
           narrows what the agent takes on");
-    (* Measured 2026-08-05. kidsnote's operator instructions say "@kidsnote로
+    (* Measured 2026-08-05. gamma's operator instructions say "@gamma로
        요청받으면 같은 post_id에 구체적인 댓글을 남긴다" -- when to act. The
        stored memory reads "standing-by policy, only intervening in board posts
-       or tasks when directly mentioned (@kidsnote) or assigned" -- the
+       or tasks when directly mentioned (@gamma) or assigned" -- the
        inverse, with an exclusivity the operator never wrote. The category
        rules do not catch it because it looks like operator policy, which is
        the family they preserve. This is about the shape of the statement, not

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -712,7 +712,7 @@ let test_prompt_omits_tool_result_payload_and_has_one_message () =
 ;;
 
 (* The constraint category is scoped to rules something outside the agent
-   applies. Measured on the live workspace 2026-08-05: excluding taskmaster,
+   applies. Measured on the live workspace 2026-08-05: excluding fixture-keeper,
    12 of 25 stored facts were category constraint, and five of those were the
    agent's own scope decisions -- "unclaimed implementation tasks are outside
    the epsilon-reviewer's scope and should be ignored", "only intervening when

--- a/test/test_keeper_meta_cwd_resilience.ml
+++ b/test/test_keeper_meta_cwd_resilience.ml
@@ -32,12 +32,12 @@ let test_meta_of_json_survives_deleted_cwd () =
       let json =
         `Assoc
           [
-            ("name", `String "sangsu");
-            ("trace_id", `String "trace-sangsu-live");
+            ("name", `String "alpha");
+            ("trace_id", `String "trace-alpha-live");
           ]
       in
       match Masc_test_deps.meta_of_json_fixture json with
-      | Ok meta -> check string "keeper name" "sangsu" meta.name
+      | Ok meta -> check string "keeper name" "alpha" meta.name
       | Error err -> fail ("meta_of_json failed under deleted cwd: " ^ err))
 
 let () =

--- a/test/test_keeper_model_input_demotion.ml
+++ b/test/test_keeper_model_input_demotion.ml
@@ -440,7 +440,7 @@ let projection_reuses_candidate_measurements () =
 
 (* --- 7. Last resort: the newest atom does not fit (#28845) ------------- *)
 
-(* The sangsu incident shape: parallel WebSearch results joined the assistant
+(* The alpha incident shape: parallel WebSearch results joined the assistant
    atom that called them, and that one atom (indivisible to the tail window)
    outgrew the whole history budget. Ordinary demotion cannot help — its
    boundary excludes the current turn (RFC-0351 §4) — so composition refused

--- a/test/test_keeper_path_ssot.ml
+++ b/test/test_keeper_path_ssot.ml
@@ -85,8 +85,8 @@ let write_keeper_toml ~config ~name ~sandbox_profile =
 
 let test_config_agent_projection_docker () =
   let config = make_config () in
-  write_keeper_toml ~config ~name:"sangsu" ~sandbox_profile:"docker";
-  let agent_name = "keeper-sangsu-agent" in
+  write_keeper_toml ~config ~name:"alpha" ~sandbox_profile:"docker";
+  let agent_name = "keeper-alpha-agent" in
   Alcotest.(check string)
     "config-backed backend"
     "docker"
@@ -94,7 +94,7 @@ let test_config_agent_projection_docker () =
      |> Keeper_sandbox.backend_to_string);
   Alcotest.(check string)
     "config-backed host root rel"
-    ".masc/playground/docker/sangsu/"
+    ".masc/playground/docker/alpha/"
     (Keeper_sandbox.host_root_rel_of_config_agent ~config ~agent_name);
   let visible =
     Filename.concat
@@ -104,7 +104,7 @@ let test_config_agent_projection_docker () =
   let expected =
     Filename.concat
       config.Workspace.base_path
-      ".masc/playground/docker/sangsu/repos/masc/lib/foo.ml"
+      ".masc/playground/docker/alpha/repos/masc/lib/foo.ml"
   in
   Alcotest.(check string)
     "sandbox-visible path maps to backend-scoped host path"
@@ -113,7 +113,7 @@ let test_config_agent_projection_docker () =
 
 let test_config_agent_projection_local () =
   let config = make_config () in
-  let agent_name = "keeper-sangsu-agent" in
+  let agent_name = "keeper-alpha-agent" in
   Alcotest.(check string)
     "missing config defaults to local backend"
     "local"
@@ -121,7 +121,7 @@ let test_config_agent_projection_local () =
      |> Keeper_sandbox.backend_to_string);
   Alcotest.(check string)
     "local host root rel"
-    ".masc/playground/sangsu/"
+    ".masc/playground/alpha/"
     (Keeper_sandbox.host_root_rel_of_config_agent ~config ~agent_name)
 
 (* ── Invariant: one projection, and it is fail-closed ─────────────────
@@ -149,7 +149,7 @@ let docker_sandbox ~config ~name =
 
 let test_projection_docker_maps_root_and_subpath () =
   let config = make_config () in
-  let sandbox, meta = docker_sandbox ~config ~name:"sangsu" in
+  let sandbox, meta = docker_sandbox ~config ~name:"alpha" in
   let host_root = Keeper_sandbox.host_root_abs_of_meta ~config meta in
   let container_root = Keeper_sandbox.container_root meta.name in
   Alcotest.(check string)
@@ -170,7 +170,7 @@ let test_projection_docker_maps_root_and_subpath () =
 
 let test_projection_docker_rejects_outside_root () =
   let config = make_config () in
-  let sandbox, _meta = docker_sandbox ~config ~name:"sangsu" in
+  let sandbox, _meta = docker_sandbox ~config ~name:"alpha" in
   let outside = "/Users/dancer/me/workspace/yousleepwhen/masc/lib/keeper" in
   match
     Keeper_sandbox.visible_path_of_host
@@ -194,7 +194,7 @@ let test_projection_docker_rejects_outside_root () =
    must not be treated as being inside it. *)
 let test_projection_docker_requires_segment_boundary () =
   let config = make_config () in
-  let sandbox, meta = docker_sandbox ~config ~name:"sangsu" in
+  let sandbox, meta = docker_sandbox ~config ~name:"alpha" in
   let host_root = Keeper_sandbox.host_root_abs_of_meta ~config meta in
   let sibling =
     Env_config_core.strip_trailing_slashes host_root ^ "-scratch/notes.md"
@@ -215,7 +215,7 @@ let test_projection_docker_requires_segment_boundary () =
    Keeper_alerting_path, and must not be smuggled in here. *)
 let test_projection_local_is_identity () =
   let config = make_config () in
-  let meta = make_meta ~name:"sangsu" ~sandbox:Keeper_types_profile_sandbox.Local in
+  let meta = make_meta ~name:"alpha" ~sandbox:Keeper_types_profile_sandbox.Local in
   let sandbox = Keeper_sandbox.of_meta ~config ~meta in
   let outside = "/tmp/anywhere/at/all.ml" in
   Alcotest.(check string)
@@ -231,7 +231,7 @@ let test_projection_local_is_identity () =
    land on the same visible answer. *)
 let test_raw_accepts_either_coordinate_system () =
   let config = make_config () in
-  let sandbox, meta = docker_sandbox ~config ~name:"sangsu" in
+  let sandbox, meta = docker_sandbox ~config ~name:"alpha" in
   let host_root = Keeper_sandbox.host_root_abs_of_meta ~config meta in
   let container_root = Keeper_sandbox.container_root meta.name in
   let expected = Filename.concat container_root "repos/masc" in
@@ -263,10 +263,10 @@ let test_projection_docker_resolves_symlinked_spelling () =
   let link_parent = temp_dir () in
   let linked_base = Filename.concat link_parent "workspace-link" in
   Unix.symlink real_base linked_base;
-  let playground_rel = ".masc/playground/docker/sangsu" in
+  let playground_rel = ".masc/playground/docker/alpha" in
   let check_projection ~msg ~base_spelling ~cwd_spelling =
     let config = Workspace.default_config base_spelling in
-    let sandbox, meta = docker_sandbox ~config ~name:"sangsu" in
+    let sandbox, meta = docker_sandbox ~config ~name:"alpha" in
     let container_root = Keeper_sandbox.container_root meta.name in
     let host_cwd =
       Filename.concat (Filename.concat cwd_spelling playground_rel) "repos/masc"
@@ -290,7 +290,7 @@ let test_projection_docker_resolves_symlinked_spelling () =
 
 let test_config_agent_projection_rejects_legacy_alias () =
   let config = make_config () in
-  write_keeper_toml ~config ~name:"sangsu" ~sandbox_profile:"docker_hardened";
+  write_keeper_toml ~config ~name:"alpha" ~sandbox_profile:"docker_hardened";
   Alcotest.check_raises
     "legacy sandbox_profile aliases are rejected"
     (Keeper_sandbox_config.Invalid_keeper_sandbox_config
@@ -298,13 +298,13 @@ let test_config_agent_projection_rejects_legacy_alias () =
           "%s: invalid sandbox_profile %S (allowed: local, docker)"
           (Keeper_sandbox_config.keeper_toml_path
              ~base_path:config.Workspace.base_path
-             ~agent_name:"keeper-sangsu-agent")
+             ~agent_name:"keeper-alpha-agent")
           "docker_hardened"))
     (fun () ->
        ignore
          (Keeper_sandbox_config.sandbox_profile_of_agent
             ~base_path:config.Workspace.base_path
-            ~agent_name:"keeper-sangsu-agent"))
+            ~agent_name:"keeper-alpha-agent"))
 
 let () =
   Alcotest.run "Keeper Path SSOT" [

--- a/test/test_keeper_paused_work_resume_surface.ml
+++ b/test/test_keeper_paused_work_resume_surface.ml
@@ -29,7 +29,7 @@ let test_bulk_resume_requires_per_owner_targets () =
   let names_only =
     `Assoc
       [ "action", `String "resume"
-      ; "names", `List [ `String "rondo"; `String "qa-king" ]
+      ; "names", `List [ `String "beta"; `String "mu-king" ]
       ]
   in
   (match Surface.parse_bulk_resume_requests names_only with
@@ -42,12 +42,12 @@ let test_bulk_resume_requires_per_owner_targets () =
          ; ( "targets"
            , `List
                [ `Assoc
-                   [ "name", `String "rondo"
+                   [ "name", `String "beta"
                    ; "owner_nonce", `Int 3
-                   ; "operator_operation_id", `String "resume-rondo-1"
+                   ; "operator_operation_id", `String "resume-beta-1"
                    ]
                ; `Assoc
-                   [ "name", `String "qa-king"
+                   [ "name", `String "mu-king"
                    ; "owner_nonce", `Int 5
                    ; "operator_operation_id", `String "resume-qa-1"
                    ]
@@ -58,7 +58,7 @@ let test_bulk_resume_requires_per_owner_targets () =
   check
     (list (triple string int string))
     "per-owner fences"
-    [ "rondo", 3, "resume-rondo-1"; "qa-king", 5, "resume-qa-1" ]
+    [ "beta", 3, "resume-beta-1"; "mu-king", 5, "resume-qa-1" ]
     parsed
 ;;
 

--- a/test/test_keeper_playground_checkout_discovery.ml
+++ b/test/test_keeper_playground_checkout_discovery.ml
@@ -89,7 +89,7 @@ let test_root_itself_is_a_checkout () =
       (C.discover ~root))
 ;;
 
-(* Measured live: code-reviewer and sangsu both put checkouts under a
+(* Measured live: epsilon-reviewer and alpha both put checkouts under a
    dot-directory. A scan that skips hidden names loses them. *)
 let test_finds_checkout_under_hidden_directory () =
   with_temp_root (fun root ->
@@ -147,7 +147,7 @@ let test_hierarchical_worktree_is_not_a_separate_checkout () =
       (C.discover ~root))
 ;;
 
-(* Measured live: kidsnote/repos/masc-task-188 sits beside the checkout it
+(* Measured live: gamma/repos/masc-task-188 sits beside the checkout it
    belongs to, not under it. The old scan already counted these, so the
    behaviour must not change. *)
 let test_flat_worktree_is_its_own_checkout () =
@@ -159,7 +159,7 @@ let test_flat_worktree_is_its_own_checkout () =
       (C.discover ~root))
 ;;
 
-(* Measured live: code-reviewer/repos/masc/review-pr-28304 is a worktree
+(* Measured live: epsilon-reviewer/repos/masc/review-pr-28304 is a worktree
    outside the .worktrees/ convention. Naming that directory would miss it. *)
 let test_worktree_outside_the_worktrees_convention () =
   with_temp_root (fun root ->

--- a/test/test_keeper_prompt_metrics.ml
+++ b/test/test_keeper_prompt_metrics.ml
@@ -212,9 +212,9 @@ let test_assembled_prompt_opens_with_system_tag () =
     [ ("no instructions", KP.build_keeper_system_prompt ~instructions:"" ())
     ; ( "with instructions and identity"
       , KP.build_keeper_system_prompt ~instructions:"stay terse"
-          ~keeper_name:"imseonghan" ~workspace_root:"/tmp/ws" () )
+          ~keeper_name:"tau" ~workspace_root:"/tmp/ws" () )
     ; ( "with active goals"
-      , KP.build_keeper_system_prompt ~instructions:"" ~keeper_name:"imseonghan"
+      , KP.build_keeper_system_prompt ~instructions:"" ~keeper_name:"tau"
           ~active_goals:[ ("g-1", "ship it") ]
           () )
     ]

--- a/test/test_keeper_provider_call_deadline.ml
+++ b/test/test_keeper_provider_call_deadline.ml
@@ -82,7 +82,7 @@ let threshold_sec = 900.0
 let attempt_started_at = 1_000_000.0
 
 let test_a_progressing_attempt_is_not_stalled () =
-  (* rondo, 2026-08-12 13:59:44Z: the attempt was cancelled 6 seconds after a
+  (* beta, 2026-08-12 13:59:44Z: the attempt was cancelled 6 seconds after a
      successful masc_transition, with 30+ tool calls inside the window. Its
      ELAPSED time had reached the threshold -- which is exactly why the
      pre-#28417 axis killed it -- while its progress was 6 seconds old. *)
@@ -97,7 +97,7 @@ let test_a_progressing_attempt_is_not_stalled () =
 ;;
 
 let test_a_wedged_attempt_is_stalled () =
-  (* sangsu, 2026-08-12 10:04Z-11:10Z: zero trajectory events for 65 minutes.
+  (* alpha, 2026-08-12 10:04Z-11:10Z: zero trajectory events for 65 minutes.
      This is the class #27355 introduced the deadline for and it must still
      fire on the new axis. *)
   let now = attempt_started_at +. 4_000.0 in
@@ -110,7 +110,7 @@ let test_a_wedged_attempt_is_stalled () =
 ;;
 
 let test_a_tool_in_flight_is_not_a_stall () =
-  (* One Execute ran 120s inside rondo's window without refreshing the
+  (* One Execute ran 120s inside beta's window without refreshing the
      progress signal. A tool that has been issued but not completed is work,
      not a stall -- the exclusion [active_tool_count] has documented since
      RFC-0197 with no code reading it until now. *)

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -827,7 +827,7 @@ let test_reaction_kind_string_roundtrip () =
 let test_unexpected_schema_rows_are_quarantined_without_double_counting () =
   with_temp_base
   @@ fun base_path ->
-  let keeper_name = "sangsu" in
+  let keeper_name = "alpha" in
   let stimulus = board_stimulus () in
   let stimulus_id = Keeper_reaction_ledger.stimulus_id_of_event_queue stimulus in
   Keeper_reaction_ledger.record_event_queue_stimulus

--- a/test/test_keeper_registry_hardening.ml
+++ b/test/test_keeper_registry_hardening.ml
@@ -721,7 +721,7 @@ let test_goal_reconciliation_prefers_authoritative_assignment
        Fs_compat.set_fs (Eio.Stdenv.fs env);
        KR.For_testing.clear ();
        let config = Masc.Workspace.default_config dir in
-       let completing_agent_name = "keeper-executor-agent-agent" in
+       let completing_agent_name = "keeper-omega-agent-agent" in
        ignore (Masc.Workspace.init config ~agent_name:(Some completing_agent_name));
        let producer_meta =
          { (make_meta "producer") with agent_name = completing_agent_name }

--- a/test/test_keeper_repo_mapping.ml
+++ b/test/test_keeper_repo_mapping.ml
@@ -92,8 +92,8 @@ let test_malformed_top_level_mapping_is_explicit () =
 
 let test_wildcard_scope_is_parsed_at_boundary () =
   with_temp_base_path (fun base_path ->
-    write_mapping_raw base_path "[mapping.executor]\nrepositories = [\"*\"]\n";
-    let mapping = load_mapping base_path "executor" in
+    write_mapping_raw base_path "[mapping.omega]\nrepositories = [\"*\"]\n";
+    let mapping = load_mapping base_path "omega" in
     match mapping.repository_scope with
     | Repo_manager_types.All_repositories -> ()
     | Repo_manager_types.Selected_repositories _ ->
@@ -102,16 +102,16 @@ let test_wildcard_scope_is_parsed_at_boundary () =
 
 let test_save_creates_directory_and_replaces_same_keeper () =
   with_temp_base_path (fun base_path ->
-    save_mapping base_path "executor" [ "masc"; "agent_core" ];
+    save_mapping base_path "omega" [ "masc"; "agent_core" ];
     save_mapping base_path "reviewer" [ "docs" ];
-    save_mapping base_path "executor" [ "masc" ];
+    save_mapping base_path "omega" [ "masc" ];
     let mappings = Keeper_repo_mapping.load_all ~base_path |> Result.get_ok in
     Alcotest.(check int) "one row per keeper" 2 (List.length mappings);
-    let executor = load_mapping base_path "executor" in
+    let mapping = load_mapping base_path "omega" in
     Alcotest.(check (list string))
       "latest preference"
       [ "masc" ]
-      executor.repository_ids)
+      mapping.repository_ids)
 ;;
 
 let () =

--- a/test/test_keeper_response_feedback.ml
+++ b/test/test_keeper_response_feedback.ml
@@ -23,7 +23,7 @@ let test_signal_unknown_is_error () =
   check "empty signal -> Error" (Result.is_error (F.signal_of_wire ""))
 
 let test_json_roundtrip () =
-  let r = mk ~turn_id:"masc-improver:42" ~signal:F.Not_helpful ~recorded_at:1718000000.5 () in
+  let r = mk ~turn_id:"omicron-improver:42" ~signal:F.Not_helpful ~recorded_at:1718000000.5 () in
   check "json roundtrip" (F.of_json (F.to_json r) = Ok r)
 
 let test_json_strict () =

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -2069,7 +2069,7 @@ let test_docker_mount_failure_structured_details () =
   match
     Keeper_sandbox_runtime.docker_mount_failure_details
       ~base_path_hash:"hash456"
-      ~keeper_name:"ramarama"
+      ~keeper_name:"nu"
       ~image:"masc-keeper-sandbox:local"
       ~status_label:"exit=125"
       ~container_kind:"turn"
@@ -2083,7 +2083,7 @@ let test_docker_mount_failure_structured_details () =
     Alcotest.(check string) "event" "keeper_docker_mount_failure" (field "event");
     Alcotest.(check string) "mount_path" mount_path (field "mount_path");
     Alcotest.(check string) "base_path_hash" "hash456" (field "base_path_hash");
-    Alcotest.(check string) "keeper" "ramarama" (field "keeper");
+    Alcotest.(check string) "keeper" "nu" (field "keeper");
     Alcotest.(check string) "container_kind" "turn" (field "container_kind");
     Alcotest.(check string) "network" "none" (field "network")
 

--- a/test/test_keeper_sandbox_read_backend.ml
+++ b/test/test_keeper_sandbox_read_backend.ml
@@ -934,7 +934,7 @@ let test_sandbox_container_label_args_include_managed_ttl () =
     Keeper_sandbox_runtime.docker_label_args
       ~ttl_sec:90.0
       ~base_path:"/tmp/masc"
-      ~keeper_name:"issue-king"
+      ~keeper_name:"kappa-keeper"
       ~container_kind:"managed"
       ~network_label:"inherit" ()
   in

--- a/test/test_keeper_self_authored_task_exclusion.ml
+++ b/test/test_keeper_self_authored_task_exclusion.ml
@@ -62,7 +62,7 @@ let test_other_keeper_task_is_not_self_authored () =
     false
     (WOI.task_is_self_authored_todo
        ~meta
-       (task ~created_by:"executor" "task-2"))
+       (task ~created_by:"omega" "task-2"))
 ;;
 
 (* An unattributed task has no known author, so it must stay claimable rather
@@ -92,7 +92,7 @@ let test_self_authored_verification_remains_eligible () =
   let meta = make_meta "taskmaster" in
   let task_status =
     Masc_domain.AwaitingVerification
-      { assignee = "executor"
+      { assignee = "omega"
       ; started_at = "2026-07-20T00:00:00Z"
       ; submitted_at = "2026-07-20T01:00:00Z"
       ; verification_id = "verification-1"

--- a/test/test_keeper_self_authored_task_exclusion.ml
+++ b/test/test_keeper_self_authored_task_exclusion.ml
@@ -4,7 +4,7 @@
     a Keeper whose response to "an unclaimed task exists" is to create a
     routing or report task emits a new unclaimed Todo authored by itself, which
     re-satisfies the same trigger on the next observation. Observed live on
-    2026-07-20: keeper "taskmaster" authored 367 of the active tasks, 272 of
+    2026-07-20: keeper "fixture-keeper" authored 367 of the active tasks, 272 of
     them the same four "Route g0700 #N" templates re-emitted once per iteration
     (#28..#90), none ever claimed since 2026-07-09. *)
 
@@ -44,19 +44,19 @@ let task ?created_by ?(task_status = Masc_domain.Todo) id : Masc_domain.task =
 ;;
 
 (* [created_by] carries the keeper handle ([meta.name]), which is what the live
-   backlog records ("taskmaster"), not the agent name. *)
+   backlog records ("fixture-keeper"), not the agent name. *)
 let test_own_todo_is_self_authored () =
-  let meta = make_meta "taskmaster" in
+  let meta = make_meta "fixture-keeper" in
   Alcotest.(check bool)
     "a task authored by this keeper is self-authored"
     true
     (WOI.task_is_self_authored_todo
        ~meta
-       (task ~created_by:"taskmaster" "task-1"))
+       (task ~created_by:"fixture-keeper" "task-1"))
 ;;
 
 let test_other_keeper_task_is_not_self_authored () =
-  let meta = make_meta "taskmaster" in
+  let meta = make_meta "fixture-keeper" in
   Alcotest.(check bool)
     "a task authored by another keeper is not self-authored"
     false
@@ -68,7 +68,7 @@ let test_other_keeper_task_is_not_self_authored () =
 (* An unattributed task has no known author, so it must stay claimable rather
    than being silently withheld from everyone. *)
 let test_unattributed_task_is_not_self_authored () =
-  let meta = make_meta "taskmaster" in
+  let meta = make_meta "fixture-keeper" in
   Alcotest.(check bool)
     "a task with no created_by is never excluded"
     false
@@ -76,20 +76,20 @@ let test_unattributed_task_is_not_self_authored () =
 ;;
 
 (* The agent name must not be mistaken for the author key: the live backlog
-   stores "taskmaster", never "keeper-taskmaster-agent". Matching on the agent
+   stores "fixture-keeper", never "keeper-fixture-agent". Matching on the agent
    name would silently exclude nothing and leave the loop intact. *)
 let test_agent_name_is_not_the_author_key () =
-  let meta = make_meta "taskmaster" in
+  let meta = make_meta "fixture-keeper" in
   Alcotest.(check bool)
     "agent-name-shaped author does not match the keeper handle"
     false
     (WOI.task_is_self_authored_todo
        ~meta
-       (task ~created_by:"keeper-taskmaster-agent" "task-4"))
+       (task ~created_by:"keeper-fixture-agent" "task-4"))
 ;;
 
 let test_self_authored_verification_remains_eligible () =
-  let meta = make_meta "taskmaster" in
+  let meta = make_meta "fixture-keeper" in
   let task_status =
     Masc_domain.AwaitingVerification
       { assignee = "omega"
@@ -103,7 +103,7 @@ let test_self_authored_verification_remains_eligible () =
     false
     (WOI.task_is_self_authored_todo
        ~meta
-       (task ~created_by:"taskmaster" ~task_status "task-5"))
+       (task ~created_by:"fixture-keeper" ~task_status "task-5"))
 ;;
 
 let () =

--- a/test/test_keeper_shutdown_reconciliation_settlement.ml
+++ b/test/test_keeper_shutdown_reconciliation_settlement.ml
@@ -286,7 +286,7 @@ let test_recovery_blocks_interrupted_lane_join () =
    the same absence is observed one step later is a TOCTOU verdict split — and
    the losing side is permanent: a blocked operation fences keeper admission
    with no runtime release, so every later boot of that keeper fails until the
-   process restarts. Observed live on 2026-07-27 (sangsu).
+   process restarts. Observed live on 2026-07-27 (alpha).
 
    Lane *replacement* is a different fact and must still fail: someone else
    owns the keeper, and this operation must not write its retained meta over

--- a/test/test_keeper_status_bridge.ml
+++ b/test/test_keeper_status_bridge.ml
@@ -5,9 +5,9 @@ let make_meta () =
     Masc_test_deps.meta_of_json_fixture
       (`Assoc
         [
-          ("name", `String "verifier");
-          ("agent_name", `String "keeper-verifier-agent");
-          ("trace_id", `String "trace-verifier");
+          ("name", `String "omega");
+          ("agent_name", `String "keeper-omega-agent");
+          ("trace_id", `String "trace-omega");
         ])
   with
   | Ok meta -> meta
@@ -98,7 +98,7 @@ let shutdown_operation_with_phase phase =
       Keeper_shutdown_types.schema_version
   ; revision = 1
   ; operation_id = Keeper_shutdown_types.Operation_id.generate ()
-  ; keeper_name = "verifier"
+  ; keeper_name = "omega"
   ; lane_ownership = Keeper_shutdown_types.Dormant_meta
   ; trace_id
   ; generation = 1

--- a/test/test_keeper_task_cancellation_wake.ml
+++ b/test/test_keeper_task_cancellation_wake.ml
@@ -41,8 +41,8 @@ let with_workspace f =
 ;;
 
 (* [agent_name] is deliberately distinct from [name]: the production data has
-   authors recorded as "sangsu" and cancellers arriving as
-   "keeper-sangsu-agent", and the identity binding is what closes that gap. *)
+   authors recorded as "alpha" and cancellers arriving as
+   "keeper-alpha-agent", and the identity binding is what closes that gap. *)
 let ensure_keeper config ~keeper_name ~agent_name =
   match
     Result.bind
@@ -114,27 +114,27 @@ let queued_cancellations ~base_path ~keeper_name =
 
 let test_cross_keeper_cancellation_is_delivered () =
   with_workspace (fun config ->
-    ensure_keeper config ~keeper_name:"sangsu" ~agent_name:"keeper-sangsu-agent";
-    ensure_keeper config ~keeper_name:"rondo" ~agent_name:"keeper-rondo-agent";
+    ensure_keeper config ~keeper_name:"alpha" ~agent_name:"keeper-alpha-agent";
+    ensure_keeper config ~keeper_name:"beta" ~agent_name:"keeper-beta-agent";
     seed_task
       config
       ~task_id:"task-161"
-      ~created_by:(Some "sangsu")
+      ~created_by:(Some "alpha")
       ~status:
         (cancelled
-           ~by:"keeper-rondo-agent"
+           ~by:"keeper-beta-agent"
            ~reason:(Some "BLOCKED: service absent from sandbox"));
     let outcome =
       Wake.notify_author
         ~config
-        ~cancelling_agent_name:"keeper-rondo-agent"
+        ~cancelling_agent_name:"keeper-beta-agent"
         ~task_id:"task-161"
     in
     check string "delivered to the author's lane" "delivered" (Wake.outcome_label outcome);
-    match queued_cancellations ~base_path:config.base_path ~keeper_name:"sangsu" with
+    match queued_cancellations ~base_path:config.base_path ~keeper_name:"alpha" with
     | [ cancellation ] ->
       check string "task id" "task-161" cancellation.Event_queue.tc_task_id;
-      check string "canceller" "keeper-rondo-agent" cancellation.tc_cancelled_by;
+      check string "canceller" "keeper-beta-agent" cancellation.tc_cancelled_by;
       check
         (option string)
         "the reason travels with the wake"
@@ -149,22 +149,22 @@ let test_cross_keeper_cancellation_is_delivered () =
    wakes a Keeper about a decision it just made itself. *)
 let test_self_cancellation_across_naming_forms_is_silent () =
   with_workspace (fun config ->
-    ensure_keeper config ~keeper_name:"sangsu" ~agent_name:"keeper-sangsu-agent";
+    ensure_keeper config ~keeper_name:"alpha" ~agent_name:"keeper-alpha-agent";
     seed_task
       config
       ~task_id:"task-155"
-      ~created_by:(Some "sangsu")
-      ~status:(cancelled ~by:"keeper-sangsu-agent" ~reason:(Some "focus change"));
+      ~created_by:(Some "alpha")
+      ~status:(cancelled ~by:"keeper-alpha-agent" ~reason:(Some "focus change"));
     let outcome =
       Wake.notify_author
         ~config
-        ~cancelling_agent_name:"keeper-sangsu-agent"
+        ~cancelling_agent_name:"keeper-alpha-agent"
         ~task_id:"task-155"
     in
     check string "recognised as self-cancellation" "self_cancelled"
       (Wake.outcome_label outcome);
     check int "nothing queued" 0
-      (List.length (queued_cancellations ~base_path:config.base_path ~keeper_name:"sangsu")))
+      (List.length (queued_cancellations ~base_path:config.base_path ~keeper_name:"alpha")))
 ;;
 
 (* A [masc_transition] cancel with no top-level reason but a persisted handoff
@@ -174,12 +174,12 @@ let test_self_cancellation_across_naming_forms_is_silent () =
    losing exactly the context it exists to carry. *)
 let test_handoff_reason_reaches_the_author_when_the_status_carries_none () =
   with_workspace (fun config ->
-    ensure_keeper config ~keeper_name:"sangsu" ~agent_name:"keeper-sangsu-agent";
-    ensure_keeper config ~keeper_name:"rondo" ~agent_name:"keeper-rondo-agent";
+    ensure_keeper config ~keeper_name:"alpha" ~agent_name:"keeper-alpha-agent";
+    ensure_keeper config ~keeper_name:"beta" ~agent_name:"keeper-beta-agent";
     seed_task
       config
       ~task_id:"task-171"
-      ~created_by:(Some "sangsu")
+      ~created_by:(Some "alpha")
       ~handoff_context:
         { D.summary = "sandbox lacks the request-menu service"
         ; D.reason = Some "cannot verify without the service"
@@ -190,15 +190,15 @@ let test_handoff_reason_reaches_the_author_when_the_status_carries_none () =
         ; updated_at = None
         ; updated_by = None
         }
-      ~status:(cancelled ~by:"keeper-rondo-agent" ~reason:None);
+      ~status:(cancelled ~by:"keeper-beta-agent" ~reason:None);
     let outcome =
       Wake.notify_author
         ~config
-        ~cancelling_agent_name:"keeper-rondo-agent"
+        ~cancelling_agent_name:"keeper-beta-agent"
         ~task_id:"task-171"
     in
     check string "delivered" "delivered" (Wake.outcome_label outcome);
-    match queued_cancellations ~base_path:config.base_path ~keeper_name:"sangsu" with
+    match queued_cancellations ~base_path:config.base_path ~keeper_name:"alpha" with
     | [ cancellation ] ->
       check
         (option string)
@@ -238,109 +238,109 @@ let test_ambiguous_canceller_suppresses_delivery () =
 
 (* [cancelled_by] holds the acting agent name verbatim, so a non-Keeper actor
    lands here under its own id. When that id happens to equal a Keeper lane —
-   an operator called "sangsu" against lane "sangsu", whose agent is
-   "keeper-sangsu-agent" — resolving it as a lane, or comparing the raw string
+   an operator called "alpha" against lane "alpha", whose agent is
+   "keeper-alpha-agent" — resolving it as a lane, or comparing the raw string
    against [created_by], read as a self-cancellation and swallowed the wake the
    author was owed. A canceller with no lane is not the author, who has one. *)
 let test_operator_sharing_the_author_lane_name_still_delivers () =
   with_workspace (fun config ->
-    ensure_keeper config ~keeper_name:"sangsu" ~agent_name:"keeper-sangsu-agent";
+    ensure_keeper config ~keeper_name:"alpha" ~agent_name:"keeper-alpha-agent";
     seed_task
       config
       ~task_id:"task-177"
-      ~created_by:(Some "sangsu")
-      ~status:(cancelled ~by:"sangsu" ~reason:(Some "operator stood the work down"));
+      ~created_by:(Some "alpha")
+      ~status:(cancelled ~by:"alpha" ~reason:(Some "operator stood the work down"));
     let outcome =
-      Wake.notify_author ~config ~cancelling_agent_name:"sangsu" ~task_id:"task-177"
+      Wake.notify_author ~config ~cancelling_agent_name:"alpha" ~task_id:"task-177"
     in
     check string "an operator cancellation still reaches the author" "delivered"
       (Wake.outcome_label outcome);
-    match queued_cancellations ~base_path:config.base_path ~keeper_name:"sangsu" with
+    match queued_cancellations ~base_path:config.base_path ~keeper_name:"alpha" with
     | [ cancellation ] ->
-      check string "canceller recorded as written" "sangsu"
+      check string "canceller recorded as written" "alpha"
         cancellation.Event_queue.tc_cancelled_by
     | queued -> failf "expected one queued cancellation, got %d" (List.length queued))
 ;;
 
 let test_author_without_a_keeper_lane_is_not_an_error () =
   with_workspace (fun config ->
-    ensure_keeper config ~keeper_name:"rondo" ~agent_name:"keeper-rondo-agent";
+    ensure_keeper config ~keeper_name:"beta" ~agent_name:"keeper-beta-agent";
     seed_task
       config
       ~task_id:"task-007"
       ~created_by:(Some "dashboard")
-      ~status:(cancelled ~by:"keeper-rondo-agent" ~reason:None);
+      ~status:(cancelled ~by:"keeper-beta-agent" ~reason:None);
     check string "no lane to wake" "author_not_a_keeper"
       (Wake.outcome_label
          (Wake.notify_author
             ~config
-            ~cancelling_agent_name:"keeper-rondo-agent"
+            ~cancelling_agent_name:"keeper-beta-agent"
             ~task_id:"task-007")))
 ;;
 
 let test_task_without_author_has_no_addressee () =
   with_workspace (fun config ->
-    ensure_keeper config ~keeper_name:"rondo" ~agent_name:"keeper-rondo-agent";
+    ensure_keeper config ~keeper_name:"beta" ~agent_name:"keeper-beta-agent";
     seed_task
       config
       ~task_id:"task-008"
       ~created_by:None
-      ~status:(cancelled ~by:"keeper-rondo-agent" ~reason:None);
+      ~status:(cancelled ~by:"keeper-beta-agent" ~reason:None);
     check string "no author recorded" "no_author"
       (Wake.outcome_label
          (Wake.notify_author
             ~config
-            ~cancelling_agent_name:"keeper-rondo-agent"
+            ~cancelling_agent_name:"keeper-beta-agent"
             ~task_id:"task-008")))
 ;;
 
 (* Completion posts a verdict to Board, so it must not also travel this path. *)
 let test_completion_is_not_a_cancellation () =
   with_workspace (fun config ->
-    ensure_keeper config ~keeper_name:"sangsu" ~agent_name:"keeper-sangsu-agent";
-    ensure_keeper config ~keeper_name:"rondo" ~agent_name:"keeper-rondo-agent";
+    ensure_keeper config ~keeper_name:"alpha" ~agent_name:"keeper-alpha-agent";
+    ensure_keeper config ~keeper_name:"beta" ~agent_name:"keeper-beta-agent";
     seed_task
       config
       ~task_id:"task-009"
-      ~created_by:(Some "sangsu")
+      ~created_by:(Some "alpha")
       ~status:
-        (D.Done { assignee = "keeper-rondo-agent"; completed_at = now; notes = None });
+        (D.Done { assignee = "keeper-beta-agent"; completed_at = now; notes = None });
     check string "other terminal outcomes are declined" "not_cancelled"
       (Wake.outcome_label
          (Wake.notify_author
             ~config
-            ~cancelling_agent_name:"keeper-rondo-agent"
+            ~cancelling_agent_name:"keeper-beta-agent"
             ~task_id:"task-009"));
     check int "nothing queued" 0
-      (List.length (queued_cancellations ~base_path:config.base_path ~keeper_name:"sangsu")))
+      (List.length (queued_cancellations ~base_path:config.base_path ~keeper_name:"alpha")))
 ;;
 
 let test_repeat_delivery_dedups_on_task_identity () =
   with_workspace (fun config ->
-    ensure_keeper config ~keeper_name:"sangsu" ~agent_name:"keeper-sangsu-agent";
-    ensure_keeper config ~keeper_name:"rondo" ~agent_name:"keeper-rondo-agent";
+    ensure_keeper config ~keeper_name:"alpha" ~agent_name:"keeper-alpha-agent";
+    ensure_keeper config ~keeper_name:"beta" ~agent_name:"keeper-beta-agent";
     seed_task
       config
       ~task_id:"task-160"
-      ~created_by:(Some "sangsu")
-      ~status:(cancelled ~by:"keeper-rondo-agent" ~reason:(Some "blocked"));
+      ~created_by:(Some "alpha")
+      ~status:(cancelled ~by:"keeper-beta-agent" ~reason:(Some "blocked"));
     let first =
       Wake.notify_author
         ~config
-        ~cancelling_agent_name:"keeper-rondo-agent"
+        ~cancelling_agent_name:"keeper-beta-agent"
         ~task_id:"task-160"
     in
     let second =
       Wake.notify_author
         ~config
-        ~cancelling_agent_name:"keeper-rondo-agent"
+        ~cancelling_agent_name:"keeper-beta-agent"
         ~task_id:"task-160"
     in
     check string "first delivers" "delivered" (Wake.outcome_label first);
     check string "second is recognised as the same event" "already_present"
       (Wake.outcome_label second);
     check int "one queue entry, not two" 1
-      (List.length (queued_cancellations ~base_path:config.base_path ~keeper_name:"sangsu")))
+      (List.length (queued_cancellations ~base_path:config.base_path ~keeper_name:"alpha")))
 ;;
 
 (* Durability: the wake survives a restart, and "no reason given" must not come
@@ -370,12 +370,12 @@ let test_stimulus_round_trips_including_absent_reason () =
   in
   assert_round_trip
     { Event_queue.tc_task_id = "task-1"
-    ; tc_cancelled_by = "keeper-rondo-agent"
+    ; tc_cancelled_by = "keeper-beta-agent"
     ; tc_reason = Some "blocked on sandbox"
     };
   assert_round_trip
     { Event_queue.tc_task_id = "task-2"
-    ; tc_cancelled_by = "keeper-rondo-agent"
+    ; tc_cancelled_by = "keeper-beta-agent"
     ; tc_reason = None
     }
 ;;

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -827,7 +827,7 @@ let test_bundled_keeper_profiles_resolve_prompt_defaults () =
                   (KTP.keeper_toml_load_error_to_string e))
            | Ok _defaults -> ()))
 
-let test_bundled_issue_king_uses_local_sandbox () =
+let test_bundled_profiles_include_local_sandbox () =
   let repo = repo_root () in
   Fun.protect
     ~finally:(fun () -> Config_dir_resolver.reset ())
@@ -835,17 +835,22 @@ let test_bundled_issue_king_uses_local_sandbox () =
       with_env_restore [ "MASC_CONFIG_DIR" ] (fun () ->
           Unix.putenv "MASC_CONFIG_DIR" (Filename.concat repo "config");
           Config_dir_resolver.reset ();
-          match KTP.load_keeper_profile_defaults_result "issue_king" with
-          | Error e ->
-            fail
-              (Printf.sprintf
-                 "issue_king failed to resolve: %s"
-                 (KTP.keeper_toml_load_error_to_string e))
-          | Ok defaults ->
-            check (option string) "issue_king sandbox" (Some "local")
-              (Option.map KTP.sandbox_profile_to_string defaults.sandbox_profile);
-            check (option string) "issue_king network" (Some "inherit")
-              (Option.map KTP.network_mode_to_string defaults.network_mode)))
+          let keepers_dir = Filename.concat repo "config/keepers" in
+          let has_local_profile =
+            Sys.readdir keepers_dir
+            |> Array.to_list
+            |> List.filter (fun file -> Filename.check_suffix file ".toml")
+            |> List.exists (fun file ->
+                 let name = Filename.chop_extension file in
+                 match KTP.load_keeper_profile_defaults_result name with
+                 | Error _ -> false
+                 | Ok defaults ->
+                   Option.map KTP.sandbox_profile_to_string defaults.sandbox_profile
+                   = Some "local"
+                   && Option.map KTP.network_mode_to_string defaults.network_mode
+                      = Some "inherit")
+          in
+          check bool "a bundled profile exercises local/inherit" true has_local_profile))
 
 let with_temp_dir prefix f =
   let dir = Filename.temp_file prefix "" in
@@ -1098,8 +1103,8 @@ let test_absent_profile_is_legitimate_empty_defaults () =
 
 let test_keeper_agent_prompt_loads_with_keeper_toml () =
   with_profile_base @@ fun ~base_path ~config_dir:_ ~keepers_dir ->
-  let keeper_path = Filename.concat keepers_dir "analyst.toml" in
-  let agent_dir = Filename.concat keepers_dir "analyst" in
+  let keeper_path = Filename.concat keepers_dir "delta.toml" in
+  let agent_dir = Filename.concat keepers_dir "delta" in
   mkdir_p agent_dir;
   let instructions_path = Filename.concat agent_dir "AGENT.md" in
   write_file keeper_path "[keeper]\nautoboot_enabled = true\n";
@@ -1107,7 +1112,7 @@ let test_keeper_agent_prompt_loads_with_keeper_toml () =
   match
     KTP.load_keeper_profile_defaults_result_for_base_path
       ~base_path
-      "analyst"
+      "delta"
   with
   | Error error -> fail (KTP.keeper_toml_load_error_to_string error)
   | Ok defaults ->
@@ -1141,8 +1146,8 @@ let test_empty_keeper_agent_prompt_is_typed_profile_error () =
 
 let test_keeper_agent_read_failure_is_typed_profile_error () =
   with_profile_base @@ fun ~base_path ~config_dir:_ ~keepers_dir ->
-  let keeper_path = Filename.concat keepers_dir "analyst.toml" in
-  let agent_dir = Filename.concat keepers_dir "analyst" in
+  let keeper_path = Filename.concat keepers_dir "delta.toml" in
+  let agent_dir = Filename.concat keepers_dir "delta" in
   mkdir_p agent_dir;
   let instructions_path = Filename.concat agent_dir "AGENT.md" in
   write_file keeper_path "[keeper]\nautoboot_enabled = true\n";
@@ -1150,7 +1155,7 @@ let test_keeper_agent_read_failure_is_typed_profile_error () =
   match
     KTP.load_keeper_profile_defaults_result_for_base_path
       ~base_path
-      "analyst"
+      "delta"
   with
   | Ok _ -> fail "unreadable keeper instructions must fail before defaults projection"
   | Error error ->
@@ -1704,7 +1709,7 @@ let () =
             test_profile_defaults_materializable_for_name_uses_base_path;
           test_case "bundled keeper profiles resolve prompt defaults" `Quick
             test_bundled_keeper_profiles_resolve_prompt_defaults;
-          test_case "bundled issue_king uses local sandbox" `Quick
-            test_bundled_issue_king_uses_local_sandbox;
+          test_case "bundled profiles include local sandbox" `Quick
+            test_bundled_profiles_include_local_sandbox;
         ] );
     ]

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -311,7 +311,7 @@ let test_composition_action_context_persisted () =
         }
     in
     Keeper_tool_call_log.log_call
-      ~keeper_name:"analyst"
+      ~keeper_name:"delta"
       ~tool_name:"keeper_fs_read"
       ~input:(`Assoc [ "path", `String "lib/runtime.ml" ])
       ~output_text:"typed output"
@@ -716,7 +716,7 @@ let test_turn_context_fields_absent_without_context () =
 let test_route_evidence_stored_for_git_push () =
   with_tmp_log (fun () ->
     Keeper_tool_call_log.log_call
-      ~keeper_name:"executor"
+      ~keeper_name:"omega"
       ~tool_name:"tool_execute"
       ~input:
         (`Assoc
@@ -788,7 +788,7 @@ let test_route_evidence_stored_for_blob_backed_git_push () =
               ~preview:{|{"ok":true,"via":"docker","sandbox_profile":"docker","network_mode":"bridge","status":{"label":"success","kind":"exit","code":0},"output":"branch pushed"}|}))
     in
     Keeper_tool_call_log.log_call
-      ~keeper_name:"executor"
+      ~keeper_name:"omega"
       ~tool_name:"tool_execute"
       ~input:
         (`Assoc
@@ -831,7 +831,7 @@ let test_route_evidence_stored_for_blob_backed_git_push () =
 let test_route_evidence_redacts_wrapped_git_push () =
   with_tmp_log (fun () ->
     Keeper_tool_call_log.log_call
-      ~keeper_name:"executor"
+      ~keeper_name:"omega"
       ~tool_name:"tool_execute"
       ~input:
         (`Assoc
@@ -868,7 +868,7 @@ let test_route_evidence_command_redaction_fails_closed () =
     (fun command ->
        with_tmp_log (fun () ->
          Keeper_tool_call_log.log_call
-           ~keeper_name:"executor"
+           ~keeper_name:"omega"
            ~tool_name:"tool_execute"
            ~input:(`Assoc [ ("cmd", `String command) ])
            ~output_text:
@@ -904,7 +904,7 @@ let test_route_evidence_command_redaction_fails_closed () =
 let test_route_evidence_records_descriptor_for_filesystem_calls () =
   with_tmp_log (fun () ->
     Keeper_tool_call_log.log_call
-      ~keeper_name:"executor"
+      ~keeper_name:"omega"
       ~tool_name:"Read"
       ~input:(`Assoc [ ("file_path", `String "README.md") ])
       ~output_text:"file contents"
@@ -942,7 +942,7 @@ let test_route_evidence_records_descriptor_for_filesystem_calls () =
 let test_route_evidence_records_internal_descriptor () =
   with_tmp_log (fun () ->
     Keeper_tool_call_log.log_call
-      ~keeper_name:"executor"
+      ~keeper_name:"omega"
       ~tool_name:"keeper_time_now"
       ~input:(`Assoc [])
       ~output_text:
@@ -984,7 +984,7 @@ let test_route_evidence_records_internal_descriptor () =
 let test_route_evidence_records_masc_board_descriptor () =
   with_tmp_log (fun () ->
     Keeper_tool_call_log.log_call
-      ~keeper_name:"executor"
+      ~keeper_name:"omega"
       ~tool_name:"mcp__masc__masc_board_post"
       ~input:(`Assoc [ "body", `String "descriptor evidence test" ])
       ~output_text:{|{"ok":true,"post_id":"post-1"}|}
@@ -1045,7 +1045,7 @@ let test_route_evidence_records_descriptor_eval_tags () =
 let test_non_object_input_still_logs_action_radius () =
   with_tmp_log (fun () ->
     Keeper_tool_call_log.log_call
-      ~keeper_name:"executor"
+      ~keeper_name:"omega"
       ~tool_name:"tool_write_file"
       ~input:(`String "raw pre-tool gate payload")
       ~output_text:"gate_waiting_for_operator"

--- a/test/test_keeper_tool_call_sse_io_preview.ml
+++ b/test/test_keeper_tool_call_sse_io_preview.ml
@@ -87,7 +87,7 @@ let test_sensitive_named_tool_preserves_redacted_io () =
 let test_tool_call_event_uses_canonical_disposition () =
   let event =
     Keeper_tools_agent_core_handler_telemetry.keeper_tool_call_event_json
-      ~keeper_name:"sangsu"
+      ~keeper_name:"alpha"
       ~tool_name:"keeper_file_write"
       ~duration_ms:12
       ~disposition:(Tool_result.Deferred ())

--- a/test/test_keeper_tool_execute_exit_result.ml
+++ b/test/test_keeper_tool_execute_exit_result.ml
@@ -6,7 +6,7 @@
     [Keeper_tool_execution.failure], whose [Failed] disposition the tool
     bundle promotes to a sticky [Terminal_effect_failed], killing the
     whole turn: four keeper turn deaths across the E0 campaign and the
-    polisher pilot (2026-08-18) traced to probes like [ls] on a missing
+    eta pilot (2026-08-18) traced to probes like [ls] on a missing
     path.
 
     Pins: a nonzero exit produces a [Completed] execution whose payload

--- a/test/test_keeper_tool_search_files_containment.ml
+++ b/test/test_keeper_tool_search_files_containment.ml
@@ -363,7 +363,7 @@ let test_relative_cwd_is_not_rewritten () =
       (String_util.contains_substring error "path_outside_sandbox")
 
 let test_container_cwd_is_not_rewritten () =
-  setup ~keeper_name:"executor" ~sandbox:Keeper_types_profile_sandbox.Docker
+  setup ~keeper_name:"omega" ~sandbox:Keeper_types_profile_sandbox.Docker
   @@ fun ~base:_ ~config ~meta ~playground ->
   let host_worktree =
     Filename.concat playground "repos/masc/.worktrees/task-186"
@@ -422,7 +422,7 @@ let test_readonly_execute_omitted_cwd_does_not_create_playground () =
   Alcotest.(check bool) "playground remains absent" false (Sys.file_exists playground)
 
 let test_container_file_path_is_not_rewritten () =
-  setup ~keeper_name:"executor" ~sandbox:Keeper_types_profile_sandbox.Docker
+  setup ~keeper_name:"omega" ~sandbox:Keeper_types_profile_sandbox.Docker
   @@ fun ~base:_ ~config ~meta ~playground ->
   let host_file =
     Filename.concat playground
@@ -447,11 +447,11 @@ let test_container_file_path_is_not_rewritten () =
       (String_util.contains_substring error "path_outside_sandbox")
 
 let test_docker_other_container_root_stays_blocked () =
-  setup ~keeper_name:"executor" ~sandbox:Keeper_types_profile_sandbox.Docker
+  setup ~keeper_name:"omega" ~sandbox:Keeper_types_profile_sandbox.Docker
   @@ fun ~base:_ ~config ~meta ~playground:_ ->
   let other_container_cwd =
     Filename.concat
-      (Keeper_sandbox.container_root "analyst")
+      (Keeper_sandbox.container_root "delta")
       "repos/masc"
   in
   let args = `Assoc [ ("cwd", `String other_container_cwd) ] in

--- a/test/test_keeper_turn_up_args.ml
+++ b/test/test_keeper_turn_up_args.ml
@@ -82,11 +82,11 @@ let test_parse_rejects_runtime_agent_identity_as_keeper_name () =
           (String.starts_with body ~prefix:"invalid keeper name:");
         check bool "names the canonical keeper" true
           (String.ends_with body
-             ~suffix:"use the canonical keeper name \"executor\""))
-    [ "keeper-executor-agent"
-    ; "keeper_executor_agent"
-    ; "keeper-executor_agent"
-    ; "keeper_executor-agent"
+             ~suffix:"use the canonical keeper name \"omega\""))
+    [ "keeper-omega-agent"
+    ; "keeper_omega_agent"
+    ; "keeper-omega_agent"
+    ; "keeper_omega-agent"
     ]
 
 let test_parse_max_context_override () =

--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -174,8 +174,8 @@ let init_runtime_default_for_tests () =
 (* A verifier is not a Keeper. An AwaitingVerification obligation is decided by
    the application-owned system LLM completion authority or an authenticated
    HITL operator, never through the Keeper tool surface, so no Keeper is
-   offered a task_verify affordance. Guards against a Keeper named "verifier"
-   re-acquiring approval authority. *)
+   offered a task_verify affordance. Guards against any Keeper whose name
+   resembles an authority role re-acquiring approval authority. *)
 let test_no_task_verify_affordance_for_any_keeper () =
   check bool "no task_verify affordance" false
     (List.mem "task_verify" (UM.observed_affordances_of_observation base_observation))
@@ -210,7 +210,7 @@ let test_board_authors_share_one_neutral_observation_boundary () =
     {
       sample_board_event with
       post_id = "peer-post-1";
-      author = "keeper-ramarama-agent";
+      author = "keeper-nu-agent";
       preview = "I assert the build is green.";
       post_kind = Masc.Board.Automation_post;
       explicit_mention = true;
@@ -661,16 +661,16 @@ let test_untitled_wake_keeps_pointer_out_of_prose () =
 let sample_task_cancellation : WO.pending_board_event =
   let cancellation : Keeper_event_queue.task_cancellation =
     { tc_task_id = "task-161"
-    ; tc_cancelled_by = "keeper-rondo-agent"
+    ; tc_cancelled_by = "keeper-beta-agent"
     ; tc_reason = Some "BLOCKED: request-menu service absent from sandbox"
     }
   in
   { sample_board_event with
     event_kind = WO.Task_cancelled cancellation
   ; post_id = "task-cancelled:task-161"
-  ; author = "keeper-rondo-agent"
+  ; author = "keeper-beta-agent"
   ; title = "Task task-161 was cancelled"
-  ; preview = "Task task-161, which you created, was cancelled by keeper-rondo-agent"
+  ; preview = "Task task-161, which you created, was cancelled by keeper-beta-agent"
   ; post_kind = Masc.Board.System_post
   }
 ;;
@@ -689,7 +689,7 @@ let test_task_cancellation_has_own_prompt_layer () =
   check bool "cancellation section is present" true
     (contains_sub "### Cancelled Tasks You Created (1)" world_state);
   check bool "the canceller is named" true
-    (contains_sub "cancelled_by=\"keeper-rondo-agent\"" world_state);
+    (contains_sub "cancelled_by=\"keeper-beta-agent\"" world_state);
   check bool "the reason reaches the author" true
     (contains_sub
        "reason=\"BLOCKED: request-menu service absent from sandbox\""
@@ -714,7 +714,7 @@ let test_task_cancellation_without_reason_omits_the_field () =
   init_runtime_default_for_tests ();
   let render tc_reason =
     let cancellation : Keeper_event_queue.task_cancellation =
-      { tc_task_id = "task-162"; tc_cancelled_by = "keeper-rondo-agent"; tc_reason }
+      { tc_task_id = "task-162"; tc_cancelled_by = "keeper-beta-agent"; tc_reason }
     in
     let obs =
       { base_observation with
@@ -739,7 +739,7 @@ let test_task_cancellation_without_reason_omits_the_field () =
     (contains_sub "reason=\"\"" empty);
   check bool "the identity fields survive the omission" true
     (contains_sub "task_id=\"task-162\"" absent
-     && contains_sub "cancelled_by=\"keeper-rondo-agent\"" absent);
+     && contains_sub "cancelled_by=\"keeper-beta-agent\"" absent);
   check bool "no OCaml option leaks into the prompt" false
     (contains_sub "None" absent);
   check bool "no JSON null leaks into the prompt" false (contains_sub "null" absent)

--- a/test/test_keeper_visible_path_projection.ml
+++ b/test/test_keeper_visible_path_projection.ml
@@ -459,7 +459,7 @@ let test_repo_prefixed_missing_read_preserves_exact_input () =
 
 (* A keeper that guesses the host layout and one whose repos were never
    materialized both got "directory does not exist", and the two need opposite
-   responses. Live taskmaster asked for
+   responses. Live fixture-keeper asked for
    [workspace/yousleepwhen/masc] and retried (#23442).
 
    The hint enumerates the playground's own [repos/]; it does not infer which

--- a/test/test_keeper_wire_capture.ml
+++ b/test/test_keeper_wire_capture.ml
@@ -184,7 +184,7 @@ let env_is_restored () =
 let disabled_is_noop () =
   with_flag "" (fun () ->
     let base = Filename.temp_dir "wirecap_off" "" in
-    Wire.capture_request ~base_path:base ~masc_root:base ~keeper_name:"sangsu"
+    Wire.capture_request ~base_path:base ~masc_root:base ~keeper_name:"alpha"
       ~turn_id:1
       ~agent_core_turn:1 ~system_prompt:"sys" ~extra_system_context:None
       ~user_message:"u" ~history_messages:[] ~tools:[] ();
@@ -194,14 +194,14 @@ let disabled_is_noop () =
 let enabled_writes_redacted () =
   with_flag "1" (fun () ->
     let base = Filename.temp_dir "wirecap_on" "" in
-    install_projected_secret ~base_path:base ~keeper_name:"sangsu";
+    install_projected_secret ~base_path:base ~keeper_name:"alpha";
     let history =
       [
         Agent_core.Types.assistant_msg "좋아, 연구 시작한다";
         Agent_core.Types.user_msg "continue";
       ]
     in
-    Wire.capture_request ~base_path:base ~masc_root:base ~keeper_name:"sangsu"
+    Wire.capture_request ~base_path:base ~masc_root:base ~keeper_name:"alpha"
       ~turn_id:7
       ~agent_core_turn:3
       ~system_prompt:("token " ^ projected_secret ^ " end")
@@ -216,7 +216,7 @@ let enabled_writes_redacted () =
     Alcotest.(check bool) "redaction marker present" true
       (contains ~needle:"[REDACTED]" (json_string "system_prompt" json));
     check_json_string "request kind recorded" "kind" "request" json;
-    check_json_string "keeper name recorded" "keeper" "sangsu" json;
+    check_json_string "keeper name recorded" "keeper" "alpha" json;
     check_json_int "turn_id recorded" "turn_id" 7 json;
     check_json_int "agent_core_turn recorded" "agent_core_turn" 3 json;
     check_json_null "missing trace_id is null" "trace_id" json;
@@ -254,7 +254,7 @@ let record_size_is_independent_of_history_length () =
     let capture ~history_messages =
       let base = Filename.temp_dir "wirecap_size" "" in
       Wire.capture_request ~base_path:base ~masc_root:base
-        ~keeper_name:"sangsu" ~turn_id:1 ~agent_core_turn:1 ~system_prompt:"sys"
+        ~keeper_name:"alpha" ~turn_id:1 ~agent_core_turn:1 ~system_prompt:"sys"
         ~extra_system_context:None ~user_message:"u" ~history_messages
         ~tools:[] ();
       match find_jsonl base with
@@ -280,7 +280,7 @@ let record_size_is_independent_of_history_length () =
 let request_captures_exact_redacted_tool_schemas () =
   with_flag "1" (fun () ->
     let base = Filename.temp_dir "wirecap_tools" "" in
-    install_projected_secret ~base_path:base ~keeper_name:"sangsu";
+    install_projected_secret ~base_path:base ~keeper_name:"alpha";
     let tool =
       Agent_core.Tool.create
         ~name:"probe_tool"
@@ -295,7 +295,7 @@ let request_captures_exact_redacted_tool_schemas () =
         (fun _input -> Ok { Agent_core.Types.content = "ok"; _meta = None })
     in
     let raw_tools = `List [ Agent_core.Tool.schema_to_json tool ] in
-    Wire.capture_request ~base_path:base ~masc_root:base ~keeper_name:"sangsu"
+    Wire.capture_request ~base_path:base ~masc_root:base ~keeper_name:"alpha"
       ~turn_id:8
       ~agent_core_turn:2 ~system_prompt:"sys" ~extra_system_context:None
       ~user_message:"hello" ~history_messages:[] ~tools:[ tool ] ();
@@ -351,7 +351,7 @@ let tools_blob_is_shared_across_requests () =
     in
     let capture ~turn_id =
       Wire.capture_request ~base_path:base ~masc_root:base
-        ~keeper_name:"sangsu" ~turn_id ~agent_core_turn:1 ~system_prompt:"sys"
+        ~keeper_name:"alpha" ~turn_id ~agent_core_turn:1 ~system_prompt:"sys"
         ~extra_system_context:None ~user_message:"u" ~history_messages:[]
         ~tools:[ tool ] ()
     in
@@ -377,7 +377,7 @@ let request_trace_id_emitted () =
   with_flag "1" (fun () ->
     let base = Filename.temp_dir "wirecap_req_trace" "" in
     let trace_id = Keeper_id.For_testing.unsafe_trace_id_of_string "trace-req-abc" in
-    Wire.capture_request ~base_path:base ~masc_root:base ~keeper_name:"sangsu"
+    Wire.capture_request ~base_path:base ~masc_root:base ~keeper_name:"alpha"
       ~turn_id:1
       ~trace_id ~agent_core_turn:1 ~system_prompt:"sys" ~extra_system_context:None
       ~user_message:"hello" ~history_messages:[] ~tools:[] ();
@@ -406,7 +406,7 @@ let request_capture_failure_is_best_effort () =
 let response_disabled_is_noop () =
   with_flag "" (fun () ->
     let base = Filename.temp_dir "wirecap_resp_off" "" in
-    Wire.capture_response ~base_path:base ~masc_root:base ~keeper_name:"sangsu"
+    Wire.capture_response ~base_path:base ~masc_root:base ~keeper_name:"alpha"
       ~turn_id:1
       ~agent_core_turn:2 ~response_text:"anything" ();
     Alcotest.(check (list string))
@@ -415,8 +415,8 @@ let response_disabled_is_noop () =
 let response_capture_writes_redacted () =
   with_flag "1" (fun () ->
     let base = Filename.temp_dir "wirecap_resp_on" "" in
-    install_projected_secret ~base_path:base ~keeper_name:"sangsu";
-    Wire.capture_response ~base_path:base ~masc_root:base ~keeper_name:"sangsu"
+    install_projected_secret ~base_path:base ~keeper_name:"alpha";
+    Wire.capture_response ~base_path:base ~masc_root:base ~keeper_name:"alpha"
       ~turn_id:9
       ~agent_core_turn:4 ~response_text:("out " ^ projected_secret ^ " done") ();
     let files = find_jsonl base in
@@ -428,7 +428,7 @@ let response_capture_writes_redacted () =
       (contains ~needle:projected_secret content);
     Alcotest.(check bool) "redaction marker present" true
       (contains ~needle:"[REDACTED]" (json_string "response_text" json));
-    check_json_string "keeper name recorded" "keeper" "sangsu" json;
+    check_json_string "keeper name recorded" "keeper" "alpha" json;
     check_json_int "turn_id recorded" "turn_id" 9 json;
     check_json_int "agent_core_turn recorded" "agent_core_turn" 4 json;
     check_json_null "missing trace_id is null" "trace_id" json)
@@ -454,7 +454,7 @@ let response_trace_id_emitted () =
   with_flag "1" (fun () ->
     let base = Filename.temp_dir "wirecap_resp_trace" "" in
     let trace_id = Keeper_id.For_testing.unsafe_trace_id_of_string "trace-resp-xyz" in
-    Wire.capture_response ~base_path:base ~masc_root:base ~keeper_name:"sangsu"
+    Wire.capture_response ~base_path:base ~masc_root:base ~keeper_name:"alpha"
       ~turn_id:2
       ~agent_core_turn:1 ~trace_id ~response_text:"ok" ();
     let json = read_single_json_record base in
@@ -472,7 +472,7 @@ let capture_prunes_old_files () =
         ensure_dir old_month;
         let old_file = Filename.concat old_month "01.jsonl" in
         write_file old_file (String.make 1024 'x');
-        Wire.capture_response ~base_path:base ~masc_root:base ~keeper_name:"sangsu"
+        Wire.capture_response ~base_path:base ~masc_root:base ~keeper_name:"alpha"
           ~turn_id:10
           ~agent_core_turn:1 ~response_text:"bounded" ();
         Alcotest.(check bool) "old capture file pruned" false
@@ -516,13 +516,13 @@ let capture_cache_reloads_when_retention_changes () =
       let old_file = Filename.concat old_month old_day_name in
       write_file old_file (String.make 1024 'x');
       with_env "MASC_KEEPER_WIRE_CAPTURE_RETENTION_DAYS" "30" (fun () ->
-        Wire.capture_response ~base_path:base ~masc_root:base ~keeper_name:"sangsu"
+        Wire.capture_response ~base_path:base ~masc_root:base ~keeper_name:"alpha"
           ~turn_id:20
           ~agent_core_turn:1 ~response_text:"cache warmup" ());
       Alcotest.(check bool) "old capture retained by warm cache" true
         (Sys.file_exists old_file);
       with_env "MASC_KEEPER_WIRE_CAPTURE_RETENTION_DAYS" "1" (fun () ->
-        Wire.capture_response ~base_path:base ~masc_root:base ~keeper_name:"sangsu"
+        Wire.capture_response ~base_path:base ~masc_root:base ~keeper_name:"alpha"
           ~turn_id:21
           ~agent_core_turn:1 ~response_text:"cache reload" ());
       Alcotest.(check bool) "old capture pruned after retention change" false

--- a/test/test_librarian_journal_failures.ml
+++ b/test/test_librarian_journal_failures.ml
@@ -24,7 +24,7 @@ let with_keepers_dir f =
     (fun () -> f dir)
 ;;
 
-let keeper_id = "masc-improver"
+let keeper_id = "omicron-improver"
 
 let append_raw ~keepers_dir line =
   let path = Current.journal_path_for_keepers_dir ~keepers_dir ~keeper_id in

--- a/test/test_log_ring_encoder.ml
+++ b/test/test_log_ring_encoder.ml
@@ -40,14 +40,14 @@ let test_round_trip_all_sources () =
 
 let test_round_trip_optional_fields () =
   let with_optional =
-    entry_of ~keeper_name:"analyst" ~turn_id:7
+    entry_of ~keeper_name:"delta" ~turn_id:7
       ~details:(`Assoc [("k", `String "v")]) ()
   in
   let decoded =
     Log.Ring.entry_of_json (Log.Ring.entry_to_json with_optional)
   in
   Alcotest.(check (option string)) "keeper_name"
-    (Some "analyst") decoded.keeper_name;
+    (Some "delta") decoded.keeper_name;
   Alcotest.(check (option int)) "turn_id" (Some 7) decoded.turn_id;
   Alcotest.(check bool) "details preserved" true
     (decoded.details = `Assoc [("k", `String "v")])

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1836,7 +1836,7 @@ let test_execute_tool_hyphenated_generated_alias_claim_next_rejected_without_mut
   ignore (Masc.Workspace.init (Mcp_server.workspace_config state) ~agent_name:None);
   ignore (Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
   let raw_token =
-    match Auth.create_token base_path ~agent_name:"qa-king" ~role:Masc_domain.Admin with
+    match Auth.create_token base_path ~agent_name:"mu-king" ~role:Masc_domain.Admin with
     | Ok (token, _cred) -> token
     | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e)
   in
@@ -1849,7 +1849,7 @@ let test_execute_tool_hyphenated_generated_alias_claim_next_rejected_without_mut
       ~mcp_session_id:"sid-hyphenated-generated-alias"
       ~auth_token:raw_token state
       ~name:"keeper_task_claim"
-      ~arguments:(`Assoc [ ("agent_name", `String "qa-king-warm-heron") ])
+      ~arguments:(`Assoc [ ("agent_name", `String "mu-king-warm-heron") ])
   in
   Alcotest.(check bool) "claim_next rejected by public MCP path" false
     (Tool_result.is_success result);
@@ -2181,7 +2181,7 @@ let test_handle_request_tools_call_records_keeper_usage_for_public_mcp () =
       Keeper_registry.For_testing.clear ();
       cleanup_dir base_path)
     (fun () ->
-      let keeper_name = "sangsu" in
+      let keeper_name = "alpha" in
       let keeper_agent_name = Keeper_identity.keeper_agent_name keeper_name in
       let keeper_meta =
         make_keeper_meta ~agent_name:keeper_agent_name keeper_name
@@ -2219,7 +2219,7 @@ let test_handle_request_tools_call_records_keeper_usage_for_public_mcp () =
           Masc.Keeper_registry_tool_usage_persistence.flush ~base_path keeper_name;
           let persisted =
             Yojson.Safe.from_file
-              (Filename.concat base_path ".masc/keepers/tool_usage/sangsu.json")
+              (Filename.concat base_path ".masc/keepers/tool_usage/alpha.json")
           in
           let open Yojson.Safe.Util in
           Alcotest.(check int) "persisted schema version" 2
@@ -2273,7 +2273,7 @@ let test_handle_request_tools_call_records_keeper_usage_for_public_mcp () =
             (Some 1)
             (Option.map (fun restored -> restored.Keeper_types.count) restored);
           let persisted_path =
-            Filename.concat base_path ".masc/keepers/tool_usage/sangsu.json"
+            Filename.concat base_path ".masc/keepers/tool_usage/alpha.json"
           in
           Fs_compat.save_file
             persisted_path
@@ -2389,7 +2389,7 @@ let test_handle_request_tools_call_internal_keeper_runtime_rejects_unknown_execu
       cleanup_dir base_path)
     (fun () ->
       Keeper_registry.For_testing.clear ();
-      let keeper_name = "sangsu" in
+      let keeper_name = "alpha" in
       let keeper_agent_name = Keeper_identity.keeper_agent_name keeper_name in
       ignore
         (Keeper_registry.For_testing.register ~base_path keeper_name

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -636,7 +636,7 @@ let test_records_mcp_server_operation_duration_metric () =
 
 let test_runtime_mcp_keeper_log_context_uses_keeper_trace_and_current_turn () =
   let base_path = temp_dir () in
-  let keeper_name = "sangsu-context" in
+  let keeper_name = "alpha-context" in
   let meta =
     make_keeper_meta
       ~current_task_id:"task-123"
@@ -689,7 +689,7 @@ let test_runtime_mcp_keeper_log_context_loads_current_task_contract () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_path = temp_dir () in
-  let keeper_name = "sangsu-task-contract" in
+  let keeper_name = "alpha-task-contract" in
   let config = Masc.Workspace.default_config base_path in
   ignore (Masc.Workspace.init config ~agent_name:(Some keeper_name));
   let contract = empty_contract in
@@ -729,7 +729,7 @@ let test_record_runtime_mcp_keeper_tool_trace_logs_and_broadcasts () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_path = temp_dir () in
-  let keeper_name = "sangsu-runtime-mcp" in
+  let keeper_name = "alpha-runtime-mcp" in
   let meta =
     make_keeper_meta
       ~current_task_id:"task-456"

--- a/test/test_mcp_session_coverage.ml
+++ b/test/test_mcp_session_coverage.ml
@@ -216,7 +216,7 @@ let test_actor_injection_reducer_skips_absent_actor () =
 
 let test_actor_injection_reducer_rewrites_with_http_auth () =
   let body =
-    {|{"jsonrpc":"2.0","method":"tools/call","params":{"name":"masc_keeper_status","arguments":{"_agent_name":"dashboard","token":"stale-token","name":"sangsu"}},"id":1}|}
+    {|{"jsonrpc":"2.0","method":"tools/call","params":{"name":"masc_keeper_status","arguments":{"_agent_name":"dashboard","token":"stale-token","name":"alpha"}},"id":1}|}
   in
   let args =
     Actor_injection.reduce ~actor:(Some "codex") ~auth_token:(Some "token") body
@@ -227,7 +227,7 @@ let test_actor_injection_reducer_rewrites_with_http_auth () =
     (member "_agent_name" args |> to_string_option);
   check (option string) "actor reducer strips stale token" None
     (member "token" args |> to_string_option);
-  check (option string) "actor reducer preserves target name" (Some "sangsu")
+  check (option string) "actor reducer preserves target name" (Some "alpha")
     (member "name" args |> to_string_option)
 
 let test_body_with_canonical_http_actor_uses_token_owner () =
@@ -251,7 +251,7 @@ let test_body_with_canonical_http_actor_uses_token_owner () =
       in
       let request = Httpun.Request.create ~headers `POST "/mcp" in
       let body =
-        {|{"jsonrpc":"2.0","method":"tools/call","params":{"name":"masc_keeper_status","arguments":{"_agent_name":"dashboard","token":"stale-token","name":"sangsu"}},"id":1}|}
+        {|{"jsonrpc":"2.0","method":"tools/call","params":{"name":"masc_keeper_status","arguments":{"_agent_name":"dashboard","token":"stale-token","name":"alpha"}},"id":1}|}
       in
       let args =
         Http_transport.body_with_canonical_http_actor ~base_path:dir
@@ -264,7 +264,7 @@ let test_body_with_canonical_http_actor_uses_token_owner () =
         (member "_agent_name" args |> to_string_option);
       check (option string) "http auth strips stale argument token" None
         (member "token" args |> to_string_option);
-      check (option string) "tool target arg preserved" (Some "sangsu")
+      check (option string) "tool target arg preserved" (Some "alpha")
         (member "name" args |> to_string_option))
 
 (* ============================================================

--- a/test/test_minted_name_gate.ml
+++ b/test/test_minted_name_gate.ml
@@ -48,7 +48,7 @@ let test_resolved_external_never_transient_by_shape () =
     [
       "alice";
       "gemini";
-      "keeper-sangsu-agent";
+      "keeper-alpha-agent";
       "admin-board-keeper";
       "agent-foo";
       "role-swift-fox";

--- a/test/test_nickname_coverage.ml
+++ b/test/test_nickname_coverage.ml
@@ -90,8 +90,8 @@ let test_is_dictionary_generated_nickname_accepts_real () =
     (Nickname.is_dictionary_generated_nickname "claude-swift-fox");
   check bool "claude-swift-fox-a3b2" true
     (Nickname.is_dictionary_generated_nickname "claude-swift-fox-a3b2");
-  check bool "qa-king-warm-heron multi-part type" true
-    (Nickname.is_dictionary_generated_nickname "qa-king-warm-heron");
+  check bool "mu-king-warm-heron multi-part type" true
+    (Nickname.is_dictionary_generated_nickname "mu-king-warm-heron");
   check bool "fresh generated" true
     (Nickname.is_dictionary_generated_nickname (Nickname.generate "claude"));
   check bool "fresh unique" true
@@ -99,14 +99,14 @@ let test_is_dictionary_generated_nickname_accepts_real () =
        (Nickname.generate_unique "claude"))
 
 let test_is_dictionary_generated_nickname_rejects_structured () =
-  check bool "keeper-sangsu-agent" false
-    (Nickname.is_dictionary_generated_nickname "keeper-sangsu-agent");
-  check bool "keeper-issue_king-agent" false
-    (Nickname.is_dictionary_generated_nickname "keeper-issue_king-agent");
-  check bool "keeper-verifier-agent" false
-    (Nickname.is_dictionary_generated_nickname "keeper-verifier-agent");
-  check bool "keeper-nick0cave-agent" false
-    (Nickname.is_dictionary_generated_nickname "keeper-nick0cave-agent");
+  check bool "keeper-alpha-agent" false
+    (Nickname.is_dictionary_generated_nickname "keeper-alpha-agent");
+  check bool "keeper-kappa_keeper-agent" false
+    (Nickname.is_dictionary_generated_nickname "keeper-kappa_keeper-agent");
+  check bool "keeper-fixture-reviewer-agent" false
+    (Nickname.is_dictionary_generated_nickname "keeper-fixture-reviewer-agent");
+  check bool "keeper-theta0-agent" false
+    (Nickname.is_dictionary_generated_nickname "keeper-theta0-agent");
   check bool "admin-board-keeper" false
     (Nickname.is_dictionary_generated_nickname "admin-board-keeper");
   check bool "non-list adj/animal" false
@@ -150,14 +150,14 @@ let test_extract_agent_type_unique () =
   | None -> fail "should extract from unique"
 
 let test_extract_agent_type_hyphenated_manual () =
-  match Nickname.extract_agent_type "qa-king-warm-heron" with
-  | Some at -> check string "extracted qa-king" "qa-king" at
+  match Nickname.extract_agent_type "mu-king-warm-heron" with
+  | Some at -> check string "extracted mu-king" "mu-king" at
   | None -> fail "should extract hyphenated stable prefix"
 
 let test_extract_agent_type_hyphenated_unique () =
-  let nick = Nickname.generate_unique "qa-king" in
+  let nick = Nickname.generate_unique "mu-king" in
   match Nickname.extract_agent_type nick with
-  | Some at -> check string "extracted qa-king from unique" "qa-king" at
+  | Some at -> check string "extracted mu-king from unique" "mu-king" at
   | None -> fail "should extract hyphenated stable prefix from unique"
 
 (* ============================================================

--- a/test/test_observability_redact.ml
+++ b/test/test_observability_redact.ml
@@ -263,11 +263,11 @@ let test_no_false_positive_on_keeper_identities () =
   let inputs =
     [ "task-claim-bot"; "heartbeat-keeper"; "diagnostic-judge"
       (* 20+ char identities: these were redacted to [REDACTED] by the former
-         generic "20+ alphanumeric run" matcher (keeper-issue_king-agent=23,
-         keeper-ramarama-agent=21 chars) and are preserved now that the length
+         generic "20+ alphanumeric run" matcher (keeper-kappa_keeper-agent=23,
+         keeper-nu-agent=21 chars) and are preserved now that the length
          heuristic is removed. This is the regression the generic-matcher
          removal targets. *)
-    ; "keeper-issue_king-agent"; "keeper-ramarama-agent"
+    ; "keeper-kappa_keeper-agent"; "keeper-nu-agent"
     ; "task-claim-bot-9a8b7c6d"; "heartbeat-keeper-2f4a1b" ]
   in
   List.iter

--- a/test/test_official_client_session_store.ml
+++ b/test/test_official_client_session_store.ml
@@ -359,7 +359,7 @@ let test_moved_tool_surface_starts_fresh () =
    operator's judgement on what a crash left behind; the owner knows the turn
    did not finish and why, and already classifies the operation as
    Turn_cancelled. Routing it to Recovery_required blocked every later turn for
-   that keeper until someone resolved it by hand -- kidsnote re-entered three
+   that keeper until someone resolved it by hand -- gamma re-entered three
    minutes after being cleared (#28012). *)
 let test_owner_stop_releases_without_recovery () =
   check bool

--- a/test/test_playground_paths.ml
+++ b/test/test_playground_paths.ml
@@ -8,8 +8,8 @@ module PP = Playground_paths
 
 let test_sanitize_allows_safe_chars () =
   check string "alphanumerics pass through"
-    "cheolsu_1.2-test"
-    (PP.sanitize_keeper_name "cheolsu_1.2-test");
+    "beta_1.2-test"
+    (PP.sanitize_keeper_name "beta_1.2-test");
   check string "already sanitized stays the same"
     "Abc-123_x.y"
     (PP.sanitize_keeper_name "Abc-123_x.y")
@@ -40,8 +40,8 @@ let test_all_playgrounds_prefix_stable () =
 
 let test_bundle_root_format () =
   check string "bundle root has trailing slash"
-    ".masc/playground/cheolsu/"
-    (PP.bundle_root "cheolsu");
+    ".masc/playground/beta/"
+    (PP.bundle_root "beta");
   check string "bundle root sanitizes name"
     ".masc/playground/a_b/"
     (PP.bundle_root "a/b")
@@ -82,17 +82,17 @@ let test_strip_canonical_to_short () =
   check string "short stays short"
     "omicron-improver"
     (PP.sanitize_keeper_name "omicron-improver");
-  check string "cheolsu canonical"
-    "cheolsu"
-    (PP.sanitize_keeper_name "keeper-cheolsu-agent");
+  check string "beta canonical"
+    "beta"
+    (PP.sanitize_keeper_name "keeper-beta-agent");
   check string "alpha canonical"
     "alpha"
     (PP.sanitize_keeper_name "keeper-alpha-agent")
 
 let test_canonical_short_path_identity () =
   check string "bundle_root identity"
-    (PP.bundle_root "cheolsu")
-    (PP.bundle_root "keeper-cheolsu-agent")
+    (PP.bundle_root "beta")
+    (PP.bundle_root "keeper-beta-agent")
 
 let test_strip_edge_cases () =
   check string "keeper-agent not stripped (inner would be empty)"
@@ -108,10 +108,10 @@ let test_strip_edge_cases () =
   check string "different keepers stay different"
     "alpha"
     (PP.sanitize_keeper_name "keeper-alpha-agent");
-  check bool "alpha != cheolsu after normalize"
+  check bool "alpha != beta after normalize"
     true
     (PP.sanitize_keeper_name "keeper-alpha-agent"
-     <> PP.sanitize_keeper_name "keeper-cheolsu-agent")
+     <> PP.sanitize_keeper_name "keeper-beta-agent")
 
 let test_strip_no_traversal () =
   let result = PP.sanitize_keeper_name "keeper-../../etc-agent" in
@@ -155,25 +155,25 @@ let test_parse_playground_file_path () =
   in
   check bool "local playground artifact"
     true
-    (parse ".masc/playground/executor/artifact.txt"
+    (parse ".masc/playground/omega/artifact.txt"
      = parsed "omega" "artifact.txt");
   check bool "docker playground artifact"
     true
-    (parse ".masc/playground/docker/executor/artifact.txt"
+    (parse ".masc/playground/docker/omega/artifact.txt"
      = parsed "omega" "artifact.txt");
   check bool "nested artifact"
     true
-    (parse ".masc/playground/docker/executor/scratch/report.txt"
+    (parse ".masc/playground/docker/omega/scratch/report.txt"
      = parsed "omega" "scratch/report.txt");
   check bool "outside playground rejected"
     true
     (parse "workspace/report.txt" = None);
   check bool "dot-dot segment rejected"
     true
-    (parse ".masc/playground/executor/../other/secret.txt" = None);
+    (parse ".masc/playground/omega/../other/secret.txt" = None);
   check bool "bundle root alone rejected"
     true
-    (parse ".masc/playground/executor" = None)
+    (parse ".masc/playground/omega" = None)
 
 let () =
   run "Playground_paths"

--- a/test/test_playground_paths.ml
+++ b/test/test_playground_paths.ml
@@ -77,17 +77,17 @@ let test_no_path_escape () =
 
 let test_strip_canonical_to_short () =
   check string "canonical stripped to short"
-    "masc-improver"
-    (PP.sanitize_keeper_name "keeper-masc-improver-agent");
+    "omicron-improver"
+    (PP.sanitize_keeper_name "keeper-omicron-improver-agent");
   check string "short stays short"
-    "masc-improver"
-    (PP.sanitize_keeper_name "masc-improver");
+    "omicron-improver"
+    (PP.sanitize_keeper_name "omicron-improver");
   check string "cheolsu canonical"
     "cheolsu"
     (PP.sanitize_keeper_name "keeper-cheolsu-agent");
-  check string "sangsu canonical"
-    "sangsu"
-    (PP.sanitize_keeper_name "keeper-sangsu-agent")
+  check string "alpha canonical"
+    "alpha"
+    (PP.sanitize_keeper_name "keeper-alpha-agent")
 
 let test_canonical_short_path_identity () =
   check string "bundle_root identity"
@@ -102,15 +102,15 @@ let test_strip_edge_cases () =
     "x"
     (PP.sanitize_keeper_name "keeper-x-agent");
   check string "idempotent"
-    (PP.sanitize_keeper_name "masc-improver")
+    (PP.sanitize_keeper_name "omicron-improver")
     (PP.sanitize_keeper_name
-       (PP.sanitize_keeper_name "keeper-masc-improver-agent"));
+       (PP.sanitize_keeper_name "keeper-omicron-improver-agent"));
   check string "different keepers stay different"
-    "sangsu"
-    (PP.sanitize_keeper_name "keeper-sangsu-agent");
-  check bool "sangsu != cheolsu after normalize"
+    "alpha"
+    (PP.sanitize_keeper_name "keeper-alpha-agent");
+  check bool "alpha != cheolsu after normalize"
     true
-    (PP.sanitize_keeper_name "keeper-sangsu-agent"
+    (PP.sanitize_keeper_name "keeper-alpha-agent"
      <> PP.sanitize_keeper_name "keeper-cheolsu-agent")
 
 let test_strip_no_traversal () =
@@ -129,10 +129,10 @@ let test_parse_playground_repo_path () =
   in
   check (option (pair string string)) "local sandbox path"
     (Some ("masc", "lib/foo.ml"))
-    (parse ".masc/playground/sangsu/repos/masc/lib/foo.ml");
+    (parse ".masc/playground/alpha/repos/masc/lib/foo.ml");
   check (option (pair string string)) "docker sandbox path"
     (Some ("masc", "lib/foo.ml"))
-    (parse ".masc/playground/docker/sangsu/repos/masc/lib/foo.ml");
+    (parse ".masc/playground/docker/alpha/repos/masc/lib/foo.ml");
   check (option (pair string string)) "keeper named repos"
     (Some ("masc", "lib/foo.ml"))
     (parse ".masc/playground/repos/repos/masc/lib/foo.ml");
@@ -141,7 +141,7 @@ let test_parse_playground_repo_path () =
     (parse ".masc/playground/docker/repos/repos/masc/lib/foo.ml");
   check (option (pair string string)) "nested repo-local pattern is not sandbox"
     None
-    (parse "workspace/repo/.masc/playground/sangsu/repos/masc/lib/foo.ml")
+    (parse "workspace/repo/.masc/playground/alpha/repos/masc/lib/foo.ml")
 
 let test_parse_playground_file_path () =
   let base_path = "/tmp/masc-base" in
@@ -156,15 +156,15 @@ let test_parse_playground_file_path () =
   check bool "local playground artifact"
     true
     (parse ".masc/playground/executor/artifact.txt"
-     = parsed "executor" "artifact.txt");
+     = parsed "omega" "artifact.txt");
   check bool "docker playground artifact"
     true
     (parse ".masc/playground/docker/executor/artifact.txt"
-     = parsed "executor" "artifact.txt");
+     = parsed "omega" "artifact.txt");
   check bool "nested artifact"
     true
     (parse ".masc/playground/docker/executor/scratch/report.txt"
-     = parsed "executor" "scratch/report.txt");
+     = parsed "omega" "scratch/report.txt");
   check bool "outside playground rejected"
     true
     (parse "workspace/report.txt" = None);

--- a/test/test_review_prompt_sections_reach_the_model.ml
+++ b/test/test_review_prompt_sections_reach_the_model.ml
@@ -41,7 +41,7 @@ let review_prompt_keys =
 let marker name = Printf.sprintf "@@SECTION_%s_REACHED@@" (String.uppercase_ascii name)
 
 let request : AR.review_request =
-  { agent_name = "keeper-taskmaster-agent"
+  { agent_name = "keeper-fixture-agent"
   ; task_title = marker "task_title"
   ; task_description = marker "task_description"
   ; completion_notes = marker "completion_notes"

--- a/test/test_run_local_script.ml
+++ b/test/test_run_local_script.ml
@@ -107,12 +107,12 @@ let make_config_root root =
   config
 
 let write_keeper_seed repo_root =
-  mkdir_p (Filename.concat repo_root "config/keepers/sangsu");
+  mkdir_p (Filename.concat repo_root "config/keepers/alpha");
   write_file
-    (Filename.concat repo_root "config/keepers/sangsu.toml")
+    (Filename.concat repo_root "config/keepers/alpha.toml")
     "[keeper]\nautoboot_enabled = true\n";
   write_file
-    (Filename.concat repo_root "config/keepers/sangsu/AGENT.md")
+    (Filename.concat repo_root "config/keepers/alpha/AGENT.md")
     "Keep working autonomously.\n"
 
 let write_fake_eio_exe exe_path =
@@ -169,7 +169,7 @@ let test_bootstraps_local_config_and_sets_http_only_env () =
         (Sys.file_exists (Filename.concat target_abs ".masc/config/runtime.json"));
       check bool "bootstrapped keepers excluded by default" false
         (Sys.file_exists
-           (Filename.concat target_abs ".masc/config/keepers/sangsu.toml"));
+           (Filename.concat target_abs ".masc/config/keepers/alpha.toml"));
       check bool "base path set" true
         (String_util.contains_substring captured ("MASC_BASE_PATH=" ^ target_abs));
       check bool "config dir set" true
@@ -206,7 +206,7 @@ let test_bootstrap_keepers_flag_is_opt_in () =
         failf "run-local bootstrap-keepers failed (%d)\nstdout:\n%s\nstderr:\n%s"
           code stdout stderr;
       check bool "bootstrapped keeper copied with flag" true
-        (Sys.file_exists (Filename.concat target ".masc/config/keepers/sangsu.toml"));
+        (Sys.file_exists (Filename.concat target ".masc/config/keepers/alpha.toml"));
       check bool "keepers included message" true
         (String_util.contains_substring stderr "keepers included"))
 

--- a/test/test_run_registry_concurrent_mutation.ml
+++ b/test/test_run_registry_concurrent_mutation.ml
@@ -46,7 +46,7 @@ let register t ~verification_id ~started_at =
     t
     ~verification_id
     ~task_id:"task-concurrent"
-    ~producer:"keeper-rondo-agent"
+    ~producer:"keeper-beta-agent"
     ~authority_kind:"system_llm_agent"
     ~authority_actor:("system-llm-agent-" ^ verification_id)
     ~started_at
@@ -149,7 +149,7 @@ let register_exact t ~run_id =
     ~run_id
     ~lane:Ex.Board_attention
     ~subject_id:("cand-" ^ run_id)
-    ~actor:"keeper-rondo-agent"
+    ~actor:"keeper-beta-agent"
     ~started_at:100.0
     ~input:(Ex.Exact_input (`Assoc []))
 ;;

--- a/test/test_runtime_agent_advanced_outcome.ml
+++ b/test/test_runtime_agent_advanced_outcome.ml
@@ -1,6 +1,6 @@
 (* Pure-decision tests for [Runtime_agent.classify_advanced_outcome].
 
-   Live defect (2026-08-14, sangsu discord-msg-1537658864005021797): a
+   Live defect (2026-08-14, alpha discord-msg-1537658864005021797): a
    terminal-contract tool delivered its effect, Agent Core ended the run with
    [Terminal_tool_completed], and the runtime mapped that success to
    [Internal "runtime_agent_terminal_tool_completion_unsupported"] — an error

--- a/test/test_runtime_antigravity.ml
+++ b/test/test_runtime_antigravity.ml
@@ -398,7 +398,7 @@ let test_duplicate_keys_fail_closed () =
 
 (* A live init event announced request-review. It was not modelled, the parse
    failed, and the resulting protocol error put the official-client session in
-   Recovery_required -- taskmaster, 110 turns in one hour (#28008).
+   Recovery_required -- fixture-keeper, 110 turns in one hour (#28008).
 
    Nothing branches on [permission_mode]: the only read of the field is its own
    parse site. Naming the one member that stalled a keeper leaves the next one
@@ -422,7 +422,7 @@ let test_observed_permission_modes_are_admitted () =
 ;;
 
 (* #28029 opened step_type with [Unrecognized] after Antigravity began emitting
-   "system_message" and taskmaster stopped. #28037 closed it again and named
+   "system_message" and fixture-keeper stopped. #28037 closed it again and named
    [System_message] instead -- which admits the value that already stalled a
    keeper and leaves the next one to stall it again. Nothing branches on
    [System_message]: it appears at its declaration and at the parse site only.

--- a/test/test_runtime_antigravity_home.ml
+++ b/test/test_runtime_antigravity_home.ml
@@ -29,14 +29,14 @@ let test_prepares_private_home_with_oauth_seed () =
   let layout =
     Runtime_antigravity_home.prepare
       ~runtime_root
-      ~owner_leaf:"keeper-sangsu"
+      ~owner_leaf:"keeper-alpha"
       ~oauth_source
     |> require_ok
   in
   let expected_home =
     Filename.concat runtime_root "official-clients"
     |> fun path -> Filename.concat path "antigravity"
-    |> fun path -> Filename.concat path "keeper-sangsu"
+    |> fun path -> Filename.concat path "keeper-alpha"
   in
   let home_dir = Runtime_antigravity_home.home_dir layout in
   let paths = Runtime_antigravity_home.For_testing.paths layout in
@@ -94,7 +94,7 @@ let test_rejects_non_private_or_indirect_oauth_source () =
   (match
      Runtime_antigravity_home.prepare
        ~runtime_root
-       ~owner_leaf:"keeper-sangsu"
+       ~owner_leaf:"keeper-alpha"
        ~oauth_source
    with
    | Error (Runtime_antigravity_home.Invalid_oauth_source _) -> ()
@@ -108,7 +108,7 @@ let test_rejects_non_private_or_indirect_oauth_source () =
   match
     Runtime_antigravity_home.prepare
       ~runtime_root
-      ~owner_leaf:"keeper-sangsu"
+      ~owner_leaf:"keeper-alpha"
       ~oauth_source:oauth_symlink
   with
   | Error (Runtime_antigravity_home.Invalid_oauth_source _) -> ()
@@ -124,7 +124,7 @@ let test_preserves_runtime_managed_oauth_after_initial_seed () =
   let layout =
     Runtime_antigravity_home.prepare
       ~runtime_root
-      ~owner_leaf:"keeper-sangsu"
+      ~owner_leaf:"keeper-alpha"
       ~oauth_source
     |> require_ok
   in
@@ -134,7 +134,7 @@ let test_preserves_runtime_managed_oauth_after_initial_seed () =
   let refreshed =
     Runtime_antigravity_home.prepare
       ~runtime_root
-      ~owner_leaf:"keeper-sangsu"
+      ~owner_leaf:"keeper-alpha"
       ~oauth_source
     |> require_ok
   in
@@ -163,7 +163,7 @@ let test_rejects_unsafe_existing_runtime_oauth () =
   let layout =
     Runtime_antigravity_home.prepare
       ~runtime_root
-      ~owner_leaf:"keeper-sangsu"
+      ~owner_leaf:"keeper-alpha"
       ~oauth_source
     |> require_ok
   in
@@ -172,7 +172,7 @@ let test_rejects_unsafe_existing_runtime_oauth () =
   match
     Runtime_antigravity_home.prepare
       ~runtime_root
-      ~owner_leaf:"keeper-sangsu"
+      ~owner_leaf:"keeper-alpha"
       ~oauth_source
   with
   | Error (Runtime_antigravity_home.Invalid_managed_oauth _) -> ()
@@ -188,7 +188,7 @@ let test_mcp_capability_is_turn_scoped () =
   let layout =
     Runtime_antigravity_home.prepare
       ~runtime_root
-      ~owner_leaf:"keeper-sangsu"
+      ~owner_leaf:"keeper-alpha"
       ~oauth_source
     |> require_ok
   in

--- a/test/test_runtime_codex_app_server.ml
+++ b/test/test_runtime_codex_app_server.ml
@@ -620,7 +620,7 @@ let test_failed_turn_uses_official_context_error_enum () =
 
 (* The named-field form could not distinguish "the server sent no scalar" from
    "the scalar is called something else": both printed the sentence with no
-   annotation. That is what live sangsu produced on 2026-08-11 after the narrow
+   annotation. That is what live alpha produced on 2026-08-11 after the narrow
    form deployed. This fixture carries no [code] and no [type], so it renders
    the sentence unannotated under the named form and fails there. The
    expectations are literals rather than a re-render of the function, and one
@@ -1100,8 +1100,8 @@ let test_item_output_deltas_are_typed_and_unbounded () =
    this decoder never reads the payload. It used to reject both, which ended
    the turn, put the official-client session into Recovery_required, and made
    every later turn for that keeper fail closed until an operator resolved it
-   by hand: three such chunks accounted for 3,236 rejected turns across sangsu,
-   kidsnote and taskmaster in one retained log window (#27967).
+   by hand: three such chunks accounted for 3,236 rejected turns across alpha,
+   gamma and fixture-keeper in one retained log window (#27967).
 
    The rejections that must survive are in the same test, because widening a
    decoder is only correct if it stops accepting nothing else: an empty

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -840,7 +840,7 @@ let test_model_without_reasoning_effort_leaves_it_unset () =
    entirely (claude-code, codex-app-server, both fixed at 300s in the adapter).
    A max-effort binding could therefore not be given more wall clock than a
    low-effort one sharing its provider. Live evidence, 2026-08-10: keeper
-   analyst on claude_code.claude-opus-5-max failed every turn with "timed out
+   delta on claude_code.claude-opus-5-max failed every turn with "timed out
    after 300.000s" at 5,884 bytes of system+user input.
 
    The rejection case is the load-bearing one, but only for values that state

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -271,7 +271,7 @@ let runtime_config_messages_http =
 default = "kimi.kimi-for-coding"
 
 [runtime.assignments]
-ramarama = "kimi.kimi-for-coding"
+nu = "kimi.kimi-for-coding"
 
 [providers.kimi]
 display-name = "Kimi Code Plan"
@@ -389,9 +389,9 @@ let test_messages_http_runtime_loads_and_assignment_resolves () =
          Alcotest.failf "messages-http runtime init_default failed: %s" msg
        | Ok () ->
          Alcotest.(check string)
-           "ramarama assignment resolves to kimi.kimi-for-coding"
+           "nu assignment resolves to kimi.kimi-for-coding"
            "kimi.kimi-for-coding"
-           (KMC.runtime_id_of_meta (make_meta "ramarama"));
+           (KMC.runtime_id_of_meta (make_meta "nu"));
          Alcotest.(check bool)
            "messages-http runtime is materialized"
            true
@@ -1759,7 +1759,7 @@ let test_historical_qwen36_context_overflow_fixture_replays_provider_cap () =
    Regression guard for messages-http boot diagnostics (2026-07-03): an
    unregistered [messages-http] provider binding cannot be materialized into a
    provider_config, so it is dropped from the runtime list. An assignment
-   targeting it used to report the misleading "[runtime.assignments].ramarama =
+   targeting it used to report the misleading "[runtime.assignments].nu =
    ... not found among N runtimes" — pointing the operator at a typo that does
    not exist — when the real cause is that the binding was defined but failed to
    materialize. Behavior is unchanged (the binding is still excluded,
@@ -1768,7 +1768,7 @@ let test_historical_qwen36_context_overflow_fixture_replays_provider_cap () =
    "not found among N runtimes". Registered providers such as Kimi keep using
    the provider registry SSOT to materialize their messages-compatible kind. *)
 
-(* [ramarama] is assigned [local.kimi-for-coding], a defined binding whose
+(* [nu] is assigned [local.kimi-for-coding], a defined binding whose
    provider uses protocol messages-http but has no provider-registry entry. The
    default [openai.gpt] materializes so validation reaches the assignment. *)
 let runtime_config_messages_http_assignment =
@@ -1777,7 +1777,7 @@ let runtime_config_messages_http_assignment =
 default = "openai.gpt"
 
 [runtime.assignments]
-ramarama = "local.kimi-for-coding"
+nu = "local.kimi-for-coding"
 
 [providers.openai]
 display-name = "OpenAI"
@@ -1810,7 +1810,7 @@ max-concurrent = 1
 |}
 ;;
 
-(* [ramarama] is assigned [bogus.binding], which names no declared binding at
+(* [nu] is assigned [bogus.binding], which names no declared binding at
    all — the genuine operator-typo case whose "not found among N runtimes"
    message must be preserved. *)
 let runtime_config_typo_assignment =
@@ -1819,7 +1819,7 @@ let runtime_config_typo_assignment =
 default = "openai.gpt"
 
 [runtime.assignments]
-ramarama = "bogus.binding"
+nu = "bogus.binding"
 
 [providers.openai]
 display-name = "OpenAI"

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1228,8 +1228,8 @@ let test_otel_exporter_setup_failure_is_soft () =
     (Otel_spans.is_exporter_active ());
   Otel_spans.shutdown ~enabled:true ()
 
-let make_keeper_meta_json ?(name = "sangsu")
-    ?(trace_id = "trace-sangsu-live")
+let make_keeper_meta_json ?(name = "alpha")
+    ?(trace_id = "trace-alpha-live")
     ?(updated_at = "2026-03-29T10:36:57Z") () =
   match
     Masc_test_deps.meta_of_json_fixture
@@ -1244,8 +1244,8 @@ let make_keeper_meta_json ?(name = "sangsu")
   | Ok meta -> Keeper_meta_json.meta_to_json meta |> Yojson.Safe.pretty_to_string
   | Error err -> Alcotest.fail ("meta_of_json failed: " ^ err)
 
-let make_keeper_meta ?(paused = false) ?(name = "sangsu")
-    ?(trace_id = "trace-sangsu-live")
+let make_keeper_meta ?(paused = false) ?(name = "alpha")
+    ?(trace_id = "trace-alpha-live")
     ?(updated_at = "2026-03-29T10:36:57Z") () =
   match
     Masc_test_deps.meta_of_json_fixture
@@ -1748,7 +1748,7 @@ let test_keeper_identity_drift_health_json_surfaces_config_meta_split () =
         Server_auth.For_testing.restore_server_state @@ Some state;
         let config = Mcp_server.workspace_config state in
         write_keeper_meta_exn config
-          (make_keeper_meta ~name:"masc-improver" ~trace_id:"trace-masc-improver" ());
+          (make_keeper_meta ~name:"omicron-improver" ~trace_id:"trace-omicron-improver" ());
         write_keeper_meta_exn config
           (make_keeper_meta ~name:"operator" ~trace_id:"trace-operator" ());
         let json =
@@ -1776,14 +1776,14 @@ let test_keeper_identity_drift_health_json_surfaces_config_meta_split () =
           (json |> member "materializable_configured_keeper_names" |> to_list
            |> List.map to_string);
         Alcotest.(check (list string)) "persisted meta includes disabled keeper"
-          [ "masc-improver"; "operator" ]
+          [ "omicron-improver"; "operator" ]
           (json |> member "persisted_meta_names" |> to_list |> List.map to_string);
         Alcotest.(check (list string)) "configured without meta"
           [ "mad-improver" ]
           (json |> member "configured_without_meta_names" |> to_list
            |> List.map to_string);
         Alcotest.(check (list string)) "meta without config"
-          [ "masc-improver" ]
+          [ "omicron-improver" ]
           (json |> member "meta_without_config_names" |> to_list
            |> List.map to_string);
         Alcotest.(check string) "drift next action"
@@ -1891,7 +1891,7 @@ let test_health_json_reports_dormant_task_owner_as_advisory () =
     let config_root = make_config_root dir in
     Sys.remove (Filename.concat (Filename.concat config_root "keepers") "example.toml");
     write_file
-      (Filename.concat (Filename.concat config_root "keepers") "executor.toml")
+      (Filename.concat (Filename.concat config_root "keepers") "omega.toml")
       "[keeper]\nautoboot_enabled = false\n";
     with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
     let previous_state = Server_auth.For_testing.snapshot_server_state () in
@@ -1905,7 +1905,7 @@ let test_health_json_reports_dormant_task_owner_as_advisory () =
         Server_auth.For_testing.restore_server_state @@ Some state;
         let config = Mcp_server.workspace_config state in
         let executor =
-          make_keeper_meta ~name:"executor" ~trace_id:"trace-executor" ()
+          make_keeper_meta ~name:"omega" ~trace_id:"trace-omega" ()
         in
         write_keeper_meta_exn config executor;
         let task =
@@ -1968,7 +1968,7 @@ let test_health_json_ignores_stale_active_task_alias_when_agent_executable () =
   with_temp_dir "health-active-task-owner-executable-alias" (fun dir ->
     let config_root = make_config_root dir in
     Sys.remove (Filename.concat (Filename.concat config_root "keepers") "example.toml");
-    List.iter (write_config_root_keeper_toml config_root) [ "executor"; "executor-stale" ];
+    List.iter (write_config_root_keeper_toml config_root) [ "omega"; "omega-stale" ];
     with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
     let previous_state = Server_auth.For_testing.snapshot_server_state () in
     Config_dir_resolver.reset ();
@@ -1981,13 +1981,13 @@ let test_health_json_ignores_stale_active_task_alias_when_agent_executable () =
         Server_auth.For_testing.restore_server_state @@ Some state;
         let config = Mcp_server.workspace_config state in
         let executor =
-          make_keeper_meta ~name:"executor" ~trace_id:"trace-executor" ()
+          make_keeper_meta ~name:"omega" ~trace_id:"trace-omega" ()
         in
         let stale_executor =
           {
             (make_keeper_meta
-               ~name:"executor-stale"
-               ~trace_id:"trace-executor-stale"
+               ~name:"omega-stale"
+               ~trace_id:"trace-omega-stale"
                ())
             with
             Keeper_meta_contract.agent_name = executor.agent_name;
@@ -4575,7 +4575,7 @@ let test_sync_bootable_keeper_credentials_mints_keeper_alias_token () =
       with_env "MASC_CONFIG_DIR" None @@ fun () ->
       with_cwd (project_root ()) @@ fun () ->
       Server_runtime_bootstrap.bootstrap_base_path_config_root ~base_path:dir;
-      write_basepath_keeper_toml dir "masc-improver";
+      write_basepath_keeper_toml dir "omicron-improver";
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let clock, mono_clock, net, _domain_mgr, proc_mgr, fs =
@@ -4594,15 +4594,15 @@ let test_sync_bootable_keeper_credentials_mints_keeper_alias_token () =
         | _ -> Alcotest.fail "missing internal keeper token after startup sync"
       in
       let raw_token_path =
-        Filename.concat (Auth.auth_dir dir) "keeper-masc-improver-agent.token"
+        Filename.concat (Auth.auth_dir dir) "keeper-omicron-improver-agent.token"
       in
       let raw_token = String.trim (read_file raw_token_path) in
       let credential =
-        match Auth.load_credential dir "keeper-masc-improver-agent" with
+        match Auth.load_credential dir "keeper-omicron-improver-agent" with
         | Some cred -> cred
         | None ->
             Alcotest.fail
-              "missing keeper-masc-improver-agent credential after startup sync"
+              "missing keeper-omicron-improver-agent credential after startup sync"
       in
       Alcotest.(check bool) "internal keeper token hash persisted" true
         (Sys.file_exists (Auth.internal_keeper_token_hash_file dir));
@@ -4611,12 +4611,12 @@ let test_sync_bootable_keeper_credentials_mints_keeper_alias_token () =
       Alcotest.(check bool) "keeper bearer separated from internal token" false
         (String.equal raw_token internal_raw_token);
       match
-        Auth.verify_token dir ~agent_name:"keeper-masc-improver-agent"
+        Auth.verify_token dir ~agent_name:"keeper-omicron-improver-agent"
           ~token:raw_token
       with
       | Ok alias_cred ->
           Alcotest.(check string) "keeper credential resolves exact agent"
-            "keeper-masc-improver-agent" alias_cred.agent_name
+            "keeper-omicron-improver-agent" alias_cred.agent_name
       | Error err ->
           Alcotest.failf "bootable keeper token should verify exactly: %s"
             (Masc_domain.masc_error_to_string err))
@@ -4627,8 +4627,8 @@ let test_sync_bootable_keeper_credentials_rotates_shared_keeper_tokens () =
       with_env "MASC_CONFIG_DIR" None @@ fun () ->
       with_cwd (project_root ()) @@ fun () ->
       Server_runtime_bootstrap.bootstrap_base_path_config_root ~base_path:dir;
-      write_basepath_keeper_toml dir "analyst";
-      write_basepath_keeper_toml dir "executor";
+      write_basepath_keeper_toml dir "delta";
+      write_basepath_keeper_toml dir "omega";
       let shared_raw_token = "shared-keeper-bootstrap-token" in
       let seed agent_name =
         match
@@ -4643,8 +4643,8 @@ let test_sync_bootable_keeper_credentials_rotates_shared_keeper_tokens () =
             Alcotest.failf "failed to seed shared credential for %s: %s"
               agent_name (Masc_domain.masc_error_to_string err)
       in
-      seed "keeper-analyst-agent";
-      seed "keeper-executor-agent";
+      seed "keeper-delta-agent";
+      seed "keeper-omega-agent";
       Alcotest.(check int) "seeded one duplicate group"
         1 (List.length (Auth.audit_token_uniqueness dir));
       Eio_main.run @@ fun env ->
@@ -4659,21 +4659,21 @@ let test_sync_bootable_keeper_credentials_rotates_shared_keeper_tokens () =
       in
       Server_runtime_bootstrap.bootstrap_server_state_blocking state;
       Server_runtime_bootstrap.sync_bootable_keeper_credentials state;
-      let analyst =
-        match Auth.load_credential dir "keeper-analyst-agent" with
+      let delta =
+        match Auth.load_credential dir "keeper-delta-agent" with
         | Some cred -> cred
-        | None -> Alcotest.fail "missing keeper-analyst-agent credential"
+        | None -> Alcotest.fail "missing keeper-delta-agent credential"
       in
       let executor =
-        match Auth.load_credential dir "keeper-executor-agent" with
+        match Auth.load_credential dir "keeper-omega-agent" with
         | Some cred -> cred
-        | None -> Alcotest.fail "missing keeper-executor-agent credential"
+        | None -> Alcotest.fail "missing keeper-omega-agent credential"
       in
       Alcotest.(check bool) "boot repair made keeper tokens unique" false
-        (String.equal analyst.token executor.token);
+        (String.equal delta.token executor.token);
       Alcotest.(check int) "audit clean after boot repair"
         0 (List.length (Auth.audit_token_uniqueness dir));
-      [ "keeper-analyst-agent"; "keeper-executor-agent" ]
+      [ "keeper-delta-agent"; "keeper-omega-agent" ]
       |> List.iter (fun agent_name ->
              let raw_token_path =
                Filename.concat (Auth.auth_dir dir) (agent_name ^ ".token")

--- a/test/test_server_slack_gateway_attention.ml
+++ b/test/test_server_slack_gateway_attention.ml
@@ -36,7 +36,7 @@ let pending ~base_path ~keeper_name =
 let record ~base_path ?(team_id = Some "T1") ?(thread_ts = None) ~ts ~route
     ~urgency () =
   G.For_testing.record_external_attention ~base_dir:base_path
-    ~keeper_name:"sangsu" ~team_id ~channel_id:"C1" ~thread_ts ~ts
+    ~keeper_name:"alpha" ~team_id ~channel_id:"C1" ~thread_ts ~ts
     ~user_id:"U1" ~user_name:(Some "user-one") ~content:"hello keeper"
     ~mentions_bot:(urgency = A.Mention) ~route ~urgency
 
@@ -46,7 +46,7 @@ let test_triggered_record_is_pending_with_slack_surface () =
           ~urgency:A.Mention () with
   | None -> fail "record returned None"
   | Some event_id -> (
-    match pending ~base_path ~keeper_name:"sangsu" with
+    match pending ~base_path ~keeper_name:"alpha" with
     | [ item ] ->
       check string "event id" event_id item.A.event_id;
       check string "urgency" "mention" (A.urgency_to_string item.A.urgency);
@@ -67,7 +67,7 @@ let test_ambient_record_uses_ambient_urgency () =
           ~urgency:A.Ambient () with
   | None -> fail "record returned None"
   | Some _ -> (
-    match pending ~base_path ~keeper_name:"sangsu" with
+    match pending ~base_path ~keeper_name:"alpha" with
     | [ item ] ->
       check string "urgency" "ambient" (A.urgency_to_string item.A.urgency)
     | items ->
@@ -84,7 +84,7 @@ let test_duplicate_wire_delivery_keeps_one_pending () =
       ~urgency:A.Mention ()
   in
   check (option string) "same event id" first second;
-  check int "one pending" 1 (List.length (pending ~base_path ~keeper_name:"sangsu"))
+  check int "one pending" 1 (List.length (pending ~base_path ~keeper_name:"alpha"))
 
 let test_sent_reply_retires_attention () =
   with_temp_base "slack-attention-resolve" @@ fun base_path ->
@@ -93,11 +93,11 @@ let test_sent_reply_retires_attention () =
   | None -> fail "record returned None"
   | Some event_id ->
     check int "pending before reply" 1
-      (List.length (pending ~base_path ~keeper_name:"sangsu"));
+      (List.length (pending ~base_path ~keeper_name:"alpha"));
     G.For_testing.mark_attention_resolved ~base_dir:base_path
-      ~keeper_name:"sangsu" ~event_id ~reason:"slack_reply_sent";
+      ~keeper_name:"alpha" ~event_id ~reason:"slack_reply_sent";
     check int "pending after reply" 0
-      (List.length (pending ~base_path ~keeper_name:"sangsu"))
+      (List.length (pending ~base_path ~keeper_name:"alpha"))
 
 (* Inbound identity rendering (issue #28376): the lane-shared mapping
    resolves the author label and rewrites mention escapes, and never touches

--- a/test/test_sse_external_sub.ml
+++ b/test/test_sse_external_sub.ml
@@ -84,7 +84,7 @@ let test_waiting_inventory_changed_wire_contract () =
         received_events := ev.Masc.Sse.ext_frame :: !received_events)
       ();
     Masc.Keeper_waiting_inventory_broadcast.changed
-      ~keeper_name:"kidsnote"
+      ~keeper_name:"gamma"
       ~source:Event_queue;
     Alcotest.(check int) "received invalidation" 1 (List.length !received_events);
     let frame = List.hd !received_events in
@@ -101,7 +101,7 @@ let test_waiting_inventory_changed_wire_contract () =
       (payload |> member "type" |> to_string);
     Alcotest.(check string)
       "keeper name"
-      "kidsnote"
+      "gamma"
       (payload |> member "keeper_name" |> to_string);
     Alcotest.(check string)
       "queue kind"

--- a/test/test_task_cache_invariant_13397.ml
+++ b/test/test_task_cache_invariant_13397.ml
@@ -137,7 +137,7 @@ let test_with_fresh_terminal_returns_none () =
     seed_backlog config (make_task ~id:"task-102" ~status:status_done);
     let result =
       TCI.with_fresh_task_status config
-        ~agent_name:"keeper-executor-agent"
+        ~agent_name:"keeper-omega-agent"
         ~task_id:"task-102"
         ~module_name:"test.mention_tracker"
         (fun _ -> `should_not_run)

--- a/test/test_telemetry_eio_coverage.ml
+++ b/test/test_telemetry_eio_coverage.ml
@@ -181,7 +181,7 @@ let check_one_tool_called_record label json ~operation_id ~worker_run_id =
           check bool (label ^ " success") false r.success;
           check int (label ^ " duration_ms") 658 r.duration_ms;
           check (option string) (label ^ " agent_id")
-            (Some "keeper-masc-improver-agent") r.agent_id;
+            (Some "keeper-omicron-improver-agent") r.agent_id;
           check (option string) (label ^ " operation_id") operation_id
             r.operation_id;
           check (option string) (label ^ " worker_run_id") worker_run_id
@@ -206,7 +206,7 @@ let test_parse_event_records_tool_called_null_options () =
                   ("tool_name", `String "tool_execute");
                   ("success", `Bool false);
                   ("duration_ms", `Int 658);
-                  ("agent_id", `String "keeper-masc-improver-agent");
+                  ("agent_id", `String "keeper-omicron-improver-agent");
                   ("source", `String "keeper_internal");
                   ("session_id", `String "mcp-session");
                   ("operation_id", `Null);
@@ -232,7 +232,7 @@ let test_parse_event_records_tool_called_missing_options () =
                   ("tool_name", `String "tool_execute");
                   ("success", `Bool false);
                   ("duration_ms", `Int 658);
-                  ("agent_id", `String "keeper-masc-improver-agent");
+                  ("agent_id", `String "keeper-omicron-improver-agent");
                   ("source", `String "keeper_internal");
                   ("session_id", `String "mcp-session");
                 ];
@@ -248,7 +248,7 @@ let check_one_tool_assigned_record label json =
       match record.event with
       | Telemetry_eio.Tool_assigned r ->
           check string (label ^ " agent_id")
-            "keeper-masc-improver-agent" r.agent_id;
+            "keeper-omicron-improver-agent" r.agent_id;
           check string (label ^ " profile") "default" r.profile;
           check int (label ^ " tool_count") 32 r.tool_count;
           check string (label ^ " assignment_id") "asg-001" r.assignment_id
@@ -269,7 +269,7 @@ let test_parse_event_records_tool_assigned_minimal_payload () =
               `String "Tool_assigned";
               `Assoc
                 [
-                  ("agent_id", `String "keeper-masc-improver-agent");
+                  ("agent_id", `String "keeper-omicron-improver-agent");
                   ("profile", `String "default");
                   ("tool_count", `Int 32);
                   ("assignment_id", `String "asg-001");
@@ -290,7 +290,7 @@ let test_parse_event_records_tool_assigned_missing_optional_fields () =
               `String "Tool_assigned";
               `Assoc
                 [
-                  ("agent_id", `String "keeper-masc-improver-agent");
+                  ("agent_id", `String "keeper-omicron-improver-agent");
                   ("profile", `String "default");
                   ("tool_count", `Int 32);
                   ("assignment_id", `String "asg-001");

--- a/test/test_telemetry_error_occurred_wire_10358.ml
+++ b/test/test_telemetry_error_occurred_wire_10358.ml
@@ -121,7 +121,7 @@ let test_failure_with_error_kind_pairs () =
   with_temp_config @@ fun config ->
   T.track_tool_called config ~tool_name:"tool_execute"
     ~success:false ~duration_ms:30000
-    ~agent_id:"keeper-executor-agent"
+    ~agent_id:"keeper-omega-agent"
     ~source:"keeper_internal"
     ~session_id:"sess-10358"
     ~error_kind:(error_kind "timeout")

--- a/test/test_telemetry_unified.ml
+++ b/test/test_telemetry_unified.ml
@@ -406,12 +406,12 @@ let test_keeper_metrics_per_keeper () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir "telem_keeper_metrics" in
-  let cheolsu_dir = Filename.concat dir ".masc/keepers/cheolsu/metrics" in
+  let beta_dir = Filename.concat dir ".masc/keepers/beta/metrics" in
   let alpha_dir = Filename.concat dir ".masc/keepers/alpha/metrics" in
-  Fs_compat.mkdir_p cheolsu_dir;
+  Fs_compat.mkdir_p beta_dir;
   Fs_compat.mkdir_p alpha_dir;
-  write_jsonl cheolsu_dir [
-    `Assoc [("ts_unix", `Float 3000.0); ("name", `String "cheolsu");
+  write_jsonl beta_dir [
+    `Assoc [("ts_unix", `Float 3000.0); ("name", `String "beta");
             ("channel", `String "turn")];
   ];
   write_jsonl alpha_dir [
@@ -423,10 +423,10 @@ let test_keeper_metrics_per_keeper () =
       ~sources:[Telemetry_unified.Keeper_metric] () in
   Alcotest.(check int) "two keeper entries" 2 (List.length all);
   (* Filter by keeper *)
-  let cheolsu_only = Telemetry_unified.read_unified ~base_path:dir ~masc_root:(masc_root dir)
+  let beta_only = Telemetry_unified.read_unified ~base_path:dir ~masc_root:(masc_root dir)
       ~sources:[Telemetry_unified.Keeper_metric]
-      ~keeper_name:"cheolsu" () in
-  Alcotest.(check int) "one cheolsu entry" 1 (List.length cheolsu_only)
+      ~keeper_name:"beta" () in
+  Alcotest.(check int) "one beta entry" 1 (List.length beta_only)
 
 let test_keeper_metrics_fast_path_preserves_noisy_keeper_top_n () =
   Eio_main.run @@ fun env ->

--- a/test/test_telemetry_unified.ml
+++ b/test/test_telemetry_unified.ml
@@ -259,7 +259,7 @@ let test_shadow_keeper_tool_called_deduped_from_unified_view () =
                   ("tool_name", `String "masc_status");
                   ("success", `Bool true);
                   ("duration_ms", `Int 12);
-                  ("agent_id", `String "keeper-sangsu-agent");
+                  ("agent_id", `String "keeper-alpha-agent");
                   ("execution_id", `String "exec-a");
                 ];
             ] );
@@ -269,7 +269,7 @@ let test_shadow_keeper_tool_called_deduped_from_unified_view () =
     `Assoc
       [
         ("ts", `Float 1000.0);
-        ("keeper", `String "sangsu");
+        ("keeper", `String "alpha");
         ("tool", `String "masc_status");
         ("success", `Bool true);
         ("duration_ms", `Float 12.0);
@@ -321,7 +321,7 @@ let test_distinct_calls_within_the_old_window_are_both_kept () =
                   ("tool_name", `String "masc_status");
                   ("success", `Bool true);
                   ("duration_ms", `Int 12);
-                  ("agent_id", `String "keeper-sangsu-agent");
+                  ("agent_id", `String "keeper-alpha-agent");
                   ("execution_id", `String execution_id);
                 ];
             ] );
@@ -331,7 +331,7 @@ let test_distinct_calls_within_the_old_window_are_both_kept () =
     `Assoc
       [
         ("ts", `Float ts);
-        ("keeper", `String "sangsu");
+        ("keeper", `String "alpha");
         ("tool", `String "masc_status");
         ("success", `Bool true);
         ("duration_ms", `Float 12.0);
@@ -378,13 +378,13 @@ let test_agent_event_without_execution_id_is_kept () =
                   [ ("tool_name", `String "masc_status")
                   ; ("success", `Bool true)
                   ; ("duration_ms", `Int 12)
-                  ; ("agent_id", `String "keeper-sangsu-agent")
+                  ; ("agent_id", `String "keeper-alpha-agent")
                   ] ] ) ]
     ];
   write_jsonl tool_calls_dir
     [ `Assoc
         [ ("ts", `Float 1000.0)
-        ; ("keeper", `String "sangsu")
+        ; ("keeper", `String "alpha")
         ; ("tool", `String "masc_status")
         ; ("success", `Bool true)
         ; ("duration_ms", `Float 12.0)
@@ -407,15 +407,15 @@ let test_keeper_metrics_per_keeper () =
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let dir = tmpdir "telem_keeper_metrics" in
   let cheolsu_dir = Filename.concat dir ".masc/keepers/cheolsu/metrics" in
-  let sangsu_dir = Filename.concat dir ".masc/keepers/sangsu/metrics" in
+  let alpha_dir = Filename.concat dir ".masc/keepers/alpha/metrics" in
   Fs_compat.mkdir_p cheolsu_dir;
-  Fs_compat.mkdir_p sangsu_dir;
+  Fs_compat.mkdir_p alpha_dir;
   write_jsonl cheolsu_dir [
     `Assoc [("ts_unix", `Float 3000.0); ("name", `String "cheolsu");
             ("channel", `String "turn")];
   ];
-  write_jsonl sangsu_dir [
-    `Assoc [("ts_unix", `Float 4000.0); ("name", `String "sangsu");
+  write_jsonl alpha_dir [
+    `Assoc [("ts_unix", `Float 4000.0); ("name", `String "alpha");
             ("channel", `String "turn")];
   ];
   (* All keepers *)

--- a/test/test_tool_agent_coverage.ml
+++ b/test/test_tool_agent_coverage.ml
@@ -155,11 +155,11 @@ let record_completed_metric config ~agent_id ~task_id =
 let test_get_metrics_resolves_keeper_agent_alias () =
   with_ctx (fun ctx ->
   record_completed_metric ctx.config
-    ~agent_id:"nick0cave"
+    ~agent_id:"theta0"
     ~task_id:"task-alias-metric";
   let args =
     `Assoc
-      [ ("agent_name", `String "keeper-nick0cave-agent")
+      [ ("agent_name", `String "keeper-theta0-agent")
       ; ("days", `Int 7)
       ]
   in
@@ -168,11 +168,11 @@ let test_get_metrics_resolves_keeper_agent_alias () =
     (Tool_result.is_success result);
   let open Yojson.Safe.Util in
   let json = Yojson.Safe.from_string (Tool_result.message result) in
-  Alcotest.(check string) "resolved agent id" "nick0cave"
+  Alcotest.(check string) "resolved agent id" "theta0"
     (json |> member "agent_id" |> to_string);
-  Alcotest.(check string) "requested agent name" "keeper-nick0cave-agent"
+  Alcotest.(check string) "requested agent name" "keeper-theta0-agent"
     (json |> member "requested_agent_name" |> to_string);
-  Alcotest.(check string) "resolved agent name" "nick0cave"
+  Alcotest.(check string) "resolved agent name" "theta0"
     (json |> member "resolved_agent_name" |> to_string);
   Alcotest.(check int) "total tasks" 1
     (json |> member "total_tasks" |> to_int);

--- a/test/test_tool_agent_timeline_name_match.ml
+++ b/test/test_tool_agent_timeline_name_match.ml
@@ -23,7 +23,7 @@ let test_keeper_prefix () =
 
 let test_non_match () =
   check bool "different agent does not match" false
-    (m ~agent_name:"albini" "keeper-taskmaster-agent");
+    (m ~agent_name:"albini" "keeper-fixture-agent");
   check bool "empty candidate does not match" false (m ~agent_name:"albini" "")
 
 let test_exact_per_form_not_substring () =

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -275,15 +275,15 @@ let test_board_actor_identity_canonicalizes_keeper_alias () =
   with_eio @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
-  let json = Server_utils.board_actor_identity_json "keeper-analyst-agent" in
+  let json = Server_utils.board_actor_identity_json "keeper-delta-agent" in
   Alcotest.(check string) "kind" "keeper" (json_member_string json "kind");
-  Alcotest.(check string) "id" "analyst" (json_member_string json "id");
-  Alcotest.(check string) "key" "keeper:analyst" (json_member_string json "key");
-  Alcotest.(check string) "raw" "keeper-analyst-agent"
+  Alcotest.(check string) "id" "delta" (json_member_string json "id");
+  Alcotest.(check string) "key" "keeper:delta" (json_member_string json "key");
+  Alcotest.(check string) "raw" "keeper-delta-agent"
     (json_member_string json "raw");
   Alcotest.(check string) "source" "keeper_alias_contract"
     (json_member_string json "source");
-  Alcotest.(check string) "runtime agent" "keeper-analyst-agent"
+  Alcotest.(check string) "runtime agent" "keeper-delta-agent"
     (json_member_string json "runtime_agent_name")
 
 let test_board_actor_identity_keeps_non_keeper_agent () =
@@ -513,20 +513,20 @@ let test_inline_board_post_author_rewrites_caller_claim () =
     make_args
       [
         ("content", `String "ctx-owned post");
-        ("author", `String "analyst");
+        ("author", `String "delta");
         ("meta", `Assoc [ ("trace", `String "probe-10297") ]);
       ]
   in
   let normalized =
     Mcp_tool_runtime_board.ensure_board_post_author
-      ~agent_name:"keeper-velvet-hammer-agent" args
+      ~agent_name:"keeper-xi-hammer-agent" args
   in
-  Alcotest.(check string) "author from ctx" "velvet-hammer"
+  Alcotest.(check string) "author from ctx" "xi-hammer"
     Yojson.Safe.Util.(normalized |> member "author" |> to_string);
-  Alcotest.(check string) "caller claim preserved" "analyst"
+  Alcotest.(check string) "caller claim preserved" "delta"
     Yojson.Safe.Util.(
       normalized |> member "meta" |> member "author_caller_claim" |> to_string);
-  Alcotest.(check string) "raw ctx agent preserved" "keeper-velvet-hammer-agent"
+  Alcotest.(check string) "raw ctx agent preserved" "keeper-xi-hammer-agent"
     Yojson.Safe.Util.(
       normalized
       |> member "meta"
@@ -540,14 +540,14 @@ let test_inline_board_post_author_accepts_matching_alias () =
     make_args
       [
         ("content", `String "ctx-owned post");
-        ("author", `String "keeper-analyst-agent");
+        ("author", `String "keeper-delta-agent");
       ]
   in
   let normalized =
     Mcp_tool_runtime_board.ensure_board_post_author
-      ~agent_name:"keeper-analyst-agent" args
+      ~agent_name:"keeper-delta-agent" args
   in
-  Alcotest.(check string) "author canonical" "analyst"
+  Alcotest.(check string) "author canonical" "delta"
     Yojson.Safe.Util.(normalized |> member "author" |> to_string);
   Alcotest.(check bool) "no mismatch claim" true
     Yojson.Safe.Util.(
@@ -615,7 +615,7 @@ let test_post_create_metadata_payload () =
        [
          ("title", `String "Why");
          ("content", `String "Visible answer\n\nSupporting detail");
-         ("author", `String "sangsu");
+         ("author", `String "alpha");
          ("meta", `Assoc [ ("source", `String "keeper_autonomy") ]);
        ])
   in
@@ -1952,9 +1952,9 @@ let test_a_named_broadcast_selector_is_still_refused () =
 
 let test_a_well_shaped_name_is_still_a_target () =
   Alcotest.(check string) "plain name" "targets"
-    (label_of (comment_audience "@analyst please look"));
+    (label_of (comment_audience "@delta please look"));
   Alcotest.(check string) "namespaced name" "targets"
-    (label_of (comment_audience "@keeper:analyst please look"))
+    (label_of (comment_audience "@keeper:delta please look"))
 
 let () =
   Eio_main.run @@ fun env ->

--- a/test/test_tool_call_quality_benchmark.ml
+++ b/test/test_tool_call_quality_benchmark.ml
@@ -123,18 +123,18 @@ let test_summary_rollups_and_stability () =
   check int "scored runs" 6 summary.scored_runs;
   check int "unsupported runs" 1 summary.unsupported_runs;
   check int "runtime unreachable runs" 0 summary.runtime_unreachable_runs;
-  let analyst_row =
+  let delta_row =
     find_row
       ~provider:(Some "openai")
       ~model:(Some "gpt-5.4")
-      ~keeper:(Some "bench-analyst")
+      ~keeper:(Some "bench-delta")
       summary.grouped_by_provider_model_keeper
   in
-  check int "analyst unique cases" 2 analyst_row.cases_total;
-  check int "analyst passed cases" 2 analyst_row.cases_passed;
-  check (option (float 0.0001)) "analyst stability score" (Some 1.0)
-    analyst_row.stability_score;
-  check int "analyst repeated groups" 1 analyst_row.repeated_case_groups;
+  check int "delta unique cases" 2 delta_row.cases_total;
+  check int "delta passed cases" 2 delta_row.cases_passed;
+  check (option (float 0.0001)) "delta stability score" (Some 1.0)
+    delta_row.stability_score;
+  check int "delta repeated groups" 1 delta_row.repeated_case_groups;
   let executor_row =
     find_row
       ~provider:(Some "openai")
@@ -180,8 +180,8 @@ let test_csv_render_has_headers () =
   in
   check bool "csv header includes stability column" true
     (String_util.contains_substring csv "stability_score");
-  check bool "csv contains analyst keeper row" true
-    (String_util.contains_substring csv "bench-analyst")
+  check bool "csv contains delta keeper row" true
+    (String_util.contains_substring csv "bench-delta")
 
 let test_forbidden_selector_matches_descriptor_evidence () =
   let route_evidence =

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -671,7 +671,7 @@ let test_registered_hook_masc_board_post_accepts_sources_array () =
 (* Regression: the board_list/search backends already read [compact]
    (board_tool_post.ml handle_post_list, board_tool_handlers.ml
    handle_search), but the Keeper Board projection omitted it, so
-   qa-king's masc_board_list compact=true was rejected as an
+   mu-king's masc_board_list compact=true was rejected as an
    unsupported field. Assert the keeper surface now accepts compact while
    additionalProperties stays false (unknown fields still rejected). *)
 let test_validate_args_masc_board_list_accepts_compact () =
@@ -776,12 +776,12 @@ let test_keeper_down_rejects_undeclared_field () =
 let test_keeper_up_accepts_live_traffic_fields () =
   let args =
     `Assoc
-      [ "name", `String "sangsu"
+      [ "name", `String "alpha"
       ; "instructions", `String "do the thing"
       ; "active_goal_ids", `List [ `String "g1" ]
       ; "sandbox_profile", `String "local"
       ; "allowed_paths", `List [ `String "/tmp" ]
-      ; "mention_targets", `List [ `String "sangsu" ]
+      ; "mention_targets", `List [ `String "alpha" ]
       ; "autoboot_enabled", `Bool true
       ; "proactive_enabled", `Bool true
       ; "runtime_id", `String "rt"
@@ -808,7 +808,7 @@ let test_keeper_clear_accepts_live_traffic_fields () =
       ~name:"masc_keeper_clear"
       ~args:
         (`Assoc
-          [ "name", `String "sangsu"
+          [ "name", `String "alpha"
           ; "preserve_system_prompt", `Bool true
           ; "reason", `String "context overflow"
           ])

--- a/test/test_tool_schema_constraint_enforcement.ml
+++ b/test/test_tool_schema_constraint_enforcement.ml
@@ -7,7 +7,7 @@
     validation hook therefore never saw them, and a caller learned about an
     out-of-range value only if the handler happened to re-check it — which
     is how [keeper_artifact_read] answered [max_bytes=565244] with a message
-    that named [sha256] first (2026-08-05 20:06:36, keeper kidsnote).
+    that named [sha256] first (2026-08-05 20:06:36, keeper gamma).
 
     These tests pin that the bounds are read from the raw schema, that the
     rejection names the field and the bound, that a schema without a bound

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -369,11 +369,11 @@ let () = test "dispatch_add_task" (fun () ->
 )
 
 let () = test "keeper dispatch keeps task author distinct from actor identity" (fun () ->
-  let ctx = make_test_ctx_with_agent "taskmaster-agent" in
+  let ctx = make_test_ctx_with_agent "fixture-keeper-agent" in
   let args = `Assoc [ ("title", `String "Keeper-authored task") ] in
   let result =
     Task.Tool.dispatch_for_keeper
-      ~created_by:"taskmaster"
+      ~created_by:"fixture-keeper"
       ctx
       ~name:"masc_add_task"
       ~args
@@ -382,7 +382,7 @@ let () = test "keeper dispatch keeps task author distinct from actor identity" (
    | Some result -> assert (Tool_result.is_success result)
    | None -> failwith "Keeper add-task dispatch returned None");
   match (Workspace.read_backlog ctx.config).tasks with
-  | [ task ] -> assert (task.created_by = Some "taskmaster")
+  | [ task ] -> assert (task.created_by = Some "fixture-keeper")
   | tasks ->
     failwith
       (Printf.sprintf "expected exactly one task, got %d" (List.length tasks)))
@@ -464,25 +464,25 @@ let claimed_title = function
 ;;
 
 let () = test "auto_claim_takes_self_authored_task_without_filter" (fun () ->
-  let ctx = make_test_ctx_with_agent "taskmaster" in
+  let ctx = make_test_ctx_with_agent "fixture-keeper" in
   let _ =
     Workspace.add_task_with_result ctx.Task.Tool.config
-      ~created_by:"taskmaster" ~title:"self routing task" ~priority:1
+      ~created_by:"fixture-keeper" ~title:"self routing task" ~priority:1
       ~description:""
   in
-  let result = Workspace.claim_next_r ctx.Task.Tool.config ~agent_name:"taskmaster" () in
+  let result = Workspace.claim_next_r ctx.Task.Tool.config ~agent_name:"fixture-keeper" () in
   assert (claimed_title result = Some "self routing task"))
 
 let () = test "auto_claim_self_author_filter_excludes_self_authored_task" (fun () ->
-  let ctx = make_test_ctx_with_agent "taskmaster" in
+  let ctx = make_test_ctx_with_agent "fixture-keeper" in
   let _ =
     Workspace.add_task_with_result ctx.Task.Tool.config
-      ~created_by:"taskmaster" ~title:"self routing task" ~priority:1
+      ~created_by:"fixture-keeper" ~title:"self routing task" ~priority:1
       ~description:""
   in
-  let self_excluding (t : Masc_domain.task) = t.created_by <> Some "taskmaster" in
+  let self_excluding (t : Masc_domain.task) = t.created_by <> Some "fixture-keeper" in
   let result =
-    Workspace.claim_next_r ctx.Task.Tool.config ~agent_name:"taskmaster"
+    Workspace.claim_next_r ctx.Task.Tool.config ~agent_name:"fixture-keeper"
       ~hard_filter:self_excluding ()
   in
   assert (claimed_title result = None))
@@ -496,15 +496,15 @@ let () = test "auto_claim_self_author_filter_excludes_self_authored_task" (fun (
    moved to [hard_filter] the widening still respects it, so the own-task is NOT
    claimed. Reverting the exclusion back into [task_filter] turns this RED. *)
 let () = test "auto_claim_hard_filter_survives_scope_fallback" (fun () ->
-  let ctx = make_test_ctx_with_agent "taskmaster" in
+  let ctx = make_test_ctx_with_agent "fixture-keeper" in
   let _ =
     Workspace.add_task_with_result ctx.Task.Tool.config
-      ~created_by:"taskmaster" ~title:"self routing task" ~priority:1
+      ~created_by:"fixture-keeper" ~title:"self routing task" ~priority:1
       ~description:""
   in
-  let self_excluding (t : Masc_domain.task) = t.created_by <> Some "taskmaster" in
+  let self_excluding (t : Masc_domain.task) = t.created_by <> Some "fixture-keeper" in
   let result =
-    Workspace.claim_next_r ctx.Task.Tool.config ~agent_name:"taskmaster"
+    Workspace.claim_next_r ctx.Task.Tool.config ~agent_name:"fixture-keeper"
       ~task_filter:(fun _ -> false)
       ~hard_filter:self_excluding
       ~allow_scope_fallback:true ()

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -1102,12 +1102,12 @@ let () = test "handle_transition_submit_does_not_have_a_disable_bypass"
 let () = test "handle_transition_submit_rejects_registered_keeper_alias"
     (fun () ->
   (
-    let ctx = make_test_ctx_with_agent "keeper-executor-agent" in
+    let ctx = make_test_ctx_with_agent "keeper-omega-agent" in
     ignore
-      (Workspace.bind_session ctx.config ~agent_name:"keeper-executor-agent"
+      (Workspace.bind_session ctx.config ~agent_name:"keeper-omega-agent"
          ~capabilities:[] ());
-    register_test_keeper ctx ~keeper_name:"executor"
-      ~agent_name:"keeper-executor-agent";
+    register_test_keeper ctx ~keeper_name:"omega"
+      ~agent_name:"keeper-omega-agent";
     let _ =
       Task.Tool.handle_add_task
         ~tool_name:"test_tool"
@@ -1116,13 +1116,13 @@ let () = test "handle_transition_submit_rejects_registered_keeper_alias"
         (`Assoc [ ("title", `String "Canonical submit identity") ])
     in
     (match
-       Workspace.claim_task_r ctx.config ~agent_name:"keeper-executor-agent"
+       Workspace.claim_task_r ctx.config ~agent_name:"keeper-omega-agent"
          ~task_id:"task-001" ()
      with
      | Ok _ -> ()
      | Error err -> failwith (Masc_domain.masc_error_to_string err));
     let alias_ctx =
-      { ctx with Task.Tool.agent_name = "keeper-executor" }
+      { ctx with Task.Tool.agent_name = "keeper-omega" }
     in
     let result =
       Task.Tool.handle_transition
@@ -1145,15 +1145,15 @@ let () = test "handle_transition_submit_rejects_registered_keeper_alias"
        an incidental FSM one. The old assertion pinned the literal "requires
        owning the task", which the message stopped using while still rejecting
        for exactly this reason. *)
-    assert (str_contains (Tool_result.message result) "keeper-executor-agent");
-    assert_task_claimed_by ctx "keeper-executor-agent"))
+    assert (str_contains (Tool_result.message result) "keeper-omega-agent");
+    assert_task_claimed_by ctx "keeper-omega-agent"))
 
 let () = test "keeper_reconciliation_ignores_prefix_matched_agent"
     (fun () ->
   let ctx = make_test_ctx_with_agent "codex-mcp-client" in
-  let keeper_name = "executor" in
-  let keeper_agent_name = "keeper-executor-agent" in
-  let foreign_agent_name = "keeper-executor-agent-shadow" in
+  let keeper_name = "omega" in
+  let keeper_agent_name = "keeper-omega-agent" in
+  let foreign_agent_name = "keeper-omega-agent-shadow" in
   ignore
     (Workspace.bind_session
        ctx.config
@@ -1307,7 +1307,7 @@ let () = test "handle_transition_release_prefers_notes_then_reason_for_synthesis
   | _ -> failwith "expected exactly one task"
 )
 
-(* Regression: 2026-05-17 nick0cave production case. masc_transition with
+(* Regression: 2026-05-17 theta0 production case. masc_transition with
    action=claim/start does not require [handoff_context.summary]; the LLM
    has nothing to summarize at work entry. Previously the parser rejected
    any empty summary regardless of action, which broke entry-class
@@ -1562,7 +1562,7 @@ let () = test "handle_transition_done_on_awaiting_verification_is_explicit" (fun
 
 let () = test "agent verdict verbs remain refused after terminal completion" (fun () ->
   let ctx = make_test_ctx_with_agent "worker" in
-  let verifier_ctx = { ctx with Task.Tool.agent_name = "verifier" } in
+  let verifier_ctx = { ctx with Task.Tool.agent_name = "fixture-reviewer" } in
   let _ = Workspace.add_task ctx.config ~title:"Already done" ~priority:1 ~description:"" in
   let _ = Workspace.claim_task ctx.config ~agent_name:"worker" ~task_id:"task-001" in
   let _ =
@@ -1614,7 +1614,7 @@ let () = test "agent verdict verbs remain refused after terminal completion" (fu
 let () = test "operator verdict path replaces verifier agent actions" (fun () ->
   (
     let worker_ctx = make_test_ctx_with_agent "worker" in
-    let verifier_ctx = { worker_ctx with Task.Tool.agent_name = "verifier" } in
+    let verifier_ctx = { worker_ctx with Task.Tool.agent_name = "fixture-reviewer" } in
     let _ =
       Task.Tool.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 worker_ctx
         (`Assoc [ ("title", `String "Verifier may approve") ])
@@ -1912,12 +1912,12 @@ let () = test "keeper_claim_does_not_clobber_planning_current_task" (fun () ->
    | Ok () -> ()
    | Error msg -> failwith ("failed to seed current_task: " ^ msg));
   ignore
-    (Workspace.bind_session ctx.config ~agent_name:"keeper-executor-agent"
+    (Workspace.bind_session ctx.config ~agent_name:"keeper-omega-agent"
        ~capabilities:[] ());
-  register_test_keeper ctx ~keeper_name:"executor"
-    ~agent_name:"keeper-executor-agent";
+  register_test_keeper ctx ~keeper_name:"omega"
+    ~agent_name:"keeper-omega-agent";
   let keeper_ctx =
-    { ctx with Task.Tool.agent_name = "keeper-executor-agent" }
+    { ctx with Task.Tool.agent_name = "keeper-omega-agent" }
   in
   let result =
     Task.Tool.handle_claim
@@ -1949,12 +1949,12 @@ let () = test "keeper_alias_claim_updates_planning_as_exact_agent" (fun () ->
    | Ok () -> ()
    | Error msg -> failwith ("failed to seed current_task: " ^ msg));
   ignore
-    (Workspace.bind_session ctx.config ~agent_name:"keeper-executor-agent"
+    (Workspace.bind_session ctx.config ~agent_name:"keeper-omega-agent"
        ~capabilities:[] ());
-  register_test_keeper ctx ~keeper_name:"executor"
-    ~agent_name:"keeper-executor-agent";
+  register_test_keeper ctx ~keeper_name:"omega"
+    ~agent_name:"keeper-omega-agent";
   let keeper_ctx =
-    { ctx with Task.Tool.agent_name = "keeper-executor" }
+    { ctx with Task.Tool.agent_name = "keeper-omega" }
   in
   let result =
     Task.Tool.handle_claim
@@ -1986,15 +1986,15 @@ let () = test "keeper_generated_alias_claim_updates_planning_as_exact_agent" (fu
    | Ok () -> ()
    | Error msg -> failwith ("failed to seed current_task: " ^ msg));
   ignore
-    (Workspace.bind_session ctx.config ~agent_name:"keeper-executor-agent"
+    (Workspace.bind_session ctx.config ~agent_name:"keeper-omega-agent"
        ~capabilities:[] ());
   ignore
-    (Workspace.bind_session ctx.config ~agent_name:"keeper-executor-warm-raven-agent"
+    (Workspace.bind_session ctx.config ~agent_name:"keeper-omega-warm-raven-agent"
        ~capabilities:[] ());
-  register_test_keeper ctx ~keeper_name:"executor"
-    ~agent_name:"keeper-executor-agent";
+  register_test_keeper ctx ~keeper_name:"omega"
+    ~agent_name:"keeper-omega-agent";
   let keeper_ctx =
-    { ctx with Task.Tool.agent_name = "keeper-executor-warm-raven-agent" }
+    { ctx with Task.Tool.agent_name = "keeper-omega-warm-raven-agent" }
   in
   let result =
     Task.Tool.handle_claim
@@ -2026,15 +2026,15 @@ let () = test "keeper_separator_alias_claim_updates_planning_as_exact_agent" (fu
    | Ok () -> ()
    | Error msg -> failwith ("failed to seed current_task: " ^ msg));
   ignore
-    (Workspace.bind_session ctx.config ~agent_name:"keeper-tech-glutton-agent"
+    (Workspace.bind_session ctx.config ~agent_name:"keeper-pi-glutton-agent"
        ~capabilities:[] ());
   ignore
-    (Workspace.bind_session ctx.config ~agent_name:"keeper-tech_glutton-agent"
+    (Workspace.bind_session ctx.config ~agent_name:"keeper-pi_glutton-agent"
        ~capabilities:[] ());
-  register_test_keeper ctx ~keeper_name:"tech-glutton"
-    ~agent_name:"keeper-tech-glutton-agent";
+  register_test_keeper ctx ~keeper_name:"pi-glutton"
+    ~agent_name:"keeper-pi-glutton-agent";
   let keeper_ctx =
-    { ctx with Task.Tool.agent_name = "keeper-tech_glutton-agent" }
+    { ctx with Task.Tool.agent_name = "keeper-pi_glutton-agent" }
   in
   let result =
     Task.Tool.handle_claim
@@ -2907,7 +2907,7 @@ let () = test "claim_next_filters_out_cancelled_tasks" (fun () ->
 let () =
   test "strict verdict validates justification and credits producer metrics" (fun () ->
     let ctx = make_test_ctx_with_agent "producer" in
-    let verifier_ctx = { ctx with Task.Tool.agent_name = "verifier" } in
+    let verifier_ctx = { ctx with Task.Tool.agent_name = "fixture-reviewer" } in
     add_priority_task ctx ~title:"Strict completion metrics";
     set_only_task_contract
       ctx

--- a/test/test_tool_workspace_coverage.ml
+++ b/test/test_tool_workspace_coverage.ml
@@ -884,8 +884,8 @@ let () =
     Eio_main.run
     @@ fun env ->
     Fs_compat.set_fs (Eio.Stdenv.fs env);
-    let ctx = { (make_test_ctx ()) with agent_name = "keeper-sangsu-agent" } in
-    let _ = Workspace.init ctx.config ~agent_name:(Some "keeper-sangsu-agent") in
+    let ctx = { (make_test_ctx ()) with agent_name = "keeper-alpha-agent" } in
+    let _ = Workspace.init ctx.config ~agent_name:(Some "keeper-alpha-agent") in
     ignore (Auth.enable_auth ctx.config.base_path ~require_token:true ~agent_name:"admin");
     ignore (Auth.ensure_internal_keeper_token ctx.config.base_path);
     ignore (Workspace.add_task ctx.config ~title:"Keeper work" ~priority:3 ~description:"");
@@ -896,12 +896,12 @@ let () =
       assert (
         str_contains
           result
-          "Credential: required=yes | available=yes | candidates=keeper-sangsu-agent");
+          "Credential: required=yes | available=yes | candidates=keeper-alpha-agent");
       assert (
         not
           (str_contains
              result
-             "Lifecycle actions are credential-blocked for keeper-sangsu-agent"));
+             "Lifecycle actions are credential-blocked for keeper-alpha-agent"));
       assert (not (str_contains result "Suggested next:"))
     | None -> failwith "dispatch returned None")
 ;;

--- a/test/test_trajectory_atomicity.ml
+++ b/test/test_trajectory_atomicity.ml
@@ -3,7 +3,7 @@
     Drives many concurrent OCaml threads against [Trajectory.append_entry]
     for the same trace file (the contention surface that produced ~89
     utf-8 multibyte-tear lines in
-    [.masc/trajectories/{analyst,imseonghan,sangsu,ramarama,issue_king,…}]
+    [.masc/trajectories/{delta,tau,alpha,nu,kappa_keeper,…}]
     on 2026-05-17). Post-fix the file must contain every record exactly
     once and every line must parse as JSON. *)
 

--- a/test/test_turn_record.ml
+++ b/test/test_turn_record.ml
@@ -49,8 +49,8 @@ let sample_record () : Turn_record.t =
       [ Ids.Execution_id.of_string "exec-1781200000000-0001"
       ; Ids.Execution_id.of_string "exec-1781200000001-0002"
       ]
-  ; keeper = "sangsu"
-  ; agent_name = "sangsu-agent"
+  ; keeper = "alpha"
+  ; agent_name = "alpha-agent"
   ; generation = 12
   ; turn_kind = Turn_record.Direct
   ; trace_id = "trace-1780648779957-00000"

--- a/test/test_types_coverage.ml
+++ b/test/test_types_coverage.ml
@@ -915,7 +915,7 @@ let test_agent_credential_of_yojson_role_string_admin () =
 let test_agent_credential_of_yojson_role_string_worker () =
   let json =
     current_agent_credential_json
-      ~agent_name:"nick0cave"
+      ~agent_name:"theta0"
       ~token:"t"
       ~role:"worker"
       ~created_at:"2026-04-23T08:07:00Z"

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -303,7 +303,7 @@ let test_system_llm_review_notes_are_metadata_only () =
     ; output =
         `Assoc [ "secret_output", `String "must not be duplicated" ]
     ; criteria = [ "secret criterion should stay in the audit store" ]
-    ; worker = "keeper-executor-agent"
+    ; worker = "keeper-omega-agent"
     ; created_at = 1234.5
     }
   in
@@ -438,7 +438,7 @@ let test_unreadable_evidence_uses_structured_current_contract () =
   let request : VS.request_header =
     { id = "vrf-structured-reason"
     ; task_id = "task-structured-reason"
-    ; worker = "keeper-executor-agent"
+    ; worker = "keeper-omega-agent"
     ; created_at = 1.0
     }
   in
@@ -497,7 +497,7 @@ let test_invalid_reference_snapshot_rejects_hidden_payload () =
          ~task_id:"task-001"
          ~output
          ~criteria:[]
-         ~worker:"keeper-executor-agent"
+         ~worker:"keeper-omega-agent"
          ()
      with
      | Ok _ -> ()
@@ -507,7 +507,7 @@ let test_invalid_reference_snapshot_rejects_hidden_payload () =
         ~base_path
         ~request_id
         ~task_id:"task-001"
-        ~task_worker:"keeper-executor-agent"
+        ~task_worker:"keeper-omega-agent"
         ~authority:(Masc_domain.Human_operator { operator_id = "operator-test" })
     with
     | VS.Evidence_unavailable { reason = VS.Evidence_snapshot_invalid detail; _ } ->
@@ -601,8 +601,8 @@ let test_system_llm_rejection_is_durably_delivered_to_producer_keeper () =
 let test_system_llm_rejection_prefers_registered_producer_binding () =
   with_eio_temp_dir (fun base_path ->
     let config = W.default_config base_path in
-    let keeper_name = "keeper-executor-agent" in
-    let producer = "keeper-executor-agent-agent" in
+    let keeper_name = "keeper-omega-agent" in
+    let producer = "keeper-omega-agent-agent" in
     let meta_json =
       `Assoc
         [ "name", `String keeper_name
@@ -680,7 +680,7 @@ let test_system_llm_rejection_prefers_registered_producer_binding () =
 let test_system_llm_rejection_does_not_derive_unregistered_keeper () =
   with_eio_temp_dir (fun base_path ->
     let config = W.default_config base_path in
-    let producer = "keeper-executor-agent-agent" in
+    let producer = "keeper-omega-agent-agent" in
     Masc.Keeper_registry.For_testing.clear ();
     Fun.protect
       ~finally:Masc.Keeper_registry.For_testing.clear
@@ -1584,7 +1584,7 @@ let create_evidence_request ~base_path ~request_id ~artifact_path =
   let profile_path =
     Keeper_sandbox_config.keeper_toml_path
       ~base_path
-      ~agent_name:"keeper-executor-agent"
+      ~agent_name:"keeper-omega-agent"
   in
   Fs_compat.mkdir_p (Filename.dirname profile_path);
   Fs_compat.save_file profile_path "[keeper]\nsandbox_profile = \"docker\"\n";
@@ -1594,15 +1594,15 @@ let create_evidence_request ~base_path ~request_id ~artifact_path =
         ~base_path
         ~abs_path:artifact_path
     with
-    | Some { keeper_name = "executor"; relative_path } ->
-      [ "artifact:" ^ relative_path; "note:executor summary" ]
+    | Some { keeper_name = "omega"; relative_path } ->
+      [ "artifact:" ^ relative_path; "note:producer summary" ]
     | Some _ | None ->
-      [ "artifact:../outside-worker-playground"; "note:executor summary" ]
+      [ "artifact:../outside-worker-playground"; "note:producer summary" ]
   in
   let evidence_snapshot =
     VS.snapshot_submitted_evidence_json
       ~base_path
-      ~worker:"keeper-executor-agent"
+      ~worker:"keeper-omega-agent"
       submitted_evidence
   in
   match
@@ -1614,7 +1614,7 @@ let create_evidence_request ~base_path ~request_id ~artifact_path =
         (`Assoc
             [ "submitted_evidence", evidence_snapshot ])
       ~criteria:[ "inspect artifact" ]
-      ~worker:"keeper-executor-agent"
+      ~worker:"keeper-omega-agent"
       ()
   with
   | Ok request -> request
@@ -1650,7 +1650,7 @@ let create_protocol_evidence_request ~base_path ~request_id ~evidence_refs =
      VP.create_submit_request
        ~config
        ~task
-       ~assignee:"keeper-executor-agent"
+       ~assignee:"keeper-omega-agent"
        ~verification_id:request_id
        ~evidence_refs
    with
@@ -1659,7 +1659,7 @@ let create_protocol_evidence_request ~base_path ~request_id ~evidence_refs =
   task
 
 let inspect_evidence ?(task_id = "task-001")
-    ?(task_worker = "keeper-executor-agent") ~base_path ~request_id
+    ?(task_worker = "keeper-omega-agent") ~base_path ~request_id
     () =
   VS.inspect_submitted_evidence_for_authority
     ~base_path
@@ -1673,7 +1673,7 @@ let test_submitted_evidence_inspection_is_authority_scoped_and_contained () =
     let artifact_dir =
       Filename.concat
         base_path
-        ".masc/playground/docker/executor"
+        ".masc/playground/docker/omega"
     in
     Fs_compat.mkdir_p artifact_dir;
     let artifact_path = Filename.concat artifact_dir "artifact-task-001.txt" in
@@ -1689,7 +1689,7 @@ let test_submitted_evidence_inspection_is_authority_scoped_and_contained () =
      | VS.Evidence_available
          { items =
              VS.Evidence_artifact { content; truncated = false; _ }
-             :: VS.Evidence_note "executor summary"
+             :: VS.Evidence_note "producer summary"
              :: []
          ; _
          } ->
@@ -1703,7 +1703,7 @@ let test_submitted_evidence_inspection_is_authority_scoped_and_contained () =
         ~base_path
         ~request_id
         ~task_id:"task-001"
-        ~task_worker:"keeper-executor-agent"
+        ~task_worker:"keeper-omega-agent"
         ~authority:(Masc_domain.Human_operator { operator_id = "" })
     with
     | VS.Evidence_unavailable _ -> ()
@@ -1713,13 +1713,13 @@ let test_submit_snapshot_resolves_docker_relative_artifact_and_explicit_note () 
   with_eio_temp_dir (fun base_path ->
     write_keeper_profile
       ~base_path
-      ~keeper_name:"keeper-executor-agent"
+      ~keeper_name:"keeper-omega-agent"
       ~sandbox_profile:"docker";
     let artifact_dir =
       Filename.concat
         (Keeper_sandbox_config.host_root_abs_of_agent
            ~base_path
-           ~agent_name:"keeper-executor-agent")
+           ~agent_name:"keeper-omega-agent")
         "artifacts"
     in
     Fs_compat.mkdir_p artifact_dir;
@@ -1732,7 +1732,7 @@ let test_submit_snapshot_resolves_docker_relative_artifact_and_explicit_note () 
         ~base_path
         ~request_id
         ~evidence_refs:
-          [ "artifact:artifacts/proof.txt"; "note:executor summary" ]
+          [ "artifact:artifacts/proof.txt"; "note:producer summary" ]
     in
     match
       inspect_evidence
@@ -1745,7 +1745,7 @@ let test_submit_snapshot_resolves_docker_relative_artifact_and_explicit_note () 
         { items =
             VS.Evidence_artifact
               { reference = "artifact:artifacts/proof.txt"; content; _ }
-            :: VS.Evidence_note "executor summary"
+            :: VS.Evidence_note "producer summary"
             :: []
         ; _
         } ->
@@ -1782,13 +1782,13 @@ let test_submit_snapshot_survives_mutation_deletion_and_authority_cwd () =
   with_eio_temp_dir (fun base_path ->
     write_keeper_profile
       ~base_path
-      ~keeper_name:"keeper-executor-agent"
+      ~keeper_name:"keeper-omega-agent"
       ~sandbox_profile:"docker";
     let artifact_dir =
       Filename.concat
         (Keeper_sandbox_config.host_root_abs_of_agent
            ~base_path
-           ~agent_name:"keeper-executor-agent")
+           ~agent_name:"keeper-omega-agent")
         "artifacts"
     in
     Fs_compat.mkdir_p artifact_dir;
@@ -1854,12 +1854,12 @@ let test_submit_snapshot_rejects_relative_traversal_and_symlink_escape () =
   with_eio_temp_dir (fun base_path ->
     write_keeper_profile
       ~base_path
-      ~keeper_name:"keeper-executor-agent"
+      ~keeper_name:"keeper-omega-agent"
       ~sandbox_profile:"docker";
     let producer_root =
       Keeper_sandbox_config.host_root_abs_of_agent
         ~base_path
-        ~agent_name:"keeper-executor-agent"
+        ~agent_name:"keeper-omega-agent"
     in
     let artifact_dir = Filename.concat producer_root "artifacts" in
     Fs_compat.mkdir_p artifact_dir;
@@ -1906,12 +1906,12 @@ let test_submit_snapshot_rejects_bare_and_absolute_references () =
   with_eio_temp_dir (fun base_path ->
     write_keeper_profile
       ~base_path
-      ~keeper_name:"keeper-executor-agent"
+      ~keeper_name:"keeper-omega-agent"
       ~sandbox_profile:"docker";
     let producer_root =
       Keeper_sandbox_config.host_root_abs_of_agent
         ~base_path
-        ~agent_name:"keeper-executor-agent"
+        ~agent_name:"keeper-omega-agent"
     in
     Fs_compat.mkdir_p producer_root;
     let absolute_path = Filename.concat producer_root "absolute.txt" in
@@ -1920,7 +1920,7 @@ let test_submit_snapshot_rejects_bare_and_absolute_references () =
     let snapshot =
       VS.snapshot_submitted_evidence_json
         ~base_path
-        ~worker:"keeper-executor-agent"
+        ~worker:"keeper-omega-agent"
         [ "artifacts/bare.txt"; absolute_path ]
     in
     let persisted_snapshot = Yojson.Safe.to_string snapshot in
@@ -1937,7 +1937,7 @@ let test_submit_snapshot_rejects_bare_and_absolute_references () =
            ~task_id:"task-001"
            ~output:(`Assoc [ "submitted_evidence", snapshot ])
            ~criteria:[ "inspect explicit refs" ]
-           ~worker:"keeper-executor-agent"
+           ~worker:"keeper-omega-agent"
            ()
        with
        | Ok request -> request
@@ -1992,7 +1992,7 @@ let test_submitted_evidence_rejects_unknown_artifact_field () =
     let profile_path =
       Keeper_sandbox_config.keeper_toml_path
         ~base_path
-        ~agent_name:"keeper-executor-agent"
+        ~agent_name:"keeper-omega-agent"
     in
     Fs_compat.mkdir_p (Filename.dirname profile_path);
     Fs_compat.save_file profile_path "[keeper]\nsandbox_profile = \"docker\"\n";
@@ -2008,7 +2008,7 @@ let test_submitted_evidence_rejects_unknown_artifact_field () =
             ; "truncated", `Bool false
             ; "unexpected_field", `String "not part of the current contract"
             ]
-        ; `Assoc [ "kind", `String "note"; "content", `String "executor summary" ]
+        ; `Assoc [ "kind", `String "note"; "content", `String "producer summary" ]
         ]
     in
     (match
@@ -2018,7 +2018,7 @@ let test_submitted_evidence_rejects_unknown_artifact_field () =
          ~task_id:"task-001"
          ~output:(`Assoc [ "submitted_evidence", snapshot ])
          ~criteria:[ "inspect artifact" ]
-         ~worker:"keeper-executor-agent"
+         ~worker:"keeper-omega-agent"
          ()
      with
      | Ok _ -> ()
@@ -2040,7 +2040,7 @@ let test_submitted_evidence_inspection_is_bounded_and_utf8_safe () =
     let artifact_dir =
       Filename.concat
         base_path
-        ".masc/playground/docker/executor"
+        ".masc/playground/docker/omega"
     in
     Fs_compat.mkdir_p artifact_dir;
     let artifact_path = Filename.concat artifact_dir "large-artifact.txt" in
@@ -2075,7 +2075,7 @@ let test_submitted_evidence_rejects_malformed_utf8 () =
     let artifact_dir =
       Filename.concat
         base_path
-        ".masc/playground/docker/executor"
+        ".masc/playground/docker/omega"
     in
     Fs_compat.mkdir_p artifact_dir;
     let artifact_path = Filename.concat artifact_dir "malformed.txt" in
@@ -2103,7 +2103,7 @@ let test_submitted_evidence_rejects_symlink_escape_and_fifo () =
     let artifact_dir =
       Filename.concat
         base_path
-        ".masc/playground/docker/executor"
+        ".masc/playground/docker/omega"
     in
     Fs_compat.mkdir_p artifact_dir;
     let outside_path = Filename.concat base_path "outside-secret.txt" in
@@ -2168,7 +2168,7 @@ let test_submitted_evidence_requires_exact_task_assignment_identity () =
     let artifact_dir =
       Filename.concat
         base_path
-        ".masc/playground/docker/executor"
+        ".masc/playground/docker/omega"
     in
     Fs_compat.mkdir_p artifact_dir;
     let artifact_path = Filename.concat artifact_dir "assignment.txt" in
@@ -2185,11 +2185,11 @@ let test_submitted_evidence_requires_exact_task_assignment_identity () =
                 [ ( "submitted_evidence"
                   , VS.snapshot_submitted_evidence_json
                       ~base_path
-                      ~worker:"keeper-executor-agent"
+                      ~worker:"keeper-omega-agent"
                       [ "artifact:assignment.txt" ] )
                 ])
           ~criteria:[ "inspect artifact" ]
-          ~worker:"keeper-executor-agent"
+          ~worker:"keeper-omega-agent"
           ()
       with
       | Ok request -> request
@@ -2235,7 +2235,7 @@ let test_keeper_task_projection_never_exposes_snapshot_or_verdict_action () =
     let artifact_dir =
       Filename.concat
         base_path
-        ".masc/playground/docker/executor"
+        ".masc/playground/docker/omega"
     in
     Fs_compat.mkdir_p artifact_dir;
     let artifact_path = Filename.concat artifact_dir "artifact-task-001.txt" in
@@ -2249,7 +2249,7 @@ let test_keeper_task_projection_never_exposes_snapshot_or_verdict_action () =
            { task with
              task_status =
                Masc_domain.AwaitingVerification
-                 { assignee = "keeper-executor-agent"
+                 { assignee = "keeper-omega-agent"
                  ; started_at = "2026-07-27T23:59:00Z"
                  ; submitted_at = "2026-07-28T00:00:00Z"
                  ; verification_id = request_id
@@ -2269,17 +2269,17 @@ let test_keeper_task_projection_never_exposes_snapshot_or_verdict_action () =
       false
       (String_util.contains_substring projection "ACTION:");
     (match
-       W.claim_task_r config ~agent_name:"keeper-executor-agent" ~task_id:"task-001" ()
+       W.claim_task_r config ~agent_name:"keeper-omega-agent" ~task_id:"task-001" ()
      with
      | Error _ -> ()
      | Ok _ -> Alcotest.fail "producer must not claim its pending obligation");
     (match
-       W.claim_task_r config ~agent_name:"keeper-verifier-agent" ~task_id:"task-001" ()
+       W.claim_task_r config ~agent_name:"keeper-fixture-reviewer-agent" ~task_id:"task-001" ()
      with
      | Error _ -> ()
      | Ok _ -> Alcotest.fail "no Keeper may claim a pending obligation");
     (match
-       W.claim_task_r config ~agent_name:"keeper-sangsu-agent" ~task_id:"task-001" ()
+       W.claim_task_r config ~agent_name:"keeper-alpha-agent" ~task_id:"task-001" ()
      with
      | Error _ -> ()
      | Ok _ -> Alcotest.fail "another Keeper claimed the pending obligation");

--- a/test/test_verification_run_registry.ml
+++ b/test/test_verification_run_registry.ml
@@ -47,7 +47,7 @@ let register t ~verification_id ~started_at =
     t
     ~verification_id
     ~task_id:"task-136"
-    ~producer:"keeper-kidsnote-agent"
+    ~producer:"keeper-gamma-agent"
     ~authority_kind:"system_llm_agent"
     ~authority_actor:("system-llm-agent-" ^ verification_id)
     ~started_at
@@ -77,7 +77,7 @@ let test_running_before_completion () =
   | Some run ->
     check string "status" "running" (R.status_label run.status);
     check string "task" "task-136" run.task_id;
-    check string "producer" "keeper-kidsnote-agent" run.producer;
+    check string "producer" "keeper-gamma-agent" run.producer;
     (* A running review carries no elapsed time — a surface must not read one. *)
     check
       (option string)
@@ -262,7 +262,7 @@ let test_retry_replaces_the_prior_attempt () =
     t
     ~verification_id:"vrf-retry"
     ~task_id:"task-136"
-    ~producer:"keeper-kidsnote-agent"
+    ~producer:"keeper-gamma-agent"
     ~authority_actor:"system-llm-agent-second"
     ~authority_kind:"system_llm_agent"
     ~started_at:20.0;

--- a/test/test_voice_runtime_overlay.ml
+++ b/test/test_voice_runtime_overlay.ml
@@ -1029,7 +1029,7 @@ let test_playback_open_fallback_reports_handoff () =
     match
       Voice_bridge_core.run_local_playback
         ~sw
-        ~agent_id:"sangsu"
+        ~agent_id:"alpha"
         ~message:"open fallback regression"
         ~audio_file
         ()

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -309,7 +309,7 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
   Workspace.write_json config agent_file (Masc_domain.agent_to_yojson stale_agent);
 
   let stale_message =
-    "@nick0cave task-001 stale claim detected: current_task_id=null but \
+    "@theta0 task-001 stale claim detected: current_task_id=null but \
      MASC still lists task-001 as claimed by you. Please release it."
   in
   let since_seq =
@@ -330,7 +330,7 @@ let test_broadcast_replaces_terminal_task_cache_desync () =
     (str_contains result.content "[cache_invalidated]");
   Alcotest.(check (option string))
     "delivery preserves the original mention"
-    (Some "nick0cave")
+    (Some "theta0")
     result.mention;
   Alcotest.(check string)
     "delivery exposes the canonical persisted sender"

--- a/test/test_workspace_state_recovery.ml
+++ b/test/test_workspace_state_recovery.ml
@@ -74,7 +74,7 @@ let test_read_state_drops_legacy_active_agent_objects () =
                 [
                   `Assoc [ ("name", `String "codex-swift-fox") ];
                   `String "gemini-brave-bear";
-                  `Assoc [ ("agent_name", `String "keeper-sangsu-agent") ];
+                  `Assoc [ ("agent_name", `String "keeper-alpha-agent") ];
                   `Assoc [ ("id", `String "ignored") ];
                 ] );
           ]
@@ -132,7 +132,7 @@ let test_agent_of_yojson_accepts_numeric_last_seen () =
   let json =
     `Assoc
       [
-        ("name", `String "keeper-sangsu-agent");
+        ("name", `String "keeper-alpha-agent");
         ("agent_type", `String "keeper");
         ("status", `String "active");
         ("capabilities", `List []);
@@ -143,7 +143,7 @@ let test_agent_of_yojson_accepts_numeric_last_seen () =
   in
   match Masc_domain.agent_of_yojson json with
   | Ok agent ->
-      check string "agent parsed" "keeper-sangsu-agent" agent.name;
+      check string "agent parsed" "keeper-alpha-agent" agent.name;
       check bool "last_seen normalized to ISO" true
         (String.length agent.last_seen > 0 && String.contains agent.last_seen 'T')
   | Error msg -> fail ("expected numeric last_seen compatibility: " ^ msg)
@@ -285,7 +285,7 @@ let test_heartbeat_repairs_legacy_agent_last_seen () =
       let legacy_agent_json =
         `Assoc
           [
-            ("name", `String "keeper-sangsu-agent");
+            ("name", `String "keeper-alpha-agent");
             ("agent_type", `String "keeper");
             ("status", `String "active");
             ("capabilities", `List [ `String "heartbeat" ]);
@@ -294,13 +294,13 @@ let test_heartbeat_repairs_legacy_agent_last_seen () =
             ("last_seen", `Int 1711411200);
           ]
       in
-      write_text_file (agent_path config "keeper-sangsu-agent")
+      write_text_file (agent_path config "keeper-alpha-agent")
         (Yojson.Safe.to_string legacy_agent_json);
 
-      ignore (Workspace.heartbeat config ~agent_name:"keeper-sangsu-agent");
+      ignore (Workspace.heartbeat config ~agent_name:"keeper-alpha-agent");
 
       let repaired_json =
-        match Safe_ops.read_file_safe (agent_path config "keeper-sangsu-agent") with
+        match Safe_ops.read_file_safe (agent_path config "keeper-alpha-agent") with
         | Error error -> fail error
         | Ok raw ->
             raw

--- a/test/test_workspace_task_lifecycle.ml
+++ b/test/test_workspace_task_lifecycle.ml
@@ -262,7 +262,7 @@ let test_awaiting_is_claimable_by_nobody () =
          when String.equal verification_id "vrf-1" -> ()
        | _ ->
          failwith (actor ^ " must not claim an obligation awaiting a completion verdict"))
-    [ owner; "verifier"; "other" ]
+    [ owner; "fixture-reviewer"; "other" ]
 ;;
 
 let () =

--- a/test/test_ws_transport.ml
+++ b/test/test_ws_transport.ml
@@ -350,7 +350,7 @@ let test_dashboard_event_composite_change_maps_to_composite () =
     dashboard_event
       (`Assoc
         [ ("type", `String "keeper_composite_changed")
-        ; ("name", `String "qa-king")
+        ; ("name", `String "mu-king")
         ; ("ts_unix", `Float 1_774_000_000.0)
         ])
   with


### PR DESCRIPTION
Split from #29271 and stacked on #29282.

Scope:
- replace historical concrete Keeper identities in lib, test, packages, and bin OCaml sources
- preserve protocol vocabulary such as verifier and executor where it denotes a role rather than an instance
- keep fixtures structurally representative with neutral names

Explicit non-scope:
- no regex blacklist or blocking name gate
- no retry policy, schedule, Goal verifier, Task notification, Dashboard, or voice behavior changes

Validation:
- retired concrete-name scan across all .ml/.mli files: 0 matches
- OCaml @check PASS
- Keeper identity normalize 12 tests PASS
- Keeper TOML 85 tests PASS
- runtime per-Keeper routing 41 tests PASS
- Workspace 82 tests PASS
- CI target audit PASS (380 declared / 516 unwired baseline)
- gRPC descriptor check PASS

The branch is stacked only to avoid duplicating the 5-file identity-neutral behavior change from #29282.