### PR TITLE
fix(tui): align task, keeper, and planning read contracts

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -230,6 +230,7 @@
   fs_compat
   time_compat
   masc_log
+  masc_goal
   masc_workspace
   masc_backend
   masc_process

--- a/bin/masc_tui.ml
+++ b/bin/masc_tui.ml
@@ -828,6 +828,7 @@ let run_with_eio_context f =
   Eio.Switch.run @@ fun sw ->
   Eio_guard.enable ();
   Eio.Switch.on_release sw Eio_guard.disable;
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Eio_context.set_env env;
   Eio_context.set_switch sw;
   Eio_context.set_net (Eio.Stdenv.net env);

--- a/bin/masc_tui_ansi.ml
+++ b/bin/masc_tui_ansi.ml
@@ -99,10 +99,12 @@ let status_color status =
 (** Task status icon *)
 let task_status_icon status =
   match status with
-  | "done" | "completed" -> "\xe2\x97\x8f"  (* filled circle *)
-  | "in_progress" | "claimed" -> "\xe2\x97\x90"  (* half circle *)
-  | "pending" | "todo" -> "\xe2\x97\x8b"  (* empty circle *)
-  | _ -> "\xe2\x97\x8b"
+  | Masc_domain.Done _ -> "\xe2\x97\x8f"  (* filled circle *)
+  | Masc_domain.Claimed _
+  | Masc_domain.InProgress _
+  | Masc_domain.AwaitingVerification _ -> "\xe2\x97\x90"  (* half circle *)
+  | Masc_domain.Todo -> "\xe2\x97\x8b"  (* empty circle *)
+  | Masc_domain.Cancelled _ -> "\xc3\x97"
 
 (** Priority indicator *)
 let priority_indicator p =
@@ -119,21 +121,6 @@ let soul_color profile =
   | "balanced" -> Ansi.cyan
   | "creative" -> Ansi.yellow
   | _ -> Ansi.white
-
-(** Shorten model string for display *)
-let short_model s =
-  (* Extract the part after the last colon, or last slash, keeping it short *)
-  let s = match String.index_opt s ':' with
-    | Some i -> String.sub s (i + 1) (String.length s - i - 1)
-    | None -> s
-  in
-  if String.length s > 24 then String.sub s 0 21 ^ "..."
-  else s
-
-(** Format a boolean as on/off indicator *)
-let bool_indicator b =
-  if b then Ansi.green ^ "on" ^ Ansi.reset
-  else Ansi.gray ^ "off" ^ Ansi.reset
 
 (** Format a timestamp for display (show date portion or relative) *)
 let short_ts s =

--- a/bin/masc_tui_loader.ml
+++ b/bin/masc_tui_loader.ml
@@ -1,5 +1,9 @@
 (** TUI data loading functions — split from masc_tui.ml (#3808) *)
 
+module Keeper_meta_store = Masc.Keeper_meta_store
+module Keeper_types_support = Masc.Keeper_types_support
+module Keeper_types_profile = Masc.Keeper_types_profile
+
 open Masc_tui_types
 open Tui_decode
 open Masc_tui_http
@@ -7,41 +11,64 @@ open Masc_tui_http
 let report path err =
   Printf.eprintf "[masc-tui] decode failed for %s: %s\n%!" path err
 
-(** Load keepers from .masc/keepers/ *)
-let load_keepers (base_path : string) : keeper list =
-  let keepers_dir = Filename.concat (Filename.concat base_path Common.masc_dirname) Common.keepers_runtime_dirname in
-  if Sys.file_exists keepers_dir && Sys.is_directory keepers_dir then
-    Sys.readdir keepers_dir
-    |> Array.to_list
-    |> List.filter (fun f ->
-         Filename.check_suffix f ".json"
-         && not (String.contains f '.'))  (* This won't work, use different filter *)
-    |> (fun _ ->
-         (* Re-filter: only files that are exactly <name>.json, not <name>.reward-model.json *)
-         Sys.readdir keepers_dir
-         |> Array.to_list
-         |> List.filter (fun f ->
-              Filename.check_suffix f ".json"
-              && (let base = Filename.chop_suffix f ".json" in
-                  not (String.contains base '.'))))
-    |> List.filter_map (fun f ->
-         try
-           let path = Filename.concat keepers_dir f in
-           let json = Yojson.Safe.from_file path in
-           match Tui_decode.decode_keeper ~filename:f json with
-           | Ok keeper -> Some keeper
-           | Error err ->
-               report path err;
-               None
-         with Yojson.Json_error err ->
-           report (Filename.concat keepers_dir f) ("invalid JSON: " ^ err);
-           None
-         | Sys_error err ->
-           report (Filename.concat keepers_dir f) err;
-           None
-       )
-    |> List.sort (fun a b -> String.compare a.k_name b.k_name)
-  else []
+let summarize_errors label errors =
+  match List.rev errors with
+  | [] -> None
+  | first :: rest ->
+      let suffix =
+        match rest with
+        | [] -> ""
+        | _ -> Printf.sprintf " (+%d more)" (List.length rest)
+      in
+      Some (Printf.sprintf "%s: %s%s" label first suffix)
+
+(** Load keepers through the canonical metadata classifier and typed store.
+    The classifier preserves valid dotted names and excludes sidecars. *)
+let load_keepers (base_path : string) : keeper list * string option =
+  let config = Workspace_core.default_config base_path in
+  match Keeper_meta_store.persisted_keeper_names_result config with
+  | Error err ->
+      report (Keeper_types_profile.keeper_dir config) err;
+      [], Some ("keeper metadata unavailable: " ^ err)
+  | Ok names ->
+      let keepers, errors =
+        List.fold_left
+          (fun (keepers, errors) name ->
+             let path = Keeper_types_profile.keeper_meta_path config name in
+             match Keeper_meta_store.read_meta config name with
+             | Ok (Some meta) ->
+                 Tui_decode.keeper_of_meta meta :: keepers, errors
+             | Ok None ->
+                 let err = "metadata disappeared during refresh" in
+                 report path err;
+                 keepers, (Printf.sprintf "%s: %s" name err :: errors)
+             | Error err ->
+                 report path err;
+                 keepers, (Printf.sprintf "%s: %s" name err :: errors))
+          ([], []) names
+      in
+      ( List.sort (fun a b -> String.compare a.k_name b.k_name) keepers
+      , summarize_errors "keeper metadata read failed" errors )
+
+(** Load active tasks from the canonical workspace backlog. Terminal tasks
+    remain available in Planning rollups but do not occupy the Overview list. *)
+let load_active_tasks (base_path : string) : task list * string option =
+  let config = Workspace_core.default_config base_path in
+  let path = Workspace_backlog.backlog_path config in
+  match Workspace_backlog.read_backlog_observation_with_source_r config with
+  | Error err ->
+      report path err;
+      [], Some ("task backlog unavailable: " ^ err)
+  | Ok observation ->
+      let recovery_error =
+        match observation.recovered_from with
+        | None -> None
+        | Some recovery ->
+            report path recovery.primary_error;
+            Some ("task backlog recovered from backup: " ^ recovery.primary_error)
+      in
+      ( Tui_decode.active_tasks_of_domain observation.observed_backlog.tasks
+      , recovery_error )
 
 (** Read the last N lines from a file (tail) *)
 let read_last_lines path n =
@@ -72,11 +99,8 @@ let parse_log_entry (line : string) : log_entry option =
 
 (** Find the most recent metrics file for a keeper *)
 let find_metrics_files (base_path : string) (keeper_name : string) : string list =
-  let metrics_dir = Filename.concat
-    (Filename.concat
-       (Filename.concat base_path Common.masc_dirname)
-       "keepers")
-    (Filename.concat keeper_name "metrics") in
+  let config = Workspace_core.default_config base_path in
+  let metrics_dir = Keeper_types_support.keeper_metrics_dir config keeper_name in
   if not (Sys.file_exists metrics_dir && Sys.is_directory metrics_dir) then []
   else begin
     (* List year-month directories, pick the most recent *)
@@ -178,35 +202,15 @@ let load_from_masc_dir (state : state) (base_path : string) =
     else []
   );
 
-  (* Load tasks *)
-  let tasks_dir = Filename.concat masc_dir "tasks" in
-  state.tasks <- (
-    if Sys.file_exists tasks_dir && Sys.is_directory tasks_dir then
-      Sys.readdir tasks_dir
-      |> Array.to_list
-      |> List.filter (fun f -> Filename.check_suffix f ".json")
-      |> List.filter_map (fun f ->
-           try
-             let path = Filename.concat tasks_dir f in
-             let json = Yojson.Safe.from_file path in
-             match Tui_decode.decode_task json with
-             | Ok task -> Some task
-             | Error err ->
-                 report path err;
-                 None
-           with Yojson.Json_error err ->
-             report (Filename.concat tasks_dir f) ("invalid JSON: " ^ err);
-             None
-           | Sys_error err ->
-             report (Filename.concat tasks_dir f) err;
-             None
-         )
-      |> List.sort (fun a b -> compare a.priority b.priority)
-    else []
-  );
+  (* Load tasks from their single durable source. *)
+  let tasks, tasks_error = load_active_tasks base_path in
+  state.tasks <- tasks;
+  state.tasks_error <- tasks_error;
 
   (* Load keepers *)
-  state.keepers <- load_keepers base_path;
+  let keepers, keepers_error = load_keepers base_path in
+  state.keepers <- keepers;
+  state.keepers_error <- keepers_error;
 
   (* Clamp cursor if keepers changed *)
   if state.keeper_cursor >= List.length state.keepers then
@@ -442,75 +446,9 @@ let load_overview ~(host : string) ~(port : int) :
           ov_generated_at;
         }
 
-let decode_planning_goal json =
-  let* pg_id = required_string_field json "id" in
-  let* pg_title = required_string_field json "title" in
-  let* raw_status = required_string_field json "status" in
-  let* pg_status =
-    match String.lowercase_ascii raw_status with
-    | "active" -> Ok Planning_goal_active
-    | "paused" -> Ok Planning_goal_paused
-    | "done" -> Ok Planning_goal_done
-    | "dropped" -> Ok Planning_goal_dropped
-    | other ->
-        Error
-          (Printf.sprintf
-             "unknown planning goal status %S (normalized %S)"
-             raw_status
-             other)
-  in
-  let* pg_phase = required_string_field json "phase" in
-  let* pg_priority = required_int_field json "priority" in
-  let* pg_due_date = optional_string_field json "due_date" in
-  let* pg_metric = optional_string_field json "metric" in
-  let* pg_target_value = optional_string_field json "target_value" in
-  Ok
-    {
-      pg_id;
-      pg_title;
-      pg_status;
-      pg_phase;
-      pg_priority;
-      pg_due_date;
-      pg_metric;
-      pg_target_value;
-    }
-
-let decode_planning_goals json_list =
-  decode_list "goals" decode_planning_goal json_list
-
-let decode_planning_rollup json =
-  let* pr_active = required_int_field json "active_count" in
-  let* pr_paused = required_int_field json "paused_count" in
-  let* pr_done = required_int_field json "done_count" in
-  let* pr_dropped = required_int_field json "dropped_count" in
-  Ok { pr_active; pr_paused; pr_done; pr_dropped }
-
-let decode_planning_backlog json =
-  let* pb_todo = required_int_field json "todo" in
-  let* pb_claimed = required_int_field json "claimed" in
-  let* pb_running = required_int_any_field json [ "in_progress"; "running" ] in
-  let* pb_done = required_int_field json "done" in
-  let* pb_cancelled = required_int_field json "cancelled" in
-  Ok { pb_todo; pb_claimed; pb_running; pb_done; pb_cancelled }
-
 (** Load planning snapshot from /api/v1/dashboard/planning *)
 let load_planning ~(host : string) ~(port : int) :
     (planning_snapshot, string) result =
   match fetch_dashboard_planning ~host ~port with
   | Error err -> Error ("planning load failed: " ^ err)
-  | Ok json ->
-      let* goals_json = required_list_field json "goals" in
-      let* goals = decode_planning_goals goals_json in
-      let* rollup_json = required_object_field json "rollup" in
-      let* rollup = decode_planning_rollup rollup_json in
-      let* backlog_json = required_object_field json "task_backlog" in
-      let* backlog = decode_planning_backlog backlog_json in
-      let* generated_at = required_string_field json "generated_at" in
-      Ok
-        {
-          pl_goals = goals;
-          pl_rollup = rollup;
-          pl_backlog = backlog;
-          pl_generated_at = generated_at;
-        }
+  | Ok json -> Tui_decode.decode_planning_snapshot json

--- a/bin/masc_tui_render.ml
+++ b/bin/masc_tui_render.ml
@@ -893,7 +893,7 @@ let render_keeper_detail (state : state) =
     (* Current work section *)
     add_section "Current Work";
     add_row "Task:" (Option.value ~default:"-" k.k_current_task_id);
-    add_row "Last Blocker:" (Option.value ~default:"-" k.k_last_blocker);
+    add_row "Last Blocker:" (Tui_decode.keeper_blocker_for_terminal k);
     add_empty ();
 
     (* Live Context section (Phase 2) *)

--- a/bin/masc_tui_render.ml
+++ b/bin/masc_tui_render.ml
@@ -45,6 +45,21 @@ let attention_severity_color = function
   | Attention_warning -> Ansi.yellow
   | Attention_info -> Ansi.cyan
 
+let task_line (task : task) =
+  let status = Masc_domain.task_status_to_string task.status in
+  let assignee =
+    match Masc_domain.task_assignee_of_status task.status with
+    | Some name -> Printf.sprintf " @%s" name
+    | None -> ""
+  in
+  Printf.sprintf "  %s [%s] %s (%s%s) %s"
+    (task_status_icon task.status)
+    task.id
+    task.title
+    status
+    assignee
+    (priority_indicator task.priority)
+
 (** Render the dashboard (original view) *)
 let render_dashboard (state : state) =
   let (rows, cols) = get_terminal_size () in
@@ -144,21 +159,9 @@ let render_dashboard (state : state) =
   else
     for i = 0 to task_rows - 1 do
       let t = List.nth state.tasks i in
-      let claimed_str = match t.claimed_by with
-        | Some a -> Printf.sprintf " @%s" a
-        | None -> ""
-      in
-      let task_line = Printf.sprintf "  %s [%s] %s (%s%s) %s"
-        (task_status_icon t.status)
-        t.id
-        t.title
-        t.status
-        claimed_str
-        (priority_indicator t.priority)
-      in
       Buffer.add_string buf (Printf.sprintf "%s%s%s %s %s%s%s\n"
         Ansi.gray Ansi.box_v Ansi.reset
-        (fit_width task_line (cols - 4))
+        (fit_width (task_line t) (cols - 4))
         Ansi.gray Ansi.box_v Ansi.reset)
     done;
 
@@ -281,25 +284,21 @@ let render_overview (state : state) =
     (String.make (max 0 (cols - 10)) ' ')
     Ansi.gray Ansi.box_v Ansi.reset);
 
