### PR TITLE
fix(canary): bind evidence to packaged build identity

### DIFF
--- a/bin/keeper_canary_run.ml
+++ b/bin/keeper_canary_run.ml
@@ -234,25 +234,11 @@ let iso8601_now () =
     tm.Unix.tm_min
     tm.Unix.tm_sec
 
-(* With_process.with_process_args_in gives exact argv control (no shell
-   string parsing, unlike Unix.open_process_in) and guarantees the
-   subprocess is reaped on every exit path. The exit status is consumed:
-   a captured line is only trusted when git actually reported success —
-   e.g. a detached-HEAD-less checkout can print nothing on stdout while
-   still exiting 0, and a failing invocation must not be read as "no
-   commit" the same way a genuinely commit-less checkout would be. *)
-let git_commit_opt () =
-  try
-    let lines, status =
-      With_process.with_process_args_in
-        "git"
-        [| "git"; "rev-parse"; "HEAD" |]
-        With_process.drain_lines
-    in
-    match status, lines with
-    | Unix.WEXITED 0, line :: _ -> Some (String.trim line)
-    | _ -> None
-  with _ -> None
+(* This must testify to the canary executable that is running, not to an
+   arbitrary checkout it happens to be launched from.  The trusted runtime
+   manifest binds the companion binary digest to the same build source SHA;
+   [binary_commit] is that SHA embedded by the Dune build rule. *)
+let build_commit_opt () = (Masc.Build_identity.current ()).binary_commit
 
 let sha256_hex text = Digestif.SHA256.(to_hex (digest_string text))
 
@@ -987,7 +973,7 @@ let run ?(judge : judge_fn option) ~(base_path : string) (args : args) :
     in
     Ok
       { Keeper_canary_evidence.captured_at = iso8601_now ()
-      ; harness_git_commit = git_commit_opt ()
+      ; harness_git_commit = build_commit_opt ()
       ; run_id = args.run_id
       ; keeper_name = args.keeper
       ; runtime = args.runtime

--- a/lib/keeper_canary/keeper_canary_evidence.mli
+++ b/lib/keeper_canary/keeper_canary_evidence.mli
@@ -85,6 +85,8 @@ val restart_is_continuation : restart_injection -> bool
 type run_evidence = {
   captured_at : string;
   harness_git_commit : string option;
+      (** Build-time commit embedded in the canary executable.  This is not
+          the HEAD of a checkout from which the packaged binary is invoked. *)
   run_id : string;
   keeper_name : string;
   runtime : string option;

--- a/test/test_build_identity.ml
+++ b/test/test_build_identity.ml
@@ -54,6 +54,33 @@ let test_resolve_commit_details_marks_repo_head_fallback () =
   Alcotest.(check (option string)) "repo head source"
     (Some "runtime_repo_head") details.repo_head_commit_source
 
+let test_binary_identity_ignores_mismatched_ambient_checkout () =
+  let details =
+    Build_identity.resolve_commit_details
+      ~embedded:(Some "canary-build-source")
+      ~probe:(fun () -> Some "ambient-checkout-head")
+  in
+  Alcotest.(check (option string))
+    "canary identity remains its build source"
+    (Some "canary-build-source")
+    details.binary_commit;
+  Alcotest.(check (option string))
+    "ambient checkout remains separately observable"
+    (Some "ambient-checkout-head")
+    details.repo_head_commit
+
+let test_binary_identity_survives_without_checkout () =
+  let details =
+    Build_identity.resolve_commit_details
+      ~embedded:(Some "packaged-canary-source")
+      ~probe:(fun () -> None)
+  in
+  Alcotest.(check (option string))
+    "packaged canary keeps its build source"
+    (Some "packaged-canary-source")
+    details.binary_commit;
+  Alcotest.(check (option string)) "no ambient checkout" None details.repo_head_commit
+
 let test_current_started_at_is_stable () =
   let first = Build_identity.current () in
   Unix.sleepf 0.01;
@@ -210,6 +237,12 @@ let () =
           Alcotest.test_case
             "resolve commit details marks repo head fallback" `Quick
             test_resolve_commit_details_marks_repo_head_fallback;
+          Alcotest.test_case
+            "binary identity ignores mismatched ambient checkout" `Quick
+            test_binary_identity_ignores_mismatched_ambient_checkout;
+          Alcotest.test_case
+            "binary identity survives without checkout" `Quick
+            test_binary_identity_survives_without_checkout;
           Alcotest.test_case "current started_at stable" `Quick
             test_current_started_at_is_stable;
           Alcotest.test_case "runtime cwd snapshot is resolver backed" `Quick

--- a/test/test_keeper_canary_evidence.ml
+++ b/test/test_keeper_canary_evidence.ml
@@ -3,6 +3,8 @@
    dashboard will read — see lib/keeper_canary/keeper_canary_evidence.ml
    for the module under test. *)
 
+open Masc
+
 let sample_fact : Keeper_canary_facts.fact =
   { category = "project_codename"; statement = "The project codename is X."; value = "X" }
 
@@ -267,6 +269,36 @@ let test_timing_fields_are_present () =
   | `Float 1.0, `Float 1.25, `Float 1.5 -> ()
   | _ -> Alcotest.fail "expected timing.{min_s,median_s,max_s} to round-trip"
 
+let serialized_harness_git_commit resolution =
+  Keeper_canary_evidence.to_yojson
+    { sample_evidence with
+      harness_git_commit = resolution.Build_identity.binary_commit
+    }
+  |> member "harness"
+  |> member "git_commit"
+
+let test_harness_commit_uses_embedded_binary_identity () =
+  let resolution =
+    Build_identity.resolve_commit_details
+      ~embedded:(Some "embedded-canary-source")
+      ~probe:(fun () -> Some "ambient-checkout-head")
+  in
+  Alcotest.(check string)
+    "serialized harness commit is the embedded binary source"
+    "embedded-canary-source"
+    (serialized_harness_git_commit resolution |> as_string)
+
+let test_harness_commit_is_null_without_build_stamp () =
+  let resolution =
+    Build_identity.resolve_commit_details
+      ~embedded:None
+      ~probe:(fun () -> Some "ambient-checkout-head")
+  in
+  Alcotest.(check bool)
+    "ambient checkout does not populate harness identity"
+    true
+    (serialized_harness_git_commit resolution = `Null)
+
 let test_pretty_string_is_parseable_json () =
   let text = Keeper_canary_evidence.to_pretty_string sample_evidence in
   match Yojson.Safe.from_string text with
@@ -340,6 +372,14 @@ let () =
             `Quick
             test_runtime_none_becomes_null_under_keeper
         ; Alcotest.test_case "timing fields are present" `Quick test_timing_fields_are_present
+        ; Alcotest.test_case
+            "harness commit uses embedded binary identity"
+            `Quick
+            test_harness_commit_uses_embedded_binary_identity
+        ; Alcotest.test_case
+            "harness commit is null without build stamp"
+            `Quick
+            test_harness_commit_is_null_without_build_stamp
         ] )
     ; ( "to_pretty_string"
       , [ Alcotest.test_case "is parseable JSON" `Quick test_pretty_string_is_parseable_json ] )


### PR DESCRIPTION
## Summary

- replace ambient `git rev-parse HEAD` in `keeper_canary_run` evidence with the executable embedded `Build_identity.binary_commit`
- keep `masc.keeper_canary_run.v1` and `harness.git_commit` backward-compatible
- cover packaged no-checkout and mismatched ambient-checkout cases

## Why

The canary is shipped as a companion binary in the trusted macOS runtime artifact. Running that binary outside the source checkout, or from an unrelated checkout, must report the source stamped into the binary. The trusted manifest already binds that source SHA to the companion SHA-256; ambient repository state is not build identity.

Follow-up to #29283.

## Validation

- `opam exec -- dune exec test/test_build_identity.exe` — 16/16 pass on exact head
- `opam exec -- dune exec test/test_keeper_canary_evidence.exe` — 18/18 pass; v1 JSON schema unchanged
- `opam exec -- dune build --release bin/keeper_canary_run.exe` — pass on exact head
- generated build stamp and Mach-O binary strings both contain exact head `b84ac4129355b99a349acfe05b08ddcf25eb71a1`
- `opam exec -- dune build @check` — pass before the main rebase; `git range-diff` reports the rebased patch unchanged
- `git diff --check` — pass
- CI trusted-runtime manifest contract statically verified: top-level `source_sha` is checked against `github.sha`, and `companion_binaries.keeper_canary_run.sha256` is checked against the packaged binary digest

## Merge gate

Keep `status:do-not-merge` until independent review and exact-head CI complete.