### PR TITLE
feat(tui): make operator approvals actionable

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -205,6 +205,12 @@
 
 ;; TUI Dashboard - Terminal interface for multi-agent workspace
 
+(library
+ (name masc_tui_operator_projection)
+ (wrapped false)
+ (modules masc_tui_operator_projection)
+ (libraries masc masc.operator masc.masc_core yojson))
+
 (executable
  (name masc_tui)
  (modules
@@ -218,6 +224,7 @@
  (package masc)
  (libraries
   masc
+  masc_tui_operator_projection
   masc.dashboard
   masc.server
   masc.config

--- a/bin/dune
+++ b/bin/dune
@@ -230,6 +230,7 @@
   fs_compat
   time_compat
   masc_log
+  masc_goal
   masc_workspace
   masc_backend
   masc_process

--- a/bin/masc_tui.ml
+++ b/bin/masc_tui.ml
@@ -3,6 +3,8 @@ open Masc_tui_ansi
 open Masc_tui_render
 open Masc_tui_loader
 
+module Approval = Masc_tui_operator_projection
+
 (** Local exception for breaking the main TUI loop without using Exit. *)
 exception Break
 
@@ -180,10 +182,6 @@ let handle_message_key (state : state) (base_path : string) (key : string) : boo
       true  (* Consume but ignore other control chars *)
   | _ -> true
 
-let approval_decision_wire = function
-  | Confirm -> "confirm"
-  | Deny -> "deny"
-
 let approval_decision_key = function
   | Confirm -> "y"
   | Deny -> "n"
@@ -192,33 +190,32 @@ let approval_decision_done = function
   | Confirm -> "Confirmed"
   | Deny -> "Denied"
 
-let approval_decision_failed = function
-  | Confirm -> "Confirm failed"
-  | Deny -> "Deny failed"
+let approval_decision_unverified = function
+  | Confirm -> "Confirmation outcome unverified"
+  | Deny -> "Denial outcome unverified"
 
-let pending_approval_matches pending approval decision =
-  match pending with
-  | Some p ->
-      String.equal p.paa_token approval.ap_token && p.paa_decision = decision
-  | None -> false
+type approval_observation = {
+  ao_generation: Approval.Flow.generation;
+  ao_result: (approval_snapshot, string) result;
+}
 
 type http_surface_results = {
   http_overview: (overview_snapshot, string) result;
+  http_approvals: approval_observation option;
   http_board: (board_post list, string) result;
   http_planning: (planning_snapshot, string) result;
 }
 
 type async_msg =
   | Http_refresh_done of http_surface_results
-  | Http_refresh_failed of string
+  | Http_refresh_failed of string * Approval.Flow.generation option
   | Board_post_refresh_done of string * (board_post * board_comment list, string) result
   | Board_post_refresh_failed of string * string
   | Approval_decision_done of
       approval_item
       * approval_decision
-      * (Yojson.Safe.t, string) result
-      * (overview_snapshot, string) result option
-  | Approval_decision_failed of approval_item * approval_decision * string
+      * (Approval.confirm_outcome, string) result
+      * approval_observation
 
 let enqueue_async mailbox msg = Eio.Stream.add mailbox msg
 
@@ -243,6 +240,33 @@ let apply_overview_load state = function
         ~current_error:state.overview_error
         ~set_error:(fun value -> state.overview_error <- value)
         err
+
+let apply_approvals_load state = function
+  | Ok snapshot ->
+      state.approval_snapshot <- Some snapshot;
+      state.approvals_error <- None;
+      if state.approval_cursor >= List.length snapshot.aps_items then
+        state.approval_cursor <- max 0 (List.length snapshot.aps_items - 1);
+      (match state.pending_approval_action with
+       | Some pending
+         when not
+                (List.exists
+                   (fun item -> String.equal item.ap_token pending.paa_token)
+                   snapshot.aps_items) ->
+           state.pending_approval_action <- None
+       | Some _ | None -> ())
+  | Error err ->
+      state.approval_snapshot <- None;
+      state.approval_cursor <- 0;
+      state.pending_approval_action <- None;
+      remember_surface_error state ~surface:"approvals"
+        ~current_error:state.approvals_error
+        ~set_error:(fun value -> state.approvals_error <- value)
+        err
+
+let apply_approval_observation state observation =
+  if Approval.Flow.is_current state.approval_flow observation.ao_generation then
+    apply_approvals_load state observation.ao_result
 
 let apply_board_list_load state = function
   | Ok posts ->
@@ -287,19 +311,34 @@ let refresh_status results =
   | n, total when n = total -> Masc_tui_types.Connected
   | _ -> Masc_tui_types.Degraded
 
-let load_http_surfaces ~host ~port =
-  {
-    http_overview = load_overview ~host ~port;
-    http_board = load_board_list ~host ~port;
-    http_planning = load_planning ~host ~port;
-  }
+let load_http_surfaces ~host ~port ~approval_generation =
+  let http_overview = load_overview ~host ~port in
+  let http_approvals =
+    Option.map
+      (fun ao_generation ->
+         { ao_generation; ao_result = load_approvals ~host ~port })
+      approval_generation
+  in
+  let http_board = load_board_list ~host ~port in
+  let http_planning = load_planning ~host ~port in
+  { http_overview; http_approvals; http_board; http_planning }
 
 let apply_http_surfaces state results =
   apply_overview_load state results.http_overview;
+  Option.iter (apply_approval_observation state) results.http_approvals;
   apply_board_list_load state results.http_board;
   apply_planning_load state results.http_planning;
+  let approval_status =
+    Option.map
+      (fun observation ->
+         Result.map (fun _ -> ()) observation.ao_result
+         |> Result.map_error (fun _ -> ()))
+      results.http_approvals
+    |> Option.to_list
+  in
   state.connection_status <-
     refresh_status
+      (
       [
         Result.map (fun _ -> ()) results.http_overview
         |> Result.map_error (fun _ -> ());
@@ -307,22 +346,31 @@ let apply_http_surfaces state results =
         |> Result.map_error (fun _ -> ());
         Result.map (fun _ -> ()) results.http_planning
         |> Result.map_error (fun _ -> ());
-      ]
+      ] @ approval_status)
 
 let start_http_refresh state ~host ~port ~refresh_inflight ~mailbox =
   if not !refresh_inflight then begin
     refresh_inflight := true;
+    let flow, approval_generation =
+      Approval.Flow.reserve_refresh state.approval_flow
+    in
+    state.approval_flow <- flow;
     state.connection_status <-
       (match state.connection_status with
        | Connected | Degraded -> Masc_tui_types.Reconnecting
        | Disconnected | Connecting | Reconnecting -> Masc_tui_types.Connecting);
     let run_refresh () =
-      try enqueue_async mailbox (Http_refresh_done (load_http_surfaces ~host ~port)) with
+      try
+        enqueue_async mailbox
+          (Http_refresh_done
+             (load_http_surfaces ~host ~port ~approval_generation))
+      with
       | Eio.Cancel.Cancelled _ as exn -> raise exn
       | exn ->
         enqueue_async mailbox
           (Http_refresh_failed
-             (Printf.sprintf "HTTP refresh failed: %s" (Printexc.to_string exn)))
+             ( Printf.sprintf "HTTP refresh failed: %s" (Printexc.to_string exn)
+             , approval_generation ))
     in
     match Eio_context.get_switch_opt () with
     | Some sw ->
@@ -330,7 +378,9 @@ let start_http_refresh state ~host ~port ~refresh_inflight ~mailbox =
     | None ->
         Fun.protect
           ~finally:(fun () -> refresh_inflight := false)
-          (fun () -> apply_http_surfaces state (load_http_surfaces ~host ~port))
+          (fun () ->
+             apply_http_surfaces state
+               (load_http_surfaces ~host ~port ~approval_generation))
   end
 
 let board_detail_still_current state post_id =
@@ -386,83 +436,110 @@ let start_board_post_refresh state ~host ~port ~post_id ~refresh_inflight
               (load_board_post ~host ~port ~post_id))
   end
 
-let apply_approval_decision_result state approval decision overview = function
-  | Ok _ ->
-      add_event state "system"
-        (Printf.sprintf "%s: %s" (approval_decision_done decision)
-           approval.ap_summary);
-      Option.iter (apply_overview_load state) overview;
-      state.approval_cursor <- 0
-  | Error err ->
-      add_event state "error"
-        (Printf.sprintf "%s: %s" (approval_decision_failed decision) err)
+let apply_approval_decision_result state approval decision approvals result =
+  (match result with
+   | Ok (Approval.Completed _) ->
+       add_event state "system"
+         (Printf.sprintf "%s: %s" (approval_decision_done decision)
+            approval.ap_summary)
+   | Ok (Approval.Deferred _) ->
+       add_event state "system"
+         (Printf.sprintf "Confirmation accepted; action deferred: %s"
+            approval.ap_summary)
+   | Ok (Approval.Execution_failed (_, detail)) ->
+       add_event state "error"
+         (Printf.sprintf "Confirmation accepted; action failed: %s" detail)
+   | Error err ->
+       add_event state "error"
+         (Printf.sprintf "%s: %s" (approval_decision_unverified decision) err));
+  apply_approvals_load state approvals
 
-let start_approval_decision state approval decision ~action_inflight ~mailbox =
-  if !action_inflight then
-    add_event state "system" "Approval action already in progress"
-  else
-    let () = action_inflight := true in
+let apply_approval_decision_completion state generation approval decision result
+    approvals =
+  state.pending_approval_action <- None;
+  let flow, owns_action =
+    Approval.Flow.finish_action state.approval_flow generation
+  in
+  state.approval_flow <- flow;
+  if owns_action then
+    apply_approval_decision_result state approval decision approvals result
+
+let start_approval_decision state approval decision ~mailbox =
+  match Approval.Flow.begin_action state.approval_flow with
+  | Error `Already_inflight ->
+      state.pending_approval_action <- None;
+      add_event state "system" "Approval action already in progress"
+  | Ok (flow, generation) ->
+    let () = state.approval_flow <- flow in
     let () = state.pending_approval_action <- None in
     let host = Env_config_core.masc_host () in
     let port = state.port in
-    let decision_wire = approval_decision_wire decision in
-    let clear_inflight () = action_inflight := false in
     let run_action () =
-      try
-        let result =
-          Masc_tui_http.post_operator_confirm ~host ~port ~token:approval.ap_token
-            ~decision:decision_wire
-        in
-        let overview =
-          match result with
-          | Ok _ -> Some (load_overview ~host ~port)
-          | Error _ -> None
-        in
-        enqueue_async mailbox
-          (Approval_decision_done (approval, decision, result, overview))
-      with
-      | Eio.Cancel.Cancelled _ as exn -> raise exn
-      | exn ->
-        enqueue_async mailbox
-          (Approval_decision_failed
-             (approval, decision, Printexc.to_string exn))
+      let result =
+        try
+          Masc_tui_http.post_operator_confirm ~host ~port
+            ~token:approval.ap_token ~decision
+        with
+        | Eio.Cancel.Cancelled _ as exn -> raise exn
+        | exn -> Error (Printexc.to_string exn)
+      in
+      let approvals =
+        try load_approvals ~host ~port with
+        | Eio.Cancel.Cancelled _ as exn -> raise exn
+        | exn -> Error ("approvals reload failed: " ^ Printexc.to_string exn)
+      in
+      let approvals = { ao_generation = generation; ao_result = approvals } in
+      enqueue_async mailbox
+        (Approval_decision_done (approval, decision, result, approvals))
     in
     match Eio_context.get_switch_opt () with
     | Some sw -> Eio.Fiber.fork ~sw run_action
     | None ->
-        Fun.protect ~finally:clear_inflight (fun () ->
-            let result =
-              Masc_tui_http.post_operator_confirm ~host ~port
-                ~token:approval.ap_token ~decision:decision_wire
-            in
-            let overview =
-              match result with
-              | Ok _ -> Some (load_overview ~host ~port)
-              | Error _ -> None
-            in
-            apply_approval_decision_result state approval decision overview result)
+        let result =
+          try
+            Masc_tui_http.post_operator_confirm ~host ~port
+              ~token:approval.ap_token ~decision
+          with exn -> Error (Printexc.to_string exn)
+        in
+        let approvals =
+          try load_approvals ~host ~port with
+          | exn -> Error ("approvals reload failed: " ^ Printexc.to_string exn)
+        in
+        apply_approval_decision_completion state generation approval decision
+          result approvals
 
 (* TEL-OK: TUI-local confirmation gate emits user-visible events here; the
    operator confirmation endpoint owns durable approval telemetry. *)
-let handle_approval_decision state approval decision ~action_inflight ~mailbox =
-  if pending_approval_matches state.pending_approval_action approval decision then
-    start_approval_decision state approval decision ~action_inflight ~mailbox
-  else begin
-    state.pending_approval_action <-
-      Some { paa_token = approval.ap_token; paa_decision = decision };
-    add_event state "system"
-      (Printf.sprintf "Press %s again: %s"
-         (approval_decision_key decision)
-         approval.ap_summary)
-  end
+let handle_approval_decision state approval decision ~mailbox =
+  match
+    Approval.approval_gate_transition
+      ~inflight:(Approval.Flow.action_inflight state.approval_flow)
+      ~pending:state.pending_approval_action ~token:approval.ap_token ~decision
+  with
+  | Approval.Gate_blocked_inflight ->
+      state.pending_approval_action <- None;
+      add_event state "system" "Approval action already in progress"
+  | Approval.Gate_submit ->
+      start_approval_decision state approval decision ~mailbox
+  | Approval.Gate_arm pending ->
+      state.pending_approval_action <- Some pending;
+      add_event state "system"
+        (Printf.sprintf "Press %s again: %s"
+           (approval_decision_key decision)
+           approval.ap_summary)
 
 let apply_async_message state ~http_refresh_inflight
-    ~board_post_refresh_inflight ~approval_action_inflight = function
+    ~board_post_refresh_inflight = function
   | Http_refresh_done results ->
       http_refresh_inflight := false;
       apply_http_surfaces state results
-  | Http_refresh_failed err ->
+  | Http_refresh_failed (err, approval_generation) ->
       http_refresh_inflight := false;
+      Option.iter
+        (fun ao_generation ->
+           apply_approval_observation state
+             { ao_generation; ao_result = Error err })
+        approval_generation;
       state.connection_status <- Masc_tui_types.Disconnected;
       add_event state "error" err
   | Board_post_refresh_done (post_id, result) ->
@@ -477,22 +554,18 @@ let apply_async_message state ~http_refresh_inflight
           ~current_error:state.board_error
           ~set_error:(fun value -> state.board_error <- value)
           err
-  | Approval_decision_done (approval, decision, result, overview) ->
-      approval_action_inflight := false;
-      apply_approval_decision_result state approval decision overview result
-  | Approval_decision_failed (approval, decision, err) ->
-      approval_action_inflight := false;
-      add_event state "error"
-        (Printf.sprintf "%s: %s" (approval_decision_failed decision) err)
+  | Approval_decision_done (approval, decision, result, approvals) ->
+      apply_approval_decision_completion state approvals.ao_generation approval
+        decision result approvals.ao_result
 
 let drain_async_messages state ~http_refresh_inflight
-    ~board_post_refresh_inflight ~approval_action_inflight mailbox =
+    ~board_post_refresh_inflight mailbox =
   let rec loop () =
     match Eio.Stream.take_nonblocking mailbox with
     | None -> ()
     | Some msg ->
         apply_async_message state ~http_refresh_inflight
-          ~board_post_refresh_inflight ~approval_action_inflight msg;
+          ~board_post_refresh_inflight msg;
         loop ()
   in
   loop ()
@@ -524,7 +597,6 @@ let main () =
   let port = state.port in
   let http_refresh_inflight = ref false in
   let board_post_refresh_inflight = ref None in
-  let approval_action_inflight = ref false in
   let async_messages = Eio.Stream.create 32 in
   start_http_refresh state ~host ~port ~refresh_inflight:http_refresh_inflight
     ~mailbox:async_messages;
@@ -535,9 +607,13 @@ let main () =
   try
     while true do
       drain_async_messages state ~http_refresh_inflight
-        ~board_post_refresh_inflight ~approval_action_inflight async_messages;
+        ~board_post_refresh_inflight async_messages;
       (* Check for input *)
       let key = read_key () in
+      (match state.view, key with
+       | Approvals, Some ("y" | "Y" | "n" | "N") -> ()
+       | Approvals, Some _ -> state.pending_approval_action <- None
+       | _ -> ());
       (match key with
        | Some k when state.view = Keepers Keeper_message ->
            let _handled = handle_message_key state base_path k in
@@ -546,28 +622,20 @@ let main () =
        | Some "y" | Some "Y" ->
            (match state.view with
             | Approvals ->
-                (match state.overview with
-                 | None -> ()
-                 | Some o ->
-                     (match List.nth_opt o.ov_pending_confirms state.approval_cursor with
-                      | Some a ->
-                          handle_approval_decision state a Confirm
-                            ~action_inflight:approval_action_inflight
-                            ~mailbox:async_messages
-                      | None -> ()))
+                (match List.nth_opt (approval_items state) state.approval_cursor with
+                 | Some a ->
+                     handle_approval_decision state a Confirm
+                       ~mailbox:async_messages
+                 | None -> ())
             | _ -> ())
        | Some "n" | Some "N" ->
            (match state.view with
             | Approvals ->
-                (match state.overview with
-                 | None -> ()
-                 | Some o ->
-                     (match List.nth_opt o.ov_pending_confirms state.approval_cursor with
-                      | Some a ->
-                          handle_approval_decision state a Deny
-                            ~action_inflight:approval_action_inflight
-                            ~mailbox:async_messages
-                      | None -> ()))
+                (match List.nth_opt (approval_items state) state.approval_cursor with
+                 | Some a ->
+                     handle_approval_decision state a Deny
+                       ~mailbox:async_messages
+                 | None -> ())
             | _ -> ())
        | Some "r" | Some "R" ->
            state.pending_approval_action <- None;
@@ -575,7 +643,8 @@ let main () =
            let host = Env_config_core.masc_host () in
            let port = state.port in
            start_http_refresh state ~host ~port
-             ~refresh_inflight:http_refresh_inflight ~mailbox:async_messages;
+             ~refresh_inflight:http_refresh_inflight
+             ~mailbox:async_messages;
            (* Also reload logs / board / planning detail if viewing them *)
            (match state.view with
             | Keepers Keeper_logs ->
@@ -608,7 +677,9 @@ let main () =
            (match state.view with
             | Overview -> state.view <- Keepers Keeper_list
             | Keepers _ -> state.view <- Approvals
-            | Approvals -> state.view <- Board
+            | Approvals ->
+                state.pending_approval_action <- None;
+                state.view <- Board
             | Board -> state.view <- Planning
             | Planning -> state.view <- Overview)
        | Some "esc" ->
@@ -651,7 +722,7 @@ let main () =
             | Keepers Keeper_logs ->
                 state.log_scroll <- state.log_scroll + 1
             | Approvals ->
-                let count = match state.overview with None -> 0 | Some o -> List.length o.ov_pending_confirms in
+                let count = List.length (approval_items state) in
                 if state.approval_cursor < count - 1 then begin
                   state.pending_approval_action <- None;
                   state.approval_cursor <- state.approval_cursor + 1
@@ -778,7 +849,7 @@ let main () =
 
       Eio.Fiber.yield ();
       drain_async_messages state ~http_refresh_inflight
-        ~board_post_refresh_inflight ~approval_action_inflight async_messages;
+        ~board_post_refresh_inflight async_messages;
 
       (* Periodic refresh *)
       let now = Unix.gettimeofday () in
@@ -788,7 +859,8 @@ let main () =
         let host = Env_config_core.masc_host () in
         let port = state.port in
         start_http_refresh state ~host ~port
-          ~refresh_inflight:http_refresh_inflight ~mailbox:async_messages;
+          ~refresh_inflight:http_refresh_inflight
+          ~mailbox:async_messages;
         (* Also refresh logs / board / planning detail if viewing them *)
         (match state.view with
          | Keepers Keeper_logs ->

--- a/bin/masc_tui.ml
+++ b/bin/masc_tui.ml
@@ -828,6 +828,7 @@ let run_with_eio_context f =
   Eio.Switch.run @@ fun sw ->
   Eio_guard.enable ();
   Eio.Switch.on_release sw Eio_guard.disable;
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   Eio_context.set_env env;
   Eio_context.set_switch sw;
   Eio_context.set_net (Eio.Stdenv.net env);

--- a/bin/masc_tui_ansi.ml
+++ b/bin/masc_tui_ansi.ml
@@ -99,10 +99,12 @@ let status_color status =
 (** Task status icon *)
 let task_status_icon status =
   match status with
-  | "done" | "completed" -> "\xe2\x97\x8f"  (* filled circle *)
-  | "in_progress" | "claimed" -> "\xe2\x97\x90"  (* half circle *)
-  | "pending" | "todo" -> "\xe2\x97\x8b"  (* empty circle *)
-  | _ -> "\xe2\x97\x8b"
+  | Masc_domain.Done _ -> "\xe2\x97\x8f"  (* filled circle *)
+  | Masc_domain.Claimed _
+  | Masc_domain.InProgress _
+  | Masc_domain.AwaitingVerification _ -> "\xe2\x97\x90"  (* half circle *)
+  | Masc_domain.Todo -> "\xe2\x97\x8b"  (* empty circle *)
+  | Masc_domain.Cancelled _ -> "\xc3\x97"
 
 (** Priority indicator *)
 let priority_indicator p =
@@ -119,21 +121,6 @@ let soul_color profile =
   | "balanced" -> Ansi.cyan
   | "creative" -> Ansi.yellow
   | _ -> Ansi.white
-
-(** Shorten model string for display *)
-let short_model s =
-  (* Extract the part after the last colon, or last slash, keeping it short *)
-  let s = match String.index_opt s ':' with
-    | Some i -> String.sub s (i + 1) (String.length s - i - 1)
-    | None -> s
-  in
-  if String.length s > 24 then String.sub s 0 21 ^ "..."
-  else s
-
-(** Format a boolean as on/off indicator *)
-let bool_indicator b =
-  if b then Ansi.green ^ "on" ^ Ansi.reset
-  else Ansi.gray ^ "off" ^ Ansi.reset
 
 (** Format a timestamp for display (show date portion or relative) *)
 let short_ts s =

--- a/bin/masc_tui_http.ml
+++ b/bin/masc_tui_http.ml
@@ -95,14 +95,28 @@ let post_raw_json ~(host : string) ~(port : int) ~(path : string) ~(body : strin
 let fetch_dashboard_briefing ~(host : string) ~(port : int) : (Yojson.Safe.t, string) result =
   get_json ~host ~port ~path:"/api/v1/dashboard/briefing"
 
+(** Fetch the actor-scoped operator summary that owns pending confirmations. *)
+let fetch_operator_snapshot ~(host : string) ~(port : int) :
+    (Yojson.Safe.t, string) result =
+  get_json ~host ~port
+    ~path:"/api/v1/operator?view=summary&include_messages=0&include_keepers=0"
+
 (** POST /api/v1/operator/confirm to approve/deny a pending confirmation. *)
-let operator_confirm_body ~(token : string) ~(decision : string) =
+let operator_confirm_body ~(token : string)
+    ~(decision : Masc_tui_operator_projection.approval_decision) =
+  let decision = Masc_tui_operator_projection.approval_decision_wire decision in
   Yojson.Safe.to_string
     (`Assoc [ ("confirm_token", `String token); ("decision", `String decision) ])
 
