### PR TITLE
chore(legacy): 벤치마크 로더의 이중 모양 리더 둘 — 뒤에 데이터가 없었다

### DIFF
--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_loader.ml
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_loader.ml
@@ -83,9 +83,7 @@ let parse_arg_check json =
         (match Eval_tool_selector.of_yojson value with
          | Ok selector -> Ok selector
          | Error msg -> errorf "invalid arg_check selector: %s" msg)
-    | None ->
-        let* tool_name = required_string_field json "tool_name" in
-        Ok (Eval_tool_selector.Tool_name tool_name)
+    | None -> errorf "arg_check requires a selector"
   in
   let* path = required_string_field json "path" in
   Ok {
@@ -162,10 +160,7 @@ let benchmark_case_of_yojson json =
 
 let tool_call_of_yojson json =
   {
-    tool_name =
-      (match Json_util.get_string json "tool_name" with
-       | Some value -> value
-       | None -> Json_util.get_string_with_default json ~key:"tool" ~default:"");
+    tool_name = Json_util.get_string_with_default json ~key:"tool_name" ~default:"";
     success = Json_util.get_bool json "success" |> Option.value ~default:false;
     input = (match member_opt "input" json with Some value -> value | None -> `Assoc []);
     output = member_opt "output" json;

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_loader.mli
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_loader.mli
@@ -50,8 +50,8 @@ val load_cases_from_file :
       category: <other>"]
     - [forbidden_tools] / [forbidden_selectors] /
       [required_selectors] / [arg_checks] default to empty lists.
-      [arg_checks] accepts either legacy [tool_name] or a structured
-      [selector] using the same schema as [required_selectors].
+      each [arg_checks] entry requires a structured [selector] using the
+      same schema as [required_selectors].
     - [recovery_policy] defaults to [None] (case has no recovery
       requirement)
 
@@ -93,7 +93,5 @@ val load_runs_from_file :
     | [route_evidence] | [None] |
     | [duration_ms] | [None] |
 
-    The [tool_name] vs [tool] alias is intentional — older
-    fixtures use [tool], newer ones use [tool_name].  Pinning
-    at the contract seam so a future "drop legacy tool field"
-    PR must touch this explicitly. *)
+    [tool_name] is the only accepted key. The [tool] alias it replaced is
+    not read: no fixture in the repo carries it and nothing writes it. *)

--- a/test/test_tool_call_quality_benchmark.ml
+++ b/test/test_tool_call_quality_benchmark.ml
@@ -414,54 +414,6 @@ let test_loader_parses_selector_backed_case_fields () =
                (List.length cases))
       | Error msg -> fail ("load_cases_from_file failed: " ^ msg))
 
-(* Regression guard for the legacy [tool_name] arg_check shape: case JSON that
-   predates typed selectors carries a bare ["tool_name"] field instead of a
-   ["selector"] object. parse_arg_check must keep parsing it as
-   [Eval_tool_selector.Tool_name], so removing that fallback fails here. *)
-let test_loader_parses_legacy_tool_name_arg_check () =
-  let path = Filename.temp_file "tool-call-quality-legacy" ".json" in
-  Fun.protect
-    ~finally:(fun () -> if Sys.file_exists path then Sys.remove path)
-    (fun () ->
-      Fs_compat.save_file path
-        {|{
-  "cases": [
-    {
-      "id": "legacy_arg_check_case",
-      "prompt": "synthetic legacy arg_check case",
-      "category": "tool_use",
-      "keeper_profiles": ["bench-selector"],
-      "forbidden_tools": [],
-      "forbidden_selectors": [],
-      "required_selectors": [],
-      "max_tool_calls": 3,
-      "success_checks": [
-        {"path": "$.status", "equals": "completed"}
-      ],
-      "arg_checks": [
-        {
-          "tool_name": "tool_read_file",
-          "path": "$.path",
-          "contains": "keeper_tool_call_log"
-        }
-      ]
-    }
-  ]
-}|};
-      match Tool_call_quality_benchmark.load_cases_from_file path with
-      | Ok [ case ] ->
-          check int "arg check count" 1
-            (List.length case.Tool_call_quality_benchmark.arg_checks);
-          let arg_check = List.hd case.Tool_call_quality_benchmark.arg_checks in
-          check string "legacy tool_name selector" "tool_name:tool_read_file"
-            (Eval_tool_selector.label
-               arg_check.Tool_call_quality_benchmark.selector)
-      | Ok cases ->
-          fail
-            (Printf.sprintf "expected one parsed case, got %d"
-               (List.length cases))
-      | Error msg -> fail ("load_cases_from_file failed: " ^ msg))
-
 (* When a case uses semantic selectors but none of the run's tool calls carry
    usable route_evidence, scoring cannot distinguish "wrong tool" from
    "missing evidence". Per the evidence-quality contract, such runs are excluded
@@ -631,8 +583,6 @@ let () =
              test_route_evidence_quality_reports_semantic_case_gaps;
            test_case "loader parses selector-backed case fields" `Quick
              test_loader_parses_selector_backed_case_fields;
-           test_case "loader parses legacy tool_name arg check" `Quick
-             test_loader_parses_legacy_tool_name_arg_check;
            test_case "route evidence quality treats empty fields as missing"
              `Quick test_route_evidence_quality_treats_empty_evidence_as_missing;
            test_case "unavailable route evidence excludes run from scoring"


### PR DESCRIPTION
## 목표

`#29379` 후속. 벤치마크 로더에 남아 있던 이중 모양 리더 둘을 지웁니다. **둘 다 뒤에 데이터가 없었습니다.**

## 1. `arg_checks` 의 `tool_name` 폴백

```ocaml
| None ->
    let* tool_name = required_string_field json "tool_name" in
    Ok (Eval_tool_selector.Tool_name tool_name)
```

회귀 가드가 자기 역할을 그대로 적어 뒀습니다.

> parse_arg_check must keep parsing it as [Eval_tool_selector.Tool_name], **so removing that fallback fails here.**

세어봤습니다 — `benchmarks/data/tool_call_quality_cases.json` 의 `arg_checks` **5개 전부 `selector`, `tool_name` 0건**. 그 형태를 보내는 유일한 곳이 자기를 지키려고 만든 합성 테스트였습니다. **폴백이 자기 테스트를 먹여 살리고 있었습니다.**

`selector` 를 필수로 하고 가드도 같이 뺐습니다.

## 2. `tool_call_of_yojson` 의 `tool` 별칭

`.mli` 주석이 예고해 뒀습니다.

> The [tool_name] vs [tool] alias is intentional — older fixtures use [tool], newer ones use [tool_name]. Pinning at the contract seam so **a future "drop legacy tool field" PR must touch this explicitly.**

이 PR 이 그겁니다. 픽스처에서 `"tool_name"` **14건**, bare `"tool"` **0건**. 라이브러리에 그 별칭을 쓰는 생산자도 없습니다.

## 왜 세고 나서 지웠나

**테스트가 어떤 모양을 단언한다는 건 누가 그 모양을 보낸다는 증거가 아닙니다.** 데이터를 세지 않으면 실패하는 테스트를 보고 "아직 쓰이는구나" 하고 물러서게 됩니다 — 그게 이 두 폴백이 살아남은 방식입니다.

이번 스윕에서 같은 구조를 네 번 만났습니다: `..._accepts_legacy_empty_response`, `test_keeper_cooldown_cause_23438`, `..._parses_legacy_tool_name_arg_check`, 그리고 위의 "removing that fallback fails here" 주석.

## 검증

```
scripts/dune-local.sh build @test/runtest-test_tool_call_quality_benchmark
                                       16 tests run, EXIT=0
ocamlformat --check (변경 3파일)        통과
```

## 관련

`#29379`(병합), `#29381`(main red 수정, 병합), `#29393`(대시보드), `#29384`(대시보드 나머지 인벤토리)
