### PR TITLE
fix(goal): finish owner hard-cut contracts

### DIFF
--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -1117,7 +1117,6 @@ let validate_keeper_context ~keeper_name json =
       ; "keeper_record_id"
       ; "keeper_runtime_uid"
       ; "instructions"
-      ; "active_goal_ids"
       ; "current_task_id"
       ; "mention_keeper_ids"
       ]
@@ -1153,12 +1152,6 @@ let validate_keeper_context ~keeper_name json =
     optional_string_of_yojson
       ~context:(context ^ ".keeper_runtime_uid")
       keeper_runtime_uid
-  in
-  let* active_goal_ids = field ~context "active_goal_ids" fields in
-  let* () =
-    string_list_of_yojson
-      ~context:(context ^ ".active_goal_ids")
-      active_goal_ids
   in
   let* current_task_id = field ~context "current_task_id" fields in
   let* () =

--- a/lib/keeper/keeper_goal_reconciliation_wake.ml
+++ b/lib/keeper/keeper_goal_reconciliation_wake.ml
@@ -32,13 +32,6 @@ let exact_producer_keeper_name ~config ~completing_agent_name =
   | Keeper_identity_binding.Lookup_failed detail -> Error detail
 ;;
 
-(* A wake is a message into a keeper's queue, not a contract, so several
-   recipients is an ordinary outcome rather than a condition to fail on.
-   Several keepers carrying one goal is what a collaboration mission looks
-   like, and every one of them wants to know its Task finished -- so every one
-   of them hears. Nothing narrows the list: narrowing would need a declared
-   responsible keeper, and a Goal names none. *)
-
 (* A Goal names no keeper, so the wake goes to whoever just finished the Task
    that moved it. That is the one identity the event actually carries. *)
 let target_keeper_names ~config ~completing_agent_name ~goal_id =
@@ -90,7 +83,7 @@ let enqueue_ready ?(wake_if_present = false) ~config ~completing_agent_name
        Keeper_target_lookup_failed { goal_id; detail }
      | Ok [] ->
        Log.Keeper.warn
-         "goal reconciliation ready but nobody carries the Goal goal_id=%s \
+         "goal reconciliation ready but Task producer has no Keeper binding goal_id=%s \
           triggering_task_id=%s completing_agent=%s"
          goal_id
          triggering_task_id

--- a/lib/keeper/keeper_goal_reconciliation_wake.mli
+++ b/lib/keeper/keeper_goal_reconciliation_wake.mli
@@ -21,13 +21,11 @@ val enqueue_if_ready :
   task_id:string ->
   enqueue_outcome
 (** Re-read canonical Goal/Task state after a terminal Task commit, durably
-    enqueue one typed reconciliation stimulus, then wake its Keeper. The
-    registered or persisted Keeper assignment whose [active_goal_ids] contains
-    the Goal is authoritative. When no unambiguous assignment exists, an
-    exact live or persisted [agent_name] binding may identify the producer;
-    identity strings are never parsed to invent a Keeper name. The function
-    never mutates Goal phase, and reports a non-authoritative recovery snapshot
-    as [Backlog_read_failed]. *)
+    enqueue one typed reconciliation stimulus, then wake the exact Keeper bound
+    to the Task performer. A Goal names no owner and no per-Keeper assignment
+    participates in routing; identity strings are never parsed to invent a
+    Keeper name. The function never mutates Goal phase, and reports a
+    non-authoritative recovery snapshot as [Backlog_read_failed]. *)
 
 val reconcile_startup :
   config:Workspace.config -> reconciliation_summary

--- a/test/test_goal_verification_agent.ml
+++ b/test/test_goal_verification_agent.ml
@@ -134,6 +134,7 @@ let producer_playground (config : Workspace.config) producer =
    proof verdict need one; they do not all need an artifact to read. *)
 let link_bare_task config ~goal_id =
   let producer = "proof-producer" in
+  ignore (ensure_producer_playground config producer);
   let created =
     match
       Workspace.add_task_with_result config ~goal_id ~created_by:producer

