### PR TITLE
fix(log): 2시간 런타임 로그에서 확인된 로깅 결함 7건

### DIFF
--- a/lib/keeper/keeper_board_attention_worker.ml
+++ b/lib/keeper/keeper_board_attention_worker.ml
@@ -27,11 +27,26 @@ type retry_reason =
   | Exact_claim_contended
   | Selected_generation_changed
 
+(* What the drain loop actually did before it stopped. A wake that finds an
+   empty partition returns the same verdict as one that judged twenty
+   candidates, so without these counts the log line cannot tell an operator
+   whether the worker did any work: the two hours to 2026-08-22T02:03Z held
+   120 pairs of textually identical [outcome=drained] lines, each pair a real
+   drain followed by a wake that found nothing left. *)
+type drain_progress =
+  { judgments : int
+      (* Candidates that produced a judgment on this drain. *)
+  ; steps : int
+      (* Loop iterations, including visits that found the candidate already
+         consumed or its partition blocked. *)
+  }
+
 type drain_outcome =
-  | Drained
+  | Drained of drain_progress
   | Retry_later of
       { contention : contention
       ; reason : retry_reason
+      ; progress : drain_progress
       }
 
 type rearm_schedule =
@@ -353,7 +368,7 @@ let reset_contention_rearms scheduler ~keep =
    another flow holds the claim, Selected_generation_changed means the partition
    moved under this worker. *)
 let drain_outcome_label = function
-  | Drained -> "drained"
+  | Drained _ -> "drained"
   | Retry_later { reason = Exact_claim_contended; _ } -> "retry_claim_contended"
   | Retry_later { reason = Selected_generation_changed; _ } ->
     "retry_generation_changed"
@@ -364,12 +379,17 @@ let drain_outcome_label = function
    worker that keeps returning it makes no progress while its candidate ledger
    grows; at [Info] that state reads the same as normal draining. *)
 let drain_outcome_log_level = function
-  | Drained -> Log.Info
+  | Drained _ -> Log.Info
   | Retry_later _ -> Log.Warn
 ;;
 
+let drain_outcome_progress = function
+  | Drained progress -> progress
+  | Retry_later { progress; _ } -> progress
+;;
+
 let apply_drain_rearm scheduler = function
-  | Drained ->
+  | Drained _ ->
     reset_contention_rearms scheduler ~keep:None;
     None
   | Retry_later { contention; reason = _ } ->
@@ -1790,17 +1810,26 @@ let observe_error ~base_path ~keeper_name detail =
   Log.Keeper.error "Board attention worker failed keeper=%s: %s" keeper_name detail
 ;;
 
-let rec drain_available_with_process ~yield ~process =
-  match process () with
-  | Ok Idle -> Ok Drained
-  | Ok (Contended contention) ->
-    Ok (Retry_later { contention; reason = Exact_claim_contended })
-  | Ok (Rescan_later contention) ->
-    Ok (Retry_later { contention; reason = Selected_generation_changed })
-  | Ok (Judgment_completed _ | Candidate_already_consumed _ | Partition_blocked _) ->
-    yield ();
-    drain_available_with_process ~yield ~process
-  | Error detail -> Error detail
+let drain_available_with_process ~yield ~process =
+  let rec loop progress =
+    match process () with
+    | Ok Idle -> Ok (Drained progress)
+    | Ok (Contended contention) ->
+      Ok (Retry_later { contention; reason = Exact_claim_contended; progress })
+    | Ok (Rescan_later contention) ->
+      Ok
+        (Retry_later
+           { contention; reason = Selected_generation_changed; progress })
+    | Ok (Judgment_completed _) ->
+      yield ();
+      loop
+        { judgments = progress.judgments + 1; steps = progress.steps + 1 }
+    | Ok (Candidate_already_consumed _ | Partition_blocked _) ->
+      yield ();
+      loop { progress with steps = progress.steps + 1 }
+    | Error detail -> Error detail
+  in
+  loop { judgments = 0; steps = 0 }
 ;;
 
 let drain_available_current
@@ -1928,12 +1957,16 @@ let run
                  ~execute
              with
              | Ok outcome ->
+               let progress = drain_outcome_progress outcome in
                Log.Keeper.emit
                  (drain_outcome_log_level outcome)
                  (Printf.sprintf
-                    "board_attention_worker_drain keeper=%s outcome=%s"
+                    "board_attention_worker_drain keeper=%s outcome=%s \
+                     judgments=%d steps=%d"
                     keeper_name
-                    (drain_outcome_label outcome));
+                    (drain_outcome_label outcome)
+                    progress.judgments
+                    progress.steps);
                ignore
                  (apply_drain_rearm contention_rearms outcome
                   : rearm_schedule option);
@@ -1962,6 +1995,7 @@ module For_testing = struct
   let schedule_contention_rearm = schedule_contention_rearm
   let reset_contention_rearms = reset_contention_rearms
   let drain_outcome_label = drain_outcome_label
+  let drain_outcome_progress = drain_outcome_progress
   let drain_outcome_log_level = drain_outcome_log_level
   let apply_drain_rearm = apply_drain_rearm
   let replay_completed_owner_wake = replay_completed_owner_wake

--- a/lib/keeper/keeper_board_attention_worker.mli
+++ b/lib/keeper/keeper_board_attention_worker.mli
@@ -28,18 +28,30 @@ type retry_reason =
   | Exact_claim_contended
   | Selected_generation_changed
 
+type drain_progress =
+  { judgments : int
+  ; steps : int
+  }
+(** What one drain did before it stopped: [judgments] counts candidates that
+    produced a judgment, [steps] every loop iteration including visits that
+    found the candidate already consumed or its partition blocked. A wake that
+    finds an empty partition carries zeroes, which is what separates it from a
+    drain that did work — the verdict alone cannot. *)
+
 type drain_outcome =
-  | Drained
+  | Drained of drain_progress
   | Retry_later of
       { contention : contention
       ; reason : retry_reason
+      ; progress : drain_progress
       }
 (** [Drained] clears the contention re-arms; [Retry_later] keeps the durable
     partition undrained and re-arms the contention timer, so the same worker
     re-inspects it (see [apply_drain_rearm]). A generation that moved under the
     worker arrives here as [Retry_later { reason = Selected_generation_changed }]
     and is retried, not abandoned. The ledger stays the work authority in both
-    cases. *)
+    cases. Both carry the progress made before the verdict: contention after
+    ten judgments is not the same event as contention on the first visit. *)
 
 type rearm_schedule =
   | Rearm_scheduled of { delay_s : float }
@@ -112,6 +124,9 @@ module For_testing : sig
   (** The drain verdict as one token, as logged. Retry_later keeps its reason
       so a worker stuck on a moved generation is distinguishable from one
       losing a claim race. *)
+
+  val drain_outcome_progress : drain_outcome -> drain_progress
+  (** The work counts the outcome carries, as logged. *)
 
   val drain_outcome_log_level : drain_outcome -> Log.level
   (** The level the drain line is emitted at, derived from the outcome.

--- a/lib/keeper/keeper_hooks_agent_core.ml
+++ b/lib/keeper/keeper_hooks_agent_core.ml
@@ -199,22 +199,27 @@ let make_hooks
           | None -> cost_usd_json None
         in
         let total_tok = input_tok + output_tok in
+        let context_max_log =
+          match context_max_of_telemetry response.telemetry with
+          | Some n -> string_of_int n
+          | None -> "-"
+        in
         (match usage_trust with
          | Keeper_usage_trust.Usage_untrusted reasons when not usage_missing ->
           if Keeper_usage_trust.warns_operator usage_trust then
             Log.Keeper.warn ~keeper_name:meta.name
-              "after_turn usage telemetry untrusted runtime_lane=%s reasons=%s input=%d output=%d context_max=%d"
+              "after_turn usage telemetry untrusted runtime_lane=%s reasons=%s input=%d output=%d context_max=%s"
               runtime_lane_label
               (String.concat "," reasons)
               raw_input_tok raw_output_tok
-              (context_max_of_telemetry response.telemetry)
+              context_max_log
           else
             Log.Keeper.info ~keeper_name:meta.name
-              "after_turn usage telemetry unavailable runtime_lane=%s reasons=%s input=%d output=%d context_max=%d"
+              "after_turn usage telemetry unavailable runtime_lane=%s reasons=%s input=%d output=%d context_max=%s"
               runtime_lane_label
               (String.concat "," reasons)
               raw_input_tok raw_output_tok
-              (context_max_of_telemetry response.telemetry)
+              context_max_log
          | Keeper_usage_trust.Usage_missing
          | Keeper_usage_trust.Usage_trusted
          | Keeper_usage_trust.Usage_untrusted _ -> ());
@@ -296,10 +301,10 @@ let make_hooks
               t.prompt_per_second, t.predicted_per_second
           | None | Some { timings = None; _ } -> None, None
         in
-        let latency_ms =
+        let latency_ms_opt =
           match response.telemetry with
-          | Some t -> Option.value ~default:0 t.request_latency_ms
-          | None -> 0
+          | Some t -> t.request_latency_ms
+          | None -> None
         in
         let wall_tok_s_opt =
           wall_tokens_per_second ~usage_missing ~output_tokens:output_tok
@@ -314,13 +319,18 @@ let make_hooks
            windows from 200K to 1M, so the same absolute count means a
            different amount of pressure per keeper and the log cannot be
            compared across them. The window is already on the turn record;
-           carrying it here makes the log self-sufficient. [0] means the
-           provider reported no window rather than a window of zero. *)
-        let context_window = context_max_of_telemetry response.telemetry in
+           carrying it here makes the log self-sufficient. An absent window
+           renders ["-"], the same as the other unread counters on this line;
+           it used to render [0], which reads as a window of zero (25 lines in
+           the two hours to 2026-08-22T02:03Z). *)
         let fmt_int_opt = function
           | Some v -> string_of_int v
           | None -> "-"
         in
