### PR TITLE
chore(goal): verifier 의 retry 플래그와 재시도 타이머 제거

### DIFF
--- a/lib/goal_verification_agent.ml
+++ b/lib/goal_verification_agent.ml
@@ -26,7 +26,9 @@
 
     Failure keeps evidence: an unavailable evaluator, a malformed reply after
     all slots failed, or a refused commit leaves the pending row durable and
-    schedules a maintenance-pulse retry. No wall-clock expiry anywhere. *)
+    stops. Nothing re-runs the same review on a clock — the next scan comes
+    from a Keeper requesting completion or from another review committing a
+    verdict. No wall-clock expiry and no retry timer anywhere. *)
 
 type pending_kind =
   | Criterion_check
@@ -39,15 +41,7 @@ type pending_work =
 
 type process_outcome =
   | Committed
-  | Deferred of
-      { retryable : bool
-      ; reason : string
-      }
-
-let should_schedule_retry = function
-  | Committed -> false
-  | Deferred { retryable; reason = _ } -> retryable
-;;
+  | Deferred of string
 
 let pending_kind_to_string = function
   | Criterion_check -> "criterion"
@@ -419,14 +413,13 @@ let commit_gate_verdict config ~goal_id ~verification_run_id ~decision ~evidence
 
 (* {1 Processing} *)
 
-let defer ~goal_id ~kind ~retryable ~reason =
+let defer ~goal_id ~kind ~reason =
   Log.Misc.warn
-    "goal verifier deferred goal_id=%s kind=%s retryable=%b reason=%s"
+    "goal verifier deferred goal_id=%s kind=%s reason=%s"
     goal_id
     (pending_kind_to_string kind)
-    retryable
     reason;
-  Deferred { retryable; reason }
+  Deferred reason
 ;;
 
 let admit_proof_against_criterion config (work : pending_work) =
@@ -434,9 +427,9 @@ let admit_proof_against_criterion config (work : pending_work) =
   | Criterion_check -> Ok ()
   | Completion_proof ->
     (match Goal_verification.get_record config ~goal_id:work.goal_id with
-     | Error detail -> Error (true, detail)
-     | Ok None ->
-       Error (true, "proof request has no verification ledger record")
+     | Error detail -> Error detail
+     | Ok None -> Error "proof request has no verification ledger record"
+
      | Ok (Some record) ->
        (match record.Goal_verification.criterion with
         | Goal_verification.Criterion_viable _ ->
@@ -448,26 +441,20 @@ let admit_proof_against_criterion config (work : pending_work) =
              claim by reading the claim -- the independent proof gate would be
              satisfied by prose.
 
-             Retryable: nothing is wrong with the request, there is just
-             nothing to verify yet. The pending row stays durable, and the
-             first linked Task makes the next drain admissible. *)
+             The pending row stays durable, and the first linked Task makes
+             the next drain admissible. *)
           (match linked_task_rollup config ~goal_id:work.goal_id with
-           | Error detail -> Error (true, detail)
+           | Error detail -> Error detail
            | Ok (_, _, []) ->
              Error
-               ( true
-               , "proof has no linked Task: the Goal's own metric and target \
-                  are the claim under review, not evidence for it" )
+               "proof has no linked Task: the Goal's own metric and target \
+                are the claim under review, not evidence for it"
            | Ok (_, _, _ :: _) -> Ok ())
         | Goal_verification.Criterion_pending _
         | Goal_verification.Criterion_unchecked ->
-          Error
-            ( true
-            , "proof waits until the durable criterion verdict is viable" )
+          Error "proof waits until the durable criterion verdict is viable"
         | Goal_verification.Criterion_unreachable _ ->
-          Error
-            ( false
-            , "proof refused because the durable criterion is unreachable" )))
+          Error "proof refused because the durable criterion is unreachable"))
 ;;
 
 let process_pending_work_inner
@@ -481,8 +468,7 @@ let process_pending_work_inner
   : process_outcome
   =
   match admit_proof_against_criterion config work with
-  | Error (retryable, reason) ->
-    defer ~goal_id:work.goal_id ~kind:work.kind ~retryable ~reason
+  | Error reason -> defer ~goal_id:work.goal_id ~kind:work.kind ~reason
   | Ok () ->
   match Goal_store.get_goal config ~goal_id:work.goal_id with
   | None ->
