### PR TITLE
chore(labels): 라벨 설명을 한국어로 다시 쓰고 PR 상태 라벨을 신설

### DIFF
--- a/.github/issue-taxonomy.json
+++ b/.github/issue-taxonomy.json
@@ -7,27 +7,27 @@
         "defect": {
           "label": "kind/defect",
           "color": "1d76db",
-          "description": "[kind] 구현이 계약을 어긴다 — 동작이 틀리거나 회귀"
+          "description": "부르면 동작은 하는데 결과가 틀리다. 되던 게 안 되는 것도 여기"
         },
         "gap": {
           "label": "kind/gap",
           "color": "1d76db",
-          "description": "[kind] 계약·배선이 없다 — 이름만 있고 연결 안 됨, 미구현"
+          "description": "부를 경로가 아예 없다. 이름·타입만 있고 실제로 이어지지 않았다"
         },
         "capability": {
           "label": "kind/capability",
           "color": "1d76db",
-          "description": "[kind] 새 표면·기능 요구"
+          "description": "새로 만들어 달라는 요청. 대응하는 약속 자체가 아직 없다"
         },
         "erosion": {
           "label": "kind/erosion",
           "color": "1d76db",
-          "description": "[kind] 죽은 코드·실험 잔재·틀린 문서 — 지울 것"
+          "description": "지울 것. 안 쓰는 코드, 실험하다 남은 것, 사실과 다른 문서"
         },
         "inquiry": {
           "label": "kind/inquiry",
           "color": "1d76db",
-          "description": "[kind] 결함 여부 미확정 — 조사·실측 필요"
+          "description": "버그인지 아직 모른다. 재현하거나 재보는 일이 먼저다"
         }
       },
       "required": true,
@@ -38,67 +38,67 @@
         "turn": {
           "label": "area/turn",
           "color": "5319e7",
-          "description": "[area] 턴 진행·스케줄러·DrainQueue·자율 루프"
+          "description": "턴을 돌리는 쪽. 스케줄러·DrainQueue·자율 루프"
         },
         "continuity": {
           "label": "area/continuity",
           "color": "5319e7",
-          "description": "[area] 컨텍스트·컴팩션·메모리·회상"
+          "description": "턴 사이를 잇는 쪽. 컨텍스트·컴팩션·기억·회상"
         },
         "collab": {
           "label": "area/collab",
           "color": "5319e7",
-          "description": "[area] Keeper 간 통신·Broadcast·Board·Comment"
+          "description": "Keeper끼리 주고받는 쪽. Broadcast·Board·Comment"
         },
         "goal-task": {
           "label": "area/goal-task",
           "color": "5319e7",
-          "description": "[area] Goal·Task·Plan 도메인"
+          "description": "Goal·Task·Plan 도메인"
         },
         "verification": {
           "label": "area/verification",
           "color": "5319e7",
-          "description": "[area] Verifier·Judge·Judge-of-Judge·Fusion·교차검증"
+          "description": "Verifier·Judge·Judge-of-Judge·Fusion·교차 검증"
         },
         "tools": {
           "label": "area/tools",
           "color": "5319e7",
-          "description": "[area] 도구 카탈로그·Multi/Async/Batch·Sandbox·MCP"
+          "description": "도구 목록과 실행. Multi/Async/Batch·Sandbox·MCP"
         },
         "runtime": {
           "label": "area/runtime",
           "color": "5319e7",
-          "description": "[area] 프로바이더·모델·런타임 페일오버"
+          "description": "무엇으로 부를지. 프로바이더·모델·런타임 레인·대체 경로"
         },
         "transport": {
           "label": "area/transport",
           "color": "5319e7",
-          "description": "[area] auth·health·프로토콜·전송 계층"
+          "description": "어떻게 실어 나를지. 인증·헬스체크·프로토콜·전송 계층"
         },
         "dashboard": {
           "label": "area/dashboard",
           "color": "5319e7",
-          "description": "[area] 대시보드·읽기 모델·뷰어"
+          "description": "관측 데이터를 보여주는 쪽. 대시보드·TUI·읽기 모델"
         },
         "connector": {
           "label": "area/connector",
           "color": "5319e7",
-          "description": "[area] Slack·Discord 등 외부 출력 경로"
+          "description": "밖으로 내보내는 쪽. Slack·Discord 등"
         },
         "observability": {
           "label": "area/observability",
           "color": "5319e7",
-          "description": "[area] 로그·메트릭·트레이스·스트리밍 관측"
+          "description": "관측 데이터를 만드는 쪽. 로그·메트릭·트레이스·스트리밍"
         },
         "persistence": {
           "label": "area/persistence",
           "color": "5319e7",
-          "description": "[area] 저장소·원장·체크포인트·파일시스템"
+          "description": "디스크에 쓰고 읽는 쪽. 저장소·원장(ledger)·체크포인트"
         },
         "ci": {
           "label": "area/ci",
           "color": "5319e7",
-          "description": "[area] CI·빌드·릴리스·ratchet"
+          "description": "CI·빌드·릴리스. 되돌림 방지 기준선(ratchet) 포함"
         }
       },
       "required": true,
