### PR TITLE
docs(labels): 라벨 설명을 실제로 쓰는 말로 다시 쓴다

### DIFF
--- a/.github/issue-taxonomy.json
+++ b/.github/issue-taxonomy.json
@@ -7,27 +7,27 @@
         "defect": {
           "label": "kind/defect",
           "color": "1d76db",
-          "description": "부르면 동작은 하는데 결과가 틀리다. 되던 게 안 되는 것도 여기"
+          "description": "동작은 하는데 결과가 틀리다. 잘 되던 게 안 되는 것도 여기"
         },
         "gap": {
           "label": "kind/gap",
           "color": "1d76db",
-          "description": "부를 경로가 아예 없다. 이름·타입만 있고 실제로 이어지지 않았다"
+          "description": "만들다 말았다. 이름만 있고 실제로 동작하는 코드가 없다"
         },
         "capability": {
           "label": "kind/capability",
           "color": "1d76db",
-          "description": "새로 만들어 달라는 요청. 대응하는 약속 자체가 아직 없다"
+          "description": "새 기능을 만들어 달라는 요청. 원래부터 없던 기능이다"
         },
         "erosion": {
           "label": "kind/erosion",
           "color": "1d76db",
-          "description": "지울 것. 안 쓰는 코드, 실험하다 남은 것, 사실과 다른 문서"
+          "description": "지워야 할 것. 안 쓰는 코드, 실험하다 남은 것, 틀린 문서"
         },
         "inquiry": {
           "label": "kind/inquiry",
           "color": "1d76db",
-          "description": "버그인지 아직 모른다. 재현하거나 재보는 일이 먼저다"
+          "description": "버그인지 아직 모른다. 먼저 확인해 봐야 한다"
         }
       },
       "required": true,
@@ -38,67 +38,67 @@
         "turn": {
           "label": "area/turn",
           "color": "5319e7",
-          "description": "턴을 돌리는 쪽. 스케줄러·DrainQueue·자율 루프"
+          "description": "턴을 실행하는 곳. 스케줄러, 대기열, 자동 반복"
         },
         "continuity": {
           "label": "area/continuity",
           "color": "5319e7",
-          "description": "턴 사이를 잇는 쪽. 컨텍스트·컴팩션·기억·회상"
+          "description": "턴이 끝나도 기억이 이어지게 하는 곳. 대화 저장·요약·다시 불러오기"
         },
         "collab": {
           "label": "area/collab",
           "color": "5319e7",
-          "description": "Keeper끼리 주고받는 쪽. Broadcast·Board·Comment"
+          "description": "Keeper 끼리 이야기하는 곳. Broadcast, Board, 댓글"
         },
         "goal-task": {
           "label": "area/goal-task",
           "color": "5319e7",
-          "description": "Goal·Task·Plan 도메인"
+          "description": "Goal, Task, Plan 을 다루는 곳"
         },
         "verification": {
           "label": "area/verification",
           "color": "5319e7",
-          "description": "Verifier·Judge·Judge-of-Judge·Fusion·교차 검증"
+          "description": "결과가 맞는지 검사하는 곳. Verifier, Judge, 여러 번 다르게 검사"
         },
         "tools": {
           "label": "area/tools",
           "color": "5319e7",
-          "description": "도구 목록과 실행. Multi/Async/Batch·Sandbox·MCP"
+          "description": "도구를 고르고 실행하는 곳. Sandbox, MCP"
         },
         "runtime": {
           "label": "area/runtime",
           "color": "5319e7",
-          "description": "무엇으로 부를지. 프로바이더·모델·런타임 레인·대체 경로"
+          "description": "어떤 AI 모델로 부를지 정하는 곳. 실패했을 때 다른 모델로 넘기는 것도 여기"
         },
         "transport": {
           "label": "area/transport",
           "color": "5319e7",
-          "description": "어떻게 실어 나를지. 인증·헬스체크·프로토콜·전송 계층"
+          "description": "네트워크로 주고받는 곳. 로그인, 상태 확인, 통신 방식"
         },
         "dashboard": {
           "label": "area/dashboard",
           "color": "5319e7",
-          "description": "관측 데이터를 보여주는 쪽. 대시보드·TUI·읽기 모델"
+          "description": "사람에게 보여 주는 화면. 대시보드, TUI"
         },
         "connector": {
           "label": "area/connector",
           "color": "5319e7",
-          "description": "밖으로 내보내는 쪽. Slack·Discord 등"
+          "description": "밖으로 내보내는 곳. Slack, Discord"
         },
         "observability": {
           "label": "area/observability",
           "color": "5319e7",
-          "description": "관측 데이터를 만드는 쪽. 로그·메트릭·트레이스·스트리밍"
+          "description": "무슨 일이 있었는지 남기는 곳. 로그, 숫자 기록, 추적"
         },
         "persistence": {
           "label": "area/persistence",
           "color": "5319e7",
-          "description": "디스크에 쓰고 읽는 쪽. 저장소·원장(ledger)·체크포인트"
+          "description": "디스크에 저장하고 다시 읽는 곳. 파일, ledger, 중간 저장"
         },
         "ci": {
           "label": "area/ci",
           "color": "5319e7",
-          "description": "CI·빌드·릴리스. 되돌림 방지 기준선(ratchet) 포함"
+          "description": "빌드하고 테스트하고 배포하는 곳. 자동 검사도 여기"
         }
       },
       "required": true,
