### PR TITLE
fix(rw23): defer shared verifier goal creation

### DIFF
--- a/scripts/fixtures/keeper-multi-collaboration/missions.json
+++ b/scripts/fixtures/keeper-multi-collaboration/missions.json
@@ -38,7 +38,6 @@
     "masc_keeper_status",
     "masc_agent_timeline",
     "masc_goal_upsert",
-    "masc_goal_assign",
     "masc_goal_list",
     "masc_goal_transition",
     "masc_add_task",
@@ -81,11 +80,11 @@
     {
       "id": "RW02",
       "phase": "bootstrap",
-      "name": "shared_goal_assignment",
+      "name": "shared_goal_open_set",
       "actors": ["coordinator", "builder-a", "builder-b", "reviewer", "researcher"],
       "capabilities": ["Goal", "Task"],
-      "user_story": "공유 Goal이 coordinator에게 배정되고 모든 작업이 그 Goal identity를 유지한다.",
-      "assertions": ["goal_visible", "goal_assignment_visible", "tasks_linked_to_goal"],
+      "user_story": "owner 없는 공유 Goal이 모든 Keeper에게 같은 open set으로 보이고 모든 작업이 그 Goal identity를 유지한다.",
+      "assertions": ["goal_visible", "goal_shared_open_set_visible", "tasks_linked_to_goal"],
       "evidence": ["observations/goals.json", "observations/tasks.json"]
     },
     {

--- a/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
+++ b/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
@@ -62,7 +62,7 @@ KNOWN_ASSERTIONS = {
     "role_identity_preserved",
     "runtime_assignment_serving_observed",
     "goal_visible",
-    "goal_assignment_visible",
+    "goal_shared_open_set_visible",
     "tasks_linked_to_goal",
     "parallel_wave_completed",
     "parallel_keeper_overlap_observed",
@@ -1289,35 +1289,6 @@ class MissionRun:
                 "priority": 1,
             },
         )
-        self.call(
-            "goal-assign",
-            "masc_goal_assign",
-            {"goal_id": self.goal_id, "owner": self.roles["coordinator"]},
-        )
-        self.call(
-            "goal-verifier-upsert",
-            "masc_goal_upsert",
-            {
-                "id": self.verifier_goal_id,
-                "title": f"Artifact-gated Goal verifier mission {self.marker}",
-                "metric": (
-                    f"owner artifact {self.verifier_artifact} contains the exact "
-                    f"token {self.verifier_success_token}"
-                ),
-                "target_value": self.verifier_success_token,
-                "priority": 1,
-            },
-        )
-        for role, keeper in self.roles.items():
-            arguments: dict[str, Any] = {
-                "name": keeper,
-                "active_goal_ids": [self.goal_id],
-            }
-            runtime_id = self.runtime_for_role(role)
-            if runtime_id:
-                arguments["runtime_id"] = runtime_id
-            self.call(f"keeper-goal-scope-{role}", "masc_keeper_up", arguments)
-
         task_specs = {
             "builder-a": "Build the first durable collaboration artifact",
             "builder-b": "Build the second durable collaboration artifact",
@@ -1820,6 +1791,20 @@ class MissionRun:
         )
 
     def run_goal_verifier_refute_reenter_prove(self) -> None:
