### PR TITLE
fix(keeper): 이벤트 큐를 턴 속도로 비우고, Immediate 도착을 맨 앞에 앉힌다

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -135,6 +135,9 @@ let decide_keepalive_cycle_action = function
 type keepalive_turn_outcome = {
   meta : keeper_meta;
   cycle_status : keepalive_cycle_status;
+  stimuli_acked : bool;
+      (** The cycle admitted at least one event-queue stimulus and acked
+          every entry of that batch on completion. *)
 }
 
 let consume_deferred_runtime_lane_hint hint_ref expected =
@@ -411,6 +414,26 @@ let turn_status_event ~turn_fail_count : Keeper_state_machine.event =
   else Keeper_state_machine.Turn_succeeded
 ;;
 
+(* Whether the event queue still holds any pending entry. Read errors are
+   logged and answered [false]: the cycle then sleeps the cadence and the
+   next intake reports the same error through its own path. *)
+let pending_stimulus_remains ~ctx ~keeper_name =
+  match
+    Keeper_registry_event_queue.peek_when_result
+      ~base_path:ctx.config.base_path
+      keeper_name
+      ~ready:(fun (_ : Keeper_event_queue.stimulus) -> true)
+  with
+  | Ok (Some _) -> true
+  | Ok None -> false
+  | Error detail ->
+    Log.Keeper.warn
+      ~keeper_name
+      "event queue peek after acked cycle failed; sleeping the cadence: %s"
+      detail;
+    false
+;;
+
 let run_keepalive_unified_turn
       ~(ctx : _ context)
       ~(meta_after_triage : keeper_meta)
@@ -426,7 +449,11 @@ let run_keepalive_unified_turn
   : keepalive_turn_outcome
   =
   if not proactive_warmup_elapsed
-  then { meta = meta_after_triage; cycle_status = Turn_cycle_completed }
+  then
+    { meta = meta_after_triage
+    ; cycle_status = Turn_cycle_completed
+    ; stimuli_acked = false
+    }
   else
     match
       Keeper_owner_registry.run_autonomous_if_idle
@@ -455,6 +482,7 @@ let run_keepalive_unified_turn
     in
     let cycle_outcome_ref = ref None in
     let selection_acked = ref false in
+    let stimuli_acked = ref false in
     let event_queue_failed = ref false in
     let record_event_queue_failure message =
       event_queue_failed := true;
@@ -944,6 +972,7 @@ let run_keepalive_unified_turn
                  (fun selection -> terminalize_completed_selection ~selection)
                  selections
              in
+             stimuli_acked := all_acked;
              if all_acked
              then (
                let event_ids =
@@ -1019,6 +1048,7 @@ let run_keepalive_unified_turn
       { meta = meta_after_cycle
       ; cycle_status =
           if !event_queue_failed then Turn_cycle_crashed else Turn_cycle_completed
+      ; stimuli_acked = !stimuli_acked
       }
     with
     | Eio.Cancel.Cancelled _ as e ->
@@ -1035,7 +1065,10 @@ let run_keepalive_unified_turn
         ~base_path:ctx.config.base_path
         ~keeper_name:meta_after_triage.name
         exn;
-      { meta = meta_after_triage; cycle_status = Turn_cycle_crashed }))
+      { meta = meta_after_triage
+      ; cycle_status = Turn_cycle_crashed
+      ; stimuli_acked = false
+      }))
     with
   | Ok (`Ran outcome) -> outcome
   | Ok (`Busy ((Keeper_owner.Turn_busy (Some in_flight)) as block)) ->
@@ -1044,9 +1077,15 @@ let run_keepalive_unified_turn
       "keeper owner busy before stimulus intake: %s"
       (Keeper_owner.autonomous_block_to_string
          (Keeper_owner.Turn_busy (Some in_flight)));