-  let task_rows = min 5 (List.length state.tasks) in
-  if task_rows = 0 then
+  let task_capacity =
+    match state.tasks_error with
+    | None -> 5
+    | Some err ->
+        box_line buf cols
+          (Ansi.red ^ "  " ^ fit_width err (cols - 8) ^ Ansi.reset);
+        4
+  in
+  let task_rows = min task_capacity (List.length state.tasks) in
+  if task_rows = 0 && Option.is_none state.tasks_error then
     box_line buf cols (Ansi.dim ^ "  (no tasks)" ^ Ansi.reset)
   else
     for i = 0 to task_rows - 1 do
       let t = List.nth state.tasks i in
-      let claimed_str = match t.claimed_by with
-        | Some a -> Printf.sprintf " @%s" a
-        | None -> ""
-      in
-      let task_line = Printf.sprintf "  %s [%s] %s (%s%s) %s"
-        (task_status_icon t.status)
-        t.id
-        t.title
-        t.status
-        claimed_str
-        (priority_indicator t.priority)
-      in
-      box_line buf cols task_line
+      box_line buf cols (task_line t)
     done;
 
   box_bottom buf cols;
@@ -554,17 +553,15 @@ let render_board_read (state : state) (post : board_post) =
   print_string (Buffer.contents buf);
   flush stdout
 
-let planning_status_label = function
-  | Planning_goal_active -> "active"
-  | Planning_goal_paused -> "paused"
-  | Planning_goal_done -> "done"
-  | Planning_goal_dropped -> "dropped"
+let planning_phase_label phase = Goal_phase.to_string phase
 
-let planning_status_color = function
-  | Planning_goal_active -> Ansi.cyan
-  | Planning_goal_paused -> Ansi.yellow
-  | Planning_goal_done -> Ansi.green
-  | Planning_goal_dropped -> Ansi.red
+let planning_phase_color = function
+  | Goal_phase.Executing -> Ansi.cyan
+  | Goal_phase.Blocked -> Ansi.red
+  | Goal_phase.Paused -> Ansi.yellow
+  | Goal_phase.Verifying -> Ansi.magenta
+  | Goal_phase.Completed -> Ansi.green
+  | Goal_phase.Dropped -> Ansi.gray
 
 (** Render the Planning surface (list view). *)
 let render_planning_list (state : state) =
@@ -607,8 +604,11 @@ let render_planning_list (state : state) =
        done
    | Some p ->
        let rollup =
-         Printf.sprintf "  Active: %d  Paused: %d  Done: %d  Dropped: %d"
-           p.pl_rollup.pr_active p.pl_rollup.pr_paused p.pl_rollup.pr_done p.pl_rollup.pr_dropped
+         Printf.sprintf
+           "  Executing: %d  Paused/Blocked: %d  Verifying: %d  Done: %d  Dropped: %d"
+           p.pl_rollup.pr_active p.pl_rollup.pr_paused
+           p.pl_rollup.pr_verifying p.pl_rollup.pr_done
+           p.pl_rollup.pr_dropped
        in
        let backlog =
          Printf.sprintf "  Backlog: todo=%d  claimed=%d  running=%d  done=%d  cancelled=%d"
@@ -639,8 +639,8 @@ let render_planning_list (state : state) =
              let depth = planning_goal_depth p.pl_goals g in
              let indent = String.make (depth * 2) ' ' in
              let branch = if depth > 0 then "└─ " else "  " in
-             let status_color = planning_status_color g.pg_status in
-             let status_label = planning_status_label g.pg_status in
+             let status_color = planning_phase_color g.pg_phase in
+             let status_label = planning_phase_label g.pg_phase in
              let due = match g.pg_due_date with Some d -> "  " ^ d | None -> "" in
              let line =
                Printf.sprintf "%s%s%s[%s]%s P%d  %s%s"
@@ -679,8 +679,8 @@ let render_planning_detail (state : state) (goal : planning_goal) =
   Buffer.add_string buf Ansi.clear;
   Buffer.add_string buf Ansi.hide_cursor;
 
-  let status_color = planning_status_color goal.pg_status in
-  let status_label = planning_status_label goal.pg_status in
+  let status_color = planning_phase_color goal.pg_phase in
+  let status_label = planning_phase_label goal.pg_phase in
   let header = Printf.sprintf " MASC Planning  %s[%s]%s  %s"
     status_color (fit_width status_label 8) Ansi.reset
     (fit_width goal.pg_id 20)
@@ -693,7 +693,7 @@ let render_planning_detail (state : state) (goal : planning_goal) =
   box_line buf cols (Printf.sprintf "  %s%s%s"
     Ansi.bold (fit_width goal.pg_title (cols - 6)) Ansi.reset);
   box_line buf cols (Printf.sprintf "  Phase: %s  Priority: P%d"
-    (fit_width goal.pg_phase 14) goal.pg_priority);
+    (fit_width (planning_phase_label goal.pg_phase) 14) goal.pg_priority);
   (match goal.pg_due_date with
    | Some d -> box_line buf cols (Printf.sprintf "  Due: %s" d)
    | None -> box_empty buf cols);
@@ -748,8 +748,8 @@ let render_keeper_list (state : state) =
     Ansi.gray Ansi.box_l (draw_hline (cols - 2)) Ansi.box_r Ansi.reset);
 
   (* Column headers *)
