### PR TITLE
fix(agent-core): 도구 못 찾음 응답이 등록 목록 전체를 모델에게 되돌려보내던 문제

### DIFF
--- a/packages/agent_core/lib/agent/agent_tools.ml
+++ b/packages/agent_core/lib/agent/agent_tools.ml
@@ -130,9 +130,18 @@ let closest_registered ~requested ~available =
 ;;
 
 let unknown_tool_failure ~requested ~available =
-  let available_preview = render_tool_names available in
+  (* The catalog does not belong in the result the model reads back. Every
+     request already carries the tool schemas, and the operator copy is logged
+     beside this call, so listing the names here only sends the surface back
+     into the conversation on each miss. Measured 2026-08-21 with 101 tools
+     registered: 1,915 of the message's 1,975 bytes were the list, and one turn
+     missed 88 times in a row, so a model already failing under tool-surface
+     pressure was handed 170 KB more of it. What it cannot derive is which name
+     failed and how that name was malformed; those stay. *)
   let base =
-    Printf.sprintf "Tool not found: %s. Available tools: %s" requested available_preview
+    match available with
+    | [] -> Printf.sprintf "Tool not found: %s. No tools are registered" requested
+    | _ :: _ -> Printf.sprintf "Tool not found: %s" requested
   in
   let extras =
     match identifier_prefix requested with

--- a/packages/agent_core/test/test_event_bus.ml
+++ b/packages/agent_core/test/test_event_bus.ml
@@ -806,9 +806,9 @@ let test_unknown_tool_reports_available_tools_and_retries () =
     (string_contains ~needle:"Tool not found: MissingRead" result.content);
   check
     bool
-    "content includes available tools"
-    true
-    (string_contains ~needle:"Available tools: ReadFile" result.content);
+    "content withholds the registry the request already carries"
+    false
+    (string_contains ~needle:"Available tools" result.content);
   match List.rev !fired with
   | [ (detail, ctx) ] ->
     check
@@ -818,9 +818,9 @@ let test_unknown_tool_reports_available_tools_and_retries () =
       (string_contains ~needle:"Tool not found: MissingRead" detail);
     check
       bool
-      "detail includes available tools"
-      true
-      (string_contains ~needle:"Available tools: ReadFile" detail);
+      "detail withholds the registry too, since it is the same string"
+      false
+      (string_contains ~needle:"Available tools" detail);
     check string "context labels dispatch site" "agent_tools.find_and_execute_tool" ctx
   | [] -> fail "on_error hook not fired"
   | _ -> fail "on_error fired more than once"

--- a/packages/agent_core/test/test_tool_execution.ml
+++ b/packages/agent_core/test/test_tool_execution.ml
@@ -742,7 +742,9 @@ let test_block_is_deterministic_failure () =
   | _ -> fail "expected exactly one result"
 ;;
 
-let test_unknown_tool_is_uniform_validation_with_full_diagnostics () =
+let test_unknown_tool_is_uniform_validation_without_the_catalog () =
+  (* Fourteen names so a regression that reinstates the catalog cannot hide
+     behind a short list. *)
   let names = List.init 14 (fun index -> Printf.sprintf "tool_%02d" index) in
   let run tools =
     match
@@ -766,15 +768,16 @@ let test_unknown_tool_is_uniform_validation_with_full_diagnostics () =
   check_validation "empty catalog" without_registered_tools;
   check
     string
-    "empty catalog diagnostic"
-    "Tool not found: Missing. Available tools: (none)"
+    "an empty registry is stated, because the model cannot read absence off its \
+     own request"
+    "Tool not found: Missing. No tools are registered"
     without_registered_tools.content;
   let with_registered_tools = run (List.map make_echo_tool names) in
   check_validation "populated catalog" with_registered_tools;
   check
     string
-    "all available names are rendered without truncation"
-    ("Tool not found: Missing. Available tools: " ^ String.concat "," names)
+    "a populated registry stays out of the result the model reads back"
+    "Tool not found: Missing"
     with_registered_tools.content
 ;;
 
@@ -782,8 +785,9 @@ let test_unknown_tool_is_uniform_validation_with_full_diagnostics () =
    ([Execute["argv"]], live rondo shape) or typo a name. Lookup stays
    exact; the reject message must name the received shape and the
    nearest registered name so the model can repair the call instead of
-   resending the same broken string. A bare unknown identifier with no
-   near miss keeps the exact legacy message (pinned above). *)
+   resending the same broken string. Both are short and specific to the
+   failed call, which is why they stay in the result while the registry
+   listing does not. *)
 let run_unknown_name ~tools name =
   match
     run_execute_with_tools
@@ -812,7 +816,7 @@ let test_fused_name_reject_names_the_registered_prefix () =
   check
     string
     "fused name reject quotes the registered prefix and the repair"
