### PR TITLE
fix(verifier): carry retryable runtime lane failure

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -229,16 +229,7 @@ let attempt_runtime_candidates
      overflow and let it represent a naturally exhausted lane. A lane that
      stops on a non-recoverable error keeps that error: it is the immediate
      operator signal, and the overflow will be observed again on the next
-     cycle.
-
-     Retryability is also a lane-wide fact once every declared candidate has
-     been attempted without crossing an effect boundary.  A transient failure
-     on an earlier candidate must not be masked by a statically unavailable
-     terminal fallback: the earlier provider may recover on the next worker
-     cycle even though the fallback cannot.  Keep the first actual retryable
-     error as the exhausted lane's representative; every candidate-specific
-     failure, including the terminal fallback, remains in the runtime
-     manifest.  This does not override a mid-walk terminal or an effect fence. *)
+     cycle. *)
   let quota_scope_of =
     match quota_scope_of with
     | Some quota_scope_of -> quota_scope_of
@@ -274,19 +265,16 @@ let attempt_runtime_candidates
       dispatchable
     @ undispatchable
   in
-  let rec loop ~observed_overflow ~observed_retryable_error idx = function
+  let rec loop ~observed_overflow idx = function
     | [] ->
       (match observed_overflow with
        | Some overflow_error -> Error overflow_error
        | None ->
-         (match observed_retryable_error with
-          | Some retryable_error -> Error retryable_error
-          | None ->
-            Error
-              (Agent_core.Error.Internal
-                 (Printf.sprintf
-                    "runtime lane %S exhausted all candidates"
-                    runtime_id))))
+         Error
+           (Agent_core.Error.Internal
+              (Printf.sprintf
+                 "runtime lane %S exhausted all candidates"
+                 runtime_id)))
     | candidate :: rest ->
       let is_last = rest = [] in
       let attempt_runtime_id = runtime_id_of candidate in
@@ -402,12 +390,6 @@ let attempt_runtime_candidates
              ~allow_accept_no_progress_retry
              error
          in
-         let observed_retryable_error =
-           match observed_retryable_error with
-           | Some _ -> observed_retryable_error
-           | None ->
-             if Agent_core.Error.is_retryable error then Some error else None
-         in
          let observed_overflow =
            match observed_overflow with
            | Some _ -> observed_overflow
@@ -421,26 +403,16 @@ let attempt_runtime_candidates
          if not effect_retry_admitted
          then Error terminal_error
          else if retry_admitted && error_is_retryable
-         then
-           loop
-             ~observed_overflow
-             ~observed_retryable_error
-             (idx + 1)
-             rest
+         then loop ~observed_overflow (idx + 1) rest
          else if is_last
          then (
            (* Lane fully exhausted: an overflow seen anywhere in the rotation
               outranks the last candidate's error so the failure route and
-              blocker report the deterministic capacity bound. Otherwise an
-              earlier retryable error keeps the lane eligible for a later
-              worker cycle instead of letting a terminal fallback mask it.
-              Cascade telemetry already published each candidate's own error. *)
+              blocker report the deterministic capacity bound. Cascade
+              telemetry already published each candidate's own error. *)
            match observed_overflow with
            | Some overflow_error -> Error overflow_error
-           | None ->
-             (match observed_retryable_error with
-              | Some retryable_error -> Error retryable_error
-              | None -> Error error))
+           | None -> Error error)
          else (
            (match error_is_retryable, effect_retry_admitted, rest with
             | true, true, next :: later ->
@@ -454,7 +426,7 @@ let attempt_runtime_candidates
             | false, _, _ | true, false, _ | true, true, [] -> ());
            Error terminal_error))
   in
-  loop ~observed_overflow:None ~observed_retryable_error:None 0 candidates
+  loop ~observed_overflow:None 0 candidates
 
 let runtime_candidate_missing_error id =
   Agent_core.Error.Internal

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -229,7 +229,16 @@ let attempt_runtime_candidates
      overflow and let it represent a naturally exhausted lane. A lane that
      stops on a non-recoverable error keeps that error: it is the immediate
      operator signal, and the overflow will be observed again on the next
-     cycle. *)
+     cycle.
+
+     Retryability is also a lane-wide fact once every declared candidate has
+     been attempted without crossing an effect boundary.  A transient failure
+     on an earlier candidate must not be masked by a statically unavailable
+     terminal fallback: the earlier provider may recover on the next worker
+     cycle even though the fallback cannot.  Keep the first actual retryable
+     error as the exhausted lane's representative; every candidate-specific
+     failure, including the terminal fallback, remains in the runtime
+     manifest.  This does not override a mid-walk terminal or an effect fence. *)
   let quota_scope_of =
     match quota_scope_of with
     | Some quota_scope_of -> quota_scope_of
