### PR TITLE
test(keeper): budget Goal verifier retry convergence

### DIFF
--- a/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
+++ b/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
@@ -108,6 +108,18 @@ KNOWN_ASSERTIONS = {
     "goal_verifier_dashboard_browser_observed",
 }
 
+# Goal verification is an autonomous durable drain, not one synchronous model
+# request. A retryable provider failure is re-armed by the runtime's default
+# 60-second maintenance pulse. The acceptance budget must therefore cover a
+# full first request, that re-arm interval, and a full second request. Keep one
+# additional pulse as scheduling/polling margin so a retry observed near the
+# request boundary is not turned into a false-negative campaign result.
+GOAL_VERIFIER_RETRY_INTERVAL_SEC = 60.0
+
+
+def goal_verifier_convergence_timeout(request_timeout: float) -> float:
+    return (2.0 * request_timeout) + (2.0 * GOAL_VERIFIER_RETRY_INTERVAL_SEC)
+
 
 class AcceptanceError(RuntimeError):
     pass
@@ -1142,8 +1154,10 @@ class MissionRun:
         phase: str,
         completion_state: str | None = None,
         criterion_state: str | None = None,
-        timeout: float = 300.0,
+        timeout: float | None = None,
     ) -> dict[str, Any]:
+        if timeout is None:
+            timeout = goal_verifier_convergence_timeout(self.timeout)
         deadline = time.monotonic() + timeout
         attempt = 0
         last: dict[str, Any] | None = None

--- a/test/test_keeper_multi_collaboration_acceptance.py
+++ b/test/test_keeper_multi_collaboration_acceptance.py
@@ -192,6 +192,17 @@ class KeeperMultiCollaborationAcceptanceTest(unittest.TestCase):
             ["A", "B", "C"],
         )
 
+    def test_goal_verifier_convergence_budget_covers_one_retry_cycle(self):
+        # The live worker re-arms retryable deferred reviews on the default
+        # 60-second maintenance pulse. A 300-second evaluator request that
+        # fails near its boundary still needs a complete second attempt.
+        self.assertEqual(
+            acceptance.goal_verifier_convergence_timeout(300.0),
+            720.0,
+        )
+        wait_source = inspect.getsource(acceptance.MissionRun.wait_for_goal_state)
+        self.assertIn("goal_verifier_convergence_timeout(self.timeout)", wait_source)
+
     def test_runtime_serving_evidence_requires_exact_completed_receipt_per_role(self):
         keepers = {"coordinator": "keeper-c", "reviewer": "keeper-r"}
         expected = {"coordinator": "runtime-c", "reviewer": "runtime-r"}


### PR DESCRIPTION
## Summary
- derive Goal-state convergence budget from two full request windows plus two maintenance-pulse margins
- keep ordinary MCP/turn request timeout unchanged
- lock the protected-main failure contract with a focused unit test

## Evidence
- protected main run 32536862056 at c07ae18fa10b1db69a4829107470b74a2203ad4d reached criterion viable, then proof review deferred with retryable=true after a connection reset at 00:27:23Z
- the 300s harness deadline expired about 22s later, before the default 60s maintenance-pulse re-arm
- `python3 test/test_keeper_multi_collaboration_acceptance.py` (16/16)
- `python3 scripts/harness/workload/keeper_multi_collaboration_acceptance.py --validate-catalog`
- `python3 -m py_compile scripts/harness/workload/keeper_multi_collaboration_acceptance.py test/test_keeper_multi_collaboration_acceptance.py`
- `git diff --check`

No local Dune build was run.