### PR TITLE
fix(goal): validate retired owner tombstone

### DIFF
--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -98,15 +98,32 @@ and goal_of_yojson = function
             if List.mem field accepted_fields then None else Some field)
           fields
       in
+      let retired_owner =
+        match
+          List.filter_map
+            (fun (field, value) ->
+               if String.equal field "owner" then Some value else None)
+            fields
+        with
+        | [] -> Ok ()
+        | [ (`String _ | `Null) ] -> Ok ()
+        | [ value ] ->
+          Error
+            (Printf.sprintf
+               "goal_of_yojson: retired owner must retain its former string-or-null shape, got %s"
+               (Yojson.Safe.to_string value))
+        | _ -> Error "goal_of_yojson: duplicate retired owner field"
+      in
       let id_opt = Json_util.assoc_member_opt "id" json in
       let title_opt = Json_util.assoc_member_opt "title" json in
-      (match unknown_field, id_opt, title_opt with
-      | Some field, _, _ ->
+      (match unknown_field, retired_owner, id_opt, title_opt with
+      | Some field, _, _, _ ->
           Error
             (Printf.sprintf
                "goal_of_yojson: unknown Goal field %S is not accepted"
                field)
-      | None, Some (`String id), Some (`String title) ->
+      | None, Error detail, _, _ -> Error detail
+      | None, Ok (), Some (`String id), Some (`String title) ->
           let phase =
             (* Phase is required: a row without [phase] is a decode error, not
                a silent Active default. The silent default caused main red
@@ -149,7 +166,7 @@ and goal_of_yojson = function
            | Error msg, _, _ -> Error msg
            | _, Error msg, _ -> Error msg
            | _, _, Error msg -> Error msg)
-      | None, _, _ -> Error "goal_of_yojson: invalid goal")
+      | None, Ok (), _, _ -> Error "goal_of_yojson: invalid goal")
   | other_json ->
       Error ("goal_of_yojson: " ^ Yojson.Safe.to_string other_json)
 

--- a/lib/goal/goal_store.mli
+++ b/lib/goal/goal_store.mli
@@ -7,9 +7,11 @@
 
     - a {!Goal_phase.t} (canonical lifecycle: [Executing] / [Blocked] /
       [Completed] / [Paused] / [Dropped]) — the only persisted
-      lifecycle representation.  The retired ["owner"] field is accepted
-      and discarded on read so pre-cut stores remain available, but it is
-      never written and does not re-enter the runtime model.  ["status"] is
+      lifecycle representation.  One retired ["owner"] field is accepted
+      and discarded on read only when it retains the former string-or-null
+      shape, so valid pre-cut stores remain available without licensing
+      malformed or duplicate tombstones.  It is never written and does not
+      re-enter the runtime model.  ["status"] is
       not an accepted field:
       a row carrying it fails to decode, and {!read_state} then applies
       the corrupt-store policy (recovery mirror if usable, otherwise an

--- a/test/test_goal_store.ml
+++ b/test/test_goal_store.ml
@@ -270,6 +270,50 @@ let test_legacy_owner_is_read_only_tombstone () =
   in
   check bool "canonical rewrite drops legacy owner" false owner_persisted
 
+let test_legacy_owner_null_retains_former_optional_shape () =
+  with_workspace @@ fun config ->
+  let goal = make_goal "legacy-owner-null" "legacy null owner is ignored" in
+  Goal_store.write_state config
+    { version = 1; updated_at = iso_now (); goals = [ goal ] };
+  add_goal_field config "owner" `Null;
+  check int "legacy null owner remains readable" 1
+    (List.length (Goal_store.read_state config).goals)
+
+let test_legacy_owner_rejects_malformed_payloads () =
+  [ "integer", `Int 7
+  ; "object", `Assoc [ "keeper", `String "retired" ]
+  ; "array", `List [ `String "retired" ]
+  ; "boolean", `Bool false
+  ]
+  |> List.iter (fun (label, payload) ->
+    with_workspace @@ fun config ->
+    let goal = make_goal ("legacy-owner-" ^ label) "malformed owner fails" in
+    Goal_store.write_state config
+      { version = 1; updated_at = iso_now (); goals = [ goal ] };
+    add_goal_field config "owner" payload;
+    check int (label ^ " owner keeps store undecodable") 0
+      (List.length (Goal_store.read_state config).goals);
+    match Goal_store.update_goal config ~goal_id:goal.id Fun.id with
+    | Ok _ -> fail (label ^ " owner licensed a canonical rewrite")
+    | Error detail ->
+      check bool (label ^ " owner fails closed") true
+        (String_util.contains_substring detail "refusing to write"))
+
+let test_legacy_owner_rejects_duplicate_tombstones () =
+  with_workspace @@ fun config ->
+  let goal = make_goal "legacy-owner-duplicate" "duplicate owner fails" in
+  Goal_store.write_state config
+    { version = 1; updated_at = iso_now (); goals = [ goal ] };
+  add_goal_field config "owner" (`String "retired-a");
+  add_goal_field config "owner" (`String "retired-b");
+  check int "duplicate owner keeps store undecodable" 0
+    (List.length (Goal_store.read_state config).goals);
+  match Goal_store.update_goal config ~goal_id:goal.id Fun.id with
+  | Ok _ -> fail "duplicate retired owner licensed a canonical rewrite"
+  | Error detail ->
+    check bool "duplicate owner fails closed" true
+      (String_util.contains_substring detail "refusing to write")
+
 let test_other_unknown_goal_field_still_fails () =
   with_workspace @@ fun config ->
   let goal = make_goal "unknown-field" "unknown field fails" in
@@ -434,6 +478,12 @@ let () =
             test_serializer_omits_status;
           test_case "legacy owner is a read-only tombstone" `Quick
             test_legacy_owner_is_read_only_tombstone;
+          test_case "legacy null owner retains former optional shape" `Quick
+            test_legacy_owner_null_retains_former_optional_shape;
+          test_case "legacy owner rejects malformed payloads" `Quick
+            test_legacy_owner_rejects_malformed_payloads;
+          test_case "legacy owner rejects duplicate tombstones" `Quick
+            test_legacy_owner_rejects_duplicate_tombstones;
           test_case "other unknown goal field still fails" `Quick
             test_other_unknown_goal_field_still_fails;
           test_case "phase-less row no longer decodes" `Quick


### PR DESCRIPTION
Follow-up to merged #29298 for the remaining adversarial-review blocker.

The retired Goal `owner` field is decode-only compatibility data. It now accepts exactly one value with the former `string | null` shape, rejects malformed and duplicate tombstones, and remains absent from current runtime types and writers.

Validation:
- `test_goal_store` — 19/19
- `git diff --check` — clean

This PR is intentionally Draft pending exact-head CI and review.