### PR TITLE
fix(keeper): blocked purge를 admission-open 없이 exact reissue

### DIFF
--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -98,15 +98,32 @@ and goal_of_yojson = function
             if List.mem field accepted_fields then None else Some field)
           fields
       in
+      let retired_owner =
+        match
+          List.filter_map
+            (fun (field, value) ->
+               if String.equal field "owner" then Some value else None)
+            fields
+        with
+        | [] -> Ok ()
+        | [ (`String _ | `Null) ] -> Ok ()
+        | [ value ] ->
+          Error
+            (Printf.sprintf
+               "goal_of_yojson: retired owner must retain its former string-or-null shape, got %s"
+               (Yojson.Safe.to_string value))
+        | _ -> Error "goal_of_yojson: duplicate retired owner field"
+      in
       let id_opt = Json_util.assoc_member_opt "id" json in
       let title_opt = Json_util.assoc_member_opt "title" json in
-      (match unknown_field, id_opt, title_opt with
-      | Some field, _, _ ->
+      (match unknown_field, retired_owner, id_opt, title_opt with
+      | Some field, _, _, _ ->
           Error
             (Printf.sprintf
                "goal_of_yojson: unknown Goal field %S is not accepted"
                field)
-      | None, Some (`String id), Some (`String title) ->
+      | None, Error detail, _, _ -> Error detail
+      | None, Ok (), Some (`String id), Some (`String title) ->
           let phase =
             (* Phase is required: a row without [phase] is a decode error, not
                a silent Active default. The silent default caused main red
@@ -149,7 +166,7 @@ and goal_of_yojson = function
            | Error msg, _, _ -> Error msg
            | _, Error msg, _ -> Error msg
            | _, _, Error msg -> Error msg)
-      | None, _, _ -> Error "goal_of_yojson: invalid goal")
+      | None, Ok (), _, _ -> Error "goal_of_yojson: invalid goal")
   | other_json ->
       Error ("goal_of_yojson: " ^ Yojson.Safe.to_string other_json)
 

--- a/lib/goal/goal_store.mli
+++ b/lib/goal/goal_store.mli
@@ -7,9 +7,11 @@
 
     - a {!Goal_phase.t} (canonical lifecycle: [Executing] / [Blocked] /
       [Completed] / [Paused] / [Dropped]) — the only persisted
-      lifecycle representation.  The retired ["owner"] field is accepted
-      and discarded on read so pre-cut stores remain available, but it is
-      never written and does not re-enter the runtime model.  ["status"] is
+      lifecycle representation.  One retired ["owner"] field is accepted
+      and discarded on read only when it retains the former string-or-null
+      shape, so valid pre-cut stores remain available without licensing
+      malformed or duplicate tombstones.  It is never written and does not
+      re-enter the runtime model.  ["status"] is
       not an accepted field:
       a row carrying it fails to decode, and {!read_state} then applies
       the corrupt-store policy (recovery mirror if usable, otherwise an

--- a/lib/keeper/keeper_dashboard_purge.ml
+++ b/lib/keeper/keeper_dashboard_purge.ml
@@ -52,8 +52,9 @@ let resolve_error_to_string = function
   | Keeper_purge_blocked { keeper_name; operation_id; detail } ->
     Printf.sprintf
       "keeper purge %s is blocked and will not resume on its own: keeper=%s \
-       failure=%s; release the admission fence with an operator supersession, \
-       then reissue the purge"
+       failure=%s; invoke the authenticated exact purge reissue, which keeps \
+       admission fenced while it materializes paused recovery metadata and \
+       finishes the purge"
       (Keeper_shutdown_types.Operation_id.to_string operation_id)
       keeper_name
       detail

--- a/lib/keeper/keeper_dashboard_purge.mli
+++ b/lib/keeper/keeper_dashboard_purge.mli
@@ -54,8 +54,9 @@ type resolve_error =
           flight and no retry advances it: the fence stops the Keeper's meta
           being materialized, and {!resolve} needs that meta. Reporting it as
           an accepted operation told the dashboard a purge was running that
-          had already stopped for good. The exit is an operator supersession,
-          which releases the fence and lets the purge be reissued. *)
+          had already stopped for good. The exit is the authenticated exact
+          purge reissue, which keeps the same fence through paused recovery
+          materialization and finalization. *)
       (** The lane is still taking turns. Purge deletes the Keeper and every
           store it owns, so a Keeper that can still execute is refused here
           rather than raced: stop or pause it first. The dashboard hides the

--- a/lib/keeper/keeper_owner_registry.ml
+++ b/lib/keeper/keeper_owner_registry.ml
@@ -671,6 +671,30 @@ let create_meta ?intake_token ~base_path meta =
                (Keeper_shutdown_types.Operation_id.to_string operation_id))))
 ;;
 
+let create_meta_for_shutdown ~base_path ~operation_id meta =
+  match
+    Keeper_shutdown_intake_fence.run_durable_intake_for_shutdown
+      ~base_path
+      ~keeper_name:meta.Keeper_meta_contract.name
+      ~operation_id
+      (fun intake_token -> create_meta ~intake_token ~base_path meta)
+  with
+  | Keeper_shutdown_intake_fence.Shutdown_owned_intake_committed result -> result
+  | Shutdown_owned_intake_not_reserved ->
+    Error
+      (shutdown_fence_error
+         (Printf.sprintf
+            "keeper=%s shutdown recovery intake is not reserved"
+            meta.name))
+  | Shutdown_owned_intake_reserved_by_other existing ->
+    Error
+      (shutdown_fence_error
+         (Printf.sprintf
+            "keeper=%s shutdown recovery intake is reserved by %s"
+            meta.name
+            (Keeper_shutdown_types.Operation_id.to_string existing)))
+;;
+
 let all_projections ~base_path =
   match find_pool base_path with
   | Error _ as error -> error

--- a/lib/keeper/keeper_owner_registry.mli
+++ b/lib/keeper/keeper_owner_registry.mli
@@ -138,6 +138,14 @@ val create_meta
     already-open exact-name intake transaction is reused instead of reacquiring
     the same fence. *)
 
+val create_meta_for_shutdown :
+  base_path:string ->
+  operation_id:Keeper_shutdown_types.Operation_id.t ->
+  Keeper_meta_contract.keeper_meta ->
+  (Keeper_meta_contract.keeper_meta option, command_error) result
+(** Recovery-only metadata materialization while [operation_id] remains the
+    exact shutdown admission owner. Ordinary intake stays fenced throughout. *)
+
 val exact_operation
   :  base_path:string
   -> keeper_name:string

--- a/lib/keeper/keeper_shutdown_blocked_purge_release.ml
+++ b/lib/keeper/keeper_shutdown_blocked_purge_release.ml
@@ -543,6 +543,24 @@ let success_json ~audit command released =
     ]
 ;;
 
+let reissue_same_command_json ~actor command =
+  `Assoc
+    [ "schema", `String "masc.keeper.blocked-purge.next-action.v1"
+    ; "kind", `String "reissue_same_command"
+    ; "actor", `String actor
+    ; ( "command"
+      , `Assoc
+          [ "schema", `String command_schema
+          ; "keeper_id", `String command.keeper_id
+          ; ( "operation_id"
+            , `String
+                (Keeper_shutdown_types.Operation_id.to_string command.operation_id) )
+          ; "expected_revision", `Int command.expected_revision
+          ; "reason", `String command.reason
+          ] )
+    ]
+;;
+
 module For_testing = struct
   let reset_audit_writer () =
     Atomic.set audit_writer (fun config ~actor command ~outcome ->

--- a/lib/keeper/keeper_shutdown_blocked_purge_release.ml
+++ b/lib/keeper/keeper_shutdown_blocked_purge_release.ml
@@ -199,28 +199,6 @@ let error_to_string = function
   | Injected_after_reissue detail -> detail
 ;;
 
-let operator_reissue_matches ~actor command operation =
-  match operation.Keeper_shutdown_types.join_evidence with
-  | Some
-      { lane_outcome =
-          Lane_operator_purge_reissue
-            { actor = persisted_actor; reason; expected_revision }
-      ; _
-      } ->
-    String.equal actor persisted_actor
-    && String.equal command.reason reason
-    && Int.equal command.expected_revision expected_revision
-  | Some
-      { lane_outcome =
-          ( Lane_completed
-          | Lane_shutdown_requested
-          | Lane_cancelled_by_parent _
-          | Lane_failed _ )
-      ; _
-      }
-  | None -> false
-;;
-
 let paused_meta_from_profile ~config command operation =
   let open Result.Syntax in
   let* context =
@@ -251,6 +229,23 @@ let paused_meta_from_profile ~config command operation =
       Profile_materialization_failed
         (Keeper_types_profile.keeper_toml_load_error_to_string error))
   in
+  let* instructions =
+    match defaults.instructions with
+    | Some instructions -> Ok instructions
+    | None ->
+      Error
+        (Profile_materialization_failed
+           "surviving Keeper profile did not resolve exact instructions")
+  in
+  let allowed_paths =
+    match defaults.allowed_paths with
+    | Some allowed_paths -> allowed_paths
+    | None ->
+      (* DET-OK: the normal Keeper create contract maps an omitted
+         [allowed_paths] profile field to the least-privilege empty set. This
+         recovery materialization applies that same total mapping. *)
+      []
+  in
   let sandbox_profile =
     Keeper_turn_up_args.resolve_sandbox_profile
       ?requested:None
@@ -269,12 +264,12 @@ let paused_meta_from_profile ~config command operation =
     { id = defaults.id
     ; name = command.keeper_id
     ; agent_name = context.agent_name
-    ; instructions = Option.value ~default:"" defaults.instructions
+    ; instructions
     ; autonomous_instructions = defaults.autonomous_instructions
     ; sandbox_profile
     ; sandbox_image = defaults.sandbox_image
     ; network_mode
-    ; allowed_paths = Option.value ~default:[] defaults.allowed_paths
+    ; allowed_paths
     ; mention_targets =
         Keeper_turn_up_args.resolve_mention_targets
           ~mention_targets_opt:(Some defaults.mention_targets)
@@ -351,18 +346,60 @@ let paused_meta_from_profile ~config command operation =
     }
 ;;
 
-let exact_paused_meta operation meta =
+let exact_recovery_snapshot operation meta =
   String.equal meta.Keeper_meta_contract.name operation.Keeper_shutdown_types.keeper_name
   && Keeper_id.Trace_id.equal meta.runtime.trace_id operation.trace_id
   && Int.equal meta.runtime.nonce operation.generation
   && meta.paused
 ;;
 
+let exact_paused_meta operation meta =
+  exact_recovery_snapshot operation meta
+  && not meta.proactive.enabled
+  && not meta.autoboot_enabled
+;;
+
+let apply_paused_profile ~config desired =
+  Keeper_owner_registry.apply_meta
+    ~base_path:config.Workspace.base_path
+    ~keeper_name:desired.Keeper_meta_contract.name
+    (Keeper_owner_reducer.Update_profile
+       { instructions = desired.instructions
+       ; autonomous_instructions = desired.autonomous_instructions
+       ; sandbox_profile = desired.sandbox_profile
+       ; sandbox_image = desired.sandbox_image
+       ; network_mode = desired.network_mode
+       ; allowed_paths = desired.allowed_paths
+       ; mention_targets = desired.mention_targets
+       ; proactive_enabled = false
+       ; max_context_override = desired.max_context_override
+       ; autoboot_enabled = false
+       ; telemetry_feedback_enabled = desired.telemetry_feedback_enabled
+       ; telemetry_feedback_window_hours =
+           desired.telemetry_feedback_window_hours
+       ; always_allow = desired.always_allow
+       ; agent_core_env = desired.agent_core_env
+       ; updated_at = desired.updated_at
+       })
+  |> Result.map_error (fun error ->
+    Metadata_materialization_failed
+      (Keeper_owner_registry.command_error_to_string error))
+;;
+
 let ensure_paused_meta ~config command operation =
   let open Result.Syntax in
   match Keeper_meta_store.read_meta config command.keeper_id with
   | Error detail -> Error (Metadata_materialization_failed detail)
