### PR TITLE
chore(dashboard): decision 행의 terminal_reason 은 typed 객체만 읽고, 죽은 transport 필드 제거

### DIFF
--- a/lib/dashboard/dashboard_http_keeper_types.ml
+++ b/lib/dashboard/dashboard_http_keeper_types.ml
@@ -6,10 +6,6 @@
 let runtime_warning_ctx_ratio =
   Env_config_keeper.DashboardHealth.runtime_warning_ctx_ratio
 
-(* RFC-0149 §3.3 — typed Result resolver for dashboard call sites.  The
-   legacy live runtime-id facade + its silent-fallback carrier
-   ([Keeper_runtime_profile.resolve_live]) were removed in the §3.3
-   sunset closeout. *)
 let live_keeper_runtime_id_result (raw : string) :
     (string, [ `Unresolved of string ]) result =
   let trimmed = String.trim raw in
@@ -32,13 +28,10 @@ let last_latency_ms_json latency_ms =
   if latency_ms <= 0 then `Null else `Int latency_ms
 
 let terminal_reason_code_of_decision_json json =
-  match Json_util.assoc_string_opt "terminal_reason_code" json with
-  | Some _ as value -> value
-  | None ->
-    (match Json_util.assoc_member_opt "terminal_reason" json with
-     | Some (`Assoc _ as terminal_reason) ->
-       Json_util.assoc_string_opt "code" terminal_reason
-     | _ -> None)
+  match Json_util.assoc_member_opt "terminal_reason" json with
+  | Some (`Assoc _ as terminal_reason) ->
+    Option.map Keeper_turn_terminal.code (Keeper_turn_terminal.of_json terminal_reason)
+  | Some _ | None -> None
 
 let execution_trust_source = "execution_receipt"
 let execution_trust_producer = "keeper_agent_run.execution_receipt"

--- a/lib/dashboard/dashboard_http_keeper_types.mli
+++ b/lib/dashboard/dashboard_http_keeper_types.mli
@@ -10,16 +10,9 @@ val runtime_warning_ctx_ratio : float
 
 val live_keeper_runtime_id_result :
   string -> (string, [ `Unresolved of string ]) result
-(** Resolve a raw runtime id to its live (post-rotation) identifier.
-    Returns [Error (`Unresolved raw)] when the input cannot be resolved
-    to any catalog member; the caller is expected to surface the
-    unresolved input directly (e.g. as JSON [null] on the canonical
-    field) rather than fall back to a silent default.
-
-    The legacy [live_keeper_runtime_id : string -> string] facade was
-    removed in the RFC-0149 §3.3 sunset closeout.
-
-    @since RFC-0149 Phase 1 *)
+(** [Ok] carries the trimmed runtime id; a blank input is
+    [Error (`Unresolved raw)], which the caller surfaces as JSON [null]
+    on the canonical field. *)
 
 val prompt_block_json : string -> Yojson.Safe.t
 (** Pure: resolve a prompt key and emit the dashboard JSON record. *)
@@ -38,6 +31,9 @@ val last_latency_ms_json : int -> Yojson.Safe.t
 
 val terminal_reason_code_of_decision_json :
   Yojson.Safe.t -> string option
+(** The code of the decision row's typed [terminal_reason] object
+    ({!Keeper_turn_terminal.of_json}); [None] when the row has no such
+    object or it does not decode. *)
 
 val execution_trust_source : string
 val execution_trust_producer : string

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -58,11 +58,7 @@ module Completion_contract_result = Keeper_completion_contract_result_label
 let terminal_reason_from_decision json =
   match json_member "terminal_reason" json with
   | `Assoc _ as terminal_reason -> Keeper_turn_terminal.of_json terminal_reason
-  | _ ->
-      Option.map
-        (fun code ->
-          Keeper_turn_terminal.of_code ~source:"decision_log" code)
-        (json_string_opt_member "terminal_reason_code" json)
+  | _ -> None
 
 let terminal_reason_from_receipt receipt =
   Option.map

--- a/lib/transport_read_model.ml
+++ b/lib/transport_read_model.ml
@@ -109,44 +109,6 @@ let maybe_configured_fields ~include_configured enabled =
   if include_configured then [ "configured", `Bool enabled ] else []
 ;;
 
-(* [tcp_port_reachable] used to open a stdlib [Unix.socket], call
-   [Unix.connect] against the configured loopback host, and close the
-   socket — all synchronously on the calling fiber's Eio domain.
-
-   That implementation is incompatible with Eio's cooperative
-   scheduling: from the official docs,
-
-     "When a fiber executes CPU-bound or blocking I/O work without
-      yielding control, it blocks all other fibers in that domain."
-
-   The probe was wired into every /health response builder
-   ([websocket_discovery_json], [transport_status_json]) where it
-   short-circuits behind [Transport_metrics.{ws,grpc}_listening].
-   Under normal operation the listening flag is [true] and the
-   stdlib call never runs.  But during startup / warm-up the
-   listening flag is [false] and every concurrent /health probe
-   queued waiting for a blocking [Unix.connect], stalling every
-   other fiber on the main Eio HTTP domain for the duration of the
-   connect.  Concurrent dashboard requests saw this as multi-second
-   latency cliffs at startup.
-
-   Fix: drop the blocking probe entirely.  Callers already OR with
-   the in-memory listening flag, so:
-
-   - listening = true  → reachable = true   (unchanged)
-   - listening = false → reachable = false  (warming up, accurate)
-
-   The latter is the truthful state during warm-up — a listener that
-   has not bound the socket yet is not reachable.  The previous
-   implementation could only have flipped this to [true] by racing
-   against another listener binding the same port, which is not a
-   useful signal.
-
-   Argument kept for API stability; callers still pass [port] from
-   the relevant configured-port lookup but the value is unused. *)
-let tcp_port_reachable (_port : int) : bool = false
-;;
-
 let get_ws_session_count () =
   match Transport_bridge.provider_by_name "ws" with
   | Some m ->
