### PR TITLE
docs: align English and Korean README with current workflow

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -3,340 +3,306 @@
 [![OCaml](https://img.shields.io/badge/OCaml-5.5-orange.svg)](https://ocaml.org/)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
-[English version](README.md)
+[English](README.md)
 
-> 정확한 설치 릴리스, 로컬 포트, provider 환경변수 같은 휘발성 값의 SSOT는
-> [`README.md`](README.md), [`config/runtime.toml`](config/runtime.toml), typed
-> `masc_config` 도구와 `/api/v1/dashboard/config`입니다. 이 한글 문서는
-> 한국어 진입점이며, 그런 값은 의도적으로 복제하지 않습니다.
+MASC(Multi-Agent Shared Context)는 같은 프로젝트에서 일하는 여러
+에이전트가 작업 상태를 공유하도록 돕는 로컬 MCP 서버입니다. 목표, 작업,
+담당자, 보드 글, 실행 근거를 한 작업 공간에 저장하고 MCP와 웹 대시보드로
+보여줍니다.
 
-**MASC는 agent 작업을 위한 로컬 조율·관찰 레이어입니다.** 저장소 옆에서 MCP 서버로 돌면서 coding agent와 상주 Keeper가 goal, task, board 글, repository ownership, approval state를 같은 workspace에서 공유하게 합니다. 대시보드와 turn receipt로 agent의 결정과 실패를 들여다봅니다.
+**Keeper**는 MASC가 관리하는 선택형 상주 에이전트입니다. 공유 작업 공간에서
+이벤트를 받아 장기 작업을 수행합니다. MASC를 협업용 MCP 서버로만 쓸 때는
+Keeper가 없어도 됩니다.
 
-빠르게 일을 끝내는 도구라기보다, 속도 대신 조율·관찰성·장기 실행 keeper 기반 agent 실험을 택한 도구입니다.
+> **개발 상태:** MASC는 로컬의 신뢰할 수 있는 환경을 대상으로 하는 pre-1.0
+> 프로젝트입니다. 운영 서비스나 보안 경계로 사용할 수 없습니다. Gate, 사람
+> 승인(HITL), Docker 실행은 일부 작업을 제한하지만, 무인 에이전트의 모든 위험한
+> 행동을 막아주지는 않습니다. IDE와 TUI는 실험 단계입니다. `main`의 코드는
+> 최신 공개 바이너리보다 앞서 있을 수 있습니다.
 
-> **개발 상태:** MASC는 아직 pre-1.0 실험입니다. 생산성 도구, production service,
-> 또는 security boundary가 아닙니다. 지금은 로컬 실험과 관찰 용도로만 사용하세요.
-> CODE/IDE 흐름은 아직 실사용 가능한 상태가 아니며, HITL/Sandbox 기능도 사고를
-> 일부 줄이는 운영 장치일 뿐 코드, secret, 인프라, 무인 agent 실행을 보호한다고
-> 믿으면 안 됩니다. 현재 목표는 agent 실패를 충분히 보이게 만들어 어떤 workflow가
-> 쓸모 있어질 수 있는지 찾는 것입니다.
+![MASC 대시보드 개요](docs/screenshots/dashboard/2026-08-21/01-overview.png)
 
-**Keeper**는 MASC가 관리하는 선택적 상주 agent입니다. 서버가 살아 있는 동안 상주하며, heartbeat 주기로 스스로 turn을 돌거나 멘션·메시지를 받으면 반응합니다. 이름은 불프로그의 *던전 키퍼*에서 따왔습니다. 프로젝트 용어일 뿐 아키텍처 주장은 아닙니다.
+로컬에서 실행 중인 MASC를 캡처한 화면입니다. 운영 정보는 알아볼 수 없도록
+바꿨습니다. [대시보드 화면 목록](docs/screenshots/dashboard/2026-08-21/README.md)에서
+24개 화면과 캡처 조건을 확인할 수 있습니다.
 
----
+## 먼저 실행하기
 
-## MASC로 할 수 있는 일 / What you can do
+### 로컬 소스에서 실행
 
-- **Goal·Task를 MCP 도구로 공유합니다.** 작업 소유권, 상태 전이, 검증 증거를 하나의 로컬 workspace에 둡니다.
-- **상주 Keeper를 굴리고 관찰합니다.** Keeper마다 페르소나·목표·지시문을 주고, 같은 주제나 저장소 위에서 서로 소통하게 둡니다.
-- **서로 다른 에이전트 스타일을 실험합니다.** Keeper마다 다른 관심사와 지시문을 줄 수 있고, 한 환경에서 무엇을 결정하고 어디서 부딪히는지 봅니다.
-- **기성 코딩 에이전트를 붙입니다.** MASC는 MCP 서버라, Claude Code·Codex 같은 MCP 클라이언트를 `/mcp`에 연결하면 같은 워크스페이스에 참여합니다 — 태스크 claim·전이, 보드, goal을 공유하고 `masc_broadcast`·@mention으로 Keeper를 깨웁니다. (외부에서 Keeper turn을 동기로 직접 호출하는 도구는 없고, 워크스페이스와 멘션으로 상호작용합니다.)
-- **같이 코드를 만질 때 뻔한 충돌을 줄입니다.** 여러 Keeper가 한 저장소를 고치면 turn·lock·작업자 소유권으로 조율을 시도하지만, concurrency safety를 보장하지는 않습니다.
-- **결정과 실패를 들여다봅니다.** 웹 대시보드로 Keeper / Goal / Task / Board를 실시간으로 보고, turn마다 receipt가 남습니다.
-- **외부 효과는 하나의 Gate로 보냅니다.** Always Allow·LLM Auto Judge·HITL은 비계층 명시 모드입니다. HITL은 exact request를 영속화하되 Keeper를 멈추지 않고, 결정이 오면 해당 lane을 깨웁니다.
-- **Keeper마다 모델을 다르게 설정합니다.** `runtime.toml` 한 줄로 runtime catalog에 있는 provider × model을 Keeper별로 지정합니다.
-
----
-
-## 기능 / Features
-
-상태 표기 — ✅ 지금 동작 · 🟡 부분 동작 · ❌ 미동작. 상태는 로컬 구현 경로 기준이며, production readiness나 security assurance가 아닙니다. 더 넓은 계획(cluster mode, 외부 IDE 확장, 추가 플랫폼 바이너리 등)은 [`ROADMAP.md`](ROADMAP.md)를 참고해 주세요.
-
-| 기능 | 상태 | 한 줄 설명 | 사용자 진입점 |
-|------|:----:|-----------|--------------|
-| **Keepers** | ✅ | 페르소나·목표·지시문을 가진 상주 에이전트. 서버 기동 시 자동 부팅, 상태는 디스크에 영속 | `.masc/config/keepers/*.toml` |
-| **Gate: Always Allow / Auto Judge / HITL** | 🟡 | exact 1회성 grant와 Keeper별 wake-up을 갖는 제품 중립 외부 효과 경계 | 대시보드 승인 큐 |
-| **Board** | ✅ | Keeper들이 글·댓글·투표로 비동기 협업, 게시가 관련 Keeper를 깨움 | `masc_board_*` 툴 / 대시보드 |
-| **Sandbox (Docker)** | 🟡 | Docker profile 셸 실행은 컨테이너를 쓰지만, local profile과 fallback 경로가 있어 security boundary가 아님 | keeper toml `sandbox_profile` |
-| **Dashboard** | ✅ | Keeper/Goal/Task/Board를 실시간으로 보고 명령을 내리는 웹 SPA | `dashboard/` (vite) |
-| **TUI** | ❌ | Not working — `masc-tui` 실행 파일이 있으나, CJK/emoji 레이아웃·스트리밍 진행·rich-block 렌더링 등 주요 공백으로 실제로 사용할 수 없음 | `masc-tui` |
-| **CODE / IDE (관망형)** | ❌ | Not working — LSP 프록시·주석 오버레이·대시보드 CODE 셸은 구현되어 있으나, 사람이 명령만 내리는 관망형 흐름이 검증되지 않아 실제로 사용할 수 없음 | 대시보드 Code |
-| **OpenTelemetry** | 🟡 | OTLP HTTP exporter + GenAI semconv span/metric은 동작하나, 아직 수집되지 않는 signal과 instrumentation 공백이 많음 | `OTEL_EXPORTER_OTLP_ENDPOINT` |
-| **Goal + Task** | 🟡 | Goal/Task CRUD·전이·검증·프롬프트 주입은 동작. 자동 스케줄링은 미구현 | `masc_goal_*` / `masc_*task*` 툴 |
-| **Multi-Runtime** | 🟡 | Keeper별 provider×model 라우팅 | `runtime.toml` |
-| **Provider Failover** | 🟡 | `[runtime.lanes]`로 순서 있는 failover 그룹 지원; health 기반 자동 회전은 미구현 | `runtime.toml` `[runtime.lanes]` |
-| **Fusion (+ JoJ)** | 🟡 | 여러 모델에 같은 질문 후 심판 모델이 종합. Simple/Refine/Conditional 동작, JoJ는 `runtime.toml`의 judges preset 필요 | `masc_fusion` 툴 |
-| **Multi-Channel** | 🟡 | 외부 채널 메시지로 turn 시작/응답. Discord·Slack 라이브 동작, Telegram은 사이드카 필요 | `POST /api/v1/gate/message` |
-
-### 현재 동작과 한계
-
-- **Keepers** — 각 Keeper는 서버가 살아 있는 동안 상주하는 장기 실행 에이전트입니다. heartbeat로 깨어나 turn을 돌고, 메모리·결정 로그는 디스크에 남아 재시작에도 복원됩니다. **한 Keeper는 한 번에 turn 하나만 돕니다**(동시에 두 일을 하지 않음) — 병렬은 여러 Keeper가 함께 도는 데서 옵니다. MASC는 전역 active-Keeper 상한을 강제하지 않습니다.
-- **Gate / HITL** — 디스패치 경계는 opaque operation identity와 complete typed input을 하나의 Gate에 보냅니다. Workspace/Keeper Always Allow는 즉시 진행하고 Auto Judge는 비동기로 판단하며 Manual은 HITL request를 영속화합니다. Deferred request는 promise를 기다리지 않고 Keeper로 반환되며, 결정 후 깨어난 해당 Keeper lane에서 exact 승인 request가 한 번만 소비됩니다. Gate는 승인 workflow이며 sandbox나 credential boundary가 아닙니다.
-- **Sandbox** — `docker run --rm`을 실제로 호출하고 cap-drop / no-new-privileges / read-only rootfs를 적용합니다. MASC는 Docker 동작을 관측하지만 전역 spawn slot으로 사전 허가하지 않습니다. 네트워크는 keeper의 `network_mode`로 제어합니다(기본 `inherit`, `none`으로 격리 가능). *한계*: 모든 Keeper가 docker가 아닙니다(일부는 `local`=호스트 실행). 이미지가 없고 playground 안이면 host 실행으로 강등됩니다(텔레메트리 기록). security boundary로 취급하지 마세요.
-- **Multi-Runtime** — `runtime.toml`의 `runtime.assignments`에 `keeper = provider.model` 한 줄이면 그 Keeper의 매 turn이 해당 provider로 갑니다.
-- **Provider Failover** — `runtime.toml`의 `[runtime.lanes]`가 순서 있는 failover 그룹을 정의하며, 현재 runtime이 거부되면 Keeper는 lane의 다음 runtime으로 넘어갑니다. provider health 기반 자동 회전은 미구현입니다.
-- **Fusion + JoJ** — Keeper가 `masc_fusion`을 호출하면 패널 모델들이 같은 질문에 각자 답고 심판 모델이 합의/모순/맹점을 종합합니다. *한계*: JoJ(Judge of Judges) 위상은 `config/runtime.toml`의 judges preset(RFC-0283)이 설정돼 있지 않으면 fail-closed로 에러를 반환합니다. run 결과는 `.masc/fusion-runs.jsonl`에 영속됩니다.
-- **Goal + Task** — Goal/Task는 MCP 툴로 만들고 상태 전이하며, active goal은 Keeper system prompt에 주입됩니다. turn은 채널/이벤트로 구동됩니다. (goal-loop OODA 기계는 2026-07-21 전면 은퇴 — RFC-0352 Path B: Goal 엔티티·MCP tool·task linkage는 유지, 스케줄러 스크립트·서버 broadcast·대시보드 패널은 제거)
-- **OpenTelemetry** — OTLP HTTP exporter와 GenAI semconv span/metric이 동작합니다. *한계*: 아직 수집되지 않는 signal과 instrumentation 공백이 많습니다. 예를 들어 Keeper turn 낮은 수준 이벤트, fusion 내부 metric, provider별 latency breakdown 등은 부분적으로만 커버됩니다.
-- **CODE / IDE (관망형, 미동작)** — 사람이 코드를 직접 수정하지 않고 에이전트에게 명령만 내리는 관망형 IDE를 지향합니다. LSP 프록시·주석 오버레이·대시보드 CODE 셸은 구현되어 있으나, **관망형 명령 흐름이 검증되지 않아 현재 실사용 가능한 상태가 아닙니다.**
-
----
-
-## 빠른 시작 / Quick Start
-
-```bash
-# 1. 바이너리 설치 (macOS arm64 / Linux x86_64)
-brew install jeong-sik/masc/masc            # Homebrew (이 repo의 Formula/masc.rb)
-#   또는:  curl -fsSL https://raw.githubusercontent.com/jeong-sik/masc/main/scripts/install.sh | bash
-#   소스 빌드: git clone https://github.com/jeong-sik/masc.git && cd masc &&
-#     scripts/opam-pin-external-deps.sh --install && opam install . --deps-only &&
-#     scripts/dune-local.sh build @default
-
-# 2. 설정 시드 + provider 키 입력
-masc init
-#   .masc/config/.env.local 편집:
-#     export OLLAMA_CLOUD_API_KEY=...     # 아래 표에서 하나 선택
-
-# 3. 키 적용 + 시작
-source .masc/config/.env.local && masc start
-curl http://127.0.0.1:8935/health        # → 200 OK
-
-# 4. (선택) 대시보드
-cd dashboard && pnpm install && pnpm dev
-```
-
-Provider 키 (사용할 것을 `.masc/config/.env.local`에):
-
-| `runtime.toml` provider | 환경 변수 |
-|---|---|
-| `ollama_cloud` | `OLLAMA_CLOUD_API_KEY` |
-| `deepseek` | `DEEPSEEK_API_KEY` |
-| `glm-coding` | `ZAI_API_KEY_SB` |
-| `ollama` (로컬) | — (키 불필요) |
-
-> `masc init`이 `.masc/config/runtime.toml`을 시드합니다(`[runtime].default` 포함). 서버가 `refusing to boot`를 로그하면 워크스페이스에서 먼저 `masc init`을 실행하세요. `masc start`는 subcommand 없이 `masc`를 실행한 것과 동일(가이드용 명시적 이름).
-
----
-
-## 설치 / Install
-
-### 바이너리 (prebuilt)
-
-설치 스크립트를 먼저 확인하고 릴리스를 고정하는 경로를 권장합니다:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/jeong-sik/masc/main/scripts/install.sh -o /tmp/masc-install.sh
-less /tmp/masc-install.sh
-bash /tmp/masc-install.sh --version <release-tag>
-```
-
-버리는 로컬 환경에서는 편의상 아래 한 줄도 사용할 수 있습니다:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/jeong-sik/masc/main/scripts/install.sh | bash
-```
-
-`$HOME/.local/bin/masc`에 바이너리를 설치하고 `runtime.toml`을 `<base-path>/.masc/config/`에 시드합니다. 제공 바이너리: **macOS arm64**, **Linux x86_64**. 그 외 플랫폼은 소스 빌드를 사용합니다.
-
-설치 스크립트 요구 도구: `curl`과 기본 Unix 도구(`uname`, `chmod`, `mkdir`, `mktemp`)입니다. `jq`는 `--version` / `MASC_VERSION`을 생략해 GitHub latest release를 조회할 때만 필요합니다. Python/tomllib는 사용하지 않습니다. 재현 가능한 설치가 필요하면 `--version <release-tag>`로 고정하세요.
-
-릴리스 바이너리는 GitHub releases에서 내려받습니다. 선택한 릴리스가 `SHA256SUMS`를 제공하면 설치 스크립트는 다운로드한 바이너리와 seed config(`runtime.toml`)를 검증합니다. 기대 항목은 모두 존재해야 하며 값도 일치해야 합니다. 일부 기존 릴리스는 `SHA256SUMS`를 제공하지 않으며, 그런 릴리스는 검증된 바이너리 설치 경로를 사용할 수 없습니다. checksum 파일을 가져오지 못하면 기본값은 실패 종료입니다. 이 경우 아래 source build 경로를 쓰거나, 버리는 로컬 환경이나 air-gapped 설치에서만 `--allow-unverified` 또는 `MASC_ALLOW_UNVERIFIED=1`로 검증을 명시적으로 우회하세요. 이 경우 스크립트가 경고를 출력한 뒤 계속합니다.
-
-> `runtime.toml`이 없거나 `[runtime].default`가 비어 있으면 서버는 `refusing to boot` 로그를 남기고 status 1로 종료합니다 — 환경 기본값 폴백은 없습니다. 기동에 필요한 파일이므로 설치 스크립트가 [`config/runtime.toml`](config/runtime.toml)을 시드합니다. 직접 작성하려면 `[runtime].default = "<provider>.<model>"`와 그에 대응하는 `[provider.model]` runtime binding table을 정의하세요. `[runtime.assignments]`는 선택 사항이며 Keeper별 override에만 씁니다.
-
-### 소스 빌드 / From source
+기본 실행 스크립트는 `config/runtime.toml`에 지정된 기본 런타임을 사용합니다.
+`classic` Keeper 네 명을 추가하고 서버를 시작한 뒤 대시보드를 엽니다. 이 경로를
+사용하려면 OCaml 의존성이 먼저 설치되어 있어야 합니다.
 
 ```bash
 git clone https://github.com/jeong-sik/masc.git
 cd masc
-scripts/opam-pin-external-deps.sh --install   # 외부 OCaml 의존성 핀 및 설치
+
+export OLLAMA_CLOUD_API_KEY=...
+./quickstart.sh
+```
+
+기본값은 다음과 같습니다.
+
+- 런타임 상태: `~/masc-quickstart/.masc`
+- HTTP 포트: `8935`
+- 대시보드: `http://127.0.0.1:8935/dashboard/`
+- MCP 주소: `http://127.0.0.1:8935/mcp`
+- Keeper 구성: `classic`
+- 런타임: `config/runtime.toml`의 현재 `[runtime].default`
+
+`--base-path`, `--team`, `--port`, `--no-open`, `--no-start` 옵션은
+`./quickstart.sh --help`에서 확인할 수 있습니다.
+
+`./quickstart.sh --docker`는 소스에서 완결된 컨테이너 이미지를 만듭니다.
+컨테이너는 네트워크 주소에 바인딩되므로 대시보드 데이터를 읽으려면 인증
+토큰이 필요합니다. 대시보드를 간단히 확인하려면 loopback에 바인딩되는 기본
+실행이 낫습니다.
+
+### 소스에서 직접 빌드
+
+필요한 OCaml과 Dune 버전은 `dune-project`에 적혀 있습니다.
+
+```bash
+scripts/opam-pin-external-deps.sh --install
 opam install . --deps-only
 scripts/dune-local.sh build @default
+
+export OLLAMA_CLOUD_API_KEY=...
+./start-masc.sh --http --base-path "$PWD" --port 8935
+curl http://127.0.0.1:8935/health
 ```
 
-요구 사항: OCaml 5.5.0 (`dune-project`에 고정), opam ≥ 2.0, dune ≥ 3.22. 빌드/테스트/CI 세부는 [`CONTRIBUTING.md`](CONTRIBUTING.md)를 참고해 주세요.
+`start-masc.sh`는 대시보드 소스가 저장된 결과물보다 새로우면 대시보드도
+빌드합니다. Vite로 대시보드를 개발할 때만 `cd dashboard && pnpm dev`를 따로
+실행하면 됩니다.
 
----
+### 공개 바이너리 설치
 
-## 실행 / Run
-
-MASC는 MCP 서버입니다. 기동한 뒤 에이전트/MCP 클라이언트를 그 서버에 붙입니다.
+공개 릴리스는 `main`보다 늦을 수 있습니다. 먼저
+[GitHub Releases](https://github.com/jeong-sik/masc/releases)에서 설치할 태그를
+고르세요. 설치 스크립트도 같은 태그에서 내려받아야 새 설치 스크립트와 예전
+릴리스 파일을 섞지 않을 수 있습니다.
 
 ```bash
-# 1. 서버 기동 (loopback)
-PORT=8935   # 8935가 이미 사용 중이면 다른 로컬 포트 사용
-masc --base-path "$PWD" --port "$PORT"     # 바이너리 설치 시
-# 또는 소스에서:
-./start-masc.sh --http --port "$PORT"
-
-# 2. 상태 확인
-curl "http://127.0.0.1:${PORT}/health"
-
-# 3. MCP 클라이언트를 http://127.0.0.1:${PORT}/mcp 에 연결
+TAG=vX.Y.Z
+curl -fsSL "https://raw.githubusercontent.com/jeong-sik/masc/${TAG}/scripts/install.sh" \
+  -o /tmp/masc-install.sh
+less /tmp/masc-install.sh
+bash /tmp/masc-install.sh --version "$TAG"
 ```
 
-| 실행 모드 | 명령 | 용도 |
-|----------|------|------|
-| 전체 런타임 | `./start-masc.sh --http --port <port>` | Keeper 스케줄러 포함 정식 기동 |
-| 격리 기동 | `scripts/run-local.sh --target-dir /path` | 폴더별 격리, 로컬 포트 자동 할당 |
-| Loopback | `scripts/start-loopback.sh` | 고정 loopback 포트, 스케줄러 끔(로컬 디버깅) |
+설치 방식은 선택한 태그에 따라 달라집니다. 최근 릴리스의 스크립트는
+`SHA256SUMS`가 있으면 내려받은 파일을 검증하고, 필요한 파일이 없으면 설치를
+중단합니다. 지원 플랫폼은 각 릴리스에 첨부된 파일을 기준으로 확인하세요. 설치가
+끝나면 스크립트가 출력한 명령으로 서버를 시작합니다.
 
-대시보드는 별도로 띄웁니다:
+## MCP 클라이언트 연결
 
-```bash
-cd dashboard && pnpm install && pnpm dev   # vite가 로컬 서버로 프록시
-# 프로덕션 빌드: pnpm build
+공개 MCP 경로는 HTTP입니다. 사용하는 MCP 클라이언트 설정에 아래 항목을
+합치면 됩니다.
+
+```json
+{
+  "mcpServers": {
+    "masc": {
+      "type": "http",
+      "url": "http://127.0.0.1:8935/mcp"
+    }
+  }
+}
 ```
 
-바이너리 설치 스크립트는 dashboard 소스를 clone하지 않습니다. 위 dashboard 명령은 repository checkout에서 실행하는 개발 경로입니다. 로컬 dashboard auth와 admin token 설정은 [`docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md`](docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md)를 참고하세요.
+클라이언트가 연결되면 아래 두 호출로 첫 작업을 시작할 수 있습니다.
 
----
+```text
+masc_start(path="/path/to/project", task_title="첫 작업 설명")
+masc_status()
+```
 
-## 설정 / Configuration
+`masc_start`는 작업할 프로젝트를 선택하고 작업 공간에 참여합니다. 제목을
+전달하면 새 작업을 만들고 자신이 맡습니다. 이후 MASC 도구를 통해 목표, 작업,
+보드 글, 상태 변경을 다른 에이전트와 공유합니다.
 
-런타임 설정과 상태는 `--base-path` 아래 `.masc/`에 모입니다. 설정 파일은 `.masc/config/`에 있습니다.
+loopback 개발 환경에서 토큰 없이 연결할 수 있는지는 현재 인증 설정에 따라
+달라집니다. loopback이 아닌 주소에 바인딩하거나 인증을 엄격하게 설정하면
+토큰이 필요합니다. 자세한 설정은 [`docs/MCP-TEMPLATE.md`](docs/MCP-TEMPLATE.md)와
+[`docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md`](docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md)를
+참고하세요.
 
-**시작에 필요한 것**
+## 현재 범위
 
-| 파일 | 역할 |
-|------|------|
-| `runtime.toml` | provider/model 카탈로그 + `[runtime].default`. 기동에 필요: 파일(또는 `[runtime].default`)이 없으면 서버는 `refusing to boot` 로그를 남기고 status 1로 종료합니다 — 환경 기본값 폴백 없음 |
+| 영역 | 현재 용도 | 알아둘 점 |
+|---|---|---|
+| 작업 공간 협업 | MCP로 목표(Goal), 작업(Task), 담당자, 상태 변경, 보드 글, 검증 근거를 공유합니다 | 협업 정보는 여러 에이전트가 동시에 같은 소스 파일을 고칠 때 발생하는 충돌을 완전히 막지 못합니다 |
+| Keeper | 설정된 에이전트가 작업 공간의 이벤트를 받아 작업하고 실행 기록을 남깁니다 | 고급 기능이며 선택한 런타임과 Keeper 설정에 따라 동작이 달라집니다 |
+| 대시보드 | 작업 공간과 런타임 상태를 보고 운영 명령을 실행합니다 | 대시보드 빌드 상태와 인증 방식에 따라 화면 및 쓰기 권한이 달라집니다 |
+| Gate와 사람 승인 | 지원하는 외부 작업에 Always Allow, 모델 판단, 사람 승인을 적용합니다 | 승인 절차이며 샌드박스나 자격증명 보호 장치가 아닙니다 |
+| 런타임 선택 | Keeper마다 프로바이더와 모델을 지정하고 순서가 있는 후보 목록을 설정합니다 | 올바른 카탈로그와 프로바이더 자격증명이 필요합니다 |
+| Fusion | `masc_fusion`으로 여러 모델의 답과 심판 결과를 모읍니다 | 사용 전에 preset과 심판 런타임을 설정해야 합니다 |
+| 외부 채널 | Discord와 Slack 등 지원 채널을 작업 공간에 연결합니다 | token과 채널별 Keeper 연결을 운영자가 직접 설정해야 합니다 |
+| 로컬 또는 Docker 실행 | Keeper의 셸 작업에 `local` 또는 `docker`를 선택합니다 | `local`은 호스트에서 실행됩니다. Docker도 완전한 보안 경계가 아닙니다 |
+| IDE와 TUI | 실험 중인 화면과 터미널 UI를 살펴봅니다 | 일반 작업을 시작하는 기본 경로가 아닙니다 |
 
-**에이전트를 만들 때**
+현재 제품의 기본 경로는 저장소 작업 공간 협업입니다. Keeper 운영과 운영자
+기능은 그다음 단계입니다. 원격 환경의 안전성, 클러스터 배포, 운영 서비스 수준은
+현재 보장하지 않습니다. 범위와 우선순위는
+[`docs/PRODUCT-OPERATING-PLAN.md`](docs/PRODUCT-OPERATING-PLAN.md)를 참고하세요.
 
-| 파일 | 역할 |
-|------|------|
-| `prompts/keeper.world.md` | 모든 Keeper에 공통 주입되는 **World 프롬프트**(공통 무대·규칙, `<world>` 블록). 고치면 전체 무대가 바뀝니다 |
-| `keepers/<name>.toml` | Keeper(등장인물) 정의 — goal·지시문·`keeper_name`·`sandbox_profile`. World 위에 stack 됩니다 |
-| `keepers/<name>/AGENT.md` | 전체 Keeper 프롬프트. `keeper_name`으로 참조하며 여러 Keeper가 공유할 수 있습니다 |
+## 설정
 
-**저장소에 코드 작업을 시킬 때만**
+MASC는 런타임 상태를 `<base-path>/.masc` 아래에 둡니다. 사용자가 작성하는
+설정은 기본적으로 `<base-path>/.masc/config`에 있습니다. `MASC_CONFIG_DIR`를
+지정하면 다른 설정 폴더를 사용할 수 있습니다.
 
-| 파일 | 역할 |
-|------|------|
-| `repositories.toml` | Keeper가 clone/작업할 저장소 등록. repo 작업이 없으면 불필요합니다 |
-| `keeper_repo_mappings.toml` | Keeper → credential + 접근 가능 저장소 매핑 |
-| `credentials.toml` | PR용 GitHub 자격증명 |
+| 경로 | 용도 |
+|---|---|
+| `runtime.toml` | 프로바이더와 모델 목록, 필수 `[runtime].default`, 런타임 후보 목록, Keeper별 런타임 지정 |
+| `agent-core-models-overlay.toml` | 배포 환경에서 추가하는 모델 기능 정보. 파일이 없으면 Agent Core에 포함된 기본 카탈로그만 사용합니다 |
+| `keepers/<name>.toml` | Keeper 실행 설정 |
+| `keepers/<name>/AGENT.md` | Keeper의 전체 프롬프트. TOML로 만든 Keeper마다 필요합니다 |
+| `repositories.toml` | 저장소 작업에 사용할 저장소 이름과 체크아웃 정보 |
+| `keeper_repo_mappings.toml` | Keeper별 저장소 선호값. 기본 선택에만 쓰며 접근 권한을 제한하지 않습니다 |
+| `.env.local` | 현재 설치 스크립트와 빠른 실행 절차가 기록하는 프로바이더 환경 변수 |
 
-> `prompts/`의 나머지 `.md`는 행동·거버넌스·검증·메모리용 시스템 템플릿입니다. 이름으로 필요한 자리에서만 불려가고, 기본값으로 동작하므로 보통 건드리지 않습니다. "무대"를 바꾸려고 편집하는 것은 `keeper.world.md`입니다.
->
-> 직접 작성하는 것은 `keepers/<name>.toml`(Keeper 정의)와 `keepers/<name>/AGENT.md`(Keeper 프롬프트)입니다. 런타임 상태(`.masc/keepers/*.json` + `*.jsonl` 로그)는 서버가 생성하므로 손대지 않습니다.
->
-> 실행 런타임 `.masc/`는 `--base-path`가 가리키는 곳입니다. 저장소 안의 `masc/.masc/`는 lock·scratch용입니다.
+Keeper 하나에는 사용자가 작성하는 파일 두 개가 필요합니다.
 
-Keeper 정의 예시 (`keepers/<name>.toml`):
+```text
+<base-path>/.masc/config/keepers/reviewer.toml
+<base-path>/.masc/config/keepers/reviewer/AGENT.md
+```
 
 ```toml
+# keepers/reviewer.toml
 [keeper]
-name = "albini"
-goal = "흐름이 끊긴 task의 owner를 호명해 추궁합니다. 본인은 코드를 만들지 않습니다."
-active_goal_ids = ["goal-pm-flow"]
-sandbox_profile = "docker"     # 또는 "local"
-
-instructions = """
-... Keeper 행동 지시 ...
-"""
+autoboot_enabled = true
+proactive_enabled = true
+sandbox_profile = "local"
+mention_targets = ["operator"]
+allowed_paths = ["workspace/yousleepwhen/masc"]
 ```
 
-Keeper → runtime 할당은 `runtime.toml`에서 합니다 (keeper toml은 model/runtime을 직접 갖지 않습니다):
+```markdown
+<!-- keepers/reviewer/AGENT.md -->
+현재 변경 내용을 검토하고, 파일 경로와 실행 명령을 포함한 근거를 보고하세요.
+```
 
-Provider와 binding 테이블은 `enabled = false`를 지원합니다.
-`[providers.<id>]`를 비활성화하면 해당 provider의 모든 binding이 실행
-inventory에서 빠지고, `[<provider>.<model>]`을 비활성화하면 해당
-runtime만 빠집니다. 비활성 runtime ID를 `[runtime].default`, lane, assignment,
-failover list가 계속 참조하면 설정 오류로 거부합니다.
+Keeper TOML에는 실행 설정만 둡니다. 프롬프트는 `AGENT.md`에 작성합니다.
+정의되지 않은 Keeper TOML 항목이 있으면 설정을 거부합니다.
+
+Keeper별 런타임은 `runtime.toml`에서 지정합니다.
 
 ```toml
 [runtime.assignments]
-albini = "<provider>.<model>"   # config/runtime.toml에 정의된 id로 교체
+reviewer = "<provider>.<model>"
 ```
 
-선택한 runtime이 cloud provider를 사용한다면 서버 시작 전에 필요한 provider credential을 export해야 합니다. runtime ID는 [`config/runtime.toml`](config/runtime.toml), 적용된 환경 설정은 typed `masc_config` 도구와 `/api/v1/dashboard/config`에서 확인합니다.
+전체 파일 규칙은 [`docs/KEEPER-FILE-MODEL.md`](docs/KEEPER-FILE-MODEL.md)에
+있습니다. 실제로 적용된 설정은 `masc_config` 도구나
+`/api/v1/dashboard/config`에서 확인할 수 있습니다.
 
----
+## 실행 방식
 
-## 디렉토리 구조 / Layout
-
-```
-masc/
-├── bin/            서버·CLI 진입점 (main_eio = HTTP 서버, masc_tui = TUI, fusion_run …)
-├── lib/            핵심 로직 (keeper/, board/, fusion/, gate/, ide/, server/, runtime/ …)
-├── dashboard/      TypeScript + Preact 대시보드 SPA
-├── docs/           스펙, 런북, RFC, 경계 문서
-├── scripts/        설치·빌드·CI·운영 스크립트
-├── config/         체크인된 기본 설정 (런타임이 시드로 사용)
-├── test/           Alcotest 스위트
-└── start-masc.sh   전체 런타임 기동 스크립트
-
-<base-path>/.masc/ (런타임 상태, --base-path 아래)
-├── config/         runtime.toml, keepers/, repositories.toml, credentials.toml …
-├── keepers/        Keeper별 런타임 상태·메모리 (*.json + *.jsonl 로그, 서버 생성)
-├── goals.json      Goal 상태
-├── tasks/          Task 백로그, goal↔task 링크
-├── board_*.jsonl   Board 글·댓글·투표 (append-only)
-└── audit-approvals/  HITL 승인 이력
-```
-
----
-
-
-## Dashboard
-
-대시보드는 해시 기반 라우터(`dashboard#<tab>?section=<section>`)로 서피스를 노출하는 웹 패널입니다. 서피스와 섹션의 canonical 정의는 `dashboard/src/config/navigation.ts`의 `DASHBOARD_SURFACES`와 `DASHBOARD_SECTION_ITEMS`이며, `hidden: true`로 표시된 항목(cockpit 등)은 UI에 노출되지 않습니다.
-
-메인 네비게이션 레일에 고정되는 서피스(`V2_PRIMARY_SURFACE_IDS`):
-
-| 서피스 | 설명 |
+| 명령 | 용도 |
 |---|---|
-| Overview | 빠른 신호와 브리핑 요약 |
-| Workspace | 작업 목표, 계획, 저장소, 검증 |
-| Keepers | Keeper 로스터, 대화, 컨텍스트 워크스페이스 |
-| Board | 사람·에이전트·자동화·시스템 게시물 |
-| Schedule | 예약된 Keeper 자동화와 wake 신호 |
-| Approvals | Keeper HITL 승인 큐 (도구 호출 게이트) |
-| Fusion | masc_fusion 패널·심판 숙의 |
-| Code | 실험적 CODE/IDE 셸; 실제 코딩 workflow에는 아직 사용할 수 없음 |
-| Connectors | 채널 사이드카와 Keeper 바인딩 |
-| Settings | Keeper 설정 운영 콘솔 |
-| Logs | 시스템 실행 로그 |
+| `masc start --base-path <path>` | 설치된 바이너리 실행. 하위 명령 없이 `masc`만 실행해도 같습니다 |
+| `./start-masc.sh --http --base-path <path>` | 소스 checkout에서 전체 런타임 실행 |
+| `scripts/start-loopback.sh` | Keeper 자동 시작을 기본으로 끈 채 `127.0.0.1:8935`에서 실행 |
+| `scripts/run-local.sh --target-dir <path>` | 경로에서 계산한 포트로 격리된 개발 런타임 실행 |
 
-레일 외부에서 접근 가능한 추가 서피스: Monitor (keeper fleet, 도구 모니터, 런타임, observatory), Command (개입·Gate·승인), Lab (도구 진단, safety harness, 성능, Memory OS, 키퍼 메모리 상태).
+상태 파일을 확인하거나 고치기 전에 서버가 실제로 사용하는 경로부터 확인하세요.
 
-라우트 예시: `dashboard#monitoring?section=agents`, `dashboard#monitoring?section=journey`, `dashboard#command?section=operations`, `dashboard#connectors?section=connector-status`, `dashboard#lab?section=memory-subsystems`, `dashboard#workspace?section=verification`.
+```bash
+curl -fsS 'http://127.0.0.1:8935/health?full=1' \
+  | jq '.paths | {effective_base_path, effective_masc_root, roots_diverge}'
+```
 
-(`monitoring?section=journey` 같은 일부 진단 뷰는 `navigation.ts` 레일 서피스가 아니라 `dashboard/src/components/status.ts`의 라우트-전용 매핑으로 제공됩니다 — 레일 라벨 없이 라우트로만 도달합니다.)
+`.masc/config/` 밖에서 서버가 만든 파일은 설정 입력이 아닙니다. Keeper 상태,
+작업 저장소, 보드 로그, 실행 기록, 승인 이력을 직접 고치지 마세요.
 
----
+## 대시보드
 
-## 문서 / Documentation
+서버는 `/dashboard/`에서 대시보드를 제공합니다. 화면 구성은
+`dashboard/src/config/navigation.ts`에 정의되어 있습니다.
 
-이 저장소의 문서는 모두 같은 신뢰도를 갖지 않습니다. `status`와 `last_verified`를 명시한 파일을 우선하고, 오래된 design/RFC 문서는 현재 runbook에서 다시 링크하지 않는 한 역사/맥락 문서로 읽어야 합니다.
+사이드바의 기본 화면은 다음과 같습니다.
 
-| 문서 | 용도 | 현재성 메모 |
-|---|---|---|
-| [`CONTRIBUTING.md`](CONTRIBUTING.md) | 빌드/테스트/PR 기대치 | contributor workflow 문서이며 제품 홍보 문서가 아님 |
-| [`ROADMAP.md`](ROADMAP.md) | 6-8주 운영 관점 | 버전 헤더는 `dune-project`와 `CHANGELOG.md`에 맞는지 확인 |
-| [`docs/AGENT-CORE-BOUNDARY.md`](docs/AGENT-CORE-BOUNDARY.md) | MASC ↔ agent core 경계 | reference 문서; 오래된 본문보다 `last_verified`와 generated pin block 우선 |
-| [`docs/spec/SPEC-INDEX.md`](docs/spec/SPEC-INDEX.md) | spec suite 진입점 | living draft; 개별 spec에는 migration context가 남아 있을 수 있음 |
-| [`docs/KEEPER-USER-MANUAL.md`](docs/KEEPER-USER-MANUAL.md) | Keeper 개념과 운영 메모 | 오래된 manual; config truth는 [`docs/KEEPER-FILE-MODEL.md`](docs/KEEPER-FILE-MODEL.md), [`config/runtime.toml`](config/runtime.toml), live code 우선 |
-| [`docs/RELEASE-EVIDENCE.md`](docs/RELEASE-EVIDENCE.md) | release evidence bundle | 형식 문서; 사용 전 version line을 current release metadata와 맞출 것 |
+| 화면 | 용도 |
+|---|---|
+| Overview | 작업 공간과 런타임 요약 |
+| Keepers | Keeper 목록, 대화, 현재 작업 맥락 |
+| Registry | Keeper 설정과 런타임 연결 |
+| Monitor | Keeper 목록, 도구 상태, 런타임, 관찰 기록 |
+| Work | 목표, 계획, 저장소, 검증 상태 |
+| Gate | 사람 승인 대기 목록과 Always 규칙 |
+| Schedule | 예약 작업과 깨우기 신호 |
+| Board | 사람, 에이전트, 자동화, 시스템 글 |
+| Fusion | 패널과 심판 실행 결과 |
+| Logs | 런타임 이벤트 로그 |
+| IDE | 실험 중인 협업 IDE 화면 |
+| Connectors | 외부 채널 상태와 Keeper 연결 |
+| Settings | 운영 설정 화면 |
 
-대시보드 라우트 포맷·서피스 목록은 위 [Dashboard](#dashboard) 섹션을 참고해 주세요.
+화면 안에서 선택할 수 있는 하위 항목은 다음과 같습니다.
 
----
+| 화면 | 하위 항목 |
+|---|---|
+| Monitor | `agents`, `internal-agents`, `fleet-health`, `runtime`, `observatory` |
+| Work | `work`, `planning`, `repositories`, `verification` |
+| Connectors | `connector-status` |
+| IDE | `ide-shell` |
+| Lab | `tools`, `harness`, `performance`, `keeper-memory-health` |
 
-## 남은 과제 / Roadmap
+`Lab`과 `Command`는 주소로 열 수 있지만 기본 사이드바에는 없습니다. 숨겨진
+진단 화면은 사용자가 보는 기본 메뉴에 포함되지 않습니다.
 
-아래는 현재 한계를 바탕으로 정리한 구체적인 남은 작업입니다. 더 넓은 운영 계획은 [`ROADMAP.md`](ROADMAP.md)를 참고해 주세요.
+현재 대시보드에서 지원하는 주소 예시는
+`dashboard#monitoring?section=journey`,
+`dashboard#command?section=operations`,
+`dashboard#connectors?section=connector-status`,
+`dashboard#workspace?section=verification`입니다. `journey`는 메뉴에 표시되지 않는
+진단 화면입니다.
 
-| # | 영역 | 남은 작업 | 상태 변화 예상 |
-|---|------|----------|---------------|
-| 2 | **Provider Failover** | 순서 있는 `[runtime.lanes]` 그룹 위에 provider health 기반 자동 회전을 얹고, 복구 로그/메트릭을 남깁니다. | 🟡→✅ |
-| 3 | **Fusion + JoJ** | 제공된 judges preset으로 staged judge-of-judges 경로를 끝까지 검증합니다. | 🟡→✅ |
-| 5 | **TUI** | `masc-tui`를 실제로 사용 가능한 상태로 만듭니다. 실행 파일은 있으나 CJK/emoji 레이아웃·스트리밍 진행·rich-block 렌더링 공백으로 현재는 사용할 수 없습니다. | ❌→🟡/✅ |
-| 6 | **IDE** | 관망형 IDE를 실제로 사용 가능한 상태로 만듭니다. LSP 프록시·주석 오버레이·대시보드 IDE 셸은 있으나, 사람이 명령만 내리는 흐름이 검증되지 않아 현재는 사용할 수 없습니다. | ❌→🟡/✅ |
-| 7 | **Multi-Channel** | Discord·Slack 외 채널(Telegram 등)용 사이드카를 추가하고, gate message 스키마를 채널별로 확장합니다. | 🟡→✅ |
-| 8 | **Sandbox** | docker 이미지 미설치·playground 내 fallback 시 host 실행 비율을 줄이고, `sandbox_profile=local` 사용처를 명시적으로 문서화합니다. | ✅ 안정화 |
-| 9 | **HITL** | 사람의 결정을 기다리는 동안 Keeper를 블로킹하지 않습니다. exact request를 영속화하고 다른 작업을 계속하며, 결정이 오면 해당 Keeper lane만 깨웁니다. | ✅ 안정화 |
-| 10 | **Gate** | Always Allow·LLM Auto Judge·HITL을 비계층 선택지로 유지합니다. 제품·명령·risk level을 분류하지 않고 exact 1회성 grant를 감사합니다. | ✅ 안정화 |
-| 11 | **OpenTelemetry** | Keeper turn 낮은 수준 이벤트, fusion 내부 metric, provider별 latency breakdown 등 누락된 signal과 instrumentation을 추가합니다. | 🟡→✅ |
+[24개 화면 목록](docs/screenshots/dashboard/2026-08-21/README.md)에서 기본 화면과
+Monitor, Work, Lab 화면을 확인할 수 있습니다.
 
----
+## 저장소 구조
 
-## 상태 / Status
+```text
+masc/
+├── bin/          서버와 CLI 시작점
+├── lib/          작업 공간, Keeper, 런타임, Gate, 서버 코드
+├── packages/     저장소에 포함된 Agent Core 패키지
+├── dashboard/    TypeScript와 Preact 대시보드 소스
+├── assets/       빌드된 웹 파일
+├── config/       초기 설정에 사용하는 기본 파일
+├── docs/         실행 안내, 계약, 스펙, 이전 RFC
+├── scripts/      빌드, 설치, 검사, 로컬 운영 스크립트
+└── test/         OCaml 테스트와 테스트 데이터
+```
 
-pre-1.0 (`0.y.z`). API와 설정 형식은 바뀔 수 있습니다. `1.0.0`은 저장소 협업·릴리스·운영자 경로가 caveat 없이 신뢰될 때까지 열지 않습니다.
+## 문서
 
-## License
+| 문서 | 용도 |
+|---|---|
+| [`docs/MCP-TEMPLATE.md`](docs/MCP-TEMPLATE.md) | MCP 클라이언트 설정 |
+| [`docs/KEEPER-FILE-MODEL.md`](docs/KEEPER-FILE-MODEL.md) | 현재 Keeper 파일과 런타임 지정 규칙 |
+| [`docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md`](docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md) | 로컬 토큰 발급과 대시보드 쓰기 권한 |
+| [`docs/AGENT-CORE-BOUNDARY.md`](docs/AGENT-CORE-BOUNDARY.md) | MASC와 저장소에 포함된 Agent Core의 역할 구분 |
+| [`docs/spec/SPEC-INDEX.md`](docs/spec/SPEC-INDEX.md) | 스펙 목록. 최신이라고 표시하지 않은 개수와 규모 정보는 과거 기록입니다 |
+| [`docs/RELEASE-EVIDENCE.md`](docs/RELEASE-EVIDENCE.md) | 릴리스 근거 형식. 다시 쓸 때는 문서의 버전부터 확인해야 합니다 |
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | 빌드, 테스트, pull request 작업 방식 |
+| [`ROADMAP.md`](ROADMAP.md) | 현재 계획. 릴리스 약속은 아닙니다 |
 
-MIT. 보증 없이 "있는 그대로" 제공됩니다. 자세한 내용은 [`LICENSE`](LICENSE)를 참고해 주세요.
+## 개발 및 릴리스 상태
+
+- 패키지 버전은 `dune-project`에 정의되고 `masc.opam`에 반영됩니다.
+- 소스 릴리스 기록은 `CHANGELOG.md`에 있습니다.
+- 공개 바이너리와 지원 플랫폼은
+  [GitHub Releases](https://github.com/jeong-sik/masc/releases)의 첨부 파일을
+  기준으로 확인합니다.
+- 1.0 전에는 API와 설정 형식이 바뀔 수 있습니다.
+
+## 라이선스
+
+MIT. 자세한 내용은 [`LICENSE`](LICENSE)를 참고하세요.

--- a/README.md
+++ b/README.md
@@ -3,352 +3,249 @@
 [![OCaml](https://img.shields.io/badge/OCaml-5.5-orange.svg)](https://ocaml.org/)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
-[한국어 버전](README.ko.md)
+[한국어](README.ko.md)
 
-**MASC is a local coordination and observability layer for agent work.** It runs
-next to a repository as an MCP server, so coding agents and resident Keepers can
-share goals, tasks, board posts, repository ownership, and approval state. The
-dashboard and per-turn receipts make agent decisions and failures inspectable.
+MASC (Multi-Agent Shared Context) is a repo-local MCP server for agents that
+work in the same project. It keeps goals, tasks, ownership, board messages, and
+execution evidence in one workspace and exposes that state through MCP and a
+web dashboard.
 
-It is not meant to be the fastest way to get work done. MASC trades speed for
-coordination, observability, and experiments with long-running keeper-based
-agents.
+A **Keeper** is an optional long-running agent managed by MASC. Keepers add
+autonomous and event-driven work to the shared workspace. They are an advanced
+path, not a requirement for using MASC as an MCP collaboration server.
 
-> **Development status:** MASC is still a pre-1.0 experiment. It is not a
-> productivity tool, production service, or security boundary. Use it for local
-> experiments and observation only. CODE/IDE workflows are not usable yet, and
-> HITL/Sandbox features can reduce some accidents but cannot be relied on to
-> protect code, secrets, infrastructure, or unattended agents. The current goal
-> is to make agent failures visible enough to discover which workflows may
-> become useful.
-
-A **Keeper** is an optional resident agent managed by MASC. It stays alive while
-the server is running, wakes on heartbeat intervals, and reacts to mentions or
-messages. The name is borrowed from Bullfrog\'s *Dungeon Keeper*; it is project
-vocabulary, not an architecture claim.
-
----
+> **Status:** MASC is a pre-1.0 project for local, trusted environments. It is
+> not a production service or a security boundary. Gate, HITL, and Docker
+> execution can constrain specific operations, but they do not protect an
+> unattended agent from every unsafe action. The IDE and TUI are experimental.
+> `main` can be ahead of the latest published binary release.
 
 ![MASC dashboard overview](docs/screenshots/dashboard/2026-08-21/01-overview.png)
 
-Live local dashboard capture from `0.23.0`; operational identifiers are
-redacted. See the [24-screen dashboard inventory](docs/screenshots/dashboard/2026-08-21/README.md).
+This image was captured from a live local runtime with operational identifiers
+redacted. The [dashboard inventory](docs/screenshots/dashboard/2026-08-21/README.md)
+contains 24 screens and the exact capture metadata.
 
-## What you can do with MASC
+## Start here
 
-- **Run shared Goals and Tasks through MCP tools.** Keep task ownership, status transitions, and verification evidence in one local workspace.
-- **Run and observe resident Keepers.** Give a Keeper its own keeper, goal, and instructions, and let it communicate over shared topics or repositories.
-- **Experiment with different agent styles.** Keepers can carry different concerns and instructions, so you can watch what they decide and where they clash.
-- **Attach existing coding agents.** Because MASC is an MCP server, MCP clients such as Claude Code or Codex can connect to `/mcp` and join the same workspace — sharing task claim/transition, board, and goals, and waking Keepers via `masc_broadcast` or @mention. (There is no synchronous external tool for directly invoking a Keeper turn; interaction is through the workspace and mentions.)
-- **Reduce obvious collisions when multiple agents touch the same code.** Turns, locks, and worker ownership can coordinate multiple Keepers working on one repository, but this is not a concurrency-safety guarantee.
-- **Inspect decisions and failures.** The web dashboard shows Keeper / Goal / Task / Board state in real time, and every turn leaves a receipt.
-- **Route external effects through one Gate.** Always Allow, LLM Auto Judge, and HITL are explicit non-hierarchical modes. HITL persists the exact request without blocking the Keeper; its lane is woken when the decision arrives.
-- **Run each Keeper on a different model.** A single line in `runtime.toml` routes a Keeper to a provider × model from the runtime catalog.
+### Local source checkout
 
----
-
-## Features
-
-Legend — ✅ working now · 🟡 partially working · ❌ not working. Status is about implemented local paths, not production readiness or security assurance. Broader plans (cluster mode, external IDE extensions, additional platform binaries, etc.) are in [`ROADMAP.md`](ROADMAP.md).
-
-| Feature | Status | One-line description | Entry point |
-|------|:----:|-----------|--------------|
-| **Keepers** | ✅ | Resident agents with keeper, goal, and instructions. Auto-boot when the server starts; state persists to disk | `.masc/config/keepers/*.toml` |
-| **Gate: Always Allow / Auto Judge / HITL** | 🟡 | Product-neutral external-effect boundary with exact one-use grants and per-Keeper wake-up | Dashboard approvals queue |
-| **Board** | ✅ | Keepers collaborate asynchronously via posts, comments, and votes; publishing wakes related Keepers | `masc_board_*` tools / dashboard |
-| **Sandbox (Docker)** | 🟡 | Docker-profile shell execution uses containers, but local profiles and fallback paths mean this is not a security boundary | keeper toml `sandbox_profile` |
-| **Dashboard** | ✅ | Web SPA for observing and commanding Keeper/Goal/Task/Board in real time | `dashboard/` (vite) |
-| **TUI** | ❌ | Not working — `masc-tui` binary exists, but major gaps (CJK/emoji layout, streaming progress, rich-block rendering) make it unusable in practice | `masc-tui` |
-| **CODE / IDE (observational)** | ❌ | Not working — LSP proxy, annotation overlay, and dashboard CODE shell are implemented, but the observational command-only flow is not validated, so it is unusable in practice | Dashboard Code |
-| **OpenTelemetry** | 🟡 | OTLP HTTP exporter + GenAI semconv spans/metrics work, but many signals and instrumentation gaps are not yet collected | `OTEL_EXPORTER_OTLP_ENDPOINT` |
-| **Goal + Task** | 🟡 | Goal/Task CRUD, transitions, verification, and prompt injection work. Automatic scheduling is not implemented | `masc_goal_*` / `masc_*task*` tools |
-| **Multi-Runtime** | 🟡 | Keeper-specific provider × model routing | `runtime.toml` |
-| **Provider Failover** | 🟡 | Ordered failover groups via `[runtime.lanes]`; health-based automatic rotation is not implemented | `runtime.toml` `[runtime.lanes]` |
-| **Fusion (+ JoJ)** | 🟡 | Ask several models the same question and let a judge synthesize consensus/contradictions/blind spots. Simple/Refine/Conditional work; JoJ requires the judges preset in `runtime.toml` | `masc_fusion` tool |
-| **Multi-Channel** | 🟡 | External channel messages start/respond to turns. Discord and Slack are live; Telegram needs a sidecar | `POST /api/v1/gate/message` |
-
-### Current behavior and limits
-
-- **Keepers** — Each Keeper is a long-running agent that stays resident while the server is alive. It wakes on heartbeat, runs turns, and its memory and decision logs persist across restarts. **A Keeper runs only one turn at a time** — parallelism comes from multiple Keepers running together. MASC does not impose a global active-Keeper cap.
-- **Gate / HITL** — The dispatch boundary sends the opaque operation identity and complete typed input to one Gate. Workspace or Keeper Always Allow proceeds directly; Auto Judge runs asynchronously; Manual persists a HITL request. Deferred requests return to the Keeper instead of awaiting a promise, and an exact approved request is consumed once when that Keeper lane wakes. Gate decisions are authorization workflow, not a sandbox or credential boundary.
-- **Sandbox** — Actually invokes `docker run --rm` with cap-drop / no-new-privileges / read-only rootfs. MASC observes active Docker operations but does not pre-admit them through a global spawn slot. Network is controlled by the keeper's `network_mode` (default `inherit`, can be `none`). *Limit*: not every Keeper runs Docker (some use `local`=host execution). If the image is missing and the path is inside the playground, execution falls back to host (telemetry is recorded). Do not treat this as a security boundary.
-- **Multi-Runtime** — A single line in `runtime.toml` under `runtime.assignments`, `keeper = provider.model`, sends every turn for that Keeper to the chosen provider.
-- **Provider Failover** — `[runtime.lanes]` in `runtime.toml` defines ordered failover groups; a Keeper falls through a lane when its current runtime is rejected. Health-based automatic rotation across providers is not implemented.
-- **Fusion + JoJ** — When a Keeper calls `masc_fusion`, panel models answer the same question independently and a judge synthesizes consensus, contradictions, and blind spots. *Limit*: the Judge-of-Judges (JoJ) phase fails closed unless the JoJ judges preset from `config/runtime.toml` (RFC-0283) is configured. Run results persist to `.masc/fusion-runs.jsonl`.
-- **Goal + Task** — Goals and tasks are created via MCP tools, transitioned through states, and active goals are injected into the Keeper system prompt. Turns are driven by channels/events. (The goal-loop OODA machinery was fully retired on 2026-07-21 — RFC-0352 Path B: the Goal entity, MCP tools, and task linkage stay; the scheduler scripts, server broadcast, and dashboard panel are gone.)
-- **OpenTelemetry** — The OTLP HTTP exporter and GenAI semconv spans/metrics work. *Limit*: many signals and instrumentation gaps are not yet collected. For example, low-level Keeper turn events, internal fusion metrics, and per-provider latency breakdowns are only partially covered.
-- **CODE / IDE (observational, not working)** — The aim is an observational IDE where humans issue commands rather than editing code directly. The LSP proxy, annotation overlay, and dashboard CODE shell are implemented, but **the observational command-only flow is not validated, so CODE is not usable in practice.**
-
----
-
-## Quick Start
-
-### One-touch (recommended)
-
-From a clone, one command builds/starts the server, seeds a four-keeper team
-(tech lead, backend, frontend, QA) on `ollama_cloud.deepseek-v4-flash`, and opens
-the dashboard. Works on macOS and Linux.
-
-```bash
-export OLLAMA_CLOUD_API_KEY=...      # from https://ollama.com/settings/keys
-./quickstart.sh                      # native build+run, then opens the dashboard
-#   or fully containerized (self-contained image, builds from source):
-./quickstart.sh --docker
-```
-
-Then open `http://127.0.0.1:8935/dashboard`. Options: `--team <preset>` (see
-`presets/`), `--port N`, `--base-path DIR`, `--no-open`, `--no-start`,
-`./quickstart.sh --help`.
-
-- **Native** binds loopback, so the dashboard is served with data and needs no
-  login — this is the path to actually see the dashboard.
-- **`--docker`** builds a self-contained image and reproducibly boots the server
-  + the team; the container binds a network address, so the dashboard shell
-  serves but its live data needs an explicit bearer token (the loopback
-  dev-token is intentionally not exposed on a non-loopback bind). Use it to verify the
-  install/boot; use native to browse the dashboard.
-
-For the `curl | bash` installer, add `--team classic` to seed the same team:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/jeong-sik/masc/main/scripts/install.sh \
-  | bash -s -- --team classic
-```
-
-### Manual (step by step)
-
-```bash
-# 1. Install the binary (macOS arm64 / Linux x86_64)
-brew install jeong-sik/masc/masc            # Homebrew (Formula/masc.rb in this repo)
-#   or:  curl -fsSL https://raw.githubusercontent.com/jeong-sik/masc/main/scripts/install.sh | bash
-#   from source: git clone https://github.com/jeong-sik/masc.git && cd masc &&
-#     scripts/opam-pin-external-deps.sh --install && opam install . --deps-only &&
-#     scripts/dune-local.sh build @default
-
-# 2. Seed config, then set your provider key
-masc init
-#   edit .masc/config/.env.local:
-#     export OLLAMA_CLOUD_API_KEY=...     # one provider, see table below
-
-# 3. Load your key + start
-source .masc/config/.env.local && masc start
-curl http://127.0.0.1:8935/health        # → 200 OK
-
-# 4. (optional) Dashboard
-cd dashboard && pnpm install && pnpm dev
-```
-
-Provider keys (put the one you use in `.masc/config/.env.local`):
-
-| Provider in `runtime.toml` | Environment variable |
-|---|---|
-| `ollama_cloud` | `OLLAMA_CLOUD_API_KEY` |
-| `deepseek` | `DEEPSEEK_API_KEY` |
-| `glm-coding` | `ZAI_API_KEY_SB` |
-| `ollama` (local) | — (no key) |
-
-> `masc init` seeds `.masc/config/runtime.toml`, which already sets `[runtime].default`. If the server logs `refusing to boot`, run `masc init` in your workspace first. `masc start` is the same as running `masc` with no subcommand (kept as an explicit name for tutorials).
-
----
-
-## Install
-
-### Prebuilt binary
-
-Prefer inspecting the install script and pinning a release:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/jeong-sik/masc/main/scripts/install.sh -o /tmp/masc-install.sh
-less /tmp/masc-install.sh
-bash /tmp/masc-install.sh --version <release-tag>
-```
-
-For disposable local installs, the convenience path is:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/jeong-sik/masc/main/scripts/install.sh | bash
-```
-
-This installs the binary to `$HOME/.local/bin/masc` and seeds `runtime.toml` into `<base-path>/.masc/config/`. Binaries are provided for **macOS arm64** and **Linux x86_64**. Other platforms build from source.
-
-Installer requirements: `curl` and standard Unix tools (`uname`, `chmod`, `mkdir`, `mktemp`). `jq` is required only when `--version` / `MASC_VERSION` is omitted and the script queries GitHub for the latest release. Use `--version <release-tag>` when you need a reproducible install.
-
-Release assets are downloaded from GitHub releases. When the selected release publishes `SHA256SUMS`, the installer verifies the downloaded binary plus seeded `runtime.toml`; every expected entry must exist and match. Some existing releases do not publish `SHA256SUMS`; for those releases, the verified binary install path is unavailable. If the checksum file cannot be fetched, the installer fails closed by default. Use the source build path below, or bypass verification only for a disposable or air-gapped install by passing `--allow-unverified` or setting `MASC_ALLOW_UNVERIFIED=1`; the script prints a warning before continuing.
-
-> If `runtime.toml` is missing (or its `[runtime].default` is absent), the server logs `refusing to boot` and exits with status 1 — there is no environment-default fallback. Because the file is required to start, the install script seeds [`config/runtime.toml`](config/runtime.toml). To write it manually, define `[runtime].default = "<provider>.<model>"` and a matching `[provider.model]` runtime binding table; `[runtime.assignments]` is optional and only overrides individual Keepers.
-
-### From source
+The native launcher uses the default runtime in `config/runtime.toml`, seeds the
+`classic` four-Keeper preset, starts the server, and opens the dashboard.
+It expects the OCaml dependencies to be installed already.
 
 ```bash
 git clone https://github.com/jeong-sik/masc.git
 cd masc
-scripts/opam-pin-external-deps.sh --install   # pin and install external OCaml dependencies
+
+export OLLAMA_CLOUD_API_KEY=...
+./quickstart.sh
+```
+
+Defaults:
+
+- runtime state: `~/masc-quickstart/.masc`
+- HTTP port: `8935`
+- dashboard: `http://127.0.0.1:8935/dashboard/`
+- MCP endpoint: `http://127.0.0.1:8935/mcp`
+- Keeper preset: `classic`
+- runtime: the current `[runtime].default` in `config/runtime.toml`
+
+Use `./quickstart.sh --help` for `--base-path`, `--team`, `--port`,
+`--no-open`, and `--no-start`.
+
+`./quickstart.sh --docker` builds a self-contained image. The container binds a
+network address, so dashboard data requires an explicit bearer token. The
+loopback native path is the simpler dashboard path.
+
+### Build from source manually
+
+The exact compiler and Dune versions are defined in `dune-project`.
+
+```bash
+scripts/opam-pin-external-deps.sh --install
 opam install . --deps-only
 scripts/dune-local.sh build @default
+
+export OLLAMA_CLOUD_API_KEY=...
+./start-masc.sh --http --base-path "$PWD" --port 8935
+curl http://127.0.0.1:8935/health
 ```
 
-Requirements: OCaml 5.5.0 (pinned in `dune-project`), opam >= 2.0, dune >= 3.22. Build/test/CI details are in [`CONTRIBUTING.md`](CONTRIBUTING.md).
+`start-masc.sh` builds the dashboard when its source is newer than the checked-in
+bundle. Use `cd dashboard && pnpm dev` only when developing the dashboard with
+Vite.
 
-`scripts/dune-local.sh` uses a global lock file (`/tmp/me-dune-local.lock`) to avoid concurrent build collisions across worktrees, and disables the Dune shared cache by default for local builds. This avoids stale native artifacts after shared opam pins move; set `MASC_DUNE_CACHE=enabled` explicitly if you need to re-enable it.
+### Published binaries
 
-### Run modes
-
-- **`scripts/start-loopback.sh`**: starts on fixed port `8935` with the Keeper scheduler off for local mock debugging. Pass `--with-keeper-bootstrap` when Keeper autoboot is required.
-- **`scripts/run-local.sh --target-dir /path`**: starts an isolated runtime for the target directory. The port is auto-allocated in the `9100-9999` range from the directory path hash.
-- **`./start-masc.sh --http --port <port>`**: starts the full runtime including the Keeper scheduler.
-
----
-
-## Run
-
-MASC is an MCP server. Start it, then attach agents or MCP clients.
+Published releases can lag behind `main`. Choose a tag from
+[GitHub Releases](https://github.com/jeong-sik/masc/releases), then use the
+installer from that same tag. Keeping the script and assets on one tag avoids
+mixing a newer installer contract with older release files.
 
 ```bash
-# 1. Start the server (loopback)
-PORT=8935   # use another local port if 8935 is already busy
-masc --base-path "$PWD" --port "$PORT"     # if installed from binary
-# or from source:
-./start-masc.sh --http --port "$PORT"
-
-# 2. Health check
-curl "http://127.0.0.1:${PORT}/health"
-
-# 3. Connect an MCP client to http://127.0.0.1:${PORT}/mcp
+TAG=vX.Y.Z
+curl -fsSL "https://raw.githubusercontent.com/jeong-sik/masc/${TAG}/scripts/install.sh" \
+  -o /tmp/masc-install.sh
+less /tmp/masc-install.sh
+bash /tmp/masc-install.sh --version "$TAG"
 ```
 
-| Mode | Command | Purpose |
-|----------|------|------|
-| Full runtime | `./start-masc.sh --http --port <port>` | Official start including Keeper scheduler |
-| Isolated | `scripts/run-local.sh --target-dir /path` | Per-directory isolation, auto-allocated local port |
-| Loopback | `scripts/start-loopback.sh` | Fixed loopback port, scheduler off (local debugging) |
+Installation behavior is versioned with the selected tag. Recent release
+scripts verify `SHA256SUMS` when it is present and stop when required files are
+absent. Supported platforms are the assets attached to that release. Follow
+the start command printed by the installer.
 
-Start the dashboard separately:
+## MCP client setup
 
-```bash
-cd dashboard && pnpm install && pnpm dev   # vite proxies to the local server
-# production build: pnpm build
+HTTP is the public MCP path. Merge this entry into the MCP configuration used
+by your client:
+
+```json
+{
+  "mcpServers": {
+    "masc": {
+      "type": "http",
+      "url": "http://127.0.0.1:8935/mcp"
+    }
+  }
+}
 ```
 
-The prebuilt binary installer does not clone dashboard source. The dashboard commands above are for a repository checkout. For local dashboard auth and admin-token setup, see [`docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md`](docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md).
+After the client connects, the shortest workspace flow is:
 
----
+```text
+masc_start(path="/path/to/project", task_title="Describe the first task")
+masc_status()
+```
+
+`masc_start` selects the project, joins the workspace, and optionally creates
+and claims a task. Goals, tasks, board posts, and status changes are then shared
+through the MASC tool set.
+
+Loopback development can run without a client bearer depending on the active
+auth configuration. Non-loopback binds and stricter local setups require an
+explicit token. See [`docs/MCP-TEMPLATE.md`](docs/MCP-TEMPLATE.md) and
+[`docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md`](docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md).
+
+## Current scope
+
+| Area | Current use | Important limit |
+|---|---|---|
+| Workspace collaboration | Share Goals, Tasks, claims, transitions, board posts, and verification evidence through MCP | Coordination data does not provide transactional protection for concurrent source edits |
+| Keepers | Run configured agents that react to workspace events and write execution records | Advanced path; behavior depends on the selected runtime and Keeper configuration |
+| Dashboard | Read workspace and runtime state and perform operator actions | Availability and write access depend on the built SPA and auth mode |
+| Gate and HITL | Apply Always Allow, model judgment, or human approval to supported external effects | Authorization workflow, not a sandbox or credential boundary |
+| Runtime routing | Assign a provider/model runtime to each Keeper and define ordered runtime lanes | A valid catalog and provider credentials are still required |
+| Fusion | Run panel and judge workflows through `masc_fusion` | Presets and judge runtimes must be configured before use |
+| Connectors | Connect workspace activity to supported external channels, including Discord and Slack | Tokens and channel-to-Keeper bindings are explicit operator configuration |
+| Local or Docker execution | Select `local` or `docker` for Keeper shell work | `local` runs on the host; Docker profiles are not a complete security boundary |
+| IDE and TUI | Inspect experimental interfaces | Not the supported front door for normal work |
+
+The product front door is repo workspace collaboration. Keeper supervision and
+operator controls are secondary. Remote-safe operation, cluster deployment,
+and production service guarantees are outside the current promise. See
+[`docs/PRODUCT-OPERATING-PLAN.md`](docs/PRODUCT-OPERATING-PLAN.md).
 
 ## Configuration
 
-Runtime settings and state live under `.masc/` below `--base-path`. Config files are in `.masc/config/`.
+MASC resolves runtime data below `<base-path>/.masc`. Authored configuration is
+under `<base-path>/.masc/config` unless `MASC_CONFIG_DIR` explicitly selects a
+different config root.
 
-**Required to start**
+| Path | Purpose |
+|---|---|
+| `runtime.toml` | Provider/model catalog, required `[runtime].default`, runtime lanes, and Keeper assignments |
+| `agent-core-models-overlay.toml` | Optional deployment-specific model capability rows; the embedded Agent Core catalog is used when the file is absent |
+| `keepers/<name>.toml` | Operational Keeper settings |
+| `keepers/<name>/AGENT.md` | Complete Keeper prompt; required for every TOML-backed Keeper |
+| `repositories.toml` | Registered repository identity and checkout metadata for repository workflows |
+| `keeper_repo_mappings.toml` | Keeper-to-repository preferences; these are defaults, not an authorization boundary |
+| `.env.local` | Provider environment variables written by current installer and quickstart flows |
 
-| File | Role |
-|------|------|
-| `runtime.toml` | Provider/model catalog + `[runtime].default`. Required to start: if it (or `[runtime].default`) is missing, the server logs `refusing to boot` and exits 1 — no environment-default fallback |
-| `agent-core-models-overlay.toml` | Deployment-local capability rows merged onto agent core's embedded catalog. Do not copy upstream catalog rows here |
+A Keeper uses two authored files:
 
-**When creating agents**
-
-| File | Role |
-|------|------|
-| `prompts/keeper.world.md` | The shared **World prompt** injected into every Keeper (common stage and rules, `<world>` block). Editing it changes the whole stage |
-| `keepers/<name>.toml` | Keeper (character) definition — goal, instructions, `keeper_name`, `sandbox_profile`. Stacked on top of the World |
-| `keepers/<name>/AGENT.md` | Complete Keeper prompt. Referenced by `keeper_name` and shareable by multiple Keepers |
-
-**Only when asking agents to work on repositories**
-
-| File | Role |
-|------|------|
-| `repositories.toml` | Register repositories for Keeper clone/work. Not needed if there is no repo work |
-| `keeper_repo_mappings.toml` | Keeper → credential + accessible repository mapping |
-| `credentials.toml` | GitHub credentials for PR work |
-
-> The remaining files under `prompts/` are behavior, analysis, deliberation, verification, and memory system templates. They are loaded by name where needed and work with defaults, so you usually do not edit them. The file to edit when you want to change the "stage" is `keeper.world.md`.
->
-> The files you hand-author are `keepers/<name>.toml` (Keeper definitions) and `keepers/<name>/AGENT.md` (Keeper prompts). Runtime state (`.masc/keepers/*.json` + `*.jsonl` logs) is created by the server and should not be edited.
->
-> The active runtime `.masc/` is wherever `--base-path` points. The `masc/.masc/` inside a repository is for locks and scratch only.
-
-Example Keeper definition (`keepers/<name>.toml`):
-
-```toml
-[keeper]
-name = "albini"
-goal = "Call out and chase owners of stalled tasks. Does not write code."
-active_goal_ids = ["goal-pm-flow"]
-sandbox_profile = "docker"     # or "local"
-
-instructions = """
-... Keeper behavior instructions ...
-"""
+```text
+<base-path>/.masc/config/keepers/reviewer.toml
+<base-path>/.masc/config/keepers/reviewer/AGENT.md
 ```
 
-Keeper → runtime assignment is done in `runtime.toml` (the keeper toml does not hold model/runtime directly):
+```toml
+# keepers/reviewer.toml
+[keeper]
+autoboot_enabled = true
+proactive_enabled = true
+sandbox_profile = "local"
+mention_targets = ["operator"]
+allowed_paths = ["workspace/yousleepwhen/masc"]
+```
 
-Provider and binding tables accept `enabled = false`. Disabling a
-`[providers.<id>]` table excludes all of its bindings; disabling a
-`[<provider>.<model>]` table excludes only that runtime. Disabled runtime IDs
-must not remain selected by `[runtime].default`, lanes, assignments, or
-failover lists.
+```markdown
+<!-- keepers/reviewer/AGENT.md -->
+You are the review Keeper. Inspect the current change and report concrete
+evidence with file paths and commands.
+```
+
+Keeper TOML contains operational settings only. Prompt text belongs in
+`AGENT.md`. Unknown Keeper TOML keys are rejected.
+
+Runtime assignment belongs in `runtime.toml`:
 
 ```toml
 [runtime.assignments]
-albini = "<provider>.<model>"   # replace with an id from config/runtime.toml
+reviewer = "<provider>.<model>"
 ```
 
-If the selected runtime uses a cloud provider, export the provider credentials before starting the server. Runtime IDs come from [`config/runtime.toml`](config/runtime.toml); applied environment configuration is exposed by the typed `masc_config` tool and `/api/v1/dashboard/config`.
+Use [`docs/KEEPER-FILE-MODEL.md`](docs/KEEPER-FILE-MODEL.md) for the complete
+file contract. Use the `masc_config` tool or `/api/v1/dashboard/config` to
+inspect the resolved configuration.
 
----
+## Run modes
 
-## Directory layout
+| Command | Use |
+|---|---|
+| `masc start --base-path <path>` | Start an installed binary; `masc` with no subcommand is equivalent |
+| `./start-masc.sh --http --base-path <path>` | Start the full source-checkout runtime |
+| `scripts/start-loopback.sh` | Start on `127.0.0.1:8935` with Keeper bootstrap disabled unless explicitly enabled |
+| `scripts/run-local.sh --target-dir <path>` | Start an isolated development runtime with a path-derived port |
 
-```
-masc/
-├── bin/            Server and CLI entry points (main_eio = HTTP server, masc_tui = TUI, fusion_run …)
-├── lib/            Core logic (keeper/, board/, fusion/, gate/, ide/, server/, runtime/ …)
-├── dashboard/      TypeScript + Preact dashboard SPA
-├── docs/           Specs, runbooks, RFCs, boundary docs
-├── scripts/        Install, build, CI, and ops scripts
-├── config/         Checked-in defaults used as seeds by the runtime
-├── test/           Alcotest suite
-└── start-masc.sh   Full-runtime launch script
+Always inspect the effective runtime root before editing state:
 
-<base-path>/.masc/ (runtime state, under --base-path)
-├── config/         runtime.toml, keepers/, repositories.toml, credentials.toml …
-├── keepers/        Per-Keeper runtime state and memory (*.json + *.jsonl logs, created by server)
-├── goals.json      Goal state
-├── tasks/          Task backlog and goal↔task links
-├── board_*.jsonl   Board posts, comments, votes (append-only)
-└── audit-approvals/  HITL approval history
+```bash
+curl -fsS 'http://127.0.0.1:8935/health?full=1' \
+  | jq '.paths | {effective_base_path, effective_masc_root, roots_diverge}'
 ```
 
----
-
+Runtime-owned files outside `.masc/config/` are not configuration inputs. Do
+not edit Keeper snapshots, task stores, board logs, receipts, or approval
+history by hand.
 
 ## Dashboard
 
-The dashboard is a hash-routed web UI served at `/dashboard/`. Its navigation
-SSOT is `dashboard/src/config/navigation.ts`; entries marked `hidden: true` are
-not shown in the UI.
+The server exposes the dashboard at `/dashboard/`. Navigation is defined in
+`dashboard/src/config/navigation.ts`.
 
-Surfaces pinned to the main navigation rail (`V2_PRIMARY_SURFACE_IDS`):
+Primary sidebar screens:
 
-| Surface | Description |
+| Screen | Purpose |
 |---|---|
-| Overview | Quick signals and briefing summary |
-| Keepers | Keeper roster, conversations, context workspace |
-| Registry | Keeper instances, instructions, and runtime bindings |
-| Monitor | Keeper fleet, internal agents, tool health, runtime, and observatory |
+| Overview | Workspace and runtime summary |
+| Keepers | Keeper roster, conversation, and context |
+| Registry | Keeper declarations and runtime bindings |
+| Monitor | Fleet, tool, runtime, and observation views |
 | Work | Goals, plans, repositories, and verification |
-| Gate | Nonblocking Keeper HITL queue and exact Always rules |
-| Schedule | Scheduled Keeper automations and wake signals |
-| Board | Human / agent / automation / system posts |
-| Fusion | masc_fusion panel and judge deliberation |
-| Logs | System execution logs |
-| IDE | Experimental collaboration shell; not usable for real coding workflows yet |
-| Connectors | Channel sidecars and Keeper bindings |
-| Settings | Operator configuration console |
+| Gate | Human approval queue and Always rules |
+| Schedule | Scheduled work and wake signals |
+| Board | Human, agent, automation, and system posts |
+| Fusion | Panel and judge runs |
+| Logs | Runtime event log |
+| IDE | Experimental collaboration shell |
+| Connectors | External channel status and bindings |
+| Settings | Operator configuration views |
 
-Visible second-level routes:
+Visible second-level sections:
 
-| Surface | Sections |
+| Screen | Sections |
 |---|---|
 | Monitor | `agents`, `internal-agents`, `fleet-health`, `runtime`, `observatory` |
 | Work | `work`, `planning`, `repositories`, `verification` |
@@ -356,63 +253,55 @@ Visible second-level routes:
 | IDE | `ide-shell` |
 | Lab | `tools`, `harness`, `performance`, `keeper-memory-health` |
 
-`Lab` and `Command` are route-accessible surfaces but are not pinned to the
-primary rail. Hidden diagnostics remain implementation routes and are not part
-of the user-visible navigation contract.
+`Lab` and `Command` are addressable but are not pinned to the primary sidebar.
+Hidden diagnostics are not part of the visible navigation contract.
 
-Route examples: `dashboard#monitoring?section=journey`,
+Route examples required by the current dashboard contract:
+`dashboard#monitoring?section=journey`,
 `dashboard#command?section=operations`,
 `dashboard#connectors?section=connector-status`, and
-`dashboard#workspace?section=verification`. The `journey` route is a hidden
-diagnostic; it is addressable but does not appear in the rail.
+`dashboard#workspace?section=verification`. `journey` is a hidden diagnostic.
 
-The [dashboard screenshot inventory](docs/screenshots/dashboard/2026-08-21/README.md)
-contains the 13 primary screens plus visible Monitor, Work, and Lab sections
-captured from a live loopback runtime.
+See the [24-screen inventory](docs/screenshots/dashboard/2026-08-21/README.md)
+for the captured primary, Monitor, Work, and Lab views.
 
----
+## Repository layout
+
+```text
+masc/
+├── bin/          server and CLI entry points
+├── lib/          workspace, Keeper, runtime, Gate, and server code
+├── packages/     embedded Agent Core package
+├── dashboard/    TypeScript and Preact dashboard source
+├── assets/       built web assets
+├── config/       default configuration seeds
+├── docs/         runbooks, contracts, specs, and historical RFCs
+├── scripts/      build, install, validation, and local operations
+└── test/         OCaml tests and fixtures
+```
 
 ## Documentation
 
-Docs in this repo are not all equally current. Prefer files that name their
-status and `last_verified` date, and treat older design/RFC files as historical
-unless they are linked from a current runbook.
+| Document | Use |
+|---|---|
+| [`docs/MCP-TEMPLATE.md`](docs/MCP-TEMPLATE.md) | MCP client configuration |
+| [`docs/KEEPER-FILE-MODEL.md`](docs/KEEPER-FILE-MODEL.md) | Current Keeper file and runtime assignment contract |
+| [`docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md`](docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md) | Local bearer and dashboard write access |
+| [`docs/AGENT-CORE-BOUNDARY.md`](docs/AGENT-CORE-BOUNDARY.md) | Responsibility split between MASC and embedded Agent Core |
+| [`docs/spec/SPEC-INDEX.md`](docs/spec/SPEC-INDEX.md) | Specification index; inventory counts inside it are historical unless marked current |
+| [`docs/RELEASE-EVIDENCE.md`](docs/RELEASE-EVIDENCE.md) | Release evidence format; verify its version header before reuse |
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | Build, test, and pull-request workflow |
+| [`ROADMAP.md`](ROADMAP.md) | Current planning view, not a release promise |
 
-| Document | Use it for | Currentness note |
-|---|---|---|
-| [`CONTRIBUTING.md`](CONTRIBUTING.md) | Build/test/PR expectations | Contributor workflow, not product marketing |
-| [`ROADMAP.md`](ROADMAP.md) | 6-8 week operating view | Check its version header against `dune-project` and `CHANGELOG.md` |
-| [`docs/AGENT-CORE-BOUNDARY.md`](docs/AGENT-CORE-BOUNDARY.md) | MASC ↔ agent core boundary | Reference doc; prefer its `last_verified` and generated pin block over old prose elsewhere |
-| [`docs/spec/SPEC-INDEX.md`](docs/spec/SPEC-INDEX.md) | Spec suite entry point | Living draft; individual spec files may still carry migration context |
-| [`docs/KEEPER-USER-MANUAL.md`](docs/KEEPER-USER-MANUAL.md) | Keeper concepts and operator notes | Older manual; for config truth prefer [`docs/KEEPER-FILE-MODEL.md`](docs/KEEPER-FILE-MODEL.md), [`config/runtime.toml`](config/runtime.toml), and live code |
-| [`docs/RELEASE-EVIDENCE.md`](docs/RELEASE-EVIDENCE.md) | Release evidence bundle | Evidence format; version lines must match current release metadata before use |
+## Development and release status
 
-See the [Dashboard](#dashboard) section above for dashboard route formats and surface list.
-
----
-
-## Roadmap / Remaining work
-
-The table below lists concrete remaining tasks derived from the current limits described above. Broader operating plans are in [`ROADMAP.md`](ROADMAP.md).
-
-| # | Area | Remaining work | Expected status change |
-|---|------|---------------|------------------------|
-| 2 | **Provider Failover** | Add provider-health based automatic rotation on top of the ordered `[runtime.lanes]` groups, with recovery logs/metrics. | 🟡→✅ |
-| 3 | **Fusion + JoJ** | Validate the staged judge-of-judges path end to end with the shipped judges preset. | 🟡→✅ |
-| 5 | **TUI** | Make `masc-tui` usable in practice. The binary exists but is currently unusable due to CJK/emoji layout, streaming progress, and rich-block rendering gaps. | ❌→🟡/✅ |
-| 6 | **IDE** | Make the observational IDE usable in practice. The LSP proxy, annotation overlay, and dashboard IDE shell exist, but the command-only flow is not validated and the IDE is currently unusable. | ❌→🟡/✅ |
-| 7 | **Multi-Channel** | Add sidecars for Telegram and other channels beyond Discord/Slack, and extend the gate message schema per channel. | 🟡→✅ |
-| 8 | **Sandbox** | Reduce host-execution fallback cases when Docker image is missing or the path is inside the playground, and document `sandbox_profile=local` usage explicitly. | ✅ stabilization |
-| 9 | **HITL** | Keep human decisions nonblocking: persist the exact request, let the Keeper continue other work, and wake only that Keeper lane when a decision arrives. | ✅ stabilization |
-| 10 | **Gate** | Keep Always Allow, LLM Auto Judge, and HITL as non-hierarchical choices; audit exact one-use grants without classifying products, commands, or risk levels. | ✅ stabilization |
-| 11 | **OpenTelemetry** | Add missing signals and instrumentation such as low-level Keeper turn events, internal fusion metrics, and per-provider latency breakdowns. | 🟡→✅ |
-
----
-
-## Status
-
-pre-1.0 (`0.y.z`). APIs and configuration formats may change. `1.0.0` will not be declared until repository collaboration, release, and operator paths are trustworthy without caveats.
+- The package version is defined in `dune-project` and generated into
+  `masc.opam`.
+- `CHANGELOG.md` records the source release line.
+- [GitHub Releases](https://github.com/jeong-sik/masc/releases) is the source of
+  truth for published binaries and their assets.
+- APIs and configuration may change before 1.0.
 
 ## License
 
-MIT. Provided "as is" without warranty. See [`LICENSE`](LICENSE) for details.
+MIT. See [`LICENSE`](LICENSE).


### PR DESCRIPTION
## Summary

- Rewrite the English and Korean READMEs around the current repository-first collaboration workflow.
- Correct quickstart, MCP client, Keeper configuration, Dashboard, and release installation guidance against the current source.
- Remove stale Homebrew, credential-file, inline Keeper instruction, and roadmap claims.

## Product impact

The README now presents shared repository work as the primary entry point and Keepers as an optional long-running layer. This is documentation-only and does not change runtime behavior.

## Evidence

- `scripts/check-doc-truth.sh`
- `git diff --check origin/main...HEAD`
- Local Markdown link and code-fence checks for both README files
- Source comparison against `quickstart.sh`, `scripts/install.sh`, `start-masc.sh`, `config/runtime.toml`, `docs/KEEPER-FILE-MODEL.md`, and Dashboard navigation

## Review evidence

- Three-pass generate, evaluate, and refine review
- English and Korean structures checked for parity
- Time-sensitive version and release claims separated

## Linked issue

Documentation follow-up to #29291. No issue is closed by this PR.