@@ -109,27 +109,27 @@
         "breaks-continuity": {
           "label": "impact/breaks-continuity",
           "color": "b60205",
-          "description": "[impact 1] 턴이 끊기거나 기억이 안 이어진다 — 제품 정의상 실패"
+          "description": "1순위 · 턴이 멈추거나 기억이 안 이어진다. 이러면 제품이라 할 수 없다"
         },
         "breaks-collab": {
           "label": "impact/breaks-collab",
           "color": "d93f0b",
-          "description": "[impact 2] Keeper 간 소통이 끊기거나, 출력이 맥락에 맞지 않는 곳에 도착한다"
+          "description": "2순위 · Keeper끼리 말이 안 닿거나, 결과가 엉뚱한 데로 간다"
         },
         "blinds-operator": {
           "label": "impact/blinds-operator",
           "color": "e99695",
-          "description": "[impact 3] 돌긴 도는데 보이지 않는다"
+          "description": "3순위 · 돌긴 도는데 사람이 볼 수가 없다"
         },
         "degrades": {
           "label": "impact/degrades",
           "color": "fbca04",
-          "description": "[impact 4] 마찰·성능·정확도 저하"
+          "description": "4순위 · 느리거나 번거롭거나, 정확도가 떨어진다"
         },
         "internal": {
           "label": "impact/internal",
           "color": "c5c5c5",
-          "description": "[impact 5] 개발 흐름에만 영향"
+          "description": "5순위 · 개발할 때만 걸린다. 사용자에게는 안 보인다"
         }
       },
       "required": true,
@@ -147,42 +147,42 @@
         "ssot": {
           "label": "root/ssot",
           "color": "d4a017",
-          "description": "[root] 같은 진실이 여러 곳에 — SSOT 위반"
+          "description": "같은 값이 여러 군데에 따로 있다. 원본이 하나가 아니다"
         },
         "silent": {
           "label": "root/silent",
           "color": "d4a017",
-          "description": "[root] Silent failure — 실패를 기본값·fail-open 으로 삼킴"
+          "description": "실패했는데 조용히 넘어간다. 기본값으로 때우거나 그냥 통과시킨다"
         },
         "string": {
           "label": "root/string",
           "color": "d4a017",
-          "description": "[root] 문자열·정규식 비교로 분기 — 구조적 파싱 부재"
+          "description": "문자열을 맞춰 보고 갈라진다. 타입으로 안 갈랐다"
         },
         "variant": {
           "label": "root/variant",
           "color": "d4a017",
-          "description": "[root] 와일드카드가 분기를 삼킴 — 비망라 매치"
+          "description": "와일드카드가 갈래를 삼킨다. 모든 경우를 안 따졌다"
         },
         "boundary": {
           "label": "root/boundary",
           "color": "d4a017",
-          "description": "[root] 경계 위반 — 의존성 역방향, 책임 침범"
+          "description": "의존 방향이 거꾸로거나, 남의 책임까지 들고 있다"
         },
         "telemetry": {
           "label": "root/telemetry",
           "color": "d4a017",
-          "description": "[root] 관측 공백 — 메트릭·스팬·상관관계 누락"
+          "description": "볼 수가 없다. 메트릭·스팬·이어 볼 실마리가 빠졌다"
         },
         "det": {
           "label": "root/det",
           "color": "d4a017",
-          "description": "[root] 결정론 가정 — 단일 입력 모양 가정, 경쟁 미모델링"
+          "description": "입력이 한 모양일 거라 믿는다. 동시에 들어오는 경우를 안 봤다"
         },
         "ndt": {
           "label": "root/ndt",
           "color": "d4a017",
-          "description": "[root] 비결정론 미수용 — 재시도·폴백·지터 부재"
+          "description": "흔들리는 걸 확정처럼 다룬다. 재시도·대체 경로·지터가 없다"
         }
       },
       "required": false,
