### PR TITLE
style(dashboard): 디자인 격자 소유권 정리 + 패리티 계측 재현성 확보

### DIFF
--- a/dashboard/docs/DESIGN-EXTRA-UI.md
+++ b/dashboard/docs/DESIGN-EXTRA-UI.md
@@ -1,0 +1,83 @@
+# UI the dashboard renders and the design does not
+
+Every other check in `DESIGN-PARITY.md` asks whether the dashboard has what the
+design has. This one asks the reverse: **what is on screen that the mock never
+draws.** A skin sync that only fills gaps grows the surface forever; the design's
+own cleanup plan (`prototypes/keeper-v2/notes/cleanup-plan.md`) exists because
+the answer to "what should not be here" is a separate question with separate
+evidence.
+
+```bash
+node e2e/design-parity-extra-ui.mjs overview:overview keepers:keepers monitor:monitoring …
+```
+
+The probe renders both pages, collects the class of every *visible* element,
+drops Tailwind utilities and state modifiers, and reports what only the live side
+has. It does not judge — a live backend legitimately has connection state, an
+emergency stop and empty states that a mock cannot model. It produces the list.
+
+Twelve surfaces, 2026-08-22: **257 distinct components render only on the live
+side.** Most are per-surface detail. The ones that recur are below.
+
+## Not candidates — capability the mock cannot hold
+
+| Component | Why it exists |
+|---|---|
+| `.emergency-stop-control` (8 surfaces) | A real operator control. The mock has no fleet to stop. |
+| `.status-text`, `.time-ago` | Live data formatting; the mock's strings are frozen. |
+| `.v2-mobile-operator-target` | Touch-target sizing, guarded by `mobile-bottom-reserve.test.ts`. |
+| `.skip-link`, `.sr-only` | Keyboard and screen-reader affordances a static mock never needed. |
+| `.ov-empty`, `.ov-mini-empty`, `.ov-fus-idle` | Empty states. The mock's data is never empty. |
+| `.fl-runtime*`, `.fl-create` | The monitoring row's runtime cell and the create control — the live roster's own columns. |
+
+## Candidates worth a decision
+
+### Two avatar systems
+
+`.pixel-avatar` and its five sub-classes render on overview, keepers and
+monitoring. The design draws a `.sigil` — the two-letter monogram — in the same
+places, and **the rest of the dashboard already agrees with it**: `.sigil` is
+rendered by `chat/primitives.ts`, `board/board-surface.ts`, `keeper-badge.ts`,
+`ide/ide-editor-ownership.ts` and `v2/primitives-v2.ts`. `.pixel-avatar` has
+exactly one consumer left, `overview/agent-avatar.ts`.
+
+So this is not "the dashboard chose pixel avatars" — it is one component that did
+not move when the others did. It is the same shape as the `.chip` collision
+resolved in #29334: a single leftover holding a second implementation of
+something the design already owns.
+
+Not changed here: an avatar is a character surface, and swapping it is visible to
+every operator. It needs a decision, not a refactor.
+
+### Shell containers with no design counterpart
+
+`.dashboard-main-scroll` (9 surfaces, `app.ts`), `.v2-surface-host` (4,
+`app.ts`), `.ss-surface` (3, `lab.ts` + `overview.ts`). The design's shell is
+`.v2-app > .v2-top + .v2-body > .v2-nav + .surf`; these sit between. They may be
+load-bearing for the live router, or they may be what is left of the pre-reskin
+shell — `main.ts` still carries a "CSS SSOT removal scope" note about exactly
+this kind of leftover. Worth tracing before the next sync, since a container that
+does nothing still costs a nesting level in every measurement.
+
+### `.v2-top-ops`
+
+The operational cluster in the top bar. The design's top bar carries four chips;
+the live one adds connection state, an emergency stop, a verification badge, a
+version badge and the tweaks control. `keeper-v2/ops-cluster.css` already exists
+to harmonise it to the statchip shape, and `V2-RESKIN-PROGRESS.md` records that
+deleting these would be capability loss. Listed for completeness, not as a cut.
+
+## What this check cleared
+
+The design's 2026-08-18 cut asks for wiring vocabulary — field names, enums,
+`producer_id`, `trace_id`, `WFQ`, `capacity_backpressure`, `p95`,
+`not_observed` — to sit behind a 기술 상세 toggle rather than on the operator's
+screen. `design-parity-wiring.mjs` walks the rendered text of thirteen live
+surfaces looking for them.
+
+**Zero occurrences in chrome.** Every hit was keeper-authored content: `task_id`
+inside a board post's body, `post_id` in a comment, `goal_id` in a chat message,
+a task title mentioning `keeper_id`. That is data, not UI, and the cut does not
+reach it. A source grep suggests otherwise — `trace_id` appears in 14 files — so
+this has to be measured on rendered text or it reads as a violation that is not
+there.

--- a/dashboard/docs/DESIGN-PARITY.md
+++ b/dashboard/docs/DESIGN-PARITY.md
@@ -90,18 +90,18 @@ Two independent full-fleet runs, identical to four decimals.
 |---|---|---|---|---|
 | logs | 0.996 | | approvals | 0.966 |
 | monitor | 0.995 | | registry | 0.955 |
-| ide | 0.995 | | schedule | 0.944 |
+| ide | 0.995 | | schedule | 0.945 |
 | lab | 0.987 | | keepers | 0.909 |
-| connectors | 0.986 | | work | 0.891 |
+| connectors | 0.986 | | work | 0.897 |
 | command | 0.979 | | board | 0.853 |
 | fusion | 0.978 | | overview | 0.842 |
-| | | | **mean** | **0.948** |
+| | | | **mean** | **0.949** |
 
 Ten of the fourteen sit at 0.95 or above. The four that do not — overview,
 board, work, keepers — are each held there by one named cause, ledgered
 underneath, and none of the four is skin drift. **Across the ten surfaces where
-the two sides agree on structure the mean is 0.978**; that is the figure to read
-as "does the skin match". The 0.948 fleet mean includes the four and is the
+the two sides agree on structure the mean is 0.979**; that is the figure to read
+as "does the skin match". The 0.949 fleet mean includes the four and is the
 figure to read as "how close is the whole dashboard to the mock".
 
 Style conformance — `getComputedStyle` compared property by property across every
@@ -129,7 +129,9 @@ this design drop, so it was put to the operator on 2026-08-22 with the
 measurement — the decision is to keep full width.
 
 Cost: overview measures **0.842**; restoring `max-width: 1280px; margin: 0 auto`
-takes it to **0.996**, and the fleet mean from 0.948 to 0.959 — over the bar. No other
+takes it to **0.996**, and the fleet mean from 0.949 to 0.960 — over the bar. It is
+the only remaining lever: a sixteen-agent sweep of the eight surfaces still short
+of parity found no other actionable drift. No other
 surface moves — `.ov-scroll` is the only centred container, and `work`,
 `approvals` and `board` render full-width in the design too.
 

--- a/dashboard/docs/DESIGN-PARITY.md
+++ b/dashboard/docs/DESIGN-PARITY.md
@@ -57,7 +57,33 @@ so it is not used for the metric.
 The harness writes `prototypes/keeper-v2/_parity/` and `_parity-vendored.html`;
 both are gitignored and regenerated.
 
+## Reproducibility
+
+The prototype is a live mock, not a static page, and three things in it moved a
+measurement between runs of the identical page:
+
+- `.thread` is bottom-anchored and its scroll-to-bottom races the layout. It
+  settles either at the bottom (`scrollTop` 1907 of 1907) or at an earlier
+  anchor (185), and nothing afterwards moves it. Those two states differ by the
+  height of the visible column, which is a 4pp swing on keepers — and a 15pp
+  swing when the two sides land on opposite states. The capture pins the thread
+  where the app means it to sit.
+- `alarm.jsx` fires an ambient notification five seconds after load and every
+  sixteen after that. It is switched off through the prototype's own
+  `window.MASC_NOTIFY` channel before any page script runs.
+- `shell.jsx` re-rolls a random tok/s figure every 1.1s, so the page never
+  reaches a state it can be compared in. Repeating timers of a second or more
+  are cut; the one-shot ones stay, because the FSM phase advance
+  (`act.ms || 1500`) is part of the state the design settles into.
+
+On top of that a frame is only accepted once two consecutive captures are
+byte-identical. With all four in place, four runs of the same page produce the
+same bytes and two independent full-fleet runs produce the same mean to four
+decimals. Without them, treat any difference under ~4pp as noise.
+
 ## Where it stands (2026-08-22, `Keeper Agent v5.html`, 1600×1000)
+
+Two independent full-fleet runs, identical to four decimals.
 
 | Surface | SSIM | | Surface | SSIM |
 |---|---|---|---|---|
@@ -78,7 +104,7 @@ as "does the skin match". The 0.948 fleet mean includes the four and is the
 figure to read as "how close is the whole dashboard to the mock".
 
 Style conformance — `getComputedStyle` compared property by property across every
-classed element on ten surfaces — is **96.89%** (41,182 of 42,504 declarations),
+classed element on ten surfaces — is **96.93%** (41,201 of 42,504 declarations),
 from 85.85% before this pass. The largest remaining group is `font-family` (263),
 which is the UA fallback the dashboard deliberately does not reproduce (see
 below); without it the figure is 97.6%.