--- a/test/test_keeper_approval_resolved_history.ml
+++ b/test/test_keeper_approval_resolved_history.ml
@@ -87,7 +87,6 @@ let seed_resolved ~base_path ~ts ~id ?(keeper = "rondo") ?(tool = "tool_execute"
     ; "turn_id", `Null
     ; "task_id", `Null
     ; "goal_id", `Null
-    ; "goal_ids", `List []
     ; "actor", `String "operator"
     ; "decision_source", `String source
     ; "authorization_source", `Null
@@ -290,7 +289,6 @@ let test_nullable_string_projection_is_literal base_path =
         ; "turn_id", `Null
         ; "task_id", `Null
         ; "goal_id", `Null
-        ; "goal_ids", `List []
         ; "actor", `Null
         ; "decision_source", `String "auto_judge"
         ; "authorization_source", `Null
@@ -315,7 +313,6 @@ let test_nullable_string_projection_is_literal base_path =
         ; "turn_id", `Null
         ; "task_id", `String "task-7"
         ; "goal_id", `String "goal-9"
-        ; "goal_ids", `List [ `String "goal-9" ]
         ; "actor", `String "operator"
         ; "decision_source", `String "human_operator"
         ; "authorization_source", `Null
@@ -343,7 +340,6 @@ let test_nullable_string_projection_is_literal base_path =
         ; "turn_id", `Null
         ; "task_id", `String "task-7"
         ; "goal_id", `String "goal-9"
-        ; "goal_ids", `List [ `String "goal-9" ]
         ; "actor", `String "operator"
         ; "decision_source", `String "human_operator"
         ; "summary_status", `String "not_requested"
@@ -361,7 +357,6 @@ let test_nullable_string_projection_is_literal base_path =
         ; "turn_id", `Null
         ; "task_id", `Null
         ; "goal_id", `Null
-        ; "goal_ids", `List []
         ; "actor", `Null
         ; "decision_source", `String "auto_judge"
         ; "summary_status", `String "not_requested"
@@ -389,7 +384,6 @@ let test_judge_evidence_passes_through base_path =
         ; "turn_id", `Null
         ; "task_id", `Null
         ; "goal_id", `Null
-        ; "goal_ids", `List []
         ; "actor", `String "operator"
         ; "decision_source", `String "auto_judge"
         ; "authorization_source", `Null

--- a/test/test_keeper_board_attention_candidate.ml
+++ b/test/test_keeper_board_attention_candidate.ml
@@ -114,16 +114,16 @@ let comment_of_signal
   }
 ;;
 
-let keeper_context ?(active_goal_ids = []) () =
+let keeper_context ?(mention_keeper_ids = [ "sangsu" ]) () =
   `Assoc
     [ "lane_keeper_name", `String "sangsu"
     ; "agent_name", `String "sangsu-agent"
     ; "keeper_record_id", `Null
     ; "keeper_runtime_uid", `Null
     ; "instructions", `String "continue"
-    ; "active_goal_ids", `List (List.map (fun id -> `String id) active_goal_ids)
     ; "current_task_id", `Null
-    ; "mention_keeper_ids", `List [ `String "sangsu" ]
+    ; ( "mention_keeper_ids"
+      , `List (List.map (fun id -> `String id) mention_keeper_ids) )
     ]
 ;;
 
@@ -253,7 +253,7 @@ let load_one ~base_path =
 let test_codec_and_context_identity_are_strict () =
   let original =
     candidate
-      ~context:(keeper_context ~active_goal_ids:[ "g-1"; "g-2" ] ())
+      ~context:(keeper_context ~mention_keeper_ids:[ "sangsu"; "peer" ] ())
       (signal "post-codec")
   in
   let encoded = A.candidate_to_json original in
@@ -280,7 +280,7 @@ let test_codec_and_context_identity_are_strict () =
   let reordered =
     candidate
       ~context:
-        (match keeper_context ~active_goal_ids:[ "g-1"; "g-2" ] () with
+        (match keeper_context ~mention_keeper_ids:[ "sangsu"; "peer" ] () with
          | `Assoc fields -> `Assoc (List.rev fields)
          | _ -> assert false)
       (signal "post-reordered")
@@ -293,7 +293,7 @@ let test_codec_and_context_identity_are_strict () =
     (A.Context_key.equal left reordered);
   let changed_list =
     candidate
-      ~context:(keeper_context ~active_goal_ids:[ "g-2"; "g-1" ] ())
+      ~context:(keeper_context ~mention_keeper_ids:[ "peer"; "sangsu" ] ())
       (signal "post-list-order")
     |> A.Context_key.of_candidate
     |> ok "changed list context"

--- a/test/test_keeper_goal_phase_projection.ml
+++ b/test/test_keeper_goal_phase_projection.ml
@@ -1,11 +1,6 @@
-(** A keeper is handed only the goals it can still progress.
+(** A keeper is handed only the shared Goals it can still progress.
 
-    [keeper_meta.active_goal_ids] records which goals were assigned to a keeper.
-    Nothing removes an id when the goal reaches a terminal phase, and
-    [resolve_active_goal_ids] only checks that the id exists — so a Completed or
-    Dropped goal stays on the list indefinitely.
-
-    Two prompt surfaces read that list: [<available_goals>] in the system prompt
+    Two prompt surfaces read the open Goal store: [<available_goals>] in the system prompt
     (via {!Keeper_unified_prompt.active_goal_summaries_of_store}) and [### Active Goals]
     in the per-turn world state (via [world_observation.active_goals]). Both
     announced terminal goals as this keeper's work, on every turn, under
@@ -87,7 +82,7 @@ let seed_terminal_phases_only config =
     }
 ;;
 
-let meta_with_goals ids =
+let keeper_meta () =
   match
     Masc_test_deps.meta_of_json_fixture
       (`Assoc
@@ -97,16 +92,6 @@ let meta_with_goals ids =
   with
   | Ok m -> m
   | Error e -> failwith ("meta_of_json failed: " ^ e)
-;;
-
-let all_ids =
-  [ "goal-executing"
-  ; "goal-verifying"
-  ; "goal-blocked"
-  ; "goal-paused"
-  ; "goal-completed"
-  ; "goal-dropped"
-  ]
 ;;
 
 let summary_ids summaries =
@@ -129,7 +114,7 @@ let summary_title_opt goal_id summaries =
 let test_system_prompt_surface_drops_terminal_goals () =
   with_workspace @@ fun config ->
   seed_all_phases config;
-  let _meta = meta_with_goals all_ids in
+  let _meta = keeper_meta () in
   let summaries = Keeper_unified_prompt.active_goal_summaries_of_store ~config in
   check (list string) "only progressable goals are offered"
     [ "goal-executing"; "goal-verifying" ]
@@ -141,7 +126,7 @@ let test_system_prompt_surface_drops_terminal_goals () =
 let test_world_observation_drops_terminal_goals () =
   with_workspace @@ fun config ->
   seed_all_phases config;
-  let meta = meta_with_goals all_ids in
+  let meta = keeper_meta () in
   let observation =
     Keeper_world_observation.observe ~pending_board_events:(Some []) ~config
       ~meta
@@ -157,7 +142,7 @@ let test_world_observation_drops_terminal_goals () =
 let test_no_goals_surface_when_all_are_terminal () =
   with_workspace @@ fun config ->
   seed_terminal_phases_only config;
-  let meta = meta_with_goals [] in
+  let meta = keeper_meta () in
   check (list string) "no goal block rather than an empty-looking one" []
     (summary_ids (Keeper_unified_prompt.active_goal_summaries_of_store ~config));
   let observation =
@@ -169,8 +154,7 @@ let test_no_goals_surface_when_all_are_terminal () =
 ;;
 
 (* An executing Goal that no Task serves is one fact addressed to every Keeper.
-   The keeper's [active_goal_ids] is empty here on purpose: the fact lives on
-   the Goal store and must surface without any keeper-side pointer.
+   The fact lives on the Goal store and surfaces without a keeper-side pointer.
 
    Four exclusions in one predicate: terminal Goals are not open work, a Goal
    already carrying a Task is not an invitation, and [Verifying] is held back so
@@ -251,7 +235,7 @@ let test_goal_with_a_linked_task_is_not_surfaced () =
    handed them: a correct list nobody renders is the state this block exists to
    end. *)
 let rendered_world_state config =
-  let meta = meta_with_goals [] in
+  let meta = keeper_meta () in
   let observation =
     Keeper_world_observation.observe ~pending_board_events:(Some []) ~config ~meta
   in

--- a/test/test_keeper_meta_current_schema.ml
+++ b/test/test_keeper_meta_current_schema.ml
@@ -64,8 +64,8 @@ let nullable_field_names =
 
 let test_current_writer_roundtrip_and_keyset () =
   check int
-    "current schema has 53 fields"
-    53
+    "current schema has 52 fields"
+    52
     (List.length Keeper_meta_json.current_field_names);
   let meta =
     match Keeper_meta_json_parse.meta_of_json (current_json ()) with

--- a/test/test_keeper_registry_hardening.ml
+++ b/test/test_keeper_registry_hardening.ml
@@ -707,11 +707,11 @@ let test_goal_reconciliation_enqueues_once_after_last_terminal_task () =
        | None -> fail "Goal disappeared")
 ;;
 
-let test_goal_reconciliation_prefers_authoritative_assignment
-      ?(assigned_paused = false)
-      ?(corrupt_persisted_assignment = false)
+let test_goal_reconciliation_targets_exact_producer
+      ?(unrelated_paused = false)
+      ?(corrupt_unrelated_meta = false)
       () =
-  let dir = temp_dir "registry_goal_reconciliation_assignment" in
+  let dir = temp_dir "registry_goal_reconciliation_producer" in
   Fun.protect
     ~finally:(fun () ->
       KR.For_testing.clear ();
@@ -731,7 +731,7 @@ let test_goal_reconciliation_prefers_authoritative_assignment
            Goal_store.upsert_goal
              config
              ~id:"goal-reconciliation-assignment"
-             ~title:"Use the assigned Keeper"
+             ~title:"Wake the exact Task producer"
              ~metric:"m"
              ~target_value:"1"
              ()
@@ -743,14 +743,14 @@ let test_goal_reconciliation_prefers_authoritative_assignment
          (Workspace_task.add_task
             ~goal_id:goal.id
             config
-            ~title:"first assigned task"
+            ~title:"first producer task"
             ~priority:2
             ~description:"first linked task");
        ignore
          (Workspace_task.add_task
             ~goal_id:goal.id
             config
-            ~title:"second assigned task"
+            ~title:"second producer task"
             ~priority:2
             ~description:"second linked task");
        let transition task_id action =
@@ -779,7 +779,7 @@ let test_goal_reconciliation_prefers_authoritative_assignment
             producer_meta);
        let assigned_meta =
          { (make_goal_reconciler_meta ()) with
-           paused = assigned_paused
+           paused = unrelated_paused
          }
        in
        ignore
@@ -787,10 +787,10 @@ let test_goal_reconciliation_prefers_authoritative_assignment
             ~base_path:config.base_path
             assigned_meta.name
             assigned_meta);
-       if corrupt_persisted_assignment
+       if corrupt_unrelated_meta
        then
          write_text_file
-           (Masc.Keeper_types_profile.keeper_meta_path config "corrupt-assignment")
+           (Masc.Keeper_types_profile.keeper_meta_path config "corrupt-unrelated")
            "{ malformed Keeper metadata";
        (match
           Masc.Keeper_goal_reconciliation_wake.enqueue_if_ready
@@ -799,34 +799,17 @@ let test_goal_reconciliation_prefers_authoritative_assignment
             ~task_id:"task-002"
         with
         | Masc.Keeper_goal_reconciliation_wake.Enqueued { keeper_name } ->
-          if corrupt_persisted_assignment
-          then fail "incomplete assignment scan was treated as routable"
-          else
-            check string
-              "assigned Keeper owns reconciliation wake"
-              assigned_meta.name
-              keeper_name
-        | Masc.Keeper_goal_reconciliation_wake.Keeper_target_lookup_failed
-            { goal_id; detail = _ } ->
-          if not corrupt_persisted_assignment
-          then fail "authoritative Goal assignment lookup unexpectedly failed"
-          else check string "incomplete scan remains a typed failure" goal.id goal_id
-        | _ -> fail "authoritative Goal assignment did not produce a durable wake");
-       check int "producer does not receive an assignment-owned wake" 0
+          check string
+            "Task producer receives reconciliation wake"
+            producer_meta.name
+            keeper_name
+        | _ -> fail "exact Task producer did not receive a durable wake");
+       check int "producer receives one reconciliation wake" 1
          (registry_snapshot ~base_path:config.base_path producer_meta.name
           |> Keeper_event_queue.length);
