### PR TITLE
perf(tui): bound Keeper metrics tail reads

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -224,6 +224,12 @@
  (libraries masc.masc_core))
 
 (library
+ (name masc_tui_metrics_tail)
+ (wrapped false)
+ (modules masc_tui_metrics_tail)
+ (libraries masc dated_jsonl))
+
+(library
  (name masc_tui_context_state)
  (wrapped false)
  (modules masc_tui_context_state)
@@ -256,6 +262,7 @@
   masc_tui_context_state
   masc_tui_keeper_chat_projection
   masc_tui_message_layout
+  masc_tui_metrics_tail
   masc_tui_observation_layout
   masc_tui_operator_projection
   masc_tui_render_schedule

--- a/bin/masc_tui.ml
+++ b/bin/masc_tui.ml
@@ -5,6 +5,7 @@ open Masc_tui_loader
 
 module Approval = Masc_tui_operator_projection
 module Keeper_chat = Masc_tui_keeper_chat_projection
+module Metrics_tail = Masc_tui_metrics_tail
 module Render_schedule = Masc_tui_render_schedule
 
 (** Local exception for breaking the main TUI loop without using Exit. *)
@@ -15,6 +16,10 @@ exception Break
 let frame_interval_ns = 16_000_000L
 let maximum_input_wait_seconds = 0.016
 let nanoseconds_per_second = 1_000_000_000.0
+
+let keeper_log_content_height (state : state) =
+  let rows, _columns = get_terminal_size () in
+  Metrics_tail.content_height ~terminal_rows:rows ~error:state.log_error
 
 (** Read a single byte from stdin, returning Some char or None. *)
 let read_byte_unix ?(timeout = 0.1) () : char option =
@@ -941,10 +946,8 @@ let main () =
            (* Also reload logs / board / planning detail if viewing them *)
            (match state.view with
             | Keepers Keeper_logs ->
-                (match List.nth_opt state.keepers state.keeper_cursor with
-                 | Some k ->
-                     state.log_entries <- load_keeper_logs base_path k.k_name 200
-                 | None -> ())
+                load_selected_keeper_logs state base_path 200
+                  (List.nth_opt state.keepers state.keeper_cursor)
             | Board ->
                 (match state.board_mode with
                  | Board_read post_id ->
@@ -1013,7 +1016,11 @@ let main () =
             | Keepers Keeper_detail ->
                 state.detail_scroll <- state.detail_scroll + 1
             | Keepers Keeper_logs ->
-                state.log_scroll <- state.log_scroll + 1
+                state.log_scroll <-
+                  Metrics_tail.scroll_down
+                    ~entry_count:(List.length state.log_entries)
+                    ~content_height:(keeper_log_content_height state)
+                    state.log_scroll
             | Approvals ->
                 let count = List.length (approval_items state) in
                 if state.approval_cursor < count - 1 then begin
@@ -1053,8 +1060,11 @@ let main () =
                 if state.detail_scroll > 0 then
                   state.detail_scroll <- state.detail_scroll - 1
             | Keepers Keeper_logs ->
-                if state.log_scroll > 0 then
-                  state.log_scroll <- state.log_scroll - 1
+                state.log_scroll <-
+                  Metrics_tail.scroll_up
+                    ~entry_count:(List.length state.log_entries)
+                    ~content_height:(keeper_log_content_height state)
+                    state.log_scroll
             | Approvals ->
                 if state.approval_cursor > 0 then begin
                   state.pending_approval_action <- None;
@@ -1122,10 +1132,16 @@ let main () =
            (* L opens log view from detail *)
            (match state.view with
             | Keepers Keeper_detail ->
-                (match List.nth_opt state.keepers state.keeper_cursor with
-                 | Some k ->
-                     state.log_entries <- load_keeper_logs base_path k.k_name 200;
-                     state.log_scroll <- max 0 (List.length state.log_entries - 1);
+                let keeper =
+                  List.nth_opt state.keepers state.keeper_cursor
+                in
+                load_selected_keeper_logs state base_path 200 keeper;
+                (match keeper with
+                 | Some _ ->
+                     state.log_scroll <-
+                       Metrics_tail.maximum_scroll
+                         ~entry_count:(List.length state.log_entries)
+                         ~content_height:(keeper_log_content_height state);
                      state.view <- Keepers Keeper_logs
                  | None -> ())
             | Overview | Keepers Keeper_list | Keepers Keeper_logs | Keepers Keeper_message
@@ -1162,10 +1178,8 @@ let main () =
         (* Also refresh logs / board / planning detail if viewing them *)
         (match state.view with
          | Keepers Keeper_logs ->
-             (match List.nth_opt state.keepers state.keeper_cursor with
-              | Some k ->
-                  state.log_entries <- load_keeper_logs base_path k.k_name 200
-              | None -> ())
+             load_selected_keeper_logs state base_path 200
+               (List.nth_opt state.keepers state.keeper_cursor)
          | Board ->
              (match state.board_mode with
               | Board_read post_id ->

--- a/bin/masc_tui_loader.ml
+++ b/bin/masc_tui_loader.ml
@@ -87,7 +87,9 @@ let load_selected_keeper_logs (state : state) (base_path : string)
   Metrics_tail.for_selection
     ~load:(fun keeper ->
       Keeper_types_support.keeper_metrics_store config keeper.k_name
-      |> fun store -> Metrics_tail.load ~store ~limit:max_entries)
+      |> fun store ->
+      Metrics_tail.load ~store ~expected_keeper:keeper.k_name
+        ~limit:max_entries)
     keeper
   |> apply_keeper_log_snapshot state
 

--- a/bin/masc_tui_loader.ml
+++ b/bin/masc_tui_loader.ml
@@ -4,6 +4,7 @@ module Keeper_meta_store = Masc.Keeper_meta_store
 module Keeper_types_support = Masc.Keeper_types_support
 module Keeper_types_profile = Masc.Keeper_types_profile
 module Context_state = Masc_tui_context_state
+module Metrics_tail = Masc_tui_metrics_tail
 
 open Masc_tui_types
 open Tui_decode
@@ -71,76 +72,24 @@ let load_active_tasks (base_path : string) : task list * string option =
       ( Tui_decode.active_tasks_of_domain observation.observed_backlog.tasks
       , recovery_error )
 
-(** Read the last N lines from a file (tail) *)
-let read_last_lines path n =
-  try
-    let ic = open_in path in
-    Fun.protect
-      ~finally:(fun () -> close_in_noerr ic)
-      (fun () ->
-        (* Read all lines then take last N -- simple for JSONL files < 1MB *)
-        let lines = ref [] in
-        (try while true do
-           lines := input_line ic :: !lines
-         done with End_of_file -> ());
-        let all = List.rev !lines in
-        let len = List.length all in
-        if len <= n then all
-        else
-          List.filteri (fun i _ -> i >= len - n) all)
-  with Sys_error _ -> []
+(** Apply one strict bounded metrics snapshot to the mutable screen state. *)
+let apply_keeper_log_snapshot (state : state)
+    (snapshot : Metrics_tail.snapshot) =
+  state.log_entries <- snapshot.entries;
+  state.log_error <- snapshot.error;
+  state.log_scroll <-
+    min state.log_scroll (max 0 (List.length snapshot.entries - 1))
 
-(** Parse a single metrics JSONL line into a log_entry *)
-let parse_log_entry (line : string) : log_entry option =
-  match Tui_decode.parse_log_entry line with
-  | Ok entry -> Some entry
-  | Error err ->
-      Printf.eprintf "[masc-tui] log decode failed: %s\n%!" err;
-      None
-
-(** Find the most recent metrics file for a keeper *)
-let find_metrics_files (base_path : string) (keeper_name : string) : string list =
+(** Load the newest physical metrics rows across months and rotations. *)
+let load_selected_keeper_logs (state : state) (base_path : string)
+    (max_entries : int) (keeper : keeper option) =
   let config = Workspace_core.default_config base_path in
-  let metrics_dir = Keeper_types_support.keeper_metrics_dir config keeper_name in
-  if not (Sys.file_exists metrics_dir && Sys.is_directory metrics_dir) then []
-  else begin
-    (* List year-month directories, pick the most recent *)
-    let months = Sys.readdir metrics_dir
-      |> Array.to_list
-      |> List.filter (fun d ->
-           let full = Filename.concat metrics_dir d in
-           Sys.is_directory full)
-      |> List.sort (fun a b -> String.compare b a)  (* Reverse sort: most recent first *)
-    in
-    match months with
-    | [] -> []
-    | month :: _ ->
-      let month_dir = Filename.concat metrics_dir month in
-      Sys.readdir month_dir
-      |> Array.to_list
-      |> List.filter (fun f -> Filename.check_suffix f ".jsonl")
-      |> List.sort (fun a b -> String.compare b a)  (* Most recent first *)
-      |> List.map (fun f -> Filename.concat month_dir f)
-  end
-
-(** Load log entries for the currently selected keeper *)
-let load_keeper_logs (base_path : string) (keeper_name : string) (max_entries : int) : log_entry list =
-  let files = find_metrics_files base_path keeper_name in
-  let entries = ref [] in
-  let remaining = ref max_entries in
-  List.iter (fun path ->
-    if !remaining > 0 then begin
-      let lines = read_last_lines path !remaining in
-      let parsed = List.filter_map parse_log_entry lines in
-      entries := parsed @ !entries;
-      remaining := !remaining - List.length parsed
-    end
-  ) files;
-  (* Return in chronological order, limited to max_entries *)
-  let all = List.rev !entries in
-  let len = List.length all in
-  if len <= max_entries then all
-  else List.filteri (fun i _ -> i >= len - max_entries) all
+  Metrics_tail.for_selection
+    ~load:(fun keeper ->
+      Keeper_types_support.keeper_metrics_store config keeper.k_name
+      |> fun store -> Metrics_tail.load ~store ~limit:max_entries)
+    keeper
+  |> apply_keeper_log_snapshot state
 
 (** Apply one exclusive context projection to the mutable screen state. *)
 let apply_live_context_state (state : state) (context_state : Context_state.t) =
@@ -216,9 +165,21 @@ let load_from_masc_dir (state : state) (base_path : string) =
           | None -> min state.keeper_cursor (max 0 (List.length state.keepers - 1)))
      | None -> min state.keeper_cursor (max 0 (List.length state.keepers - 1)));
 
-  (* Load live context for selected keeper *)
-  load_selected_live_context state base_path
-    (List.nth_opt state.keepers state.keeper_cursor);
+  let selected_keeper = List.nth_opt state.keepers state.keeper_cursor in
+
+  (* Load live context for the selected keeper. Metadata-only refresh paths do
+     not read metrics, but an empty roster must clear any cached log state. *)
+  load_selected_live_context state base_path selected_keeper;
+  let current_logs : Metrics_tail.snapshot =
+    { entries = state.log_entries; error = state.log_error }
+  in
+  let selected_keeper_name_after_refresh =
+    Option.map (fun keeper -> keeper.k_name) selected_keeper
+  in
+  Metrics_tail.reconcile_selection ~current:current_logs
+    ~previous_keeper:selected_keeper_name
+    ~selected_keeper:selected_keeper_name_after_refresh
+  |> apply_keeper_log_snapshot state;
 
   state.last_refresh <- Unix.gettimeofday ()
 

--- a/bin/masc_tui_metrics_tail.ml
+++ b/bin/masc_tui_metrics_tail.ml
@@ -1,0 +1,117 @@
+module Decode = Masc.Tui_decode
+
+type row_error =
+  | Malformed_json of {
+      path : string;
+      line_number : int option;
+      detail : string;
+    }
+  | Invalid_metrics_row of {
+      physical_index : int;
+      detail : string;
+    }
+
+type load_error =
+  | Storage_error of Dated_jsonl.read_error
+  | Row_errors of {
+      physical_rows : int;
+      errors : row_error list;
+    }
+
+type snapshot = {
+  entries : Decode.log_entry list;
+  error : load_error option;
+}
+
+let empty = { entries = []; error = None }
+
+let row_error_to_string = function
+  | Malformed_json { path; line_number; detail } ->
+      let location =
+        match line_number with
+        | Some line -> Printf.sprintf "%s:%d" path line
+        | None -> path
+      in
+      Printf.sprintf "malformed JSON at %s: %s" location detail
+  | Invalid_metrics_row { physical_index; detail } ->
+      Printf.sprintf "physical row %d is not current Keeper metrics: %s"
+        physical_index detail
+
+let error_to_string = function
+  | Storage_error error ->
+      "metrics storage read failed: " ^ Dated_jsonl.read_error_to_string error
+  | Row_errors { physical_rows; errors } ->
+      let rejected = List.length errors in
+      let first =
+        match errors with
+        | first :: _ -> row_error_to_string first
+        | [] -> "unknown row error"
+      in
+      let suffix =
+        if rejected <= 1 then ""
+        else Printf.sprintf " (+%d more)" (rejected - 1)
+      in
+      Printf.sprintf "metrics tail rejected %d/%d physical rows: %s%s" rejected
+        physical_rows first suffix
+
+let resolve_with ~read_recent ~limit =
+  match read_recent limit with
+  | Error error -> { entries = []; error = Some (Storage_error error) }
+  | Ok rows ->
+      let indexed = List.mapi (fun index row -> index + 1, row) rows in
+      let entries, errors =
+        List.fold_right
+          (fun (physical_index, row) (entries, errors) ->
+            match row with
+            | Dated_jsonl.Parsed json -> (
+                match Decode.decode_log_entry json with
+                | Ok entry -> entry :: entries, errors
+                | Error detail ->
+                    ( entries,
+                      Invalid_metrics_row { physical_index; detail } :: errors ))
+            | Dated_jsonl.Malformed_json { path; line_number; detail } ->
+                ( entries,
+                  Malformed_json { path; line_number; detail } :: errors ))
+          indexed ([], [])
+      in
+      let error =
+        match errors with
+        | [] -> None
+        | _ -> Some (Row_errors { physical_rows = List.length rows; errors })
+      in
+      { entries; error }
+
+let load ~store ~limit =
+  resolve_with ~read_recent:(Dated_jsonl.read_recent_result store) ~limit
+
+let for_selection ~load = function
+  | Some keeper -> load keeper
+  | None -> empty
+
+let reconcile_selection ~current ~previous_keeper ~selected_keeper =
+  match previous_keeper, selected_keeper with
+  | Some previous, Some selected when String.equal previous selected -> current
+  | Some _, Some _ | Some _, None | None, Some _ | None, None -> empty
+
+let content_height ~terminal_rows ~error =
+  let diagnostic_rows = if Option.is_some error then 2 else 0 in
+  max 0 (terminal_rows - 8 - diagnostic_rows)
+
+let maximum_scroll ~entry_count ~content_height =
+  max 0 (entry_count - content_height)
+
+let normalize_scroll ~entry_count ~content_height scroll =
+  max 0 (min scroll (maximum_scroll ~entry_count ~content_height))
+
+let scroll_up ~entry_count ~content_height scroll =
+  max 0 (normalize_scroll ~entry_count ~content_height scroll - 1)
+
+let scroll_down ~entry_count ~content_height scroll =
+  min
+    (maximum_scroll ~entry_count ~content_height)
+    (normalize_scroll ~entry_count ~content_height scroll + 1)
+
+let empty_message = function
+  | None -> "(no log entries found)"
+  | Some (Storage_error _) -> "(log entries unavailable)"
+  | Some (Row_errors _) -> "(no valid rows in newest physical window)"

--- a/bin/masc_tui_metrics_tail.ml
+++ b/bin/masc_tui_metrics_tail.ml
@@ -54,7 +54,28 @@ let error_to_string = function
       Printf.sprintf "metrics tail rejected %d/%d physical rows: %s%s" rejected
         physical_rows first suffix
 
-let resolve_with ~read_recent ~limit =
+let decode_for_keeper ~expected_keeper json =
+  match Decode.decode_log_entry json with
+  | Error detail -> Error detail
+  | Ok entry ->
+      let actual_keeper =
+        match json with
+        | `Assoc fields ->
+            (match List.assoc_opt "name" fields with
+             | Some (`String name) -> Some name
+             | Some _ | None -> None)
+        | _ -> None
+      in
+      (match actual_keeper with
+       | Some actual when String.equal actual expected_keeper -> Ok entry
+       | Some actual ->
+           Error
+             (Printf.sprintf
+                "metrics Keeper name %S does not match selected Keeper %S"
+                actual expected_keeper)
+       | None -> Error "current Keeper metrics row lost its required name")
+
+let resolve_with ~expected_keeper ~read_recent ~limit =
   match read_recent limit with
   | Error error -> { entries = []; error = Some (Storage_error error) }
   | Ok rows ->
@@ -64,7 +85,7 @@ let resolve_with ~read_recent ~limit =
           (fun (physical_index, row) (entries, errors) ->
             match row with
             | Dated_jsonl.Parsed json -> (
-                match Decode.decode_log_entry json with
+                match decode_for_keeper ~expected_keeper json with
                 | Ok entry -> entry :: entries, errors
                 | Error detail ->
                     ( entries,
@@ -81,8 +102,9 @@ let resolve_with ~read_recent ~limit =
       in
       { entries; error }
 
-let load ~store ~limit =
-  resolve_with ~read_recent:(Dated_jsonl.read_recent_result store) ~limit
+let load ~store ~expected_keeper ~limit =
+  resolve_with ~expected_keeper
+    ~read_recent:(Dated_jsonl.read_recent_result store) ~limit
 
 let for_selection ~load = function
   | Some keeper -> load keeper

--- a/bin/masc_tui_metrics_tail.mli
+++ b/bin/masc_tui_metrics_tail.mli
@@ -30,12 +30,14 @@ val error_to_string : load_error -> string
 (** Operator-facing diagnostic that delegates storage failures to
     [Dated_jsonl.read_error_to_string]. *)
 val resolve_with :
+  expected_keeper:string ->
   read_recent:(int -> (Dated_jsonl.recent_entry list, Dated_jsonl.read_error) result) ->
   limit:int ->
   snapshot
-val load : store:Dated_jsonl.t -> limit:int -> snapshot
+val load : store:Dated_jsonl.t -> expected_keeper:string -> limit:int -> snapshot
 (** Read exactly the newest [limit] physical non-empty rows. Rejected rows
-    consume that bound and are reported; they are never backfilled. *)
+    and rows attributed to a different Keeper consume that bound and are
+    reported; they are never backfilled. *)
 val for_selection : load:('a -> snapshot) -> 'a option -> snapshot
 val reconcile_selection :
   current:snapshot ->

--- a/bin/masc_tui_metrics_tail.mli
+++ b/bin/masc_tui_metrics_tail.mli
@@ -1,0 +1,52 @@
+module Decode = Masc.Tui_decode
+
+type row_error =
+  | Malformed_json of {
+      path : string;
+      line_number : int option;
+      detail : string;
+    }
+  | Invalid_metrics_row of {
+      (** One-based chronological position inside the selected physical-row
+          window; this is not a source-file line number. *)
+      physical_index : int;
+      detail : string;
+    }
+
+type load_error =
+  | Storage_error of Dated_jsonl.read_error
+  | Row_errors of {
+      physical_rows : int;
+      errors : row_error list;
+    }
+
+type snapshot = {
+  entries : Decode.log_entry list;
+  error : load_error option;
+}
+
+val empty : snapshot
+val error_to_string : load_error -> string
+(** Operator-facing diagnostic that delegates storage failures to
+    [Dated_jsonl.read_error_to_string]. *)
+val resolve_with :
+  read_recent:(int -> (Dated_jsonl.recent_entry list, Dated_jsonl.read_error) result) ->
+  limit:int ->
+  snapshot
+val load : store:Dated_jsonl.t -> limit:int -> snapshot
+(** Read exactly the newest [limit] physical non-empty rows. Rejected rows
+    consume that bound and are reported; they are never backfilled. *)
+val for_selection : load:('a -> snapshot) -> 'a option -> snapshot
+val reconcile_selection :
+  current:snapshot ->
+  previous_keeper:string option ->
+  selected_keeper:string option ->
+  snapshot
+(** Retain a cached snapshot only while the selected Keeper identity is
+    unchanged. A missing or replacement selection clears the cache. *)
+val content_height : terminal_rows:int -> error:load_error option -> int
+val maximum_scroll : entry_count:int -> content_height:int -> int
+val normalize_scroll : entry_count:int -> content_height:int -> int -> int
+val scroll_up : entry_count:int -> content_height:int -> int -> int
+val scroll_down : entry_count:int -> content_height:int -> int -> int
+val empty_message : load_error option -> string

--- a/bin/masc_tui_render.ml
+++ b/bin/masc_tui_render.ml
@@ -5,6 +5,7 @@ open Tui_decode
 open Masc_tui_ansi
 
 module Message_layout = Masc_tui_message_layout
+module Metrics_tail = Masc_tui_metrics_tail
 module Observation_layout = Masc_tui_observation_layout
 module Keeper_chat = Masc_tui_keeper_chat_projection
 
@@ -1090,12 +1091,35 @@ let render_keeper_logs (state : state) =
     box_line_styled buf cols ~style:Ansi.dim col_hdr;
     box_divider buf cols;
 
+    (match state.log_error with
+      | None -> ()
+      | Some error ->
+          let style =
+            match error with
+            | Metrics_tail.Storage_error _ -> Ansi.red
+            | Metrics_tail.Row_errors _ -> Ansi.yellow
+          in
+          let diagnostic =
+            Keeper_chat.terminal_safe_text
+              (Metrics_tail.error_to_string error)
+          in
+          box_line_styled buf cols ~style
+            ("  " ^ diagnostic);
+          box_divider buf cols);
+
     (* Content area *)
-    let content_height = rows - 8 in
-    let scroll = min state.log_scroll (max 0 (total_entries - content_height)) in
+    let content_height =
+      Metrics_tail.content_height ~terminal_rows:rows ~error:state.log_error
+    in
+    let scroll =
+      Metrics_tail.normalize_scroll ~entry_count:total_entries ~content_height
+        state.log_scroll
+    in
+    state.log_scroll <- scroll;
 
     if total_entries = 0 then begin
-      box_line_styled buf cols ~style:Ansi.dim "  (no log entries found)";
+      box_line_styled buf cols ~style:Ansi.dim
+        ("  " ^ Metrics_tail.empty_message state.log_error);
       for _ = 1 to content_height - 1 do
         box_empty buf cols
       done

--- a/bin/masc_tui_types.ml
+++ b/bin/masc_tui_types.ml
@@ -1,5 +1,6 @@
 [@@@warning "-32-69"]
 module Tui_decode = Masc.Tui_decode
+module Metrics_tail = Masc_tui_metrics_tail
 
 (** TUI shared types — split from masc_tui.ml (#3808) *)
 
@@ -234,6 +235,7 @@ type state = {
   mutable view: view_mode;
   mutable keeper_cursor: int;
   mutable log_entries: log_entry list;
+  mutable log_error: Metrics_tail.load_error option;
   mutable log_scroll: int;
   mutable live_context: Tui_decode.context_observation option;
   mutable live_context_error: string option;
@@ -280,6 +282,7 @@ let create_state ~workspace ~port ~refresh_interval = {
   view = Overview;
   keeper_cursor = 0;
   log_entries = [];
+  log_error = None;
   log_scroll = 0;
   live_context = None;
   live_context_error = None;

--- a/docs/TUI-GUIDE.md
+++ b/docs/TUI-GUIDE.md
@@ -106,7 +106,9 @@ Keeper's canonical dated metrics store, spanning month boundaries and rotated
 day segments. Reads are tail-bounded by row count rather than file size.
 Malformed JSON, current-schema decode failures, and storage/layout failures are
 shown explicitly; rejected rows consume the 200-row window and are never
-silently backfilled with older data.
+silently backfilled with older data. A current-schema row whose `name` does not
+match the selected Keeper is rejected instead of being attributed to that
+Keeper by its file location.
 
 ```
 Keeper Logs: sangsu  (85 entries)

--- a/docs/TUI-GUIDE.md
+++ b/docs/TUI-GUIDE.md
@@ -101,7 +101,12 @@ Keeper: sangsu
 
 ### Keeper Log View
 
-Press `l` from detail view. Shows recent heartbeat/metrics entries from `<name>/metrics/YYYY-MM/DD.jsonl`.
+Press `l` from detail view. Shows the newest 200 physical rows from the
+Keeper's canonical dated metrics store, spanning month boundaries and rotated
+day segments. Reads are tail-bounded by row count rather than file size.
+Malformed JSON, current-schema decode failures, and storage/layout failures are
+shown explicitly; rejected rows consume the 200-row window and are never
+silently backfilled with older data.
 
 ```
 Keeper Logs: sangsu  (85 entries)
@@ -185,7 +190,7 @@ Dashboard <--Tab--> Keeper List
 | Active task list | `.masc/tasks/backlog.json` | No |
 | Keeper list/detail | current-schema `.masc/keepers/*.json` | No |
 | Live context status | `<name>/turn-records/YYYY-MM/DD.jsonl` (strict newest trace-matched row) | No |
-| Keeper logs | `<name>/metrics/YYYY-MM/DD.jsonl` (last 200 entries) | No |
+| Keeper logs | canonical `<name>/metrics/` dated store (newest 200 physical rows) | No |
 | Goal planning | `GET /api/v1/dashboard/planning` | Yes |
 | Actor-scoped approvals | `GET /api/v1/operator?view=summary&include_messages=0&include_keepers=0` | Yes |
 | Send messages | request-correlated `POST /api/v1/keepers/chat/stream` SSE | Yes |

--- a/docs/design/tui/TUI-SPEC.md
+++ b/docs/design/tui/TUI-SPEC.md
@@ -170,7 +170,7 @@ scope가 결합된 서버 계약이므로 파일시스템이나 briefing을 대�
 
 - List: name, generation, runtime lane, composite phase, goal
 - Detail: identity, live context, runtime lane, runtime stats, behavior, timestamps
-- Logs: exact `keeper.metrics.v1` Turn/Heartbeat tail; context occupancy is not a metrics-ledger field
+- Logs: strict newest-200 physical-row tail across dated months/rotations; malformed, invalid current-schema, and storage failures remain explicit. Valid Turn/Heartbeat rows stay chronological, and context occupancy is not a metrics-ledger field.
 - Message: request-correlated asynchronous chat stream. The TUI creates one durable UUIDv7 request ID per send, accepts only the current Keeper SSE contract, and applies a completion only when both request and Keeper identities match. Partial text, interrupted streams, and terminal outcomes without a visible reply are explicit status/error values rather than successful replies.
 
 강화: 24h bucket 요약, tool call 카운트, composite phase (`Stable <- paused`)

--- a/docs/design/tui/TUI-SPEC.md
+++ b/docs/design/tui/TUI-SPEC.md
@@ -170,7 +170,7 @@ scope가 결합된 서버 계약이므로 파일시스템이나 briefing을 대�
 
 - List: name, generation, runtime lane, composite phase, goal
 - Detail: identity, live context, runtime lane, runtime stats, behavior, timestamps
-- Logs: strict newest-200 physical-row tail across dated months/rotations; malformed, invalid current-schema, and storage failures remain explicit. Valid Turn/Heartbeat rows stay chronological, and context occupancy is not a metrics-ledger field.
+- Logs: strict newest-200 physical-row tail across dated months/rotations; malformed, invalid current-schema, cross-Keeper identity mismatches, and storage failures remain explicit. Valid Turn/Heartbeat rows stay chronological, and context occupancy is not a metrics-ledger field.
 - Message: request-correlated asynchronous chat stream. The TUI creates one durable UUIDv7 request ID per send, accepts only the current Keeper SSE contract, and applies a completion only when both request and Keeper identities match. Partial text, interrupted streams, and terminal outcomes without a visible reply are explicit status/error values rather than successful replies.
 
 강화: 24h bucket 요약, tool call 카운트, composite phase (`Stable <- paused`)

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -400,6 +400,7 @@ sse_targets=(
   @test/runtest-test_tui_decode
   @test/runtest-test_tui_keeper_chat_projection
   @test/runtest-test_tui_message_layout
+  @test/runtest-test_tui_metrics_tail
   @test/runtest-test_tui_observation_layout
   @test/runtest-test_tui_http_ast
   @test/runtest-test_tui_render_schedule

--- a/test/dune
+++ b/test/dune
@@ -2585,6 +2585,19 @@
  (libraries alcotest masc_tui_context_state masc))
 
 (test
+ (name test_tui_metrics_tail)
+ (modules test_tui_metrics_tail)
+ (libraries
+  alcotest
+  masc_tui_keeper_chat_projection
+  masc_tui_metrics_tail
+  masc
+  dated_jsonl
+  fs_compat
+  unix
+  yojson))
+
+(test
  (name test_tui_render_schedule)
  (modules test_tui_render_schedule)
  (libraries alcotest masc_tui_render_schedule))

--- a/test/test_tui_http_ast.ml
+++ b/test/test_tui_http_ast.ml
@@ -244,10 +244,48 @@ let test_tui_current_projection_wiring () =
        ~callee:"Tui_decode.keeper_of_meta"
      >= 1);
   check bool "keeper metrics use the cluster-aware canonical path" true
-    (Ast_grep.count_calls
+    (Ast_grep.count_calls_in_value_binding
        ~module_path:"bin/masc_tui_loader.ml"
-       ~callee:"Keeper_types_support.keeper_metrics_dir"
+       ~binding_name:"load_selected_keeper_logs"
+       ~callee:"Keeper_types_support.keeper_metrics_store"
+     = 1);
+  check bool "keeper metrics use the strict bounded physical tail" true
+    (Ast_grep.count_calls_in_value_binding
+       ~module_path:"bin/masc_tui_metrics_tail.ml" ~binding_name:"load"
+       ~callee:"Dated_jsonl.read_recent_result"
+     = 1);
+  check bool "all log interactions use the selected Keeper loader" true
+    (Ast_grep.count_calls
+       ~module_path:"bin/masc_tui.ml"
+       ~callee:"load_selected_keeper_logs"
+     >= 3);
+  check bool "metadata refresh reconciles the selected log identity" true
+    (Ast_grep.count_calls_in_value_binding
+       ~module_path:"bin/masc_tui_loader.ml"
+       ~binding_name:"load_from_masc_dir"
+       ~callee:"Metrics_tail.reconcile_selection"
+     = 1);
+  check bool "metrics diagnostics are terminal-safe before rendering" true
+    (Ast_grep.count_calls_in_value_binding
+       ~module_path:"bin/masc_tui_render.ml"
+       ~binding_name:"render_keeper_logs"
+       ~callee:"Keeper_chat.terminal_safe_text"
      >= 1);
+  check bool "log input uses viewport-bounded scrolling" true
+    (Ast_grep.count_calls_across_files
+       ~module_paths:[ "bin/masc_tui.ml" ]
+       ~callee:"Metrics_tail.scroll_up"
+     = 1
+     && Ast_grep.count_calls_across_files
+          ~module_paths:[ "bin/masc_tui.ml" ]
+          ~callee:"Metrics_tail.scroll_down"
+        = 1);
+  List.iter
+    (fun retired ->
+      check int ("retired raw metrics helper absent: " ^ retired) 0
+        (Ast_grep.count_value_bindings
+           ~module_path:"bin/masc_tui_loader.ml" ~name:retired))
+    [ "read_last_lines"; "parse_log_entry"; "find_metrics_files"; "load_keeper_logs" ];
   check bool "Keeper log rows use the current typed discriminator" true
     (Ast_grep.count_calls_in_value_binding
        ~module_path:"lib/tui_decode.ml" ~binding_name:"decode_log_entry"
@@ -264,10 +302,18 @@ let test_tui_current_projection_wiring () =
        ~binding_name:"load_selected_live_context"
        ~callee:"Context_state.for_selection"
      = 1);
-  check int "live context never tails the metrics ledger" 0
+  check bool "log diagnostics remain operator-visible" true
     (Ast_grep.count_calls_in_value_binding
-       ~module_path:"bin/masc_tui_loader.ml" ~binding_name:"load_live_context"
-       ~callee:"read_last_lines");
+       ~module_path:"bin/masc_tui_render.ml"
+       ~binding_name:"render_keeper_logs"
+       ~callee:"Metrics_tail.error_to_string"
+     = 1);
+  check bool "log empty copy distinguishes typed outcomes" true
+    (Ast_grep.count_calls_in_value_binding
+       ~module_path:"bin/masc_tui_render.ml"
+       ~binding_name:"render_keeper_logs"
+       ~callee:"Metrics_tail.empty_message"
+     = 1);
   check int "retired planning running alias absent" 0
     (Ast_grep.count_string_literals
        ~module_path:"lib/tui_decode.ml"

--- a/test/test_tui_http_ast.ml
+++ b/test/test_tui_http_ast.ml
@@ -254,6 +254,10 @@ let test_tui_current_projection_wiring () =
        ~module_path:"bin/masc_tui_metrics_tail.ml" ~binding_name:"load"
        ~callee:"Dated_jsonl.read_recent_result"
      = 1);
+  check int "selected Keeper identity reaches the metrics decoder" 1
+    (Ast_grep.count_calls_with_label
+       ~module_path:"bin/masc_tui_loader.ml"
+       ~callee:"Metrics_tail.load" ~label:"expected_keeper");
   check bool "all log interactions use the selected Keeper loader" true
     (Ast_grep.count_calls
        ~module_path:"bin/masc_tui.ml"

--- a/test/test_tui_metrics_tail.ml
+++ b/test/test_tui_metrics_tail.ml
@@ -16,14 +16,15 @@ let tmpdir prefix =
   Fs_compat.mkdir_p path;
   path
 
-let heartbeat ?(timestamp = "2026-08-21T12:00:00Z") count =
+let heartbeat ?(timestamp = "2026-08-21T12:00:00Z")
+    ?(name = "keeper-main") count =
   `Assoc
     [ "schema", `String Masc.Keeper_metrics_record.schema
     ; "record_kind", `String "heartbeat"
     ; "ts", `String timestamp
     ; "ts_unix", `Float 1787313600.0
     ; "channel", `String "heartbeat"
-    ; "name", `String "keeper-main"
+    ; "name", `String name
     ; "agent_name", `String "codex"
     ; "trace_id", `String "trace-current"
     ; "generation", `Int 4
@@ -47,7 +48,8 @@ let test_resolve_is_physical_bounded_and_chronological () =
     ]
   in
   let snapshot =
-    Tail.resolve_with ~limit:4 ~read_recent:(fun limit ->
+    Tail.resolve_with ~expected_keeper:"keeper-main" ~limit:4
+      ~read_recent:(fun limit ->
         seen_limit := Some limit;
         Ok rows)
   in
@@ -76,7 +78,8 @@ let test_storage_error_and_empty_selection_are_explicit () =
       }
   in
   let failed =
-    Tail.resolve_with ~limit:200 ~read_recent:(fun _ -> Error read_error)
+    Tail.resolve_with ~expected_keeper:"keeper-main" ~limit:200
+      ~read_recent:(fun _ -> Error read_error)
   in
   check int "storage failure has no stale entries" 0
     (List.length failed.entries);
@@ -141,6 +144,28 @@ let test_diagnostic_controls_are_terminal_safe () =
   check bool "diagnostic removes escape" false (String.contains safe '\027');
   check bool "diagnostic removes bell" false (String.contains safe '\007')
 
+let test_selected_keeper_rejects_misfiled_current_row () =
+  let snapshot =
+    Tail.resolve_with ~expected_keeper:"keeper-main" ~limit:1
+      ~read_recent:(fun _ -> Ok [ Dated_jsonl.Parsed (heartbeat ~name:"keeper-other" 1) ])
+  in
+  check int "misfiled row is not rendered" 0 (List.length snapshot.entries);
+  match snapshot.error with
+  | Some
+      (Tail.Row_errors
+        { physical_rows = 1;
+          errors = [ Tail.Invalid_metrics_row { physical_index = 1; detail } ];
+        }) ->
+      check bool "mismatch names selected Keeper" true
+        (String.starts_with
+           ~prefix:
+             "metrics Keeper name \"keeper-other\" does not match selected Keeper \"keeper-main\""
+           detail)
+  | Some (Tail.Row_errors { physical_rows; errors }) ->
+      failf "unexpected mismatch summary: rows=%d errors=%d" physical_rows
+        (List.length errors)
+  | Some (Tail.Storage_error _) | None -> fail "misfiled row was not rejected"
+
 let test_scroll_and_empty_copy_follow_viewport_state () =
   let normal_height = Tail.content_height ~terminal_rows:24 ~error:None in
   check int "normal viewport content rows" 16 normal_height;
@@ -201,7 +226,9 @@ let test_load_does_not_backfill_rejected_rows () =
     ; Yojson.Safe.to_string (heartbeat 2)
     ];
   let snapshot =
-    Dated_jsonl.create ~base_dir () |> fun store -> Tail.load ~store ~limit:4
+    Dated_jsonl.create ~base_dir ()
+    |> fun store ->
+    Tail.load ~store ~expected_keeper:"keeper-main" ~limit:4
   in
   check (list (option int)) "older row is not used to backfill rejects"
     [ Some 1; Some 2 ] (message_counts snapshot.entries);
@@ -222,7 +249,9 @@ let test_load_surfaces_malformed_newest_without_backfill () =
   write_raw_lines base_dir "2026-01" "31.jsonl"
     [ Yojson.Safe.to_string (heartbeat 1); "not-json" ];
   let snapshot =
-    Dated_jsonl.create ~base_dir () |> fun store -> Tail.load ~store ~limit:1
+    Dated_jsonl.create ~base_dir ()
+    |> fun store ->
+    Tail.load ~store ~expected_keeper:"keeper-main" ~limit:1
   in
   check int "malformed newest row does not backfill" 0
     (List.length snapshot.entries);
@@ -247,7 +276,9 @@ let test_load_spans_months_and_rotations () =
   write_rows base_dir "2026-02" "01.jsonl" [ heartbeat 5; heartbeat 6 ]
     ~terminate:true;
   let store = Dated_jsonl.create ~base_dir () in
-  let snapshot = Tail.load ~store ~limit:5 in
+  let snapshot =
+    Tail.load ~store ~expected_keeper:"keeper-main" ~limit:5
+  in
   check (list (option int)) "newest physical rows are chronological"
     [ Some 2; Some 3; Some 4; Some 5; Some 6 ]
     (message_counts snapshot.entries);
@@ -258,7 +289,9 @@ let test_load_keeps_unterminated_newest_row () =
   write_rows base_dir "2026-02" "02.jsonl" [ heartbeat 8; heartbeat 9 ]
     ~terminate:false;
   let snapshot =
-    Dated_jsonl.create ~base_dir () |> fun store -> Tail.load ~store ~limit:1
+    Dated_jsonl.create ~base_dir ()
+    |> fun store ->
+    Tail.load ~store ~expected_keeper:"keeper-main" ~limit:1
   in
   check (list (option int)) "unterminated newest row remains visible"
     [ Some 9 ] (message_counts snapshot.entries);
@@ -269,7 +302,9 @@ let test_load_surfaces_invalid_layout () =
   let base_dir = tmpdir "tui_metrics_tail_invalid_layout" in
   Fs_compat.mkdir_p (Filename.concat base_dir "2026-aa");
   let snapshot =
-    Dated_jsonl.create ~base_dir () |> fun store -> Tail.load ~store ~limit:1
+    Dated_jsonl.create ~base_dir ()
+    |> fun store ->
+    Tail.load ~store ~expected_keeper:"keeper-main" ~limit:1
   in
   check int "invalid layout has no entries" 0 (List.length snapshot.entries);
   match snapshot.error with
@@ -303,7 +338,9 @@ let test_load_is_bounded_by_tail_not_file_size () =
   Gc.full_major ();
   let allocated_before = Gc.allocated_bytes () in
   let snapshot =
-    Dated_jsonl.create ~base_dir () |> fun store -> Tail.load ~store ~limit:1
+    Dated_jsonl.create ~base_dir ()
+    |> fun store ->
+    Tail.load ~store ~expected_keeper:"keeper-main" ~limit:1
   in
   let allocated = Gc.allocated_bytes () -. allocated_before in
   check (list (option int)) "sparse newest row is decoded" [ Some 10 ]
@@ -320,6 +357,8 @@ let () =
             test_storage_error_and_empty_selection_are_explicit
         ; test_case "diagnostic control safety" `Quick
             test_diagnostic_controls_are_terminal_safe
+        ; test_case "selected Keeper rejects misfiled row" `Quick
+            test_selected_keeper_rejects_misfiled_current_row
         ; test_case "viewport scroll and empty copy" `Quick
             test_scroll_and_empty_copy_follow_viewport_state
         ; test_case "rejected rows are not backfilled" `Quick

--- a/test/test_tui_metrics_tail.ml
+++ b/test/test_tui_metrics_tail.ml
@@ -1,0 +1,337 @@
+open Alcotest
+
+module Decode = Masc.Tui_decode
+module Keeper_chat = Masc_tui_keeper_chat_projection
+module Tail = Masc_tui_metrics_tail
+
+let counter = ref 0
+
+let tmpdir prefix =
+  incr counter;
+  let path =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "%s_%d_%d_%.0f" prefix !counter (Unix.getpid ())
+         (Unix.gettimeofday ()))
+  in
+  Fs_compat.mkdir_p path;
+  path
+
+let heartbeat ?(timestamp = "2026-08-21T12:00:00Z") count =
+  `Assoc
+    [ "schema", `String Masc.Keeper_metrics_record.schema
+    ; "record_kind", `String "heartbeat"
+    ; "ts", `String timestamp
+    ; "ts_unix", `Float 1787313600.0
+    ; "channel", `String "heartbeat"
+    ; "name", `String "keeper-main"
+    ; "agent_name", `String "codex"
+    ; "trace_id", `String "trace-current"
+    ; "generation", `Int 4
+    ; "message_count", `Int count
+    ]
+
+let message_counts entries =
+  List.map (fun (entry : Decode.log_entry) -> entry.le_message_count) entries
+
+let test_resolve_is_physical_bounded_and_chronological () =
+  let seen_limit = ref None in
+  let rows =
+    [ Dated_jsonl.Parsed (heartbeat 1)
+    ; Dated_jsonl.Malformed_json
+        { path = "/tmp/metrics/21.jsonl";
+          line_number = None;
+          detail = "invalid JSON";
+        }
+    ; Dated_jsonl.Parsed (`Assoc [])
+    ; Dated_jsonl.Parsed (heartbeat 2)
+    ]
+  in
+  let snapshot =
+    Tail.resolve_with ~limit:4 ~read_recent:(fun limit ->
+        seen_limit := Some limit;
+        Ok rows)
+  in
+  check (option int) "physical limit forwarded" (Some 4) !seen_limit;
+  check (list (option int)) "valid rows remain chronological"
+    [ Some 1; Some 2 ] (message_counts snapshot.entries);
+  match snapshot.error with
+  | Some (Tail.Row_errors { physical_rows = 4; errors = [ first; second ] }) ->
+      (match first, second with
+       | ( Tail.Malformed_json _,
+           Tail.Invalid_metrics_row { physical_index = 3; _ } ) ->
+           ()
+       | _ -> fail "row failures changed kind or chronological position")
+  | Some (Tail.Row_errors { physical_rows; errors }) ->
+      failf "unexpected row error summary: rows=%d errors=%d" physical_rows
+        (List.length errors)
+  | Some (Tail.Storage_error _) -> fail "row failures became a storage error"
+  | None -> fail "row failures were silently discarded"
+
+let test_storage_error_and_empty_selection_are_explicit () =
+  let read_error =
+    Dated_jsonl.Io_error
+      { operation = Dated_jsonl.Read_file;
+        path = "/tmp/metrics/2026-08/21.jsonl";
+        detail = "injected read failure";
+      }
+  in
+  let failed =
+    Tail.resolve_with ~limit:200 ~read_recent:(fun _ -> Error read_error)
+  in
+  check int "storage failure has no stale entries" 0
+    (List.length failed.entries);
+  (match failed.error with
+   | Some
+       (Tail.Storage_error
+         (Dated_jsonl.Io_error
+           { operation = Dated_jsonl.Read_file;
+             path = "/tmp/metrics/2026-08/21.jsonl";
+             detail = "injected read failure";
+           })) ->
+       ()
+   | Some (Tail.Storage_error _) -> fail "wrong typed storage error"
+   | Some (Tail.Row_errors _) | None -> fail "storage failure was flattened");
+  let calls = ref 0 in
+  let cleared =
+    Tail.for_selection
+      ~load:(fun _ ->
+        incr calls;
+        failed)
+      None
+  in
+  check int "empty selection does not read storage" 0 !calls;
+  check int "empty selection clears entries" 0 (List.length cleared.entries);
+  check bool "empty selection clears error" true (Option.is_none cleared.error);
+  let retained =
+    Tail.reconcile_selection ~current:failed
+      ~previous_keeper:(Some "keeper-a") ~selected_keeper:(Some "keeper-a")
+  in
+  check bool "metadata refresh retains same Keeper logs" true
+    (Option.is_some retained.error);
+  let cleared_after_replacement =
+    Tail.reconcile_selection ~current:failed
+      ~previous_keeper:(Some "keeper-a") ~selected_keeper:(Some "keeper-b")
+  in
+  check int "replacement Keeper clears entries" 0
+    (List.length cleared_after_replacement.entries);
+  check bool "replacement Keeper clears error" true
+    (Option.is_none cleared_after_replacement.error);
+  let cleared_after_empty_roster =
+    Tail.reconcile_selection ~current:failed
+      ~previous_keeper:(Some "keeper-a") ~selected_keeper:None
+  in
+  check int "empty refreshed roster clears entries" 0
+    (List.length cleared_after_empty_roster.entries);
+  check bool "empty refreshed roster clears error" true
+    (Option.is_none cleared_after_empty_roster.error)
+
+let test_diagnostic_controls_are_terminal_safe () =
+  let unsafe_error =
+    Tail.Storage_error
+      (Dated_jsonl.Io_error
+         { operation = Dated_jsonl.Read_file;
+           path = "/tmp/metrics\nnext-row";
+           detail = "failed\027]8;;https://example.invalid\007link";
+         })
+  in
+  let safe =
+    Tail.error_to_string unsafe_error |> Keeper_chat.terminal_safe_text
+  in
+  check bool "diagnostic removes newline" false (String.contains safe '\n');
+  check bool "diagnostic removes escape" false (String.contains safe '\027');
+  check bool "diagnostic removes bell" false (String.contains safe '\007')
+
+let test_scroll_and_empty_copy_follow_viewport_state () =
+  let normal_height = Tail.content_height ~terminal_rows:24 ~error:None in
+  check int "normal viewport content rows" 16 normal_height;
+  check int "entry-index scroll normalizes to viewport" 184
+    (Tail.normalize_scroll ~entry_count:200 ~content_height:normal_height 199);
+  check int "up moves immediately after normalization" 183
+    (Tail.scroll_up ~entry_count:200 ~content_height:normal_height 199);
+  check int "down stops at the normal viewport end" 184
+    (Tail.scroll_down ~entry_count:200 ~content_height:normal_height 184);
+  let row_error =
+    Tail.Row_errors
+      { physical_rows = 1;
+        errors =
+          [ Tail.Invalid_metrics_row
+              { physical_index = 1; detail = "invalid row" }
+          ];
+      }
+  in
+  let warning_height =
+    Tail.content_height ~terminal_rows:24 ~error:(Some row_error)
+  in
+  check int "diagnostic banner reduces viewport" 14 warning_height;
+  check int "down uses the warning viewport immediately" 185
+    (Tail.scroll_down ~entry_count:200 ~content_height:warning_height 184);
+  check int "removed warning clamps the prior offset" 184
+    (Tail.normalize_scroll ~entry_count:200 ~content_height:normal_height 186);
+  check string "true empty copy" "(no log entries found)"
+    (Tail.empty_message None);
+  check string "all-rejected copy"
+    "(no valid rows in newest physical window)"
+    (Tail.empty_message (Some row_error));
+  let storage_error =
+    Tail.Storage_error (Dated_jsonl.Not_a_directory { path = "/tmp/metrics" })
+  in
+  check string "storage failure copy" "(log entries unavailable)"
+    (Tail.empty_message (Some storage_error))
+
+let write_rows base_dir month filename rows ~terminate =
+  let month_dir = Filename.concat base_dir month in
+  Fs_compat.mkdir_p month_dir;
+  let content = String.concat "\n" (List.map Yojson.Safe.to_string rows) in
+  let content = if terminate then content ^ "\n" else content in
+  Fs_compat.append_file (Filename.concat month_dir filename) content
+
+let write_raw_lines base_dir month filename lines =
+  let month_dir = Filename.concat base_dir month in
+  Fs_compat.mkdir_p month_dir;
+  Fs_compat.append_file (Filename.concat month_dir filename)
+    (String.concat "\n" lines ^ "\n")
+
+let test_load_does_not_backfill_rejected_rows () =
+  let base_dir = tmpdir "tui_metrics_tail_physical_bound" in
+  write_raw_lines base_dir "2026-01" "31.jsonl"
+    [ Yojson.Safe.to_string (heartbeat 0)
+    ; Yojson.Safe.to_string (heartbeat 1)
+    ; "{}"
+    ; "not-json"
+    ; Yojson.Safe.to_string (heartbeat 2)
+    ];
+  let snapshot =
+    Dated_jsonl.create ~base_dir () |> fun store -> Tail.load ~store ~limit:4
+  in
+  check (list (option int)) "older row is not used to backfill rejects"
+    [ Some 1; Some 2 ] (message_counts snapshot.entries);
+  match snapshot.error with
+  | Some (Tail.Row_errors { physical_rows = 4; errors = [ first; second ] }) ->
+      (match first, second with
+       | ( Tail.Invalid_metrics_row { physical_index = 2; _ },
+           Tail.Malformed_json _ ) ->
+           ()
+       | _ -> fail "physical row failure positions changed")
+  | Some (Tail.Row_errors { physical_rows; errors }) ->
+      failf "unexpected physical window: rows=%d errors=%d" physical_rows
+        (List.length errors)
+  | Some (Tail.Storage_error _) | None -> fail "physical row errors were hidden"
+
+let test_load_surfaces_malformed_newest_without_backfill () =
+  let base_dir = tmpdir "tui_metrics_tail_malformed_newest" in
+  write_raw_lines base_dir "2026-01" "31.jsonl"
+    [ Yojson.Safe.to_string (heartbeat 1); "not-json" ];
+  let snapshot =
+    Dated_jsonl.create ~base_dir () |> fun store -> Tail.load ~store ~limit:1
+  in
+  check int "malformed newest row does not backfill" 0
+    (List.length snapshot.entries);
+  match snapshot.error with
+  | Some
+      (Tail.Row_errors
+        { physical_rows = 1; errors = [ Tail.Malformed_json _ ] }) ->
+      ()
+  | Some (Tail.Row_errors { physical_rows; errors }) ->
+      failf "unexpected malformed window: rows=%d errors=%d" physical_rows
+        (List.length errors)
+  | Some (Tail.Storage_error _) | None -> fail "malformed newest row was hidden"
+
+let test_load_spans_months_and_rotations () =
+  let base_dir = tmpdir "tui_metrics_tail_order" in
+  write_rows base_dir "2026-01" "31.jsonl" [ heartbeat 1; heartbeat 2 ]
+    ~terminate:true;
+  write_rows base_dir "2026-02" "01.001.jsonl" [ heartbeat 3 ]
+    ~terminate:true;
+  write_rows base_dir "2026-02" "01.002.jsonl" [ heartbeat 4 ]
+    ~terminate:true;
+  write_rows base_dir "2026-02" "01.jsonl" [ heartbeat 5; heartbeat 6 ]
+    ~terminate:true;
+  let store = Dated_jsonl.create ~base_dir () in
+  let snapshot = Tail.load ~store ~limit:5 in
+  check (list (option int)) "newest physical rows are chronological"
+    [ Some 2; Some 3; Some 4; Some 5; Some 6 ]
+    (message_counts snapshot.entries);
+  check bool "valid rotated tail has no error" true (Option.is_none snapshot.error)
+
+let test_load_keeps_unterminated_newest_row () =
+  let base_dir = tmpdir "tui_metrics_tail_unterminated" in
+  write_rows base_dir "2026-02" "02.jsonl" [ heartbeat 8; heartbeat 9 ]
+    ~terminate:false;
+  let snapshot =
+    Dated_jsonl.create ~base_dir () |> fun store -> Tail.load ~store ~limit:1
+  in
+  check (list (option int)) "unterminated newest row remains visible"
+    [ Some 9 ] (message_counts snapshot.entries);
+  check bool "unterminated valid row has no error" true
+    (Option.is_none snapshot.error)
+
+let test_load_surfaces_invalid_layout () =
+  let base_dir = tmpdir "tui_metrics_tail_invalid_layout" in
+  Fs_compat.mkdir_p (Filename.concat base_dir "2026-aa");
+  let snapshot =
+    Dated_jsonl.create ~base_dir () |> fun store -> Tail.load ~store ~limit:1
+  in
+  check int "invalid layout has no entries" 0 (List.length snapshot.entries);
+  match snapshot.error with
+  | Some
+      (Tail.Storage_error
+        (Dated_jsonl.Invalid_layout_entry
+          { expected = Dated_jsonl.Month_directory; _ })) ->
+      ()
+  | Some (Tail.Storage_error error) ->
+      failf "unexpected storage error: %s"
+        (Dated_jsonl.read_error_to_string error)
+  | Some (Tail.Row_errors _) | None -> fail "invalid layout was hidden"
+
+let test_load_is_bounded_by_tail_not_file_size () =
+  let base_dir = tmpdir "tui_metrics_tail_sparse" in
+  let month_dir = Filename.concat base_dir "2026-02" in
+  Fs_compat.mkdir_p month_dir;
+  let path = Filename.concat month_dir "03.jsonl" in
+  let descriptor =
+    Unix.openfile path [ Unix.O_CREAT; Unix.O_TRUNC; Unix.O_WRONLY ] 0o600
+  in
+  let sparse_prefix_bytes = 64 * 1024 * 1024 in
+  Fun.protect
+    ~finally:(fun () -> Unix.close descriptor)
+    (fun () ->
+      Unix.ftruncate descriptor sparse_prefix_bytes;
+      ignore (Unix.lseek descriptor sparse_prefix_bytes Unix.SEEK_SET);
+      let suffix = "\n" ^ Yojson.Safe.to_string (heartbeat 10) ^ "\n" in
+      ignore
+        (Unix.write_substring descriptor suffix 0 (String.length suffix)));
+  Gc.full_major ();
+  let allocated_before = Gc.allocated_bytes () in
+  let snapshot =
+    Dated_jsonl.create ~base_dir () |> fun store -> Tail.load ~store ~limit:1
+  in
+  let allocated = Gc.allocated_bytes () -. allocated_before in
+  check (list (option int)) "sparse newest row is decoded" [ Some 10 ]
+    (message_counts snapshot.entries);
+  check bool "tail allocation stays below a whole-file read" true
+    (allocated < Float.of_int (4 * 1024 * 1024))
+
+let () =
+  run "tui_metrics_tail"
+    [ ( "strict tail"
+      , [ test_case "physical bound and chronology" `Quick
+            test_resolve_is_physical_bounded_and_chronological
+        ; test_case "storage and empty selection" `Quick
+            test_storage_error_and_empty_selection_are_explicit
+        ; test_case "diagnostic control safety" `Quick
+            test_diagnostic_controls_are_terminal_safe
+        ; test_case "viewport scroll and empty copy" `Quick
+            test_scroll_and_empty_copy_follow_viewport_state
+        ; test_case "rejected rows are not backfilled" `Quick
+            test_load_does_not_backfill_rejected_rows
+        ; test_case "malformed newest row is explicit" `Quick
+            test_load_surfaces_malformed_newest_without_backfill
+        ; test_case "cross-month rotation order" `Quick
+            test_load_spans_months_and_rotations
+        ; test_case "unterminated newest row" `Quick
+            test_load_keeps_unterminated_newest_row
+        ; test_case "invalid layout" `Quick test_load_surfaces_invalid_layout
+        ; test_case "large sparse prefix is bounded" `Quick
+            test_load_is_bounded_by_tail_not_file_size
+        ] )
+    ]


### PR DESCRIPTION
## Summary

- replace the single-month whole-file log scan with the canonical `Dated_jsonl` newest-200 physical-row tail across months and rotations
- keep valid current-schema metrics chronological while surfacing malformed rows, schema rejects, and storage failures without backfill
- bind every decoded metrics row to the selected Keeper's required `name`; cross-Keeper rows fail closed and consume the physical bound
- normalize the log viewport, clear cached rows on Keeper identity changes, and sanitize diagnostics before terminal rendering
- document the physical-row and identity contracts and wire focused regression coverage into CI

## Performance evidence

- a 64 MiB sparse-prefix fixture with `limit=1` allocates less than 4 MiB while decoding the newest row

## Verification

- `scripts/dune-local.sh build @test/runtest-test_tui_metrics_tail @test/runtest-test_tui_http_ast @test/runtest-test_dated_jsonl bin/masc_tui.exe`
- metrics tail: 11/11 tests, including order, cross-month rotation, physical no-backfill, scroll reset, and selected-Keeper name mismatch
- `bash scripts/audit-ci-test-targets.sh` (`388` declared targets; `514` unwired at baseline)
- `python3 scripts/audit-dead-surface.py --exports --ratchet` (`537` at baseline)
- `ocamlformat --check` on all changed OCaml files
- `git diff --check`
- two final independent read-only reviews: no actionable findings

## Stack

- base: #29322 (`fix/tui-current-metrics-projection`)
- keep Draft until the parent stack and exact-head CI are ready