### PR TITLE
fix(verifier): preserve retryable lane failures

### DIFF
--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -404,8 +404,11 @@ let review
           compaction lanes: each slot is tried at most once, in declaration
           order, and a slot that produces no usable verdict — provider error or
           a reply without exactly one valid verdict tool call — yields to the
-          next slot. The terminal result describes the last attempt, so a
-          single-slot lane reports exactly what the pre-lane path reported. *)
+          next slot. The terminal runtime/reason describes the last attempt,
+          while retryability aggregates every typed evaluator error: one
+          transient slot must not be masked by a later statically unavailable
+          fallback. A single-slot lane still reports exactly what the pre-lane
+          path reported. *)
        let run_attempt slot =
          try
            (Atomic.get run_llm_reviewer_fn)
@@ -426,7 +429,7 @@ let review
                    "task completion evaluator raised unexpectedly: %s"
                    (Printexc.to_string exn)))
        in
-       let rec attempt slot remaining =
+       let rec attempt ~retryable_error_seen slot remaining =
          match run_attempt slot with
          | Ok (Some verdict) ->
            (match verdict with
@@ -461,7 +464,7 @@ let review
                 detail
                 slot
                 next;
-              attempt next rest
+              attempt ~retryable_error_seen next rest
             | [] ->
               task_warn "[task-completion-review] %s" detail;
               emit
@@ -470,7 +473,8 @@ let review
                 ; generator_runtime
                 ; gate = Invalid_verdict
                 ; fallback_reason = Some detail
-                ; evaluator_error_retryable = None
+                ; evaluator_error_retryable =
+                    (if retryable_error_seen then Some true else None)
                 })
          | Error error ->
            let detail = Agent_core.Error.to_string error in
@@ -486,12 +490,16 @@ let review
                 retryable
                 next
                 detail;
-              attempt next rest
+              attempt
+                ~retryable_error_seen:(retryable_error_seen || retryable)
+                next
+                rest
             | [] ->
+              let exhausted_retryable = retryable_error_seen || retryable in
               task_warn
                 "[task-completion-review] evaluator unavailable runtime=%s retryable=%b; task remains nonterminal: %s"
                 slot
-                retryable
+                exhausted_retryable
                 detail;
               emit
                 { verdict = None
@@ -499,8 +507,9 @@ let review
                 ; generator_runtime
                 ; gate = Evaluator_unavailable
                 ; fallback_reason = Some detail
-                ; evaluator_error_retryable = Some retryable
+                ; evaluator_error_retryable =
+                    Some exhausted_retryable
                 })
        in
-       attempt first_slot rest_slots)
+       attempt ~retryable_error_seen:false first_slot rest_slots)
 ;;

--- a/lib/task/anti_rationalization.mli
+++ b/lib/task/anti_rationalization.mli
@@ -73,17 +73,16 @@ type review_result =
   ; gate : gate
   ; fallback_reason : string option
   ; evaluator_error_retryable : bool option
-        (** [Some b] only where a typed {!Agent_core.Error.t} existed to
-            classify — the [Error error] arm of [run_llm_reviewer_fn] — and
-            [b] is then [Agent_core.Error.is_retryable error]. [None]
-            everywhere else: a produced verdict, a reply without exactly one
-            verdict tool call, a prompt or slot resolution failure. [None] is
-            not "retry": nothing about those outcomes says a repeat of the
-            same request would end differently, and a caller that wants to
-            repeat one must say so on its own evidence. This was a plain
-            [bool] defaulting to [true], which is why an [Invalid_verdict]
-            review re-ran on the maintenance pulse forever without telling
-            anyone. *)
+        (** [Some true] when a verdict-less exhausted lane observed at least
+            one typed retryable {!Agent_core.Error.t}; a later non-retryable
+            fallback cannot mask that transient candidate. [Some false] when
+            typed evaluator errors existed but all were non-retryable. [None]
+            for a produced verdict, an invalid-verdict-only reply, or a prompt
+            or slot resolution failure. [None] is not "retry": nothing about
+            those outcomes says a repeat of the same request would end
+            differently. This was once a plain [bool] defaulting to [true],
+            which is why an [Invalid_verdict] review re-ran on the maintenance
+            pulse forever without telling anyone. *)
   }
 
 val review