+        let context_window =
+          fmt_int_opt (context_max_of_telemetry response.telemetry)
+        in
+        let latency_ms = fmt_int_opt latency_ms_opt in
         let cache_n_log, prompt_n_log =
           match response.telemetry with
           | Some { timings = Some t; _ } ->
@@ -328,7 +338,7 @@ let make_hooks
           | Some { timings = None; _ } | None -> "-", "-"
         in
         Log.Keeper.info ~keeper_name:meta.name
-          "turn=%d total_turns=%d runtime_lane=%s tokens=%d context_window=%d wall_tok_s=%s prompt_tok_s=%s decode_tok_s=%s cache_n=%s prompt_n=%s latency_ms=%d thinking_present=%b thinking_blocks=%d thinking_chars=%d redacted_thinking_blocks=%d thinking_kind=%s"
+          "turn=%d total_turns=%d runtime_lane=%s tokens=%d context_window=%s wall_tok_s=%s prompt_tok_s=%s decode_tok_s=%s cache_n=%s prompt_n=%s latency_ms=%s thinking_present=%b thinking_blocks=%d thinking_chars=%d redacted_thinking_blocks=%d thinking_kind=%s"
           turn meta.runtime.usage.total_turns model total_tok context_window
           wall_tok_s prompt_tok_s decode_tok_s cache_n_log prompt_n_log latency_ms
           thinking.thinking_present
@@ -683,7 +693,20 @@ let make_hooks
             ; (label_callback, callback_label_on_tool_error)
             ]
           ();
-        Log.Keeper.error ~keeper_name "tool_error: %s — %s" tool_name error;
+        (* One tool failure used to leave three operator-facing lines. On
+           2026-08-21 all 184 of them carried, for the same call and the same
+           public tool name, the richer [keeper:<k> tool_call tool=... params=...
+           input_shape=... outcome=error out_len=... error_preview=...] line
+           emitted above at Error, and 174 also carried [tool <internal> returned
+           error result: ...] from [Keeper_tools_agent_core] — which derives its
+           level from the typed failure class, so an expected policy rejection is
+           not an Error there. This arm has only opaque text and no failure
+           class, so it can neither honour that contract nor add anything the
+           other two lack; it hardcoded Error and made a rejection read as a
+           fault while double-counting every failure. Its sibling
+           [post_tool_use_failure] was demoted for the same reason and left this
+           one behind. The counter above keeps the event. *)
+        Log.Keeper.debug ~keeper_name "tool_error: %s — %s" tool_name error;
         Agent_core.Hooks.Continue
       | _event -> Agent_core.Hooks.Continue);
 

--- a/lib/keeper/keeper_supervisor_supervise_keepalive.ml
+++ b/lib/keeper/keeper_supervisor_supervise_keepalive.ml
@@ -283,7 +283,16 @@ let supervise_keepalive
       Keeper_activation_readiness.retained_disabled_reason_to_wire reason
     in
     record_recovery_retained reason;
-    Log.Keeper.info
+    (* Configured-off is a state the sweep re-observes, not something that
+       happened. Emitting it per sweep per keeper made it 4,795 of the 20,458
+       lines (23%%) written in the two hours to 2026-08-22T02:03Z, from 25
+       keepers, and [Executable] — the other steady state — logs nothing at
+       all. [record_recovery_retained] above already keeps the fact on two
+       authoritative planes: a per-keeper/reason counter and an
+       [Admission_denied] lifecycle event the dashboard consumes. This is the
+       third rendering, so it belongs on the routine channel where the text
+       stays retrievable at Debug. *)
+    Log.Keeper.routine
       "%s: supervisor keepalive recovery retained by disabled policy: %s"
       meta.name
       reason
@@ -292,7 +301,10 @@ let supervise_keepalive
       Keeper_activation_readiness.paused_dead_reason_to_wire reason
     in
     record_recovery_retained reason;
-    Log.Keeper.info
+    (* Same shape as the disabled-policy arm above: a paused or dead owner is
+       a state the sweep keeps re-reading, and the counter plus the
+       [Admission_denied] lifecycle event already carry it. *)
+    Log.Keeper.routine
       "%s: supervisor keepalive recovery retained by paused/dead owner truth: %s"
       meta.name
       reason

--- a/lib/keeper_hooks_agent_core_types/keeper_hooks_agent_core_types.ml
+++ b/lib/keeper_hooks_agent_core_types/keeper_hooks_agent_core_types.ml
@@ -143,13 +143,15 @@ let inference_telemetry_to_runtime_json telemetry =
   |> Agent_core.Types.inference_telemetry_to_yojson
   |> redact_inference_telemetry_json
 
-let default_context_max = 0
-
+(* [None] is "the provider reported no window", which is not the same claim as
+   a window of zero. The turn log line renders the two the same way when this
+   collapses to an int, and it shares that line with [cache_n] / [prompt_n],
+   which already render an absent reading as ["-"]. *)
 let context_max_of_telemetry
     (telemetry : Agent_core.Types.inference_telemetry option) =
   match telemetry with
-  | Some { effective_context_window = Some n; _ } when n > 0 -> n
-  | _ -> default_context_max
+  | Some { effective_context_window = Some n; _ } when n > 0 -> Some n
+  | _ -> None
 
 type thinking_log_summary =
   { thinking_present : bool

--- a/lib/keeper_hooks_agent_core_types/keeper_hooks_agent_core_types.mli
+++ b/lib/keeper_hooks_agent_core_types/keeper_hooks_agent_core_types.mli
@@ -95,8 +95,9 @@ val inference_telemetry_to_runtime_json :
     provider/model identity is collapsed before leaving the AGENT_CORE boundary. *)
 
 val context_max_of_telemetry :
