### PR TITLE
feat(dashboard): Work 탭 Goal 상세를 완료 조건 중심으로 다시 짬

### DIFF
--- a/dashboard/src/components/goals/goal-metric-unevaluated.test.ts
+++ b/dashboard/src/components/goals/goal-metric-unevaluated.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { GoalAttainmentProjection } from '../../types'
 
-import { attainmentValueLabel } from './goal-tree'
+import { attainmentValueLabel } from '../../lib/goal-attainment'
 
 // task-1743: a goal.metric is stored but never evaluated (the Task completion
 // evaluator has no caller), so the attainment percentage is derived from

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -22,6 +22,7 @@ import { FilterChips } from '../common/filter-chips'
 import { StatusBadge } from '../common/status-badge'
 import { executionOutcomeLabel } from '../fsm-hub-types'
 import { operatorDispositionReasonLabel } from '../fsm-hub-types'
+import { attainmentTone, attainmentValueLabel } from '../../lib/goal-attainment'
 import { runtimeOutcomeLabel } from '../fsm-hub-types'
 import { ringFocusClasses } from '../common/ring'
 import { trustDispositionLabel } from '../fsm-hub-types'
@@ -309,25 +310,6 @@ async function refreshGoalDetail(goalId: string) {
   } finally {
     if (detailRequestSeq === reqId) detailLoading.value = false
   }
