### PR TITLE
fix(dashboard): Goal 트리의 timeline 을 정규화기를 거쳐 내보내도록

### DIFF
--- a/lib/dashboard/dashboard_goals.ml
+++ b/lib/dashboard/dashboard_goals.ml
@@ -108,7 +108,15 @@ let rec tree_node_to_json ?(events_for_goal = fun _ -> []) node =
                (fun (task : Masc_domain.task) -> task_is_done task)
                node.tasks)));
       ("task_summary", task_summary);
-      ("timeline_events", `List (events_for_goal goal.id));
+      (* The normalizer, not the raw ledger row. [build_goal_events_projection]
+         hands back whatever [goal_events.jsonl] holds — {event_type, payload} —
+         and every consumer of this field reads the normalized shape
+         {kind, lane, title, summary, severity}. The detail view has always
+         mapped through [goal_event_timeline_json] (see [build_goal_timeline]);
+         the tree emitted the raw rows, so the dashboard's strict decoder
+         dropped all of them and every goal read as having no history (#29299). *)
+      ( "timeline_events",
+        `List (List.map goal_event_timeline_json (events_for_goal goal.id)) );
       ( "children",
         `List
           (List.map

--- a/lib/dashboard/dashboard_goals_types_timeline.ml
+++ b/lib/dashboard/dashboard_goals_types_timeline.ml
@@ -254,9 +254,15 @@ let goal_event_timeline_json event =
            [json_member_or_null] return [`Null] for every event ever written,
            so the summary silently lost the actor — the one field that says
            who moved the goal. Marked like [phase] when absent, so a producer
-           that stops writing it shows up instead of disappearing. *)
+           that stops writing it shows up instead of disappearing.
+
+           The alternative — dropping the "by %s" clause when the field is
+           absent — is what this change is fixing. The summary read
+           "phase=blocked" for months and read correctly, which is exactly
+           why nobody looked. *)
         let actor =
           payload_field "actor" |> json_to_string_opt