-  Agent_core.Types.inference_telemetry option -> int
-(** Provider-reported context window max, or [0] when telemetry omits it. *)
+  Agent_core.Types.inference_telemetry option -> int option
+(** Provider-reported context window max, or [None] when telemetry omits it or
+    reports a non-positive window. *)
 
 type thinking_log_summary =
   { thinking_present : bool

--- a/lib/masc_log/log.ml
+++ b/lib/masc_log/log.ml
@@ -248,7 +248,16 @@ module Ring = struct
       details = `Null;
       category = None;
     }
-  let total = Atomic.make 0 (* total entries ever written *)
+  let total = Atomic.make 0 (* next sequence to hand out *)
+
+  (* Sequence of the oldest entry the ring can answer for.  Zero for a
+     process that started with an empty log directory; after
+     [load_from_file] it is the sequence handed to the first restored
+     entry, which resumes above every sequence already on disk (see
+     [load_from_file]).  Without it the window math below would derive a
+     lower bound of [total - capacity] and scan ring slots that this
+     process never filled. *)
+  let first_seq = Atomic.make 0
 
   (* File sink state *)
   let file_channel : out_channel option ref = ref None
@@ -576,23 +585,42 @@ module Ring = struct
        [normalized_level] / [legacy_classified]) could pass through as a
        WARN; those schemas are gone and nothing writes them. *)
     let buf_ring : entry Queue.t = Queue.create () in
+    (* Highest sequence any row on disk carries, counted over every decoded
+       row rather than the [capacity]-bounded tail the queue keeps: a file
+       whose tail comes from a short-lived run can hold a lower maximum
+       than an earlier run wrote. *)
+    let max_seq_on_disk = ref (-1) in
     let push_file path =
       Fs_compat.fold_jsonl_lines
         ~init:()
         ~f:(fun () ~line_no:_ json ->
           let e = entry_of_json json in
+          if e.seq > !max_seq_on_disk then max_seq_on_disk := e.seq;
           Queue.add e buf_ring;
           if Queue.length buf_ring > capacity then ignore (Queue.pop buf_ring))
         path
     in
     push_file (log_file_path dir yesterday);
     push_file (log_file_path dir today);
+    (* [total] is process-local but the JSONL sink is per-UTC-day and
+       append-only, so a restart used to re-issue sequences that rows
+       already in the file carry.  Measured on
+       [.masc/logs/system_log_2026-08-21.jsonl]: 130,102 rows, 35,068
+       distinct [seq], one value reused ten times across twelve restarts —
+       [seq] identified no row, and a dashboard cursor taken before a
+       restart landed in the middle of the reissued range, silently
+       skipping or replaying records.  Resuming above the on-disk maximum
+       keeps the sequence a key for the whole file. *)
+    let base_seq = !max_seq_on_disk + 1 in
+    Atomic.set total base_seq;
+    Atomic.set first_seq base_seq;
     Queue.iter
       (fun e ->
         let seq = Atomic.fetch_and_add total 1 in
         let idx = seq mod capacity in
         buf.(idx) <- { e with seq })
-      buf_ring
+      buf_ring;
+    Queue.length buf_ring
 
   let init_file_sink
       ?(identity_recheck_interval_s = default_sink_identity_recheck_interval_s)
@@ -600,8 +628,7 @@ module Ring = struct
     sink_identity_recheck_interval_s := identity_recheck_interval_s;
     last_sink_identity_check_at := neg_infinity;
     close_sink ();
-    load_from_file dir;
-    let loaded = Atomic.get total in
+    let loaded = load_from_file dir in
     open_sink dir;
     if loaded > 0 then
       Printf.eprintf "[%s] [INFO] [Log] Restored %d log entries from disk\n%!" (timestamp ()) loaded
@@ -679,7 +706,7 @@ module Ring = struct
     let t = Atomic.get total in
     if t = 0 then []
     else begin
-      let start = max 0 (t - capacity) in
+      let start = max (Atomic.get first_seq) (t - capacity) in
       (* [since_seq] raises the lower bound (entries strictly newer than the
          cursor); [before_seq] lowers the upper bound (entries strictly older
          than the cursor). For retained slots in [start, t-1] the entry seq
@@ -774,13 +801,17 @@ module Ring = struct
      response so the operator sees the cut, not silence. *)
   let bounds () =
     let t = Atomic.get total in
-    { start_seq = max 0 (t - capacity)
+    let first = Atomic.get first_seq in
+    { start_seq = max first (t - capacity)
     ; total = t
-    ; dropped_before = t > capacity
+    ; dropped_before = t - first > capacity
     }
 
   let summary_json () =
-    let total_entries = Atomic.get total in
+    (* Counts, not sequences: [total] is the next sequence to hand out and
+       starts above the on-disk maximum after a restore, so subtracting
+       [first_seq] is what turns it back into "records this process holds". *)
+    let total_entries = Atomic.get total - Atomic.get first_seq in
     let retained_entries = min total_entries capacity in
     let recent_window = recent ~limit:200 () in
     let recent_errors =

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -222,14 +222,14 @@ let observed_http_transport
       (fun req ->
         (* RFC-0095 Phase 0 diagnostic trace — verify which transport path is invoked
            per turn for each provider. Removed at Phase 0 closeout. *)
-        Log.Misc.debug
+        Log.Runtime_agent.debug
           "rfc0095-trace: runtime_runner http_transport.complete_sync invoked";
         http_transport.complete_sync req);
       complete_stream =
       (fun ?on_telemetry ~on_event req ->
         (* RFC-0095 Phase 0 diagnostic trace — verify which transport path is invoked
            per turn for each provider. Removed at Phase 0 closeout. *)
-        Log.Misc.debug
+        Log.Runtime_agent.debug
           "rfc0095-trace: runtime_runner http_transport.complete_stream invoked";
         http_transport.complete_stream
           ?on_telemetry
@@ -917,19 +917,19 @@ let record_dashboard_agent_core_response ~config ~total_duration_ms ?serializati
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
-      Log.Misc.warn
-        "runtime_agent %s: dashboard agent record failed: %s"
+      Log.Runtime_agent.warn
+        "%s: dashboard agent record failed: %s"
         config.name (Printexc.to_string exn)
 
 let close_agent_for_cleanup ?(propagate_cancel = true) ~config agent =
   try Agent_core.Agent.close agent with
   | Eio.Cancel.Cancelled _ as e ->
-      Log.Misc.warn
-        "runtime_agent %s: agent close cancelled during cleanup"
+      Log.Runtime_agent.warn
+        "%s: agent close cancelled during cleanup"
         config.name;
       if propagate_cancel then raise e
   | close_exn ->
-      Log.Misc.warn "runtime_agent %s: agent close failed during cleanup: %s"
+      Log.Runtime_agent.warn "%s: agent close failed during cleanup: %s"
         config.name (Printexc.to_string close_exn)
 
 (* ================================================================ *)
@@ -977,8 +977,12 @@ let resume_from_checkpoint
       let prepared_resume =
         Runtime_agent_context.prepare_resume ~config ~checkpoint
       in
-      Log.Misc.info
-        "runtime_agent %s: resume checkpoint_turn_count=%d turn_limit=unlimited"
+      (* [turn_limit=unlimited] used to ride on this line. Nothing in the
+         runtime agent or in [Agent_core.Agent.resume] carries a turn limit,
+         so the field asserted a configuration that has no producer — 256 of
+         these lines in the two hours to 2026-08-22T02:03Z all repeated it. *)
+      Log.Runtime_agent.info
+        "%s: resume checkpoint_turn_count=%d"
         config.name checkpoint.turn_count;
       let options = { prepared_resume.options with transport } in
       Ok
@@ -1085,7 +1089,7 @@ let run_blocks
   (match config.transport with
   | Masc_grpc_transport.Local -> ()
   | t ->
-    Log.Misc.info "runtime_agent %s: transport=%s"
+    Log.Runtime_agent.info "%s: transport=%s"
       config.name (Masc_grpc_transport.to_string t));
   let agent_result =
     select_agent_result
@@ -1212,7 +1216,7 @@ let run_blocks
         (match Agent_core.Raw_trace_query.validate_run ref_ with
          | Ok v -> Some v
          | Error err ->
-           Log.Misc.warn "runtime_agent: run_validation failed: %s"
+           Log.Runtime_agent.warn "run_validation failed: %s"
              (Agent_core.Error.to_string err);
            None)
       | None -> None
@@ -1277,8 +1281,8 @@ let run_blocks
         ~total_duration_ms:run_total_duration_ms
         ~status:(dashboard_status_of_stop_reason stop_reason)
         partial_response;
-      Log.Misc.info
-        "runtime_agent %s: typed input required request_id=%s turns=%d"
+      Log.Runtime_agent.info
+        "%s: typed input required request_id=%s turns=%d"
         config.name
         request.request_id
         turns;
@@ -1311,7 +1315,7 @@ let run_blocks
          next provider.  Emitting WARN/ERROR here creates noise on
          recovered runtimes.  The runtime layer logs [runtime-fallback] at
          INFO when it retries and emits ERROR only on full exhaustion. *)
-      Log.Misc.debug "runtime_agent: agent errored: %s" detail;
+      Log.Runtime_agent.debug "agent errored: %s" detail;
       close_agent_for_cleanup ~propagate_cancel:false ~config agent;
       Error err)
   with
@@ -1331,7 +1335,7 @@ let run_blocks
       ~total_duration_ms:(run_duration_ms_since run_started_at)
       ~status:(Dashboard_agent_core_bridge.Error { transient = false })
       error_response;
-    Log.Misc.error "runtime_agent %s: execution exception: %s\nBacktrace: %s"
+    Log.Runtime_agent.error "%s: execution exception: %s\nBacktrace: %s"
       config.name (Printexc.to_string exn) bt;
     let typed_internal_error =
       Keeper_internal_error.Internal_unhandled_exception

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -1227,7 +1227,16 @@ let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(thread_mode = Start) ~mgr
     match validate_turn_input ~dynamic_tools ~thread_mode ~cwd config ~prompt with
     | Error _ as error -> error
     | Ok protocol_cwd ->
-      Log.Runtime_agent.info "Codex app-server subscription turn starting";
+      (* Eight keepers starting a turn in the same second produced eight
+         identical lines with nothing to tell them apart (2026-08-22
+         01:36:25Z, seven within one second). The thread is the only identity
+         this entry point holds before [on_thread_ready] fires. *)
+      Log.Runtime_agent.info
+        "Codex app-server subscription turn starting thread=%s model=%s"
+        (match thread_mode with
+         | Start -> "new"
+         | Resume { thread_id } -> thread_id)
+        (Option.value ~default:"-" config.model);
       (match
          (try
             run_spawned

--- a/lib/runtime/runtime_codex_app_server.ml
+++ b/lib/runtime/runtime_codex_app_server.ml
@@ -1236,7 +1236,9 @@ let run_turn ?(dynamic_tools = []) ?reasoning_effort ?(thread_mode = Start) ~mgr
         (match thread_mode with
          | Start -> "new"
          | Resume { thread_id } -> thread_id)
-        (Option.value ~default:"-" config.model);
+        (match config.model with
+         | Some model -> model
+         | None -> "-");
       (match
          (try
             run_spawned

--- a/lib/runtime_log_sink.ml
+++ b/lib/runtime_log_sink.ml
@@ -64,32 +64,32 @@ let truncate_value value =
     Printf.sprintf "%s...(%dB)" (String.sub value 0 !cut) len
   end
 
-let render_scalar (json : Yojson.Safe.t) : string option =
+(* A field the producer attached is rendered whatever its value: a key with a
+   null value is a statement that the value is unset, and dropping it from the
+   line would be the same omission this renderer exists to stop. Total, so a
+   new [Agent_core.Log.field] arm has to be given a rendering here. *)
+let render_scalar (json : Yojson.Safe.t) : string =
   match json with
-  | `Null -> None
-  | `String value -> Some value
-  | `Int value -> Some (string_of_int value)
-  | `Intlit value -> Some value
-  | `Float value -> Some (Printf.sprintf "%.3f" value)
-  | `Bool value -> Some (string_of_bool value)
-  | composite -> Some (Yojson.Safe.to_string composite)
+  | `Null -> "null"
+  | `String value -> value
+  | `Int value -> string_of_int value
+  | `Intlit value -> value
+  | `Float value -> Printf.sprintf "%.3f" value
+  | `Bool value -> string_of_bool value
+  | composite -> Yojson.Safe.to_string composite
 
 (* Quote whenever the raw form would break the [key=value] reading a log
    line invites: spaces, quotes, or an empty value. *)
 let render_pair (key, json) =
-  match render_scalar json with
-  | None -> None
-  | Some raw ->
-    let value = truncate_value raw in
-    let needs_quoting =
-      String.equal value ""
-      || String.exists (fun c -> c = ' ' || c = '"' || c = '\n' || c = '\t') value
-    in
-    Some
-      (Printf.sprintf
-         "%s=%s"
-         key
-         (if needs_quoting then Printf.sprintf "%S" value else value))
+  let value = truncate_value (render_scalar json) in
+  let needs_quoting =
+    String.equal value ""
+    || String.exists (fun c -> c = ' ' || c = '"' || c = '\n' || c = '\t') value
+  in
+  Printf.sprintf
+    "%s=%s"
+    key
+    (if needs_quoting then Printf.sprintf "%S" value else value)
 
 (* The human line renders every field the producer attached, in the order it
    attached them.
@@ -107,7 +107,7 @@ let render_message (record : Agent_core.Log.record) : string =
   let rendered =
     List.filteri (fun index _ -> index < max_rendered_fields) record.fields
     |> List.map field_to_json
-    |> List.filter_map render_pair
+    |> List.map render_pair
   in
   let omitted = List.length record.fields - max_rendered_fields in
   let parts =

--- a/lib/runtime_log_sink.ml
+++ b/lib/runtime_log_sink.ml
@@ -37,74 +37,6 @@ let field_to_json (field : Agent_core.Log.field) : string * Yojson.Safe.t =
   | Agent_core.Log.Secret (k, _) -> (k, `String "[REDACTED]")
   | field -> Agent_core.Log.field_to_json field
 