@@ -193,7 +193,7 @@
     "must-do": {
       "label": "must-do",
       "color": "000000",
-      "description": "반드시 처리 — 지금 제품 약속을 깨고 있다"
+      "description": "지금 당장. 제품이 한 약속을 지금 깨고 있다"
     }
   }
 }

--- a/.github/pull-request-labels.json
+++ b/.github/pull-request-labels.json
@@ -1,0 +1,26 @@
+{
+  "$comment": "PR 상태 라벨의 SSOT. GitHub 가 이미 아는 상태를 PR 목록 화면에 비춰 주기만 한다. 사람이 손으로 붙이지 않고, 어떤 게이트도 이 라벨을 읽지 않는다.",
+  "prefix": "pr/",
+  "labels": {
+    "conflict": {
+      "label": "pr/conflict",
+      "color": "006b75",
+      "description": "base 와 충돌한다. 이 상태에서는 CI 가 아예 돌지 않는다"
+    },
+    "review-changes": {
+      "label": "pr/review-changes",
+      "color": "006b75",
+      "description": "리뷰에서 변경 요청을 받았다. 저자가 답할 차례"
+    },
+    "review-approved": {
+      "label": "pr/review-approved",
+      "color": "006b75",
+      "description": "리뷰 승인. 남은 것은 필수 체크 통과뿐"
+    },
+    "unresolved": {
+      "label": "pr/unresolved",
+      "color": "006b75",
+      "description": "아직 닫지 않은 리뷰 스레드가 있다"
+    }
+  }
+}

