### PR TITLE
fix(dashboard): Goal 상세의 "완료 요청" 행이 검사한 적 없는 조건을 판정한 것처럼 쓰던 문제

### DIFF
--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -1580,7 +1580,7 @@ describe('Work', () => {
                 by_status: {},
               },
               completion_summary: {
-                state: 'in_progress',
+                state: 'ready_for_completion',
                 pct: 100,
                 pct_source: 'attainment',
                 attainment_state: 'attained',
@@ -1591,7 +1591,7 @@ describe('Work', () => {
                 task_open: 0,
                 is_complete: false,
                 is_terminal: false,
-                ready_to_request_completion: false,
+                ready_to_request_completion: true,
               },
               timeline_events: [{
                 ts: '2026-01-04T10:00:00Z',
@@ -1635,13 +1635,55 @@ describe('Work', () => {
         expect(text).toContain('Derived from completed linked tasks against a count target.')
         // Cancelled tasks are named so the done/total gap is not a mystery.
         expect(text).toContain('끝남 3 · 남음 0 · 취소 1 · 전체 4')
-        expect(text).toContain('아직 조건을 채우지 못했어요.')
+        expect(text).toContain('지금 완료를 요청할 수 있어요.')
         // Why the goal sits where it does.
         expect(text).toContain('metric 미충족 — merged PR은 1건뿐')
         // Where to go next.
         expect(text).toContain('sangsu')
         expect(text).toContain('턴 42')
         expect(text).toContain('2건 승인 대기')
+      })
+
+      it('gives the phase reason a goal cannot request completion, not a conditions verdict', () => {
+        goals.value = [
+          { id: 'G-1', title: 'Goal One', priority: 5, phase: 'blocked', created_at: '2026-01-01', updated_at: '2026-01-04' },
+        ]
+        tasks.value = []
+        goalTreeData.value = {
+          tree: [
+            goalTreeNode({
+              id: 'G-1',
+              phase: 'blocked',
+              completion_summary: {
+                state: 'blocked',
+                pct: null,
+                pct_source: 'none',
+                attainment_state: 'unmeasured',
+                attainment_basis: 'unmeasured',
+                metric_evaluation: 'absent',
+                task_total: 0,
+                task_done: 0,
+                task_open: 0,
+                is_complete: false,
+                is_terminal: false,
+                ready_to_request_completion: false,
+              },
+            }),
+          ],
+          summary: emptyGoalTreeSummary({ total_goals: 1, active_goals: 1 }),
+        }
+
+        render(html`<${Work} />`)
+        fireEvent.click(screen.getByTestId('goal-card').querySelector('.wk-goal-h')!)
+
+        // The backend's `ready_to_request_completion` is `phase = Executing`
+        // and nothing else — no metric, target, or task count is consulted.
+        // Rendering its false branch as "conditions unmet" would state a check
+        // that never ran.
+        const row = screen.getByTestId('goal-dossier')
+          .querySelector('[data-goal-detail-row="ready"]')
+        expect(row?.textContent).toContain('막혀 있는 동안에는 완료를 요청할 수 없어요.')
+        expect(row?.textContent).not.toContain('조건')
       })
 
       it('marks a declared-but-unmeasured metric as unevaluated instead of attained', () => {

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -32,6 +32,7 @@ import {
   attainmentTargetProblem,
   attainmentUnitSuffix,
   attainmentVerdict,
+  completionRequestText,
 } from '../lib/goal-attainment'
 import { statusLabel } from '../lib/status-label'
 import { GoalCreateForm } from './goals/goal-create-form'
@@ -588,9 +589,7 @@ function GoalCompletionCriteria({ node }: { node: GoalTreeNode }) {
           tone=${summary.ready_to_request_completion ? 'ok' : undefined}
           testHook="ready"
         >
-          ${summary.ready_to_request_completion
-            ? '지금 완료를 요청할 수 있어요.'
-            : '아직 조건을 채우지 못했어요.'}
+          ${completionRequestText(summary.state)}
         <//>
       ` : null}
     <//>

--- a/dashboard/src/lib/goal-attainment.ts
+++ b/dashboard/src/lib/goal-attainment.ts
@@ -124,3 +124,27 @@ export function attainmentVerdict(attainment: GoalAttainmentProjection): Attainm
     tone,
   }
 }
+
+/** What the goal's completion-request state actually means.
+ *
+ *  `completion_summary.ready_to_request_completion` is the goal phase and
+ *  nothing else — the backend returns `phase = Executing` (see
+ *  dashboard_goals_types_attainment.ml `ready_to_request_completion`), and no
+ *  metric, target, or task count is consulted. Rendering its false branch as
+ *  "the completion conditions are unmet" states a check that never ran: a
+ *  blocked goal with every condition satisfied would still read that way.
+ *  The completion `state` token carries the real reason, so the row reports
+ *  that instead. An unrecognised token surfaces itself rather than collapsing
+ *  into whichever sentence happens to look plausible. */
+const COMPLETION_REQUEST_TEXT: Record<string, string> = {
+  ready_for_completion: '지금 완료를 요청할 수 있어요.',
+  verifying: '완료 요청이 접수돼서 검증 결과를 기다리는 중이에요.',
+  blocked: '막혀 있는 동안에는 완료를 요청할 수 없어요.',
+  paused: '멈춰 있는 동안에는 완료를 요청할 수 없어요.',
+  completed: '완료됐어요.',
+  dropped: '폐기된 목표예요.',
+}
+
+export function completionRequestText(state: string): string {
+  return COMPLETION_REQUEST_TEXT[state] ?? state
+}


### PR DESCRIPTION
## 문제

#29300 에서 제가 넣은 문구가 틀렸습니다.

```
완료 요청   아직 조건을 채우지 못했어요.
```

이 문장은 "완료 조건을 확인해봤더니 아직 못 채웠다" 로 읽힙니다. 그런데 아무것도 확인하지 않습니다.

백엔드는 이 값을 phase 하나로 계산합니다.

```ocaml
(* lib/dashboard/dashboard_goals_types_attainment.ml:279 *)
let ready_to_request_completion =
  match goal.phase with
  | Goal_phase.Executing -> true
  | Goal_phase.Blocked | Goal_phase.Paused | Goal_phase.Verifying
  | Goal_phase.Completed | Goal_phase.Dropped -> false
```

지표도, 목표치도, task 수도 보지 않습니다. 조건을 다 채운 Goal 이라도 막혀 있으면 "조건을 못 채웠다" 로 나갑니다. 실제로 라이브에서 이 행을 달고 있는 Goal 이 바로 그 경우입니다.

## 바꾼 것

`completion_summary.state` 가 진짜 이유를 들고 있어서 그걸 씁니다.

| state | 문구 |
|---|---|
| `ready_for_completion` | 지금 완료를 요청할 수 있어요. |
| `verifying` | 완료 요청이 접수돼서 검증 결과를 기다리는 중이에요. |
| `blocked` | 막혀 있는 동안에는 완료를 요청할 수 없어요. |
| `paused` | 멈춰 있는 동안에는 완료를 요청할 수 없어요. |
| `completed` | 완료됐어요. |
| `dropped` | 폐기된 목표예요. |

모르는 토큰은 토큰 자체를 그대로 보여줍니다. 그럴듯해 보이는 문장으로 접지 않습니다.

## 검증

- `pnpm typecheck` · `pnpm lint` 통과
- `work.test.ts` 66개 통과. blocked Goal 이 조건 이야기를 하지 않는지 확인하는 케이스를 추가했습니다 (`not.toContain('조건')`).
- 기존 케이스의 픽스처가 `phase: executing` 인데 `state: in_progress` / `ready: false` 로 서로 안 맞았어서, `ready_for_completion` / `true` 로 맞췄습니다. 백엔드가 executing Goal 에 실제로 내보내는 값입니다.

## 배경

#29300 이후 Goal 구현 전반을 점검하다 나왔습니다. 같이 나온 것들은 별도 이슈로 올렸습니다 — #29301 (Verifying 트랩), #29303 (metric 이 장식), #29299 (timeline 투영 불일치).