-let details_of_fields (fields : Agent_core.Log.field list)
-    : (string * Yojson.Safe.t) list =
-  List.map field_to_json fields
-
-let json_stringish = function
-  | `String s ->
-      let trimmed = String.trim s in
-      if trimmed = "" then None else Some trimmed
-  | `Int n -> Some (string_of_int n)
-  | `Float f when Float.is_finite f ->
-      Some
-        (if Float.equal f (Float.of_int (int_of_float f)) then
-           string_of_int (int_of_float f)
-         else
-           string_of_float f)
-  | `Bool b -> Some (string_of_bool b)
-  | _ -> None
-
-let first_detail_label details keys =
-  let rec find_key = function
-    | [] -> None
-    | key :: rest -> (
-        match List.assoc_opt key details with
-        | Some value -> (
-            match json_stringish value with
-            | Some _ as label -> label
-            | None -> find_key rest)
-        | None -> find_key rest)
-  in
-  find_key keys
-
-let replace_first_placeholder message value =
-  let len = String.length message in
-  let rec loop idx =
-    if idx + 1 >= len then
-      message
-    else if message.[idx] = '%'
-            && (message.[idx + 1] = 's' || message.[idx + 1] = 'd')
-    then
-      String.sub message 0 idx ^ value
-      ^ String.sub message (idx + 2) (len - idx - 2)
-    else
-      loop (idx + 1)
-  in
-  loop 0
-
-let interpolate_printf_message message details =
-  if not (String.contains message '%') then
-    message
-  else
-    let replacements =
-      [
-        first_detail_label details [ "tool_name"; "tool" ];
-        first_detail_label details [ "fixes" ];
-        first_detail_label details [ "count" ];
-        first_detail_label details [ "client_name" ];
-        first_detail_label details [ "phase" ];
-        first_detail_label details [ "request_id" ];
-        first_detail_label details [ "session_id" ];
-      ]
-      |> List.filter_map Fun.id
-    in
-    List.fold_left replace_first_placeholder message replacements
-
-let render_record_message (record : Agent_core.Log.record) : string =
-  let details = details_of_fields record.fields in
-  interpolate_printf_message record.message details
-
 let level_to_masc (level : Agent_core.Log.level) : Log.level =
   match level with
   | Debug -> Log.Debug
@@ -112,46 +44,80 @@ let level_to_masc (level : Agent_core.Log.level) : Log.level =
   | Warn -> Log.Warn
   | Error -> Log.Error
 
-let field_value_to_human (json : Yojson.Safe.t) : string option =
+(* Rendered-line budget.  Every field also rides in [details] as JSON, so
+   these caps only bound the human mirror; the record itself is never
+   trimmed. *)
+let max_rendered_value_bytes = 160
+let max_rendered_fields = 16
+
+(* Truncate on a UTF-8 character boundary and say so, so a cut value is
+   never mistaken for the whole value.  Continuation bytes are 0b10xxxxxx;
+   walking back off them keeps the prefix decodable. *)
+let truncate_value value =
+  let len = String.length value in
+  if len <= max_rendered_value_bytes then value
+  else begin
+    let cut = ref max_rendered_value_bytes in
+    while !cut > 0 && Char.code value.[!cut] land 0xC0 = 0x80 do
+      decr cut
+    done;
+    Printf.sprintf "%s...(%dB)" (String.sub value 0 !cut) len
+  end
+
+let render_scalar (json : Yojson.Safe.t) : string option =
   match json with