-  | Ok (Some meta) when exact_paused_meta operation meta -> Ok meta
+  | Ok (Some meta) when exact_recovery_snapshot operation meta ->
+    let* desired = paused_meta_from_profile ~config command operation in
+    let* committed = apply_paused_profile ~config desired in
+    (match committed with
+     | Some committed when exact_paused_meta operation committed -> Ok committed
+     | Some _ ->
+       Error
+         (Metadata_materialization_failed
+            "Owner did not retain the paused recovery policy")
+     | None -> Error (Metadata_materialization_failed "metadata disappeared during repair"))
   | Ok (Some _) ->
     Error
       (Metadata_materialization_failed
@@ -392,50 +429,63 @@ let finalize_reissued ~config operation =
   | Joined_idle
   | Finalizing_tasks _
   | Cleanup_ready _
+  | Blocked { resume = Some _; _ }
   | Finalized _ ->
     Keeper_shutdown_finalize.run ~config ~entry:None operation
     |> Result.map_error (fun error -> Finalization_failed error)
   | Prepared
   | Joining_lanes
   | Reconciliation_required _
-  | Blocked _
+  | Blocked { resume = None; _ }
   | Superseded _ ->
     Error (Store_reissue_failed (Keeper_shutdown_store.Supersession_phase_mismatch operation))
 ;;
 
 let fail_after_reissue_once : string option Atomic.t = Atomic.make None
 
+let needs_initial_recovery_meta operation =
+  match operation.Keeper_shutdown_types.phase, operation.join_evidence with
+  | ( Blocked { stage = Lane_join; resume = Some Resume_joined_idle; _ }
+    , Some { lane_outcome = Lane_operator_purge_reissue _; _ } ) -> true
+  | _ -> false
+;;
+
 let execute ~config ~actor command =
   let open Result.Syntax in
-  let* observed =
-    Keeper_shutdown_store.load
-      ~config
-      ~keeper_name:command.keeper_id
-      command.operation_id
-    |> Result.map_error (fun error -> Operation_load_failed error)
-  in
-  let already_reissued = operator_reissue_matches ~actor command observed in
-  let* (_meta : Keeper_meta_contract.keeper_meta option) =
-    if already_reissued
-    then Ok None
-    else ensure_paused_meta ~config command observed |> Result.map Option.some
-  in
-  let* reissue =
-    Keeper_shutdown_store.reissue_blocked_dashboard_purge
+  let* prepared =
+    Keeper_shutdown_store.prepare_blocked_dashboard_purge_reissue
       ~config
       ~keeper_name:command.keeper_id
       ~operation_id:command.operation_id
       ~expected_revision:command.expected_revision
       ~actor
       ~reason:command.reason
-      ~now:Masc_domain.now_iso
     |> Result.map_error (fun error -> Store_reissue_failed error)
   in
-  let reissued, already_reissued =
-    match reissue with
-    | Keeper_shutdown_store.Purge_reissue_persisted operation -> operation, false
+  let* reissued, already_reissued =
+    match prepared with
     | Keeper_shutdown_store.Purge_reissue_already_persisted operation ->
-      operation, true
+      let* () =
+        if needs_initial_recovery_meta operation
+        then ensure_paused_meta ~config command operation |> Result.map ignore
+        else Ok ()
+      in
+      Ok (operation, true)
+    | Purge_reissue_initial_prepared (token, _operation) ->
+      let* reissued =
+        Keeper_shutdown_store.reissue_blocked_dashboard_purge
+          ~config
+          ~token
+          ~now:Masc_domain.now_iso
+        |> Result.map_error (fun error -> Store_reissue_failed error)
+        |> Result.map
+             (fun (Keeper_shutdown_store.Purge_reissue_persisted operation) ->
+                operation)
+      in
+      let* (_meta : Keeper_meta_contract.keeper_meta) =
+        ensure_paused_meta ~config command reissued
+      in
+      Ok (reissued, false)
   in
   let* () =
     match Atomic.exchange fail_after_reissue_once None with

--- a/lib/keeper/keeper_shutdown_blocked_purge_release.ml
+++ b/lib/keeper/keeper_shutdown_blocked_purge_release.ml
@@ -1,5 +1,5 @@
-let command_schema = "masc.keeper_shutdown.blocked_purge_release.command.v1"
-let result_schema = "masc.keeper_shutdown.blocked_purge_release.result.v1"
+let command_schema = "masc.keeper_shutdown.blocked_purge_reissue.command.v1"
+let result_schema = "masc.keeper_shutdown.blocked_purge_reissue.result.v1"
 
 type command =
   { keeper_id : string
@@ -20,27 +20,29 @@ type input_error =
   | Unsupported_schema of string
 
 type error =
-  | Store_release_failed of Keeper_shutdown_store.error
-  | Successor_lookup_failed of Keeper_shutdown_store.error
-  | Admission_reserved_by_other of Keeper_shutdown_types.Operation_id.t
-  | Admission_release_failed of string
+  | Operation_load_failed of Keeper_shutdown_store.error
+  | Profile_materialization_failed of string
+  | Metadata_materialization_failed of string
+  | Store_reissue_failed of Keeper_shutdown_store.error
+  | Finalization_failed of Keeper_shutdown_finalize.error
+  | Injected_after_reissue of string
 
 type released =
   { operation : Keeper_shutdown_types.t
-  ; already_released : bool
+  ; already_reissued : bool
   }
 
 let input_error_to_string = function
   | Object_required observed_kind ->
-    Printf.sprintf "blocked purge release command must be an object (received %s)" observed_kind
+    Printf.sprintf "blocked purge reissue command must be an object (received %s)" observed_kind
   | Duplicate_fields fields ->
-    Printf.sprintf "blocked purge release command contains duplicate field(s): %s" (String.concat ", " fields)
+    Printf.sprintf "blocked purge reissue command contains duplicate field(s): %s" (String.concat ", " fields)
   | Unsupported_fields fields ->
-    Printf.sprintf "blocked purge release command contains unsupported field(s): %s" (String.concat ", " fields)
+    Printf.sprintf "blocked purge reissue command contains unsupported field(s): %s" (String.concat ", " fields)
   | Missing_fields fields ->
-    Printf.sprintf "blocked purge release command is missing required field(s): %s" (String.concat ", " fields)
+    Printf.sprintf "blocked purge reissue command is missing required field(s): %s" (String.concat ", " fields)
   | Invalid_field { field; expectation } -> Printf.sprintf "%s %s" field expectation
-  | Unsupported_schema schema -> Printf.sprintf "unsupported blocked purge release schema %S" schema
+  | Unsupported_schema schema -> Printf.sprintf "unsupported blocked purge reissue schema %S" schema
 ;;
 
 let input_error_to_json error =
@@ -60,7 +62,7 @@ let input_error_to_json error =
       "unsupported_schema", [ "schema", `String schema ]
   in
   `Assoc
-    ([ "error", `String "blocked_purge_release_invalid_input"
+    ([ "error", `String "blocked_purge_reissue_invalid_input"
      ; "kind", `String kind
      ; "message", `String (input_error_to_string error)
      ]
@@ -187,59 +189,239 @@ let parse_command = function
 ;;
 
 let error_to_string = function
-  | Store_release_failed error -> Keeper_shutdown_store.error_to_string error
-  | Successor_lookup_failed error ->
-    "blocked purge was released, but successor admission lookup failed: "
-    ^ Keeper_shutdown_store.error_to_string error
-  | Admission_reserved_by_other operation_id ->
-    Printf.sprintf
-      "blocked purge was released, but admission belongs to operation %s"
-      (Keeper_shutdown_types.Operation_id.to_string operation_id)
-  | Admission_release_failed detail ->
-    "blocked purge was released, but its admission fence could not be released: " ^ detail
+  | Operation_load_failed error -> Keeper_shutdown_store.error_to_string error
+  | Profile_materialization_failed detail ->
+    "blocked purge profile materialization failed: " ^ detail
+  | Metadata_materialization_failed detail ->
+    "blocked purge paused metadata materialization failed: " ^ detail
+  | Store_reissue_failed error -> Keeper_shutdown_store.error_to_string error
+  | Finalization_failed error -> Keeper_shutdown_finalize.error_to_string error
+  | Injected_after_reissue detail -> detail
 ;;
 
-let release_admission ~config operation =
-  let open Result.Syntax in
-  let* successor_operation_id =
-    Keeper_shutdown_store.corrupt_operation_id_for_keeper
-      ~config
-      ~keeper_name:operation.Keeper_shutdown_types.keeper_name
-    |> Result.map_error (fun error -> Successor_lookup_failed error)
-  in
-  let transition () =
-    Keeper_owner_registry.transition_shutdown
-      ~base_path:config.Workspace.base_path
-      ~keeper_name:operation.keeper_name
-      ~from_operation_id:operation.operation_id
-      ~to_operation_id:successor_operation_id
-  in
-  match transition () with
-  | Ok Keeper_owner.Shutdown_transition_applied
-  | Ok Keeper_owner.Shutdown_transition_already_applied -> Ok ()
-  | Ok (Keeper_owner.Shutdown_transition_reserved_by_other existing) ->
-    Error (Admission_reserved_by_other existing)
-  | Error error ->
-    if Keeper_shutdown_finalize.admission_already_released_by_removal ~config operation error
-    then
-      (match
-         Keeper_shutdown_intake_fence.transition_shutdown
-           ~base_path:config.Workspace.base_path
-           ~keeper_name:operation.keeper_name
-           ~from_operation_id:operation.operation_id
-           ~to_operation_id:successor_operation_id
-       with
-       | Keeper_shutdown_intake_fence.Transition_applied
-       | Keeper_shutdown_intake_fence.Transition_already_applied -> Ok ()
-       | Keeper_shutdown_intake_fence.Transition_reserved_by_other existing ->
-         Error (Admission_reserved_by_other existing))
-    else Error (Admission_release_failed (Keeper_owner_registry.command_error_to_string error))
+let operator_reissue_matches ~actor command operation =
+  match operation.Keeper_shutdown_types.join_evidence with
+  | Some
+      { lane_outcome =
+          Lane_operator_purge_reissue
+            { actor = persisted_actor; reason; expected_revision }
+      ; _
+      } ->
+    String.equal actor persisted_actor
+    && String.equal command.reason reason
+    && Int.equal command.expected_revision expected_revision
+  | Some
+      { lane_outcome =
+          ( Lane_completed
+          | Lane_shutdown_requested
+          | Lane_cancelled_by_parent _
+          | Lane_failed _ )
+      ; _
+      }
+  | None -> false
 ;;
+
+let paused_meta_from_profile ~config command operation =
+  let open Result.Syntax in
+  let* context =
+    match operation.Keeper_shutdown_types.cleanup_intent.reason with
+    | Dashboard_keeper_purge context -> Ok context
+    | Operator_stop_retain_meta
+    | Operator_stop_remove_meta
+    | Supervisor_cleanup ->
+      Error (Profile_materialization_failed "operation is not a dashboard purge")
+  in
+  let* () =
+    match
+      Keeper_types_profile.keeper_toml_path_opt_for_base_path
+        ~base_path:config.Workspace.base_path
+        command.keeper_id
+    with
+    | Some _ -> Ok ()
+    | None ->
+      Error
+        (Profile_materialization_failed
+           "surviving Keeper TOML is required for exact purge reissue")
+  in
+  let* defaults =
+    Keeper_types_profile.load_keeper_profile_defaults_result_for_base_path
+      ~base_path:config.Workspace.base_path
+      command.keeper_id
+    |> Result.map_error (fun error ->
+      Profile_materialization_failed
+        (Keeper_types_profile.keeper_toml_load_error_to_string error))
+  in
+  let sandbox_profile =
+    Keeper_turn_up_args.resolve_sandbox_profile
+      ?requested:None
+      ~fallback:defaults.sandbox_profile
+      ()
+  in
+  let network_mode =
+    Keeper_turn_up_args.resolve_network_mode
+      ~sandbox_profile
+      ~fallback:defaults.network_mode
+  in
+  let now = Masc_domain.now_iso () in
+  let now_ts = Time_compat.now () in
+  let open Keeper_meta_contract in
+  Ok
+    { id = defaults.id
+    ; name = command.keeper_id
+    ; agent_name = context.agent_name
+    ; instructions = Option.value ~default:"" defaults.instructions
+    ; autonomous_instructions = defaults.autonomous_instructions
+    ; sandbox_profile
+    ; sandbox_image = defaults.sandbox_image
+    ; network_mode
+    ; allowed_paths = Option.value ~default:[] defaults.allowed_paths
+    ; mention_targets =
+        Keeper_turn_up_args.resolve_mention_targets
+          ~mention_targets_opt:(Some defaults.mention_targets)
+          ~fallback_targets:defaults.mention_targets
+          ~name:command.keeper_id
+    ; proactive = { enabled = false }
+    ; multimodal_policy =
+        Option.value
+          ~default:Keeper_types_profile.default_multimodal_policy
+          defaults.multimodal_policy
+    ; created_at = operation.created_at
+    ; updated_at = now
+    ; max_context_override = defaults.max_context_override
+    ; paused = true
+    ; latched_reason =
+        Some
+          (Keeper_latched_reason.Operator_paused
+             { operator_actor = Keeper_latched_reason.operator_actor_keeper_down })
+    ; autoboot_enabled = false
+    ; current_task_id = None
+    ; telemetry_feedback_enabled = defaults.telemetry_feedback_enabled
+    ; telemetry_feedback_window_hours = defaults.telemetry_feedback_window_hours
+    ; always_allow = defaults.always_allow
+    ; runtime =
+        { usage =
+            { total_turns = 0
+            ; total_input_tokens = 0
+            ; total_output_tokens = 0
+            ; total_tokens = 0
+            ; total_cost_usd = 0.0
+            ; last_turn_ts = 0.0
+            ; last_input_tokens = 0
+            ; last_output_tokens = 0
+            ; last_total_tokens = 0
+            ; last_usage_reported_at = None
+            ; last_latency_ms = 0
+            }
+        ; compaction_rt =
+            { count = 0
+            ; last_ts = 0.0
+            ; last_before_tokens = 0
+            ; last_after_tokens = 0
+            ; last_check_ts = now_ts
+            ; last_decision = compaction_runtime_decision_of_string "initialized"
+            }
+        ; proactive_rt =
+            { count_total = 0
+            ; last_ts = 0.0
+            ; visible_count_total = 0
+            ; last_visible_ts = 0.0
+            ; last_outcome = Proactive_never_started
+            ; last_reason = ""
+            ; last_preview = ""
+            ; consecutive_noop_count = 0
+            }
+        ; nonce = operation.generation
+        ; trace_id = operation.trace_id
+        ; trace_history = []
+        ; last_handoff_ts = 0.0
+        ; last_autonomous_action_at = ""
+        ; autonomous_action_count = 0
+        ; autonomous_turn_count = 0
+        ; autonomous_text_turn_count = 0
+        ; autonomous_tool_turn_count = 0
+        ; board_reactive_turn_count = 0
+        ; mention_reactive_turn_count = 0
+        ; noop_turn_count = 0
+        ; message_scope_ack_id = None
+        ; last_blocker = None
+        ; last_runtime_attempt = None
+        }
+    ; keeper_id = Some (Keeper_id.Uid.generate ())
+    ; agent_core_env = defaults.agent_core_env
+    }
+;;
+
+let exact_paused_meta operation meta =
+  String.equal meta.Keeper_meta_contract.name operation.Keeper_shutdown_types.keeper_name
+  && Keeper_id.Trace_id.equal meta.runtime.trace_id operation.trace_id
+  && Int.equal meta.runtime.nonce operation.generation
+  && meta.paused
+;;
+
+let ensure_paused_meta ~config command operation =
+  let open Result.Syntax in
+  match Keeper_meta_store.read_meta config command.keeper_id with
+  | Error detail -> Error (Metadata_materialization_failed detail)
+  | Ok (Some meta) when exact_paused_meta operation meta -> Ok meta
+  | Ok (Some _) ->
+    Error
+      (Metadata_materialization_failed
+         "existing metadata does not match the blocked purge identity and paused policy")
+  | Ok None ->
+    let* meta = paused_meta_from_profile ~config command operation in
+    let* committed =
+      Keeper_owner_registry.create_meta_for_shutdown
+        ~base_path:config.Workspace.base_path
+        ~operation_id:operation.operation_id
+        meta
+      |> Result.map_error (fun error ->
+        Metadata_materialization_failed
+          (Keeper_owner_registry.command_error_to_string error))
+    in
+    (match committed with
+     | Some committed when exact_paused_meta operation committed -> Ok committed
+     | Some _ ->
+       Error
+         (Metadata_materialization_failed
+            "committed metadata did not preserve the blocked purge identity")
+     | None -> Error (Metadata_materialization_failed "metadata disappeared during commit"))
+;;
+
+let finalize_reissued ~config operation =
+  match operation.Keeper_shutdown_types.phase with
+  | Joined_idle
+  | Finalizing_tasks _
+  | Cleanup_ready _
+  | Finalized _ ->
+    Keeper_shutdown_finalize.run ~config ~entry:None operation
+    |> Result.map_error (fun error -> Finalization_failed error)
+  | Prepared
+  | Joining_lanes
+  | Reconciliation_required _
+  | Blocked _
+  | Superseded _ ->
+    Error (Store_reissue_failed (Keeper_shutdown_store.Supersession_phase_mismatch operation))
+;;
+
+let fail_after_reissue_once : string option Atomic.t = Atomic.make None
 
 let execute ~config ~actor command =
   let open Result.Syntax in
-  let* release =
-    Keeper_shutdown_store.release_blocked_dashboard_purge
+  let* observed =
+    Keeper_shutdown_store.load
+      ~config
+      ~keeper_name:command.keeper_id
+      command.operation_id
+    |> Result.map_error (fun error -> Operation_load_failed error)
+  in
+  let already_reissued = operator_reissue_matches ~actor command observed in
+  let* (_meta : Keeper_meta_contract.keeper_meta option) =
+    if already_reissued
+    then Ok None
+    else ensure_paused_meta ~config command observed |> Result.map Option.some
+  in
+  let* reissue =
+    Keeper_shutdown_store.reissue_blocked_dashboard_purge
       ~config
       ~keeper_name:command.keeper_id
       ~operation_id:command.operation_id
@@ -247,23 +429,32 @@ let execute ~config ~actor command =
       ~actor
       ~reason:command.reason
       ~now:Masc_domain.now_iso
-    |> Result.map_error (fun error -> Store_release_failed error)
+    |> Result.map_error (fun error -> Store_reissue_failed error)
   in
-  let operation, already_released =
-    match release with
-    | Keeper_shutdown_store.Superseded_persisted operation -> operation, false
-    | Keeper_shutdown_store.Superseded_already_persisted operation -> operation, true
+  let reissued, already_reissued =
+    match reissue with
+    | Keeper_shutdown_store.Purge_reissue_persisted operation -> operation, false
+    | Keeper_shutdown_store.Purge_reissue_already_persisted operation ->
+      operation, true
   in
-  let* () = release_admission ~config operation in
-  Ok { operation; already_released }
+  let* () =
+    match Atomic.exchange fail_after_reissue_once None with
+    | None -> Ok ()
+    | Some detail -> Error (Injected_after_reissue detail)
+  in
+  let* operation = finalize_reissued ~config reissued in
+  Ok { operation; already_reissued }
 ;;
 
-let audit config ~actor command ~outcome =
-  try
+let audit_writer
+    : (Workspace.config -> actor:string -> command -> outcome:Audit_log.outcome -> unit)
+        Atomic.t
+  =
+  Atomic.make (fun config ~actor command ~outcome ->
     Audit_log.log_action
       config
       ~agent_id:actor
-      ~action:(Audit_log.Custom "keeper_blocked_purge_release")
+      ~action:(Audit_log.Custom "keeper_blocked_purge_reissue")
       ~details:
         (`Assoc
           [ "keeper_id", `String command.keeper_id
@@ -274,7 +465,11 @@ let audit config ~actor command ~outcome =
           ; "reason", `String command.reason
           ])
       ~outcome
-      ();
+      ())
+
+let audit config ~actor command ~outcome =
+  try
+    Atomic.get audit_writer config ~actor command ~outcome;
     Ok ()
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -290,17 +485,51 @@ let success_json ~audit command released =
       , `String (Keeper_shutdown_types.Operation_id.to_string command.operation_id) )
     ; "expected_revision", `Int command.expected_revision
     ; "revision", `Int released.operation.Keeper_shutdown_types.revision
-    ; "already_released", `Bool released.already_released
-    ; "admission_released", `Bool true
-    ; ( "next_action"
-      , `String "materialize_keeper_paused_then_reissue_exact_purge" )
+    ; "already_reissued", `Bool released.already_reissued
+    ; "phase", `String (Keeper_shutdown_types.phase_to_string released.operation.phase)
+    ; "audit_durable", `Bool true
+    ; "purge_reissue_completed", `Bool true
     ; "audit", audit
     ]
 ;;
 
+module For_testing = struct
+  let reset_audit_writer () =
+    Atomic.set audit_writer (fun config ~actor command ~outcome ->
+      Audit_log.log_action
+        config
+        ~agent_id:actor
+        ~action:(Audit_log.Custom "keeper_blocked_purge_reissue")
+        ~details:
+          (`Assoc
+            [ "keeper_id", `String command.keeper_id
+            ; ( "operation_id"
+              , `String
+                  (Keeper_shutdown_types.Operation_id.to_string command.operation_id) )
+            ; "expected_revision", `Int command.expected_revision
+            ; "reason", `String command.reason
+            ])
+        ~outcome
+        ())
+  ;;
+
+  let fail_next_audit_write detail =
+    let failed = Atomic.make false in
+    let fallback = Atomic.get audit_writer in
+    Atomic.set audit_writer (fun config ~actor command ~outcome ->
+      if Atomic.compare_and_set failed false true
+      then raise (Sys_error detail)
+      else fallback config ~actor command ~outcome)
+  ;;
+
+  let fail_next_after_reissue detail =
+    Atomic.set fail_after_reissue_once (Some detail)
+  ;;
+end
+
 let error_json ~audit error =
   `Assoc
-    [ "error", `String "blocked_purge_release_failed"
+    [ "error", `String "blocked_purge_reissue_failed"
     ; "message", `String (error_to_string error)
     ; "audit", audit
     ]

--- a/lib/keeper/keeper_shutdown_blocked_purge_release.ml
+++ b/lib/keeper/keeper_shutdown_blocked_purge_release.ml
@@ -1,0 +1,307 @@
+let command_schema = "masc.keeper_shutdown.blocked_purge_release.command.v1"
+let result_schema = "masc.keeper_shutdown.blocked_purge_release.result.v1"
+
+type command =
+  { keeper_id : string
+  ; operation_id : Keeper_shutdown_types.Operation_id.t
+  ; expected_revision : int
+  ; reason : string
+  }
+
+type input_error =
+  | Object_required of string
+  | Duplicate_fields of string list
+  | Unsupported_fields of string list
+  | Missing_fields of string list
+  | Invalid_field of
+      { field : string
+      ; expectation : string
+      }
+  | Unsupported_schema of string
+
+type error =
+  | Store_release_failed of Keeper_shutdown_store.error
+  | Successor_lookup_failed of Keeper_shutdown_store.error
+  | Admission_reserved_by_other of Keeper_shutdown_types.Operation_id.t
+  | Admission_release_failed of string
+
+type released =
+  { operation : Keeper_shutdown_types.t
+  ; already_released : bool
+  }
+
+let input_error_to_string = function
+  | Object_required observed_kind ->
+    Printf.sprintf "blocked purge release command must be an object (received %s)" observed_kind
+  | Duplicate_fields fields ->
+    Printf.sprintf "blocked purge release command contains duplicate field(s): %s" (String.concat ", " fields)
+  | Unsupported_fields fields ->
+    Printf.sprintf "blocked purge release command contains unsupported field(s): %s" (String.concat ", " fields)
+  | Missing_fields fields ->
+    Printf.sprintf "blocked purge release command is missing required field(s): %s" (String.concat ", " fields)
+  | Invalid_field { field; expectation } -> Printf.sprintf "%s %s" field expectation
+  | Unsupported_schema schema -> Printf.sprintf "unsupported blocked purge release schema %S" schema
+;;
+
+let input_error_to_json error =
+  let kind, details =
+    match error with
+    | Object_required observed_kind ->
+      "object_required", [ "observed_kind", `String observed_kind ]
+    | Duplicate_fields fields ->
+      "duplicate_fields", [ "fields", `List (List.map (fun field -> `String field) fields) ]
+    | Unsupported_fields fields ->
+      "unsupported_fields", [ "fields", `List (List.map (fun field -> `String field) fields) ]
+    | Missing_fields fields ->
+      "missing_fields", [ "fields", `List (List.map (fun field -> `String field) fields) ]
+    | Invalid_field { field; expectation } ->
+      "invalid_field", [ "field", `String field; "expectation", `String expectation ]
+    | Unsupported_schema schema ->
+      "unsupported_schema", [ "schema", `String schema ]
+  in
+  `Assoc
+    ([ "error", `String "blocked_purge_release_invalid_input"
+     ; "kind", `String kind
+     ; "message", `String (input_error_to_string error)
+     ]
+     @ details)
+;;
+
+let expected_fields =
+  [ "schema"; "keeper_id"; "operation_id"; "expected_revision"; "reason" ]
+;;
+
+let duplicate_fields fields =
+  let rec loop seen duplicates = function
+    | [] -> List.rev duplicates |> List.sort_uniq String.compare
+    | (field, _) :: rest ->
+      if List.mem field seen
+      then loop seen (field :: duplicates) rest
+      else loop (field :: seen) duplicates rest
+  in
+  loop [] [] fields
+;;
+
+let validate_exact_fields fields =
+  match duplicate_fields fields with
+  | _ :: _ as duplicates -> Error (Duplicate_fields duplicates)
+  | [] ->
+    let unsupported =
+      List.filter_map
+        (fun (field, _) -> if List.mem field expected_fields then None else Some field)
+        fields
+    in
+    let missing =
+      List.filter (fun field -> not (List.mem_assoc field fields)) expected_fields
+    in
+    if unsupported <> []
+    then Error (Unsupported_fields unsupported)
+    else if missing <> []
+    then Error (Missing_fields missing)
+    else Ok ()
+;;
+
+let required field fields =
+  match List.assoc_opt field fields with
+  | Some value -> Ok value
+  | None -> Error (Missing_fields [ field ])
+;;
+
+let exact_nonblank_string ?(max_length = max_int) ~field = function
+  | `String value
+    when not (String.equal value "")
+         && String.equal value (String.trim value)
+         && String.length value <= max_length ->
+    Ok value
+  | `String _ ->
+    Error
+      (Invalid_field
+         { field
+         ; expectation =
+             Printf.sprintf
+               "must be non-empty without surrounding whitespace and at most %d bytes"
+               max_length
+         })
+  | value ->
+    Error
+      (Invalid_field
+         { field
+         ; expectation =
+             Printf.sprintf "must be a string (received %s)" (Json_util.kind_name value)
+         })
+;;
+
+let positive_int ~field = function
+  | `Int value when value > 0 -> Ok value
+  | `Int _ -> Error (Invalid_field { field; expectation = "must be a positive integer" })
+  | value ->
+    Error
+      (Invalid_field
+         { field
+         ; expectation =
+             Printf.sprintf "must be an integer (received %s)" (Json_util.kind_name value)
+         })
+;;
+
+let parse_command = function
+  | `Assoc fields ->
+    let open Result.Syntax in
+    let* () = validate_exact_fields fields in
+    let* schema_json = required "schema" fields in
+    let* schema = exact_nonblank_string ~field:"schema" schema_json in
+    let* () =
+      if String.equal schema command_schema
+      then Ok ()
+      else Error (Unsupported_schema schema)
+    in
+    let* keeper_id_json = required "keeper_id" fields in
+    let* keeper_id = exact_nonblank_string ~field:"keeper_id" keeper_id_json in
+    let* () =
+      if Keeper_config.validate_name keeper_id
+      then Ok ()
+      else
+        Error
+          (Invalid_field
+             { field = "keeper_id"; expectation = "must be a valid Keeper id" })
+    in
+    let* operation_id_json = required "operation_id" fields in
+    let* operation_id_string =
+      exact_nonblank_string ~field:"operation_id" operation_id_json
+    in
+    let* operation_id =
+      Keeper_shutdown_types.Operation_id.of_string operation_id_string
+      |> Result.map_error (fun _ ->
+        Invalid_field
+          { field = "operation_id"
+          ; expectation = "must be a valid Keeper shutdown operation id"
+          })
+    in
+    let* expected_revision_json = required "expected_revision" fields in
+    let* expected_revision =
+      positive_int ~field:"expected_revision" expected_revision_json
+    in
+    let* reason_json = required "reason" fields in
+    let* reason = exact_nonblank_string ~max_length:1024 ~field:"reason" reason_json in
+    Ok { keeper_id; operation_id; expected_revision; reason }
+  | value -> Error (Object_required (Json_util.kind_name value))
+;;
+
+let error_to_string = function
+  | Store_release_failed error -> Keeper_shutdown_store.error_to_string error
+  | Successor_lookup_failed error ->
+    "blocked purge was released, but successor admission lookup failed: "
+    ^ Keeper_shutdown_store.error_to_string error
+  | Admission_reserved_by_other operation_id ->
+    Printf.sprintf
+      "blocked purge was released, but admission belongs to operation %s"
+      (Keeper_shutdown_types.Operation_id.to_string operation_id)
+  | Admission_release_failed detail ->
+    "blocked purge was released, but its admission fence could not be released: " ^ detail
+;;
+
+let release_admission ~config operation =
+  let open Result.Syntax in
+  let* successor_operation_id =
+    Keeper_shutdown_store.corrupt_operation_id_for_keeper
+      ~config
+      ~keeper_name:operation.Keeper_shutdown_types.keeper_name
+    |> Result.map_error (fun error -> Successor_lookup_failed error)
+  in
+  let transition () =
+    Keeper_owner_registry.transition_shutdown
+      ~base_path:config.Workspace.base_path
+      ~keeper_name:operation.keeper_name
+      ~from_operation_id:operation.operation_id
+      ~to_operation_id:successor_operation_id
+  in
+  match transition () with
+  | Ok Keeper_owner.Shutdown_transition_applied
+  | Ok Keeper_owner.Shutdown_transition_already_applied -> Ok ()
+  | Ok (Keeper_owner.Shutdown_transition_reserved_by_other existing) ->
+    Error (Admission_reserved_by_other existing)
+  | Error error ->
+    if Keeper_shutdown_finalize.admission_already_released_by_removal ~config operation error
+    then
+      (match
+         Keeper_shutdown_intake_fence.transition_shutdown
+           ~base_path:config.Workspace.base_path
+           ~keeper_name:operation.keeper_name
+           ~from_operation_id:operation.operation_id
+           ~to_operation_id:successor_operation_id
+       with
+       | Keeper_shutdown_intake_fence.Transition_applied
+       | Keeper_shutdown_intake_fence.Transition_already_applied -> Ok ()
+       | Keeper_shutdown_intake_fence.Transition_reserved_by_other existing ->
+         Error (Admission_reserved_by_other existing))
+    else Error (Admission_release_failed (Keeper_owner_registry.command_error_to_string error))
+;;
+
+let execute ~config ~actor command =
+  let open Result.Syntax in
+  let* release =
+    Keeper_shutdown_store.release_blocked_dashboard_purge
+      ~config
+      ~keeper_name:command.keeper_id
+      ~operation_id:command.operation_id
+      ~expected_revision:command.expected_revision
+      ~actor
+      ~reason:command.reason
+      ~now:Masc_domain.now_iso
+    |> Result.map_error (fun error -> Store_release_failed error)
+  in
+  let operation, already_released =
+    match release with
+    | Keeper_shutdown_store.Superseded_persisted operation -> operation, false
+    | Keeper_shutdown_store.Superseded_already_persisted operation -> operation, true
+  in
+  let* () = release_admission ~config operation in
+  Ok { operation; already_released }
+;;
+
+let audit config ~actor command ~outcome =
+  try
+    Audit_log.log_action
+      config
+      ~agent_id:actor
+      ~action:(Audit_log.Custom "keeper_blocked_purge_release")
+      ~details:
+        (`Assoc
+          [ "keeper_id", `String command.keeper_id
+          ; ( "operation_id"
+            , `String
+                (Keeper_shutdown_types.Operation_id.to_string command.operation_id) )
+          ; "expected_revision", `Int command.expected_revision
+          ; "reason", `String command.reason
+          ])
+      ~outcome
+      ();
+    Ok ()
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Printexc.to_string exn)
+;;
+
+let success_json ~audit command released =
+  `Assoc
+    [ "schema", `String result_schema
+    ; "ok", `Bool true
+    ; "keeper_id", `String command.keeper_id
+    ; ( "operation_id"
+      , `String (Keeper_shutdown_types.Operation_id.to_string command.operation_id) )
+    ; "expected_revision", `Int command.expected_revision
+    ; "revision", `Int released.operation.Keeper_shutdown_types.revision
+    ; "already_released", `Bool released.already_released
+    ; "admission_released", `Bool true
+    ; ( "next_action"
+      , `String "materialize_keeper_paused_then_reissue_exact_purge" )
+    ; "audit", audit
+    ]
+;;
+
+let error_json ~audit error =
+  `Assoc
+    [ "error", `String "blocked_purge_release_failed"
+    ; "message", `String (error_to_string error)
+    ; "audit", audit
+    ]
+;;

--- a/lib/keeper/keeper_shutdown_blocked_purge_release.mli
+++ b/lib/keeper/keeper_shutdown_blocked_purge_release.mli
@@ -1,6 +1,7 @@
-(** Authenticated operator command for releasing one exact blocked dashboard
-    purge. The HTTP adapter owns authentication; this module owns strict input,
-    store CAS, durable release audit, and admission-fence release. *)
+(** Authenticated operator command for reissuing one exact blocked dashboard
+    purge without opening admission. The HTTP adapter owns authentication;
+    this module owns strict input, paused recovery materialization, store CAS,
+    durable intent/audit, and synchronous finalization. *)
 
 val command_schema : string
 val result_schema : string
@@ -24,14 +25,16 @@ type input_error =
   | Unsupported_schema of string
 
 type error =
-  | Store_release_failed of Keeper_shutdown_store.error
-  | Successor_lookup_failed of Keeper_shutdown_store.error
-  | Admission_reserved_by_other of Keeper_shutdown_types.Operation_id.t
-  | Admission_release_failed of string
+  | Operation_load_failed of Keeper_shutdown_store.error
+  | Profile_materialization_failed of string
+  | Metadata_materialization_failed of string
+  | Store_reissue_failed of Keeper_shutdown_store.error
+  | Finalization_failed of Keeper_shutdown_finalize.error
+  | Injected_after_reissue of string
 
 type released =
   { operation : Keeper_shutdown_types.t
-  ; already_released : bool
+  ; already_reissued : bool
   }
 
 val input_error_to_string : input_error -> string
@@ -56,3 +59,9 @@ val success_json :
   audit:Yojson.Safe.t -> command -> released -> Yojson.Safe.t
 
 val error_json : audit:Yojson.Safe.t -> error -> Yojson.Safe.t
+
+module For_testing : sig
+  val fail_next_audit_write : string -> unit
+  val fail_next_after_reissue : string -> unit
+  val reset_audit_writer : unit -> unit
+end

--- a/lib/keeper/keeper_shutdown_blocked_purge_release.mli
+++ b/lib/keeper/keeper_shutdown_blocked_purge_release.mli
@@ -1,0 +1,58 @@
+(** Authenticated operator command for releasing one exact blocked dashboard
+    purge. The HTTP adapter owns authentication; this module owns strict input,
+    store CAS, durable release audit, and admission-fence release. *)
+
+val command_schema : string
+val result_schema : string
+
+type command =
+  { keeper_id : string
+  ; operation_id : Keeper_shutdown_types.Operation_id.t
+  ; expected_revision : int
+  ; reason : string
+  }
+
+type input_error =
+  | Object_required of string
+  | Duplicate_fields of string list
+  | Unsupported_fields of string list
+  | Missing_fields of string list
+  | Invalid_field of
+      { field : string
+      ; expectation : string
+      }
+  | Unsupported_schema of string
+
+type error =
+  | Store_release_failed of Keeper_shutdown_store.error
+  | Successor_lookup_failed of Keeper_shutdown_store.error
+  | Admission_reserved_by_other of Keeper_shutdown_types.Operation_id.t
+  | Admission_release_failed of string
+
+type released =
+  { operation : Keeper_shutdown_types.t
+  ; already_released : bool
+  }
+
+val input_error_to_string : input_error -> string
+val input_error_to_json : input_error -> Yojson.Safe.t
+val parse_command : Yojson.Safe.t -> (command, input_error) result
+val error_to_string : error -> string
+
+val execute :
+  config:Workspace.config ->
+  actor:string ->
+  command ->
+  (released, error) result
+
+val audit :
+  Workspace.config ->
+  actor:string ->
+  command ->
+  outcome:Audit_log.outcome ->
+  (unit, string) result
+
+val success_json :
+  audit:Yojson.Safe.t -> command -> released -> Yojson.Safe.t
+
+val error_json : audit:Yojson.Safe.t -> error -> Yojson.Safe.t

--- a/lib/keeper/keeper_shutdown_blocked_purge_release.mli
+++ b/lib/keeper/keeper_shutdown_blocked_purge_release.mli
@@ -58,6 +58,12 @@ val audit :
 val success_json :
   audit:Yojson.Safe.t -> command -> released -> Yojson.Safe.t
 
+val reissue_same_command_json : actor:string -> command -> Yojson.Safe.t
+(** Exact operator action returned when the immutable audit append fails after
+    the operation intent is already durable. This is not generic retry
+    authority: callers must resubmit the same actor, operation identity,
+    reason, and expected revision. *)
+
 val error_json : audit:Yojson.Safe.t -> error -> Yojson.Safe.t
 
 module For_testing : sig

--- a/lib/keeper/keeper_shutdown_finalize.ml
+++ b/lib/keeper/keeper_shutdown_finalize.ml
@@ -12,7 +12,7 @@ let error_to_string = function
   | Store_error error -> Keeper_shutdown_store.error_to_string error
   | Unsupported_phase -> "Keeper shutdown operation is not ready for finalization"
   | Finalization_blocked
-      ({ phase = Blocked { stage; detail }; _ } as operation) ->
+      ({ phase = Blocked { stage; detail; _ }; _ } as operation) ->
     Printf.sprintf
       "Keeper shutdown finalization blocked in operation %s at %s: %s"
       (Operation_id.to_string operation.operation_id)
@@ -77,16 +77,68 @@ let replace ~config operation =
   |> Result.map_error (fun error -> Store_error error)
 ;;
 
+let blocked_resume_of_phase = function
+  | Joined_idle -> Some Resume_joined_idle
+  | Finalizing_tasks settled_task_ids ->
+    Some (Resume_finalizing_tasks settled_task_ids)
+  | Cleanup_ready cleanup -> Some (Resume_cleanup_ready cleanup)
+  | Blocked failure -> failure.resume
+  | Prepared
+  | Joining_lanes
+  | Reconciliation_required _
+  | Finalized _
+  | Superseded _ -> None
+;;
+
+let has_operator_purge_reissue operation =
+  match operation.join_evidence with
+  | Some { lane_outcome = Lane_operator_purge_reissue _; _ } -> true
+  | Some
+      { lane_outcome =
+          ( Lane_completed
+          | Lane_shutdown_requested
+          | Lane_cancelled_by_parent _
+          | Lane_failed _ )
+      ; _
+      }
+  | None -> false
+;;
+
 let block ~config operation stage detail =
   let blocked =
     { operation with
-      phase = Blocked { stage; detail }
+      phase =
+        Blocked
+          { stage
+          ; detail
+          ; resume =
+              (if has_operator_purge_reissue operation
+               then blocked_resume_of_phase operation.phase
+               else None)
+          }
     ; updated_at = Masc_domain.now_iso ()
     }
   in
   match replace ~config blocked with
   | Ok persisted -> Error (Finalization_blocked persisted)
   | Error _ as error -> error
+;;
+
+let injected_failure_stage : failure_stage option Atomic.t = Atomic.make None
+
+let rec take_injected_failure stage =
+  let current = Atomic.get injected_failure_stage in
+  match current with
+  | Some injected when injected = stage ->
+    Atomic.compare_and_set injected_failure_stage current None
+    || take_injected_failure stage
+  | Some _ | None -> false
+;;
+
+let inject_or_run ~config operation stage run =
+  if take_injected_failure stage
+  then block ~config operation stage "injected finalization failure"
+  else run ()
 ;;
 
 let task_id_equal = Keeper_id.Task_id.equal
@@ -407,30 +459,31 @@ let prepare_cleanup ~config ~entry operation settled_task_ids =
     (match validate_registry_owner_exact ~config operation with
      | Error detail -> block ~config operation Meta_update detail
      | Ok () ->
-         (match
-            Atomic.get remove_pending_confirms_by_target_callback
-              config
-              ~target_type:Operator_action_constants.Keeper
-              ~target_id:(Some operation.keeper_name)
-          with
-          | Error detail -> block ~config operation Pending_confirm_cleanup detail
-          | Ok pending_confirms_removed ->
-            let cleanup =
-              { settled_task_ids
-              ; pending_confirms_removed
-              ; meta_snapshot_digest =
-                  Keeper_meta_json.Snapshot_digest.of_meta prepared_meta
-              }
-            in
-            let ready =
-              { operation with
-                phase = Cleanup_ready cleanup
-              ; updated_at = Masc_domain.now_iso ()
-              }
-            in
-            (match replace ~config ready with
-             | Ok persisted -> Ok persisted
-             | Error _ as error -> error)))
+         inject_or_run ~config operation Pending_confirm_cleanup (fun () ->
+           match
+             Atomic.get remove_pending_confirms_by_target_callback
+               config
+               ~target_type:Operator_action_constants.Keeper
+               ~target_id:(Some operation.keeper_name)
+           with
+           | Error detail -> block ~config operation Pending_confirm_cleanup detail
+           | Ok pending_confirms_removed ->
+             let cleanup =
+               { settled_task_ids
+               ; pending_confirms_removed
+               ; meta_snapshot_digest =
+                   Keeper_meta_json.Snapshot_digest.of_meta prepared_meta
+               }
+             in
+             let ready =
+               { operation with
+                 phase = Cleanup_ready cleanup
+               ; updated_at = Masc_domain.now_iso ()
+               }
+             in
+             (match replace ~config ready with
+              | Ok persisted -> Ok persisted
+              | Error _ as error -> error)))
 ;;
 
 let rec remove_tree_blocking path =
@@ -724,12 +777,14 @@ let complete_cleanup
                     error))))
   in
   let finish registry_unregistered =
-    match remove_meta_file ~config operation cleanup with
-    | Error detail -> block ~config operation Meta_remove detail
-    | Ok () ->
-      (match remove_session_dir ~config operation with
-       | Error detail -> block ~config operation Session_remove detail
-       | Ok () ->
+    inject_or_run ~config operation Meta_remove (fun () ->
+      match remove_meta_file ~config operation cleanup with
+      | Error detail -> block ~config operation Meta_remove detail
+      | Ok () ->
+        inject_or_run ~config operation Session_remove (fun () ->
+          match remove_session_dir ~config operation with
+          | Error detail -> block ~config operation Session_remove detail
+          | Ok () ->
          let meta_removed =
            match meta_disposition_of_cleanup_reason operation.cleanup_intent.reason with
            | Remove_meta -> true
@@ -771,65 +826,86 @@ let complete_cleanup
            deliver_finalized_completion
              ~config
              ?successor_operation_id
-             persisted_finalized)
+             persisted_finalized))
   in
-  match validate_exact_registry_generation ~base_path:config.base_path operation entry with
-  | Error detail -> block ~config operation Registry_unregister detail
-  | Ok () ->
-    (match require_released_summary_owner () with
-     | Error (`Draining detail) ->
-       Error (Finalization_draining (operation, detail))
-     | Error (`Failed detail) ->
-       block ~config operation Approval_summary_retirement detail
-     | Ok () ->
-       (match
-          unregister_retired_exact ~base_path:config.base_path operation entry
-        with
-        | Error detail -> block ~config operation Registry_unregister detail
-        | Ok registry_unregistered -> finish registry_unregistered))
+  inject_or_run ~config operation Registry_unregister (fun () ->
+    match validate_exact_registry_generation ~base_path:config.base_path operation entry with
+    | Error detail -> block ~config operation Registry_unregister detail
+    | Ok () ->
+      inject_or_run ~config operation Approval_summary_retirement (fun () ->
+        match require_released_summary_owner () with
+        | Error (`Draining detail) ->
+          Error (Finalization_draining (operation, detail))
+        | Error (`Failed detail) ->
+          block ~config operation Approval_summary_retirement detail
+        | Ok () ->
+          (match
+             unregister_retired_exact ~base_path:config.base_path operation entry
+           with
+           | Error detail -> block ~config operation Registry_unregister detail
+           | Ok registry_unregistered -> finish registry_unregistered)))
+;;
+
+let run_from_tasks
+      ~config
+      ~entry
+      ?successor_operation_id
+      operation
+      settled_task_ids
+  =
+  inject_or_run ~config operation Meta_update (fun () ->
+    match read_operation_meta ~config operation with
+    | Error detail -> block ~config operation Meta_update detail
+    | Ok meta ->
+      inject_or_run ~config operation Task_settlement (fun () ->
+        match settle_tasks ~config ~meta operation settled_task_ids with
+        | Error _ as error -> error
+        | Ok (settled_operation, settled_task_ids) ->
+          (match prepare_cleanup ~config ~entry settled_operation settled_task_ids with
+           | Error _ as error -> error
+           | Ok ready ->
+             (match ready.phase with
+              | Cleanup_ready cleanup ->
+                complete_cleanup
+                  ~config
+                  ~entry
+                  ?successor_operation_id
+                  ready
+                  cleanup
+              | _ -> Error Unsupported_phase))))
 ;;
 
 let run ~config ~entry ?successor_operation_id operation =
   match operation.phase with
   | Joined_idle ->
-    (match read_operation_meta ~config operation with
-     | Error detail -> block ~config operation Meta_update detail
-     | Ok meta ->
-       (match settle_tasks ~config ~meta operation [] with
-        | Error _ as error -> error
-        | Ok (settled_operation, settled_task_ids) ->
-          (match prepare_cleanup ~config ~entry settled_operation settled_task_ids with
-           | Error _ as error -> error
-           | Ok ready ->
-             (match ready.phase with
-              | Cleanup_ready cleanup ->
-                complete_cleanup
-                  ~config
-                  ~entry
-                  ?successor_operation_id
-                  ready
-                  cleanup
-              | _ -> Error Unsupported_phase))))
+    run_from_tasks ~config ~entry ?successor_operation_id operation []
   | Finalizing_tasks settled_task_ids ->
-    (match read_operation_meta ~config operation with
-     | Error detail -> block ~config operation Meta_update detail
-     | Ok meta ->
-       (match settle_tasks ~config ~meta operation settled_task_ids with
-        | Error _ as error -> error
-        | Ok (settled_operation, settled_task_ids) ->
-          (match prepare_cleanup ~config ~entry settled_operation settled_task_ids with
-           | Error _ as error -> error
-           | Ok ready ->
-             (match ready.phase with
-              | Cleanup_ready cleanup ->
-                complete_cleanup
-                  ~config
-                  ~entry
-                  ?successor_operation_id
-                  ready
-                  cleanup
-              | _ -> Error Unsupported_phase))))
+    run_from_tasks
+      ~config
+      ~entry
+      ?successor_operation_id
+      operation
+      settled_task_ids
   | Cleanup_ready cleanup ->
+    complete_cleanup
+      ~config
+      ~entry
+      ?successor_operation_id
+      operation
+      cleanup
+  | Blocked { resume = Some Resume_joined_idle; _ }
+    when has_operator_purge_reissue operation ->
+    run_from_tasks ~config ~entry ?successor_operation_id operation []
+  | Blocked { resume = Some (Resume_finalizing_tasks settled_task_ids); _ }
+    when has_operator_purge_reissue operation ->
+    run_from_tasks
+      ~config
+      ~entry
+      ?successor_operation_id
+      operation
+      settled_task_ids
+  | Blocked { resume = Some (Resume_cleanup_ready cleanup); _ }
+    when has_operator_purge_reissue operation ->
     complete_cleanup
       ~config
       ~entry
@@ -862,5 +938,9 @@ module For_testing = struct
     Atomic.set completion_handler (fun _config _operation _action ->
       Error "shutdown completion handler is not registered")
   ;;
+
+  let fail_next_at_stage stage = Atomic.set injected_failure_stage (Some stage)
+
+  let reset_failure_injection () = Atomic.set injected_failure_stage None
 
 end

--- a/lib/keeper/keeper_shutdown_finalize.mli
+++ b/lib/keeper/keeper_shutdown_finalize.mli
@@ -66,5 +66,7 @@ module For_testing : sig
 
   val reset_remove_pending_confirms_by_target : unit -> unit
   val reset_completion_handler : unit -> unit
+  val fail_next_at_stage : Keeper_shutdown_types.failure_stage -> unit
+  val reset_failure_injection : unit -> unit
 
 end

--- a/lib/keeper/keeper_shutdown_intake_fence.ml
+++ b/lib/keeper/keeper_shutdown_intake_fence.ml
@@ -202,6 +202,9 @@ let run_durable_intake_for_shutdown
   =
   let slot = slot_for ~base_path ~keeper_name in
   Eio.Mutex.lock slot.intake_mu;
+  (* fun-protect-finally-ok: [Eio.Mutex.unlock] is a non-suspending release;
+     it must run on cancellation so shutdown-owned recovery cannot strand the
+     keeper intake lock. *)
   Fun.protect
     ~finally:(fun () -> Eio.Mutex.unlock slot.intake_mu)
     (fun () ->

--- a/lib/keeper/keeper_shutdown_intake_fence.ml
+++ b/lib/keeper/keeper_shutdown_intake_fence.ml
@@ -28,6 +28,12 @@ type 'a durable_intake_result =
   | Intake_committed of 'a
   | Intake_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
 
+type 'a shutdown_owned_intake_result =
+  | Shutdown_owned_intake_committed of 'a
+  | Shutdown_owned_intake_not_reserved
+  | Shutdown_owned_intake_reserved_by_other of
+      Keeper_shutdown_types.Operation_id.t
+
 type 'a transfer_intake_result =
   | Transfer_intake_committed of 'a
   | Transfer_intake_source_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
@@ -37,6 +43,7 @@ type slot =
   { base_path : string
   ; keeper_name : string
   ; intake_mu : Eio.Mutex.t
+  ; transition_mu : Cross_context_mutex.t
   ; state_mu : Stdlib.Mutex.t
   ; mutable shutdown_operation_id : Keeper_shutdown_types.Operation_id.t option
   }
@@ -60,6 +67,7 @@ let slot_for ~base_path ~keeper_name =
         { base_path
         ; keeper_name
         ; intake_mu = Eio.Mutex.create ()
+        ; transition_mu = Cross_context_mutex.create ()
         ; state_mu = Stdlib.Mutex.create ()
         ; shutdown_operation_id = None
         }
@@ -80,38 +88,42 @@ let peek_shutdown slot =
 
 let begin_shutdown ~base_path ~keeper_name ~operation_id =
   let slot = slot_for ~base_path ~keeper_name in
-  Stdlib.Mutex.protect slot.state_mu (fun () ->
-    match slot.shutdown_operation_id with
-    | None ->
-      slot.shutdown_operation_id <- Some operation_id;
-      Reserved { operation_id }
-    | Some existing -> Already_reserved { operation_id = existing })
+  Cross_context_mutex.with_durable_lock slot.transition_mu (fun () ->
+    Stdlib.Mutex.protect slot.state_mu (fun () ->
+      match slot.shutdown_operation_id with
+      | None ->
+        slot.shutdown_operation_id <- Some operation_id;
+        Reserved { operation_id }
+      | Some existing -> Already_reserved { operation_id = existing }))
 ;;
 
 let rollback_shutdown ~base_path ~keeper_name ~operation_id =
   match find_slot ~base_path ~keeper_name with
   | None -> Not_reserved
   | Some slot ->
-    Stdlib.Mutex.protect slot.state_mu (fun () ->
-      match slot.shutdown_operation_id with
-      | None -> Not_reserved
-      | Some existing
-        when Keeper_shutdown_types.Operation_id.equal existing operation_id ->
-        slot.shutdown_operation_id <- None;
-        Rolled_back
-      | Some existing -> Reserved_by_other existing)
+    Cross_context_mutex.with_durable_lock slot.transition_mu (fun () ->
+      Stdlib.Mutex.protect slot.state_mu (fun () ->
+        match slot.shutdown_operation_id with
+        | None -> Not_reserved
+        | Some existing
+          when Keeper_shutdown_types.Operation_id.equal existing operation_id ->
+          slot.shutdown_operation_id <- None;
+          Rolled_back
+        | Some existing -> Reserved_by_other existing))
 ;;
 
 let restore_shutdown ~base_path ~keeper_name ~operation_id =
   let slot = slot_for ~base_path ~keeper_name in
-  Stdlib.Mutex.protect slot.state_mu (fun () ->
-    match slot.shutdown_operation_id with
-    | None ->
-      slot.shutdown_operation_id <- Some operation_id;
-      Restored
-    | Some existing when Keeper_shutdown_types.Operation_id.equal existing operation_id ->
-      Already_restored
-    | Some existing -> Restore_conflict existing)
+  Cross_context_mutex.with_durable_lock slot.transition_mu (fun () ->
+    Stdlib.Mutex.protect slot.state_mu (fun () ->
+      match slot.shutdown_operation_id with
+      | None ->
+        slot.shutdown_operation_id <- Some operation_id;
+        Restored
+      | Some existing
+        when Keeper_shutdown_types.Operation_id.equal existing operation_id ->
+        Already_restored
+      | Some existing -> Restore_conflict existing))
 ;;
 
 let transition_shutdown
@@ -128,20 +140,23 @@ let transition_shutdown
   match slot with
   | None -> Transition_already_applied
   | Some slot ->
-    Stdlib.Mutex.protect slot.state_mu (fun () ->
-      match slot.shutdown_operation_id, to_operation_id with
-      | Some existing, _
-        when Keeper_shutdown_types.Operation_id.equal existing from_operation_id ->
-        slot.shutdown_operation_id <- to_operation_id;
-        Transition_applied
-      | None, None -> Transition_already_applied
-      | Some existing, Some successor
-        when Keeper_shutdown_types.Operation_id.equal existing successor ->
-        Transition_already_applied
-      | None, Some successor ->
-        slot.shutdown_operation_id <- Some successor;
-        Transition_applied
-      | Some existing, _ -> Transition_reserved_by_other existing)
+    Cross_context_mutex.with_durable_lock slot.transition_mu (fun () ->
+      Stdlib.Mutex.protect slot.state_mu (fun () ->
+        match slot.shutdown_operation_id, to_operation_id with
+        | Some existing, _
+          when Keeper_shutdown_types.Operation_id.equal
+                 existing
+                 from_operation_id ->
+          slot.shutdown_operation_id <- to_operation_id;
+          Transition_applied
+        | None, None -> Transition_already_applied
+        | Some existing, Some successor
+          when Keeper_shutdown_types.Operation_id.equal existing successor ->
+          Transition_already_applied
+        | None, Some successor ->
+          slot.shutdown_operation_id <- Some successor;
+          Transition_applied
+        | Some existing, _ -> Transition_reserved_by_other existing))
 ;;
 
 let shutdown_operation_id ~base_path ~keeper_name =
@@ -177,6 +192,33 @@ let run_durable_intake_if_open ~base_path ~keeper_name intake =
        token.intake_active <- false;
        release ();
        raise exn)
+;;
+
+let run_durable_intake_for_shutdown
+      ~base_path
+      ~keeper_name
+      ~operation_id
+      intake
+  =
+  let slot = slot_for ~base_path ~keeper_name in
+  Eio.Mutex.lock slot.intake_mu;
+  Fun.protect
+    ~finally:(fun () -> Eio.Mutex.unlock slot.intake_mu)
+    (fun () ->
+       Cross_context_mutex.with_durable_lock slot.transition_mu (fun () ->
+         match peek_shutdown slot with
+         | None -> Shutdown_owned_intake_not_reserved
+         | Some existing
+           when not
+                  (Keeper_shutdown_types.Operation_id.equal
+                     existing
+                     operation_id) ->
+           Shutdown_owned_intake_reserved_by_other existing
+         | Some _ ->
+           let token = { intake_slot = slot; intake_active = true } in
+           Fun.protect
+             ~finally:(fun () -> token.intake_active <- false)
+             (fun () -> Shutdown_owned_intake_committed (intake token))))
 ;;
 
 let run_transfer_intake_if_open

--- a/lib/keeper/keeper_shutdown_intake_fence.mli
+++ b/lib/keeper/keeper_shutdown_intake_fence.mli
@@ -33,6 +33,12 @@ type 'a durable_intake_result =
   | Intake_committed of 'a
   | Intake_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
 
+type 'a shutdown_owned_intake_result =
+  | Shutdown_owned_intake_committed of 'a
+  | Shutdown_owned_intake_not_reserved
+  | Shutdown_owned_intake_reserved_by_other of
+      Keeper_shutdown_types.Operation_id.t
+
 type 'a transfer_intake_result =
   | Transfer_intake_committed of 'a
   | Transfer_intake_source_shutdown_reserved of Keeper_shutdown_types.Operation_id.t
@@ -81,6 +87,17 @@ val run_durable_intake_if_open
   -> keeper_name:string
   -> (intake_token -> 'a)
   -> 'a durable_intake_result
+
+(** Run one recovery-only intake while the exact shutdown operation continues
+    to own the fence. This never opens admission. It exists so an operator can
+    materialize the paused metadata needed to finish a remove-meta purge
+    without admitting create, keepalive, or ordinary durable intake. *)
+val run_durable_intake_for_shutdown :
+  base_path:string ->
+  keeper_name:string ->
+  operation_id:Keeper_shutdown_types.Operation_id.t ->
+  (intake_token -> 'a) ->
+  'a shutdown_owned_intake_result
 
 val run_transfer_intake_if_open
   :  base_path:string

--- a/lib/keeper/keeper_shutdown_prepare_join.ml
+++ b/lib/keeper/keeper_shutdown_prepare_join.ml
@@ -145,7 +145,7 @@ let persist_blocked ~config operation stage detail =
   let blocked =
     { operation with
       revision = operation.revision + 1
-    ; phase = Blocked { stage; detail }
+    ; phase = Blocked { stage; detail; resume = None }
     ; updated_at = Masc_domain.now_iso ()
     }
   in

--- a/lib/keeper/keeper_shutdown_runtime.ml
+++ b/lib/keeper/keeper_shutdown_runtime.ml
@@ -263,7 +263,7 @@ let persist_unhandled_failure
       Keeper_shutdown_store.persist_blocked_latest
         ~config
         ~identity:operation
-        ~failure:{ stage = Unhandled_worker; detail }
+        ~failure:{ stage = Unhandled_worker; detail; resume = None }
         ~now
     with
     | Ok (Keeper_shutdown_store.Blocked_persisted blocked) ->
@@ -519,6 +519,7 @@ let blocked_interrupted_join_state (operation : Keeper_shutdown_types.t) =
         { stage = Lane_join
         ; detail =
             "server process ended while joining Keeper and Librarian lanes; Librarian completion is unknown"
+        ; resume = None
         }
   ; updated_at = Masc_domain.now_iso ()
   }

--- a/lib/keeper/keeper_shutdown_store.ml
+++ b/lib/keeper/keeper_shutdown_store.ml
@@ -17,6 +17,7 @@ type error =
   | Supersession_intent_mismatch of Keeper_shutdown_types.t
   | Invalid_supersession_actor of string
   | Invalid_supersession_reason of string
+  | Invalid_purge_recovery_proof of string
 
 type persist_blocked_result =
   | State_preserved of Keeper_shutdown_types.t
@@ -28,6 +29,19 @@ type supersede_blocked_result =
 
 type reissue_blocked_purge_result =
   | Purge_reissue_persisted of Keeper_shutdown_types.t
+
+type blocked_purge_reissue_token =
+  { base_path : string
+  ; keeper_name : string
+  ; operation_id : Operation_id.t
+  ; expected_revision : int
+  ; actor : string
+  ; reason : string
+  }
+
+type prepare_blocked_purge_reissue_result =
+  | Purge_reissue_initial_prepared of
+      blocked_purge_reissue_token * Keeper_shutdown_types.t
   | Purge_reissue_already_persisted of Keeper_shutdown_types.t
 
 (* What the operator is releasing. [Blocked_operator_stop] carries no
@@ -116,6 +130,8 @@ let error_to_string = function
     Printf.sprintf "shutdown supersession actor is invalid: %s" detail
   | Invalid_supersession_reason detail ->
     Printf.sprintf "shutdown supersession reason is invalid: %s" detail
+  | Invalid_purge_recovery_proof detail ->
+    Printf.sprintf "blocked purge recovery proof is invalid: %s" detail
 ;;
 
 type lock_access =
@@ -234,13 +250,6 @@ let turn_disposition_to_json = function
       ]
 ;;
 
-let failure_to_json failure =
-  `Assoc
-    [ "stage", `String (failure_stage_to_string failure.stage)
-    ; "detail", `String failure.detail
-    ]
-;;
-
 let task_ids_to_json task_ids =
   `List
     (List.map
@@ -256,6 +265,31 @@ let cleanup_evidence_to_json evidence =
       , `String
           (Keeper_meta_json.Snapshot_digest.to_string
              evidence.meta_snapshot_digest) )
+    ]
+;;
+
+let blocked_resume_to_json = function
+  | Resume_joined_idle -> `Assoc [ "kind", `String "joined_idle" ]
+  | Resume_finalizing_tasks settled_task_ids ->
+    `Assoc
+      [ "kind", `String "finalizing_tasks"
+      ; "settled_task_ids", task_ids_to_json settled_task_ids
+      ]
+  | Resume_cleanup_ready cleanup ->
+    `Assoc
+      [ "kind", `String "cleanup_ready"
+      ; "evidence", cleanup_evidence_to_json cleanup
+      ]
+;;
+
+let failure_to_json failure =
+  `Assoc
+    [ "stage", `String (failure_stage_to_string failure.stage)
+    ; "detail", `String failure.detail
+    ; ( "resume"
+      , match failure.resume with
+        | None -> `Null
+        | Some resume -> blocked_resume_to_json resume )
     ]
 ;;
 
