### PR TITLE
fix(ci): 이슈 라벨이 선언과 어긋나지 않도록 시간당 스윕을 단다

### DIFF
--- a/.github/workflows/issue-taxonomy.yml
+++ b/.github/workflows/issue-taxonomy.yml
@@ -3,10 +3,22 @@ name: Issue Taxonomy
 # Applies taxonomy labels from the masc-triage declaration block in the issue body.
 # The vocabulary SSOT is .github/issue-taxonomy.json. This workflow never creates labels.
 # labeled/unlabeled are not triggers: labelling would re-enter this workflow and storm.
+#
+# The hourly sweep is here because the issues events do not all arrive. On 2026-08-21, 62
+# issues were filed and this workflow ran 16 times; the rest were labelled at creation
+# time by `gh issue create --label`, which puts a human actor on the timeline event and
+# leaves nothing to reconcile the labels against the body afterwards. The measured cost of
+# that on 2026-08-22: 30 open issues whose labels disagree with their own declaration (29
+# of them missing a declared root/*), 6 carrying labels with no declaration block at all,
+# and 7 carrying none. Why the events go missing is not established, so this repairs the
+# state rather than the delivery. A run that changes nothing says nothing, so a quiet
+# repository produces no notifications.
 
 on:
   issues:
     types: [opened, edited, reopened]
+  schedule:
+    - cron: '41 * * * *'
   workflow_dispatch:
     inputs:
       issue_number:
@@ -159,7 +171,7 @@ jobs:
               if (!Number.isInteger(n) || n <= 0) { core.setFailed(`invalid issue number: ${dispatchNumber}`); return; }
               const { data } = await github.rest.issues.get({ owner, repo, issue_number: n });
               issues = [data];
-            } else if (dispatchScope === 'open') {
+            } else if (dispatchScope === 'open' || context.eventName === 'schedule') {
               // listForRepo already carries body and labels; re-fetching each issue would
               // spend the token's hourly budget before the sweep finishes.
               issues = (await github.paginate(github.rest.issues.listForRepo, {

--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -115,7 +115,13 @@ describing the repository.
 
 Humans file through the issue form; keepers file with `gh issue create`. Both produce the same fenced
 `masc-triage` block, so there is one format and one parser. An issue filed without the block gets a comment
-naming the expected shape, and no labels.
+naming the expected shape, and no labels. Do not pass `--label` to `gh issue create`: labels set that way
+have no declaration behind them, and the sweep takes them off again.
+
+The workflow also sweeps every open issue once an hour, because the `issues` events do not all arrive - 62
+issues were filed on 2026-08-21 against 16 workflow runs. The sweep, not the event, is what keeps labels
+and bodies in agreement. It touches only the issues where the two disagree, so a quiet repository produces
+no comments and no notifications.
 
 ### PR status labels
 


### PR DESCRIPTION
## Summary

`Issue Taxonomy` 워크플로에 시간당 스윕을 답니다. 이미 있던 `scope=open` 경로를 그대로 씁니다.

운영 문서는 "분류는 이슈 본문에 선언하고 라벨은 그 투영이다. 그 외에는 아무것도 라벨을 설정하지 않는다" 라고 말합니다. 저장소 상태는 그렇지 않습니다.

08-21 에 이슈 62건이 생겼고 이 워크플로는 16번 돌았습니다. 나머지는 `gh issue create --label` 로 만들 때 라벨이 붙었고, 타임라인 actor 가 사람(`jeong-sik`)으로 남습니다. 게이트가 붙인 건은 `github-actions[bot]` 입니다. 만들 때 붙인 라벨은 이후 본문과 대조되는 일이 없습니다.

## Product impact

- User-visible change: 라벨이 선언과 어긋난 이슈가 자동으로 맞춰집니다. 첫 실행에서 약 40건이 바뀌고, 선언 블록이 없는 11건에 게이트 안내 코멘트가 한 번 달립니다. 이후 정상 상태에서는 아무 변화도 코멘트도 없습니다.

## Evidence

2026-08-22 기준, 열린 이슈 831건 전수. 본문의 선언 블록을 게이트와 같은 규칙으로 파싱해 실제 라벨과 대조했습니다.

| 관측 | 값 |
|------|-----|
| 라벨이 선언과 어긋남 | 30건 (29건이 선언된 `root/*` 누락) |
| 선언 블록 없이 라벨만 있음 | 6건 |
| 그중 `area` 를 2개 단 이슈 | #29331, #29329 — SSOT 가 `cardinality: one` 이라 불가능하다고 말하는 상태 |
| 라벨 없음 | 7건 (#29396 은 선언 블록이 유효한데도 라벨 0개) |
| 08-21 이슈 생성 / 워크플로 실행 | 62건 / 16회 |

이벤트가 왜 유실되는지는 **확인 필요**입니다. 그래서 전달을 고치는 대신 상태를 고칩니다. 원인을 몰라도 닫히는 수리입니다.

## 왜 시간당인가

스윕 1회는 이슈 목록 페이지 9회 + 어긋난 건에 대한 코멘트 조회 몇 회로 API 20회 안팎입니다. 하루 24회면 500회 미만이라 시간당 5,000회 예산에 여유가 있습니다. 정상 상태에서는 라벨 변경이 0건이라 알림도 나가지 않습니다.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 3/3
provenance: direct
stages: [declaration-vs-label-diff-831-issues, workflow-run-census, yaml-and-script-syntax]
```

## 로컬 검증

- 워크플로 YAML 파싱 통과
- 내부 github-script 본문 `node --check` 통과
- `node scripts/test-issue-taxonomy-core.cjs` → pass (파서·조정 계약 변경 없음)

## 남은 것

첫 스윕은 선언 없이 손으로 붙은 라벨 6건을 걷어냅니다. 그 6건은 라벨을 되살리려면 본문에 `masc-triage` 블록을 넣어야 합니다. 의도한 동작입니다.

## Linked issue

- Relates #29423

## Variant addition checklist

OCaml variant / TypeScript union / TLA+ 도메인 / JSON schema enum 변경 없음. 해당 없음.