-let post_operator_confirm ~(host : string) ~(port : int) ~(token : string) ~(decision : string) : (Yojson.Safe.t, string) result =
+let post_operator_confirm ~(host : string) ~(port : int) ~(token : string)
+    ~(decision : Masc_tui_operator_projection.approval_decision) :
+    (Masc_tui_operator_projection.confirm_outcome, string) result =
   let body = operator_confirm_body ~token ~decision in
-  post_json ~host ~port ~path:"/api/v1/operator/confirm" ~body
+  match post_json ~host ~port ~path:"/api/v1/operator/confirm" ~body with
+  | Error _ as error -> error
+  | Ok json ->
+      Masc_tui_operator_projection.decode_confirm_response
+        ~expected_token:token ~expected_decision:decision json
 
 (** Fetch /api/v1/board (post list). *)
 let fetch_board ~(host : string) ~(port : int) : (Yojson.Safe.t, string) result =

--- a/bin/masc_tui_loader.ml
+++ b/bin/masc_tui_loader.ml
@@ -1,5 +1,9 @@
 (** TUI data loading functions — split from masc_tui.ml (#3808) *)
 
+module Keeper_meta_store = Masc.Keeper_meta_store
+module Keeper_types_support = Masc.Keeper_types_support
+module Keeper_types_profile = Masc.Keeper_types_profile
+
 open Masc_tui_types
 open Tui_decode
 open Masc_tui_http
@@ -7,41 +11,64 @@ open Masc_tui_http
 let report path err =
   Printf.eprintf "[masc-tui] decode failed for %s: %s\n%!" path err
 
-(** Load keepers from .masc/keepers/ *)
-let load_keepers (base_path : string) : keeper list =
-  let keepers_dir = Filename.concat (Filename.concat base_path Common.masc_dirname) Common.keepers_runtime_dirname in
-  if Sys.file_exists keepers_dir && Sys.is_directory keepers_dir then
-    Sys.readdir keepers_dir
-    |> Array.to_list
-    |> List.filter (fun f ->
-         Filename.check_suffix f ".json"
-         && not (String.contains f '.'))  (* This won't work, use different filter *)
-    |> (fun _ ->
-         (* Re-filter: only files that are exactly <name>.json, not <name>.reward-model.json *)
-         Sys.readdir keepers_dir
-         |> Array.to_list
-         |> List.filter (fun f ->
-              Filename.check_suffix f ".json"
-              && (let base = Filename.chop_suffix f ".json" in
-                  not (String.contains base '.'))))
-    |> List.filter_map (fun f ->
-         try
-           let path = Filename.concat keepers_dir f in
-           let json = Yojson.Safe.from_file path in
-           match Tui_decode.decode_keeper ~filename:f json with
-           | Ok keeper -> Some keeper
-           | Error err ->
-               report path err;
-               None
-         with Yojson.Json_error err ->
-           report (Filename.concat keepers_dir f) ("invalid JSON: " ^ err);
-           None
-         | Sys_error err ->
-           report (Filename.concat keepers_dir f) err;
-           None
-       )
-    |> List.sort (fun a b -> String.compare a.k_name b.k_name)
-  else []
+let summarize_errors label errors =
+  match List.rev errors with
+  | [] -> None
+  | first :: rest ->
+      let suffix =
+        match rest with
+        | [] -> ""
+        | _ -> Printf.sprintf " (+%d more)" (List.length rest)
+      in
+      Some (Printf.sprintf "%s: %s%s" label first suffix)
+
+(** Load keepers through the canonical metadata classifier and typed store.
+    The classifier preserves valid dotted names and excludes sidecars. *)
+let load_keepers (base_path : string) : keeper list * string option =
+  let config = Workspace_core.default_config base_path in
+  match Keeper_meta_store.persisted_keeper_names_result config with
+  | Error err ->
+      report (Keeper_types_profile.keeper_dir config) err;
+      [], Some ("keeper metadata unavailable: " ^ err)
+  | Ok names ->
+      let keepers, errors =
+        List.fold_left
+          (fun (keepers, errors) name ->
+             let path = Keeper_types_profile.keeper_meta_path config name in
+             match Keeper_meta_store.read_meta config name with
+             | Ok (Some meta) ->
+                 Tui_decode.keeper_of_meta meta :: keepers, errors
+             | Ok None ->
+                 let err = "metadata disappeared during refresh" in
+                 report path err;
+                 keepers, (Printf.sprintf "%s: %s" name err :: errors)
+             | Error err ->
+                 report path err;
+                 keepers, (Printf.sprintf "%s: %s" name err :: errors))
+          ([], []) names
+      in
+      ( List.sort (fun a b -> String.compare a.k_name b.k_name) keepers
+      , summarize_errors "keeper metadata read failed" errors )
+
+(** Load active tasks from the canonical workspace backlog. Terminal tasks
+    remain available in Planning rollups but do not occupy the Overview list. *)
+let load_active_tasks (base_path : string) : task list * string option =
+  let config = Workspace_core.default_config base_path in
+  let path = Workspace_backlog.backlog_path config in
+  match Workspace_backlog.read_backlog_observation_with_source_r config with
+  | Error err ->
+      report path err;
+      [], Some ("task backlog unavailable: " ^ err)
+  | Ok observation ->
+      let recovery_error =
+        match observation.recovered_from with
+        | None -> None
+        | Some recovery ->
+            report path recovery.primary_error;
+            Some ("task backlog recovered from backup: " ^ recovery.primary_error)
+      in
+      ( Tui_decode.active_tasks_of_domain observation.observed_backlog.tasks
+      , recovery_error )
 
 (** Read the last N lines from a file (tail) *)
 let read_last_lines path n =
@@ -72,11 +99,8 @@ let parse_log_entry (line : string) : log_entry option =
 
 (** Find the most recent metrics file for a keeper *)
 let find_metrics_files (base_path : string) (keeper_name : string) : string list =
-  let metrics_dir = Filename.concat
-    (Filename.concat
-       (Filename.concat base_path Common.masc_dirname)
-       "keepers")
-    (Filename.concat keeper_name "metrics") in
+  let config = Workspace_core.default_config base_path in
+  let metrics_dir = Keeper_types_support.keeper_metrics_dir config keeper_name in
   if not (Sys.file_exists metrics_dir && Sys.is_directory metrics_dir) then []
   else begin
     (* List year-month directories, pick the most recent *)
@@ -178,35 +202,15 @@ let load_from_masc_dir (state : state) (base_path : string) =
     else []
   );
 
-  (* Load tasks *)
-  let tasks_dir = Filename.concat masc_dir "tasks" in
-  state.tasks <- (
-    if Sys.file_exists tasks_dir && Sys.is_directory tasks_dir then
-      Sys.readdir tasks_dir
-      |> Array.to_list
-      |> List.filter (fun f -> Filename.check_suffix f ".json")
-      |> List.filter_map (fun f ->
-           try
-             let path = Filename.concat tasks_dir f in
-             let json = Yojson.Safe.from_file path in
-             match Tui_decode.decode_task json with
-             | Ok task -> Some task
-             | Error err ->
-                 report path err;
-                 None
-           with Yojson.Json_error err ->
-             report (Filename.concat tasks_dir f) ("invalid JSON: " ^ err);
-             None
-           | Sys_error err ->
-             report (Filename.concat tasks_dir f) err;
-             None
-         )
-      |> List.sort (fun a b -> compare a.priority b.priority)
-    else []
-  );
+  (* Load tasks from their single durable source. *)
+  let tasks, tasks_error = load_active_tasks base_path in
+  state.tasks <- tasks;
+  state.tasks_error <- tasks_error;
 
   (* Load keepers *)
-  state.keepers <- load_keepers base_path;
+  let keepers, keepers_error = load_keepers base_path in
+  state.keepers <- keepers;
+  state.keepers_error <- keepers_error;
 
   (* Clamp cursor if keepers changed *)
   if state.keeper_cursor >= List.length state.keepers then
@@ -442,75 +446,9 @@ let load_overview ~(host : string) ~(port : int) :
           ov_generated_at;
         }
 
-let decode_planning_goal json =
-  let* pg_id = required_string_field json "id" in
-  let* pg_title = required_string_field json "title" in
-  let* raw_status = required_string_field json "status" in
-  let* pg_status =
-    match String.lowercase_ascii raw_status with
-    | "active" -> Ok Planning_goal_active
-    | "paused" -> Ok Planning_goal_paused
-    | "done" -> Ok Planning_goal_done
-    | "dropped" -> Ok Planning_goal_dropped
-    | other ->
-        Error
-          (Printf.sprintf
-             "unknown planning goal status %S (normalized %S)"
-             raw_status
-             other)
-  in
-  let* pg_phase = required_string_field json "phase" in
-  let* pg_priority = required_int_field json "priority" in
-  let* pg_due_date = optional_string_field json "due_date" in
-  let* pg_metric = optional_string_field json "metric" in
-  let* pg_target_value = optional_string_field json "target_value" in
-  Ok
-    {
-      pg_id;
-      pg_title;
-      pg_status;
-      pg_phase;
-      pg_priority;
-      pg_due_date;
-      pg_metric;
-      pg_target_value;
-    }
-
-let decode_planning_goals json_list =
-  decode_list "goals" decode_planning_goal json_list
-
-let decode_planning_rollup json =
-  let* pr_active = required_int_field json "active_count" in
-  let* pr_paused = required_int_field json "paused_count" in
-  let* pr_done = required_int_field json "done_count" in
-  let* pr_dropped = required_int_field json "dropped_count" in
-  Ok { pr_active; pr_paused; pr_done; pr_dropped }
-
-let decode_planning_backlog json =
-  let* pb_todo = required_int_field json "todo" in
-  let* pb_claimed = required_int_field json "claimed" in
-  let* pb_running = required_int_any_field json [ "in_progress"; "running" ] in
-  let* pb_done = required_int_field json "done" in
-  let* pb_cancelled = required_int_field json "cancelled" in
-  Ok { pb_todo; pb_claimed; pb_running; pb_done; pb_cancelled }
-
 (** Load planning snapshot from /api/v1/dashboard/planning *)
 let load_planning ~(host : string) ~(port : int) :
     (planning_snapshot, string) result =
   match fetch_dashboard_planning ~host ~port with
   | Error err -> Error ("planning load failed: " ^ err)
-  | Ok json ->
-      let* goals_json = required_list_field json "goals" in
-      let* goals = decode_planning_goals goals_json in
-      let* rollup_json = required_object_field json "rollup" in
-      let* rollup = decode_planning_rollup rollup_json in
-      let* backlog_json = required_object_field json "task_backlog" in
-      let* backlog = decode_planning_backlog backlog_json in
-      let* generated_at = required_string_field json "generated_at" in
-      Ok
-        {
-          pl_goals = goals;
-          pl_rollup = rollup;
-          pl_backlog = backlog;
-          pl_generated_at = generated_at;
-        }
+  | Ok json -> Tui_decode.decode_planning_snapshot json

--- a/bin/masc_tui_loader.ml
+++ b/bin/masc_tui_loader.ml
@@ -279,31 +279,6 @@ let decode_attention_item json =
 let decode_attention_items json_list =
   decode_list "attention_items" decode_attention_item json_list
 
-let decode_approval_item json =
-  let* ap_token = required_string_field json "confirm_token" in
-  let* ap_actor = required_string_field json "actor" in
-  let* ap_action_type = required_string_field json "action_type" in
-  let* ap_target_type = required_string_field json "target_type" in
-  let* ap_target_id = optional_string_field json "target_id" in
-  let* ap_delegated_tool = required_string_field json "delegated_tool" in
-  let ap_summary =
-    Printf.sprintf "%s on %s (%s)" ap_action_type ap_target_type
-      ap_delegated_tool
-  in
-  Ok
-    {
-      ap_token;
-      ap_actor;
-      ap_action_type;
-      ap_target_type;
-      ap_target_id;
-      ap_delegated_tool;
-      ap_summary;
-    }
-
-let decode_approval_items json_list =
-  decode_list "pending_confirms" decode_approval_item json_list
-
 let decode_board_post ?(require_body = false) json =
   let* bp_id = required_string_field json "id" in
   let* bp_author = required_string_field json "author" in
@@ -367,6 +342,14 @@ let load_board_post ~(host : string) ~(port : int) ~(post_id : string) :
       let* comments = decode_board_comments comments_json in
       Ok (post, comments)
 
+(** Load the actor-scoped pending confirmation envelope from the operator
+    surface. Missing or malformed envelopes remain explicit errors. *)
+let load_approvals ~(host : string) ~(port : int) :
+    (approval_snapshot, string) result =
+  match fetch_operator_snapshot ~host ~port with
+  | Error err -> Error ("approvals load failed: " ^ err)
+  | Ok json -> Masc_tui_operator_projection.decode_snapshot json
+
 (** Load overview snapshot from /api/v1/dashboard/briefing *)
 let load_overview ~(host : string) ~(port : int) :
     (overview_snapshot, string) result =
@@ -386,14 +369,6 @@ let load_overview ~(host : string) ~(port : int) :
       let* attention_items =
         let* items = optional_list_field json "attention_items" in
         decode_attention_items items
-      in
-      let* pending_confirms =
-        let* operator_targets = optional_object_field json "operator_targets" in
-        match operator_targets with
-        | None -> Ok []
-        | Some operator_targets ->
-            let* items = optional_list_field operator_targets "pending_confirms" in
-            decode_approval_items items
       in
       let* agent_briefs = optional_list_field json "agent_briefs" in
       let* top_attention =
@@ -419,15 +394,6 @@ let load_overview ~(host : string) ~(port : int) :
       let* ov_active_agents =
         int_field_or summary "active_agents" ~default:(List.length agent_briefs)
       in
-      let* ov_pending_approvals =
-        match command_focus with
-        | Some command_focus ->
-            int_field_or command_focus "pending_approvals"
-              ~default:(List.length pending_confirms)
-        | None ->
-            int_field_or summary "pending_approvals"
-              ~default:(List.length pending_confirms)
-      in
       let* ov_incident_count =
         int_field_or summary "incident_count" ~default:(List.length incidents)
       in
@@ -438,11 +404,9 @@ let load_overview ~(host : string) ~(port : int) :
           ov_cluster;
           ov_project;
           ov_active_agents;
-          ov_pending_approvals;
           ov_incident_count;
           ov_attention_items = incidents @ attention_queue @ attention_items;
           ov_top_attention = top_attention;
-          ov_pending_confirms = pending_confirms;
           ov_generated_at;
         }
 