@@ -526,13 +560,6 @@ let turn_disposition_of_json json =
   | value -> Error (Decode_error (Printf.sprintf "unknown turn disposition: %S" value))
 ;;
 
-let failure_of_json json =
-  let* stage_wire = string "stage" json in
-  let* stage = failure_stage_of_string stage_wire |> Result.map_error (fun e -> Decode_error e) in
-  let* detail = string "detail" json in
-  Ok { stage; detail }
-;;
-
 let task_ids_field_of_json field json =
   match assoc field json with
   | Error _ as error -> error
@@ -563,6 +590,38 @@ let cleanup_evidence_of_json json =
     |> Result.map_error (fun detail -> Decode_error detail)
   in
   Ok { settled_task_ids; pending_confirms_removed; meta_snapshot_digest }
+;;
+
+let blocked_resume_of_json json =
+  let* kind = string "kind" json in
+  match kind with
+  | "joined_idle" -> Ok Resume_joined_idle
+  | "finalizing_tasks" ->
+    let* settled_task_ids = task_ids_field_of_json "settled_task_ids" json in
+    Ok (Resume_finalizing_tasks settled_task_ids)
+  | "cleanup_ready" ->
+    let* evidence_json = assoc "evidence" json in
+    let* cleanup = cleanup_evidence_of_json evidence_json in
+    Ok (Resume_cleanup_ready cleanup)
+  | value ->
+    Error
+      (Decode_error
+         (Printf.sprintf "unknown shutdown blocked resume phase: %S" value))
+;;
+
+let failure_of_json json =
+  let* stage_wire = string "stage" json in
+  let* stage =
+    failure_stage_of_string stage_wire
+    |> Result.map_error (fun e -> Decode_error e)
+  in
+  let* detail = string "detail" json in
+  let* resume =
+    match Json_util.assoc_member_opt "resume" json with
+    | None | Some `Null -> Ok None
+    | Some value -> blocked_resume_of_json value |> Result.map Option.some
+  in
+  Ok { stage; detail; resume }
 ;;
 
 let completion_receipt_of_json json =
@@ -813,7 +872,8 @@ let contextualize_error operation_path = function
     | Supersession_phase_mismatch _
     | Supersession_intent_mismatch _
     | Invalid_supersession_actor _
-    | Invalid_supersession_reason _ ) as error ->
+    | Invalid_supersession_reason _
+    | Invalid_purge_recovery_proof _ ) as error ->
     error
 ;;
 
@@ -1051,15 +1111,7 @@ let supersede_blocked_operator_stop ~config ~token ~now =
          | Ok existing -> Error (Supersession_phase_mismatch existing)))
 ;;
 
-let reissue_blocked_dashboard_purge
-      ~config
-      ~keeper_name
-      ~operation_id
-      ~expected_revision
-      ~actor
-      ~reason
-      ~now
-  =
+let validate_purge_reissue_operator ~actor ~reason =
   let* actor =
     Workspace.validate_agent_name actor
     |> Result.map_error (fun detail -> Invalid_supersession_actor detail)
@@ -1070,13 +1122,85 @@ let reissue_blocked_dashboard_purge
     then Error (Invalid_supersession_reason "reason must be non-empty")
     else Ok ()
   in
+  Ok (actor, reason)
+;;
+
+let is_exact_initial_blocked_purge operation =
+  match operation with
+  | { phase = Blocked { stage = Lane_join; resume = None; _ }
+    ; cleanup_intent = { reason = Dashboard_keeper_purge _; remove_session = true }
+    ; lane_ownership = Registered_lane _
+    ; turn_disposition = No_inflight_turn
+    ; owned_task_ids = []
+    ; join_evidence = None
+    ; _ } -> true
+  | _ -> false
+;;
+
+let invalid_purge_proof detail = Error (Invalid_purge_recovery_proof detail)
+
+let prove_ownerless_process_boundary
+      ~config
+      (operation : Keeper_shutdown_types.t)
+  =
+  let* () =
+    match Keeper_meta_store.read_meta config operation.keeper_name with
+    | Ok None -> Ok ()
+    | Ok (Some _) -> invalid_purge_proof "Keeper metadata is present"
+    | Error detail -> invalid_purge_proof ("metadata lookup failed: " ^ detail)
+  in
+  let* () =
+    match
+      Keeper_owner_registry.get
+        ~base_path:config.Workspace.base_path
+        ~keeper_name:operation.keeper_name
+    with
+    | Error (Keeper_owner_registry.Owner_not_found _) -> Ok ()
+    | Error error ->
+      invalid_purge_proof
+        ("Owner lookup did not prove absence: "
+         ^ Keeper_owner_registry.lookup_error_to_string error)
+    | Ok _ -> invalid_purge_proof "Keeper Owner is present"
+  in
+  let* () =
+    match
+      Keeper_registry.get
+        ~base_path:config.Workspace.base_path
+        operation.keeper_name
+    with
+    | None -> Ok ()
+    | Some _ -> invalid_purge_proof "live Keeper registry lane is present"
+  in
+  match
+    Keeper_shutdown_intake_fence.shutdown_operation_id
+      ~base_path:config.Workspace.base_path
+      ~keeper_name:operation.keeper_name
+  with
+  | Some existing when Operation_id.equal existing operation.operation_id -> Ok ()
+  | Some existing ->
+    invalid_purge_proof
+      (Printf.sprintf
+         "intake fence is owned by %s"
+         (Operation_id.to_string existing))
+  | None -> invalid_purge_proof "exact shutdown intake fence is absent"
+;;
+
+let prepare_blocked_dashboard_purge_reissue
+      ~config
+      ~keeper_name
+      ~operation_id
+      ~expected_revision
+      ~actor
+      ~reason
+  =
+  let* actor, reason = validate_purge_reissue_operator ~actor ~reason in
   let* operation_path = path ~config ~keeper_name operation_id in
   with_keeper_inventory_lock
-    ~access:Write
+    ~access:Read
     ~config
     ~keeper_name
     (fun () ->
-       with_operation_lock ~access:Write operation_path (fun () ->
+       with_operation_lock ~access:Read operation_path (fun () ->
          match
            load_path_unlocked ~operation_path ~keeper_name ~operation_id
          with
@@ -1104,25 +1228,97 @@ let reissue_blocked_dashboard_purge
                 && String.equal reason persisted_reason
                 && Int.equal expected_revision persisted_revision ->
            Ok (Purge_reissue_already_persisted existing)
-         | Ok
-             ({ phase = Blocked _
-              ; cleanup_intent = { reason = Dashboard_keeper_purge _; _ }
-              ; _ } as existing) ->
+         | Ok existing when is_exact_initial_blocked_purge existing ->
            if not (Int.equal existing.revision expected_revision)
            then
              Error
                (Revision_conflict
                   { expected = expected_revision; actual = existing.revision })
            else
+             let* () = prove_ownerless_process_boundary ~config existing in
+             Ok
+               (Purge_reissue_initial_prepared
+                  ( { base_path = config.Workspace.base_path
+                    ; keeper_name
+                    ; operation_id
+                    ; expected_revision
+                    ; actor
+                    ; reason
+                    }
+                  , existing ))
+         | Ok ({ phase = Blocked _; _ } as existing) ->
+           (match existing.cleanup_intent.reason with
+            | Dashboard_keeper_purge _ -> Error (Supersession_phase_mismatch existing)
+            | Operator_stop_retain_meta
+            | Operator_stop_remove_meta
+            | Supervisor_cleanup -> Error (Supersession_intent_mismatch existing))
+         | Ok existing -> Error (Supersession_phase_mismatch existing)))
+;;
+
+let reissue_blocked_dashboard_purge
+      ~config
+      ~(token : blocked_purge_reissue_token)
+      ~now
+  =
+  if not (String.equal config.Workspace.base_path token.base_path)
+  then invalid_purge_proof "prepared token belongs to another BasePath"
+  else
+    let* operation_path =
+      path ~config ~keeper_name:token.keeper_name token.operation_id
+    in
+    with_keeper_inventory_lock
+      ~access:Write
+      ~config
+      ~keeper_name:token.keeper_name
+      (fun () ->
+         with_operation_lock ~access:Write operation_path (fun () ->
+           let* existing =
+             load_path_unlocked
+               ~operation_path
+               ~keeper_name:token.keeper_name
+               ~operation_id:token.operation_id
+           in
+           if not (Int.equal existing.revision token.expected_revision)
+           then
+             Error
+               (Revision_conflict
+                  { expected = token.expected_revision
+                  ; actual = existing.revision
+                  })
+           else if not (is_exact_initial_blocked_purge existing)
+           then Error (Supersession_phase_mismatch existing)
+           else
+             let* () =
+               match
+                 Keeper_shutdown_intake_fence.shutdown_operation_id
+                   ~base_path:config.Workspace.base_path
+                   ~keeper_name:token.keeper_name
+               with
+               | Some operation_id
+                 when Operation_id.equal operation_id token.operation_id -> Ok ()
+               | Some operation_id ->
+                 invalid_purge_proof
+                   (Printf.sprintf
+                      "intake fence changed to %s"
+                      (Operation_id.to_string operation_id))
+               | None -> invalid_purge_proof "shutdown intake fence disappeared"
+             in
              let reissued =
                { existing with
                  revision = existing.revision + 1
-               ; phase = Joined_idle
+               ; phase =
+                   (match existing.phase with
+                    | Blocked failure ->
+                      Blocked { failure with resume = Some Resume_joined_idle }
+                    | _ -> existing.phase)
                ; join_evidence =
                    Some
                      { lane_outcome =
                          Lane_operator_purge_reissue
-                           { actor; reason; expected_revision }
+                           { actor = token.actor
+                           ; reason = token.reason
+                           ; expected_revision = token.expected_revision
+                           }
                      ; terminal = Terminal_stopped
                      ; cleanup_error = None
                      }
@@ -1131,10 +1327,7 @@ let reissue_blocked_dashboard_purge
              in
              Keeper_fs.save_json_atomic operation_path (to_json reissued)
              |> Result.map_error (fun detail -> Io_error detail)
-             |> Result.map (fun () -> Purge_reissue_persisted reissued)
-         | Ok ({ phase = Blocked _; _ } as existing) ->
-           Error (Supersession_intent_mismatch existing)
-         | Ok existing -> Error (Supersession_phase_mismatch existing)))
+             |> Result.map (fun () -> Purge_reissue_persisted reissued)))
 ;;
 
 let persist_blocked_latest ~config ~identity ~failure ~now =

--- a/lib/keeper/keeper_shutdown_store.ml
+++ b/lib/keeper/keeper_shutdown_store.ml
@@ -26,6 +26,10 @@ type supersede_blocked_result =
   | Superseded_persisted of Keeper_shutdown_types.t
   | Superseded_already_persisted of Keeper_shutdown_types.t
 
+type reissue_blocked_purge_result =
+  | Purge_reissue_persisted of Keeper_shutdown_types.t
+  | Purge_reissue_already_persisted of Keeper_shutdown_types.t
+
 (* What the operator is releasing. [Blocked_operator_stop] carries no
    effect-duplication risk: the shutdown worker failed, so the turn it was
    finalizing did not proceed. [Unreconciled_turn] does: the process ended
@@ -36,7 +40,6 @@ type supersede_blocked_result =
    recovered from the record afterwards. *)
 type superseded_admission =
   | Blocked_operator_stop
-  | Blocked_dashboard_purge
   | Unreconciled_turn of Keeper_shutdown_types.active_turn
 
 type operator_metadata_supersession_token =
@@ -282,12 +285,10 @@ let finalization_evidence_to_json evidence =
 ;;
 
 let supersession_to_json = function
-  | Operator_blocked_purge_released { actor; reason; expected_revision } ->
+  | Operator_blocked_purge_released { actor } ->
     `Assoc
       [ "kind", `String "operator_blocked_purge_released"
       ; "actor", `String actor
-      ; "reason", `String reason
-      ; "expected_revision", `Int expected_revision
       ]
   | Operator_metadata_update { actor } ->
     `Assoc
@@ -374,6 +375,13 @@ let lane_outcome_to_json = function
     `Assoc
       [ "kind", `String "failed"
       ; "detail", `String detail
+      ]
+  | Lane_operator_purge_reissue { actor; reason; expected_revision } ->
+    `Assoc
+      [ "kind", `String "operator_purge_reissue"
+      ; "actor", `String actor
+      ; "reason", `String reason
+      ; "expected_revision", `Int expected_revision
       ]
 ;;
 
@@ -605,9 +613,7 @@ let supersession_of_json json =
   match kind with
   | "operator_blocked_purge_released" ->
     let* actor = string "actor" json in
-    let* reason = string "reason" json in
-    let* expected_revision = int "expected_revision" json in
-    Ok (Operator_blocked_purge_released { actor; reason; expected_revision })
+    Ok (Operator_blocked_purge_released { actor })
   | "operator_metadata_update" ->
     let* actor = string "actor" json in
     Ok (Operator_metadata_update { actor })
@@ -665,6 +671,13 @@ let lane_outcome_of_json json =
   | "failed" ->
     let* detail = string "detail" json in
     Ok (Lane_failed detail)
+  | "operator_purge_reissue" ->
+    let* actor = string "actor" json in
+    let* reason = string "reason" json in
+    let* expected_revision = int "expected_revision" json in
+    Ok
+      (Lane_operator_purge_reissue
+         { actor; reason; expected_revision })
   | value -> Error (Decode_error (Printf.sprintf "unknown lane outcome: %S" value))
 ;;
 
@@ -944,20 +957,6 @@ let prepare_operator_metadata_supersession
       ; superseded_admission = Unreconciled_turn turn
       }
   | Ok
-      ({ phase = Superseded (Operator_blocked_purge_released _)
-       ; revision
-       ; _ } as _operation) ->
-    (* Idempotent: a second release of the same purge re-mints the same token
-       rather than reporting a phase mismatch. *)
-    Ok
-      { base_path
-      ; keeper_name
-      ; operation_id
-      ; expected_revision = revision
-      ; actor
-      ; superseded_admission = Blocked_dashboard_purge
-      }
-  | Ok
       ({ phase = Superseded (Operator_metadata_update _ | Operator_reconciliation_accepted _)
        ; revision
        ; _ } as _operation) ->
@@ -968,25 +967,6 @@ let prepare_operator_metadata_supersession
       ; expected_revision = revision
       ; actor
       ; superseded_admission = Blocked_operator_stop
-      }
-  (* A purge whose worker died in [Joining_lanes] holds the admission fence,
-     and that fence is what stops its own reissue: meta cannot be materialized
-     while it is held, and [Keeper_dashboard_purge.resolve] needs that meta to
-     build a target. Releasing it is the only exit, and it is as safe here as
-     for an operator stop -- the phase, not the intent, is what says the work
-     failed. *)
-  | Ok
-      ({ phase = Blocked _
-       ; cleanup_intent = { reason = Dashboard_keeper_purge _; _ }
-       ; revision
-       ; _ } as _operation) ->
-    Ok
-      { base_path
-      ; keeper_name
-      ; operation_id
-      ; expected_revision = revision
-      ; actor
-      ; superseded_admission = Blocked_dashboard_purge
       }
   | Ok ({ phase = Blocked _; _ } as operation) ->
     Error (Supersession_intent_mismatch operation)
@@ -1032,18 +1012,12 @@ let supersede_blocked_operator_stop ~config ~token ~now =
          | Ok
              ({ phase =
                   Superseded
-                    ( Operator_metadata_update _
-                    | Operator_reconciliation_accepted _
-                    | Operator_blocked_purge_released _ )
+                    (Operator_metadata_update _ | Operator_reconciliation_accepted _)
               ; _ } as existing) ->
            Ok (Superseded_already_persisted existing)
          | Ok
              ({ phase = Blocked _ | Reconciliation_required _
               ; cleanup_intent = { reason = Operator_stop_retain_meta; _ }
-              ; _ } as existing)
-         | Ok
-             ({ phase = Blocked _
-              ; cleanup_intent = { reason = Dashboard_keeper_purge _; _ }
               ; _ } as existing) ->
            if not (Int.equal existing.revision token.expected_revision)
            then
@@ -1058,12 +1032,6 @@ let supersede_blocked_operator_stop ~config ~token ~now =
                match token.superseded_admission with
                | Blocked_operator_stop ->
                  Operator_metadata_update { actor = token.actor }
-               | Blocked_dashboard_purge ->
-                 Operator_blocked_purge_released
-                   { actor = token.actor
-                   ; reason = "operator released blocked dashboard purge"
-                   ; expected_revision = token.expected_revision
-                   }
                | Unreconciled_turn unreconciled_turn ->
                  Operator_reconciliation_accepted
                    { actor = token.actor; unreconciled_turn }
@@ -1083,7 +1051,7 @@ let supersede_blocked_operator_stop ~config ~token ~now =
          | Ok existing -> Error (Supersession_phase_mismatch existing)))
 ;;
 
-let release_blocked_dashboard_purge
+let reissue_blocked_dashboard_purge
       ~config
       ~keeper_name
       ~operation_id
@@ -1114,20 +1082,28 @@ let release_blocked_dashboard_purge
          with
          | Error _ as error -> error
          | Ok
-             ({ phase =
-                  Superseded
-                    (Operator_blocked_purge_released
-                       { actor = persisted_actor
-                       ; reason = persisted_reason
-                       ; expected_revision = persisted_revision
-                       })
+             ({ join_evidence =
+                  Some
+                    { lane_outcome =
+                        Lane_operator_purge_reissue
+                          { actor = persisted_actor
+                          ; reason = persisted_reason
+                          ; expected_revision = persisted_revision
+                          }
+                    ; _
+                    }
+              ; cleanup_intent = { reason = Dashboard_keeper_purge _; _ }
+              ; phase =
+                  ( Joined_idle
+                  | Finalizing_tasks _
+                  | Cleanup_ready _
+                  | Finalized _
+                  | Blocked _ )
               ; _ } as existing)
            when String.equal actor persisted_actor
                 && String.equal reason persisted_reason
                 && Int.equal expected_revision persisted_revision ->
-           Ok (Superseded_already_persisted existing)
-         | Ok ({ phase = Superseded (Operator_blocked_purge_released _); _ } as existing) ->
-           Error (Supersession_phase_mismatch existing)
+           Ok (Purge_reissue_already_persisted existing)
          | Ok
              ({ phase = Blocked _
               ; cleanup_intent = { reason = Dashboard_keeper_purge _; _ }
@@ -1138,19 +1114,24 @@ let release_blocked_dashboard_purge
                (Revision_conflict
                   { expected = expected_revision; actual = existing.revision })
            else
-             let superseded =
+             let reissued =
                { existing with
                  revision = existing.revision + 1
-               ; phase =
-                   Superseded
-                     (Operator_blocked_purge_released
-                        { actor; reason; expected_revision })
+               ; phase = Joined_idle
+               ; join_evidence =
+                   Some
+                     { lane_outcome =
+                         Lane_operator_purge_reissue
+                           { actor; reason; expected_revision }
+                     ; terminal = Terminal_stopped
+                     ; cleanup_error = None
+                     }
                ; updated_at = now ()
                }
              in
-             Keeper_fs.save_json_atomic operation_path (to_json superseded)
+             Keeper_fs.save_json_atomic operation_path (to_json reissued)
              |> Result.map_error (fun detail -> Io_error detail)
-             |> Result.map (fun () -> Superseded_persisted superseded)
+             |> Result.map (fun () -> Purge_reissue_persisted reissued)
          | Ok ({ phase = Blocked _; _ } as existing) ->
            Error (Supersession_intent_mismatch existing)
          | Ok existing -> Error (Supersession_phase_mismatch existing)))

--- a/lib/keeper/keeper_shutdown_store.ml
+++ b/lib/keeper/keeper_shutdown_store.ml
@@ -16,6 +16,7 @@ type error =
   | Supersession_phase_mismatch of Keeper_shutdown_types.t
   | Supersession_intent_mismatch of Keeper_shutdown_types.t
   | Invalid_supersession_actor of string
+  | Invalid_supersession_reason of string
 
 type persist_blocked_result =
   | State_preserved of Keeper_shutdown_types.t
@@ -110,6 +111,8 @@ let error_to_string = function
       (cleanup_reason_label operation.cleanup_intent.reason)
   | Invalid_supersession_actor detail ->
     Printf.sprintf "shutdown supersession actor is invalid: %s" detail
+  | Invalid_supersession_reason detail ->
+    Printf.sprintf "shutdown supersession reason is invalid: %s" detail
 ;;
 
 type lock_access =
@@ -279,10 +282,12 @@ let finalization_evidence_to_json evidence =
 ;;
 
 let supersession_to_json = function
-  | Operator_blocked_purge_released { actor } ->
+  | Operator_blocked_purge_released { actor; reason; expected_revision } ->
     `Assoc
       [ "kind", `String "operator_blocked_purge_released"
       ; "actor", `String actor
+      ; "reason", `String reason
+      ; "expected_revision", `Int expected_revision
       ]
   | Operator_metadata_update { actor } ->
     `Assoc
@@ -600,7 +605,9 @@ let supersession_of_json json =
   match kind with
   | "operator_blocked_purge_released" ->
     let* actor = string "actor" json in
-    Ok (Operator_blocked_purge_released { actor })
+    let* reason = string "reason" json in
+    let* expected_revision = int "expected_revision" json in
+    Ok (Operator_blocked_purge_released { actor; reason; expected_revision })
   | "operator_metadata_update" ->
     let* actor = string "actor" json in
     Ok (Operator_metadata_update { actor })
@@ -792,7 +799,8 @@ let contextualize_error operation_path = function
     | Revision_conflict _
     | Supersession_phase_mismatch _
     | Supersession_intent_mismatch _
-    | Invalid_supersession_actor _ ) as error ->
+    | Invalid_supersession_actor _
+    | Invalid_supersession_reason _ ) as error ->
     error
 ;;
 
@@ -1051,7 +1059,11 @@ let supersede_blocked_operator_stop ~config ~token ~now =
                | Blocked_operator_stop ->
                  Operator_metadata_update { actor = token.actor }
                | Blocked_dashboard_purge ->
-                 Operator_blocked_purge_released { actor = token.actor }
+                 Operator_blocked_purge_released
+                   { actor = token.actor
+                   ; reason = "operator released blocked dashboard purge"
+                   ; expected_revision = token.expected_revision
+                   }
                | Unreconciled_turn unreconciled_turn ->
                  Operator_reconciliation_accepted
                    { actor = token.actor; unreconciled_turn }
@@ -1060,6 +1072,79 @@ let supersede_blocked_operator_stop ~config ~token ~now =
                { existing with
                  revision = existing.revision + 1
                ; phase = Superseded supersession
+               ; updated_at = now ()
+               }
+             in
+             Keeper_fs.save_json_atomic operation_path (to_json superseded)
+             |> Result.map_error (fun detail -> Io_error detail)
+             |> Result.map (fun () -> Superseded_persisted superseded)
+         | Ok ({ phase = Blocked _; _ } as existing) ->
+           Error (Supersession_intent_mismatch existing)
+         | Ok existing -> Error (Supersession_phase_mismatch existing)))
+;;
+
+let release_blocked_dashboard_purge
+      ~config
+      ~keeper_name
+      ~operation_id
+      ~expected_revision
+      ~actor
+      ~reason
+      ~now
+  =
+  let* actor =
+    Workspace.validate_agent_name actor
+    |> Result.map_error (fun detail -> Invalid_supersession_actor detail)
+  in
+  let reason = String.trim reason in
+  let* () =
+    if String.equal reason ""
+    then Error (Invalid_supersession_reason "reason must be non-empty")
+    else Ok ()
+  in
+  let* operation_path = path ~config ~keeper_name operation_id in
+  with_keeper_inventory_lock
+    ~access:Write
+    ~config
+    ~keeper_name
+    (fun () ->
+       with_operation_lock ~access:Write operation_path (fun () ->
+         match
+           load_path_unlocked ~operation_path ~keeper_name ~operation_id
+         with
+         | Error _ as error -> error
+         | Ok
+             ({ phase =
+                  Superseded
+                    (Operator_blocked_purge_released
+                       { actor = persisted_actor
+                       ; reason = persisted_reason
+                       ; expected_revision = persisted_revision
+                       })
+              ; _ } as existing)
+           when String.equal actor persisted_actor
+                && String.equal reason persisted_reason
+                && Int.equal expected_revision persisted_revision ->
+           Ok (Superseded_already_persisted existing)
+         | Ok ({ phase = Superseded (Operator_blocked_purge_released _); _ } as existing) ->
+           Error (Supersession_phase_mismatch existing)
+         | Ok
+             ({ phase = Blocked _
+              ; cleanup_intent = { reason = Dashboard_keeper_purge _; _ }
+              ; _ } as existing) ->
+           if not (Int.equal existing.revision expected_revision)
+           then
+             Error
+               (Revision_conflict
+                  { expected = expected_revision; actual = existing.revision })
+           else
+             let superseded =
+               { existing with
+                 revision = existing.revision + 1
+               ; phase =
+                   Superseded
+                     (Operator_blocked_purge_released
+                        { actor; reason; expected_revision })
                ; updated_at = now ()
                }
              in

--- a/lib/keeper/keeper_shutdown_store.mli
+++ b/lib/keeper/keeper_shutdown_store.mli
@@ -18,6 +18,7 @@ type error =
   | Supersession_phase_mismatch of Keeper_shutdown_types.t
   | Supersession_intent_mismatch of Keeper_shutdown_types.t
   | Invalid_supersession_actor of string
+  | Invalid_supersession_reason of string
 
 type persist_blocked_result =
   | State_preserved of Keeper_shutdown_types.t
@@ -90,6 +91,20 @@ val supersession_token_operation_id :
 val supersede_blocked_operator_stop :
   config:Workspace.config ->
   token:operator_metadata_supersession_token ->
+  now:(unit -> string) ->
+  (supersede_blocked_result, error) result
+
+(** CAS one exact [Blocked] dashboard purge to its typed operator release.
+    The command is idempotent only when actor, reason, and the originally
+    observed revision all match the persisted supersession. Other cleanup
+    intents and phases fail closed. *)
+val release_blocked_dashboard_purge :
+  config:Workspace.config ->
+  keeper_name:string ->
+  operation_id:Keeper_shutdown_types.Operation_id.t ->
+  expected_revision:int ->
+  actor:string ->
+  reason:string ->
   now:(unit -> string) ->
   (supersede_blocked_result, error) result
 

--- a/lib/keeper/keeper_shutdown_store.mli
+++ b/lib/keeper/keeper_shutdown_store.mli
@@ -28,6 +28,10 @@ type supersede_blocked_result =
   | Superseded_persisted of Keeper_shutdown_types.t
   | Superseded_already_persisted of Keeper_shutdown_types.t
 
+type reissue_blocked_purge_result =
+  | Purge_reissue_persisted of Keeper_shutdown_types.t
+  | Purge_reissue_already_persisted of Keeper_shutdown_types.t
+
 type operator_metadata_supersession_token
 
 type corrupt_record =
@@ -94,11 +98,11 @@ val supersede_blocked_operator_stop :
   now:(unit -> string) ->
   (supersede_blocked_result, error) result
 
-(** CAS one exact [Blocked] dashboard purge to its typed operator release.
-    The command is idempotent only when actor, reason, and the originally
-    observed revision all match the persisted supersession. Other cleanup
-    intents and phases fail closed. *)
-val release_blocked_dashboard_purge :
+(** CAS one exact [Blocked] dashboard purge back into [Joined_idle] while the
+    same operation continues to own admission. The typed operator intent is
+    persisted in [join_evidence] and remains through finalization. An exact
+    retry observes the same intent and reconciles from the current phase. *)
+val reissue_blocked_dashboard_purge :
   config:Workspace.config ->
   keeper_name:string ->
   operation_id:Keeper_shutdown_types.Operation_id.t ->
@@ -106,7 +110,7 @@ val release_blocked_dashboard_purge :
   actor:string ->
   reason:string ->
   now:(unit -> string) ->
-  (supersede_blocked_result, error) result
+  (reissue_blocked_purge_result, error) result
 
 (** Read the latest durable revision and persist [Blocked failure] while
     holding the operation's write lock. Existing [Finalized], [Blocked], and

--- a/lib/keeper/keeper_shutdown_store.mli
+++ b/lib/keeper/keeper_shutdown_store.mli
@@ -19,6 +19,7 @@ type error =
   | Supersession_intent_mismatch of Keeper_shutdown_types.t
   | Invalid_supersession_actor of string
   | Invalid_supersession_reason of string
+  | Invalid_purge_recovery_proof of string
 
 type persist_blocked_result =
   | State_preserved of Keeper_shutdown_types.t
@@ -30,6 +31,12 @@ type supersede_blocked_result =
 
 type reissue_blocked_purge_result =
   | Purge_reissue_persisted of Keeper_shutdown_types.t
+
+type blocked_purge_reissue_token
+
+type prepare_blocked_purge_reissue_result =
+  | Purge_reissue_initial_prepared of
+      blocked_purge_reissue_token * Keeper_shutdown_types.t
   | Purge_reissue_already_persisted of Keeper_shutdown_types.t
 
 type operator_metadata_supersession_token
@@ -98,17 +105,28 @@ val supersede_blocked_operator_stop :
   now:(unit -> string) ->
   (supersede_blocked_result, error) result
 
-(** CAS one exact [Blocked] dashboard purge back into [Joined_idle] while the
-    same operation continues to own admission. The typed operator intent is
-    persisted in [join_evidence] and remains through finalization. An exact
-    retry observes the same intent and reconciles from the current phase. *)
-val reissue_blocked_dashboard_purge :
+(** Prove that the initial record is the exact ownerless post-process-boundary
+    recovery shape: [Blocked Lane_join], dashboard purge with session removal,
+    registered historical lane, no in-flight turn or owned tasks, no join
+    evidence, missing metadata/Owner/live registry lane, and the exact intake
+    fence. Matching typed reissue evidence is the only retry entry. *)
+val prepare_blocked_dashboard_purge_reissue :
   config:Workspace.config ->
   keeper_name:string ->
   operation_id:Keeper_shutdown_types.Operation_id.t ->
   expected_revision:int ->
   actor:string ->
   reason:string ->
+  (prepare_blocked_purge_reissue_result, error) result
+
+(** Use the abstract proof to durably attach the typed operator intent and a
+    [Resume_joined_idle] checkpoint to the exact [Blocked Lane_join] record.
+    Recovery metadata is materialized only after this CAS, so a crash before
+    or after the write is an identical-retry state. No caller can pass an
+    arbitrary [Blocked] record. The same operation owns admission throughout. *)
+val reissue_blocked_dashboard_purge :
+  config:Workspace.config ->
+  token:blocked_purge_reissue_token ->
   now:(unit -> string) ->
   (reissue_blocked_purge_result, error) result
 

--- a/lib/keeper/keeper_shutdown_types.ml
+++ b/lib/keeper/keeper_shutdown_types.ml
@@ -141,7 +141,11 @@ type finalization_evidence =
   }
 
 type supersession =
-  | Operator_blocked_purge_released of { actor : string }
+  | Operator_blocked_purge_released of
+      { actor : string
+      ; reason : string
+      ; expected_revision : int
+      }
   | Operator_metadata_update of { actor : string }
   | Operator_reconciliation_accepted of
       { actor : string

--- a/lib/keeper/keeper_shutdown_types.ml
+++ b/lib/keeper/keeper_shutdown_types.ml
@@ -104,11 +104,6 @@ type failure_stage =
   | Session_remove
   | Registry_unregister
 
-type failure =
-  { stage : failure_stage
-  ; detail : string
-  }
-
 type operator_purge_reissue =
   { actor : string
   ; reason : string
@@ -136,6 +131,17 @@ type cleanup_evidence =
   { settled_task_ids : Keeper_id.Task_id.t list
   ; pending_confirms_removed : int
   ; meta_snapshot_digest : Keeper_meta_json.Snapshot_digest.t
+  }
+
+type blocked_resume =
+  | Resume_joined_idle
+  | Resume_finalizing_tasks of Keeper_id.Task_id.t list
+  | Resume_cleanup_ready of cleanup_evidence
+
+type failure =
+  { stage : failure_stage
+  ; detail : string
+  ; resume : blocked_resume option
   }
 
 type finalization_evidence =
@@ -201,6 +207,7 @@ type invariant_error =
   | Required_accumulator_not_dropped
   | Finalized_completion_mismatch of cleanup_reason * completion_receipt
   | Superseded_cleanup_reason_mismatch of cleanup_reason
+  | Blocked_resume_without_purge_reissue
 
 let schema_version = 8
 
@@ -306,6 +313,8 @@ let invariant_error_to_string = function
     Printf.sprintf
       "shutdown supersession requires operator_stop_retain_meta, actual=%s"
       (cleanup_reason_label cleanup_reason)
+  | Blocked_resume_without_purge_reissue ->
+    "shutdown blocked retry checkpoint requires typed operator purge reissue evidence"
 ;;
 
 let validate operation =
@@ -316,6 +325,15 @@ let validate operation =
          { expected_schema_version = schema_version
          ; actual_schema_version = operation.schema_version
          })
+  else if
+    match operation.phase with
+    | Blocked { resume = Some _; _ } ->
+      (match operation.join_evidence, operation.cleanup_intent.reason with
+       | ( Some { lane_outcome = Lane_operator_purge_reissue _; _ }
+         , Dashboard_keeper_purge _ ) -> false
+       | _ -> true)
+    | _ -> false
+  then Error Blocked_resume_without_purge_reissue
   else
     match operation.phase with
     | Finalized evidence ->

--- a/lib/keeper/keeper_shutdown_types.ml
+++ b/lib/keeper/keeper_shutdown_types.ml
@@ -109,11 +109,18 @@ type failure =
   ; detail : string
   }
 
+type operator_purge_reissue =
+  { actor : string
+  ; reason : string
+  ; expected_revision : int
+  }
+
 type lane_outcome =
   | Lane_completed
   | Lane_shutdown_requested
   | Lane_cancelled_by_parent of string
   | Lane_failed of string
+  | Lane_operator_purge_reissue of operator_purge_reissue
 
 type terminal =
   | Terminal_stopped
@@ -141,11 +148,7 @@ type finalization_evidence =
   }
 
 type supersession =
-  | Operator_blocked_purge_released of
-      { actor : string
-      ; reason : string
-      ; expected_revision : int
-      }
+  | Operator_blocked_purge_released of { actor : string }
   | Operator_metadata_update of { actor : string }
   | Operator_reconciliation_accepted of
       { actor : string
@@ -484,7 +487,7 @@ let dashboard_purge_artifact_plan ~keeper_name context =
   ]
 ;;
 
-let cleanup_intent_equal left right =
+let cleanup_intent_equal (left : cleanup_intent) (right : cleanup_intent) =
   cleanup_reason_equal left.reason right.reason
   && Bool.equal left.remove_session right.remove_session
 ;;

--- a/lib/keeper/keeper_shutdown_types.mli
+++ b/lib/keeper/keeper_shutdown_types.mli
@@ -124,13 +124,19 @@ type finalization_evidence =
   }
 
 type supersession =
-  | Operator_blocked_purge_released of { actor : string }
+  | Operator_blocked_purge_released of
+      { actor : string
+      ; reason : string
+      ; expected_revision : int
+      }
       (** The operator released a [Blocked] dashboard purge whose worker died
           before it finished. Like {!Operator_metadata_update} this carries no
           effect-duplication risk -- the work failed -- but it is not a
           metadata update: a purge leaves no metadata to update, and the
           admission fence it holds is what stops the purge being reissued.
           Kept apart so the durable record says which release was signed off.
+          [expected_revision] and [reason] are the operator's exact CAS input,
+          not values inferred after the mutation.
 
           Without this the pair ([Blocked], [Dashboard_keeper_purge]) had no
           exit: the fence blocks meta materialization, {!val:resolve} needs

--- a/lib/keeper/keeper_shutdown_types.mli
+++ b/lib/keeper/keeper_shutdown_types.mli
@@ -92,11 +92,21 @@ type failure =
   ; detail : string
   }
 
+type operator_purge_reissue =
+  { actor : string
+  ; reason : string
+  ; expected_revision : int
+  }
+(** Exact operator intent that moved a failed purge back into its cleanup
+    state machine without releasing admission. Stored in [join_evidence] so it
+    remains authoritative through finalization and retry reconciliation. *)
+
 type lane_outcome =
   | Lane_completed
   | Lane_shutdown_requested
   | Lane_cancelled_by_parent of string
   | Lane_failed of string
+  | Lane_operator_purge_reissue of operator_purge_reissue
 
 type terminal =
   | Terminal_stopped
@@ -124,19 +134,19 @@ type finalization_evidence =
   }
 
 type supersession =
-  | Operator_blocked_purge_released of
-      { actor : string
-      ; reason : string
-      ; expected_revision : int
-      }
-      (** The operator released a [Blocked] dashboard purge whose worker died
+  | Operator_blocked_purge_released of { actor : string }
+      (** Legacy #29295 wire state for an operator-released [Blocked] dashboard
+          purge. No current public producer writes this variant: opening the
+          fence before exact reissue admitted supervisor autoboot. The safe
+          route records [Lane_operator_purge_reissue] and keeps the same
+          operation fenced through finalization.
+
+          Historically, the operator released a purge whose worker died
           before it finished. Like {!Operator_metadata_update} this carries no
           effect-duplication risk -- the work failed -- but it is not a
           metadata update: a purge leaves no metadata to update, and the
           admission fence it holds is what stops the purge being reissued.
           Kept apart so the durable record says which release was signed off.
-          [expected_revision] and [reason] are the operator's exact CAS input,
-          not values inferred after the mutation.
 
           Without this the pair ([Blocked], [Dashboard_keeper_purge]) had no
           exit: the fence blocks meta materialization, {!val:resolve} needs

--- a/lib/keeper/keeper_shutdown_types.mli
+++ b/lib/keeper/keeper_shutdown_types.mli
@@ -87,11 +87,6 @@ type failure_stage =
   | Session_remove
   | Registry_unregister
 
-type failure =
-  { stage : failure_stage
-  ; detail : string
-  }
-
 type operator_purge_reissue =
   { actor : string
   ; reason : string
@@ -122,6 +117,19 @@ type cleanup_evidence =
   { settled_task_ids : Keeper_id.Task_id.t list
   ; pending_confirms_removed : int
   ; meta_snapshot_digest : Keeper_meta_json.Snapshot_digest.t
+  }
+
+type blocked_resume =
+  | Resume_joined_idle
+  | Resume_finalizing_tasks of Keeper_id.Task_id.t list
+  | Resume_cleanup_ready of cleanup_evidence
+(** Durable checkpoint for retrying a cleanup failure. Legacy blocked records
+    have no checkpoint and remain fail closed. *)
+
+type failure =
+  { stage : failure_stage
+  ; detail : string
+  ; resume : blocked_resume option
   }
 
 type finalization_evidence =
@@ -224,6 +232,7 @@ type invariant_error =
   | Required_accumulator_not_dropped
   | Finalized_completion_mismatch of cleanup_reason * completion_receipt
   | Superseded_cleanup_reason_mismatch of cleanup_reason
+  | Blocked_resume_without_purge_reissue
 
 val schema_version : int
 val requires_admission_fence : t -> bool

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -556,12 +556,14 @@ let blocked_purge_reissue_status =
   | Store_reissue_failed
       ( Keeper_shutdown_store.Revision_conflict _
       | Supersession_phase_mismatch _
-      | Supersession_intent_mismatch _ )
+      | Supersession_intent_mismatch _
+      | Invalid_purge_recovery_proof _ )
   -> `Conflict
   | Operation_load_failed
       ( Keeper_shutdown_store.Revision_conflict _
       | Supersession_phase_mismatch _
-      | Supersession_intent_mismatch _ ) -> `Conflict
+      | Supersession_intent_mismatch _
+      | Invalid_purge_recovery_proof _ ) -> `Conflict
   | Operation_load_failed
       ( Keeper_shutdown_store.Already_exists _
       | Io_error _

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -807,7 +807,11 @@ let add_delete_action_routes router =
                           [ "ok", `Bool false
                           ; "error", `String "blocked_purge_reissue_audit_failed"
                           ; "message", `String detail
-                          ; "retryable", `Bool true
+                          ; ( "next_action"
+                            , Keeper_shutdown_blocked_purge_release
+                              .reissue_same_command_json
+                                ~actor
+                                command )
                           ; "operation_audit_durable", `Bool true
                           ; "audit", Audit_log.write_result_to_json audit_result
                           ])

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -547,17 +547,22 @@ let keeper_purge_submit_status = function
   | Existing_operation_intent_mismatch _ -> `Conflict
 ;;
 
-let blocked_purge_release_status =
+let blocked_purge_reissue_status =
   let open Keeper_shutdown_blocked_purge_release in
   function
-  | Keeper_shutdown_blocked_purge_release.Store_release_failed
-      (Keeper_shutdown_store.Not_found _) -> `Not_found
-  | Store_release_failed
+  | Keeper_shutdown_blocked_purge_release.Operation_load_failed
+      (Keeper_shutdown_store.Not_found _)
+  | Store_reissue_failed (Keeper_shutdown_store.Not_found _) -> `Not_found
+  | Store_reissue_failed
       ( Keeper_shutdown_store.Revision_conflict _
       | Supersession_phase_mismatch _
       | Supersession_intent_mismatch _ )
-  | Admission_reserved_by_other _ -> `Conflict
-  | Store_release_failed
+  -> `Conflict
+  | Operation_load_failed
+      ( Keeper_shutdown_store.Revision_conflict _
+      | Supersession_phase_mismatch _
+      | Supersession_intent_mismatch _ ) -> `Conflict
+  | Operation_load_failed
       ( Keeper_shutdown_store.Already_exists _
       | Io_error _
       | Decode_error _
@@ -565,8 +570,18 @@ let blocked_purge_release_status =
       | Identity_mismatch _
       | Invalid_supersession_actor _
       | Invalid_supersession_reason _ )
-  | Successor_lookup_failed _
-  | Admission_release_failed _ -> `Internal_server_error
+  | Store_reissue_failed
+      ( Keeper_shutdown_store.Already_exists _
+      | Io_error _
+      | Decode_error _
+      | Invalid_operation _
+      | Identity_mismatch _
+      | Invalid_supersession_actor _
+      | Invalid_supersession_reason _ )
+  | Profile_materialization_failed _
+  | Metadata_materialization_failed _
+  | Finalization_failed _
+  | Injected_after_reissue _ -> `Internal_server_error
 ;;
 
 let respond_keeper_purge_operation_accepted ~request reqd operation =
@@ -744,7 +759,7 @@ let add_delete_action_routes router =
          )
        ) request reqd)
 
-  |> Http.Router.post "/api/v1/dashboard/agents/purge/release" (fun request reqd ->
+  |> Http.Router.post "/api/v1/dashboard/agents/purge/reissue" (fun request reqd ->
        with_token_permission_auth ~permission:Masc_domain.CanAdmin
          (fun state actor req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->
@@ -766,22 +781,35 @@ let add_delete_action_routes router =
                      command
                  with
                  | Ok released ->
-                   let audit =
-                     Keeper_shutdown_blocked_purge_release.audit
-                       config
-                       ~actor
-                       command
-                       ~outcome:Audit_log.Success
-                     |> Audit_log.write_result_to_json
-                   in
-                   Http.Response.json_value
-                     ~compress:true
-                     ~request:req
-                     (Keeper_shutdown_blocked_purge_release.success_json
-                        ~audit
+                   (match
+                      Keeper_shutdown_blocked_purge_release.audit
+                        config
+                        ~actor
                         command
-                        released)
-                     reqd
+                        ~outcome:Audit_log.Success
+                    with
+                    | Ok () as audit_result ->
+                      Http.Response.json_value
+                        ~compress:true
+                        ~request:req
+                        (Keeper_shutdown_blocked_purge_release.success_json
+                           ~audit:(Audit_log.write_result_to_json audit_result)
+                           command
+                           released)
+                        reqd
+                    | Error detail as audit_result ->
+                      Http.Response.json_value
+                        ~status:`Internal_server_error
+                        ~request:req
+                        (`Assoc
+                          [ "ok", `Bool false
+                          ; "error", `String "blocked_purge_reissue_audit_failed"
+                          ; "message", `String detail
+                          ; "retryable", `Bool true
+                          ; "operation_audit_durable", `Bool true
+                          ; "audit", Audit_log.write_result_to_json audit_result
+                          ])
+                        reqd)
                  | Error error ->
                    let audit =
                      Keeper_shutdown_blocked_purge_release.audit
