### PR TITLE
docs: PR 라벨의 실제 상태를 사실대로 적는다

### DIFF
--- a/.github/workflows/pr-status-labels.yml
+++ b/.github/workflows/pr-status-labels.yml
@@ -4,9 +4,10 @@ name: PR Status Labels
 # nothing gates on them and nobody sets them by hand.
 #
 # Two of the four states cannot be reached any other way:
-#   - `mergeable` has no search qualifier, and a CONFLICTING PR starts no `pull_request`
-#     workflow at all, so it carries zero check runs and reads as a slow queue rather than
-#     a blocked branch.
+#   - `mergeable` has no search qualifier. GitHub also cannot build a merge commit while a
+#     PR conflicts, so no new `pull_request` workflow starts: the checks freeze at whatever
+#     the last clean push produced, and a PR that conflicted from the start shows none at
+#     all. Either way the PR reads as a slow queue rather than a blocked branch.
 #   - Unresolved review threads have no search qualifier either, and answering them is a
 #     merge precondition here.
 # The two review-decision labels do duplicate the `review:` search qualifiers. They earn

--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -119,13 +119,19 @@ naming the expected shape, and no labels.
 
 ### PR status labels
 
-Pull requests carry no taxonomy. `kind`/`area`/`impact` describe a problem and a PR is an answer, so the
-`Issue Taxonomy` workflow skips them outright. What a PR does carry is `pr/*`, projected from GitHub's own
-view of it by the `PR Status Labels` workflow out of `.github/pull-request-labels.json`.
+The `Issue Taxonomy` workflow skips pull requests outright: `kind`/`area`/`impact` describe a problem and a
+PR is an answer. Practice disagrees - on 2026-08-22, 15 of 29 open PRs and 13 of the last 30 merged ones
+carried taxonomy labels, applied by hand at `gh pr create --label` time. Nothing declares those and nothing
+reconciles them, so they are the one place in this model where a label asserts a classification with no
+source behind it. Either the hand-labelling stops or PRs get a declaration of their own; today it is
+neither.
+
+What a PR does carry by machine is `pr/*`, projected from GitHub's own view of it by the `PR Status Labels`
+workflow out of `.github/pull-request-labels.json`.
 
 | Label | Set when |
 |-------|----------|
-| `pr/conflict` | `mergeable` is `CONFLICTING`. No `pull_request` workflow runs in that state, so the PR shows zero checks and reads as a slow queue |
+| `pr/conflict` | `mergeable` is `CONFLICTING`. GitHub cannot build a merge commit in that state, so no new `pull_request` workflow starts and the checks stop updating - a PR that conflicted from the start shows none at all (#29332) |
 | `pr/review-changes` | the review decision is `CHANGES_REQUESTED` |
 | `pr/review-approved` | the review decision is `APPROVED` |
 | `pr/unresolved` | at least one review thread is still open |


### PR DESCRIPTION
## Summary

#29423 이 머지된 뒤에 올린 수정 커밋이라 squash merge 에 실려 가지 못했습니다. 같은 내용을 main 기준으로 다시 올립니다.

문서와 주석 두 군데가 사실과 다릅니다.

1. `docs/PRODUCT-OPERATING-PLAN.md` 에 "Pull requests carry no taxonomy" 라고 적혀 있습니다. 실제로는 열린 PR 29건 중 15건, 최근 머지된 30건 중 13건이 `kind`/`area`/`impact` 를 달고 있습니다. `Issue Taxonomy` 워크플로는 PR 을 건너뛰므로 전부 `gh pr create --label` 로 손으로 붙은 것이고, 선언도 조정도 없습니다. 이 모델에서 유일하게 근거 없이 분류를 주장하는 자리입니다.
2. `pr-status-labels.yml` 주석이 충돌 PR 은 "체크가 0건" 이라고 단정했습니다. 정확히는 충돌 중에 GitHub 이 머지 커밋을 못 만들어 새 `pull_request` 워크플로가 시작되지 않고, 체크가 마지막 정상 푸시 시점에 멈춥니다. 0건은 첫 실행 전부터 충돌한 PR 에만 해당합니다.

## Product impact

- User-visible change: 없음. 문서와 주석만 바뀝니다.

## Evidence

2026-08-22 측정.

| 관측 | 값 |
|------|-----|
| taxonomy 라벨을 단 열린 PR | 15/29 |
| taxonomy 라벨을 단 최근 머지 PR | 13/30 |
| `mergeable=CONFLICTING` 인 열린 PR | #29325, #29313 |
| 그 두 PR 의 체크 수 | 각각 21건 — "0건" 이 아님 |

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 2/2
provenance: direct
stages: [gh-pr-list-label-census, gh-pr-view-statuscheckrollup]
```

## Linked issue

- Relates #29423

## Variant addition checklist

변경 없음. 해당 없음.
