### PR TITLE
fix(tui): project current Keeper observations

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -224,6 +224,18 @@
  (libraries masc.masc_core))
 
 (library
+ (name masc_tui_context_state)
+ (wrapped false)
+ (modules masc_tui_context_state)
+ (libraries masc masc.masc_workspace yojson))
+
+(library
+ (name masc_tui_observation_layout)
+ (wrapped false)
+ (modules masc_tui_observation_layout)
+ (libraries masc))
+
+(library
  (name masc_tui_render_schedule)
  (wrapped false)
  (modules masc_tui_render_schedule))
@@ -241,8 +253,10 @@
  (package masc)
  (libraries
   masc
+  masc_tui_context_state
   masc_tui_keeper_chat_projection
   masc_tui_message_layout
+  masc_tui_observation_layout
   masc_tui_operator_projection
   masc_tui_render_schedule
   masc.dashboard

--- a/bin/masc_tui.ml
+++ b/bin/masc_tui.ml
@@ -1007,7 +1007,7 @@ let main () =
                 if state.keeper_cursor < List.length state.keepers - 1 then begin
                   state.keeper_cursor <- state.keeper_cursor + 1;
                   (match List.nth_opt state.keepers state.keeper_cursor with
-                   | Some k -> load_live_context state base_path k.k_name
+                   | Some k -> load_live_context state base_path k
                    | None -> ())
                 end
             | Keepers Keeper_detail ->
@@ -1046,7 +1046,7 @@ let main () =
                 if state.keeper_cursor > 0 then begin
                   state.keeper_cursor <- state.keeper_cursor - 1;
                   (match List.nth_opt state.keepers state.keeper_cursor with
-                   | Some k -> load_live_context state base_path k.k_name
+                   | Some k -> load_live_context state base_path k
                    | None -> ())
                 end
             | Keepers Keeper_detail ->
@@ -1085,7 +1085,7 @@ let main () =
                  | Some k ->
                      state.view <- Keepers Keeper_detail;
                      state.detail_scroll <- 0;
-                     load_live_context state base_path k.k_name
+                     load_live_context state base_path k
                  | None -> ())
             | Board ->
                 (match state.board_mode with

--- a/bin/masc_tui_context_state.ml
+++ b/bin/masc_tui_context_state.ml
@@ -1,0 +1,28 @@
+module Decode = Masc.Tui_decode
+module Projection = Masc.Keeper_context_observation_projection
+
+type t = {
+  observation : Decode.context_observation option;
+  error : string option;
+}
+
+let empty = { observation = None; error = None }
+
+let resolve_with ~project (keeper : Decode.keeper) =
+  let json =
+    project ~keeper_name:keeper.k_name ~current_trace_id:keeper.k_trace_id
+    |> fun fields -> `Assoc fields
+  in
+  match
+    Decode.decode_context_observation ~expected_trace_id:keeper.k_trace_id json
+  with
+  | Ok observation -> { observation = Some observation; error = None }
+  | Error error -> { observation = None; error = Some error }
+
+let load ~config =
+  resolve_with ~project:(fun ~keeper_name ~current_trace_id ->
+      Projection.context_fields ~config ~keeper_name ~current_trace_id)
+
+let for_selection ~load = function
+  | Some keeper -> load keeper
+  | None -> empty

--- a/bin/masc_tui_context_state.mli
+++ b/bin/masc_tui_context_state.mli
@@ -1,0 +1,19 @@
+module Decode = Masc.Tui_decode
+
+type t = {
+  observation : Decode.context_observation option;
+  error : string option;
+}
+
+val empty : t
+
+val resolve_with :
+  project:
+    (keeper_name:string ->
+    current_trace_id:string ->
+    (string * Yojson.Safe.t) list) ->
+  Decode.keeper ->
+  t
+
+val load : config:Workspace_core.config -> Decode.keeper -> t
+val for_selection : load:(Decode.keeper -> t) -> Decode.keeper option -> t

--- a/bin/masc_tui_loader.ml
+++ b/bin/masc_tui_loader.ml
@@ -3,6 +3,7 @@
 module Keeper_meta_store = Masc.Keeper_meta_store
 module Keeper_types_support = Masc.Keeper_types_support
 module Keeper_types_profile = Masc.Keeper_types_profile
+module Context_state = Masc_tui_context_state
 
 open Masc_tui_types
 open Tui_decode
@@ -141,36 +142,20 @@ let load_keeper_logs (base_path : string) (keeper_name : string) (max_entries : 
   if len <= max_entries then all
   else List.filteri (fun i _ -> i >= len - max_entries) all
 
-(** Load live context status from the latest metrics entry *)
-let load_live_context (state : state) (base_path : string) (keeper_name : string) =
-  let files = find_metrics_files base_path keeper_name in
-  match files with
-  | [] ->
-    state.live_context_ratio <- 0.0;
-    state.live_context_tokens <- 0;
-    state.live_context_max <- 0;
-    state.live_message_count <- 0
-  | latest_file :: _ ->
-    (* Read just the last line *)
-    let lines = read_last_lines latest_file 1 in
-    (match lines with
-     | [] ->
-       state.live_context_ratio <- 0.0;
-       state.live_context_tokens <- 0;
-       state.live_context_max <- 0;
-       state.live_message_count <- 0
-     | line :: _ ->
-       match parse_log_entry line with
-       | None ->
-         state.live_context_ratio <- 0.0;
-         state.live_context_tokens <- 0;
-         state.live_context_max <- 0;
-         state.live_message_count <- 0
-       | Some e ->
-         state.live_context_ratio <- e.le_context_ratio;
-         state.live_context_tokens <- e.le_context_tokens;
-         state.live_context_max <- e.le_context_max;
-         state.live_message_count <- e.le_message_count)
+(** Apply one exclusive context projection to the mutable screen state. *)
+let apply_live_context_state (state : state) (context_state : Context_state.t) =
+  state.live_context <- context_state.observation;
+  state.live_context_error <- context_state.error
+
+(** Load trace-scoped context occupancy from its current TurnRecord SSOT. *)
+let load_selected_live_context (state : state) (base_path : string)
+    (keeper : keeper option) =
+  let config = Workspace_core.default_config base_path in
+  Context_state.for_selection ~load:(Context_state.load ~config) keeper
+  |> apply_live_context_state state
+
+let load_live_context state base_path keeper =
+  load_selected_live_context state base_path (Some keeper)
 
 (** Load state from .masc directory *)
 let load_from_masc_dir (state : state) (base_path : string) =
@@ -232,10 +217,8 @@ let load_from_masc_dir (state : state) (base_path : string) =
      | None -> min state.keeper_cursor (max 0 (List.length state.keepers - 1)));
 
   (* Load live context for selected keeper *)
-  if state.keeper_cursor < List.length state.keepers then begin
-    let k = List.nth state.keepers state.keeper_cursor in
-    load_live_context state base_path k.k_name
-  end;
+  load_selected_live_context state base_path
+    (List.nth_opt state.keepers state.keeper_cursor);
 
   state.last_refresh <- Unix.gettimeofday ()
 

--- a/bin/masc_tui_observation_layout.ml
+++ b/bin/masc_tui_observation_layout.ml
@@ -1,0 +1,101 @@
+module Tui_decode = Masc.Tui_decode
+
+type context_summary =
+  | Context_measured of {
+      ratio : float;
+      tokens : int;
+      maximum : int;
+      observed_at : string;
+      turn_ref : string;
+    }
+  | Context_partial of {
+      tokens : int;
+      observed_at : string;
+      turn_ref : string;
+    }
+  | Context_unavailable of string
+
+type log_cells = {
+  kind : string;
+  channel : string;
+  messages : string;
+  usage : string;
+  latency : string;
+  cost : string;
+  work : string;
+}
+
+let fit width value =
+  let length = String.length value in
+  if length <= width then value
+  else if width <= 1 then String.make width '~'
+  else String.sub value 0 (width - 1) ^ "~"
+
+let pad_left width value =
+  let value = fit width value in
+  String.make (width - String.length value) ' ' ^ value
+
+let pad_right width value =
+  let value = fit width value in
+  value ^ String.make (width - String.length value) ' '
+
+let log_kind_label = function
+  | Tui_decode.Log_turn -> "turn"
+  | Tui_decode.Log_heartbeat -> "hb"
+
+let log_channel_label = function
+  | Tui_decode.Log_channel_turn -> "turn"
+  | Tui_decode.Log_channel_scheduled_autonomous -> "sched"
+  | Tui_decode.Log_channel_heartbeat -> "hb"
+
+let message_count_label = function
+  | Some count -> string_of_int count
+  | None -> "--"
+
+let usage_value = function
+  | Some value -> string_of_int value
+  | None -> "--"
+
+let usage_label ~input ~output =
+  Printf.sprintf "%s/%s" (usage_value input) (usage_value output)
+
+let latency_label = function
+  | Some latency -> Printf.sprintf "%dms" latency
+  | None -> "--"
+
+let cost_label = function
+  | Some cost -> Printf.sprintf "$%.3f" cost
+  | None -> "--"
+
+let log_cells (entry : Tui_decode.log_entry) =
+  { kind = pad_right 4 (log_kind_label entry.le_kind);
+    channel = pad_right 8 (log_channel_label entry.le_channel);
+    messages = pad_left 5 (message_count_label entry.le_message_count);
+    usage =
+      pad_left 13
+        (usage_label ~input:entry.le_input_tokens ~output:entry.le_output_tokens);
+    latency = pad_left 9 (latency_label entry.le_latency_ms);
+    cost = pad_left 9 (cost_label entry.le_cost_usd);
+    work = pad_right 10 (Option.value ~default:"" entry.le_work_kind);
+  }
+
+let plain_log_row ~time entry =
+  let cells = log_cells entry in
+  Printf.sprintf "  %-8s %s %s %s %s %s %s  %s" time cells.kind
+    cells.channel cells.messages cells.usage cells.latency cells.cost cells.work
+
+let context_summary = function
+  | Tui_decode.Context_observed
+      { ratio = Some ratio;
+        tokens;
+        maximum = Some maximum;
+        observed_at;
+        turn_ref;
+      }
+    when maximum > 0 ->
+      Context_measured { ratio; tokens; maximum; observed_at; turn_ref }
+  | Tui_decode.Context_observed { tokens; observed_at; turn_ref; _ } ->
+      Context_partial { tokens; observed_at; turn_ref }
+  | Tui_decode.Context_unavailable reason ->
+      Context_unavailable
+        (Tui_decode.context_unavailable_reason_to_string reason)

--- a/bin/masc_tui_observation_layout.mli
+++ b/bin/masc_tui_observation_layout.mli
@@ -1,0 +1,36 @@
+module Tui_decode = Masc.Tui_decode
+
+type context_summary =
+  | Context_measured of {
+      ratio : float;
+      tokens : int;
+      maximum : int;
+      observed_at : string;
+      turn_ref : string;
+    }
+  | Context_partial of {
+      tokens : int;
+      observed_at : string;
+      turn_ref : string;
+    }
+  | Context_unavailable of string
+
+type log_cells = {
+  kind : string;
+  channel : string;
+  messages : string;
+  usage : string;
+  latency : string;
+  cost : string;
+  work : string;
+}
+
+val log_kind_label : Tui_decode.log_kind -> string
+val log_channel_label : Tui_decode.log_channel -> string
+val message_count_label : int option -> string
+val usage_label : input:int option -> output:int option -> string
+val latency_label : int option -> string
+val cost_label : float option -> string
+val log_cells : Tui_decode.log_entry -> log_cells
+val plain_log_row : time:string -> Tui_decode.log_entry -> string
+val context_summary : Tui_decode.context_observation -> context_summary

--- a/bin/masc_tui_observation_layout.mli
+++ b/bin/masc_tui_observation_layout.mli
@@ -15,22 +15,11 @@ type context_summary =
     }
   | Context_unavailable of string
 
-type log_cells = {
-  kind : string;
-  channel : string;
-  messages : string;
-  usage : string;
-  latency : string;
-  cost : string;
-  work : string;
-}
-
 val log_kind_label : Tui_decode.log_kind -> string
 val log_channel_label : Tui_decode.log_channel -> string
 val message_count_label : int option -> string
 val usage_label : input:int option -> output:int option -> string
 val latency_label : int option -> string
 val cost_label : float option -> string
-val log_cells : Tui_decode.log_entry -> log_cells
 val plain_log_row : time:string -> Tui_decode.log_entry -> string
 val context_summary : Tui_decode.context_observation -> context_summary

--- a/bin/masc_tui_render.ml
+++ b/bin/masc_tui_render.ml
@@ -5,6 +5,7 @@ open Tui_decode
 open Masc_tui_ansi
 
 module Message_layout = Masc_tui_message_layout
+module Observation_layout = Masc_tui_observation_layout
 module Keeper_chat = Masc_tui_keeper_chat_projection
 
 (* Exhaustive over [connection_status]: a new state is a compile error
@@ -945,19 +946,34 @@ let render_keeper_detail (state : state) =
 
     (* Live Context section (Phase 2) *)
     add_section "Live Context";
-    if state.live_context_max > 0 then begin
-      let pct = state.live_context_ratio *. 100.0 in
-      let bar_width =
-        Masc_tui_render_schedule.keeper_context_bar_width ~inner_width:inner
-      in
-      add_row "Context:" (Printf.sprintf "%s%.1f%%%s  %s  %d / %d tokens"
-        (ctx_color state.live_context_ratio) pct Ansi.reset
-        (ctx_bar state.live_context_ratio bar_width)
-        state.live_context_tokens state.live_context_max);
-      add_row "Messages:" (string_of_int state.live_message_count);
-    end else begin
-      add_row "Context:" (Ansi.dim ^ "(no metrics data)" ^ Ansi.reset);
-    end;
+    (match state.live_context_error, state.live_context with
+     | Some error, _ -> add_row "Context:" (Ansi.red ^ error ^ Ansi.reset)
+     | None, Some observation ->
+         (match Observation_layout.context_summary observation with
+          | Observation_layout.Context_measured observation ->
+              let ratio = observation.ratio in
+              let pct = ratio *. 100.0 in
+              let bar_width =
+                Masc_tui_render_schedule.keeper_context_bar_width
+                  ~inner_width:inner
+              in
+              add_row "Context:"
+                (Printf.sprintf "%s%.1f%%%s  %s  %d / %d tokens"
+                   (ctx_color ratio) pct Ansi.reset
+                   (ctx_bar ratio bar_width) observation.tokens
+                   observation.maximum);
+              add_row "Observed:" (short_ts observation.observed_at);
+              add_row "Turn Ref:" observation.turn_ref
+          | Observation_layout.Context_partial observation ->
+              add_row "Context:"
+                (Printf.sprintf "%d tokens; context window not observed"
+                   observation.tokens);
+              add_row "Observed:" (short_ts observation.observed_at);
+              add_row "Turn Ref:" observation.turn_ref
+          | Observation_layout.Context_unavailable reason ->
+              add_row "Context:" (Ansi.dim ^ reason ^ Ansi.reset))
+     | None, None ->
+         add_row "Context:" (Ansi.dim ^ "not loaded" ^ Ansi.reset));
     add_empty ();
 
     (* Runtime section *)
@@ -1058,17 +1074,20 @@ let render_keeper_logs (state : state) =
     let total_entries = List.length state.log_entries in
 
     (* Header *)
-    let header = Printf.sprintf " Keeper Logs: %s%s%s  (%d entries)"
-      Ansi.bold k.k_name Ansi.reset total_entries in
+    let header =
+      Printf.sprintf " Keeper Logs: %s  (%d entries)" k.k_name total_entries
+    in
 
     box_top buf cols;
-    box_line buf cols header;
+    box_line_styled buf cols ~style:Ansi.bold header;
     box_divider buf cols;
 
     (* Column header *)
-    let col_hdr = Printf.sprintf "%s  %-8s %-5s %-7s %12s %8s %7s %6s  %-10s%s"
-      Ansi.dim "Time" "Chan" "Ctx" "Tokens" "In/Out" "Lat" "Cost" "Work" Ansi.reset in
-    box_line buf cols col_hdr;
+    let col_hdr =
+      Printf.sprintf "  %-8s %-4s %-8s %5s %13s %9s %9s  %-10s" "Time"
+        "Kind" "Channel" "Msgs" "In/Out" "Lat" "Cost" "Work"
+    in
+    box_line_styled buf cols ~style:Ansi.dim col_hdr;
     box_divider buf cols;
 
     (* Content area *)
@@ -1076,7 +1095,7 @@ let render_keeper_logs (state : state) =
     let scroll = min state.log_scroll (max 0 (total_entries - content_height)) in
 
     if total_entries = 0 then begin
-      box_line buf cols (Ansi.dim ^ "  (no log entries found)" ^ Ansi.reset);
+      box_line_styled buf cols ~style:Ansi.dim "  (no log entries found)";
       for _ = 1 to content_height - 1 do
         box_empty buf cols
       done
@@ -1091,36 +1110,14 @@ let render_keeper_logs (state : state) =
               String.sub e.le_ts 11 8  (* HH:MM:SS *)
             else e.le_ts
           in
-          let pct = e.le_context_ratio *. 100.0 in
-          let ctx_str = Printf.sprintf "%s%5.1f%%%s"
-            (ctx_color e.le_context_ratio) pct Ansi.reset in
-          let tokens_str = Printf.sprintf "%6d/%6d"
-            e.le_context_tokens e.le_context_max in
-          let io_str =
-            match e.le_input_tokens, e.le_output_tokens with
-            | Some input, Some output -> Printf.sprintf "%4d/%4d" input output
-            | _ -> Ansi.dim ^ "   --/--" ^ Ansi.reset
-          in
-          let lat_str =
-            match e.le_latency_ms with
-            | Some latency when latency > 0 -> Printf.sprintf "%5dms" latency
-            | _ -> Ansi.dim ^ "     --" ^ Ansi.reset
-          in
-          let cost_str =
-            match e.le_cost_usd with
-            | Some cost when cost > 0.0 -> Printf.sprintf "$%.3f" cost
-            | _ -> Ansi.dim ^ "   --" ^ Ansi.reset
-          in
           let tools_str =
             if List.length e.le_tools_used > 0 then
-              " " ^ Ansi.dim ^ (String.concat "," (List.filteri (fun i _ -> i < 2) e.le_tools_used)) ^ Ansi.reset
+              " "
+              ^ String.concat ","
+                  (List.filteri (fun i _ -> i < 2) e.le_tools_used)
             else ""
           in
-          let work_kind = Option.value ~default:"" e.le_work_kind in
-          let line = Printf.sprintf "  %s %s %s %s %s %s %s  %-10s%s"
-            time_str (channel_color e.le_channel) ctx_str tokens_str
-            io_str lat_str cost_str work_kind tools_str
-          in
+          let line = Observation_layout.plain_log_row ~time:time_str e ^ tools_str in
           box_line buf cols line
         end else
           box_empty buf cols
@@ -1129,9 +1126,11 @@ let render_keeper_logs (state : state) =
 
     (* Scroll indicator *)
     if total_entries > content_height then begin
-      let indicator = Printf.sprintf "%s[%d/%d entries, scroll %d]%s"
-        Ansi.dim total_entries (total_entries) scroll Ansi.reset in
-      box_line buf cols indicator
+      let indicator =
+        Printf.sprintf "[%d/%d entries, scroll %d]" total_entries total_entries
+          scroll
+      in
+      box_line_styled buf cols ~style:Ansi.dim indicator
     end;
 
     box_bottom buf cols;

--- a/bin/masc_tui_types.ml
+++ b/bin/masc_tui_types.ml
@@ -235,10 +235,8 @@ type state = {
   mutable keeper_cursor: int;
   mutable log_entries: log_entry list;
   mutable log_scroll: int;
-  mutable live_context_ratio: float;
-  mutable live_context_tokens: int;
-  mutable live_context_max: int;
-  mutable live_message_count: int;
+  mutable live_context: Tui_decode.context_observation option;
+  mutable live_context_error: string option;
   mutable overview: overview_snapshot option;
   mutable overview_error: string option;
   mutable approval_snapshot: approval_snapshot option;
@@ -283,10 +281,8 @@ let create_state ~workspace ~port ~refresh_interval = {
   keeper_cursor = 0;
   log_entries = [];
   log_scroll = 0;
-  live_context_ratio = 0.0;
-  live_context_tokens = 0;
-  live_context_max = 0;
-  live_message_count = 0;
+  live_context = None;
+  live_context_error = None;
   overview = None;
   overview_error = None;
   approval_snapshot = None;

--- a/docs/TUI-GUIDE.md
+++ b/docs/TUI-GUIDE.md
@@ -65,7 +65,9 @@ MASC Keepers (5 registered)
 
 ### Keeper Detail View
 
-Press `Enter` on a keeper to see details. Includes live context status from metrics JSONL.
+Press `Enter` on a keeper to see details. Live context comes from the newest
+trace-matched TurnRecord; missing, malformed, unreadable, usage-less, and
+prior-trace observations remain distinct unavailable states.
 
 ```
 Keeper: sangsu
@@ -81,7 +83,8 @@ Keeper: sangsu
 
   Live Context
   Context:               55.2%  ########-----------  70629 / 128000 tokens
-  Messages:              430
+  Observed:              2026-08-21T12:00:00
+  Turn Ref:              trace-current#30317
 
   Runtime Stats
   Total Turns:           30317
@@ -103,24 +106,22 @@ Press `l` from detail view. Shows recent heartbeat/metrics entries from `<name>/
 ```
 Keeper Logs: sangsu  (85 entries)
 
-  Time     Chan  Ctx        Tokens      In/Out   Lat    Cost    Work
-  14:31:08  hb   55.2%  70629/128000  0/0        --      --    status_tick
-  14:31:32  hb   55.2%  70629/128000  0/0        --      --    status_tick
-  14:33:03  hb   55.2%  70629/128000  0/0        --      --    status_tick
+  Time     Kind Channel   Msgs          In/Out       Lat      Cost  Work
+  14:31:08 turn turn         7            10/12       0ms    $0.000  tool_use
+  14:31:32 hb   hb          --            --/--        --        --
 
 [j/k] Scroll  [Esc] Back  [q] Quit
 ```
 
 Fields displayed per entry:
 - **Time**: HH:MM:SS from the timestamp
-- **Chan**: channel (hb=heartbeat, turn, comp=compaction, hand=handoff, init=initiative)
-- **Ctx**: context_ratio percentage with color coding (green < 50%, yellow 50-80%, red > 80%)
-- **Tokens**: context_tokens / context_max
+- **Kind**: current `keeper.metrics.v1` Turn or Heartbeat row
+- **Channel**: canonical short label (`turn`, `sched`, or `hb`)
+- **Msgs**: observed message count, or `--` when the Heartbeat did not observe it
 - **In/Out**: input_tokens / output_tokens from usage
-- **Lat**: latency_ms (if > 0)
-- **Cost**: cost_usd (if > 0)
+- **Lat**: observed latency_ms, including zero; `--` when unavailable
+- **Cost**: observed cost_usd, including zero; `--` when unavailable
 - **Work**: work_kind label
-- Guardrail stops are highlighted with a red STOP marker
 
 ### Keeper Message View
 
@@ -183,7 +184,7 @@ Dashboard <--Tab--> Keeper List
 |---------|--------|-----------------|
 | Active task list | `.masc/tasks/backlog.json` | No |
 | Keeper list/detail | current-schema `.masc/keepers/*.json` | No |
-| Live context status | `<name>/metrics/YYYY-MM/DD.jsonl` (latest entry) | No |
+| Live context status | `<name>/turn-records/YYYY-MM/DD.jsonl` (strict newest trace-matched row) | No |
 | Keeper logs | `<name>/metrics/YYYY-MM/DD.jsonl` (last 200 entries) | No |
 | Goal planning | `GET /api/v1/dashboard/planning` | Yes |
 | Actor-scoped approvals | `GET /api/v1/operator?view=summary&include_messages=0&include_keepers=0` | Yes |

--- a/docs/design/tui/TUI-SPEC.md
+++ b/docs/design/tui/TUI-SPEC.md
@@ -103,7 +103,8 @@ scope가 결합된 서버 계약이므로 파일시스템이나 briefing을 대�
 | agents | `.masc/agents/*.json` |
 | tasks | `.masc/tasks/backlog.json` |
 | keepers | `.masc/keepers/*.json` |
-| keeper metrics | `.masc/keepers/<name>/metrics/YYYY-MM/DD.jsonl` |
+| keeper metrics | `.masc/keepers/<name>/metrics/YYYY-MM/DD.jsonl` (`keeper.metrics.v1` Turn/Heartbeat) |
+| keeper context | `.masc/keepers/<name>/turn-records/YYYY-MM/DD.jsonl` (strict newest trace-matched TurnRecord) |
 | board posts | `.masc/board_posts.jsonl` |
 | board comments | `.masc/board_comments.jsonl` |
 | board votes | `.masc/board_votes.jsonl` |
@@ -169,7 +170,7 @@ scope가 결합된 서버 계약이므로 파일시스템이나 briefing을 대�
 
 - List: name, generation, runtime lane, composite phase, goal
 - Detail: identity, live context, runtime lane, runtime stats, behavior, timestamps
-- Logs: metrics JSONL tail
+- Logs: exact `keeper.metrics.v1` Turn/Heartbeat tail; context occupancy is not a metrics-ledger field
 - Message: request-correlated asynchronous chat stream. The TUI creates one durable UUIDv7 request ID per send, accepts only the current Keeper SSE contract, and applies a completion only when both request and Keeper identities match. Partial text, interrupted streams, and terminal outcomes without a visible reply are explicit status/error values rather than successful replies.
 
 강화: 24h bucket 요약, tool call 카운트, composite phase (`Stable <- paused`)

--- a/lib/tui_decode.ml
+++ b/lib/tui_decode.ml
@@ -16,6 +16,7 @@ type task = {
 
 type keeper = {
   k_name : string;
+  k_trace_id : string;
   k_generation : int;
   k_paused : bool;
   k_current_task_id : string option;
@@ -69,22 +70,44 @@ type planning_snapshot = {
   pl_generated_at : string;
 }
 
+type log_kind =
+  | Log_turn
+  | Log_heartbeat
+
+type log_channel =
+  | Log_channel_turn
+  | Log_channel_scheduled_autonomous
+  | Log_channel_heartbeat
+
 type log_entry = {
+  le_kind : log_kind;
   le_ts : string;
-  le_channel : string;
-  le_context_ratio : float;
-  le_context_tokens : int;
-  le_context_max : int;
-  le_message_count : int;
-  le_model_used : string option;
+  le_channel : log_channel;
+  le_message_count : int option;
   le_input_tokens : int option;
   le_output_tokens : int option;
   le_latency_ms : int option;
   le_cost_usd : float option;
   le_work_kind : string option;
   le_tools_used : string list;
-  le_compacted : bool option;
 }
+
+type context_unavailable_reason =
+  | Context_measurement_missing
+  | Context_turn_record_undecodable
+  | Context_turn_record_read_failed
+  | Context_turn_record_without_usage
+  | Context_turn_record_trace_mismatch
+
+type context_observation =
+  | Context_observed of {
+      ratio : float option;
+      tokens : int;
+      maximum : int option;
+      observed_at : string;
+      turn_ref : string;
+    }
+  | Context_unavailable of context_unavailable_reason
 
 let ( let* ) = Result.bind
 
@@ -92,6 +115,11 @@ let member key json =
   match Json_util.assoc_member_opt key json with
   | Some v -> v
   | None -> `Null
+
+let required_member json key =
+  match Json_util.assoc_member_opt key json with
+  | Some value -> Ok value
+  | None -> Error (Printf.sprintf "missing required field '%s'" key)
 
 let optional_string json key =
   match member key json with
@@ -102,37 +130,39 @@ let optional_string json key =
         (Printf.sprintf "field '%s' must be a string (received %s)" key
            (Json_util.kind_name other))
 
-let optional_int json key =
-  match member key json with
-  | `Null -> Ok None
-  | `Int n -> Ok (Some n)
-  | `Intlit s -> (
+let required_nullable_int_field json key =
+  match Json_util.assoc_member_opt key json with
+  | None -> Error (Printf.sprintf "missing required field '%s'" key)
+  | Some `Null -> Ok None
+  | Some (`Int n) -> Ok (Some n)
+  | Some (`Intlit s) -> (
       match int_of_string_opt s with
       | Some n -> Ok (Some n)
       | None ->
           Error (Printf.sprintf "field '%s' has non-integer intlit %S" key s))
-  | other ->
+  | Some other ->
       Error
-        (Printf.sprintf "field '%s' must be an int (received %s)" key
+        (Printf.sprintf "field '%s' must be an int or null (received %s)" key
            (Json_util.kind_name other))
 
-let optional_float json key =
-  match member key json with
-  | `Null -> Ok None
-  | `Float f -> Ok (Some f)
-  | `Int n -> Ok (Some (Float.of_int n))
-  | other ->
+let required_nullable_float_field json key =
+  match Json_util.assoc_member_opt key json with
+  | None -> Error (Printf.sprintf "missing required field '%s'" key)
+  | Some `Null -> Ok None
+  | Some (`Float value) -> Ok (Some value)
+  | Some (`Int value) -> Ok (Some (Float.of_int value))
+  | Some other ->
       Error
-        (Printf.sprintf "field '%s' must be a float (received %s)" key
+        (Printf.sprintf "field '%s' must be a float or null (received %s)" key
            (Json_util.kind_name other))
 
-let optional_bool json key =
-  match member key json with
-  | `Null -> Ok None
-  | `Bool b -> Ok (Some b)
-  | other ->
+let require_null_field json key =
+  match Json_util.assoc_member_opt key json with
+  | None -> Error (Printf.sprintf "missing required field '%s'" key)
+  | Some `Null -> Ok ()
+  | Some other ->
       Error
-        (Printf.sprintf "field '%s' must be a bool (received %s)" key
+        (Printf.sprintf "field '%s' must be null (received %s)" key
            (Json_util.kind_name other))
 
 let require_string_field json key = require_string json key
@@ -226,6 +256,7 @@ let keeper_of_meta (meta : Keeper_meta_contract.keeper_meta) =
   in
   {
     k_name = meta.name;
+    k_trace_id = Keeper_id.Trace_id.to_string runtime.trace_id;
     k_generation = runtime.nonce;
     k_paused = meta.paused;
     k_current_task_id =
@@ -253,62 +284,345 @@ let decode_keeper json =
   let* meta = Keeper_meta_json_parse.meta_of_json json in
   Ok (keeper_of_meta meta)
 
+let decode_turn_channel raw =
+  match Keeper_world_observation.channel_of_string raw with
+  | Some Keeper_world_observation.Reactive -> Ok Log_channel_turn
+  | Some Keeper_world_observation.Scheduled_autonomous ->
+      Ok Log_channel_scheduled_autonomous
+  | None -> Error (Printf.sprintf "unknown current turn channel %S" raw)
+
+let decode_turn_mode json =
+  let* raw = require_string_field json "turn_mode" in
+  match Turn_mode_codec.turn_mode_of_string raw with
+  | Some mode -> Ok mode
+  | None -> Error (Printf.sprintf "unknown current turn mode %S" raw)
+
+let validate_usage_projection ~input_tokens ~output_tokens
+    ~cache_creation_tokens ~cache_read_tokens ~total_tokens ~cost_usd
+    ~inner_trust ~inner_anomaly ~inner_reasons ~outer_trust ~outer_reasons =
+  let classified =
+    match
+      ( input_tokens,
+        output_tokens,
+        cache_creation_tokens,
+        cache_read_tokens,
+        total_tokens,
+        cost_usd )
+    with
+    | ( Some input_tokens,
+        Some output_tokens,
+        Some cache_creation_tokens,
+        Some cache_read_tokens,
+        Some total_tokens,
+        Some cost_usd ) ->
+        if total_tokens <> input_tokens + output_tokens then
+          Error "usage total_tokens does not equal input_tokens + output_tokens"
+        else
+          let usage : Agent_core.Types.api_usage =
+            { input_tokens;
+              output_tokens;
+              cache_creation_input_tokens = cache_creation_tokens;
+              cache_read_input_tokens = cache_read_tokens;
+              cost_usd = Some cost_usd;
+            }
+          in
+          Ok (Keeper_usage_trust.classify ~usage_reported:true ~usage)
+    | None, None, None, None, None, None ->
+        let usage : Agent_core.Types.api_usage =
+          { input_tokens = 0;
+            output_tokens = 0;
+            cache_creation_input_tokens = 0;
+            cache_read_input_tokens = 0;
+            cost_usd = None;
+          }
+        in
+        Ok (Keeper_usage_trust.classify ~usage_reported:false ~usage)
+    | _ ->
+        Error
+          "usage tokens, cost, and trust must form one current atomic observation"
+  in
+  let* classified = classified in
+  let expected_trust = Keeper_usage_trust.to_string classified in
+  let expected_reasons = Keeper_usage_trust.reasons classified in
+  let expected_anomaly =
+    match classified with
+    | Keeper_usage_trust.Usage_untrusted _ -> true
+    | Keeper_usage_trust.Usage_missing | Keeper_usage_trust.Usage_trusted ->
+        false
+  in
+  if
+    not
+      (String.equal inner_trust expected_trust
+      && String.equal outer_trust expected_trust)
+  then Error "usage trust does not match the current counter observation"
+  else if inner_anomaly <> expected_anomaly then
+    Error "usage anomaly flag does not match the current trust classification"
+  else if inner_reasons <> expected_reasons || outer_reasons <> expected_reasons
+  then Error "usage anomaly reasons do not match the current trust classification"
+  else Ok ()
+
+let decode_log_entry json =
+  let* kind =
+    match Keeper_metrics_record.kind_of_json json with
+    | Some kind -> Ok kind
+    | None -> Error "unknown current keeper metrics schema or record kind"
+  in
+  let* le_ts = require_string_field json "ts" in
+  let* _ts_unix = require_float_field json "ts_unix" in
+  let* raw_channel = require_string_field json "channel" in
+  let* _name = require_string_field json "name" in
+  let* _agent_name = require_string_field json "agent_name" in
+  let* _trace_id = require_string_field json "trace_id" in
+  let* _generation = require_int_field json "generation" in
+  match kind with
+  | Keeper_metrics_record.Heartbeat ->
+      if not (String.equal raw_channel "heartbeat") then
+        Error
+          (Printf.sprintf "heartbeat metrics row has invalid channel %S"
+             raw_channel)
+      else
+        let* le_message_count =
+          required_nullable_int_field json "message_count"
+        in
+        let* () =
+          if Option.exists (fun count -> count < 0) le_message_count then
+            Error "heartbeat message_count must be non-negative"
+          else Ok ()
+        in
+        Ok
+          { le_kind = Log_heartbeat;
+            le_ts;
+            le_channel = Log_channel_heartbeat;
+            le_message_count;
+            le_input_tokens = None;
+            le_output_tokens = None;
+            le_latency_ms = None;
+            le_cost_usd = None;
+            le_work_kind = None;
+            le_tools_used = [];
+          }
+  | Keeper_metrics_record.Turn ->
+      let* le_channel = decode_turn_channel raw_channel in
+      let* le_message_count = require_int_field json "message_count" in
+      let* () =
+        if le_message_count < 0 then
+          Error "turn message_count must be non-negative"
+        else Ok ()
+      in
+      let* usage =
+        match member "usage" json with
+        | `Assoc _ as usage -> Ok usage
+        | `Null -> Error "missing required field 'usage'"
+        | other ->
+            Error
+              (Printf.sprintf "field 'usage' must be an object (received %s)"
+                 (Json_util.kind_name other))
+      in
+      let* le_input_tokens =
+        required_nullable_int_field usage "input_tokens"
+      in
+      let* le_output_tokens =
+        required_nullable_int_field usage "output_tokens"
+      in
+      let* cache_creation_tokens =
+        required_nullable_int_field usage "cache_creation_tokens"
+      in
+      let* cache_read_tokens =
+        required_nullable_int_field usage "cache_read_tokens"
+      in
+      let* total_tokens = required_nullable_int_field usage "total_tokens" in
+      let* inner_usage_trust = require_string_field usage "usage_trust" in
+      let* inner_usage_anomaly = require_bool usage "usage_anomaly" in
+      let* inner_usage_anomaly_reasons =
+        require_string_list usage "usage_anomaly_reasons"
+      in
+      let* outer_usage_trust = require_string_field json "usage_trust" in
+      let* outer_usage_anomaly_reasons =
+        require_string_list json "usage_anomaly_reasons"
+      in
+      let* latency_ms = require_int_field json "latency_ms" in
+      let* () =
+        if latency_ms < 0 then Error "latency_ms must be non-negative" else Ok ()
+      in
+      let* le_cost_usd = required_nullable_float_field json "cost_usd" in
+      let* () =
+        validate_usage_projection ~input_tokens:le_input_tokens
+          ~output_tokens:le_output_tokens ~cache_creation_tokens
+          ~cache_read_tokens ~total_tokens ~cost_usd:le_cost_usd
+          ~inner_trust:inner_usage_trust
+          ~inner_anomaly:inner_usage_anomaly
+          ~inner_reasons:inner_usage_anomaly_reasons
+          ~outer_trust:outer_usage_trust
+          ~outer_reasons:outer_usage_anomaly_reasons
+      in
+      let* turn_mode = decode_turn_mode json in
+      let* tool_call_count = require_int_field json "tool_call_count" in
+      let* le_tools_used = require_string_list json "tools_used" in
+      let* () =
+        if tool_call_count < 0 then Error "tool_call_count must be non-negative"
+        else if tool_call_count <> List.length le_tools_used then
+          Error "tool_call_count does not match tools_used"
+        else
+          match turn_mode with
+          | Turn_mode_codec.Tool_use -> Ok ()
+          | Turn_mode_codec.Text_response
+          | Turn_mode_codec.Skip_text
+          | Turn_mode_codec.Noop ->
+              if tool_call_count = 0 then Ok ()
+              else Error "non-tool turn mode cannot carry tool calls"
+      in
+      Ok
+        { le_kind = Log_turn;
+          le_ts;
+          le_channel;
+          le_message_count = Some le_message_count;
+          le_input_tokens;
+          le_output_tokens;
+          le_latency_ms = Some latency_ms;
+          le_cost_usd;
+          le_work_kind =
+            Some (Turn_mode_codec.work_kind_of_turn_mode turn_mode);
+          le_tools_used;
+        }
+
 let parse_log_entry line =
   let json =
     try Ok (Yojson.Safe.from_string line)
     with Yojson.Json_error msg -> Error ("invalid JSON: " ^ msg)
   in
   let* json = json in
-  let* le_ts = require_string_field json "ts" in
-  let* le_channel = require_string_field json "channel" in
-  let* le_context_ratio = require_float_field json "context_ratio" in
-  let* le_context_tokens = require_int_field json "context_tokens" in
-  let* le_context_max = require_int_field json "context_max" in
-  let* le_message_count = require_int_field json "message_count" in
-  let le_model_used = get_string json "model_used" in
-  let usage_json = get_object json "usage" in
-  let* le_input_tokens =
-    match usage_json with
-    | None -> Ok None
-    | Some usage -> optional_int usage "input_tokens"
-  in
-  let* le_output_tokens =
-    match usage_json with
-    | None -> Ok None
-    | Some usage -> optional_int usage "output_tokens"
-  in
-  let* le_latency_ms = optional_int json "latency_ms" in
-  let* le_cost_usd = optional_float json "cost_usd" in
-  let* le_work_kind = optional_string json "work_kind" in
-  let le_tools_used =
-    match member "tools_used" json with
-    | `Null -> Ok []
-    | `List _ -> require_string_list json "tools_used"
-    | other ->
-        Error
-          (Printf.sprintf
-             "field 'tools_used' must be an array (received %s)"
-             (Json_util.kind_name other))
-  in
-  let* le_tools_used = le_tools_used in
-  let* le_compacted = optional_bool json "compacted" in
-  Ok
-    {
-      le_ts;
-      le_channel;
-      le_context_ratio;
-      le_context_tokens;
-      le_context_max;
-      le_message_count;
-      le_model_used;
-      le_input_tokens;
-      le_output_tokens;
-      le_latency_ms;
-      le_cost_usd;
-      le_work_kind;
-      le_tools_used;
-      le_compacted;
-    }
+  decode_log_entry json
+
+let context_unavailable_reason_of_string = function
+  | "context_measurement_missing" -> Ok Context_measurement_missing
+  | "turn_record_undecodable" -> Ok Context_turn_record_undecodable
+  | "turn_record_read_failed" -> Ok Context_turn_record_read_failed
+  | "turn_record_without_usage" -> Ok Context_turn_record_without_usage
+  | "turn_record_trace_mismatch" -> Ok Context_turn_record_trace_mismatch
+  | raw -> Error (Printf.sprintf "unknown context unavailable reason %S" raw)
+
+let context_unavailable_reason_to_string = function
+  | Context_measurement_missing -> "context measurement missing"
+  | Context_turn_record_undecodable -> "turn record undecodable"
+  | Context_turn_record_read_failed -> "turn record read failed"
+  | Context_turn_record_without_usage -> "turn record has no provider usage"
+  | Context_turn_record_trace_mismatch -> "turn record belongs to a prior trace"
+
+let require_object_member json key =
+  let* value = required_member json key in
+  match value with
+  | `Assoc _ as object_value -> Ok object_value
+  | other ->
+      Error
+        (Printf.sprintf "field '%s' must be an object (received %s)" key
+           (Json_util.kind_name other))
+
+let decode_context_unavailable_payload json =
+  let* kind = require_string_field json "kind" in
+  if not (String.equal kind "not_observed") then
+    Error (Printf.sprintf "unknown context unavailable kind %S" kind)
+  else
+    let* reason = require_string_field json "reason" in
+    context_unavailable_reason_of_string reason
+
+let validate_context_ratio ~tokens ~maximum ~ratio =
+  match maximum, ratio with
+  | Some maximum, Some ratio when maximum > 0 ->
+      let expected = Float.of_int tokens /. Float.of_int maximum in
+      let tolerance = 1e-12 *. Float.max 1.0 (Float.abs expected) in
+      if Float.is_finite ratio && Float.abs (ratio -. expected) <= tolerance then
+        Ok ()
+      else Error "context ratio does not match tokens / context window"
+  | Some maximum, None when maximum > 0 ->
+      Error "positive context window requires an observed ratio"
+  | (None | Some 0), None -> Ok ()
+  | (None | Some 0), Some _ ->
+      Error "context ratio requires a positive context window"
+  | Some _, (Some _ | None) -> Error "context window must be non-negative"
+
+let decode_context_observation ~expected_trace_id json =
+  match Json_util.assoc_member_opt "context_metrics_unavailable" json with
+  | None -> Error "missing required field 'context_metrics_unavailable'"
+  | Some (`Assoc _ as unavailable) ->
+      let* reason = decode_context_unavailable_payload unavailable in
+      let* () = require_null_field json "context_ratio" in
+      let* () = require_null_field json "context_tokens" in
+      let* () = require_null_field json "context_max" in
+      let* () = require_null_field json "context_source" in
+      let* context = require_object_member json "context" in
+      let* () = require_null_field context "source" in
+      let* () = require_null_field context "context_ratio" in
+      let* () = require_null_field context "context_tokens" in
+      let* () = require_null_field context "context_max" in
+      let* nested_unavailable =
+        require_object_member context "metrics_unavailable"
+      in
+      let* nested_reason =
+        decode_context_unavailable_payload nested_unavailable
+      in
+      if nested_reason <> reason then
+        Error "nested and top-level context unavailable reasons disagree"
+      else Ok (Context_unavailable reason)
+  | Some `Null ->
+      let* ratio = required_nullable_float_field json "context_ratio" in
+      let* tokens = require_int_field json "context_tokens" in
+      let* maximum = required_nullable_int_field json "context_max" in
+      let* source = require_string_field json "context_source" in
+      if not (String.equal source "turn_record") then
+        Error (Printf.sprintf "unknown context observation source %S" source)
+      else if
+        tokens < 0
+        || Option.exists (fun value -> not (Float.is_finite value)) ratio
+      then
+        Error "context observation has an invalid numeric range"
+      else
+        let* () = validate_context_ratio ~tokens ~maximum ~ratio in
+        let* context = require_object_member json "context" in
+        let* nested_source = require_string_field context "source" in
+        let* nested_ratio =
+          required_nullable_float_field context "context_ratio"
+        in
+        let* nested_tokens = require_int_field context "context_tokens" in
+        let* nested_maximum =
+          required_nullable_int_field context "context_max"
+        in
+        let* () = require_null_field context "metrics_unavailable" in
+        if not (String.equal nested_source source) then
+          Error "nested and top-level context sources disagree"
+        else if
+          nested_ratio <> ratio || nested_tokens <> tokens
+          || nested_maximum <> maximum
+        then Error "nested and top-level context measurements disagree"
+        else
+          let* observed_at = require_string_field context "observed_at" in
+          let* turn_ref_json = required_member context "turn_ref" in
+          let* turn_ref = Ids.Turn_ref.of_yojson turn_ref_json in
+          let* absolute_turn = require_int_field context "absolute_turn" in
+          let* request_body_bytes =
+            required_nullable_int_field context "request_body_bytes"
+          in
+          if
+            not
+              (String.equal (Ids.Turn_ref.trace_id turn_ref) expected_trace_id)
+          then Error "context turn reference belongs to a different trace"
+          else if absolute_turn <> Ids.Turn_ref.absolute_turn turn_ref then
+            Error "context absolute turn disagrees with its turn reference"
+          else if Option.exists (fun value -> value < 0) request_body_bytes then
+            Error "context request body bytes must be non-negative"
+          else
+            Ok
+              (Context_observed
+                 { ratio;
+                   tokens;
+                   maximum;
+                   observed_at;
+                   turn_ref = Ids.Turn_ref.to_string turn_ref;
+                 })
+  | Some other ->
+      Error
+        (Printf.sprintf
+           "field 'context_metrics_unavailable' must be an object or null (received %s)"
+           (Json_util.kind_name other))
 
 let trim = String.trim
 

--- a/lib/tui_decode.mli
+++ b/lib/tui_decode.mli
@@ -14,6 +14,7 @@ type task = {
 
 type keeper = {
   k_name : string;
+  k_trace_id : string;
   k_generation : int;
   k_paused : bool;
   k_current_task_id : string option;
@@ -67,22 +68,44 @@ type planning_snapshot = {
   pl_generated_at : string;
 }
 
+type log_kind =
+  | Log_turn
+  | Log_heartbeat
+
+type log_channel =
+  | Log_channel_turn
+  | Log_channel_scheduled_autonomous
+  | Log_channel_heartbeat
+
 type log_entry = {
+  le_kind : log_kind;
   le_ts : string;
-  le_channel : string;
-  le_context_ratio : float;
-  le_context_tokens : int;
-  le_context_max : int;
-  le_message_count : int;
-  le_model_used : string option;
+  le_channel : log_channel;
+  le_message_count : int option;
   le_input_tokens : int option;
   le_output_tokens : int option;
   le_latency_ms : int option;
   le_cost_usd : float option;
   le_work_kind : string option;
   le_tools_used : string list;
-  le_compacted : bool option;
 }
+
+type context_unavailable_reason =
+  | Context_measurement_missing
+  | Context_turn_record_undecodable
+  | Context_turn_record_read_failed
+  | Context_turn_record_without_usage
+  | Context_turn_record_trace_mismatch
+
+type context_observation =
+  | Context_observed of {
+      ratio : float option;
+      tokens : int;
+      maximum : int option;
+      observed_at : string;
+      turn_ref : string;
+    }
+  | Context_unavailable of context_unavailable_reason
 
 val decode_agent : Yojson.Safe.t -> (agent, string) result
 val task_of_domain : Masc_domain.task -> task
@@ -93,6 +116,12 @@ val decode_keeper : Yojson.Safe.t -> (keeper, string) result
 val decode_planning_snapshot :
   Yojson.Safe.t -> (planning_snapshot, string) result
 val parse_log_entry : string -> (log_entry, string) result
+val decode_log_entry : Yojson.Safe.t -> (log_entry, string) result
+val decode_context_observation :
+  expected_trace_id:string ->
+  Yojson.Safe.t ->
+  (context_observation, string) result
+val context_unavailable_reason_to_string : context_unavailable_reason -> string
 val is_success_http_status : int -> bool
 val http_status_error : status_code:int -> body:string -> string
 val decode_json_response_body :

--- a/scripts/audit-ci-test-targets.sh
+++ b/scripts/audit-ci-test-targets.sh
@@ -124,7 +124,7 @@ fi
 echo "[ci-test-targets] OK - $(wc -l < "$referenced" | tr -d ' ') CI targets, all declared in Dune"
 
 # Exact current count. Adding an unwired suite is a regression.
-UNWIRED_BASELINE=515
+UNWIRED_BASELINE=514
 unwired="$(comm -13 "$referenced" "$declared" | wc -l | tr -d ' ')"
 
 if [ "$unwired" -gt "$UNWIRED_BASELINE" ]; then

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -396,8 +396,11 @@ operator_targets=(
 )
 
 sse_targets=(
+  @test/runtest-test_tui_context_state
+  @test/runtest-test_tui_decode
   @test/runtest-test_tui_keeper_chat_projection
   @test/runtest-test_tui_message_layout
+  @test/runtest-test_tui_observation_layout
   @test/runtest-test_tui_http_ast
   @test/runtest-test_tui_render_schedule
   @test/runtest-test_sse_coverage

--- a/test/dune
+++ b/test/dune
@@ -2575,6 +2575,16 @@
  (libraries alcotest masc_tui_message_layout))
 
 (test
+ (name test_tui_observation_layout)
+ (modules test_tui_observation_layout)
+ (libraries alcotest masc_tui_observation_layout masc))
+
+(test
+ (name test_tui_context_state)
+ (modules test_tui_context_state)
+ (libraries alcotest masc_tui_context_state masc))
+
+(test
  (name test_tui_render_schedule)
  (modules test_tui_render_schedule)
  (libraries alcotest masc_tui_render_schedule))

--- a/test/test_tui_context_state.ml
+++ b/test/test_tui_context_state.ml
@@ -1,0 +1,102 @@
+open Alcotest
+
+module Decode = Masc.Tui_decode
+module Context_state = Masc_tui_context_state
+
+let keeper =
+  Decode.
+    { k_name = "keeper-main";
+      k_trace_id = "trace-current";
+      k_generation = 4;
+      k_paused = false;
+      k_current_task_id = None;
+      k_total_turns = 0;
+      k_total_tokens = 0;
+      k_total_cost_usd = 0.0;
+      k_last_turn_ts = "";
+      k_compaction_count = 0;
+      k_autonomous_turn_count = 0;
+      k_autonomous_text_turn_count = 0;
+      k_autonomous_tool_turn_count = 0;
+      k_board_reactive_turn_count = 0;
+      k_mention_reactive_turn_count = 0;
+      k_noop_turn_count = 0;
+      k_last_proactive_outcome = "never";
+      k_last_blocker = None;
+      k_created_at = "2026-08-21T00:00:00Z";
+      k_updated_at = "2026-08-21T00:00:00Z";
+    }
+
+let observed_fields ~trace_id =
+  [ "context_ratio", `Float 0.5
+  ; "context_tokens", `Int 100
+  ; "context_max", `Int 200
+  ; "context_source", `String "turn_record"
+  ; "context_metrics_unavailable", `Null
+  ; ( "context"
+    , `Assoc
+        [ "source", `String "turn_record"
+        ; "context_ratio", `Float 0.5
+        ; "context_tokens", `Int 100
+        ; "context_max", `Int 200
+        ; "observed_at", `String "2026-08-21T12:00:00Z"
+        ; "turn_ref", `String (trace_id ^ "#4")
+        ; "absolute_turn", `Int 4
+        ; "request_body_bytes", `Int 4096
+        ; "metrics_unavailable", `Null
+        ] )
+  ]
+
+let test_resolve_binds_keeper_identity_and_current_trace () =
+  let seen_name = ref None in
+  let seen_trace = ref None in
+  let state =
+    Context_state.resolve_with keeper
+      ~project:(fun ~keeper_name ~current_trace_id ->
+        seen_name := Some keeper_name;
+        seen_trace := Some current_trace_id;
+        observed_fields ~trace_id:current_trace_id)
+  in
+  check (option string) "keeper name" (Some "keeper-main") !seen_name;
+  check (option string) "current trace" (Some "trace-current") !seen_trace;
+  check bool "observation loaded" true (Option.is_some state.observation);
+  check bool "successful load has no error" true (Option.is_none state.error)
+
+let test_decode_error_is_exclusive () =
+  let state =
+    Context_state.resolve_with keeper
+      ~project:(fun ~keeper_name:_ ~current_trace_id:_ ->
+        observed_fields ~trace_id:"trace-prior")
+  in
+  check bool "failed decode clears observation" true
+    (Option.is_none state.observation);
+  check bool "failed decode preserves error" true (Option.is_some state.error)
+
+let test_empty_selection_clears_loaded_state () =
+  let load_count = ref 0 in
+  let load _keeper =
+    incr load_count;
+    Context_state.resolve_with keeper
+      ~project:(fun ~keeper_name:_ ~current_trace_id ->
+        observed_fields ~trace_id:current_trace_id)
+  in
+  let loaded = Context_state.for_selection ~load (Some keeper) in
+  check bool "nonempty selection loads context" true
+    (Option.is_some loaded.observation);
+  let cleared = Context_state.for_selection ~load None in
+  check bool "empty selection clears observation" true
+    (Option.is_none cleared.observation);
+  check bool "empty selection clears error" true (Option.is_none cleared.error);
+  check int "empty selection does not call loader" 1 !load_count
+
+let () =
+  run "tui_context_state"
+    [ ( "selection"
+      , [ test_case "binds current Keeper identity" `Quick
+            test_resolve_binds_keeper_identity_and_current_trace
+        ; test_case "decode error is exclusive" `Quick
+            test_decode_error_is_exclusive
+        ; test_case "empty roster clears loaded context" `Quick
+            test_empty_selection_clears_loaded_state
+        ] )
+    ]

--- a/test/test_tui_decode.ml
+++ b/test/test_tui_decode.ml
@@ -124,6 +124,8 @@ let test_decode_keeper_projects_current_schema () =
   with
   | Ok keeper ->
       Alcotest.(check string) "name" "keeper-main" keeper.k_name;
+      Alcotest.(check bool) "trace identity is projected" true
+        (String.trim keeper.k_trace_id <> "");
       Alcotest.(check int) "generation" 2 keeper.k_generation;
       Alcotest.(check bool) "paused" true keeper.k_paused;
       Alcotest.(check (option string)) "current task" (Some "task-42")
@@ -279,76 +281,462 @@ let test_decode_planning_snapshot_rejects_running_alias () =
        (Tui_decode.decode_planning_snapshot
           (planning_snapshot_json ~running_key:"running" ())))
 
-let test_parse_log_entry_success () =
-  let line =
-    Yojson.Safe.to_string
-      (`Assoc [
-         ("ts", `String "2026-03-31T12:00:00Z");
-         ("channel", `String "hb");
-         ("context_ratio", `Float 0.55);
-         ("context_tokens", `Int 100);
-         ("context_max", `Int 200);
-         ("message_count", `Int 4);
-         ("usage", `Assoc [("input_tokens", `Int 10); ("output_tokens", `Int 12)]);
-         ("work_kind", `String "heartbeat");
-       ])
+let metrics_common_fields ~kind ~channel =
+  [ "schema", `String Keeper_metrics_record.schema
+  ; "record_kind", `String kind
+  ; "ts", `String "2026-08-21T12:00:00Z"
+  ; "ts_unix", `Float 1787313600.0
+  ; "channel", `String channel
+  ; "name", `String "keeper-main"
+  ; "agent_name", `String "codex"
+  ; "trace_id", `String "trace-current"
+  ; "generation", `Int 4
+  ]
+
+type usage_fixture =
+  | Usage_trusted
+  | Usage_untrusted
+  | Usage_missing
+  | Usage_mixed
+  | Usage_bad_total
+
+let usage_fields = function
+  | Usage_trusted ->
+      ( `Assoc
+          [ "input_tokens", `Int 10
+          ; "output_tokens", `Int 12
+          ; "cache_creation_tokens", `Int 3
+          ; "cache_read_tokens", `Int 4
+          ; "total_tokens", `Int 22
+          ; "usage_trust", `String "trusted"
+          ; "usage_anomaly", `Bool false
+          ; "usage_anomaly_reasons", `List []
+          ]
+      , `Float 0.0
+      , "trusted"
+      , [] )
+  | Usage_untrusted ->
+      let reasons = [ `String "negative_input_tokens" ] in
+      ( `Assoc
+          [ "input_tokens", `Int (-10)
+          ; "output_tokens", `Int 12
+          ; "cache_creation_tokens", `Int 3
+          ; "cache_read_tokens", `Int 4
+          ; "total_tokens", `Int 2
+          ; "usage_trust", `String "untrusted"
+          ; "usage_anomaly", `Bool true
+          ; "usage_anomaly_reasons", `List reasons
+          ]
+      , `Float 0.25
+      , "untrusted"
+      , reasons )
+  | Usage_missing ->
+      ( `Assoc
+          [ "input_tokens", `Null
+          ; "output_tokens", `Null
+          ; "cache_creation_tokens", `Null
+          ; "cache_read_tokens", `Null
+          ; "total_tokens", `Null
+          ; "usage_trust", `String "missing"
+          ; "usage_anomaly", `Bool false
+          ; "usage_anomaly_reasons", `List []
+          ]
+      , `Null
+      , "missing"
+      , [] )
+  | Usage_mixed ->
+      ( `Assoc
+          [ "input_tokens", `Int 10
+          ; "output_tokens", `Null
+          ; "cache_creation_tokens", `Int 3
+          ; "cache_read_tokens", `Int 4
+          ; "total_tokens", `Int 17
+          ; "usage_trust", `String "trusted"
+          ; "usage_anomaly", `Bool false
+          ; "usage_anomaly_reasons", `List []
+          ]
+      , `Float 0.25
+      , "trusted"
+      , [] )
+  | Usage_bad_total ->
+      ( `Assoc
+          [ "input_tokens", `Int 10
+          ; "output_tokens", `Int 12
+          ; "cache_creation_tokens", `Int 3
+          ; "cache_read_tokens", `Int 4
+          ; "total_tokens", `Int 29
+          ; "usage_trust", `String "trusted"
+          ; "usage_anomaly", `Bool false
+          ; "usage_anomaly_reasons", `List []
+          ]
+      , `Float 0.0
+      , "trusted"
+      , [] )
+
+let current_turn_metrics ?(channel = "turn") ?(turn_mode = "tool_use")
+    ?(usage = Usage_trusted) ?tools_used ?tool_call_count () =
+  let usage_json, cost_json, usage_trust, usage_anomaly_reasons =
+    usage_fields usage
   in
-  match Tui_decode.parse_log_entry line with
+  let tools_used =
+    Option.value tools_used
+      ~default:
+        (if String.equal turn_mode "tool_use" then [ "masc_task_claim" ]
+         else [])
+  in
+  let tool_call_count =
+    Option.value tool_call_count ~default:(List.length tools_used)
+  in
+  `Assoc
+    (metrics_common_fields ~kind:"turn" ~channel
+    @ [ "message_count", `Int 7
+      ; "usage", usage_json
+      ; "usage_trust", `String usage_trust
+      ; "usage_anomaly_reasons", `List usage_anomaly_reasons
+      ; "latency_ms", `Int 0
+      ; "cost_usd", cost_json
+      ; "turn_mode", `String turn_mode
+      ; "tool_call_count", `Int tool_call_count
+      ; "tools_used", `List (List.map (fun name -> `String name) tools_used)
+      ])
+
+let set_field key value = function
+  | `Assoc fields -> `Assoc ((key, value) :: List.remove_assoc key fields)
+  | _ -> Alcotest.failf "cannot set field %s on a non-object" key
+
+let remove_field key = function
+  | `Assoc fields -> `Assoc (List.remove_assoc key fields)
+  | _ -> Alcotest.failf "cannot remove field %s from a non-object" key
+
+let update_field key update = function
+  | `Assoc fields as json -> (
+      match List.assoc_opt key fields with
+      | Some value -> set_field key (update value) json
+      | None -> Alcotest.failf "fixture has no field %s" key)
+  | _ -> Alcotest.failf "cannot update field %s on a non-object" key
+
+let update_usage update = update_field "usage" update
+
+let current_heartbeat_metrics ?(channel = "heartbeat") ?(message_count = `Null)
+    () =
+  `Assoc
+    (metrics_common_fields ~kind:"heartbeat" ~channel
+    @ [ "message_count", message_count ])
+
+let test_decode_current_turn_metrics () =
+  match Tui_decode.decode_log_entry (current_turn_metrics ()) with
   | Ok entry ->
-      Alcotest.(check (option int)) "input tokens" (Some 10) entry.le_input_tokens;
-      Alcotest.(check (option string)) "work kind" (Some "heartbeat") entry.le_work_kind
+      Alcotest.(check bool) "turn kind" true
+        (entry.le_kind = Tui_decode.Log_turn);
+      Alcotest.(check bool) "canonical channel" true
+        (entry.le_channel = Tui_decode.Log_channel_turn);
+      Alcotest.(check (option int)) "message count" (Some 7)
+        entry.le_message_count;
+      Alcotest.(check (option int)) "input tokens" (Some 10)
+        entry.le_input_tokens;
+      Alcotest.(check (option int)) "output tokens" (Some 12)
+        entry.le_output_tokens;
+      Alcotest.(check (option int)) "zero latency remains observed" (Some 0)
+        entry.le_latency_ms;
+      Alcotest.(check (option (float 0.001))) "zero cost remains observed"
+        (Some 0.0) entry.le_cost_usd;
+      Alcotest.(check (option string)) "derived work kind" (Some "tool_use")
+        entry.le_work_kind
   | Error err -> Alcotest.fail err
 
-let test_parse_log_entry_missing_required_field_fails () =
-  let line =
-    Yojson.Safe.to_string
-      (`Assoc [
-         ("ts", `String "2026-03-31T12:00:00Z");
-         ("channel", `String "hb");
-         ("context_ratio", `Float 0.55);
-         ("context_max", `Int 200);
-         ("message_count", `Int 4);
-       ])
-  in
-  Alcotest.(check bool) "missing context_tokens rejected" true
-    (Result.is_error (Tui_decode.parse_log_entry line))
-
-let test_parse_log_entry_partial_usage_is_allowed () =
-  let line =
-    Yojson.Safe.to_string
-      (`Assoc [
-         ("ts", `String "2026-03-31T12:00:00Z");
-         ("channel", `String "hb");
-         ("context_ratio", `Float 0.55);
-         ("context_tokens", `Int 100);
-         ("context_max", `Int 200);
-         ("message_count", `Int 4);
-         ("usage", `Assoc [("input_tokens", `Int 10)]);
-       ])
-  in
-  match Tui_decode.parse_log_entry line with
+let test_decode_current_turn_variants () =
+  List.iter
+    (fun (channel, expected_channel) ->
+      List.iter
+        (fun (mode, expected_work_kind) ->
+          match
+            Tui_decode.decode_log_entry
+              (current_turn_metrics ~channel ~turn_mode:mode ())
+          with
+          | Ok entry ->
+              Alcotest.(check bool) (channel ^ " channel") true
+                (entry.le_channel = expected_channel);
+              Alcotest.(check (option string)) (mode ^ " work kind")
+                (Some expected_work_kind) entry.le_work_kind
+          | Error err -> Alcotest.failf "%s/%s: %s" channel mode err)
+        [ "tool_use", "tool_use"
+        ; "text_response", "text_turn"
+        ; "skip_text", "text_turn"
+        ; "noop", "noop"
+        ])
+    [ "turn", Tui_decode.Log_channel_turn
+    ; ( "scheduled_autonomous"
+      , Tui_decode.Log_channel_scheduled_autonomous )
+    ];
+  (match
+     Tui_decode.decode_log_entry
+       (current_turn_metrics ~usage:Usage_missing ())
+   with
+   | Ok entry ->
+       Alcotest.(check (option int)) "missing input usage" None
+         entry.le_input_tokens;
+       Alcotest.(check (option int)) "missing output usage" None
+         entry.le_output_tokens;
+       Alcotest.(check (option (float 0.001))) "missing cost" None
+         entry.le_cost_usd
+   | Error err -> Alcotest.fail err);
+  match
+    Tui_decode.decode_log_entry
+      (current_turn_metrics ~usage:Usage_untrusted ())
+  with
   | Ok entry ->
-      Alcotest.(check (option int)) "input tokens" (Some 10) entry.le_input_tokens;
-      Alcotest.(check (option int)) "missing output tokens" None entry.le_output_tokens
+      Alcotest.(check (option int)) "untrusted negative input remains observed"
+        (Some (-10)) entry.le_input_tokens;
+      Alcotest.(check (option int)) "untrusted output remains observed"
+        (Some 12) entry.le_output_tokens
   | Error err -> Alcotest.fail err
 
-let test_parse_log_entry_missing_usage_is_allowed () =
-  let line =
-    Yojson.Safe.to_string
-      (`Assoc [
-         ("ts", `String "2026-03-31T12:00:00Z");
-         ("channel", `String "hb");
-         ("context_ratio", `Float 0.55);
-         ("context_tokens", `Int 100);
-         ("context_max", `Int 200);
-         ("message_count", `Int 4);
-       ])
-  in
-  match Tui_decode.parse_log_entry line with
+let test_decode_current_heartbeat_metrics () =
+  match Tui_decode.decode_log_entry (current_heartbeat_metrics ()) with
   | Ok entry ->
-      Alcotest.(check (option int)) "missing input tokens" None entry.le_input_tokens;
-      Alcotest.(check (option int)) "missing output tokens" None entry.le_output_tokens
+      Alcotest.(check bool) "heartbeat kind" true
+        (entry.le_kind = Tui_decode.Log_heartbeat);
+      Alcotest.(check bool) "heartbeat channel" true
+        (entry.le_channel = Tui_decode.Log_channel_heartbeat);
+      Alcotest.(check (option int)) "unknown message count" None
+        entry.le_message_count;
+      Alcotest.(check (option int)) "heartbeat has no turn usage" None
+        entry.le_input_tokens;
+      (match
+         Tui_decode.decode_log_entry
+           (current_heartbeat_metrics ~message_count:(`Int 9) ())
+       with
+       | Ok counted ->
+           Alcotest.(check (option int)) "observed message count" (Some 9)
+             counted.le_message_count
+       | Error err -> Alcotest.fail err)
   | Error err -> Alcotest.fail err
+
+let test_metrics_contract_rejects_retired_or_unknown_rows () =
+  let versionless =
+    match current_turn_metrics () with
+    | `Assoc fields -> `Assoc (List.remove_assoc "schema" fields)
+    | _ -> Alcotest.fail "turn fixture must be an object"
+  in
+  let missing_usage_field =
+    current_turn_metrics ~usage:Usage_missing ()
+    |> update_usage (remove_field "input_tokens")
+  in
+  let anomaly_flag_mismatch =
+    current_turn_metrics ~usage:Usage_untrusted ()
+    |> update_usage (set_field "usage_anomaly" (`Bool false))
+  in
+  let anomaly_reasons_mismatch =
+    current_turn_metrics ~usage:Usage_untrusted ()
+    |> set_field "usage_anomaly_reasons" (`List [])
+  in
+  let cases =
+    [ "versionless", versionless
+    ; "mixed usage observation", current_turn_metrics ~usage:Usage_mixed ()
+    ; "incorrect usage total", current_turn_metrics ~usage:Usage_bad_total ()
+    ; "missing explicit-null usage field", missing_usage_field
+    ; "usage anomaly flag mismatch", anomaly_flag_mismatch
+    ; "usage anomaly reasons mismatch", anomaly_reasons_mismatch
+    ; "unknown turn channel", current_turn_metrics ~channel:"reactive" ()
+    ; "unknown turn mode", current_turn_metrics ~turn_mode:"text" ()
+    ; ( "non-tool mode with tool calls"
+      , current_turn_metrics ~turn_mode:"noop"
+          ~tools_used:[ "masc_task_claim" ] ~tool_call_count:1 () )
+    ; ( "tool call count mismatch"
+      , current_turn_metrics ~tool_call_count:2 () )
+    ; ( "missing tool call count"
+      , current_turn_metrics () |> remove_field "tool_call_count" )
+    ; ( "negative turn message count"
+      , current_turn_metrics () |> set_field "message_count" (`Int (-1)) )
+    ; ( "negative turn latency"
+      , current_turn_metrics () |> set_field "latency_ms" (`Int (-1)) )
+    ; "heartbeat channel mismatch", current_heartbeat_metrics ~channel:"hb" ()
+    ; ( "negative heartbeat message count"
+      , current_heartbeat_metrics ~message_count:(`Int (-1)) () )
+    ; ( "heartbeat missing nullable message count"
+      , current_heartbeat_metrics () |> remove_field "message_count" )
+    ]
+  in
+  List.iter
+    (fun (label, json) ->
+      Alcotest.(check bool) label true
+        (Result.is_error (Tui_decode.decode_log_entry json)))
+    cases
+
+let observed_context ?(ratio = `Float 0.5) ?(maximum = `Int 200)
+    ?(absolute_turn = 4) ?(request_body_bytes = `Int 4096) () =
+  `Assoc
+    [ "context_ratio", ratio
+    ; "context_tokens", `Int 100
+    ; "context_max", maximum
+    ; "context_source", `String "turn_record"
+    ; "context_metrics_unavailable", `Null
+    ; ( "context"
+      , `Assoc
+          [ "source", `String "turn_record"
+          ; "context_ratio", ratio
+          ; "context_tokens", `Int 100
+          ; "context_max", maximum
+          ; "observed_at", `String "2026-08-21T12:00:00Z"
+          ; "turn_ref", `String "trace-current#4"
+          ; "absolute_turn", `Int absolute_turn
+          ; "request_body_bytes", request_body_bytes
+          ; "metrics_unavailable", `Null
+          ] )
+    ]
+
+let unavailable_context ?(reverse_nested_payload = false) reason =
+  let unavailable_fields =
+    [ "kind", `String "not_observed"; "reason", `String reason ]
+  in
+  let unavailable = `Assoc unavailable_fields in
+  let nested_unavailable =
+    `Assoc
+      (if reverse_nested_payload then List.rev unavailable_fields
+       else unavailable_fields)
+  in
+  `Assoc
+    [ "context_ratio", `Null
+    ; "context_tokens", `Null
+    ; "context_max", `Null
+    ; "context_source", `Null
+    ; "context_metrics_unavailable", unavailable
+    ; ( "context"
+      , `Assoc
+          [ "source", `Null
+          ; "context_ratio", `Null
+          ; "context_tokens", `Null
+          ; "context_max", `Null
+          ; "metrics_unavailable", nested_unavailable
+          ] )
+    ]
+
+let test_decode_context_observation () =
+  (match
+     Tui_decode.decode_context_observation ~expected_trace_id:"trace-current"
+       (observed_context ())
+   with
+   | Ok (Tui_decode.Context_observed observation) ->
+       Alcotest.(check (option (float 0.001))) "ratio" (Some 0.5)
+         observation.ratio;
+       Alcotest.(check int) "tokens" 100 observation.tokens;
+       Alcotest.(check (option int)) "maximum" (Some 200)
+         observation.maximum;
+       Alcotest.(check string) "turn ref" "trace-current#4"
+         observation.turn_ref
+   | Ok (Tui_decode.Context_unavailable _) ->
+       Alcotest.fail "observed context decoded as unavailable"
+   | Error err -> Alcotest.fail err);
+  match
+    Tui_decode.decode_context_observation ~expected_trace_id:"trace-current"
+      (observed_context ~ratio:`Null ~maximum:`Null ())
+  with
+  | Ok (Tui_decode.Context_observed observation) ->
+      Alcotest.(check (option (float 0.001))) "missing ratio is preserved" None
+        observation.ratio;
+      Alcotest.(check (option int)) "missing window is preserved" None
+        observation.maximum
+  | Ok (Tui_decode.Context_unavailable _) ->
+      Alcotest.fail "partial observation decoded as unavailable"
+  | Error err -> Alcotest.fail err
+
+let test_decode_context_unavailable_reasons () =
+  let reasons =
+    [ "context_measurement_missing"
+    ; "turn_record_undecodable"
+    ; "turn_record_read_failed"
+    ; "turn_record_without_usage"
+    ; "turn_record_trace_mismatch"
+    ]
+  in
+  List.iter
+    (fun reason ->
+      let json =
+        unavailable_context
+          ~reverse_nested_payload:
+            (String.equal reason "context_measurement_missing")
+          reason
+      in
+      match
+        Tui_decode.decode_context_observation
+          ~expected_trace_id:"trace-current" json
+      with
+      | Ok (Tui_decode.Context_unavailable _) -> ()
+      | Ok (Tui_decode.Context_observed _) ->
+          Alcotest.failf "%s decoded as observed" reason
+      | Error err -> Alcotest.failf "%s: %s" reason err)
+    reasons;
+  let unknown =
+    `Assoc
+      [ ( "context_metrics_unavailable"
+        , `Assoc
+            [ "kind", `String "not_observed"; "reason", `String "unknown" ] )
+      ]
+  in
+  Alcotest.(check bool) "unknown unavailable reason rejected" true
+    (Result.is_error
+       (Tui_decode.decode_context_observation
+          ~expected_trace_id:"trace-current" unknown))
+
+let test_context_observation_rejects_hybrids_and_prior_trace () =
+  let prior_trace =
+    match observed_context () with
+    | `Assoc fields ->
+        let context =
+          match List.assoc "context" fields with
+          | `Assoc nested ->
+              `Assoc
+                (("turn_ref", `String "trace-prior#4")
+                :: List.remove_assoc "turn_ref" nested)
+          | _ -> Alcotest.fail "observed context fixture must be an object"
+        in
+        `Assoc (("context", context) :: List.remove_assoc "context" fields)
+    | _ -> Alcotest.fail "observed context fixture must be an object"
+  in
+  let hybrid =
+    `Assoc
+      [ "context_ratio", `Float 0.5
+      ; "context_tokens", `Int 100
+      ; "context_max", `Int 200
+      ; "context_source", `String "turn_record"
+      ; ( "context_metrics_unavailable"
+        , `Assoc
+            [ "kind", `String "not_observed"
+            ; "reason", `String "context_measurement_missing"
+            ] )
+      ]
+  in
+  let missing_observed_nullable =
+    observed_context () |> remove_field "context_ratio"
+  in
+  let missing_observed_provenance =
+    observed_context ()
+    |> update_field "context" (remove_field "request_body_bytes")
+  in
+  let missing_unavailable_nullable =
+    unavailable_context "context_measurement_missing"
+    |> remove_field "context_tokens"
+  in
+  let absolute_turn_mismatch = observed_context ~absolute_turn:5 () in
+  let negative_request_bytes =
+    observed_context ~request_body_bytes:(`Int (-1)) ()
+  in
+  let ratio_mismatch = observed_context ~ratio:(`Float 0.75) () in
+  List.iter
+    (fun (label, json) ->
+      Alcotest.(check bool) label true
+        (Result.is_error
+           (Tui_decode.decode_context_observation
+              ~expected_trace_id:"trace-current" json)))
+    [ "prior trace rejected", prior_trace
+    ; "hybrid rejected", hybrid
+    ; "missing observed nullable field rejected", missing_observed_nullable
+    ; "missing observed provenance rejected", missing_observed_provenance
+    ; "missing unavailable nullable field rejected", missing_unavailable_nullable
+    ; "absolute turn mismatch rejected", absolute_turn_mismatch
+    ; "negative request bytes rejected", negative_request_bytes
+    ; "ratio mismatch rejected", ratio_mismatch
+    ]
 
 let test_parse_keeper_chat_response_sse_delta () =
   let response =
@@ -480,13 +868,23 @@ let () =
       ] );
     ( "parse_log_entry",
       [
-        Alcotest.test_case "success" `Quick test_parse_log_entry_success;
-        Alcotest.test_case "missing required field fails" `Quick
-          test_parse_log_entry_missing_required_field_fails;
-        Alcotest.test_case "partial usage is allowed" `Quick
-          test_parse_log_entry_partial_usage_is_allowed;
-        Alcotest.test_case "missing usage is allowed" `Quick
-          test_parse_log_entry_missing_usage_is_allowed;
+        Alcotest.test_case "current turn contract" `Quick
+          test_decode_current_turn_metrics;
+        Alcotest.test_case "all current turn variants" `Quick
+          test_decode_current_turn_variants;
+        Alcotest.test_case "current heartbeat contract" `Quick
+          test_decode_current_heartbeat_metrics;
+        Alcotest.test_case "retired and unknown rows fail closed" `Quick
+          test_metrics_contract_rejects_retired_or_unknown_rows;
+      ] );
+    ( "context_observation",
+      [
+        Alcotest.test_case "observed and partial current context" `Quick
+          test_decode_context_observation;
+        Alcotest.test_case "closed unavailable reasons" `Quick
+          test_decode_context_unavailable_reasons;
+        Alcotest.test_case "hybrid and prior trace fail closed" `Quick
+          test_context_observation_rejects_hybrids_and_prior_trace;
       ] );
     ( "parse_keeper_chat_response",
       [

--- a/test/test_tui_http_ast.ml
+++ b/test/test_tui_http_ast.ml
@@ -248,6 +248,26 @@ let test_tui_current_projection_wiring () =
        ~module_path:"bin/masc_tui_loader.ml"
        ~callee:"Keeper_types_support.keeper_metrics_dir"
      >= 1);
+  check bool "Keeper log rows use the current typed discriminator" true
+    (Ast_grep.count_calls_in_value_binding
+       ~module_path:"lib/tui_decode.ml" ~binding_name:"decode_log_entry"
+       ~callee:"Keeper_metrics_record.kind_of_json"
+     = 1);
+  check bool "live context uses the trace-scoped TurnRecord projection" true
+    (Ast_grep.count_calls_in_value_binding
+       ~module_path:"bin/masc_tui_context_state.ml" ~binding_name:"load"
+       ~callee:"Projection.context_fields"
+     = 1);
+  check bool "loader applies the behavior-tested selection transition" true
+    (Ast_grep.count_calls_in_value_binding
+       ~module_path:"bin/masc_tui_loader.ml"
+       ~binding_name:"load_selected_live_context"
+       ~callee:"Context_state.for_selection"
+     = 1);
+  check int "live context never tails the metrics ledger" 0
+    (Ast_grep.count_calls_in_value_binding
+       ~module_path:"bin/masc_tui_loader.ml" ~binding_name:"load_live_context"
+       ~callee:"read_last_lines");
   check int "retired planning running alias absent" 0
     (Ast_grep.count_string_literals
        ~module_path:"lib/tui_decode.ml"

--- a/test/test_tui_observation_layout.ml
+++ b/test/test_tui_observation_layout.ml
@@ -1,0 +1,120 @@
+open Alcotest
+
+module Decode = Masc.Tui_decode
+module Layout = Masc_tui_observation_layout
+
+let test_log_labels_preserve_observed_zeroes () =
+  check string "turn kind" "turn" (Layout.log_kind_label Decode.Log_turn);
+  check string "scheduled channel" "sched"
+    (Layout.log_channel_label Decode.Log_channel_scheduled_autonomous);
+  check string "observed zero latency" "0ms" (Layout.latency_label (Some 0));
+  check string "observed zero cost" "$0.000" (Layout.cost_label (Some 0.0));
+  check string "missing latency" "--" (Layout.latency_label None);
+  check string "missing cost" "--" (Layout.cost_label None)
+
+let test_usage_labels_preserve_each_side () =
+  check string "both observed" "10/12"
+    (Layout.usage_label ~input:(Some 10) ~output:(Some 12));
+  check string "input only" "10/--"
+    (Layout.usage_label ~input:(Some 10) ~output:None);
+  check string "output only" "--/12"
+    (Layout.usage_label ~input:None ~output:(Some 12));
+  check string "both missing" "--/--"
+    (Layout.usage_label ~input:None ~output:None)
+
+let log_entry ~kind ~channel ~message_count ~input_tokens ~output_tokens
+    ~latency_ms ~cost_usd ~work_kind =
+  Decode.
+    { le_kind = kind;
+      le_ts = "2026-08-21T12:00:00Z";
+      le_channel = channel;
+      le_message_count = message_count;
+      le_input_tokens = input_tokens;
+      le_output_tokens = output_tokens;
+      le_latency_ms = latency_ms;
+      le_cost_usd = cost_usd;
+      le_work_kind = work_kind;
+      le_tools_used = [];
+    }
+
+let test_log_rows_keep_stable_columns () =
+  let turn =
+    log_entry ~kind:Decode.Log_turn ~channel:Decode.Log_channel_turn
+      ~message_count:(Some 7) ~input_tokens:(Some 10)
+      ~output_tokens:(Some 12) ~latency_ms:(Some 0) ~cost_usd:(Some 0.0)
+      ~work_kind:(Some "tool_use")
+  in
+  let heartbeat =
+    log_entry ~kind:Decode.Log_heartbeat
+      ~channel:Decode.Log_channel_heartbeat ~message_count:None
+      ~input_tokens:None ~output_tokens:None ~latency_ms:None ~cost_usd:None
+      ~work_kind:None
+  in
+  let turn_row = Layout.plain_log_row ~time:"12:00:00" turn in
+  let heartbeat_row = Layout.plain_log_row ~time:"12:00:00" heartbeat in
+  check int "fits the 80-column box interior" 76 (String.length turn_row);
+  check int "missing values keep row width" (String.length turn_row)
+    (String.length heartbeat_row);
+  check string "kind column" "turn" (String.sub turn_row 11 4);
+  check string "channel column" "turn    " (String.sub turn_row 16 8);
+  check string "message column" "    7" (String.sub turn_row 25 5);
+  check string "usage column" "        10/12" (String.sub turn_row 31 13);
+  check string "latency column" "      0ms" (String.sub turn_row 45 9);
+  check string "cost column" "   $0.000" (String.sub turn_row 55 9);
+  check string "heartbeat channel offset" "hb      "
+    (String.sub heartbeat_row 16 8)
+
+let observed ?ratio ?maximum () =
+  Decode.Context_observed
+    { ratio;
+      tokens = 100;
+      maximum;
+      observed_at = "2026-08-21T12:00:00Z";
+      turn_ref = "trace-current#4";
+    }
+
+let test_context_summaries () =
+  (match Layout.context_summary (observed ~ratio:0.5 ~maximum:200 ()) with
+   | Layout.Context_measured summary ->
+       check (float 0.001) "ratio" 0.5 summary.ratio;
+       check int "maximum" 200 summary.maximum
+   | Layout.Context_partial _ | Layout.Context_unavailable _ ->
+       fail "measured context lost");
+  (match Layout.context_summary (observed ()) with
+   | Layout.Context_partial summary ->
+       check int "partial tokens" 100 summary.tokens;
+       check string "partial turn ref" "trace-current#4" summary.turn_ref
+   | Layout.Context_measured _ | Layout.Context_unavailable _ ->
+       fail "partial context lost");
+  let reasons =
+    [ Decode.Context_measurement_missing, "context measurement missing"
+    ; Decode.Context_turn_record_undecodable, "turn record undecodable"
+    ; Decode.Context_turn_record_read_failed, "turn record read failed"
+    ; ( Decode.Context_turn_record_without_usage
+      , "turn record has no provider usage" )
+    ; ( Decode.Context_turn_record_trace_mismatch
+      , "turn record belongs to a prior trace" )
+    ]
+  in
+  List.iter
+    (fun (reason, expected) ->
+      match Layout.context_summary (Decode.Context_unavailable reason) with
+      | Layout.Context_unavailable label ->
+          check string "exact unavailable label" expected label
+      | Layout.Context_measured _ | Layout.Context_partial _ ->
+          fail "unavailable context became observed")
+    reasons
+
+let () =
+  run "tui_observation_layout"
+    [ ( "operator rows"
+      , [ test_case "zero and missing log labels" `Quick
+            test_log_labels_preserve_observed_zeroes
+        ; test_case "usage sides remain distinct" `Quick
+            test_usage_labels_preserve_each_side
+        ; test_case "complete rows keep stable columns" `Quick
+            test_log_rows_keep_stable_columns
+        ; test_case "context states remain distinct" `Quick
+            test_context_summaries
+        ] )
+    ]


### PR DESCRIPTION
Closes #29320

## Summary
- decode only current keeper.metrics.v1 Turn and Heartbeat rows, including producer-derived usage trust, totals, modes, channels, and tool-call invariants
- source live context from the newest current-trace TurnRecord projection with typed partial and unavailable states
- render stable 76-cell log rows that preserve observed zeroes and fit the default 80-column terminal without ANSI-width corruption
- add a behavior seam for current-trace binding, decode-error exclusivity, and empty-roster clearing
- update TUI docs and wire all new decoder/state/layout coverage into focused CI

## Verification
- focused build: TUI binary plus decoder, context-state, observation-layout, HTTP AST, context producer, dashboard metrics, and keeper status targets
- 63 directly run focused tests passed (28 decoder, 4 layout, 3 context state, 11 AST, 9 frame scheduler, 8 context producer)
- CI target audit: 387 declared targets; 514 unwired at the ratcheted baseline
- ocamlformat --check and git diff --check passed
- three independent read-only re-audits reported no remaining findings

## Stack
- base: #29319
- next: bounded strict metrics tail; intentionally not included here

This remains Draft because the inherited base stack has unrelated failing checks and is not merge-ready.