### PR TITLE
test(keeper): honor browser proof timeout contract

### DIFF
--- a/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
+++ b/scripts/harness/workload/keeper_multi_collaboration_acceptance.py
@@ -115,10 +115,19 @@ KNOWN_ASSERTIONS = {
 # additional pulse as scheduling/polling margin so a retry observed near the
 # request boundary is not turned into a false-negative campaign result.
 GOAL_VERIFIER_RETRY_INTERVAL_SEC = 60.0
+BROWSER_PROOF_TIMEOUT_FLOOR_SEC = 600.0
 
 
 def goal_verifier_convergence_timeout(request_timeout: float) -> float:
     return (2.0 * request_timeout) + (2.0 * GOAL_VERIFIER_RETRY_INTERVAL_SEC)
+
+
+def browser_proof_subprocess_timeout(request_timeout: float) -> float:
+    # The Node proof's declared Keeper-ready window is 240 seconds. It then
+    # verifies three independent dashboard surfaces and owns the failure-state
+    # screenshot/console capture. The parent must never terminate it before
+    # that inner contract can settle and emit its diagnostic artifacts.
+    return max(BROWSER_PROOF_TIMEOUT_FLOOR_SEC, 2.0 * request_timeout)
 
 
 class AcceptanceError(RuntimeError):
@@ -1572,7 +1581,7 @@ class MissionRun:
             check=False,
             capture_output=True,
             text=True,
-            timeout=120,
+            timeout=browser_proof_subprocess_timeout(self.timeout),
         )
         if completed.returncode != 0:
             raise AcceptanceError(

--- a/test/test_keeper_multi_collaboration_acceptance.py
+++ b/test/test_keeper_multi_collaboration_acceptance.py
@@ -203,6 +203,13 @@ class KeeperMultiCollaborationAcceptanceTest(unittest.TestCase):
         wait_source = inspect.getsource(acceptance.MissionRun.wait_for_goal_state)
         self.assertIn("goal_verifier_convergence_timeout(self.timeout)", wait_source)
 
+    def test_browser_proof_parent_outlives_inner_readiness_and_capture(self):
+        self.assertEqual(acceptance.browser_proof_subprocess_timeout(300.0), 600.0)
+        self.assertEqual(acceptance.browser_proof_subprocess_timeout(400.0), 800.0)
+        capture_source = inspect.getsource(acceptance.MissionRun.capture_browser_proof)
+        self.assertIn("browser_proof_subprocess_timeout(self.timeout)", capture_source)
+        self.assertNotIn("timeout=120", capture_source)
+
     def test_runtime_serving_evidence_requires_exact_completed_receipt_per_role(self):
         keepers = {"coordinator": "keeper-c", "reviewer": "keeper-r"}
         expected = {"coordinator": "runtime-c", "reviewer": "runtime-r"}


### PR DESCRIPTION
## Summary
- make the Python parent outlive the Node browser proof's declared 240s Keeper-ready window
- reserve enough time for composition, persistence, and Goal-verification surfaces plus failure capture
- keep the timeout proportional when the request timeout exceeds the 300s campaign default

## Exact evidence
- protected-main run `32542846399`, source `1c6d91deefd79330e29a1e14e3f04a941addd052`
- same run reached Goal criterion viable, proof refuted, re-entry, proof proven, and Goal completed
- browser child was then killed by the Python parent at 120s while the child readiness contract is 240s; no browser failure artifact could be emitted
- this does **not** claim the removed 4-vCPU CI lane can pass: #29183 documents dashboard/keeper shared-pool starvation, and #29458 removed that blocking lane

## Checks
- `python3 test/test_keeper_multi_collaboration_acceptance.py` (17/17)
- catalog validation (23 missions, 48 assertions, A/B/C)
- Python compile
- `git diff --check`

No local Dune build was run.