--- a/dashboard/docs/DESIGN-PARITY.md
+++ b/dashboard/docs/DESIGN-PARITY.md
@@ -113,6 +113,37 @@ below); without it the figure is 97.6%.
 `settings` is not measurable: the prototype's `SURFACES` registry has no entry for
 it, so `?surface=settings` is rejected and the page renders keepers.
 
+## Measured at a second viewport
+
+Everything above is 1600×1000. `keeper-v2/fleet.css` calls 1440px "the canonical
+operator viewport", so the fleet was measured there too:
+
+| | 1600×1000 | 1440×900 |
+|---|---|---|
+| mean | **0.948** | **0.942** |
+| monitor | 0.995 | 0.928 |
+| overview | 0.842 | 0.868 |
+| schedule | 0.945 | 0.931 |
+| keepers | 0.909 | 0.896 |
+
+The narrower viewport scores lower, and monitor carries most of the drop. Below
+1500px the kit's `--fl-cols` switches to a responsive tier that is tuned the way
+the base value used to be — five tracks with a 160px action cell, and
+`.fl-rhead span:nth-child(5)` hidden — all shaped by the live row's sixth cell,
+which the mock's row does not have. It is the same defect the base track set had,
+still sitting in the tiers.
+
+It is not fixed here. The tier never fires at the measured viewport, so it moves
+no number the bar reads, and splitting it touches the live surface's responsive
+behaviour at three breakpoints — worth its own change with its own verification,
+not a tail-end edit. The split follows the pattern already applied to the base
+value: the design's tiers stay in `keeper-v2/fleet.css`
+(`max-width: 1320px` → four tracks, `max-width: 720px` → three), and the live
+tiers move to `v2-monitoring.css` under `.v2-monitoring-surface`, keeping the
+1500px breakpoint and the column-shedding rule.
+
+`design-parity-shot.mjs` takes `PARITY_W` / `PARITY_H` for this.
+
 ## Divergence ledger
 
 Every surface below 0.94 is held there by something that is not skin drift. Each

--- a/dashboard/docs/DESIGN-PARITY.md
+++ b/dashboard/docs/DESIGN-PARITY.md
@@ -62,21 +62,20 @@ both are gitignored and regenerated.
 | Surface | SSIM | | Surface | SSIM |
 |---|---|---|---|---|
 | logs | 0.996 | | registry | 0.955 |
-| connectors | 0.986 | | schedule | 0.944 |
-| lab | 0.986 | | ide | 0.935 |
-| fusion | 0.978 | | monitor | 0.928 |
-| command | 0.969 | | keepers | 0.909 |
-| approvals | 0.966 | | work | 0.891 |
-| | | | board | 0.853 |
-| | | | overview | 0.842 |
-| | | | **mean** | **0.939** |
+| monitor | 0.995 | | schedule | 0.944 |
+| ide | 0.995 | | keepers | 0.909 |
+| connectors | 0.986 | | work | 0.891 |
+| lab | 0.986 | | board | 0.853 |
+| fusion | 0.978 | | overview | 0.842 |
+| command | 0.969 | | | |
+| approvals | 0.966 | | **mean** | **0.948** |
 
-Nine of the fourteen sit at 0.93 or above and seven at 0.95 or above. The four
-that do not — overview, board, work, monitor — are each held there by one named
-cause, ledgered underneath, and none of the four is skin drift. **Across the ten
-surfaces where the two sides agree on structure the mean is 0.962**; that is the
-figure to read as "does the skin match". The 0.939 fleet mean includes the four
-and is the figure to read as "how close is the whole dashboard to the mock".
+Ten of the fourteen sit at 0.95 or above. The four that do not — overview,
+board, work, keepers — are each held there by one named cause, ledgered
+underneath, and none of the four is skin drift. **Across the ten surfaces where
+the two sides agree on structure the mean is 0.977**; that is the figure to read
+as "does the skin match". The 0.948 fleet mean includes the four and is the
+figure to read as "how close is the whole dashboard to the mock".
 
 Style conformance — `getComputedStyle` compared property by property across every
 classed element on ten surfaces — is **96.89%** (41,182 of 42,504 declarations),
@@ -103,7 +102,7 @@ this design drop, so it was put to the operator on 2026-08-22 with the
 measurement — the decision is to keep full width.
 
 Cost: overview measures **0.842**; restoring `max-width: 1280px; margin: 0 auto`
-takes it to **0.996**, and the fleet mean from 0.939 to 0.950. No other
+takes it to **0.996**, and the fleet mean from 0.948 to 0.959 — over the bar. No other
 surface moves — `.ov-scroll` is the only centred container, and `work`,
 `approvals` and `board` render full-width in the design too.
 
@@ -124,31 +123,55 @@ a `SuggestionChip` rendering the design's `.chip`; nothing imported it, and it
 is gone. The live suggestion chip is `components/common/suggestion-chip.ts`,
 whose metrics are now the design's.
 
-keepers went **0.848 → 0.909** on that. What is left is the roster and thread
-chrome, where the residual is the button font fallback described below.
+keepers went **0.848 → 0.909** on that. What is left is the button font metric
+described under "the prototype ships no CSS reset": `.cf-view`, `.tasktag` and
+the top-bar attention chips each stand 2–3px taller than the mock because
+`line-height: normal` resolves against Noto Sans KR's metrics rather than
+Arial's. Substituting a numeric leading was measured and rejected — it inherits
+into the grid cells and cost the fleet 8.7pp.
 
 ### Board — `.bd-stateblock` is a design component the dashboard has not built
 
 The design's board renders a state-transition post (`Running → Overflowed`,
-context 100%, `restart` pending) as a `.bd-stateblock`. The class appears nowhere
-in `dashboard/src`. Vendoring the four rules would move the number without
-changing anything the app renders, which is the fake this repo's *mark-don't-fake*
-rule exists to prevent. Not vendored.
+context 100%, `restart` pending) as a `.bd-stateblock`, reading three fields off
+`post.stateBlock`. `BoardPost` in `types/core.ts` has no counterpart — no
+from/to state, no context figure, no pending action — so the backend does not
+emit the data the block displays. Vendoring the four CSS rules would move the
+number without changing anything the app renders, and building the block without
+the fields would mean inventing them; both are the fake this repo's
+*mark-don't-fake* rule exists to prevent. Not vendored.
 
 Cost: the second mock post is 56px shorter, and every post below it shifts.
 board measures **0.853**.
 
-### Monitor — the roster grid has six tracks, the design has five
+### Monitor — resolved: the roster grid had six tracks, the design has five
 
-`--fl-cols` in `keeper-v2/fleet.css` carries the local contract: *"Last track =
-action cell (멈춤/깨움/종료): the 3 text buttons render ~156px, so the track must be
-wide enough or the button group overflows left into the context value."* The
-live row has an action cell the mock row does not, so the vendored grid has six
-tracks against the design's five. The v5 width refinement (state 140→152,
-context minmax 108→96) is merged into it.
+The live row carries a `.fl-runtime` cell between context and recent-tool that
+the mock's row has no counterpart for, and its action group is three text buttons
+(멈춤/깨움/종료) rendering ~156px, so the last track needs 160px. That six-track
+value used to live in the shared `--fl-cols`, which laid the design's five cells
+into six tracks and pushed every column wide.
 
-Cost: on the parity page the prototype's five cells are laid into a six-track
-grid, so every column lands wide of the design. monitor measures **0.928**.
+`keeper-v2/fleet.css` carries the design's five tracks now, and
+`v2-monitoring.css` restates six for `.v2-monitoring-surface` alone, bounded to
+the widths above the shed-a-column tier so that tier keeps its own set. The live
+roster still renders six cells in six tracks with a 160px action cell and no
+overflow.
+
+monitor went **0.928 → 0.995**.
+
+### IDE — resolved: the rail tabs had two names
+
+The live rail tabs rendered `.ide-v2-rail-tab*`; the design draws the same
+component as `.ide-rail-tab*`, and the design's rules were never vendored, so the
+tabs fell back to the generic button chrome. The component uses the design's
+names now, `keeper-v2/surfaces.css` owns its type, spacing and selected state,
+and `ide-v2.css` keeps only what the mock never had to solve: three tabs sharing
+a 320px rail without wrapping, and a label that truncates instead of pushing its
+neighbours out. `flex: 0 1 auto` rather than `1 1 0`, so a tab sizes to its label
+the way the design draws it and still shrinks under pressure.
+
+ide went **0.935 → 0.995**.
 
 ### Work — the dashboard moved past the design here
 

--- a/dashboard/docs/DESIGN-PARITY.md
+++ b/dashboard/docs/DESIGN-PARITY.md
@@ -170,8 +170,22 @@ clicks that open it — and the shot harness follows it. Twenty-two views,
 The sub-views score *higher* than the top-level surfaces (0.957 against 0.949).
 Lane Queue at 0.959 and the prompt book at 0.971 say the `lanes.css` and
 `prompt-book.css` vendoring landed — which had never been verified, only
