### PR TITLE
feat(catalog): Antigravity 구독용 gemini-3.7-flash 행 추가

### DIFF
--- a/packages/agent_core/models.toml
+++ b/packages/agent_core/models.toml
@@ -1528,6 +1528,19 @@ supports_reasoning_budget = true
 accepted_reasoning_efforts = []
 
 [[models]]
+# gemini-3.7-flash-{high,medium,low}, served through the Antigravity Google
+# subscription (agy 1.1.17 `agy models` lists the three). Official page
+# ai.google.dev/gemini-api/docs/models/gemini-3.7-flash, read 2026-08-22:
+# 1,048,576 in / 65,536 out, thinking low|medium|high — "minimal is not
+# supported and returns an error", so it is not admitted here.
+id_prefix = "gemini-3.7-flash"
+base = "gemini"
+max_context_tokens = 1048576
+max_output_tokens = 65536
+supports_reasoning_budget = false
+accepted_reasoning_efforts = ["low", "medium", "high"]
+
+[[models]]
 # gemini-3.6-flash-{high,medium,low}, served through the Antigravity Google
 # subscription. Without this row they prefix-match the generic "gemini-3" row,
 # which declares no accepted_reasoning_efforts at all — so no effort level is

--- a/packages/agent_core/test/test_model_catalog_default.ml
+++ b/packages/agent_core/test/test_model_catalog_default.ml
@@ -32,6 +32,9 @@ let subscription_model_rows =
   ; "gpt-5.6-terra", "gpt-5.6"
   ; "gpt-5.6-luna", "gpt-5.6"
   ; "gpt-5.3-codex-spark", "gpt-5.3-codex-spark"
+  ; "gemini-3.7-flash-high", "gemini-3.7-flash"
+  ; "gemini-3.7-flash-medium", "gemini-3.7-flash"
+  ; "gemini-3.7-flash-low", "gemini-3.7-flash"
   ; "gemini-3.6-flash-high", "gemini-3.6-flash"
   ; "gemini-3.6-flash-medium", "gemini-3.6-flash"
   ; "gemini-3.6-flash-low", "gemini-3.6-flash"
@@ -70,6 +73,7 @@ let subscription_model_efforts =
   [ "claude-opus-5", [ "low"; "medium"; "high"; "xhigh"; "max" ]
   ; "gpt-5.6-sol", [ "none"; "minimal"; "low"; "medium"; "high"; "xhigh" ]
   ; "gpt-5.3-codex-spark", [ "none"; "minimal"; "low"; "medium"; "high"; "xhigh" ]
+  ; "gemini-3.7-flash-high", [ "low"; "medium"; "high" ]
   ; "gemini-3.6-flash-high", [ "minimal"; "low"; "medium"; "high" ]
   ]
 ;;


### PR DESCRIPTION
## Evidence Record

- **Evidence**: https://ai.google.dev/gemini-api/docs/models/gemini-3.7-flash (model code `gemini-3.7-flash`, Stable, 입력 1,048,576 / 출력 65,536, thinking `low|medium|high`, "minimal is not supported and returns an error"), https://ai.google.dev/gemini-api/docs/models (3.x 목록에 `gemini-3.7-flash` 만 추가 — pro/flash-lite/preview 접미사 없음), https://blog.google/innovation-and-ai/models-and-research/gemini-models/introducing-gemini-3-7-flash/ (2026-08-13 발표, 노출 표면에 Google Antigravity 포함), 로컬 `agy` 1.1.17 `agy models` 에 `gemini-3.7-flash-{high,medium,low}` 3개 노출.
- **Timestamp**: 2026-08-22T02:05Z
- **Confidence**: High (API id·한도·thinking 레벨·발표일 전부 공식 페이지 원문). Vertex 가용성은 공식 페이지 미언급 → 확인 필요.
- **Delta vs 3.6**: id 만 바뀌고 컨텍스트/출력/가격 동일. 3.7 은 `minimal` 을 오류로 거부하므로 3.6 행(`["minimal","low","medium","high"]`)을 복사하지 않았습니다.

## 바꾼 것

- `packages/agent_core/models.toml`: `id_prefix = "gemini-3.7-flash"` 행 (1,048,576 / 65,536, efforts `low|medium|high`). 이 행이 없으면 `gemini-3.7-flash-high` 는 generic `gemini-3` 행에 prefix 매치되어 effort 가 하나도 admit 되지 않습니다.
- `test_model_catalog_default.ml`: `subscription_model_rows` 3줄, `subscription_model_efforts` 1줄.

official-client 실행은 카탈로그 면제(`runtime.ml:807-815`)라 턴 동작은 불변이고, HTTP 백엔드와 대시보드 runtime info 가 읽는 데이터 정정입니다.

## 런타임 (이 PR 밖, 운영자 작업)

`~/me/.masc/config/runtime.toml` 에 3-6 행과 같은 모양으로 `[models.gemini-3-7-flash-{high,medium,low}]` + `[antigravity_subscription.gemini-3-7-flash-*]` 를 추가하면 됩니다(`/api/v1/runtime/config/raw` RMW 로 핫리로드, 직접 편집은 무시됨). 명시 lane·analyst 배정·`fusion.presets.subscription_trio` 교체는 3.6 때와 같이 10턴 canary(`--expect-runtime` 실서빙 검증) PASS 뒤에.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3a8sWueQQPyYyoXerLJvj
