### PR TITLE
fix(dashboard): 보드 쓰기가 캐시된 보드 프로젝션을 전부 비운다

### DIFF
--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1417,6 +1417,7 @@ let start_keeper_loops_owned
       signal);
   Board_dispatch.set_board_sse_hook (fun event ->
     let params = board_sse_event_params event in
+    Server_dashboard_http_core_cache.invalidate_board_projections ();
     Sse.broadcast
       (`Assoc
           [ "jsonrpc", `String "2.0"

--- a/lib/server/server_dashboard_http_core_cache.ml
+++ b/lib/server/server_dashboard_http_core_cache.ml
@@ -42,6 +42,17 @@ let feature_health_cache_ttl_s = 60.0
 (** Shared dashboard projection cache TTL — 120 seconds. *)
 let dashboard_projection_cache_ttl_s = 120.0
 
+(* Every cached projection of the board store. A board write drops all of
+   them so the SSE-triggered refetch reads the write instead of the
+   previous projection for the rest of the TTL. *)
+let board_projection_cache_prefixes =
+  [ "board:memory:"; "board:list:"; "board:hearths:" ]
+;;
+
+let invalidate_board_projections () =
+  List.iter Dashboard_cache.invalidate_prefix board_projection_cache_prefixes
+;;
+
 (** Track whether shell cache has been populated at least once.
     Atomic.t for cross-domain visibility: read from executor pool
     worker domains via namespace-truth and warmup helpers. *)

--- a/lib/server/server_dashboard_http_core_cache.mli
+++ b/lib/server/server_dashboard_http_core_cache.mli
@@ -10,6 +10,15 @@ val live_cache_ttl_s : float
 val realtime_cache_ttl_s : float
 val feature_health_cache_ttl_s : float
 val dashboard_projection_cache_ttl_s : float
+
+val board_projection_cache_prefixes : string list
+(** Cache-key prefixes of every cached board projection
+    ([/api/v1/dashboard/board], [/api/v1/board/list], hearths). *)
+
+val invalidate_board_projections : unit -> unit
+(** Drop every cached board projection. Called on each board write so the
+    next read, including the one the [notifications/board] SSE event
+    triggers in the dashboard, computes from the store. *)
 val shell_warmed : bool Atomic.t
 val shell_warming : bool Atomic.t
 val last_good_shell : Yojson.Safe.t Atomic.t

--- a/test/test_dashboard_cache.ml
+++ b/test/test_dashboard_cache.ml
@@ -264,6 +264,36 @@ let test_invalidate_prefix () =
   Alcotest.(check int) "proof entries recomputed" 4 !proof_counter;
   Alcotest.(check int) "non-matching prefix preserved" 1 !mission_counter
 
+(* A board write must not leave the 120s projection cache serving the
+   previous list: the dashboard refetches on notifications/board and read
+   the stale projection until the TTL lapsed (2026-08-22, #board only
+   updated after a hard refresh). *)
+let test_board_write_invalidates_every_board_projection () =
+  Dashboard_cache.invalidate_all ();
+  let memory_counter = ref 0 in
+  let list_counter = ref 0 in
+  let hearths_counter = ref 0 in
+  let unrelated_counter = ref 0 in
+  let read key counter =
+    Dashboard_cache.get_or_compute key ~ttl:120.0 (fun () ->
+      incr counter;
+      `Int !counter)
+  in
+  ignore (read "board:memory:-;-;recent;true;false;50;0;ws;-;true" memory_counter);
+  ignore (read "board:list:ws:-:-:true:false:recent:50:0:-:-:true:false" list_counter);
+  ignore (read "board:hearths:ws:exclude-system=true:exclude-automation=false" hearths_counter);
+  ignore (read "workspace:default" unrelated_counter);
+  Server_dashboard_http_core_cache.invalidate_board_projections ();
+  ignore (read "board:memory:-;-;recent;true;false;50;0;ws;-;true" memory_counter);
+  ignore (read "board:list:ws:-:-:true:false:recent:50:0:-:-:true:false" list_counter);
+  ignore (read "board:hearths:ws:exclude-system=true:exclude-automation=false" hearths_counter);
+  ignore (read "workspace:default" unrelated_counter);
+  Alcotest.(check int) "board memory projection recomputed" 2 !memory_counter;
+  Alcotest.(check int) "board list projection recomputed" 2 !list_counter;
+  Alcotest.(check int) "board hearths projection recomputed" 2 !hearths_counter;
+  Alcotest.(check int) "unrelated projection untouched" 1 !unrelated_counter;
+  Dashboard_cache.invalidate_all ()
+
 let test_task_mutation_hook_invalidates_all_execution_variants () =
   Dashboard_cache.invalidate_all ();
   let default_counter = ref 0 in
@@ -853,6 +883,8 @@ let () =
             test_projection_digest_cache_separates_actors;
           test_case "invalidate" `Quick test_invalidate;
           test_case "invalidate_prefix" `Quick test_invalidate_prefix;
+          test_case "board write invalidates every board projection" `Quick
+            test_board_write_invalidates_every_board_projection;
           test_case "task mutation invalidates every execution variant" `Quick
             test_task_mutation_hook_invalidates_all_execution_variants;
           test_case "stats" `Quick test_stats;


### PR DESCRIPTION
## 현상

`#board` 에 새 글·댓글이 강제 새로고침 뒤에만 나타납니다.

## 원인 (실측)

- `/api/v1/dashboard/board` 는 `Dashboard_cache` 에 TTL 120초(`dashboard_projection_cache_ttl_s`, stale-while-revalidate ×3)로 캐시되는데, 보드 쓰기 경로 어디에서도 `board:memory:` 프리픽스를 invalidate 하지 않았습니다(`rg invalidate_prefix lib` → execution/workspace/keeper/operator 키만).
- 클라이언트 배선은 맞습니다: 서버가 `notifications/board` 를 보내고(`Board_dispatch.set_board_sse_hook`), `sse-store.ts` 가 `post_created/comment_added` 를 `refreshBoard()` 로 보냅니다. 라이브로 ack 하는 WS 세션이 26초 동안 board 프레임 3건을 받았습니다. 그러나 그 refetch 가 캐시된 프로젝션을 읽어 목록이 그대로였습니다 — 같은 키를 45초 간격으로 읽어 `generated_at=02:26:30Z`, etag `W/"f420c090050d"` 동일.

## 바꾼 것

- `Server_dashboard_http_core_cache.invalidate_board_projections ()` — `board:memory:`, `board:list:`, `board:hearths:` 세 프리픽스를 비움.
- `server_bootstrap_loops.ml` 의 board SSE hook 에서 `Sse.broadcast` 직전에 호출. 보드 writer 6곳이 전부 `Board_dispatch` 를 지나므로 hook 한 자리면 전부 덮입니다.

## 테스트

`test_dashboard_cache`: `board write invalidates every board projection` — 세 프리픽스 키와 무관 키를 데운 뒤 호출 → 보드 3건 recompute(2), 무관 키 1 유지.

## 범위 밖 (후속)

- 열린 글 상세의 댓글은 `comment_added` 에 `loadPostDetail` 을 안 불러 여전히 수동 갱신 — TS 3파일 후속.
- 새 글/읽은 글 구분(`board-last-seen` 커서) — 후속.
- 비-ack WS 세션은 30초 뒤 raw 전달이 전부 끊김(`session_is_backpressured`), 라이브 `throttled_deliveries: 1485` — 관측만 기록.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3a8sWueQQPyYyoXerLJvj
