### PR TITLE
fix(gate): goal_ids 제거가 바꾼 pending store 버전을 올린다

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -301,7 +301,12 @@ let install_error_to_string = function
   | Install_storage_failed error -> storage_error_to_string error
 ;;
 
-let pending_store_version = 8
+(* Bumped to 9 by the goal_ids removal: #29256 dropped the field from the entry
+   contract without moving the version, so an installed v8 store failed the
+   field check with "contains unsupported field goal_ids" instead of the version
+   check that tells an operator what to do about it. A format change the version
+   does not record is a format change nobody can diagnose. *)
+let pending_store_version = 9
 let pending_store_surface = "keeper_gate_pending"
 let replay_results_store_version = 1
 let replay_results_store_surface = "keeper_gate_replay_results"

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -600,7 +600,7 @@ let test_install_serializes_snapshot_read_with_same_base_mutation () =
        write_pending_snapshot
          ~base_path
          (`Assoc
-             [ "version", `Int 8
+             [ "version", `Int 9
             ; "next_sequence", `Int 1
             ; "pending", `List []
             ; "deliveries", `List []
@@ -1678,7 +1678,7 @@ let test_exact_binding_codec_validates_entry_identity () =
          (run_exact_transition AQ.bind_summary_exact_attempt identity);
        let snapshot = read_pending_snapshot ~base_path in
        let open Yojson.Safe.Util in
-       Alcotest.(check int) "v8 snapshot" 8 (snapshot |> member "version" |> to_int);
+       Alcotest.(check int) "v9 snapshot" 9 (snapshot |> member "version" |> to_int);
        let exact_json =
          snapshot
          |> member "pending"
@@ -3085,7 +3085,7 @@ let test_malformed_snapshot_fails_install_and_is_observed () =
        write_pending_snapshot
          ~base_path
          (`Assoc
-            [ "version", `Int 8
+            [ "version", `Int 9
             ; "next_sequence", `Int 1
             ; "pending", `List [ `String "malformed-entry" ]
             ; "deliveries", `List []
@@ -3120,7 +3120,7 @@ let test_malformed_snapshot_fails_install_and_is_observed () =
          (Yojson.Safe.equal
             persisted
             (`Assoc
-               [ "version", `Int 8
+               [ "version", `Int 9
                ; "next_sequence", `Int 1
                ; "pending", `List [ `String "malformed-entry" ]
                ; "deliveries", `List []
@@ -3145,7 +3145,7 @@ let test_unsupported_version_snapshot_requires_runtime_reset () =
        write_pending_snapshot
          ~base_path
          (`Assoc
-            [ "version", `Int 7
+            [ "version", `Int 8
             ; "pending", `List []
             ; "deliveries", `List []
             ]);
@@ -3155,7 +3155,7 @@ let test_unsupported_version_snapshot_requires_runtime_reset () =
         | Error
             (AQ.Install_storage_failed
               { reason =
-                  "gate_pending.version 7 is unsupported (current 8); reset \
+                  "gate_pending.version 8 is unsupported (current 9); reset \
                    runtime state before restarting MASC"
               ; _
               }) ->
@@ -3366,7 +3366,7 @@ let test_persisted_delivery_replays_before_origin_wake () =
        write_pending_snapshot
          ~base_path
          (`Assoc
-             [ "version", `Int 8
+             [ "version", `Int 9
             ; "next_sequence", `Int 2
             ; "pending", `List []
             ; ( "deliveries"
@@ -3575,7 +3575,7 @@ let test_one_delivery_replay_failure_does_not_stop_others () =
        write_pending_snapshot
          ~base_path
          (`Assoc
-             [ "version", `Int 8
+             [ "version", `Int 9
             ; "next_sequence", `Int 4
             ; "pending", `List []
             ; ( "deliveries"


### PR DESCRIPTION
## 현상

라이브 워크스페이스에서 Gate durable queue가 안 열립니다.

```
Gate durable queue unavailable · runtime reset required
/Users/dancer/me/.masc/gate/pending.json:
  gate_pending.deliveries[0]: gate_pending.entry contains unsupported field goal_ids
```

## 원인

`#29256`(Goal에서 owner 개념 제거)이 approval entry 계약에서 `goal_ids`를 걷어냈는데, **`pending_store_version`은 8 그대로 뒀습니다.**

설치된 스토어도 자기를 8이라고 적어두니 버전 검사는 통과하고, 그다음 필드 검사에서 걸립니다. 그래서 운영자가 보는 메시지에는 **필드 이름만 있고 버전이 없습니다** — 이 파일이 포맷 변경 이전 것이라는 사실도, 리셋이 곧 해결이라는 사실도 그 문장에서 읽히지 않습니다.

실측: 라이브 파일은 8/17 01:22 이후 갱신이 멈춰 있었고, `deliveries` 1138건에 `pending`은 0건이었습니다. 모든 entry가 `goal_ids: []`(빈 배열)를 들고 있습니다 — 값이 있어서가 아니라 필드가 있어서 거부됩니다.

## 수정

`pending_store_version` 8 → 9.

같은 스토어를 이제 버전 검사가 먼저 잡고, 할 일을 말합니다.

```
gate_pending.version 8 is unsupported (current 9); reset runtime state before restarting MASC
```

옛 모양을 읽는 코드는 추가하지 않았습니다. `#29256`이 이미 한 hard cut을, 파일을 읽는 사람이 볼 수 있는 자리에 기록하는 것뿐입니다.

거부 테스트는 v7 대신 **v8 스토어**를 재생합니다 — 실제로 이 사고가 난 모양이니까요. install은 여전히 거부하고, 파일도 그대로 남겨 운영자가 옮기게 합니다(`original remains for operator reset`).

## 검증

| | |
|---|---|
| `test_keeper_approval_queue` | 45 통과 |
| 관련 스위트 6종 (`ide_bridge`, `waiting_inventory`, `approval_audit_timeline`, `runtime_trust_snapshot`, `hitl_replay_delivery`, `dashboard_gate_metrics`) | 전부 통과 |
| `dune build @check` / `@fmt` | 통과 |
| Meta bug-class gates 20종 | 전부 PASS |

## 함께 발견한 별건

`test_heartbeat_integration`의 `direct_keepalive / fork rejection terminalize` 가 실패합니다. **이 브랜치와 무관합니다** — base(`55380f54f0`)에서 변경을 되돌리고 돌려도 동일하게 실패합니다.

이 스위트는 `scripts/ci-run-focused-tests.sh` allowlist에 **없어서** CI가 돌지 않습니다. 그래서 main이 green인 채로 깨져 있었습니다. 별도 이슈로 올리겠습니다.

## 운영 조치

라이브 `pending.json`은 `~/me/.masc/backups/gate-pending-v8-20260822/` 로 백업한 뒤 치웠습니다. 파일이 없으면 빈 큐로 정상 시작합니다(`Ok (SMap.empty, …)`). 반영에는 런타임 재시작이 필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019aJnBnLwzk1domqs3wqzZe