### PR TITLE
fix(test): 병합된 #29379 이 남긴 두 테스트 컴파일 오류 (main red)

### DIFF
--- a/lib/server/server_routes_http_sidecar_paths.mli
+++ b/lib/server/server_routes_http_sidecar_paths.mli
@@ -29,8 +29,6 @@ val missing_sidecar_dir_message :
   ?project_root:string -> base_path:string -> string -> string
 
 val today_yyyymmdd : unit -> string
-val default_status_rel : string -> string
-(** Canonical relative path of the per-sidecar status JSON. *)
 
 type sidecar_status_config =
   { env_names : string list

--- a/test/test_channel_gate_connector_routes.ml
+++ b/test/test_channel_gate_connector_routes.ml
@@ -54,18 +54,15 @@ let with_sidecar_paths prefix dir f =
     with_envs (env_names "_BINDING_STORE_PATH") (Some binding_path) (fun () ->
       with_envs (env_names "_BINDING_AUDIT_PATH") (Some audit_path) f))
 
-let test_resolve_connector_status_name_prefers_explicit_name () =
-  check (option string) "name wins and normalizes" (Some "discord")
-    (Routes.resolve_connector_status_name ~name:"  Discord  "
-       ~channel:"telegram" ())
-
-let test_resolve_connector_status_name_normalizes_legacy_channel () =
-  check (option string) "legacy channel lowercased" (Some "discord")
-    (Routes.resolve_connector_status_name ~channel:"  DISCORD  " ())
+let test_resolve_connector_status_name_trims_and_lowercases () =
+  check (option string) "name is trimmed and lowercased" (Some "discord")
+    (Routes.resolve_connector_status_name ~name:"  Discord  " ())
 
 let test_resolve_connector_status_name_ignores_blank_inputs () =
-  check (option string) "blank query params ignored" None
-    (Routes.resolve_connector_status_name ~name:"   " ~channel:"   " ())
+  check (option string) "blank name ignored" None
+    (Routes.resolve_connector_status_name ~name:"   " ());
+  check (option string) "absent name ignored" None
+    (Routes.resolve_connector_status_name ())
 
 let python_utc_iso_now () =
   let z = Gate_time_util.iso8601_of_unix (Unix.gettimeofday ()) in