--- a/.github/workflows/pr-status-labels.yml
+++ b/.github/workflows/pr-status-labels.yml
@@ -1,0 +1,177 @@
+name: PR Status Labels
+
+# Projects GitHub's own view of a pull request onto pr/* labels. The labels are a view:
+# nothing gates on them and nobody sets them by hand.
+#
+# Two of the four states cannot be reached any other way:
+#   - `mergeable` has no search qualifier, and a CONFLICTING PR starts no `pull_request`
+#     workflow at all, so it carries zero check runs and reads as a slow queue rather than
+#     a blocked branch.
+#   - Unresolved review threads have no search qualifier either, and answering them is a
+#     merge precondition here.
+# The two review-decision labels do duplicate the `review:` search qualifiers. They earn
+# their place by putting the state in the PR list itself; drop those two entries from the
+# SSOT if that stops being worth the duplication.
+#
+# Conflict state flips when main moves, and resolving a thread emits no webhook at all,
+# so PR events alone cannot keep this honest. push-to-main and the hourly sweep are the
+# repair loop, and they are what stops the labels from rotting into a lie.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, closed]
+  pull_request_review:
+    types: [submitted, dismissed]
+  push:
+    branches: [main]
+  schedule:
+    - cron: '23 * * * *'
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Single PR number. Leave empty to sweep every open PR.
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-status-labels-${{ github.event.pull_request.number || inputs.pr_number || 'sweep' }}
+  cancel-in-progress: true
+
+jobs:
+  project:
+    name: Project PR state onto labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          sparse-checkout: .github/pull-request-labels.json
+          sparse-checkout-cone-mode: false
+
+      - uses: actions/github-script@v9
+        env:
+          DISPATCH_PR_NUMBER: ${{ inputs.pr_number }}
+        with:
+          script: |
+            const fs = require('fs');
+            const { owner, repo } = context.repo;
+            const SSOT = JSON.parse(fs.readFileSync('.github/pull-request-labels.json', 'utf8'));
+            const PREFIX = SSOT.prefix;
+            const spec = SSOT.labels;
+            const defs = Object.values(spec);
+            const NAME = Object.fromEntries(Object.entries(spec).map(([k, v]) => [k, v.label]));
+
+            // This workflow is the only writer of pr/*, so there is no human-declared
+            // vocabulary to drift from and nothing to fail closed against. It creates what
+            // it is missing instead of waiting for someone to run a sync script.
+            const existing = new Map(
+              (await github.paginate(github.rest.issues.listLabelsForRepo, { owner, repo, per_page: 100 }))
+                .map((l) => [l.name, l]),
+            );
+            for (const d of defs) {
+              const cur = existing.get(d.label);
+              if (!cur) {
+                await github.rest.issues.createLabel({ owner, repo, name: d.label, color: d.color, description: d.description });
+              } else if (cur.color !== d.color || (cur.description || '') !== d.description) {
+                await github.rest.issues.updateLabel({ owner, repo, name: d.label, color: d.color, description: d.description });
+              }
+            }
+
+            const FIELDS = `
+              number state isDraft mergeable reviewDecision
+              labels(first: 100) { nodes { name } }
+              reviewThreads(first: 100) { pageInfo { hasNextPage } nodes { isResolved } }
+            `;
+
+            async function fetchOne(number) {
+              const q = `query($owner:String!,$repo:String!,$number:Int!){
+                repository(owner:$owner,name:$repo){ pullRequest(number:$number){ ${FIELDS} } } }`;
+              const r = await github.graphql(q, { owner, repo, number });
+              return r.repository.pullRequest;
+            }
+
+            async function fetchOpen() {
+              const q = `query($owner:String!,$repo:String!,$cursor:String){
+                repository(owner:$owner,name:$repo){
+                  pullRequests(states: OPEN, first: 50, after: $cursor){
+                    pageInfo { hasNextPage endCursor }
+                    nodes { ${FIELDS} } } } }`;
+              const out = [];
+              let cursor = null;
+              for (;;) {
+                const page = (await github.graphql(q, { owner, repo, cursor })).repository.pullRequests;
+                out.push(...page.nodes);
+                if (!page.pageInfo.hasNextPage) return out;
+                cursor = page.pageInfo.endCursor;
+              }
+            }
+
+            // GitHub computes the merge check lazily: the first read of a PR it has not
+            // looked at answers UNKNOWN and starts the work. Read once more before deciding.
+            async function settle(pr) {
+              if (pr.state !== 'OPEN' || pr.mergeable !== 'UNKNOWN') return pr;
+              await new Promise((r) => setTimeout(r, 4000));
+              return await fetchOne(pr.number);
+            }
+
+            // UNKNOWN and a truncated thread page are both "GitHub has not told us yet".
+            // Carrying the current answer forward beats flapping the label on every push.
+            function target(pr, current) {
+              if (pr.state !== 'OPEN') return new Set();
+              const want = new Set();
+              if (pr.mergeable === 'CONFLICTING') want.add(NAME.conflict);
+              else if (pr.mergeable === 'UNKNOWN' && current.has(NAME.conflict)) want.add(NAME.conflict);
+              if (pr.reviewDecision === 'APPROVED') want.add(NAME['review-approved']);
+              if (pr.reviewDecision === 'CHANGES_REQUESTED') want.add(NAME['review-changes']);
+              const threads = pr.reviewThreads;
+              if (threads.nodes.some((t) => !t.isResolved)) want.add(NAME.unresolved);
+              else if (threads.pageInfo.hasNextPage && current.has(NAME.unresolved)) want.add(NAME.unresolved);
+              return want;
+            }
+
+            async function reconcile(pr) {
+              const current = new Set(pr.labels.nodes.map((l) => l.name));
+              const want = target(pr, current);
+              const toRemove = [...current].filter((n) => n.startsWith(PREFIX) && !want.has(n));
+              const toAdd = [...want].filter((n) => !current.has(n));
+              try {
+                for (const name of toRemove)
+                  await github.rest.issues.removeLabel({ owner, repo, issue_number: pr.number, name })
+                    .catch((e) => { if (e.status !== 404) throw e; });
+                if (toAdd.length)
+                  await github.rest.issues.addLabels({ owner, repo, issue_number: pr.number, labels: toAdd });
+              } catch (e) {
+                // A pull_request event from a fork hands this job a read-only token. The
+                // scheduled sweep runs with write and will catch the PR up.
+                if (e.status === 403) {
+                  core.warning(`no write access for #${pr.number}; the sweep will pick it up`);
+                  return { number: pr.number, skipped: 'read-only token' };
+                }
+                throw e;
+              }
+              return { number: pr.number, added: toAdd, removed: toRemove };
+            }
+
+            const dispatchNumber = (process.env.DISPATCH_PR_NUMBER || '').trim();
+            let prs;
+            if (context.payload.pull_request?.number) {
+              prs = [await fetchOne(context.payload.pull_request.number)];
+            } else if (dispatchNumber) {
+              const n = Number(dispatchNumber);
+              if (!Number.isInteger(n) || n <= 0) { core.setFailed(`invalid PR number: ${dispatchNumber}`); return; }
+              prs = [await fetchOne(n)];
+            } else {
+              prs = await fetchOpen();
+            }
+
+            let changed = 0;
+            for (const raw of prs) {
+              if (!raw) continue;
+              const r = await reconcile(await settle(raw));
+              if (r.added?.length || r.removed?.length) changed++;
+              core.info(JSON.stringify(r));
+            }
+            core.info(`scanned ${prs.length}, changed ${changed}`);