@@ -794,7 +822,7 @@ let add_delete_action_routes router =
                      |> Audit_log.write_result_to_json
                    in
                    Http.Response.json_value
-                     ~status:(blocked_purge_release_status error)
+                     ~status:(blocked_purge_reissue_status error)
                      ~request:req
                      (Keeper_shutdown_blocked_purge_release.error_json ~audit error)
                      reqd))

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -547,6 +547,28 @@ let keeper_purge_submit_status = function
   | Existing_operation_intent_mismatch _ -> `Conflict
 ;;
 
+let blocked_purge_release_status =
+  let open Keeper_shutdown_blocked_purge_release in
+  function
+  | Keeper_shutdown_blocked_purge_release.Store_release_failed
+      (Keeper_shutdown_store.Not_found _) -> `Not_found
+  | Store_release_failed
+      ( Keeper_shutdown_store.Revision_conflict _
+      | Supersession_phase_mismatch _
+      | Supersession_intent_mismatch _ )
+  | Admission_reserved_by_other _ -> `Conflict
+  | Store_release_failed
+      ( Keeper_shutdown_store.Already_exists _
+      | Io_error _
+      | Decode_error _
+      | Invalid_operation _
+      | Identity_mismatch _
+      | Invalid_supersession_actor _
+      | Invalid_supersession_reason _ )
+  | Successor_lookup_failed _
+  | Admission_release_failed _ -> `Internal_server_error
+;;
+
 let respond_keeper_purge_operation_accepted ~request reqd operation =
   match operation.Keeper_shutdown_types.cleanup_intent.reason with
   | Keeper_shutdown_types.Dashboard_keeper_purge context ->
