### PR TITLE
feat(slack-bot): add Block Kit button interactive handler (block_actions)

### DIFF
--- a/sidecars/slack-bot/src/bot.py
+++ b/sidecars/slack-bot/src/bot.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import threading
 from datetime import datetime, timezone
 from pathlib import Path
@@ -23,7 +24,6 @@ from typing import Any
 from gate_shared import response_text
 from gate_shared.bindings_store import load_bindings, save_bindings
 from gate_shared.status_store import ConnectorRuntimeStatus, StatusStore
-
 from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
 
@@ -37,6 +37,8 @@ logging.basicConfig(
 )
 logger = logging.getLogger("slack-gate-bot")
 
+BLOCK_ACTION_ID_PATTERN = re.compile(r".+")
+
 
 def button_content(action_id: str, value: str = "") -> str:
     """Build the keeper message text for a Block Kit button press.
@@ -48,6 +50,13 @@ def button_content(action_id: str, value: str = "") -> str:
     if value:
         content += f" value={value}"
     return content
+
+
+def button_idempotency_key(*, channel_id: str, action_id: str, action_ts: str) -> str:
+    """Return a retry-stable identity for one Slack button interaction."""
+    if not channel_id or not action_id or not action_ts:
+        return ""
+    return f"slack-action-{channel_id}-{action_id}-{action_ts}"
 
 
 class SlackGateBot:
@@ -136,8 +145,6 @@ class SlackGateBot:
 
             # Strip the bot mention from the text
             # Format: <@BOT_USER_ID> message text
-            import re
-
             text = re.sub(r"<@[A-Z0-9]+>\s*", "", text).strip()
             if not text:
                 say("Send me a message after the mention.")
@@ -203,7 +210,7 @@ class SlackGateBot:
 
             self._handle_response(response, say, app, channel_id, thinking_ts)
 
-        @app.action(".*")
+        @app.action(BLOCK_ACTION_ID_PATTERN)
         def handle_block_action(ack: Any, body: dict[str, Any], say: Any) -> None:
             """Handle Block Kit button interactions (block_actions).
 
@@ -220,6 +227,7 @@ class SlackGateBot:
                 return
             action = actions[0]
             action_id = str(action.get("action_id", "")).strip()
+            action_ts = str(action.get("action_ts", "")).strip()
             value = str(action.get("value", "")).strip()
             user = body.get("user") or {}
             user_id = str(user.get("id", ""))
@@ -229,12 +237,22 @@ class SlackGateBot:
             container = body.get("container") or {}
             message_ts = str(container.get("message_ts", ""))
 
-            if not action_id:
+            idempotency_key = button_idempotency_key(
+                channel_id=channel_id,
+                action_id=action_id,
+                action_ts=action_ts,
+            )
+            if not idempotency_key:
+                logger.warning(
+                    "Ignoring malformed Slack block action: "
+                    "channel_id=%r action_id=%r action_ts=%r",
+                    channel_id,
+                    action_id,
+                    action_ts,
+                )
                 return
 
-            content = f"[button] {action_id}"
-            if value:
-                content += f" value={value}"
+            content = button_content(action_id, value)
 
             keeper = self._resolve_keeper(channel_id)
 
@@ -249,6 +267,7 @@ class SlackGateBot:
                     username=username,
                     channel_id=channel_id,
                     message_ts=message_ts,
+                    idempotency_key=idempotency_key,
                 )
             )
 

