### PR TITLE
docs: v0.24.0 을 최신 공개 릴리즈로 기록

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Current package version: v0.24.0
 > Latest changelog entry: v0.24.0 (2026-08-22)
-> Latest published GitHub release: v0.21.1 (2026-07-20)
+> Latest published GitHub release: v0.24.0 (2026-08-22)
 > Updated: 2026-08-22
 
 This roadmap is the 6-8 week operating view for `masc`. It is a planning document, not a release promise.

--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -11,7 +11,7 @@ code_refs:
 
 > Current package version: v0.24.0
 > Latest changelog entry: v0.24.0 (2026-08-22)
-> Latest published GitHub release: v0.21.1 (2026-07-20)
+> Latest published GitHub release: v0.24.0 (2026-08-22)
 > Updated: 2026-08-16
 > Release line: pre-1.0 (`0.y.z`)
 


### PR DESCRIPTION
release.yml 32530843742 가 linux-x64 / linux-arm64 / macos-arm64 세 빌드 모두 success 로 끝나 GitHub Release v0.24.0 이 2026-08-21T22:11Z 에 공개됐습니다(바이너리 3 + preflight helper 3 + evidence 번들). ROADMAP 과 운영계획의 "Latest published GitHub release" 를 v0.21.1 → v0.24.0 으로 올립니다. `check-version-truth.sh` / `check-doc-truth.sh` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3a8sWueQQPyYyoXerLJvj