### PR TITLE
fix(agent-core): 타임아웃 에러가 phase와 provider 를 잃지 않게

### DIFF
--- a/packages/agent_core/lib/error_domain.ml
+++ b/packages/agent_core/lib/error_domain.ml
@@ -10,7 +10,7 @@ type provider_error =
   | `Server_error of int * string
   | `Network_error of string
   | `Provider_timeout of Http_client.timeout_phase option * string
-  | `Streaming_timeout of Http_client.timeout_phase * string
+  | `Streaming_timeout of Http_client.timeout_phase * string * string option
   | `Overloaded
   | `Invalid_request of Llm_provider.Retry.invalid_request_reason * string
   | `Not_found of string
@@ -94,7 +94,7 @@ let of_api_error (err : Retry.api_error) : provider_error =
   | Retry.Timeout r ->
     (match r.phase with
      | Some phase when is_streaming_timeout_phase phase ->
-       `Streaming_timeout (phase, r.message)
+       `Streaming_timeout (phase, r.message, None)
      | phase -> `Provider_timeout (phase, r.message))
   | Retry.Overloaded _ -> `Overloaded
   | Retry.InvalidRequest r -> `Invalid_request (r.reason, r.message)
@@ -115,7 +115,7 @@ let of_provider_error (err : Llm_provider.Error.provider_error) : provider_error
   | Llm_provider.Error.Timeout r ->
     (match r.timeout_phase with
      | Some phase when is_streaming_timeout_phase phase ->
-       `Streaming_timeout (phase, r.detail)
+       `Streaming_timeout (phase, r.detail, Some r.provider)
      | phase -> `Provider_timeout (phase, r.detail))
   | Llm_provider.Error.CapacityExhausted _ -> `Overloaded
   | Llm_provider.Error.InvalidRequest r ->
@@ -181,10 +181,21 @@ let provider_to_error : provider_error -> Error.t = function
   | `Server_error (status, msg) -> Error.Api (Retry.ServerError { status; message = msg })
   | `Network_error msg -> Error.Api (Retry.NetworkError { message = msg; kind = Unknown })
   | `Provider_timeout (phase, msg) -> Error.Api (Retry.Timeout { message = msg; phase })
-  | `Streaming_timeout (phase, msg) ->
+  (* The provider rides along so the round trip does not have to invent one.
+     It used to be dropped here and reconstructed as the literal "unknown",
+     which is how a stalled stream reached the route stage naming no provider
+     while every other surface named it. An API-level timeout genuinely has no
+     provider, and says so by converting back to the API error it came from. *)
+  | `Streaming_timeout (phase, msg, Some provider) ->
     Error.Provider
       (Llm_provider.Error.Timeout
-         { provider = "unknown"; timeout_phase = Some phase; detail = msg })
+         { provider; timeout_phase = Some phase; detail = msg })
+  | `Streaming_timeout (phase, msg, None) ->
+    (* No provider to name, so it stays the API error it arrived as. That used
+       to lose the phase, because [Retry.to_string] dropped it; the phase is
+       rendered there now, so this no longer has to borrow a provider error to
+       stay diagnostic. *)
+    Error.Api (Retry.Timeout { message = msg; phase = Some phase })
   | `Overloaded -> Error.Api (Retry.Overloaded { message = "overloaded" })
   (* The reverse direction used to overwrite the reason with
      Unknown_invalid_request, so a round trip through this module erased a typed

--- a/packages/agent_core/lib/error_domain.mli
+++ b/packages/agent_core/lib/error_domain.mli
@@ -28,7 +28,12 @@ type provider_error =
   | `Server_error of int * string (** status, message *)
   | `Network_error of string
   | `Provider_timeout of Llm_provider.Http_client.timeout_phase option * string
-  | `Streaming_timeout of Llm_provider.Http_client.timeout_phase * string
+  | `Streaming_timeout of
+      Llm_provider.Http_client.timeout_phase * string * string option
+    (** phase, message, and the provider that stalled when one is known.
+            [None] is an API-level timeout, which has no provider to name; it
+            converts back to an API error rather than a provider error wearing a
+            placeholder name. *)
   | `Overloaded
   | `Invalid_request of Llm_provider.Retry.invalid_request_reason * string
     (** Typed reason first, mirroring [`Input_capacity]. The reason used to be

