### PR TITLE
chore(dashboard): 서버가 보내지 않는 goal 필드의 소비 지점 제거

### DIFF
--- a/dashboard/src/api/dashboard-goals.test.ts
+++ b/dashboard/src/api/dashboard-goals.test.ts
@@ -280,7 +280,6 @@ describe('fetchDashboardGoalsTree decoding', () => {
           name: 'keeper-a',
           agent_name: 'agent-a',
           current_task_id: null,
-          active_goal_ids: ['goal-runtime'],
           sandbox_profile: 'workspace',
           network_mode: 'enabled',
           runtime_id: 'runtime-a',

--- a/dashboard/src/api/dashboard-goals.ts
+++ b/dashboard/src/api/dashboard-goals.ts
@@ -276,7 +276,6 @@ function decodeGoalDetailKeeper(raw: unknown): GoalDetailKeeper | null {
     name,
     agent_name: agentName,
     current_task_id: asNullableString(raw.current_task_id),
-    active_goal_ids: asStringArray(raw.active_goal_ids),
     sandbox_profile: sandboxProfile,
     network_mode: networkMode,
     runtime_id: runtimeName,

--- a/dashboard/src/components/keeper-detail-page.test.ts
+++ b/dashboard/src/components/keeper-detail-page.test.ts
@@ -15,7 +15,6 @@ function makeKeeper(overrides: Partial<Keeper> = {}): Keeper {
     lifecycle_phase: 'Running',
     active_model_label: 'claude-sonnet-4',
     runtime_canonical: 'agent-core-seoul-1',
-    active_goal_ids: ['goal-runtime-lane-cleanup'],
     context_ratio: 0.62,
     context_tokens: 124_000,
     context_max: 200_000,

--- a/dashboard/src/components/keeper-detail.test.ts
+++ b/dashboard/src/components/keeper-detail.test.ts
@@ -295,7 +295,6 @@ describe('KeeperDetailPage', () => {
       agent_name: 'keeper-analyst-agent',
       runtime_class: 'keeper',
       keepalive_running: true,
-      active_goal_ids: ['goal-evidence-first'],
       recent_output_preview: '현재 대화의 근거와 핵심 수치를 먼저 정리한다.',
       generation: 0,
       turn_count: 97,

--- a/dashboard/src/keeper-store-normalize.test.ts
+++ b/dashboard/src/keeper-store-normalize.test.ts
@@ -385,7 +385,6 @@ describe('normalizeKeepers lifecycle metrics', () => {
         sandbox_target: 'docker',
         blocked_task_count: 2,
         goal_progress: {
-          active_goal_count: 1,
           linked_task_count: 4,
           done_task_count: 1,
           open_task_count: 3,

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -727,7 +727,6 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
         blocked_task_count: asNumber(row.blocked_task_count) ?? null,
         goal_progress: isRecord(row.goal_progress)
           ? {
-              active_goal_count: asNumber(row.goal_progress.active_goal_count) ?? undefined,
               linked_task_count: asNumber(row.goal_progress.linked_task_count) ?? undefined,
               done_task_count: asNumber(row.goal_progress.done_task_count) ?? undefined,
               open_task_count: asNumber(row.goal_progress.open_task_count) ?? undefined,

--- a/dashboard/src/mission-normalizers.ts
+++ b/dashboard/src/mission-normalizers.ts
@@ -42,7 +42,6 @@ function normalizeKeeper(raw: unknown): OperatorKeeperSnapshot | null {
     status: asString(raw.status),
     context_ratio: asNumber(raw.context_ratio),
     generation: asNumber(raw.generation),
-    active_goal_ids: asStringArray(raw.active_goal_ids),
     last_autonomous_action_at: asString(raw.last_autonomous_action_at) ?? null,
     last_turn_ago_s: asNumber(raw.last_turn_ago_s),
     model: asString(raw.model),

--- a/dashboard/src/operator-normalizers.ts
+++ b/dashboard/src/operator-normalizers.ts
@@ -167,7 +167,6 @@ function normalizeKeeper(raw: unknown): OperatorKeeperSnapshot | null {
     context_metrics_unavailable: normalizeKeeperContextMetricsUnavailable(raw.context_metrics_unavailable),
     last_turn_usage: normalizeKeeperLastTurnUsage(raw.last_turn_usage),
     generation: asNumber(raw.generation),
-    active_goal_ids: asStringArray(raw.active_goal_ids),
     last_autonomous_action_at: asString(raw.last_autonomous_action_at) ?? null,
     last_turn_ago_s: asNumber(raw.last_turn_ago_s),
     model: hasModelLabel ? 'runtime' : undefined,

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -1155,7 +1155,6 @@ export interface Keeper {
   sandbox_last_error?: string | null
   blocked_task_count?: number | null
   goal_progress?: {
-    active_goal_count?: number
     linked_task_count?: number
     done_task_count?: number
     open_task_count?: number
@@ -1345,11 +1344,6 @@ interface KeeperConfigProactive {
 export interface RuntimeRef {
   group: string
   item: string | null
-}
-
-export interface KeeperConfigActiveGoal {
-  id: string
-  title: string
 }
 
 export interface KeeperConfigRuntimeTrust {

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -790,7 +790,6 @@ export interface GoalDetailKeeper {
   name: string
   agent_name: string
   current_task_id: string | null
-  active_goal_ids: string[]
   sandbox_profile: string
   network_mode: string
   runtime_id: string

--- a/dashboard/src/types/dashboard-mission.ts
+++ b/dashboard/src/types/dashboard-mission.ts
@@ -234,7 +234,6 @@ export interface OperatorKeeperSnapshot {
   status?: string
   context_ratio?: number | null
   generation?: number
-  active_goal_ids?: string[]
   last_autonomous_action_at?: string | null
   last_turn_ago_s?: number
   model?: string


### PR DESCRIPTION
#29325 를 main 기준으로 다시 만든 것입니다. 그 PR 의 diff 가 지금 트리에 더는 맞지 않아서 리베이스 대신 재유도했습니다.

## 왜 다시 만들었나

#29325 를 리베이스하니 8파일 13곳이 충돌했는데, 열어보니 main 이 **더 지운 곳**과 **덜 지운 곳**이 섞여 있었습니다.

- `types/core.ts` — 그 PR 은 4필드 중 3개를 지우고 `active_goals` 를 남겼는데, main 은 이미 4개 전부 지웠습니다.
- normalizer 8파일 — main 에 그대로 남아 있습니다.

이런 트리에서 옛 diff 를 재생하면 어느 쪽으로든 의도가 뒤집힙니다. 그래서 목표를 다시 정의했습니다 — **서버가 보내지 않는 필드를 읽는 소비자 제거**. 이건 세어서 확인할 수 있습니다.

## 지우기 전에 센 것

| 필드 | `lib/` 안 생산자 |
|------|------------------|
| `active_goal_count` | 0건 |
| `active_goal_ids` | 1건 — `keeper_board_attention_candidate.ml` 이 낡은 v4 원장 행에서 **벗겨내는** 정규화기. 생산자가 아닙니다. |

`goal_progress` 는 서버가 runtime contract 에서 통째로 중계하는데 그 안에 `active_goal_count` 를 쓰는 곳도 없습니다.

## 걷어낸 것

**읽기 3곳** — `dashboard-goals.ts`, `mission-normalizers.ts`, `operator-normalizers.ts` 의 `active_goal_ids`, `keeper-store-normalize.ts` 의 `goal_progress.active_goal_count`.

**타입 선언 4곳** — `dashboard-execution.ts`, `dashboard-mission.ts`, `core.ts` 의 `active_goal_count?`, 그리고 아무도 참조하지 않게 된 `KeeperConfigActiveGoal`.

**픽스처 4곳** — 테스트가 서버가 만들지 않는 모양을 계속 흉내내면, 지운 필드가 그 길로 돌아옵니다.

## 검증

- dashboard typecheck PASS
- vitest 9036/9036 PASS
- 제거 후 `dashboard/src` 안 잔여 참조 0건

## 남은 것

`keeper_board_attention_candidate.ml` 의 `normalize_legacy_v4_keeper_context` 는 그대로 뒀습니다. 낡은 원장 행에서 `active_goal_ids` 를 받아 벗겨내는 코드라 이 PR 범위 밖이고, 지우려면 라이브 v4 원장에 그 필드를 든 행이 실제로 남아 있는지 먼저 세야 합니다.