-  | `String value when String.trim value <> "" -> Some value
+  | `Null -> None
+  | `String value -> Some value
   | `Int value -> Some (string_of_int value)
   | `Intlit value -> Some value
   | `Float value -> Some (Printf.sprintf "%.3f" value)
   | `Bool value -> Some (string_of_bool value)
-  | _ -> None
+  | composite -> Some (Yojson.Safe.to_string composite)
 
-let preferred_summary_keys message =
-  match message with
-  | "turn completed" | "turn started" ->
-      [ "turn"; "turn_duration_sec"; "elapsed_run_sec"; "model"; "stop" ]
-  | "agent completed" | "agent started" ->
-      [ "agent_name"; "agent"; "task_id"; "elapsed_s"; "input_tokens"; "output_tokens" ]
-  | "tool completed" | "tool called" ->
-      [ "agent_name"; "agent"; "tool_name"; "turn" ]
-  | _ ->
-      [ "agent_name"; "agent"; "task_id"; "turn"; "tool_name"; "model"; "stop" ]
+(* Quote whenever the raw form would break the [key=value] reading a log
+   line invites: spaces, quotes, or an empty value. *)
+let render_pair (key, json) =
+  match render_scalar json with
+  | None -> None
+  | Some raw ->
+    let value = truncate_value raw in
+    let needs_quoting =
+      String.equal value ""
+      || String.exists (fun c -> c = ' ' || c = '"' || c = '\n' || c = '\t') value
+    in
+    Some
+      (Printf.sprintf
+         "%s=%s"
+         key
+         (if needs_quoting then Printf.sprintf "%S" value else value))
 
-let summarize_fields ~message (fields : Agent_core.Log.field list) : string list =
-  let assoc = List.map field_to_json fields in
-  preferred_summary_keys message
-  |> List.filter_map (fun key ->
-       match List.assoc_opt key assoc with
-       | None -> None
-       | Some value -> (
-           match field_value_to_human value with
-           | Some rendered -> Some (Printf.sprintf "%s=%s" key rendered)
-           | None -> None))
+(* The human line renders every field the producer attached, in the order it
+   attached them.
 
-let render_message_with_summary (record : Agent_core.Log.record) =
-  let base_message = render_record_message record in
-  if not (String.equal base_message record.message) then
-    base_message
-  else
-    match summarize_fields ~message:record.message record.fields with
-    | [] -> base_message
-    | summary ->
-        Printf.sprintf "%s %s" base_message (String.concat " " summary)
+   The projection this replaced kept a per-message allowlist of keys and fell
+   back to a fixed guess for anything it did not recognise, which made the
+   line lie by omission: [turn checkpoint persisted] carries [stage], [turn]
+   and [messages] but only [turn] was in the fallback list, so the three
+   checkpoint stages of one turn rendered as three identical lines (1,289 of
+   them in the two hours to 2026-08-22T02:03Z); [pipeline stage failed]
+   carries [stage] and [error] and rendered with neither; [tool not found]
+   rendered without the tool name.  Selecting keys by matching on the message
+   text also meant every new producer message silently fell into the guess. *)
+let render_message (record : Agent_core.Log.record) : string =
+  let rendered =
+    List.filteri (fun index _ -> index < max_rendered_fields) record.fields
+    |> List.map field_to_json
+    |> List.filter_map render_pair
+  in
+  let omitted = List.length record.fields - max_rendered_fields in
+  let parts =
+    if omitted > 0
+    then rendered @ [ Printf.sprintf "(+%d more in details)" omitted ]
+    else rendered
+  in
+  match parts with
+  | [] -> record.message
+  | parts -> Printf.sprintf "%s %s" record.message (String.concat " " parts)
 
 (** Build the sink function.  Prefix the module name with ["agent_core:"] so a
     record emitted by [Agent_core.Log.create ~module_name:"agent"] lands
@@ -159,7 +125,7 @@ let render_message_with_summary (record : Agent_core.Log.record) =
     masc module called "agent". *)
 let make_sink () : Agent_core.Log.sink =
  fun record ->
-  let message = render_message_with_summary record in
+  let message = render_message record in
   let details =
     match record.fields with
     | [] -> None

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -340,6 +340,7 @@ normal_targets=(
   @test/runtest-test_board_vote_persistence
   @test/runtest-test_log_ring_bounds
   @test/runtest-test_log_seq_restart_continuity
+  @test/runtest-test_runtime_log_sink_render
   @test/runtest-test_board_comment_post_write_ahead
   @test/runtest-test_board_sub_board_write_ahead
   @test/runtest-test_keeper_event_queue

--- a/scripts/ci-run-focused-tests.sh
+++ b/scripts/ci-run-focused-tests.sh
@@ -339,6 +339,7 @@ normal_targets=(
   @test/runtest-test_board_karma_ledger
   @test/runtest-test_board_vote_persistence
   @test/runtest-test_log_ring_bounds
+  @test/runtest-test_log_seq_restart_continuity
   @test/runtest-test_board_comment_post_write_ahead
   @test/runtest-test_board_sub_board_write_ahead
   @test/runtest-test_keeper_event_queue

--- a/scripts/ci/check-log-severity-anti-patterns.sh
+++ b/scripts/ci/check-log-severity-anti-patterns.sh
@@ -121,36 +121,57 @@ check_rule() {
   fi
 }
 
+# The module part of every pattern below was 'Log\.[A-Z][a-z]+\.', which
+# matches only single-word capitalised logger names. Fourteen loggers are
+# spelled with an underscore or a second capital (Log.Runtime_agent,
+# Log.Tool_validation, Log.BoardLog, Log.KeeperExec, ...), so 131 call sites
+# were invisible to all six rules — the counters read 0 for code the rules
+# never looked at. Widened to accept the real module grammar; the counts are
+# unchanged today, so nothing was hiding there yet.
+
 # L1 — silent fallback should be Error, not Info/Warn.
 check_rule "L1a" "silent + warn" \
-  'Log\.[A-Z][a-z]+\.warn[^"]*"[^"]*silent[^"]*' \
+  'Log\.[A-Za-z][A-Za-z_0-9]*\.warn[^"]*"[^"]*silent[^"]*' \
   "$BASELINE_L1_SILENT" \
   "§ 3.1"
 
 check_rule "L1b" "logging-only mode + warn" \
-  'Log\.[A-Z][a-z]+\.warn[^"]*(?s:.{0,500})logging-only mode' \
+  'Log\.[A-Za-z][A-Za-z_0-9]*\.warn[^"]*(?s:.{0,500})logging-only mode' \
   "$BASELINE_L1_LOGGING_ONLY" \
   "§ 3.1"
 
 # L2 — operator_broadcast emission is Warn/Error, not Info.
 check_rule "L2" "operator_broadcast + info" \
-  'Log\.[A-Z][a-z]+\.info[^"]*(?s:.{0,500})operator_broadcast' \
+  'Log\.[A-Za-z][A-Za-z_0-9]*\.info[^"]*(?s:.{0,500})operator_broadcast' \
   "$BASELINE_L2_OPERATOR_BROADCAST" \
   "§ 3.2"
 
 # L4 — periodic ticks (watchdog/keepalive/heartbeat) are Debug, not Info.
+# KNOWN DEAD (measured 2026-08-22): none of the three phrases below occurs
+# anywhere in lib/ or bin/, so this rule has never matched and its 0 is not
+# evidence of compliance. It did not see the supervisor keepalive line that
+# wrote 4,795 of 20,458 log rows in the two hours to 2026-08-22T02:03Z. The
+# vocabulary cannot simply be widened: broadening it to (keepalive|heartbeat|
+# watchdog) matches three one-shot "started keepalive" lines and no periodic
+# tick at all, while the one real offender found in that window
+# (lib/gate/discord_gateway_state.ml, "presence update: %s", 248 rows in two
+# hours) is built as a `Log { level = `Info; ... }` data value rather than a
+# Log.X.info call and is out of reach of this rule family entirely. Repairing
+# it needs a detection model that covers log-as-data, not a longer phrase
+# list, so the rule is left as-is rather than given a false-positive
+# vocabulary.
 # L3 (model behavior promoted to Error) and L5 (validation success as Info) are
 # intentionally omitted from this initial gate — current count is 0 in main, so
 # there's no baseline to drift from. Add them as separate check_rule calls if a
 # regression appears.
 check_rule "L4" "watchdog/keepalive/heartbeat + info" \
-  'Log\.[A-Z][a-z]+\.info[^"]*(?s:.{0,500})(watchdog tick|keepalive emitted|heartbeat sent)' \
+  'Log\.[A-Za-z][A-Za-z_0-9]*\.info[^"]*(?s:.{0,500})(watchdog tick|keepalive emitted|heartbeat sent)' \
   "$BASELINE_L4_WATCHDOG_TICK" \
   "§ 3.4"
 
 # L5 — validation success log is Debug, not Info.
 check_rule "L5" "validation success (coerced) + info" \
-  'Log\.[A-Z][a-z]+\.info[^"]*(?s:.{0,500})tool_input_validation coerced' \
+  'Log\.[A-Za-z][A-Za-z_0-9]*\.info[^"]*(?s:.{0,500})tool_input_validation coerced' \
   "$BASELINE_L5_VALIDATION_SUCCESS" \
   "§ 3.5"
 
@@ -160,7 +181,7 @@ check_rule "L5" "validation success (coerced) + info" \
 # level-selecting [(match outcome with ... -> Log.X.info) "...outcome=%s..."]
 # expression (which closes with [)] before the string) is NOT flagged.
 check_rule "L6" "outcome-carrying line + static info" \
-  'Log\.[A-Z][a-z]+\.info\s*"(?s:.{0,500})outcome=%s' \
+  'Log\.[A-Za-z][A-Za-z_0-9]*\.info\s*"(?s:.{0,500})outcome=%s' \
   "$BASELINE_L6_OUTCOME_CARRYING" \
   "§ 3.6"
 

--- a/test/dune
+++ b/test/dune
@@ -72,6 +72,7 @@
   test_mcp_error_code
   test_error_body_wire_shape
   test_log_ring_bounds
+  test_log_seq_restart_continuity
   test_session_lifecycle_event
   test_fd_accountant
   test_keeper_disk_pressure
@@ -374,6 +375,7 @@
   test_mcp_error_code
   test_error_body_wire_shape
   test_log_ring_bounds
+  test_log_seq_restart_continuity
   test_session_lifecycle_event
   test_fd_accountant
   test_keeper_disk_pressure

--- a/test/dune
+++ b/test/dune
@@ -73,6 +73,7 @@
   test_error_body_wire_shape
   test_log_ring_bounds
   test_log_seq_restart_continuity
+  test_runtime_log_sink_render
   test_session_lifecycle_event
   test_fd_accountant
   test_keeper_disk_pressure
@@ -376,6 +377,7 @@
   test_error_body_wire_shape
   test_log_ring_bounds
   test_log_seq_restart_continuity
+  test_runtime_log_sink_render
   test_session_lifecycle_event
   test_fd_accountant
   test_keeper_disk_pressure

--- a/test/test_keeper_board_attention_worker.ml
+++ b/test/test_keeper_board_attention_worker.ml
@@ -555,7 +555,7 @@ let test_setup_error_stops_before_claim_without_hot_retry () =
        "typed setup failure stops the lifecycle"
        "Board attention exact setup unavailable before claim: network context unavailable"
        detail
-   | Ok (W.Drained | W.Retry_later _) ->
+   | Ok (W.Drained _ | W.Retry_later _) ->
      Alcotest.fail "setup-unavailable drain returned normally");
   Alcotest.(check int) "one setup attempt" 1 !calls;
   Alcotest.(check int) "setup failure did not yield into a retry" 0 !yields;
@@ -887,6 +887,7 @@ let test_rescan_later_reaches_delayed_run_rearm () =
    | W.Retry_later
        { contention = observed
        ; reason = W.Selected_generation_changed
+       ; progress = _
        } ->
      Alcotest.(check string)
        "rescan retains old partition"
@@ -896,7 +897,7 @@ let test_rescan_later_reaches_delayed_run_rearm () =
        "rescan retains old generation"
        true
        (P.Generation.equal contention.generation observed.generation)
-   | W.Drained
+   | W.Drained _
    | W.Retry_later { reason = W.Exact_claim_contended; _ } ->
      Alcotest.fail "changed selection did not reach typed delayed rescan");
   Alcotest.(check int) "no same-turn rescan" 1 !process_calls;
@@ -2259,6 +2260,70 @@ let test_cross_domain_wake_is_coalesced_and_rearmed () =
    two of them back into one string would restore the state the measurement on
    2026-08-05 found: pending 425 -> 1031 with zero contention lines and zero
    worker failures, and no way to tell which of the three was happening. *)