@@ -265,16 +274,19 @@ let attempt_runtime_candidates
       dispatchable
     @ undispatchable
   in
-  let rec loop ~observed_overflow idx = function
+  let rec loop ~observed_overflow ~observed_retryable_error idx = function
     | [] ->
       (match observed_overflow with
        | Some overflow_error -> Error overflow_error
        | None ->
-         Error
-           (Agent_core.Error.Internal
-              (Printf.sprintf
-                 "runtime lane %S exhausted all candidates"
-                 runtime_id)))
+         (match observed_retryable_error with
+          | Some retryable_error -> Error retryable_error
+          | None ->
+            Error
+              (Agent_core.Error.Internal
+                 (Printf.sprintf
+                    "runtime lane %S exhausted all candidates"
+                    runtime_id))))
     | candidate :: rest ->
       let is_last = rest = [] in
       let attempt_runtime_id = runtime_id_of candidate in
@@ -390,6 +402,12 @@ let attempt_runtime_candidates
              ~allow_accept_no_progress_retry
              error
          in
+         let observed_retryable_error =
+           match observed_retryable_error with
+           | Some _ -> observed_retryable_error
+           | None ->
+             if Agent_core.Error.is_retryable error then Some error else None
+         in
          let observed_overflow =
            match observed_overflow with
            | Some _ -> observed_overflow
@@ -403,16 +421,26 @@ let attempt_runtime_candidates
          if not effect_retry_admitted
          then Error terminal_error
          else if retry_admitted && error_is_retryable
-         then loop ~observed_overflow (idx + 1) rest
+         then
+           loop
+             ~observed_overflow
+             ~observed_retryable_error
+             (idx + 1)
+             rest
          else if is_last
          then (
            (* Lane fully exhausted: an overflow seen anywhere in the rotation
               outranks the last candidate's error so the failure route and
-              blocker report the deterministic capacity bound. Cascade
-              telemetry already published each candidate's own error. *)
+              blocker report the deterministic capacity bound. Otherwise an
+              earlier retryable error keeps the lane eligible for a later
+              worker cycle instead of letting a terminal fallback mask it.
+              Cascade telemetry already published each candidate's own error. *)
            match observed_overflow with
            | Some overflow_error -> Error overflow_error
-           | None -> Error error)
+           | None ->
+             (match observed_retryable_error with
+              | Some retryable_error -> Error retryable_error
+              | None -> Error error))
          else (
            (match error_is_retryable, effect_retry_admitted, rest with
             | true, true, next :: later ->
@@ -426,7 +454,7 @@ let attempt_runtime_candidates
             | false, _, _ | true, false, _ | true, true, [] -> ());
            Error terminal_error))
   in
-  loop ~observed_overflow:None 0 candidates
+  loop ~observed_overflow:None ~observed_retryable_error:None 0 candidates
 
 let runtime_candidate_missing_error id =
   Agent_core.Error.Internal

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -211,6 +211,7 @@ let attempt_runtime_candidates
       true)
     ?lane_id
     ?(on_retry_deferred = fun _ -> ())
+    ?(on_attempt_error = fun ~runtime_id:_ ~attempt:_ _error -> ())
     ?quota_scope_of
     ?candidate_dispatchable
     ~runtime_id ~runtime_id_of
@@ -308,6 +309,10 @@ let attempt_runtime_candidates
            ~status:"failed"
            ~decision:(runtime_failed_decision ~idx ~runtime_id:attempt_runtime_id error)
            Keeper_runtime_manifest.Runtime_failed;