@@ -491,7 +477,6 @@ let process_pending_work_inner
     defer
       ~goal_id:work.goal_id
       ~kind:work.kind
-      ~retryable:false
       ~reason:"pending verification row names a goal that does not exist"
   | Some goal ->
     (match work.kind, goal.Goal_store.phase with
@@ -502,7 +487,7 @@ let process_pending_work_inner
      | Criterion_check, Goal_phase.Verifying ->
        (match build_review_request config goal work.kind with
         | Error detail ->
-          defer ~goal_id:work.goal_id ~kind:work.kind ~retryable:true ~reason:detail
+          defer ~goal_id:work.goal_id ~kind:work.kind ~reason:detail
         | Ok (review_request, prompt_name, lookup) ->
           (* The verdict channel drops the reason for [Approve]; capture the
              stated reason from the successful verdict tool call — exactly one
@@ -540,22 +525,12 @@ let process_pending_work_inner
                | Some reason -> reason
                | None -> Task.Anti_rationalization.gate_to_string result.gate
              in
-             (* No verdict was committed. Only a typed evaluator error says
-                anything about whether a repeat would end differently; without
-                one — a reply that skipped the verdict tool call, a prompt or
-                slot that would not resolve — nothing here justifies running
-                the same review again, so this stops instead of re-arming the
-                pulse. The row stays durable and the next real wake rescans
-                it. *)
-             let retryable =
-               match result.evaluator_error_retryable with
-               | Some retryable -> retryable
-               | None -> false
-             in
+             (* No verdict was committed. The row stays durable and the next
+                real wake rescans it — a Keeper re-requesting completion, or a
+                worker slot coming free with work still queued. *)
              defer
                ~goal_id:work.goal_id
                ~kind:work.kind
-               ~retryable
                ~reason:detail
            | Some review_verdict ->
              let evidence =
@@ -600,13 +575,11 @@ let process_pending_work_inner
                    defer
                      ~goal_id:work.goal_id
                      ~kind:work.kind
-                     ~retryable:true
                      ~reason:detail)
               | Some _ | None ->
                 defer
                   ~goal_id:work.goal_id
                   ~kind:work.kind
-                  ~retryable:true
                   ~reason:
                     "verdict without a stated reason is not a judgment; the \
                      pending row stays durable")))
@@ -621,7 +594,6 @@ let process_pending_work_inner
        defer
          ~goal_id:work.goal_id
          ~kind:work.kind
-         ~retryable:true
          ~reason:
            "proof request is pending but the phase never entered verifying; \
             waiting for the gate to re-converge"
@@ -630,7 +602,6 @@ let process_pending_work_inner
        defer
          ~goal_id:work.goal_id
          ~kind:work.kind
-         ~retryable:false
          ~reason:"proof request pending on a terminal goal; left durable"
      | Criterion_check, Goal_phase.Completed
      | Criterion_check, Goal_phase.Dropped ->
@@ -640,7 +611,6 @@ let process_pending_work_inner
        defer
          ~goal_id:work.goal_id
          ~kind:work.kind
-         ~retryable:false
          ~reason:"criterion request pending on a terminal goal; left durable")
 ;;
 