+let no_progress : W.drain_progress = { judgments = 0; steps = 0 }
+
+(* A wake that finds an empty partition and a drain that judged twenty
+   candidates both end as [Drained], so the verdict token alone cannot tell an
+   operator whether the worker did any work. Live evidence: the two hours to
+   2026-08-22T02:03Z held 120 pairs of textually identical
+   [board_attention_worker_drain ... outcome=drained] lines — each pair one
+   real drain followed by a re-wake that found nothing left — against 64
+   single lines. The counts are what separate them. *)
+let test_drain_outcome_carries_the_work_it_did () =
+  let drive steps =
+    let remaining = ref steps in
+    W.For_testing.drain_available_with_process
+      ~yield:(fun () -> ())
+      ~process:(fun () ->
+        match !remaining with
+        | [] -> Ok W.Idle
+        | step :: rest ->
+          remaining := rest;
+          Ok step)
+  in
+  let judged id =
+    W.Judgment_completed
+      { candidate_id = id; owner_wake = Masc.Keeper_registry.Exact_wake_signaled }
+  in
+  let progress_of = function
+    | Ok outcome -> W.For_testing.drain_outcome_progress outcome
+    | Error detail -> Alcotest.failf "drain failed: %s" detail
+  in
+  let empty = progress_of (drive []) in
+  Alcotest.(check (pair int int))
+    "a wake that finds nothing reports no work"
+    (0, 0)
+    (empty.judgments, empty.steps);
+  let worked = progress_of (drive [ judged "c1"; judged "c2" ]) in
+  Alcotest.(check (pair int int))
+    "two judgments are two judgments and two steps"
+    (2, 2)
+    (worked.judgments, worked.steps);
+  (* A visit that finds the candidate already consumed advanced the loop but
+     produced no judgment; collapsing it into [judgments] would put a no-op
+     drain back on the same line as a productive one. *)
+  let visited =
+    progress_of (drive [ W.Candidate_already_consumed { candidate_id = "c3" } ])
+  in
+  Alcotest.(check (pair int int))
+    "an already-consumed visit is a step without a judgment"
+    (0, 1)
+    (visited.judgments, visited.steps);
+  let contended =
+    { W.keeper_name = "k"
+    ; partition_id = "p"
+    ; generation = P.Generation.initial
+    }
+  in
+  let after_contention =
+    progress_of (drive [ judged "c4"; W.Contended contended ])
+  in
+  Alcotest.(check (pair int int))
+    "contention after a judgment keeps the judgment"
+    (1, 1)
+    (after_contention.judgments, after_contention.steps)
+;;
+
 let test_drain_outcome_labels_stay_distinct () =
   let contention =
     { W.keeper_name = "k"
@@ -2269,9 +2334,17 @@ let test_drain_outcome_labels_stay_distinct () =
   let labels =
     List.map
       W.For_testing.drain_outcome_label
-      [ W.Drained
-      ; W.Retry_later { contention; reason = W.Exact_claim_contended }
-      ; W.Retry_later { contention; reason = W.Selected_generation_changed }
+      [ W.Drained no_progress
+      ; W.Retry_later
+          { contention
+          ; reason = W.Exact_claim_contended
+          ; progress = no_progress
+          }
+      ; W.Retry_later
+          { contention
+          ; reason = W.Selected_generation_changed
+          ; progress = no_progress
+          }
       ]
   in
   Alcotest.(check (list string))
@@ -2305,16 +2378,25 @@ let test_undrained_outcomes_are_not_routine () =
   Alcotest.(check string)
     "a completed drain is routine"
     "info"
-    (level_name W.Drained);
+    (level_name (W.Drained no_progress));
   Alcotest.(check string)
     "a contended claim is not routine"
     "warn"
-    (level_name (W.Retry_later { contention; reason = W.Exact_claim_contended }));
+    (level_name
+       (W.Retry_later
+          { contention
+          ; reason = W.Exact_claim_contended
+          ; progress = no_progress
+          }));
   Alcotest.(check string)
     "a moved generation is not routine"
     "warn"
     (level_name
-       (W.Retry_later { contention; reason = W.Selected_generation_changed }))
+       (W.Retry_later
+          { contention
+          ; reason = W.Selected_generation_changed
+          ; progress = no_progress
+          }))
 ;;
 
 (* task-336 sibling defect (masc, 2026-08-16): before this fix,
@@ -2587,6 +2669,10 @@ let () =
             "drain outcome labels stay distinct"
             `Quick
             test_drain_outcome_labels_stay_distinct
+        ; Alcotest.test_case
+            "drain outcome carries the work it did"
+            `Quick
+            test_drain_outcome_carries_the_work_it_did
         ; Alcotest.test_case
             "settle_one_completed terminalizes a partition whose candidate was retired"
             `Quick

--- a/test/test_log_seq_restart_continuity.ml
+++ b/test/test_log_seq_restart_continuity.ml
@@ -1,0 +1,112 @@
+(* Regression: [seq] stopped identifying a row in the daily JSONL.
+
+   [Log.Ring.total] is process-local but the JSONL sink is per-UTC-day and
+   append-only, so every restart used to resume the sequence at the number of
+   rows it managed to restore — capped at [capacity] — and then re-issue
+   numbers that rows already in the file carried. Measured on
+   [.masc/logs/system_log_2026-08-21.jsonl]: 130,102 rows, 35,068 distinct
+   [seq], twelve resets inside the one file, one value reused ten times. A
+   dashboard cursor taken before a restart therefore pointed into the middle
+   of the reissued range and silently skipped or replayed records.
+
+   The file below reproduces the shape the resets leave behind — a row from a
+   run that reached a high sequence, followed by rows from a run that resumed
+   low — and pins two things: the next sequence this process hands out is
+   above every sequence on disk, and the restored window still answers
+   exactly the rows it holds rather than scanning ring slots this process
+   never filled. *)
+
+open Masc
+
+let high_seq_on_disk = 90_000
+
+let utc_today () =
+  let tm = Unix.gmtime (Unix.gettimeofday ()) in
+  Printf.sprintf
+    "%04d-%02d-%02d"
+    (tm.Unix.tm_year + 1900)
+    (tm.Unix.tm_mon + 1)
+    tm.Unix.tm_mday
+
+let row ~seq ~message =
+  Printf.sprintf
+    {|{"seq":%d,"ts":"2026-08-22T00:00:00Z","level":"INFO","source":"structured","module":"Misc","keeper_name":"system","turn_id":null,"message":%s,"details":null,"category":null}|}
+    seq
+    (Yojson.Safe.to_string (`String message))
+
+let rec rm_rf path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then begin
+      Array.iter
+        (fun name -> rm_rf (Filename.concat path name))
+        (Sys.readdir path);
+      Sys.rmdir path
+    end
+    else Sys.remove path
+
+let write_restart_shaped_log dir =
+  rm_rf dir;
+  Sys.mkdir dir 0o755;
+  let path =
+    Filename.concat dir (Printf.sprintf "system_log_%s.jsonl" (utc_today ()))
+  in
+  let oc = open_out path in
+  List.iter
+    (fun line -> output_string oc (line ^ "\n"))
+    [ row ~seq:0 ~message:"run-a first"
+    ; row ~seq:1 ~message:"run-a second"
+    ; row ~seq:high_seq_on_disk ~message:"run-a last before restart"
+    ; row ~seq:2 ~message:"run-b reissued 2"
+    ];
+  close_out oc;
+  path
+
+let restored_rows = 4
+
+let test_next_sequence_clears_every_sequence_on_disk () =
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      "masc-test-log-seq-restart-continuity"
+  in
+  let path = write_restart_shaped_log dir in
+  Log.Ring.init_file_sink dir;
+  Log.Misc.info "seq-restart-continuity: first emit after restore";
+  (match Log.Ring.recent ~limit:1 () with
+   | [] -> Alcotest.fail "the emit after restore is not in the ring"
+   | newest :: _ ->
+     Alcotest.(check bool)
+       "a sequence issued after restore is above every sequence on disk"
+       true
+       (newest.Log.Ring.seq > high_seq_on_disk));
+  let bounds = Log.Ring.bounds () in
+  Alcotest.(check int)
+    "the live window starts at the first restored sequence"
+    (high_seq_on_disk + 1)
+    bounds.Log.Ring.start_seq;
+  Alcotest.(check bool)
+    "nothing was evicted from a window this small"
+    false
+    bounds.Log.Ring.dropped_before;
+  (* Resuming the counter without moving the window lower bound would make
+     [recent] scan [total - capacity, total), i.e. tens of thousands of ring
+     slots this process never wrote. *)
+  Alcotest.(check int)
+    "the window answers the restored rows and the new one, nothing else"
+    (restored_rows + 1)
+    (List.length (Log.Ring.recent ~limit:Log.Ring.capacity ()));
+  Alcotest.(check bool) "the daily file is still the sink" true (Sys.file_exists path);
+  rm_rf dir
+
+let () =
+  Alcotest.run
+    "log_seq_restart_continuity"
+    [ ( "restart"
+      , [ Alcotest.test_case
+            "the sequence resumes above the file"
+            `Quick
+            test_next_sequence_clears_every_sequence_on_disk
+        ] )
+    ]

--- a/test/test_runtime_log_sink_render.ml
+++ b/test/test_runtime_log_sink_render.ml
@@ -115,6 +115,30 @@ let test_overflowing_fields_are_announced_not_dropped () =
   | other ->
     Alcotest.failf "details is not an object: %s" (Yojson.Safe.to_string other)
 
+(* A key whose value is null is the producer saying the value is unset. Leaving
+   it off the line is the same omission the allowlist used to make, and the
+   overflow marker counts fields rather than rendered pairs, so a dropped null
+   would not even be announced. *)
+let test_null_and_oversized_values_stay_visible () =
+  let long = String.make 400 'x' in
+  emit_record
+    ~module_name:"pipeline"
+    ~message:"partial record"
+    [ Agent_core.Log.J ("cost_usd", `Null); Agent_core.Log.S ("body", long) ];
+  let message = newest_message () in
+  Alcotest.(check bool)
+    "an unset field is stated, not dropped"
+    true
+    (Astring.String.is_infix ~affix:"cost_usd=null" message);
+  Alcotest.(check bool)
+    "an oversized value is cut and says how long it really was"
+    true
+    (Astring.String.is_infix ~affix:"...(400B)" message);
+  Alcotest.(check bool)
+    "the cut line is shorter than the value it reports"
+    true
+    (String.length message < 400)
+
 let () =
   Alcotest.run
     "runtime_log_sink_render"
@@ -135,5 +159,9 @@ let () =
             "overflowing fields are announced"
             `Quick
             test_overflowing_fields_are_announced_not_dropped
+        ; Alcotest.test_case
+            "null and oversized values stay visible"
+            `Quick
+            test_null_and_oversized_values_stay_visible
         ] )
     ]