-       if corrupt_persisted_assignment
-       then
-         check int "assigned Keeper does not receive a partial-scan wake" 0
-           (registry_snapshot ~base_path:config.base_path assigned_meta.name
-            |> Keeper_event_queue.length);
-       if corrupt_persisted_assignment
-       then (
-         let summary =
-           Masc.Keeper_goal_reconciliation_wake.reconcile_startup ~config
-         in
-         check int "assignment scan error is classified as failed" 1 summary.failed_count;
-         check int "assignment scan error is not unresolved" 0 summary.unresolved_count);
+       check int "unrelated Keeper receives no reconciliation wake" 0
+         (registry_snapshot ~base_path:config.base_path assigned_meta.name
+          |> Keeper_event_queue.length);
        let discovery =
          Keeper_event_queue_persistence.discover_keeper_names_with_durable_state
            ~base_path:config.base_path
@@ -836,20 +819,20 @@ let test_goal_reconciliation_prefers_authoritative_assignment
        | None ->
          check
            (list string)
-           "only the assigned canonical Keeper receives the wake"
-           (if corrupt_persisted_assignment then [] else [ assigned_meta.name ])
+           "only the exact producer receives the wake"
+           [ producer_meta.name ]
            discovery.keeper_names)
 ;;
 
-let test_goal_reconciliation_keeps_paused_assignment_authoritative () =
-  test_goal_reconciliation_prefers_authoritative_assignment
-    ~assigned_paused:true
+let test_goal_reconciliation_ignores_unrelated_paused_keeper () =
+  test_goal_reconciliation_targets_exact_producer
+    ~unrelated_paused:true
     ()
 ;;
 
