### PR TITLE
chore(keeper): 퇴역한 active_goal_ids 표면 정리

### DIFF
--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -222,36 +222,6 @@ let repair_non_canonical_enum_fields json =
   | _ -> None
 ;;
 
-(* [active_goal_ids] was present in the immediately preceding durable schema,
-   but goal assignment is no longer Keeper metadata.  Accepting this one key
-   on read is a migration tombstone, not a schema field: it is discarded before
-   current-schema validation and is never available to [decode_current_meta] or
-   emitted by the writer.  The retired payload still has to match its former
-   string-list contract before it is discarded; accepting arbitrary JSON here
-   would silently turn corruption into a valid current snapshot.  Duplicate
-   tombstones still fail closed, as do all other unknown fields. *)
-let drop_legacy_active_goal_ids = function
-  | `Assoc fields ->
-    let count =
-      List.fold_left
-        (fun count (key, _) ->
-           if String.equal key "active_goal_ids" then count + 1 else count)
-        0
-        fields
-    in
-    if count > 1
-    then invalidf "duplicate field active_goal_ids"
-    else if count = 0
-    then Ok (`Assoc fields)
-    else (
-      let* (_ : string list) = string_list_field fields "active_goal_ids" in
-      Ok
-        (`Assoc
-           (List.filter
-              (fun (key, _) -> not (String.equal key "active_goal_ids"))
-              fields)))
-  | json -> Ok json
-;;
 
 let parse_last_blocker fields =
   let* value = required_field fields "last_blocker" in
@@ -585,7 +555,6 @@ let decode_current_meta fields =
 
 let meta_of_json json =
   try
-    let* json = drop_legacy_active_goal_ids json in
     match validate_current_object json with
     | Error error -> Error (validation_error_detail error)
     | Ok fields ->

--- a/lib/keeper/keeper_meta_json_parse.mli
+++ b/lib/keeper/keeper_meta_json_parse.mli
@@ -3,12 +3,8 @@
 val meta_of_json :
   Yojson.Safe.t -> (Keeper_meta_contract.keeper_meta, string) result
 (** Decode the exact top-level shape emitted by
-    [Keeper_meta_json.meta_to_json]. The immediately preceding
-    ["active_goal_ids"] field is accepted in its former string-list shape and
-    discarded as a read-only migration tombstone; it never reaches the runtime
-    record or writer. Wrong-shaped tombstone payloads remain reset-required.
-    Missing, wrong-typed, other retired, duplicate, unknown, or malformed
-    fields are explicit reset-required errors. Nullable domain fields still
+    [Keeper_meta_json.meta_to_json]. Missing, wrong-typed, retired, duplicate,
+    unknown, or malformed fields are explicit reset-required errors. Nullable domain fields still
     accept their current [`Null] representation. *)
 
 (** One enumerated-field repair: [field] held [previous_value], which is not a

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -160,11 +160,6 @@ let schemas : tool_schema list = [
           ("items", `Assoc [("type", `String "string")]);
           ("description", `String "Exact direct-mention tokens that can wake the keeper in workspace traffic (for example ['sangsu']).");
         ]);
-        ("active_goal_ids", `Assoc [
-          ("type", `String "array");
-          ("items", `Assoc [("type", `String "string")]);
-          ("description", `String "Goal IDs this keeper is allowed to claim work for. Empty clears goal scoping.");
-        ]);
         ("sandbox_profile", `Assoc [
           ("type", `String "string");
           ("enum", `List [`String "local"; `String "docker"]);

--- a/lib/keeper/keeper_tool_keeper_audit.ml
+++ b/lib/keeper/keeper_tool_keeper_audit.ml
@@ -246,8 +246,6 @@ let summary items =
       ("autoboot_disabled", `Int count_autoboot_disabled);
       ("keeper_paused", `Int (count_issue "keeper_paused"));
       ("keepalive_not_running", `Int (count_issue "keepalive_not_running"));
-      ("empty_active_goal_ids", `Int (count_issue "empty_active_goal_ids"));
-      ("stale_active_goal_ids", `Int (count_issue "stale_active_goal_ids"));
     ]
 
 let handle ~(config : Workspace.config) args : tool_result =

--- a/lib/keeper/keeper_types_profile_defaults.ml
+++ b/lib/keeper/keeper_types_profile_defaults.ml
@@ -20,7 +20,6 @@ type keeper_profile_defaults = {
      the system prompt once, this is the conversation input the keeper receives
      every cycle and which the durable checkpoint keeps. [None] inherits. *)
   autonomous_wake_prompt : string option;
-  active_goal_ids : string list option;
   max_context_override : int option;
   (* Telemetry Feedback — inject behavioral stats into keeper context *)
   telemetry_feedback_enabled : bool option;
@@ -50,7 +49,6 @@ let empty_keeper_profile_defaults =
     network_mode = None;
     multimodal_policy = None;
     autonomous_wake_prompt = None;
-    active_goal_ids = None;
     max_context_override = None;
     telemetry_feedback_enabled = None;
     telemetry_feedback_window_hours = None;

--- a/lib/keeper/keeper_types_profile_defaults.mli
+++ b/lib/keeper/keeper_types_profile_defaults.mli
@@ -18,7 +18,6 @@ type keeper_profile_defaults = {
   network_mode : Keeper_types_profile_sandbox.network_mode option;
   multimodal_policy : Keeper_types_profile_sandbox.multimodal_policy option;
   autonomous_wake_prompt : string option;
-  active_goal_ids : string list option;
   max_context_override : int option;
   telemetry_feedback_enabled : bool option;
   telemetry_feedback_window_hours : int option;

--- a/lib/keeper/keeper_types_profile_toml.mli
+++ b/lib/keeper/keeper_types_profile_toml.mli
@@ -65,7 +65,6 @@ type keeper_profile_defaults =
   network_mode : Keeper_types_profile_sandbox.network_mode option;
   multimodal_policy : Keeper_types_profile_sandbox.multimodal_policy option;
   autonomous_wake_prompt : string option;
-  active_goal_ids : string list option;
   max_context_override : int option;
   telemetry_feedback_enabled : bool option;
   telemetry_feedback_window_hours : int option;

--- a/lib/keeper/keeper_types_profile_toml_io.mli
+++ b/lib/keeper/keeper_types_profile_toml_io.mli
@@ -65,7 +65,6 @@ type keeper_profile_defaults =
   network_mode : Keeper_types_profile_sandbox.network_mode option;
   multimodal_policy : Keeper_types_profile_sandbox.multimodal_policy option;
   autonomous_wake_prompt : string option;
-  active_goal_ids : string list option;
   max_context_override : int option;
   telemetry_feedback_enabled : bool option;
   telemetry_feedback_window_hours : int option;

--- a/lib/keeper/keeper_types_profile_toml_normalizers.mli
+++ b/lib/keeper/keeper_types_profile_toml_normalizers.mli
@@ -65,7 +65,6 @@ type keeper_profile_defaults =
   network_mode : Keeper_types_profile_sandbox.network_mode option;
   multimodal_policy : Keeper_types_profile_sandbox.multimodal_policy option;
   autonomous_wake_prompt : string option;
-  active_goal_ids : string list option;
   max_context_override : int option;
   telemetry_feedback_enabled : bool option;
   telemetry_feedback_window_hours : int option;

--- a/lib/keeper/keeper_types_profile_toml_parser.ml
+++ b/lib/keeper/keeper_types_profile_toml_parser.ml
@@ -33,7 +33,6 @@ let keeper_toml_fields =
   ; "sandbox_image", Field_string
   ; "network_mode", Field_string
   ; "multimodal_policy", Field_string
-  ; "active_goal_ids", Field_string_array
   ; "max_context_override", Field_int
   ; "telemetry_feedback_enabled", Field_bool
   ; "telemetry_feedback_window_hours", Field_int
@@ -231,10 +230,6 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         multimodal_policy =
           Option.bind (str "multimodal_policy") multimodal_policy_of_string;
         autonomous_wake_prompt;
-        active_goal_ids =
-          if has "active_goal_ids" then
-            Some (normalize_name_list (strs "active_goal_ids"))
-          else None;
         max_context_override;
         telemetry_feedback_enabled = bool_ "telemetry_feedback_enabled";
         telemetry_feedback_window_hours = int_ "telemetry_feedback_window_hours";
@@ -281,7 +276,6 @@ let merge_keeper_profile_defaults
     sandbox_image = prefer overlay.sandbox_image base.sandbox_image;
     network_mode = prefer overlay.network_mode base.network_mode;
     multimodal_policy = prefer overlay.multimodal_policy base.multimodal_policy;
-    active_goal_ids = prefer overlay.active_goal_ids base.active_goal_ids;
     max_context_override =
       prefer overlay.max_context_override base.max_context_override;
     telemetry_feedback_enabled =

--- a/lib/keeper/keeper_types_profile_toml_parser.mli
+++ b/lib/keeper/keeper_types_profile_toml_parser.mli
@@ -65,7 +65,6 @@ type keeper_profile_defaults =
   network_mode : Keeper_types_profile_sandbox.network_mode option;
   multimodal_policy : Keeper_types_profile_sandbox.multimodal_policy option;
   autonomous_wake_prompt : string option;
-  active_goal_ids : string list option;
   max_context_override : int option;
   telemetry_feedback_enabled : bool option;
   telemetry_feedback_window_hours : int option;

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -561,7 +561,6 @@ let dashboard_config_bool_fields =
 
 let dashboard_config_string_list_fields =
   [
-    "active_goal_ids";
     "mention_targets";
     "allowed_paths";
   ]

--- a/lib/tool_surface/tool_shard_types_schemas_taskboard.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_taskboard.ml
@@ -104,9 +104,7 @@ let taskboard_tools : Masc_domain.tool_schema list =
          keeper_tasks_list row identifies it; an awaiting_verification task returns \
          the typed pending-verdict refusal. If you already own another \
          Claimed/InProgress task, finish it with keeper_task_done or explicitly \
-         release it first; keeper_task_claim does not auto-release active work. If \
-         active_goal_ids are configured, the no-arg claim prefers goal-linked work \
-         and only widens when the scoped pool has no eligible task."
+         release it first; keeper_task_claim does not auto-release active work."
     ; input_schema =
         `Assoc
           [ "type", `String "object"

--- a/test/test_keeper_meta_current_schema.ml
+++ b/test/test_keeper_meta_current_schema.ml
@@ -148,51 +148,11 @@ let test_every_outside_field_has_one_classification () =
       (current_json () |> replace_field key (`String "ignored-value")))
 ;;
 
-let test_legacy_active_goal_ids_is_read_only_tombstone () =
-  let legacy_json =
-    current_json ()
-    |> replace_field
-         "active_goal_ids"
-         (`List [ `String "goal-a"; `String "goal-b" ])
-  in
-  let decoded =
-    match Keeper_meta_json_parse.meta_of_json legacy_json with
-    | Ok meta -> meta
-    | Error detail -> Alcotest.failf "legacy active_goal_ids rejected: %s" detail
-  in
-  let rewritten_fields = Keeper_meta_json.meta_to_json decoded |> fields_exn in
-  check bool
-    "current writer drops active_goal_ids"
-    false
-    (List.mem_assoc "active_goal_ids" rewritten_fields)
-;;
-
-let test_legacy_tombstone_does_not_weaken_closed_schema () =
-  let fields = fields_exn (current_json ()) in
+let test_retired_active_goal_ids_requires_reset () =
   expect_rejected
-    "legacy tombstone plus unrelated unknown"
-    (`Assoc
-       (("active_goal_ids", `List [ `String "goal-a" ])
-        :: ("unexpected_assignment", `String "still-closed")
-        :: fields));
-  expect_rejected
-    "duplicate legacy tombstone"
-    (`Assoc
-       (("active_goal_ids", `List [])
-        :: ("active_goal_ids", `List [ `String "goal-a" ])
-        :: fields))
-;;
-
-let test_legacy_tombstone_rejects_wrong_payload_shapes () =
-  [ "scalar", `String "goal-a"
-  ; "null", `Null
-  ; "object", `Assoc [ "goal", `String "goal-a" ]
-  ; "mixed element", `List [ `String "goal-a"; `Int 7 ]
-  ]
-  |> List.iter (fun (label, payload) ->
-    expect_rejected
-      ("legacy tombstone " ^ label)
-      (current_json () |> replace_field "active_goal_ids" payload))
+    "retired active_goal_ids"
+    (current_json ()
+     |> replace_field "active_goal_ids" (`List [ `String "goal-a" ]))
 ;;
 
 let test_retired_compaction_failure_authority_requires_reset () =
@@ -218,12 +178,8 @@ let () =
             test_nullability_is_exact
         ; test_case "outside fields share one classification" `Quick
             test_every_outside_field_has_one_classification
-        ; test_case "legacy active_goal_ids is a read-only tombstone" `Quick
-            test_legacy_active_goal_ids_is_read_only_tombstone
-        ; test_case "legacy tombstone keeps the remaining schema closed" `Quick
-            test_legacy_tombstone_does_not_weaken_closed_schema
-        ; test_case "legacy tombstone rejects wrong payload shapes" `Quick
-            test_legacy_tombstone_rejects_wrong_payload_shapes
+        ; test_case "retired active_goal_ids requires reset" `Quick
+            test_retired_active_goal_ids_requires_reset
         ; test_case
             "retired compaction failure authority requires reset"
             `Quick


### PR DESCRIPTION
#29256 이 keeper meta 스키마에서 `Active_goal_ids` 를 뺐는데, 그 필드를 설명하던 표면들이 그대로 남아 있었습니다. 이번에 같이 정리합니다.

## 죽어 있었다는 근거

TOML 설정 체인을 통째로 지우고 `dune build @check` 를 돌렸더니 **에러가 하나도 안 났습니다.** 파싱한 값을 읽는 코드가 없었다는 뜻입니다. parser 안에서 base/overlay 병합만 하고 끝나고 있었어요.

## 지운 것

| 표면 | 문제 |
|---|---|
| TOML 설정 체인 | 필드 스펙, 파서, overlay 병합, 레코드 선언 5곳 — 소비처 0 |
| `keeper_meta_json_parse` 의 migration tombstone | 읽을 때 이 키를 받아서 버리던 호환 리더 |
| `keeper_task_claim` 도구 설명 | "active_goal_ids 가 설정되면 goal 연결 작업을 선호한다" — #29175 가 지운 동작입니다 |
| keeper config 스키마 설명 | "이 keeper 가 claim 할 수 있는 Goal ID" — goal scoping 자체가 없습니다 |
| 대시보드 설정 쓰기 표면 | UI 에서 편집은 되는데 저장해도 아무 일도 안 났습니다 |
| audit 카운터 2종 | `empty_active_goal_ids` / `stale_active_goal_ids` — 만드는 쪽이 없어서 늘 0 |

도구 설명 두 건이 특히 문제였습니다. keeper 가 매 턴 읽는 계약인데 없는 기능을 약속하고 있었어요.

## 남긴 것

`keeper_board_attention_candidate` 의 v4 ledger tombstone 은 그대로 뒀습니다. 라이브 `exact-lane-runs-v4.jsonl` 에 이 키를 가진 레코드가 **1363건** 살아 있어서, 지우면 읽기가 깨집니다. 주석이 이미 "v4 ledger read boundary only" 로 범위를 좁혀놨고요.

## 테스트

`test_keeper_meta_current_schema` 의 tombstone 테스트 3건을 정리했습니다. 수용을 검증하던 1건은 **거부 검증으로 바꿨고**(`retired active_goal_ids requires reset`), 나머지 2건은 `test_every_outside_field_has_one_classification` 이 이미 덮는 내용이라 지웠습니다.

- `dune build @check` 통과
- `test_keeper_meta_current_schema` 9/9
- `test_keeper_toml` · `test_keeper_effective_meta_overlay` · `test_keeper_tool_descriptor_registry_integrity` · `test_keeper_turn_up_args` 168건 통과

## 안 한 것

`Goal_assigned` 이벤트 계열이 아직 남아 있습니다. 전용 모듈 `keeper_goal_assignment_wake` 는 **호출부가 0** 이고, `keeper_turn_up_update.ml:353` 의 주석은 실제 코드와 이미 어긋나 있습니다. 다만 durable event queue 에 기록이 남아 있어서 variant 를 지우면 읽기가 깨집니다. 별도로 다루는 게 맞다고 봅니다.

살아 있는 쪽 이름도 손대지 않았습니다. 대시보드 snapshot 의 `active_goal_ids` 는 주석대로 **의도적으로 전역**입니다(`Goals name no keeper`). 그런데 이름은 "이 keeper 의 goal" 로 읽혀서, `keeper_has_goal` 이 모든 keeper 에 같은 값을 돌려줍니다. 리네임은 API 계약 변경이라 이 PR 에 섞지 않았습니다.

## 참고

`test_dashboard_http_core` 는 base(55380f54f0)에서 이미 4건 실패합니다. 파일을 되돌려 대조했고 실패 목록이 동일해서 이 변경과는 무관합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAmvJ8HTPaseKtQafqyaMm