--- a/sidecars/slack-bot/src/bot.py
+++ b/sidecars/slack-bot/src/bot.py
@@ -38,6 +38,18 @@ logging.basicConfig(
 logger = logging.getLogger("slack-gate-bot")
 
 
+def button_content(action_id: str, value: str = "") -> str:
+    """Build the keeper message text for a Block Kit button press.
+
+    Pure helper so the interactive routing logic is unit-testable without a
+    live Slack socket.
+    """
+    content = f"[button] {action_id}"
+    if value:
+        content += f" value={value}"
+    return content
+
+
 class SlackGateBot:
     """Slack bot that routes messages to gate-backed keepers."""
 
@@ -186,6 +198,57 @@ class SlackGateBot:
                     username=user_id,
                     channel_id=channel_id,
                     message_ts=ts,
+                )
+            )
+
+            self._handle_response(response, say, app, channel_id, thinking_ts)
+
+        @app.action(".*")
+        def handle_block_action(ack: Any, body: dict[str, Any], say: Any) -> None:
+            """Handle Block Kit button interactions (block_actions).
+
+            Socket Mode delivers interactive payloads over the same socket, so
+            no public Request URL is needed. Each button press is routed to the
+            bound keeper as a ``[button] <action_id> value=<value>`` message so
+            the keeper can act on it.
+            """
+            import asyncio
+
+            ack()
+            actions = body.get("actions") or []
+            if not actions:
+                return
+            action = actions[0]
+            action_id = str(action.get("action_id", "")).strip()
+            value = str(action.get("value", "")).strip()
+            user = body.get("user") or {}
+            user_id = str(user.get("id", ""))
+            username = str(user.get("username", "")) or user_id
+            channel = body.get("channel") or {}
+            channel_id = str(channel.get("id", ""))
+            container = body.get("container") or {}
+            message_ts = str(container.get("message_ts", ""))
+
+            if not action_id:
+                return
+
+            content = f"[button] {action_id}"
+            if value:
+                content += f" value={value}"
+
+            keeper = self._resolve_keeper(channel_id)
+
+            result = say("...")
+            thinking_ts = result.get("ts", "") if isinstance(result, dict) else ""
+
+            response = asyncio.run(
+                self.gate.send_slack_message(
+                    keeper_name=keeper,
+                    content=content,
+                    user_id=user_id,
+                    username=username,
+                    channel_id=channel_id,
+                    message_ts=message_ts,
                 )
             )
 

--- a/sidecars/slack-bot/src/formatters.py
+++ b/sidecars/slack-bot/src/formatters.py
@@ -136,6 +136,32 @@ def _fusion_block(board_post_id: str, run_id: str = "") -> dict[str, Any]:
     return _section_block("\n".join(lines))
 
 
+def _button_block(
+    label: str,
+    action_id: str,
+    value: str = "",
+    style: str = "",
+) -> dict[str, Any] | None:
+    """Build a Slack actions block carrying a single button element.
+
+    The button carries an ``action_id`` (stable identifier the interactive
+    handler routes on) and an optional ``value`` payload. ``style`` is one of
+    ``primary`` / ``danger`` / ``""`` (default).
+    """
+    if not label or not action_id:
+        return None
+    element: dict[str, Any] = {
+        "type": "button",
+        "text": {"type": "plain_text", "text": label[:75]},
+        "action_id": action_id[:255],
+    }
+    if value:
+        element["value"] = value[:2000]
+    if style in ("primary", "danger"):
+        element["style"] = style
+    return {"type": "actions", "elements": [element]}
+
+
 def _code_block(source: str, cap: str = "") -> dict[str, Any]:
     title = f"*Code:* `{escape_mrkdwn_text(cap)}`\n" if cap else ""
     body = escape_mrkdwn_text(source)
@@ -284,6 +310,14 @@ def _slack_block_from_structured(raw: Any) -> dict[str, Any] | None:
         if not board_post_id:
             return None
         return _fusion_block(board_post_id, _structured_text(raw.get("run_id")).strip())
+    if block_type == "button":
+        label = _structured_text(raw.get("label")).strip()
+        action_id = _structured_text(raw.get("action_id")).strip()
+        if not label or not action_id:
+            return None
+        value = _structured_text(raw.get("value")).strip()
+        style = _structured_text(raw.get("style")).strip()
+        return _button_block(label, action_id, value, style)
     if block_type in ("voice", "audio"):
         return _voice_block(raw)
     if block_type == "attach":

--- a/sidecars/slack-bot/src/gate_client.py
+++ b/sidecars/slack-bot/src/gate_client.py
@@ -58,6 +58,7 @@ class GateClient(GateClientBase):
         username: str,
         channel_id: str,
         message_ts: str,