-let test_goal_reconciliation_fails_closed_on_assignment_scan_error () =
-  test_goal_reconciliation_prefers_authoritative_assignment
-    ~corrupt_persisted_assignment:true
+let test_goal_reconciliation_ignores_unrelated_corrupt_meta () =
+  test_goal_reconciliation_targets_exact_producer
+    ~corrupt_unrelated_meta:true
     ()
 ;;
 
@@ -1051,10 +1034,11 @@ let test_goal_reconciliation_retry_after_keeper_registration () =
        let retried =
          Masc.Keeper_goal_reconciliation_wake.reconcile_startup ~config
        in
-       check int "later registered owner receives durable event" 1 retried.enqueued_count;
-       check bool "later reconciliation emits wake" true
+       check int "unrelated Keeper does not acquire producer wake" 0 retried.enqueued_count;
+       check int "missing producer remains unresolved" 1 retried.unresolved_count;
+       check bool "unrelated Keeper is not woken" false
          (Atomic.get entry.fiber_wakeup);
-       check int "later reconciliation enqueues once" 1
+       check int "unrelated Keeper queue stays empty" 0
          (registry_snapshot ~base_path:config.base_path meta.name
           |> Keeper_event_queue.length))
 ;;
@@ -1470,17 +1454,17 @@ let () =
             `Quick
             test_goal_reconciliation_enqueues_once_after_last_terminal_task
         ; test_case
-            "goal reconciliation prefers authoritative assignment"
+            "goal reconciliation targets exact Task producer"
             `Quick