--- a/test/test_verifier_exact_lane.ml
+++ b/test/test_verifier_exact_lane.ml
@@ -133,7 +133,7 @@ let test_invalid_verdict_fails_over () =
        | None -> Alcotest.fail "failover lost the second slot's verdict")
 ;;
 
-let test_exhaustion_reports_the_last_attempt () =
+let test_exhaustion_preserves_any_retryable_attempt () =
   let calls = ref [] in
   with_lane_and_reviewer
     ~slots:(fun () -> Ok [ "slot-a"; "slot-b" ])
@@ -151,10 +151,27 @@ let test_exhaustion_reports_the_last_attempt () =
          "slot-b"
          result.evaluator_runtime;
        Alcotest.(check (option bool))
-         "the last attempt's non-retryable classification wins"
-         (Some false)
+         "a transient slot is not masked by a later non-retryable fallback"
+         (Some true)
          result.evaluator_error_retryable;
        Alcotest.(check bool) "no fabricated verdict" true (Option.is_none result.verdict))
+;;
+
+let test_exhaustion_reports_all_nonretryable_attempts () =
+  let calls = ref [] in
+  with_lane_and_reviewer
+    ~slots:(fun () -> Ok [ "slot-a"; "slot-b" ])
+    ~reviewer:
+      (recording_reviewer
+         calls
+         [ "slot-a", budget_refusal; "slot-b", budget_refusal ])
+    (fun () ->
+       let result = review () in
+       Alcotest.(check (list string)) "both slots tried" [ "slot-a"; "slot-b" ] !calls;
+       Alcotest.(check (option bool))
+         "all typed evaluator errors are non-retryable"
+         (Some false)
+         result.evaluator_error_retryable)
 ;;
 
 let test_unconfigured_lane_is_unavailable_not_rerouted () =
@@ -316,9 +333,13 @@ let () =
             `Quick
             test_invalid_verdict_fails_over
         ; Alcotest.test_case
-            "exhaustion reports the last attempt"
+            "exhaustion preserves any retryable attempt"
             `Quick
-            test_exhaustion_reports_the_last_attempt
+            test_exhaustion_preserves_any_retryable_attempt
+        ; Alcotest.test_case
+            "exhaustion reports all non-retryable attempts"
+            `Quick
+            test_exhaustion_reports_all_nonretryable_attempts
         ; Alcotest.test_case
             "unconfigured lane is unavailable, not rerouted"
             `Quick


### PR DESCRIPTION
## Summary
- aggregate typed evaluator retryability across the entire frozen verifier_exact ladder when no verdict is produced
- preserve the last attempted runtime and failure reason for diagnostics while preventing a later static/unavailable fallback from masking an earlier transient slot
- keep invalid-only exhaustion as `None` and all-nonretryable typed errors as `Some false`

## Exact protected-main evidence
- source: `61e2f04b7fb69a6662edcfc6c103208bcbc518f4`
- workflow run: `32495075086`
- evidence artifact: `9452587557`
- verifier Goal criterion run exhausted deepseek 401, GLM 429, then terminal deepseek 401
- the pre-fix result copied only the last error and emitted `retryable=false`, so the durable criterion row remained pending for the full 5-minute wait
- #29318 already re-arms the maintenance pulse when the typed result is retryable; this PR preserves that authority across lane failover

## Checks
- `ocamlformat --check`
- `ocamlc -stop-after parsing` for changed ML/MLI/test
- OCaml structure ratchet
- stringly-boundary ratchet
- HITL exact-flow boundary
- Keeper tool-boundary matrix
- silent-failure ratchet
- `git diff --check`

CI remains compile/test authority; no local Dune build.