### PR TITLE
fix(dashboard): fusion 보드 행의 시작 시각을 증거에 사본이 없으면 레지스트리에서 가져온다

### DIFF
--- a/dashboard/src/components/fusion/fusion-surface.test.ts
+++ b/dashboard/src/components/fusion/fusion-surface.test.ts
@@ -1173,7 +1173,42 @@ describe('FusionSurface', () => {
     expect(ids).toEqual(['fus-created-early-started-new', 'fus-created-late-started-old'])
   })
 
-  it('does not list board evidence that carries no run start', () => {
+  // Live 2026-08-22: 13 fusion posts written before the sink copied
+  // started_at into the evidence, all 13 still in the registry. The list
+  // showed 13 "waiting for board sink" registry rows while the board rows
+  // carried the panel and judge.
+  it('takes the start from the registry record when the board evidence has no copy', () => {
+    fusionRuns.value = [
+      {
+        runId: 'fus-registry-start',
+        keeper: 'sangsu',
+        preset: 'balanced',
+        topology: null,
+        startedAt: Date.parse('2026-06-19T12:00:00Z') / 1000,
+        status: 'completed',
+      },
+    ]
+    fusionBoardPosts.value = [
+      minimalFusionPost(
+        'fus-registry-start',
+        '2026-06-19T09:00:00Z',
+        '2026-06-19T09:01:00Z',
+        null,
+      ),
+      minimalFusionPost('fus-known-start', '2026-06-19T01:00:00Z', '2026-06-19T01:01:00Z'),
+    ]
+
+    render(html`<${FusionSurface} />`, container)
+
+    const ids = Array.from(container.querySelectorAll('.fus-run-id')).map(
+      element => element.textContent,
+    )
+    expect(ids).toEqual(['fus-registry-start', 'fus-known-start'])
+    // The board row wins over its registry duplicate: one row, board detail.
+    expect(container.querySelectorAll('[data-testid="fusion-registry-row"]').length).toBe(0)
+  })
+
+  it('does not list board evidence with no start in the evidence or the registry', () => {
     fusionBoardPosts.value = [
       minimalFusionPost(
         'fus-no-start',

--- a/dashboard/src/components/fusion/fusion-surface.ts
+++ b/dashboard/src/components/fusion/fusion-surface.ts
@@ -134,7 +134,10 @@ interface FusionRunView {
   usage: FusionUsage
   preset: string | null
   params: FusionRunParams
-  startedAt: number
+  // Run start (unix seconds) as the board sink copied it from the registry;
+  // null when the evidence predates that copy. The list resolves the start
+  // from the registry record in that case (buildMergedRuns).
+  startedAt: number | null
   createdAt: string
   updatedAt: string
 }
@@ -354,11 +357,11 @@ function fusionRunFromPost(post: BoardPost): FusionRunView | null {
   const judges = normalizeFusionJudgeNodes(meta.judges)
   const usage = normalizeUsage(meta, panel)
   const params = normalizeParams(meta)
-  // A fusion run is identified on the list by its start coordinate; board
-  // evidence without a finite non-negative `started_at` is not a run row.
   const rawStartedAt = firstNumber(meta, ['started_at'])
-  if (rawStartedAt === null || !Number.isFinite(rawStartedAt) || rawStartedAt < 0) return null
-  const startedAt = rawStartedAt
+  const startedAt =
+    rawStartedAt !== null && Number.isFinite(rawStartedAt) && rawStartedAt >= 0
+      ? rawStartedAt
+      : null
   const question = firstString(meta, ['question', 'prompt']) ?? post.body ?? post.content ?? post.title
   const status = statusFor(judge, panel)
   const tone = toneFor(status, judge.decision)
@@ -405,7 +408,7 @@ function registryToRunStatus(status: FusionRunStatusLabel): FusionRunStatus {
 // surface matches the prototype's 2-pane master/detail instead of stacking a
 // separate registry panel above it.
 type MergedRun =
-  | { kind: 'board'; runId: string; sortTime: number; view: FusionRunView }
+  | { kind: 'board'; runId: string; sortTime: number; startedAt: number; view: FusionRunView }
   | { kind: 'registry'; runId: string; sortTime: number; record: FusionRunRecord }
 
 // Master-list page size: rows rendered initially and added per "더 보기" click.
@@ -414,21 +417,26 @@ const FUSION_LIST_PAGE_SIZE = 30
 // Dedup key is runId: once a deliberation lands a board post the board entry wins
 // (it carries the detail), so the registry duplicate is dropped. Ordering uses
 // one visible policy — newest first — on a SINGLE axis for every row: the run's
-// START time, which both board evidence (`started_at`) and the registry persist.
-// Sorting board rows by createdAt and registry rows by startedAt was the mixed
-// axis this list must not reintroduce (38-bug campaign #34 follow-up).
+// START time. The registry records it and the board sink copies it into the
+// evidence so a completed row outlives the registry's Latest-64 retention. A
+// board row whose evidence has no copy takes the start from its registry
+// record; without either there is no start coordinate and the row is not
+// listed. Sorting board rows by createdAt and registry rows by startedAt was
+// the mixed axis this list must not reintroduce (38-bug campaign #34).
 function buildMergedRuns(
   boardRuns: readonly FusionRunView[],
   registryRuns: readonly FusionRunRecord[],
 ): MergedRun[] {
   const boardIds = new Set(boardRuns.map(run => run.runId))
+  const registryByRun = new Map(registryRuns.map(record => [record.runId, record]))
+  const boardRows: MergedRun[] = []
+  for (const view of boardRuns) {
+    const startedAt = view.startedAt ?? registryByRun.get(view.runId)?.startedAt ?? null
+    if (startedAt === null) continue
+    boardRows.push({ kind: 'board', runId: view.runId, sortTime: startedAt * 1000, startedAt, view })
+  }
   const merged: MergedRun[] = [
-    ...boardRuns.map((view): MergedRun => ({
-      kind: 'board',
-      runId: view.runId,
-      sortTime: view.startedAt * 1000,
-      view,
-    })),
+    ...boardRows,
     ...registryRuns
       .filter(record => !boardIds.has(record.runId))
       .map((record): MergedRun => ({
@@ -925,7 +933,7 @@ function FusionJudgeEvidence({ judge }: { judge: FusionJudge }) {
 }
 
 // Row timestamp renders the same durable start coordinate used for sorting.
-function FusionRunRow({ run, active }: { run: FusionRunView; active: boolean }) {
+function FusionRunRow({ run, startedAt, active }: { run: FusionRunView; startedAt: number; active: boolean }) {
   const dec = decisionSpecFor(run.judge.decision)
   return html`
     <button
@@ -937,7 +945,7 @@ function FusionRunRow({ run, active }: { run: FusionRunView; active: boolean }) 
       <span class="fus-row-h">
         <${FusionStatusGlyph} status=${run.status} />
         <span class="fus-run-id mono">${run.runId}</span>
-        <span class="fus-row-ts"><${TimeAgo} timestamp=${run.startedAt} /></span>
+        <span class="fus-row-ts"><${TimeAgo} timestamp=${startedAt} /></span>
       </span>
       <span class="fus-row-prompt">${compactText(run.question, 110)}</span>
       <span class="fus-row-f">
@@ -1385,6 +1393,7 @@ export function FusionSurface() {
                     ? html`<${FusionRunRow}
                         key=${run.runId}
                         run=${run.view}
+                        startedAt=${run.startedAt}
                         active=${selected?.runId === run.runId}
                       />`
                     : html`<${FusionRegistryRow}


### PR DESCRIPTION
## 현상 (0.24.0 배포 직후, 소유자 보고)

`#fusion` 의 모든 행이 "완료됨 — 보드 sink 기록을 기다리는 중입니다" 로만 보이고 상세가 없음.

## 원인

#29315 는 `meta.started_at` 없는 보드 증거를 목록에서 뺐습니다. 라이브 실측: fusion 보드 포스트 13건 중 `started_at` 보유 **0** (sink 가 사본을 쓰기 시작한 것이 배포 01:31Z 이후이고 최신 포스트는 08-20), 레지스트리 19행(completed 16 · failed 3) 중 run_id 13/13 이 그 보드 포스트와 겹침. 보드 행이 전부 탈락하자 `buildMergedRuns` 가 레지스트리 행만 내고 상세는 "sink 대기" 자리표시자 — 패널·심판 증거가 보드에 있는데도요. #29315 의 설계 결함이 맞습니다(제가 넣은 하드컷이 축의 SSOT 인 레지스트리를 보지 않았습니다).

## 바꾼 것

시작 좌표는 여전히 한 축입니다. 레지스트리가 기록하고 sink 가 증거에 사본을 둬서 행이 Latest-64 보존을 넘겨 살아남게 합니다. 이제 `buildMergedRuns` 는 보드 행의 시작을 `view.startedAt ?? registry[runId].startedAt` 로 해석하고, 둘 다 없을 때만 목록에서 뺍니다. `FusionRunView.startedAt` 은 `number | null`, 행 타임스탬프는 병합 행의 해석된 값.

## 테스트 (`fusion-surface.test.ts`, 68/68)

- `takes the start from the registry record when the board evidence has no copy` — 사본 없는 보드 포스트 + 같은 run_id 레지스트리 레코드 → 보드 행으로 표시(레지스트리 중복 행 0), 레지스트리 시각으로 정렬.
- `does not list board evidence with no start in the evidence or the registry` — 둘 다 없으면 미표시(기존 하드컷 유지).
- `tsc --noEmit` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3a8sWueQQPyYyoXerLJvj