-            test_goal_reconciliation_prefers_authoritative_assignment
+            test_goal_reconciliation_targets_exact_producer
         ; test_case
-            "paused Goal assignment remains authoritative"
+            "unrelated paused Keeper does not affect producer routing"
             `Quick
-            test_goal_reconciliation_keeps_paused_assignment_authoritative
+            test_goal_reconciliation_ignores_unrelated_paused_keeper
         ; test_case
-            "Goal reconciliation fails closed on assignment scan error"
+            "unrelated corrupt metadata does not affect producer routing"
             `Quick
-            test_goal_reconciliation_fails_closed_on_assignment_scan_error
+            test_goal_reconciliation_ignores_unrelated_corrupt_meta
         ; test_case
             "restart scan retries missed reconciliation exactly once"
             `Quick

--- a/test/test_keeper_task_create_typed_failure.ml
+++ b/test/test_keeper_task_create_typed_failure.ml
@@ -41,7 +41,7 @@ let make_path_unwritable path =
   if not (Sys.file_exists path) then Unix.mkdir path 0o755
 ;;
 
-let meta_with_active_goals goal_ids =
+let keeper_meta () =
   let name = "task-create-typed-failure-test" in
   match
     Masc_test_deps.meta_of_json_fixture
@@ -49,8 +49,6 @@ let meta_with_active_goals goal_ids =
         [ "name", `String name
         ; "agent_name", `String (Keeper_identity.keeper_agent_name name)
         ; "trace_id", `String "trace-task-create-typed-failure"
-        ; ( "active_goal_ids"
-          , `List (List.map (fun goal_id -> `String goal_id) goal_ids) )
         ])
   with
   | Ok meta -> meta
@@ -64,7 +62,7 @@ let test_task_create_goal_link_write_failure_returns_typed_failure () =
      | Ok _ -> ()
      | Error msg -> fail ("upsert_goal failed: " ^ msg));
     make_path_unwritable (Workspace_goal_index.goal_task_links_path config);
-    let meta = meta_with_active_goals [ "goal-a" ] in
+    let meta = keeper_meta () in
     let execution =
       Task.handle_keeper_task_tool_with_outcome
         ~config