+          (* NDT-OK: bracketed marker, not a permissive default. *)
           |> Option.value ~default:"<missing payload.actor>"
         in
         ( "Goal Phase",

--- a/lib/dashboard/dashboard_goals_types_timeline.ml
+++ b/lib/dashboard/dashboard_goals_types_timeline.ml
@@ -265,12 +265,25 @@ let goal_event_timeline_json event =
           (* NDT-OK: bracketed marker, not a permissive default. *)
           |> Option.value ~default:"<missing payload.actor>"
         in
-        ( "Goal Phase",
-          Printf.sprintf "phase=%s by %s" phase actor,
-          (match phase with
-          | "blocked" -> "bad"
-          | "paused" -> "warn"
-          | _ -> "ok") )
+        (* Enumerated over [Goal_phase.t] rather than matched on the string, so
+           adding a phase to the variant fails this match instead of landing in
+           a healthy-looking bucket by default.
+
+           A phase this build cannot parse — including the [<missing ...>]
+           marker above — is `warn`, not `ok`. The marker is loud in the summary
+           text but the old `_ -> "ok"` made the row render neutral, the same as
+           a healthy event, so a corrupted producer event was invisible to an
+           operator scanning by colour. Live ledger check before the change: all
+           78 goal_phase rows carry one of the six known tokens, so nothing
+           in the store moves to `warn` because of this. *)
+        let severity =
+          match Goal_phase.of_string phase with
+          | Some Blocked -> "bad"
+          | Some Paused -> "warn"
+          | Some (Executing | Verifying | Completed | Dropped) -> "ok"
+          | None -> "warn"
+        in
+        ("Goal Phase", Printf.sprintf "phase=%s by %s" phase actor, severity)
     | _ ->
         ("Goal Event", event_type, "ok")
   in

--- a/lib/dashboard/dashboard_goals_types_timeline.ml
+++ b/lib/dashboard/dashboard_goals_types_timeline.ml
@@ -248,13 +248,19 @@ let goal_event_timeline_json event =
           payload_field "phase" |> json_to_string_opt
           |> Option.value ~default:"<missing payload.phase>"
         in
+        (* [payload.actor] is the agent name, a bare string: every producer
+           builds it that way ([gate_event_payload] and the two inline
+           payloads in workspace_goals.ml). Reading it as [actor.id] made
+           [json_member_or_null] return [`Null] for every event ever written,
+           so the summary silently lost the actor — the one field that says
+           who moved the goal. Marked like [phase] when absent, so a producer
+           that stops writing it shows up instead of disappearing. *)
         let actor =
-          payload_field "actor" |> json_member_or_null "id" |> json_to_string_opt
+          payload_field "actor" |> json_to_string_opt
+          |> Option.value ~default:"<missing payload.actor>"
         in
         ( "Goal Phase",
-          (match actor with
-          | Some actor_id -> Printf.sprintf "phase=%s by %s" phase actor_id
-          | None -> Printf.sprintf "phase=%s" phase),
+          Printf.sprintf "phase=%s by %s" phase actor,
           (match phase with
           | "blocked" -> "bad"
           | "paused" -> "warn"

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -159,6 +159,7 @@ normal_targets=(
   @test/runtest-test_dashboard_feature_health
   @test/runtest-test_dashboard_gate_metrics
   @test/runtest-test_dashboard_goal_id_projection
+  @test/runtest-test_goal_timeline_projection
   @test/runtest-test_dashboard_k2_feeds
   @test/runtest-test_dashboard_keeper_cost_aggregates
   @test/runtest-test_dashboard_keeper_metrics_10286

--- a/test/dune
+++ b/test/dune
@@ -918,6 +918,14 @@
  (modules test_dashboard_goal_id_projection)
  (libraries masc_test_deps))
 
+; #29299: the goal tree emitted raw goal_events.jsonl rows under
+; timeline_events while every consumer reads the normalized shape.
+
+(test
+ (name test_goal_timeline_projection)
+ (modules test_goal_timeline_projection)
+ (libraries masc_test_deps))
+
 ; RFC-0267 Phase 2: validated task->goal assignment
 ; (Task.Goal_assignment.set_task_goal).
 

--- a/test/test_goal_timeline_projection.ml
+++ b/test/test_goal_timeline_projection.ml
@@ -72,7 +72,30 @@ let test_severity_follows_the_phase () =
   check (option string) "blocked" (Some "bad") (severity_of "blocked");
   check (option string) "paused" (Some "warn") (severity_of "paused");
   check (option string) "executing" (Some "ok") (severity_of "executing");
-  check (option string) "completed" (Some "ok") (severity_of "completed")
+  check (option string) "verifying" (Some "ok") (severity_of "verifying");
+  check (option string) "completed" (Some "ok") (severity_of "completed");
+  check (option string) "dropped" (Some "ok") (severity_of "dropped")
+;;
+
+(* A phase this build cannot parse is not healthy. The old string match sent
+   every unrecognised token to "ok", so a corrupted producer event rendered
+   neutral — indistinguishable from a running goal for anyone scanning the
+   timeline by colour. The markers are loud in the summary text; this keeps
+   them loud in the severity too. *)
+let test_unparseable_phase_is_not_ok () =
+  let severity_of phase =
+    field
+      "severity"
+      (DGT.goal_event_timeline_json
+         (goal_phase_event (live_phase_payload ~phase ~actor:"sangsu")))
+  in
+  check (option string) "token no producer writes" (Some "warn") (severity_of "retired");
+  check (option string) "empty token" (Some "warn") (severity_of "");
+  check
+    (option string)
+    "missing phase falls to the marker, which is also unparseable"
+    (Some "warn")
+    (field "severity" (DGT.goal_event_timeline_json (goal_phase_event (`Assoc []))))
 ;;
 
 (* A producer that stops writing a field must show up, not disappear: the
@@ -175,6 +198,7 @@ let () =
       , [ test_case "phase event shape" `Quick test_normalizes_a_phase_event
         ; test_case "summary names the actor" `Quick test_summary_names_the_actor
         ; test_case "severity follows the phase" `Quick test_severity_follows_the_phase
+        ; test_case "unparseable phase is not ok" `Quick test_unparseable_phase_is_not_ok
         ; test_case "missing fields are marked" `Quick test_missing_payload_fields_are_marked
         ; test_case
             "unknown event type keeps its token"

--- a/test/test_goal_timeline_projection.ml
+++ b/test/test_goal_timeline_projection.ml
@@ -1,0 +1,189 @@
+(** Goal timeline projection — the normalizer and the tree field that carries it.
+
+    [goal_events.jsonl] stores {ts, goal_id, event_type, payload}. Every
+    consumer reads {ts, kind, lane, title, summary, severity}.
+    [Dashboard_goals_types.goal_event_timeline_json] is the only translation
+    between the two, and until #29299 the goal tree skipped it: the raw rows
+    went out under [timeline_events] and the dashboard's strict decoder
+    dropped all of them, so every goal read as having no history.
+
+    These tests pin both halves — the normalizer's own output, and the fact
+    that the tree field is normalized — without booting Eio or touching disk. *)
+
+open Alcotest
+
+module DG = Dashboard_goals
+module DGT = Dashboard_goals_types
+
+let field name json =
+  match Yojson.Safe.Util.member name json with
+  | `String s -> Some s
+  | `Null -> None
+  | other -> Some ("<non-string:" ^ Yojson.Safe.to_string other ^ ">")
+;;
+
+let goal_phase_event ?(ts = "2026-08-21T03:20:29Z") payload =
+  `Assoc
+    [ "ts", `String ts
+    ; "goal_id", `String "goal-1"
+    ; "event_type", `String "goal_phase"
+    ; "payload", payload
+    ]
+;;
+
+(* The exact payload shape every producer writes: [gate_event_payload] and the
+   two inline payloads in workspace_goals.ml all put [actor] as a bare string. *)
+let live_phase_payload ~phase ~actor =
+  `Assoc [ "phase", `String phase; "actor", `String actor ]
+;;
+
+let test_normalizes_a_phase_event () =
+  let json =
+    DGT.goal_event_timeline_json
+      (goal_phase_event (live_phase_payload ~phase:"completed" ~actor:"rondo"))
+  in
+  check (option string) "kind is the event type" (Some "goal_phase") (field "kind" json);
+  check (option string) "lane" (Some "goal") (field "lane" json);
+  check (option string) "title" (Some "Goal Phase") (field "title" json);
+  check (option string) "ts survives" (Some "2026-08-21T03:20:29Z") (field "ts" json)
+;;
+
+(* Reading [payload.actor] as [actor.id] returned `Null for every event ever
+   written, so the summary silently lost who moved the goal. *)
+let test_summary_names_the_actor () =
+  let json =
+    DGT.goal_event_timeline_json
+      (goal_phase_event (live_phase_payload ~phase:"blocked" ~actor:"sangsu"))
+  in
+  check
+    (option string)
+    "summary carries phase and actor"
+    (Some "phase=blocked by sangsu")
+    (field "summary" json)
+;;
+
+let test_severity_follows_the_phase () =
+  let severity_of phase =
+    field
+      "severity"
+      (DGT.goal_event_timeline_json
+         (goal_phase_event (live_phase_payload ~phase ~actor:"sangsu")))
+  in
+  check (option string) "blocked" (Some "bad") (severity_of "blocked");
+  check (option string) "paused" (Some "warn") (severity_of "paused");
+  check (option string) "executing" (Some "ok") (severity_of "executing");
+  check (option string) "completed" (Some "ok") (severity_of "completed")
+;;
+
+(* A producer that stops writing a field must show up, not disappear: the
+   bracketed markers are emitted by no producer, so a non-zero appearance is an
+   unambiguous producer-side fix signal. *)
+let test_missing_payload_fields_are_marked () =
+  let json = DGT.goal_event_timeline_json (goal_phase_event (`Assoc [])) in
+  check
+    (option string)
+    "both markers"
+    (Some "phase=<missing payload.phase> by <missing payload.actor>")
+    (field "summary" json)
+;;
+
+let test_unknown_event_type_keeps_its_token () =
+  let json =
+    DGT.goal_event_timeline_json
+      (`Assoc
+         [ "ts", `String "2026-08-05T23:03:13Z"
+         ; "goal_id", `String "goal-1"
+         ; "event_type", `String "goal_owner"
+         ; "payload", `Assoc [ "owner", `String "taskmaster" ]
+         ])
+  in
+  check (option string) "kind" (Some "goal_owner") (field "kind" json);
+  check (option string) "title" (Some "Goal Event") (field "title" json);
+  check (option string) "summary is the token" (Some "goal_owner") (field "summary" json)
+;;
+
+(* {1 The tree field} *)
+
+let goal : Goal_store.goal =
+  { id = "goal-1"
+  ; title = "Goal One"
+  ; metric = None
+  ; target_value = None
+  ; due_date = None
+  ; priority = 3
+  ; phase = Goal_phase.Executing
+  ; last_review_note = None
+  ; last_review_at = None
+  ; created_at = "2026-08-01T00:00:00Z"
+  ; updated_at = "2026-08-21T00:00:00Z"
+  }
+;;
+
+let node : DG.tree_node =
+  { goal
+  ; children = []
+  ; tasks = []
+  ; last_activity_at = "2026-08-21T00:00:00Z"
+  ; stagnation_seconds = Some 0
+  ; linked_keeper_names = []
+  ; pending_approval_count = 0
+  ; latest_keeper_ref = None
+  ; latest_turn_ref = None
+  ; activity_observation = "goal_metadata"
+  }
+;;
+
+let timeline_events_of json =
+  match Yojson.Safe.Util.member "timeline_events" json with
+  | `List items -> items
+  | _ -> []
+;;
+
+let test_tree_field_is_normalized () =
+  let json =
+    DG.tree_node_to_json
+      ~events_for_goal:(fun _ ->
+        [ goal_phase_event (live_phase_payload ~phase:"blocked" ~actor:"sangsu") ])
+      node
+  in
+  match timeline_events_of json with
+  | [ event ] ->
+    (* The raw ledger row has no [kind]; its normalized form does. Asserting
+       the summary too pins that the tree runs the same normalizer as the
+       detail view rather than a second, drifting copy. *)
+    check (option string) "kind" (Some "goal_phase") (field "kind" event);
+    check (option string) "lane" (Some "goal") (field "lane" event);
+    check
+      (option string)
+      "summary"
+      (Some "phase=blocked by sangsu")
+      (field "summary" event);
+    check (option string) "raw event_type is gone" None (field "event_type" event)
+  | items ->
+    failf "expected exactly one timeline event, got %d" (List.length items)
+;;
+
+let test_tree_field_is_empty_without_events () =
+  let json = DG.tree_node_to_json ~events_for_goal:(fun _ -> []) node in
+  check int "no events" 0 (List.length (timeline_events_of json))
+;;
+
+let () =
+  run
+    "goal timeline projection"
+    [ ( "normalizer"
+      , [ test_case "phase event shape" `Quick test_normalizes_a_phase_event
+        ; test_case "summary names the actor" `Quick test_summary_names_the_actor
+        ; test_case "severity follows the phase" `Quick test_severity_follows_the_phase
+        ; test_case "missing fields are marked" `Quick test_missing_payload_fields_are_marked
+        ; test_case
+            "unknown event type keeps its token"
+            `Quick
+            test_unknown_event_type_keeps_its_token
+        ] )
+    ; ( "tree field"
+      , [ test_case "timeline_events is normalized" `Quick test_tree_field_is_normalized
+        ; test_case "empty without events" `Quick test_tree_field_is_empty_without_events
+        ] )
+    ]
+;;


