### PR TITLE
chore(goal): 은퇴한 owner 묘비 reader 를 지워 goal 스키마를 닫는다

### DIFF
--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -72,11 +72,6 @@ and state_of_yojson = function
 
 and goal_of_yojson = function
   | `Assoc fields as json ->
-      (* [owner] was persisted by the immediately preceding schema.  It no
-         longer has any runtime meaning, but existing stores must remain
-         readable across the hard cut.  Keep this as a read-only tombstone:
-         the decoder accepts and drops it, while [goal_to_yojson] never writes
-         it again.  Every other field remains closed-schema strict. *)
       let accepted_fields =
         [ "id"
         ; "title"
@@ -87,7 +82,6 @@ and goal_of_yojson = function
         ; "phase"
         ; "last_review_note"
         ; "last_review_at"
-        ; "owner"
         ; "created_at"
         ; "updated_at"
         ]

--- a/lib/goal/goal_store.mli
+++ b/lib/goal/goal_store.mli
@@ -7,14 +7,10 @@
 
     - a {!Goal_phase.t} (canonical lifecycle: [Executing] / [Blocked] /
       [Completed] / [Paused] / [Dropped]) — the only persisted
-      lifecycle representation.  The retired ["owner"] field is accepted
-      and discarded on read so pre-cut stores remain available, but it is
-      never written and does not re-enter the runtime model.  ["status"] is
-      not an accepted field:
-      a row carrying it fails to decode, and {!read_state} then applies
-      the corrupt-store policy (recovery mirror if usable, otherwise an
-      empty state plus a warning).  A store written before the field was
-      dropped must be reset rather than loaded.
+      lifecycle representation.  The goal schema is closed: a row
+      carrying any other field fails to decode, and {!read_state} then
+      applies the corrupt-store policy (recovery mirror if usable,
+      otherwise an empty state plus a warning).
 
     Every type is exposed concretely because external
     callers ([test/test_dashboard_goals],

--- a/test/test_goal_store.ml
+++ b/test/test_goal_store.ml
@@ -248,28 +248,6 @@ let add_goal_field config key value =
       (`Assoc (("goals", goals) :: List.remove_assoc "goals" state_fields))
   | _ -> fail "expected persisted goal state object"
 
-let test_legacy_owner_is_read_only_tombstone () =
-  with_workspace @@ fun config ->
-  let goal = make_goal "legacy-owner" "legacy owner is ignored" in
-  Goal_store.write_state config
-    { version = 1; updated_at = iso_now (); goals = [ goal ] };
-  add_goal_field config "owner" (`String "retired-keeper");
-  let loaded = Goal_store.read_state config in
-  check int "legacy owner row remains readable" 1 (List.length loaded.goals);
-  (match Goal_store.update_goal config ~goal_id:goal.id Fun.id with
-   | Ok _ -> ()
-   | Error detail -> failf "canonical rewrite failed: %s" detail);
-  let rewritten = Yojson.Safe.from_file (Goal_store.goals_path config) in
-  let owner_persisted =
-    match rewritten with
-    | `Assoc state_fields ->
-      (match List.assoc_opt "goals" state_fields with
-       | Some (`List [ `Assoc goal_fields ]) -> List.mem_assoc "owner" goal_fields
-       | _ -> fail "expected one rewritten goal")
-    | _ -> fail "expected rewritten goal state object"
-  in
-  check bool "canonical rewrite drops legacy owner" false owner_persisted
-
 let test_other_unknown_goal_field_still_fails () =
   with_workspace @@ fun config ->
   let goal = make_goal "unknown-field" "unknown field fails" in
@@ -432,8 +410,6 @@ let () =
             test_status_field_no_longer_decodes;
           test_case "serializer omits status" `Quick
             test_serializer_omits_status;
-          test_case "legacy owner is a read-only tombstone" `Quick
-            test_legacy_owner_is_read_only_tombstone;
           test_case "other unknown goal field still fails" `Quick
             test_other_unknown_goal_field_still_fails;
           test_case "phase-less row no longer decodes" `Quick


### PR DESCRIPTION
## 무엇이 남아 있었나

`goal_of_yojson` 은 `owner` 를 accepted field 에 넣어 두고 읽으면 버렸습니다. 주석과 mli 가 "pre-cut 저장소가 계속 읽히도록 하는 read-only tombstone" 이라고 설명하는 전형적인 레거시 reader 입니다. #29339 는 이 묘비를 지우지 않고 값 검증을 **강화**하는 방향이라 반대 방향입니다(#29339 리뷰 P0).

## 바꾼 것

- `accepted_fields` 에서 `"owner"` 제거. 이제 `owner` 가 있는 행은 다른 unknown field 와 똑같이 디코드 실패 → `read_state` 의 corrupt-store 정책(복구 미러 또는 빈 상태 + 경고).
- 묘비 설명 주석과 mli 의 "retired owner … pre-cut stores remain available" 문단 삭제. mli 는 "goal 스키마는 닫혀 있다" 만 말합니다.
- `test_legacy_owner_is_read_only_tombstone` 삭제. unknown field 거부는 `test_other_unknown_goal_field_still_fails` 가 그대로 고정합니다.

## 런타임 데이터

`~/me/.masc/goals.json` 실측: goals 48건 중 `owner` 키 보유 **0건** (현재 바이너리의 `goal_to_yojson` 이 이미 쓰지 않음). 데이터 strip 단계가 필요 없습니다. 같은 디렉터리의 `goals.json.pre-owner-cut-20260822` 두 사본은 owner 키를 가진 과거 스냅샷이라 런타임 정리 대상입니다(이 PR 밖).

## 스택에 미치는 영향

#29339(`codex/fix-retired-goal-owner-tombstone`)와 #29308(그 커밋 `e58a218e27` 을 포함)은 이 PR 과 `goal_store.ml` 같은 구간을 만집니다. 이 PR 이 먼저 들어가면 #29339 는 닫고, #29308 은 main 으로 rebase 하면서 해당 커밋을 떨어뜨리면 됩니다.

## 검증

- 변경 `.ml` 2개 `ocamlc -stop-after parsing` 통과. 로컬 dune 빌드는 돌리지 않았습니다.
- 3파일 +4 −38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3a8sWueQQPyYyoXerLJvj