--- a/packages/agent_core/lib/llm_provider/retry.ml
+++ b/packages/agent_core/lib/llm_provider/retry.ml
@@ -102,7 +102,18 @@ let error_message = function
   | NetworkError { message; kind = Unknown } -> Printf.sprintf "Network error: %s" message
   | NetworkError { message; kind } ->
     Printf.sprintf "Network error (%s): %s" (network_error_kind_label kind) message
-  | Timeout r -> Printf.sprintf "Timeout: %s" r.message
+  | Timeout r ->
+    (* The phase is the whole diagnostic value of a timeout -- a stalled stream
+       and a refused admission are different failures. It was carried in the
+       record and dropped here, which is why the only way to see it in a log was
+       to convert the error into a provider error it was not. *)
+    let phase_suffix =
+      match r.phase with
+      | None -> ""
+      | Some phase ->
+        Printf.sprintf " phase=%s" (Http_client.timeout_phase_to_label phase)
+    in
+    Printf.sprintf "Timeout%s: %s" phase_suffix r.message
 ;;
 
 let is_retryable = function

--- a/packages/agent_core/test/test_error_domain.ml
+++ b/packages/agent_core/test/test_error_domain.ml
@@ -134,7 +134,7 @@ let test_to_string_each_variant () =
     ; `Server_error (503, "unavailable")
     ; `Network_error "connection refused"
     ; `Provider_timeout (None, "3s elapsed")
-    ; `Streaming_timeout (Http_client.Stream_body, "stream body elapsed")
+    ; `Streaming_timeout (Http_client.Stream_body, "stream body elapsed", None)
     ; `Overloaded
     ; `Invalid_request (Llm_provider.Retry.Unknown_invalid_request, "bad body")
     ; `Tool_exec_failed ("search", "crash")
@@ -172,7 +172,8 @@ let test_all_variants_convert () =
     ; `Server_error (500, "x")
     ; `Network_error "x"
     ; `Provider_timeout (None, "x")
-    ; `Streaming_timeout (Http_client.Stream_idle Http_client.Streaming_thinking, "idle")
+    ; `Streaming_timeout
+        (Http_client.Stream_idle Http_client.Streaming_thinking, "idle", None)
     ; `Overloaded
     ; `Invalid_request (Llm_provider.Retry.Unknown_invalid_request, "x")
     ; `Tool_exec_failed ("t", "d")
@@ -272,14 +273,23 @@ let test_roundtrip_api_timeout_preserves_phase () =
   in
   let poly = Error_domain.of_core_error orig in
   (match poly with
-   | `Streaming_timeout (Http_client.First_token, "prefill") -> ()
+   | `Streaming_timeout (Http_client.First_token, "prefill", _) -> ()
    | _ -> Alcotest.fail "expected Streaming_timeout with First_token");
   let back = Error_domain.to_core_error poly in
-  match back with
-  | Error.Provider
-      (Llm_provider.Error.Timeout { timeout_phase = Some Http_client.First_token; _ }) ->
-    ()
-  | _ -> Alcotest.fail "roundtrip lost timeout phase"
+  (* It arrived as an API error with no provider, so it goes back as one. It
+     used to be handed back as a provider error named "unknown", which was the
+     only way the phase survived rendering. *)
+  (match back with
+   | Error.Api (Retry.Timeout { phase = Some Http_client.First_token; message = "prefill" })
+     -> ()
+   | _ -> Alcotest.fail "roundtrip lost the API timeout it started as");
+  (* The phase is the point: a rendered timeout that does not say which phase
+     stalled cannot be told apart from any other timeout, and naming a provider
+     that does not exist is worse than naming none. *)
+  Alcotest.(check string)
+    "renders its phase and invents no provider"
+    "Timeout phase=first_token: prefill"
+    (Error.to_string back)
 ;;
 
 let test_roundtrip_api_timeout_preserves_non_streaming_phase () =
