### PR TITLE
fix(tool): 지원하지 않는 필드 거부 문구에 허용 필드 목록을 싣는다

### DIFF
--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -165,8 +165,6 @@ let schema_shape_json schema =
   `Assoc fields
 ;;
 
-let schema_has_property_name schema name = List.mem name (schema_property_names schema)
-
 let prepare_args ?schema:_ ~name:_ args = strip_internal_marker_args args
 
 let schema_has_properties = function
@@ -199,8 +197,6 @@ let unsupported_arg_names schema = function
     |> List.sort_uniq String.compare
   | _ -> []
 ;;
-
-let schema_has_property schema name = schema_has_property_name schema name
 
 type one_of_branch = {
   required : string list;

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -202,21 +202,6 @@ let unsupported_arg_names schema = function
 
 let schema_has_property schema name = schema_has_property_name schema name
 
-let typed_shell_unsupported_field_hint schema names =
-  let has_shell_fields =
-    schema_has_property schema "argv" && schema_has_property schema "pipeline"
-  in
-  let has_legacy_shell_string =
-    List.exists (fun name -> String.equal name "cmd" || String.equal name "command") names
-  in
-  if has_shell_fields && has_legacy_shell_string
-  then
-    Some
-      "typed shell execution has no cmd/command field; use one non-empty argv \
-       process vector, e.g. argv=[\"git\",\"status\",\"--short\"]"
-  else None
-;;
-
 type one_of_branch = {
   required : string list;
   consts : (string * Yojson.Safe.t) list;
@@ -317,17 +302,24 @@ let one_of_required_shape_error schema = function
   | _ -> None
 ;;
 
+(* The rejection names the fields the schema does accept, so the model can
+   correct the call from the message alone instead of guessing a new name
+   (analyst, 2026-08-22: agent → agent_name → author before it found the
+   declared shape). *)
 let schema_shape_error schema args =
   match unsupported_arg_names schema args with
   | name :: names ->
-    let names = name :: names in
-    let names_text = String.concat ", " names in
-    let hint =
-      match typed_shell_unsupported_field_hint schema names with
-      | None -> ""
-      | Some hint -> "; " ^ hint
+    let names_text = String.concat ", " (name :: names) in
+    let accepted =
+      match property_names schema with
+      | [] -> "(none)"
+      | accepted -> String.concat ", " accepted
     in
-    Some (Printf.sprintf "received unsupported field(s): %s%s" names_text hint)
+    Some
+      (Printf.sprintf
+         "received unsupported field(s): %s; accepted: %s"
+         names_text
+         accepted)
   | [] -> one_of_required_shape_error schema args
 ;;
 

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -960,9 +960,9 @@ let test_validate_args_tool_execute_rejects_cmd_string () =
       (String.length msg > 0);
     assert_policy_validation_payload ~label:"cmd string" result;
     Alcotest.(check bool)
-      "validation error points to typed argv"
+      "validation error names the accepted fields"
       true
-      (string_contains msg "argv=[\\\"git\\\",\\\"status\\\",\\\"--short\\\"]")
+      (string_contains msg "accepted: argv")
 
 let test_validate_args_tool_execute_rejects_command_string () =
   let args = `Assoc [ "command", `String "pwd" ] in
@@ -981,9 +981,9 @@ let test_validate_args_tool_execute_rejects_command_string () =
       true
       (string_contains msg "unsupported field(s): command");
     Alcotest.(check bool)
-      "validation error says command field is unavailable"
+      "validation error names the accepted fields"
       true
-      (string_contains msg "no cmd/command field")
+      (string_contains msg "accepted: argv")
 
 let test_validate_args_tool_execute_rejects_background_flag () =
   let args =
@@ -1806,7 +1806,7 @@ let test_typed_tool_contract_rejection_corpus () =
       , "tool_execute"
       , tool_execute_schema
       , `Assoc [ "cmd", `String "git status --short" ]
-      , [ "cmd"; "non-empty argv" ] )
+      , [ "cmd"; "accepted: argv" ] )
     ; ( "keeper_task_done notes-only drift"
       , "keeper_task_done"
       , keeper_task_done_schema


### PR DESCRIPTION
## 현상

`Tool 'masc_board_post' received unsupported field(s): agent` — 모델은 무엇을 틀렸는지는 듣지만 스키마가 무엇을 받는지는 못 듣습니다. analyst 턴(2026-08-22T01:39Z)은 `agent` → `agent_name, author, post_kind` → 성공 순으로 세 번 시도했습니다. `schema_shape_error` 는 `property_names schema` 를 손에 쥐고도 목록을 생략하고 있었습니다(`lib/tool_input_validation.ml`).

## 바꾼 것

- 거부 문구: `received unsupported field(s): <names>; accepted: <schema property names>` (속성이 없으면 `(none)`).
- `typed_shell_unsupported_field_hint` 삭제. 필드 이름이 `cmd`/`command` 인지 문자열로 분류해 argv 힌트를 붙이던 장치인데, 허용 목록(`argv, pipeline, …`)이 모든 도구에 같은 정보를 분류기 없이 줍니다.

## 테스트

`test_tool_input_validation`: cmd/command 케이스 2건이 `accepted: argv` 를 단언하도록 교체, 테이블 케이스 `execute raw cmd string` 의 기대 조각을 `accepted: argv` 로. `unsupported field(s): <name>` 접두는 그대로라 기존 pin 11건은 유지됩니다.

`mcp_server_eio_tool_profile.ml` 의 MCP 파라미터 거부("Invalid params: unsupported field(s)")는 다른 스키마 경로라 이번 범위 밖입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3a8sWueQQPyYyoXerLJvj