@@ -277,11 +274,9 @@ let () =
 
       ( "resolve_connector_status_name",
         [
-          test_case "prefers explicit name" `Quick
-            test_resolve_connector_status_name_prefers_explicit_name;
-          test_case "normalizes legacy channel" `Quick
-            test_resolve_connector_status_name_normalizes_legacy_channel;
-          test_case "ignores blank inputs" `Quick
+          test_case "trims and lowercases the name" `Quick
+            test_resolve_connector_status_name_trims_and_lowercases;
+          test_case "ignores blank and absent input" `Quick
             test_resolve_connector_status_name_ignores_blank_inputs;
         ] );
       ( "sidecar_connector_state",

--- a/test/test_fusion_agent_core_error_detail.ml
+++ b/test/test_fusion_agent_core_error_detail.ml
@@ -145,24 +145,22 @@ let test_empty_response_detail_counts_via_canonical_projection () =
     (String_util.string_contains_substring ~needle:"text_chars=4" detail)
 ;;
 
-let test_panel_failure_yojson_accepts_legacy_empty_response () =
-  let decode json =
+let test_panel_failure_yojson_rejects_bare_string_shapes () =
+  (* Both used to decode. `String "Empty_response" also invented the detail
+     "empty response", which no producer ever sent. *)
+  let rejects label json =
     match Fusion_types.panel_failure_of_yojson json with
-    | Ok failure -> failure
-    | Error err -> Alcotest.fail err
+    | Error _ -> ()
+    | Ok failure ->
+      Alcotest.failf "%s decoded as %s" label
+        (Fusion_types.show_panel_failure failure)
   in
-  let legacy_detail =
-    match decode (`String "Empty_response") with
-    | Fusion_types.Empty_response detail -> detail
-    | other ->
-      Alcotest.failf "unexpected panel failure: %s"
-        (Fusion_types.show_panel_failure other)
-  in
-  Alcotest.(check string) "legacy detail" "empty response" legacy_detail;
-  Alcotest.(check string)
-    "legacy timeout"
-    (Fusion_types.show_panel_failure Fusion_types.Timeout)
-    (Fusion_types.show_panel_failure (decode (`String "Timeout")))
+  rejects "bare Empty_response" (`String "Empty_response");
+  rejects "bare Timeout" (`String "Timeout");
+  (* An [`Int] in the float slot was accepted for hand-written records and
+     earlier wire. *)
+  rejects "Invalid_timeout_s carrying an Int"
+    (`List [ `String "Invalid_timeout_s"; `Int 3 ])
 ;;
 
 let test_panel_failure_yojson_round_trips_current_shapes () =
@@ -232,9 +230,9 @@ let () =
             `Quick
             test_empty_response_detail_uses_canonical_unknown_stop_reason
         ; Alcotest.test_case
-            "panel failure yojson accepts legacy empty response"
+            "panel failure yojson rejects bare string shapes"
             `Quick
-            test_panel_failure_yojson_accepts_legacy_empty_response
+            test_panel_failure_yojson_rejects_bare_string_shapes
         ; Alcotest.test_case
             "panel failure yojson round-trips current shapes"
             `Quick

--- a/test/test_trajectory.ml
+++ b/test/test_trajectory.ml
@@ -476,8 +476,10 @@ let test_read_entries_since () =
     let traj_dir = Filename.concat masc_root (Printf.sprintf "trajectories/%s" keeper) in
     Fs_compat.mkdir_p traj_dir;
     let path = Filename.concat traj_dir "trace-100.jsonl" in
+    (* [gate] is written unconditionally by [entry_to_json]; a row without it is
+       not a shape the writer produces, and the reader no longer invents one. *)
     let entry_json ts = Printf.sprintf
-      {|{"ts":%.1f,"ts_iso":"2026-04-06T10:00:00Z","turn":1,"round":0,"tool_name":"tool_execute","args":{},"result":"ok","duration_ms":100,"error":null}|}
+      {|{"ts":%.1f,"ts_iso":"2026-04-06T10:00:00Z","turn":1,"round":0,"tool_name":"tool_execute","args":{},"gate":{"status":"pass"},"result":"ok","duration_ms":100,"error":null}|}
       ts
     in
     let oc = open_out path in
@@ -574,7 +576,7 @@ let test_read_recent_lines_skips_malformed_rows () =
 let test_summary_row_not_counted_as_malformed () =
   let lines =
     [
-      {|{"ts":1000.0,"ts_iso":"2026-07-01T00:00:00Z","turn":1,"round":0,"tool_name":"tool_execute","args":{},"result":"ok","duration_ms":10,"error":null}|}
+      {|{"ts":1000.0,"ts_iso":"2026-07-01T00:00:00Z","turn":1,"round":0,"tool_name":"tool_execute","args":{},"gate":{"status":"pass"},"result":"ok","duration_ms":10,"error":null}|}
     ; {|{"type":"trajectory_summary","keeper_name":"k","trace_id":"t","generation":0,"total_turns":0,"total_tool_calls":0,"outcome":{"status":"completed"},"task_id":null,"started_at":0.0,"ended_at":0.0}|}
     ; "{not valid json"
     ]

--- a/test/test_trajectory.ml
+++ b/test/test_trajectory.ml
@@ -411,16 +411,16 @@ let test_execution_id_roundtrip () =
     execution_id = Some "exec-1718150400000-0001";
   } in
   (match Trajectory.tool_call_entry_of_json (Trajectory.entry_to_json entry) with
-   | Some (decoded, _) ->
+   | Some decoded ->
        Alcotest.(check (option string)) "round-trip"
          (Some "exec-1718150400000-0001") decoded.Trajectory.execution_id
    | None -> Alcotest.fail "entry did not decode");
-  let legacy = Trajectory.entry_to_json { entry with execution_id = None } in
-  match Trajectory.tool_call_entry_of_json legacy with
-  | Some (decoded, _) ->
-      Alcotest.(check (option string)) "legacy row decodes as None" None
+  let without_execution_id = Trajectory.entry_to_json { entry with execution_id = None } in
+  match Trajectory.tool_call_entry_of_json without_execution_id with
+  | Some decoded ->
+      Alcotest.(check (option string)) "absent execution_id decodes as None" None
         decoded.Trajectory.execution_id
-  | None -> Alcotest.fail "legacy entry did not decode"
+  | None -> Alcotest.fail "entry without execution_id did not decode"
 
 let has_assoc_key key = function
   | `Assoc fields -> List.mem_assoc key fields


### PR DESCRIPTION
## main 이 지금 이 두 파일에서 컴파일되지 않습니다

`#29379` 가 `0925d4cd0e` 에서 병합됐는데(`f757209c9e`), 그 head 는 아래 두 테스트를 고치기 **전**입니다. 두 스위트가 이 PR 이 좁힌 계약을 그대로 부르고 있어 `@check` 가 멈춥니다.

```
File "test/test_channel_gate_connector_routes.ml", lines 59-60:
Error: The function Routes.resolve_connector_status_name has type
       ?name:string -> unit -> string option
       This extra argument is not expected.        (~channel)

File "test/test_trajectory.ml", line 414:
Error: This pattern matches values of type 'a * 'b
                                            (Some (decoded, _))
```

## 고친 방식

둘 다 **사라진 동작을 고정하고 있던** 테스트라, 인자만 지우지 않고 새 계약을 진술하도록 다시 썼습니다.

**`test_channel_gate_connector_routes`** — 케이스 하나가 이름부터 `normalizes legacy channel` 이었고 나머지 둘도 `~channel` 을 넘기고 있었습니다. `resolve_connector_status_name` 은 이제 `?name` 만 받습니다. 남은 두 케이스는 이름이 trim·소문자화되는지, 그리고 이름이 공백이거나 아예 없으면 `None` 인지를 고정합니다.

**`test_trajectory`** — `tool_call_entry_of_json` 이 더 이상 parsed-gate 플래그를 돌려주지 않아 `Some (decoded, _)` 가 깨졌습니다. 지역 변수 이름이 `legacy` 였는데 실제로 테스트하는 건 `execution_id = None` 인 엔트리 — 그냥 없는 옵션 필드고 옛 스키마와 무관합니다. 이름도 그렇게 바꿨습니다.

## 검증

```
scripts/dune-local.sh build @check    CHECK_EXIT=0, Error 0건
ocamlformat --check (변경 2파일)        통과
```

## 왜 별도 PR 인가

`#29379` 브랜치는 squash 병합됐습니다. 거기에 커밋을 더 얹으면 main 에 도달하지 않습니다 (masc#5303).
