### PR TITLE
fix(ci): complete goal hard-cut contract propagation

### DIFF
--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -1106,20 +1106,81 @@ let optional_string_of_yojson ~context = function
     Ok ()
 ;;
 
+let keeper_context_current_fields =
+  [ "lane_keeper_name"
+  ; "agent_name"
+  ; "keeper_record_id"
+  ; "keeper_runtime_uid"
+  ; "instructions"
+  ; "current_task_id"
+  ; "mention_keeper_ids"
+  ]
+;;
+
+(* [active_goal_ids] was emitted by early v4 writers before Goal ownership
+   moved to the canonical Goal/Task stores. Keep this tombstone normalization
+   on the v4 ledger read boundary only: in-memory candidates and every current
+   write still have to satisfy the exact seven-field schema below. *)
+let normalize_legacy_v4_keeper_context json =
+  let context = "candidate.judgment_request.keeper_context" in
+  let* fields = assoc ~context json in
+  let retired_fields =
+    List.filter
+      (fun (name, _) -> String.equal name "active_goal_ids")
+      fields
+  in
+  match retired_fields with
+  | [] -> Ok json
+  | [ (_, active_goal_ids) ] ->
+    let* () =
+      exact_fields
+        ~context
+        ("active_goal_ids" :: keeper_context_current_fields)
+        fields
+    in
+    let* () =
+      string_list_of_yojson
+        ~context:(context ^ ".active_goal_ids")
+        active_goal_ids
+    in
+    Ok
+      (`Assoc
+         (List.filter
+            (fun (name, _) -> not (String.equal name "active_goal_ids"))
+            fields))
+  | _ -> Error (context ^ ".active_goal_ids must occur exactly once")
+;;
+
+let normalize_legacy_v4_judgment_request json =
+  let context = "candidate.judgment_request" in
+  let* fields = assoc ~context json in
+  let keeper_contexts =
+    List.filter_map
+      (fun (name, value) ->
+         if String.equal name "keeper_context" then Some value else None)
+      fields
+  in
+  match keeper_contexts with
+  | [ keeper_context ] ->
+    let* normalized = normalize_legacy_v4_keeper_context keeper_context in
+    Ok
+      (`Assoc
+         (List.map
+            (fun (name, value) ->
+               if String.equal name "keeper_context"
+               then name, normalized
+               else name, value)
+            fields))
+  | [] | _ :: _ :: _ -> Ok json
+;;
+
 let validate_keeper_context ~keeper_name json =
   let context = "candidate.judgment_request.keeper_context" in
   let* fields = assoc ~context json in
   let* () =
     exact_fields
       ~context
-      [ "lane_keeper_name"
-      ; "agent_name"
-      ; "keeper_record_id"
-      ; "keeper_runtime_uid"
-      ; "instructions"
-      ; "current_task_id"
-      ; "mention_keeper_ids"
-      ]
+      keeper_context_current_fields
       fields
   in
   let* lane_keeper_name_json = field ~context "lane_keeper_name" fields in
@@ -1319,7 +1380,10 @@ let candidate_of_json json =
     then Ok ()
     else Error "candidate_id does not match the exact Keeper and Board signal identity"
   in
-  let* judgment_request = field ~context "judgment_request" fields in
+  let* judgment_request_json = field ~context "judgment_request" fields in
+  let* judgment_request =
+    normalize_legacy_v4_judgment_request judgment_request_json
+  in
   let* recorded_at_json = field ~context "recorded_at" fields in
   let* recorded_at =
     finite_float_json ~context:(context ^ ".recorded_at") recorded_at_json

--- a/test/test_keeper_board_attention_candidate.ml
+++ b/test/test_keeper_board_attention_candidate.ml
@@ -346,6 +346,53 @@ let set_assoc_field key value = function
   | _ -> Alcotest.fail ("expected object while setting field " ^ key)
 ;;
 
