### PR TITLE
chore(board): 투표 방향을 필수로 받고 은퇴한 vote 파라미터 묘비 제거

### DIFF
--- a/dashboard/src/api/board.test.ts
+++ b/dashboard/src/api/board.test.ts
@@ -1179,10 +1179,9 @@ describe('voteComment', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
     expect(url).toBe('/api/v1/tools/masc_board_comment_vote')
-    expect(JSON.parse(String(init.body))).toMatchObject({
+    expect(JSON.parse(String(init.body))).toEqual({
       comment_id: 'comment-1',
       direction: 'down',
-      vote: 'down',
       voter: 'dashboard-reviewer',
     })
   })

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -1093,7 +1093,6 @@ export function votePost(postId: string, direction: 'up' | 'down'): Promise<unkn
   return post('/api/v1/tools/masc_board_vote', {
     post_id: postId,
     direction,
-    vote: direction,
     voter: defaultBoardVoter(),
   })
 }
@@ -1102,7 +1101,6 @@ export function voteComment(commentId: string, direction: 'up' | 'down'): Promis
   return post('/api/v1/tools/masc_board_comment_vote', {
     comment_id: commentId,
     direction,
-    vote: direction,
     voter: defaultBoardVoter(),
   })
 }

--- a/lib/board_tool_adapter/board_tool_handlers.ml
+++ b/lib/board_tool_adapter/board_tool_handlers.ml
@@ -96,31 +96,20 @@ let invalid_vote_direction ~tool_name ~start_time raw : Tool_result.result =
     (Printf.sprintf "invalid vote direction %S; expected up or down" raw)
 ;;
 
-(* Rejection tombstone for the retired [vote] parameter. Deleting it (#23710)
-   made a legacy {vote:"down"} call silently default direction to "up" —
-   an inverted vote instead of a typed rejection (main red #23901, voting). *)
-let legacy_vote_parameter_removed ~tool_name ~start_time raw : Tool_result.result =
+let missing_vote_direction ~tool_name ~start_time : Tool_result.result =
   Tool_result.make_err
     ~tool_name
-    ~class_:Tool_result.Policy_rejection
+    ~class_:Tool_result.Workflow_rejection
     ~start_time
-    (Printf.sprintf
-       "legacy vote parameter %S is no longer accepted; use direction"
-       raw)
+    "vote direction required; expected up or down"
 ;;
 
 let handle_vote ~tool_name ~start_time args =
   let post_id = get_string args "post_id" "" in
   let voter = get_string args "voter" "anonymous" in
-  match Safe_ops.json_string_opt "direction" args, get_string_opt args "vote" with
-  | None, Some raw ->
-    legacy_vote_parameter_removed ~tool_name ~start_time raw
-  | direction_arg, _ ->
-    let direction_str =
-      match direction_arg with
-      | Some raw -> raw
-      | None -> "up"
-    in
+  match Safe_ops.json_string_opt "direction" args with
+  | None -> missing_vote_direction ~tool_name ~start_time
+  | Some direction_str ->
     (match Board.vote_direction_of_string_opt direction_str with
      | None -> invalid_vote_direction ~tool_name ~start_time direction_str
      | Some direction ->
@@ -246,10 +235,12 @@ let handle_search ~tool_name ~start_time args : Tool_result.result =
 let handle_comment_vote ~tool_name ~start_time args : Tool_result.result =
   let comment_id = get_string args "comment_id" "" in
   let voter = get_string args "voter" "anonymous" in
-  let direction_str = get_string args "direction" "up" in
-  match Board.vote_direction_of_string_opt direction_str with
-  | None -> invalid_vote_direction ~tool_name ~start_time direction_str
-  | Some direction ->
+  match Safe_ops.json_string_opt "direction" args with
+  | None -> missing_vote_direction ~tool_name ~start_time
+  | Some direction_str ->
+    (match Board.vote_direction_of_string_opt direction_str with
+     | None -> invalid_vote_direction ~tool_name ~start_time direction_str
+     | Some direction ->
     if String.equal comment_id ""
     then
       Tool_result.make_err
@@ -267,7 +258,7 @@ let handle_comment_vote ~tool_name ~start_time args : Tool_result.result =
             (`String
                (Printf.sprintf
                   "%s 코멘트 투표 완료! 점수: %+d"
-                  (if String.equal direction_str "down" then "👎" else "👍")
+                  (if direction = Board.Down then "👎" else "👍")
                   score))
           ()
       | Error (Board.Already_voted _) ->
@@ -278,10 +269,10 @@ let handle_comment_vote ~tool_name ~start_time args : Tool_result.result =
             (`String
                (Printf.sprintf
                   "%s Already voted (idempotent)."
-                  (if String.equal direction_str "down" then "👎" else "👍")))
+                  (if direction = Board.Down then "👎" else "👍")))
           ()
       | Error e ->
-        Board_tool_format.error_of_board_error ~tool_name ~start_time e)
+        Board_tool_format.error_of_board_error ~tool_name ~start_time e))
 ;;
 
 let handle_reaction ~tool_name ~start_time args : Tool_result.result =

