### PR TITLE
test: pin RW23 producer artifact contract

### DIFF
--- a/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
+++ b/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
@@ -1829,14 +1829,7 @@ class MissionRun:
         self.run_turn(
             "coordinator",
             "goal-verifier-refute-artifact",
-            (
-                f"Mission {self.marker}. composition 도구는 호출하지 마세요. "
-                f"exact Task {self.verifier_task_id}를 claim하세요. "
-                f"Write(tool_write_file)로 playground의 {self.verifier_artifact}에 "
-                f"정확히 '{failure_token}' 한 줄만 쓰세요. 다른 토큰을 추가하지 마세요. "
-                f"keeper_task_done으로 artifact:{self.verifier_artifact}를 evidence로 "
-                "제출하세요. 실패 내용이어도 완료를 가장하지 말고 실제 파일을 그대로 제출하세요."
-            ),
+            self._goal_verifier_refute_prompt(failure_token),
         )
         rejected_task_verdict = self.wait_for_verifier_task_verdict("in_progress")
         self.writer.write_json(
@@ -1866,14 +1859,7 @@ class MissionRun:
         self.run_turn(
             "coordinator",
             "goal-verifier-proven-artifact",
-            (
-                f"Mission {self.marker}. composition 도구는 호출하지 마세요. "
-                f"Write(tool_write_file)로 playground의 {self.verifier_artifact}를 "
-                f"정확히 '{self.verifier_success_token}' 한 줄로 교체하세요. "
-                "쓴 뒤 파일의 exact content를 다시 읽어 확인하고, "
-                f"keeper_task_done으로 artifact:{self.verifier_artifact}를 evidence로 "
-                "다시 제출하세요."
-            ),
+            self._goal_verifier_proven_prompt(),
         )
         approved_task_verdict = self.wait_for_verifier_task_verdict("done")
         self.writer.write_json(
@@ -1950,6 +1936,32 @@ class MissionRun:
         self.writer.write_json(
             "observations/goal-verification-runs.json",
             {"payload": runs_payload, "evidence": self.goal_verifier_evidence},
+        )
+
+    def _goal_verifier_refute_prompt(self, failure_token: str) -> str:
+        return (
+            f"Mission {self.marker}. composition 도구는 호출하지 마세요. "
+            f"exact Task {self.verifier_task_id}를 claim하세요. "
+            f"tool_write_file을 path='{self.verifier_artifact}', "
+            f"content='{failure_token}', mode='overwrite'로 호출하세요. "
+            "path에 'playground/' 접두사나 절대 경로를 붙이지 마세요. "
+            f"keeper_task_done은 task_id='{self.verifier_task_id}', "
+            f"evidence_refs=['artifact:{self.verifier_artifact}']로 제출하세요. "
+            "실패 내용이어도 완료를 가장하지 말고 실제 파일을 그대로 제출하세요."
+        )
+
+    def _goal_verifier_proven_prompt(self) -> str:
+        return (
+            f"Mission {self.marker}. composition 도구는 호출하지 마세요. "
+            f"반려 뒤 in_progress인 exact Task {self.verifier_task_id}만 계속 처리하세요. "
+            "keeper_task_release, masc_add_task, keeper_task_claim을 호출하지 말고 "
+            "Task를 release하거나 대체 Task를 만들거나 claim하지 마세요. "
+            f"tool_write_file을 path='{self.verifier_artifact}', "
+            f"content='{self.verifier_success_token}', mode='overwrite'로 호출하세요. "
+            "path에 'playground/' 접두사나 절대 경로를 붙이지 마세요. "
+            f"tool_read_file도 path='{self.verifier_artifact}'로 호출해 exact content를 확인하세요. "
+            f"keeper_task_done은 task_id='{self.verifier_task_id}', "
+            f"evidence_refs=['artifact:{self.verifier_artifact}']로 다시 제출하세요."
         )
 
     def restart_and_recall(self, post_id: str) -> None:

--- a/test/test_keeper_multi_collaboration_acceptance.py
+++ b/test/test_keeper_multi_collaboration_acceptance.py
@@ -383,6 +383,43 @@ class KeeperMultiCollaborationAcceptanceTest(unittest.TestCase):
         self.assertIn('wait_for_verifier_task_verdict("in_progress")', rw23_source)
         self.assertIn('wait_for_verifier_task_verdict("done")', rw23_source)
 
+    def test_rw23_prompts_pin_canonical_artifact_path_and_original_task(self):
+        run = object.__new__(acceptance.MissionRun)
+        run.marker = "keeper-collab-contract"
+        run.verifier_task_id = "task-009"
+        run.verifier_artifact = "artifacts/keeper-collab-contract-goal-proof.txt"
+        run.verifier_success_token = "GOAL_PROOF_PASS=keeper-collab-contract"
+
+        refute = run._goal_verifier_refute_prompt(
+            "GOAL_PROOF_FAIL=keeper-collab-contract"
+        )
+        proven = run._goal_verifier_proven_prompt()
+
+        canonical_write = (
+            "path='artifacts/keeper-collab-contract-goal-proof.txt'"
+        )
+        canonical_evidence = (
+            "evidence_refs=['artifact:artifacts/"
+            "keeper-collab-contract-goal-proof.txt']"
+        )
+        self.assertIn(canonical_write, refute)
+        self.assertIn(canonical_write, proven)
+        self.assertIn(canonical_evidence, refute)
+        self.assertIn(canonical_evidence, proven)
+        self.assertIn("path에 'playground/' 접두사", refute)
+        self.assertIn("path에 'playground/' 접두사", proven)
+        self.assertNotIn("playground의 artifacts/", refute)
+        self.assertNotIn("playground의 artifacts/", proven)
+        self.assertIn("task_id='task-009'", refute)
+        self.assertIn("task_id='task-009'", proven)
+        for forbidden_tool in (
+            "keeper_task_release",
+            "masc_add_task",
+            "keeper_task_claim",
+        ):
+            self.assertIn(forbidden_tool, proven)
+        self.assertIn("대체 Task를 만들거나 claim하지 마세요", proven)
+
     def test_persistence_browser_validator_requires_exact_monotonic_fleet(self):
         expected = {"keeper-a", "keeper-b"}
         with tempfile.TemporaryDirectory() as tmp_name:


### PR DESCRIPTION
## Summary
- make RW23 tell the producer to call `tool_write_file` with the exact producer-root-relative `artifacts/...` path
- forbid a `playground/` prefix or absolute path, which previously created a nested `<keeper>/playground/artifacts/...` file
- keep the corrected submission on the original rejected Task and forbid release/replacement/claim calls
- pin the directed prompt contract with a focused unit test

## Protected-main evidence
Run `32501162788` reached independent criterion approval, Task rejection, and Goal proof refutation. The corrected producer turn then:
- wrote to `<keeper>/playground/artifacts/...` because the prompt said “playground의 artifacts/...”
- released `task-009`, created `task-010`, then reclaimed `task-009`
- submitted `artifact:artifacts/...`, which the independent verifier correctly rejected as missing (`vrf-224484108066b18a40c9922b8a1de3e3`)

This PR changes the directed producer contract only. It does not claim a protected-main PASS and does not start a fourth blind live attempt.

## Validation
- `python3 test/test_keeper_multi_collaboration_acceptance.py` — 15/15 PASS
- catalog validation — 23 missions / 48 assertions / A-B-C PASS
- `python3 -m py_compile` on harness and test
- `git diff --check`