--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -83,6 +83,13 @@ if the repository drifts from the SSOT the run fails and names the missing label
 | `root` | zero or more | `ssot` `silent` `string` `variant` `boundary` `telemetry` `det` `ndt` |
 | `must-do` | flag | `true` when the product promise is broken right now |
 
+Two rules settle the overlaps the table cannot spell out:
+
+- `area` is where the fix lands, not where the symptom shows. A panel rendering a stale metric is
+  `dashboard` when the panel is wrong and `observability` when the metric is.
+- `impact` takes the highest row that applies. The values are ordered, so an issue that both blinds the
+  operator and stops turns is `breaks-continuity`.
+
 ### Priority comes from impact, not from an assertion
 
 `impact` is ordered, and that order is the priority order:
@@ -97,16 +104,35 @@ There is no separate priority or scheduling label. Severity is derived from whic
 causes, so it can be argued about with evidence instead of asserted. A roadmap decides *when* work happens;
 a label decides *what is at stake*.
 
-`root` is optional and follows `docs/spec/16-root-cause-rubric.md`. Multiple values are expected:
-the 2026-04-19 sweep found 60% of issues match two or more categories, for example a boundary violation
-that also swallows errors. A missing `root` is not a triage violation; the rubric only applies when a
-structural marker actually matches.
+`root` is optional and follows `docs/spec/16-root-cause-rubric.md`. A missing `root` is not a triage
+violation; the rubric only applies when a structural marker actually matches. Multiple values are allowed,
+and overlap is real - a boundary violation that also swallows errors takes both - but it is rare in the
+intake we actually have: on 2026-08-22, 48 of the 820 open issues that declare `root` name two or more,
+and 401 declare none. This paragraph used to quote 60% from the 2026-04-19 sweep; that number stopped
+describing the repository.
 
 ### Issue intake
 
 Humans file through the issue form; keepers file with `gh issue create`. Both produce the same fenced
 `masc-triage` block, so there is one format and one parser. An issue filed without the block gets a comment
 naming the expected shape, and no labels.
