### PR TITLE
chore(legacy): target 없는 External_effect_completed 응답을 거부 (스윕 마지막 계약)

### DIFF
--- a/lib/server/server_keeper_chat_agui_projection.ml
+++ b/lib/server/server_keeper_chat_agui_projection.ml
@@ -103,9 +103,11 @@ let project ~timestamp ~redact_text ~redact_json state event =
              ~run_id:state.run_id ~message_id:state.message_id
              Ag_ui.Text_message_end) )
   | External_effect_completed { target } ->
-      (* [`Null] is the legacy wire value; a typed target upgrades it to an
-         object naming the real destination so the dashboard stops assuming
-         an external connector (#28374). *)
+      (* The reply decoder rejects an External_effect_completed payload with no
+         target, so [None] does not reach here from a live turn; the arm stays
+         because the event type carries the same option every other outcome
+         uses. A typed target names the real destination so the dashboard stops
+         assuming an external connector (#28374). *)
       let value =
         match target with
         | None -> `Null

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -881,8 +881,13 @@ let canonical_reply_payload_of_body ~redact_text body =
     | None -> Error Invalid_turn_ref
   in
   let* external_effect_target =
-    (* Absent on legacy payloads that predate the field; present means the
-       producer serialized a typed delivery target and it must decode. *)
+    (* Absent means the turn recorded no surface-post receipt, which is the
+       live shape for every outcome except External_effect_completed. That
+       outcome and the receipt are decided from the same
+       [terminal_effect_state] (keeper_agent_run.ml:1064-1076), so a completed
+       external effect always serializes its target. A payload claiming the
+       outcome without one predates the field, and is rejected rather than
+       projected downstream as a null destination. *)
     match
       List.filter_map
         (fun (key, value) ->
@@ -891,7 +896,14 @@ let canonical_reply_payload_of_body ~redact_text body =
            else None)
         fields
     with
-    | [] -> Ok None
+    | [] ->
+      if
+        Keeper_turn_outcome.equal turn_outcome
+          Keeper_turn_outcome.External_effect_completed
+      then
+        Error
+          (Missing_payload_field Keeper_surface_post.delivery_target_wire_key)
+      else Ok None
     | [ value ] ->
       (match Keeper_surface_post.delivery_target_of_yojson value with
        | Ok target -> Ok (Some target)

--- a/scripts/audit-dead-surface.py
+++ b/scripts/audit-dead-surface.py
@@ -561,7 +561,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 # (measured 2026-08-20: 539). The one count of slack predates this change;
 # goal_verification's exports all have callers (dashboard joins + tests), so
 # the ledger added none.
-DEAD_EXPORT_BASELINE = 537
+DEAD_EXPORT_BASELINE = 536
 
 
 def run_ratchet(count: int) -> int:

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -105,15 +105,16 @@ let test_external_effect_completed_has_no_direct_reply_error () =
 
 let test_canonical_payload_carries_delivery_target () =
   let turn_ref = Ids.Turn_ref.make ~trace_id:"post-target" ~absolute_turn:3 in
-  let body_with target_json =
+  let body_for outcome target_json =
     `Assoc
       ([ "reply", `String ""
-       ; TO.wire_key, `String (TO.to_label TO.External_effect_completed)
+       ; TO.wire_key, `String (TO.to_label outcome)
        ; TO.turn_ref_wire_key, Ids.Turn_ref.to_yojson turn_ref
        ]
        @ target_json)
     |> Yojson.Safe.to_string
   in
+  let body_with = body_for TO.External_effect_completed in
   (match
      Stream.For_testing.canonical_reply_payload_of_body ~redact_text:Fun.id
        (body_with
@@ -130,14 +131,31 @@ let test_canonical_payload_carries_delivery_target () =
      fail
        (Server_routes_http_keeper_stream.canonical_reply_payload_error_to_string
           error));
+  (* The outcome and the receipt come from the same terminal_effect_state
+     (keeper_agent_run.ml:1064-1076), so a completed external effect always
+     serializes its target. A payload claiming the outcome without one predates
+     the field and is rejected rather than projected as a null destination. *)
   (match
      Stream.For_testing.canonical_reply_payload_of_body ~redact_text:Fun.id
        (body_with [])
    with
+   | Error (Server_routes_http_keeper_stream.Missing_payload_field field) ->
+     check string "the missing field is named" "external_effect_target" field
+   | Error other ->
+     fail
+       (Server_routes_http_keeper_stream.canonical_reply_payload_error_to_string
+          other)
+   | Ok _ ->
+     fail "External_effect_completed without a target must be rejected");
+  (* Absence is the ordinary shape for every other outcome. *)
+  (match
+     Stream.For_testing.canonical_reply_payload_of_body ~redact_text:Fun.id
+       (body_for TO.Visible_reply [])
+   with
    | Ok canonical ->
      (match canonical.external_effect_target with
       | None -> ()
-      | Some _ -> fail "legacy payload without the field must decode to None")
+      | Some _ -> fail "a visible reply carries no delivery target")
    | Error error ->
      fail
        (Server_routes_http_keeper_stream.canonical_reply_payload_error_to_string


### PR DESCRIPTION
## 목표

`#29379` 스윕에서 **"계약 미정"으로 보류했던 마지막 항목**을 근거를 만들어 판정합니다.

## 왜 보류했었나

디코더 주석이 이렇게 적혀 있었습니다.

> Absent on legacy payloads that predate the field; present means the producer serialized a typed delivery target and it must decode.

필드를 필수로 만들면 될 것 같지만 안 됩니다. **부재가 다른 모든 결과에서는 정상**이기 때문입니다 — 아무것도 게시하지 않은 턴은 직렬화할 surface-post 수신증이 없습니다. `None` 하나가 두 가지를 뜻하고 있었고, 어느 쪽으로 지워도 틀립니다.

## 근거

결과와 수신증이 **같은 곳에서 결정됩니다.**

```ocaml
(* keeper_agent_run.ml:1064-1076 *)
match terminal_effect_state with
| Terminal_effect_completed receipt -> Some receipt     (* 수신증 *)
...
match terminal_effect_state with
| Terminal_effect_completed _ -> Ok External_effect_completed   (* 결과 *)
```

그리고 쓰는 쪽(`keeper_turn.ml:785-793`)은 수신증이 `Some` 이면 **반드시** 필드를 넣습니다.

즉 `External_effect_completed` 를 실은 payload 에 target 이 없다면, **이 writer 가 만든 것일 수 없습니다.**

## 무엇이 바뀌나

그런 payload 는 이제 `Missing_payload_field` 로 실패합니다. 전에는 `None` 으로 흘러가 AG-UI 투영이 `` `Null `` 을 delivery target 으로 발행했고, **대시보드는 목적지 없는 완료된 외부 효과를 읽었습니다.**

투영의 `None` arm 은 남깁니다 — 이벤트 타입이 다른 모든 결과와 같은 option 을 씁니다. 다만 주석에서 `` `Null `` 을 *"the legacy wire value"* 라 부르던 것은 뺐습니다. 이제 디코더가 그걸 건네주지 않으니까요.

## 테스트

`test_canonical_payload_carries_delivery_target` 이 이름으로 옛 동작을 고정하고 있었습니다.

```ocaml
| Some _ -> fail "legacy payload without the field must decode to None"
```

픽스처가 **항상 `External_effect_completed`** 를 씁니다. 이제 거부를 고정하고, **반대편도 함께** 못 박았습니다 — `Visible_reply` 에 target 이 없는 것은 여전히 `None` 입니다. 한쪽만 고정하면 다음 사람이 나머지 절반을 같은 레거시로 오해하고 지웁니다.

## 검증

```
scripts/dune-local.sh build @check                     CHECK_EXIT=0
@test/runtest-test_keeper_turn_outcome                 28 tests, EXIT=0
@test/runtest-test_keeper_chat_slack                   35 tests
@test/runtest-test_keeper_chat_discord                 19 tests
audit-dead-surface.py --exports --ratchet              OK - 536, at baseline
audit-ci-test-targets.sh                               OK - 380 / 515, at baseline
ocamlformat --check (변경 4파일)                        통과
```

`DEAD_EXPORT_BASELINE` 537 → 536: `Missing_payload_field` 가 첫 호출자를 얻었습니다.

## 스윕 종료 상태

이 PR 이후 남는 것은 **지우면 안 되는 것들뿐**입니다.

- **하드컷 4곳** — `durable_event`(`input_tokens` 거부), `checkpoint`(legacy 필드 거부), `prompt_override_persistence`(bare legacy map 을 typed error 로), `board_tool_handlers`(옛 vote 파라미터 거부). `legacy` 라는 단어를 담고 있지만 하는 일은 **레거시를 막는 것**입니다. 지우면 이 스윕이 되돌리려던 것이 되살아납니다.
- **이름만 legacy 2곳** — `event_bus_slots`(버스 미설치 도메인 폴백), `runtime_observation.attempt_details_source`(메트릭 sink 배선 진단축). 낡은 데이터와 무관합니다.

## 관련

`#29379` · `#29381` · `#29393` · `#29394` · `#29395` (모두 병합), `#29384`