@@ -309,13 +319,17 @@ let test_roundtrip_provider_streaming_timeout () =
   in
   let poly = Error_domain.of_core_error orig in
   (match poly with
-   | `Streaming_timeout (Http_client.Stream_body, "stream body cap") -> ()
-   | _ -> Alcotest.fail "expected Streaming_timeout");
+   | `Streaming_timeout (Http_client.Stream_body, "stream body cap", Some "openai") ->
+     ()
+   | _ -> Alcotest.fail "expected Streaming_timeout carrying its provider");
   let back = Error_domain.to_core_error poly in
   match back with
   | Error.Provider
       (Llm_provider.Error.Timeout
-         { timeout_phase = Some Http_client.Stream_body; detail = "stream body cap"; _ })
+         { provider = "openai"
+         ; timeout_phase = Some Http_client.Stream_body
+         ; detail = "stream body cap"
+         })
     ->
     let first_token =
       Error.Provider
@@ -327,7 +341,8 @@ let test_roundtrip_provider_streaming_timeout () =
       |> Error_domain.of_core_error
     in
     (match first_token with
-     | `Streaming_timeout (Http_client.First_token, "awaiting first token") -> ()
+     | `Streaming_timeout (Http_client.First_token, "awaiting first token", Some "openai")
+       -> ()
      | _ -> Alcotest.fail "expected First_token Streaming_timeout")
   | _ -> Alcotest.fail "roundtrip mismatch for streaming Timeout"
 ;;
@@ -629,7 +644,8 @@ let test_retryable_streaming_timeout () =
     "streaming_timeout retryable"
     true
     (Error_domain.is_retryable
-       (`Streaming_timeout (Http_client.Stream_idle Http_client.Streaming_answer, "idle")))
+       (`Streaming_timeout
+          (Http_client.Stream_idle Http_client.Streaming_answer, "idle", None)))
 ;;
 
 let test_retryable_network_error () =
@@ -793,7 +809,8 @@ let test_provider_roundtrip_all_via_to_sdk () =
     ; `Server_error (500, "x")
     ; `Network_error "x"
     ; `Provider_timeout (None, "x")
-    ; `Streaming_timeout (Http_client.Stream_body, "x")
+    ; `Streaming_timeout (Http_client.Stream_body, "x", Some "openai")
+    ; `Streaming_timeout (Http_client.Stream_body, "x", None)
     ; `Overloaded
     ; `Invalid_request (Llm_provider.Retry.Unknown_invalid_request, "x")
     ]
@@ -804,9 +821,11 @@ let test_provider_roundtrip_all_via_to_sdk () =
        let s = Error.to_string core_error in
        Alcotest.(check bool) "nonempty to_string" true (String.length s > 0);
        match v, core_error with
-       | `Streaming_timeout _, Error.Provider _ -> ()
+       | `Streaming_timeout (_, _, Some _), Error.Provider _ -> ()
+       | `Streaming_timeout (_, _, None), Error.Api _ -> ()
        | `Streaming_timeout _, _ ->
-         Alcotest.fail "expected Provider for streaming_timeout"
+         Alcotest.fail
+           "a streaming timeout keeps its provider or stays the API error it was"
        | _, Error.Api _ -> ()
        | _ -> Alcotest.fail "expected Api for provider_error")
     variants

--- a/packages/agent_core/test/test_retry.ml
+++ b/packages/agent_core/test/test_retry.ml
@@ -1,6 +1,7 @@
 open Alcotest
 open Agent_core
 module Retry = Llm_provider.Retry
+module Http_client = Llm_provider.Http_client
 
 let expect_rate_limited err =
   match err with
@@ -268,6 +269,17 @@ let test_error_message_all_variants () =
     ; ( Retry.NetworkError { message = "reset"; kind = Connection_refused }
       , "Network error (connection_refused): reset" )
     ; Retry.Timeout { message = "10s"; phase = None }, "Timeout: 10s"
