### PR TITLE
fix(verifier): retry transient completion reviews

### DIFF
--- a/lib/completion_authority_agent.ml
+++ b/lib/completion_authority_agent.ml
@@ -299,15 +299,21 @@ let prepare_review
 type process_outcome =
   | Committed
   | Deferred
+  | Retryable_deferred
 
-let defer ~task_id ~verification_id ~authority ~reason () =
+let process_outcome_of_evaluator_retryable = function
+  | Some true -> Retryable_deferred
+  | Some false | None -> Deferred
+;;
+
+let defer ?(evaluator_retryable = None) ~task_id ~verification_id ~authority ~reason () =
   Log.Misc.warn
     "system LLM completion authority deferred task_id=%s verification_id=%s authority=%s reason=%s"
     task_id
     verification_id
     (Masc_domain.completion_authority_actor authority)
     reason;
-  Deferred
+  process_outcome_of_evaluator_retryable evaluator_retryable
 ;;
 
 let observe_rejection_wakeup
@@ -563,7 +569,13 @@ let process_task_once
            ~detail;
          complete
            ~evaluator_runtime
-           ( defer ~task_id:task.id ~verification_id ~authority ~reason:detail ()
+           ( defer
+               ~evaluator_retryable:result.evaluator_error_retryable
+               ~task_id:task.id
+               ~verification_id
+               ~authority
+               ~reason:detail
+               ()
            , Verification_run_registry.Not_reviewed { gate; detail } )
        | Some review_verdict ->
          let verdict = completion_verdict_of_review review_verdict in
@@ -621,18 +633,26 @@ let process_task (runtime : runtime) (task : Masc_domain.task) ~assignee ~verifi
   let key = { task_id = task.id; verification_id } in
   if claim_review runtime key
   then (
-    (* The outcome is already durable where it belongs: the run registry, and
-       for a review that committed no verdict the Board post as well. Nothing
-       here re-arms a timer — that outcome is a fact for the producer Keeper
-       to act on, and its resubmission is what rescans the backlog. The
-       annotated binding keeps that discard deliberate: a future outcome the
-       caller must handle changes this line's type. *)
-    let (_ : process_outcome) =
+    (* A retryable evaluator failure has no producer action that can legally
+       advance the Task: it is still [AwaitingVerification]. Re-arm the
+       application-owned scan after the durable run/Board observation is
+       recorded. Non-retryable deferrals keep the existing producer/operator
+       contract, and restart recovery still comes from [start]'s initial
+       pending scan. *)
+    let outcome =
       Fun.protect
         ~finally:(fun () -> release_review runtime key)
         (fun () -> process_task_once runtime task ~assignee ~verification_id)
     in
-    ())
+    match outcome with
+    | Retryable_deferred ->
+      Log.Misc.info
+        "system LLM completion authority scheduled retry task_id=%s verification_id=%s interval_sec=%.1f"
+        task.id
+        verification_id
+        runtime.retry_interval_sec;
+      schedule_retry runtime
+    | Committed | Deferred -> ())
   else
     Log.Misc.debug
       "system LLM completion authority skipped duplicate in-flight review task_id=%s verification_id=%s"
@@ -753,5 +773,9 @@ module For_testing = struct
   type nonrec process_outcome = process_outcome =
     | Committed
     | Deferred
+    | Retryable_deferred
+
+  let process_outcome_of_evaluator_retryable =
+    process_outcome_of_evaluator_retryable
 
 end

--- a/lib/completion_authority_agent.mli
+++ b/lib/completion_authority_agent.mli
@@ -31,8 +31,15 @@ module For_testing : sig
 
   (** How one review attempt ended. [Deferred] carries no payload: a review
       that did not commit a verdict is reported to the Board and the producer
-      Keeper chooses what happens next. *)
+      Keeper chooses what happens next. [Retryable_deferred] means the typed
+      evaluator error was retryable and the application-owned lane must
+      re-arm its maintenance scan while the Task stays awaiting verification. *)
   type process_outcome =
     | Committed
     | Deferred
+    | Retryable_deferred
+
+  val process_outcome_of_evaluator_retryable : bool option -> process_outcome
+  (** [Some true] is the only automatic-retry authority. [Some false] and
+      [None] preserve the producer/operator action contract. *)
 end

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -312,6 +312,20 @@ let test_system_llm_authority_helpers_are_typed () =
     Alcotest.(check string) "typed rejection reason" "missing evidence" reason
   | Masc_domain.Verdict_approved -> Alcotest.fail "reject must remain a rejection"
 
+let test_system_llm_retry_disposition_is_typed () =
+  let module For_testing = Masc.Completion_authority_agent.For_testing in
+  (match For_testing.process_outcome_of_evaluator_retryable (Some true) with
+   | For_testing.Retryable_deferred -> ()
+   | For_testing.Committed | For_testing.Deferred ->
+     Alcotest.fail "typed retryable evaluator failure must re-arm the lane");
+  List.iter
+    (fun retryable ->
+       match For_testing.process_outcome_of_evaluator_retryable retryable with
+       | For_testing.Deferred -> ()
+       | For_testing.Committed | For_testing.Retryable_deferred ->
+         Alcotest.fail "non-retryable or unclassified deferral must await action")
+    [ Some false; None ]
+
 let test_system_llm_review_notes_are_metadata_only () =
   let request : V.verification_request =
     { id = "vrf-metadata-only"
@@ -2423,6 +2437,8 @@ let () =
     "completion_authority", [
       Alcotest.test_case "system LLM helpers keep typed facts" `Quick
         test_system_llm_authority_helpers_are_typed;
+      Alcotest.test_case "system LLM retry disposition is typed" `Quick
+        test_system_llm_retry_disposition_is_typed;
       Alcotest.test_case "system LLM notes keep metadata only" `Quick
         test_system_llm_review_notes_are_metadata_only;
       Alcotest.test_case "unreadable evidence uses structured current contract" `Quick


### PR DESCRIPTION
## Summary
- classify a no-verdict completion review as `Retryable_deferred` only when the typed evaluator result says `Some true`
- re-arm the application-owned maintenance scan after the durable deferred observation while the Task remains `AwaitingVerification`
- preserve existing producer/operator action semantics for `Some false` and `None`; restart recovery continues through the startup pending scan

## Exact protected-main evidence
- source: `a67038505534837f175c4e0a10c6d1a35802e83a`
- workflow run: `32488329492`
- evidence artifact: `9450333174`
- RW23 first artifact was independently rejected (`vrf-589ed90543974f765c021566f951976b`)
- corrected artifact submission created `vrf-f84164400a0186da0558548354035bed`; deepseek was unauthorized and GLM returned typed retryable 429
- current code durably deferred the Task but explicitly did not re-arm a timer, so it stayed nonterminal for the full harness wait

## Checks
- `ocamlformat --check`
- `ocamlc -stop-after parsing` for changed ML/MLI/test
- OCaml structure ratchet
- stringly-boundary ratchet
- HITL exact-flow boundary
- Keeper tool-boundary matrix
- silent-failure ratchet
- `git diff --check`

CI remains compile/test authority; no local Dune build.