@@ -109,27 +109,27 @@
         "breaks-continuity": {
           "label": "impact/breaks-continuity",
           "color": "b60205",
-          "description": "1순위 · 턴이 멈추거나 기억이 안 이어진다. 이러면 제품이라 할 수 없다"
+          "description": "1순위 · 턴이 멈추거나 앞 내용을 기억 못 한다. 이러면 제품이 아니다"
         },
         "breaks-collab": {
           "label": "impact/breaks-collab",
           "color": "d93f0b",
-          "description": "2순위 · Keeper끼리 말이 안 닿거나, 결과가 엉뚱한 데로 간다"
+          "description": "2순위 · Keeper 끼리 말이 안 통하거나, 결과가 엉뚱한 곳으로 간다"
         },
         "blinds-operator": {
           "label": "impact/blinds-operator",
           "color": "e99695",
-          "description": "3순위 · 돌긴 도는데 사람이 볼 수가 없다"
+          "description": "3순위 · 동작은 하는데 사람이 상태를 볼 수 없다"
         },
         "degrades": {
           "label": "impact/degrades",
           "color": "fbca04",
-          "description": "4순위 · 느리거나 번거롭거나, 정확도가 떨어진다"
+          "description": "4순위 · 느리거나, 불편하거나, 결과가 덜 정확하다"
         },
         "internal": {
           "label": "impact/internal",
           "color": "c5c5c5",
-          "description": "5순위 · 개발할 때만 걸린다. 사용자에게는 안 보인다"
+          "description": "5순위 · 개발할 때만 불편하다. 쓰는 사람은 모른다"
         }
       },
       "required": true,
@@ -147,42 +147,42 @@
         "ssot": {
           "label": "root/ssot",
           "color": "d4a017",
-          "description": "같은 값이 여러 군데에 따로 있다. 원본이 하나가 아니다"
+          "description": "같은 정보가 여러 곳에 따로 적혀 있다. 어디가 진짜인지 모른다"
         },
         "silent": {
           "label": "root/silent",
           "color": "d4a017",
-          "description": "실패했는데 조용히 넘어간다. 기본값으로 때우거나 그냥 통과시킨다"
+          "description": "실패했는데 아무 말 없이 넘어간다. 에러를 숨기고 기본값을 쓴다"
         },
         "string": {
           "label": "root/string",
           "color": "d4a017",
-          "description": "문자열을 맞춰 보고 갈라진다. 타입으로 안 갈랐다"
+          "description": "글자를 맞춰 보고 처리를 나눈다. 오타 하나에 무너진다"
         },
         "variant": {
           "label": "root/variant",
           "color": "d4a017",
-          "description": "와일드카드가 갈래를 삼킨다. 모든 경우를 안 따졌다"
+          "description": "경우를 다 안 따졌다. 나머지로 뭉뚱그려서 새 경우가 조용히 무시된다"
         },
         "boundary": {
           "label": "root/boundary",
           "color": "d4a017",
-          "description": "의존 방향이 거꾸로거나, 남의 책임까지 들고 있다"
+          "description": "부르면 안 되는 쪽을 부른다. 남이 할 일까지 가져다 한다"
         },
         "telemetry": {
           "label": "root/telemetry",
           "color": "d4a017",
-          "description": "볼 수가 없다. 메트릭·스팬·이어 볼 실마리가 빠졌다"
+          "description": "무슨 일이 있었는지 기록이 없다. 나중에 볼 수가 없다"
         },
         "det": {
           "label": "root/det",
           "color": "d4a017",
-          "description": "입력이 한 모양일 거라 믿는다. 동시에 들어오는 경우를 안 봤다"
+          "description": "항상 똑같이 들어온다고 믿는다. 순서가 바뀌거나 동시에 오면 깨진다"
         },
         "ndt": {
           "label": "root/ndt",
           "color": "d4a017",
-          "description": "흔들리는 걸 확정처럼 다룬다. 재시도·대체 경로·지터가 없다"
+          "description": "실패할 수 있다는 걸 안 챙겼다. 한 번 실패하면 그대로 멈춘다"
         }
       },
       "required": false,