@@ -226,15 +188,12 @@ let transport_status_json (ctx : http_context) =
   let registrations = Atomic.get runtime_registrations in
   let grpc_enabled = Env_config.Transport.grpc_enabled () in
   let grpc_port = Env_config.Transport.grpc_port in
-  let grpc_reachable =
-    Transport_metrics.grpc_listening () || tcp_port_reachable grpc_port
-  in
+  let grpc_reachable = Transport_metrics.grpc_listening () in
   let streamable_auth_policy_present =
     Env_config.Transport.http_auth_strict_env_enabled ()
   in
   `Assoc
     [ "streamable_http_default", `Bool true
-    ; "legacy_endpoints_deprecated", `Bool true
     ; ( "http"
       , `Assoc
           (maybe_configured_fields ~include_configured:ctx.include_configured true

--- a/lib/transport_read_model.mli
+++ b/lib/transport_read_model.mli
@@ -102,8 +102,7 @@ val websocket_discovery_json : http_context -> Yojson.Safe.t
 (** [websocket_discovery_json ctx] returns the WebSocket
     discovery payload used by browser dashboards to learn the
     same-origin [ws://]/[wss://] upgrade URL.  Includes the
-    legacy standalone configured-port + runtime-listening fields
-    when [ctx.include_configured] is [true]. *)
+    [configured] field when [ctx.include_configured] is [true]. *)
 
 val transport_status_json : http_context -> Yojson.Safe.t
 (** [transport_status_json ctx] returns the full transport


### PR DESCRIPTION
## 무엇이 남아 있었나

#29379 "남은 것" 중 `dashboard_http_keeper_types` 와 `transport_read_model` 자리입니다. 읽다 보니 같은 파일 안에 하드컷 대상이 더 있었습니다.

### decision 행을 읽는 두 리더가 서로 반대 순서였습니다

`keeper_unified_metrics_decision` 은 한 행에 typed 객체 `terminal_reason` (`Keeper_turn_terminal.to_json`) 과 평면 복사본 `terminal_reason_code` 를 **둘 다** 씁니다.

| 리더 | 전 |
|---|---|
| `dashboard_http_keeper_types.terminal_reason_code_of_decision_json` | 평면 → 없으면 객체 `.code` |
| `keeper_runtime_trust_snapshot.terminal_reason_from_decision` | 객체 → 없으면 평면 (`source:"decision_log"` 로 지어냄) |

두 폴백 모두 평면 필드가 생기기 전·후 행을 받아주려는 것이고, 같은 행을 두 리더가 다르게 해석할 수 있는 자리였습니다. 둘 다 typed 객체 하나만 읽습니다. 객체가 없거나 디코드되지 않으면 `None` 입니다.

### 항상 같은 값을 쓰던 것

- `transport_status_json` 의 `legacy_endpoints_deprecated: true` — 소비자 0건 (lib/test/dashboard/scripts 전수).
- `tcp_port_reachable` — 본문이 `false` 고 인자는 "API stability" 를 위해 남겨둔 상태. `grpc_reachable = grpc_listening () || false` 였습니다. 함수를 지우고 `grpc_listening ()` 만 남깁니다.

### 지워진 것에 대한 서술

- `dashboard_http_keeper_types.ml/.mli` 의 "legacy live runtime-id facade was removed in RFC-0149 §3.3" 문단. `live_keeper_runtime_id_result` 의 mli 는 "catalog member 로 해석한다" 고 적혀 있었지만 구현은 trim 후 공백이면 `Unresolved` 입니다. 하는 일 그대로 적었습니다.
- `transport_read_model.mli` 의 "legacy standalone configured-port + runtime-listening fields" — 실제로 붙는 건 `configured` 하나입니다.

## 남겨둔 것 (범위 밖)

생산자가 평면 복사본 3개(`terminal_reason_code/_severity/_source`)를 typed 객체 옆에 계속 씁니다. 이 PR 이후 decision 행에서 그 복사본을 읽는 코드는 없으므로 생산자 쪽 제거는 다음 PR 후보입니다. execution receipt 의 `terminal_reason_code` 는 별개 저장소라 손대지 않았습니다.

## 검증

- `test_dashboard_k2_feeds` 는 fixture 가 typed 객체만 쓰므로 유지되는 경로를 그대로 고정합니다.
- 변경 `.ml` 3개 `ocamlc -stop-after parsing` 통과. 로컬 dune 빌드는 돌리지 않았습니다.

5파일 +13 −70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3a8sWueQQPyYyoXerLJvj