+         on_attempt_error
+           ~runtime_id:attempt_runtime_id
+           ~attempt:idx
+           error;
          (* A hard-quota rejection with a provider-stated reset time is an
             account-scoped fact; remember it so later lane ordering stops
             re-dispatching into the exhausted window (RFC-0370 §3.3). The
@@ -576,6 +581,7 @@ let run_named
     ?runtime_manifest_append
     ?deferred_runtime_lane
     ?on_runtime_retry_deferred
+    ?on_runtime_attempt_error
     ?on_deferred_runtime_consumed
     ?provider_config_transform
     ?sw
@@ -842,6 +848,7 @@ let run_named
     ~pre_tool_rejects
     ?lane_id:lane_id_opt
     ?on_retry_deferred:on_runtime_retry_deferred
+    ?on_attempt_error:on_runtime_attempt_error
     ~allow_retry:(fun ~runtime_id:attempt_runtime_id ~attempt error ->
       let allowed =
         Keeper_turn_driver_try_provider.same_run_retry_allowed

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -147,6 +147,8 @@ val run_named :
   ?runtime_manifest_append:(Keeper_runtime_manifest.t -> unit) ->
   ?deferred_runtime_lane:deferred_runtime_lane ->
   ?on_runtime_retry_deferred:(deferred_runtime_lane -> unit) ->
+  ?on_runtime_attempt_error:
+    (runtime_id:string -> attempt:int -> Agent_core.Error.t -> unit) ->
   ?on_deferred_runtime_consumed:(unit -> unit) ->
   ?provider_config_transform:
     (Llm_provider.Provider_config.t ->
@@ -159,7 +161,12 @@ val run_named :
     MASC drives the runtime FSM directly: resolves runtime providers,
     resolves each candidate's model temperature before trying it with AGENT_CORE, and
     uses [Runtime_fsm.decide] on failure.
-    The runtime loop runs inside a capacity-managed queue permit. *)
+    The runtime loop runs inside a capacity-managed queue permit.
+
+    [on_runtime_attempt_error] observes every typed candidate failure after
+    its runtime manifest row is emitted. It does not change candidate
+    selection or the final error; verifier callers use it to aggregate
+    retryability across a bare runtime and its terminal default fallback. *)
 
 type attempt_inference_policy =
   { attempt_enable_thinking : bool option
@@ -259,6 +266,8 @@ module For_testing : sig
       (runtime_id:string -> attempt:int -> Agent_core.Error.t -> bool) ->
     ?lane_id:string ->
     ?on_retry_deferred:(deferred_runtime_lane -> unit) ->
+    ?on_attempt_error:
+      (runtime_id:string -> attempt:int -> Agent_core.Error.t -> unit) ->
     ?quota_scope_of:('candidate -> Runtime_quota_window.scope option) ->
     ?candidate_dispatchable:('candidate -> bool) ->
     runtime_id:string ->

--- a/lib/keeper/keeper_turn_driver_wrappers.ml
+++ b/lib/keeper/keeper_turn_driver_wrappers.ml
@@ -162,6 +162,7 @@ let run_named_with_masc_tools
     ?on_event
     ?on_yield
     ?on_resume
+    ?on_runtime_attempt_error
     ?transport
     ?(yield_on_tool = false)
     ?provider_config_transform
@@ -192,6 +193,7 @@ let run_named_with_masc_tools
       ?on_event
       ?on_yield
       ?on_resume
+      ?on_runtime_attempt_error
       ?transport
       ~yield_on_tool
       ?provider_config_transform

--- a/lib/keeper/keeper_turn_driver_wrappers.mli
+++ b/lib/keeper/keeper_turn_driver_wrappers.mli
@@ -50,6 +50,8 @@ val run_named_with_masc_tools :
   ?on_event:(Agent_core.Types.sse_event -> unit) ->
   ?on_yield:(unit -> unit) ->
   ?on_resume:(unit -> unit) ->
+  ?on_runtime_attempt_error:
+    (runtime_id:string -> attempt:int -> Agent_core.Error.t -> unit) ->
   ?transport:Masc_grpc_transport.t ->
   ?yield_on_tool:bool ->
   ?provider_config_transform:
@@ -62,7 +64,9 @@ val run_named_with_masc_tools :
 (** [run_named] variant that bridges MASC tool schemas into AGENT_CORE tools
     via {!Tool_bridge.agent_core_tool_of_masc}. [keeper_name] preserves per-Keeper
     lane ownership in runtime manifests and metrics; the default retains
-    compatibility for non-Keeper callers. *)
+    compatibility for non-Keeper callers. [on_runtime_attempt_error] forwards
+    the typed per-candidate observation from {!Keeper_turn_driver.run_named}
+    without changing its terminal result. *)
 
 val run_model_with_masc_tools :
   model_label:string ->

--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -52,8 +52,10 @@ let run_llm_reviewer_fn
      report_tool_schema:Types_core.tool_schema ->
      lookup:lookup_surface ->
      on_tool_result:(input:Yojson.Safe.t -> Tool_result.result -> unit) ->
+     on_runtime_attempt_error:
+       (runtime_id:string -> attempt:int -> Agent_core.Error.t -> unit) ->
      unit -> (verdict option, Agent_core.Error.t) result) Atomic.t
-  = Atomic.make (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~lookup:_ ~on_tool_result:_ () ->
+  = Atomic.make (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~lookup:_ ~on_tool_result:_ ~on_runtime_attempt_error:_ () ->
       Error (Agent_core.Error.Internal "Workspace_hooks: run_llm_reviewer_fn not connected"))
 
 (** Issue #8436: schema enum used to be hand-rolled as a 2-element
@@ -407,31 +409,42 @@ let review
           next slot. The terminal runtime/reason describes the last attempt,
           while retryability aggregates every typed evaluator error: one
           transient slot must not be masked by a later statically unavailable
-          fallback. A single-slot lane still reports exactly what the pre-lane
-          path reported. *)
+          fallback. The same aggregation includes typed failures from the
+          runtime candidates inside each slot, while the slot's terminal error
+          remains the operator-facing reason. A single-slot lane still reports
+          exactly what the pre-lane path reported. *)
        let run_attempt slot =
+         let nested_retryable_error_seen = ref false in
          try
-           (Atomic.get run_llm_reviewer_fn)
-             ~base_path
-             ?sw
-             ~evaluator_runtime:slot
-             ~prompt
-             ~report_tool_schema:report_review_verdict_schema
-             ~lookup
-             ~on_tool_result
-             ()
+           let result =
+             (Atomic.get run_llm_reviewer_fn)
+               ~base_path
+               ?sw
+               ~evaluator_runtime:slot
+               ~prompt
+               ~report_tool_schema:report_review_verdict_schema
+               ~lookup
+               ~on_tool_result
+               ~on_runtime_attempt_error:
+                 (fun ~runtime_id:_ ~attempt:_ error ->
+                    if Agent_core.Error.is_retryable error
+                    then nested_retryable_error_seen := true)
+               ()
+           in
+           result, !nested_retryable_error_seen
          with
          | Eio.Cancel.Cancelled _ as exn -> raise exn
          | exn ->
-           Error
-             (Agent_core.Error.Internal
-                (Printf.sprintf
-                   "task completion evaluator raised unexpectedly: %s"
-                   (Printexc.to_string exn)))
+           ( Error
+               (Agent_core.Error.Internal
+                  (Printf.sprintf
+                     "task completion evaluator raised unexpectedly: %s"
+                     (Printexc.to_string exn)))
+           , !nested_retryable_error_seen )
        in
        let rec attempt ~retryable_error_seen slot remaining =
          match run_attempt slot with
-         | Ok (Some verdict) ->
+         | Ok (Some verdict), _nested_retryable_error_seen ->
            (match verdict with
             | Approve ->
               task_info
@@ -450,7 +463,7 @@ let review
              ; fallback_reason = None
              ; evaluator_error_retryable = None
              }
-         | Ok None ->
+         | Ok None, nested_retryable_error_seen ->
            let detail =
              "task completion evaluator did not call report_review_verdict exactly once"
            in
@@ -474,11 +487,16 @@ let review
                 ; gate = Invalid_verdict
                 ; fallback_reason = Some detail
                 ; evaluator_error_retryable =
-                    (if retryable_error_seen then Some true else None)
+                    (if retryable_error_seen || nested_retryable_error_seen
+                     then Some true
+                     else None)
                 })
