### PR TITLE
feat: 채팅에서 도구 호출이 무엇을 만졌는지 보이게

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -12,6 +12,7 @@ import {
   ChatComposer,
   ChatTranscript,
   THINKING_TRACE_PREVIEW_CHARS,
+  autonomousToolSummary,
   _resetTraceCardOpenChoicesForTests,
   type ChatComposerSendPayload,
 } from './primitives'
@@ -4032,5 +4033,62 @@ describe('ChatComposer v2 prototype surface', () => {
     fireEvent.dragOver(composer)
     const textareaAfterDrag = container.querySelector('.composer-box textarea') as HTMLTextAreaElement
     expect(textareaAfterDrag.placeholder).toBe(CHAT_COMPOSER_DROP_PLACEHOLDER)
+  })
+})
+
+// ================================================================
+// autonomousToolSummary
+// ================================================================
+// A collapsed run's header is the only thing a reader sees without clicking, so
+// it has to say what the run did, not just how many wakes it held.
+
+describe('autonomousToolSummary', () => {
+  const withTools = (id: string, names: string[]): KeeperConversationEntry =>
+    entry({
+      id,
+      text: '',
+      traceSteps: names.map((name) => ({ kind: 'tool' as const, name })),
+    })
+
+  it('returns null when the run called no tools', () => {
+    expect(autonomousToolSummary([entry({ id: 'a', text: 'hi' })])).toBeNull()
+    expect(
+      autonomousToolSummary([
+        entry({ id: 'b', text: '', traceSteps: [{ kind: 'think', text: 'thinking' }] }),
+      ]),
+    ).toBeNull()
+    expect(autonomousToolSummary([])).toBeNull()
+  })
+
+  it('folds consecutive repeats into a count', () => {
+    expect(autonomousToolSummary([withTools('a', ['Execute', 'Execute', 'Execute'])]))
+      .toBe('Execute×3')
+  })
+
+  it('keeps the order the tools ran in', () => {
+    expect(autonomousToolSummary([withTools('a', ['Read', 'Execute', 'Execute', 'Read'])]))
+      .toBe('Read Execute×2 Read')
+  })
+
+  it('spans every turn in the run', () => {
+    expect(autonomousToolSummary([withTools('a', ['Read']), withTools('b', ['Grep'])]))
+      .toBe('Read Grep')
+  })
+
+  it('strips the keeper_ and masc_ prefixes the rows already hide', () => {
+    expect(autonomousToolSummary([withTools('a', ['keeper_tasks_list', 'masc_board_search'])]))
+      .toBe('tasks_list board_search')
+  })
+
+  it('counts the groups it did not show', () => {
+    const out = autonomousToolSummary([withTools('a', ['A', 'B', 'C', 'D', 'E', 'F'])])
+    expect(out).toBe('A B C D +2')
+  })
+
+  it('marks a scan it cut short rather than reporting a short run', () => {
+    const many = Array.from({ length: 2100 }, (_, i) => (i % 2 === 0 ? 'Read' : 'Execute'))
+    const out = autonomousToolSummary([withTools('a', many)])
+    expect(out).not.toBeNull()
+    expect(out!.endsWith('…')).toBe(true)
   })
 })

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -11,7 +11,7 @@ import { UNREAD_DIVIDER_LABEL, unreadDividerAnchorKey } from './unread-divider'
 import { showToast } from '../common/toast'
 import { copyToClipboard } from '../common/copyable-code'
 import { ArrowRight, ExternalLink, Mic, ShieldCheck, Square } from 'lucide-preact'
-import { prettyJson } from '../tool-call-shared'
+import { normalizeToolName, prettyJson, toolSubject } from '../tool-call-shared'
 import { useVoiceInput } from './voice-input'
 
 const CHAT_FOCUS_RING = ringFocusClasses({ tone: 'accent-medium', width: 2 })