-}
-
-// Task-derived attainment_pct must not read as a metric result when the goal
-// declares a metric that no evaluator measures (task-1743): show "미평가"
-// rather than a percentage. Distinct from "미측정" (no task data at all).
-export function attainmentValueLabel(attainment: GoalTreeNode['attainment']): string {
-  if (attainment.metric_evaluation === 'unevaluated') return '미평가'
-  if (attainment.attainment_pct == null) return '미측정'
-  return `${attainment.attainment_pct}%`
-}
-
-function attainmentTone(attainment: GoalTreeNode['attainment']): 'default' | 'ok' | 'warn' | 'bad' {
-  // A declared-but-unevaluated metric is never "attained": the pct is
-  // task-derived, so surface it as attention (warn), not success (ok).
-  if (attainment.metric_evaluation === 'unevaluated') return 'warn'
-  if (attainment.state === 'attained') return 'ok'
-  if (attainment.state === 'unmeasured') return 'warn'
-  if (attainment.state === 'not_started') return 'bad'
-  return 'default'
 }
 
 function attainmentClass(attainment: GoalTreeNode['attainment']): string {

--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -1530,9 +1530,17 @@ describe('Work', () => {
         expect(screen.getByTestId('work-backlog').textContent).toContain('Tree Only Goal')
       })
 
-      it('renders Goal Store projection dossier evidence on matching goal cards', () => {
+      it('renders the declared completion criteria and the operator context on a goal card', () => {
         goals.value = [
-          { id: 'G-1', title: 'Goal One', priority: 5, phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-04' },
+          {
+            id: 'G-1',
+            title: 'Goal One',
+            priority: 5,
+            phase: 'executing',
+            created_at: '2026-01-01',
+            updated_at: '2026-01-04',
+            last_review_note: 'metric 미충족 — merged PR은 1건뿐',
+          },
         ]
         tasks.value = []
         goalTreeData.value = {
@@ -1542,22 +1550,45 @@ describe('Work', () => {
               title: 'Goal One',
               priority: 5,
               phase: 'executing',
-              goal_fsm: {
-                state: 'executing',
-                source: 'goal.phase',
-                next_actions: ['request completion'],
-                activity_observation: 'task',
+              owner: 'dancer',
+              metric: 'merged PR count',
+              target_value: '5 PRs',
+              attainment: {
+                state: 'attained',
+                basis: 'metric_target_count',
+                metric: 'merged PR count',
+                metric_evaluation: 'unevaluated',
+                target_value: '5 PRs',
+                target_parse_status: 'parseable',
+                unit: 'count',
+                observed_value: 6,
+                target_numeric: 5,
+                attainment_pct: 100,
+                task_done_count: 3,
+                task_count: 4,
+                note: 'Derived from completed linked tasks against a count target.',
+              },
+              task_summary: {
+                total: 4,
+                done: 3,
+                open: 0,
+                terminal: 4,
+                awaiting_verification: 0,
+                cancelled: 1,
+                unassigned: 0,
+                completion_pct: 75,
+                by_status: {},
               },
               completion_summary: {
                 state: 'in_progress',
-                pct: 75,
-                pct_source: 'goal_store',
-                attainment_state: 'in_progress',
-                attainment_basis: 'linked_tasks',
-                metric_evaluation: 'absent',
+                pct: 100,
+                pct_source: 'attainment',
+                attainment_state: 'attained',
+                attainment_basis: 'metric_target_count',
+                metric_evaluation: 'unevaluated',
                 task_total: 4,
                 task_done: 3,
-                task_open: 1,
+                task_open: 0,
                 is_complete: false,
                 is_terminal: false,
                 ready_to_request_completion: false,
@@ -1574,7 +1605,6 @@ describe('Work', () => {
               stagnation_seconds: 3600,
               linked_keeper_names: ['sangsu'],
               pending_approval_count: 2,
-              owner: 'dancer',
               latest_keeper_ref: 'sangsu',
               latest_turn_ref: 42,
             }),
@@ -1589,19 +1619,202 @@ describe('Work', () => {
 
         const dossier = within(goalCard).getByTestId('goal-dossier')
         expect(dossier).toHaveAttribute('data-goal-dossier', 'G-1')
-        expect(dossier).toHaveAttribute('data-goal-dossier-fsm-state', 'executing')
+        expect(dossier).toHaveAttribute('data-goal-dossier-attainment-state', 'attained')
         expect(dossier).toHaveAttribute('data-goal-dossier-timeline-count', '1')
-        expect(dossier.textContent).toContain('state executing')
-        expect(dossier.textContent).toContain('request completion')
-        expect(dossier.textContent).toContain('state in_progress')
-        expect(dossier.textContent).toContain('tasks 3/4')
-        expect(dossier.textContent).toContain('owner dancer')
-        expect(dossier.textContent).toContain('keeper sangsu')
-        expect(dossier.textContent).toContain('turn 42')
-        expect(dossier.textContent).toContain('approvals 2')
+
+        const text = dossier.textContent ?? ''
+        // What the goal is.
+        expect(text).toContain('G-1')
+        expect(text).toContain('dancer')
+        // What counts as done — declared metric, target, observed value.
+        expect(text).toContain('merged PR count')
+        expect(text).toContain('5 PRs')
+        expect(text).toContain('숫자로는 5건')
+        expect(text).toContain('6건')
+        expect(text).toContain('지표 목표치(건수) 대비')
+        expect(text).toContain('Derived from completed linked tasks against a count target.')
+        // Cancelled tasks are named so the done/total gap is not a mystery.
+        expect(text).toContain('끝남 3 · 남음 0 · 취소 1 · 전체 4')
+        expect(text).toContain('아직 조건을 채우지 못했어요.')
+        // Why the goal sits where it does.
+        expect(text).toContain('metric 미충족 — merged PR은 1건뿐')
+        // Where to go next.
+        expect(text).toContain('sangsu')
+        expect(text).toContain('턴 42')
+        expect(text).toContain('2건 승인 대기')
       })
 
-      it('expands the goal dossier timeline events behind the toggle', () => {
+      it('marks a declared-but-unmeasured metric as unevaluated instead of attained', () => {
+        goals.value = [
+          { id: 'G-1', title: 'Goal One', priority: 5, phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-04' },
+        ]
+        tasks.value = []
+        goalTreeData.value = {
+          tree: [
+            goalTreeNode({
+              id: 'G-1',
+              metric: 'merged PR count',
+              target_value: '5 PRs',
+              attainment: {
+                state: 'attained',
+                basis: 'metric_target_count',
+                metric: 'merged PR count',
+                metric_evaluation: 'unevaluated',
+                target_value: '5 PRs',
+                target_parse_status: 'parseable',
+                unit: 'count',
+                observed_value: 6,
+                target_numeric: 5,
+                attainment_pct: 100,
+                task_done_count: 6,
+                task_count: 7,
+                note: 'Derived from completed linked tasks against a count target.',
+              },
+            }),
+          ],
+          summary: emptyGoalTreeSummary({ total_goals: 1, active_goals: 1 }),
+        }
+
+        render(html`<${Work} />`)
+        fireEvent.click(screen.getByTestId('goal-card').querySelector('.wk-goal-h')!)
+
+        const dossier = screen.getByTestId('goal-dossier')
+        // The backend calls this goal attained on a task-derived count. The
+        // panel must not present that as a metric result: the verdict reads
+        // 미평가 and carries the reason.
+        const verdict = dossier.querySelector('[data-goal-detail-row="verdict"]')!
+        expect(verdict.className).toContain('warn')
+        expect(verdict.textContent).toContain('미평가')
+        // The backend's own state token is `attained`; printing it would state
+        // a measurement that was never taken.
+        expect(verdict.textContent).not.toContain('달성')
+        expect(verdict.textContent).toContain('하위 작업 기준으로는 100%')
+        const caveat = dossier.querySelector('[data-goal-detail-caveat]')
+        expect(caveat?.textContent).toContain('직접 잰 값이 아니라')
+      })
+
+      it('states the problem when the declared target cannot drive completion', () => {
+        goals.value = [
+          { id: 'G-1', title: 'Goal One', priority: 5, phase: 'blocked', created_at: '2026-01-01', updated_at: '2026-01-04' },
+        ]
+        tasks.value = []
+        goalTreeData.value = {
+          tree: [
+            goalTreeNode({
+              id: 'G-1',
+              phase: 'blocked',
+              metric: 'unclaimed_tasks',
+              target_value: '0',
+              attainment: {
+                state: 'unmeasured',
+                basis: 'unmeasured',
+                metric: 'unclaimed_tasks',
+                metric_evaluation: 'unevaluated',
+                target_value: '0',
+                target_parse_status: 'invalid_target',
+                unit: 'unknown',
+                observed_value: null,
+                target_numeric: null,
+                attainment_pct: null,
+                task_done_count: 1,
+                task_count: 2,
+                note: 'Target value must be greater than zero.',
+              },
+            }),
+          ],
+          summary: emptyGoalTreeSummary({ total_goals: 1, active_goals: 1 }),
+        }
+
+        render(html`<${Work} />`)
+        fireEvent.click(screen.getByTestId('goal-card').querySelector('.wk-goal-h')!)
+
+        const dossier = screen.getByTestId('goal-dossier')
+        const target = dossier.querySelector('[data-goal-detail-row="target"]')!
+        expect(target.className).toContain('warn')
+        expect(target.textContent).toContain('목표치가 완료 판정에 쓸 수 없는 값이에요.')
+        expect(dossier.querySelector('[data-goal-detail-caveat]')?.textContent)
+          .toContain('완료 여부를 아직 판정하지 못했어요')
+        expect(dossier.textContent).toContain('Target value must be greater than zero.')
+      })
+
+      it('says a metricless goal is finished by its linked tasks instead of listing three empty fields', () => {
+        goals.value = [
+          { id: 'G-1', title: 'Goal One', priority: 5, phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-04' },
+        ]
+        tasks.value = []
+        goalTreeData.value = {
+          tree: [goalTreeNode({ id: 'G-1' })],
+          summary: emptyGoalTreeSummary({ total_goals: 1, active_goals: 1 }),
+        }
+
+        render(html`<${Work} />`)
+        fireEvent.click(screen.getByTestId('goal-card').querySelector('.wk-goal-h')!)
+
+        const dossier = screen.getByTestId('goal-dossier')
+        expect(dossier.querySelector('[data-goal-detail-row="metric"]')?.textContent)
+          .toContain('완료 지표가 정해져 있지 않아요')
+        expect(dossier.querySelector('[data-goal-detail-row="target"]')).toBeNull()
+        expect(dossier.querySelector('[data-goal-detail-row="observed"]')).toBeNull()
+      })
+
+      it('drops the goal_fsm projection tokens from the goal detail panel', () => {
+        goals.value = [
+          { id: 'G-1', title: 'Goal One', priority: 5, phase: 'blocked', created_at: '2026-01-01', updated_at: '2026-01-04' },
+        ]
+        tasks.value = []
+        goalTreeData.value = {
+          tree: [
+            goalTreeNode({
+              id: 'G-1',
+              phase: 'blocked',
+              goal_fsm: {
+                state: 'blocked',
+                source: 'goal.phase',
+                next_actions: ['unblock', 'drop'],
+                activity_observation: 'runtime',
+              },
+            }),
+          ],
+          summary: emptyGoalTreeSummary({ total_goals: 1, active_goals: 1 }),
+        }
+
+        render(html`<${Work} />`)
+        fireEvent.click(screen.getByTestId('goal-card').querySelector('.wk-goal-h')!)
+
+        // `source` was the constant `goal.phase` on every node, and the
+        // next_actions strings named transitions this panel does not perform.
+        const text = screen.getByTestId('goal-dossier').textContent ?? ''
+        expect(text).not.toContain('goal.phase')
+        expect(text).not.toContain('unblock')
+        expect(text).not.toContain('drop')
+        expect(text).not.toContain('activity runtime')
+      })
+
+      it('opens the keeper workspace from a linked keeper in the goal detail panel', () => {
+        goals.value = [
+          { id: 'G-1', title: 'Goal One', priority: 5, phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-04' },
+        ]
+        tasks.value = []
+        goalTreeData.value = {
+          tree: [goalTreeNode({ id: 'G-1', linked_keeper_names: ['polisher', 'rondo'] })],
+          summary: emptyGoalTreeSummary({ total_goals: 1, active_goals: 1 }),
+        }
+
+        render(html`<${Work} />`)
+        fireEvent.click(screen.getByTestId('goal-card').querySelector('.wk-goal-h')!)
+
+        const link = screen.getByTestId('goal-dossier')
+          .querySelector<HTMLButtonElement>('[data-goal-detail-keeper="rondo"]')
+        expect(link).not.toBeNull()
+        fireEvent.click(link!)
+
+        expect(navigateMock).toHaveBeenCalledWith(
+          'monitoring',
+          { section: 'agents', view: 'keepers', keeper: 'rondo' },
+        )
+      })
+
+      it('expands the goal detail timeline events behind the toggle', () => {
         goals.value = [
           { id: 'G-1', title: 'Goal One', priority: 5, phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-04' },
         ]
@@ -1635,6 +1848,7 @@ describe('Work', () => {
         const toggle = dossier.querySelector('[data-goal-dossier-timeline-toggle="G-1"]')
         expect(toggle).not.toBeNull()
         expect(toggle).toHaveAttribute('aria-expanded', 'false')
+        expect(toggle!.textContent).toContain('기록 1건 보기')
         expect(dossier.querySelectorAll('[data-goal-dossier-timeline-event]')).toHaveLength(0)
 
         fireEvent.click(toggle!)
@@ -1645,9 +1859,8 @@ describe('Work', () => {
         expect(rows[0]!.textContent).toContain('goal_owner')
         expect(rows[0]!.textContent).toContain('2026-01-04T10:00:00Z')
         expect(rows[0]!.textContent).toContain('owner: <unassigned> -> dancer by operator')
-        // The count chip and its hook stay put while the list opens.
+        // The count hook stays put while the list opens.
         expect(dossier).toHaveAttribute('data-goal-dossier-timeline-count', '1')
-        expect(dossier.textContent).toContain('events 1')
       })
 
       it('renders tree-only Goal Store goals in the list without an execution goal mirror', () => {
@@ -1660,12 +1873,6 @@ describe('Work', () => {
               title: 'Tree Only Goal',
               priority: 4,
               phase: 'blocked',
-              goal_fsm: {
-                state: 'blocked',
-                source: 'goal.phase',
-                next_actions: ['unblock linked task'],
-                activity_observation: 'task',
-              },
               tasks: [goalTreeTask({ id: 'T-tree', goal_id: 'G-tree', status: 'todo' })],
             }),
           ],
@@ -1680,11 +1887,9 @@ describe('Work', () => {
         fireEvent.click(goalCard.querySelector('.wk-goal-h')!)
 
         const dossier = within(goalCard).getByTestId('goal-dossier')
-        expect(dossier).toHaveAttribute('data-goal-dossier-fsm-state', 'blocked')
-        expect(dossier.textContent).toContain('unblock linked task')
+        expect(dossier).toHaveAttribute('data-goal-dossier', 'G-tree')
         expect(screen.getByTestId('work-backlog').textContent).toContain('Tree Only Goal')
       })
-
       it('preserves blocked and unknown Goal Store task statuses instead of remapping them', () => {
         goals.value = [
           { id: 'G-1', title: 'Goal One', priority: 1, phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -25,6 +25,14 @@ import { VirtualList } from './common/virtual-list'
 import { KeeperBadge } from './keeper-badge'
 import { openTaskDetail } from './goals/task-detail-state'
 import { goalPhaseLabel } from './goals/goal-helpers'
+import type { AttainmentTone } from '../lib/goal-attainment'
+import {
+  attainmentBasisLabel,
+  attainmentEvaluationCaveat,
+  attainmentTargetProblem,
+  attainmentUnitSuffix,
+  attainmentVerdict,
+} from '../lib/goal-attainment'
 import { statusLabel } from '../lib/status-label'
 import { GoalCreateForm } from './goals/goal-create-form'
 import { showGoalCreate, GOAL_PRIORITY_MAX } from './goals/goal-create-state'
@@ -437,93 +445,266 @@ function TaskEvidenceLedger({ rows }: { rows: readonly TaskEvidenceLedgerRow[] }
   `
 }
 
-function GoalProjectionDossier({ node }: { node: GoalTreeNode | null | undefined }) {
+// ── Goal detail panel (expanded goal card body) ─────────────────────────────
+//
+// The panel answers four operator questions, in order: what this goal is,
+// what counts as done, why it sits in its current phase, and where to go next.
+//
+// There is no "기록 0건" fallback on the activity row. The goals-tree endpoint
+// serves timeline rows as {event_type, payload} while the decoder requires
+// {kind, lane, title, summary, severity} (api/dashboard-goals.ts:375), so every
+// row is dropped before it reaches this component and the list is empty for
+// reasons that have nothing to do with whether the goal has history — see
+// masc#29299. Printing a zero would assert something the payload does not say.
+//
+// The goal_fsm triple (state / source / activity_observation) and its
+// `next_actions` labels are deliberately not rendered here. `state` repeats the
+// phase pill in the card header, `source` was the constant `goal.phase` on
+// every node the API serves, `activity_observation` names which projection lane
+// last moved — none of which changes what an operator does — and the
+// `next_actions` strings were rendered as plain labels next to no control that
+// performs them.
+
+interface GoalDetailTaskCounts {
+  readonly done: number
+  readonly open: number
+  readonly cancelled: number | null
+  readonly total: number
+}
+
+function goalDetailTaskCounts(node: GoalTreeNode): GoalDetailTaskCounts {
+  const summary = node.completion_summary
+  const byStatus = node.task_summary
+  return {
+    done: summary?.task_done ?? node.task_done_count,
+    open: summary?.task_open ?? Math.max(node.task_count - node.task_done_count, 0),
+    cancelled: byStatus?.cancelled ?? null,
+    total: summary?.task_total ?? node.task_count,
+  }
+}
+
+function goalDetailTaskCountsText(counts: GoalDetailTaskCounts): string {
+  const parts = [`끝남 ${counts.done}`, `남음 ${counts.open}`]
+  if (counts.cancelled != null && counts.cancelled > 0) parts.push(`취소 ${counts.cancelled}`)
+  parts.push(`전체 ${counts.total}`)
+  return parts.join(' · ')
+}
+
+type GoalDetailRowTone = 'ok' | 'warn' | 'bad'
+
+/** htm templates pass props untyped, so an `AttainmentTone` reaching a row
+ *  would silently render `class="wk-dossier-row default"` — a class no
+ *  stylesheet defines. Narrowing here keeps the neutral tone spelled as the
+ *  absence of a modifier. */
+function goalDetailRowTone(tone: AttainmentTone): GoalDetailRowTone | undefined {
+  return tone === 'default' ? undefined : tone
+}
+
+function GoalDetailRow({
+  label,
+  tone,
+  testHook,
+  children,
+}: {
+  label: string
+  tone?: GoalDetailRowTone
+  testHook: string
+  children: unknown
+}) {
+  return html`
+    <div class=${`wk-dossier-row${tone ? ` ${tone}` : ''}`} data-goal-detail-row=${testHook}>
+      <span class="wk-dossier-k">${label}</span>
+      <span class="wk-dossier-v">${children}</span>
+    </div>
+  `
+}
+
+function GoalDetailSection({ title, children }: { title: string; children: unknown }) {
+  return html`
+    <section class="wk-dossier-sec">
+      <h4 class="wk-dossier-h">${title}</h4>
+      ${children}
+    </section>
+  `
+}
+
+function GoalCompletionCriteria({ node }: { node: GoalTreeNode }) {
+  const attainment = node.attainment
+  const summary = node.completion_summary
+  const counts = goalDetailTaskCounts(node)
+  const verdict = attainmentVerdict(attainment)
+  const caveat = attainmentEvaluationCaveat(attainment)
+  const targetProblem = attainmentTargetProblem(attainment)
+  // A goal with neither metric nor target is not "missing" three values — it
+  // is complete when its linked tasks are. Saying that once beats three
+  // separate "없음" rows that read like a broken payload.
+  const metricless = attainment.metric == null && attainment.target_value == null
+
+  return html`
+    <${GoalDetailSection} title="완료 조건">
+      ${metricless ? html`
+        <${GoalDetailRow} label="지표" testHook="metric">
+          완료 지표가 정해져 있지 않아요. 연결된 하위 작업이 모두 끝나야 완료로 봅니다.
+        <//>
+      ` : html`
+        <${GoalDetailRow} label="지표" testHook="metric">
+          <span class="mono">${attainment.metric ?? '지표 없음'}</span>
+        <//>
+        <${GoalDetailRow} label="목표치" tone=${targetProblem ? 'warn' : undefined} testHook="target">
+          <span class="mono">${attainment.target_value ?? '목표치 없음'}</span>
+          ${attainment.target_numeric != null ? html`
+            <span class="wk-dossier-sub">숫자로는 ${attainment.target_numeric}${attainmentUnitSuffix(attainment.unit)}</span>
+          ` : null}
+          ${targetProblem ? html`<span class="wk-dossier-sub warn">${targetProblem}</span>` : null}
+        <//>
+        <${GoalDetailRow} label="현재값" testHook="observed">
+          ${attainment.observed_value == null
+            ? html`<span class="wk-dossier-sub">아직 잰 값이 없어요</span>`
+            : html`<span class="mono">${attainment.observed_value}${attainmentUnitSuffix(attainment.unit)}</span>`}
+        <//>
+      `}
+
+      <${GoalDetailRow} label="판정" tone=${goalDetailRowTone(verdict.tone)} testHook="verdict">
+        <span class="wk-dossier-strong">${verdict.label}</span>
+        ${verdict.detail ? html`<span class="wk-dossier-sub">${verdict.detail}</span>` : null}
+      <//>
+
+      ${caveat ? html`
+        <div class="wk-dossier-callout warn" data-goal-detail-caveat>${caveat}</div>
+      ` : null}
+
+      <${GoalDetailRow} label="판정 근거" testHook="basis">
+        ${attainmentBasisLabel(attainment.basis)}
+        ${attainment.note ? html`<span class="wk-dossier-sub">${attainment.note}</span>` : null}
+      <//>
+
+      <${GoalDetailRow} label="하위 작업" testHook="tasks">
+        ${goalDetailTaskCountsText(counts)}
+      <//>
+
+      ${summary ? html`
+        <${GoalDetailRow}
+          label="완료 요청"
+          tone=${summary.ready_to_request_completion ? 'ok' : undefined}
+          testHook="ready"
+        >
+          ${summary.ready_to_request_completion
+            ? '지금 완료를 요청할 수 있어요.'
+            : '아직 조건을 채우지 못했어요.'}
+        <//>
+      ` : null}
+    <//>
+  `
+}
+
+function GoalProjectionDossier({
+  node,
+  reviewNote,
+}: {
+  node: GoalTreeNode | null | undefined
+  reviewNote?: string | null
+}) {
   const [timelineOpen, setTimelineOpen] = useState(false)
   if (!node) return null
 
-  const completion = node.completion_summary ?? null
+  const keeperLinks = node.linked_keeper_names
+  const latestRun = [
+    node.latest_keeper_ref ? `키퍼 ${node.latest_keeper_ref}` : null,
+    node.latest_turn_ref != null ? `턴 ${node.latest_turn_ref}` : null,
+  ].filter((part): part is string => part !== null)
 
   return html`
     <div
       class="wk-dossier"
       data-testid="goal-dossier"
       data-goal-dossier=${node.id}
-      data-goal-dossier-fsm-state=${node.goal_fsm.state}
+      data-goal-dossier-attainment-state=${node.attainment.state}
       data-goal-dossier-timeline-count=${node.timeline_events.length}
     >
-      <div class="wk-dossier-row">
-        <span class="wk-dossier-k">FSM</span>
-        <span class="wk-dossier-chip mono">state ${node.goal_fsm.state}</span>
-        <span class="wk-dossier-chip mono">source ${node.goal_fsm.source}</span>
-        <span class="wk-dossier-chip mono">activity ${node.goal_fsm.activity_observation}</span>
-      </div>
-
-      ${node.goal_fsm.next_actions.length > 0 ? html`
-        <div class="wk-dossier-row">
-          <span class="wk-dossier-k">next actions</span>
-          ${node.goal_fsm.next_actions.map((action) => html`
-            <span key=${action} class="wk-dossier-chip mono">${action}</span>
-          `)}
-        </div>
-      ` : null}
-
-      ${completion ? html`
-        <div class="wk-dossier-row">
-          <span class="wk-dossier-k">completion</span>
-          <span class="wk-dossier-chip mono">state ${completion.state}</span>
-          <span class="wk-dossier-chip mono">tasks ${completion.task_done}/${completion.task_total}</span>
-          <span class="wk-dossier-chip mono">pct ${completion.pct == null ? 'unmeasured' : `${completion.pct}%`}</span>
-          ${completion.ready_to_request_completion ? html`
-            <span class="wk-dossier-chip ok mono">ready to request</span>
-          ` : null}
-        </div>
-      ` : null}
-
-      <div class="wk-dossier-row">
-        <span class="wk-dossier-k">activity</span>
-        ${node.last_activity_at ? html`
-          <span class="wk-dossier-chip mono">last ${node.last_activity_at}</span>
-        ` : html`
-          <span class="wk-dossier-chip mono">last unavailable</span>
-        `}
-        <span class="wk-dossier-chip mono">events ${node.timeline_events.length}</span>
-        ${node.timeline_events.length > 0 ? html`
-          <button
-            type="button"
-            class="wk-dossier-chip mono"
-            style="cursor: pointer"
-            onClick=${() => setTimelineOpen(open => !open)}
-            aria-expanded=${timelineOpen}
-            data-goal-dossier-timeline-toggle=${node.id}
-          >
-            ${timelineOpen ? 'hide timeline' : 'show timeline'}
-          </button>
+      <${GoalDetailSection} title="이 Goal 은">
+        <${GoalDetailRow} label="목표 ID" testHook="id"><span class="mono">${node.id}</span><//>
+        <${GoalDetailRow} label="담당" testHook="owner">
+          ${node.owner ?? html`<span class="wk-dossier-sub">담당자가 없어요</span>`}
+        <//>
+        ${node.due_date ? html`
+          <${GoalDetailRow} label="기한" testHook="due"><span class="mono">${node.due_date}</span><//>
         ` : null}
-        <span class="wk-dossier-chip mono">stagnation ${node.stagnation_seconds == null ? 'unavailable' : `${node.stagnation_seconds}s`}</span>
-        ${node.owner ? html`<span class="wk-dossier-chip mono">owner ${node.owner}</span>` : null}
-        ${node.latest_keeper_ref ? html`<span class="wk-dossier-chip mono">keeper ${node.latest_keeper_ref}</span>` : null}
-        ${node.latest_turn_ref != null ? html`<span class="wk-dossier-chip mono">turn ${node.latest_turn_ref}</span>` : null}
-        ${node.linked_keeper_names.map((name) => html`
-          <span key=${name} class="wk-dossier-chip mono">linked ${name}</span>
-        `)}
+        <${GoalDetailRow} label="만든 날" testHook="created"><span class="mono">${node.created_at}</span><//>
+        <${GoalDetailRow} label="마지막 변경" testHook="updated"><span class="mono">${node.updated_at}</span><//>
+      <//>
+
+      <${GoalCompletionCriteria} node=${node} />
+
+      ${reviewNote ? html`
+        <${GoalDetailSection} title="진행 판정 메모">
+          <p class="wk-dossier-text" data-goal-detail-review-note>${reviewNote}</p>
+        <//>
+      ` : null}
+
+      <${GoalDetailSection} title="관련">
+        ${keeperLinks.length > 0 ? html`
+          <${GoalDetailRow} label="키퍼" testHook="keepers">
+            ${keeperLinks.map((name) => html`
+              <button
+                key=${name}
+                type="button"
+                class="wk-dossier-link mono"
+                data-goal-detail-keeper=${name}
+                onClick=${() => openKeeperWorkspace(name)}
+                title=${`${name} 작업 공간 열기`}
+              >${name}</button>
+            `)}
+          <//>
+        ` : null}
+        ${latestRun.length > 0 ? html`
+          <${GoalDetailRow} label="최근 실행" testHook="latest-run">
+            <span class="mono">${latestRun.join(' · ')}</span>
+          <//>
+        ` : null}
         ${node.pending_approval_count > 0 ? html`
-          <span class="wk-dossier-chip warn mono">approvals ${node.pending_approval_count}</span>
+          <${GoalDetailRow} label="승인 대기" tone="warn" testHook="approvals">
+            <button
+              type="button"
+              class="wk-dossier-link"
+              data-goal-detail-approvals
+              onClick=${() => navigate('approvals')}
+              title="승인 화면 열기"
+            >${node.pending_approval_count}건 승인 대기 →</button>
+          <//>
         ` : null}
-      </div>
-
-      ${timelineOpen
-        ? node.timeline_events.map(event => html`
-          <div
-            key=${`${event.kind}:${event.lane}:${event.ts}`}
-            class="wk-dossier-row"
-            data-goal-dossier-timeline-event
-          >
-            <span class="wk-dossier-k">${event.kind}</span>
-            <span class="wk-dossier-chip mono">${event.ts}</span>
-            <span class=${`wk-dossier-chip ${event.severity} mono`}>${event.summary}</span>
-          </div>
-        `)
-        : null}
+        <${GoalDetailRow} label="활동" testHook="activity">
+          <span class="mono">${node.last_activity_at || '기록 없음'}</span>
+          <span class="wk-dossier-sub">
+            ${node.stagnation_seconds == null ? '멈춘 시간 알 수 없음' : `${node.stagnation_seconds}초째 변화 없음`}
+          </span>
+          ${node.timeline_events.length > 0 ? html`
+            <button
+              type="button"
+              class="wk-dossier-link"
+              onClick=${() => setTimelineOpen(open => !open)}
+              aria-expanded=${timelineOpen}
+              data-goal-dossier-timeline-toggle=${node.id}
+            >
+              ${timelineOpen ? '기록 접기' : `기록 ${node.timeline_events.length}건 보기`}
+            </button>
+          ` : null}
+        <//>
+        ${timelineOpen
+          ? node.timeline_events.map(event => html`
+            <div
+              key=${`${event.kind}:${event.lane}:${event.ts}`}
+              class="wk-dossier-row"
+              data-goal-dossier-timeline-event
+            >
+              <span class="wk-dossier-k mono">${event.kind}</span>
+              <span class="wk-dossier-v">
+                <span class="mono">${event.ts}</span>
+                <span class=${`wk-dossier-sub ${event.severity}`}>${event.summary}</span>
+              </span>
+            </div>
+          `)
+          : null}
+      <//>
     </div>
   `
 }
@@ -643,13 +824,11 @@ function GoalCard({
         <span class="wk-prog-lbl mono">
           ${progress.done}/${progress.total}${progress.verify > 0 ? ` · 검증 ${progress.verify}` : ''}${progress.blocked > 0 ? ` · 막힘 ${progress.blocked}` : ''}
         </span>
-        ${goal.phase ? html`<span class="wk-goal-phase mono" title="goal phase">${goal.phase}</span>` : null}
         ${goal.metric ? html`<span class="wk-metric mono" title="목표 지표">${goal.metric}</span>` : null}
       </div>
       ${open ? html`
         <div class="wk-jobs">
-          ${goal.last_review_note ? html`<div class="wk-note">${goal.last_review_note}</div>` : null}
-          <${GoalProjectionDossier} node=${goalNode} />
+          <${GoalProjectionDossier} node=${goalNode} reviewNote=${goal.last_review_note} />
           ${goalTasks.map(t => html`<${TaskRow} key=${t.id} task=${t} onClaim=${onClaim} />`)}
         </div>
       ` : null}

--- a/dashboard/src/lib/goal-attainment.ts
+++ b/dashboard/src/lib/goal-attainment.ts
@@ -1,0 +1,126 @@
+// Goal attainment presentation SSOT.
+//
+// The rule that a declared-but-unevaluated metric never reads as "attained"
+// (task-1743) lives here rather than in one surface, so the Goals tree and the
+// Work goal detail cannot disagree about the same projection. Every lookup is a
+// closed record over the backend's enum tokens with the raw token as fallback:
+// an unrecognised token surfaces itself instead of collapsing into a
+// convenient-looking default.
+
+import type { GoalAttainmentProjection } from '../types'
+
+export type AttainmentTone = 'default' | 'ok' | 'warn' | 'bad'
+
+// Task-derived attainment_pct must not read as a metric result when the goal
+// declares a metric that no evaluator measures (task-1743): show "미평가"
+// rather than a percentage. Distinct from "미측정" (no task data at all).
+export function attainmentValueLabel(attainment: GoalAttainmentProjection): string {
+  if (attainment.metric_evaluation === 'unevaluated') return '미평가'
+  if (attainment.attainment_pct == null) return '미측정'
+  return `${attainment.attainment_pct}%`
+}
+
+export function attainmentTone(attainment: GoalAttainmentProjection): AttainmentTone {
+  // A declared-but-unevaluated metric is never "attained": the pct is
+  // task-derived, so surface it as attention (warn), not success (ok).
+  if (attainment.metric_evaluation === 'unevaluated') return 'warn'
+  if (attainment.state === 'attained') return 'ok'
+  if (attainment.state === 'unmeasured') return 'warn'
+  if (attainment.state === 'not_started') return 'bad'
+  return 'default'
+}
+
+const ATTAINMENT_STATE_LABEL: Record<string, string> = {
+  attained: '달성',
+  in_progress: '진행 중',
+  not_started: '시작 전',
+  unmeasured: '측정 안 됨',
+}
+
+export function attainmentStateLabel(state: string): string {
+  return ATTAINMENT_STATE_LABEL[state] ?? state
+}
+
+const ATTAINMENT_BASIS_LABEL: Record<string, string> = {
+  goal_phase: 'Goal 단계로만 판정',
+  linked_tasks: '연결된 하위 작업 완료 수',
+  metric_target_percent: '지표 목표치(%) 대비',
+  metric_target_count: '지표 목표치(건수) 대비',
+  unmeasured: '판정 근거 없음',
+}
+
+export function attainmentBasisLabel(basis: string): string {
+  return ATTAINMENT_BASIS_LABEL[basis] ?? basis
+}
+
+const ATTAINMENT_UNIT_LABEL: Record<string, string> = {
+  percent: '%',
+  count: '건',
+  unknown: '',
+}
+
+/** Suffix for a numeric observed/target value. Empty when the unit is unknown
+ *  — a bare number is honest, an invented unit is not. */
+export function attainmentUnitSuffix(unit: string): string {
+  return ATTAINMENT_UNIT_LABEL[unit] ?? unit
+}
+
+const TARGET_PARSE_PROBLEM: Record<string, string> = {
+  unparseable: '목표치를 숫자로 읽지 못했어요.',
+  invalid_target: '목표치가 완료 판정에 쓸 수 없는 값이에요.',
+  unsupported_metric: '이 지표는 자동으로 잴 수 있는 종류가 아니에요.',
+  no_linked_tasks: '연결된 하위 작업이 없어서 진행률을 계산할 수 없어요.',
+}
+
+/** Why the declared target cannot drive completion, or null when it can.
+ *  `absent` (no target declared) and `parseable` are not problems — the
+ *  "목표치 없음" case is stated by the target row itself. */
+export function attainmentTargetProblem(attainment: GoalAttainmentProjection): string | null {
+  const status = attainment.target_parse_status
+  if (status === 'absent' || status === 'parseable') return null
+  return TARGET_PARSE_PROBLEM[status] ?? status
+}
+
+/** Why the attainment verdict is not a measurement of the declared metric,
+ *  or null when no such caveat applies. The two `unevaluated` shapes differ:
+ *  with a pct the panel is showing a task-derived stand-in, without one the
+ *  goal has no completion verdict at all. */
+export function attainmentEvaluationCaveat(attainment: GoalAttainmentProjection): string | null {
+  if (attainment.metric_evaluation !== 'unevaluated') return null
+  const metric = attainment.metric ?? '이 지표'
+  if (attainment.attainment_pct == null && attainment.observed_value == null) {
+    return `${metric} 값을 재는 평가기가 없어서, 완료 여부를 아직 판정하지 못했어요.`
+  }
+  return `${metric} 를 직접 잰 값이 아니라, 끝난 하위 작업 수로 대신 계산한 숫자예요.`
+}
+
+export interface AttainmentVerdict {
+  readonly label: string
+  readonly detail: string | null
+  readonly tone: AttainmentTone
+}
+
+/** The one-line completion verdict for a goal.
+ *
+ *  When the declared metric was never evaluated the backend still fills
+ *  `state` from the task-derived percentage, so a goal whose metric nobody
+ *  measured can arrive carrying `state: 'attained'`. Printing that as 달성
+ *  would state a measurement that does not exist, so the verdict reads 미평가
+ *  and the task-derived percentage moves into the detail line, labelled for
+ *  what it is. */
+export function attainmentVerdict(attainment: GoalAttainmentProjection): AttainmentVerdict {
+  const tone = attainmentTone(attainment)
+  const pct = attainment.attainment_pct
+  if (attainment.metric_evaluation === 'unevaluated') {
+    return {
+      label: '미평가',
+      detail: pct == null ? null : `하위 작업 기준으로는 ${pct}%`,
+      tone,
+    }
+  }
+  return {
+    label: attainmentStateLabel(attainment.state),
+    detail: pct == null ? null : `${pct}%`,
+    tone,
+  }
+}

--- a/dashboard/src/styles/keeper-v2/v2.css
+++ b/dashboard/src/styles/keeper-v2/v2.css
@@ -821,7 +821,6 @@
 .wk-prog-lbl { flex: none; font-size: var(--fs-11); color: var(--text-mid); }
 .wk-metric { margin-left: auto; flex: none; font-size: var(--fs-11); color: var(--text-dim); }
 .wk-jobs { border-top: 1px solid var(--border-soft); padding: 10px 15px 13px; display: flex; flex-direction: column; gap: 2px; }
-.wk-note { font-size: var(--fs-12); color: var(--text-mid); line-height: 1.5; padding: 2px 0 9px; border-bottom: 1px dashed var(--border-soft); margin-bottom: 7px; }
 .wk-job { display: flex; align-items: center; gap: 10px; padding: 7px 8px; border-radius: var(--radius-xs); }
 .wk-job:hover { background: var(--bg-sunken); }
 .wk-job-dot { flex: none; width: 7px; height: 7px; border-radius: 50%; background: var(--text-dim); }
@@ -958,7 +957,6 @@
 .wk-gstatus.bad { color: var(--status-bad); border-color: color-mix(in oklab, var(--status-bad) 42%, transparent); background: color-mix(in oklab, var(--status-bad) 8%, transparent); }
 .wk-gstatus.volt { color: var(--volt-strong); border-color: var(--volt-dim); background: var(--volt-wash); }
 .wk-approval { flex: none; font-size: var(--fs-10); color: var(--volt-strong); border: 1px solid var(--volt-dim); background: var(--volt-wash); border-radius: var(--radius-pill); padding: 2px 8px; }
-.wk-goal-phase { flex: none; font-size: 10.5px; color: var(--text-dim); }
 .wk-seg.verify { background: var(--volt-strong); }
 
 .wk-tasks { border-top: 1px solid var(--border-soft); padding: 10px 15px 13px; display: flex; flex-direction: column; gap: 3px; }

--- a/dashboard/src/styles/work-v2.css
+++ b/dashboard/src/styles/work-v2.css
@@ -278,76 +278,128 @@
   gap: 2px;
 }
 
-.wk-note {
-  font-size: var(--fs-12);
-  color: var(--text-mid);
-  line-height: 1.5;
-  padding: 2px 0 10px;
+/* ── Goal detail panel (expanded goal card body) ───────────────────────────
+   Two-column label/value grid. The previous chip-row layout put every field —
+   identity, completion criteria, activity — into one undifferentiated strip of
+   mono pills, so the panel had no reading order and the completion criteria
+   were indistinguishable from projection bookkeeping. */
+.wk-dossier {
+  display: grid;
+  gap: 12px;
+  padding: 2px 0 12px;
   border-bottom: 1px dashed var(--border-soft);
   margin-bottom: 8px;
 }
 
-.wk-dossier {
+.wk-dossier-sec {
   display: grid;
-  gap: 6px;
-  padding: 2px 0 10px;
-  border-bottom: 1px dashed var(--border-soft);
-  margin-bottom: 8px;
+  gap: 3px;
+  min-width: 0;
+}
+
+/* Section headings mix Korean with product nouns ("이 Goal 은"). base.css puts
+   every h1-h4 in the Cinzel display face, which has no lowercase glyphs and so
+   renders "Goal" as "GOAL" while leaving the Korean alone — the UI face keeps
+   both halves in one voice. No uppercase transform either, for the same
+   reason. */
+.wk-dossier-h {
+  margin: 0 0 3px;
+  font-family: var(--font-ui);
+  font-size: var(--fs-10);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: none;
+  color: var(--text-dim);
 }
 
 .wk-dossier-row {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 6px;
+  display: grid;
+  grid-template-columns: 88px minmax(0, 1fr);
+  gap: 10px;
+  align-items: baseline;
   min-width: 0;
 }
 
 .wk-dossier-k {
-  flex: 0 0 78px;
   font-size: var(--fs-10);
   color: var(--text-dim);
-  text-transform: uppercase;
-  font-weight: 700;
+  font-weight: 600;
+  overflow-wrap: anywhere;
 }
 
-.wk-dossier-chip {
-  max-width: 100%;
+.wk-dossier-v {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 6px;
   min-width: 0;
+  font-size: var(--fs-11);
+  color: var(--text-mid);
+  line-height: 1.45;
   overflow-wrap: anywhere;
+}
+
+.wk-dossier-row.ok .wk-dossier-v { color: var(--status-ok); }
+.wk-dossier-row.warn .wk-dossier-v { color: var(--status-warn); }
+.wk-dossier-row.bad .wk-dossier-v { color: var(--status-bad); }
+
+.wk-dossier-strong {
+  font-weight: 700;
+  color: inherit;
+}
+
+.wk-dossier-sub {
+  font-size: var(--fs-10);
+  color: var(--text-dim);
+  overflow-wrap: anywhere;
+}
+
+.wk-dossier-sub.warn { color: var(--status-warn); }
+.wk-dossier-sub.bad { color: var(--status-bad); }
+.wk-dossier-sub.ok { color: var(--status-ok); }
+
+.wk-dossier-callout {
+  grid-column: 1 / -1;
+  margin: 2px 0 4px;
+  padding: 5px 8px;
+  border-radius: var(--radius-xs);
+  font-size: var(--fs-10);
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+.wk-dossier-callout.warn {
+  color: var(--status-warn);
+  border: 1px solid color-mix(in oklab, var(--status-warn) 32%, transparent);
+  background: color-mix(in oklab, var(--status-warn) 9%, transparent);
+}
+
+.wk-dossier-link {
+  display: inline-flex;
+  align-items: center;
   font-size: var(--fs-10);
   color: var(--text-mid);
   border: 1px solid var(--border-soft);
   border-radius: var(--radius-xs);
   padding: 1px 6px;
   background: var(--surface-1);
+  cursor: pointer;
 }
 
-.wk-dossier-chip.ok {
-  color: var(--status-ok);
-  border-color: color-mix(in oklab, var(--status-ok) 30%, transparent);
-  background: color-mix(in oklab, var(--status-ok) 8%, transparent);
-}
-
-.wk-dossier-chip.warn {
-  color: var(--status-warn);
-  border-color: color-mix(in oklab, var(--status-warn) 32%, transparent);
-  background: color-mix(in oklab, var(--status-warn) 9%, transparent);
-}
-
-.wk-dossier-chip.bad {
-  color: var(--status-bad);
-  border-color: color-mix(in oklab, var(--status-bad) 32%, transparent);
-  background: color-mix(in oklab, var(--status-bad) 8%, transparent);
+.wk-dossier-link:hover {
+  color: var(--text-strong);
+  border-color: var(--border-strong);
 }
 
 .wk-dossier-text {
+  margin: 0;
   min-width: 0;
   max-width: 100%;
   overflow-wrap: anywhere;
   font-size: var(--fs-11);
   color: var(--text-mid);
-  line-height: 1.4;
+  line-height: 1.55;
+  white-space: pre-wrap;
 }
 
 .wk-verifier {
@@ -1776,8 +1828,14 @@
   .wk-viewseg button,
   .wk-newgoal,
   .wk-task-claim,
-  .wk-task-kp {
+  .wk-task-kp,
+  .wk-dossier-link {
     min-height: var(--mobile-touch-target-min);
+  }
+
+  .wk-dossier-row {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 2px;
   }
 
   .wk-metric {


### PR DESCRIPTION
## 문제

`#workspace?section=work` 에서 Goal 카드를 펼치면 이런 게 나왔습니다.

```
FSM      state blocked   source goal.phase   activity runtime
next actions   unblock   drop
completion   state blocked   tasks 6/7   pct 100%
activity   last 2026-08-21T10:59:50Z   events 0   stagnation 20s
           keeper rondo   turn 26688   linked polisher   linked rondo
```

한 줄로 늘어선 mono 칩 더미인데, 정작 **이 Goal 이 무엇을 기준으로 끝나는지**가 없습니다.

- `state` 는 바로 위 헤더의 `차단됨` 배지와 같은 말입니다.
- `source` 는 서버가 주는 48개 노드 전부 `goal.phase` 로 고정값입니다.
- `activity` 는 어느 투영 레인이 마지막으로 움직였는지를 가리키는 내부 토큰입니다.
- `next actions` 의 `unblock` / `drop` 은 누르는 곳 없는 그냥 글자였습니다.

더 문제는 `pct 100%` 입니다. 같은 카드의 판정 메모가 `merged PR count(=5) 미충족, 실제 merged PR 은 1건` 이라고 적혀 있는데 화면은 100% 라고 말합니다. 서버 응답을 보면 이유가 나옵니다.

```json
"attainment": {
  "metric": "merged PR count", "target_value": "5 PRs",
  "metric_evaluation": "unevaluated",
  "observed_value": 6.0, "attainment_pct": 100,
  "note": "Derived from completed linked tasks against a count target."
}
```

`merged PR count` 를 잰 평가기가 없어서, 끝난 하위 작업 수 6건을 대신 넣은 값입니다. 화면은 그 사정을 하나도 안 보여주고 100% 만 띄웠습니다.

실측하면 이게 예외가 아닙니다. 지표를 선언한 35개 Goal **전부** `metric_evaluation: unevaluated` 이고, 그 중 19개는 목표치조차 숫자로 못 읽는 상태(`invalid_target` 12 · `unparseable` 6 · `no_linked_tasks` 1)입니다.

## 바꾼 것

패널을 읽는 순서대로 네 덩이로 나눴습니다. **이 Goal 은 / 완료 조건 / 진행 판정 메모 / 관련**.

완료 조건 칸이 이번 작업의 핵심입니다.

| 행 | 내용 |
|---|---|
| 지표 | 선언된 metric |
| 목표치 | 원문 + 숫자로 읽힌 값. 못 읽으면 어떻게 못 쓰는 값인지 |
| 현재값 | observed_value + 단위 |
| 판정 | 미평가 / 달성 / 진행 중 / 시작 전 |
| 판정 근거 | basis 를 한국어로 + 서버 note |
| 하위 작업 | 끝남 · 남음 · 취소 · 전체 |
| 완료 요청 | 지금 요청 가능한지 |

지표를 안 잰 Goal 은 판정이 **달성이 아니라 미평가**로 나오고, 그 아래에 왜 그런지가 한 줄로 붙습니다.

```
판정   미평가   하위 작업 기준으로는 100%
⚠ merged PR count 를 직접 잰 값이 아니라, 끝난 하위 작업 수로 대신 계산한 숫자예요.
```

지표가 아예 없는 Goal(48개 중 13개)은 `지표 없음 / 목표치 없음 / 현재값 없음` 세 줄 대신 한 줄로 정리했습니다. "완료 지표가 정해져 있지 않아요. 연결된 하위 작업이 모두 끝나야 완료로 봅니다."

`하위 작업  끝남 6 · 남음 0 · 취소 1 · 전체 7` — 헤더의 `6/6` 과 상세의 `6/7` 이 왜 다른지가 취소 건수로 설명됩니다. 전에는 두 숫자가 그냥 어긋나 보였습니다.

## 지운 것

- `goal_fsm` 의 state / source / activity 칩
- `next actions` 라벨
- 단독 `pct`
- 헤더에서 `차단됨` 배지 옆에 붙던 raw phase 토큰 (`blocked`)
- 쓰는 곳이 없어진 `.wk-note` 규칙

## 링크가 된 것

- `키퍼` 행의 이름은 눌러서 해당 키퍼 작업 공간으로 갑니다.
- 승인 대기 건수는 눌러서 승인 화면으로 갑니다.

## SSOT

`attainmentValueLabel` / `attainmentTone` 이 `goals/goal-tree.ts` 안에 있었습니다. 같은 규칙(“평가 안 된 지표는 달성이 아니다”, task-1743)을 Work 패널에서도 써야 해서 `lib/goal-attainment.ts` 로 옮겼습니다. 복사하면 두 화면이 같은 투영을 놓고 다른 말을 하게 됩니다.

## 곁다리로 찾은 것 — #29299

`활동` 행에 `기록 0건` 을 안 씁니다. goals-tree 엔드포인트는 timeline 을 `{event_type, payload}` 로 주는데 디코더는 `{kind, lane, title, summary, severity}` 를 요구해서, 44개 노드의 72개 이벤트가 전부 조용히 버려지고 있습니다. 상세 엔드포인트는 디코더가 원하는 모양 그대로 줍니다. 없는 게 아니라 못 읽는 것이라 0을 쓰면 거짓말이 됩니다. 근본 수정은 #29299 로 넘겼습니다.

## 검증

- `pnpm typecheck` · `pnpm lint` 통과
- `pnpm test` 전체 통과
- 실행 중인 로컬 백엔드(`:8935`)에 dev 서버를 붙여 Playwright 로 두 Goal(`goal-polish-backlog-20260818` 미평가 케이스, `goal-kidsnote-backlog-zero` invalid_target 케이스) 실측 렌더 확인
- work.test.ts 에 7개 케이스 추가/교체: 완료 조건 표시, 미평가 판정, 목표치 불가 사유, 지표 없는 Goal, goal_fsm 토큰 부재(제거 회귀 방지), 키퍼 링크, 타임라인 토글

## 안 건드린 것

- Goals 트리 화면(`goals/goal-tree.ts`)의 FSM 배지 — 같은 정리가 필요해 보이지만 이번 요청 범위 밖입니다.
- 백엔드 투영과 attainment 평가기 — #29299 및 지표 미평가 문제는 별건입니다.