+        self.call(
+            "goal-verifier-upsert",
+            "masc_goal_upsert",
+            {
+                "id": self.verifier_goal_id,
+                "title": f"Artifact-gated Goal verifier mission {self.marker}",
+                "metric": (
+                    f"producer artifact {self.verifier_artifact} contains the exact "
+                    f"token {self.verifier_success_token}"
+                ),
+                "target_value": self.verifier_success_token,
+                "priority": 1,
+            },
+        )
         self.wait_for_goal_state(
             phase="executing",
             criterion_state="viable",
@@ -1857,14 +1842,6 @@ class MissionRun:
         self.writer.write_json(
             "observations/goal-verifier-task-refuted.json",
             rejected_task_verdict,
-        )
-        self.call(
-            "goal-verifier-assign",
-            "masc_goal_assign",
-            {
-                "goal_id": self.verifier_goal_id,
-                "owner": self.roles["coordinator"],
-            },
         )
         self.call(
             "goal-verifier-request-refute",
@@ -2256,6 +2233,15 @@ class MissionRun:
         board_text = json.dumps(board, ensure_ascii=False)
         task_text = json.dumps(tasks, ensure_ascii=False)
         goal_text = json.dumps(goals, ensure_ascii=False)
+        goal_rows = goals.get("goals", []) if isinstance(goals, dict) else []
+        shared_goal = next(
+            (
+                row
+                for row in goal_rows
+                if isinstance(row, dict) and row.get("id") == self.goal_id
+            ),
+            None,
+        )
         history_text = json.dumps(histories, ensure_ascii=False)
         qa_verdicts = [
             self._completion_verdict(key) for key in ("qa-implement", "qa-test")
@@ -2771,9 +2757,9 @@ class MissionRun:
                 ),
             ),
             "goal_visible": (self.goal_id.lower() in goal_text.lower(), self.goal_id),
-            "goal_assignment_visible": (
-                self.roles["coordinator"].lower() in goal_text.lower(),
-                self.roles["coordinator"],
+            "goal_shared_open_set_visible": (
+                isinstance(shared_goal, dict) and "owner" not in shared_goal,
+                "shared Goal is present and the removed owner field is absent",
             ),
             "tasks_linked_to_goal": (
                 # Goal linkage is judged from the creation receipts (the

--- a/test/test_keeper_multi_collaboration_acceptance.py
+++ b/test/test_keeper_multi_collaboration_acceptance.py
@@ -343,26 +343,31 @@ class KeeperMultiCollaborationAcceptanceTest(unittest.TestCase):
             acceptance.MissionRun.run_goal_verifier_refute_reenter_prove
         )
 
-        # The success-token Task and Goal assignment both used to be visible
-        # during fleet setup. A capable coordinator completed them autonomously
-        # before RW23 could write the failing artifact. Keep both inside the
-        # directed RW23 phase and the verifier Goal out of ordinary fleet scope.
+        # The success-token Task and verifier Goal both used to be visible
+        # during fleet setup. The autonomous fleet completed them before RW23
+        # could write the failing artifact. Create the Goal only inside the
+        # directed RW23 phase. Goals are now an ownerless shared open set, so
+        # no removed assignment/scope compatibility call may return.
         self.assertNotIn("goal-verifier-task-create", setup_source)
+        self.assertNotIn("goal-verifier-upsert", setup_source)
         self.assertNotIn("goal-verifier-assign", setup_source)
-        self.assertIn('"active_goal_ids": [self.goal_id]', setup_source)
-        self.assertNotIn(
-            '"active_goal_ids": [self.goal_id, self.verifier_goal_id]',
-            setup_source,
-        )
+        self.assertNotIn("masc_goal_assign", setup_source)
+        self.assertNotIn("active_goal_ids", setup_source)
         self.assertIn("goal-verifier-task-create", rw23_source)
-        self.assertIn("goal-verifier-assign", rw23_source)
+        self.assertIn("goal-verifier-upsert", rw23_source)
+        self.assertNotIn("goal-verifier-assign", rw23_source)
+        self.assertNotIn("masc_goal_assign", rw23_source)
+        self.assertLess(
+            rw23_source.index("goal-verifier-upsert"),
+            rw23_source.index('criterion_state="viable"'),
+        )
+        self.assertLess(
+            rw23_source.index('criterion_state="viable"'),
+            rw23_source.index("goal-verifier-task-create"),
+        )
         self.assertLess(
             rw23_source.index("goal-verifier-task-create"),
             rw23_source.index("goal-verifier-refute-artifact"),
-        )
-        self.assertLess(
-            rw23_source.index('wait_for_verifier_task_verdict("in_progress")'),
-            rw23_source.index("goal-verifier-assign"),
         )
 
     def test_rw23_uses_durable_verdict_without_parsing_board_text(self):


### PR DESCRIPTION
## Summary
- keep the verifier Goal absent during ordinary fleet work
- create it only when the directed RW23 phase starts, then wait for the independent criterion verifier before creating the success-token Task
- align RW02 and the harness with the current ownerless shared-Goal hard cut: remove the deleted `masc_goal_assign` and `active_goal_ids` surfaces

## Exact failure evidence
- protected-main run 32475963566 at source `64e02b23844aef3a11d9e02821cf24a558280419` failed with `criterion=pending`, `owner=null` under the pre-hard-cut Goal contract
- heterogeneous run `hetero-822161d3...` completed 19/19 directed turns, then the autonomous fleet discovered the setup Goal and reached `proof_proven/completed` before directed refutation
- #29256 removed Goal ownership entirely, so assignment is no longer a valid repair; the directed Goal creation boundary is the durable fix
- #29310 (`ead97098861427cfa6d969b6163061cac5c2574a`) repaired the owner-hard-cut CI contracts and is the exact base of this head

## Checks
- Python unittest discovery: 14/14
- catalog validation: 23 missions / 48 assertions / A-B-C
- Python bytecode compile
- `git diff --check`

Exact-head CI run 32486275152 is in progress. CI remains compile authority; no local Dune build.