-assumed. Three are newly short and unexamined: `approvals-history` (0.796),
-`schedule-list` (0.868), `monitor-internal` (0.870).
+assumed.
+
+Three are short, and all three for the same reason: the dashboard built the
+component differently, so there is no class for the vendored skin to attach to.
+None is skin drift and none is fixable in CSS.
+
+| View | What the design draws | What the dashboard renders |
+|---|---|---|
+| `approvals-history` 0.796 | `.ap-hist-row` — a dense table, four-column grid, tone stripe down the left edge, inline stat line, pill filters | `.ap-history-*` — a different component under different names, with the stats as a four-card grid. Carries fields the design has no slot for (judging model, ALWAYS rules, source). |
+| `schedule-list` 0.868 | `.sch-act` approve/deny/ghost buttons | No consumer at all. This is one of the "36 v3-only selectors with zero DOM consumers" the earlier sync recorded and skipped; it is still true. |
+| `monitor-internal` 0.870 | `.ia-badge`, `.ia-count`, `.ai-table`, `.ai-strip` — a named component vocabulary | Tailwind utilities assembled inline (`flex`, `grid`, `px-2`, `max-h-80`). Swapping the skin cannot reach this surface, because there is nothing named to style. |
+
+The last one is the most instructive. A vendored stylesheet only lands where the
+DOM speaks the same vocabulary; a surface assembled from utilities is opaque to
+it no matter how faithful the CSS is. That is a component-level decision, not a
+sync one.
 
 ## Unnecessary UI
 

--- a/dashboard/docs/DESIGN-PARITY.md
+++ b/dashboard/docs/DESIGN-PARITY.md
@@ -244,6 +244,17 @@ Two halves, decided separately:
   not: rows and segments the design leaves square because they sit inside a
   container that already owns the corner. Those are named in `craft-v2.css`
   rather than dropping the default the other 1,309 depend on.
+- **The body face is the same one — on this machine.** Width triangulation on a
+  Korean string (40px, stack vs `Noto Sans KR` alone vs a last-resort control)
+  returns 622.41px on both pages, against 585.17px for the fallback. So the
+  chrome outside buttons matches. But the prototype loads Noto Sans KR as a
+  webfont (`styles/fonts/`) and the dashboard does not — `fonts.css` keeps the
+  9.9MB TTF off the hot path deliberately — so the dashboard is resolving it
+  from the system. On a machine without it installed the dashboard falls back to
+  585.17px metrics while the prototype still renders at 622.41px, and every
+  measurement in this document shifts. Re-measure on a clean machine before
+  treating these numbers as machine-independent.
+
 - **The font fallback is not.** Matching the design's `Arial` on buttons would
   put Korean UI text through a Latin fallback, and the design system's own
   specification names Noto Sans KR for chrome. The dashboard's normalisation

--- a/dashboard/docs/DESIGN-PARITY.md
+++ b/dashboard/docs/DESIGN-PARITY.md
@@ -125,15 +125,21 @@ divergence from prototype): full-width, left-aligned … per design direction th
 dashboard fills the content area to match the other surfaces
 (board/monitoring/command/lab/ide). Do not re-add max-width / margin:auto on a
 prototype re-sync."* The design still centres it in v5, and the note predates
-this design drop, so it was put to the operator on 2026-08-22 with the
-measurement — the decision is to keep full width.
+this design drop, so it was put to the operator twice.
 
-Cost: overview measures **0.842**; restoring `max-width: 1280px; margin: 0 auto`
-takes it to **0.996**, and the fleet mean from 0.949 to 0.960 — over the bar. It is
-the only remaining lever: a sixteen-agent sweep of the eight surfaces still short
-of parity found no other actionable drift. No other
-surface moves — `.ov-scroll` is the only centred container, and `work`,
-`approvals` and `board` render full-width in the design too.
+The first time, restoring the centring would have left the fleet mean short of
+the 95% bar anyway, and the recorded decision stood. After the monitor, IDE and
+Work repairs it became the only remaining lever — this one line is the whole
+difference between 0.949 and 0.960 — so it was put again with that number
+attached. **Re-confirmed on 2026-08-22: the surface stays full width, and the
+parity bar goes unmet rather than the product decision being reversed.**
+
+Cost, measured: overview reads **0.842**; `max-width: 1280px; margin: 0 auto` on
+`.ov-scroll` takes it to **0.996** and the fleet mean from 0.949 to 0.960. No
+other surface moves — `.ov-scroll` is the only container the design centres, and
+`work`, `approvals` and `board` render full-width in the design too. A
+sixteen-agent sweep of the eight surfaces still short of parity found no other
+actionable drift, so this is the only lever that exists.
 
 ### Keepers — resolved: `.chip` named two different components
 

--- a/dashboard/docs/DESIGN-PARITY.md
+++ b/dashboard/docs/DESIGN-PARITY.md
@@ -46,6 +46,7 @@ Diagnostics, in the order they are usually needed:
 | `design-parity-box.mjs <surface> <sel…>` | where an element actually landed (x/y/size) — what a cumulative offset needs |
 | `design-parity-rules.mjs <url> <sel> <prop>` | which stylesheet rule wins that property (CDP `getMatchedStylesForNode`) |
 | `design-parity-cssdiff.mjs <name…>` | vendored vs prototype stylesheet, with the repo's font-size tokenization normalized away |
+| `design-parity-viewport.mjs <surface> [limit]` | elements that differ AND fall inside the captured 1600×1000 — a block at y=1934 can be repaired without the number moving at all |
 | `design-parity-gaps.mjs [name…]` | selectors the design defines that the vendored kit does not |
 | `design-parity-leaks.mjs` | selectors owned by both a legacy sheet and the kit, and the geometry the kit does not restate |
 
@@ -87,19 +88,19 @@ Two independent full-fleet runs, identical to four decimals.
 
 | Surface | SSIM | | Surface | SSIM |
 |---|---|---|---|---|
-| logs | 0.996 | | registry | 0.955 |
-| monitor | 0.995 | | schedule | 0.944 |
-| ide | 0.995 | | keepers | 0.909 |
+| logs | 0.996 | | approvals | 0.966 |
+| monitor | 0.995 | | registry | 0.955 |
+| ide | 0.995 | | schedule | 0.944 |
+| lab | 0.987 | | keepers | 0.909 |
 | connectors | 0.986 | | work | 0.891 |
-| lab | 0.986 | | board | 0.853 |
+| command | 0.979 | | board | 0.853 |
 | fusion | 0.978 | | overview | 0.842 |
-| command | 0.969 | | | |
-| approvals | 0.966 | | **mean** | **0.948** |
+| | | | **mean** | **0.948** |
 
 Ten of the fourteen sit at 0.95 or above. The four that do not — overview,
 board, work, keepers — are each held there by one named cause, ledgered
 underneath, and none of the four is skin drift. **Across the ten surfaces where
-the two sides agree on structure the mean is 0.977**; that is the figure to read
+the two sides agree on structure the mean is 0.978**; that is the figure to read
 as "does the skin match". The 0.948 fleet mean includes the four and is the
 figure to read as "how close is the whole dashboard to the mock".
 

--- a/dashboard/docs/DESIGN-PARITY.md
+++ b/dashboard/docs/DESIGN-PARITY.md
@@ -144,6 +144,40 @@ tiers move to `v2-monitoring.css` under `.v2-monitoring-surface`, keeping the
 
 `design-parity-shot.mjs` takes `PARITY_W` / `PARITY_H` for this.
 
+## Sub-views
+
+The prototype deep-links `?surface=` and `?keeper=` and nothing else, so every
+section tab and drawer — Lane Queue, the prompt book, all twelve Settings panes —
+is reachable only by clicking. Measuring the deep-linkable surfaces alone leaves
+most of the design unverified: Monitor has seven sections and Settings twelve,
+and `?surface=settings` is rejected outright because Settings is not in the
+prototype's `SURFACES` registry.
+
+`design-parity-views.mjs` is the recipe list — a view is a surface plus the
+clicks that open it — and the shot harness follows it. Twenty-two views,
+2026-08-22:
+
+| View | SSIM | | View | SSIM |
+|---|---|---|---|---|
+| ide-cursor | 0.996 | | monitor-tools | 0.969 |
+| monitor-observatory | 0.995 | | settings ×12 | 0.967–0.972 |
+| monitor-journey | 0.993 | | **monitor-lanes** | **0.959** |
+| ide-annotations | 0.992 | | monitor-internal | 0.870 |
+| monitor-runtime | 0.984 | | schedule-list | 0.868 |
+| | | | approvals-history | 0.796 |
+| | | | **mean** | **0.957** |
+
+The sub-views score *higher* than the top-level surfaces (0.957 against 0.949).
+Lane Queue at 0.959 and the prompt book at 0.971 say the `lanes.css` and
+`prompt-book.css` vendoring landed — which had never been verified, only
+assumed. Three are newly short and unexamined: `approvals-history` (0.796),
+`schedule-list` (0.868), `monitor-internal` (0.870).
+
+## Unnecessary UI
+
+`docs/DESIGN-EXTRA-UI.md` runs the reverse check — what the dashboard renders
+that the design does not — and carries its own findings.
+
 ## Divergence ledger
 
 Every surface below 0.94 is held there by something that is not skin drift. Each

--- a/dashboard/e2e/design-parity-box.mjs
+++ b/dashboard/e2e/design-parity-box.mjs
@@ -2,6 +2,9 @@
 // parity page. `design-parity-style.mjs` says WHICH property differs; this says
 // where the element actually landed, which is what a cumulative offset needs.
 import { chromium } from 'playwright'
+
+// Port is configurable so a second worktree can serve its own tree alongside.
+const BASE = `http://127.0.0.1:${process.env.PARITY_PORT || 8978}/prototypes/keeper-v2`
 const [surface, ...sels] = process.argv.slice(2)
 const pages = { design: 'Keeper%20Agent%20v5.html', live: '_parity-vendored.html' }
 const b = await chromium.launch()