@@ -721,6 +743,65 @@ let add_delete_action_routes router =
              respond_error ~request:req reqd (invalid_request "goal_id")
          )
        ) request reqd)
+
+  |> Http.Router.post "/api/v1/dashboard/agents/purge/release" (fun request reqd ->
+       with_token_permission_auth ~permission:Masc_domain.CanAdmin
+         (fun state actor req reqd ->
+         Http.Request.read_body_async reqd (fun body_str ->
+           let config = Mcp_server.workspace_config state in
+           try
+             let json = Yojson.Safe.from_string body_str in
+             (match Keeper_shutdown_blocked_purge_release.parse_command json with
+              | Error error ->
+                Http.Response.json_value
+                  ~status:`Bad_request
+                  ~request:req
+                  (Keeper_shutdown_blocked_purge_release.input_error_to_json error)
+                  reqd
+              | Ok command ->
+                (match
+                   Keeper_shutdown_blocked_purge_release.execute
+                     ~config
+                     ~actor
+                     command
+                 with
+                 | Ok released ->
+                   let audit =
+                     Keeper_shutdown_blocked_purge_release.audit
+                       config
+                       ~actor
+                       command
+                       ~outcome:Audit_log.Success
+                     |> Audit_log.write_result_to_json
+                   in
+                   Http.Response.json_value
+                     ~compress:true
+                     ~request:req
+                     (Keeper_shutdown_blocked_purge_release.success_json
+                        ~audit
+                        command
+                        released)
+                     reqd
+                 | Error error ->
+                   let audit =
+                     Keeper_shutdown_blocked_purge_release.audit
+                       config
+                       ~actor
+                       command
+                       ~outcome:
+                         (Audit_log.Failure
+                            (Keeper_shutdown_blocked_purge_release.error_to_string error))
+                     |> Audit_log.write_result_to_json
+                   in
+                   Http.Response.json_value
+                     ~status:(blocked_purge_release_status error)
+                     ~request:req
+                     (Keeper_shutdown_blocked_purge_release.error_json ~audit error)
+                     reqd))
+           with Yojson.Json_error _ ->
+             respond_error ~request:req reqd "invalid JSON body"))
+       request
+       reqd)
 
   |> Http.Router.post "/api/v1/dashboard/agents/purge" (fun request reqd ->
        with_token_permission_auth ~permission:Masc_domain.CanAdmin

--- a/lib/server/server_dashboard_http_delete_actions.mli
+++ b/lib/server/server_dashboard_http_delete_actions.mli
@@ -6,6 +6,8 @@
     - [/api/v1/dashboard/board/delete] — delete one board post
     - [/api/v1/dashboard/tasks/delete] — delete one task
     - [/api/v1/dashboard/goals/delete] — delete one goal
+    - [/api/v1/dashboard/agents/purge/release] — release one exact blocked
+      Keeper purge admission fence
     - [/api/v1/dashboard/agents/purge] — delete an exact agent or accept a
       durable Keeper purge operation
 

--- a/lib/server/server_dashboard_http_delete_actions.mli
+++ b/lib/server/server_dashboard_http_delete_actions.mli
@@ -6,8 +6,8 @@
     - [/api/v1/dashboard/board/delete] — delete one board post
     - [/api/v1/dashboard/tasks/delete] — delete one task
     - [/api/v1/dashboard/goals/delete] — delete one goal
-    - [/api/v1/dashboard/agents/purge/release] — release one exact blocked
-      Keeper purge admission fence
+    - [/api/v1/dashboard/agents/purge/reissue] — finish one exact blocked
+      Keeper purge without opening its admission fence
     - [/api/v1/dashboard/agents/purge] — delete an exact agent or accept a
       durable Keeper purge operation
 

--- a/test/stanzas/test_keeper_shutdown_blocked_purge_release.inc
+++ b/test/stanzas/test_keeper_shutdown_blocked_purge_release.inc
@@ -4,4 +4,4 @@
 (test
  (name test_keeper_shutdown_blocked_purge_release)
  (modules test_keeper_shutdown_blocked_purge_release)
- (libraries masc_test_deps))
+ (libraries masc_test_deps bigstringaf))

--- a/test/test_goal_store.ml
+++ b/test/test_goal_store.ml
@@ -270,6 +270,50 @@ let test_legacy_owner_is_read_only_tombstone () =
   in
   check bool "canonical rewrite drops legacy owner" false owner_persisted
 
+let test_legacy_owner_null_retains_former_optional_shape () =
+  with_workspace @@ fun config ->
+  let goal = make_goal "legacy-owner-null" "legacy null owner is ignored" in
+  Goal_store.write_state config
+    { version = 1; updated_at = iso_now (); goals = [ goal ] };
+  add_goal_field config "owner" `Null;
+  check int "legacy null owner remains readable" 1
+    (List.length (Goal_store.read_state config).goals)
+
+let test_legacy_owner_rejects_malformed_payloads () =
+  [ "integer", `Int 7
+  ; "object", `Assoc [ "keeper", `String "retired" ]
+  ; "array", `List [ `String "retired" ]
+  ; "boolean", `Bool false
+  ]
+  |> List.iter (fun (label, payload) ->
+    with_workspace @@ fun config ->
+    let goal = make_goal ("legacy-owner-" ^ label) "malformed owner fails" in
+    Goal_store.write_state config
+      { version = 1; updated_at = iso_now (); goals = [ goal ] };
+    add_goal_field config "owner" payload;
+    check int (label ^ " owner keeps store undecodable") 0
+      (List.length (Goal_store.read_state config).goals);
+    match Goal_store.update_goal config ~goal_id:goal.id Fun.id with
+    | Ok _ -> fail (label ^ " owner licensed a canonical rewrite")
+    | Error detail ->
+      check bool (label ^ " owner fails closed") true
+        (String_util.contains_substring detail "refusing to write"))
+
+let test_legacy_owner_rejects_duplicate_tombstones () =
+  with_workspace @@ fun config ->
+  let goal = make_goal "legacy-owner-duplicate" "duplicate owner fails" in
+  Goal_store.write_state config
+    { version = 1; updated_at = iso_now (); goals = [ goal ] };
+  add_goal_field config "owner" (`String "retired-a");
+  add_goal_field config "owner" (`String "retired-b");
+  check int "duplicate owner keeps store undecodable" 0
+    (List.length (Goal_store.read_state config).goals);
+  match Goal_store.update_goal config ~goal_id:goal.id Fun.id with
+  | Ok _ -> fail "duplicate retired owner licensed a canonical rewrite"
+  | Error detail ->
+    check bool "duplicate owner fails closed" true
+      (String_util.contains_substring detail "refusing to write")
+
 let test_other_unknown_goal_field_still_fails () =
   with_workspace @@ fun config ->
   let goal = make_goal "unknown-field" "unknown field fails" in
@@ -434,6 +478,12 @@ let () =
             test_serializer_omits_status;
           test_case "legacy owner is a read-only tombstone" `Quick
             test_legacy_owner_is_read_only_tombstone;
+          test_case "legacy null owner retains former optional shape" `Quick
+            test_legacy_owner_null_retains_former_optional_shape;
+          test_case "legacy owner rejects malformed payloads" `Quick
+            test_legacy_owner_rejects_malformed_payloads;
+          test_case "legacy owner rejects duplicate tombstones" `Quick
+            test_legacy_owner_rejects_duplicate_tombstones;
           test_case "other unknown goal field still fails" `Quick
             test_other_unknown_goal_field_still_fails;
           test_case "phase-less row no longer decodes" `Quick

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -1078,7 +1078,12 @@ let test_keeper_shutdown_store_round_trip_and_identity_guard () =
       let stale =
         { loaded with
           revision = loaded.revision + 1
-        ; phase = Shutdown_types.Blocked { stage = Shutdown_types.Record_update; detail = "stale" }
+        ; phase =
+            Shutdown_types.Blocked
+              { stage = Shutdown_types.Record_update
+              ; detail = "stale"
+              ; resume = None
+              }
         }
       in
       (match Shutdown_store.replace ~config ~expected_revision:loaded.revision stale with
@@ -1177,7 +1182,8 @@ let test_keeper_shutdown_store_round_trip_and_identity_guard () =
         failure_timestamp
         blocked.updated_at;
       (match blocked.phase with
-       | Shutdown_types.Blocked { stage = Shutdown_types.Unhandled_worker; detail } ->
+       | Shutdown_types.Blocked
+           { stage = Shutdown_types.Unhandled_worker; detail; _ } ->
          check string
            "unhandled worker failure detail"
            (Printexc.to_string worker_failure)
@@ -1276,6 +1282,7 @@ let test_operator_update_supersedes_exact_blocked_shutdown () =
         Shutdown_types.Blocked
           { stage = Shutdown_types.Record_update
           ; detail = "operator repair required"
+          ; resume = None
           }
       in
       let blocked =
@@ -1613,6 +1620,7 @@ let test_operator_update_supersedes_exact_blocked_shutdown () =
             Shutdown_types.Blocked
               { stage = Shutdown_types.Meta_update
               ; detail = "new durable failure"
+              ; resume = None
               }
         }
       in
@@ -2046,6 +2054,7 @@ let test_keeper_shutdown_store_isolates_corrupt_owner () =
           (Shutdown_types.Blocked
              { stage = Shutdown_types.Record_update
              ; detail = "operator repair required"
+             ; resume = None
              })
       in
       let corrupt_path =
@@ -2757,7 +2766,7 @@ let test_keeper_shutdown_owner_failure_persists_blocked_join () =
         | Ok _ -> fail "closed owner was reported as a successful lane join"
       in
       (match blocked.phase with
-       | Shutdown_types.Blocked { stage = Shutdown_types.Lane_join; detail } ->
+       | Shutdown_types.Blocked { stage = Shutdown_types.Lane_join; detail; _ } ->
          check bool "owner failure records a non-empty join detail" true
            (String.length detail > 0)
        | _ -> fail "owner failure did not become durable Blocked/Lane_join");

--- a/test/test_keeper_shutdown_blocked_purge_release.ml
+++ b/test/test_keeper_shutdown_blocked_purge_release.ml
@@ -135,6 +135,7 @@ let with_workspace f =
            Keeper_shutdown_finalize.For_testing
            .reset_remove_pending_confirms_by_target ();
            Keeper_shutdown_finalize.For_testing.reset_completion_handler ();
+           Keeper_shutdown_finalize.For_testing.reset_failure_injection ();
            Keeper_shutdown_blocked_purge_release.For_testing.reset_audit_writer ();
            Fs_compat.clear_fs ())
          (fun () ->
@@ -173,6 +174,7 @@ let interrupted_lane_join =
   Blocked
     { stage = Lane_join
     ; detail = "server process ended while joining Keeper and Librarian lanes"
+    ; resume = None
     }
 ;;
 
@@ -205,27 +207,64 @@ let persist_exn ~config operation =
 
 let reissue_store_exn ~config operation =
   match
-    Keeper_shutdown_store.reissue_blocked_dashboard_purge
+    Keeper_shutdown_store.prepare_blocked_dashboard_purge_reissue
       ~config
       ~keeper_name
       ~operation_id:operation.operation_id
       ~expected_revision:operation.revision
       ~actor:"operator"
       ~reason:"test exact reissue"
-      ~now:Masc_domain.now_iso
   with
-  | Ok (Purge_reissue_persisted reissued | Purge_reissue_already_persisted reissued) ->
-    reissued
+  | Ok (Purge_reissue_initial_prepared (token, _)) ->
+    (match
+       Keeper_shutdown_store.reissue_blocked_dashboard_purge
+         ~config
+         ~token
+         ~now:Masc_domain.now_iso
+     with
+     | Ok (Purge_reissue_persisted reissued) -> reissued
+     | Error error -> fail (Keeper_shutdown_store.error_to_string error))
+  | Ok (Purge_reissue_already_persisted reissued) -> reissued
   | Error error ->
     failf
       "blocked purge refused exact reissue: %s"
       (Keeper_shutdown_store.error_to_string error)
 ;;
 
+let store_live_shape operation =
+  { operation with
+    lane_ownership =
+      Registered_lane
+        (lane_id_exn "lane-ec166371-dc82-41dc-81df-1fd9ffcc7c39")
+  }
+;;
+
+let with_store_reissue_fixture ~config f =
+  Eio.Switch.run @@ fun sw ->
+  (match
+     Keeper_owner_registry.install_from_store
+       ~sw
+       ~operation_runner:None
+       ~on_turn_slot_released:None
+       config
+   with
+   | Ok 0 -> ()
+   | Ok count -> failf "store fixture installed %d owner(s)" count
+   | Error error -> fail (Keeper_owner_registry.install_error_to_string error));
+  let operation =
+    make_operation ~cleanup_intent:purge_intent ~phase:interrupted_lane_join
+    |> store_live_shape
+  in
+  persist_exn ~config operation;
+  (match Keeper_shutdown_runtime.recover_at_boot ~config with
+   | [ Ok _ ] -> ()
+   | _ -> fail "store fixture did not restore exact shutdown fence");
+  f operation
+;;
+
 let test_reissue_keeps_the_admission_fence () =
   with_workspace (fun ~config ->
-    let operation = make_operation ~cleanup_intent:purge_intent ~phase:interrupted_lane_join in
-    persist_exn ~config operation;
+    with_store_reissue_fixture ~config @@ fun operation ->
     check bool "a blocked purge holds the fence" true
       (requires_admission_fence operation);
     let reissued = reissue_store_exn ~config operation in
@@ -234,11 +273,10 @@ let test_reissue_keeps_the_admission_fence () =
 
 let test_reissue_is_recorded_in_join_evidence () =
   with_workspace (fun ~config ->
-    let operation = make_operation ~cleanup_intent:purge_intent ~phase:interrupted_lane_join in
-    persist_exn ~config operation;
+    with_store_reissue_fixture ~config @@ fun operation ->
     let reissued = reissue_store_exn ~config operation in
     match reissued.phase, reissued.join_evidence with
-    | ( Joined_idle
+    | ( Blocked { stage = Lane_join; resume = Some Resume_joined_idle; _ }
       , Some
           { lane_outcome =
               Lane_operator_purge_reissue
@@ -251,8 +289,7 @@ let test_reissue_is_recorded_in_join_evidence () =
 
 let test_reissue_survives_a_reload () =
   with_workspace (fun ~config ->
-    let operation = make_operation ~cleanup_intent:purge_intent ~phase:interrupted_lane_join in
-    persist_exn ~config operation;
+    with_store_reissue_fixture ~config @@ fun operation ->
     let (_reissued : Keeper_shutdown_types.t) = reissue_store_exn ~config operation in
     match Keeper_shutdown_store.load ~config ~keeper_name operation.operation_id with
     | Error error ->
@@ -266,18 +303,142 @@ let test_operator_stop_reissue_is_refused () =
     let operation = make_operation ~cleanup_intent:stop_intent ~phase:interrupted_lane_join in
     persist_exn ~config operation;
     match
-      Keeper_shutdown_store.reissue_blocked_dashboard_purge
+      Keeper_shutdown_store.prepare_blocked_dashboard_purge_reissue
         ~config
         ~keeper_name
         ~operation_id:operation.operation_id
         ~expected_revision:operation.revision
         ~actor:"operator"
         ~reason:"must fail"
-        ~now:Masc_domain.now_iso
     with
     | Error (Supersession_intent_mismatch _) -> ()
     | Error error -> fail (Keeper_shutdown_store.error_to_string error)
     | Ok _ -> fail "operator stop was reissued as a purge")
+;;
+
+let all_failure_stages =
+  [ Task_discovery
+  ; Record_persist
+  ; Turn_cancel
+  ; Lane_cancel
+  ; Turn_join
+  ; Lane_join
+  ; Record_update
+  ; Unhandled_worker
+  ; Task_settlement
+  ; Pending_confirm_cleanup
+  ; Approval_summary_retirement
+  ; Meta_update
+  ; Meta_remove
+  ; Session_remove
+  ; Registry_unregister
+  ]
+;;
+
+let test_initial_reissue_accepts_only_lane_join_stage () =
+  List.iter
+    (fun stage ->
+       with_workspace (fun ~config ->
+         if stage = Lane_join
+         then
+           with_store_reissue_fixture ~config @@ fun operation ->
+           (match
+              Keeper_shutdown_store.prepare_blocked_dashboard_purge_reissue
+                ~config
+                ~keeper_name
+                ~operation_id:operation.operation_id
+                ~expected_revision:operation.revision
+                ~actor:"operator"
+                ~reason:"stage table"
+            with
+            | Ok (Purge_reissue_initial_prepared _) -> ()
+            | Ok (Purge_reissue_already_persisted _) ->
+              fail "fresh lane_join was reported as already reissued"
+            | Error error -> fail (Keeper_shutdown_store.error_to_string error))
+         else
+           let operation =
+             { (make_operation
+                  ~cleanup_intent:purge_intent
+                  ~phase:
+                    (Blocked
+                       { stage
+                       ; detail = "stage-table fixture"
+                       ; resume = None
+                       })) with
+               lane_ownership =
+                 Registered_lane
+                   (lane_id_exn
+                      "lane-ec166371-dc82-41dc-81df-1fd9ffcc7c39")
+             }
+           in
+           persist_exn ~config operation;
+           match
+             Keeper_shutdown_store.prepare_blocked_dashboard_purge_reissue
+               ~config
+               ~keeper_name
+               ~operation_id:operation.operation_id
+               ~expected_revision:operation.revision
+               ~actor:"operator"
+               ~reason:"stage table"
+           with
+           | Error (Supersession_phase_mismatch _) -> ()
+           | Error error -> fail (Keeper_shutdown_store.error_to_string error)
+           | Ok _ ->
+             failf
+               "initial reissue accepted blocked stage %s"
+               (failure_stage_to_string stage)))
+    all_failure_stages
+;;
+
+let test_initial_reissue_refuses_other_intents_and_revision () =
+  let intent_cases =
+    [ { reason = Operator_stop_retain_meta; remove_session = false }
+    ; { reason = Operator_stop_remove_meta; remove_session = false }
+    ; { reason = Supervisor_cleanup; remove_session = true }
+    ; { purge_intent with remove_session = false }
+    ]
+  in
+  List.iter
+    (fun cleanup_intent ->
+       with_workspace (fun ~config ->
+         let operation =
+           make_operation ~cleanup_intent ~phase:interrupted_lane_join
+           |> store_live_shape
+         in
+         persist_exn ~config operation;
+         match
+           Keeper_shutdown_store.prepare_blocked_dashboard_purge_reissue
+             ~config
+             ~keeper_name
+             ~operation_id:operation.operation_id
+             ~expected_revision:operation.revision
+             ~actor:"operator"
+             ~reason:"intent table"
+         with
+         | Error (Supersession_intent_mismatch _ | Supersession_phase_mismatch _) -> ()
+         | Error error -> fail (Keeper_shutdown_store.error_to_string error)
+         | Ok _ -> fail "initial reissue accepted a non-exact purge intent"))
+    intent_cases;
+  with_workspace (fun ~config ->
+    let operation =
+      make_operation ~cleanup_intent:purge_intent ~phase:interrupted_lane_join
+      |> store_live_shape
+    in
+    persist_exn ~config operation;
+    match
+      Keeper_shutdown_store.prepare_blocked_dashboard_purge_reissue
+        ~config
+        ~keeper_name
+        ~operation_id:operation.operation_id
+        ~expected_revision:(operation.revision + 1)
+        ~actor:"operator"
+        ~reason:"revision mismatch"
+    with
+    | Error (Revision_conflict { expected; actual }) ->
+      check int "expected revision preserved" (operation.revision + 1) expected;
+      check int "actual revision reported" operation.revision actual
+    | Error error -> fail (Keeper_shutdown_store.error_to_string error)
+    | Ok _ -> fail "initial reissue accepted a revision mismatch")
 ;;
 
 let live_release_command operation =
@@ -543,7 +704,7 @@ let test_crash_after_reissue_keeps_exact_fence_and_retry_finishes () =
       | Error error -> fail (Keeper_shutdown_store.error_to_string error)
     in
     (match current.phase, current.join_evidence with
-     | ( Joined_idle
+     | ( Blocked { stage = Lane_join; resume = Some Resume_joined_idle; _ }
        , Some { lane_outcome = Lane_operator_purge_reissue _; _ } ) -> ()
      | _ -> fail "crash window did not retain durable reissue intent");
     check
@@ -563,7 +724,14 @@ let test_crash_after_reissue_keeps_exact_fence_and_retry_finishes () =
      | Ok owner ->
        (match Keeper_owner.exact_projection owner with
         | Ok { meta = Some meta; _ } ->
-       check bool "recovery meta is paused" true meta.paused;
+          check string "recovery meta keeps name" operation.keeper_name meta.name;
+          check
+            string
+            "recovery meta keeps trace"
+            (Keeper_id.Trace_id.to_string operation.trace_id)
+            (Keeper_id.Trace_id.to_string meta.runtime.trace_id);
+          check int "recovery meta keeps generation" operation.generation meta.runtime.nonce;
+          check bool "recovery meta is paused" true meta.paused;
        check bool "recovery meta disables proactive" false meta.proactive.enabled;
        check bool "recovery meta disables autoboot" false meta.autoboot_enabled
         | Ok { meta = None; _ } -> fail "crash window lost recovery metadata"
@@ -581,6 +749,18 @@ let test_crash_after_reissue_keeps_exact_fence_and_retry_finishes () =
          (Operation_id.to_string operation.operation_id)
          (Operation_id.to_string existing)
      | Intake_committed _ -> fail "ordinary intake crossed the reissue fence");
+    (match Keeper_meta_store.read_meta config keeper_name with
+     | Ok (Some meta) ->
+       check string "stored recovery meta keeps name" operation.keeper_name meta.name;
+       check
+         string
+         "stored recovery meta keeps trace"
+         (Keeper_id.Trace_id.to_string operation.trace_id)
+         (Keeper_id.Trace_id.to_string meta.runtime.trace_id);
+       check int "stored recovery meta keeps generation" operation.generation meta.runtime.nonce;
+       check bool "stored recovery meta is paused" true meta.paused
+     | Ok None -> fail "stored recovery metadata disappeared"
+     | Error detail -> fail detail);
     (match Keeper_runtime.autoboot_exclusion_reason config keeper_name with
      | Some Keeper_runtime.Shutdown_admission_fence
      | Some Keeper_runtime.Paused -> ()
@@ -613,6 +793,70 @@ let test_crash_after_reissue_keeps_exact_fence_and_retry_finishes () =
     | Error error ->
       failf
         "crash-window retry failed: %s"
+        (Keeper_shutdown_blocked_purge_release.error_to_string error))
+;;
+
+let test_crash_after_intent_before_meta_is_retryable () =
+  with_workspace (fun ~config ->
+    Eio.Switch.run @@ fun sw ->
+    install_empty_owner_inventory_exn ~config ~sw;
+    let operation, _toml_path = persist_live_fixture ~config in
+    let command = live_release_command operation in
+    let token =
+      match
+        Keeper_shutdown_store.prepare_blocked_dashboard_purge_reissue
+          ~config
+          ~keeper_name
+          ~operation_id:operation.operation_id
+          ~expected_revision:command.expected_revision
+          ~actor:"purge-operator"
+          ~reason:command.reason
+      with
+      | Ok (Purge_reissue_initial_prepared (token, _)) -> token
+      | Ok (Purge_reissue_already_persisted _) ->
+        fail "fresh operation unexpectedly had reissue evidence"
+      | Error error -> fail (Keeper_shutdown_store.error_to_string error)
+    in
+    (match
+       Keeper_shutdown_store.reissue_blocked_dashboard_purge
+         ~config
+         ~token
+         ~now:Masc_domain.now_iso
+     with
+     | Ok (Purge_reissue_persisted _) -> ()
+     | Error error -> fail (Keeper_shutdown_store.error_to_string error));
+    (match Keeper_meta_store.read_meta config keeper_name with
+     | Ok None -> ()
+     | Ok (Some _) -> fail "pre-meta crash fixture materialized metadata"
+     | Error detail -> fail detail);
+    let durable =
+      match Keeper_shutdown_store.load ~config ~keeper_name operation.operation_id with
+      | Ok operation -> operation
+      | Error error -> fail (Keeper_shutdown_store.error_to_string error)
+    in
+    (match durable.phase, durable.join_evidence with
+     | ( Blocked { stage = Lane_join; resume = Some Resume_joined_idle; _ }
+       , Some { lane_outcome = Lane_operator_purge_reissue _; _ } ) -> ()
+     | _ -> fail "pre-meta crash lost durable typed reissue checkpoint");
+    check
+      (option string)
+      "pre-meta crash keeps exact fence"
+      (Some (Operation_id.to_string operation.operation_id))
+      (Keeper_shutdown_intake_fence.shutdown_operation_id
+         ~base_path:config.base_path
+         ~keeper_name
+       |> Option.map Operation_id.to_string);
+    match
+      Keeper_shutdown_blocked_purge_release.execute
+        ~config
+        ~actor:"purge-operator"
+        command
+    with
+    | Ok { operation = { phase = Finalized _; _ }; already_reissued = true } -> ()
+    | Ok _ -> fail "pre-meta crash retry did not finalize"
+    | Error error ->
+      failf
+        "pre-meta crash retry failed: %s"
         (Keeper_shutdown_blocked_purge_release.error_to_string error))
 ;;
 
@@ -695,6 +939,161 @@ let test_audit_failure_is_http_error_and_identical_retry_repairs () =
          | _ -> false)))
 ;;
 
+let resumable_cleanup_stages =
+  [ Meta_update
+  ; Task_settlement
+  ; Pending_confirm_cleanup
+  ; Approval_summary_retirement
+  ; Registry_unregister
+  ; Meta_remove
+  ; Session_remove
+  ]
+;;
+
+let expect_replay_rejected ~config ~actor command =
+  match Keeper_shutdown_blocked_purge_release.execute ~config ~actor command with
+  | Error (Store_reissue_failed _) -> ()
+  | Error error ->
+    failf
+      "mismatched replay returned wrong error: %s"
+      (Keeper_shutdown_blocked_purge_release.error_to_string error)
+  | Ok _ -> fail "mismatched replay was accepted"
+;;
+
+let test_cleanup_blocked_stages_resume_exact_retry () =
+  List.iter
+    (fun stage ->
+       with_workspace (fun ~config ->
+         Eio.Switch.run @@ fun sw ->
+         install_empty_owner_inventory_exn ~config ~sw;
+         let operation, _toml_path = persist_live_fixture ~config in
+         let auth_config =
+           { Masc_domain.default_auth_config with enabled = true; require_token = true }
+         in
+         Auth.save_auth_config config.base_path auth_config;
+         let actor = "purge-stage-operator" in
+         let admin_token =
+           create_token_exn config.base_path ~agent_name:actor ~role:Masc_domain.Admin
+         in
+         let command = live_release_command operation in
+         let body = release_command_json command in
+         let path = "/api/v1/dashboard/agents/purge/reissue" in
+         let saved_state = Server_auth.For_testing.snapshot_server_state () in
+         Fun.protect
+           ~finally:(fun () -> Server_auth.For_testing.restore_server_state saved_state)
+           (fun () ->
+              Server_auth.For_testing.restore_server_state
+                (Some (Mcp_server.For_testing.create_state ~base_path:config.base_path));
+              let router =
+                Server_dashboard_http_delete_actions.add_delete_action_routes
+                  (Http.Router.create ())
+              in
+              Keeper_shutdown_finalize.For_testing.fail_next_at_stage stage;
+              let first =
+                dispatch_with_body
+                  router
+                  (post_request ~path ~token:admin_token body)
+                  body
+              in
+              check
+                int
+                ("first " ^ failure_stage_to_string stage ^ " failure is HTTP 500")
+                500
+                (status_of_response first);
+              let blocked =
+                match
+                  Keeper_shutdown_store.load
+                    ~config
+                    ~keeper_name
+                    operation.operation_id
+                with
+                | Ok operation -> operation
+                | Error error -> fail (Keeper_shutdown_store.error_to_string error)
+              in
+              (match blocked.phase, blocked.join_evidence with
+               | ( Blocked { stage = persisted_stage; resume = Some _; _ }
+                 , Some
+                     { lane_outcome =
+                         Lane_operator_purge_reissue
+                           { actor = persisted_actor
+                           ; reason = persisted_reason
+                           ; expected_revision
+                           }
+                     ; _
+                     } ) ->
+                 check
+                   string
+                   "blocked stage persisted"
+                   (failure_stage_to_string stage)
+                   (failure_stage_to_string persisted_stage);
+                 check string "typed actor retained" actor persisted_actor;
+                 check string "typed reason retained" command.reason persisted_reason;
+                 check int "typed original revision retained" 2 expected_revision
+               | _ -> fail "cleanup failure lost typed retry checkpoint");
+              let blocked_revision = blocked.revision in
+              expect_replay_rejected
+                ~config
+                ~actor:"different-operator"
+                command;
+              expect_replay_rejected
+                ~config
+                ~actor
+                { command with reason = command.reason ^ " mismatched" };
+              expect_replay_rejected
+                ~config
+                ~actor
+                { command with expected_revision = command.expected_revision + 1 };
+              (match
+                 Keeper_shutdown_store.load
+                   ~config
+                   ~keeper_name
+                   operation.operation_id
+               with
+               | Ok current ->
+                 check int "mismatched retries do not write" blocked_revision current.revision
+               | Error error -> fail (Keeper_shutdown_store.error_to_string error));
+              check
+                (option string)
+                "blocked retry keeps exact fence"
+                (Some (Operation_id.to_string operation.operation_id))
+                (Keeper_shutdown_intake_fence.shutdown_operation_id
+                   ~base_path:config.base_path
+                   ~keeper_name
+                 |> Option.map Operation_id.to_string);
+              let retry =
+                dispatch_with_body
+                  router
+                  (post_request ~path ~token:admin_token body)
+                  body
+              in
+              check int "identical retry finalizes" 200 (status_of_response retry);
+              check
+                bool
+                "identical retry reports durable audit"
+                true
+                (Astring.String.is_infix ~affix:"\"audit_durable\":true" retry));
+         (match
+            Keeper_shutdown_store.load
+              ~config
+              ~keeper_name
+              operation.operation_id
+          with
+          | Ok { phase = Finalized _; _ } -> ()
+          | Ok _ -> fail "identical cleanup retry did not finalize"
+          | Error error -> fail (Keeper_shutdown_store.error_to_string error));
+         check
+           bool
+           "success audit row is durable"
+           true
+           (Audit_log.read_entries config
+            |> List.exists (fun (entry : Audit_log.audit_entry) ->
+              match entry.action with
+              | Audit_log.Custom "keeper_blocked_purge_reissue" ->
+                String.equal entry.agent_id actor
+              | _ -> false))))
+    resumable_cleanup_stages
+;;
+
 let test_non_purge_is_refused_and_stays_fenced () =
   with_workspace (fun ~config ->
     let operation =
@@ -711,7 +1110,8 @@ let test_non_purge_is_refused_and_stays_fenced () =
         ~actor:"operator"
         (live_release_command operation)
     with
-    | Error (Profile_materialization_failed _) ->
+    | Error
+        (Store_reissue_failed (Keeper_shutdown_store.Supersession_intent_mismatch _)) ->
       (match Keeper_shutdown_store.load ~config ~keeper_name operation.operation_id with
        | Ok { phase = Blocked _; revision = 2; _ } -> ()
        | Ok _ -> fail "non-purge operation changed despite fail-closed reissue"
@@ -758,6 +1158,14 @@ let () =
             `Quick
             test_operator_stop_reissue_is_refused
         ; test_case
+            "accepts only blocked lane_join initially"
+            `Quick
+            test_initial_reissue_accepts_only_lane_join_stage
+        ; test_case
+            "refuses mismatched intent and revision"
+            `Quick
+            test_initial_reissue_refuses_other_intents_and_revision
+        ; test_case
             "releases live-shaped missing-meta fence"
             `Quick
             test_missing_meta_live_shape_releases_exact_fence
@@ -766,9 +1174,17 @@ let () =
             `Quick
             test_crash_after_reissue_keeps_exact_fence_and_retry_finishes
         ; test_case
+            "recovers the pre-meta crash window"
+            `Quick
+            test_crash_after_intent_before_meta_is_retryable
+        ; test_case
             "fails closed and repairs an audit write"
             `Quick
             test_audit_failure_is_http_error_and_identical_retry_repairs
+        ; test_case
+            "resumes every cleanup blocked stage"
+            `Quick
+            test_cleanup_blocked_stages_resume_exact_retry
         ; test_case
             "refuses a non-purge operation"
             `Quick

--- a/test/test_keeper_shutdown_blocked_purge_release.ml
+++ b/test/test_keeper_shutdown_blocked_purge_release.ml
@@ -113,8 +113,30 @@ let with_workspace f =
     (fun () ->
        Eio_main.run @@ fun env ->
        Fs_compat.set_fs (Eio.Stdenv.fs env);
+       Keeper_shutdown_finalize.register_remove_pending_confirms_by_target
+         (fun _config ~target_type:_ ~target_id:_ -> Ok 0);
+       Keeper_shutdown_finalize.register_completion_handler
+         (fun config operation action ->
+           match action with
+           | Dashboard_keeper_purged ->
+             let toml_path =
+               Filename.concat
+                 (Config_dir_resolver.keepers_dir_for_base_path
+                    ~base_path:config.Workspace.base_path)
+                 (operation.Keeper_shutdown_types.keeper_name ^ ".toml")
+             in
+             (try
+                if Fs_compat.file_exists toml_path then Unix.unlink toml_path;
+                Ok ()
+              with exn -> Error (Printexc.to_string exn))
+           | Supervisor_cleaned -> Ok ());
        Fun.protect
-         ~finally:(fun () -> Fs_compat.clear_fs ())
+         ~finally:(fun () ->
+           Keeper_shutdown_finalize.For_testing
+           .reset_remove_pending_confirms_by_target ();
+           Keeper_shutdown_finalize.For_testing.reset_completion_handler ();
+           Keeper_shutdown_blocked_purge_release.For_testing.reset_audit_writer ();
+           Fs_compat.clear_fs ())
          (fun () ->
             let config = Workspace.default_config base in
             let (_init_msg : string) = Workspace.init config ~agent_name:None in
@@ -181,103 +203,88 @@ let persist_exn ~config operation =
     failf "persist_new failed: %s" (Keeper_shutdown_store.error_to_string error)
 ;;
 
-let release_exn ~config operation =
+let reissue_store_exn ~config operation =
   match
-    Keeper_shutdown_store.prepare_operator_metadata_supersession
+    Keeper_shutdown_store.reissue_blocked_dashboard_purge
       ~config
       ~keeper_name
       ~operation_id:operation.operation_id
+      ~expected_revision:operation.revision
       ~actor:"operator"
+      ~reason:"test exact reissue"
+      ~now:Masc_domain.now_iso
   with
+  | Ok (Purge_reissue_persisted reissued | Purge_reissue_already_persisted reissued) ->
+    reissued
   | Error error ->
     failf
-      "blocked purge refused a supersession token: %s"
+      "blocked purge refused exact reissue: %s"
       (Keeper_shutdown_store.error_to_string error)
-  | Ok token ->
-    (match
-       Keeper_shutdown_store.supersede_blocked_operator_stop
-         ~config
-         ~token
-         ~now:Masc_domain.now_iso
-     with
-     | Ok (Superseded_persisted released | Superseded_already_persisted released) ->
-       released
-     | Error error ->
-       failf
-         "supersession did not persist: %s"
-         (Keeper_shutdown_store.error_to_string error))
 ;;
 
-(* The fence is the whole wedge: while it is held nothing else can move, so a
-   release that only rewrites the phase would leave the Keeper exactly as
-   stuck. *)
-let test_release_frees_the_admission_fence () =
+let test_reissue_keeps_the_admission_fence () =
   with_workspace (fun ~config ->
     let operation = make_operation ~cleanup_intent:purge_intent ~phase:interrupted_lane_join in
     persist_exn ~config operation;
     check bool "a blocked purge holds the fence" true
       (requires_admission_fence operation);
-    let released = release_exn ~config operation in
-    check bool "the release frees it" false (requires_admission_fence released))
+    let reissued = reissue_store_exn ~config operation in
+    check bool "exact reissue keeps it" true (requires_admission_fence reissued))
 ;;
 
-(* The durable record has to say which release was signed off. Recording a
-   purge release as [Operator_metadata_update] would claim an operator updated
-   metadata that a purge deletes. *)
-let test_release_is_recorded_as_a_purge_release () =
+let test_reissue_is_recorded_in_join_evidence () =
   with_workspace (fun ~config ->
     let operation = make_operation ~cleanup_intent:purge_intent ~phase:interrupted_lane_join in
     persist_exn ~config operation;
-    let released = release_exn ~config operation in
-    match released.phase with
-    | Superseded (Operator_blocked_purge_released { actor; _ }) ->
+    let reissued = reissue_store_exn ~config operation in
+    match reissued.phase, reissued.join_evidence with
+    | ( Joined_idle
+      , Some
+          { lane_outcome =
+              Lane_operator_purge_reissue
+                { actor; reason = "test exact reissue"; expected_revision = 1 }
+          ; _
+          } ) ->
       check string "records the operator" "operator" actor
-    | Superseded (Operator_metadata_update _) ->
-      fail "a purge release was recorded as a metadata update"
-    | Superseded (Operator_reconciliation_accepted _) ->
-      fail "a purge release was recorded as a reconciliation acceptance"
-    | Prepared | Joining_lanes | Joined_idle | Finalizing_tasks _ | Cleanup_ready _
-    | Reconciliation_required _ | Finalized _ | Blocked _ ->
-      fail "the blocked purge was not superseded")
+    | _ -> fail "the exact reissue audit was not persisted")
 ;;
 
-(* Reloading proves the new supersession survives the codec: a release that
-   cannot be read back reappears as [Blocked] on the next boot. *)
-let test_release_survives_a_reload () =
+let test_reissue_survives_a_reload () =
   with_workspace (fun ~config ->
     let operation = make_operation ~cleanup_intent:purge_intent ~phase:interrupted_lane_join in
     persist_exn ~config operation;
-    let (_released : Keeper_shutdown_types.t) = release_exn ~config operation in
+    let (_reissued : Keeper_shutdown_types.t) = reissue_store_exn ~config operation in
     match Keeper_shutdown_store.load ~config ~keeper_name operation.operation_id with
     | Error error ->
-      failf "released purge did not load: %s" (Keeper_shutdown_store.error_to_string error)
+      failf "reissued purge did not load: %s" (Keeper_shutdown_store.error_to_string error)
     | Ok reloaded ->
-      (match reloaded.phase with
-       | Superseded (Operator_blocked_purge_released _) ->
-         check bool "still unfenced after a reload" false
-           (requires_admission_fence reloaded)
-       | _ -> fail "the reloaded phase was not a purge release"))
+      check bool "still fenced after reload" true (requires_admission_fence reloaded))
 ;;
 
-(* The release exists for a purge, so it must not become a way around the
-   metadata-update route: an operator stop still records its own supersession. *)
-let test_operator_stop_release_is_unchanged () =
+let test_operator_stop_reissue_is_refused () =
   with_workspace (fun ~config ->
     let operation = make_operation ~cleanup_intent:stop_intent ~phase:interrupted_lane_join in
     persist_exn ~config operation;
-    let released = release_exn ~config operation in
-    match released.phase with
-    | Superseded (Operator_metadata_update _) -> ()
-    | Superseded (Operator_blocked_purge_released _) ->
-      fail "an operator stop was recorded as a purge release"
-    | _ -> fail "the blocked operator stop was not superseded")
+    match
+      Keeper_shutdown_store.reissue_blocked_dashboard_purge
+        ~config
+        ~keeper_name
+        ~operation_id:operation.operation_id
+        ~expected_revision:operation.revision
+        ~actor:"operator"
+        ~reason:"must fail"
+        ~now:Masc_domain.now_iso
+    with
+    | Error (Supersession_intent_mismatch _) -> ()
+    | Error error -> fail (Keeper_shutdown_store.error_to_string error)
+    | Ok _ -> fail "operator stop was reissued as a purge")
 ;;
 
 let live_release_command operation =
   { Keeper_shutdown_blocked_purge_release.keeper_id = operation.keeper_name
   ; operation_id = operation.operation_id
   ; expected_revision = operation.revision
-  ; reason = "incident rw-e0: release failed lane join before exact purge reissue"
+  ; reason = "incident rw-e0: recover failed lane join with exact purge reissue"
   }
 ;;
 
@@ -318,10 +325,47 @@ let restore_live_fence_exn ~config operation =
   | outcomes -> failf "unexpected recovery outcome count: %d" (List.length outcomes)
 ;;
 
+let live_shaped_operation () =
+  { (make_operation
+       ~cleanup_intent:purge_intent
+       ~phase:interrupted_lane_join) with
+    revision = 2
+  ; lane_ownership =
+      Registered_lane
+        (lane_id_exn "lane-ec166371-dc82-41dc-81df-1fd9ffcc7c39")
+  ; actor = "dashboard"
+  ; expected_backlog_version = 3839
+  }
+;;
+
+let write_live_toml ~config =
+  let keepers_dir =
+    Config_dir_resolver.keepers_dir_for_base_path
+      ~base_path:config.Workspace.base_path
+  in
+  Fs_compat.mkdir_p keepers_dir;
+  let toml_path = Filename.concat keepers_dir (keeper_name ^ ".toml") in
+  Fs_compat.save_file
+    toml_path
+    (Printf.sprintf
+       "[keeper]\nname = %S\ninstructions = %S\nsandbox_profile = \"local\"\nautoboot_enabled = true\nproactive_enabled = true\n"
+       keeper_name
+       "finish the exact blocked purge only");
+  toml_path
+;;
+
+let persist_live_fixture ~config =
+  let operation = live_shaped_operation () in
+  let toml_path = write_live_toml ~config in
+  persist_exn ~config operation;
+  restore_live_fence_exn ~config operation;
+  operation, toml_path
+;;
+
 (* Mirrors the two live P0 records: revision 2, registered lane, dashboard
    purge, no meta.json, surviving TOML, and an ownerless intake fence. The
-   public command must persist revision 3 and release that actual fence; merely
-   changing [requires_admission_fence] on an in-memory value is insufficient. *)
+   public command must persist revision 3 while keeping that actual fence,
+   then release it only after durable finalization. *)
 let test_missing_meta_live_shape_releases_exact_fence () =
   with_workspace (fun ~config ->
     Eio.Switch.run @@ fun sw ->
@@ -360,7 +404,12 @@ let test_missing_meta_live_shape_releases_exact_fence () =
     in
     Fs_compat.mkdir_p keepers_dir;
     let toml_path = Filename.concat keepers_dir (keeper_name ^ ".toml") in
-    Fs_compat.save_file toml_path (Printf.sprintf "[keeper]\nname = %S\n" keeper_name);
+    Fs_compat.save_file
+      toml_path
+      (Printf.sprintf
+         "[keeper]\nname = %S\ninstructions = %S\nsandbox_profile = \"local\"\nautoboot_enabled = true\nproactive_enabled = true\n"
+         keeper_name
+         "finish the exact blocked purge only");
     check bool "live-shaped TOML survives" true (Fs_compat.file_exists toml_path);
     (match Keeper_meta_store.read_meta config keeper_name with
      | Ok None -> ()
@@ -378,7 +427,7 @@ let test_missing_meta_live_shape_releases_exact_fence () =
        |> Option.map Operation_id.to_string);
     let command = live_release_command operation in
     let body = release_command_json command in
-    let path = "/api/v1/dashboard/agents/purge/release" in
+    let path = "/api/v1/dashboard/agents/purge/reissue" in
     let saved_state = Server_auth.For_testing.snapshot_server_state () in
     Fun.protect
       ~finally:(fun () -> Server_auth.For_testing.restore_server_state saved_state)
@@ -392,35 +441,40 @@ let test_missing_meta_live_shape_releases_exact_fence () =
          let anonymous =
            dispatch_with_body router (post_request ~path body) body
          in
-         check int "anonymous release denied" 401 (status_of_response anonymous);
+         check int "anonymous reissue denied" 401 (status_of_response anonymous);
          let worker =
            dispatch_with_body
              router
              (post_request ~path ~token:worker_token body)
              body
          in
-         check int "Worker release denied" 403 (status_of_response worker);
+         check int "Worker reissue denied" 403 (status_of_response worker);
          let admin =
            dispatch_with_body
              router
              (post_request ~path ~token:admin_token body)
              body
          in
-         check int "Admin release accepted" 200 (status_of_response admin));
+         if status_of_response admin <> 200
+         then failf "Admin reissue response: %s" admin);
     let released =
       match Keeper_shutdown_store.load ~config ~keeper_name operation.operation_id with
       | Ok operation -> operation
       | Error error -> fail (Keeper_shutdown_store.error_to_string error)
     in
-    check int "release advances exact revision" 3 released.revision;
-    (match released.phase with
-     | Superseded
-         (Operator_blocked_purge_released
-            { actor; reason; expected_revision }) ->
+    check bool "finalization advanced revisions" true (released.revision > 3);
+    (match released.phase, released.join_evidence with
+     | ( Finalized _
+       , Some
+           { lane_outcome =
+               Lane_operator_purge_reissue
+                 { actor; reason; expected_revision }
+           ; _
+           } ) ->
        check string "authenticated actor persisted" "purge-operator" actor;
        check string "operator reason persisted" command.reason reason;
        check int "observed revision persisted" 2 expected_revision
-     | _ -> fail "release did not persist its typed audit");
+     | _ -> fail "reissue did not finalize with its typed audit");
     check
       bool
       "immutable operator audit persisted"
@@ -428,7 +482,7 @@ let test_missing_meta_live_shape_releases_exact_fence () =
       (Audit_log.read_entries config
        |> List.exists (fun (entry : Audit_log.audit_entry) ->
          match entry.action with
-         | Audit_log.Custom "keeper_blocked_purge_release" ->
+         | Audit_log.Custom "keeper_blocked_purge_reissue" ->
            String.equal entry.agent_id "purge-operator"
            && Yojson.Safe.Util.member "expected_revision" entry.details = `Int 2
            && Yojson.Safe.Util.member "reason" entry.details
@@ -436,7 +490,7 @@ let test_missing_meta_live_shape_releases_exact_fence () =
          | _ -> false));
     check
       (option string)
-      "ownerless intake fence is actually open"
+      "admission opens only after exact purge finalization"
       None
       (Keeper_shutdown_intake_fence.shutdown_operation_id
          ~base_path:config.base_path
@@ -455,7 +509,190 @@ let test_missing_meta_live_shape_releases_exact_fence () =
           "exact command retry failed: %s"
           (Keeper_shutdown_blocked_purge_release.error_to_string error)
     in
-    check bool "exact retry is idempotent" true replayed.already_released)
+    check bool "exact retry is idempotent" true replayed.already_reissued;
+    check bool "surviving TOML was purged" false (Fs_compat.file_exists toml_path);
+    match Keeper_meta_store.read_meta config keeper_name with
+    | Ok None -> ()
+    | Ok (Some _) -> fail "reissued purge left materialized metadata"
+    | Error detail -> failf "post-purge meta lookup failed: %s" detail)
+;;
+
+let test_crash_after_reissue_keeps_exact_fence_and_retry_finishes () =
+  with_workspace (fun ~config ->
+    Eio.Switch.run @@ fun sw ->
+    install_empty_owner_inventory_exn ~config ~sw;
+    let operation, _toml_path = persist_live_fixture ~config in
+    let command = live_release_command operation in
+    Keeper_shutdown_blocked_purge_release.For_testing.fail_next_after_reissue
+      "injected crash after durable reissue";
+    (match
+       Keeper_shutdown_blocked_purge_release.execute
+         ~config
+         ~actor:"purge-operator"
+         command
+     with
+     | Error (Injected_after_reissue _) -> ()
+     | Error error ->
+       failf
+         "wrong crash-window result: %s"
+         (Keeper_shutdown_blocked_purge_release.error_to_string error)
+     | Ok _ -> fail "injected post-reissue crash returned success");
+    let current =
+      match Keeper_shutdown_store.load ~config ~keeper_name operation.operation_id with
+      | Ok operation -> operation
+      | Error error -> fail (Keeper_shutdown_store.error_to_string error)
+    in
+    (match current.phase, current.join_evidence with
+     | ( Joined_idle
+       , Some { lane_outcome = Lane_operator_purge_reissue _; _ } ) -> ()
+     | _ -> fail "crash window did not retain durable reissue intent");
+    check
+      (option string)
+      "same operation remains the fence"
+      (Some (Operation_id.to_string operation.operation_id))
+      (Keeper_shutdown_intake_fence.shutdown_operation_id
+         ~base_path:config.base_path
+         ~keeper_name
+       |> Option.map Operation_id.to_string);
+    (match
+       Keeper_owner_registry.get
+         ~base_path:config.base_path
+         ~keeper_name
+     with
+     | Error error -> fail (Keeper_owner_registry.lookup_error_to_string error)
+     | Ok owner ->
+       (match Keeper_owner.exact_projection owner with
+        | Ok { meta = Some meta; _ } ->
+       check bool "recovery meta is paused" true meta.paused;
+       check bool "recovery meta disables proactive" false meta.proactive.enabled;
+       check bool "recovery meta disables autoboot" false meta.autoboot_enabled
+        | Ok { meta = None; _ } -> fail "crash window lost recovery metadata"
+        | Error error -> fail (Keeper_owner.error_to_string error)));
+    (match
+       Keeper_shutdown_intake_fence.run_durable_intake_if_open
+         ~base_path:config.base_path
+         ~keeper_name
+         (fun _ -> `Unexpectedly_admitted)
+     with
+     | Keeper_shutdown_intake_fence.Intake_shutdown_reserved existing ->
+       check
+         string
+         "ordinary supervisor/create intake sees exact fence"
+         (Operation_id.to_string operation.operation_id)
+         (Operation_id.to_string existing)
+     | Intake_committed _ -> fail "ordinary intake crossed the reissue fence");
+    (match Keeper_runtime.autoboot_exclusion_reason config keeper_name with
+     | Some Keeper_runtime.Shutdown_admission_fence
+     | Some Keeper_runtime.Paused -> ()
+     | Some reason ->
+       failf
+         "wrong autoboot exclusion: %s"
+         (Keeper_runtime.autoboot_exclusion_reason_to_string reason)
+     | None -> fail "default autoboot ignored the exact shutdown fence");
+    check
+      bool
+      "supervisor boot set excludes the fenced Keeper"
+      false
+      (List.mem keeper_name (Keeper_runtime.bootable_keeper_names config));
+    match
+      Keeper_shutdown_blocked_purge_release.execute
+        ~config
+        ~actor:"purge-operator"
+        command
+    with
+    | Ok { operation = { phase = Finalized _; _ }; already_reissued = true } ->
+      check
+        (option string)
+        "retry releases only after finalization"
+        None
+        (Keeper_shutdown_intake_fence.shutdown_operation_id
+           ~base_path:config.base_path
+           ~keeper_name
+         |> Option.map Operation_id.to_string)
+    | Ok _ -> fail "crash-window retry did not finalize idempotently"
+    | Error error ->
+      failf
+        "crash-window retry failed: %s"
+        (Keeper_shutdown_blocked_purge_release.error_to_string error))
+;;
+
+let test_audit_failure_is_http_error_and_identical_retry_repairs () =
+  with_workspace (fun ~config ->
+    Eio.Switch.run @@ fun sw ->
+    install_empty_owner_inventory_exn ~config ~sw;
+    let operation, _toml_path = persist_live_fixture ~config in
+    let auth_config =
+      { Masc_domain.default_auth_config with enabled = true; require_token = true }
+    in
+    Auth.save_auth_config config.base_path auth_config;
+    let admin_token =
+      create_token_exn
+        config.base_path
+        ~agent_name:"purge-audit-operator"
+        ~role:Masc_domain.Admin
+    in
+    let command = live_release_command operation in
+    let body = release_command_json command in
+    let path = "/api/v1/dashboard/agents/purge/reissue" in
+    let saved_state = Server_auth.For_testing.snapshot_server_state () in
+    Fun.protect
+      ~finally:(fun () -> Server_auth.For_testing.restore_server_state saved_state)
+      (fun () ->
+         Server_auth.For_testing.restore_server_state
+           (Some (Mcp_server.For_testing.create_state ~base_path:config.base_path));
+         let router =
+           Server_dashboard_http_delete_actions.add_delete_action_routes
+             (Http.Router.create ())
+         in
+         Keeper_shutdown_blocked_purge_release.For_testing.fail_next_audit_write
+           "injected immutable audit append failure";
+         let first =
+           dispatch_with_body
+             router
+             (post_request ~path ~token:admin_token body)
+             body
+         in
+         check int "audit failure is not success" 500 (status_of_response first);
+         check
+           bool
+           "audit failure response is fail closed"
+           true
+           (Astring.String.is_infix ~affix:"\"ok\":false" first);
+         let durable =
+           match Keeper_shutdown_store.load ~config ~keeper_name operation.operation_id with
+           | Ok operation -> operation
+           | Error error -> fail (Keeper_shutdown_store.error_to_string error)
+         in
+         (match durable.join_evidence with
+          | Some
+              { lane_outcome =
+                  Lane_operator_purge_reissue
+                    { actor = "purge-audit-operator"; expected_revision = 2; _ }
+              ; _
+              } -> ()
+          | _ -> fail "audit failure lost authoritative operation intent");
+         let retry =
+           dispatch_with_body
+             router
+             (post_request ~path ~token:admin_token body)
+             body
+         in
+         check int "identical retry repairs audit" 200 (status_of_response retry);
+         check
+           bool
+           "success reports durable audit"
+           true
+           (Astring.String.is_infix ~affix:"\"audit_durable\":true" retry));
+    check
+      bool
+      "retry persisted immutable audit row"
+      true
+      (Audit_log.read_entries config
+       |> List.exists (fun (entry : Audit_log.audit_entry) ->
+         match entry.action with
+         | Audit_log.Custom "keeper_blocked_purge_reissue" ->
+           String.equal entry.agent_id "purge-audit-operator"
+         | _ -> false)))
 ;;
 
 let test_non_purge_is_refused_and_stays_fenced () =
@@ -474,16 +711,16 @@ let test_non_purge_is_refused_and_stays_fenced () =
         ~actor:"operator"
         (live_release_command operation)
     with
-    | Error (Store_release_failed (Keeper_shutdown_store.Supersession_intent_mismatch _)) ->
+    | Error (Profile_materialization_failed _) ->
       (match Keeper_shutdown_store.load ~config ~keeper_name operation.operation_id with
        | Ok { phase = Blocked _; revision = 2; _ } -> ()
-       | Ok _ -> fail "non-purge operation changed despite fail-closed release"
+       | Ok _ -> fail "non-purge operation changed despite fail-closed reissue"
        | Error error -> fail (Keeper_shutdown_store.error_to_string error))
     | Error error ->
       failf
         "non-purge failed with wrong error: %s"
         (Keeper_shutdown_blocked_purge_release.error_to_string error)
-    | Ok _ -> fail "operator-stop record passed the purge-only release")
+    | Ok _ -> fail "operator-stop record passed the purge-only reissue")
 ;;
 
 let test_command_requires_exact_shape () =
@@ -509,21 +746,29 @@ let test_command_requires_exact_shape () =
 let () =
   run
     "keeper-shutdown-blocked-purge-release"
-    [ ( "operator release"
-      , [ test_case "frees the admission fence" `Quick test_release_frees_the_admission_fence
+    [ ( "operator reissue"
+      , [ test_case "keeps the admission fence" `Quick test_reissue_keeps_the_admission_fence
         ; test_case
-            "is recorded as a purge release"
+            "records exact reissue evidence"
             `Quick
-            test_release_is_recorded_as_a_purge_release
-        ; test_case "survives a reload" `Quick test_release_survives_a_reload
+            test_reissue_is_recorded_in_join_evidence
+        ; test_case "survives a reload" `Quick test_reissue_survives_a_reload
         ; test_case
-            "leaves the operator-stop route alone"
+            "refuses operator stop"
             `Quick
-            test_operator_stop_release_is_unchanged
+            test_operator_stop_reissue_is_refused
         ; test_case
             "releases live-shaped missing-meta fence"
             `Quick
             test_missing_meta_live_shape_releases_exact_fence
+        ; test_case
+            "recovers the post-reissue crash window"
+            `Quick
+            test_crash_after_reissue_keeps_exact_fence_and_retry_finishes
+        ; test_case
+            "fails closed and repairs an audit write"
+            `Quick
+            test_audit_failure_is_http_error_and_identical_retry_repairs
         ; test_case
             "refuses a non-purge operation"
             `Quick

--- a/test/test_keeper_shutdown_blocked_purge_release.ml
+++ b/test/test_keeper_shutdown_blocked_purge_release.ml
@@ -11,6 +11,8 @@ open Alcotest
 open Masc
 open Keeper_shutdown_types
 
+module Http = Http_server_eio
+
 let temp_dir prefix =
   let dir = Filename.temp_file prefix "" in
   Unix.unlink dir;
@@ -28,6 +30,80 @@ let cleanup_dir path =
     | exception Unix.Unix_error _ -> ()
   in
   rm path
+;;
+
+let create_token_exn base_path ~agent_name ~role =
+  match Auth.create_token base_path ~agent_name ~role with
+  | Ok (raw_token, _) -> raw_token
+  | Error error -> fail (Masc_domain.masc_error_to_string error)
+;;
+
+let post_request ~path ?token body =
+  let headers =
+    [ "host", "localhost"
+    ; "content-type", "application/json"
+    ; "content-length", string_of_int (String.length body)
+    ]
+  in
+  let headers =
+    match token with
+    | None -> headers
+    | Some value -> ("authorization", "Bearer " ^ value) :: headers
+  in
+  Httpun.Request.create ~headers:(Httpun.Headers.of_list headers) `POST path
+;;
+
+let dispatch_with_body router request body =
+  let response_buf = Buffer.create 1024 in
+  let conn =
+    Httpun.Server_connection.create (fun reqd ->
+      Http.Router.dispatch router (Httpun.Reqd.request reqd) reqd)
+  in
+  let request_head =
+    Printf.sprintf
+      "%s %s HTTP/1.1\r\n%s%s"
+      (Httpun.Method.to_string request.Httpun.Request.meth)
+      request.Httpun.Request.target
+      (Httpun.Headers.to_string request.Httpun.Request.headers)
+      body
+  in
+  let bytes = Bigstringaf.of_string ~off:0 ~len:(String.length request_head) request_head in
+  let rec feed off =
+    let remaining = Bigstringaf.length bytes - off in
+    if remaining > 0
+    then (
+      let consumed = Httpun.Server_connection.read conn bytes ~off ~len:remaining in
+      if consumed <= 0 then fail "httpun test feed made no progress";
+      feed (off + consumed))
+  in
+  feed 0;
+  let rec flush () =
+    match Httpun.Server_connection.next_write_operation conn with
+    | `Write iovecs ->
+      List.iter
+        (fun (iov : Bigstringaf.t Httpun.IOVec.t) ->
+           Buffer.add_string
+             response_buf
+             (Bigstringaf.substring iov.buffer ~off:iov.off ~len:iov.len))
+        iovecs;
+      let written =
+        List.fold_left
+          (fun total (iov : Bigstringaf.t Httpun.IOVec.t) -> total + iov.len)
+          0
+          iovecs
+      in
+      Httpun.Server_connection.report_write_result conn (`Ok written);
+      flush ()
+    | `Yield | `Close _ -> ()
+  in
+  flush ();
+  Buffer.contents response_buf
+;;
+
+let status_of_response response =
+  match String.split_on_char ' ' response with
+  | _ :: status :: _ -> int_of_string status
+  | _ -> failf "could not parse response status: %S" response
 ;;
 
 let with_workspace f =
@@ -49,6 +125,12 @@ let trace_id_exn value =
   match Keeper_id.Trace_id.of_string value with
   | Ok trace_id -> trace_id
   | Error detail -> failf "trace id rejected: %s" detail
+;;
+
+let lane_id_exn value =
+  match Keeper_lane.Id.of_string value with
+  | Ok lane_id -> lane_id
+  | Error detail -> failf "lane id rejected: %s" detail
 ;;
 
 let keeper_name = "rw-e0-blocked-purge"
@@ -148,7 +230,7 @@ let test_release_is_recorded_as_a_purge_release () =
     persist_exn ~config operation;
     let released = release_exn ~config operation in
     match released.phase with
-    | Superseded (Operator_blocked_purge_released { actor }) ->
+    | Superseded (Operator_blocked_purge_released { actor; _ }) ->
       check string "records the operator" "operator" actor
     | Superseded (Operator_metadata_update _) ->
       fail "a purge release was recorded as a metadata update"
@@ -191,6 +273,239 @@ let test_operator_stop_release_is_unchanged () =
     | _ -> fail "the blocked operator stop was not superseded")
 ;;
 
+let live_release_command operation =
+  { Keeper_shutdown_blocked_purge_release.keeper_id = operation.keeper_name
+  ; operation_id = operation.operation_id
+  ; expected_revision = operation.revision
+  ; reason = "incident rw-e0: release failed lane join before exact purge reissue"
+  }
+;;
+
+let release_command_json command =
+  `Assoc
+    [ "schema", `String Keeper_shutdown_blocked_purge_release.command_schema
+    ; "keeper_id", `String command.Keeper_shutdown_blocked_purge_release.keeper_id
+    ; ( "operation_id"
+      , `String (Operation_id.to_string command.operation_id) )
+    ; "expected_revision", `Int command.expected_revision
+    ; "reason", `String command.reason
+    ]
+  |> Yojson.Safe.to_string
+;;
+
+let install_empty_owner_inventory_exn ~config ~sw =
+  match
+    Keeper_owner_registry.install_from_store
+      ~sw
+      ~operation_runner:None
+      ~on_turn_slot_released:None
+      config
+  with
+  | Ok 0 -> ()
+  | Ok count -> failf "missing-meta fixture unexpectedly installed %d owner(s)" count
+  | Error error -> fail (Keeper_owner_registry.install_error_to_string error)
+;;
+
+let restore_live_fence_exn ~config operation =
+  match Keeper_shutdown_runtime.recover_at_boot ~config with
+  | [ Ok recovered ] ->
+    check
+      string
+      "boot recovered exact operation"
+      (Operation_id.to_string operation.operation_id)
+      (Operation_id.to_string recovered.operation_id)
+  | [ Error detail ] -> failf "live-shaped blocked purge recovery failed: %s" detail
+  | outcomes -> failf "unexpected recovery outcome count: %d" (List.length outcomes)
+;;
+
+(* Mirrors the two live P0 records: revision 2, registered lane, dashboard
+   purge, no meta.json, surviving TOML, and an ownerless intake fence. The
+   public command must persist revision 3 and release that actual fence; merely
+   changing [requires_admission_fence] on an in-memory value is insufficient. *)
+let test_missing_meta_live_shape_releases_exact_fence () =
+  with_workspace (fun ~config ->
+    Eio.Switch.run @@ fun sw ->
+    install_empty_owner_inventory_exn ~config ~sw;
+    let auth_config =
+      { Masc_domain.default_auth_config with enabled = true; require_token = true }
+    in
+    Auth.save_auth_config config.base_path auth_config;
+    let worker_token =
+      create_token_exn
+        config.base_path
+        ~agent_name:"purge-worker"
+        ~role:Masc_domain.Worker
+    in
+    let admin_token =
+      create_token_exn
+        config.base_path
+        ~agent_name:"purge-operator"
+        ~role:Masc_domain.Admin
+    in
+    let operation =
+      { (make_operation
+           ~cleanup_intent:purge_intent
+           ~phase:interrupted_lane_join) with
+        revision = 2
+      ; lane_ownership =
+          Registered_lane
+            (lane_id_exn "lane-ec166371-dc82-41dc-81df-1fd9ffcc7c39")
+      ; actor = "dashboard"
+      ; expected_backlog_version = 3839
+      }
+    in
+    let keepers_dir =
+      Config_dir_resolver.keepers_dir_for_base_path
+        ~base_path:config.Workspace.base_path
+    in
+    Fs_compat.mkdir_p keepers_dir;
+    let toml_path = Filename.concat keepers_dir (keeper_name ^ ".toml") in
+    Fs_compat.save_file toml_path (Printf.sprintf "[keeper]\nname = %S\n" keeper_name);
+    check bool "live-shaped TOML survives" true (Fs_compat.file_exists toml_path);
+    (match Keeper_meta_store.read_meta config keeper_name with
+     | Ok None -> ()
+     | Ok (Some _) -> fail "live-shaped fixture unexpectedly has meta.json"
+     | Error detail -> failf "meta lookup failed: %s" detail);
+    persist_exn ~config operation;
+    restore_live_fence_exn ~config operation;
+    check
+      (option string)
+      "exact ownerless intake fence is installed"
+      (Some (Operation_id.to_string operation.operation_id))
+      (Keeper_shutdown_intake_fence.shutdown_operation_id
+         ~base_path:config.base_path
+         ~keeper_name
+       |> Option.map Operation_id.to_string);
+    let command = live_release_command operation in
+    let body = release_command_json command in
+    let path = "/api/v1/dashboard/agents/purge/release" in
+    let saved_state = Server_auth.For_testing.snapshot_server_state () in
+    Fun.protect
+      ~finally:(fun () -> Server_auth.For_testing.restore_server_state saved_state)
+      (fun () ->
+         Server_auth.For_testing.restore_server_state
+           (Some (Mcp_server.For_testing.create_state ~base_path:config.base_path));
+         let router =
+           Server_dashboard_http_delete_actions.add_delete_action_routes
+             (Http.Router.create ())
+         in
+         let anonymous =
+           dispatch_with_body router (post_request ~path body) body
+         in
+         check int "anonymous release denied" 401 (status_of_response anonymous);
+         let worker =
+           dispatch_with_body
+             router
+             (post_request ~path ~token:worker_token body)
+             body
+         in
+         check int "Worker release denied" 403 (status_of_response worker);
+         let admin =
+           dispatch_with_body
+             router
+             (post_request ~path ~token:admin_token body)
+             body
+         in
+         check int "Admin release accepted" 200 (status_of_response admin));
+    let released =
+      match Keeper_shutdown_store.load ~config ~keeper_name operation.operation_id with
+      | Ok operation -> operation
+      | Error error -> fail (Keeper_shutdown_store.error_to_string error)
+    in
+    check int "release advances exact revision" 3 released.revision;
+    (match released.phase with
+     | Superseded
+         (Operator_blocked_purge_released
+            { actor; reason; expected_revision }) ->
+       check string "authenticated actor persisted" "purge-operator" actor;
+       check string "operator reason persisted" command.reason reason;
+       check int "observed revision persisted" 2 expected_revision
+     | _ -> fail "release did not persist its typed audit");
+    check
+      bool
+      "immutable operator audit persisted"
+      true
+      (Audit_log.read_entries config
+       |> List.exists (fun (entry : Audit_log.audit_entry) ->
+         match entry.action with
+         | Audit_log.Custom "keeper_blocked_purge_release" ->
+           String.equal entry.agent_id "purge-operator"
+           && Yojson.Safe.Util.member "expected_revision" entry.details = `Int 2
+           && Yojson.Safe.Util.member "reason" entry.details
+              = `String command.reason
+         | _ -> false));
+    check
+      (option string)
+      "ownerless intake fence is actually open"
+      None
+      (Keeper_shutdown_intake_fence.shutdown_operation_id
+         ~base_path:config.base_path
+         ~keeper_name
+       |> Option.map Operation_id.to_string);
+    let replayed =
+      match
+        Keeper_shutdown_blocked_purge_release.execute
+          ~config
+          ~actor:"purge-operator"
+          command
+      with
+      | Ok released -> released
+      | Error error ->
+        failf
+          "exact command retry failed: %s"
+          (Keeper_shutdown_blocked_purge_release.error_to_string error)
+    in
+    check bool "exact retry is idempotent" true replayed.already_released)
+;;
+
+let test_non_purge_is_refused_and_stays_fenced () =
+  with_workspace (fun ~config ->
+    let operation =
+      { (make_operation
+           ~cleanup_intent:stop_intent
+           ~phase:interrupted_lane_join) with
+        revision = 2
+      }
+    in
+    persist_exn ~config operation;
+    match
+      Keeper_shutdown_blocked_purge_release.execute
+        ~config
+        ~actor:"operator"
+        (live_release_command operation)
+    with
+    | Error (Store_release_failed (Keeper_shutdown_store.Supersession_intent_mismatch _)) ->
+      (match Keeper_shutdown_store.load ~config ~keeper_name operation.operation_id with
+       | Ok { phase = Blocked _; revision = 2; _ } -> ()
+       | Ok _ -> fail "non-purge operation changed despite fail-closed release"
+       | Error error -> fail (Keeper_shutdown_store.error_to_string error))
+    | Error error ->
+      failf
+        "non-purge failed with wrong error: %s"
+        (Keeper_shutdown_blocked_purge_release.error_to_string error)
+    | Ok _ -> fail "operator-stop record passed the purge-only release")
+;;
+
+let test_command_requires_exact_shape () =
+  let json =
+    `Assoc
+      [ "schema", `String Keeper_shutdown_blocked_purge_release.command_schema
+      ; "keeper_id", `String keeper_name
+      ; "operation_id", `String (Operation_id.to_string (Operation_id.generate ()))
+      ; "expected_revision", `Int 2
+      ; "reason", `String "incident release"
+      ; "reason", `String "duplicate must fail"
+      ]
+  in
+  match Keeper_shutdown_blocked_purge_release.parse_command json with
+  | Error (Duplicate_fields [ "reason" ]) -> ()
+  | Error error ->
+    failf
+      "exact-shape parser returned wrong error: %s"
+      (Keeper_shutdown_blocked_purge_release.input_error_to_string error)
+  | Ok _ -> fail "duplicate command field was accepted"
+;;
+
 let () =
   run
     "keeper-shutdown-blocked-purge-release"
@@ -205,6 +520,18 @@ let () =
             "leaves the operator-stop route alone"
             `Quick
             test_operator_stop_release_is_unchanged
+        ; test_case
+            "releases live-shaped missing-meta fence"
+            `Quick
+            test_missing_meta_live_shape_releases_exact_fence
+        ; test_case
+            "refuses a non-purge operation"
+            `Quick
+            test_non_purge_is_refused_and_stays_fenced
+        ; test_case
+            "requires an exact command shape"
+            `Quick
+            test_command_requires_exact_shape
         ] )
     ]
 ;;

--- a/test/test_keeper_shutdown_blocked_purge_release.ml
+++ b/test/test_keeper_shutdown_blocked_purge_release.ml
@@ -796,7 +796,78 @@ let test_crash_after_reissue_keeps_exact_fence_and_retry_finishes () =
         (Keeper_shutdown_blocked_purge_release.error_to_string error))
 ;;
 
-let test_crash_after_intent_before_meta_is_retryable () =
+let test_process_restart_reloads_reissue_checkpoint_before_retry () =
+  with_workspace (fun ~config ->
+    let operation, command =
+      Eio.Switch.run @@ fun sw ->
+      install_empty_owner_inventory_exn ~config ~sw;
+      let operation, _toml_path = persist_live_fixture ~config in
+      let command = live_release_command operation in
+      Keeper_shutdown_blocked_purge_release.For_testing.fail_next_after_reissue
+        "injected process-boundary crash";
+      (match
+         Keeper_shutdown_blocked_purge_release.execute
+           ~config
+           ~actor:"purge-operator"
+           command
+       with
+       | Error (Injected_after_reissue _) -> ()
+       | Error error ->
+         fail
+           ("process-boundary fixture failed: "
+            ^ Keeper_shutdown_blocked_purge_release.error_to_string error)
+       | Ok _ -> fail "process-boundary crash fixture returned success");
+      operation, command
+    in
+    check int "first process owner inventory is gone" 0
+      (Keeper_owner_registry.For_testing.installed_owner_count
+         ~base_path:config.base_path);
+    Eio.Switch.run @@ fun sw ->
+    (match
+       Keeper_owner_registry.install_from_store
+         ~sw
+         ~operation_runner:None
+         ~on_turn_slot_released:None
+         config
+     with
+     | Ok 1 -> ()
+     | Ok count -> failf "restart loaded %d owners, expected one" count
+     | Error error -> fail (Keeper_owner_registry.install_error_to_string error));
+    restore_live_fence_exn ~config operation;
+    (match
+       Keeper_owner_registry.get
+         ~base_path:config.base_path
+         ~keeper_name
+     with
+     | Ok owner ->
+       (match Keeper_owner.exact_projection owner with
+        | Ok { meta = Some meta; _ } ->
+          check bool "restart reloads paused recovery metadata" true meta.paused;
+          check int "restart reloads exact generation" operation.generation
+            meta.runtime.nonce
+        | Ok { meta = None; _ } -> fail "restart owner lost durable recovery metadata"
+        | Error error -> fail (Keeper_owner.error_to_string error))
+     | Error error -> fail (Keeper_owner_registry.lookup_error_to_string error));
+    match
+      Keeper_shutdown_blocked_purge_release.execute
+        ~config
+        ~actor:"purge-operator"
+        command
+    with
+    | Ok { operation = { phase = Finalized _; _ }; already_reissued = true } ->
+      check (option string) "restart retry opens admission only after finalization" None
+        (Keeper_shutdown_intake_fence.shutdown_operation_id
+           ~base_path:config.base_path
+           ~keeper_name
+         |> Option.map Operation_id.to_string)
+    | Ok _ -> fail "restart retry did not finalize the exact reissue"
+    | Error error ->
+      fail
+        ("restart retry failed: "
+         ^ Keeper_shutdown_blocked_purge_release.error_to_string error))
+;;
+
+let test_crash_after_intent_before_meta_resumes_by_exact_reissue () =
   with_workspace (fun ~config ->
     Eio.Switch.run @@ fun sw ->
     install_empty_owner_inventory_exn ~config ~sw;
@@ -902,6 +973,23 @@ let test_audit_failure_is_http_error_and_identical_retry_repairs () =
            "audit failure response is fail closed"
            true
            (Astring.String.is_infix ~affix:"\"ok\":false" first);
+         check bool "audit failure has no ambiguous retryable bit" false
+           (Astring.String.is_infix ~affix:"\"retryable\"" first);
+         check bool "audit failure requires exact command reissue" true
+           (Astring.String.is_infix
+              ~affix:"\"kind\":\"reissue_same_command\""
+              first);
+         check bool "next action binds the authenticated actor" true
+           (Astring.String.is_infix
+              ~affix:"\"actor\":\"purge-audit-operator\""
+              first);
+         check bool "next action binds the expected revision" true
+           (Astring.String.is_infix ~affix:"\"expected_revision\":2" first);
+         check bool "next action binds the exact reason" true
+           (Astring.String.is_infix
+              ~affix:
+                "\"reason\":\"incident rw-e0: recover failed lane join with exact purge reissue\""
+              first);
          let durable =
            match Keeper_shutdown_store.load ~config ~keeper_name operation.operation_id with
            | Ok operation -> operation
@@ -1174,9 +1262,13 @@ let () =
             `Quick
             test_crash_after_reissue_keeps_exact_fence_and_retry_finishes
         ; test_case
+            "reloads the reissue checkpoint across a process boundary"
+            `Quick
+            test_process_restart_reloads_reissue_checkpoint_before_retry
+        ; test_case
             "recovers the pre-meta crash window"
             `Quick
-            test_crash_after_intent_before_meta_is_retryable
+            test_crash_after_intent_before_meta_resumes_by_exact_reissue
         ; test_case
             "fails closed and repairs an audit write"
             `Quick

--- a/test/test_keeper_shutdown_ownerless_admission_release.ml
+++ b/test/test_keeper_shutdown_ownerless_admission_release.ml
@@ -417,7 +417,7 @@ let test_predicate_answers_every_cleanup_reason () =
       let operation =
         make_operation
           ~keeper_name:label
-          ~phase:(Blocked { stage = Meta_remove; detail = "fixture" })
+          ~phase:(Blocked { stage = Meta_remove; detail = "fixture"; resume = None })
           ~cleanup_intent:{ reason; remove_session = false }
       in
       check
@@ -474,6 +474,7 @@ let test_boot_recovery_keeps_blocked_ownerless_cleanup_fenced () =
           (Blocked
              { stage = Session_remove
              ; detail = "remove_session_dir failed after remove_meta_file"
+             ; resume = None
              })
         ~cleanup_intent:
           { reason = Operator_stop_remove_meta; remove_session = true }
@@ -499,7 +500,7 @@ let check_boot_recovery_rejects_ownerless_retain_intent label reason =
     let operation =
       make_operation
         ~keeper_name:label
-        ~phase:(Blocked { stage = Meta_remove; detail = "fixture" })
+        ~phase:(Blocked { stage = Meta_remove; detail = "fixture"; resume = None })
         ~cleanup_intent:{ reason; remove_session = false }
     in
     persist_exn ~config operation;
@@ -530,7 +531,7 @@ let check_corrupt_sibling_does_not_hide_ownerless_retain label reason =
     let operation =
       make_operation
         ~keeper_name:label
-        ~phase:(Blocked { stage = Meta_remove; detail = "fixture" })
+        ~phase:(Blocked { stage = Meta_remove; detail = "fixture"; resume = None })
         ~cleanup_intent:{ reason; remove_session = false }
     in
     let corrupt_sibling =

--- a/test/test_keeper_shutdown_reconciliation_settlement.ml
+++ b/test/test_keeper_shutdown_reconciliation_settlement.ml
@@ -258,7 +258,7 @@ let test_recovery_blocks_interrupted_lane_join () =
     persist_exn ~config operation;
     let recovered = recover_exn ~config operation in
     (match recovered.phase with
-     | Blocked { stage = Lane_join; detail } ->
+     | Blocked { stage = Lane_join; detail; _ } ->
        check string
          "blocked evidence names unknown Librarian completion"
          "server process ended while joining Keeper and Librarian lanes; Librarian completion is unknown"


### PR DESCRIPTION
## Problem

#29295 exposed a low-level blocked-purge release, but a plain fence release is unsafe and incomplete for the live shape:

1. `meta.json` and the Owner are absent while Keeper TOML survives;
2. opening admission before exact reissue lets supervisor/default-autoboot race the operator;
3. `Blocked _` is too broad: turn/lane cancellation and cleanup failures cannot justify synthesizing a stopped terminal;
4. cleanup can persist a later `Blocked` after reissue, so identical retry needs a typed durable continuation;
5. HTTP success must remain fail-closed on immutable audit failure.

## Safe state machine

`POST /api/v1/dashboard/agents/purge/reissue` is bearer-bound `CanAdmin`. Its strict v1 command binds exact `keeper_id`, typed `operation_id`, positive `expected_revision`, nonblank `reason`, and the bearer-derived actor.

The same shutdown operation owns admission throughout:

1. Store preparation accepts only the exact initial live recovery proof: dashboard purge with session removal, `Blocked Lane_join`, historical `Registered_lane`, `No_inflight_turn`, no owned tasks, no join evidence, missing metadata, `Owner_not_found`, no live registry lane, and the exact intake-fence owner. Every other blocked stage/intent/revision fails closed.
2. An abstract proof token CASes typed `Lane_operator_purge_reissue { actor; reason; expected_revision }` plus `Resume_joined_idle` into that same blocked record before recovery metadata is created. A crash before or after this CAS is therefore an identical-retry state, never an admission-open state.
3. Exact shutdown-owned intake materializes recovery metadata from the surviving TOML. Owner policy is paused, proactive=false, autoboot=false. Since proactive/autoboot are TOML-only wire policy, an identical retry re-applies the recovery profile to the Owner projection before continuation; the exact shutdown fence independently excludes supervisor/default-autoboot.
4. Finalizer failures persist a typed continuation checkpoint (`Resume_joined_idle`, `Resume_finalizing_tasks`, or exact `Resume_cleanup_ready` evidence). Only a blocked dashboard purge carrying matching typed reissue evidence may consume it. Retry continues from the recorded stage without resetting durable state or fabricating lane proof.
5. Finalization releases admission only after artifact cleanup and durable finalization. Immutable audit append happens afterward; append failure returns HTTP 500/`ok:false`, and the identical command repairs it before any HTTP 200.

A two-operation handoff remains deliberately rejected because persistence is atomic per operation file. Reusing the exact operation gives one durable fence owner and one CAS lineage.

Non-purge intents fail closed. Legacy #29295 actor-only supersession decoding remains readable, but has no current public producer.

## Proof

- `dune build @test/runtest-test_keeper_shutdown_blocked_purge_release` — 13/13
  - real HTTP auth: anonymous 401, Worker 403, Admin 200
  - live-shaped revision 2, registered historical lane, TOML present, `meta.json`/Owner/live lane absent
  - all 15 `failure_stage` values table-tested; only initial `Lane_join` is accepted
  - mismatched purge intent/remove-session/revision rejected
  - injected pre-meta and post-meta crash windows retain the exact fence and recover by identical retry
  - injected `Meta_update`, `Task_settlement`, `Pending_confirm_cleanup`, `Approval_summary_retirement`, `Registry_unregister`, `Meta_remove`, and `Session_remove`: first HTTP 500, typed checkpoint durable, actor/reason/revision mismatch rejected without write, identical retry Finalized with `audit_durable=true`
  - injected audit append failure returns HTTP 500/`ok:false`; identical retry persists audit and returns 200
  - finalization removes TOML/meta/session and only then opens admission
- ownerless admission regression — 12/12
- Keeper Owner regression — 42/42
- shutdown reconciliation settlement — 4/4
- `dune build @check` — pass
- blocking lint suite — 34/34
- deterministic-boundary / Meta Guards — pass
- `git diff --check` — pass

Touched OCaml files were formatted directly. Repository-wide `@fmt` still has unrelated current-main dune-format drift.

## Safe rollout

Required stack/deployment order: **#29312 → #29298 → #29308**.

1. Merge/deploy the store hard-cut compatibility hotfix (#29298) before restarting the current live process.
2. Deploy a binary containing this PR.
3. Re-read one blocked dashboard purge and submit `/api/v1/dashboard/agents/purge/reissue` with its exact current revision and incident reason.
4. Require HTTP 200 with `phase=finalized`, `audit_durable=true`, and `purge_reissue_completed=true`. A 500 is not success; inspect the typed operation state and retry the identical command.
5. Verify the exact shutdown fence is empty and TOML/meta/session artifacts are absent before moving to the next purge.

This PR does not mutate live state and deliberately refuses the separate blocked `Operator_stop_retain_meta` record.