+      (* A timeout that does not say which phase stalled reads the same as
+         every other timeout. The phase was in the record and absent from
+         the rendering, so the only way to see it in a log was to convert
+         the error into a provider error it was not. *)
+    ; ( Retry.Timeout
+          { message = "no token for 120s"
+          ; phase = Some (Http_client.Stream_idle Http_client.Streaming_answer)
+          }
+      , "Timeout phase=stream_idle:streaming_answer: no token for 120s" )
+    ; ( Retry.Timeout { message = "prefill"; phase = Some Http_client.First_token }
+      , "Timeout phase=first_token: prefill" )
     ]
   in
   List.iter


### PR DESCRIPTION
## 목표

타임아웃 에러가 로그에서 **어느 phase가 멈췄는지**와 **어느 프로바이더였는지**를 잃지 않게 한다.

## 증상

2026-08-21 라이브 로그에서 같은 stall 하나가 두 가지로 찍혔다.

```
30줄:  Provider 'glm-coding' timeout phase=stream_idle:streaming_answer: ...
 5줄:  Provider 'unknown'    timeout phase=stream_idle:streaming_answer: ...
        └ agent_core:pipeline stage=route
```

`pipeline.ml`의 `tag_error`가 로그 문자열을 만들려고 에러를 `Error_domain`으로 한 바퀴 돌린다. 반환되는 타입 에러는 그대로라서(`Stage context is observation-only`) failover나 provider attribution은 영향이 없다. 잃는 것은 **사람이 읽는 줄** 하나다.

## 근본 원인

`"unknown"`은 증상이었다. 사슬은 이렇다.

1. `Retry.error_message`가 `Timeout: %s`로 렌더하고 `r.phase`를 안 쓴다 — 레코드는 갖고 있는데.
2. phase 없는 타임아웃은 다른 타임아웃과 구별이 안 된다. stall인지 admission 거절인지 모른다.
3. 그래서 phase를 로그에 넣으려면 API 에러를 provider 에러로 바꿔야 했다 (provider 렌더는 phase suffix를 붙인다).
4. 그 변환에는 provider 이름이 필요한데 없다. → 문자열 `"unknown"`을 지어냈다.

## 변경

- `Retry.error_message`가 자기 `phase`를 렌더한다. → 3~4번이 필요 없어진다.
- `` `Streaming_timeout ``이 provider를 `string option`으로 싣고 다닌다. provider가 있으면 그 이름이 살아남는다.
- provider가 없는 API 레벨 타임아웃은 원래의 API 에러로 되돌아간다. 아무도 안 지어낸다.
- `"unknown"` 리터럴 제거.

## 왜 테스트가 못 잡았나

- `test_roundtrip_provider_streaming_timeout`이 provider 자리에 `_`를 두고 레코드를 `; _ }`로 열었다. `"openai"` → `"unknown"`이 되어도 통과했다. **둘 다 정확한 값으로 조였다.**
- `test_retry`의 렌더링 표에 `Timeout` 행이 하나 있는데 `phase = None`이었다. 필드를 무시하는 렌더러가 살아남은 이유다. **`Some phase` 케이스 2종을 추가했다.**

## 로컬 검증

```
dune build @packages/agent_core/check            exit 0
runtest-test_error_domain                        exit 0   65 tests
runtest-test_retry                               exit 0    9 tests
```

`error_message`는 모든 타임아웃의 렌더라 전수 확인했다. 옛 문자열을 단언하던 곳은 `test_retry.ml:270` 한 곳이고 `phase = None`이라 렌더가 안 바뀐다. 나머지 `Timeout: ` 매치는 전부 `Unix.error_message`거나 별개 문자열이다.

## 미검증

- 전체 스위트는 안 돌렸다. 변경 범위가 `packages/agent_core` 안이라 해당 패키지 check + 관련 테스트 2종으로 갈음했다. 원격 CI로 확인한다.
