### PR TITLE
fix(test): #29256 이 남긴 main 적색 정리 — gate allowlist 복원 + goal 픽스처 계약 이행

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -850,6 +850,7 @@ let pending_entry_of_yojson ~base_path json =
           ; "request_context_version"
           ; "task_id"
           ; "goal_id"
+          ; "continuation_channel"
           ; "summary_status"
           ; "exact_attempt"
           ; "summary_attempt_disposition"

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -1664,7 +1664,6 @@ let test_execution_trust_uses_narrow_keeper_projection () =
          ; "trace_id"
          ; "generation"
          ; "current_task_id"
-         ; "active_goal_ids"
          ; "trust"
          ])
   in
@@ -1683,8 +1682,6 @@ let test_execution_trust_uses_narrow_keeper_projection () =
   check string "trace id" "execution-trust-narrow-trace"
     (row |> member "trace_id" |> to_string);
   check int "generation" 17 (row |> member "generation" |> to_int);
-  check (list string) "active goals" [ "goal-narrow-1" ]
-    (row |> member "active_goal_ids" |> to_list |> List.map to_string);
   check bool "trust summary remains populated" true
     (match row |> member "trust" with `Assoc _ -> true | _ -> false)
 

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -291,22 +291,9 @@ let test_dedup_never_merges_distinct_origins () =
            ~input
            ()
        in
-       let another_goal_context =
-         submit_with_context
-           ~turn_id:1
-           ~continuation_channel:dashboard_a
-           ~base_path
-           ~keeper_name
-           ~input
-           ()
-       in
-       List.iter
-         (fun id ->
-            Alcotest.(check bool) "distinct origin has its own request" true
-              (not (String.equal first id)))
-         [ another_channel; another_goal_context ];
-       List.iter (reject_and_cleanup ~base_path)
-         [ first; another_channel; another_goal_context ])
+       Alcotest.(check bool) "distinct origin has its own request" true
+         (not (String.equal first another_channel));
+       List.iter (reject_and_cleanup ~base_path) [ first; another_channel ])
 ;;
 
 (* The measured 2026-08-16 incident, end to end: the retry lands after the

--- a/test/test_keeper_goal_phase_projection.ml
+++ b/test/test_keeper_goal_phase_projection.ml
@@ -74,6 +74,19 @@ let seed_all_phases config =
     }
 ;;
 
+(* Only terminal Goals: nothing on the surface, and nothing that could be
+   mistaken for an empty list produced some other way. *)
+let seed_terminal_phases_only config =
+  Goal_store.write_state config
+    { version = 1
+    ; updated_at = Masc_domain.now_iso ()
+    ; goals =
+        [ goal_in Goal_phase.Completed "goal-completed" "already achieved"
+        ; goal_in Goal_phase.Dropped "goal-dropped" "abandoned"
+        ]
+    }
+;;
+
 let meta_with_goals ids =
   match
     Masc_test_deps.meta_of_json_fixture
@@ -138,24 +151,12 @@ let test_world_observation_drops_terminal_goals () =
     observation.Keeper_world_observation.active_goals
 ;;
 
-let test_unresolved_goal_id_stays_visible () =
-  (* An assigned goal that no longer exists is a different fault. Dropping it
-     alongside the terminal ones would replace a visible inconsistency with a
-     silent one, so it keeps its bare-id rendering. *)
-  with_workspace @@ fun config ->
-  seed_all_phases config;
-  let _meta = meta_with_goals [ "goal-completed"; "goal-vanished" ] in
-  let summaries = Keeper_unified_prompt.active_goal_summaries_of_store ~config in
-  check (list string) "the terminal goal goes, the unknown id stays"
-    [ "goal-vanished" ] (summary_ids summaries);
-  check (option string) "unknown id renders with no title" (Some "")
-    (summary_title_opt "goal-vanished" summaries)
-;;
-
+(* Terminal phases are the only thing that removes a Goal from the surface.
+   Seed a store whose Goals are all terminal and neither surface offers any --
+   an empty block rather than one that looks empty for a different reason. *)
 let test_no_goals_surface_when_all_are_terminal () =
   with_workspace @@ fun config ->
-  seed_all_phases config;
-  let _meta = meta_with_goals [ "goal-completed"; "goal-dropped" ] in
+  seed_terminal_phases_only config;
   let meta = meta_with_goals [] in
   check (list string) "no goal block rather than an empty-looking one" []
     (summary_ids (Keeper_unified_prompt.active_goal_summaries_of_store ~config));
@@ -166,7 +167,6 @@ let test_no_goals_surface_when_all_are_terminal () =
   check (list string) "and the frame carries none either" []
     observation.Keeper_world_observation.active_goals
 ;;
-
 
 (* An executing Goal that no Task serves is one fact addressed to every Keeper.
    The keeper's [active_goal_ids] is empty here on purpose: the fact lives on
@@ -300,8 +300,6 @@ let () =
             test_system_prompt_surface_drops_terminal_goals
         ; test_case "world observation drops terminal goals" `Quick
             test_world_observation_drops_terminal_goals
-        ; test_case "unresolved goal id stays visible" `Quick
-            test_unresolved_goal_id_stays_visible
         ; test_case "all-terminal yields no goals at either surface" `Quick
             test_no_goals_surface_when_all_are_terminal
         ] )