-    { meta = meta_after_triage; cycle_status = Turn_cycle_busy block }
+    { meta = meta_after_triage
+    ; cycle_status = Turn_cycle_busy block
+    ; stimuli_acked = false
+    }
   | Ok (`Busy block) ->
-    { meta = meta_after_triage; cycle_status = Turn_cycle_busy block }
+    { meta = meta_after_triage
+    ; cycle_status = Turn_cycle_busy block
+    ; stimuli_acked = false
+    }
   | Error
       (Keeper_owner_registry.Command_rejected Keeper_owner.Owner_stopping) ->
     { meta = meta_after_triage; cycle_status = Turn_cycle_completed }
@@ -1403,15 +1442,25 @@ let run_heartbeat_loop
           ~t_turn_end;
         (* Carry the inter-cycle sleep result into the next iteration so the
            turn evaluator can distinguish a broadcast wakeup ([Woken]) from this
-           keeper's configured cadence ([Timeout]). *)
+           keeper's configured cadence ([Timeout]).
+
+           A cycle that acked its stimulus batch and left more entries pending
+           does not sleep the cadence: the queue is the wake signal, and the
+           next cycle dispatches as [Woken]. A checkpointed, failed, or busy
+           cycle keeps the cadence so a turn that made no progress is not
+           re-run back to back. *)
         last_wake_source :=
-          Keeper_keepalive_signal.interruptible_sleep
-            ~cadence_sleeping
-            ~clock:ctx.clock
-            ~stop
-            ~wakeup
-            (fun () ->
-              float_of_int (Keeper_heartbeat_snapshot.keepalive_interval_sec ()));
+          (if turn_outcome.stimuli_acked
+              && pending_stimulus_remains ~ctx ~keeper_name:m.name
+           then Keeper_keepalive_signal.Woken
+           else
+             Keeper_keepalive_signal.interruptible_sleep
+               ~cadence_sleeping
+               ~clock:ctx.clock
+               ~stop
+               ~wakeup
+               (fun () ->
+                 float_of_int (Keeper_heartbeat_snapshot.keepalive_interval_sec ())));
       if Atomic.get stop then () else loop ())
   in
   loop ()

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -1088,13 +1088,19 @@ let run_keepalive_unified_turn
     }
   | Error
       (Keeper_owner_registry.Command_rejected Keeper_owner.Owner_stopping) ->
-    { meta = meta_after_triage; cycle_status = Turn_cycle_completed }
+    { meta = meta_after_triage
+    ; cycle_status = Turn_cycle_completed
+    ; stimuli_acked = false
+    }
   | Error error ->
     Log.Keeper.error
       ~keeper_name:meta_after_triage.name
       "keeper owner rejected autonomous turn: %s"
       (Keeper_owner_registry.command_error_to_string error);
-    { meta = meta_after_triage; cycle_status = Turn_cycle_crashed }
+    { meta = meta_after_triage
+    ; cycle_status = Turn_cycle_crashed
+    ; stimuli_acked = false
+    }
 ;;
 
 let refresh_work_as_heartbeat = Keeper_heartbeat_loop_refresh_work.refresh_work_as_heartbeat
@@ -1326,7 +1332,11 @@ let run_heartbeat_loop
         let t_turn_start = t_board_end in
         let turn_outcome =
           if not admitted_turn
-          then { meta = meta_current; cycle_status = Turn_cycle_completed }
+          then
+            { meta = meta_current
+            ; cycle_status = Turn_cycle_completed
+            ; stimuli_acked = false
+            }
           else (
             (* Cycle 43: KeeperHeartbeat.tla TurnComplete bracket — the
                [turn_running] flag toggles around the dispatch and the

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -134,6 +134,10 @@ val decide_keepalive_cycle_action :
 type keepalive_turn_outcome = {
   meta : keeper_meta;
   cycle_status : keepalive_cycle_status;
+  stimuli_acked : bool;
+      (** The cycle admitted at least one event-queue stimulus and acked
+          every entry of that batch on completion. The loop reads it to
+          skip the cadence sleep while more entries are pending. *)
 }
 
 (** Record a swallowed keepalive-cycle exception as a turn failure:

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -235,8 +235,13 @@ let with_pending pending state =
       in
       reconcile available (entry :: acc) rest
   in
+  (* Urgency order is a property of the pending list, not of the
+     reprioritize/defer transitions alone: an [Immediate] arrival lands ahead
+     of every [Normal] entry on arrival, and the sort is stable so arrival
+     order is kept among entries of the same urgency. *)
   let pending_entries =
-    Keeper_event_queue.to_list pending
+    Keeper_event_queue.sort_by_urgency pending
+    |> Keeper_event_queue.to_list
     |> Keeper_event_queue.uniq_stimuli
     |> reconcile state.pending_entries []
   in

--- a/test/test_keeper_connector_attention_batch.ml
+++ b/test/test_keeper_connector_attention_batch.ml
@@ -184,10 +184,13 @@ let connector_attention_stimulus
 (* A Board_signal distractor that is never expected to be read: it exists
    only to prove the batch filter skips a non-[Connector_attention] entry
    sitting between two conversation matches instead of taking a naive
-   contiguous prefix. *)
+   contiguous prefix. It shares the connector entries' [Low] urgency so the
+   pending list keeps it between them: a [Normal] entry would sort ahead of
+   both and be admitted first, which is urgency order working as designed,
+   not the case this fixture isolates. *)
 let board_distractor_stimulus ~post_id ~arrived_at : Q.stimulus =
   { Q.post_id
-  ; urgency = Q.Normal
+  ; urgency = Q.Low
   ; arrived_at
   ; payload =
       Q.Board_signal

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -496,6 +496,42 @@ let test_durable_peek_ack_restart () =
     Alcotest.(check (list string)) "restart sees only unacked source" [ "two" ] (post_ids restarted))
 ;;
 
+(* taskmaster, 2026-08-22: two Immediate completion_authority_rejected
+   stimuli sat at queue_index 41 and 48 behind forty Normal entries because
+   enqueue only appended. Urgency is a property of the pending list. *)
+let test_immediate_arrival_precedes_pending_normal_entries () =
+  with_temp_dir "keeper-pending-urgency-arrival" (fun base_path ->
+    let keeper_name = "urgency-keeper" in
+    let immediate =
+      { (stimulus "urgent" 3.0) with urgency = Queue.Immediate }
+    in
+    Persistence.update_result ~base_path ~keeper_name (fun pending ->
+      let pending = Queue.enqueue pending (stimulus "first" 1.0) in
+      let pending = Queue.enqueue pending (stimulus "second" 2.0) in
+      Queue.enqueue pending immediate)
+    |> require_ok "seed pending with a late Immediate arrival";
+    let restarted =
+      Persistence.load_pending_result ~base_path ~keeper_name
+      |> require_ok "restart load"
+    in
+    Alcotest.(check (list string))
+      "Immediate arrival is selected first; Normal entries keep arrival order"
+      [ "urgent"; "first"; "second" ]
+      (post_ids restarted);
+    let selected =
+      Persistence.select_when_result
+        ~base_path
+        ~keeper_name
+        ~ready:(fun _ -> true)
+      |> require_ok "select head"
+      |> require_some "head selection"
+    in
+    Alcotest.(check string)
+      "head is the Immediate entry"
+      "urgent"
+      selected.source.Queue.post_id)
+;;
+
 let test_durable_reprioritize_is_source_incarnation_fenced () =
   with_temp_dir "keeper-event-reprioritize" (fun base_path ->
     let keeper_name = "priority-keeper" in
@@ -923,6 +959,10 @@ let () =
         ] )
     ; ( "persistence"
       , [ Alcotest.test_case "durable peek ack restart" `Quick test_durable_peek_ack_restart
+        ; Alcotest.test_case
+            "Immediate arrival precedes pending Normal entries"
+            `Quick
+            test_immediate_arrival_precedes_pending_normal_entries
         ; Alcotest.test_case
             "durable reprioritize is source incarnation fenced"
             `Quick


### PR DESCRIPTION
## 현상

`taskmaster` 이벤트 큐에 미처리 52건(2026-08-21T07:17Z 부터 schedule_due 16 · board_attention 34 · task_cancelled 1 · completion_authority_rejected 2), `analyst` 11건. keeper 는 계속 task 를 claim/release 하며 돌고 있는데도 큐가 18시간째 줄지 않았습니다.

## 원인 (실측)

드레인은 모델이 고르는 도구가 아니라 런타임이 매 자율 사이클 진입 시 합니다(`keeper_heartbeat_loop.ml` → `heartbeat_event_intake`). 그런데

1. 사이클당 stimulus **1건** admit (RFC-0020 §3 Rule 4, Connector_attention 만 RFC-0377 배치 예외)
2. admit 뒤 **300초 고정 수면** — `wakeup` atomic 은 새 enqueue 때만 set 되고, 잔여 pending 이 50건이어도 루프는 큐를 보지 않고 cadence 를 잡니다. 실측: 사이클 종료→다음 intake 간격 120건 중 95건이 295~320초(p50 302초), 턴 자체는 p50 54초. **벽시계의 85% 가 대기.**
3. Checkpointed 사이클은 ack 없이 같은 head 를 재admit — 07:17Z 이후 128 사이클 중 36건, intake 122회 중 45회(37%)가 같은 head 재읽기.
4. urgency 미반영 — `enqueue` 는 append 뿐이라 `Immediate` 인 completion_authority_rejected 2건이 queue_index 41·48 에서 Normal 40건 뒤에 대기.

18.9시간 수치: 자율 사이클 ≈118, ack 78 (≈4.1/h), 도착 57 (≈3.0/h), pending 52→55. 0.24.0 배포와 무관(드레인 경로 diff 없음).

## 바꾼 것 (게이트·캡 없음)

- **acked 사이클 뒤 수면 생략**: `keepalive_turn_outcome` 에 `stimuli_acked : bool` 추가. admit 한 배치를 전부 ack 한 사이클이 끝났을 때 큐에 pending 이 남아 있으면(`Keeper_registry_event_queue.peek_when_result ~ready:(fun _ -> true)`) 300초를 자지 않고 다음 사이클을 `Woken` 으로 돌립니다. Checkpointed/Failed/Busy 사이클은 기존대로 cadence 를 잡니다 — 진전 없는 턴을 연달아 돌리지 않기 위한 **상태 조건**이지 cooldown 이 아닙니다.
- **urgency 는 pending 목록의 성질**: `Keeper_event_queue_state.with_pending` 이 유일한 writer 이므로 거기서 `sort_by_urgency`(stable) 를 적용. Immediate 도착이 Normal 앞에 앉고, 같은 urgency 끼리는 도착순 유지. reprioritize/defer 의 기존 정렬은 그대로(멱등).

기대 효과: 처리량 상한 12/h → 턴 길이 bound(p50 54초 ≈ 60/h). taskmaster 백로그 52건은 약 1시간에 소진.

## 테스트

- `test_keeper_event_queue_state_v2`: `Immediate arrival precedes pending Normal entries` — Normal 2건 뒤에 Immediate 도착 → 재로드 순서 `[urgent; first; second]`, `select_when` head = urgent.
- 기존 reprioritize 테스트의 `[2.0; 1.0; 3.0]` 기대는 그대로 성립(stable sort).
- 루프 쪽 변경은 live 관측으로 검증합니다: 병합·배포 후 taskmaster `event_queue_pending` 카운트와 사이클 간격 p50 을 같은 스크립트(`scratchpad/tm-timeline.tsv` 생성 방법)로 다시 잽니다.

## 남겨둔 것 (후속 PR / RFC)

- 사이클당 1건 → ready 전부 배치 admit (RFC-0377 일반화). 배치 admit 은 `Batch_quarantine` 이 런타임 귀책 실패로 N 건을 한꺼번에 폐기하는 문제와 얽혀 있어 RFC 선행.
- 묵은 `Schedule_due` occurrence(18h~112h 지연 65건)가 풀 LLM 턴을 소비하는 문제 — 같은 schedule_id 의 occurrence 묶음 투영.
- 대시보드 `작업 대기열` 이 최신순 정렬에 "HEAD" 라벨을 붙여 실제 드레인 head(가장 오래된 행)와 반대 — 대시보드 PR 에서 다룹니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3a8sWueQQPyYyoXerLJvj