-  let col_header = Printf.sprintf "  %s  %-16s %-14s %5s  %-20s %s  %s"
-    " " "Name" "Profile" "Gen" "Model" "Pro" "Goal" in
+  let col_header = Printf.sprintf "  %s  %-20s %5s  %-8s %10s  %s"
+    " " "Name" "Gen" "Paused" "Turns" "Current Task" in
   Buffer.add_string buf (Printf.sprintf "%s%s%s %s%s%s %s%s%s\n"
     Ansi.gray Ansi.box_v Ansi.reset
     Ansi.dim (fit_width col_header (cols - 4)) Ansi.reset
@@ -760,55 +760,74 @@ let render_keeper_list (state : state) =
     Ansi.gray Ansi.box_l (draw_hline (cols - 2)) Ansi.box_r Ansi.reset);
 
   (* Keeper rows *)
-  let content_height = rows - 8 in  (* header + column header + footer *)
-  let visible_count = min content_height (List.length state.keepers) in
+  let content_height = max 0 (rows - 8) in
+  let keeper_rows =
+    match state.keepers_error with
+    | None -> content_height
+    | Some err ->
+        box_line buf cols
+          (Ansi.red ^ "  " ^ fit_width err (cols - 8) ^ Ansi.reset);
+        max 0 (content_height - 1)
+  in
+  let visible_count = min keeper_rows (List.length state.keepers) in
   (* Scroll offset: keep cursor visible *)
   let scroll_offset =
-    if state.keeper_cursor >= content_height then
-      state.keeper_cursor - content_height + 1
+    if keeper_rows > 0 && state.keeper_cursor >= keeper_rows then
+      state.keeper_cursor - keeper_rows + 1
     else 0
   in
 
   if visible_count = 0 then begin
-    Buffer.add_string buf (Printf.sprintf "%s%s%s   %s(no keepers found in .masc/keepers/)%s %s%s%s%s\n"
-      Ansi.gray Ansi.box_v Ansi.reset
-      Ansi.dim Ansi.reset
-      (String.make (max 0 (cols - 50)) ' ')
-      Ansi.gray Ansi.box_v Ansi.reset);
-    for _ = 1 to max 0 (content_height - 1) do
+    let empty_rows =
+      match state.keepers_error with
+      | Some _ -> keeper_rows
+      | None ->
+          Buffer.add_string buf (Printf.sprintf "%s%s%s   %s(no keepers found in .masc/keepers/)%s %s%s%s%s\n"
+            Ansi.gray Ansi.box_v Ansi.reset
+            Ansi.dim Ansi.reset
+            (String.make (max 0 (cols - 50)) ' ')
+            Ansi.gray Ansi.box_v Ansi.reset);
+          max 0 (keeper_rows - 1)
+    in
+    for _ = 1 to empty_rows do
       Buffer.add_string buf (Printf.sprintf "%s%s%s %s %s%s%s\n"
         Ansi.gray Ansi.box_v Ansi.reset
         (String.make (cols - 4) ' ')
         Ansi.gray Ansi.box_v Ansi.reset)
     done
   end else begin
-    for i = 0 to content_height - 1 do
+    for i = 0 to keeper_rows - 1 do
       let idx = i + scroll_offset in
       if idx < List.length state.keepers then begin
         let k = List.nth state.keepers idx in
         let is_selected = idx = state.keeper_cursor in
-        let model_short = short_model (Option.value ~default:"-" k.k_active_model) in
-        let proactive_str = if k.k_proactive_enabled then
-          Ansi.green ^ "on" ^ Ansi.reset
+        let paused_str = if k.k_paused then
+          Ansi.yellow ^ "yes" ^ Ansi.reset
         else
-          Ansi.gray ^ "--" ^ Ansi.reset
+          Ansi.dim ^ "no" ^ Ansi.reset
         in
-        let name_col = Printf.sprintf "%-16s" k.k_name in
+        let task_width = max 8 (cols - 58) in
+        let current_task =
+          fit_width (Option.value ~default:"-" k.k_current_task_id) task_width
+        in
+        let name_col = Printf.sprintf "%-20s" k.k_name in
         let gen_col = Printf.sprintf "%5d" k.k_generation in
-        let model_col = Printf.sprintf "%-20s" model_short in
+        let turns_col = Printf.sprintf "%10d" k.k_total_turns in
         let line_content =
           if is_selected then
             Ansi.reverse ^ ">" ^ Ansi.reset
             ^ "  " ^ Ansi.bold ^ name_col ^ Ansi.reset
             ^ " " ^ gen_col
-            ^ "  " ^ model_col
-            ^ " " ^ proactive_str
+            ^ "  " ^ paused_str
+            ^ " " ^ turns_col
+            ^ "  " ^ Ansi.dim ^ current_task ^ Ansi.reset
           else
             " "
             ^ "  " ^ name_col
             ^ " " ^ gen_col
