### PR TITLE
fix(keeper): 중간에 죽은 대시보드 purge 에 출구 복원

### DIFF
--- a/lib/keeper/keeper_dashboard_purge.ml
+++ b/lib/keeper/keeper_dashboard_purge.ml
@@ -37,6 +37,11 @@ type resolve_error =
       ; operation_id : Keeper_shutdown_types.Operation_id.t
       ; detail : string
       }
+  | Keeper_purge_blocked of
+      { keeper_name : string
+      ; operation_id : Keeper_shutdown_types.Operation_id.t
+      ; detail : string
+      }
   | Keeper_lane_executing of
       { keeper_name : string
       ; phase : string
@@ -44,6 +49,14 @@ type resolve_error =
       }
 
 let resolve_error_to_string = function
+  | Keeper_purge_blocked { keeper_name; operation_id; detail } ->
+    Printf.sprintf
+      "keeper purge %s is blocked and will not resume on its own: keeper=%s \
+       failure=%s; release the admission fence with an operator supersession, \
+       then reissue the purge"
+      (Keeper_shutdown_types.Operation_id.to_string operation_id)
+      keeper_name
+      detail
   | Keeper_lane_executing { keeper_name; phase; live_turn_id } ->
     (match live_turn_id with
      | None ->
@@ -200,12 +213,32 @@ let existing_operation (config : Workspace.config) requested_name =
                ; detail = Keeper_shutdown_store.error_to_string error
                })
         | Ok operation ->
-          Ok
-            (match operation.cleanup_intent.reason with
-             | Keeper_shutdown_types.Dashboard_keeper_purge _ -> Some operation
-             | Operator_stop_retain_meta
-             | Operator_stop_remove_meta
-             | Supervisor_cleanup -> None)))
+          (match operation.cleanup_intent.reason with
+           | Keeper_shutdown_types.Dashboard_keeper_purge _ ->
+             (match operation.phase with
+              | Keeper_shutdown_types.Blocked failure ->
+                Error
+                  (Keeper_purge_blocked
+                     { keeper_name
+                     ; operation_id
+                     ; detail =
+                         Printf.sprintf
+                           "%s: %s"
+                           (Keeper_shutdown_types.failure_stage_to_string
+                              failure.Keeper_shutdown_types.stage)
+                           failure.Keeper_shutdown_types.detail
+                     })
+              | Prepared
+              | Joining_lanes
+              | Joined_idle
+              | Finalizing_tasks _
+              | Cleanup_ready _
+              | Reconciliation_required _
+              | Finalized _
+              | Superseded _ -> Ok (Some operation))
+           | Operator_stop_retain_meta
+           | Operator_stop_remove_meta
+           | Supervisor_cleanup -> Ok None)))
 ;;
 
 let submit ~config ~actor ({ requested_name; keeper_name; meta } : target) =

--- a/lib/keeper/keeper_dashboard_purge.mli
+++ b/lib/keeper/keeper_dashboard_purge.mli
@@ -45,6 +45,17 @@ type resolve_error =
       ; operation_id : Keeper_shutdown_types.Operation_id.t
       ; detail : string
       }
+  | Keeper_purge_blocked of
+      { keeper_name : string
+      ; operation_id : Keeper_shutdown_types.Operation_id.t
+      ; detail : string
+      }
+      (** A prior purge holds the admission fence in [Blocked]. It is not in
+          flight and no retry advances it: the fence stops the Keeper's meta
+          being materialized, and {!resolve} needs that meta. Reporting it as
+          an accepted operation told the dashboard a purge was running that
+          had already stopped for good. The exit is an operator supersession,
+          which releases the fence and lets the purge be reissued. *)
       (** The lane is still taking turns. Purge deletes the Keeper and every
           store it owns, so a Keeper that can still execute is refused here
           rather than raced: stop or pause it first. The dashboard hides the

--- a/lib/keeper/keeper_shutdown_store.ml
+++ b/lib/keeper/keeper_shutdown_store.ml
@@ -35,6 +35,7 @@ type supersede_blocked_result =
    recovered from the record afterwards. *)
 type superseded_admission =
   | Blocked_operator_stop
+  | Blocked_dashboard_purge
   | Unreconciled_turn of Keeper_shutdown_types.active_turn
 
 type operator_metadata_supersession_token =
@@ -278,6 +279,11 @@ let finalization_evidence_to_json evidence =
 ;;
 
 let supersession_to_json = function