--- a/test/test_keeper_task_create_typed_failure.ml
+++ b/test/test_keeper_task_create_typed_failure.ml
@@ -4,9 +4,10 @@
     Before this fix, the handler called [Workspace_task.add_task], which
     folds [add_task_with_result]'s [Error] into a display string and drops
     it. This branch then unconditionally returned [ok:true,
-    typed_outcome:Progress] -- a failed goal-link write (or backlog write)
-    was invisible to the keeper. See [Workspace_task.add_task_with_result]
-    for the typed error this now surfaces instead. *)
+    typed_outcome:Progress] -- a failed explicit goal-link write (or backlog
+    write) was invisible to the keeper. See
+    [Workspace_task.add_task_with_result] for the typed error this now
+    surfaces instead. *)
 
 open Alcotest
 open Masc
@@ -73,6 +74,7 @@ let test_task_create_goal_link_write_failure_returns_typed_failure () =
             [ "title", `String "Blocked by goal-link write failure"
             ; "description", `String "must not silently report success"
             ; "priority", `Int 3
+            ; "goal_id", `String "goal-a"
             ])
     in
     (* An IO/write failure is [Runtime_failure], not [Workflow_rejection]:

--- a/test/test_keeper_task_outcomes.ml
+++ b/test/test_keeper_task_outcomes.ml
@@ -27,28 +27,26 @@ let cleanup_dir dir =
   in
   try rm dir with _ -> ()
 
-let meta_with_active_goals goal_ids =
+let keeper_meta () =
   match
     Masc_test_deps.meta_of_json_fixture
       (`Assoc
         [ "name", `String "task-create-test"
         ; "agent_name", `String "keeper-task-create-test-agent"
         ; "trace_id", `String "trace-task-create-test"
-        ; ( "active_goal_ids"
-          , `List (List.map (fun goal_id -> `String goal_id) goal_ids) )
         ])
   with
   | Ok meta -> meta
   | Error err -> fail ("meta_of_json_fixture failed: " ^ err)
 