@@ -1666,6 +1666,9 @@ function ChatTraceStep({
   }
 
   const statusUi = traceToolStatusUi(step.status)
+  // The name alone repeats: six `Execute` rows read identically. The subject is
+  // the argument that tells them apart, and it is already on the step.
+  const subject = toolSubject(step.args)
 
   return html`
     <div
@@ -1686,6 +1689,9 @@ function ChatTraceStep({
           <span class="chat-block-tstep-kind">Tool</span>
           <${TraceSourceBadge} info=${sourceBadge} />
           <span class="chat-block-tstep-name">${step.name}</span>
+          ${subject
+            ? html`<span class="chat-block-tstep-subject" title=${subject}>${subject}</span>`
+            : null}
           <span
             class="chat-block-tstep-status ${statusUi.className}"
             title=${statusUi.title}
@@ -3064,6 +3070,8 @@ function ToolCallBubble({ entry }: { entry: KeeperConversationEntry }) {
   const toolCallId = toolCallIdFromToolEntryId(entry.id)
   const displayArgs = prettyJsonish(entry.text || '')
   const isEmptyArgs = EMPTY_ARG_TEXTS.has(displayArgs.trim())
+  // Same reason as the trace-step row: the name repeats, the subject does not.
+  const subject = isEmptyArgs ? null : toolSubject(displayArgs)
 
   // Tool results never travel on the chat stream — they are joined here from
   // the tool-call output store by this row's id (`tool-<tool_use_id>`). Null
@@ -3113,6 +3121,9 @@ function ToolCallBubble({ entry }: { entry: KeeperConversationEntry }) {
       >
         <span class="inline-flex size-5 shrink-0 items-center justify-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] text-2xs font-mono font-bold text-[var(--color-fg-secondary)]">T</span>
         <span class="font-mono text-sm font-semibold text-[var(--color-accent-fg)] truncate">${toolName}</span>
+        ${subject
+          ? html`<span class="chat-block-tstep-subject" title=${subject}>${subject}</span>`
+          : null}
         <span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] px-1.5 py-0.5 text-2xs font-semibold text-[var(--color-fg-secondary)]">입력</span>
         ${outputEntry
           ? html`<span
@@ -3255,6 +3266,8 @@ function ToolTraceStep({
   const callId = toolTraceCallId(entry, traceStep)
   const displayArgs = prettyJsonish(entry?.text || traceStep?.args || '')
   const isEmptyArgs = EMPTY_ARG_TEXTS.has(displayArgs.trim())
+  // Same reason as the trace-step row: the name repeats, the subject does not.
+  const subject = isEmptyArgs ? null : toolSubject(displayArgs)
   const unlinkedTraceTool = !structuralSummary && isUnlinkedTraceTool(entry, traceStep)
   const sourceBadge = structuralSummary
     ? { label: 'activity', title: 'source: autonomous activity summary', tone: 'tool' as const }
@@ -3308,6 +3321,9 @@ function ToolTraceStep({
           <span class="chat-block-tstep-kind">Tool</span>
           <${TraceSourceBadge} info=${sourceBadge} />
           <span class="chat-block-tstep-name">${name}</span>
+          ${subject
+            ? html`<span class="chat-block-tstep-subject" title=${subject}>${subject}</span>`
+            : null}
           <span
             class="chat-block-tstep-status ${status}"
             title=${TOOL_STATUS_TITLE[status]}
@@ -3747,6 +3763,44 @@ const TurnWorkBundle = memo(function TurnWorkBundle({
 // transcript stops yanking the viewport while old messages are read.
 const STICK_TO_BOTTOM_THRESHOLD_PX = 80
 
+const AUTONOMOUS_SUMMARY_MAX_GROUPS = 4
+// A run can hold hundreds of turns; the header is a glance, not an audit. The
+// scan stops here and says so with a trailing ellipsis rather than paying for
+// the whole run on every render.
+const AUTONOMOUS_SUMMARY_SCAN_LIMIT = 2000
+
+/** Which tools a collapsed run of autonomous turns ran, in the order it ran
+ *  them, consecutive repeats folded into a count. A header reading only
+ *  "자율턴 145개" says how many times the keeper woke, not what any wake did,
+ *  so the run stays closed and the reader still cannot tell a fetch from a
+ *  rewrite. Returns null for a run that called no tools. */
+export function autonomousToolSummary(entries: KeeperConversationEntry[]): string | null {
+  const groups: { name: string; count: number }[] = []
+  let scanned = 0
+  let truncated = false
+  for (const entry of entries) {
+    for (const step of entry.traceSteps ?? []) {
+      if (step.kind !== 'tool') continue
+      if (scanned >= AUTONOMOUS_SUMMARY_SCAN_LIMIT) {
+        truncated = true
+        break
+      }
+      scanned++
+      const name = normalizeToolName(step.name)
+      const last = groups[groups.length - 1]
+      if (last && last.name === name) last.count++
+      else groups.push({ name, count: 1 })
+    }
+    if (truncated) break
+  }
+  if (groups.length === 0) return null
+  const shown = groups.slice(0, AUTONOMOUS_SUMMARY_MAX_GROUPS)
+  const text = shown.map((g) => (g.count > 1 ? `${g.name}×${g.count}` : g.name)).join(' ')
+  const rest = groups.length - shown.length
+  const more = rest > 0 ? ` +${rest}` : ''
+  return truncated ? `${text}${more}…` : `${text}${more}`
+}
+
 /** One autonomous turn, collapsed into a single row. Starts closed: the turn is
  *  the keeper working on its own, and the transcript's subject is the
  *  conversation around it. Expanding renders the exact turn's final text and
@@ -3772,6 +3826,7 @@ function AutonomousTurnGroup({
 }) {
   const [open, setOpen] = useState(false)
   const timestamp = timeLabel(entry.timestamp)
+  const toolSummary = useMemo(() => autonomousToolSummary([entry]), [entry])
   return html`
     <div class="chat-block-trace ${open ? 'open' : ''}">
       <button
@@ -3783,6 +3838,9 @@ function AutonomousTurnGroup({
         <span class="chat-block-trace-chev">${open ? '▾' : '▸'}</span>
         <span class="chat-block-trace-label">자율턴</span>
         <span class="chat-block-trace-count">1개</span>
+        ${toolSummary
+          ? html`<span class="chat-block-trace-tools" title=${toolSummary}>${toolSummary}</span>`
+          : null}
         ${timestamp ? html`<span class="chat-block-trace-meta">${timestamp}</span>` : null}
       </button>
       ${open
@@ -3874,6 +3932,7 @@ function AutonomousTurnRun({
   // Both ends or neither: a half range would read as a single point in time.
   const range = first && last ? (first === last ? first : `${first} ~ ${last}`) : null
   const drawn = autonomousRunWindow(entries.length, headCount)
+  const toolSummary = useMemo(() => autonomousToolSummary(entries), [entries])
   const turn = (entry: KeeperConversationEntry) => html`<${AutonomousTurnGroup}
     key=${entry.id}
     entry=${entry}
@@ -3896,6 +3955,9 @@ function AutonomousTurnRun({
         <span class="chat-block-trace-chev">${open ? '▾' : '▸'}</span>
         <span class="chat-block-trace-label">자율턴</span>
         <span class="chat-block-trace-count">${entries.length}개</span>
+        ${toolSummary
+          ? html`<span class="chat-block-trace-tools" title=${toolSummary}>${toolSummary}</span>`
+          : null}
         ${range ? html`<span class="chat-block-trace-meta">${range}</span>` : null}
       </button>
       ${open

--- a/dashboard/src/components/tool-call-shared.test.ts
+++ b/dashboard/src/components/tool-call-shared.test.ts
@@ -6,6 +6,7 @@ import {
   formatArgs,
   prettyArgs,
   prettyJson,
+  toolSubject,
 } from './tool-call-shared'
 
 // ================================================================
@@ -212,5 +213,59 @@ describe('prettyJson', () => {
   it('preserves legitimate JSON-text string values (no over-coercion)', () => {
     const out = prettyJson(JSON.stringify({ note: '{"x":1}' }))
     expect(out).toBe('{\n  "note": "{\\"x\\":1}"\n}')
+  })
+})
+
+// ================================================================
+// toolSubject
+// ================================================================
+// Argument shapes below are the ones live keepers actually emit, read off
+// ~/.masc/trajectories: Execute carries argv/cwd, Read carries file_path, Grep
+// carries pattern/path/glob.
+
+describe('toolSubject', () => {
+  it('renders argv as the command that ran', () => {
+    expect(toolSubject({ argv: ['git', 'fetch', 'origin'], cwd: 'repos/masc', timeout_sec: 120 }))
+      .toBe('git fetch origin')
+  })
+
+  it('prefers the path for a file call', () => {
+    expect(toolSubject({ file_path: 'repos/masc/lib/tool_agent.ml', limit: 40, offset: 270 }))
+      .toBe('repos/masc/lib/tool_agent.ml')
+  })
+
+  it('prefers the pattern over the path for a search', () => {
+    expect(toolSubject({ glob: '*.ml', path: 'repos/masc/lib', pattern: 'agent block' }))
+      .toBe('agent block')
+  })
+
+  it('accepts a JSON string, which is how the trace step carries args', () => {
+    expect(toolSubject('{"file_path":"lib/keeper/keeper_chat_blocks.ml"}'))
+      .toBe('lib/keeper/keeper_chat_blocks.ml')
+  })
+
+  it('keeps the tail of an over-long path', () => {
+    const long = `repos/masc/${'nested/'.repeat(20)}target.ml`
+    const out = toolSubject({ file_path: long })
+    expect(out).not.toBeNull()
+    expect(out!.startsWith('…')).toBe(true)
+    expect(out!.endsWith('target.ml')).toBe(true)
+    expect(out!.length).toBeLessThanOrEqual(72)
+  })
+
+  it('returns null when no known key is present, so the caller can fall back', () => {
+    expect(toolSubject({ include_done: true, if_revision: 12 })).toBeNull()
+    expect(toolSubject({})).toBeNull()
+    expect(toolSubject(undefined)).toBeNull()
+    expect(toolSubject('')).toBeNull()
+  })
+
+  it('does not invent a subject from an empty value', () => {
+    expect(toolSubject({ file_path: '   ' })).toBeNull()
+    expect(toolSubject({ argv: [] })).toBeNull()
+  })
+
+  it('falls back to the raw text when args is not JSON', () => {
+    expect(toolSubject('git status')).toBe('git status')
   })
 })

--- a/dashboard/src/components/tool-call-shared.ts
+++ b/dashboard/src/components/tool-call-shared.ts
@@ -141,3 +141,91 @@ export function prettyJson(s: string): string | null {
 export function normalizeToolName(name: string): string {
   return name.replace(/^(keeper_|masc_)/, '')
 }
+
+// ── Tool subject ────────────────────────────────────────
+// A row that carries only the tool name cannot be told apart from the row above
+// it: a keeper that runs `Execute` six times renders six identical lines. The
+// subject is the argument a reader uses to tell them apart — the command for a
+// shell call, the path for a file call, the pattern for a search.
+//
+// Keys are ordered, not matched by tool name, because the same key means the
+// same thing across tools and a name table would need an entry per tool. An
+// argument shape with none of these keys returns null and the caller falls back
+// to formatArgs, so no call renders with less than it does today.
+
+const SUBJECT_MAX_CHARS = 72
+
+const SUBJECT_KEYS = [
+  'argv',        // Execute: ['git', 'fetch', 'origin']
+  'command',
+  'cmd',
+  'file_path',   // Read / Edit / Write
+  'pattern',     // Grep — what it looked for, before where it looked
+  'path',        // Grep scope, and the subject for tools that carry no pattern
+  'query',       // board search, web search
+  'url',
+  'target',      // delegate
+  'task_id',
+  'post_id',
+  'operation_id',
+  'sha256',      // artifact read
+  'title',
+  'action',      // transition
+  'status',      // task list filters
+  'content',
+] as const
+
+/** Render one argument value as the row's subject text. */
+function subjectValue(v: unknown): string | null {
+  if (typeof v === 'string') return v.trim() || null
+  if (typeof v === 'number' || typeof v === 'boolean') return String(v)
+  if (Array.isArray(v)) {
+    // argv: show it the way it was run, not as JSON.
+    const parts = v.map(p => (typeof p === 'string' ? p : JSON.stringify(p) ?? '')).filter(Boolean)
+    return parts.length > 0 ? parts.join(' ') : null
+  }
+  if (v && typeof v === 'object') {
+    try {
+      const s = JSON.stringify(v)
+      return s && s !== '{}' ? s : null
+    } catch {
+      return null
+    }
+  }
+  return null
+}
+
+/** Keep the tail of an over-long path: the file name identifies it, the root does not. */
+function truncateSubject(s: string): string {
+  const flat = s.replace(/\s+/g, ' ').trim()
+  if (flat.length <= SUBJECT_MAX_CHARS) return flat
+  if (flat.includes('/')) return `…${flat.slice(flat.length - (SUBJECT_MAX_CHARS - 1))}`
+  return `${flat.slice(0, SUBJECT_MAX_CHARS - 1)}…`
+}
+
+/**
+ * The one argument that identifies what a tool call acted on, or null when the
+ * argument shape carries none of the known keys.
+ */
+export function toolSubject(args: Record<string, unknown> | string | undefined | null): string | null {
+  if (args === undefined || args === null) return null
+  if (typeof args === 'string') {
+    const trimmed = args.trim()
+    if (!trimmed) return null
+    if (!trimmed.startsWith('{')) return truncateSubject(trimmed)
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(trimmed)
+    } catch {
+      return truncateSubject(trimmed)
+    }
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return truncateSubject(trimmed)
+    return toolSubject(parsed as Record<string, unknown>)
+  }
+  for (const key of SUBJECT_KEYS) {
+    if (!(key in args)) continue
+    const rendered = subjectValue(args[key])
+    if (rendered) return truncateSubject(rendered)
+  }
+  return null
+}

--- a/dashboard/src/demo/keeper-chat-interleave-contract-fixture.ts
+++ b/dashboard/src/demo/keeper-chat-interleave-contract-fixture.ts
@@ -1,5 +1,6 @@
 import '../styles/ds-theme-tokens.css'
 import '../styles/global.css'
+import '../styles/chat-blocks-v2.css'
 import '../styles/keeper-workspace.css'
 
 import { render } from 'preact'

--- a/dashboard/src/styles/chat-blocks-v2.css
+++ b/dashboard/src/styles/chat-blocks-v2.css
@@ -137,6 +137,21 @@
   white-space: nowrap;
 }
 
+/* What a collapsed run actually did. Takes the header's spare width so the time
+   range stays pinned right, and truncates rather than wraps: a header that grows
+   to two lines defeats the fold it labels. */
+.chat-block-trace-tools {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: left;
+  font-family: var(--font-mono);
+  font-size: var(--fs-2xs);
+  color: var(--color-fg-muted);
+}
+
 .chat-block-trace-meta {
   display: inline-flex;
   align-items: center;
@@ -169,13 +184,45 @@
   margin-top: 8px;
 }
 
+/* Tools are what a turn did, not steps beside it. Indenting them under one
+   continuous line makes a run of six Execute calls read as one turn's work.
+   Consecutive tools drop the gap so the line does not break between them. */
+.chat-block-tstep.tool {
+  margin-left: 13px;
+  padding-left: 11px;
+  border-left: 1px solid var(--color-border-default);
+}
+
+.chat-block-tstep.tool + .chat-block-tstep.tool {
+  margin-top: 0;
+  padding-top: 8px;
+}
+
+.chat-block-tstep.tool .chat-block-tnode::before {
+  width: 8px;
+}
+
 .chat-block-tnode {
+  position: relative;
   width: 7px;
   height: 7px;
   margin-top: 6px;
   border-radius: 50%;
   background: var(--color-border-strong);
   flex-shrink: 0;
+}
+
+/* The rail sits at 12px and the steps start at 28px, so without this the dots
+   float beside the line instead of hanging off it. The branch closes that gap:
+   16px of padding minus the 3px the dot's own radius already covers. */
+.chat-block-tnode::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: 100%;
+  width: 13px;
+  height: 1px;
+  background: var(--color-border-default);
 }
 .chat-block-tstep.think .chat-block-tnode,
 .chat-block-tstep.reason .chat-block-tnode {
@@ -252,6 +299,21 @@
   font-family: var(--font-mono);
   font-size: var(--fs-xs);
   color: var(--chat-tool-fg, var(--color-fg-secondary));
+  flex-shrink: 0;
+}
+
+/* The argument the call acted on. It takes the row's spare width and truncates,
+   because a path or a command is identified by its tail as much as its head and
+   a wrapped row would cost the scan-ability the subject exists to give. */
+.chat-block-tstep-subject {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: var(--fs-2xs);
+  color: var(--color-fg-muted);
 }
 
 .chat-block-tstep-status {

--- a/dashboard/src/styles/chat-blocks-v2.test.ts
+++ b/dashboard/src/styles/chat-blocks-v2.test.ts
@@ -15,6 +15,41 @@ describe('chat-blocks-v2.css', () => {
     expect(trace['flex-direction']).toBe('column')
   })
 
+  it('truncates a tool row subject instead of wrapping the row', () => {
+    const subject = declarationsForSelector(css, '.chat-block-tstep-subject')
+    expect(subject.flex).toBe('1 1 auto')
+    expect(subject['min-width']).toBe('0')
+    expect(subject.overflow).toBe('hidden')
+    expect(subject['white-space']).toBe('nowrap')
+    expect(subject['text-overflow']).toBe('ellipsis')
+  })
+
+  it('indents tool rows under a branch line so a run reads as one turn', () => {
+    const tool = declarationsForSelector(css, '.chat-block-tstep.tool')
+    expect(tool['margin-left']).toBe('13px')
+    expect(tool['border-left']).toBe('1px solid var(--color-border-default)')
+  })
+
+  it('closes the gap between consecutive tool rows so the branch line is continuous', () => {
+    const run = declarationsForSelector(css, '.chat-block-tstep.tool + .chat-block-tstep.tool')
+    expect(run['margin-top']).toBe('0')
+  })
+
+  it('hangs each step off the rail instead of leaving it floating beside it', () => {
+    const branch = declarationsForSelector(css, '.chat-block-tnode::before')
+    expect(branch.position).toBe('absolute')
+    expect(branch.right).toBe('100%')
+    expect(branch.height).toBe('1px')
+  })
+
+  it('truncates a collapsed run header summary rather than growing the header', () => {
+    const tools = declarationsForSelector(css, '.chat-block-trace-tools')
+    expect(tools.flex).toBe('1 1 auto')
+    expect(tools['min-width']).toBe('0')
+    expect(tools['white-space']).toBe('nowrap')
+    expect(tools['text-overflow']).toBe('ellipsis')
+  })
+
   it('keeps work trace and answer in one fixed-width turn bundle', () => {
     const bundle = declarationsForSelector(css, '.chat-turn-bundle')
     expect(bundle.display).toBe('flex')

--- a/lib/keeper/keeper_chat_discord.ml
+++ b/lib/keeper/keeper_chat_discord.ml
@@ -282,6 +282,7 @@ let adapter_loop_with_transport ~token ~channel_id ~events ~post_message
     | None -> None
   in
   let external_effect_completed = ref false in
+  let tool_trail = ref (Keeper_chat_tool_trail.create ()) in
   let activity_error_logged = ref false in
   let refresh_activity () =
     match show_activity with
@@ -302,7 +303,12 @@ let adapter_loop_with_transport ~token ~channel_id ~events ~post_message
         ?(last_edited_text = last_edited_text) () =
       loop ~acc_text ~msg_id ~last_edit_time ~last_edited_text
     in
-    match Keeper_chat_events.subscribe events with
+    let event = Keeper_chat_events.subscribe events in
+    (* This adapter keeps tool activity off the channel as messages; the trail
+       collects the same events so the delivered reply can still name the work.
+       See keeper_chat_tool_trail.mli. *)
+    Keeper_chat_tool_trail.on_event !tool_trail event;
+    match event with
     | Text_delta text ->
         let acc_text = acc_text ^ text in
         let patch_content = streaming_patch_content acc_text in
@@ -349,6 +355,7 @@ let adapter_loop_with_transport ~token ~channel_id ~events ~post_message
                   continue ())
          | _ -> continue ())
     | Run_finished { run_id = _ } ->
+        let delivered_text = Keeper_chat_tool_trail.append_to !tool_trail ~text:acc_text in
         let final_result =
           match msg_id with
           | None when !external_effect_completed -> Ok ()
@@ -360,9 +367,9 @@ let adapter_loop_with_transport ~token ~channel_id ~events ~post_message
                      ; reason = "primary final Discord reply contained no text"
                      ; body_bytes = 0
                      })
-              else send_message ~content:acc_text
+              else send_message ~content:delivered_text
           | Some mid ->
-              let head, overflow = final_head_and_overflow acc_text in
+              let head, overflow = final_head_and_overflow delivered_text in
               let patch_result = edit_message ~message_id:mid ~content:head in
               let overflow_result =
                 match overflow with
@@ -380,6 +387,9 @@ let adapter_loop_with_transport ~token ~channel_id ~events ~post_message
         on_send_result (send_message ~content:("Keeper error: " ^ message))
     | Run_started { run_id = _; thread_id = _ } ->
         refresh_activity ();
+        (* A new run's work is its own; the previous run's trail was delivered
+           with the previous run's reply. *)
+        tool_trail := Keeper_chat_tool_trail.create ();
         loop ~acc_text:"" ~msg_id:None ~last_edit_time:0.0
           ~last_edited_text:""
     | Text_message_start _ -> continue ()

--- a/lib/keeper/keeper_chat_discord.mli
+++ b/lib/keeper/keeper_chat_discord.mli
@@ -11,7 +11,11 @@
 
     While the run is active, the production adapter refreshes Discord's
     native typing indicator. Tool lifecycle events refresh that indicator
-    but never create standalone tool messages.
+    but never create standalone tool messages: {!Keeper_chat_tool_trail}
+    collects them into one fenced block appended to the final reply instead.
+    That block carries each call's name and the one argument it acted on -- a
+    path, a command, a search pattern -- which a channel with readers beyond
+    the keeper's operator should be bound with in mind.
 
     @since 2.145.0 *)
 
@@ -57,8 +61,10 @@ val adapter_loop :
     - [Status_block]: replace the terminal assistant text with typed status UI
       or messages.
     - [Tool_call_start], [Tool_call_args], [Tool_call_args_snapshot],
-      [Tool_call_end], and [Tool_context_block]: no message projection;
-      activity stays on Discord's native typing surface.
+      [Tool_call_end]: no message of their own; activity stays on Discord's
+      native typing surface and the calls are appended to the final reply as
+      one {!Keeper_chat_tool_trail} block. [Tool_context_block] is not
+      projected at all.
 
     [base_url] is used to build public voice-audio URLs; when omitted the
     configured {!Env_config_core.masc_http_base_url} is used.

--- a/lib/keeper/keeper_chat_slack.ml
+++ b/lib/keeper/keeper_chat_slack.ml
@@ -548,6 +548,7 @@ let adapter_loop_with_transport
     ?base_url
     ?(on_send_result = fun _ -> ()) () =
   let external_effect_completed = ref false in
+  let tool_trail = ref (Keeper_chat_tool_trail.create ()) in
   let external_effect_cleanup_result = ref (Ok ()) in
   let activity_error_logged = ref false in
   let last_activity_status = ref None in
@@ -588,7 +589,12 @@ let adapter_loop_with_transport
       loop ~acc_text ~acc_blocks ~run_id_opt ~message_id ~last_edit_time
         ~last_edited_text
     in
-    match Keeper_chat_events.subscribe events with
+    let event = Keeper_chat_events.subscribe events in
+    (* Tool activity shows here as a transient "사용 중" line that the next one
+       overwrites; the trail keeps the same events so the delivered reply can
+       still name the work. See keeper_chat_tool_trail.mli. *)
+    Keeper_chat_tool_trail.on_event !tool_trail event;
+    match event with
     | Text_delta text ->
         let acc_text = acc_text ^ text in
         let patch_content = stream_content acc_text in
@@ -642,8 +648,9 @@ let adapter_loop_with_transport
         if !external_effect_completed
         then on_send_result !external_effect_cleanup_result
         else begin
+          let delivered_text = Keeper_chat_tool_trail.append_to !tool_trail ~text:acc_text in
           let blocks =
-            final_message_blocks ~content:acc_text
+            final_message_blocks ~content:delivered_text
               ~event_blocks:(List.rev acc_blocks)
           in
           if String.length acc_text > 0 || List.length blocks > 0
@@ -651,14 +658,14 @@ let adapter_loop_with_transport
             let result =
               match streaming_transport, message_id with
               | Some (_, _, edit_final, _), Some message_id ->
-                let final_content = final_stream_content acc_text in
+                let final_content = final_stream_content delivered_text in
                 if final_content = last_edited_text && blocks = []
                 then Ok ()
                 else begin
                   pace_edit last_edit_time;
-                  edit_final ~message_id ~content:acc_text ~blocks
+                  edit_final ~message_id ~content:delivered_text ~blocks
                 end
-              | _ -> send_blocks ~content:acc_text ~blocks
+              | _ -> send_blocks ~content:delivered_text ~blocks
             in
             on_send_result result
           else
@@ -688,6 +695,9 @@ let adapter_loop_with_transport
         ()
     | Run_started { run_id; thread_id = _ } ->
         update_activity "답변을 준비하고 있어요…";
+        (* A new run's work is its own; the previous run's trail went out with
+           the previous run's reply. *)
+        tool_trail := Keeper_chat_tool_trail.create ();
         loop ~acc_text:"" ~acc_blocks:[] ~run_id_opt:(Some run_id)
           ~message_id:None ~last_edit_time:0.0 ~last_edited_text:""
     | Text_message_start { message_id = _; role = _ } ->

--- a/lib/keeper/keeper_chat_slack.mli
+++ b/lib/keeper/keeper_chat_slack.mli
@@ -91,10 +91,15 @@ val adapter_loop :
 
     Rich events ([Link_block], [Image_block], [Status_block], [Audio_block])
     are rendered as Slack Block Kit sections and included alongside the final
-    message. [Tool_call_start],
-    [Tool_call_args], [Tool_call_args_snapshot], and [Tool_call_end] are
-    projected only as native activity; [Tool_context_block] is not exposed in
-    the conversation.
+    message. [Tool_call_start], [Tool_call_args], [Tool_call_args_snapshot],
+    and [Tool_call_end] create no message of their own: they show as native
+    activity while the run is open, and {!Keeper_chat_tool_trail} collects them
+    into one fenced block appended to the terminal reply, so the delivered
+    message names the work the turn did. That block carries each call's name and
+    the one argument it acted on -- a path, a command, a search pattern -- which
+    a channel with readers beyond the keeper's operator should be bound with in
+    mind. [Tool_context_block] stays out of the conversation entirely: its
+    summaries are the tool's own account of itself, not the call's identity.
 
     [base_url] is used to build public voice-audio URLs; when omitted the
     configured {!Env_config_core.masc_http_base_url} is used.

--- a/lib/keeper/keeper_chat_tool_trail.ml
+++ b/lib/keeper/keeper_chat_tool_trail.ml
@@ -1,0 +1,214 @@
+(* See keeper_chat_tool_trail.mli for why a connector renders a turn's tools as
+   one block instead of a message per call. *)
+
+let subject_max_bytes = 72
+(* A channel delivers the trail on the same message as the reply, and the reply
+   is the part the reader asked for. *)
+let default_max_rows = 8
+
+(* Past this the padding costs more room than the alignment buys: a name like
+   masc_keeper_delegate_status would indent every other row behind it. *)
+let name_pad_max = 16
+
+type call =
+  { name : string
+  ; mutable args : string
+  }
+
+type t =
+  { by_id : (string, call) Hashtbl.t
+  ; mutable rev_order : call list
+  }
+
+let create () = { by_id = Hashtbl.create 8; rev_order = [] }
+
+let on_event t (event : Keeper_chat_events.keeper_chat_event) =
+  match event with
+  | Tool_call_start { tool_call_id; tool_call_name } ->
+    (* A repeated id is the same call, not a second one. *)
+    if not (Hashtbl.mem t.by_id tool_call_id)
+    then begin
+      let call = { name = tool_call_name; args = "" } in
+      Hashtbl.replace t.by_id tool_call_id call;
+      t.rev_order <- call :: t.rev_order
+    end
+  | Tool_call_args { tool_call_id; delta } ->
+    (match Hashtbl.find_opt t.by_id tool_call_id with
+     | None -> ()
+     | Some call -> call.args <- call.args ^ delta)
+  | Tool_call_args_snapshot { tool_call_id; snapshot } ->
+    (match Hashtbl.find_opt t.by_id tool_call_id with
+     | None -> ()
+     | Some call -> call.args <- snapshot)
+  | _ ->
+    (* Every other chat event belongs to the reply the adapter is already
+       delivering; this collector only holds the trail beside it. *)
+    ()
+;;
+
+let calls t = List.rev t.rev_order
+let call_count t = List.length t.rev_order
+
+(* --- Subject: the one argument a reader identifies a call by --------------- *)
+
+(* Ordered, not keyed by tool name: the same key means the same thing across
+   tools, and a name table would need an entry per tool. Mirrors SUBJECT_KEYS in
+   dashboard/src/components/tool-call-shared.ts. *)
+let subject_keys =
+  [ "argv" (* Execute: the command that ran *)
+  ; "command"
+  ; "cmd"
+  ; "file_path" (* Read / Edit / Write *)
+  ; "pattern" (* Grep: what it looked for, before where it looked *)
+  ; "path"
+  ; "query"
+  ; "url"
+  ; "target"
+  ; "task_id"
+  ; "post_id"
+  ; "operation_id"
+  ; "sha256"
+  ; "title"
+  ; "action"
+  ; "status"
+  ; "content"
+  ]
+;;
+
+let rec value_text (json : Yojson.Safe.t) =
+  match json with
+  | `String s ->
+    let s = String.trim s in
+    if s = "" then None else Some s
+  | `Int i -> Some (string_of_int i)
+  | `Intlit s -> Some s
+  | `Float f -> Some (Printf.sprintf "%g" f)
+  | `Bool b -> Some (string_of_bool b)
+  | `List items ->
+    (* argv: show it the way it was run, not as JSON. *)
+    (match List.filter_map value_text items with
+     | [] -> None
+     | parts -> Some (String.concat " " parts))
+  | `Assoc _ as assoc ->
+    let s = Yojson.Safe.to_string assoc in
+    if String.equal s "{}" then None else Some s
+  | `Null -> None
+;;
+
+let collapse_whitespace s =
+  let buf = Buffer.create (String.length s) in
+  let pending_space = ref false in
+  String.iter
+    (fun c ->
+      match c with
+      | ' ' | '\t' | '\n' | '\r' -> if Buffer.length buf > 0 then pending_space := true
+      | c ->
+        if !pending_space
+        then begin
+          Buffer.add_char buf ' ';
+          pending_space := false
+        end;
+        Buffer.add_char buf c)
+    s;
+  Buffer.contents buf
+;;
+
+(* A path is identified by its tail as much as its head, and '/' is always a
+   UTF-8 boundary, so segments are the safe cut points. *)
+let keep_path_tail s =
+  let segments = List.rev (String.split_on_char '/' s) in
+  let rec take kept len = function
+    | [] -> kept
+    | segment :: rest ->
+      let len' = len + String.length segment + 1 in
+      if len' > subject_max_bytes then kept else take (segment :: kept) len' rest
+  in
+  match take [] 1 segments with
+  | [] -> None
+  | kept -> Some ("…/" ^ String.concat "/" kept)
+;;
+
+let shorten s =
+  let flat = collapse_whitespace s in
+  if String.length flat <= subject_max_bytes
+  then flat
+  else (
+    match if String.contains flat '/' then keep_path_tail flat else None with
+    | Some tail -> tail
+    | None ->
+      let head, _truncated =
+        Keeper_text_processing.truncate_utf8_prefix ~max_bytes:(subject_max_bytes - 3) flat
+      in
+      head ^ "…")
+;;
+
+let subject_of_assoc fields =
+  List.find_map
+    (fun key ->
+      match List.assoc_opt key fields with
+      | None -> None
+      | Some value -> Option.map shorten (value_text value))
+    subject_keys
+;;
+
+let tool_subject ~name:_ ~args =
+  let trimmed = String.trim args in
+  if String.equal trimmed ""
+  then None
+  else (
+    match Yojson.Safe.from_string trimmed with
+    | `Assoc fields -> subject_of_assoc fields
+    | _ -> Some (shorten trimmed)
+    | exception Yojson.Json_error _ ->
+      (* Arguments still streaming in, or a provider that does not send JSON.
+         The fragment names the call better than nothing does. *)
+      Some (shorten trimmed))
+;;
+
+(* --- Rendering ------------------------------------------------------------ *)
+
+let pad_to width s =
+  let len = String.length s in
+  if len >= width then s else s ^ String.make (width - len) ' '
+;;
+
+let render ?(max_rows = default_max_rows) t =
+  match calls t with
+  | [] -> None
+  | all ->
+    let total = List.length all in
+    let shown = if total <= max_rows then all else List.filteri (fun i _ -> i < max_rows) all in
+    let hidden = total - List.length shown in
+    let name_width =
+      List.fold_left (fun acc call -> max acc (String.length call.name)) 0 shown
+      |> min name_pad_max
+    in
+    let last_row = List.length shown - 1 in
+    let row index call =
+      let branch = if index = last_row && hidden = 0 then "└" else "├" in
+      match tool_subject ~name:call.name ~args:call.args with
+      | None -> Printf.sprintf "%s %s" branch call.name
+      | Some subject ->
+        Printf.sprintf
+          "%s %s %s"
+          branch
+          (pad_to name_width call.name)
+          (Observability_redact.redact_text subject)
+    in
+    let rows = List.mapi row shown in
+    let rows = if hidden > 0 then rows @ [ Printf.sprintf "└ 그 외 %d개" hidden ] else rows in
+    Some (String.concat "\n" rows)
+;;
+
+let append_to ?max_rows t ~text =
+  if String.length text = 0
+  then text
+  else (
+    match render ?max_rows t with
+    | None -> text
+    | Some rows -> Printf.sprintf "%s\n```\n%s\n```" text rows)
+;;
+
+module For_testing = struct
+  let tool_subject = tool_subject
+end

--- a/lib/keeper/keeper_chat_tool_trail.ml
+++ b/lib/keeper/keeper_chat_tool_trail.ml
@@ -158,7 +158,12 @@ let tool_subject ~name:_ ~args =
   else (
     match Yojson.Safe.from_string trimmed with
     | `Assoc fields -> subject_of_assoc fields
-    | _ -> Some (shorten trimmed)
+    | `String _ | `Int _ | `Intlit _ | `Float _ | `Bool _ | `List _ | `Null ->
+      (* A tool whose whole argument is one scalar or array has no key to pick,
+         so the argument is its own subject. Spelled out rather than left to a
+         catch-all: a new Yojson variant should stop the build, not silently
+         land here. *)
+      Some (shorten trimmed)
     | exception Yojson.Json_error _ ->
       (* Arguments still streaming in, or a provider that does not send JSON.
          The fragment names the call better than nothing does. *)

--- a/lib/keeper/keeper_chat_tool_trail.mli
+++ b/lib/keeper/keeper_chat_tool_trail.mli
@@ -1,0 +1,58 @@
+(** Keeper_chat_tool_trail — the tool calls of one keeper turn, rendered as one
+    block of text a connector can carry on the reply it already sends.
+
+    Connector adapters see every tool event and project none of them:
+    {!Keeper_chat_discord} keeps tool activity on Discord's native typing
+    surface and {!Keeper_chat_slack} shows a transient "사용 중" line, both
+    because a message per call would bury the channel it posts to. What arrives
+    is therefore a reply with no trace of the work behind it — a turn that read
+    six files and edited two reads exactly like one answered from memory.
+
+    This collects a turn's calls and renders them once, so the work is visible
+    without a message per call and the adapters' no-standalone-message contract
+    holds.
+
+    The renderer names each call by one argument, the way the dashboard chat
+    does: see [toolSubject] in [dashboard/src/components/tool-call-shared.ts],
+    whose key order this mirrors. The two are separate because one runs in a
+    browser over a persisted trace and this one runs in the server over a live
+    stream; they are expected to name the same call the same way. *)
+
+type t
+
+val create : unit -> t
+
+val on_event : t -> Keeper_chat_events.keeper_chat_event -> unit
+(** Feed one chat event. [Tool_call_start] opens a call, [Tool_call_args]
+    appends an argument fragment to it, [Tool_call_args_snapshot] replaces the
+    fragments accumulated so far (the provider sends a snapshot instead of, not
+    in addition to, its deltas), and every other event is ignored. A fragment
+    for an id that never opened is dropped: a row with no tool name would say
+    less than no row. *)
+
+val call_count : t -> int
+(** How many calls opened this turn, including ones whose arguments never
+    arrived. *)
+
+val render : ?max_rows:int -> t -> string option
+(** The turn's calls as one text block, or [None] when the turn called no tools.
+
+    Rows past [max_rows] (default 8) are replaced by a count, because the block
+    rides along with a reply that a channel may already be close to truncating
+    and the reply is the part the reader asked for. Argument text is redacted
+    through {!Observability_redact.redact_text} before it is rendered. *)
+
+val append_to : ?max_rows:int -> t -> text:string -> string
+(** [text] with the trail appended as a fenced block — the fence is the same
+    syntax on every connector this serves, and it holds the rows' alignment.
+
+    Returns [text] unchanged when the turn called no tools, and when [text] is
+    empty: the reply is what the reader asked for, so a turn that produced none
+    keeps whatever no-text outcome its adapter already has rather than being
+    answered with a bare trail. *)
+
+module For_testing : sig
+  val tool_subject : name:string -> args:string -> string option
+  (** The one argument a reader identifies a call by, or [None] when the
+      argument shape carries none of the known keys. *)
+end

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -96,6 +96,7 @@ normal_targets=(
   @test/runtest-test_http_auth_strict_flag
   @test/runtest-test_keeper_chat_broadcast
   @test/runtest-test_keeper_chat_slack
+  @test/runtest-test_keeper_chat_tool_trail
   @test/runtest-test_keeper_memory_lane
   @test/runtest-test_server_dashboard_http_keeper_chat_page
   @test/runtest-test_keeper_codex_effort_clamp

--- a/test/dune
+++ b/test/dune
@@ -1697,6 +1697,7 @@
 (include stanzas/test_discord_wss_lifecycle.inc)
 
 (include stanzas/test_keeper_chat_discord.inc)
+(include stanzas/test_keeper_chat_tool_trail.inc)
 
 (test
  (name test_keeper_chat_slack)

--- a/test/stanzas/test_keeper_chat_tool_trail.inc
+++ b/test/stanzas/test_keeper_chat_tool_trail.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_chat_tool_trail)
+ (modules test_keeper_chat_tool_trail)
+ (libraries alcotest masc_test_deps))

--- a/test/test_keeper_chat_discord.ml
+++ b/test/test_keeper_chat_discord.ml
@@ -339,8 +339,14 @@ let test_tool_activity_uses_native_surface_without_messages () =
   in
   check int "run start and tool start refresh native activity" 2
     !activity_refreshes;
-  check (list string) "only the final reply is sent" [ "done" ]
+  (* The tool trail rides on that one reply. Tool activity still creates no
+     message of its own -- post_message and edit_message fail the test above if
+     it does -- which is the property this case exists to hold. *)
+  check (list string) "only the final reply is sent, carrying the turn's trail"
+    [ "done\n```\n\xe2\x94\x94 keeper_surface_read\n```" ]
     (List.rev !final_sends);
+  check bool "private tool context never reaches the channel" false
+    (List.exists (fun sent -> contains sent "private tool result") !final_sends);
   check_single_ok "activity failure does not affect delivery" outcomes
 
 let () =

--- a/test/test_keeper_chat_slack.ml
+++ b/test/test_keeper_chat_slack.ml
@@ -539,8 +539,17 @@ let test_native_activity_failure_does_not_affect_delivery () =
   check (list string) "typed activity lifecycle"
     [ "답변을 준비하고 있어요…"; "🔧 keeper_surface_post 사용 중…"; "" ]
     (List.rev !statuses);
-  check (list string) "tool context is not exposed" [ "final" ]
+  (* The trail names the call the turn made. Tool_context_block's summaries are
+     a different thing and stay off the channel -- that is the property this
+     case exists to hold, so it is now checked for itself rather than implied
+     by the reply being bare. *)
+  check (list string) "the reply carries the call's name"
+    [ "final\n```\n\xe2\x94\x94 keeper_surface_post\n```" ]
     (List.rev !sends);
+  check bool "private tool context never reaches the channel" false
+    (List.exists
+       (fun sent -> contains sent "private args" || contains sent "private result")
+       !sends);
   check bool "delivery still succeeds" true (outcomes = [ Ok () ])
 
 let disposition_testable =

--- a/test/test_keeper_chat_tool_trail.ml
+++ b/test/test_keeper_chat_tool_trail.ml
@@ -1,0 +1,222 @@
+(* Keeper_chat_tool_trail turns the tool events a connector adapter deliberately
+   does not project into one block it can carry on the reply. These cases pin
+   what a reader gets from that block. *)
+
+module Trail = Masc.Keeper_chat_tool_trail
+module Events = Masc.Keeper_chat_events
+
+let subject ~name ~args = Trail.For_testing.tool_subject ~name ~args
+
+let check_subject description ~args expected =
+  Alcotest.(check (option string)) description expected (subject ~name:"Tool" ~args)
+;;
+
+(* --- subject ------------------------------------------------------------- *)
+
+let test_subject_argv () =
+  check_subject
+    "argv renders as the command that ran"
+    ~args:{|{"argv":["git","fetch","origin"],"cwd":"repos/masc","timeout_sec":120}|}
+    (Some "git fetch origin")
+;;
+
+let test_subject_file_path () =
+  check_subject
+    "a file call is named by its path"
+    ~args:{|{"file_path":"repos/masc/lib/tool_agent.ml","limit":40}|}
+    (Some "repos/masc/lib/tool_agent.ml")
+;;
+
+let test_subject_pattern_before_path () =
+  check_subject
+    "a search is named by what it looked for, not where"
+    ~args:{|{"glob":"*.ml","path":"repos/masc/lib","pattern":"agent block"}|}
+    (Some "agent block")
+;;
+
+let test_subject_absent_keys () =
+  check_subject
+    "an argument shape with no known key names nothing"
+    ~args:{|{"include_done":true,"if_revision":12}|}
+    None
+;;
+
+let test_subject_empty_args () = check_subject "no arguments name nothing" ~args:"" None
+
+let test_subject_empty_value () =
+  check_subject "an empty value is not a name" ~args:{|{"file_path":"   "}|} None
+;;
+
+let test_subject_partial_json () =
+  (* Arguments stream in as fragments; a fragment still names the call better
+     than nothing does. *)
+  check_subject
+    "an unparsable fragment falls back to its own text"
+    ~args:{|{"file_path":"lib/keep|}
+    (Some {|{"file_path":"lib/keep|})
+;;
+
+let test_subject_keeps_path_tail () =
+  let long = "repos/masc/" ^ String.concat "" (List.init 20 (fun _ -> "nested/")) ^ "target.ml" in
+  match subject ~name:"Read" ~args:(Printf.sprintf {|{"file_path":%S}|} long) with
+  | None -> Alcotest.fail "a long path should still name the call"
+  | Some rendered ->
+    Alcotest.(check bool) "keeps the file name" true (Filename.basename rendered = "target.ml");
+    Alcotest.(check bool) "marks the cut" true (String.length rendered > 0 && rendered.[0] = '\xe2');
+    Alcotest.(check bool) "stays within the row budget" true (String.length rendered <= 72)
+;;
+
+(* --- accumulation and rendering ------------------------------------------ *)
+
+let trail_of events =
+  let t = Trail.create () in
+  List.iter (Trail.on_event t) events;
+  t
+;;
+
+let tool_start id name =
+  Events.Tool_call_start { tool_call_id = id; tool_call_name = name }
+;;
+
+let tool_args id delta = Events.Tool_call_args { tool_call_id = id; delta }
+
+let tool_snapshot id snapshot =
+  Events.Tool_call_args_snapshot { tool_call_id = id; snapshot }
+;;
+
+let test_no_tools_renders_nothing () =
+  let t = trail_of [ Events.Text_delta "answered from memory" ] in
+  Alcotest.(check int) "no calls" 0 (Trail.call_count t);
+  Alcotest.(check (option string)) "no block" None (Trail.render t)
+;;
+
+let test_argument_deltas_accumulate () =
+  let t =
+    trail_of
+      [ tool_start "c1" "Read"
+      ; tool_args "c1" {|{"file_pa|}
+      ; tool_args "c1" {|th":"lib/a.ml"}|}
+      ]
+  in
+  Alcotest.(check (option string))
+    "deltas join into one argument object"
+    (Some "└ Read lib/a.ml")
+    (Trail.render t)
+;;
+
+let test_snapshot_replaces_deltas () =
+  (* The provider sends a snapshot instead of its deltas, not in addition. *)
+  let t =
+    trail_of
+      [ tool_start "c1" "Read"; tool_args "c1" {|{"file_path":"wr|}
+      ; tool_snapshot "c1" {|{"file_path":"lib/right.ml"}|}
+      ]
+  in
+  Alcotest.(check (option string))
+    "the snapshot wins"
+    (Some "└ Read lib/right.ml")
+    (Trail.render t)
+;;
+
+let test_fragment_for_unknown_id_is_dropped () =
+  let t = trail_of [ tool_args "never-opened" {|{"file_path":"lib/a.ml"}|} ] in
+  Alcotest.(check int) "no call opened" 0 (Trail.call_count t);
+  Alcotest.(check (option string)) "nothing to render" None (Trail.render t)
+;;
+
+let test_repeated_start_is_one_call () =
+  let t = trail_of [ tool_start "c1" "Read"; tool_start "c1" "Read" ] in
+  Alcotest.(check int) "same id is the same call" 1 (Trail.call_count t)
+;;
+
+let test_rows_keep_call_order_and_branch () =
+  let t =
+    trail_of
+      [ tool_start "c1" "Read"
+      ; tool_snapshot "c1" {|{"file_path":"lib/a.ml"}|}
+      ; tool_start "c2" "Execute"
+      ; tool_snapshot "c2" {|{"argv":["git","status"]}|}
+      ]
+  in
+  Alcotest.(check (option string))
+    "rows follow the order the calls opened, last one closing the branch"
+    (Some "├ Read    lib/a.ml\n└ Execute git status")
+    (Trail.render t)
+;;
+
+let test_rows_past_the_cap_become_a_count () =
+  let events =
+    List.concat_map
+      (fun i ->
+        let id = Printf.sprintf "c%d" i in
+        [ tool_start id "Read"; tool_snapshot id (Printf.sprintf {|{"file_path":"lib/%d.ml"}|} i) ])
+      (List.init 5 Fun.id)
+  in
+  match Trail.render ~max_rows:2 (trail_of events) with
+  | None -> Alcotest.fail "five calls should render"
+  | Some rendered ->
+    let lines = String.split_on_char '\n' rendered in
+    Alcotest.(check int) "two rows and the count" 3 (List.length lines);
+    Alcotest.(check string) "the count names what it left out" "└ 그 외 3개" (List.nth lines 2)
+;;
+
+let test_call_without_arguments_still_gets_a_row () =
+  let t = trail_of [ tool_start "c1" "keeper_context_status" ] in
+  Alcotest.(check (option string))
+    "a call with no arguments is still work the reader should see"
+    (Some "└ keeper_context_status")
+    (Trail.render t)
+;;
+
+(* --- append_to ------------------------------------------------------------ *)
+
+let test_append_to_fences_the_block () =
+  let t = trail_of [ tool_start "c1" "Read"; tool_snapshot "c1" {|{"file_path":"lib/a.ml"}|} ] in
+  Alcotest.(check string)
+    "the reply keeps its text and gains a fenced trail"
+    "answer\n```\n└ Read lib/a.ml\n```"
+    (Trail.append_to t ~text:"answer")
+;;
+
+let test_append_to_leaves_a_toolless_reply_alone () =
+  let t = trail_of [] in
+  Alcotest.(check string) "unchanged" "answer" (Trail.append_to t ~text:"answer")
+;;
+
+let test_append_to_leaves_an_empty_reply_empty () =
+  (* A turn with no text keeps whatever no-text outcome its adapter has; a bare
+     trail is not an answer. *)
+  let t = trail_of [ tool_start "c1" "Read"; tool_snapshot "c1" {|{"file_path":"lib/a.ml"}|} ] in
+  Alcotest.(check string) "unchanged" "" (Trail.append_to t ~text:"")
+;;
+
+let () =
+  Alcotest.run
+    "keeper_chat_tool_trail"
+    [ ( "subject"
+      , [ Alcotest.test_case "argv" `Quick test_subject_argv
+        ; Alcotest.test_case "file_path" `Quick test_subject_file_path
+        ; Alcotest.test_case "pattern before path" `Quick test_subject_pattern_before_path
+        ; Alcotest.test_case "unknown keys" `Quick test_subject_absent_keys
+        ; Alcotest.test_case "empty args" `Quick test_subject_empty_args
+        ; Alcotest.test_case "empty value" `Quick test_subject_empty_value
+        ; Alcotest.test_case "partial json" `Quick test_subject_partial_json
+        ; Alcotest.test_case "long path keeps its tail" `Quick test_subject_keeps_path_tail
+        ] )
+    ; ( "trail"
+      , [ Alcotest.test_case "no tools" `Quick test_no_tools_renders_nothing
+        ; Alcotest.test_case "deltas accumulate" `Quick test_argument_deltas_accumulate
+        ; Alcotest.test_case "snapshot replaces" `Quick test_snapshot_replaces_deltas
+        ; Alcotest.test_case "unknown id dropped" `Quick test_fragment_for_unknown_id_is_dropped
+        ; Alcotest.test_case "repeated start" `Quick test_repeated_start_is_one_call
+        ; Alcotest.test_case "order and branch" `Quick test_rows_keep_call_order_and_branch
+        ; Alcotest.test_case "cap becomes a count" `Quick test_rows_past_the_cap_become_a_count
+        ; Alcotest.test_case "no arguments" `Quick test_call_without_arguments_still_gets_a_row
+        ] )
+    ; ( "append_to"
+      , [ Alcotest.test_case "fences the block" `Quick test_append_to_fences_the_block
+        ; Alcotest.test_case "no tools" `Quick test_append_to_leaves_a_toolless_reply_alone
+        ; Alcotest.test_case "empty reply" `Quick test_append_to_leaves_an_empty_reply_empty
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 왜

키퍼가 `Execute`를 여섯 번 돌려도 채팅에는 `Execute` 여섯 줄이 똑같이 찍혔어요. 무엇을 실행했는지는 각 줄을 열어봐야 알 수 있었고, 커넥터(Discord·Slack)로 나가는 답장에는 도구 흔적이 아예 없었습니다.

참고한 화면은 [pi coding-agent의 tree view](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/images/tree-view.png)입니다. 저기가 읽히는 이유는 펼쳐놔서가 아니라 **줄마다 주어가 있어서**예요. `[read: src/core/sdk.ts]`, `[bash: git status]`처럼요.

## 확인한 것

| | 상태 | 근거 |
|---|---|---|
| 대시보드 도구 줄 | 이름만 표시 | `primitives.ts` 도구 헤더가 `step.name`만 렌더. 인자는 백엔드가 이미 보내고 있었음 (`server_dashboard_http_keeper_api_trace.ml`) |
| 위계 | CSS에 없음 | 레일(`left:12px`)과 노드가 이어져 있지 않았음 |
| 접힌 헤더 | 내용 불명 | `자율턴 145개` — 13시간치가 한 줄. 무슨 일을 했는지는 안 나옴 |
| 커넥터 | 구조 0 | `gate_keeper_backend.ml`의 `structured = None`이 유일한 사용처. 도구 이벤트는 받아서 버림 |

## 무엇을 바꿨나

**대시보드**
- 도구 줄에 그 호출이 만진 대상을 붙였습니다 — `Read  lib/keeper/keeper_chat_blocks.ml`
- 도구 줄을 한 단계 들여쓰고 이어진 선 아래 묶어, 연속 호출이 한 턴의 작업으로 읽히게 했습니다
- 각 스텝이 레일에 매달리도록 가지를 그렸습니다
- 접힌 자율턴 헤더가 그 안에서 무슨 도구를 썼는지 말합니다 — `Read Execute×6 Grep +2`

**커넥터**
- `Keeper_chat_tool_trail` 모듈을 추가했습니다. 두 어댑터가 이미 받고 버리던 도구 이벤트를 모아, 보내려던 답장 끝에 코드블록 한 장으로 붙입니다.
- 호출마다 메시지를 만들지 않으므로 기존 계약(standalone 메시지 금지)은 그대로입니다.

```
작업을 마쳤어요.
├ Read    lib/keeper/keeper_chat_blocks.ml
├ Execute git fetch origin
└ Grep    agent block
```

## 접는 건 그대로 둡니다

`#28065`가 자율턴을 접은 이유(키퍼가 분당 한 번 깨어나 99행이 연속으로 쌓임)는 지금도 유효해요. 그래서 **행 수를 늘리지 않고 각 행이 말하는 양만 늘렸습니다.** 펼쳐 보고 싶으면 `#29104`가 넣은 Tweaks 토글이 이미 있습니다.

## 노출 범위

트레일에는 경로·명령어·검색어가 그대로 들어갑니다. 두 `.mli`에 그 사실을 적어뒀어요 — 채널을 바인딩할 때 감안해야 하는 부분이라서요. `Tool_context_block`의 요약(도구가 자기 자신에 대해 말하는 내용)은 계속 채널로 나가지 않고, 이번에 그걸 **명시적으로 검사하도록** 테스트를 강화했습니다. 전에는 답장이 비어 있다는 사실로 간접 확인하고 있었습니다.

## 검증

| 항목 | 결과 |
|---|---|
| `vitest` (tool-call-shared) | 43 통과 (신규 8) |
| `vitest` (chat/primitives) | 150 통과 (신규 7) |
| `vitest` (chat-blocks-v2 CSS 계약) | 7 통과 (신규 5) |
| `tsc --noEmit` / `eslint` | 통과 |
| `dune build @check` | 통과 |
| `test_keeper_chat_tool_trail` | 19 통과 (신규) |
| `test_keeper_chat_discord` | 19 통과 |
| `test_keeper_chat_slack` | 35 통과 |
| `audit-ci-test-targets.sh` | 380 타깃, unwired 516 — baseline |
| `audit-dead-surface.py --exports --ratchet` | 537 — baseline |

새 테스트는 `scripts/ci-run-focused-tests.sh` allowlist에도 등록했습니다.

## 아직 안 본 것

- 실제 Discord/Slack 채널에 나가는 렌더는 어댑터 테스트로만 확인했고, 실물 전송은 아직입니다.
- 대시보드는 dev 서버 픽스처로 확인했습니다. 배포 후 라이브 트랜스크립트에서 한 번 더 봐야 합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019aJnBnLwzk1domqs3wqzZe