-         | Error error ->
+         | Error error, nested_retryable_error_seen ->
            let detail = Agent_core.Error.to_string error in
-           let retryable = Agent_core.Error.is_retryable error in
+           let retryable =
+             nested_retryable_error_seen
+             || Agent_core.Error.is_retryable error
+           in
            (Atomic.get outcome_observer_fn)
              ~outcome:"unavailable"
              ~runtime:slot;

--- a/lib/task/anti_rationalization.mli
+++ b/lib/task/anti_rationalization.mli
@@ -139,6 +139,8 @@ val run_llm_reviewer_fn
       -> report_tool_schema:Types_core.tool_schema
       -> lookup:lookup_surface
       -> on_tool_result:(input:Yojson.Safe.t -> Tool_result.result -> unit)
+      -> on_runtime_attempt_error:
+        (runtime_id:string -> attempt:int -> Agent_core.Error.t -> unit)
       -> unit
       -> (verdict option, Agent_core.Error.t) result)
        Atomic.t

--- a/lib/workspace_metric_hooks.ml
+++ b/lib/workspace_metric_hooks.ml
@@ -303,7 +303,7 @@ let install () =
 
   Atomic.set Task.Anti_rationalization.outcome_observer_fn record_anti_rationalization_outcome;
 
-  Atomic.set Task.Anti_rationalization.run_llm_reviewer_fn (fun ~base_path ?sw ~evaluator_runtime ~prompt ~report_tool_schema ~lookup ~on_tool_result () ->
+  Atomic.set Task.Anti_rationalization.run_llm_reviewer_fn (fun ~base_path ?sw ~evaluator_runtime ~prompt ~report_tool_schema ~lookup ~on_tool_result ~on_runtime_attempt_error () ->
     let verdict_ref = ref None in
     let protocol_error_ref = ref None in
     let lookup_schemas, lookup_dispatch =
@@ -397,6 +397,7 @@ let install () =
           ~masc_tools:(report_tool_schema :: lookup_schemas)
           ~dispatch
           ~provider_config_transform:apply_review_verdict_output_contract
+          ~on_runtime_attempt_error
           ?sw
           ())
     with

--- a/test/test_anti_rationalization_empty_reject.ml
+++ b/test/test_anti_rationalization_empty_reject.ml
@@ -34,7 +34,7 @@ let test_explicit_base_path_reaches_reviewer () =
   in
   let received = ref None in
   with_reviewer
-    (fun ~base_path ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~lookup:_ ~on_tool_result:_ () ->
+    (fun ~base_path ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~lookup:_ ~on_tool_result:_ ~on_runtime_attempt_error:_ () ->
        received := Some base_path;
        Ok None)
     (fun () ->
@@ -54,7 +54,7 @@ let configure_prompt_registry () =
 
 let test_structured_tool_is_the_only_semantic_verdict () =
   with_reviewer
-    (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~lookup:_ ~on_tool_result:_ () ->
+    (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~lookup:_ ~on_tool_result:_ ~on_runtime_attempt_error:_ () ->
        Ok (Some AR.Approve))
     (fun () ->
        let result = review () in
@@ -70,7 +70,7 @@ let test_structured_tool_is_the_only_semantic_verdict () =
 
 let test_response_text_is_never_parsed_as_verdict () =
   with_reviewer
-    (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~lookup:_ ~on_tool_result:_ () ->
+    (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~lookup:_ ~on_tool_result:_ ~on_runtime_attempt_error:_ () ->
        Ok None)
     (fun () ->
        let result = review () in
@@ -83,7 +83,7 @@ let test_response_text_is_never_parsed_as_verdict () =
 
 let test_evaluator_failure_is_unavailable_not_reject () =
   with_reviewer
-    (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~lookup:_ ~on_tool_result:_ () ->
+    (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~lookup:_ ~on_tool_result:_ ~on_runtime_attempt_error:_ () ->
        Error (Agent_core.Error.Internal "review transport unavailable"))
     (fun () ->
        let result = review () in
@@ -102,7 +102,7 @@ let test_evaluator_failure_is_unavailable_not_reject () =
    always-retry [true] every other gate uses. *)
 let test_structural_budget_failure_is_not_retryable () =
   with_reviewer
-    (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~lookup:_ ~on_tool_result:_ () ->
+    (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~lookup:_ ~on_tool_result:_ ~on_runtime_attempt_error:_ () ->
        Error
          (Agent_core.Error.Agent
             (Agent_core.Error.HookExecutionFailed
@@ -131,7 +131,7 @@ let test_structural_budget_failure_is_not_retryable () =
    [Api (RateLimited _)]), so the always-retry default must survive here. *)
 let test_rate_limit_failure_stays_retryable () =
   with_reviewer
-    (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~lookup:_ ~on_tool_result:_ () ->
+    (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~lookup:_ ~on_tool_result:_ ~on_runtime_attempt_error:_ () ->
        Error
          (Agent_core.Error.Api
             (Agent_core.Error.Retry.RateLimited

--- a/test/test_completion_trust_harness.ml
+++ b/test/test_completion_trust_harness.ml
@@ -20,7 +20,7 @@ type reviewer_response =
 
 let reviewer_response = ref (Reviewer_verdict AR.Approve)
 
-let reviewer ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~lookup:_ ~on_tool_result:_ () =
+let reviewer ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~lookup:_ ~on_tool_result:_ ~on_runtime_attempt_error:_ () =
   match !reviewer_response with
   | Reviewer_verdict verdict -> Ok (Some verdict)
   | Reviewer_unavailable ->

--- a/test/test_goal_verification_agent.ml
+++ b/test/test_goal_verification_agent.ml
@@ -273,7 +273,7 @@ type stub_behavior =
 
 let recording_reviewer calls behaviors =
   fun ~base_path:_ ?sw:_ ~evaluator_runtime ~prompt:_ ~report_tool_schema:_ ~lookup:_
-      ~on_tool_result () ->
+      ~on_tool_result ~on_runtime_attempt_error:_ () ->
     calls := !calls @ [ evaluator_runtime ];
     let answer verdict_json verdict =
       on_tool_result
@@ -304,7 +304,7 @@ let recording_reviewer calls behaviors =
 
 let inspecting_goal_reviewer ~producer ~file_name ~expected ~forest_reads =
   fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt ~report_tool_schema:_
-      ~lookup ~on_tool_result () ->
+      ~lookup ~on_tool_result ~on_runtime_attempt_error:_ () ->
     let report reason =
       let input =
         `Assoc [ "verdict", `String "APPROVE"; "reason", `String reason ]

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -1773,11 +1773,14 @@ let test_typed_checkpoint_is_the_same_run_retry_authority () =
 
 let test_attempt_loop_preserves_last_core_error () =
   let events = ref [] in
+  let observed_errors = ref [] in
   let result =
     Driver.For_testing.attempt_runtime_candidates
       ~runtime_id:"resilient"
       ~runtime_id_of:(fun runtime_id -> runtime_id)
       ~emit_runtime_manifest:(emit_manifest_collector events)
+      ~on_attempt_error:(fun ~runtime_id ~attempt error ->
+        observed_errors := (runtime_id, attempt, error) :: !observed_errors)
       ~run_attempt:(fun ~idx:_ ~runtime_id _candidate ->
         attempt_without_effect
           (Error (retryable_network_error (runtime_id ^ " failed")))
@@ -1805,6 +1808,18 @@ let test_attempt_loop_preserves_last_core_error () =
        | Runtime_manifest.Runtime_failed -> true
        | _ -> false)
      |> List.map decision_runtime_id)
+  ;
+  let observed_errors = List.rev !observed_errors in
+  Alcotest.(check (list (pair string int)))
+    "typed attempt observer sees every candidate without changing the terminal error"
+    [ "primary.test_model", 0; "fallback.test_model", 1 ]
+    (List.map (fun (runtime_id, attempt, _) -> runtime_id, attempt) observed_errors);
+  Alcotest.(check bool)
+    "attempt observer preserves typed retryability"
+    true
+    (List.exists
+       (fun (_, _, error) -> Agent_core.Error.is_retryable error)
+       observed_errors)
 
 let context_overflow_error message =
   Agent_core.Error.Api

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -1974,6 +1974,49 @@ let test_attempt_loop_exhaustion_preserves_earlier_overflow () =
     [ "small.test_model"; "fallback.test_model" ]
     !attempts
 
+(* A fully exhausted runtime lane is retryable when any real candidate failure
+   was transient.  This is the inner boundary used by verifier_exact: a GLM
+   rate limit followed by an unavailable default must re-arm the verifier
+   worker instead of leaving its durable request pending forever. *)
+let test_attempt_loop_exhaustion_preserves_earlier_retryable_error () =
+  let attempts = ref [] in
+  let result =
+    Driver.For_testing.attempt_runtime_candidates
+      ~runtime_id:"verifier-runtime"
+      ~runtime_id_of:Fun.id
+      ~emit_runtime_manifest:(fun ?status:_ ?decision:_ _ -> ())
+      ~run_attempt:(fun ~idx:_ ~runtime_id candidate ->
+        attempts := !attempts @ [ runtime_id ];
+        match candidate with
+        | "glm.test-model" ->
+          attempt_without_effect
+            (Error
+               (Agent_core.Error.Api
+                  (Agent_core.Retry.RateLimited
+                     { retry_after = Some 1.0; message = "provider busy" })))
+            None
+        | "default.test-model" ->
+          attempt_without_effect
+            (Error
+               (Agent_core.Error.Api
+                  (Agent_core.Retry.AuthError
+                     { message = "fallback credential rejected" })))
+            None
+        | other -> Alcotest.failf "unexpected candidate %s" other)
+      [ "glm.test-model"; "default.test-model" ]
+  in
+  (match result with
+   | Ok _ -> Alcotest.fail "expected exhausted verifier runtime lane"
+   | Error error ->
+     Alcotest.(check bool)
+       "an earlier transient candidate keeps the exhausted lane retryable"
+       true
+       (Agent_core.Error.is_retryable error));
+  Alcotest.(check (list string))
+    "both declared candidates were attempted"
+    [ "glm.test-model"; "default.test-model" ]
+    !attempts
+
 (* Overflow precedence applies only to an exhausted lane: a walk stopped
    mid-lane by a non-retryable error keeps that stopping error, which is the
    immediate operator signal. *)
@@ -2358,6 +2401,10 @@ let () =
             "mid-lane terminal outranks observed overflow"
             `Quick
             test_attempt_loop_midwalk_terminal_outranks_observed_overflow;
+          Alcotest.test_case
+            "exhaustion preserves earlier retryable error"
+            `Quick
+            test_attempt_loop_exhaustion_preserves_earlier_retryable_error;
           Alcotest.test_case
             "checkpoint denial defers exact frozen suffix once"
             `Quick

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -1974,49 +1974,6 @@ let test_attempt_loop_exhaustion_preserves_earlier_overflow () =
     [ "small.test_model"; "fallback.test_model" ]
     !attempts
 
-(* A fully exhausted runtime lane is retryable when any real candidate failure
-   was transient.  This is the inner boundary used by verifier_exact: a GLM
-   rate limit followed by an unavailable default must re-arm the verifier
-   worker instead of leaving its durable request pending forever. *)
-let test_attempt_loop_exhaustion_preserves_earlier_retryable_error () =
-  let attempts = ref [] in
-  let result =
-    Driver.For_testing.attempt_runtime_candidates
-      ~runtime_id:"verifier-runtime"
-      ~runtime_id_of:Fun.id
-      ~emit_runtime_manifest:(fun ?status:_ ?decision:_ _ -> ())
-      ~run_attempt:(fun ~idx:_ ~runtime_id candidate ->
-        attempts := !attempts @ [ runtime_id ];
-        match candidate with
-        | "glm.test-model" ->
-          attempt_without_effect
-            (Error
-               (Agent_core.Error.Api
-                  (Agent_core.Retry.RateLimited
-                     { retry_after = Some 1.0; message = "provider busy" })))
-            None
-        | "default.test-model" ->
-          attempt_without_effect
-            (Error
-               (Agent_core.Error.Api
-                  (Agent_core.Retry.AuthError
-                     { message = "fallback credential rejected" })))
-            None
-        | other -> Alcotest.failf "unexpected candidate %s" other)
-      [ "glm.test-model"; "default.test-model" ]
-  in
-  (match result with
-   | Ok _ -> Alcotest.fail "expected exhausted verifier runtime lane"
-   | Error error ->
-     Alcotest.(check bool)
-       "an earlier transient candidate keeps the exhausted lane retryable"
-       true
-       (Agent_core.Error.is_retryable error));
-  Alcotest.(check (list string))
-    "both declared candidates were attempted"
-    [ "glm.test-model"; "default.test-model" ]
-    !attempts
-
 (* Overflow precedence applies only to an exhausted lane: a walk stopped
    mid-lane by a non-retryable error keeps that stopping error, which is the
    immediate operator signal. *)
@@ -2401,10 +2358,6 @@ let () =
             "mid-lane terminal outranks observed overflow"
             `Quick
             test_attempt_loop_midwalk_terminal_outranks_observed_overflow;
-          Alcotest.test_case
-            "exhaustion preserves earlier retryable error"
-            `Quick
-            test_attempt_loop_exhaustion_preserves_earlier_retryable_error;
           Alcotest.test_case
             "checkpoint denial defers exact frozen suffix once"
             `Quick

--- a/test/test_telemetry_task_transition_10358.ml
+++ b/test/test_telemetry_task_transition_10358.ml
@@ -129,7 +129,7 @@ let test_masc_transition_claim_done_emits_task_lifecycle () =
      structured APPROVE so the [done] transition reaches its terminal state and
      emits the lifecycle telemetry under test. *)
   Atomic.set Task.Anti_rationalization.run_llm_reviewer_fn
-    (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~lookup:_ ~on_tool_result:_ () ->
+    (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~lookup:_ ~on_tool_result:_ ~on_runtime_attempt_error:_ () ->
       Ok (Some Task.Anti_rationalization.Approve));
   Atomic.set Workspace_hooks.get_default_runtime_id_fn
     (fun () -> "test-evaluator-runtime");

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -103,7 +103,7 @@ let install_test_hooks () =
     Workspace_hooks.get_verifier_exact_lane_slot_ids_fn
     (fun () -> Ok [ "test-evaluator-runtime" ]);
   Atomic.set Task.Anti_rationalization.run_llm_reviewer_fn
-    (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~lookup:_ ~on_tool_result:_ () ->
+    (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~lookup:_ ~on_tool_result:_ ~on_runtime_attempt_error:_ () ->
        Ok (Some Task.Anti_rationalization.Approve))
 
 let with_env name value_opt f =
@@ -1479,7 +1479,7 @@ let () = test "handle_transition_force_is_not_a_done_action" (fun () ->
             String.equal agent_name "admin-agent");
        let reviewer_called = ref false in
        Atomic.set Task.Anti_rationalization.run_llm_reviewer_fn
-         (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~lookup:_ ~on_tool_result:_ () ->
+         (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~lookup:_ ~on_tool_result:_ ~on_runtime_attempt_error:_ () ->
             reviewer_called := true;
             Ok (Some Task.Anti_rationalization.Approve));
        let result =

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -814,7 +814,7 @@ let test_system_llm_agent_commits_without_a_keeper_verifier () =
                  Eio.Promise.resolve resolve_run_completed ()
                | _ -> ()));
           Atomic.set Masc.Task.Anti_rationalization.run_llm_reviewer_fn
-            (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~lookup:_ ~on_tool_result () ->
+            (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ ~lookup:_ ~on_tool_result ~on_runtime_attempt_error:_ () ->
                on_tool_result
                  ~input:(`Assoc [ "path", `String "evidence.md" ])
                  (Tool_result.ok
@@ -1043,7 +1043,7 @@ let test_system_llm_agent_uses_persisted_request_contract_snapshot () =
           let verdict_committed, resolve_verdict_committed = Eio.Promise.create () in
           let captured_prompt = ref None in
           Atomic.set Masc.Task.Anti_rationalization.run_llm_reviewer_fn
-            (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt ~report_tool_schema:_ ~lookup:_ ~on_tool_result:_ () ->
+            (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt ~report_tool_schema:_ ~lookup:_ ~on_tool_result:_ ~on_runtime_attempt_error:_ () ->
                captured_prompt := Some prompt;
                Eio.Promise.resolve resolve_reviewer_called ();
                Ok (Some Masc.Task.Anti_rationalization.Approve));

--- a/test/test_verifier_exact_lane.ml
+++ b/test/test_verifier_exact_lane.ml
@@ -43,7 +43,7 @@ let review () =
 
 (* A reviewer that answers per slot and records the attempt order. *)
 let recording_reviewer calls behaviors =
-  fun ~base_path:_ ?sw:_ ~evaluator_runtime ~prompt:_ ~report_tool_schema:_ ~lookup:_ ~on_tool_result:_ () ->
+  fun ~base_path:_ ?sw:_ ~evaluator_runtime ~prompt:_ ~report_tool_schema:_ ~lookup:_ ~on_tool_result:_ ~on_runtime_attempt_error:_ () ->
     calls := !calls @ [ evaluator_runtime ];
     match List.assoc_opt evaluator_runtime behaviors with
     | Some behavior -> behavior
@@ -155,6 +155,34 @@ let test_exhaustion_preserves_any_retryable_attempt () =
          (Some true)
          result.evaluator_error_retryable;
        Alcotest.(check bool) "no fabricated verdict" true (Option.is_none result.verdict))
+;;
+
+let test_nested_runtime_retryable_attempt_survives_terminal_error () =
+  with_lane_and_reviewer
+    ~slots:(fun () -> Ok [ "slot-a" ])
+    ~reviewer:
+      (fun ~base_path:_ ?sw:_ ~evaluator_runtime:_ ~prompt:_
+           ~report_tool_schema:_ ~lookup:_ ~on_tool_result:_
+           ~on_runtime_attempt_error () ->
+         on_runtime_attempt_error
+           ~runtime_id:"glm.test-model"
+           ~attempt:0
+           (Agent_core.Error.Api
+              (Agent_core.Error.Retry.RateLimited
+                 { retry_after = None; message = "rate limited" }));
+         budget_refusal)
+    (fun () ->
+       let result = review () in
+       Alcotest.(check (option bool))
+         "a nested transient candidate is not masked by its terminal fallback"
+         (Some true)
+         result.evaluator_error_retryable;
+       Alcotest.(check string)
+         "terminal fallback remains the reported reason"
+         (match budget_refusal with
+          | Error error -> Agent_core.Error.to_string error
+          | Ok _ -> Alcotest.fail "budget refusal fixture must be an error")
+         (Option.value result.fallback_reason ~default:""))
 ;;
 
 let test_exhaustion_reports_all_nonretryable_attempts () =
@@ -340,6 +368,10 @@ let () =
             "exhaustion reports all non-retryable attempts"
             `Quick
             test_exhaustion_reports_all_nonretryable_attempts
+        ; Alcotest.test_case
+            "nested runtime retryable attempt survives terminal error"
+            `Quick
+            test_nested_runtime_retryable_attempt_survives_terminal_error
         ; Alcotest.test_case
             "unconfigured lane is unavailable, not rerouted"
             `Quick


### PR DESCRIPTION
## Summary

- observe every typed candidate error inside a named runtime lane without changing candidate selection or the terminal error
- aggregate nested candidate retryability into the verifier_exact review result, so a GLM 429 is not masked by its terminal default fallback 401
- preserve existing last-core-error, final config-rejection, mid-walk terminal, overflow, and effect-fence contracts

## Evidence

- protected-main run 32526569275: Goal criterion verification stayed pending after GLM 429 was masked by the terminal default DeepSeek 401
- first implementation attempt intentionally rejected by exact-head CI run 32532356803 because changing the generic lane terminal error broke two existing contracts; replacement uses a read-only typed observer
- `ocamlc -stop-after parsing -c` on all changed OCaml files
- `ocamlformat --check` on all changed OCaml files
- `git diff --check`
- local Dune intentionally not run; exact-head CI is the compile/test authority