@@ -688,8 +658,7 @@ let process_pending_work ?(sw : Eio.Switch.t option = None) config (work : pendi
     let registry_outcome =
       match outcome with
       | Committed -> Goal_verification_run_registry.Committed
-      | Deferred { retryable; reason } ->
-        Goal_verification_run_registry.Deferred { retryable; detail = reason }
+      | Deferred reason -> Goal_verification_run_registry.Deferred { detail = reason }
     in
     persist registry_outcome
   in
@@ -748,11 +717,8 @@ let drain_once ?(sw : Eio.Switch.t option = None) config : (unit, string) result
 type runtime =
   { config : Workspace_utils_backend_setup.config
   ; sw : Eio.Switch.t
-  ; clock : float Eio.Time.clock_ty Eio.Resource.t
   ; wake : Eio.Condition.t
   ; pending : bool Atomic.t
-  ; retry_scheduled : bool Atomic.t
-  ; retry_interval_sec : float
   ; in_flight : pending_work list Atomic.t
   }
 
@@ -791,21 +757,17 @@ let request_scan (runtime : runtime) =
   Eio.Condition.broadcast runtime.wake
 ;;
 
-let schedule_retry (runtime : runtime) =
-  if Atomic.compare_and_set runtime.retry_scheduled false true
-  then
-    Eio.Fiber.fork_daemon ~sw:runtime.sw (fun () ->
-      Eio.Time.sleep runtime.clock runtime.retry_interval_sec;
-      Atomic.set runtime.retry_scheduled false;
-      request_scan runtime;
-      `Stop_daemon)
-;;
-
+(* Rescanning is driven by what happened, not by a clock. A committed verdict
+   changes the ledger, so whatever else was queued deserves another look, and
+   the worker slot this fiber held has just come free. A run that committed
+   nothing changes nothing: scanning again would read the same rows and defer
+   them again, so it stops and waits for a real wake — a Keeper requesting
+   completion, or another worker committing. *)
 let process_goal_work (runtime : runtime) work =
   match work with
   | [] -> ()
   | representative :: _ ->
-    let retryable =
+    let committed_any =
       Eio.Switch.run (fun work_sw ->
         Eio.Switch.on_release work_sw (fun () ->
           release_review runtime representative);
@@ -815,10 +777,10 @@ let process_goal_work (runtime : runtime) work =
               "goal verifier isolated unexpected worker failure goal_id=%s detail=%s"
               representative.goal_id
               (Printexc.to_string exn);
-            true)
+            false)
           (fun () ->
-             let rec loop = function
-               | [] -> false
+             let rec loop committed = function
+               | [] -> committed
                | item :: rest ->
                  (match
                     process_pending_work
@@ -826,12 +788,12 @@ let process_goal_work (runtime : runtime) work =
                       runtime.config
                       item
                   with
-                  | Committed -> loop rest
-                  | Deferred { retryable; reason = _ } -> retryable)
+                  | Committed -> loop true rest
+                  | Deferred _ -> committed)
              in
-             loop work))
+             loop false work))
     in
-    if retryable then schedule_retry runtime
+    if committed_any then request_scan runtime
 ;;
 
 let take_items limit items =
@@ -848,8 +810,7 @@ let process_pending (runtime : runtime) =
   | Error detail ->
     Log.Misc.error
       "goal verifier ledger read failed; pending rows remain undrained: %s"
-      detail;
-    schedule_retry runtime
+      detail
   | Ok work ->
     let active = Atomic.get runtime.in_flight in
     let available = max 0 (max_concurrent_reviews - List.length active) in
@@ -869,8 +830,7 @@ let process_pending (runtime : runtime) =
           then
             Eio.Fiber.fork ~sw:runtime.sw (fun () ->
               process_goal_work runtime goal_work))
-      selected;
-    if List.length selected < List.length eligible then schedule_retry runtime
+      selected
 ;;
 
 let run (runtime : runtime) : [ `Stop_daemon ] =
@@ -881,8 +841,7 @@ let run (runtime : runtime) : [ `Stop_daemon ] =
         ~on_exn:(fun exn ->
           Log.Misc.error
             "goal verifier isolated unexpected scan failure detail=%s"
-            (Printexc.to_string exn);
-          schedule_retry runtime)
+            (Printexc.to_string exn))
         (fun () -> process_pending runtime);
       None)
     else None)
@@ -903,16 +862,13 @@ let install_callback (runtime : runtime) =
          Log.Misc.info "goal verifier scheduled goal_id=%s" goal_id))
 ;;
 
-let start ~sw ~clock ~(config : Workspace_utils_backend_setup.config) =
+let start ~sw ~(config : Workspace_utils_backend_setup.config) =
   Eio.Switch.check sw;
   let runtime =
     { config
     ; sw
-    ; clock
     ; wake = Eio.Condition.create ()
     ; pending = Atomic.make true
-    ; retry_scheduled = Atomic.make false
-    ; retry_interval_sec = Env_config.Timeouts.maintenance_pulse_interval_sec
     ; in_flight = Atomic.make []
     }
   in
@@ -964,11 +920,7 @@ module For_testing = struct
 
   type nonrec process_outcome = process_outcome =
     | Committed
-    | Deferred of
-        { retryable : bool
-        ; reason : string
-        }
+    | Deferred of string
 
-  let should_schedule_retry = should_schedule_retry
   let group_pending_by_goal = group_pending_by_goal
 end

--- a/lib/goal_verification_agent.mli
+++ b/lib/goal_verification_agent.mli
@@ -11,12 +11,12 @@
 
     Typed non-verdicts (evaluator unavailable, malformed reply after all
     slots failed, verdict without a stated reason, refused commit) leave the
-    pending row durable and schedule a maintenance-pulse retry — a pending
-    row is never consumed on failure, and there is no wall-clock expiry. *)
+    pending row durable and stop — a pending row is never consumed on
+    failure, nothing re-runs the same review on a clock, and there is no
+    wall-clock expiry. *)
 
 val start :
   sw:Eio.Switch.t ->
-  clock:float Eio.Time.clock_ty Eio.Resource.t ->
   config:Workspace_utils_backend_setup.config ->
   unit
 
@@ -30,18 +30,11 @@ module For_testing : sig
     kind : pending_kind;
   }
 
-  (** How one review ended, decoupled from the Eio scheduling loop so the
-      retry decision is a pure function of it. *)
+  (** How one review ended. [Deferred] carries the reason no verdict was
+      committed; the pending row it names is still durable. *)
   type process_outcome =
     | Committed
-    | Deferred of {
-        retryable : bool;
-        reason : string;
-      }
-
-  val should_schedule_retry : process_outcome -> bool
-  (** Whether the maintenance-pulse retry timer should arm for this outcome.
-      [false] for [Committed] and for non-retryable deferrals. *)
+    | Deferred of string
 
   val group_pending_by_goal : pending_work list -> pending_work list list
   (** Stable grouping used by the daemon: criterion work precedes proof work

--- a/lib/goal_verification_run_registry.ml
+++ b/lib/goal_verification_run_registry.ml
@@ -6,9 +6,7 @@ type outcome =
   | Reviewed
   | Committed
   | Deferred of
-      { retryable : bool
-      ; detail : string
-      }
+      { detail : string }
   | Raised of { detail : string }
 
 type run_status =
@@ -98,8 +96,7 @@ module Payload = struct
       match completion.outcome with
       | Reviewed -> []
       | Committed -> []
-      | Deferred { retryable; detail } ->
-        [ "retryable", `Bool retryable; "detail", `String detail ]
+      | Deferred { detail } -> [ "detail", `String detail ]
       | Raised { detail } -> [ "detail", `String detail ]
     in
     `Assoc
@@ -126,7 +123,7 @@ module Payload = struct
       match outcome_label with
       | "reviewed" -> Ok []
       | "committed" -> Ok []
-      | "deferred" -> Ok [ "retryable"; "detail" ]
+      | "deferred" -> Ok [ "detail" ]
       | "raised" -> Ok [ "detail" ]
       | label -> Error (Printf.sprintf "unknown Goal review outcome %S" label)
     in
@@ -159,14 +156,8 @@ module Payload = struct
       | "reviewed" -> Ok Reviewed
       | "committed" -> Ok Committed
       | "deferred" ->
-        let* retryable =
-          match List.assoc_opt "retryable" fields with
-          | Some (`Bool retryable) -> Ok retryable
-          | Some _ -> Error "field retryable must be a boolean"
-          | None -> Error "missing field retryable"
-        in
         let* detail = Run_registry_core.Json.string_field "detail" fields in
-        Ok (Deferred { retryable; detail })
+        Ok (Deferred { detail })
       | "raised" ->
         let* detail = Run_registry_core.Json.string_field "detail" fields in
         Ok (Raised { detail })
@@ -249,8 +240,7 @@ let run_to_yojson run =
         match outcome with
         | Reviewed -> []
         | Committed -> []
-        | Deferred { retryable; detail } ->
-          [ "retryable", `Bool retryable; "detail", `String detail ]
+        | Deferred { detail } -> [ "detail", `String detail ]
         | Raised { detail } -> [ "detail", `String detail ]
       in
       [ "elapsed_s", `Float elapsed_s

--- a/lib/goal_verification_run_registry.mli
+++ b/lib/goal_verification_run_registry.mli
@@ -10,10 +10,7 @@ type review_kind =
 type outcome =
   | Reviewed
   | Committed
-  | Deferred of
-      { retryable : bool
-      ; detail : string
-      }
+  | Deferred of { detail : string }
   | Raised of { detail : string }
 
 type run_status =

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1235,11 +1235,8 @@ let start_completion_authority ~sw ~clock (state : Mcp_server.server_state) =
    same post-readiness lane as the task completion authority — the stage-2
    gate is illegal to merge without it (a gate no one calls wedges every goal
    that enters [Verifying]). *)
-let start_goal_verifier ~sw ~clock (state : Mcp_server.server_state) =
-  Goal_verification_agent.start
-    ~sw
-    ~clock
-    ~config:(Mcp_server.workspace_config state)
+let start_goal_verifier ~sw (state : Mcp_server.server_state) =
+  Goal_verification_agent.start ~sw ~config:(Mcp_server.workspace_config state)
 
 let start_post_ready_owner_lanes
       ~sw
@@ -1251,7 +1248,7 @@ let start_post_ready_owner_lanes
      and stdio must install the system-LLM authority before maintenance can
      observe or resume AwaitingVerification work. *)
   start_completion_authority ~sw ~clock state;
-  start_goal_verifier ~sw ~clock state;
+  start_goal_verifier ~sw state;
   Server_bootstrap_loops.start_background_maintenance ~sw ~clock ~env state
 
 let install_keeper_gate_persistence state =

--- a/test/test_goal_verification_agent.ml
+++ b/test/test_goal_verification_agent.ml
@@ -578,7 +578,7 @@ let test_criterion_pending_drains_to_viable () =
 ;;
 
 (* (d) An unavailable evaluator is a typed non-verdict: the row stays
-   pending, the phase stays Verifying, and the outcome schedules a retry. *)
+   pending, the phase stays Verifying, and the outcome names why. *)
 let test_lane_unavailable_keeps_the_pending_row () =
   with_workspace
   @@ fun config ->