--- a/lib/board_tool_adapter/board_tool_schemas.ml
+++ b/lib/board_tool_adapter/board_tool_schemas.ml
@@ -447,10 +447,11 @@ let tool_vote : Masc_domain.tool_schema =
               ; ( "direction"
                 , `Assoc
                     [ "type", `String "string"
-                    ; "description", `String "up or down (default: up)"
+                    ; "enum", `List [ `String "up"; `String "down" ]
+                    ; "description", `String "Required vote direction: up or down"
                     ] )
               ] )
-        ; "required", `List [ `String "post_id" ]
+        ; "required", `List [ `String "post_id"; `String "direction" ]
         ]
   }
 ;;
@@ -521,10 +522,11 @@ let tool_comment_vote : Masc_domain.tool_schema =
               ; ( "direction"
                 , `Assoc
                     [ "type", `String "string"
-                    ; "description", `String "up or down (default: up)"
+                    ; "enum", `List [ `String "up"; `String "down" ]
+                    ; "description", `String "Required vote direction: up or down"
                     ] )
               ] )
-        ; "required", `List [ `String "comment_id" ]
+        ; "required", `List [ `String "comment_id"; `String "direction" ]
         ]
   }
 ;;

--- a/lib/tool_surface/tool_shard_types_board_keeper_projection.ml
+++ b/lib/tool_surface/tool_shard_types_board_keeper_projection.ml
@@ -261,10 +261,10 @@ let schemas : Masc_domain.tool_schema list =
                       ; ( "enum"
                         , `List
                             (List.map (fun s -> `String s) vote_direction_enum_strings) )
-                      ; "description", `String "Vote direction (default: up)"
+                      ; "description", `String "Required vote direction: up or down"
                       ] )
                 ] )
-          ; "required", `List [ `String "post_id" ]
+          ; "required", `List [ `String "post_id"; `String "direction" ]
           ; "additionalProperties", `Bool false
           ]
     }

--- a/scripts/harness/contract/public_tool_live_sweep.sh
+++ b/scripts/harness/contract/public_tool_live_sweep.sh
@@ -269,7 +269,7 @@ if [[ -z "$comment_id" ]]; then
 fi
 
 next_step "masc_board_vote"
-r_board_vote="$(call_tool 5029 "masc_board_vote" "$(jq -cn --arg post_id "$post_id" --arg voter "$AGENT_NAME" '{post_id:$post_id,voter:$voter}')")"
+r_board_vote="$(call_tool 5029 "masc_board_vote" "$(jq -cn --arg post_id "$post_id" --arg voter "$AGENT_NAME" '{post_id:$post_id,voter:$voter,direction:"up"}')")"
 expect_ok "masc_board_vote" "$r_board_vote"
 
 next_step "masc_board_comment_vote"

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -978,7 +978,7 @@ let test_keeper_board_dispatch_uses_typed_tool_names () =
     Keeper_tool_board_runtime.handle_board_tool
       ~meta:keeper_meta
       ~name:"masc_board_comment_vote"
-      ~args:(make_args [ ("comment_id", `String "") ])
+      ~args:(make_args [ ("comment_id", `String ""); ("direction", `String "up") ])
   in
   Alcotest.(check bool) "typed comment vote reaches board handler" true
     (String_util.contains_substring comment_vote "comment_id required");

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -1660,7 +1660,7 @@ let test_vote_not_found () =
     result;
   Alcotest.(check bool) "has error" true (String.length body > 0)
 
-let test_vote_rejects_legacy_direction_fallbacks () =
+let test_vote_requires_explicit_direction () =
   with_eio @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   cleanup ();
@@ -1681,23 +1681,37 @@ let test_vote_rejects_legacy_direction_fallbacks () =
     (String_util.contains_substring
        ((Tool_result.message empty_direction))
        "invalid vote direction");
-  let legacy_vote_alias =
+  let missing_direction =
     dispatch_result
       "masc_board_vote"
-      (make_args
-         [
-           ("post_id", `String "missing");
-           ("voter", `String "v");
-           ("vote", `String "down");
-         ])
+      (make_args [ ("post_id", `String "missing"); ("voter", `String "v") ])
   in