--- a/bin/masc_tui_operator_projection.ml
+++ b/bin/masc_tui_operator_projection.ml
@@ -1,0 +1,323 @@
+(** Exact TUI projection for the actor-scoped operator confirmation surface.
+
+    This module lives above [masc.operator] so it can reuse the canonical
+    pending-confirm parser without introducing a dependency cycle into the
+    core [Masc.Tui_decode] library. *)
+
+type approval_item = {
+  ap_token : string;
+  ap_trace_id : string;
+  ap_actor : string;
+  ap_action_type : string;
+  ap_target_type : string;
+  ap_target_id : string option;
+  ap_payload : Yojson.Safe.t;
+  ap_delegated_tool : string;
+  ap_created_at : string;
+  ap_expires_at : string option;
+  ap_summary : string;
+}
+
+type approval_snapshot = {
+  aps_items : approval_item list;
+  aps_actor_filter : string option;
+  aps_filter_active : bool;
+  aps_visible_count : int;
+  aps_total_count : int;
+  aps_hidden_count : int;
+}
+
+type approval_decision =
+  | Confirm
+  | Deny
+
+type pending_approval_action = {
+  paa_token : string;
+  paa_decision : approval_decision;
+}
+
+type approval_gate_transition =
+  | Gate_blocked_inflight
+  | Gate_arm of pending_approval_action
+  | Gate_submit
+
+type confirm_outcome =
+  | Completed of Yojson.Safe.t
+  | Deferred of Yojson.Safe.t
+  | Execution_failed of Yojson.Safe.t * string
+
+module Flow = struct
+  type generation = int
+
+  type t = {
+    latest : generation;
+    action : generation option;
+  }
+
+  let initial = { latest = 0; action = None }
+  let action_inflight state = Option.is_some state.action
+
+  let reserve_refresh state =
+    match state.action with
+    | Some _ -> state, None
+    | None ->
+        let generation = state.latest + 1 in
+        { latest = generation; action = None }, Some generation
+
+  let begin_action state =
+    match state.action with
+    | Some _ -> Error `Already_inflight
+    | None ->
+        let generation = state.latest + 1 in
+        Ok ({ latest = generation; action = Some generation }, generation)
+
+  let finish_action state generation =
+    match state.action with
+    | Some current when current = generation ->
+        { state with action = None }, true
+    | Some _ | None -> state, false
+
+  let is_current state generation = state.latest = generation
+end
+
+let ( let* ) = Result.bind
+
+let member key json =
+  match Json_util.assoc_member_opt key json with
+  | Some value -> value
+  | None -> `Null
+
+let approval_of_pending_confirm
+    (entry : Operator_pending_confirm.pending_confirm) =
+  {
+    ap_token = entry.confirm_token;
+    ap_trace_id = entry.trace_id;
+    ap_actor = entry.actor;
+    ap_action_type = entry.action_type;
+    ap_target_type = entry.target_type;
+    ap_target_id = entry.target_id;
+    ap_payload = entry.payload;
+    ap_delegated_tool = entry.delegated_tool;
+    ap_created_at = entry.created_at;
+    ap_expires_at = entry.expires_at;
+    ap_summary =
+      Printf.sprintf "%s on %s (%s)" entry.action_type entry.target_type
+        entry.delegated_tool;
+  }
+
+let approval_decision_wire = function
+  | Confirm -> "confirm"
+  | Deny -> "deny"
+
+let approval_gate_transition ~inflight ~pending ~token ~decision =
+  if inflight then Gate_blocked_inflight
+  else
+    match pending with
+    | Some pending
+      when String.equal pending.paa_token token
+           && pending.paa_decision = decision ->
+        Gate_submit
+    | Some _ | None -> Gate_arm { paa_token = token; paa_decision = decision }
+
+let decode_string_list label values =
+  Masc.Tui_decode.decode_list label
+    (function
+      | `String value when String.trim value <> "" -> Ok ()
+      | `String _ -> Error "must not contain blank strings"
+      | other ->
+          Error
+            (Printf.sprintf "must contain strings (received %s)"
+               (Json_util.kind_name other)))
+    values
+
+let decode_object_list label values =
+  Masc.Tui_decode.decode_list label
+    (function
+      | `Assoc _ -> Ok ()
+      | other ->
+          Error
+            (Printf.sprintf "must contain objects (received %s)"
+               (Json_util.kind_name other)))
+    values
+
+let duplicate_token items =
+  let module Tokens = Set.Make (String) in
+  let rec loop seen = function
+    | [] -> None
+    | item :: rest ->
+        if Tokens.mem item.ap_token seen then Some item.ap_token
+        else loop (Tokens.add item.ap_token seen) rest
+  in
+  loop Tokens.empty items
+
+let decode_snapshot json =
+  let* envelope =
+    Masc.Tui_decode.required_object_field json "pending_confirm_envelope"
+  in
+  let* items = Masc.Tui_decode.required_list_field envelope "items" in
+  let* aps_items =
+    Masc.Tui_decode.decode_list "pending_confirm_envelope.items"
+      (fun item ->
+        let* pending = Operator_pending_confirm.pending_confirm_of_yojson item in
+        Ok (approval_of_pending_confirm pending))
+      items
+  in
+  let* summary = Masc.Tui_decode.required_object_field envelope "summary" in
+  let* aps_actor_filter =
+    Masc.Tui_decode.optional_string_field summary "actor_filter"
+  in
+  let* aps_filter_active =
+    match member "filter_active" summary with
+    | `Bool value -> Ok value
+    | `Null -> Error "missing required field 'filter_active'"
+    | other ->
+        Error
+          (Printf.sprintf
+             "field 'filter_active' must be a bool (received %s)"
+             (Json_util.kind_name other))
+  in
+  let* aps_visible_count =
+    Masc.Tui_decode.required_int_field summary "visible_count"
+  in
+  let* aps_total_count =
+    Masc.Tui_decode.required_int_field summary "total_count"
+  in
+  let* aps_hidden_count =
+    Masc.Tui_decode.required_int_field summary "hidden_count"
+  in
+  let* hidden_actors =
+    Masc.Tui_decode.required_list_field summary "hidden_actors"
+  in
+  let* _ = decode_string_list "pending_confirm_envelope.summary.hidden_actors" hidden_actors in
+  let* confirm_required_actions =
+    Masc.Tui_decode.required_list_field summary "confirm_required_actions"
+  in
+  let* _ =
+    decode_object_list
+      "pending_confirm_envelope.summary.confirm_required_actions"
+      confirm_required_actions
+  in
+  let actual_visible = List.length aps_items in
+  let duplicate_token = duplicate_token aps_items in
+  let actor_filter = Option.bind aps_actor_filter (fun actor ->
+      let trimmed = String.trim actor in
+      if trimmed = "" || not (String.equal trimmed actor) then None
+      else Some trimmed)
+  in
+  if not aps_filter_active then
+    Error "pending confirmation snapshot must be actor-scoped"
+  else if Option.is_none actor_filter then
+    Error "pending confirmation actor_filter must be a non-blank string"
+  else if aps_visible_count < 0 || aps_total_count < 0 || aps_hidden_count < 0 then
+    Error "pending confirmation counts must be nonnegative"
+  else if
+    not
+      (List.for_all
+         (fun item -> Option.equal String.equal actor_filter (Some item.ap_actor))
+         aps_items)
+  then
+    Error "pending confirmation item actor does not match actor_filter"
+  else
+    match duplicate_token with
+    | Some token ->
+        Error (Printf.sprintf "duplicate pending confirmation token %S" token)
+    | None when aps_visible_count <> actual_visible ->
+        Error
+          (Printf.sprintf
+             "pending confirmation visible_count mismatch: summary=%d items=%d"
+             aps_visible_count actual_visible)
+    | None when aps_total_count <> aps_visible_count + aps_hidden_count ->
+        Error
+          (Printf.sprintf
+             "pending confirmation count mismatch: total=%d visible=%d hidden=%d"
+             aps_total_count aps_visible_count aps_hidden_count)
+    | None ->
+        Ok
+          {
+            aps_items;
+            aps_actor_filter = actor_filter;
+            aps_filter_active;
+            aps_visible_count;
+            aps_total_count;
+            aps_hidden_count;
+          }
+
+let bounded_json json =
+  let rendered = Yojson.Safe.to_string json in
+  if String.length rendered <= 240 then rendered
+  else String.sub rendered 0 240 ^ "..."
+
+let required_nonempty_string json field =
+  let* value = Masc.Tui_decode.required_string_field json field in
+  if String.trim value = "" then
+    Error (Printf.sprintf "field '%s' must not be blank" field)
+  else Ok value
+
+let has_field json field =
+  match json with
+  | `Assoc fields -> List.mem_assoc field fields
+  | _ -> false
+
+let failure_detail json =
+  match member "message" json with
+  | `String message when String.trim message <> "" -> message
+  | _ -> (
+      match member "result" json with
+      | `Null -> bounded_json json
+      | result -> bounded_json result)
+
+let decode_confirm_envelope ~expected_token ~expected_decision ~status json =
+  let expected_decision_wire = approval_decision_wire expected_decision in
+  let* trace_id = required_nonempty_string json "trace_id" in
+  let* decision = required_nonempty_string json "decision" in
+  let* tool_name = required_nonempty_string json "tool_name" in
+  let* executed_action =
+    Masc.Tui_decode.required_object_field json "executed_action"
+  in
+  let* executed_action =
+    Operator_pending_confirm.pending_confirm_of_yojson executed_action
+  in
+  if not (String.equal decision expected_decision_wire) then
+    Error
+      (Printf.sprintf
+         "operator action decision mismatch: expected %S, received %S"
+         expected_decision_wire decision)
+  else if not (String.equal executed_action.confirm_token expected_token) then
+    Error "operator action confirm_token does not match the submitted token"
+  else if not (String.equal executed_action.trace_id trace_id) then
+    Error "operator action trace_id does not match executed_action"
+  else if not (String.equal executed_action.delegated_tool tool_name) then
+    Error "operator action tool_name does not match executed_action"
+  else
+    match expected_decision with
+    | Deny ->
+        if not (String.equal status "ok") then
+          Error "denied operator action must complete with status 'ok'"
+        else
+          let* result_status = required_nonempty_string json "result_status" in
+          if String.equal result_status "not_executed" then Ok (Completed json)
+          else
+            Error
+              (Printf.sprintf
+                 "denied operator action must have result_status 'not_executed' (received %S)"
+                 result_status)
+    | Confirm ->
+        if not (has_field json "result") then
+          Error "confirmed operator action response missing result"
+        else if String.equal status "deferred" then Ok (Deferred json)
+        else if String.equal status "error" then
+          Ok (Execution_failed (json, failure_detail json))
+        else Ok (Completed json)
+
+let decode_confirm_response ~expected_token ~expected_decision json =
+  match member "status" json with
+  | `String ("ok" | "deferred" | "error" as status) ->
+      decode_confirm_envelope ~expected_token ~expected_decision ~status json
+  | `String status ->
+      Error (Printf.sprintf "unknown operator action status %S" status)
+  | `Null -> Error "operator action response missing status"
+  | other ->
+      Error
+        (Printf.sprintf
+           "operator action status must be a string (received %s)"
+           (Json_util.kind_name other))

--- a/bin/masc_tui_operator_projection.mli
+++ b/bin/masc_tui_operator_projection.mli
@@ -1,0 +1,67 @@
+type approval_item = {
+  ap_token : string;
+  ap_trace_id : string;
+  ap_actor : string;
+  ap_action_type : string;
+  ap_target_type : string;
+  ap_target_id : string option;
+  ap_payload : Yojson.Safe.t;
+  ap_delegated_tool : string;
+  ap_created_at : string;
+  ap_expires_at : string option;
+  ap_summary : string;
+}
+
+type approval_snapshot = {
+  aps_items : approval_item list;
+  aps_actor_filter : string option;
+  aps_filter_active : bool;
+  aps_visible_count : int;
+  aps_total_count : int;
+  aps_hidden_count : int;
+}
+
+type approval_decision =
+  | Confirm
+  | Deny
+
+type pending_approval_action = {
+  paa_token : string;
+  paa_decision : approval_decision;
+}
+
+type approval_gate_transition =
+  | Gate_blocked_inflight
+  | Gate_arm of pending_approval_action
+  | Gate_submit
+
+type confirm_outcome =
+  | Completed of Yojson.Safe.t
+  | Deferred of Yojson.Safe.t
+  | Execution_failed of Yojson.Safe.t * string
+
+module Flow : sig
+  type generation = private int
+  type t
+
+  val initial : t
+  val action_inflight : t -> bool
+  val reserve_refresh : t -> t * generation option
+  val begin_action : t -> (t * generation, [ `Already_inflight ]) result
+  val finish_action : t -> generation -> t * bool
+  val is_current : t -> generation -> bool
+end
+
+val decode_snapshot : Yojson.Safe.t -> (approval_snapshot, string) result
+val approval_decision_wire : approval_decision -> string
+val approval_gate_transition :
+  inflight:bool ->
+  pending:pending_approval_action option ->
+  token:string ->
+  decision:approval_decision ->
+  approval_gate_transition
+val decode_confirm_response :
+  expected_token:string ->
+  expected_decision:approval_decision ->
+  Yojson.Safe.t ->
+  (confirm_outcome, string) result

--- a/bin/masc_tui_render.ml
+++ b/bin/masc_tui_render.ml
@@ -210,9 +210,14 @@ let render_overview (state : state) =
     | Some o, None ->
         let health_color = workspace_health_color o.ov_workspace_health in
         let health_label = workspace_health_label o.ov_workspace_health in
-        Printf.sprintf "  Health: %s%s%s  Agents: %d  Approvals: %d  Incidents: %d"
+        let approval_count =
+          match state.approval_snapshot, state.approvals_error with
+          | Some snapshot, None -> string_of_int snapshot.aps_visible_count
+          | None, _ | Some _, Some _ -> "?"
+        in
+        Printf.sprintf "  Health: %s%s%s  Agents: %d  Approvals: %s  Incidents: %d"
           health_color health_label Ansi.reset
-          o.ov_active_agents o.ov_pending_approvals o.ov_incident_count
+          o.ov_active_agents approval_count o.ov_incident_count
   in
   box_line buf cols summary_line;
 
@@ -320,37 +325,55 @@ let render_approvals (state : state) =
   let now = Unix.localtime (Unix.gettimeofday ()) in
   let timestamp = Printf.sprintf "%02d:%02d:%02d"
     now.Unix.tm_hour now.Unix.tm_min now.Unix.tm_sec in
-  let approvals =
-    match state.overview with
-    | None -> []
-    | Some o -> o.ov_pending_confirms
+  let approvals = approval_items state in
+  let scope, visible_count, total_count, hidden_count =
+    match state.approval_snapshot with
+    | None -> "-", "?", "?", "?"
+    | Some snapshot ->
+        ( (if snapshot.aps_filter_active then
+             Option.value ~default:"?" snapshot.aps_actor_filter
+           else "all")
+        , string_of_int snapshot.aps_visible_count
+        , string_of_int snapshot.aps_total_count
+        , string_of_int snapshot.aps_hidden_count )
   in
   let count = List.length approvals in
-  let header = Printf.sprintf " MASC Approvals (%d)  %s  %s"
-    count timestamp
-    (connection_badge state.connection_status) in
+  let action_inflight =
+    Masc_tui_operator_projection.Flow.action_inflight state.approval_flow
+  in
+  let action_badge = if action_inflight then "  [submitting]" else "" in
+  let header =
+    Printf.sprintf
+      " MASC Approvals (%s/%s, hidden %s, actor %s)  %s  %s%s"
+      visible_count total_count hidden_count scope timestamp
+      (connection_badge state.connection_status) action_badge
+  in
 
   box_top buf cols;
   box_line buf cols header;
   box_divider buf cols;
 
   if count = 0 then begin
-    (match state.overview_error with
-     | Some err ->
+    (match state.approval_snapshot, state.approvals_error with
+     | _, Some err ->
          box_line buf cols
            (Ansi.red ^ "  (data unreliable: "
            ^ fit_width err (cols - 24)
            ^ ")" ^ Ansi.reset)
-     | None ->
+     | None, None ->
+         box_line buf cols
+           (Ansi.dim ^ "  (no approval data — press 'r' to refresh)"
+           ^ Ansi.reset)
+     | Some _, None ->
          box_line buf cols
            (Ansi.dim ^ "  (no pending approvals)" ^ Ansi.reset));
-    for _ = 1 to rows - 8 do
+    for _ = 1 to rows - 10 do
       box_empty buf cols
     done
   end else begin
-    let content_height = rows - 8 in
+    let content_height = max 0 (rows - 10) in
     let scroll_offset =
-      if state.approval_cursor >= content_height then
+      if content_height > 0 && state.approval_cursor >= content_height then
         state.approval_cursor - content_height + 1
       else 0
     in
@@ -384,7 +407,11 @@ let render_approvals (state : state) =
   let detail_line =
     if state.approval_cursor < count then
       let a = List.nth approvals state.approval_cursor in
-      match state.pending_approval_action with
+      if action_inflight then
+        Printf.sprintf "  %sApproval request in progress…%s" Ansi.yellow
+          Ansi.reset
+      else
+        match state.pending_approval_action with
       | Some { paa_token; paa_decision }
         when String.equal paa_token a.ap_token ->
           let key =
@@ -403,8 +430,25 @@ let render_approvals (state : state) =
   in
   Buffer.add_string buf (Printf.sprintf "%s\n" detail_line);
 
-  Buffer.add_string buf (Printf.sprintf "%s  j/k:move  y:confirm  n:deny  r:refresh  Tab:next  | Port: %d%s\n"
-    Ansi.dim state.port Ansi.reset);
+  let metadata_line, payload_line =
+    match List.nth_opt approvals state.approval_cursor with
+    | None -> "", ""
+    | Some approval ->
+        let expires = Option.value ~default:"-" approval.ap_expires_at in
+        let payload = Yojson.Safe.to_string approval.ap_payload in
+        ( Printf.sprintf "  %strace=%s  created=%s  expires=%s%s" Ansi.dim
+            (fit_width approval.ap_trace_id 18)
+            approval.ap_created_at expires Ansi.reset
+        , Printf.sprintf "  %spayload=%s%s" Ansi.dim
+            (fit_width payload (max 8 (cols - 12)))
+            Ansi.reset )
+  in
+  Buffer.add_string buf (Printf.sprintf "%s\n%s\n" metadata_line payload_line);
+
+  Buffer.add_string buf
+    (Printf.sprintf
+       "%s  j/k:move  y/y:confirm  n/n:deny  r:refresh  Tab:next  | Port: %d%s\n"
+       Ansi.dim state.port Ansi.reset);
 
   print_string (Buffer.contents buf);
   flush stdout

--- a/bin/masc_tui_render.ml
+++ b/bin/masc_tui_render.ml
@@ -45,6 +45,21 @@ let attention_severity_color = function
   | Attention_warning -> Ansi.yellow
   | Attention_info -> Ansi.cyan
 
+let task_line (task : task) =
+  let status = Masc_domain.task_status_to_string task.status in
+  let assignee =
+    match Masc_domain.task_assignee_of_status task.status with
+    | Some name -> Printf.sprintf " @%s" name
+    | None -> ""
+  in
+  Printf.sprintf "  %s [%s] %s (%s%s) %s"
+    (task_status_icon task.status)
+    task.id
+    task.title
+    status
+    assignee
+    (priority_indicator task.priority)
+
 (** Render the dashboard (original view) *)
 let render_dashboard (state : state) =
   let (rows, cols) = get_terminal_size () in
@@ -144,21 +159,9 @@ let render_dashboard (state : state) =
   else
     for i = 0 to task_rows - 1 do
       let t = List.nth state.tasks i in
-      let claimed_str = match t.claimed_by with
-        | Some a -> Printf.sprintf " @%s" a
-        | None -> ""
-      in
-      let task_line = Printf.sprintf "  %s [%s] %s (%s%s) %s"
-        (task_status_icon t.status)
-        t.id
-        t.title
-        t.status
-        claimed_str
-        (priority_indicator t.priority)
-      in
       Buffer.add_string buf (Printf.sprintf "%s%s%s %s %s%s%s\n"
         Ansi.gray Ansi.box_v Ansi.reset
-        (fit_width task_line (cols - 4))
+        (fit_width (task_line t) (cols - 4))
         Ansi.gray Ansi.box_v Ansi.reset)
     done;
 
@@ -281,25 +284,21 @@ let render_overview (state : state) =
     (String.make (max 0 (cols - 10)) ' ')
     Ansi.gray Ansi.box_v Ansi.reset);
 
-  let task_rows = min 5 (List.length state.tasks) in
-  if task_rows = 0 then
+  let task_capacity =
+    match state.tasks_error with
+    | None -> 5
+    | Some err ->
+        box_line buf cols
+          (Ansi.red ^ "  " ^ fit_width err (cols - 8) ^ Ansi.reset);
+        4
+  in
+  let task_rows = min task_capacity (List.length state.tasks) in
+  if task_rows = 0 && Option.is_none state.tasks_error then
     box_line buf cols (Ansi.dim ^ "  (no tasks)" ^ Ansi.reset)
   else
     for i = 0 to task_rows - 1 do
       let t = List.nth state.tasks i in
-      let claimed_str = match t.claimed_by with
-        | Some a -> Printf.sprintf " @%s" a
-        | None -> ""
-      in
-      let task_line = Printf.sprintf "  %s [%s] %s (%s%s) %s"
-        (task_status_icon t.status)
-        t.id
-        t.title
-        t.status
-        claimed_str
-        (priority_indicator t.priority)
-      in
-      box_line buf cols task_line
+      box_line buf cols (task_line t)
     done;
 
   box_bottom buf cols;
@@ -554,17 +553,15 @@ let render_board_read (state : state) (post : board_post) =
   print_string (Buffer.contents buf);
   flush stdout
 