+  | Operator_blocked_purge_released { actor } ->
+    `Assoc
+      [ "kind", `String "operator_blocked_purge_released"
+      ; "actor", `String actor
+      ]
   | Operator_metadata_update { actor } ->
     `Assoc
       [ "kind", `String "operator_metadata_update"
@@ -592,6 +598,9 @@ let finalization_evidence_of_json json =
 let supersession_of_json json =
   let* kind = string "kind" json in
   match kind with
+  | "operator_blocked_purge_released" ->
+    let* actor = string "actor" json in
+    Ok (Operator_blocked_purge_released { actor })
   | "operator_metadata_update" ->
     let* actor = string "actor" json in
     Ok (Operator_metadata_update { actor })
@@ -927,6 +936,20 @@ let prepare_operator_metadata_supersession
       ; superseded_admission = Unreconciled_turn turn
       }
   | Ok
+      ({ phase = Superseded (Operator_blocked_purge_released _)
+       ; revision
+       ; _ } as _operation) ->
+    (* Idempotent: a second release of the same purge re-mints the same token
+       rather than reporting a phase mismatch. *)
+    Ok
+      { base_path
+      ; keeper_name
+      ; operation_id
+      ; expected_revision = revision
+      ; actor
+      ; superseded_admission = Blocked_dashboard_purge
+      }
+  | Ok
       ({ phase = Superseded (Operator_metadata_update _ | Operator_reconciliation_accepted _)
        ; revision
        ; _ } as _operation) ->
@@ -937,6 +960,25 @@ let prepare_operator_metadata_supersession
       ; expected_revision = revision
       ; actor
       ; superseded_admission = Blocked_operator_stop
+      }
+  (* A purge whose worker died in [Joining_lanes] holds the admission fence,
+     and that fence is what stops its own reissue: meta cannot be materialized
+     while it is held, and [Keeper_dashboard_purge.resolve] needs that meta to
+     build a target. Releasing it is the only exit, and it is as safe here as
+     for an operator stop -- the phase, not the intent, is what says the work
+     failed. *)
+  | Ok
+      ({ phase = Blocked _
+       ; cleanup_intent = { reason = Dashboard_keeper_purge _; _ }
+       ; revision
+       ; _ } as _operation) ->
+    Ok
+      { base_path
+      ; keeper_name
+      ; operation_id
+      ; expected_revision = revision
+      ; actor
+      ; superseded_admission = Blocked_dashboard_purge
       }
   | Ok ({ phase = Blocked _; _ } as operation) ->
     Error (Supersession_intent_mismatch operation)
@@ -982,12 +1024,18 @@ let supersede_blocked_operator_stop ~config ~token ~now =
          | Ok
              ({ phase =
                   Superseded
-                    (Operator_metadata_update _ | Operator_reconciliation_accepted _)
+                    ( Operator_metadata_update _
+                    | Operator_reconciliation_accepted _
+                    | Operator_blocked_purge_released _ )
               ; _ } as existing) ->
            Ok (Superseded_already_persisted existing)
          | Ok
              ({ phase = Blocked _ | Reconciliation_required _
               ; cleanup_intent = { reason = Operator_stop_retain_meta; _ }
+              ; _ } as existing)
+         | Ok
+             ({ phase = Blocked _
+              ; cleanup_intent = { reason = Dashboard_keeper_purge _; _ }
               ; _ } as existing) ->
            if not (Int.equal existing.revision token.expected_revision)
            then
@@ -1002,6 +1050,8 @@ let supersede_blocked_operator_stop ~config ~token ~now =
                match token.superseded_admission with
                | Blocked_operator_stop ->
                  Operator_metadata_update { actor = token.actor }
+               | Blocked_dashboard_purge ->
+                 Operator_blocked_purge_released { actor = token.actor }
                | Unreconciled_turn unreconciled_turn ->
                  Operator_reconciliation_accepted
                    { actor = token.actor; unreconciled_turn }

--- a/lib/keeper/keeper_shutdown_types.ml
+++ b/lib/keeper/keeper_shutdown_types.ml
@@ -141,6 +141,7 @@ type finalization_evidence =
   }
 
 type supersession =
+  | Operator_blocked_purge_released of { actor : string }
   | Operator_metadata_update of { actor : string }
   | Operator_reconciliation_accepted of
       { actor : string
@@ -366,6 +367,15 @@ let validate operation =
        | ( Operator_stop_remove_meta
          | Supervisor_cleanup
          | Dashboard_keeper_purge _ ) as cleanup_reason ->
+         Error (Superseded_cleanup_reason_mismatch cleanup_reason))
+    | Superseded (Operator_blocked_purge_released _) ->
+      (* The mirror of the arm above: this release exists only for a purge, so
+         every other intent is as wrong here as a purge is there. *)
+      (match operation.cleanup_intent.reason with
+       | Dashboard_keeper_purge _ -> Ok ()
+       | ( Operator_stop_retain_meta
+         | Operator_stop_remove_meta
+         | Supervisor_cleanup ) as cleanup_reason ->
          Error (Superseded_cleanup_reason_mismatch cleanup_reason))
     | Prepared
     | Joining_lanes

--- a/lib/keeper/keeper_shutdown_types.mli
+++ b/lib/keeper/keeper_shutdown_types.mli
@@ -124,6 +124,21 @@ type finalization_evidence =
   }
 
 type supersession =
+  | Operator_blocked_purge_released of { actor : string }
+      (** The operator released a [Blocked] dashboard purge whose worker died
+          before it finished. Like {!Operator_metadata_update} this carries no
+          effect-duplication risk -- the work failed -- but it is not a
+          metadata update: a purge leaves no metadata to update, and the
+          admission fence it holds is what stops the purge being reissued.
+          Kept apart so the durable record says which release was signed off.
+
+          Without this the pair ([Blocked], [Dashboard_keeper_purge]) had no
+          exit: the fence blocks meta materialization, {!val:resolve} needs
+          that meta to build a purge target, and supersession refused any
+          intent but [Operator_stop_retain_meta]. A worker that died in
+          [Joining_lanes] left the Keeper permanently half-purged
+          (RFC-0000 1.2 LAW 1 "No dead-end", the same law #25491 restored for
+          [Reconciliation_required]). *)
   | Operator_metadata_update of { actor : string }
   | Operator_reconciliation_accepted of
       { actor : string

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -534,6 +534,9 @@ let keeper_purge_resolve_status = function
   | Keeper_lane_executing _ -> `Conflict
   | Keeper_owner_unavailable _ -> `Service_unavailable
   | Keeper_operation_unreadable _ -> `Internal_server_error
+  (* Not 500: the record is readable and the state is exact. It is a conflict
+     the operator resolves by releasing the fence. *)
+  | Keeper_purge_blocked _ -> `Conflict
 ;;
 
 let keeper_purge_submit_status = function

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -79,6 +79,7 @@ fi
 
 paused_targets=(
   @test/runtest-test_keeper_turn_outcome
+  @test/runtest-test_keeper_shutdown_blocked_purge_release
   @test/runtest-test_keeper_paused_work_transfer_transaction
   @test/runtest-test_keeper_paused_work_source_terminal_transaction
   @test/runtest-test_keeper_paused_work_operator

--- a/test/dune
+++ b/test/dune
@@ -2065,6 +2065,7 @@
 (include stanzas/test_shutdown_flag.inc)
 
 (include stanzas/test_keeper_shutdown_reconciliation_settlement.inc)
+(include stanzas/test_keeper_shutdown_blocked_purge_release.inc)
 
 (include stanzas/test_keeper_shutdown_ownerless_admission_release.inc)
 

--- a/test/stanzas/test_keeper_shutdown_blocked_purge_release.inc
+++ b/test/stanzas/test_keeper_shutdown_blocked_purge_release.inc
@@ -1,0 +1,7 @@
+; A dashboard purge blocked in Lane_join had no exit: the fence it holds stops
+; the meta that resolve needs, and supersession admitted only operator stops.
+
+(test
+ (name test_keeper_shutdown_blocked_purge_release)
+ (modules test_keeper_shutdown_blocked_purge_release)
+ (libraries masc_test_deps))

--- a/test/test_keeper_shutdown_blocked_purge_release.ml
+++ b/test/test_keeper_shutdown_blocked_purge_release.ml
@@ -1,0 +1,210 @@
+(* A dashboard purge whose worker died in [Joining_lanes] is recovered as
+   [Blocked Lane_join], which keeps the admission fence. Nothing then moved it:
+   the fence stopped the Keeper's meta being materialized, [resolve] needs that
+   meta to build a purge target, and supersession admitted no intent but
+   [Operator_stop_retain_meta]. Three keepers sat half-purged from 2026-08-19,
+   with reconcile re-attempting ~238 times an hour and the dashboard answering
+   every retry with "accepted" — the same no-exit shape #25491 fixed for
+   [Reconciliation_required], reached through a different pair. *)
+
+open Alcotest
+open Masc
+open Keeper_shutdown_types
+
+let temp_dir prefix =
+  let dir = Filename.temp_file prefix "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+;;
+
+let cleanup_dir path =
+  let rec rm p =
+    match Unix.lstat p with
+    | { Unix.st_kind = Unix.S_DIR; _ } ->
+      Array.iter (fun name -> rm (Filename.concat p name)) (Sys.readdir p);
+      Unix.rmdir p
+    | _ -> Unix.unlink p
+    | exception Unix.Unix_error _ -> ()
+  in
+  rm path
+;;
+
+let with_workspace f =
+  let base = temp_dir "keeper_shutdown_blocked_purge_" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base)
+    (fun () ->
+       Eio_main.run @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       Fun.protect
+         ~finally:(fun () -> Fs_compat.clear_fs ())
+         (fun () ->
+            let config = Workspace.default_config base in
+            let (_init_msg : string) = Workspace.init config ~agent_name:None in
+            f ~config))
+;;
+
+let trace_id_exn value =
+  match Keeper_id.Trace_id.of_string value with
+  | Ok trace_id -> trace_id
+  | Error detail -> failf "trace id rejected: %s" detail
+;;
+
+let keeper_name = "rw-e0-blocked-purge"
+
+let purge_intent =
+  { reason =
+      Dashboard_keeper_purge
+        { requested_name = keeper_name
+        ; agent_name = Printf.sprintf "keeper-%s-agent" keeper_name
+        }
+  ; remove_session = true
+  }
+;;
+
+let stop_intent = { reason = Operator_stop_retain_meta; remove_session = false }
+
+let interrupted_lane_join =
+  Blocked
+    { stage = Lane_join
+    ; detail = "server process ended while joining Keeper and Librarian lanes"
+    }
+;;
+
+let make_operation ~cleanup_intent ~phase =
+  { schema_version = Keeper_shutdown_types.schema_version
+  ; revision = 1
+  ; operation_id = Operation_id.generate ()
+  ; keeper_name
+  ; lane_ownership = Dormant_meta
+  ; trace_id = trace_id_exn "trace-blocked-purge-release-test"
+  ; generation = 1
+  ; actor = "dashboard"
+  ; cleanup_intent
+  ; turn_disposition = No_inflight_turn
+  ; expected_backlog_version = 0
+  ; owned_task_ids = []
+  ; join_evidence = None
+  ; phase
+  ; created_at = Masc_domain.now_iso ()
+  ; updated_at = Masc_domain.now_iso ()
+  }
+;;
+
+let persist_exn ~config operation =
+  match Keeper_shutdown_store.persist_new ~config operation with
+  | Ok () -> ()
+  | Error error ->
+    failf "persist_new failed: %s" (Keeper_shutdown_store.error_to_string error)
+;;
+
+let release_exn ~config operation =
+  match
+    Keeper_shutdown_store.prepare_operator_metadata_supersession
+      ~config
+      ~keeper_name
+      ~operation_id:operation.operation_id
+      ~actor:"operator"
+  with
+  | Error error ->
+    failf
+      "blocked purge refused a supersession token: %s"
+      (Keeper_shutdown_store.error_to_string error)
+  | Ok token ->
+    (match
+       Keeper_shutdown_store.supersede_blocked_operator_stop
+         ~config
+         ~token
+         ~now:Masc_domain.now_iso
+     with
+     | Ok (Superseded_persisted released | Superseded_already_persisted released) ->
+       released
+     | Error error ->
+       failf
+         "supersession did not persist: %s"
+         (Keeper_shutdown_store.error_to_string error))
+;;
+
+(* The fence is the whole wedge: while it is held nothing else can move, so a
+   release that only rewrites the phase would leave the Keeper exactly as
+   stuck. *)
+let test_release_frees_the_admission_fence () =
+  with_workspace (fun ~config ->
+    let operation = make_operation ~cleanup_intent:purge_intent ~phase:interrupted_lane_join in
+    persist_exn ~config operation;
+    check bool "a blocked purge holds the fence" true
+      (requires_admission_fence operation);
+    let released = release_exn ~config operation in
+    check bool "the release frees it" false (requires_admission_fence released))
+;;
+
+(* The durable record has to say which release was signed off. Recording a
+   purge release as [Operator_metadata_update] would claim an operator updated
+   metadata that a purge deletes. *)
+let test_release_is_recorded_as_a_purge_release () =
+  with_workspace (fun ~config ->
+    let operation = make_operation ~cleanup_intent:purge_intent ~phase:interrupted_lane_join in
+    persist_exn ~config operation;
+    let released = release_exn ~config operation in
+    match released.phase with
+    | Superseded (Operator_blocked_purge_released { actor }) ->
+      check string "records the operator" "operator" actor
+    | Superseded (Operator_metadata_update _) ->
+      fail "a purge release was recorded as a metadata update"
+    | Superseded (Operator_reconciliation_accepted _) ->
+      fail "a purge release was recorded as a reconciliation acceptance"
+    | Prepared | Joining_lanes | Joined_idle | Finalizing_tasks _ | Cleanup_ready _
+    | Reconciliation_required _ | Finalized _ | Blocked _ ->
+      fail "the blocked purge was not superseded")
+;;
+
+(* Reloading proves the new supersession survives the codec: a release that
+   cannot be read back reappears as [Blocked] on the next boot. *)
+let test_release_survives_a_reload () =
+  with_workspace (fun ~config ->
+    let operation = make_operation ~cleanup_intent:purge_intent ~phase:interrupted_lane_join in
+    persist_exn ~config operation;
+    let (_released : Keeper_shutdown_types.t) = release_exn ~config operation in
+    match Keeper_shutdown_store.load ~config ~keeper_name operation.operation_id with
+    | Error error ->
+      failf "released purge did not load: %s" (Keeper_shutdown_store.error_to_string error)
+    | Ok reloaded ->
+      (match reloaded.phase with
+       | Superseded (Operator_blocked_purge_released _) ->
+         check bool "still unfenced after a reload" false
+           (requires_admission_fence reloaded)
+       | _ -> fail "the reloaded phase was not a purge release"))
+;;
+
+(* The release exists for a purge, so it must not become a way around the
+   metadata-update route: an operator stop still records its own supersession. *)
+let test_operator_stop_release_is_unchanged () =
+  with_workspace (fun ~config ->
+    let operation = make_operation ~cleanup_intent:stop_intent ~phase:interrupted_lane_join in
+    persist_exn ~config operation;
+    let released = release_exn ~config operation in
+    match released.phase with
+    | Superseded (Operator_metadata_update _) -> ()
+    | Superseded (Operator_blocked_purge_released _) ->
+      fail "an operator stop was recorded as a purge release"
+    | _ -> fail "the blocked operator stop was not superseded")
+;;
+
+let () =
+  run
+    "keeper-shutdown-blocked-purge-release"
+    [ ( "operator release"
+      , [ test_case "frees the admission fence" `Quick test_release_frees_the_admission_fence
+        ; test_case
+            "is recorded as a purge release"
+            `Quick
+            test_release_is_recorded_as_a_purge_release
+        ; test_case "survives a reload" `Quick test_release_survives_a_reload
+        ; test_case
+            "leaves the operator-stop route alone"
+            `Quick
+            test_operator_stop_release_is_unchanged
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 목표

대시보드 purge 가 중간에 죽었을 때 **완료도 취소도 못 하는 상태**를 없앤다.

## 라이브 증상

2026-08-19T15:52:42Z 부터 3일째. keeper 3개가 "반쯤 지워진" 채 있다 — 실행은 멈췄고, TOML·memory 파일은 디스크에 남았고, reconcile 이 시간당 ~238회 재생성을 시도해 매번 거부당한다.

```
actor          = dashboard
cleanup_intent = dashboard_keeper_purge
phase          = blocked
                 stage:  lane_join
                 detail: "server process ended while joining Keeper and Librarian lanes"
```

durable 기록 174건 중 171건은 `finalized` 다. 기전 자체는 정상이고, `lane_join` 중 프로세스가 죽은 3건만 갇혔다.

## 왜 빠져나올 수 없었나

```
Blocked purge 가 admission fence 를 잡음
   → fence 때문에 keeper meta 를 materialize 못 함
   → resolve 가 meta 를 요구 (target 에 meta 필드)
   → purge 재제출 불가
   → 유일한 fence 해제 경로인 supersession 은 Operator_stop_retain_meta 에만 열림
```

`Blocked Lane_join` 으로 fence 를 유지하는 것 자체는 맞다. 프로세스 경계에서 Librarian 완료 여부를 추론할 수 없기 때문이고, 타입 주석에 그렇게 적혀 있다. 문제는 **그 다음 문이 없다**는 것.

`#25491` 이 `Reconciliation_required` 에서 없앤 것과 같은 모양이다 (RFC-0000 §1.2 LAW 1 "No dead-end"). 그때는 5개 keeper 가 재시작을 넘어 부팅 불가였고, 이번엔 (phase, intent) 조합이 다를 뿐이다.

안전성 근거는 이미 코드에 있었고, 이미 일반적이었다.

> `Blocked_operator_stop` carries no effect-duplication risk: the shutdown worker failed, so the turn it was finalizing did not proceed.

이 근거는 **phase 기준**이지 intent 기준이 아니다.

## 게이트가 셋이었다

같은 술어("이 operation 을 supersede 할 수 있는가")가 세 곳에 각각 손으로 적혀 있었다.

| # | 위치 | |
|---|---|---|
| 1 | `prepare_operator_metadata_supersession` | 토큰 발급 |
| 2 | `validate` 불변식 | `Superseded` + intent 조합 |
| 3 | `supersede_blocked_operator_stop` 의 재확인 | 저장 직전 재검증 |

하나를 열어야 다음이 보였다. **3번은 코드를 읽어서가 아니라 테스트가 실패해서 찾았다** — 타입체크는 셋 다 통과한다. 이 셋을 술어 함수 하나로 뽑는 건 이 PR 범위 밖으로 둔다.

## 변경

- `supersession` 에 `Operator_blocked_purge_released` 추가. 기존 `Operator_metadata_update` 재사용은 하지 않았다 — durable 기록은 운영자가 무엇에 서명했는지 말해야 하고, purge 는 수정할 메타데이터를 남기지 않는다.
- 불변식에 대칭 arm: 이 해제는 purge intent 에만 유효.
- 게이트 3곳이 `Blocked` + `Dashboard_keeper_purge` 를 받도록. 재호출 idempotent.
- `existing_operation` 이 `Blocked` purge 를 반환하지 않는다. 이게 3일이 지나간 이유다 — 대시보드 재시도마다 "accepted" 가 돌아왔다. 이제 409 + 해제 경로 안내.

## 테스트

`test_keeper_shutdown_blocked_purge_release` 신규 4종. `test/dune` 과 `scripts/ci-run-focused-tests.sh` **양쪽에** 등록했다.

1. **fence 가 실제로 풀린다** (`requires_admission_fence` false) — 핵심. phase 만 다시 쓰는 해제는 wedge 를 그대로 둔다
2. `Operator_blocked_purge_released` 로 기록된다 (메타 수정으로 둔갑 안 함)
3. 재로드 후에도 유지된다 (코덱 왕복)
4. operator stop 경로는 그대로다

## 로컬 검증

```
dune build @check                                       exit 0
runtest-test_keeper_shutdown_blocked_purge_release      exit 0   4 tests
runtest-test_keeper_shutdown_reconciliation_settlement  exit 0
runtest-test_keeper_shutdown_ownerless_admission_release exit 0
runtest-test_keeper_status_bridge                       exit 0
scripts/audit-ci-test-targets.sh                        OK  381 targets / 516 unwired (baseline 유지)
```

## 미검증

- `test_heartbeat_integration` 의 `direct_keepalive / fork rejection` 케이스가 실패한다. `origin/main` 대조군을 돌리는 중이라 이 PR 탓인지 아직 미확정. 확인되면 코멘트로 남긴다.
- 곁가지: `test_keeper_shutdown_reconciliation_settlement` (#25491 회귀 테스트) 는 `test/dune` 에만 있고 CI allowlist 에는 없어 CI 에서 돌지 않는다. 이 PR 에서는 건드리지 않았다.

## 라이브 복구는 별개

코드가 고쳐져도 이미 `Blocked` 인 기록 3건은 저절로 안 풀린다. 새 출구가 생겼을 뿐 운영자가 그 문으로 나가야 한다. 자동 정착(boot recovery 가 알아서 해제)은 "Librarian 완료를 추론할 수 없다"는 결정과 충돌하므로 별도 판단이 필요하다.