+
+### PR status labels
+
+Pull requests carry no taxonomy. `kind`/`area`/`impact` describe a problem and a PR is an answer, so the
+`Issue Taxonomy` workflow skips them outright. What a PR does carry is `pr/*`, projected from GitHub's own
+view of it by the `PR Status Labels` workflow out of `.github/pull-request-labels.json`.
+
+| Label | Set when |
+|-------|----------|
+| `pr/conflict` | `mergeable` is `CONFLICTING`. No `pull_request` workflow runs in that state, so the PR shows zero checks and reads as a slow queue |
+| `pr/review-changes` | the review decision is `CHANGES_REQUESTED` |
+| `pr/review-approved` | the review decision is `APPROVED` |
+| `pr/unresolved` | at least one review thread is still open |
+
+Nothing gates on these and nobody sets them by hand. Conflict flips when main moves and resolving a thread
+emits no webhook at all, so the workflow sweeps every open PR on push-to-main and once an hour as well as
+on PR and review events.
 
 ### PR rules
 


### PR DESCRIPTION
## Summary

라벨 정책을 실측으로 점검하고 세 가지를 고쳤습니다.

1. 이슈 라벨 32개의 한국어 설명을 전부 다시 썼습니다. 영어 용어를 옮겨 붙인 말(`표면`, `비망라 매치`, `경쟁 미모델링`, `결함 여부 미확정`)을 걷어내고, 각 설명이 **그 값을 고르게 하는 판단 기준**을 담도록 바꿨습니다.
2. PR 전용 라벨 `pr/*` 4종과 이를 유지하는 워크플로를 넣었습니다. PR 에는 기계가 붙이는 라벨이 하나도 없었습니다.
3. 운영 문서의 틀린 수치 두 개와, 표에 적혀 있지 않던 축 선택 규칙 두 개를 채웠습니다.

## Product impact

- User-visible change: 라벨 설명이 바뀌고, 열린 PR 에 `pr/conflict`·`pr/unresolved`·`pr/review-approved`·`pr/review-changes` 가 붙습니다. 코드 동작 변화는 없습니다.

## 설명을 왜 다시 썼나

기존 설명은 영어 원문을 그대로 옮긴 말이라, 읽어도 어느 값을 골라야 할지 알 수 없었습니다. 새 설명은 **경계를 가르는 질문**을 문장에 넣었습니다.

| 짝 | 기존 | 새 기준 |
|----|------|---------|
| defect ↔ gap | "계약을 어긴다" ↔ "계약·배선이 없다" | 부를 경로가 있느냐 |
| observability ↔ dashboard | "로그·메트릭·트레이스" ↔ "대시보드·읽기 모델·뷰어" | 데이터를 만드는 쪽이냐 보여주는 쪽이냐 |
| runtime ↔ transport | "프로바이더·모델" ↔ "auth·health·프로토콜" | 무엇으로 부르느냐 어떻게 실어 나르느냐 |
| turn ↔ continuity | "턴 진행" ↔ "컨텍스트·컴팩션" | 턴을 돌리는 쪽이냐 턴 사이를 잇는 쪽이냐 |
| det ↔ ndt | "결정론 가정" ↔ "비결정론 미수용" | 입력 모양 가정이냐 흔들리는 결과 미수용이냐 |

`[kind]`/`[area]`/`[root]` 접두사는 뺐습니다. 라벨 이름이 이미 축을 들고 있어 중복입니다. `impact` 만 숫자를 `1순위`~`5순위` 로 남겼습니다. 순서가 곧 우선순위인데 이름에는 그 정보가 없습니다.

## `pr/*` 는 왜 이 넷인가

둘은 GitHub 검색으로 도달할 방법이 아예 없습니다.