-  Alcotest.(check bool) "legacy vote alias rejected" false (Tool_result.is_success legacy_vote_alias);
+  Alcotest.(check bool) "missing direction rejected" false (Tool_result.is_success missing_direction);
+  check_failure_class
+    "missing direction is workflow rejection"
+    (Some "workflow_rejection")
+    missing_direction;
   Alcotest.(check bool)
-    "legacy vote alias error"
+    "missing direction error"
     true
     (String_util.contains_substring
-       ((Tool_result.message legacy_vote_alias))
-       "legacy vote parameter")
+       ((Tool_result.message missing_direction))
+       "vote direction required");
+  let comment_missing_direction =
+    dispatch_result
+      "masc_board_comment_vote"
+      (make_args [ ("comment_id", `String "c-missing"); ("voter", `String "v") ])
+  in
+  Alcotest.(check bool)
+    "comment vote missing direction rejected"
+    false
+    (Tool_result.is_success comment_missing_direction);
+  Alcotest.(check bool)
+    "comment vote missing direction error"
+    true
+    (String_util.contains_substring
+       ((Tool_result.message comment_missing_direction))
+       "vote direction required")
 
 (** {2 Group 5: Comment} *)
 
@@ -2060,9 +2074,9 @@ let () =
         [
           Alcotest.test_case "vote not found" `Quick test_vote_not_found;
           Alcotest.test_case
-            "legacy direction fallbacks rejected"
+            "explicit direction required"
             `Quick
-            test_vote_rejects_legacy_direction_fallbacks;
+            test_vote_requires_explicit_direction;
         ] );
       ( "comments",
         [


### PR DESCRIPTION
## 무엇이 남아 있었나

#29379 가 "남은 것" 으로 적어둔 `board_tool_handlers` 의 legacy vote 파라미터 자리입니다.

- `handle_vote` 는 `direction` 이 없으면 조용히 `"up"` 으로 투표했고, 은퇴한 `vote` 키가 오면 묘비(`legacy_vote_parameter_removed`) 메시지를 돌려줬습니다.
- `handle_comment_vote` 도 `get_string args "direction" "up"` 으로 같은 기본값을 갖고 있었습니다.
- 대시보드 `votePost` / `voteComment` 는 `direction` 옆에 은퇴한 `vote` 키를 **아직도 같이 보내고** 있었습니다.
- 스키마 3곳(`board_tool_schemas` 2, keeper projection 1)은 `direction` 을 선택 필드로 두고 설명에 `(default: up)` 을 적어 두었습니다.

## 바꾼 것

| 자리 | 전 | 후 |
|---|---|---|
| `masc_board_vote` / `masc_board_comment_vote` 스키마 | `direction` 선택, 설명 "(default: up)" | `required` + `enum ["up","down"]` |
| `handle_vote` | `vote` 키 묘비 + `None -> "up"` | `direction` 없으면 `Workflow_rejection` "vote direction required; expected up or down" |
| `handle_comment_vote` | `"up"` 기본값 | 동일한 typed rejection |
| 결과 이모지 | `direction_str = "down"` 문자열 비교 | `direction = Board.Down` 패턴 |
| `dashboard/src/api/board.ts` | `vote: direction` 동봉 | `direction` 만 전송 |

묘비 함수와 `"legacy"` 단어는 이 경로에서 0건입니다.

## 검증

- `test_tool_board_coverage`: `legacy vote alias` 케이스를 `missing direction` (post / comment 각각, `workflow_rejection` 클래스 확인) 으로 교체. 케이스 이름 `explicit direction required`.
- `dashboard/src/api/board.test.ts` `voteComment`: 페이로드를 `toEqual` 로 고정해 `vote` 키가 사라졌음을 단언.
- MCP/keeper 매트릭스 테스트는 스키마 `required`+`enum` 에서 인자를 생성하므로(`enum_first`) 추가 수정 없이 `direction = "up"` 을 공급합니다.
- 로컬 dune 빌드는 돌리지 않았습니다. 변경 4개 `.ml` 은 `ocamlc -stop-after parsing` 통과.

## 범위 밖 (기록만)

`masc_board_vote` 스키마가 `board_tool_schemas.ml` 과 `tool_shard_types_board_keeper_projection.ml` 두 곳에 따로 정의돼 있습니다(생산자 2, SSOT 위반). 이 PR 은 둘을 같은 계약으로 맞추기만 하고 합치지는 않습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3a8sWueQQPyYyoXerLJvj
