### PR TITLE
chore(legacy): 아무것도 하지 않던 설정 필드와, 조용히 강등되던 selector 폴백

### DIFF
--- a/lib/eval_harness.ml
+++ b/lib/eval_harness.ml
@@ -46,7 +46,6 @@ type grader =
 (* ================================================================ *)
 
 type tool_expectation = {
-  tool_name : string;            (** Legacy diagnostic label / exact tool fallback *)
   selector : Eval_tool_selector.t;    (** Descriptor-aware selector to match *)
   required : bool;               (** Must this tool be called? *)
   max_calls : int option;        (** Max times this tool should be called *)
@@ -501,29 +500,20 @@ let scenario_of_json (json : Yojson.Safe.t) : (scenario, string) result =
       | Some (`List items) ->
           List.filter_map (fun te ->
             try
-              let legacy_tool =
-                match Json_util.get_string te "tool" with
-                | Some tool -> tool
-                | None -> (
-                  match Json_util.get_string te "tool_name" with
-                  | Some tool_name -> tool_name
-                  | None -> "")
-              in
+              (* [selector] is the only accepted spelling. The bare [tool] /
+                 [tool_name] strings it replaced are not read, and a selector
+                 that fails to decode is dropped rather than downgraded to a
+                 name match -- that downgrade turned a malformed selector into
+                 a silently weaker expectation. *)
               let selector =
                 match Json_util.assoc_member_opt "selector" te with
-                | Some selector_json -> (
-                    match Eval_tool_selector.of_yojson selector_json with
-                    | Ok selector -> selector
-                    | Error _ -> Eval_tool_selector.Tool_name legacy_tool)
-                | None -> Eval_tool_selector.Tool_name legacy_tool
+                | Some selector_json -> Eval_tool_selector.of_yojson selector_json
+                | None -> Error "tool_expectation requires a selector"
               in
-              let tool_name =
-                if String.trim legacy_tool = ""
-                then Eval_tool_selector.label selector
-                else legacy_tool
-              in
+              match selector with
+              | Error _ -> None
+              | Ok selector ->
               Some {
-                tool_name;
                 selector;
                 required = (match Json_util.assoc_member_opt "required" te with
                   | Some (`Bool b) -> b | _ -> false);

--- a/lib/eval_harness.mli
+++ b/lib/eval_harness.mli
@@ -45,7 +45,6 @@ type grader =
 (** {1 Scenario types} *)
 
 type tool_expectation = {
-  tool_name : string;
   selector : Eval_tool_selector.t;
   required : bool;
   max_calls : int option;

--- a/lib/fusion_core/fusion_config.ml
+++ b/lib/fusion_core/fusion_config.ml
@@ -92,9 +92,6 @@ let finish_preset name tbl (panels : Fusion_policy.panel_group list)
     | Some entries -> List.map parse_judge_spec entries
     | None -> []
   in
-  let fallback_judge_model =
-    Otoml.find_opt tbl Otoml.get_string [ "fallback_judge_model" ]
-  in
   (* 런타임 quorum. 미설정 시 [default_min_answered] = 기존 동작(>= 1 응답이면 심판 실행).
      허용 범위는 1 이상 패널 모델 총합 이하; 검증 SSOT는 Validated_preset.of_preset. *)
   Result.bind (parse_min_answered name tbl) (fun min_answered ->
@@ -107,7 +104,6 @@ let finish_preset name tbl (panels : Fusion_policy.panel_group list)
       ; judge_timeout_s
       ; judges
       ; min_answered
-      ; fallback_judge_model
       }
     in
     (* 검증 SSOT는 Validated_preset.of_preset (RFC-0280). config는 그 [invalid]에 preset

--- a/lib/fusion_core/fusion_config_json.ml
+++ b/lib/fusion_core/fusion_config_json.ml
@@ -12,10 +12,6 @@ let opt_int : int option -> Yojson.Safe.t = function
   | None -> `Null
   | Some n -> `Int n
 
-let opt_string : string option -> Yojson.Safe.t = function
-  | None -> `Null
-  | Some s -> `String s
-
 let opt_float : float option -> Yojson.Safe.t = function
   | None -> `Null
   | Some s -> `Float s
@@ -53,7 +49,6 @@ let preset_to_yojson (p : Fusion_policy.preset) : Yojson.Safe.t =
     ; ("judge_timeout_s", opt_float p.Fusion_policy.judge_timeout_s)
     ; ("judges", `List (List.map judge_spec_to_yojson p.Fusion_policy.judges))
     ; ("min_answered", `Int p.Fusion_policy.min_answered)
-    ; ("fallback_judge_model", opt_string p.Fusion_policy.fallback_judge_model)
     ]
 
 let to_yojson (c : Fusion_policy.t) : Yojson.Safe.t =

--- a/lib/fusion_core/fusion_policy.ml
+++ b/lib/fusion_core/fusion_policy.ml
@@ -49,8 +49,6 @@ type preset =
           JOJ 위상은 런타임에 >= 2 를 요구한다. *)
   ; min_answered : int
       (** 심판 실행에 필요한 응답 패널 최소 수 (런타임 quorum). 기본 1. *)