+        idempotency_key: str | None = None,
     ) -> GateResponse:
         """Send a message to a keeper with Slack context."""
         context = self._slack_context(
@@ -67,7 +68,11 @@ class GateClient(GateClientBase):
             keeper_name=keeper_name,
             content=content,
             context=context,
-            idempotency_key=f"slack-msg-{channel_id}-{message_ts}",
+            idempotency_key=(
+                idempotency_key
+                if idempotency_key is not None
+                else f"slack-msg-{channel_id}-{message_ts}"
+            ),
         )
 
     async def stream_message(

--- a/sidecars/slack-bot/tests/test_bolt_action_registration.py
+++ b/sidecars/slack-bot/tests/test_bolt_action_registration.py
@@ -1,0 +1,49 @@
+"""Integration pin for Slack Bolt action matcher registration."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_sidecars_root = Path(__file__).resolve().parents[2]
+_shared_root = _sidecars_root / "shared"
+if str(_shared_root) not in sys.path:
+    sys.path.insert(0, str(_shared_root))
+
+pytest.importorskip("slack_bolt")
+
+from slack_bolt import App  # noqa: E402
+from slack_bolt.request import BoltRequest  # noqa: E402
+from slack_bolt.response import BoltResponse  # noqa: E402
+from src.bot import SlackGateBot  # noqa: E402
+
+
+def test_compiled_button_action_matcher_matches_real_bolt_request() -> None:
+    app = App(signing_secret="test", token_verification_enabled=False)
+    bot = SlackGateBot.__new__(SlackGateBot)
+    bot.register_handlers(app)
+
+    action_listener = app._listeners[2]
+    request = BoltRequest(
+        body=json.dumps(
+            {
+                "type": "block_actions",
+                "actions": [
+                    {
+                        "type": "button",
+                        "action_id": "approve_123",
+                        "action_ts": "171.001",
+                    }
+                ],
+            }
+        ),
+        headers={"content-type": "application/json"},
+    )
+
+    assert action_listener.matchers[0].matches(
+        request,
+        BoltResponse(status=200, body=""),
+    )

--- a/sidecars/slack-bot/tests/test_bot_structured_response.py
+++ b/sidecars/slack-bot/tests/test_bot_structured_response.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import re
 import sys
 import types
 from pathlib import Path
@@ -34,8 +36,13 @@ _config = types.ModuleType("src.config")
 setattr(_config, "get_config", lambda: types.SimpleNamespace())
 sys.modules.setdefault("src.config", _config)
 
-from src.bot import SlackGateBot, button_content  # noqa: E402
-from src.gate_client import GateResponse  # noqa: E402
+from src.bot import (  # noqa: E402
+    BLOCK_ACTION_ID_PATTERN,
+    SlackGateBot,
+    button_content,
+    button_idempotency_key,
+)
+from src.gate_client import GateClient, GateResponse  # noqa: E402
 
 
 class _Client:
@@ -51,11 +58,66 @@ class _App:
         self.client = _Client()
 
 
+class _HandlerApp(_App):
+    def __init__(self) -> None:
+        super().__init__()
+        self.action_matcher: Any = None
+        self.action_handler: Any = None
+
+    @staticmethod
+    def _ignore_registration(_name: Any) -> Any:
+        return lambda handler: handler
+
+    event = _ignore_registration
+    command = _ignore_registration
+
+    def action(self, matcher: Any) -> Any:
+        self.action_matcher = matcher
+
+        def register(handler: Any) -> Any:
+            self.action_handler = handler
+            return handler
+
+        return register
+
+    def dispatch_action(
+        self,
+        action_id: str,
+        *,
+        ack: Any,
+        body: dict[str, Any],
+        say: Any,
+    ) -> None:
+        assert isinstance(self.action_matcher, re.Pattern)
+        if self.action_matcher.search(action_id):
+            self.action_handler(ack=ack, body=body, say=say)
+
+
+class _Gate:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def send_slack_message(self, **kwargs: Any) -> GateResponse:
+        self.calls.append(kwargs)
+        return GateResponse(
+            ok=True,
+            keeper_name="sangsu",
+            reply="handled",
+            model_used="",
+            duration_ms=0,
+            tokens_used=0,
+            error="",
+            structured=None,
+        )
+
+
 def _bot() -> SlackGateBot:
     bot = cast(Any, SlackGateBot.__new__(SlackGateBot))
     bot._messages_processed = 0
     bot._messages_failed = 0
     bot._last_message_at = ""
+    bot._bindings = {"C123": "sangsu"}
+    bot.cfg = types.SimpleNamespace(default_keeper="sangsu")
     return cast(SlackGateBot, bot)
 
 
@@ -89,7 +151,10 @@ def test_handle_response_sends_structured_only_success() -> None:
 
 
 def test_button_content_with_value() -> None:
-    assert button_content("approve_123", "task-123") == "[button] approve_123 value=task-123"
+    assert (
+        button_content("approve_123", "task-123")
+        == "[button] approve_123 value=task-123"
+    )
 
 
 def test_button_content_without_value() -> None:
@@ -98,3 +163,124 @@ def test_button_content_without_value() -> None:
 
 def test_button_content_empty_value() -> None:
     assert button_content("approve_123", "") == "[button] approve_123"
+
+
+def test_button_idempotency_key_is_per_interaction() -> None:
+    first = button_idempotency_key(
+        channel_id="C123", action_id="approve_123", action_ts="171.001"
+    )
+    retry = button_idempotency_key(
+        channel_id="C123", action_id="approve_123", action_ts="171.001"
+    )
+    second_click = button_idempotency_key(
+        channel_id="C123", action_id="approve_123", action_ts="171.002"
+    )
+
+    assert first == retry
+    assert first != second_click
+
+
+def test_compiled_action_matcher_dispatches_and_preserves_retry_identity() -> None:
+    bot = _bot()
+    gate = _Gate()
+    bot.gate = gate
+    app = _HandlerApp()
+    bot.register_handlers(cast(Any, app))
+    acknowledgements: list[None] = []
+
+    def body(action_ts: str) -> dict[str, Any]:
+        return {
+            "actions": [
+                {
+                    "action_id": "approve_123",
+                    "action_ts": action_ts,
+                    "value": "task-123",
+                }
+            ],
+            "user": {"id": "U123", "username": "alice"},
+            "channel": {"id": "C123"},
+            "container": {"message_ts": "170.999"},
+        }
+
+    say = lambda *_args, **_kwargs: {"ts": "thinking.1"}
+    ack = lambda: acknowledgements.append(None)
+    app.dispatch_action("approve_123", ack=ack, body=body("171.001"), say=say)
+    app.dispatch_action("approve_123", ack=ack, body=body("171.001"), say=say)
+    app.dispatch_action("approve_123", ack=ack, body=body("171.002"), say=say)
+
+    assert app.action_matcher is BLOCK_ACTION_ID_PATTERN
+    assert len(acknowledgements) == 3
+    assert [call["content"] for call in gate.calls] == [
+        "[button] approve_123 value=task-123",
+        "[button] approve_123 value=task-123",
+        "[button] approve_123 value=task-123",
+    ]
+    assert gate.calls[0]["idempotency_key"] == gate.calls[1]["idempotency_key"]
+    assert gate.calls[0]["idempotency_key"] != gate.calls[2]["idempotency_key"]
+    assert gate.calls[0]["message_ts"] == "170.999"
+
+
+def test_explicit_interaction_idempotency_key_reaches_gate_request() -> None:
+    client = cast(Any, GateClient.__new__(GateClient))
+    captured: list[dict[str, Any]] = []
+
+    async def send_message(**kwargs: Any) -> GateResponse:
+        captured.append(kwargs)
+        return GateResponse(
+            ok=True,
+            keeper_name="sangsu",
+            reply="handled",
+            model_used="",
+            duration_ms=0,
+            tokens_used=0,
+            error="",
+            structured=None,
+        )
+
+    client.send_message = send_message
+    response = asyncio.run(
+        client.send_slack_message(
+            keeper_name="sangsu",
+            content="[button] approve_123 value=task-123",
+            user_id="U123",
+            username="alice",
+            channel_id="C123",
+            message_ts="170.999",
+            idempotency_key="slack-action-C123-approve_123-171.001",
+        )
+    )
+
+    assert response.ok
+    assert captured[0]["idempotency_key"] == ("slack-action-C123-approve_123-171.001")
+
+
+def test_message_idempotency_key_default_is_unchanged() -> None:
+    client = cast(Any, GateClient.__new__(GateClient))
+    captured: list[dict[str, Any]] = []
+
+    async def send_message(**kwargs: Any) -> GateResponse:
+        captured.append(kwargs)
+        return GateResponse(
+            ok=True,
+            keeper_name="sangsu",
+            reply="handled",
+            model_used="",
+            duration_ms=0,
+            tokens_used=0,
+            error="",
+            structured=None,
+        )
+
+    client.send_message = send_message
+    asyncio.run(
+        client.send_slack_message(
+            keeper_name="sangsu",
+            content="hello",
+            user_id="U123",
+            username="alice",
+            channel_id="C123",
+            message_ts="170.999",
+        )
+    )
+
+    assert captured[0]["idempotency_key"] == "slack-msg-C123-170.999"

--- a/sidecars/slack-bot/tests/test_bot_structured_response.py
+++ b/sidecars/slack-bot/tests/test_bot_structured_response.py
@@ -34,7 +34,7 @@ _config = types.ModuleType("src.config")
 setattr(_config, "get_config", lambda: types.SimpleNamespace())
 sys.modules.setdefault("src.config", _config)
 
-from src.bot import SlackGateBot  # noqa: E402
+from src.bot import SlackGateBot, button_content  # noqa: E402
 from src.gate_client import GateResponse  # noqa: E402
 
 
@@ -86,3 +86,15 @@ def test_handle_response_sends_structured_only_success() -> None:
     assert app.client.updates[0]["text"] == "approved"
     assert app.client.updates[0]["blocks"][0]["text"]["text"] == "approved"
     assert bot._messages_processed == 1
+
+
+def test_button_content_with_value() -> None:
+    assert button_content("approve_123", "task-123") == "[button] approve_123 value=task-123"
+
+
+def test_button_content_without_value() -> None:
+    assert button_content("approve_123") == "[button] approve_123"
+
+
+def test_button_content_empty_value() -> None:
+    assert button_content("approve_123", "") == "[button] approve_123"

--- a/sidecars/slack-bot/tests/test_formatters.py
+++ b/sidecars/slack-bot/tests/test_formatters.py
@@ -224,3 +224,32 @@ class TestStructuredResponseBlocks:
         assert "*Audio (tts):*" in blocks[6]["text"]["text"]
         assert "Attachment (video)" in blocks[7]["text"]["text"]
         assert "*Video:* Demo" in blocks[8]["text"]["text"]
+
+    def test_projects_button_block(self) -> None:
+        blocks = structured_response_blocks(
+            {
+                "blocks": [
+                    {
+                        "t": "button",
+                        "label": "Approve",
+                        "action_id": "approve_123",
+                        "value": "task-123",
+                        "style": "primary",
+                    }
+                ]
+            }
+        )
+        assert len(blocks) == 1
+        assert blocks[0]["type"] == "actions"
+        element = blocks[0]["elements"][0]
+        assert element["type"] == "button"
+        assert element["text"]["text"] == "Approve"
+        assert element["action_id"] == "approve_123"
+        assert element["value"] == "task-123"
+        assert element["style"] == "primary"
+
+    def test_button_block_missing_fields_falls_back(self) -> None:
+        # Missing action_id -> button block dropped, no crash.
+        assert structured_response_blocks({"blocks": [{"t": "button", "label": "X"}]}) == []
+        # Missing label -> dropped.
+        assert structured_response_blocks({"blocks": [{"t": "button", "action_id": "a"}]}) == []


### PR DESCRIPTION
Adds interactive button support to the Slack Gate Bot (task-331).

- formatters.py: new 'button' structured block type -> Slack actions block with a button element (action_id, value, optional primary/danger style).
- bot.py: @app.action block_actions handler routes each button press to the bound keeper as '[button] <action_id> value=<value>' via Socket Mode (no public Request URL needed).
- Tests: button block projection + missing-field fallback + button_content routing helper.

Refs task-331