### PR TITLE
chore(voice): 로컬 재생 dedup 의 message 를 필수 인자로

### DIFF
--- a/lib/voice_bridge_core/voice_bridge_core.ml
+++ b/lib/voice_bridge_core/voice_bridge_core.ml
@@ -10,12 +10,6 @@
     2. Railway proxy (ELEVENLABS_PROXY_URL)
     3. Voice MCP session endpoint (HTTP /mcp)
     4. text_fallback (silent)
-
-    Eio Migration Notes:
-    - Direct style (no monads)
-    - Cohttp_eio.Client for HTTP
-    - Eio.Time.sleep for delays
-    - Eio.Fiber.first for timeouts
 *)
 
 (** ============================================
@@ -251,11 +245,8 @@ let audio_duration_seconds ~audio_file =
     - [`Skipped reason] if playback was intentionally skipped.
     - [`Failed reason] if playback was requested but unavailable or failed.
     - [`Opened dur] if playback was handed off to macOS [open(1)].
-    - [`Played dur] if playback succeeded with the given duration.
-
-    When [message] is [None] the dedup re-check is skipped (legacy callers that
-    do not propagate the message string). *)
-let run_local_playback ~sw:_ ~agent_id ?message ~audio_file () =
+    - [`Played dur] if playback succeeded with the given duration. *)
+let run_local_playback ~sw:_ ~agent_id ~message ~audio_file () =
   match load_voice_config () with
   | Error e ->
     Log.Misc.warn "voice config load failed, skipping playback for %s: %s" agent_id e;
@@ -280,11 +271,7 @@ let run_local_playback ~sw:_ ~agent_id ?message ~audio_file () =
             ~duration_sec:(audio_duration_seconds ~audio_file)
         in
         File_lock_eio.with_lock (playback_lock_path ()) (fun () ->
-          let dedup_hit =
-            match message with
-            | Some m -> is_dedup_hit ~agent_id ~message:m
-            | None -> false
-          in
+          let dedup_hit = is_dedup_hit ~agent_id ~message in
           if dedup_hit then begin
             log_info (Printf.sprintf
               "voice dedup skip inside mutex: agent=%s (same message within %.0fs window)"
@@ -294,9 +281,7 @@ let run_local_playback ~sw:_ ~agent_id ?message ~audio_file () =
           else begin
             (* Record BEFORE playing so concurrent callers waiting on this mutex
                will observe the in-flight playback when they acquire it. *)
-            (match message with
-             | Some m -> record_playback ~agent_id ~message:m
-             | None -> ());
+            record_playback ~agent_id ~message;
             let rec try_candidates failures = function
               | [] ->
                 let reason =
@@ -406,15 +391,6 @@ let run_local_playback ~sw:_ ~agent_id ?message ~audio_file () =
             try_candidates [] candidates
           end)
 
-let start_local_playback ~sw ~agent_id ~audio_file =
-  ignore
-    (run_local_playback ~sw ~agent_id ~audio_file ()
-      : [ `Dedup_hit
-        | `Failed of string
-        | `Opened of float
-        | `Played of float
-        | `Skipped of string
-        ])
 
 (** Voice used when [load_voice_config ()] itself fails. This is the
     only remaining hardcoded fallback; the normal "agent not listed"

--- a/lib/voice_bridge_core/voice_bridge_core.mli
+++ b/lib/voice_bridge_core/voice_bridge_core.mli
@@ -69,12 +69,6 @@ val voice_health_uri : unit -> Uri.t
 val voice_mcp_host : unit -> string
 val voice_mcp_port : unit -> int
 
-(* RFC-0107 Phase D.2c bis-2 — [client_for_uri] / [client_for_uri_result]
-   removed.  Voice HTTP callers now route through [Masc_http_client]
-   {[post_sync]/[get_sync]/[get_response_sync]} which delegate to the
-   per-process piaf pool.  See voice_bridge_core.ml for the in-place
-   note explaining the migration. *)
-
 (** {1 Playback timeout} *)
 
 val playback_timeout_margin_sec : float
@@ -118,7 +112,7 @@ val is_dedup_hit : agent_id:string -> message:string -> bool
 val run_local_playback :
   sw:Eio.Switch.t ->
   agent_id:string ->
-  ?message:string ->
+  message:string ->
   audio_file:string ->
   unit ->
   [ `Dedup_hit | `Opened of float | `Played of float | `Skipped of string | `Failed of string ]
@@ -140,14 +134,7 @@ val run_local_playback :
     - [`Opened duration_seconds] — the file was handed to macOS [open(1)] after
       all blocking players failed. This is a GUI handoff fallback; playback
       completion is not observable from the runtime;
-    - [`Played duration_seconds] — playback succeeded.
-
-    When [message] is omitted the dedup re-check is skipped (legacy
-    callers that do not propagate the message string). *)
-
-val start_local_playback :
-  sw:Eio.Switch.t -> agent_id:string -> audio_file:string -> unit
-(** Fire-and-forget wrapper around {!run_local_playback}. *)
+    - [`Played duration_seconds] — playback succeeded. *)
 
 (** {1 Filesystem layout} *)
 

--- a/lib/voice_bridge_core/voice_bridge_transport.mli
+++ b/lib/voice_bridge_core/voice_bridge_transport.mli
@@ -5,9 +5,8 @@ val make_audio_file : unit -> string
 (** [make_audio_file ()] returns a fresh path under
     [$MASC_BASE_PATH/audio/<token>.mp3] where [token] is a 128-bit
     unguessable [Random_id.hex] value. The token doubles as the HTTP
-    capability for [/api/v1/voice/audio/:token] (RFC-0235 P1). The
-    legacy [<ts>_<agent>.mp3] name exposed agent identity in the
-    filename and was enumerable; callers that need the token call
+    capability for [/api/v1/voice/audio/:token] (RFC-0235 P1); callers
+    that need the token call
     [Filename.basename path |> Filename.chop_extension]. *)
 val read_file : string -> string
 


### PR DESCRIPTION
## 무엇이 남아 있었나

#29379 "남은 것" 의 `voice_bridge_core` 자리입니다.

`run_local_playback ~sw ~agent_id ?message ~audio_file ()` 는 `message` 가 없으면 30초 dedup 재확인을 건너뛰고 재생 기록도 남기지 않았습니다. mli 는 이를 "legacy callers that do not propagate the message string" 용이라 설명했는데, 그런 호출자는 이 모듈 안의 `start_local_playback` 하나뿐이고 그 래퍼를 부르는 곳은 lib/bin/test 에 없습니다.

## 바꾼 것

- `message` 를 필수 라벨 인자로. dedup 확인과 기록은 항상 실행됩니다.
- `start_local_playback` 삭제 (호출자 0).
- `voice_bridge_core.ml` 머리의 "Eio Migration Notes", mli 의 "RFC-0107 … client_for_uri removed … note explaining the migration" 문단, `voice_bridge_transport.mli` 의 "legacy `<ts>_<agent>.mp3` name" 서술 삭제.

실 호출자 `voice_bridge.ml:410` 과 `test_voice_runtime_overlay.ml:1030` 은 이미 `~message` 를 넘기고 있어 변경이 없습니다.

## 검증

- 변경 3파일 `ocamlc -stop-after parsing` 통과. 로컬 dune 빌드는 돌리지 않았습니다.
- 3파일 +8 −46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3a8sWueQQPyYyoXerLJvj