### PR DESCRIPTION
#29256 이 main 을 빨갛게 만든 것을 되돌립니다. 22건 → 0건 (제 몫 기준).

## 진짜 결함 하나

**gate pending allowlist 가 `continuation_channel` 을 잃었습니다.**

`goal_ids` 를 지우는 정규식이 바로 다음 줄까지 가져갔습니다. 병합 전 목록에서 두 키는 인접해 있었습니다.

```
  ; "goal_id"
  ; "goal_ids"            <- 지우려던 것
  ; "continuation_channel" <- 같이 지워진 것
  ; "summary_status"
```

결과: 저장된 gate entry 가 전부 디코드 실패합니다.

```
gate_pending.entry contains unsupported field continuation_channel
```

`keeper_approval_queue` 15건이 이것 하나 때문이었습니다. 복원 후 45/45.

## 계약이 바뀐 테스트 3건

**dedup origin** — `another_goal_context` 는 `~goal_ids:[ "goal-b" ]` 하나만 다른 요청이었습니다. goal 멤버십은 애초에 origin 이 아니었으므로 케이스를 제거했습니다. 남은 두 origin(continuation channel, turn)은 그대로 구분됩니다.

**execution-trust narrow projection** — 기대 컬럼 목록과 단언에서 `active_goal_ids` 를 뺐습니다.

**prompt surfaces** — 두 테스트가 meta 에 적힌 id 를 전제로 했습니다.
- `unresolved goal id stays visible`: id 가 store 에서 오면 존재하지 않는 id 자체가 불가능합니다. 삭제.
- `all-terminal yields no goals`: terminal-only **meta** 대신 terminal-only **store** 를 심도록 다시 썼습니다 (`seed_terminal_phases_only`).

## 남기는 것

`test_dashboard_http_core` 3건(`executor_pool`, `context-window shrink guard` 2건)은 그대로입니다. `d4b059d47f^1` 을 체크아웃해 같은 스위트를 돌려 **동일하게 3건 실패**함을 확인했습니다. 이 작업 이전부터 있던 것입니다.

`test_heartbeat_integration` 1건도 같은 방법으로 병합 전/후 동일함을 확인했습니다.

## 검증

```
dune build @check                    통과
audit-ci-test-targets.sh             OK
test_keeper_approval_queue           45 OK   (was 15 fail)
test_keeper_goal_phase_projection     8 OK   (was 2 fail)
test_dashboard_http_core             3 fail  (pre-existing, 4 -> 3)
```

## 다음 (같은 슬라이스에 이어짐)

- **store strip** — `goals.json` 의 `owner`, keeper meta 의 `active_goal_ids`. 두 디코더 모두 unknown 필드를 거부하므로 **이게 들어가기 전까지 재배포 금지**입니다. 라이브 meta 35 개 전부 해당됩니다.
- dashboard TS 의 `owner` / `active_goal_ids` 소비 제거.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