--- a/test/test_runtime_log_sink_render.ml
+++ b/test/test_runtime_log_sink_render.ml
@@ -1,0 +1,139 @@
+(* The agent-core → MASC log bridge renders the human line for every record
+   the core emits. It used to build that line from a hardcoded key allowlist
+   selected by matching on the message text, and fell back to a fixed guess
+   for anything it did not recognise. The line then lied by omission:
+
+     - [turn checkpoint persisted] carries [stage], [turn] and [messages], but
+       only [turn] was in the fallback list, so the three checkpoint stages of
+       one turn rendered as three identical lines — 1,289 of them in the two
+       hours to 2026-08-22T02:03Z, and the pairs read as duplicate emissions.
+     - [pipeline stage failed] carries [stage] and [error] and rendered with
+       neither, so a WARN told the operator a stage failed without saying
+       which stage or why.
+     - Selecting keys by message text meant every message a producer added
+       later fell into the guess by default.
+
+   These tests pin the replacement contract: the line carries the fields the
+   producer attached, in the order it attached them, and anything the line
+   cannot fit says so instead of vanishing. *)
+
+open Masc
+
+let install_once = lazy (Runtime_log_sink.install ())
+
+let emit_record ~module_name ~message fields =
+  Lazy.force install_once;
+  let logger = Agent_core.Log.create ~module_name () in
+  Agent_core.Log.info logger message fields
+
+let newest_message () =
+  match Log.Ring.recent ~limit:1 () with
+  | [] -> Alcotest.fail "the emitted record never reached the ring"
+  | entry :: _ -> entry.Log.Ring.message
+
+let newest_entry () =
+  match Log.Ring.recent ~limit:1 () with
+  | [] -> Alcotest.fail "the emitted record never reached the ring"
+  | entry :: _ -> entry
+
+let checkpoint stage =
+  emit_record
+    ~module_name:"pipeline_checkpoint"
+    ~message:"turn checkpoint persisted"
+    [ Agent_core.Log.S ("stage", stage)
+    ; Agent_core.Log.I ("turn", 392)
+    ; Agent_core.Log.I ("messages", 691)
+    ];
+  newest_message ()
+
+let test_checkpoint_stages_do_not_collapse () =
+  let collected = checkpoint "after_assistant_collected" in
+  let appended = checkpoint "after_tool_results_appended" in
+  let injected = checkpoint "after_context_injection" in
+  Alcotest.(check int)
+    "one turn's three checkpoint stages are three distinct lines"
+    3
+    (List.length (List.sort_uniq compare [ collected; appended; injected ]));
+  Alcotest.(check bool)
+    "the stage that distinguishes them is on the line"
+    true
+    (String.length collected
+     > String.length "turn checkpoint persisted"
+     && Astring.String.is_infix ~affix:"stage=after_assistant_collected" collected)
+
+let test_unknown_message_keeps_its_fields () =
+  emit_record
+    ~module_name:"pipeline"
+    ~message:"pipeline stage failed"
+    [ Agent_core.Log.S ("stage", "route")
+    ; Agent_core.Log.S ("error", "[route] Rate limited: Rate limit reached")
+    ];
+  let message = newest_message () in
+  Alcotest.(check bool)
+    "the failing stage is named"
+    true
+    (Astring.String.is_infix ~affix:"stage=route" message);
+  (* The value carries spaces, so it must be quoted or the line stops being
+     readable as a sequence of key=value pairs. *)
+  Alcotest.(check bool)
+    "the error is on the line, quoted"
+    true
+    (Astring.String.is_infix
+       ~affix:{|error="[route] Rate limited: Rate limit reached"|}
+       message)
+
+let test_details_still_carry_every_field () =
+  emit_record
+    ~module_name:"pipeline_checkpoint"
+    ~message:"turn checkpoint persisted"
+    [ Agent_core.Log.S ("stage", "after_context_injection")
+    ; Agent_core.Log.I ("turn", 7)
+    ; Agent_core.Log.I ("messages", 13)
+    ];
+  match (newest_entry ()).Log.Ring.details with
+  | `Assoc fields ->
+    Alcotest.(check (list string))
+      "details keep the producer's fields"
+      [ "stage"; "turn"; "messages" ]
+      (List.map fst fields)
+  | other ->
+    Alcotest.failf "details is not an object: %s" (Yojson.Safe.to_string other)
+
+let test_overflowing_fields_are_announced_not_dropped () =
+  let fields =
+    List.init 20 (fun i -> Agent_core.Log.I (Printf.sprintf "f%02d" i, i))
+  in
+  emit_record ~module_name:"pipeline" ~message:"wide record" fields;
+  let entry = newest_entry () in
+  Alcotest.(check bool)
+    "the fields the line could not fit are counted on the line"
+    true
+    (Astring.String.is_infix ~affix:"(+4 more in details)" entry.Log.Ring.message);
+  match entry.Log.Ring.details with
+  | `Assoc kept ->
+    Alcotest.(check int) "details drop nothing" 20 (List.length kept)
+  | other ->
+    Alcotest.failf "details is not an object: %s" (Yojson.Safe.to_string other)
+
+let () =
+  Alcotest.run
+    "runtime_log_sink_render"
+    [ ( "render"
+      , [ Alcotest.test_case
+            "checkpoint stages do not collapse"
+            `Quick
+            test_checkpoint_stages_do_not_collapse
+        ; Alcotest.test_case
+            "an unrecognised message keeps its fields"
+            `Quick
+            test_unknown_message_keeps_its_fields
+        ; Alcotest.test_case
+            "details still carry every field"
+            `Quick
+            test_details_still_carry_every_field
+        ; Alcotest.test_case
+            "overflowing fields are announced"
+            `Quick
+            test_overflowing_fields_are_announced_not_dropped
+        ] )
+    ]


### PR DESCRIPTION
`~/me/.masc/logs/system_log_2026-08-22.jsonl` 의 09:00–11:03 KST 구간(20,458행)과 전날 파일(130,102행)을 읽고, 거기서 실제로 관측된 결함만 고쳤습니다. 각 항목은 코드가 아니라 로그 실측에서 출발했습니다.

## 고친 것

### 1. `seq` 가 하루치 파일 안에서 행을 식별하지 못했습니다
`Log.Ring.total` 은 프로세스 안에서만 유효한데 JSONL 싱크는 UTC 하루 단위 append 파일입니다. 재시작하면 최대 `capacity` 만큼만 복원한 뒤 그 개수부터 번호를 다시 발급해서, 파일에 이미 있는 번호 위로 덮어썼습니다.

`system_log_2026-08-21.jsonl`: 130,102행에 서로 다른 `seq` 는 35,068개. 한 파일 안에서 되감김 12회, 한 번호는 10번 재사용. 재시작 전에 받아둔 대시보드 커서(`since_seq`)가 재발급 구간 한가운데를 가리키게 되어 조용히 건너뛰거나 다시 읽습니다.

이제 디코드한 **모든** 행의 최대 `seq` 위에서 이어갑니다(꼬리 `capacity`행만 보면 짧게 끝난 런의 낮은 최대값을 집을 수 있음). 하한을 같이 옮기지 않으면 `recent` 가 이 프로세스가 채운 적 없는 링 슬롯을 수만 개 훑기 때문에 `first_seq` 를 두고 `recent`/`bounds` 가 읽습니다.