-let planning_status_label = function
-  | Planning_goal_active -> "active"
-  | Planning_goal_paused -> "paused"
-  | Planning_goal_done -> "done"
-  | Planning_goal_dropped -> "dropped"
+let planning_phase_label phase = Goal_phase.to_string phase
 
-let planning_status_color = function
-  | Planning_goal_active -> Ansi.cyan
-  | Planning_goal_paused -> Ansi.yellow
-  | Planning_goal_done -> Ansi.green
-  | Planning_goal_dropped -> Ansi.red
+let planning_phase_color = function
+  | Goal_phase.Executing -> Ansi.cyan
+  | Goal_phase.Blocked -> Ansi.red
+  | Goal_phase.Paused -> Ansi.yellow
+  | Goal_phase.Verifying -> Ansi.magenta
+  | Goal_phase.Completed -> Ansi.green
+  | Goal_phase.Dropped -> Ansi.gray
 
 (** Render the Planning surface (list view). *)
 let render_planning_list (state : state) =
@@ -607,8 +604,11 @@ let render_planning_list (state : state) =
        done
    | Some p ->
        let rollup =
-         Printf.sprintf "  Active: %d  Paused: %d  Done: %d  Dropped: %d"
-           p.pl_rollup.pr_active p.pl_rollup.pr_paused p.pl_rollup.pr_done p.pl_rollup.pr_dropped
+         Printf.sprintf
+           "  Executing: %d  Paused/Blocked: %d  Verifying: %d  Done: %d  Dropped: %d"
+           p.pl_rollup.pr_active p.pl_rollup.pr_paused
+           p.pl_rollup.pr_verifying p.pl_rollup.pr_done
+           p.pl_rollup.pr_dropped
        in
        let backlog =
          Printf.sprintf "  Backlog: todo=%d  claimed=%d  running=%d  done=%d  cancelled=%d"
@@ -639,8 +639,8 @@ let render_planning_list (state : state) =
              let depth = planning_goal_depth p.pl_goals g in
              let indent = String.make (depth * 2) ' ' in
              let branch = if depth > 0 then "└─ " else "  " in
-             let status_color = planning_status_color g.pg_status in
-             let status_label = planning_status_label g.pg_status in
+             let status_color = planning_phase_color g.pg_phase in
+             let status_label = planning_phase_label g.pg_phase in
              let due = match g.pg_due_date with Some d -> "  " ^ d | None -> "" in
              let line =
                Printf.sprintf "%s%s%s[%s]%s P%d  %s%s"
@@ -679,8 +679,8 @@ let render_planning_detail (state : state) (goal : planning_goal) =
   Buffer.add_string buf Ansi.clear;
   Buffer.add_string buf Ansi.hide_cursor;
 
-  let status_color = planning_status_color goal.pg_status in
-  let status_label = planning_status_label goal.pg_status in
+  let status_color = planning_phase_color goal.pg_phase in
+  let status_label = planning_phase_label goal.pg_phase in
   let header = Printf.sprintf " MASC Planning  %s[%s]%s  %s"
     status_color (fit_width status_label 8) Ansi.reset
     (fit_width goal.pg_id 20)
@@ -693,7 +693,7 @@ let render_planning_detail (state : state) (goal : planning_goal) =
   box_line buf cols (Printf.sprintf "  %s%s%s"
     Ansi.bold (fit_width goal.pg_title (cols - 6)) Ansi.reset);
   box_line buf cols (Printf.sprintf "  Phase: %s  Priority: P%d"
-    (fit_width goal.pg_phase 14) goal.pg_priority);
+    (fit_width (planning_phase_label goal.pg_phase) 14) goal.pg_priority);
   (match goal.pg_due_date with
    | Some d -> box_line buf cols (Printf.sprintf "  Due: %s" d)
    | None -> box_empty buf cols);
@@ -748,8 +748,8 @@ let render_keeper_list (state : state) =
     Ansi.gray Ansi.box_l (draw_hline (cols - 2)) Ansi.box_r Ansi.reset);
 
   (* Column headers *)
-  let col_header = Printf.sprintf "  %s  %-16s %-14s %5s  %-20s %s  %s"
-    " " "Name" "Profile" "Gen" "Model" "Pro" "Goal" in
+  let col_header = Printf.sprintf "  %s  %-20s %5s  %-8s %10s  %s"
+    " " "Name" "Gen" "Paused" "Turns" "Current Task" in
   Buffer.add_string buf (Printf.sprintf "%s%s%s %s%s%s %s%s%s\n"
     Ansi.gray Ansi.box_v Ansi.reset
     Ansi.dim (fit_width col_header (cols - 4)) Ansi.reset
@@ -760,61 +760,74 @@ let render_keeper_list (state : state) =
     Ansi.gray Ansi.box_l (draw_hline (cols - 2)) Ansi.box_r Ansi.reset);
 
   (* Keeper rows *)
-  let content_height = rows - 8 in  (* header + column header + footer *)
-  let visible_count = min content_height (List.length state.keepers) in
+  let content_height = max 0 (rows - 8) in
+  let keeper_rows =
+    match state.keepers_error with
+    | None -> content_height
+    | Some err ->
+        box_line buf cols
+          (Ansi.red ^ "  " ^ fit_width err (cols - 8) ^ Ansi.reset);
+        max 0 (content_height - 1)
+  in
+  let visible_count = min keeper_rows (List.length state.keepers) in
   (* Scroll offset: keep cursor visible *)
   let scroll_offset =
-    if state.keeper_cursor >= content_height then
-      state.keeper_cursor - content_height + 1
+    if keeper_rows > 0 && state.keeper_cursor >= keeper_rows then
+      state.keeper_cursor - keeper_rows + 1
     else 0
   in
 
   if visible_count = 0 then begin
-    Buffer.add_string buf (Printf.sprintf "%s%s%s   %s(no keepers found in .masc/keepers/)%s %s%s%s%s\n"
-      Ansi.gray Ansi.box_v Ansi.reset
-      Ansi.dim Ansi.reset
-      (String.make (max 0 (cols - 50)) ' ')
-      Ansi.gray Ansi.box_v Ansi.reset);
-    for _ = 1 to max 0 (content_height - 1) do
+    let empty_rows =
+      match state.keepers_error with
+      | Some _ -> keeper_rows
+      | None ->
+          Buffer.add_string buf (Printf.sprintf "%s%s%s   %s(no keepers found in .masc/keepers/)%s %s%s%s%s\n"
+            Ansi.gray Ansi.box_v Ansi.reset
+            Ansi.dim Ansi.reset
+            (String.make (max 0 (cols - 50)) ' ')
+            Ansi.gray Ansi.box_v Ansi.reset);
+          max 0 (keeper_rows - 1)
+    in
+    for _ = 1 to empty_rows do
       Buffer.add_string buf (Printf.sprintf "%s%s%s %s %s%s%s\n"
         Ansi.gray Ansi.box_v Ansi.reset
         (String.make (cols - 4) ' ')
         Ansi.gray Ansi.box_v Ansi.reset)
     done
   end else begin
-    for i = 0 to content_height - 1 do
+    for i = 0 to keeper_rows - 1 do
       let idx = i + scroll_offset in
       if idx < List.length state.keepers then begin
         let k = List.nth state.keepers idx in
         let is_selected = idx = state.keeper_cursor in
-        let model_short = short_model (Option.value ~default:"-" k.k_active_model) in
-        let proactive_str = if k.k_proactive_enabled then
-          Ansi.green ^ "on" ^ Ansi.reset
+        let paused_str = if k.k_paused then
+          Ansi.yellow ^ "yes" ^ Ansi.reset
         else
-          Ansi.gray ^ "--" ^ Ansi.reset
+          Ansi.dim ^ "no" ^ Ansi.reset
         in
-        let goal_ids_width = max 10 (cols - 68) in
-        let goal_ids_trunc =
-          fit_width (String.concat "," k.k_active_goal_ids) goal_ids_width
+        let task_width = max 8 (cols - 58) in
+        let current_task =
+          fit_width (Option.value ~default:"-" k.k_current_task_id) task_width
         in
-        let name_col = Printf.sprintf "%-16s" k.k_name in
+        let name_col = Printf.sprintf "%-20s" k.k_name in
         let gen_col = Printf.sprintf "%5d" k.k_generation in
-        let model_col = Printf.sprintf "%-20s" model_short in
+        let turns_col = Printf.sprintf "%10d" k.k_total_turns in
         let line_content =
           if is_selected then
             Ansi.reverse ^ ">" ^ Ansi.reset
             ^ "  " ^ Ansi.bold ^ name_col ^ Ansi.reset
             ^ " " ^ gen_col
-            ^ "  " ^ model_col
-            ^ " " ^ proactive_str
-            ^ "  " ^ Ansi.dim ^ goal_ids_trunc ^ Ansi.reset
+            ^ "  " ^ paused_str
+            ^ " " ^ turns_col
+            ^ "  " ^ Ansi.dim ^ current_task ^ Ansi.reset
           else
             " "
             ^ "  " ^ name_col
             ^ " " ^ gen_col