@@ -599,10 +599,11 @@ let test_lane_unavailable_keeps_the_pending_row () =
        List.iter
          (fun outcome ->
             match outcome with
-            | Agent.Deferred { retryable = true; reason = _ } ->
-              check bool "retry scheduled for a retryable deferral" true
-                (Agent.should_schedule_retry outcome)
-            | _ -> fail "an unavailable evaluator must defer retryable")
+            | Agent.Deferred reason ->
+              check bool "the deferral states a reason" true
+                (String.trim reason <> "")
+            | Agent.Committed ->
+              fail "an unavailable evaluator must not commit a verdict")
          outcomes);
   check string "the phase never left verifying" "verifying"
     (stored_phase config goal_id);


### PR DESCRIPTION
완료 심사는 판정이 나오거나 안 나오거나 둘 중 하나입니다. 그런데 "같은 심사를 다시 돌릴지"를 deferral 에 불리언으로 달고, 그 값으로 maintenance-pulse 타이머를 켜고 있었어요. 아무도 다시 묻지 않은 질문을 verifier 가 혼자 다시 묻는 구조였습니다.

## 지운 것

| | |
|---|---|
| `process_outcome` | `Deferred { retryable; reason }` → `Deferred of string` (사유만) |
| `should_schedule_retry` / `schedule_retry` | 삭제 |
| `retry_scheduled` / `retry_interval_sec` | 삭제 |
| `runtime.clock` | 타이머가 유일한 소비자였습니다. `start ~clock` 인자까지 제거 |
| run registry 의 `retryable` | 인코더·디코더·필드 목록에서 제거 |