+let append_assoc_field key value = function
+  | `Assoc fields -> `Assoc (fields @ [ key, value ])
+  | _ -> Alcotest.fail ("expected object while appending field " ^ key)
+;;
+
+let insert_assoc_field_after anchor key value = function
+  | `Assoc fields ->
+    let rec insert reversed = function
+      | [] -> Alcotest.fail ("missing object field " ^ anchor)
+      | ((name, _) as field) :: rest ->
+        if String.equal name anchor
+        then `Assoc (List.rev_append reversed (field :: (key, value) :: rest))
+        else insert (field :: reversed) rest
+    in
+    insert [] fields
+  | _ -> Alcotest.fail ("expected object while inserting field " ^ key)
+;;
+
+let rewrite_candidate_keeper_context rewrite candidate =
+  A.candidate_to_json candidate
+  |> rewrite_assoc_field "judgment_request" (fun request ->
+    rewrite_assoc_field "keeper_context" rewrite request)
+;;
+
+let with_legacy_active_goal_ids value candidate =
+  rewrite_candidate_keeper_context
+    (insert_assoc_field_after "instructions" "active_goal_ids" value)
+    candidate
+;;
+
+let ledger_path ~base_path =
+  Filename.concat
+    (Filename.concat
+       (Common.masc_dir_from_base_path ~base_path)
+       "board_attention_candidates")
+    "sangsu.jsonl"
+;;
+
+let write_ledger_rows ~base_path rows =
+  Out_channel.with_open_bin (ledger_path ~base_path) (fun channel ->
+    List.iter
+      (fun row ->
+         output_string channel (Yojson.Safe.to_string row);
+         output_char channel '\n')
+      rows)
+;;
+
 let rewrite_first_comment rewrite = function
   | `List (comment :: rest) -> `List (rewrite comment :: rest)
   | `List [] -> Alcotest.fail "expected one Board comment fixture"
@@ -360,6 +407,112 @@ let expect_record_error ?expected_detail ~base_path label candidate =
          Alcotest.(check string) (label ^ " error") expected detail)
       expected_detail
   | A.Recorded _ | A.Duplicate _ -> Alcotest.fail (label ^ " was recorded")
+;;
+
+let test_legacy_v4_context_tombstone_normalizes_on_read_and_rewrite () =
+  with_temp_base "board-attention-candidate-legacy-v4" @@ fun base_path ->
+  let first = candidate (signal "post-legacy-v4-first") in
+  let second = candidate (signal "post-legacy-v4-second") in
+  let in_memory_legacy_request =
+    rewrite_assoc_field
+      "keeper_context"
+      (set_assoc_field "active_goal_ids" (`List []))
+      first.judgment_request
+  in
+  (match
+     A.record
+       ~base_path
+       { first with judgment_request = in_memory_legacy_request }
+   with
+   | A.Record_error _ -> ()
+   | A.Recorded _ | A.Duplicate _ ->
+     Alcotest.fail "current writer accepted the retired keeper-context field");
+  ignore (record ~base_path first : A.candidate);
+  let legacy_goal_ids = `List [ `String "goal-old-a"; `String "goal-old-b" ] in
+  write_ledger_rows
+    ~base_path
+    [ with_legacy_active_goal_ids legacy_goal_ids first
+    ; with_legacy_active_goal_ids (`List []) second
+    ];
+  let loaded =
+    ok
+      "load multi-row legacy v4 ledger"
+      (A.load_candidates ~base_path ~keeper_name:first.keeper_name)
+  in
+  Alcotest.(check bool)
+    "legacy rows normalize to current candidates"
+    true
+    (loaded = [ first; second ]);
+  let third = candidate (signal "post-current-after-legacy-v4") in
+  ignore (record ~base_path third : A.candidate);
+  let rewritten =
+    ok
+      "load ledger after current write"
+      (A.load_candidates ~base_path ~keeper_name:first.keeper_name)
+  in
+  Alcotest.(check bool)
+    "current write preserves every normalized row"
+    true
+    (rewritten = [ first; second; third ]);
+  let durable_content =
+    In_channel.with_open_bin (ledger_path ~base_path) In_channel.input_all
+  in
+  Alcotest.(check bool)
+    "compacted ledger drops the retired field"
+    false
+    (String_util.contains_substring durable_content "active_goal_ids")
+;;
+
+let test_legacy_v4_context_tombstone_rejects_malformed_shapes () =
+  let base = candidate (signal "post-legacy-v4-invalid") in
+  let legacy =
+    with_legacy_active_goal_ids (`List [ `String "goal-old" ]) base
+  in
+  let unrelated_row =
+    rewrite_candidate_keeper_context
+      (set_assoc_field "unrelated_extra" (`String "reject"))
+      base
+  in
+  let invalid_rows =
+    [ "unrelated keeper-context field", unrelated_row
+    ; ( "legacy field with unrelated keeper-context field"
+      , rewrite_assoc_field
+          "judgment_request"
+          (fun request ->
+             rewrite_assoc_field
+               "keeper_context"
+               (set_assoc_field "unrelated_extra" (`String "reject"))
+               request)
+          legacy )
+    ; ( "duplicate legacy field"
+      , rewrite_assoc_field
+          "judgment_request"
+          (fun request ->
+             rewrite_assoc_field
+               "keeper_context"
+               (append_assoc_field
+                  "active_goal_ids"
+                  (`List [ `String "goal-duplicate" ]))
+               request)
+          legacy )
+    ; ( "wrong-typed legacy field"
+      , with_legacy_active_goal_ids (`String "goal-not-an-array") base )
+    ; ( "wrong-typed legacy field element"
+      , with_legacy_active_goal_ids (`List [ `Int 7 ]) base )
+    ]
+  in
+  List.iter
+    (fun (label, row) ->
+       match A.candidate_of_json row with
+       | Error _ -> ()
+       | Ok _ -> Alcotest.fail (label ^ " was accepted"))
+    invalid_rows;
+  with_temp_base "board-attention-candidate-legacy-v4-invalid" @@ fun base_path ->
+  ignore (record ~base_path base : A.candidate);
+  write_ledger_rows ~base_path [ unrelated_row ];
+  match A.load_candidates ~base_path ~keeper_name:base.keeper_name with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "persisted unrelated keeper-context field was accepted"
 ;;
 
 let test_singleton_request_is_canonical_and_identity_bound () =
@@ -873,6 +1026,14 @@ let () =
             "status view preserves resumability and quarantine"
             `Quick
             test_status_view_preserves_resumability_and_quarantine
+        ; Alcotest.test_case
+            "legacy v4 context tombstone normalizes on read and rewrite"
+            `Quick
+            test_legacy_v4_context_tombstone_normalizes_on_read_and_rewrite
+        ; Alcotest.test_case
+            "legacy v4 context tombstone rejects malformed shapes"
+            `Quick
+            test_legacy_v4_context_tombstone_rejects_malformed_shapes
         ; Alcotest.test_case
             "singleton request is canonical and identity bound"
             `Quick

--- a/test/test_keeper_registry_hardening.ml
+++ b/test/test_keeper_registry_hardening.ml
@@ -710,6 +710,7 @@ let test_goal_reconciliation_enqueues_once_after_last_terminal_task () =
 let test_goal_reconciliation_targets_exact_producer
       ?(unrelated_paused = false)
       ?(corrupt_unrelated_meta = false)
+      ?(producer_persisted_only = false)
       () =
   let dir = temp_dir "registry_goal_reconciliation_producer" in
   Fun.protect
@@ -721,10 +722,15 @@ let test_goal_reconciliation_targets_exact_producer
        Fs_compat.set_fs (Eio.Stdenv.fs env);
        KR.For_testing.clear ();
        let config = Masc.Workspace.default_config dir in
-       let completing_agent_name = "keeper-executor-agent-agent" in
+       let producer_name = "producer" in
+       let completing_agent_name =
+         if producer_persisted_only
+         then Masc.Keeper_identity.keeper_agent_name producer_name
+         else "keeper-executor-agent-agent"
+       in
        ignore (Masc.Workspace.init config ~agent_name:(Some completing_agent_name));
        let producer_meta =
-         { (make_meta "producer") with agent_name = completing_agent_name }
+         { (make_meta producer_name) with agent_name = completing_agent_name }
        in
        let goal, _ =
          match
@@ -772,11 +778,17 @@ let test_goal_reconciliation_targets_exact_producer
        in
        finish "task-001";
        finish "task-002";
-       ignore
-         (KR.register_offline
-            ~base_path:config.base_path
-            producer_meta.name
-            producer_meta);
+       if producer_persisted_only
+       then
+         (match Masc.Keeper_meta_store.replace_snapshot config producer_meta with
+          | Ok () -> ()
+          | Error detail -> failf "persist producer metadata failed: %s" detail)
+       else
+         ignore
+           (KR.register_offline
+              ~base_path:config.base_path
+              producer_meta.name
+              producer_meta);
        let assigned_meta =
          { (make_goal_reconciler_meta ()) with
            paused = unrelated_paused
@@ -787,6 +799,14 @@ let test_goal_reconciliation_targets_exact_producer
             ~base_path:config.base_path
             assigned_meta.name
             assigned_meta);
+       if producer_persisted_only
+       then
+         check
+           (option string)
+           "producer has no live registry entry"
+           None
+           (KR.get ~base_path:config.base_path producer_meta.name
+            |> Option.map (fun (entry : KR.registry_entry) -> entry.name));
        if corrupt_unrelated_meta
        then
          write_text_file
@@ -833,6 +853,12 @@ let test_goal_reconciliation_ignores_unrelated_paused_keeper () =
 let test_goal_reconciliation_ignores_unrelated_corrupt_meta () =
   test_goal_reconciliation_targets_exact_producer
     ~corrupt_unrelated_meta:true
+    ()
+;;
+
+let test_goal_reconciliation_resolves_persisted_only_producer () =
+  test_goal_reconciliation_targets_exact_producer
+    ~producer_persisted_only:true
     ()
 ;;
 
@@ -1465,6 +1491,10 @@ let () =
             "unrelated corrupt metadata does not affect producer routing"
             `Quick
             test_goal_reconciliation_ignores_unrelated_corrupt_meta
+        ; test_case
+            "goal reconciliation resolves a persisted-only producer"
+            `Quick
+            test_goal_reconciliation_resolves_persisted_only_producer
         ; test_case
             "restart scan retries missed reconciliation exactly once"
             `Quick


### PR DESCRIPTION
## Summary

- keep the schema-v4 Board attention writer and validator on the current exact seven-field Keeper context supplied by #29310
- normalize the retired `active_goal_ids` tombstone only while reading legacy v4 ledger rows, with exact field, duplicate, and type checks
- prove persisted multi-row legacy load, canonical compaction on the next write, and current re-read
- cover exact producer reconciliation when the Keeper binding exists only in persisted metadata

## Root cause

#29310 completed the owner hard cut and correctly removed `active_goal_ids` from the current Board candidate schema. Existing durable v4 rows, however, were written before that hard cut and still contain the retired field. Rejecting those rows poisons the whole candidate ledger. This PR confines compatibility handling to the v4 read boundary; the canonical serializer and in-memory persistence validator still reject the retired field.

## Rebase

Rebased on current main `ead9709886`. Range-diff dropped the superseded owner-hard-cut/CI-fixture commit `c59f535`; the remaining main-relative delta is one commit and three files: Board read normalization, its persisted ledger tests, and persisted-only producer coverage.

## Validation

- `scripts/dune-local.sh build @check`
- affected 6 test executables, 173 tests: pass
- `test_keeper_board_attention_candidate`: 15/15 pass
- `test_keeper_registry_hardening`: 26/26 pass
- persisted two-row legacy v4 load, normalization, current rewrite, and re-read pass
- unrelated extra fields, duplicate tombstones, and wrong container/element types reject
- `git diff --check`

Draft pending independent source review and CI.