-let test_task_create_multi_active_goals_without_goal_id_is_unscoped () =
+let test_task_create_without_goal_id_is_unscoped () =
   let base_path = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_path)
     (fun () ->
        let config = Masc.Workspace.default_config base_path in
        ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
-       let meta = meta_with_active_goals [ "goal-a"; "goal-b" ] in
+       let meta = keeper_meta () in
        let payload =
          Task.handle_keeper_task_tool
            ~config
@@ -81,7 +79,7 @@ let test_tasks_list_reports_truncation () =
     (fun () ->
        let config = Masc.Workspace.default_config base_path in
        ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
-       let meta = meta_with_active_goals [] in
+       let meta = keeper_meta () in
        for index = 1 to 4 do
          ignore
            (Task.handle_keeper_task_tool
@@ -124,7 +122,7 @@ let test_tasks_list_returns_snapshot_and_unchanged () =
     (fun () ->
        let config = Masc.Workspace.default_config base_path in
        ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
-       let meta = meta_with_active_goals [] in
+       let meta = keeper_meta () in
        let execution =
          Task.handle_keeper_task_tool_with_outcome
            ~config
@@ -187,7 +185,7 @@ let test_tasks_list_recovery_is_degraded_and_never_unchanged () =
             ~description:"");
        Out_channel.with_open_text (Masc.Workspace.backlog_path config) (fun oc ->
          output_string oc "{not valid json");
-       let meta = meta_with_active_goals [] in
+       let meta = keeper_meta () in
        let execute args =
          Task.handle_keeper_task_tool_with_outcome
            ~config
@@ -226,7 +224,7 @@ let test_tasks_list_revision_covers_projected_contents () =
             ~title:"First workspace task"
             ~priority:1
             ~description:"");
-       let meta = meta_with_active_goals [] in
+       let meta = keeper_meta () in
        let snapshot () =
          match
            (Task.handle_keeper_task_tool_with_outcome
@@ -320,7 +318,7 @@ let test_done_missing_task_id_emits_typed_error () =
     (fun () ->
        let config = Masc.Workspace.default_config base_path in
        ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
-       let meta = meta_with_active_goals [] in
+       let meta = keeper_meta () in
        (* task_id omitted -> early workflow_rejection path. *)
        match
          rejected_done_typed_outcome ~base_path config meta
@@ -342,7 +340,7 @@ let test_done_missing_evidence_refs_emits_typed_error () =
     (fun () ->
        let config = Masc.Workspace.default_config base_path in
        ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
-       let meta = meta_with_active_goals [] in
+       let meta = keeper_meta () in
        match
          rejected_done_typed_outcome ~base_path config meta
            (`Assoc
@@ -366,7 +364,7 @@ let test_done_failed_transition_emits_typed_error () =
     (fun () ->
        let config = Masc.Workspace.default_config base_path in
        ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
-       let meta = meta_with_active_goals [] in
+       let meta = keeper_meta () in
        (* A done on a task that does not exist fails the transition -> the
           [else] branch must emit a typed [Error], not [None]. *)
        match
@@ -443,7 +441,7 @@ let test_strict_done_submits_for_verification () =
         | Error error ->
           fail
             ("claim failed: " ^ Masc_domain.masc_error_to_string error));
-       let meta = meta_with_active_goals [] in
+       let meta = keeper_meta () in
        ignore
          (Task.handle_keeper_task_tool
             ~config
@@ -498,7 +496,7 @@ let test_default_done_is_terminal () =
         | Error error ->
           fail
             ("claim failed: " ^ Masc_domain.masc_error_to_string error));
-       let meta = meta_with_active_goals [] in
+       let meta = keeper_meta () in
        let execution =
          Task.handle_keeper_task_tool_with_outcome
            ~config
@@ -576,9 +574,9 @@ let () =
   run "keeper task outcomes"
     [ ( "outcomes"
       , [ test_case
-            "keeper_task_create treats ambiguous active_goal_ids as advisory"
+            "keeper_task_create without goal_id remains unscoped"
             `Quick
-            test_task_create_multi_active_goals_without_goal_id_is_unscoped
+            test_task_create_without_goal_id_is_unscoped
         ; test_case
             "keeper_tasks_list reports a truncated page"
             `Quick

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -577,9 +577,6 @@ let test_turn_context_fields_stored () =
     Alcotest.(check (option string)) "task_id field"
       (Some "task-runtime-trust")
       (Safe_ops.json_string_opt "task_id" entry);
-    Alcotest.(check (list string)) "goal_ids field"
-      ["goal-short"; "goal-long"]
-      Yojson.Safe.Util.(entry |> member "goal_ids" |> to_list |> List.map to_string);
     Alcotest.(check (option string)) "sandbox_profile field"
       (Some "docker")
       (Safe_ops.json_string_opt "sandbox_profile" entry);

--- a/test/test_keeper_wake_turn_context.ml
+++ b/test/test_keeper_wake_turn_context.ml
@@ -398,7 +398,7 @@ let test_direct_and_autonomous_share_system_prompt () =
   check bool "shared contract leads with the result" true
     (contains_prose ~needle:"lead with the result" base_system_prompt)
 
-let test_unresolved_goal_keeps_one_stable_safety_contract () =
+let test_open_goal_store_keeps_one_stable_safety_contract () =
   with_repo_prompt_config @@ fun () ->
   let meta_with_goal =
     meta_of_json
@@ -434,7 +434,7 @@ let test_unresolved_goal_keeps_one_stable_safety_contract () =
     "unresolved goal does not split direct and autonomous prompts"
     base_system_prompt
     autonomous_system_prompt;
-  check bool "unresolved goal remains as a bare id" true
+  check bool "removed per-Keeper goal id is absent" false
     (contains ~needle:"- missing-goal\n" base_system_prompt);
   check bool "identity block is preserved" true
     (contains ~needle:"<identity>" base_system_prompt);
@@ -634,7 +634,7 @@ let () =
             `Quick
             test_direct_and_autonomous_share_system_prompt;
           test_case "unresolved goal keeps one stable safety contract" `Quick
-            test_unresolved_goal_keeps_one_stable_safety_contract;
+            test_open_goal_store_keeps_one_stable_safety_contract;
         ] );
       ( "threaded turn decision",
         [

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -21,7 +21,7 @@ let cleanup_dir dir =
   in
   try rm dir with _ -> ()
 
-let make_keeper_meta ?agent_name ?current_task_id ?(goal_ids = []) name =
+let make_keeper_meta ?agent_name ?current_task_id name =
   let agent_name =
     Option.value agent_name
       ~default:(Masc.Keeper_identity.keeper_agent_name name)
@@ -36,14 +36,6 @@ let make_keeper_meta ?agent_name ?current_task_id ?(goal_ids = []) name =
     (match current_task_id with
      | Some task_id -> [ ("current_task_id", `String task_id) ]
      | None -> [])
-    @
-    (match goal_ids with
-     | [] -> []
-     | ids ->
-         [
-           ( "active_goal_ids",
-             `List (List.map (fun goal_id -> `String goal_id) goal_ids) );
-         ])
   in
   match Masc_test_deps.meta_of_json_fixture (`Assoc fields) with
   | Ok meta -> meta
@@ -640,7 +632,6 @@ let test_runtime_mcp_keeper_log_context_uses_keeper_trace_and_current_turn () =
   let meta =
     make_keeper_meta
       ~current_task_id:"task-123"
-      ~goal_ids:[ "goal-1"; "goal-2" ]
       keeper_name
   in
   Fun.protect
@@ -730,7 +721,6 @@ let test_record_runtime_mcp_keeper_tool_trace_logs_and_broadcasts () =
   let meta =
     make_keeper_meta
       ~current_task_id:"task-456"
-      ~goal_ids:[ "goal-runtime" ]
       keeper_name
   in
   let subscriber_id = "test-runtime-mcp-tool-trace" in
@@ -792,8 +782,6 @@ let test_record_runtime_mcp_keeper_tool_trace_logs_and_broadcasts () =
         (row |> U.member "keeper_turn_id" |> U.to_int);
       check string "task id" "task-456"
         (row |> U.member "task_id" |> U.to_string);
-      check int "goal id count" 1
-        (row |> U.member "goal_ids" |> U.to_list |> List.length);
       let runtime_contract = row |> U.member "runtime_contract" in
       check string "runtime contract agent"
         (Masc.Keeper_identity.keeper_agent_name keeper_name)

--- a/test/test_workspace.ml
+++ b/test/test_workspace.ml
@@ -1691,7 +1691,7 @@ let keeper_meta_for_self_filter agent_name =
   | Error err -> Alcotest.fail ("keeper_meta_for_self_filter failed: " ^ err)
 
 (* Same canonical-name requirement as [keeper_meta_for_self_filter]. *)
-let keeper_meta_for_goal_filter agent_name active_goal_ids =
+let keeper_meta_for_goal_filter agent_name =
   let name =
     match Keeper_identity.canonical_keeper_name_from_agent_name agent_name with
     | Some keeper -> keeper
@@ -1735,7 +1735,7 @@ let test_read_backlog_snapshot_falls_back_to_unscoped_claimable_task () =
       Workspace.add_task config ~goal_id:"goal-b" ~title:"Goal B work"
         ~priority:1 ~description:""
     in
-    let meta = keeper_meta_for_goal_filter keeper [ "goal-a" ] in
+    let meta = keeper_meta_for_goal_filter keeper in
     let snapshot =
       Keeper_world_observation_inputs.read_backlog_snapshot ~config ~meta
     in
@@ -1918,7 +1918,7 @@ let test_read_current_task_preserves_unavailable_and_missing () =
 let test_self_authored_scoped_task_does_not_hide_peer_work () =
   with_test_env (fun config ->
     let keeper = "keeper-goal-filter-agent" in
-    let meta = keeper_meta_for_goal_filter keeper [ "goal-a" ] in
+    let meta = keeper_meta_for_goal_filter keeper in
     let _ =
       Workspace.add_task config ~goal_id:"goal-a" ~created_by:meta.name
         ~title:"Own goal routing task" ~priority:1 ~description:""


### PR DESCRIPTION
## Summary
- remove the retired per-Keeper Goal field from the durable Board-attention context validator
- make Goal proof fixtures materialize the producer root that the independent verifier is required to inspect
- align strict metadata, audit, tool-log, prompt, and reconciliation tests with ownerless shared Goals and exact Task-producer wake routing

## Exact base-main failure
- main run 32478443892 at `58ee736e5cddada0935f38da491f9711b0dc856e` is red
- Goal verifier tests defer five proof rows because `proof-producer` has no readable verification root
- focused suites reject current Board candidates because the reader still requires removed `active_goal_ids`, then expose the same stale field across strict metadata fixtures and projections

## Verification
- `ocamlformat --check` on every changed OCaml file
- OCaml parser pass with `ocamlc -stop-after parsing` on every changed implementation/interface
- OCaml structure ratchet: PASS
- stringly-boundary ratchet: PASS
- HITL exact-flow self-test/check: PASS
- Keeper tool-boundary matrix ratchet: PASS
- silent-failure ratchet: PASS
- `git diff --check`: PASS

CI is the compile/test authority; no local Dune build.