## 재스캔을 무엇으로 바꿨나

그냥 타이머만 지우면 핫 루프가 됩니다. 스캔 → 전부 보류 → 재스캔 → 같은 행 → 반복.

그래서 **일어난 일** 을 신호로 삼습니다.

- 판정을 하나라도 커밋했다 → 원장이 바뀌었고 작업 슬롯도 비었으니 다시 본다
- 아무것도 커밋 안 했다 → 바뀐 게 없으니 멈춘다. 다시 읽어봐야 같은 행을 또 보류할 뿐입니다

멈춘 뒤의 재개는 실제 wake 로 옵니다 — Keeper 가 완료를 청원하거나, 다른 심사가 판정을 커밋하거나.

`process_pending` 의 ledger 읽기 실패, 동시성 상한, scan 예외에 붙어 있던 `schedule_retry` 도 같이 뗐습니다. pending 행은 durable 하므로 유실은 없고, 다음 wake 에 다시 집힙니다.

## 배포 주의

run registry 디코더가 `exact_fields` 로 엄격합니다. `retryable` 을 지웠으므로 **그 필드를 달고 기록된 기존 행은 디코드되지 않습니다.** 레거시 reader 를 두지 않는 방침이라, 배포 창에서 store strip 이 같이 가야 합니다.

## 검증

```
goal verification agent   14/14
dune build @check         통과
```

관련: MASC task-449 계열 (Goal 이 다른 것을 제약하는 지점 숙청)