-    ("Tool not found: Execute[\"argv\"]. Available tools: Execute. "
+    ("Tool not found: Execute[\"argv\"]. "
      ^ "The name carries extra characters after \"Execute\"; send the tool name "
      ^ "alone and put arguments in the input object.")
     result.content
@@ -828,9 +832,7 @@ let test_typo_name_reject_suggests_closest_registered () =
   check
     string
     "typo reject suggests the closest registered name"
-    ("Tool not found: keeper_broadcst. Available tools: "
-     ^ "keeper_broadcast,keeper_tasks_list. Closest registered name: "
-     ^ "keeper_broadcast.")
+    "Tool not found: keeper_broadcst. Closest registered name: keeper_broadcast."
     result.content
 ;;
 
@@ -842,7 +844,7 @@ let test_fused_typo_prefix_reject_suggests_closest_registered () =
   check
     string
     "fused typo reject pairs the shape note with the closest name"
-    ("Tool not found: Exceute[\"x\"]. Available tools: Execute. "
+    ("Tool not found: Exceute[\"x\"]. "
      ^ "The name is not a bare identifier (closest registered name: Execute); "
      ^ "send the registered tool name alone and put arguments in the input object.")
     result.content
@@ -1554,9 +1556,9 @@ let () =
         ] )
     ; ( "routing"
       , [ test_case
-            "unknown tools are uniform validation failures with full diagnostics"
+            "unknown tools are uniform validation failures without the registry listing"
             `Quick
-            test_unknown_tool_is_uniform_validation_with_full_diagnostics
+            test_unknown_tool_is_uniform_validation_without_the_catalog
         ; test_case
             "fused name reject names the registered prefix"
             `Quick


### PR DESCRIPTION
## 목표

도구를 못 찾았을 때 모델에게 돌려주는 응답에서 **등록 도구 목록 전체를 뺀다**.

## 현상

`Tool not found` 응답이 등록된 도구를 전부 나열합니다. 키퍼 표면 기준으로 101개고, 메시지 1,975바이트 중 **1,915바이트(97%)** 가 그 목록입니다.

그런데 모델은 그 목록을 이미 갖고 있습니다. 요청의 `tools` 필드가 스키마를 싣고 갑니다. 운영자용 사본도 바로 위 로그 줄(`agent_tools.ml:532-536`)에 따로 남습니다.

## 왜 지금

2026-08-21 polisher 턴 하나가 이 응답을 88번 받았습니다. GLM-5-Turbo 가 인자를 이름 자리에 섞어 보내고(`Execute195919443553601392883936E-11`, `input` 은 `{}`) 그 턴에서 회복하지 못한 건입니다.

그 결과 **도구 표면 때문에 무너진 모델에게 같은 표면을 170KB 더 밀어넣었습니다.** 컨텍스트 창 200k 안에서요.

이 응답이 도움이 될 자리에서는 목록이 필요 없고, 목록이 비싼 자리에서는 도움이 안 됩니다.

## 남긴 것

모델이 자기 요청에서 알 수 없는 것만 남깁니다.

- 어느 이름이 실패했는지
- 가장 가까운 등록 이름 (`Closest registered name: ...`)
- 이름이 어떻게 망가졌는지 (`The name carries extra characters after "Execute"; ...`)
- 등록된 도구가 **하나도 없을 때**는 그대로 말합니다 — 부재는 요청을 봐서 알 수 없는 유일한 사실입니다

## 바뀐 문구

| | 전 | 후 |
|---|---|---|
| 융합된 이름 | `Tool not found: Execute["argv"]. Available tools: Execute. The name carries...` | `Tool not found: Execute["argv"]. The name carries...` |
| 오타 | `Tool not found: keeper_broadcst. Available tools: keeper_broadcast,keeper_tasks_list. Closest registered name: keeper_broadcast.` | `Tool not found: keeper_broadcst. Closest registered name: keeper_broadcast.` |
| 빈 레지스트리 | `Tool not found: Missing. Available tools: (none)` | `Tool not found: Missing. No tools are registered` |

## 안 바뀐 것

로그는 그대로 전체 목록을 남깁니다. 레지스트리 드리프트 진단 경로는 손대지 않았습니다.

## 테스트

계약이 바뀐 만큼 계약을 고정한 테스트도 새 계약을 진술하도록 바꿨습니다.

- `test_unknown_tool_is_uniform_validation_with_full_diagnostics` → `..._without_the_catalog`. 도구 14개를 등록해 두고 결과에 `Tool not found: Missing` 만 오는지 정확히 대조합니다 — 목록이 되살아나면 짧은 목록 뒤에 숨을 수 없습니다.
- `test_event_bus` 의 두 단언을 `Available tools` **부재** 확인으로 뒤집었습니다.
- 융합 이름·오타·융합 오타 세 케이스(masc#29008)는 힌트 부분을 그대로 유지한 채 목록만 빠졌는지 확인합니다.

## 로컬 검증

```
scripts/dune-local.sh build @packages/agent_core/check                   CHECK_EXIT=0
scripts/dune-local.sh build @packages/agent_core/runtest-test_tool_execution
                            @packages/agent_core/runtest-test_event_bus   49 + 29 통과, TEST_EXIT=0
ocamlformat --check (변경 3파일)                                          FMT_EXIT=0
```

## 미검증

- 실제 키퍼 턴에서의 컨텍스트 절감량은 재지 않았습니다. 위 170KB 는 로그의 메시지 길이 × 실패 횟수로 계산한 값입니다.
- 이 변경은 모델 열화 자체를 고치지 않습니다. 제공자 쪽 현상은 #29337 에 측정과 함께 정리했습니다.