### 2. agent-core → masc 로그 브리지가 필드를 추측하고 버렸습니다
메시지 문자열로 분기하는 하드코딩 키 허용목록 + 못 알아본 메시지용 고정 추측이었습니다.

| 메시지 | 실제 필드 | 렌더된 것 |
|---|---|---|
| `turn checkpoint persisted` | stage, turn, messages | `turn` 만 → 한 턴의 3개 stage가 **동일한 3줄** (2시간 1,289행) |
| `pipeline stage failed` | stage, error | 둘 다 누락 → 어느 stage가 왜 실패했는지 없는 WARN |
| `tool not found` | tool | 툴 이름 없음 |

허용목록의 4개 arm(`agent completed`/`agent started`/`tool called`/`tool completed`)은 이 브리지를 통과한 적이 없습니다. 해당 메시지는 `Keeper_event_bridge` 가 자기 모듈로 직접 씁니다.

`interpolate_printf_message` 는 더 나갔습니다. 메시지에서 `%s`/`%d` 를 찾아 고정 키 우선순위로 값을 끼워 넣는데, `packages/agent_core` 에 그 placeholder를 담은 메시지가 **하나도 없습니다**. 건드릴 일이 없는 줄을 망가뜨리는 것만 가능한 코드였습니다.

둘 다 제거했습니다. 이제 producer가 붙인 순서대로 전 필드를 싣고, 값에 공백이 있으면 인용하고, UTF-8 경계에서 자르며 원래 바이트 길이를 남기고, 상한을 넘긴 필드 수를 명시합니다. `packages/agent_core` 의 자체 `stderr_sink` 가 이미 하던 방식입니다.

### 3. drain 로그가 한 일을 말하지 않았습니다 (보고해주신 중복 라인)
```
board_attention_worker_drain keeper=canary-... outcome=drained
board_attention_worker_drain keeper=canary-... outcome=drained
```
중복 emit이 아니라 **서로 다른 두 번의 drain** 입니다. `drain_outcome` 이 판정만 들고 있어서, 빈 partition을 만난 wake와 20개를 판정한 drain이 같은 문장이 됩니다. 2시간 동안 동일 문자열 쌍 120건 / 단독 64건.

`Drained` 와 `Retry_later` 가 `drain_progress` 를 싣습니다. `judgments` 는 판정이 나온 후보 수, `steps` 는 이미 소비됨/차단됨 방문을 포함한 루프 횟수입니다.

### 4. 툴 실패 1건에 operator 라인 3줄
2026-08-21 기준 184건 전부가 같은 호출·같은 공개 툴 이름으로 더 자세한
`keeper:<k> tool_call tool=<t> params=... outcome=error out_len=... error_preview=...` 를 Error로 갖고 있었고, 174건은 typed failure class에서 레벨을 뽑는 `tool <internal> returned error result` 도 갖고 있었습니다. `on_tool_error` arm 은 opaque text만 있고 failure class가 없어 그 계약을 지킬 수 없는데 Error를 하드코딩해서, 정상적인 정책 거절을 장애처럼 보이게 하고 실패를 두 번 셌습니다. 형제인 `post_tool_use_failure` 는 같은 이유로 이미 강등됐는데 이쪽만 남아 있었습니다.

### 5. 모르는 값을 0으로 적었습니다
`context_window=0`, `latency_ms=0` 은 "provider가 보고 안 함"인데 "창 크기 0", "0ms 호출"로 읽힙니다. 같은 줄의 `cache_n`/`prompt_n`/`wall_tok_s` 는 이미 `-` 를 씁니다. 2시간에 `context_window=0` 25행.

### 6. 설정값을 매 sweep마다 사건으로 찍었습니다
`Retained_disabled`/`Paused_dead` 는 sweep이 다시 읽는 상태지 발생한 일이 아닙니다. 키퍼당 sweep당 Info 1줄이라 2시간 20,458행 중 **4,795행(23%)**, 키퍼 25개. 다른 정상 상태인 `Executable` 은 아무것도 안 찍습니다. `record_recovery_retained` 가 이미 카운터 + `Admission_denied` 라이프사이클 이벤트 두 평면에 사실을 남기므로 routine 채널로 옮겼습니다.

### 7. `runtime_agent` 이 남의 모듈로 찍히고, 없는 설정을 주장했습니다
`lib/runtime/runtime_agent.ml` 의 모든 로그가 `Log.Misc` 를 거치면서 메시지 앞에 `runtime_agent ` 를 손으로 붙였습니다. 콘솔은 `[Misc] runtime_agent ...` 로 자기모순이고, 로그 API는 module 필드로 필터하므로 `module=runtime_agent` 질의가 302행 중 46행만 돌려줬습니다.

resume 라인은 256행 전부에 `turn_limit=unlimited` 를 실었는데, 런타임 에이전트에도 `Agent_core.Agent.resume` 에도 turn limit 개념이 없습니다. 없는 설정을 매번 단언한 셈이라 제거했습니다.

Codex `app-server subscription turn starting` 은 식별자가 아예 없어서, 같은 초에 턴을 시작한 키퍼 8개가 구분 불가능한 8줄이 됩니다(2026-08-22 01:36:25Z 에 1초 안에 7줄). thread와 model을 싣습니다.

### 8. severity lint가 로거 절반을 못 봤습니다
6개 룰 전부가 `Log\.[A-Z][a-z]+\.` 로 모듈을 매칭합니다. 밑줄이나 두 번째 대문자가 있는 로거 14개(`Log.Runtime_agent`, `Log.Tool_validation`, `Log.BoardLog`, `Log.KeeperExec` 등) — 호출 지점 131곳이 전 룰에 안 보였고, 카운터는 들여다본 적 없는 코드에 대해 0을 보고했습니다. 지금 숨어 있던 위반은 없습니다.

L4는 **고치지 않고 표기만** 했습니다. 세 문구(`watchdog tick`, `keepalive emitted`, `heartbeat sent`)가 `lib/`·`bin/` 어디에도 없어 한 번도 매칭된 적이 없고, 그 0은 준수의 증거가 아닙니다. 어휘를 넓혀도 안 됩니다 — `(keepalive|heartbeat|watchdog)` 는 일회성 "started keepalive" 3곳만 잡고 주기 tick은 못 잡으며, 그 구간의 실제 위반(`discord_gateway_state.ml` 의 `presence update: %s`, 2시간 248행)은 `Log { level = `Info; ... }` 데이터 값이라 이 룰 계열이 닿지 않습니다. log-as-data를 보는 탐지 모델이 필요합니다.

## 검증

```
dune build --root . @default @check @install          exit 0
scripts/hardening-ratchet.sh --check --fail-on-critical  exit 0
scripts/check-ssot.sh                                  exit 0
scripts/ci/check-log-severity-anti-patterns.sh         exit 0 (delta -9)
check-variants / check-eio-conventions / check-tool-error-format /
check-boundary-guard / check-doc-truth / check-spec-truth /
check-agent-core-boundary                              모두 exit 0
```

테스트 13개 스위트 168건 통과. 신규 스위트 2개는 CI focused 목록에 배선했습니다.

수정 전 트리에서 실패하는지 확인한 것:
- `test_log_seq_restart_continuity` — 수정 전 FAIL, 수정 후 PASS
- `test_runtime_log_sink_render` — 수정 전 4건 중 3건 FAIL, 수정 후 4건 PASS

## 검증 못 한 것

- `test_runtime_codex_app_server` 의 `subscription boundary` 4건이 실패합니다. **이 브랜치 이전부터 실패**합니다 — `lib/runtime/runtime_codex_app_server.ml` 을 HEAD 원본으로 되돌리고 돌려도 같은 4건이 같은 방식(`stream was idle for 0.050s`)으로 실패합니다. 0.05초 idle deadline 테스트라 부하 영향으로 보이지만 확정하지 않았습니다.

## 남긴 것

- `Log.Misc` 호출 지점이 아직 100개 파일 328곳입니다. 대부분 메시지 앞에 실제 소속(`tool_usage_log`, `audit_log`, `goal`, `startup`, `channel_gate` …)을 손으로 붙이고 있어 7번과 같은 필터 실패를 계속 만듭니다. 기계적 대량 변경이라 분리했습니다.
- `goal verifier deferred ... retryable=true` 가 WARN으로 2시간 125행, 전체 WARN의 44%입니다. 설계된 대기(criterion 판정이 나와야 proof를 볼 수 있음)로 보이지만, `retryable`/`reason` 분류 전수를 확인하지 못했고 이 영역이 #29403/#29415로 최근에 계속 바뀌고 있어 건드리지 않았습니다.
- `discord_gateway_state.ml` 의 `presence update: online` 이 2시간 248행(약 29초 간격)인데 값이 항상 `online` 입니다. 상태 재선언을 사건으로 찍는 6번과 같은 모양입니다.
- `Builder.with_log_sink` 는 빌더 조합자처럼 생겼지만 `Agent_core.Log.add_sink` 로 프로세스 전역 싱크를 등록하고 빌더는 그대로 돌려줍니다. 제거 수단이 없어서, 에이전트마다 부르면 레코드가 N번 전달됩니다. 현재 호출자는 0입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHjBDqkxabEkGddetYVvB4
