### PR TITLE
test: honor Dashboard warm-up in Keeper browser proof

### DIFF
--- a/dashboard/e2e/keeper-composition-browser-evidence.mjs
+++ b/dashboard/e2e/keeper-composition-browser-evidence.mjs
@@ -1,5 +1,19 @@
 const EXPECTED_INLINE_NODES = ['board', 'board-peer', 'clock', 'memory']
 
+// namespace-truth-actions.ts retries a cold project snapshot after
+// 3s/5s/10s/20s and then at the 30s cap for the remaining attempts. Its
+// complete ten-retry budget is 218s, so the real-backend proof must not fail
+// at Playwright's 30s default while the product is still inside its declared
+// warm-up window. The composer is the user-visible readiness boundary: it is
+// rendered only after the selected Keeper exists in the live registry.
+export const DASHBOARD_KEEPER_READY_TIMEOUT_MS = 240_000
+
+export async function waitForKeeperComposerReady(page) {
+  await page.getByLabel('메시지 입력').waitFor({
+    timeout: DASHBOARD_KEEPER_READY_TIMEOUT_MS,
+  })
+}
+
 export function selectCompleteInlineRun(rows) {
   const byRun = new Map()
   for (const row of rows) {

--- a/dashboard/e2e/keeper-composition-browser-evidence.test.mjs
+++ b/dashboard/e2e/keeper-composition-browser-evidence.test.mjs
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { selectCompleteInlineRun } from './keeper-composition-browser-evidence.mjs'
+import {
+  DASHBOARD_KEEPER_READY_TIMEOUT_MS,
+  selectCompleteInlineRun,
+  waitForKeeperComposerReady,
+} from './keeper-composition-browser-evidence.mjs'
 
 const completeRows = ['board', 'board-peer', 'clock', 'memory'].map(node => ({
   run: 'run-complete',
@@ -28,4 +32,26 @@ test('rejects duplicate, failed, deferred, and async rows', () => {
   assert.equal(selectCompleteInlineRun(
     completeRows.map(row => ({ ...row, execution: 'async' })),
   ), null)
+})
+
+test('waits through the complete Dashboard project-snapshot warm-up budget', async () => {
+  const calls = []
+  const page = {
+    getByLabel(label) {
+      calls.push({ kind: 'label', label })
+      return {
+        async waitFor(options) {
+          calls.push({ kind: 'wait', options })
+        },
+      }
+    },
+  }
+
+  await waitForKeeperComposerReady(page)
+
+  assert.deepEqual(calls, [
+    { kind: 'label', label: '메시지 입력' },
+    { kind: 'wait', options: { timeout: DASHBOARD_KEEPER_READY_TIMEOUT_MS } },
+  ])
+  assert.ok(DASHBOARD_KEEPER_READY_TIMEOUT_MS > 218_000)
 })

--- a/dashboard/e2e/keeper-composition-real-backend.mjs
+++ b/dashboard/e2e/keeper-composition-real-backend.mjs
@@ -2,7 +2,10 @@ import { chromium } from 'playwright'
 import { createHash } from 'node:crypto'
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { selectCompleteInlineRun } from './keeper-composition-browser-evidence.mjs'
+import {
+  selectCompleteInlineRun,
+  waitForKeeperComposerReady,
+} from './keeper-composition-browser-evidence.mjs'
 
 function required(name) {
   const value = process.env[name]?.trim()
@@ -79,7 +82,7 @@ try {
   route.searchParams.set('token', token)
   route.hash = `monitoring?section=agents&keeper=${encodeURIComponent(keeperName)}`
   await page.goto(route.toString())
-  await page.getByLabel('메시지 입력').waitFor()
+  await waitForKeeperComposerReady(page)
   await page.getByTestId('kw-chat-command-menu-toggle').click()
   await page.getByTestId('kw-chat-command-detail').click()
   await page.getByRole('tab', { name: '진단', exact: true }).click()


### PR DESCRIPTION
## Summary
- wait for the selected Keeper composer through the Dashboard's full bounded project-snapshot warm-up window
- keep the composer as the user-visible readiness boundary instead of substituting an API-only assertion
- pin the 240s readiness timeout with a focused Node regression test

## Protected-main evidence
Exact merge `d7abd90633bcac261843613e6d6d0a306006287d`, workflow `32517449248`:
- RW23 passed the canonical producer path and original Task contract
- Task `task-009` was independently rejected (`vrf-412e300a6c9aee960fee0f6a8c56cce0`) and then approved (`vrf-c1759d85afbd81cc48f24ae04d4fd0d7`)
- Goal proof was refuted (`01a025eb-32bb-7000-894e-c30ef74b6ca3`) and then proven/completed (`01a025eb-f2e4-7000-aef4-728d04678d2a`)
- the run then failed in the real-backend browser proof because Playwright waited 30s for `메시지 입력` while the UI was still at project-snapshot warm-up retry 4/10

Dashboard's declared retry schedule is 3s/5s/10s/20s and then the 30s cap through ten attempts: 218s total. The proof now waits 240s, still bounded, before declaring the user-visible Keeper detail unavailable.

This PR does not promote the failed run to PASS and does not claim same-run browser evidence.

## Validation
- `node --check` on both evidence and real-backend scripts
- `node --test dashboard/e2e/keeper-composition-browser-evidence.test.mjs` — 3/3 PASS
- `git diff --check`