### PR DESCRIPTION
Closes #29299

## 현상

Goal 상세의 활동 기록이 항상 0건입니다. 기록이 없는 게 아니라 **읽지 못하는** 거였어요.

`goal_events.jsonl` 은 `{ts, goal_id, event_type, payload}` 로 저장합니다. `timeline_events` 를 읽는 쪽은 전부 `{ts, kind, lane, title, summary, severity}` 를 기대합니다. 둘 사이 번역기는 `goal_event_timeline_json` 하나뿐인데, Goal 트리가 그걸 안 거쳤습니다.

```ocaml
(* dashboard_goals.ml:147 — 수정 전 *)
("timeline_events", `List (events_for_goal goal.id));
```

`build_goal_events_projection` 은 `load_jsonl` 결과를 `goal_id` 로 묶기만 하고 변환하지 않습니다. 그래서 원본 행이 그대로 나갔고, 여섯 필드를 다 요구하는 대시보드 디코더가 전부 버렸습니다.

라이브 기준 44개 Goal 의 72개 이벤트가 전량 폐기 중이었습니다. 상세 엔드포인트는 `build_goal_timeline` 을 타서 영향이 없었습니다.

## 두 번째 버그 — actor 가 늘 사라진다

정규화기 안에도 문제가 있었습니다.

```ocaml
let actor = payload_field "actor" |> json_member_or_null "id" |> json_to_string_opt in
```

생산자는 전부 `actor` 를 **문자열**로 씁니다 (`gate_event_payload` + workspace_goals.ml 의 인라인 payload 두 곳). `json_member_or_null` 은 객체가 아니면 `` `Null `` 을 돌려주니, 지금까지 기록된 모든 이벤트에서 actor 가 `None` 이었습니다.

즉 **정상 동작하던 상세 화면에서도** 요약이 계속 `phase=blocked` 로만 나왔습니다. 누가 Goal 을 옮겼는지가 통째로 빠진 채로요. 라이브 이벤트 91건 전수 확인했고 예외 0건입니다.

문자열로 읽도록 고쳤고, 없을 때는 옆의 `phase` 필드와 같은 방식으로 `<missing payload.actor>` 를 씁니다. 생산자가 안 쓰기 시작하면 조용히 사라지는 대신 눈에 띄게요.

## 안 한 것

`goal_owner` 이벤트(라이브 22건)는 catch-all 로 떨어져 요약이 `goal_owner` 토큰 그대로 나옵니다. 이 이벤트를 쓰는 생산자가 현재 코드베이스에 없습니다 — 과거 데이터만 남은 형태라, 이걸 위한 reader 를 새로 만드는 건 `projects.md` 의 "레거시 데이터용 reader 를 만들지 않는다" 에 걸립니다. 그대로 뒀습니다.

`gate_event_payload` 가 싣는 `outcome` / `evidence` 도 요약에 안 넣었습니다. 증명이 refuted 로 뒤집힌 전이가 평범한 phase 변경으로 보이는 문제가 있는데, 이번 건과 별개라 손대지 않았습니다.

## 테스트

`test_goal_timeline_projection` 을 새로 만들었습니다. 이 투영에는 테스트가 **하나도 없었고**, 생산자/소비자 모양이 갈라진 채 살아남은 이유가 그거라고 봅니다.

7개 케이스 — 정규화 결과 모양, actor 를 실은 요약, phase 별 severity, 누락 필드 마커, 미지 event_type, 트리 필드가 정규화됐는지, 이벤트 없을 때.

뮤테이션 확인했습니다. 소스 수정 두 개를 되돌리고 돌리면 7개 중 3개가 깨집니다.

```
> [FAIL]  normalizer  1  summary names the actor.
  [FAIL]  normalizer  3  missing fields are marked.
  [FAIL]  tree field  0  timeline_events is normalized.
3 failures! in 0.001s. 7 tests run.
```

되돌리기 전후로 `git diff --stat` 확인해 원상복구도 검증했습니다.

## 검증

- `dune build --root . lib/dashboard` 통과
- 새 테스트 7/7 통과, `test/dune` 과 `scripts/ci-run-focused-tests.sh` 양쪽에 등록
- `audit-ci-test-targets.sh`: `380 CI targets, all declared in Dune` / `516 suites unwired, at baseline`
- 주변 Goal 테스트 재실행: `test_dashboard_goal_id_projection` · `test_goal_store` · `test_goal_metric_unevaluated` · `test_goal_phase_all` 전부 통과

## 별건 — main 이 이미 빨간 곳이 있습니다

작업 중 `test_goal_tools` 의 3케이스가 `origin/main`(f4c974e854)에서 실패하는 걸 확인했습니다. 제 변경과 무관합니다 (변경을 되돌린 상태에서도 동일하게 실패).

```
[FAIL] tool_workspace 7  completion accepts no linked tasks.
[FAIL] tool_workspace 8  completion ignores open task count.
[FAIL] tool_workspace 9  completion ignores metric text.
```

셋 다 같은 지점입니다. `request_complete` 는 통과해서 `verifying` 까지 가는데, 이어지는 검증기의 `Proof_proven` 커밋이 거부됩니다.

```
goal_verification: proof verdict for goal-... requires a viable criterion
```

#29301 이 말한 바로 그 트랩이고, 저장소 안의 테스트가 이미 그걸 재현하고 있었습니다. `test_goal_tools` 가 CI allowlist 에 없어서(516개 unwired 중 하나) 안 보였을 뿐입니다. 자세한 건 #29301 에 코멘트로 적었습니다.

이 PR 에서는 안 건드립니다. 지금 wiring 하면 main 이 빨개지고, 고칠 대상은 테스트가 아니라 게이트입니다.