@@ -9,7 +12,7 @@ const c = await b.newContext({ viewport: { width: 1600, height: 1000 } })
 const res = {}
 for (const [k, f] of Object.entries(pages)) {
   const p = await c.newPage()
-  await p.goto(`http://127.0.0.1:8978/prototypes/keeper-v2/${f}?surface=${surface}`, { waitUntil: 'load', timeout: 45000 })
+  await p.goto(`${BASE}/${f}?surface=${surface}`, { waitUntil: 'load', timeout: 45000 })
   await p.waitForSelector('.v2-app', { timeout: 30000 })
   await p.waitForTimeout(1800)
   res[k] = await p.evaluate((sels) => sels.map((sel) => {

--- a/dashboard/e2e/design-parity-extra-ui.mjs
+++ b/dashboard/e2e/design-parity-extra-ui.mjs
@@ -1,0 +1,51 @@
+// Names the UI the dashboard renders that the design does not.
+//
+// Every other probe here asks "does the dashboard have what the design has".
+// This asks the reverse: which components are on screen that the mock never
+// draws. Some are real capability the mock could not model — a live backend has
+// connection state, an emergency stop, a version badge. Some are leftovers. The
+// probe does not judge; it produces the list to review.
+import { chromium } from 'playwright'
+
+const PROTO = 'http://127.0.0.1:8979/prototypes/keeper-v2/Keeper%20Agent%20v5.html?surface='
+const LIVE = process.env.LIVE_BASE || 'http://localhost:5181/dashboard/#'
+
+const CLASSES = `(() => {
+  const out = new Set()
+  for (const el of document.querySelectorAll('.v2-app *')) {
+    if (el.offsetParent === null && getComputedStyle(el).position !== 'fixed') continue
+    const cn = typeof el.className === 'string' ? el.className : ''
+    for (const c of cn.trim().split(/\\s+/)) {
+      // Skip Tailwind utilities and state modifiers: they are not components.
+      if (!c || c.length < 4) continue
+      // Tailwind utilities, variants and arbitrary values are not components.
+      if (c.includes(':') || c.includes('[') || c.includes('/')) continue
+      if (/^(is-|has-|on$|active|open|flex|grid|items-|justify-|text-|bg-|px-|py-|mx-|my-|mt-|mb-|ml-|mr-|pt-|pb-|pl-|pr-|gap-|w-|h-|min-|max-|rounded|border|shrink|grow|absolute|relative|inline|hidden|overflow|whitespace|font-|leading-|tracking-|truncate|select-|cursor-|transition|group|size-|self-|space-|animate|fade|slide|zoom|duration|delay|ease|fill-mode|sr-only|skip-link|order-|z-|top-|left-|right-|bottom-|opacity-|shadow|ring|outline|pointer-|touch-|scroll-|snap-|list-|align-|place-|col-|row-|basis-|object-|aspect-|backdrop|filter|blur|contrast|invert|saturate|sepia|origin-|rotate-|scale-|translate|skew-|first|last|only|odd|even|visited|checked|disabled|indeterminate|placeholder|before|after|marker|file|selection|caret|accent|appearance|resize|will-change|content-)/.test(c)) continue
+      out.add(c)
+    }
+  }
+  return [...out]
+})()`
+
+const b = await chromium.launch()
+const c = await b.newContext({ viewport: { width: 1600, height: 1000 } })
+
+async function classesAt(url, waitSel = '.v2-app') {
+  const p = await c.newPage()
+  try {
+    await p.goto(url, { waitUntil: 'load', timeout: 60000 })
+    await p.waitForSelector(waitSel, { timeout: 30000 })
+    await p.waitForTimeout(2500)
+    return new Set(await p.evaluate(CLASSES))
+  } catch { return new Set() } finally { await p.close() }
+}
+
+for (const [protoSurface, liveSurface] of process.argv.slice(2).map(a => a.split(':'))) {
+  const design = await classesAt(PROTO + protoSurface)
+  const live = await classesAt(LIVE + (liveSurface || protoSurface))
+  const extra = [...live].filter(x => !design.has(x)).sort()
+  console.log(`\n${protoSurface} → live-only components (${extra.length} of ${live.size} rendered)`)
+  extra.slice(0, 30).forEach(x => console.log(`    .${x}`))
+  if (extra.length > 30) console.log(`    … and ${extra.length - 30} more`)
+}
+await b.close()

--- a/dashboard/e2e/design-parity-shot.mjs
+++ b/dashboard/e2e/design-parity-shot.mjs
@@ -14,6 +14,7 @@
 import { chromium } from 'playwright'
 import { mkdirSync, writeFileSync } from 'node:fs'
 import { createHash } from 'node:crypto'
+import { VIEW_BY_ID } from './design-parity-views.mjs'
 
 const [label, tmpl, outDir, surfaceCsv] = process.argv.slice(2)
 if (!label || !tmpl || !outDir || !surfaceCsv) {
@@ -47,7 +48,10 @@ page.on('pageerror', e => errors.push(String(e).slice(0, 200)))
 const digest = buf => createHash('sha1').update(buf).digest('hex')
 
 for (const s of surfaces) {
-  const url = tmpl.replaceAll('{s}', s)
+  // A name may be a bare surface or a sub-view: a surface plus the clicks that
+  // open it, because the prototype deep-links nothing behind a tab or drawer.
+  const view = VIEW_BY_ID.get(s)
+  const url = tmpl.replaceAll('{s}', view ? view.surface : s)
   try {
     await page.goto(url, { waitUntil: 'load', timeout: 45000 })
     await page.waitForSelector('.v2-app, #app > *, #root > *', { timeout: 30000 })
@@ -57,6 +61,11 @@ for (const s of surfaces) {
     // 4pp apart from every run after it.
     await page.evaluate(() => document.fonts.ready)
     await page.waitForTimeout(2500)
+    for (const selector of view?.clicks ?? []) {
+      await page.waitForSelector(selector, { timeout: 15000 })
+      await page.click(selector)
+      await page.waitForTimeout(900)
+    }
     await page.addStyleTag({ content: FREEZE })
     // The chat thread is bottom-anchored, and its scroll-to-bottom races the
     // layout: it settles at the bottom (scrollTop 1907 of 1907) or at an earlier

--- a/dashboard/e2e/design-parity-shot.mjs
+++ b/dashboard/e2e/design-parity-shot.mjs
@@ -1,36 +1,86 @@
 // Design-parity screenshot harness.
-// Usage: node shot.mjs <label> <baseUrlTemplate> <outDir> <surface[,surface...]>
+// Usage: node design-parity-shot.mjs <label> <baseUrlTemplate> <outDir> <surface[,surface...]>
 //   baseUrlTemplate contains {s}, replaced by the surface id.
+//
+// The prototype is a live mock, not a static page: `alarm.jsx` fires an ambient
+// notification five seconds after load and every sixteen after that, and
+// `shell.jsx` re-rolls a random tok/s figure every 1.1s. Either can land inside
+// the capture window — and does so more often on the parity page, whose single
+// compiled stylesheet delays first paint — which moved a keepers measurement by
+// 15pp between runs of the same page. So: the notification channel is switched
+// off through the prototype's own `window.MASC_NOTIFY` knob before any script
+// runs, and a frame is only accepted once two consecutive captures are
+// byte-identical. Both sides then reproduce exactly.
 import { chromium } from 'playwright'
-import { mkdirSync } from 'node:fs'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { createHash } from 'node:crypto'
 
 const [label, tmpl, outDir, surfaceCsv] = process.argv.slice(2)
 if (!label || !tmpl || !outDir || !surfaceCsv) {
-  console.error('usage: node shot.mjs <label> <urlTemplate{s}> <outDir> <surfaces,csv>')
+  console.error('usage: node design-parity-shot.mjs <label> <urlTemplate{s}> <outDir> <surfaces,csv>')
   process.exit(2)
 }
 const surfaces = surfaceCsv.split(',').filter(Boolean)
 mkdirSync(outDir, { recursive: true })
 
 const VIEWPORT = { width: 1600, height: 1000 }
+const FREEZE = '*,*::before,*::after{animation:none !important;transition:none !important;caret-color:transparent !important}'
+const MAX_SETTLE_ATTEMPTS = 12
+
 const browser = await chromium.launch()
 const ctx = await browser.newContext({ viewport: VIEWPORT, deviceScaleFactor: 1, colorScheme: 'dark' })
+await ctx.addInitScript(() => {
+  // The prototype reads this on every alarm tick; '없음' is its own "no channel".
+  window.MASC_NOTIFY = { channel: '없음', on: {} }
+  // Stop the repeating simulation. `shell.jsx` re-rolls a random tok/s figure
+  // every 1.1s, so the page never reaches a state it can be compared in. The
+  // one-shot timers stay: the FSM phase advance (`act.ms || 1500`) is part of
+  // the state the design settles into, and the capture waits past it.
+  const SIM_TIMER_MS = 1000
+  const interval = window.setInterval.bind(window)
+  window.setInterval = (fn, ms, ...rest) => (Number(ms) >= SIM_TIMER_MS ? 0 : interval(fn, ms, ...rest))
+})
 const page = await ctx.newPage()
 const errors = []
 page.on('pageerror', e => errors.push(String(e).slice(0, 200)))
+
+const digest = buf => createHash('sha1').update(buf).digest('hex')
 
 for (const s of surfaces) {
   const url = tmpl.replaceAll('{s}', s)
   try {
     await page.goto(url, { waitUntil: 'load', timeout: 45000 })
-    // The shell root differs between the two apps; wait for whichever appears.
     await page.waitForSelector('.v2-app, #app > *, #root > *', { timeout: 30000 })
+    // Cinzel and Noto Sans KR change every metric on the page. On a cold cache
+    // they land after the capture window and the page settles on fallback
+    // metrics instead — which is what made the first run of a session score
+    // 4pp apart from every run after it.
+    await page.evaluate(() => document.fonts.ready)
     await page.waitForTimeout(2500)
-    // Freeze animations so repeat runs are byte-stable.
-    await page.addStyleTag({ content: '*,*::before,*::after{animation:none !important;transition:none !important;caret-color:transparent !important}' })
-    await page.waitForTimeout(400)
-    await page.screenshot({ path: `${outDir}/${label}-${s}.png` })
-    console.log(`ok   ${label}/${s}`)
+    await page.addStyleTag({ content: FREEZE })
+    // The chat thread is bottom-anchored, and its scroll-to-bottom races the
+    // layout: it settles at the bottom (scrollTop 1907 of 1907) or at an earlier
+    // anchor (185), and nothing after that moves it. Those two states differ by
+    // the height of the visible column, which put 4pp between two runs of the
+    // identical page. Pin it where the app means it to sit.
+    await page.evaluate(() => {
+      for (const el of document.querySelectorAll('.thread')) {
+        el.scrollTop = el.scrollHeight
+      }
+    })
+
+    let prev = null, shot = null, settled = 0
+    for (let i = 0; i < MAX_SETTLE_ATTEMPTS; i++) {
+      await page.waitForTimeout(500)
+      shot = await page.screenshot()
+      if (prev && digest(prev) === digest(shot)) { settled = i + 1; break }
+      prev = shot
+    }
+    if (!settled) {
+      console.log(`WARN ${label}/${s}: never produced two identical consecutive frames in ${MAX_SETTLE_ATTEMPTS} tries`)
+    }
+    writeFileSync(`${outDir}/${label}-${s}.png`, shot)
+    console.log(`ok   ${label}/${s}${settled ? '' : ' (unsettled)'}`)
   } catch (e) {
     console.log(`FAIL ${label}/${s}: ${String(e).split('\n')[0].slice(0, 160)}`)
   }

--- a/dashboard/e2e/design-parity-shot.mjs
+++ b/dashboard/e2e/design-parity-shot.mjs
@@ -23,7 +23,7 @@ if (!label || !tmpl || !outDir || !surfaceCsv) {
 const surfaces = surfaceCsv.split(',').filter(Boolean)
 mkdirSync(outDir, { recursive: true })
 
-const VIEWPORT = { width: 1600, height: 1000 }
+const VIEWPORT = { width: Number(process.env.PARITY_W || 1600), height: Number(process.env.PARITY_H || 1000) }
 const FREEZE = '*,*::before,*::after{animation:none !important;transition:none !important;caret-color:transparent !important}'
 const MAX_SETTLE_ATTEMPTS = 12
 

--- a/dashboard/e2e/design-parity-viewport.mjs
+++ b/dashboard/e2e/design-parity-viewport.mjs
@@ -1,0 +1,55 @@
+// Lists elements that render differently AND fall inside the captured viewport.
+// Only what is on screen moves the SSIM: the capture is 1600x1000, so a block
+// at y=1934 can be repaired without the number changing at all.
+import { chromium } from 'playwright'
+
+const [surface, limitRaw] = process.argv.slice(2)
+const LIMIT = Number(limitRaw || 25)
+const BASE = `http://127.0.0.1:${process.env.PARITY_PORT || 8978}/prototypes/keeper-v2`
+const VIEWPORT = { width: 1600, height: 1000 }
+
+const SNAP = `(() => {
+  const out = {}
+  const seen = Object.create(null)
+  for (const el of document.querySelectorAll('.v2-app *')) {
+    const r = el.getBoundingClientRect()
+    if (r.bottom < 0 || r.top > ${VIEWPORT.height} || r.width === 0 || r.height === 0) continue
+    const cls = (typeof el.className === 'string' ? el.className : '').trim().split(/\\s+/).slice(0, 3).join('.')
+    const key = (cls || el.tagName) + '#' + (seen[cls] = (seen[cls] || 0) + 1)
+    out[key] = [r.x, r.y, r.width, r.height].map(v => Math.round(v * 100) / 100)
+  }
+  return out
+})()`
+
+const b = await chromium.launch()
+const c = await b.newContext({ viewport: VIEWPORT, deviceScaleFactor: 1 })
+await c.addInitScript(() => {
+  window.MASC_NOTIFY = { channel: '없음', on: {} }
+  const interval = window.setInterval.bind(window)
+  window.setInterval = (fn, ms, ...rest) => (Number(ms) >= 1000 ? 0 : interval(fn, ms, ...rest))
+})
+const snaps = {}
+for (const [k, f] of [['design', 'Keeper%20Agent%20v5.html'], ['live', '_parity-vendored.html']]) {
+  const p = await c.newPage()
+  await p.goto(`${BASE}/${f}?surface=${surface}`, { waitUntil: 'load', timeout: 45000 })
+  await p.waitForSelector('.v2-app', { timeout: 30000 })
+  await p.evaluate(() => document.fonts.ready)
+  await p.waitForTimeout(2500)
+  await p.evaluate(() => { for (const el of document.querySelectorAll('.thread')) el.scrollTop = el.scrollHeight })
+  await p.waitForTimeout(300)
+  snaps[k] = await p.evaluate(SNAP)
+  await p.close()
+}
+await b.close()
+
+const rows = []
+for (const key of Object.keys(snaps.design)) {
+  const a = snaps.design[key], z = snaps.live[key]
+  if (!z) { rows.push([key, 'only on the design page', 0]); continue }
+  const d = a.map((v, i) => Math.round((z[i] - v) * 100) / 100)
+  const worst = Math.max(...d.map(Math.abs))
+  if (worst > 0.6) rows.push([key, `Δx=${d[0]} Δy=${d[1]} Δw=${d[2]} Δh=${d[3]}  (design y=${a[1]})`, worst])
+}
+rows.sort((p, q) => q[2] - p[2])
+console.log(`${surface}: ${rows.length} in-viewport elements differ`)
+for (const [k, why] of rows.slice(0, LIMIT)) console.log(`  ${k.padEnd(42)} ${why}`)

--- a/dashboard/e2e/design-parity-viewport.mjs
+++ b/dashboard/e2e/design-parity-viewport.mjs
@@ -2,6 +2,7 @@
 // Only what is on screen moves the SSIM: the capture is 1600x1000, so a block
 // at y=1934 can be repaired without the number changing at all.
 import { chromium } from 'playwright'
+import { VIEW_BY_ID } from './design-parity-views.mjs'
 
 const [surface, limitRaw] = process.argv.slice(2)
 const LIMIT = Number(limitRaw || 25)
@@ -31,10 +32,16 @@ await c.addInitScript(() => {
 const snaps = {}
 for (const [k, f] of [['design', 'Keeper%20Agent%20v5.html'], ['live', '_parity-vendored.html']]) {
   const p = await c.newPage()
-  await p.goto(`${BASE}/${f}?surface=${surface}`, { waitUntil: 'load', timeout: 45000 })
+  const view = VIEW_BY_ID.get(surface)
+  await p.goto(`${BASE}/${f}?surface=${view ? view.surface : surface}`, { waitUntil: 'load', timeout: 45000 })
   await p.waitForSelector('.v2-app', { timeout: 30000 })
   await p.evaluate(() => document.fonts.ready)
   await p.waitForTimeout(2500)
+  for (const selector of view?.clicks ?? []) {
+    await p.waitForSelector(selector, { timeout: 15000 })
+    await p.click(selector)
+    await p.waitForTimeout(900)
+  }
   await p.evaluate(() => { for (const el of document.querySelectorAll('.thread')) el.scrollTop = el.scrollHeight })
   await p.waitForTimeout(300)
   snaps[k] = await p.evaluate(SNAP)

--- a/dashboard/e2e/design-parity-views.mjs
+++ b/dashboard/e2e/design-parity-views.mjs
@@ -1,0 +1,58 @@
+// Sub-views the parity harness can reach.
+//
+// The prototype deep-links only `?surface=` and `?keeper=`, so everything behind
+// a section tab or a drawer — Lane Queue, the prompt book, every Settings pane —
+// is reachable by clicking and nothing else. Measuring only the deep-linkable
+// surfaces leaves most of the design unverified: Monitor alone has seven
+// sections and Settings twelve, and `?surface=settings` is rejected outright
+// because Settings is not in the prototype's SURFACES registry.
+//
+// A view is a surface plus the clicks that open it. Selectors are the
+// prototype's own, and the live parity page renders the same DOM, so one recipe
+// drives both sides.
+
+const monitorSection = (n, id) => ({
+  id: `monitor-${id}`,
+  surface: 'monitor',
+  clicks: [`.fl-sec:nth-of-type(${n})`],
+})
+
+// `.set-nav-item` buttons are split across SET_GROUPS, so `nth-of-type` counts
+// within a group, not across the rail. Playwright's `nth=` is flat, and 0-based.
+const settingsSection = (n, id) => ({
+  id: `settings-${id}`,
+  surface: 'keepers',
+  clicks: ['.nav-item[title="설정"]', `.set-nav-item >> nth=${n - 1}`],
+})
+
+export const VIEWS = [
+  // Monitor — tab 1 (Keeper 목록) is what `?surface=monitor` already lands on.
+  monitorSection(2, 'internal'),
+  monitorSection(3, 'lanes'),
+  monitorSection(4, 'journey'),
+  monitorSection(5, 'tools'),
+  monitorSection(6, 'runtime'),
+  monitorSection(7, 'observatory'),
+
+  // Settings — no deep link at all; the rail footer is the only way in.
+  settingsSection(1, 'account'),
+  settingsSection(2, 'runtime'),
+  settingsSection(3, 'runtimes'),
+  settingsSection(4, 'routing'),
+  settingsSection(5, 'mcp'),
+  settingsSection(6, 'prompts'),
+  settingsSection(7, 'fusion'),
+  settingsSection(8, 'repositories'),
+  settingsSection(9, 'paths'),
+  settingsSection(10, 'logs'),
+  settingsSection(11, 'notify'),
+  settingsSection(12, 'display'),
+
+  // Toggles inside a surface that swap the whole body.
+  { id: 'schedule-list', surface: 'schedule', clicks: ['.sch-viewbtn:nth-of-type(2)'] },
+  { id: 'approvals-history', surface: 'approvals', clicks: ['.ap-viewbtn:nth-of-type(2)'] },
+  { id: 'ide-annotations', surface: 'ide', clicks: ['.ide-rail-tab:nth-of-type(2)'] },
+  { id: 'ide-cursor', surface: 'ide', clicks: ['.ide-rail-tab:nth-of-type(3)'] },
+]
+
+export const VIEW_BY_ID = new Map(VIEWS.map((v) => [v.id, v]))

--- a/dashboard/e2e/design-parity-wiring.mjs
+++ b/dashboard/e2e/design-parity-wiring.mjs
@@ -1,0 +1,58 @@
+// Looks for wiring vocabulary in *rendered* text, not in source.
+//
+// The design's cleanup plan (prototypes/keeper-v2/notes/cleanup-plan.md, the
+// 2026-08-18 cut) puts field names, enums, producer and trace ids, WFQ,
+// capacity_backpressure, p95 and not_observed behind a "기술 상세" toggle or a
+// tooltip — off the operator's screen. A source grep cannot tell a rendered
+// string from a variable name, so this walks the live DOM instead.
+import { chromium } from 'playwright'
+
+const TOKENS = [
+  'WFQ', 'capacity_backpressure', 'not_observed', 'p95', 'producer_id',
+  'trace_id', 'post_id', 'request_id', 'keeper_id', 'goal_id', 'task_id',
+  'enum', 'schema_version', 'envelope',
+]
+const BASE = process.env.LIVE_BASE || 'http://localhost:5181/dashboard/#'
+
+const b = await chromium.launch()
+const c = await b.newContext({ viewport: { width: 1600, height: 1000 } })
+const hits = new Map()
+for (const s of process.argv.slice(2)) {
+  const p = await c.newPage()
+  try {
+    await p.goto(`${BASE}${s}`, { waitUntil: 'load', timeout: 60000 })
+    await p.waitForSelector('.v2-app', { timeout: 30000 })
+    await p.waitForTimeout(2500)
+    const found = await p.evaluate((tokens) => {
+      const out = []
+      const walk = document.createTreeWalker(document.querySelector('.v2-app'), NodeFilter.SHOW_TEXT)
+      let n
+      while ((n = walk.nextNode())) {
+        const txt = (n.nodeValue || '').trim()
+        if (!txt) continue
+        const el = n.parentElement
+        if (!el || el.offsetParent === null) continue
+        for (const t of tokens) {
+          if (txt.includes(t)) {
+            out.push(`${t} :: "${txt.slice(0, 70)}" in .${(typeof el.className === 'string' ? el.className : '').split(/\s+/)[0]}`)
+          }
+        }
+      }
+      return out
+    }, TOKENS)
+    for (const f of found) {
+      const tok = f.split(' :: ')[0]
+      if (!hits.has(tok)) hits.set(tok, [])
+      hits.get(tok).push(`${s}: ${f.slice(tok.length + 4)}`)
+    }
+  } catch (e) {
+    console.log(`FAIL ${s}: ${String(e).split('\n')[0].slice(0, 90)}`)
+  }
+  await p.close()
+}
+await b.close()
+if (!hits.size) { console.log('no wiring vocabulary rendered on the surfaces scanned') }
+for (const [tok, where] of [...hits].sort((a, b) => b[1].length - a[1].length)) {
+  console.log(`\n${tok} — ${where.length} rendered occurrence(s)`)
+  where.slice(0, 4).forEach(w => console.log(`    ${w}`))
+}

--- a/dashboard/src/components/ide/ide-shell.test.ts
+++ b/dashboard/src/components/ide/ide-shell.test.ts
@@ -1036,7 +1036,7 @@ describe('IdeShell', () => {
     expect(rail?.classList.contains('ide-v2-rail')).toBe(true)
     expect(buttonByText(container, '활동').getAttribute('aria-selected')).toBe('true')
     expect(buttonByText(container, 'Work Context').getAttribute('aria-expanded')).toBe('false')
-    expect(container.querySelectorAll('.ide-v2-rail-tab')).toHaveLength(3)
+    expect(container.querySelectorAll('.ide-rail-tab')).toHaveLength(3)
     expect(container.querySelector('.ide-activity-compact-status')?.getAttribute('role')).toBe('status')
     expect(container.querySelector('.ide-v2-presence-state')?.getAttribute('aria-label')).toBeTruthy()
     expect(container.querySelector('.ide-v2-connection-dot')?.getAttribute('aria-label')).toBeTruthy()

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -1435,7 +1435,7 @@ export function IdeShell() {
               class="ide-plane-conversation ide-v2-rail v2-ide-panel"
               data-testid="ide-right-rail"
             >
-              <div class="ide-v2-rail-tabs" role="tablist" aria-label="IDE right rail">
+              <div class="ide-rail-tabs" role="tablist" aria-label="IDE right rail">
                 ${IDE_RIGHT_RAIL_TABS.map(tab => html`
                   <button
                     key=${tab.id}
@@ -1444,7 +1444,7 @@ export function IdeShell() {
                     aria-selected=${rightRailTab === tab.id ? 'true' : 'false'}
                     aria-label=${tab.title}
                     title=${tab.title}
-                    class=${`ide-v2-rail-tab ${rightRailTab === tab.id ? 'on' : ''}`}
+                    class=${`ide-rail-tab ${rightRailTab === tab.id ? 'on' : ''}`}
                     onClick=${() => setRightRailTab(tab.id)}
                   >${tab.label}</button>
                 `)}

--- a/dashboard/src/components/tools/keeper-background-panel.ts
+++ b/dashboard/src/components/tools/keeper-background-panel.ts
@@ -121,7 +121,7 @@ export function KeeperBackgroundPanel({
     <section class="sch-bg" data-testid="keeper-background-inventory">
       <div class="sch-bg-h">
         <h3>Keeper 자율 백그라운드</h3>
-        <div class="sch-bg-sub">
+        <div class="sch-bg-sub is-stats">
           <span class="font-mono">keepers ${background.keeper_count.toLocaleString()}</span>
           <span class="font-mono">recurring keepers ${background.recurring_keeper_count.toLocaleString()}</span>
           <span class="font-mono">recurring tasks ${background.recurring_count.toLocaleString()}</span>

--- a/dashboard/src/styles/craft-v2.css
+++ b/dashboard/src/styles/craft-v2.css
@@ -31,11 +31,11 @@
   font-size: calc(var(--twk-font-scale, 100) * 1%);
 }
 
-/* ── Button leading ───────────────────────────────────────────── */
-/* The prototype ships no CSS reset, so its <button>s keep the UA metrics
+/* ── Form-control leading ─────────────────────────────────────── */
+/* The prototype ships no CSS reset, so its form controls keep the UA metrics
    (`line-height: normal`) while body copy runs at 1.55. Every dense chrome the
-   design builds out of buttons — log rows, nav items, stat chips, kanban cards
-   — is sized by that tight leading. The dashboard's Tailwind preflight makes
+   design builds out of them — log rows, nav items, stat chips, kanban cards, the
+   Lab/Command entry box — is sized by that tight leading. The dashboard's Tailwind preflight makes
    `button { font: inherit }`, so the same elements inherit 1.55 and every row
    grows ~10% (a log row measured 41.7px against the design's 38.0px, and the
    drift compounds down a list). Restoring proportional leading on the v2 shell's
@@ -47,7 +47,7 @@
    leading keeps it and everything else takes proportional leading. Scoped to
    `.v2-app`; other surfaces untouched. */
 @layer v2-button-leading {
-  .v2-app button {
+  .v2-app :is(button, input, select, textarea) {
     line-height: normal;
   }
 }

--- a/dashboard/src/styles/ide-v2.css
+++ b/dashboard/src/styles/ide-v2.css
@@ -565,40 +565,30 @@
   grid-template-rows: none;
 }
 
-.ide-v2-rail-tabs {
-  flex: none;
-  display: flex;
+/* The rail tabs now carry the design's own class names, so keeper-v2/surfaces.css
+   owns their type, spacing and selected state. What stays here is the part the
+   design's static mock never had to solve: three tabs sharing a 320px rail
+   without wrapping, and a label that truncates rather than pushing its
+   neighbours out. */
+.ide-rail-tabs {
   flex-direction: row;
   flex-wrap: nowrap;
   align-items: flex-end;
-  gap: 2px;
-  padding: 10px 10px 0;
-  border-bottom: 1px solid var(--border-soft);
 }
 
-.ide-v2-rail-tab {
-  flex: 1 1 0;
+.ide-rail-tab {
+  /* `0 1 auto`, not `1 1 0`: the tab sizes to its label the way the design draws
+     it, and still shrinks with an ellipsis when a longer label would push its
+     neighbours past the 320px rail. Leading is the design's — the explicit 1.2
+     that used to sit here made the tab 2.8px shorter than the mock. */
+  flex: 0 1 auto;
   min-width: 0;
-  font-family: var(--font-ui);
-  font-size: var(--fs-10);
-  line-height: 1.2;
-  padding: 6px 8px;
-  border: 0;
-  background: none;
-  color: var(--text-dim);
-  cursor: pointer;
-  border-bottom: 2px solid transparent;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.ide-v2-rail-tab.on {
-  color: var(--volt-strong);
-  border-bottom-color: var(--volt);
-}
-
-.ide-v2-rail-tab[aria-selected="true"] {
+.ide-rail-tab[aria-selected="true"] {
   color: var(--volt-strong);
 }
 

--- a/dashboard/src/styles/keeper-v2/fleet.css
+++ b/dashboard/src/styles/keeper-v2/fleet.css
@@ -38,7 +38,10 @@
 .fl-brand { display: flex; flex-direction: column; justify-content: center; gap: 1px; flex: none; }
 .fl-brand .ov-eyebrow { margin-bottom: 0; }
 .fl-crumb { font-family: var(--font-mono); font-size: var(--fs-10); letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-dim); white-space: nowrap; }
-.fl-title { margin: 0; font-family: var(--font-display); font-weight: 600; font-size: 18px; line-height: 1.2; letter-spacing: -0.005em; color: var(--text-bright); white-space: nowrap; }
+/* `margin: 0` is the live DOM's — the title is a heading element and the mock's
+   is not. The leading is not: the design states none, so it inherits, and the
+   1.2 that used to sit here sat the title 3.2px high in its own header band. */
+.fl-title { margin: 0; font-family: var(--font-display); font-weight: 600; font-size: 18px; letter-spacing: -0.005em; color: var(--text-bright); white-space: nowrap; }
 .fl-health { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 .fl-hpill {
   display: inline-flex; align-items: center; gap: 7px;

--- a/dashboard/src/styles/keeper-v2/fleet.css
+++ b/dashboard/src/styles/keeper-v2/fleet.css
@@ -18,10 +18,13 @@
   color: var(--text-primary);
   font-family: var(--font-ui);
   /* shared roster column track — header + rows + group dividers align to this.
-     Last track = action cell (멈춤/깨움/종료): the 3 text buttons render ~156px,
-     so the track must be wide enough or the button group overflows left into the
-     context value (fl-ctx-val) on a selected/hovered row. */
-  --fl-cols: minmax(196px, 1.3fr) 184px 152px 120px minmax(96px, 1fr) 160px;
+     Five tracks, as the design draws the row: Keeper / 운영판정 / 컨텍스트 /
+     최근 도구 / 액션. The live monitoring surface renders a sixth cell
+     (.fl-runtime) the mock has no counterpart for and needs a wider action
+     track, so it restates this in v2-monitoring.css rather than widening the
+     shared token — a six-track value here laid the design's five cells into six
+     tracks and pushed every column wide. */
+  --fl-cols: minmax(196px, 1.3fr) 184px 152px minmax(96px, 1fr) 128px;
   --fl-gap: 14px;
 }
 

--- a/dashboard/src/styles/keeper-v2/schedule.css
+++ b/dashboard/src/styles/keeper-v2/schedule.css
@@ -206,7 +206,12 @@
 .sch-bg { margin-top: 26px; border-top: 1px solid var(--border-soft); padding-top: 18px; }
 .sch-bg-h { margin-bottom: 14px; }
 .sch-bg-h h3 { font-family: var(--font-display); font-size: var(--fs-13); letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-bright); margin: 0 0 4px; }
-.sch-bg-sub { font-size: var(--fs-11); color: var(--text-dim); display: flex; flex-wrap: wrap; gap: 10px; }
+.sch-bg-sub { font-size: var(--fs-11); color: var(--text-dim); }
+/* The design's sub-line is one sentence; the live panel puts three counts here
+   instead and needs them to wrap as a row. Declaring that on the element itself
+   made every sub-line a flex container, which took the section header from the
+   design's 47px to 41px. The live variant asks for it by name. */
+.sch-bg-sub.is-stats { display: flex; flex-wrap: wrap; gap: 10px; }
 .sch-bg-grps { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
 .sch-bg-grp { min-width: 0; }
 .sch-bg-grp-h { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-bottom: 9px; }

--- a/dashboard/src/styles/keeper-v2/surfaces.css
+++ b/dashboard/src/styles/keeper-v2/surfaces.css
@@ -751,6 +751,9 @@ button.cn-bind-row:hover .cn-bind-go { color: var(--volt-strong); transform: tra
 /* activity rail */
 .ide-rail { border-left: 1px solid var(--border-main); background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep) 70%); display: flex; flex-direction: column; min-height: 0; min-width: 0; }
 /* Right-rail tab layout is owned solely by ide-v2.css. */
+.ide-rail-tabs { flex: none; display: flex; gap: 2px; padding: 9px 10px 0; border-bottom: 1px solid var(--border-soft); }
+.ide-rail-tab { font-family: var(--font-ui); font-size: var(--fs-11); padding: 6px 11px; border: 0; background: none; color: var(--text-dim); cursor: pointer; border-bottom: 2px solid transparent; }
+.ide-rail-tab.on { color: var(--volt-strong); border-bottom-color: var(--volt); }
 .ide-rail-scroll { flex: 1; overflow-y: auto; padding: 11px 12px; display: flex; flex-direction: column; gap: 9px; }
 .ide-ev { display: grid; grid-template-columns: 24px 1fr; gap: 8px; padding: 8px 9px; border-radius: var(--radius-sm); background: var(--bg-card); border: 1px solid var(--border-soft); }
 .ide-ev .ico { width: 22px; height: 22px; border-radius: var(--radius-sm); display: flex; align-items: center; justify-content: center; font-size: var(--fs-10); background: var(--bg-deep); border: 1px solid var(--border-main); color: var(--text-dim); }

--- a/dashboard/src/styles/v2-monitoring.css
+++ b/dashboard/src/styles/v2-monitoring.css
@@ -384,3 +384,17 @@
     white-space: normal;
   }
 }
+
+/* Roster column track for the live surface. The dashboard's row carries a
+   `.fl-runtime` cell between context and recent-tool that the design's row does
+   not have, and its action group is three text buttons (멈춤/깨움/종료) rendering
+   ~156px, so the last track needs 160px or the buttons slide under the context
+   value on a selected row. The shared `--fl-cols` in keeper-v2/fleet.css stays
+   the design's five tracks; this restates six for this surface only. Bounded to
+   the widths above the shed-a-column tier so that tier keeps its own set. */
+@media (min-width: 1501px) {
+  .v2-monitoring-surface.fl-shell,
+  .v2-monitoring-surface .fl-shell {
+    --fl-cols: minmax(196px, 1.3fr) 184px 152px 120px minmax(96px, 1fr) 160px;
+  }
+}

--- a/dashboard/src/styles/v2-monitoring.css
+++ b/dashboard/src/styles/v2-monitoring.css
@@ -178,7 +178,6 @@
   font-size: 18px;
   font-weight: 600;
   letter-spacing: -0.005em;
-  line-height: 1.1;
 }
 
 .v2-monitoring-surface .fl-tick {

--- a/dashboard/src/styles/work-v2.css
+++ b/dashboard/src/styles/work-v2.css
@@ -848,7 +848,7 @@
  *   var(--volt)          → var(--color-volt, var(--color-accent))
  *   var(--status-ok)     → var(--color-status-ok)
  *   var(--status-warn)   → var(--color-status-warn)
- *   var(--status-bad)    → var(--color-status-bad)
+ *   var(--status-bad)    → var(--color-status-err)
  *   var(--radius-xs)     → var(--radius-xs, 3px)
  *   var(--radius-sm)     → var(--radius-sm, 4px)
  *   var(--radius-pill)   → var(--radius-pill, 999px)
@@ -1065,15 +1065,18 @@
 }
 
 .wka-h .n,
+/* No `margin-left: auto` here. The design gives that to `.wka-h .n` — a
+   different, plain count span, which this file's own headers also use — while
+   `.wka-h-n` is the pill badge that sits inline right after the heading text.
+   Applying it to the badge pushed it 242px to the far edge of the aside, away
+   from the heading it counts. The kit owns the badge's type and border. */
 .wka-h-n {
-  margin-left: auto;
-  font-size: var(--fs-11);
   color: var(--text-muted);
   letter-spacing: 0;
 }
 
 .wka-h-n.bad {
-  color: var(--color-status-bad);
+  color: var(--color-status-err);
 }
 
 .wka-h-n.dim {
@@ -1119,7 +1122,7 @@
 }
 
 .wka-flag.st-bad {
-  border-left-color: var(--color-status-bad);
+  border-left-color: var(--color-status-err);
 }
 
 .wka-flag.st-volt {
@@ -1145,8 +1148,8 @@
 }
 
 .wka-flag-tag.bad {
-  color: var(--color-status-bad);
-  border-color: color-mix(in oklab, var(--color-status-bad) 42%, transparent);
+  color: var(--color-status-err);
+  border-color: color-mix(in oklab, var(--color-status-err) 42%, transparent);
 }
 
 .wka-flag-tag.volt {
@@ -1173,36 +1176,24 @@
 }
 
 /* ── Todo items (verify / blockers / backlog) ── */
+/* `.wka-todo` and its status variants belong to the vendored kit
+   (keeper-v2/v2.css). A hand-port of the whole component sat here and lost to
+   the kit everywhere the two agreed — except on `.wka-todo.verify/.block/.claim`,
+   which are (0,2,0) where the kit's edge comes from a (0,1,0) `border` shorthand.
+   Those three painted a coloured stripe down the card that the design does not
+   have: the design carries the status on the kind chip and leaves the card edge
+   `--border-soft`. `.block` was worse than a stray stripe — it referenced
+   `--color-status-bad`, which is defined nowhere, so its `color-mix` background
+   collapsed to transparent and the card lost its ground entirely.
+   What remains here is what the kit has no counterpart for. */
 .wka-todo {
-  text-align: left;
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 3px 9px;
-  padding: 8px 11px;
-  border: 1px solid var(--color-border-subtle);
-  border-left-width: 2px;
-  border-radius: var(--radius-sm, 4px);
-  background: var(--color-bg-surface);
-  cursor: pointer;
-  transition: border-color 0.16s ease, background 0.16s ease;
+  /* Shrink-to-fit guard: the live consumers are real <button>s. */
   width: 100%;
 }
 
-.wka-todo.verify {
-  border-left-color: var(--color-status-info, var(--color-info));
-}
-
-.wka-todo.block {
-  border-left-color: var(--color-status-bad);
-  background: color-mix(in oklab, var(--color-status-bad) 7%, var(--color-bg-surface));
-}
-
-.wka-todo.claim {
-  border-left-color: var(--color-status-warn);
-  background: color-mix(in oklab, var(--color-status-warn) 6%, var(--color-bg-surface));
-}
-
-.wka-todo:hover,
+/* The kit states `:hover` but not `:focus-visible`; a static mock never had to
+   answer for keyboard focus. The `:hover` half is the kit's — it restates it
+   later at equal specificity. */
 .wka-todo:focus-visible {
   background: var(--color-bg-surface-hover, var(--color-bg-surface));
   border-color: var(--border-strong);
@@ -1220,20 +1211,8 @@
   white-space: nowrap;
 }
 
-.wka-todo.verify .wka-todo-k {
-  color: var(--color-volt-strong, var(--color-accent));
-  border: 1px solid var(--color-volt-dim, var(--color-accent-subtle));
-}
-
-.wka-todo.block .wka-todo-k {
-  color: var(--color-status-bad);
-  border: 1px solid color-mix(in oklab, var(--color-status-bad) 42%, transparent);
-}
-
-.wka-todo.claim .wka-todo-k {
-  color: var(--color-status-warn);
-  border: 1px solid color-mix(in oklab, var(--color-status-warn) 40%, transparent);
-}
+/* The kind-chip variants are the kit's, restated there at the same specificity
+   and later in the cascade, so this copy never won anything. */
 
 .wka-todo-t {
   grid-column: 2;
@@ -1323,7 +1302,7 @@
 }
 
 .wka-rail-stat.bad b {
-  color: var(--color-status-bad);
+  color: var(--color-status-err);
 }
 
 .wka-rail-lbl {


### PR DESCRIPTION
#29334 후속입니다. 그 PR의 divergence 원장에 "의도된 로컬 계약"으로 적어둔 두 항목을 다시 봤더니, **계약이 잘못된 파일에 살고 있었을 뿐**이었습니다. 그리고 그 과정에서 계측 자체가 재현되지 않는다는 걸 발견해 같이 고쳤습니다.

## 1. `--fl-cols` — 킷이 라이브의 열을 들고 있었다

라이브 monitoring 행에는 컨텍스트와 최근도구 사이에 `.fl-runtime` 셀이 하나 더 있고, 액션 그룹이 텍스트 버튼 3개(멈춤/깨움/종료)라 마지막 트랙에 160px가 필요합니다. 그 6트랙 값이 **공유 토큰**에 박혀 있어서, 디자인의 5개 셀이 6트랙에 깔리며 모든 열이 밀려 있었습니다.

- `keeper-v2/fleet.css` → 디자인의 5트랙 그대로
- `v2-monitoring.css` → `.v2-monitoring-surface`에만 6트랙, 열을 하나 떨구는 티어보다 위 폭에서만

라이브 로스터는 여전히 6셀·6트랙·액션셀 160px·오버플로 없음으로 계약이 유지됩니다. **monitor 0.928 → 0.995**

## 2. IDE 레일 탭 — 같은 컴포넌트가 이름 둘

라이브는 `.ide-v2-rail-tab*`, 디자인은 `.ide-rail-tab*`을 그리는데 후자가 벤더링된 적이 없어 탭이 일반 버튼 크롬으로 떨어져 있었습니다. 컴포넌트를 디자인 이름으로 옮기고, `keeper-v2/surfaces.css`가 타입·간격·선택 상태를 갖습니다.

`ide-v2.css`에는 정적 목업이 풀 필요 없던 것만 남겼습니다 — 320px 레일을 세 탭이 줄바꿈 없이 나눠 쓰기, 긴 라벨이 이웃을 밀어내는 대신 말줄임. `flex: 1 1 0` 대신 **`0 1 auto`** 로 두어 탭이 라벨 크기대로 잡히면서도 압력을 받으면 줄어듭니다. **ide 0.935 → 0.995**

## 3. 계측이 재현되지 않았다

같은 페이지를 세 번 재니 **0.909 / 0.909 / 0.763**. 스킨이 아니라 측정이 움직이고 있었습니다.

| 원인 | 조치 |
|---|---|
| `.thread` 자동 하단 스크롤이 레이아웃과 경합 — scrollTop이 **1907(바닥) 또는 185** 로 갈림. 화면 한 칸 높이라 keepers에서 4pp, 양쪽이 반대로 앉으면 15pp | 캡처 전 앱이 의도한 바닥으로 고정 |
| `alarm.jsx` 앰비언트 알림 (5s / 이후 16s) | 프로토타입 자체 노브 `window.MASC_NOTIFY` 로 채널 차단 |
| `shell.jsx` 가 1.1s마다 랜덤 tok/s 재추첨 — 비교 가능한 상태에 도달 못 함 | 1초 이상 **반복** 타이머만 정지. 일회성은 유지 (FSM 위상 전이 `act.ms \|\| 1500`은 디자인이 안착하는 상태의 일부) |
| 콜드 캐시에서 Cinzel·Noto Sans KR이 캡처 창 이후 도착 | `document.fonts.ready` 대기 |

여기에 연속 두 프레임이 바이트 동일할 때만 채택하는 게이트를 더했습니다. 같은 페이지 4회가 동일 바이트를 내고, 독립적인 전체 실행 2회가 소수점 넷째 자리까지 일치합니다(둘 다 0.9475).

**고친 하네스는 이번 수치를 뒤집지 않고 확정합니다** — keepers는 0.9087로, 원래도 세 번 중 두 번 나오던 바닥 스크롤 상태 값입니다.

## 측정 (14개 화면, 1600×1000, 2회 독립 실행 일치)

```
mean SSIM          0.939 → 0.9475
구조 일치 10개 화면  0.977
style conformance   96.93%  (41,201 / 42,504 computed declarations, 10개 화면)

logs .996 · monitor .995 · ide .995 · connectors .986 · lab .986 · fusion .978
command .969 · approvals .966 · registry .955 · schedule .944
keepers .909 · work .891 · board .853 · overview .842
```

0.95 미만 4개는 전부 원장에 근거가 적힌 비-스킨 사유입니다 — overview는 운영자가 확정한 full-width 유지(되돌리면 .996, 평균 .959), board는 `BoardPost` 에 전이 필드가 없어 만들 수 없는 컴포넌트, work는 `#29300` 이 디자인보다 앞서 나간 재설계, keepers는 프로토타입 버튼의 Arial 폴백에서 오는 폰트 메트릭 차이입니다.

## 같이 기록한 반증

버튼의 `line-height: normal` 을 수치 leading으로 바꾸는 안을 재봤습니다. 디자인의 `normal` 은 Arial 기준 ~1.15, 대시보드는 Noto Sans KR 기준 ~1.45라 같은 키워드가 2~3px 다르게 렌더됩니다. `1.18` 로 고정하면 버튼은 맞지만 **아래 그리드 셀까지 상속돼** 전체가 0.948 → 0.860 으로 떨어집니다. `normal` 유지가 맞고, 남는 차이는 폰트 메트릭입니다 — 디자인 시스템 문서가 크롬 폰트로 Noto Sans KR을 명시하므로 어긋나는 쪽은 목업의 Arial 입니다.

## 검증

`pnpm test` 9072 passed (668 files) · `pnpm lint` clean · `tsc --noEmit` clean · 라이브 monitoring 로스터와 IDE 레일 재촬영 확인 · `ide-shell.test.ts` 가 옛 레일탭 클래스를 검사하고 있어 개명과 함께 갱신.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
