### PR TITLE
fix(dashboard): 서버 warm-up 중에도 키퍼 목록이 비어 보이지 않게

### DIFF
--- a/dashboard/src/api/core.test.ts
+++ b/dashboard/src/api/core.test.ts
@@ -437,6 +437,25 @@ describe('get bootstrap warm-up mapping', () => {
     expect(data.message).toContain('warming up')
   })
 
+  // The server answers /api/v1/dashboard/* warm-up reads with
+  // {"status":"initializing"} (server_auth.ml not_initialized_response), not
+  // {"error":"not initialized"}. Until 2026-08-22 that envelope flowed into
+  // the execution store as an empty fleet.
+  it('maps the dashboard status:initializing envelope to the execution initializing payload', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{"status":"initializing","message":"Server is warming up"}', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const data = await get<{ status?: { project?: string }; keepers?: unknown[] }>('/api/v1/dashboard/execution')
+
+    expect(data.status?.project).toBe('initializing')
+    expect(data.keepers).toEqual([])
+  })
+
   it('maps dashboard shell not-initialized errors to an empty bootstrap shell payload', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response('{"error":"not initialized"}', {

--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -577,8 +577,13 @@ async function parseJsonResponse<T>(
   }
 }
 
+// The server answers a warm-up read with `{"status":"initializing"}` on
+// /api/v1/dashboard/* paths and `{"error":"not initialized"}` elsewhere
+// (lib/server/server_auth.ml not_initialized_response). Both mean the same
+// thing: no state yet, try again.
 function isNotInitializedEnvelope(raw: unknown): boolean {
   if (!isRecord(raw)) return false
+  if (typeof raw.status === 'string' && raw.status === 'initializing') return true
   return typeof raw.error === 'string' && raw.error.trim().toLowerCase() === 'not initialized'
 }
 

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
@@ -18,10 +18,10 @@ vi.mock('../keeper-detail-helpers', () => ({
 }))
 
 import { navigate } from '../../router'
-import { keepers } from '../../store'
+import { keepers, executionError, executionLoaded } from '../../store'
 import { keeperMobilePane } from '../keeper-detail-state'
 import { runKeeperAction } from '../keeper-action-panel'
-import { KeeperWorkspaceRoster, rosterFilterPref, rosterFleetSummary, rosterSortPref } from './keeper-workspace-roster'
+import { KeeperWorkspaceRoster, rosterEmptyText, rosterFilterPref, rosterFleetSummary, rosterSortPref } from './keeper-workspace-roster'
 import { keeperBucket } from './keeper-workspace-shared'
 import type { Keeper } from '../../types'
 
@@ -53,6 +53,30 @@ afterEach(() => {
   render(null, host)
   host.remove()
   keepers.value = []
+})
+
+describe('rosterEmptyText', () => {
+  afterEach(() => {
+    executionLoaded.value = false
+    executionError.value = null
+  })
+
+  it('says loading before the fleet has hydrated', () => {
+    executionLoaded.value = false
+    expect(rosterEmptyText(0)).toBe('키퍼 목록을 불러오는 중…')
+  })
+
+  it('says the load failed when the execution fetch errored', () => {
+    executionLoaded.value = true
+    executionError.value = 'boom'
+    expect(rosterEmptyText(0)).toContain('불러오지 못했습니다')
+  })
+
+  it('distinguishes an empty fleet from a filter that matched nothing', () => {
+    executionLoaded.value = true
+    expect(rosterEmptyText(0)).toBe('등록된 키퍼가 없습니다')
+    expect(rosterEmptyText(3)).toBe('일치하는 키퍼가 없습니다')
+  })
 })
 
 describe('KeeperWorkspaceRoster', () => {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -13,7 +13,7 @@ import {
 } from 'lucide-preact'
 import { useEffect, useMemo, useState } from 'preact/hooks'
 import type { VNode } from 'preact'
-import { keepers } from '../../store'
+import { keepers, executionError, executionLoaded } from '../../store'
 import { navigate } from '../../router'
 import { selectKeeper } from '../../keeper-actions'
 import { keeperMobilePane } from '../keeper-detail-state'
@@ -502,6 +502,16 @@ function KeeperRosterMenu({
   `
 }
 
+// An empty list has three different causes and the text must say which:
+// the fleet has not loaded yet, the load failed, or the filter excluded
+// every keeper. Loaded-and-empty is the only case that is "no keepers".
+export function rosterEmptyText(fleetSize: number): string {
+  if (executionError.value !== null) return `키퍼 목록을 불러오지 못했습니다: ${executionError.value}`
+  if (!executionLoaded.value) return '키퍼 목록을 불러오는 중…'
+  if (fleetSize === 0) return '등록된 키퍼가 없습니다'
+  return '일치하는 키퍼가 없습니다'
+}
+
 export function KeeperWorkspaceRoster({
   activeName,
   onSelect,
@@ -746,7 +756,7 @@ export function KeeperWorkspaceRoster({
               : null}
           </div>
           ${visible.length === 0
-            ? html`<div class="kw-roster-list roster-list"><div class="kw-roster-empty v2-monitoring-row">일치하는 키퍼가 없습니다</div></div>`
+            ? html`<div class="kw-roster-list roster-list"><div class="kw-roster-empty v2-monitoring-row">${rosterEmptyText(all.length)}</div></div>`
         : useVirtual
           ? html`<${VirtualList}
               items=${items}

--- a/dashboard/src/lib/warm-retry.ts
+++ b/dashboard/src/lib/warm-retry.ts
@@ -1,0 +1,19 @@
+// Warm-up retry schedule shared by the bootstrap reads (namespace truth,
+// execution). Exponential backoff replaces a fixed 3 000 ms cadence, which
+// kept beating the server at 3 s intervals during cold starts and raced
+// Dashboard_cache stampede protection. The schedule (3 s / 5 s / 10 s / 20 s /
+// cap 30 s) keeps the worst-case warm-up budget (WARM_MAX_RETRIES retries)
+// while smoothing client load.
+
+export const WARM_RETRY_DELAYS_MS = [3_000, 5_000, 10_000, 20_000, 30_000]
+export const WARM_RETRY_CAP_MS = 30_000
+export const WARM_MAX_RETRIES = 10
+
+export function warmRetryDelayFor(attempt: number): number {
+  // attempt is 1-indexed by callers; clamp to the schedule, falling back
+  // to the cap so a misuse never produces 0 / NaN / negative delay.
+  if (!Number.isFinite(attempt) || attempt < 1) return WARM_RETRY_DELAYS_MS[0] ?? WARM_RETRY_CAP_MS
+  const idx = Math.min(attempt - 1, WARM_RETRY_DELAYS_MS.length - 1)
+  const delay = WARM_RETRY_DELAYS_MS[idx]
+  return delay ?? WARM_RETRY_CAP_MS
+}

--- a/dashboard/src/namespace-truth-actions.ts
+++ b/dashboard/src/namespace-truth-actions.ts
@@ -10,29 +10,12 @@ import {
 import { normalizeNamespaceTruth } from './namespace-truth-normalizers'
 import { mergeServerStatus } from './store-normalizers'
 import { FetchScheduler } from './lib/fetch-scheduler'
+import { WARM_MAX_RETRIES, warmRetryDelayFor } from './lib/warm-retry'
 
 // --- Warm-up retry state ---
-//
-// Phase 2 Action 6 — exponential backoff replaces the fixed 3 000 ms cadence.
-// The fixed cadence kept beating the server at 3 s intervals during cold
-// starts, which interacted poorly with Dashboard_cache stampede protection
-// (every retry races to start a fresh compute).  The schedule below
-// (3 s / 5 s / 10 s / 20 s / cap 30 s) preserves the worst-case warm-up
-// budget (WARM_MAX_RETRIES retries) while smoothing client load.
 
-export const WARM_RETRY_DELAYS_MS = [3_000, 5_000, 10_000, 20_000, 30_000]
-export const WARM_RETRY_CAP_MS = 30_000
+export { WARM_RETRY_DELAYS_MS, WARM_RETRY_CAP_MS, warmRetryDelayFor } from './lib/warm-retry'
 
-export function warmRetryDelayFor(attempt: number): number {
-  // attempt is 1-indexed by callers; clamp to the schedule, falling back
-  // to the cap so a misuse never produces 0 / NaN / negative delay.
-  if (!Number.isFinite(attempt) || attempt < 1) return WARM_RETRY_DELAYS_MS[0] ?? WARM_RETRY_CAP_MS
-  const idx = Math.min(attempt - 1, WARM_RETRY_DELAYS_MS.length - 1)
-  const delay = WARM_RETRY_DELAYS_MS[idx]
-  return delay ?? WARM_RETRY_CAP_MS
-}
-
-const WARM_MAX_RETRIES = 10
 let warmRetryAttempt = 0
 let warmRetryTimer: ReturnType<typeof setTimeout> | null = null
 

--- a/dashboard/src/store-reconcile.test.ts
+++ b/dashboard/src/store-reconcile.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { reconcileBoardPosts, reconcileKeepers } from './store'
+import { isInitializingExecutionPayload, reconcileBoardPosts, reconcileKeepers } from './store'
 import type { BoardPost, Keeper } from './types'
 
 function makePost(overrides: Partial<BoardPost> = {}): BoardPost {
@@ -191,5 +191,16 @@ describe('reconcileKeepers', () => {
     expect(result).not.toBe(prev)
     expect(result[0]).toBe(unchanged)
     expect(result[1]).toBe(updatedChanged)
+  })
+})
+
+describe('isInitializingExecutionPayload', () => {
+  it('recognises the warm-up envelope by status.project', () => {
+    expect(isInitializingExecutionPayload({ status: { project: 'initializing' }, keepers: [] })).toBe(true)
+  })
+
+  it('treats a real snapshot, even an empty one, as hydratable', () => {
+    expect(isInitializingExecutionPayload({ status: { project: 'me' }, keepers: [] })).toBe(false)
+    expect(isInitializingExecutionPayload({ keepers: [] })).toBe(false)
   })
 })

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -43,6 +43,7 @@ import {
 import { groupByKey } from './components/common/collection'
 import { setArrayByKeyIfChanged } from './signal-utils'
 import { FetchScheduler } from './lib/fetch-scheduler'
+import { WARM_MAX_RETRIES, warmRetryDelayFor } from './lib/warm-retry'
 import { isRecord, asString, asNumber } from './components/common/normalize'
 import { setCanonicalDashboardActor } from './lib/dashboard-session-actor'
 import { refreshDevTokenAfterAuthError } from './api/dev-token'
@@ -1216,6 +1217,31 @@ export function hydrateExecutionSnapshot(
 
 let nextExecutionForce = false
 
+// A warm-up envelope carries no fleet. Hydrating it would reconcile the
+// keeper list against [] and report the fleet as loaded-and-empty (the
+// "일치하는 키퍼가 없습니다" screen 37s after a restart, 2026-08-22).
+export function isInitializingExecutionPayload(data: DashboardExecutionResponse): boolean {
+  return data.status?.project === 'initializing'
+}
+
+let executionWarmRetryAttempt = 0
+let executionWarmRetryTimer: ReturnType<typeof setTimeout> | null = null
+
+function scheduleExecutionWarmRetry(): void {
+  executionWarmRetryAttempt += 1
+  if (executionWarmRetryAttempt > WARM_MAX_RETRIES) {
+    executionWarmRetryAttempt = 0
+    executionError.value = 'Server warm-up timed out. Try refreshing.'
+    return
+  }
+  const delayMs = warmRetryDelayFor(executionWarmRetryAttempt)
+  if (executionWarmRetryTimer) clearTimeout(executionWarmRetryTimer)
+  executionWarmRetryTimer = setTimeout(() => {
+    executionWarmRetryTimer = null
+    executionScheduler.requestNow()
+  }, delayMs)
+}
+
 async function doFetchExecution(): Promise<void> {
   const force = nextExecutionForce
   nextExecutionForce = false
@@ -1225,6 +1251,11 @@ async function doFetchExecution(): Promise<void> {
   try {
     const { fetchDashboardExecution } = await import('./api/dashboard-execution')
     const data = await fetchDashboardExecution({ force })
+    if (isInitializingExecutionPayload(data)) {
+      scheduleExecutionWarmRetry()
+      return
+    }
+    executionWarmRetryAttempt = 0
     hydrateExecutionSnapshot(data, { requestGeneration })
   } catch (err) {
     console.warn('[Dashboard] execution fetch error:', err)


### PR DESCRIPTION
## 현상 (소유자 보고)

재기동 직후 `#keepers` 가 "일치하는 키퍼가 없습니다" — keeper 34개가 돌고 있는데도. fresh load 와 Playwright 헤드리스로는 재현 안 됨(34행 정상); 리스너 01:31:03Z ↔ execution warm 01:31:40Z 의 37초 창이 남은 후보였습니다.

## 원인 (3겹)

1. 서버는 state 가 없을 때 `/api/v1/dashboard/*` 에 HTTP 200 `{"status":"initializing"}` 을 돌려줍니다(`server_auth.ml` `not_initialized_response`). 클라이언트 `isNotInitializedEnvelope` 는 `{"error":"not initialized"}` 만 알아봐서(#4886 당시 모양) 이 봉투가 그대로 execution 스토어로 들어갔습니다.
2. `doFetchExecution` 은 받은 것을 무조건 hydrate → `reconcileKeepers(prev, [])` → fleet `[]`, `executionLoaded=true`, 오류도 토스트도 재시도도 없음.
3. 로스터(`keeper-workspace-roster.ts:748`)는 `visible.length === 0` 이면 원인과 무관하게 같은 문구.

## 바꾼 것

- `api/core.ts`: `status: "initializing"` 봉투도 warm-up 으로 인식(기존 `error` 모양 유지).
- `store.ts`: `isInitializingExecutionPayload`(`status.project === 'initializing'`) 이면 hydrate 하지 않고 warm-up 재시도(3/5/10/20/30초, 최대 10회 — namespace-truth 와 같은 스케줄). 스케줄은 `lib/warm-retry.ts` 로 뽑아 두 소비자가 공유(`namespace-truth-actions.ts` 는 re-export 유지).
- 로스터: `rosterEmptyText` — 불러오는 중 / 불러오지 못함(`executionError`) / 등록된 키퍼 없음 / 일치하는 키퍼 없음 을 구분.

## 테스트 (111/111, `tsc --noEmit` 0)

- `core.test.ts`: `status:initializing` 봉투 → execution initializing payload.
- `keeper-workspace-roster.test.ts`: `rosterEmptyText` 4상태.
- `store-reconcile.test.ts`: `isInitializingExecutionPayload` 판별(빈 fleet 의 실제 스냅샷은 hydrate 대상).

## 범위 밖

`?force=1` 이 인증된 브라우저 요청(`X-MASC-Agent` 동반)에서 무시되는 문제(`server_dashboard_http_execution_surfaces.ml:1211` force 분기가 `actor=None` 일 때만) — OCaml 1파일 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3a8sWueQQPyYyoXerLJvj