-            ^ "  " ^ model_col
-            ^ " " ^ proactive_str
+            ^ "  " ^ paused_str
+            ^ " " ^ turns_col
+            ^ "  " ^ Ansi.dim ^ current_task ^ Ansi.reset
         in
         Buffer.add_string buf (Printf.sprintf "%s%s%s %s %s%s%s\n"
           Ansi.gray Ansi.box_v Ansi.reset
@@ -866,8 +885,15 @@ let render_keeper_detail (state : state) =
     add_section "Identity";
     add_row "Name:" k.k_name;
     add_row "Generation:" (string_of_int k.k_generation);
-    add_row "Trigger Mode:" k.k_trigger_mode;
-    add_row "Verify:" (bool_indicator k.k_verify);
+    add_row "Paused:"
+      (if k.k_paused then Ansi.yellow ^ "yes" ^ Ansi.reset
+       else Ansi.dim ^ "no" ^ Ansi.reset);
+    add_empty ();
+
+    (* Current work section *)
+    add_section "Current Work";
+    add_row "Task:" (Option.value ~default:"-" k.k_current_task_id);
+    add_row "Last Blocker:" (Option.value ~default:"-" k.k_last_blocker);
     add_empty ();
 
     (* Live Context section (Phase 2) *)
@@ -885,12 +911,6 @@ let render_keeper_detail (state : state) =
     end;
     add_empty ();
 
-    (* Model section *)
-    add_section "Model";
-    add_row "Active Model:" (Option.value ~default:"-" k.k_active_model);
-    add_row "Available:" (String.concat ", " k.k_models);
-    add_empty ();
-
     (* Runtime section *)
     add_section "Runtime Stats";
     add_row "Total Turns:" (string_of_int k.k_total_turns);
@@ -898,14 +918,20 @@ let render_keeper_detail (state : state) =
     add_row "Total Cost:" (Printf.sprintf "$%.4f" k.k_total_cost_usd);
     add_row "Last Turn:" (short_ts k.k_last_turn_ts);
     add_row "Compactions:" (string_of_int k.k_compaction_count);
-    add_row "Context Budget:" (string_of_int k.k_context_budget);
     add_empty ();
 
-    (* Behavior section *)
-    add_section "Behavior";
-    add_row "Proactive:" (bool_indicator k.k_proactive_enabled);
-    add_row "Initiative:" (bool_indicator (Option.value ~default:false k.k_initiative_enabled));
-    add_row "Drift:" (bool_indicator k.k_drift_enabled);
+    (* Autonomy section *)
+    add_section "Autonomy";
+    add_row "Autonomous Turns:"
+      (string_of_int k.k_autonomous_turn_count);
+    add_row "Text / Tool:"
+      (Printf.sprintf "%d / %d" k.k_autonomous_text_turn_count
+         k.k_autonomous_tool_turn_count);
+    add_row "Board / Mention:"
+      (Printf.sprintf "%d / %d" k.k_board_reactive_turn_count
+         k.k_mention_reactive_turn_count);
+    add_row "No-op Turns:" (string_of_int k.k_noop_turn_count);
+    add_row "Last Outcome:" k.k_last_proactive_outcome;
     add_empty ();
 
     (* Timestamps section *)

--- a/bin/masc_tui_types.ml
+++ b/bin/masc_tui_types.ml
@@ -83,14 +83,6 @@ type planning_mode =
   | Planning_list
   | Planning_detail of string
 
-(** Goal status from /api/v1/dashboard/planning. Unknown wire values are
-    rejected at decode time so the renderer cannot silently dim a new state. *)
-type planning_goal_status =
-  | Planning_goal_active
-  | Planning_goal_paused
-  | Planning_goal_done
-  | Planning_goal_dropped
-
 (** Approval / pending confirmation item *)
 type approval_item = {
   ap_token: string;
@@ -135,28 +127,30 @@ type overview_snapshot = {
   ov_generated_at: string;
 }
 
-(** Planning goal from /api/v1/dashboard/planning *)
-type planning_goal = {
+(** Planning projections from [Tui_decode], which owns the current wire
+    contract and its behavioral decoder tests. *)
+type planning_goal = Tui_decode.planning_goal
+  = {
   pg_id: string;
   pg_title: string;
-  pg_status: planning_goal_status;
-  pg_phase: string;
+  pg_phase: Goal_phase.t;
   pg_priority: int;
   pg_due_date: string option;
   pg_metric: string option;
   pg_target_value: string option;
 }
 
-(** Planning rollup from /api/v1/dashboard/planning *)
-type planning_rollup = {
+type planning_rollup = Tui_decode.planning_rollup
+  = {
   pr_active: int;
   pr_paused: int;
+  pr_verifying: int;
   pr_done: int;
   pr_dropped: int;
 }
 
-(** Planning task backlog summary *)
-type planning_backlog = {
+type planning_backlog = Tui_decode.planning_backlog
+  = {
   pb_todo: int;
   pb_claimed: int;
   pb_running: int;
@@ -164,8 +158,8 @@ type planning_backlog = {
   pb_cancelled: int;
 }
 
-(** Planning snapshot from /api/v1/dashboard/planning *)
-type planning_snapshot = {
+type planning_snapshot = Tui_decode.planning_snapshot
+  = {
   pl_goals: planning_goal list;
   pl_rollup: planning_rollup;
   pl_backlog: planning_backlog;
@@ -210,8 +204,10 @@ type view_mode = surface
 type state = {
   mutable agents: agent list;
   mutable tasks: task list;
+  mutable tasks_error: string option;
   mutable events: event list;
   mutable keepers: keeper list;
+  mutable keepers_error: string option;
   mutable connection_status: connection_status;
   mutable last_refresh: float;
   mutable view: view_mode;
@@ -250,8 +246,10 @@ type state = {
 let create_state ~workspace ~port ~refresh_interval = {
   agents = [];
   tasks = [];
+  tasks_error = None;
   events = [];
   keepers = [];
+  keepers_error = None;
   connection_status = Disconnected;
   last_refresh = 0.0;
   view = Overview;

--- a/docs/TUI-GUIDE.md
+++ b/docs/TUI-GUIDE.md
@@ -53,11 +53,12 @@ Press `Tab` to switch. Shows all registered keepers with status.
 ```
 MASC Keepers (5 registered)
 
-> dm-keeper        gen=0  model=qwen3.5  proactive=true
-  qa-ui-smoke      gen=0  model=qwen3.5  proactive=true
-  qa-surface       gen=0  model=qwen3.5  proactive=true
-  qa-harness       gen=0  model=qwen3.5  proactive=true
-  sangsu           gen=0  model=qwen3.5  proactive=true
+  Name                   Gen  Paused        Turns  Current Task
+> dm-keeper                2  no              128  task-42
+  qa-ui-smoke              1  yes              31  -
+  qa-surface               3  no              204  task-57
+  qa-harness               1  no               89  -
+  sangsu                   1  no            30317  -
 
 [j/k] Navigate  [Enter] Detail  [Tab] Dashboard  [q] Quit
 ```
@@ -71,17 +72,26 @@ Keeper: sangsu
 
   Identity
   Name:                  sangsu
-  Generation:            0
+  Generation:            1
+  Paused:                no
+
+  Current Work
+  Task:                  -
+  Last Blocker:          -
 
   Live Context
   Context:               55.2%  ########-----------  70629 / 128000 tokens
   Messages:              430
 
-  Goals
-  Goal:                  keeper for Vincent
+  Runtime Stats
+  Total Turns:           30317
+  Total Tokens:          2046321197
+  Compactions:           18
 
-  Model
-  Active Model:          llama:qwen3.5-35b-a3b-ud-q8-xl
+  Autonomy
+  Autonomous Turns:      22023
+  Text / Tool:           14457 / 7565
+  Board / Mention:       1187 / 56
 
 [j/k] Scroll  [l] Logs  [m] Message  [Esc] Back  [q] Quit
 ```
@@ -164,9 +174,11 @@ Dashboard <--Tab--> Keeper List
 
 | Feature | Source | Server Required |
 |---------|--------|-----------------|
-| Keeper list/detail | `.masc/keepers/*.json` | No |
+| Active task list | `.masc/tasks/backlog.json` | No |
+| Keeper list/detail | current-schema `.masc/keepers/*.json` | No |
 | Live context status | `<name>/metrics/YYYY-MM/DD.jsonl` (latest entry) | No |
 | Keeper logs | `<name>/metrics/YYYY-MM/DD.jsonl` (last 200 entries) | No |
+| Goal planning | `GET /api/v1/dashboard/planning` | Yes |
 | Send messages | `POST /api/v1/keepers/chat/stream` | Yes |
 
 ## Requirements

--- a/docs/design/tui/TUI-SPEC.md
+++ b/docs/design/tui/TUI-SPEC.md
@@ -88,7 +88,7 @@ type surface =
 | 데이터 | 경로 |
 |---|---|
 | agents | `.masc/agents/*.json` |
-| tasks | `.masc/tasks/*.json` |
+| tasks | `.masc/tasks/backlog.json` |
 | keepers | `.masc/keepers/*.json` |
 | keeper metrics | `.masc/keepers/<name>/metrics/YYYY-MM/DD.jsonl` |
 | board posts | `.masc/board_posts.jsonl` |

--- a/lib/tui_decode.ml
+++ b/lib/tui_decode.ml
@@ -298,7 +298,9 @@ let sanitize_terminal_text text =
 ;;
 
 let keeper_blocker_for_terminal keeper =
-  Option.value ~default:"-" keeper.k_last_blocker |> sanitize_terminal_text
+  match keeper.k_last_blocker with
+  | None -> "-"
+  | Some blocker -> sanitize_terminal_text blocker
 ;;
 
 let keeper_of_meta (meta : Keeper_meta_contract.keeper_meta) =

--- a/lib/tui_decode.ml
+++ b/lib/tui_decode.ml
@@ -10,31 +10,63 @@ type agent = {
 type task = {
   id : string;
   title : string;
-  status : string;
+  status : Masc_domain.task_status;
   priority : int;
-  claimed_by : string option;
-  parent_task_id : string option;
-  goal_id : string option;
 }
 
 type keeper = {
   k_name : string;
   k_generation : int;
-  k_active_model : string option;
-  k_models : string list;
-  k_proactive_enabled : bool;
-  k_initiative_enabled : bool option;
+  k_paused : bool;
+  k_current_task_id : string option;
   k_total_turns : int;
   k_total_tokens : int;
   k_total_cost_usd : float;
   k_last_turn_ts : string;
   k_compaction_count : int;
-  k_trigger_mode : string;
-  k_context_budget : int;
-  k_drift_enabled : bool;
-  k_verify : bool;
+  k_autonomous_turn_count : int;
+  k_autonomous_text_turn_count : int;
+  k_autonomous_tool_turn_count : int;
+  k_board_reactive_turn_count : int;
+  k_mention_reactive_turn_count : int;
+  k_noop_turn_count : int;
+  k_last_proactive_outcome : string;
+  k_last_blocker : string option;
   k_created_at : string;
   k_updated_at : string;
+}
+
+type planning_goal = {
+  pg_id : string;
+  pg_title : string;
+  pg_phase : Goal_phase.t;
+  pg_priority : int;
+  pg_due_date : string option;
+  pg_metric : string option;
+  pg_target_value : string option;
+}
+
+type planning_rollup = {
+  pr_active : int;
+  pr_paused : int;
+  pr_verifying : int;
+  pr_done : int;
+  pr_dropped : int;
+}
+
+type planning_backlog = {
+  pb_todo : int;
+  pb_claimed : int;
+  pb_running : int;
+  pb_done : int;
+  pb_cancelled : int;
+}
+
+type planning_snapshot = {
+  pl_goals : planning_goal list;
+  pl_rollup : planning_rollup;
+  pl_backlog : planning_backlog;
+  pl_generated_at : string;
 }
 
 type log_entry = {
@@ -106,8 +138,6 @@ let optional_bool json key =
 let require_string_field json key = require_string json key
 let require_int_field json key = require_int json key
 let require_float_field json key = require_float json key
-let require_bool_field json key = require_bool json key
-
 let require_string_list json key =
   match member key json with
   | `List items ->
@@ -134,14 +164,6 @@ let require_string_list json key =
         (Printf.sprintf "field '%s' must be an array (received %s)" key
            (Json_util.kind_name other))
 
-let string_of_intlike_float_field key f =
-  if not (Float.is_finite f) then
-    Error (Printf.sprintf "field '%s' must be a finite number" key)
-  else
-    try Ok (string_of_int (int_of_float f))
-    with Invalid_argument _ ->
-      Error (Printf.sprintf "field '%s' is out of range for int" key)
-
 let decode_status json =
   match member "status" json with
   | `String s -> Ok s
@@ -167,90 +189,69 @@ let decode_agent json =
   let* last_seen = require_string_field json "last_seen" in
   Ok { name; status; current_task; last_seen }
 
-let decode_task json =
-  let* id = require_string_field json "id" in
-  let* title = require_string_field json "title" in
-  let* status = require_string_field json "status" in
-  let* priority = optional_int json "priority" in
-  let* claimed_by = optional_string json "claimed_by" in
-  let* parent_task_id = optional_string json "parent_task_id" in
-  let* goal_id = optional_string json "goal_id" in
-  Ok
-    {
-      id;
-      title;
-      status;
-      priority = Option.value priority ~default:3;
-      claimed_by;
-      parent_task_id;
-      goal_id;
-    }
+let task_of_domain (task : Masc_domain.task) =
+  {
+    id = task.id;
+    title = task.title;
+    status = task.task_status;
+    priority = task.priority;
+  }
 
-let decode_keeper ~filename json =
-  let* k_generation = require_int_field json "generation" in
-  let* k_active_model = optional_string json "active_model" in
-  let* k_models =
-    match member "models" json with
-    | `Null -> Ok []
-    | `List _ -> require_string_list json "models"
-    | other ->
-        Error
-          (Printf.sprintf
-             "field 'models' must be a list of strings (received %s)"
-             (Json_util.kind_name other))
+let active_tasks_of_domain tasks =
+  tasks
+  |> List.map task_of_domain
+  |> List.filter (fun task ->
+       not (Masc_domain.task_status_is_terminal task.status))
+  |> List.stable_sort (fun left right ->
+       Int.compare left.priority right.priority)
+
+let decode_task json =
+  let* task = Masc_domain.task_of_yojson json in
+  Ok (task_of_domain task)
+
+let blocker_summary (blocker : Keeper_meta_contract.blocker_info) =
+  let label = Keeper_meta_contract.blocker_class_to_string blocker.klass in
+  match String.trim blocker.detail with
+  | "" -> label
+  | detail -> label ^ ": " ^ detail
+
+let keeper_of_meta (meta : Keeper_meta_contract.keeper_meta) =
+  let runtime = meta.runtime in
+  let usage = runtime.usage in
+  let compaction = runtime.compaction_rt in
+  let proactive = runtime.proactive_rt in
+  let k_last_turn_ts =
+    if Float.compare usage.last_turn_ts 0.0 <= 0 then ""
+    else Masc_domain.iso8601_of_unix_seconds usage.last_turn_ts
   in
-  let* k_proactive_enabled = require_bool_field json "proactive_enabled" in
-  let* k_initiative_enabled = optional_bool json "initiative_enabled" in
-  let* k_total_turns = require_int_field json "total_turns" in
-  let* k_total_tokens = require_int_field json "total_tokens" in
-  let* k_total_cost_usd = require_float_field json "total_cost_usd" in
-  let* k_last_turn_ts =
-    match member "last_turn_ts" json with
-    | `String s -> Ok s
-    | `Float f -> string_of_intlike_float_field "last_turn_ts" f
-    | `Int n -> Ok (string_of_int n)
-    | `Null -> Ok ""
-    | other ->
-        Error
-          (Printf.sprintf
-             "field 'last_turn_ts' must be a string, number, or null \
-              (received %s)"
-             (Json_util.kind_name other))
-  in
-  let* k_compaction_count = require_int_field json "compaction_count" in
-  let* k_trigger_mode = require_string_field json "trigger_mode" in
-  let* k_context_budget = require_int_field json "context_budget" in
-  let* k_drift_enabled = require_bool_field json "drift_enabled" in
-  let* k_verify = require_bool_field json "verify" in
-  let* k_created_at = require_string_field json "created_at" in
-  let* k_updated_at = require_string_field json "updated_at" in
-  let default_name =
-    if Filename.check_suffix filename ".json" then
-      Filename.chop_suffix filename ".json"
-    else
-      Filename.remove_extension filename
-  in
-  let k_name = Option.value (get_string json "name") ~default:default_name in
-  Ok
-    {
-      k_name;
-      k_generation;
-      k_active_model;
-      k_models;
-      k_proactive_enabled;
-      k_initiative_enabled;
-      k_total_turns;
-      k_total_tokens;
-      k_total_cost_usd;
-      k_last_turn_ts;
-      k_compaction_count;
-      k_trigger_mode;
-      k_context_budget;
-      k_drift_enabled;
-      k_verify;
-      k_created_at;
-      k_updated_at;
-    }
+  {
+    k_name = meta.name;
+    k_generation = runtime.nonce;
+    k_paused = meta.paused;
+    k_current_task_id =
+      Option.map Keeper_id.Task_id.to_string meta.current_task_id;
+    k_total_turns = usage.total_turns;
+    k_total_tokens = usage.total_tokens;
+    k_total_cost_usd = usage.total_cost_usd;
+    k_last_turn_ts;
+    k_compaction_count = compaction.count;
+    k_autonomous_turn_count = runtime.autonomous_turn_count;
+    k_autonomous_text_turn_count = runtime.autonomous_text_turn_count;
+    k_autonomous_tool_turn_count = runtime.autonomous_tool_turn_count;
+    k_board_reactive_turn_count = runtime.board_reactive_turn_count;
+    k_mention_reactive_turn_count = runtime.mention_reactive_turn_count;
+    k_noop_turn_count = runtime.noop_turn_count;
+    k_last_proactive_outcome =
+      Keeper_meta_contract.proactive_cycle_outcome_to_string
+        proactive.last_outcome;
+    k_last_blocker = Option.map blocker_summary runtime.last_blocker;
+    k_created_at = meta.created_at;
+    k_updated_at = meta.updated_at;
+  }
+
+let decode_keeper json =
+  let* meta = Keeper_meta_json_parse.meta_of_json json in
+  Ok (keeper_of_meta meta)
 
 let parse_log_entry line =
   let json =
@@ -464,6 +465,56 @@ let decode_list label decode items =
         | Error err -> Error (Printf.sprintf "%s[%d]: %s" label idx err))
   in
   loop 0 [] items
+
+let decode_planning_goal json =
+  let* pg_id = required_string_field json "id" in
+  let* pg_title = required_string_field json "title" in
+  let* raw_phase = required_string_field json "phase" in
+  let* pg_phase =
+    match Goal_phase.parse raw_phase with
+    | Some phase -> Ok phase
+    | None -> Error (Printf.sprintf "unknown planning goal phase %S" raw_phase)
+  in
+  let* pg_priority = required_int_field json "priority" in
+  let* pg_due_date = optional_string_field json "due_date" in
+  let* pg_metric = optional_string_field json "metric" in
+  let* pg_target_value = optional_string_field json "target_value" in
+  Ok
+    {
+      pg_id;
+      pg_title;
+      pg_phase;
+      pg_priority;
+      pg_due_date;
+      pg_metric;
+      pg_target_value;
+    }
+
+let decode_planning_rollup json =
+  let* pr_active = required_int_field json "active_count" in
+  let* pr_paused = required_int_field json "paused_count" in
+  let* pr_verifying = required_int_field json "verifying_count" in
+  let* pr_done = required_int_field json "done_count" in
+  let* pr_dropped = required_int_field json "dropped_count" in
+  Ok { pr_active; pr_paused; pr_verifying; pr_done; pr_dropped }
+
+let decode_planning_backlog json =
+  let* pb_todo = required_int_field json "todo" in
+  let* pb_claimed = required_int_field json "claimed" in
+  let* pb_running = required_int_field json "in_progress" in
+  let* pb_done = required_int_field json "done" in
+  let* pb_cancelled = required_int_field json "cancelled" in
+  Ok { pb_todo; pb_claimed; pb_running; pb_done; pb_cancelled }
+
+let decode_planning_snapshot json =
+  let* goals_json = required_list_field json "goals" in
+  let* pl_goals = decode_list "goals" decode_planning_goal goals_json in
+  let* rollup_json = required_object_field json "rollup" in
+  let* pl_rollup = decode_planning_rollup rollup_json in
+  let* backlog_json = required_object_field json "task_backlog" in
+  let* pl_backlog = decode_planning_backlog backlog_json in
+  let* pl_generated_at = required_string_field json "generated_at" in
+  Ok { pl_goals; pl_rollup; pl_backlog; pl_generated_at }
 
 let bounded_parent_depth ?(max_depth = 64) ~(id_of : 'a -> string)
     ~(parent_id_of : 'a -> string option) (items : 'a list) (item : 'a) : int =

--- a/lib/tui_decode.ml
+++ b/lib/tui_decode.ml
@@ -376,19 +376,6 @@ let required_int_field json key =
   | `Null -> missing_field key
   | bad -> field_type_error key "an int" bad
 
-let required_int_any_field json keys =
-  let rec loop = function
-    | [] ->
-        Error
-          (Printf.sprintf "missing required field '%s'"
-             (String.concat "' or '" keys))
-    | key :: rest -> (
-        match member key json with
-        | `Null -> loop rest
-        | _ -> required_int_field json key)
-  in
-  loop keys
-
 let int_field_or json key ~default =
   match member key json with
   | `Null -> Ok default

--- a/lib/tui_decode.ml
+++ b/lib/tui_decode.ml
@@ -215,6 +215,92 @@ let blocker_summary (blocker : Keeper_meta_contract.blocker_info) =
   | "" -> label
   | detail -> label ^ ": " ^ detail
 
+let sanitize_terminal_text text =
+  let escaped_byte byte = Printf.sprintf "\\x%02X" byte in
+  let escaped_codepoint byte = Printf.sprintf "\\u00%02X" byte in
+  let output = Buffer.create (String.length text) in
+  let byte_at index = Char.code text.[index] in
+  let is_continuation byte = byte >= 0x80 && byte <= 0xBF in
+  let valid_utf8_length index =
+    let remaining = String.length text - index in
+    let first = byte_at index in
+    if first >= 0xC2 && first <= 0xDF && remaining >= 2
+       && is_continuation (byte_at (index + 1))
+    then Some 2
+    else if first = 0xE0 && remaining >= 3
+            && byte_at (index + 1) >= 0xA0
+            && byte_at (index + 1) <= 0xBF
+            && is_continuation (byte_at (index + 2))
+    then Some 3
+    else if first >= 0xE1 && first <= 0xEC && remaining >= 3
+            && is_continuation (byte_at (index + 1))
+            && is_continuation (byte_at (index + 2))
+    then Some 3
+    else if first = 0xED && remaining >= 3
+            && byte_at (index + 1) >= 0x80
+            && byte_at (index + 1) <= 0x9F
+            && is_continuation (byte_at (index + 2))
+    then Some 3
+    else if first >= 0xEE && first <= 0xEF && remaining >= 3
+            && is_continuation (byte_at (index + 1))
+            && is_continuation (byte_at (index + 2))
+    then Some 3
+    else if first = 0xF0 && remaining >= 4
+            && byte_at (index + 1) >= 0x90
+            && byte_at (index + 1) <= 0xBF
+            && is_continuation (byte_at (index + 2))
+            && is_continuation (byte_at (index + 3))
+    then Some 4
+    else if first >= 0xF1 && first <= 0xF3 && remaining >= 4
+            && is_continuation (byte_at (index + 1))
+            && is_continuation (byte_at (index + 2))
+            && is_continuation (byte_at (index + 3))
+    then Some 4
+    else if first = 0xF4 && remaining >= 4
+            && byte_at (index + 1) >= 0x80
+            && byte_at (index + 1) <= 0x8F
+            && is_continuation (byte_at (index + 2))
+            && is_continuation (byte_at (index + 3))
+    then Some 4
+    else None
+  in
+  let rec append index =
+    if index < String.length text
+    then (
+      let byte = Char.code text.[index] in
+      if
+        byte = 0xC2
+        && index + 1 < String.length text
+        && let next = Char.code text.[index + 1] in
+           next >= 0x80 && next <= 0x9F
+      then (
+        Buffer.add_string output (escaped_codepoint (Char.code text.[index + 1]));
+        append (index + 2))
+      else if byte >= 0xC2
+      then (
+        match valid_utf8_length index with
+        | Some length ->
+          Buffer.add_substring output text index length;
+          append (index + length)
+        | None ->
+          Buffer.add_char output text.[index];
+          append (index + 1))
+      else if byte < 0x20 || (byte >= 0x7F && byte <= 0x9F)
+      then (
+        Buffer.add_string output (escaped_byte byte);
+        append (index + 1))
+      else (
+        Buffer.add_char output text.[index];
+        append (index + 1)))
+  in
+  append 0;
+  Buffer.contents output
+;;
+
+let keeper_blocker_for_terminal keeper =
+  Option.value ~default:"-" keeper.k_last_blocker |> sanitize_terminal_text
+;;
+
 let keeper_of_meta (meta : Keeper_meta_contract.keeper_meta) =
   let runtime = meta.runtime in
   let usage = runtime.usage in

--- a/lib/tui_decode.mli
+++ b/lib/tui_decode.mli
@@ -34,6 +34,16 @@ type keeper = {
   k_updated_at : string;
 }
 
+val sanitize_terminal_text : string -> string
+(** Escape C0, DEL, C1 bytes, and UTF-8 encoded C1 code points so external
+    diagnostics cannot emit terminal control sequences. Call at the terminal
+    rendering boundary; decoded records intentionally retain their raw typed
+    diagnostic for non-terminal consumers. *)
+
+val keeper_blocker_for_terminal : keeper -> string
+(** Terminal-boundary projection for the raw typed blocker stored in
+    {!type-keeper}. Missing blockers render as [-]. *)
+
 type planning_goal = {
   pg_id : string;
   pg_title : string;

--- a/lib/tui_decode.mli
+++ b/lib/tui_decode.mli
@@ -101,7 +101,6 @@ val required_string_field : Yojson.Safe.t -> string -> (string, string) result
 val optional_string_field :
   Yojson.Safe.t -> string -> (string option, string) result
 val required_int_field : Yojson.Safe.t -> string -> (int, string) result
-val required_int_any_field : Yojson.Safe.t -> string list -> (int, string) result
 val int_field_or : Yojson.Safe.t -> string -> default:int -> (int, string) result
 val required_display_field : Yojson.Safe.t -> string -> (string, string) result
 val required_display_any_field :

--- a/lib/tui_decode.mli
+++ b/lib/tui_decode.mli
@@ -8,31 +8,63 @@ type agent = {
 type task = {
   id : string;
   title : string;
-  status : string;
+  status : Masc_domain.task_status;
   priority : int;
-  claimed_by : string option;
-  parent_task_id : string option;
-  goal_id : string option;
 }
 
 type keeper = {
   k_name : string;
   k_generation : int;
-  k_active_model : string option;
-  k_models : string list;
-  k_proactive_enabled : bool;
-  k_initiative_enabled : bool option;
+  k_paused : bool;
+  k_current_task_id : string option;
   k_total_turns : int;
   k_total_tokens : int;
   k_total_cost_usd : float;
   k_last_turn_ts : string;
   k_compaction_count : int;
-  k_trigger_mode : string;
-  k_context_budget : int;
-  k_drift_enabled : bool;
-  k_verify : bool;
+  k_autonomous_turn_count : int;
+  k_autonomous_text_turn_count : int;
+  k_autonomous_tool_turn_count : int;
+  k_board_reactive_turn_count : int;
+  k_mention_reactive_turn_count : int;
+  k_noop_turn_count : int;
+  k_last_proactive_outcome : string;
+  k_last_blocker : string option;
   k_created_at : string;
   k_updated_at : string;
+}
+
+type planning_goal = {
+  pg_id : string;
+  pg_title : string;
+  pg_phase : Goal_phase.t;
+  pg_priority : int;
+  pg_due_date : string option;
+  pg_metric : string option;
+  pg_target_value : string option;
+}
+
+type planning_rollup = {
+  pr_active : int;
+  pr_paused : int;
+  pr_verifying : int;
+  pr_done : int;
+  pr_dropped : int;
+}
+
+type planning_backlog = {
+  pb_todo : int;
+  pb_claimed : int;
+  pb_running : int;
+  pb_done : int;
+  pb_cancelled : int;
+}
+
+type planning_snapshot = {
+  pl_goals : planning_goal list;
+  pl_rollup : planning_rollup;
+  pl_backlog : planning_backlog;
+  pl_generated_at : string;
 }
 
 type log_entry = {
@@ -53,8 +85,13 @@ type log_entry = {
 }
 
 val decode_agent : Yojson.Safe.t -> (agent, string) result
+val task_of_domain : Masc_domain.task -> task
+val active_tasks_of_domain : Masc_domain.task list -> task list
 val decode_task : Yojson.Safe.t -> (task, string) result
-val decode_keeper : filename:string -> Yojson.Safe.t -> (keeper, string) result
+val keeper_of_meta : Keeper_meta_contract.keeper_meta -> keeper
+val decode_keeper : Yojson.Safe.t -> (keeper, string) result
+val decode_planning_snapshot :
+  Yojson.Safe.t -> (planning_snapshot, string) result
 val parse_log_entry : string -> (log_entry, string) result
 val is_success_http_status : int -> bool
 val http_status_error : status_code:int -> body:string -> string

--- a/test/test_tui_decode.ml
+++ b/test/test_tui_decode.ml
@@ -35,87 +35,249 @@ let test_decode_task_missing_priority_defaults () =
     ]
   in
   match Tui_decode.decode_task json with
-  | Ok task -> Alcotest.(check int) "default priority" 3 task.priority
+  | Ok task ->
+      Alcotest.(check int) "default priority" 3 task.priority;
+      Alcotest.(check string) "typed status" "todo"
+        (Masc_domain.task_status_to_string task.status)
   | Error err -> Alcotest.fail err
 
-let keeper_json ?(models = `List [ `String "glm-5.1" ]) ?(last_turn_ts = `String "1700000000")
-    ?(active_model = Some (`String "glm-5.1"))
-    ?(initiative_enabled = Some (`Bool true)) () =
+let domain_task ~id ~priority status_fields =
+  let json =
+    `Assoc
+      ([ "id", `String id
+       ; "title", `String ("Task " ^ id)
+       ; "priority", `Int priority
+       ; "created_at", `String "2026-08-21T00:00:00Z"
+       ]
+      @ status_fields)
+  in
+  match Masc_domain.task_of_yojson json with
+  | Ok task -> task
+  | Error err -> Alcotest.fail err
+
+let test_active_tasks_of_domain_filters_and_sorts () =
+  let tasks =
+    [ domain_task ~id:"done" ~priority:0
+        [ "status", `String "done"
+        ; "assignee", `String "alice"
+        ; "completed_at", `String "2026-08-21T00:00:00Z"
+        ]
+    ; domain_task ~id:"todo" ~priority:3 [ "status", `String "todo" ]
+    ; domain_task ~id:"running" ~priority:1
+        [ "status", `String "in_progress"
+        ; "assignee", `String "bob"
+        ; "started_at", `String "2026-08-21T00:00:00Z"
+        ]
+    ; domain_task ~id:"cancelled" ~priority:2
+        [ "status", `String "cancelled"
+        ; "cancelled_by", `String "operator"
+        ; "cancelled_at", `String "2026-08-21T00:00:00Z"
+        ]
+    ]
+  in
+  let active = Tui_decode.active_tasks_of_domain tasks in
+  Alcotest.(check (list string)) "terminal tasks removed, priority preserved"
+    [ "running"; "todo" ]
+    (List.map (fun (task : Tui_decode.task) -> task.id) active)
+
+let current_keeper_json ?(last_turn_ts = 0.0) ?(paused = false)
+    ?(current_task_id = None) () =
   let optional_field key = function
     | Some value -> [ (key, value) ]
     | None -> []
   in
-  `Assoc
-    ([
-       ("goal", `String "keep the system healthy");
-       ("soul_profile", `String "balanced");
-       ("generation", `Int 2);
-       ("models", models);
-       ("proactive_enabled", `Bool true);
-       ("total_turns", `Int 4);
-       ("total_tokens", `Int 120);
-       ("total_cost_usd", `Float 0.42);
-       ("last_turn_ts", last_turn_ts);
-       ("compaction_count", `Int 1);
-       ("trigger_mode", `String "mention");
-       ("context_budget", `Int 32000);
-       ("drift_enabled", `Bool true);
-       ("verify", `Bool true);
-       ("created_at", `String "2026-03-31T12:00:00Z");
-       ("updated_at", `String "2026-03-31T12:05:00Z");
-     ]
-    @ optional_field "active_model" active_model
-    @ optional_field "initiative_enabled" initiative_enabled)
-
-let test_decode_keeper_missing_legacy_fields_defaults_to_none () =
-  match
-    Tui_decode.decode_keeper ~filename:"keeper-main.json"
-      (keeper_json ~active_model:None ~initiative_enabled:None ())
-  with
-  | Ok keeper ->
-      Alcotest.(check string) "filename fallback" "keeper-main" keeper.k_name;
-      Alcotest.(check (option string)) "missing active_model" None
-        keeper.k_active_model;
-      Alcotest.(check (option bool)) "missing initiative_enabled" None
-        keeper.k_initiative_enabled
+  let fixture =
+    `Assoc
+      ([ ("name", `String "keeper-main")
+       ; ("generation", `Int 2)
+       ; ("paused", `Bool paused)
+       ; ("total_turns", `Int 4)
+       ; ("total_tokens", `Int 120)
+       ; ("total_cost_usd", `Float 0.42)
+       ; ("last_turn_ts", `Float last_turn_ts)
+       ; ("compaction_count", `Int 1)
+       ; ("autonomous_turn_count", `Int 7)
+       ; ("autonomous_text_turn_count", `Int 5)
+       ; ("autonomous_tool_turn_count", `Int 2)
+       ; ("board_reactive_turn_count", `Int 3)
+       ; ("mention_reactive_turn_count", `Int 1)
+       ; ("noop_turn_count", `Int 4)
+       ; ("last_proactive_outcome", `String "tool_use")
+       ; ( "last_blocker"
+         , Keeper_meta_contract.(
+             blocker_info_of_class ~detail:"queue full" Capacity_backpressure
+             |> blocker_info_to_json) )
+       ; ("created_at", `String "2026-08-20T01:02:03Z")
+       ; ("updated_at", `String "2026-08-21T04:05:06Z")
+       ]
+      @ optional_field "current_task_id"
+          (Option.map (fun id -> `String id) current_task_id))
+  in
+  match Masc_test_deps.meta_of_json_fixture fixture with
+  | Ok meta -> Keeper_meta_json.meta_to_json meta
   | Error err -> Alcotest.fail err
 
-let test_decode_keeper_numeric_last_turn_ts_truncates () =
+let test_decode_keeper_projects_current_schema () =
   match
-    Tui_decode.decode_keeper ~filename:"keeper-main.json"
-      (keeper_json ~last_turn_ts:(`Float 1700000000.9) ())
+    Tui_decode.decode_keeper
+      (current_keeper_json ~paused:true ~current_task_id:(Some "task-42") ())
   with
   | Ok keeper ->
-      Alcotest.(check string) "float timestamp truncates" "1700000000"
+      Alcotest.(check string) "name" "keeper-main" keeper.k_name;
+      Alcotest.(check int) "generation" 2 keeper.k_generation;
+      Alcotest.(check bool) "paused" true keeper.k_paused;
+      Alcotest.(check (option string)) "current task" (Some "task-42")
+        keeper.k_current_task_id;
+      Alcotest.(check int) "autonomous turns" 7
+        keeper.k_autonomous_turn_count;
+      Alcotest.(check int) "total turns" 4 keeper.k_total_turns;
+      Alcotest.(check int) "total tokens" 120 keeper.k_total_tokens;
+      Alcotest.(check (float 0.0001)) "total cost" 0.42
+        keeper.k_total_cost_usd;
+      Alcotest.(check int) "compactions" 1 keeper.k_compaction_count;
+      Alcotest.(check int) "autonomous text turns" 5
+        keeper.k_autonomous_text_turn_count;
+      Alcotest.(check int) "autonomous tool turns" 2
+        keeper.k_autonomous_tool_turn_count;
+      Alcotest.(check int) "board turns" 3
+        keeper.k_board_reactive_turn_count;
+      Alcotest.(check int) "mention turns" 1
+        keeper.k_mention_reactive_turn_count;
+      Alcotest.(check int) "no-op turns" 4 keeper.k_noop_turn_count;
+      Alcotest.(check string) "last outcome" "tool_use"
+        keeper.k_last_proactive_outcome;
+      Alcotest.(check (option string)) "last blocker"
+        (Some "capacity_backpressure: queue full")
+        keeper.k_last_blocker;
+      Alcotest.(check string) "created at" "2026-08-20T01:02:03Z"
+        keeper.k_created_at;
+      Alcotest.(check string) "updated at" "2026-08-21T04:05:06Z"
+        keeper.k_updated_at
+  | Error err -> Alcotest.fail err
+
+let test_decode_keeper_formats_last_turn_timestamp () =
+  let timestamp = 1700000000.9 in
+  match
+    Tui_decode.decode_keeper (current_keeper_json ~last_turn_ts:timestamp ())
+  with
+  | Ok keeper ->
+      Alcotest.(check string) "timestamp uses canonical ISO formatter"
+        (Masc_domain.iso8601_of_unix_seconds timestamp)
         keeper.k_last_turn_ts
   | Error err -> Alcotest.fail err
 
-let test_decode_keeper_null_last_turn_ts_is_empty () =
-  match
-    Tui_decode.decode_keeper ~filename:"keeper-main.json"
-      (keeper_json ~last_turn_ts:`Null ())
-  with
+let test_decode_keeper_zero_last_turn_is_empty () =
+  match Tui_decode.decode_keeper (current_keeper_json ()) with
   | Ok keeper ->
-      Alcotest.(check string) "null timestamp becomes empty" "" keeper.k_last_turn_ts
+      Alcotest.(check string) "zero timestamp becomes empty" ""
+        keeper.k_last_turn_ts
   | Error err -> Alcotest.fail err
 
-let test_decode_keeper_rejects_invalid_models_type () =
-  Alcotest.(check bool) "invalid models rejected" true
-    (Result.is_error
-       (Tui_decode.decode_keeper ~filename:"keeper-main.json"
-          (keeper_json ~models:(`String "glm-5.1") ())))
+let test_decode_keeper_rejects_retired_fields () =
+  List.iter
+    (fun field ->
+      let json =
+        match current_keeper_json () with
+        | `Assoc fields -> `Assoc ((field, `Bool true) :: fields)
+        | _ -> Alcotest.fail "current keeper fixture must be an object"
+      in
+      Alcotest.(check bool) ("retired field rejected: " ^ field) true
+        (Result.is_error (Tui_decode.decode_keeper json)))
+    [ "active_goal_ids"
+    ; "active_model"
+    ; "models"
+    ; "proactive_enabled"
+    ; "initiative_enabled"
+    ; "trigger_mode"
+    ; "context_budget"
+    ; "drift_enabled"
+    ; "verify"
+    ]
 
-let test_decode_keeper_rejects_non_string_model_items () =
-  Alcotest.(check bool) "non-string model entries rejected" true
-    (Result.is_error
-       (Tui_decode.decode_keeper ~filename:"keeper-main.json"
-          (keeper_json ~models:(`List [ `String "glm-5.1"; `Int 7 ]) ())))
+let test_dotted_keeper_metadata_name_is_preserved () =
+  Alcotest.(check (option string)) "portable dotted Keeper name"
+    (Some "alpha.with.dot")
+    (Keeper_runtime_root_entry.metadata_keeper_name "alpha.with.dot.json")
 
-let test_decode_keeper_rejects_non_finite_last_turn_ts () =
-  Alcotest.(check bool) "non-finite timestamp rejected" true
+let test_decode_keeper_rejects_missing_current_field () =
+  let json =
+    match current_keeper_json () with
+    | `Assoc fields ->
+        `Assoc (List.filter (fun (key, _) -> key <> "paused") fields)
+    | _ -> Alcotest.fail "current keeper fixture must be an object"
+  in
+  Alcotest.(check bool) "missing current field rejected" true
+    (Result.is_error (Tui_decode.decode_keeper json))
+
+let planning_goal_json id phase priority =
+  `Assoc
+    [ "id", `String id
+    ; "title", `String ("Goal " ^ id)
+    ; "phase", `String phase
+    ; "priority", `Int priority
+    ]
+
+let planning_snapshot_json ?(running_key = "in_progress") () =
+  `Assoc
+    [ ( "goals"
+      , `List
+          (List.mapi
+             (fun index phase ->
+                planning_goal_json (Printf.sprintf "goal-%d" index) phase index)
+             [ "executing"
+             ; "blocked"
+             ; "paused"
+             ; "verifying"
+             ; "completed"
+             ; "dropped"
+             ]) )
+    ; ( "rollup"
+      , `Assoc
+          [ "active_count", `Int 1
+          ; "paused_count", `Int 2
+          ; "verifying_count", `Int 3
+          ; "done_count", `Int 4
+          ; "dropped_count", `Int 5
+          ] )
+    ; ( "task_backlog"
+      , `Assoc
+          [ "todo", `Int 6
+          ; "claimed", `Int 7
+          ; running_key, `Int 8
+          ; "done", `Int 9
+          ; "cancelled", `Int 10
+          ] )
+    ; "generated_at", `String "2026-08-21T05:06:07Z"
+    ]
+
+let test_decode_planning_snapshot_current_contract () =
+  match Tui_decode.decode_planning_snapshot (planning_snapshot_json ()) with
+  | Error err -> Alcotest.fail err
+  | Ok snapshot ->
+      Alcotest.(check (list string)) "all canonical phases"
+        [ "executing"; "blocked"; "paused"; "verifying"; "completed"; "dropped" ]
+        (List.map
+           (fun (goal : Tui_decode.planning_goal) ->
+              Goal_phase.to_string goal.pg_phase)
+           snapshot.pl_goals);
+      Alcotest.(check int) "active" 1 snapshot.pl_rollup.pr_active;
+      Alcotest.(check int) "paused and blocked" 2 snapshot.pl_rollup.pr_paused;
+      Alcotest.(check int) "verifying" 3 snapshot.pl_rollup.pr_verifying;
+      Alcotest.(check int) "done" 4 snapshot.pl_rollup.pr_done;
+      Alcotest.(check int) "dropped" 5 snapshot.pl_rollup.pr_dropped;
+      Alcotest.(check int) "todo" 6 snapshot.pl_backlog.pb_todo;
+      Alcotest.(check int) "claimed" 7 snapshot.pl_backlog.pb_claimed;
+      Alcotest.(check int) "in progress" 8 snapshot.pl_backlog.pb_running;
+      Alcotest.(check int) "backlog done" 9 snapshot.pl_backlog.pb_done;
+      Alcotest.(check int) "cancelled" 10 snapshot.pl_backlog.pb_cancelled;
+      Alcotest.(check string) "generated at" "2026-08-21T05:06:07Z"
+        snapshot.pl_generated_at
+
+let test_decode_planning_snapshot_rejects_running_alias () =
+  Alcotest.(check bool) "retired running alias rejected" true
     (Result.is_error
-       (Tui_decode.decode_keeper ~filename:"keeper-main.json"
-          (keeper_json ~last_turn_ts:(`Float Float.infinity) ())))
+       (Tui_decode.decode_planning_snapshot
+          (planning_snapshot_json ~running_key:"running" ())))
 
 let test_parse_log_entry_success () =
   let line =
@@ -291,21 +453,30 @@ let () =
       [
         Alcotest.test_case "missing priority defaults" `Quick
           test_decode_task_missing_priority_defaults;
+        Alcotest.test_case "active projection filters and sorts" `Quick
+          test_active_tasks_of_domain_filters_and_sorts;
       ] );
     ( "decode_keeper",
       [
-        Alcotest.test_case "missing legacy fields default to none" `Quick
-          test_decode_keeper_missing_legacy_fields_defaults_to_none;
-        Alcotest.test_case "numeric last_turn_ts truncates" `Quick
-          test_decode_keeper_numeric_last_turn_ts_truncates;
-        Alcotest.test_case "null last_turn_ts is empty" `Quick
-          test_decode_keeper_null_last_turn_ts_is_empty;
-        Alcotest.test_case "rejects invalid models type" `Quick
-          test_decode_keeper_rejects_invalid_models_type;
-        Alcotest.test_case "rejects non-string model items" `Quick
-          test_decode_keeper_rejects_non_string_model_items;
-        Alcotest.test_case "rejects non-finite last_turn_ts" `Quick
-          test_decode_keeper_rejects_non_finite_last_turn_ts;
+        Alcotest.test_case "projects current schema" `Quick
+          test_decode_keeper_projects_current_schema;
+        Alcotest.test_case "formats last turn timestamp" `Quick
+          test_decode_keeper_formats_last_turn_timestamp;
+        Alcotest.test_case "zero last turn is empty" `Quick
+          test_decode_keeper_zero_last_turn_is_empty;
+        Alcotest.test_case "rejects retired fields" `Quick
+          test_decode_keeper_rejects_retired_fields;
+        Alcotest.test_case "preserves dotted metadata name" `Quick
+          test_dotted_keeper_metadata_name_is_preserved;
+        Alcotest.test_case "rejects missing current field" `Quick
+          test_decode_keeper_rejects_missing_current_field;
+      ] );
+    ( "decode_planning",
+      [
+        Alcotest.test_case "current contract" `Quick
+          test_decode_planning_snapshot_current_contract;
+        Alcotest.test_case "rejects running alias" `Quick
+          test_decode_planning_snapshot_rejects_running_alias;
       ] );
     ( "parse_log_entry",
       [

--- a/test/test_tui_decode.ml
+++ b/test/test_tui_decode.ml
@@ -81,7 +81,7 @@ let test_active_tasks_of_domain_filters_and_sorts () =
     (List.map (fun (task : Tui_decode.task) -> task.id) active)
 
 let current_keeper_json ?(last_turn_ts = 0.0) ?(paused = false)
-    ?(current_task_id = None) () =
+    ?(current_task_id = None) ?(blocker_detail = "queue full") () =
   let optional_field key = function
     | Some value -> [ (key, value) ]
     | None -> []
@@ -105,7 +105,7 @@ let current_keeper_json ?(last_turn_ts = 0.0) ?(paused = false)
        ; ("last_proactive_outcome", `String "tool_use")
        ; ( "last_blocker"
          , Keeper_meta_contract.(
-             blocker_info_of_class ~detail:"queue full" Capacity_backpressure
+             blocker_info_of_class ~detail:blocker_detail Capacity_backpressure
              |> blocker_info_to_json) )
        ; ("created_at", `String "2026-08-20T01:02:03Z")
        ; ("updated_at", `String "2026-08-21T04:05:06Z")
@@ -172,6 +172,38 @@ let test_decode_keeper_zero_last_turn_is_empty () =
       Alcotest.(check string) "zero timestamp becomes empty" ""
         keeper.k_last_turn_ts
   | Error err -> Alcotest.fail err
+
+let test_terminal_text_escapes_control_sequences () =
+  let payload = "safe\027]0;owned\007\n\t\194\128done" in
+  Alcotest.(check string)
+    "C0, ESC, OSC terminator, and UTF-8 C1 are rendered inert"
+    "safe\\x1B]0;owned\\x07\\x0A\\x09\\u0080done"
+    (Tui_decode.sanitize_terminal_text payload)
+
+let test_terminal_text_preserves_printable_utf8 () =
+  Alcotest.(check string)
+    "printable UTF-8 survives"
+    "정상 blocker — café"
+    (Tui_decode.sanitize_terminal_text "정상 blocker — café")
+
+let test_keeper_blocker_terminal_boundary_keeps_raw_and_renders_safe () =
+  let detail = "queue\027]8;;https://attacker.invalid\007owned\027]8;;\007" in
+  match Tui_decode.decode_keeper (current_keeper_json ~blocker_detail:detail ()) with
+  | Error error -> Alcotest.fail error
+  | Ok keeper ->
+    Alcotest.(check bool)
+      "typed decode retains the raw diagnostic"
+      true
+      (Option.exists (fun raw -> String.contains raw '\027') keeper.k_last_blocker);
+    let rendered = Tui_decode.keeper_blocker_for_terminal keeper in
+    Alcotest.(check bool)
+      "terminal projection contains no ESC byte"
+      false
+      (String.contains rendered '\027');
+    Alcotest.(check bool)
+      "terminal projection exposes escaped control evidence"
+      true
+      (String_util.contains_substring rendered "\\x1B]8;;")
 
 let test_decode_keeper_rejects_retired_fields () =
   List.iter
@@ -477,6 +509,14 @@ let () =
           test_decode_planning_snapshot_current_contract;
         Alcotest.test_case "rejects running alias" `Quick
           test_decode_planning_snapshot_rejects_running_alias;
+      ] );
+    ( "terminal_text",
+      [ Alcotest.test_case "escapes control sequences" `Quick
+          test_terminal_text_escapes_control_sequences
+      ; Alcotest.test_case "preserves printable UTF-8" `Quick
+          test_terminal_text_preserves_printable_utf8
+      ; Alcotest.test_case "keeper blocker keeps raw and renders safe" `Quick
+          test_keeper_blocker_terminal_boundary_keeps_raw_and_renders_safe
       ] );
     ( "parse_log_entry",
       [

--- a/test/test_tui_http_ast.ml
+++ b/test/test_tui_http_ast.ml
@@ -64,28 +64,94 @@ let test_planning_constructors_do_not_collide () =
     (List.mem "Planning" surface_constructors)
 ;;
 
-let test_planning_status_is_closed_sum () =
-  let constructors =
-    Ast_grep.constructor_names_of_type
-      ~module_path:"bin/masc_tui_types.ml"
-      ~type_name:"planning_goal_status"
-  in
-  check (list string) "planning status constructors"
-    [
-      "Planning_goal_active";
-      "Planning_goal_paused";
-      "Planning_goal_done";
-      "Planning_goal_dropped";
-    ]
-    constructors;
+let test_planning_phase_uses_goal_ssot () =
+  check bool "projection parses the canonical goal phase" true
+    (Ast_grep.count_calls
+       ~module_path:"lib/tui_decode.ml"
+       ~callee:"Goal_phase.parse"
+     >= 1);
+  check bool "loader uses the behavioral planning decoder" true
+    (Ast_grep.count_calls
+       ~module_path:"bin/masc_tui_loader.ml"
+       ~callee:"Tui_decode.decode_planning_snapshot"
+     >= 1);
+  check bool "renderer labels the canonical goal phase" true
+    (Ast_grep.count_calls
+       ~module_path:"bin/masc_tui_render.ml"
+       ~callee:"Goal_phase.to_string"
+     >= 1);
   check int "renderer does not lowercase planning status strings" 0
     (Ast_grep.count_calls
        ~module_path:"bin/masc_tui_render.ml"
        ~callee:"String.lowercase_ascii");
-  check int "loader has an explicit unknown-status decode error" 1
+  check int "projection rejects an unknown canonical phase" 1
     (Ast_grep.count_string_literals
+       ~module_path:"lib/tui_decode.ml"
+       ~needle:"unknown planning goal phase")
+;;
+
+let test_tui_current_projection_wiring () =
+  check int "task loader is a named canonical-backlog projection" 1
+    (Ast_grep.count_value_bindings
        ~module_path:"bin/masc_tui_loader.ml"
-       ~needle:"unknown planning goal status")
+       ~name:"load_active_tasks");
+  check bool "task loader uses the canonical backlog observation" true
+    (Ast_grep.count_calls
+       ~module_path:"bin/masc_tui_loader.ml"
+       ~callee:"Workspace_backlog.read_backlog_observation_with_source_r"
+     >= 1);
+  check bool "loader uses the behavior-tested active task projection" true
+    (Ast_grep.count_calls
+       ~module_path:"bin/masc_tui_loader.ml"
+       ~callee:"Tui_decode.active_tasks_of_domain"
+     >= 1);
+  check int "task row projection has one domain boundary" 1
+    (Ast_grep.count_value_bindings
+       ~module_path:"lib/tui_decode.ml"
+       ~name:"task_of_domain");
+  check bool "keeper loader uses canonical persisted-name classification" true
+    (Ast_grep.count_calls
+       ~module_path:"bin/masc_tui_loader.ml"
+       ~callee:"Keeper_meta_store.persisted_keeper_names_result"
+     >= 1);
+  check bool "keeper loader uses the typed current-schema store" true
+    (Ast_grep.count_calls
+       ~module_path:"bin/masc_tui_loader.ml"
+       ~callee:"Keeper_meta_store.read_meta"
+     >= 1);
+  check bool "keeper loader projects typed metadata" true
+    (Ast_grep.count_calls
+       ~module_path:"bin/masc_tui_loader.ml"
+       ~callee:"Tui_decode.keeper_of_meta"
+     >= 1);
+  check bool "keeper metrics use the cluster-aware canonical path" true
+    (Ast_grep.count_calls
+       ~module_path:"bin/masc_tui_loader.ml"
+       ~callee:"Keeper_types_support.keeper_metrics_dir"
+     >= 1);
+  check int "retired planning running alias absent" 0
+    (Ast_grep.count_string_literals
+       ~module_path:"lib/tui_decode.ml"
+       ~needle:"running");
+  check int "verify appears only inside verifying_count" 1
+    (Ast_grep.count_string_literals
+       ~module_path:"lib/tui_decode.ml"
+       ~needle:"verify");
+  List.iter
+    (fun retired ->
+       check int ("retired keeper field absent: " ^ retired) 0
+         (Ast_grep.count_string_literals
+            ~module_path:"lib/tui_decode.ml"
+            ~needle:retired))
+    [ "active_goal_ids"
+    ; "active_model"
+    ; "models"
+    ; "proactive_enabled"
+    ; "initiative_enabled"
+    ; "trigger_mode"
+    ; "context_budget"
+    ; "drift_enabled"
+    ]
 ;;
 
 let test_overview_state_domains_are_closed_sum () =
@@ -177,10 +243,10 @@ let () =
           "planning constructors do not collide"
           `Quick
           test_planning_constructors_do_not_collide;
-        test_case
-          "planning status is closed-sum"
-          `Quick
-          test_planning_status_is_closed_sum;
+        test_case "planning phase uses goal SSOT" `Quick
+          test_planning_phase_uses_goal_ssot;
+        test_case "current projection wiring" `Quick
+          test_tui_current_projection_wiring;
         test_case
           "overview state domains are closed-sum"
           `Quick


### PR DESCRIPTION
## What

- read Overview tasks from the canonical aggregate backlog and keep Task status typed
- project Keeper rows through the current metadata schema and canonical dotted-name classifier
- decode Planning through Goal_phase, including verifying rollup, with no retired running alias
- keep task and Keeper read failures visible instead of presenting them as empty collections
- resolve Keeper metrics through the same cluster-aware workspace configuration

## Why

The TUI still read retired per-task files and retired Keeper fields, and its Planning decoder expected the removed status contract. Those mismatches made core surfaces empty or misleading on current source.

## Verification

- `scripts/dune-local.sh build bin/masc_tui.exe test/test_tui_decode.exe test/test_tui_http_ast.exe`
- `test_tui_decode`: 25/25 passed
- `test_tui_http_ast`: 9/9 passed
- `ocamlformat --check` on touched OCaml files
- `git diff --check`
- three independent read-only reviews, followed by targeted re-review of every blocker

## Live/runtime note

Live smoke evidence is intentionally separate from source and local tests. At 2026-08-21 21:39 KST, `/health?full=1` reported server commit `ddb2c03e7f42589ddca5b5136df451922bf8a297`, while this branch is based on current `main` `58ee736e5cddada0935f38da491f9711b0dc856e`. The exact-current TUI showed canonical backlog tasks and the six-phase Planning rollup against that runtime. Existing live Keeper metadata still carries removed `active_goal_ids`, so the current-schema reader reports reset required rather than adding a compatibility fallback.

Approvals, Keeper chat protocol, and renderer performance are intentionally left for follow-up Draft PRs.