### PR TITLE
fix(store): preserve pre-cut goal stores during owner purge

### DIFF
--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -72,6 +72,11 @@ and state_of_yojson = function
 
 and goal_of_yojson = function
   | `Assoc fields as json ->
+      (* [owner] was persisted by the immediately preceding schema.  It no
+         longer has any runtime meaning, but existing stores must remain
+         readable across the hard cut.  Keep this as a read-only tombstone:
+         the decoder accepts and drops it, while [goal_to_yojson] never writes
+         it again.  Every other field remains closed-schema strict. *)
       let accepted_fields =
         [ "id"
         ; "title"
@@ -82,6 +87,7 @@ and goal_of_yojson = function
         ; "phase"
         ; "last_review_note"
         ; "last_review_at"
+        ; "owner"
         ; "created_at"
         ; "updated_at"
         ]

--- a/lib/goal/goal_store.mli
+++ b/lib/goal/goal_store.mli
@@ -7,7 +7,10 @@
 
     - a {!Goal_phase.t} (canonical lifecycle: [Executing] / [Blocked] /
       [Completed] / [Paused] / [Dropped]) — the only persisted
-      lifecycle representation.  ["status"] is not an accepted field:
+      lifecycle representation.  The retired ["owner"] field is accepted
+      and discarded on read so pre-cut stores remain available, but it is
+      never written and does not re-enter the runtime model.  ["status"] is
+      not an accepted field:
       a row carrying it fails to decode, and {!read_state} then applies
       the corrupt-store policy (recovery mirror if usable, otherwise an
       empty state plus a warning).  A store written before the field was

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -222,6 +222,32 @@ let repair_non_canonical_enum_fields json =
   | _ -> None
 ;;
 
+(* [active_goal_ids] was present in the immediately preceding durable schema,
+   but goal assignment is no longer Keeper metadata.  Accepting this one key
+   on read is a migration tombstone, not a schema field: it is discarded before
+   current-schema validation and is never available to [decode_current_meta] or
+   emitted by the writer.  Duplicate tombstones still fail closed, as do all
+   other unknown fields. *)
+let drop_legacy_active_goal_ids = function
+  | `Assoc fields ->
+    let count =
+      List.fold_left
+        (fun count (key, _) ->
+           if String.equal key "active_goal_ids" then count + 1 else count)
+        0
+        fields
+    in
+    if count > 1
+    then invalidf "duplicate field active_goal_ids"
+    else
+      Ok
+        (`Assoc
+           (List.filter
+              (fun (key, _) -> not (String.equal key "active_goal_ids"))
+              fields))
+  | json -> Ok json
+;;
+
 let parse_last_blocker fields =
   let* value = required_field fields "last_blocker" in
   match value with
@@ -554,6 +580,7 @@ let decode_current_meta fields =
 
 let meta_of_json json =
   try
+    let* json = drop_legacy_active_goal_ids json in
     match validate_current_object json with
     | Error error -> Error (validation_error_detail error)
     | Ok fields ->

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -226,8 +226,10 @@ let repair_non_canonical_enum_fields json =
    but goal assignment is no longer Keeper metadata.  Accepting this one key
    on read is a migration tombstone, not a schema field: it is discarded before
    current-schema validation and is never available to [decode_current_meta] or
-   emitted by the writer.  Duplicate tombstones still fail closed, as do all
-   other unknown fields. *)
+   emitted by the writer.  The retired payload still has to match its former
+   string-list contract before it is discarded; accepting arbitrary JSON here
+   would silently turn corruption into a valid current snapshot.  Duplicate
+   tombstones still fail closed, as do all other unknown fields. *)
 let drop_legacy_active_goal_ids = function
   | `Assoc fields ->
     let count =
@@ -239,12 +241,15 @@ let drop_legacy_active_goal_ids = function
     in
     if count > 1
     then invalidf "duplicate field active_goal_ids"
-    else
+    else if count = 0
+    then Ok (`Assoc fields)
+    else (
+      let* (_ : string list) = string_list_field fields "active_goal_ids" in
       Ok
         (`Assoc
            (List.filter
               (fun (key, _) -> not (String.equal key "active_goal_ids"))
-              fields))
+              fields)))
   | json -> Ok json
 ;;
 

--- a/lib/keeper/keeper_meta_json_parse.mli
+++ b/lib/keeper/keeper_meta_json_parse.mli
@@ -2,10 +2,13 @@
 
 val meta_of_json :
   Yojson.Safe.t -> (Keeper_meta_contract.keeper_meta, string) result
-(** Decode only the exact top-level shape emitted by
-    [Keeper_meta_json.meta_to_json]. Missing, wrong-typed, retired, duplicate,
-    unknown, or malformed fields are explicit reset-required errors. Nullable
-    domain fields still accept their current [`Null] representation. *)
+(** Decode the exact top-level shape emitted by
+    [Keeper_meta_json.meta_to_json]. The immediately preceding
+    ["active_goal_ids"] field is accepted and discarded as a read-only
+    migration tombstone; it never reaches the runtime record or writer.
+    Missing, wrong-typed, other retired, duplicate, unknown, or malformed
+    fields are explicit reset-required errors. Nullable domain fields still
+    accept their current [`Null] representation. *)
 
 (** One enumerated-field repair: [field] held [previous_value], which is not a
     canonical spelling of any variant, and is reset to [repaired_value]. *)

--- a/lib/keeper/keeper_meta_json_parse.mli
+++ b/lib/keeper/keeper_meta_json_parse.mli
@@ -4,8 +4,9 @@ val meta_of_json :
   Yojson.Safe.t -> (Keeper_meta_contract.keeper_meta, string) result
 (** Decode the exact top-level shape emitted by
     [Keeper_meta_json.meta_to_json]. The immediately preceding
-    ["active_goal_ids"] field is accepted and discarded as a read-only
-    migration tombstone; it never reaches the runtime record or writer.
+    ["active_goal_ids"] field is accepted in its former string-list shape and
+    discarded as a read-only migration tombstone; it never reaches the runtime
+    record or writer. Wrong-shaped tombstone payloads remain reset-required.
     Missing, wrong-typed, other retired, duplicate, unknown, or malformed
     fields are explicit reset-required errors. Nullable domain fields still
     accept their current [`Null] representation. *)

--- a/test/test_goal_store.ml
+++ b/test/test_goal_store.ml
@@ -229,6 +229,65 @@ let test_serializer_omits_status () =
           check bool "serializer omits status" false (List.mem_assoc "status" fields)
       | _ -> fail "goal_to_yojson: expected object")
 
+let add_goal_field config key value =
+  match Yojson.Safe.from_file (Goal_store.goals_path config) with
+  | `Assoc state_fields ->
+    let goals =
+      match List.assoc_opt "goals" state_fields with
+      | Some (`List [ `Assoc goal_fields ]) ->
+        `List [ `Assoc ((key, value) :: goal_fields) ]
+      | _ -> fail "expected one persisted goal"
+    in
+    Workspace.write_json
+      config
+      (Goal_store.goals_path config)
+      (`Assoc (("goals", goals) :: List.remove_assoc "goals" state_fields));
+    Workspace.write_json
+      config
+      (goals_recovery_path config)
+      (`Assoc (("goals", goals) :: List.remove_assoc "goals" state_fields))
+  | _ -> fail "expected persisted goal state object"
+
+let test_legacy_owner_is_read_only_tombstone () =
+  with_workspace @@ fun config ->
+  let goal = make_goal "legacy-owner" "legacy owner is ignored" in
+  Goal_store.write_state config
+    { version = 1; updated_at = iso_now (); goals = [ goal ] };
+  add_goal_field config "owner" (`String "retired-keeper");
+  let loaded = Goal_store.read_state config in
+  check int "legacy owner row remains readable" 1 (List.length loaded.goals);
+  (match Goal_store.update_goal config ~goal_id:goal.id Fun.id with
+   | Ok _ -> ()
+   | Error detail -> failf "canonical rewrite failed: %s" detail);
+  let rewritten = Yojson.Safe.from_file (Goal_store.goals_path config) in
+  let owner_persisted =
+    match rewritten with
+    | `Assoc state_fields ->
+      (match List.assoc_opt "goals" state_fields with
+       | Some (`List [ `Assoc goal_fields ]) -> List.mem_assoc "owner" goal_fields
+       | _ -> fail "expected one rewritten goal")
+    | _ -> fail "expected rewritten goal state object"
+  in
+  check bool "canonical rewrite drops legacy owner" false owner_persisted
+
+let test_other_unknown_goal_field_still_fails () =
+  with_workspace @@ fun config ->
+  let goal = make_goal "unknown-field" "unknown field fails" in
+  Goal_store.write_state config
+    { version = 1; updated_at = iso_now (); goals = [ goal ] };
+  add_goal_field config "unexpected_assignment" (`String "still-closed");
+  check int
+    "unrelated unknown field keeps store undecodable"
+    0
+    (List.length (Goal_store.read_state config).goals);
+  match Goal_store.update_goal config ~goal_id:goal.id Fun.id with
+  | Ok _ -> fail "unknown field licensed a write"
+  | Error detail ->
+    check bool
+      "unknown field write remains fail-closed"
+      true
+      (String_util.contains_substring detail "refusing to write")
+
 let test_phaseless_row_no_longer_decodes () =
   with_workspace @@ fun config ->
   (* Counterfactual for the removed status->phase inference: a status-only
@@ -373,6 +432,10 @@ let () =
             test_status_field_no_longer_decodes;
           test_case "serializer omits status" `Quick
             test_serializer_omits_status;
+          test_case "legacy owner is a read-only tombstone" `Quick
+            test_legacy_owner_is_read_only_tombstone;
+          test_case "other unknown goal field still fails" `Quick
+            test_other_unknown_goal_field_still_fails;
           test_case "phase-less row no longer decodes" `Quick
             test_phaseless_row_no_longer_decodes;
           test_case "blocked phase serializes without status" `Quick

--- a/test/test_keeper_meta_current_schema.ml
+++ b/test/test_keeper_meta_current_schema.ml
@@ -183,6 +183,18 @@ let test_legacy_tombstone_does_not_weaken_closed_schema () =
         :: fields))
 ;;
 
+let test_legacy_tombstone_rejects_wrong_payload_shapes () =
+  [ "scalar", `String "goal-a"
+  ; "null", `Null
+  ; "object", `Assoc [ "goal", `String "goal-a" ]
+  ; "mixed element", `List [ `String "goal-a"; `Int 7 ]
+  ]
+  |> List.iter (fun (label, payload) ->
+    expect_rejected
+      ("legacy tombstone " ^ label)
+      (current_json () |> replace_field "active_goal_ids" payload))
+;;
+
 let test_retired_compaction_failure_authority_requires_reset () =
   expect_rejected
     "retired compaction failure authority"
@@ -210,6 +222,8 @@ let () =
             test_legacy_active_goal_ids_is_read_only_tombstone
         ; test_case "legacy tombstone keeps the remaining schema closed" `Quick
             test_legacy_tombstone_does_not_weaken_closed_schema
+        ; test_case "legacy tombstone rejects wrong payload shapes" `Quick
+            test_legacy_tombstone_rejects_wrong_payload_shapes
         ; test_case
             "retired compaction failure authority requires reset"
             `Quick

--- a/test/test_keeper_meta_current_schema.ml
+++ b/test/test_keeper_meta_current_schema.ml
@@ -148,6 +148,41 @@ let test_every_outside_field_has_one_classification () =
       (current_json () |> replace_field key (`String "ignored-value")))
 ;;
 
+let test_legacy_active_goal_ids_is_read_only_tombstone () =
+  let legacy_json =
+    current_json ()
+    |> replace_field
+         "active_goal_ids"
+         (`List [ `String "goal-a"; `String "goal-b" ])
+  in
+  let decoded =
+    match Keeper_meta_json_parse.meta_of_json legacy_json with
+    | Ok meta -> meta
+    | Error detail -> Alcotest.failf "legacy active_goal_ids rejected: %s" detail
+  in
+  let rewritten_fields = Keeper_meta_json.meta_to_json decoded |> fields_exn in
+  check bool
+    "current writer drops active_goal_ids"
+    false
+    (List.mem_assoc "active_goal_ids" rewritten_fields)
+;;
+
+let test_legacy_tombstone_does_not_weaken_closed_schema () =
+  let fields = fields_exn (current_json ()) in
+  expect_rejected
+    "legacy tombstone plus unrelated unknown"
+    (`Assoc
+       (("active_goal_ids", `List [ `String "goal-a" ])
+        :: ("unexpected_assignment", `String "still-closed")
+        :: fields));
+  expect_rejected
+    "duplicate legacy tombstone"
+    (`Assoc
+       (("active_goal_ids", `List [])
+        :: ("active_goal_ids", `List [ `String "goal-a" ])
+        :: fields))
+;;
+
 let test_retired_compaction_failure_authority_requires_reset () =
   expect_rejected
     "retired compaction failure authority"
@@ -161,16 +196,20 @@ let () =
     [ ( "current-schema"
       , [ test_case "writer roundtrip and keyset" `Quick
             test_current_writer_roundtrip_and_keyset
-        ; test_case "all 53 fields are required" `Quick
+        ; test_case "all 52 fields are required" `Quick
             test_every_current_field_is_required
-        ; test_case "all 53 duplicate fields reject" `Quick
+        ; test_case "all 52 duplicate fields reject" `Quick
             test_every_duplicate_is_rejected
-        ; test_case "all 53 fields reject a wrong type" `Quick
+        ; test_case "all 52 fields reject a wrong type" `Quick
             test_every_field_rejects_a_wrong_type
         ; test_case "nullability is exact" `Quick
             test_nullability_is_exact
         ; test_case "outside fields share one classification" `Quick
             test_every_outside_field_has_one_classification
+        ; test_case "legacy active_goal_ids is a read-only tombstone" `Quick
+            test_legacy_active_goal_ids_is_read_only_tombstone
+        ; test_case "legacy tombstone keeps the remaining schema closed" `Quick
+            test_legacy_tombstone_does_not_weaken_closed_schema
         ; test_case
             "retired compaction failure authority requires reset"
             `Quick


### PR DESCRIPTION
## Problem

Merged #29256 removed `goal.owner` and Keeper-meta `active_goal_ids` from the runtime model and closed JSON readers. The deployed pre-merge store still contains `owner` in 48/48 Goal rows (`null` or `string`) and `active_goal_ids` in 35/35 Keeper snapshots (`array`). Deploying the hard cut without a compatibility read would make those stores undecodable.

## Stack dependency

This PR is stacked on #29312 at exact head `e0bbaa4060ee58753ff9178f6ec4f27cb82864c6`. That stack already contains merged #29310, including the current-schema key-count correction from 53 to 52. Restacking therefore dropped only that redundant test hunk; the store-compatibility semantic delta is unchanged.

## Fix

- accept and discard exactly `owner` while decoding a Goal row
- validate `active_goal_ids` through its former array-of-strings contract, then discard it before current Keeper-meta validation
- reject scalar, null, object, mixed-element, duplicate, and unrelated unknown payloads fail-closed
- keep both retired fields absent from types, runtime semantics, and serializers

This is a read-only tombstone, not a restored legacy model. A later legitimate Goal/Keeper metadata mutation rewrites canonical JSON without the retired field; reads do not eagerly mutate live state.

## Evidence

- exact head: `cf9c7b8b7d037edd8c7dc65b74b945033f88e191`
- exact base (#29312): `e0bbaa4060ee58753ff9178f6ec4f27cb82864c6`
- `test_goal_store`: 16/16 pass
- `test_keeper_meta_current_schema`: 11/11 pass
- exact stacked head `dune build @check`: pass
- exact stacked head diff-check: pass
- range-diff differs only by the redundant 53-to-52 key-count hunk already supplied by #29310

## Deployment caveat

Do not deploy the #29256 hard cut without this fix or an out-of-band atomic migration of both stores. This PR deliberately does not modify `/Users/dancer/me/.masc`; canonical cleanup occurs on normal writes after the compatible reader is deployed.