- **`mergeable` 에는 검색 한정자가 없습니다.** 충돌 중에는 GitHub 이 머지 커밋을 만들 수 없어 새 `pull_request` 워크플로가 시작되지 않습니다. 체크는 마지막 정상 푸시 시점에 멈춰 있고, 처음부터 충돌한 PR 은 체크가 0건입니다. 어느 쪽이든 큐가 밀린 것처럼 읽힙니다 (#29332).
- **미해결 리뷰 스레드에도 한정자가 없습니다.** 이 저장소는 코멘트 대응을 머지 선행 조건으로 둡니다.

`pr/review-approved` / `pr/review-changes` 는 `review:` 한정자와 겹칩니다. PR 목록 화면 자체가 상태를 들고 있게 하려고 넣었고, 값이 없다 판단되면 SSOT 에서 그 두 항목만 지우면 됩니다.

라벨은 전부 **투영**입니다. 사람이 손으로 붙이지 않고, 어떤 게이트도 이 라벨을 읽지 않습니다.

## Evidence

2026-08-22 기준, 열린 이슈 831건 / 열린 PR 29건 전수 측정입니다.

| 관측 | 값 |
|------|-----|
| `root` 다중 선언 비율 (본문 기준) | 48/820 = 5.9% — 문서는 60% 라고 적고 있었음 |
| `root` 미선언 | 401/820 |
| `area/ci` → `impact/internal` | 157/164 = 95.7% |
| 선언과 라벨이 어긋난 이슈 | 30건 (29건이 `root/*` 누락) |
| 선언 블록 없이 라벨만 있는 이슈 | 6건 (`area` 를 2개 단 #29331·#29329 포함) |
| 라벨이 하나도 없는 이슈 | 7건 |
| 이슈 taxonomy 라벨을 단 PR | 열린 PR 15/29, 최근 머지 13/30 — 문서는 "PR 은 taxonomy 를 안 쓴다" 였음 |
| root 축 값끼리 겹침 | det∩ndt 1/65, silent∩telemetry 1/112 — 경계 자체는 갈라짐 |

라이브 동작 확인 (이 PR 브랜치의 워크플로가 실제로 실행됨):

- `pr/*` 라벨 4개 생성됨
- 열린 PR 29건 스윕 → `mergeable=CONFLICTING` 인 #29325·#29313 정확히 2건에만 `pr/conflict` 부착, 나머지 27건 무변경
- 이슈 라벨 32개 설명 라이브 반영 완료 (`APPLY=1 scripts/sync-issue-labels.sh`)

로컬 검증:

- `node scripts/test-issue-taxonomy-core.cjs` → pass
- `bash scripts/sync-issue-labels.sh` (dry run) → 생성/삭제 0건
- 워크플로 YAML 파싱 + 내부 스크립트 `node --check` 통과
- 라벨 설명 32개 전부 GitHub 상한 100자 이내

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 6/6
provenance: direct
stages: [taxonomy-core-test, label-sync-dry-run, yaml-parse, workflow-script-syntax, live-label-sync, live-pr-sweep]
```

## 이 PR 이 고치지 않은 것

같은 조사에서 나왔지만 범위를 넘어서 손대지 않았습니다.

1. **게이트가 인입의 일부에만 돕니다.** 08-21 에 이슈 62건이 생겼고 `Issue Taxonomy` 실행은 16건입니다. 나머지는 `gh issue create --label` 로 붙은 라벨이라 타임라인 actor 가 `jeong-sik` 입니다 (게이트가 붙인 건은 `github-actions[bot]`). 이벤트가 왜 유실되는지는 **확인 필요**입니다. 별도 PR 로 스윕 크론을 답니다.
2. **PR 에 붙는 taxonomy 라벨에는 출처가 없습니다.** 절반쯤 되는 PR 이 손으로 `kind`/`area`/`impact` 를 답니다. 선언도 없고 조정도 없어서, 이 모델에서 유일하게 근거 없이 분류를 주장하는 자리입니다. 손으로 다는 걸 멈추든 PR 에도 선언을 두든 결정이 필요합니다.
3. **`.gitignore:147` 의 `pr-*.json` 이 트리 전체에 걸립니다.** "Operator-local scratch" 절의 패턴인데 앵커가 없어 `.github/pr-status-labels.json` 을 조용히 삼켰습니다. 그래서 이 PR 의 파일 이름은 `.github/pull-request-labels.json` 입니다. 앵커(`/pr-*.json`)가 근본 수리지만 다른 운영자의 스크래치 경로를 바꿀 수 있어 두었습니다.

## Linked issue

- Relates #29332

## Variant addition checklist

OCaml variant / TypeScript union / TLA+ 도메인 / JSON schema enum 변경 없음. 해당 없음.