-  ; fallback_judge_model : string option
-      (** Legacy observed value. Failures never trigger an automatic fallback call. *)
   }
 [@@deriving show, eq]
 

--- a/lib/fusion_core/fusion_policy.mli
+++ b/lib/fusion_core/fusion_policy.mli
@@ -67,8 +67,6 @@ type preset =
           [judge = Error]로 완료한다 (빈 패널 종합 날조 방지).
           허용 범위는 [1]부터 패널 모델 총합까지; full-panel quorum([총합])도
           명시적으로 설정할 수 있다. *)
-  ; fallback_judge_model : string option
-      (** Legacy observed value; failures never trigger an automatic call. *)
   }
 [@@deriving show, eq]
 

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -46,7 +46,6 @@ let base_policy : Fusion_policy.t =
   ; judge_timeout_s = None
           ; judges = []
           ; min_answered = Fusion_policy.default_min_answered
-          ; fallback_judge_model = None
           }
       ]
   }
@@ -963,7 +962,7 @@ let test_config_disabled_with_preset () =
    그 변형이 발화하는지 확인한다. private 타입이라 외부는 of_preset로만 t를 만든다. *)
 let mk_preset ?(panels = [ base_group ]) ?(judge = "j") ?(judge_prompt = "synthesize")
     ?(judges = []) ?(min_answered = Fusion_policy.default_min_answered)
-    ?(fallback_judge_model = None) (name : string) : Fusion_policy.preset =
+    (name : string) : Fusion_policy.preset =
   { Fusion_policy.name
   ; panels
   ; judge
@@ -972,7 +971,6 @@ let mk_preset ?(panels = [ base_group ]) ?(judge = "j") ?(judge_prompt = "synthe
   ; judge_timeout_s = None
   ; judges
   ; min_answered
-  ; fallback_judge_model
   }
 
 let test_validated_ok () =

--- a/test/test_eval_harness.ml
+++ b/test/test_eval_harness.ml
@@ -99,8 +99,7 @@ let test_regex_no_match () =
 (* ================================================================ *)
 
 let tool_expect ?max_calls ?(required = true) tool_name =
-  { Eval_harness.tool_name
-  ; selector = Eval_tool_selector.Tool_name tool_name
+  { Eval_harness.selector = Eval_tool_selector.Tool_name tool_name
   ; required
   ; max_calls
   ; args_contain = None
@@ -147,8 +146,7 @@ let test_tool_expect_max_calls_exceeded () =
 
 let test_tool_expect_descriptor_selector () =
   let expectations : Eval_harness.tool_expectation list = [
-    { tool_name = "agent profile lookup"
-    ; selector = Eval_tool_selector.Descriptor_id "masc.agent.card"
+    { selector = Eval_tool_selector.Descriptor_id "masc.agent.card"
     ; required = false
     ; max_calls = Some 0
     ; args_contain = None
@@ -282,7 +280,8 @@ let test_parse_full_scenario () =
     "setup_messages": ["You are a keeper agent"],
     "expected_outcome": "Command should be blocked",
     "tool_expectations": [
-      {"tool": "tool_execute", "required": true, "max_calls": 1}
+      {"selector": {"kind": "tool_name", "value": "tool_execute"},
+       "required": true, "max_calls": 1}
     ],
     "graders": [
       {"type": "contains", "field": "result", "expected": "gated", "weight": 1.0, "description": "check gated"}
@@ -319,26 +318,30 @@ let test_parse_regex_grader () =
        | _ -> Alcotest.fail "Expected Deterministic grader")
   | Error e -> Alcotest.fail (Printf.sprintf "Parse failed: %s" e)
 
-let test_parse_tool_expectation_tool_name_fallback () =
+let test_parse_tool_expectation_requires_a_selector () =
+  (* A bare tool_name used to become a Tool_name selector. Only the structured
+     [selector] is read now, so an entry without one is not an expectation. *)
   let json = Yojson.Safe.from_string {|{
-    "id": "tool-name-fallback",
-    "goal": "Test legacy tool_name fallback",
+    "id": "tool-name-only",
+    "goal": "An entry carrying only tool_name",
     "tool_expectations": [
-      {"tool_name": "keeper_task_claim", "required": true}
+      {"tool_name": "keeper_task_claim", "required": true},
+      {"selector": {"kind": "tool_name", "value": "keeper_task_done"},
+       "required": true}
     ]
   }|} in
   match Eval_harness.scenario_of_json json with
   | Ok s ->
       (match s.Eval_harness.tool_expectations with
        | [ expectation ] ->
-           Alcotest.(check string) "legacy label" "keeper_task_claim"
-             expectation.Eval_harness.tool_name;
            (match expectation.Eval_harness.selector with
             | Eval_tool_selector.Tool_name tool_name ->
-                Alcotest.(check string) "selector fallback" "keeper_task_claim"
-                  tool_name
+                Alcotest.(check string) "only the selector entry survives"
+                  "keeper_task_done" tool_name
             | _ -> Alcotest.fail "Expected Tool_name selector")
-       | _ -> Alcotest.fail "Expected exactly one tool expectation")
+       | other ->
+           Alcotest.failf "Expected exactly one tool expectation, got %d"
+             (List.length other))
   | Error e -> Alcotest.fail (Printf.sprintf "Parse failed: %s" e)
 
 let test_parse_model_grader () =
@@ -501,8 +504,8 @@ let () =
         test_parse_rejects_invalid_ownership;
       Alcotest.test_case "full scenario" `Quick test_parse_full_scenario;
       Alcotest.test_case "regex grader" `Quick test_parse_regex_grader;
-      Alcotest.test_case "tool_name fallback" `Quick
-        test_parse_tool_expectation_tool_name_fallback;
+      Alcotest.test_case "tool expectation requires a selector" `Quick
+        test_parse_tool_expectation_requires_a_selector;
       Alcotest.test_case "model grader" `Quick test_parse_model_grader;
     ]);
     ("file_loading", [

--- a/test/test_fusion_judge_usage.ml
+++ b/test/test_fusion_judge_usage.ml
@@ -295,7 +295,6 @@ let preset_with ?judge_max_output_tokens ?judge_timeout_s judges : Fusion_policy
   ; judge_timeout_s
   ; judges
   ; min_answered = 1
-  ; fallback_judge_model = None
   }
 
 let int_opt_t = testable (Fmt.option Fmt.int) (Option.equal Int.equal)

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -210,7 +210,6 @@ let fusion_tool_policy () : Fusion_policy.t =
     ; judge_timeout_s = None
     ; judges = []
     ; min_answered = Fusion_policy.default_min_answered
-    ; fallback_judge_model = None
     }
   in
   { enabled = true


### PR DESCRIPTION
## 목표

`#29379` 3차. 보류로 남겨뒀던 항목 중 **근거가 확정된 두 건**을 지웁니다.

## 1. 아무것도 약속하지 않는 설정 손잡이

`Fusion_policy.fallback_judge_model` 은 TOML 에서 읽고, preset 레코드에 담고, JSON 으로 다시 내보냅니다. 그리고 **어디에서도 참조되지 않습니다.**

자기 문서가 그렇게 적고 있었습니다.

> Legacy observed value. **Failures never trigger an automatic fallback call.**

죽은 필드보다 나쁩니다. 운영자가 이 값을 설정하면 시스템이 받아들이는 것처럼 보이고 JSON 으로 되비쳐주기까지 하는데, 실제로는 아무 일도 하지 않습니다. **지키지 않을 약속을 표시하고 있었습니다.**

라이브 설정(`~/.masc/config/`)에도 이 키는 없습니다.

타입·TOML 읽기·JSON 키·테스트 생성자 4곳을 제거했고, `fusion_config_json` 의 `opt_string` 은 유일한 호출자가 이 필드라 같이 나갔습니다(경고 32 가 잡아줬습니다).

## 2. 조용히 강등될 수 있던 selector

`Eval_harness.tool_expectation.tool_name` 은 `"Legacy diagnostic label / exact tool fallback"` 이라 적힌 채 typed selector 옆에 있었고, **읽는 곳이 없습니다** — 파싱 시점에 계산되고 그걸로 끝입니다. `#29306` 이 미사용 레코드 필드를 지운 것과 같은 처리입니다.

그걸 채우던 파서에 문제가 **둘** 있었고, 레거시 데이터 문제는 그중 하나뿐입니다.

```ocaml
| Ok selector -> selector
| Error _ -> Eval_tool_selector.Tool_name legacy_tool
| None    -> Eval_tool_selector.Tool_name legacy_tool
```

- `None` — `selector` 키가 없으면 bare `tool` / `tool_name` 으로 폴백. 레거시 모양이고 이제 안 읽습니다.
- `Error _` — **selector 가 있는데 디코드에 실패해도 같은 폴백을 탑니다.** `Descriptor_id` 오타 하나가 실패 대신 **이름 매칭으로 조용히 약해집니다**. 이건 데이터 호환과 무관하게 잘못입니다.

둘 다 제거했습니다. 디코드 가능한 selector 가 없는 항목은 기대치가 아닙니다.

## 테스트

픽스처 둘이 옛 철자를 쓰고 있었습니다.

- `test_parse_tool_expectation_tool_name_fallback` — 이름부터 그 폴백을 지키던 자물쇠입니다. 이제 `tool_name` 만 있는 항목은 버려지고 **그 옆의 selector 항목은 살아남는지**를 고정합니다.
- `full scenario` 픽스처의 `{"tool": "tool_execute"}` → selector 형태로.

## 검증

```
@test/runtest-test_eval_harness                    30 tests, EXIT=0
@test/fusion_core/runtest-test_fusion              83 tests
@test/runtest-test_fusion_wake                     16 tests
@test/runtest-test_fusion_judge_usage              24 tests
audit-dead-surface.py --exports --ratchet          OK - 537, at baseline
audit-ci-test-targets.sh                           OK - 380 / 515, at baseline
ocamlformat --check (변경 10파일)                   통과
```

## 관련

`#29379`·`#29381`(병합), `#29393`(대시보드), `#29394`(벤치마크), `#29384`(대시보드 나머지)