@@ -193,7 +193,7 @@
     "must-do": {
       "label": "must-do",
       "color": "000000",
-      "description": "지금 당장. 제품이 한 약속을 지금 깨고 있다"
+      "description": "지금 당장 고쳐야 한다. 제품이 되어야 할 일이 지금 안 되고 있다"
     }
   }
 }

--- a/.github/pull-request-labels.json
+++ b/.github/pull-request-labels.json
@@ -5,22 +5,22 @@
     "conflict": {
       "label": "pr/conflict",
       "color": "006b75",
-      "description": "base 와 충돌한다. 이 상태에서는 CI 가 아예 돌지 않는다"
+      "description": "다른 수정과 부딪혀서 합칠 수 없다. 이 상태면 CI 검사도 새로 안 돈다"
     },
     "review-changes": {
       "label": "pr/review-changes",
       "color": "006b75",
-      "description": "리뷰에서 변경 요청을 받았다. 저자가 답할 차례"
+      "description": "리뷰에서 고쳐 달라고 했다. 올린 사람이 답할 차례"
     },
     "review-approved": {
       "label": "pr/review-approved",
       "color": "006b75",
-      "description": "리뷰 승인. 남은 것은 필수 체크 통과뿐"
+      "description": "리뷰 통과. 검사만 다 초록이면 합칠 수 있다"
     },
     "unresolved": {
       "label": "pr/unresolved",
       "color": "006b75",
-      "description": "아직 닫지 않은 리뷰 스레드가 있다"
+      "description": "아직 안 닫힌 리뷰 댓글이 남아 있다"
     }
   }
 }


### PR DESCRIPTION
## Summary

앞선 #29423 이 영어 번역투를 걷어냈지만, 대신 시적인 한국어로 바꿔 놓고 개선이라고 했습니다. `약속`(contract), `갈래를 삼킨다`, `되돌림 방지 기준선`(ratchet) — 답을 모르는 사람은 여전히 값을 고를 수 없습니다.

이번에는 사람이 실제로 쓰는 말로 씁니다.

| 라벨 | #29423 | 이 PR |
|---|---|---|
| `kind/capability` | 새로 만들어 달라는 요청. 대응하는 약속 자체가 아직 없다 | 새 기능을 만들어 달라는 요청. 원래부터 없던 기능이다 |
| `root/variant` | 와일드카드가 갈래를 삼킨다. 모든 경우를 안 따졌다 | 경우를 다 안 따졌다. 나머지로 뭉뚱그려서 새 경우가 조용히 무시된다 |
| `root/det` | 입력이 한 모양일 거라 믿는다. 동시에 들어오는 경우를 안 봤다 | 항상 똑같이 들어온다고 믿는다. 순서가 바뀌거나 동시에 오면 깨진다 |
| `root/boundary` | 의존 방향이 거꾸로거나, 남의 책임까지 들고 있다 | 부르면 안 되는 쪽을 부른다. 남이 할 일까지 가져다 한다 |
| `area/ci` | CI·빌드·릴리스. 되돌림 방지 기준선(ratchet) 포함 | 빌드하고 테스트하고 배포하는 곳. 자동 검사도 여기 |
| `area/persistence` | 디스크에 쓰고 읽는 쪽. 저장소·원장(ledger)·체크포인트 | 디스크에 저장하고 다시 읽는 곳. 파일, ledger, 중간 저장 |

## Product impact

- User-visible change: 라벨 설명 문구만 바뀝니다. 어휘·값·동작 변화 없음.

## Evidence

- `node scripts/test-issue-taxonomy-core.cjs` → pass
- diff 는 description 줄 36개뿐 (issue 32 + pr 4)
- 가장 긴 설명 44자, GitHub 상한 100자

## Linked issue

- Relates #29423

## Variant addition checklist

변경 없음. 해당 없음.