-            ^ "  " ^ model_col
-            ^ " " ^ proactive_str
-            ^ "  " ^ Ansi.dim ^ goal_ids_trunc ^ Ansi.reset
+            ^ "  " ^ paused_str
+            ^ " " ^ turns_col
+            ^ "  " ^ Ansi.dim ^ current_task ^ Ansi.reset
         in
         Buffer.add_string buf (Printf.sprintf "%s%s%s %s %s%s%s\n"
           Ansi.gray Ansi.box_v Ansi.reset
@@ -872,14 +885,15 @@ let render_keeper_detail (state : state) =
     add_section "Identity";
     add_row "Name:" k.k_name;
     add_row "Generation:" (string_of_int k.k_generation);
-    add_row "Trigger Mode:" k.k_trigger_mode;
-    add_row "Verify:" (bool_indicator k.k_verify);
+    add_row "Paused:"
+      (if k.k_paused then Ansi.yellow ^ "yes" ^ Ansi.reset
+       else Ansi.dim ^ "no" ^ Ansi.reset);
     add_empty ();
 
-    (* Goals section *)
-    add_section "Goals";
-    add_row "Active Goal IDs:"
-      (fit_width (String.concat ", " k.k_active_goal_ids) (inner - 26));
+    (* Current work section *)
+    add_section "Current Work";
+    add_row "Task:" (Option.value ~default:"-" k.k_current_task_id);
+    add_row "Last Blocker:" (Option.value ~default:"-" k.k_last_blocker);
     add_empty ();
 
     (* Live Context section (Phase 2) *)
@@ -897,12 +911,6 @@ let render_keeper_detail (state : state) =
     end;
     add_empty ();
 
-    (* Model section *)
-    add_section "Model";
-    add_row "Active Model:" (Option.value ~default:"-" k.k_active_model);
-    add_row "Available:" (String.concat ", " k.k_models);
-    add_empty ();
-
     (* Runtime section *)
     add_section "Runtime Stats";
     add_row "Total Turns:" (string_of_int k.k_total_turns);
@@ -910,14 +918,20 @@ let render_keeper_detail (state : state) =
     add_row "Total Cost:" (Printf.sprintf "$%.4f" k.k_total_cost_usd);
     add_row "Last Turn:" (short_ts k.k_last_turn_ts);
     add_row "Compactions:" (string_of_int k.k_compaction_count);
-    add_row "Context Budget:" (string_of_int k.k_context_budget);
     add_empty ();
 
-    (* Behavior section *)
-    add_section "Behavior";
-    add_row "Proactive:" (bool_indicator k.k_proactive_enabled);
-    add_row "Initiative:" (bool_indicator (Option.value ~default:false k.k_initiative_enabled));
-    add_row "Drift:" (bool_indicator k.k_drift_enabled);
+    (* Autonomy section *)
+    add_section "Autonomy";
+    add_row "Autonomous Turns:"
+      (string_of_int k.k_autonomous_turn_count);
+    add_row "Text / Tool:"
+      (Printf.sprintf "%d / %d" k.k_autonomous_text_turn_count
+         k.k_autonomous_tool_turn_count);
+    add_row "Board / Mention:"
+      (Printf.sprintf "%d / %d" k.k_board_reactive_turn_count
+         k.k_mention_reactive_turn_count);
+    add_row "No-op Turns:" (string_of_int k.k_noop_turn_count);
+    add_row "Last Outcome:" k.k_last_proactive_outcome;
     add_empty ();
 
     (* Timestamps section *)

--- a/bin/masc_tui_render.ml
+++ b/bin/masc_tui_render.ml
@@ -893,7 +893,7 @@ let render_keeper_detail (state : state) =
     (* Current work section *)
     add_section "Current Work";
     add_row "Task:" (Option.value ~default:"-" k.k_current_task_id);
-    add_row "Last Blocker:" (Option.value ~default:"-" k.k_last_blocker);
+    add_row "Last Blocker:" (Tui_decode.keeper_blocker_for_terminal k);
     add_empty ();
 
     (* Live Context section (Phase 2) *)

--- a/bin/masc_tui_types.ml
+++ b/bin/masc_tui_types.ml
@@ -83,22 +83,37 @@ type planning_mode =
   | Planning_list
   | Planning_detail of string
 
-(** Approval / pending confirmation item *)
-type approval_item = {
+(** Actor-scoped pending confirmation from the exact operator projection. *)
+type approval_item = Masc_tui_operator_projection.approval_item
+  = {
   ap_token: string;
+  ap_trace_id: string;
   ap_actor: string;
   ap_action_type: string;
   ap_target_type: string;
   ap_target_id: string option;
+  ap_payload: Yojson.Safe.t;
   ap_delegated_tool: string;
+  ap_created_at: string;
+  ap_expires_at: string option;
   ap_summary: string;
 }
 
-type approval_decision =
+type approval_snapshot = Masc_tui_operator_projection.approval_snapshot
+  = {
+  aps_items: approval_item list;
+  aps_actor_filter: string option;
+  aps_filter_active: bool;
+  aps_visible_count: int;
+  aps_total_count: int;
+  aps_hidden_count: int;
+}
+
+type approval_decision = Masc_tui_operator_projection.approval_decision =
   | Confirm
   | Deny
 
-type pending_approval_action = {
+type pending_approval_action = Masc_tui_operator_projection.pending_approval_action = {
   paa_token: string;
   paa_decision: approval_decision;
 }
@@ -119,11 +134,9 @@ type overview_snapshot = {
   ov_cluster: string;
   ov_project: string;
   ov_active_agents: int;
-  ov_pending_approvals: int;
   ov_incident_count: int;
   ov_attention_items: attention_item list;
   ov_top_attention: attention_item option;
-  ov_pending_confirms: approval_item list;
   ov_generated_at: string;
 }
 
@@ -220,6 +233,9 @@ type state = {
   mutable live_message_count: int;
   mutable overview: overview_snapshot option;
   mutable overview_error: string option;
+  mutable approval_snapshot: approval_snapshot option;
+  mutable approvals_error: string option;
+  mutable approval_flow: Masc_tui_operator_projection.Flow.t;
   mutable approval_cursor: int;
   mutable pending_approval_action: pending_approval_action option;
   mutable board_posts: board_post list;
@@ -262,6 +278,9 @@ let create_state ~workspace ~port ~refresh_interval = {
   live_message_count = 0;
   overview = None;
   overview_error = None;
+  approval_snapshot = None;
+  approvals_error = None;
+  approval_flow = Masc_tui_operator_projection.Flow.initial;
   approval_cursor = 0;
   pending_approval_action = None;
   board_posts = [];
@@ -283,3 +302,8 @@ let create_state ~workspace ~port ~refresh_interval = {
   port;
   refresh_interval;
 }
+
+let approval_items (state : state) =
+  match state.approval_snapshot with
+  | Some snapshot -> snapshot.aps_items
+  | None -> []

--- a/bin/masc_tui_types.ml
+++ b/bin/masc_tui_types.ml
@@ -83,14 +83,6 @@ type planning_mode =
   | Planning_list
   | Planning_detail of string
 
-(** Goal status from /api/v1/dashboard/planning. Unknown wire values are
-    rejected at decode time so the renderer cannot silently dim a new state. *)
-type planning_goal_status =
-  | Planning_goal_active
-  | Planning_goal_paused
-  | Planning_goal_done
-  | Planning_goal_dropped
-
 (** Approval / pending confirmation item *)
 type approval_item = {
   ap_token: string;
@@ -135,28 +127,30 @@ type overview_snapshot = {
   ov_generated_at: string;
 }
 
-(** Planning goal from /api/v1/dashboard/planning *)
-type planning_goal = {
+(** Planning projections from [Tui_decode], which owns the current wire
+    contract and its behavioral decoder tests. *)
+type planning_goal = Tui_decode.planning_goal
+  = {
   pg_id: string;
   pg_title: string;
-  pg_status: planning_goal_status;
-  pg_phase: string;
+  pg_phase: Goal_phase.t;
   pg_priority: int;
   pg_due_date: string option;
   pg_metric: string option;
   pg_target_value: string option;
 }
 
-(** Planning rollup from /api/v1/dashboard/planning *)
-type planning_rollup = {
+type planning_rollup = Tui_decode.planning_rollup
+  = {
   pr_active: int;
   pr_paused: int;
+  pr_verifying: int;
   pr_done: int;
   pr_dropped: int;
 }
 
-(** Planning task backlog summary *)
-type planning_backlog = {
+type planning_backlog = Tui_decode.planning_backlog
+  = {
   pb_todo: int;
   pb_claimed: int;
   pb_running: int;
@@ -164,8 +158,8 @@ type planning_backlog = {
   pb_cancelled: int;
 }
 
-(** Planning snapshot from /api/v1/dashboard/planning *)
-type planning_snapshot = {
+type planning_snapshot = Tui_decode.planning_snapshot
+  = {
   pl_goals: planning_goal list;
   pl_rollup: planning_rollup;
   pl_backlog: planning_backlog;
@@ -210,8 +204,10 @@ type view_mode = surface
 type state = {
   mutable agents: agent list;
   mutable tasks: task list;
+  mutable tasks_error: string option;
   mutable events: event list;
   mutable keepers: keeper list;
+  mutable keepers_error: string option;
   mutable connection_status: connection_status;
   mutable last_refresh: float;
   mutable view: view_mode;
@@ -250,8 +246,10 @@ type state = {
 let create_state ~workspace ~port ~refresh_interval = {
   agents = [];
   tasks = [];
+  tasks_error = None;
   events = [];
   keepers = [];
+  keepers_error = None;
   connection_status = Disconnected;
   last_refresh = 0.0;
   view = Overview;

--- a/docs/TUI-GUIDE.md
+++ b/docs/TUI-GUIDE.md
@@ -53,11 +53,12 @@ Press `Tab` to switch. Shows all registered keepers with status.
 ```
 MASC Keepers (5 registered)
 
-> dm-keeper        gen=0  model=qwen3.5  proactive=true
-  qa-ui-smoke      gen=0  model=qwen3.5  proactive=true
-  qa-surface       gen=0  model=qwen3.5  proactive=true
-  qa-harness       gen=0  model=qwen3.5  proactive=true
-  sangsu           gen=0  model=qwen3.5  proactive=true
+  Name                   Gen  Paused        Turns  Current Task
+> dm-keeper                2  no              128  task-42
+  qa-ui-smoke              1  yes              31  -
+  qa-surface               3  no              204  task-57
+  qa-harness               1  no               89  -
+  sangsu                   1  no            30317  -
 
 [j/k] Navigate  [Enter] Detail  [Tab] Dashboard  [q] Quit
 ```
@@ -71,17 +72,26 @@ Keeper: sangsu
 
   Identity
   Name:                  sangsu
-  Generation:            0
+  Generation:            1
+  Paused:                no
+
+  Current Work
+  Task:                  -
+  Last Blocker:          -
 
   Live Context
   Context:               55.2%  ########-----------  70629 / 128000 tokens
   Messages:              430
 
-  Goals
-  Goal:                  keeper for Vincent
+  Runtime Stats
+  Total Turns:           30317
+  Total Tokens:          2046321197
+  Compactions:           18
 
-  Model
-  Active Model:          llama:qwen3.5-35b-a3b-ud-q8-xl
+  Autonomy
+  Autonomous Turns:      22023
+  Text / Tool:           14457 / 7565
+  Board / Mention:       1187 / 56
 
 [j/k] Scroll  [l] Logs  [m] Message  [Esc] Back  [q] Quit
 ```
@@ -164,9 +174,11 @@ Dashboard <--Tab--> Keeper List
 
 | Feature | Source | Server Required |
 |---------|--------|-----------------|
-| Keeper list/detail | `.masc/keepers/*.json` | No |
+| Active task list | `.masc/tasks/backlog.json` | No |
+| Keeper list/detail | current-schema `.masc/keepers/*.json` | No |
 | Live context status | `<name>/metrics/YYYY-MM/DD.jsonl` (latest entry) | No |
 | Keeper logs | `<name>/metrics/YYYY-MM/DD.jsonl` (last 200 entries) | No |
+| Goal planning | `GET /api/v1/dashboard/planning` | Yes |
 | Send messages | `POST /api/v1/keepers/chat/stream` | Yes |
 
 ## Requirements

--- a/docs/TUI-GUIDE.md
+++ b/docs/TUI-GUIDE.md
@@ -179,6 +179,7 @@ Dashboard <--Tab--> Keeper List
 | Live context status | `<name>/metrics/YYYY-MM/DD.jsonl` (latest entry) | No |
 | Keeper logs | `<name>/metrics/YYYY-MM/DD.jsonl` (last 200 entries) | No |
 | Goal planning | `GET /api/v1/dashboard/planning` | Yes |
+| Actor-scoped approvals | `GET /api/v1/operator?view=summary&include_messages=0&include_keepers=0` | Yes |
 | Send messages | `POST /api/v1/keepers/chat/stream` | Yes |
 
 ## Requirements

--- a/docs/design/tui/TUI-SPEC.md
+++ b/docs/design/tui/TUI-SPEC.md
@@ -88,7 +88,7 @@ type surface =
 | 데이터 | 경로 |
 |---|---|
 | agents | `.masc/agents/*.json` |
-| tasks | `.masc/tasks/*.json` |
+| tasks | `.masc/tasks/backlog.json` |
 | keepers | `.masc/keepers/*.json` |
 | keeper metrics | `.masc/keepers/<name>/metrics/YYYY-MM/DD.jsonl` |
 | board posts | `.masc/board_posts.jsonl` |

--- a/docs/design/tui/TUI-SPEC.md
+++ b/docs/design/tui/TUI-SPEC.md
@@ -1,6 +1,6 @@
 ---
 status: draft
-last_verified: 2026-06-26
+last_verified: 2026-08-21
 code_refs:
   - bin/masc_tui.ml
   - bin/masc_tui_types.ml
@@ -76,10 +76,13 @@ type surface =
 | 소스 | 우선순위 | 사용 시나리오 |
 |---|---|---|
 | `.masc/` 파일시스템 | 기본 (serverless) | agent, task, keeper, board JSONL 등 정적/준정적 데이터 |
-| HTTP `/api/v1/dashboard/*` | 서버 실행 시 | overview, monitoring, approvals, operator action 등 |
+| HTTP `/api/v1/dashboard/*` | 서버 실행 시 | overview, monitoring, planning 등 |
+| HTTP `/api/v1/operator` | 서버 실행 시 | actor-scoped approvals와 operator action |
 | HTTP `/api/v1/*` | 필요 시 | board, keepers, tasks 등 |
 
-로더는 HTTP API 실패/미가용 시 파일시스템 폴백을 시도할 수 있다.
+각 surface는 독립적으로 성공/실패를 반영한다. 특히 Approvals는 권한과 actor
+scope가 결합된 서버 계약이므로 파일시스템이나 briefing을 대체 소스로 사용하지 않고,
+응답이 없거나 계약이 다르면 큐 대신 명시적 오류를 표시한다.
 
 ## 3. 데이터 소스
 
@@ -117,6 +120,7 @@ type surface =
 | `GET /api/v1/verification/requests` | Verification queue |
 | `GET /api/v1/verification/summary` | Verification summary |
 | `GET /api/v1/operator/digest` | Operator digest |
+| `GET /api/v1/operator?view=summary&include_messages=0&include_keepers=0` | Actor-scoped approval queue |
 | `POST /api/v1/operator/confirm` | Confirm approval |
 | `POST /api/v1/operator/action` | Operator action |
 | `GET /api/v1/gate/connectors` | Connector status |
@@ -181,11 +185,11 @@ type surface =
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│ Approvals  (2 pending)                                       │
+│ Approvals  (2/5, hidden 3, actor masc-tui)                   │
 ├─────────────────────────────────────────────────────────────┤
-│ > keeper alpha requests tool_call: shell_exec               │
-│   reason: run tests for PR #12345                           │
-│   [y] confirm  [n] deny  [d] details                        │
+│ > namespace_pause on workspace (masc_pause)                 │
+│   trace=ops_…  created=…  expires=…  payload={…}            │
+│   [y][y] confirm  [n][n] deny                               │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -240,9 +244,14 @@ type surface =
 
 | 키 | 동작 |
 |---|---|
-| `y` | confirm |
-| `n` | deny |
-| `d` | details |
+| `y` 두 번 | 선택한 token confirm |
+| `n` 두 번 | 선택한 token deny |
+
+다른 키, surface 이동, 요청 완료는 준비된 두 번째 키를 해제한다. 요청 중에는
+다음 승인을 준비할 수 없다. POST 응답의 token/decision/trace/tool/action 계약을
+검증한 뒤 같은 actor scope를 다시 읽으며, 오래된 refresh generation은 폐기한다.
+identity가 일치하는 `status=error`는 confirmation 수락 후 action 실행 실패로,
+전송/계약 오류는 결과 불확정으로 표시하며 둘 다 큐를 다시 읽어 사실을 갱신한다.
 
 ## 6. 상태 모델
 
@@ -259,7 +268,10 @@ type tui_state = {
   overview: overview_snapshot option;
   board_posts: board_post list;
   board_selected_post: Post_id.t option;
-  approvals: approval_item list;
+  approval_snapshot: approval_snapshot option;
+  approvals_error: string option;
+  approval_flow: approval_flow;
+  pending_approval_action: pending_approval_action option;
   planning: goal_tree option;
 
   (* keepers (기존) *)
@@ -317,7 +329,7 @@ type tui_state = {
 
 | Risk | Mitigation |
 |---|---|
-| HTTP API 의존 시 서버 미실행으로 기능 제한 | 파일시스템 폴백 + `connection_status` 명시 |
+| HTTP API 의존 시 서버 미실행으로 기능 제한 | surface별 오류와 `connection_status`를 명시하고 권한 surface는 fail closed |
 | 터미널 크기 제한으로 정보 밀도 과다 | fold/unfold, scroll, section collapse 지원 |
 | 쓰기 작업(confirm/action) 실수 | confirm dialog (`y` 두 번 누르기 등) 추가 |
 | ANSI 호환성 문제 | `NO_COLOR` 환경 변수 존중, plain-text fallback |
@@ -327,6 +339,7 @@ type tui_state = {
 
 - P0 surface 중 **첫 번째 prototype**으로 어떤 것을 선택할 것인가?
 - WebSocket/SSE 실시간 업데이트를 TUI에서 수용할 것인가, 아니면 폴링만 할 것인가?
-- TUI에서의 **인증 흐름**: `ensureDevToken`을 어떻게 처리할 것인가?
-- 쓰기 작업의 **권한/안전성**: operator action/confirm은 누구나 가능한가?
+- TUI 인증은 `MASC_TOKEN` Bearer identity를 우선하고, 없으면 GET/POST 모두
+  `X-MASC-Agent: masc-tui` actor를 사용한다. 서버가 승인한 동일 actor만 자신의
+  pending confirmation을 조회하고 처리할 수 있다.
 - Overview의 briefing은 `/api/v1/dashboard/briefing/sections`(LLM 생성)을 사용할 것인가, 아니면 light 요약만 할 것인가?

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -253,6 +253,10 @@ let validate_request request =
     | Some _ -> Ok ()
     | None -> Error (Printf.sprintf "unsupported action_type: %s" request.action_type)
 
+let invalidate_operator_snapshot_views config =
+  invalidate_snapshot_cache ();
+  Dashboard_projection_cache.invalidate_snapshot_json ~config
+
 let action_json ?actor_hint (ctx : _ context) args :
     (Yojson.Safe.t, string) result =
   let* request = action_request_of_args ?actor_hint ctx args in
@@ -280,6 +284,7 @@ let action_json ?actor_hint (ctx : _ context) args :
       }
     in
     let* () = upsert_pending_confirm ctx.config entry in
+    let () = invalidate_operator_snapshot_views ctx.config in
     append_action_log ctx.config
       {
         trace_id;
@@ -357,6 +362,7 @@ let confirm_json ?actor_hint (ctx : _ context) args :
       | None -> Error "pending confirmation not found"
       | Some entry when pending_confirm_expired entry ->
           let* () = remove_pending_confirm ctx.config confirm_token in
+          let () = invalidate_operator_snapshot_views ctx.config in
           append_action_log ctx.config
             {
               trace_id = entry.trace_id;
@@ -401,6 +407,7 @@ let confirm_json ?actor_hint (ctx : _ context) args :
       | Some entry ->
           if String.equal decision "deny" then (
             let* () = remove_pending_confirm ctx.config confirm_token in
+            let () = invalidate_operator_snapshot_views ctx.config in
             append_action_log ctx.config
               {
                 trace_id = entry.trace_id;
@@ -440,7 +447,9 @@ let confirm_json ?actor_hint (ctx : _ context) args :
               }
             in
             let* () = remove_pending_confirm ctx.config confirm_token in
+            let () = invalidate_operator_snapshot_views ctx.config in
             let* executed, result_status = execute_action ctx request in
+            let () = invalidate_operator_snapshot_views ctx.config in
             let latency_ms = int_of_float ((Unix.gettimeofday () -. started_at) *. 1000.0) in
             append_action_log ctx.config
               {

--- a/lib/tui_decode.ml
+++ b/lib/tui_decode.ml
@@ -298,7 +298,9 @@ let sanitize_terminal_text text =
 ;;
 
 let keeper_blocker_for_terminal keeper =
-  Option.value ~default:"-" keeper.k_last_blocker |> sanitize_terminal_text
+  match keeper.k_last_blocker with
+  | None -> "-"
+  | Some blocker -> sanitize_terminal_text blocker
 ;;
 
 let keeper_of_meta (meta : Keeper_meta_contract.keeper_meta) =

--- a/lib/tui_decode.ml
+++ b/lib/tui_decode.ml
@@ -376,19 +376,6 @@ let required_int_field json key =
   | `Null -> missing_field key
   | bad -> field_type_error key "an int" bad
 
-let required_int_any_field json keys =
-  let rec loop = function
-    | [] ->
-        Error
-          (Printf.sprintf "missing required field '%s'"
-             (String.concat "' or '" keys))
-    | key :: rest -> (
-        match member key json with
-        | `Null -> loop rest
-        | _ -> required_int_field json key)
-  in
-  loop keys
-
 let int_field_or json key ~default =
   match member key json with
   | `Null -> Ok default

--- a/lib/tui_decode.ml
+++ b/lib/tui_decode.ml
@@ -215,6 +215,92 @@ let blocker_summary (blocker : Keeper_meta_contract.blocker_info) =
   | "" -> label
   | detail -> label ^ ": " ^ detail
 
+let sanitize_terminal_text text =
+  let escaped_byte byte = Printf.sprintf "\\x%02X" byte in
+  let escaped_codepoint byte = Printf.sprintf "\\u00%02X" byte in
+  let output = Buffer.create (String.length text) in
+  let byte_at index = Char.code text.[index] in
+  let is_continuation byte = byte >= 0x80 && byte <= 0xBF in
+  let valid_utf8_length index =
+    let remaining = String.length text - index in
+    let first = byte_at index in
+    if first >= 0xC2 && first <= 0xDF && remaining >= 2
+       && is_continuation (byte_at (index + 1))
+    then Some 2
+    else if first = 0xE0 && remaining >= 3
+            && byte_at (index + 1) >= 0xA0
+            && byte_at (index + 1) <= 0xBF
+            && is_continuation (byte_at (index + 2))
+    then Some 3
+    else if first >= 0xE1 && first <= 0xEC && remaining >= 3
+            && is_continuation (byte_at (index + 1))
+            && is_continuation (byte_at (index + 2))
+    then Some 3
+    else if first = 0xED && remaining >= 3
+            && byte_at (index + 1) >= 0x80
+            && byte_at (index + 1) <= 0x9F
+            && is_continuation (byte_at (index + 2))
+    then Some 3
+    else if first >= 0xEE && first <= 0xEF && remaining >= 3
+            && is_continuation (byte_at (index + 1))
+            && is_continuation (byte_at (index + 2))
+    then Some 3
+    else if first = 0xF0 && remaining >= 4
+            && byte_at (index + 1) >= 0x90
+            && byte_at (index + 1) <= 0xBF
+            && is_continuation (byte_at (index + 2))
+            && is_continuation (byte_at (index + 3))
+    then Some 4
+    else if first >= 0xF1 && first <= 0xF3 && remaining >= 4
+            && is_continuation (byte_at (index + 1))
+            && is_continuation (byte_at (index + 2))
+            && is_continuation (byte_at (index + 3))
+    then Some 4
+    else if first = 0xF4 && remaining >= 4
+            && byte_at (index + 1) >= 0x80
+            && byte_at (index + 1) <= 0x8F
+            && is_continuation (byte_at (index + 2))
+            && is_continuation (byte_at (index + 3))
+    then Some 4
+    else None
+  in
+  let rec append index =
+    if index < String.length text
+    then (
+      let byte = Char.code text.[index] in
+      if
+        byte = 0xC2
+        && index + 1 < String.length text
+        && let next = Char.code text.[index + 1] in
+           next >= 0x80 && next <= 0x9F
+      then (
+        Buffer.add_string output (escaped_codepoint (Char.code text.[index + 1]));
+        append (index + 2))
+      else if byte >= 0xC2
+      then (
+        match valid_utf8_length index with
+        | Some length ->
+          Buffer.add_substring output text index length;
+          append (index + length)
+        | None ->
+          Buffer.add_char output text.[index];
+          append (index + 1))
+      else if byte < 0x20 || (byte >= 0x7F && byte <= 0x9F)
+      then (
+        Buffer.add_string output (escaped_byte byte);
+        append (index + 1))
+      else (
+        Buffer.add_char output text.[index];
+        append (index + 1)))
+  in
+  append 0;
+  Buffer.contents output
+;;
+
+let keeper_blocker_for_terminal keeper =
+  Option.value ~default:"-" keeper.k_last_blocker |> sanitize_terminal_text
+;;
+
 let keeper_of_meta (meta : Keeper_meta_contract.keeper_meta) =
   let runtime = meta.runtime in
   let usage = runtime.usage in

--- a/lib/tui_decode.ml
+++ b/lib/tui_decode.ml
@@ -10,32 +10,63 @@ type agent = {
 type task = {
   id : string;
   title : string;
-  status : string;
+  status : Masc_domain.task_status;
   priority : int;
-  claimed_by : string option;
-  parent_task_id : string option;
-  goal_id : string option;
 }
 
 type keeper = {
   k_name : string;
-  k_active_goal_ids : string list;
   k_generation : int;
-  k_active_model : string option;
-  k_models : string list;
-  k_proactive_enabled : bool;
-  k_initiative_enabled : bool option;
+  k_paused : bool;
+  k_current_task_id : string option;
   k_total_turns : int;
   k_total_tokens : int;
   k_total_cost_usd : float;
   k_last_turn_ts : string;
   k_compaction_count : int;
-  k_trigger_mode : string;
-  k_context_budget : int;
-  k_drift_enabled : bool;
-  k_verify : bool;
+  k_autonomous_turn_count : int;
+  k_autonomous_text_turn_count : int;
+  k_autonomous_tool_turn_count : int;
+  k_board_reactive_turn_count : int;
+  k_mention_reactive_turn_count : int;
+  k_noop_turn_count : int;
+  k_last_proactive_outcome : string;
+  k_last_blocker : string option;
   k_created_at : string;
   k_updated_at : string;
+}
+
+type planning_goal = {
+  pg_id : string;
+  pg_title : string;
+  pg_phase : Goal_phase.t;
+  pg_priority : int;
+  pg_due_date : string option;
+  pg_metric : string option;
+  pg_target_value : string option;
+}
+
+type planning_rollup = {
+  pr_active : int;
+  pr_paused : int;
+  pr_verifying : int;
+  pr_done : int;
+  pr_dropped : int;
+}
+
+type planning_backlog = {
+  pb_todo : int;
+  pb_claimed : int;
+  pb_running : int;
+  pb_done : int;
+  pb_cancelled : int;
+}
+
+type planning_snapshot = {
+  pl_goals : planning_goal list;
+  pl_rollup : planning_rollup;
+  pl_backlog : planning_backlog;
+  pl_generated_at : string;
 }
 
 type log_entry = {
@@ -107,8 +138,6 @@ let optional_bool json key =
 let require_string_field json key = require_string json key
 let require_int_field json key = require_int json key
 let require_float_field json key = require_float json key
-let require_bool_field json key = require_bool json key
-
 let require_string_list json key =
   match member key json with
   | `List items ->
@@ -135,14 +164,6 @@ let require_string_list json key =
         (Printf.sprintf "field '%s' must be an array (received %s)" key
            (Json_util.kind_name other))
 
-let string_of_intlike_float_field key f =
-  if not (Float.is_finite f) then
-    Error (Printf.sprintf "field '%s' must be a finite number" key)
-  else
-    try Ok (string_of_int (int_of_float f))
-    with Invalid_argument _ ->
-      Error (Printf.sprintf "field '%s' is out of range for int" key)
-
 let decode_status json =
   match member "status" json with
   | `String s -> Ok s
@@ -168,92 +189,69 @@ let decode_agent json =
   let* last_seen = require_string_field json "last_seen" in
   Ok { name; status; current_task; last_seen }
 
-let decode_task json =
-  let* id = require_string_field json "id" in
-  let* title = require_string_field json "title" in
-  let* status = require_string_field json "status" in
-  let* priority = optional_int json "priority" in
-  let* claimed_by = optional_string json "claimed_by" in
-  let* parent_task_id = optional_string json "parent_task_id" in
-  let* goal_id = optional_string json "goal_id" in
-  Ok
-    {
-      id;
-      title;
-      status;
-      priority = Option.value priority ~default:3;
-      claimed_by;
-      parent_task_id;
-      goal_id;
-    }
+let task_of_domain (task : Masc_domain.task) =
+  {
+    id = task.id;
+    title = task.title;
+    status = task.task_status;
+    priority = task.priority;
+  }
 
-let decode_keeper ~filename json =
-  let* k_active_goal_ids = require_string_list json "active_goal_ids" in
-  let* k_generation = require_int_field json "generation" in
-  let* k_active_model = optional_string json "active_model" in
-  let* k_models =
-    match member "models" json with
-    | `Null -> Ok []
-    | `List _ -> require_string_list json "models"
-    | other ->
-        Error
-          (Printf.sprintf
-             "field 'models' must be a list of strings (received %s)"
-             (Json_util.kind_name other))
+let active_tasks_of_domain tasks =
+  tasks
+  |> List.map task_of_domain
+  |> List.filter (fun task ->
+       not (Masc_domain.task_status_is_terminal task.status))
+  |> List.stable_sort (fun left right ->
+       Int.compare left.priority right.priority)
+
+let decode_task json =
+  let* task = Masc_domain.task_of_yojson json in
+  Ok (task_of_domain task)
+
+let blocker_summary (blocker : Keeper_meta_contract.blocker_info) =
+  let label = Keeper_meta_contract.blocker_class_to_string blocker.klass in
+  match String.trim blocker.detail with
+  | "" -> label
+  | detail -> label ^ ": " ^ detail
+
+let keeper_of_meta (meta : Keeper_meta_contract.keeper_meta) =
+  let runtime = meta.runtime in
+  let usage = runtime.usage in
+  let compaction = runtime.compaction_rt in
+  let proactive = runtime.proactive_rt in
+  let k_last_turn_ts =
+    if Float.compare usage.last_turn_ts 0.0 <= 0 then ""
+    else Masc_domain.iso8601_of_unix_seconds usage.last_turn_ts
   in
-  let* k_proactive_enabled = require_bool_field json "proactive_enabled" in
-  let* k_initiative_enabled = optional_bool json "initiative_enabled" in
-  let* k_total_turns = require_int_field json "total_turns" in
-  let* k_total_tokens = require_int_field json "total_tokens" in
-  let* k_total_cost_usd = require_float_field json "total_cost_usd" in
-  let* k_last_turn_ts =
-    match member "last_turn_ts" json with
-    | `String s -> Ok s
-    | `Float f -> string_of_intlike_float_field "last_turn_ts" f
-    | `Int n -> Ok (string_of_int n)
-    | `Null -> Ok ""
-    | other ->
-        Error
-          (Printf.sprintf
-             "field 'last_turn_ts' must be a string, number, or null \
-              (received %s)"
-             (Json_util.kind_name other))
-  in
-  let* k_compaction_count = require_int_field json "compaction_count" in
-  let* k_trigger_mode = require_string_field json "trigger_mode" in
-  let* k_context_budget = require_int_field json "context_budget" in
-  let* k_drift_enabled = require_bool_field json "drift_enabled" in
-  let* k_verify = require_bool_field json "verify" in
-  let* k_created_at = require_string_field json "created_at" in
-  let* k_updated_at = require_string_field json "updated_at" in
-  let default_name =
-    if Filename.check_suffix filename ".json" then
-      Filename.chop_suffix filename ".json"
-    else
-      Filename.remove_extension filename
-  in
-  let k_name = Option.value (get_string json "name") ~default:default_name in
-  Ok
-    {
-      k_name;
-      k_active_goal_ids;
-      k_generation;
-      k_active_model;
-      k_models;
-      k_proactive_enabled;
-      k_initiative_enabled;
-      k_total_turns;
-      k_total_tokens;
-      k_total_cost_usd;
-      k_last_turn_ts;
-      k_compaction_count;
-      k_trigger_mode;
-      k_context_budget;
-      k_drift_enabled;
-      k_verify;
-      k_created_at;
-      k_updated_at;
-    }
+  {
+    k_name = meta.name;
+    k_generation = runtime.nonce;
+    k_paused = meta.paused;
+    k_current_task_id =
+      Option.map Keeper_id.Task_id.to_string meta.current_task_id;
+    k_total_turns = usage.total_turns;
+    k_total_tokens = usage.total_tokens;
+    k_total_cost_usd = usage.total_cost_usd;
+    k_last_turn_ts;
+    k_compaction_count = compaction.count;
+    k_autonomous_turn_count = runtime.autonomous_turn_count;
+    k_autonomous_text_turn_count = runtime.autonomous_text_turn_count;
+    k_autonomous_tool_turn_count = runtime.autonomous_tool_turn_count;
+    k_board_reactive_turn_count = runtime.board_reactive_turn_count;
+    k_mention_reactive_turn_count = runtime.mention_reactive_turn_count;
+    k_noop_turn_count = runtime.noop_turn_count;
+    k_last_proactive_outcome =
+      Keeper_meta_contract.proactive_cycle_outcome_to_string
+        proactive.last_outcome;
+    k_last_blocker = Option.map blocker_summary runtime.last_blocker;
+    k_created_at = meta.created_at;
+    k_updated_at = meta.updated_at;
+  }
+
+let decode_keeper json =
+  let* meta = Keeper_meta_json_parse.meta_of_json json in
+  Ok (keeper_of_meta meta)
 
 let parse_log_entry line =
   let json =
@@ -467,6 +465,56 @@ let decode_list label decode items =
         | Error err -> Error (Printf.sprintf "%s[%d]: %s" label idx err))
   in
   loop 0 [] items
+
+let decode_planning_goal json =
+  let* pg_id = required_string_field json "id" in
+  let* pg_title = required_string_field json "title" in
+  let* raw_phase = required_string_field json "phase" in
+  let* pg_phase =
+    match Goal_phase.parse raw_phase with
+    | Some phase -> Ok phase
+    | None -> Error (Printf.sprintf "unknown planning goal phase %S" raw_phase)
+  in
+  let* pg_priority = required_int_field json "priority" in
+  let* pg_due_date = optional_string_field json "due_date" in
+  let* pg_metric = optional_string_field json "metric" in
+  let* pg_target_value = optional_string_field json "target_value" in
+  Ok
+    {
+      pg_id;
+      pg_title;
+      pg_phase;
+      pg_priority;
+      pg_due_date;
+      pg_metric;
+      pg_target_value;
+    }
+
+let decode_planning_rollup json =
+  let* pr_active = required_int_field json "active_count" in
+  let* pr_paused = required_int_field json "paused_count" in
+  let* pr_verifying = required_int_field json "verifying_count" in
+  let* pr_done = required_int_field json "done_count" in
+  let* pr_dropped = required_int_field json "dropped_count" in
+  Ok { pr_active; pr_paused; pr_verifying; pr_done; pr_dropped }
+
+let decode_planning_backlog json =
+  let* pb_todo = required_int_field json "todo" in
+  let* pb_claimed = required_int_field json "claimed" in
+  let* pb_running = required_int_field json "in_progress" in
+  let* pb_done = required_int_field json "done" in
+  let* pb_cancelled = required_int_field json "cancelled" in
+  Ok { pb_todo; pb_claimed; pb_running; pb_done; pb_cancelled }
+
+let decode_planning_snapshot json =
+  let* goals_json = required_list_field json "goals" in
+  let* pl_goals = decode_list "goals" decode_planning_goal goals_json in
+  let* rollup_json = required_object_field json "rollup" in
+  let* pl_rollup = decode_planning_rollup rollup_json in
+  let* backlog_json = required_object_field json "task_backlog" in
+  let* pl_backlog = decode_planning_backlog backlog_json in
+  let* pl_generated_at = required_string_field json "generated_at" in
+  Ok { pl_goals; pl_rollup; pl_backlog; pl_generated_at }
 
 let bounded_parent_depth ?(max_depth = 64) ~(id_of : 'a -> string)
     ~(parent_id_of : 'a -> string option) (items : 'a list) (item : 'a) : int =

--- a/lib/tui_decode.mli
+++ b/lib/tui_decode.mli
@@ -8,32 +8,63 @@ type agent = {
 type task = {
   id : string;
   title : string;
-  status : string;
+  status : Masc_domain.task_status;
   priority : int;
-  claimed_by : string option;
-  parent_task_id : string option;
-  goal_id : string option;
 }
 
 type keeper = {
   k_name : string;
-  k_active_goal_ids : string list;
   k_generation : int;
-  k_active_model : string option;
-  k_models : string list;
-  k_proactive_enabled : bool;
-  k_initiative_enabled : bool option;
+  k_paused : bool;
+  k_current_task_id : string option;
   k_total_turns : int;
   k_total_tokens : int;
   k_total_cost_usd : float;
   k_last_turn_ts : string;
   k_compaction_count : int;
-  k_trigger_mode : string;
-  k_context_budget : int;
-  k_drift_enabled : bool;
-  k_verify : bool;
+  k_autonomous_turn_count : int;
+  k_autonomous_text_turn_count : int;
+  k_autonomous_tool_turn_count : int;
+  k_board_reactive_turn_count : int;
+  k_mention_reactive_turn_count : int;
+  k_noop_turn_count : int;
+  k_last_proactive_outcome : string;
+  k_last_blocker : string option;
   k_created_at : string;
   k_updated_at : string;
+}
+
+type planning_goal = {
+  pg_id : string;
+  pg_title : string;
+  pg_phase : Goal_phase.t;
+  pg_priority : int;
+  pg_due_date : string option;
+  pg_metric : string option;
+  pg_target_value : string option;
+}
+
+type planning_rollup = {
+  pr_active : int;
+  pr_paused : int;
+  pr_verifying : int;
+  pr_done : int;
+  pr_dropped : int;
+}
+
+type planning_backlog = {
+  pb_todo : int;
+  pb_claimed : int;
+  pb_running : int;
+  pb_done : int;
+  pb_cancelled : int;
+}
+
+type planning_snapshot = {
+  pl_goals : planning_goal list;
+  pl_rollup : planning_rollup;
+  pl_backlog : planning_backlog;
+  pl_generated_at : string;
 }
 
 type log_entry = {
@@ -54,8 +85,13 @@ type log_entry = {
 }
 
 val decode_agent : Yojson.Safe.t -> (agent, string) result
+val task_of_domain : Masc_domain.task -> task
+val active_tasks_of_domain : Masc_domain.task list -> task list
 val decode_task : Yojson.Safe.t -> (task, string) result
-val decode_keeper : filename:string -> Yojson.Safe.t -> (keeper, string) result
+val keeper_of_meta : Keeper_meta_contract.keeper_meta -> keeper
+val decode_keeper : Yojson.Safe.t -> (keeper, string) result
+val decode_planning_snapshot :
+  Yojson.Safe.t -> (planning_snapshot, string) result
 val parse_log_entry : string -> (log_entry, string) result
 val is_success_http_status : int -> bool
 val http_status_error : status_code:int -> body:string -> string

--- a/lib/tui_decode.mli
+++ b/lib/tui_decode.mli
@@ -34,6 +34,16 @@ type keeper = {
   k_updated_at : string;
 }
 
+val sanitize_terminal_text : string -> string
+(** Escape C0, DEL, C1 bytes, and UTF-8 encoded C1 code points so external
+    diagnostics cannot emit terminal control sequences. Call at the terminal
+    rendering boundary; decoded records intentionally retain their raw typed
+    diagnostic for non-terminal consumers. *)
+
+val keeper_blocker_for_terminal : keeper -> string
+(** Terminal-boundary projection for the raw typed blocker stored in
+    {!type-keeper}. Missing blockers render as [-]. *)
+
 type planning_goal = {
   pg_id : string;
   pg_title : string;

--- a/lib/tui_decode.mli
+++ b/lib/tui_decode.mli
@@ -101,7 +101,6 @@ val required_string_field : Yojson.Safe.t -> string -> (string, string) result
 val optional_string_field :
   Yojson.Safe.t -> string -> (string option, string) result
 val required_int_field : Yojson.Safe.t -> string -> (int, string) result
-val required_int_any_field : Yojson.Safe.t -> string list -> (int, string) result
 val int_field_or : Yojson.Safe.t -> string -> default:int -> (int, string) result
 val required_display_field : Yojson.Safe.t -> string -> (string, string) result
 val required_display_any_field :

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -389,6 +389,7 @@ agent_core_targets=(
 )
 
 operator_targets=(
+  @test/runtest-test_tui_operator_projection
   @test/runtest-test_operator_control_snapshot_state
   @test/runtest-test_operator_control_snapshot
   @test/runtest-test_operator_control_snapshot_cache

--- a/test/dune
+++ b/test/dune
@@ -2557,6 +2557,11 @@
   (source_tree ../bin)))
 
 (test
+ (name test_tui_operator_projection)
+ (modules test_tui_operator_projection)
+ (libraries alcotest masc_tui_operator_projection yojson))
+
+(test
  (name test_fs_compat_capability_exact_read)
  (modules test_fs_compat_capability_exact_read)
  (libraries alcotest fs_compat fs_compat_test_support eio eio_main eio.unix unix)

--- a/test/test_operator_control_actions.ml
+++ b/test/test_operator_control_actions.ml
@@ -162,6 +162,90 @@ let test_task_inject_executes_after_confirmation () =
       Alcotest.(check int) "task injected after confirmation" 1
         (List.length tasks))
 
+let test_pending_confirmation_mutations_invalidate_snapshot_views () =
+  Eio_main.run @@ fun env ->
+  Eio_guard.enable ();
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Workspace.default_config base_dir in
+      ignore (Workspace.init config ~agent_name:(Some "operator"));
+      let ctx = operator_ctx env sw config "operator" in
+      Operator_control.invalidate_snapshot_cache ();
+      Dashboard_projection_cache.invalidate_snapshot_json ~config;
+      let snapshot () =
+        Operator_control.snapshot_json ~actor:"operator" ~view:"summary"
+          ~include_messages:false ~include_keepers:false ctx
+      in
+      let pending snapshot =
+        snapshot |> Yojson.Safe.Util.member "pending_confirm_envelope"
+        |> Yojson.Safe.Util.member "items" |> Yojson.Safe.Util.to_list
+      in
+      let action payload =
+        Operator_control.action_json ctx
+          (`Assoc
+            [ "actor", `String "operator"
+            ; "action_type", `String "task_inject"
+            ; ( "target_type"
+              , `String Operator_action_constants.workspace_target_type )
+            ; "payload", payload
+            ])
+        |> Result.get_ok
+      in
+      let token json =
+        Yojson.Safe.Util.(json |> member "confirm_token" |> to_string)
+      in
+      let confirm token decision =
+        Operator_control.confirm_json ctx
+          (`Assoc
+            [ "actor", `String "operator"
+            ; "confirm_token", `String token
+            ; "decision", `String decision
+            ])
+      in
+      let projection_computes = ref 0 in
+      let projection () =
+        Dashboard_projection_cache.get_or_compute_snapshot_json ~config
+          ~actor:(Some "operator") (fun _ ->
+            incr projection_computes;
+            `Int !projection_computes)
+      in
+      Alcotest.(check int) "prewarmed queue is empty" 0
+        (List.length (pending (snapshot ())));
+      ignore (projection ());
+      Alcotest.(check int) "projection prewarmed once" 1 !projection_computes;
+
+      let valid =
+        action
+          (`Assoc
+            [ "title", `String "Injected task"
+            ; "description", `String "created by operator"
+            ])
+      in
+      Alcotest.(check int) "preview appears after cached empty snapshot" 1
+        (List.length (pending (snapshot ())));
+      ignore (projection ());
+      Alcotest.(check int) "preview invalidates dashboard projection" 2
+        !projection_computes;
+      ignore (confirm (token valid) "deny" |> Result.get_ok);
+      Alcotest.(check int) "denied preview disappears immediately" 0
+        (List.length (pending (snapshot ())));
+      ignore (projection ());
+      Alcotest.(check int) "deny invalidates dashboard projection" 3
+        !projection_computes;
+
+      let invalid = action (`Assoc []) in
+      Alcotest.(check int) "invalid action preview is cached" 1
+        (List.length (pending (snapshot ())));
+      let result = confirm (token invalid) "confirm" in
+      Alcotest.(check bool) "execution fails after consuming preview" true
+        (Result.is_error result);
+      Alcotest.(check int) "failed execution cannot leave cached preview" 0
+        (List.length (pending (snapshot ()))))
+
 let test_digest_defaults_to_workspace_target () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
@@ -366,6 +450,10 @@ let () =
             "task inject executes after confirmation"
             `Quick
             test_task_inject_executes_after_confirmation
+        ; Alcotest.test_case
+            "pending-confirm mutations invalidate snapshot views"
+            `Quick
+            test_pending_confirmation_mutations_invalidate_snapshot_views
         ; Alcotest.test_case
             "snapshot preserves backlog failure contract"
             `Quick

--- a/test/test_operator_control_confirm.ml
+++ b/test/test_operator_control_confirm.ml
@@ -3,6 +3,7 @@ open Test_operator_control_support
 
 let test_confirm_rejects_expired_token () =
   Eio_main.run @@ fun env ->
+  Eio_guard.enable ();
   ensure_fs env;
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
@@ -38,10 +39,29 @@ let test_confirm_rejects_expired_token () =
                      ];
                  ])));
       let ctx = operator_ctx env sw config "operator" in
+      Operator_control.invalidate_snapshot_cache ();
+      ignore
+        (Operator_control_snapshot_cache.get_or_compute "expired-sentinel"
+           ~ttl:60.0 (fun () -> `String "stale"));
+      let projection_computes = ref 0 in
+      let projection () =
+        Dashboard_projection_cache.get_or_compute_snapshot_json ~config
+          ~actor:(Some "operator") (fun _ ->
+            incr projection_computes;
+            `Int !projection_computes)
+      in
+      ignore (projection ());
       match
         Operator_control.confirm_json ctx
           (`Assoc [ ("actor", `String "operator"); ("confirm_token", `String "expired-token") ])
       with
       | Ok _ -> Alcotest.fail "expected expired confirmation error"
       | Error err ->
-          Alcotest.(check string) "expired error" "pending confirmation expired" err)
+          Alcotest.(check string) "expired error" "pending confirmation expired" err;
+          Alcotest.(check bool) "expired removal clears operator snapshot cache"
+            false
+            (Option.is_some
+               (Operator_control_snapshot_cache.peek "expired-sentinel"));
+          ignore (projection ());
+          Alcotest.(check int) "expired removal clears dashboard projection" 2
+            !projection_computes)

--- a/test/test_tui_decode.ml
+++ b/test/test_tui_decode.ml
@@ -35,87 +35,249 @@ let test_decode_task_missing_priority_defaults () =
     ]
   in
   match Tui_decode.decode_task json with
-  | Ok task -> Alcotest.(check int) "default priority" 3 task.priority
+  | Ok task ->
+      Alcotest.(check int) "default priority" 3 task.priority;
+      Alcotest.(check string) "typed status" "todo"
+        (Masc_domain.task_status_to_string task.status)
   | Error err -> Alcotest.fail err
 
-let keeper_json ?(models = `List [ `String "glm-5.1" ]) ?(last_turn_ts = `String "1700000000")
-    ?(active_model = Some (`String "glm-5.1"))
-    ?(initiative_enabled = Some (`Bool true)) () =
+let domain_task ~id ~priority status_fields =
+  let json =
+    `Assoc
+      ([ "id", `String id
+       ; "title", `String ("Task " ^ id)
+       ; "priority", `Int priority
+       ; "created_at", `String "2026-08-21T00:00:00Z"
+       ]
+      @ status_fields)
+  in
+  match Masc_domain.task_of_yojson json with
+  | Ok task -> task
+  | Error err -> Alcotest.fail err
+
+let test_active_tasks_of_domain_filters_and_sorts () =
+  let tasks =
+    [ domain_task ~id:"done" ~priority:0
+        [ "status", `String "done"
+        ; "assignee", `String "alice"
+        ; "completed_at", `String "2026-08-21T00:00:00Z"
+        ]
+    ; domain_task ~id:"todo" ~priority:3 [ "status", `String "todo" ]
+    ; domain_task ~id:"running" ~priority:1
+        [ "status", `String "in_progress"
+        ; "assignee", `String "bob"
+        ; "started_at", `String "2026-08-21T00:00:00Z"
+        ]
+    ; domain_task ~id:"cancelled" ~priority:2
+        [ "status", `String "cancelled"
+        ; "cancelled_by", `String "operator"
+        ; "cancelled_at", `String "2026-08-21T00:00:00Z"
+        ]
+    ]
+  in
+  let active = Tui_decode.active_tasks_of_domain tasks in
+  Alcotest.(check (list string)) "terminal tasks removed, priority preserved"
+    [ "running"; "todo" ]
+    (List.map (fun (task : Tui_decode.task) -> task.id) active)
+
+let current_keeper_json ?(last_turn_ts = 0.0) ?(paused = false)
+    ?(current_task_id = None) () =
   let optional_field key = function
     | Some value -> [ (key, value) ]
     | None -> []
   in
-  `Assoc
-    ([
-       ("goal", `String "keep the system healthy");
-       ("soul_profile", `String "balanced");
-       ("generation", `Int 2);
-       ("models", models);
-       ("proactive_enabled", `Bool true);
-       ("total_turns", `Int 4);
-       ("total_tokens", `Int 120);
-       ("total_cost_usd", `Float 0.42);
-       ("last_turn_ts", last_turn_ts);
-       ("compaction_count", `Int 1);
-       ("trigger_mode", `String "mention");
-       ("context_budget", `Int 32000);
-       ("drift_enabled", `Bool true);
-       ("verify", `Bool true);
-       ("created_at", `String "2026-03-31T12:00:00Z");
-       ("updated_at", `String "2026-03-31T12:05:00Z");
-     ]
-    @ optional_field "active_model" active_model
-    @ optional_field "initiative_enabled" initiative_enabled)
-
-let test_decode_keeper_missing_legacy_fields_defaults_to_none () =
-  match
-    Tui_decode.decode_keeper ~filename:"keeper-main.json"
-      (keeper_json ~active_model:None ~initiative_enabled:None ())
-  with
-  | Ok keeper ->
-      Alcotest.(check string) "filename fallback" "keeper-main" keeper.k_name;
-      Alcotest.(check (option string)) "missing active_model" None
-        keeper.k_active_model;
-      Alcotest.(check (option bool)) "missing initiative_enabled" None
-        keeper.k_initiative_enabled
+  let fixture =
+    `Assoc
+      ([ ("name", `String "keeper-main")
+       ; ("generation", `Int 2)
+       ; ("paused", `Bool paused)
+       ; ("total_turns", `Int 4)
+       ; ("total_tokens", `Int 120)
+       ; ("total_cost_usd", `Float 0.42)
+       ; ("last_turn_ts", `Float last_turn_ts)
+       ; ("compaction_count", `Int 1)
+       ; ("autonomous_turn_count", `Int 7)
+       ; ("autonomous_text_turn_count", `Int 5)
+       ; ("autonomous_tool_turn_count", `Int 2)
+       ; ("board_reactive_turn_count", `Int 3)
+       ; ("mention_reactive_turn_count", `Int 1)
+       ; ("noop_turn_count", `Int 4)
+       ; ("last_proactive_outcome", `String "tool_use")
+       ; ( "last_blocker"
+         , Keeper_meta_contract.(
+             blocker_info_of_class ~detail:"queue full" Capacity_backpressure
+             |> blocker_info_to_json) )
+       ; ("created_at", `String "2026-08-20T01:02:03Z")
+       ; ("updated_at", `String "2026-08-21T04:05:06Z")
+       ]
+      @ optional_field "current_task_id"
+          (Option.map (fun id -> `String id) current_task_id))
+  in
+  match Masc_test_deps.meta_of_json_fixture fixture with
+  | Ok meta -> Keeper_meta_json.meta_to_json meta
   | Error err -> Alcotest.fail err
 
-let test_decode_keeper_numeric_last_turn_ts_truncates () =
+let test_decode_keeper_projects_current_schema () =
   match
-    Tui_decode.decode_keeper ~filename:"keeper-main.json"
-      (keeper_json ~last_turn_ts:(`Float 1700000000.9) ())
+    Tui_decode.decode_keeper
+      (current_keeper_json ~paused:true ~current_task_id:(Some "task-42") ())
   with
   | Ok keeper ->
-      Alcotest.(check string) "float timestamp truncates" "1700000000"
+      Alcotest.(check string) "name" "keeper-main" keeper.k_name;
+      Alcotest.(check int) "generation" 2 keeper.k_generation;
+      Alcotest.(check bool) "paused" true keeper.k_paused;
+      Alcotest.(check (option string)) "current task" (Some "task-42")
+        keeper.k_current_task_id;
+      Alcotest.(check int) "autonomous turns" 7
+        keeper.k_autonomous_turn_count;
+      Alcotest.(check int) "total turns" 4 keeper.k_total_turns;
+      Alcotest.(check int) "total tokens" 120 keeper.k_total_tokens;
+      Alcotest.(check (float 0.0001)) "total cost" 0.42
+        keeper.k_total_cost_usd;
+      Alcotest.(check int) "compactions" 1 keeper.k_compaction_count;
+      Alcotest.(check int) "autonomous text turns" 5
+        keeper.k_autonomous_text_turn_count;
+      Alcotest.(check int) "autonomous tool turns" 2
+        keeper.k_autonomous_tool_turn_count;
+      Alcotest.(check int) "board turns" 3
+        keeper.k_board_reactive_turn_count;
+      Alcotest.(check int) "mention turns" 1
+        keeper.k_mention_reactive_turn_count;
+      Alcotest.(check int) "no-op turns" 4 keeper.k_noop_turn_count;
+      Alcotest.(check string) "last outcome" "tool_use"
+        keeper.k_last_proactive_outcome;
+      Alcotest.(check (option string)) "last blocker"
+        (Some "capacity_backpressure: queue full")
+        keeper.k_last_blocker;
+      Alcotest.(check string) "created at" "2026-08-20T01:02:03Z"
+        keeper.k_created_at;
+      Alcotest.(check string) "updated at" "2026-08-21T04:05:06Z"
+        keeper.k_updated_at
+  | Error err -> Alcotest.fail err
+
+let test_decode_keeper_formats_last_turn_timestamp () =
+  let timestamp = 1700000000.9 in
+  match
+    Tui_decode.decode_keeper (current_keeper_json ~last_turn_ts:timestamp ())
+  with
+  | Ok keeper ->
+      Alcotest.(check string) "timestamp uses canonical ISO formatter"
+        (Masc_domain.iso8601_of_unix_seconds timestamp)
         keeper.k_last_turn_ts
   | Error err -> Alcotest.fail err
 
-let test_decode_keeper_null_last_turn_ts_is_empty () =
-  match
-    Tui_decode.decode_keeper ~filename:"keeper-main.json"
-      (keeper_json ~last_turn_ts:`Null ())
-  with
+let test_decode_keeper_zero_last_turn_is_empty () =
+  match Tui_decode.decode_keeper (current_keeper_json ()) with
   | Ok keeper ->
-      Alcotest.(check string) "null timestamp becomes empty" "" keeper.k_last_turn_ts
+      Alcotest.(check string) "zero timestamp becomes empty" ""
+        keeper.k_last_turn_ts
   | Error err -> Alcotest.fail err
 
-let test_decode_keeper_rejects_invalid_models_type () =
-  Alcotest.(check bool) "invalid models rejected" true
-    (Result.is_error
-       (Tui_decode.decode_keeper ~filename:"keeper-main.json"
-          (keeper_json ~models:(`String "glm-5.1") ())))
+let test_decode_keeper_rejects_retired_fields () =
+  List.iter
+    (fun field ->
+      let json =
+        match current_keeper_json () with
+        | `Assoc fields -> `Assoc ((field, `Bool true) :: fields)
+        | _ -> Alcotest.fail "current keeper fixture must be an object"
+      in
+      Alcotest.(check bool) ("retired field rejected: " ^ field) true
+        (Result.is_error (Tui_decode.decode_keeper json)))
+    [ "active_goal_ids"
+    ; "active_model"
+    ; "models"
+    ; "proactive_enabled"
+    ; "initiative_enabled"
+    ; "trigger_mode"
+    ; "context_budget"
+    ; "drift_enabled"
+    ; "verify"
+    ]
 
-let test_decode_keeper_rejects_non_string_model_items () =
-  Alcotest.(check bool) "non-string model entries rejected" true
-    (Result.is_error
-       (Tui_decode.decode_keeper ~filename:"keeper-main.json"
-          (keeper_json ~models:(`List [ `String "glm-5.1"; `Int 7 ]) ())))
+let test_dotted_keeper_metadata_name_is_preserved () =
+  Alcotest.(check (option string)) "portable dotted Keeper name"
+    (Some "alpha.with.dot")
+    (Keeper_runtime_root_entry.metadata_keeper_name "alpha.with.dot.json")
 
-let test_decode_keeper_rejects_non_finite_last_turn_ts () =
-  Alcotest.(check bool) "non-finite timestamp rejected" true
+let test_decode_keeper_rejects_missing_current_field () =
+  let json =
+    match current_keeper_json () with
+    | `Assoc fields ->
+        `Assoc (List.filter (fun (key, _) -> key <> "paused") fields)
+    | _ -> Alcotest.fail "current keeper fixture must be an object"
+  in
+  Alcotest.(check bool) "missing current field rejected" true
+    (Result.is_error (Tui_decode.decode_keeper json))
+
+let planning_goal_json id phase priority =
+  `Assoc
+    [ "id", `String id
+    ; "title", `String ("Goal " ^ id)
+    ; "phase", `String phase
+    ; "priority", `Int priority
+    ]
+
+let planning_snapshot_json ?(running_key = "in_progress") () =
+  `Assoc
+    [ ( "goals"
+      , `List
+          (List.mapi
+             (fun index phase ->
+                planning_goal_json (Printf.sprintf "goal-%d" index) phase index)
+             [ "executing"
+             ; "blocked"
+             ; "paused"
+             ; "verifying"
+             ; "completed"
+             ; "dropped"
+             ]) )
+    ; ( "rollup"
+      , `Assoc
+          [ "active_count", `Int 1
+          ; "paused_count", `Int 2
+          ; "verifying_count", `Int 3
+          ; "done_count", `Int 4
+          ; "dropped_count", `Int 5
+          ] )
+    ; ( "task_backlog"
+      , `Assoc
+          [ "todo", `Int 6
+          ; "claimed", `Int 7
+          ; running_key, `Int 8
+          ; "done", `Int 9
+          ; "cancelled", `Int 10
+          ] )
+    ; "generated_at", `String "2026-08-21T05:06:07Z"
+    ]
+
+let test_decode_planning_snapshot_current_contract () =
+  match Tui_decode.decode_planning_snapshot (planning_snapshot_json ()) with
+  | Error err -> Alcotest.fail err
+  | Ok snapshot ->
+      Alcotest.(check (list string)) "all canonical phases"
+        [ "executing"; "blocked"; "paused"; "verifying"; "completed"; "dropped" ]
+        (List.map
+           (fun (goal : Tui_decode.planning_goal) ->
+              Goal_phase.to_string goal.pg_phase)
+           snapshot.pl_goals);
+      Alcotest.(check int) "active" 1 snapshot.pl_rollup.pr_active;
+      Alcotest.(check int) "paused and blocked" 2 snapshot.pl_rollup.pr_paused;
+      Alcotest.(check int) "verifying" 3 snapshot.pl_rollup.pr_verifying;
+      Alcotest.(check int) "done" 4 snapshot.pl_rollup.pr_done;
+      Alcotest.(check int) "dropped" 5 snapshot.pl_rollup.pr_dropped;
+      Alcotest.(check int) "todo" 6 snapshot.pl_backlog.pb_todo;
+      Alcotest.(check int) "claimed" 7 snapshot.pl_backlog.pb_claimed;
+      Alcotest.(check int) "in progress" 8 snapshot.pl_backlog.pb_running;
+      Alcotest.(check int) "backlog done" 9 snapshot.pl_backlog.pb_done;
+      Alcotest.(check int) "cancelled" 10 snapshot.pl_backlog.pb_cancelled;
+      Alcotest.(check string) "generated at" "2026-08-21T05:06:07Z"
+        snapshot.pl_generated_at
+
+let test_decode_planning_snapshot_rejects_running_alias () =
+  Alcotest.(check bool) "retired running alias rejected" true
     (Result.is_error
-       (Tui_decode.decode_keeper ~filename:"keeper-main.json"
-          (keeper_json ~last_turn_ts:(`Float Float.infinity) ())))
+       (Tui_decode.decode_planning_snapshot
+          (planning_snapshot_json ~running_key:"running" ())))
 
 let test_parse_log_entry_success () =
   let line =
@@ -291,21 +453,30 @@ let () =
       [
         Alcotest.test_case "missing priority defaults" `Quick
           test_decode_task_missing_priority_defaults;
+        Alcotest.test_case "active projection filters and sorts" `Quick
+          test_active_tasks_of_domain_filters_and_sorts;
       ] );
     ( "decode_keeper",
       [
-        Alcotest.test_case "missing legacy fields default to none" `Quick
-          test_decode_keeper_missing_legacy_fields_defaults_to_none;
-        Alcotest.test_case "numeric last_turn_ts truncates" `Quick
-          test_decode_keeper_numeric_last_turn_ts_truncates;
-        Alcotest.test_case "null last_turn_ts is empty" `Quick
-          test_decode_keeper_null_last_turn_ts_is_empty;
-        Alcotest.test_case "rejects invalid models type" `Quick
-          test_decode_keeper_rejects_invalid_models_type;
-        Alcotest.test_case "rejects non-string model items" `Quick
-          test_decode_keeper_rejects_non_string_model_items;
-        Alcotest.test_case "rejects non-finite last_turn_ts" `Quick
-          test_decode_keeper_rejects_non_finite_last_turn_ts;
+        Alcotest.test_case "projects current schema" `Quick
+          test_decode_keeper_projects_current_schema;
+        Alcotest.test_case "formats last turn timestamp" `Quick
+          test_decode_keeper_formats_last_turn_timestamp;
+        Alcotest.test_case "zero last turn is empty" `Quick
+          test_decode_keeper_zero_last_turn_is_empty;
+        Alcotest.test_case "rejects retired fields" `Quick
+          test_decode_keeper_rejects_retired_fields;
+        Alcotest.test_case "preserves dotted metadata name" `Quick
+          test_dotted_keeper_metadata_name_is_preserved;
+        Alcotest.test_case "rejects missing current field" `Quick
+          test_decode_keeper_rejects_missing_current_field;
+      ] );
+    ( "decode_planning",
+      [
+        Alcotest.test_case "current contract" `Quick
+          test_decode_planning_snapshot_current_contract;
+        Alcotest.test_case "rejects running alias" `Quick
+          test_decode_planning_snapshot_rejects_running_alias;
       ] );
     ( "parse_log_entry",
       [

--- a/test/test_tui_decode.ml
+++ b/test/test_tui_decode.ml
@@ -81,7 +81,7 @@ let test_active_tasks_of_domain_filters_and_sorts () =
     (List.map (fun (task : Tui_decode.task) -> task.id) active)
 
 let current_keeper_json ?(last_turn_ts = 0.0) ?(paused = false)
-    ?(current_task_id = None) () =
+    ?(current_task_id = None) ?(blocker_detail = "queue full") () =
   let optional_field key = function
     | Some value -> [ (key, value) ]
     | None -> []
@@ -105,7 +105,7 @@ let current_keeper_json ?(last_turn_ts = 0.0) ?(paused = false)
        ; ("last_proactive_outcome", `String "tool_use")
        ; ( "last_blocker"
          , Keeper_meta_contract.(
-             blocker_info_of_class ~detail:"queue full" Capacity_backpressure
+             blocker_info_of_class ~detail:blocker_detail Capacity_backpressure
              |> blocker_info_to_json) )
        ; ("created_at", `String "2026-08-20T01:02:03Z")
        ; ("updated_at", `String "2026-08-21T04:05:06Z")
@@ -172,6 +172,38 @@ let test_decode_keeper_zero_last_turn_is_empty () =
       Alcotest.(check string) "zero timestamp becomes empty" ""
         keeper.k_last_turn_ts
   | Error err -> Alcotest.fail err
+
+let test_terminal_text_escapes_control_sequences () =
+  let payload = "safe\027]0;owned\007\n\t\194\128done" in
+  Alcotest.(check string)
+    "C0, ESC, OSC terminator, and UTF-8 C1 are rendered inert"
+    "safe\\x1B]0;owned\\x07\\x0A\\x09\\u0080done"
+    (Tui_decode.sanitize_terminal_text payload)
+
+let test_terminal_text_preserves_printable_utf8 () =
+  Alcotest.(check string)
+    "printable UTF-8 survives"
+    "정상 blocker — café"
+    (Tui_decode.sanitize_terminal_text "정상 blocker — café")
+
+let test_keeper_blocker_terminal_boundary_keeps_raw_and_renders_safe () =
+  let detail = "queue\027]8;;https://attacker.invalid\007owned\027]8;;\007" in
+  match Tui_decode.decode_keeper (current_keeper_json ~blocker_detail:detail ()) with
+  | Error error -> Alcotest.fail error
+  | Ok keeper ->
+    Alcotest.(check bool)
+      "typed decode retains the raw diagnostic"
+      true
+      (Option.exists (fun raw -> String.contains raw '\027') keeper.k_last_blocker);
+    let rendered = Tui_decode.keeper_blocker_for_terminal keeper in
+    Alcotest.(check bool)
+      "terminal projection contains no ESC byte"
+      false
+      (String.contains rendered '\027');
+    Alcotest.(check bool)
+      "terminal projection exposes escaped control evidence"
+      true
+      (String_util.contains_substring rendered "\\x1B]8;;")
 
 let test_decode_keeper_rejects_retired_fields () =
   List.iter
@@ -477,6 +509,14 @@ let () =
           test_decode_planning_snapshot_current_contract;
         Alcotest.test_case "rejects running alias" `Quick
           test_decode_planning_snapshot_rejects_running_alias;
+      ] );
+    ( "terminal_text",
+      [ Alcotest.test_case "escapes control sequences" `Quick
+          test_terminal_text_escapes_control_sequences
+      ; Alcotest.test_case "preserves printable UTF-8" `Quick
+          test_terminal_text_preserves_printable_utf8
+      ; Alcotest.test_case "keeper blocker keeps raw and renders safe" `Quick
+          test_keeper_blocker_terminal_boundary_keeps_raw_and_renders_safe
       ] );
     ( "parse_log_entry",
       [

--- a/test/test_tui_http_ast.ml
+++ b/test/test_tui_http_ast.ml
@@ -64,28 +64,94 @@ let test_planning_constructors_do_not_collide () =
     (List.mem "Planning" surface_constructors)
 ;;
 
-let test_planning_status_is_closed_sum () =
-  let constructors =
-    Ast_grep.constructor_names_of_type
-      ~module_path:"bin/masc_tui_types.ml"
-      ~type_name:"planning_goal_status"
-  in
-  check (list string) "planning status constructors"
-    [
-      "Planning_goal_active";
-      "Planning_goal_paused";
-      "Planning_goal_done";
-      "Planning_goal_dropped";
-    ]
-    constructors;
+let test_planning_phase_uses_goal_ssot () =
+  check bool "projection parses the canonical goal phase" true
+    (Ast_grep.count_calls
+       ~module_path:"lib/tui_decode.ml"
+       ~callee:"Goal_phase.parse"
+     >= 1);
+  check bool "loader uses the behavioral planning decoder" true
+    (Ast_grep.count_calls
+       ~module_path:"bin/masc_tui_loader.ml"
+       ~callee:"Tui_decode.decode_planning_snapshot"
+     >= 1);
+  check bool "renderer labels the canonical goal phase" true
+    (Ast_grep.count_calls
+       ~module_path:"bin/masc_tui_render.ml"
+       ~callee:"Goal_phase.to_string"
+     >= 1);
   check int "renderer does not lowercase planning status strings" 0
     (Ast_grep.count_calls
        ~module_path:"bin/masc_tui_render.ml"
        ~callee:"String.lowercase_ascii");
-  check int "loader has an explicit unknown-status decode error" 1
+  check int "projection rejects an unknown canonical phase" 1
     (Ast_grep.count_string_literals
+       ~module_path:"lib/tui_decode.ml"
+       ~needle:"unknown planning goal phase")
+;;
+
+let test_tui_current_projection_wiring () =
+  check int "task loader is a named canonical-backlog projection" 1
+    (Ast_grep.count_value_bindings
        ~module_path:"bin/masc_tui_loader.ml"
-       ~needle:"unknown planning goal status")
+       ~name:"load_active_tasks");
+  check bool "task loader uses the canonical backlog observation" true
+    (Ast_grep.count_calls
+       ~module_path:"bin/masc_tui_loader.ml"
+       ~callee:"Workspace_backlog.read_backlog_observation_with_source_r"
+     >= 1);
+  check bool "loader uses the behavior-tested active task projection" true
+    (Ast_grep.count_calls
+       ~module_path:"bin/masc_tui_loader.ml"
+       ~callee:"Tui_decode.active_tasks_of_domain"
+     >= 1);
+  check int "task row projection has one domain boundary" 1
+    (Ast_grep.count_value_bindings
+       ~module_path:"lib/tui_decode.ml"
+       ~name:"task_of_domain");
+  check bool "keeper loader uses canonical persisted-name classification" true
+    (Ast_grep.count_calls
+       ~module_path:"bin/masc_tui_loader.ml"
+       ~callee:"Keeper_meta_store.persisted_keeper_names_result"
+     >= 1);
+  check bool "keeper loader uses the typed current-schema store" true
+    (Ast_grep.count_calls
+       ~module_path:"bin/masc_tui_loader.ml"
+       ~callee:"Keeper_meta_store.read_meta"
+     >= 1);
+  check bool "keeper loader projects typed metadata" true
+    (Ast_grep.count_calls
+       ~module_path:"bin/masc_tui_loader.ml"
+       ~callee:"Tui_decode.keeper_of_meta"
+     >= 1);
+  check bool "keeper metrics use the cluster-aware canonical path" true
+    (Ast_grep.count_calls
+       ~module_path:"bin/masc_tui_loader.ml"
+       ~callee:"Keeper_types_support.keeper_metrics_dir"
+     >= 1);
+  check int "retired planning running alias absent" 0
+    (Ast_grep.count_string_literals
+       ~module_path:"lib/tui_decode.ml"
+       ~needle:"running");
+  check int "verify appears only inside verifying_count" 1
+    (Ast_grep.count_string_literals
+       ~module_path:"lib/tui_decode.ml"
+       ~needle:"verify");
+  List.iter
+    (fun retired ->
+       check int ("retired keeper field absent: " ^ retired) 0
+         (Ast_grep.count_string_literals
+            ~module_path:"lib/tui_decode.ml"
+            ~needle:retired))
+    [ "active_goal_ids"
+    ; "active_model"
+    ; "models"
+    ; "proactive_enabled"
+    ; "initiative_enabled"
+    ; "trigger_mode"
+    ; "context_budget"
+    ; "drift_enabled"
+    ]
 ;;
 
 let test_overview_state_domains_are_closed_sum () =
@@ -177,10 +243,10 @@ let () =
           "planning constructors do not collide"
           `Quick
           test_planning_constructors_do_not_collide;
-        test_case
-          "planning status is closed-sum"
-          `Quick
-          test_planning_status_is_closed_sum;
+        test_case "planning phase uses goal SSOT" `Quick
+          test_planning_phase_uses_goal_ssot;
+        test_case "current projection wiring" `Quick
+          test_tui_current_projection_wiring;
         test_case
           "overview state domains are closed-sum"
           `Quick

--- a/test/test_tui_http_ast.ml
+++ b/test/test_tui_http_ast.ml
@@ -46,6 +46,81 @@ let test_keeper_chat_omits_removed_model_args () =
        ~needle:"/api/v1/keepers/chat/stream")
 ;;
 
+let test_operator_approvals_use_current_contract () =
+  check int "operator summary endpoint is exact" 1
+    (Ast_grep.count_string_literals
+       ~module_path:"bin/masc_tui_http.ml"
+       ~needle:
+         "/api/v1/operator?view=summary&include_messages=0&include_keepers=0");
+  check bool "loader uses exact operator projection" true
+    (Ast_grep.count_calls
+       ~module_path:"bin/masc_tui_loader.ml"
+       ~callee:"Masc_tui_operator_projection.decode_snapshot"
+     >= 1);
+  check bool "semantic action status is checked" true
+    (Ast_grep.count_calls
+       ~module_path:"bin/masc_tui_http.ml"
+       ~callee:"Masc_tui_operator_projection.decode_confirm_response"
+     >= 1);
+  check bool "submitted token is bound into response validation" true
+    (Ast_grep.count_calls_with_label
+       ~module_path:"bin/masc_tui_http.ml"
+       ~callee:"Masc_tui_operator_projection.decode_confirm_response"
+       ~label:"expected_token"
+     >= 1);
+  check bool "submitted decision is bound into response validation" true
+    (Ast_grep.count_calls_with_label
+       ~module_path:"bin/masc_tui_http.ml"
+       ~callee:"Masc_tui_operator_projection.decode_confirm_response"
+       ~label:"expected_decision"
+     >= 1);
+  check bool "HTTP refresh and action reconciliation reload approvals" true
+    (Ast_grep.count_calls
+       ~module_path:"bin/masc_tui.ml"
+       ~callee:"load_approvals"
+     >= 2);
+  check bool "refreshes reserve an approval generation" true
+    (Ast_grep.count_calls
+       ~module_path:"bin/masc_tui.ml"
+       ~callee:"Approval.Flow.reserve_refresh"
+     >= 1);
+  check bool "actions invalidate older approval generations" true
+    (Ast_grep.count_calls
+       ~module_path:"bin/masc_tui.ml"
+       ~callee:"Approval.Flow.begin_action"
+     >= 1);
+  check bool "only the owning action completion clears inflight state" true
+    (Ast_grep.count_calls
+       ~module_path:"bin/masc_tui.ml"
+       ~callee:"Approval.Flow.finish_action"
+     >= 1);
+  check bool "approval input uses the behavior-tested two-key gate" true
+    (Ast_grep.count_calls
+       ~module_path:"bin/masc_tui.ml"
+       ~callee:"Approval.approval_gate_transition"
+     >= 1);
+  check int "deferred confirmation has truthful operator copy" 1
+    (Ast_grep.count_string_literals
+       ~module_path:"bin/masc_tui.ml"
+       ~needle:"Confirmation accepted; action deferred: %s");
+  check int "execution failure preserves accepted confirmation" 1
+    (Ast_grep.count_string_literals
+       ~module_path:"bin/masc_tui.ml"
+       ~needle:"Confirmation accepted; action failed: %s");
+  check int "transport failure remains unverified" 1
+    (Ast_grep.count_string_literals
+       ~module_path:"bin/masc_tui.ml"
+       ~needle:"Confirmation outcome unverified");
+  check int "payload has its own visible row" 1
+    (Ast_grep.count_string_literals
+       ~module_path:"bin/masc_tui_render.ml"
+       ~needle:"  %spayload=%s%s");
+  check int "briefing is not an approval source" 0
+    (Ast_grep.count_string_literals
+       ~module_path:"bin/masc_tui_loader.ml"
+       ~needle:"pending_confirms")
+;;
+
 let test_planning_constructors_do_not_collide () =
   let module_path = "bin/masc_tui_types.ml" in
   let planning_mode_constructors =
@@ -239,6 +314,10 @@ let () =
           "keeper chat omits removed model args"
           `Quick
           test_keeper_chat_omits_removed_model_args;
+        test_case
+          "operator approvals use current contract"
+          `Quick
+          test_operator_approvals_use_current_contract;
         test_case
           "planning constructors do not collide"
           `Quick

--- a/test/test_tui_operator_projection.ml
+++ b/test/test_tui_operator_projection.ml
@@ -1,0 +1,271 @@
+open Alcotest
+
+module Projection = Masc_tui_operator_projection
+
+let string_option_to_json = function
+  | Some value -> `String value
+  | None -> `Null
+
+let approval_item_json ?(action_type = "namespace_pause")
+    ?(target_type = "workspace") ?(target_id = None)
+    ?(delegated_tool = "masc_pause")
+    ?(expires_at = Some "2026-08-21T12:15:00Z")
+    ?(actor = "masc-tui") ?trace_id token =
+  let trace_id = Option.value ~default:("trace-" ^ token) trace_id in
+  `Assoc
+    [ "confirm_token", `String token
+    ; "trace_id", `String trace_id
+    ; "actor", `String actor
+    ; "action_type", `String action_type
+    ; "target_type", `String target_type
+    ; "target_id", string_option_to_json target_id
+    ; "payload", `Assoc [ "reason", `String "operator requested" ]
+    ; "delegated_tool", `String delegated_tool
+    ; "created_at", `String "2026-08-21T12:00:00Z"
+    ; "expires_at", string_option_to_json expires_at
+    ]
+
+let default_items () =
+  [ approval_item_json "token-pause"
+  ; approval_item_json ~action_type:"keeper_probe"
+      ~target_type:"keeper" ~target_id:(Some "keeper.one")
+      ~delegated_tool:"masc_keeper_status" ~expires_at:None
+      "token-probe"
+  ]
+
+let snapshot_json ?(actor_filter = Some "masc-tui") ?(filter_active = true)
+    ?(visible_count = 2) ?(total_count = 3) ?(hidden_count = 1)
+    ?items ?(hidden_actors = Some [ `String "other-agent" ])
+    ?(confirm_required_actions = Some [ `Assoc [] ]) () =
+  let items = Option.value ~default:(default_items ()) items in
+  let optional_field name = Option.map (fun value -> name, `List value) in
+  let summary_fields =
+    [ Some ("actor_filter", string_option_to_json actor_filter)
+    ; Some ("filter_active", `Bool filter_active)
+    ; Some ("visible_count", `Int visible_count)
+    ; Some ("total_count", `Int total_count)
+    ; Some ("hidden_count", `Int hidden_count)
+    ; optional_field "hidden_actors" hidden_actors
+    ; optional_field "confirm_required_actions" confirm_required_actions
+    ]
+    |> List.filter_map Fun.id
+  in
+  `Assoc
+    [ ( "pending_confirm_envelope"
+      , `Assoc
+          [ "items", `List items; "summary", `Assoc summary_fields ] )
+    ]
+
+let test_current_contract () =
+  match Projection.decode_snapshot (snapshot_json ()) with
+  | Error err -> fail err
+  | Ok snapshot ->
+      check int "visible count" 2 snapshot.aps_visible_count;
+      check int "total count" 3 snapshot.aps_total_count;
+      check int "hidden count" 1 snapshot.aps_hidden_count;
+      check (option string) "actor scope" (Some "masc-tui")
+        snapshot.aps_actor_filter;
+      check bool "filter active" true snapshot.aps_filter_active;
+      (match snapshot.aps_items with
+       | pause :: probe :: [] ->
+           check string "pause token" "token-pause" pause.ap_token;
+           check (option string) "workspace target id" None pause.ap_target_id;
+           check (option string) "pause expiry"
+             (Some "2026-08-21T12:15:00Z") pause.ap_expires_at;
+           check string "payload" {|{"reason":"operator requested"}|}
+             (Yojson.Safe.to_string pause.ap_payload);
+           check (option string) "keeper target" (Some "keeper.one")
+             probe.ap_target_id;
+           check (option string) "nullable expiry" None probe.ap_expires_at
+       | _ -> fail "expected two approval items")
+
+let test_fails_closed () =
+  let malformed =
+    [ `Assoc []
+    ; `Assoc [ "pending_confirm_envelope", `Null ]
+    ; `Assoc
+        [ ( "pending_confirm_envelope"
+          , `Assoc [ "items", `String "not-a-list"; "summary", `Assoc [] ] )
+        ]
+    ; snapshot_json ~visible_count:1 ()
+    ; snapshot_json ~total_count:4 ()
+    ; snapshot_json ~actor_filter:None ()
+    ; snapshot_json ~filter_active:false ()
+    ; snapshot_json ~visible_count:(-1) ()
+    ; snapshot_json
+        ~items:
+          [ approval_item_json "duplicate"
+          ; approval_item_json "duplicate"
+          ]
+        ()
+    ; snapshot_json
+        ~items:
+          [ approval_item_json "token-pause"
+          ; approval_item_json ~actor:"other-agent" "token-probe"
+          ]
+        ()
+    ; snapshot_json ~hidden_actors:None ()
+    ; snapshot_json ~hidden_actors:(Some [ `Int 1 ]) ()
+    ; snapshot_json ~confirm_required_actions:None ()
+    ; snapshot_json ~confirm_required_actions:(Some [ `String "bad" ]) ()
+    ]
+  in
+  List.iteri
+    (fun index json ->
+      check bool (Printf.sprintf "malformed snapshot %d rejected" index) true
+        (Result.is_error (Projection.decode_snapshot json)))
+    malformed
+
+let confirm_response ?(status = "ok") ?(decision = "confirm")
+    ?(token = "token-pause") ?trace_id ?tool_name ?(include_result = true)
+    ?executed_trace_id ?result_status () =
+  let trace_id = Option.value ~default:("trace-" ^ token) trace_id in
+  let executed_trace_id = Option.value ~default:trace_id executed_trace_id in
+  let tool_name = Option.value ~default:"masc_pause" tool_name in
+  let fields =
+    [ Some ("status", `String status)
+    ; Some ("trace_id", `String trace_id)
+    ; Some ("decision", `String decision)
+    ; Some ("tool_name", `String tool_name)
+    ; (if include_result then Some ("result", `Assoc []) else None)
+    ; Option.map (fun value -> "result_status", `String value) result_status
+    ; Some
+        ( "executed_action"
+        , approval_item_json ~trace_id:executed_trace_id
+            ~delegated_tool:tool_name token )
+    ]
+    |> List.filter_map Fun.id
+  in
+  `Assoc fields
+
+let decode_confirm ?(token = "token-pause") decision json =
+  Projection.decode_confirm_response ~expected_token:token
+    ~expected_decision:decision json
+
+let test_confirm_response_status () =
+  (match decode_confirm Projection.Confirm (confirm_response ()) with
+   | Ok (Projection.Completed _) -> ()
+   | Ok (Projection.Deferred _ | Projection.Execution_failed _) ->
+       fail "ok response misclassified"
+   | Error err -> fail err);
+  (match
+     decode_confirm Projection.Confirm (confirm_response ~status:"deferred" ())
+   with
+   | Ok (Projection.Deferred _) -> ()
+   | Ok (Projection.Completed _ | Projection.Execution_failed _) ->
+       fail "deferred response misclassified"
+   | Error err -> fail err);
+  (match
+     decode_confirm Projection.Confirm
+       (confirm_response ~status:"error" ())
+   with
+   | Ok (Projection.Execution_failed _) -> ()
+   | Ok (Projection.Completed _ | Projection.Deferred _) ->
+       fail "execution error misclassified"
+   | Error err -> fail err);
+  check bool "deny accepted" true
+    (Result.is_ok
+       (decode_confirm Projection.Deny
+          (confirm_response ~decision:"deny" ~include_result:false
+             ~result_status:"not_executed" ())));
+  List.iter
+    (fun json ->
+      check bool "non-success status rejected" true
+        (Result.is_error (decode_confirm Projection.Confirm json)))
+    [ `Assoc [ "status", `String "error"; "message", `String "failed" ]
+    ; `Assoc [ "status", `String "unknown" ]
+    ; `Assoc []
+    ; `Assoc [ "status", `String "ok" ]
+    ; confirm_response ~decision:"deny" ()
+    ; confirm_response ~token:"other-token" ()
+    ; confirm_response ~trace_id:"other-trace"
+        ~executed_trace_id:"trace-token-pause" ()
+    ; confirm_response ~tool_name:"masc_other" ()
+    ; confirm_response ~include_result:false ()
+    ]
+
+let test_deny_response_fails_closed () =
+  List.iter
+    (fun json ->
+      check bool "invalid deny response rejected" true
+        (Result.is_error (decode_confirm Projection.Deny json)))
+    [ confirm_response ~status:"deferred" ~decision:"deny"
+        ~include_result:false ~result_status:"not_executed" ()
+    ; confirm_response ~decision:"deny" ~include_result:false ()
+    ; confirm_response ~decision:"deny" ~include_result:false
+        ~result_status:"executed" ()
+    ]
+
+let test_approval_flow_rejects_stale_results () =
+  let flow, old_generation = Projection.Flow.reserve_refresh Projection.Flow.initial in
+  let old_generation = Option.get old_generation in
+  let flow, action_generation =
+    match Projection.Flow.begin_action flow with
+    | Ok value -> value
+    | Error `Already_inflight -> fail "first action unexpectedly in flight"
+  in
+  check bool "pre-action refresh is stale" false
+    (Projection.Flow.is_current flow old_generation);
+  check bool "action generation is current" true
+    (Projection.Flow.is_current flow action_generation);
+  let unchanged, refresh = Projection.Flow.reserve_refresh flow in
+  check bool "refresh suppressed during action" true (Option.is_none refresh);
+  check bool "action remains in flight" true
+    (Projection.Flow.action_inflight unchanged);
+  let unchanged, owned = Projection.Flow.finish_action flow old_generation in
+  check bool "stale completion does not own action" false owned;
+  check bool "stale completion cannot clear action" true
+    (Projection.Flow.action_inflight unchanged);
+  let finished, owned = Projection.Flow.finish_action unchanged action_generation in
+  check bool "current completion owns action" true owned;
+  check bool "current completion clears action" false
+    (Projection.Flow.action_inflight finished)
+
+let test_two_key_gate () =
+  let armed =
+    match
+      Projection.approval_gate_transition ~inflight:false ~pending:None
+        ~token:"token-pause" ~decision:Projection.Confirm
+    with
+    | Projection.Gate_arm pending -> pending
+    | Projection.Gate_blocked_inflight | Projection.Gate_submit ->
+        fail "first key did not arm"
+  in
+  (match
+     Projection.approval_gate_transition ~inflight:false ~pending:(Some armed)
+       ~token:"token-pause" ~decision:Projection.Confirm
+   with
+   | Projection.Gate_submit -> ()
+   | Projection.Gate_blocked_inflight | Projection.Gate_arm _ ->
+       fail "matching second key did not submit");
+  (match
+     Projection.approval_gate_transition ~inflight:false ~pending:(Some armed)
+       ~token:"token-pause" ~decision:Projection.Deny
+   with
+   | Projection.Gate_arm pending ->
+       check bool "opposite decision re-arms" true
+         (pending.paa_decision = Projection.Deny)
+   | Projection.Gate_blocked_inflight | Projection.Gate_submit ->
+       fail "opposite decision submitted");
+  (match
+     Projection.approval_gate_transition ~inflight:true ~pending:(Some armed)
+       ~token:"token-pause" ~decision:Projection.Confirm
+   with
+   | Projection.Gate_blocked_inflight -> ()
+   | Projection.Gate_arm _ | Projection.Gate_submit ->
+       fail "inflight key was not blocked")
+
+let () =
+  run "tui_operator_projection"
+    [ ( "operator approvals"
+      , [ test_case "current contract" `Quick test_current_contract
+        ; test_case "fails closed" `Quick test_fails_closed
+        ; test_case "semantic confirm status" `Quick
+            test_confirm_response_status
+        ; test_case "deny response fails closed" `Quick
+            test_deny_response_fails_closed
+        ; test_case "stale request generations" `Quick
+            test_approval_flow_rejects_stale_results
+        ; test_case "two-key safety gate" `Quick test_two_key_gate
+        ] )
+    ]


### PR DESCRIPTION
Stacked on #29311. Review this PR after its parent.

## Summary
- read the exact actor-scoped Operator pending-confirm envelope and fail closed on missing, unscoped, or drifted data
- bind confirm/deny responses to the submitted token and decision, distinguish completed, deferred, execution-failed, and unverified outcomes
- serialize approval refresh/action generations so stale observations cannot resurrect consumed rows
- make the two-key safety gate and in-flight state visible, and show action payload evidence at 80 columns
- invalidate Operator and Dashboard snapshot caches at pending-confirm mutation boundaries

## Focused validation
- scripts/dune-local.sh build bin/masc_tui.exe test/test_tui_decode.exe test/test_tui_operator_projection.exe test/test_tui_http_ast.exe test/test_operator_control_actions.exe
- test_tui_decode: 25/25
- test_tui_operator_projection: 6/6
- test_tui_http_ast: 10/10
- test_operator_control_actions: 8/8
- ocamlformat --check
- git diff --check

## Live read-only evidence
The local server returned an actor-filtered masc-tui envelope with filter_active=true and visible=total=hidden=0; no mutation was performed.